### PR TITLE
Review-loop flows as first-class agent links on the scheme (#16)

### DIFF
--- a/src/components/flows/FlowHub.tsx
+++ b/src/components/flows/FlowHub.tsx
@@ -1,0 +1,167 @@
+"use client";
+
+import { Pause, Play, RefreshCw, Square, X } from "lucide-react";
+import { useState } from "react";
+
+import type { Flow, FlowAction } from "@/lib/flows/types";
+import { useLocale } from "@/lib/i18n";
+
+import { useRuntimeFlow } from "@/hooks/useRuntime";
+import { currentRound, flowLinkPhase, type FlowLinkPhase } from "@/components/scheme/agentLinks";
+
+import { patchFlow, PENDING_ACTIONS, stateLabel } from "./flowModel";
+
+/* Hub tone per link phase: work in accent, waiting-on-you in amber, done in
+   verdict green, idle gray — the palette the strip and verdict chips use. */
+const PHASE_TONE: Record<FlowLinkPhase, string> = {
+  waiting: "#9a9aa4",
+  running: "#5a51e0",
+  awaiting_verdict: "#5a51e0",
+  attention: "#e0ae45",
+  paused: "#e0ae45",
+  done: "#1a8a3e",
+};
+
+/**
+ * The ⟳ hub of a flow link, sitting in the corridor between the implementer
+ * and its reviewer side: current round number and lifecycle tone at a glance,
+ * and a click opens the compact control popover — pause/resume, the one
+ * pending transition, stop-reviewer and close, all via PATCH /api/flows/:id.
+ * The full strip above the pair stays the detailed surface; the hub is the
+ * on-the-link shortcut.
+ */
+export function FlowHub({
+  flow: polledFlow,
+  x,
+  y,
+  interactive,
+  moveTransition,
+}: {
+  flow: Flow;
+  /** World coordinates of the hub center. */
+  x: number;
+  y: number;
+  interactive: boolean;
+  /** Matches the board's layout-glide transition. */
+  moveTransition: string;
+}) {
+  const { t } = useLocale();
+  /* Event-driven progression wins over the poll, same as the strip. */
+  const flow = useRuntimeFlow(polledFlow.id) ?? polledFlow;
+  const [open, setOpen] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const phase = flowLinkPhase(flow.state);
+  const tone = PHASE_TONE[phase];
+  const round = currentRound(flow)?.n ?? 0;
+  const state = stateLabel(t, flow.state);
+  const label = round > 0 ? t("flowHub.aria", { n: round, state }) : t("flowHub.ariaNoRound", { state });
+  const pending = PENDING_ACTIONS[flow.state];
+  const closed = flow.state === "closed" || flow.state === "approved";
+
+  const run = async (action: FlowAction) => {
+    if (busy) return;
+    setBusy(true);
+    setError(null);
+    const fail = await patchFlow(flow.id, { action });
+    if (fail) setError(fail);
+    else if (action === "close") setOpen(false);
+    setBusy(false);
+  };
+
+  return (
+    <div
+      className={`absolute left-0 top-0 ${open ? "z-30" : "z-[5]"} ${interactive ? "" : "pointer-events-none"}`}
+      style={{ transform: `translate(${x}px, ${y}px)`, transition: moveTransition }}
+      onKeyDown={(event) => {
+        if (event.key !== "Escape" || !open) return;
+        event.stopPropagation();
+        setOpen(false);
+      }}
+    >
+      <button
+        data-scheme-ui
+        className="absolute inline-flex h-[34px] -translate-x-1/2 -translate-y-1/2 items-center gap-1 whitespace-nowrap rounded-full border-2 bg-panel px-2.5 shadow-card hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40"
+        style={{ borderColor: tone, color: tone }}
+        title={label}
+        aria-label={label}
+        aria-expanded={open}
+        onClick={() => setOpen((value) => !value)}
+      >
+        <span className="text-[15px] font-bold leading-none" aria-hidden>
+          ⟳
+        </span>
+        {round > 0 ? <span className="text-[11px] font-bold">R{round}</span> : null}
+      </button>
+      {open ? (
+        <div
+          data-scheme-ui
+          aria-label={t("flowHub.controls")}
+          className="absolute bottom-[27px] left-0 z-30 flex w-[230px] -translate-x-1/2 flex-col gap-1.5 rounded-[12px] border border-line bg-panel p-2.5 shadow-[0_10px_36px_rgb(20_20_30/0.18)]"
+        >
+          <span className="flex min-w-0 items-center gap-1.5">
+            <span className="h-2 w-2 shrink-0 rounded-full" style={{ backgroundColor: tone }} aria-hidden />
+            <span className="shrink-0 text-[11.5px] font-bold">{state}</span>
+            {flow.stateDetail ? (
+              <span className="min-w-0 truncate text-[10.5px] font-semibold text-dim" title={flow.stateDetail}>
+                {flow.stateDetail}
+              </span>
+            ) : null}
+            {busy ? <RefreshCw className="ml-auto h-3 w-3 shrink-0 animate-spin text-dim" aria-hidden /> : null}
+          </span>
+          {error ? (
+            <span className="truncate text-[10.5px] font-semibold text-err" title={error}>
+              {error}
+            </span>
+          ) : null}
+          {pending ? (
+            <button
+              className="rounded-full border border-accent bg-accent px-3 py-1 text-[11px] font-bold text-white hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/50 disabled:opacity-40"
+              disabled={busy}
+              onClick={() => void run(pending.action)}
+            >
+              {t(pending.labelKey)}
+            </button>
+          ) : null}
+          {flow.state === "reviewing" ? (
+            <button
+              className="inline-flex items-center justify-center gap-1 rounded-full border border-err/40 bg-[#fbeaea] px-3 py-1 text-[11px] font-bold text-err hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 disabled:opacity-40"
+              disabled={busy}
+              title={t("flowStrip.stopReviewerTitle")}
+              onClick={() => void run("cancel-round")}
+            >
+              <Square className="h-3 w-3" aria-hidden /> {t("flowStrip.stopReviewer")}
+            </button>
+          ) : null}
+          <span className="flex items-center gap-1.5">
+            {closed ? null : flow.state === "paused" ? (
+              <button
+                className="inline-flex flex-1 items-center justify-center gap-1 rounded-full border border-ok/40 bg-[#eef8f0] px-3 py-1 text-[11px] font-bold text-ok hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 disabled:opacity-40"
+                disabled={busy}
+                onClick={() => void run("resume")}
+              >
+                <Play className="h-3 w-3" aria-hidden /> {t("flowStrip.resume")}
+              </button>
+            ) : (
+              <button
+                className="inline-flex flex-1 items-center justify-center gap-1 rounded-full border border-line bg-bg px-3 py-1 text-[11px] font-bold text-dim hover:text-ink focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 disabled:opacity-40"
+                disabled={busy}
+                onClick={() => void run("pause")}
+              >
+                <Pause className="h-3 w-3" aria-hidden /> {t("flowStrip.pause")}
+              </button>
+            )}
+            <button
+              className="inline-flex flex-1 items-center justify-center gap-1 rounded-full border border-line bg-bg px-3 py-1 text-[11px] font-bold text-dim hover:text-err focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 disabled:opacity-40"
+              disabled={busy}
+              onClick={() => void run("close")}
+            >
+              <X className="h-3 w-3" aria-hidden /> {t("flowStrip.close")}
+            </button>
+          </span>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/src/components/flows/FlowStrip.tsx
+++ b/src/components/flows/FlowStrip.tsx
@@ -4,23 +4,14 @@ import { useState } from "react";
 
 import { Infinity as InfinityIcon, Pause, Play, RefreshCw, Square, X } from "lucide-react";
 
-import { type MessageKey, useLocale } from "@/lib/i18n";
+import { useLocale } from "@/lib/i18n";
 import type { Flow, FlowAction } from "@/lib/flows/types";
 
 import { Hint } from "@/components/Hint";
 import { useRuntimeFlow } from "@/hooks/useRuntime";
 
-import { ATTENTION_STATES, patchFlow, stateLabel, verdictTone } from "./flowModel";
+import { ATTENTION_STATES, patchFlow, PENDING_ACTIONS, stateLabel, verdictTone } from "./flowModel";
 import { RoundStateIcon } from "./RoundIcons";
-
-/* The one button the current state is waiting on, rendered prominent. */
-const PENDING_ACTIONS: Partial<Record<Flow["state"], { labelKey: MessageKey; action: FlowAction }>> = {
-  waiting_ready: { labelKey: "flowStrip.startReview", action: "advance" },
-  spawn_pending: { labelKey: "flowStrip.spawnReviewer", action: "advance" },
-  relay_pending: { labelKey: "flowStrip.relayNotes", action: "advance" },
-  needs_decision: { labelKey: "flowStrip.retryRound", action: "retry-round" },
-  done_comment: { labelKey: "flowStrip.anotherRound", action: "another-round" },
-};
 
 const BUSY_STATES: ReadonlySet<Flow["state"]> = new Set(["spawning", "reviewing", "relaying", "fixing"]);
 

--- a/src/components/flows/flowModel.ts
+++ b/src/components/flows/flowModel.ts
@@ -1,6 +1,6 @@
 import { useMemo, useSyncExternalStore } from "react";
 
-import { getLocale, type TFunction, translate } from "@/lib/i18n";
+import { getLocale, type MessageKey, type TFunction, translate } from "@/lib/i18n";
 import type { Flow, FlowAction, FlowRoleKey, FlowState, ReviewVerdict } from "@/lib/flows/types";
 import type { FileEntry } from "@/lib/types";
 
@@ -166,6 +166,16 @@ export const ATTENTION_STATES: ReadonlySet<FlowState> = new Set([
 
 /** Flow states in which one of the loop sides is visibly doing work. */
 export const BUSY_FLOW_STATES: ReadonlySet<FlowState> = new Set(["spawning", "reviewing", "relaying", "fixing"]);
+
+/** The one action the current state is waiting on, rendered prominent on the
+    strip and in the loop hub's controls. */
+export const PENDING_ACTIONS: Partial<Record<FlowState, { labelKey: MessageKey; action: FlowAction }>> = {
+  waiting_ready: { labelKey: "flowStrip.startReview", action: "advance" },
+  spawn_pending: { labelKey: "flowStrip.spawnReviewer", action: "advance" },
+  relay_pending: { labelKey: "flowStrip.relayNotes", action: "advance" },
+  needs_decision: { labelKey: "flowStrip.retryRound", action: "retry-round" },
+  done_comment: { labelKey: "flowStrip.anotherRound", action: "another-round" },
+};
 
 /** The loop side working right now — drives the role tags on the scheme. */
 export function activeLoopRole(flow: Flow): FlowRoleKey | null {

--- a/src/components/scheme/SchemeBoard.tsx
+++ b/src/components/scheme/SchemeBoard.tsx
@@ -24,7 +24,7 @@ import { BulkActionBar } from "./BulkActionBar";
 import { nodesInRect, pruneSelection, selectionBBox } from "./lasso";
 import { buildSchemeLayout } from "./layout";
 import { Minimap } from "./Minimap";
-import { EdgesLayer, LoopsLayer, MOVE_EASE, NodesLayer, type DeckFocus } from "./nodes";
+import { AgentLinksLayer, EdgesLayer, LoopsLayer, MOVE_EASE, NodesLayer, type DeckFocus } from "./nodes";
 import type { TaskCardHandlers } from "./TaskCard";
 import { TaskEdgesLayer } from "./TaskEdgesLayer";
 import { TasksLayer } from "./TasksLayer";
@@ -614,6 +614,7 @@ export function SchemeBoard({
       >
         <EdgesLayer edges={layout.edges} width={layout.width} height={layout.height} />
         <LoopsLayer loops={layout.loops} width={layout.width} height={layout.height} />
+        <AgentLinksLayer links={layout.links} byPath={layout.byPath} interactive={!mapMode && !handLike && !session} />
         <NodesLayer
           layout={layout}
           project={project}

--- a/src/components/scheme/agentLinks.test.ts
+++ b/src/components/scheme/agentLinks.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, test } from "bun:test";
+
+import type { Flow, FlowState, Round } from "@/lib/flows/types";
+
+import { buildAnchorIndex, currentRound, deckKey, deriveFlowLinks, flowLinkKey, flowLinkPhase } from "./agentLinks";
+
+const roleConfig = { engine: "claude" as const, model: null, effort: null };
+
+function round(overrides: Partial<Round> & { n: number }): Round {
+  return {
+    reviewerPath: null,
+    findingsPath: null,
+    triggeredBy: "marker",
+    readyNote: null,
+    verdict: null,
+    findingsCount: null,
+    startedAt: "2026-07-05T00:00:00Z",
+    reviewedAt: null,
+    relayedAt: null,
+    error: null,
+    ...overrides,
+  };
+}
+
+function flow(overrides: Partial<Flow> & { id: string; implementerPath: string }): Flow {
+  return {
+    template: "implement-review-loop",
+    project: "demo",
+    cwd: "/tmp",
+    roles: { implementer: roleConfig, reviewer: roleConfig },
+    baseRef: "abc",
+    baseMode: "head",
+    mode: "auto",
+    reviewerMode: "headless",
+    roundLimit: 5,
+    state: "reviewing",
+    stateDetail: null,
+    rounds: [round({ n: 1, reviewerPath: "/reviewer-1" })],
+    createdAt: "2026-07-05T00:00:00Z",
+    closedAt: null,
+    ...overrides,
+  };
+}
+
+describe("flowLinkPhase", () => {
+  const cases: [FlowState, ReturnType<typeof flowLinkPhase>][] = [
+    ["waiting_ready", "waiting"],
+    ["spawn_pending", "attention"],
+    ["spawning", "running"],
+    ["reviewing", "awaiting_verdict"],
+    ["relay_pending", "attention"],
+    ["relaying", "running"],
+    ["fixing", "running"],
+    ["approved", "done"],
+    ["done_comment", "attention"],
+    ["needs_decision", "attention"],
+    ["paused", "paused"],
+    ["closed", "done"],
+  ];
+  test.each(cases)("%s → %s", (state, phase) => {
+    expect(flowLinkPhase(state)).toBe(phase);
+  });
+});
+
+describe("buildAnchorIndex", () => {
+  test("resolves nodes to themselves, deck-claimed reviewers to their deck, stack items to their stack", () => {
+    const f = flow({ id: "f1", implementerPath: "/impl" });
+    const index = buildAnchorIndex(
+      ["/impl"],
+      [{ key: deckKey("f1"), flow: f }],
+      [{ key: "/impl::stack", paths: ["/quiet-branch"] }],
+    );
+    expect(index.get("/impl")).toBe("/impl");
+    expect(index.get("/reviewer-1")).toBe(deckKey("f1"));
+    expect(index.get("/quiet-branch")).toBe("/impl::stack");
+    expect(index.get("/somewhere-else")).toBeUndefined();
+  });
+
+  test("deck keys self-resolve so a roundless flow can still link to its deck placeholder", () => {
+    const f = flow({ id: "f1", implementerPath: "/impl", rounds: [] });
+    const index = buildAnchorIndex([], [{ key: deckKey("f1"), flow: f }], []);
+    expect(index.get(deckKey("f1"))).toBe(deckKey("f1"));
+  });
+
+  test("a full node wins over a stack or deck claim of the same path", () => {
+    const f = flow({ id: "f1", implementerPath: "/impl" });
+    const index = buildAnchorIndex(
+      ["/reviewer-1"],
+      [{ key: deckKey("f1"), flow: f }],
+      [{ key: "/impl::stack", paths: ["/reviewer-1"] }],
+    );
+    expect(index.get("/reviewer-1")).toBe("/reviewer-1");
+  });
+});
+
+describe("deriveFlowLinks", () => {
+  const anchorsFor = (flows: Flow[], nodePaths: string[] = ["/impl"]) => {
+    const index = buildAnchorIndex(
+      nodePaths,
+      flows.map((f) => ({ key: deckKey(f.id), flow: f })),
+      [],
+    );
+    return (key: string) => index.get(key) ?? null;
+  };
+
+  test("an active flow links its implementer node to the deck claiming the current reviewer", () => {
+    const f = flow({ id: "f1", implementerPath: "/impl" });
+    const links = deriveFlowLinks([f], anchorsFor([f]));
+    expect(links).toHaveLength(1);
+    expect(links[0]).toMatchObject({
+      key: flowLinkKey("f1"),
+      kind: "flow",
+      from: "/impl",
+      to: deckKey("f1"),
+      leg: "forward",
+    });
+    expect(links[0]!.flow).toMatchObject({ round: 1, phase: "awaiting_verdict" });
+  });
+
+  test("a round without a transcript yet falls back to the deck placeholder", () => {
+    const f = flow({ id: "f1", implementerPath: "/impl", state: "spawning", rounds: [round({ n: 2 })] });
+    const links = deriveFlowLinks([f], anchorsFor([f]));
+    expect(links[0]!.to).toBe(deckKey("f1"));
+    expect(links[0]!.flow).toMatchObject({ round: 2, phase: "running" });
+  });
+
+  test("a reviewer visible as its own full node links directly to that node", () => {
+    const f = flow({ id: "f1", implementerPath: "/impl" });
+    const links = deriveFlowLinks([f], anchorsFor([f], ["/impl", "/reviewer-1"]));
+    expect(links[0]!.to).toBe("/reviewer-1");
+  });
+
+  test("relay traffic reports the back leg", () => {
+    const f = flow({ id: "f1", implementerPath: "/impl", state: "fixing" });
+    const links = deriveFlowLinks([f], anchorsFor([f]));
+    expect(links[0]!.leg).toBe("back");
+    expect(links[0]!.flow!.phase).toBe("running");
+  });
+
+  test("a flow with no rounds yet reports round 0 and links to its deck", () => {
+    const f = flow({ id: "f1", implementerPath: "/impl", state: "waiting_ready", rounds: [] });
+    const links = deriveFlowLinks([f], anchorsFor([f]));
+    expect(links[0]!.to).toBe(deckKey("f1"));
+    expect(links[0]!.flow).toMatchObject({ round: 0, phase: "waiting" });
+    expect(links[0]!.leg).toBeNull();
+  });
+
+  test("closed flows emit nothing", () => {
+    const f = flow({ id: "f1", implementerPath: "/impl", state: "closed", closedAt: "2026-07-06T00:00:00Z" });
+    expect(deriveFlowLinks([f], anchorsFor([f]))).toHaveLength(0);
+  });
+
+  test("an implementer off the board emits nothing (conservative endpoints)", () => {
+    const f = flow({ id: "f1", implementerPath: "/impl" });
+    const links = deriveFlowLinks([f], anchorsFor([f], []));
+    expect(links).toHaveLength(0);
+  });
+
+  test("an unresolved reviewer side emits nothing", () => {
+    const f = flow({ id: "f1", implementerPath: "/impl" });
+    /* No deck on the board and the reviewer transcript is unknown. */
+    const index = buildAnchorIndex(["/impl"], [], []);
+    expect(deriveFlowLinks([f], (key) => index.get(key) ?? null)).toHaveLength(0);
+  });
+
+  test("the newest active flow per implementer wins", () => {
+    const older = flow({ id: "f1", implementerPath: "/impl", createdAt: "2026-07-01T00:00:00Z" });
+    const newer = flow({ id: "f2", implementerPath: "/impl", createdAt: "2026-07-05T00:00:00Z" });
+    const links = deriveFlowLinks([older, newer], anchorsFor([older, newer]));
+    expect(links).toHaveLength(1);
+    expect(links[0]!.key).toBe(flowLinkKey("f2"));
+  });
+
+  test("currentRound returns the last round", () => {
+    const f = flow({ id: "f1", implementerPath: "/impl", rounds: [round({ n: 1 }), round({ n: 2 })] });
+    expect(currentRound(f)!.n).toBe(2);
+    expect(currentRound(flow({ id: "f2", implementerPath: "/impl", rounds: [] }))).toBeNull();
+  });
+});

--- a/src/components/scheme/agentLinks.ts
+++ b/src/components/scheme/agentLinks.ts
@@ -1,0 +1,135 @@
+import type { Flow, FlowState, Round } from "@/lib/flows/types";
+
+import { activeLoopLeg, flowByImplementer } from "@/components/flows/flowModel";
+
+/*
+ * The scheme's agent-to-agent link family (issue #16): first-class typed
+ * connections between two board occupants, separate from the structural
+ * parent→child edges and the task edges. Review-loop flows are the first
+ * producer; queue/transcript message links (#12) join later as another
+ * producer of the same AgentLink shape, rendered through the same layer.
+ *
+ * Endpoints are board keys (layout.byPath keys), never raw transcript paths:
+ * a link exists only when both of its conversations resolve to something the
+ * current board actually draws (the approved #16 slice's conservative
+ * endpoint resolution). buildAnchorIndex owns that resolution.
+ */
+
+export type AgentLinkKind = "flow" | "message";
+
+/** Coarse lifecycle of a flow link — drives the hub tone and pulse. */
+export type FlowLinkPhase = "waiting" | "running" | "awaiting_verdict" | "attention" | "paused" | "done";
+
+export interface AgentLink {
+  key: string;
+  kind: AgentLinkKind;
+  /** Board key of the sending/implementing side. */
+  from: string;
+  /** Board key of the receiving/reviewing side. */
+  to: string;
+  /** The leg traffic is on right now: forward = from → to. */
+  leg: "forward" | "back" | null;
+  /** Flow links: the loop this link materializes. */
+  flow?: { flow: Flow; round: number; phase: FlowLinkPhase };
+  /** Message links (#12): one aggregated edge per endpoint pair. */
+  message?: { count: number; lastAt: number };
+}
+
+/** Board key of a flow's reviewer round deck (owned here, used by layout). */
+export function deckKey(flowId: string): string {
+  return "deck::" + flowId;
+}
+
+export function flowLinkKey(flowId: string): string {
+  return "flowlink::" + flowId;
+}
+
+export function flowLinkPhase(state: FlowState): FlowLinkPhase {
+  switch (state) {
+    case "reviewing":
+      return "awaiting_verdict";
+    case "spawning":
+    case "relaying":
+    case "fixing":
+      return "running";
+    case "spawn_pending":
+    case "relay_pending":
+    case "needs_decision":
+    case "done_comment":
+      return "attention";
+    case "paused":
+      return "paused";
+    case "approved":
+    case "closed":
+      return "done";
+    case "waiting_ready":
+      return "waiting";
+  }
+}
+
+/** The round the loop is currently on, if any started. */
+export function currentRound(flow: Flow): Round | null {
+  return flow.rounds.at(-1) ?? null;
+}
+
+export interface AnchorDeck {
+  key: string;
+  flow: Flow;
+}
+
+export interface AnchorStack {
+  key: string;
+  paths: string[];
+}
+
+/**
+ * Conservative transcript-path → board-key resolution: the rect that visually
+ * hosts a conversation on the current board. A full node represents itself; a
+ * reviewer transcript claimed by a round deck resolves to that deck; a quiet
+ * branch resolves to the mini-stack holding it. Later writes win, so a full
+ * node overrides any stack/deck claim of the same path. Deck keys self-resolve
+ * so a link can target the deck placeholder before its reviewer transcript
+ * exists. Anything absent from the map is off the board — no link endpoint.
+ */
+export function buildAnchorIndex(nodePaths: Iterable<string>, decks: AnchorDeck[], stacks: AnchorStack[]): Map<string, string> {
+  const index = new Map<string, string>();
+  for (const stack of stacks) {
+    for (const path of stack.paths) index.set(path, stack.key);
+  }
+  for (const deck of decks) {
+    index.set(deck.key, deck.key);
+    for (const round of deck.flow.rounds) {
+      if (round.reviewerPath) index.set(round.reviewerPath, deck.key);
+    }
+  }
+  for (const path of nodePaths) index.set(path, path);
+  return index;
+}
+
+/**
+ * Flow links: one per active flow, implementer side → current reviewer side.
+ * The reviewer endpoint prefers the current round's transcript anchor (its
+ * deck once the scanner claims it, or a full node if it ever renders as one)
+ * and falls back to the flow's deck placeholder while the round has no
+ * transcript yet. Both endpoints must resolve, and a link never points at
+ * itself — an unresolved or degenerate pair emits nothing.
+ */
+export function deriveFlowLinks(flows: Flow[], anchorOf: (pathOrKey: string) => string | null): AgentLink[] {
+  const links: AgentLink[] = [];
+  for (const flow of flowByImplementer(flows).values()) {
+    const from = anchorOf(flow.implementerPath);
+    if (!from) continue;
+    const round = currentRound(flow);
+    const to = (round?.reviewerPath ? anchorOf(round.reviewerPath) : null) ?? anchorOf(deckKey(flow.id));
+    if (!to || to === from) continue;
+    links.push({
+      key: flowLinkKey(flow.id),
+      kind: "flow",
+      from,
+      to,
+      leg: activeLoopLeg(flow),
+      flow: { flow, round: round?.n ?? 0, phase: flowLinkPhase(flow.state) },
+    });
+  }
+  return links;
+}

--- a/src/components/scheme/layout.test.ts
+++ b/src/components/scheme/layout.test.ts
@@ -5,6 +5,7 @@ import type { FileEntry } from "@/lib/types";
 
 import { type BranchGroup, buildBranchGroups } from "@/components/projectModel";
 
+import { deckKey, flowLinkKey } from "./agentLinks";
 import { buildSchemeLayout } from "./layout";
 
 function entry(overrides: Partial<FileEntry> & { path: string }): FileEntry {
@@ -84,6 +85,41 @@ describe("buildSchemeLayout byPath", () => {
     expect(layout.byPath.get(layout.stacks[0]!.key)).toBe(layout.stacks[0]!);
     expect(layout.decks).toHaveLength(1);
     expect(layout.byPath.get(layout.decks[0]!.key)).toBe(layout.decks[0]!);
+  });
+
+  test("derives a flow link whose endpoints resolve to placed board rects", () => {
+    const root = entry({ path: "/root", activity: "live" });
+    const group: BranchGroup = {
+      key: "/root",
+      columns: [{ file: root, tasks: [] }],
+      returnable: [],
+      finished: [],
+      smt: root.mtime,
+      orphanTask: false,
+    };
+    const layout = buildSchemeLayout([group], [], [root], [flow({ id: "f1", implementerPath: "/root" })], []);
+
+    expect(layout.links).toHaveLength(1);
+    const link = layout.links[0]!;
+    expect(link).toMatchObject({ key: flowLinkKey("f1"), kind: "flow", from: "/root", to: deckKey("f1") });
+    /* Both endpoints must be drawable rects, or the link layer has nothing to anchor to. */
+    expect(layout.byPath.has(link.from)).toBe(true);
+    expect(layout.byPath.has(link.to)).toBe(true);
+    expect(link.flow).toMatchObject({ round: 1, phase: "awaiting_verdict" });
+  });
+
+  test("a flow whose implementer is off the board derives no link", () => {
+    const root = entry({ path: "/root", activity: "live" });
+    const group: BranchGroup = {
+      key: "/root",
+      columns: [{ file: root, tasks: [] }],
+      returnable: [],
+      finished: [],
+      smt: root.mtime,
+      orphanTask: false,
+    };
+    const layout = buildSchemeLayout([group], [], [root], [flow({ id: "f1", implementerPath: "/elsewhere" })], []);
+    expect(layout.links).toHaveLength(0);
   });
 
   test("expanded reviewer children render as connected nodes below the implementer", () => {

--- a/src/components/scheme/layout.ts
+++ b/src/components/scheme/layout.ts
@@ -4,6 +4,8 @@ import type { FileEntry } from "@/lib/types";
 import type { DeckRound } from "@/components/flows/RoundDeck";
 import { draftSrc } from "@/components/DraftAgentPane";
 import { claimedReviewerPaths, flowByImplementer } from "@/components/flows/flowModel";
+
+import { buildAnchorIndex, deckKey, deriveFlowLinks, type AgentLink } from "./agentLinks";
 import { type BranchGroup, descendantsOf, isChildConversation, kidsIndex } from "@/components/projectModel";
 import { engineColor } from "@/components/utils";
 
@@ -114,6 +116,9 @@ export interface SchemeLayout {
   stacks: MiniStack[];
   decks: DeckNode[];
   loops: FlowLoop[];
+  /** Agent-to-agent links between board occupants (flow links today, message
+      links from #12 later), endpoints resolved against byPath keys. */
+  links: AgentLink[];
   drafts: DraftNode[];
   byPath: Map<string, SchemeRect>;
   width: number;
@@ -184,7 +189,7 @@ export function buildSchemeLayout(
       round,
       file: round.reviewerPath ? (byAll.get(round.reviewerPath) ?? null) : null,
     }));
-    const deck: DeckNode = { key: "deck::" + flow.id, flow, rounds, x, y, w: NODE_W, h: deckHeight(flow.rounds.length, baseH) };
+    const deck: DeckNode = { key: deckKey(flow.id), flow, rounds, x, y, w: NODE_W, h: deckHeight(flow.rounds.length, baseH) };
     decks.push(deck);
     return deck;
   };
@@ -359,12 +364,20 @@ export function buildSchemeLayout(
   for (const stack of stacks) bottom = Math.max(bottom, stack.y + stack.h);
   for (const deck of decks) bottom = Math.max(bottom, deck.y + deck.h);
   for (const draft of drafts) bottom = Math.max(bottom, draft.y + draft.h);
+  /* Links resolve against what this pass actually placed, so geometry and
+     link endpoints can never disagree. */
+  const anchors = buildAnchorIndex(
+    nodes.map((node) => node.file.path),
+    decks.map((deck) => ({ key: deck.key, flow: deck.flow })),
+    stacks.map((stack) => ({ key: stack.key, paths: stack.items.map((item) => item.file.path) })),
+  );
   return {
     nodes,
     edges,
     stacks,
     decks,
     loops,
+    links: deriveFlowLinks(flows, (key) => anchors.get(key) ?? null),
     drafts,
     byPath: new Map<string, SchemeRect>([
       ...nodes.map((node) => [node.file.path, node] as const),

--- a/src/components/scheme/nodes.tsx
+++ b/src/components/scheme/nodes.tsx
@@ -14,14 +14,8 @@ import { deriveSessionState, hasBlockingAttention, runtimeActivity } from "@/com
 import { BranchPane, kindLabel } from "@/components/BranchPane";
 import { DraftAgentPane } from "@/components/DraftAgentPane";
 import { FlowDialog } from "@/components/flows/FlowDialog";
-import {
-  activeLoopLeg,
-  activeLoopRole,
-  ATTENTION_STATES,
-  BUSY_FLOW_STATES,
-  canStartFlow,
-  verdictTone,
-} from "@/components/flows/flowModel";
+import { activeLoopLeg, activeLoopRole, canStartFlow, verdictTone } from "@/components/flows/flowModel";
+import { FlowHub } from "@/components/flows/FlowHub";
 import { FlowStrip } from "@/components/flows/FlowStrip";
 import { RoleTag } from "@/components/flows/RoleTag";
 import { RoundDeck } from "@/components/flows/RoundDeck";
@@ -31,6 +25,7 @@ import { isWorkflowDraftId } from "@/components/workflows/workflowModel";
 import { WorkflowDraftPane } from "@/components/workflows/WorkflowDraftPane";
 import { activityDot, cleanTitle, engineBadge, engineEdge, fmtAge } from "@/components/utils";
 
+import type { AgentLink } from "./agentLinks";
 import {
   LOOP_GAP,
   NODE_W,
@@ -41,6 +36,7 @@ import {
   type SchemeEdge,
   type SchemeLayout,
   type SchemeNode,
+  type SchemeRect,
 } from "./layout";
 
 /* Layout reshuffles glide instead of jumping. */
@@ -132,31 +128,20 @@ function loopArrowHead(x: number, y: number, angle: number): string {
   return `M ${bx + half * nx} ${by + half * ny} L ${bx - half * nx} ${by - half * ny} L ${x} ${y} Z`;
 }
 
-/** Hub color of a loop: green while a side works, amber when it waits on the
-    user, verdict green once approved, gray otherwise. */
-function loopTone(flow: FlowLoop["flow"]): string {
-  if (flow.state === "approved") return "#1a8a3e";
-  if (BUSY_FLOW_STATES.has(flow.state)) return "#5a51e0";
-  if (ATTENTION_STATES.has(flow.state)) return "#e0ae45";
-  return "#9a9aa4";
-}
-
 /* The implement↔review pair drawn as an explicit cycle: a forward arc into
-   the reviewer, a return arc back into the implementer, and a ⟳ hub between
-   them. The leg traffic is currently on runs an animated dash in its travel
-   direction; the other leg stays quiet. Geometry transitions mirror
-   EdgesLayer so layout reshuffles glide. */
+   the reviewer and a return arc back into the implementer. The leg traffic is
+   currently on runs an animated dash in its travel direction; the other leg
+   stays quiet. The ⟳ hub between the arcs is the AgentLinksLayer's FlowHub —
+   an interactive control, so it lives outside this aria-hidden SVG. Geometry
+   transitions mirror EdgesLayer so layout reshuffles glide. */
 export const LoopsLayer = memo(function LoopsLayer({ loops, width, height }: { loops: FlowLoop[]; width: number; height: number }) {
   if (!loops.length) return null;
   return (
     <svg width={width} height={height} className="absolute left-0 top-0" aria-hidden>
       {loops.map((loop) => {
         const leg = activeLoopLeg(loop.flow);
-        const tone = loopTone(loop.flow);
         const yTop = loop.y + LOOP_ARC_TOP;
         const yBot = loop.y + LOOP_ARC_BOT;
-        const midX = (loop.x1 + loop.x2) / 2;
-        const midY = (yTop + yBot) / 2;
         const forward = `M ${loop.x1} ${yTop} C ${loop.x1 + LOOP_REACH} ${yTop - LOOP_BULGE}, ${loop.x2 - LOOP_REACH} ${
           yTop - LOOP_BULGE
         }, ${loop.x2 - LOOP_HEAD_INSET} ${yTop}`;
@@ -182,30 +167,46 @@ export const LoopsLayer = memo(function LoopsLayer({ loops, width, height }: { l
             <path d={forwardHead} style={headStyle(forwardHead)} fill={leg === "forward" ? "#5a51e0" : "#c9c9d1"} />
             <path {...arc(back, leg === "back")} />
             <path d={backHead} style={headStyle(backHead)} fill={leg === "back" ? "#5a51e0" : "#c9c9d1"} />
-            <circle
-              cx={midX}
-              cy={midY}
-              r={17}
-              fill="#ffffff"
-              stroke={tone}
-              strokeWidth={2}
-              style={{ cx: `${midX}px`, cy: `${midY}px`, transition: `cx ${MOVE_MS}ms ${MOVE_EASE}, cy ${MOVE_MS}ms ${MOVE_EASE}` } as React.CSSProperties}
-            />
-            <text
-              x={midX}
-              y={midY + 6}
-              textAnchor="middle"
-              fontSize={17}
-              fontWeight={700}
-              fill={tone}
-              style={{ x: `${midX}px`, y: `${midY + 6}px`, transition: `x ${MOVE_MS}ms ${MOVE_EASE}, y ${MOVE_MS}ms ${MOVE_EASE}` } as React.CSSProperties}
-            >
-              ⟳
-            </text>
           </g>
         );
       })}
     </svg>
+  );
+});
+
+/**
+ * The agent-to-agent link layer (issue #16): renders the interactive face of
+ * every AgentLink the layout derived. Flow links materialize as the ⟳ hub in
+ * the corridor between the pair (round number, lifecycle tone, click →
+ * controls); message links (#12) will add their aggregated edges here. Both
+ * endpoints come pre-resolved to board rects, so this layer never repositions
+ * anything — it only decorates geometry the layout already owns.
+ */
+export const AgentLinksLayer = memo(function AgentLinksLayer({
+  links,
+  byPath,
+  interactive,
+}: {
+  links: AgentLink[];
+  byPath: Map<string, SchemeRect>;
+  interactive: boolean;
+}) {
+  if (!links.length) return null;
+  return (
+    <>
+      {links.map((link) => {
+        if (!link.flow) return null;
+        const from = byPath.get(link.from);
+        const to = byPath.get(link.to);
+        if (!from || !to) return null;
+        /* Corridor midpoint of the pair, level with the cycle arcs' center. */
+        const x = (from.x + from.w + to.x) / 2;
+        const y = Math.min(from.y, to.y) + (LOOP_ARC_TOP + LOOP_ARC_BOT) / 2;
+        return (
+          <FlowHub key={link.key} flow={link.flow.flow} x={x} y={y} interactive={interactive} moveTransition={MOVE_TRANSITION} />
+        );
+      })}
+    </>
   );
 });
 

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -536,6 +536,11 @@ export const en = {
   "flowStrip.pause": "Pause",
   "flowStrip.close": "Close flow",
 
+  // flows/FlowHub
+  "flowHub.aria": "Flow controls — round {n}, {state}",
+  "flowHub.ariaNoRound": "Flow controls — {state}",
+  "flowHub.controls": "Flow controls",
+
   // flows/RoundDeck
   "roundDeck.roundAborted": "Round {n} · aborted",
   "roundDeck.roundVerdict": "Round {n} · {verdict}",

--- a/src/lib/i18n/uk.ts
+++ b/src/lib/i18n/uk.ts
@@ -512,6 +512,10 @@ export const uk: Record<keyof typeof en, Message> = {
   "flowStrip.pause": "Пауза",
   "flowStrip.close": "Закрити флоу",
 
+  "flowHub.aria": "Керування флоу — раунд {n}, {state}",
+  "flowHub.ariaNoRound": "Керування флоу — {state}",
+  "flowHub.controls": "Керування флоу",
+
   "roundDeck.roundAborted": "Раунд {n} · перервано",
   "roundDeck.roundVerdict": "Раунд {n} · {verdict}",
   "roundDeck.roundInProgress": "Раунд {n} · триває",


### PR DESCRIPTION
## What

First slice of #16: review-loop flows now render as first-class, interactive **agent links** on the scheme board, and the link family is designed for the agent-to-agent message links to join later.

- **`agentLinks.ts`** — the `AgentLink` type (`kind: "flow" | "message"`), pure derivation and conservative endpoint resolution: a link exists only when both conversations resolve to rects the current board draws (per the approved #16 UX gate). Flow links derive one per active flow, implementer → current reviewer (deck placeholder until the round claims a transcript).
- **Layout integration** — `buildSchemeLayout` derives links against exactly what it placed (`SchemeLayout.links`), so endpoints and geometry can never disagree. The slot system from #60 is untouched — no node moves.
- **`FlowHub`** — the corridor's ⟳ hub between implementer and reviewer deck, previously decorative, is now the link's interactive face: round number + lifecycle tone at a glance (running / awaiting verdict / attention / paused / done), and a click opens a compact popover with the pending transition (**advance / retry round / another round**), **stop reviewer**, **pause/resume**, and **close** — all through `PATCH /api/flows/<id>`. Role tags and the full strip stay as the detailed surface.
- **Shared model** — `PENDING_ACTIONS` moves from `FlowStrip` into `flowModel` so strip and hub share one table; i18n added in en + uk.
- **Tests** — `agentLinks.test.ts` (derivation, phases, anchor resolution) plus `layout.test.ts` cases for resolved and off-board endpoints.

## Verification

- `bun test`: 986 pass, 0 fail (one earlier full-run flake in the accounts registry byte-stability tests reproduced on a clean tree under load and passes in isolation — pre-existing, unrelated).
- `eslint` on all touched files and `tsc --noEmit`: clean.

## Follow-ups

- A flow whose implementer is folded into a quiet mini-stack derives no link (no deck placed, reviewer folded away) — planned answer is a sender-side chip anchored to the stack rect, mirroring the unresolved-peer chip from the frozen #16 UX slice.
- Message links (#12/#25 queue receipts) plug in as a second producer of the same `AgentLink` shape through the same layer; non-adjacent pairs will want `rectAnchor`-style endpoint anchors from `taskGeometry.ts`.

Refs #16.

🤖 Generated with [Claude Code](https://claude.com/claude-code)