### PR TITLE
Board fast path: incremental parsing, one log channel, sleeping panes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-log-viewer",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "bin": {
     "agent-log-viewer": "bin/cli.mjs"
   },

--- a/src/app/api/files/route.ts
+++ b/src/app/api/files/route.ts
@@ -1,3 +1,5 @@
+import { createHash } from "node:crypto";
+
 import { NextResponse } from "next/server";
 
 import { listFiles } from "@/lib/scanner";
@@ -11,7 +13,7 @@ import type { FilesResponse } from "@/lib/types";
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
-export async function GET(): Promise<NextResponse<FilesResponse>> {
+export async function GET(request: Request): Promise<NextResponse> {
   const files = await listFiles();
   /* Reconciliation runs inside the serialized read-modify-write: the file
      scan above is the slow part, so a task edit landing during it is picked
@@ -23,5 +25,17 @@ export async function GET(): Promise<NextResponse<FilesResponse>> {
     });
     return { tasks: reconciled.dirty ? reconciled.tasks : undefined, result: reconciled.tasks };
   });
-  return NextResponse.json({ files, flows: loadFlows(), workflows: loadWorkflows(), tasks });
+  const body = JSON.stringify({ files, flows: loadFlows(), workflows: loadWorkflows(), tasks } satisfies FilesResponse);
+  /* The client re-polls every 10 s and this ~410 KB payload is usually
+     identical between polls; a strong ETag over the exact bytes lets an
+     unchanged response come back as a bodyless 304. force-dynamic still holds
+     — the body is recomputed every request, only its transfer is skipped. */
+  const etag = `"${createHash("sha1").update(body).digest("hex")}"`;
+  if (request.headers.get("if-none-match") === etag) {
+    return new NextResponse(null, { status: 304, headers: { ETag: etag } });
+  }
+  return new NextResponse(body, {
+    status: 200,
+    headers: { "content-type": "application/json", ETag: etag },
+  });
 }

--- a/src/app/api/log/route.ts
+++ b/src/app/api/log/route.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 
 import { NextRequest, NextResponse } from "next/server";
 
+import { readTailChunk } from "@/lib/logRead";
 import { rejectCrossOrigin } from "@/lib/sameOrigin";
 import { listFiles } from "@/lib/scanner";
 import { MAX_CHUNK, pathAllowed, ROOTS } from "@/lib/scanner/roots";
@@ -23,19 +24,18 @@ export async function GET(
 ): Promise<NextResponse<LogChunk | ApiError>> {
   const path = req.nextUrl.searchParams.get("path") ?? "";
 
-  let stat;
-  try {
-    stat = await fs.stat(path);
-  } catch {
-    stat = null;
-  }
-  if (!path || !stat?.isFile() || !pathAllowed(path)) {
-    return NextResponse.json({ error: "path not allowed" }, { status: 403 });
-  }
-  const size = stat.size;
-
   const beforeParam = req.nextUrl.searchParams.get("before");
   if (beforeParam !== null) {
+    let stat;
+    try {
+      stat = await fs.stat(path);
+    } catch {
+      stat = null;
+    }
+    if (!path || !stat?.isFile() || !pathAllowed(path)) {
+      return NextResponse.json({ error: "path not allowed" }, { status: 403 });
+    }
+    const size = stat.size;
     let before = Number(beforeParam);
     if (!Number.isFinite(before) || before < 0) before = 0;
     if (before > size) before = size;
@@ -55,24 +55,9 @@ export async function GET(
     }
   }
 
-  let offset = Number(req.nextUrl.searchParams.get("offset") ?? "0");
-  if (!Number.isFinite(offset) || offset < 0) offset = 0;
-  if (offset > size) offset = 0;
-  if (offset === 0 && size > MAX_CHUNK) offset = size - MAX_CHUNK;
-
-  const fh = await fs.open(path, "r");
-  try {
-    const buf = Buffer.alloc(Math.min(MAX_CHUNK, Math.max(0, size - offset)));
-    const { bytesRead } = await fh.read(buf, 0, buf.length, offset);
-    return NextResponse.json({
-      offset: offset + bytesRead,
-      start: offset,
-      size,
-      data: buf.subarray(0, bytesRead).toString("utf-8"),
-    });
-  } finally {
-    await fh.close();
-  }
+  const chunk = await readTailChunk(path, Number(req.nextUrl.searchParams.get("offset") ?? "0"));
+  if (!chunk) return NextResponse.json({ error: "path not allowed" }, { status: 403 });
+  return NextResponse.json(chunk);
 }
 
 /**

--- a/src/app/api/logs/route.ts
+++ b/src/app/api/logs/route.ts
@@ -1,0 +1,64 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { readTailChunk } from "@/lib/logRead";
+import { MAX_CHUNK } from "@/lib/scanner/roots";
+import type { ApiError, LogChunk } from "@/lib/types";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+/** Requests beyond this are ignored (the client slices its batches too). */
+const MAX_REQS = 64;
+/* One batch answer stays within ~4×MAX_CHUNK of log bytes: the first paint of
+   a board full of panes would otherwise multiply MAX_CHUNK by the pane count
+   in a single response. Files past the budget return an idle chunk at their
+   current offset and catch up on later ticks. */
+const BATCH_BUDGET = 4 * MAX_CHUNK;
+
+interface BatchReq {
+  id: string;
+  path: string;
+  offset: number;
+}
+
+function parseReqs(body: unknown): BatchReq[] {
+  if (!body || typeof body !== "object") return [];
+  const raw = (body as { reqs?: unknown }).reqs;
+  if (!Array.isArray(raw)) return [];
+  const reqs: BatchReq[] = [];
+  for (const entry of raw.slice(0, MAX_REQS)) {
+    if (!entry || typeof entry !== "object") continue;
+    const { id, path, offset } = entry as Record<string, unknown>;
+    if (typeof id !== "string" || typeof path !== "string") continue;
+    reqs.push({ id, path, offset: typeof offset === "number" ? offset : 0 });
+  }
+  return reqs;
+}
+
+/**
+ * The multiplexed tail poll: every visible pane's forward read in one request
+ * instead of one HTTP round-trip per pane per tick. Same chunk semantics as
+ * GET /api/log; history (`before`) reads stay on the single-file route.
+ */
+export async function POST(req: NextRequest): Promise<NextResponse<{ chunks: Record<string, LogChunk | ApiError> }>> {
+  let body: unknown = null;
+  try {
+    body = await req.json();
+  } catch {
+    body = null;
+  }
+  const chunks: Record<string, LogChunk | ApiError> = {};
+  let budget = BATCH_BUDGET;
+  /* Sequential on purpose: the byte budget is spent in request order, and a
+     dozen warm stat+read pairs cost far less than the parallelism would win. */
+  for (const { id, path, offset } of parseReqs(body)) {
+    const chunk = await readTailChunk(path, offset, budget);
+    if (!chunk) {
+      chunks[id] = { error: "path not allowed" };
+      continue;
+    }
+    budget -= chunk.offset - chunk.start;
+    chunks[id] = chunk;
+  }
+  return NextResponse.json({ chunks });
+}

--- a/src/app/api/logs/stream/route.ts
+++ b/src/app/api/logs/stream/route.ts
@@ -1,0 +1,18 @@
+import { NextRequest } from "next/server";
+
+import { createLogTailEventStream, parseLogStreamSubs } from "@/lib/logTailStream";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function GET(req: NextRequest): Promise<Response> {
+  const subs = parseLogStreamSubs(req.nextUrl.searchParams.get("subs"));
+  const stream = createLogTailEventStream(subs, req.signal);
+  return new Response(stream, {
+    headers: {
+      "content-type": "text/event-stream",
+      "cache-control": "no-store",
+      "x-accel-buffering": "no",
+    },
+  });
+}

--- a/src/app/api/tmux/route.ts
+++ b/src/app/api/tmux/route.ts
@@ -7,13 +7,11 @@ import {
   interruptConversation,
   killConversation,
   resumeConversation,
-  targetForKnownPid,
   type DeliveryOutcome,
 } from "@/lib/delivery";
 import { allowedKillTarget, consumeKillTarget } from "@/lib/resources";
 import { rejectCrossOrigin } from "@/lib/sameOrigin";
-import { pathAllowed } from "@/lib/scanner/roots";
-import { collectImagePayloads, killPane, liveResumePane, panePidOf } from "@/lib/tmux";
+import { collectImagePayloads, killPane, panePidOf, resolveRequestedTmuxTarget } from "@/lib/tmux";
 import type { ApiError } from "@/lib/types";
 
 export const runtime = "nodejs";
@@ -44,16 +42,7 @@ export async function GET(req: NextRequest): Promise<NextResponse<TargetResponse
   if (!hasPid && !filePath) {
     return NextResponse.json({ error: "потрібен pid або path" }, { status: 400 });
   }
-  if (hasPid) {
-    const target = await targetForKnownPid(pid);
-    if (target !== "unknown" && target !== null) return NextResponse.json({ target });
-  }
-  /* A finished conversation has no pid, but its resume window may still run. */
-  if (filePath && pathAllowed(filePath)) {
-    const pane = await liveResumePane(filePath);
-    if (pane) return NextResponse.json({ target: pane.display });
-  }
-  return NextResponse.json({ target: null });
+  return NextResponse.json({ target: await resolveRequestedTmuxTarget(hasPid ? pid : null, filePath) });
 }
 
 export async function POST(req: NextRequest): Promise<NextResponse<SendResponse | ApiError>> {

--- a/src/app/api/tmux/targets/route.ts
+++ b/src/app/api/tmux/targets/route.ts
@@ -1,0 +1,50 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { resolveRequestedTmuxTarget } from "@/lib/tmux";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const MAX_REQS = 64;
+
+interface TargetBatchReq {
+  id: string;
+  pid: number | null;
+  path: string;
+}
+
+interface TargetBatchResponse {
+  targets: Record<string, string | null>;
+}
+
+function parseReqs(body: unknown): TargetBatchReq[] | null {
+  if (!body || typeof body !== "object") return null;
+  const raw = (body as { reqs?: unknown }).reqs;
+  if (!Array.isArray(raw) || raw.length > MAX_REQS) return null;
+  const reqs: TargetBatchReq[] = [];
+  for (const entry of raw) {
+    if (!entry || typeof entry !== "object") return null;
+    const { id, pid: rawPid, path: rawPath } = entry as Record<string, unknown>;
+    if (typeof id !== "string") return null;
+    const pid = typeof rawPid === "number" && Number.isInteger(rawPid) && rawPid > 0 ? rawPid : null;
+    const path = typeof rawPath === "string" ? rawPath : "";
+    reqs.push({ id, pid, path });
+  }
+  return reqs;
+}
+
+export async function POST(req: NextRequest): Promise<NextResponse<TargetBatchResponse | { error: string }>> {
+  let body: unknown = null;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "некоректний JSON" }, { status: 400 });
+  }
+  const reqs = parseReqs(body);
+  if (reqs === null) return NextResponse.json({ error: "некоректний список запитів" }, { status: 400 });
+
+  const pairs = await Promise.all(
+    reqs.map(async ({ id, pid, path }) => [id, pid === null && !path ? null : await resolveRequestedTmuxTarget(pid, path)] as const),
+  );
+  return NextResponse.json({ targets: Object.fromEntries(pairs) });
+}

--- a/src/components/BranchPane.tsx
+++ b/src/components/BranchPane.tsx
@@ -85,14 +85,33 @@ interface Props {
       collapse, and pane registries (chime, link arrows) stay with the board
       pane underneath. */
   expanded?: boolean;
+  /** Far-zoom board state: pane content is unreadable behind the identity
+      labels, so feeds and composer polling go to sleep until zoom returns. */
+  dormant?: boolean;
 }
 
-export function BranchPane({ file, files, tasks, onSelect, isRoot, onClose, dragHandle, noComposer, banner, onToggleExpand, expanded }: Props) {
+export function BranchPane({ file, files, tasks, onSelect, isRoot, onClose, dragHandle, noComposer, banner, onToggleExpand, expanded, dormant }: Props) {
   const { t } = useLocale();
   const paneRef = useRef<HTMLElement | null>(null);
   const badge = engineBadge(file);
   const state = paneState(file);
   const tone = PANE_TONES[state];
+  /* Panes outside the viewport stop polling and parsing: the board can hold
+     dozens of live conversations while only a handful fit on screen. The
+     margin pre-wakes panes just beyond the edge so panning never shows a
+     stale card; ancestor overflow clipping is part of the intersection, so
+     a pane translated out of the board viewport counts as off screen. */
+  const [offscreen, setOffscreen] = useState(() => typeof IntersectionObserver !== "undefined");
+  useEffect(() => {
+    const el = paneRef.current;
+    if (!el || typeof IntersectionObserver === "undefined") return;
+    const observer = new IntersectionObserver((entries) => setOffscreen(!entries.some((entry) => entry.isIntersecting)), {
+      rootMargin: "256px",
+    });
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, []);
+  const feedPaused = Boolean(dormant) || offscreen;
   /* The chime of this conversation pans to wherever this pane sits on screen.
      The overlay pane never registers: the board pane of the same path keeps
      owning both registries, so collapsing leaves them intact. */
@@ -202,7 +221,7 @@ export function BranchPane({ file, files, tasks, onSelect, isRoot, onClose, drag
           <FlipRow className="shrink-0 border-b border-line bg-[#fbfbfd]" enter="fade">
             {tasks.map((task) => (
               <div key={task.path} data-flip-key={task.path}>
-                <TaskStrip file={task} files={files} onSelect={onSelect} />
+                <TaskStrip file={task} files={files} onSelect={onSelect} paused={feedPaused} />
               </div>
             ))}
           </FlipRow>
@@ -214,19 +233,29 @@ export function BranchPane({ file, files, tasks, onSelect, isRoot, onClose, drag
           showSvc={false}
           lineFilter=""
           onStatus={noop}
-          paused={false}
+          paused={feedPaused}
           follow
           setFollow={noop}
           compact
         />
-        {noComposer ? null : <TmuxComposer file={file} />}
+        {noComposer ? null : <TmuxComposer file={file} pollPaused={feedPaused} />}
       </section>
     </div>
   );
 }
 
 /** Collapsed background-task row: glyph, title, PID chip, kill; click expands an inline mini feed. */
-export function TaskStrip({ file, files, onSelect }: { file: FileEntry; files: FileEntry[]; onSelect: (file: FileEntry) => void }) {
+export function TaskStrip({
+  file,
+  files,
+  onSelect,
+  paused = false,
+}: {
+  file: FileEntry;
+  files: FileEntry[];
+  onSelect: (file: FileEntry) => void;
+  paused?: boolean;
+}) {
   const { t } = useLocale();
   const [open, setOpen] = useState(false);
   const title = cleanTitle(file.cmdDesc || file.title, 80);
@@ -256,7 +285,7 @@ export function TaskStrip({ file, files, onSelect }: { file: FileEntry; files: F
             showSvc={false}
             lineFilter=""
             onStatus={noop}
-            paused={false}
+            paused={paused}
             follow
             setFollow={noop}
             compact

--- a/src/components/BranchPane.tsx
+++ b/src/components/BranchPane.tsx
@@ -124,72 +124,78 @@ export function BranchPane({ file, files, tasks, onSelect, isRoot, onClose, drag
         } ${tone.section}`}
         style={state === "done" ? { borderTopColor: "#c9c9d1" } : engineEdge(file)}
       >
+        {/* Two deliberate rows: identity + actions on top (the close X pinned
+            to the corner at every width), the metadata chips below. */}
         <header
-          className={`flex min-h-10 shrink-0 flex-wrap items-center gap-x-1.5 gap-y-1 border-b border-line px-2.5 py-1 ${tone.header} ${
+          className={`flex shrink-0 flex-col gap-y-1 border-b border-line px-2.5 py-1.5 ${tone.header} ${
             dragHandle ? "cursor-grab active:cursor-grabbing" : ""
           }`}
           {...dragHandle}
         >
-          <span className={`h-2 w-2 shrink-0 rounded-full ${activityDot(file.activity)}`} title={t(`branch.${state}`)} />
-          <LastActivity file={file} />
-          {/* One identity chip: the model when known (engine lives in the tint
-              and the tooltip), the engine label as fallback. */}
-          {file.model ? (
-            <span
-              className="shrink-0 rounded-full px-1.5 py-0.5 font-mono text-[9.5px] font-semibold"
-              style={{ backgroundColor: effortTint(file).soft, color: effortTint(file).color }}
-              title={[badge.label, effortTitle(file)].filter(Boolean).join(" · ")}
-            >
-              {file.model}
+          <div className="flex min-w-0 items-center gap-1.5">
+            <span className={`h-2 w-2 shrink-0 rounded-full ${activityDot(file.activity)}`} title={t(`branch.${state}`)} />
+            <span className="min-w-0 flex-1 truncate text-[12px] font-semibold" title={cleanTitle(file.title)}>
+              {cleanTitle(file.title, 90)}
             </span>
-          ) : (
-            <span className="inline-flex shrink-0 items-center rounded-full px-2 py-0.5 text-[10px] font-bold" style={badge.style}>
-              {badge.label}
-            </span>
-          )}
-          {file.ctx ? <CtxChip ctx={file.ctx} /> : null}
-          {file.worktree ? (
-            <span
-              className="inline-flex shrink-0 items-center gap-0.5 rounded-full border border-line/80 px-1.5 py-0.5 font-mono text-[9.5px] text-dim"
-              title={t("branch.worktree", { name: file.worktree })}
-            >
-              <GitBranch className="h-2.5 w-2.5" aria-hidden /> {file.worktree}
-            </span>
-          ) : null}
-          {file.plan ? <PlanChip plan={file.plan} /> : null}
-          {file.goal ? <GoalChip goal={file.goal} /> : null}
-          {isRoot ? null : (
-            <span
-              className="inline-flex shrink-0 items-center gap-0.5 text-[10px] text-dim"
-              title={file.handoff ? t("branch.handoffTitle") : t("branch.branchTitle")}
-            >
-              <CornerDownRight className="h-3 w-3" aria-hidden /> {file.handoff ? t("kind.handoff") : kindLabel(t, file.kind)}
-            </span>
-          )}
-          <span className="min-w-24 flex-1 truncate text-[12px] font-semibold" title={cleanTitle(file.title)}>
-            {cleanTitle(file.title, 90)}
-          </span>
-          <ProcessStatusControls file={file} compact />
-          {onToggleExpand ? (
-            <button
-              className="inline-flex shrink-0 items-center rounded-[8px] border border-line bg-bg px-1.5 py-0.5 text-dim hover:border-accent/45 hover:text-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40"
-              aria-label={expanded ? t("branch.collapseFull") : t("branch.expandFull", { title: cleanTitle(file.title, 60) })}
-              title={expanded ? t("branch.collapseFull") : t("branch.expandFull", { title: cleanTitle(file.title, 60) })}
-              onClick={onToggleExpand}
-            >
-              {expanded ? <Minimize2 className="h-3 w-3" aria-hidden /> : <Maximize2 className="h-3 w-3" aria-hidden />}
-            </button>
-          ) : null}
-          <DeleteFileButton file={file} onDeleted={onClose} />
-          {onClose ? (
-            <button
-              className="inline-flex shrink-0 items-center rounded-[8px] border border-line bg-bg px-1.5 py-0.5 text-dim hover:border-err/40 hover:text-err focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40"
-              aria-label={t("branch.removeColumn", { title: cleanTitle(file.title, 60) })}
-              onClick={onClose}
-            >
-              <X className="h-3 w-3" aria-hidden />
-            </button>
-          ) : null}
+            <ProcessStatusControls file={file} compact />
+            {onToggleExpand ? (
+              <button
+                className="inline-flex shrink-0 items-center rounded-[8px] border border-line bg-bg px-1.5 py-0.5 text-dim hover:border-accent/45 hover:text-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40"
+                aria-label={expanded ? t("branch.collapseFull") : t("branch.expandFull", { title: cleanTitle(file.title, 60) })}
+                title={expanded ? t("branch.collapseFull") : t("branch.expandFull", { title: cleanTitle(file.title, 60) })}
+                onClick={onToggleExpand}
+              >
+                {expanded ? <Minimize2 className="h-3 w-3" aria-hidden /> : <Maximize2 className="h-3 w-3" aria-hidden />}
+              </button>
+            ) : null}
+            <DeleteFileButton file={file} onDeleted={onClose} />
+            {onClose ? (
+              <button
+                className="inline-flex shrink-0 items-center rounded-[8px] border border-line bg-bg px-1.5 py-0.5 text-dim hover:border-err/40 hover:text-err focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40"
+                aria-label={t("branch.removeColumn", { title: cleanTitle(file.title, 60) })}
+                onClick={onClose}
+              >
+                <X className="h-3 w-3" aria-hidden />
+              </button>
+            ) : null}
+          </div>
+          <div className="flex min-w-0 flex-wrap items-center gap-x-1.5 gap-y-1">
+            <LastActivity file={file} />
+            {/* One identity chip: the model when known (engine lives in the tint
+                and the tooltip), the engine label as fallback. */}
+            {file.model ? (
+              <span
+                className="shrink-0 rounded-full px-1.5 py-0.5 font-mono text-[9.5px] font-semibold"
+                style={{ backgroundColor: effortTint(file).soft, color: effortTint(file).color }}
+                title={[badge.label, effortTitle(file)].filter(Boolean).join(" · ")}
+              >
+                {file.model}
+              </span>
+            ) : (
+              <span className="inline-flex shrink-0 items-center rounded-full px-2 py-0.5 text-[10px] font-bold" style={badge.style}>
+                {badge.label}
+              </span>
+            )}
+            {file.ctx ? <CtxChip ctx={file.ctx} /> : null}
+            {file.worktree ? (
+              <span
+                className="inline-flex shrink-0 items-center gap-0.5 rounded-full border border-line/80 px-1.5 py-0.5 font-mono text-[9.5px] text-dim"
+                title={t("branch.worktree", { name: file.worktree })}
+              >
+                <GitBranch className="h-2.5 w-2.5" aria-hidden /> {file.worktree}
+              </span>
+            ) : null}
+            {file.plan ? <PlanChip plan={file.plan} /> : null}
+            {file.goal ? <GoalChip goal={file.goal} /> : null}
+            {isRoot ? null : (
+              <span
+                className="inline-flex shrink-0 items-center gap-0.5 text-[10px] text-dim"
+                title={file.handoff ? t("branch.handoffTitle") : t("branch.branchTitle")}
+              >
+                <CornerDownRight className="h-3 w-3" aria-hidden /> {file.handoff ? t("kind.handoff") : kindLabel(t, file.kind)}
+              </span>
+            )}
+          </div>
         </header>
         {banner ?? null}
         {tasks.length ? (

--- a/src/components/LogFeed.tsx
+++ b/src/components/LogFeed.tsx
@@ -10,7 +10,7 @@ import type { FileEntry } from "@/lib/types";
 
 import { isAwaitingUser } from "@/hooks/useSwitchboardData";
 
-import { buildFeed } from "./feed/parse";
+import { createFeedSession, type FeedSession, type FeedSnapshot } from "./feed/parse";
 import { FeedItem } from "./feed/FeedItem";
 import { QuestionCard } from "./feed/QuestionCard";
 import { isSubagent } from "./projectModel";
@@ -27,6 +27,13 @@ const COMPACT_STEP = 500;
     a far smaller tab memory budget (iOS kills the renderer past it), so the
     window shrinks there; «показати раніше» still walks the full history. */
 const TAIL_CAP = typeof window !== "undefined" && window.matchMedia("(pointer: coarse)").matches ? 500 : 2500;
+/** Focused (non-compact) panes read with more context but must not grow the
+    window forever while the magnet holds — a live agent left open overnight
+    used to accumulate an unbounded line array. A released reader still keeps
+    everything, so trimming never shifts what is being read. */
+const FOCUS_CAP = typeof window !== "undefined" && window.matchMedia("(pointer: coarse)").matches ? 1000 : 6000;
+
+const EMPTY_FEED: FeedSnapshot = { items: [], hiddenServiceCount: 0 };
 
 /** How long after a programmatic glue a not-at-bottom scroll event is treated
     as layout settling (content-visibility estimates, pane resizes) and glued
@@ -81,7 +88,7 @@ export function LogFeed({ file, files, onSelect, showSvc, lineFilter, onStatus, 
   const [magnet, setMagnetState] = useState(() => (file ? (scrollMemory.get(file.path)?.magnet ?? follow) : follow));
   /* Released reader must never lose lines above the viewport: the tail cap
      applies only while the magnet holds the bottom in view anyway. */
-  const tail = useLogTail(file, paused, magnet && compact ? TAIL_CAP : 0);
+  const tail = useLogTail(file, paused, magnet ? (compact ? TAIL_CAP : FOCUS_CAP) : 0);
   const scroller = useRef<HTMLDivElement | null>(null);
   const content = useRef<HTMLDivElement | null>(null);
   const anchorRef = useRef<{ top: number; height: number } | null>(null);
@@ -167,13 +174,22 @@ export function LogFeed({ file, files, onSelect, showSvc, lineFilter, onStatus, 
     }
   }, [file?.pendingQuestion?.toolUseId, file?.proc, file, locale]);
 
-  /* buildFeed reads only engine/fmt/activity off the file: depending on those
-     fields (not the object identity, which changes every /api/files poll)
-     keeps item identities stable, so memoized FeedItems skip re-rendering. */
-  const feed = useMemo(
-    () => (file ? buildFeed(file, tail.lines, showSvc, lineFilter.toLowerCase()) : { items: [], hiddenServiceCount: 0 }),
+  /* The incremental feed session parses only lines it has not seen and keeps
+     untouched item identities, so a tail tick re-renders one or two rows, not
+     the whole window. The session is keyed on the fields that change the
+     parse itself (path/format/filters/locale — not the file object identity,
+     which changes every /api/files poll); anything else reuses it. Feeding
+     inside the memo is safe: feed() is idempotent for an unchanged window. */
+  const lf = lineFilter.toLowerCase();
+  const session: FeedSession | null = useMemo(
+    () => (file ? createFeedSession({ engine: file.engine, fmt: file.fmt, showSvc, lineFilter: lf }) : null),
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [file?.path, file?.engine, file?.fmt, file?.activity, tail.lines, showSvc, lineFilter, locale],
+    [file?.path, file?.engine, file?.fmt, showSvc, lf, locale],
+  );
+  const feed = useMemo(
+    () => (file && session ? session.feed(tail.lines, tail.linesStart, file.activity === "live") : EMPTY_FEED),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [session, file?.activity, tail.lines, tail.linesStart],
   );
   const hiddenLocal = Math.max(0, feed.items.length - visibleCount);
   const visibleItems = hiddenLocal ? feed.items.slice(-visibleCount) : feed.items;
@@ -248,7 +264,7 @@ export function LogFeed({ file, files, onSelect, showSvc, lineFilter, onStatus, 
   };
   const canRevealOlder = hiddenLocal > 0 || tail.hasMore;
 
-  const lastItem = feed.items.at(-1);
+  const lastItem = feed.items.at(-1)?.item;
   const working: { icon: LucideIcon; label: string } =
     lastItem?.kind === "cmd" && lastItem.call.status === "run"
       ? { icon: Wrench, label: t("feed.running", { tool: lastItem.call.cmd.split(/[\s:]/, 1)[0] || t("feed.tool") }) }
@@ -350,18 +366,18 @@ export function LogFeed({ file, files, onSelect, showSvc, lineFilter, onStatus, 
             {compact ? null : <TaskHeader file={file} files={files} onSelect={onSelect} />}
             {feed.items.length ? (
               <>
-                {visibleItems.map((item, idx) => {
-                  const key = idx + feed.items.length - visibleItems.length;
-                  /* Compact panes live on the zoomable canvas: off-screen rows
-                     skip layout/paint entirely via content-visibility. */
-                  return compact ? (
+                {visibleItems.map(({ key, item }) =>
+                  /* Session-stable keys: a row keeps its DOM node while the
+                     window slides. Compact panes live on the zoomable canvas:
+                     off-screen rows skip layout/paint via content-visibility. */
+                  compact ? (
                     <div key={key} className="feed-cv">
                       <FeedItem item={item} />
                     </div>
                   ) : (
                     <FeedItem key={key} item={item} />
-                  );
-                })}
+                  ),
+                )}
                 {file.pendingQuestion || file.waitingInput ? <QuestionCard key={file.pendingQuestion?.toolUseId ?? "waiting"} file={file} /> : null}
                 {!file.pendingQuestion && !file.waitingInput && endedQuestion ? (
                   <div className="my-4 rounded-[8px] border border-line bg-chip px-4 py-3 text-[13px] font-semibold text-dim">{endedQuestion}</div>

--- a/src/components/ResourcesFooter.tsx
+++ b/src/components/ResourcesFooter.tsx
@@ -319,6 +319,12 @@ function CleanupPanel({
   );
 }
 
+/** Last two path segments — enough to recognize a worktree or project dir. */
+function tailPath(dir: string): string {
+  const parts = dir.split("/").filter(Boolean);
+  return parts.slice(-2).join("/") || dir;
+}
+
 function SessionRow({
   session,
   busy,
@@ -349,12 +355,15 @@ function SessionRow({
       >
         {session.engine === "codex" ? "Codex" : session.engine === "claude" ? "Claude" : "?"}
       </span>
-      <span className="min-w-0 flex-1" title={`${session.target} · ${t("resources.procs", { count: session.procCount })}`}>
+      <span
+        className="min-w-0 flex-1"
+        title={[session.cwd, session.target, t("resources.procs", { count: session.procCount })].filter(Boolean).join(" · ")}
+      >
         <span className="block truncate text-[12px] font-semibold">
-          {session.title ?? t("resources.orphan")}
+          {session.title ?? (session.cwd ? tailPath(session.cwd) : t("resources.orphan"))}
         </span>
         <span className="block truncate text-[10.5px] text-dim">
-          {session.project ? session.project + " · " : ""}
+          {session.title === null ? t("resources.orphan") + " · " : session.project ? session.project + " · " : ""}
           {lastActive !== null ? fmtAge(lastActive) : session.target}
         </span>
       </span>

--- a/src/components/TmuxComposer.tsx
+++ b/src/components/TmuxComposer.tsx
@@ -68,9 +68,11 @@ const hhmm = (at: number) =>
  * agent window in the current tmux session with the text as the first prompt.
  * Sent messages stay visible as a queue above the input until dismissed.
  */
-export function TmuxComposer({ file }: { file: FileEntry }) {
+export function TmuxComposer({ file, pollPaused = false }: { file: FileEntry; pollPaused?: boolean }) {
   const { t } = useLocale();
-  const target = useTmuxTarget(file.pid, canMessageWithoutPane(file) ? file.path : undefined);
+  /* An off-screen or far-zoom pane skips the pane-resolution poll; the last
+     known target keeps the composer usable the moment it comes back. */
+  const target = useTmuxTarget(file.pid, canMessageWithoutPane(file) ? file.path : undefined, !pollPaused);
   /* Column reshuffles can remount the composer mid-typing; the draft lives in
      sessionStorage so the text survives the remount. */
   const composer = useComposer({

--- a/src/components/feed/parse.test.ts
+++ b/src/components/feed/parse.test.ts
@@ -1,0 +1,227 @@
+import { describe, expect, test } from "bun:test";
+
+import type { FileEntry } from "@/lib/types";
+
+import { buildFeed, createFeedSession, type Item } from "./parse";
+
+const claudeFile = { path: "/tmp/x.jsonl", engine: "claude", fmt: "claude", activity: "recent" } as FileEntry;
+const codexFile = { path: "/tmp/x.jsonl", engine: "codex", fmt: "codex", activity: "recent" } as FileEntry;
+const plainFile = { path: "/tmp/x.output", engine: "codex", fmt: "plain", activity: "recent" } as FileEntry;
+
+/* Auto-incrementing ids inside plain-cmd items depend on how many pushes the
+   session has ever seen, so a slid window numbers them differently than a
+   fresh one-shot parse. The ids are opaque uniqueness tokens; normalize them
+   before structural comparison. */
+function normalize(items: Item[]): unknown {
+  return JSON.parse(
+    JSON.stringify(items, (key, value) =>
+      typeof value === "string" && (key === "id" || key === "ids") ? value.replace(/^plain-\d+-/, "plain-N-") : value,
+    ),
+  );
+}
+
+/**
+ * Feed `lines` into one session chunk-by-chunk with useLogTail's cap-trim
+ * semantics, and after every chunk compare the incremental snapshot against a
+ * fresh one-shot parse of the same window.
+ */
+function assertParity(file: FileEntry, lines: string[], opts: { cap?: number; chunks?: number[]; showSvc?: boolean; live?: boolean } = {}) {
+  const { cap = 0, chunks = [1, 3, 2, 5, 1, 4], showSvc = false, live = false } = opts;
+  const session = createFeedSession({ engine: file.engine, fmt: file.fmt, showSvc, lineFilter: "" });
+  const liveFile = { ...file, activity: live ? "live" : file.activity } as FileEntry;
+  let window: string[] = [];
+  let start = 0;
+  let fed = 0;
+  let step = 0;
+  while (fed < lines.length) {
+    const take = Math.min(chunks[step % chunks.length], lines.length - fed);
+    window = window.concat(lines.slice(fed, fed + take));
+    fed += take;
+    step += 1;
+    if (cap > 0 && window.length > cap) {
+      start += window.length - cap;
+      window = window.slice(-cap);
+    }
+    const incremental = session.feed(window, start, live);
+    const oneShot = buildFeed(liveFile, window, showSvc, "");
+    expect(normalize(incremental.items.map((entry) => entry.item))).toEqual(normalize(oneShot.items));
+    expect(incremental.hiddenServiceCount).toBe(oneShot.hiddenServiceCount);
+  }
+  return session;
+}
+
+const claudeUser = (text: string) => JSON.stringify({ type: "user", timestamp: "2026-07-06T10:00:00Z", message: { content: text } });
+const claudeProse = (text: string, stop: string | null = "end_turn") =>
+  JSON.stringify({
+    type: "assistant",
+    timestamp: "2026-07-06T10:00:01Z",
+    message: { stop_reason: stop, content: [{ type: "text", text }] },
+  });
+const claudeThink = (text: string) =>
+  JSON.stringify({ type: "assistant", message: { content: [{ type: "thinking", thinking: text }] } });
+const claudeTool = (id: string, name: string, command: string) =>
+  JSON.stringify({
+    type: "assistant",
+    timestamp: "2026-07-06T10:00:02Z",
+    message: { content: [{ type: "tool_use", id, name, input: { command } }] },
+  });
+const claudeResult = (id: string, text: string, isError = false) =>
+  JSON.stringify({
+    type: "user",
+    timestamp: "2026-07-06T10:00:03Z",
+    message: { content: [{ type: "tool_result", tool_use_id: id, content: [{ type: "text", text }], is_error: isError }] },
+  });
+const claudeSend = (id: string, to: string, message: string) =>
+  JSON.stringify({
+    type: "assistant",
+    timestamp: "2026-07-06T10:00:04Z",
+    message: { content: [{ type: "tool_use", id, name: "SendMessage", input: { to, summary: "s", message } }] },
+  });
+
+describe("feed session parity with one-shot parse", () => {
+  test("claude transcript: tools, results, grouping, tmsg delivery, compaction", () => {
+    const lines = [
+      claudeUser("зроби перший крок"),
+      claudeThink("мізкую про перший крок і план дій"),
+      claudeTool("c1", "Bash", "ls -la"),
+      claudeResult("c1", "total 8"),
+      claudeProse("Готово, ось результат."),
+      // A run of five commands: folds into one cmd-group once a prose lands after.
+      claudeTool("g1", "Bash", "echo 1"),
+      claudeResult("g1", "1"),
+      claudeTool("g2", "Bash", "echo 2"),
+      claudeResult("g2", "exited with code 3"),
+      claudeTool("g3", "Read", "cat a.txt"),
+      claudeResult("g3", "aaa"),
+      claudeTool("g4", "Bash", "echo 4"),
+      claudeResult("g4", "4"),
+      claudeTool("g5", "Bash", "echo 5"),
+      claudeResult("g5", "5"),
+      claudeProse("Серія завершена."),
+      claudeSend("m1", "worker-1", "перевір гілку"),
+      claudeResult("m1", '{"success": true, "msg_id": "abc123"}'),
+      JSON.stringify({ type: "system", subtype: "compact_boundary", timestamp: "t", compactMetadata: { trigger: "auto", preTokens: 9000 } }),
+      JSON.stringify({ type: "user", isCompactSummary: true, message: { content: "Підсумок розмови." } }),
+      claudeUser("продовжуй"),
+      claudeProse("Продовжую."),
+    ];
+    assertParity(claudeFile, lines);
+    assertParity(claudeFile, lines, { cap: 7, chunks: [2, 1, 3] });
+    assertParity(claudeFile, lines, { showSvc: true });
+    assertParity(claudeFile, lines, { live: true, chunks: [1] });
+  });
+
+  test("codex rollout: echo dedup, shell calls, compaction pair, service rows", () => {
+    const lines = [
+      JSON.stringify({ type: "session_meta", timestamp: "t0", payload: { model: "gpt-5.2", cwd: "/tmp" } }),
+      JSON.stringify({ type: "response_item", timestamp: "t1", payload: { type: "message", role: "user", content: [{ type: "input_text", text: "запусти тести" }] } }),
+      JSON.stringify({ type: "event_msg", timestamp: "t1", payload: { type: "user_message", message: "запусти тести" } }),
+      JSON.stringify({ type: "event_msg", timestamp: "t2", payload: { type: "task_started" } }),
+      JSON.stringify({ type: "response_item", timestamp: "t3", payload: { type: "function_call", name: "shell", call_id: "s1", arguments: JSON.stringify({ command: "bun test" }) } }),
+      JSON.stringify({ type: "response_item", timestamp: "t4", payload: { type: "function_call_output", call_id: "s1", output: "42 pass" } }),
+      JSON.stringify({ type: "response_item", timestamp: "t5", payload: { type: "reasoning" } }),
+      JSON.stringify({ type: "response_item", timestamp: "t6", payload: { type: "message", role: "assistant", content: [{ type: "text", text: "Тести зелені." }] } }),
+      JSON.stringify({ type: "event_msg", timestamp: "t6", payload: { type: "agent_message", message: "Тести зелені." } }),
+      JSON.stringify({ type: "compacted", timestamp: "t7" }),
+      JSON.stringify({ type: "event_msg", timestamp: "t7", payload: { type: "context_compacted" } }),
+      JSON.stringify({ type: "event_msg", timestamp: "t8", payload: { type: "task_complete" } }),
+    ];
+    assertParity(codexFile, lines);
+    assertParity(codexFile, lines, { showSvc: true });
+    /* The sliding-cap variant leaves out the doubled echo records: a full
+       re-parse of a window whose original slid out resurrects the echo as a
+       fresh bubble, while the session correctly keeps it deduplicated — that
+       divergence is the artifact, so parity is asserted without it. */
+    const noEcho = lines.filter((_, idx) => idx !== 2 && idx !== 8 && idx !== 10);
+    assertParity(codexFile, noEcho, { cap: 4, chunks: [1, 2] });
+    assertParity(codexFile, noEcho, { cap: 3, chunks: [1] });
+  });
+
+  test("plain job log: command lifecycle and a pending structured block", () => {
+    const lines = [
+      "[10:00] Running command: /usr/bin/zsh -lc bun run build",
+      "[10:01] Command completed",
+      "[10:01] Проміжна відповідь агента",
+      "[10:02] Running command: bun test",
+      "[10:03] Command failed: exited with code 1",
+      "plain raw line without brackets",
+    ];
+    assertParity(plainFile, lines, { chunks: [1] });
+    assertParity(plainFile, lines, { cap: 3, chunks: [2, 1] });
+  });
+
+  test("window slide past a tool_use: its result degrades to the svc fallback", () => {
+    const lines = [
+      claudeTool("c1", "Bash", "sleep 100"),
+      claudeUser("а"),
+      claudeUser("б"),
+      claudeUser("в"),
+      claudeResult("c1", "done late"),
+    ];
+    // cap 3 evicts the tool_use before its result arrives on both sides.
+    assertParity(claudeFile, lines, { cap: 3, chunks: [1], showSvc: true });
+  });
+});
+
+describe("feed session identity stability", () => {
+  test("appending prose keeps every existing item identity", () => {
+    const session = createFeedSession({ engine: "claude", fmt: "claude", showSvc: false, lineFilter: "" });
+    const lines = [claudeUser("раз"), claudeProse("один"), claudeUser("два")];
+    const before = session.feed(lines, 0, true);
+    const after = session.feed([...lines, claudeProse("другий")], 0, true);
+    expect(after.items.length).toBe(before.items.length + 1);
+    for (let i = 0; i < before.items.length; i += 1) {
+      expect(after.items[i].item).toBe(before.items[i].item);
+      expect(after.items[i].key).toBe(before.items[i].key);
+    }
+  });
+
+  test("a tool_result changes only its own cmd item", () => {
+    const session = createFeedSession({ engine: "claude", fmt: "claude", showSvc: false, lineFilter: "" });
+    const lines = [claudeUser("го"), claudeTool("c1", "Bash", "ls"), claudeTool("c2", "Bash", "pwd")];
+    const before = session.feed(lines, 0, true);
+    const after = session.feed([...lines, claudeResult("c1", "ok done")], 0, true);
+    // user bubble and the untouched second call keep their identity
+    expect(after.items[0].item).toBe(before.items[0].item);
+    expect(after.items[2].item).toBe(before.items[2].item);
+    // the resolved call is a fresh object with the result attached
+    expect(after.items[1].item).not.toBe(before.items[1].item);
+    const resolved = after.items[1].item;
+    if (resolved.kind !== "cmd") throw new Error("expected cmd item");
+    expect(resolved.call.status).toBe("ok");
+    expect(after.items[1].key).toBe(before.items[1].key);
+  });
+
+  test("idempotent re-feed of an unchanged window returns the cached snapshot", () => {
+    const session = createFeedSession({ engine: "claude", fmt: "claude", showSvc: false, lineFilter: "" });
+    const lines = [claudeUser("раз"), claudeProse("один")];
+    const first = session.feed(lines, 0, false);
+    const second = session.feed(lines, 0, false);
+    expect(second).toBe(first);
+  });
+
+  test("a folded cmd-group keeps its identity across unrelated appends", () => {
+    const session = createFeedSession({ engine: "claude", fmt: "claude", showSvc: false, lineFilter: "" });
+    const lines: string[] = [];
+    for (let i = 1; i <= 4; i += 1) {
+      lines.push(claudeTool("g" + i, "Bash", "echo " + i), claudeResult("g" + i, String(i)));
+    }
+    lines.push(claudeProse("після серії"));
+    const before = session.feed(lines, 0, false);
+    const group = before.items[0].item;
+    expect(group.kind).toBe("cmd-group");
+    const after = session.feed([...lines, claudeProse("ще одна відповідь")], 0, false);
+    expect(after.items[0].item).toBe(group);
+  });
+
+  test("prepended history resets the session and reparses the wider window", () => {
+    const session = createFeedSession({ engine: "claude", fmt: "claude", showSvc: false, lineFilter: "" });
+    const older = [claudeUser("стара репліка")];
+    const recent = [claudeUser("нова"), claudeProse("відповідь")];
+    session.feed(recent, 0, false);
+    const widened = session.feed(older.concat(recent), -1, false);
+    expect(normalize(widened.items.map((entry) => entry.item))).toEqual(
+      normalize(buildFeed(claudeFile, older.concat(recent), false, "").items),
+    );
+  });
+});

--- a/src/components/feed/parse.ts
+++ b/src/components/feed/parse.ts
@@ -72,6 +72,38 @@ export type Item =
   | { kind: "compact"; ts: unknown; trigger?: string; preTokens?: number; summary?: string }
   | { kind: "raw"; text: string; err: boolean };
 
+/** One rendered feed row: `key` is stable across incremental re-feeds, so a
+    row keeps its DOM node (and its memoized render) while the tail grows. */
+export interface FeedEntry {
+  key: string;
+  item: Item;
+}
+
+export interface FeedSnapshot {
+  items: FeedEntry[];
+  hiddenServiceCount: number;
+}
+
+export interface FeedSessionConfig {
+  engine: string;
+  fmt: string;
+  showSvc: boolean;
+  /** Lowercased needle; empty string disables filtering. */
+  lineFilter: string;
+}
+
+export interface FeedSession {
+  /**
+   * Consume the current line window and return the rendered feed. `start` is
+   * the absolute index of `lines[0]` in the tail stream (see useLogTail's
+   * `linesStart`): the session parses only lines it has not seen, drops items
+   * whose source lines slid out of the window, and keeps every untouched
+   * item's identity so memoized rows skip re-rendering. A window that moved
+   * backwards (prepend, truncation) resets the session and re-parses.
+   */
+  feed(lines: string[], start: number, isLive: boolean): FeedSnapshot;
+}
+
 const BLOB_MIN = 20_000;
 const BLOB_KEEP = 200_000;
 const MEM_CITATION_RE = /<oai-mem-citation>\s*<citation_entries>([\s\S]*?)<\/citation_entries>\s*<rollout_ids>([\s\S]*?)<\/rollout_ids>\s*<\/oai-mem-citation>/g;
@@ -204,25 +236,6 @@ function newCmd(cmd: string, icon: GlyphName = "shell"): Call {
   return { cmd: redacted, display: displayCmd(redacted), icon, output: "", status: "run", label: tr("render.executing"), open: false };
 }
 
-function attach(call: Call | undefined, output: string, errFlag?: boolean) {
-  if (!call) return null;
-  const code = output.match(/exited with code (\d+)/)?.[1];
-  const body = output
-    .replace(/^Chunk ID:[^\n]*\n/, "")
-    .replace(/Wall time:[^\n]*\n/, "")
-    .replace(/Original token count:[^\n]*\n?/, "")
-    .trim();
-  const isErr = errFlag === true || (code !== undefined && code !== "0");
-  call.status = isErr ? "err" : "ok";
-  call.label = isErr ? (code && code !== "0" ? "exit " + code : tr("render.error")) : "ok";
-  call.open ||= isErr;
-  if (body) {
-    const limit = isErr ? 60_000 : 12_000;
-    call.output = (call.output + "\n" + redactSecrets(body)).trim().slice(-limit);
-  }
-  return call;
-}
-
 const CMD_GROUP_MIN = 4;
 
 /* First word of the tool-name prefix ("Bash: ls" → "Bash"); Codex shell/exec
@@ -231,69 +244,71 @@ function toolNameOf(cmd: string): string {
   return cmd.match(/^([A-Za-z][\w.]*): /)?.[1] ?? "cmd";
 }
 
-/* Collapses runs of >=4 consecutive cmd items into one cmd-group item so a
-   long unbroken command series reads as a single summary line. "think" items
-   inside a run don't break it (and are absorbed into the group, since they
-   carry no signal once the run they annotate is folded); prose/user/tmsg/
-   edit/review/image do break it. The last run of a live transcript is never
-   folded, so the currently running call always stays visible. */
-function groupCmdRuns(items: Item[], isLive: boolean): Item[] {
-  const out: Item[] = [];
-  let i = 0;
-  while (i < items.length) {
-    if (items[i].kind !== "cmd") {
-      out.push(items[i]);
-      i += 1;
-      continue;
-    }
-    let j = i;
-    const cmdItems: Extract<Item, { kind: "cmd" }>[] = [];
-    while (j < items.length) {
-      const cur = items[j];
-      if (cur.kind === "cmd") cmdItems.push(cur);
-      else if (cur.kind !== "think") break;
-      j += 1;
-    }
-    const isLastRun = j === items.length;
-    if (cmdItems.length >= CMD_GROUP_MIN && !(isLive && isLastRun)) {
-      const byTool: Record<string, number> = {};
-      let okCount = 0;
-      let errCount = 0;
-      for (const it of cmdItems) {
-        const tool = toolNameOf(it.call.cmd);
-        byTool[tool] = (byTool[tool] ?? 0) + 1;
-        if (it.call.status === "ok") okCount += 1;
-        else if (it.call.status === "err") errCount += 1;
-      }
-      out.push({
-        kind: "cmd-group",
-        ids: cmdItems.map((it) => it.id),
-        calls: cmdItems.map((it) => it.call),
-        t0: cmdItems[0]?.ts,
-        t1: cmdItems.at(-1)?.ts,
-        byTool,
-        okCount,
-        errCount,
-        hasErr: errCount > 0,
-      });
-      i = j;
-    } else {
-      out.push(items[i]);
-      i += 1;
-    }
-  }
-  return out;
+interface StoredEntry {
+  /** Monotonic push counter — the React key; consecutive within `entries`. */
+  seq: number;
+  /** Absolute index of the source line, for window-slide eviction. */
+  src: number;
+  item: Item;
 }
 
-export function buildFeed(file: FileEntry, lines: string[], showSvc: boolean, lineFilter: string) {
-  const calls = new Map<string, Call>();
-  const tmsgs = new Map<string, Tmsg>();
-  const items: Item[] = [];
+interface CallRec {
+  call: Call;
+  seq: number;
+}
+
+/**
+ * The stateful line-window parser behind a feed pane. All cross-line effects
+ * (tool_result attaching to its call, teammate delivery echoes, compaction
+ * summaries, prose/echo dedup) mutate copy-on-write: the affected entry gets
+ * a new item object while every other entry keeps its identity — that is what
+ * lets memoized FeedItems skip markdown re-render on every tail tick.
+ */
+export function createFeedSession(cfg: FeedSessionConfig): FeedSession {
+  const { showSvc, lineFilter } = cfg;
+  const jsonl = cfg.fmt === "claude" || cfg.fmt === "codex";
+
+  const entries: StoredEntry[] = [];
+  const calls = new Map<string, CallRec>();
+  /* Outgoing teammate messages awaiting their delivery echo, by tool_use id;
+     the reverse map exists only so window-slide eviction can prune. */
+  const tmsgSeqs = new Map<string, number>();
+  const tmsgKeyBySeq = new Map<number, string>();
+  /* Hidden service rows are counted, not stored; per-line counts let the
+     total shrink when their source lines slide out of the window. */
+  const hiddenSvcBySrc = new Map<number, number>();
   let hiddenServiceCount = 0;
-  let lastProse = "";
+  let pushSeq = 0;
+  let curSrc = 0;
+  /** Absolute index just past the last consumed line; null before first feed. */
+  let consumedEnd: number | null = null;
+  /** Window start of the previous feed — a start that moved backwards means
+      prepended history, which a sequential parser cannot resume across. */
+  let lastStart = -Infinity;
+  /* Dedup/marker state remembers the source line it came from: when that line
+     slides out of the window the state clears, matching what a re-parse of
+     the shortened window would know. */
+  let lastProse: { text: string; src: number } | null = null;
+  let lastUser: { text: string; at: number; src: number } | null = null;
+  let codexCompacted: { src: number } | null = null;
+  let plainBlock: { lines: string[]; src: number } | null = null;
+  let lastPlainCall: CallRec | null = null;
+  /* Snapshot cache + fold-group identity reuse across re-feeds. */
+  let prevGroups = new Map<number, CmdGroupItem>();
+  let snapshot: FeedSnapshot | null = null;
+  let snapshotLive: boolean | null = null;
+
+  const entryIndex = (seq: number): number => (entries.length ? seq - entries[0].seq : -1);
+
+  const push = (item: Item): number => {
+    entries.push({ seq: pushSeq, src: curSrc, item });
+    snapshot = null;
+    return pushSeq++;
+  };
+
   const pushBlobIfHuge = (text: string): boolean => {
     if (!looksLikeBlob(text)) return false;
-    items.push({ kind: "blob", bytes: text.length, text: redactSecrets(text).slice(0, BLOB_KEEP) });
+    push({ kind: "blob", bytes: text.length, text: redactSecrets(text).slice(0, BLOB_KEEP) });
     return true;
   };
   const pushImage = (block: Record<string, unknown>, fileWrap: Record<string, unknown>) => {
@@ -303,7 +318,7 @@ export function buildFeed(file: FileEntry, lines: string[], showSvc: boolean, li
     const mt = textPart(source.media_type) || textPart(fileWrap.type);
     const media = mt.startsWith("image/") ? mt : "image/png";
     const dims = rec(fileWrap.dimensions);
-    items.push({
+    push({
       kind: "image",
       media,
       data,
@@ -316,15 +331,17 @@ export function buildFeed(file: FileEntry, lines: string[], showSvc: boolean, li
      block inside `text`, rendering them as structured cards. Runs for both the
      codex feed and quoted review text inside a claude transcript. Non-structured
      segments are handed back through `fallback` so callers keep their own bubble
-     style (prose vs user). Returns true when at least one card was produced. */
-  const pushStructured = (ts: unknown, text: string, fallback: (segment: string) => void): boolean => {
+     style (prose vs user). Returns true when at least one card was produced.
+     `emit` defaults to the session store; the pending-plain-block preview passes
+     a transient collector instead. */
+  const pushStructured = (ts: unknown, text: string, fallback: (segment: string) => void, emit: (item: Item) => void = push): boolean => {
     MEM_CITATION_RE.lastIndex = 0;
     const hasCitation = MEM_CITATION_RE.test(text);
     MEM_CITATION_RE.lastIndex = 0;
     if (!hasCitation) {
       const review = parseReview(text.trim(), ts);
       if (!review) return false;
-      items.push(review);
+      emit(review);
       return true;
     }
     let handled = false;
@@ -334,7 +351,7 @@ export function buildFeed(file: FileEntry, lines: string[], showSvc: boolean, li
       if (!trimmed) return;
       const review = parseReview(trimmed, ts);
       if (review) {
-        items.push(review);
+        emit(review);
         handled = true;
       } else {
         fallback(trimmed);
@@ -344,7 +361,7 @@ export function buildFeed(file: FileEntry, lines: string[], showSvc: boolean, li
       const whole = match[0];
       const index = match.index ?? 0;
       pushTextPart(text.slice(last, index));
-      items.push(parseMemCitation(whole, match[1] ?? "", match[2] ?? ""));
+      emit(parseMemCitation(whole, match[1] ?? "", match[2] ?? ""));
       handled = true;
       last = index + whole.length;
     }
@@ -365,38 +382,82 @@ export function buildFeed(file: FileEntry, lines: string[], showSvc: boolean, li
     return { cleaned, cites };
   };
   const addProse = (ts: unknown, text: string) => {
-    if (!text.trim() || text === lastProse) return;
-    lastProse = text;
+    if (!text.trim() || text === lastProse?.text) return;
+    lastProse = { text, src: curSrc };
     if (pushBlobIfHuge(text)) return;
-    const engine = file.engine === "codex" ? "codex" : "claude";
-    if (pushStructured(ts, text, (segment) => items.push({ kind: "prose", ts, text: segment, engine }))) return;
-    items.push({ kind: "prose", ts, text, engine });
+    const engine = cfg.engine === "codex" ? "codex" : "claude";
+    if (pushStructured(ts, text, (segment) => push({ kind: "prose", ts, text: segment, engine }))) return;
+    push({ kind: "prose", ts, text, engine });
   };
   const addCmd = (ts: unknown, cmd: string, callId?: string, icon?: GlyphName) => {
-    const id = callId || "plain-" + items.length + "-" + String(ts ?? "");
+    const id = callId || "plain-" + pushSeq + "-" + String(ts ?? "");
     const call = newCmd(cmd, icon);
-    calls.set(id, call);
-    items.push({ kind: "cmd", id, call, ts });
+    const seq = push({ kind: "cmd", id, call, ts });
+    const callRec: CallRec = { call, seq };
+    calls.set(id, callRec);
+    lastPlainCall = callRec;
+    return call;
+  };
+  /* Attaches a result to its call copy-on-write: the record gets a fresh Call
+     and the owning entry a fresh item, so exactly one row changes identity. */
+  const attach = (callRec: CallRec | undefined, output: string, errFlag?: boolean) => {
+    if (!callRec) return null;
+    const code = output.match(/exited with code (\d+)/)?.[1];
+    const body = output
+      .replace(/^Chunk ID:[^\n]*\n/, "")
+      .replace(/Wall time:[^\n]*\n/, "")
+      .replace(/Original token count:[^\n]*\n?/, "")
+      .trim();
+    const isErr = errFlag === true || (code !== undefined && code !== "0");
+    const call: Call = { ...callRec.call };
+    call.status = isErr ? "err" : "ok";
+    call.label = isErr ? (code && code !== "0" ? "exit " + code : tr("render.error")) : "ok";
+    call.open ||= isErr;
+    if (body) {
+      const limit = isErr ? 60_000 : 12_000;
+      call.output = (call.output + "\n" + redactSecrets(body)).trim().slice(-limit);
+    }
+    callRec.call = call;
+    const idx = entryIndex(callRec.seq);
+    if (idx >= 0 && idx < entries.length) {
+      const old = entries[idx].item;
+      if (old.kind === "cmd") {
+        entries[idx] = { ...entries[idx], item: { ...old, call } };
+        snapshot = null;
+      }
+    }
     return call;
   };
   const addOutput = (callId: string | undefined, output: string, err?: boolean) => {
     if (!callId) return;
-    const tmsg = tmsgs.get(callId);
-    if (tmsg) {
+    const tseq = tmsgSeqs.get(callId);
+    if (tseq !== undefined) {
       /* The routing echo repeats the whole message body; keep only the delivery state. */
-      tmsg.delivery = err || /"success"\s*:\s*false/.test(output) ? "err" : "ok";
-      tmsg.msgId = output.match(/"msg_id"\s*:\s*"([^"]+)"/)?.[1];
+      const idx = entryIndex(tseq);
+      if (idx >= 0 && idx < entries.length) {
+        const old = entries[idx].item;
+        if (old.kind === "tmsg") {
+          const delivery: "ok" | "err" = err || /"success"\s*:\s*false/.test(output) ? "err" : "ok";
+          const msgId = output.match(/"msg_id"\s*:\s*"([^"]+)"/)?.[1];
+          entries[idx] = { ...entries[idx], item: { ...old, delivery, msgId } };
+          snapshot = null;
+        }
+      }
       return;
     }
     const call = attach(calls.get(callId), output, err);
-    if (!call && output && showSvc) items.push({ kind: "svc", text: "output: " + redactSecrets(output).slice(0, 200) });
+    if (!call && output && showSvc) push({ kind: "svc", text: "output: " + redactSecrets(output).slice(0, 200) });
   };
   const addSvc = (text: string) => {
-    if (showSvc) items.push({ kind: "svc", text: text.slice(0, 300) });
-    else hiddenServiceCount += 1;
+    if (showSvc) push({ kind: "svc", text: text.slice(0, 300) });
+    else {
+      hiddenServiceCount += 1;
+      hiddenSvcBySrc.set(curSrc, (hiddenSvcBySrc.get(curSrc) ?? 0) + 1);
+      snapshot = null;
+    }
   };
   const addNote = (text: string) => {
-    items.push({ kind: "note", text });
+    push({ kind: "note", text });
   };
   /* Inbound teammate traffic arrives as user text wrapped in <teammate-message>;
      idle_notification JSON bodies collapse to a thin service-style row. */
@@ -410,7 +471,7 @@ export function buildFeed(file: FileEntry, lines: string[], showSvc: boolean, li
           const obj = JSON.parse(trimmed) as Record<string, unknown>;
           if (obj.type === "idle_notification") {
             const at = hhmm(obj.timestamp);
-            items.push({ kind: "tnote", text: tr("render.left", { peer, at: at ? " · " + at : "" }) });
+            push({ kind: "tnote", text: tr("render.left", { peer, at: at ? " · " + at : "" }) });
             return "";
           }
         } catch {
@@ -422,58 +483,55 @@ export function buildFeed(file: FileEntry, lines: string[], showSvc: boolean, li
          render the content as a review card. The strict start anchor keeps task
          briefs that merely mention APPROVE/REQUEST_CHANGES as plain text. */
       const review = VERDICT_LINE_RE.test(cleaned) ? parseReview(cleaned, ts) : null;
-      items.push({ kind: "tmsg", ts, dir: "in", peer, summary, text: review ? "" : cleaned });
-      if (review) items.push(review);
-      for (const cite of cites) items.push(cite);
+      push({ kind: "tmsg", ts, dir: "in", peer, summary, text: review ? "" : cleaned });
+      if (review) push(review);
+      for (const cite of cites) push(cite);
       return "";
     });
     const leftover = rest.replace(/Another Claude session sent a message:\s*/g, "").trim();
     if (!leftover || pushBlobIfHuge(leftover)) return;
-    if (SYS_MSG_RE.test(leftover)) return void items.push({ kind: "sysmsg", label: sysMsgLabel(leftover), text: leftover });
+    if (SYS_MSG_RE.test(leftover)) return void push({ kind: "sysmsg", label: sysMsgLabel(leftover), text: leftover });
     const { cleaned, images } = extractInboxImages(leftover);
-    if (cleaned && !pushStructured(ts, cleaned, (segment) => items.push({ kind: "user", ts, text: segment }))) {
-      items.push({ kind: "user", ts, text: cleaned });
+    if (cleaned && !pushStructured(ts, cleaned, (segment) => push({ kind: "user", ts, text: segment }))) {
+      push({ kind: "user", ts, text: cleaned });
     }
-    for (const image of images) items.push({ kind: "inbox-image", name: image.name, path: image.path });
+    for (const image of images) push({ kind: "inbox-image", name: image.name, path: image.path });
   };
   /* Codex user turns carry no envelopes to unwrap: the bubble text plus a card
      per attached inbox image. A rollout logs the same turn twice — as a
      response_item and as an event_msg echo right next to it — so an exact
      repeat with nothing rendered in between folds away; a message the user
      really sent twice has agent output between the copies and stays. */
-  let lastUser: { text: string; at: number } | null = null;
   const addPlainUser = (ts: unknown, text: string) => {
-    if (lastUser && lastUser.text === text && lastUser.at === items.length) return;
+    if (lastUser && lastUser.text === text && lastUser.at === pushSeq) return;
     const { cleaned, images } = extractInboxImages(text);
-    if (cleaned) items.push({ kind: "user", ts, text: cleaned });
-    for (const image of images) items.push({ kind: "inbox-image", name: image.name, path: image.path });
-    lastUser = { text, at: items.length };
+    if (cleaned) push({ kind: "user", ts, text: cleaned });
+    for (const image of images) push({ kind: "inbox-image", name: image.name, path: image.path });
+    lastUser = { text, at: pushSeq, src: curSrc };
   };
   /* Harness turns fold into a sysmsg row; the same echo dedup applies since
      they arrive through the same doubled user-role records. */
   const addSysMsg = (text: string, fallbackLabel?: string) => {
-    if (lastUser && lastUser.text === text && lastUser.at === items.length) return;
-    items.push({ kind: "sysmsg", label: sysMsgLabel(text, fallbackLabel), text });
-    lastUser = { text, at: items.length };
+    if (lastUser && lastUser.text === text && lastUser.at === pushSeq) return;
+    push({ kind: "sysmsg", label: sysMsgLabel(text, fallbackLabel), text });
+    lastUser = { text, at: pushSeq, src: curSrc };
   };
-  /* One Codex compaction leaves two markers (a `compacted` record, then an
-     event_msg echo a few hidden records later); the flag folds the pair. */
-  let codexCompacted = false;
   const addCompact = (ts: unknown, meta?: { trigger?: string; preTokens?: number }) => {
-    items.push({ kind: "compact", ts, trigger: meta?.trigger, preTokens: meta?.preTokens });
+    push({ kind: "compact", ts, trigger: meta?.trigger, preTokens: meta?.preTokens });
   };
   /* The Claude compact summary follows its boundary record; attach it there,
      skipping the service rows that may sit between them. */
   const attachCompactSummary = (ts: unknown, summary: string) => {
-    for (let i = items.length - 1; i >= 0; i -= 1) {
-      const it = items[i];
+    for (let i = entries.length - 1; i >= 0; i -= 1) {
+      const it = entries[i].item;
       if (it.kind === "compact") {
-        it.summary = summary;
+        entries[i] = { ...entries[i], item: { ...it, summary } };
+        snapshot = null;
         return;
       }
       if (it.kind !== "svc" && it.kind !== "note") break;
     }
-    items.push({ kind: "compact", ts, summary });
+    push({ kind: "compact", ts, summary });
   };
   const renderCodex = (obj: Record<string, unknown>) => {
     const p = rec(obj.payload);
@@ -491,7 +549,7 @@ export function buildFeed(file: FileEntry, lines: string[], showSvc: boolean, li
       if (p.type === "task_started") return addNote(tr("render.taskStarted") + (ts ? " · " + hhmm(ts) : ""));
       if (p.type === "task_complete") return addNote(tr("render.taskComplete") + (ts ? " · " + hhmm(ts) : ""));
       if (p.type === "context_compacted") {
-        if (codexCompacted) return void (codexCompacted = false);
+        if (codexCompacted) return void (codexCompacted = null);
         return addCompact(ts);
       }
       return addSvc(textPart(p.type) || "event");
@@ -520,7 +578,7 @@ export function buildFeed(file: FileEntry, lines: string[], showSvc: boolean, li
         }
         if (name === "apply_patch") {
           const files = String(args.input ?? "").match(/(Add|Update|Delete) File: [^\n]+/g);
-          items.push({ kind: "edit", files: files ? files.join(", ").replace(/(Add|Update|Delete) File: /g, "") : tr("render.patch") });
+          push({ kind: "edit", files: files ? files.join(", ").replace(/(Add|Update|Delete) File: /g, "") : tr("render.patch") });
           return;
         }
         if (name === "write_stdin") return addSvc(tr("render.stdinSession", { id: String(args.session_id ?? "") }));
@@ -532,7 +590,7 @@ export function buildFeed(file: FileEntry, lines: string[], showSvc: boolean, li
          JSON-encoded string), so no JSON.parse step is needed here. */
       if (p.type === "custom_tool_call" && textPart(p.name) === "apply_patch") {
         const files = textPart(p.input).match(/(Add|Update|Delete) File: [^\n]+/g);
-        items.push({ kind: "edit", files: files ? files.join(", ").replace(/(Add|Update|Delete) File: /g, "") : tr("render.patch") });
+        push({ kind: "edit", files: files ? files.join(", ").replace(/(Add|Update|Delete) File: /g, "") : tr("render.patch") });
         return;
       }
       if (p.type === "custom_tool_call_output") return addOutput(textPart(p.call_id), typeof p.output === "string" ? p.output : JSON.stringify(p.output ?? ""));
@@ -540,7 +598,7 @@ export function buildFeed(file: FileEntry, lines: string[], showSvc: boolean, li
       return addSvc(textPart(p.type) || "item");
     }
     if (obj.type === "compacted") {
-      codexCompacted = true;
+      codexCompacted = { src: curSrc };
       return addCompact(ts);
     }
     addSvc(textPart(obj.type) || tr("render.record"));
@@ -585,7 +643,7 @@ export function buildFeed(file: FileEntry, lines: string[], showSvc: boolean, li
       for (const part of arr(rec(obj.message).content)) {
         if (part.type === "text" && textPart(part.text).trim()) addProse(ts, textPart(part.text));
         else if (part.type === "thinking" && textPart(part.thinking).trim()) {
-          items.push({ kind: "think", text: textPart(part.thinking).replace(/\s+/g, " ").trim() });
+          push({ kind: "think", text: textPart(part.thinking).replace(/\s+/g, " ").trim() });
         } else if (part.type === "tool_use" && textPart(part.name) === "SendMessage") {
           const input = rec(part.input);
           const message = input.message;
@@ -600,10 +658,14 @@ export function buildFeed(file: FileEntry, lines: string[], showSvc: boolean, li
               summary: String(input.summary ?? ""),
               text: review ? "" : cleaned,
             };
-            items.push(item);
-            if (review) items.push(review);
-            for (const cite of cites) items.push(cite);
-            if (textPart(part.id)) tmsgs.set(textPart(part.id), item);
+            const seq = push(item);
+            if (review) push(review);
+            for (const cite of cites) push(cite);
+            const key = textPart(part.id);
+            if (key) {
+              tmsgSeqs.set(key, seq);
+              tmsgKeyBySeq.set(seq, key);
+            }
           } else {
             addSvc(`SendMessage → ${String(input.to ?? "")} · ${textPart(rec(message).type) || tr("render.protocol")}`);
           }
@@ -624,19 +686,32 @@ export function buildFeed(file: FileEntry, lines: string[], showSvc: boolean, li
   /* Job .output logs echo the final review/citation block as bare lines after the
      [codex] stream ends; collect that run so it renders as one structured card
      instead of per-line raw rows. Falls back to the old raw rows when the block
-     turns out not to be structured. */
-  let plainBlock: string[] | null = null;
+     turns out not to be structured. A block still open at the window end is
+     previewed transiently by the snapshot (pendingPlainItems) and committed
+     only when its terminator arrives — an incremental feed must not consume
+     state it may need for the block's continuation. */
+  const rawLinesInto = (emit: (item: Item) => void) => (segment: string) => {
+    for (const raw of segment.split("\n")) {
+      if (raw.trim()) emit({ kind: "raw", text: redactSecrets(raw), err: /error|failed|traceback|exception/i.test(raw) });
+    }
+  };
   const flushPlainBlock = () => {
     if (!plainBlock) return;
-    const text = plainBlock.join("\n").trim();
+    const text = plainBlock.lines.join("\n").trim();
     plainBlock = null;
     if (!text) return;
-    const pushRawLines = (segment: string) => {
-      for (const raw of segment.split("\n")) {
-        if (raw.trim()) items.push({ kind: "raw", text: redactSecrets(raw), err: /error|failed|traceback|exception/i.test(raw) });
-      }
-    };
+    const pushRawLines = rawLinesInto(push);
     if (!pushStructured(null, text, pushRawLines)) pushRawLines(text);
+  };
+  const pendingPlainItems = (): Item[] => {
+    if (!plainBlock) return [];
+    const text = plainBlock.lines.join("\n").trim();
+    if (!text) return [];
+    const out: Item[] = [];
+    const emit = (item: Item) => out.push(item);
+    const fallback = rawLinesInto(emit);
+    if (!pushStructured(null, text, fallback, emit)) fallback(text);
+    return out;
   };
   const renderPlain = (rawLine: string) => {
     // Shell .output files carry terminal ANSI/OSC escapes; strip them for display.
@@ -644,7 +719,8 @@ export function buildFeed(file: FileEntry, lines: string[], showSvc: boolean, li
     if (plainBlock) {
       if (/^\[codex\]/.test(line)) flushPlainBlock();
       else {
-        plainBlock.push(line);
+        plainBlock.lines.push(line);
+        snapshot = null;
         return;
       }
     }
@@ -654,36 +730,186 @@ export function buildFeed(file: FileEntry, lines: string[], showSvc: boolean, li
     const rest = m?.[2] ?? line;
     if (!rest || /^Assistant message captured/.test(rest)) return;
     if (!m && (VERDICT_LINE_RE.test(line) || line.startsWith("<oai-mem-citation>"))) {
-      plainBlock = [line];
+      plainBlock = { lines: [line], src: curSrc };
+      snapshot = null;
       return;
     }
-    if (/^Running command: /.test(rest)) return addCmd(ts, rest.replace(/^Running command: /, "").replace(/^\/usr\/bin\/zsh -lc /, ""));
+    if (/^Running command: /.test(rest)) return void addCmd(ts, rest.replace(/^Running command: /, "").replace(/^\/usr\/bin\/zsh -lc /, ""));
     if (/^Command (completed|failed)/.test(rest)) {
-      const last = [...calls.values()].at(-1);
-      if (last) {
-        attach(last, /^Command failed/.test(rest) ? rest + "\n" + tr("render.jobLogNote") : rest, /^Command failed/.test(rest));
+      if (lastPlainCall) {
+        attach(lastPlainCall, /^Command failed/.test(rest) ? rest + "\n" + tr("render.jobLogNote") : rest, /^Command failed/.test(rest));
       }
       return;
     }
-    if (/^Applying \d+ file/.test(rest)) return items.push({ kind: "edit", files: rest });
+    if (/^Applying \d+ file/.test(rest)) return void push({ kind: "edit", files: rest });
     if (m && !/^(Running|Command|Applying)/.test(rest)) return addProse(ts, rest);
     if (pushBlobIfHuge(line)) return;
-    items.push({ kind: "raw", text: redactSecrets(line), err: /error|failed|traceback|exception/i.test(line) });
+    push({ kind: "raw", text: redactSecrets(line), err: /error|failed|traceback|exception/i.test(line) });
   };
-  for (const line of lines) {
-    if (lineFilter && !line.toLowerCase().includes(lineFilter)) continue;
-    if (file.fmt === "claude" || file.fmt === "codex") {
+  const consume = (line: string) => {
+    if (lineFilter && !line.toLowerCase().includes(lineFilter)) return;
+    if (jsonl) {
       try {
         const obj = JSON.parse(line);
         if (obj && typeof obj === "object" && !Array.isArray(obj)) {
-          if (file.fmt === "claude") renderClaude(obj);
+          if (cfg.fmt === "claude") renderClaude(obj);
           else renderCodex(obj);
         }
       } catch {
         renderPlain(line);
       }
     } else renderPlain(line);
-  }
-  flushPlainBlock();
-  return { items: groupCmdRuns(items, file.activity === "live"), hiddenServiceCount };
+  };
+
+  const reset = () => {
+    entries.length = 0;
+    calls.clear();
+    tmsgSeqs.clear();
+    tmsgKeyBySeq.clear();
+    hiddenSvcBySrc.clear();
+    hiddenServiceCount = 0;
+    lastProse = null;
+    lastUser = null;
+    codexCompacted = null;
+    plainBlock = null;
+    lastPlainCall = null;
+    prevGroups = new Map();
+    snapshot = null;
+    /* pushSeq keeps counting across resets so React keys never collide. */
+  };
+
+  /** Evicts entries and state owned by lines that left the window. Returns
+      true when a pending plain block lost its opening line — sequential state
+      that cannot be resumed, so the caller re-parses the window whole. */
+  const dropBefore = (start: number): boolean => {
+    while (entries.length && entries[0].src < start) {
+      const gone = entries.shift()!;
+      snapshot = null;
+      if (gone.item.kind === "cmd") {
+        const callRec = calls.get(gone.item.id);
+        /* A later tool_result for an evicted call now falls back to the svc
+           row, exactly like a full re-parse of the shortened window would. */
+        if (callRec && callRec.seq === gone.seq) calls.delete(gone.item.id);
+      }
+      const tkey = tmsgKeyBySeq.get(gone.seq);
+      if (tkey !== undefined) {
+        tmsgKeyBySeq.delete(gone.seq);
+        if (tmsgSeqs.get(tkey) === gone.seq) tmsgSeqs.delete(tkey);
+      }
+    }
+    for (const [src, count] of hiddenSvcBySrc) {
+      if (src >= start) break;
+      hiddenServiceCount -= count;
+      hiddenSvcBySrc.delete(src);
+      snapshot = null;
+    }
+    if (lastProse && lastProse.src < start) lastProse = null;
+    if (lastUser && lastUser.src < start) lastUser = null;
+    if (codexCompacted && codexCompacted.src < start) codexCompacted = null;
+    if (lastPlainCall && entryIndex(lastPlainCall.seq) < 0) lastPlainCall = null;
+    return plainBlock !== null && plainBlock.src < start;
+  };
+
+  /* Collapses runs of >=4 consecutive cmd entries into one cmd-group item so a
+     long unbroken command series reads as a single summary line. "think" items
+     inside a run don't break it (and are absorbed into the group, since they
+     carry no signal once the run they annotate is folded); prose/user/tmsg/
+     edit/review/image do break it. The last run of a live transcript is never
+     folded, so the currently running call always stays visible. A group whose
+     members' calls are all identity-equal to the previous snapshot's is reused
+     as-is, keeping its card memoized. */
+  const buildSnapshot = (isLive: boolean): FeedSnapshot => {
+    const out: FeedEntry[] = [];
+    const nextGroups = new Map<number, CmdGroupItem>();
+    let i = 0;
+    while (i < entries.length) {
+      const head = entries[i];
+      if (head.item.kind !== "cmd") {
+        out.push({ key: String(head.seq), item: head.item });
+        i += 1;
+        continue;
+      }
+      let j = i;
+      const cmdEntries: { seq: number; item: Extract<Item, { kind: "cmd" }> }[] = [];
+      while (j < entries.length) {
+        const cur = entries[j];
+        if (cur.item.kind === "cmd") cmdEntries.push({ seq: cur.seq, item: cur.item });
+        else if (cur.item.kind !== "think") break;
+        j += 1;
+      }
+      const isLastRun = j === entries.length;
+      if (cmdEntries.length >= CMD_GROUP_MIN && !(isLive && isLastRun)) {
+        const gkey = cmdEntries[0].seq;
+        const prev = prevGroups.get(gkey);
+        let group: CmdGroupItem;
+        if (prev && prev.calls.length === cmdEntries.length && cmdEntries.every((entry, k) => prev.calls[k] === entry.item.call)) {
+          group = prev;
+        } else {
+          const byTool: Record<string, number> = {};
+          let okCount = 0;
+          let errCount = 0;
+          for (const entry of cmdEntries) {
+            const tool = toolNameOf(entry.item.call.cmd);
+            byTool[tool] = (byTool[tool] ?? 0) + 1;
+            if (entry.item.call.status === "ok") okCount += 1;
+            else if (entry.item.call.status === "err") errCount += 1;
+          }
+          group = {
+            kind: "cmd-group",
+            ids: cmdEntries.map((entry) => entry.item.id),
+            calls: cmdEntries.map((entry) => entry.item.call),
+            t0: cmdEntries[0]?.item.ts,
+            t1: cmdEntries.at(-1)?.item.ts,
+            byTool,
+            okCount,
+            errCount,
+            hasErr: errCount > 0,
+          };
+        }
+        nextGroups.set(gkey, group);
+        out.push({ key: "g" + gkey, item: group });
+        i = j;
+      } else {
+        out.push({ key: String(head.seq), item: head.item });
+        i += 1;
+      }
+    }
+    prevGroups = nextGroups;
+    pendingPlainItems().forEach((item, idx) => out.push({ key: "pb" + idx, item }));
+    return { items: out, hiddenServiceCount };
+  };
+
+  const feed = (lines: string[], start: number, isLive: boolean): FeedSnapshot => {
+    const end = start + lines.length;
+    /* A window that moved backwards (prepended history, truncation reset) or
+       past unseen lines cannot be resumed — re-parse it whole. */
+    if (consumedEnd === null || end < consumedEnd || start > consumedEnd || start < lastStart) {
+      reset();
+      consumedEnd = start;
+    }
+    lastStart = start;
+    if (dropBefore(start)) {
+      reset();
+      consumedEnd = start;
+    }
+    for (let i = consumedEnd - start; i < lines.length; i += 1) {
+      curSrc = start + i;
+      consume(lines[i]);
+    }
+    consumedEnd = end;
+    if (!snapshot || snapshotLive !== isLive) {
+      snapshot = buildSnapshot(isLive);
+      snapshotLive = isLive;
+    }
+    return snapshot;
+  };
+
+  return { feed };
+}
+
+/** One-shot parse of a whole window — a fresh session fed once. */
+export function buildFeed(file: FileEntry, lines: string[], showSvc: boolean, lineFilter: string) {
+  const session = createFeedSession({ engine: file.engine, fmt: file.fmt, showSvc, lineFilter });
+  const snap = session.feed(lines, 0, file.activity === "live");
+  return { items: snap.items.map((entry) => entry.item), hiddenServiceCount: snap.hiddenServiceCount };
 }

--- a/src/components/flows/RoundDeck.tsx
+++ b/src/components/flows/RoundDeck.tsx
@@ -83,6 +83,7 @@ export function RoundDeck({
   files,
   onSelect,
   focusRound,
+  dormant = false,
 }: {
   flow: Flow;
   rounds: DeckRound[];
@@ -90,6 +91,8 @@ export function RoundDeck({
   onSelect: (file: FileEntry) => void;
   /** Round chip clicked on the strip; nonce-encoded as `n + fraction` changes. */
   focusRound: number | null;
+  /** Far zoom on the board: the front pane's feed sleeps behind the labels. */
+  dormant?: boolean;
 }) {
   const { t } = useLocale();
   const latest = rounds.length ? rounds[rounds.length - 1]! : null;
@@ -143,6 +146,7 @@ export function RoundDeck({
             tasks={[]}
             onSelect={onSelect}
             isRoot={false}
+            dormant={dormant}
             noComposer={flow.reviewerMode === "headless" || finished}
             banner={
               <div

--- a/src/components/scheme/SchemeBoard.tsx
+++ b/src/components/scheme/SchemeBoard.tsx
@@ -29,6 +29,11 @@ import { useSchemeCamera } from "./useSchemeCamera";
 
 /* Below this zoom the big node labels fade in over the unreadable panes. */
 const LABEL_Z = 0.45;
+/* Feed-sleep hysteresis around LABEL_Z: panes go dormant a notch below the
+   label threshold and wake a notch above it, so pinching around the boundary
+   never flaps every pane's polling on and off. */
+const DORMANT_ENTER_Z = LABEL_Z * 0.95;
+const DORMANT_EXIT_Z = LABEL_Z * 1.1;
 
 const EMPTY_PATHS: ReadonlySet<string> = new Set();
 
@@ -480,6 +485,17 @@ export function SchemeBoard({
   );
   const cancelCreate = useCallback(() => setPendingTask(null), []);
 
+  /* Far-zoom feed sleep: behind the identity labels the pane content is
+     unreadable, so the live feeds stop polling until zoom comes back. One
+     boolean flip re-renders the memoized nodes layer once per crossing —
+     never per camera frame. */
+  const [dormant, setDormant] = useState(false);
+  useEffect(() => {
+    /* eslint-disable-next-line react-hooks/set-state-in-effect -- hysteresis
+       over a per-frame camera value; same-value writes bail out in React */
+    setDormant((prev) => (prev ? cam.z < DORMANT_EXIT_Z : cam.z < DORMANT_ENTER_Z));
+  }, [cam.z]);
+
   const tile = 24 * cam.z;
 
   return (
@@ -532,6 +548,7 @@ export function SchemeBoard({
           files={files}
           interactive={!handLike && !session}
           lite={mapMode}
+          dormant={dormant}
           selected={selected}
           multi={multi}
           session={session}

--- a/src/components/scheme/nodes.tsx
+++ b/src/components/scheme/nodes.tsx
@@ -413,6 +413,7 @@ function NodeShell({
   ringed,
   marked,
   dimmed,
+  dormant,
   flow,
   canFlow,
   onSelect,
@@ -428,6 +429,8 @@ function NodeShell({
   marked: boolean;
   /** «Show only needs me» attention filter dim. */
   dimmed: boolean;
+  /** Far zoom: pane feeds sleep behind the identity labels. */
+  dormant: boolean;
   /** Active review-loop flow attached to this conversation, if any. */
   flow: Flow | null;
   /** This node may host a new flow (root claude/codex conversation without one). */
@@ -496,6 +499,7 @@ function NodeShell({
           files={files}
           onSelect={onSelect}
           isRoot={node.isRoot}
+          dormant={dormant}
           onClose={() => onClose(node.file.path)}
           onToggleExpand={() => onExpand(node.file.path)}
         />
@@ -580,12 +584,14 @@ function DeckShell({
   files,
   focus,
   dimmed,
+  dormant,
   onSelect,
 }: {
   deck: DeckNode;
   files: FileEntry[];
   focus: DeckFocus | null;
   dimmed: boolean;
+  dormant: boolean;
   onSelect: (file: FileEntry) => void;
 }) {
   const focusRound = focus && focus.flowId === deck.flow.id ? focus.round + focus.nonce / 1000 : null;
@@ -595,7 +601,7 @@ function DeckShell({
       className={`scheme-enter absolute${dimClass(dimmed)}`}
       style={{ transform: `translate(${deck.x}px, ${deck.y}px)`, width: deck.w, height: deck.h, transition: MOVE_TRANSITION }}
     >
-      <RoundDeck flow={deck.flow} rounds={deck.rounds} files={files} onSelect={onSelect} focusRound={focusRound} />
+      <RoundDeck flow={deck.flow} rounds={deck.rounds} files={files} onSelect={onSelect} focusRound={focusRound} dormant={dormant} />
       <RoleTag role="reviewer" active={activeLoopRole(deck.flow) === "reviewer"} />
     </div>
   );
@@ -607,6 +613,7 @@ export const NodesLayer = memo(function NodesLayer({
   files,
   interactive,
   lite,
+  dormant,
   selected,
   multi,
   session,
@@ -628,6 +635,8 @@ export const NodesLayer = memo(function NodesLayer({
   interactive: boolean;
   /** Map mode: identity cards instead of live panes (no feeds, no polling). */
   lite: boolean;
+  /** Far zoom: live panes keep their DOM but stop polling behind the labels. */
+  dormant: boolean;
   selected: string | null;
   /** Selection-session member paths; visuals only change on commit. */
   multi: ReadonlySet<string>;
@@ -666,7 +675,15 @@ export const NodesLayer = memo(function NodesLayer({
         lite ? (
           <LiteDeckShell key={deck.key} deck={deck} dimmed={deckDimmed(deck)} />
         ) : (
-          <DeckShell key={deck.key} deck={deck} files={files} focus={deckFocus} dimmed={deckDimmed(deck)} onSelect={onSelect} />
+          <DeckShell
+            key={deck.key}
+            deck={deck}
+            files={files}
+            focus={deckFocus}
+            dimmed={deckDimmed(deck)}
+            dormant={dormant}
+            onSelect={onSelect}
+          />
         ),
       )}
       {layout.drafts.map((draft) =>
@@ -707,6 +724,7 @@ export const NodesLayer = memo(function NodesLayer({
             ringed={session ? multi.has(node.file.path) : selected === node.file.path || focus === node.file.path}
             marked={session && multi.has(node.file.path)}
             dimmed={attentionPaths !== null && !attentionPaths.has(node.file.path)}
+            dormant={dormant}
             flow={flowsByImpl.get(node.file.path) ?? null}
             canFlow={canStartFlow(node.file, flowsByImpl)}
             onSelect={onSelect}

--- a/src/hooks/logBus.ts
+++ b/src/hooks/logBus.ts
@@ -1,0 +1,100 @@
+"use client";
+
+import type { LogChunk } from "@/lib/types";
+
+const POLL_MS = 1200;
+/** Server-side cap per batch request; larger subscriber sets split into
+    sequential slices within one tick. */
+const MAX_REQS = 64;
+
+export type LogBusResult = LogChunk | { error: string } | { transportError: true };
+
+export interface LogSubscriber {
+  path: string;
+  /** Read at send time, so the poll always continues from the live offset. */
+  getOffset(): number;
+  onChunk(result: LogBusResult): void;
+}
+
+/**
+ * One multiplexed tail poll for every mounted feed pane: subscribers join and
+ * leave (mount/unmount, pause/resume, scroll out of view), and a single
+ * POST /api/logs per 1.2 s tick carries all of their forward reads. A new
+ * subscriber triggers an immediate coalesced tick, so a pane that just
+ * appeared or resumed paints without waiting out the interval.
+ */
+const subs = new Set<LogSubscriber>();
+let timer: ReturnType<typeof setInterval> | null = null;
+let inFlight = false;
+let kickPending = false;
+let kickScheduled = false;
+
+async function tick(): Promise<void> {
+  if (subs.size === 0) return;
+  if (inFlight) {
+    kickPending = true;
+    return;
+  }
+  inFlight = true;
+  try {
+    const batch = [...subs];
+    for (let base = 0; base < batch.length; base += MAX_REQS) {
+      const slice = batch.slice(base, base + MAX_REQS);
+      const reqs = slice.map((sub, i) => ({ id: String(i), path: sub.path, offset: sub.getOffset() }));
+      let chunks: Record<string, LogBusResult> = {};
+      let transportError = false;
+      try {
+        const res = await fetch("/api/logs", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ reqs }),
+        });
+        const json = (await res.json()) as { chunks?: Record<string, LogBusResult> };
+        chunks = json.chunks ?? {};
+      } catch {
+        transportError = true;
+      }
+      for (let i = 0; i < slice.length; i += 1) {
+        const sub = slice[i];
+        /* Unsubscribed mid-flight (unmount, pause): the chunk is simply
+           dropped — offsets only advance inside the subscriber, so nothing
+           is lost and the next poll re-reads the same bytes. */
+        if (!subs.has(sub)) continue;
+        if (transportError) sub.onChunk({ transportError: true });
+        else {
+          const chunk = chunks[String(i)];
+          if (chunk) sub.onChunk(chunk);
+        }
+      }
+    }
+  } finally {
+    inFlight = false;
+    if (kickPending) {
+      kickPending = false;
+      void tick();
+    }
+  }
+}
+
+/** Coalesces the immediate first read of simultaneously-mounting panes. */
+function kick(): void {
+  if (kickScheduled) return;
+  kickScheduled = true;
+  setTimeout(() => {
+    kickScheduled = false;
+    void tick();
+  }, 0);
+}
+
+export function subscribeLog(sub: LogSubscriber): () => void {
+  subs.add(sub);
+  if (timer === null) timer = setInterval(() => void tick(), POLL_MS);
+  kick();
+  return () => {
+    subs.delete(sub);
+    if (subs.size === 0 && timer !== null) {
+      clearInterval(timer);
+      timer = null;
+    }
+  };
+}

--- a/src/hooks/logBus.ts
+++ b/src/hooks/logBus.ts
@@ -1,35 +1,63 @@
 "use client";
 
+import type { LogTailStreamResult } from "@/lib/logTailStream";
 import type { LogChunk } from "@/lib/types";
 
 const POLL_MS = 1200;
-/** Server-side cap per batch request; larger subscriber sets split into
-    sequential slices within one tick. */
 const MAX_REQS = 64;
+const RECONNECT_DEBOUNCE_MS = 300;
+const SSE_RETRY_MS = 60_000;
 
 export type LogBusResult = LogChunk | { error: string } | { transportError: true };
 
 export interface LogSubscriber {
   path: string;
-  /** Read at send time, so the poll always continues from the live offset. */
+  /** Read at send time, so transport changes continue from the live offset. */
   getOffset(): number;
   onChunk(result: LogBusResult): void;
 }
 
-/**
- * One multiplexed tail poll for every mounted feed pane: subscribers join and
- * leave (mount/unmount, pause/resume, scroll out of view), and a single
- * POST /api/logs per 1.2 s tick carries all of their forward reads. A new
- * subscriber triggers an immediate coalesced tick, so a pane that just
- * appeared or resumed paints without waiting out the interval.
- */
 const subs = new Set<LogSubscriber>();
-let timer: ReturnType<typeof setInterval> | null = null;
+
+let pollTimer: ReturnType<typeof setInterval> | null = null;
+let sseRetryTimer: ReturnType<typeof setTimeout> | null = null;
+let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+let source: EventSource | null = null;
 let inFlight = false;
 let kickPending = false;
 let kickScheduled = false;
+let usingFallback = false;
+let sseGeneration = 0;
+let connectedSubs = new Map<string, LogSubscriber>();
 
-async function tick(): Promise<void> {
+function clearTimer<T extends ReturnType<typeof setTimeout> | ReturnType<typeof setInterval>>(timer: T | null, clear: (timer: T) => void): null {
+  if (timer) clear(timer);
+  return null;
+}
+
+function closeSource(): void {
+  sseGeneration += 1;
+  source?.close();
+  source = null;
+  connectedSubs = new Map();
+}
+
+function stopPolling(): void {
+  pollTimer = clearTimer(pollTimer, clearInterval);
+}
+
+function stopAllTransports(): void {
+  closeSource();
+  stopPolling();
+  sseRetryTimer = clearTimer(sseRetryTimer, clearTimeout);
+  reconnectTimer = clearTimer(reconnectTimer, clearTimeout);
+  usingFallback = false;
+  inFlight = false;
+  kickPending = false;
+  kickScheduled = false;
+}
+
+async function pollTick(): Promise<void> {
   if (subs.size === 0) return;
   if (inFlight) {
     kickPending = true;
@@ -56,9 +84,6 @@ async function tick(): Promise<void> {
       }
       for (let i = 0; i < slice.length; i += 1) {
         const sub = slice[i];
-        /* Unsubscribed mid-flight (unmount, pause): the chunk is simply
-           dropped — offsets only advance inside the subscriber, so nothing
-           is lost and the next poll re-reads the same bytes. */
         if (!subs.has(sub)) continue;
         if (transportError) sub.onChunk({ transportError: true });
         else {
@@ -71,30 +96,110 @@ async function tick(): Promise<void> {
     inFlight = false;
     if (kickPending) {
       kickPending = false;
-      void tick();
+      void pollTick();
     }
   }
 }
 
-/** Coalesces the immediate first read of simultaneously-mounting panes. */
-function kick(): void {
+function kickPoll(): void {
   if (kickScheduled) return;
   kickScheduled = true;
   setTimeout(() => {
     kickScheduled = false;
-    void tick();
+    if (usingFallback) void pollTick();
   }, 0);
+}
+
+function startFallback(): void {
+  if (subs.size === 0) return;
+  closeSource();
+  usingFallback = true;
+  if (pollTimer === null) pollTimer = setInterval(() => void pollTick(), POLL_MS);
+  kickPoll();
+  sseRetryTimer = clearTimer(sseRetryTimer, clearTimeout);
+  sseRetryTimer = setTimeout(() => {
+    sseRetryTimer = null;
+    if (subs.size === 0) return;
+    usingFallback = false;
+    stopPolling();
+    scheduleSseReconnect(0);
+  }, SSE_RETRY_MS);
+}
+
+function notifyTransportError(): void {
+  for (const sub of subs) sub.onChunk({ transportError: true });
+}
+
+function deliverStreamChunk(id: string, chunk: LogTailStreamResult): void {
+  const sub = connectedSubs.get(id);
+  if (!sub || !subs.has(sub)) return;
+  sub.onChunk(chunk);
+}
+
+function startSse(): void {
+  reconnectTimer = clearTimer(reconnectTimer, clearTimeout);
+  if (subs.size === 0) return;
+  if (typeof EventSource === "undefined" || subs.size > MAX_REQS) {
+    startFallback();
+    return;
+  }
+
+  usingFallback = false;
+  stopPolling();
+  sseRetryTimer = clearTimer(sseRetryTimer, clearTimeout);
+  closeSource();
+
+  const generation = sseGeneration;
+  const active = [...subs];
+  const reqs = active.map((sub, i) => ({ id: String(i), path: sub.path, offset: sub.getOffset() }));
+  connectedSubs = new Map(reqs.map((req, i) => [req.id, active[i]]));
+  const url = `/api/logs/stream?subs=${encodeURIComponent(JSON.stringify(reqs))}`;
+  const nextSource = new EventSource(url);
+  source = nextSource;
+
+  nextSource.addEventListener("chunk", (event) => {
+    if (generation !== sseGeneration || nextSource !== source) return;
+    let payload: { id?: unknown; chunk?: unknown };
+    try {
+      payload = JSON.parse((event as MessageEvent<string>).data) as { id?: unknown; chunk?: unknown };
+    } catch {
+      return;
+    }
+    if (typeof payload.id !== "string" || !payload.chunk || typeof payload.chunk !== "object") return;
+    deliverStreamChunk(payload.id, payload.chunk as LogTailStreamResult);
+  });
+
+  nextSource.onerror = () => {
+    if (generation !== sseGeneration || nextSource !== source) return;
+    notifyTransportError();
+    startFallback();
+  };
+}
+
+function scheduleSseReconnect(delay = RECONNECT_DEBOUNCE_MS): void {
+  if (usingFallback) {
+    kickPoll();
+    return;
+  }
+  reconnectTimer = clearTimer(reconnectTimer, clearTimeout);
+  reconnectTimer = setTimeout(startSse, delay);
 }
 
 export function subscribeLog(sub: LogSubscriber): () => void {
   subs.add(sub);
-  if (timer === null) timer = setInterval(() => void tick(), POLL_MS);
-  kick();
+  if (usingFallback) {
+    if (pollTimer === null) pollTimer = setInterval(() => void pollTick(), POLL_MS);
+    kickPoll();
+  } else {
+    scheduleSseReconnect();
+  }
   return () => {
     subs.delete(sub);
-    if (subs.size === 0 && timer !== null) {
-      clearInterval(timer);
-      timer = null;
+    if (subs.size === 0) {
+      stopAllTransports();
+      return;
     }
+    if (usingFallback) kickPoll();
+    else scheduleSseReconnect();
   };
 }

--- a/src/hooks/tmuxBus.ts
+++ b/src/hooks/tmuxBus.ts
@@ -1,0 +1,89 @@
+"use client";
+
+const POLL_MS = 5_000;
+const MAX_REQS = 64;
+
+export type TmuxBusResult = string | null | { transportError: true };
+
+export interface TmuxSubscriber {
+  pid: number | null;
+  path: string;
+  onTarget(result: TmuxBusResult): void;
+}
+
+const subs = new Set<TmuxSubscriber>();
+let timer: ReturnType<typeof setInterval> | null = null;
+let inFlight = false;
+let kickPending = false;
+let kickScheduled = false;
+
+async function tick(): Promise<void> {
+  if (subs.size === 0) return;
+  if (inFlight) {
+    kickPending = true;
+    return;
+  }
+  inFlight = true;
+  try {
+    const batch = [...subs];
+    for (let base = 0; base < batch.length; base += MAX_REQS) {
+      const slice = batch.slice(base, base + MAX_REQS);
+      const reqs = slice.map((sub, i) => ({
+        id: String(i),
+        ...(sub.pid !== null ? { pid: sub.pid } : {}),
+        ...(sub.path ? { path: sub.path } : {}),
+      }));
+      let targets: Record<string, string | null> = {};
+      let transportError = false;
+      try {
+        const res = await fetch("/api/tmux/targets", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ reqs }),
+        });
+        if (!res.ok) {
+          transportError = true;
+        } else {
+          const json = (await res.json()) as { targets?: Record<string, string | null> };
+          targets = json.targets ?? {};
+        }
+      } catch {
+        transportError = true;
+      }
+      for (let i = 0; i < slice.length; i += 1) {
+        const sub = slice[i];
+        if (!subs.has(sub)) continue;
+        if (transportError) sub.onTarget({ transportError: true });
+        else if (Object.prototype.hasOwnProperty.call(targets, String(i))) sub.onTarget(targets[String(i)] ?? null);
+      }
+    }
+  } finally {
+    inFlight = false;
+    if (kickPending) {
+      kickPending = false;
+      void tick();
+    }
+  }
+}
+
+function kick(): void {
+  if (kickScheduled) return;
+  kickScheduled = true;
+  setTimeout(() => {
+    kickScheduled = false;
+    void tick();
+  }, 0);
+}
+
+export function subscribeTmuxTarget(sub: TmuxSubscriber): () => void {
+  subs.add(sub);
+  if (timer === null) timer = setInterval(() => void tick(), POLL_MS);
+  kick();
+  return () => {
+    subs.delete(sub);
+    if (subs.size === 0 && timer !== null) {
+      clearInterval(timer);
+      timer = null;
+    }
+  };
+}

--- a/src/hooks/useFiles.ts
+++ b/src/hooks/useFiles.ts
@@ -27,12 +27,18 @@ export function useFiles(): FilesData {
   useEffect(() => {
     let alive = true;
     let lastBody = "";
+    let lastEtag = "";
     const load = async () => {
       try {
-        const res = await fetch("/api/files");
+        const res = await fetch("/api/files", lastEtag ? { headers: { "If-None-Match": lastEtag } } : undefined);
+        /* 304: the server confirms the payload is byte-identical to the last
+           one, so there is nothing to read or re-parse. */
+        if (res.status === 304) return;
+        const etag = res.headers.get("ETag");
         const body = await res.text();
         if (!alive || body === lastBody) return;
         lastBody = body;
+        if (etag) lastEtag = etag;
         const parsed = JSON.parse(body) as FilesResponse | FileEntry[];
         /* The flows rollout changes the payload from a bare array to
            {files, flows}; accept both so client and server can deploy in

--- a/src/hooks/useLogTail.ts
+++ b/src/hooks/useLogTail.ts
@@ -8,7 +8,8 @@ import { getLocale, translate } from "@/lib/i18n";
 import type { FileEntry } from "@/lib/types";
 import type { LogChunk } from "@/lib/types";
 
-const POLL_MS = 1200;
+import { subscribeLog } from "./logBus";
+
 /** Longest single jsonl line we are willing to chase across history chunks. */
 const OLDER_CHUNK_HOPS = 4;
 
@@ -16,6 +17,10 @@ const utf8len = (text: string) => new TextEncoder().encode(text).length;
 
 export interface LogTailState {
   lines: string[];
+  /** Absolute index of `lines[0]` in the tail stream: grows as the cap trims
+      the front, goes negative when history is prepended. Feed sessions use it
+      to parse only lines they have not seen. */
+  linesStart: number;
   size: number;
   loading: boolean;
   error: string | null;
@@ -42,7 +47,9 @@ export interface LogTailState {
  */
 export function useLogTail(file: FileEntry | null, pausedInput = false, cap = 2500): LogTailState {
   const capRef = useRef(cap);
-  const [lines, setLines] = useState<string[]>([]);
+  /* One atomic window state: the lines plus the absolute index of lines[0],
+     updated together so a trim and its start shift can never tear. */
+  const [win, setWin] = useState<{ lines: string[]; start: number }>({ lines: [], start: 0 });
   const [size, setSize] = useState(0);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -56,16 +63,11 @@ export function useLogTail(file: FileEntry | null, pausedInput = false, cap = 25
   const tailRef = useRef("");
   const firstRef = useRef(true);
   const genRef = useRef(0);
-  const pausedRef = useRef(false);
   const olderBusyRef = useRef(false);
 
   useEffect(() => {
     capRef.current = cap;
   }, [cap]);
-
-  useEffect(() => {
-    pausedRef.current = paused || pausedInput;
-  }, [paused, pausedInput]);
 
   const resetWindow = () => {
     offsetRef.current = 0;
@@ -76,38 +78,46 @@ export function useLogTail(file: FileEntry | null, pausedInput = false, cap = 25
   };
 
   const clear = useCallback(() => {
-    setLines([]);
+    setWin({ lines: [], start: 0 });
     resetWindow();
   }, []);
 
   useEffect(() => {
     genRef.current += 1;
     resetWindow();
-    setLines([]);
+    setWin({ lines: [], start: 0 });
     setSize(file?.size ?? 0);
     setError(null);
     setLoading(Boolean(file));
   }, [file?.path]);
 
+  /* Forward polling rides the shared log bus: one batched request per tick
+     for every mounted pane. A paused pane unsubscribes entirely — the server
+     must not keep re-reading bytes nobody consumes — and resuming triggers
+     the bus's immediate tick, so catch-up beats the old fixed interval. */
   useEffect(() => {
-    if (!file) return;
+    if (!file || paused || pausedInput) return;
     let alive = true;
     const gen = genRef.current;
-    const poll = async () => {
-      if (!alive || pausedRef.current) return;
-      try {
-        const res = await fetch(`/api/log?path=${encodeURIComponent(file.path)}&offset=${offsetRef.current}`);
-        const json = (await res.json()) as LogChunk | { error?: string };
+    const unsubscribe = subscribeLog({
+      path: file.path,
+      getOffset: () => offsetRef.current,
+      onChunk: (result) => {
         if (!alive || gen !== genRef.current) return;
-        if ("error" in json && json.error) {
-          setError(json.error);
+        if ("transportError" in result) {
+          setError(translate(getLocale(), "common.serverUnavailable"));
           setLoading(false);
           return;
         }
-        const chunk = json as LogChunk;
+        if ("error" in result && result.error) {
+          setError(result.error);
+          setLoading(false);
+          return;
+        }
+        const chunk = result as LogChunk;
         if (offsetRef.current > chunk.size) {
           resetWindow();
-          setLines([]);
+          setWin({ lines: [], start: 0 });
         }
         if (chunk.data) {
           let data = tailRef.current + chunk.data;
@@ -124,9 +134,16 @@ export function useLogTail(file: FileEntry | null, pausedInput = false, cap = 25
           const parts = data.split("\n");
           tailRef.current = parts.pop() ?? "";
           const complete = parts.map((line) => line.trim()).filter(Boolean);
-          if (offsetRef.current === 0) setLines(complete);
+          if (offsetRef.current === 0) setWin({ lines: complete, start: 0 });
           else if (complete.length)
-            setLines((prev) => (capRef.current > 0 ? prev.concat(complete).slice(-capRef.current) : prev.concat(complete)));
+            setWin((prev) => {
+              const merged = prev.lines.concat(complete);
+              const capNow = capRef.current;
+              if (capNow > 0 && merged.length > capNow) {
+                return { lines: merged.slice(-capNow), start: prev.start + (merged.length - capNow) };
+              }
+              return { lines: merged, start: prev.start };
+            });
           firstRef.current = false;
         }
         offsetRef.current = chunk.offset;
@@ -136,20 +153,13 @@ export function useLogTail(file: FileEntry | null, pausedInput = false, cap = 25
            moves only when bytes actually arrived (status reads "last data"). */
         if (chunk.data) setTickTime(new Date());
         setLoading(false);
-      } catch {
-        if (alive && gen === genRef.current) {
-          setError(translate(getLocale(), "common.serverUnavailable"));
-          setLoading(false);
-        }
-      }
-    };
-    void poll();
-    const t = setInterval(poll, POLL_MS);
+      },
+    });
     return () => {
       alive = false;
-      clearInterval(t);
+      unsubscribe();
     };
-  }, [file?.path]);
+  }, [file?.path, paused, pausedInput]);
 
   const loadOlder = useCallback(async (): Promise<number> => {
     if (!file || olderBusyRef.current || startRef.current <= 0) return 0;
@@ -185,7 +195,7 @@ export function useLogTail(file: FileEntry | null, pausedInput = false, cap = 25
       startRef.current = newStart;
       setHasMore(newStart > 0);
       if (complete.length) {
-        setLines((prev) => complete.concat(prev));
+        setWin((prev) => ({ lines: complete.concat(prev.lines), start: prev.start - complete.length }));
         setPrependGen((value) => value + 1);
       }
       return complete.length;
@@ -197,5 +207,5 @@ export function useLogTail(file: FileEntry | null, pausedInput = false, cap = 25
     }
   }, [file?.path]);
 
-  return { lines, size, loading, error, tickTime, paused, setPaused, clear, hasMore, loadingOlder, loadOlder, prependGen };
+  return { lines: win.lines, linesStart: win.start, size, loading, error, tickTime, paused, setPaused, clear, hasMore, loadingOlder, loadOlder, prependGen };
 }

--- a/src/hooks/useTmuxTarget.ts
+++ b/src/hooks/useTmuxTarget.ts
@@ -2,39 +2,27 @@
 
 import { useEffect, useState } from "react";
 
-const POLL_MS = 5_000;
+import { subscribeTmuxTarget, type TmuxBusResult } from "./tmuxBus";
 
 /**
- * Polls /api/tmux for the tmux pane behind a conversation: the pane its `pid`
- * runs in, or — for a finished conversation — the resume window previously
- * spawned for its transcript `path`. Returns the `session:window.pane` target
- * string, or null when neither yields a live pane.
+ * Resolves the tmux pane behind a conversation through the shared tmux target
+ * bus: the pane its `pid` runs in, or the resume window previously spawned for
+ * its transcript `path`.
  */
 export function useTmuxTarget(pid: number | null, path?: string, enabled = true): string | null {
   const [target, setTarget] = useState<string | null>(null);
 
   useEffect(() => {
     if (!enabled || (pid === null && !path)) return;
-    let alive = true;
-    const load = async () => {
-      try {
-        const query = new URLSearchParams();
-        if (pid !== null) query.set("pid", String(pid));
-        if (path) query.set("path", path);
-        const res = await fetch(`/api/tmux?${query.toString()}`);
-        if (!res.ok) return;
-        const body = (await res.json()) as { target?: string | null };
-        if (alive) setTarget(body.target ?? null);
-      } catch {
-        /* keep previous target */
-      }
-    };
-    void load();
-    const timer = setInterval(load, POLL_MS);
-    return () => {
-      alive = false;
-      clearInterval(timer);
-    };
+    const unsubscribe = subscribeTmuxTarget({
+      pid,
+      path: path ?? "",
+      onTarget(result: TmuxBusResult) {
+        if (typeof result === "object" && result !== null && "transportError" in result) return;
+        setTarget(result);
+      },
+    });
+    return unsubscribe;
   }, [pid, path, enabled]);
 
   return pid === null && !path ? null : target;

--- a/src/hooks/useTmuxTarget.ts
+++ b/src/hooks/useTmuxTarget.ts
@@ -10,11 +10,11 @@ const POLL_MS = 5_000;
  * spawned for its transcript `path`. Returns the `session:window.pane` target
  * string, or null when neither yields a live pane.
  */
-export function useTmuxTarget(pid: number | null, path?: string): string | null {
+export function useTmuxTarget(pid: number | null, path?: string, enabled = true): string | null {
   const [target, setTarget] = useState<string | null>(null);
 
   useEffect(() => {
-    if (pid === null && !path) return;
+    if (!enabled || (pid === null && !path)) return;
     let alive = true;
     const load = async () => {
       try {
@@ -35,7 +35,7 @@ export function useTmuxTarget(pid: number | null, path?: string): string | null 
       alive = false;
       clearInterval(timer);
     };
-  }, [pid, path]);
+  }, [pid, path, enabled]);
 
   return pid === null && !path ? null : target;
 }

--- a/src/lib/logRead.ts
+++ b/src/lib/logRead.ts
@@ -1,0 +1,46 @@
+import fs from "node:fs/promises";
+
+import { MAX_CHUNK, pathAllowed } from "@/lib/scanner/roots";
+import type { LogChunk } from "@/lib/types";
+
+/**
+ * Forward tail read shared by /api/log and the batched /api/logs: `offset`
+ * continues a poll, the very first read of a large file jumps to the last
+ * MAX_CHUNK bytes. `budget` caps how many bytes this read may return — a
+ * batch response splits one byte budget across many files, and a file that
+ * ran out of budget gets an idle chunk at its current offset so the client
+ * simply catches up on the next tick. Returns null for a path outside the
+ * whitelisted roots (or one that is not a file).
+ */
+export async function readTailChunk(pathname: string, offsetInput: number, budget = MAX_CHUNK): Promise<LogChunk | null> {
+  let stat;
+  try {
+    stat = await fs.stat(pathname);
+  } catch {
+    stat = null;
+  }
+  if (!pathname || !stat?.isFile() || !pathAllowed(pathname)) return null;
+  const size = stat.size;
+
+  let offset = offsetInput;
+  if (!Number.isFinite(offset) || offset < 0) offset = 0;
+  if (offset > size) offset = 0;
+  if (offset === 0 && size > MAX_CHUNK) offset = size - MAX_CHUNK;
+
+  const want = Math.min(MAX_CHUNK, Math.max(0, budget), Math.max(0, size - offset));
+  if (want === 0) return { offset, start: offset, size, data: "" };
+
+  const fh = await fs.open(pathname, "r");
+  try {
+    const buf = Buffer.alloc(want);
+    const { bytesRead } = await fh.read(buf, 0, buf.length, offset);
+    return {
+      offset: offset + bytesRead,
+      start: offset,
+      size,
+      data: buf.subarray(0, bytesRead).toString("utf-8"),
+    };
+  } finally {
+    await fh.close();
+  }
+}

--- a/src/lib/logTailStream.test.ts
+++ b/src/lib/logTailStream.test.ts
@@ -83,6 +83,27 @@ describe("LogTailStreamSession", () => {
     }
   });
 
+  test("file growth still arrives when native watching fails", async () => {
+    const file = writeLog("watch-fails.log", "one\n");
+    const events: LogTailStreamEvent[] = [];
+    const session = new LogTailStreamSession([{ id: "log", path: file, offset: 4 }], {
+      restatMs: 20,
+      heartbeatMs: 60_000,
+      watchFile: () => {
+        throw new Error("watch unavailable");
+      },
+      onEvent: (event) => events.push(event),
+    });
+    try {
+      session.start();
+      await waitFor(() => events.length >= 1);
+      fs.appendFileSync(file, "two\n");
+      await waitFor(() => events.some((event) => event.id === "log" && !("error" in event.chunk) && event.chunk.data === "two\n"));
+    } finally {
+      session.close();
+    }
+  });
+
   test("teardown closes watchers and stops timers", async () => {
     const file = writeLog("teardown.log", "ready\n");
     let openCount = 0;

--- a/src/lib/logTailStream.test.ts
+++ b/src/lib/logTailStream.test.ts
@@ -1,0 +1,115 @@
+import { afterAll, describe, expect, test } from "bun:test";
+import fs from "node:fs";
+import path from "node:path";
+
+import { ROOTS } from "@/lib/scanner/roots";
+import type { LogChunk } from "@/lib/types";
+
+import { LogTailStreamSession, type LogTailStreamEvent } from "./logTailStream";
+
+const SANDBOX = fs.mkdtempSync(path.join(ROOTS["codex-sessions"], "llv-log-tail-stream-test-"));
+
+afterAll(() => {
+  fs.rmSync(SANDBOX, { recursive: true, force: true });
+});
+
+function writeLog(name: string, data: string): string {
+  const pathname = path.join(SANDBOX, name);
+  fs.mkdirSync(path.dirname(pathname), { recursive: true });
+  fs.writeFileSync(pathname, data);
+  return pathname;
+}
+
+async function waitFor(check: () => boolean, timeoutMs = 2500): Promise<void> {
+  const started = Date.now();
+  while (!check()) {
+    if (Date.now() - started > timeoutMs) throw new Error("condition timed out");
+    await Bun.sleep(20);
+  }
+}
+
+function asChunk(event: LogTailStreamEvent): LogChunk {
+  if ("error" in event.chunk) throw new Error(event.chunk.error);
+  return event.chunk;
+}
+
+describe("LogTailStreamSession", () => {
+  test("initial catch-up spends one connection byte budget and continues later", async () => {
+    const first = writeLog("budget-a.log", "0123456789");
+    const second = writeLog("budget-b.log", "abcde");
+    const events: LogTailStreamEvent[] = [];
+    const session = new LogTailStreamSession(
+      [
+        { id: "a", path: first, offset: 2 },
+        { id: "b", path: second, offset: 0 },
+      ],
+      {
+        batchBudget: 4,
+        restatMs: 60_000,
+        heartbeatMs: 60_000,
+        catchUpDelayMs: 20,
+        onEvent: (event) => events.push(event),
+      },
+    );
+    try {
+      session.start();
+      await waitFor(() => events.length >= 2);
+      expect(events[0].id).toBe("a");
+      expect(asChunk(events[0])).toMatchObject({ start: 2, offset: 6, data: "2345" });
+      expect(events[1].id).toBe("b");
+      expect(asChunk(events[1])).toMatchObject({ start: 0, offset: 0, size: 5, data: "" });
+
+      await waitFor(() => events.some((event) => event.id === "b" && !("error" in event.chunk) && event.chunk.data === "abcd"));
+    } finally {
+      session.close();
+    }
+  });
+
+  test("file growth pushes the appended bytes", async () => {
+    const file = writeLog("growth.log", "one\n");
+    const events: LogTailStreamEvent[] = [];
+    const session = new LogTailStreamSession([{ id: "log", path: file, offset: 4 }], {
+      restatMs: 60_000,
+      heartbeatMs: 60_000,
+      onEvent: (event) => events.push(event),
+    });
+    try {
+      session.start();
+      await waitFor(() => events.length >= 1);
+      fs.appendFileSync(file, "two\n");
+      await waitFor(() => events.some((event) => event.id === "log" && !("error" in event.chunk) && event.chunk.data === "two\n"));
+    } finally {
+      session.close();
+    }
+  });
+
+  test("teardown closes watchers and stops timers", async () => {
+    const file = writeLog("teardown.log", "ready\n");
+    let openCount = 0;
+    let closeCount = 0;
+    let comments = 0;
+    const session = new LogTailStreamSession([{ id: "log", path: file, offset: 0 }], {
+      restatMs: 60_000,
+      heartbeatMs: 20,
+      watchFile: () => {
+        openCount += 1;
+        return {
+          close: () => {
+            closeCount += 1;
+          },
+        };
+      },
+      onEvent: () => undefined,
+      onComment: () => {
+        comments += 1;
+      },
+    });
+    session.start();
+    await waitFor(() => openCount === 1);
+    session.close();
+    const commentsAtClose = comments;
+    await Bun.sleep(80);
+    expect(closeCount).toBe(1);
+    expect(comments).toBe(commentsAtClose);
+  });
+});

--- a/src/lib/logTailStream.test.ts
+++ b/src/lib/logTailStream.test.ts
@@ -7,6 +7,7 @@ import type { LogChunk } from "@/lib/types";
 
 import { LogTailStreamSession, type LogTailStreamEvent } from "./logTailStream";
 
+fs.mkdirSync(ROOTS["codex-sessions"], { recursive: true });
 const SANDBOX = fs.mkdtempSync(path.join(ROOTS["codex-sessions"], "llv-log-tail-stream-test-"));
 
 afterAll(() => {

--- a/src/lib/logTailStream.test.ts
+++ b/src/lib/logTailStream.test.ts
@@ -105,6 +105,36 @@ describe("LogTailStreamSession", () => {
     }
   });
 
+  test("a rejected read reports an error and keeps other subscribers moving", async () => {
+    const events: LogTailStreamEvent[] = [];
+    const session = new LogTailStreamSession(
+      [
+        { id: "bad", path: "bad.log", offset: 0 },
+        { id: "ok", path: "ok.log", offset: 0 },
+      ],
+      {
+        restatMs: 60_000,
+        heartbeatMs: 60_000,
+        readTailChunk: async (pathname) => {
+          if (pathname === "bad.log") throw new Error("rotated during read");
+          return { offset: 4, start: 0, size: 4, data: "ok\n" };
+        },
+        watchFile: () => ({
+          close: () => undefined,
+        }),
+        onEvent: (event) => events.push(event),
+      },
+    );
+    try {
+      session.start();
+      await waitFor(() => events.length >= 2);
+      expect(events.find((event) => event.id === "bad")?.chunk).toEqual({ error: "failed to read log" });
+      expect(events.find((event) => event.id === "ok")?.chunk).toMatchObject({ offset: 4, start: 0, size: 4, data: "ok\n" });
+    } finally {
+      session.close();
+    }
+  });
+
   test("teardown closes watchers and stops timers", async () => {
     const file = writeLog("teardown.log", "ready\n");
     let openCount = 0;

--- a/src/lib/logTailStream.ts
+++ b/src/lib/logTailStream.ts
@@ -215,7 +215,7 @@ export class LogTailStreamSession {
   private async restat(): Promise<void> {
     if (this.closed) return;
     for (const state of this.states) {
-      if (this.closed || !state.watcher) continue;
+      if (this.closed) continue;
       let stat;
       try {
         stat = await fsp.stat(state.path);
@@ -226,7 +226,7 @@ export class LogTailStreamSession {
         this.queue(state);
         continue;
       }
-      if (state.size === null || stat.size !== state.size || stat.size < state.offset) this.queue(state);
+      if (!state.watcher || state.size === null || stat.size !== state.size || stat.size < state.offset) this.queue(state);
     }
   }
 }

--- a/src/lib/logTailStream.ts
+++ b/src/lib/logTailStream.ts
@@ -1,0 +1,260 @@
+import fs from "node:fs";
+import fsp from "node:fs/promises";
+
+import { readTailChunk as defaultReadTailChunk } from "@/lib/logRead";
+import { MAX_CHUNK } from "@/lib/scanner/roots";
+import type { ApiError, LogChunk } from "@/lib/types";
+
+export const MAX_STREAM_SUBS = 64;
+export const STREAM_BATCH_BUDGET = 4 * MAX_CHUNK;
+const DEFAULT_RESTAT_MS = 5000;
+const DEFAULT_HEARTBEAT_MS = 15000;
+const DEFAULT_CATCH_UP_DELAY_MS = 0;
+
+export interface LogStreamSub {
+  id: string;
+  path: string;
+  offset: number;
+}
+
+export type LogTailStreamResult = LogChunk | ApiError;
+
+export interface LogTailStreamEvent {
+  id: string;
+  chunk: LogTailStreamResult;
+}
+
+type WatchHandle = { close(): void };
+type WatchFile = (pathname: string, onChange: () => void) => WatchHandle;
+type ReadTail = typeof defaultReadTailChunk;
+
+export interface LogTailStreamOptions {
+  signal?: AbortSignal;
+  batchBudget?: number;
+  restatMs?: number;
+  heartbeatMs?: number;
+  catchUpDelayMs?: number;
+  readTailChunk?: ReadTail;
+  watchFile?: WatchFile;
+  onEvent: (event: LogTailStreamEvent) => void;
+  onComment?: (comment: string) => void;
+}
+
+interface TailState {
+  id: string;
+  path: string;
+  offset: number;
+  size: number | null;
+  initial: boolean;
+  watcher: WatchHandle | null;
+}
+
+function defaultWatchFile(pathname: string, onChange: () => void): WatchHandle {
+  return fs.watch(pathname, () => onChange());
+}
+
+export function parseLogStreamSubs(raw: string | null): LogStreamSub[] {
+  if (!raw) return [];
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return [];
+  }
+  if (!Array.isArray(parsed)) return [];
+  const out: LogStreamSub[] = [];
+  for (const entry of parsed.slice(0, MAX_STREAM_SUBS)) {
+    if (!entry || typeof entry !== "object") continue;
+    const { id, path, offset } = entry as Record<string, unknown>;
+    if (typeof id !== "string" || typeof path !== "string") continue;
+    out.push({ id, path, offset: typeof offset === "number" ? offset : 0 });
+  }
+  return out;
+}
+
+export class LogTailStreamSession {
+  private readonly states: TailState[];
+  private readonly pending = new Set<TailState>();
+  private readonly readTailChunk: ReadTail;
+  private readonly watchFile: WatchFile;
+  private readonly onEvent: (event: LogTailStreamEvent) => void;
+  private readonly onComment?: (comment: string) => void;
+  private readonly batchBudget: number;
+  private readonly restatMs: number;
+  private readonly heartbeatMs: number;
+  private readonly catchUpDelayMs: number;
+  private readonly signal?: AbortSignal;
+  private readonly abort = () => this.close();
+
+  private restatTimer: ReturnType<typeof setInterval> | null = null;
+  private heartbeatTimer: ReturnType<typeof setInterval> | null = null;
+  private pumpTimer: ReturnType<typeof setTimeout> | null = null;
+  private started = false;
+  private pumping = false;
+  private closed = false;
+
+  constructor(subs: LogStreamSub[], options: LogTailStreamOptions) {
+    this.states = subs.slice(0, MAX_STREAM_SUBS).map((sub) => ({
+      id: sub.id,
+      path: sub.path,
+      offset: Number.isFinite(sub.offset) && sub.offset >= 0 ? sub.offset : 0,
+      size: null,
+      initial: true,
+      watcher: null,
+    }));
+    this.readTailChunk = options.readTailChunk ?? defaultReadTailChunk;
+    this.watchFile = options.watchFile ?? defaultWatchFile;
+    this.onEvent = options.onEvent;
+    this.onComment = options.onComment;
+    this.batchBudget = options.batchBudget ?? STREAM_BATCH_BUDGET;
+    this.restatMs = options.restatMs ?? DEFAULT_RESTAT_MS;
+    this.heartbeatMs = options.heartbeatMs ?? DEFAULT_HEARTBEAT_MS;
+    this.catchUpDelayMs = options.catchUpDelayMs ?? DEFAULT_CATCH_UP_DELAY_MS;
+    this.signal = options.signal;
+  }
+
+  start(): void {
+    if (this.started || this.closed) return;
+    this.started = true;
+    if (this.signal?.aborted) {
+      this.close();
+      return;
+    }
+    this.signal?.addEventListener("abort", this.abort, { once: true });
+    this.heartbeatTimer = setInterval(() => {
+      if (!this.closed) this.onComment?.("heartbeat");
+    }, this.heartbeatMs);
+    this.restatTimer = setInterval(() => {
+      void this.restat();
+    }, this.restatMs);
+    for (const state of this.states) this.queue(state);
+  }
+
+  close(): void {
+    if (this.closed) return;
+    this.closed = true;
+    this.pending.clear();
+    if (this.pumpTimer) clearTimeout(this.pumpTimer);
+    if (this.restatTimer) clearInterval(this.restatTimer);
+    if (this.heartbeatTimer) clearInterval(this.heartbeatTimer);
+    this.pumpTimer = null;
+    this.restatTimer = null;
+    this.heartbeatTimer = null;
+    for (const state of this.states) {
+      state.watcher?.close();
+      state.watcher = null;
+    }
+    this.signal?.removeEventListener("abort", this.abort);
+  }
+
+  private queue(state: TailState): void {
+    if (this.closed) return;
+    this.pending.add(state);
+    this.schedulePump();
+  }
+
+  private schedulePump(): void {
+    if (this.closed || this.pumping || this.pumpTimer) return;
+    this.pumpTimer = setTimeout(() => {
+      this.pumpTimer = null;
+      void this.pump();
+    }, this.catchUpDelayMs);
+  }
+
+  private async pump(): Promise<void> {
+    if (this.closed || this.pumping) return;
+    this.pumping = true;
+    let budget = this.batchBudget;
+    const cycle = [...this.pending];
+    this.pending.clear();
+    try {
+      for (const state of cycle) {
+        if (this.closed) return;
+        const spent = await this.readState(state, budget);
+        budget = Math.max(0, budget - spent);
+      }
+    } finally {
+      this.pumping = false;
+      if (!this.closed && this.pending.size > 0) this.schedulePump();
+    }
+  }
+
+  private async readState(state: TailState, budget: number): Promise<number> {
+    const previousOffset = state.offset;
+    const chunk = await this.readTailChunk(state.path, state.offset, budget);
+    if (this.closed) return 0;
+    if (!chunk) {
+      state.initial = false;
+      this.onEvent({ id: state.id, chunk: { error: "path not allowed" } });
+      return 0;
+    }
+
+    state.offset = chunk.offset;
+    state.size = chunk.size;
+    if (!state.watcher) this.openWatcher(state);
+
+    const spent = Math.max(0, chunk.offset - chunk.start);
+    if (state.initial || chunk.data.length > 0 || previousOffset > chunk.size) {
+      state.initial = false;
+      this.onEvent({ id: state.id, chunk });
+    } else {
+      state.initial = false;
+    }
+    if (chunk.offset < chunk.size) this.pending.add(state);
+    return spent;
+  }
+
+  private openWatcher(state: TailState): void {
+    try {
+      state.watcher = this.watchFile(state.path, () => this.queue(state));
+    } catch {
+      state.watcher = null;
+    }
+  }
+
+  private async restat(): Promise<void> {
+    if (this.closed) return;
+    for (const state of this.states) {
+      if (this.closed || !state.watcher) continue;
+      let stat;
+      try {
+        stat = await fsp.stat(state.path);
+      } catch {
+        stat = null;
+      }
+      if (!stat?.isFile()) {
+        this.queue(state);
+        continue;
+      }
+      if (state.size === null || stat.size !== state.size || stat.size < state.offset) this.queue(state);
+    }
+  }
+}
+
+const encoder = new TextEncoder();
+
+function encodeChunk(event: LogTailStreamEvent): Uint8Array {
+  return encoder.encode(`event: chunk\ndata: ${JSON.stringify(event)}\n\n`);
+}
+
+function encodeComment(comment: string): Uint8Array {
+  return encoder.encode(`: ${comment}\n\n`);
+}
+
+export function createLogTailEventStream(subs: LogStreamSub[], signal?: AbortSignal): ReadableStream<Uint8Array> {
+  let session: LogTailStreamSession | null = null;
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      session = new LogTailStreamSession(subs, {
+        signal,
+        onEvent: (event) => controller.enqueue(encodeChunk(event)),
+        onComment: (comment) => controller.enqueue(encodeComment(comment)),
+      });
+      session.start();
+    },
+    cancel() {
+      session?.close();
+      session = null;
+    },
+  });
+}

--- a/src/lib/logTailStream.ts
+++ b/src/lib/logTailStream.ts
@@ -181,7 +181,16 @@ export class LogTailStreamSession {
 
   private async readState(state: TailState, budget: number): Promise<number> {
     const previousOffset = state.offset;
-    const chunk = await this.readTailChunk(state.path, state.offset, budget);
+    let chunk: LogChunk | null;
+    try {
+      chunk = await this.readTailChunk(state.path, state.offset, budget);
+    } catch {
+      if (!this.closed) {
+        state.initial = false;
+        this.onEvent({ id: state.id, chunk: { error: "failed to read log" } });
+      }
+      return 0;
+    }
     if (this.closed) return 0;
     if (!chunk) {
       state.initial = false;

--- a/src/lib/resources.ts
+++ b/src/lib/resources.ts
@@ -73,6 +73,37 @@ function entriesByPid(entries: FileEntry[]): Map<number, FileEntry> {
   return byPid;
 }
 
+const UUID_RE = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/;
+
+/**
+ * session-uuid → transcript entry, keyed by the uuid in the file basename
+ * (claude `<uuid>.jsonl`, codex `rollout-<ts>-<uuid>.jsonl`). Pid attribution
+ * needs the CLI to hold its transcript open, which an idle session at the
+ * prompt does not — the uuid the CLI was launched with (`--session-id`,
+ * `--resume`, `codex resume <id>`) still names it.
+ */
+function entriesBySessionUuid(entries: FileEntry[]): Map<string, FileEntry> {
+  const byUuid = new Map<string, FileEntry>();
+  for (const entry of entries) {
+    if (!entry.path.endsWith(".jsonl")) continue;
+    const base = entry.path.slice(entry.path.lastIndexOf("/") + 1);
+    const uuid = base.match(UUID_RE)?.[0];
+    if (!uuid) continue;
+    const current = byUuid.get(uuid);
+    if (!current || (current.parent && !entry.parent)) byUuid.set(uuid, entry);
+  }
+  return byUuid;
+}
+
+/** Last uuid-shaped token in the CLI's argv, if any. */
+function argvSessionUuid(argv: string[]): string | null {
+  for (let i = argv.length - 1; i >= 0; i--) {
+    const match = argv[i].match(UUID_RE);
+    if (match) return match[0];
+  }
+  return null;
+}
+
 /** `fresh` skips the pane/agent-process memos too, all the way down: a
     rebuild triggered right after a kill would otherwise read 5s-old caches
     and re-list (and re-allowlist) the session that was just killed. */
@@ -84,9 +115,11 @@ async function buildResources(fresh: boolean): Promise<ResourcesPayload> {
   const sessions: ResourceSession[] = [];
   if (panes.size > 0) {
     const ppids = procBackend.ppidMap();
-    const agentEngine = new Map<number, AgentEngine>();
-    for (const proc of agentProcesses(fresh)) agentEngine.set(proc.pid, proc.engine);
-    const byPid = entriesByPid(await listFiles());
+    const agents = new Map<number, { engine: AgentEngine; argv: string[]; cwd: string }>();
+    for (const proc of agentProcesses(fresh)) agents.set(proc.pid, { engine: proc.engine, argv: proc.argv, cwd: proc.cwd });
+    const files = await listFiles();
+    const byPid = entriesByPid(files);
+    const byUuid = entriesBySessionUuid(files);
 
     /* Trees first, memory second: one processMemory() batch over the union
        keeps the portable backend at a single `ps` spawn for all panes. */
@@ -94,7 +127,7 @@ async function buildResources(fresh: boolean): Promise<ResourcesPayload> {
     const treePids = new Set<number>();
     for (const [panePid, pane] of panes) {
       const tree = descendantPids(panePid, ppids);
-      const agentPids = tree.filter((pid) => agentEngine.has(pid));
+      const agentPids = tree.filter((pid) => agents.has(pid));
       if (agentPids.length === 0) continue; // plain shell / editor / dev-server pane
       paneTrees.push({ target: pane.target, paneId: pane.paneId, panePid, tree, agentPids });
       for (const pid of tree) treePids.add(pid);
@@ -111,16 +144,28 @@ async function buildResources(fresh: boolean): Promise<ResourcesPayload> {
         rssBytes += mem.rssBytes;
         swapBytes += mem.swapBytes;
       }
-      const entry = agentPids.map((pid) => byPid.get(pid)).find(Boolean) ?? null;
+      /* Pid attribution first (live sessions), argv session-uuid second (idle
+         CLIs sitting at their prompt no longer hold the transcript open). */
+      const entry =
+        agentPids.map((pid) => byPid.get(pid)).find(Boolean) ??
+        agentPids
+          .map((pid) => {
+            const uuid = argvSessionUuid(agents.get(pid)?.argv ?? []);
+            return uuid ? byUuid.get(uuid) : undefined;
+          })
+          .find(Boolean) ??
+        null;
+      const lead = agents.get(agentPids[0]) ?? null;
       sessions.push({
         target,
         panePid,
         path: entry?.path ?? null,
-        engine: agentEngine.get(agentPids[0]) ?? null,
+        engine: lead?.engine ?? null,
         title: entry?.title ?? null,
         project: entry?.project || null,
         activity: entry?.activity ?? null,
         lastActiveAt: entry ? isoFromUnix(entry.mtime) : null,
+        cwd: lead?.cwd ?? null,
         rssBytes,
         swapBytes,
         procCount: tree.length,

--- a/src/lib/scanner/activity.ts
+++ b/src/lib/scanner/activity.ts
@@ -7,7 +7,31 @@ import { outputHolders, pidAlive } from "./process";
 
 const turnCache = globalCache<[number, string | null]>("turn");
 
+/** Shared tail read+parse, keyed by path → [size, nbytes, records]. Within one
+    /api/files scan the per-entry derivations (turn state, model, context, plan,
+    effort, questions) all ask for the same (path, size) tail, so the first pays
+    the 128 KB read and JSON parse and the rest reuse it. Replaced when the file
+    grows. Unlike its siblings this cache holds whole parsed record arrays, so
+    it is bounded: only actively-growing transcripts benefit from it anyway
+    (idle files resolve through the small derived caches and never come back). */
+const tailCache = globalCache<[number, number, Record<string, unknown>[]]>("tail");
+const TAIL_CACHE_CAP = 64;
+
 export function tailRecords(pathname: string, size: number, nbytes = 131_072) {
+  const cached = tailCache.get(pathname);
+  if (cached && cached[0] === size && cached[1] === nbytes) return cached[2].slice();
+  const records = readTail(pathname, size, nbytes);
+  if (tailCache.size >= TAIL_CACHE_CAP && !tailCache.has(pathname)) {
+    const oldest = tailCache.keys().next().value;
+    if (oldest !== undefined) tailCache.delete(oldest);
+  }
+  tailCache.set(pathname, [size, nbytes, records]);
+  /* Hand out a fresh copy every call: consumers reverse() the result in place,
+     which must never reorder the shared cached array under the next consumer. */
+  return records.slice();
+}
+
+function readTail(pathname: string, size: number, nbytes: number): Record<string, unknown>[] {
   let data: string;
   let seek = 0;
   try {

--- a/src/lib/scanner/discover.test.ts
+++ b/src/lib/scanner/discover.test.ts
@@ -1,0 +1,84 @@
+import { mkdtemp, mkdir, rm, utimes, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { expect, test } from "bun:test";
+
+import type { RootKey } from "../types";
+import { discoverFiles } from "./discover";
+import { FILE_CAP } from "./roots";
+
+async function writeFixture(pathname: string, content: string, mtimeSeconds: number): Promise<void> {
+  await mkdir(path.dirname(pathname), { recursive: true });
+  await writeFile(pathname, content);
+  await utimes(pathname, mtimeSeconds, mtimeSeconds);
+}
+
+test("discoverFiles preserves scanner filters, mtime ordering, and the cap", async () => {
+  const base = await mkdtemp(path.join(os.tmpdir(), "llv-discover-"));
+  try {
+    const roots: Record<RootKey, string> = {
+      "codex-jobs": path.join(base, "codex-jobs"),
+      "codex-sessions": path.join(base, "codex-sessions"),
+      "claude-projects": path.join(base, "claude-projects"),
+      "claude-tasks": path.join(base, "claude-tasks"),
+    };
+    await Promise.all(Object.values(roots).map((root) => mkdir(root, { recursive: true })));
+
+    const startedAt = 1_700_000_000;
+    for (let index = 0; index < FILE_CAP; index += 1) {
+      const pathname = path.join(roots["codex-sessions"], `session-${String(index).padStart(3, "0")}.jsonl`);
+      await writeFixture(
+        pathname,
+        JSON.stringify({ payload: { cwd: "/home/user/project" }, type: "session" }) + "\n",
+        startedAt + index,
+      );
+    }
+
+    const taskPath = path.join(roots["claude-tasks"], "project-a", "sid-a", "tasks", "keep.output");
+    await writeFixture(taskPath, "", startedAt + FILE_CAP + 10);
+
+    await writeFixture(path.join(roots["codex-sessions"], "too-new.bin"), "skip", startedAt + FILE_CAP + 20);
+    await writeFixture(path.join(roots["codex-sessions"], "empty.jsonl"), "", startedAt + FILE_CAP + 30);
+    await writeFixture(
+      path.join(roots["claude-projects"], "project-a", "sid-a", "tool-results", "tool.jsonl"),
+      "{}\n",
+      startedAt + FILE_CAP + 40,
+    );
+    await writeFixture(
+      path.join(roots["claude-tasks"], "project-a", "sid-a", "scratchpad.txt"),
+      "skip\n",
+      startedAt + FILE_CAP + 50,
+    );
+    await writeFixture(
+      path.join(roots["claude-tasks"], "project-a", "sid-a", "tasks", "mirrored.output"),
+      "skip\n",
+      startedAt + FILE_CAP + 60,
+    );
+    await writeFixture(
+      path.join(roots["claude-projects"], "project-a", "sid-a", "subagents", "agent-mirrored.jsonl"),
+      "{}\n",
+      startedAt - 1,
+    );
+
+    const entries = await discoverFiles(roots);
+
+    expect(entries).toHaveLength(FILE_CAP);
+    expect(entries[0]?.path).toBe(taskPath);
+    expect(entries.slice(1).map((entry) => entry.name)).toEqual(
+      Array.from({ length: FILE_CAP - 1 }, (_, offset) => {
+        const index = FILE_CAP - 1 - offset;
+        return `session-${String(index).padStart(3, "0")}.jsonl`;
+      }),
+    );
+    expect(entries.some((entry) => entry.name === "session-000.jsonl")).toBe(false);
+    expect(entries.map((entry) => entry.path)).toEqual([...entries].sort((a, b) => b.mtime - a.mtime).map((entry) => entry.path));
+    expect(entries.every((entry) => entry.path !== path.join(roots["codex-sessions"], "too-new.bin"))).toBe(true);
+    expect(entries.every((entry) => entry.path !== path.join(roots["codex-sessions"], "empty.jsonl"))).toBe(true);
+    expect(entries.every((entry) => !entry.path.includes(path.sep + "tool-results" + path.sep))).toBe(true);
+    expect(entries.every((entry) => !entry.path.endsWith("scratchpad.txt"))).toBe(true);
+    expect(entries.every((entry) => !entry.path.endsWith("mirrored.output"))).toBe(true);
+  } finally {
+    await rm(base, { recursive: true, force: true });
+  }
+});

--- a/src/lib/scanner/discover.ts
+++ b/src/lib/scanner/discover.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs";
+import { access, readdir, stat } from "node:fs/promises";
 import path from "node:path";
 
 import type { FileEntry, RootKey } from "../types";
@@ -20,45 +21,78 @@ interface RawEntry {
   st: fs.Stats;
 }
 
-function walk(rootName: RootKey, root: string, dir: string, out: RawEntry[]) {
+type Roots = Record<RootKey, string>;
+type Limit = <T>(work: () => Promise<T>) => Promise<T>;
+
+function createLimiter(max: number): Limit {
+  let active = 0;
+  const queue: (() => void)[] = [];
+  return async function limit<T>(work: () => Promise<T>): Promise<T> {
+    if (active >= max) await new Promise<void>((resolve) => queue.push(resolve));
+    active += 1;
+    try {
+      return await work();
+    } finally {
+      active -= 1;
+      queue.shift()?.();
+    }
+  };
+}
+
+async function walk(rootName: RootKey, roots: Roots, root: string, dir: string, limit: Limit): Promise<RawEntry[]> {
   let entries: fs.Dirent[];
   try {
-    entries = fs.readdirSync(dir, { withFileTypes: true });
+    entries = await limit(() => readdir(dir, { withFileTypes: true }));
   } catch {
-    return;
+    return [];
   }
-  for (const entry of entries) {
+  const chunks = await Promise.all(entries.map(async (entry): Promise<RawEntry[]> => {
     if (entry.isDirectory()) {
-      if (entry.name.startsWith(".git")) continue;
-      walk(rootName, root, path.join(dir, entry.name), out);
-      continue;
+      if (entry.name.startsWith(".git")) return [];
+      return walk(rootName, roots, root, path.join(dir, entry.name), limit);
     }
-    if (!entry.isFile() || !EXTS.some((ext) => entry.name.endsWith(ext))) continue;
+    if (!entry.isFile() || !EXTS.some((ext) => entry.name.endsWith(ext))) return [];
     const pathname = path.join(dir, entry.name);
-    if (rootName === "claude-projects" && pathname.includes(path.sep + "tool-results" + path.sep)) continue;
+    if (rootName === "claude-projects" && pathname.includes(path.sep + "tool-results" + path.sep)) return [];
     let st: fs.Stats;
     try {
-      st = fs.statSync(pathname);
+      st = await limit(() => stat(pathname));
     } catch {
-      continue;
+      return [];
     }
-    const isTask = rootName === "claude-tasks" ? taskParts(ROOTS["claude-tasks"], pathname) : null;
-    if (rootName === "claude-tasks" && !isTask) continue;
-    if (st.size === 0 && !isTask) continue;
+    const isTask = rootName === "claude-tasks" ? taskParts(roots["claude-tasks"], pathname) : null;
+    if (rootName === "claude-tasks" && !isTask) return [];
+    if (st.size === 0 && !isTask) return [];
     if (isTask) {
       const [slug, sid, tid] = isTask;
-      const twin = path.join(ROOTS["claude-projects"], slug, sid, "subagents", "agent-" + tid + ".jsonl");
-      if (fs.existsSync(twin)) continue;
+      const twin = path.join(roots["claude-projects"], slug, sid, "subagents", "agent-" + tid + ".jsonl");
+      try {
+        await limit(() => access(twin));
+        return [];
+      } catch {
+        /* no mirrored subagent */
+      }
     }
-    out.push({ rootName, root, path: pathname, st });
+    return [{ rootName, root, path: pathname, st }];
+  }));
+  return chunks.flat();
+}
+
+async function rootExists(root: string, limit: Limit): Promise<boolean> {
+  try {
+    await limit(() => access(root));
+    return true;
+  } catch {
+    return false;
   }
 }
 
-export function discoverFiles(): FileEntry[] {
-  const raw: RawEntry[] = [];
-  for (const [rootName, root] of Object.entries(ROOTS) as [RootKey, string][]) {
-    if (fs.existsSync(root)) walk(rootName, root, root, raw);
-  }
+export async function discoverFiles(roots: Roots = ROOTS): Promise<FileEntry[]> {
+  const limit = createLimiter(48);
+  const raw = (await Promise.all((Object.entries(roots) as [RootKey, string][]).map(async ([rootName, root]) => {
+    if (!(await rootExists(root, limit))) return [];
+    return walk(rootName, roots, root, root, limit);
+  }))).flat();
   // describe() reads file heads, so it runs only on the capped shortlist; the
   // walk stays a cheap stat pass over every candidate.
   raw.sort((a, b) => b.st.mtimeMs - a.st.mtimeMs);

--- a/src/lib/scanner/index.ts
+++ b/src/lib/scanner/index.ts
@@ -68,30 +68,54 @@ function applyProcessState(entry: FileEntry, holders: Map<string, number>, job: 
  * Steps 3-5 run only on the capped shortlist.
  */
 const NO_HOLDERS: Map<string, number> = new Map();
+const YIELD_EVERY = 75;
+
+function yieldToEventLoop(): Promise<void> {
+  return new Promise((resolve) => setImmediate(resolve));
+}
+
+async function forEachEntryYielding(entries: FileEntry[], visit: (entry: FileEntry) => void): Promise<void> {
+  for (let index = 0; index < entries.length; index += 1) {
+    visit(entries[index]!);
+    if ((index + 1) % YIELD_EVERY === 0) await yieldToEventLoop();
+  }
+}
+
+async function forEachEntryBatchYielding(
+  entries: FileEntry[],
+  visit: (entry: FileEntry) => Promise<void>,
+): Promise<void> {
+  for (let start = 0; start < entries.length; start += YIELD_EVERY) {
+    await Promise.all(entries.slice(start, start + YIELD_EVERY).map(visit));
+    if (start + YIELD_EVERY < entries.length) await yieldToEventLoop();
+  }
+}
 
 export async function listFiles(): Promise<FileEntry[]> {
-  const entries = discoverFiles();
+  const entries = await discoverFiles();
   // The /proc fd scan is only needed to attribute background-task outputs to a
   // live pid. When the shortlist has no such entries, skip the scan entirely;
   // activity() only consults holders on the same claude-tasks/.output path.
   const needsHolders = entries.some((entry) => entry.root === "claude-tasks" && entry.path.endsWith(".output"));
   const holders = needsHolders ? outputHolders() : NO_HOLDERS;
   const jobs = new Map<string, Record<string, unknown> | null>();
-  for (const entry of entries) {
+  await forEachEntryYielding(entries, (entry) => {
     const job = entry.root === "codex-jobs" ? readJson(entry.path.replace(/\.log$/, ".json")) : null;
     jobs.set(entry.path, job);
     const verdict = activityVerdict(entry.root, entry.path, entry.mtime, entry.size, job);
     entry.activity = verdict.state;
     entry.activityReason = verdict.reason;
     entry.model = entryModel(entry);
-  }
-  for (const entry of entries) {
+  });
+  await forEachEntryYielding(entries, (entry) => {
     applyProcessState(entry, holders, jobs.get(entry.path) ?? null);
-  }
+  });
   assignTranscriptPids(entries);
   // After pid assignment: the claude effort source is the live process argv.
-  for (const entry of entries) entry.effort = entryEffort(entry);
-  await Promise.all(entries.map(async (entry) => {
+  await forEachEntryYielding(entries, (entry) => {
+    entry.effort = entryEffort(entry);
+  });
+  await forEachEntryBatchYielding(entries, async (entry) => {
     const pending = pendingQuestionFor(entry);
     entry.pendingQuestion = pending && entry.pid !== null ? { ...pending, paneTarget: await resolveTarget(entry.pid) } : pending;
     const probe = await waitingInputProbe(entry);
@@ -106,11 +130,11 @@ export async function listFiles(): Promise<FileEntry[]> {
     entry.plan = planFor(entry);
     entry.goal = goalFor(entry);
     entry.ctx = ctxFor(entry);
-  }));
-  for (const entry of entries) {
+  });
+  await forEachEntryYielding(entries, (entry) => {
     if (entry.pendingQuestion || entry.waitingInput) void notifyQuestion(entry);
-  }
-  linkEntries(entries);
+  });
+  await linkEntries(entries);
   await tickFlows(entries);
   /* Workflows tick after flows: a workflow watching its embedded flow sees
      the state that same poll just produced. */

--- a/src/lib/scanner/links.ts
+++ b/src/lib/scanner/links.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs";
+import { readdir } from "node:fs/promises";
 import path from "node:path";
 
 import { statePath } from "@/lib/configDir";
@@ -22,6 +23,22 @@ const bgcmdCache = globalCache<{ command: string; description: string; source: s
 const chainCache = globalCache<[number, string | null]>("chain-uuid");
 
 const CHAIN_HEAD_BYTES = 512 * 1024;
+type Limit = <T>(work: () => Promise<T>) => Promise<T>;
+
+function createLimiter(max: number): Limit {
+  let active = 0;
+  const queue: (() => void)[] = [];
+  return async function limit<T>(work: () => Promise<T>): Promise<T> {
+    if (active >= max) await new Promise<void>((resolve) => queue.push(resolve));
+    active += 1;
+    try {
+      return await work();
+    } finally {
+      active -= 1;
+      queue.shift()?.();
+    }
+  };
+}
 
 /**
  * A transcript created by compaction opens with a system record
@@ -104,33 +121,34 @@ function chainCompactedSessions(entries: FileEntry[]): void {
   }
 }
 
-function globWalk(dir: string, pred: (pathname: string) => boolean, out: string[] = []): string[] {
+async function globWalk(dir: string, pred: (pathname: string) => boolean, limit: Limit): Promise<string[]> {
   let entries: fs.Dirent[];
   try {
-    entries = fs.readdirSync(dir, { withFileTypes: true });
+    entries = await limit(() => readdir(dir, { withFileTypes: true }));
   } catch {
-    return out;
+    return [];
   }
-  for (const entry of entries) {
+  const chunks = await Promise.all(entries.map(async (entry): Promise<string[]> => {
     const pathname = path.join(dir, entry.name);
-    if (entry.isDirectory()) globWalk(pathname, pred, out);
-    else if (entry.isFile() && pred(pathname)) out.push(pathname);
-  }
-  return out;
+    if (entry.isDirectory()) return globWalk(pathname, pred, limit);
+    if (entry.isFile() && pred(pathname)) return [pathname];
+    return [];
+  }));
+  return chunks.flat();
 }
 
-function sessionTranscripts(sid: string, slug?: string | null): [string | null, string[]] {
+async function sessionTranscripts(sid: string, limit: Limit, slug?: string | null): Promise<[string | null, string[]]> {
   const base = ROOTS["claude-projects"];
   let realSlug = slug ?? sidSlugCache.get(sid) ?? null;
   if (!realSlug) {
-    const hit = globWalk(base, (p) => path.basename(p) === sid + ".jsonl")[0];
+    const hit = (await globWalk(base, (p) => path.basename(p) === sid + ".jsonl", limit))[0];
     if (!hit) return [null, []];
     realSlug = path.basename(path.dirname(hit));
     sidSlugCache.set(sid, realSlug);
   }
   const main = path.join(base, realSlug, sid + ".jsonl");
   const subDir = path.join(base, realSlug, sid, "subagents");
-  const subs = globWalk(subDir, (p) => path.basename(p).startsWith("agent-") && p.endsWith(".jsonl")).sort();
+  const subs = (await globWalk(subDir, (p) => path.basename(p).startsWith("agent-") && p.endsWith(".jsonl"), limit)).sort();
   return [fs.existsSync(main) ? main : null, subs];
 }
 
@@ -364,13 +382,15 @@ function attachHandoffParents(entries: FileEntry[]): void {
   persistHandoffLineage();
 }
 
-export function linkEntries(entries: FileEntry[]): void {
+export async function linkEntries(entries: FileEntry[]): Promise<void> {
+  const limit = createLimiter(48);
   const byPath = new Map(entries.map((entry) => [entry.path, entry]));
   const threadMap = new Map<string, string>();
   if (fs.existsSync(ROOTS["codex-jobs"])) {
-    for (const jsonPath of globWalk(
+    for (const jsonPath of await globWalk(
       ROOTS["codex-jobs"],
       (p) => path.basename(p).startsWith("task-") && p.endsWith(".json"),
+      limit,
     )) {
       const job = readJson(jsonPath);
       const threadId = stringValue(job?.threadId);
@@ -383,7 +403,7 @@ export function linkEntries(entries: FileEntry[]): void {
       if (parts.length >= 3 && parts.at(-2) === "subagents") {
         const slug = parts[0] ?? "";
         const sid = parts.at(-3) ?? "";
-        const [main, subs] = sessionTranscripts(sid, slug);
+        const [main, subs] = await sessionTranscripts(sid, limit, slug);
         entry.parent = main;
         const meta = readJson(entry.path.slice(0, -".jsonl".length) + ".meta.json") ?? {};
         const toolUse = stringValue(meta.toolUseId);
@@ -402,8 +422,8 @@ export function linkEntries(entries: FileEntry[]): void {
       if (sid) {
         const ws = stringValue(job.workspaceRoot) ?? "";
         const slug = ws ? ws.replace(/[^A-Za-z0-9-]/g, "-") : null;
-        let [main, subs] = sessionTranscripts(sid, slug);
-        if (!main && slug) [main, subs] = sessionTranscripts(sid, null);
+        let [main, subs] = await sessionTranscripts(sid, limit, slug);
+        if (!main && slug) [main, subs] = await sessionTranscripts(sid, limit, null);
         const jobId = path.basename(entry.path).slice(0, -".log".length);
         const found = findNeedle(jobId, subs);
         entry.parent = found ?? main;
@@ -415,7 +435,7 @@ export function linkEntries(entries: FileEntry[]): void {
       const parts = taskParts(ROOTS["claude-tasks"], entry.path);
       if (!parts) continue;
       const [slug, sid, tid] = parts;
-      const [main, subs] = sessionTranscripts(sid, slug);
+      const [main, subs] = await sessionTranscripts(sid, limit, slug);
       const info = bgCommand(tid, (main ? [main] : []).concat(subs), slugMainTranscripts(slug, sid));
       if (info) {
         entry.parent = info.source;

--- a/src/lib/scanner/process.ts
+++ b/src/lib/scanner/process.ts
@@ -4,7 +4,10 @@ import path from "node:path";
 import { procBackend } from "@/lib/proc";
 import { ROOTS } from "./roots";
 
-const HOLDERS_TTL_MS = 5_000;
+/* Outlives the client's 10 s /api/files poll so these memos survive a full
+   poll instead of rebuilding every request; freshness-critical callers (a
+   rebuild right after a kill) pass fresh=true to bypass the memo. */
+const HOLDERS_TTL_MS = 12_000;
 const MAX_PATH_HOLDER_CANDIDATES = 256;
 
 export type AgentEngine = "claude" | "codex";

--- a/src/lib/tmux.ts
+++ b/src/lib/tmux.ts
@@ -10,6 +10,7 @@ import { inboxImageExt, MAX_INBOX_IMAGE_BYTES } from "@/lib/imagePolicy";
 import { INBOX_DIR } from "@/lib/inbox";
 import { listFiles } from "@/lib/scanner";
 import { isHelperArgv, pidAlive, readArgv, readPpid } from "@/lib/scanner/process";
+import { pathAllowed } from "@/lib/scanner/roots";
 import {
   composerLine,
   detectBlockingGate,
@@ -176,6 +177,25 @@ export async function knownLivePids(): Promise<Set<number>> {
     if (entry.pid !== null && entry.proc === "running" && pidAlive(entry.pid)) pids.add(entry.pid);
   }
   return pids;
+}
+
+/** Resolves and revalidates a request pid against the scanner's live set. */
+export async function targetForKnownPid(pid: number): Promise<TmuxTarget | null | "unknown"> {
+  const live = await knownLivePids();
+  if (!live.has(pid)) return "unknown";
+  return resolveTarget(pid);
+}
+
+export async function resolveRequestedTmuxTarget(pid: number | null, filePath: string): Promise<TmuxTarget | null> {
+  if (pid !== null) {
+    const target = await targetForKnownPid(pid);
+    if (target !== "unknown" && target !== null) return target;
+  }
+  if (filePath && pathAllowed(filePath)) {
+    const pane = await liveResumePane(filePath);
+    if (pane) return pane.display;
+  }
+  return null;
 }
 
 const PASTE_SETTLE_MS = 250;

--- a/src/lib/tmux.ts
+++ b/src/lib/tmux.ts
@@ -23,7 +23,9 @@ import {
 export { READY_MARKERS, screenTail } from "@/lib/status";
 
 const TMUX = "tmux";
-const PANE_MAP_TTL_MS = 5_000;
+/* Outlives the 10 s /api/files poll so the pane map is not rebuilt every
+   request; a post-kill rebuild passes fresh=true to bypass the memo. */
+const PANE_MAP_TTL_MS = 12_000;
 const MAX_ANCESTRY_HOPS = 64;
 
 export interface InboxImagePayload {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -232,6 +232,8 @@ export interface ResourceSession {
   project: string | null;
   activity: Activity | null;
   lastActiveAt: string | null;
+  /** Agent CLI working directory — the identity fallback for orphan rows. */
+  cwd: string | null;
   /** Tree totals across the pane pid and every descendant (MCP children included). */
   rssBytes: number;
   swapBytes: number;


### PR DESCRIPTION
## Why

With many live agents the board janked hard: every visible pane ran its own 1.2 s `/api/log` poll (~16 req/s at 15 agents), every byte tick re-parsed the pane's whole line window (up to 2500 lines ≈ 10 MB of `JSON.parse`) and re-rendered every message's markdown, and the 10 s `/api/files` scan blocked the event loop, stalling log responses behind it.

## What

**Client feed pipeline**
- `buildFeed` → incremental per-pane parse sessions: only appended lines are parsed, cross-line effects (tool results, delivery echoes, compact summaries) land copy-on-write, untouched items keep identity so memoized rows skip re-render. Session-stable row keys survive window trims. Measured 27.3 ms → 0.12 ms per tick on a real 10 MB transcript (225×).
- One batched `POST /api/logs` per tick for all panes (byte-budgeted), then **SSE push** (`GET /api/logs/stream`, `fs.watch` + safety re-stat + heartbeat) with automatic fallback to the batch poll. `useLogTail` is unchanged.
- Glued focused panes get a line cap instead of unbounded growth.

**Scheme board**
- Panes pause feed + composer polling off-viewport (IntersectionObserver, 256px pre-wake margin) and below the far-zoom label threshold (hysteresis). Activity dots, questions and notifications ride the files poll as before. Far zoom on a live board: 0 log requests.
- Batched `POST /api/tmux/targets` + client `tmuxBus` replaces per-pane 5 s target polls.

**Server scanner**
- One shared 128 KB tail read+parse per growing file per scan instead of 4–6 (bounded cache).
- Cooperative async discovery walk + glob scans with bounded concurrency and event-loop yields between pipeline phases — `/api/files` no longer head-of-line-blocks log responses.
- `/proc` and tmux pane-map memos outlive the 10 s poll; `/api/files` answers `If-None-Match` with a bodyless 304.

## Verification

- 204 tests green, incl. new parity tests (incremental chunked feeding vs one-shot parse across claude/codex/plain with sliding caps), item-identity stability tests, SSE stream tests (watcher failure → poll fallback, read-failure isolation, offset catch-up), discovery ordering/cap tests.
- `bunx tsc --noEmit`, `bun run build` green.
- The tmux-batch, async-scan and logs-sse changes each went through an implement→review loop with a fresh headless reviewer per round (verdicts: APPROVE ×3; logs-sse took 4 rounds — watcher-failure staleness, CI-hostile test setup and an unhandled pump rejection were caught and fixed).
- Live smoke on a scratch instance: batch first-tick 43 ms / idle 6 ms, 304 on unchanged payloads, path gate rejects out-of-root reads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)