### PR TITLE
fix(accounts): unblock Codex migration preflight

### DIFF
--- a/src/lib/accounts/migration/coordinator.test.ts
+++ b/src/lib/accounts/migration/coordinator.test.ts
@@ -336,7 +336,12 @@ describe("durable account migration coordinator", () => {
 
     const failed = await advanceConversationMigration(conversation.id, store, provider);
 
-    expect(failed.migration?.phase).toBe("failed-recoverable");
+    expect(failed.migration).toMatchObject({
+      phase: "failed-recoverable",
+      errorCode: "provider-failed",
+      error: "successor provider failed a recoverable preflight",
+    });
+    expect(JSON.stringify(failed.migration)).not.toContain("durability check failed");
     expect(cleaned).toEqual(["failed-successor"]);
   });
 });

--- a/src/lib/accounts/migration/coordinator.ts
+++ b/src/lib/accounts/migration/coordinator.ts
@@ -21,7 +21,7 @@ import {
   type ViewerConversationId,
 } from "./contracts";
 import { RegisteredSuccessorProvider } from "./provider";
-import { sanitizeProviderError } from "./safeHistoryCopy";
+import { safeProviderDiagnostic, sanitizeProviderError } from "./safeHistoryCopy";
 import { turnStateFromRecords } from "./turnState";
 import { AUTO_BALANCE_COOLDOWN_MS } from "./quotaPolicy";
 
@@ -247,6 +247,13 @@ export async function advanceConversationMigration(
       await cleanupDiscardedSuccessor(successorProvider, receipt, latest);
       return latest;
     }
+    console.warn("[account-migration] recoverable successor provider failure", {
+      conversationId: conversation.id,
+      engine: conversation.engine,
+      phase: migration.phase,
+      targetAccountId: migration.targetId,
+      error: safeProviderDiagnostic(error),
+    });
     const safe = sanitizeProviderError(error);
     const failed = registry.transitionConversationMigration(conversation.id, migration.revision, ["requested", "preparing", "successor-starting", "verifying"], {
       phase: "failed-recoverable",

--- a/src/lib/accounts/migration/provider.test.ts
+++ b/src/lib/accounts/migration/provider.test.ts
@@ -118,7 +118,7 @@ test("unknown Claude transcript model omits the successor override", async () =>
   expect(command).not.toContain("--model");
 });
 
-test("Codex successor provider accepts standard 0755 account roots and migrates through app-server ports", async () => {
+test("Codex successor provider accepts authenticated ChatGPT account responses and standard 0755 roots", async () => {
   const base = fs.mkdtempSync(path.join(os.tmpdir(), "llv-provider-codex-"));
   roots.push(base);
   const source = accountRoot("codex", base, "source");
@@ -132,8 +132,9 @@ test("Codex successor provider accepts standard 0755 account roots and migrates 
   const calls: string[] = [];
   let resumeOptions: unknown = null;
   let goalOptions: unknown = null;
+  let appServerAccount: { type: string } | null = { type: "chatgpt" };
   const client = (home: string) => ({
-    async readAccount() { calls.push(`${path.basename(home)}:account`); return { account: { type: "chatgpt" }, requiresOpenaiAuth: false }; },
+    async readAccount() { calls.push(`${path.basename(home)}:account`); return { account: appServerAccount, requiresOpenaiAuth: true }; },
     async forkThread() { calls.push("source:fork"); fs.writeFileSync(forkPath, "{\"type\":\"session_meta\"}\n", { mode: 0o644 }); return { id: forkId, path: forkPath }; },
     async resumeThread(id: string, options: unknown) { calls.push("target:resume"); resumeOptions = options; return { id, path: null }; },
     async readThread(id: string) { calls.push("target:read"); return { id, path: null }; },
@@ -167,4 +168,7 @@ test("Codex successor provider accepts standard 0755 account roots and migrates 
   expect(goalOptions).toEqual({ objective: "Ship", status: "active" });
   await provider.verify(receipt, { engine: "codex", targetAccountId: "target", launchProfile: profile });
   expect(calls.filter((call) => call === "target:read").length).toBeGreaterThanOrEqual(2);
+  appServerAccount = null;
+  await expect(provider.verify(receipt, { engine: "codex", targetAccountId: "target", launchProfile: profile }))
+    .rejects.toThrow("target Codex account is not authenticated");
 });

--- a/src/lib/accounts/migration/provider.ts
+++ b/src/lib/accounts/migration/provider.ts
@@ -143,7 +143,9 @@ export class RegisteredSuccessorProvider implements SuccessorProviderPort {
     const client = await this.dependencies.startCodex(target.home);
     try {
       const account = await client.readAccount();
-      if (!account.account || account.requiresOpenaiAuth) throw new Error("target Codex account is not authenticated");
+      // Authenticated ChatGPT responses carry requiresOpenaiAuth=true because
+      // the field describes the active provider's credential requirement.
+      if (!account.account) throw new Error("target Codex account is not authenticated");
       const thread = await client.readThread(receipt.nativeId);
       if (thread.id !== receipt.nativeId) throw new Error("target Codex thread identity does not match");
     } finally { client.close(); }
@@ -177,7 +179,7 @@ export class RegisteredSuccessorProvider implements SuccessorProviderPort {
     let fork: Awaited<ReturnType<CodexAppServerClient["forkThread"]>>;
     try {
       const account = await sourceClient.readAccount();
-      if (!account.account || account.requiresOpenaiAuth) throw new Error("source Codex account is not authenticated");
+      if (!account.account) throw new Error("source Codex account is not authenticated");
       fork = await sourceClient.forkThread(sourceNativeId);
     } finally { sourceClient.close(); }
     const sourceFork = fork.path ?? findCodexRollout(source.transcriptRoot, fork.id);
@@ -192,7 +194,7 @@ export class RegisteredSuccessorProvider implements SuccessorProviderPort {
     const targetClient = await this.dependencies.startCodex(target.home);
     try {
       const account = await targetClient.readAccount();
-      if (!account.account || account.requiresOpenaiAuth) throw new Error("target Codex account is not authenticated");
+      if (!account.account) throw new Error("target Codex account is not authenticated");
       const approvalPolicy = profile.permissionMode && ["never", "on-request", "untrusted"].includes(profile.permissionMode)
         ? profile.permissionMode
         : null;

--- a/src/lib/accounts/migration/safeHistoryCopy.test.ts
+++ b/src/lib/accounts/migration/safeHistoryCopy.test.ts
@@ -3,7 +3,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
-import { HistorySecurityError, safeCopyHistory } from "./safeHistoryCopy";
+import { HistorySecurityError, safeCopyHistory, safeProviderDiagnostic } from "./safeHistoryCopy";
 
 const roots: string[] = [];
 
@@ -24,6 +24,18 @@ afterEach(() => {
 });
 
 describe("safe history copy", () => {
+  test("provider diagnostics redact credential-shaped details and ignore opaque values", () => {
+    const diagnostic = safeProviderDiagnostic(new Error("access_token=secret-value bearer hidden-value api_key=another-secret"));
+    expect(diagnostic).toEqual({
+      type: "Error",
+      message: "access_token=[REDACTED] bearer [REDACTED] api_key=[REDACTED]",
+    });
+    expect(safeProviderDiagnostic({ refresh_token: "never-serialize-me" })).toEqual({
+      type: "object",
+      message: "provider failed without an Error detail",
+    });
+  });
+
   test("accepts owner-controlled 0755 directory trees and rejects writable peer roots", () => {
     const f = fixture();
     const year = path.join(f.sourceRoot, "2026");

--- a/src/lib/accounts/migration/safeHistoryCopy.ts
+++ b/src/lib/accounts/migration/safeHistoryCopy.ts
@@ -2,6 +2,8 @@ import crypto from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 
+import { redactAppServerDetail } from "../codexAppServerProtocol";
+
 export const DEFAULT_HISTORY_LIMIT = 512 * 1024 * 1024;
 
 export type HistorySecurityCode =
@@ -190,6 +192,19 @@ export interface SafeHistoryCopyInput {
 }
 
 export interface SafeHistoryCopyResult { path: string; hash: string; size: number; reused: boolean }
+
+export interface SafeProviderDiagnostic { type: string; message: string }
+
+/** Preserves actionable server detail while keeping routes and registry state generic. */
+export function safeProviderDiagnostic(error: unknown): SafeProviderDiagnostic {
+  if (error instanceof Error) {
+    return {
+      type: redactAppServerDetail(error.name || "Error"),
+      message: redactAppServerDetail(error.message),
+    };
+  }
+  return { type: typeof error, message: "provider failed without an Error detail" };
+}
 
 /** Streams one transcript into a registered target root with an operation/hash receipt. */
 export function safeCopyHistory(input: SafeHistoryCopyInput): SafeHistoryCopyResult {


### PR DESCRIPTION
## Summary

- accept authenticated ChatGPT `account/read` responses during Codex successor creation and verification;
- emit structured, credential-redacted provider diagnostics in server logs while preserving the generic registry/API failure contract;
- cover the live response shape, unauthenticated account rejection, diagnostic redaction, and durable error sanitization.

## Root cause

Codex app-server v0.144.1 returns an authenticated ChatGPT account object together with `requiresOpenaiAuth: true`. That field describes whether the active provider requires OpenAI credentials. The migration provider treated it as login state at the source fork and target verification fences, so every eligible conversation failed before `thread/fork`. The coordinator then stored the expected generic `provider-failed` message.

Read-only host and container probes returned the same account response, clearing the nsenter shim and credential-store override. The live public-API loop reproduced 46 recoverable failures and two waiting turns for intent `efd36421-6c1f-484f-af28-fc07986bfcd3`.

Refs #40.

## Validation

- `bun test` — 954 tests, 5,619 assertions
- `./node_modules/.bin/tsc --noEmit`
- `bun run lint`
- `bun run build`
- `git diff --check`
- full read-only review pass against `origin/main`

Production was left untouched for the orchestrator deployment flow.
