### PR TITLE
Surface rate-limited conversations and blocked flows

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -1,0 +1,17 @@
+# Issue #97: Rate-limit visibility and blocked flows
+
+## Task statement
+
+Detect current per-conversation engine usage limits, combine pane and structured account-limit evidence, and expose the blocked state in the viewer so operators can see why a conversation or attached flow cannot progress. Preserve ready composers containing historical quota text and keep successor spawning, flow rebinding, and migration-lineage handling outside this PR.
+
+## Acceptance criteria
+
+- AC1: A current usage-limit banner in a live conversation pane marks that conversation as rate-limited and captures a reliable reset time when one can be parsed.
+- AC2: Historical quota prose in a ready composer does not mark the conversation as rate-limited.
+- AC3: Fresh structured account exhaustion is joined to live conversations using stable account identity, including when automatic account balancing is disabled.
+- AC4: Rate-limited conversations expose a visible badge and attention state; exact reset copy is omitted when the exhausted window has no reliable timestamp.
+- AC5: An attached implementer flow projects the rate-limited conversation as `blocked: rate-limited` instead of remaining silently in `waiting_ready`.
+- AC6: A rate-limited flow does not offer the waiting-state transition action while its implementer is blocked.
+- AC7: Conversation and exhausted-account identifiers remain available as stable seams for a later continue-on-account successor workflow.
+- AC8: Rate-limit evidence refreshes with live state and clears when the active signal is no longer present or fresh.
+- AC9: Existing automated tests pass with `bun test`, and the project type-checks with `bunx tsc --noEmit`.

--- a/src/app/api/files/route.ts
+++ b/src/app/api/files/route.ts
@@ -13,6 +13,7 @@ import { pathForPanePid, reconcileTasks } from "@/lib/tasks/reconcile";
 import { loadTasks } from "@/lib/tasks/store";
 import { loadWorkflows } from "@/lib/workflows/store";
 import { filterWorkflowsForFileScan } from "@/lib/workflows/visibility";
+import { projectRateLimitReadModel } from "@/lib/rateLimit";
 import type { FilesResponse } from "@/lib/types";
 
 export const runtime = "nodejs";
@@ -93,7 +94,16 @@ export async function GET(request: Request): Promise<NextResponse> {
     pipelinesError = error instanceof Error ? error.message : "pipeline registry unreadable";
     console.error("[files] pipelines store unreadable; serving without pipelines", error);
   }
-  const body = JSON.stringify({ files, projectCatalog, flows: loadFlows(), pipelines, workflows, tasks: tasks.tasks, ...(pipelinesError ? { pipelinesError } : {}) } satisfies FilesResponse);
+  const projected = projectRateLimitReadModel(files, loadFlows(), registrySnapshot);
+  const body = JSON.stringify({
+    files: projected.files,
+    projectCatalog,
+    flows: projected.flows,
+    pipelines,
+    workflows,
+    tasks: tasks.tasks,
+    ...(pipelinesError ? { pipelinesError } : {}),
+  } satisfies FilesResponse);
   /* The client re-polls every 10 s and this ~410 KB payload is usually
      identical between polls; a strong ETag over the exact bytes lets an
      unchanged response come back as a bodyless 304. force-dynamic still holds

--- a/src/components/BranchPane.tsx
+++ b/src/components/BranchPane.tsx
@@ -22,6 +22,7 @@ import { paneState, type PaneState } from "./paneState";
 import { CtxChip, GoalChip, PlanChip } from "./PlanChip";
 import { ProcessStatusControls } from "./TaskHeader";
 import { TmuxComposer } from "./TmuxComposer";
+import { RateLimitBadge } from "./RateLimitBadge";
 import { activityDot, cleanTitle, effortTint, effortTitle, engineBadge, engineEdge, fmtAge } from "./utils";
 
 const noop = () => undefined;
@@ -224,6 +225,7 @@ export function BranchPane({ file, tasks, isRoot, onClose, dragHandle, noCompose
               </span>
             )}
             <EffortPills file={file} />
+            <RateLimitBadge rateLimit={file.rateLimit} />
             {/* The phone header keeps only actionable or alarming chips: ctx
                 appears once it nears the limit, the worktree name and the
                 branch-kind label yield their room to the rest of the row. */}

--- a/src/components/RateLimitBadge.test.tsx
+++ b/src/components/RateLimitBadge.test.tsx
@@ -1,0 +1,15 @@
+import { expect, test } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { RateLimitBadge } from "./RateLimitBadge";
+
+test("rate-limit badge carries the reset time", () => {
+  const html = renderToStaticMarkup(
+    <RateLimitBadge
+      rateLimit={{ source: "account", accountId: "main", window: "session", resetAt: 1_800_003_300 }}
+    />,
+  );
+
+  expect(html).toContain("data-rate-limited");
+  expect(html).toContain("rate-limited until");
+});

--- a/src/components/RateLimitBadge.tsx
+++ b/src/components/RateLimitBadge.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+import { useLocale } from "@/lib/i18n";
+import type { RateLimitState } from "@/lib/types";
+
+import { rateLimitText } from "./rateLimit";
+
+export function RateLimitBadge({ rateLimit }: { rateLimit?: RateLimitState | null }) {
+  const { locale, t } = useLocale();
+  if (!rateLimit) return null;
+  const label = rateLimitText(t, locale, rateLimit);
+  return (
+    <span
+      data-rate-limited
+      className="inline-flex shrink-0 items-center rounded-full border border-err/35 bg-[#fbeaea] px-2 py-0.5 text-[10px] font-bold text-err"
+      title={label}
+    >
+      {label}
+    </span>
+  );
+}

--- a/src/components/SwitchCard.tsx
+++ b/src/components/SwitchCard.tsx
@@ -9,6 +9,7 @@ import type { FileEntry } from "@/lib/types";
 import { EffortPills } from "./EffortPills";
 import { CtxChip } from "./PlanChip";
 import { ProcessStatusControls } from "./TaskHeader";
+import { RateLimitBadge } from "./RateLimitBadge";
 import { activityDot, cleanTitle, effortTint, effortTitle, engineBadge, fmtAge } from "./utils";
 
 export type SwitchCardSize = "large" | "small";
@@ -79,6 +80,7 @@ export function SwitchCard({ file, title, project, currentProject, descendants, 
           <span className="shrink-0 rounded-full px-1.5 py-0.5 text-[9.5px] font-bold" style={badge.style}>{badge.label}</span>
         )}
         <EffortPills file={file} />
+        <RateLimitBadge rateLimit={file.rateLimit} />
         <span
           className={`ml-auto min-w-0 truncate rounded-full border border-line bg-bg px-1.5 py-0.5 text-[9.5px] font-semibold ${
             project === currentProject ? "text-dim" : "text-ink"

--- a/src/components/Viewer.tsx
+++ b/src/components/Viewer.tsx
@@ -62,6 +62,7 @@ function attentionSnippet(t: TFunction, item: AttentionItem): string {
     const first = q.questions?.[0];
     return first?.header || first?.question.split("\n")[0] || t("status.awaitingAnswer");
   }
+  if (item.file.rateLimit) return t("status.rateLimited");
   const w = item.file.waitingInput;
   if (w) return w.menu?.question.split("\n")[0] || w.screenTail || t("status.awaitingTerminal");
   return t("status.stalled");
@@ -299,7 +300,7 @@ export function Viewer() {
     const ids = files
       .map((file) => ({
         file,
-        id: file.pendingQuestion || file.waitingInput ? attentionId(file) : null,
+        id: file.pendingQuestion || file.rateLimit || file.waitingInput ? attentionId(file) : null,
       }))
       .filter((item): item is { file: FileEntry; id: string } => item.id !== null);
     if (seenQuestionsRef.current === null) {

--- a/src/components/attention.test.ts
+++ b/src/components/attention.test.ts
@@ -60,6 +60,20 @@ describe("attentionId", () => {
     expect(attentionId(entry({ path: "/live", activity: "live" }), NOW)).toBeNull();
   });
 
+  test("a rate-limited live conversation enters hard-blocked attention", () => {
+    const limited = entry({
+      path: "/limited",
+      activity: "live",
+      proc: "running",
+      rateLimit: { source: "pane", accountId: "main", window: "session", resetAt: NOW + 900 },
+    });
+
+    expect(attentionId(limited, NOW)).toBe(`/limited:rate-limited:${NOW + 900}`);
+    expect(buildAttentionQueue([limited], NOW)).toMatchObject([
+      { file: { path: "/limited" }, tier: "blocked", since: limited.mtime },
+    ]);
+  });
+
   /* The toast seen-set and push-sent.json entries carry ids in the historical
      inline format; the shared helper must reproduce it byte for byte. */
   test("id strings are byte-identical to the historical inline derivation", () => {

--- a/src/components/attention.test.ts
+++ b/src/components/attention.test.ts
@@ -44,14 +44,22 @@ function waiting(since: number): WaitingInput {
 }
 
 describe("attentionId", () => {
-  test("precedence: question > waiting > stalled > null", () => {
+  test("precedence: question > rate limit > waiting > stalled > null", () => {
     const both = entry({
       path: "/q",
       activity: "stalled",
       pendingQuestion: question("toolu_1", NOW - 10),
+      rateLimit: { source: "pane", accountId: null, window: null, resetAt: NOW + 60 },
       waitingInput: waiting(NOW - 20),
     });
     expect(attentionId(both, NOW)).toBe("toolu_1");
+    const limited = entry({
+      path: "/limited",
+      activity: "stalled",
+      rateLimit: { source: "pane", accountId: null, window: null, resetAt: NOW + 60 },
+      waitingInput: waiting(NOW - 20),
+    });
+    expect(attentionId(limited, NOW)).toBe(`/limited:rate-limited:${NOW + 60}`);
     const wait = entry({ path: "/w", activity: "stalled", waitingInput: waiting(NOW - 20) });
     expect(attentionId(wait, NOW)).toBe(`/w:waiting:${NOW - 20}`);
     const stalled = entry({ path: "/s", activity: "stalled", proc: "running", mtime: NOW - 300 });

--- a/src/components/attention.ts
+++ b/src/components/attention.ts
@@ -63,6 +63,9 @@ function isoSeconds(iso: string): number | null {
  */
 export function attentionId(file: FileEntry, now: number = Date.now() / 1000): string | null {
   if (file.pendingQuestion) return file.pendingQuestion.toolUseId;
+  if (file.rateLimit) {
+    return `${file.path}:rate-limited:${file.rateLimit.resetAt ?? "unknown"}`;
+  }
   if (file.waitingInput) return `${file.path}:waiting:${Math.floor(file.waitingInput.since)}`;
   /* The stalled tier needs a live process behind the transcript: an open turn
      whose agent already exited is an abandoned session, not a pending
@@ -89,9 +92,11 @@ export function buildAttentionQueue(
     if (project !== undefined && projectKey(file) !== project) continue;
     const id = attentionId(file, now);
     if (id === null) continue;
-    const tier: AttentionTier = file.pendingQuestion || file.waitingInput ? "blocked" : "stalled";
+    const tier: AttentionTier = file.pendingQuestion || file.rateLimit || file.waitingInput ? "blocked" : "stalled";
     const since = file.pendingQuestion
       ? (isoSeconds(file.pendingQuestion.askedAt) ?? file.mtime)
+      : file.rateLimit
+        ? file.mtime
       : file.waitingInput
         ? file.waitingInput.since
         : file.mtime;

--- a/src/components/attention.ts
+++ b/src/components/attention.ts
@@ -3,8 +3,8 @@ import type { FileEntry } from "@/lib/types";
 import { projectKey } from "./projectModel";
 
 /**
- * The attention queue: which agents are blocked on the user right now, oldest
- * wait first. Pure derived state over the polled file list — every surface
+ * The attention queue: which agents need operator attention right now, oldest
+ * signal first. Pure derived state over the polled file list — every surface
  * (badge, popover, title, N-cycle, push/toast seen-sets) derives identity from
  * the one `attentionId` helper here so counts and dedupe keys cannot drift.
  */
@@ -13,7 +13,7 @@ import { projectKey } from "./projectModel";
  * Attention severity tiers, highest first:
  * - «unowned» — a hosted approval with no attached owner (a first-class alarm,
  *   issue #25 R10-5); always sorts to the queue head.
- * - «blocked» — a hard structured question/prompt.
+ * - «blocked» — a hard question, prompt, or rate-limit wall.
  * - «heuristic» — a low-confidence "possibly waiting" signal (turn-ended +
  *   idle + nothing pending); visually distinct, ranks below hard blocks.
  * - «stalled» — an interrupted agent (FIFO tail segment).
@@ -55,8 +55,8 @@ function isoSeconds(iso: string): number | null {
 
 /**
  * The shared attention identity of a file, by signal precedence:
- * a structured question wins over the screen-scrape fallback, which wins over
- * the stalled state; anything else is not in the queue. The id doubles as the
+ * a structured question wins, followed by a rate-limit wall, the screen-scrape
+ * fallback, and the stalled state. The id doubles as the
  * dedupe key of the toast and push pipelines, so the formats here must stay
  * byte-identical to the historical inline derivations (`push-sent.json`
  * entries survive the refactor).
@@ -77,8 +77,8 @@ export function attentionId(file: FileEntry, now: number = Date.now() / 1000): s
 }
 
 /**
- * Ordered queue of everyone blocked on the user: hard-blocked segment first,
- * stalled tail after, oldest wait first inside each segment, id as the
+ * Ordered queue of every agent needing operator attention: hard-blocked segment
+ * first, stalled tail after, oldest signal first inside each segment, id as the
  * tie-breaker. The sort keys are frozen at enqueue (`since` never moves while
  * the id is unchanged), so polls cannot reshuffle the order.
  */

--- a/src/components/flows/FlowHub.tsx
+++ b/src/components/flows/FlowHub.tsx
@@ -9,7 +9,7 @@ import { useLocale } from "@/lib/i18n";
 import { useRuntimeFlow } from "@/hooks/useRuntime";
 import { currentRound, flowLinkPhase, type FlowLinkPhase } from "@/components/scheme/agentLinks";
 
-import { patchFlow, PENDING_ACTIONS, stateLabel } from "./flowModel";
+import { flowPresentation, patchFlow } from "./flowModel";
 
 /* Hub tone per link phase: work in accent, waiting-on-you in amber, done in
    verdict green, idle gray — the palette the strip and verdict chips use. */
@@ -45,9 +45,10 @@ export function FlowHub({
   /** Matches the board's layout-glide transition. */
   moveTransition: string;
 }) {
-  const { t } = useLocale();
+  const { locale, t } = useLocale();
   /* Event-driven progression wins over the poll, same as the strip. */
-  const flow = useRuntimeFlow(polledFlow.id) ?? polledFlow;
+  const runtimeFlow = useRuntimeFlow(polledFlow.id);
+  const flow = runtimeFlow ? { ...runtimeFlow, block: polledFlow.block } : polledFlow;
   const [open, setOpen] = useState(false);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -55,9 +56,10 @@ export function FlowHub({
   const phase = flowLinkPhase(flow.state);
   const tone = PHASE_TONE[phase];
   const round = currentRound(flow)?.n ?? 0;
-  const state = stateLabel(t, flow.state);
+  const presentation = flowPresentation(t, flow, locale);
+  const state = presentation.label;
   const label = round > 0 ? t("flowHub.aria", { n: round, state }) : t("flowHub.ariaNoRound", { state });
-  const pending = PENDING_ACTIONS[flow.state];
+  const pending = presentation.pending;
   const closed = flow.state === "closed" || flow.state === "approved";
 
   const run = async (action: FlowAction) => {
@@ -103,9 +105,9 @@ export function FlowHub({
           <span className="flex min-w-0 items-center gap-1.5">
             <span className="h-2 w-2 shrink-0 rounded-full" style={{ backgroundColor: tone }} aria-hidden />
             <span className="shrink-0 text-[11.5px] font-bold">{state}</span>
-            {flow.stateDetail ? (
-              <span className="min-w-0 truncate text-[10.5px] font-semibold text-dim" title={flow.stateDetail}>
-                {flow.stateDetail}
+            {presentation.detail ? (
+              <span className="min-w-0 truncate text-[10.5px] font-semibold text-dim" title={presentation.detail}>
+                {presentation.detail}
               </span>
             ) : null}
             {busy ? <RefreshCw className="ml-auto h-3 w-3 shrink-0 animate-spin text-dim" aria-hidden /> : null}

--- a/src/components/flows/FlowStrip.tsx
+++ b/src/components/flows/FlowStrip.tsx
@@ -10,7 +10,7 @@ import type { Flow, FlowAction } from "@/lib/flows/types";
 import { Hint } from "@/components/Hint";
 import { useRuntimeFlow } from "@/hooks/useRuntime";
 
-import { ATTENTION_STATES, patchFlow, PENDING_ACTIONS, stateLabel, verdictTone } from "./flowModel";
+import { flowPresentation, patchFlow, verdictTone } from "./flowModel";
 import { RoundStateIcon } from "./RoundIcons";
 
 const BUSY_STATES: ReadonlySet<Flow["state"]> = new Set(["spawning", "reviewing", "relaying", "fixing"]);
@@ -19,6 +19,7 @@ const BUSY_STATES: ReadonlySet<Flow["state"]> = new Set(["spawning", "reviewing"
 const LIMIT_STOPS = [1, 2, 3, 4, 5, 0];
 
 function stateDot(flow: Flow): string {
+  if (flow.block) return "bg-err";
   if (flow.state === "approved") return "bg-ok";
   if (flow.state === "needs_decision") return "bg-err";
   if (flow.state === "paused") return "bg-[#e0ae45]";
@@ -33,10 +34,11 @@ function stateDot(flow: Flow): string {
  * refresh carries the resulting state back.
  */
 export function FlowStrip({ flow: polledFlow, onFocusRound }: { flow: Flow; onFocusRound?: (n: number) => void }) {
-  const { t } = useLocale();
+  const { locale, t } = useLocale();
   /* Event-driven progression wins over the poll: if the runtime bus carries
      this flow, its state is fresher than the last /api/files snapshot. */
-  const flow = useRuntimeFlow(polledFlow.id) ?? polledFlow;
+  const runtimeFlow = useRuntimeFlow(polledFlow.id);
+  const flow = runtimeFlow ? { ...runtimeFlow, block: polledFlow.block } : polledFlow;
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [note, setNote] = useState("");
@@ -51,11 +53,12 @@ export function FlowStrip({ flow: polledFlow, onFocusRound }: { flow: Flow; onFo
     setBusy(false);
   };
 
-  const pending = PENDING_ACTIONS[flow.state];
-  const attention = ATTENTION_STATES.has(flow.state);
+  const presentation = flowPresentation(t, flow, locale);
+  const pending = presentation.pending;
+  const attention = presentation.attention;
   const closed = flow.state === "closed" || flow.state === "approved";
   /* The note rides along with the action that starts the next round. */
-  const noteTakingAction = flow.state === "waiting_ready" || flow.state === "needs_decision";
+  const noteTakingAction = Boolean(pending) && (flow.state === "waiting_ready" || flow.state === "needs_decision");
 
   return (
     <div
@@ -68,10 +71,10 @@ export function FlowStrip({ flow: polledFlow, onFocusRound }: { flow: Flow; onFo
       <span className="flex min-w-0 max-w-[38%] shrink-0 items-center gap-2">
         <span className={`h-2.5 w-2.5 shrink-0 rounded-full ${stateDot(flow)}`} aria-hidden />
         <span className="shrink-0 text-[10.5px] font-bold tracking-[0.08em] text-dim">{t("flowStrip.flow")}</span>
-        <span className="shrink-0 text-[12px] font-bold">{stateLabel(t, flow.state)}</span>
-        {flow.stateDetail ? (
-          <span className="min-w-0 truncate text-[11.5px] font-semibold text-dim" title={flow.stateDetail}>
-            {flow.stateDetail}
+        <span className="shrink-0 text-[12px] font-bold">{presentation.label}</span>
+        {presentation.detail ? (
+          <span className="min-w-0 truncate text-[11.5px] font-semibold text-dim" title={presentation.detail}>
+            {presentation.detail}
           </span>
         ) : null}
       </span>

--- a/src/components/flows/flowModel.test.ts
+++ b/src/components/flows/flowModel.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, test } from "bun:test";
 import type { Flow } from "@/lib/flows/types";
 import type { FileEntry } from "@/lib/types";
 
-import { claimedReviewerDescendantPaths, foldClaimedReviewers, isActiveFlow } from "./flowModel";
+import { claimedReviewerDescendantPaths, flowPresentation, foldClaimedReviewers, isActiveFlow } from "./flowModel";
 
 function entry(overrides: Partial<FileEntry> & { path: string }): FileEntry {
   return {
@@ -100,5 +100,27 @@ describe("reviewer folding", () => {
     expect(claimedReviewerDescendantPaths(files, active).size).toBe(0);
     // …but folding still consumes the full list, so the reviewer is re-homed.
     expect(foldClaimedReviewers(files, [closed]).map((file) => file.path)).toEqual(["/implementer", "/subtask"]);
+  });
+});
+
+test("a quota-blocked flow presents the transient block and suppresses its pending action", () => {
+  const limited = flow({
+    implementerPath: "/implementer",
+    reviewerPath: "/reviewer",
+    state: "waiting_ready",
+    block: {
+      reason: "rate_limited",
+      conversationId: "conversation_impl",
+      accountId: "main",
+      resetAt: 1_800_003_300,
+    },
+  });
+  const t = (key: string) => key;
+
+  expect(flowPresentation(t as never, limited, "en")).toEqual({
+    label: "flowState.blocked_rate_limited",
+    detail: "flowState.rate_limit_until",
+    attention: true,
+    pending: null,
   });
 });

--- a/src/components/flows/flowModel.ts
+++ b/src/components/flows/flowModel.ts
@@ -1,10 +1,11 @@
 import { useMemo, useSyncExternalStore } from "react";
 
-import { getLocale, type MessageKey, type TFunction, translate } from "@/lib/i18n";
+import { getLocale, type Locale, type MessageKey, type TFunction, translate } from "@/lib/i18n";
 import type { Flow, FlowAction, FlowRoleKey, FlowState, ReviewVerdict } from "@/lib/flows/types";
 import type { FileEntry } from "@/lib/types";
 
 import { isConversation } from "@/components/projectModel";
+import { formatRateLimitTime } from "@/components/rateLimit";
 
 /** Fired after any successful flow PATCH so pollers refresh immediately. */
 export const FLOWS_CHANGED_EVENT = "llv:flows-changed";
@@ -177,8 +178,28 @@ export const PENDING_ACTIONS: Partial<Record<FlowState, { labelKey: MessageKey; 
   done_comment: { labelKey: "flowStrip.anotherRound", action: "another-round" },
 };
 
+export function flowPresentation(t: TFunction, flow: Flow, locale: Locale) {
+  if (flow.block?.reason === "rate_limited") {
+    return {
+      label: t("flowState.blocked_rate_limited"),
+      detail: flow.block.resetAt
+        ? t("flowState.rate_limit_until", { time: formatRateLimitTime(flow.block.resetAt, locale) })
+        : t("flowState.rate_limit_wait"),
+      attention: true,
+      pending: null,
+    };
+  }
+  return {
+    label: stateLabel(t, flow.state),
+    detail: flow.stateDetail,
+    attention: ATTENTION_STATES.has(flow.state),
+    pending: PENDING_ACTIONS[flow.state] ?? null,
+  };
+}
+
 /** The loop side working right now — drives the role tags on the scheme. */
 export function activeLoopRole(flow: Flow): FlowRoleKey | null {
+  if (flow.block) return null;
   if (flow.state === "spawning" || flow.state === "reviewing") return "reviewer";
   if (flow.state === "waiting_ready" || flow.state === "relaying" || flow.state === "fixing") return "implementer";
   return null;
@@ -186,6 +207,7 @@ export function activeLoopRole(flow: Flow): FlowRoleKey | null {
 
 /** The cycle leg traffic is on: forward = implementer → reviewer. */
 export function activeLoopLeg(flow: Flow): "forward" | "back" | null {
+  if (flow.block) return null;
   if (flow.state === "spawn_pending" || flow.state === "spawning" || flow.state === "reviewing") return "forward";
   if (flow.state === "relay_pending" || flow.state === "relaying" || flow.state === "fixing") return "back";
   if (flow.state === "waiting_ready") return flow.rounds.length ? "back" : null;

--- a/src/components/paneState.ts
+++ b/src/components/paneState.ts
@@ -16,7 +16,7 @@ import { isChildConversation } from "./projectModel";
 export type PaneState = "live" | "waiting" | "returned" | "stalled" | "done";
 
 export function paneState(file: FileEntry, now = Date.now() / 1000): PaneState {
-  if (file.pendingQuestion || file.waitingInput) return "waiting";
+  if (file.pendingQuestion || file.rateLimit || file.waitingInput) return "waiting";
   if (file.activity === "live") return "live";
   if (file.activity === "recent" && isChildConversation(file) && file.proc !== "running") return "returned";
   if (isAwaitingUser(file, now)) return file.activity === "stalled" ? "stalled" : "waiting";

--- a/src/components/rateLimit.ts
+++ b/src/components/rateLimit.ts
@@ -1,0 +1,16 @@
+import type { TFunction, Locale } from "@/lib/i18n";
+import type { RateLimitState } from "@/lib/types";
+
+export function formatRateLimitTime(resetAt: number, locale: Locale): string {
+  return new Date(resetAt * 1000).toLocaleTimeString(locale === "uk" ? "uk-UA" : "en-US", {
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+  });
+}
+
+export function rateLimitText(t: TFunction, locale: Locale, rateLimit: Pick<RateLimitState, "resetAt">): string {
+  return rateLimit.resetAt
+    ? t("rateLimit.badgeUntil", { time: formatRateLimitTime(rateLimit.resetAt, locale) })
+    : t("rateLimit.badge");
+}

--- a/src/components/scheme/nodes.tsx
+++ b/src/components/scheme/nodes.tsx
@@ -19,6 +19,7 @@ import { FlowHub } from "@/components/flows/FlowHub";
 import { PipelineHub } from "@/components/pipelines/PipelineHub";
 import { FlowStrip } from "@/components/flows/FlowStrip";
 import { RoleTag } from "@/components/flows/RoleTag";
+import { RateLimitBadge } from "@/components/RateLimitBadge";
 import { RoundDeck } from "@/components/flows/RoundDeck";
 import { RoundStateIcon } from "@/components/flows/RoundIcons";
 import { canHandoff, HandoffHandle } from "@/components/HandoffHandle";
@@ -258,6 +259,7 @@ function FarLabel({ file }: { file: FileEntry }) {
         <span className="shrink-0 rounded-full px-[0.45em] font-bold" style={{ ...badge.style, fontSize: "0.72em" }}>
           {badge.label}
         </span>
+        <RateLimitBadge rateLimit={file.rateLimit} />
         <span className="line-clamp-2 min-w-0 font-bold">{cleanTitle(file.title, 70)}</span>
       </div>
     </div>
@@ -312,6 +314,7 @@ function LiteNodeShell({ node, ringed, dimmed, flow }: { node: SchemeNode; ringe
             {badge.label}
           </span>
           {node.file.model ? <span className="min-w-0 truncate font-mono text-[11px] text-dim">{node.file.model}</span> : null}
+          <RateLimitBadge rateLimit={node.file.rateLimit} />
           <span className="ml-auto shrink-0 text-[11px] text-dim">{fmtAge(node.file.mtime)}</span>
         </div>
         <div className="min-w-0 flex-1 px-3 py-2.5 text-[14px] font-semibold leading-snug">

--- a/src/hooks/useSwitchboardData.ts
+++ b/src/hooks/useSwitchboardData.ts
@@ -8,7 +8,7 @@ import type { ActionEvent, FileEntry } from "@/lib/types";
 import { cleanTitle } from "@/lib/title";
 
 import { attentionId } from "@/components/attention";
-import { ATTENTION_STATES, claimedReviewerPaths, flowByImplementer, stateLabel } from "@/components/flows/flowModel";
+import { claimedReviewerPaths, flowByImplementer, flowPresentation } from "@/components/flows/flowModel";
 import { descendantCounts, isAuxTask, isConversation, isSubagent, projectKey } from "@/components/projectModel";
 import { fmtAge } from "@/components/utils";
 
@@ -41,6 +41,7 @@ function recentBucketSort(a: SwitchboardItem, b: SwitchboardItem): number {
 
 function timelineLabel(t: TFunction, file: FileEntry, latestByFile: ReadonlyMap<string, ActionEvent>): string {
   if (file.pendingQuestion) return file.pendingQuestion.kind === "plan" ? t("status.awaitingPlan") : t("status.awaitingAnswer");
+  if (file.rateLimit) return t("status.rateLimited");
   if (file.waitingInput) return t("status.awaitingTerminal");
   /* A live agent's own plan step names its current goal better than the last
      timeline event does. */
@@ -61,7 +62,7 @@ function isReturnedSubagent(file: FileEntry): boolean {
 }
 
 export function isAwaitingUser(file: FileEntry, now = Date.now() / 1000): boolean {
-  if (file.pendingQuestion || file.waitingInput) return true;
+  if (file.pendingQuestion || file.rateLimit || file.waitingInput) return true;
   /* An interrupted session stops being "yours to answer" after a while: a
      permission prompt from two days ago is dead context, so old stalled
      entries sink into the recency buckets instead of inflating the waiting
@@ -109,7 +110,7 @@ export function useSwitchboardData(
         const age = now - file.mtime;
         const flow = flowByImpl.get(file.path);
         let kind: SwitchboardCardKind =
-          file.pendingQuestion || file.waitingInput
+          file.pendingQuestion || file.rateLimit || file.waitingInput
             ? "waiting"
             : file.activity === "live"
             ? "working"
@@ -120,9 +121,10 @@ export function useSwitchboardData(
                 : "older";
         let statusLine = timelineLabel(t, file, latestByFile);
         if (flow) {
-          if (ATTENTION_STATES.has(flow.state)) kind = "waiting";
+          const presentation = flowPresentation(t, flow, locale);
+          if (presentation.attention) kind = "waiting";
           else if (flow.state === "reviewing" || flow.state === "relaying" || flow.state === "spawning") kind = "working";
-          statusLine = `${t("status.flow", { label: stateLabel(t, flow.state) })}${flow.stateDetail ? ` — ${flow.stateDetail}` : ""}`;
+          statusLine = `${t("status.flow", { label: presentation.label })}${presentation.detail ? ` — ${presentation.detail}` : ""}`;
         }
         return {
           file,

--- a/src/lib/accounts/migration/quotaController.test.ts
+++ b/src/lib/accounts/migration/quotaController.test.ts
@@ -8,25 +8,52 @@ import type { CodexAccount } from "@/lib/accounts/codex";
 
 import { QuotaController, type QuotaProbePort } from "./quotaController";
 
-test("durable per-engine policy is the quota evaluation guard", async () => {
+test("quota visibility remains fresh when automatic balancing is disabled", async () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "llv-quota-controller-"));
   try {
     const registry = new AgentRegistry(path.join(root, "registry.json"));
     let listed = 0;
+    let current = Date.parse("2026-07-10T12:00:00.000Z");
+    const accounts: CodexAccount[] = [
+      { id: "default", label: "Main", kind: "legacy", home: "/homes/main", sessionsDir: "/homes/main/sessions", authPresent: true, loginPane: null, createdAt: 0 },
+      { id: "managed", label: "Managed", kind: "managed", home: "/homes/managed", sessionsDir: "/homes/managed/sessions", authPresent: true, loginPane: null, createdAt: 1 },
+    ];
     const probe: QuotaProbePort = {
-      list() { listed += 1; return []; },
+      list() { listed += 1; return accounts; },
       active() { return "default"; },
-      async probe() { throw new Error("no account should be probed"); },
+      async probe(engine, candidate, now) {
+        return {
+          engine,
+          accountId: candidate.id,
+          authenticated: true,
+          authCheckedAt: now,
+          limits: {
+            session: { usedPercent: candidate.id === "default" ? 100 : 10, resetsAt: Math.floor(now / 1000) + 3_600 },
+            weekly: null,
+            plan: "pro",
+            capturedAt: Math.floor(now / 1000),
+          },
+          provenance: { source: "live", reason: null, staleSince: null },
+          observedAt: now,
+        };
+      },
     };
-    const controller = new QuotaController(registry, probe, "00000000-0000-4000-8000-000000000000", () => Date.parse("2026-07-10T12:00:00.000Z"));
+    const controller = new QuotaController(registry, probe, "00000000-0000-4000-8000-000000000000", () => current);
 
     registry.setAutoBalancePolicy("codex", false);
     await controller.tick("codex");
-    expect(listed).toBe(0);
-
-    registry.setAutoBalancePolicy("codex", true);
+    current += 60_000;
     await controller.tick("codex");
-    expect(listed).toBe(1);
+    expect(listed).toBe(2);
+    expect(registry.snapshot().quotaObservations.codex.default).toMatchObject({
+      authenticated: true,
+      limits: { session: { usedPercent: 100 } },
+    });
+    expect(registry.snapshot().quotaObservations.codex.managed).toMatchObject({
+      authenticated: true,
+      limits: { session: { usedPercent: 10 } },
+    });
+    expect(Object.values(registry.snapshot().migrationIntents)).toHaveLength(0);
   } finally {
     fs.rmSync(root, { recursive: true, force: true });
   }

--- a/src/lib/accounts/migration/quotaController.ts
+++ b/src/lib/accounts/migration/quotaController.ts
@@ -92,7 +92,6 @@ export class QuotaController {
   ) {}
 
   async tick(engine: MigrationEngine): Promise<void> {
-    if (!this.registry.autoBalancePolicy(engine).enabled) return;
     const now = this.now();
     const accounts = this.probe.list(engine);
     const observations = await mapLimit(accounts, 2, async (account) => {

--- a/src/lib/flows/types.ts
+++ b/src/lib/flows/types.ts
@@ -30,6 +30,15 @@ export type FlowState =
 
 export type ReviewVerdict = "APPROVE" | "REQUEST_CHANGES" | "COMMENT";
 
+export type FlowBlock = {
+  reason: "rate_limited";
+  /** Stable address for a future continue-on-account action. */
+  conversationId: string | null;
+  /** Exhausted account. A successor action can exclude it from targets. */
+  accountId: string | null;
+  resetAt: number | null;
+};
+
 export type Round = {
   n: number; // 1-based
   reviewerPath: string | null; // reviewer run's transcript path once known
@@ -82,6 +91,8 @@ export type Flow = {
   pausedState?: FlowState | null;
   /** Human-readable reason shown on the strip for needs_decision/paused. */
   stateDetail: string | null;
+  /** Ephemeral read-model block derived from the attached implementer. */
+  block?: FlowBlock | null;
   rounds: Round[];
   createdAt: string;
   closedAt: string | null;

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -586,6 +586,9 @@ export const en = {
   "flowState.needs_decision": "needs a decision",
   "flowState.paused": "paused",
   "flowState.closed": "closed",
+  "flowState.blocked_rate_limited": "blocked: rate-limited",
+  "flowState.rate_limit_until": "resets at {time}",
+  "flowState.rate_limit_wait": "waiting for the quota reset",
   "flowModel.failed": "failed ({status})",
 
   "wfState.provisioning": "provisioning the worktree",
@@ -771,7 +774,10 @@ export const en = {
   "status.returnedResult": "returned with a result",
   "status.stalled": "interrupted or awaiting permission",
   "status.finishedTurn": "finished the turn — waiting for a reply",
+  "status.rateLimited": "rate-limited",
   "status.flow": "flow: {label}",
+  "rateLimit.badge": "rate-limited",
+  "rateLimit.badgeUntil": "rate-limited until {time}",
 
   // useDictation errors
   "dictation.capWarn": "less than a minute of recording left",

--- a/src/lib/i18n/uk.ts
+++ b/src/lib/i18n/uk.ts
@@ -559,6 +559,9 @@ export const uk: Record<keyof typeof en, Message> = {
   "flowState.needs_decision": "потребує рішення",
   "flowState.paused": "пауза",
   "flowState.closed": "закрито",
+  "flowState.blocked_rate_limited": "заблоковано: вичерпано ліміт",
+  "flowState.rate_limit_until": "скинеться о {time}",
+  "flowState.rate_limit_wait": "чекає на скидання ліміту",
   "flowModel.failed": "не вдалося ({status})",
 
   "wfState.provisioning": "готую worktree",
@@ -739,7 +742,10 @@ export const uk: Record<keyof typeof en, Message> = {
   "status.returnedResult": "повернувся з результатом",
   "status.stalled": "перервано або чекає дозволу",
   "status.finishedTurn": "закінчив хід — чекає відповіді",
+  "status.rateLimited": "вичерпано ліміт",
   "status.flow": "флоу: {label}",
+  "rateLimit.badge": "вичерпано ліміт",
+  "rateLimit.badgeUntil": "ліміт до {time}",
 
   "dictation.capWarn": "залишилось менше хвилини запису",
   "dictation.capStopped": "Запис зупинено на 10-хвилинній межі; текст зʼявиться в полі.",

--- a/src/lib/rateLimit.test.ts
+++ b/src/lib/rateLimit.test.ts
@@ -1,0 +1,161 @@
+import { expect, test } from "bun:test";
+
+import type { Flow } from "@/lib/flows/types";
+import type { FileEntry } from "@/lib/types";
+
+import { projectRateLimitReadModel, rateLimitFromQuotaObservation } from "./rateLimit";
+
+const NOW = new Date("2026-07-10T16:00:00.000Z").getTime();
+const RESET = Math.floor(NOW / 1000) + 7_200;
+
+function entry(overrides: Partial<FileEntry> = {}): FileEntry {
+  return {
+    path: "/sessions/implementer.jsonl",
+    root: "codex-sessions",
+    name: "implementer.jsonl",
+    project: "demo",
+    title: "Implementer",
+    engine: "codex",
+    kind: "session",
+    fmt: "codex",
+    parent: null,
+    mtime: NOW / 1000 - 60,
+    size: 10,
+    activity: "live",
+    proc: "running",
+    pid: 42,
+    model: "gpt-5.6",
+    pendingQuestion: null,
+    waitingInput: null,
+    ...overrides,
+  };
+}
+
+function flow(): Flow {
+  const role = { engine: "codex" as const, model: null, effort: null };
+  return {
+    id: "flow-1",
+    template: "implement-review-loop",
+    project: "demo",
+    cwd: "/repo",
+    implementerPath: "/sessions/implementer.jsonl",
+    implementerConversationId: "conversation_impl",
+    roles: { implementer: role, reviewer: role },
+    baseRef: "abc",
+    baseMode: "head",
+    mode: "auto",
+    reviewerMode: "headless",
+    roundLimit: 5,
+    state: "waiting_ready",
+    stateDetail: null,
+    rounds: [],
+    createdAt: "2026-07-10T15:00:00.000Z",
+    closedAt: null,
+  };
+}
+
+function observation(usedPercent: number, observedAt = NOW) {
+  const iso = new Date(observedAt).toISOString();
+  return {
+    engine: "codex" as const,
+    accountId: "main",
+    authenticated: true,
+    authCheckedAt: iso,
+    limits: {
+      session: { usedPercent, resetsAt: RESET },
+      weekly: { usedPercent: 35, resetsAt: RESET + 86_400 },
+      plan: "pro",
+      capturedAt: Math.floor(observedAt / 1000),
+    },
+    provenance: { source: "live" as const, reason: null, staleSince: null },
+    observedAt: iso,
+    bootId: "boot-1",
+  };
+}
+
+test("fresh exhausted account limits become a structured rate-limit signal", () => {
+  expect(rateLimitFromQuotaObservation(observation(100), NOW)).toEqual({
+    source: "account",
+    accountId: "main",
+    window: "session",
+    resetAt: RESET,
+  });
+  expect(rateLimitFromQuotaObservation(observation(99), NOW)).toBeNull();
+  expect(rateLimitFromQuotaObservation(observation(100, NOW - 10 * 60_000), NOW)).toBeNull();
+  expect(rateLimitFromQuotaObservation({
+    ...observation(100),
+    limits: {
+      ...observation(100).limits,
+      session: { usedPercent: 100, resetsAt: Math.floor(NOW / 1000) - 1 },
+    },
+  }, NOW)).toBeNull();
+});
+
+test("reviewer-side flow work keeps its own state while the implementer account is exhausted", () => {
+  const reviewing = { ...flow(), state: "reviewing" as const };
+  const snapshot = {
+    conversations: {
+      conversation_impl: {
+        id: "conversation_impl",
+        engine: "codex" as const,
+        generations: [{ path: "/sessions/implementer.jsonl", accountId: "main" }],
+      },
+    },
+    quotaObservations: { claude: {}, codex: { main: observation(100) } },
+  };
+
+  expect(projectRateLimitReadModel([entry()], [reviewing], snapshot, NOW).flows[0]?.block).toBeUndefined();
+});
+
+test("the files read model joins account exhaustion to a live conversation and its flow", () => {
+  const snapshot = {
+    conversations: {
+      conversation_impl: {
+        id: "conversation_impl",
+        engine: "codex" as const,
+        generations: [{ path: "/sessions/implementer.jsonl", accountId: "main" }],
+      },
+    },
+    quotaObservations: { claude: {}, codex: { main: observation(100) } },
+  };
+
+  const projected = projectRateLimitReadModel([entry()], [flow()], snapshot, NOW);
+
+  expect(projected.files[0]?.rateLimit).toEqual({
+    source: "account",
+    accountId: "main",
+    window: "session",
+    resetAt: RESET,
+  });
+  expect(projected.flows[0]?.block).toEqual({
+    reason: "rate_limited",
+    conversationId: "conversation_impl",
+    accountId: "main",
+    resetAt: RESET,
+  });
+});
+
+test("a pane signal wins and receives the structured reset time", () => {
+  const file = entry({
+    rateLimit: { source: "pane", accountId: null, window: null, resetAt: null },
+  });
+  const snapshot = {
+    conversations: {
+      conversation_impl: {
+        id: "conversation_impl",
+        engine: "codex" as const,
+        generations: [{ path: file.path, accountId: "main" }],
+      },
+    },
+    quotaObservations: { claude: {}, codex: { main: observation(100) } },
+  };
+
+  const projected = projectRateLimitReadModel([file], [flow()], snapshot, NOW);
+
+  expect(projected.files[0]?.rateLimit).toEqual({
+    source: "pane",
+    accountId: "main",
+    window: "session",
+    resetAt: RESET,
+  });
+});

--- a/src/lib/rateLimit.test.ts
+++ b/src/lib/rateLimit.test.ts
@@ -91,6 +91,22 @@ test("fresh exhausted account limits become a structured rate-limit signal", () 
   }, NOW)).toBeNull();
 });
 
+test("an unknown exhausted-window reset suppresses a misleading badge time", () => {
+  const limited = observation(100);
+  expect(rateLimitFromQuotaObservation({
+    ...limited,
+    limits: {
+      ...limited.limits,
+      weekly: { usedPercent: 100, resetsAt: null },
+    },
+  }, NOW)).toMatchObject({
+    source: "account",
+    accountId: "main",
+    window: "weekly",
+    resetAt: null,
+  });
+});
+
 test("reviewer-side flow work keeps its own state while the implementer account is exhausted", () => {
   const reviewing = { ...flow(), state: "reviewing" as const };
   const snapshot = {

--- a/src/lib/rateLimit.ts
+++ b/src/lib/rateLimit.ts
@@ -1,0 +1,122 @@
+import type { DurableQuotaObservation } from "@/lib/accounts/migration/contracts";
+import { effectiveRemaining } from "@/lib/accounts/migration/quotaPolicy";
+import type { Flow } from "@/lib/flows/types";
+import type { Engine, FileEntry, RateLimitState } from "@/lib/types";
+
+type HostedEngine = Extract<Engine, "claude" | "codex">;
+
+export interface RateLimitProjectionSnapshot {
+  conversations: Record<string, {
+    id: string;
+    engine: HostedEngine;
+    generations: Array<{ path: string; accountId: string | null }>;
+  }>;
+  quotaObservations: Record<HostedEngine, Record<string, DurableQuotaObservation>>;
+}
+
+export function rateLimitFromQuotaObservation(
+  observation: DurableQuotaObservation | undefined,
+  now = Date.now(),
+): RateLimitState | null {
+  if (!observation) return null;
+  const observedAt = Date.parse(observation.observedAt);
+  const authCheckedAt = Date.parse(observation.authCheckedAt);
+  const remaining = effectiveRemaining({
+    engine: observation.engine,
+    accountId: observation.accountId,
+    authenticated: observation.authenticated,
+    limits: observation.limits,
+    provenance: observation.provenance,
+    observedAt,
+    authCheckedAt,
+  }, now);
+  if (remaining?.percent !== 0 || !observation.limits) return null;
+
+  const exhausted = (["session", "weekly"] as const).flatMap((window) => {
+    const value = observation.limits?.[window];
+    return value && value.usedPercent >= 100 ? [{ window, resetAt: value.resetsAt }] : [];
+  });
+  if (!exhausted.length) return null;
+  const activeExhausted = exhausted.filter((item) => item.resetAt === null || item.resetAt * 1000 > now);
+  if (!activeExhausted.length) return null;
+  const governing = activeExhausted
+    .filter((item) => item.resetAt !== null && item.resetAt * 1000 > now)
+    .sort((left, right) => right.resetAt! - left.resetAt!)[0]
+    ?? activeExhausted.find((item) => item.window === remaining.window)
+    ?? activeExhausted[0]!;
+  return {
+    source: "account",
+    accountId: observation.accountId,
+    window: governing.window,
+    resetAt: governing.resetAt !== null && governing.resetAt * 1000 > now ? governing.resetAt : null,
+  };
+}
+
+function mergeRateLimits(
+  pane: RateLimitState | null | undefined,
+  structured: RateLimitState | null,
+  accountId: string | null,
+): RateLimitState | null {
+  if (!pane) return structured;
+  return {
+    source: "pane",
+    accountId: accountId ?? pane.accountId,
+    window: structured?.window ?? pane.window,
+    resetAt: structured?.resetAt ?? pane.resetAt,
+  };
+}
+
+/** Pure projection over the scanner and registry snapshots. The returned
+    flow block carries the stable conversation seam for successor reseating. */
+export function projectRateLimitReadModel(
+  files: FileEntry[],
+  flows: Flow[],
+  snapshot: RateLimitProjectionSnapshot,
+  now = Date.now(),
+): { files: FileEntry[]; flows: Flow[] } {
+  const hosts = new Map<string, { conversationId: string; engine: HostedEngine; accountId: string | null }>();
+  for (const conversation of Object.values(snapshot.conversations)) {
+    for (const generation of conversation.generations) {
+      hosts.set(generation.path, {
+        conversationId: conversation.id,
+        engine: conversation.engine,
+        accountId: generation.accountId,
+      });
+    }
+  }
+
+  const projectedFiles = files.map((file) => {
+    const host = hosts.get(file.path);
+    const observation = host?.accountId
+      ? snapshot.quotaObservations[host.engine][host.accountId]
+      : undefined;
+    const structured = file.proc === "running"
+      ? rateLimitFromQuotaObservation(observation, now)
+      : null;
+    const rateLimit = mergeRateLimits(file.rateLimit, structured, host?.accountId ?? null);
+    return {
+      ...file,
+      conversationId: file.conversationId ?? host?.conversationId,
+      rateLimit,
+    };
+  });
+  const filesByPath = new Map(projectedFiles.map((file) => [file.path, file]));
+  const implementerStates = new Set<Flow["state"]>(["waiting_ready", "relaying", "fixing"]);
+  const projectedFlows = flows.map((flow) => {
+    const implementer = filesByPath.get(flow.implementerPath);
+    const rateLimit = implementer?.rateLimit;
+    if (!rateLimit || !implementerStates.has(flow.state)) {
+      return flow.block ? { ...flow, block: null } : flow;
+    }
+    return {
+      ...flow,
+      block: {
+        reason: "rate_limited" as const,
+        conversationId: implementer.conversationId ?? flow.implementerConversationId ?? null,
+        accountId: rateLimit.accountId,
+        resetAt: rateLimit.resetAt,
+      },
+    };
+  });
+  return { files: projectedFiles, flows: projectedFlows };
+}

--- a/src/lib/rateLimit.ts
+++ b/src/lib/rateLimit.ts
@@ -39,11 +39,8 @@ export function rateLimitFromQuotaObservation(
   if (!exhausted.length) return null;
   const activeExhausted = exhausted.filter((item) => item.resetAt === null || item.resetAt * 1000 > now);
   if (!activeExhausted.length) return null;
-  const governing = activeExhausted
-    .filter((item) => item.resetAt !== null && item.resetAt * 1000 > now)
-    .sort((left, right) => right.resetAt! - left.resetAt!)[0]
-    ?? activeExhausted.find((item) => item.window === remaining.window)
-    ?? activeExhausted[0]!;
+  const governing = activeExhausted.find((item) => item.resetAt === null)
+    ?? activeExhausted.sort((left, right) => right.resetAt! - left.resetAt!)[0]!;
   return {
     source: "account",
     accountId: observation.accountId,

--- a/src/lib/scanner/index.ts
+++ b/src/lib/scanner/index.ts
@@ -119,6 +119,7 @@ async function listFilesInternal(
     entry.pendingQuestion = pending && entry.pid !== null ? { ...pending, paneTarget: await resolveTarget(entry.pid) } : pending;
     const probe = await waitingInputProbe(entry);
     entry.waitingInput = probe.waiting;
+    entry.rateLimit = probe.rateLimit;
     /* A stalled transcript whose pane sits at a plain composer was interrupted
        mid-turn (Esc leaves the turn open in the jsonl): the agent is idle, not
        blocked, so it must not wear the «interrupted or waiting for permission» state. */

--- a/src/lib/scanner/observe.ts
+++ b/src/lib/scanner/observe.ts
@@ -41,7 +41,7 @@ export async function observeFiles(): Promise<FileEntry[]> {
   await each(entries, async (entry) => {
     const pending = pendingQuestionFor(entry);
     entry.pendingQuestion = pending && entry.pid !== null ? { ...pending, paneTarget: await resolveTarget(entry.pid) } : pending;
-    const probe = await waitingInputProbe(entry); entry.waitingInput = probe.waiting;
+    const probe = await waitingInputProbe(entry); entry.waitingInput = probe.waiting; entry.rateLimit = probe.rateLimit;
     if (probe.atComposer && entry.activity === "stalled") { entry.activity = Date.now() / 1000 - entry.mtime < 900 ? "recent" : "idle"; entry.activityReason = "pane_at_composer"; }
     entry.plan = planFor(entry); entry.goal = goalFor(entry); entry.ctx = ctxFor(entry);
   });

--- a/src/lib/scanner/waitingInput.test.ts
+++ b/src/lib/scanner/waitingInput.test.ts
@@ -1,0 +1,48 @@
+import { expect, test } from "bun:test";
+
+import type { FileEntry } from "@/lib/types";
+
+import { waitingInputProbe } from "./waitingInput";
+
+const NOW = new Date(2026, 6, 10, 18, 0, 0).getTime();
+
+function entry(): FileEntry {
+  return {
+    path: "/sessions/fresh-limit.jsonl",
+    root: "codex-sessions",
+    name: "fresh-limit.jsonl",
+    project: "demo",
+    title: "Fresh limit",
+    engine: "codex",
+    kind: "session",
+    fmt: "codex",
+    parent: null,
+    mtime: NOW / 1000 - 16,
+    size: 10,
+    activity: "live",
+    proc: "running",
+    pid: 42,
+    model: null,
+    pendingQuestion: null,
+    waitingInput: null,
+  };
+}
+
+test("a live usage wall bypasses the stable-screen delay", async () => {
+  const result = await waitingInputProbe(entry(), {
+    now: () => NOW,
+    resolveTarget: async () => "agents:3.0",
+    paneScreen: async () => "You've hit your usage limit\nTry again at 7:55 PM.",
+  });
+
+  expect(result).toEqual({
+    waiting: null,
+    rateLimit: {
+      source: "pane",
+      accountId: null,
+      window: null,
+      resetAt: new Date(2026, 6, 10, 19, 55, 0).getTime() / 1000,
+    },
+    atComposer: false,
+  });
+});

--- a/src/lib/scanner/waitingInput.ts
+++ b/src/lib/scanner/waitingInput.ts
@@ -1,7 +1,7 @@
-import { parseScreenMenu, screenAtIdleComposer, screenWaitsForInput } from "@/lib/status";
+import { detectLiveRateLimit, parseScreenMenu, screenAtIdleComposer, screenWaitsForInput } from "@/lib/status";
 import { paneScreen, resolveTarget } from "@/lib/tmux";
 
-import type { FileEntry, WaitingInput } from "../types";
+import type { FileEntry, RateLimitState, WaitingInput } from "../types";
 
 const QUIET_SECONDS = 15;
 const STABLE_MS = 15_000;
@@ -28,16 +28,29 @@ function screenBlock(screen: string): string {
 
 export interface WaitingProbe {
   waiting: WaitingInput | null;
+  rateLimit: RateLimitState | null;
   /** The pane was read and shows a plain composer, no dialog: the agent is
       parked at its prompt, so a still-open turn in the transcript is an
       interrupt artifact rather than a wait on the user. */
   atComposer: boolean;
 }
 
-const NO_PROBE: WaitingProbe = { waiting: null, atComposer: false };
+const NO_PROBE: WaitingProbe = { waiting: null, rateLimit: null, atComposer: false };
 
-export async function waitingInputProbe(entry: FileEntry): Promise<WaitingProbe> {
-  const now = Date.now();
+export interface WaitingInputProbeDeps {
+  now(): number;
+  resolveTarget(pid: number): Promise<string | null>;
+  paneScreen(target: string): Promise<string>;
+}
+
+const DEFAULT_DEPS: WaitingInputProbeDeps = {
+  now: () => Date.now(),
+  resolveTarget,
+  paneScreen,
+};
+
+export async function waitingInputProbe(entry: FileEntry, deps: WaitingInputProbeDeps = DEFAULT_DEPS): Promise<WaitingProbe> {
+  const now = deps.now();
   for (const [key, value] of probes) {
     if (now - value.at > PROBE_TTL_MS) probes.delete(key);
   }
@@ -45,17 +58,26 @@ export async function waitingInputProbe(entry: FileEntry): Promise<WaitingProbe>
     probes.delete(entry.path);
     return NO_PROBE;
   }
-  if (Date.now() / 1000 - entry.mtime < QUIET_SECONDS) return NO_PROBE;
-  const target = await resolveTarget(entry.pid);
+  if (now / 1000 - entry.mtime < QUIET_SECONDS) return NO_PROBE;
+  const target = await deps.resolveTarget(entry.pid);
   if (target === null) return NO_PROBE;
-  const screen = await paneScreen(target);
+  const screen = await deps.paneScreen(target);
+  const liveRateLimit = detectLiveRateLimit(screen, now / 1000);
+  if (liveRateLimit) {
+    probes.delete(entry.path);
+    return {
+      waiting: null,
+      rateLimit: { source: "pane", accountId: null, window: null, resetAt: liveRateLimit.resetAt },
+      atComposer: false,
+    };
+  }
   if (!looksPromptLike(screen)) {
     probes.delete(entry.path);
     /* Only a positively idle composer counts: a quiet busy screen (long
        command, streamed output, no menu) must keep its stalled verdict, or
        the turn-open guard downstream (activity, STAGE_DONE detection) loses
        its meaning. */
-    return { waiting: null, atComposer: screenAtIdleComposer(screen) };
+    return { waiting: null, rateLimit: null, atComposer: screenAtIdleComposer(screen) };
   }
   const previous = probes.get(entry.path);
   if (!previous || previous.screen !== screen) {
@@ -66,6 +88,7 @@ export async function waitingInputProbe(entry: FileEntry): Promise<WaitingProbe>
   if (now / 1000 - previous.since < STABLE_MS / 1000) return NO_PROBE;
   return {
     waiting: { since: previous.since, screenTail: screenBlock(screen), target, menu: parseScreenMenu(screen) },
+    rateLimit: null,
     atComposer: false,
   };
 }

--- a/src/lib/status.test.ts
+++ b/src/lib/status.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "bun:test";
 
-import { screenAtIdleComposer } from "./status";
+import { detectLiveRateLimit, screenAtIdleComposer } from "./status";
 
 const IDLE_CLAUDE = ["● Done. The tests pass.", "", "❯ ", "  ? for shortcuts"].join("\n");
 
@@ -25,4 +25,27 @@ test("quiet streamed output without a composer never reads as at-composer", () =
 
 test("a waiting menu is a dialog, never an idle composer", () => {
   expect(screenAtIdleComposer(MENU_SCREEN)).toBe(false);
+});
+
+test("a current Codex usage wall exposes its reset timestamp", () => {
+  const now = new Date(2026, 6, 10, 18, 0, 0).getTime() / 1000;
+  const resetAt = new Date(2026, 6, 10, 19, 55, 0).getTime() / 1000;
+  const screen = [
+    "You've hit your usage limit",
+    "You can keep using Codex when your limit resets. Try again at 7:55 PM.",
+  ].join("\n");
+
+  expect(detectLiveRateLimit(screen, now)).toEqual({ resetAt });
+});
+
+test("historical usage prose above a ready composer stays clear", () => {
+  const screen = [
+    "You've hit your usage limit. Try again at 7:55 PM.",
+    "The previous attempt was rate-limited, so I resumed later.",
+    "",
+    "› ",
+    "  Context 37% used",
+  ].join("\n");
+
+  expect(detectLiveRateLimit(screen, Date.now() / 1000)).toBeNull();
 });

--- a/src/lib/status.ts
+++ b/src/lib/status.ts
@@ -105,6 +105,33 @@ export function detectBlockingGate(screen: string): BlockingGate | null {
   return null;
 }
 
+function nextLocalClockTime(now: number, hour: number, minute: number): number | null {
+  if (!Number.isFinite(now) || hour < 0 || hour > 23 || minute < 0 || minute > 59) return null;
+  const current = new Date(now * 1000);
+  const reset = new Date(current);
+  reset.setHours(hour, minute, 0, 0);
+  if (reset.getTime() <= current.getTime()) reset.setDate(reset.getDate() + 1);
+  return Math.floor(reset.getTime() / 1000);
+}
+
+function resetTimeFromRateLimitScreen(screen: string, now: number): number | null {
+  const match = /(?:try again|resets?)(?:\s+\w+){0,4}\s+(?:at\s+)?(\d{1,2})(?::(\d{2}))?\s*([ap])\.?m\.?/i.exec(screen);
+  if (!match) return null;
+  const rawHour = Number(match[1]);
+  const minute = Number(match[2] ?? "0");
+  if (rawHour < 1 || rawHour > 12) return null;
+  const hour = rawHour % 12 + (match[3]?.toLowerCase() === "p" ? 12 : 0);
+  return nextLocalClockTime(now, hour, minute);
+}
+
+/** Typed view of a current full-screen quota wall. Region-aware gate logic
+    preserves ready composers whose transcript happens to discuss limits. */
+export function detectLiveRateLimit(screen: string, now = Date.now() / 1000): { resetAt: number | null } | null {
+  if (detectBlockingGate(screen) !== "rate_limit") return null;
+  const tail = screen.split("\n").slice(-14).join("\n");
+  return { resetAt: resetTimeFromRateLimitScreen(tail, now) };
+}
+
 /* Prompt shapes of the waiting-input scrape fallback: a numbered option menu
    under a highlight cursor is how both CLIs draw questions the viewer has no
    structured record for. Anchored to the line start — menu options always

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -12,6 +12,16 @@ export type Engine = "codex" | "claude" | "shell";
 export type Activity = "live" | "recent" | "stalled" | "idle";
 export type Fmt = "codex" | "claude" | "plain";
 
+/** Current quota wall affecting a hosted conversation. Account provenance
+    joins the existing conversation identity at the read-model boundary. */
+export interface RateLimitState {
+  source: "pane" | "account";
+  accountId: string | null;
+  window: "session" | "weekly" | null;
+  /** Unix seconds when work can resume, when the engine reports it. */
+  resetAt: number | null;
+}
+
 /** One sidebar entry returned by GET /api/files. */
 export interface FileEntry {
   path: string;
@@ -57,6 +67,8 @@ export interface FileEntry {
   goal?: AgentGoal | null;
   /** Best-effort TUI scrape fallback for prompts without a transcript protocol. */
   waitingInput: WaitingInput | null;
+  /** Live pane wall or fresh structured account exhaustion. */
+  rateLimit?: RateLimitState | null;
   /** claude-tasks only: recovered originating Bash command ("" if not found). */
   cmd?: string;
   /** claude-tasks only: the Bash tool `description` field. */


### PR DESCRIPTION
## Summary\n\n- detect current pane usage walls with reset-time parsing while preserving ready composers that contain older quota prose\n- join fresh structured account exhaustion to live conversations, including when automatic account balancing is disabled\n- expose rate-limit badges plus attention state and suppress exact reset copy when an exhausted window has no reliable timestamp\n- project attached implementer-side flows as blocked: rate-limited and suppress their waiting transition action\n- carry stable conversation and exhausted-account identifiers as the seam for a later continue-on-account successor action\n\n## Root cause\n\nThe waiting-input fallback required an unchanged pane before surfacing a signal, structured account limits stayed isolated from the files read model, disabled balancing stopped quota sampling, and flows had no transient quota-block contract.\n\n## Follow-up boundary\n\nSuccessor spawning and flow rebinding remain a focused follow-up built on the conversationId and accountId fields added here.\n\n## Verification\n\n- bun test: 1,126 passed\n- bunx tsc --noEmit\n- bun run lint\n\nCloses #97