### PR TITLE
Fix duplicated Codex assistant messages

### DIFF
--- a/src/components/feed/parse.test.ts
+++ b/src/components/feed/parse.test.ts
@@ -80,6 +80,10 @@ const claudeSend = (id: string, to: string, message: string) =>
 const codexUserResponse = (timestamp: string, content: Record<string, unknown>[]) =>
   JSON.stringify({ type: "response_item", timestamp, payload: { type: "message", role: "user", content } });
 const codexUserEvent = (timestamp: string, message: string) => JSON.stringify({ type: "event_msg", timestamp, payload: { type: "user_message", message } });
+const codexAssistantResponse = (timestamp: string, text: string) =>
+  JSON.stringify({ type: "response_item", timestamp, payload: { type: "message", role: "assistant", phase: "commentary", content: [{ type: "output_text", text }] } });
+const codexAssistantEvent = (timestamp: string, message: string) =>
+  JSON.stringify({ type: "event_msg", timestamp, payload: { type: "agent_message", phase: "commentary", message } });
 const codexUserPair = (timestamp: string, text: string) => [codexUserResponse(timestamp, [{ type: "input_text", text }]), codexUserEvent(timestamp, text)];
 const codexReasoning = (timestamp: string) => JSON.stringify({ type: "response_item", timestamp, payload: { type: "reasoning" } });
 
@@ -452,6 +456,114 @@ describe("Codex user-turn coalescing", () => {
     expect(itemsOfKind({ items: echoOnly.items.map((entry) => entry.item), hiddenServiceCount: echoOnly.hiddenServiceCount }, "user")).toHaveLength(1);
     assertParity(codexFile, [response, echo, next], { chunks: [2, 1], cap: 2 });
     assertParity(codexFile, [response, echo, next], { chunks: [1], cap: 1 });
+  });
+});
+
+describe("Codex assistant prose coalescing", () => {
+  test("coalesces production-shaped echoes in either record order and gives the event timestamp ownership", () => {
+    const sevenMsText = "Причина `sudo` тоже найдена точно: сокет Docker имеет права `root:docker`, пользователь `latand` уже записан в группу `docker`, однако текущая login-сессия запущена без этой дополнительной группы. Host network, PID namespace и маунты к этому отношения не имеют. После нового входа в сессию группа подхватится; для текущей оболочки можно запускать через `sg docker -c ...`. Проверяю доступ этим способом без изменения системы.";
+    const zeroMsText = "Account-switch UI готов и закоммичен: bare `select()` удалён, обе поверхности используют preview → confirm/migrate, активный аккаунт можно нажать для ремонта застрявших поколений, retry получает свежую revision. Переношу UI-коммит в общую ветку и запускаю интеграционную проверку backend+frontend. После неё будет один свежий независимый review-round.";
+    const productionOrder = [
+      JSON.stringify({ type: "event_msg", timestamp: "2026-07-10T07:05:12.128Z", payload: { type: "agent_message", message: sevenMsText, phase: "commentary", memory_citation: null } }),
+      JSON.stringify({ type: "response_item", timestamp: "2026-07-10T07:05:12.135Z", payload: { type: "message", id: "msg_0393b5967eeb6b3d016a5099a6c6f881918750dcfe9b95b684", role: "assistant", content: [{ type: "output_text", text: sevenMsText }], phase: "commentary" } }),
+    ];
+    const reversedOrder = [
+      JSON.stringify({ type: "response_item", timestamp: "2026-07-10T07:05:24.424Z", payload: { type: "message", id: "msg_0393b5967eeb6b3d016a5099b33df88191bfb8b5a7b245ebb7", role: "assistant", content: [{ type: "output_text", text: zeroMsText }], phase: "commentary" } }),
+      JSON.stringify({ type: "event_msg", timestamp: "2026-07-10T07:05:24.424Z", payload: { type: "agent_message", message: zeroMsText, phase: "commentary", memory_citation: null } }),
+    ];
+
+    expect(itemsOfKind(buildFeed(codexFile, productionOrder, false, ""), "prose")).toEqual([
+      { kind: "prose", ts: "2026-07-10T07:05:12.128Z", text: sevenMsText, engine: "codex" },
+    ]);
+    expect(itemsOfKind(buildFeed(codexFile, reversedOrder, false, ""), "prose")).toEqual([
+      { kind: "prose", ts: "2026-07-10T07:05:24.424Z", text: zeroMsText, engine: "codex" },
+    ]);
+  });
+
+  test("requires opposite shapes, adjacent source records, matching normalized text, and the correlation boundary", () => {
+    const text = "same assistant message";
+    const at = "2026-07-10T07:06:16.000Z";
+    const cases: { lines: string[]; count: number; label: string }[] = [
+      { label: "two events", lines: [codexAssistantEvent(at, text), codexAssistantEvent(at, text)], count: 2 },
+      { label: "two responses", lines: [codexAssistantResponse(at, text), codexAssistantResponse(at, text)], count: 2 },
+      { label: "different text", lines: [codexAssistantEvent(at, text), codexAssistantResponse(at, "different")], count: 2 },
+      { label: "normalized whitespace", lines: [codexAssistantEvent(at, `  ${text}  `), codexAssistantResponse("2026-07-10T07:06:16.500Z", `\n${text}\n`)], count: 1 },
+      { label: "one second", lines: [codexAssistantEvent(at, text), codexAssistantResponse("2026-07-10T07:06:17.000Z", text)], count: 1 },
+      { label: "one second plus one millisecond", lines: [codexAssistantEvent(at, text), codexAssistantResponse("2026-07-10T07:06:17.001Z", text)], count: 2 },
+    ];
+    for (const { lines, count, label } of cases) {
+      expect(itemsOfKind(buildFeed(codexFile, lines, false, ""), "prose"), label).toHaveLength(count);
+    }
+
+    const separated = [codexAssistantEvent(at, text), codexReasoning("2026-07-10T07:06:16.100Z"), codexAssistantResponse("2026-07-10T07:06:16.200Z", text)];
+    for (const showSvc of [false, true]) {
+      expect(itemsOfKind(buildFeed(codexFile, separated, showSvc, ""), "prose")).toHaveLength(2);
+    }
+  });
+
+  test("consumes echo eligibility one pair at a time", () => {
+    const text = "alternate";
+    const event = codexAssistantEvent("2026-07-10T07:06:16.000Z", text);
+    const response = codexAssistantResponse("2026-07-10T07:06:16.001Z", text);
+    expect(itemsOfKind(buildFeed(codexFile, [event, response, event, response], false, ""), "prose")).toHaveLength(2);
+    expect(itemsOfKind(buildFeed(codexFile, [event, response, event], false, ""), "prose")).toHaveLength(2);
+  });
+
+  test("preserves the first live-tail key in both orders", () => {
+    const text = "live tail";
+    const orders = [
+      { lines: [codexAssistantEvent("2026-07-10T07:06:16.000Z", text), codexAssistantResponse("2026-07-10T07:06:16.007Z", text)], eventTs: "2026-07-10T07:06:16.000Z" },
+      { lines: [codexAssistantResponse("2026-07-10T07:06:17.000Z", text), codexAssistantEvent("2026-07-10T07:06:17.007Z", text)], eventTs: "2026-07-10T07:06:17.007Z" },
+    ];
+    for (const { lines: [first, second], eventTs } of orders) {
+      const session = createFeedSession({ engine: "codex", fmt: "codex", showSvc: false, lineFilter: "" });
+      const preview = session.feed([first], 0, true);
+      const complete = session.feed([first, second], 0, true);
+      expect(complete.items).toHaveLength(1);
+      expect(complete.items[0]?.key).toBe(preview.items[0]?.key);
+      expect(complete.items[0]?.item).toMatchObject({ kind: "prose", ts: eventTs });
+    }
+  });
+
+  test("keeps review, citation, and blob payloads intact while coalescing their sources", () => {
+    const review = "VERDICT: APPROVE\n\nSummary: parser contract holds.";
+    const citation = "<oai-mem-citation>\n<citation_entries>\nMEMORY.md:1-2|note=[contract]\n</citation_entries>\n<rollout_ids>\n019f4944-97f1-7f20-bd8b-7c3c23085bb0\n</rollout_ids>\n</oai-mem-citation>";
+    const variants = [review, `${review}\n\n${citation}`, "x".repeat(20_001)];
+    for (const text of variants) {
+      for (const [first, second] of [
+        [codexAssistantEvent("2026-07-10T07:06:16.000Z", text), codexAssistantResponse("2026-07-10T07:06:16.007Z", text)],
+        [codexAssistantResponse("2026-07-10T07:06:17.000Z", text), codexAssistantEvent("2026-07-10T07:06:17.007Z", text)],
+      ]) {
+        const paired = buildFeed(codexFile, [first, second], false, "").items;
+        const eventRecord = first.includes("event_msg") ? first : second;
+        const standalone = buildFeed(codexFile, [eventRecord], false, "").items;
+        expect(paired.map((item) => ({ ...item, ts: undefined }))).toEqual(standalone.map((item) => ({ ...item, ts: undefined })));
+        expect(paired.filter((item) => item.kind === "review")).toHaveLength(text.startsWith("VERDICT") ? 1 : 0);
+        expect(paired.filter((item) => item.kind === "mem-citation")).toHaveLength(text.includes("<oai-mem-citation>") ? 1 : 0);
+        expect(paired.filter((item) => item.kind === "blob")).toHaveLength(text.length === 20_001 ? 1 : 0);
+        const reviewItem = paired.find((item) => item.kind === "review");
+        if (reviewItem?.kind === "review") expect(reviewItem.ts).toBe(second.includes("event_msg") ? JSON.parse(second).timestamp : JSON.parse(first).timestamp);
+      }
+    }
+  }, 15_000);
+
+  test("keeps incremental, prepend, and sliding-window parsing equivalent to a fresh parse", () => {
+    const event = codexAssistantEvent("2026-07-10T07:06:16.000Z", "seam");
+    const response = codexAssistantResponse("2026-07-10T07:06:16.007Z", "seam");
+    for (const lines of [[event, response], [response, event]]) {
+      assertParity(codexFile, lines, { chunks: [1], cap: 1, live: true });
+      assertParity(codexFile, lines, { chunks: [2, 1], cap: 2 });
+      const session = createFeedSession({ engine: "codex", fmt: "codex", showSvc: false, lineFilter: "" });
+      const prepend = session.feed([lines[1]], 1, false);
+      const widened = session.feed(lines, 0, false);
+      expect(widened.items.map((entry) => entry.item)).toEqual(buildFeed(codexFile, lines, false, "").items);
+      expect(prepend.items).toHaveLength(1);
+
+      const sliding = createFeedSession({ engine: "codex", fmt: "codex", showSvc: false, lineFilter: "" });
+      sliding.feed(lines, 0, false);
+      const secondOnly = sliding.feed([lines[1]], 1, false);
+      expect(secondOnly.items.map((entry) => entry.item)).toEqual(buildFeed(codexFile, [lines[1]], false, "").items);
+    }
   });
 });
 

--- a/src/components/feed/parse.ts
+++ b/src/components/feed/parse.ts
@@ -353,7 +353,18 @@ interface PendingCodexUser {
   entrySeqs: number[];
 }
 
-function sameCodexUserTurn(leftTs: unknown, leftText: unknown, rightTs: unknown, rightText: unknown): boolean {
+type CodexAssistantShape = "event-agent" | "response-assistant";
+
+interface CodexAssistantRecord {
+  shape: CodexAssistantShape;
+  text: string;
+  ts: unknown;
+  src: number;
+  firstSeq: number;
+  lastSeq: number;
+}
+
+function sameCodexTextAtTime(leftTs: unknown, leftText: unknown, rightTs: unknown, rightText: unknown): boolean {
   const leftNormalizedText = textPart(leftText).trim();
   const rightNormalizedText = textPart(rightText).trim();
   if (!leftNormalizedText || leftNormalizedText !== rightNormalizedText) return false;
@@ -422,7 +433,7 @@ export function createFeedSession(cfg: FeedSessionConfig): FeedSession {
   /* Dedup/marker state remembers the source line it came from: when that line
      slides out of the window the state clears, matching what a re-parse of
      the shortened window would know. */
-  let lastProse: { text: string; src: number; seq: number } | null = null;
+  let codexAssistantRecord: CodexAssistantRecord | null = null;
   /* A composer turn is recorded as a user response item immediately followed
      by its user_message event. The event owns the logical turn, while this
      provisional record keeps a live tail visible until its echo arrives. */
@@ -518,23 +529,47 @@ export function createFeedSession(cfg: FeedSessionConfig): FeedSession {
       .trim();
     return { cleaned, cites };
   };
-  const addProse = (ts: unknown, text: string) => {
-    if (!text.trim()) return;
-    const src = curSrc;
-    if (pushBlobIfHuge(text)) return;
+  const addProse = (ts: unknown, text: string): { firstSeq: number; lastSeq: number } | null => {
+    if (!text.trim()) return null;
+    const firstSeq = pushSeq;
+    if (pushBlobIfHuge(text)) return { firstSeq, lastSeq: pushSeq - 1 };
     const engine = cfg.engine === "codex" ? "codex" : "claude";
-    if (pushStructured(ts, text, (segment) => push({ kind: "prose", ts, text: segment, engine }))) return;
-    const seq = push({ kind: "prose", ts, text, engine });
-    lastProse = { text, src, seq };
+    if (pushStructured(ts, text, (segment) => push({ kind: "prose", ts, text: segment, engine }))) {
+      return { firstSeq, lastSeq: pushSeq - 1 };
+    }
+    push({ kind: "prose", ts, text, engine });
+    return { firstSeq, lastSeq: pushSeq - 1 };
   };
-  const adoptCodexProseEcho = (ts: unknown, text: string): boolean => {
-    if (!lastProse || lastProse.text !== text || lastProse.src !== curSrc - 1) return false;
-    const idx = entryIndex(lastProse.seq);
-    if (idx < 0 || idx >= entries.length || entries[idx]?.item.kind !== "prose") return false;
-    entries[idx] = { ...entries[idx], src: curSrc, item: { ...entries[idx].item, ts } };
-    lastProse = { ...lastProse, src: curSrc };
-    snapshot = null;
-    return true;
+  const addCodexAssistant = (shape: CodexAssistantShape, ts: unknown, text: string) => {
+    const normalizedText = text.trim();
+    const candidate = codexAssistantRecord;
+    if (
+      candidate &&
+      candidate.shape !== shape &&
+      candidate.src === curSrc - 1 &&
+      candidate.text === normalizedText &&
+      sameCodexTextAtTime(candidate.ts, candidate.text, ts, normalizedText)
+    ) {
+      const eventTimestamp = shape === "event-agent" ? ts : candidate.shape === "event-agent" ? candidate.ts : ts;
+      for (let seq = candidate.firstSeq; seq <= candidate.lastSeq; seq += 1) {
+        const idx = entryIndex(seq);
+        if (idx < 0 || idx >= entries.length) continue;
+        const entry = entries[idx];
+        const item = entry.item;
+        entries[idx] = {
+          ...entry,
+          src: curSrc,
+          item: item.kind === "prose" || item.kind === "review" ? { ...item, ts: eventTimestamp } : item,
+        };
+      }
+      codexAssistantRecord = null;
+      snapshot = null;
+      return;
+    }
+    const emitted = addProse(ts, text);
+    codexAssistantRecord = emitted
+      ? { shape, text: normalizedText, ts, src: curSrc, firstSeq: emitted.firstSeq, lastSeq: emitted.lastSeq }
+      : null;
   };
   const addCmd = (ts: unknown, cmd: string, callId?: string, icon?: GlyphName) => {
     const id = callId || "plain-" + pushSeq + "-" + String(ts ?? "");
@@ -700,7 +735,7 @@ export function createFeedSession(cfg: FeedSessionConfig): FeedSession {
     pendingCodexUsers.push(pending);
   };
   const addCodexEventUser = (ts: unknown, text: string) => {
-    const pendingIndex = pendingCodexUsers.findIndex((pending) => sameCodexUserTurn(pending.ts, pending.text, ts, text));
+    const pendingIndex = pendingCodexUsers.findIndex((pending) => sameCodexTextAtTime(pending.ts, pending.text, ts, text));
     if (pendingIndex < 0) {
       emitCodexUserContent(ts, { text, attachments: [] });
       return;
@@ -747,9 +782,7 @@ export function createFeedSession(cfg: FeedSessionConfig): FeedSession {
       if (p.type === "user_message" && p.message) return addCodexEventUser(ts, textPart(p.message));
       finalizePendingCodexUsers();
       if (p.type === "agent_message" && p.message) {
-        const text = textPart(p.message);
-        if (!adoptCodexProseEcho(ts, text)) addProse(ts, text);
-        return;
+        return addCodexAssistant("event-agent", ts, textPart(p.message));
       }
       if (p.type === "task_started") return addNote(tr("render.taskStarted") + (ts ? " · " + hhmm(ts) : ""));
       if (p.type === "task_complete") return addNote(tr("render.taskComplete") + (ts ? " · " + hhmm(ts) : ""));
@@ -765,7 +798,7 @@ export function createFeedSession(cfg: FeedSessionConfig): FeedSession {
         finalizePendingCodexUsers();
         const text = normalizeCodexUserContent(p.content).text;
         if (!text) return addSvc("message " + textPart(p.role));
-        if (p.role === "assistant") return addProse(ts, text);
+        if (p.role === "assistant") return addCodexAssistant("response-assistant", ts, text);
         /* developer/system turns (<permissions instructions>, collaboration
            mode, …) are harness-injected, never something the user typed. */
         return addSysMsg(text, textPart(p.role));
@@ -991,7 +1024,7 @@ export function createFeedSession(cfg: FeedSessionConfig): FeedSession {
     tmsgKeyBySeq.clear();
     hiddenSvcBySrc.clear();
     hiddenServiceCount = 0;
-    lastProse = null;
+    codexAssistantRecord = null;
     pendingCodexUsers = [];
     codexCompacted = null;
     plainBlock = null;
@@ -1027,7 +1060,7 @@ export function createFeedSession(cfg: FeedSessionConfig): FeedSession {
       hiddenSvcBySrc.delete(src);
       snapshot = null;
     }
-    if (lastProse && lastProse.src < start) lastProse = null;
+    if (codexAssistantRecord && codexAssistantRecord.src < start) codexAssistantRecord = null;
     pendingCodexUsers = pendingCodexUsers.filter((pending) => pending.src >= start);
     if (codexCompacted && codexCompacted.src < start) codexCompacted = null;
     if (lastPlainCall && entryIndex(lastPlainCall.seq) < 0) lastPlainCall = null;


### PR DESCRIPTION
Fixes #64

## Summary

- coalesce adjacent Codex assistant `event_msg` and `response_item` echoes in both source orders
- preserve deliberate repeated messages from the same record shape
- keep event timestamps, stable keys, structured review blocks, memory citations, and large blobs across incremental and sliding windows
- add production-shaped fixtures and boundary coverage for adjacency, 1000 ms correlation, one-to-one pairing, live tails, prepend parity, and eviction

## Verification

- focused parser tests: 29 passed
- full test suite: 743 passed
- TypeScript check passed
- owned-file lint passed
- production build passed
- diff check passed
- fresh Sol review: APPROVE with zero findings