### PR TITLE
Edit cards: parse apply_patch into a real diff, expanded by default (both engines)

### DIFF
--- a/src/components/feed/cards/DiffCard.tsx
+++ b/src/components/feed/cards/DiffCard.tsx
@@ -8,8 +8,9 @@ import { tr, type ToolBody } from "../parse";
 import { FileRef } from "./shared";
 import type { DiffLine, FileDiff, Hunk } from "../diff";
 
-/** Level-1 visible-line budget per file; "show all" reveals the capped rest. */
-const PREVIEW_LINES = 10;
+/** Level-1 visible-line budget per file: a compact preview of the first lines
+    shown expanded by default; "show all" reveals the capped rest (issue #90). */
+const PREVIEW_LINES = 8;
 
 const OP_TONE: Record<FileDiff["op"], string> = {
   add: "text-diff-add",

--- a/src/components/feed/cards/OrchestrationCard.tsx
+++ b/src/components/feed/cards/OrchestrationCard.tsx
@@ -33,7 +33,7 @@ export function OrchestrationCard({ orchestration, source }: { orchestration: Or
           ))}
         </div>
       ) : null}
-      {orchestration.source || source ? (
+      {orchestration.source.trim() || source?.trim() ? (
         <details className="overflow-hidden rounded-[10px] border border-line bg-panel-alt">
           <summary className="cursor-pointer list-none px-2.5 py-1 text-[11px] font-semibold text-dim">{tr("tools.source")}</summary>
           <pre className="max-h-[300px] max-w-full overflow-auto whitespace-pre border-t border-line px-3 py-2 font-mono text-[11px]">

--- a/src/components/feed/cards/toolCards.render.test.tsx
+++ b/src/components/feed/cards/toolCards.render.test.tsx
@@ -77,6 +77,37 @@ test("similar replacement lines render stronger intraline add/remove emphasis", 
   expect(html).toContain("bg-diff-del-strong");
 });
 
+test("an edit card opens its diff preview inline with a full-diff toggle", () => {
+  const patch = [
+    "*** Begin Patch",
+    "*** Update File: src/big.ts",
+    "@@",
+    ...Array.from({ length: 20 }, (_, i) => [`-old${i}`, `+new${i}`]).flat(),
+    "*** End Patch",
+  ].join("\n");
+  const model = diffFromApplyPatch(patch);
+  const total = model.files[0].hunks.flatMap((hunk) => hunk.lines).length;
+  const html = renderToStaticMarkup(
+    <ToolCard
+      event={toolEvent({
+        family: "edit",
+        tool: "apply_patch",
+        icon: "edit",
+        summary: "Edit big.ts",
+        open: true,
+        body: { type: "diff", files: model.files, filesTruncated: model.filesTruncated },
+      })}
+    />,
+  );
+  // The diff renders inline (no click needed) with the structural colors.
+  expect(html).toContain("bg-diff-add-soft");
+  expect(html).toContain("src/big.ts");
+  // Only a compact preview is shown, with a toggle revealing the full diff.
+  expect(html).toContain(en("tools.showAllLines", { count: total }));
+  // A line past the preview budget stays hidden until the toggle is used.
+  expect(html).not.toContain("+new19");
+});
+
 test("output preview shows content with an accessible copy control", () => {
   const html = renderToStaticMarkup(<OutputPreview output={"line1\nline2"} truncated={false} />);
   expect(html).toContain("line1");

--- a/src/components/feed/parse.test.ts
+++ b/src/components/feed/parse.test.ts
@@ -701,6 +701,62 @@ describe("Codex functions.exec orchestration", () => {
     expect(event.family).toBe("shell");
     expect(event.summary).not.toContain("/home/user/repo");
   });
+
+  /* Issue #90: a `const patch = "*** Begin Patch\n…"` assignment driving
+     tools.apply_patch is the common Codex edit shape. Its escaped JS string must
+     parse into the structured diff model — never a raw source dump. */
+  test("a buried apply_patch payload parses into a structured diff, not a raw source dump", () => {
+    const src =
+      'const patch = "*** Begin Patch\\n*** Update File: src/limit.ts\\n@@\\n-const limit = 10;\\n+const limit = 20;\\n*** End Patch";\ntext(await tools.apply_patch(patch));';
+    const event = single(src);
+    expect(event.family).toBe("edit");
+    expect(event.summary).toContain("limit.ts");
+    expect(event.body?.type).toBe("diff");
+    if (event.body?.type !== "diff") throw new Error("expected a diff body");
+    expect(event.body.files).toHaveLength(1);
+    const lines = event.body.files[0].hunks.flatMap((hunk) => hunk.lines.map((line) => line.t + line.text));
+    expect(lines).toContain("-const limit = 10;");
+    expect(lines).toContain("+const limit = 20;");
+    // The escaped JS source is never dumped as an orchestration body, and the
+    // edit row is represented by the diff (not duplicated as a nested call).
+    expect(event.orchestration).toBeUndefined();
+    // The diff is expanded inline by default.
+    expect(event.open).toBe(true);
+  });
+
+  test("apply_patch string escapes (\\n, \\\") decode into real diff lines", () => {
+    const src =
+      'const patch = "*** Begin Patch\\n*** Update File: src/a.ts\\n@@\\n-const s = \\"old\\";\\n+const s = \\"new\\";\\n*** End Patch";\nawait tools.apply_patch(patch);';
+    const event = single(src);
+    if (event.body?.type !== "diff") throw new Error("expected a diff body");
+    const texts = event.body.files[0].hunks.flatMap((hunk) => hunk.lines.map((line) => line.text));
+    // The `\"` decoded to a real quote and each `\n` became a line boundary.
+    expect(texts).toContain('const s = "old";');
+    expect(texts).toContain('const s = "new";');
+    // No raw escape residue (a literal backslash-n) survives inside any line.
+    expect(texts.every((line) => !line.includes("\\n"))).toBe(true);
+  });
+
+  test("a record mixing apply_patch with another op keeps the diff and the non-edit nested row", () => {
+    const src =
+      'const patch = "*** Begin Patch\\n*** Update File: src/a.ts\\n@@\\n-a\\n+b\\n*** End Patch";\nawait tools.exec_command({cmd:"bun test src/a.test.ts"});\nawait tools.apply_patch(patch);';
+    const event = single(src);
+    expect(event.body?.type).toBe("diff");
+    const nested = event.orchestration?.calls ?? [];
+    // The edit op is carried by the diff, so it is not duplicated as a row.
+    expect(nested.every((call) => call.family !== "edit")).toBe(true);
+    expect(nested.some((call) => call.summary.includes("bun test"))).toBe(true);
+  });
+
+  test("the Script completed / Wall time / Output {} preamble is suppressed as no-signal output", () => {
+    const src = 'const patch = "*** Begin Patch\\n*** Add File: src/new.ts\\n+export const x = 1;\\n*** End Patch";\ntext(await tools.apply_patch(patch));';
+    const feed = buildFeed(codexFile, [orch(src, "p"), orchOutput("p", "Script completed\nWall time 0.1 seconds\nOutput:\n\n{}")], false, "");
+    const event = feed.items.find((item) => item.kind === "tool");
+    if (event?.kind !== "tool") throw new Error("expected a tool item");
+    expect(event.status).toBe("ok");
+    expect(event.outputPreview).toBe("");
+    expect(event.body?.type).toBe("diff");
+  });
 });
 
 describe("Codex orchestration over a real rollout fixture (issue #83)", () => {

--- a/src/components/feed/parse.ts
+++ b/src/components/feed/parse.ts
@@ -484,6 +484,55 @@ function resolveField(argsSrc: string, fullInput: string, keys: readonly string[
   return "";
 }
 
+/* Decodes the escape sequences of a JavaScript string literal's body. The
+   apply_patch payload usually lives inside a `const patch = "…"` double-quoted
+   literal, so its newlines arrive as a two-char `\n` and its quotes as `\"`;
+   left raw they would render as one escaped line rather than a diff. A template
+   literal (backticks) carries real newlines and needs no decode — its body has
+   no escapes to match, so this is a no-op there. */
+function decodeJsString(raw: string): string {
+  return raw.replace(/\\(u[0-9a-fA-F]{4}|x[0-9a-fA-F]{2}|[\s\S])/g, (whole, seq: string) => {
+    switch (seq[0]) {
+      case "n":
+        return "\n";
+      case "t":
+        return "\t";
+      case "r":
+        return "\r";
+      case "b":
+        return "\b";
+      case "f":
+        return "\f";
+      case "v":
+        return "\v";
+      case "0":
+        return seq.length === 1 ? "\0" : whole;
+      case "u":
+      case "x":
+        return String.fromCodePoint(parseInt(seq.slice(1), 16));
+      case "\n":
+        return ""; // escaped line continuation
+      case '"':
+      case "'":
+      case "`":
+      case "\\":
+        return seq;
+      default:
+        return seq; // unknown escape: keep the char, drop the backslash
+    }
+  });
+}
+
+/* Pulls every apply_patch payload out of a Codex exec's JS source and decodes
+   the surrounding literal, so a `const patch = "*** Begin Patch\n…"` assignment
+   (or an inline string argument) becomes real multi-line patch text ready for
+   {@link diffFromApplyPatch}. Empty when no `*** Begin Patch` block is present
+   or the patch is built at runtime. */
+function applyPatchBody(input: string): string {
+  const blocks = input.match(/\*\*\* Begin Patch[\s\S]*?\*\*\* End Patch/g);
+  return blocks ? blocks.map(decodeJsString).join("\n") : "";
+}
+
 /* Builds canonical summarizer args for one nested `tools.method(argsSrc)` call,
    pulling the meaningful field (command, path, pattern, url) out of the argument
    source so the nested row summarizes like a first-class tool call rather than
@@ -504,10 +553,9 @@ function orchCallArgs(tool: string, argsSrc: string, fullInput: string): Record<
       return { url: resolveField(argsSrc, fullInput, ["url"]) || positionalLiteral(argsSrc) };
     case "edit": {
       /* apply_patch's argument is usually a `patch` variable, so recover the
-         patch body from the surrounding source (the `\n` escapes of a
-         double-quoted literal are unfolded) to keep the file names in view. */
-      const raw = fullInput.match(/\*\*\* Begin Patch[\s\S]*?\*\*\* End Patch/)?.[0] ?? "";
-      return { input: raw.replace(/\\n/g, "\n") };
+         patch body from the surrounding source (the literal's `\n`, `\"`, … are
+         decoded) to keep the file names — and the real diff — in view. */
+      return { input: applyPatchBody(fullInput) };
     }
     default:
       /* Codex helper methods (create_goal, update_plan, view_image, …) carry no
@@ -547,7 +595,7 @@ function batchCommands(fullInput: string): string[] {
  * the full source and raw record expose the ground truth at level 2. Returns
  * null for a plain custom tool, which keeps rendering as one generic row.
  */
-function parseOrchestration(input: string): { overlay: Partial<ToolEvent>; body: Orchestration } | null {
+function parseOrchestration(input: string): { overlay: Partial<ToolEvent>; body?: Orchestration; diff?: DiffModel } | null {
   if (!input || !/\btools\.[A-Za-z_]\w*\s*\(/.test(input)) return null;
   const calls: NestedCall[] = [];
   ORCH_CALL_RE.lastIndex = 0;
@@ -568,6 +616,38 @@ function parseOrchestration(input: string): { overlay: Partial<ToolEvent>; body:
   }
   const toolCalls = calls.filter((call) => call.icon !== "note");
   if (!toolCalls.length) return null;
+  const source = redactSecrets(input).slice(0, COMMAND_MAX);
+  const sourceTruncated = input.length > COMMAND_MAX;
+
+  /* An apply_patch payload embedded in the JS source parses into the same diff
+     model a first-class apply_patch gets, so the card renders the structured
+     DiffCard instead of dumping the escaped `const patch = "…"` string. The edit
+     op is represented by the diff itself, so it is dropped from the nested rows
+     to avoid showing the same change twice (issue #90). */
+  const patchText = applyPatchBody(input);
+  const patchDiff = patchText ? diffFromApplyPatch(patchText) : undefined;
+  if (patchDiff && patchDiff.files.length) {
+    const editView = summarizeTool("apply_patch", { input: patchText }, "codex", patchDiff);
+    const others = toolCalls.filter((call) => call.family !== "edit");
+    if (others.length === 0) {
+      /* Pure apply_patch: a clean diff card. The JS source stays reachable
+         through the level-2 raw record, never dumped into the body. */
+      return { overlay: { summary: editView.summary, icon: editView.icon, family: "edit", chips: editView.chips }, diff: patchDiff };
+    }
+    /* Mixed record: the diff plus the remaining (non-edit) nested operations. */
+    const nested = calls.filter((call) => call.family !== "edit");
+    return {
+      overlay: {
+        summary: `${editView.summary} · ${tr("tools.orchestration", { count: others.length })}`.slice(0, 160),
+        icon: "cmd-group",
+        family: "edit",
+        chips: editView.chips,
+      },
+      body: { source, sourceTruncated, calls: nested },
+      diff: patchDiff,
+    };
+  }
+
   /* A single shell op whose command didn't resolve (summary is the bare tool
      name, no space) but which maps over a static command-tuple array expands
      into one nested row per command — the batch it actually runs. */
@@ -583,19 +663,16 @@ function parseOrchestration(input: string): { overlay: Partial<ToolEvent>; body:
       ops = nested;
     }
   }
-  const source = redactSecrets(input).slice(0, COMMAND_MAX);
   const lead = ops[0];
   /* A lone operation reads as its own card — same summary, icon, and family a
      first-class shell/read/edit call would get. A multi-op record leads with
-     the first command's head and tags the remaining count. */
+     the first command's head and tags the remaining count. The raw JS source is
+     carried by the orchestration body, so the card never needs an argument chip. */
   const overlay: Partial<ToolEvent> =
     ops.length === 1
-      ? { summary: lead.summary, icon: lead.icon, family: lead.family }
-      : { summary: `${lead.summary} · ${tr("tools.orchestration", { count: ops.length })}`.slice(0, 160), icon: "cmd-group" };
-  return {
-    overlay,
-    body: { source, sourceTruncated: input.length > COMMAND_MAX, calls: nested },
-  };
+      ? { summary: lead.summary, icon: lead.icon, family: lead.family, chips: [] }
+      : { summary: `${lead.summary} · ${tr("tools.orchestration", { count: ops.length })}`.slice(0, 160), icon: "cmd-group", chips: [] };
+  return { overlay, body: { source, sourceTruncated, calls: nested } };
 }
 
 interface StoredEntry {
@@ -882,7 +959,10 @@ export function createFeedSession(cfg: FeedSessionConfig): FeedSession {
       statusLabel: tr("render.executing"),
       outputPreview: "",
       outputTruncated: false,
-      open: false,
+      /* An edit/write card opens its structured diff inline by default — a
+         compact preview of the first lines, with a toggle for the rest — so the
+         change is visible without a click (issue #90). */
+      open: Boolean(body),
     };
   };
   const registerCall = (event: ToolEvent): CallRec => {
@@ -914,9 +994,9 @@ export function createFeedSession(cfg: FeedSessionConfig): FeedSession {
      get their meaningful outer summary and structured nested children. */
   const emitCustomTool = (ts: unknown, name: string, input: string, callId?: string): ToolEvent => {
     const id = callId || "plain-" + pushSeq + "-" + String(ts ?? "");
-    const orchestration = parseOrchestration(input);
-    const base = newToolEvent({ ts, id, tool: name, args: { input }, engine: "codex" });
-    const event = orchestration ? { ...base, ...orchestration.overlay, orchestration: orchestration.body } : base;
+    const orch = parseOrchestration(input);
+    const base = newToolEvent({ ts, id, tool: name, args: { input }, engine: "codex", diff: orch?.diff });
+    const event = orch ? { ...base, ...orch.overlay, ...(orch.body ? { orchestration: orch.body } : {}) } : base;
     registerCall(event);
     return event;
   };
@@ -925,11 +1005,19 @@ export function createFeedSession(cfg: FeedSessionConfig): FeedSession {
   const attach = (callRec: CallRec | undefined, output: string, errFlag?: boolean) => {
     if (!callRec) return null;
     const code = output.match(/exited with code (\d+)/)?.[1];
-    const body = output
+    /* Codex wraps every custom-tool result in a `Script completed / Wall time N
+       seconds / Output:` preamble; strip it, and treat a bare `{}` (a script
+       that returned nothing) as no output at all, so an apply_patch card is not
+       trailed by a signal-free block (issue #90). */
+    const cleaned = output
       .replace(/^Chunk ID:[^\n]*\n/, "")
       .replace(/Wall time:[^\n]*\n/, "")
       .replace(/Original token count:[^\n]*\n?/, "")
+      .replace(/^Script completed[ \t]*\r?\n/, "")
+      .replace(/^Wall time [\d.]+ seconds?[ \t]*\r?\n/, "")
+      .replace(/^Output:[ \t]*\r?\n/, "")
       .trim();
+    const body = cleaned === "{}" ? "" : cleaned;
     const isErr = errFlag === true || (code !== undefined && code !== "0");
     const prev = callRec.event;
     let outputPreview = prev.outputPreview;


### PR DESCRIPTION
Fixes #90.

## Problem

Codex edit cards summarized correctly («Редагування registry.ts · +66 −12», #87) but the card **body** dumped the raw JS source — `const patch = "*** Begin Patch\n*** Update File: …"` as one escaped string — instead of a diff. Nested calls duplicated the edit row, an empty «джерело» chip and a `Script completed … {}` noise block trailed the card.

## Changes

**`src/components/feed/parse.ts`**
- `decodeJsString` / `applyPatchBody`: pull every `*** Begin Patch … *** End Patch` block out of the exec's JS source and decode the surrounding string literal's escapes (`\n`, `\"`, `\\`, `\uXXXX`, …). A backtick/template payload with real newlines is a no-op. The recovered patch feeds the existing `diffFromApplyPatch` model — the same one Claude Edit/Write and first-class `apply_patch` already use, with intraline character highlighting (#78/#81).
- `parseOrchestration` now returns an optional `diff`. A **pure** apply_patch exec renders a clean DiffCard with no orchestration body (raw source stays reachable via the level-2 raw record). A **mixed** record keeps the diff plus the remaining non-edit nested rows. Either way the edit row is dropped from the nested list (dedupe) and the raw-source argument chip is cleared.
- Edit/write cards open their diff **inline by default** (`open: Boolean(body)`).
- `attach` strips the Codex `Script completed / Wall time N seconds / Output:` preamble and treats a bare `{}` as no output.

**`src/components/feed/cards/DiffCard.tsx`** — preview budget 10 → 8 lines (the «~6–8 lines expanded by default», with the existing "show all" toggle for the full diff).

**`src/components/feed/cards/OrchestrationCard.tsx`** — hide the «джерело» source block when it is empty/whitespace.

## Tests

- `parse.test.ts`: buried apply_patch → structured diff (no raw dump, deduped edit row, open by default); `\n`/`\"` decode into real diff lines; mixed record keeps the diff and the non-edit nested row; `Script completed … {}` preamble suppressed.
- `toolCards.render.test.tsx`: an edit card renders its diff preview inline with the full-diff toggle and hides lines beyond the 8-line budget.
- Verified against the real rollout fixture `codex-orchestration.jsonl` (an 8-file apply_patch with escaped quotes): summary «Edit · 7 files · +11 −11», 7-file diff body, no orchestration body, empty output, no raw escape residue.

`bun test src/components/feed` → 94 pass / 0 fail. Full suite green apart from a pre-existing flake in `src/lib/accounts/migration/coordinator.test.ts` (passes 140/0 in isolation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)