### PR TITLE
feat(feed): add intraline diff highlighting

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -27,8 +27,10 @@
      later in one place. */
   --color-diff-add: #1a7f37;
   --color-diff-add-soft: #e6ffec;
+  --color-diff-add-strong: #b7ebc6;
   --color-diff-del: #cf222e;
   --color-diff-del-soft: #ffebe9;
+  --color-diff-del-strong: #ffd1cf;
   --font-sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Inter, Roboto,
     sans-serif;
   --font-mono: ui-monospace, "JetBrains Mono", Menlo, monospace;

--- a/src/components/feed/cards/DiffCard.tsx
+++ b/src/components/feed/cards/DiffCard.tsx
@@ -41,11 +41,22 @@ function LineRow({ line }: { line: DiffLine }) {
       : line.t === "-"
         ? "bg-diff-del-soft text-diff-del"
         : "text-ink";
+  const intralineTone = line.t === "+" ? "bg-diff-add-strong" : "bg-diff-del-strong";
   return (
     <div className={`whitespace-pre px-2 ${tone}`}>
       {/* The +/- marker is real text content, so screen readers and copy keep it. */}
       {line.t}
-      {line.text || " "}
+      {line.intraline
+        ? line.intraline.map((span, index) =>
+            span.changed ? (
+              <span key={index} className={intralineTone}>
+                {span.text}
+              </span>
+            ) : (
+              span.text
+            ),
+          )
+        : line.text || " "}
     </div>
   );
 }

--- a/src/components/feed/cards/toolCards.render.test.tsx
+++ b/src/components/feed/cards/toolCards.render.test.tsx
@@ -68,6 +68,15 @@ test("diff lines carry structural token colors and real +/- markers", () => {
   expect(html).not.toMatch(/#[0-9a-fA-F]{6}/);
 });
 
+test("similar replacement lines render stronger intraline add/remove emphasis", () => {
+  const patch = ["*** Begin Patch", "*** Update File: src/limit.ts", "@@", "-const limit = 10;", "+const limit = 20;", "*** End Patch"].join("\n");
+  const body = diffFromApplyPatch(patch);
+  const html = renderToStaticMarkup(<DiffCard body={{ type: "diff", files: body.files, filesTruncated: body.filesTruncated }} />);
+
+  expect(html).toContain("bg-diff-add-strong");
+  expect(html).toContain("bg-diff-del-strong");
+});
+
 test("output preview shows content with an accessible copy control", () => {
   const html = renderToStaticMarkup(<OutputPreview output={"line1\nline2"} truncated={false} />);
   expect(html).toContain("line1");

--- a/src/components/feed/diff.test.ts
+++ b/src/components/feed/diff.test.ts
@@ -127,6 +127,70 @@ describe("Codex apply_patch grammar", () => {
   });
 });
 
+describe("intraline replacement highlighting", () => {
+  test("segments a similar removed and added line around their changed characters", () => {
+    const model = diffFromApplyPatch(
+      ["*** Begin Patch", "*** Update File: src/limit.ts", "@@", "-const limit = 10;", "+const limit = 20;", "*** End Patch"].join("\n"),
+    );
+    const lines = only(model.files).hunks[0].lines;
+
+    expect(lines).toEqual([
+      {
+        t: "-",
+        text: "const limit = 10;",
+        intraline: [
+          { text: "const limit = ", changed: false },
+          { text: "1", changed: true },
+          { text: "0;", changed: false },
+        ],
+      },
+      {
+        t: "+",
+        text: "const limit = 20;",
+        intraline: [
+          { text: "const limit = ", changed: false },
+          { text: "2", changed: true },
+          { text: "0;", changed: false },
+        ],
+      },
+    ]);
+  });
+
+  test("pairs replacement runs by line position", () => {
+    const model = diffFromApplyPatch(
+      [
+        "*** Begin Patch",
+        "*** Update File: src/limit.ts",
+        "@@",
+        "-const first = 10;",
+        "-const second = 30;",
+        "+const first = 20;",
+        "+const second = 40;",
+        "*** End Patch",
+      ].join("\n"),
+    );
+    const changes = only(model.files).hunks[0].lines.map((line) =>
+      line.intraline
+        ?.filter((span) => span.changed)
+        .map((span) => span.text)
+        .join(""),
+    );
+
+    expect(changes).toEqual(["1", "3", "2", "4"]);
+  });
+
+  test("keeps unrelated replacement lines at line-level emphasis", () => {
+    const model = diffFromApplyPatch(
+      ["*** Begin Patch", "*** Update File: src/value.ts", "@@", "-aaaaaaaaaaaaaaaa", "+bbbbbbbbbbbbbbbb", "*** End Patch"].join("\n"),
+    );
+
+    expect(only(model.files).hunks[0].lines).toEqual([
+      { t: "-", text: "aaaaaaaaaaaaaaaa" },
+      { t: "+", text: "bbbbbbbbbbbbbbbb" },
+    ]);
+  });
+});
+
 describe("caps and safety", () => {
   test("more than the file cap flags filesTruncated and drops the rest", () => {
     const parts = ["*** Begin Patch"];

--- a/src/components/feed/diff.ts
+++ b/src/components/feed/diff.ts
@@ -6,7 +6,8 @@ import { redactSecrets } from "@/lib/review";
    unredacted line — the funnel invariant from the issue #9 contract §4/§5. */
 
 export type FileOp = "add" | "update" | "delete" | "move";
-export type DiffLine = { t: "+" | "-" | " "; text: string };
+export type IntralineSpan = { text: string; changed: boolean };
+export type DiffLine = { t: "+" | "-" | " "; text: string; intraline?: IntralineSpan[] };
 export type Hunk = { header?: string; lines: DiffLine[] };
 export interface FileDiff {
   path: string;
@@ -33,6 +34,99 @@ export const DIFF_CAPS = {
 } as const;
 
 const BLOB_MIN = 20_000;
+const INTRALINE_MIN_SIMILARITY = 0.5;
+const INTRALINE_MAX_CELLS = 250_000;
+
+type IntralineEdit = { kind: "same" | "remove" | "add"; text: string };
+
+function addSpan(spans: IntralineSpan[], text: string, changed: boolean): void {
+  if (!text) return;
+  const previous = spans.at(-1);
+  if (previous && previous.changed === changed) {
+    previous.text += text;
+    return;
+  }
+  spans.push({ text, changed });
+}
+
+/**
+ * Build a compact character-level LCS edit sequence for a pair of replacement
+ * lines. A bounded table prevents generated lines from making one tool event
+ * expensive to render.
+ */
+function intralineEdits(removed: string, added: string): IntralineEdit[] | null {
+  const oldChars = Array.from(removed);
+  const newChars = Array.from(added);
+  if (!oldChars.length || !newChars.length || oldChars.length * newChars.length > INTRALINE_MAX_CELLS) return null;
+
+  const columns = newChars.length + 1;
+  const table = new Uint16Array((oldChars.length + 1) * columns);
+  for (let oldIndex = 1; oldIndex <= oldChars.length; oldIndex += 1) {
+    for (let newIndex = 1; newIndex <= newChars.length; newIndex += 1) {
+      const cell = oldIndex * columns + newIndex;
+      table[cell] =
+        oldChars[oldIndex - 1] === newChars[newIndex - 1]
+          ? table[(oldIndex - 1) * columns + newIndex - 1] + 1
+          : Math.max(table[(oldIndex - 1) * columns + newIndex], table[oldIndex * columns + newIndex - 1]);
+    }
+  }
+  const lcsLength = table[oldChars.length * columns + newChars.length];
+  if (lcsLength / Math.max(oldChars.length, newChars.length) < INTRALINE_MIN_SIMILARITY) return null;
+
+  const reverse: IntralineEdit[] = [];
+  let oldIndex = oldChars.length;
+  let newIndex = newChars.length;
+  while (oldIndex || newIndex) {
+    if (oldIndex && newIndex && oldChars[oldIndex - 1] === newChars[newIndex - 1]) {
+      reverse.push({ kind: "same", text: oldChars[oldIndex - 1] });
+      oldIndex -= 1;
+      newIndex -= 1;
+    } else if (oldIndex && (!newIndex || table[(oldIndex - 1) * columns + newIndex] >= table[oldIndex * columns + newIndex - 1])) {
+      reverse.push({ kind: "remove", text: oldChars[oldIndex - 1] });
+      oldIndex -= 1;
+    } else {
+      reverse.push({ kind: "add", text: newChars[newIndex - 1] });
+      newIndex -= 1;
+    }
+  }
+  return reverse.reverse();
+}
+
+function intralineSpans(edits: IntralineEdit[], side: "remove" | "add"): IntralineSpan[] {
+  const spans: IntralineSpan[] = [];
+  for (const edit of edits) {
+    if (edit.kind === "same") addSpan(spans, edit.text, false);
+    else if (edit.kind === side) addSpan(spans, edit.text, true);
+  }
+  return spans;
+}
+
+/** Add spans only to paired runs of removed and added lines in one hunk. */
+function addIntralineHighlights(lines: DiffLine[]): DiffLine[] {
+  const highlighted = lines.map((line) => ({ ...line }));
+  let index = 0;
+  while (index < highlighted.length) {
+    if (highlighted[index].t !== "-") {
+      index += 1;
+      continue;
+    }
+    const removedStart = index;
+    while (index < highlighted.length && highlighted[index].t === "-") index += 1;
+    const addedStart = index;
+    while (index < highlighted.length && highlighted[index].t === "+") index += 1;
+    const pairs = Math.min(addedStart - removedStart, index - addedStart);
+    for (let pair = 0; pair < pairs; pair += 1) {
+      const removed = highlighted[removedStart + pair];
+      const added = highlighted[addedStart + pair];
+      if (removed.text === added.text) continue;
+      const edits = intralineEdits(removed.text, added.text);
+      if (!edits) continue;
+      removed.intraline = intralineSpans(edits, "remove");
+      added.intraline = intralineSpans(edits, "add");
+    }
+  }
+  return highlighted;
+}
 
 /* A near-whitespace-free run this large is base64/binary content. Its renderer
    shows a size chip and hides thousands of unreadable "+" lines. */
@@ -109,7 +203,8 @@ function finalizeFile(raw: RawFile, budget: { remaining: number }): FileDiff {
     /* Flush the lines gathered before the cap tripped, then stop — a `break`
        past this push would silently drop the kept half of the diff. */
     if (lines.length) {
-      hunks.push(rawHunk.header ? { header: rawHunk.header, lines } : { lines });
+      const highlighted = addIntralineHighlights(lines);
+      hunks.push(rawHunk.header ? { header: rawHunk.header, lines: highlighted } : { lines: highlighted });
       hunkCount += 1;
     }
     if (stop) break;


### PR DESCRIPTION
## Summary

- Adds bounded Unicode-aware LCS spans for paired replacement lines.
- Uses a similarity threshold to preserve whole-line emphasis for unrelated replacements.
- Renders changed characters with stronger add/remove theme backgrounds.

## Validation

- bun test: 957 passed
- bun run lint
- bun run build

Closes #78