### PR TITLE
fix(feed): preserve queued human message role

### DIFF
--- a/src/components/feed/fixtures/claude-queued-mid-turn.jsonl
+++ b/src/components/feed/fixtures/claude-queued-mid-turn.jsonl
@@ -1,0 +1,3 @@
+{"type":"assistant","timestamp":"2026-07-10T11:43:20.000Z","message":{"role":"assistant","content":[{"type":"tool_use","id":"toolu_active","name":"Bash","input":{"command":"bun test"}}]}}
+{"type":"user","timestamp":"2026-07-10T11:43:21.443Z","message":{"role":"user","content":"<system-reminder>\nThe user sent a new message while you were working.\n</system-reminder>\n\nKeep this request styled as a user message."},"promptSource":"typed","origin":{"kind":"human"}}
+{"type":"user","timestamp":"2026-07-10T11:43:22.000Z","message":{"role":"user","content":"<task-notification>\n<status>completed</status>\n</task-notification>"},"promptSource":"system","origin":{"kind":"task-notification"}}

--- a/src/components/feed/parse.test.ts
+++ b/src/components/feed/parse.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import path from "node:path";
 
 import type { FileEntry } from "@/lib/types";
 
@@ -89,6 +91,10 @@ const codexAssistantEvent = (timestamp: string, message: string) =>
   JSON.stringify({ type: "event_msg", timestamp, payload: { type: "agent_message", phase: "commentary", message } });
 const codexUserPair = (timestamp: string, text: string) => [codexUserResponse(timestamp, [{ type: "input_text", text }]), codexUserEvent(timestamp, text)];
 const codexReasoning = (timestamp: string) => JSON.stringify({ type: "response_item", timestamp, payload: { type: "reasoning" } });
+
+function fixtureLines(name: string): string[] {
+  return readFileSync(path.join(import.meta.dir, "fixtures", name), "utf8").trim().split("\n");
+}
 
 function itemsOfKind(feed: ReturnType<typeof buildFeed>, kind: Item["kind"]) {
   return feed.items.filter((item) => item.kind === kind);
@@ -643,6 +649,19 @@ describe("Codex functions.exec orchestration", () => {
 });
 
 describe("Claude protocol and repeated prose", () => {
+  test("keeps a queued human message in the user role beside harness records", () => {
+    const lines = fixtureLines("claude-queued-mid-turn.jsonl");
+    const feed = buildFeed(claudeFile, lines, false, "");
+
+    expect(itemsOfKind(feed, "user")).toEqual([
+      expect.objectContaining({ text: expect.stringContaining("Keep this request styled as a user message.") }),
+    ]);
+    expect(itemsOfKind(feed, "sysmsg")).toEqual([
+      expect.objectContaining({ text: expect.stringContaining("<task-notification>") }),
+    ]);
+    assertParity(claudeFile, lines, { chunks: [1] });
+  });
+
   test("classifies structural and complete-wrapper protocol rows as system messages", () => {
     const lines = [
       JSON.stringify({ type: "user", isMeta: true, message: { content: "<local-command-caveat>Caveat: command</local-command-caveat>" } }),

--- a/src/components/feed/parse.ts
+++ b/src/components/feed/parse.ts
@@ -503,6 +503,11 @@ function claudeContentText(content: unknown): string {
 }
 
 function isClaudeProtocolUser(obj: Record<string, unknown>, content: unknown): boolean {
+  const originKind = textPart(rec(obj.origin).kind);
+  /* Claude records queued human input with the same envelope fields that its
+     harness uses. Explicit human provenance and typed prompts keep their
+     transcript role through any wrapper text. */
+  if (originKind === "human" || textPart(obj.promptSource) === "typed") return false;
   if (obj.isMeta === true || "interruptedMessageId" in obj || "promptSource" in obj || "origin" in obj) return true;
   const text = claudeContentText(content).trim();
   return (


### PR DESCRIPTION
Fixes #77.

Claude queued human inputs retain user styling when their transcript record carries `origin.kind: "human"` or `promptSource: "typed"`. Harness task notifications continue through the system-message path.

Verification:
- `bun test`
- `bun run build`