### PR TITLE
Add a durable external tmux supervisor contract

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -133,7 +133,7 @@ if [ "$1" = "new-window" ]; then
   err=$(mktemp)
   run_host_tmux "$@" >"$out" 2>"$err"
   code=$?
-  normalized=$(sed -E 's/^([^_]+)_(.*)_([0-9]+)$/\1\t\2\t\3/' "$out")
+  normalized=$(sed -E 's/^([^_]+)_(.*)_([0-9]+)_(.*)$/\1\t\2\t\3\t\4/' "$out")
   printf '%s\n' "$normalized"
   if [ "$code" -eq 0 ] && [ -n "$cwd" ]; then
     target=$(printf '%s' "$normalized" | awk 'NR == 1 { print $1 }')

--- a/deploy/systemd/agent-log-viewer-legacy-tmux.service
+++ b/deploy/systemd/agent-log-viewer-legacy-tmux.service
@@ -1,0 +1,21 @@
+[Unit]
+Description=Agent Log Viewer legacy tmux supervisor
+After=default.target
+
+[Service]
+Type=simple
+RuntimeDirectory=agent-log-viewer
+RuntimeDirectoryMode=0700
+UMask=0077
+Environment=HOME=/home/latand
+Environment=SHELL=/usr/bin/zsh
+Environment=LANG=C.UTF-8
+Environment=TMUX_TMPDIR=%t/agent-log-viewer
+ExecStart=/usr/bin/tmux -D
+ExecStartPost=/home/latand/.agents/tools/live-log-viewer-next/scripts/ensure-legacy-tmux-session.sh
+Restart=always
+RestartSec=1
+KillMode=control-group
+
+[Install]
+WantedBy=default.target

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,10 @@ x-viewer-common: &viewer-common
     PATH: /usr/local/bin:/home/latand/.bun/bin:/home/latand/.npm-global/bin:/home/latand/.local/bin:/usr/bin:/bin
     XDG_CONFIG_HOME: /home/latand/.config
     XDG_CACHE_HOME: /home/latand/.cache
-    TMUX_TMPDIR: /tmp
+    # Keep /tmp until the explicit migration flag is enabled. The supervisor
+    # endpoint lives outside the disposable Viewer container.
+    TMUX_TMPDIR: ${LLV_TMUX_TMPDIR:-/tmp}
+    LLV_LEGACY_TMUX_EXTERNAL: ${LLV_LEGACY_TMUX_EXTERNAL:-0}
     HF_HOME: /home/latand/.cache/huggingface
     LLV_WHISPER_VENV: /opt/llv-whisper-venv
     LLV_TRANSCRIBE_BACKEND: ${LLV_TRANSCRIBE_BACKEND:-}
@@ -40,7 +43,8 @@ services:
       PATH: /usr/local/bin:/home/latand/.bun/bin:/home/latand/.npm-global/bin:/home/latand/.local/bin:/usr/bin:/bin
       XDG_CONFIG_HOME: /home/latand/.config
       XDG_CACHE_HOME: /home/latand/.cache
-      TMUX_TMPDIR: /tmp
+      TMUX_TMPDIR: ${LLV_TMUX_TMPDIR:-/tmp}
+      LLV_LEGACY_TMUX_EXTERNAL: ${LLV_LEGACY_TMUX_EXTERNAL:-0}
       HF_HOME: /home/latand/.cache/huggingface
       LLV_WHISPER_VENV: /opt/llv-whisper-venv
       LLV_TRANSCRIBE_BACKEND: ${LLV_TRANSCRIBE_BACKEND:-}
@@ -58,7 +62,8 @@ services:
       PATH: /usr/local/bin:/home/latand/.bun/bin:/home/latand/.npm-global/bin:/home/latand/.local/bin:/usr/bin:/bin
       XDG_CONFIG_HOME: /home/latand/.config
       XDG_CACHE_HOME: /home/latand/.cache
-      TMUX_TMPDIR: /tmp
+      TMUX_TMPDIR: ${LLV_TMUX_TMPDIR:-/tmp}
+      LLV_LEGACY_TMUX_EXTERNAL: ${LLV_LEGACY_TMUX_EXTERNAL:-0}
       HF_HOME: /home/latand/.cache/huggingface
       LLV_WHISPER_VENV: /opt/llv-whisper-venv
       LLV_TRANSCRIBE_BACKEND: ${LLV_TRANSCRIBE_BACKEND:-}

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -16,6 +16,34 @@ docker compose up -d --build viewer
 
 `restart: unless-stopped` gives reboot survival (it replaces the systemd `Restart=always`). Manage the viewer with `docker compose` — `docker compose restart viewer`, `docker compose logs -f viewer` — not `systemctl`. If you ever re-enable the old systemd unit, stop the container first: both bind `127.0.0.1:8898` and only one process can own the port.
 
+## Legacy tmux supervisor migration
+
+The Viewer listens on `127.0.0.1:8898`. Legacy tmux panes acquire a separate user-service owner only after the explicitly approved migration. The service runs a foreground tmux server at `/run/user/1000/agent-log-viewer`, then bootstraps the canonical `agents` session.
+
+Run this read-only preflight first:
+
+```bash
+./scripts/install-legacy-tmux-supervisor.sh
+```
+
+The installation command requires `--install` and a later operator approval. It enables `agent-log-viewer-legacy-tmux.service`; it does not run as a Compose service. A human can attach after installation with:
+
+```bash
+TMUX_TMPDIR=/run/user/1000/agent-log-viewer tmux attach -t agents
+```
+
+Keep `LLV_LEGACY_TMUX_EXTERNAL=0` while the container-owned server still hosts legacy panes. That preserves the current `/tmp/tmux-1000` behavior. After the root handoff succeeds and its completion marker exists, deploy the Viewer with:
+
+```bash
+LLV_LEGACY_TMUX_EXTERNAL=1 \
+LLV_TMUX_TMPDIR=/run/user/1000/agent-log-viewer \
+./scripts/rebuild.sh
+```
+
+External-host mode fails closed when `agents` cannot be found through the dedicated endpoint. It never creates a replacement tmux server from the Viewer container. The migration preflight records a nonce-bound approval token; the later operator runbook must checkpoint the root, verify its successor uses the same engine-native thread, and roll back on any failed verification.
+
+The `scripts/e2e-viewer-replacement.ts` helper provides prepare and verify snapshots for that later runbook. Its normal modes only inspect state. It does not recreate a container, send a root message, or kill a pane.
+
 ## Test instance
 
 Use the test profile for local validation on another port:

--- a/scripts/e2e-viewer-replacement.ts
+++ b/scripts/e2e-viewer-replacement.ts
@@ -1,0 +1,26 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import { procBackend } from "@/lib/proc";
+import { tmuxServerPid } from "@/lib/tmux";
+
+const state = process.env.LLV_E2E_STATE || path.join(process.cwd(), ".llv-e2e-viewer-replacement.json");
+const command = process.argv[2];
+
+if (command === "prepare") {
+  const root = process.argv[process.argv.indexOf("--root") + 1];
+  if (!root || !fs.existsSync(root)) throw new Error("prepare requires --root <existing transcript>");
+  const serverPid = await tmuxServerPid();
+  const snapshot = { root, tmux: serverPid ? { pid: serverPid, identity: procBackend.processIdentity(serverPid) } : null, preparedAt: new Date().toISOString() };
+  fs.writeFileSync(state, JSON.stringify(snapshot, null, 2) + "\n", { mode: 0o600 });
+  console.log(JSON.stringify({ mode: "prepare", dryRun: true, snapshot }, null, 2));
+} else if (command === "verify") {
+  const snapshot = JSON.parse(fs.readFileSync(state, "utf8")) as { root: string; tmux: { pid: number; identity: string | null } | null };
+  const currentPid = await tmuxServerPid();
+  const currentIdentity = currentPid ? procBackend.processIdentity(currentPid) : null;
+  const stable = snapshot.tmux !== null && snapshot.tmux.identity !== null && snapshot.tmux.identity === currentIdentity;
+  console.log(JSON.stringify({ mode: "verify", dryRun: true, rootStillExists: fs.existsSync(snapshot.root), tmuxStable: stable, expected: snapshot.tmux, current: currentPid ? { pid: currentPid, identity: currentIdentity } : null }, null, 2));
+  if (!stable || !fs.existsSync(snapshot.root)) process.exitCode = 1;
+} else {
+  throw new Error("use prepare --root <transcript> or verify");
+}

--- a/scripts/ensure-legacy-tmux-session.sh
+++ b/scripts/ensure-legacy-tmux-session.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+runtime_dir="${XDG_RUNTIME_DIR:-/run/user/$(id -u)}/agent-log-viewer"
+expected="${TMUX_TMPDIR:-$runtime_dir}"
+[ "$expected" = "$runtime_dir" ] || { echo "unexpected TMUX_TMPDIR: $expected" >&2; exit 1; }
+[ -d "$runtime_dir" ] || { echo "supervisor runtime directory is unavailable" >&2; exit 1; }
+
+for _ in $(seq 1 20); do
+  tmux list-sessions >/dev/null 2>&1 && break
+  sleep 0.1
+done
+tmux list-sessions >/dev/null 2>&1 || { echo "tmux server did not become ready" >&2; exit 1; }
+
+sessions="$(tmux list-sessions -F '#{session_name}')"
+if [ -n "$sessions" ] && [ "$sessions" != "agents" ]; then
+  echo "foreign session exists on supervisor endpoint" >&2
+  exit 1
+fi
+tmux has-session -t agents 2>/dev/null || tmux new-session -d -x 220 -y 50 -s agents

--- a/scripts/install-legacy-tmux-supervisor.sh
+++ b/scripts/install-legacy-tmux-supervisor.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+unit_source="$repo_dir/deploy/systemd/agent-log-viewer-legacy-tmux.service"
+unit_target="$HOME/.config/systemd/user/agent-log-viewer-legacy-tmux.service"
+
+if [ "${1:-}" != "--install" ]; then
+  echo "SAFE PREFLIGHT: pass --install only after explicit operator approval"
+  systemctl --user show-environment >/dev/null
+  loginctl show-user "$(id -u)" -p Linger
+  test -r "$unit_source"
+  test -d "${XDG_RUNTIME_DIR:-/run/user/$(id -u)}"
+  echo "unit=$unit_source"
+  echo "runtime=${XDG_RUNTIME_DIR:-/run/user/$(id -u)}/agent-log-viewer"
+  exit 0
+fi
+
+install -Dm0644 "$unit_source" "$unit_target"
+systemctl --user daemon-reload
+systemctl --user enable --now agent-log-viewer-legacy-tmux.service
+TMUX_TMPDIR="${XDG_RUNTIME_DIR:-/run/user/$(id -u)}/agent-log-viewer" tmux has-session -t agents

--- a/scripts/migrate-legacy-tmux.ts
+++ b/scripts/migrate-legacy-tmux.ts
@@ -1,7 +1,6 @@
 import fs from "node:fs";
-import path from "node:path";
 
-import { createLegacyMigration, type LegacyMigration } from "@/lib/agent/migration";
+import { createLegacyMigration, persistLegacyMigration } from "@/lib/agent/migration";
 import { sessionKeyFromTranscript } from "@/lib/agent/sessionKey";
 import { statePath } from "@/lib/configDir";
 
@@ -11,11 +10,6 @@ function arg(name: string): string | null {
 }
 
 function migrationPath(id: string): string { return statePath("migrations", `legacy-tmux-${id}.json`); }
-function writeMigration(migration: LegacyMigration): void {
-  const filename = migrationPath(migration.id);
-  fs.mkdirSync(path.dirname(filename), { recursive: true, mode: 0o700 });
-  fs.writeFileSync(filename, JSON.stringify(migration, null, 2) + "\n", { mode: 0o600 });
-}
 
 const command = process.argv[2];
 if (command !== "preflight") {
@@ -31,7 +25,7 @@ if (command !== "preflight") {
     process.exitCode = 2;
   } else {
     const migration = createLegacyMigration(key, rootPath);
-    writeMigration(migration);
+    persistLegacyMigration(migrationPath(migration.id), migration);
     console.log(JSON.stringify({ migration: migration.id, phase: migration.phase, approvalToken: migration.approvalToken, root: migration.root, rootPath }, null, 2));
     console.log("SAFE PREFLIGHT COMPLETE: this command sent no message, started no tmux server, and changed no service.");
   }

--- a/scripts/migrate-legacy-tmux.ts
+++ b/scripts/migrate-legacy-tmux.ts
@@ -1,0 +1,38 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import { createLegacyMigration, type LegacyMigration } from "@/lib/agent/migration";
+import { sessionKeyFromTranscript } from "@/lib/agent/sessionKey";
+import { statePath } from "@/lib/configDir";
+
+function arg(name: string): string | null {
+  const index = process.argv.indexOf(name);
+  return index >= 0 ? process.argv[index + 1] ?? null : null;
+}
+
+function migrationPath(id: string): string { return statePath("migrations", `legacy-tmux-${id}.json`); }
+function writeMigration(migration: LegacyMigration): void {
+  const filename = migrationPath(migration.id);
+  fs.mkdirSync(path.dirname(filename), { recursive: true, mode: 0o700 });
+  fs.writeFileSync(filename, JSON.stringify(migration, null, 2) + "\n", { mode: 0o600 });
+}
+
+const command = process.argv[2];
+if (command !== "preflight") {
+  console.error("only `preflight --root <transcript>` is available in this implementation build");
+  console.error("cutover remains gated for the later explicit operator-approved runbook");
+  process.exitCode = 2;
+} else {
+  const rootPath = arg("--root");
+  const engine = rootPath?.includes("/.codex/") ? "codex" : rootPath?.includes("/.claude/") ? "claude" : null;
+  const key = rootPath && engine ? sessionKeyFromTranscript(engine, rootPath) : null;
+  if (!rootPath || !key || !fs.existsSync(rootPath)) {
+    console.error("preflight requires an existing Codex or Claude root transcript path");
+    process.exitCode = 2;
+  } else {
+    const migration = createLegacyMigration(key, rootPath);
+    writeMigration(migration);
+    console.log(JSON.stringify({ migration: migration.id, phase: migration.phase, approvalToken: migration.approvalToken, root: migration.root, rootPath }, null, 2));
+    console.log("SAFE PREFLIGHT COMPLETE: this command sent no message, started no tmux server, and changed no service.");
+  }
+}

--- a/scripts/rebuild.sh
+++ b/scripts/rebuild.sh
@@ -16,13 +16,24 @@ cd "$REPO_DIR"
 
 PORT="${PORT:-8898}"
 TOKEN="$(sed -n 's/^LLV_TOKEN=//p' "$HOME/.config/agent-log-viewer/service.env" 2>/dev/null | head -1)"
+MIGRATION_MARKER="$HOME/.config/agent-log-viewer/state/legacy-tmux-migration-complete"
+SUPERVISOR_TMUX_TMPDIR="/run/user/$(id -u)/agent-log-viewer"
+
+if [ -f "$MIGRATION_MARKER" ]; then
+  if [ "${LLV_LEGACY_TMUX_EXTERNAL:-1}" = "0" ] && [ "${LLV_ALLOW_LEGACY_TMUX_ROLLBACK:-0}" != "1" ]; then
+    echo "!! migrated supervisor endpoint cannot be downgraded without LLV_ALLOW_LEGACY_TMUX_ROLLBACK=1" >&2
+    exit 1
+  fi
+  export LLV_LEGACY_TMUX_EXTERNAL=1
+  export LLV_TMUX_TMPDIR="$SUPERVISOR_TMUX_TMPDIR"
+fi
 
 if [ "${LLV_LEGACY_TMUX_EXTERNAL:-0}" = "1" ]; then
   systemctl --user is-active --quiet agent-log-viewer-legacy-tmux.service || {
     echo "!! external legacy tmux supervisor is inactive; Viewer-only rebuild refused" >&2
     exit 1
   }
-  [ -f "$HOME/.config/agent-log-viewer/state/legacy-tmux-migration-complete" ] || {
+  [ -f "$MIGRATION_MARKER" ] || {
     echo "!! legacy tmux migration completion marker is absent; Viewer-only rebuild refused" >&2
     exit 1
   }

--- a/scripts/rebuild.sh
+++ b/scripts/rebuild.sh
@@ -17,13 +17,24 @@ cd "$REPO_DIR"
 PORT="${PORT:-8898}"
 TOKEN="$(sed -n 's/^LLV_TOKEN=//p' "$HOME/.config/agent-log-viewer/service.env" 2>/dev/null | head -1)"
 
+if [ "${LLV_LEGACY_TMUX_EXTERNAL:-0}" = "1" ]; then
+  systemctl --user is-active --quiet agent-log-viewer-legacy-tmux.service || {
+    echo "!! external legacy tmux supervisor is inactive; Viewer-only rebuild refused" >&2
+    exit 1
+  }
+  [ -f "$HOME/.config/agent-log-viewer/state/legacy-tmux-migration-complete" ] || {
+    echo "!! legacy tmux migration completion marker is absent; Viewer-only rebuild refused" >&2
+    exit 1
+  }
+fi
+
 # --- 1. build the image (clean-env .next build happens inside it) ----------
 echo "==> building image"
 docker compose build viewer
 
 # --- 2. redeploy ----------------------------------------------------------
 echo "==> redeploying viewer (127.0.0.1:${PORT})"
-docker compose up -d viewer
+docker compose up -d --no-deps --force-recreate viewer
 
 # --- 3. verify page + CSS -------------------------------------------------
 BASE="http://127.0.0.1:${PORT}/"
@@ -47,4 +58,4 @@ else
   echo "==> page 200 (no <link> css found — check manually)"
 fi
 
-echo "==> done. tmux agents: $(tmux has-session -t agents 2>/dev/null && echo alive || echo none)"
+echo "==> done. Viewer replacement completed without Compose dependency recreation"

--- a/src/app/api/files/route.ts
+++ b/src/app/api/files/route.ts
@@ -3,6 +3,7 @@ import { createHash } from "node:crypto";
 import { NextResponse } from "next/server";
 
 import { listFilesWithProjectCatalog } from "@/lib/scanner";
+import { readTranscriptHosts } from "@/lib/agent/transcriptHost";
 import { pidAlive, readPpid } from "@/lib/scanner/process";
 import { loadFlows } from "@/lib/flows/store";
 import { pathForPanePid, reconcileTasks } from "@/lib/tasks/reconcile";
@@ -18,6 +19,9 @@ export async function GET(request: Request): Promise<NextResponse> {
   const url = new URL(request.url);
   const selectedProject = url.searchParams.get("project")?.trim() || undefined;
   const { files, projectCatalog } = await listFilesWithProjectCatalog(selectedProject);
+  /* This is the scanner-refresh reconciliation point. A failed tmux probe is
+     represented by the resolver and preserves durable rows for a later retry. */
+  await readTranscriptHosts(true);
   /* Reconciliation runs inside the serialized read-modify-write: the file
      scan above is the slow part, so a task edit landing during it is picked
      up by this fresh load instead of being overwritten by a stale snapshot. */

--- a/src/app/api/spawn/route.ts
+++ b/src/app/api/spawn/route.ts
@@ -8,7 +8,7 @@ import { UnknownAccountError } from "@/lib/accounts/codex";
 import { UnknownClaudeAccountError } from "@/lib/accounts/claude";
 import { accountManager } from "@/lib/accounts/manager";
 import { freshSpecFor, type AgentEngine } from "@/lib/agent/cli";
-import { agentRegistry, type SpawnReceipt } from "@/lib/agent/registry";
+import { agentRegistry } from "@/lib/agent/registry";
 import { reasoningFromBody } from "@/lib/agent/efforts";
 import { modelFromBody } from "@/lib/agent/models";
 import { sessionKeyFromTranscript } from "@/lib/agent/sessionKey";
@@ -167,7 +167,6 @@ export async function POST(req: NextRequest): Promise<NextResponse<SpawnResponse
   /* Saved paths stay visible to the catch: a failed spawn deletes them so a
      retry cannot pile duplicates into the inbox. */
   let imagePaths: string[] = [];
-  let receipt: SpawnReceipt | null = null;
   try {
     /* Pasted images land in the inbox and reach the fresh agent as file paths
        appended to its first prompt — the same contract the pane composer uses. */
@@ -182,7 +181,6 @@ export async function POST(req: NextRequest): Promise<NextResponse<SpawnResponse
       claudeConfigDir: engine === "claude" ? account.home : null,
       claudeProjectsDir: engine === "claude" ? account.transcriptRoot : null,
     });
-    receipt = agentRegistry().beginSpawn(engine, cwd);
     const startedAtMs = Date.now();
     const pane = await spawnAgentWithPrompt(spec, bundle.payload);
     const childPath = await resolveSpawnedTranscriptPath({
@@ -194,12 +192,16 @@ export async function POST(req: NextRequest): Promise<NextResponse<SpawnResponse
       codexSessionsDir: engine === "codex" ? account.transcriptRoot : null,
     });
     const key = childPath ? sessionKeyFromTranscript(engine, childPath) : null;
-    if (receipt && childPath && key) {
-      agentRegistry().completeSpawn(receipt.launchId, {
+    if (!childPath || !key || !pane.receipt) {
+      if (pane.receipt) agentRegistry().failSpawn(pane.receipt.launchId, "spawned transcript could not be identified");
+      throw new Error("spawned transcript could not be identified safely");
+    }
+    {
+      agentRegistry().completeSpawn(pane.receipt.launchId, {
         key,
         artifactPath: childPath,
         cwd,
-        accountId: body.accountId ?? null,
+        accountId: account.accountId,
         status: "starting",
         host: null,
         claimEpoch: 0,
@@ -215,7 +217,6 @@ export async function POST(req: NextRequest): Promise<NextResponse<SpawnResponse
     }
     return NextResponse.json({ ok: true, target: pane.display, path: childPath });
   } catch (error) {
-    if (receipt) agentRegistry().failSpawn(receipt.launchId, error instanceof Error ? error.message : String(error));
     deleteInboxImages(imagePaths);
     if (error instanceof UnknownAccountError || error instanceof UnknownClaudeAccountError) return NextResponse.json({ error: error.message }, { status: 400 });
     return NextResponse.json({ error: error instanceof Error ? error.message : String(error) }, { status: 500 });

--- a/src/app/api/spawn/route.ts
+++ b/src/app/api/spawn/route.ts
@@ -8,8 +8,10 @@ import { UnknownAccountError } from "@/lib/accounts/codex";
 import { UnknownClaudeAccountError } from "@/lib/accounts/claude";
 import { accountManager } from "@/lib/accounts/manager";
 import { freshSpecFor, type AgentEngine } from "@/lib/agent/cli";
+import { agentRegistry, type SpawnReceipt } from "@/lib/agent/registry";
 import { reasoningFromBody } from "@/lib/agent/efforts";
 import { modelFromBody } from "@/lib/agent/models";
+import { sessionKeyFromTranscript } from "@/lib/agent/sessionKey";
 import { resolveSpawnedTranscriptPath } from "@/lib/agent/spawnedTranscript";
 import { headCwd } from "@/lib/agent/transcript";
 import { persistHandoffLineage, rememberHandoffChild, rememberHandoffPane } from "@/lib/handoffLineage";
@@ -165,6 +167,7 @@ export async function POST(req: NextRequest): Promise<NextResponse<SpawnResponse
   /* Saved paths stay visible to the catch: a failed spawn deletes them so a
      retry cannot pile duplicates into the inbox. */
   let imagePaths: string[] = [];
+  let receipt: SpawnReceipt | null = null;
   try {
     /* Pasted images land in the inbox and reach the fresh agent as file paths
        appended to its first prompt — the same contract the pane composer uses. */
@@ -179,6 +182,7 @@ export async function POST(req: NextRequest): Promise<NextResponse<SpawnResponse
       claudeConfigDir: engine === "claude" ? account.home : null,
       claudeProjectsDir: engine === "claude" ? account.transcriptRoot : null,
     });
+    receipt = agentRegistry().beginSpawn(engine, cwd);
     const startedAtMs = Date.now();
     const pane = await spawnAgentWithPrompt(spec, bundle.payload);
     const childPath = await resolveSpawnedTranscriptPath({
@@ -189,6 +193,20 @@ export async function POST(req: NextRequest): Promise<NextResponse<SpawnResponse
       startedAtMs,
       codexSessionsDir: engine === "codex" ? account.transcriptRoot : null,
     });
+    const key = childPath ? sessionKeyFromTranscript(engine, childPath) : null;
+    if (receipt && childPath && key) {
+      agentRegistry().completeSpawn(receipt.launchId, {
+        key,
+        artifactPath: childPath,
+        cwd,
+        accountId: body.accountId ?? null,
+        status: "starting",
+        host: null,
+        claimEpoch: 0,
+        claimOwner: null,
+        pendingAction: "spawn",
+      });
+    }
     const src = parentFromBody(body);
     if (src && transcriptAllowed(src)) {
       if (childPath) rememberHandoffChild(childPath, src);
@@ -197,6 +215,7 @@ export async function POST(req: NextRequest): Promise<NextResponse<SpawnResponse
     }
     return NextResponse.json({ ok: true, target: pane.display, path: childPath });
   } catch (error) {
+    if (receipt) agentRegistry().failSpawn(receipt.launchId, error instanceof Error ? error.message : String(error));
     deleteInboxImages(imagePaths);
     if (error instanceof UnknownAccountError || error instanceof UnknownClaudeAccountError) return NextResponse.json({ error: error.message }, { status: 400 });
     return NextResponse.json({ error: error instanceof Error ? error.message : String(error) }, { status: 500 });

--- a/src/lib/agent/migration.test.ts
+++ b/src/lib/agent/migration.test.ts
@@ -24,4 +24,13 @@ describe("legacy migration phase machine", () => {
     expect(result.phase).toBe("rolled-back");
     expect(rolledBack).toBe(true);
   });
+
+  test("recovers an interrupted root-ready migration and records rollback failure", async () => {
+    const migration = { ...createLegacyMigration(ROOT, "/root.jsonl"), phase: "root-ready" as const };
+    const resumed = await runLegacyCutover(migration, migration.approvalToken, actions(), () => {});
+    expect(resumed.phase).toBe("successor-confirmed");
+    const failed = await runLegacyCutover(migration, migration.approvalToken, actions({ startSuccessor: async () => false, rollback: async () => { throw new Error("network unavailable"); } }), () => {});
+    expect(failed.phase).toBe("failed");
+    expect(failed.error).toContain("rollback failed");
+  });
 });

--- a/src/lib/agent/migration.test.ts
+++ b/src/lib/agent/migration.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from "bun:test";
+
+import { createLegacyMigration, runLegacyCutover, type MigrationActions } from "@/lib/agent/migration";
+
+const ROOT = { engine: "codex" as const, sessionId: "019f4906-3f67-7b72-9fbc-9ec3b5ad1326" };
+
+function actions(overrides: Partial<MigrationActions> = {}): MigrationActions {
+  return { checkpoint: async () => true, freezeViewer: async () => {}, stopOldRoot: async () => {}, startSuccessor: async () => true, verifySuccessor: async () => true, rollback: async () => {}, ...overrides };
+}
+
+describe("legacy migration phase machine", () => {
+  test("requires a matching approval and confirms a verified successor", async () => {
+    const migration = createLegacyMigration(ROOT, "/root.jsonl");
+    const phases: string[] = [];
+    const result = await runLegacyCutover(migration, migration.approvalToken, actions(), (next) => phases.push(next.phase));
+    expect(result.phase).toBe("successor-confirmed");
+    expect(phases).toEqual(["root-ready", "successor-started", "successor-confirmed"]);
+  });
+
+  test("rolls back if successor verification fails", async () => {
+    const migration = createLegacyMigration(ROOT, "/root.jsonl");
+    let rolledBack = false;
+    const result = await runLegacyCutover(migration, migration.approvalToken, actions({ verifySuccessor: async () => false, rollback: async () => { rolledBack = true; } }), () => {});
+    expect(result.phase).toBe("rolled-back");
+    expect(rolledBack).toBe(true);
+  });
+});

--- a/src/lib/agent/migration.ts
+++ b/src/lib/agent/migration.ts
@@ -1,4 +1,6 @@
 import crypto from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
 
 import type { SessionKey } from "./sessionKey";
 import { sessionKeyId } from "./sessionKey";
@@ -41,6 +43,17 @@ function transition(migration: LegacyMigration, phase: MigrationPhase, error: st
   return { ...migration, phase, error, updatedAt: stamp() };
 }
 
+export function persistLegacyMigration(filename: string, migration: LegacyMigration): void {
+  fs.mkdirSync(path.dirname(filename), { recursive: true, mode: 0o700 });
+  const temp = `${filename}.${process.pid}.${crypto.randomUUID()}.tmp`;
+  try {
+    fs.writeFileSync(temp, JSON.stringify(migration, null, 2) + "\n", { mode: 0o600 });
+    fs.renameSync(temp, filename);
+  } finally {
+    try { fs.unlinkSync(temp); } catch { /* rename completed */ }
+  }
+}
+
 /** The side-effect adapter is deliberately injected. Production execution is
     gated by a separate operator-only script; tests exercise every branch with
     fakes and no pane receives a signal during ordinary Viewer operation. */
@@ -50,27 +63,39 @@ export async function runLegacyCutover(
   actions: MigrationActions,
   persist: (next: LegacyMigration) => void,
 ): Promise<LegacyMigration> {
-  if (migration.phase !== "preflight") throw new Error(`migration is already ${migration.phase}`);
+  if (migration.phase === "successor-confirmed" || migration.phase === "rolled-back" || migration.phase === "failed") return migration;
   if (!crypto.timingSafeEqual(Buffer.from(migration.approvalToken), Buffer.from(approvalToken))) {
     throw new Error("migration approval token is invalid");
   }
   try {
-    if (!(await actions.checkpoint(migration.nonce))) throw new Error("root checkpoint was not observed");
-    let next = transition(migration, "root-ready");
-    persist(next);
-    await actions.freezeViewer();
-    await actions.stopOldRoot();
-    if (!(await actions.startSuccessor())) throw new Error("successor root did not start");
-    next = transition(next, "successor-started");
-    persist(next);
-    if (!(await actions.verifySuccessor(migration.nonce))) throw new Error("successor root verification failed");
+    let next = migration;
+    if (next.phase === "preflight") {
+      if (!(await actions.checkpoint(next.nonce))) throw new Error("root checkpoint was not observed");
+      next = transition(next, "root-ready");
+      persist(next);
+      await actions.freezeViewer();
+      await actions.stopOldRoot();
+    }
+    if (next.phase === "root-ready") {
+      if (!(await actions.startSuccessor())) throw new Error("successor root did not start");
+      next = transition(next, "successor-started");
+      persist(next);
+    }
+    if (next.phase !== "successor-started" || !(await actions.verifySuccessor(next.nonce))) throw new Error("successor root verification failed");
     next = transition(next, "successor-confirmed");
     persist(next);
     return next;
   } catch (error) {
-    await actions.rollback();
-    const rolledBack = transition(migration, "rolled-back", error instanceof Error ? error.message : String(error));
-    persist(rolledBack);
-    return rolledBack;
+    const detail = error instanceof Error ? error.message : String(error);
+    try {
+      await actions.rollback();
+      const rolledBack = transition(migration, "rolled-back", detail);
+      persist(rolledBack);
+      return rolledBack;
+    } catch (rollbackError) {
+      const failed = transition(migration, "failed", `${detail}; rollback failed: ${rollbackError instanceof Error ? rollbackError.message : String(rollbackError)}`);
+      persist(failed);
+      return failed;
+    }
   }
 }

--- a/src/lib/agent/migration.ts
+++ b/src/lib/agent/migration.ts
@@ -1,0 +1,76 @@
+import crypto from "node:crypto";
+
+import type { SessionKey } from "./sessionKey";
+import { sessionKeyId } from "./sessionKey";
+
+export type MigrationPhase = "preflight" | "root-ready" | "successor-started" | "successor-confirmed" | "rolled-back" | "failed";
+
+export interface LegacyMigration {
+  id: string;
+  root: SessionKey;
+  rootPath: string;
+  nonce: string;
+  approvalToken: string;
+  phase: MigrationPhase;
+  updatedAt: string;
+  error: string | null;
+}
+
+export interface MigrationActions {
+  checkpoint(nonce: string): Promise<boolean>;
+  freezeViewer(): Promise<void>;
+  stopOldRoot(): Promise<void>;
+  startSuccessor(): Promise<boolean>;
+  verifySuccessor(nonce: string): Promise<boolean>;
+  rollback(): Promise<void>;
+}
+
+function stamp(): string { return new Date().toISOString(); }
+
+function token(id: string, root: SessionKey, nonce: string): string {
+  return crypto.createHash("sha256").update(`${id}:${sessionKeyId(root)}:${nonce}`).digest("hex").slice(0, 32);
+}
+
+export function createLegacyMigration(root: SessionKey, rootPath: string): LegacyMigration {
+  const id = crypto.randomUUID();
+  const nonce = crypto.randomUUID();
+  return { id, root, rootPath, nonce, approvalToken: token(id, root, nonce), phase: "preflight", updatedAt: stamp(), error: null };
+}
+
+function transition(migration: LegacyMigration, phase: MigrationPhase, error: string | null = null): LegacyMigration {
+  return { ...migration, phase, error, updatedAt: stamp() };
+}
+
+/** The side-effect adapter is deliberately injected. Production execution is
+    gated by a separate operator-only script; tests exercise every branch with
+    fakes and no pane receives a signal during ordinary Viewer operation. */
+export async function runLegacyCutover(
+  migration: LegacyMigration,
+  approvalToken: string,
+  actions: MigrationActions,
+  persist: (next: LegacyMigration) => void,
+): Promise<LegacyMigration> {
+  if (migration.phase !== "preflight") throw new Error(`migration is already ${migration.phase}`);
+  if (!crypto.timingSafeEqual(Buffer.from(migration.approvalToken), Buffer.from(approvalToken))) {
+    throw new Error("migration approval token is invalid");
+  }
+  try {
+    if (!(await actions.checkpoint(migration.nonce))) throw new Error("root checkpoint was not observed");
+    let next = transition(migration, "root-ready");
+    persist(next);
+    await actions.freezeViewer();
+    await actions.stopOldRoot();
+    if (!(await actions.startSuccessor())) throw new Error("successor root did not start");
+    next = transition(next, "successor-started");
+    persist(next);
+    if (!(await actions.verifySuccessor(migration.nonce))) throw new Error("successor root verification failed");
+    next = transition(next, "successor-confirmed");
+    persist(next);
+    return next;
+  } catch (error) {
+    await actions.rollback();
+    const rolledBack = transition(migration, "rolled-back", error instanceof Error ? error.message : String(error));
+    persist(rolledBack);
+    return rolledBack;
+  }
+}

--- a/src/lib/agent/registry.test.ts
+++ b/src/lib/agent/registry.test.ts
@@ -7,9 +7,9 @@ import { AgentRegistry } from "@/lib/agent/registry";
 
 const KEY = { engine: "codex" as const, sessionId: "019f4906-3f67-7b72-9fbc-9ec3b5ad1326" };
 
-function registry() {
+function registry(ownerAlive: (owner: { pid: number; startIdentity: string | null }) => boolean = () => true) {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "llv-registry-"));
-  return new AgentRegistry(path.join(dir, "agent-registry.json"));
+  return new AgentRegistry(path.join(dir, "agent-registry.json"), ownerAlive);
 }
 
 describe("agent registry", () => {
@@ -29,5 +29,21 @@ describe("agent registry", () => {
     store.upsert({ key: KEY, artifactPath: "/a", cwd: "/repo", accountId: null, status: "live", host: null, claimEpoch: 0, claimOwner: null, pendingAction: null });
     expect(await store.withOperationLock(KEY, { pid: 1, startIdentity: "1:one" }, async () => "done")).toBe("done");
     await expect(store.withOperationLock(KEY, { pid: 1, startIdentity: "1:one" }, async () => { throw new Error("boom"); })).rejects.toThrow("boom");
+  });
+
+  test("reclaims a lock only after its recorded process identity is stale", () => {
+    const store = registry(() => false);
+    const lock = `${store.filename}.write-lock`;
+    fs.mkdirSync(lock, { recursive: true });
+    fs.writeFileSync(path.join(lock, "owner.json"), JSON.stringify({ pid: 42, startIdentity: "42:old" }));
+    expect(() => store.beginSpawn("codex", "/repo")).not.toThrow();
+  });
+
+  test("preserves corrupt registry bytes and rejects mutation", () => {
+    const store = registry();
+    fs.mkdirSync(path.dirname(store.filename), { recursive: true });
+    fs.writeFileSync(store.filename, "{ broken");
+    expect(() => store.beginSpawn("codex", "/repo")).toThrow("cannot be read");
+    expect(fs.readFileSync(store.filename, "utf8")).toBe("{ broken");
   });
 });

--- a/src/lib/agent/registry.test.ts
+++ b/src/lib/agent/registry.test.ts
@@ -1,0 +1,33 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, test } from "bun:test";
+
+import { AgentRegistry } from "@/lib/agent/registry";
+
+const KEY = { engine: "codex" as const, sessionId: "019f4906-3f67-7b72-9fbc-9ec3b5ad1326" };
+
+function registry() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "llv-registry-"));
+  return new AgentRegistry(path.join(dir, "agent-registry.json"));
+}
+
+describe("agent registry", () => {
+  test("writes receipts and a canonical atomic entry", () => {
+    const store = registry();
+    const receipt = store.beginSpawn("codex", "/repo");
+    const entry = store.completeSpawn(receipt.launchId, {
+      key: KEY, artifactPath: "/sessions/rollout-019f4906-3f67-7b72-9fbc-9ec3b5ad1326.jsonl", cwd: "/repo", accountId: null,
+      status: "starting", host: null, claimEpoch: 0, claimOwner: null, pendingAction: "spawn",
+    });
+    expect(entry.key).toEqual(KEY);
+    expect(store.snapshot().receipts[receipt.launchId]?.state).toBe("completed");
+  });
+
+  test("serializes durable operations", async () => {
+    const store = registry();
+    store.upsert({ key: KEY, artifactPath: "/a", cwd: "/repo", accountId: null, status: "live", host: null, claimEpoch: 0, claimOwner: null, pendingAction: null });
+    expect(await store.withOperationLock(KEY, { pid: 1, startIdentity: "1:one" }, async () => "done")).toBe("done");
+    await expect(store.withOperationLock(KEY, { pid: 1, startIdentity: "1:one" }, async () => { throw new Error("boom"); })).rejects.toThrow("boom");
+  });
+});

--- a/src/lib/agent/registry.ts
+++ b/src/lib/agent/registry.ts
@@ -3,6 +3,7 @@ import fs from "node:fs";
 import path from "node:path";
 
 import { statePath } from "@/lib/configDir";
+import { procBackend } from "@/lib/proc";
 
 import type { AgentEngine } from "./cli";
 import { sessionKeyId, type SessionKey } from "./sessionKey";
@@ -56,10 +57,12 @@ interface RegistryFile {
   importedResumePanes: boolean;
   /** Compatibility evidence only. It never authorizes a pane until the live
       resolver proves server, process, engine, and transcript ownership. */
-  legacyResumePanes: Record<string, ResumePaneRecord>;
+  legacyResumePanes: { serverPid: number | null; panes: Record<string, ResumePaneRecord> };
 }
 
-const EMPTY: RegistryFile = { version: 1, entries: {}, receipts: {}, importedResumePanes: false, legacyResumePanes: {} };
+const EMPTY: RegistryFile = { version: 1, entries: {}, receipts: {}, importedResumePanes: false, legacyResumePanes: { serverPid: null, panes: {} } };
+
+export class RegistryReadError extends Error {}
 
 function clone<T>(value: T): T {
   return JSON.parse(JSON.stringify(value)) as T;
@@ -72,16 +75,23 @@ function now(): string {
 function readFile(filename: string): RegistryFile {
   try {
     const parsed = JSON.parse(fs.readFileSync(filename, "utf8")) as Partial<RegistryFile>;
-    if (parsed.version !== 1 || !parsed.entries || !parsed.receipts) return clone(EMPTY);
+    if (parsed.version !== 1 || !parsed.entries || !parsed.receipts || typeof parsed.entries !== "object" || typeof parsed.receipts !== "object") {
+      throw new RegistryReadError("agent registry schema is unsupported");
+    }
+    const legacy = parsed.legacyResumePanes;
     return {
       version: 1,
       entries: parsed.entries,
       receipts: parsed.receipts,
       importedResumePanes: parsed.importedResumePanes === true,
-      legacyResumePanes: parsed.legacyResumePanes && typeof parsed.legacyResumePanes === "object" ? parsed.legacyResumePanes : {},
+      legacyResumePanes: legacy && typeof legacy === "object" && "panes" in legacy
+        ? { serverPid: typeof (legacy as { serverPid?: unknown }).serverPid === "number" ? (legacy as { serverPid: number }).serverPid : null, panes: ((legacy as { panes?: unknown }).panes as Record<string, ResumePaneRecord>) ?? {} }
+        : { serverPid: null, panes: {} },
     };
-  } catch {
-    return clone(EMPTY);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return clone(EMPTY);
+    if (error instanceof RegistryReadError) throw error;
+    throw new RegistryReadError(`agent registry cannot be read: ${error instanceof Error ? error.message : String(error)}`);
   }
 }
 
@@ -109,23 +119,41 @@ function writeAtomic(filename: string, value: RegistryFile): void {
     intentionally separate from in-memory promises, so a Viewer replacement
     cannot leave an imaginary owner behind. */
 export class AgentRegistry {
-  constructor(readonly filename = statePath("agent-registry.json")) {}
+  constructor(
+    readonly filename = statePath("agent-registry.json"),
+    private readonly ownerAlive: (owner: ProcessIdentity) => boolean = (owner) =>
+      procBackend.pidAlive(owner.pid) && (owner.startIdentity === null || procBackend.processIdentity(owner.pid) === owner.startIdentity),
+  ) {}
 
-  private mutate<T>(fn: (file: RegistryFile) => T): T {
-    const lock = `${this.filename}.write-lock`;
+  private acquireLock(lock: string, owner: ProcessIdentity): void {
     fs.mkdirSync(path.dirname(lock), { recursive: true, mode: 0o700 });
-    let acquired = false;
     for (let attempt = 0; attempt < 100; attempt += 1) {
       try {
         fs.mkdirSync(lock, 0o700);
-        acquired = true;
-        break;
+        fs.writeFileSync(path.join(lock, "owner.json"), JSON.stringify(owner), { mode: 0o600 });
+        return;
       } catch (error) {
         if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
+        let stale = false;
+        try {
+          const previous = JSON.parse(fs.readFileSync(path.join(lock, "owner.json"), "utf8")) as ProcessIdentity;
+          stale = Number.isInteger(previous.pid) && previous.pid > 0 && !this.ownerAlive(previous);
+        } catch {
+          /* A creator may still be writing owner.json. Preserve unknown locks. */
+        }
+        if (stale) {
+          fs.rmSync(lock, { recursive: true, force: true });
+          continue;
+        }
         Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 5);
       }
     }
-    if (!acquired) throw new Error("agent registry is busy");
+    throw new Error("agent registry is busy");
+  }
+
+  private mutate<T>(fn: (file: RegistryFile) => T): T {
+    const lock = `${this.filename}.write-lock`;
+    this.acquireLock(lock, { pid: process.pid, startIdentity: procBackend.processIdentity(process.pid) });
     try {
       const file = readFile(this.filename);
       const result = fn(file);
@@ -212,26 +240,57 @@ export class AgentRegistry {
       identity and may be recovered by an explicit caller after verification. */
   async withOperationLock<T>(key: SessionKey, owner: ProcessIdentity, fn: () => Promise<T>): Promise<T> {
     const lock = `${this.filename}.locks/${encodeURIComponent(sessionKeyId(key))}`;
-    fs.mkdirSync(path.dirname(lock), { recursive: true, mode: 0o700 });
+    this.acquireLock(lock, owner);
     try {
-      fs.mkdirSync(lock, 0o700);
-    } catch (error) {
-      if ((error as NodeJS.ErrnoException).code === "EEXIST") throw new Error("agent operation is already in progress");
-      throw error;
-    }
-    try {
-      fs.writeFileSync(path.join(lock, "owner.json"), JSON.stringify(owner), { mode: 0o600 });
       return await fn();
     } finally {
       fs.rmSync(lock, { recursive: true, force: true });
     }
   }
 
-  importResumePanes(records: Map<string, ResumePaneRecord>): void {
+  importResumePanes(serverPid: number, records: Map<string, ResumePaneRecord>): void {
     this.mutate((file) => {
-      if (file.importedResumePanes) return;
-      file.legacyResumePanes = Object.fromEntries(records);
+      if (file.importedResumePanes && file.legacyResumePanes.serverPid === serverPid) return;
+      file.legacyResumePanes = { serverPid, panes: Object.fromEntries(records) };
       file.importedResumePanes = true;
+    });
+  }
+
+  resumePanes(serverPid: number): Map<string, ResumePaneRecord> {
+    const saved = this.snapshot().legacyResumePanes;
+    return saved.serverPid === serverPid ? new Map(Object.entries(saved.panes)) : new Map();
+  }
+
+  rememberResumePane(serverPid: number, pathname: string, record: ResumePaneRecord): void {
+    this.mutate((file) => {
+      if (file.legacyResumePanes.serverPid !== serverPid) file.legacyResumePanes = { serverPid, panes: {} };
+      file.legacyResumePanes.panes[pathname] = record;
+      file.importedResumePanes = true;
+    });
+  }
+
+  reconcileSpawnReceipts(live: Iterable<SessionKey>): void {
+    const liveIds = new Set([...live].map(sessionKeyId));
+    this.mutate((file) => {
+      for (const entry of Object.values(file.entries)) {
+        if (liveIds.has(sessionKeyId(entry.key))) entry.pendingAction = null;
+      }
+      for (const receipt of Object.values(file.receipts)) {
+        if (receipt.state !== "starting" || !receipt.artifactPath) continue;
+        const key = Object.values(file.entries).find((entry) => entry.artifactPath === receipt.artifactPath)?.key;
+        if (key && liveIds.has(sessionKeyId(key))) receipt.state = "completed";
+      }
+    });
+  }
+
+  completeObservedSpawn(key: SessionKey, artifactPath: string, cwd: string): void {
+    this.mutate((file) => {
+      for (const receipt of Object.values(file.receipts)) {
+        if (receipt.state === "starting" && receipt.engine === key.engine && receipt.cwd === cwd) {
+          receipt.state = "completed";
+          receipt.artifactPath = artifactPath;
+        }
+      }
     });
   }
 }

--- a/src/lib/agent/registry.ts
+++ b/src/lib/agent/registry.ts
@@ -1,0 +1,243 @@
+import crypto from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+
+import { statePath } from "@/lib/configDir";
+
+import type { AgentEngine } from "./cli";
+import { sessionKeyId, type SessionKey } from "./sessionKey";
+import type { ResumePaneRecord } from "@/lib/resumePanesFile";
+
+export type AgentHostStatus = "starting" | "live" | "idle" | "handoff" | "unhosted" | "dead";
+
+export interface ProcessIdentity {
+  pid: number;
+  startIdentity: string | null;
+}
+
+export interface TmuxHostEvidence {
+  kind: "tmux";
+  endpoint: string;
+  server: ProcessIdentity;
+  paneId: string;
+  panePid: ProcessIdentity;
+  windowName: string;
+  agent: ProcessIdentity;
+  argv: string[];
+}
+
+export interface AgentRegistryEntry {
+  key: SessionKey;
+  artifactPath: string;
+  cwd: string;
+  accountId: string | null;
+  status: AgentHostStatus;
+  host: TmuxHostEvidence | null;
+  claimEpoch: number;
+  claimOwner: string | null;
+  pendingAction: "spawn" | "resume" | "handoff" | null;
+  updatedAt: string;
+}
+
+export interface SpawnReceipt {
+  launchId: string;
+  engine: AgentEngine;
+  cwd: string;
+  createdAt: string;
+  state: "starting" | "completed" | "failed";
+  artifactPath: string | null;
+  error: string | null;
+}
+
+interface RegistryFile {
+  version: 1;
+  entries: Record<string, AgentRegistryEntry>;
+  receipts: Record<string, SpawnReceipt>;
+  importedResumePanes: boolean;
+  /** Compatibility evidence only. It never authorizes a pane until the live
+      resolver proves server, process, engine, and transcript ownership. */
+  legacyResumePanes: Record<string, ResumePaneRecord>;
+}
+
+const EMPTY: RegistryFile = { version: 1, entries: {}, receipts: {}, importedResumePanes: false, legacyResumePanes: {} };
+
+function clone<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T;
+}
+
+function now(): string {
+  return new Date().toISOString();
+}
+
+function readFile(filename: string): RegistryFile {
+  try {
+    const parsed = JSON.parse(fs.readFileSync(filename, "utf8")) as Partial<RegistryFile>;
+    if (parsed.version !== 1 || !parsed.entries || !parsed.receipts) return clone(EMPTY);
+    return {
+      version: 1,
+      entries: parsed.entries,
+      receipts: parsed.receipts,
+      importedResumePanes: parsed.importedResumePanes === true,
+      legacyResumePanes: parsed.legacyResumePanes && typeof parsed.legacyResumePanes === "object" ? parsed.legacyResumePanes : {},
+    };
+  } catch {
+    return clone(EMPTY);
+  }
+}
+
+function writeAtomic(filename: string, value: RegistryFile): void {
+  fs.mkdirSync(path.dirname(filename), { recursive: true, mode: 0o700 });
+  const temp = `${filename}.${process.pid}.${crypto.randomUUID()}.tmp`;
+  const payload = JSON.stringify(value, null, 2) + "\n";
+  let fd: number | null = null;
+  try {
+    fd = fs.openSync(temp, "w", 0o600);
+    fs.writeFileSync(fd, payload, "utf8");
+    fs.fsyncSync(fd);
+    fs.closeSync(fd);
+    fd = null;
+    fs.renameSync(temp, filename);
+    const dir = fs.openSync(path.dirname(filename), "r");
+    try { fs.fsyncSync(dir); } finally { fs.closeSync(dir); }
+  } finally {
+    if (fd !== null) fs.closeSync(fd);
+    try { fs.unlinkSync(temp); } catch { /* rename completed */ }
+  }
+}
+
+/** Durable source for identity and handoff evidence. The lock directory is
+    intentionally separate from in-memory promises, so a Viewer replacement
+    cannot leave an imaginary owner behind. */
+export class AgentRegistry {
+  constructor(readonly filename = statePath("agent-registry.json")) {}
+
+  private mutate<T>(fn: (file: RegistryFile) => T): T {
+    const lock = `${this.filename}.write-lock`;
+    fs.mkdirSync(path.dirname(lock), { recursive: true, mode: 0o700 });
+    let acquired = false;
+    for (let attempt = 0; attempt < 100; attempt += 1) {
+      try {
+        fs.mkdirSync(lock, 0o700);
+        acquired = true;
+        break;
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
+        Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 5);
+      }
+    }
+    if (!acquired) throw new Error("agent registry is busy");
+    try {
+      const file = readFile(this.filename);
+      const result = fn(file);
+      writeAtomic(this.filename, file);
+      return result;
+    } finally {
+      fs.rmSync(lock, { recursive: true, force: true });
+    }
+  }
+
+  snapshot(): RegistryFile { return readFile(this.filename); }
+
+  beginSpawn(engine: AgentEngine, cwd: string): SpawnReceipt {
+    return this.mutate((file) => {
+      const receipt: SpawnReceipt = { launchId: crypto.randomUUID(), engine, cwd, createdAt: now(), state: "starting", artifactPath: null, error: null };
+      file.receipts[receipt.launchId] = receipt;
+      return clone(receipt);
+    });
+  }
+
+  completeSpawn(launchId: string, entry: Omit<AgentRegistryEntry, "updatedAt">): AgentRegistryEntry {
+    return this.mutate((file) => {
+      const receipt = file.receipts[launchId];
+      if (!receipt || receipt.state !== "starting") throw new Error("unknown or completed spawn receipt");
+      const full = { ...entry, updatedAt: now() };
+      file.entries[sessionKeyId(entry.key)] = full;
+      receipt.state = "completed";
+      receipt.artifactPath = entry.artifactPath;
+      return clone(full);
+    });
+  }
+
+  failSpawn(launchId: string, error: string): void {
+    this.mutate((file) => {
+      const receipt = file.receipts[launchId];
+      if (receipt && receipt.state === "starting") {
+        receipt.state = "failed";
+        receipt.error = error;
+      }
+    });
+  }
+
+  upsert(entry: Omit<AgentRegistryEntry, "updatedAt">): AgentRegistryEntry {
+    return this.mutate((file) => {
+      const full = { ...entry, updatedAt: now() };
+      file.entries[sessionKeyId(entry.key)] = full;
+      return clone(full);
+    });
+  }
+
+  markUnhosted(key: SessionKey): void {
+    this.mutate((file) => {
+      const entry = file.entries[sessionKeyId(key)];
+      if (!entry) return;
+      entry.host = null;
+      entry.status = "unhosted";
+      entry.updatedAt = now();
+    });
+  }
+
+  claim(key: SessionKey, owner: string): AgentRegistryEntry {
+    return this.mutate((file) => {
+      const entry = file.entries[sessionKeyId(key)];
+      if (!entry) throw new Error("agent registry entry is missing");
+      if (entry.claimOwner && entry.claimOwner !== owner) throw new Error("agent session is claimed by another operation");
+      entry.claimOwner = owner;
+      entry.claimEpoch += 1;
+      entry.updatedAt = now();
+      return clone(entry);
+    });
+  }
+
+  releaseClaim(key: SessionKey, owner: string): void {
+    this.mutate((file) => {
+      const entry = file.entries[sessionKeyId(key)];
+      if (entry?.claimOwner === owner) {
+        entry.claimOwner = null;
+        entry.updatedAt = now();
+      }
+    });
+  }
+
+  /** Cross-process operation lock. Stale owners include their process start
+      identity and may be recovered by an explicit caller after verification. */
+  async withOperationLock<T>(key: SessionKey, owner: ProcessIdentity, fn: () => Promise<T>): Promise<T> {
+    const lock = `${this.filename}.locks/${encodeURIComponent(sessionKeyId(key))}`;
+    fs.mkdirSync(path.dirname(lock), { recursive: true, mode: 0o700 });
+    try {
+      fs.mkdirSync(lock, 0o700);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "EEXIST") throw new Error("agent operation is already in progress");
+      throw error;
+    }
+    try {
+      fs.writeFileSync(path.join(lock, "owner.json"), JSON.stringify(owner), { mode: 0o600 });
+      return await fn();
+    } finally {
+      fs.rmSync(lock, { recursive: true, force: true });
+    }
+  }
+
+  importResumePanes(records: Map<string, ResumePaneRecord>): void {
+    this.mutate((file) => {
+      if (file.importedResumePanes) return;
+      file.legacyResumePanes = Object.fromEntries(records);
+      file.importedResumePanes = true;
+    });
+  }
+}
+
+let registry: AgentRegistry | null = null;
+export function agentRegistry(): AgentRegistry {
+  registry ??= new AgentRegistry();
+  return registry;
+}

--- a/src/lib/agent/sessionKey.test.ts
+++ b/src/lib/agent/sessionKey.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, test } from "bun:test";
+
+import { sessionKeyFromArgv, sessionKeyFromTranscript, sessionKeyId } from "@/lib/agent/sessionKey";
+
+const ID = "019f4906-3f67-7b72-9fbc-9ec3b5ad1326";
+
+describe("engine-native session keys", () => {
+  test("uses the engine and normalized native id", () => {
+    const key = sessionKeyFromTranscript("codex", `/home/user/rollout-${ID.toUpperCase()}.jsonl`);
+    expect(key && sessionKeyId(key)).toBe(`codex:${ID}`);
+  });
+
+  test("extracts a resume identity from argv", () => {
+    expect(sessionKeyFromArgv("claude", ["claude", "--resume", ID])).toEqual({ engine: "claude", sessionId: ID });
+  });
+
+  test("rejects arbitrary path text", () => {
+    expect(sessionKeyFromTranscript("codex", "/home/user/session.jsonl")).toBeNull();
+  });
+});

--- a/src/lib/agent/sessionKey.ts
+++ b/src/lib/agent/sessionKey.ts
@@ -1,0 +1,40 @@
+import path from "node:path";
+
+import type { AgentEngine } from "./cli";
+
+/** Stable identity for an engine conversation. Mutable host details deliberately
+    live elsewhere: a pane, PID, or tmux server can disappear and be replaced. */
+export interface SessionKey {
+  engine: AgentEngine;
+  sessionId: string;
+}
+
+const SESSION_ID = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/i;
+
+export function normalizeSessionId(value: string): string | null {
+  const match = value.match(SESSION_ID)?.[0];
+  return match && match.length === value.length ? match.toLowerCase() : null;
+}
+
+export function sessionKey(engine: AgentEngine, sessionId: string): SessionKey | null {
+  const normalized = normalizeSessionId(sessionId);
+  return normalized ? { engine, sessionId: normalized } : null;
+}
+
+export function sessionKeyId(key: SessionKey): string {
+  return `${key.engine}:${key.sessionId}`;
+}
+
+export function sessionKeyFromTranscript(engine: AgentEngine, pathname: string): SessionKey | null {
+  const base = path.basename(pathname);
+  const match = base.match(SESSION_ID);
+  return match ? sessionKey(engine, match[0]) : null;
+}
+
+export function sessionKeyFromArgv(engine: AgentEngine, argv: string[]): SessionKey | null {
+  for (let index = argv.length - 1; index >= 0; index -= 1) {
+    const match = argv[index]?.match(SESSION_ID);
+    if (match) return sessionKey(engine, match[0]);
+  }
+  return null;
+}

--- a/src/lib/agent/transcriptHost.ts
+++ b/src/lib/agent/transcriptHost.ts
@@ -8,6 +8,7 @@ import { agentProcesses, argvEngine, pidAlive, readArgv, readPpid, type AgentPro
 import {
   panePidMap,
   panePidOf,
+  paneInfo,
   rememberResumePane,
   resumePaneRecords,
   sendText,
@@ -37,6 +38,7 @@ export interface TranscriptHost {
   panePid: number;
   agentPid: number;
   display: string;
+  windowName?: string;
   engine: "claude" | "codex";
   cwd: string;
   /** argv observed with this pid; detects a pid that was recycled between
@@ -84,6 +86,7 @@ interface HostDependencies {
   serverPid: () => Promise<number | null>;
   resumeRecords: () => ReturnType<typeof resumePaneRecords>;
   panePid: (paneId: string) => Promise<number | null>;
+  paneWindowName?: (paneId: string) => Promise<string | null>;
   alive: (pid: number) => boolean;
   argv: (pid: number) => string[];
   parentPid: (pid: number) => number | null;
@@ -221,15 +224,16 @@ export function createTranscriptHostResolver(
 
   async function observe(fresh: boolean): Promise<TranscriptHostSnapshot> {
     const [entries, paneObservation, records] = await Promise.all([dependencies.listFiles(), dependencies.panes(fresh), dependencies.resumeRecords()]);
-    if (records) agentRegistry().importResumePanes(records.records);
     const serverPid = records?.serverPid ?? (await dependencies.serverPid());
     if (paneObservation.kind === "failure" && serverPid !== null) {
       return { hosts: [], observation: "failure", observationError: paneObservation.error, canonicalFor: () => null };
     }
     if (serverPid === null || paneObservation.kind === "no-server") {
+      dependencies.reconcile?.([]);
       return { hosts: [], observation: "no-server", canonicalFor: () => null };
     }
     if (paneObservation.kind !== "available" || paneObservation.panes.size === 0) {
+      dependencies.reconcile?.([]);
       return { hosts: [], observation: "available", canonicalFor: () => null };
     }
     const { panes } = paneObservation;
@@ -252,6 +256,7 @@ export function createTranscriptHostResolver(
           panePid,
           agentPid: agent.pid,
           display: pane.target,
+          windowName: pane.windowName ?? "",
           engine: agent.engine,
           cwd: agent.cwd,
           agentArgv: [...agent.argv],
@@ -275,6 +280,7 @@ export function createTranscriptHostResolver(
   async function revalidate(host: TranscriptHost, entry: FileEntry): Promise<boolean> {
     if (host.engine !== entry.engine || (await dependencies.serverPid()) !== host.tmuxServerPid) return false;
     if ((await dependencies.panePid(host.paneId)) !== host.panePid || !dependencies.alive(host.agentPid)) return false;
+    if (host.windowName && dependencies.paneWindowName && (await dependencies.paneWindowName(host.paneId)) !== host.windowName) return false;
     if (!isDescendantOf(host.agentPid, host.panePid, dependencies.parentPid)) return false;
     const argv = dependencies.argv(host.agentPid);
     if (argv.length !== host.agentArgv.length || argv.some((value, index) => value !== host.agentArgv[index])) return false;
@@ -402,11 +408,12 @@ function reconcileRegistry(hosts: TranscriptHost[]): void {
       server: { pid: host.tmuxServerPid, startIdentity: serverStart },
       paneId: host.paneId,
       panePid: { pid: host.panePid, startIdentity: procBackend.processIdentity(host.panePid) },
-      windowName: host.display.slice(0, host.display.indexOf(":")) || "agents",
+      windowName: host.windowName ?? "",
       agent: { pid: host.agentPid, startIdentity: host.agentIdentity },
       argv: host.agentArgv,
     };
     const existing = registry.snapshot().entries[`${key.engine}:${key.sessionId}`];
+    registry.completeObservedSpawn(key, host.primaryPath, host.cwd);
     registry.upsert({
       key,
       artifactPath: host.primaryPath,
@@ -416,13 +423,36 @@ function reconcileRegistry(hosts: TranscriptHost[]): void {
       host: evidence,
       claimEpoch: existing?.claimEpoch ?? 0,
       claimOwner: existing?.claimOwner ?? null,
-      pendingAction: existing?.pendingAction ?? null,
+      pendingAction: null,
     });
     seen.add(`${key.engine}:${key.sessionId}`);
   }
   for (const [id, entry] of Object.entries(registry.snapshot().entries)) {
     if (entry.host?.kind === "tmux" && !seen.has(id)) registry.markUnhosted(entry.key);
   }
+  registry.reconcileSpawnReceipts([...seen].map((id) => {
+    const [engine, sessionId] = id.split(":");
+    return { engine: engine as "claude" | "codex", sessionId };
+  }));
+}
+
+async function registryResumeRecords(): ReturnType<typeof resumePaneRecords> {
+  const serverPid = await tmuxServerPid();
+  if (serverPid === null) return null;
+  const registry = agentRegistry();
+  const snapshot = registry.snapshot();
+  if (!snapshot.importedResumePanes) {
+    const legacy = await resumePaneRecords();
+    if (legacy) registry.importResumePanes(legacy.serverPid, legacy.records);
+  }
+  return { serverPid, records: registry.resumePanes(serverPid) };
+}
+
+async function rememberRegistryResume(pathname: string, spec: ResumeSpec, pane: SpawnedPane): Promise<void> {
+  await rememberResumePane(pathname, spec, pane);
+  if (!pane.panePid) return;
+  const serverPid = await tmuxServerPid();
+  if (serverPid !== null) agentRegistry().rememberResumePane(serverPid, pathname, { paneId: pane.paneId, panePid: pane.panePid, windowName: spec.windowName, engine: spec.engine });
 }
 
 async function serializeRegistryDelivery(entry: FileEntry, task: () => Promise<HostDeliveryOutcome>): Promise<HostDeliveryOutcome> {
@@ -443,14 +473,15 @@ const runtimeResolver = createTranscriptHostResolver({
   ppidMap: () => procBackend.ppidMap(),
   agents: agentProcesses,
   serverPid: tmuxServerPid,
-  resumeRecords: resumePaneRecords,
+  resumeRecords: registryResumeRecords,
   panePid: panePidOf,
+  paneWindowName: async (paneId) => (await paneInfo(paneId))?.windowName ?? null,
   alive: pidAlive,
   argv: readArgv,
   parentPid: readPpid,
   identity: procBackend.processIdentity,
   spawn: spawnAgentWithPrompt,
-  remember: rememberResumePane,
+  remember: rememberRegistryResume,
   deliver: sendText,
   reconcile: reconcileRegistry,
   serializeDelivery: serializeRegistryDelivery,

--- a/src/lib/agent/transcriptHost.ts
+++ b/src/lib/agent/transcriptHost.ts
@@ -1,5 +1,6 @@
 import type { ResumeSpec } from "@/lib/agent/cli";
-import fs from "node:fs";
+import { agentRegistry, type TmuxHostEvidence } from "@/lib/agent/registry";
+import { sessionKeyFromTranscript } from "@/lib/agent/sessionKey";
 import { procBackend } from "@/lib/proc";
 import { descendantPids } from "@/lib/proc/memory";
 import { listFiles } from "@/lib/scanner";
@@ -11,6 +12,7 @@ import {
   resumePaneRecords,
   sendText,
   spawnAgentWithPrompt,
+  tmuxEndpoint,
   tmuxServerPid,
   type PaneRef,
   type PaneObservation,
@@ -89,6 +91,8 @@ interface HostDependencies {
   spawn: (spec: ResumeSpec, text: string) => Promise<SpawnedPane>;
   remember: (pathname: string, spec: ResumeSpec, pane: SpawnedPane) => Promise<void>;
   deliver: (paneId: string, text: string) => Promise<void>;
+  reconcile?: (hosts: TranscriptHost[]) => void;
+  serializeDelivery?: (entry: FileEntry, task: () => Promise<HostDeliveryOutcome>) => Promise<HostDeliveryOutcome>;
 }
 
 interface HostClaim {
@@ -205,18 +209,6 @@ function failure(error: unknown, status = 500): HostDeliveryOutcome {
   return { ok: false, outcome: "failed", error: error instanceof Error ? error.message : String(error), status };
 }
 
-function processIdentity(pid: number): string | null {
-  try {
-    const raw = fs.readFileSync(`/proc/${pid}/stat`, "utf8");
-    const closing = raw.lastIndexOf(")");
-    const fields = raw.slice(closing + 2).trim().split(/\s+/);
-    const startTicks = fields[19];
-    return startTicks ? `${pid}:${startTicks}` : null;
-  } catch {
-    return null;
-  }
-}
-
 /**
  * Creates the deep transcript-host module. The optional dependencies form a
  * test seam; production callers use the singleton below and only learn the
@@ -229,6 +221,7 @@ export function createTranscriptHostResolver(
 
   async function observe(fresh: boolean): Promise<TranscriptHostSnapshot> {
     const [entries, paneObservation, records] = await Promise.all([dependencies.listFiles(), dependencies.panes(fresh), dependencies.resumeRecords()]);
+    if (records) agentRegistry().importResumePanes(records.records);
     const serverPid = records?.serverPid ?? (await dependencies.serverPid());
     if (paneObservation.kind === "failure" && serverPid !== null) {
       return { hosts: [], observation: "failure", observationError: paneObservation.error, canonicalFor: () => null };
@@ -269,6 +262,8 @@ export function createTranscriptHostResolver(
         });
       }
     }
+
+    dependencies.reconcile?.(hosts);
 
     return {
       hosts,
@@ -336,9 +331,7 @@ export function createTranscriptHostResolver(
     return { owner: true, task };
   }
 
-  return {
-    readTranscriptHosts: observe,
-    async deliverToTranscriptHost(input): Promise<HostDeliveryOutcome> {
+  async function deliverToTranscriptHost(input: { entry: FileEntry; spec: ResumeSpec; payload: string }): Promise<HostDeliveryOutcome> {
       let owner = false;
       let resumed = false;
       let decision: Decision;
@@ -385,8 +378,63 @@ export function createTranscriptHostResolver(
         }
       }
       return failure("agent host became unavailable during delivery");
-    },
+  }
+
+  return {
+    readTranscriptHosts: observe,
+    deliverToTranscriptHost: (input) => dependencies.serializeDelivery
+      ? dependencies.serializeDelivery(input.entry, () => deliverToTranscriptHost(input))
+      : deliverToTranscriptHost(input),
   };
+}
+
+function reconcileRegistry(hosts: TranscriptHost[]): void {
+  const registry = agentRegistry();
+  const seen = new Set<string>();
+  for (const host of hosts) {
+    if (!host.primaryPath) continue;
+    const key = sessionKeyFromTranscript(host.engine, host.primaryPath);
+    if (!key) continue;
+    const serverStart = procBackend.processIdentity(host.tmuxServerPid);
+    const evidence: TmuxHostEvidence = {
+      kind: "tmux",
+      endpoint: tmuxEndpoint(),
+      server: { pid: host.tmuxServerPid, startIdentity: serverStart },
+      paneId: host.paneId,
+      panePid: { pid: host.panePid, startIdentity: procBackend.processIdentity(host.panePid) },
+      windowName: host.display.slice(0, host.display.indexOf(":")) || "agents",
+      agent: { pid: host.agentPid, startIdentity: host.agentIdentity },
+      argv: host.agentArgv,
+    };
+    const existing = registry.snapshot().entries[`${key.engine}:${key.sessionId}`];
+    registry.upsert({
+      key,
+      artifactPath: host.primaryPath,
+      cwd: host.cwd,
+      accountId: existing?.accountId ?? null,
+      status: "live",
+      host: evidence,
+      claimEpoch: existing?.claimEpoch ?? 0,
+      claimOwner: existing?.claimOwner ?? null,
+      pendingAction: existing?.pendingAction ?? null,
+    });
+    seen.add(`${key.engine}:${key.sessionId}`);
+  }
+  for (const [id, entry] of Object.entries(registry.snapshot().entries)) {
+    if (entry.host?.kind === "tmux" && !seen.has(id)) registry.markUnhosted(entry.key);
+  }
+}
+
+async function serializeRegistryDelivery(entry: FileEntry, task: () => Promise<HostDeliveryOutcome>): Promise<HostDeliveryOutcome> {
+  if (entry.engine !== "claude" && entry.engine !== "codex") return task();
+  const key = sessionKeyFromTranscript(entry.engine, entry.path);
+  if (!key) return task();
+  const owner = { pid: process.pid, startIdentity: procBackend.processIdentity(process.pid) };
+  try {
+    return await agentRegistry().withOperationLock(key, owner, task);
+  } catch (error) {
+    return failure(error, 409);
+  }
 }
 
 const runtimeResolver = createTranscriptHostResolver({
@@ -400,10 +448,12 @@ const runtimeResolver = createTranscriptHostResolver({
   alive: pidAlive,
   argv: readArgv,
   parentPid: readPpid,
-  identity: processIdentity,
+  identity: procBackend.processIdentity,
   spawn: spawnAgentWithPrompt,
   remember: rememberResumePane,
   deliver: sendText,
+  reconcile: reconcileRegistry,
+  serializeDelivery: serializeRegistryDelivery,
 }, globalStore.__llvTranscriptHostDecisions ??= new Map());
 
 export const readTranscriptHosts = runtimeResolver.readTranscriptHosts;

--- a/src/lib/proc/linux.ts
+++ b/src/lib/proc/linux.ts
@@ -54,6 +54,12 @@ function readPpid(pid: number): number | null {
   return Number.isInteger(ppid) && ppid > 1 ? ppid : null;
 }
 
+function processIdentity(pid: number): string | null {
+  const fields = statFields(pid);
+  const startTicks = fields?.[19];
+  return startTicks ? `${pid}:${startTicks}` : null;
+}
+
 /**
  * Value of `name` in /proc/<pid>/environ. The environ array can carry the
  * variable more than once when wrapper shells re-export it; the last
@@ -237,6 +243,7 @@ export const linuxBackend: ProcBackend = {
   readArgv,
   readCwd,
   readPpid,
+  processIdentity,
   readEnvVar,
   listProcesses,
   systemMemory,

--- a/src/lib/proc/portable.ts
+++ b/src/lib/proc/portable.ts
@@ -175,6 +175,13 @@ function readPpid(pid: number): number | null {
   return snapshot().get(pid)?.ppid ?? null;
 }
 
+/* ps does not provide a portable process-birth identity. Null makes callers
+   require their other live-host evidence on platforms without Linux /proc. */
+function processIdentity(pid: number): string | null {
+  void pid;
+  return null;
+}
+
 /**
  * No portable route to another process's environment without root (macOS has
  * no /proc, and reading another process's memory needs task_for_pid
@@ -271,6 +278,7 @@ export const portableBackend: ProcBackend = {
   readArgv,
   readCwd,
   readPpid,
+  processIdentity,
   readEnvVar,
   listProcesses,
   systemMemory,

--- a/src/lib/proc/types.ts
+++ b/src/lib/proc/types.ts
@@ -46,6 +46,8 @@ export interface ProcBackend {
   readArgv(pid: number): string[];
   readCwd(pid: number): string | null;
   readPpid(pid: number): number | null;
+  /** PID plus a kernel start-time token where the platform exposes one. */
+  processIdentity(pid: number): string | null;
 
   /**
    * Value of an environment variable for a live pid. Reading another

--- a/src/lib/tmux.test.ts
+++ b/src/lib/tmux.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 
-import { cdCommandForCwd } from "@/lib/tmux";
+import { cdCommandForCwd, tmuxEndpoint } from "@/lib/tmux";
 
 describe("cdCommandForCwd", () => {
   test("quotes paths with spaces for a shell cd command", () => {
@@ -10,4 +10,8 @@ describe("cdCommandForCwd", () => {
   test("escapes single quotes in cwd paths", () => {
     expect(cdCommandForCwd("/home/user/it's here")).toBe("cd -- '/home/user/it'\\''s here'");
   });
+});
+
+test("reports the configured tmux endpoint", () => {
+  expect(tmuxEndpoint()).toBe(process.env.TMUX_TMPDIR || "/tmp");
 });

--- a/src/lib/tmux.ts
+++ b/src/lib/tmux.ts
@@ -4,6 +4,7 @@ import fs from "node:fs";
 import path from "node:path";
 
 import type { ResumeSpec } from "@/lib/agent/cli";
+import { agentRegistry, type SpawnReceipt } from "@/lib/agent/registry";
 import { statePath } from "@/lib/configDir";
 import { logEvent } from "@/lib/events";
 import { inboxImageExt, MAX_INBOX_IMAGE_BYTES } from "@/lib/imagePolicy";
@@ -86,6 +87,7 @@ export type TmuxTarget = string;
 export interface PaneRef {
   target: TmuxTarget;
   paneId: string;
+  windowName?: string;
 }
 
 /** A pane listing has three meaningful states. A missing tmux server is an
@@ -143,7 +145,7 @@ export async function panePidMap(fresh = false): Promise<PaneObservation> {
       "list-panes",
       "-a",
       "-F",
-      "#{session_name}:#{window_index}.#{pane_index}\t#{pane_id}\t#{pane_pid}",
+      "#{session_name}:#{window_index}.#{pane_index}\t#{pane_id}\t#{pane_pid}\t#{window_name}",
     ]);
   } catch (error) {
     return { kind: "failure", error: error instanceof Error ? error.message : String(error) };
@@ -154,10 +156,10 @@ export async function panePidMap(fresh = false): Promise<PaneObservation> {
     return { kind: "failure", error };
   }
   for (const line of result.stdout.split("\n")) {
-    const [target = "", paneId = "", pidRaw = ""] = line.split("\t");
+    const [target = "", paneId = "", pidRaw = "", windowName = ""] = line.split("\t");
     const panePid = Number(pidRaw.trim());
     if (target.trim() && paneId.startsWith("%") && Number.isInteger(panePid) && panePid > 0) {
-      map.set(panePid, { target: target.trim(), paneId: paneId.trim() });
+      map.set(panePid, { target: target.trim(), paneId: paneId.trim(), windowName: windowName.trim() });
     }
   }
   const observation: PaneObservation = { kind: "available", panes: map };
@@ -507,6 +509,7 @@ export interface SpawnedPane {
   /** Shell pid of the pane, set on freshly spawned windows: handoff lineage
       matches a later-born conversation to its source through this pid. */
   panePid?: number;
+  receipt?: SpawnReceipt;
 }
 
 /** Resume records scoped to the current tmux server. Callers still have to
@@ -604,7 +607,7 @@ export async function sendKeys(target: TmuxTarget, keys: string[]): Promise<void
  * the agent CLI — a pane that fell back to the shell would otherwise execute
  * the prompt text as a shell command.
  */
-export async function spawnAgentWithPrompt(spec: ResumeSpec, text: string): Promise<SpawnedPane> {
+async function spawnAgentWithPromptUnchecked(spec: ResumeSpec, text: string): Promise<SpawnedPane> {
   const session = await activeTmuxSession();
   const spawned = await runTmux([
     "new-window",
@@ -696,6 +699,18 @@ export async function spawnAgentWithPrompt(spec: ResumeSpec, text: string): Prom
     display: display || target,
     ...(Number.isInteger(panePid) && panePid > 0 ? { panePid } : {}),
   };
+}
+
+/** Every visible legacy launch receives a durable receipt before tmux creates
+    its window. Callers may later attach the engine-native transcript identity. */
+export async function spawnAgentWithPrompt(spec: ResumeSpec, text: string): Promise<SpawnedPane> {
+  const receipt = agentRegistry().beginSpawn(spec.engine, spec.cwd);
+  try {
+    return { ...(await spawnAgentWithPromptUnchecked(spec, text)), receipt };
+  } catch (error) {
+    agentRegistry().failSpawn(receipt.launchId, error instanceof Error ? error.message : String(error));
+    throw error;
+  }
 }
 
 /** Opens a visible shell window and types one command without agent readiness or paste handling. */

--- a/src/lib/tmux.ts
+++ b/src/lib/tmux.ts
@@ -9,6 +9,7 @@ import { logEvent } from "@/lib/events";
 import { inboxImageExt, MAX_INBOX_IMAGE_BYTES } from "@/lib/imagePolicy";
 import { INBOX_DIR } from "@/lib/inbox";
 import { normalizeResumePanesFile, type ResumePaneRecord, type ResumePanesFile } from "@/lib/resumePanesFile";
+import { procBackend } from "@/lib/proc";
 import { listFiles } from "@/lib/scanner";
 import { isHelperArgv, pidAlive, readArgv, readPpid } from "@/lib/scanner/process";
 import {
@@ -24,6 +25,7 @@ import {
 export { READY_MARKERS, screenTail } from "@/lib/status";
 
 const TMUX = "tmux";
+const CANONICAL_EXTERNAL_SESSION = "agents";
 /* Outlives the 10 s /api/files poll so the pane map is not rebuilt every
    request; a post-kill rebuild passes fresh=true to bypass the memo. */
 const PANE_MAP_TTL_MS = 12_000;
@@ -102,10 +104,20 @@ interface RunResult {
   stderr: string;
 }
 
+/** The service endpoint is intentionally an environment contract. During the
+    migration the old /tmp server remains reachable until this flag is enabled. */
+export function externalTmuxMode(): boolean {
+  return process.env.LLV_LEGACY_TMUX_EXTERNAL === "1";
+}
+
+export function tmuxEndpoint(): string {
+  return process.env.TMUX_TMPDIR || "/tmp";
+}
+
 /** Runs tmux with an explicit argv (no shell) and optional stdin payload. */
 function runTmux(args: string[], input?: Buffer | string): Promise<RunResult> {
   return new Promise((resolve, reject) => {
-    const child = spawn(TMUX, args, { stdio: ["pipe", "pipe", "pipe"] });
+    const child = spawn(TMUX, args, { stdio: ["pipe", "pipe", "pipe"], env: { ...process.env, TMUX_TMPDIR: tmuxEndpoint() } });
     let stdout = "";
     let stderr = "";
     child.stdout.on("data", (chunk: Buffer) => (stdout += chunk.toString("utf8")));
@@ -367,6 +379,13 @@ export async function killPane(target: TmuxTarget): Promise<void> {
  * session; no server at all yields a fresh detached «agents» session.
  */
 export async function activeTmuxSession(): Promise<string> {
+  if (externalTmuxMode()) {
+    const healthy = await runTmux(["has-session", "-t", CANONICAL_EXTERNAL_SESSION]).catch(() => null);
+    if (!healthy || healthy.code !== 0) {
+      throw new Error("external legacy tmux supervisor is unavailable; refusing to create a container-owned server");
+    }
+    return CANONICAL_EXTERNAL_SESSION;
+  }
   const clients = await runTmux(["list-clients", "-F", "#{client_activity} #{client_session}"]).catch(() => null);
   const pick = (stdout: string) => {
     let best: { at: number; name: string } | null = null;
@@ -458,6 +477,11 @@ export async function tmuxServerPid(): Promise<number | null> {
   const res = await runTmux(["display-message", "-p", "#{pid}"]).catch(() => null);
   const pid = res && res.code === 0 ? Number(res.stdout.trim()) : NaN;
   return Number.isInteger(pid) && pid > 0 ? pid : null;
+}
+
+export async function tmuxServerIdentity(): Promise<string | null> {
+  const pid = await tmuxServerPid();
+  return pid === null ? null : procBackend.processIdentity(pid);
 }
 
 /**


### PR DESCRIPTION
Closes #10

## Outcome

Moves the legacy tmux runtime behind an explicit external-supervisor contract and adds durable registry, ownership, resume, and migration state needed for a safe Viewer cutover.

## Key guarantees

- canonical tmux socket and server identity
- atomic, fail-closed agent registry with stale-lock recovery
- fenced transcript ownership and serialized cold resume
- durable spawn receipts and restart recovery
- phase-aware legacy migration with rollback records
- explicit external-supervisor mode and downgrade protection

## Verification

- focused supervisor tests: 20 passed
- full suite: 468 passed, 2746 assertions
- TypeScript: passed
- ESLint: passed
- production build: passed
- clean diff check: passed

## Release boundary

This PR publishes the contract and implementation. Installing the user service and moving the live production Viewer remain a separate approved cutover because the current container still owns active agent processes.