### PR TITLE
Add spatial keyboard navigation and anchor-follow camera

### DIFF
--- a/src/components/scheme/SchemeBoard.tsx
+++ b/src/components/scheme/SchemeBoard.tsx
@@ -28,6 +28,7 @@ import { TasksLayer } from "./TasksLayer";
 import { buildTaskEdges, buildTaskTargetIndex, TASK_W, taskRect, type SchemeRect } from "./taskGeometry";
 import { useLasso } from "./useLasso";
 import { useSchemeCamera } from "./useSchemeCamera";
+import { useSpatialNav } from "./useSpatialNav";
 
 /* Below this zoom the big node labels fade in over the unreadable panes. */
 const LABEL_Z = 0.45;
@@ -336,6 +337,12 @@ export function SchemeBoard({
     setPendingTask({ x: Math.round(wx - TASK_W / 2), y: Math.round(wy - 14) });
   }, []);
 
+  /* Spatial-nav handlers behind refs: the camera's keydown listener reads these
+     while useSpatialNav (created below) needs the camera's own outputs — the
+     ref breaks that creation cycle, same as lassoDownRef. */
+  const navArrowRef = useRef<(event: KeyboardEvent) => boolean>(() => false);
+  const navZoomRef = useRef<(dir: 1 | -1) => boolean>(() => false);
+
   const {
     cam,
     vp,
@@ -356,6 +363,9 @@ export function SchemeBoard({
     fit,
     fitRect,
     jump,
+    manualNonce,
+    glideBy,
+    glideFrame,
   } = useSchemeCamera({
     project,
     layout,
@@ -372,7 +382,29 @@ export function SchemeBoard({
     onWorldTap: mapMode ? undefined : onWorldTap,
     taskRects,
     onPlaceTask: mapMode ? undefined : onPlaceTask,
+    onArrowNav: navArrowRef,
+    onZoomKey: navZoomRef,
   });
+
+  /* Spatial keyboard navigation: live only on the desktop board — a selection
+     session, an expanded overlay, or map mode all suspend it. */
+  const navEnabled = !mapMode && !session && !overlayOpen;
+  const { onArrow, onZoomKey, announcement } = useSpatialNav({
+    enabled: navEnabled,
+    layout,
+    cam,
+    vp,
+    selected,
+    setSelected,
+    centerOn,
+    glideBy,
+    glideFrame,
+    manualNonce,
+  });
+  useEffect(() => {
+    navArrowRef.current = onArrow;
+    navZoomRef.current = onZoomKey;
+  }, [onArrow, onZoomKey]);
 
   const commitMarquee = useCallback((paths: string[], additive: boolean) => {
     marqueeClickGuard.current = true;
@@ -499,11 +531,17 @@ export function SchemeBoard({
       className={`relative min-h-0 flex-1 overflow-hidden ${
         panning ? "cursor-grabbing select-none" : taskTool ? "cursor-crosshair" : handLike ? "cursor-grab" : ""
       } ${handLike ? "touch-none" : ""}`}
+      tabIndex={mapMode ? undefined : 0}
+      aria-label={mapMode ? undefined : t("scheme.boardAria")}
       onPointerDown={onPointerDown}
       onPointerMove={onPointerMove}
       onDoubleClick={onDoubleClick}
       onClick={onClick}
     >
+      {/* Announces the window the arrow keys just landed on, for screen readers. */}
+      <div className="sr-only" aria-live="polite" role="status">
+        {announcement}
+      </div>
       {/* Dot grid on its own composited layer: panning moves it with a
           transform (modulo one tile) instead of repainting the viewport
           background every frame. */}

--- a/src/components/scheme/layout.ts
+++ b/src/components/scheme/layout.ts
@@ -11,7 +11,7 @@ import { engineColor } from "@/components/utils";
 export const NODE_W = 600;
 const ROOT_H = 780;
 const CHILD_H = 680;
-const GAP_X = 48;
+export const GAP_X = 48;
 /* Vertical corridor between generations: arrows plus the under-deck chip. */
 const GAP_Y = 130;
 /* Children start slightly right of the parent's left edge — the requested

--- a/src/components/scheme/spatialNav.test.ts
+++ b/src/components/scheme/spatialNav.test.ts
@@ -1,0 +1,199 @@
+import { describe, expect, test } from "bun:test";
+
+import type { Camera } from "./Minimap";
+import { GAP_X, NODE_W } from "./layout";
+import {
+  collectNavTargets,
+  LABEL_Z,
+  MAX_Z,
+  nearestToViewportCenter,
+  type NavTarget,
+  nextZoomStep,
+  pickDirectional,
+  zoomLadderSteps,
+} from "./spatialNav";
+
+function target(key: string, x: number, y: number, w = NODE_W, h = 680): NavTarget {
+  return { key, x, y, w, h };
+}
+
+/* Node dimensions used across the geometry cases (root 780, child 680). */
+const H = 680;
+
+describe("pickDirectional — rows", () => {
+  /* Three panes in a row at the same y, one NODE_W + GAP_X apart. */
+  const step = NODE_W + GAP_X;
+  const row = [target("a", 0, 0), target("b", step, 0), target("c", step * 2, 0)];
+
+  test("Right walks to the adjacent pane, one at a time", () => {
+    expect(pickDirectional(row, "a", "right")).toBe("b");
+    expect(pickDirectional(row, "b", "right")).toBe("c");
+  });
+
+  test("Right at the last pane returns null (edge, no wrap)", () => {
+    expect(pickDirectional(row, "c", "right")).toBeNull();
+  });
+
+  test("Left walks back symmetrically and stops at the edge", () => {
+    expect(pickDirectional(row, "c", "left")).toBe("b");
+    expect(pickDirectional(row, "b", "left")).toBe("a");
+    expect(pickDirectional(row, "a", "left")).toBeNull();
+  });
+
+  test("picks are independent of array order", () => {
+    const shuffled = [row[2]!, row[0]!, row[1]!];
+    expect(pickDirectional(shuffled, "a", "right")).toBe("b");
+    expect(pickDirectional(shuffled, "b", "right")).toBe("c");
+    expect(pickDirectional(shuffled, "b", "left")).toBe("a");
+  });
+});
+
+describe("pickDirectional — staircase", () => {
+  /* Indented parent→child chain: Δx=64 (INDENT), Δy=810 (ROOT/ CHILD + GAP_Y). */
+  const rungs = [
+    target("r0", 0, 0, NODE_W, 780),
+    target("r1", 64, 810),
+    target("r2", 128, 1620),
+    target("r3", 192, 2430),
+  ];
+
+  test("Down chains through every rung", () => {
+    expect(pickDirectional(rungs, "r0", "down")).toBe("r1");
+    expect(pickDirectional(rungs, "r1", "down")).toBe("r2");
+    expect(pickDirectional(rungs, "r2", "down")).toBe("r3");
+    expect(pickDirectional(rungs, "r3", "down")).toBeNull();
+  });
+
+  test("Up chains back through every rung", () => {
+    expect(pickDirectional(rungs, "r3", "up")).toBe("r2");
+    expect(pickDirectional(rungs, "r1", "up")).toBe("r0");
+    expect(pickDirectional(rungs, "r0", "up")).toBeNull();
+  });
+});
+
+describe("pickDirectional — sparse fallback", () => {
+  /* A lone root far to the upper-left of a deep child: only the half-plane tier
+     reaches it, but Up must still find it (traversal is total). */
+  const sparse = [target("root", 100, 100, NODE_W, 780), target("child", 13124, 1010)];
+
+  test("Up from a far-right child reaches the sole root via the half-plane tier", () => {
+    expect(pickDirectional(sparse, "child", "up")).toBe("root");
+  });
+
+  test("unknown anchor key yields null", () => {
+    expect(pickDirectional(sparse, "ghost", "up")).toBeNull();
+  });
+});
+
+describe("pickDirectional — tiers and ties", () => {
+  test("a same-band candidate far along wins over a near off-band one", () => {
+    /* Same-row b at dp=5000 beats off-band c at dp=900 (tier 1 before tier 2). */
+    const anchor = target("a", 0, 0);
+    const b = target("b", 5000, 0); // same band (y overlaps)
+    const c = target("c", 900, 4000); // off band, closer along x
+    expect(pickDirectional([anchor, b, c], "a", "right")).toBe("b");
+  });
+
+  test("equidistant candidates break ties by perpendicular distance then key", () => {
+    const anchor = target("a", 0, 0);
+    /* Two candidates dead ahead, mirrored in y (equal ds), no band overlap. */
+    const up = target("z", 2000, -3000);
+    const down = target("y", 2000, 3000);
+    /* Equal score and equal ds → lexicographic: "y" < "z". */
+    expect(pickDirectional([anchor, up, down], "a", "right")).toBe("y");
+  });
+
+  test("candidates behind or barely ahead are discarded", () => {
+    const anchor = target("a", 1000, 0);
+    const behind = target("b", 0, 0); // dp < 0
+    const barely = target("c", 1000 + 4, 0); // centre only 4px ahead → below DP_MIN
+    expect(pickDirectional([anchor, behind, barely], "a", "right")).toBeNull();
+  });
+});
+
+describe("collectNavTargets", () => {
+  test("mirrors every byPath entry with its key", () => {
+    const layout = {
+      byPath: new Map([
+        ["p1", { x: 1, y: 2, w: 3, h: 4 }],
+        ["deck::x", { x: 5, y: 6, w: 7, h: 8 }],
+      ]),
+    } as unknown as Parameters<typeof collectNavTargets>[0];
+    const targets = collectNavTargets(layout);
+    expect(targets).toHaveLength(2);
+    expect(targets.find((t) => t.key === "deck::x")).toEqual({ key: "deck::x", x: 5, y: 6, w: 7, h: 8 });
+  });
+});
+
+describe("nearestToViewportCenter", () => {
+  const targets = [target("a", 0, 0), target("b", 2000, 0), target("c", 4000, 0)];
+
+  test("respects the camera transform to find the on-screen-centre window", () => {
+    const vp = { w: 1600, h: 900 };
+    /* Put b's centre (x=2000+300=2300, y=340) at the viewport centre. */
+    const cam: Camera = { x: 800 - 2300, y: 450 - 340, z: 1 };
+    expect(nearestToViewportCenter(targets, cam, vp)).toBe("b");
+  });
+
+  test("keeps a still-visible selection instead of re-picking", () => {
+    const vp = { w: 1600, h: 900 };
+    /* Camera centred on b, but a is passed as selected and fully in view. */
+    const cam: Camera = { x: 800 - 2300, y: 450 - 340, z: 1 };
+    /* a's screen box: left = -300, still ~50%+ visible? a is off-screen left
+       here, so selection is NOT kept — nearest (b) wins. */
+    expect(nearestToViewportCenter(targets, cam, vp, "a")).toBe("b");
+  });
+
+  test("keeps the selection when it is at least half visible", () => {
+    const vp = { w: 1600, h: 900 };
+    /* Centre a in view; a is fully visible so it is retained even if b is
+       marginally closer to the exact centre. */
+    const cam: Camera = { x: 800 - 300, y: 450 - 340, z: 1 };
+    expect(nearestToViewportCenter(targets, cam, vp, "a")).toBe("a");
+  });
+});
+
+describe("zoomLadderSteps", () => {
+  const vp = { w: 1600, h: 900 };
+  const anchor = { x: 0, y: 0, w: NODE_W, h: H };
+
+  test("is ascending, bounded by MAX_Z above and LABEL_Z below", () => {
+    const steps = zoomLadderSteps(anchor, vp);
+    expect(steps.length).toBeGreaterThan(1);
+    for (let i = 1; i < steps.length; i++) expect(steps[i]!).toBeGreaterThan(steps[i - 1]!);
+    expect(steps[steps.length - 1]!).toBeLessThanOrEqual(MAX_Z + 1e-9);
+    expect(steps[0]!).toBeGreaterThanOrEqual(LABEL_Z - 1e-9);
+  });
+
+  test("step n frames n whole windows across", () => {
+    const steps = zoomLadderSteps(anchor, vp);
+    /* The 2-window framing must appear: (1600-48)/(2·600+48). */
+    const two = (1600 - 48) / (2 * NODE_W + GAP_X);
+    expect(steps.some((s) => Math.abs(s - two) < 1e-6)).toBe(true);
+  });
+
+  test("caps the single-window step at MAX_Z for a small anchor", () => {
+    const tiny = { x: 0, y: 0, w: 40, h: 40 };
+    const steps = zoomLadderSteps(tiny, vp);
+    expect(Math.max(...steps)).toBeLessThanOrEqual(MAX_Z + 1e-9);
+  });
+});
+
+describe("nextZoomStep", () => {
+  const steps = [0.47, 0.59, 0.79, 1.2, 1.24];
+
+  test("+ picks the next higher step, null at the ceiling", () => {
+    expect(nextZoomStep(steps, 0.59, 1)).toBe(0.79);
+    expect(nextZoomStep(steps, 1.24, 1)).toBeNull();
+  });
+
+  test("− picks the next lower step, null at the floor", () => {
+    expect(nextZoomStep(steps, 0.79, -1)).toBe(0.59);
+    expect(nextZoomStep(steps, 0.47, -1)).toBeNull();
+  });
+
+  test("ignores a step within ±1% of the current zoom", () => {
+    expect(nextZoomStep(steps, 0.79, 1)).toBe(1.2);
+    expect(nextZoomStep(steps, 0.79, -1)).toBe(0.59);
+  });
+});

--- a/src/components/scheme/spatialNav.ts
+++ b/src/components/scheme/spatialNav.ts
@@ -1,0 +1,245 @@
+import type { Camera } from "./Minimap";
+import { GAP_X, NODE_W, type SchemeLayout, type SchemeRect } from "./layout";
+
+/**
+ * Pure geometry for spatial keyboard navigation on the scheme board (issue #27).
+ * DOM-free and deterministic — the board's Arrow keys pick agent windows by
+ * world position (never DOM/freshness order) and the keyboard zoom ladder snaps
+ * to framings that show whole windows. Everything here is a plain function of
+ * rects + camera, so it runs under `bun test` like `lasso.ts`/`taskGeometry.ts`.
+ */
+
+export type NavDir = "up" | "down" | "left" | "right";
+
+/** Arrow key → direction, or null for any other key. */
+export function keyToDir(key: string): NavDir | null {
+  switch (key) {
+    case "ArrowUp":
+      return "up";
+    case "ArrowDown":
+      return "down";
+    case "ArrowLeft":
+      return "left";
+    case "ArrowRight":
+      return "right";
+    default:
+      return null;
+  }
+}
+
+/** What the camera should do when the followed anchor is re-laid-out. */
+export type ReflowPlan =
+  /** The anchor moved: translate the camera by −(dx, dy)·z to hold its screen
+      spot (the caller applies the ×z and sign). */
+  | { kind: "translate"; dx: number; dy: number }
+  /** The anchor left the layout: drop follow and clear the selection. */
+  | { kind: "drop" }
+  /** Nothing to do (no prior rect, or the anchor did not move). */
+  | { kind: "none" };
+
+/** Sub-pixel jitter that must not trigger a follow glide. */
+const MOVE_EPS = 0.5;
+
+/**
+ * Decide the follow reaction to a relayout: `next` is the anchor's rect in the
+ * new layout (undefined/null ⇒ it left the board). Pure so the follow lifecycle
+ * is unit-testable without a renderer.
+ */
+export function planReflow(prev: SchemeRect | null, next: SchemeRect | null | undefined): ReflowPlan {
+  if (!next) return { kind: "drop" };
+  if (!prev) return { kind: "none" };
+  const dx = next.x - prev.x;
+  const dy = next.y - prev.y;
+  if (Math.abs(dx) < MOVE_EPS && Math.abs(dy) < MOVE_EPS) return { kind: "none" };
+  return { kind: "translate", dx, dy };
+}
+
+/** A world-space box the camera can land on, tagged with its selection key. */
+export interface NavTarget extends SchemeRect {
+  key: string;
+}
+
+/* Directional-pick tuning (exported so the tests pin the exact behaviour). */
+/** Candidate must sit at least this far along the primary axis to count — a
+    tiny forward nudge is the same band, not a step. */
+export const DP_MIN = 8;
+/** Secondary-axis penalty per tier: same-band ≪ 90° cone ≪ half-plane. */
+export const TIER1_S = 0.3;
+export const TIER2_S = 2;
+export const TIER3_S = 4;
+
+/* Readable-zoom bounds for the keyboard ladder. MAX_Z mirrors useSchemeCamera's
+   clamp ceiling; LABEL_Z mirrors SchemeBoard's label-fade threshold — below it
+   panes are unreadable labels and the deeper overview belongs to Fit All. */
+export const MAX_Z = 1.6;
+export const LABEL_Z = 0.45;
+/* Ladder framings run 1 window up to this many across before dropping under the
+   readable floor; the loop also stops at LABEL_Z, this is a hard backstop. */
+const MAX_LADDER_N = 20;
+
+/** Every layout entry the camera can select — nodes, drafts, mini-stacks, decks
+    (exactly the `data-scheme-node` set). Task cards live elsewhere and are not
+    navigation targets. */
+export function collectNavTargets(layout: SchemeLayout): NavTarget[] {
+  const out: NavTarget[] = [];
+  for (const [key, rect] of layout.byPath) out.push({ key, x: rect.x, y: rect.y, w: rect.w, h: rect.h });
+  return out;
+}
+
+const overlap1D = (a0: number, a1: number, b0: number, b1: number) => Math.min(a1, b1) - Math.max(a0, b0);
+
+interface Metric {
+  key: string;
+  /** Distance along the direction of travel (always > 0 for a real candidate). */
+  dp: number;
+  /** Absolute distance on the perpendicular axis. */
+  ds: number;
+  /** Extent overlap on the perpendicular axis (> 0 ⇒ same row/column band). */
+  ov: number;
+}
+
+/* dp/ds/ov of candidate B relative to anchor A for one direction. */
+function metric(a: NavTarget, b: NavTarget, dir: NavDir): Metric {
+  const acx = a.x + a.w / 2;
+  const acy = a.y + a.h / 2;
+  const bcx = b.x + b.w / 2;
+  const bcy = b.y + b.h / 2;
+  let dp: number;
+  let ds: number;
+  let ov: number;
+  if (dir === "right") {
+    dp = bcx - acx;
+    ds = Math.abs(bcy - acy);
+    ov = overlap1D(a.y, a.y + a.h, b.y, b.y + b.h);
+  } else if (dir === "left") {
+    dp = acx - bcx;
+    ds = Math.abs(bcy - acy);
+    ov = overlap1D(a.y, a.y + a.h, b.y, b.y + b.h);
+  } else if (dir === "down") {
+    dp = bcy - acy;
+    ds = Math.abs(bcx - acx);
+    ov = overlap1D(a.x, a.x + a.w, b.x, b.x + b.w);
+  } else {
+    dp = acy - bcy;
+    ds = Math.abs(bcx - acx);
+    ov = overlap1D(a.x, a.x + a.w, b.x, b.x + b.w);
+  }
+  return { key: b.key, dp, ds, ov };
+}
+
+const EPS = 1e-9;
+
+/* Lowest `dp + weight·ds` wins; ties break by smaller ds, then lexicographic
+   key — so the pick is fully deterministic and array-order independent. */
+function bestOf(cands: readonly Metric[], weight: number): string | null {
+  let best: { key: string; score: number; ds: number } | null = null;
+  for (const c of cands) {
+    const score = c.dp + weight * c.ds;
+    if (
+      !best ||
+      score < best.score - EPS ||
+      (Math.abs(score - best.score) < EPS && (c.ds < best.ds - EPS || (Math.abs(c.ds - best.ds) < EPS && c.key < best.key)))
+    ) {
+      best = { key: c.key, score, ds: c.ds };
+    }
+  }
+  return best?.key ?? null;
+}
+
+/**
+ * The next agent window in `dir` from `fromKey`, or null at an edge (no wrap, no
+ * cycle — on a 26,000px world a wrap teleport destroys the spatial model).
+ * Three tiers make traversal total on ragged boards: same-band neighbours first,
+ * then a 90° cone, then the whole forward half-plane.
+ */
+export function pickDirectional(targets: readonly NavTarget[], fromKey: string, dir: NavDir): string | null {
+  const anchor = targets.find((t) => t.key === fromKey);
+  if (!anchor) return null;
+  const cands: Metric[] = [];
+  for (const b of targets) {
+    if (b.key === fromKey) continue;
+    const m = metric(anchor, b, dir);
+    if (m.dp > DP_MIN) cands.push(m);
+  }
+  if (!cands.length) return null;
+  const tier1 = cands.filter((c) => c.ov > 0);
+  if (tier1.length) return bestOf(tier1, TIER1_S);
+  const tier2 = cands.filter((c) => c.ds <= c.dp);
+  if (tier2.length) return bestOf(tier2, TIER2_S);
+  return bestOf(cands, TIER3_S);
+}
+
+/* World-space centre of a target mapped into viewport pixels. */
+const screenCenter = (t: NavTarget, cam: Camera) => ({ x: (t.x + t.w / 2) * cam.z + cam.x, y: (t.y + t.h / 2) * cam.z + cam.y });
+
+/* Fraction of a target's on-screen area that lies inside the viewport. */
+function visibleFraction(t: NavTarget, cam: Camera, vp: { w: number; h: number }): number {
+  const left = t.x * cam.z + cam.x;
+  const top = t.y * cam.z + cam.y;
+  const w = t.w * cam.z;
+  const h = t.h * cam.z;
+  if (w <= 0 || h <= 0) return 0;
+  const ix = Math.max(0, Math.min(left + w, vp.w) - Math.max(left, 0));
+  const iy = Math.max(0, Math.min(top + h, vp.h) - Math.max(top, 0));
+  return (ix * iy) / (w * h);
+}
+
+/**
+ * Start target for the first Arrow press when nothing is selected: the window
+ * whose centre is closest to the viewport centre in screen space. A selection
+ * that is still ≥50% on screen keeps its anchor, so re-baselining never causes a
+ * surprise jump on the first press.
+ */
+export function nearestToViewportCenter(
+  targets: readonly NavTarget[],
+  cam: Camera,
+  vp: { w: number; h: number },
+  selectedKey?: string | null,
+): string | null {
+  if (selectedKey) {
+    const sel = targets.find((t) => t.key === selectedKey);
+    if (sel && visibleFraction(sel, cam, vp) >= 0.5) return selectedKey;
+  }
+  const vx = vp.w / 2;
+  const vy = vp.h / 2;
+  let best: { key: string; d: number } | null = null;
+  for (const t of targets) {
+    const c = screenCenter(t, cam);
+    const d = Math.hypot(c.x - vx, c.y - vy);
+    if (!best || d < best.d - EPS || (Math.abs(d - best.d) < EPS && t.key < best.key)) best = { key: t.key, d };
+  }
+  return best?.key ?? null;
+}
+
+/**
+ * Keyboard zoom ladder for an anchor rect: ascending zoom levels that each frame
+ * a whole number of windows across. Step 1 fits the anchor alone (capped at
+ * MAX_Z); step n fits n node-widths + gaps, kept only while it stays at/above
+ * the readable floor LABEL_Z. Wheel/pinch stay continuous — this is keys only.
+ */
+export function zoomLadderSteps(anchor: SchemeRect, vp: { w: number; h: number }): number[] {
+  const usableW = vp.w - 48;
+  const usableH = vp.h - 48;
+  const z1 = Math.min(usableW / anchor.w, usableH / anchor.h, MAX_Z);
+  const set = new Set<number>([z1]);
+  for (let n = 2; n <= MAX_LADDER_N; n++) {
+    const zn = usableW / (n * NODE_W + (n - 1) * GAP_X);
+    if (zn < LABEL_Z) break;
+    set.add(zn);
+  }
+  return [...set].sort((a, b) => a - b);
+}
+
+/** Next ladder step strictly beyond the current zoom (`dir` +1 in / −1 out), or
+    null at the ceiling/floor. The ±1% deadband stops a step that equals the
+    current zoom from being re-selected. */
+export function nextZoomStep(steps: readonly number[], currentZ: number, dir: 1 | -1): number | null {
+  if (dir > 0) {
+    let pick: number | null = null;
+    for (const s of steps) if (s > currentZ * 1.01 && (pick === null || s < pick)) pick = s;
+    return pick;
+  }
+  let pick: number | null = null;
+  for (const s of steps) if (s < currentZ * 0.99 && (pick === null || s > pick)) pick = s;
+  return pick;
+}

--- a/src/components/scheme/useSchemeCamera.ts
+++ b/src/components/scheme/useSchemeCamera.ts
@@ -16,6 +16,9 @@ export type Mode = "hand" | "select";
 
 const dist = (a: { x: number; y: number }, b: { x: number; y: number }) => Math.hypot(a.x - b.x, a.y - b.y);
 
+/* Reduced-motion: camera glides become instant jumps (matches useFlip.ts:7). */
+const reducedMotion = () => typeof matchMedia !== "undefined" && matchMedia("(prefers-reduced-motion: reduce)").matches;
+
 interface CameraOptions {
   project: string;
   layout: SchemeLayout;
@@ -41,6 +44,14 @@ interface CameraOptions {
   /** One-shot «task» tool sink: the next canvas click lands here in world
       coordinates, then the tool reverts to select. Absent in map mode. */
   onPlaceTask?: (wx: number, wy: number) => void;
+  /** Spatial keyboard navigation (issue #27), held behind a ref to break the
+      camera↔nav creation cycle. `onArrowNav` handles an Arrow press and returns
+      true when it consumed it (the old fixed 160px pan is gone — an unconsumed
+      press does nothing). `onZoomKey` gets first refusal on +/−: true means it
+      snapped the anchor to a ladder framing, false falls back to continuous
+      zoom around the viewport centre. */
+  onArrowNav?: React.RefObject<(event: KeyboardEvent) => boolean>;
+  onZoomKey?: React.RefObject<(dir: 1 | -1) => boolean>;
 }
 
 export interface SchemeCamera {
@@ -68,6 +79,15 @@ export interface SchemeCamera {
   /** Glide to fit a world rect (the "show selection" bulk action). */
   fitRect: (rect: SchemeRect) => void;
   jump: (wx: number, wy: number) => void;
+  /** Bumps whenever the user drives the camera by hand (pan >9px, pinch end,
+      wheel settle) — spatial nav watches it to drop follow and re-baseline. */
+  manualNonce: number;
+  /** Glide-translate so a point that moved by (worldDx, worldDy) keeps its
+      screen position: the follow anchor holds still through a reflow. */
+  glideBy: (worldDx: number, worldDy: number) => void;
+  /** Glide the anchor to the `centerOn` placement at an explicit zoom — the
+      keyboard zoom ladder, which unlike `centerOn` may zoom out below `c.z`. */
+  glideFrame: (rect: SchemeRect, z: number) => void;
 }
 
 /**
@@ -90,6 +110,8 @@ export function useSchemeCamera({
   onWorldTap,
   taskRects,
   onPlaceTask,
+  onArrowNav,
+  onZoomKey,
 }: CameraOptions): SchemeCamera {
   const viewportRef = useRef<HTMLDivElement | null>(null);
   const tapRef = useRef<{ x: number; y: number } | null>(null);
@@ -100,7 +122,13 @@ export function useSchemeCamera({
   const [panning, setPanning] = useState(false);
   const [glide, setGlide] = useState(false);
   const [vp, setVp] = useState({ w: 1, h: 1 });
+  const [manualNonce, setManualNonce] = useState(0);
   const panRef = useRef<{ sx: number; sy: number; cx: number; cy: number } | null>(null);
+  /* A pan that actually travelled >9px, and an active two-finger pinch — both
+     bump manualNonce when they end so a settled hand gesture re-baselines nav. */
+  const panMovedRef = useRef(false);
+  const pinchActiveRef = useRef(false);
+  const wheelSettle = useRef<number | null>(null);
   const pointersRef = useRef(new Map<number, { x: number; y: number }>());
   const pinchRef = useRef<{ d: number; cx: number; cy: number } | null>(null);
   const modeRef = useRef<Mode>(mode);
@@ -233,7 +261,8 @@ export function useSchemeCamera({
   }, [layout]);
 
   const glideTo = useCallback((next: Camera | ((c: Camera) => Camera)) => {
-    setGlide(true);
+    /* Reduced motion: skip the CSS transition — the move lands instantly. */
+    if (!reducedMotion()) setGlide(true);
     setCam(next);
     if (glideTimer.current) window.clearTimeout(glideTimer.current);
     glideTimer.current = window.setTimeout(() => setGlide(false), 500);
@@ -276,6 +305,33 @@ export function useSchemeCamera({
       });
     },
     [glideTo],
+  );
+
+  /* Follow-anchor reflow: the anchor's world position shifted by (wdx, wdy);
+     translate the camera the opposite way (× z) so it holds its screen spot. */
+  const glideBy = useCallback(
+    (wdx: number, wdy: number) => {
+      glideTo((c) => clampCam({ ...c, x: c.x - wdx * c.z, y: c.y - wdy * c.z }));
+    },
+    [glideTo, clampCam],
+  );
+
+  /* The keyboard zoom ladder: same centered/head-near-top placement as
+     `centerOn`, but at an explicit zoom (it may zoom out below the current z). */
+  const glideFrame = useCallback(
+    (node: SchemeRect, z: number) => {
+      const rect = viewportRef.current?.getBoundingClientRect();
+      if (!rect) return;
+      const zz = Math.min(MAX_Z, Math.max(MIN_Z, z));
+      glideTo(
+        clampCam({
+          z: zz,
+          x: rect.width / 2 - (node.x + node.w / 2) * zz,
+          y: Math.min(rect.height / 2 - node.y * zz, rect.height * 0.08 - (node.y - 40) * zz),
+        }),
+      );
+    },
+    [glideTo, clampCam],
   );
 
   /* First layout of a project: restore the saved camera or fit everything.
@@ -333,12 +389,19 @@ export function useSchemeCamera({
   useEffect(() => {
     const el = viewportRef.current;
     if (!el) return;
+    /* A camera-moving wheel re-baselines nav once it stops: bump manualNonce
+       250ms after the last such event (a wheel that scrolls a feed does not). */
+    const armSettle = () => {
+      if (wheelSettle.current) window.clearTimeout(wheelSettle.current);
+      wheelSettle.current = window.setTimeout(() => setManualNonce((n) => n + 1), 250);
+    };
     const onWheel = (event: WheelEvent) => {
       if ((event.target as HTMLElement).closest("[data-scheme-ui]")) return;
       const rect = el.getBoundingClientRect();
       if (event.ctrlKey || event.metaKey) {
         event.preventDefault();
         applyZoom(event.clientX - rect.left, event.clientY - rect.top, Math.exp(-event.deltaY * 0.0022));
+        armSettle();
         return;
       }
       if (modeRef.current === "select" && !spaceRef.current) {
@@ -353,9 +416,13 @@ export function useSchemeCamera({
       const dx = event.shiftKey && !event.deltaX ? event.deltaY : event.deltaX;
       const dy = event.shiftKey && !event.deltaX ? 0 : event.deltaY;
       queueCam((c) => clampCam({ ...c, x: c.x - dx, y: c.y - dy }));
+      armSettle();
     };
     el.addEventListener("wheel", onWheel, { passive: false });
-    return () => el.removeEventListener("wheel", onWheel);
+    return () => {
+      el.removeEventListener("wheel", onWheel);
+      if (wheelSettle.current) window.clearTimeout(wheelSettle.current);
+    };
   }, [applyZoom, clampCam, queueCam]);
 
   /* Keyboard: H/V tools, Space-hold temporary hand, +/−/1 zoom, 0 fit,
@@ -367,6 +434,16 @@ export function useSchemeCamera({
       return ["INPUT", "TEXTAREA", "SELECT", "BUTTON"].includes(el.tagName) || el.isContentEditable;
     };
     const onDown = (event: KeyboardEvent) => {
+      /* Arrows go to spatial nav before the typing() guard: they must still
+         work when a pane's button holds focus after a click. Nav runs its own
+         richer guards (inputs, dialogs, scroll-consuming feeds) and only
+         preventDefaults when it actually consumed the key. Modifier variants
+         are left to the browser (no MVP bindings). */
+      if (event.key.startsWith("Arrow")) {
+        if (event.metaKey || event.ctrlKey || event.altKey) return;
+        if (onArrowNav?.current?.(event)) event.preventDefault();
+        return;
+      }
       if (typing(event.target)) return;
       if (event.key === " ") {
         event.preventDefault();
@@ -386,14 +463,12 @@ export function useSchemeCamera({
       }
       else if (event.key === "0") fit();
       else if (event.key === "1") zoomTo(1);
-      else if (event.key === "+" || event.key === "=") zoomCenter(1.25);
-      else if (event.key === "-") zoomCenter(0.8);
-      else if (event.key.startsWith("Arrow")) {
-        event.preventDefault();
-        const step = 160;
-        const dx = event.key === "ArrowLeft" ? step : event.key === "ArrowRight" ? -step : 0;
-        const dy = event.key === "ArrowUp" ? step : event.key === "ArrowDown" ? -step : 0;
-        setCam((c) => clampCam({ ...c, x: c.x + dx, y: c.y + dy }));
+      /* +/− first offer the anchor-preserving zoom ladder; without a followed
+         anchor it falls back to continuous zoom around the viewport centre. */
+      else if (event.key === "+" || event.key === "=") {
+        if (!onZoomKey?.current?.(1)) zoomCenter(1.25);
+      } else if (event.key === "-") {
+        if (!onZoomKey?.current?.(-1)) zoomCenter(0.8);
       }
     };
     const onUp = (event: KeyboardEvent) => {
@@ -405,7 +480,7 @@ export function useSchemeCamera({
       window.removeEventListener("keydown", onDown);
       window.removeEventListener("keyup", onUp);
     };
-  }, [fit, zoomCenter, zoomTo, setMode, clampCam, setSelected]);
+  }, [fit, zoomCenter, zoomTo, setMode, setSelected, onArrowNav, onZoomKey]);
 
   const localPoint = (event: { clientX: number; clientY: number }) => {
     const rect = viewportRef.current?.getBoundingClientRect();
@@ -414,6 +489,7 @@ export function useSchemeCamera({
 
   const startPan = (event: React.PointerEvent<HTMLDivElement>) => {
     panRef.current = { sx: event.clientX, sy: event.clientY, cx: cam.x, cy: cam.y };
+    panMovedRef.current = false;
     setPanning(true);
     try {
       viewportRef.current?.setPointerCapture(event.pointerId);
@@ -434,6 +510,7 @@ export function useSchemeCamera({
       if (pointersRef.current.size === 2) {
         const [a, b] = [...pointersRef.current.values()];
         pinchRef.current = { d: dist(a!, b!), cx: (a!.x + b!.x) / 2, cy: (a!.y + b!.y) / 2 };
+        pinchActiveRef.current = true;
         panRef.current = null;
         setPanning(false);
         return;
@@ -509,6 +586,9 @@ export function useSchemeCamera({
     if (!pan) return;
     const dx = event.clientX - pan.sx;
     const dy = event.clientY - pan.sy;
+    /* Past the 9px tap threshold this is a real drag, not a click — mark it so
+       its end re-baselines nav. */
+    if (Math.hypot(dx, dy) > 9) panMovedRef.current = true;
     queueCam((c) => clampCam({ ...c, x: pan.cx + dx, y: pan.cy + dy }));
   };
 
@@ -518,7 +598,16 @@ export function useSchemeCamera({
   useEffect(() => {
     const end = (event: PointerEvent) => {
       pointersRef.current.delete(event.pointerId);
-      if (pointersRef.current.size < 2) pinchRef.current = null;
+      if (pointersRef.current.size < 2) {
+        pinchRef.current = null;
+        if (pinchActiveRef.current) {
+          pinchActiveRef.current = false;
+          setManualNonce((n) => n + 1);
+        }
+      }
+      /* A drag that actually moved is a manual camera gesture — re-baseline. */
+      if (panRef.current && panMovedRef.current) setManualNonce((n) => n + 1);
+      panMovedRef.current = false;
       panRef.current = null;
       setPanning(false);
     };
@@ -609,5 +698,8 @@ export function useSchemeCamera({
     fit,
     fitRect,
     jump,
+    manualNonce,
+    glideBy,
+    glideFrame,
   };
 }

--- a/src/components/scheme/useSpatialNav.test.ts
+++ b/src/components/scheme/useSpatialNav.test.ts
@@ -1,0 +1,166 @@
+import { describe, expect, test } from "bun:test";
+
+import type { Camera } from "./Minimap";
+import { GAP_X, NODE_W, type SchemeLayout, type SchemeRect } from "./layout";
+import {
+  collectNavTargets,
+  keyToDir,
+  nearestToViewportCenter,
+  type NavDir,
+  planReflow,
+  pickDirectional,
+} from "./spatialNav";
+
+/* A minimal SchemeLayout-shaped stub: the nav decision logic only touches
+   `byPath` and `nodes` (for labels), so the rest can stay empty. */
+function layoutOf(rects: Record<string, SchemeRect>): SchemeLayout {
+  const byPath = new Map<string, SchemeRect>(Object.entries(rects));
+  return { byPath, nodes: [], edges: [], stacks: [], decks: [], loops: [], drafts: [], width: 0, height: 0 } as unknown as SchemeLayout;
+}
+
+const rect = (x: number, y: number, w = NODE_W, h = 680): SchemeRect => ({ x, y, w, h });
+
+describe("keyToDir", () => {
+  test("maps arrows and ignores everything else", () => {
+    expect(keyToDir("ArrowUp")).toBe("up");
+    expect(keyToDir("ArrowDown")).toBe("down");
+    expect(keyToDir("ArrowLeft")).toBe("left");
+    expect(keyToDir("ArrowRight")).toBe("right");
+    expect(keyToDir("a")).toBeNull();
+    expect(keyToDir(" ")).toBeNull();
+  });
+});
+
+describe("planReflow — follow lifecycle", () => {
+  test("a moved anchor translates by its exact world delta", () => {
+    const plan = planReflow(rect(100, 100), rect(340, 190));
+    expect(plan).toEqual({ kind: "translate", dx: 240, dy: 90 });
+  });
+
+  test("an anchor that left the layout drops follow", () => {
+    expect(planReflow(rect(100, 100), null)).toEqual({ kind: "drop" });
+    expect(planReflow(rect(100, 100), undefined)).toEqual({ kind: "drop" });
+  });
+
+  test("no prior baseline is a no-op (the select just seeded it)", () => {
+    expect(planReflow(null, rect(100, 100))).toEqual({ kind: "none" });
+  });
+
+  test("sub-pixel jitter never triggers a glide", () => {
+    expect(planReflow(rect(100, 100), rect(100.2, 99.8))).toEqual({ kind: "none" });
+  });
+});
+
+/**
+ * End-to-end state-machine simulation of the hook without a renderer: it drives
+ * the same pure functions the hook calls, in the same order, so the traversal +
+ * follow-translate + manual-disarm behaviour is covered as an integration.
+ */
+describe("nav state machine (hook logic simulation)", () => {
+  const step = NODE_W + GAP_X;
+  const cam: Camera = { x: 0, y: 0, z: 1 };
+  const vp = { w: 1600, h: 900 };
+
+  /* Mirrors the hook's onArrow selection + reflow bookkeeping. */
+  function makeMachine(layout: SchemeLayout) {
+    let selected: string | null = null;
+    let follow = false;
+    let prev: SchemeRect | null = null;
+    const translates: { dx: number; dy: number }[] = [];
+    return {
+      get selected() {
+        return selected;
+      },
+      get follow() {
+        return follow;
+      },
+      get translates() {
+        return translates;
+      },
+      seed(key: string) {
+        selected = key;
+        follow = true;
+        prev = layout.byPath.get(key) ?? null;
+      },
+      arrow(dir: NavDir, live: SchemeLayout = layout) {
+        const targets = collectNavTargets(live);
+        const hasSel = selected != null && targets.some((t) => t.key === selected);
+        const pick = hasSel
+          ? pickDirectional(targets, selected!, dir)
+          : nearestToViewportCenter(targets, cam, vp, selected);
+        if (pick) {
+          selected = pick;
+          follow = true;
+          prev = live.byPath.get(pick) ?? null;
+        }
+        return pick;
+      },
+      reflow(live: SchemeLayout) {
+        if (!follow || selected == null) return;
+        const next = live.byPath.get(selected) ?? null;
+        const plan = planReflow(prev, next);
+        if (plan.kind === "drop") {
+          follow = false;
+          selected = null;
+          prev = null;
+        } else if (plan.kind === "translate") {
+          translates.push({ dx: plan.dx, dy: plan.dy });
+          prev = next;
+        }
+      },
+      manualGesture() {
+        follow = false;
+        prev = null;
+      },
+    };
+  }
+
+  test("first Right selects the on-screen-centre window, then walks the row", () => {
+    /* Row of three, camera centred so the middle one is at viewport centre. */
+    const layout = layoutOf({ a: rect(0, 0), b: rect(step, 0), c: rect(step * 2, 0) });
+    const centred: Camera = { x: vp.w / 2 - (step + NODE_W / 2), y: vp.h / 2 - 340, z: 1 };
+    const targets = collectNavTargets(layout);
+    /* First press with no selection lands on the centre window without stepping. */
+    expect(nearestToViewportCenter(targets, centred, vp, null)).toBe("b");
+
+    const m = makeMachine(layout);
+    m.seed("a");
+    expect(m.follow).toBe(true);
+    expect(m.arrow("right")).toBe("b");
+    expect(m.arrow("right")).toBe("c");
+    expect(m.arrow("right")).toBeNull(); // edge holds the selection
+    expect(m.selected).toBe("c");
+  });
+
+  test("a reflow under the anchor translates the camera to hold its screen spot", () => {
+    const before = layoutOf({ a: rect(0, 0), b: rect(step, 0) });
+    const m = makeMachine(before);
+    m.seed("a");
+    /* Freshness re-sort shifts every pane right by one slot. */
+    const after = layoutOf({ a: rect(step, 0), b: rect(step * 2, 0) });
+    m.reflow(after);
+    expect(m.translates).toEqual([{ dx: step, dy: 0 }]);
+    expect(m.selected).toBe("a"); // the anchor never left view
+  });
+
+  test("the anchor leaving the layout drops follow and the selection", () => {
+    const before = layoutOf({ a: rect(0, 0), b: rect(step, 0) });
+    const m = makeMachine(before);
+    m.seed("a");
+    const after = layoutOf({ b: rect(step, 0) }); // "a" closed
+    m.reflow(after);
+    expect(m.selected).toBeNull();
+    expect(m.follow).toBe(false);
+  });
+
+  test("a manual gesture disarms follow so later reflows stop moving the camera", () => {
+    const before = layoutOf({ a: rect(0, 0), b: rect(step, 0) });
+    const m = makeMachine(before);
+    m.seed("a");
+    m.manualGesture(); // pan/wheel/pinch settle
+    expect(m.follow).toBe(false);
+    const after = layoutOf({ a: rect(step, 0), b: rect(step * 2, 0) });
+    m.reflow(after);
+    expect(m.translates).toEqual([]); // no camera write after re-baseline
+  });
+});

--- a/src/components/scheme/useSpatialNav.test.ts
+++ b/src/components/scheme/useSpatialNav.test.ts
@@ -82,12 +82,12 @@ describe("nav state machine (hook logic simulation)", () => {
         follow = true;
         prev = layout.byPath.get(key) ?? null;
       },
-      arrow(dir: NavDir, live: SchemeLayout = layout) {
+      arrow(dir: NavDir, live: SchemeLayout = layout, liveCam: Camera = cam) {
         const targets = collectNavTargets(live);
-        const hasSel = selected != null && targets.some((t) => t.key === selected);
+        const hasSel = follow && selected != null && targets.some((t) => t.key === selected);
         const pick = hasSel
           ? pickDirectional(targets, selected!, dir)
-          : nearestToViewportCenter(targets, cam, vp, selected);
+          : nearestToViewportCenter(targets, liveCam, vp, selected);
         if (pick) {
           selected = pick;
           follow = true;
@@ -162,5 +162,17 @@ describe("nav state machine (hook logic simulation)", () => {
     const after = layoutOf({ a: rect(step, 0), b: rect(step * 2, 0) });
     m.reflow(after);
     expect(m.translates).toEqual([]); // no camera write after re-baseline
+  });
+
+  test("the first Arrow after a manual gesture starts from the new viewport centre", () => {
+    const layout = layoutOf({ a: rect(0, 0), b: rect(step, 0), c: rect(step * 2, 0) });
+    const m = makeMachine(layout);
+    m.seed("a");
+    m.manualGesture();
+    const centredOnC: Camera = { x: vp.w / 2 - (step * 2 + NODE_W / 2), y: vp.h / 2 - 340, z: 1 };
+
+    expect(m.arrow("right", layout, centredOnC)).toBe("c");
+    expect(m.selected).toBe("c");
+    expect(m.follow).toBe(true);
   });
 });

--- a/src/components/scheme/useSpatialNav.ts
+++ b/src/components/scheme/useSpatialNav.ts
@@ -1,0 +1,254 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import type { Camera } from "./Minimap";
+import type { SchemeLayout, SchemeRect } from "./layout";
+import {
+  collectNavTargets,
+  keyToDir,
+  nearestToViewportCenter,
+  type NavDir,
+  nextZoomStep,
+  pickDirectional,
+  planReflow,
+  zoomLadderSteps,
+} from "./spatialNav";
+import { cleanTitle } from "@/components/utils";
+
+interface SpatialNavOptions {
+  /** Nav is live only on the desktop board with no session/overlay/map mode. */
+  enabled: boolean;
+  layout: SchemeLayout;
+  cam: Camera;
+  vp: { w: number; h: number };
+  /** The single-selection ring path, owned by SchemeBoard. */
+  selected: string | null;
+  setSelected: (value: string | null) => void;
+  /** Glide the anchor to view keeping zoom (arrows never change zoom). */
+  centerOn: (rect: SchemeRect, zMin: number) => void;
+  /** Translate-glide so a moved anchor keeps its screen spot (reflow follow). */
+  glideBy: (worldDx: number, worldDy: number) => void;
+  /** Glide the anchor to an explicit zoom (the keyboard ladder). */
+  glideFrame: (rect: SchemeRect, z: number) => void;
+  /** Bumps on any manual camera gesture — drops follow and re-baselines. */
+  manualNonce: number;
+}
+
+export interface SpatialNav {
+  /** Handle an Arrow keydown; true when nav consumed it (camera preventDefaults). */
+  onArrow: (event: KeyboardEvent) => boolean;
+  /** Handle a +/− keydown; true when the ladder framed the anchor. */
+  onZoomKey: (dir: 1 | -1) => boolean;
+  /** Screen-reader text for the last keyboard move (aria-live region). */
+  announcement: string;
+}
+
+/* Native-key surfaces that must keep their own arrows (§5 guards). */
+const GUARD_SELECTOR = '[role="dialog"], [role="menu"], [role="listbox"], [data-scheme-ui]';
+
+function isTypingTarget(el: HTMLElement): boolean {
+  const tag = el.tagName;
+  return tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT" || el.isContentEditable;
+}
+
+/* A focused feed consumes its own ↑/↓ until it hits the end; mirrors the wheel
+   handler's scrollable-ancestor walk in useSchemeCamera. */
+function scrollConsumes(start: HTMLElement | null, dir: NavDir): boolean {
+  if (dir !== "up" && dir !== "down") return false;
+  for (let node: HTMLElement | null = start; node; node = node.parentElement) {
+    if (node.scrollHeight > node.clientHeight + 1) {
+      const overflowY = getComputedStyle(node).overflowY;
+      if (overflowY === "auto" || overflowY === "scroll") {
+        const atTop = node.scrollTop <= 0;
+        const atBottom = node.scrollTop + node.clientHeight >= node.scrollHeight - 1;
+        if (dir === "up" && !atTop) return true;
+        if (dir === "down" && !atBottom) return true;
+      }
+    }
+  }
+  return false;
+}
+
+/**
+ * Spatial keyboard navigation for the scheme board (issue #27). Arrow keys move
+ * the selection ring between agent windows by geometry (never DOM/freshness
+ * order) and centre the pick; the selected window becomes the camera anchor and
+ * the camera translates with it through reflow so it never slides off screen. A
+ * manual gesture drops follow; +/− snap to whole-window framings around the
+ * anchor. The pure geometry lives in spatialNav.ts; this hook owns the follow
+ * lifecycle and the DOM key guards. onArrow/onZoomKey are identity-stable and
+ * read live state through refs so the camera's keydown listener never re-binds.
+ */
+export function useSpatialNav({
+  enabled,
+  layout,
+  cam,
+  vp,
+  selected,
+  setSelected,
+  centerOn,
+  glideBy,
+  glideFrame,
+  manualNonce,
+}: SpatialNavOptions): SpatialNav {
+  const followRef = useRef(false);
+  /* The anchor's rect at its last known layout, tagged with its key, so a
+     relayout yields a delta only when it is still the same anchor (a selection
+     that changed in the same render as a poll must not translate by a bogus
+     cross-anchor delta). */
+  const prevRectRef = useRef<{ key: string } & SchemeRect | null>(null);
+  const [announcement, setAnnouncement] = useState("");
+
+  /* Live inputs behind refs: the handlers below fire from a window keydown
+     listener and must stay identity-stable across camera frames. */
+  const enabledRef = useRef(enabled);
+  const layoutRef = useRef(layout);
+  const camRef = useRef(cam);
+  const vpRef = useRef(vp);
+  const selectedRef = useRef(selected);
+  const centerRef = useRef(centerOn);
+  const glideByRef = useRef(glideBy);
+  const glideFrameRef = useRef(glideFrame);
+  const setSelectedRef = useRef(setSelected);
+  useEffect(() => {
+    enabledRef.current = enabled;
+    layoutRef.current = layout;
+    camRef.current = cam;
+    vpRef.current = vp;
+    selectedRef.current = selected;
+    centerRef.current = centerOn;
+    glideByRef.current = glideBy;
+    glideFrameRef.current = glideFrame;
+    setSelectedRef.current = setSelected;
+  });
+
+  const labelFor = useCallback((key: string): string => {
+    const node = layoutRef.current.nodes.find((n) => n.file.path === key);
+    if (node) return cleanTitle(node.file.title, 80);
+    return key.replace(/^(?:draft|deck)::/, "");
+  }, []);
+
+  /* Land on a target: anchor it, centre it (zoom unchanged), seed the reflow
+     baseline, ring it, and announce it. */
+  const land = useCallback(
+    (key: string) => {
+      const rect = layoutRef.current.byPath.get(key);
+      followRef.current = true;
+      if (rect) {
+        prevRectRef.current = { key, x: rect.x, y: rect.y, w: rect.w, h: rect.h };
+        centerRef.current(rect, 0);
+      }
+      setSelectedRef.current(key);
+      setAnnouncement(labelFor(key));
+    },
+    [labelFor],
+  );
+
+  const onArrow = useCallback((event: KeyboardEvent): boolean => {
+    const dir = keyToDir(event.key);
+    if (!dir || !enabledRef.current) return false;
+    const target = event.target as HTMLElement | null;
+    const active = (typeof document !== "undefined" ? document.activeElement : null) as HTMLElement | null;
+    for (const el of [target, active]) {
+      if (!el) continue;
+      if (isTypingTarget(el)) return false;
+      if (el.closest?.(GUARD_SELECTOR)) return false;
+    }
+    if (scrollConsumes(target ?? active, dir)) return false;
+
+    const targets = collectNavTargets(layoutRef.current);
+    if (!targets.length) return false;
+    const sel = selectedRef.current;
+    const hasSel = sel != null && targets.some((t) => t.key === sel);
+    if (!hasSel) {
+      /* First press after a re-baseline: pick the on-screen-centre window and
+         centre it — no directional step, so nothing jumps unexpectedly. */
+      const start = nearestToViewportCenter(targets, camRef.current, vpRef.current, sel);
+      if (start) land(start);
+      return true;
+    }
+    const pick = pickDirectional(targets, sel, dir);
+    /* Silent edge (no candidate that way): consume anyway so the page never
+       scrolls out from under the board. */
+    if (pick) land(pick);
+    return true;
+  }, [land]);
+
+  const onZoomKey = useCallback((dir: 1 | -1): boolean => {
+    if (!enabledRef.current || !followRef.current) return false;
+    const sel = selectedRef.current;
+    if (sel == null) return false;
+    const rect = layoutRef.current.byPath.get(sel);
+    if (!rect) return false;
+    const steps = zoomLadderSteps(rect, vpRef.current);
+    const next = nextZoomStep(steps, camRef.current.z, dir);
+    /* At the ceiling/floor of the readable ladder: consume, no-op. */
+    if (next == null) return true;
+    glideFrameRef.current(rect, next);
+    prevRectRef.current = { key: sel, x: rect.x, y: rect.y, w: rect.w, h: rect.h };
+    return true;
+  }, []);
+
+  /* Reflow follow: when the layout changes under a followed anchor, translate
+     the camera by the anchor's world delta so it holds its screen position;
+     if the anchor left the board, drop follow and the ring. */
+  useEffect(() => {
+    if (!followRef.current) return;
+    const sel = selectedRef.current;
+    if (sel == null) {
+      prevRectRef.current = null;
+      return;
+    }
+    const rect = layout.byPath.get(sel) ?? null;
+    const prev = prevRectRef.current;
+    const plan = planReflow(prev && prev.key === sel ? prev : null, rect);
+    if (plan.kind === "drop") {
+      followRef.current = false;
+      prevRectRef.current = null;
+      setSelectedRef.current(null);
+      return;
+    }
+    if (rect) prevRectRef.current = { key: sel, x: rect.x, y: rect.y, w: rect.w, h: rect.h };
+    if (plan.kind === "translate") glideByRef.current(plan.dx, plan.dy);
+  }, [layout]);
+
+  /* Any new anchor arms follow so it stays framed through reflow — an Arrow
+     land, a pane click, or a focus jump after a send (the original issue's
+     ask). No camera motion here: arrows/focus move it through their own paths,
+     a click deliberately stays put. Clearing the ring disarms follow. Reads the
+     layout through a ref so a poll relayout never re-seeds the baseline (which
+     would zero out every reflow delta). */
+  useEffect(() => {
+    if (selected == null) {
+      followRef.current = false;
+      prevRectRef.current = null;
+      return;
+    }
+    if (!enabledRef.current) return;
+    const rect = layoutRef.current.byPath.get(selected) ?? null;
+    followRef.current = true;
+    prevRectRef.current = rect ? { key: selected, x: rect.x, y: rect.y, w: rect.w, h: rect.h } : null;
+  }, [selected]);
+
+  /* Any manual camera gesture re-baselines: drop follow but keep the ring. */
+  const firstNonce = useRef(true);
+  useEffect(() => {
+    if (firstNonce.current) {
+      firstNonce.current = false;
+      return;
+    }
+    followRef.current = false;
+    prevRectRef.current = null;
+  }, [manualNonce]);
+
+  /* Leaving the desktop board (session/overlay/map) disarms follow. */
+  useEffect(() => {
+    if (!enabled) {
+      followRef.current = false;
+      prevRectRef.current = null;
+    }
+  }, [enabled]);
+
+  return { onArrow, onZoomKey, announcement };
+}

--- a/src/components/scheme/useSpatialNav.ts
+++ b/src/components/scheme/useSpatialNav.ts
@@ -160,7 +160,7 @@ export function useSpatialNav({
     const targets = collectNavTargets(layoutRef.current);
     if (!targets.length) return false;
     const sel = selectedRef.current;
-    const hasSel = sel != null && targets.some((t) => t.key === sel);
+    const hasSel = followRef.current && sel != null && targets.some((t) => t.key === sel);
     if (!hasSel) {
       /* First press after a re-baseline: pick the on-screen-centre window and
          centre it — no directional step, so nothing jumps unexpectedly. */

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -508,6 +508,7 @@ export const en = {
   "scheme.roleWorking": "working",
   "scheme.roleWaiting": "waiting",
   "scheme.lassoTool": "Multi-select — draw a box around agents, click cards to toggle",
+  "scheme.boardAria": "Agent board — arrow keys move between agent windows",
 
   // scheme/BulkActionBar (selection session)
   "bulk.selectedCount": { one: "{count} selected", other: "{count} selected" },

--- a/src/lib/i18n/uk.ts
+++ b/src/lib/i18n/uk.ts
@@ -481,6 +481,7 @@ export const uk: Record<keyof typeof en, Message> = {
   "scheme.roleWorking": "працює",
   "scheme.roleWaiting": "чекає",
   "scheme.lassoTool": "Вибірка — обведи агентів рамкою, кліком додавай чи знімай",
+  "scheme.boardAria": "Дошка агентів — стрілки переміщують між вікнами агентів",
 
   "bulk.selectedCount": { one: "Вибрано {count}", few: "Вибрано {count}", many: "Вибрано {count}", other: "Вибрано {count}" },
   "bulk.placeholder": "одне повідомлення кожному вибраному агенту…",


### PR DESCRIPTION
Delivers the first Fable-designed MVP slice of #27.

What changed:
- Arrow keys select agent windows by board geometry and center them one window at a time
- the selected window stays anchored on screen while freshness reflow moves the layout
- manual pan, wheel, and pinch establish a new keyboard-navigation baseline
- keyboard zoom steps frame readable whole-window counts around the anchor
- text inputs, dialogs, menus, and scroll-consuming feeds keep their native key behavior
- reduced-motion and screen-reader announcements are included

Root verification found and fixed one manual-rebaseline regression before publication.

Verification:
- focused navigation tests: 31 passing
- full suite: 488 passing, 2797 assertions
- bunx tsc --noEmit
- bun run lint
- bun run build
- git diff --check

Review status:
- Fable product architecture is complete
- one fresh Fable live UI review is pending on production port 8898 after the current architecture workers finish
- the PR stays open until that review and root browser acceptance complete

The broader multi-window held-set auto-fit remains a follow-up slice under #27.