### PR TITLE
Shared multi-device board and agent snapshot API

### DIFF
--- a/.claude/skills/live-log-viewer-orchestration/SKILL.md
+++ b/.claude/skills/live-log-viewer-orchestration/SKILL.md
@@ -56,6 +56,31 @@ detached job — the port rule and core rule above still apply.
 
 Any interactive `claude`/`codex` process in tmux is auto-matched to its transcript (fd holders, `--session-id` argv, cwd) — so a pane you spawn correctly appears in the UI with composer, kill and interrupt controls.
 
+## Reading the operator's live view — `viewer.snapshot`
+
+To see **what the human is actually looking at right now** — same board, same device — call the snapshot capability. Discover it first with the manifest:
+
+`GET http://127.0.0.1:8898/api/agent` → self-describing capability list with example calls.
+
+The capability is `viewer.snapshot`:
+
+`POST http://127.0.0.1:8898/api/agent/snapshot` with `{"schemaVersion":1}` (all fields optional). It returns the live browser view: the resolved device/view session and its freshness, the active `project` and view `mode` (`overview`/`scheme`/`list`/`mobile-focus`/`mobile-map`), the `viewport` and `camera`, the `focusedPath`, `selectedPaths`, and `visiblePaths` **in visual order** (freshest-first, left→right on the board), each visible conversation's activity + attention state, the durable board revision, and **bounded, secret-redacted compact text** for the requested scope.
+
+Scope controls only which conversations get text, never membership:
+
+```jsonc
+{ "schemaVersion": 1,
+  "scope": { "kind": "selected" },        // focused | selected | visible | focused-selected | paths
+  "text": { "include": true, "lastMessages": 6, "maxCharsPerConversation": 3000 } }
+```
+
+- **Multi-device.** Default resolution picks the **latest-interacted** view and lists the others under `resolution.alternatives`. Pin one with `view.id` / `view.deviceId`. `view.resolution: "require-explicit"` returns **409 `AMBIGUOUS_ACTIVE_VIEW`** when two devices interacted near-simultaneously — pick from the alternatives and retry.
+- **Nobody watching / after a server restart.** Returns **404 `NO_ACTIVE_VIEW`** — presence is in-memory and republishes on the browser's next heartbeat. This is honest: there is no live human view to report.
+- **Reads are inert.** The snapshot never moves a camera, adds a node, touches board state, or ticks flows/tasks — safe to poll for orientation.
+- Loopback needs no token; a remote agent caller uses `Authorization: Bearer <LLV_TOKEN>`. Port rule holds: **always `8898`**.
+
+Use this to answer "what am I looking at, and which of these is blocked" before you spawn or message — then act through `/api/spawn` and `/api/tmux` as below.
+
 ## Spawning a new agent
 
 **Preferred — viewer running:** `POST http://127.0.0.1:8898/api/spawn` with JSON `{"engine":"codex","model":"gpt-5.6-terra","cwd":"<abs dir>","prompt":"<first message>","src":"<your own transcript path>"}`. Use `gpt-5.6-sol` for architecture, diagnosis, and review. Same-origin only (call from localhost, no Origin header). **Always pass `src`** when spawning on behalf of a conversation (e.g. your own session): it records lineage in `~/.config/agent-log-viewer/state/handoff-lineage.json`, and the board draws the child under the parent with an arrow. Without it the new agent shows up as an unrelated root — the user treats that as a bug.

--- a/src/app/api/agent/route.ts
+++ b/src/app/api/agent/route.ts
@@ -1,0 +1,14 @@
+import { NextResponse } from "next/server";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export function GET(): NextResponse {
+  return NextResponse.json({
+    ok: true,
+    name: "Agent Log Viewer", version: 1,
+    capabilities: [{ name: "viewer.snapshot", method: "POST", path: "/api/agent/snapshot", description: "Read the active browser view without mutating it.", example: "curl -sS http://127.0.0.1:8898/api/agent/snapshot -H 'content-type: application/json' --data '{\"schemaVersion\":1}'" }],
+    auth: "Loopback calls are trusted. Remote callers require Authorization: Bearer $LLV_TOKEN.",
+    multiDevice: "The latest eligible interaction is selected and alternatives are reported. Send view.resolution=require-explicit to reject close races.",
+  }, { headers: { "Cache-Control": "no-store" } });
+}

--- a/src/app/api/agent/snapshot/route.test.ts
+++ b/src/app/api/agent/snapshot/route.test.ts
@@ -1,0 +1,45 @@
+import { afterEach, expect, test } from "bun:test";
+import { NextRequest } from "next/server";
+
+import type { FileEntry } from "@/lib/types";
+import { collectSnapshot } from "@/lib/view/collect";
+import { resetPresenceForTest, upsertPresence } from "@/lib/view/presenceStore";
+import type { PresencePayloadV1 } from "@/lib/view/types";
+
+import { POST } from "./route";
+
+afterEach(() => resetPresenceForTest());
+
+const presence: PresencePayloadV1 = {
+  schemaVersion: 1, viewSessionId: "route-view", deviceId: "route-device", device: { kind: "desktop", browser: "chrome" }, visibility: "visible", sequence: 1, inputSequence: 1,
+  project: "viewer", mode: "scheme", viewport: { width: 100, height: 100, dpr: 1 }, camera: null, focusedPath: "/a.jsonl", selectedPaths: [], visiblePaths: ["/a.jsonl"],
+  board: { renderedRevision: null, durableRevision: null, sync: "unavailable" },
+};
+const entry: FileEntry = { path: "/a.jsonl", root: "claude-projects", name: "a.jsonl", project: "viewer", title: "A", engine: "claude", kind: "session", fmt: "claude", parent: null, mtime: 1, size: 1, activity: "idle", proc: null, pid: null, model: null, pendingQuestion: null, waitingInput: null };
+
+test("snapshot rejects hostile browser headers before body validation", async () => {
+  const request = new NextRequest("http://127.0.0.1:8898/api/agent/snapshot", { method: "POST", headers: { host: "127.0.0.1:8898", origin: "https://evil.example", "sec-fetch-site": "cross-site" }, body: "{}" });
+  const response = await POST(request);
+  expect(response.status).toBe(403);
+  expect(response.headers.get("cache-control")).toBe("no-store");
+});
+
+test("snapshot permits a headerless CLI request to reach strict validation", async () => {
+  const response = await POST(new NextRequest("http://127.0.0.1:8898/api/agent/snapshot", { method: "POST", headers: { host: "127.0.0.1:8898" }, body: "{}" }));
+  expect(response.status).toBe(400);
+  expect(await response.json()).toMatchObject({ error: "UNSUPPORTED_SCHEMA_VERSION" });
+});
+
+test("snapshot collection performs exactly one discovery and shares its entries", async () => {
+  upsertPresence(presence);
+  let discoveries = 0;
+  const result = await collectSnapshot({ schemaVersion: 1, text: { include: false } }, {
+    observeFiles: async () => { discoveries += 1; return [entry]; },
+    resolveSiblings: async (_caller, files) => {
+      expect(files).toEqual([entry]);
+      return { selfResolution: "omitted" as const, agents: [] };
+    },
+  });
+  expect(discoveries).toBe(1);
+  expect(result.conversations[0]?.path).toBe(entry.path);
+});

--- a/src/app/api/agent/snapshot/route.ts
+++ b/src/app/api/agent/snapshot/route.ts
@@ -1,0 +1,30 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { observeFiles } from "@/lib/scanner/observe";
+import { rejectCrossOrigin } from "@/lib/sameOrigin";
+import { collectSnapshot } from "@/lib/view/collect";
+import { SnapshotError } from "@/lib/view/snapshot";
+import { resolveSiblings } from "@/lib/view/siblings";
+import { readBoundedJson, validateSnapshotRequest, ViewValidationError } from "@/lib/view/validation";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+const headers = { "Cache-Control": "no-store" };
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  const rejection = rejectCrossOrigin(request);
+  if (rejection) { rejection.headers.set("Cache-Control", "no-store"); return rejection; }
+  let body: ReturnType<typeof validateSnapshotRequest>;
+  try {
+    body = validateSnapshotRequest(await readBoundedJson(request));
+  } catch (error) {
+    if (error instanceof ViewValidationError) return NextResponse.json({ error: error.code, message: error.message }, { status: error.status, headers });
+    return NextResponse.json({ error: "INVALID_REQUEST", message: "invalid request" }, { status: 400, headers });
+  }
+  try {
+    return NextResponse.json(await collectSnapshot(body, { observeFiles, resolveSiblings }), { headers });
+  } catch (error) {
+    if (error instanceof SnapshotError) return NextResponse.json({ error: error.code, message: error.message, ...(error.sessions ? { sessions: error.sessions } : {}) }, { status: error.status, headers });
+    return NextResponse.json({ error: "SCANNER_UNAVAILABLE", message: "scanner unavailable" }, { status: 503, headers });
+  }
+}

--- a/src/app/api/board/route.ts
+++ b/src/app/api/board/route.ts
@@ -1,0 +1,38 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { boardFor, BoardStoreError, patchBoard } from "@/lib/board/store";
+import { validateBoardPatchRequest } from "@/lib/board/validation";
+import { rejectCrossOrigin } from "@/lib/sameOrigin";
+import { ViewValidationError } from "@/lib/view/validation";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+const headers = { "Cache-Control": "no-store" };
+
+export function GET(request: NextRequest): NextResponse {
+  const rejection = rejectCrossOrigin(request);
+  if (rejection) { rejection.headers.set("Cache-Control", "no-store"); return rejection; }
+  const project = request.nextUrl.searchParams.get("project");
+  if (!project || project.length > 256) return NextResponse.json({ error: "INVALID_REQUEST", message: "project is required" }, { status: 400, headers });
+  try {
+    return NextResponse.json({ ok: true, board: boardFor(project) }, { headers });
+  } catch (error) {
+    if (error instanceof BoardStoreError) return NextResponse.json({ error: "INTERNAL_ERROR", message: "board state unavailable" }, { status: 500, headers });
+    return NextResponse.json({ error: "INTERNAL_ERROR", message: "internal error" }, { status: 500, headers });
+  }
+}
+
+export async function PATCH(request: NextRequest): Promise<NextResponse> {
+  const rejection = rejectCrossOrigin(request);
+  if (rejection) { rejection.headers.set("Cache-Control", "no-store"); return rejection; }
+  try {
+    const payload = await validateBoardPatchRequest(request);
+    const result = patchBoard(payload.project, payload.baseRevision, payload.patch);
+    if (!result.ok) return NextResponse.json({ error: "BOARD_REVISION_CONFLICT", board: result.board }, { status: 409, headers });
+    return NextResponse.json({ ok: true, board: result.board }, { headers });
+  } catch (error) {
+    if (error instanceof ViewValidationError) return NextResponse.json({ error: error.code, message: error.message }, { status: error.status, headers });
+    if (error instanceof BoardStoreError) return NextResponse.json({ error: "INTERNAL_ERROR", message: "board state unavailable" }, { status: 500, headers });
+    return NextResponse.json({ error: "INTERNAL_ERROR", message: "internal error" }, { status: 500, headers });
+  }
+}

--- a/src/app/api/tmux/route.test.ts
+++ b/src/app/api/tmux/route.test.ts
@@ -51,7 +51,6 @@ mock.module("@/lib/resources", () => ({
   allowedKillTarget: () => null,
   consumeKillTarget: () => {},
 }));
-mock.module("@/lib/sameOrigin", () => ({ rejectCrossOrigin: () => null }));
 mock.module("@/lib/scanner/roots", () => ({ pathAllowed: (pathname: string) => pathname.startsWith("/allowed/") }));
 mock.module("@/lib/tmux", () => ({
   collectImagePayloads: () => ({ images: [], error: null }),

--- a/src/app/api/view/presence/route.ts
+++ b/src/app/api/view/presence/route.ts
@@ -1,0 +1,22 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { rejectCrossOrigin } from "@/lib/sameOrigin";
+import { upsertPresence } from "@/lib/view/presenceStore";
+import { readBoundedJson, validatePresence, ViewValidationError } from "@/lib/view/validation";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+const headers = { "Cache-Control": "no-store" };
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  const rejection = rejectCrossOrigin(request);
+  if (rejection) { rejection.headers.set("Cache-Control", "no-store"); return rejection; }
+  try {
+    const payload = validatePresence(await readBoundedJson(request));
+    const result = upsertPresence(payload);
+    return NextResponse.json({ ok: true, accepted: result.accepted, viewSessionId: result.session.viewSessionId }, { headers });
+  } catch (error) {
+    const known = error instanceof ViewValidationError ? error : new ViewValidationError("INVALID_REQUEST", "invalid request");
+    return NextResponse.json({ error: known.code, message: known.message }, { status: known.status, headers });
+  }
+}

--- a/src/components/ProjectDashboard.tsx
+++ b/src/components/ProjectDashboard.tsx
@@ -3,11 +3,14 @@
 import { List, ListTodo, Menu, Network } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
 
+import { queueColumnOpen, useBoardState } from "@/hooks/useBoardState";
 import { useIsMobile } from "@/hooks/useIsMobile";
+import { viewBus } from "@/hooks/viewPresenceBus";
 import type { Flow } from "@/lib/flows/types";
 import { useLocale } from "@/lib/i18n";
 import type { BoardTask } from "@/lib/tasks/types";
 import type { FileEntry } from "@/lib/types";
+import { MAX_VISIBLE_PATHS } from "@/lib/view/types";
 import type { Workflow } from "@/lib/workflows/types";
 
 import { TaskStrip } from "./BranchPane";
@@ -79,13 +82,11 @@ interface ColumnPrefs {
   expanded: string[];
 }
 
-const prefsKey = (project: string) => `llvCols:${project}`;
 /* Conversation drafts survive remounts and reloads within the tab: an agent
-   booted from a draft keeps its waiting pane until the transcript arrives. */
+   booted from a draft keeps its waiting pane until the transcript arrives. They
+   are unspawned composer state, not shared board arrangement, so they stay
+   per-tab in sessionStorage and do not sync (#38). */
 const draftsKey = (project: string) => `llvDrafts:${project}`;
-/* Project view choice: active work opens on the scheme, quiet history opens as
-   root conversations. User selections persist per project. */
-const emptyViewKey = (project: string) => `llvEmptyView:${project}`;
 
 function loadDrafts(project: string): string[] {
   try {
@@ -96,32 +97,10 @@ function loadDrafts(project: string): string[] {
   }
 }
 
-function loadPrefs(project: string): ColumnPrefs {
-  try {
-    const raw = JSON.parse(localStorage.getItem(prefsKey(project)) ?? "{}") as Partial<ColumnPrefs>;
-    return { manual: raw.manual ?? [], hidden: raw.hidden ?? [], expanded: raw.expanded ?? [] };
-  } catch {
-    return { manual: [], hidden: [], expanded: [] };
-  }
-}
-
-/**
- * Pre-adds a conversation to its project's scheme before that project mounts.
- * A child conversation (`connected` = isChildConversation, what the tree can
- * actually nest) goes into the expand set so it renders as a node wired below
- * its parent; anything else becomes a standalone manual node. Without this
- * split, cross-project opens of a connected child would detach from its parent.
- */
-export function queueColumnOpen(project: string, path: string, connected = false) {
-  const prefs = loadPrefs(project);
-  if (connected) {
-    if (!prefs.expanded.includes(path)) prefs.expanded.push(path);
-  } else if (!prefs.manual.includes(path)) {
-    prefs.manual.push(path);
-  }
-  prefs.hidden = prefs.hidden.filter((item) => item !== path);
-  localStorage.setItem(prefsKey(project), JSON.stringify(prefs));
-}
+/* Pre-adding a conversation to a project's board before it mounts is recorded
+   against the shared board store (queued, then flushed on that project's next
+   load), so cross-project opens survive across devices — see useBoardState. */
+export { queueColumnOpen };
 
 /* Kept outside the component: the React Compiler's immutability check flags
    direct global mutation (location.hash = ...) inside a component body. */
@@ -184,42 +163,30 @@ export function ProjectDashboard({
   const isMobile = useIsMobile();
   const highlightTimer = useRef<number | null>(null);
   const pendingFocusRef = useRef<string | null>(null);
-  const [prefs, setPrefs] = useState<ColumnPrefs>({ manual: [], hidden: [], expanded: [] });
+  /* The board arrangement (which windows, hidden/expanded, view mode, task
+     panel) now lives in the shared server store, synced across devices, with a
+     one-time seed from the old per-browser localStorage (#38). Reads stay
+     optimistic — a local edit shows at once, then PATCHes. */
+  const board = useBoardState(project);
+  const prefs = useMemo<ColumnPrefs>(
+    () => ({ manual: board.prefs.manual, hidden: board.prefs.hidden, expanded: board.prefs.expanded }),
+    [board.prefs],
+  );
+  const taskPanelOpen = board.prefs.taskPanelOpen;
   const [drafts, setDrafts] = useState<string[]>([]);
-  const [emptyView, setEmptyView] = useState<{ project: string; view: ProjectView } | null>(null);
   const [highlight, setHighlight] = useState<string | null>(null);
-  const [taskPanelOpen, setTaskPanelOpen] = useState(false);
   /* Jump targets the scheme would otherwise skip (a stalled root builds no
      automatic group; a stalled branch hides inside a mini stack) materialize
      as ephemeral nodes: React state only, never written to prefs, gone on
      reload — the queue can route to its quietest members while the manual
      column state stays untouched. */
   const [ephemeral, setEphemeral] = useState<string[]>([]);
-  /* Mirrors `prefs` synchronously so the missing-nodes effect below can read
-     the value the project-switch load just set, even within the same commit
-     (state updates from sibling effects are not visible via closure yet). */
-  const prefsRef = useRef(prefs);
 
   useEffect(() => {
-    const loaded = loadPrefs(project);
-    prefsRef.current = loaded;
-    /* eslint-disable react-hooks/set-state-in-effect */
-    setPrefs(loaded);
-    setDrafts(loadDrafts(project));
-    const savedView = localStorage.getItem(emptyViewKey(project));
-    setEmptyView(savedView === "scheme" || savedView === "list" ? { project, view: savedView } : null);
-    /* eslint-enable react-hooks/set-state-in-effect */
-  }, [project, openNonce]);
-  useEffect(() => {
     /* eslint-disable-next-line react-hooks/set-state-in-effect */
-    setTaskPanelOpen(localStorage.getItem("llvTaskPanel") === "1");
-  }, []);
-  const toggleTaskPanel = () => {
-    setTaskPanelOpen((open) => {
-      localStorage.setItem("llvTaskPanel", open ? "0" : "1");
-      return !open;
-    });
-  };
+    setDrafts(loadDrafts(project));
+  }, [project, openNonce]);
+  const toggleTaskPanel = () => board.setTaskPanelOpen(!taskPanelOpen);
   useEffect(
     () => () => {
       if (highlightTimer.current) window.clearTimeout(highlightTimer.current);
@@ -227,11 +194,7 @@ export function ProjectDashboard({
     [],
   );
 
-  const persistPrefs = (next: ColumnPrefs) => {
-    prefsRef.current = next;
-    setPrefs(next);
-    localStorage.setItem(prefsKey(project), JSON.stringify(next));
-  };
+  const persistPrefs = (next: ColumnPrefs) => board.patchColumns(next);
 
   /* Reviewer transcripts of active flows live inside their round decks:
      they never build their own groups, quiet trees or residual chips. */
@@ -376,10 +339,7 @@ export function ProjectDashboard({
     sessionStorage.setItem(draftsKey(project), JSON.stringify(next));
   };
 
-  const chooseEmptyView = (next: ProjectView) => {
-    setEmptyView({ project, view: next });
-    localStorage.setItem(emptyViewKey(project), next);
-  };
+  const chooseEmptyView = (next: ProjectView) => board.setViewMode(next);
 
   /* randomUUID needs a secure context; LAN http access gets the fallback. */
   const newDraftId = () =>
@@ -460,18 +420,28 @@ export function ProjectDashboard({
     setEphemeral((prev) => (prev.includes(path) ? prev.filter((item) => item !== path) : prev));
   };
 
-  /* A node never vanishes on its own: every auto node is recorded as a
-     manual one, so a branch that goes quiet keeps its place until the user
-     closes it. Capped so old projects do not accumulate forever. */
+  /* Latest prefs behind a ref so the auto-record effect below reads current
+     board state without re-running on every prefs change (which would oscillate
+     when auto nodes exceed the 40 cap). */
+  const prefsSnapshotRef = useRef(prefs);
   useEffect(() => {
-    const prev = prefsRef.current;
+    prefsSnapshotRef.current = prefs;
+  });
+
+  /* A node never vanishes on its own: every auto node is recorded as a manual
+     one, so a branch that goes quiet keeps its place until the user closes it.
+     Capped so old projects do not accumulate forever. Runs once per auto-node
+     change (like the old localStorage path) and only after the shared board has
+     loaded, so it patches on top of the server state, not over it. */
+  useEffect(() => {
+    if (!board.loaded || board.sync === "unavailable") return;
+    const prev = prefsSnapshotRef.current;
     const missing = [...autoPaths].filter((path) => !prev.manual.includes(path) && !prev.hidden.includes(path));
     if (!missing.length) return;
-    const next = { ...prev, manual: [...prev.manual, ...missing].slice(-40) };
-    prefsRef.current = next;
-    setPrefs(next);
-    localStorage.setItem(prefsKey(project), JSON.stringify(next));
-  }, [autoPaths, project]);
+    board.patchColumns({ manual: [...prev.manual, ...missing].slice(-40), hidden: prev.hidden, expanded: prev.expanded });
+    /* eslint-disable-next-line react-hooks/exhaustive-deps -- board setters are
+       ref-stable; prefs are read from the ref, not tracked as deps */
+  }, [autoPaths, board.loaded, board.sync]);
 
   /* Any open lands on the scheme: a card of another project pre-adds its node
      and switches the project; a conversation of this project joins the managed
@@ -547,12 +517,31 @@ export function ProjectDashboard({
   const schemeAvailable = hasNodes || hasArchiveNodes;
   const listAvailable = historyRows.length > 0;
   const projectView = resolveProjectView({
-    preferredView: emptyView?.project === project ? emptyView.view : null,
+    preferredView: board.prefs.viewMode,
     hasNodes,
     hasArchiveNodes,
     hasHistoryRows: listAvailable,
   });
   const viewToggle = schemeAvailable && listAvailable;
+
+  /* Presence context: which project is open and how its durable board is
+     syncing. Reported here so every leaf's slice merges under it. */
+  useEffect(() => {
+    const revision = board.sync === "unavailable" ? null : board.revision;
+    viewBus.reportContext({ project, board: { renderedRevision: revision, durableRevision: revision, sync: board.sync } });
+  }, [project, board.revision, board.sync]);
+
+  /* Presence slice for the non-scheme leaves: the flat history list reports its
+     rows in rendered (visual) order; an empty project reports an empty view.
+     When the scheme is shown, SchemeBoard / MobileFocusView owns the slice. */
+  useEffect(() => {
+    if (projectView === "scheme" && schemeAvailable) return;
+    const visiblePaths = listAvailable ? historyRows.map((row) => row.path).slice(0, MAX_VISIBLE_PATHS) : [];
+    /* A quiet history list is "list" on either platform; a truly empty project
+       on the phone is the mobile-focus empty state. */
+    const mode = listAvailable ? "list" : isMobile ? "mobile-focus" : "list";
+    viewBus.reportSlice({ mode, focusedPath: null, selectedPaths: [], visiblePaths, camera: null });
+  }, [projectView, schemeAvailable, listAvailable, historyRows, isMobile]);
 
   return (
     <div className="relative flex min-h-0 min-w-0 flex-1 flex-col">

--- a/src/components/Viewer.tsx
+++ b/src/components/Viewer.tsx
@@ -8,6 +8,8 @@ import { useArchivedProjects } from "@/hooks/useArchivedProjects";
 import { useEffectiveFlows } from "@/components/flows/flowModel";
 import { useFiles } from "@/hooks/useFiles";
 import { useIsMobile } from "@/hooks/useIsMobile";
+import { useViewPresence } from "@/hooks/useViewPresence";
+import { OVERVIEW_CONTEXT, OVERVIEW_SLICE, viewBus } from "@/hooks/viewPresenceBus";
 import { type TFunction, useLocale } from "@/lib/i18n";
 import type { FileEntry } from "@/lib/types";
 
@@ -83,6 +85,10 @@ function attentionSnippet(t: TFunction, item: AttentionItem): string {
 
 export function Viewer() {
   const { t } = useLocale();
+  /* The one presence publisher for the whole app: it reads the shared view bus
+     that the board/scheme/mobile components report into and ships an ephemeral
+     per-tab snapshot to the server. Renders nothing. */
+  useViewPresence();
   const [project, setProject] = useState<string>(() => initialProject());
   const { files, projectCatalog, flows: polledFlows, workflows, tasks, loaded } = useFiles(project === OVERVIEW ? null : project);
   /* This tab's optimistic flow closes apply before anything renders: the X
@@ -126,6 +132,15 @@ export function Viewer() {
     writeHash(nextProject);
     setDrawerOpen(false);
   }, []);
+
+  /* The overview board has no project view state to report: presence publishes
+     the overview context/slice here, and ProjectDashboard takes over the moment
+     a project opens. */
+  useEffect(() => {
+    if (project !== OVERVIEW) return;
+    viewBus.reportContext(OVERVIEW_CONTEXT);
+    viewBus.reportSlice(OVERVIEW_SLICE);
+  }, [project]);
 
   useEffect(() => {
     if (!drawerOpen) return;

--- a/src/components/mobile/MobileFocusView.tsx
+++ b/src/components/mobile/MobileFocusView.tsx
@@ -5,10 +5,12 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { Loader2, X } from "@/components/icons";
 import { TaskSheet, type TaskSheetView } from "@/components/tasks/TaskSheet";
+import { viewBus } from "@/hooks/viewPresenceBus";
 import type { Flow } from "@/lib/flows/types";
 import { useLocale } from "@/lib/i18n";
 import type { BoardTask } from "@/lib/tasks/types";
 import type { FileEntry } from "@/lib/types";
+import { MAX_VISIBLE_PATHS } from "@/lib/view/types";
 
 import { BranchPane } from "@/components/BranchPane";
 import { DraftAgentPane } from "@/components/DraftAgentPane";
@@ -136,6 +138,20 @@ export function MobileFocusView({ project, groups, manual, files, flows, tasks, 
   const activeNode = useMemo(() => layout.nodes.find((node) => node.file.path === resolvedKey) ?? null, [layout, resolvedKey]);
   const activeDeck = useMemo(() => layout.decks.find((deck) => deck.key === resolvedKey) ?? null, [layout, resolvedKey]);
   const activeDraft = useMemo(() => layout.drafts.find((draft) => draft.key === resolvedKey) ?? null, [layout, resolvedKey]);
+
+  /* Presence: the phone reports the pinned pane as the sole visible transcript
+     (a deck/draft carries no transcript path, so focus is null there); opening
+     the map switches to mobile-map and reports the whole board in layout order.
+     The nested map camera is not surfaced to observers in this MVP. */
+  useEffect(() => {
+    const focusedPath = activeNode ? activeNode.file.path : null;
+    const visiblePaths = mapOpen
+      ? layout.nodes.slice(0, MAX_VISIBLE_PATHS).map((node) => node.file.path)
+      : activeNode
+        ? [activeNode.file.path]
+        : [];
+    viewBus.reportSlice({ mode: mapOpen ? "mobile-map" : "mobile-focus", focusedPath, selectedPaths: [], visiblePaths, camera: null });
+  }, [activeNode, mapOpen, layout]);
 
   const step = useCallback(
     (dir: number) => {

--- a/src/components/scheme/SchemeBoard.tsx
+++ b/src/components/scheme/SchemeBoard.tsx
@@ -3,10 +3,12 @@
 import { BoxSelect, Hand, Maximize2, Minus, MousePointer2, Plus, StickyNote } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
+import { cameraToPresence, orderedSelection, schemeFocusedPath, schemeVisiblePaths, viewBus } from "@/hooks/viewPresenceBus";
 import type { Flow } from "@/lib/flows/types";
 import { useLocale } from "@/lib/i18n";
 import type { BoardTask } from "@/lib/tasks/types";
 import type { FileEntry } from "@/lib/types";
+import { MAX_VISIBLE_PATHS } from "@/lib/view/types";
 
 import { appendComposerDraft } from "@/components/TmuxComposer";
 import { BranchPane } from "@/components/BranchPane";
@@ -446,6 +448,43 @@ export function SchemeBoard({
   useEffect(() => {
     camRef.current = cam;
   }, [cam]);
+
+  /* Presence: the desktop scheme reports its view slice for observation. The
+     assembler reads current state each commit through this ref, so publishing a
+     camera frame never re-renders the memoized pane layers. The mobile map
+     (mapMode) reports through MobileFocusView, so this instance stays quiet. */
+  const reportView = useRef<() => void>(() => {});
+  useEffect(() => {
+    reportView.current = () => {
+      if (mapMode) return;
+      /* A full-window expanded pane is the sole visible transcript; otherwise
+         the nodes whose rect the camera frames, in layout order. */
+      const visiblePaths = expanded ? [expanded] : schemeVisiblePaths(layout, cam, vp, MAX_VISIBLE_PATHS);
+      /* The ring can sit on a virtual layout key (a deck, draft or quiet-branch
+         stack) while spatial nav walks the board; only real transcript nodes
+         are valid focus targets, so anything else publishes as no focus. */
+      const transcriptPaths = new Set(layout.nodes.map((node) => node.file.path));
+      viewBus.reportSlice({
+        mode: "scheme",
+        focusedPath: schemeFocusedPath(expanded, selected, transcriptPaths),
+        selectedPaths: orderedSelection(layout, multi),
+        visiblePaths,
+        camera: cameraToPresence(cam, vp),
+        viewport: { width: vp.w, height: vp.h, dpr: typeof window === "undefined" ? 1 : window.devicePixelRatio || 1 },
+      });
+    };
+  });
+  /* Focus, selection, overlay and layout changes publish promptly. */
+  useEffect(() => {
+    if (!mapMode) reportView.current();
+  }, [mapMode, layout, multi, selected, expanded]);
+  /* Camera and viewport settles are debounced, mirroring the 300 ms llvCam
+     persist — a pan produces one publish after it stops, never per frame. */
+  useEffect(() => {
+    if (mapMode) return;
+    const timer = window.setTimeout(() => reportView.current(), 300);
+    return () => window.clearTimeout(timer);
+  }, [mapMode, cam, vp]);
 
   /* A wrong-target legacy edge (a failed delivery from an older build) is
      cleaned up by a click — nothing is ever re-delivered from the board. */

--- a/src/components/scheme/spatialNav.test.ts
+++ b/src/components/scheme/spatialNav.test.ts
@@ -1,17 +1,19 @@
 import { describe, expect, test } from "bun:test";
 
 import type { Camera } from "./Minimap";
-import { GAP_X, NODE_W } from "./layout";
+import { GAP_X, NODE_W, type SchemeLayout } from "./layout";
 import {
   collectNavTargets,
   LABEL_Z,
   MAX_Z,
+  navTargetLabel,
   nearestToViewportCenter,
   type NavTarget,
   nextZoomStep,
   pickDirectional,
   zoomLadderSteps,
 } from "./spatialNav";
+import { translate, type TFunction } from "@/lib/i18n";
 
 function target(key: string, x: number, y: number, w = NODE_W, h = 680): NavTarget {
   return { key, x, y, w, h };
@@ -195,5 +197,42 @@ describe("nextZoomStep", () => {
   test("ignores a step within ±1% of the current zoom", () => {
     expect(nextZoomStep(steps, 0.79, 1)).toBe(1.2);
     expect(nextZoomStep(steps, 0.79, -1)).toBe(0.59);
+  });
+});
+
+describe("navTargetLabel — screen-reader labels", () => {
+  const t: TFunction = (key, params) => translate("en", key, params);
+  /* A layout with one real node and a quiet-branch stack hanging under it. */
+  const layout = {
+    nodes: [{ file: { path: "/home/u/conv/parent.jsonl", title: "Refactor the auth module" }, tasks: [], under: [], isRoot: true, x: 0, y: 0, w: 1, h: 1 }],
+    stacks: [{ key: "/home/u/conv/parent.jsonl::stack", parent: "/home/u/conv/parent.jsonl", items: [{ file: {} }, { file: {} }, { file: {} }], x: 0, y: 0, w: 1, h: 1 }],
+    decks: [],
+    edges: [],
+    loops: [],
+    drafts: [],
+    byPath: new Map(),
+    width: 0,
+    height: 0,
+  } as unknown as SchemeLayout;
+
+  test("a real node announces its clean title", () => {
+    expect(navTargetLabel(layout, "/home/u/conv/parent.jsonl", t)).toBe("Refactor the auth module");
+  });
+
+  test("a mini-stack reads as human text — no raw path, no ::stack suffix", () => {
+    const label = navTargetLabel(layout, "/home/u/conv/parent.jsonl::stack", t);
+    expect(label).toBe("3 quiet branches under Refactor the auth module");
+    expect(label).not.toContain("::stack");
+    expect(label).not.toContain("/home/u/");
+  });
+
+  test("a single-item stack uses the singular form", () => {
+    const one = { ...layout, stacks: [{ ...(layout.stacks[0] as object), items: [{ file: {} }] }] } as unknown as SchemeLayout;
+    expect(navTargetLabel(one, "/home/u/conv/parent.jsonl::stack", t)).toBe("1 quiet branch under Refactor the auth module");
+  });
+
+  test("draft and deck keys drop their prefix (never a path)", () => {
+    expect(navTargetLabel(layout, "draft::abc-123", t)).toBe("abc-123");
+    expect(navTargetLabel(layout, "deck::flow-1", t)).toBe("flow-1");
   });
 });

--- a/src/components/scheme/spatialNav.ts
+++ b/src/components/scheme/spatialNav.ts
@@ -1,3 +1,6 @@
+import type { TFunction } from "@/lib/i18n";
+import { cleanTitle } from "@/lib/title";
+
 import type { Camera } from "./Minimap";
 import { GAP_X, NODE_W, type SchemeLayout, type SchemeRect } from "./layout";
 
@@ -84,6 +87,26 @@ export function collectNavTargets(layout: SchemeLayout): NavTarget[] {
   const out: NavTarget[] = [];
   for (const [key, rect] of layout.byPath) out.push({ key, x: rect.x, y: rect.y, w: rect.w, h: rect.h });
   return out;
+}
+
+/**
+ * Screen-reader label for a nav-target key. A real conversation node announces
+ * its clean title; virtual layout keys must never leak a filesystem path or a
+ * raw `::stack` suffix — a quiet-branch stack reads as "N quiet branches under
+ * <parent title>", and drafts/decks drop their `draft::`/`deck::` prefix.
+ */
+export function navTargetLabel(layout: SchemeLayout, key: string, t: TFunction): string {
+  const node = layout.nodes.find((n) => n.file.path === key);
+  if (node) return cleanTitle(node.file.title, 80);
+  const stack = layout.stacks.find((s) => s.key === key);
+  if (stack) {
+    const parent = layout.nodes.find((n) => n.file.path === stack.parent);
+    const title = parent ? cleanTitle(parent.file.title, 60) : null;
+    return title
+      ? t("scheme.navStack", { count: stack.items.length, title })
+      : t("scheme.navStackBare", { count: stack.items.length });
+  }
+  return key.replace(/^(?:draft|deck)::/, "");
 }
 
 const overlap1D = (a0: number, a1: number, b0: number, b1: number) => Math.min(a1, b1) - Math.max(a0, b0);

--- a/src/components/scheme/useSpatialNav.ts
+++ b/src/components/scheme/useSpatialNav.ts
@@ -7,6 +7,7 @@ import type { SchemeLayout, SchemeRect } from "./layout";
 import {
   collectNavTargets,
   keyToDir,
+  navTargetLabel,
   nearestToViewportCenter,
   type NavDir,
   nextZoomStep,
@@ -14,7 +15,7 @@ import {
   planReflow,
   zoomLadderSteps,
 } from "./spatialNav";
-import { cleanTitle } from "@/components/utils";
+import { useLocale } from "@/lib/i18n";
 
 interface SpatialNavOptions {
   /** Nav is live only on the desktop board with no session/overlay/map mode. */
@@ -92,6 +93,7 @@ export function useSpatialNav({
   glideFrame,
   manualNonce,
 }: SpatialNavOptions): SpatialNav {
+  const { t } = useLocale();
   const followRef = useRef(false);
   /* The anchor's rect at its last known layout, tagged with its key, so a
      relayout yields a delta only when it is still the same anchor (a selection
@@ -111,6 +113,7 @@ export function useSpatialNav({
   const glideByRef = useRef(glideBy);
   const glideFrameRef = useRef(glideFrame);
   const setSelectedRef = useRef(setSelected);
+  const tRef = useRef(t);
   useEffect(() => {
     enabledRef.current = enabled;
     layoutRef.current = layout;
@@ -121,13 +124,10 @@ export function useSpatialNav({
     glideByRef.current = glideBy;
     glideFrameRef.current = glideFrame;
     setSelectedRef.current = setSelected;
+    tRef.current = t;
   });
 
-  const labelFor = useCallback((key: string): string => {
-    const node = layoutRef.current.nodes.find((n) => n.file.path === key);
-    if (node) return cleanTitle(node.file.title, 80);
-    return key.replace(/^(?:draft|deck)::/, "");
-  }, []);
+  const labelFor = useCallback((key: string): string => navTargetLabel(layoutRef.current, key, tRef.current), []);
 
   /* Land on a target: anchor it, centre it (zoom unchanged), seed the reflow
      baseline, ring it, and announce it. */

--- a/src/hooks/useBoardState.test.ts
+++ b/src/hooks/useBoardState.test.ts
@@ -1,0 +1,264 @@
+import { beforeEach, expect, test } from "bun:test";
+
+import type { BoardProjectStateV1 } from "@/lib/view/types";
+
+import {
+  createBoardStore,
+  EMPTY_BOARD_PREFS,
+  isEmptyPrefs,
+  isMeaningfulPrefs,
+  mergePatch,
+  queueColumnOpen,
+  readLegacyPrefs,
+  resetPendingOpensForTest,
+  type BoardPrefs,
+} from "./useBoardState";
+
+const settle = async () => {
+  for (let i = 0; i < 16; i += 1) await Promise.resolve();
+};
+
+const prefsWith = (over: Partial<BoardPrefs>): BoardPrefs => ({ ...EMPTY_BOARD_PREFS, ...over });
+const boardOf = (revision: number, prefs: Partial<BoardPrefs> = {}): BoardProjectStateV1 => ({ schemaVersion: 1, revision, updatedAt: new Date(0).toISOString(), prefs: prefsWith(prefs) });
+
+/** In-memory board API: mirrors the real GET/PATCH revision semantics. */
+function fakeServer(seed: Record<string, BoardProjectStateV1> = {}) {
+  const projects: Record<string, BoardProjectStateV1> = { ...seed };
+  const read = (project: string) => projects[project] ?? boardOf(0);
+  let patchCount = 0;
+  const fetcher = async (input: string, init?: RequestInit) => {
+    if (!init || (init.method ?? "GET") === "GET") {
+      const project = new URL(input, "http://x").searchParams.get("project")!;
+      return { ok: true, status: 200, json: async () => ({ ok: true, board: read(project) }) };
+    }
+    patchCount += 1;
+    const body = JSON.parse(String(init.body)) as { project: string; baseRevision: number; patch: Partial<BoardPrefs> };
+    const current = read(body.project);
+    if (current.revision !== body.baseRevision) return { ok: false, status: 409, json: async () => ({ error: "BOARD_REVISION_CONFLICT", board: current }) };
+    const next = boardOf(current.revision + 1, { ...current.prefs, ...body.patch });
+    projects[body.project] = next;
+    return { ok: true, status: 200, json: async () => ({ ok: true, board: next }) };
+  };
+  /* Simulate another device landing an accepted PATCH. */
+  const bump = (project: string, patch: Partial<BoardPrefs>) => {
+    const current = read(project);
+    projects[project] = boardOf(current.revision + 1, { ...current.prefs, ...patch });
+  };
+  return { projects, fetcher, bump, patchCount: () => patchCount };
+}
+
+const idleScheduler = () => {
+  let pollFn = () => {};
+  /* Captured backoff timers: never fire on their own, so a test drives PATCH
+     retry deterministically with runTimeouts() instead of wall-clock waiting. */
+  const timeouts: Array<(() => void) | null> = [];
+  return {
+    scheduler: {
+      setInterval: (fn: () => void) => ((pollFn = fn), 1 as unknown as ReturnType<typeof setInterval>),
+      clearInterval: () => {},
+      setTimeout: (fn: () => void) => (timeouts.push(fn), timeouts.length as unknown as ReturnType<typeof setTimeout>),
+      clearTimeout: (handle: ReturnType<typeof setTimeout>) => {
+        const index = (handle as unknown as number) - 1;
+        if (timeouts[index]) timeouts[index] = null;
+      },
+    },
+    tick: () => pollFn(),
+    /** Fire every pending backoff timer once, in schedule order. */
+    runTimeouts: () => {
+      const due = timeouts.splice(0);
+      for (const fn of due) fn?.();
+    },
+    pendingTimeouts: () => timeouts.filter((fn) => fn !== null).length,
+  };
+};
+
+beforeEach(() => resetPendingOpensForTest());
+
+test("prefs emptiness and meaningfulness", () => {
+  expect(isEmptyPrefs(EMPTY_BOARD_PREFS)).toBe(true);
+  expect(isMeaningfulPrefs(EMPTY_BOARD_PREFS)).toBe(false);
+  expect(isMeaningfulPrefs(prefsWith({ manual: ["/a"] }))).toBe(true);
+  expect(isMeaningfulPrefs(prefsWith({ viewMode: "list" }))).toBe(true);
+  expect(isMeaningfulPrefs(prefsWith({ taskPanelOpen: true }))).toBe(true);
+});
+
+test("readLegacyPrefs reconstructs the three old localStorage tiers", () => {
+  const map = new Map<string, string>([
+    ["llvCols:proj", JSON.stringify({ manual: ["/a"], hidden: ["/b"], expanded: ["/c"] })],
+    ["llvEmptyView:proj", "list"],
+    ["llvTaskPanel", "1"],
+  ]);
+  const storage = { getItem: (key: string) => map.get(key) ?? null };
+  expect(readLegacyPrefs("proj", storage)).toEqual({ manual: ["/a"], hidden: ["/b"], expanded: ["/c"], viewMode: "list", taskPanelOpen: true });
+  expect(readLegacyPrefs("other", storage)).toEqual({ manual: [], hidden: [], expanded: [], viewMode: null, taskPanelOpen: true });
+  expect(readLegacyPrefs("proj", { getItem: () => null })).toBeNull();
+});
+
+test("mergePatch lets later keys win", () => {
+  expect(mergePatch({ manual: ["/a"] }, { hidden: ["/b"] })).toEqual({ manual: ["/a"], hidden: ["/b"] });
+  expect(mergePatch({ taskPanelOpen: false }, { taskPanelOpen: true })).toEqual({ taskPanelOpen: true });
+  expect(mergePatch(null, { viewMode: "scheme" })).toEqual({ viewMode: "scheme" });
+});
+
+test("loads and adopts the server board", async () => {
+  const server = fakeServer({ proj: boardOf(4, { manual: ["/a"], viewMode: "scheme" }) });
+  const store = createBoardStore({ project: "proj", fetcher: server.fetcher, storage: null, scheduler: idleScheduler().scheduler });
+  await settle();
+  expect(store.getSnapshot()).toMatchObject({ revision: 4, sync: "current", loaded: true, prefs: prefsWith({ manual: ["/a"], viewMode: "scheme" }) });
+  store.dispose();
+});
+
+test("one-time migration seeds revision 0 from legacy localStorage", async () => {
+  const server = fakeServer(); // proj is uninitialized (revision 0, empty)
+  const storage = { getItem: (key: string) => (key === "llvCols:proj" ? JSON.stringify({ manual: ["/seed"], hidden: [], expanded: [] }) : null) };
+  const store = createBoardStore({ project: "proj", fetcher: server.fetcher, storage, scheduler: idleScheduler().scheduler });
+  await settle();
+  /* The seed is written as revision 1 and becomes the shared source of truth. */
+  expect(server.projects.proj.revision).toBe(1);
+  expect(server.projects.proj.prefs.manual).toEqual(["/seed"]);
+  expect(store.getSnapshot()).toMatchObject({ revision: 1, sync: "current", prefs: prefsWith({ manual: ["/seed"] }) });
+  store.dispose();
+});
+
+test("an edit queued during the legacy seed PATCH drains as soon as the seed lands", async () => {
+  const server = fakeServer(); // proj uninitialized (revision 0, empty)
+  const storage = { getItem: (key: string) => (key === "llvCols:proj" ? JSON.stringify({ manual: ["/seed"], hidden: [], expanded: [] }) : null) };
+  /* Gate the seed PATCH open so an edit can be queued while it is inflight. */
+  let releaseSeed = () => {};
+  const seedGate = new Promise<void>((resolve) => (releaseSeed = resolve));
+  let patchCount = 0;
+  const fetcher = async (input: string, init?: RequestInit) => {
+    if (!init || (init.method ?? "GET") === "GET") return server.fetcher(input, init);
+    patchCount += 1;
+    if (patchCount === 1) await seedGate; // hold the seed PATCH inflight
+    return server.fetcher(input, init);
+  };
+  const store = createBoardStore({ project: "proj", fetcher, storage, scheduler: idleScheduler().scheduler });
+  await settle(); // load(): GET resolves, the seed PATCH is now inflight and gated
+  store.patch({ viewMode: "list" }); // queued while the seed is inflight (drain early-returns)
+  expect(store.getSnapshot().prefs.viewMode).toBe("list"); // optimistic
+  releaseSeed();
+  await settle();
+  /* Without the post-seed drain the edit stays stranded (patchCount === 1) until
+     a later edit; it must flush as soon as the seed completes. */
+  expect(patchCount).toBe(2);
+  expect(store.getSnapshot()).toMatchObject({ sync: "current", prefs: prefsWith({ manual: ["/seed"], viewMode: "list" }) });
+  expect(server.projects.proj.prefs.viewMode).toBe("list");
+  expect(server.projects.proj.prefs.manual).toEqual(["/seed"]);
+  store.dispose();
+});
+
+test("an empty legacy state leaves the server uninitialized", async () => {
+  const server = fakeServer();
+  const store = createBoardStore({ project: "proj", fetcher: server.fetcher, storage: { getItem: () => null }, scheduler: idleScheduler().scheduler });
+  await settle();
+  expect(server.patchCount()).toBe(0);
+  expect(store.getSnapshot()).toMatchObject({ revision: 0, sync: "current" });
+  store.dispose();
+});
+
+test("a patch applies optimistically, then bumps the revision", async () => {
+  const server = fakeServer({ proj: boardOf(2) });
+  const store = createBoardStore({ project: "proj", fetcher: server.fetcher, storage: null, scheduler: idleScheduler().scheduler });
+  await settle();
+  store.patch({ viewMode: "list" });
+  /* Immediately visible, before the PATCH resolves. */
+  expect(store.getSnapshot().prefs.viewMode).toBe("list");
+  expect(store.getSnapshot().sync).toBe("pending");
+  await settle();
+  expect(store.getSnapshot()).toMatchObject({ revision: 3, sync: "current", prefs: prefsWith({ viewMode: "list" }) });
+  store.dispose();
+});
+
+test("a revision conflict rebases exactly once onto the server state", async () => {
+  const server = fakeServer({ proj: boardOf(1) });
+  const store = createBoardStore({ project: "proj", fetcher: server.fetcher, storage: null, scheduler: idleScheduler().scheduler });
+  await settle();
+  /* Another device advances the board after this store loaded at revision 1. */
+  server.bump("proj", { hidden: ["/other"] }); // now revision 2
+  store.patch({ manual: ["/mine"] }); // still thinks base is 1 → 409 → rebase onto 2
+  await settle();
+  const snap = store.getSnapshot();
+  expect(snap.revision).toBe(3);
+  expect(snap.sync).toBe("current");
+  /* Rebase kept the other device's change and replayed this intent on top. */
+  expect(snap.prefs.hidden).toEqual(["/other"]);
+  expect(snap.prefs.manual).toEqual(["/mine"]);
+  store.dispose();
+});
+
+test("polling adopts a change another device made", async () => {
+  const server = fakeServer({ proj: boardOf(1, { manual: ["/a"] }) });
+  const poll = idleScheduler();
+  const store = createBoardStore({ project: "proj", fetcher: server.fetcher, storage: null, scheduler: poll.scheduler });
+  await settle();
+  expect(store.getSnapshot().revision).toBe(1);
+  server.bump("proj", { manual: ["/a", "/b"] }); // revision 2 elsewhere
+  poll.tick();
+  await settle();
+  expect(store.getSnapshot()).toMatchObject({ revision: 2, prefs: prefsWith({ manual: ["/a", "/b"] }) });
+  store.dispose();
+});
+
+test("a cross-project queued open is flushed when its board loads", async () => {
+  const server = fakeServer({ proj: boardOf(3) });
+  queueColumnOpen("proj", "/opened", false); // recorded before the project mounts
+  const store = createBoardStore({ project: "proj", fetcher: server.fetcher, storage: null, scheduler: idleScheduler().scheduler });
+  await settle();
+  expect(store.getSnapshot().prefs.manual).toEqual(["/opened"]);
+  expect(server.projects.proj.prefs.manual).toEqual(["/opened"]);
+  store.dispose();
+});
+
+test("a PATCH network error backs off instead of spinning, then recovers", async () => {
+  const backing = fakeServer({ proj: boardOf(1) });
+  let failPatches = true;
+  let patchAttempts = 0;
+  /* Wrap the fake server: PATCH throws (a real network error attempt() catches)
+     while the network is down, and every PATCH attempt is counted. */
+  const fetcher = async (input: string, init?: RequestInit) => {
+    if (init && (init.method ?? "GET") !== "GET") {
+      patchAttempts += 1;
+      if (failPatches) throw new Error("network down");
+    }
+    return backing.fetcher(input, init);
+  };
+  const sched = idleScheduler();
+  const store = createBoardStore({ project: "proj", fetcher, storage: null, scheduler: sched.scheduler });
+  await settle();
+
+  store.patch({ viewMode: "list" });
+  await settle();
+  /* The regression: exactly one attempt, not a tight microtask storm. The old
+     code re-drained synchronously and reached thousands of attempts here. */
+  expect(patchAttempts).toBe(1);
+  /* Optimistic prefs survive the failure and a single backoff timer is armed. */
+  expect(store.getSnapshot().prefs.viewMode).toBe("list");
+  expect(store.getSnapshot().sync).toBe("pending");
+  expect(sched.pendingTimeouts()).toBe(1);
+
+  /* Backoff fires while still down: one more attempt, still bounded, re-armed. */
+  sched.runTimeouts();
+  await settle();
+  expect(patchAttempts).toBe(2);
+  expect(sched.pendingTimeouts()).toBe(1);
+
+  /* Network heals; the next backoff flushes the queued patch and lands it. */
+  failPatches = false;
+  sched.runTimeouts();
+  await settle();
+  expect(patchAttempts).toBe(3);
+  expect(store.getSnapshot()).toMatchObject({ revision: 2, sync: "current", prefs: prefsWith({ viewMode: "list" }) });
+  /* Recovery cancels the backoff — no timer left spinning. */
+  expect(sched.pendingTimeouts()).toBe(0);
+  store.dispose();
+});
+
+test("a connected open is queued into the expand set", async () => {
+  const server = fakeServer({ proj: boardOf(0) });
+  queueColumnOpen("proj", "/child", true);
+  const store = createBoardStore({ project: "proj", fetcher: server.fetcher, storage: null, scheduler: idleScheduler().scheduler });
+  await settle();
+  expect(store.getSnapshot().prefs.expanded).toEqual(["/child"]);
+  store.dispose();
+});

--- a/src/hooks/useBoardState.ts
+++ b/src/hooks/useBoardState.ts
@@ -1,0 +1,393 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+import type { BoardProjectStateV1 } from "@/lib/view/types";
+
+export type BoardPrefs = BoardProjectStateV1["prefs"];
+export type BoardViewMode = BoardPrefs["viewMode"];
+export type BoardSync = "current" | "pending" | "stale" | "unavailable";
+
+const POLL_MS = 10_000;
+/* Bounded PATCH retry after a network error. Re-draining synchronously spins
+   thousands of failed requests in a single microtask turn and starves every
+   timer (#11 review), so a failed flush waits a growing, capped, cancellable
+   backoff and recovery cancels it. */
+const RETRY_BASE_MS = 1_000;
+const RETRY_MAX_MS = 30_000;
+
+export const EMPTY_BOARD_PREFS: BoardPrefs = { manual: [], hidden: [], expanded: [], viewMode: null, taskPanelOpen: false };
+
+/* Legacy per-browser keys #38 migrates off of. `llvTaskPanel` is global today;
+   it seeds every project's per-project panel state and is left intact so a
+   rollback keeps working. */
+const legacyColumnsKey = (project: string) => `llvCols:${project}`;
+const legacyViewKey = (project: string) => `llvEmptyView:${project}`;
+const LEGACY_TASK_PANEL_KEY = "llvTaskPanel";
+
+export interface BoardSnapshot {
+  prefs: BoardPrefs;
+  revision: number;
+  sync: BoardSync;
+  loaded: boolean;
+}
+
+export function isEmptyPrefs(prefs: BoardPrefs): boolean {
+  return prefs.manual.length === 0 && prefs.hidden.length === 0 && prefs.expanded.length === 0 && prefs.viewMode === null && !prefs.taskPanelOpen;
+}
+
+/** Worth seeding the server with: anything a user actually arranged. Empty
+    defaults leave the server uninitialized so the first real device wins. */
+export function isMeaningfulPrefs(prefs: BoardPrefs): boolean {
+  return !isEmptyPrefs(prefs);
+}
+
+function readStringArray(raw: unknown): string[] {
+  return Array.isArray(raw) ? raw.filter((item): item is string => typeof item === "string") : [];
+}
+
+/** Reconstruct a project's arrangement from the old localStorage tiers, for the
+    one-time migration seed. Returns null when nothing legacy exists. */
+export function readLegacyPrefs(project: string, storage: Pick<Storage, "getItem"> | null): BoardPrefs | null {
+  if (!storage) return null;
+  let columns: { manual: string[]; hidden: string[]; expanded: string[] } = { manual: [], hidden: [], expanded: [] };
+  let hadColumns = false;
+  try {
+    const raw = storage.getItem(legacyColumnsKey(project));
+    if (raw) {
+      const parsed = JSON.parse(raw) as Record<string, unknown>;
+      columns = { manual: readStringArray(parsed.manual), hidden: readStringArray(parsed.hidden), expanded: readStringArray(parsed.expanded) };
+      hadColumns = true;
+    }
+  } catch {
+    /* corrupt legacy blob — treat as absent */
+  }
+  const savedView = storage.getItem(legacyViewKey(project));
+  const viewMode: BoardViewMode = savedView === "scheme" || savedView === "list" ? savedView : null;
+  const taskPanelOpen = storage.getItem(LEGACY_TASK_PANEL_KEY) === "1";
+  if (!hadColumns && viewMode === null && !taskPanelOpen) return null;
+  return { ...columns, viewMode, taskPanelOpen };
+}
+
+/** Coalesce two partial patches: later keys win, so a burst of edits collapses
+    into a single PATCH carrying the net intent. */
+export function mergePatch(base: Partial<BoardPrefs> | null, next: Partial<BoardPrefs>): Partial<BoardPrefs> {
+  return { ...(base ?? {}), ...next };
+}
+
+interface PendingOpen {
+  manual: string[];
+  expanded: string[];
+}
+/* Cross-project opens: a conversation added to a project's board before that
+   project mounts. The intent is recorded here and flushed by that project's
+   store on its next load (or at once if the store is already mounted), so the
+   opened window survives the GET/PATCH race and reaches other devices. */
+const pendingOpens = new Map<string, PendingOpen>();
+const activeStores = new Map<string, () => void>();
+
+/**
+ * Pre-add a conversation to a project's board. A child conversation (`connected`
+ * = isChildConversation, what the tree can nest) goes into the expand set so it
+ * renders wired below its parent; anything else becomes a standalone manual
+ * node. Records the intent and, if that project's board is mounted, flushes it.
+ */
+export function queueColumnOpen(project: string, path: string, connected = false): void {
+  const entry = pendingOpens.get(project) ?? { manual: [], expanded: [] };
+  if (connected) {
+    if (!entry.expanded.includes(path)) entry.expanded.push(path);
+  } else if (!entry.manual.includes(path)) {
+    entry.manual.push(path);
+  }
+  pendingOpens.set(project, entry);
+  activeStores.get(project)?.();
+}
+
+/** Test seam: clears queued cross-project opens between cases. */
+export function resetPendingOpensForTest(): void {
+  pendingOpens.clear();
+  activeStores.clear();
+}
+
+type PatchAttempt =
+  | { status: "ok"; board: BoardProjectStateV1 }
+  | { status: "conflict"; board: BoardProjectStateV1 }
+  | { status: "error" };
+
+export interface BoardStoreOptions {
+  project: string;
+  fetcher: (input: string, init?: RequestInit) => Promise<{ ok: boolean; status: number; json(): Promise<unknown> }>;
+  storage: Pick<Storage, "getItem"> | null;
+  scheduler?: {
+    setInterval(fn: () => void, ms: number): ReturnType<typeof setInterval>;
+    clearInterval(handle: ReturnType<typeof setInterval>): void;
+    setTimeout(fn: () => void, ms: number): ReturnType<typeof setTimeout>;
+    clearTimeout(handle: ReturnType<typeof setTimeout>): void;
+  };
+}
+
+export interface BoardStore {
+  getSnapshot(): BoardSnapshot;
+  subscribe(listener: () => void): () => void;
+  patch(partial: Partial<BoardPrefs>): void;
+  dispose(): void;
+}
+
+/**
+ * The per-project durable board arrangement, moved off per-browser storage into
+ * the shared server store. It loads the server state, runs the one-time legacy
+ * seed, polls for changes other devices made, and applies edits optimistically:
+ * a local patch updates the UI at once, then PATCHes; a revision conflict rebases
+ * exactly once onto the server's state before giving up to the next poll. Legacy
+ * localStorage is only read (for the seed), never written — a rollback keeps it.
+ */
+export function createBoardStore(options: BoardStoreOptions): BoardStore {
+  const { project, fetcher, storage } = options;
+  const scheduler = options.scheduler ?? {
+    setInterval: (fn, ms) => setInterval(fn, ms),
+    clearInterval: (handle) => clearInterval(handle),
+    setTimeout: (fn, ms) => setTimeout(fn, ms),
+    clearTimeout: (handle) => clearTimeout(handle),
+  };
+  const getUrl = "/api/board?project=" + encodeURIComponent(project);
+
+  let snapshot: BoardSnapshot = { prefs: EMPTY_BOARD_PREFS, revision: 0, sync: "unavailable", loaded: false };
+  let pending: Partial<BoardPrefs> | null = null;
+  let inflight = false;
+  let disposed = false;
+  let retryHandle: ReturnType<typeof scheduler.setTimeout> | null = null;
+  let retryDelay = RETRY_BASE_MS;
+  const listeners = new Set<() => void>();
+
+  const emit = () => {
+    for (const listener of listeners) listener();
+  };
+  const set = (next: Partial<BoardSnapshot>) => {
+    snapshot = { ...snapshot, ...next };
+    emit();
+  };
+  const syncFor = (): BoardSync => (inflight || pending ? "pending" : "current");
+  const adopt = (board: BoardProjectStateV1) => {
+    set({ prefs: board.prefs, revision: board.revision, sync: syncFor(), loaded: true });
+  };
+
+  const attempt = async (patch: Partial<BoardPrefs>, baseRevision: number): Promise<PatchAttempt> => {
+    try {
+      const res = await fetcher("/api/board", {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ schemaVersion: 1, project, baseRevision, patch }),
+      });
+      if (res.ok) return { status: "ok", board: ((await res.json()) as { board: BoardProjectStateV1 }).board };
+      if (res.status === 409) return { status: "conflict", board: ((await res.json()) as { board: BoardProjectStateV1 }).board };
+      return { status: "error" };
+    } catch {
+      return { status: "error" };
+    }
+  };
+
+  const applyPatch = (partial: Partial<BoardPrefs>) => {
+    /* Optimistic: reflect the edit immediately, then queue the PATCH. */
+    snapshot = { ...snapshot, prefs: { ...snapshot.prefs, ...partial }, sync: "pending" };
+    emit();
+    pending = mergePatch(pending, partial);
+    void drain();
+  };
+
+  /* Flush any cross-project opens queued for this project into a single patch.
+     Runs after the store has loaded, so it merges onto the server's arrangement
+     rather than an empty placeholder. */
+  const drainOpens = () => {
+    if (!snapshot.loaded || disposed) return;
+    const open = pendingOpens.get(project);
+    if (!open || (open.manual.length === 0 && open.expanded.length === 0)) return;
+    pendingOpens.delete(project);
+    const opened = new Set([...open.manual, ...open.expanded]);
+    applyPatch({
+      manual: [...new Set([...snapshot.prefs.manual, ...open.manual])],
+      expanded: [...new Set([...snapshot.prefs.expanded, ...open.expanded])],
+      hidden: snapshot.prefs.hidden.filter((path) => !opened.has(path)),
+    });
+  };
+
+  /* Cancel a scheduled backoff and reset the delay — called on any accepted
+     PATCH and on disposal, so a healed network starts the next failure fresh. */
+  const cancelRetry = () => {
+    if (retryHandle !== null) {
+      scheduler.clearTimeout(retryHandle);
+      retryHandle = null;
+    }
+    retryDelay = RETRY_BASE_MS;
+  };
+  /* Arm the bounded backoff after a network error: one timer at a time, delay
+     doubling up to the cap. The queued patch drains when it fires. */
+  const scheduleRetry = () => {
+    if (retryHandle !== null || disposed) return;
+    const delay = retryDelay;
+    retryDelay = Math.min(retryDelay * 2, RETRY_MAX_MS);
+    retryHandle = scheduler.setTimeout(() => {
+      retryHandle = null;
+      void drain();
+    }, delay);
+  };
+
+  const drain = async () => {
+    if (inflight || !pending || disposed) return;
+    const patch = pending;
+    pending = null;
+    inflight = true;
+    set({ sync: "pending" });
+    const first = await attempt(patch, snapshot.revision);
+    if (first.status === "ok") {
+      cancelRetry();
+      adopt(first.board);
+    } else if (first.status === "conflict") {
+      /* Rebase exactly once: take the server's state, replay this intent on top,
+         resubmit. A second conflict means another writer keeps winning — adopt
+         the server and let the poll reconcile. */
+      set({ prefs: { ...first.board.prefs, ...patch }, revision: first.board.revision });
+      const second = await attempt(patch, first.board.revision);
+      if (second.status === "ok") cancelRetry();
+      adopt(second.status === "ok" ? second.board : first.board);
+    } else {
+      /* Network error: keep the optimistic prefs and requeue, then back off on a
+         cancellable timer. Re-draining synchronously here spins thousands of
+         failed PATCHes in one microtask turn and starves every timer (#11); the
+         backoff retries and any accepted PATCH cancels it. */
+      pending = mergePatch(patch, pending ?? {});
+      inflight = false;
+      set({ sync: syncFor() });
+      scheduleRetry();
+      return;
+    }
+    inflight = false;
+    set({ sync: syncFor() });
+    if (pending) void drain();
+  };
+
+  const load = async () => {
+    let board: BoardProjectStateV1 | null = null;
+    try {
+      const res = await fetcher(getUrl);
+      if (res.ok) board = ((await res.json()) as { board: BoardProjectStateV1 }).board;
+    } catch {
+      board = null;
+    }
+    if (disposed) return;
+    if (!board) {
+      set({ sync: "unavailable", loaded: true });
+      return;
+    }
+    if (board.revision === 0 && isEmptyPrefs(board.prefs)) {
+      const seed = readLegacyPrefs(project, storage);
+      if (seed && isMeaningfulPrefs(seed)) {
+        set({ prefs: seed, revision: 0, sync: "pending", loaded: true });
+        inflight = true;
+        const result = await attempt(seed, 0);
+        inflight = false;
+        if (!disposed) {
+          adopt(result.status === "error" ? board : result.board);
+          /* An edit made while the seed PATCH was inflight parked in `pending`
+             (drain early-returns during inflight); flush it now instead of
+             leaving it stranded until the next edit. */
+          if (pending) void drain();
+        }
+        return;
+      }
+    }
+    adopt(board);
+  };
+
+  const poll = () => {
+    if (inflight || pending || disposed) return;
+    void (async () => {
+      try {
+        const res = await fetcher(getUrl);
+        if (!res.ok) return;
+        const board = ((await res.json()) as { board: BoardProjectStateV1 }).board;
+        /* Another device moved the board: adopt it, but never clobber a local
+           edit that has not yet flushed (guarded by the pending/inflight check). */
+        if (!inflight && !pending && !disposed && board.revision !== snapshot.revision) adopt(board);
+      } catch {
+        /* transient — next tick retries */
+      }
+    })();
+  };
+
+  activeStores.set(project, drainOpens);
+  void load().then(drainOpens);
+  const interval = scheduler.setInterval(poll, POLL_MS);
+
+  return {
+    getSnapshot: () => snapshot,
+    subscribe(listener) {
+      listeners.add(listener);
+      return () => listeners.delete(listener);
+    },
+    patch(partial) {
+      applyPatch(partial);
+    },
+    dispose() {
+      disposed = true;
+      cancelRetry();
+      if (activeStores.get(project) === drainOpens) activeStores.delete(project);
+      scheduler.clearInterval(interval);
+      listeners.clear();
+    },
+  };
+}
+
+const UNAVAILABLE_SNAPSHOT: BoardSnapshot = { prefs: EMPTY_BOARD_PREFS, revision: 0, sync: "unavailable", loaded: false };
+
+export interface BoardState extends BoardSnapshot {
+  patchColumns(columns: Pick<BoardPrefs, "manual" | "hidden" | "expanded">): void;
+  setViewMode(viewMode: BoardViewMode): void;
+  setTaskPanelOpen(open: boolean): void;
+}
+
+/**
+ * React binding over `createBoardStore`: one store per project, its snapshot
+ * mirrored into component state. `project === null` (overview) has no board — it
+ * returns the unavailable snapshot with inert setters.
+ */
+export function useBoardState(project: string | null): BoardState {
+  const storeRef = useRef<BoardStore | null>(null);
+  const [snapshot, setSnapshot] = useState<BoardSnapshot>(UNAVAILABLE_SNAPSHOT);
+
+  useEffect(() => {
+    if (typeof window === "undefined" || project === null) {
+      storeRef.current = null;
+      /* eslint-disable-next-line react-hooks/set-state-in-effect */
+      setSnapshot(UNAVAILABLE_SNAPSHOT);
+      return;
+    }
+    let storage: Pick<Storage, "getItem"> | null = null;
+    try {
+      storage = window.localStorage;
+    } catch {
+      storage = null;
+    }
+    const store = createBoardStore({ project, fetcher: (input, init) => fetch(input, init), storage });
+    storeRef.current = store;
+    setSnapshot(store.getSnapshot());
+    const unsubscribe = store.subscribe(() => setSnapshot(store.getSnapshot()));
+    return () => {
+      unsubscribe();
+      store.dispose();
+      storeRef.current = null;
+    };
+  }, [project]);
+
+  return {
+    ...snapshot,
+    patchColumns(columns) {
+      storeRef.current?.patch(columns);
+    },
+    setViewMode(viewMode) {
+      storeRef.current?.patch({ viewMode });
+    },
+    setTaskPanelOpen(open) {
+      storeRef.current?.patch({ taskPanelOpen: open });
+    },
+  };
+}

--- a/src/hooks/useViewPresence.test.ts
+++ b/src/hooks/useViewPresence.test.ts
@@ -1,0 +1,272 @@
+import { expect, test } from "bun:test";
+
+import { mergeView, OVERVIEW_CONTEXT, OVERVIEW_SLICE, type RenderedViewState } from "./viewPresenceBus";
+import {
+  buildPresencePayload,
+  createPresencePublisher,
+  detectBrowser,
+  detectDeviceKind,
+  newViewSessionId,
+  stableDeviceId,
+  type PresenceIdentity,
+  type PresenceResponse,
+  type PresenceScheduler,
+} from "./useViewPresence";
+
+const identity: PresenceIdentity = { viewSessionId: "vs-1", deviceId: "dev-1", device: { kind: "desktop", browser: "chrome" } };
+const view = (mode: RenderedViewState["mode"] = "scheme"): RenderedViewState =>
+  mergeView({ project: "proj", board: { renderedRevision: 3, durableRevision: 3, sync: "current" } }, { ...OVERVIEW_SLICE, mode, visiblePaths: ["a"] }, { width: 800, height: 600, dpr: 1 });
+
+const settle = async () => {
+  for (let i = 0; i < 12; i += 1) await Promise.resolve();
+};
+
+function fakeScheduler() {
+  let now = 0;
+  let id = 0;
+  const timers = new Map<number, { at: number; fn: () => void }>();
+  const scheduler: PresenceScheduler = {
+    now: () => now,
+    setTimer: (fn, ms) => {
+      const handle = ++id;
+      timers.set(handle, { at: now + ms, fn });
+      return handle;
+    },
+    clearTimer: (handle) => void timers.delete(handle as number),
+  };
+  return {
+    scheduler,
+    async advance(ms: number) {
+      now += ms;
+      let progressed = true;
+      while (progressed) {
+        progressed = false;
+        for (const [handle, timer] of [...timers.entries()].sort((a, b) => a[1].at - b[1].at)) {
+          if (timer.at <= now) {
+            timers.delete(handle);
+            timer.fn();
+            progressed = true;
+            break;
+          }
+        }
+        await settle();
+      }
+    },
+  };
+}
+
+function recordingFetcher() {
+  const calls: Array<{ payload: ReturnType<typeof buildPresencePayload>; init: RequestInit }> = [];
+  /* "ok" → 200; "throw" → network error; a number → that HTTP status. */
+  let mode: "ok" | "throw" | number = "ok";
+  let drained = 0;
+  const fetcher = async (_input: string, init: RequestInit): Promise<PresenceResponse> => {
+    calls.push({ payload: JSON.parse(String(init.body)), init });
+    if (mode === "throw") throw new Error("network down");
+    const status = mode === "ok" ? 200 : mode;
+    return {
+      ok: status >= 200 && status < 300,
+      status,
+      text: async () => {
+        drained += 1;
+        return "";
+      },
+    };
+  };
+  return {
+    calls,
+    fetcher,
+    drained: () => drained,
+    setOk: () => (mode = "ok"),
+    setThrow: () => (mode = "throw"),
+    setStatus: (status: number) => (mode = status),
+    /* Back-compat with the existing failure test. */
+    setFail: (value: boolean) => (mode = value ? "throw" : "ok"),
+  };
+}
+
+test("detectBrowser and detectDeviceKind classify common agents", () => {
+  expect(detectBrowser("Mozilla/5.0 Chrome/130 Safari/537")).toBe("chrome");
+  expect(detectBrowser("Mozilla/5.0 Firefox/130")).toBe("firefox");
+  expect(detectBrowser("Mozilla/5.0 Version/17 Safari/605")).toBe("safari");
+  expect(detectBrowser("Mozilla/5.0 Chrome/130 Edg/130")).toBe("other");
+  expect(detectDeviceKind("iPhone; Mobile Safari", false, 390)).toBe("mobile");
+  expect(detectDeviceKind("iPad; Safari", true, 1024)).toBe("tablet");
+  expect(detectDeviceKind("X11; Linux Chrome", false, 1600)).toBe("desktop");
+});
+
+test("view session id is fresh per call; device id is stable in storage", () => {
+  expect(newViewSessionId()).not.toBe(newViewSessionId());
+  const map = new Map<string, string>();
+  const storage = { getItem: (k: string) => map.get(k) ?? null, setItem: (k: string, v: string) => void map.set(k, v) };
+  const first = stableDeviceId(storage);
+  expect(stableDeviceId(storage)).toBe(first);
+});
+
+test("buildPresencePayload stamps identity, counters and visibility onto the view", () => {
+  const payload = buildPresencePayload(view(), identity, 7, 4, "hidden");
+  expect(payload.schemaVersion).toBe(1);
+  expect(payload.viewSessionId).toBe("vs-1");
+  expect(payload.sequence).toBe(7);
+  expect(payload.inputSequence).toBe(4);
+  expect(payload.visibility).toBe("hidden");
+  expect(payload.visiblePaths).toEqual(["a"]);
+  expect(payload.project).toBe("proj");
+});
+
+test("sequence is monotonic and inputSequence only advances after an interaction", async () => {
+  const clock = fakeScheduler();
+  const net = recordingFetcher();
+  const pub = createPresencePublisher({ identity, fetcher: net.fetcher, scheduler: clock.scheduler });
+  pub.setView(view());
+  pub.start(); // start publishes once immediately
+  await clock.advance(0);
+  expect(net.calls).toHaveLength(1);
+  expect(net.calls[0].payload.sequence).toBe(1);
+  expect(net.calls[0].payload.inputSequence).toBe(0);
+
+  pub.markInteraction();
+  pub.setView(view("list"));
+  await clock.advance(500); // interaction debounce
+  expect(net.calls).toHaveLength(2);
+  expect(net.calls[1].payload.sequence).toBe(2);
+  expect(net.calls[1].payload.inputSequence).toBe(1); // advanced by the interaction
+
+  await clock.advance(10_000); // heartbeat, no interaction
+  expect(net.calls[2].payload.sequence).toBe(3);
+  expect(net.calls[2].payload.inputSequence).toBe(1); // unchanged
+});
+
+test("rate limit: two publishes never land within 500ms of each other", async () => {
+  const clock = fakeScheduler();
+  const net = recordingFetcher();
+  const pub = createPresencePublisher({ identity, fetcher: net.fetcher, scheduler: clock.scheduler });
+  pub.start();
+  await clock.advance(0);
+  expect(net.calls).toHaveLength(1);
+  /* A visibility flip asks for an immediate publish, but the floor holds it. */
+  pub.setVisibility("hidden");
+  await clock.advance(200);
+  expect(net.calls).toHaveLength(1);
+  await clock.advance(300); // now 500ms since the first send
+  expect(net.calls).toHaveLength(2);
+  expect(net.calls[1].payload.visibility).toBe("hidden");
+});
+
+test("routine publishes carry no keepalive and always drain the response body", async () => {
+  const clock = fakeScheduler();
+  const net = recordingFetcher();
+  const pub = createPresencePublisher({ identity, fetcher: net.fetcher, scheduler: clock.scheduler });
+  pub.start();
+  await clock.advance(0);
+  expect(net.calls).toHaveLength(1);
+  /* keepalive:true exhausts Chrome's 64 KB quota under a 10 s heartbeat. */
+  expect("keepalive" in net.calls[0].init).toBe(false);
+  /* The body is consumed so a non-keepalive socket is freed. */
+  expect(net.drained()).toBe(1);
+});
+
+test("a 4xx rejects the payload terminally — no retry loop, a later change still publishes", async () => {
+  const clock = fakeScheduler();
+  const net = recordingFetcher();
+  const pub = createPresencePublisher({ identity, fetcher: net.fetcher, scheduler: clock.scheduler });
+  net.setStatus(400);
+  pub.start();
+  await clock.advance(0);
+  expect(net.calls).toHaveLength(1); // attempted, deterministically rejected
+  /* No 2/sec retry storm on the identical body: nothing before the 10 s heartbeat. */
+  await clock.advance(9000);
+  expect(net.calls).toHaveLength(1);
+  /* A genuinely new view publishes a fresh (different) payload. */
+  net.setOk();
+  pub.markInteraction();
+  pub.setView(view("list"));
+  await clock.advance(500);
+  expect(net.calls).toHaveLength(2);
+  expect(net.calls[1].payload.mode).toBe("list");
+});
+
+test("network failures back off exponentially, then recover on success", async () => {
+  const clock = fakeScheduler();
+  const net = recordingFetcher();
+  const pub = createPresencePublisher({ identity, fetcher: net.fetcher, scheduler: clock.scheduler });
+  net.setThrow();
+  pub.start();
+  await clock.advance(0);
+  expect(net.calls).toHaveLength(1); // t=0 attempt threw
+  /* Step 1 ≈ 1 s: nothing just before, a retry at the boundary. */
+  await clock.advance(999);
+  expect(net.calls).toHaveLength(1);
+  await clock.advance(1); // t=1000
+  expect(net.calls).toHaveLength(2);
+  /* Step 2 doubles to ≈ 2 s. */
+  await clock.advance(1999);
+  expect(net.calls).toHaveLength(2);
+  await clock.advance(1); // t=3000
+  expect(net.calls).toHaveLength(3);
+  /* Recovery: the next retry (≈ 4 s later) succeeds and clears the backoff. */
+  net.setOk();
+  await clock.advance(4000); // t=7000
+  const healthy = net.calls.length;
+  expect(healthy).toBeGreaterThanOrEqual(4);
+  /* No lingering error loop after success — nothing until the 10 s heartbeat. */
+  await clock.advance(500);
+  expect(net.calls.length).toBe(healthy);
+});
+
+test("a hidden tab keeps heartbeating its last-known slice as visibility:hidden", async () => {
+  const clock = fakeScheduler();
+  const net = recordingFetcher();
+  const pub = createPresencePublisher({ identity, fetcher: net.fetcher, scheduler: clock.scheduler });
+  pub.setView(view());
+  pub.start();
+  await clock.advance(0);
+  pub.setVisibility("hidden");
+  await clock.advance(500); // the honest hidden publish, held by the 500 ms floor
+  const hiddenAt = net.calls.length;
+  expect(net.calls.at(-1)!.payload.visibility).toBe("hidden");
+  /* The heartbeat is not gated on visibility: a backgrounded tab keeps the
+     session retainable on the server (Terra owns the freshness window). */
+  await clock.advance(10_000);
+  expect(net.calls.length).toBeGreaterThan(hiddenAt);
+  expect(net.calls.at(-1)!.payload.visibility).toBe("hidden");
+});
+
+test("a failed POST is retried on the next tick without losing a sequence", async () => {
+  const clock = fakeScheduler();
+  const net = recordingFetcher();
+  const pub = createPresencePublisher({ identity, fetcher: net.fetcher, scheduler: clock.scheduler });
+  net.setFail(true);
+  pub.start();
+  await clock.advance(0);
+  expect(net.calls).toHaveLength(1); // attempted, threw
+  net.setFail(false);
+  await clock.advance(10_000); // heartbeat retries
+  const sequences = net.calls.map((call) => call.payload.sequence);
+  /* Strictly increasing across the failed attempt and the retry. */
+  for (let i = 1; i < sequences.length; i += 1) expect(sequences[i]).toBeGreaterThan(sequences[i - 1]!);
+  expect(net.calls.at(-1)!.payload.sequence).toBeGreaterThanOrEqual(2);
+});
+
+test("sendBeacon publishes a final hidden snapshot", () => {
+  const clock = fakeScheduler();
+  const net = recordingFetcher();
+  const beacons: string[] = [];
+  const pub = createPresencePublisher({ identity, fetcher: net.fetcher, scheduler: clock.scheduler, beacon: (_url, body) => (beacons.push(body), true) });
+  pub.setView(view());
+  pub.sendBeacon();
+  expect(beacons).toHaveLength(1);
+  expect(JSON.parse(beacons[0]!).visibility).toBe("hidden");
+});
+
+test("identical views do not trigger a redundant publish", async () => {
+  const clock = fakeScheduler();
+  const net = recordingFetcher();
+  const pub = createPresencePublisher({ identity, fetcher: net.fetcher, scheduler: clock.scheduler });
+  pub.start();
+  await clock.advance(0);
+  const before = net.calls.length;
+  pub.setView(mergeView(OVERVIEW_CONTEXT, OVERVIEW_SLICE, { width: 1, height: 1, dpr: 1 })); // same as the publisher's initial default
+  await clock.advance(1000);
+  expect(net.calls.length).toBe(before);
+});

--- a/src/hooks/useViewPresence.ts
+++ b/src/hooks/useViewPresence.ts
@@ -1,0 +1,385 @@
+"use client";
+
+import { useEffect } from "react";
+
+import { VIEW_SCHEMA_VERSION, type BrowserKind, type DeviceKind, type PresencePayloadV1 } from "@/lib/view/types";
+
+import {
+  mergeView,
+  OVERVIEW_CONTEXT,
+  OVERVIEW_SLICE,
+  viewBus,
+  type PresenceViewport,
+  type RenderedViewState,
+} from "./viewPresenceBus";
+
+/* Exact cadence frozen by the architecture contract. */
+const HEARTBEAT_MS = 10_000;
+const INTERACTION_DEBOUNCE_MS = 500;
+/* No more than two publishes a second: a 500 ms floor between any two POSTs. */
+const MIN_GAP_MS = 500;
+/* Capped exponential backoff for network/5xx failures — a failed publish must
+   not re-fire at the 500 ms floor forever (that was a live 2 POSTs/sec error
+   loop). Any accepted or 4xx-rejected response clears it. */
+const RETRY_BASE_MS = 1_000;
+const RETRY_MAX_MS = 30_000;
+
+const DEVICE_ID_KEY = "llvDeviceId";
+
+export interface PresenceIdentity {
+  viewSessionId: string;
+  deviceId: string;
+  device: PresencePayloadV1["device"];
+}
+
+/** Fresh, in-memory per document — a reload or a duplicated tab is a new view
+    session, so two tabs never collide on one id (no recovery protocol needed). */
+export function newViewSessionId(): string {
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") return crypto.randomUUID();
+  return "vs-" + Math.random().toString(36).slice(2) + Date.now().toString(36);
+}
+
+/** Stable per device, in localStorage — survives reloads so a device keeps one
+    identity across its many view sessions. */
+export function stableDeviceId(storage: Pick<Storage, "getItem" | "setItem"> | null): string {
+  try {
+    const existing = storage?.getItem(DEVICE_ID_KEY);
+    if (existing) return existing;
+  } catch {
+    /* private-mode storage throw — fall through to an ephemeral id */
+  }
+  const fresh = newViewSessionId();
+  try {
+    storage?.setItem(DEVICE_ID_KEY, fresh);
+  } catch {
+    /* storage unavailable — the id stays ephemeral for this load */
+  }
+  return fresh;
+}
+
+export function detectBrowser(ua: string): BrowserKind {
+  const s = ua.toLowerCase();
+  if (s.includes("firefox") || s.includes("fxios")) return "firefox";
+  /* Edge and other Chromium skins are not "chrome" for our purposes. */
+  if (s.includes("edg/") || s.includes("opr/")) return "other";
+  if (s.includes("crios") || s.includes("chrome") || s.includes("chromium")) return "chrome";
+  /* Chrome's UA also contains "safari", so this must come after the chrome test. */
+  if (s.includes("safari")) return "safari";
+  return "other";
+}
+
+export function detectDeviceKind(ua: string, coarsePointer: boolean, width: number): DeviceKind {
+  const s = ua.toLowerCase();
+  if (s.includes("ipad") || (s.includes("tablet") && !s.includes("mobi")) || (coarsePointer && width >= 768 && width <= 1280)) return "tablet";
+  if (s.includes("mobi") || s.includes("iphone") || s.includes("android") || (coarsePointer && width < 768)) return "mobile";
+  return "desktop";
+}
+
+/** Build the exact wire body from the assembled view plus this document's
+    identity and the current sequence counters. Pure — the publisher owns the
+    counters, this only stamps them on. */
+export function buildPresencePayload(
+  view: RenderedViewState,
+  identity: PresenceIdentity,
+  sequence: number,
+  inputSequence: number,
+  visibility: "visible" | "hidden",
+): PresencePayloadV1 {
+  return {
+    schemaVersion: VIEW_SCHEMA_VERSION,
+    viewSessionId: identity.viewSessionId,
+    deviceId: identity.deviceId,
+    device: identity.device,
+    visibility,
+    sequence,
+    inputSequence,
+    project: view.project,
+    mode: view.mode,
+    viewport: view.viewport,
+    camera: view.camera,
+    focusedPath: view.focusedPath,
+    selectedPaths: view.selectedPaths,
+    visiblePaths: view.visiblePaths,
+    board: view.board,
+  };
+}
+
+export interface PresenceScheduler {
+  now(): number;
+  setTimer(fn: () => void, ms: number): unknown;
+  clearTimer(handle: unknown): void;
+}
+
+/** The slice of `fetch`'s Response the publisher needs: `ok`/`status` to classify
+    the outcome, plus the body handles so it can be consumed/cancelled — without
+    `keepalive` an undrained body pins the socket. The real `fetch` Response
+    satisfies this structurally; tests supply a stub. */
+export interface PresenceResponse {
+  ok: boolean;
+  status: number;
+  body?: ReadableStream<Uint8Array> | null;
+  text?: () => Promise<string>;
+}
+
+export interface PresencePublisherOptions {
+  identity: PresenceIdentity;
+  fetcher: (input: string, init: RequestInit) => Promise<PresenceResponse>;
+  scheduler: PresenceScheduler;
+  beacon?: (url: string, body: string) => boolean;
+  endpoint?: string;
+}
+
+/** Free the response body so a non-keepalive connection can be reused: cancel the
+    stream if present, else read it to completion; never throw. */
+async function drainBody(res: PresenceResponse): Promise<void> {
+  try {
+    if (res.body && typeof res.body.cancel === "function") {
+      await res.body.cancel();
+      return;
+    }
+    if (typeof res.text === "function") await res.text();
+  } catch {
+    /* already consumed, locked, or unavailable — nothing to free */
+  }
+}
+
+export interface PresencePublisher {
+  setView(view: RenderedViewState): void;
+  setVisibility(visibility: "visible" | "hidden"): void;
+  markInteraction(): void;
+  /** Republish now without counting as user input (reconnect, resize). */
+  poke(): void;
+  start(): void;
+  stop(): void;
+  /** Best-effort final publish on pagehide — marks the session hidden. */
+  sendBeacon(): void;
+}
+
+/**
+ * The single presence state machine: it owns the monotonic `sequence` /
+ * `inputSequence` counters, debounces view changes to at most one POST per
+ * 500 ms, heartbeats every 10 s, flushes immediately on visibility changes, and
+ * retries a failed POST on the next tick without losing a sequence. Timers and
+ * the fetcher are injected so the whole thing runs under a fake clock in tests.
+ */
+export function createPresencePublisher(options: PresencePublisherOptions): PresencePublisher {
+  const { identity, fetcher, scheduler, beacon, endpoint = "/api/view/presence" } = options;
+  let sequence = 0;
+  let inputSequence = 0;
+  let pendingInteraction = false;
+  let view: RenderedViewState = mergeView(OVERVIEW_CONTEXT, OVERVIEW_SLICE, { width: 1, height: 1, dpr: 1 });
+  let visibility: "visible" | "hidden" = "visible";
+  let started = false;
+  let needsFlush = false;
+  let inflight = false;
+  let lastSentAt = Number.NEGATIVE_INFINITY;
+  let debounceTimer: unknown = null;
+  let heartbeatTimer: unknown = null;
+  /* Backoff window after a network/5xx failure. `retryDelay` is the current
+     step (0 = healthy); `retryUntil` is the absolute time before which no flush
+     may fire, so a heartbeat or interaction during an outage is coalesced into
+     the backoff instead of shortening it. */
+  let retryDelay = 0;
+  let retryUntil = 0;
+
+  const backOff = () => {
+    retryDelay = retryDelay === 0 ? RETRY_BASE_MS : Math.min(retryDelay * 2, RETRY_MAX_MS);
+    retryUntil = scheduler.now() + retryDelay;
+    needsFlush = true;
+  };
+  const clearBackoff = () => {
+    retryDelay = 0;
+    retryUntil = 0;
+  };
+
+  const scheduleFlush = (immediate: boolean) => {
+    if (!started) return;
+    const base = immediate ? 0 : INTERACTION_DEBOUNCE_MS;
+    const now = scheduler.now();
+    const wait = Math.max(base, MIN_GAP_MS - (now - lastSentAt), retryUntil - now, 0);
+    if (debounceTimer !== null) scheduler.clearTimer(debounceTimer);
+    debounceTimer = scheduler.setTimer(() => {
+      debounceTimer = null;
+      void doFlush();
+    }, wait);
+  };
+
+  const requestFlush = (immediate: boolean) => {
+    needsFlush = true;
+    scheduleFlush(immediate);
+  };
+
+  const doFlush = async () => {
+    if (!needsFlush || inflight) return;
+    needsFlush = false;
+    const seq = ++sequence;
+    if (pendingInteraction) {
+      inputSequence += 1;
+      pendingInteraction = false;
+    }
+    const payload = buildPresencePayload(view, identity, seq, inputSequence, visibility);
+    inflight = true;
+    lastSentAt = scheduler.now();
+    try {
+      /* No `keepalive`: routine heartbeats every 10 s exhaust Chrome's shared
+         64 KB keepalive quota within minutes and then every POST throws. The
+         final unload publish uses navigator.sendBeacon (see sendBeacon()). */
+      const res = await fetcher(endpoint, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+      await drainBody(res);
+      if (res.ok) {
+        clearBackoff();
+      } else if (res.status >= 400 && res.status < 500) {
+        /* Deterministic rejection (e.g. a payload the validator refuses):
+           retrying the identical body loops forever. Drop this flush and clear
+           backoff — the counters stay, so the next view change publishes a
+           fresh, different payload. */
+        clearBackoff();
+      } else {
+        /* 5xx: server transient — back off. */
+        backOff();
+      }
+    } catch {
+      /* Network error: keep the counters and back off, don't hammer. */
+      backOff();
+    } finally {
+      inflight = false;
+      if (needsFlush) scheduleFlush(false);
+    }
+  };
+
+  /* The heartbeat is visibility-agnostic: a hidden tab keeps publishing its
+     last-known slice (marked `visibility:"hidden"`) so the server can retain it
+     as a background view. Chrome throttles chained timers in hidden tabs, so
+     this can only slow — the client publishes the honest hidden state and the
+     backend (Terra) owns how long a last-known-hidden session stays fresh; the
+     two coordinate solely through the `visibility` field on the DTO. */
+  const armHeartbeat = () => {
+    if (heartbeatTimer !== null) scheduler.clearTimer(heartbeatTimer);
+    heartbeatTimer = scheduler.setTimer(() => {
+      requestFlush(true);
+      armHeartbeat();
+    }, HEARTBEAT_MS);
+  };
+
+  return {
+    setView(next) {
+      if (JSON.stringify(next) === JSON.stringify(view)) return;
+      view = next;
+      requestFlush(false);
+    },
+    setVisibility(next) {
+      if (next === visibility) return;
+      visibility = next;
+      /* A tab going hidden/visible is worth an immediate, honest update. */
+      requestFlush(true);
+    },
+    markInteraction() {
+      pendingInteraction = true;
+      requestFlush(false);
+    },
+    poke() {
+      requestFlush(true);
+    },
+    start() {
+      if (started) return;
+      started = true;
+      armHeartbeat();
+      requestFlush(true);
+    },
+    stop() {
+      started = false;
+      if (debounceTimer !== null) scheduler.clearTimer(debounceTimer);
+      if (heartbeatTimer !== null) scheduler.clearTimer(heartbeatTimer);
+      debounceTimer = null;
+      heartbeatTimer = null;
+      needsFlush = false;
+      clearBackoff();
+    },
+    sendBeacon() {
+      if (!beacon) return;
+      const payload = buildPresencePayload(view, identity, ++sequence, inputSequence, "hidden");
+      try {
+        beacon(endpoint, JSON.stringify(payload));
+      } catch {
+        /* beacon unavailable — nothing more we can do on unload */
+      }
+    },
+  };
+}
+
+const INTERACTION_EVENTS = ["pointerdown", "keydown", "touchstart", "wheel"] as const;
+
+function windowViewport(): PresenceViewport {
+  return { width: window.innerWidth || 1, height: window.innerHeight || 1, dpr: window.devicePixelRatio || 1 };
+}
+
+/**
+ * Mounts the one presence publisher for the whole app (in Viewer). It resolves
+ * this document's identity, subscribes to the view bus, wires interaction /
+ * visibility / online / resize / pagehide, and drives the publisher. It renders
+ * nothing and adds no visible pixels — presence is invisible plumbing.
+ */
+export function useViewPresence(): void {
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    let storage: Storage | null = null;
+    try {
+      storage = window.localStorage;
+    } catch {
+      storage = null;
+    }
+    const coarse = typeof window.matchMedia === "function" && window.matchMedia("(pointer: coarse)").matches;
+    const identity: PresenceIdentity = {
+      viewSessionId: newViewSessionId(),
+      deviceId: stableDeviceId(storage),
+      device: {
+        kind: detectDeviceKind(navigator.userAgent, coarse, window.innerWidth || 1),
+        browser: detectBrowser(navigator.userAgent),
+      },
+    };
+    const publisher = createPresencePublisher({
+      identity,
+      fetcher: (input, init) => fetch(input, init),
+      beacon:
+        typeof navigator !== "undefined" && typeof navigator.sendBeacon === "function"
+          ? (url, body) => navigator.sendBeacon(url, new Blob([body], { type: "application/json" }))
+          : undefined,
+      scheduler: {
+        now: () => Date.now(),
+        setTimer: (fn, ms) => setTimeout(fn, ms),
+        clearTimer: (handle) => clearTimeout(handle as ReturnType<typeof setTimeout>),
+      },
+    });
+
+    const push = () => publisher.setView(mergeView(viewBus.getContext(), viewBus.getSlice(), windowViewport()));
+    const unsubscribe = viewBus.subscribe(push);
+    const onInteract = () => publisher.markInteraction();
+    for (const event of INTERACTION_EVENTS) window.addEventListener(event, onInteract, { passive: true });
+    const onVisibility = () => publisher.setVisibility(document.visibilityState === "hidden" ? "hidden" : "visible");
+    document.addEventListener("visibilitychange", onVisibility);
+    const onOnline = () => publisher.poke();
+    window.addEventListener("online", onOnline);
+    const onResize = () => push();
+    window.addEventListener("resize", onResize);
+    const onHide = () => publisher.sendBeacon();
+    window.addEventListener("pagehide", onHide);
+
+    publisher.setVisibility(document.visibilityState === "hidden" ? "hidden" : "visible");
+    push();
+    publisher.start();
+
+    return () => {
+      unsubscribe();
+      for (const event of INTERACTION_EVENTS) window.removeEventListener(event, onInteract);
+      document.removeEventListener("visibilitychange", onVisibility);
+      window.removeEventListener("online", onOnline);
+      window.removeEventListener("resize", onResize);
+      window.removeEventListener("pagehide", onHide);
+      publisher.stop();
+    };
+  }, []);
+}

--- a/src/hooks/viewPresenceBus.test.ts
+++ b/src/hooks/viewPresenceBus.test.ts
@@ -1,0 +1,115 @@
+import { expect, test } from "bun:test";
+
+import type { SchemeLayout } from "@/components/scheme/layout";
+import { MAX_SELECTED_PATHS } from "@/lib/view/types";
+
+import {
+  cameraToPresence,
+  createViewBus,
+  mergeView,
+  OVERVIEW_CONTEXT,
+  OVERVIEW_SLICE,
+  orderedSelection,
+  schemeFocusedPath,
+  schemeVisiblePaths,
+  UNAVAILABLE_BOARD,
+  worldRectFor,
+  type ViewSlice,
+} from "./viewPresenceBus";
+
+const node = (path: string, x: number, y: number, w = 100, h = 100) =>
+  ({ file: { path }, tasks: [], under: [], isRoot: false, x, y, w, h }) as unknown as SchemeLayout["nodes"][number];
+
+const layoutOf = (...nodes: SchemeLayout["nodes"]): SchemeLayout => ({ nodes }) as unknown as SchemeLayout;
+
+const vp = { w: 800, h: 600 };
+
+test("worldRect solves screen = world*zoom + camera for both viewport corners", () => {
+  const cam = { x: -200, y: -100, z: 2 };
+  const rect = worldRectFor(cam, vp);
+  /* screen (0,0) → world (100,50); screen (800,600) spans 400x300 in world. */
+  expect(rect).toEqual({ x: 100, y: 50, width: 400, height: 300 });
+  const presence = cameraToPresence(cam, vp);
+  expect(presence).toEqual({ x: -200, y: -100, zoom: 2, worldRect: rect });
+});
+
+test("visible paths are the camera-intersecting nodes in layout order", () => {
+  const layout = layoutOf(node("a", 0, 0), node("b", 500, 0), node("c", 5000, 0));
+  /* Camera framing world x∈[0,800): a and b intersect, c is far off-screen. */
+  const cam = { x: 0, y: 0, z: 1 };
+  expect(schemeVisiblePaths(layout, cam, vp, 128)).toEqual(["a", "b"]);
+});
+
+test("visible paths cap drops the freshest-last nodes", () => {
+  const layout = layoutOf(node("a", 0, 0), node("b", 100, 0), node("c", 200, 0));
+  const cam = { x: 0, y: 0, z: 1 };
+  expect(schemeVisiblePaths(layout, cam, vp, 2)).toEqual(["a", "b"]);
+});
+
+test("selection is reported in visual (layout) order regardless of set insertion", () => {
+  const layout = layoutOf(node("a", 0, 0), node("b", 100, 0), node("c", 200, 0));
+  expect(orderedSelection(layout, new Set(["c", "a"]))).toEqual(["a", "c"]);
+  expect(orderedSelection(layout, new Set())).toEqual([]);
+  /* A selected path no longer on the board drops out. */
+  expect(orderedSelection(layout, new Set(["a", "gone"]))).toEqual(["a"]);
+});
+
+test("selection is capped at MAX_SELECTED_PATHS in visual order before publishing", () => {
+  /* A marquee over more panes than the server accepts (65 > 64) must not make
+     every presence POST 400 — the bus caps it in layout order. */
+  const nodes = Array.from({ length: 70 }, (_, i) => node(`p${String(i).padStart(2, "0")}`, i * 100, 0));
+  const layout = layoutOf(...nodes);
+  const all = new Set(nodes.map((n) => n.file.path));
+  const out = orderedSelection(layout, all);
+  expect(out.length).toBe(MAX_SELECTED_PATHS);
+  /* Kept the freshest-first (left) run; dropped the freshest-last off the right. */
+  expect(out[0]).toBe("p00");
+  expect(out.at(-1)).toBe(`p${String(MAX_SELECTED_PATHS - 1).padStart(2, "0")}`);
+});
+
+test("focus precedence: expanded overlay wins over a real transcript ring", () => {
+  const transcripts = new Set(["/x", "/y"]);
+  expect(schemeFocusedPath("/x", "/y", transcripts)).toBe("/x");
+  expect(schemeFocusedPath(null, "/y", transcripts)).toBe("/y");
+  expect(schemeFocusedPath(null, null, transcripts)).toBeNull();
+});
+
+test("a ring on a virtual layout key focuses nothing (never leaks PATH_OUTSIDE_CURRENT_VIEW)", () => {
+  /* Spatial nav rings deck/stack/draft keys, which are not scanner transcripts;
+     publishing one as focusedPath makes composeSnapshot reject the whole
+     snapshot, so schemeFocusedPath filters them to null. */
+  const transcripts = new Set(["/a", "/b"]);
+  expect(schemeFocusedPath(null, "deck::flow-1", transcripts)).toBeNull();
+  expect(schemeFocusedPath(null, "/a::stack", transcripts)).toBeNull();
+  expect(schemeFocusedPath(null, "draft::123", transcripts)).toBeNull();
+  /* A real transcript ring still publishes, and an overlay still wins even when
+     the ring underneath it is a virtual key. */
+  expect(schemeFocusedPath(null, "/a", transcripts)).toBe("/a");
+  expect(schemeFocusedPath("/b", "deck::flow-1", transcripts)).toBe("/b");
+});
+
+test("mergeView takes the slice viewport when present, else the window viewport", () => {
+  const windowVp = { width: 1000, height: 900, dpr: 1 };
+  const slice: ViewSlice = { mode: "scheme", focusedPath: "a", selectedPaths: ["a"], visiblePaths: ["a", "b"], camera: cameraToPresence({ x: 0, y: 0, z: 1 }, vp), viewport: { width: 800, height: 600, dpr: 2 } };
+  const merged = mergeView({ project: "proj", board: UNAVAILABLE_BOARD }, slice, windowVp);
+  expect(merged.project).toBe("proj");
+  expect(merged.viewport).toEqual({ width: 800, height: 600, dpr: 2 });
+  const overview = mergeView(OVERVIEW_CONTEXT, OVERVIEW_SLICE, windowVp);
+  expect(overview.viewport).toEqual(windowVp);
+  expect(overview.mode).toBe("overview");
+  expect(overview.camera).toBeNull();
+});
+
+test("the bus notifies only on a real change and merges context under the slice", () => {
+  const bus = createViewBus();
+  let notifications = 0;
+  bus.subscribe(() => (notifications += 1));
+  bus.reportContext({ project: "p", board: UNAVAILABLE_BOARD });
+  bus.reportContext({ project: "p", board: UNAVAILABLE_BOARD }); // identical → dropped
+  bus.reportSlice({ mode: "list", focusedPath: null, selectedPaths: [], visiblePaths: ["a"], camera: null });
+  expect(notifications).toBe(2);
+  const merged = mergeView(bus.getContext(), bus.getSlice(), { width: 1, height: 1, dpr: 1 });
+  expect(merged.project).toBe("p");
+  expect(merged.mode).toBe("list");
+  expect(merged.visiblePaths).toEqual(["a"]);
+});

--- a/src/hooks/viewPresenceBus.ts
+++ b/src/hooks/viewPresenceBus.ts
@@ -1,0 +1,195 @@
+"use client";
+
+import type { SchemeLayout, SchemeRect } from "@/components/scheme/layout";
+import { MAX_SELECTED_PATHS, type PresencePayloadV1 } from "@/lib/view/types";
+
+/* The client-assembled view the presence publisher ships to the server: every
+   non-identity field of the wire DTO, so the hook only has to stamp identity,
+   sequence and visibility on top. Reusing PresencePayloadV1 keeps this in lock
+   step with Terra's validator — a field renamed there breaks the build here. */
+export type RenderedViewState = Pick<
+  PresencePayloadV1,
+  "project" | "mode" | "focusedPath" | "selectedPaths" | "visiblePaths" | "camera" | "viewport" | "board"
+>;
+
+export type PresenceCamera = PresencePayloadV1["camera"];
+export type PresenceBoard = PresencePayloadV1["board"];
+export type PresenceViewport = PresencePayloadV1["viewport"];
+export type ViewMode = PresencePayloadV1["mode"];
+
+/** Minimal camera shape the scheme camera engine exposes (`{x,y,z}`). */
+export interface CameraLike {
+  x: number;
+  y: number;
+  z: number;
+}
+
+/* The board arrangement lives outside a project view (overview) or before the
+   store answers: presence still publishes, marked unavailable. */
+export const UNAVAILABLE_BOARD: PresenceBoard = { renderedRevision: null, durableRevision: null, sync: "unavailable" };
+
+/** Cross-cutting fields owned by the shell: which project is open and how its
+    durable board arrangement is syncing. Merged under every leaf's slice. */
+export interface ViewContext {
+  project: string | null;
+  board: PresenceBoard;
+}
+
+/** The active leaf's view: what is focused, selected and visible right now, plus
+    the camera/viewport for spatial modes. `viewport` is optional — only the
+    scheme board reports its own canvas size; every other mode inherits the
+    window viewport the publisher supplies. */
+export interface ViewSlice {
+  mode: ViewMode;
+  focusedPath: string | null;
+  selectedPaths: string[];
+  visiblePaths: string[];
+  camera: PresenceCamera;
+  viewport?: PresenceViewport;
+}
+
+export const OVERVIEW_CONTEXT: ViewContext = { project: null, board: UNAVAILABLE_BOARD };
+export const OVERVIEW_SLICE: ViewSlice = {
+  mode: "overview",
+  focusedPath: null,
+  selectedPaths: [],
+  visiblePaths: [],
+  camera: null,
+};
+
+export type WorldRect = NonNullable<PresenceCamera>["worldRect"];
+
+/** Visible world box: solving `screen = world * zoom + {x,y}` for the two screen
+    corners `(0,0)` and `(vp.w, vp.h)`. */
+export function worldRectFor(cam: CameraLike, vp: { w: number; h: number }): WorldRect {
+  const zoom = cam.z || 1;
+  return { x: -cam.x / zoom, y: -cam.y / zoom, width: vp.w / zoom, height: vp.h / zoom };
+}
+
+/** Camera published for observation: the device's own frame, never used to
+    drive another device's rendering (per-device camera stays authoritative). */
+export function cameraToPresence(cam: CameraLike, vp: { w: number; h: number }): PresenceCamera {
+  return { x: cam.x, y: cam.y, zoom: cam.z, worldRect: worldRectFor(cam, vp) };
+}
+
+function intersects(rect: SchemeRect, world: { x: number; y: number; width: number; height: number }): boolean {
+  return rect.x < world.x + world.width && rect.x + rect.w > world.x && rect.y < world.y + world.height && rect.y + rect.h > world.y;
+}
+
+/**
+ * The scheme's visible transcripts, in layout order (groups left→right
+ * freshest-first, depth-first within a group). A node counts as visible when
+ * its world rect intersects the camera's world rect. Capped so an extreme
+ * zoom-out never publishes more than the wire limit; the cap drops the
+ * furthest-right (freshest-last) nodes, matching what falls off screen last.
+ */
+export function schemeVisiblePaths(layout: SchemeLayout, cam: CameraLike, vp: { w: number; h: number }, cap: number): string[] {
+  const world = worldRectFor(cam, vp);
+  const out: string[] = [];
+  for (const node of layout.nodes) {
+    if (intersects(node, world)) out.push(node.file.path);
+    if (out.length >= cap) break;
+  }
+  return out;
+}
+
+/** Lasso selection in visual order: the layout node order filtered to the set.
+    A path that has left the board drops out (the set is transcript paths, so a
+    relayout keeps membership for free). Capped at MAX_SELECTED_PATHS in visual
+    order — the server rejects a larger selection outright (400), so a marquee
+    over 65+ panes must not kill every presence POST; the freshest-last nodes
+    off the right are dropped, matching the visible-paths cap. */
+export function orderedSelection(layout: SchemeLayout, selected: ReadonlySet<string>): string[] {
+  if (selected.size === 0) return [];
+  const out: string[] = [];
+  for (const node of layout.nodes) {
+    if (selected.has(node.file.path)) {
+      out.push(node.file.path);
+      if (out.length >= MAX_SELECTED_PATHS) break;
+    }
+  }
+  return out;
+}
+
+/** Desktop focus precedence: the full-window expanded pane wins over the single
+    selection ring. Both must be real transcript paths. The ring can land on a
+    virtual layout key while spatial navigation walks the board — a review-round
+    deck (`deck::<flow>`), a not-yet-spawned draft (`draft::<id>`), or a
+    quiet-branch stack (`<path>::stack`) — none of which is a scanner transcript.
+    Publishing such a key as `focusedPath` makes the server reject the entire
+    snapshot with PATH_OUTSIDE_CURRENT_VIEW, so a ring on a virtual key focuses
+    nothing. `transcriptPaths` is the set of real conversation node paths in the
+    current layout. */
+export function schemeFocusedPath(expanded: string | null, ringed: string | null, transcriptPaths: ReadonlySet<string>): string | null {
+  if (expanded !== null) return expanded;
+  if (ringed !== null && transcriptPaths.has(ringed)) return ringed;
+  return null;
+}
+
+/** Stable structural compare for the small view objects — avoids notifying the
+    publisher (and re-POSTing) when a report reproduces the current value, which
+    is what keeps per-frame camera settles from spamming the network. */
+function sameShape(a: unknown, b: unknown): boolean {
+  return JSON.stringify(a) === JSON.stringify(b);
+}
+
+/** Merge the shell context and the active leaf slice into the full view. The
+    leaf's viewport wins (the scheme canvas size); otherwise the window viewport
+    the publisher passes is used, so camera-less modes still report a viewport. */
+export function mergeView(context: ViewContext, slice: ViewSlice, windowViewport: PresenceViewport): RenderedViewState {
+  return {
+    project: context.project,
+    board: context.board,
+    mode: slice.mode,
+    focusedPath: slice.focusedPath,
+    selectedPaths: slice.selectedPaths,
+    visiblePaths: slice.visiblePaths,
+    camera: slice.camera,
+    viewport: slice.viewport ?? windowViewport,
+  };
+}
+
+export interface ViewBus {
+  reportContext(next: ViewContext): void;
+  reportSlice(next: ViewSlice): void;
+  getContext(): ViewContext;
+  getSlice(): ViewSlice;
+  subscribe(listener: () => void): () => void;
+}
+
+/**
+ * The module-level merger every view component reports into: the shell reports
+ * context (project + board sync), the active leaf reports its slice, and the
+ * single publisher mounted in Viewer subscribes once. No prop-drilling and no
+ * render coupling — a report that reproduces the current value is dropped, so
+ * publishing a camera frame never cascades a React render through the tree.
+ */
+export function createViewBus(): ViewBus {
+  let context: ViewContext = OVERVIEW_CONTEXT;
+  let slice: ViewSlice = OVERVIEW_SLICE;
+  const listeners = new Set<() => void>();
+  const notify = () => {
+    for (const listener of listeners) listener();
+  };
+  return {
+    reportContext(next) {
+      if (sameShape(context, next)) return;
+      context = next;
+      notify();
+    },
+    reportSlice(next) {
+      if (sameShape(slice, next)) return;
+      slice = next;
+      notify();
+    },
+    getContext: () => context,
+    getSlice: () => slice,
+    subscribe(listener) {
+      listeners.add(listener);
+      return () => listeners.delete(listener);
+    },
+  };
+}
+
+/** The app-wide singleton. Components import this; tests build isolated buses. */
+export const viewBus: ViewBus = createViewBus();

--- a/src/lib/board/store.test.ts
+++ b/src/lib/board/store.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { boardFor, BoardStoreError, patchBoard } from "./store";
+import { validateBoardPatchRequest } from "./validation";
+
+function temporaryFile(): string { return path.join(fs.mkdtempSync(path.join(os.tmpdir(), "llv-board-")), "board.json"); }
+
+describe("board store", () => {
+  test("increments revisions atomically and rejects stale concurrent writers", () => {
+    const file = temporaryFile();
+    expect(boardFor("viewer", file).revision).toBe(0);
+    const first = patchBoard("viewer", 0, { manual: ["/a"] }, file);
+    expect(first).toMatchObject({ ok: true, board: { revision: 1 } });
+    const stale = patchBoard("viewer", 0, { hidden: ["/a"] }, file);
+    expect(stale).toMatchObject({ ok: false, board: { revision: 1 } });
+    expect(boardFor("viewer", file).prefs.manual).toEqual(["/a"]);
+  });
+  test("fails closed on corrupt durable state and preserves its bytes", () => {
+    const file = temporaryFile();
+    fs.mkdirSync(path.dirname(file), { recursive: true });
+    fs.writeFileSync(file, "{ corrupt", "utf8");
+    expect(() => boardFor("viewer", file)).toThrow(BoardStoreError);
+    expect(() => patchBoard("viewer", 0, { manual: ["/a"] }, file)).toThrow(BoardStoreError);
+    expect(fs.readFileSync(file, "utf8")).toBe("{ corrupt");
+  });
+  test("accepts missing storage as revision-zero initialization", () => {
+    expect(boardFor("viewer", temporaryFile())).toMatchObject({ revision: 0, prefs: { manual: [] } });
+  });
+  test("strict bounded PATCH validation rejects unknown and empty changes", async () => {
+    const request = (body: unknown) => new Request("http://127.0.0.1:8898/api/board", { method: "PATCH", headers: { "content-type": "application/json" }, body: JSON.stringify(body) });
+    await expect(validateBoardPatchRequest(request({ schemaVersion: 1, project: "viewer", baseRevision: 0, patch: { surprise: true } }))).rejects.toMatchObject({ code: "INVALID_REQUEST" });
+    await expect(validateBoardPatchRequest(request({ schemaVersion: 1, project: "viewer", baseRevision: 0, patch: {} }))).rejects.toMatchObject({ code: "INVALID_REQUEST" });
+    const parsed = await validateBoardPatchRequest(request({ schemaVersion: 1, project: "viewer", baseRevision: 0, patch: { taskPanelOpen: true } }));
+    expect(parsed.patch).toEqual({ taskPanelOpen: true });
+  });
+});

--- a/src/lib/board/store.ts
+++ b/src/lib/board/store.ts
@@ -1,0 +1,60 @@
+import crypto from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+
+import { statePath } from "@/lib/configDir";
+
+import type { BoardFileV1, BoardProjectStateV1 } from "@/lib/view/types";
+
+export const BOARD_FILE = statePath("board.json");
+const EMPTY_PREFS: BoardProjectStateV1["prefs"] = { manual: [], hidden: [], expanded: [], viewMode: null, taskPanelOpen: false };
+
+export class BoardStoreError extends Error {
+  constructor(message = "board state unavailable") { super(message); }
+}
+
+function stringArray(value: unknown): value is string[] { return Array.isArray(value) && value.every((item) => typeof item === "string"); }
+function projectState(value: unknown): value is BoardProjectStateV1 {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  const state = value as Partial<BoardProjectStateV1>;
+  const prefs = state.prefs;
+  return state.schemaVersion === 1 && Number.isInteger(state.revision) && state.revision! >= 0 && typeof state.updatedAt === "string" && Boolean(prefs) &&
+    stringArray(prefs!.manual) && stringArray(prefs!.hidden) && stringArray(prefs!.expanded) &&
+    (prefs!.viewMode === null || prefs!.viewMode === "scheme" || prefs!.viewMode === "list") && typeof prefs!.taskPanelOpen === "boolean";
+}
+
+function emptyBoard(): BoardProjectStateV1 {
+  return { schemaVersion: 1, revision: 0, updatedAt: new Date(0).toISOString(), prefs: { ...EMPTY_PREFS, manual: [], hidden: [], expanded: [] } };
+}
+
+function read(filePath: string): BoardFileV1 {
+  try {
+    const parsed = JSON.parse(fs.readFileSync(filePath, "utf8")) as Partial<BoardFileV1>;
+    if (!parsed || typeof parsed.projects !== "object" || parsed.projects === null || Array.isArray(parsed.projects)) throw new BoardStoreError("invalid board state");
+    if (!Object.values(parsed.projects).every(projectState)) throw new BoardStoreError("invalid board project state");
+    return { projects: parsed.projects };
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return { projects: {} };
+    if (error instanceof BoardStoreError) throw error;
+    throw new BoardStoreError();
+  }
+}
+function write(value: BoardFileV1, filePath: string): void {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  const temp = path.join(path.dirname(filePath), `.${path.basename(filePath)}.${process.pid}.${crypto.randomUUID()}.tmp`);
+  fs.writeFileSync(temp, JSON.stringify(value, null, 2) + "\n", "utf8");
+  fs.renameSync(temp, filePath);
+}
+export function boardFor(project: string, filePath = BOARD_FILE): BoardProjectStateV1 {
+  return read(filePath).projects[project] ?? emptyBoard();
+}
+export type BoardPatch = Partial<BoardProjectStateV1["prefs"]>;
+export function patchBoard(project: string, baseRevision: number, patch: BoardPatch, filePath = BOARD_FILE): { ok: true; board: BoardProjectStateV1 } | { ok: false; board: BoardProjectStateV1 } {
+  const value = read(filePath);
+  const current = value.projects[project] ?? emptyBoard();
+  if (current.revision !== baseRevision) return { ok: false, board: current };
+  const next: BoardProjectStateV1 = { schemaVersion: 1, revision: current.revision + 1, updatedAt: new Date().toISOString(), prefs: { ...current.prefs, ...patch } };
+  value.projects[project] = next;
+  write(value, filePath);
+  return { ok: true, board: next };
+}

--- a/src/lib/board/types.ts
+++ b/src/lib/board/types.ts
@@ -1,0 +1,1 @@
+export type { BoardFileV1, BoardProjectStateV1 } from "@/lib/view/types";

--- a/src/lib/board/validation.ts
+++ b/src/lib/board/validation.ts
@@ -1,0 +1,42 @@
+import type { BoardProjectStateV1 } from "@/lib/view/types";
+import { readBoundedJson, ViewValidationError } from "@/lib/view/validation";
+
+export const MAX_BOARD_BODY_BYTES = 32 * 1024;
+export type BoardPatch = Partial<BoardProjectStateV1["prefs"]>;
+
+function exact(value: Record<string, unknown>, allowed: readonly string[], field: string): void {
+  const unknown = Object.keys(value).find((key) => !allowed.includes(key));
+  if (unknown) throw new ViewValidationError("INVALID_REQUEST", `unknown ${field}.${unknown}`);
+}
+function record(value: unknown, field: string): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) throw new ViewValidationError("INVALID_REQUEST", `invalid ${field}`);
+  return value as Record<string, unknown>;
+}
+function pathList(value: unknown, field: string): string[] {
+  if (!Array.isArray(value) || value.length > 512 || value.some((item) => typeof item !== "string" || item.length === 0 || item.length > 4096)) throw new ViewValidationError("INVALID_REQUEST", `invalid ${field}`);
+  if (new Set(value).size !== value.length) throw new ViewValidationError("INVALID_REQUEST", `duplicate ${field}`);
+  return value as string[];
+}
+
+export async function validateBoardPatchRequest(request: Request): Promise<{ project: string; baseRevision: number; patch: BoardPatch }> {
+  const body = record(await readBoundedJson(request, MAX_BOARD_BODY_BYTES), "request");
+  exact(body, ["schemaVersion", "project", "baseRevision", "patch"], "request");
+  if (body.schemaVersion !== 1) throw new ViewValidationError("UNSUPPORTED_SCHEMA_VERSION", "schemaVersion must be 1");
+  if (typeof body.project !== "string" || body.project.length === 0 || body.project.length > 256) throw new ViewValidationError("INVALID_REQUEST", "invalid project");
+  if (!Number.isInteger(body.baseRevision) || (body.baseRevision as number) < 0) throw new ViewValidationError("INVALID_REQUEST", "invalid baseRevision");
+  const rawPatch = record(body.patch, "patch"); exact(rawPatch, ["manual", "hidden", "expanded", "viewMode", "taskPanelOpen"], "patch");
+  if (Object.keys(rawPatch).length === 0) throw new ViewValidationError("INVALID_REQUEST", "empty patch");
+  const patch: BoardPatch = {};
+  if (rawPatch.manual !== undefined) patch.manual = pathList(rawPatch.manual, "patch.manual");
+  if (rawPatch.hidden !== undefined) patch.hidden = pathList(rawPatch.hidden, "patch.hidden");
+  if (rawPatch.expanded !== undefined) patch.expanded = pathList(rawPatch.expanded, "patch.expanded");
+  if (rawPatch.viewMode !== undefined) {
+    if (rawPatch.viewMode !== null && rawPatch.viewMode !== "scheme" && rawPatch.viewMode !== "list") throw new ViewValidationError("INVALID_REQUEST", "invalid patch.viewMode");
+    patch.viewMode = rawPatch.viewMode;
+  }
+  if (rawPatch.taskPanelOpen !== undefined) {
+    if (typeof rawPatch.taskPanelOpen !== "boolean") throw new ViewValidationError("INVALID_REQUEST", "invalid patch.taskPanelOpen");
+    patch.taskPanelOpen = rawPatch.taskPanelOpen;
+  }
+  return { project: body.project, baseRevision: body.baseRevision as number, patch };
+}

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -509,6 +509,9 @@ export const en = {
   "scheme.roleWaiting": "waiting",
   "scheme.lassoTool": "Multi-select — draw a box around agents, click cards to toggle",
   "scheme.boardAria": "Agent board — arrow keys move between agent windows",
+  // Screen-reader announcement when the arrow keys land on a quiet-branch stack.
+  "scheme.navStack": { one: "{count} quiet branch under {title}", other: "{count} quiet branches under {title}" },
+  "scheme.navStackBare": { one: "{count} quiet branch", other: "{count} quiet branches" },
 
   // scheme/BulkActionBar (selection session)
   "bulk.selectedCount": { one: "{count} selected", other: "{count} selected" },

--- a/src/lib/i18n/uk.ts
+++ b/src/lib/i18n/uk.ts
@@ -482,6 +482,8 @@ export const uk: Record<keyof typeof en, Message> = {
   "scheme.roleWaiting": "чекає",
   "scheme.lassoTool": "Вибірка — обведи агентів рамкою, кліком додавай чи знімай",
   "scheme.boardAria": "Дошка агентів — стрілки переміщують між вікнами агентів",
+  "scheme.navStack": { one: "{count} тиха гілка під {title}", few: "{count} тихі гілки під {title}", many: "{count} тихих гілок під {title}", other: "{count} тихих гілок під {title}" },
+  "scheme.navStackBare": { one: "{count} тиха гілка", few: "{count} тихі гілки", many: "{count} тихих гілок", other: "{count} тихих гілок" },
 
   "bulk.selectedCount": { one: "Вибрано {count}", few: "Вибрано {count}", many: "Вибрано {count}", other: "Вибрано {count}" },
   "bulk.placeholder": "одне повідомлення кожному вибраному агенту…",

--- a/src/lib/scanner/links.test.ts
+++ b/src/lib/scanner/links.test.ts
@@ -172,4 +172,15 @@ describe("linkEntries", () => {
 
     expect(child.parent as string | null).toBe(parent.path);
   });
+
+  test("pure linking leaves scanner state files byte-identical", async () => {
+    const stateFiles = ["codex-lineage.json", "handoff-lineage.json", "worktree-map.json"].map((name) => path.join(SANDBOX, name));
+    const before = stateFiles.map((file) => fs.existsSync(file) ? fs.readFileSync(file) : null);
+    const parent = entry("/home/user/.codex/sessions/pure-parent.jsonl", { pid: 700 });
+    const child = entry("/home/user/.codex/sessions/pure-child.jsonl", { pid: 900 });
+    parentByPid = new Map([[900, 800], [800, 700], [700, null]]);
+    await linkEntries([parent, child], { persist: false });
+    expect(child.parent).toBe(parent.path);
+    expect(stateFiles.map((file) => fs.existsSync(file) ? fs.readFileSync(file) : null)).toEqual(before);
+  });
 });

--- a/src/lib/scanner/links.ts
+++ b/src/lib/scanner/links.ts
@@ -294,7 +294,7 @@ function persistLineage(): void {
   }
 }
 
-function attachNativeCodexSubagentParents(entries: FileEntry[]): void {
+function attachNativeCodexSubagentParents(entries: FileEntry[], persist: boolean): void {
   loadLineage();
   const pathByThreadId = new Map<string, string>();
   for (const entry of entries) {
@@ -308,10 +308,10 @@ function attachNativeCodexSubagentParents(entries: FileEntry[]): void {
     const parent = parentThreadId ? (pathByThreadId.get(parentThreadId) ?? null) : null;
     if (parent && parent !== entry.path) {
       entry.parent = parent;
-      rememberLineage(entry.path, parent);
+      if (persist) rememberLineage(entry.path, parent);
     }
   }
-  persistLineage();
+  if (persist) persistLineage();
 }
 
 /**
@@ -320,7 +320,7 @@ function attachNativeCodexSubagentParents(entries: FileEntry[]): void {
  * is the spawner: the nearest Claude or Codex ancestor owns the child rollout.
  * This is a spawn-lineage fact; no mtime or project heuristics participate.
  */
-function attachLiveCodexParents(entries: FileEntry[]): void {
+function attachLiveCodexParents(entries: FileEntry[], persist: boolean): void {
   loadLineage();
   const orphans = entries.filter((entry) => entry.root === "codex-sessions" && !entry.parent);
   if (orphans.length === 0) return;
@@ -344,14 +344,14 @@ function attachLiveCodexParents(entries: FileEntry[]): void {
     }
     if (resolved) {
       rollout.parent = resolved;
-      rememberLineage(rollout.path, resolved);
+      if (persist) rememberLineage(rollout.path, resolved);
     } else {
       // pid is gone or ancestry dead-ended: reuse the parent proven while live.
       const remembered = lineageCache.get(rollout.path);
       if (remembered) rollout.parent = remembered;
     }
   }
-  persistLineage();
+  if (persist) persistLineage();
 }
 
 /**
@@ -362,7 +362,7 @@ function attachLiveCodexParents(entries: FileEntry[]): void {
  * The `handoff` flag makes the UI treat the child as a branch of its source
  * rather than a compaction predecessor.
  */
-function attachHandoffParents(entries: FileEntry[]): void {
+function attachHandoffParents(entries: FileEntry[], persist: boolean): void {
   const byPath = new Map(entries.map((entry) => [entry.path, entry]));
   for (const entry of entries) {
     if (entry.parent) continue;
@@ -377,17 +377,18 @@ function attachHandoffParents(entries: FileEntry[]): void {
         parent = handoffParentForPid(pid);
         if (parent) break;
       }
-      if (parent && parent !== entry.path) rememberHandoffChild(entry.path, parent);
+      if (persist && parent && parent !== entry.path) rememberHandoffChild(entry.path, parent);
     }
     if (parent && parent !== entry.path && byPath.has(parent)) {
       entry.parent = parent;
       entry.handoff = true;
     }
   }
-  persistHandoffLineage();
+  if (persist) persistHandoffLineage();
 }
 
-export async function linkEntries(entries: FileEntry[]): Promise<void> {
+export async function linkEntries(entries: FileEntry[], options: { persist?: boolean } = {}): Promise<void> {
+  const persist = options.persist !== false;
   const limit = createLimiter(48);
   const byPath = new Map(entries.map((entry) => [entry.path, entry]));
   for (const entry of entries) {
@@ -435,9 +436,9 @@ export async function linkEntries(entries: FileEntry[]): Promise<void> {
       }
     }
   }
-  attachNativeCodexSubagentParents(entries);
-  attachLiveCodexParents(entries);
-  attachHandoffParents(entries);
+  attachNativeCodexSubagentParents(entries, persist);
+  attachLiveCodexParents(entries, persist);
+  attachHandoffParents(entries, persist);
   chainCompactedSessions(entries);
   const rootProject = (entry: FileEntry): string => {
     const seen = new Set<string>();
@@ -454,5 +455,5 @@ export async function linkEntries(entries: FileEntry[]): Promise<void> {
     if (!entry.parent || !byPath.has(entry.parent)) entry.parent = null;
     else entry.project = rootProject(entry);
   }
-  persistWorktreeMap();
+  if (persist) persistWorktreeMap();
 }

--- a/src/lib/scanner/observe.ts
+++ b/src/lib/scanner/observe.ts
@@ -1,0 +1,50 @@
+import type { FileEntry } from "../types";
+import { resolveTarget } from "../tmux";
+import { ctxFor } from "./context";
+import { discoverFiles } from "./discover";
+import { entryEffort } from "./effort";
+import { linkEntries } from "./links";
+import { entryModels } from "./model";
+import { outputHolders } from "./process";
+import { goalFor, planFor } from "./plan";
+import { pendingQuestionFor } from "./questions";
+import { assignTranscriptPids } from "./transcripts";
+import { waitingInputProbe } from "./waitingInput";
+import { activityVerdict } from "./activity";
+
+const YIELD_EVERY = 75;
+const NO_HOLDERS: Map<string, number> = new Map();
+const yieldToEventLoop = (): Promise<void> => new Promise((resolve) => setImmediate(resolve));
+
+async function each(entries: FileEntry[], visit: (entry: FileEntry) => void | Promise<void>): Promise<void> {
+  for (let index = 0; index < entries.length; index += YIELD_EVERY) {
+    await Promise.all(entries.slice(index, index + YIELD_EVERY).map(visit));
+    if (index + YIELD_EVERY < entries.length) await yieldToEventLoop();
+  }
+}
+
+/** An inert mirror of the scanner enrichment pipeline for snapshot reads. */
+export async function observeFiles(): Promise<FileEntry[]> {
+  const entries = await discoverFiles();
+  const holders = entries.some((entry) => entry.root === "claude-tasks" && entry.path.endsWith(".output")) ? outputHolders() : NO_HOLDERS;
+  await each(entries, (entry) => {
+    const verdict = activityVerdict(entry.root, entry.path, entry.mtime, entry.size);
+    entry.activity = verdict.state; entry.activityReason = verdict.reason;
+    const models = entryModels(entry); entry.model = models.display; entry.launchModel = models.launch;
+    if (entry.root === "claude-tasks" && entry.path.endsWith(".output")) {
+      const holder = holders.get(entry.path) ?? null; entry.pid = holder; entry.proc = holder === null ? "done" : "running";
+      if (holder !== null) { entry.activity = "live"; entry.activityReason = "output_held"; }
+    }
+  });
+  assignTranscriptPids(entries);
+  await each(entries, (entry) => { entry.effort = entryEffort(entry); });
+  await each(entries, async (entry) => {
+    const pending = pendingQuestionFor(entry);
+    entry.pendingQuestion = pending && entry.pid !== null ? { ...pending, paneTarget: await resolveTarget(entry.pid) } : pending;
+    const probe = await waitingInputProbe(entry); entry.waitingInput = probe.waiting;
+    if (probe.atComposer && entry.activity === "stalled") { entry.activity = Date.now() / 1000 - entry.mtime < 900 ? "recent" : "idle"; entry.activityReason = "pane_at_composer"; }
+    entry.plan = planFor(entry); entry.goal = goalFor(entry); entry.ctx = ctxFor(entry);
+  });
+  await linkEntries(entries, { persist: false });
+  return entries;
+}

--- a/src/lib/view/collect.ts
+++ b/src/lib/view/collect.ts
@@ -1,0 +1,15 @@
+import { observeFiles } from "@/lib/scanner/observe";
+
+import { composeSnapshot } from "./snapshot";
+import { resolveSiblings } from "./siblings";
+import type { SnapshotRequestV1 } from "./types";
+
+export async function collectSnapshot(
+  body: SnapshotRequestV1,
+  dependencies = { observeFiles, resolveSiblings },
+): Promise<Awaited<ReturnType<typeof composeSnapshot>>> {
+  const started = Date.now();
+  const files = await dependencies.observeFiles();
+  const siblings = await dependencies.resolveSiblings(body.caller, files);
+  return composeSnapshot({ request: body, files, siblings, scannerDurationMs: Date.now() - started });
+}

--- a/src/lib/view/compactText.ts
+++ b/src/lib/view/compactText.ts
@@ -1,0 +1,90 @@
+import fs from "node:fs";
+
+import { redactSecrets } from "@/lib/review";
+import type { FileEntry } from "@/lib/types";
+
+import type { SnapshotConversation } from "./types";
+
+const SCAN_BYTES = 1024 * 1024;
+
+export function hardenedRedact(text: string): string {
+  return redactSecrets(text)
+    .replace(/-----BEGIN [A-Z ]*PRIVATE KEY-----[\s\S]*?-----END [A-Z ]*PRIVATE KEY-----/g, "[redacted]")
+    .replace(/(^|\n)(\s*(?:proxy-)?authorization\s*:\s*)[^\r\n]*/gi, "$1$2[redacted]")
+    .replace(/(^|\n)(\s*(?:set-)?cookie\s*:\s*)[^\r\n]*/gi, "$1$2[redacted]")
+    .replace(/\b(?:sk-[A-Za-z0-9_-]{12,}|sk-ant-[A-Za-z0-9_-]{12,}|gh[pousr]_[A-Za-z0-9_]{20,}|github_pat_[A-Za-z0-9_]{20,}|npm_[A-Za-z0-9]{20,}|xox[baprs]-[A-Za-z0-9-]{10,}|AKIA[0-9A-Z]{16}|ASIA[0-9A-Z]{16}|AIza[0-9A-Za-z_-]{35})\b/g, "[redacted]")
+    .replace(/\beyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\b/g, "[redacted]")
+    .replace(/(?<=Bearer\s)[A-Za-z0-9._-]{12,}/gi, "[redacted]");
+}
+
+type CompactMessage = { role: "user" | "assistant"; at: string | null; text: string };
+function object(value: unknown): Record<string, unknown> { return value && typeof value === "object" && !Array.isArray(value) ? value as Record<string, unknown> : {}; }
+function text(value: unknown): string { return typeof value === "string" ? value : ""; }
+function contentText(value: unknown): string {
+  if (typeof value === "string") return value;
+  if (!Array.isArray(value)) return "";
+  return value.filter((part): part is Record<string, unknown> => Boolean(part) && typeof part === "object" && !Array.isArray(part)).filter((part) => part.type === "text").map((part) => text(part.text)).join("\n");
+}
+function tailMessages(entry: FileEntry): { messages: CompactMessage[]; scannedBytes: number; error: boolean } {
+  let data: string; let scannedBytes: number;
+  let descriptor: number | null = null;
+  try {
+    descriptor = fs.openSync(entry.path, fs.constants.O_RDONLY | fs.constants.O_NOFOLLOW);
+    const stat = fs.fstatSync(descriptor);
+    if (!stat.isFile()) throw new Error("transcript is not a regular file");
+    const pathStat = fs.lstatSync(entry.path);
+    if (!pathStat.isFile() || pathStat.dev !== stat.dev || pathStat.ino !== stat.ino) throw new Error("transcript identity changed");
+    const start = Math.max(0, stat.size - SCAN_BYTES); scannedBytes = stat.size - start;
+    const buffer = Buffer.alloc(scannedBytes); fs.readSync(descriptor, buffer, 0, buffer.length, start); data = buffer.toString("utf8");
+    if (start > 0) data = data.slice(data.indexOf("\n") + 1);
+  } catch { return { messages: [], scannedBytes: 0, error: true }; }
+  finally { if (descriptor !== null) fs.closeSync(descriptor); }
+  const messages: CompactMessage[] = [];
+  for (const line of data.split("\n")) {
+    try {
+      const row = object(JSON.parse(line)); const at = text(row.timestamp) || text(row.ts) || null;
+      if (entry.engine === "claude") {
+        const role = row.type === "user" ? "user" : row.type === "assistant" ? "assistant" : null;
+        const value = contentText(object(row.message).content);
+        if (role && value.trim()) messages.push({ role, at, text: value });
+      } else {
+        const payload = object(row.payload); const type = text(payload.type);
+        const role = type === "user_message" ? "user" : type === "agent_message" ? "assistant" : null;
+        const value = text(payload.message);
+        if (role && value.trim()) messages.push({ role, at, text: value });
+      }
+    } catch { /* malformed transcript tail */ }
+  }
+  return { messages, scannedBytes, error: false };
+}
+
+function truncateUtf8(value: string, maxCodePoints: number, maxBytes: number): { value: string; truncated: boolean } {
+  let bytes = 0; let points = 0; let output = "";
+  for (const point of value) {
+    const pointBytes = Buffer.byteLength(point, "utf8");
+    if (points >= maxCodePoints || bytes + pointBytes > maxBytes) return { value: output, truncated: true };
+    output += point; bytes += pointBytes; points += 1;
+  }
+  return { value: output, truncated: false };
+}
+
+export function compactText(entry: FileEntry, lastMessages: number, maxChars: number, remainingBytes: number): NonNullable<SnapshotConversation["text"]> {
+  const tail = tailMessages(entry);
+  const messages = tail.messages.slice(-lastMessages);
+  let usedCodePoints = 0;
+  let usedBytes = 0;
+  let truncated = false;
+  const output: NonNullable<SnapshotConversation["text"]>["messages"] = [];
+  for (const message of messages) {
+    const clean = hardenedRedact(message.text).replace(/\s+/g, " ").trim();
+    const availablePoints = Math.max(0, maxChars - usedCodePoints);
+    const availableBytes = Math.max(0, remainingBytes - usedBytes);
+    if (availablePoints <= 0 || availableBytes <= 0) { truncated = true; break; }
+    const bounded = truncateUtf8(clean, availablePoints, availableBytes);
+    truncated ||= bounded.truncated;
+    usedCodePoints += [...bounded.value].length;
+    usedBytes += Buffer.byteLength(bounded.value, "utf8");
+    if (bounded.value) output.push({ role: message.role, at: message.at, text: bounded.value });
+  }
+  return { messages: output, truncated: truncated || tail.error, scannedBytes: tail.scannedBytes, ...(tail.error ? { error: "unavailable" as const } : {}) };
+}

--- a/src/lib/view/presenceStore.ts
+++ b/src/lib/view/presenceStore.ts
@@ -1,0 +1,59 @@
+import type { PresencePayloadV1, StoredViewSession, ViewFreshness, ViewSessionSummary } from "./types";
+
+const ACTIVE_MS = 25_000;
+const RETENTION_MS = 120_000;
+const CAPACITY = 32;
+
+type Store = Map<string, StoredViewSession>;
+const globals = globalThis as unknown as { __llvViewPresence?: Store };
+function store(): Store { return (globals.__llvViewPresence ??= new Map()); }
+
+export function freshness(session: StoredViewSession, now = Date.now()): ViewFreshness {
+  const age = Math.max(0, now - session.lastSeenAt);
+  if (session.visibility === "visible") return age < ACTIVE_MS ? "active" : "stale";
+  if (age <= RETENTION_MS) return "background";
+  return "stale";
+}
+
+function expire(now = Date.now()): void {
+  const sessions = store();
+  for (const [id, session] of sessions) if (now - session.lastSeenAt > RETENTION_MS) sessions.delete(id);
+}
+
+function makeRoomForNewSession(): void {
+  const sessions = store();
+  while (sessions.size >= CAPACITY) {
+    const oldest = [...sessions.values()].sort((a, b) => a.lastSeenAt - b.lastSeenAt)[0];
+    if (!oldest) break;
+    sessions.delete(oldest.viewSessionId);
+  }
+}
+
+export function upsertPresence(payload: PresencePayloadV1, now = Date.now()): { accepted: boolean; session: StoredViewSession } {
+  expire(now);
+  const sessions = store();
+  const current = sessions.get(payload.viewSessionId);
+  if (current && payload.sequence <= current.sequence) return { accepted: false, session: current };
+  if (!current) makeRoomForNewSession();
+  const inputAdvanced = !current || payload.inputSequence > current.inputSequence;
+  const session: StoredViewSession = {
+    ...payload,
+    inputSequence: Math.max(current?.inputSequence ?? 0, payload.inputSequence),
+    lastSeenAt: now,
+    lastInteractionAt: inputAdvanced ? now : current?.lastInteractionAt ?? now,
+  };
+  sessions.set(payload.viewSessionId, session);
+  return { accepted: true, session };
+}
+
+export function sessionSummary(session: StoredViewSession, now = Date.now()): ViewSessionSummary {
+  return { viewSessionId: session.viewSessionId, deviceId: session.deviceId, device: session.device, visibility: session.visibility, freshness: freshness(session, now), presenceAgeMs: Math.max(0, now - session.lastSeenAt), lastSeenAt: new Date(session.lastSeenAt).toISOString(), lastInteractionAt: new Date(session.lastInteractionAt).toISOString(), project: session.project, mode: session.mode };
+}
+
+export function listPresence(now = Date.now()): StoredViewSession[] {
+  expire(now);
+  return [...store().values()].sort((a, b) => b.lastInteractionAt - a.lastInteractionAt || b.lastSeenAt - a.lastSeenAt || a.viewSessionId.localeCompare(b.viewSessionId));
+}
+
+export function resetPresenceForTest(): void { globals.__llvViewPresence = new Map(); }
+export const presenceLimits = { ACTIVE_MS, RETENTION_MS, CAPACITY };

--- a/src/lib/view/siblings.ts
+++ b/src/lib/view/siblings.ts
@@ -1,0 +1,36 @@
+import { createTranscriptHostResolver } from "@/lib/agent/transcriptHost";
+import { procBackend } from "@/lib/proc";
+import { agentProcesses, pidAlive, readArgv, readPpid } from "@/lib/scanner/process";
+import { panePidMap, panePidOf, rememberResumePane, resumePaneRecords, sendText, spawnAgentWithPrompt, tmuxServerPid } from "@/lib/tmux";
+import type { FileEntry } from "@/lib/types";
+
+import type { SnapshotRequestV1, ViewerSnapshotV1 } from "./types";
+
+export async function resolveSiblings(caller: SnapshotRequestV1["caller"], files: FileEntry[]): Promise<ViewerSnapshotV1["siblings"]> {
+  if (!caller) return { selfResolution: "omitted", agents: [] };
+  const observationResolver = createTranscriptHostResolver({
+    listFiles: async () => files,
+    panes: panePidMap,
+    ppidMap: () => procBackend.ppidMap(),
+    agents: agentProcesses,
+    serverPid: tmuxServerPid,
+    resumeRecords: resumePaneRecords,
+    panePid: panePidOf,
+    alive: pidAlive,
+    argv: readArgv,
+    parentPid: readPpid,
+    identity: () => null,
+    spawn: spawnAgentWithPrompt,
+    remember: rememberResumePane,
+    deliver: sendText,
+  });
+  const hosts = await observationResolver.readTranscriptHosts();
+  const byPath = new Map(files.map((file) => [file.path, file]));
+  const seed = caller.transcriptPath ? hosts.canonicalFor(caller.transcriptPath) : hosts.hosts.find((host) => host.agentPid === caller.pid);
+  if (!seed) return { selfResolution: "unmatched", agents: [] };
+  const agents = hosts.hosts.filter((host) => host.cwd === seed.cwd && host.primaryPath !== null).map((host) => {
+    const file = host.primaryPath ? byPath.get(host.primaryPath) : undefined;
+    return { transcriptPath: host.primaryPath!, engine: host.engine, project: file?.project ?? null, title: file?.title ?? null, activity: file?.activity ?? null, pid: host.agentPid, self: host.agentPid === caller.pid || host.primaryPath === caller.transcriptPath };
+  });
+  return { selfResolution: agents.some((agent) => agent.self) ? "matched" : "unmatched", agents };
+}

--- a/src/lib/view/snapshot.ts
+++ b/src/lib/view/snapshot.ts
@@ -1,0 +1,97 @@
+import type { FileEntry } from "@/lib/types";
+
+import { compactText } from "./compactText";
+import { freshness, listPresence, sessionSummary } from "./presenceStore";
+import { MAX_RESPONSE_BYTES, MAX_SCOPE_PATHS, MAX_TEXT_BYTES, type SnapshotConversation, type SnapshotRequestV1, type StoredViewSession, type ViewerSnapshotV1, type ViewScopeKind, type ViewSessionSummary } from "./types";
+
+type SnapshotErrorCode = "NO_ACTIVE_VIEW" | "VIEW_SESSION_NOT_FOUND" | "AMBIGUOUS_ACTIVE_VIEW" | "PATH_OUTSIDE_CURRENT_VIEW" | "INTERNAL_ERROR";
+export class SnapshotError extends Error {
+  constructor(readonly code: SnapshotErrorCode, readonly status: number, message: string, readonly sessions?: ViewSessionSummary[]) { super(message); }
+}
+
+interface Selection { session: StoredViewSession; by: ViewerSnapshotV1["resolution"]["by"]; alternatives: StoredViewSession[]; ambiguous: boolean }
+function choose(request: SnapshotRequestV1, now: number): Selection {
+  const retained = listPresence(now);
+  const id = request.view?.id;
+  const deviceId = request.view?.deviceId;
+  if (id) {
+    const selected = retained.find((session) => session.viewSessionId === id && (!deviceId || session.deviceId === deviceId));
+    if (!selected) throw new SnapshotError("VIEW_SESSION_NOT_FOUND", 404, "view session not found");
+    return { session: selected, by: "explicit", alternatives: retained.filter((session) => session.viewSessionId !== selected.viewSessionId), ambiguous: false };
+  }
+
+  const filtered = deviceId ? retained.filter((session) => session.deviceId === deviceId) : retained;
+  const foreground = filtered.filter((session) => freshness(session, now) === "active");
+  const background = filtered.filter((session) => freshness(session, now) === "background");
+  const candidates = foreground.length > 0 ? foreground : background;
+  if (candidates.length === 0) throw new SnapshotError("NO_ACTIVE_VIEW", 404, "no active view");
+  const selected = candidates[0]!;
+  const second = candidates[1];
+  const ambiguous = Boolean(second && Math.abs(selected.lastInteractionAt - second.lastInteractionAt) <= 30_000);
+  if (ambiguous && request.view?.resolution === "require-explicit") {
+    throw new SnapshotError("AMBIGUOUS_ACTIVE_VIEW", 409, "active view is ambiguous", candidates.map((session) => sessionSummary(session, now)));
+  }
+  return {
+    session: selected,
+    by: deviceId ? "explicit" : candidates.length === 1 ? "only-eligible" : "latest-interaction",
+    alternatives: retained.filter((session) => session.viewSessionId !== selected.viewSessionId),
+    ambiguous,
+  };
+}
+
+function scopedPaths(session: StoredViewSession, scope: SnapshotRequestV1["scope"]): { kind: ViewScopeKind; all: string[] } {
+  const kind = scope?.kind ?? "focused-selected";
+  const focus = session.focusedPath ? [session.focusedPath] : [];
+  const selected = session.selectedPaths;
+  const values = kind === "focused" ? focus : kind === "selected" ? selected : kind === "visible" ? session.visiblePaths : kind === "paths" ? (scope?.paths ?? []) : [...focus, ...selected.filter((path) => path !== session.focusedPath)];
+  return { kind, all: values };
+}
+
+function validateExplicitMembership(session: StoredViewSession, explicit: readonly string[]): void {
+  const currentView = new Set([session.focusedPath, ...session.selectedPaths, ...session.visiblePaths].filter((value): value is string => value !== null));
+  if (explicit.some((pathname) => !currentView.has(pathname))) throw new SnapshotError("PATH_OUTSIDE_CURRENT_VIEW", 422, "path is outside current view");
+}
+
+function transcriptEntry(byPath: ReadonlyMap<string, FileEntry>, pathname: string): FileEntry | undefined {
+  const entry = byPath.get(pathname);
+  return entry?.engine === "claude" || entry?.engine === "codex" ? entry : undefined;
+}
+
+function conversation(entry: FileEntry): SnapshotConversation {
+  const attention = entry.pendingQuestion ? { state: "question" as const, since: entry.pendingQuestion.askedAt } : entry.waitingInput ? { state: "terminal" as const, since: new Date(entry.waitingInput.since * 1000).toISOString() } : entry.activity === "stalled" ? { state: "stalled" as const, since: new Date(entry.mtime * 1000).toISOString() } : null;
+  return { path: entry.path, project: entry.project, title: entry.title, engine: entry.engine as "claude" | "codex", model: entry.model, activity: entry.activity, proc: entry.proc, attention };
+}
+
+export async function composeSnapshot(input: { request: SnapshotRequestV1; files: FileEntry[]; scannerDurationMs: number; siblings: ViewerSnapshotV1["siblings"]; now?: number }): Promise<ViewerSnapshotV1> {
+  const now = input.now ?? Date.now();
+  const selection = choose(input.request, now);
+  const session = selection.session;
+  const byPath = new Map(input.files.map((file) => [file.path, file]));
+  const requestedPaths = input.request.scope?.kind === "paths" ? input.request.scope.paths ?? [] : [];
+  validateExplicitMembership(session, requestedPaths);
+  const scope = scopedPaths(session, input.request.scope);
+  const returnedPaths = scope.all.filter((pathname) => transcriptEntry(byPath, pathname)).slice(0, MAX_SCOPE_PATHS);
+  let textRemaining = MAX_TEXT_BYTES;
+  const conversations = returnedPaths.map((pathname) => {
+    const entry = transcriptEntry(byPath, pathname);
+    if (!entry) throw new SnapshotError("INTERNAL_ERROR", 500, "snapshot membership changed during composition");
+    const card = conversation(entry);
+    if (input.request.text?.include !== false) {
+      const text = compactText(entry, input.request.text?.lastMessages ?? 6, input.request.text?.maxCharsPerConversation ?? 3000, textRemaining);
+      textRemaining -= text.messages.reduce((total, message) => total + Buffer.byteLength(message.text, "utf8"), 0);
+      card.text = text;
+    }
+    return card;
+  });
+  const omittedCount = scope.all.length - returnedPaths.length;
+  const snapshot: ViewerSnapshotV1 = {
+    ok: true, schemaVersion: 1, capability: "viewer.snapshot", generatedAt: new Date(now).toISOString(),
+    resolution: { by: selection.by, ambiguous: selection.ambiguous, alternatives: selection.alternatives.map((item) => sessionSummary(item, now)) },
+    view: { viewSessionId: session.viewSessionId, deviceId: session.deviceId, device: session.device, visibility: session.visibility, freshness: freshness(session, now), presenceAgeMs: Math.max(0, now - session.lastSeenAt), project: session.project, mode: session.mode, viewport: session.viewport, camera: session.camera, focusedPath: session.focusedPath, selectedPaths: session.selectedPaths, visiblePaths: session.visiblePaths, board: session.board },
+    scope: { kind: scope.kind, totalPaths: scope.all.length, returnedPaths, truncated: omittedCount > 0, omittedCount },
+    conversations, siblings: input.siblings,
+    scanner: { scannedAt: new Date(now).toISOString(), ageMs: 0, durationMs: input.scannerDurationMs, entryCount: input.files.length },
+  };
+  if (Buffer.byteLength(JSON.stringify(snapshot), "utf8") > MAX_RESPONSE_BYTES) throw new SnapshotError("INTERNAL_ERROR", 500, "snapshot response limit exceeded");
+  return snapshot;
+}

--- a/src/lib/view/types.ts
+++ b/src/lib/view/types.ts
@@ -1,0 +1,93 @@
+import type { Activity, Engine, FileEntry } from "@/lib/types";
+
+export const VIEW_SCHEMA_VERSION = 1 as const;
+export const MAX_PRESENCE_BYTES = 32 * 1024;
+export const MAX_VISIBLE_PATHS = 128;
+export const MAX_SELECTED_PATHS = 64;
+export const MAX_SCOPE_PATHS = 16;
+export const MAX_RESPONSE_BYTES = 96 * 1024;
+export const MAX_TEXT_BYTES = 32 * 1024;
+
+export type ViewMode = "overview" | "scheme" | "list" | "mobile-focus" | "mobile-map";
+export type DeviceKind = "desktop" | "tablet" | "mobile";
+export type BrowserKind = "chrome" | "firefox" | "safari" | "other";
+export type ViewFreshness = "active" | "background" | "stale";
+export type ViewScopeKind = "focused" | "selected" | "visible" | "focused-selected" | "paths";
+
+export interface PresencePayloadV1 {
+  schemaVersion: 1;
+  viewSessionId: string;
+  deviceId: string;
+  device: { kind: DeviceKind; browser: BrowserKind };
+  visibility: "visible" | "hidden";
+  sequence: number;
+  inputSequence: number;
+  project: string | null;
+  mode: ViewMode;
+  viewport: { width: number; height: number; dpr: number };
+  camera: { x: number; y: number; zoom: number; worldRect: { x: number; y: number; width: number; height: number } } | null;
+  focusedPath: string | null;
+  selectedPaths: string[];
+  visiblePaths: string[];
+  board: { renderedRevision: number | null; durableRevision: number | null; sync: "current" | "pending" | "stale" | "unavailable" };
+}
+
+export interface StoredViewSession extends PresencePayloadV1 {
+  lastSeenAt: number;
+  lastInteractionAt: number;
+}
+
+export interface ViewSessionSummary {
+  viewSessionId: string;
+  deviceId: string;
+  device: PresencePayloadV1["device"];
+  visibility: PresencePayloadV1["visibility"];
+  freshness: ViewFreshness;
+  presenceAgeMs: number;
+  lastSeenAt: string;
+  lastInteractionAt: string;
+  project: string | null;
+  mode: ViewMode;
+}
+
+export interface SnapshotRequestV1 {
+  schemaVersion: 1;
+  view?: { id?: string; deviceId?: string; resolution?: "latest-interaction" | "require-explicit" };
+  scope?: { kind: ViewScopeKind; paths?: string[] };
+  text?: { include?: boolean; lastMessages?: number; maxCharsPerConversation?: number };
+  caller?: { pid?: number; transcriptPath?: string };
+}
+
+export interface SnapshotConversation {
+  path: string;
+  project: string;
+  title: string;
+  engine: Extract<Engine, "claude" | "codex">;
+  model: string | null;
+  activity: Activity;
+  proc: FileEntry["proc"];
+  attention: { state: "question" | "terminal" | "stalled"; since: string } | null;
+  text?: { messages: Array<{ role: "user" | "assistant"; at: string | null; text: string }>; truncated: boolean; scannedBytes: number; error?: "unavailable" };
+}
+
+export interface ViewerSnapshotV1 {
+  ok: true;
+  schemaVersion: 1;
+  capability: "viewer.snapshot";
+  generatedAt: string;
+  resolution: { by: "explicit" | "latest-interaction" | "only-eligible"; ambiguous: boolean; alternatives: ViewSessionSummary[] };
+  view: Omit<PresencePayloadV1, "schemaVersion" | "sequence" | "inputSequence"> & { freshness: ViewFreshness; presenceAgeMs: number };
+  scope: { kind: ViewScopeKind; totalPaths: number; returnedPaths: string[]; truncated: boolean; omittedCount: number };
+  conversations: SnapshotConversation[];
+  siblings: { selfResolution: "matched" | "unmatched" | "omitted"; agents: Array<{ transcriptPath: string; engine: "claude" | "codex"; project: string | null; title: string | null; activity: string | null; pid: number; self: boolean }> };
+  scanner: { scannedAt: string; ageMs: number; durationMs: number; entryCount: number };
+}
+
+export interface BoardProjectStateV1 {
+  schemaVersion: 1;
+  revision: number;
+  updatedAt: string;
+  prefs: { manual: string[]; hidden: string[]; expanded: string[]; viewMode: "scheme" | "list" | null; taskPanelOpen: boolean };
+}
+
+export interface BoardFileV1 { projects: Record<string, BoardProjectStateV1> }

--- a/src/lib/view/validation.ts
+++ b/src/lib/view/validation.ts
@@ -1,0 +1,94 @@
+import { MAX_PRESENCE_BYTES, MAX_SCOPE_PATHS, MAX_SELECTED_PATHS, MAX_VISIBLE_PATHS, type PresencePayloadV1, type SnapshotRequestV1 } from "./types";
+
+export class ViewValidationError extends Error {
+  constructor(readonly code: "INVALID_REQUEST" | "UNSUPPORTED_SCHEMA_VERSION" | "SCOPE_TOO_LARGE" | "PAYLOAD_TOO_LARGE", message: string, readonly status = 400) { super(message); }
+}
+
+function record(value: unknown, field = "request"): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) throw new ViewValidationError("INVALID_REQUEST", `invalid ${field}`);
+  return value as Record<string, unknown>;
+}
+function exact(value: Record<string, unknown>, allowed: readonly string[], field: string): void {
+  const unknown = Object.keys(value).find((key) => !allowed.includes(key));
+  if (unknown) throw new ViewValidationError("INVALID_REQUEST", `unknown ${field}.${unknown}`);
+}
+function string(value: unknown, field: string, options: { nullable?: boolean; max?: number } = {}): string | null {
+  if (options.nullable && value === null) return null;
+  if (typeof value !== "string" || value.length === 0 || value.length > (options.max ?? 4096)) throw new ViewValidationError("INVALID_REQUEST", `invalid ${field}`);
+  return value;
+}
+function finite(value: unknown, field: string, min = -1_000_000_000, max = 1_000_000_000): number {
+  if (typeof value !== "number" || !Number.isFinite(value) || value < min || value > max) throw new ViewValidationError("INVALID_REQUEST", `invalid ${field}`);
+  return value;
+}
+function integer(value: unknown, field: string, min = 0, max = Number.MAX_SAFE_INTEGER): number {
+  const parsed = finite(value, field, min, max);
+  if (!Number.isInteger(parsed)) throw new ViewValidationError("INVALID_REQUEST", `invalid ${field}`);
+  return parsed;
+}
+function oneOf<T extends string>(value: unknown, field: string, values: readonly T[]): T {
+  if (typeof value !== "string" || !values.includes(value as T)) throw new ViewValidationError("INVALID_REQUEST", `invalid ${field}`);
+  return value as T;
+}
+function paths(value: unknown, field: string, maximum: number): string[] {
+  if (!Array.isArray(value) || value.length > maximum) throw new ViewValidationError(field === "scope.paths" ? "SCOPE_TOO_LARGE" : "INVALID_REQUEST", `invalid ${field}`, field === "scope.paths" ? 413 : 400);
+  const parsed = value.map((item) => string(item, field)!);
+  if (new Set(parsed).size !== parsed.length) throw new ViewValidationError("INVALID_REQUEST", `duplicate ${field}`);
+  return parsed;
+}
+function optionalRecord(value: unknown, field: string): Record<string, unknown> | undefined { return value === undefined ? undefined : record(value, field); }
+
+export function validatePresence(value: unknown): PresencePayloadV1 {
+  const body = record(value);
+  exact(body, ["schemaVersion", "viewSessionId", "deviceId", "device", "visibility", "sequence", "inputSequence", "project", "mode", "viewport", "camera", "focusedPath", "selectedPaths", "visiblePaths", "board"], "request");
+  if (body.schemaVersion !== 1) throw new ViewValidationError("UNSUPPORTED_SCHEMA_VERSION", "schemaVersion must be 1");
+  const device = record(body.device, "device"); exact(device, ["kind", "browser"], "device");
+  const viewport = record(body.viewport, "viewport"); exact(viewport, ["width", "height", "dpr"], "viewport");
+  const board = record(body.board, "board"); exact(board, ["renderedRevision", "durableRevision", "sync"], "board");
+  const mode = oneOf(body.mode, "mode", ["overview", "scheme", "list", "mobile-focus", "mobile-map"] as const);
+  const camera = body.camera === null ? null : record(body.camera, "camera");
+  if (camera) exact(camera, ["x", "y", "zoom", "worldRect"], "camera");
+  const worldRect = camera ? record(camera.worldRect, "camera.worldRect") : null;
+  if (worldRect) exact(worldRect, ["x", "y", "width", "height"], "camera.worldRect");
+  if ((mode === "overview" || mode === "list" || mode === "mobile-focus") && camera !== null) throw new ViewValidationError("INVALID_REQUEST", `camera must be null in ${mode}`);
+  return {
+    schemaVersion: 1,
+    viewSessionId: string(body.viewSessionId, "viewSessionId")!, deviceId: string(body.deviceId, "deviceId")!,
+    device: { kind: oneOf(device.kind, "device.kind", ["desktop", "tablet", "mobile"] as const), browser: oneOf(device.browser, "device.browser", ["chrome", "firefox", "safari", "other"] as const) },
+    visibility: oneOf(body.visibility, "visibility", ["visible", "hidden"] as const), sequence: integer(body.sequence, "sequence"), inputSequence: integer(body.inputSequence, "inputSequence"),
+    project: string(body.project, "project", { nullable: true, max: 256 }), mode,
+    viewport: { width: finite(viewport.width, "viewport.width", 1, 100_000), height: finite(viewport.height, "viewport.height", 1, 100_000), dpr: finite(viewport.dpr, "viewport.dpr", 0.1, 100) },
+    camera: camera ? { x: finite(camera.x, "camera.x"), y: finite(camera.y, "camera.y"), zoom: finite(camera.zoom, "camera.zoom", 0.0001, 1000), worldRect: { x: finite(worldRect!.x, "camera.worldRect.x"), y: finite(worldRect!.y, "camera.worldRect.y"), width: finite(worldRect!.width, "camera.worldRect.width", 0, 1_000_000_000), height: finite(worldRect!.height, "camera.worldRect.height", 0, 1_000_000_000) } } : null,
+    focusedPath: string(body.focusedPath, "focusedPath", { nullable: true }), selectedPaths: paths(body.selectedPaths, "selectedPaths", MAX_SELECTED_PATHS), visiblePaths: paths(body.visiblePaths, "visiblePaths", MAX_VISIBLE_PATHS),
+    board: { renderedRevision: board.renderedRevision === null ? null : integer(board.renderedRevision, "board.renderedRevision"), durableRevision: board.durableRevision === null ? null : integer(board.durableRevision, "board.durableRevision"), sync: oneOf(board.sync, "board.sync", ["current", "pending", "stale", "unavailable"] as const) },
+  };
+}
+
+export function validateSnapshotRequest(value: unknown): SnapshotRequestV1 {
+  const body = record(value); exact(body, ["schemaVersion", "view", "scope", "text", "caller"], "request");
+  if (body.schemaVersion !== 1) throw new ViewValidationError("UNSUPPORTED_SCHEMA_VERSION", "schemaVersion must be 1");
+  const view = optionalRecord(body.view, "view"); if (view) exact(view, ["id", "deviceId", "resolution"], "view");
+  const scope = optionalRecord(body.scope, "scope"); if (scope) exact(scope, ["kind", "paths"], "scope");
+  const textOptions = optionalRecord(body.text, "text"); if (textOptions) exact(textOptions, ["include", "lastMessages", "maxCharsPerConversation"], "text");
+  const caller = optionalRecord(body.caller, "caller"); if (caller) exact(caller, ["pid", "transcriptPath"], "caller");
+  const kind = scope ? oneOf(scope.kind, "scope.kind", ["focused", "selected", "visible", "focused-selected", "paths"] as const) : undefined;
+  const scopePaths = scope?.paths === undefined ? undefined : paths(scope.paths, "scope.paths", MAX_SCOPE_PATHS);
+  if (kind === "paths" && !scopePaths) throw new ViewValidationError("INVALID_REQUEST", "scope.paths is required");
+  if (kind !== "paths" && scopePaths) throw new ViewValidationError("INVALID_REQUEST", "scope.paths requires paths scope");
+  if (textOptions?.include !== undefined && typeof textOptions.include !== "boolean") throw new ViewValidationError("INVALID_REQUEST", "invalid text.include");
+  return {
+    schemaVersion: 1,
+    view: view ? { id: view.id === undefined ? undefined : string(view.id, "view.id")!, deviceId: view.deviceId === undefined ? undefined : string(view.deviceId, "view.deviceId")!, resolution: view.resolution === undefined ? undefined : oneOf(view.resolution, "view.resolution", ["latest-interaction", "require-explicit"] as const) } : undefined,
+    scope: kind ? { kind, paths: scopePaths } : undefined,
+    text: textOptions ? { include: textOptions.include as boolean | undefined, lastMessages: textOptions.lastMessages === undefined ? undefined : integer(textOptions.lastMessages, "text.lastMessages", 1, 20), maxCharsPerConversation: textOptions.maxCharsPerConversation === undefined ? undefined : integer(textOptions.maxCharsPerConversation, "text.maxCharsPerConversation", 1, 4000) } : undefined,
+    caller: caller ? { pid: caller.pid === undefined ? undefined : integer(caller.pid, "caller.pid", 1), transcriptPath: caller.transcriptPath === undefined ? undefined : string(caller.transcriptPath, "caller.transcriptPath")! } : undefined,
+  };
+}
+
+export async function readBoundedJson(request: Request, maximum = MAX_PRESENCE_BYTES): Promise<unknown> {
+  const length = request.headers.get("content-length");
+  if (length && Number(length) > maximum) throw new ViewValidationError("PAYLOAD_TOO_LARGE", "payload too large", 413);
+  const body = await request.text();
+  if (Buffer.byteLength(body, "utf8") > maximum) throw new ViewValidationError("PAYLOAD_TOO_LARGE", "payload too large", 413);
+  try { return JSON.parse(body) as unknown; } catch { throw new ViewValidationError("INVALID_REQUEST", "invalid JSON"); }
+}

--- a/src/lib/view/view.test.ts
+++ b/src/lib/view/view.test.ts
@@ -1,0 +1,192 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import type { FileEntry } from "@/lib/types";
+
+import { compactText, hardenedRedact } from "./compactText";
+import { freshness, listPresence, presenceLimits, resetPresenceForTest, upsertPresence } from "./presenceStore";
+import { composeSnapshot, SnapshotError } from "./snapshot";
+import type { PresencePayloadV1, SnapshotRequestV1 } from "./types";
+import { validatePresence, validateSnapshotRequest, ViewValidationError } from "./validation";
+
+const sandbox = fs.mkdtempSync(path.join(os.tmpdir(), "llv-view-"));
+afterEach(() => resetPresenceForTest());
+
+function presence(overrides: Partial<PresencePayloadV1> = {}): PresencePayloadV1 {
+  return { schemaVersion: 1, viewSessionId: "view-a", deviceId: "desktop", device: { kind: "desktop", browser: "chrome" }, visibility: "visible", sequence: 1, inputSequence: 1, project: "viewer", mode: "scheme", viewport: { width: 100, height: 100, dpr: 1 }, camera: null, focusedPath: "/a.jsonl", selectedPaths: ["/b.jsonl"], visiblePaths: ["/a.jsonl", "/b.jsonl", "/c.jsonl"], board: { renderedRevision: 1, durableRevision: 1, sync: "current" }, ...overrides };
+}
+function file(pathname: string, overrides: Partial<FileEntry> = {}): FileEntry {
+  return { path: pathname, root: "claude-projects", name: path.basename(pathname), project: "viewer", title: pathname, engine: "claude", kind: "session", fmt: "claude", parent: null, mtime: 1, size: 1, activity: "idle", proc: null, pid: null, model: null, pendingQuestion: null, waitingInput: null, ...overrides };
+}
+async function snapshot(request: Partial<SnapshotRequestV1> = {}) {
+  upsertPresence(presence(), 1000);
+  return composeSnapshot({ request: { schemaVersion: 1, ...request }, files: [file("/a.jsonl"), file("/b.jsonl"), file("/c.jsonl")], siblings: { selfResolution: "omitted", agents: [] }, scannerDurationMs: 1, now: 2000 });
+}
+
+describe("view presence", () => {
+  test("ignores old sequences and derives freshness from server receipt time", () => {
+    upsertPresence(presence({ sequence: 2, inputSequence: 2 }), 1000);
+    const ignored = upsertPresence(presence({ sequence: 1, inputSequence: 3, project: "wrong" }), 2000);
+    expect(ignored.accepted).toBe(false);
+    expect(ignored.session.project).toBe("viewer");
+  });
+  test("evicts old retained presence and caps sessions", () => {
+    for (let index = 0; index < presenceLimits.CAPACITY; index += 1) upsertPresence(presence({ viewSessionId: `v-${index}`, sequence: 1 }), index);
+    expect(listPresence(100).length).toBe(presenceLimits.CAPACITY);
+    upsertPresence(presence({ viewSessionId: "v-new", sequence: 1 }), 101);
+    expect(listPresence(101).length).toBe(presenceLimits.CAPACITY);
+    expect(listPresence(101).some((session) => session.viewSessionId === "v-new")).toBe(true);
+  });
+  test("preserves the maximum input sequence across accepted transport updates", () => {
+    upsertPresence(presence({ sequence: 1, inputSequence: 10 }), 1000);
+    upsertPresence(presence({ sequence: 2, inputSequence: 5 }), 2000);
+    const result = upsertPresence(presence({ sequence: 3, inputSequence: 6 }), 3000);
+    expect(result.session.inputSequence).toBe(10);
+    expect(result.session.lastInteractionAt).toBe(1000);
+  });
+  test("keeps a hidden session eligible across one-minute heartbeats until retention expires", async () => {
+    const files = [file("/a.jsonl"), file("/b.jsonl"), file("/c.jsonl")];
+    for (const [sequence, seenAt] of [1000, 61_000, 121_000].entries()) {
+      upsertPresence(presence({ visibility: "hidden", sequence: sequence + 1 }), seenAt);
+      const result = await composeSnapshot({ request: { schemaVersion: 1, text: { include: false } }, files, siblings: { selfResolution: "omitted", agents: [] }, scannerDurationMs: 0, now: seenAt + 59_999 });
+      expect(result.view.freshness).toBe("background");
+    }
+    await expect(composeSnapshot({ request: { schemaVersion: 1 }, files, siblings: { selfResolution: "omitted", agents: [] }, scannerDurationMs: 0, now: 241_001 })).rejects.toMatchObject({ code: "NO_ACTIVE_VIEW", status: 404 } satisfies Partial<SnapshotError>);
+  });
+  test("keeps visible active freshness at the existing 25-second boundary", async () => {
+    upsertPresence(presence(), 1000);
+    const session = listPresence(1000)[0]!;
+    expect(freshness(session, 25_999)).toBe("active");
+    expect(freshness(session, 26_000)).toBe("stale");
+    await expect(composeSnapshot({ request: { schemaVersion: 1 }, files: [file("/a.jsonl")], siblings: { selfResolution: "omitted", agents: [] }, scannerDurationMs: 0, now: 26_000 })).rejects.toMatchObject({ code: "NO_ACTIVE_VIEW", status: 404 } satisfies Partial<SnapshotError>);
+  });
+  test("has no active view after an in-memory restart", async () => {
+    upsertPresence(presence(), 1000);
+    resetPresenceForTest();
+    await expect(composeSnapshot({ request: { schemaVersion: 1 }, files: [], siblings: { selfResolution: "omitted", agents: [] }, scannerDurationMs: 0, now: 2000 })).rejects.toMatchObject({ code: "NO_ACTIVE_VIEW", status: 404 } satisfies Partial<SnapshotError>);
+  });
+});
+
+describe("snapshot scope", () => {
+  test("keeps full membership independent from focused text scope", async () => {
+    const result = await snapshot({ scope: { kind: "focused" }, text: { include: false } });
+    expect(result.view.visiblePaths).toEqual(["/a.jsonl", "/b.jsonl", "/c.jsonl"]);
+    expect(result.view.selectedPaths).toEqual(["/b.jsonl"]);
+    expect(result.conversations.map((item) => item.path)).toEqual(["/a.jsonl"]);
+  });
+  test("rejects an explicit path outside published membership even when the scanner finds it", async () => {
+    upsertPresence(presence(), 1000);
+    await expect(composeSnapshot({ request: { schemaVersion: 1, scope: { kind: "paths", paths: ["/escape.jsonl"] } }, files: [file("/a.jsonl"), file("/b.jsonl"), file("/c.jsonl"), file("/escape.jsonl")], siblings: { selfResolution: "omitted", agents: [] }, scannerDurationMs: 0, now: 2000 })).rejects.toMatchObject({ code: "PATH_OUTSIDE_CURRENT_VIEW", status: 422 } satisfies Partial<SnapshotError>);
+  });
+  test("filters an unknown visible path while preserving published view metadata", async () => {
+    upsertPresence(presence({ focusedPath: null, selectedPaths: [], visiblePaths: ["/a.jsonl", "/missing.jsonl", "/b.jsonl"] }), 1000);
+    const result = await composeSnapshot({ request: { schemaVersion: 1, scope: { kind: "visible" }, text: { include: false } }, files: [file("/a.jsonl"), file("/b.jsonl")], siblings: { selfResolution: "omitted", agents: [] }, scannerDurationMs: 0, now: 2000 });
+    expect(result.view.visiblePaths).toEqual(["/a.jsonl", "/missing.jsonl", "/b.jsonl"]);
+    expect(result.scope).toEqual({ kind: "visible", totalPaths: 3, returnedPaths: ["/a.jsonl", "/b.jsonl"], truncated: true, omittedCount: 1 });
+    expect(result.conversations.map((item) => item.path)).toEqual(["/a.jsonl", "/b.jsonl"]);
+  });
+  test("filters rendered shell-task paths from the transcript scope", async () => {
+    upsertPresence(presence({ focusedPath: null, selectedPaths: [], visiblePaths: ["/a.jsonl", "/task.output"] }), 1000);
+    const result = await composeSnapshot({ request: { schemaVersion: 1, scope: { kind: "visible" }, text: { include: false } }, files: [file("/a.jsonl"), file("/task.output", { engine: "shell" })], siblings: { selfResolution: "omitted", agents: [] }, scannerDurationMs: 0, now: 2000 });
+    expect(result.scope).toEqual({ kind: "visible", totalPaths: 2, returnedPaths: ["/a.jsonl"], truncated: true, omittedCount: 1 });
+    expect(result.conversations.map((item) => item.path)).toEqual(["/a.jsonl"]);
+  });
+  test("filters missing focused and selected paths independently", async () => {
+    upsertPresence(presence({ focusedPath: "/focused-missing.jsonl", selectedPaths: ["/b.jsonl", "/selected-missing.jsonl"], visiblePaths: ["/b.jsonl"] }), 1000);
+    const result = await composeSnapshot({ request: { schemaVersion: 1, text: { include: false } }, files: [file("/b.jsonl")], siblings: { selfResolution: "omitted", agents: [] }, scannerDurationMs: 0, now: 2000 });
+    expect(result.scope).toEqual({ kind: "focused-selected", totalPaths: 3, returnedPaths: ["/b.jsonl"], truncated: true, omittedCount: 2 });
+    expect(result.conversations.map((item) => item.path)).toEqual(["/b.jsonl"]);
+  });
+  test("accepts an explicit published path that has become unavailable", async () => {
+    upsertPresence(presence({ focusedPath: null, selectedPaths: [], visiblePaths: ["/missing.jsonl"] }), 1000);
+    const result = await composeSnapshot({ request: { schemaVersion: 1, scope: { kind: "paths", paths: ["/missing.jsonl"] }, text: { include: false } }, files: [], siblings: { selfResolution: "omitted", agents: [] }, scannerDurationMs: 0, now: 2000 });
+    expect(result.scope).toEqual({ kind: "paths", totalPaths: 1, returnedPaths: [], truncated: true, omittedCount: 1 });
+    expect(result.conversations).toEqual([]);
+  });
+  test("reports pre-cap totals and omissions", async () => {
+    const selected = Array.from({ length: 20 }, (_, index) => `/selected-${index}.jsonl`);
+    upsertPresence(presence({ focusedPath: null, selectedPaths: selected, visiblePaths: selected }), 1000);
+    const result = await composeSnapshot({ request: { schemaVersion: 1, scope: { kind: "selected" }, text: { include: false } }, files: selected.map((pathname) => file(pathname)), siblings: { selfResolution: "omitted", agents: [] }, scannerDurationMs: 0, now: 2000 });
+    expect(result.scope).toMatchObject({ totalPaths: 20, truncated: true, omittedCount: 4 });
+    expect(result.scope.returnedPaths).toHaveLength(16);
+  });
+  test("requires an explicit target for close multi-device interactions", async () => {
+    upsertPresence(presence(), 1000);
+    upsertPresence(presence({ viewSessionId: "view-b", deviceId: "phone", device: { kind: "mobile", browser: "safari" } }), 1001);
+    try {
+      await composeSnapshot({ request: { schemaVersion: 1, view: { resolution: "require-explicit" } }, files: [], siblings: { selfResolution: "omitted", agents: [] }, scannerDurationMs: 0, now: 2000 });
+      throw new Error("expected ambiguity");
+    } catch (error) {
+      expect(error).toMatchObject({ code: "AMBIGUOUS_ACTIVE_VIEW", status: 409 } satisfies Partial<SnapshotError>);
+      expect((error as SnapshotError).sessions?.map((session) => session.viewSessionId)).toEqual(["view-b", "view-a"]);
+    }
+  });
+  test("reads an explicitly selected stale retained session", async () => {
+    upsertPresence(presence(), 1000);
+    const result = await composeSnapshot({ request: { schemaVersion: 1, view: { id: "view-a" }, text: { include: false } }, files: [file("/a.jsonl"), file("/b.jsonl"), file("/c.jsonl")], siblings: { selfResolution: "omitted", agents: [] }, scannerDurationMs: 0, now: 30_000 });
+    expect(result.view.freshness).toBe("stale");
+    expect(result.resolution.by).toBe("explicit");
+  });
+  test("includes stale retained alternatives and only flags close interactions", async () => {
+    upsertPresence(presence({ viewSessionId: "old" }), 1000);
+    upsertPresence(presence({ viewSessionId: "new" }), 50_000);
+    const result = await composeSnapshot({ request: { schemaVersion: 1, text: { include: false } }, files: [file("/a.jsonl"), file("/b.jsonl"), file("/c.jsonl")], siblings: { selfResolution: "omitted", agents: [] }, scannerDurationMs: 0, now: 60_000 });
+    expect(result.view.viewSessionId).toBe("new");
+    expect(result.resolution.ambiguous).toBe(false);
+    expect(result.resolution.alternatives.map((session) => session.viewSessionId)).toEqual(["old"]);
+  });
+});
+
+describe("snapshot text", () => {
+  test("redacts token-shaped content and excludes tool records", () => {
+    const pathname = path.join(sandbox, "redaction.jsonl");
+    fs.writeFileSync(pathname, [
+      JSON.stringify({ type: "user", timestamp: "t1", message: { content: "token=secret sk-ant-abcdefghijklmnopqrstuvwxyz" } }),
+      JSON.stringify({ type: "assistant", timestamp: "t2", message: { content: [{ type: "text", text: "Bearer abcdefghijklmnopqrstuvwxyz" }, { type: "tool_use", name: "Bash", input: { secret: "x" } }] } }),
+    ].join("\n"));
+    const value = compactText(file(pathname), 6, 4000, 4000);
+    expect(JSON.stringify(value)).not.toContain("abcdefghijklmnopqrstuvwxyz");
+    expect(hardenedRedact("ghp_abcdefghijklmnopqrstuvwxyz1234567890")).toBe("[redacted]");
+  });
+  test("redacts credential families and header values", () => {
+    const fixtures = [
+      "Authorization: Basic dXNlcjpwYXNz", "Cookie: session=secret; csrf=secret", "Set-Cookie: auth=secret",
+      "github_pat_abcdefghijklmnopqrstuvwxyz123456", "xoxb-" + "1234567890-abcdefghijklmnopqrstuvwxyz", "npm_abcdefghijklmnopqrstuvwxyz123456",
+      "AKIAABCDEFGHIJKLMNOP", "AIzaabcdefghijklmnopqrstuvwxyz123456789", "eyJabcdefghij.abcdefghijk.abcdefghijk",
+      "-----BEGIN PRIVATE KEY-----\nsecret\n-----END PRIVATE KEY-----",
+    ];
+    for (const fixture of fixtures) expect(hardenedRedact(fixture)).not.toContain("secret");
+    expect(hardenedRedact(fixtures.join("\n"))).not.toMatch(/github_pat_|xoxb-|npm_|AKIA|AIza|eyJ/);
+  });
+  test("refuses a scan-then-symlink transcript swap", () => {
+    const target = path.join(sandbox, "outside.txt");
+    const pathname = path.join(sandbox, "swapped.jsonl");
+    fs.writeFileSync(target, "TOP_SECRET_OUTSIDE");
+    fs.rmSync(pathname, { force: true });
+    fs.symlinkSync(target, pathname);
+    const result = compactText(file(pathname), 6, 4000, 4000);
+    expect(result).toMatchObject({ messages: [], truncated: true, error: "unavailable" });
+    expect(JSON.stringify(result)).not.toContain("TOP_SECRET_OUTSIDE");
+  });
+  test("keeps aggregate multibyte text within 32 KiB", async () => {
+    const paths = Array.from({ length: 9 }, (_, index) => path.join(sandbox, `emoji-${index}.jsonl`));
+    for (const pathname of paths) fs.writeFileSync(pathname, JSON.stringify({ type: "assistant", timestamp: "t", message: { content: [{ type: "text", text: "😀".repeat(4000) }] } }) + "\n");
+    upsertPresence(presence({ focusedPath: null, selectedPaths: paths, visiblePaths: paths }), 1000);
+    const result = await composeSnapshot({ request: { schemaVersion: 1, scope: { kind: "selected" }, text: { maxCharsPerConversation: 4000 } }, files: paths.map((pathname) => file(pathname)), siblings: { selfResolution: "omitted", agents: [] }, scannerDurationMs: 0, now: 2000 });
+    const bytes = result.conversations.flatMap((item) => item.text?.messages ?? []).reduce((total, message) => total + Buffer.byteLength(message.text, "utf8"), 0);
+    expect(bytes).toBeLessThanOrEqual(32 * 1024);
+  });
+});
+
+test("validators bound membership and scope", () => {
+  expect(() => validatePresence({ ...presence(), visiblePaths: Array.from({ length: 129 }, (_, index) => `/p-${index}`) })).toThrow(ViewValidationError);
+  expect(() => validateSnapshotRequest({ schemaVersion: 1, scope: { kind: "paths", paths: Array.from({ length: 17 }, (_, index) => `/p-${index}`) } })).toThrow(ViewValidationError);
+  expect(() => validatePresence({ ...presence(), sequence: 1.5 })).toThrow(ViewValidationError);
+  expect(() => validatePresence({ ...presence(), project: "p".repeat(257) })).toThrow(ViewValidationError);
+  expect(() => validatePresence({ ...presence(), mode: "list", camera: { x: 0, y: 0, zoom: 1, worldRect: { x: 0, y: 0, width: 1, height: 1 } } })).toThrow(ViewValidationError);
+  expect(() => validatePresence({ ...presence(), extra: true })).toThrow(ViewValidationError);
+  expect(() => validateSnapshotRequest({ schemaVersion: 1, text: { lastMessages: 1.5 } })).toThrow(ViewValidationError);
+  expect(() => validateSnapshotRequest({ schemaVersion: 1, unknown: true })).toThrow(ViewValidationError);
+});

--- a/src/proxy.test.ts
+++ b/src/proxy.test.ts
@@ -1,0 +1,20 @@
+import { afterEach, expect, test } from "bun:test";
+import { NextRequest } from "next/server";
+
+import { proxy } from "./proxy";
+
+const originalToken = process.env.LLV_TOKEN;
+afterEach(() => {
+  if (originalToken === undefined) delete process.env.LLV_TOKEN;
+  else process.env.LLV_TOKEN = originalToken;
+});
+
+function remote(authorization: string): NextRequest {
+  return new NextRequest("http://viewer.example/api/agent/snapshot", { headers: { host: "viewer.example", "x-forwarded-for": "203.0.113.10", authorization } });
+}
+
+test("remote agent access accepts the exact Bearer LLV_TOKEN", () => {
+  process.env.LLV_TOKEN = "viewer-token";
+  expect(proxy(remote("Bearer viewer-token")).headers.get("x-middleware-next")).toBe("1");
+  expect(proxy(remote("Bearer wrong-token")).status).toBe(403);
+});

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -108,6 +108,12 @@ export function proxy(request: NextRequest): NextResponse {
     return NextResponse.next();
   }
 
+  const authorization = request.headers.get("authorization");
+  const bearer = authorization?.match(/^Bearer\s+(.+)$/i)?.[1];
+  if (tokenMatches(bearer, token)) {
+    return NextResponse.next();
+  }
+
   const queryToken = request.nextUrl.searchParams.get("k");
   if (queryToken !== null && tokensMatch(queryToken, token)) {
     return redirectWithCookie(request, token);


### PR DESCRIPTION
## Outcome

Viewer state now follows the user across devices, and agents can inspect the active board through a bounded, redacted snapshot API.

## Included

- durable per-project board state with revision-safe updates
- bounded presence publishing for visible, focused, and selected conversations
- agent snapshot endpoint with explicit multi-device targeting and hardened text redaction
- keyboard navigation and accessibility preservation through the shared board integration
- orchestration skill guidance for the agent-facing surface

## Review and verification

- one fresh Fable UI/UX review round completed
- all eight review findings addressed across frontend and backend
- 567 tests passed with 3,030 assertions
- ESLint passed
- TypeScript passed
- production build passed
- diff check passed

Closes #11
Closes #38