### PR TITLE
feat(accounts): remove managed Claude and Codex accounts

### DIFF
--- a/src/app/api/accounts/claude/route.test.ts
+++ b/src/app/api/accounts/claude/route.test.ts
@@ -13,6 +13,8 @@ process.env.LLV_STATE_DIR = path.join(sandbox, "state");
 process.env.LLV_CLAUDE_HOME = path.join(sandbox, "legacy");
 
 const { ClaudeLoginSupervisor, setClaudeLoginSupervisorForTests } = await import("@/lib/accounts/claudeLogin");
+const { claudeRegistryPath, createManagedClaudeAccount } = await import("@/lib/accounts/claude");
+const { agentRegistry } = await import("@/lib/agent/registry");
 const { DELETE: remove, POST } = await import("./route");
 const { DELETE } = await import("./login/[operationId]/route");
 const { POST: submitInput } = await import("./login/[operationId]/input/route");
@@ -141,4 +143,38 @@ test("managed Claude removal requires force during login and cancels the operati
   }));
   expect(forced.status).toBe(200);
   await expect(forced.json()).resolves.toEqual({ removed: { id: account.id } });
+});
+
+test("managed Claude removal retires routing and migration intents targeting the account", async () => {
+  const account = createManagedClaudeAccount("Routed removal");
+  const registry = agentRegistry();
+  registry.setEngineRouting("claude", account.id);
+  const intent = registry.commitMigrationIntent({
+    engine: "claude",
+    targetId: account.id,
+    origin: "manual",
+    requestId: "remove-routed-claude",
+    expectedRevision: registry.engineRouting("claude").revision,
+  });
+
+  const response = await remove(new NextRequest("http://127.0.0.1/api/accounts/claude", {
+    method: "DELETE", headers: { host: "127.0.0.1", "content-type": "application/json" }, body: JSON.stringify({ id: account.id }),
+  }));
+
+  expect(response.status).toBe(200);
+  expect(registry.engineRouting("claude").activeAccountId).toBe("default");
+  expect(registry.snapshot().migrationIntents[intent.id]?.state).toBe("stopped");
+});
+
+test("managed Claude removal reports a corrupt registry as locked", async () => {
+  const file = claudeRegistryPath();
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, "{ corrupt");
+
+  const response = await remove(new NextRequest("http://127.0.0.1/api/accounts/claude", {
+    method: "DELETE", headers: { host: "127.0.0.1", "content-type": "application/json" }, body: JSON.stringify({ id: "missing" }),
+  }));
+
+  expect(response.status).toBe(409);
+  await expect(response.json()).resolves.toEqual(expect.objectContaining({ code: "accounts_locked" }));
 });

--- a/src/app/api/accounts/claude/route.test.ts
+++ b/src/app/api/accounts/claude/route.test.ts
@@ -13,7 +13,7 @@ process.env.LLV_STATE_DIR = path.join(sandbox, "state");
 process.env.LLV_CLAUDE_HOME = path.join(sandbox, "legacy");
 
 const { ClaudeLoginSupervisor, setClaudeLoginSupervisorForTests } = await import("@/lib/accounts/claudeLogin");
-const { POST } = await import("./route");
+const { DELETE: remove, POST } = await import("./route");
 const { DELETE } = await import("./login/[operationId]/route");
 const { POST: submitInput } = await import("./login/[operationId]/input/route");
 
@@ -28,6 +28,7 @@ let child: FakeChild;
 
 beforeEach(() => {
   fs.rmSync(process.env.LLV_STATE_DIR!, { recursive: true, force: true });
+  fs.rmSync(path.join(sandbox, "accounts"), { recursive: true, force: true });
   child = new FakeChild();
   setClaudeLoginSupervisorForTests(new ClaudeLoginSupervisor({
     spawn: () => child as never,
@@ -115,4 +116,29 @@ test("the authorization code is accepted through stdin and never appears in the 
   expect(submitted.status).toBe(200);
   expect(submittedBody).toEqual({ login: expect.objectContaining({ phase: "verifying", acceptsCode: false }) });
   expect(JSON.stringify(submittedBody)).not.toContain(code);
+});
+
+test("managed Claude removal requires force during login and cancels the operation before removing credentials", async () => {
+  const created = await POST(new NextRequest("http://127.0.0.1/api/accounts/claude", {
+    method: "POST",
+    headers: { host: "127.0.0.1", "content-type": "application/json" },
+    body: JSON.stringify({ label: "Remove me" }),
+  }));
+  const { account } = await created.json() as { account: { id: string } };
+
+  const blocked = await remove(new NextRequest("http://127.0.0.1/api/accounts/claude", {
+    method: "DELETE",
+    headers: { host: "127.0.0.1", "content-type": "application/json" },
+    body: JSON.stringify({ id: account.id }),
+  }));
+  expect(blocked.status).toBe(409);
+  await expect(blocked.json()).resolves.toEqual(expect.objectContaining({ code: "account_removal_blocked", blockers: ["login_pending"] }));
+
+  const forced = await remove(new NextRequest("http://127.0.0.1/api/accounts/claude", {
+    method: "DELETE",
+    headers: { host: "127.0.0.1", "content-type": "application/json" },
+    body: JSON.stringify({ id: account.id, force: true }),
+  }));
+  expect(forced.status).toBe(200);
+  await expect(forced.json()).resolves.toEqual({ removed: { id: account.id } });
 });

--- a/src/app/api/accounts/claude/route.test.ts
+++ b/src/app/api/accounts/claude/route.test.ts
@@ -166,6 +166,32 @@ test("managed Claude removal retires routing and migration intents targeting the
   expect(registry.snapshot().migrationIntents[intent.id]?.state).toBe("stopped");
 });
 
+test("managed Claude removal restores routing when the underlying deletion fails after routing was retired", async () => {
+  const account = createManagedClaudeAccount("Unsafe home");
+  const registry = agentRegistry();
+  registry.setEngineRouting("claude", account.id);
+  // Simulates the home becoming unsafe in the window between the route's
+  // initial listClaudeAccounts() check and removeManagedClaudeAccount's own
+  // re-read: retireAccount is the last synchronous step before that re-read,
+  // so corrupting the home here lands exactly in that window.
+  const originalRetire = registry.retireAccount.bind(registry);
+  registry.retireAccount = ((...args: Parameters<typeof originalRetire>) => {
+    originalRetire(...args);
+    fs.chmodSync(account.home, 0o755);
+  }) as typeof registry.retireAccount;
+
+  try {
+    const response = await remove(new NextRequest("http://127.0.0.1/api/accounts/claude", {
+      method: "DELETE", headers: { host: "127.0.0.1", "content-type": "application/json" }, body: JSON.stringify({ id: account.id }),
+    }));
+    expect(response.status).toBe(409);
+    await expect(response.json()).resolves.toEqual(expect.objectContaining({ code: "accounts_locked" }));
+    expect(registry.engineRouting("claude").activeAccountId).toBe(account.id);
+  } finally {
+    registry.retireAccount = originalRetire;
+  }
+});
+
 test("managed Claude removal reports a corrupt registry as locked", async () => {
   const file = claudeRegistryPath();
   fs.mkdirSync(path.dirname(file), { recursive: true });

--- a/src/app/api/accounts/claude/route.ts
+++ b/src/app/api/accounts/claude/route.ts
@@ -1,8 +1,9 @@
 import { NextRequest, NextResponse } from "next/server";
 
-import { CorruptClaudeAccountsError, InvalidClaudeAccountLabelError, UnknownClaudeAccountError, UnsafeClaudeHomeError, cleanupOrphanedClaudeHomes, createManagedClaudeAccount, listClaudeAccounts, removeManagedClaudeAccount } from "@/lib/accounts/claude";
+import { CorruptClaudeAccountsError, InvalidClaudeAccountLabelError, UnknownClaudeAccountError, UnsafeClaudeHomeError, cleanupOrphanedClaudeHomes, claudeAccountsMutationLocked, createManagedClaudeAccount, listClaudeAccounts, removeManagedClaudeAccount } from "@/lib/accounts/claude";
 import { claudeLoginSupervisor } from "@/lib/accounts/claudeLogin";
 import { accountRemovalBlockers } from "@/lib/accounts/removal";
+import { agentRegistry } from "@/lib/agent/registry";
 import { rejectCrossOrigin } from "@/lib/sameOrigin";
 
 export const runtime = "nodejs";
@@ -77,6 +78,7 @@ export async function DELETE(req: NextRequest) {
   if (typeof body.id !== "string" || typeof body.force !== "undefined" && typeof body.force !== "boolean") {
     return failure(400, "invalid_request", "Account id and force flag are invalid");
   }
+  if (claudeAccountsMutationLocked()) return failure(409, "accounts_locked", "Claude accounts require registry repair");
   const account = listClaudeAccounts().find((candidate) => candidate.id === body.id);
   if (!account || account.kind !== "managed") return failure(404, "unknown_account", "Claude account is unavailable");
   const login = claudeLoginSupervisor.forAccount(account.id);
@@ -89,6 +91,7 @@ export async function DELETE(req: NextRequest) {
   }
   try {
     if (login && LIVE_CLAUDE_LOGIN_PHASES.has(login.phase)) await claudeLoginSupervisor.cancel(login.operationId);
+    agentRegistry().retireAccount("claude", account.id, "default");
     removeManagedClaudeAccount(account.id);
     return NextResponse.json({ removed: { id: account.id } });
   } catch (error) {

--- a/src/app/api/accounts/claude/route.ts
+++ b/src/app/api/accounts/claude/route.ts
@@ -89,12 +89,19 @@ export async function DELETE(req: NextRequest) {
   if (blockers.length && body.force !== true) {
     return NextResponse.json({ error: "Claude account has active sessions or sign-in", code: "account_removal_blocked", blockers }, { status: 409 });
   }
+  const wasActive = agentRegistry().engineRouting("claude").activeAccountId === account.id;
   try {
     if (login && LIVE_CLAUDE_LOGIN_PHASES.has(login.phase)) await claudeLoginSupervisor.cancel(login.operationId);
     agentRegistry().retireAccount("claude", account.id, "default");
-    removeManagedClaudeAccount(account.id);
+    try {
+      removeManagedClaudeAccount(account.id);
+    } catch (error) {
+      if (wasActive) agentRegistry().setEngineRouting("claude", account.id);
+      throw error;
+    }
     return NextResponse.json({ removed: { id: account.id } });
   } catch (error) {
+    if (error instanceof UnknownClaudeAccountError) return failure(404, "unknown_account", "Claude account is unavailable");
     if (error instanceof CorruptClaudeAccountsError) return failure(409, "accounts_locked", "Claude accounts require registry repair");
     if (error instanceof UnsafeClaudeHomeError) return failure(409, "unsafe_home", "Claude account home failed safety checks");
     return failure(500, "removal_failed", "Claude account could not be removed");

--- a/src/app/api/accounts/claude/route.ts
+++ b/src/app/api/accounts/claude/route.ts
@@ -1,7 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
 
-import { CorruptClaudeAccountsError, InvalidClaudeAccountLabelError, UnknownClaudeAccountError, createManagedClaudeAccount, listClaudeAccounts, removeManagedClaudeAccount } from "@/lib/accounts/claude";
+import { CorruptClaudeAccountsError, InvalidClaudeAccountLabelError, UnknownClaudeAccountError, UnsafeClaudeHomeError, cleanupOrphanedClaudeHomes, createManagedClaudeAccount, listClaudeAccounts, removeManagedClaudeAccount } from "@/lib/accounts/claude";
 import { claudeLoginSupervisor } from "@/lib/accounts/claudeLogin";
+import { accountRemovalBlockers } from "@/lib/accounts/removal";
 import { rejectCrossOrigin } from "@/lib/sameOrigin";
 
 export const runtime = "nodejs";
@@ -56,5 +57,43 @@ export async function POST(req: NextRequest) {
     if (error instanceof InvalidClaudeAccountLabelError || error instanceof CorruptClaudeAccountsError) return failure(400, "invalid_account", "Claude account could not be created");
     if (error instanceof Error && error.message === "a Claude login operation is already running") return failure(409, "login_busy", "A Claude login operation is already running");
     return failure(503, "login_unavailable", "Claude login is temporarily unavailable");
+  }
+}
+
+const LIVE_CLAUDE_LOGIN_PHASES = new Set(["starting", "awaiting_browser", "awaiting_code", "verifying", "canceling"]);
+
+export async function DELETE(req: NextRequest) {
+  const rejected = rejectCrossOrigin(req); if (rejected) return rejected;
+  let body: { id?: unknown; force?: unknown; cleanupOrphans?: unknown };
+  try { body = await req.json() as { id?: unknown; force?: unknown; cleanupOrphans?: unknown }; } catch { return failure(400, "invalid_json", "Invalid JSON"); }
+  if (body.cleanupOrphans === true) {
+    if (body.id !== undefined) return failure(400, "invalid_request", "Cleanup accepts no account id");
+    try { return NextResponse.json({ removed: cleanupOrphanedClaudeHomes() }); }
+    catch (error) {
+      if (error instanceof CorruptClaudeAccountsError) return failure(409, "accounts_locked", "Claude accounts require registry repair");
+      return failure(500, "cleanup_failed", "Claude orphan cleanup failed");
+    }
+  }
+  if (typeof body.id !== "string" || typeof body.force !== "undefined" && typeof body.force !== "boolean") {
+    return failure(400, "invalid_request", "Account id and force flag are invalid");
+  }
+  const account = listClaudeAccounts().find((candidate) => candidate.id === body.id);
+  if (!account || account.kind !== "managed") return failure(404, "unknown_account", "Claude account is unavailable");
+  const login = claudeLoginSupervisor.forAccount(account.id);
+  const blockers = [
+    ...accountRemovalBlockers("claude", account.id),
+    ...(login && LIVE_CLAUDE_LOGIN_PHASES.has(login.phase) ? ["login_pending"] : []),
+  ];
+  if (blockers.length && body.force !== true) {
+    return NextResponse.json({ error: "Claude account has active sessions or sign-in", code: "account_removal_blocked", blockers }, { status: 409 });
+  }
+  try {
+    if (login && LIVE_CLAUDE_LOGIN_PHASES.has(login.phase)) await claudeLoginSupervisor.cancel(login.operationId);
+    removeManagedClaudeAccount(account.id);
+    return NextResponse.json({ removed: { id: account.id } });
+  } catch (error) {
+    if (error instanceof CorruptClaudeAccountsError) return failure(409, "accounts_locked", "Claude accounts require registry repair");
+    if (error instanceof UnsafeClaudeHomeError) return failure(409, "unsafe_home", "Claude account home failed safety checks");
+    return failure(500, "removal_failed", "Claude account could not be removed");
   }
 }

--- a/src/app/api/accounts/codex/route.test.ts
+++ b/src/app/api/accounts/codex/route.test.ts
@@ -13,8 +13,10 @@ process.env.LLV_STATE_DIR = path.join(SANDBOX, "state");
 process.env.LLV_CODEX_HOME = path.join(SANDBOX, "legacy");
 
 const { DELETE: remove, POST } = await import("./route");
+const { createManagedCodexAccount } = await import("@/lib/accounts/codex");
 const { CodexAppServerClient } = await import("@/lib/accounts/codexAppServer");
 const { ManagedCodexRuntime, setManagedCodexRuntimeForTests } = await import("@/lib/accounts/codexRuntime");
+const { agentRegistry } = await import("@/lib/agent/registry");
 
 class FakeChild extends EventEmitter {
   readonly stdin = { write: (line: string) => { this.onWrite(JSON.parse(line) as Record<string, unknown>); return true; }, end: () => undefined };
@@ -114,4 +116,38 @@ test("managed Codex removal requires force during device login and cancels the l
   }));
   expect(forced.status).toBe(200);
   expect(children[0]?.kills).toBeGreaterThan(0);
+});
+
+test("managed Codex removal retires routing and migration intents targeting the account", async () => {
+  const account = createManagedCodexAccount("Routed removal");
+  const registry = agentRegistry();
+  registry.setEngineRouting("codex", account.id);
+  const intent = registry.commitMigrationIntent({
+    engine: "codex",
+    targetId: account.id,
+    origin: "manual",
+    requestId: "remove-routed-codex",
+    expectedRevision: registry.engineRouting("codex").revision,
+  });
+
+  const response = await remove(new NextRequest("http://127.0.0.1/api/accounts/codex", {
+    method: "DELETE", headers: { host: "127.0.0.1", "content-type": "application/json" }, body: JSON.stringify({ id: account.id }),
+  }));
+
+  expect(response.status).toBe(200);
+  expect(registry.engineRouting("codex").activeAccountId).toBe("default");
+  expect(registry.snapshot().migrationIntents[intent.id]?.state).toBe("stopped");
+});
+
+test("managed Codex removal reports a corrupt registry as locked", async () => {
+  const file = path.join(process.env.LLV_STATE_DIR!, "codex-accounts.json");
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, "{ corrupt");
+
+  const response = await remove(new NextRequest("http://127.0.0.1/api/accounts/codex", {
+    method: "DELETE", headers: { host: "127.0.0.1", "content-type": "application/json" }, body: JSON.stringify({ id: "missing" }),
+  }));
+
+  expect(response.status).toBe(409);
+  await expect(response.json()).resolves.toEqual(expect.objectContaining({ code: "accounts_locked" }));
 });

--- a/src/app/api/accounts/codex/route.test.ts
+++ b/src/app/api/accounts/codex/route.test.ts
@@ -139,6 +139,32 @@ test("managed Codex removal retires routing and migration intents targeting the 
   expect(registry.snapshot().migrationIntents[intent.id]?.state).toBe("stopped");
 });
 
+test("managed Codex removal restores routing when the underlying deletion fails after routing was retired", async () => {
+  const account = createManagedCodexAccount("Unsafe home");
+  const registry = agentRegistry();
+  registry.setEngineRouting("codex", account.id);
+  // Simulates the home becoming unsafe in the window between the route's
+  // initial listCodexAccounts() check and removeManagedCodexAccount's own
+  // re-read: retireAccount is the last synchronous step before that re-read,
+  // so corrupting the home here lands exactly in that window.
+  const originalRetire = registry.retireAccount.bind(registry);
+  registry.retireAccount = ((...args: Parameters<typeof originalRetire>) => {
+    originalRetire(...args);
+    fs.chmodSync(account.home, 0o755);
+  }) as typeof registry.retireAccount;
+
+  try {
+    const response = await remove(new NextRequest("http://127.0.0.1/api/accounts/codex", {
+      method: "DELETE", headers: { host: "127.0.0.1", "content-type": "application/json" }, body: JSON.stringify({ id: account.id }),
+    }));
+    expect(response.status).toBe(409);
+    await expect(response.json()).resolves.toEqual(expect.objectContaining({ code: "accounts_locked" }));
+    expect(registry.engineRouting("codex").activeAccountId).toBe(account.id);
+  } finally {
+    registry.retireAccount = originalRetire;
+  }
+});
+
 test("managed Codex removal reports a corrupt registry as locked", async () => {
   const file = path.join(process.env.LLV_STATE_DIR!, "codex-accounts.json");
   fs.mkdirSync(path.dirname(file), { recursive: true });

--- a/src/app/api/accounts/codex/route.test.ts
+++ b/src/app/api/accounts/codex/route.test.ts
@@ -12,7 +12,7 @@ const OLD_HOME = process.env.LLV_CODEX_HOME;
 process.env.LLV_STATE_DIR = path.join(SANDBOX, "state");
 process.env.LLV_CODEX_HOME = path.join(SANDBOX, "legacy");
 
-const { POST } = await import("./route");
+const { DELETE: remove, POST } = await import("./route");
 const { CodexAppServerClient } = await import("@/lib/accounts/codexAppServer");
 const { ManagedCodexRuntime, setManagedCodexRuntimeForTests } = await import("@/lib/accounts/codexRuntime");
 
@@ -87,4 +87,31 @@ test("managed account creation returns an app-server challenge without the tmux 
   const source = fs.readFileSync(path.join(import.meta.dir, "route.ts"), "utf8");
   expect(source).not.toContain("@/lib/tmux");
   expect(source).not.toContain("spawnCommandWindow");
+});
+
+test("managed Codex removal requires force during device login and cancels the login child", async () => {
+  const children: FakeChild[] = [];
+  setManagedCodexRuntimeForTests(new ManagedCodexRuntime({
+    startClient: async (home) => {
+      const child = new FakeChild();
+      children.push(child);
+      return CodexAppServerClient.start({ home, spawn: () => child as never });
+    },
+  }));
+  const created = await POST(new NextRequest("http://127.0.0.1/api/accounts/codex", {
+    method: "POST", headers: { host: "127.0.0.1", "content-type": "application/json" }, body: JSON.stringify({ label: "Remove me" }),
+  }));
+  const { account } = await created.json() as { account: { id: string } };
+
+  const blocked = await remove(new NextRequest("http://127.0.0.1/api/accounts/codex", {
+    method: "DELETE", headers: { host: "127.0.0.1", "content-type": "application/json" }, body: JSON.stringify({ id: account.id }),
+  }));
+  expect(blocked.status).toBe(409);
+  await expect(blocked.json()).resolves.toEqual(expect.objectContaining({ code: "account_removal_blocked", blockers: ["login_pending"] }));
+
+  const forced = await remove(new NextRequest("http://127.0.0.1/api/accounts/codex", {
+    method: "DELETE", headers: { host: "127.0.0.1", "content-type": "application/json" }, body: JSON.stringify({ id: account.id, force: true }),
+  }));
+  expect(forced.status).toBe(200);
+  expect(children[0]?.kills).toBeGreaterThan(0);
 });

--- a/src/app/api/accounts/codex/route.ts
+++ b/src/app/api/accounts/codex/route.ts
@@ -1,8 +1,9 @@
 import { NextRequest, NextResponse } from "next/server";
 
-import { CorruptCodexAccountsError, InvalidAccountLabelError, UnknownAccountError, UnsafeCodexHomeError, cleanupOrphanedCodexHomes, createManagedCodexAccount, listCodexAccounts, removeManagedCodexAccount, setCodexAccountLoginPane } from "@/lib/accounts/codex";
+import { CorruptCodexAccountsError, InvalidAccountLabelError, UnknownAccountError, UnsafeCodexHomeError, cleanupOrphanedCodexHomes, codexAccountsMutationLocked, createManagedCodexAccount, listCodexAccounts, removeManagedCodexAccount, setCodexAccountLoginPane } from "@/lib/accounts/codex";
 import { managedCodexRuntime } from "@/lib/accounts/codexRuntime";
 import { accountRemovalBlockers } from "@/lib/accounts/removal";
+import { agentRegistry } from "@/lib/agent/registry";
 import { rejectCrossOrigin } from "@/lib/sameOrigin";
 
 export const runtime = "nodejs";
@@ -60,6 +61,7 @@ export async function DELETE(req: NextRequest) {
   if (typeof body.id !== "string" || typeof body.force !== "undefined" && typeof body.force !== "boolean") {
     return NextResponse.json({ error: "account id and force flag are invalid", code: "invalid_request" }, { status: 400 });
   }
+  if (codexAccountsMutationLocked()) return NextResponse.json({ error: "Codex accounts require registry repair", code: "accounts_locked" }, { status: 409 });
   const account = listCodexAccounts().find((candidate) => candidate.id === body.id);
   if (!account || account.kind !== "managed") return NextResponse.json({ error: "Codex account is unavailable", code: "unknown_account" }, { status: 404 });
   const login = managedCodexRuntime().peekLogin(account);
@@ -73,6 +75,7 @@ export async function DELETE(req: NextRequest) {
   try {
     if (login.attemptState === "pending") await managedCodexRuntime().cancelLogin(account.id);
     if (account.loginPane !== null) setCodexAccountLoginPane(account.id, null);
+    agentRegistry().retireAccount("codex", account.id, "default");
     removeManagedCodexAccount(account.id);
     return NextResponse.json({ removed: { id: account.id } });
   } catch (error) {

--- a/src/app/api/accounts/codex/route.ts
+++ b/src/app/api/accounts/codex/route.ts
@@ -72,13 +72,20 @@ export async function DELETE(req: NextRequest) {
   if (blockers.length && body.force !== true) {
     return NextResponse.json({ error: "Codex account has active sessions or sign-in", code: "account_removal_blocked", blockers }, { status: 409 });
   }
+  const wasActive = agentRegistry().engineRouting("codex").activeAccountId === account.id;
   try {
     if (login.attemptState === "pending") await managedCodexRuntime().cancelLogin(account.id);
     if (account.loginPane !== null) setCodexAccountLoginPane(account.id, null);
     agentRegistry().retireAccount("codex", account.id, "default");
-    removeManagedCodexAccount(account.id);
+    try {
+      removeManagedCodexAccount(account.id);
+    } catch (error) {
+      if (wasActive) agentRegistry().setEngineRouting("codex", account.id);
+      throw error;
+    }
     return NextResponse.json({ removed: { id: account.id } });
   } catch (error) {
+    if (error instanceof UnknownAccountError) return NextResponse.json({ error: "Codex account is unavailable", code: "unknown_account" }, { status: 404 });
     if (error instanceof CorruptCodexAccountsError) return NextResponse.json({ error: "Codex accounts require registry repair", code: "accounts_locked" }, { status: 409 });
     if (error instanceof UnsafeCodexHomeError) return NextResponse.json({ error: "Codex account home failed safety checks", code: "unsafe_home" }, { status: 409 });
     return NextResponse.json({ error: "Codex account could not be removed", code: "removal_failed" }, { status: 500 });

--- a/src/app/api/accounts/codex/route.ts
+++ b/src/app/api/accounts/codex/route.ts
@@ -1,7 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
 
-import { CorruptCodexAccountsError, InvalidAccountLabelError, UnknownAccountError, createManagedCodexAccount, listCodexAccounts } from "@/lib/accounts/codex";
+import { CorruptCodexAccountsError, InvalidAccountLabelError, UnknownAccountError, UnsafeCodexHomeError, cleanupOrphanedCodexHomes, createManagedCodexAccount, listCodexAccounts, removeManagedCodexAccount, setCodexAccountLoginPane } from "@/lib/accounts/codex";
 import { managedCodexRuntime } from "@/lib/accounts/codexRuntime";
+import { accountRemovalBlockers } from "@/lib/accounts/removal";
 import { rejectCrossOrigin } from "@/lib/sameOrigin";
 
 export const runtime = "nodejs";
@@ -40,5 +41,43 @@ export async function POST(req: NextRequest) {
   } catch (error) {
     const status = error instanceof InvalidAccountLabelError || error instanceof CorruptCodexAccountsError || error instanceof UnknownAccountError ? 400 : 500;
     return NextResponse.json({ error: error instanceof Error ? error.message : "could not create account" }, { status });
+  }
+}
+
+export async function DELETE(req: NextRequest) {
+  const rejected = rejectCrossOrigin(req);
+  if (rejected) return rejected;
+  let body: { id?: unknown; force?: unknown; cleanupOrphans?: unknown };
+  try { body = await req.json() as { id?: unknown; force?: unknown; cleanupOrphans?: unknown }; } catch { return NextResponse.json({ error: "invalid JSON" }, { status: 400 }); }
+  if (body.cleanupOrphans === true) {
+    if (body.id !== undefined) return NextResponse.json({ error: "cleanup accepts no account id", code: "invalid_request" }, { status: 400 });
+    try { return NextResponse.json({ removed: cleanupOrphanedCodexHomes() }); }
+    catch (error) {
+      if (error instanceof CorruptCodexAccountsError) return NextResponse.json({ error: "Codex accounts require registry repair", code: "accounts_locked" }, { status: 409 });
+      return NextResponse.json({ error: "Codex orphan cleanup failed", code: "cleanup_failed" }, { status: 500 });
+    }
+  }
+  if (typeof body.id !== "string" || typeof body.force !== "undefined" && typeof body.force !== "boolean") {
+    return NextResponse.json({ error: "account id and force flag are invalid", code: "invalid_request" }, { status: 400 });
+  }
+  const account = listCodexAccounts().find((candidate) => candidate.id === body.id);
+  if (!account || account.kind !== "managed") return NextResponse.json({ error: "Codex account is unavailable", code: "unknown_account" }, { status: 404 });
+  const login = managedCodexRuntime().peekLogin(account);
+  const blockers = [
+    ...accountRemovalBlockers("codex", account.id),
+    ...(login.attemptState === "pending" || account.loginPane !== null ? ["login_pending"] : []),
+  ];
+  if (blockers.length && body.force !== true) {
+    return NextResponse.json({ error: "Codex account has active sessions or sign-in", code: "account_removal_blocked", blockers }, { status: 409 });
+  }
+  try {
+    if (login.attemptState === "pending") await managedCodexRuntime().cancelLogin(account.id);
+    if (account.loginPane !== null) setCodexAccountLoginPane(account.id, null);
+    removeManagedCodexAccount(account.id);
+    return NextResponse.json({ removed: { id: account.id } });
+  } catch (error) {
+    if (error instanceof CorruptCodexAccountsError) return NextResponse.json({ error: "Codex accounts require registry repair", code: "accounts_locked" }, { status: 409 });
+    if (error instanceof UnsafeCodexHomeError) return NextResponse.json({ error: "Codex account home failed safety checks", code: "unsafe_home" }, { status: 409 });
+    return NextResponse.json({ error: "Codex account could not be removed", code: "removal_failed" }, { status: 500 });
   }
 }

--- a/src/components/AccountsPanel.dom.test.tsx
+++ b/src/components/AccountsPanel.dom.test.tsx
@@ -111,6 +111,44 @@ test("keyboard Submit code restores focus to the Claude sign-in row after it ent
   expect(document.activeElement).toBe(view.host.querySelector('[role="group"]'));
 });
 
+test("removing a managed account arms on the first click and only removes on an explicit confirm", async () => {
+  let removed: string | null = null;
+  const initial = state(login({ phase: "authenticated" }), {
+    accounts: [{ id: "acc", label: "Acc", kind: "managed", authPresent: true, loginPending: false, loginState: "authenticated", deviceAuth: null, login: null }],
+    remove: async (id) => { removed = id; return true; },
+  });
+  const view = await mount(initial);
+  mounted.push(view);
+  const remove = [...view.host.querySelectorAll("button")].find((button) => button.textContent === "Remove")!;
+
+  flushSync(() => { remove.click(); });
+  expect(removed).toBeNull();
+  expect(view.host.textContent).toContain("Remove this account?");
+
+  const confirm = [...view.host.querySelectorAll("button")].find((button) => button.textContent === "Confirm")!;
+  flushSync(() => { confirm.click(); });
+  expect(removed as unknown as string).toBe("acc");
+});
+
+test("canceling an armed removal backs out without removing the account", async () => {
+  let removed: string | null = null;
+  const initial = state(login({ phase: "authenticated" }), {
+    accounts: [{ id: "acc", label: "Acc", kind: "managed", authPresent: true, loginPending: false, loginState: "authenticated", deviceAuth: null, login: null }],
+    remove: async (id) => { removed = id; return true; },
+  });
+  const view = await mount(initial);
+  mounted.push(view);
+  const remove = [...view.host.querySelectorAll("button")].find((button) => button.textContent === "Remove")!;
+  flushSync(() => { remove.click(); });
+
+  const cancel = [...view.host.querySelectorAll("button")].find((button) => button.textContent === "Cancel")!;
+  flushSync(() => { cancel.click(); });
+
+  expect(removed).toBeNull();
+  expect(view.host.textContent).not.toContain("Remove this account?");
+  expect([...view.host.querySelectorAll("button")].some((button) => button.textContent === "Remove")).toBe(true);
+});
+
 test("keyboard Cancel restores focus to the Claude sign-in row after it enters canceling", async () => {
   let canceled: string | null = null;
   const initial = state(login(), {

--- a/src/components/AccountsPanel.dom.test.tsx
+++ b/src/components/AccountsPanel.dom.test.tsx
@@ -48,6 +48,8 @@ function state(currentLogin: ClaudeLoginView, over: Partial<EngineAccountsState>
     submitLoginCode: async () => true,
     cancelLogin: async () => true,
     retryLogin: async () => true,
+    remove: async () => true,
+    cleanupOrphans: async () => true,
     ...over,
   };
 }

--- a/src/components/AccountsPanel.render.test.tsx
+++ b/src/components/AccountsPanel.render.test.tsx
@@ -9,8 +9,8 @@ import { AccountsPanel } from "./AccountsPanel";
 const base = (over: Partial<EngineAccountsState> = {}): EngineAccountsState => ({
   engine: "codex",
   accounts: [
-    { id: "main", label: "Main", authPresent: true, loginPending: false, loginState: "authenticated", deviceAuth: null, effective: { percent: 12, window: "session", freshness: "fresh" } },
-    { id: "work", label: "Work", authPresent: true, loginPending: false, loginState: "authenticated", deviceAuth: null, effective: { percent: 64, window: "weekly", freshness: "stale" } },
+    { id: "main", label: "Main", kind: "legacy", authPresent: true, loginPending: false, loginState: "authenticated", deviceAuth: null, effective: { percent: 12, window: "session", freshness: "fresh" } },
+    { id: "work", label: "Work", kind: "managed", authPresent: true, loginPending: false, loginState: "authenticated", deviceAuth: null, effective: { percent: 64, window: "weekly", freshness: "stale" } },
   ],
   active: "main",
   identityVersion: 0,
@@ -31,6 +31,8 @@ const base = (over: Partial<EngineAccountsState> = {}): EngineAccountsState => (
   submitLoginCode: async () => true,
   cancelLogin: async () => true,
   retryLogin: async () => true,
+  remove: async () => true,
+  cleanupOrphans: async () => true,
   ...over,
 });
 
@@ -108,6 +110,13 @@ test("the active account row stays clickable so a same-active repair can run", (
   // React renders a disabled control as the bare `disabled=""` attribute; the
   // `disabled:` tailwind class variants in className are not the disabled state.
   expect(active).not.toContain('disabled=""');
+});
+
+test("shows removal only for a managed account and keeps cleanup reachable", () => {
+  const html = render(base());
+  expect(html).toContain('aria-label="Remove Work"');
+  expect(html).not.toContain('aria-label="Remove Main"');
+  expect(html).toContain("Clean up abandoned homes");
 });
 
 test("a draining migration with failures offers a Retry-failed affordance", () => {

--- a/src/components/AccountsPanel.tsx
+++ b/src/components/AccountsPanel.tsx
@@ -79,6 +79,11 @@ function AccountRow({ account, engine, activeId, onSelect, onRemove, disabled }:
   const { t } = useLocale();
   const state = rowState(account, activeId);
   const isActive = account.id === activeId;
+  // Removal deletes the managed home (including its credentials) with no undo,
+  // so the unblocked path arms on the first click and only executes on a
+  // second, explicit confirm — mirroring the confirm step migration already
+  // requires for its far less destructive account switch.
+  const [confirmingRemove, setConfirmingRemove] = useState(false);
   return (
     <div>
       <button
@@ -100,16 +105,41 @@ function AccountRow({ account, engine, activeId, onSelect, onRemove, disabled }:
         </div>
       ) : null}
       {account.kind === "managed" ? (
-        <div className="flex px-3 pb-1.5 pl-[26px]">
-          <button
-            type="button"
-            aria-label={t("accounts.removeAria", { label: account.label })}
-            disabled={disabled}
-            onClick={onRemove}
-            className="rounded-[7px] border border-line bg-bg px-2 py-0.5 text-[10.5px] font-semibold text-err hover:bg-[#fff5f5] disabled:opacity-45 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40"
-          >
-            {t("accounts.remove")}
-          </button>
+        <div className="flex items-center gap-2 px-3 pb-1.5 pl-[26px]">
+          {confirmingRemove ? (
+            <>
+              <span className="min-w-0 flex-1 text-[10.5px] font-semibold text-err">{t("accounts.removeConfirm")}</span>
+              <button
+                type="button"
+                disabled={disabled}
+                onClick={() => {
+                  setConfirmingRemove(false);
+                  onRemove();
+                }}
+                className="shrink-0 rounded-[7px] border border-err bg-err px-2 py-0.5 text-[10.5px] font-semibold text-white hover:opacity-90 disabled:opacity-45 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40"
+              >
+                {t("accounts.removeConfirmCta")}
+              </button>
+              <button
+                type="button"
+                disabled={disabled}
+                onClick={() => setConfirmingRemove(false)}
+                className="shrink-0 rounded-[7px] border border-line bg-bg px-2 py-0.5 text-[10.5px] font-semibold hover:bg-chip disabled:opacity-45 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40"
+              >
+                {t("accounts.removeConfirmCancel")}
+              </button>
+            </>
+          ) : (
+            <button
+              type="button"
+              aria-label={t("accounts.removeAria", { label: account.label })}
+              disabled={disabled}
+              onClick={() => setConfirmingRemove(true)}
+              className="rounded-[7px] border border-line bg-bg px-2 py-0.5 text-[10.5px] font-semibold text-err hover:bg-[#fff5f5] disabled:opacity-45 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40"
+            >
+              {t("accounts.remove")}
+            </button>
+          )}
         </div>
       ) : null}
     </div>

--- a/src/components/AccountsPanel.tsx
+++ b/src/components/AccountsPanel.tsx
@@ -75,7 +75,7 @@ function StateChip({ state }: { state: RowState }) {
   return null;
 }
 
-function AccountRow({ account, engine, activeId, onSelect, disabled }: { account: AccountOption; engine: "claude" | "codex"; activeId: string; onSelect: () => void; disabled: boolean }) {
+function AccountRow({ account, engine, activeId, onSelect, onRemove, disabled }: { account: AccountOption; engine: "claude" | "codex"; activeId: string; onSelect: () => void; onRemove: () => void; disabled: boolean }) {
   const { t } = useLocale();
   const state = rowState(account, activeId);
   const isActive = account.id === activeId;
@@ -97,6 +97,19 @@ function AccountRow({ account, engine, activeId, onSelect, disabled }: { account
         <div className="flex items-center gap-2 px-3 pb-1.5 pl-[26px] text-[10px] text-dim">
           <a href={account.deviceAuth.url} target="_blank" rel="noreferrer" className="truncate underline">{t("accounts.openLogin")}</a>
           <code className="select-all font-semibold text-ink">{account.deviceAuth.code}</code>
+        </div>
+      ) : null}
+      {account.kind === "managed" ? (
+        <div className="flex px-3 pb-1.5 pl-[26px]">
+          <button
+            type="button"
+            aria-label={t("accounts.removeAria", { label: account.label })}
+            disabled={disabled}
+            onClick={onRemove}
+            className="rounded-[7px] border border-line bg-bg px-2 py-0.5 text-[10.5px] font-semibold text-err hover:bg-[#fff5f5] disabled:opacity-45 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40"
+          >
+            {t("accounts.remove")}
+          </button>
         </div>
       ) : null}
     </div>
@@ -637,7 +650,7 @@ export function AccountsPanel({
               {status === "error" && accounts.length === 0 ? <div className="px-3 py-2 text-[11px] text-dim">{t("accounts.noAccounts")}</div> : null}
               {accounts.map((account) => (
                 <Fragment key={account.id}>
-                  <AccountRow account={account} engine={engine} activeId={active} disabled={mutation !== null} onSelect={() => void onSelect(account.id)} />
+                  <AccountRow account={account} engine={engine} activeId={active} disabled={mutation !== null} onSelect={() => void onSelect(account.id)} onRemove={() => void state.remove(account.id)} />
                   {engine === "claude" ? <ClaudeLoginRow key={account.login?.operationId ?? account.id} account={account} state={state} loginBusy={loginBusy} /> : null}
                 </Fragment>
               ))}
@@ -657,6 +670,16 @@ export function AccountsPanel({
                 {t("accounts.confirmAdd")}
               </button>
             </form>
+            <div className="flex justify-end border-t border-line px-3 py-1.5">
+              <button
+                type="button"
+                disabled={mutation !== null}
+                onClick={() => void state.cleanupOrphans()}
+                className="text-[10.5px] font-semibold text-dim underline underline-offset-2 hover:text-ink disabled:opacity-45 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40"
+              >
+                {t("accounts.cleanupOrphans")}
+              </button>
+            </div>
             {notice ? (
               <div className="flex items-center gap-2 border-t border-line px-3 py-1.5">
                 <span className="min-w-0 flex-1 truncate text-[11px] text-dim" title={accountNoticeText(t, notice)}>{accountNoticeText(t, notice)}</span>
@@ -669,7 +692,7 @@ export function AccountsPanel({
                     })}
                     className="shrink-0 rounded-[7px] border border-line bg-bg px-2 py-0.5 text-[11px] font-semibold hover:bg-chip focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40"
                   >
-                    {t("accounts.retry")}
+                    {notice.action.kind === "forceRemove" ? t("accounts.forceRemove") : t("accounts.retry")}
                   </button>
                 ) : null}
               </div>

--- a/src/hooks/useEngineAccounts.test.ts
+++ b/src/hooks/useEngineAccounts.test.ts
@@ -619,5 +619,6 @@ test("managed account removal retries with force only after the API reports a sa
     { id: "work", force: true },
   ]);
   expect(store.accounts.some((account) => account.id === "work")).toBeFalse();
+  expect(store.notice).toBeNull();
   unsub();
 });

--- a/src/hooks/useEngineAccounts.test.ts
+++ b/src/hooks/useEngineAccounts.test.ts
@@ -583,3 +583,41 @@ test("a non-202 claude add keeps the add retry action with the draft label (C12g
   expect(store.notice?.messageKey).toBe("accounts.claudeLogin.err.generic");
   unsub();
 });
+
+test("managed account removal retries with force only after the API reports a safety blocker", async () => {
+  let removed = false;
+  const { calls, fetcher } = scripted((url, body) => {
+    if (url === "/api/accounts") {
+      return {
+        claude: {
+          active: "main",
+          accounts: [
+            claudeMain,
+            ...(removed ? [] : [claudeAcct({ id: "work", label: "Work", login: null })]),
+          ],
+        },
+      };
+    }
+    if (url === "/api/accounts/claude" && (body as { id?: string }).id === "work") {
+      if ((body as { force?: boolean }).force !== true) {
+        return new Response(JSON.stringify({ code: "account_removal_blocked", blockers: ["live_sessions"] }), { status: 409 });
+      }
+      removed = true;
+      return new Response(JSON.stringify({ removed: { id: "work" } }));
+    }
+    return new Response(null, { status: 204 });
+  });
+  const store = createEngineAccountsStore("claude", { fetcher });
+  const unsub = store.subscribe(() => {});
+  await advance();
+
+  expect(await store.remove("work")).toBeFalse();
+  expect(store.notice?.action).toMatchObject({ type: "retry", kind: "forceRemove", accountId: "work" });
+  expect(await store.retryNotice()).toBeTrue();
+  expect(calls.filter((call) => call.url === "/api/accounts/claude").map((call) => call.body)).toEqual([
+    { id: "work", force: false },
+    { id: "work", force: true },
+  ]);
+  expect(store.accounts.some((account) => account.id === "work")).toBeFalse();
+  unsub();
+});

--- a/src/hooks/useEngineAccounts.test.ts
+++ b/src/hooks/useEngineAccounts.test.ts
@@ -622,3 +622,27 @@ test("managed account removal retries with force only after the API reports a sa
   expect(store.notice).toBeNull();
   unsub();
 });
+
+test("a blocked removal's force-remove notice survives the follow-up refresh failing", async () => {
+  let accountsCalls = 0;
+  const { fetcher } = scripted((url) => {
+    if (url === "/api/accounts") {
+      accountsCalls += 1;
+      // First read succeeds so the store hydrates; the refresh triggered by
+      // the blocked removal below fails transiently.
+      if (accountsCalls > 1) return new Response(null, { status: 500 });
+      return { claude: { active: "main", accounts: [claudeMain, claudeAcct({ id: "work", label: "Work", login: null })] } };
+    }
+    if (url === "/api/accounts/claude") {
+      return new Response(JSON.stringify({ code: "account_removal_blocked", blockers: ["live_sessions"] }), { status: 409 });
+    }
+    return new Response(null, { status: 204 });
+  });
+  const store = createEngineAccountsStore("claude", { fetcher });
+  const unsub = store.subscribe(() => {});
+  await advance();
+
+  expect(await store.remove("work")).toBeFalse();
+  expect(store.notice?.action).toMatchObject({ type: "retry", kind: "forceRemove", accountId: "work" });
+  unsub();
+});

--- a/src/hooks/useEngineAccounts.ts
+++ b/src/hooks/useEngineAccounts.ts
@@ -718,7 +718,7 @@ export function createEngineAccountsStore(
           return false;
         }
         const accounts = snapshot.accounts.filter((account) => account.id !== accountId);
-        patchSnapshot({ accounts, challenge: pendingDeviceAuth(accounts), identityVersion: snapshot.identityVersion + 1 });
+        patchSnapshot({ accounts, challenge: pendingDeviceAuth(accounts), identityVersion: snapshot.identityVersion + 1, notice: null });
       } catch {
         patchSnapshot({ notice: { kind: "error", operation: "remove", messageKey: "accounts.removeFailed", target: label, action: null } });
         await refresh();

--- a/src/hooks/useEngineAccounts.ts
+++ b/src/hooks/useEngineAccounts.ts
@@ -386,7 +386,11 @@ export function createEngineAccountsStore(
     } catch {
       if (generation !== requestGeneration) return false;
       activeRequest = null;
-      setSnapshot({ ...snapshot, status: "error", notice: refreshFailure() });
+      // A more specific notice already in flight (e.g. removeBlocked's
+      // force-remove action) survives a transient refresh failure — only a
+      // refresh-owned or absent notice gets replaced by the generic failure.
+      const notice = snapshot.notice && snapshot.notice.operation !== "refresh" ? snapshot.notice : refreshFailure();
+      setSnapshot({ ...snapshot, status: "error", notice });
       return false;
     } finally {
       clearTimeout(timeout);

--- a/src/hooks/useEngineAccounts.ts
+++ b/src/hooks/useEngineAccounts.ts
@@ -110,7 +110,7 @@ export type AccountOption = {
   effective?: AccountEffective | null;
 };
 export type AccountLoadState = "loading" | "ready" | "error";
-export type AccountOperation = "refresh" | "add" | "migrate" | "policy" | "login";
+export type AccountOperation = "refresh" | "add" | "migrate" | "policy" | "login" | "remove";
 
 /** A retry action carries exactly the identifier its endpoint needs. The account
     target id drives the preview → migrate path; the durable intent id drives the
@@ -123,11 +123,13 @@ export type AccountRetryAction =
   | { type: "retry"; kind: "migrate"; accountId: string }
   | { type: "retry"; kind: "stop"; intentId: string }
   | { type: "retry"; kind: "retryFailed"; intentId: string }
-  | { type: "retry"; kind: "loginRetry"; accountId: string };
+  | { type: "retry"; kind: "loginRetry"; accountId: string }
+  | { type: "retry"; kind: "forceRemove"; accountId: string };
 
 export type AccountNoticeKey =
   | "accounts.refreshFailed" | "accounts.switchFailed" | "accounts.addFailed" | "accounts.loginOpened"
   | "accounts.claudeLoginStarted"
+  | "accounts.removeBlocked" | "accounts.removeFailed"
   | ClaudeLoginErrKey;
 
 export interface AccountNotice {
@@ -206,6 +208,10 @@ export interface EngineAccountsState extends EngineAccountsSnapshot {
   /** Restarts sign-in for an existing managed Claude account (claude only) —
       recovers a canceled/failed/broken account without deleting it. */
   retryLogin: (accountId: string) => Promise<boolean>;
+  /** Removes one managed account. A blocked safety check exposes an explicit force retry. */
+  remove: (accountId: string, force?: boolean) => Promise<boolean>;
+  /** Removes safe managed-home directories that have no registry owner. */
+  cleanupOrphans: () => Promise<boolean>;
 }
 
 type Fetcher = (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
@@ -687,6 +693,61 @@ export function createEngineAccountsStore(
     });
   };
 
+  const remove = (accountId: string, force = false): Promise<boolean> => {
+    const label = snapshot.accounts.find((account) => account.id === accountId)?.label ?? accountId;
+    return runMutation("remove", async () => {
+      try {
+        const response = await fetcher(addUrl, {
+          method: "DELETE",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ id: accountId, force }),
+        });
+        if (!response.ok) {
+          const body = await response.json().catch(() => null) as { code?: unknown } | null;
+          const blocked = body?.code === "account_removal_blocked";
+          patchSnapshot({
+            notice: {
+              kind: "error",
+              operation: "remove",
+              messageKey: blocked ? "accounts.removeBlocked" : "accounts.removeFailed",
+              target: label,
+              action: blocked ? { type: "retry", kind: "forceRemove", accountId } : null,
+            },
+          });
+          await refresh();
+          return false;
+        }
+        const accounts = snapshot.accounts.filter((account) => account.id !== accountId);
+        patchSnapshot({ accounts, challenge: pendingDeviceAuth(accounts), identityVersion: snapshot.identityVersion + 1 });
+      } catch {
+        patchSnapshot({ notice: { kind: "error", operation: "remove", messageKey: "accounts.removeFailed", target: label, action: null } });
+        await refresh();
+        return false;
+      }
+      await refresh();
+      return true;
+    });
+  };
+
+  const cleanupOrphans = (): Promise<boolean> => {
+    return runMutation("remove", async () => {
+      try {
+        const response = await fetcher(addUrl, {
+          method: "DELETE",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ cleanupOrphans: true }),
+        });
+        if (!response.ok) throw new Error("orphan cleanup failed");
+      } catch {
+        patchSnapshot({ notice: { kind: "error", operation: "remove", messageKey: "accounts.removeFailed", action: null } });
+        await refresh();
+        return false;
+      }
+      await refresh();
+      return true;
+    });
+  };
+
   const retryNotice = async (): Promise<boolean> => {
     const action = snapshot.notice?.action;
     if (!action) return false;
@@ -697,6 +758,8 @@ export function createEngineAccountsStore(
         return add(action.label);
       case "loginRetry":
         return retryLogin(action.accountId);
+      case "forceRemove":
+        return remove(action.accountId, true);
       case "migrate": {
         // A migrate retry re-fences against a fresh preview revision: the stored
         // one is stale once the intent moved on or another switch raced, so it
@@ -753,6 +816,8 @@ export function createEngineAccountsStore(
     submitLoginCode,
     cancelLogin,
     retryLogin,
+    remove,
+    cleanupOrphans,
   };
 }
 
@@ -790,5 +855,7 @@ export function useEngineAccounts(engine: Engine): EngineAccountsState {
     submitLoginCode: store.submitLoginCode,
     cancelLogin: store.cancelLogin,
     retryLogin: store.retryLogin,
+    remove: store.remove,
+    cleanupOrphans: store.cleanupOrphans,
   };
 }

--- a/src/hooks/useEngineAccounts.ts
+++ b/src/hooks/useEngineAccounts.ts
@@ -129,7 +129,7 @@ export type AccountRetryAction =
 export type AccountNoticeKey =
   | "accounts.refreshFailed" | "accounts.switchFailed" | "accounts.addFailed" | "accounts.loginOpened"
   | "accounts.claudeLoginStarted"
-  | "accounts.removeBlocked" | "accounts.removeFailed"
+  | "accounts.removeBlocked" | "accounts.removeFailed" | "accounts.cleanupFailed"
   | ClaudeLoginErrKey;
 
 export interface AccountNotice {
@@ -739,7 +739,7 @@ export function createEngineAccountsStore(
         });
         if (!response.ok) throw new Error("orphan cleanup failed");
       } catch {
-        patchSnapshot({ notice: { kind: "error", operation: "remove", messageKey: "accounts.removeFailed", action: null } });
+        patchSnapshot({ notice: { kind: "error", operation: "remove", messageKey: "accounts.cleanupFailed", action: null } });
         await refresh();
         return false;
       }

--- a/src/lib/accounts/claude.test.ts
+++ b/src/lib/accounts/claude.test.ts
@@ -86,6 +86,39 @@ test("managed account removal deletes its registry record and home, while orphan
   expect(fs.existsSync(orphan)).toBe(false);
 });
 
+test("a home deletion failure keeps the Claude account registered and retryable", () => {
+  const account = mod.createManagedClaudeAccount("Retry removal");
+  const originalRm = fs.rmSync;
+  fs.rmSync = ((target: fs.PathLike, options?: fs.RmDirOptions) => {
+    if (String(target).includes(account.id)) throw Object.assign(new Error("denied"), { code: "EACCES" });
+    return originalRm(target, options);
+  }) as typeof fs.rmSync;
+  try {
+    expect(() => mod.removeManagedClaudeAccount(account.id)).toThrow("denied");
+  } finally {
+    fs.rmSync = originalRm;
+  }
+
+  expect(mod.listClaudeAccounts().map((item) => item.id)).toContain(account.id);
+  expect(fs.existsSync(account.home)).toBe(true);
+  expect(() => mod.removeManagedClaudeAccount(account.id)).not.toThrow();
+});
+
+test("orphan cleanup propagates a Claude accounts-root read failure", () => {
+  const root = mod.claudeAccountsRoot();
+  fs.mkdirSync(root, { recursive: true, mode: 0o700 });
+  const originalRead = fs.readdirSync;
+  fs.readdirSync = ((target: fs.PathLike, options?: unknown) => {
+    if (path.resolve(String(target)) === path.resolve(root)) throw Object.assign(new Error("unreadable"), { code: "EACCES" });
+    return originalRead(target, options as never);
+  }) as typeof fs.readdirSync;
+  try {
+    expect(() => mod.cleanupOrphanedClaudeHomes()).toThrow("unreadable");
+  } finally {
+    fs.readdirSync = originalRead;
+  }
+});
+
 test("an interrupted registry replacement leaves the prior atomic registry readable", () => {
   const account = mod.createManagedClaudeAccount("Atomic");
   const registry = mod.claudeRegistryPath();

--- a/src/lib/accounts/claude.test.ts
+++ b/src/lib/accounts/claude.test.ts
@@ -14,6 +14,7 @@ const mod = await import("./claude");
 beforeEach(() => {
   fs.rmSync(process.env.LLV_STATE_DIR!, { recursive: true, force: true });
   fs.rmSync(process.env.LLV_CLAUDE_HOME!, { recursive: true, force: true });
+  fs.rmSync(path.join(SANDBOX, "accounts"), { recursive: true, force: true });
 });
 afterAll(() => {
   if (OLD_STATE === undefined) delete process.env.LLV_STATE_DIR; else process.env.LLV_STATE_DIR = OLD_STATE;
@@ -69,6 +70,20 @@ test("managed credentials reject symlinks and broad modes before an agent can sp
   expect(() => mod.claudeAccountForSpawn(account.id)).toThrow(mod.UnsafeClaudeHomeError);
   fs.rmSync(credentials); fs.symlinkSync(path.join(process.env.LLV_CLAUDE_HOME!, "missing"), credentials);
   expect(mod.managedClaudeCredentialIsSafe(account.home, true)).toBe(false);
+});
+
+test("managed account removal deletes its registry record and home, while orphan cleanup only removes safe managed children", () => {
+  const account = mod.createManagedClaudeAccount("Delete me");
+  const orphan = path.join(mod.claudeAccountsRoot(), "probe-login");
+  fs.mkdirSync(orphan, { recursive: true, mode: 0o700 });
+
+  mod.removeManagedClaudeAccount(account.id);
+  const cleaned = mod.cleanupOrphanedClaudeHomes();
+
+  expect(mod.listClaudeAccounts().map((item) => item.id)).not.toContain(account.id);
+  expect(fs.existsSync(account.home)).toBe(false);
+  expect(cleaned).toEqual(["probe-login"]);
+  expect(fs.existsSync(orphan)).toBe(false);
 });
 
 test("an interrupted registry replacement leaves the prior atomic registry readable", () => {

--- a/src/lib/accounts/claude.ts
+++ b/src/lib/accounts/claude.ts
@@ -180,11 +180,12 @@ export function createManagedClaudeAccount(label: string): ClaudeAccount {
 
 export function removeManagedClaudeAccount(id: string): void {
   withRegistryLock(() => {
-    cached = null; const registry = mutable(); const existing = registry.accounts.find((item) => item.id === id); if (!existing) return;
+    cached = null; const registry = mutable(); const existing = registry.accounts.find((item) => item.id === id); if (!existing) throw new UnknownClaudeAccountError(id);
     const home = managedHome(id);
-    if (fs.existsSync(home) && !managedClaudeHomeIsSafe(id, true)) throw new UnsafeClaudeHomeError();
+    const exists = fs.existsSync(home);
+    if (exists && !managedClaudeHomeIsSafe(id, true)) throw new UnsafeClaudeHomeError();
+    if (exists) fs.rmSync(home, { recursive: true, force: true });
     write({ ...registry, active: registry.active === id ? DEFAULT_ID : registry.active, accounts: registry.accounts.filter((item) => item.id !== id) });
-    fs.rmSync(home, { recursive: true, force: true });
   });
 }
 
@@ -195,7 +196,8 @@ export function cleanupOrphanedClaudeHomes(): string[] {
     const registry = mutable();
     const registered = new Set(registry.accounts.map((account) => account.id));
     let entries: fs.Dirent[];
-    try { entries = fs.readdirSync(claudeAccountsRoot(), { withFileTypes: true }); } catch { return []; }
+    try { entries = fs.readdirSync(claudeAccountsRoot(), { withFileTypes: true }); }
+    catch (error) { if ((error as NodeJS.ErrnoException).code === "ENOENT") return []; throw error; }
     const removed: string[] = [];
     for (const entry of entries) {
       if (!entry.isDirectory() || registered.has(entry.name) || !managedClaudeHomeIsSafe(entry.name, true)) continue;

--- a/src/lib/accounts/claude.ts
+++ b/src/lib/accounts/claude.ts
@@ -181,8 +181,28 @@ export function createManagedClaudeAccount(label: string): ClaudeAccount {
 export function removeManagedClaudeAccount(id: string): void {
   withRegistryLock(() => {
     cached = null; const registry = mutable(); const existing = registry.accounts.find((item) => item.id === id); if (!existing) return;
+    const home = managedHome(id);
+    if (fs.existsSync(home) && !managedClaudeHomeIsSafe(id, true)) throw new UnsafeClaudeHomeError();
     write({ ...registry, active: registry.active === id ? DEFAULT_ID : registry.active, accounts: registry.accounts.filter((item) => item.id !== id) });
-    fs.rmSync(managedHome(id), { recursive: true, force: true });
+    fs.rmSync(home, { recursive: true, force: true });
+  });
+}
+
+/** Removes failed-login homes that have no registry owner. Only safe direct children qualify. */
+export function cleanupOrphanedClaudeHomes(): string[] {
+  return withRegistryLock(() => {
+    cached = null;
+    const registry = mutable();
+    const registered = new Set(registry.accounts.map((account) => account.id));
+    let entries: fs.Dirent[];
+    try { entries = fs.readdirSync(claudeAccountsRoot(), { withFileTypes: true }); } catch { return []; }
+    const removed: string[] = [];
+    for (const entry of entries) {
+      if (!entry.isDirectory() || registered.has(entry.name) || !managedClaudeHomeIsSafe(entry.name, true)) continue;
+      fs.rmSync(managedHome(entry.name), { recursive: true, force: true });
+      removed.push(entry.name);
+    }
+    return removed.sort();
   });
 }
 

--- a/src/lib/accounts/codex.test.ts
+++ b/src/lib/accounts/codex.test.ts
@@ -105,6 +105,76 @@ test("managed Codex account removal deletes its registry record and home, then c
   expect(fs.existsSync(orphan)).toBe(false);
 });
 
+test("a home deletion failure keeps the Codex account registered and retryable", () => {
+  const account = createManagedCodexAccount("Retry removal");
+  const originalRm = fs.rmSync;
+  fs.rmSync = ((target: fs.PathLike, options?: fs.RmDirOptions) => {
+    if (String(target).includes(account.id)) throw Object.assign(new Error("denied"), { code: "EACCES" });
+    return originalRm(target, options);
+  }) as typeof fs.rmSync;
+  try {
+    expect(() => removeManagedCodexAccount(account.id)).toThrow("denied");
+  } finally {
+    fs.rmSync = originalRm;
+  }
+
+  expect(listCodexAccounts().map((item) => item.id)).toContain(account.id);
+  expect(fs.existsSync(account.home)).toBe(true);
+  expect(() => removeManagedCodexAccount(account.id)).not.toThrow();
+});
+
+test("orphan cleanup propagates a Codex accounts-root read failure", () => {
+  const root = codexAccountsRoot();
+  fs.mkdirSync(root, { recursive: true, mode: 0o700 });
+  const originalRead = fs.readdirSync;
+  fs.readdirSync = ((target: fs.PathLike, options?: unknown) => {
+    if (path.resolve(String(target)) === path.resolve(root)) throw Object.assign(new Error("unreadable"), { code: "EACCES" });
+    return originalRead(target, options as never);
+  }) as typeof fs.readdirSync;
+  try {
+    expect(() => cleanupOrphanedCodexHomes()).toThrow("unreadable");
+  } finally {
+    fs.readdirSync = originalRead;
+  }
+});
+
+test("concurrent Codex removal and creation preserve both mutations", async () => {
+  const removed = createManagedCodexAccount("Remove child");
+  const modulePath = path.join(import.meta.dir, "codex.ts");
+  const registry = path.join(process.env.LLV_STATE_DIR!, "codex-accounts.json");
+  const ready = path.join(SANDBOX, "remove-ready");
+  const createReady = path.join(SANDBOX, "create-ready");
+  const removedDone = path.join(SANDBOX, "remove-done");
+  const common = `
+    const fs = (await import("node:fs")).default;
+    const sleep = (ms) => Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+    const wait = (file) => { const until = Date.now() + 1000; while (!fs.existsSync(file) && Date.now() < until) sleep(5); };
+    const originalRename = fs.renameSync;
+  `;
+  const remover = Bun.spawn({
+    cmd: [process.execPath, "-e", `${common}
+      fs.renameSync = (from, to) => { if (to === ${JSON.stringify(registry)}) { fs.writeFileSync(${JSON.stringify(ready)}, "1"); wait(${JSON.stringify(createReady)}); } originalRename(from, to); if (to === ${JSON.stringify(registry)}) fs.writeFileSync(${JSON.stringify(removedDone)}, "1"); };
+      const m = await import(${JSON.stringify(modulePath)}); m.removeManagedCodexAccount(${JSON.stringify(removed.id)});
+    `],
+    env: { ...process.env, LLV_STATE_DIR: process.env.LLV_STATE_DIR!, LLV_CODEX_HOME: process.env.LLV_CODEX_HOME! },
+    stdout: "ignore", stderr: "pipe",
+  });
+  const creator = Bun.spawn({
+    cmd: [process.execPath, "-e", `${common}
+      wait(${JSON.stringify(ready)});
+      fs.renameSync = (from, to) => { if (to === ${JSON.stringify(registry)}) { fs.writeFileSync(${JSON.stringify(createReady)}, "1"); wait(${JSON.stringify(removedDone)}); } originalRename(from, to); };
+      const m = await import(${JSON.stringify(modulePath)}); m.createManagedCodexAccount("Created child");
+    `],
+    env: { ...process.env, LLV_STATE_DIR: process.env.LLV_STATE_DIR!, LLV_CODEX_HOME: process.env.LLV_CODEX_HOME! },
+    stdout: "ignore", stderr: "pipe",
+  });
+
+  expect(await remover.exited).toBe(0);
+  expect(await creator.exited).toBe(0);
+  expect(listCodexAccounts().map((item) => item.id)).toContain("created-child");
+  expect(listCodexAccounts().map((item) => item.id)).not.toContain(removed.id);
+});
+
 test("a shell during login startup grace remains pending", () => {
   const startedAt = 1_000;
   expect(codexLoginPaneStatus(false, { paneId: "%4", windowName: "codex-login", startedAt }, { windowName: "codex-login", command: "zsh" }, startedAt + LOGIN_STARTUP_GRACE_MS - 1)).toEqual({ state: "pending", clear: false });

--- a/src/lib/accounts/codex.test.ts
+++ b/src/lib/accounts/codex.test.ts
@@ -10,10 +10,11 @@ const OLD_HOME = process.env.LLV_CODEX_HOME;
 process.env.LLV_STATE_DIR = path.join(SANDBOX, "state");
 process.env.LLV_CODEX_HOME = path.join(SANDBOX, "legacy-codex");
 
-const { CorruptCodexAccountsError, LOGIN_STARTUP_GRACE_MS, activeCodexAccountId, codexLoginPaneStatus, createManagedCodexAccount, listCodexAccounts, setActiveCodexAccount } = await import("./codex");
+const { CorruptCodexAccountsError, LOGIN_STARTUP_GRACE_MS, activeCodexAccountId, cleanupOrphanedCodexHomes, codexAccountsRoot, codexLoginPaneStatus, createManagedCodexAccount, listCodexAccounts, removeManagedCodexAccount, setActiveCodexAccount } = await import("./codex");
 
 beforeEach(() => {
   fs.rmSync(process.env.LLV_STATE_DIR!, { recursive: true, force: true });
+  fs.rmSync(path.join(SANDBOX, "accounts"), { recursive: true, force: true });
 });
 
 afterAll(() => {
@@ -88,6 +89,20 @@ test("account creation preserves an occupied home and chooses a safe suffix", ()
   expect(account.id).toBe("work-1");
   expect(fs.readFileSync(auth, "utf8")).toBe("credential sentinel");
   expect(fs.readFileSync(session, "utf8")).toBe("session sentinel");
+});
+
+test("managed Codex account removal deletes its registry record and home, then cleans safe orphan homes", () => {
+  const account = createManagedCodexAccount("Delete me");
+  const orphan = path.join(codexAccountsRoot(), "probe-login");
+  fs.mkdirSync(orphan, { recursive: true, mode: 0o700 });
+
+  removeManagedCodexAccount(account.id);
+  const cleaned = cleanupOrphanedCodexHomes();
+
+  expect(listCodexAccounts().map((item) => item.id)).not.toContain(account.id);
+  expect(fs.existsSync(account.home)).toBe(false);
+  expect(cleaned).toEqual(["probe-login"]);
+  expect(fs.existsSync(orphan)).toBe(false);
 });
 
 test("a shell during login startup grace remains pending", () => {

--- a/src/lib/accounts/codex.ts
+++ b/src/lib/accounts/codex.ts
@@ -8,6 +8,8 @@ import { isShellCommand } from "@/lib/status";
 const ACCOUNT_ID = /^[a-z0-9][a-z0-9-]{0,31}$/;
 const DEFAULT_ID = "default";
 const REGISTRY_VERSION = 1;
+const REGISTRY_LOCK_WAIT_MS = 5_000;
+const REGISTRY_LOCK_STALE_MS = 30_000;
 export const LOGIN_STARTUP_GRACE_MS = 15_000;
 /* Shared, read-mostly capability state. Account tokens, sessions, plugin data,
    and MCP OAuth state deliberately have no link and remain home-local. */
@@ -207,6 +209,46 @@ function mutableRegistry(): Registry {
   return loaded.registry;
 }
 
+function sleep(ms: number): void {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}
+
+function registryLockPath(): string {
+  return `${registryPath()}.lock`;
+}
+
+function withRegistryLock<T>(operation: () => T): T {
+  const lock = registryLockPath();
+  const started = Date.now();
+  fs.mkdirSync(path.dirname(lock), { recursive: true, mode: 0o700 });
+  for (;;) {
+    let fd: number;
+    try {
+      fd = fs.openSync(lock, "wx", 0o600);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
+      try {
+        if (Date.now() - fs.statSync(lock).mtimeMs > REGISTRY_LOCK_STALE_MS) {
+          fs.rmSync(lock, { force: true });
+          continue;
+        }
+      } catch {
+        continue;
+      }
+      if (Date.now() - started >= REGISTRY_LOCK_WAIT_MS) throw new Error("Codex account registry is busy; retry shortly");
+      sleep(10);
+      continue;
+    }
+    try {
+      fs.writeFileSync(fd, `${process.pid}\n`, "utf8");
+      return operation();
+    } finally {
+      fs.closeSync(fd);
+      fs.rmSync(lock, { force: true });
+    }
+  }
+}
+
 /** True when the registry is degraded and any persistence would throw
  *  `CorruptCodexAccountsError`. Lets read paths (e.g. `GET /api/accounts`)
  *  skip best-effort writes instead of turning a readable store into a 500. */
@@ -284,9 +326,12 @@ export function isManagedCodexHome(home: string): boolean {
 }
 
 export function setActiveCodexAccount(id: string): void {
-  const registry = mutableRegistry();
-  if (!listCodexAccounts().some((account) => account.id === id)) throw new UnknownAccountError(id);
-  writeRegistry({ ...registry, active: id });
+  withRegistryLock(() => {
+    cached = null;
+    const registry = mutableRegistry();
+    if (!listCodexAccounts().some((account) => account.id === id)) throw new UnknownAccountError(id);
+    writeRegistry({ ...registry, active: id });
+  });
 }
 
 export function codexSessionRoots(): string[] {
@@ -322,63 +367,77 @@ function accountIdForLabel(label: string, existing: Set<string>): string {
 export function createManagedCodexAccount(label: string): CodexAccount {
   const cleanLabel = label.trim();
   if (!cleanLabel || cleanLabel.length > 80 || /[\u0000-\u001f\u007f]/.test(cleanLabel)) throw new InvalidAccountLabelError();
-  const registry = mutableRegistry();
-  const id = accountIdForLabel(cleanLabel, new Set(listCodexAccounts().map((account) => account.id)));
-  const home = managedHome(id);
-  let createdHome = false;
-  try {
-    fs.mkdirSync(path.dirname(home), { recursive: true, mode: 0o700 });
-    fs.mkdirSync(home, { recursive: false, mode: 0o700 });
-    createdHome = true;
-    fs.chmodSync(home, 0o700);
-    for (const entry of OVERLAY_LINKS) fs.symlinkSync(path.join(legacyHome(), entry), path.join(home, entry));
-    fs.mkdirSync(path.join(home, "plugins"), { mode: 0o700 });
-    fs.symlinkSync(path.join(legacyHome(), "plugins", "cache"), path.join(home, "plugins", "cache"));
-    const stored: StoredAccount = { id, label: cleanLabel, kind: "managed", createdAt: Date.now(), loginPane: null };
-    writeRegistry({ ...registry, accounts: [...registry.accounts, stored] });
-    return asAccount(stored);
-  } catch (error) {
-    if (createdHome) fs.rmSync(home, { recursive: true, force: true });
-    throw error;
-  }
+  return withRegistryLock(() => {
+    cached = null;
+    const registry = mutableRegistry();
+    const id = accountIdForLabel(cleanLabel, new Set(listCodexAccounts().map((account) => account.id)));
+    const home = managedHome(id);
+    let createdHome = false;
+    try {
+      fs.mkdirSync(path.dirname(home), { recursive: true, mode: 0o700 });
+      fs.mkdirSync(home, { recursive: false, mode: 0o700 });
+      createdHome = true;
+      fs.chmodSync(home, 0o700);
+      for (const entry of OVERLAY_LINKS) fs.symlinkSync(path.join(legacyHome(), entry), path.join(home, entry));
+      fs.mkdirSync(path.join(home, "plugins"), { mode: 0o700 });
+      fs.symlinkSync(path.join(legacyHome(), "plugins", "cache"), path.join(home, "plugins", "cache"));
+      const stored: StoredAccount = { id, label: cleanLabel, kind: "managed", createdAt: Date.now(), loginPane: null };
+      writeRegistry({ ...registry, accounts: [...registry.accounts, stored] });
+      return asAccount(stored);
+    } catch (error) {
+      if (createdHome) fs.rmSync(home, { recursive: true, force: true });
+      throw error;
+    }
+  });
 }
 
 export function removeManagedCodexAccount(id: string): void {
-  const registry = mutableRegistry();
-  const existing = registry.accounts.find((account) => account.id === id);
-  if (!existing) throw new UnknownAccountError(id);
-  const home = managedHome(id);
-  if (fs.existsSync(home) && !managedHomeIsSafe(id, true)) throw new UnsafeCodexHomeError();
-  writeRegistry({
-    ...registry,
-    active: registry.active === id ? DEFAULT_ID : registry.active,
-    accounts: registry.accounts.filter((account) => account.id !== id),
+  withRegistryLock(() => {
+    cached = null;
+    const registry = mutableRegistry();
+    const existing = registry.accounts.find((account) => account.id === id);
+    if (!existing) throw new UnknownAccountError(id);
+    const home = managedHome(id);
+    const exists = fs.existsSync(home);
+    if (exists && !managedHomeIsSafe(id, true)) throw new UnsafeCodexHomeError();
+    if (exists) fs.rmSync(home, { recursive: true, force: true });
+    writeRegistry({
+      ...registry,
+      active: registry.active === id ? DEFAULT_ID : registry.active,
+      accounts: registry.accounts.filter((account) => account.id !== id),
+    });
   });
-  fs.rmSync(home, { recursive: true, force: true });
 }
 
 /** Removes failed-login homes that have no registry owner. Only safe direct children qualify. */
 export function cleanupOrphanedCodexHomes(): string[] {
-  const registry = mutableRegistry();
-  const registered = new Set(registry.accounts.map((account) => account.id));
-  let entries: fs.Dirent[];
-  try { entries = fs.readdirSync(codexAccountsRoot(), { withFileTypes: true }); } catch { return []; }
-  const removed: string[] = [];
-  for (const entry of entries) {
-    if (!entry.isDirectory() || registered.has(entry.name) || !managedHomeIsSafe(entry.name, true)) continue;
-    fs.rmSync(managedHome(entry.name), { recursive: true, force: true });
-    removed.push(entry.name);
-  }
-  return removed.sort();
+  return withRegistryLock(() => {
+    cached = null;
+    const registry = mutableRegistry();
+    const registered = new Set(registry.accounts.map((account) => account.id));
+    let entries: fs.Dirent[];
+    try { entries = fs.readdirSync(codexAccountsRoot(), { withFileTypes: true }); }
+    catch (error) { if ((error as NodeJS.ErrnoException).code === "ENOENT") return []; throw error; }
+    const removed: string[] = [];
+    for (const entry of entries) {
+      if (!entry.isDirectory() || registered.has(entry.name) || !managedHomeIsSafe(entry.name, true)) continue;
+      fs.rmSync(managedHome(entry.name), { recursive: true, force: true });
+      removed.push(entry.name);
+    }
+    return removed.sort();
+  });
 }
 
 export function setCodexAccountLoginPane(id: string, loginPane: LoginPane | null): void {
-  const registry = mutableRegistry();
-  const index = registry.accounts.findIndex((account) => account.id === id);
-  if (index < 0) throw new UnknownAccountError(id);
-  const accounts = [...registry.accounts];
-  accounts[index] = { ...accounts[index]!, loginPane };
-  writeRegistry({ ...registry, accounts });
+  withRegistryLock(() => {
+    cached = null;
+    const registry = mutableRegistry();
+    const index = registry.accounts.findIndex((account) => account.id === id);
+    if (index < 0) throw new UnknownAccountError(id);
+    const accounts = [...registry.accounts];
+    accounts[index] = { ...accounts[index]!, loginPane };
+    writeRegistry({ ...registry, accounts });
+  });
 }
 
 export type CodexLoginState = "pending" | "idle" | "authenticated";

--- a/src/lib/accounts/codex.ts
+++ b/src/lib/accounts/codex.ts
@@ -79,11 +79,18 @@ export class CorruptCodexAccountsError extends Error {
   }
 }
 
+export class UnsafeCodexHomeError extends Error {
+  constructor() {
+    super("managed Codex home failed safety checks");
+    this.name = "UnsafeCodexHomeError";
+  }
+}
+
 function legacyHome(): string {
   return path.resolve(process.env.LLV_CODEX_HOME || path.join(os.homedir(), ".codex"));
 }
 
-function accountsRoot(): string {
+export function codexAccountsRoot(): string {
   return path.join(path.dirname(stateDir()), "accounts", "codex");
 }
 
@@ -128,21 +135,22 @@ function isStoredAccount(value: unknown): value is StoredAccount {
 }
 
 function managedHome(id: string): string {
-  return path.join(accountsRoot(), id);
+  return path.join(codexAccountsRoot(), id);
 }
 
-function managedHomeIsSafe(id: string): boolean {
+function managedHomeIsSafe(id: string, requireExisting = false): boolean {
   if (!ACCOUNT_ID.test(id) || id === DEFAULT_ID) return false;
-  const root = path.resolve(accountsRoot());
+  const root = path.resolve(codexAccountsRoot());
   const home = path.resolve(managedHome(id));
   if (path.dirname(home) !== root) return false;
   try {
+    const rootStat = fs.lstatSync(root);
     const stat = fs.lstatSync(home);
-    if (stat.isSymbolicLink()) return false;
+    if (!rootStat.isDirectory() || rootStat.isSymbolicLink() || !stat.isDirectory() || stat.isSymbolicLink() || (stat.mode & 0o077) !== 0) return false;
     const rootReal = fs.realpathSync(root);
     return path.dirname(fs.realpathSync(home)) === rootReal;
   } catch {
-    return true;
+    return !requireExisting;
   }
 }
 
@@ -333,6 +341,35 @@ export function createManagedCodexAccount(label: string): CodexAccount {
     if (createdHome) fs.rmSync(home, { recursive: true, force: true });
     throw error;
   }
+}
+
+export function removeManagedCodexAccount(id: string): void {
+  const registry = mutableRegistry();
+  const existing = registry.accounts.find((account) => account.id === id);
+  if (!existing) throw new UnknownAccountError(id);
+  const home = managedHome(id);
+  if (fs.existsSync(home) && !managedHomeIsSafe(id, true)) throw new UnsafeCodexHomeError();
+  writeRegistry({
+    ...registry,
+    active: registry.active === id ? DEFAULT_ID : registry.active,
+    accounts: registry.accounts.filter((account) => account.id !== id),
+  });
+  fs.rmSync(home, { recursive: true, force: true });
+}
+
+/** Removes failed-login homes that have no registry owner. Only safe direct children qualify. */
+export function cleanupOrphanedCodexHomes(): string[] {
+  const registry = mutableRegistry();
+  const registered = new Set(registry.accounts.map((account) => account.id));
+  let entries: fs.Dirent[];
+  try { entries = fs.readdirSync(codexAccountsRoot(), { withFileTypes: true }); } catch { return []; }
+  const removed: string[] = [];
+  for (const entry of entries) {
+    if (!entry.isDirectory() || registered.has(entry.name) || !managedHomeIsSafe(entry.name, true)) continue;
+    fs.rmSync(managedHome(entry.name), { recursive: true, force: true });
+    removed.push(entry.name);
+  }
+  return removed.sort();
 }
 
 export function setCodexAccountLoginPane(id: string, loginPane: LoginPane | null): void {

--- a/src/lib/accounts/codexRuntime.test.ts
+++ b/src/lib/accounts/codexRuntime.test.ts
@@ -80,6 +80,25 @@ test("cancellation and independent homes never share a managed app-server child"
   expect(children[1]!.kills).toBe(0);
 });
 
+test("cancellation waits for an in-flight client startup to be reaped", async () => {
+  let release!: (client: CodexAppServerClient) => void;
+  const starting = new Promise<CodexAppServerClient>((resolve) => { release = resolve; });
+  const child = new FakeChild();
+  const runtime = new ManagedCodexRuntime({ startClient: () => starting });
+  const work = account("starting", "/accounts/starting");
+  const launch = runtime.startLogin(work).catch(() => null);
+  let cancelled = false;
+  const cancel = runtime.cancelLogin(work.id).then((value) => { cancelled = value; });
+
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  expect(cancelled).toBe(false);
+  release(await CodexAppServerClient.start({ home: work.home, spawn: () => child as never }));
+  await cancel;
+  await launch;
+  expect(cancelled).toBe(true);
+  expect(child.kills).toBeGreaterThan(0);
+});
+
 test("child death, false completion, and account-read failure become recoverable states", async () => {
   const stateFile = path.join(fs.mkdtempSync(path.join(os.tmpdir(), "llv-runtime-state-")), "attempts.json");
   const children: FakeChild[] = [];

--- a/src/lib/accounts/codexRuntime.ts
+++ b/src/lib/accounts/codexRuntime.ts
@@ -198,7 +198,15 @@ export class ManagedCodexRuntime {
     if (!this.owns(attempt)) return;
     const client = attempt.client;
     this.settle(attempt, "cancelled", reason, false);
-    if (!client || !attempt.loginId) return;
+    if (!client) {
+      await attempt.startPromise.catch(() => undefined);
+      return;
+    }
+    if (!attempt.loginId) {
+      client.close();
+      await attempt.startPromise.catch(() => undefined);
+      return;
+    }
     try { await client.cancelLogin(attempt.loginId); } catch { /* closing the child finalizes the cancellation */ }
     finally { client.close(); }
   }

--- a/src/lib/accounts/removal.test.ts
+++ b/src/lib/accounts/removal.test.ts
@@ -30,3 +30,12 @@ test("a pending Viewer spawn blocks managed-home removal for its assigned accoun
   expect(accountRemovalBlockers("claude", "work")).toEqual(["live_sessions"]);
   expect(accountRemovalBlockers("claude", "other")).toEqual([]);
 });
+
+test("an unresolved live launch blocks removal of every managed account for its engine", () => {
+  const registry = new AgentRegistry(path.join(process.env.LLV_STATE_DIR!, "agent-registry.json"));
+  setAgentRegistryForTests(registry);
+  registry.beginSpawnRequest({ engine: "codex", cwd: "/repo", accountId: null });
+
+  expect(accountRemovalBlockers("codex", "work")).toEqual(["live_sessions"]);
+  expect(accountRemovalBlockers("claude", "work")).toEqual([]);
+});

--- a/src/lib/accounts/removal.test.ts
+++ b/src/lib/accounts/removal.test.ts
@@ -1,0 +1,32 @@
+import { afterAll, beforeEach, expect, test } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const sandbox = fs.mkdtempSync(path.join(os.tmpdir(), "llv-account-removal-test-"));
+const previousState = process.env.LLV_STATE_DIR;
+process.env.LLV_STATE_DIR = path.join(sandbox, "state");
+
+const { AgentRegistry, setAgentRegistryForTests } = await import("@/lib/agent/registry");
+const { accountRemovalBlockers } = await import("./removal");
+
+beforeEach(() => {
+  fs.rmSync(process.env.LLV_STATE_DIR!, { recursive: true, force: true });
+  setAgentRegistryForTests(new AgentRegistry(path.join(process.env.LLV_STATE_DIR!, "agent-registry.json")));
+});
+
+afterAll(() => {
+  setAgentRegistryForTests(null);
+  if (previousState === undefined) delete process.env.LLV_STATE_DIR;
+  else process.env.LLV_STATE_DIR = previousState;
+  fs.rmSync(sandbox, { recursive: true, force: true });
+});
+
+test("a pending Viewer spawn blocks managed-home removal for its assigned account", () => {
+  const registry = new AgentRegistry(path.join(process.env.LLV_STATE_DIR!, "agent-registry.json"));
+  setAgentRegistryForTests(registry);
+  registry.beginSpawnRequest({ engine: "claude", cwd: "/repo", accountId: "work" });
+
+  expect(accountRemovalBlockers("claude", "work")).toEqual(["live_sessions"]);
+  expect(accountRemovalBlockers("claude", "other")).toEqual([]);
+});

--- a/src/lib/accounts/removal.ts
+++ b/src/lib/accounts/removal.ts
@@ -10,8 +10,8 @@ const LIVE_RECEIPT_STATES = new Set(["starting", "pane-bound", "host-verified", 
 export function accountRemovalBlockers(engine: ManagedAccountEngine, accountId: string): AccountRemovalBlocker[] {
   const snapshot = agentRegistry().snapshot();
   const liveEntry = Object.values(snapshot.entries).some((entry) =>
-    entry.key.engine === engine && entry.accountId === accountId && LIVE_ENTRY_STATUSES.has(entry.status));
+    entry.key.engine === engine && (entry.accountId === accountId || entry.accountId === null) && LIVE_ENTRY_STATUSES.has(entry.status));
   const liveReceipt = Object.values(snapshot.receipts).some((receipt) =>
-    receipt.engine === engine && receipt.accountId === accountId && LIVE_RECEIPT_STATES.has(receipt.state));
+    receipt.engine === engine && (receipt.accountId === accountId || receipt.accountId === null) && LIVE_RECEIPT_STATES.has(receipt.state));
   return liveEntry || liveReceipt ? ["live_sessions"] : [];
 }

--- a/src/lib/accounts/removal.ts
+++ b/src/lib/accounts/removal.ts
@@ -6,7 +6,12 @@ export type AccountRemovalBlocker = "live_sessions";
 const LIVE_ENTRY_STATUSES = new Set(["starting", "live", "idle", "handoff"]);
 const LIVE_RECEIPT_STATES = new Set(["starting", "pane-bound", "host-verified", "prompt-delivered", "path-pending"]);
 
-/** Durable Viewer ownership is the authority for account-home removal safety. */
+/** Durable Viewer ownership is the authority for account-home removal safety.
+ *  This reads the agent registry outside any accounts-registry lock, so a
+ *  spawn that begins in the gap between this check and the home deletion can
+ *  still bind a session to the home mid-removal — the same outcome `force`
+ *  already opts into, and the window is milliseconds. Closing it fully would
+ *  need cross-store atomicity between the agent and accounts registries. */
 export function accountRemovalBlockers(engine: ManagedAccountEngine, accountId: string): AccountRemovalBlocker[] {
   const snapshot = agentRegistry().snapshot();
   const liveEntry = Object.values(snapshot.entries).some((entry) =>

--- a/src/lib/accounts/removal.ts
+++ b/src/lib/accounts/removal.ts
@@ -1,0 +1,17 @@
+import { agentRegistry } from "@/lib/agent/registry";
+
+export type ManagedAccountEngine = "claude" | "codex";
+export type AccountRemovalBlocker = "live_sessions";
+
+const LIVE_ENTRY_STATUSES = new Set(["starting", "live", "idle", "handoff"]);
+const LIVE_RECEIPT_STATES = new Set(["starting", "pane-bound", "host-verified", "prompt-delivered", "path-pending"]);
+
+/** Durable Viewer ownership is the authority for account-home removal safety. */
+export function accountRemovalBlockers(engine: ManagedAccountEngine, accountId: string): AccountRemovalBlocker[] {
+  const snapshot = agentRegistry().snapshot();
+  const liveEntry = Object.values(snapshot.entries).some((entry) =>
+    entry.key.engine === engine && entry.accountId === accountId && LIVE_ENTRY_STATUSES.has(entry.status));
+  const liveReceipt = Object.values(snapshot.receipts).some((receipt) =>
+    receipt.engine === engine && receipt.accountId === accountId && LIVE_RECEIPT_STATES.has(receipt.state));
+  return liveEntry || liveReceipt ? ["live_sessions"] : [];
+}

--- a/src/lib/agent/registry.ts
+++ b/src/lib/agent/registry.ts
@@ -897,6 +897,34 @@ export class AgentRegistry {
     return clone(this.snapshot().engineRouting[engine]);
   }
 
+  retireAccount(engine: Extract<AgentEngine, "claude" | "codex">, accountId: string, fallbackAccountId: string): void {
+    this.mutate((file) => {
+      const changedAt = now();
+      const route = file.engineRouting[engine];
+      if (route.activeAccountId === accountId) {
+        route.activeAccountId = fallbackAccountId;
+        route.revision += 1;
+      }
+      const retiredIntentIds = new Set<string>();
+      for (const intent of Object.values(file.migrationIntents)) {
+        if (intent.engine !== engine || intent.targetId !== accountId) continue;
+        retiredIntentIds.add(intent.id);
+        if (intent.state === "stopped") continue;
+        intent.state = "stopped";
+        intent.revision += 1;
+        intent.updatedAt = changedAt;
+        intent.stoppedAt = changedAt;
+      }
+      if (retiredIntentIds.size === 0) return;
+      for (const conversation of Object.values(file.conversations)) {
+        if (!conversation.migration || !retiredIntentIds.has(conversation.migration.intentId)) continue;
+        conversation.migration = null;
+        conversation.updatedAt = changedAt;
+        file.conversationRevision[conversation.engine] += 1;
+      }
+    });
+  }
+
   commitMigrationIntent(input: {
     engine: Extract<AgentEngine, "claude" | "codex">;
     targetId: string;

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -121,8 +121,12 @@ export const en = {
   "accounts.close": "Close",
   "accounts.remove": "Remove",
   "accounts.removeAria": "Remove {label}",
+  "accounts.removeConfirm": "Remove this account?",
+  "accounts.removeConfirmCta": "Confirm",
+  "accounts.removeConfirmCancel": "Cancel",
   "accounts.removeBlocked": "{label} still has an active session or sign-in.",
   "accounts.removeFailed": "Could not remove this account.",
+  "accounts.cleanupFailed": "Could not clean up abandoned homes.",
   "accounts.forceRemove": "Force remove",
   "accounts.cleanupOrphans": "Clean up abandoned homes",
   // Account migration (#40) — unified panel, confirm, banner, ribbons

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -119,6 +119,12 @@ export const en = {
   "accounts.labelPlaceholder": "New account label",
   "accounts.confirmAdd": "Add",
   "accounts.close": "Close",
+  "accounts.remove": "Remove",
+  "accounts.removeAria": "Remove {label}",
+  "accounts.removeBlocked": "{label} still has an active session or sign-in.",
+  "accounts.removeFailed": "Could not remove this account.",
+  "accounts.forceRemove": "Force remove",
+  "accounts.cleanupOrphans": "Clean up abandoned homes",
   // Account migration (#40) — unified panel, confirm, banner, ribbons
   "accounts.titleFor": "{engine} accounts",
   "accounts.triggerAria": "{engine} accounts — switch, migrate, or add",

--- a/src/lib/i18n/uk.ts
+++ b/src/lib/i18n/uk.ts
@@ -115,8 +115,12 @@ export const uk: Record<keyof typeof en, Message> = {
   "accounts.close": "Закрити",
   "accounts.remove": "Видалити",
   "accounts.removeAria": "Видалити {label}",
+  "accounts.removeConfirm": "Видалити цей акаунт?",
+  "accounts.removeConfirmCta": "Підтвердити",
+  "accounts.removeConfirmCancel": "Скасувати",
   "accounts.removeBlocked": "Для {label} ще є активна сесія або вхід.",
   "accounts.removeFailed": "Не вдалося видалити цей акаунт.",
+  "accounts.cleanupFailed": "Не вдалося очистити покинуті теки.",
   "accounts.forceRemove": "Видалити примусово",
   "accounts.cleanupOrphans": "Очистити покинуті теки",
   // Міграція акаунтів (#40) — уніфікована панель, підтвердження, банер, стрічки

--- a/src/lib/i18n/uk.ts
+++ b/src/lib/i18n/uk.ts
@@ -113,6 +113,12 @@ export const uk: Record<keyof typeof en, Message> = {
   "accounts.labelPlaceholder": "Назва нового акаунта",
   "accounts.confirmAdd": "Додати",
   "accounts.close": "Закрити",
+  "accounts.remove": "Видалити",
+  "accounts.removeAria": "Видалити {label}",
+  "accounts.removeBlocked": "Для {label} ще є активна сесія або вхід.",
+  "accounts.removeFailed": "Не вдалося видалити цей акаунт.",
+  "accounts.forceRemove": "Видалити примусово",
+  "accounts.cleanupOrphans": "Очистити покинуті теки",
   // Міграція акаунтів (#40) — уніфікована панель, підтвердження, банер, стрічки
   "accounts.titleFor": "Акаунти {engine}",
   "accounts.triggerAria": "Акаунти {engine} — змінити, мігрувати або додати",


### PR DESCRIPTION
Closes #79.

- adds guarded DELETE APIs for managed Claude and Codex accounts
- blocks removal while Viewer sessions or sign-in are active; Force remove cancels supervised login first
- adds safe orphan managed-home cleanup and panel controls
- covers API, store, UI, and managed-home behavior with tests

Verification: `bun test`, `bunx tsc --noEmit`.