### PR TITLE
fix(scanner): heal phantom worktree projects

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,20 +16,23 @@ parent repo by trying these recognizers in order:
 The **pure path recognizers** run first — they need nothing on disk, so they
 work identically for live and deleted checkouts:
 
-1. `worktreeFromPath` — Claude worktrees at `<repo>/.claude/worktrees/<name>/…`
-2. `worktreeFromNested` — the `git worktree add worktrees/<name>` (and dotted
+1. `projectInfoFromClaudeTaskCwd` — Claude scratchpad descendants at
+   `<tmp>/claude-<uid>/<encoded-cwd>/<session>/scratchpad/…`; dotted worktree
+   containers survive in the encoded cwd and recover the parent project.
+2. `worktreeFromPath` — Claude worktrees at `<repo>/.claude/worktrees/<name>/…`
+3. `worktreeFromNested` — the `git worktree add worktrees/<name>` (and dotted
    `.worktrees/<name>`) convention: the checkout nests inside the repo, so the
-   repo is the path prefix before the first `worktrees`/`.worktrees` segment (a
-   `worktrees` segment directly under `.claude`/`.codex` is left to #1/#3). The
+   repo is the path prefix before the first `worktrees`/`.worktrees` segment;
+   specialized `.claude`/`.codex` containers are left to #2/#4. The
    first container wins, so a worktree-of-a-worktree groups under the outermost repo.
-3. `worktreeFromCodexPath` — Codex worktrees at `~/.codex/worktrees/<hash>/<Repo>`
+4. `worktreeFromCodexPath` — Codex worktrees at `~/.codex/worktrees/<hash>/<Repo>`
 
 Only then the **disk-dependent** resolvers, as fallbacks:
 
-4. `worktreeFromGitFile` — any linked git worktree, resolved from its `.git`
+5. `worktreeFromGitFile` — any linked git worktree, resolved from its `.git`
    **file** (`gitdir:` pointer) — works **only while the checkout exists on
    disk**. Every live resolution here is written to a persistent map (below).
-5. `worktreeFromMemory` — replays a `worktreeFromGitFile` resolution recorded
+6. `worktreeFromMemory` — replays a `worktreeFromGitFile` resolution recorded
    (to `state/worktree-map.json`) while the checkout was alive. This is the only
    thing that saves an **arbitrary-path** `git worktree add ../sibling` checkout
    (e.g. `~/.agents/tools/live-log-viewer-<branch>`), which has NO recognizable
@@ -38,15 +41,15 @@ Only then the **disk-dependent** resolvers, as fallbacks:
 
 **The invariant that keeps biting:** a worktree's grouping must survive the
 checkout being **deleted**. Any mapping that finds the parent repo only by
-reading on-disk git metadata (#4) silently fails afterward and the session
+reading on-disk git metadata (#5) silently fails afterward and the session
 fragments into a phantom lookalike project (`-codex-worktrees-<hash>-<Repo>`,
 `…-Projects-<Repo>-worktrees-<name>`, `…-<branch>`, …). Recognize each layout by
-**path** (#1–#3) wherever the path reveals the repo; fall back to the persisted
-resolution (#5) only for arbitrary sibling paths that cannot. Live and dead
+**path** (#1–#4) wherever the path reveals the repo; fall back to the persisted
+resolution (#6) only for arbitrary sibling paths that cannot. Live and dead
 checkouts of the same repo must resolve to the **same** project name.
 
 When adding a new agent/worktree layout: prefer a pure path recognizer beside
-#1–#3 and wire it into `projectInfoFromCwd`; only reach for the persisted map
+#1–#4 and wire it into `projectInfoFromCwd`; only reach for the persisted map
 when the path genuinely cannot name the repo. Add a "deleted worktree still
 groups under its parent repo" case to `describe.test.ts`. Don't rely on the
 checkout being present, and don't invent a second naming scheme.

--- a/src/lib/board/store.test.ts
+++ b/src/lib/board/store.test.ts
@@ -3,7 +3,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
-import { boardFor, BoardStoreError, mutateBoard, patchBoard } from "./store";
+import { boardFor, BoardStoreError, migrateBoardProjects, mutateBoard, patchBoard } from "./store";
 import { validateBoardPatchRequest } from "./validation";
 
 function temporaryFile(): string { return path.join(fs.mkdtempSync(path.join(os.tmpdir(), "llv-board-")), "board.json"); }
@@ -55,6 +55,42 @@ describe("board store", () => {
     const replay = mutateBoard("viewer", 0, [{ kind: "remap-paths", pairs: [{ from: "/old", to: "/new" }] }], file);
     expect(first).toMatchObject({ ok: true, board: { revision: 1 } });
     expect(replay).toMatchObject({ ok: true, board: { revision: 1 } });
+  });
+  test("many stale projects merge by original timestamp with newer membership roles winning", () => {
+    const run = (migrations: Map<string, string>) => {
+      const file = temporaryFile();
+      fs.mkdirSync(path.dirname(file), { recursive: true });
+      const state = (
+        updatedAt: string,
+        prefs: Partial<{ manual: string[]; hidden: string[]; expanded: string[]; viewMode: "scheme" | "list" | null; taskPanelOpen: boolean }>,
+        pathAliases: Record<string, string>,
+      ) => ({
+        schemaVersion: 1,
+        revision: 1,
+        updatedAt,
+        pathAliases,
+        prefs: { manual: [], hidden: [], expanded: [], viewMode: null, taskPanelOpen: false, ...prefs },
+      });
+      fs.writeFileSync(file, JSON.stringify({ projects: {
+        canonical: state("2026-07-10T00:01:00.000Z", { expanded: ["/base"], viewMode: "scheme" }, { "/alias": "/base" }),
+        older: state("2026-07-10T00:00:00.000Z", { hidden: ["/a"] }, { "/alias": "/old" }),
+        newest: state("2026-07-10T00:02:00.000Z", { manual: ["/a"], expanded: ["/b"], viewMode: "list", taskPanelOpen: true }, { "/alias": "/new" }),
+      } }), "utf8");
+      expect(migrateBoardProjects(migrations, file)).toBe(true);
+      return JSON.parse(fs.readFileSync(file, "utf8")).projects;
+    };
+
+    const forward = run(new Map([["older", "canonical"], ["newest", "canonical"]]));
+    const reverse = run(new Map([["newest", "canonical"], ["older", "canonical"]]));
+
+    expect(forward.older).toBeUndefined();
+    expect(forward.newest).toBeUndefined();
+    expect(forward.canonical.prefs).toEqual({
+      manual: ["/a"], hidden: [], expanded: ["/base", "/b"], viewMode: "list", taskPanelOpen: true,
+    });
+    expect(forward.canonical.pathAliases).toEqual({ "/alias": "/new" });
+    expect(reverse.canonical.prefs).toEqual(forward.canonical.prefs);
+    expect(reverse.canonical.pathAliases).toEqual(forward.canonical.pathAliases);
   });
   test("strict bounded PATCH validation rejects unknown and empty changes", async () => {
     const request = (body: unknown) => new Request("http://127.0.0.1:8898/api/board", { method: "PATCH", headers: { "content-type": "application/json" }, body: JSON.stringify(body) });

--- a/src/lib/board/store.ts
+++ b/src/lib/board/store.ts
@@ -85,3 +85,89 @@ export function patchBoard(project: string, baseRevision: number, patch: BoardPa
 export function mutateBoard(project: string, baseRevision: number, mutations: readonly BoardMutationV1[], filePath = boardFileForTests ?? BOARD_FILE): BoardWriteResult {
   return writeReduced(project, baseRevision, (current) => applyBoardMutations(current, mutations), filePath);
 }
+
+function mergedBoards(states: readonly BoardProjectStateV1[]): BoardProjectStateV1 {
+  const ordered = states
+    .map((state, index) => ({ state, index, timestamp: Date.parse(state.updatedAt) }))
+    .sort((left, right) => {
+      const leftTime = Number.isFinite(left.timestamp) ? left.timestamp : 0;
+      const rightTime = Number.isFinite(right.timestamp) ? right.timestamp : 0;
+      return leftTime - rightTime || left.index - right.index;
+    })
+    .map(({ state }) => state);
+  const aliases = ordered.reduce<Record<string, string>>(
+    (combined, state) => ({ ...combined, ...(state.pathAliases ?? {}) }),
+    {},
+  );
+  const roles = new Map<string, "manual" | "hidden" | "expanded">();
+  let viewMode: BoardProjectStateV1["prefs"]["viewMode"] = null;
+  let taskPanelOpen = false;
+  let normalizedAliases: Record<string, string> = aliases;
+  for (const state of ordered) {
+    const normalized = applyBoardMutations({ ...state, pathAliases: aliases }, []);
+    normalizedAliases = normalized.pathAliases ?? {};
+    for (const role of ["manual", "hidden", "expanded"] as const) {
+      for (const pathname of normalized.prefs[role]) {
+        roles.delete(pathname);
+        roles.set(pathname, role);
+      }
+    }
+    viewMode = normalized.prefs.viewMode;
+    taskPanelOpen = normalized.prefs.taskPanelOpen;
+  }
+  const prefs = {
+    manual: [] as string[],
+    hidden: [] as string[],
+    expanded: [] as string[],
+    viewMode,
+    taskPanelOpen,
+  };
+  for (const [pathname, role] of roles) prefs[role].push(pathname);
+  return { ...ordered.at(-1)!, pathAliases: normalizedAliases, prefs };
+}
+
+/** Move durable board preferences along with catalog project-key repairs.
+    Sources remain intact whenever a merge cannot preserve board invariants. */
+export function migrateBoardProjects(
+  migrations: ReadonlyMap<string, string>,
+  filePath = statePath("board.json"),
+): boolean {
+  if (migrations.size === 0) return true;
+  const value = read(filePath);
+  let changed = false;
+  let complete = true;
+  const sourcesByTarget = new Map<string, string[]>();
+  for (const [sourceProject, targetProject] of migrations) {
+    if (sourceProject === targetProject) continue;
+    sourcesByTarget.set(targetProject, [...(sourcesByTarget.get(targetProject) ?? []), sourceProject]);
+  }
+  for (const [targetProject, sourceProjects] of sourcesByTarget) {
+    const sources = sourceProjects.flatMap((project) => value.projects[project] ? [value.projects[project]!] : []);
+    if (sources.length === 0) continue;
+    const target = value.projects[targetProject];
+    if (!target && sources.length === 1) {
+      value.projects[targetProject] = sources[0]!;
+      for (const sourceProject of sourceProjects) delete value.projects[sourceProject];
+      changed = true;
+      continue;
+    }
+    try {
+      const states = target ? [target, ...sources] : sources;
+      const merged = mergedBoards(states);
+      value.projects[targetProject] = target && sameReduced(target, merged)
+        ? target
+        : {
+            ...merged,
+            revision: Math.max(...states.map((state) => state.revision)) + 1,
+            updatedAt: new Date().toISOString(),
+          };
+      for (const sourceProject of sourceProjects) delete value.projects[sourceProject];
+      changed = true;
+    } catch {
+      complete = false;
+      continue;
+    }
+  }
+  if (changed) write(value, filePath);
+  return complete;
+}

--- a/src/lib/scanner/describe.test.ts
+++ b/src/lib/scanner/describe.test.ts
@@ -48,6 +48,77 @@ test("a deleted codex worktree still groups under its parent repo project", () =
   expect(projectForCwd(dead)).toBe(projectForCwd(liveRepo));
 });
 
+test("a deleted nested checkout inside a Codex worktree groups under the main repo", () => {
+  const dead = path.join(
+    os.homedir(),
+    ".codex",
+    "worktrees",
+    "deleted-catalog-fixture",
+    "CelestiaCompose",
+    "worktrees",
+    "deleted-child",
+  );
+  expect(fs.existsSync(dead)).toBe(false);
+  expect(projectForCwd(dead)).toBe("CelestiaCompose");
+});
+
+test("a deleted worktree scratchpad cwd groups under the encoded parent repo", () => {
+  const repo = path.join(os.homedir(), ".agents", "tools", "live-log-viewer-next");
+  const worktree = path.join(repo, ".worktrees", "runtime-host-spike");
+  const slug = worktree.replace(/[^a-zA-Z0-9]/g, "-");
+  const dead = path.join(os.tmpdir(), `claude-${process.getuid?.() ?? 1000}`, slug, "deleted-session", "scratchpad", "probes");
+  expect(fs.existsSync(dead)).toBe(false);
+  expect(projectForCwd(dead)).toBe(projectForCwd(repo));
+});
+
+test("a main-checkout scratchpad cwd groups under its encoded project", () => {
+  const repo = path.join(os.homedir(), ".agents", "tools", "live-log-viewer-next");
+  const slug = repo.replace(/[^a-zA-Z0-9]/g, "-");
+  const dead = path.join(os.tmpdir(), `claude-${process.getuid?.() ?? 1000}`, slug, "deleted-session", "scratchpad", "probes");
+  expect(fs.existsSync(dead)).toBe(false);
+  expect(projectForCwd(dead)).toBe(projectForCwd(repo));
+});
+
+test("the outer nested worktree wins over a later specialized container", () => {
+  const repo = path.join(SANDBOX, "outer-repo");
+  const dead = path.join(repo, "worktrees", "outer", ".codex", "worktrees", "inner-hash", "InnerRepo");
+  expect(fs.existsSync(dead)).toBe(false);
+  expect(projectForCwd(dead)).toBe(projectForCwd(repo));
+});
+
+test("a scratchpad encoded from nested worktrees keeps the outer project", () => {
+  const repo = path.join(os.homedir(), ".agents", "tools", "live-log-viewer-next");
+  const nested = path.join(repo, ".worktrees", "outer", ".claude", "worktrees", "inner");
+  const slug = nested.replace(/[^a-zA-Z0-9]/g, "-");
+  const dead = path.join(os.tmpdir(), `claude-${process.getuid?.() ?? 1000}`, slug, "deleted-session", "scratchpad");
+  expect(fs.existsSync(dead)).toBe(false);
+  expect(projectForCwd(dead)).toBe(projectForCwd(repo));
+  const root = path.join(SANDBOX, "nested-scratchpad-transcripts");
+  const transcript = path.join(root, "nested-scratchpad", "session.jsonl");
+  fs.mkdirSync(path.dirname(transcript), { recursive: true });
+  fs.writeFileSync(transcript, JSON.stringify({ type: "user", cwd: dead, message: { content: "Nested scratchpad" } }) + "\n");
+  expect(describe("claude-projects", root, transcript, fs.statSync(transcript))).toMatchObject({
+    project: projectForCwd(repo),
+    worktree: "outer",
+  });
+});
+
+test("a scratchpad encoded from a deleted Codex worktree keeps the repo project", () => {
+  const codexWorktree = path.join(
+    os.homedir(),
+    ".codex",
+    "worktrees",
+    "2d25",
+    "CelestiaCompose",
+    "worktrees",
+    "inner",
+  );
+  const slug = codexWorktree.replace(/[^a-zA-Z0-9]/g, "-");
+  const dead = path.join(os.tmpdir(), `claude-${process.getuid?.() ?? 1000}`, slug, "deleted-session", "scratchpad");
+  expect(fs.existsSync(dead)).toBe(false);
+  expect(projectForCwd(dead)).toBe("CelestiaCompose");
+});
+
 test("a deleted nested worktree (repo/worktrees/<name>) still groups under its parent repo", () => {
   /* `git worktree add worktrees/foo` and the dotted `.worktrees/foo` nest the
      checkout inside the repo, so the repo is the path prefix — recognizable by

--- a/src/lib/scanner/describe.ts
+++ b/src/lib/scanner/describe.ts
@@ -77,15 +77,15 @@ function worktreeFromPath(cwd: string): { repo: string; worktree: string } | nul
     dotted `.worktrees/<name>`) puts checkouts under a container dir INSIDE the
     repo, so the parent repo is literally the path prefix before that container.
     Recognizing them by path means a deleted nested worktree still names its
-    repo — no on-disk `.git` needed. `.claude/worktrees` (#1) and
-    `.codex/worktrees` (#3) have dedicated recognizers, so a `worktrees` segment
+    repo — no on-disk `.git` needed. `.claude/worktrees` and
+    `.codex/worktrees` have dedicated recognizers, so a `worktrees` segment
     sitting directly under `.claude`/`.codex` is left to them. The FIRST
     container wins, so a worktree-of-a-worktree groups under the outermost repo. */
 function worktreeFromNested(cwd: string): { repo: string; worktree: string } | null {
   const parts = cwd.split(path.sep);
   for (let i = 1; i < parts.length - 1; i++) {
     if (parts[i] !== "worktrees" && parts[i] !== ".worktrees") continue;
-    if (parts[i - 1] === ".claude" || parts[i - 1] === ".codex") continue;
+    if (parts[i - 1] === ".claude" || parts[i - 1] === ".codex") return null;
     const worktree = parts[i + 1];
     if (!worktree) return null;
     return { repo: parts.slice(0, i).join(path.sep) || path.sep, worktree };
@@ -322,6 +322,8 @@ function persistedProjects(): {
     means a codex session, a claude session, and any worktree of the same repo
     all land in the SAME sidebar group instead of lookalike neighbors. */
 function projectInfoFromCwd(cwd: string): { project: string; worktree?: string } | null {
+  const scratchpad = projectInfoFromClaudeTaskCwd(cwd);
+  if (scratchpad) return scratchpad;
   let worktree =
     worktreeFromPath(cwd) ??
     worktreeFromNested(cwd) ??
@@ -348,16 +350,59 @@ export function projectForCwd(cwd: string): string | null {
 }
 
 function worktreeFromSlug(slug: string): { project: string; worktree: string } | null {
-  const marker = "--claude-worktrees-";
-  const index = slug.indexOf(marker);
-  if (index < 0) return null;
-  const worktree = slug.slice(index + marker.length);
+  const codexMarker = "--codex-worktrees-";
+  const markers = ["--claude-worktrees-", codexMarker, "--worktrees-"];
+  let marker: string | null = null;
+  let index = Number.POSITIVE_INFINITY;
+  for (const candidate of markers) {
+    const candidateIndex = slug.indexOf(candidate);
+    if (candidateIndex >= 0 && candidateIndex < index) {
+      marker = candidate;
+      index = candidateIndex;
+    }
+  }
+  if (!marker || !Number.isFinite(index)) return null;
+  const suffix = slug.slice(index + marker.length);
+  if (marker === codexMarker) {
+    const hashEnd = suffix.indexOf("-");
+    if (hashEnd <= 0) return null;
+    const worktree = suffix.slice(0, hashEnd);
+    const repoAndNested = suffix.slice(hashEnd + 1);
+    const nestedAt = ["--claude-worktrees-", "--codex-worktrees-", "--worktrees-", "-worktrees-"]
+      .map((candidate) => repoAndNested.indexOf(candidate))
+      .filter((candidateIndex) => candidateIndex >= 0)
+      .sort((left, right) => left - right)[0];
+    const repoName = nestedAt === undefined ? repoAndNested : repoAndNested.slice(0, nestedAt);
+    if (!repoName) return null;
+    const project = projectFromSlug(existingRepoPath(repoName).replace(/[^a-zA-Z0-9]/g, "-"));
+    return project ? { project, worktree } : null;
+  }
+  const nextAt = ["--claude-worktrees-", "--codex-worktrees-", "--worktrees-", "-worktrees-"]
+    .map((candidate) => suffix.indexOf(candidate))
+    .filter((candidateIndex) => candidateIndex >= 0)
+    .sort((left, right) => left - right)[0];
+  const worktree = nextAt === undefined ? suffix : suffix.slice(0, nextAt);
   if (!worktree) return null;
   const repoSlug = slug.slice(0, index);
-  const project = repoSlug.split("--").at(-1)?.split("-").filter(Boolean).at(-1);
+  const project = projectFromSlug(repoSlug);
   if (!project) return null;
-  const dashedProject = repoSlug.slice(repoSlug.lastIndexOf("-" + project) + 1) || project;
-  return { project: dashedProject, worktree };
+  return { project, worktree };
+}
+
+/** Claude places nested scratchpad agents under
+    `<tmp>/claude-<uid>/<encoded-cwd>/<session>/scratchpad/...`. The encoded
+    cwd retains dotted worktree containers as `--worktrees-`, which is enough
+    to recover the parent project after the checkout and scratchpad disappear. */
+function projectInfoFromClaudeTaskCwd(cwd: string): { project: string; worktree?: string } | null {
+  const parts = cwd.split(path.sep);
+  const container = parts.findIndex((part) => /^claude-\d+$/.test(part));
+  const slug = container >= 0 ? parts[container + 1] : undefined;
+  const session = container >= 0 ? parts[container + 2] : undefined;
+  if (!slug || !session || parts[container + 3] !== "scratchpad") return null;
+  const worktree = worktreeFromSlug(slug);
+  if (worktree) return worktree;
+  const project = projectFromSlug(slug);
+  return project ? { project } : null;
 }
 
 function cwdFromLines(lines: string[]): string | null {

--- a/src/lib/scanner/discover.test.ts
+++ b/src/lib/scanner/discover.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, mkdir, rm, utimes, writeFile } from "node:fs/promises";
+import { mkdtemp, mkdir, readFile, rm, stat, utimes, writeFile } from "node:fs/promises";
 import { existsSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -7,6 +7,8 @@ import { expect, test } from "bun:test";
 
 import type { RootKey } from "../types";
 import { discoverFiles, discoverFilesWithProjectCatalog } from "./discover";
+import { projectForCwd } from "./describe";
+import { projectResolutionStateKey } from "./projectState";
 import { FILE_CAP } from "./roots";
 
 async function writeFixture(pathname: string, content: string, mtimeSeconds: number): Promise<void> {
@@ -28,6 +30,31 @@ test("pure project-catalog discovery leaves the state directory unchanged", asyn
     await Promise.all(Object.values(roots).map((root) => mkdir(root, { recursive: true })));
     await discoverFilesWithProjectCatalog(roots, undefined, { persist: false });
     expect(existsSync(path.join(process.env.LLV_STATE_DIR, "project-catalog.json"))).toBe(false);
+  } finally {
+    if (previousStateDir === undefined) delete process.env.LLV_STATE_DIR;
+    else process.env.LLV_STATE_DIR = previousStateDir;
+    await rm(base, { recursive: true, force: true });
+  }
+});
+
+test("project catalog omits task-only residue from a clean state", async () => {
+  const base = await mkdtemp(path.join(os.tmpdir(), "llv-discover-task-residue-"));
+  const previousStateDir = process.env.LLV_STATE_DIR;
+  process.env.LLV_STATE_DIR = path.join(base, "state");
+  try {
+    const roots: Record<RootKey, string> = {
+      "codex-sessions": path.join(base, "codex-sessions"),
+      "claude-projects": path.join(base, "claude-projects"),
+      "claude-tasks": path.join(base, "claude-tasks"),
+    };
+    await Promise.all(Object.values(roots).map((root) => mkdir(root, { recursive: true })));
+    const taskPath = path.join(roots["claude-tasks"], "orphan-project", "missing-session", "tasks", "task.output");
+    await writeFixture(taskPath, "finished\n", 1_700_000_000);
+
+    const scan = await discoverFilesWithProjectCatalog(roots);
+
+    expect(scan.files.some((entry) => entry.path === taskPath)).toBe(true);
+    expect(scan.projectCatalog).toEqual([]);
   } finally {
     if (previousStateDir === undefined) delete process.env.LLV_STATE_DIR;
     else process.env.LLV_STATE_DIR = previousStateDir;
@@ -301,6 +328,196 @@ test("discoverFilesWithProjectCatalog refreshes cached projects when flow state 
       conversations: 1,
       smt: startedAt - 10,
     });
+  } finally {
+    if (previousStateDir === undefined) delete process.env.LLV_STATE_DIR;
+    else process.env.LLV_STATE_DIR = previousStateDir;
+    await rm(base, { recursive: true, force: true });
+  }
+});
+
+test("discoverFilesWithProjectCatalog heals pre-resolver catalog and board project keys", async () => {
+  const base = await mkdtemp(path.join(os.tmpdir(), "llv-discover-catalog-heal-"));
+  const previousStateDir = process.env.LLV_STATE_DIR;
+  try {
+    const stateDir = path.join(base, "state");
+    process.env.LLV_STATE_DIR = stateDir;
+    const roots: Record<RootKey, string> = {
+      "codex-sessions": path.join(base, "codex-sessions"),
+      "claude-projects": path.join(base, "claude-projects"),
+      "claude-tasks": path.join(base, "claude-tasks"),
+    };
+    await Promise.all([...Object.values(roots), stateDir].map((root) => mkdir(root, { recursive: true })));
+
+    const repo = path.join(os.homedir(), ".agents", "tools", "catalog-heal-repo");
+    const deletedWorktree = path.join(repo, ".worktrees", "deleted-branch");
+    const slug = deletedWorktree.replace(/[^a-zA-Z0-9]/g, "-");
+    const sessionPath = path.join(roots["claude-projects"], slug, "session-id.jsonl");
+    const taskPath = path.join(roots["claude-tasks"], slug, "session-id", "tasks", "task.output");
+    const codexPath = path.join(roots["codex-sessions"], "codex.jsonl");
+    const deletedCodexCwd = path.join(
+      os.homedir(),
+      ".codex",
+      "worktrees",
+      "deleted-catalog-fixture",
+      "CelestiaCompose",
+      "worktrees",
+      "deleted-child",
+    );
+    await writeFixture(
+      sessionPath,
+      JSON.stringify({ type: "user", cwd: deletedWorktree, message: { content: "Heal catalog" } }) + "\n",
+      1_700_040_000,
+    );
+    await writeFixture(taskPath, "finished\n", 1_700_040_001);
+    await writeFixture(
+      codexPath,
+      JSON.stringify({ type: "session_meta", payload: { cwd: deletedCodexCwd } }) + "\n",
+      1_700_040_002,
+    );
+
+    const canonicalProject = projectForCwd(repo)!;
+    const staleProject = projectForCwd(deletedWorktree.replace(".worktrees", "old-worktrees"))!;
+    const staleCodexProject = "-codex-worktrees-deleted-catalog-fixture-CelestiaCompose";
+    const stateKey = projectResolutionStateKey();
+    const cached = async (rootName: RootKey, pathname: string, project: string, kind: string, session: boolean) => {
+      const fileStat = await stat(pathname);
+      return { rootName, size: fileStat.size, mtimeMs: fileStat.mtimeMs, stateKey, project, kind, session };
+    };
+    await writeFile(
+      path.join(stateDir, "project-catalog.json"),
+      JSON.stringify({
+        version: 1,
+        resolutionVersion: 0,
+        files: {
+          [sessionPath]: await cached("claude-projects", sessionPath, staleProject, "session", true),
+          [taskPath]: await cached("claude-tasks", taskPath, staleProject, "background", false),
+          [codexPath]: await cached("codex-sessions", codexPath, staleCodexProject, "session", true),
+        },
+      }),
+    );
+    const boardState = (manual: string[]) => ({
+      schemaVersion: 1,
+      revision: 1,
+      updatedAt: "2026-07-10T00:00:00.000Z",
+      pathAliases: {},
+      prefs: { manual, hidden: [], expanded: [], viewMode: null, taskPanelOpen: false },
+    });
+    const boardFile = path.join(stateDir, "board.json");
+    const boardValue = { projects: {
+        [canonicalProject]: boardState(["/canonical"]),
+        [staleProject]: boardState(["/stale"]),
+        [staleCodexProject]: boardState([]),
+    } };
+    await writeFile(boardFile, "{ corrupt");
+
+    const preview = await discoverFilesWithProjectCatalog(roots);
+
+    expect(preview.projectCatalog.some((entry) => entry.project === staleProject || entry.project === staleCodexProject)).toBe(false);
+    const deferredCatalog = JSON.parse(await readFile(path.join(stateDir, "project-catalog.json"), "utf8"));
+    expect(deferredCatalog.resolutionVersion).toBe(0);
+    expect(deferredCatalog.files[sessionPath].project).toBe(staleProject);
+
+    await writeFile(boardFile, JSON.stringify(boardValue));
+
+    const scan = await discoverFilesWithProjectCatalog(roots);
+
+    expect(scan.projectCatalog.some((entry) => entry.project === staleProject || entry.project === staleCodexProject)).toBe(false);
+    expect(scan.projectCatalog.find((entry) => entry.project === canonicalProject)).toMatchObject({ conversations: 1 });
+    expect(scan.projectCatalog.find((entry) => entry.project === "CelestiaCompose")).toMatchObject({ conversations: 1 });
+    expect(scan.files.find((entry) => entry.path === taskPath)?.project).toBe(canonicalProject);
+
+    const persistedCatalog = JSON.parse(await readFile(path.join(stateDir, "project-catalog.json"), "utf8"));
+    expect(persistedCatalog.files[sessionPath].project).toBe(canonicalProject);
+    expect(persistedCatalog.files[taskPath].project).toBe(canonicalProject);
+    expect(persistedCatalog.files[codexPath].project).toBe("CelestiaCompose");
+    const persistedBoard = JSON.parse(await readFile(path.join(stateDir, "board.json"), "utf8"));
+    expect(persistedBoard.projects[staleProject]).toBeUndefined();
+    expect(persistedBoard.projects[staleCodexProject]).toBeUndefined();
+    expect(persistedBoard.projects[canonicalProject].prefs.manual).toEqual(["/canonical", "/stale"]);
+  } finally {
+    if (previousStateDir === undefined) delete process.env.LLV_STATE_DIR;
+    else process.env.LLV_STATE_DIR = previousStateDir;
+    await rm(base, { recursive: true, force: true });
+  }
+});
+
+test("catalog healing preserves board state for a source project with surviving conversations", async () => {
+  const base = await mkdtemp(path.join(os.tmpdir(), "llv-discover-catalog-split-"));
+  const previousStateDir = process.env.LLV_STATE_DIR;
+  try {
+    const stateDir = path.join(base, "state");
+    process.env.LLV_STATE_DIR = stateDir;
+    const roots: Record<RootKey, string> = {
+      "codex-sessions": path.join(base, "codex-sessions"),
+      "claude-projects": path.join(base, "claude-projects"),
+      "claude-tasks": path.join(base, "claude-tasks"),
+    };
+    await Promise.all([...Object.values(roots), stateDir].map((root) => mkdir(root, { recursive: true })));
+
+    const sourceProject = "legacy-shared";
+    const retiredProject = "retired-legacy-project";
+    const retainedPath = path.join(roots["codex-sessions"], "retained.jsonl");
+    const movedPath = path.join(roots["codex-sessions"], "moved.jsonl");
+    const retiredPath = path.join(roots["codex-sessions"], "retired.jsonl");
+    const canonicalRepo = path.join(os.homedir(), ".agents", "tools", "catalog-split-repo");
+    const canonicalProject = projectForCwd(canonicalRepo)!;
+    await writeFixture(
+      retainedPath,
+      JSON.stringify({ type: "session_meta", payload: { cwd: path.join(os.homedir(), "Projects", sourceProject) } }) + "\n",
+      1_700_050_000,
+    );
+    await writeFixture(
+      movedPath,
+      JSON.stringify({ type: "session_meta", payload: { cwd: path.join(canonicalRepo, ".worktrees", "deleted") } }) + "\n",
+      1_700_050_001,
+    );
+    await writeFixture(
+      retiredPath,
+      JSON.stringify({ type: "session_meta", payload: { cwd: path.join(os.homedir(), "Projects", sourceProject) } }) + "\n",
+      1_700_050_002,
+    );
+    const stateKey = projectResolutionStateKey();
+    const cached = async (pathname: string, project = sourceProject) => {
+      const fileStat = await stat(pathname);
+      return {
+        rootName: "codex-sessions",
+        size: fileStat.size,
+        mtimeMs: fileStat.mtimeMs,
+        stateKey,
+        project,
+        kind: "session",
+        session: true,
+      };
+    };
+    await writeFile(path.join(stateDir, "project-catalog.json"), JSON.stringify({
+      version: 1,
+      resolutionVersion: 0,
+      files: {
+        [retainedPath]: await cached(retainedPath),
+        [movedPath]: await cached(movedPath),
+        [retiredPath]: await cached(retiredPath, retiredProject),
+      },
+    }));
+    const sourceBoard = {
+      schemaVersion: 1,
+      revision: 1,
+      updatedAt: "2026-07-10T00:00:00.000Z",
+      pathAliases: {},
+      prefs: { manual: ["/source"], hidden: [], expanded: [], viewMode: null, taskPanelOpen: false },
+    };
+    await writeFile(path.join(stateDir, "board.json"), JSON.stringify({ projects: {
+      [sourceProject]: sourceBoard,
+      [retiredProject]: { ...sourceBoard, prefs: { ...sourceBoard.prefs, manual: ["/retired"] } },
+    } }));
+
+    const scan = await discoverFilesWithProjectCatalog(roots);
+
+    expect(scan.projectCatalog.find((entry) => entry.project === sourceProject)).toMatchObject({ conversations: 2 });
+    expect(scan.projectCatalog.find((entry) => entry.project === canonicalProject)).toMatchObject({ conversations: 1 });
+    const board = JSON.parse(await readFile(path.join(stateDir, "board.json"), "utf8"));
+    expect(board.projects[sourceProject]?.prefs.manual).toEqual(["/source", "/retired"]);
+    expect(board.projects[retiredProject]).toBeUndefined();
+    expect(board.projects[canonicalProject]).toBeUndefined();
   } finally {
     if (previousStateDir === undefined) delete process.env.LLV_STATE_DIR;
     else process.env.LLV_STATE_DIR = previousStateDir;

--- a/src/lib/scanner/discover.ts
+++ b/src/lib/scanner/discover.ts
@@ -137,7 +137,7 @@ function entriesFromRaw(raw: RawEntry[], selectedProject?: string, projectByPath
       path: entry.path,
       root: entry.rootName,
       name: path.relative(entry.root, entry.path),
-      project: meta.project,
+      project: projectByPath?.get(entry.path) ?? meta.project,
       worktree: meta.worktree,
       title: meta.title,
       engine: meta.engine,

--- a/src/lib/scanner/projectCatalog.ts
+++ b/src/lib/scanner/projectCatalog.ts
@@ -3,11 +3,12 @@ import fs from "node:fs";
 import path from "node:path";
 
 import { statePath } from "@/lib/configDir";
+import { migrateBoardProjects } from "@/lib/board/store";
 
 import type { ProjectCatalogEntry } from "../types";
 import { describe } from "./describe";
 import type { RawEntry } from "./discover";
-import { projectResolutionStateKey } from "./projectState";
+import { PROJECT_RESOLUTION_VERSION, projectResolutionStateKey } from "./projectState";
 
 type CachedProjectFile = {
   rootName: RawEntry["rootName"];
@@ -23,6 +24,7 @@ type ProjectCatalogFile = CachedProjectFile & { path: string };
 
 type ProjectCatalogState = {
   version: 1;
+  resolutionVersion: number;
   files: Record<string, CachedProjectFile>;
 };
 
@@ -36,7 +38,7 @@ function readState(): ProjectCatalogState {
   try {
     const raw = JSON.parse(fs.readFileSync(catalogPath(), "utf8")) as Partial<ProjectCatalogState>;
     if (raw.version !== 1 || !raw.files || typeof raw.files !== "object" || Array.isArray(raw.files)) {
-      return { version: 1, files: {} };
+      return { version: 1, resolutionVersion: PROJECT_RESOLUTION_VERSION, files: {} };
     }
     const files: Record<string, CachedProjectFile> = {};
     for (const [pathname, value] of Object.entries(raw.files)) {
@@ -63,9 +65,9 @@ function readState(): ProjectCatalogState {
         session: file.session,
       };
     }
-    return { version: 1, files };
+    return { version: 1, resolutionVersion: raw.resolutionVersion ?? 0, files };
   } catch {
-    return { version: 1, files: {} };
+    return { version: 1, resolutionVersion: PROJECT_RESOLUTION_VERSION, files: {} };
   }
 }
 
@@ -87,7 +89,13 @@ function isRootSession(rootName: RawEntry["rootName"], kind: string): boolean {
 
 function cachedFile(raw: RawEntry, state: ProjectCatalogState, stateKey: string): ProjectCatalogFile {
   const cached = state.files[raw.path];
-  if (cached && cached.size === raw.st.size && cached.mtimeMs === raw.st.mtimeMs && cached.stateKey === stateKey) {
+  if (
+    state.resolutionVersion === PROJECT_RESOLUTION_VERSION &&
+    cached &&
+    cached.size === raw.st.size &&
+    cached.mtimeMs === raw.st.mtimeMs &&
+    cached.stateKey === stateKey
+  ) {
     return { path: raw.path, ...cached };
   }
   const meta = describe(raw.rootName, raw.root, raw.path, raw.st);
@@ -113,6 +121,36 @@ function cachedFile(raw: RawEntry, state: ProjectCatalogState, stateKey: string)
   return file;
 }
 
+function claudeSlug(raw: RawEntry): string | null {
+  if (raw.rootName !== "claude-projects" && raw.rootName !== "claude-tasks") return null;
+  return path.relative(raw.root, raw.path).split(path.sep)[0] || null;
+}
+
+function unambiguousMigrations(
+  changes: ReadonlyMap<string, ReadonlySet<string>>,
+  groups: ReadonlyMap<string, ProjectCatalogEntry>,
+): Map<string, string> {
+  const migrations = new Map<string, string>();
+  for (const [source, targets] of changes) {
+    if ((groups.get(source)?.conversations ?? 0) > 0) continue;
+    if (targets.size !== 1) continue;
+    let target = targets.values().next().value;
+    const seen = new Set([source]);
+    while (target && (groups.get(target)?.conversations ?? 0) === 0) {
+      if (seen.has(target)) {
+        target = undefined;
+        break;
+      }
+      seen.add(target);
+      const next = changes.get(target);
+      if (next?.size !== 1) break;
+      target = next.values().next().value;
+    }
+    if (target && target !== source && (groups.get(target)?.conversations ?? 0) > 0) migrations.set(source, target);
+  }
+  return migrations;
+}
+
 export function projectCatalogSnapshotFromRaw(raw: RawEntry[], options: { persist?: boolean } = {}): {
   projectCatalog: ProjectCatalogEntry[];
   projectByPath: Map<string, string>;
@@ -122,8 +160,22 @@ export function projectCatalogSnapshotFromRaw(raw: RawEntry[], options: { persis
   const nextFiles: Record<string, CachedProjectFile> = {};
   const groups = new Map<string, ProjectCatalogEntry>();
   const projectByPath = new Map<string, string>();
-  for (const entry of raw) {
-    const file = cachedFile(entry, state, stateKey);
+  const previousProjects = new Map(raw.map((entry) => [entry.path, state.files[entry.path]?.project]));
+  const files = raw.map((entry) => cachedFile(entry, state, stateKey));
+  const claudeSessionProjects = new Map<string, string>();
+  for (let index = 0; index < raw.length; index += 1) {
+    const entry = raw[index]!;
+    const file = files[index]!;
+    const slug = file.rootName === "claude-projects" && file.session ? claudeSlug(entry) : null;
+    if (slug) claudeSessionProjects.set(slug, file.project);
+  }
+  for (let index = 0; index < raw.length; index += 1) {
+    const slug = claudeSlug(raw[index]!);
+    const project = slug ? claudeSessionProjects.get(slug) : undefined;
+    if (project) files[index]!.project = project;
+  }
+  const changes = new Map<string, Set<string>>();
+  for (const file of files) {
     nextFiles[file.path] = {
       rootName: file.rootName,
       size: file.size,
@@ -133,6 +185,12 @@ export function projectCatalogSnapshotFromRaw(raw: RawEntry[], options: { persis
       kind: file.kind,
       session: file.session,
     };
+    const previousProject = previousProjects.get(file.path);
+    if (previousProject && previousProject !== file.project) {
+      const targets = changes.get(previousProject) ?? new Set<string>();
+      targets.add(file.project);
+      changes.set(previousProject, targets);
+    }
     const project = file.project || "other";
     projectByPath.set(file.path, project);
     let group = groups.get(project);
@@ -143,9 +201,23 @@ export function projectCatalogSnapshotFromRaw(raw: RawEntry[], options: { persis
     group.smt = Math.max(group.smt, file.mtimeMs / 1000);
     if (file.session) group.conversations += 1;
   }
-  if (options.persist !== false) writeState({ version: 1, files: nextFiles });
+  if (options.persist !== false) {
+    let boardHealed = true;
+    try {
+      boardHealed = migrateBoardProjects(unambiguousMigrations(changes, groups));
+    } catch {
+      boardHealed = false;
+    }
+    if (boardHealed) {
+      writeState({ version: 1, resolutionVersion: PROJECT_RESOLUTION_VERSION, files: nextFiles });
+    } else {
+      console.error("[project catalog] board project migration deferred; a later scan will retry");
+    }
+  }
   return {
-    projectCatalog: [...groups.values()].sort((a, b) => b.smt - a.smt || a.project.localeCompare(b.project)),
+    projectCatalog: [...groups.values()]
+      .filter((entry) => entry.conversations > 0)
+      .sort((a, b) => b.smt - a.smt || a.project.localeCompare(b.project)),
     projectByPath,
   };
 }

--- a/src/lib/scanner/projectState.ts
+++ b/src/lib/scanner/projectState.ts
@@ -5,11 +5,13 @@ import path from "node:path";
 import { stateDir } from "@/lib/configDir";
 
 const PROJECT_STATE_FILES = ["flows.json", "workflows.json", "worktree-map.json"] as const;
+export const PROJECT_RESOLUTION_VERSION = 2;
 
 export function projectResolutionStateKey(): string {
   const dir = stateDir();
   const hash = crypto.createHash("sha1");
   hash.update(dir);
+  hash.update(`\0resolver-version\0${PROJECT_RESOLUTION_VERSION}`);
   for (const name of PROJECT_STATE_FILES) {
     hash.update("\0");
     hash.update(name);


### PR DESCRIPTION
## Summary

- re-resolve persisted catalog rows when the project resolver version changes
- group deleted nested, Codex, and scratchpad worktree sessions under their parent repository
- suppress zero-conversation catalog rows and migrate stale board buckets with retry-safe, timestamp-aware merges

## Root cause

`project-catalog.json` reused cached project keys after resolver improvements because unchanged transcript metadata bypassed `describe()`. Background-task and scratchpad residue then kept obsolete project keys visible in the rail.

## Verification

- `bun test` — 969 passing
- `bun run lint`
- `bunx tsc --noEmit`
- `bun run build`
- read-only production-state scan returned zero phantom patterns and zero zero-conversation rows; catalog and board hashes stayed unchanged
- fresh-context full-diff review completed with a clean gate

Closes #46