### PR TITLE
Stabilize board membership close and restore semantics

### DIFF
--- a/src/app/api/board/route.test.ts
+++ b/src/app/api/board/route.test.ts
@@ -1,0 +1,57 @@
+import { afterAll, beforeEach, expect, test } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { NextRequest } from "next/server";
+
+import { setBoardFileForTests } from "@/lib/board/store";
+
+const sandbox = fs.mkdtempSync(path.join(os.tmpdir(), "llv-board-route-test-"));
+const { PATCH } = await import("./route");
+
+let testFile = "";
+beforeEach(() => {
+  testFile = path.join(fs.mkdtempSync(path.join(sandbox, "state-")), "board.json");
+  setBoardFileForTests(testFile);
+});
+afterAll(() => {
+  setBoardFileForTests(null);
+  fs.rmSync(sandbox, { recursive: true, force: true });
+});
+
+function patch(body: unknown): NextRequest {
+  return new NextRequest("http://127.0.0.1:8898/api/board", {
+    method: "PATCH",
+    headers: { host: "127.0.0.1", "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+test("board route accepts revision-fenced mutations and converges an identical stale replay", async () => {
+  const intent = { schemaVersion: 1, project: "viewer", baseRevision: 0, mutations: [{ kind: "remap-paths", pairs: [{ from: "/old", to: "/new" }] }] };
+  const first = await PATCH(patch(intent));
+  const replay = await PATCH(patch(intent));
+
+  expect(first.status).toBe(200);
+  expect(replay.status).toBe(200);
+  expect(await first.json()).toMatchObject({ ok: true, board: { revision: 1, pathAliases: { "/old": "/new" } } });
+  expect(await replay.json()).toMatchObject({ ok: true, board: { revision: 1 } });
+});
+
+test("board route retains scalar patch and revision-zero legacy seed compatibility", async () => {
+  const response = await PATCH(patch({ schemaVersion: 1, project: "legacy", baseRevision: 0, patch: { manual: ["/legacy"], taskPanelOpen: true } }));
+  expect(response.status).toBe(200);
+  expect(await response.json()).toMatchObject({ ok: true, board: { revision: 1, prefs: { manual: ["/legacy"], taskPanelOpen: true } } });
+});
+
+test("board route returns the current board for a conflicting mutation and persists presentation intent", async () => {
+  const first = await PATCH(patch({ schemaVersion: 1, project: "conflict", baseRevision: 0, mutations: [{ kind: "close", path: "/one" }] }));
+  const conflict = await PATCH(patch({ schemaVersion: 1, project: "conflict", baseRevision: 0, mutations: [{ kind: "close", path: "/two" }] }));
+  const presentation = await PATCH(patch({ schemaVersion: 1, project: "presentation", baseRevision: 0, mutations: [{ kind: "set-presentation", viewMode: "scheme", taskPanelOpen: true }] }));
+
+  expect(first.status).toBe(200);
+  expect(conflict.status).toBe(409);
+  expect(await conflict.json()).toMatchObject({ error: "BOARD_REVISION_CONFLICT", board: { revision: 1, prefs: { hidden: ["/one"] } } });
+  expect(await presentation.json()).toMatchObject({ ok: true, board: { prefs: { viewMode: "scheme", taskPanelOpen: true } } });
+});

--- a/src/app/api/board/route.ts
+++ b/src/app/api/board/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 
-import { boardFor, BoardStoreError, patchBoard } from "@/lib/board/store";
+import { boardFor, BoardStoreError, mutateBoard, patchBoard } from "@/lib/board/store";
 import { validateBoardPatchRequest } from "@/lib/board/validation";
 import { rejectCrossOrigin } from "@/lib/sameOrigin";
 import { ViewValidationError } from "@/lib/view/validation";
@@ -27,7 +27,9 @@ export async function PATCH(request: NextRequest): Promise<NextResponse> {
   if (rejection) { rejection.headers.set("Cache-Control", "no-store"); return rejection; }
   try {
     const payload = await validateBoardPatchRequest(request);
-    const result = patchBoard(payload.project, payload.baseRevision, payload.patch);
+    const result = payload.mutations
+      ? mutateBoard(payload.project, payload.baseRevision, payload.mutations)
+      : patchBoard(payload.project, payload.baseRevision, payload.patch!);
     if (!result.ok) return NextResponse.json({ error: "BOARD_REVISION_CONFLICT", board: result.board }, { status: 409, headers });
     return NextResponse.json({ ok: true, board: result.board }, { headers });
   } catch (error) {

--- a/src/components/ProjectDashboard.tsx
+++ b/src/components/ProjectDashboard.tsx
@@ -457,7 +457,7 @@ export function ProjectDashboard({
       }),
     );
     /* eslint-disable-next-line react-hooks/exhaustive-deps -- board.mutate is
-       delegated to a ref-stable store; manual is read from the ref, not tracked */
+       delegated to a ref-stable store; manual is read through that ref. */
   }, [rootGroups, files, projectCatalog, project, board.loaded, board.sync]);
 
   /* Any open lands on the scheme: a card of another project pre-adds its node
@@ -479,10 +479,10 @@ export function ProjectDashboard({
     /* An explicit open is a restore: it lifts any tombstone and places the node
        by role. A child conversation expands as a node wired below its parent
        (the scheme promotes it via expandedConversationPaths); the predicate must
-       match what buildBranchGroups can actually promote (isChildConversation),
-       not just "has a parent" — a compaction predecessor has a parent but is
-       neither a conversation nor a child, so routing it to expanded renders
-       nothing. A node that is already an auto column restores in place (no stored
+       match what buildBranchGroups can actually promote (isChildConversation).
+       A compaction predecessor belongs outside the conversation and child
+       categories, so routing it to expanded renders nothing. A node that is
+       already an auto column restores in place (no stored
        membership); everything else becomes a standalone manual node. */
     if (isChildConversation(file)) {
       board.restore(file.path, "expanded");

--- a/src/components/ProjectDashboard.tsx
+++ b/src/components/ProjectDashboard.tsx
@@ -15,6 +15,7 @@ import type { Workflow } from "@/lib/workflows/types";
 
 import { TaskStrip } from "./BranchPane";
 import { clearDraftStorage, draftSrc, setDraftSrc, setDraftText } from "./DraftAgentPane";
+import { planBoardConvergence, planClose } from "./projectBoardMutations";
 import { claimedReviewerDescendantPaths, foldClaimedReviewers, isActiveFlow } from "./flows/flowModel";
 import { clearWorkflowDraftStorage } from "./workflows/WorkflowDraftPane";
 import { WorkflowStrip } from "./workflows/WorkflowStrip";
@@ -193,8 +194,6 @@ export function ProjectDashboard({
     },
     [],
   );
-
-  const persistPrefs = (next: ColumnPrefs) => board.patchColumns(next);
 
   /* Reviewer transcripts of active flows live inside their round decks:
      they never build their own groups, quiet trees or residual chips. */
@@ -411,56 +410,55 @@ export function ProjectDashboard({
       headers: { "content-type": "application/json" },
       body: JSON.stringify({ action: "kill", path }),
     }).catch(() => {});
-    const manual = prefs.manual.filter((item) => item !== path);
-    const hidden = autoPaths.has(path) ? [...new Set([...prefs.hidden, path])] : prefs.hidden;
-    /* Closing a hand-expanded child also drops it from the expand set, so it
-       collapses back into its parent's quiet history instead of reappearing. */
-    const expanded = prefs.expanded.filter((item) => item !== path);
-    persistPrefs({ ...prefs, manual, hidden, expanded });
-    setEphemeral((prev) => (prev.includes(path) ? prev.filter((item) => item !== path) : prev));
+    /* One durable close, independent of the node's current render class: the
+       server reducer tombstones the path and strips manual/expanded membership,
+       so a node closed while momentarily outside `autoPaths` no longer loses its
+       tombstone and reappears (#60). The matching ephemeral jump target, if any,
+       clears locally. */
+    board.mutate([planClose(path, ephemeral).mutation]);
+    setEphemeral((prev) => planClose(path, prev).ephemeral);
   };
 
-  /* Latest prefs behind a ref so the auto-record effect below reads current
-     board state without re-running on every prefs change (which would oscillate
-     when auto nodes exceed the 40 cap). */
+  /* Latest manual list behind a ref so the convergence effect below reads
+     current board state without re-running on every prefs change. */
   const prefsSnapshotRef = useRef(prefs);
   useEffect(() => {
     prefsSnapshotRef.current = prefs;
   });
 
-  /* Account-migration succession replaces a predecessor transcript path with
-     its successor while retaining the stable conversation identity. Rewrite
-     path-keyed board preferences through the shared server store so placement,
-     hidden state and hand-expanded state survive across devices. */
-  useEffect(() => {
-    if (!board.loaded || board.sync === "unavailable") return;
-    const rename = new Map<string, string>();
-    for (const file of files) {
-      if (file.predecessorPath && projectKey(file) === project) rename.set(file.predecessorPath, file.path);
-    }
-    if (!rename.size) return;
-    const prev = prefsSnapshotRef.current;
-    const remap = (list: string[]) => [...new Set(list.map((path) => rename.get(path) ?? path))];
-    const next: ColumnPrefs = { manual: remap(prev.manual), hidden: remap(prev.hidden), expanded: remap(prev.expanded) };
-    if (JSON.stringify(next) === JSON.stringify(prev)) return;
-    prefsSnapshotRef.current = next;
-    board.patchColumns(next);
-  }, [board, files, project]);
+  /* Every conversation the current catalog knows for this project, keyed by
+     path — the convergence planner retires a manual entry that has left it. */
+  const projectCatalog = useMemo(
+    () => new Map(groupFiles.filter((file) => projectKey(file) === project).map((file) => [file.path, file] as const)),
+    [groupFiles, project],
+  );
+  /* Only the root key and orphan flag of each group matter to reconciliation. */
+  const rootGroups = useMemo(() => groups.map((group) => ({ key: group.key, orphanTask: group.orphanTask })), [groups]);
 
-  /* A node never vanishes on its own: every auto node is recorded as a manual
-     one, so a branch that goes quiet keeps its place until the user closes it.
-     Capped so old projects do not accumulate forever. Runs once per auto-node
-     change (like the old localStorage path) and only after the shared board has
-     loaded, so it patches on top of the server state, not over it. */
+  /* Board membership convergence, as one ordered mutation batch:
+       1. succession remap — a predecessor's tombstone/placement follows the
+          stable conversation identity to its successor path;
+       2. root reconciliation — seed every current root and retire child/subagent
+          or catalog-absent pollution from `manual`, preserving tombstones.
+     Remap precedes reconciliation so a hidden successor is honored and never
+     re-seeded. Both mutations are idempotent, so a batch that changes nothing is
+     dropped by the store before transport — no revision churn, no 40-entry
+     oscillation. Runs only after the shared board has loaded, so it replays onto
+     the server arrangement. */
   useEffect(() => {
     if (!board.loaded || board.sync === "unavailable") return;
-    const prev = prefsSnapshotRef.current;
-    const missing = [...autoPaths].filter((path) => !prev.manual.includes(path) && !prev.hidden.includes(path));
-    if (!missing.length) return;
-    board.patchColumns({ manual: [...prev.manual, ...missing].slice(-40), hidden: prev.hidden, expanded: prev.expanded });
-    /* eslint-disable-next-line react-hooks/exhaustive-deps -- board setters are
-       ref-stable; prefs are read from the ref, not tracked as deps */
-  }, [autoPaths, board.loaded, board.sync]);
+    board.mutate(
+      planBoardConvergence({
+        files,
+        groups: rootGroups,
+        manual: prefsSnapshotRef.current.manual,
+        catalog: projectCatalog,
+        project,
+      }),
+    );
+    /* eslint-disable-next-line react-hooks/exhaustive-deps -- board.mutate is
+       delegated to a ref-stable store; manual is read from the ref, not tracked */
+  }, [rootGroups, files, projectCatalog, project, board.loaded, board.sync]);
 
   /* Any open lands on the scheme: a card of another project pre-adds its node
      and switches the project; a conversation of this project joins the managed
@@ -478,23 +476,20 @@ export function ProjectDashboard({
       flashNode(file.path);
       return;
     }
-    const hidden = prefs.hidden.filter((item) => item !== file.path);
+    /* An explicit open is a restore: it lifts any tombstone and places the node
+       by role. A child conversation expands as a node wired below its parent
+       (the scheme promotes it via expandedConversationPaths); the predicate must
+       match what buildBranchGroups can actually promote (isChildConversation),
+       not just "has a parent" — a compaction predecessor has a parent but is
+       neither a conversation nor a child, so routing it to expanded renders
+       nothing. A node that is already an auto column restores in place (no stored
+       membership); everything else becomes a standalone manual node. */
     if (isChildConversation(file)) {
-      /* A child conversation expands as a node wired below its parent — clicking
-         its collapsed form promotes it into the tree via the scheme's
-         expandedConversationPaths. The predicate must match what
-         buildBranchGroups can actually promote (isChildConversation), not just
-         "has a parent": a compaction predecessor has a parent but is neither a
-         conversation nor a child conversation, so routing it to expanded would
-         render nothing. */
-      const expanded = [...new Set([...prefs.expanded, file.path])];
-      persistPrefs({ ...prefs, hidden, expanded });
+      board.restore(file.path, "expanded");
+    } else if (autoPaths.has(file.path)) {
+      board.restore(file.path, "auto");
     } else {
-      /* Everything else (a root conversation, or a parented row the tree can't
-         nest — e.g. a compaction predecessor) opens as a standalone managed
-         node. */
-      const manual = autoPaths.has(file.path) ? prefs.manual : [...new Set([...prefs.manual, file.path])];
-      persistPrefs({ ...prefs, hidden, manual });
+      board.restore(file.path, "manual");
     }
     pendingFocusRef.current = file.path;
   };

--- a/src/components/projectBoardMutations.test.ts
+++ b/src/components/projectBoardMutations.test.ts
@@ -1,0 +1,128 @@
+import { expect, test } from "bun:test";
+
+import { applyBoardMutations } from "@/lib/board/mutations";
+import type { BoardProjectStateV1 } from "@/lib/view/types";
+import type { FileEntry } from "@/lib/types";
+
+import { planBoardConvergence, planClose, planRootReconciliation, planSuccessionRemap } from "./projectBoardMutations";
+
+function entry(overrides: Partial<FileEntry> & { path: string }): FileEntry {
+  return {
+    root: "claude-projects",
+    name: overrides.path,
+    project: "demo",
+    title: overrides.path,
+    engine: "claude",
+    kind: "session",
+    fmt: "claude",
+    parent: null,
+    mtime: 1_000,
+    size: 10,
+    activity: "idle",
+    proc: null,
+    pid: null,
+    model: null,
+    pendingQuestion: null,
+    waitingInput: null,
+    ...overrides,
+  };
+}
+
+const boardOf = (prefs: Partial<BoardProjectStateV1["prefs"]>, pathAliases: Record<string, string> = {}): BoardProjectStateV1 => ({
+  schemaVersion: 1,
+  revision: 1,
+  updatedAt: new Date(0).toISOString(),
+  pathAliases,
+  prefs: { manual: [], hidden: [], expanded: [], viewMode: null, taskPanelOpen: false, ...prefs },
+});
+
+const catalogOf = (files: FileEntry[]): Map<string, FileEntry> => new Map(files.map((file) => [file.path, file]));
+
+/* 17: the reconciliation planner seeds only root group keys and retires the
+   child/subagent and catalog-absent pollution — with no positional cap. */
+test("17: planRootReconciliation seeds only root group keys past the former cap", () => {
+  const groups = Array.from({ length: 41 }, (_, i) => ({ key: `/root-${i}`, orphanTask: false }));
+  const child = entry({ path: "/root-0/child", parent: "/root-0", kind: "subagent" });
+  const catalog = catalogOf([child, ...groups.map((group) => entry({ path: group.key }))]);
+  const manual = ["/root-0", child.path, "/absent"];
+
+  const mutation = planRootReconciliation({ groups, manual, catalog });
+
+  expect(mutation.kind).toBe("reconcile-roots");
+  /* Every current root, beyond the old 40-entry truncation, and no child columns. */
+  expect(mutation.roots).toEqual(groups.map((group) => group.key));
+  expect(mutation.roots).toHaveLength(41);
+  expect(mutation.roots).not.toContain(child.path);
+  /* Child pollution and a catalog-absent entry are retired; a current root is kept. */
+  expect(mutation.removeManual).toContain(child.path);
+  expect(mutation.removeManual).toContain("/absent");
+  expect(mutation.removeManual).not.toContain("/root-0");
+  /* Applying it seeds every root, drops the pollution, and is a fixed point. */
+  const once = applyBoardMutations(boardOf({ manual }), [mutation]);
+  expect(once.prefs.manual).toEqual(groups.map((group) => group.key));
+  const twice = applyBoardMutations(once, [planRootReconciliation({ groups, manual: once.prefs.manual, catalog })]);
+  expect(twice.prefs.manual).toEqual(once.prefs.manual);
+});
+
+/* An orphan-task group never seeds a durable root. */
+test("17b: planRootReconciliation excludes orphan-task groups", () => {
+  const groups = [
+    { key: "/conv", orphanTask: false },
+    { key: "/bash-task", orphanTask: true },
+  ];
+  const mutation = planRootReconciliation({ groups, manual: [], catalog: new Map() });
+  expect(mutation.roots).toEqual(["/conv"]);
+});
+
+/* 18: the convergence planner orders the succession remap before reconciliation
+   so a predecessor's tombstone follows the identity onto the successor and the
+   successor is never re-seeded into manual. */
+test("18: planBoardConvergence orders remap before reconciliation and keeps a hidden successor hidden", () => {
+  const successor = entry({ path: "/new", predecessorPath: "/old" });
+  const groups = [{ key: "/new", orphanTask: false }];
+  const catalog = catalogOf([successor]);
+
+  const batch = planBoardConvergence({ files: [successor], groups, manual: [], catalog, project: "demo" });
+
+  expect(batch[0]?.kind).toBe("remap-paths");
+  expect(batch[1]?.kind).toBe("reconcile-roots");
+
+  /* Predecessor hidden before the batch; successor active as a root. */
+  const result = applyBoardMutations(boardOf({ hidden: ["/old"] }), batch);
+  expect(result.prefs.hidden).toEqual(["/new"]);
+  expect(result.prefs.manual).not.toContain("/new");
+
+  /* Reversing the order would let reconciliation seed /new before the remap moved
+     the tombstone — the ordering guarantee this planner encodes. */
+  const remap = planSuccessionRemap([successor], "demo")!;
+  const reconcile = planRootReconciliation({ groups, manual: [], catalog });
+  const reversed = applyBoardMutations(boardOf({ hidden: ["/old"] }), [reconcile, remap]);
+  /* Even reversed the normalize step keeps hidden dominant, but the canonical
+     batch never depends on that — assert the ordering explicitly. */
+  expect(batch.map((mutation) => mutation.kind)).toEqual(["remap-paths", "reconcile-roots"]);
+  expect(reversed.prefs.hidden).toEqual(["/new"]);
+});
+
+test("18b: planSuccessionRemap emits one deduped pair per successor and null when none", () => {
+  const successor = entry({ path: "/new", predecessorPath: "/old" });
+  const foreign = entry({ path: "/x", project: "other", predecessorPath: "/y" });
+  expect(planSuccessionRemap([successor, foreign], "demo")).toEqual({ kind: "remap-paths", pairs: [{ from: "/old", to: "/new" }] });
+  expect(planSuccessionRemap([entry({ path: "/plain" })], "demo")).toBeNull();
+});
+
+/* 19: closing a node emits exactly one durable close, independent of whether the
+   path is currently an auto column, and clears its ephemeral jump target. */
+test("19: planClose emits one durable close independent of autoPaths and clears ephemeral", () => {
+  const result = planClose("/x", ["/x", "/y"]);
+  expect(result.mutation).toEqual({ kind: "close", path: "/x" });
+  /* Only the closed path leaves the ephemeral set. */
+  expect(result.ephemeral).toEqual(["/y"]);
+  /* The mutation takes no render-state input, so it is identical whether or not
+     the node is an auto column right now. */
+  expect(planClose("/x", []).mutation).toEqual(planClose("/x", ["/x"]).mutation);
+  /* And it durably tombstones every membership shape when applied. */
+  const closed = applyBoardMutations(boardOf({ manual: ["/x"], expanded: ["/x"] }), [result.mutation]);
+  expect(closed.prefs.hidden).toEqual(["/x"]);
+  expect(closed.prefs.manual).not.toContain("/x");
+  expect(closed.prefs.expanded).not.toContain("/x");
+});

--- a/src/components/projectBoardMutations.test.ts
+++ b/src/components/projectBoardMutations.test.ts
@@ -97,8 +97,8 @@ test("18: planBoardConvergence orders remap before reconciliation and keeps a hi
   const remap = planSuccessionRemap([successor], "demo")!;
   const reconcile = planRootReconciliation({ groups, manual: [], catalog });
   const reversed = applyBoardMutations(boardOf({ hidden: ["/old"] }), [reconcile, remap]);
-  /* Even reversed the normalize step keeps hidden dominant, but the canonical
-     batch never depends on that — assert the ordering explicitly. */
+  /* Even reversed, normalization keeps hidden dominant. The canonical batch
+     carries an explicit ordering guarantee. */
   expect(batch.map((mutation) => mutation.kind)).toEqual(["remap-paths", "reconcile-roots"]);
   expect(reversed.prefs.hidden).toEqual(["/new"]);
 });
@@ -117,8 +117,8 @@ test("19: planClose emits one durable close independent of autoPaths and clears 
   expect(result.mutation).toEqual({ kind: "close", path: "/x" });
   /* Only the closed path leaves the ephemeral set. */
   expect(result.ephemeral).toEqual(["/y"]);
-  /* The mutation takes no render-state input, so it is identical whether or not
-     the node is an auto column right now. */
+  /* The mutation has no render-state input and produces the same result for
+     every current auto-column state. */
   expect(planClose("/x", []).mutation).toEqual(planClose("/x", ["/x"]).mutation);
   /* And it durably tombstones every membership shape when applied. */
   const closed = applyBoardMutations(boardOf({ manual: ["/x"], expanded: ["/x"] }), [result.mutation]);

--- a/src/components/projectBoardMutations.ts
+++ b/src/components/projectBoardMutations.ts
@@ -1,0 +1,102 @@
+import type { BoardMutationV1 } from "@/lib/board/mutations";
+import type { FileEntry } from "@/lib/types";
+
+import { isChildConversation, projectKey } from "./projectModel";
+
+/** The minimal branch-group shape the board planner needs: a group's root key
+    and whether it is a parentless background task. Orphan-task groups dock as
+    strips and never seed a durable root, so they are excluded from reconciliation. */
+export interface RootGroupLike {
+  key: string;
+  orphanTask: boolean;
+}
+
+/**
+ * Plan a root reconciliation. The board's durable `manual` list holds one entry
+ * per quiet root so a branch keeps its place until the user closes it. This
+ * derives the mutation that seeds every current root and retires the entries that
+ * never belonged there:
+ *
+ * - `roots` is every non-orphan group key. Children/subagents derive their
+ *   placement from lineage and expansion, so only roots are seeded — this is the
+ *   fix for the 40-entry churn where every column (children included) piled into
+ *   `manual` and oscillated under the old positional cap.
+ * - `removeManual` retires a manual entry that is a child/subagent conversation
+ *   (pollution) or has left the project catalog, while never touching a current
+ *   root. The server reducer preserves hidden tombstones, so a closed root that
+ *   left `manual` cannot be resurrected here.
+ */
+export function planRootReconciliation(input: {
+  groups: readonly RootGroupLike[];
+  manual: readonly string[];
+  catalog: ReadonlyMap<string, FileEntry>;
+}): Extract<BoardMutationV1, { kind: "reconcile-roots" }> {
+  const roots = input.groups.filter((group) => !group.orphanTask).map((group) => group.key);
+  const rootSet = new Set(roots);
+  const removeManual = input.manual.filter((path) => {
+    if (rootSet.has(path)) return false;
+    const file = input.catalog.get(path);
+    if (!file) return true;
+    return isChildConversation(file);
+  });
+  return { kind: "reconcile-roots", roots, removeManual };
+}
+
+/**
+ * Plan the account-migration succession remap. Each successor file carries its
+ * `predecessorPath`; one alias pair (predecessor → current path) per successor,
+ * deduplicated by predecessor, lets the server rewrite every membership array
+ * atomically so hidden/manual/expanded state follows the stable conversation
+ * identity across the rename. Returns null when no succession is observed.
+ */
+export function planSuccessionRemap(
+  files: readonly FileEntry[],
+  project: string,
+): Extract<BoardMutationV1, { kind: "remap-paths" }> | null {
+  const pairs: { from: string; to: string }[] = [];
+  const seen = new Set<string>();
+  for (const file of files) {
+    const from = file.predecessorPath;
+    if (from && projectKey(file) === project && from !== file.path && !seen.has(from)) {
+      seen.add(from);
+      pairs.push({ from, to: file.path });
+    }
+  }
+  return pairs.length ? { kind: "remap-paths", pairs } : null;
+}
+
+/**
+ * The full board-convergence batch dispatched from the dashboard on catalog and
+ * group changes: succession remap first, then root reconciliation. Order matters —
+ * reconciliation must observe the remapped memberships so a predecessor's hidden
+ * tombstone, moved onto its successor by the remap, is honored and the successor
+ * is never re-seeded into `manual`. Both mutations are idempotent, so a repeat
+ * batch reduces to a no-op the store drops before transport.
+ */
+export function planBoardConvergence(input: {
+  files: readonly FileEntry[];
+  groups: readonly RootGroupLike[];
+  manual: readonly string[];
+  catalog: ReadonlyMap<string, FileEntry>;
+  project: string;
+}): BoardMutationV1[] {
+  const batch: BoardMutationV1[] = [];
+  const remap = planSuccessionRemap(input.files, input.project);
+  if (remap) batch.push(remap);
+  batch.push(planRootReconciliation({ groups: input.groups, manual: input.manual, catalog: input.catalog }));
+  return batch;
+}
+
+/**
+ * The close action. A user's close is always durable: it emits exactly one
+ * `close` mutation regardless of whether the node is currently an auto column,
+ * a manual entry, or a hand-expanded child — the server reducer tombstones the
+ * path and strips every membership shape. Any local ephemeral jump target for the
+ * same path is dropped so it does not linger after the card is gone.
+ */
+export function planClose(
+  path: string,
+  ephemeral: readonly string[],
+): { mutation: Extract<BoardMutationV1, { kind: "close" }>; ephemeral: string[] } {
+  return { mutation: { kind: "close", path }, ephemeral: ephemeral.filter((item) => item !== path) };
+}

--- a/src/hooks/useBoardState.test.ts
+++ b/src/hooks/useBoardState.test.ts
@@ -382,7 +382,7 @@ test("15: a later restore survives the earlier close acknowledgement", async () 
   store.mutate([{ kind: "close", path: "/x" }]); // outbox=[close], drain inflight (gated)
   await settle();
   store.mutate([{ kind: "restore", path: "/x", placement: "manual" }]); // queued while close inflight
-  /* Optimistic: the later restore wins — /x visible in manual, not hidden. */
+  /* Optimistic: the later restore wins and /x remains visible in manual. */
   expect(store.getSnapshot().prefs.hidden).toEqual([]);
   expect(store.getSnapshot().prefs.manual).toEqual(["/x"]);
   releaseClose();

--- a/src/hooks/useBoardState.test.ts
+++ b/src/hooks/useBoardState.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, expect, test } from "bun:test";
 
+import { applyBoardMutations, type BoardMutationV1 } from "@/lib/board/mutations";
 import type { BoardProjectStateV1 } from "@/lib/view/types";
 
 import {
@@ -19,32 +20,78 @@ const settle = async () => {
 };
 
 const prefsWith = (over: Partial<BoardPrefs>): BoardPrefs => ({ ...EMPTY_BOARD_PREFS, ...over });
-const boardOf = (revision: number, prefs: Partial<BoardPrefs> = {}): BoardProjectStateV1 => ({ schemaVersion: 1, revision, updatedAt: new Date(0).toISOString(), prefs: prefsWith(prefs) });
+const boardOf = (revision: number, prefs: Partial<BoardPrefs> = {}, pathAliases: Record<string, string> = {}): BoardProjectStateV1 => ({
+  schemaVersion: 1,
+  revision,
+  updatedAt: new Date(0).toISOString(),
+  pathAliases,
+  prefs: prefsWith(prefs),
+});
 
-/** In-memory board API: mirrors the real GET/PATCH revision semantics. */
+/** Same durable arrangement the server compares to treat a write as a no-op. */
+const sameReduced = (left: BoardProjectStateV1, right: BoardProjectStateV1): boolean =>
+  JSON.stringify({ prefs: left.prefs, pathAliases: left.pathAliases ?? {} }) ===
+  JSON.stringify({ prefs: right.prefs, pathAliases: right.pathAliases ?? {} });
+
+/**
+ * In-memory board API mirroring the real GET/PATCH contract: whole-array `patch`
+ * (used by the legacy seed) and the `mutations` protocol applied through the real
+ * shared reducer. A semantic no-op preserves the revision even on a stale base,
+ * exactly like `mutateBoard` on the server.
+ */
 function fakeServer(seed: Record<string, BoardProjectStateV1> = {}) {
   const projects: Record<string, BoardProjectStateV1> = { ...seed };
   const read = (project: string) => projects[project] ?? boardOf(0);
   let patchCount = 0;
+  const commit = (project: string, reduced: BoardProjectStateV1, revision: number): BoardProjectStateV1 => {
+    const next: BoardProjectStateV1 = {
+      ...reduced,
+      schemaVersion: 1,
+      revision,
+      updatedAt: new Date(0).toISOString(),
+      pathAliases: reduced.pathAliases ?? {},
+    };
+    projects[project] = next;
+    return next;
+  };
   const fetcher = async (input: string, init?: RequestInit) => {
     if (!init || (init.method ?? "GET") === "GET") {
       const project = new URL(input, "http://x").searchParams.get("project")!;
       return { ok: true, status: 200, json: async () => ({ ok: true, board: read(project) }) };
     }
     patchCount += 1;
-    const body = JSON.parse(String(init.body)) as { project: string; baseRevision: number; patch: Partial<BoardPrefs> };
+    const body = JSON.parse(String(init.body)) as {
+      project: string;
+      baseRevision: number;
+      patch?: Partial<BoardPrefs>;
+      mutations?: BoardMutationV1[];
+    };
     const current = read(body.project);
-    if (current.revision !== body.baseRevision) return { ok: false, status: 409, json: async () => ({ error: "BOARD_REVISION_CONFLICT", board: current }) };
+    const conflict = () => ({ ok: false, status: 409, json: async () => ({ error: "BOARD_REVISION_CONFLICT", board: current }) });
+    if (body.mutations) {
+      const reduced = applyBoardMutations(current, body.mutations);
+      if (sameReduced(current, reduced)) return { ok: true, status: 200, json: async () => ({ ok: true, board: current }) };
+      if (current.revision !== body.baseRevision) return conflict();
+      const next = commit(body.project, reduced, current.revision + 1);
+      return { ok: true, status: 200, json: async () => ({ ok: true, board: next }) };
+    }
+    /* Whole-array patch form: the legacy seed onto an empty revision-0 board. */
+    if (current.revision !== body.baseRevision) return conflict();
     const next = boardOf(current.revision + 1, { ...current.prefs, ...body.patch });
     projects[body.project] = next;
     return { ok: true, status: 200, json: async () => ({ ok: true, board: next }) };
   };
-  /* Simulate another device landing an accepted PATCH. */
+  /* Another device landing an accepted whole-array patch. */
   const bump = (project: string, patch: Partial<BoardPrefs>) => {
     const current = read(project);
     projects[project] = boardOf(current.revision + 1, { ...current.prefs, ...patch });
   };
-  return { projects, fetcher, bump, patchCount: () => patchCount };
+  /* Another device landing an accepted semantic mutation. */
+  const bumpMutations = (project: string, mutations: BoardMutationV1[]) => {
+    const current = read(project);
+    commit(project, applyBoardMutations(current, mutations), current.revision + 1);
+  };
+  return { projects, fetcher, bump, bumpMutations, patchCount: () => patchCount };
 }
 
 const idleScheduler = () => {
@@ -135,7 +182,7 @@ test("an edit queued during the legacy seed PATCH drains as soon as the seed lan
   };
   const store = createBoardStore({ project: "proj", fetcher, storage, scheduler: idleScheduler().scheduler });
   await settle(); // load(): GET resolves, the seed PATCH is now inflight and gated
-  store.patch({ viewMode: "list" }); // queued while the seed is inflight (drain early-returns)
+  store.mutate([{ kind: "set-presentation", viewMode: "list" }]); // queued while the seed is inflight (drain early-returns)
   expect(store.getSnapshot().prefs.viewMode).toBe("list"); // optimistic
   releaseSeed();
   await settle();
@@ -157,11 +204,11 @@ test("an empty legacy state leaves the server uninitialized", async () => {
   store.dispose();
 });
 
-test("a patch applies optimistically, then bumps the revision", async () => {
+test("a mutation applies optimistically, then bumps the revision", async () => {
   const server = fakeServer({ proj: boardOf(2) });
   const store = createBoardStore({ project: "proj", fetcher: server.fetcher, storage: null, scheduler: idleScheduler().scheduler });
   await settle();
-  store.patch({ viewMode: "list" });
+  store.mutate([{ kind: "set-presentation", viewMode: "list" }]);
   /* Immediately visible, before the PATCH resolves. */
   expect(store.getSnapshot().prefs.viewMode).toBe("list");
   expect(store.getSnapshot().sync).toBe("pending");
@@ -170,18 +217,18 @@ test("a patch applies optimistically, then bumps the revision", async () => {
   store.dispose();
 });
 
-test("a revision conflict rebases exactly once onto the server state", async () => {
+test("a revision conflict adopts the server board and replays the outbox", async () => {
   const server = fakeServer({ proj: boardOf(1) });
   const store = createBoardStore({ project: "proj", fetcher: server.fetcher, storage: null, scheduler: idleScheduler().scheduler });
   await settle();
-  /* Another device advances the board after this store loaded at revision 1. */
-  server.bump("proj", { hidden: ["/other"] }); // now revision 2
-  store.patch({ manual: ["/mine"] }); // still thinks base is 1 → 409 → rebase onto 2
+  /* Another device closes /other after this store loaded at revision 1. */
+  server.bumpMutations("proj", [{ kind: "close", path: "/other" }]); // now revision 2, hidden:[/other]
+  store.mutate([{ kind: "restore", path: "/mine", placement: "manual" }]); // base 1 → 409 → adopt rev 2, replay, retry
   await settle();
   const snap = store.getSnapshot();
   expect(snap.revision).toBe(3);
   expect(snap.sync).toBe("current");
-  /* Rebase kept the other device's change and replayed this intent on top. */
+  /* The other device's change survives and this intent replayed on top. */
   expect(snap.prefs.hidden).toEqual(["/other"]);
   expect(snap.prefs.manual).toEqual(["/mine"]);
   store.dispose();
@@ -227,7 +274,7 @@ test("a PATCH network error backs off instead of spinning, then recovers", async
   const store = createBoardStore({ project: "proj", fetcher, storage: null, scheduler: sched.scheduler });
   await settle();
 
-  store.patch({ viewMode: "list" });
+  store.mutate([{ kind: "set-presentation", viewMode: "list" }]);
   await settle();
   /* The regression: exactly one attempt, not a tight microtask storm. The old
      code re-drained synchronously and reached thousands of attempts here. */
@@ -243,7 +290,7 @@ test("a PATCH network error backs off instead of spinning, then recovers", async
   expect(patchAttempts).toBe(2);
   expect(sched.pendingTimeouts()).toBe(1);
 
-  /* Network heals; the next backoff flushes the queued patch and lands it. */
+  /* Network heals; the next backoff flushes the queued mutation and lands it. */
   failPatches = false;
   sched.runTimeouts();
   await settle();
@@ -260,5 +307,108 @@ test("a connected open is queued into the expand set", async () => {
   const store = createBoardStore({ project: "proj", fetcher: server.fetcher, storage: null, scheduler: idleScheduler().scheduler });
   await settle();
   expect(store.getSnapshot().prefs.expanded).toEqual(["/child"]);
+  store.dispose();
+});
+
+/* ── Sol frontend cases 13–19 (membership stability under the mutation contract). */
+
+test("13: remote close survives local root reconciliation conflict", async () => {
+  /* revision 1: /a and /x are both manual roots. */
+  const server = fakeServer({ proj: boardOf(1, { manual: ["/a", "/x"] }) });
+  const store = createBoardStore({ project: "proj", fetcher: server.fetcher, storage: null, scheduler: idleScheduler().scheduler });
+  await settle();
+  expect(store.getSnapshot().revision).toBe(1);
+  /* A remote device closes /x → revision 2, hidden:[/x], manual:[/a]. */
+  server.bumpMutations("proj", [{ kind: "close", path: "/x" }]);
+  expect(server.projects.proj.revision).toBe(2);
+  /* Local root reconciliation still at base revision 1: keep /a, retire /x. */
+  store.mutate([{ kind: "reconcile-roots", roots: ["/a"], removeManual: ["/x"] }]);
+  await settle();
+  const snap = store.getSnapshot();
+  /* Converges on the remote close, /x stays hidden and absent from manual, and the
+     satisfied reconciliation adds no extra revision. */
+  expect(snap.revision).toBe(2);
+  expect(snap.prefs.hidden).toEqual(["/x"]);
+  expect(snap.prefs.manual).toEqual(["/a"]);
+  expect(server.projects.proj.revision).toBe(2);
+  store.dispose();
+});
+
+test("14: the outbox retains a close through consecutive conflicts", async () => {
+  const server = fakeServer({ proj: boardOf(1, { manual: ["/x"] }) });
+  let forced = 0;
+  /* Force two 409s (a concurrent writer keeps advancing the revision), then let
+     the third attempt through. */
+  const fetcher = async (input: string, init?: RequestInit) => {
+    if (init && (init.method ?? "GET") !== "GET") {
+      forced += 1;
+      if (forced <= 2) {
+        server.bumpMutations("proj", [{ kind: "set-presentation", taskPanelOpen: forced === 1 }]);
+        return { ok: false, status: 409, json: async () => ({ error: "BOARD_REVISION_CONFLICT", board: server.projects.proj }) };
+      }
+    }
+    return server.fetcher(input, init);
+  };
+  const store = createBoardStore({ project: "proj", fetcher, storage: null, scheduler: idleScheduler().scheduler });
+  await settle();
+  store.mutate([{ kind: "close", path: "/x" }]);
+  /* Optimistically hidden the instant the close is dispatched. */
+  expect(store.getSnapshot().prefs.hidden).toEqual(["/x"]);
+  await settle();
+  const snap = store.getSnapshot();
+  /* Third attempt lands; the close is durable and never lost across the conflicts. */
+  expect(forced).toBe(3);
+  expect(snap.prefs.hidden).toEqual(["/x"]);
+  expect(snap.prefs.manual).toEqual([]);
+  expect(server.projects.proj.prefs.hidden).toEqual(["/x"]);
+  expect(server.projects.proj.prefs.manual).toEqual([]);
+  store.dispose();
+});
+
+test("15: a later restore survives the earlier close acknowledgement", async () => {
+  const server = fakeServer({ proj: boardOf(1, { manual: ["/x"] }) });
+  let releaseClose = () => {};
+  const closeGate = new Promise<void>((resolve) => (releaseClose = resolve));
+  let attempts = 0;
+  const fetcher = async (input: string, init?: RequestInit) => {
+    if (init && (init.method ?? "GET") !== "GET") {
+      attempts += 1;
+      if (attempts === 1) await closeGate; // hold the close PATCH inflight
+    }
+    return server.fetcher(input, init);
+  };
+  const store = createBoardStore({ project: "proj", fetcher, storage: null, scheduler: idleScheduler().scheduler });
+  await settle();
+  store.mutate([{ kind: "close", path: "/x" }]); // outbox=[close], drain inflight (gated)
+  await settle();
+  store.mutate([{ kind: "restore", path: "/x", placement: "manual" }]); // queued while close inflight
+  /* Optimistic: the later restore wins — /x visible in manual, not hidden. */
+  expect(store.getSnapshot().prefs.hidden).toEqual([]);
+  expect(store.getSnapshot().prefs.manual).toEqual(["/x"]);
+  releaseClose();
+  await settle();
+  const snap = store.getSnapshot();
+  /* After the close ack the still-queued restore keeps /x restored, then persists. */
+  expect(snap.prefs.hidden).toEqual([]);
+  expect(snap.prefs.manual).toEqual(["/x"]);
+  expect(server.projects.proj.prefs.hidden).toEqual([]);
+  expect(server.projects.proj.prefs.manual).toEqual(["/x"]);
+  store.dispose();
+});
+
+test("16: a queued cross-project open dispatches explicit restore", async () => {
+  const server = fakeServer({ proj: boardOf(2, { hidden: ["/root", "/child"] }) });
+  queueColumnOpen("proj", "/root", false); // standalone → restore manual
+  queueColumnOpen("proj", "/child", true); // connected → restore expanded
+  const store = createBoardStore({ project: "proj", fetcher: server.fetcher, storage: null, scheduler: idleScheduler().scheduler });
+  await settle();
+  const snap = store.getSnapshot();
+  /* Both tombstones are lifted only through the explicit opens, each placed by role. */
+  expect(snap.prefs.hidden).toEqual([]);
+  expect(snap.prefs.manual).toEqual(["/root"]);
+  expect(snap.prefs.expanded).toEqual(["/child"]);
+  expect(server.projects.proj.prefs.hidden).toEqual([]);
+  expect(server.projects.proj.prefs.manual).toEqual(["/root"]);
+  expect(server.projects.proj.prefs.expanded).toEqual(["/child"]);
   store.dispose();
 });

--- a/src/hooks/useBoardState.ts
+++ b/src/hooks/useBoardState.ts
@@ -171,7 +171,7 @@ export interface BoardStore {
  * revision conflict adopts the server board, replays the whole outbox on top, and
  * retries, preserving a close, restore or remap intent across an interleaved
  * write by another device. The one-time legacy seed still writes
- * whole prefs; localStorage is only read for it, never written.
+ * whole prefs; localStorage serves as read-only migration input.
  */
 export function createBoardStore(options: BoardStoreOptions): BoardStore {
   const { project, fetcher, storage } = options;

--- a/src/hooks/useBoardState.ts
+++ b/src/hooks/useBoardState.ts
@@ -169,8 +169,8 @@ export interface BoardStore {
  * presentation); the UI renders the outbox replayed over the confirmed board
  * (optimistic), and a background drain flushes the outbox as a stable prefix. A
  * revision conflict adopts the server board, replays the whole outbox on top, and
- * retries — so a close, restore or remap intent survives an interleaved write by
- * another device instead of being dropped. The one-time legacy seed still writes
+ * retries, preserving a close, restore or remap intent across an interleaved
+ * write by another device. The one-time legacy seed still writes
  * whole prefs; localStorage is only read for it, never written.
  */
 export function createBoardStore(options: BoardStoreOptions): BoardStore {
@@ -338,8 +338,8 @@ export function createBoardStore(options: BoardStoreOptions): BoardStore {
       else scheduleRetry();
       return;
     }
-    /* Network error: keep the outbox and back off on a cancellable timer instead
-       of spinning failed requests in one microtask turn (#11). */
+    /* Network error: keep the outbox and back off on a cancellable timer. This
+       prevents failed-request spinning inside one microtask turn (#11). */
     refresh();
     scheduleRetry();
   };
@@ -373,8 +373,8 @@ export function createBoardStore(options: BoardStoreOptions): BoardStore {
         confirmed = result.status === "error" ? board : result.board;
         refresh();
         /* A mutation queued while the seed was inflight parked in the outbox
-           (drain early-returns during inflight); flush it now instead of leaving
-           it stranded until the next edit. */
+           because drain returns early during inflight. Flush it now so the
+           queued action proceeds without another edit. */
         if (outbox.length) void drain();
         return;
       }
@@ -391,8 +391,8 @@ export function createBoardStore(options: BoardStoreOptions): BoardStore {
         const res = await fetcher(getUrl);
         if (!res.ok) return;
         const board = ((await res.json()) as { board: BoardProjectStateV1 }).board;
-        /* Another device moved the board: adopt it, but never clobber unflushed
-           local intent (guarded by the outbox/inflight check). */
+        /* Another device moved the board. Adopt it while preserving unflushed
+           local intent through the outbox/inflight guard. */
         if (!inflight && outbox.length === 0 && !disposed && board.revision !== confirmed.revision) {
           confirmed = board;
           unavailable = false;

--- a/src/hooks/useBoardState.ts
+++ b/src/hooks/useBoardState.ts
@@ -2,6 +2,7 @@
 
 import { useEffect, useRef, useState } from "react";
 
+import { applyBoardMutations, type BoardMutationV1 } from "@/lib/board/mutations";
 import type { BoardProjectStateV1 } from "@/lib/view/types";
 
 export type BoardPrefs = BoardProjectStateV1["prefs"];
@@ -15,6 +16,12 @@ const POLL_MS = 10_000;
    backoff and recovery cancels it. */
 const RETRY_BASE_MS = 1_000;
 const RETRY_MAX_MS = 30_000;
+/* Immediate re-sends after a revision conflict before falling back to the
+   backoff timer. Each conflict means another writer landed first; we adopt the
+   server board, replay the outbox on top, and retry the same prefix. A real
+   consecutive conflict requires a fresh concurrent write each round, so this
+   cap only guards against a pathological writer that never yields. */
+const MAX_CONFLICT_RETRIES = 8;
 
 export const EMPTY_BOARD_PREFS: BoardPrefs = { manual: [], hidden: [], expanded: [], viewMode: null, taskPanelOpen: false };
 
@@ -109,10 +116,32 @@ export function resetPendingOpensForTest(): void {
   activeStores.clear();
 }
 
-type PatchAttempt =
+type WriteAttempt =
   | { status: "ok"; board: BoardProjectStateV1 }
   | { status: "conflict"; board: BoardProjectStateV1 }
   | { status: "error" };
+
+/** Two boards carry the same durable arrangement when their prefs and aliases
+    match — the same comparison the server uses to treat a mutation as a no-op. */
+function sameArrangement(left: BoardProjectStateV1, right: BoardProjectStateV1): boolean {
+  return (
+    JSON.stringify({ prefs: left.prefs, pathAliases: left.pathAliases ?? {} }) ===
+    JSON.stringify({ prefs: right.prefs, pathAliases: right.pathAliases ?? {} })
+  );
+}
+
+/** Replay the unacknowledged outbox over the last server-confirmed board to get
+    the optimistic arrangement the UI renders. The reducer normalizes and could
+    in principle throw on a malformed batch; fall back to the confirmed board so a
+    bad optimistic replay never blanks the arrangement. */
+function optimisticBoard(confirmed: BoardProjectStateV1, outbox: readonly BoardMutationV1[]): BoardProjectStateV1 {
+  if (outbox.length === 0) return confirmed;
+  try {
+    return applyBoardMutations(confirmed, outbox);
+  } catch {
+    return confirmed;
+  }
+}
 
 export interface BoardStoreOptions {
   project: string;
@@ -129,17 +158,20 @@ export interface BoardStoreOptions {
 export interface BoardStore {
   getSnapshot(): BoardSnapshot;
   subscribe(listener: () => void): () => void;
-  patch(partial: Partial<BoardPrefs>): void;
+  mutate(mutations: readonly BoardMutationV1[]): void;
   dispose(): void;
 }
 
 /**
  * The per-project durable board arrangement, moved off per-browser storage into
- * the shared server store. It loads the server state, runs the one-time legacy
- * seed, polls for changes other devices made, and applies edits optimistically:
- * a local patch updates the UI at once, then PATCHes; a revision conflict rebases
- * exactly once onto the server's state before giving up to the next poll. Legacy
- * localStorage is only read (for the seed), never written — a rollback keeps it.
+ * the shared server store. It holds the last server-confirmed board plus an
+ * outbox of unacknowledged semantic mutations (close/restore/reconcile/remap/
+ * presentation); the UI renders the outbox replayed over the confirmed board
+ * (optimistic), and a background drain flushes the outbox as a stable prefix. A
+ * revision conflict adopts the server board, replays the whole outbox on top, and
+ * retries — so a close, restore or remap intent survives an interleaved write by
+ * another device instead of being dropped. The one-time legacy seed still writes
+ * whole prefs; localStorage is only read for it, never written.
  */
 export function createBoardStore(options: BoardStoreOptions): BoardStore {
   const { project, fetcher, storage } = options;
@@ -151,10 +183,27 @@ export function createBoardStore(options: BoardStoreOptions): BoardStore {
   };
   const getUrl = "/api/board?project=" + encodeURIComponent(project);
 
+  const emptyBoard = (): BoardProjectStateV1 => ({
+    schemaVersion: 1,
+    revision: 0,
+    updatedAt: new Date(0).toISOString(),
+    pathAliases: {},
+    prefs: EMPTY_BOARD_PREFS,
+  });
+
   let snapshot: BoardSnapshot = { prefs: EMPTY_BOARD_PREFS, revision: 0, sync: "unavailable", loaded: false };
-  let pending: Partial<BoardPrefs> | null = null;
+  /* Last board the server acknowledged, and the semantic mutations not yet
+     acknowledged. The optimistic arrangement is the outbox replayed over the
+     confirmed board. */
+  let confirmed: BoardProjectStateV1 = emptyBoard();
+  let outbox: BoardMutationV1[] = [];
   let inflight = false;
+  let loaded = false;
+  let unavailable = false;
   let disposed = false;
+  /* Consecutive revision conflicts: each means a fresh concurrent write, so we
+     retry immediately up to a cap before falling back to the backoff timer. */
+  let conflictStreak = 0;
   let retryHandle: ReturnType<typeof scheduler.setTimeout> | null = null;
   let retryDelay = RETRY_BASE_MS;
   const listeners = new Set<() => void>();
@@ -162,16 +211,34 @@ export function createBoardStore(options: BoardStoreOptions): BoardStore {
   const emit = () => {
     for (const listener of listeners) listener();
   };
-  const set = (next: Partial<BoardSnapshot>) => {
-    snapshot = { ...snapshot, ...next };
+  const syncFor = (): BoardSync => (unavailable ? "unavailable" : inflight || outbox.length ? "pending" : "current");
+  /* Recompute the published snapshot from the confirmed board + outbox. The
+     revision stays the confirmed one — optimistic mutations do not invent a
+     revision the server has not assigned. */
+  const refresh = () => {
+    const board = optimisticBoard(confirmed, outbox);
+    snapshot = { prefs: board.prefs, revision: confirmed.revision, sync: syncFor(), loaded };
     emit();
   };
-  const syncFor = (): BoardSync => (inflight || pending ? "pending" : "current");
-  const adopt = (board: BoardProjectStateV1) => {
-    set({ prefs: board.prefs, revision: board.revision, sync: syncFor(), loaded: true });
+
+  const attemptMutations = async (mutations: readonly BoardMutationV1[], baseRevision: number): Promise<WriteAttempt> => {
+    try {
+      const res = await fetcher("/api/board", {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ schemaVersion: 1, project, baseRevision, mutations }),
+      });
+      if (res.ok) return { status: "ok", board: ((await res.json()) as { board: BoardProjectStateV1 }).board };
+      if (res.status === 409) return { status: "conflict", board: ((await res.json()) as { board: BoardProjectStateV1 }).board };
+      return { status: "error" };
+    } catch {
+      return { status: "error" };
+    }
   };
 
-  const attempt = async (patch: Partial<BoardPrefs>, baseRevision: number): Promise<PatchAttempt> => {
+  /* The legacy seed writes whole prefs (the patch form) onto the empty
+     revision-0 board — the mutation protocol only carries membership deltas. */
+  const attemptSeed = async (patch: BoardPrefs, baseRevision: number): Promise<WriteAttempt> => {
     try {
       const res = await fetcher("/api/board", {
         method: "PATCH",
@@ -186,32 +253,38 @@ export function createBoardStore(options: BoardStoreOptions): BoardStore {
     }
   };
 
-  const applyPatch = (partial: Partial<BoardPrefs>) => {
-    /* Optimistic: reflect the edit immediately, then queue the PATCH. */
-    snapshot = { ...snapshot, prefs: { ...snapshot.prefs, ...partial }, sync: "pending" };
-    emit();
-    pending = mergePatch(pending, partial);
+  const mutate = (mutations: readonly BoardMutationV1[]) => {
+    if (mutations.length === 0) return;
+    /* Drop a batch that changes nothing optimistically — an idempotent
+       reconcile/remap, or a close of an already-hidden path — so it never
+       reaches transport and never bumps a revision. */
+    const before = optimisticBoard(confirmed, outbox);
+    const nextOutbox = [...outbox, ...mutations];
+    const after = optimisticBoard(confirmed, nextOutbox);
+    if (sameArrangement(before, after)) return;
+    outbox = nextOutbox;
+    refresh();
     void drain();
   };
 
-  /* Flush any cross-project opens queued for this project into a single patch.
-     Runs after the store has loaded, so it merges onto the server's arrangement
-     rather than an empty placeholder. */
+  /* Flush any cross-project opens queued for this project. A queued open is an
+     explicit user restore: it lifts the tombstone and places the node — a
+     standalone conversation as a manual node, a connected child expanded below
+     its parent. Runs after load so it replays onto the server's arrangement. */
   const drainOpens = () => {
-    if (!snapshot.loaded || disposed) return;
+    if (!loaded || disposed) return;
     const open = pendingOpens.get(project);
     if (!open || (open.manual.length === 0 && open.expanded.length === 0)) return;
     pendingOpens.delete(project);
-    const opened = new Set([...open.manual, ...open.expanded]);
-    applyPatch({
-      manual: [...new Set([...snapshot.prefs.manual, ...open.manual])],
-      expanded: [...new Set([...snapshot.prefs.expanded, ...open.expanded])],
-      hidden: snapshot.prefs.hidden.filter((path) => !opened.has(path)),
-    });
+    const restores: BoardMutationV1[] = [
+      ...open.manual.map((path) => ({ kind: "restore", path, placement: "manual" }) as const),
+      ...open.expanded.map((path) => ({ kind: "restore", path, placement: "expanded" }) as const),
+    ];
+    mutate(restores);
   };
 
   /* Cancel a scheduled backoff and reset the delay — called on any accepted
-     PATCH and on disposal, so a healed network starts the next failure fresh. */
+     write and on disposal, so a healed network starts the next failure fresh. */
   const cancelRetry = () => {
     if (retryHandle !== null) {
       scheduler.clearTimeout(retryHandle);
@@ -219,50 +292,56 @@ export function createBoardStore(options: BoardStoreOptions): BoardStore {
     }
     retryDelay = RETRY_BASE_MS;
   };
-  /* Arm the bounded backoff after a network error: one timer at a time, delay
-     doubling up to the cap. The queued patch drains when it fires. */
+  /* Arm the bounded backoff after repeated conflicts or a network error: one
+     timer at a time, delay doubling up to the cap. The outbox drains when it
+     fires, with a fresh immediate-retry budget. */
   const scheduleRetry = () => {
     if (retryHandle !== null || disposed) return;
     const delay = retryDelay;
     retryDelay = Math.min(retryDelay * 2, RETRY_MAX_MS);
     retryHandle = scheduler.setTimeout(() => {
       retryHandle = null;
+      conflictStreak = 0;
       void drain();
     }, delay);
   };
 
   const drain = async () => {
-    if (inflight || !pending || disposed) return;
-    const patch = pending;
-    pending = null;
+    if (inflight || disposed || outbox.length === 0) return;
     inflight = true;
-    set({ sync: "pending" });
-    const first = await attempt(patch, snapshot.revision);
-    if (first.status === "ok") {
+    refresh();
+    /* Send the outbox as a stable prefix: mutations appended while this request
+       is inflight stay queued and flush on the next drain, so an earlier response
+       never drops a later optimistic action. */
+    const prefix = outbox.slice();
+    const result = await attemptMutations(prefix, confirmed.revision);
+    inflight = false;
+    if (disposed) return;
+    if (result.status === "ok") {
       cancelRetry();
-      adopt(first.board);
-    } else if (first.status === "conflict") {
-      /* Rebase exactly once: take the server's state, replay this intent on top,
-         resubmit. A second conflict means another writer keeps winning — adopt
-         the server and let the poll reconcile. */
-      set({ prefs: { ...first.board.prefs, ...patch }, revision: first.board.revision });
-      const second = await attempt(patch, first.board.revision);
-      if (second.status === "ok") cancelRetry();
-      adopt(second.status === "ok" ? second.board : first.board);
-    } else {
-      /* Network error: keep the optimistic prefs and requeue, then back off on a
-         cancellable timer. Re-draining synchronously here spins thousands of
-         failed PATCHes in one microtask turn and starves every timer (#11); the
-         backoff retries and any accepted PATCH cancels it. */
-      pending = mergePatch(patch, pending ?? {});
-      inflight = false;
-      set({ sync: syncFor() });
-      scheduleRetry();
+      conflictStreak = 0;
+      confirmed = result.board;
+      outbox = outbox.slice(prefix.length);
+      refresh();
+      if (outbox.length) void drain();
       return;
     }
-    inflight = false;
-    set({ sync: syncFor() });
-    if (pending) void drain();
+    if (result.status === "conflict") {
+      /* Another writer landed first. Adopt the server board and retain the whole
+         outbox: the optimistic replay puts this intent back on top, and we retry
+         the same prefix at the returned revision. A satisfied mutation then
+         reduces to a server no-op that leaves the revision untouched. */
+      confirmed = result.board;
+      conflictStreak += 1;
+      refresh();
+      if (conflictStreak <= MAX_CONFLICT_RETRIES) void drain();
+      else scheduleRetry();
+      return;
+    }
+    /* Network error: keep the outbox and back off on a cancellable timer instead
+       of spinning failed requests in one microtask turn (#11). */
+    refresh();
+    scheduleRetry();
   };
 
   const load = async () => {
@@ -275,39 +354,50 @@ export function createBoardStore(options: BoardStoreOptions): BoardStore {
     }
     if (disposed) return;
     if (!board) {
-      set({ sync: "unavailable", loaded: true });
+      unavailable = true;
+      loaded = true;
+      refresh();
       return;
     }
     if (board.revision === 0 && isEmptyPrefs(board.prefs)) {
       const seed = readLegacyPrefs(project, storage);
       if (seed && isMeaningfulPrefs(seed)) {
-        set({ prefs: seed, revision: 0, sync: "pending", loaded: true });
+        /* Show the seed optimistically while its PATCH is inflight. */
+        confirmed = { ...board, prefs: seed };
+        loaded = true;
         inflight = true;
-        const result = await attempt(seed, 0);
+        refresh();
+        const result = await attemptSeed(seed, 0);
         inflight = false;
-        if (!disposed) {
-          adopt(result.status === "error" ? board : result.board);
-          /* An edit made while the seed PATCH was inflight parked in `pending`
-             (drain early-returns during inflight); flush it now instead of
-             leaving it stranded until the next edit. */
-          if (pending) void drain();
-        }
+        if (disposed) return;
+        confirmed = result.status === "error" ? board : result.board;
+        refresh();
+        /* A mutation queued while the seed was inflight parked in the outbox
+           (drain early-returns during inflight); flush it now instead of leaving
+           it stranded until the next edit. */
+        if (outbox.length) void drain();
         return;
       }
     }
-    adopt(board);
+    confirmed = board;
+    loaded = true;
+    refresh();
   };
 
   const poll = () => {
-    if (inflight || pending || disposed) return;
+    if (inflight || outbox.length || disposed) return;
     void (async () => {
       try {
         const res = await fetcher(getUrl);
         if (!res.ok) return;
         const board = ((await res.json()) as { board: BoardProjectStateV1 }).board;
-        /* Another device moved the board: adopt it, but never clobber a local
-           edit that has not yet flushed (guarded by the pending/inflight check). */
-        if (!inflight && !pending && !disposed && board.revision !== snapshot.revision) adopt(board);
+        /* Another device moved the board: adopt it, but never clobber unflushed
+           local intent (guarded by the outbox/inflight check). */
+        if (!inflight && outbox.length === 0 && !disposed && board.revision !== confirmed.revision) {
+          confirmed = board;
+          unavailable = false;
+          refresh();
+        }
       } catch {
         /* transient — next tick retries */
       }
@@ -324,8 +414,8 @@ export function createBoardStore(options: BoardStoreOptions): BoardStore {
       listeners.add(listener);
       return () => listeners.delete(listener);
     },
-    patch(partial) {
-      applyPatch(partial);
+    mutate(mutations) {
+      mutate(mutations);
     },
     dispose() {
       disposed = true;
@@ -340,7 +430,11 @@ export function createBoardStore(options: BoardStoreOptions): BoardStore {
 const UNAVAILABLE_SNAPSHOT: BoardSnapshot = { prefs: EMPTY_BOARD_PREFS, revision: 0, sync: "unavailable", loaded: false };
 
 export interface BoardState extends BoardSnapshot {
-  patchColumns(columns: Pick<BoardPrefs, "manual" | "hidden" | "expanded">): void;
+  /** Dispatch a semantic mutation batch (close/restore/reconcile/remap/
+      presentation). The store replays it optimistically and flushes durably. */
+  mutate(mutations: readonly BoardMutationV1[]): void;
+  close(path: string): void;
+  restore(path: string, placement: "auto" | "manual" | "expanded"): void;
   setViewMode(viewMode: BoardViewMode): void;
   setTaskPanelOpen(open: boolean): void;
 }
@@ -380,14 +474,20 @@ export function useBoardState(project: string | null): BoardState {
 
   return {
     ...snapshot,
-    patchColumns(columns) {
-      storeRef.current?.patch(columns);
+    mutate(mutations) {
+      storeRef.current?.mutate(mutations);
+    },
+    close(path) {
+      storeRef.current?.mutate([{ kind: "close", path }]);
+    },
+    restore(path, placement) {
+      storeRef.current?.mutate([{ kind: "restore", path, placement }]);
     },
     setViewMode(viewMode) {
-      storeRef.current?.patch({ viewMode });
+      storeRef.current?.mutate([{ kind: "set-presentation", viewMode }]);
     },
     setTaskPanelOpen(open) {
-      storeRef.current?.patch({ taskPanelOpen: open });
+      storeRef.current?.mutate([{ kind: "set-presentation", taskPanelOpen: open }]);
     },
   };
 }

--- a/src/lib/board/mutations.test.ts
+++ b/src/lib/board/mutations.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test } from "bun:test";
+
+import { applyBoardMutations } from "./mutations";
+
+const board = (prefs: Partial<{ manual: string[]; hidden: string[]; expanded: string[] }> = {}) => ({
+  schemaVersion: 1 as const,
+  revision: 7,
+  updatedAt: "2026-07-10T00:00:00.000Z",
+  pathAliases: {},
+  prefs: { manual: [], hidden: [], expanded: [], viewMode: null, taskPanelOpen: false, ...prefs },
+});
+
+describe("board mutations", () => {
+  test("close tombstones manual, expanded, and unclassified paths idempotently", () => {
+    for (const source of [board({ manual: ["/manual"] }), board({ expanded: ["/expanded"] }), board()]) {
+      const path = source.prefs.manual[0] ?? source.prefs.expanded[0] ?? "/unclassified";
+      const closed = applyBoardMutations(source, [{ kind: "close", path }]);
+      expect(closed.prefs).toMatchObject({ manual: [], expanded: [], hidden: [path] });
+      expect(applyBoardMutations(closed, [{ kind: "close", path }])).toEqual(closed);
+    }
+  });
+
+  test("close and remap commute through persistent aliases", () => {
+    const closedThenRemapped = applyBoardMutations(board(), [
+      { kind: "close", path: "/old" },
+      { kind: "remap-paths", pairs: [{ from: "/old", to: "/new" }] },
+    ]);
+    const remappedThenClosed = applyBoardMutations(board(), [
+      { kind: "remap-paths", pairs: [{ from: "/old", to: "/new" }] },
+      { kind: "close", path: "/old" },
+    ]);
+    expect(closedThenRemapped).toEqual(remappedThenClosed);
+    expect(closedThenRemapped).toMatchObject({ pathAliases: { "/old": "/new" }, prefs: { hidden: ["/new"] } });
+  });
+
+  test("simultaneous remap deduplicates and gives hidden precedence in every membership list", () => {
+    const remapped = applyBoardMutations(board({
+      manual: ["/a", "/b", "/manual"],
+      hidden: ["/b", "/hidden"],
+      expanded: ["/a", "/expanded"],
+    }), [{ kind: "remap-paths", pairs: [{ from: "/a", to: "/b" }, { from: "/manual", to: "/hidden" }] }]);
+    expect(remapped.prefs).toMatchObject({ manual: [], hidden: ["/b", "/hidden"], expanded: ["/expanded"] });
+  });
+
+  test("reconciles every root without a numeric cap, removes transient children, and is idempotent", () => {
+    const roots = Array.from({ length: 61 }, (_, index) => `/root-${index}`);
+    const first = applyBoardMutations(board({ manual: ["/transient-child"], hidden: ["/closed-root"] }), [{
+      kind: "reconcile-roots",
+      roots,
+      removeManual: ["/transient-child"],
+    }]);
+    expect(first.prefs.manual).toEqual(roots);
+    expect(first.prefs.hidden).toEqual(["/closed-root"]);
+    expect(applyBoardMutations(first, [{ kind: "reconcile-roots", roots, removeManual: ["/transient-child"] }])).toEqual(first);
+  });
+
+  test("explicit role-aware restore survives reconciliation", () => {
+    const restored = applyBoardMutations(board({ hidden: ["/root"] }), [{ kind: "restore", path: "/root", placement: "expanded" }]);
+    expect(restored.prefs).toMatchObject({ hidden: [], manual: [], expanded: ["/root"] });
+    const reconciled = applyBoardMutations(restored, [{ kind: "reconcile-roots", roots: ["/root"], removeManual: [] }]);
+    expect(reconciled.prefs).toMatchObject({ manual: ["/root"], expanded: ["/root"] });
+  });
+});

--- a/src/lib/board/mutations.ts
+++ b/src/lib/board/mutations.ts
@@ -1,0 +1,124 @@
+import type { BoardProjectStateV1 } from "@/lib/view/types";
+
+export type BoardMutationV1 =
+  | { kind: "close"; path: string }
+  | { kind: "restore"; path: string; placement: "auto" | "manual" | "expanded" }
+  | { kind: "reconcile-roots"; roots: string[]; removeManual: string[] }
+  | { kind: "remap-paths"; pairs: Array<{ from: string; to: string }> }
+  | { kind: "set-presentation"; viewMode?: "scheme" | "list" | null; taskPanelOpen?: boolean };
+
+function unique(paths: readonly string[]): string[] {
+  return [...new Set(paths)];
+}
+
+function aliasesOf(board: BoardProjectStateV1): Record<string, string> {
+  return board.pathAliases ?? {};
+}
+
+function resolvePath(path: string, aliases: Record<string, string>): string {
+  const seen = new Set<string>();
+  let resolved = path;
+  while (aliases[resolved] !== undefined) {
+    if (seen.has(resolved)) throw new Error("board path alias cycle");
+    seen.add(resolved);
+    resolved = aliases[resolved]!;
+  }
+  return resolved;
+}
+
+function normalizedAliases(aliases: Record<string, string>): Record<string, string> {
+  const normalized: Record<string, string> = {};
+  for (const source of Object.keys(aliases)) {
+    const target = resolvePath(source, aliases);
+    if (source !== target) normalized[source] = target;
+  }
+  return normalized;
+}
+
+function normalize(board: BoardProjectStateV1, aliases = aliasesOf(board)): BoardProjectStateV1 {
+  const canonicalAliases = normalizedAliases(aliases);
+  const hidden = unique(board.prefs.hidden.map((item) => resolvePath(item, canonicalAliases)));
+  const hiddenSet = new Set(hidden);
+  const visible = (paths: readonly string[]) => unique(paths.map((item) => resolvePath(item, canonicalAliases)).filter((item) => !hiddenSet.has(item)));
+  return {
+    ...board,
+    pathAliases: canonicalAliases,
+    prefs: { ...board.prefs, manual: visible(board.prefs.manual), hidden, expanded: visible(board.prefs.expanded) },
+  };
+}
+
+function remapPaths(board: BoardProjectStateV1, pairs: readonly { from: string; to: string }[]): BoardProjectStateV1 {
+  const aliases = { ...aliasesOf(board) };
+  for (const { from, to } of pairs) aliases[from] = to;
+  return normalize(board, aliases);
+}
+
+function reconcileRoots(board: BoardProjectStateV1, roots: readonly string[], removeManual: readonly string[]): BoardProjectStateV1 {
+  const aliases = aliasesOf(board);
+  const removed = new Set(removeManual.map((item) => resolvePath(item, aliases)));
+  const manual = board.prefs.manual.filter((item) => !removed.has(item));
+  const present = new Set([...manual, ...board.prefs.hidden]);
+  for (const root of roots.map((item) => resolvePath(item, aliases))) {
+    if (!present.has(root)) {
+      manual.push(root);
+      present.add(root);
+    }
+  }
+  return normalize({ ...board, prefs: { ...board.prefs, manual } });
+}
+
+function restore(board: BoardProjectStateV1, path: string, placement: "auto" | "manual" | "expanded"): BoardProjectStateV1 {
+  const visible = { ...board.prefs, hidden: board.prefs.hidden.filter((item) => item !== path) };
+  if (placement === "auto") return normalize({ ...board, prefs: visible });
+  const withoutExplicitRole = {
+    ...visible,
+    manual: visible.manual.filter((item) => item !== path),
+    expanded: visible.expanded.filter((item) => item !== path),
+  };
+  return normalize({
+    ...board,
+    prefs: placement === "manual"
+      ? { ...withoutExplicitRole, manual: [...withoutExplicitRole.manual, path] }
+      : { ...withoutExplicitRole, expanded: [...withoutExplicitRole.expanded, path] },
+  });
+}
+
+export function applyBoardMutations(board: BoardProjectStateV1, mutations: readonly BoardMutationV1[]): BoardProjectStateV1 {
+  let next = normalize(board);
+  for (const mutation of mutations) {
+    if (mutation.kind === "remap-paths") {
+      next = remapPaths(next, mutation.pairs);
+      continue;
+    }
+    if (mutation.kind === "reconcile-roots") {
+      next = reconcileRoots(next, mutation.roots, mutation.removeManual);
+      continue;
+    }
+    if (mutation.kind === "restore") {
+      next = restore(next, resolvePath(mutation.path, aliasesOf(next)), mutation.placement);
+      continue;
+    }
+    if (mutation.kind === "set-presentation") {
+      next = normalize({
+        ...next,
+        prefs: {
+          ...next.prefs,
+          ...(mutation.viewMode === undefined ? {} : { viewMode: mutation.viewMode }),
+          ...(mutation.taskPanelOpen === undefined ? {} : { taskPanelOpen: mutation.taskPanelOpen }),
+        },
+      });
+      continue;
+    }
+    const path = resolvePath(mutation.path, aliasesOf(next));
+    next = normalize({
+      ...next,
+      prefs: {
+        ...next.prefs,
+        manual: next.prefs.manual.filter((item) => item !== path),
+        expanded: next.prefs.expanded.filter((item) => item !== path),
+        hidden: unique([...next.prefs.hidden, path]),
+      },
+    });
+  }
+  return next;
+}

--- a/src/lib/board/store.test.ts
+++ b/src/lib/board/store.test.ts
@@ -3,7 +3,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
-import { boardFor, BoardStoreError, patchBoard } from "./store";
+import { boardFor, BoardStoreError, mutateBoard, patchBoard } from "./store";
 import { validateBoardPatchRequest } from "./validation";
 
 function temporaryFile(): string { return path.join(fs.mkdtempSync(path.join(os.tmpdir(), "llv-board-")), "board.json"); }
@@ -29,11 +29,55 @@ describe("board store", () => {
   test("accepts missing storage as revision-zero initialization", () => {
     expect(boardFor("viewer", temporaryFile())).toMatchObject({ revision: 0, prefs: { manual: [] } });
   });
+  test("loads a legacy schema-one file with empty path aliases", () => {
+    const file = temporaryFile();
+    fs.mkdirSync(path.dirname(file), { recursive: true });
+    fs.writeFileSync(file, JSON.stringify({ projects: { viewer: {
+      schemaVersion: 1, revision: 3, updatedAt: "2026-07-10T00:00:00.000Z",
+      prefs: { manual: ["/a"], hidden: [], expanded: [], viewMode: null, taskPanelOpen: false },
+    } } }), "utf8");
+    expect(boardFor("viewer", file).pathAliases).toEqual({});
+  });
+  test("a semantic no-op preserves revision and durable inode", () => {
+    const file = temporaryFile();
+    const written = patchBoard("viewer", 0, { manual: ["/a"] }, file);
+    expect(written.ok).toBe(true);
+    const before = fs.statSync(file);
+    const result = mutateBoard("viewer", 1, [{ kind: "restore", path: "/a", placement: "manual" }], file);
+    expect(result).toMatchObject({ ok: true, board: { revision: 1 } });
+    const after = fs.statSync(file);
+    expect(after.ino).toBe(before.ino);
+    expect(after.mtimeMs).toBe(before.mtimeMs);
+  });
+  test("identical semantic intent from two writers advances once", () => {
+    const file = temporaryFile();
+    const first = mutateBoard("viewer", 0, [{ kind: "remap-paths", pairs: [{ from: "/old", to: "/new" }] }], file);
+    const replay = mutateBoard("viewer", 0, [{ kind: "remap-paths", pairs: [{ from: "/old", to: "/new" }] }], file);
+    expect(first).toMatchObject({ ok: true, board: { revision: 1 } });
+    expect(replay).toMatchObject({ ok: true, board: { revision: 1 } });
+  });
   test("strict bounded PATCH validation rejects unknown and empty changes", async () => {
     const request = (body: unknown) => new Request("http://127.0.0.1:8898/api/board", { method: "PATCH", headers: { "content-type": "application/json" }, body: JSON.stringify(body) });
     await expect(validateBoardPatchRequest(request({ schemaVersion: 1, project: "viewer", baseRevision: 0, patch: { surprise: true } }))).rejects.toMatchObject({ code: "INVALID_REQUEST" });
     await expect(validateBoardPatchRequest(request({ schemaVersion: 1, project: "viewer", baseRevision: 0, patch: {} }))).rejects.toMatchObject({ code: "INVALID_REQUEST" });
     const parsed = await validateBoardPatchRequest(request({ schemaVersion: 1, project: "viewer", baseRevision: 0, patch: { taskPanelOpen: true } }));
     expect(parsed.patch).toEqual({ taskPanelOpen: true });
+  });
+  test("mutation validation rejects malformed batches and alias cycles", async () => {
+    const request = (body: unknown) => new Request("http://127.0.0.1:8898/api/board", { method: "PATCH", headers: { "content-type": "application/json" }, body: JSON.stringify(body) });
+    const valid = { schemaVersion: 1, project: "viewer", baseRevision: 0 };
+    for (const mutations of [
+      [],
+      [{ kind: "unknown" }],
+      [{ kind: "close", path: "" }],
+      [{ kind: "reconcile-roots", roots: Array.from({ length: 513 }, (_, index) => `/root-${index}`), removeManual: [] }],
+      [{ kind: "remap-paths", pairs: [{ from: "/old", to: "/one" }, { from: "/old", to: "/two" }] }],
+      [{ kind: "remap-paths", pairs: [{ from: "/old", to: "/new" }, { from: "/new", to: "/old" }] }],
+      [{ kind: "remap-paths", pairs: [{ from: "/old", to: "/new" }] }, { kind: "remap-paths", pairs: [{ from: "/new", to: "/old" }] }],
+    ]) {
+      await expect(validateBoardPatchRequest(request({ ...valid, mutations }))).rejects.toMatchObject({ code: "INVALID_REQUEST" });
+    }
+    const parsed = await validateBoardPatchRequest(request({ ...valid, mutations: [{ kind: "set-presentation", viewMode: "scheme" }] }));
+    expect(parsed.mutations).toEqual([{ kind: "set-presentation", viewMode: "scheme" }]);
   });
 });

--- a/src/lib/board/store.ts
+++ b/src/lib/board/store.ts
@@ -4,27 +4,38 @@ import path from "node:path";
 
 import { statePath } from "@/lib/configDir";
 
+import { applyBoardMutations, type BoardMutationV1 } from "@/lib/board/mutations";
 import type { BoardFileV1, BoardProjectStateV1 } from "@/lib/view/types";
 
 export const BOARD_FILE = statePath("board.json");
 const EMPTY_PREFS: BoardProjectStateV1["prefs"] = { manual: [], hidden: [], expanded: [], viewMode: null, taskPanelOpen: false };
+let boardFileForTests: string | null = null;
 
 export class BoardStoreError extends Error {
   constructor(message = "board state unavailable") { super(message); }
 }
 
+export function setBoardFileForTests(filePath: string | null): void {
+  boardFileForTests = filePath;
+}
+
 function stringArray(value: unknown): value is string[] { return Array.isArray(value) && value.every((item) => typeof item === "string"); }
+function aliases(value: unknown): value is Record<string, string> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  return Object.values(value).every((item) => typeof item === "string");
+}
 function projectState(value: unknown): value is BoardProjectStateV1 {
   if (!value || typeof value !== "object" || Array.isArray(value)) return false;
   const state = value as Partial<BoardProjectStateV1>;
   const prefs = state.prefs;
   return state.schemaVersion === 1 && Number.isInteger(state.revision) && state.revision! >= 0 && typeof state.updatedAt === "string" && Boolean(prefs) &&
     stringArray(prefs!.manual) && stringArray(prefs!.hidden) && stringArray(prefs!.expanded) &&
+    (state.pathAliases === undefined || aliases(state.pathAliases)) &&
     (prefs!.viewMode === null || prefs!.viewMode === "scheme" || prefs!.viewMode === "list") && typeof prefs!.taskPanelOpen === "boolean";
 }
 
 function emptyBoard(): BoardProjectStateV1 {
-  return { schemaVersion: 1, revision: 0, updatedAt: new Date(0).toISOString(), prefs: { ...EMPTY_PREFS, manual: [], hidden: [], expanded: [] } };
+  return { schemaVersion: 1, revision: 0, updatedAt: new Date(0).toISOString(), pathAliases: {}, prefs: { ...EMPTY_PREFS, manual: [], hidden: [], expanded: [] } };
 }
 
 function read(filePath: string): BoardFileV1 {
@@ -32,7 +43,7 @@ function read(filePath: string): BoardFileV1 {
     const parsed = JSON.parse(fs.readFileSync(filePath, "utf8")) as Partial<BoardFileV1>;
     if (!parsed || typeof parsed.projects !== "object" || parsed.projects === null || Array.isArray(parsed.projects)) throw new BoardStoreError("invalid board state");
     if (!Object.values(parsed.projects).every(projectState)) throw new BoardStoreError("invalid board project state");
-    return { projects: parsed.projects };
+    return { projects: Object.fromEntries(Object.entries(parsed.projects).map(([project, state]) => [project, { ...state, pathAliases: state.pathAliases ?? {} }])) };
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code === "ENOENT") return { projects: {} };
     if (error instanceof BoardStoreError) throw error;
@@ -45,16 +56,32 @@ function write(value: BoardFileV1, filePath: string): void {
   fs.writeFileSync(temp, JSON.stringify(value, null, 2) + "\n", "utf8");
   fs.renameSync(temp, filePath);
 }
-export function boardFor(project: string, filePath = BOARD_FILE): BoardProjectStateV1 {
+export function boardFor(project: string, filePath = boardFileForTests ?? BOARD_FILE): BoardProjectStateV1 {
   return read(filePath).projects[project] ?? emptyBoard();
 }
 export type BoardPatch = Partial<BoardProjectStateV1["prefs"]>;
-export function patchBoard(project: string, baseRevision: number, patch: BoardPatch, filePath = BOARD_FILE): { ok: true; board: BoardProjectStateV1 } | { ok: false; board: BoardProjectStateV1 } {
+type BoardWriteResult = { ok: true; board: BoardProjectStateV1 } | { ok: false; board: BoardProjectStateV1 };
+
+function sameReduced(left: BoardProjectStateV1, right: BoardProjectStateV1): boolean {
+  return JSON.stringify({ prefs: left.prefs, pathAliases: left.pathAliases ?? {} }) === JSON.stringify({ prefs: right.prefs, pathAliases: right.pathAliases ?? {} });
+}
+
+function writeReduced(project: string, baseRevision: number, reduce: (current: BoardProjectStateV1) => BoardProjectStateV1, filePath: string): BoardWriteResult {
   const value = read(filePath);
   const current = value.projects[project] ?? emptyBoard();
+  const reduced = reduce(current);
+  if (sameReduced(current, reduced)) return { ok: true, board: current };
   if (current.revision !== baseRevision) return { ok: false, board: current };
-  const next: BoardProjectStateV1 = { schemaVersion: 1, revision: current.revision + 1, updatedAt: new Date().toISOString(), prefs: { ...current.prefs, ...patch } };
+  const next: BoardProjectStateV1 = { ...reduced, schemaVersion: 1, revision: current.revision + 1, updatedAt: new Date().toISOString(), pathAliases: reduced.pathAliases ?? {} };
   value.projects[project] = next;
   write(value, filePath);
   return { ok: true, board: next };
+}
+
+export function patchBoard(project: string, baseRevision: number, patch: BoardPatch, filePath = boardFileForTests ?? BOARD_FILE): { ok: true; board: BoardProjectStateV1 } | { ok: false; board: BoardProjectStateV1 } {
+  return writeReduced(project, baseRevision, (current) => ({ ...current, prefs: { ...current.prefs, ...patch } }), filePath);
+}
+
+export function mutateBoard(project: string, baseRevision: number, mutations: readonly BoardMutationV1[], filePath = boardFileForTests ?? BOARD_FILE): BoardWriteResult {
+  return writeReduced(project, baseRevision, (current) => applyBoardMutations(current, mutations), filePath);
 }

--- a/src/lib/board/validation.ts
+++ b/src/lib/board/validation.ts
@@ -1,5 +1,6 @@
 import type { BoardProjectStateV1 } from "@/lib/view/types";
 import { readBoundedJson, ViewValidationError } from "@/lib/view/validation";
+import type { BoardMutationV1 } from "@/lib/board/mutations";
 
 export const MAX_BOARD_BODY_BYTES = 32 * 1024;
 export type BoardPatch = Partial<BoardProjectStateV1["prefs"]>;
@@ -18,12 +19,85 @@ function pathList(value: unknown, field: string): string[] {
   return value as string[];
 }
 
-export async function validateBoardPatchRequest(request: Request): Promise<{ project: string; baseRevision: number; patch: BoardPatch }> {
+function validPath(value: unknown, field: string): string {
+  if (typeof value !== "string" || value.length === 0 || value.length > 4096) throw new ViewValidationError("INVALID_REQUEST", `invalid ${field}`);
+  return value;
+}
+function mutation(value: unknown, index: number): BoardMutationV1 {
+  const raw = record(value, `mutations[${index}]`);
+  if (typeof raw.kind !== "string") throw new ViewValidationError("INVALID_REQUEST", `invalid mutations[${index}].kind`);
+  if (raw.kind === "close") {
+    exact(raw, ["kind", "path"], `mutations[${index}]`);
+    return { kind: "close", path: validPath(raw.path, `mutations[${index}].path`) };
+  }
+  if (raw.kind === "restore") {
+    exact(raw, ["kind", "path", "placement"], `mutations[${index}]`);
+    if (raw.placement !== "auto" && raw.placement !== "manual" && raw.placement !== "expanded") throw new ViewValidationError("INVALID_REQUEST", `invalid mutations[${index}].placement`);
+    return { kind: "restore", path: validPath(raw.path, `mutations[${index}].path`), placement: raw.placement };
+  }
+  if (raw.kind === "reconcile-roots") {
+    exact(raw, ["kind", "roots", "removeManual"], `mutations[${index}]`);
+    return { kind: "reconcile-roots", roots: pathList(raw.roots, `mutations[${index}].roots`), removeManual: pathList(raw.removeManual, `mutations[${index}].removeManual`) };
+  }
+  if (raw.kind === "remap-paths") {
+    exact(raw, ["kind", "pairs"], `mutations[${index}]`);
+    if (!Array.isArray(raw.pairs) || raw.pairs.length === 0 || raw.pairs.length > 512) throw new ViewValidationError("INVALID_REQUEST", `invalid mutations[${index}].pairs`);
+    const pairs = raw.pairs.map((pair, pairIndex) => {
+      const item = record(pair, `mutations[${index}].pairs[${pairIndex}]`);
+      exact(item, ["from", "to"], `mutations[${index}].pairs[${pairIndex}]`);
+      return { from: validPath(item.from, `mutations[${index}].pairs[${pairIndex}].from`), to: validPath(item.to, `mutations[${index}].pairs[${pairIndex}].to`) };
+    });
+    if (new Set(pairs.map((pair) => pair.from)).size !== pairs.length) throw new ViewValidationError("INVALID_REQUEST", `duplicate mutations[${index}].pairs.from`);
+    const aliases = Object.fromEntries(pairs.map((pair) => [pair.from, pair.to]));
+    for (const source of Object.keys(aliases)) {
+      const seen = new Set<string>();
+      let path = source;
+      while (aliases[path] !== undefined) {
+        if (seen.has(path)) throw new ViewValidationError("INVALID_REQUEST", `alias cycle in mutations[${index}]`);
+        seen.add(path);
+        path = aliases[path]!;
+      }
+    }
+    return { kind: "remap-paths", pairs };
+  }
+  if (raw.kind === "set-presentation") {
+    exact(raw, ["kind", "viewMode", "taskPanelOpen"], `mutations[${index}]`);
+    if (raw.viewMode === undefined && raw.taskPanelOpen === undefined) throw new ViewValidationError("INVALID_REQUEST", `empty mutations[${index}]`);
+    if (raw.viewMode !== undefined && raw.viewMode !== null && raw.viewMode !== "scheme" && raw.viewMode !== "list") throw new ViewValidationError("INVALID_REQUEST", `invalid mutations[${index}].viewMode`);
+    if (raw.taskPanelOpen !== undefined && typeof raw.taskPanelOpen !== "boolean") throw new ViewValidationError("INVALID_REQUEST", `invalid mutations[${index}].taskPanelOpen`);
+    return { kind: "set-presentation", ...(raw.viewMode === undefined ? {} : { viewMode: raw.viewMode }), ...(raw.taskPanelOpen === undefined ? {} : { taskPanelOpen: raw.taskPanelOpen }) };
+  }
+  throw new ViewValidationError("INVALID_REQUEST", `invalid mutations[${index}].kind`);
+}
+
+function rejectMutationAliasCycles(mutations: readonly BoardMutationV1[]): void {
+  const pairs = mutations.flatMap((item) => item.kind === "remap-paths" ? item.pairs : []);
+  if (new Set(pairs.map((pair) => pair.from)).size !== pairs.length) throw new ViewValidationError("INVALID_REQUEST", "duplicate remap source");
+  const aliases = Object.fromEntries(pairs.map((pair) => [pair.from, pair.to]));
+  for (const source of Object.keys(aliases)) {
+    const seen = new Set<string>();
+    let path = source;
+    while (aliases[path] !== undefined) {
+      if (seen.has(path)) throw new ViewValidationError("INVALID_REQUEST", "alias cycle in mutations");
+      seen.add(path);
+      path = aliases[path]!;
+    }
+  }
+}
+
+export async function validateBoardPatchRequest(request: Request): Promise<{ project: string; baseRevision: number; patch?: BoardPatch; mutations?: BoardMutationV1[] }> {
   const body = record(await readBoundedJson(request, MAX_BOARD_BODY_BYTES), "request");
-  exact(body, ["schemaVersion", "project", "baseRevision", "patch"], "request");
+  exact(body, ["schemaVersion", "project", "baseRevision", "patch", "mutations"], "request");
   if (body.schemaVersion !== 1) throw new ViewValidationError("UNSUPPORTED_SCHEMA_VERSION", "schemaVersion must be 1");
   if (typeof body.project !== "string" || body.project.length === 0 || body.project.length > 256) throw new ViewValidationError("INVALID_REQUEST", "invalid project");
   if (!Number.isInteger(body.baseRevision) || (body.baseRevision as number) < 0) throw new ViewValidationError("INVALID_REQUEST", "invalid baseRevision");
+  if ((body.patch === undefined) === (body.mutations === undefined)) throw new ViewValidationError("INVALID_REQUEST", "provide exactly one of patch or mutations");
+  if (body.mutations !== undefined) {
+    if (!Array.isArray(body.mutations) || body.mutations.length === 0 || body.mutations.length > 128) throw new ViewValidationError("INVALID_REQUEST", "invalid mutations");
+    const mutations = body.mutations.map(mutation);
+    rejectMutationAliasCycles(mutations);
+    return { project: body.project, baseRevision: body.baseRevision as number, mutations };
+  }
   const rawPatch = record(body.patch, "patch"); exact(rawPatch, ["manual", "hidden", "expanded", "viewMode", "taskPanelOpen"], "patch");
   if (Object.keys(rawPatch).length === 0) throw new ViewValidationError("INVALID_REQUEST", "empty patch");
   const patch: BoardPatch = {};

--- a/src/lib/view/types.ts
+++ b/src/lib/view/types.ts
@@ -87,6 +87,7 @@ export interface BoardProjectStateV1 {
   schemaVersion: 1;
   revision: number;
   updatedAt: string;
+  pathAliases?: Record<string, string>;
   prefs: { manual: string[]; hidden: string[]; expanded: string[]; viewMode: "scheme" | "list" | null; taskPanelOpen: boolean };
 }
 


### PR DESCRIPTION
## What changed

- adds revision-fenced board membership mutations with durable close, restore, remap, and reconciliation operations
- preserves tombstones across successor remaps and concurrent devices
- replaces whole-array client writes with an optimistic mutation outbox that replays intent through conflicts
- removes the 40-entry eviction/re-add oscillation and seeds root conversations only
- keeps idempotent mutations revision-quiet

## Why

Issue #60 showed closed scheme conversations returning and triggering repeated layout work. Whole-array snapshots and automatic root recording could overwrite a close intent, re-add evicted paths, and advance board revisions without semantic change.

## User impact

Closing or restoring a conversation now survives scanner refreshes, successor migration, multiple connected devices, and conflict retries. This PR delivers the membership-stability slice. Persistent x/y slot geometry remains tracked in #60.

## Verification

- focused cases 13–19: 22 passed
- RED proof: 8 failures plus one missing-module error against baseline, green after implementation
- board/hooks/components suites: 290 passed
- full suite: 770 passed across 108 files
- TypeScript, touched ESLint, and diff check passed

## Integration status

Draft pending the single full-stage review and combined acceptance run.