### PR TITLE
Restore quota-aware Codex account balancing

### DIFF
--- a/src/lib/accounts/codexAppServer.test.ts
+++ b/src/lib/accounts/codexAppServer.test.ts
@@ -30,8 +30,8 @@ class FakeChild extends EventEmitter {
     this.emit("stdout", value);
   }
 
-  respond(id: number, result: unknown): void {
-    this.output(JSON.stringify({ jsonrpc: "2.0", id, result }) + "\n");
+  respond(id: number, result: unknown, headerless = false): void {
+    this.output(JSON.stringify({ ...(headerless ? {} : { jsonrpc: "2.0" }), id, result }) + "\n");
   }
 
   failRequest(id: number, message: string): void {
@@ -79,6 +79,24 @@ test("JSON-RPC initialization frames lines, correlates ids, and sends initialize
   expect(child.killed).toBe(1);
 });
 
+test("headerless app-server responses, notifications, and requests keep the client healthy", async () => {
+  const { child, start } = clientWith((fake, message) => {
+    if (message.method === "initialize") fake.respond(requestId(message), {}, true);
+    if (message.method === "account/read") fake.respond(requestId(message), { account: { type: "chatgpt" }, requiresOpenaiAuth: true }, true);
+  });
+  const client = await start();
+  const notifications: string[] = [];
+  client.onNotification((message) => notifications.push(message.method));
+  client.onRequest(() => ({ accepted: true }));
+  child.output('{"method":"account/rateLimits/updated","params":{}}\n');
+  child.output('{"id":"request-1","method":"item/tool/requestUserInput","params":{}}\n');
+  await expect(client.readAccount()).resolves.toEqual({ account: { type: "chatgpt" }, requiresOpenaiAuth: true });
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  expect(notifications).toEqual(["account/rateLimits/updated"]);
+  expect(JSON.parse(child.writes.at(-1)!)).toEqual({ jsonrpc: "2.0", id: "request-1", result: { accepted: true } });
+  client.close();
+});
+
 test("out-of-order responses stay attached to their request ids", async () => {
   const pending: Record<string, number> = {};
   const { child, start } = clientWith((fake, message) => {
@@ -97,6 +115,28 @@ test("out-of-order responses stay attached to their request ids", async () => {
   await expect(limits).resolves.toEqual({ rateLimits: { primary: { usedPercent: 12, resetsAt: 42, windowDurationMins: null }, secondary: null, planType: null } });
   expect(child.writes.map((line) => JSON.parse(line)).find((message) => message.method === "account/rateLimits/read")).toEqual({ jsonrpc: "2.0", id: pending.limits, method: "account/rateLimits/read" });
   client.close();
+});
+
+test("response ids require an exact numeric correlation and duplicate replies fail the transport", async () => {
+  const mismatched = clientWith((fake, message) => {
+    if (message.method === "initialize") fake.respond(requestId(message), {});
+    if (message.method === "account/read") fake.output(JSON.stringify({ id: String(requestId(message)), result: {} }) + "\n");
+  });
+  const first = await mismatched.start();
+  await expect(first.readAccount()).rejects.toThrow("response has an invalid id");
+  expect(mismatched.child.signals).toContain("SIGTERM");
+
+  const duplicate = clientWith((fake, message) => {
+    if (message.method === "initialize") fake.respond(requestId(message), {});
+    if (message.method === "account/read") {
+      const id = requestId(message);
+      fake.respond(id, { account: null, requiresOpenaiAuth: true }, true);
+      fake.respond(id, { account: null, requiresOpenaiAuth: true }, true);
+    }
+  });
+  const second = await duplicate.start();
+  await expect(second.readAccount()).resolves.toEqual({ account: null, requiresOpenaiAuth: true });
+  expect(duplicate.child.signals).toContain("SIGTERM");
 });
 
 test("device-code login validates official challenge fields and forwards completion notifications safely", async () => {
@@ -187,6 +227,20 @@ test("fragmented and coalesced JSONL messages preserve request and notification 
   client.onNotification((notification) => seen.push(notification.method));
   await expect(client.readAccount()).resolves.toEqual({ account: null, requiresOpenaiAuth: true });
   expect(seen).toEqual(["account/login/completed"]);
+  client.close();
+});
+
+test("coalesced bounded frames exceed no transport limit", async () => {
+  const { start } = clientWith((fake, message) => {
+    if (message.method === "initialize") fake.respond(requestId(message), {});
+    if (message.method === "account/read") {
+      const padding = "x".repeat(600_000);
+      fake.output(JSON.stringify({ id: requestId(message), result: { account: null, requiresOpenaiAuth: true, padding } }) + "\n" +
+        JSON.stringify({ method: "account/updated", params: { padding } }) + "\n");
+    }
+  });
+  const client = await start();
+  await expect(client.readAccount()).resolves.toEqual({ account: null, requiresOpenaiAuth: true });
   client.close();
 });
 

--- a/src/lib/accounts/codexAppServer.ts
+++ b/src/lib/accounts/codexAppServer.ts
@@ -1,6 +1,14 @@
 import { spawn } from "node:child_process";
 import type { ChildProcessWithoutNullStreams } from "node:child_process";
 
+import {
+  CodexAppServerProtocolError,
+  parseAppServerMessage,
+  redactAppServerDetail,
+  type AppServerEnvelope,
+  type AppServerRequestId,
+} from "./codexAppServerProtocol";
+
 export interface CodexAppServerChild {
   stdin: Pick<ChildProcessWithoutNullStreams["stdin"], "write" | "end">;
   stdout: Pick<ChildProcessWithoutNullStreams["stdout"], "on">;
@@ -100,16 +108,9 @@ function spawnCodexAppServer(home: string): CodexAppServerChild {
 /** Errors crossing the app-server boundary are deliberately safe for logs and routes. */
 export class CodexAppServerError extends Error {
   constructor(message: string) {
-    super(redact(message));
+    super(redactAppServerDetail(message));
     this.name = "CodexAppServerError";
   }
-}
-
-function redact(value: string): string {
-  return value
-    .replace(/(bearer\s+)[^\s,;]+/gi, "$1[REDACTED]")
-    .replace(/(["']?(?:access|refresh|id)[_-]?token["']?\s*[:=]\s*["']?)[^\s,"'}]+/gi, "$1[REDACTED]")
-    .replace(/(["']?(?:api[_-]?key|authorization)["']?\s*[:=]\s*["']?)[^\s,"'}]+/gi, "$1[REDACTED]");
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -120,9 +121,8 @@ function protocolError(message: string): CodexAppServerError {
   return new CodexAppServerError(`Codex app-server protocol error: ${message}`);
 }
 
-function serverError(value: unknown): CodexAppServerError {
-  if (!isRecord(value)) return protocolError("server returned an invalid error payload");
-  const message = typeof value.message === "string" ? value.message : "server request failed";
+function serverError(value: { code: number; message: string }): CodexAppServerError {
+  const message = value.message;
   return new CodexAppServerError(`Codex app-server request failed: ${message}`);
 }
 
@@ -133,7 +133,7 @@ function requiredString(value: Record<string, unknown>, key: string, method: str
 
 function optionalWindow(value: unknown, method: string): AppServerRateLimitWindow | null {
   if (value === null || value === undefined) return null;
-  if (!isRecord(value) || typeof value.usedPercent !== "number") throw protocolError(`${method} response has an invalid rate-limit window`);
+  if (!isRecord(value) || typeof value.usedPercent !== "number" || !Number.isFinite(value.usedPercent) || value.usedPercent < 0 || value.usedPercent > 100) throw protocolError(`${method} response has an invalid rate-limit window`);
   const resetsAt = value.resetsAt;
   const windowDurationMins = value.windowDurationMins;
   if (resetsAt !== null && resetsAt !== undefined && (typeof resetsAt !== "number" || !Number.isInteger(resetsAt) || resetsAt < 0)) {
@@ -168,6 +168,7 @@ export class CodexAppServerClient {
   private nextId = 1;
   private stdoutBuffer = "";
   private stderrTail = "";
+  private lastInboundEnvelope: AppServerEnvelope | null = null;
   private closed = false;
   private reaped = false;
   private shutdownTimer: ReturnType<typeof setTimeout> | null = null;
@@ -180,7 +181,7 @@ export class CodexAppServerClient {
   ) {
     child.stdout.on("data", (chunk: Buffer | string) => this.acceptStdout(String(chunk)));
     child.stderr?.on("data", (chunk: Buffer | string) => {
-      this.stderrTail = redact((this.stderrTail + String(chunk)).slice(-2_000));
+      this.stderrTail = redactAppServerDetail((this.stderrTail + String(chunk)).slice(-2_000));
     });
     child.on("error", (error) => this.fail(new CodexAppServerError(`Codex app-server child error: ${error.message}`)));
     child.on("close", (code, signal) => {
@@ -230,6 +231,10 @@ export class CodexAppServerClient {
   onLifecycle(listener: (event: CodexAppServerLifecycleEvent) => void): () => void {
     this.lifecycleListeners.add(listener);
     return () => this.lifecycleListeners.delete(listener);
+  }
+
+  inboundEnvelope(): AppServerEnvelope | null {
+    return this.lastInboundEnvelope;
   }
 
   async readAccount(): Promise<AppServerAccountRead> {
@@ -375,16 +380,20 @@ export class CodexAppServerClient {
   private acceptStdout(chunk: string): void {
     if (this.closed) return;
     this.stdoutBuffer += chunk;
-    if (this.stdoutBuffer.length > MAX_STDOUT_BUFFER_BYTES) {
-      this.fail(protocolError("received an oversized unterminated JSONL line"));
-      return;
-    }
     let newline = this.stdoutBuffer.indexOf("\n");
     while (newline >= 0) {
-      const line = this.stdoutBuffer.slice(0, newline).trim();
+      const rawLine = this.stdoutBuffer.slice(0, newline);
       this.stdoutBuffer = this.stdoutBuffer.slice(newline + 1);
+      if (Buffer.byteLength(rawLine, "utf8") > MAX_STDOUT_BUFFER_BYTES) {
+        this.fail(protocolError("received an oversized JSONL line"));
+        return;
+      }
+      const line = rawLine.trim();
       if (line) this.acceptMessage(line);
       newline = this.stdoutBuffer.indexOf("\n");
+    }
+    if (Buffer.byteLength(this.stdoutBuffer, "utf8") > MAX_STDOUT_BUFFER_BYTES) {
+      this.fail(protocolError("received an oversized unterminated JSONL line"));
     }
   }
 
@@ -396,37 +405,38 @@ export class CodexAppServerClient {
       this.fail(protocolError("received malformed JSON"));
       return;
     }
-    if (!isRecord(message) || message.jsonrpc !== "2.0") {
-      this.fail(protocolError("received malformed JSON-RPC"));
+    let parsed;
+    try {
+      parsed = parseAppServerMessage(message);
+    } catch (error) {
+      const detail = error instanceof CodexAppServerProtocolError ? error.message : "received malformed JSON-RPC";
+      this.fail(new CodexAppServerError(detail));
       return;
     }
-    if (typeof message.method === "string") {
-      if ("id" in message) {
-        if (typeof message.id !== "string" && (typeof message.id !== "number" || !Number.isInteger(message.id))) {
-          this.fail(protocolError(`server request ${message.method} has an invalid id`));
-          return;
-        }
+    this.lastInboundEnvelope = parsed.envelope;
+    if (parsed.kind === "request") {
         const listener = this.requestListeners.values().next().value as ((request: AppServerRequest) => unknown | Promise<unknown>) | undefined;
         if (!listener) {
-          console.warn(`[codex app-server] rejected unhandled server request ${message.method}`);
-          this.write({ jsonrpc: "2.0", id: message.id, error: { code: -32601, message: "Viewer has no handler for this request" } });
+          console.warn(`[codex app-server] rejected unhandled server request ${parsed.method}`);
+          this.write({ jsonrpc: "2.0", id: parsed.id, error: { code: -32601, message: "Viewer has no handler for this request" } });
           return;
         }
         // Requests have one response owner. Additional listeners are observers
         // for notifications and never compete to answer a JSON-RPC request.
-        Promise.resolve(listener({ id: message.id, method: message.method, params: message.params }))
-          .then((result) => this.write({ jsonrpc: "2.0", id: message.id, result: result ?? {} }))
-          .catch((error) => this.write({ jsonrpc: "2.0", id: message.id, error: { code: -32000, message: redact(error instanceof Error ? error.message : "request handler failed") } }));
+        Promise.resolve(listener({ id: parsed.id, method: parsed.method, params: parsed.params }))
+          .then((result) => this.write({ jsonrpc: "2.0", id: parsed.id, result: result ?? {} }))
+          .catch((error) => this.write({ jsonrpc: "2.0", id: parsed.id, error: { code: -32000, message: redactAppServerDetail(error instanceof Error ? error.message : "request handler failed") } }));
         return;
-      }
-      const notification = { method: message.method, params: message.params };
+    }
+    if (parsed.kind === "notification") {
+      const notification = { method: parsed.method, params: parsed.params };
       for (const listener of this.notificationListeners) {
         try { listener(notification); } catch { /* one consumer cannot break the transport */ }
       }
       return;
     }
-    const id = message.id;
-    if (typeof id !== "number" || !Number.isInteger(id)) {
+    const id: AppServerRequestId = parsed.id;
+    if (typeof id !== "number") {
       this.fail(protocolError("response has an invalid id"));
       return;
     }
@@ -435,16 +445,10 @@ export class CodexAppServerClient {
       this.fail(protocolError(`response id ${id} has no matching request`));
       return;
     }
-    const hasResult = Object.prototype.hasOwnProperty.call(message, "result");
-    const hasError = Object.prototype.hasOwnProperty.call(message, "error");
-    if (hasResult === hasError) {
-      this.fail(protocolError(`response for ${pending.method} must contain exactly one of result or error`));
-      return;
-    }
     this.pending.delete(id);
     this.clock.clearTimeout(pending.timeout);
-    if (hasError) pending.reject(serverError(message.error));
-    else pending.resolve(message.result);
+    if (parsed.error) pending.reject(serverError(parsed.error));
+    else pending.resolve(parsed.result);
   }
 
   private fail(error: CodexAppServerError): void {

--- a/src/lib/accounts/codexAppServerProtocol.test.ts
+++ b/src/lib/accounts/codexAppServerProtocol.test.ts
@@ -1,0 +1,63 @@
+import { expect, test } from "bun:test";
+import fs from "node:fs";
+import path from "node:path";
+
+import { parseAppServerMessage, redactAppServerDetail } from "./codexAppServerProtocol";
+
+const fixtures = path.join(import.meta.dir, "fixtures");
+
+function rows(name: string): unknown[] {
+  return fs.readFileSync(path.join(fixtures, name), "utf8").trim().split("\n").map((line) => JSON.parse(line));
+}
+
+function semantic(message: ReturnType<typeof parseAppServerMessage>): Record<string, unknown> {
+  if (message.kind === "response") return message.error
+    ? { kind: message.kind, id: message.id, error: message.error }
+    : { kind: message.kind, id: message.id, result: message.result };
+  if (message.kind === "request") return { kind: message.kind, id: message.id, method: message.method, params: message.params };
+  return { kind: message.kind, method: message.method, params: message.params };
+}
+
+test("headerless and JSON-RPC 2.0 fixtures classify identically", () => {
+  const headerless = rows("codex-app-server-v0.144.1-headerless.jsonl").map(parseAppServerMessage);
+  const explicit = rows("codex-app-server-jsonrpc2.jsonl").map(parseAppServerMessage);
+  expect(headerless.map(semantic)).toEqual(explicit.map(semantic));
+  expect(headerless.map((message) => message.kind)).toEqual(["response", "notification", "request"]);
+});
+
+test("classifier rejects hybrid envelopes, bad versions, and malformed errors", () => {
+  for (const value of [
+    { jsonrpc: "1.0", id: 1, result: {} },
+    { jsonrpc: null, method: "event" },
+    { id: 1, method: "event", result: {} },
+    { id: 1, result: {}, error: { code: 1, message: "x" } },
+    { id: 1, error: { code: "-1", message: "x" } },
+    { method: "" },
+    { id: 1 },
+  ]) expect(() => parseAppServerMessage(value)).toThrow("protocol error");
+});
+
+test("classifier preserves integer and string ids and redacts bounded detail", () => {
+  expect(parseAppServerMessage({ id: 7, method: "ask" })).toMatchObject({ kind: "request", id: 7 });
+  expect(parseAppServerMessage({ id: "request-7", method: "ask" })).toMatchObject({ kind: "request", id: "request-7" });
+  const detail = redactAppServerDetail("authorization=very-secret access_token=another-secret");
+  expect(detail).toContain("[REDACTED]");
+  expect(detail).not.toContain("very-secret");
+  expect(detail.length).toBeLessThanOrEqual(500);
+});
+
+test("seeded generated objects have one accepted message class at most", () => {
+  let state = 0x40c0de;
+  const next = () => { state = (state * 1664525 + 1013904223) >>> 0; return state; };
+  for (let index = 0; index < 500; index += 1) {
+    const value: Record<string, unknown> = {};
+    if (next() & 1) value.jsonrpc = next() & 1 ? "2.0" : "1.0";
+    if (next() & 1) value.id = next() & 1 ? next() % 100 : `id-${next()}`;
+    if (next() & 1) value.method = next() & 1 ? `method-${next()}` : "";
+    if (next() & 1) value.result = {};
+    if (next() & 1) value.error = { code: next() & 1 ? -1 : "-1", message: "error" };
+    let accepted = 0;
+    try { parseAppServerMessage(value); accepted += 1; } catch { /* rejected frames are expected */ }
+    expect(accepted).toBeLessThanOrEqual(1);
+  }
+});

--- a/src/lib/accounts/codexAppServerProtocol.ts
+++ b/src/lib/accounts/codexAppServerProtocol.ts
@@ -1,0 +1,80 @@
+const MAX_METHOD_LENGTH = 256;
+const MAX_ID_LENGTH = 512;
+const MAX_ERROR_MESSAGE_LENGTH = 2_000;
+const MAX_REDACTED_DETAIL_LENGTH = 500;
+
+export type AppServerRequestId = string | number;
+export type AppServerEnvelope = "headerless" | "jsonrpc-2.0";
+
+export type AppServerMessage =
+  | { kind: "response"; envelope: AppServerEnvelope; id: AppServerRequestId; result?: unknown; error?: { code: number; message: string } }
+  | { kind: "request"; envelope: AppServerEnvelope; id: AppServerRequestId; method: string; params: unknown }
+  | { kind: "notification"; envelope: AppServerEnvelope; method: string; params: unknown };
+
+export class CodexAppServerProtocolError extends Error {
+  constructor(message: string) {
+    super(`Codex app-server protocol error: ${redactAppServerDetail(message)}`);
+    this.name = "CodexAppServerProtocolError";
+  }
+}
+
+export function redactAppServerDetail(value: string): string {
+  return value
+    .replace(/(bearer\s+)[^\s,;]+/gi, "$1[REDACTED]")
+    .replace(/(["']?(?:access|refresh|id)[_-]?token["']?\s*[:=]\s*["']?)[^\s,"'}]+/gi, "$1[REDACTED]")
+    .replace(/(["']?(?:api[_-]?key|authorization)["']?\s*[:=]\s*["']?)[^\s,"'}]+/gi, "$1[REDACTED]")
+    .slice(0, MAX_REDACTED_DETAIL_LENGTH);
+}
+
+export function isAppServerRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function has(value: Record<string, unknown>, key: string): boolean {
+  return Object.prototype.hasOwnProperty.call(value, key);
+}
+
+function validId(value: unknown): value is AppServerRequestId {
+  return (typeof value === "string" && value.length > 0 && value.length <= MAX_ID_LENGTH) ||
+    (typeof value === "number" && Number.isSafeInteger(value));
+}
+
+function validMethod(value: unknown): value is string {
+  return typeof value === "string" && value.length > 0 && value.length <= MAX_METHOD_LENGTH;
+}
+
+function protocol(message: string): never {
+  throw new CodexAppServerProtocolError(message);
+}
+
+/** Classifies installed headerless frames and explicit JSON-RPC 2.0 envelopes. */
+export function parseAppServerMessage(value: unknown): AppServerMessage {
+  if (!isAppServerRecord(value)) protocol("message must be an object");
+  if (has(value, "jsonrpc") && value.jsonrpc !== "2.0") protocol("jsonrpc must be 2.0 when present");
+  const envelope: AppServerEnvelope = has(value, "jsonrpc") ? "jsonrpc-2.0" : "headerless";
+
+  const hasId = has(value, "id");
+  const hasMethod = has(value, "method");
+  const hasResult = has(value, "result");
+  const hasError = has(value, "error");
+
+  if (hasResult || hasError) {
+    if (hasMethod || !hasId || hasResult === hasError) protocol("response shape is invalid");
+    if (!validId(value.id)) protocol("response id is invalid");
+    if (hasError) {
+      if (!isAppServerRecord(value.error) || typeof value.error.code !== "number" || !Number.isSafeInteger(value.error.code) ||
+        typeof value.error.message !== "string" || value.error.message.length > MAX_ERROR_MESSAGE_LENGTH) {
+        protocol("response error is invalid");
+      }
+      return { kind: "response", envelope, id: value.id, error: { code: value.error.code, message: value.error.message } };
+    }
+    return { kind: "response", envelope, id: value.id, result: value.result };
+  }
+
+  if (!hasMethod || !validMethod(value.method)) protocol("method is invalid");
+  if (hasId) {
+    if (!validId(value.id)) protocol(`server request ${value.method} has an invalid id`);
+    return { kind: "request", envelope, id: value.id, method: value.method, params: value.params };
+  }
+  return { kind: "notification", envelope, method: value.method, params: value.params };
+}

--- a/src/lib/accounts/codexRuntime.test.ts
+++ b/src/lib/accounts/codexRuntime.test.ts
@@ -16,6 +16,7 @@ class FakeChild extends EventEmitter {
   readonly methods: string[] = [];
   kills = 0;
   authenticated = false;
+  requiresOpenaiAuth = false;
   readFailure = false;
   onWrite(message: Record<string, unknown>): void {
     if (typeof message.method === "string") this.methods.push(message.method);
@@ -24,7 +25,7 @@ class FakeChild extends EventEmitter {
     if (message.method === "account/login/cancel") this.respond(message.id as number, { status: "canceled" });
     if (message.method === "account/read") {
       if (this.readFailure) this.emit("stdout", JSON.stringify({ jsonrpc: "2.0", id: message.id, error: { message: "offline" } }) + "\n");
-      else this.respond(message.id as number, this.authenticated ? { account: { type: "chatgpt" }, requiresOpenaiAuth: false } : { account: null, requiresOpenaiAuth: true });
+      else this.respond(message.id as number, this.authenticated ? { account: { type: "chatgpt" }, requiresOpenaiAuth: this.requiresOpenaiAuth } : { account: null, requiresOpenaiAuth: true });
     }
     if (message.method === "account/rateLimits/read") this.respond(message.id as number, { rateLimits: { primary: { usedPercent: 7, resetsAt: 99 }, secondary: { usedPercent: 31, resetsAt: 199 }, planType: "pro" } });
   }
@@ -165,4 +166,27 @@ test("account/read owns authentication independently from auth.json diagnostics"
   } });
   const missingFile = { ...work, authPresent: false };
   await expect(valid.loginSnapshot(missingFile)).resolves.toEqual({ state: "authenticated", attemptState: "completed", deviceAuth: null });
+});
+
+test("legacy Main and managed homes use the read-only account-plus-limits probe", async () => {
+  const children: FakeChild[] = [];
+  const runtime = new ManagedCodexRuntime({ startClient: async (home) => {
+    const child = new FakeChild();
+    child.authenticated = true;
+    child.requiresOpenaiAuth = true;
+    children.push(child);
+    return CodexAppServerClient.start({ home, spawn: () => child as never });
+  } });
+  const main: CodexAccount = { id: "default", label: "Main", kind: "legacy", home: "/accounts/main", sessionsDir: "/accounts/main/sessions", authPresent: true, loginPane: null, createdAt: 0 };
+  const managed = account("managed", "/accounts/managed");
+
+  await expect(runtime.probeQuota(main)).resolves.toMatchObject({ authenticated: true, rateLimits: { primary: { usedPercent: 7 } } });
+  await expect(runtime.probeQuota(managed)).resolves.toMatchObject({ authenticated: true, rateLimits: { secondary: { usedPercent: 31 } } });
+
+  for (const child of children) {
+    expect(child.methods).toEqual(["initialize", "initialized", "account/read", "account/rateLimits/read"]);
+    expect(child.methods).not.toContain("account/rateLimitResetCredit/consume");
+    expect(child.methods).not.toContain("account/login/start");
+    expect(child.methods).not.toContain("account/login/cancel");
+  }
 });

--- a/src/lib/accounts/codexRuntime.ts
+++ b/src/lib/accounts/codexRuntime.ts
@@ -5,9 +5,11 @@ import type { CodexAccount } from "./codex";
 import { statePath } from "../configDir";
 import {
   CodexAppServerClient,
+  type AppServerAccountRead,
   type AppServerRateLimits,
   type DeviceCodeChallenge,
 } from "./codexAppServer";
+import type { AppServerEnvelope } from "./codexAppServerProtocol";
 
 /** Authentication is only asserted after `account/read`; attempt state is a
  * separate recoverable record for device-login supervision. */
@@ -32,6 +34,13 @@ export interface ManagedCodexRuntimeOptions {
   startClient?: (home: string) => Promise<CodexAppServerClient>;
   now?: () => number;
   stateFile?: string;
+}
+
+export interface CodexQuotaProbe {
+  account: AppServerAccountRead;
+  rateLimits: AppServerRateLimits;
+  authenticated: boolean;
+  envelope: AppServerEnvelope | null;
 }
 
 type AttemptReason = "child-died" | "login-unsuccessful" | "cancelled" | "viewer-restarted" | "account-read-failed" | "start-failed";
@@ -214,7 +223,7 @@ export class ManagedCodexRuntime {
     const stored = this.records.get(home);
     try {
       const status = await this.readAccount(active?.client ?? null, account.home);
-      if (status.account && !status.requiresOpenaiAuth) {
+      if (isSupportedChatGptAccount(status)) {
         if (active) this.settle(active, "completed", null, true);
         else if (stored) this.record(home, { ...stored, state: "completed", updatedAt: this.now(), reason: null });
         return { state: "authenticated", attemptState: "completed", deviceAuth: null };
@@ -257,17 +266,20 @@ export class ManagedCodexRuntime {
 
   /** Reads a structured rate snapshot through an active login child when one exists. */
   async readRateLimits(account: CodexAccount): Promise<AppServerRateLimits> {
-    const active = this.active.get(canonicalHome(account.home));
-    if (active?.client) return this.readRateLimitsFrom(active.client);
-    const client = await this.startClient(account.home);
-    try { return await this.readRateLimitsFrom(client); }
-    finally { client.close(); }
+    return (await this.probeQuota(account)).rateLimits;
   }
 
   async verifyAuthentication(account: CodexAccount): Promise<boolean> {
+    return (await this.probeQuota(account)).authenticated;
+  }
+
+  /** Performs the two read-only account calls on one app-server client. */
+  async probeQuota(account: CodexAccount): Promise<CodexQuotaProbe> {
     const active = this.active.get(canonicalHome(account.home));
-    const status = await this.readAccount(active?.client ?? null, account.home);
-    return Boolean(status.account && !status.requiresOpenaiAuth);
+    if (active?.client) return this.probeQuotaFrom(active.client);
+    const client = await this.startClient(account.home);
+    try { return await this.probeQuotaFrom(client); }
+    finally { client.close(); }
   }
 
   private async readAccount(existing: CodexAppServerClient | null, home: string) {
@@ -277,10 +289,10 @@ export class ManagedCodexRuntime {
     finally { client.close(); }
   }
 
-  private async readRateLimitsFrom(client: CodexAppServerClient): Promise<AppServerRateLimits> {
+  private async probeQuotaFrom(client: CodexAppServerClient): Promise<CodexQuotaProbe> {
     const account = await client.readAccount();
-    if (!account.account || account.requiresOpenaiAuth) throw new Error("Codex account is not authenticated");
-    return (await client.readRateLimits()).rateLimits;
+    const rateLimits = (await client.readRateLimits()).rateLimits;
+    return { account, rateLimits, authenticated: isSupportedChatGptAccount(account), envelope: client.inboundEnvelope() };
   }
 
   private owns(attempt: ActiveAttempt): boolean {
@@ -314,6 +326,10 @@ export class ManagedCodexRuntime {
       fs.rmSync(tmp, { force: true });
     }
   }
+}
+
+function isSupportedChatGptAccount(account: AppServerAccountRead): boolean {
+  return account.account?.type === "chatgpt";
 }
 
 function publicAttempt(attempt: ActiveAttempt): ManagedLoginAttempt {

--- a/src/lib/accounts/fixtures/codex-app-server-jsonrpc2.jsonl
+++ b/src/lib/accounts/fixtures/codex-app-server-jsonrpc2.jsonl
@@ -1,0 +1,3 @@
+{"jsonrpc":"2.0","id":1,"result":{"serverInfo":{"name":"codex"}}}
+{"jsonrpc":"2.0","method":"account/rateLimits/updated","params":{"rateLimits":{}}}
+{"jsonrpc":"2.0","id":"request-1","method":"item/tool/requestUserInput","params":{"questions":[]}}

--- a/src/lib/accounts/fixtures/codex-app-server-v0.144.1-headerless.jsonl
+++ b/src/lib/accounts/fixtures/codex-app-server-v0.144.1-headerless.jsonl
@@ -1,0 +1,3 @@
+{"id":1,"result":{"serverInfo":{"name":"codex"}}}
+{"method":"account/rateLimits/updated","params":{"rateLimits":{}}}
+{"id":"request-1","method":"item/tool/requestUserInput","params":{"questions":[]}}

--- a/src/lib/accounts/migration/autoBalance.ts
+++ b/src/lib/accounts/migration/autoBalance.ts
@@ -1,6 +1,7 @@
 import crypto from "node:crypto";
 
 import { agentRegistry, MigrationRevisionError, type AgentRegistry } from "@/lib/agent/registry";
+import { logAccountMigrationEvent } from "@/lib/events";
 
 import type { DurableQuotaObservation, MigrationIntent } from "./contracts";
 import { AUTO_BALANCE_COOLDOWN_MS, AUTO_BALANCE_SAMPLE_GAP_MS, chooseAutoBalance, type QuotaObservation } from "./quotaPolicy";
@@ -52,6 +53,17 @@ export function evaluateAutoBalance(
     if (intent.origin === "auto" && intent.state === "complete") {
       registry.recordAutoBalanceOutcome(engine, "complete", intent.evidence, new Date(now + AUTO_BALANCE_COOLDOWN_MS).toISOString());
     }
+    if (intent.origin === "auto") {
+      logAccountMigrationEvent({
+        engine,
+        intentId: intent.id,
+        origin: intent.origin,
+        sourceId: intent.evidence?.sourceId ?? null,
+        targetId: intent.targetId,
+        outcome: intent.state === "complete" ? "complete" : "committed",
+        cooldownUntil: intent.state === "complete" ? new Date(now + AUTO_BALANCE_COOLDOWN_MS).toISOString() : null,
+      });
+    }
     return intent.origin === "auto" ? intent : null;
   } catch (error) {
     if (error instanceof MigrationRevisionError) return null;
@@ -63,4 +75,16 @@ export function completeAutoBalanceIntent(engine: "claude" | "codex", intentId: 
   registry.setMigrationIntentState(intentId, outcome === "stopped" ? "stopped" : "complete");
   const snapshot = registry.snapshot();
   registry.recordAutoBalanceOutcome(engine, outcome, snapshot.migrationIntents[intentId]?.evidence ?? null, new Date(now + AUTO_BALANCE_COOLDOWN_MS).toISOString());
+  const intent = snapshot.migrationIntents[intentId];
+  if (intent?.origin === "auto") {
+    logAccountMigrationEvent({
+      engine,
+      intentId,
+      origin: "auto",
+      sourceId: intent.evidence?.sourceId ?? null,
+      targetId: intent.targetId,
+      outcome,
+      cooldownUntil: new Date(now + AUTO_BALANCE_COOLDOWN_MS).toISOString(),
+    });
+  }
 }

--- a/src/lib/accounts/migration/controller.test.ts
+++ b/src/lib/accounts/migration/controller.test.ts
@@ -4,7 +4,9 @@ import os from "node:os";
 import path from "node:path";
 
 import { AgentRegistry } from "@/lib/agent/registry";
+import type { CodexAccount } from "@/lib/accounts/codex";
 import { emptyLaunchProfile, type SuccessorProviderPort } from "./contracts";
+import { QuotaController, type QuotaProbePort } from "./quotaController";
 
 const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "llv-account-controller-"));
 const { reconcileAccountMigrationCycle } = await import("./controller");
@@ -36,4 +38,73 @@ test("controller migration cycle reconciles and ticks both durable quota policy 
 
   expect(ticks.sort()).toEqual(["claude", "codex"]);
   expect(registry.conversation(conversation.id)?.migration?.phase).toBe("committed");
+}, 20_000);
+
+test("three controller cycles move depleted Main to a stronger managed account and suppress a bounce", async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "llv-account-controller-auto-"));
+  try {
+    const registry = new AgentRegistry(path.join(root, "registry.json"));
+    let current = Date.parse("2026-07-10T12:00:00.000Z");
+    const main: CodexAccount = { id: "default", label: "Main", kind: "legacy", home: "/homes/main", sessionsDir: "/homes/main/sessions", authPresent: true, loginPane: null, createdAt: 0 };
+    const managed: CodexAccount = { id: "managed", label: "Managed", kind: "managed", home: "/homes/managed", sessionsDir: "/homes/managed/sessions", authPresent: true, loginPane: null, createdAt: 1 };
+    const probe: QuotaProbePort = {
+      list: (engine) => engine === "codex" ? [main, managed] : [],
+      active: () => "default",
+      async probe(engine, candidate, observedAt) {
+        const used = candidate.id === "default" ? 80 : 20;
+        return {
+          engine,
+          accountId: candidate.id,
+          authenticated: true,
+          authCheckedAt: observedAt,
+          limits: { session: { usedPercent: used, resetsAt: null }, weekly: null, plan: "pro", capturedAt: Math.floor(observedAt / 1000) },
+          provenance: { source: "live", reason: null, staleSince: null },
+          observedAt,
+        };
+      },
+    };
+    const quota = new QuotaController(registry, probe, "00000000-0000-4000-8000-000000000040", () => current);
+    registry.setAutoBalancePolicy("codex", true);
+    registry.reconcileConversations([{
+      engine: "codex",
+      path: "/main.jsonl",
+      accountId: "default",
+      launchProfile: emptyLaunchProfile({ title: "Main card" }),
+      turn: { state: "idle", source: "empty", terminalAt: null },
+      observedAt: new Date(current).toISOString(),
+    }]);
+    const conversationId = registry.conversationForPath("/main.jsonl")!.id;
+    const provider: SuccessorProviderPort = {
+      async create(input) {
+        return {
+          operationId: input.operationId,
+          nativeId: "managed-successor",
+          path: "/managed.jsonl",
+          historyHash: "managed-history",
+          host: { kind: "codex-app-server", identity: "managed-successor", epoch: 1, verifiedAt: new Date(current).toISOString() },
+        };
+      },
+      async verify() {},
+    };
+
+    await reconcileAccountMigrationCycle(registry, quota, provider, { async deliver() { return "delivered"; } });
+    expect(registry.snapshot().autoBalance.codex.sustain).toMatchObject({ bootId: "00000000-0000-4000-8000-000000000040" });
+
+    current += 60_000;
+    await reconcileAccountMigrationCycle(registry, quota, provider, { async deliver() { return "delivered"; } });
+    const intent = Object.values(registry.snapshot().migrationIntents).find((item) => item.engine === "codex");
+    expect(intent).toMatchObject({ origin: "auto", targetId: "managed", state: "draining" });
+    expect(registry.engineRouting("codex").activeAccountId).toBe("managed");
+
+    current += 60_000;
+    await reconcileAccountMigrationCycle(registry, quota, provider, { async deliver() { return "delivered"; } });
+    const snapshot = registry.snapshot();
+    expect(snapshot.conversations[conversationId]?.migration?.phase).toBe("committed");
+    expect(snapshot.conversations[conversationId]?.generations.at(-1)?.accountId).toBe("managed");
+    expect(snapshot.migrationIntents[intent!.id]?.state).toBe("complete");
+    expect(snapshot.autoBalance.codex.cooldownUntil).toBeTruthy();
+    expect(Object.values(snapshot.migrationIntents)).toHaveLength(1);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
 }, 20_000);

--- a/src/lib/accounts/migration/quotaController.test.ts
+++ b/src/lib/accounts/migration/quotaController.test.ts
@@ -4,6 +4,7 @@ import os from "node:os";
 import path from "node:path";
 
 import { AgentRegistry } from "@/lib/agent/registry";
+import type { CodexAccount } from "@/lib/accounts/codex";
 
 import { QuotaController, type QuotaProbePort } from "./quotaController";
 
@@ -26,6 +27,41 @@ test("durable per-engine policy is the quota evaluation guard", async () => {
     registry.setAutoBalancePolicy("codex", true);
     await controller.tick("codex");
     expect(listed).toBe(1);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("a failed home records a closed code while the controller sweeps later homes", async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "llv-quota-sweep-"));
+  try {
+    const registry = new AgentRegistry(path.join(root, "registry.json"));
+    const accounts: CodexAccount[] = [
+      { id: "default", label: "Main", kind: "legacy", home: "/homes/main", sessionsDir: "/homes/main/sessions", authPresent: true, loginPane: null, createdAt: 0 },
+      { id: "managed", label: "Managed", kind: "managed", home: "/homes/managed", sessionsDir: "/homes/managed/sessions", authPresent: true, loginPane: null, createdAt: 1 },
+    ];
+    const visited: string[] = [];
+    const controller = new QuotaController(registry, {
+      list: () => accounts,
+      active: () => "default",
+      async probe(engine, account, now) {
+        visited.push(account.id);
+        if (account.id === "default") throw new Error("access_token=secret");
+        return {
+          engine,
+          accountId: account.id,
+          authenticated: true,
+          authCheckedAt: now,
+          limits: { session: { usedPercent: 20, resetsAt: null }, weekly: null, plan: "pro", capturedAt: Math.floor(now / 1000) },
+          provenance: { source: "live" as const, reason: null, staleSince: null },
+          observedAt: now,
+        };
+      },
+    }, "00000000-0000-4000-8000-000000000040", () => Date.parse("2026-07-10T12:00:00.000Z"));
+    await controller.tick("codex");
+    expect(visited.sort()).toEqual(["default", "managed"]);
+    expect(registry.snapshot().quotaObservations.codex.default?.provenance.reason).toBe("quota-probe-failed");
+    expect(JSON.stringify(registry.snapshot())).not.toContain("secret");
   } finally {
     fs.rmSync(root, { recursive: true, force: true });
   }

--- a/src/lib/accounts/migration/quotaController.ts
+++ b/src/lib/accounts/migration/quotaController.ts
@@ -6,7 +6,8 @@ import { realClaudeLoginPorts } from "@/lib/accounts/claudeLogin";
 import { activeCodexAccountId, listCodexAccounts, type CodexAccount } from "@/lib/accounts/codex";
 import { managedCodexRuntime } from "@/lib/accounts/codexRuntime";
 import { agentRegistry, type AgentRegistry } from "@/lib/agent/registry";
-import { fetchClaudeLimits, readCodexLimits } from "@/lib/limits";
+import { logQuotaEvent } from "@/lib/events";
+import { fetchClaudeLimits, mapAppServerRateLimits, readCodexLimits } from "@/lib/limits";
 
 import { evaluateAutoBalance } from "./autoBalance";
 import type { MigrationEngine } from "./contracts";
@@ -39,19 +40,33 @@ const productionProbe: QuotaProbePort = {
       };
     }
     const candidate = account as CodexAccount;
-    const authenticated = await managedCodexRuntime().verifyAuthentication(candidate).catch(() => false);
-    const limits = authenticated
-      ? await readCodexLimits({ account: candidate })
-      : { data: null, source: "unavailable" as const, reason: "live authentication check failed" };
-    return {
-      engine,
-      accountId: candidate.id,
-      authenticated,
-      authCheckedAt: now,
-      limits: limits.data,
-      provenance: { source: limits.source, reason: limits.reason, staleSince: null },
-      observedAt: now,
-    };
+    try {
+      const probe = await managedCodexRuntime().probeQuota(candidate);
+      return {
+        engine,
+        accountId: candidate.id,
+        authenticated: probe.authenticated,
+        authCheckedAt: now,
+        limits: mapAppServerRateLimits(probe.rateLimits, Math.floor(now / 1000)),
+        provenance: { source: "live", reason: probe.authenticated ? null : "unsupported-account-type", staleSince: null },
+        observedAt: now,
+        envelope: probe.envelope,
+      };
+    } catch (error) {
+      // The reader owns redacted server-local detail and returns a closed code
+      // suitable for the durable quota registry.
+      const limits = await readCodexLimits({ account: candidate, liveReader: async () => Promise.reject(error) });
+      return {
+        engine,
+        accountId: candidate.id,
+        authenticated: false,
+        authCheckedAt: now,
+        limits: limits.data,
+        provenance: { source: limits.source, reason: limits.reason, staleSince: null },
+        observedAt: now,
+        envelope: null,
+      };
+    }
   },
 };
 
@@ -79,7 +94,35 @@ export class QuotaController {
   async tick(engine: MigrationEngine): Promise<void> {
     if (!this.registry.autoBalancePolicy(engine).enabled) return;
     const now = this.now();
-    const observations = await mapLimit(this.probe.list(engine), 2, (account) => this.probe.probe(engine, account, now));
+    const accounts = this.probe.list(engine);
+    const observations = await mapLimit(accounts, 2, async (account) => {
+      try {
+        return await this.probe.probe(engine, account, now);
+      } catch {
+        return {
+          engine,
+          accountId: account.id,
+          authenticated: false,
+          authCheckedAt: now,
+          limits: null,
+          provenance: { source: "unavailable" as const, reason: "quota-probe-failed", staleSince: null },
+          observedAt: now,
+          envelope: null,
+        };
+      }
+    });
+    observations.forEach((observation, index) => {
+      const account = accounts[index]!;
+      logQuotaEvent({
+        engine,
+        accountId: observation.accountId,
+        accountKind: account.kind,
+        envelope: observation.envelope ?? null,
+        probePhase: "account-rate-limits",
+        provenance: observation.provenance.source,
+        reasonCode: observation.provenance.reason,
+      });
+    });
     const active = this.registry.engineRouting(engine).activeAccountId ?? this.probe.active(engine);
     evaluateAutoBalance(engine, active, observations, now, this.registry, this.bootId);
   }

--- a/src/lib/accounts/migration/quotaPolicy.test.ts
+++ b/src/lib/accounts/migration/quotaPolicy.test.ts
@@ -21,4 +21,43 @@ describe("quota migration policy", () => {
     const blocked = policy(); blocked.departed.b = new Date(now - 1_000).toISOString();
     expect(chooseAutoBalance("codex", "a", [observation("a", 80, 80), observation("b", 70, 70)], blocked, now)).toBeNull();
   });
+
+  test("rejects invalid percentages and timestamps before an automatic decision", () => {
+    const invalidPercent = observation("a", 101, 10);
+    const invalidTime = { ...observation("a", 80, 10), observedAt: Number.NaN };
+    const invalidReset = { ...observation("a", 80, 10), limits: { ...observation("a", 80, 10).limits, session: { usedPercent: 80, resetsAt: -1 } } };
+    expect(effectiveRemaining(invalidPercent, now)).toBeNull();
+    expect(effectiveRemaining(invalidTime, now)).toBeNull();
+    expect(effectiveRemaining(invalidReset, now)).toBeNull();
+    expect(chooseAutoBalance("codex", "a", [invalidPercent, observation("b", 10, 10)], policy(), now)).toBeNull();
+  });
+
+  test("seeded policy cases preserve threshold, eligibility, and deterministic winner", () => {
+    let state = 40;
+    const next = () => { state = (state * 1103515245 + 12345) >>> 0; return state; };
+    for (let index = 0; index < 250; index += 1) {
+      const activeUsed = next() % 101;
+      const leftUsed = next() % 101;
+      const rightUsed = next() % 101;
+      const decision = chooseAutoBalance("codex", "active", [
+        observation("active", activeUsed, activeUsed),
+        observation("left", leftUsed, leftUsed),
+        observation("right", rightUsed, rightUsed),
+      ], policy(), now);
+      if (!decision) continue;
+      const source = effectiveRemaining(observation("active", activeUsed, activeUsed), now)!;
+      const target = effectiveRemaining(observation(decision.targetId, decision.targetId === "left" ? leftUsed : rightUsed, decision.targetId === "left" ? leftUsed : rightUsed), now)!;
+      expect(source.percent).toBeLessThan(25);
+      expect(target.percent).toBeGreaterThan(25);
+      const eligible = ["left", "right"].filter((id) => {
+        const used = id === "left" ? leftUsed : rightUsed;
+        return 100 - used > 25;
+      }).sort((a, b) => {
+        const usedA = a === "left" ? leftUsed : rightUsed;
+        const usedB = b === "left" ? leftUsed : rightUsed;
+        return usedA - usedB || a.localeCompare(b);
+      });
+      expect(decision.targetId).toBe(eligible[0]);
+    }
+  });
 });

--- a/src/lib/accounts/migration/quotaPolicy.ts
+++ b/src/lib/accounts/migration/quotaPolicy.ts
@@ -17,6 +17,7 @@ export interface QuotaObservation {
   provenance: LimitsProvenance;
   observedAt: number;
   authCheckedAt?: number;
+  envelope?: "headerless" | "jsonrpc-2.0" | null;
 }
 
 export interface EffectiveRemaining {
@@ -25,15 +26,19 @@ export interface EffectiveRemaining {
 }
 
 export function effectiveRemaining(observation: QuotaObservation, now = Date.now()): EffectiveRemaining | null {
+  if (!Number.isFinite(now) || !Number.isFinite(observation.observedAt) ||
+    (observation.authCheckedAt !== undefined && !Number.isFinite(observation.authCheckedAt))) return null;
   const age = now - observation.observedAt;
   const authAge = now - (observation.authCheckedAt ?? observation.observedAt);
   if (!observation.authenticated || observation.provenance.source !== "live" || age < 0 || authAge < 0 || age > AUTO_BALANCE_FRESH_MS || authAge > AUTO_BALANCE_FRESH_MS || !observation.limits) return null;
-  const windows = (["session", "weekly"] as const)
+  const reportedWindows = (["session", "weekly"] as const)
     .map((window) => ({ window, value: observation.limits?.[window] }))
-    .filter((entry): entry is { window: "session" | "weekly"; value: NonNullable<EngineLimits["session"]> } =>
-      entry.value !== null && entry.value !== undefined && Number.isFinite(entry.value.usedPercent));
+    .filter((entry): entry is { window: "session" | "weekly"; value: NonNullable<EngineLimits["session"]> } => entry.value !== null && entry.value !== undefined);
+  if (reportedWindows.some(({ value }) => !Number.isFinite(value.usedPercent) || value.usedPercent < 0 || value.usedPercent > 100 ||
+    (value.resetsAt !== null && (!Number.isSafeInteger(value.resetsAt) || value.resetsAt < 0)))) return null;
+  const windows = reportedWindows;
   if (!windows.length) return null;
-  return windows.map(({ window, value }) => ({ window, percent: Math.max(0, Math.min(100, 100 - value.usedPercent)) }))
+  return windows.map(({ window, value }) => ({ window, percent: 100 - value.usedPercent }))
     .sort((a, b) => a.percent - b.percent || a.window.localeCompare(b.window))[0] ?? null;
 }
 

--- a/src/lib/events.ts
+++ b/src/lib/events.ts
@@ -21,7 +21,9 @@ export type ViewerEventAction =
   | "kill"
   | "gate"
   | "answer"
-  | "flow";
+  | "flow"
+  | "quota"
+  | "account-migration";
 
 export interface ViewerEventFields {
   /** tmux target the action addressed, when known. */
@@ -51,4 +53,56 @@ export function logEvent(action: ViewerEventAction, fields: ViewerEventFields): 
   } catch {
     /* logging is advisory */
   }
+}
+
+function bounded(value: string | null | undefined, max = 128): string | null {
+  if (!value) return null;
+  return value.replace(/[^a-zA-Z0-9:_-]/g, "_").slice(0, max);
+}
+
+/** Account telemetry keeps protocol diagnostics useful without exposing homes or payloads. */
+export function logQuotaEvent(fields: {
+  engine: "claude" | "codex";
+  accountId: string;
+  accountKind: "legacy" | "managed";
+  envelope?: "headerless" | "jsonrpc-2.0" | null;
+  probePhase: "account-rate-limits";
+  provenance: "live" | "transcript" | "cache" | "unavailable";
+  reasonCode: string | null;
+}): void {
+  logEvent("quota", {
+    result: fields.provenance === "live" ? "ok" : "error",
+    meta: {
+      engine: fields.engine,
+      accountId: bounded(fields.accountId) ?? "unknown",
+      accountKind: fields.accountKind,
+      envelope: fields.envelope ?? "unknown",
+      probePhase: fields.probePhase,
+      provenance: fields.provenance,
+      reasonCode: bounded(fields.reasonCode),
+    },
+  });
+}
+
+export function logAccountMigrationEvent(fields: {
+  engine: "claude" | "codex";
+  intentId: string;
+  origin: "manual" | "auto";
+  sourceId: string | null;
+  targetId: string;
+  outcome: "committed" | "complete" | "stopped" | "failed-partial";
+  cooldownUntil: string | null;
+}): void {
+  logEvent("account-migration", {
+    result: fields.outcome === "failed-partial" ? "error" : "ok",
+    meta: {
+      engine: fields.engine,
+      intentId: bounded(fields.intentId) ?? "unknown",
+      origin: fields.origin,
+      sourceId: bounded(fields.sourceId),
+      targetId: bounded(fields.targetId) ?? "unknown",
+      outcome: fields.outcome,
+      cooldown: Boolean(fields.cooldownUntil),
+    },
+  });
 }

--- a/src/lib/limits.test.ts
+++ b/src/lib/limits.test.ts
@@ -24,11 +24,11 @@ test("switching to an account without events never reuses another account's Code
   const legacySession = path.join(process.env.LLV_CODEX_HOME!, "sessions", "2026", "07", "09", "rollout.jsonl");
   fs.mkdirSync(path.dirname(legacySession), { recursive: true });
   fs.writeFileSync(legacySession, JSON.stringify({ timestamp: "2026-07-09T00:00:00.000Z", payload: { rate_limits: { primary: { used_percent: 37 }, plan_type: "pro" } } }) + "\n");
-  expect((await readCodexLimits()).data?.session?.usedPercent).toBe(37);
+  expect((await readCodexLimits({ liveReader: async () => { throw new Error("offline"); } })).data?.session?.usedPercent).toBe(37);
 
   const fresh = createManagedCodexAccount("No events");
   setActiveCodexAccount(fresh.id);
-  expect(await readCodexLimits({ liveReader: async () => { throw new Error("offline"); } })).toEqual({ data: null, reason: "app-server unavailable: offline; no codex session files", source: "unavailable" });
+  expect(await readCodexLimits({ liveReader: async () => { throw new Error("offline"); } })).toEqual({ data: null, reason: "app-server-unavailable", source: "unavailable" });
 });
 
 test("structured app-server windows map directly to the account-panel limits shape", () => {
@@ -52,7 +52,8 @@ test("managed transcript fallback reports per-engine provenance without account 
   const result = await readCodexLimits({ account: fallback, liveReader: async () => { throw new Error("offline access_token=secret"); } });
   expect(result.data?.session?.usedPercent).toBe(22);
   expect(result.source).toBe("transcript");
-  expect(result.reason).toContain("transcript fallback");
+  expect(result.reason).toBe("transcript-fallback");
+  expect(result.reason).not.toContain("secret");
 });
 
 test("readLimits stamps the active account id into the payload and disk cache", async () => {
@@ -65,13 +66,13 @@ test("readLimits stamps the active account id into the payload and disk cache", 
     // though there is no Codex data and nothing is written to the cache.
     const empty = createManagedCodexAccount("Stamp empty");
     setActiveCodexAccount(empty.id);
-    const emptyPayload = await readLimits();
+    const emptyPayload = await readLimits({ codexLiveReader: async () => { throw new Error("offline"); } });
     expect(emptyPayload.codexAccountId).toBe(empty.id);
 
     // The legacy account has a rate-limits event, so its payload is remembered:
     // the disk cache must round-trip the account id inside the payload too.
     setActiveCodexAccount("default");
-    const payload = await readLimits();
+    const payload = await readLimits({ codexLiveReader: async () => { throw new Error("offline"); } });
     expect(payload.codexAccountId).toBe("default");
     const cacheFile = path.join(process.env.LLV_STATE_DIR!, "limits-cache.json");
     const cached = JSON.parse(fs.readFileSync(cacheFile, "utf8")) as { accountId: string; data: { codexAccountId: string } };
@@ -105,7 +106,7 @@ test("readLimits stamps a fresh legacy Codex cache while refreshing Claude", asy
     throw new Error("Claude refresh unavailable");
   }) as unknown as typeof fetch;
   try {
-    const payload = await readLimits();
+    const payload = await readLimits({ codexLiveReader: async () => { throw new Error("offline"); } });
     expect(payload.codexAccountId).toBe(account.id);
     expect(payload.codex?.session?.usedPercent).toBe(37);
     expect(fetchCalled).toBeTrue();
@@ -141,7 +142,7 @@ test("a fresh Claude cache still refreshes missing Codex limits", async () => {
     throw new Error("fresh Claude cache should skip the OAuth request");
   }) as unknown as typeof fetch;
   try {
-    const payload = await readLimits();
+    const payload = await readLimits({ codexLiveReader: async () => { throw new Error("offline"); } });
     expect(payload.claude?.session?.usedPercent).toBe(11);
     expect(payload.codex?.session?.usedPercent).toBe(37);
     expect(payload.codexAccountId).toBe("default");

--- a/src/lib/limits.ts
+++ b/src/lib/limits.ts
@@ -5,6 +5,7 @@ import { accountForSpawn, type CodexAccount } from "@/lib/accounts/codex";
 import { claudeAccountForSpawn } from "@/lib/accounts/claude";
 import { managedCodexRuntime } from "@/lib/accounts/codexRuntime";
 import type { AppServerRateLimits } from "@/lib/accounts/codexAppServer";
+import { redactAppServerDetail } from "@/lib/accounts/codexAppServerProtocol";
 import { statePath } from "@/lib/configDir";
 import type { EngineLimits, LimitsPayload, LimitsProvenance, LimitWindow } from "./types";
 
@@ -124,10 +125,7 @@ function remember(engine: EngineName, accountId: string, resolved: { data: Engin
 }
 
 function safeReason(reason: string): string {
-  return reason
-    .replace(/(bearer\s+)[^\s,;]+/gi, "$1[REDACTED]")
-    .replace(/((?:access|refresh|id)[_-]?token\s*[:=]\s*)[^\s,;}]+/gi, "$1[REDACTED]")
-    .slice(0, 500);
+  return redactAppServerDetail(reason);
 }
 
 function provenance(read: LimitRead, cached: EngineCacheEntry | null, staleSince: string): { data: EngineLimits | null; meta: LimitsProvenance } {
@@ -143,7 +141,7 @@ function logFallbackReasons(claude: LimitsProvenance, codex: LimitsProvenance): 
 }
 
 /** Claude Code + Codex plan limits, cached briefly so UI polling stays cheap. */
-export async function readLimits(): Promise<LimitsPayload> {
+export async function readLimits(options: { codexLiveReader?: CodexLiveLimitsReader } = {}): Promise<LimitsPayload> {
   const claudeAccount = claudeAccountForSpawn();
   const codexAccount = accountForSpawn();
   const cachedClaude = lastCache("claude", claudeAccount.id);
@@ -156,7 +154,7 @@ export async function readLimits(): Promise<LimitsPayload> {
   const staleSince = new Date().toISOString();
   const [claude, codex] = await Promise.all([
     claudeFresh ? Promise.resolve(null) : fetchClaudeLimits(path.join(claudeAccount.home, ".credentials.json")),
-    codexFresh ? Promise.resolve(null) : readCodexLimits({ account: codexAccount }),
+    codexFresh ? Promise.resolve(null) : readCodexLimits({ account: codexAccount, liveReader: options.codexLiveReader }),
   ]);
   const resolvedClaude = claudeFresh
     ? { data: cachedClaude!.data, meta: cachedClaude!.provenance }
@@ -256,7 +254,7 @@ export function mapAppServerRateLimits(rateLimits: AppServerRateLimits, captured
 }
 
 /**
- * Managed homes receive a fresh structured snapshot from the app-server. The
+ * Every Codex home receives a fresh structured snapshot from the app-server. The
  * transcript scanner remains a compatibility fallback when that local host is
  * unavailable; its reason keeps old quota data visibly stale.
  */
@@ -265,18 +263,16 @@ export async function readCodexLimits(options: {
   liveReader?: CodexLiveLimitsReader;
 } = {}): Promise<LimitRead> {
   const account = options.account ?? accountForSpawn();
-  if (account.kind === "managed") {
-    try {
-      const rateLimits = await (options.liveReader ?? ((candidate) => managedCodexRuntime().readRateLimits(candidate as CodexAccount)))(account);
-      return { data: mapAppServerRateLimits(rateLimits), reason: null, source: "live" };
-    } catch (error) {
-      const fallback = readCodexTranscriptLimits(account.sessionsDir);
-      const detail = error instanceof Error ? error.message : String(error);
-      if (fallback.data) return { data: fallback.data, reason: `app-server unavailable; transcript fallback: ${detail}`, source: "transcript" };
-      return { data: null, reason: `app-server unavailable: ${detail}; ${fallback.reason}`, source: "unavailable" };
-    }
+  try {
+    const rateLimits = await (options.liveReader ?? ((candidate) => managedCodexRuntime().readRateLimits(candidate as CodexAccount)))(account);
+    return { data: mapAppServerRateLimits(rateLimits), reason: null, source: "live" };
+  } catch (error) {
+    const detail = redactAppServerDetail(error instanceof Error ? error.message : String(error));
+    console.warn(`[limits] Codex app-server probe for ${account.id} failed: ${detail}`);
+    const fallback = readCodexTranscriptLimits(account.sessionsDir);
+    if (fallback.data) return { data: fallback.data, reason: "transcript-fallback", source: "transcript" };
+    return { data: null, reason: "app-server-unavailable", source: "unavailable" };
   }
-  return readCodexTranscriptLimits(account.sessionsDir);
 }
 
 /** Compatibility reader for legacy homes and unavailable app-server children. */


### PR DESCRIPTION
## What changed

- accepts current headerless Codex app-server envelopes and explicit JSON-RPC 2.0 envelopes through one strict parser
- reads authentication and rate limits live for Main and managed Codex homes
- preserves transcript-derived percentages as display fallback with automation-ineligible provenance
- records bounded diagnostic reason codes and quota telemetry
- proves the full automatic Main-to-managed migration, cooldown, and bounce suppression sequence

## Why

Production displayed roughly 10–12% five-hour capacity on Main while Auto balance stayed in `waiting-fresh`. Codex CLI 0.144.1 omits the `jsonrpc` member on its app-server wire messages, so the client rejected both homes during authentication. Main also used transcript quota provenance, which cannot drive automatic migration.

## User impact

Auto balance can collect fresh quota from every authenticated Codex home and migrate sessions when the active account falls below the configured threshold and another account has capacity. Manual selection, cooldown, hysteresis, and reset-credit safety remain intact.

## Verification

- full suite: 761 passed
- TypeScript and ESLint passed
- production build passed
- diff check passed
- no reset-credit, login, deployment, production, or account mutation call executed

## Integration status

Draft pending the single full-stage review and combined production acceptance.