### PR TITLE
fix: preserve board continuity across account migration

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -1,0 +1,17 @@
+# Issue #97: Rate-limit visibility and blocked flows
+
+## Task statement
+
+Detect current per-conversation engine usage limits, combine pane and structured account-limit evidence, and expose the blocked state in the viewer so operators can see why a conversation or attached flow cannot progress. Preserve ready composers containing historical quota text and keep successor spawning, flow rebinding, and migration-lineage handling outside this PR.
+
+## Acceptance criteria
+
+- AC1: A current usage-limit banner in a live conversation pane marks that conversation as rate-limited and captures a reliable reset time when one can be parsed.
+- AC2: Historical quota prose in a ready composer does not mark the conversation as rate-limited.
+- AC3: Fresh structured account exhaustion is joined to live conversations using stable account identity, including when automatic account balancing is disabled.
+- AC4: Rate-limited conversations expose a visible badge and attention state; exact reset copy is omitted when the exhausted window has no reliable timestamp.
+- AC5: An attached implementer flow projects the rate-limited conversation as `blocked: rate-limited` instead of remaining silently in `waiting_ready`.
+- AC6: A rate-limited flow does not offer the waiting-state transition action while its implementer is blocked.
+- AC7: Conversation and exhausted-account identifiers remain available as stable seams for a later continue-on-account successor workflow.
+- AC8: Rate-limit evidence refreshes with live state and clears when the active signal is no longer present or fresh.
+- AC9: Existing automated tests pass with `bun test`, and the project type-checks with `bunx tsc --noEmit`.

--- a/spec.md
+++ b/spec.md
@@ -1,0 +1,19 @@
+# Issue #86: Preserve board continuity across account migration
+
+## Task statement
+
+Preserve a conversation's durable board identity, placement, delivery state, and migration history while account migration creates source forks, target copies, successor generations, restarts, and partial repairs. Ensure concurrent processes and recovery scans converge on one stable conversation owner without duplicate board cards.
+
+## Acceptance criteria
+
+- AC1: A committed migration successor inherits the predecessor conversation's durable board placement.
+- AC2: Source forks, target copies, and later successor generations converge on one stable conversation owner.
+- AC3: Board placement and held deliveries recover after controller restarts and partial migration repairs.
+- AC4: Codex fork and copy operations are journaled so recovery can identify artifacts and avoid duplicate cards.
+- AC5: Concurrent board mutations are serialized and durably persisted across processes.
+- AC6: Migration artifacts appear as archived history in the files read model.
+- AC7: Deleted or repaired migration paths retain continuity through durable remapping.
+- AC8: Provider operations and repair flows remain idempotent under retries, crashes, and concurrent scans.
+- AC9: Existing behavior remains covered by the full test suite.
+- AC10: `bun test` passes.
+- AC11: `bunx tsc --noEmit` completes without diagnostics.

--- a/src/app/api/account-migration-get-purity.test.ts
+++ b/src/app/api/account-migration-get-purity.test.ts
@@ -43,7 +43,7 @@ test("GET accounts and files preserve registry bytes exactly", async () => {
   const files = await getFiles(new Request("http://127.0.0.1/api/files"));
   expect(files.status).toBe(200);
   expect(stateBytes()).toEqual(before);
-});
+}, 15_000);
 
 test("conditional GET keeps the same durable bytes", async () => {
   const first = await getFiles(new Request("http://127.0.0.1/api/files"));
@@ -53,4 +53,4 @@ test("conditional GET keeps the same durable bytes", async () => {
   const second = await getFiles(new Request("http://127.0.0.1/api/files", { headers: { "if-none-match": etag! } }));
   expect(second.status).toBe(304);
   expect(stateBytes()).toEqual(before);
-});
+}, 15_000);

--- a/src/app/api/accounts/route.test.ts
+++ b/src/app/api/accounts/route.test.ts
@@ -295,6 +295,7 @@ test("GET retains the latest completed intent with recoverable failures for bulk
       operationId: agentRegistry().conversation(conversation.id)!.migration!.operationId,
       nativeId: "recovered-successor",
       path: "/recovered-successor.jsonl",
+      continuityPaths: [],
       historyHash: "recovered",
       host: { kind: "codex-app-server", identity: "recovered", epoch: 1, verifiedAt: "2026-07-10T12:01:00.000Z" },
     },

--- a/src/app/api/files/route.test.ts
+++ b/src/app/api/files/route.test.ts
@@ -1,12 +1,28 @@
-import { expect, mock, test } from "bun:test";
+import { afterEach, beforeEach, expect, mock, test } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 
 import { emptyLaunchProfile } from "@/lib/accounts/migration/contracts";
-import { agentRegistry } from "@/lib/agent/registry";
+import { withoutArchivedPredecessors } from "@/lib/accounts/identity";
+import { agentRegistry, AgentRegistry, setAgentRegistryForTests } from "@/lib/agent/registry";
 import type { FileEntry } from "@/lib/types";
 
 let scans = 0;
 let scanOptions: unknown;
 let scannedFiles: FileEntry[] = [];
+let registryRoot = "";
+
+beforeEach(() => {
+  registryRoot = fs.mkdtempSync(path.join(os.tmpdir(), "llv-files-route-"));
+  setAgentRegistryForTests(new AgentRegistry(path.join(registryRoot, "registry.json")));
+  scannedFiles = [];
+});
+
+afterEach(() => {
+  setAgentRegistryForTests(null);
+  fs.rmSync(registryRoot, { recursive: true, force: true });
+});
 
 mock.module("@/lib/scanner", () => ({
   listFiles: async () => [],
@@ -63,6 +79,33 @@ function file(path: string): FileEntry {
     waitingInput: null,
   };
 }
+
+test("a provisional Codex fork projects as archived history of its stable conversation", async () => {
+  const registry = agentRegistry();
+  const sourcePath = "/sessions/source-019f4906-3f67-7b72-9fbc-9ec3b5ad1301.jsonl";
+  const forkPath = "/source-account/sessions/fork-019f4906-3f67-7b72-9fbc-9ec3b5ad1302.jsonl";
+  const targetPath = "/target-account/sessions/fork-019f4906-3f67-7b72-9fbc-9ec3b5ad1302.jsonl";
+  const conversation = registry.ensureConversation("codex", sourcePath, "source");
+  registry.setConversationMigration(conversation.id, {
+    intentId: "files-route-continuity",
+    phase: "verifying",
+    targetId: "target",
+    revision: 1,
+    error: null,
+    updatedAt: "2026-07-10T12:00:00.000Z",
+  });
+  registry.recordConversationContinuityPath(conversation.id, forkPath);
+  registry.commitSuccessor(conversation.id, { id: "019f4906-3f67-7b72-9fbc-9ec3b5ad1302", path: targetPath, accountId: "target" }, 1);
+  scannedFiles = [file(forkPath), file(targetPath)];
+
+  const response = await GET(new Request("http://127.0.0.1/api/files"));
+  const body = await response.json() as { files: FileEntry[] };
+  const fork = body.files.find((entry) => entry.path === forkPath);
+
+  expect(fork?.conversationId).toBe(conversation.id);
+  expect(fork?.migratedTo).toBe(targetPath);
+  expect(withoutArchivedPredecessors(body.files).map((entry) => entry.path)).toEqual([targetPath]);
+});
 
 test("spawn-time lineage keeps the child grouped after its tmux host disappears", async () => {
   const registry = agentRegistry();

--- a/src/app/api/files/route.ts
+++ b/src/app/api/files/route.ts
@@ -13,6 +13,7 @@ import { pathForPanePid, reconcileTasks } from "@/lib/tasks/reconcile";
 import { loadTasks } from "@/lib/tasks/store";
 import { loadWorkflows } from "@/lib/workflows/store";
 import { filterWorkflowsForFileScan } from "@/lib/workflows/visibility";
+import { projectRateLimitReadModel } from "@/lib/rateLimit";
 import type { FilesResponse } from "@/lib/types";
 
 export const runtime = "nodejs";
@@ -93,7 +94,16 @@ export async function GET(request: Request): Promise<NextResponse> {
     pipelinesError = error instanceof Error ? error.message : "pipeline registry unreadable";
     console.error("[files] pipelines store unreadable; serving without pipelines", error);
   }
-  const body = JSON.stringify({ files, projectCatalog, flows: loadFlows(), pipelines, workflows, tasks: tasks.tasks, ...(pipelinesError ? { pipelinesError } : {}) } satisfies FilesResponse);
+  const projected = projectRateLimitReadModel(files, loadFlows(), registrySnapshot);
+  const body = JSON.stringify({
+    files: projected.files,
+    projectCatalog,
+    flows: projected.flows,
+    pipelines,
+    workflows,
+    tasks: tasks.tasks,
+    ...(pipelinesError ? { pipelinesError } : {}),
+  } satisfies FilesResponse);
   /* The client re-polls every 10 s and this ~410 KB payload is usually
      identical between polls; a strong ETag over the exact bytes lets an
      unchanged response come back as a bodyless 304. force-dynamic still holds

--- a/src/app/api/files/route.ts
+++ b/src/app/api/files/route.ts
@@ -26,10 +26,13 @@ export async function GET(request: Request): Promise<NextResponse> {
   // the external scheduler, keeping repeated GETs byte-stable for state files.
   const registry = agentRegistry();
   const registrySnapshot = registry.snapshot();
+  const ownsPath = (conversation: (typeof registrySnapshot.conversations)[keyof typeof registrySnapshot.conversations], pathname: string) =>
+    conversation.generations.some((generation) => generation.path === pathname)
+    || conversation.continuityPaths.includes(pathname);
   for (const file of files) {
     if (file.engine !== "claude" && file.engine !== "codex") continue;
     const conversation = Object.values(registrySnapshot.conversations).find((candidate) =>
-      candidate.engine === file.engine && candidate.generations.some((generation) => generation.path === file.path));
+      candidate.engine === file.engine && ownsPath(candidate, file.path));
     if (!conversation) continue;
     const generation = conversation.generations.find((item) => item.path === file.path);
     const generationIndex = conversation.generations.findIndex((item) => item.path === file.path);
@@ -37,6 +40,7 @@ export async function GET(request: Request): Promise<NextResponse> {
     file.conversationId = conversation.id;
     if (generationIndex >= 0) file.generation = generationIndex + 1;
     if (generation && latest && generation.path !== latest.path) file.migratedTo = latest.path;
+    if (!generation && latest && conversation.continuityPaths.includes(file.path)) file.migratedTo = latest.path;
     if (latest?.path === file.path && conversation.generations.length > 1) {
       const predecessor = conversation.generations.at(-2);
       file.predecessorPath = predecessor?.path;
@@ -75,7 +79,7 @@ export async function GET(request: Request): Promise<NextResponse> {
     pathForPanePid: (panePid, entries) => pathForPanePid(entries, panePid, readPpid),
     panePidAlive: pidAlive,
     conversationIdForPath: (pathname) => Object.values(registrySnapshot.conversations).find((conversation) =>
-      conversation.generations.some((generation) => generation.path === pathname))?.id ?? null,
+      ownsPath(conversation, pathname))?.id ?? null,
     pathForConversationId: (conversationId) => conversationId.startsWith("conversation_")
       ? registrySnapshot.conversations[conversationId as `conversation_${string}`]?.generations.at(-1)?.path ?? null
       : null,

--- a/src/app/api/files/route.ts
+++ b/src/app/api/files/route.ts
@@ -80,8 +80,11 @@ export async function GET(request: Request): Promise<NextResponse> {
     panePidAlive: pidAlive,
     conversationIdForPath: (pathname) => Object.values(registrySnapshot.conversations).find((conversation) =>
       ownsPath(conversation, pathname))?.id ?? null,
+    canonicalConversationId: (conversationId) => conversationId.startsWith("conversation_")
+      ? registry.canonicalConversationId(conversationId as `conversation_${string}`)
+      : null,
     pathForConversationId: (conversationId) => conversationId.startsWith("conversation_")
-      ? registrySnapshot.conversations[conversationId as `conversation_${string}`]?.generations.at(-1)?.path ?? null
+      ? registry.conversation(conversationId as `conversation_${string}`)?.generations.at(-1)?.path ?? null
       : null,
   });
   const workflows = filterWorkflowsForFileScan(loadWorkflows(), files);

--- a/src/components/BranchPane.tsx
+++ b/src/components/BranchPane.tsx
@@ -22,6 +22,7 @@ import { paneState, type PaneState } from "./paneState";
 import { CtxChip, GoalChip, PlanChip } from "./PlanChip";
 import { ProcessStatusControls } from "./TaskHeader";
 import { TmuxComposer } from "./TmuxComposer";
+import { RateLimitBadge } from "./RateLimitBadge";
 import { activityDot, cleanTitle, effortTint, effortTitle, engineBadge, engineEdge, fmtAge } from "./utils";
 
 const noop = () => undefined;
@@ -224,6 +225,7 @@ export function BranchPane({ file, tasks, isRoot, onClose, dragHandle, noCompose
               </span>
             )}
             <EffortPills file={file} />
+            <RateLimitBadge rateLimit={file.rateLimit} />
             {/* The phone header keeps only actionable or alarming chips: ctx
                 appears once it nears the limit, the worktree name and the
                 branch-kind label yield their room to the rest of the row. */}

--- a/src/components/RateLimitBadge.test.tsx
+++ b/src/components/RateLimitBadge.test.tsx
@@ -1,0 +1,15 @@
+import { expect, test } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { RateLimitBadge } from "./RateLimitBadge";
+
+test("rate-limit badge carries the reset time", () => {
+  const html = renderToStaticMarkup(
+    <RateLimitBadge
+      rateLimit={{ source: "account", accountId: "main", window: "session", resetAt: 1_800_003_300 }}
+    />,
+  );
+
+  expect(html).toContain("data-rate-limited");
+  expect(html).toContain("rate-limited until");
+});

--- a/src/components/RateLimitBadge.tsx
+++ b/src/components/RateLimitBadge.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+import { useLocale } from "@/lib/i18n";
+import type { RateLimitState } from "@/lib/types";
+
+import { rateLimitText } from "./rateLimit";
+
+export function RateLimitBadge({ rateLimit }: { rateLimit?: RateLimitState | null }) {
+  const { locale, t } = useLocale();
+  if (!rateLimit) return null;
+  const label = rateLimitText(t, locale, rateLimit);
+  return (
+    <span
+      data-rate-limited
+      className="inline-flex shrink-0 items-center rounded-full border border-err/35 bg-[#fbeaea] px-2 py-0.5 text-[10px] font-bold text-err"
+      title={label}
+    >
+      {label}
+    </span>
+  );
+}

--- a/src/components/SwitchCard.tsx
+++ b/src/components/SwitchCard.tsx
@@ -9,6 +9,7 @@ import type { FileEntry } from "@/lib/types";
 import { EffortPills } from "./EffortPills";
 import { CtxChip } from "./PlanChip";
 import { ProcessStatusControls } from "./TaskHeader";
+import { RateLimitBadge } from "./RateLimitBadge";
 import { activityDot, cleanTitle, effortTint, effortTitle, engineBadge, fmtAge } from "./utils";
 
 export type SwitchCardSize = "large" | "small";
@@ -79,6 +80,7 @@ export function SwitchCard({ file, title, project, currentProject, descendants, 
           <span className="shrink-0 rounded-full px-1.5 py-0.5 text-[9.5px] font-bold" style={badge.style}>{badge.label}</span>
         )}
         <EffortPills file={file} />
+        <RateLimitBadge rateLimit={file.rateLimit} />
         <span
           className={`ml-auto min-w-0 truncate rounded-full border border-line bg-bg px-1.5 py-0.5 text-[9.5px] font-semibold ${
             project === currentProject ? "text-dim" : "text-ink"

--- a/src/components/Viewer.tsx
+++ b/src/components/Viewer.tsx
@@ -62,6 +62,7 @@ function attentionSnippet(t: TFunction, item: AttentionItem): string {
     const first = q.questions?.[0];
     return first?.header || first?.question.split("\n")[0] || t("status.awaitingAnswer");
   }
+  if (item.file.rateLimit) return t("status.rateLimited");
   const w = item.file.waitingInput;
   if (w) return w.menu?.question.split("\n")[0] || w.screenTail || t("status.awaitingTerminal");
   return t("status.stalled");
@@ -299,7 +300,7 @@ export function Viewer() {
     const ids = files
       .map((file) => ({
         file,
-        id: file.pendingQuestion || file.waitingInput ? attentionId(file) : null,
+        id: file.pendingQuestion || file.rateLimit || file.waitingInput ? attentionId(file) : null,
       }))
       .filter((item): item is { file: FileEntry; id: string } => item.id !== null);
     if (seenQuestionsRef.current === null) {

--- a/src/components/attention.test.ts
+++ b/src/components/attention.test.ts
@@ -60,6 +60,20 @@ describe("attentionId", () => {
     expect(attentionId(entry({ path: "/live", activity: "live" }), NOW)).toBeNull();
   });
 
+  test("a rate-limited live conversation enters hard-blocked attention", () => {
+    const limited = entry({
+      path: "/limited",
+      activity: "live",
+      proc: "running",
+      rateLimit: { source: "pane", accountId: "main", window: "session", resetAt: NOW + 900 },
+    });
+
+    expect(attentionId(limited, NOW)).toBe(`/limited:rate-limited:${NOW + 900}`);
+    expect(buildAttentionQueue([limited], NOW)).toMatchObject([
+      { file: { path: "/limited" }, tier: "blocked", since: limited.mtime },
+    ]);
+  });
+
   /* The toast seen-set and push-sent.json entries carry ids in the historical
      inline format; the shared helper must reproduce it byte for byte. */
   test("id strings are byte-identical to the historical inline derivation", () => {

--- a/src/components/attention.test.ts
+++ b/src/components/attention.test.ts
@@ -44,14 +44,22 @@ function waiting(since: number): WaitingInput {
 }
 
 describe("attentionId", () => {
-  test("precedence: question > waiting > stalled > null", () => {
+  test("precedence: question > rate limit > waiting > stalled > null", () => {
     const both = entry({
       path: "/q",
       activity: "stalled",
       pendingQuestion: question("toolu_1", NOW - 10),
+      rateLimit: { source: "pane", accountId: null, window: null, resetAt: NOW + 60 },
       waitingInput: waiting(NOW - 20),
     });
     expect(attentionId(both, NOW)).toBe("toolu_1");
+    const limited = entry({
+      path: "/limited",
+      activity: "stalled",
+      rateLimit: { source: "pane", accountId: null, window: null, resetAt: NOW + 60 },
+      waitingInput: waiting(NOW - 20),
+    });
+    expect(attentionId(limited, NOW)).toBe(`/limited:rate-limited:${NOW + 60}`);
     const wait = entry({ path: "/w", activity: "stalled", waitingInput: waiting(NOW - 20) });
     expect(attentionId(wait, NOW)).toBe(`/w:waiting:${NOW - 20}`);
     const stalled = entry({ path: "/s", activity: "stalled", proc: "running", mtime: NOW - 300 });

--- a/src/components/attention.ts
+++ b/src/components/attention.ts
@@ -63,6 +63,9 @@ function isoSeconds(iso: string): number | null {
  */
 export function attentionId(file: FileEntry, now: number = Date.now() / 1000): string | null {
   if (file.pendingQuestion) return file.pendingQuestion.toolUseId;
+  if (file.rateLimit) {
+    return `${file.path}:rate-limited:${file.rateLimit.resetAt ?? "unknown"}`;
+  }
   if (file.waitingInput) return `${file.path}:waiting:${Math.floor(file.waitingInput.since)}`;
   /* The stalled tier needs a live process behind the transcript: an open turn
      whose agent already exited is an abandoned session, not a pending
@@ -89,9 +92,11 @@ export function buildAttentionQueue(
     if (project !== undefined && projectKey(file) !== project) continue;
     const id = attentionId(file, now);
     if (id === null) continue;
-    const tier: AttentionTier = file.pendingQuestion || file.waitingInput ? "blocked" : "stalled";
+    const tier: AttentionTier = file.pendingQuestion || file.rateLimit || file.waitingInput ? "blocked" : "stalled";
     const since = file.pendingQuestion
       ? (isoSeconds(file.pendingQuestion.askedAt) ?? file.mtime)
+      : file.rateLimit
+        ? file.mtime
       : file.waitingInput
         ? file.waitingInput.since
         : file.mtime;

--- a/src/components/attention.ts
+++ b/src/components/attention.ts
@@ -3,8 +3,8 @@ import type { FileEntry } from "@/lib/types";
 import { projectKey } from "./projectModel";
 
 /**
- * The attention queue: which agents are blocked on the user right now, oldest
- * wait first. Pure derived state over the polled file list — every surface
+ * The attention queue: which agents need operator attention right now, oldest
+ * signal first. Pure derived state over the polled file list — every surface
  * (badge, popover, title, N-cycle, push/toast seen-sets) derives identity from
  * the one `attentionId` helper here so counts and dedupe keys cannot drift.
  */
@@ -13,7 +13,7 @@ import { projectKey } from "./projectModel";
  * Attention severity tiers, highest first:
  * - «unowned» — a hosted approval with no attached owner (a first-class alarm,
  *   issue #25 R10-5); always sorts to the queue head.
- * - «blocked» — a hard structured question/prompt.
+ * - «blocked» — a hard question, prompt, or rate-limit wall.
  * - «heuristic» — a low-confidence "possibly waiting" signal (turn-ended +
  *   idle + nothing pending); visually distinct, ranks below hard blocks.
  * - «stalled» — an interrupted agent (FIFO tail segment).
@@ -55,8 +55,8 @@ function isoSeconds(iso: string): number | null {
 
 /**
  * The shared attention identity of a file, by signal precedence:
- * a structured question wins over the screen-scrape fallback, which wins over
- * the stalled state; anything else is not in the queue. The id doubles as the
+ * a structured question wins, followed by a rate-limit wall, the screen-scrape
+ * fallback, and the stalled state. The id doubles as the
  * dedupe key of the toast and push pipelines, so the formats here must stay
  * byte-identical to the historical inline derivations (`push-sent.json`
  * entries survive the refactor).
@@ -77,8 +77,8 @@ export function attentionId(file: FileEntry, now: number = Date.now() / 1000): s
 }
 
 /**
- * Ordered queue of everyone blocked on the user: hard-blocked segment first,
- * stalled tail after, oldest wait first inside each segment, id as the
+ * Ordered queue of every agent needing operator attention: hard-blocked segment
+ * first, stalled tail after, oldest signal first inside each segment, id as the
  * tie-breaker. The sort keys are frozen at enqueue (`since` never moves while
  * the id is unchanged), so polls cannot reshuffle the order.
  */

--- a/src/components/flows/FlowHub.tsx
+++ b/src/components/flows/FlowHub.tsx
@@ -9,7 +9,7 @@ import { useLocale } from "@/lib/i18n";
 import { useRuntimeFlow } from "@/hooks/useRuntime";
 import { currentRound, flowLinkPhase, type FlowLinkPhase } from "@/components/scheme/agentLinks";
 
-import { patchFlow, PENDING_ACTIONS, stateLabel } from "./flowModel";
+import { flowPresentation, patchFlow } from "./flowModel";
 
 /* Hub tone per link phase: work in accent, waiting-on-you in amber, done in
    verdict green, idle gray — the palette the strip and verdict chips use. */
@@ -45,9 +45,10 @@ export function FlowHub({
   /** Matches the board's layout-glide transition. */
   moveTransition: string;
 }) {
-  const { t } = useLocale();
+  const { locale, t } = useLocale();
   /* Event-driven progression wins over the poll, same as the strip. */
-  const flow = useRuntimeFlow(polledFlow.id) ?? polledFlow;
+  const runtimeFlow = useRuntimeFlow(polledFlow.id);
+  const flow = runtimeFlow ? { ...runtimeFlow, block: polledFlow.block } : polledFlow;
   const [open, setOpen] = useState(false);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -55,9 +56,10 @@ export function FlowHub({
   const phase = flowLinkPhase(flow.state);
   const tone = PHASE_TONE[phase];
   const round = currentRound(flow)?.n ?? 0;
-  const state = stateLabel(t, flow.state);
+  const presentation = flowPresentation(t, flow, locale);
+  const state = presentation.label;
   const label = round > 0 ? t("flowHub.aria", { n: round, state }) : t("flowHub.ariaNoRound", { state });
-  const pending = PENDING_ACTIONS[flow.state];
+  const pending = presentation.pending;
   const closed = flow.state === "closed" || flow.state === "approved";
 
   const run = async (action: FlowAction) => {
@@ -103,9 +105,9 @@ export function FlowHub({
           <span className="flex min-w-0 items-center gap-1.5">
             <span className="h-2 w-2 shrink-0 rounded-full" style={{ backgroundColor: tone }} aria-hidden />
             <span className="shrink-0 text-[11.5px] font-bold">{state}</span>
-            {flow.stateDetail ? (
-              <span className="min-w-0 truncate text-[10.5px] font-semibold text-dim" title={flow.stateDetail}>
-                {flow.stateDetail}
+            {presentation.detail ? (
+              <span className="min-w-0 truncate text-[10.5px] font-semibold text-dim" title={presentation.detail}>
+                {presentation.detail}
               </span>
             ) : null}
             {busy ? <RefreshCw className="ml-auto h-3 w-3 shrink-0 animate-spin text-dim" aria-hidden /> : null}

--- a/src/components/flows/FlowStrip.tsx
+++ b/src/components/flows/FlowStrip.tsx
@@ -10,7 +10,7 @@ import type { Flow, FlowAction } from "@/lib/flows/types";
 import { Hint } from "@/components/Hint";
 import { useRuntimeFlow } from "@/hooks/useRuntime";
 
-import { ATTENTION_STATES, patchFlow, PENDING_ACTIONS, stateLabel, verdictTone } from "./flowModel";
+import { flowPresentation, patchFlow, verdictTone } from "./flowModel";
 import { RoundStateIcon } from "./RoundIcons";
 
 const BUSY_STATES: ReadonlySet<Flow["state"]> = new Set(["spawning", "reviewing", "relaying", "fixing"]);
@@ -19,6 +19,7 @@ const BUSY_STATES: ReadonlySet<Flow["state"]> = new Set(["spawning", "reviewing"
 const LIMIT_STOPS = [1, 2, 3, 4, 5, 0];
 
 function stateDot(flow: Flow): string {
+  if (flow.block) return "bg-err";
   if (flow.state === "approved") return "bg-ok";
   if (flow.state === "needs_decision") return "bg-err";
   if (flow.state === "paused") return "bg-[#e0ae45]";
@@ -33,10 +34,11 @@ function stateDot(flow: Flow): string {
  * refresh carries the resulting state back.
  */
 export function FlowStrip({ flow: polledFlow, onFocusRound }: { flow: Flow; onFocusRound?: (n: number) => void }) {
-  const { t } = useLocale();
+  const { locale, t } = useLocale();
   /* Event-driven progression wins over the poll: if the runtime bus carries
      this flow, its state is fresher than the last /api/files snapshot. */
-  const flow = useRuntimeFlow(polledFlow.id) ?? polledFlow;
+  const runtimeFlow = useRuntimeFlow(polledFlow.id);
+  const flow = runtimeFlow ? { ...runtimeFlow, block: polledFlow.block } : polledFlow;
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [note, setNote] = useState("");
@@ -51,11 +53,12 @@ export function FlowStrip({ flow: polledFlow, onFocusRound }: { flow: Flow; onFo
     setBusy(false);
   };
 
-  const pending = PENDING_ACTIONS[flow.state];
-  const attention = ATTENTION_STATES.has(flow.state);
+  const presentation = flowPresentation(t, flow, locale);
+  const pending = presentation.pending;
+  const attention = presentation.attention;
   const closed = flow.state === "closed" || flow.state === "approved";
   /* The note rides along with the action that starts the next round. */
-  const noteTakingAction = flow.state === "waiting_ready" || flow.state === "needs_decision";
+  const noteTakingAction = Boolean(pending) && (flow.state === "waiting_ready" || flow.state === "needs_decision");
 
   return (
     <div
@@ -68,10 +71,10 @@ export function FlowStrip({ flow: polledFlow, onFocusRound }: { flow: Flow; onFo
       <span className="flex min-w-0 max-w-[38%] shrink-0 items-center gap-2">
         <span className={`h-2.5 w-2.5 shrink-0 rounded-full ${stateDot(flow)}`} aria-hidden />
         <span className="shrink-0 text-[10.5px] font-bold tracking-[0.08em] text-dim">{t("flowStrip.flow")}</span>
-        <span className="shrink-0 text-[12px] font-bold">{stateLabel(t, flow.state)}</span>
-        {flow.stateDetail ? (
-          <span className="min-w-0 truncate text-[11.5px] font-semibold text-dim" title={flow.stateDetail}>
-            {flow.stateDetail}
+        <span className="shrink-0 text-[12px] font-bold">{presentation.label}</span>
+        {presentation.detail ? (
+          <span className="min-w-0 truncate text-[11.5px] font-semibold text-dim" title={presentation.detail}>
+            {presentation.detail}
           </span>
         ) : null}
       </span>

--- a/src/components/flows/flowModel.test.ts
+++ b/src/components/flows/flowModel.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, test } from "bun:test";
 import type { Flow } from "@/lib/flows/types";
 import type { FileEntry } from "@/lib/types";
 
-import { claimedReviewerDescendantPaths, foldClaimedReviewers, isActiveFlow } from "./flowModel";
+import { claimedReviewerDescendantPaths, flowPresentation, foldClaimedReviewers, isActiveFlow } from "./flowModel";
 
 function entry(overrides: Partial<FileEntry> & { path: string }): FileEntry {
   return {
@@ -100,5 +100,27 @@ describe("reviewer folding", () => {
     expect(claimedReviewerDescendantPaths(files, active).size).toBe(0);
     // …but folding still consumes the full list, so the reviewer is re-homed.
     expect(foldClaimedReviewers(files, [closed]).map((file) => file.path)).toEqual(["/implementer", "/subtask"]);
+  });
+});
+
+test("a quota-blocked flow presents the transient block and suppresses its pending action", () => {
+  const limited = flow({
+    implementerPath: "/implementer",
+    reviewerPath: "/reviewer",
+    state: "waiting_ready",
+    block: {
+      reason: "rate_limited",
+      conversationId: "conversation_impl",
+      accountId: "main",
+      resetAt: 1_800_003_300,
+    },
+  });
+  const t = (key: string) => key;
+
+  expect(flowPresentation(t as never, limited, "en")).toEqual({
+    label: "flowState.blocked_rate_limited",
+    detail: "flowState.rate_limit_until",
+    attention: true,
+    pending: null,
   });
 });

--- a/src/components/flows/flowModel.ts
+++ b/src/components/flows/flowModel.ts
@@ -1,10 +1,11 @@
 import { useMemo, useSyncExternalStore } from "react";
 
-import { getLocale, type MessageKey, type TFunction, translate } from "@/lib/i18n";
+import { getLocale, type Locale, type MessageKey, type TFunction, translate } from "@/lib/i18n";
 import type { Flow, FlowAction, FlowRoleKey, FlowState, ReviewVerdict } from "@/lib/flows/types";
 import type { FileEntry } from "@/lib/types";
 
 import { isConversation } from "@/components/projectModel";
+import { formatRateLimitTime } from "@/components/rateLimit";
 
 /** Fired after any successful flow PATCH so pollers refresh immediately. */
 export const FLOWS_CHANGED_EVENT = "llv:flows-changed";
@@ -177,8 +178,28 @@ export const PENDING_ACTIONS: Partial<Record<FlowState, { labelKey: MessageKey; 
   done_comment: { labelKey: "flowStrip.anotherRound", action: "another-round" },
 };
 
+export function flowPresentation(t: TFunction, flow: Flow, locale: Locale) {
+  if (flow.block?.reason === "rate_limited") {
+    return {
+      label: t("flowState.blocked_rate_limited"),
+      detail: flow.block.resetAt
+        ? t("flowState.rate_limit_until", { time: formatRateLimitTime(flow.block.resetAt, locale) })
+        : t("flowState.rate_limit_wait"),
+      attention: true,
+      pending: null,
+    };
+  }
+  return {
+    label: stateLabel(t, flow.state),
+    detail: flow.stateDetail,
+    attention: ATTENTION_STATES.has(flow.state),
+    pending: PENDING_ACTIONS[flow.state] ?? null,
+  };
+}
+
 /** The loop side working right now — drives the role tags on the scheme. */
 export function activeLoopRole(flow: Flow): FlowRoleKey | null {
+  if (flow.block) return null;
   if (flow.state === "spawning" || flow.state === "reviewing") return "reviewer";
   if (flow.state === "waiting_ready" || flow.state === "relaying" || flow.state === "fixing") return "implementer";
   return null;
@@ -186,6 +207,7 @@ export function activeLoopRole(flow: Flow): FlowRoleKey | null {
 
 /** The cycle leg traffic is on: forward = implementer → reviewer. */
 export function activeLoopLeg(flow: Flow): "forward" | "back" | null {
+  if (flow.block) return null;
   if (flow.state === "spawn_pending" || flow.state === "spawning" || flow.state === "reviewing") return "forward";
   if (flow.state === "relay_pending" || flow.state === "relaying" || flow.state === "fixing") return "back";
   if (flow.state === "waiting_ready") return flow.rounds.length ? "back" : null;

--- a/src/components/paneState.ts
+++ b/src/components/paneState.ts
@@ -16,7 +16,7 @@ import { isChildConversation } from "./projectModel";
 export type PaneState = "live" | "waiting" | "returned" | "stalled" | "done";
 
 export function paneState(file: FileEntry, now = Date.now() / 1000): PaneState {
-  if (file.pendingQuestion || file.waitingInput) return "waiting";
+  if (file.pendingQuestion || file.rateLimit || file.waitingInput) return "waiting";
   if (file.activity === "live") return "live";
   if (file.activity === "recent" && isChildConversation(file) && file.proc !== "running") return "returned";
   if (isAwaitingUser(file, now)) return file.activity === "stalled" ? "stalled" : "waiting";

--- a/src/components/rateLimit.ts
+++ b/src/components/rateLimit.ts
@@ -1,0 +1,16 @@
+import type { TFunction, Locale } from "@/lib/i18n";
+import type { RateLimitState } from "@/lib/types";
+
+export function formatRateLimitTime(resetAt: number, locale: Locale): string {
+  return new Date(resetAt * 1000).toLocaleTimeString(locale === "uk" ? "uk-UA" : "en-US", {
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+  });
+}
+
+export function rateLimitText(t: TFunction, locale: Locale, rateLimit: Pick<RateLimitState, "resetAt">): string {
+  return rateLimit.resetAt
+    ? t("rateLimit.badgeUntil", { time: formatRateLimitTime(rateLimit.resetAt, locale) })
+    : t("rateLimit.badge");
+}

--- a/src/components/scheme/nodes.tsx
+++ b/src/components/scheme/nodes.tsx
@@ -19,6 +19,7 @@ import { FlowHub } from "@/components/flows/FlowHub";
 import { PipelineHub } from "@/components/pipelines/PipelineHub";
 import { FlowStrip } from "@/components/flows/FlowStrip";
 import { RoleTag } from "@/components/flows/RoleTag";
+import { RateLimitBadge } from "@/components/RateLimitBadge";
 import { RoundDeck } from "@/components/flows/RoundDeck";
 import { RoundStateIcon } from "@/components/flows/RoundIcons";
 import { canHandoff, HandoffHandle } from "@/components/HandoffHandle";
@@ -258,6 +259,7 @@ function FarLabel({ file }: { file: FileEntry }) {
         <span className="shrink-0 rounded-full px-[0.45em] font-bold" style={{ ...badge.style, fontSize: "0.72em" }}>
           {badge.label}
         </span>
+        <RateLimitBadge rateLimit={file.rateLimit} />
         <span className="line-clamp-2 min-w-0 font-bold">{cleanTitle(file.title, 70)}</span>
       </div>
     </div>
@@ -312,6 +314,7 @@ function LiteNodeShell({ node, ringed, dimmed, flow }: { node: SchemeNode; ringe
             {badge.label}
           </span>
           {node.file.model ? <span className="min-w-0 truncate font-mono text-[11px] text-dim">{node.file.model}</span> : null}
+          <RateLimitBadge rateLimit={node.file.rateLimit} />
           <span className="ml-auto shrink-0 text-[11px] text-dim">{fmtAge(node.file.mtime)}</span>
         </div>
         <div className="min-w-0 flex-1 px-3 py-2.5 text-[14px] font-semibold leading-snug">

--- a/src/hooks/useSwitchboardData.ts
+++ b/src/hooks/useSwitchboardData.ts
@@ -8,7 +8,7 @@ import type { ActionEvent, FileEntry } from "@/lib/types";
 import { cleanTitle } from "@/lib/title";
 
 import { attentionId } from "@/components/attention";
-import { ATTENTION_STATES, claimedReviewerPaths, flowByImplementer, stateLabel } from "@/components/flows/flowModel";
+import { claimedReviewerPaths, flowByImplementer, flowPresentation } from "@/components/flows/flowModel";
 import { descendantCounts, isAuxTask, isConversation, isSubagent, projectKey } from "@/components/projectModel";
 import { fmtAge } from "@/components/utils";
 
@@ -41,6 +41,7 @@ function recentBucketSort(a: SwitchboardItem, b: SwitchboardItem): number {
 
 function timelineLabel(t: TFunction, file: FileEntry, latestByFile: ReadonlyMap<string, ActionEvent>): string {
   if (file.pendingQuestion) return file.pendingQuestion.kind === "plan" ? t("status.awaitingPlan") : t("status.awaitingAnswer");
+  if (file.rateLimit) return t("status.rateLimited");
   if (file.waitingInput) return t("status.awaitingTerminal");
   /* A live agent's own plan step names its current goal better than the last
      timeline event does. */
@@ -61,7 +62,7 @@ function isReturnedSubagent(file: FileEntry): boolean {
 }
 
 export function isAwaitingUser(file: FileEntry, now = Date.now() / 1000): boolean {
-  if (file.pendingQuestion || file.waitingInput) return true;
+  if (file.pendingQuestion || file.rateLimit || file.waitingInput) return true;
   /* An interrupted session stops being "yours to answer" after a while: a
      permission prompt from two days ago is dead context, so old stalled
      entries sink into the recency buckets instead of inflating the waiting
@@ -109,7 +110,7 @@ export function useSwitchboardData(
         const age = now - file.mtime;
         const flow = flowByImpl.get(file.path);
         let kind: SwitchboardCardKind =
-          file.pendingQuestion || file.waitingInput
+          file.pendingQuestion || file.rateLimit || file.waitingInput
             ? "waiting"
             : file.activity === "live"
             ? "working"
@@ -120,9 +121,10 @@ export function useSwitchboardData(
                 : "older";
         let statusLine = timelineLabel(t, file, latestByFile);
         if (flow) {
-          if (ATTENTION_STATES.has(flow.state)) kind = "waiting";
+          const presentation = flowPresentation(t, flow, locale);
+          if (presentation.attention) kind = "waiting";
           else if (flow.state === "reviewing" || flow.state === "relaying" || flow.state === "spawning") kind = "working";
-          statusLine = `${t("status.flow", { label: stateLabel(t, flow.state) })}${flow.stateDetail ? ` — ${flow.stateDetail}` : ""}`;
+          statusLine = `${t("status.flow", { label: presentation.label })}${presentation.detail ? ` — ${presentation.detail}` : ""}`;
         }
         return {
           file,

--- a/src/lib/accounts/migration/contracts.ts
+++ b/src/lib/accounts/migration/contracts.ts
@@ -45,6 +45,16 @@ export interface GenerationHostEvidence {
   identity: string;
   epoch: number;
   verifiedAt: string;
+  tmuxHost?: {
+    kind: "tmux";
+    endpoint: string;
+    server: { pid: number; startIdentity: string | null };
+    paneId: string;
+    panePid: { pid: number; startIdentity: string | null };
+    windowName: string;
+    agent: { pid: number; startIdentity: string | null };
+    argv: string[];
+  };
 }
 
 export interface NativeGeneration {
@@ -68,6 +78,12 @@ export interface ConversationMigration {
   operationId: string;
   sourceGenerationId: string;
   providerReceipt: ProviderReceipt | null;
+  /** Canonical board project whose path aliases have converged for this generation. */
+  boardProject: string | null;
+  /** Migration operation whose aliases have converged in boardProject. */
+  boardOperationId: string | null;
+  /** Project currently holding this conversation's durable placement. */
+  boardPlacementProject: string | null;
   updatedAt: string;
 }
 
@@ -75,8 +91,43 @@ export interface ProviderReceipt {
   operationId: string;
   nativeId: string;
   path: string;
+  /** Provider-created artifacts that retain the conversation identity throughout migration. */
+  continuityPaths: string[];
   historyHash: string;
   host: GenerationHostEvidence;
+}
+
+function sameProcessIdentity(
+  left: { pid: number; startIdentity: string | null },
+  right: { pid: number; startIdentity: string | null },
+): boolean {
+  return left.pid === right.pid && left.startIdentity === right.startIdentity;
+}
+
+export function sameGenerationHostEvidence(left: GenerationHostEvidence, right: GenerationHostEvidence): boolean {
+  if (left.kind !== right.kind || left.identity !== right.identity || left.epoch !== right.epoch) return false;
+  const leftTmux = left.tmuxHost;
+  const rightTmux = right.tmuxHost;
+  if (!leftTmux || !rightTmux) return leftTmux === rightTmux;
+  return leftTmux.kind === rightTmux.kind
+    && leftTmux.endpoint === rightTmux.endpoint
+    && sameProcessIdentity(leftTmux.server, rightTmux.server)
+    && leftTmux.paneId === rightTmux.paneId
+    && sameProcessIdentity(leftTmux.panePid, rightTmux.panePid)
+    && leftTmux.windowName === rightTmux.windowName
+    && sameProcessIdentity(leftTmux.agent, rightTmux.agent)
+    && leftTmux.argv.length === rightTmux.argv.length
+    && leftTmux.argv.every((argument, index) => argument === rightTmux.argv[index]);
+}
+
+export function sameProviderReceiptOutcome(left: ProviderReceipt, right: ProviderReceipt): boolean {
+  return left.operationId === right.operationId
+    && left.nativeId === right.nativeId
+    && left.path === right.path
+    && left.historyHash === right.historyHash
+    && left.continuityPaths.length === right.continuityPaths.length
+    && left.continuityPaths.every((pathname, index) => pathname === right.continuityPaths[index])
+    && sameGenerationHostEvidence(left.host, right.host);
 }
 
 export interface MigrationEvidence {
@@ -162,6 +213,8 @@ export interface SuccessorProviderPort {
     conversationId: ViewerConversationId;
     source: NativeGeneration;
     targetAccountId: string;
+    /** Persists a provider-created artifact after its path and file identity are validated. */
+    recordContinuityPath(pathname: string): void;
   }): Promise<ProviderReceipt>;
   verify(receipt: ProviderReceipt, input: { engine: MigrationEngine; targetAccountId: string; launchProfile: LaunchProfile }): Promise<void>;
   cleanup?(receipt: ProviderReceipt): Promise<void>;

--- a/src/lib/accounts/migration/controller.test.ts
+++ b/src/lib/accounts/migration/controller.test.ts
@@ -30,7 +30,7 @@ test("controller migration cycle reconciles and ticks both durable quota policy 
   const conversation = registry.conversationForPath("/source.jsonl")!;
   registry.commitMigrationIntent({ engine: "codex", targetId: "target", origin: "manual", requestId: "controller-cycle", expectedRevision: registry.engineRouting("codex").revision });
   const provider: SuccessorProviderPort = {
-    async create(input) { return { operationId: input.operationId, nativeId: "successor", path: "/target.jsonl", historyHash: "hash", host: { kind: "codex-app-server", identity: "successor", epoch: 1, verifiedAt: "2026-07-10T12:01:00.000Z" } }; },
+    async create(input) { return { operationId: input.operationId, nativeId: "successor", path: "/target.jsonl", continuityPaths: [], historyHash: "hash", host: { kind: "codex-app-server", identity: "successor", epoch: 1, verifiedAt: "2026-07-10T12:01:00.000Z" } }; },
     async verify() {},
   };
 
@@ -80,6 +80,7 @@ test("three controller cycles move depleted Main to a stronger managed account a
           operationId: input.operationId,
           nativeId: "managed-successor",
           path: "/managed.jsonl",
+          continuityPaths: [],
           historyHash: "managed-history",
           host: { kind: "codex-app-server", identity: "managed-successor", epoch: 1, verifiedAt: new Date(current).toISOString() },
         };

--- a/src/lib/accounts/migration/controller.ts
+++ b/src/lib/accounts/migration/controller.ts
@@ -92,6 +92,9 @@ export class AccountMigrationController {
         pathForPanePid: (panePid, entries) => pathForPanePid(entries, panePid, readPpid),
         panePidAlive: pidAlive,
         conversationIdForPath: (pathname) => this.registry.conversationForPath(pathname)?.id ?? null,
+        canonicalConversationId: (conversationId) => conversationId.startsWith("conversation_")
+          ? this.registry.canonicalConversationId(conversationId as `conversation_${string}`)
+          : null,
         pathForConversationId: (conversationId) => conversationId.startsWith("conversation_")
           ? this.registry.conversation(conversationId as `conversation_${string}`)?.generations.at(-1)?.path ?? null
           : null,

--- a/src/lib/accounts/migration/coordinator.test.ts
+++ b/src/lib/accounts/migration/coordinator.test.ts
@@ -1064,6 +1064,39 @@ describe("durable account migration coordinator", () => {
     expect(latest.generations).toHaveLength(1);
   });
 
+  test("a return-to-source retarget cleans a stale successor after clearing migration state", async () => {
+    const store = registry();
+    store.reconcileConversations([observation("/source.jsonl", "a", "idle")]);
+    const conversation = store.conversationForPath("/source.jsonl")!;
+    store.commitMigrationIntent({ engine: "codex", targetId: "b", origin: "manual", requestId: "to-b-before-return", expectedRevision: store.engineRouting("codex").revision });
+    const cleaned: string[] = [];
+    let verified = false;
+    const staleProvider: SuccessorProviderPort = {
+      async create(input) {
+        input.recordContinuityPath("/stale-b.jsonl");
+        store.commitMigrationIntent({ engine: "codex", targetId: "a", origin: "manual", requestId: "return-to-a", expectedRevision: store.engineRouting("codex").revision });
+        return {
+          operationId: input.operationId,
+          nativeId: "stale-b",
+          path: "/stale-b.jsonl",
+          continuityPaths: ["/stale-b.jsonl"],
+          historyHash: "stale",
+          host: { kind: "codex-app-server", identity: "stale", epoch: 1, verifiedAt: "2026-07-10T12:01:00.000Z" },
+        };
+      },
+      async verify() { verified = true; },
+      async cleanup(receipt) { cleaned.push(receipt.nativeId); },
+    };
+
+    const latest = await advanceConversationMigration(conversation.id, store, staleProvider);
+
+    expect(latest.migration).toBeNull();
+    expect(latest.generations).toHaveLength(1);
+    expect(verified).toBeFalse();
+    expect(cleaned).toEqual(["stale-b"]);
+    expect(store.conversationForPath("/stale-b.jsonl")?.id).toBe(conversation.id);
+  });
+
   test("stopping during successor startup fences the stale completion and cleans the discarded successor", async () => {
     const store = registry();
     store.reconcileConversations([observation("/source.jsonl", "a", "idle")]);

--- a/src/lib/accounts/migration/coordinator.test.ts
+++ b/src/lib/accounts/migration/coordinator.test.ts
@@ -60,6 +60,18 @@ afterEach(() => {
 });
 
 describe("durable account migration coordinator", () => {
+  test("preview reads the controller inventory without rewriting the registry", async () => {
+    const store = registry();
+    store.reconcileConversations([observation("/owned.jsonl", "managed", "idle")]);
+    const before = fs.statSync(store.filename, { bigint: true });
+
+    const preview = await previewMigration("codex", "default", store);
+
+    const after = fs.statSync(store.filename, { bigint: true });
+    expect(preview.counts).toEqual({ total: 1, idle: 1, busy: 0, alreadyTarget: 0 });
+    expect(after.ino).toBe(before.ino);
+  });
+
   test("unowned inventory stays outside previews and committed migration scope", async () => {
     const store = registry();
     store.reconcileConversations([
@@ -67,7 +79,7 @@ describe("durable account migration coordinator", () => {
       observation("/scanner-artifact.log", null, "busy"),
     ]);
 
-    const preview = await previewMigration("codex", "default", store, []);
+    const preview = await previewMigration("codex", "default", store);
     expect(preview.counts).toEqual({ total: 1, idle: 1, busy: 0, alreadyTarget: 0 });
     store.commitMigrationIntent({
       engine: "codex",

--- a/src/lib/accounts/migration/coordinator.test.ts
+++ b/src/lib/accounts/migration/coordinator.test.ts
@@ -8,7 +8,7 @@ import { boardFor, mutateBoard, setBoardFileForTests } from "@/lib/board/store";
 
 import { advanceConversationMigration, drainHeldDeliveries, previewMigration, reconcileMigrations } from "./coordinator";
 import { emptyLaunchProfile, type ProviderReceipt, type SuccessorProviderPort } from "./contracts";
-import { SuccessorPendingError } from "./provider";
+import { CodexForkOutcomeUnknownError, SuccessorPendingError } from "./provider";
 
 const roots: string[] = [];
 
@@ -1062,6 +1062,48 @@ describe("durable account migration coordinator", () => {
     const latest = await advanceConversationMigration(conversation.id, store, staleProvider);
     expect(latest.migration).toMatchObject({ targetId: "c", phase: "requested" });
     expect(latest.generations).toHaveLength(1);
+  });
+
+  test("retry preserves an ambiguous Codex fork operation id", async () => {
+    const store = registry();
+    store.reconcileConversations([observation("/source.jsonl", "a", "idle")]);
+    const conversation = store.conversationForPath("/source.jsonl")!;
+    store.commitMigrationIntent({ engine: "codex", targetId: "b", origin: "manual", requestId: "ambiguous-fork", expectedRevision: store.engineRouting("codex").revision });
+    const operations: string[] = [];
+    const ambiguousProvider: SuccessorProviderPort = {
+      async create(input) {
+        operations.push(input.operationId);
+        if (operations.length === 1) throw new CodexForkOutcomeUnknownError();
+        input.recordContinuityPath("/recovered-fork.jsonl");
+        return { operationId: input.operationId, nativeId: "recovered", path: "/recovered.jsonl", continuityPaths: ["/recovered-fork.jsonl"], historyHash: "hash", host: { kind: "codex-app-server", identity: "recovered", epoch: 1, verifiedAt: "now" } };
+      },
+      async verify() {},
+    };
+    const failed = await advanceConversationMigration(conversation.id, store, ambiguousProvider);
+    expect(failed).toMatchObject({ migration: { phase: "failed-recoverable", errorCode: "codex-fork-outcome-unknown" } });
+    store.retryConversationMigration(conversation.id, failed.migration!.revision);
+    const committed = await advanceConversationMigration(conversation.id, store, ambiguousProvider);
+    expect(committed.migration?.phase).toBe("committed");
+    expect(operations).toEqual([operations[0]!, operations[0]!]);
+  });
+
+  test("reconciliation retries a durable stale-successor cleanup after restart", async () => {
+    const store = registry();
+    store.reconcileConversations([observation("/source.jsonl", "a", "idle")]);
+    const conversation = store.conversationForPath("/source.jsonl")!;
+    store.commitMigrationIntent({ engine: "codex", targetId: "b", origin: "manual", requestId: "cleanup-retry", expectedRevision: store.engineRouting("codex").revision });
+    let cleanupAttempts = 0;
+    const cleanupProvider: SuccessorProviderPort = {
+      async create(input) { return { operationId: input.operationId, nativeId: "stale", path: "/stale.jsonl", continuityPaths: [], historyHash: "hash", host: { kind: "claude-stream", identity: "%9:99", epoch: 1, verifiedAt: "now" } }; },
+      async verify() { throw new Error("verification failed"); },
+      async cleanup() { cleanupAttempts += 1; if (cleanupAttempts === 1) throw new Error("tmux unavailable"); },
+    };
+    await advanceConversationMigration(conversation.id, store, cleanupProvider);
+    expect(Object.keys(store.snapshot().pendingSuccessorCleanups)).toHaveLength(1);
+    const restarted = new AgentRegistry(store.filename);
+    await reconcileMigrations(cleanupProvider, { async deliver() { return "delivered"; } }, restarted);
+    expect(cleanupAttempts).toBe(2);
+    expect(Object.keys(restarted.snapshot().pendingSuccessorCleanups)).toHaveLength(0);
   });
 
   test("a return-to-source retarget cleans a stale successor after clearing migration state", async () => {

--- a/src/lib/accounts/migration/coordinator.test.ts
+++ b/src/lib/accounts/migration/coordinator.test.ts
@@ -4,19 +4,28 @@ import os from "node:os";
 import path from "node:path";
 
 import { AgentRegistry, MigrationRevisionError, type ConversationObservation } from "@/lib/agent/registry";
+import { boardFor, mutateBoard, setBoardFileForTests } from "@/lib/board/store";
 
 import { advanceConversationMigration, drainHeldDeliveries, previewMigration, reconcileMigrations } from "./coordinator";
 import { emptyLaunchProfile, type ProviderReceipt, type SuccessorProviderPort } from "./contracts";
+import { SuccessorPendingError } from "./provider";
 
 const roots: string[] = [];
 
 function registry(): AgentRegistry {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "llv-migration-coordinator-"));
   roots.push(root);
+  setBoardFileForTests(path.join(root, "board.json"));
   return new AgentRegistry(path.join(root, "registry.json"));
 }
 
-function observation(pathname: string, accountId: string | null, state: "idle" | "busy" | "terminal", role: "root" | "worker" = "worker"): ConversationObservation {
+function observation(
+  pathname: string,
+  accountId: string | null,
+  state: "idle" | "busy" | "terminal",
+  role: "root" | "worker" = "worker",
+  project = "repo",
+): ConversationObservation {
   return {
     engine: "codex",
     path: pathname,
@@ -28,7 +37,7 @@ function observation(pathname: string, accountId: string | null, state: "idle" |
       fast: true,
       permissionMode: "never",
       title: `Title ${pathname}`,
-      project: "repo",
+      project,
       role,
       goal: { objective: "Ship", status: "active", tokensUsed: 12, timeUsedSeconds: 4 },
       plan: { steps: [{ text: "Implement", status: "in_progress" }], done: 0, total: 1, current: "Implement", updatedAt: "2026-07-10T12:00:00.000Z" },
@@ -38,15 +47,18 @@ function observation(pathname: string, accountId: string | null, state: "idle" |
   };
 }
 
-function provider(paths: string[], counts = { create: 0, verify: 0 }): SuccessorProviderPort {
+function provider(paths: string[], counts = { create: 0, verify: 0 }, continuityPaths: string[][] = []): SuccessorProviderPort {
   return {
     async create(input) {
       counts.create += 1;
       const next = paths.shift() ?? `/successor-${counts.create}.jsonl`;
+      const recordedPaths = continuityPaths.shift() ?? [];
+      for (const pathname of recordedPaths) input.recordContinuityPath(pathname);
       return {
         operationId: input.operationId,
         nativeId: path.basename(next, ".jsonl"),
         path: next,
+        continuityPaths: recordedPaths,
         historyHash: `hash-${counts.create}`,
         host: { kind: "codex-app-server", identity: `host-${counts.create}`, epoch: counts.create, verifiedAt: "2026-07-10T12:01:00.000Z" },
       };
@@ -56,10 +68,766 @@ function provider(paths: string[], counts = { create: 0, verify: 0 }): Successor
 }
 
 afterEach(() => {
+  setBoardFileForTests(null);
   for (const root of roots.splice(0)) fs.rmSync(root, { recursive: true, force: true });
 });
 
 describe("durable account migration coordinator", () => {
+  test("an in-progress successor receipt remains pending for observer settlement", async () => {
+    const store = registry();
+    store.reconcileConversations([observation("/pending-source.jsonl", "a", "idle")]);
+    const conversation = store.conversationForPath("/pending-source.jsonl")!;
+    store.commitMigrationIntent({
+      engine: "codex",
+      targetId: "b",
+      origin: "manual",
+      requestId: "pending-successor-receipt",
+      expectedRevision: store.engineRouting("codex").revision,
+    });
+    const provider: SuccessorProviderPort = {
+      async create() { throw new SuccessorPendingError(); },
+      async verify() {},
+    };
+
+    const pending = await advanceConversationMigration(conversation.id, store, provider);
+
+    expect(pending.migration).toMatchObject({ phase: "successor-starting", error: null, errorCode: null });
+  });
+
+  test("concurrent same-operation advances commit one matching provider receipt", async () => {
+    const store = registry();
+    store.reconcileConversations([observation("/concurrent-source.jsonl", "a", "idle")]);
+    const conversation = store.conversationForPath("/concurrent-source.jsonl")!;
+    store.commitMigrationIntent({
+      engine: "codex",
+      targetId: "b",
+      origin: "manual",
+      requestId: "concurrent-provider-receipt",
+      expectedRevision: store.engineRouting("codex").revision,
+    });
+    let current = store.conversation(conversation.id)!;
+    current = store.transitionConversationMigration(current.id, current.migration!.revision, ["requested"], { phase: "preparing" });
+    current = store.transitionConversationMigration(current.id, current.migration!.revision, ["preparing"], { phase: "successor-starting" });
+    let arrivals = 0;
+    let release!: () => void;
+    const bothCreating = new Promise<void>((resolve) => { release = resolve; });
+    const provider: SuccessorProviderPort = {
+      async create(input) {
+        arrivals += 1;
+        const arrival = arrivals;
+        if (arrivals === 2) release();
+        await bothCreating;
+        return {
+          operationId: input.operationId,
+          nativeId: "concurrent-successor",
+          path: "/concurrent-successor.jsonl",
+          continuityPaths: [],
+          historyHash: "same-history",
+          host: { kind: "codex-app-server", identity: "concurrent-successor", epoch: 1, verifiedAt: `2026-07-10T12:01:0${arrival}.000Z` },
+        };
+      },
+      async verify() {},
+    };
+
+    await Promise.all([
+      advanceConversationMigration(conversation.id, store, provider),
+      advanceConversationMigration(conversation.id, store, provider),
+    ]);
+
+    const committed = store.conversation(conversation.id)!;
+    expect(committed.migration?.phase).toBe("committed");
+    expect(committed.generations.map((generation) => generation.path)).toEqual([
+      "/concurrent-source.jsonl",
+      "/concurrent-successor.jsonl",
+    ]);
+  });
+
+  test("concurrent Claude successors clean the losing host after one receipt commits", async () => {
+    const store = registry();
+    store.reconcileConversations([{ ...observation("/claude-source.jsonl", "a", "idle"), engine: "claude" }]);
+    const conversation = store.conversationForPath("/claude-source.jsonl")!;
+    store.commitMigrationIntent({
+      engine: "claude",
+      targetId: "b",
+      origin: "manual",
+      requestId: "concurrent-claude-hosts",
+      expectedRevision: store.engineRouting("claude").revision,
+    });
+    let current = store.conversation(conversation.id)!;
+    current = store.transitionConversationMigration(current.id, current.migration!.revision, ["requested"], { phase: "preparing" });
+    store.transitionConversationMigration(current.id, current.migration!.revision, ["preparing"], { phase: "successor-starting" });
+    let calls = 0;
+    let releaseSecond!: () => void;
+    const secondMayReturn = new Promise<void>((resolve) => { releaseSecond = resolve; });
+    const cleaned: string[] = [];
+    const provider: SuccessorProviderPort = {
+      async create(input) {
+        calls += 1;
+        const call = calls;
+        if (call === 2) await secondMayReturn;
+        return {
+          operationId: input.operationId,
+          nativeId: "same-claude-successor",
+          path: "/same-claude-successor.jsonl",
+          continuityPaths: [],
+          historyHash: "same-history",
+          host: { kind: "claude-stream", identity: call === 1 ? "%1:101" : "%2:202", epoch: 1, verifiedAt: `2026-07-10T12:01:0${call}.000Z` },
+        };
+      },
+      async verify(receipt) {
+        if (receipt.host.identity === "%1:101") setTimeout(releaseSecond, 0);
+      },
+      async cleanup(receipt) { cleaned.push(receipt.host.identity); },
+    };
+
+    await Promise.all([
+      advanceConversationMigration(conversation.id, store, provider),
+      advanceConversationMigration(conversation.id, store, provider),
+    ]);
+
+    expect(store.conversation(conversation.id)).toMatchObject({
+      migration: { phase: "committed", providerReceipt: { host: { identity: "%1:101" } } },
+      generations: [{ path: "/claude-source.jsonl" }, { path: "/same-claude-successor.jsonl", host: { identity: "%1:101" } }],
+    });
+    expect(cleaned).toEqual(["%2:202"]);
+  });
+
+  test("a Codex source fork resolves to the committed target without another manual root", async () => {
+    const project = "issue-86-codex-source-fork";
+    const sourcePath = "/codex-predecessor.jsonl";
+    const sourceForkPath = "/source-account/fork.jsonl";
+    const targetPath = "/target-account/fork.jsonl";
+    const store = registry();
+    store.reconcileConversations([observation(sourcePath, "a", "idle", "worker", project)]);
+    const conversation = store.conversationForPath(sourcePath)!;
+    store.commitMigrationIntent({
+      engine: "codex",
+      targetId: "b",
+      origin: "manual",
+      requestId: "codex-two-path-successor",
+      expectedRevision: store.engineRouting("codex").revision,
+    });
+    const closed = mutateBoard(project, boardFor(project).revision, [{ kind: "close", path: sourcePath }]);
+    expect(closed.ok).toBeTrue();
+
+    await advanceConversationMigration(
+      conversation.id,
+      store,
+      provider([targetPath], { create: 0, verify: 0 }, [[sourceForkPath]]),
+    );
+    const committed = boardFor(project);
+    const afterScan = mutateBoard(project, committed.revision, [{
+      kind: "reconcile-roots",
+      roots: [sourceForkPath, targetPath],
+      removeManual: [],
+    }]);
+
+    expect(afterScan.ok).toBeTrue();
+    expect(afterScan.board.pathAliases).toEqual({
+      [sourcePath]: targetPath,
+      [sourceForkPath]: targetPath,
+    });
+    expect(afterScan.board.prefs.hidden).toEqual([targetPath]);
+    expect(afterScan.board.prefs.manual).toEqual([]);
+  });
+
+  test("retry preserves every provider fork until the successor commits", async () => {
+    const project = "issue-86-failed-fork-retry";
+    const sourcePath = "/retry-predecessor.jsonl";
+    const firstForkPath = "/source-account/failed-fork.jsonl";
+    const secondForkPath = "/source-account/retry-fork.jsonl";
+    const targetPath = "/target-account/retry-fork.jsonl";
+    const store = registry();
+    store.reconcileConversations([observation(sourcePath, "a", "idle", "worker", project)]);
+    const conversation = store.conversationForPath(sourcePath)!;
+    store.commitMigrationIntent({
+      engine: "codex",
+      targetId: "b",
+      origin: "manual",
+      requestId: "failed-fork-retry",
+      expectedRevision: store.engineRouting("codex").revision,
+    });
+    const failingProvider: SuccessorProviderPort = {
+      async create(input) {
+        input.recordContinuityPath(firstForkPath);
+        throw new Error("target account unavailable");
+      },
+      async verify() {},
+    };
+
+    const failed = await advanceConversationMigration(conversation.id, store, failingProvider);
+    expect(failed.migration?.phase).toBe("failed-recoverable");
+    expect(failed.continuityPaths).toEqual([firstForkPath]);
+    const provisional = mutateBoard(project, boardFor(project).revision, [
+      { kind: "restore", path: firstForkPath, placement: "manual" },
+    ]);
+    expect(provisional.ok).toBeTrue();
+
+    const restarted = new AgentRegistry(store.filename);
+    restarted.reconcileConversations([observation(firstForkPath, "a", "idle", "worker", project)]);
+    expect(Object.values(restarted.snapshot().conversations)).toHaveLength(1);
+    expect(restarted.conversationForPath(firstForkPath)?.id).toBe(conversation.id);
+    restarted.retryConversationMigration(conversation.id, failed.migration!.revision);
+    const committed = await advanceConversationMigration(
+      conversation.id,
+      restarted,
+      provider([targetPath], { create: 0, verify: 0 }, [[secondForkPath]]),
+    );
+
+    expect(committed.migration?.phase).toBe("committed");
+    expect(committed.continuityPaths).toEqual([firstForkPath, secondForkPath]);
+    expect(boardFor(project).pathAliases).toEqual({
+      [sourcePath]: targetPath,
+      [firstForkPath]: targetPath,
+      [secondForkPath]: targetPath,
+    });
+    expect(boardFor(project).prefs.manual).toEqual([]);
+  });
+
+  test("a committed successor keeps its predecessor hidden through root reconciliation", async () => {
+    const project = "issue-86-hidden-successor";
+    const sourcePath = "/hidden-predecessor.jsonl";
+    const successorPath = "/hidden-successor.jsonl";
+    const store = registry();
+    store.reconcileConversations([observation(sourcePath, "a", "idle", "worker", project)]);
+    const conversation = store.conversationForPath(sourcePath)!;
+    store.commitMigrationIntent({
+      engine: "codex",
+      targetId: "b",
+      origin: "manual",
+      requestId: "hidden-board-successor",
+      expectedRevision: store.engineRouting("codex").revision,
+    });
+    const closed = mutateBoard(project, boardFor(project).revision, [{ kind: "close", path: sourcePath }]);
+    expect(closed.ok).toBeTrue();
+
+    await advanceConversationMigration(conversation.id, store, provider([successorPath]));
+    const afterCommit = boardFor(project);
+    const reconciled = mutateBoard(project, afterCommit.revision, [{
+      kind: "reconcile-roots",
+      roots: [successorPath],
+      removeManual: [],
+    }]);
+
+    expect(reconciled.ok).toBeTrue();
+    expect(reconciled.board.pathAliases).toEqual({ [sourcePath]: successorPath });
+    expect(reconciled.board.prefs.hidden).toEqual([successorPath]);
+    expect(reconciled.board.prefs.manual).toEqual([]);
+  });
+
+  test("reconciliation repairs board continuity for an already committed successor", async () => {
+    const project = "issue-86-committed-repair";
+    const sourcePath = "/repair-predecessor.jsonl";
+    const successorPath = "/repair-successor.jsonl";
+    const store = registry();
+    store.reconcileConversations([observation(sourcePath, "a", "idle", "worker", project)]);
+    const conversation = store.conversationForPath(sourcePath)!;
+    store.commitMigrationIntent({
+      engine: "codex",
+      targetId: "b",
+      origin: "manual",
+      requestId: "repair-committed-board",
+      expectedRevision: store.engineRouting("codex").revision,
+    });
+    let current = store.conversation(conversation.id)!;
+    current = store.transitionConversationMigration(current.id, current.migration!.revision, ["requested"], { phase: "preparing" });
+    current = store.transitionConversationMigration(current.id, current.migration!.revision, ["preparing"], { phase: "successor-starting" });
+    current = store.transitionConversationMigration(current.id, current.migration!.revision, ["successor-starting"], { phase: "verifying" });
+    store.holdDelivery(current.id, "continue after restart", "repair-client");
+    store.commitSuccessor(current.id, { id: "repair-successor", path: successorPath, accountId: "b" }, current.migration!.revision);
+    const closed = mutateBoard(project, boardFor(project).revision, [{ kind: "close", path: sourcePath }]);
+    expect(closed.ok).toBeTrue();
+
+    const restarted = new AgentRegistry(store.filename);
+    const delivered: string[] = [];
+    await reconcileMigrations(provider([]), {
+      async deliver(input) {
+        delivered.push(input.clientMessageId);
+        return "delivered";
+      },
+    }, restarted);
+    const repaired = boardFor(project);
+    const reconciled = mutateBoard(project, repaired.revision, [{
+      kind: "reconcile-roots",
+      roots: [successorPath],
+      removeManual: [],
+    }]);
+
+    expect(reconciled.ok).toBeTrue();
+    expect(reconciled.board.pathAliases).toEqual({ [sourcePath]: successorPath });
+    expect(reconciled.board.prefs.hidden).toEqual([successorPath]);
+    expect(reconciled.board.prefs.manual).toEqual([]);
+    expect(delivered).toEqual(["repair-client"]);
+    expect(restarted.pendingDeliveries(conversation.id)).toEqual([]);
+  });
+
+  test("restart repair preserves placement after an interleaved client remap", async () => {
+    const project = "issue-86-partial-board-convergence";
+    const sourcePath = "/partial-source.jsonl";
+    const forkPath = "/partial-source-fork.jsonl";
+    const targetPath = "/partial-target.jsonl";
+    const store = registry();
+    store.reconcileConversations([observation(sourcePath, "a", "idle", "worker", project)]);
+    const conversation = store.conversationForPath(sourcePath)!;
+    store.commitMigrationIntent({
+      engine: "codex",
+      targetId: "b",
+      origin: "manual",
+      requestId: "partial-board-convergence",
+      expectedRevision: store.engineRouting("codex").revision,
+    });
+    let current = store.conversation(conversation.id)!;
+    current = store.transitionConversationMigration(current.id, current.migration!.revision, ["requested"], { phase: "preparing" });
+    current = store.transitionConversationMigration(current.id, current.migration!.revision, ["preparing"], { phase: "successor-starting" });
+    store.recordConversationContinuityPath(current.id, forkPath);
+    const receipt: ProviderReceipt = {
+      operationId: current.migration!.operationId,
+      nativeId: "partial-target",
+      path: targetPath,
+      continuityPaths: [forkPath],
+      historyHash: "partial-history",
+      host: { kind: "codex-app-server", identity: "partial-target", epoch: 1, verifiedAt: "2026-07-10T12:01:00.000Z" },
+    };
+    current = store.transitionConversationMigration(current.id, current.migration!.revision, ["successor-starting"], { phase: "verifying", providerReceipt: receipt });
+    store.commitSuccessor(current.id, { id: receipt.nativeId, path: targetPath, accountId: "b" }, current.migration!.revision);
+    const arranged = mutateBoard(project, boardFor(project).revision, [
+      { kind: "restore", path: sourcePath, placement: "manual" },
+      { kind: "remap-paths", pairs: [{ from: sourcePath, to: targetPath }] },
+    ]);
+    expect(arranged.ok).toBeTrue();
+    expect(arranged.board.prefs.manual).toEqual([targetPath]);
+
+    const restarted = new AgentRegistry(store.filename);
+    await reconcileMigrations(provider([]), { async deliver() { return "delivered"; } }, restarted);
+
+    expect(boardFor(project)).toMatchObject({
+      pathAliases: { [sourcePath]: targetPath, [forkPath]: targetPath },
+      prefs: { manual: [targetPath] },
+    });
+  });
+
+  test("committed successors replace provisional manual roots with predecessor placement", async () => {
+    const project = "issue-86-placement";
+    const sources = ["/manual-source.jsonl", "/expanded-source.jsonl", "/auto-source.jsonl"];
+    const successors = ["/manual-next.jsonl", "/expanded-next.jsonl", "/auto-next.jsonl"];
+    const continuityPaths = ["/manual-fork.jsonl", "/expanded-fork.jsonl", "/auto-fork.jsonl"];
+    const store = registry();
+    store.reconcileConversations(sources.map((pathname) => observation(pathname, "a", "idle", "worker", project)));
+    store.commitMigrationIntent({
+      engine: "codex",
+      targetId: "b",
+      origin: "manual",
+      requestId: "preserve-board-placement",
+      expectedRevision: store.engineRouting("codex").revision,
+    });
+    const arranged = mutateBoard(project, boardFor(project).revision, [
+      { kind: "restore", path: sources[0]!, placement: "manual" },
+      { kind: "restore", path: sources[1]!, placement: "expanded" },
+      ...successors.map((pathname) => ({ kind: "restore" as const, path: pathname, placement: "manual" as const })),
+      ...continuityPaths.map((pathname) => ({ kind: "restore" as const, path: pathname, placement: "manual" as const })),
+    ]);
+    expect(arranged.ok).toBeTrue();
+
+    await reconcileMigrations(
+      provider([...successors], { create: 0, verify: 0 }, continuityPaths.map((pathname) => [pathname])),
+      { async deliver() { return "delivered"; } },
+      store,
+    );
+
+    const board = boardFor(project);
+    expect(board.pathAliases).toEqual(Object.fromEntries([
+      ...sources.map((source, index) => [source, successors[index]!] as const),
+      ...continuityPaths.map((source, index) => [source, successors[index]!] as const),
+    ]));
+    expect(board.prefs.manual).toEqual([successors[0]]);
+    expect(board.prefs.expanded).toEqual([successors[1]]);
+    expect(board.prefs.hidden).toEqual([]);
+    expect([...board.prefs.manual, ...board.prefs.expanded, ...board.prefs.hidden]).not.toContain(successors[2]);
+    const converged = mutateBoard(project, board.revision, [{
+      kind: "reconcile-roots",
+      roots: successors,
+      removeManual: [],
+    }]);
+    expect(converged.ok).toBeTrue();
+    expect(converged.board.prefs.manual).toEqual([successors[0]]);
+    expect(converged.board.prefs.expanded).toEqual([successors[1]]);
+    expect([...converged.board.prefs.manual, ...converged.board.prefs.expanded, ...converged.board.prefs.hidden]).not.toContain(successors[2]);
+  });
+
+  test("repeat migration carries manual placement across historical continuity aliases", async () => {
+    const project = "issue-86-repeat-placement";
+    const store = registry();
+    store.reconcileConversations([observation("/a.jsonl", "a", "idle", "worker", project)]);
+    const conversation = store.conversationForPath("/a.jsonl")!;
+    let arranged = mutateBoard(project, boardFor(project).revision, [
+      { kind: "restore", path: "/a.jsonl", placement: "manual" },
+    ]);
+    expect(arranged.ok).toBeTrue();
+    store.commitMigrationIntent({
+      engine: "codex",
+      targetId: "b",
+      origin: "manual",
+      requestId: "repeat-placement-b",
+      expectedRevision: store.engineRouting("codex").revision,
+    });
+    await advanceConversationMigration(
+      conversation.id,
+      store,
+      provider(["/b.jsonl"], { create: 0, verify: 0 }, [["/fork-b.jsonl"]]),
+    );
+    expect(boardFor(project).prefs.manual).toEqual(["/b.jsonl"]);
+
+    store.commitMigrationIntent({
+      engine: "codex",
+      targetId: "c",
+      origin: "manual",
+      requestId: "repeat-placement-c",
+      expectedRevision: store.engineRouting("codex").revision,
+    });
+    arranged = mutateBoard(project, boardFor(project).revision, [
+      { kind: "restore", path: "/fork-c.jsonl", placement: "manual" },
+      { kind: "restore", path: "/c.jsonl", placement: "manual" },
+    ]);
+    expect(arranged.ok).toBeTrue();
+    await advanceConversationMigration(
+      conversation.id,
+      store,
+      provider(["/c.jsonl"], { create: 0, verify: 0 }, [["/fork-c.jsonl"]]),
+    );
+
+    expect(boardFor(project)).toMatchObject({
+      pathAliases: {
+        "/a.jsonl": "/c.jsonl",
+        "/b.jsonl": "/c.jsonl",
+        "/fork-b.jsonl": "/c.jsonl",
+        "/fork-c.jsonl": "/c.jsonl",
+      },
+      prefs: { manual: ["/c.jsonl"] },
+    });
+  });
+
+  test("a 51-conversation drain keeps a two-card board from growing", async () => {
+    const project = "issue-86-mass-drain";
+    const sources = Array.from({ length: 51 }, (_, index) => `/drain-source-${index}.jsonl`);
+    const forks = Array.from({ length: 51 }, (_, index) => `/source-account/drain-fork-${index}.jsonl`);
+    const successors = Array.from({ length: 51 }, (_, index) => `/drain-successor-${index}.jsonl`);
+    const visible = ["/visible-one.jsonl", "/visible-two.jsonl"];
+    const store = registry();
+    store.reconcileConversations(sources.map((pathname) => observation(pathname, "a", "idle", "worker", project)));
+    store.commitMigrationIntent({
+      engine: "codex",
+      targetId: "b",
+      origin: "manual",
+      requestId: "mass-drain-board-continuity",
+      expectedRevision: store.engineRouting("codex").revision,
+    });
+    const arranged = mutateBoard(project, boardFor(project).revision, [
+      ...visible.map((pathname) => ({ kind: "restore" as const, path: pathname, placement: "manual" as const })),
+      ...forks.map((pathname) => ({ kind: "restore" as const, path: pathname, placement: "manual" as const })),
+      ...successors.map((pathname) => ({ kind: "restore" as const, path: pathname, placement: "manual" as const })),
+      ...sources.map((pathname) => ({ kind: "close" as const, path: pathname })),
+    ]);
+    expect(arranged.ok).toBeTrue();
+    expect(arranged.board.prefs.manual).toHaveLength(104);
+
+    await reconcileMigrations(
+      provider([...successors], { create: 0, verify: 0 }, forks.map((pathname) => [pathname])),
+      { async deliver() { return "delivered"; } },
+      store,
+    );
+    const committed = boardFor(project);
+    expect(committed.revision).toBe(arranged.board.revision + 1);
+    const afterScan = mutateBoard(project, committed.revision, [{
+      kind: "reconcile-roots",
+      roots: [...visible, ...forks, ...successors],
+      removeManual: [],
+    }]);
+
+    expect(afterScan.ok).toBeTrue();
+    expect(afterScan.board.prefs.manual).toEqual(visible);
+    expect(afterScan.board.prefs.hidden).toEqual(successors);
+    expect(Object.keys(afterScan.board.pathAliases ?? {})).toHaveLength(102);
+    expect(Object.values(store.snapshot().conversations).every((conversation) => conversation.migration?.boardProject === project)).toBeTrue();
+  });
+
+  test("board repair failures keep delivery and intent reconciliation live", async () => {
+    const project = "issue-86-board-retry";
+    const store = registry();
+    store.reconcileConversations([observation("/repair-source.jsonl", "a", "idle", "worker", project)]);
+    const conversation = store.conversationForPath("/repair-source.jsonl")!;
+    store.commitMigrationIntent({
+      engine: "codex",
+      targetId: "b",
+      origin: "manual",
+      requestId: "board-retry",
+      expectedRevision: store.engineRouting("codex").revision,
+    });
+    store.holdDelivery(conversation.id, "continue", "board-retry-delivery");
+    const delivered: string[] = [];
+
+    await reconcileMigrations(
+      provider(["/repair-target.jsonl"]),
+      { async deliver(input) { delivered.push(input.clientMessageId); return "delivered"; } },
+      store,
+      { remapBoardPaths() { throw new Error("board unavailable"); } },
+    );
+
+    expect(delivered).toEqual(["board-retry-delivery"]);
+    expect(store.snapshot().migrationIntents[store.conversation(conversation.id)!.migration!.intentId]?.state).toBe("complete");
+    expect(store.conversation(conversation.id)?.migration?.boardProject).toBeNull();
+
+    await reconcileMigrations(provider([]), { async deliver() { return "delivered"; } }, store);
+    expect(store.conversation(conversation.id)?.migration?.boardProject).toBe(project);
+    expect(boardFor(project).pathAliases).toEqual({ "/repair-source.jsonl": "/repair-target.jsonl" });
+  });
+
+  test("board repair remains pending when storage omits requested aliases", async () => {
+    const project = "issue-86-board-verification";
+    const store = registry();
+    store.reconcileConversations([observation("/verify-source.jsonl", "a", "idle", "worker", project)]);
+    const conversation = store.conversationForPath("/verify-source.jsonl")!;
+    store.commitMigrationIntent({
+      engine: "codex",
+      targetId: "b",
+      origin: "manual",
+      requestId: "board-verification",
+      expectedRevision: store.engineRouting("codex").revision,
+    });
+
+    await advanceConversationMigration(
+      conversation.id,
+      store,
+      provider(["/verify-target.jsonl"]),
+      { remapBoardPaths: () => boardFor(project) },
+    );
+
+    expect(store.conversation(conversation.id)?.migration?.boardProject).toBeNull();
+    await reconcileMigrations(provider([]), { async deliver() { return "delivered"; } }, store);
+    expect(store.conversation(conversation.id)?.migration?.boardProject).toBe(project);
+  });
+
+  test("a later migration repairs placement stranded by an earlier board outage", async () => {
+    const project = "issue-86-deferred-chain";
+    const store = registry();
+    store.reconcileConversations([observation("/a.jsonl", "a", "idle", "worker", project)]);
+    const conversation = store.conversationForPath("/a.jsonl")!;
+    const closed = mutateBoard(project, boardFor(project).revision, [{ kind: "close", path: "/a.jsonl" }]);
+    expect(closed.ok).toBeTrue();
+    const firstIntent = store.commitMigrationIntent({
+      engine: "codex",
+      targetId: "b",
+      origin: "manual",
+      requestId: "deferred-chain-b",
+      expectedRevision: store.engineRouting("codex").revision,
+    });
+    await advanceConversationMigration(
+      conversation.id,
+      store,
+      provider(["/b.jsonl"]),
+      { remapBoardPaths() { throw new Error("board unavailable"); } },
+    );
+    expect(store.conversation(conversation.id)?.migration?.boardProject).toBeNull();
+    store.setMigrationIntentState(firstIntent.id, "complete");
+    store.reconcileConversations([observation("/b.jsonl", "b", "idle", "worker", project)]);
+    store.commitMigrationIntent({
+      engine: "codex",
+      targetId: "c",
+      origin: "manual",
+      requestId: "deferred-chain-c",
+      expectedRevision: store.engineRouting("codex").revision,
+    });
+
+    await advanceConversationMigration(conversation.id, store, provider(["/c.jsonl"]));
+
+    expect(boardFor(project)).toMatchObject({
+      pathAliases: { "/a.jsonl": "/c.jsonl", "/b.jsonl": "/c.jsonl" },
+      prefs: { hidden: ["/c.jsonl"], manual: [] },
+    });
+  });
+
+  test("board repair follows a successor into its current catalog project", async () => {
+    const store = registry();
+    store.reconcileConversations([observation("/group-source.jsonl", "a", "idle", "worker", "stale-project")]);
+    const conversation = store.conversationForPath("/group-source.jsonl")!;
+    store.commitMigrationIntent({ engine: "codex", targetId: "b", origin: "manual", requestId: "group-repair", expectedRevision: store.engineRouting("codex").revision });
+    let current = store.conversation(conversation.id)!;
+    current = store.transitionConversationMigration(current.id, current.migration!.revision, ["requested"], { phase: "preparing" });
+    current = store.transitionConversationMigration(current.id, current.migration!.revision, ["preparing"], { phase: "successor-starting" });
+    current = store.transitionConversationMigration(current.id, current.migration!.revision, ["successor-starting"], { phase: "verifying" });
+    store.commitSuccessor(current.id, { id: "group-target", path: "/group-target.jsonl", accountId: "b" }, current.migration!.revision);
+    store.reconcileConversations([observation("/group-target.jsonl", "b", "idle", "worker", "canonical-project")]);
+
+    await reconcileMigrations(provider([]), { async deliver() { return "delivered"; } }, store);
+
+    expect(boardFor("canonical-project").pathAliases).toEqual({ "/group-source.jsonl": "/group-target.jsonl" });
+    expect(store.conversation(conversation.id)?.migration?.boardProject).toBe("canonical-project");
+  });
+
+  test("first restart repair transfers predecessor placement into the corrected project", async () => {
+    for (const placement of ["hidden", "manual", "expanded"] as const) {
+      const store = registry();
+      const sourcePath = `/restart-${placement}-source.jsonl`;
+      const targetPath = `/restart-${placement}-target.jsonl`;
+      const oldProject = `restart-${placement}-old`;
+      const newProject = `restart-${placement}-new`;
+      store.reconcileConversations([observation(sourcePath, "a", "idle", "worker", oldProject)]);
+      const conversation = store.conversationForPath(sourcePath)!;
+      const arranged = mutateBoard(oldProject, boardFor(oldProject).revision, [placement === "hidden"
+        ? { kind: "close", path: sourcePath }
+        : { kind: "restore", path: sourcePath, placement }]);
+      expect(arranged.ok).toBeTrue();
+      store.commitMigrationIntent({
+        engine: "codex",
+        targetId: "b",
+        origin: "manual",
+        requestId: `restart-${placement}`,
+        expectedRevision: store.engineRouting("codex").revision,
+      });
+      let current = store.conversation(conversation.id)!;
+      current = store.transitionConversationMigration(current.id, current.migration!.revision, ["requested"], { phase: "preparing" });
+      current = store.transitionConversationMigration(current.id, current.migration!.revision, ["preparing"], { phase: "successor-starting" });
+      current = store.transitionConversationMigration(current.id, current.migration!.revision, ["successor-starting"], { phase: "verifying" });
+      store.commitSuccessor(current.id, { id: `restart-${placement}-target`, path: targetPath, accountId: "b" }, current.migration!.revision);
+      store.reconcileConversations([
+        observation(sourcePath, "a", "idle", "worker", newProject),
+        observation(targetPath, "b", "idle", "worker", newProject),
+      ]);
+
+      await reconcileMigrations(provider([]), { async deliver() { return "delivered"; } }, store);
+
+      expect(boardFor(oldProject).prefs[placement]).toEqual([]);
+      expect(boardFor(newProject).prefs[placement]).toEqual([targetPath]);
+    }
+  });
+
+  test("project correction removes provisional continuity cards after a board outage", async () => {
+    const store = registry();
+    const sourcePath = "/outage-project-source.jsonl";
+    const forkPath = "/outage-project-fork.jsonl";
+    const targetPath = "/outage-project-target.jsonl";
+    store.reconcileConversations([observation(sourcePath, "a", "idle", "worker", "outage-old-project")]);
+    const conversation = store.conversationForPath(sourcePath)!;
+    store.commitMigrationIntent({
+      engine: "codex",
+      targetId: "b",
+      origin: "manual",
+      requestId: "outage-project-correction",
+      expectedRevision: store.engineRouting("codex").revision,
+    });
+    const provisional = mutateBoard("outage-old-project", boardFor("outage-old-project").revision, [
+      { kind: "restore", path: forkPath, placement: "manual" },
+    ]);
+    expect(provisional.ok).toBeTrue();
+    await advanceConversationMigration(
+      conversation.id,
+      store,
+      provider([targetPath], { create: 0, verify: 0 }, [[forkPath]]),
+      { remapBoardPaths() { throw new Error("board unavailable"); } },
+    );
+    store.reconcileConversations([
+      observation(targetPath, "b", "idle", "worker", "outage-new-project"),
+    ]);
+
+    await reconcileMigrations(provider([]), { async deliver() { return "delivered"; } }, store);
+
+    expect(boardFor("outage-old-project").prefs.manual).toEqual([]);
+    expect(boardFor("outage-new-project")).toMatchObject({
+      pathAliases: { [sourcePath]: targetPath, [forkPath]: targetPath },
+      prefs: { manual: [], hidden: [], expanded: [] },
+    });
+  });
+
+  test("project correction transfers previously repaired placement", async () => {
+    const store = registry();
+    store.reconcileConversations([observation("/project-source.jsonl", "a", "idle", "worker", "stale-project")]);
+    const conversation = store.conversationForPath("/project-source.jsonl")!;
+    const closed = mutateBoard("stale-project", boardFor("stale-project").revision, [
+      { kind: "close", path: "/project-source.jsonl" },
+    ]);
+    expect(closed.ok).toBeTrue();
+    store.commitMigrationIntent({
+      engine: "codex",
+      targetId: "b",
+      origin: "manual",
+      requestId: "project-correction",
+      expectedRevision: store.engineRouting("codex").revision,
+    });
+    await advanceConversationMigration(conversation.id, store, provider(["/project-target.jsonl"]));
+    expect(boardFor("stale-project").prefs.hidden).toEqual(["/project-target.jsonl"]);
+    expect(store.conversation(conversation.id)?.migration?.boardProject).toBe("stale-project");
+    store.reconcileConversations([
+      observation("/stays-in-source.jsonl", "a", "idle", "worker", "stale-project"),
+    ]);
+    const kept = mutateBoard("stale-project", boardFor("stale-project").revision, [
+      { kind: "close", path: "/stays-in-source.jsonl" },
+    ]);
+    expect(kept.ok).toBeTrue();
+    store.reconcileConversations([
+      observation("/project-target.jsonl", "b", "idle", "worker", "canonical-project"),
+    ]);
+
+    await reconcileMigrations(
+      provider([]),
+      { async deliver() { return "delivered"; } },
+      store,
+      { remapBoardPaths() { throw new Error("alias storage unavailable"); } },
+    );
+    expect(boardFor("canonical-project").prefs.hidden).toEqual(["/project-target.jsonl"]);
+    expect(store.conversation(conversation.id)?.migration?.boardProject).toBe("stale-project");
+    store.reconcileConversations([
+      observation("/project-target.jsonl", "b", "idle", "worker", "final-project"),
+    ]);
+
+    await reconcileMigrations(provider([]), { async deliver() { return "delivered"; } }, store);
+
+    expect(boardFor("stale-project").prefs.hidden).toEqual(["/stays-in-source.jsonl"]);
+    expect(boardFor("canonical-project").prefs.hidden).toEqual([]);
+    expect(boardFor("final-project")).toMatchObject({
+      pathAliases: { "/project-source.jsonl": "/project-target.jsonl" },
+      prefs: { hidden: ["/project-target.jsonl"], manual: [] },
+    });
+    expect(store.conversation(conversation.id)?.migration?.boardProject).toBe("final-project");
+  });
+
+  test("repeat migration carries prior project placement into the regrouped board", async () => {
+    for (const placement of ["hidden", "manual", "expanded"] as const) {
+      const store = registry();
+      const sourcePath = `/${placement}-a.jsonl`;
+      const middlePath = `/${placement}-b.jsonl`;
+      const targetPath = `/${placement}-c.jsonl`;
+      const oldProject = `${placement}-old-project`;
+      const newProject = `${placement}-new-project`;
+      store.reconcileConversations([observation(sourcePath, "a", "idle", "worker", oldProject)]);
+      const conversation = store.conversationForPath(sourcePath)!;
+      const arranged = mutateBoard(oldProject, boardFor(oldProject).revision, [placement === "hidden"
+        ? { kind: "close", path: sourcePath }
+        : { kind: "restore", path: sourcePath, placement }]);
+      expect(arranged.ok).toBeTrue();
+      const firstIntent = store.commitMigrationIntent({
+        engine: "codex",
+        targetId: "b",
+        origin: "manual",
+        requestId: `${placement}-to-b`,
+        expectedRevision: store.engineRouting("codex").revision,
+      });
+      await advanceConversationMigration(conversation.id, store, provider([middlePath]));
+      store.setMigrationIntentState(firstIntent.id, "complete");
+      store.reconcileConversations([observation(middlePath, "b", "idle", "worker", newProject)]);
+      store.commitMigrationIntent({
+        engine: "codex",
+        targetId: "c",
+        origin: "manual",
+        requestId: `${placement}-to-c`,
+        expectedRevision: store.engineRouting("codex").revision,
+      });
+
+      await advanceConversationMigration(conversation.id, store, provider([targetPath]));
+
+      expect(boardFor(oldProject).prefs[placement]).toEqual([]);
+      expect(boardFor(newProject).prefs[placement]).toEqual([targetPath]);
+    }
+  });
+
   test("unowned inventory stays outside previews and committed migration scope", async () => {
     const store = registry();
     store.reconcileConversations([
@@ -155,9 +923,11 @@ describe("durable account migration coordinator", () => {
     expect(final.generations.at(-1)?.launchProfile.plan?.current).toBe("Implement");
   });
 
-  test("restart adopts a persisted provider receipt without creating another successor", async () => {
+  test("restart adopts a persisted two-path Codex receipt and repairs board continuity", async () => {
+    const project = "issue-86-restart-two-path";
+    const sourceForkPath = "/source-account/restart-fork.jsonl";
     const store = registry();
-    store.reconcileConversations([observation("/source.jsonl", "a", "idle")]);
+    store.reconcileConversations([observation("/source.jsonl", "a", "idle", "worker", project)]);
     const conversation = store.conversationForPath("/source.jsonl")!;
     store.commitMigrationIntent({ engine: "codex", targetId: "b", origin: "manual", requestId: "restart", expectedRevision: store.engineRouting("codex").revision });
     const revision = store.conversation(conversation.id)!.migration!.revision;
@@ -167,16 +937,23 @@ describe("durable account migration coordinator", () => {
       operationId: store.conversation(conversation.id)!.migration!.operationId,
       nativeId: "native-b",
       path: "/b.jsonl",
+      continuityPaths: [sourceForkPath],
       historyHash: "hash",
       host: { kind: "codex-app-server", identity: "host", epoch: 1, verifiedAt: "2026-07-10T12:01:00.000Z" },
     };
     store.transitionConversationMigration(conversation.id, revision, ["successor-starting"], { phase: "verifying", providerReceipt: receipt });
+    const closed = mutateBoard(project, boardFor(project).revision, [{ kind: "close", path: "/source.jsonl" }]);
+    expect(closed.ok).toBeTrue();
 
     const restarted = new AgentRegistry(store.filename);
     const counts = { create: 0, verify: 0 };
     const final = await advanceConversationMigration(conversation.id, restarted, provider([], counts));
     expect(counts).toEqual({ create: 0, verify: 1 });
     expect(final.generations.at(-1)?.path).toBe("/b.jsonl");
+    expect(boardFor(project)).toMatchObject({
+      pathAliases: { "/source.jsonl": "/b.jsonl", [sourceForkPath]: "/b.jsonl" },
+      prefs: { hidden: ["/b.jsonl"], manual: [] },
+    });
   });
 
   test("busy sessions wait for authoritative terminal evidence", async () => {
@@ -275,6 +1052,7 @@ describe("durable account migration coordinator", () => {
           operationId: input.operationId,
           nativeId: "stale-b",
           path: "/stale-b.jsonl",
+          continuityPaths: [],
           historyHash: "stale",
           host: { kind: "codex-app-server", identity: "stale", epoch: 1, verifiedAt: "2026-07-10T12:01:00.000Z" },
         };
@@ -295,10 +1073,12 @@ describe("durable account migration coordinator", () => {
     const provider: SuccessorProviderPort = {
       async create(input) {
         store.setMigrationIntentState(intent.id, "stopped");
+        input.recordContinuityPath("/discarded-successor.jsonl");
         return {
           operationId: input.operationId,
           nativeId: "discarded-successor",
           path: "/discarded-successor.jsonl",
+          continuityPaths: [],
           historyHash: "discarded",
           host: { kind: "codex-app-server", identity: "discarded", epoch: 1, verifiedAt: "2026-07-10T12:01:00.000Z" },
         };
@@ -312,6 +1092,7 @@ describe("durable account migration coordinator", () => {
     expect(settled.migration?.phase).toBe("rolled-back");
     expect(settled.generations).toHaveLength(1);
     expect(cleaned).toEqual(["discarded-successor"]);
+    expect(store.conversationForPath("/discarded-successor.jsonl")?.id).toBe(conversation.id);
   });
 
   test("a verification failure releases the successor before returning a recoverable phase", async () => {
@@ -326,6 +1107,7 @@ describe("durable account migration coordinator", () => {
           operationId: input.operationId,
           nativeId: "failed-successor",
           path: "/failed-successor.jsonl",
+          continuityPaths: [],
           historyHash: "failed",
           host: { kind: "codex-app-server", identity: "failed", epoch: 1, verifiedAt: "2026-07-10T12:01:00.000Z" },
         };

--- a/src/lib/accounts/migration/coordinator.ts
+++ b/src/lib/accounts/migration/coordinator.ts
@@ -373,8 +373,9 @@ export async function advanceConversationMigration(
     const durableReceipt = latest?.migration?.providerReceipt;
     const fencedByDurableReceipt = receipt !== null && durableReceipt !== null && durableReceipt !== undefined
       && !sameProviderReceiptOutcome(durableReceipt, receipt);
-    if (latest?.migration && (
-      latest.migration.revision !== migration.revision
+    if (latest && (
+      !latest.migration
+      || latest.migration.revision !== migration.revision
       || latest.migration.operationId !== migration.operationId
       || terminalMigrationPhase(latest.migration.phase)
       || fencedByDurableReceipt

--- a/src/lib/accounts/migration/coordinator.ts
+++ b/src/lib/accounts/migration/coordinator.ts
@@ -111,9 +111,9 @@ export async function previewMigration(
   engine: MigrationEngine,
   targetId: string,
   registry: AgentRegistry = agentRegistry(),
-  files?: FileEntry[],
 ): Promise<MigrationPreview> {
-  await reconcileMigrationInventory(registry, files);
+  // AccountMigrationController owns inventory scans. The request path projects
+  // its durable snapshot so preview stays mutation-free and avoids transcript I/O.
   return previewFromSnapshot(engine, targetId, registry);
 }
 
@@ -124,10 +124,10 @@ export async function createMigrationIntent(
   requestId: string = crypto.randomUUID(),
   previewRevision?: number,
   registry: AgentRegistry = agentRegistry(),
-  files?: FileEntry[],
   evidence: MigrationIntent["evidence"] = null,
 ): Promise<{ intent: MigrationIntent; preview: MigrationPreview }> {
-  await reconcileMigrationInventory(registry, files);
+  // The revision fence below detects controller updates after confirmation.
+  // Re-scanning here would add request latency and invalidate its own preview.
   const preview = previewFromSnapshot(engine, targetId, registry);
   const intent = registry.commitMigrationIntent({
     engine,

--- a/src/lib/accounts/migration/coordinator.ts
+++ b/src/lib/accounts/migration/coordinator.ts
@@ -5,12 +5,18 @@ import { listClaudeAccounts } from "@/lib/accounts/claude";
 import { listCodexAccounts } from "@/lib/accounts/codex";
 import { agentRegistry, type AgentRegistry, type ConversationObservation, type RegistryConversation } from "@/lib/agent/registry";
 import { headCwd } from "@/lib/agent/transcript";
+import {
+  remapBoardPaths as remapDurableBoardPaths,
+  transferBoardPathPlacements as transferDurableBoardPathPlacements,
+} from "@/lib/board/store";
 import { listFiles } from "@/lib/scanner";
 import { tailRecords } from "@/lib/scanner/activity";
 import type { FileEntry } from "@/lib/types";
 
 import {
   emptyLaunchProfile,
+  sameGenerationHostEvidence,
+  sameProviderReceiptOutcome,
   type HistoryCopyPort,
   type HeldDelivery,
   type MigrationEngine,
@@ -20,7 +26,7 @@ import {
   type SuccessorProviderPort,
   type ViewerConversationId,
 } from "./contracts";
-import { RegisteredSuccessorProvider } from "./provider";
+import { RegisteredSuccessorProvider, SuccessorPendingError } from "./provider";
 import { safeProviderDiagnostic, sanitizeProviderError } from "./safeHistoryCopy";
 import { turnStateFromRecords } from "./turnState";
 import { AUTO_BALANCE_COOLDOWN_MS } from "./quotaPolicy";
@@ -157,6 +163,7 @@ function copyAdapter(copy: HistoryCopyPort): SuccessorProviderPort {
         operationId: input.operationId,
         nativeId: successor.nativeId,
         path: successor.path,
+        continuityPaths: [],
         historyHash: "legacy-copy-port",
         host: { kind: "tmux", identity: "legacy-copy-port", epoch: 1, verifiedAt: new Date().toISOString() },
       };
@@ -173,6 +180,105 @@ function terminalMigrationPhase(phase: string): boolean {
   return phase === "committed" || phase === "rolled-back" || phase === "failed-recoverable";
 }
 
+export interface MigrationCoordinatorOptions {
+  remapBoardPaths?: typeof remapDurableBoardPaths;
+  transferBoardPathPlacements?: typeof transferDurableBoardPathPlacements;
+  deferBoardRepair?: boolean;
+}
+
+interface BoardRepairPlan {
+  conversationId: ViewerConversationId;
+  operationId: string;
+  project: string;
+  previousProject: string | null;
+  placementPaths: string[];
+  pairs: { from: string; to: string }[];
+  provisionalManual: string[];
+}
+
+function boardRepairPlan(conversation: RegistryConversation): BoardRepairPlan | null {
+  if (conversation.migration?.phase !== "committed") return null;
+  const successor = conversation.generations.at(-1);
+  const source = conversation.generations.find((generation) => generation.id === conversation.migration?.sourceGenerationId)
+    ?? conversation.generations.at(-2);
+  if (!source || !successor || source.id === successor.id) return null;
+  const project = successor.launchProfile.project || source.launchProfile.project || "other";
+  if (conversation.migration.boardProject === project
+    && conversation.migration.boardOperationId === conversation.migration.operationId) return null;
+  const continuityPaths = [...new Set([
+    ...conversation.continuityPaths,
+    ...(conversation.migration.providerReceipt?.continuityPaths ?? []),
+  ])];
+  const archivedGenerationPaths = conversation.generations.slice(0, -1).map((generation) => generation.path);
+  const sources = [...new Set([...archivedGenerationPaths, ...continuityPaths])].filter((pathname) => pathname !== successor.path);
+  return {
+    conversationId: conversation.id,
+    operationId: conversation.migration.operationId,
+    project,
+    previousProject: conversation.migration.boardPlacementProject
+      ?? conversation.migration.boardProject
+      ?? source.launchProfile.project,
+    placementPaths: [...new Set([source.path, successor.path, ...continuityPaths])],
+    pairs: sources.map((from) => ({ from, to: successor.path })),
+    provisionalManual: continuityPaths.filter((pathname) => pathname !== successor.path),
+  };
+}
+
+function repairCommittedBoardSuccessions(
+  conversations: readonly RegistryConversation[],
+  registry: AgentRegistry,
+  remapPaths: typeof remapDurableBoardPaths,
+  transferPlacements: typeof transferDurableBoardPathPlacements,
+): void {
+  const plans = conversations.flatMap((conversation) => {
+    const plan = boardRepairPlan(conversation);
+    return plan ? [plan] : [];
+  });
+  const placementTransfers = plans.flatMap((plan) => plan.previousProject && plan.previousProject !== plan.project
+    ? [{ fromProject: plan.previousProject, toProject: plan.project, paths: plan.placementPaths }]
+    : []);
+  if (placementTransfers.length > 0) {
+    try {
+      transferPlacements(placementTransfers);
+    } catch (error) {
+      console.warn("[account-migration] board project repair deferred", {
+        projects: placementTransfers.length,
+        error: safeProviderDiagnostic(error),
+      });
+      return;
+    }
+  }
+  registry.markMigrationBoardPlacementProjects(
+    plans.map((plan) => ({ id: plan.conversationId, operationId: plan.operationId, project: plan.project })),
+  );
+  const byProject = new Map<string, BoardRepairPlan[]>();
+  for (const plan of plans) {
+    byProject.set(plan.project, [...(byProject.get(plan.project) ?? []), plan]);
+  }
+  const converged: { id: ViewerConversationId; operationId: string; project: string }[] = [];
+  for (const [project, plans] of byProject) {
+    try {
+      const repaired = remapPaths(
+        project,
+        plans.flatMap((plan) => plan.pairs),
+        { provisionalManual: [...new Set(plans.flatMap((plan) => plan.provisionalManual))] },
+      );
+      const aliases = repaired.pathAliases ?? {};
+      if (!plans.every((plan) => plan.pairs.every(({ from, to }) => aliases[from] === to))) {
+        throw new Error("board continuity aliases did not converge");
+      }
+      converged.push(...plans.map((plan) => ({ id: plan.conversationId, operationId: plan.operationId, project })));
+    } catch (error) {
+      console.warn("[account-migration] board continuity repair deferred", {
+        project,
+        conversations: plans.length,
+        error: safeProviderDiagnostic(error),
+      });
+    }
+  }
+  registry.markMigrationBoardProjects(converged);
+}
+
 async function cleanupDiscardedSuccessor(
   provider: SuccessorProviderPort,
   receipt: ProviderReceipt | null,
@@ -181,7 +287,9 @@ async function cleanupDiscardedSuccessor(
   if (!receipt) return;
   const committed = latest.migration?.phase === "committed";
   const current = latest.generations.at(-1);
-  if (committed && current?.id === receipt.nativeId && current.path === receipt.path) return;
+  const ownsCommittedHost = current?.host !== null && current?.host !== undefined
+    && sameGenerationHostEvidence(current.host, receipt.host);
+  if (committed && current?.id === receipt.nativeId && current.path === receipt.path && ownsCommittedHost) return;
   try { await provider.cleanup?.(receipt); } catch { /* cleanup is best effort after a fenced result */ }
 }
 
@@ -189,6 +297,7 @@ export async function advanceConversationMigration(
   conversationId: ViewerConversationId,
   registry: AgentRegistry = agentRegistry(),
   provider: SuccessorProviderPort | HistoryCopyPort = productionProvider(),
+  options: MigrationCoordinatorOptions = {},
 ): Promise<RegistryConversation> {
   let conversation = registry.conversation(conversationId);
   if (!conversation?.migration) throw new Error("conversation has no migration");
@@ -198,7 +307,16 @@ export async function advanceConversationMigration(
     conversation = registry.transitionConversationMigration(conversation.id, migration.revision, ["waiting-turn"], { phase: "requested" });
     migration = conversation.migration!;
   }
-  if (migration.phase === "committed" || migration.phase === "rolled-back" || migration.phase === "failed-recoverable") return conversation;
+  if (migration.phase === "committed") {
+    if (!options.deferBoardRepair) repairCommittedBoardSuccessions(
+      [conversation],
+      registry,
+      options.remapBoardPaths ?? remapDurableBoardPaths,
+      options.transferBoardPathPlacements ?? transferDurableBoardPathPlacements,
+    );
+    return registry.conversation(conversation.id) ?? conversation;
+  }
+  if (migration.phase === "rolled-back" || migration.phase === "failed-recoverable") return conversation;
   const source = conversation.generations.find((generation) => generation.id === migration.sourceGenerationId)
     ?? conversation.generations.at(-1);
   if (!source) throw new Error("conversation has no source generation");
@@ -216,20 +334,25 @@ export async function advanceConversationMigration(
         conversation = registry.transitionConversationMigration(conversation.id, migration.revision, ["preparing"], { phase: "successor-starting" });
         migration = conversation.migration!;
       }
+      const conversationId = conversation.id;
       receipt = await successorProvider.create({
         engine: conversation.engine,
         operationId: migration.operationId,
-        conversationId: conversation.id,
+        conversationId,
         source,
         targetAccountId: migration.targetId,
+        recordContinuityPath(pathname) {
+          conversation = registry.recordConversationContinuityPath(conversationId, pathname);
+        },
       });
       if (receipt.operationId !== migration.operationId) throw new Error("successor receipt operation does not match");
-      conversation = registry.transitionConversationMigration(conversation.id, migration.revision, ["successor-starting"], { phase: "verifying", providerReceipt: receipt });
+      conversation = registry.persistMigrationProviderReceipt(conversation.id, migration.revision, migration.operationId, receipt);
       migration = conversation.migration!;
+      receipt = migration.providerReceipt ?? receipt;
     }
     if (!receipt || receipt.operationId !== migration.operationId) throw new Error("persisted successor receipt operation does not match");
     await successorProvider.verify(receipt, { engine: conversation.engine, targetAccountId: migration.targetId, launchProfile: source.launchProfile });
-    return registry.commitSuccessor(conversation.id, {
+    const committed = registry.commitSuccessor(conversation.id, {
       id: receipt.nativeId,
       path: receipt.path,
       accountId: migration.targetId,
@@ -237,15 +360,33 @@ export async function advanceConversationMigration(
       historyHash: receipt.historyHash,
       host: receipt.host,
     }, migration.revision);
+    if (!options.deferBoardRepair) repairCommittedBoardSuccessions(
+      [committed],
+      registry,
+      options.remapBoardPaths ?? remapDurableBoardPaths,
+      options.transferBoardPathPlacements ?? transferDurableBoardPathPlacements,
+    );
+    return registry.conversation(committed.id) ?? committed;
   } catch (error) {
     const latest = registry.conversation(conversation.id);
+    if (error instanceof SuccessorPendingError) return latest ?? conversation;
+    const durableReceipt = latest?.migration?.providerReceipt;
+    const fencedByDurableReceipt = receipt !== null && durableReceipt !== null && durableReceipt !== undefined
+      && !sameProviderReceiptOutcome(durableReceipt, receipt);
     if (latest?.migration && (
       latest.migration.revision !== migration.revision
       || latest.migration.operationId !== migration.operationId
       || terminalMigrationPhase(latest.migration.phase)
+      || fencedByDurableReceipt
     )) {
       await cleanupDiscardedSuccessor(successorProvider, receipt, latest);
-      return latest;
+      if (!options.deferBoardRepair) repairCommittedBoardSuccessions(
+        [latest],
+        registry,
+        options.remapBoardPaths ?? remapDurableBoardPaths,
+        options.transferBoardPathPlacements ?? transferDurableBoardPathPlacements,
+      );
+      return registry.conversation(latest.id) ?? latest;
     }
     console.warn("[account-migration] recoverable successor provider failure", {
       conversationId: conversation.id,
@@ -291,20 +432,34 @@ export async function reconcileMigrations(
   provider: SuccessorProviderPort,
   delivery: HeldDeliveryPort,
   registry: AgentRegistry = agentRegistry(),
+  options: MigrationCoordinatorOptions = {},
 ): Promise<void> {
   const before = registry.snapshot();
+  const pendingDeliveries = new Set(Object.values(before.heldDeliveries)
+    .filter((item) => item.state !== "delivered" && item.state !== "delivery-uncertain")
+    .map((item) => item.conversationId));
   for (const conversation of Object.values(before.conversations)) {
-    if (!conversation.migration || conversation.migration.phase === "committed" || conversation.migration.phase === "rolled-back") continue;
+    if (!conversation.migration || conversation.migration.phase === "rolled-back") continue;
+    if (conversation.migration.phase === "committed") {
+      if (pendingDeliveries.has(conversation.id)) await drainHeldDeliveries(conversation.id, delivery, registry);
+      continue;
+    }
     const source = conversation.generations.find((generation) => generation.id === conversation.migration?.sourceGenerationId)
       ?? conversation.generations.at(-1);
     if (source?.accountId === null && !conversation.migration.providerReceipt) {
       registry.rollbackConversationMigration(conversation.id, conversation.migration.revision);
       continue;
     }
-    const advanced = await advanceConversationMigration(conversation.id, registry, provider);
-    if (advanced.migration?.phase === "committed") await drainHeldDeliveries(advanced.id, delivery, registry);
+    const advanced = await advanceConversationMigration(conversation.id, registry, provider, { ...options, deferBoardRepair: true });
+    if (advanced.migration?.phase === "committed" && pendingDeliveries.has(advanced.id)) await drainHeldDeliveries(advanced.id, delivery, registry);
   }
   const after = registry.snapshot();
+  repairCommittedBoardSuccessions(
+    Object.values(after.conversations),
+    registry,
+    options.remapBoardPaths ?? remapDurableBoardPaths,
+    options.transferBoardPathPlacements ?? transferDurableBoardPathPlacements,
+  );
   for (const intent of Object.values(after.migrationIntents)) {
     if (intent.state !== "draining") continue;
     const owned = Object.values(after.conversations).filter((conversation) => conversation.migration?.intentId === intent.id);

--- a/src/lib/accounts/migration/coordinator.ts
+++ b/src/lib/accounts/migration/coordinator.ts
@@ -26,7 +26,7 @@ import {
   type SuccessorProviderPort,
   type ViewerConversationId,
 } from "./contracts";
-import { RegisteredSuccessorProvider, SuccessorPendingError } from "./provider";
+import { CodexForkOutcomeUnknownError, RegisteredSuccessorProvider, SuccessorPendingError } from "./provider";
 import { safeProviderDiagnostic, sanitizeProviderError } from "./safeHistoryCopy";
 import { turnStateFromRecords } from "./turnState";
 import { AUTO_BALANCE_COOLDOWN_MS } from "./quotaPolicy";
@@ -283,14 +283,24 @@ async function cleanupDiscardedSuccessor(
   provider: SuccessorProviderPort,
   receipt: ProviderReceipt | null,
   latest: RegistryConversation,
+  registry: AgentRegistry,
 ): Promise<void> {
   if (!receipt) return;
   const committed = latest.migration?.phase === "committed";
   const current = latest.generations.at(-1);
   const ownsCommittedHost = current?.host !== null && current?.host !== undefined
     && sameGenerationHostEvidence(current.host, receipt.host);
-  if (committed && current?.id === receipt.nativeId && current.path === receipt.path && ownsCommittedHost) return;
-  try { await provider.cleanup?.(receipt); } catch { /* cleanup is best effort after a fenced result */ }
+  if (committed && current?.id === receipt.nativeId && current.path === receipt.path && ownsCommittedHost) {
+    registry.completeSuccessorCleanup(receipt.operationId);
+    return;
+  }
+  registry.queueSuccessorCleanup(latest.id, receipt);
+  try {
+    await provider.cleanup?.(receipt);
+    registry.completeSuccessorCleanup(receipt.operationId);
+  } catch (error) {
+    registry.recordSuccessorCleanupFailure(receipt.operationId, error instanceof Error ? error.message : String(error));
+  }
 }
 
 export async function advanceConversationMigration(
@@ -380,7 +390,7 @@ export async function advanceConversationMigration(
       || terminalMigrationPhase(latest.migration.phase)
       || fencedByDurableReceipt
     )) {
-      await cleanupDiscardedSuccessor(successorProvider, receipt, latest);
+      await cleanupDiscardedSuccessor(successorProvider, receipt, latest, registry);
       if (!options.deferBoardRepair) repairCommittedBoardSuccessions(
         [latest],
         registry,
@@ -396,13 +406,15 @@ export async function advanceConversationMigration(
       targetAccountId: migration.targetId,
       error: safeProviderDiagnostic(error),
     });
-    const safe = sanitizeProviderError(error);
+    const safe = error instanceof CodexForkOutcomeUnknownError
+      ? { message: "Codex fork outcome is awaiting recovery", code: "codex-fork-outcome-unknown" }
+      : sanitizeProviderError(error);
     const failed = registry.transitionConversationMigration(conversation.id, migration.revision, ["requested", "preparing", "successor-starting", "verifying"], {
       phase: "failed-recoverable",
       error: safe.message,
       errorCode: safe.code,
     });
-    await cleanupDiscardedSuccessor(successorProvider, receipt, failed);
+    await cleanupDiscardedSuccessor(successorProvider, receipt, failed, registry);
     return failed;
   }
 }
@@ -436,6 +448,10 @@ export async function reconcileMigrations(
   options: MigrationCoordinatorOptions = {},
 ): Promise<void> {
   const before = registry.snapshot();
+  for (const pending of Object.values(before.pendingSuccessorCleanups)) {
+    const owner = registry.conversation(pending.conversationId);
+    if (owner) await cleanupDiscardedSuccessor(provider, pending.receipt, owner, registry);
+  }
   const pendingDeliveries = new Set(Object.values(before.heldDeliveries)
     .filter((item) => item.state !== "delivered" && item.state !== "delivery-uncertain")
     .map((item) => item.conversationId));

--- a/src/lib/accounts/migration/provider.test.ts
+++ b/src/lib/accounts/migration/provider.test.ts
@@ -291,7 +291,11 @@ test("Claude create cancels the live host when continuity persistence fails", as
     accounts: { resolveSpawn: () => target, resolveTranscriptOwner: () => source },
     startCodex: async () => { throw new Error("unexpected Codex client"); },
     claudeStatus: async () => ({ loggedIn: true }),
-    spawnClaude: async () => ({ paneId: "%25", panePid: 2525, host: claudeHost("%25", 2525) }),
+    spawnClaude: async (spec) => {
+      fs.mkdirSync(path.dirname(spec.transcript!), { recursive: true, mode: 0o700 });
+      fs.writeFileSync(spec.transcript!, JSON.stringify({ sessionId: path.basename(spec.transcript!, ".jsonl") }) + "\n", { mode: 0o600 });
+      return { paneId: "%25", panePid: 2525, host: claudeHost("%25", 2525) };
+    },
     cancelClaude: async (host) => { cancelled.push(host.paneId); return true; },
     registry,
     claudeJournalRoot: path.join(base, "claude-operations"),
@@ -308,7 +312,18 @@ test("Claude create cancels the live host when continuity persistence fails", as
   })).rejects.toThrow("registry unavailable");
 
   expect(cancelled).toEqual(["%25"]);
-  expect(Object.values(registry.snapshot().receipts)[0]).toMatchObject({ state: "conflicted", error: "migration continuity persistence failed" });
+  const spawnReceipt = Object.values(registry.snapshot().receipts)[0]!;
+  expect(spawnReceipt).toMatchObject({ state: "path-pending", error: "migration continuity persistence failed" });
+  registry.reconcileConversations([{
+    engine: "claude",
+    path: spawnReceipt.artifactPath!,
+    accountId: "target",
+    launchProfile: emptyLaunchProfile({ cwd: "/repo" }),
+    turn: { state: "idle", source: "empty", terminalAt: null },
+    observedAt: "2026-07-10T12:01:00.000Z",
+  }]);
+  expect(registry.conversationForPath(spawnReceipt.artifactPath!)?.id).toBe(conversation.id);
+  expect(Object.values(registry.snapshot().conversations)).toHaveLength(1);
 });
 
 test("Claude replay cancels its verified host when continuity persistence fails", async () => {
@@ -348,7 +363,7 @@ test("Claude replay cancels its verified host when continuity persistence fails"
   })).rejects.toThrow("registry unavailable on replay");
 
   expect(cancelled).toEqual(["%26"]);
-  expect(Object.values(registry.snapshot().receipts)[0]).toMatchObject({ state: "conflicted", error: "migration continuity persistence failed" });
+  expect(Object.values(registry.snapshot().receipts)[0]).toMatchObject({ state: "path-pending", error: "migration continuity persistence failed" });
 });
 
 test("Claude replay resumes a pane-free birth receipt and fences terminal spawn state", async () => {

--- a/src/lib/accounts/migration/provider.test.ts
+++ b/src/lib/accounts/migration/provider.test.ts
@@ -227,7 +227,7 @@ test("Claude cleanup cancels only the pane PID recorded by the losing receipt", 
     host: { kind: "claude-stream" as const, identity: "%7:77", epoch: 1, verifiedAt: "2026-07-10T12:00:00.000Z", tmuxHost: claudeHost("%7", 77) },
   };
 
-  await provider.cleanup(receipt);
+  await expect(provider.cleanup(receipt)).rejects.toThrow("cleanup is still pending");
   expect(cancelled).toEqual([]);
   observedPid = 77;
   await provider.cleanup(receipt);

--- a/src/lib/accounts/migration/provider.test.ts
+++ b/src/lib/accounts/migration/provider.test.ts
@@ -277,6 +277,80 @@ test("concurrent Claude creates reuse one durable migration spawn receipt", asyn
   expect(launchReceipts[0]).toMatchObject({ conversationId: conversation.id, purpose: "migration-successor" });
 });
 
+test("Claude create cancels the live host when continuity persistence fails", async () => {
+  const base = fs.mkdtempSync(path.join(os.tmpdir(), "llv-provider-claude-continuity-failure-"));
+  roots.push(base);
+  const source = accountRoot("claude", base, "source");
+  const target = accountRoot("claude", base, "target");
+  const sourcePath = path.join(source.transcriptRoot, "source.jsonl");
+  fs.writeFileSync(sourcePath, "{}\n", { mode: 0o600 });
+  const registry = new AgentRegistry(path.join(base, "provider-registry.json"));
+  const conversation = registry.ensureConversation("claude", sourcePath, "source");
+  const cancelled: string[] = [];
+  const provider = new RegisteredSuccessorProvider({
+    accounts: { resolveSpawn: () => target, resolveTranscriptOwner: () => source },
+    startCodex: async () => { throw new Error("unexpected Codex client"); },
+    claudeStatus: async () => ({ loggedIn: true }),
+    spawnClaude: async () => ({ paneId: "%25", panePid: 2525, host: claudeHost("%25", 2525) }),
+    cancelClaude: async (host) => { cancelled.push(host.paneId); return true; },
+    registry,
+    claudeJournalRoot: path.join(base, "claude-operations"),
+    now: () => "2026-07-10T12:00:00.000Z",
+  });
+
+  await expect(provider.create({
+    engine: "claude",
+    operationId: "claude-continuity-failure",
+    conversationId: conversation.id,
+    targetAccountId: "target",
+    source: conversation.generations[0]!,
+    recordContinuityPath() { throw new Error("registry unavailable"); },
+  })).rejects.toThrow("registry unavailable");
+
+  expect(cancelled).toEqual(["%25"]);
+  expect(Object.values(registry.snapshot().receipts)[0]).toMatchObject({ state: "conflicted", error: "migration continuity persistence failed" });
+});
+
+test("Claude replay cancels its verified host when continuity persistence fails", async () => {
+  const base = fs.mkdtempSync(path.join(os.tmpdir(), "llv-provider-claude-replay-continuity-failure-"));
+  roots.push(base);
+  const source = accountRoot("claude", base, "source");
+  const target = accountRoot("claude", base, "target");
+  const sourcePath = path.join(source.transcriptRoot, "source.jsonl");
+  fs.writeFileSync(sourcePath, "{}\n", { mode: 0o600 });
+  const registry = new AgentRegistry(path.join(base, "provider-registry.json"));
+  const conversation = registry.ensureConversation("claude", sourcePath, "source");
+  const cancelled: string[] = [];
+  const dependencies = {
+    accounts: { resolveSpawn: () => target, resolveTranscriptOwner: () => source },
+    startCodex: async () => { throw new Error("unexpected Codex client"); },
+    claudeStatus: async () => ({ loggedIn: true }),
+    spawnClaude: async () => ({ paneId: "%26", panePid: 2626, host: claudeHost("%26", 2626) }),
+    verifyClaudeHost: async () => true,
+    cancelClaude: async (host: TmuxHostEvidence) => { cancelled.push(host.paneId); return true; },
+    registry,
+    claudeJournalRoot: path.join(base, "claude-operations"),
+    now: () => "2026-07-10T12:00:00.000Z",
+  } satisfies ProviderDependencies;
+  const input = {
+    engine: "claude" as const,
+    operationId: "claude-replay-continuity-failure",
+    conversationId: conversation.id,
+    targetAccountId: "target",
+    source: conversation.generations[0]!,
+    recordContinuityPath() {},
+  };
+  await new RegisteredSuccessorProvider(dependencies).create(input);
+
+  await expect(new RegisteredSuccessorProvider(dependencies).create({
+    ...input,
+    recordContinuityPath() { throw new Error("registry unavailable on replay"); },
+  })).rejects.toThrow("registry unavailable on replay");
+
+  expect(cancelled).toEqual(["%26"]);
+  expect(Object.values(registry.snapshot().receipts)[0]).toMatchObject({ state: "conflicted", error: "migration continuity persistence failed" });
+});
+
 test("Claude replay resumes a pane-free birth receipt and fences terminal spawn state", async () => {
   const base = fs.mkdtempSync(path.join(os.tmpdir(), "llv-provider-claude-receipt-recovery-"));
   roots.push(base);

--- a/src/lib/accounts/migration/provider.test.ts
+++ b/src/lib/accounts/migration/provider.test.ts
@@ -3,9 +3,10 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
-import { emptyLaunchProfile, type NativeGeneration } from "./contracts";
+import { emptyLaunchProfile, sameProviderReceiptOutcome, type NativeGeneration, type ProviderReceipt, type SuccessorProviderPort } from "./contracts";
 import { RegisteredSuccessorProvider, type ProviderDependencies } from "./provider";
 import type { CodexAppServerClient } from "@/lib/accounts/codexAppServer";
+import { AgentRegistry, type ConversationObservation, type TmuxHostEvidence } from "@/lib/agent/registry";
 
 const roots: string[] = [];
 
@@ -18,8 +19,65 @@ function accountRoot(engine: "claude" | "codex", base: string, id: string) {
   return { engine, accountId: id, kind: "managed" as const, home, transcriptRoot, env: { ...process.env } };
 }
 
+function codexSessionMeta(id: string, forkedFromId?: string): string {
+  return JSON.stringify({
+    type: "session_meta",
+    payload: { id, ...(forkedFromId ? { forked_from_id: forkedFromId } : {}) },
+  }) + "\n";
+}
+
+function claudeHost(paneId: string, panePid: number, agentPid = panePid + 10_000): TmuxHostEvidence {
+  return {
+    kind: "tmux",
+    endpoint: "/tmp",
+    server: { pid: 700, startIdentity: "server-start" },
+    paneId,
+    panePid: { pid: panePid, startIdentity: `pane-${panePid}` },
+    windowName: "claude-migration-successor",
+    agent: { pid: agentPid, startIdentity: `agent-${agentPid}` },
+    argv: ["claude"],
+  };
+}
+
 afterEach(() => {
   for (const root of roots.splice(0)) fs.rmSync(root, { recursive: true, force: true });
+});
+
+test("provider receipt identity ignores timestamp and object key order", () => {
+  const tmux = claudeHost("%30", 3030);
+  const left: ProviderReceipt = {
+    operationId: "canonical-receipt",
+    nativeId: "canonical-native",
+    path: "/canonical.jsonl",
+    continuityPaths: [],
+    historyHash: "history",
+    host: { kind: "claude-stream", identity: "%30:3030", epoch: 1, verifiedAt: "first", tmuxHost: tmux },
+  };
+  const right: ProviderReceipt = {
+    historyHash: "history",
+    continuityPaths: [],
+    path: "/canonical.jsonl",
+    nativeId: "canonical-native",
+    operationId: "canonical-receipt",
+    host: {
+      verifiedAt: "second",
+      epoch: 1,
+      identity: "%30:3030",
+      kind: "claude-stream",
+      tmuxHost: {
+        argv: [...tmux.argv],
+        agent: { startIdentity: tmux.agent.startIdentity, pid: tmux.agent.pid },
+        windowName: tmux.windowName,
+        panePid: { startIdentity: tmux.panePid.startIdentity, pid: tmux.panePid.pid },
+        paneId: tmux.paneId,
+        server: { startIdentity: tmux.server.startIdentity, pid: tmux.server.pid },
+        endpoint: tmux.endpoint,
+        kind: "tmux",
+      },
+    },
+  };
+
+  expect(sameProviderReceiptOutcome(left, right)).toBeTrue();
 });
 
 test("Claude successor provider uses registered homes and shared model normalization", async () => {
@@ -42,9 +100,11 @@ test("Claude successor provider uses registered homes and shared model normaliza
       command = spec.command;
       fs.mkdirSync(path.dirname(spec.transcript!), { recursive: true, mode: 0o700 });
       fs.writeFileSync(spec.transcript!, JSON.stringify({ sessionId: path.basename(spec.transcript!, ".jsonl") }) + "\n", { mode: 0o600 });
-      return { paneId: "%9", panePid: 99 };
+      return { paneId: "%9", panePid: 99, host: claudeHost("%9", 99) };
     },
-    claudeHost: async () => ({ paneId: "%9", panePid: 99, windowName: "claude-migration-successor" }),
+    verifyClaudeHost: async () => true,
+    registry: new AgentRegistry(path.join(base, "provider-registry.json")),
+    claudeJournalRoot: path.join(base, "claude-operations"),
     now: () => "2026-07-10T12:00:00.000Z",
   };
   const provider = new RegisteredSuccessorProvider(dependencies);
@@ -58,7 +118,7 @@ test("Claude successor provider uses registered homes and shared model normaliza
     createdAt: "2026-07-10T11:00:00.000Z",
     archivedAt: null,
   };
-  const receipt = await provider.create({ engine: "claude", operationId: "019f423a-d6e9-4903-8597-3e676b6ff3d4", conversationId: "conversation_test", source: sourceGeneration, targetAccountId: "target" });
+  const receipt = await provider.create({ engine: "claude", operationId: "019f423a-d6e9-4903-8597-3e676b6ff3d4", conversationId: "conversation_test", source: sourceGeneration, targetAccountId: "target", recordContinuityPath() {} });
   expect(command).toContain("CLAUDE_CONFIG_DIR=");
   expect(command).toContain("--model' 'fable'");
   expect(command).not.toContain("claude-fable-");
@@ -78,7 +138,9 @@ test("Claude successor verification rejects a missing durable transcript", async
     accounts: { resolveSpawn: () => target, resolveTranscriptOwner: () => source },
     startCodex: async () => { throw new Error("unexpected Codex client"); },
     claudeStatus: async () => ({ loggedIn: true }),
-    spawnClaude: async () => ({ paneId: "%11", panePid: 111 }),
+    spawnClaude: async () => ({ paneId: "%11", panePid: 111, host: claudeHost("%11", 111) }),
+    registry: new AgentRegistry(path.join(base, "provider-registry.json")),
+    claudeJournalRoot: path.join(base, "claude-operations"),
     now: () => "2026-07-10T12:00:00.000Z",
   });
   const receipt = await provider.create({
@@ -87,10 +149,258 @@ test("Claude successor verification rejects a missing durable transcript", async
     conversationId: "conversation_test",
     targetAccountId: "target",
     source: { id: "source", path: sourcePath, accountId: "source", launchProfile: emptyLaunchProfile({ cwd: "/repo" }), historyHash: null, host: null, createdAt: "now", archivedAt: null },
+    recordContinuityPath() {},
   });
 
   await expect(provider.verify(receipt, { engine: "claude", targetAccountId: "target", launchProfile: emptyLaunchProfile({ cwd: "/repo" }) }))
     .rejects.toThrow("durable");
+});
+
+test("Claude agent exit fails full host verification and leaves the persisted receipt immutable", async () => {
+  const base = fs.mkdtempSync(path.join(os.tmpdir(), "llv-provider-claude-host-failure-"));
+  roots.push(base);
+  const source = accountRoot("claude", base, "source");
+  const target = accountRoot("claude", base, "target");
+  const sourcePath = path.join(source.transcriptRoot, "source.jsonl");
+  fs.writeFileSync(sourcePath, "{}\n", { mode: 0o600 });
+  let verifiedHost: TmuxHostEvidence | null = null;
+  const provider = new RegisteredSuccessorProvider({
+    accounts: { resolveSpawn: () => target, resolveTranscriptOwner: () => source },
+    startCodex: async () => { throw new Error("unexpected Codex client"); },
+    claudeStatus: async () => ({ loggedIn: true }),
+    spawnClaude: async (spec) => {
+      fs.mkdirSync(path.dirname(spec.transcript!), { recursive: true, mode: 0o700 });
+      fs.writeFileSync(spec.transcript!, JSON.stringify({ sessionId: path.basename(spec.transcript!, ".jsonl") }) + "\n", { mode: 0o600 });
+      return { paneId: "%12", panePid: 1212, host: claudeHost("%12", 1212) };
+    },
+    verifyClaudeHost: async (host) => { verifiedHost = host; return false; },
+    registry: new AgentRegistry(path.join(base, "provider-registry.json")),
+    claudeJournalRoot: path.join(base, "claude-operations"),
+    now: () => "2026-07-10T12:00:00.000Z",
+  });
+  const receipt = await provider.create({
+    engine: "claude",
+    operationId: "claude-host-failure",
+    conversationId: "conversation_claude_host_failure",
+    targetAccountId: "target",
+    source: { id: "source", path: sourcePath, accountId: "source", launchProfile: emptyLaunchProfile({ cwd: "/repo" }), historyHash: null, host: null, createdAt: "now", archivedAt: null },
+    recordContinuityPath() {},
+  });
+  const persisted = structuredClone(receipt);
+
+  await expect(provider.verify(receipt, {
+    engine: "claude",
+    targetAccountId: "target",
+    launchProfile: emptyLaunchProfile({ cwd: "/repo" }),
+  })).rejects.toThrow("host is not live");
+  expect(receipt).toEqual(persisted);
+  expect(verifiedHost).toMatchObject({ paneId: "%12", panePid: { pid: 1212 }, agent: { pid: 11212 } });
+});
+
+test("Claude cleanup cancels only the pane PID recorded by the losing receipt", async () => {
+  const base = fs.mkdtempSync(path.join(os.tmpdir(), "llv-provider-claude-cleanup-fence-"));
+  roots.push(base);
+  const source = accountRoot("claude", base, "source");
+  const target = accountRoot("claude", base, "target");
+  const cancelled: Array<[string, number]> = [];
+  let observedPid = 999;
+  const provider = new RegisteredSuccessorProvider({
+    accounts: { resolveSpawn: () => target, resolveTranscriptOwner: () => source },
+    startCodex: async () => { throw new Error("unexpected Codex client"); },
+    claudeStatus: async () => ({ loggedIn: true }),
+    spawnClaude: async () => ({ paneId: "%7", panePid: 77, host: claudeHost("%7", 77) }),
+    cancelClaude: async (host) => {
+      if (observedPid !== host.panePid.pid) return false;
+      cancelled.push([host.paneId, host.panePid.pid]);
+      return true;
+    },
+    registry: new AgentRegistry(path.join(base, "provider-registry.json")),
+    claudeJournalRoot: path.join(base, "claude-operations"),
+    now: () => "2026-07-10T12:00:00.000Z",
+  });
+  const receipt = {
+    operationId: "cleanup-fence",
+    nativeId: "cleanup-fence",
+    path: path.join(target.transcriptRoot, "cleanup-fence.jsonl"),
+    continuityPaths: [],
+    historyHash: "history",
+    host: { kind: "claude-stream" as const, identity: "%7:77", epoch: 1, verifiedAt: "2026-07-10T12:00:00.000Z", tmuxHost: claudeHost("%7", 77) },
+  };
+
+  await provider.cleanup(receipt);
+  expect(cancelled).toEqual([]);
+  observedPid = 77;
+  await provider.cleanup(receipt);
+  expect(cancelled).toEqual([["%7", 77]]);
+});
+
+test("concurrent Claude creates reuse one durable migration spawn receipt", async () => {
+  const base = fs.mkdtempSync(path.join(os.tmpdir(), "llv-provider-claude-concurrent-"));
+  roots.push(base);
+  const source = accountRoot("claude", base, "source");
+  const target = accountRoot("claude", base, "target");
+  const sourcePath = path.join(source.transcriptRoot, "source.jsonl");
+  fs.writeFileSync(sourcePath, "{}\n", { mode: 0o600 });
+  const registry = new AgentRegistry(path.join(base, "provider-registry.json"));
+  const conversation = registry.ensureConversation("claude", sourcePath, "source");
+  let spawns = 0;
+  const provider = new RegisteredSuccessorProvider({
+    accounts: { resolveSpawn: () => target, resolveTranscriptOwner: () => source },
+    startCodex: async () => { throw new Error("unexpected Codex client"); },
+    claudeStatus: async () => ({ loggedIn: true }),
+    spawnClaude: async (spec) => {
+      spawns += 1;
+      fs.mkdirSync(path.dirname(spec.transcript!), { recursive: true, mode: 0o700 });
+      fs.writeFileSync(spec.transcript!, JSON.stringify({ sessionId: path.basename(spec.transcript!, ".jsonl") }) + "\n", { mode: 0o600 });
+      return { paneId: "%21", panePid: 2121, host: claudeHost("%21", 2121) };
+    },
+    verifyClaudeHost: async () => true,
+    registry,
+    claudeJournalRoot: path.join(base, "claude-operations"),
+    now: () => "2026-07-10T12:00:00.000Z",
+  });
+  const input = {
+    engine: "claude" as const,
+    operationId: "claude-concurrent-operation",
+    conversationId: conversation.id,
+    targetAccountId: "target",
+    source: conversation.generations[0]!,
+    recordContinuityPath() {},
+  };
+
+  const receipts = await Promise.all([provider.create(input), provider.create(input)]);
+
+  expect(spawns).toBe(1);
+  expect(receipts[0]).toEqual(receipts[1]);
+  const launchReceipts = Object.values(registry.snapshot().receipts);
+  expect(launchReceipts).toHaveLength(1);
+  expect(launchReceipts[0]).toMatchObject({ conversationId: conversation.id, purpose: "migration-successor" });
+});
+
+test("Claude replay resumes a pane-free birth receipt and fences terminal spawn state", async () => {
+  const base = fs.mkdtempSync(path.join(os.tmpdir(), "llv-provider-claude-receipt-recovery-"));
+  roots.push(base);
+  const source = accountRoot("claude", base, "source");
+  const target = accountRoot("claude", base, "target");
+  const sourcePath = path.join(source.transcriptRoot, "source.jsonl");
+  fs.writeFileSync(sourcePath, "{}\n", { mode: 0o600 });
+  const registry = new AgentRegistry(path.join(base, "provider-registry.json"));
+  const conversation = registry.ensureConversation("claude", sourcePath, "source");
+  let spawns = 0;
+  let forceTerminal = false;
+  const cancelled: string[] = [];
+  const dependencies = {
+    accounts: { resolveSpawn: () => target, resolveTranscriptOwner: () => source },
+    startCodex: async () => { throw new Error("unexpected Codex client"); },
+    claudeStatus: async () => ({ loggedIn: true }),
+    spawnClaude: async (spec: ReturnType<typeof import("@/lib/agent/cli").claudeSuccessorSpecFor>, launch: import("@/lib/agent/registry").SpawnReceipt) => {
+      spawns += 1;
+      fs.mkdirSync(path.dirname(spec.transcript!), { recursive: true, mode: 0o700 });
+      fs.writeFileSync(spec.transcript!, JSON.stringify({ sessionId: path.basename(spec.transcript!, ".jsonl") }) + "\n", { mode: 0o600 });
+      if (forceTerminal) registry.invalidateSpawnHost(launch.launchId, "forced terminal receipt");
+      return { paneId: "%23", panePid: 2323, host: claudeHost("%23", 2323) };
+    },
+    verifyClaudeHost: async () => true,
+    cancelClaude: async (host: TmuxHostEvidence) => { cancelled.push(host.paneId); return true; },
+    registry,
+    claudeJournalRoot: path.join(base, "claude-operations"),
+    now: () => "2026-07-10T12:00:00.000Z",
+  } satisfies ProviderDependencies;
+  const input = {
+    engine: "claude" as const,
+    operationId: "claude-pane-free-retry",
+    conversationId: conversation.id,
+    targetAccountId: "target",
+    source: conversation.generations[0]!,
+    recordContinuityPath() {},
+  };
+
+  await expect(new RegisteredSuccessorProvider({
+    ...dependencies,
+    afterClaudeReceiptCreated() { throw new Error("simulated crash after receipt birth"); },
+  }).create(input)).rejects.toThrow("simulated crash after receipt birth");
+  expect(spawns).toBe(0);
+  await expect(new RegisteredSuccessorProvider(dependencies).create(input)).resolves.toMatchObject({ host: { identity: "%23:2323" } });
+  expect(spawns).toBe(1);
+
+  forceTerminal = true;
+  const recorded: string[] = [];
+  await expect(new RegisteredSuccessorProvider(dependencies).create({
+    ...input,
+    operationId: "claude-terminal-fence",
+    recordContinuityPath(pathname) { recorded.push(pathname); },
+  })).rejects.toThrow("became terminal");
+  expect(recorded).toEqual([]);
+  expect(cancelled).toEqual(["%23"]);
+});
+
+test("Claude crash recovery reuses the exact host and observer settlement keeps one owner", async () => {
+  const base = fs.mkdtempSync(path.join(os.tmpdir(), "llv-provider-claude-crash-recovery-"));
+  roots.push(base);
+  const source = accountRoot("claude", base, "source");
+  const target = accountRoot("claude", base, "target");
+  const sourcePath = path.join(source.transcriptRoot, "source.jsonl");
+  fs.writeFileSync(sourcePath, "{}\n", { mode: 0o600 });
+  const registry = new AgentRegistry(path.join(base, "provider-registry.json"));
+  const conversation = registry.ensureConversation("claude", sourcePath, "source");
+  let spawns = 0;
+  const dependencies = {
+    accounts: { resolveSpawn: () => target, resolveTranscriptOwner: () => source },
+    startCodex: async () => { throw new Error("unexpected Codex client"); },
+    claudeStatus: async () => ({ loggedIn: true }),
+    spawnClaude: async (spec: ReturnType<typeof import("@/lib/agent/cli").claudeSuccessorSpecFor>) => {
+      spawns += 1;
+      fs.mkdirSync(path.dirname(spec.transcript!), { recursive: true, mode: 0o700 });
+      fs.writeFileSync(spec.transcript!, JSON.stringify({ sessionId: path.basename(spec.transcript!, ".jsonl") }) + "\n", { mode: 0o600 });
+      return { paneId: "%22", panePid: 2222, host: claudeHost("%22", 2222) };
+    },
+    verifyClaudeHost: async () => true,
+    registry,
+    claudeJournalRoot: path.join(base, "claude-operations"),
+    now: () => "2026-07-10T12:00:00.000Z",
+  } satisfies ProviderDependencies;
+  const input = {
+    engine: "claude" as const,
+    operationId: "claude-crash-operation",
+    conversationId: conversation.id,
+    targetAccountId: "target",
+    source: conversation.generations[0]!,
+    recordContinuityPath() {},
+  };
+
+  await expect(new RegisteredSuccessorProvider({
+    ...dependencies,
+    afterClaudeSpawned() { throw new Error("simulated crash after Claude spawn"); },
+  }).create(input)).rejects.toThrow("simulated crash after Claude spawn");
+  const launchBeforeRecovery = Object.values(registry.snapshot().receipts)[0]!;
+  registry.reconcileConversations([{
+    engine: "claude",
+    path: launchBeforeRecovery.artifactPath!,
+    accountId: "target",
+    launchProfile: emptyLaunchProfile({ cwd: "/repo", project: "repo" }),
+    turn: { state: "idle", source: "empty", terminalAt: null },
+    observedAt: "2026-07-10T12:01:00.000Z",
+  }]);
+  expect(Object.values(registry.snapshot().conversations)).toHaveLength(1);
+  expect(registry.conversationForPath(launchBeforeRecovery.artifactPath!)?.id).toBe(conversation.id);
+  const receipt = await new RegisteredSuccessorProvider(dependencies).create(input);
+  const launch = Object.values(registry.snapshot().receipts)[0]!;
+  const settled = registry.settleSpawn(launch.launchId, {
+    key: { engine: "claude", sessionId: receipt.nativeId },
+    artifactPath: receipt.path,
+    cwd: launch.cwd,
+    accountId: "target",
+    status: "live",
+    host: receipt.host.tmuxHost!,
+    claimEpoch: 0,
+    claimOwner: null,
+    pendingAction: null,
+  });
+
+  expect(spawns).toBe(1);
+  expect(settled).toMatchObject({ kind: "settled", conversation: { id: conversation.id } });
+  expect(Object.values(registry.snapshot().conversations)).toHaveLength(1);
+  expect(registry.conversation(conversation.id)?.generations.map((generation) => generation.path)).toEqual([sourcePath]);
 });
 
 test("unknown Claude transcript model omits the successor override", async () => {
@@ -105,7 +415,9 @@ test("unknown Claude transcript model omits the successor override", async () =>
     accounts: { resolveSpawn: () => target, resolveTranscriptOwner: () => source },
     startCodex: async () => { throw new Error("unexpected Codex client"); },
     claudeStatus: async () => ({ loggedIn: true }),
-    spawnClaude: async (spec) => { command = spec.command; return { paneId: "%10" }; },
+    spawnClaude: async (spec) => { command = spec.command; return { paneId: "%10", panePid: 110, host: claudeHost("%10", 110) }; },
+    registry: new AgentRegistry(path.join(base, "provider-registry.json")),
+    claudeJournalRoot: path.join(base, "claude-operations"),
     now: () => "2026-07-10T12:00:00.000Z",
   });
   await provider.create({
@@ -114,6 +426,7 @@ test("unknown Claude transcript model omits the successor override", async () =>
     conversationId: "conversation_test",
     targetAccountId: "target",
     source: { id: "native", path: sourcePath, accountId: "source", launchProfile: emptyLaunchProfile({ cwd: "/repo", model: "mythos-1" }), historyHash: null, host: null, createdAt: "now", archivedAt: null },
+    recordContinuityPath() {},
   });
   expect(command).not.toContain("--model");
 });
@@ -124,18 +437,22 @@ test("Codex successor provider accepts authenticated ChatGPT account responses a
   const source = accountRoot("codex", base, "source");
   const target = accountRoot("codex", base, "target");
   for (const directory of [source.home, source.transcriptRoot, target.home, target.transcriptRoot]) fs.chmodSync(directory, 0o755);
-  const sourcePath = path.join(source.transcriptRoot, "2026", "07", "10", "rollout-019f423a-d6e9-7903-b597-3e676b6ff3d4.jsonl");
+  const sourceId = "019f423a-d6e9-7903-b597-3e676b6ff3d4";
+  const sourcePath = path.join(source.transcriptRoot, "2026", "07", "10", `rollout-${sourceId}.jsonl`);
   fs.mkdirSync(path.dirname(sourcePath), { recursive: true, mode: 0o700 });
-  fs.writeFileSync(sourcePath, "{\"type\":\"session_meta\"}\n", { mode: 0o644 });
+  fs.writeFileSync(sourcePath, codexSessionMeta(sourceId), { mode: 0o644 });
   const forkId = "019f423a-d6e9-4903-8597-3e676b6ff3d4";
   const forkPath = path.join(source.transcriptRoot, "2026", "07", "10", `rollout-${forkId}.jsonl`);
   const calls: string[] = [];
   let resumeOptions: unknown = null;
   let goalOptions: unknown = null;
-  let appServerAccount: { type: string } | null = { type: "chatgpt" };
+  let targetAuthenticated = false;
   const client = (home: string) => ({
-    async readAccount() { calls.push(`${path.basename(home)}:account`); return { account: appServerAccount, requiresOpenaiAuth: true }; },
-    async forkThread() { calls.push("source:fork"); fs.writeFileSync(forkPath, "{\"type\":\"session_meta\"}\n", { mode: 0o644 }); return { id: forkId, path: forkPath }; },
+    async readAccount() {
+      calls.push(`${path.basename(home)}:account`);
+      return { account: home === target.home && !targetAuthenticated ? null : { type: "chatgpt" }, requiresOpenaiAuth: true };
+    },
+    async forkThread() { calls.push("source:fork"); fs.writeFileSync(forkPath, codexSessionMeta(forkId, sourceId), { mode: 0o644 }); return { id: forkId, path: forkPath }; },
     async resumeThread(id: string, options: unknown) { calls.push("target:resume"); resumeOptions = options; return { id, path: null }; },
     async readThread(id: string) { calls.push("target:read"); return { id, path: null }; },
     async setThreadName() { calls.push("target:name"); },
@@ -150,15 +467,24 @@ test("Codex successor provider accepts authenticated ChatGPT account responses a
     now: () => "2026-07-10T12:00:00.000Z",
   });
   const profile = emptyLaunchProfile({ cwd: "/repo", model: "gpt-5.6-terra", effort: "high", fast: true, permissionMode: "never", readOnly: true, title: "Migration", goal: { objective: "Ship", status: "active", tokensUsed: null, timeUsedSeconds: null } });
-  const receipt = await provider.create({
+  const recorded: string[] = [];
+  const input = {
     engine: "codex",
     operationId: "operation-codex",
     conversationId: "conversation_test",
     targetAccountId: "target",
-    source: { id: "019f423a-d6e9-7903-b597-3e676b6ff3d4", path: sourcePath, accountId: "source", launchProfile: profile, historyHash: null, host: null, createdAt: "now", archivedAt: null },
-  });
+    source: { id: sourceId, path: sourcePath, accountId: "source", launchProfile: profile, historyHash: null, host: null, createdAt: "now", archivedAt: null },
+    recordContinuityPath(pathname: string) { recorded.push(pathname); },
+  } as Parameters<SuccessorProviderPort["create"]>[0] & { recordContinuityPath(pathname: string): void };
+  await expect(provider.create(input)).rejects.toThrow("target Codex account is not authenticated");
+  const failedTargetCopy = path.join(target.transcriptRoot, "2026", "07", "10", `rollout-${forkId}.jsonl`);
+  expect(recorded).toEqual([forkPath, failedTargetCopy]);
+
+  targetAuthenticated = true;
+  const receipt = await provider.create(input);
   expect(receipt.nativeId).toBe(forkId);
   expect(receipt.path.startsWith(target.transcriptRoot + path.sep)).toBeTrue();
+  expect(receipt.continuityPaths).toEqual([forkPath, receipt.path]);
   expect(fs.readFileSync(receipt.path, "utf8")).toContain("session_meta");
   expect(calls).toContain("source:fork");
   expect(calls).toContain("target:resume");
@@ -168,7 +494,366 @@ test("Codex successor provider accepts authenticated ChatGPT account responses a
   expect(goalOptions).toEqual({ objective: "Ship", status: "active" });
   await provider.verify(receipt, { engine: "codex", targetAccountId: "target", launchProfile: profile });
   expect(calls.filter((call) => call === "target:read").length).toBeGreaterThanOrEqual(2);
-  appServerAccount = null;
+  targetAuthenticated = false;
   await expect(provider.verify(receipt, { engine: "codex", targetAccountId: "target", launchProfile: profile }))
     .rejects.toThrow("target Codex account is not authenticated");
+});
+
+test("concurrent Codex creates publish one successor for the same operation", async () => {
+  const base = fs.mkdtempSync(path.join(os.tmpdir(), "llv-provider-codex-concurrent-"));
+  roots.push(base);
+  const source = accountRoot("codex", base, "source");
+  const target = accountRoot("codex", base, "target");
+  const journalRoot = path.join(base, "provider-journal");
+  const sourceId = "119f423a-d6e9-7903-b597-3e676b6ff3d4";
+  const sourcePath = path.join(source.transcriptRoot, `rollout-${sourceId}.jsonl`);
+  fs.writeFileSync(sourcePath, codexSessionMeta(sourceId), { mode: 0o600 });
+  let forkCalls = 0;
+  const client = (home: string) => ({
+    async readAccount() { return { account: { type: "chatgpt" }, requiresOpenaiAuth: true }; },
+    async forkThread() {
+      forkCalls += 1;
+      const call = forkCalls;
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      const id = `119f423a-d6e9-4903-8597-${String(call).padStart(12, "0")}`;
+      const forkPath = path.join(source.transcriptRoot, `rollout-${id}.jsonl`);
+      fs.writeFileSync(forkPath, codexSessionMeta(id, sourceId), { mode: 0o600 });
+      return { id, path: forkPath };
+    },
+    async resumeThread(id: string) { return { id, path: null }; },
+    async readThread(id: string) { return { id, path: null }; },
+    close() {},
+  }) as unknown as CodexAppServerClient;
+  const provider = new RegisteredSuccessorProvider({
+    accounts: { resolveSpawn: () => target, resolveTranscriptOwner: () => source },
+    startCodex: async (home) => client(home),
+    claudeStatus: async () => ({ loggedIn: false }),
+    spawnClaude: async () => { throw new Error("unexpected Claude spawn"); },
+    journalRoot,
+    now: () => "2026-07-10T12:00:00.000Z",
+  });
+  const input = {
+    engine: "codex" as const,
+    operationId: "concurrent-operation",
+    conversationId: "conversation_test" as const,
+    targetAccountId: "target",
+    source: { id: sourceId, path: sourcePath, accountId: "source", launchProfile: emptyLaunchProfile({ cwd: "/repo" }), historyHash: null, host: null, createdAt: "now", archivedAt: null },
+    recordContinuityPath() {},
+  };
+
+  const results = await Promise.all([provider.create(input), provider.create(input)]);
+
+  expect(forkCalls).toBe(1);
+  expect(results[0]).toEqual(results[1]);
+});
+
+test("a fresh 51-conversation Codex drain skips recovery history scans", async () => {
+  const base = fs.mkdtempSync(path.join(os.tmpdir(), "llv-provider-codex-mass-drain-"));
+  roots.push(base);
+  const source = accountRoot("codex", base, "source");
+  const target = accountRoot("codex", base, "target");
+  const sourceId = "219f423a-d6e9-7903-b597-3e676b6ff3d4";
+  const sourcePath = path.join(source.transcriptRoot, `rollout-${sourceId}.jsonl`);
+  fs.writeFileSync(sourcePath, codexSessionMeta(sourceId), { mode: 0o600 });
+  let forkCalls = 0;
+  let scanCalls = 0;
+  const client = () => ({
+    async readAccount() { return { account: { type: "chatgpt" }, requiresOpenaiAuth: true }; },
+    async forkThread() {
+      forkCalls += 1;
+      const id = `219f423a-d6e9-4903-8597-${String(forkCalls).padStart(12, "0")}`;
+      const forkPath = path.join(source.transcriptRoot, `rollout-${id}.jsonl`);
+      fs.writeFileSync(forkPath, codexSessionMeta(id, sourceId), { mode: 0o600 });
+      return { id, path: forkPath };
+    },
+    async resumeThread(id: string) { return { id, path: null }; },
+    async readThread(id: string) { return { id, path: null }; },
+    close() {},
+  }) as unknown as CodexAppServerClient;
+  const provider = new RegisteredSuccessorProvider({
+    accounts: { resolveSpawn: () => target, resolveTranscriptOwner: () => source },
+    startCodex: async () => client(),
+    claudeStatus: async () => ({ loggedIn: false }),
+    spawnClaude: async () => { throw new Error("unexpected Claude spawn"); },
+    journalRoot: path.join(base, "provider-journal"),
+    scanCodexForkArtifacts() { scanCalls += 1; return []; },
+    now: () => "2026-07-10T12:00:00.000Z",
+  });
+  const generation = { id: sourceId, path: sourcePath, accountId: "source", launchProfile: emptyLaunchProfile({ cwd: "/repo" }), historyHash: null, host: null, createdAt: "now", archivedAt: null };
+
+  for (let index = 0; index < 51; index += 1) {
+    await provider.create({
+      engine: "codex",
+      operationId: `mass-drain-${index}`,
+      conversationId: `conversation_mass_${index}`,
+      targetAccountId: "target",
+      source: generation,
+      recordContinuityPath() {},
+    });
+  }
+
+  expect(forkCalls).toBe(51);
+  expect(scanCalls).toBe(0);
+});
+
+test("first Codex operation fsyncs every newly created journal directory entry", async () => {
+  const base = fs.mkdtempSync(path.join(os.tmpdir(), "llv-provider-codex-journal-fsync-"));
+  roots.push(base);
+  const source = accountRoot("codex", base, "source");
+  const target = accountRoot("codex", base, "target");
+  const sourceId = "319f423a-d6e9-7903-b597-3e676b6ff3d4";
+  const forkId = "319f423a-d6e9-4903-8597-3e676b6ff3d4";
+  const sourcePath = path.join(source.transcriptRoot, `rollout-${sourceId}.jsonl`);
+  const forkPath = path.join(source.transcriptRoot, `rollout-${forkId}.jsonl`);
+  const journalParent = path.join(base, "new-state");
+  const journalRoot = path.join(journalParent, "provider-journal");
+  fs.writeFileSync(sourcePath, codexSessionMeta(sourceId), { mode: 0o600 });
+  const client = () => ({
+    async readAccount() { return { account: { type: "chatgpt" }, requiresOpenaiAuth: true }; },
+    async forkThread() {
+      fs.writeFileSync(forkPath, codexSessionMeta(forkId, sourceId), { mode: 0o600 });
+      return { id: forkId, path: forkPath };
+    },
+    async resumeThread(id: string) { return { id, path: null }; },
+    async readThread(id: string) { return { id, path: null }; },
+    close() {},
+  }) as unknown as CodexAppServerClient;
+  const provider = new RegisteredSuccessorProvider({
+    accounts: { resolveSpawn: () => target, resolveTranscriptOwner: () => source },
+    startCodex: async () => client(),
+    claudeStatus: async () => ({ loggedIn: false }),
+    spawnClaude: async () => { throw new Error("unexpected Claude spawn"); },
+    journalRoot,
+    now: () => "2026-07-10T12:00:00.000Z",
+  });
+  const syncedDirectories: string[] = [];
+  const fsync = fs.fsyncSync.bind(fs);
+  fs.fsyncSync = ((descriptor: number) => {
+    try {
+      const pathname = fs.readlinkSync(`/proc/self/fd/${descriptor}`);
+      if (fs.fstatSync(descriptor).isDirectory()) syncedDirectories.push(pathname);
+    } catch { /* descriptor observability is platform-dependent */ }
+    return fsync(descriptor);
+  }) as typeof fs.fsyncSync;
+  try {
+    await provider.create({
+      engine: "codex",
+      operationId: "journal-first-operation",
+      conversationId: "conversation_journal_fsync",
+      targetAccountId: "target",
+      source: { id: sourceId, path: sourcePath, accountId: "source", launchProfile: emptyLaunchProfile({ cwd: "/repo" }), historyHash: null, host: null, createdAt: "now", archivedAt: null },
+      recordContinuityPath() {},
+    });
+  } finally {
+    fs.fsyncSync = fsync;
+  }
+
+  expect(syncedDirectories).toContain(base);
+  expect(syncedDirectories).toContain(journalParent);
+});
+
+test("Codex successor provider recovers a validated fork created before exact receipt persistence", async () => {
+  const base = fs.mkdtempSync(path.join(os.tmpdir(), "llv-provider-codex-fork-recovery-"));
+  roots.push(base);
+  const source = accountRoot("codex", base, "source");
+  const target = accountRoot("codex", base, "target");
+  const journalRoot = path.join(base, "provider-journal");
+  const sourceId = "019f423a-d6e9-7903-b597-3e676b6ff3d4";
+  const forkId = "019f423a-d6e9-4903-8597-3e676b6ff3d4";
+  const sourcePath = path.join(source.transcriptRoot, `rollout-${sourceId}.jsonl`);
+  const forkPath = path.join(source.transcriptRoot, `rollout-${forkId}.jsonl`);
+  fs.writeFileSync(sourcePath, codexSessionMeta(sourceId), { mode: 0o600 });
+  let forkCalls = 0;
+  const client = (home: string) => ({
+    async readAccount() { return { account: { type: "chatgpt" }, requiresOpenaiAuth: true }; },
+    async forkThread() {
+      forkCalls += 1;
+      fs.writeFileSync(forkPath, codexSessionMeta(forkId, sourceId), { mode: 0o600 });
+      return { id: forkId, path: forkPath };
+    },
+    async resumeThread(id: string) { return { id, path: null }; },
+    async readThread(id: string) { return { id, path: null }; },
+    close() {},
+  }) as unknown as CodexAppServerClient;
+  const dependencies = {
+    accounts: { resolveSpawn: () => target, resolveTranscriptOwner: () => source },
+    startCodex: async (home: string) => client(home),
+    claudeStatus: async () => ({ loggedIn: false }),
+    spawnClaude: async () => { throw new Error("unexpected Claude spawn"); },
+    now: () => "2026-07-10T12:00:00.000Z",
+    journalRoot,
+  } as ProviderDependencies & { journalRoot: string; afterCodexForkReturned?: () => void };
+  const registry = new AgentRegistry(path.join(base, "registry.json"));
+  const conversation = registry.ensureConversation("codex", sourcePath, "source");
+  registry.setConversationMigration(conversation.id, {
+    intentId: "fork-recovery",
+    phase: "successor-starting",
+    targetId: "target",
+    revision: 1,
+    error: null,
+    updatedAt: "2026-07-10T12:00:00.000Z",
+  });
+  const input = {
+    engine: "codex" as const,
+    operationId: "operation-fork-recovery",
+    conversationId: conversation.id,
+    targetAccountId: "target",
+    source: conversation.generations[0]!,
+    recordContinuityPath(pathname: string) { registry.recordConversationContinuityPath(conversation.id, pathname); },
+  };
+  const crashed = new RegisteredSuccessorProvider({
+    ...dependencies,
+    afterCodexForkReturned() { throw new Error("simulated crash before exact fork receipt"); },
+  } as ProviderDependencies);
+
+  await expect(crashed.create(input)).rejects.toThrow("simulated crash before exact fork receipt");
+  expect(forkCalls).toBe(1);
+
+  const ambiguousId = "019f423a-d6e9-4903-8597-3e676b6ff3ff";
+  const ambiguousPath = path.join(source.transcriptRoot, `rollout-${ambiguousId}.jsonl`);
+  fs.writeFileSync(ambiguousPath, codexSessionMeta(ambiguousId, sourceId), { mode: 0o600 });
+  await expect(new RegisteredSuccessorProvider(dependencies).create(input)).rejects.toThrow("ambiguous");
+  expect(forkCalls).toBe(1);
+  fs.rmSync(ambiguousPath);
+
+  const receipt = await new RegisteredSuccessorProvider(dependencies).create(input);
+  const observation = (pathname: string, accountId: string): ConversationObservation => ({
+    engine: "codex",
+    path: pathname,
+    accountId,
+    launchProfile: emptyLaunchProfile({ cwd: "/repo", project: "repo" }),
+    turn: { state: "idle", source: "empty", terminalAt: null },
+    observedAt: "2026-07-10T12:01:00.000Z",
+  });
+  registry.reconcileConversations([
+    observation(forkPath, "source"),
+    observation(receipt.path, "target"),
+  ]);
+
+  expect(forkCalls).toBe(1);
+  expect(receipt.nativeId).toBe(forkId);
+  expect(Object.values(registry.snapshot().conversations)).toHaveLength(1);
+  expect(registry.conversationForPath(forkPath)?.id).toBe(conversation.id);
+  expect(registry.conversationForPath(receipt.path)?.id).toBe(conversation.id);
+});
+
+test("Codex successor provider reuses one published copy after a crash", async () => {
+  const base = fs.mkdtempSync(path.join(os.tmpdir(), "llv-provider-codex-copy-recovery-"));
+  roots.push(base);
+  const source = accountRoot("codex", base, "source");
+  const target = accountRoot("codex", base, "target");
+  const journalRoot = path.join(base, "provider-journal");
+  const sourceId = "029f423a-d6e9-7903-b597-3e676b6ff3d4";
+  const forkId = "029f423a-d6e9-4903-8597-3e676b6ff3d4";
+  const sourcePath = path.join(source.transcriptRoot, `rollout-${sourceId}.jsonl`);
+  const forkPath = path.join(source.transcriptRoot, `rollout-${forkId}.jsonl`);
+  fs.writeFileSync(sourcePath, codexSessionMeta(sourceId), { mode: 0o600 });
+  let forkCalls = 0;
+  const client = () => ({
+    async readAccount() { return { account: { type: "chatgpt" }, requiresOpenaiAuth: true }; },
+    async forkThread() {
+      forkCalls += 1;
+      fs.writeFileSync(forkPath, codexSessionMeta(forkId, sourceId), { mode: 0o600 });
+      return { id: forkId, path: forkPath };
+    },
+    async resumeThread(id: string) { return { id, path: null }; },
+    async readThread(id: string) { return { id, path: null }; },
+    close() {},
+  }) as unknown as CodexAppServerClient;
+  const dependencies = {
+    accounts: { resolveSpawn: () => target, resolveTranscriptOwner: () => source },
+    startCodex: async () => client(),
+    claudeStatus: async () => ({ loggedIn: false }),
+    spawnClaude: async () => { throw new Error("unexpected Claude spawn"); },
+    now: () => "2026-07-10T12:00:00.000Z",
+    journalRoot,
+  } as ProviderDependencies & { journalRoot: string; afterCodexCopyPublished?: () => void };
+  const registry = new AgentRegistry(path.join(base, "registry.json"));
+  const conversation = registry.ensureConversation("codex", sourcePath, "source");
+  registry.setConversationMigration(conversation.id, {
+    intentId: "copy-recovery",
+    phase: "successor-starting",
+    targetId: "target",
+    revision: 1,
+    error: null,
+    updatedAt: "2026-07-10T12:00:00.000Z",
+  });
+  const input = {
+    engine: "codex" as const,
+    operationId: "operation-copy-recovery",
+    conversationId: conversation.id,
+    targetAccountId: "target",
+    source: conversation.generations[0]!,
+    recordContinuityPath(pathname: string) { registry.recordConversationContinuityPath(conversation.id, pathname); },
+  };
+  const crashed = new RegisteredSuccessorProvider({
+    ...dependencies,
+    afterCodexCopyPublished() { throw new Error("simulated crash after copy"); },
+  } as ProviderDependencies);
+
+  await expect(crashed.create(input)).rejects.toThrow("simulated crash after copy");
+  const copiedPath = path.join(target.transcriptRoot, path.basename(forkPath));
+  const published = fs.statSync(copiedPath);
+  expect(forkCalls).toBe(1);
+
+  const receipt = await new RegisteredSuccessorProvider(dependencies).create(input);
+  registry.reconcileConversations([
+    {
+      engine: "codex",
+      path: forkPath,
+      accountId: "source",
+      launchProfile: emptyLaunchProfile({ cwd: "/repo", project: "repo" }),
+      turn: { state: "idle", source: "empty", terminalAt: null },
+      observedAt: "2026-07-10T12:01:00.000Z",
+    },
+    {
+      engine: "codex",
+      path: receipt.path,
+      accountId: "target",
+      launchProfile: emptyLaunchProfile({ cwd: "/repo", project: "repo" }),
+      turn: { state: "idle", source: "empty", terminalAt: null },
+      observedAt: "2026-07-10T12:01:00.000Z",
+    },
+  ]);
+
+  expect(forkCalls).toBe(1);
+  expect(receipt.path).toBe(copiedPath);
+  expect(fs.statSync(receipt.path).ino).toBe(published.ino);
+  expect(fs.readdirSync(source.transcriptRoot).filter((name) => name.endsWith(".jsonl"))).toHaveLength(2);
+  expect(fs.readdirSync(target.transcriptRoot).filter((name) => name.endsWith(".jsonl"))).toHaveLength(1);
+  expect(Object.values(registry.snapshot().conversations)).toHaveLength(1);
+});
+
+test("Codex successor provider rejects an unregistered fork path before recording ownership", async () => {
+  const base = fs.mkdtempSync(path.join(os.tmpdir(), "llv-provider-codex-foreign-"));
+  roots.push(base);
+  const source = accountRoot("codex", base, "source");
+  const target = accountRoot("codex", base, "target");
+  const sourcePath = path.join(source.transcriptRoot, "rollout-source.jsonl");
+  const foreignPath = path.join(base, "foreign-rollout.jsonl");
+  fs.writeFileSync(sourcePath, "{}\n", { mode: 0o600 });
+  fs.writeFileSync(foreignPath, "{}\n", { mode: 0o600 });
+  const client = {
+    async readAccount() { return { account: { type: "chatgpt" }, requiresOpenaiAuth: true }; },
+    async forkThread() { return { id: "019f423a-d6e9-4903-8597-3e676b6ff3d4", path: foreignPath }; },
+    close() {},
+  } as unknown as CodexAppServerClient;
+  const provider = new RegisteredSuccessorProvider({
+    accounts: { resolveSpawn: () => target, resolveTranscriptOwner: () => source },
+    startCodex: async () => client,
+    claudeStatus: async () => ({ loggedIn: false }),
+    spawnClaude: async () => { throw new Error("unexpected Claude spawn"); },
+    now: () => "2026-07-10T12:00:00.000Z",
+  });
+  const recorded: string[] = [];
+
+  await expect(provider.create({
+    engine: "codex",
+    operationId: "foreign-fork",
+    conversationId: "conversation_test",
+    targetAccountId: "target",
+    source: { id: "source", path: sourcePath, accountId: "source", launchProfile: emptyLaunchProfile({ cwd: "/repo" }), historyHash: null, host: null, createdAt: "now", archivedAt: null },
+    recordContinuityPath(pathname) { recorded.push(pathname); },
+  })).rejects.toThrow("unsafe-source");
+  expect(recorded).toEqual([]);
 });

--- a/src/lib/accounts/migration/provider.ts
+++ b/src/lib/accounts/migration/provider.ts
@@ -508,10 +508,10 @@ export class RegisteredSuccessorProvider implements SuccessorProviderPort {
       try {
         recordContinuityPath(successorPath);
       } catch (error) {
-        registry.failSpawn(launchId, "migration continuity persistence failed");
+        registry.preserveSpawnArtifactOwnership(launchId, "migration continuity persistence failed");
         try {
           if (await this.dependencies.cancelClaude?.(host)) await forgetResumePaneIfMatches(successorPath, host);
-        } catch { /* the durable terminal receipt prevents this host from being reused */ }
+        } catch { /* durable artifact ownership remains available to inventory recovery */ }
         throw error;
       }
     };

--- a/src/lib/accounts/migration/provider.ts
+++ b/src/lib/accounts/migration/provider.ts
@@ -7,32 +7,47 @@ import type { AccountContext, AccountManager } from "@/lib/accounts/contracts";
 import { CodexAppServerClient } from "@/lib/accounts/codexAppServer";
 import { realClaudeLoginPorts } from "@/lib/accounts/claudeLogin";
 import { claudeSuccessorSpecFor } from "@/lib/agent/cli";
-import { forgetResumePane, killPane, paneInfo, panePidOf, spawnAgentWithPrompt } from "@/lib/tmux";
+import { agentRegistry, type AgentRegistry, type SpawnReceipt, type TmuxHostEvidence } from "@/lib/agent/registry";
+import { statePath } from "@/lib/configDir";
+import { procBackend } from "@/lib/proc";
+import { forgetResumePaneIfMatches, killTmuxHostIfMatches, spawnAgentWithPrompt, verifyTmuxHostEvidence } from "@/lib/tmux";
 
 import type { LaunchProfile, ProviderReceipt, SuccessorProviderPort } from "./contracts";
-import { hashValidatedHistory, safeCopyHistory, validateHistorySource } from "./safeHistoryCopy";
+import { hashValidatedHistory, HistorySecurityError, safeCopyHistory, validateHistorySource } from "./safeHistoryCopy";
 
 export interface ProviderDependencies {
   accounts: Pick<AccountManager, "resolveSpawn" | "resolveTranscriptOwner">;
   startCodex(home: string): Promise<CodexAppServerClient>;
   claudeStatus(home: string): Promise<{ loggedIn: boolean }>;
-  spawnClaude(spec: ReturnType<typeof claudeSuccessorSpecFor>): Promise<{ paneId: string; panePid?: number }>;
-  claudeHost?(paneId: string): Promise<{ paneId: string; panePid: number; windowName: string } | null>;
-  cancelClaude?(paneId: string): Promise<void>;
+  spawnClaude(spec: ReturnType<typeof claudeSuccessorSpecFor>, receipt: SpawnReceipt): Promise<{ paneId: string; panePid?: number; host?: TmuxHostEvidence }>;
+  verifyClaudeHost?(host: TmuxHostEvidence): Promise<boolean>;
+  cancelClaude?(host: TmuxHostEvidence): Promise<boolean>;
+  registry?: AgentRegistry;
+  claudeJournalRoot?: string;
+  afterClaudeSpawned?(): void;
+  afterClaudeReceiptCreated?(): void;
+  journalRoot?: string;
+  afterCodexForkCreated?(): void;
+  afterCodexForkReturned?(): void;
+  afterCodexCopyPublished?(): void;
+  scanCodexForkArtifacts?(root: string, sourceNativeId: string, createdAtMs: number): CodexForkArtifact[];
   now(): string;
+}
+
+export class SuccessorPendingError extends Error {
+  constructor() {
+    super("successor launch receipt is awaiting host settlement");
+    this.name = "SuccessorPendingError";
+  }
 }
 
 const defaultDependencies: ProviderDependencies = {
   accounts: accountManager,
   startCodex: (home) => CodexAppServerClient.start({ home }),
   claudeStatus: (home) => realClaudeLoginPorts.status(home),
-  spawnClaude: (spec) => spawnAgentWithPrompt(spec, ""),
-  claudeHost: async (paneId) => {
-    const [info, panePid] = await Promise.all([paneInfo(paneId), panePidOf(paneId)]);
-    if (!info || panePid === null) return null;
-    return { paneId, panePid, windowName: info.windowName };
-  },
-  cancelClaude: async (paneId) => { await killPane(paneId); },
+  spawnClaude: (spec, receipt) => spawnAgentWithPrompt(spec, "", receipt),
+  verifyClaudeHost: (host) => verifyTmuxHostEvidence(host),
+  cancelClaude: (host) => killTmuxHostIfMatches(host),
   now: () => new Date().toISOString(),
 };
 
@@ -68,6 +83,298 @@ function findCodexRollout(root: string, nativeId: string): string {
   throw new Error("forked Codex history was not found");
 }
 
+interface CodexSessionMeta {
+  id: string;
+  forkedFromId: string | null;
+}
+
+interface CodexForkArtifact {
+  id: string;
+  path: string;
+}
+
+interface CodexProviderOperationJournal {
+  version: 1;
+  operationId: string;
+  sourceNativeId: string;
+  sourceRoot: string;
+  targetRoot: string;
+  createdAtMs: number;
+  forkRequestedAtMs: number | null;
+  fork: CodexForkArtifact | null;
+}
+
+const CODEX_META_SCAN_BYTES = 256 * 1024;
+const CODEX_OPERATION_LOCK_ATTEMPTS = 24_000;
+const CODEX_OPERATION_LOCK_WAIT_MS = 5;
+const CODEX_OPERATION_LOCK_STALE_MS = 30_000;
+
+interface CodexOperationLockOwner {
+  pid: number;
+  startIdentity: string | null;
+  token: string;
+}
+
+function providerLockOwnerIsStale(filename: string): boolean {
+  try {
+    const owner = JSON.parse(fs.readFileSync(filename, "utf8")) as Partial<CodexOperationLockOwner>;
+    if (!Number.isInteger(owner.pid) || !owner.pid || owner.pid < 1) {
+      return Date.now() - fs.statSync(filename).mtimeMs > CODEX_OPERATION_LOCK_STALE_MS;
+    }
+    if (!procBackend.pidAlive(owner.pid)) return true;
+    if (typeof owner.startIdentity === "string") {
+      const currentIdentity = procBackend.processIdentity(owner.pid);
+      return currentIdentity !== null && currentIdentity !== owner.startIdentity;
+    }
+    return Date.now() - fs.statSync(filename).mtimeMs > CODEX_OPERATION_LOCK_STALE_MS;
+  } catch {
+    try { return Date.now() - fs.statSync(filename).mtimeMs > CODEX_OPERATION_LOCK_STALE_MS; } catch { return false; }
+  }
+}
+
+function removeProviderLockIfOwned(filename: string, token: string): void {
+  try {
+    const owner = JSON.parse(fs.readFileSync(filename, "utf8")) as Partial<CodexOperationLockOwner>;
+    if (owner.token === token) fs.rmSync(filename, { force: true });
+  } catch { /* another owner already recovered the lease */ }
+}
+
+function ensureDurableDirectory(directory: string): void {
+  const missing: string[] = [];
+  let current = path.resolve(directory);
+  while (!fs.existsSync(current)) {
+    missing.push(current);
+    const parent = path.dirname(current);
+    if (parent === current) break;
+    current = parent;
+  }
+  for (const pathname of missing.reverse()) {
+    try { fs.mkdirSync(pathname, { mode: 0o700 }); } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
+    }
+    const descriptor = fs.openSync(path.dirname(pathname), "r");
+    try { fs.fsyncSync(descriptor); } finally { fs.closeSync(descriptor); }
+    const created = fs.openSync(pathname, "r");
+    try { fs.fsyncSync(created); } finally { fs.closeSync(created); }
+  }
+}
+
+function assertProviderLockOwned(filename: string, token: string): void {
+  try {
+    const owner = JSON.parse(fs.readFileSync(filename, "utf8")) as Partial<CodexOperationLockOwner>;
+    if (owner.token === token) return;
+  } catch { /* handled by the fenced error below */ }
+  throw new Error("Codex provider operation lease was lost");
+}
+
+async function waitForProviderLock(): Promise<void> {
+  await new Promise<void>((resolve) => setTimeout(resolve, CODEX_OPERATION_LOCK_WAIT_MS));
+}
+
+async function withCodexOperationLease<T>(
+  journalRoot: string,
+  operationId: string,
+  operation: (assertOwned: () => void) => Promise<T>,
+): Promise<T> {
+  const operationPath = operationJournalPath(journalRoot, operationId);
+  const lockPath = `${operationPath}.lock`;
+  const queuePath = `${operationPath}.locks`;
+  ensureDurableDirectory(journalRoot);
+  ensureDurableDirectory(queuePath);
+  const owner: CodexOperationLockOwner = {
+    pid: process.pid,
+    startIdentity: procBackend.processIdentity(process.pid),
+    token: crypto.randomUUID(),
+  };
+  const ticketPath = path.join(
+    queuePath,
+    `${String(Date.now()).padStart(16, "0")}-${process.pid}-${owner.token}.json`,
+  );
+  fs.writeFileSync(ticketPath, JSON.stringify(owner), { encoding: "utf8", flag: "wx", mode: 0o600 });
+  try {
+    for (let attempt = 0; attempt < CODEX_OPERATION_LOCK_ATTEMPTS; attempt += 1) {
+      try { fs.utimesSync(ticketPath, new Date(), new Date()); } catch { /* ownership is checked below */ }
+      const liveTickets: string[] = [];
+      for (const entry of fs.readdirSync(queuePath).filter((candidate) => candidate.endsWith(".json")).sort()) {
+        const candidate = path.join(queuePath, entry);
+        if (providerLockOwnerIsStale(candidate)) {
+          fs.rmSync(candidate, { force: true });
+          continue;
+        }
+        if (fs.existsSync(candidate)) liveTickets.push(candidate);
+      }
+      if (liveTickets[0] !== ticketPath) {
+        await waitForProviderLock();
+        continue;
+      }
+      let descriptor: number;
+      try {
+        descriptor = fs.openSync(lockPath, "wx", 0o600);
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
+        if (providerLockOwnerIsStale(lockPath)) fs.rmSync(lockPath, { force: true });
+        await waitForProviderLock();
+        continue;
+      }
+      fs.writeFileSync(descriptor, JSON.stringify(owner), "utf8");
+      fs.fsyncSync(descriptor);
+      const renewal = setInterval(() => {
+        try {
+          const timestamp = new Date();
+          fs.utimesSync(lockPath, timestamp, timestamp);
+          fs.utimesSync(ticketPath, timestamp, timestamp);
+        } catch { /* the final ownership check fences replacement owners */ }
+      }, CODEX_OPERATION_LOCK_STALE_MS / 3);
+      renewal.unref();
+      try {
+        return await operation(() => assertProviderLockOwned(lockPath, owner.token));
+      } finally {
+        clearInterval(renewal);
+        fs.closeSync(descriptor);
+        removeProviderLockIfOwned(lockPath, owner.token);
+      }
+    }
+    throw new Error("Codex provider operation is busy");
+  } finally {
+    removeProviderLockIfOwned(ticketPath, owner.token);
+  }
+}
+
+function readCodexSessionMeta(pathname: string): CodexSessionMeta | null {
+  let descriptor: number | null = null;
+  try {
+    const listed = fs.lstatSync(pathname);
+    if (!listed.isFile() || listed.isSymbolicLink()) return null;
+    descriptor = fs.openSync(pathname, fs.constants.O_RDONLY | (fs.constants.O_NOFOLLOW ?? 0));
+    const buffer = Buffer.alloc(Math.min(CODEX_META_SCAN_BYTES, Math.max(1, listed.size)));
+    const bytes = fs.readSync(descriptor, buffer, 0, buffer.length, 0);
+    for (const line of buffer.subarray(0, bytes).toString("utf8").split("\n")) {
+      if (!line.trim()) continue;
+      try {
+        const record = JSON.parse(line) as { type?: unknown; payload?: unknown };
+        if (record.type !== "session_meta" || !record.payload || typeof record.payload !== "object" || Array.isArray(record.payload)) continue;
+        const payload = record.payload as { id?: unknown; forked_from_id?: unknown };
+        if (typeof payload.id !== "string" || !payload.id) return null;
+        return {
+          id: payload.id,
+          forkedFromId: typeof payload.forked_from_id === "string" && payload.forked_from_id ? payload.forked_from_id : null,
+        };
+      } catch { /* continue through bounded metadata rows */ }
+    }
+    return null;
+  } catch {
+    return null;
+  } finally {
+    if (descriptor !== null) fs.closeSync(descriptor);
+  }
+}
+
+function codexForkArtifacts(root: string, sourceNativeId: string, createdAtMs: number): CodexForkArtifact[] {
+  const stack: Array<{ dir: string; depth: number }> = [{ dir: root, depth: 0 }];
+  const artifacts: CodexForkArtifact[] = [];
+  while (stack.length) {
+    const current = stack.pop()!;
+    if (current.depth > 6) continue;
+    for (const entry of fs.readdirSync(current.dir, { withFileTypes: true })) {
+      const candidate = path.join(current.dir, entry.name);
+      if (entry.isSymbolicLink()) continue;
+      if (entry.isDirectory()) {
+        stack.push({ dir: candidate, depth: current.depth + 1 });
+        continue;
+      }
+      if (!entry.isFile() || !entry.name.endsWith(".jsonl")) continue;
+      if (fs.statSync(candidate).mtimeMs < createdAtMs) continue;
+      const metadata = readCodexSessionMeta(candidate);
+      if (metadata?.forkedFromId === sourceNativeId) artifacts.push({ id: metadata.id, path: fs.realpathSync(candidate) });
+    }
+  }
+  return artifacts;
+}
+
+function operationJournalPath(root: string, operationId: string): string {
+  return path.join(root, `${crypto.createHash("sha256").update(operationId).digest("hex")}.json`);
+}
+
+function writeCodexOperationJournal(root: string, journal: CodexProviderOperationJournal): void {
+  fs.mkdirSync(root, { recursive: true, mode: 0o700 });
+  const filename = operationJournalPath(root, journal.operationId);
+  const temp = `${filename}.${process.pid}.${crypto.randomUUID()}.tmp`;
+  try {
+    fs.writeFileSync(temp, JSON.stringify(journal, null, 2) + "\n", { mode: 0o600, flag: "wx" });
+    const descriptor = fs.openSync(temp, "r");
+    try { fs.fsyncSync(descriptor); } finally { fs.closeSync(descriptor); }
+    fs.renameSync(temp, filename);
+    const directory = fs.openSync(root, "r");
+    try { fs.fsyncSync(directory); } finally { fs.closeSync(directory); }
+  } finally {
+    fs.rmSync(temp, { force: true });
+  }
+}
+
+function prepareCodexOperationJournal(
+  root: string,
+  operationId: string,
+  sourceNativeId: string,
+  sourceRoot: string,
+  targetRoot: string,
+): { journal: CodexProviderOperationJournal; fresh: boolean } {
+  const filename = operationJournalPath(root, operationId);
+  try {
+    const journal = JSON.parse(fs.readFileSync(filename, "utf8")) as Partial<CodexProviderOperationJournal>;
+    if (journal.version !== 1 || journal.operationId !== operationId || journal.sourceNativeId !== sourceNativeId
+      || journal.sourceRoot !== sourceRoot || journal.targetRoot !== targetRoot
+      || typeof journal.createdAtMs !== "number" || !Number.isFinite(journal.createdAtMs)) {
+      throw new Error("Codex provider operation journal does not match");
+    }
+    const fork = journal.fork && typeof journal.fork.id === "string" && typeof journal.fork.path === "string"
+      ? { id: journal.fork.id, path: journal.fork.path }
+      : null;
+    const forkRequestedAtMs = typeof journal.forkRequestedAtMs === "number" && Number.isFinite(journal.forkRequestedAtMs)
+      ? journal.forkRequestedAtMs
+      : null;
+    return {
+      journal: { version: 1, operationId, sourceNativeId, sourceRoot, targetRoot, createdAtMs: journal.createdAtMs, forkRequestedAtMs, fork },
+      fresh: false,
+    };
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+  }
+  const journal: CodexProviderOperationJournal = {
+    version: 1,
+    operationId,
+    sourceNativeId,
+    sourceRoot,
+    targetRoot,
+    createdAtMs: Date.now(),
+    forkRequestedAtMs: null,
+    fork: null,
+  };
+  writeCodexOperationJournal(root, journal);
+  return { journal, fresh: true };
+}
+
+function validatedCodexFork(artifact: CodexForkArtifact, sourceNativeId: string, sourceRoot: string): CodexForkArtifact {
+  const validated = validateHistorySource(artifact.path, sourceRoot);
+  const metadata = readCodexSessionMeta(validated.sourcePath);
+  if (!path.basename(validated.sourcePath).endsWith(`${artifact.id}.jsonl`)
+    || metadata?.id !== artifact.id || metadata.forkedFromId !== sourceNativeId) {
+    throw new HistorySecurityError("unsafe-source");
+  }
+  return { id: artifact.id, path: validated.sourcePath };
+}
+
+function recoverCodexFork(
+  journal: CodexProviderOperationJournal,
+  scan: NonNullable<ProviderDependencies["scanCodexForkArtifacts"]> = codexForkArtifacts,
+): CodexForkArtifact | null {
+  if (journal.fork) return validatedCodexFork(journal.fork, journal.sourceNativeId, journal.sourceRoot);
+  if (journal.forkRequestedAtMs === null) return null;
+  const candidates = scan(journal.sourceRoot, journal.sourceNativeId, journal.forkRequestedAtMs)
+    .map((candidate) => validatedCodexFork(candidate, journal.sourceNativeId, journal.sourceRoot));
+  if (candidates.length > 1) throw new Error("Codex provider fork ownership is ambiguous");
+  return candidates[0] ?? null;
+}
+
 function ensureTargetRoot(account: AccountContext): void {
   const home = fs.lstatSync(account.home);
   if (!home.isDirectory() || home.isSymbolicLink() || (process.getuid && home.uid !== process.getuid()) || (home.mode & 0o022) !== 0) {
@@ -90,11 +397,13 @@ function claudePaneFromHost(receipt: ProviderReceipt): { paneId: string; panePid
   return { paneId: matched[1]!, panePid: Number(matched[2]) };
 }
 
-function claudePaneIdFromHost(receipt: ProviderReceipt): string {
-  if (receipt.host.kind !== "claude-stream") throw new Error("successor Claude host identity is invalid");
-  const matched = /^(%[0-9]+):/.exec(receipt.host.identity);
-  if (!matched) throw new Error("successor Claude host identity is invalid");
-  return matched[1]!;
+function claudeTmuxHostFromReceipt(receipt: ProviderReceipt): TmuxHostEvidence {
+  const expected = claudePaneFromHost(receipt);
+  const host = receipt.host.tmuxHost;
+  if (!host || host.kind !== "tmux" || host.paneId !== expected.paneId || host.panePid.pid !== expected.panePid) {
+    throw new Error("successor Claude host identity is invalid");
+  }
+  return host;
 }
 
 function assertClaudeTranscript(receipt: ProviderReceipt, target: AccountContext): void {
@@ -111,7 +420,6 @@ function assertClaudeTranscript(receipt: ProviderReceipt, target: AccountContext
     } catch { return false; }
   });
   if (!matchesSession) throw new Error("target Claude transcript session identity does not match");
-  receipt.historyHash = history.hash;
 }
 
 export class RegisteredSuccessorProvider implements SuccessorProviderPort {
@@ -122,8 +430,8 @@ export class RegisteredSuccessorProvider implements SuccessorProviderPort {
     const source = assertRegisteredRoots(this.dependencies.accounts.resolveTranscriptOwner(input.engine, input.source.path), target, input.source.path);
     ensureTargetRoot(target);
     return input.engine === "codex"
-      ? this.createCodex(input.operationId, input.source.id, input.source.launchProfile, source, target)
-      : this.createClaude(input.operationId, input.source.path, input.source.launchProfile, source, target);
+      ? this.createCodex(input.operationId, input.source.id, input.source.launchProfile, source, target, input.recordContinuityPath)
+      : this.createClaude(input.operationId, input.conversationId, input.source.path, input.source.launchProfile, source, target, input.recordContinuityPath);
   }
 
   async verify(receipt: ProviderReceipt, input: { engine: "claude" | "codex"; targetAccountId: string; launchProfile: LaunchProfile }): Promise<void> {
@@ -133,9 +441,8 @@ export class RegisteredSuccessorProvider implements SuccessorProviderPort {
       const status = await this.dependencies.claudeStatus(target.home);
       if (!status.loggedIn) throw new Error("target Claude account is not authenticated");
       assertClaudeTranscript(receipt, target);
-      const expected = claudePaneFromHost(receipt);
-      const host = await this.dependencies.claudeHost?.(expected.paneId);
-      if (!host || host.paneId !== expected.paneId || host.panePid !== expected.panePid || host.windowName !== "claude-migration-successor") {
+      const host = claudeTmuxHostFromReceipt(receipt);
+      if (host.windowName !== "claude-migration-successor" || !await this.dependencies.verifyClaudeHost?.(host)) {
         throw new Error("target Claude successor host is not live and canonical");
       }
       return;
@@ -153,48 +460,211 @@ export class RegisteredSuccessorProvider implements SuccessorProviderPort {
 
   async cleanup(receipt: ProviderReceipt): Promise<void> {
     if (receipt.host.kind !== "claude-stream") return;
-    const paneId = claudePaneIdFromHost(receipt);
-    forgetResumePane(receipt.path);
-    await this.dependencies.cancelClaude?.(paneId);
+    const host = claudeTmuxHostFromReceipt(receipt);
+    const cancelled = await this.dependencies.cancelClaude?.(host);
+    if (cancelled) await forgetResumePaneIfMatches(receipt.path, host);
   }
 
-  private async createClaude(operationId: string, sourcePath: string, profile: LaunchProfile, source: AccountContext, target: AccountContext): Promise<ProviderReceipt> {
+  private async createClaude(
+    operationId: string,
+    conversationId: Parameters<SuccessorProviderPort["create"]>[0]["conversationId"],
+    sourcePath: string,
+    profile: LaunchProfile,
+    source: AccountContext,
+    target: AccountContext,
+    recordContinuityPath: (pathname: string) => void,
+  ): Promise<ProviderReceipt> {
+    const journalRoot = this.dependencies.claudeJournalRoot ?? statePath("migration-provider-claude-operations");
+    return withCodexOperationLease(journalRoot, operationId, (assertLeaseOwned) => this.createClaudeLocked(
+      operationId,
+      conversationId,
+      sourcePath,
+      profile,
+      source,
+      target,
+      recordContinuityPath,
+      assertLeaseOwned,
+    ));
+  }
+
+  private async createClaudeLocked(
+    operationId: string,
+    conversationId: Parameters<SuccessorProviderPort["create"]>[0]["conversationId"],
+    sourcePath: string,
+    profile: LaunchProfile,
+    source: AccountContext,
+    target: AccountContext,
+    recordContinuityPath: (pathname: string) => void,
+    assertLeaseOwned: () => void,
+  ): Promise<ProviderReceipt> {
     const status = await this.dependencies.claudeStatus(target.home);
     if (!status.loggedIn) throw new Error("target Claude account is not authenticated");
     const history = hashValidatedHistory(sourcePath, source.transcriptRoot);
     const nativeId = candidateUuid(operationId);
     const spec = claudeSuccessorSpecFor({ sourcePath, candidateId: nativeId, targetHome: target.home, targetProjectsDir: target.transcriptRoot, profile });
-    const pane = await this.dependencies.spawnClaude(spec);
+    const successorPath = spec.transcript ?? path.join(target.transcriptRoot, `${nativeId}.jsonl`);
+    const registry = this.dependencies.registry ?? agentRegistry();
+    const requestDigest = crypto.createHash("sha256").update(JSON.stringify({ operationId, conversationId, target: target.accountId, nativeId })).digest("hex");
+    const begun = registry.beginSpawnRequest({
+      engine: "claude",
+      cwd: profile.cwd,
+      launchProfile: profile,
+      clientAttemptId: `migration-successor:${operationId}`,
+      requestDigest,
+      accountId: target.accountId,
+      conversationId,
+      purpose: "migration-successor",
+      expectedArtifactPath: successorPath,
+    });
+    if (begun.kind === "conflict") throw new Error("successor Claude operation receipt conflicts");
+    const spawnReceipt = begun.receipt;
+    if (begun.kind === "replay") {
+      if (spawnReceipt.state === "failed" || spawnReceipt.state === "conflicted") {
+        throw new Error("successor Claude operation receipt is terminal");
+      }
+      const host = spawnReceipt.verifiedHost;
+      if (host) {
+        if (!await this.dependencies.verifyClaudeHost?.(host)) {
+          throw new Error("successor Claude operation has no recoverable live host");
+        }
+        recordContinuityPath(successorPath);
+        return {
+          operationId,
+          nativeId,
+          path: successorPath,
+          continuityPaths: [successorPath],
+          historyHash: history.hash,
+          host: { kind: "claude-stream", identity: `${host.paneId}:${host.panePid.pid}`, epoch: 1, verifiedAt: this.dependencies.now(), tmuxHost: host },
+        };
+      }
+      if (spawnReceipt.state !== "starting" || spawnReceipt.pane || fs.existsSync(successorPath)) throw new SuccessorPendingError();
+    } else {
+      this.dependencies.afterClaudeReceiptCreated?.();
+    }
+    assertLeaseOwned();
+    let pane: Awaited<ReturnType<ProviderDependencies["spawnClaude"]>>;
+    try {
+      pane = await this.dependencies.spawnClaude(spec, spawnReceipt);
+    } catch (error) {
+      registry.failSpawn(spawnReceipt.launchId, error instanceof Error ? error.message : String(error));
+      throw error;
+    }
+    if (!pane.host || pane.panePid === undefined || pane.host.paneId !== pane.paneId || pane.host.panePid.pid !== pane.panePid) {
+      registry.failSpawn(spawnReceipt.launchId, "successor Claude host evidence is unavailable");
+      throw new Error("successor Claude host evidence is unavailable");
+    }
+    const fenceReceipt = async (receipt: SpawnReceipt): Promise<void> => {
+      if (receipt.state !== "failed" && receipt.state !== "conflicted") return;
+      try { await this.dependencies.cancelClaude?.(pane.host!); } catch { /* terminal receipt fencing keeps cleanup best effort */ }
+      throw new Error("successor Claude operation receipt became terminal");
+    };
+    const bound = registry.bindSpawnPane(spawnReceipt.launchId, {
+      endpoint: pane.host.endpoint,
+      server: pane.host.server,
+      paneId: pane.host.paneId,
+      panePid: pane.host.panePid,
+      target: pane.host.paneId,
+    });
+    await fenceReceipt(bound);
+    const verified = registry.markSpawnHostVerified(spawnReceipt.launchId, pane.host);
+    await fenceReceipt(verified);
+    const delivered = registry.markSpawnPromptDelivered(spawnReceipt.launchId);
+    await fenceReceipt(delivered);
+    recordContinuityPath(successorPath);
+    assertLeaseOwned();
+    this.dependencies.afterClaudeSpawned?.();
     return {
       operationId,
       nativeId,
-      path: spec.transcript ?? path.join(target.transcriptRoot, `${nativeId}.jsonl`),
+      path: successorPath,
+      continuityPaths: [successorPath],
       historyHash: history.hash,
-      host: { kind: "claude-stream", identity: `${pane.paneId}:${pane.panePid ?? "unknown"}`, epoch: 1, verifiedAt: this.dependencies.now() },
+      host: { kind: "claude-stream", identity: `${pane.paneId}:${pane.panePid}`, epoch: 1, verifiedAt: this.dependencies.now(), tmuxHost: pane.host },
     };
   }
 
-  private async createCodex(operationId: string, sourceNativeId: string, profile: LaunchProfile, source: AccountContext, target: AccountContext): Promise<ProviderReceipt> {
-    const sourceClient = await this.dependencies.startCodex(source.home);
-    let fork: Awaited<ReturnType<CodexAppServerClient["forkThread"]>>;
-    try {
-      const account = await sourceClient.readAccount();
-      if (!account.account) throw new Error("source Codex account is not authenticated");
-      fork = await sourceClient.forkThread(sourceNativeId);
-    } finally { sourceClient.close(); }
-    const sourceFork = fork.path ?? findCodexRollout(source.transcriptRoot, fork.id);
+  private async createCodex(
+    operationId: string,
+    sourceNativeId: string,
+    profile: LaunchProfile,
+    source: AccountContext,
+    target: AccountContext,
+    recordContinuityPath: (pathname: string) => void,
+  ): Promise<ProviderReceipt> {
+    const journalRoot = this.dependencies.journalRoot ?? statePath("migration-provider-operations");
+    return withCodexOperationLease(journalRoot, operationId, (assertLeaseOwned) => this.createCodexLocked(
+      operationId,
+      sourceNativeId,
+      profile,
+      source,
+      target,
+      recordContinuityPath,
+      journalRoot,
+      assertLeaseOwned,
+    ));
+  }
+
+  private async createCodexLocked(
+    operationId: string,
+    sourceNativeId: string,
+    profile: LaunchProfile,
+    source: AccountContext,
+    target: AccountContext,
+    recordContinuityPath: (pathname: string) => void,
+    journalRoot: string,
+    assertLeaseOwned: () => void,
+  ): Promise<ProviderReceipt> {
+    const prepared = prepareCodexOperationJournal(
+      journalRoot,
+      operationId,
+      sourceNativeId,
+      fs.realpathSync(source.transcriptRoot),
+      fs.realpathSync(target.transcriptRoot),
+    );
+    const journal = prepared.journal;
+    let fork = prepared.fresh ? null : recoverCodexFork(journal, this.dependencies.scanCodexForkArtifacts);
+    if (fork && !journal.fork) {
+      journal.fork = fork;
+      assertLeaseOwned();
+      writeCodexOperationJournal(journalRoot, journal);
+    }
+    if (!fork) {
+      const sourceClient = await this.dependencies.startCodex(source.home);
+      let created: Awaited<ReturnType<CodexAppServerClient["forkThread"]>>;
+      try {
+        const account = await sourceClient.readAccount();
+        if (!account.account) throw new Error("source Codex account is not authenticated");
+        journal.forkRequestedAtMs = Date.now();
+        assertLeaseOwned();
+        writeCodexOperationJournal(journalRoot, journal);
+        created = await sourceClient.forkThread(sourceNativeId);
+        this.dependencies.afterCodexForkReturned?.();
+      } finally { sourceClient.close(); }
+      const reportedSourceFork = created.path ?? findCodexRollout(source.transcriptRoot, created.id);
+      fork = validatedCodexFork({ id: created.id, path: reportedSourceFork }, sourceNativeId, source.transcriptRoot);
+      journal.fork = fork;
+      assertLeaseOwned();
+      writeCodexOperationJournal(journalRoot, journal);
+      this.dependencies.afterCodexForkCreated?.();
+    }
+    const sourceFork = fork.path;
+    recordContinuityPath(sourceFork);
     const relative = path.relative(source.transcriptRoot, sourceFork);
+    assertLeaseOwned();
     const copied = safeCopyHistory({
       sourcePath: sourceFork,
       sourceRoot: source.transcriptRoot,
       targetRoot: target.transcriptRoot,
       destinationRelative: relative,
       operationId,
+      afterDestinationPublished: this.dependencies.afterCodexCopyPublished,
     });
+    recordContinuityPath(copied.path);
     const targetClient = await this.dependencies.startCodex(target.home);
     try {
       const account = await targetClient.readAccount();
       if (!account.account) throw new Error("target Codex account is not authenticated");
+      assertLeaseOwned();
       const approvalPolicy = profile.permissionMode && ["never", "on-request", "untrusted"].includes(profile.permissionMode)
         ? profile.permissionMode
         : null;
@@ -217,6 +687,7 @@ export class RegisteredSuccessorProvider implements SuccessorProviderPort {
       operationId,
       nativeId: fork.id,
       path: copied.path,
+      continuityPaths: [sourceFork, copied.path],
       historyHash: copied.hash,
       host: { kind: "codex-app-server", identity: fork.id, epoch: 1, verifiedAt: this.dependencies.now() },
     };

--- a/src/lib/accounts/migration/provider.ts
+++ b/src/lib/accounts/migration/provider.ts
@@ -504,6 +504,17 @@ export class RegisteredSuccessorProvider implements SuccessorProviderPort {
     const spec = claudeSuccessorSpecFor({ sourcePath, candidateId: nativeId, targetHome: target.home, targetProjectsDir: target.transcriptRoot, profile });
     const successorPath = spec.transcript ?? path.join(target.transcriptRoot, `${nativeId}.jsonl`);
     const registry = this.dependencies.registry ?? agentRegistry();
+    const recordContinuityOrCancel = async (launchId: string, host: TmuxHostEvidence): Promise<void> => {
+      try {
+        recordContinuityPath(successorPath);
+      } catch (error) {
+        registry.failSpawn(launchId, "migration continuity persistence failed");
+        try {
+          if (await this.dependencies.cancelClaude?.(host)) await forgetResumePaneIfMatches(successorPath, host);
+        } catch { /* the durable terminal receipt prevents this host from being reused */ }
+        throw error;
+      }
+    };
     const requestDigest = crypto.createHash("sha256").update(JSON.stringify({ operationId, conversationId, target: target.accountId, nativeId })).digest("hex");
     const begun = registry.beginSpawnRequest({
       engine: "claude",
@@ -527,7 +538,7 @@ export class RegisteredSuccessorProvider implements SuccessorProviderPort {
         if (!await this.dependencies.verifyClaudeHost?.(host)) {
           throw new Error("successor Claude operation has no recoverable live host");
         }
-        recordContinuityPath(successorPath);
+        await recordContinuityOrCancel(spawnReceipt.launchId, host);
         return {
           operationId,
           nativeId,
@@ -570,7 +581,7 @@ export class RegisteredSuccessorProvider implements SuccessorProviderPort {
     await fenceReceipt(verified);
     const delivered = registry.markSpawnPromptDelivered(spawnReceipt.launchId);
     await fenceReceipt(delivered);
-    recordContinuityPath(successorPath);
+    await recordContinuityOrCancel(spawnReceipt.launchId, pane.host);
     assertLeaseOwned();
     this.dependencies.afterClaudeSpawned?.();
     return {

--- a/src/lib/accounts/migration/provider.ts
+++ b/src/lib/accounts/migration/provider.ts
@@ -41,6 +41,13 @@ export class SuccessorPendingError extends Error {
   }
 }
 
+export class CodexForkOutcomeUnknownError extends Error {
+  constructor(message = "Codex provider fork outcome is unknown") {
+    super(message);
+    this.name = "CodexForkOutcomeUnknownError";
+  }
+}
+
 const defaultDependencies: ProviderDependencies = {
   accounts: accountManager,
   startCodex: (home) => CodexAppServerClient.start({ home }),
@@ -371,7 +378,7 @@ function recoverCodexFork(
   if (journal.forkRequestedAtMs === null) return null;
   const candidates = scan(journal.sourceRoot, journal.sourceNativeId, journal.forkRequestedAtMs)
     .map((candidate) => validatedCodexFork(candidate, journal.sourceNativeId, journal.sourceRoot));
-  if (candidates.length > 1) throw new Error("Codex provider fork ownership is ambiguous");
+  if (candidates.length > 1) throw new CodexForkOutcomeUnknownError("Codex provider fork ownership is ambiguous");
   return candidates[0] ?? null;
 }
 
@@ -462,7 +469,8 @@ export class RegisteredSuccessorProvider implements SuccessorProviderPort {
     if (receipt.host.kind !== "claude-stream") return;
     const host = claudeTmuxHostFromReceipt(receipt);
     const cancelled = await this.dependencies.cancelClaude?.(host);
-    if (cancelled) await forgetResumePaneIfMatches(receipt.path, host);
+    if (!cancelled) throw new Error("successor Claude host cleanup is still pending");
+    await forgetResumePaneIfMatches(receipt.path, host);
   }
 
   private async createClaude(
@@ -639,6 +647,7 @@ export class RegisteredSuccessorProvider implements SuccessorProviderPort {
       assertLeaseOwned();
       writeCodexOperationJournal(journalRoot, journal);
     }
+    if (!fork && !prepared.fresh && journal.forkRequestedAtMs !== null) throw new CodexForkOutcomeUnknownError();
     if (!fork) {
       const sourceClient = await this.dependencies.startCodex(source.home);
       let created: Awaited<ReturnType<CodexAppServerClient["forkThread"]>>;
@@ -648,7 +657,11 @@ export class RegisteredSuccessorProvider implements SuccessorProviderPort {
         journal.forkRequestedAtMs = Date.now();
         assertLeaseOwned();
         writeCodexOperationJournal(journalRoot, journal);
-        created = await sourceClient.forkThread(sourceNativeId);
+        try {
+          created = await sourceClient.forkThread(sourceNativeId);
+        } catch (error) {
+          throw new CodexForkOutcomeUnknownError(error instanceof Error ? error.message : String(error));
+        }
         this.dependencies.afterCodexForkReturned?.();
       } finally { sourceClient.close(); }
       const reportedSourceFork = created.path ?? findCodexRollout(source.transcriptRoot, created.id);

--- a/src/lib/accounts/migration/quotaController.test.ts
+++ b/src/lib/accounts/migration/quotaController.test.ts
@@ -8,25 +8,52 @@ import type { CodexAccount } from "@/lib/accounts/codex";
 
 import { QuotaController, type QuotaProbePort } from "./quotaController";
 
-test("durable per-engine policy is the quota evaluation guard", async () => {
+test("quota visibility remains fresh when automatic balancing is disabled", async () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "llv-quota-controller-"));
   try {
     const registry = new AgentRegistry(path.join(root, "registry.json"));
     let listed = 0;
+    let current = Date.parse("2026-07-10T12:00:00.000Z");
+    const accounts: CodexAccount[] = [
+      { id: "default", label: "Main", kind: "legacy", home: "/homes/main", sessionsDir: "/homes/main/sessions", authPresent: true, loginPane: null, createdAt: 0 },
+      { id: "managed", label: "Managed", kind: "managed", home: "/homes/managed", sessionsDir: "/homes/managed/sessions", authPresent: true, loginPane: null, createdAt: 1 },
+    ];
     const probe: QuotaProbePort = {
-      list() { listed += 1; return []; },
+      list() { listed += 1; return accounts; },
       active() { return "default"; },
-      async probe() { throw new Error("no account should be probed"); },
+      async probe(engine, candidate, now) {
+        return {
+          engine,
+          accountId: candidate.id,
+          authenticated: true,
+          authCheckedAt: now,
+          limits: {
+            session: { usedPercent: candidate.id === "default" ? 100 : 10, resetsAt: Math.floor(now / 1000) + 3_600 },
+            weekly: null,
+            plan: "pro",
+            capturedAt: Math.floor(now / 1000),
+          },
+          provenance: { source: "live", reason: null, staleSince: null },
+          observedAt: now,
+        };
+      },
     };
-    const controller = new QuotaController(registry, probe, "00000000-0000-4000-8000-000000000000", () => Date.parse("2026-07-10T12:00:00.000Z"));
+    const controller = new QuotaController(registry, probe, "00000000-0000-4000-8000-000000000000", () => current);
 
     registry.setAutoBalancePolicy("codex", false);
     await controller.tick("codex");
-    expect(listed).toBe(0);
-
-    registry.setAutoBalancePolicy("codex", true);
+    current += 60_000;
     await controller.tick("codex");
-    expect(listed).toBe(1);
+    expect(listed).toBe(2);
+    expect(registry.snapshot().quotaObservations.codex.default).toMatchObject({
+      authenticated: true,
+      limits: { session: { usedPercent: 100 } },
+    });
+    expect(registry.snapshot().quotaObservations.codex.managed).toMatchObject({
+      authenticated: true,
+      limits: { session: { usedPercent: 10 } },
+    });
+    expect(Object.values(registry.snapshot().migrationIntents)).toHaveLength(0);
   } finally {
     fs.rmSync(root, { recursive: true, force: true });
   }

--- a/src/lib/accounts/migration/quotaController.ts
+++ b/src/lib/accounts/migration/quotaController.ts
@@ -92,7 +92,6 @@ export class QuotaController {
   ) {}
 
   async tick(engine: MigrationEngine): Promise<void> {
-    if (!this.registry.autoBalancePolicy(engine).enabled) return;
     const now = this.now();
     const accounts = this.probe.list(engine);
     const observations = await mapLimit(accounts, 2, async (account) => {

--- a/src/lib/accounts/migration/safeHistoryCopy.test.ts
+++ b/src/lib/accounts/migration/safeHistoryCopy.test.ts
@@ -88,6 +88,48 @@ describe("safe history copy", () => {
       .toThrow(HistorySecurityError);
   });
 
+  test("recovers an identical destination published before its operation receipt", () => {
+    const f = fixture();
+    const destinationRelative = "2026/07/recoverable.jsonl";
+    const destination = path.join(f.targetRoot, destinationRelative);
+    expect(() => safeCopyHistory({
+      ...f,
+      destinationRelative,
+      operationId: "publish-before-receipt",
+      afterDestinationPublished() { throw new Error("simulated crash before copy receipt"); },
+    })).toThrow("simulated crash before copy receipt");
+    expect(fs.existsSync(destination)).toBeTrue();
+    expect(fs.existsSync(`${destination}.llv-receipt.json`)).toBeFalse();
+
+    const recovered = safeCopyHistory({
+      ...f,
+      destinationRelative,
+      operationId: "publish-before-receipt",
+    });
+
+    expect(recovered).toMatchObject({ path: destination, reused: true });
+    expect(fs.existsSync(`${destination}.llv-receipt.json`)).toBeTrue();
+  });
+
+  test("recovers a published destination with its interrupted temporary hard link", () => {
+    const f = fixture();
+    const destination = path.join(f.targetRoot, "recover-hardlink.jsonl");
+    fs.copyFileSync(f.sourcePath, destination, fs.constants.COPYFILE_EXCL);
+    fs.chmodSync(destination, 0o600);
+    const interruptedTemp = path.join(f.targetRoot, ".recover-hardlink.jsonl.123.operation.tmp");
+    fs.linkSync(destination, interruptedTemp);
+
+    const recovered = safeCopyHistory({
+      ...f,
+      destinationRelative: "recover-hardlink.jsonl",
+      operationId: "recover-hardlink",
+    });
+
+    expect(recovered).toMatchObject({ path: destination, reused: true });
+    expect(fs.existsSync(interruptedTemp)).toBeFalse();
+    expect(fs.statSync(destination).nlink).toBe(1);
+  });
+
   test("rejects traversal, symlinks, unsafe modes, oversize input, and collisions", () => {
     const f = fixture();
     expect(() => safeCopyHistory({ ...f, destinationRelative: "../escape.jsonl", operationId: "traversal" }))

--- a/src/lib/accounts/migration/safeHistoryCopy.ts
+++ b/src/lib/accounts/migration/safeHistoryCopy.ts
@@ -189,11 +189,50 @@ export interface SafeHistoryCopyInput {
   destinationRelative: string;
   operationId: string;
   maxBytes?: number;
+  afterDestinationPublished?(): void;
 }
 
 export interface SafeHistoryCopyResult { path: string; hash: string; size: number; reused: boolean }
 
 export interface SafeProviderDiagnostic { type: string; message: string }
+
+function writeReceipt(pathname: string, receipt: ReceiptFile): void {
+  const parent = path.dirname(pathname);
+  const temp = `${pathname}.${process.pid}.${crypto.randomUUID()}.tmp`;
+  let descriptor: number | null = null;
+  try {
+    descriptor = fs.openSync(temp, "wx", 0o600);
+    fs.writeFileSync(descriptor, JSON.stringify(receipt) + "\n", "utf8");
+    fs.fsyncSync(descriptor);
+    fs.closeSync(descriptor);
+    descriptor = null;
+    fs.renameSync(temp, pathname);
+    const directory = fs.openSync(parent, "r");
+    try { fs.fsyncSync(directory); } finally { fs.closeSync(directory); }
+  } finally {
+    if (descriptor !== null) fs.closeSync(descriptor);
+    fs.rmSync(temp, { force: true });
+  }
+}
+
+function removeInterruptedPublishLinks(destination: string): void {
+  const listed = fs.lstatSync(destination);
+  if (listed.nlink === 1) return;
+  const parent = path.dirname(destination);
+  const prefix = `.${path.basename(destination)}.`;
+  const candidates = fs.readdirSync(parent)
+    .filter((entry) => entry.startsWith(prefix) && entry.endsWith(".tmp"))
+    .map((entry) => path.join(parent, entry))
+    .filter((candidate) => {
+      const stat = fs.lstatSync(candidate);
+      return stat.isFile() && !stat.isSymbolicLink() && stat.dev === listed.dev && stat.ino === listed.ino;
+    });
+  if (candidates.length !== listed.nlink - 1) throw new HistorySecurityError("history-collision");
+  for (const candidate of candidates) fs.unlinkSync(candidate);
+  const directory = fs.openSync(parent, "r");
+  try { fs.fsyncSync(directory); } finally { fs.closeSync(directory); }
+  if (fs.lstatSync(destination).nlink !== 1) throw new HistorySecurityError("history-collision");
+}
 
 /** Preserves actionable server detail while keeping routes and registry state generic. */
 export function safeProviderDiagnostic(error: unknown): SafeProviderDiagnostic {
@@ -215,11 +254,16 @@ export function safeCopyHistory(input: SafeHistoryCopyInput): SafeHistoryCopyRes
   const destination = path.join(parent, path.basename(relative));
   const receiptPath = `${destination}.llv-receipt.json`;
   if (fs.existsSync(destination)) {
+    if (!fs.existsSync(receiptPath)) removeInterruptedPublishLinks(destination);
     const receipt = readReceipt(receiptPath);
     const existing = hashFile(destination, maxBytes, undefined, true);
     const original = hashFile(source.sourcePath, maxBytes, source);
     if (receipt?.operationId === input.operationId && receipt.hash === existing.hash && receipt.size === existing.size
       && original.hash === existing.hash && original.size === existing.size) {
+      return { path: destination, ...existing, reused: true };
+    }
+    if (!fs.existsSync(receiptPath) && original.hash === existing.hash && original.size === existing.size) {
+      writeReceipt(receiptPath, { operationId: input.operationId, hash: existing.hash, size: existing.size });
       return { path: destination, ...existing, reused: true };
     }
     throw new HistorySecurityError("history-collision");
@@ -260,12 +304,11 @@ export function safeCopyHistory(input: SafeHistoryCopyInput): SafeHistoryCopyRes
       throw error;
     }
     fs.rmSync(temp, { force: true });
+    const publishedDirectory = fs.openSync(parent, "r");
+    try { fs.fsyncSync(publishedDirectory); } finally { fs.closeSync(publishedDirectory); }
+    input.afterDestinationPublished?.();
     const hash = digest.digest("hex");
-    const receiptTemp = `${receiptPath}.${process.pid}.${crypto.randomUUID()}.tmp`;
-    try {
-      fs.writeFileSync(receiptTemp, JSON.stringify({ operationId: input.operationId, hash, size: total }) + "\n", { mode: 0o600, flag: "wx" });
-      fs.renameSync(receiptTemp, receiptPath);
-    } finally { fs.rmSync(receiptTemp, { force: true }); }
+    writeReceipt(receiptPath, { operationId: input.operationId, hash, size: total });
     const dir = fs.openSync(parent, "r");
     try { fs.fsyncSync(dir); } finally { fs.closeSync(dir); }
     return { path: destination, hash, size: total, reused: false };

--- a/src/lib/agent/registry.test.ts
+++ b/src/lib/agent/registry.test.ts
@@ -76,6 +76,101 @@ describe("agent registry", () => {
     expect(store.canonicalPath("/a.jsonl")).toBe("/a2.jsonl");
   });
 
+  test("provisional migration paths retain one stable conversation owner", () => {
+    const store = registry();
+    const source = store.ensureConversation("codex", "/source.jsonl", "a");
+    store.setConversationMigration(source.id, {
+      intentId: "intent",
+      phase: "successor-starting",
+      targetId: "b",
+      revision: 1,
+      error: null,
+      updatedAt: "2026-07-10T12:00:00.000Z",
+    });
+    store.recordConversationContinuityPath(source.id, "/source-account/fork.jsonl");
+
+    store.reconcileConversations([{
+      engine: "codex",
+      path: "/source-account/fork.jsonl",
+      accountId: "a",
+      launchProfile: emptyLaunchProfile({ cwd: "/repo", project: "repo" }),
+      turn: { state: "idle", source: "empty", terminalAt: null },
+      observedAt: "2026-07-10T12:01:00.000Z",
+    }]);
+
+    expect(Object.values(store.snapshot().conversations)).toHaveLength(1);
+    expect(store.conversationForPath("/source-account/fork.jsonl")?.id).toBe(source.id);
+    expect(store.canonicalPath("/source-account/fork.jsonl")).toBe("/source.jsonl");
+
+    store.setConversationMigration(source.id, {
+      intentId: "later-intent",
+      phase: "requested",
+      targetId: "c",
+      revision: 2,
+      error: null,
+      updatedAt: "2026-07-10T12:02:00.000Z",
+    });
+    expect(store.conversationForPath("/source-account/fork.jsonl")?.id).toBe(source.id);
+  });
+
+  test("migration provenance adopts a path allocated by a concurrent inventory scan", () => {
+    const store = registry();
+    const source = store.ensureConversation("codex", "/source.jsonl", "a");
+    store.setConversationMigration(source.id, {
+      intentId: "intent",
+      phase: "successor-starting",
+      targetId: "b",
+      revision: 1,
+      error: null,
+      updatedAt: "2026-07-10T12:00:00.000Z",
+    });
+    const targetPath = "/target-account/fork.jsonl";
+    store.reconcileConversations([{
+      engine: "codex",
+      path: targetPath,
+      accountId: "b",
+      launchProfile: emptyLaunchProfile({ cwd: "/repo", project: "repo" }),
+      turn: { state: "idle", source: "empty", terminalAt: null },
+      observedAt: "2026-07-10T12:01:00.000Z",
+    }]);
+    expect(Object.values(store.snapshot().conversations)).toHaveLength(2);
+
+    const beforeAdoption = store.snapshot();
+    store.recordConversationContinuityPath(source.id, targetPath);
+
+    const adopted = store.snapshot();
+    expect(Object.values(adopted.conversations)).toHaveLength(1);
+    expect(store.conversationForPath(targetPath)?.id).toBe(source.id);
+    expect(store.canonicalPath(targetPath)).toBe("/source.jsonl");
+    expect(adopted.conversationRevision.codex).toBe(beforeAdoption.conversationRevision.codex + 1);
+    expect(adopted.engineRouting.codex.revision).toBe(beforeAdoption.engineRouting.codex.revision + 1);
+  });
+
+  test("validated provider provenance survives migration retarget and stop", () => {
+    const store = registry();
+    const source = store.ensureConversation("codex", "/source.jsonl", "a");
+    store.setConversationMigration(source.id, {
+      intentId: "intent",
+      phase: "successor-starting",
+      targetId: "b",
+      revision: 1,
+      error: null,
+      updatedAt: "2026-07-10T12:00:00.000Z",
+    });
+    store.setConversationMigration(source.id, {
+      intentId: "replacement",
+      phase: "rolled-back",
+      targetId: "c",
+      revision: 2,
+      error: null,
+      updatedAt: "2026-07-10T12:01:00.000Z",
+    });
+
+    store.recordConversationContinuityPath(source.id, "/late-provider-artifact.jsonl");
+
+    expect(store.conversationForPath("/late-provider-artifact.jsonl")?.id).toBe(source.id);
+  });
+
   test("coalesces durable intents and enforces policy compare-and-set", () => {
     const store = registry();
     const first = store.upsertMigrationIntent("claude", "a", "auto", "first");
@@ -178,6 +273,60 @@ describe("agent registry", () => {
     expect(conflict).toMatchObject({ kind: "conflict", code: "spawn_artifact_conflict" });
     expect(store.snapshot().receipts[first.receipt.launchId]?.artifactPath).toBe(firstPath);
     expect(store.snapshot().receipts[second.receipt.launchId]?.artifactPath).toBe(secondPath);
+  });
+
+  test("keeps a conflicted spawn receipt terminal across later settlement", () => {
+    const store = registry();
+    const begun = store.beginSpawnRequest({ engine: "codex", cwd: "/repo" });
+    if (begun.kind !== "created") throw new Error("expected create");
+    const pathname = "/sessions/019f4906-3f67-7b72-9fbc-9ec3b5ad1326.jsonl";
+    const conflict = store.settleSpawn(begun.receipt.launchId, { ...spawnEntry(pathname), cwd: "/wrong" });
+    const replay = store.settleSpawn(begun.receipt.launchId, spawnEntry(pathname));
+
+    expect(conflict).toMatchObject({ kind: "conflict", code: "spawn_identity_conflict" });
+    expect(replay).toMatchObject({ kind: "conflict", receipt: { state: "conflicted", error: "spawn_identity_conflict" } });
+    expect(store.snapshot().receipts[begun.receipt.launchId]).toMatchObject({ state: "conflicted", error: "spawn_identity_conflict" });
+  });
+
+  test("migration settlement preserves a provisional owner with durable child references", () => {
+    const store = registry();
+    const original = store.ensureConversation("claude", "/source.jsonl", "source");
+    const targetPath = "/target.jsonl";
+    store.reconcileConversations([{
+      engine: "claude",
+      path: targetPath,
+      accountId: "target",
+      launchProfile: emptyLaunchProfile({ cwd: "/repo" }),
+      turn: { state: "idle", source: "empty", terminalAt: null },
+      observedAt: "2026-07-10T12:00:00.000Z",
+    }]);
+    const provisional = store.conversationForPath(targetPath)!;
+    store.beginSpawnRequest({ engine: "claude", cwd: "/repo", parentConversationId: provisional.id });
+    const migration = store.beginSpawnRequest({
+      engine: "claude",
+      cwd: "/repo",
+      conversationId: original.id,
+      purpose: "migration-successor",
+      expectedArtifactPath: targetPath,
+    });
+    if (migration.kind !== "created") throw new Error("expected create");
+
+    const settled = store.settleSpawn(migration.receipt.launchId, {
+      key: { engine: "claude", sessionId: "target" },
+      artifactPath: targetPath,
+      cwd: "/repo",
+      accountId: "target",
+      status: "live",
+      host: null,
+      claimEpoch: 0,
+      claimOwner: null,
+      pendingAction: null,
+    });
+
+    expect(settled).toMatchObject({ kind: "conflict", code: "spawn_artifact_conflict" });
+    expect(store.conversationForPath(targetPath)?.id).toBe(provisional.id);
+    expect(store.conversation(original.id)?.continuityPaths).toEqual([]);
+    expect(Object.values(store.snapshot().conversations)).toHaveLength(2);
   });
 
   test("normalizes a legacy receipt after restart without changing its schema version", () => {

--- a/src/lib/agent/registry.test.ts
+++ b/src/lib/agent/registry.test.ts
@@ -341,6 +341,10 @@ describe("agent registry", () => {
     expect(snapshot.lineageEdges[childReceipt.receipt.conversationId]).toMatchObject({ parentConversationId: original.id });
     expect(snapshot.heldDeliveries[held.id]).toMatchObject({ conversationId: original.id });
     expect(store.conversationForPath("/child.jsonl")?.generations[0]?.launchProfile.parentConversationId).toBe(original.id);
+    expect(snapshot.conversationAliases[provisional.id]).toBe(original.id);
+    expect(store.canonicalConversationId(provisional.id)).toBe(original.id);
+    expect(store.conversation(provisional.id)?.id).toBe(original.id);
+    expect(new AgentRegistry(store.filename).conversation(provisional.id)?.id).toBe(original.id);
   });
 
   test("normalizes a legacy receipt after restart without changing its schema version", () => {

--- a/src/lib/agent/registry.test.ts
+++ b/src/lib/agent/registry.test.ts
@@ -288,7 +288,7 @@ describe("agent registry", () => {
     expect(store.snapshot().receipts[begun.receipt.launchId]).toMatchObject({ state: "conflicted", error: "spawn_identity_conflict" });
   });
 
-  test("migration settlement preserves a provisional owner with durable child references", () => {
+  test("migration settlement atomically reassigns durable provisional references", () => {
     const store = registry();
     const original = store.ensureConversation("claude", "/source.jsonl", "source");
     const targetPath = "/target.jsonl";
@@ -301,7 +301,16 @@ describe("agent registry", () => {
       observedAt: "2026-07-10T12:00:00.000Z",
     }]);
     const provisional = store.conversationForPath(targetPath)!;
-    store.beginSpawnRequest({ engine: "claude", cwd: "/repo", parentConversationId: provisional.id });
+    const childReceipt = store.beginSpawnRequest({ engine: "claude", cwd: "/repo", parentConversationId: provisional.id });
+    const held = store.holdDelivery(provisional.id, "deliver after migration");
+    store.reconcileConversations([{
+      engine: "claude",
+      path: "/child.jsonl",
+      accountId: "target",
+      launchProfile: emptyLaunchProfile({ cwd: "/repo", parentConversationId: provisional.id }),
+      turn: { state: "idle", source: "empty", terminalAt: null },
+      observedAt: "2026-07-10T12:00:01.000Z",
+    }]);
     const migration = store.beginSpawnRequest({
       engine: "claude",
       cwd: "/repo",
@@ -323,10 +332,15 @@ describe("agent registry", () => {
       pendingAction: null,
     });
 
-    expect(settled).toMatchObject({ kind: "conflict", code: "spawn_artifact_conflict" });
-    expect(store.conversationForPath(targetPath)?.id).toBe(provisional.id);
-    expect(store.conversation(original.id)?.continuityPaths).toEqual([]);
+    expect(settled).toMatchObject({ kind: "settled", conversation: { id: original.id } });
+    expect(store.conversationForPath(targetPath)?.id).toBe(original.id);
+    expect(store.conversation(original.id)?.continuityPaths).toEqual([targetPath]);
     expect(Object.values(store.snapshot().conversations)).toHaveLength(2);
+    const snapshot = store.snapshot();
+    expect(snapshot.receipts[childReceipt.receipt.launchId]).toMatchObject({ parentConversationId: original.id });
+    expect(snapshot.lineageEdges[childReceipt.receipt.conversationId]).toMatchObject({ parentConversationId: original.id });
+    expect(snapshot.heldDeliveries[held.id]).toMatchObject({ conversationId: original.id });
+    expect(store.conversationForPath("/child.jsonl")?.generations[0]?.launchProfile.parentConversationId).toBe(original.id);
   });
 
   test("normalizes a legacy receipt after restart without changing its schema version", () => {

--- a/src/lib/agent/registry.ts
+++ b/src/lib/agent/registry.ts
@@ -666,6 +666,17 @@ export class AgentRegistry {
     });
   }
 
+  preserveSpawnArtifactOwnership(launchId: string, error: string): void {
+    this.mutate((file) => {
+      const receipt = file.receipts[launchId];
+      if (!receipt || receipt.state === "completed" || receipt.state === "failed") return;
+      receipt.state = "path-pending";
+      receipt.error = error;
+      receipt.verifiedHost = null;
+      receipt.target = null;
+    });
+  }
+
   private settleSpawnInFile(file: RegistryFile, launchId: string, entry: Omit<AgentRegistryEntry, "updatedAt">, completionMode: NonNullable<SpawnReceipt["completionMode"]>): SpawnSettlement {
     const receipt = file.receipts[launchId];
     if (!receipt) throw new Error("unknown spawn receipt");

--- a/src/lib/agent/registry.ts
+++ b/src/lib/agent/registry.ts
@@ -166,6 +166,7 @@ export interface RegistryFile {
   autoBalance: Record<Extract<AgentEngine, "claude" | "codex">, AutoBalancePolicy>;
   quotaObservations: Record<Extract<AgentEngine, "claude" | "codex">, Record<string, DurableQuotaObservation>>;
   heldDeliveries: Record<string, HeldDelivery>;
+  pendingSuccessorCleanups: Record<string, { conversationId: ViewerConversationId; receipt: ProviderReceipt; createdAt: string; lastError: string | null }>;
 }
 
 type ConversationMigrationInput = Omit<ConversationMigration, "errorCode" | "operationId" | "sourceGenerationId" | "providerReceipt" | "boardProject" | "boardOperationId" | "boardPlacementProject"> &
@@ -218,6 +219,7 @@ const EMPTY: RegistryFile = {
   autoBalance: { claude: emptyPolicy(), codex: emptyPolicy() },
   quotaObservations: { claude: {}, codex: {} },
   heldDeliveries: {},
+  pendingSuccessorCleanups: {},
 };
 
 export class RegistryReadError extends Error {}
@@ -466,6 +468,9 @@ function readFile(filename: string): RegistryFile {
         : clone(EMPTY.quotaObservations),
       heldDeliveries: parsed.heldDeliveries && typeof parsed.heldDeliveries === "object"
         ? Object.fromEntries(Object.entries(parsed.heldDeliveries).map(([id, delivery]) => [id, normalizeHeldDelivery(delivery)]))
+        : {},
+      pendingSuccessorCleanups: parsed.pendingSuccessorCleanups && typeof parsed.pendingSuccessorCleanups === "object"
+        ? parsed.pendingSuccessorCleanups
         : {},
     };
   } catch (error) {
@@ -1336,7 +1341,7 @@ export class AgentRegistry {
         phase: conversation.turn.state === "busy" || conversation.turn.state === "unknown" ? "waiting-turn" : "requested",
         targetId: intent.targetId,
         revision: intent.revision,
-        operationId: crypto.randomUUID(),
+        operationId: current.errorCode === "codex-fork-outcome-unknown" ? current.operationId : crypto.randomUUID(),
         sourceGenerationId: source.id,
         providerReceipt: null,
         boardProject: current.boardProject,
@@ -1527,6 +1532,26 @@ export class AgentRegistry {
     return Object.values(snapshot.heldDeliveries)
       .filter((item) => item.conversationId === canonicalId && item.state !== "delivered")
       .sort((left, right) => left.createdAt.localeCompare(right.createdAt) || left.id.localeCompare(right.id));
+  }
+
+  queueSuccessorCleanup(conversationId: ViewerConversationId, receipt: ProviderReceipt): void {
+    this.mutate((file) => {
+      const existing = file.pendingSuccessorCleanups[receipt.operationId];
+      file.pendingSuccessorCleanups[receipt.operationId] = existing ?? {
+        conversationId: resolveConversationAlias(file, conversationId), receipt, createdAt: now(), lastError: null,
+      };
+    });
+  }
+
+  recordSuccessorCleanupFailure(operationId: string, error: string): void {
+    this.mutate((file) => {
+      const pending = file.pendingSuccessorCleanups[operationId];
+      if (pending) pending.lastError = error.slice(0, 240);
+    });
+  }
+
+  completeSuccessorCleanup(operationId: string): void {
+    this.mutate((file) => { delete file.pendingSuccessorCleanups[operationId]; });
   }
 
   beginDeliveryAttempt(id: string, generationId: string): HeldDelivery | null {

--- a/src/lib/agent/registry.ts
+++ b/src/lib/agent/registry.ts
@@ -157,6 +157,9 @@ export interface RegistryFile {
       resolver proves server, process, engine, and transcript ownership. */
   legacyResumePanes: { serverPid: number | null; panes: Record<string, ResumePaneRecord> };
   conversations: Record<string, RegistryConversation>;
+  /** Durable redirects for conversation IDs that escaped before scanner-owned
+      provisional identities were adopted by their canonical owner. */
+  conversationAliases: Record<string, ViewerConversationId>;
   conversationRevision: Record<Extract<AgentEngine, "claude" | "codex">, number>;
   migrationIntents: Record<string, MigrationIntent>;
   engineRouting: Record<Extract<AgentEngine, "claude" | "codex">, { activeAccountId: string | null; revision: number }>;
@@ -208,6 +211,7 @@ const EMPTY: RegistryFile = {
   importedResumePanes: false,
   legacyResumePanes: { serverPid: null, panes: {} },
   conversations: {},
+  conversationAliases: {},
   conversationRevision: { claude: 0, codex: 0 },
   migrationIntents: {},
   engineRouting: { claude: { activeAccountId: null, revision: 0 }, codex: { activeAccountId: null, revision: 0 } },
@@ -319,6 +323,18 @@ function scannerAllocatedProvisionalOwner(conversation: RegistryConversation, pa
     && conversation.continuityPaths.length === 0;
 }
 
+function resolveConversationAlias(file: Pick<RegistryFile, "conversationAliases">, id: ViewerConversationId): ViewerConversationId {
+  const seen = new Set<ViewerConversationId>();
+  let current = id;
+  while (!seen.has(current)) {
+    seen.add(current);
+    const next = file.conversationAliases[current];
+    if (!next) return current;
+    current = next;
+  }
+  return current;
+}
+
 function adoptProvisionalOwner(
   file: RegistryFile,
   owner: RegistryConversation,
@@ -359,6 +375,10 @@ function adoptProvisionalOwner(
       }
     }
   }
+  for (const [alias, destination] of Object.entries(file.conversationAliases)) {
+    if (destination === owner.id) file.conversationAliases[alias] = target.id;
+  }
+  file.conversationAliases[owner.id] = target.id;
   delete file.conversations[owner.id];
   file.conversationRevision[target.engine] += 1;
   file.engineRouting[target.engine].revision += 1;
@@ -400,6 +420,7 @@ function upgradeV1(parsed: Omit<Partial<RegistryFile>, "version">): RegistryFile
     ...clone(EMPTY),
     entries: (parsed.entries as RegistryFile["entries"]) ?? {},
     receipts: Object.fromEntries(Object.entries((parsed.receipts as RegistryFile["receipts"]) ?? {}).map(([id, receipt]) => [id, normalizeReceipt(receipt)])),
+    conversationAliases: {},
     importedResumePanes: parsed.importedResumePanes === true,
     legacyResumePanes: legacy && typeof legacy === "object" && "panes" in legacy
       ? { serverPid: typeof (legacy as { serverPid?: unknown }).serverPid === "number" ? (legacy as { serverPid: number }).serverPid : null, panes: ((legacy as { panes?: unknown }).panes as Record<string, ResumePaneRecord>) ?? {} }
@@ -428,6 +449,9 @@ function readFile(filename: string): RegistryFile {
         : { serverPid: null, panes: {} },
       conversations: parsed.conversations && typeof parsed.conversations === "object"
         ? Object.fromEntries(Object.entries(parsed.conversations).map(([id, conversation]) => [id, normalizeConversation(conversation)]))
+        : {},
+      conversationAliases: parsed.conversationAliases && typeof parsed.conversationAliases === "object"
+        ? Object.fromEntries(Object.entries(parsed.conversationAliases).filter(([alias, destination]) => alias.startsWith("conversation_") && typeof destination === "string" && destination.startsWith("conversation_"))) as RegistryFile["conversationAliases"]
         : {},
       conversationRevision: parsed.conversationRevision && typeof parsed.conversationRevision === "object"
         ? { ...EMPTY.conversationRevision, ...parsed.conversationRevision }
@@ -526,8 +550,10 @@ export class AgentRegistry {
       internal callers use beginSpawn() and receive an uncorrelated receipt. */
   beginSpawnRequest(input: SpawnRequest): SpawnBeginResult {
     return this.mutate((file) => {
-      const profile = emptyLaunchProfile({ cwd: input.cwd, parentConversationId: input.parentConversationId ?? null, ...(input.launchProfile ?? {}) });
-      const existingConversation = input.conversationId ? file.conversations[input.conversationId] : null;
+      const conversationId = input.conversationId ? resolveConversationAlias(file, input.conversationId) : null;
+      const parentConversationId = input.parentConversationId ? resolveConversationAlias(file, input.parentConversationId) : null;
+      const profile = emptyLaunchProfile({ cwd: input.cwd, ...(input.launchProfile ?? {}), parentConversationId });
+      const existingConversation = conversationId ? file.conversations[conversationId] : null;
       if (existingConversation && existingConversation.engine !== input.engine) {
         throw new Error("spawn conversation ownership is invalid");
       }
@@ -542,12 +568,12 @@ export class AgentRegistry {
         launchId: crypto.randomUUID(),
         clientAttemptId: input.clientAttemptId ?? null,
         requestDigest: input.requestDigest ?? null,
-        conversationId: input.conversationId ?? `conversation_${crypto.randomUUID()}`,
+        conversationId: conversationId ?? `conversation_${crypto.randomUUID()}`,
         purpose: input.purpose ?? "launch",
         engine: input.engine,
         cwd: input.cwd,
         accountId: input.accountId ?? null,
-        parentConversationId: input.parentConversationId ?? null,
+        parentConversationId,
         createdAt: now(),
         state: "starting",
         artifactPath: input.expectedArtifactPath ?? null,
@@ -1001,8 +1027,13 @@ export class AgentRegistry {
     return Object.values(this.snapshot().conversations).find((conversation) => conversationOwnsPath(conversation, artifactPath)) ?? null;
   }
 
+  canonicalConversationId(id: ViewerConversationId): ViewerConversationId {
+    return resolveConversationAlias(this.snapshot(), id);
+  }
+
   conversation(id: ViewerConversationId): RegistryConversation | null {
-    return this.snapshot().conversations[id] ?? null;
+    const snapshot = this.snapshot();
+    return snapshot.conversations[resolveConversationAlias(snapshot, id)] ?? null;
   }
 
   launchProfileForPath(artifactPath: string): LaunchProfile | null {
@@ -1162,13 +1193,14 @@ export class AgentRegistry {
 
   setConversationMigration(id: ViewerConversationId, migration: ConversationMigrationInput | null): RegistryConversation {
     return this.mutate((file) => {
-      const conversation = file.conversations[id];
+      const canonicalId = resolveConversationAlias(file, id);
+      const conversation = file.conversations[canonicalId];
       if (!conversation) throw new Error("viewer conversation is unknown");
       const source = conversation.generations.at(-1);
       conversation.migration = migration ? {
         ...migration,
         errorCode: migration.errorCode ?? null,
-        operationId: migration.operationId ?? `${migration.intentId}:${id}:${migration.revision}`,
+        operationId: migration.operationId ?? `${migration.intentId}:${canonicalId}:${migration.revision}`,
         sourceGenerationId: migration.sourceGenerationId ?? source?.id ?? "",
         providerReceipt: migration.providerReceipt ?? null,
         boardProject: migration.boardProject ?? null,
@@ -1187,7 +1219,7 @@ export class AgentRegistry {
     patch: Partial<Pick<ConversationMigration, "phase" | "error" | "errorCode" | "providerReceipt" | "targetId" | "revision">>,
   ): RegistryConversation {
     return this.mutate((file) => {
-      const conversation = file.conversations[id];
+      const conversation = file.conversations[resolveConversationAlias(file, id)];
       const migration = conversation?.migration;
       if (!conversation || !migration) throw new Error("conversation has no migration");
       if (migration.revision !== expectedRevision || !expectedPhases.includes(migration.phase)) throw new Error("migration transition is stale");
@@ -1204,7 +1236,7 @@ export class AgentRegistry {
     receipt: ProviderReceipt,
   ): RegistryConversation {
     return this.mutate((file) => {
-      const conversation = file.conversations[id];
+      const conversation = file.conversations[resolveConversationAlias(file, id)];
       const migration = conversation?.migration;
       if (!conversation || !migration) throw new Error("conversation has no migration");
       if (migration.revision !== expectedRevision || migration.operationId !== operationId) {
@@ -1226,10 +1258,11 @@ export class AgentRegistry {
 
   recordConversationContinuityPath(id: ViewerConversationId, pathname: string): RegistryConversation {
     return this.mutate((file) => {
-      const conversation = file.conversations[id];
+      const canonicalId = resolveConversationAlias(file, id);
+      const conversation = file.conversations[canonicalId];
       if (!conversation) throw new Error("viewer conversation is unknown");
       const provisionalOwner = Object.values(file.conversations).find((candidate) =>
-        candidate.id !== id && candidate.engine === conversation.engine && conversationOwnsPath(candidate, pathname));
+        candidate.id !== canonicalId && candidate.engine === conversation.engine && conversationOwnsPath(candidate, pathname));
       if (provisionalOwner) {
         if (!adoptProvisionalOwner(file, provisionalOwner, conversation, pathname)) {
           throw new Error("migration continuity path has another durable owner");
@@ -1246,7 +1279,7 @@ export class AgentRegistry {
     this.mutate((file) => {
       const updatedAt = now();
       for (const update of updates) {
-        const conversation = file.conversations[update.id];
+        const conversation = file.conversations[resolveConversationAlias(file, update.id)];
         const migration = conversation?.migration;
         if (!conversation || !migration || migration.phase !== "committed" || migration.operationId !== update.operationId) continue;
         migration.boardProject = update.project;
@@ -1263,7 +1296,7 @@ export class AgentRegistry {
     this.mutate((file) => {
       const updatedAt = now();
       for (const update of updates) {
-        const conversation = file.conversations[update.id];
+        const conversation = file.conversations[resolveConversationAlias(file, update.id)];
         const migration = conversation?.migration;
         if (!conversation || !migration || migration.phase !== "committed" || migration.operationId !== update.operationId) continue;
         migration.boardPlacementProject = update.project;
@@ -1275,7 +1308,7 @@ export class AgentRegistry {
 
   retryConversationMigration(id: ViewerConversationId, expectedRevision?: number): RegistryConversation {
     return this.mutate((file) => {
-      const conversation = file.conversations[id];
+      const conversation = file.conversations[resolveConversationAlias(file, id)];
       const current = conversation?.migration;
       if (!conversation || !current) throw new Error("conversation has no migration");
       if (expectedRevision !== undefined && current.revision !== expectedRevision) throw new Error("migration revision is stale");
@@ -1309,7 +1342,7 @@ export class AgentRegistry {
 
   commitSuccessor(id: ViewerConversationId, successor: SuccessorGenerationInput, expectedRevision: number): RegistryConversation {
     return this.mutate((file) => {
-      const conversation = file.conversations[id];
+      const conversation = file.conversations[resolveConversationAlias(file, id)];
       if (!conversation?.migration || conversation.migration.revision !== expectedRevision) throw new Error("migration revision is stale");
       if (conversation.migration.phase === "committed") {
         const current = conversation.generations.at(-1);
@@ -1454,11 +1487,12 @@ export class AgentRegistry {
   holdDelivery(conversationId: ViewerConversationId, text: string, clientMessageId: string | null = null): HeldDelivery {
     if (!text || text.length > 32_000) throw new Error("held delivery must contain at most 32000 characters");
     return this.mutate((file) => {
-      const existing = clientMessageId ? Object.values(file.heldDeliveries).find((item) => item.conversationId === conversationId && item.clientMessageId === clientMessageId) : undefined;
+      const canonicalId = resolveConversationAlias(file, conversationId);
+      const existing = clientMessageId ? Object.values(file.heldDeliveries).find((item) => item.conversationId === canonicalId && item.clientMessageId === clientMessageId) : undefined;
       if (existing) return clone(existing);
       const held: HeldDelivery = {
         id: crypto.randomUUID(),
-        conversationId,
+        conversationId: canonicalId,
         text,
         createdAt: now(),
         clientMessageId,
@@ -1469,7 +1503,7 @@ export class AgentRegistry {
         deliveredAt: null,
         error: null,
       };
-      const count = Object.values(file.heldDeliveries).filter((item) => item.conversationId === conversationId && item.state !== "delivered").length;
+      const count = Object.values(file.heldDeliveries).filter((item) => item.conversationId === canonicalId && item.state !== "delivered").length;
       if (count >= 100) throw new Error("held delivery limit reached for conversation");
       file.heldDeliveries[held.id] = held;
       return clone(held);
@@ -1477,8 +1511,10 @@ export class AgentRegistry {
   }
 
   pendingDeliveries(conversationId: ViewerConversationId): HeldDelivery[] {
-    return Object.values(this.snapshot().heldDeliveries)
-      .filter((item) => item.conversationId === conversationId && item.state !== "delivered")
+    const snapshot = this.snapshot();
+    const canonicalId = resolveConversationAlias(snapshot, conversationId);
+    return Object.values(snapshot.heldDeliveries)
+      .filter((item) => item.conversationId === canonicalId && item.state !== "delivered")
       .sort((left, right) => left.createdAt.localeCompare(right.createdAt) || left.id.localeCompare(right.id));
   }
 
@@ -1511,7 +1547,8 @@ export class AgentRegistry {
 
   rollbackConversationMigration(id: ViewerConversationId, expectedRevision?: number): RegistryConversation {
     return this.mutate((file) => {
-      const conversation = file.conversations[id];
+      const canonicalId = resolveConversationAlias(file, id);
+      const conversation = file.conversations[canonicalId];
       if (!conversation?.migration) throw new Error("conversation has no migration");
       if (expectedRevision !== undefined && conversation.migration.revision !== expectedRevision) throw new Error("migration revision is stale");
       const source = conversation.generations.find((generation) => generation.id === conversation.migration?.sourceGenerationId)
@@ -1519,7 +1556,7 @@ export class AgentRegistry {
       if (!source) throw new Error("conversation has no source generation");
       const rolledAt = now();
       for (const delivery of Object.values(file.heldDeliveries)) {
-        if (delivery.conversationId !== id || delivery.state === "delivered" || delivery.state === "delivery-uncertain") continue;
+        if (delivery.conversationId !== canonicalId || delivery.state === "delivered" || delivery.state === "delivery-uncertain") continue;
         delivery.state = "assigned";
         delivery.generationId = source.id;
         delivery.assignedAt = rolledAt;

--- a/src/lib/agent/registry.ts
+++ b/src/lib/agent/registry.ts
@@ -319,21 +319,46 @@ function scannerAllocatedProvisionalOwner(conversation: RegistryConversation, pa
     && conversation.continuityPaths.length === 0;
 }
 
-function conversationHasDurableReferences(file: RegistryFile, id: ViewerConversationId): boolean {
-  return Object.values(file.receipts).some((receipt) => receipt.conversationId === id || receipt.parentConversationId === id)
-    || Object.values(file.lineageEdges).some((edge) => edge.childConversationId === id || edge.parentConversationId === id)
-    || Object.values(file.heldDeliveries).some((delivery) => delivery.conversationId === id)
-    || Object.values(file.conversations).some((conversation) => conversation.id !== id
-      && conversation.generations.some((generation) => generation.launchProfile.parentConversationId === id));
-}
-
 function adoptProvisionalOwner(
   file: RegistryFile,
   owner: RegistryConversation,
   target: RegistryConversation,
   pathname: string,
 ): boolean {
-  if (!scannerAllocatedProvisionalOwner(owner, pathname) || conversationHasDurableReferences(file, owner.id)) return false;
+  if (!scannerAllocatedProvisionalOwner(owner, pathname)) return false;
+  for (const receipt of Object.values(file.receipts)) {
+    if (receipt.conversationId === owner.id) receipt.conversationId = target.id;
+    if (receipt.parentConversationId === owner.id) receipt.parentConversationId = target.id;
+    if (receipt.launchProfile.parentConversationId === owner.id) {
+      receipt.launchProfile = { ...receipt.launchProfile, parentConversationId: target.id };
+    }
+  }
+  const reassignedEdges: RegistryFile["lineageEdges"] = {};
+  for (const edge of Object.values(file.lineageEdges)) {
+    const reassigned = {
+      ...edge,
+      childConversationId: edge.childConversationId === owner.id ? target.id : edge.childConversationId,
+      parentConversationId: edge.parentConversationId === owner.id ? target.id : edge.parentConversationId,
+    };
+    const existing = reassignedEdges[reassigned.childConversationId];
+    if (!existing || edge.childConversationId === target.id) reassignedEdges[reassigned.childConversationId] = reassigned;
+  }
+  file.lineageEdges = reassignedEdges;
+  for (const delivery of Object.values(file.heldDeliveries)) {
+    if (delivery.conversationId === owner.id) delivery.conversationId = target.id;
+  }
+  for (const entry of Object.values(file.entries)) {
+    if (entry.launchProfile?.parentConversationId === owner.id) {
+      entry.launchProfile = { ...entry.launchProfile, parentConversationId: target.id };
+    }
+  }
+  for (const conversation of Object.values(file.conversations)) {
+    for (const generation of conversation.generations) {
+      if (generation.launchProfile.parentConversationId === owner.id) {
+        generation.launchProfile = { ...generation.launchProfile, parentConversationId: target.id };
+      }
+    }
+  }
   delete file.conversations[owner.id];
   file.conversationRevision[target.engine] += 1;
   file.engineRouting[target.engine].revision += 1;

--- a/src/lib/agent/registry.ts
+++ b/src/lib/agent/registry.ts
@@ -14,6 +14,8 @@ import {
   type MigrationIntent,
   type MigrationOrigin,
   type NativeGeneration,
+  type ProviderReceipt,
+  sameProviderReceiptOutcome,
   type TurnState,
   type ViewerConversationId,
 } from "@/lib/accounts/migration/contracts";
@@ -76,6 +78,7 @@ export interface SpawnReceipt {
   requestDigest: string | null;
   /** Reserved at receipt birth so path discovery cannot choose the identity. */
   conversationId: ViewerConversationId;
+  purpose: "launch" | "migration-successor";
   engine: AgentEngine;
   cwd: string;
   accountId: string | null;
@@ -117,6 +120,9 @@ export interface SpawnRequest {
   parentConversationId?: ViewerConversationId | null;
   parentSessionKey?: SessionKey | null;
   parentArtifactPath?: string | null;
+  conversationId?: ViewerConversationId;
+  purpose?: SpawnReceipt["purpose"];
+  expectedArtifactPath?: string | null;
 }
 
 export type SpawnBeginResult =
@@ -132,6 +138,9 @@ export interface RegistryConversation {
   id: ViewerConversationId;
   engine: Extract<AgentEngine, "claude" | "codex">;
   generations: NativeGeneration[];
+  /** Provider-created transcript artifacts that retain this conversation's
+      identity while the canonical generation path advances. */
+  continuityPaths: string[];
   migration: ConversationMigration | null;
   turn: TurnState & { observedAt: string | null };
   createdAt: string;
@@ -156,8 +165,8 @@ export interface RegistryFile {
   heldDeliveries: Record<string, HeldDelivery>;
 }
 
-type ConversationMigrationInput = Omit<ConversationMigration, "errorCode" | "operationId" | "sourceGenerationId" | "providerReceipt"> &
-  Partial<Pick<ConversationMigration, "errorCode" | "operationId" | "sourceGenerationId" | "providerReceipt">>;
+type ConversationMigrationInput = Omit<ConversationMigration, "errorCode" | "operationId" | "sourceGenerationId" | "providerReceipt" | "boardProject" | "boardOperationId" | "boardPlacementProject"> &
+  Partial<Pick<ConversationMigration, "errorCode" | "operationId" | "sourceGenerationId" | "providerReceipt" | "boardProject" | "boardOperationId" | "boardPlacementProject">>;
 type SuccessorGenerationInput = Omit<NativeGeneration, "createdAt" | "archivedAt" | "launchProfile" | "historyHash" | "host"> &
   Partial<Pick<NativeGeneration, "launchProfile" | "historyHash" | "host">>;
 
@@ -230,21 +239,41 @@ function normalizeGeneration(value: NativeGeneration): NativeGeneration {
   };
 }
 
+function normalizeProviderReceipt(value: ProviderReceipt | null | undefined): ProviderReceipt | null {
+  if (!value || typeof value !== "object") return null;
+  return {
+    ...value,
+    continuityPaths: Array.isArray(value.continuityPaths)
+      ? value.continuityPaths.filter((pathname): pathname is string => typeof pathname === "string")
+      : [],
+  };
+}
+
 function normalizeConversation(value: RegistryConversation): RegistryConversation {
   const generations = Array.isArray(value.generations) ? value.generations.map(normalizeGeneration) : [];
   const current = generations.at(-1);
+  const legacyContinuity = (value.migration as (ConversationMigration & { continuityPaths?: unknown }) | null)?.continuityPaths;
   const migration = value.migration && typeof value.migration === "object"
     ? {
       ...value.migration,
       errorCode: value.migration.errorCode ?? null,
       operationId: value.migration.operationId ?? `${value.migration.intentId}:${value.id}:${value.migration.revision}`,
       sourceGenerationId: value.migration.sourceGenerationId ?? current?.id ?? "",
-      providerReceipt: value.migration.providerReceipt ?? null,
+      providerReceipt: normalizeProviderReceipt(value.migration.providerReceipt),
+      boardProject: typeof value.migration.boardProject === "string" ? value.migration.boardProject : null,
+      boardOperationId: typeof value.migration.boardOperationId === "string" ? value.migration.boardOperationId : null,
+      boardPlacementProject: typeof value.migration.boardPlacementProject === "string" ? value.migration.boardPlacementProject : null,
     }
     : null;
+  const continuityPaths = [...new Set([
+    ...(Array.isArray(value.continuityPaths) ? value.continuityPaths.filter((pathname): pathname is string => typeof pathname === "string") : []),
+    ...(Array.isArray(legacyContinuity) ? legacyContinuity.filter((pathname): pathname is string => typeof pathname === "string") : []),
+    ...(migration?.providerReceipt?.continuityPaths ?? []),
+  ])];
   return {
     ...value,
     generations,
+    continuityPaths,
     migration,
     turn: value.turn && typeof value.turn === "object"
       ? { state: value.turn.state, source: value.turn.source, terminalAt: value.turn.terminalAt ?? null, observedAt: value.turn.observedAt ?? null }
@@ -277,6 +306,40 @@ function normalizeHeldDelivery(value: HeldDelivery): HeldDelivery {
   };
 }
 
+function conversationOwnsPath(conversation: RegistryConversation, artifactPath: string): boolean {
+  return conversation.generations.some((generation) => generation.path === artifactPath)
+    || conversation.continuityPaths.includes(artifactPath);
+}
+
+function scannerAllocatedProvisionalOwner(conversation: RegistryConversation, pathname: string): boolean {
+  const generation = conversation.generations[0];
+  return conversation.migration === null
+    && conversation.generations.length === 1
+    && generation?.path === pathname
+    && conversation.continuityPaths.length === 0;
+}
+
+function conversationHasDurableReferences(file: RegistryFile, id: ViewerConversationId): boolean {
+  return Object.values(file.receipts).some((receipt) => receipt.conversationId === id || receipt.parentConversationId === id)
+    || Object.values(file.lineageEdges).some((edge) => edge.childConversationId === id || edge.parentConversationId === id)
+    || Object.values(file.heldDeliveries).some((delivery) => delivery.conversationId === id)
+    || Object.values(file.conversations).some((conversation) => conversation.id !== id
+      && conversation.generations.some((generation) => generation.launchProfile.parentConversationId === id));
+}
+
+function adoptProvisionalOwner(
+  file: RegistryFile,
+  owner: RegistryConversation,
+  target: RegistryConversation,
+  pathname: string,
+): boolean {
+  if (!scannerAllocatedProvisionalOwner(owner, pathname) || conversationHasDurableReferences(file, owner.id)) return false;
+  delete file.conversations[owner.id];
+  file.conversationRevision[target.engine] += 1;
+  file.engineRouting[target.engine].revision += 1;
+  return true;
+}
+
 function normalizeReceipt(value: SpawnReceipt): SpawnReceipt {
   const state = value.state === "completed" || value.state === "failed" || value.state === "pane-bound" || value.state === "host-verified" || value.state === "prompt-delivered" || value.state === "path-pending" || value.state === "conflicted"
     ? value.state
@@ -291,6 +354,7 @@ function normalizeReceipt(value: SpawnReceipt): SpawnReceipt {
     conversationId: typeof value.conversationId === "string" && value.conversationId.startsWith("conversation_")
       ? value.conversationId as ViewerConversationId
       : `conversation_${crypto.randomUUID()}`,
+    purpose: value.purpose === "migration-successor" ? "migration-successor" : "launch",
     accountId: typeof value.accountId === "string" ? value.accountId : null,
     parentConversationId: typeof value.parentConversationId === "string" && value.parentConversationId.startsWith("conversation_")
       ? value.parentConversationId as ViewerConversationId
@@ -438,6 +502,10 @@ export class AgentRegistry {
   beginSpawnRequest(input: SpawnRequest): SpawnBeginResult {
     return this.mutate((file) => {
       const profile = emptyLaunchProfile({ cwd: input.cwd, parentConversationId: input.parentConversationId ?? null, ...(input.launchProfile ?? {}) });
+      const existingConversation = input.conversationId ? file.conversations[input.conversationId] : null;
+      if (existingConversation && existingConversation.engine !== input.engine) {
+        throw new Error("spawn conversation ownership is invalid");
+      }
       if (input.clientAttemptId) {
         const existing = Object.values(file.receipts).find((receipt) => receipt.clientAttemptId === input.clientAttemptId);
         if (existing) {
@@ -449,14 +517,15 @@ export class AgentRegistry {
         launchId: crypto.randomUUID(),
         clientAttemptId: input.clientAttemptId ?? null,
         requestDigest: input.requestDigest ?? null,
-        conversationId: `conversation_${crypto.randomUUID()}`,
+        conversationId: input.conversationId ?? `conversation_${crypto.randomUUID()}`,
+        purpose: input.purpose ?? "launch",
         engine: input.engine,
         cwd: input.cwd,
         accountId: input.accountId ?? null,
         parentConversationId: input.parentConversationId ?? null,
         createdAt: now(),
         state: "starting",
-        artifactPath: null,
+        artifactPath: input.expectedArtifactPath ?? null,
         key: null,
         pane: null,
         verifiedHost: null,
@@ -555,6 +624,15 @@ export class AgentRegistry {
       receipt.error = code;
       return { kind: "conflict", receipt: clone(receipt), code };
     };
+    if (receipt.state === "failed" || receipt.state === "conflicted") {
+      return {
+        kind: "conflict",
+        receipt: clone(receipt),
+        code: receipt.error === "spawn_artifact_conflict" || receipt.error === "spawn_pane_conflict" || receipt.error === "spawn_identity_conflict"
+          ? receipt.error
+          : "spawn_identity_conflict",
+      };
+    }
     if (receipt.engine !== entry.key.engine || receipt.cwd !== entry.cwd) return conflict("spawn_identity_conflict");
     if (receipt.pane && entry.host?.kind === "tmux" && (
       receipt.pane.paneId !== entry.host.paneId ||
@@ -574,13 +652,25 @@ export class AgentRegistry {
       id: receipt.conversationId,
       engine: receipt.engine as Extract<AgentEngine, "claude" | "codex">,
       generations: [],
+      continuityPaths: [],
       migration: null,
       turn: { state: "unknown" as const, source: "empty" as const, terminalAt: null, observedAt: null },
       createdAt,
       updatedAt: createdAt,
     };
     if (conversation.engine !== receipt.engine) return conflict("spawn_identity_conflict");
-    if (!conversation.generations.some((generation) => generation.path === entry.artifactPath)) {
+    if (receipt.purpose === "migration-successor") {
+      const provisionalOwner = Object.values(file.conversations).find((candidate) => candidate.id !== conversation.id
+        && candidate.engine === conversation.engine && conversationOwnsPath(candidate, entry.artifactPath));
+      if (provisionalOwner && !adoptProvisionalOwner(file, provisionalOwner, conversation, entry.artifactPath)) {
+        return conflict("spawn_artifact_conflict");
+      }
+      if (!conversation.continuityPaths.includes(entry.artifactPath)
+        && !conversation.generations.some((generation) => generation.path === entry.artifactPath)) {
+        conversation.continuityPaths.push(entry.artifactPath);
+      }
+    }
+    if (receipt.purpose !== "migration-successor" && !conversation.generations.some((generation) => generation.path === entry.artifactPath)) {
       conversation.generations.push({
         id: nativeGenerationId(entry.artifactPath),
         path: entry.artifactPath,
@@ -610,6 +700,9 @@ export class AgentRegistry {
         operationId: crypto.randomUUID(),
         sourceGenerationId: source.id,
         providerReceipt: null,
+        boardProject: null,
+        boardOperationId: null,
+        boardPlacementProject: source.launchProfile.project,
         updatedAt: createdAt,
       };
     }
@@ -767,7 +860,7 @@ export class AgentRegistry {
       remain an interoperability detail and can change on every account move. */
   ensureConversation(engine: Extract<AgentEngine, "claude" | "codex">, artifactPath: string, accountId: string | null): RegistryConversation {
     return this.mutate((file) => {
-      const existing = Object.values(file.conversations).find((conversation) => conversation.engine === engine && conversation.generations.some((generation) => generation.path === artifactPath));
+      const existing = Object.values(file.conversations).find((conversation) => conversation.engine === engine && conversationOwnsPath(conversation, artifactPath));
       if (existing) return clone(existing);
       const createdAt = now();
       const conversation: RegistryConversation = {
@@ -783,6 +876,7 @@ export class AgentRegistry {
           createdAt,
           archivedAt: null,
         }],
+        continuityPaths: [],
         migration: null,
         turn: { state: "unknown", source: "empty", terminalAt: null, observedAt: null },
         createdAt,
@@ -802,7 +896,21 @@ export class AgentRegistry {
       const scopeChanged = new Set<Extract<AgentEngine, "claude" | "codex">>();
       for (const observation of observations) {
         let conversation = Object.values(file.conversations).find((candidate) =>
-          candidate.engine === observation.engine && candidate.generations.some((generation) => generation.path === observation.path));
+          candidate.engine === observation.engine && conversationOwnsPath(candidate, observation.path));
+        if (!conversation) {
+          const migrationReceipt = Object.values(file.receipts).find((receipt) => receipt.engine === observation.engine
+            && receipt.purpose === "migration-successor"
+            && receipt.artifactPath === observation.path
+            && receipt.state !== "failed"
+            && receipt.state !== "conflicted");
+          const migrationOwner = migrationReceipt ? file.conversations[migrationReceipt.conversationId] : null;
+          if (migrationOwner) {
+            conversation = migrationOwner;
+            if (!conversation.continuityPaths.includes(observation.path)) conversation.continuityPaths.push(observation.path);
+            conversation.updatedAt = observation.observedAt;
+            scopeChanged.add(observation.engine);
+          }
+        }
         if (!conversation) {
           const createdAt = observation.observedAt;
           conversation = {
@@ -818,6 +926,7 @@ export class AgentRegistry {
               createdAt,
               archivedAt: null,
             }],
+            continuityPaths: [],
             migration: null,
             turn: { ...observation.turn, observedAt: observation.observedAt },
             createdAt,
@@ -843,7 +952,7 @@ export class AgentRegistry {
           permissionMode: generation.launchProfile.permissionMode ?? observation.launchProfile.permissionMode,
           readOnly: generation.launchProfile.readOnly ?? observation.launchProfile.readOnly,
           title: generation.launchProfile.title ?? observation.launchProfile.title,
-          project: generation.launchProfile.project ?? observation.launchProfile.project,
+          project: observation.launchProfile.project ?? generation.launchProfile.project,
           parentConversationId: generation.launchProfile.parentConversationId ?? observation.launchProfile.parentConversationId,
           role: generation.launchProfile.role === "root" || observation.launchProfile.role === "root" ? "root" : "worker",
           goal: observation.launchProfile.goal ?? generation.launchProfile.goal,
@@ -864,7 +973,7 @@ export class AgentRegistry {
   }
 
   conversationForPath(artifactPath: string): RegistryConversation | null {
-    return Object.values(this.snapshot().conversations).find((conversation) => conversation.generations.some((generation) => generation.path === artifactPath)) ?? null;
+    return Object.values(this.snapshot().conversations).find((conversation) => conversationOwnsPath(conversation, artifactPath)) ?? null;
   }
 
   conversation(id: ViewerConversationId): RegistryConversation | null {
@@ -873,8 +982,14 @@ export class AgentRegistry {
 
   launchProfileForPath(artifactPath: string): LaunchProfile | null {
     const snapshot = this.snapshot();
-    const generation = Object.values(snapshot.conversations).flatMap((conversation) => conversation.generations).find((item) => item.path === artifactPath);
-    if (generation) return clone(generation.launchProfile);
+    for (const conversation of Object.values(snapshot.conversations)) {
+      const generation = conversation.generations.find((item) => item.path === artifactPath);
+      if (generation) return clone(generation.launchProfile);
+      if (conversation.continuityPaths.includes(artifactPath)) {
+        const current = conversation.generations.at(-1);
+        if (current) return clone(current.launchProfile);
+      }
+    }
     const receipt = Object.values(snapshot.receipts).find((item) => item.artifactPath === artifactPath);
     return receipt ? clone(receipt.launchProfile) : null;
   }
@@ -977,6 +1092,10 @@ export class AgentRegistry {
           continue;
         }
         scoped += 1;
+        const boardProject = conversation.migration?.boardProject ?? null;
+        const boardPlacementProject = conversation.migration?.boardPlacementProject
+          ?? boardProject
+          ?? source.launchProfile.project;
         conversation.migration = {
           intentId: intent.id,
           phase: conversation.turn.state === "busy" || conversation.turn.state === "unknown" ? "waiting-turn" : "requested",
@@ -987,6 +1106,9 @@ export class AgentRegistry {
           operationId: crypto.randomUUID(),
           sourceGenerationId: source.id,
           providerReceipt: null,
+          boardProject,
+          boardOperationId: conversation.migration?.boardOperationId ?? null,
+          boardPlacementProject,
           updatedAt: changedAt,
         };
         conversation.updatedAt = changedAt;
@@ -1024,6 +1146,9 @@ export class AgentRegistry {
         operationId: migration.operationId ?? `${migration.intentId}:${id}:${migration.revision}`,
         sourceGenerationId: migration.sourceGenerationId ?? source?.id ?? "",
         providerReceipt: migration.providerReceipt ?? null,
+        boardProject: migration.boardProject ?? null,
+        boardOperationId: migration.boardOperationId ?? null,
+        boardPlacementProject: migration.boardPlacementProject ?? migration.boardProject ?? null,
       } : null;
       conversation.updatedAt = now();
       return clone(conversation);
@@ -1044,6 +1169,82 @@ export class AgentRegistry {
       conversation.migration = { ...migration, ...patch, updatedAt: now() };
       conversation.updatedAt = now();
       return clone(conversation);
+    });
+  }
+
+  persistMigrationProviderReceipt(
+    id: ViewerConversationId,
+    expectedRevision: number,
+    operationId: string,
+    receipt: ProviderReceipt,
+  ): RegistryConversation {
+    return this.mutate((file) => {
+      const conversation = file.conversations[id];
+      const migration = conversation?.migration;
+      if (!conversation || !migration) throw new Error("conversation has no migration");
+      if (migration.revision !== expectedRevision || migration.operationId !== operationId) {
+        throw new Error("migration provider receipt is stale");
+      }
+      if (migration.phase === "successor-starting") {
+        conversation.migration = { ...migration, phase: "verifying", providerReceipt: receipt, updatedAt: now() };
+        conversation.updatedAt = now();
+        return clone(conversation);
+      }
+      const matchingReceipt = migration.providerReceipt !== null
+        && sameProviderReceiptOutcome(migration.providerReceipt, receipt);
+      if ((migration.phase === "verifying" || migration.phase === "committed") && matchingReceipt) {
+        return clone(conversation);
+      }
+      throw new Error("migration provider receipt conflicts with durable state");
+    });
+  }
+
+  recordConversationContinuityPath(id: ViewerConversationId, pathname: string): RegistryConversation {
+    return this.mutate((file) => {
+      const conversation = file.conversations[id];
+      if (!conversation) throw new Error("viewer conversation is unknown");
+      const provisionalOwner = Object.values(file.conversations).find((candidate) =>
+        candidate.id !== id && candidate.engine === conversation.engine && conversationOwnsPath(candidate, pathname));
+      if (provisionalOwner) {
+        if (!adoptProvisionalOwner(file, provisionalOwner, conversation, pathname)) {
+          throw new Error("migration continuity path has another durable owner");
+        }
+      }
+      if (!conversation.continuityPaths.includes(pathname)) conversation.continuityPaths.push(pathname);
+      conversation.updatedAt = now();
+      return clone(conversation);
+    });
+  }
+
+  markMigrationBoardProjects(updates: readonly { id: ViewerConversationId; operationId: string; project: string }[]): void {
+    if (updates.length === 0) return;
+    this.mutate((file) => {
+      const updatedAt = now();
+      for (const update of updates) {
+        const conversation = file.conversations[update.id];
+        const migration = conversation?.migration;
+        if (!conversation || !migration || migration.phase !== "committed" || migration.operationId !== update.operationId) continue;
+        migration.boardProject = update.project;
+        migration.boardOperationId = update.operationId;
+        migration.boardPlacementProject = update.project;
+        migration.updatedAt = updatedAt;
+        conversation.updatedAt = updatedAt;
+      }
+    });
+  }
+
+  markMigrationBoardPlacementProjects(updates: readonly { id: ViewerConversationId; operationId: string; project: string }[]): void {
+    if (updates.length === 0) return;
+    this.mutate((file) => {
+      const updatedAt = now();
+      for (const update of updates) {
+        const conversation = file.conversations[update.id];
+        const migration = conversation?.migration;
+        if (!conversation || !migration || migration.phase !== "committed" || migration.operationId !== update.operationId) continue;
+        migration.boardPlacementProject = update.project;
+        migration.updatedAt = updatedAt;
+        conversation.updatedAt = updatedAt;
+      }
     });
   }
 
@@ -1069,6 +1270,9 @@ export class AgentRegistry {
         operationId: crypto.randomUUID(),
         sourceGenerationId: source.id,
         providerReceipt: null,
+        boardProject: current.boardProject,
+        boardOperationId: current.boardOperationId,
+        boardPlacementProject: current.boardPlacementProject,
         error: null,
         errorCode: null,
         updatedAt: now(),
@@ -1101,6 +1305,7 @@ export class AgentRegistry {
         archivedAt: null,
       };
       conversation.generations.push(generation);
+      conversation.continuityPaths = conversation.continuityPaths.filter((pathname) => pathname !== generation.path);
       conversation.migration = { ...conversation.migration, phase: "committed", updatedAt: now() };
       conversation.updatedAt = now();
       for (const delivery of Object.values(file.heldDeliveries)) {

--- a/src/lib/board/mutations.test.ts
+++ b/src/lib/board/mutations.test.ts
@@ -42,6 +42,26 @@ describe("board mutations", () => {
     expect(remapped.prefs).toMatchObject({ manual: [], hidden: ["/b", "/hidden"], expanded: ["/expanded"] });
   });
 
+  test("remap replaces provisional target membership with predecessor placement", () => {
+    const mutation = { kind: "remap-paths" as const, pairs: [{ from: "/source", to: "/target" }] };
+    const automatic = applyBoardMutations(board({ manual: ["/target"] }), [mutation]);
+    const expanded = applyBoardMutations(board({ manual: ["/target"], expanded: ["/source"] }), [mutation]);
+    const manual = applyBoardMutations(board({ manual: ["/source", "/target"] }), [mutation]);
+
+    expect(automatic.prefs.manual).toEqual([]);
+    expect(expanded.prefs).toMatchObject({ manual: [], expanded: ["/target"] });
+    expect(manual.prefs.manual).toEqual(["/target"]);
+    expect(applyBoardMutations(expanded, [mutation])).toEqual(expanded);
+  });
+
+  test("a remapped automatic root stays automatic through root reconciliation", () => {
+    const remapped = applyBoardMutations(board(), [{ kind: "remap-paths", pairs: [{ from: "/source", to: "/target" }] }]);
+    const reconciled = applyBoardMutations(remapped, [{ kind: "reconcile-roots", roots: ["/target"], removeManual: [] }]);
+
+    expect(reconciled.pathAliases).toEqual({ "/source": "/target" });
+    expect(reconciled.prefs).toMatchObject({ manual: [], hidden: [], expanded: [] });
+  });
+
   test("reconciles every root without a numeric cap, removes transient children, and is idempotent", () => {
     const roots = Array.from({ length: 61 }, (_, index) => `/root-${index}`);
     const first = applyBoardMutations(board({ manual: ["/transient-child"], hidden: ["/closed-root"] }), [{

--- a/src/lib/board/mutations.ts
+++ b/src/lib/board/mutations.ts
@@ -48,16 +48,29 @@ function normalize(board: BoardProjectStateV1, aliases = aliasesOf(board)): Boar
 }
 
 function remapPaths(board: BoardProjectStateV1, pairs: readonly { from: string; to: string }[]): BoardProjectStateV1 {
-  const aliases = { ...aliasesOf(board) };
-  for (const { from, to } of pairs) aliases[from] = to;
-  return normalize(board, aliases);
+  const currentAliases = aliasesOf(board);
+  const activePairs = pairs.filter(({ from, to }) => resolvePath(from, currentAliases) !== resolvePath(to, currentAliases));
+  if (activePairs.length === 0) return normalize(board);
+  const sources = new Set(pairs.map(({ from }) => resolvePath(from, currentAliases)));
+  const targets = new Set(activePairs.map(({ to }) => resolvePath(to, currentAliases)));
+  const manual = board.prefs.manual.filter((pathname) => {
+    const resolved = resolvePath(pathname, currentAliases);
+    return !targets.has(resolved) || sources.has(resolved);
+  });
+  const aliases = { ...currentAliases };
+  for (const { from, to } of activePairs) aliases[from] = to;
+  return normalize({ ...board, prefs: { ...board.prefs, manual } }, aliases);
 }
 
 function reconcileRoots(board: BoardProjectStateV1, roots: readonly string[], removeManual: readonly string[]): BoardProjectStateV1 {
   const aliases = aliasesOf(board);
   const removed = new Set(removeManual.map((item) => resolvePath(item, aliases)));
   const manual = board.prefs.manual.filter((item) => !removed.has(item));
-  const present = new Set([...manual, ...board.prefs.hidden]);
+  const present = new Set([
+    ...manual,
+    ...board.prefs.hidden,
+    ...Object.values(aliases).map((item) => resolvePath(item, aliases)),
+  ]);
   for (const root of roots.map((item) => resolvePath(item, aliases))) {
     if (!present.has(root)) {
       manual.push(root);

--- a/src/lib/board/store.test.ts
+++ b/src/lib/board/store.test.ts
@@ -3,7 +3,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
-import { boardFor, BoardStoreError, migrateBoardProjects, mutateBoard, patchBoard } from "./store";
+import { boardFor, BoardStoreError, migrateBoardProjects, mutateBoard, patchBoard, remapBoardPaths, transferBoardPathPlacements } from "./store";
 import { validateBoardPatchRequest } from "./validation";
 
 function temporaryFile(): string { return path.join(fs.mkdtempSync(path.join(os.tmpdir(), "llv-board-")), "board.json"); }
@@ -17,6 +17,22 @@ describe("board store", () => {
     const stale = patchBoard("viewer", 0, { hidden: ["/a"] }, file);
     expect(stale).toMatchObject({ ok: false, board: { revision: 1 } });
     expect(boardFor("viewer", file).prefs.manual).toEqual(["/a"]);
+  });
+  test("durable writes fsync the board file and parent directory", async () => {
+    const file = temporaryFile();
+    const modulePath = path.join(import.meta.dir, "store.ts");
+    const child = Bun.spawn({
+      cmd: [
+        process.execPath,
+        "-e",
+        `const fs = (await import("node:fs")).default; const sync = fs.fsyncSync.bind(fs); let calls = 0; fs.fsyncSync = (descriptor) => { calls += 1; return sync(descriptor); }; const m = await import(${JSON.stringify(modulePath)}); m.patchBoard("viewer", 0, { manual: ["/durable"] }, ${JSON.stringify(file)}); console.log(calls);`,
+      ],
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    expect(await child.exited).toBe(0);
+    expect(Number((await new Response(child.stdout).text()).trim())).toBeGreaterThanOrEqual(3);
   });
   test("fails closed on corrupt durable state and preserves its bytes", () => {
     const file = temporaryFile();
@@ -55,6 +71,193 @@ describe("board store", () => {
     const replay = mutateBoard("viewer", 0, [{ kind: "remap-paths", pairs: [{ from: "/old", to: "/new" }] }], file);
     expect(first).toMatchObject({ ok: true, board: { revision: 1 } });
     expect(replay).toMatchObject({ ok: true, board: { revision: 1 } });
+  });
+  test("concurrent processes preserve every successful project mutation", async () => {
+    const file = temporaryFile();
+    const modulePath = path.join(import.meta.dir, "store.ts");
+    const writers = Array.from({ length: 40 }, (_, index) => Bun.spawn({
+      cmd: [
+        process.execPath,
+        "-e",
+        `const m = await import(${JSON.stringify(modulePath)}); const result = m.patchBoard(${JSON.stringify(`project-${index}`)}, 0, { manual: [${JSON.stringify(`/path-${index}`)}] }, ${JSON.stringify(file)}); if (!result.ok) process.exit(2);`,
+      ],
+      stdout: "ignore",
+      stderr: "pipe",
+    }));
+
+    expect(await Promise.all(writers.map((writer) => writer.exited))).toEqual(Array(40).fill(0));
+    const projects = JSON.parse(fs.readFileSync(file, "utf8")).projects as Record<string, unknown>;
+    expect(Object.keys(projects)).toHaveLength(40);
+  });
+  test("concurrent writers recover a crashed lock owner without lost mutations", async () => {
+    const file = temporaryFile();
+    const writerCount = 24;
+    const staleOwner = JSON.stringify({ pid: 999_999_999, startIdentity: null });
+    const legacyLock = `${file}.write-lock`;
+    const lockDirectory = `${file}.write-locks`;
+    const staleTicket = path.join(lockDirectory, "stale-owner.json");
+    const barrier = `${file}.stale-reapers`;
+    fs.mkdirSync(path.dirname(file), { recursive: true });
+    fs.mkdirSync(lockDirectory);
+    fs.mkdirSync(barrier);
+    fs.writeFileSync(legacyLock, staleOwner, "utf8");
+    fs.writeFileSync(staleTicket, staleOwner, "utf8");
+    const modulePath = path.join(import.meta.dir, "store.ts");
+    const writers = Array.from({ length: writerCount }, (_, index) => Bun.spawn({
+      cmd: [
+        process.execPath,
+        "-e",
+        `const fs = (await import("node:fs")).default; const path = (await import("node:path")).default; const remove = fs.rmSync.bind(fs); let gated = false; fs.rmSync = (pathname, options) => { if (!gated && (pathname === ${JSON.stringify(legacyLock)} || pathname === ${JSON.stringify(staleTicket)})) { gated = true; fs.writeFileSync(path.join(${JSON.stringify(barrier)}, String(process.pid)), ""); while (fs.readdirSync(${JSON.stringify(barrier)}).length < ${writerCount}) Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 1); } return remove(pathname, options); }; const m = await import(${JSON.stringify(modulePath)}); const result = m.patchBoard(${JSON.stringify(`recovered-${index}`)}, 0, { manual: [${JSON.stringify(`/recovered-${index}`)}] }, ${JSON.stringify(file)}); if (!result.ok) process.exit(2);`,
+      ],
+      stdout: "ignore",
+      stderr: "pipe",
+    }));
+
+    expect(await Promise.all(writers.map((writer) => writer.exited))).toEqual(Array(writerCount).fill(0));
+    const projects = JSON.parse(fs.readFileSync(file, "utf8")).projects as Record<string, unknown>;
+    expect(Object.keys(projects)).toHaveLength(writerCount);
+  });
+  test("aged lock records recover when process birth identity is unavailable", () => {
+    const file = temporaryFile();
+    const lockDirectory = `${file}.write-locks`;
+    const ticket = path.join(lockDirectory, "0000-reused-pid.json");
+    const lock = `${file}.write-lock`;
+    const owner = JSON.stringify({ pid: process.pid, startIdentity: null });
+    fs.mkdirSync(lockDirectory, { recursive: true });
+    fs.writeFileSync(ticket, owner, "utf8");
+    fs.writeFileSync(lock, owner, "utf8");
+    const stale = new Date(Date.now() - 60_000);
+    fs.utimesSync(ticket, stale, stale);
+    fs.utimesSync(lock, stale, stale);
+
+    expect(patchBoard("viewer", 0, { manual: ["/recovered"] }, file)).toMatchObject({
+      ok: true,
+      board: { prefs: { manual: ["/recovered"] } },
+    });
+  });
+  test("path remap clears provisional continuity roots and replays idempotently", () => {
+    const file = temporaryFile();
+    const project = "viewer";
+    patchBoard(project, 0, { manual: ["/fork", "/target"], expanded: ["/source"] }, file);
+    const first = remapBoardPaths(
+      project,
+      [{ from: "/source", to: "/target" }, { from: "/fork", to: "/target" }],
+      { provisionalManual: ["/fork"], filePath: file },
+    );
+    const replay = remapBoardPaths(
+      project,
+      [{ from: "/source", to: "/target" }, { from: "/fork", to: "/target" }],
+      { provisionalManual: ["/fork"], filePath: file },
+    );
+    expect(first).toMatchObject({
+      revision: 2,
+      pathAliases: { "/source": "/target", "/fork": "/target" },
+      prefs: { manual: [], expanded: ["/target"] },
+    });
+    expect(replay).toEqual(first);
+  });
+  test("path remap derives provisional cleanup after a concurrent alias write", async () => {
+    const file = temporaryFile();
+    const project = "viewer";
+    const ready = `${file}.reader-ready`;
+    const release = `${file}.reader-release`;
+    patchBoard(project, 0, { manual: ["/fork"] }, file);
+    const modulePath = path.join(import.meta.dir, "store.ts");
+    const writer = Bun.spawn({
+      cmd: [
+        process.execPath,
+        "-e",
+        `const fs = (await import("node:fs")).default; const open = fs.openSync.bind(fs); let gated = false; fs.openSync = (pathname, ...args) => { if (!gated && pathname === ${JSON.stringify(`${file}.write-lock`)}) { gated = true; fs.writeFileSync(${JSON.stringify(ready)}, ""); while (!fs.existsSync(${JSON.stringify(release)})) Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 1); } return open(pathname, ...args); }; const m = await import(${JSON.stringify(modulePath)}); m.remapBoardPaths(${JSON.stringify(project)}, [{ from: "/source", to: "/target" }, { from: "/fork", to: "/target" }], { provisionalManual: ["/fork"], filePath: ${JSON.stringify(file)} });`,
+      ],
+      stdout: "ignore",
+      stderr: "pipe",
+    });
+    while (!fs.existsSync(ready)) await Bun.sleep(1);
+    const interleaved = JSON.parse(fs.readFileSync(file, "utf8"));
+    interleaved.projects[project] = {
+      ...interleaved.projects[project],
+      revision: interleaved.projects[project].revision + 1,
+      pathAliases: { "/fork": "/target" },
+      prefs: { ...interleaved.projects[project].prefs, manual: ["/target"] },
+    };
+    fs.writeFileSync(file, JSON.stringify(interleaved, null, 2) + "\n", "utf8");
+    fs.writeFileSync(release, "", "utf8");
+
+    expect(await writer.exited).toBe(0);
+    expect(boardFor(project, file)).toMatchObject({
+      pathAliases: { "/fork": "/target", "/source": "/target" },
+      prefs: { manual: ["/target"] },
+    });
+  });
+  test("project placement transfer preserves destination user intent", () => {
+    const file = temporaryFile();
+    const paths = ["/hidden", "/manual", "/expanded"];
+    mutateBoard("source", 0, [{
+      kind: "remap-paths",
+      pairs: paths.map((pathname) => ({ from: `/old${pathname}`, to: pathname })),
+    }], file);
+    mutateBoard("destination", 0, [
+      { kind: "close", path: paths[0]! },
+      { kind: "restore", path: paths[1]!, placement: "manual" },
+      { kind: "restore", path: paths[2]!, placement: "expanded" },
+    ], file);
+
+    transferBoardPathPlacements([{
+      fromProject: "source",
+      toProject: "destination",
+      paths,
+    }], file);
+
+    expect(boardFor("destination", file).prefs).toMatchObject({
+      hidden: [paths[0]],
+      manual: [paths[1]],
+      expanded: [paths[2]],
+    });
+  });
+  test("project placement transfer carries continuity aliases with manual placement", () => {
+    const file = temporaryFile();
+    const source = "/predecessor";
+    const successor = "/successor";
+    mutateBoard("source", 0, [
+      { kind: "restore", path: source, placement: "manual" },
+      { kind: "remap-paths", pairs: [{ from: source, to: successor }] },
+    ], file);
+
+    transferBoardPathPlacements([{
+      fromProject: "source",
+      toProject: "destination",
+      paths: [source, successor],
+    }], file);
+    const repaired = remapBoardPaths("destination", [{ from: source, to: successor }], { filePath: file });
+
+    expect(boardFor("source", file).prefs.manual).toEqual([]);
+    expect(repaired).toMatchObject({
+      pathAliases: { [source]: successor },
+      prefs: { manual: [successor] },
+    });
+  });
+  test("project placement transfer resolves destination intent through carried aliases", () => {
+    const file = temporaryFile();
+    const source = "/predecessor";
+    const successor = "/successor";
+    mutateBoard("source", 0, [
+      { kind: "restore", path: source, placement: "expanded" },
+      { kind: "remap-paths", pairs: [{ from: source, to: successor }] },
+    ], file);
+    mutateBoard("destination", 0, [
+      { kind: "restore", path: source, placement: "manual" },
+    ], file);
+
+    transferBoardPathPlacements([{
+      fromProject: "source",
+      toProject: "destination",
+      paths: [source, successor],
+    }], file);
+
+    expect(boardFor("destination", file)).toMatchObject({
+      pathAliases: { [source]: successor },
+      prefs: { manual: [successor], expanded: [] },
+    });
   });
   test("many stale projects merge by original timestamp with newer membership roles winning", () => {
     const run = (migrations: Map<string, string>) => {

--- a/src/lib/board/store.ts
+++ b/src/lib/board/store.ts
@@ -3,12 +3,16 @@ import fs from "node:fs";
 import path from "node:path";
 
 import { statePath } from "@/lib/configDir";
+import { procBackend } from "@/lib/proc";
 
 import { applyBoardMutations, type BoardMutationV1 } from "@/lib/board/mutations";
 import type { BoardFileV1, BoardProjectStateV1 } from "@/lib/view/types";
 
 export const BOARD_FILE = statePath("board.json");
 const EMPTY_PREFS: BoardProjectStateV1["prefs"] = { manual: [], hidden: [], expanded: [], viewMode: null, taskPanelOpen: false };
+const BOARD_LOCK_ATTEMPTS = 1_000;
+const BOARD_LOCK_WAIT_MS = 5;
+const BOARD_LOCK_STALE_MS = 30_000;
 let boardFileForTests: string | null = null;
 
 export class BoardStoreError extends Error {
@@ -53,9 +57,101 @@ function read(filePath: string): BoardFileV1 {
 function write(value: BoardFileV1, filePath: string): void {
   fs.mkdirSync(path.dirname(filePath), { recursive: true });
   const temp = path.join(path.dirname(filePath), `.${path.basename(filePath)}.${process.pid}.${crypto.randomUUID()}.tmp`);
-  fs.writeFileSync(temp, JSON.stringify(value, null, 2) + "\n", "utf8");
-  fs.renameSync(temp, filePath);
+  let descriptor: number | null = null;
+  try {
+    descriptor = fs.openSync(temp, "wx", 0o600);
+    fs.writeFileSync(descriptor, JSON.stringify(value, null, 2) + "\n", "utf8");
+    fs.fsyncSync(descriptor);
+    fs.closeSync(descriptor);
+    descriptor = null;
+    fs.renameSync(temp, filePath);
+    const directory = fs.openSync(path.dirname(filePath), "r");
+    try { fs.fsyncSync(directory); } finally { fs.closeSync(directory); }
+  } finally {
+    if (descriptor !== null) fs.closeSync(descriptor);
+    fs.rmSync(temp, { force: true });
+  }
 }
+
+function sleep(milliseconds: number): void {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, milliseconds);
+}
+
+function lockOwnerIsStale(lockPath: string): boolean {
+  try {
+    const previous = JSON.parse(fs.readFileSync(lockPath, "utf8")) as { pid?: unknown; startIdentity?: unknown };
+    if (typeof previous.pid === "number" && Number.isInteger(previous.pid) && previous.pid > 0) {
+      const identity = typeof previous.startIdentity === "string" ? previous.startIdentity : null;
+      return !procBackend.pidAlive(previous.pid)
+        || (identity !== null
+          ? (() => {
+              const currentIdentity = procBackend.processIdentity(previous.pid);
+              return currentIdentity !== null && currentIdentity !== identity;
+            })()
+          : Date.now() - fs.statSync(lockPath).mtimeMs > BOARD_LOCK_STALE_MS);
+    }
+    return Date.now() - fs.statSync(lockPath).mtimeMs > BOARD_LOCK_STALE_MS;
+  } catch {
+    try { return Date.now() - fs.statSync(lockPath).mtimeMs > BOARD_LOCK_STALE_MS; } catch { return false; }
+  }
+}
+
+function removeBoardLockIfOwned(lockPath: string, token: string): void {
+  try {
+    const owner = JSON.parse(fs.readFileSync(lockPath, "utf8")) as { token?: unknown };
+    if (owner.token === token) fs.rmSync(lockPath, { force: true });
+  } catch { /* another owner already recovered the lock */ }
+}
+
+function withBoardWriteLock<T>(filePath: string, operation: () => T): T {
+  const lockPath = `${filePath}.write-lock`;
+  const queuePath = `${filePath}.write-locks`;
+  fs.mkdirSync(queuePath, { recursive: true, mode: 0o700 });
+  const owner = { pid: process.pid, startIdentity: procBackend.processIdentity(process.pid), token: crypto.randomUUID() };
+  const ticketPath = path.join(
+    queuePath,
+    `${String(Date.now()).padStart(16, "0")}-${process.pid}-${crypto.randomUUID()}.json`,
+  );
+  fs.writeFileSync(ticketPath, JSON.stringify(owner), { encoding: "utf8", flag: "wx", mode: 0o600 });
+  try {
+    for (let attempt = 0; attempt < BOARD_LOCK_ATTEMPTS; attempt += 1) {
+      const liveTickets: string[] = [];
+      for (const entry of fs.readdirSync(queuePath).filter((candidate) => candidate.endsWith(".json")).sort()) {
+        const candidate = path.join(queuePath, entry);
+        if (lockOwnerIsStale(candidate)) {
+          fs.rmSync(candidate, { force: true });
+          continue;
+        }
+        if (fs.existsSync(candidate)) liveTickets.push(candidate);
+      }
+      if (liveTickets[0] !== ticketPath) {
+        sleep(BOARD_LOCK_WAIT_MS);
+        continue;
+      }
+      let descriptor: number;
+      try {
+        descriptor = fs.openSync(lockPath, "wx", 0o600);
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
+        if (lockOwnerIsStale(lockPath)) fs.rmSync(lockPath, { force: true });
+        sleep(BOARD_LOCK_WAIT_MS);
+        continue;
+      }
+      try {
+        fs.writeFileSync(descriptor, JSON.stringify(owner), "utf8");
+        fs.fsyncSync(descriptor);
+        return operation();
+      } finally {
+        fs.closeSync(descriptor);
+        removeBoardLockIfOwned(lockPath, owner.token);
+      }
+    }
+    throw new BoardStoreError("board state is busy");
+  } finally {
+    removeBoardLockIfOwned(ticketPath, owner.token);
+  }
+}
+
 export function boardFor(project: string, filePath = boardFileForTests ?? BOARD_FILE): BoardProjectStateV1 {
   return read(filePath).projects[project] ?? emptyBoard();
 }
@@ -67,15 +163,36 @@ function sameReduced(left: BoardProjectStateV1, right: BoardProjectStateV1): boo
 }
 
 function writeReduced(project: string, baseRevision: number, reduce: (current: BoardProjectStateV1) => BoardProjectStateV1, filePath: string): BoardWriteResult {
-  const value = read(filePath);
-  const current = value.projects[project] ?? emptyBoard();
-  const reduced = reduce(current);
-  if (sameReduced(current, reduced)) return { ok: true, board: current };
-  if (current.revision !== baseRevision) return { ok: false, board: current };
-  const next: BoardProjectStateV1 = { ...reduced, schemaVersion: 1, revision: current.revision + 1, updatedAt: new Date().toISOString(), pathAliases: reduced.pathAliases ?? {} };
-  value.projects[project] = next;
-  write(value, filePath);
-  return { ok: true, board: next };
+  return withBoardWriteLock(filePath, () => {
+    const value = read(filePath);
+    const current = value.projects[project] ?? emptyBoard();
+    const reduced = reduce(current);
+    if (sameReduced(current, reduced)) return { ok: true, board: current };
+    if (current.revision !== baseRevision) return { ok: false, board: current };
+    const next: BoardProjectStateV1 = { ...reduced, schemaVersion: 1, revision: current.revision + 1, updatedAt: new Date().toISOString(), pathAliases: reduced.pathAliases ?? {} };
+    value.projects[project] = next;
+    write(value, filePath);
+    return { ok: true, board: next };
+  });
+}
+
+function writeLatest(project: string, reduce: (current: BoardProjectStateV1) => BoardProjectStateV1, filePath: string): BoardProjectStateV1 {
+  return withBoardWriteLock(filePath, () => {
+    const value = read(filePath);
+    const current = value.projects[project] ?? emptyBoard();
+    const reduced = reduce(current);
+    if (sameReduced(current, reduced)) return current;
+    const next: BoardProjectStateV1 = {
+      ...reduced,
+      schemaVersion: 1,
+      revision: current.revision + 1,
+      updatedAt: new Date().toISOString(),
+      pathAliases: reduced.pathAliases ?? {},
+    };
+    value.projects[project] = next;
+    write(value, filePath);
+    return next;
+  });
 }
 
 export function patchBoard(project: string, baseRevision: number, patch: BoardPatch, filePath = boardFileForTests ?? BOARD_FILE): { ok: true; board: BoardProjectStateV1 } | { ok: false; board: BoardProjectStateV1 } {
@@ -84,6 +201,125 @@ export function patchBoard(project: string, baseRevision: number, patch: BoardPa
 
 export function mutateBoard(project: string, baseRevision: number, mutations: readonly BoardMutationV1[], filePath = boardFileForTests ?? BOARD_FILE): BoardWriteResult {
   return writeReduced(project, baseRevision, (current) => applyBoardMutations(current, mutations), filePath);
+}
+
+export function remapBoardPaths(
+  project: string,
+  pairs: Extract<BoardMutationV1, { kind: "remap-paths" }>["pairs"],
+  options: { provisionalManual?: readonly string[]; filePath?: string } = {},
+): BoardProjectStateV1 {
+  const filePath = options.filePath ?? boardFileForTests ?? BOARD_FILE;
+  return writeLatest(project, (current) => {
+    if (pairs.length === 0 || pairs.every(({ from, to }) => current.pathAliases?.[from] === to)) return current;
+    const provisionalManual = options.provisionalManual?.filter((pathname) => (
+      current.pathAliases?.[pathname] === undefined && current.prefs.manual.includes(pathname)
+    )) ?? [];
+    const mutations: BoardMutationV1[] = [];
+    if (provisionalManual.length) {
+      mutations.push({ kind: "reconcile-roots", roots: [], removeManual: provisionalManual });
+    }
+    mutations.push({ kind: "remap-paths", pairs });
+    return applyBoardMutations(current, mutations);
+  }, filePath);
+}
+
+export function transferBoardPathPlacements(
+  transfers: readonly { fromProject: string; toProject: string; paths: readonly string[] }[],
+  filePath = boardFileForTests ?? BOARD_FILE,
+): void {
+  if (transfers.length === 0) return;
+  withBoardWriteLock(filePath, () => {
+    const value = read(filePath);
+    let changed = false;
+    for (const transfer of transfers) {
+      if (transfer.fromProject === transfer.toProject) continue;
+      const storedSource = value.projects[transfer.fromProject];
+      if (!storedSource) continue;
+      let source = applyBoardMutations(storedSource, []);
+      let target = applyBoardMutations(value.projects[transfer.toProject] ?? emptyBoard(), []);
+      for (const pathname of [...new Set(transfer.paths)]) {
+        const sourceAliasEntries = Object.entries(source.pathAliases ?? {}).filter(([, targetPath]) => targetPath === pathname);
+        if (sourceAliasEntries.length > 0) {
+          target = applyBoardMutations({
+            ...target,
+            pathAliases: {
+              ...(target.pathAliases ?? {}),
+              ...Object.fromEntries(sourceAliasEntries),
+            },
+          }, []);
+        }
+        const sourceHasMembership = source.prefs.hidden.includes(pathname)
+          || source.prefs.expanded.includes(pathname)
+          || source.prefs.manual.includes(pathname);
+        if (!sourceHasMembership && sourceAliasEntries.length === 0) continue;
+        const sourcePlacement = source.prefs.hidden.includes(pathname)
+          ? "hidden"
+          : source.prefs.expanded.includes(pathname)
+            ? "expanded"
+            : source.prefs.manual.includes(pathname)
+              ? "manual"
+              : "auto";
+        const destinationPlacement = target.prefs.hidden.includes(pathname)
+          ? "hidden"
+          : target.prefs.expanded.includes(pathname)
+            ? "expanded"
+            : target.prefs.manual.includes(pathname)
+              ? "manual"
+              : "auto";
+        const placement = sourcePlacement === "hidden" || destinationPlacement === "hidden"
+          ? "hidden"
+          : destinationPlacement !== "auto"
+            ? destinationPlacement
+            : sourcePlacement;
+        source = {
+          ...source,
+          pathAliases: Object.fromEntries(
+            Object.entries(source.pathAliases ?? {}).filter(([, targetPath]) => targetPath !== pathname),
+          ),
+          prefs: {
+            ...source.prefs,
+            manual: source.prefs.manual.filter((item) => item !== pathname),
+            hidden: source.prefs.hidden.filter((item) => item !== pathname),
+            expanded: source.prefs.expanded.filter((item) => item !== pathname),
+          },
+        };
+        const targetPrefs = {
+          ...target.prefs,
+          manual: target.prefs.manual.filter((item) => item !== pathname),
+          hidden: target.prefs.hidden.filter((item) => item !== pathname),
+          expanded: target.prefs.expanded.filter((item) => item !== pathname),
+        };
+        target = {
+          ...target,
+          prefs: placement === "hidden"
+            ? { ...targetPrefs, hidden: [...targetPrefs.hidden, pathname] }
+            : placement === "expanded"
+              ? { ...targetPrefs, expanded: [...targetPrefs.expanded, pathname] }
+              : placement === "manual"
+                ? { ...targetPrefs, manual: [...targetPrefs.manual, pathname] }
+                : targetPrefs,
+        };
+      }
+      if (!sameReduced(storedSource, source)) {
+        value.projects[transfer.fromProject] = {
+          ...source,
+          revision: storedSource.revision + 1,
+          updatedAt: new Date().toISOString(),
+        };
+        changed = true;
+      }
+      const storedTarget = value.projects[transfer.toProject] ?? emptyBoard();
+      if (!sameReduced(storedTarget, target)) {
+        value.projects[transfer.toProject] = {
+          ...target,
+          revision: storedTarget.revision + 1,
+          updatedAt: new Date().toISOString(),
+        };
+        changed = true;
+      }
+    }
+    if (changed) write(value, filePath);
+  });
 }
 
 function mergedBoards(states: readonly BoardProjectStateV1[]): BoardProjectStateV1 {
@@ -130,44 +366,46 @@ function mergedBoards(states: readonly BoardProjectStateV1[]): BoardProjectState
     Sources remain intact whenever a merge cannot preserve board invariants. */
 export function migrateBoardProjects(
   migrations: ReadonlyMap<string, string>,
-  filePath = statePath("board.json"),
+  filePath = boardFileForTests ?? statePath("board.json"),
 ): boolean {
   if (migrations.size === 0) return true;
-  const value = read(filePath);
-  let changed = false;
-  let complete = true;
-  const sourcesByTarget = new Map<string, string[]>();
-  for (const [sourceProject, targetProject] of migrations) {
-    if (sourceProject === targetProject) continue;
-    sourcesByTarget.set(targetProject, [...(sourcesByTarget.get(targetProject) ?? []), sourceProject]);
-  }
-  for (const [targetProject, sourceProjects] of sourcesByTarget) {
-    const sources = sourceProjects.flatMap((project) => value.projects[project] ? [value.projects[project]!] : []);
-    if (sources.length === 0) continue;
-    const target = value.projects[targetProject];
-    if (!target && sources.length === 1) {
-      value.projects[targetProject] = sources[0]!;
-      for (const sourceProject of sourceProjects) delete value.projects[sourceProject];
-      changed = true;
-      continue;
+  return withBoardWriteLock(filePath, () => {
+    const value = read(filePath);
+    let changed = false;
+    let complete = true;
+    const sourcesByTarget = new Map<string, string[]>();
+    for (const [sourceProject, targetProject] of migrations) {
+      if (sourceProject === targetProject) continue;
+      sourcesByTarget.set(targetProject, [...(sourcesByTarget.get(targetProject) ?? []), sourceProject]);
     }
-    try {
-      const states = target ? [target, ...sources] : sources;
-      const merged = mergedBoards(states);
-      value.projects[targetProject] = target && sameReduced(target, merged)
-        ? target
-        : {
-            ...merged,
-            revision: Math.max(...states.map((state) => state.revision)) + 1,
-            updatedAt: new Date().toISOString(),
-          };
-      for (const sourceProject of sourceProjects) delete value.projects[sourceProject];
-      changed = true;
-    } catch {
-      complete = false;
-      continue;
+    for (const [targetProject, sourceProjects] of sourcesByTarget) {
+      const sources = sourceProjects.flatMap((project) => value.projects[project] ? [value.projects[project]!] : []);
+      if (sources.length === 0) continue;
+      const target = value.projects[targetProject];
+      if (!target && sources.length === 1) {
+        value.projects[targetProject] = sources[0]!;
+        for (const sourceProject of sourceProjects) delete value.projects[sourceProject];
+        changed = true;
+        continue;
+      }
+      try {
+        const states = target ? [target, ...sources] : sources;
+        const merged = mergedBoards(states);
+        value.projects[targetProject] = target && sameReduced(target, merged)
+          ? target
+          : {
+              ...merged,
+              revision: Math.max(...states.map((state) => state.revision)) + 1,
+              updatedAt: new Date().toISOString(),
+            };
+        for (const sourceProject of sourceProjects) delete value.projects[sourceProject];
+        changed = true;
+      } catch {
+        complete = false;
+        continue;
+      }
     }
-  }
-  if (changed) write(value, filePath);
-  return complete;
+    if (changed) write(value, filePath);
+    return complete;
+  });
 }

--- a/src/lib/flows/types.ts
+++ b/src/lib/flows/types.ts
@@ -30,6 +30,15 @@ export type FlowState =
 
 export type ReviewVerdict = "APPROVE" | "REQUEST_CHANGES" | "COMMENT";
 
+export type FlowBlock = {
+  reason: "rate_limited";
+  /** Stable address for a future continue-on-account action. */
+  conversationId: string | null;
+  /** Exhausted account. A successor action can exclude it from targets. */
+  accountId: string | null;
+  resetAt: number | null;
+};
+
 export type Round = {
   n: number; // 1-based
   reviewerPath: string | null; // reviewer run's transcript path once known
@@ -82,6 +91,8 @@ export type Flow = {
   pausedState?: FlowState | null;
   /** Human-readable reason shown on the strip for needs_decision/paused. */
   stateDetail: string | null;
+  /** Ephemeral read-model block derived from the attached implementer. */
+  block?: FlowBlock | null;
   rounds: Round[];
   createdAt: string;
   closedAt: string | null;

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -586,6 +586,9 @@ export const en = {
   "flowState.needs_decision": "needs a decision",
   "flowState.paused": "paused",
   "flowState.closed": "closed",
+  "flowState.blocked_rate_limited": "blocked: rate-limited",
+  "flowState.rate_limit_until": "resets at {time}",
+  "flowState.rate_limit_wait": "waiting for the quota reset",
   "flowModel.failed": "failed ({status})",
 
   "wfState.provisioning": "provisioning the worktree",
@@ -771,7 +774,10 @@ export const en = {
   "status.returnedResult": "returned with a result",
   "status.stalled": "interrupted or awaiting permission",
   "status.finishedTurn": "finished the turn — waiting for a reply",
+  "status.rateLimited": "rate-limited",
   "status.flow": "flow: {label}",
+  "rateLimit.badge": "rate-limited",
+  "rateLimit.badgeUntil": "rate-limited until {time}",
 
   // useDictation errors
   "dictation.capWarn": "less than a minute of recording left",

--- a/src/lib/i18n/uk.ts
+++ b/src/lib/i18n/uk.ts
@@ -559,6 +559,9 @@ export const uk: Record<keyof typeof en, Message> = {
   "flowState.needs_decision": "потребує рішення",
   "flowState.paused": "пауза",
   "flowState.closed": "закрито",
+  "flowState.blocked_rate_limited": "заблоковано: вичерпано ліміт",
+  "flowState.rate_limit_until": "скинеться о {time}",
+  "flowState.rate_limit_wait": "чекає на скидання ліміту",
   "flowModel.failed": "не вдалося ({status})",
 
   "wfState.provisioning": "готую worktree",
@@ -739,7 +742,10 @@ export const uk: Record<keyof typeof en, Message> = {
   "status.returnedResult": "повернувся з результатом",
   "status.stalled": "перервано або чекає дозволу",
   "status.finishedTurn": "закінчив хід — чекає відповіді",
+  "status.rateLimited": "вичерпано ліміт",
   "status.flow": "флоу: {label}",
+  "rateLimit.badge": "вичерпано ліміт",
+  "rateLimit.badgeUntil": "ліміт до {time}",
 
   "dictation.capWarn": "залишилось менше хвилини запису",
   "dictation.capStopped": "Запис зупинено на 10-хвилинній межі; текст зʼявиться в полі.",

--- a/src/lib/proc/portable.test.ts
+++ b/src/lib/proc/portable.test.ts
@@ -1,0 +1,11 @@
+import { expect, test } from "bun:test";
+
+import { portableBackend } from "./portable";
+
+test("portable process identity is stable for a live pid", () => {
+  const first = portableBackend.processIdentity(process.pid);
+  const second = portableBackend.processIdentity(process.pid);
+
+  expect(first).not.toBeNull();
+  expect(second).toBe(first);
+});

--- a/src/lib/proc/portable.ts
+++ b/src/lib/proc/portable.ts
@@ -175,11 +175,10 @@ function readPpid(pid: number): number | null {
   return snapshot().get(pid)?.ppid ?? null;
 }
 
-/* ps does not provide a portable process-birth identity. Null makes callers
-   require their other live-host evidence on platforms without Linux /proc. */
 function processIdentity(pid: number): string | null {
-  void pid;
-  return null;
+  if (!Number.isInteger(pid) || pid <= 0) return null;
+  const started = runCapture("ps", ["-p", String(pid), "-o", "lstart="]).trim().replace(/\s+/g, " ");
+  return started ? `${pid}:${started}` : null;
 }
 
 /**

--- a/src/lib/rateLimit.test.ts
+++ b/src/lib/rateLimit.test.ts
@@ -1,0 +1,161 @@
+import { expect, test } from "bun:test";
+
+import type { Flow } from "@/lib/flows/types";
+import type { FileEntry } from "@/lib/types";
+
+import { projectRateLimitReadModel, rateLimitFromQuotaObservation } from "./rateLimit";
+
+const NOW = new Date("2026-07-10T16:00:00.000Z").getTime();
+const RESET = Math.floor(NOW / 1000) + 7_200;
+
+function entry(overrides: Partial<FileEntry> = {}): FileEntry {
+  return {
+    path: "/sessions/implementer.jsonl",
+    root: "codex-sessions",
+    name: "implementer.jsonl",
+    project: "demo",
+    title: "Implementer",
+    engine: "codex",
+    kind: "session",
+    fmt: "codex",
+    parent: null,
+    mtime: NOW / 1000 - 60,
+    size: 10,
+    activity: "live",
+    proc: "running",
+    pid: 42,
+    model: "gpt-5.6",
+    pendingQuestion: null,
+    waitingInput: null,
+    ...overrides,
+  };
+}
+
+function flow(): Flow {
+  const role = { engine: "codex" as const, model: null, effort: null };
+  return {
+    id: "flow-1",
+    template: "implement-review-loop",
+    project: "demo",
+    cwd: "/repo",
+    implementerPath: "/sessions/implementer.jsonl",
+    implementerConversationId: "conversation_impl",
+    roles: { implementer: role, reviewer: role },
+    baseRef: "abc",
+    baseMode: "head",
+    mode: "auto",
+    reviewerMode: "headless",
+    roundLimit: 5,
+    state: "waiting_ready",
+    stateDetail: null,
+    rounds: [],
+    createdAt: "2026-07-10T15:00:00.000Z",
+    closedAt: null,
+  };
+}
+
+function observation(usedPercent: number, observedAt = NOW) {
+  const iso = new Date(observedAt).toISOString();
+  return {
+    engine: "codex" as const,
+    accountId: "main",
+    authenticated: true,
+    authCheckedAt: iso,
+    limits: {
+      session: { usedPercent, resetsAt: RESET },
+      weekly: { usedPercent: 35, resetsAt: RESET + 86_400 },
+      plan: "pro",
+      capturedAt: Math.floor(observedAt / 1000),
+    },
+    provenance: { source: "live" as const, reason: null, staleSince: null },
+    observedAt: iso,
+    bootId: "boot-1",
+  };
+}
+
+test("fresh exhausted account limits become a structured rate-limit signal", () => {
+  expect(rateLimitFromQuotaObservation(observation(100), NOW)).toEqual({
+    source: "account",
+    accountId: "main",
+    window: "session",
+    resetAt: RESET,
+  });
+  expect(rateLimitFromQuotaObservation(observation(99), NOW)).toBeNull();
+  expect(rateLimitFromQuotaObservation(observation(100, NOW - 10 * 60_000), NOW)).toBeNull();
+  expect(rateLimitFromQuotaObservation({
+    ...observation(100),
+    limits: {
+      ...observation(100).limits,
+      session: { usedPercent: 100, resetsAt: Math.floor(NOW / 1000) - 1 },
+    },
+  }, NOW)).toBeNull();
+});
+
+test("reviewer-side flow work keeps its own state while the implementer account is exhausted", () => {
+  const reviewing = { ...flow(), state: "reviewing" as const };
+  const snapshot = {
+    conversations: {
+      conversation_impl: {
+        id: "conversation_impl",
+        engine: "codex" as const,
+        generations: [{ path: "/sessions/implementer.jsonl", accountId: "main" }],
+      },
+    },
+    quotaObservations: { claude: {}, codex: { main: observation(100) } },
+  };
+
+  expect(projectRateLimitReadModel([entry()], [reviewing], snapshot, NOW).flows[0]?.block).toBeUndefined();
+});
+
+test("the files read model joins account exhaustion to a live conversation and its flow", () => {
+  const snapshot = {
+    conversations: {
+      conversation_impl: {
+        id: "conversation_impl",
+        engine: "codex" as const,
+        generations: [{ path: "/sessions/implementer.jsonl", accountId: "main" }],
+      },
+    },
+    quotaObservations: { claude: {}, codex: { main: observation(100) } },
+  };
+
+  const projected = projectRateLimitReadModel([entry()], [flow()], snapshot, NOW);
+
+  expect(projected.files[0]?.rateLimit).toEqual({
+    source: "account",
+    accountId: "main",
+    window: "session",
+    resetAt: RESET,
+  });
+  expect(projected.flows[0]?.block).toEqual({
+    reason: "rate_limited",
+    conversationId: "conversation_impl",
+    accountId: "main",
+    resetAt: RESET,
+  });
+});
+
+test("a pane signal wins and receives the structured reset time", () => {
+  const file = entry({
+    rateLimit: { source: "pane", accountId: null, window: null, resetAt: null },
+  });
+  const snapshot = {
+    conversations: {
+      conversation_impl: {
+        id: "conversation_impl",
+        engine: "codex" as const,
+        generations: [{ path: file.path, accountId: "main" }],
+      },
+    },
+    quotaObservations: { claude: {}, codex: { main: observation(100) } },
+  };
+
+  const projected = projectRateLimitReadModel([file], [flow()], snapshot, NOW);
+
+  expect(projected.files[0]?.rateLimit).toEqual({
+    source: "pane",
+    accountId: "main",
+    window: "session",
+    resetAt: RESET,
+  });
+});

--- a/src/lib/rateLimit.test.ts
+++ b/src/lib/rateLimit.test.ts
@@ -91,6 +91,22 @@ test("fresh exhausted account limits become a structured rate-limit signal", () 
   }, NOW)).toBeNull();
 });
 
+test("an unknown exhausted-window reset suppresses a misleading badge time", () => {
+  const limited = observation(100);
+  expect(rateLimitFromQuotaObservation({
+    ...limited,
+    limits: {
+      ...limited.limits,
+      weekly: { usedPercent: 100, resetsAt: null },
+    },
+  }, NOW)).toMatchObject({
+    source: "account",
+    accountId: "main",
+    window: "weekly",
+    resetAt: null,
+  });
+});
+
 test("reviewer-side flow work keeps its own state while the implementer account is exhausted", () => {
   const reviewing = { ...flow(), state: "reviewing" as const };
   const snapshot = {

--- a/src/lib/rateLimit.ts
+++ b/src/lib/rateLimit.ts
@@ -1,0 +1,122 @@
+import type { DurableQuotaObservation } from "@/lib/accounts/migration/contracts";
+import { effectiveRemaining } from "@/lib/accounts/migration/quotaPolicy";
+import type { Flow } from "@/lib/flows/types";
+import type { Engine, FileEntry, RateLimitState } from "@/lib/types";
+
+type HostedEngine = Extract<Engine, "claude" | "codex">;
+
+export interface RateLimitProjectionSnapshot {
+  conversations: Record<string, {
+    id: string;
+    engine: HostedEngine;
+    generations: Array<{ path: string; accountId: string | null }>;
+  }>;
+  quotaObservations: Record<HostedEngine, Record<string, DurableQuotaObservation>>;
+}
+
+export function rateLimitFromQuotaObservation(
+  observation: DurableQuotaObservation | undefined,
+  now = Date.now(),
+): RateLimitState | null {
+  if (!observation) return null;
+  const observedAt = Date.parse(observation.observedAt);
+  const authCheckedAt = Date.parse(observation.authCheckedAt);
+  const remaining = effectiveRemaining({
+    engine: observation.engine,
+    accountId: observation.accountId,
+    authenticated: observation.authenticated,
+    limits: observation.limits,
+    provenance: observation.provenance,
+    observedAt,
+    authCheckedAt,
+  }, now);
+  if (remaining?.percent !== 0 || !observation.limits) return null;
+
+  const exhausted = (["session", "weekly"] as const).flatMap((window) => {
+    const value = observation.limits?.[window];
+    return value && value.usedPercent >= 100 ? [{ window, resetAt: value.resetsAt }] : [];
+  });
+  if (!exhausted.length) return null;
+  const activeExhausted = exhausted.filter((item) => item.resetAt === null || item.resetAt * 1000 > now);
+  if (!activeExhausted.length) return null;
+  const governing = activeExhausted
+    .filter((item) => item.resetAt !== null && item.resetAt * 1000 > now)
+    .sort((left, right) => right.resetAt! - left.resetAt!)[0]
+    ?? activeExhausted.find((item) => item.window === remaining.window)
+    ?? activeExhausted[0]!;
+  return {
+    source: "account",
+    accountId: observation.accountId,
+    window: governing.window,
+    resetAt: governing.resetAt !== null && governing.resetAt * 1000 > now ? governing.resetAt : null,
+  };
+}
+
+function mergeRateLimits(
+  pane: RateLimitState | null | undefined,
+  structured: RateLimitState | null,
+  accountId: string | null,
+): RateLimitState | null {
+  if (!pane) return structured;
+  return {
+    source: "pane",
+    accountId: accountId ?? pane.accountId,
+    window: structured?.window ?? pane.window,
+    resetAt: structured?.resetAt ?? pane.resetAt,
+  };
+}
+
+/** Pure projection over the scanner and registry snapshots. The returned
+    flow block carries the stable conversation seam for successor reseating. */
+export function projectRateLimitReadModel(
+  files: FileEntry[],
+  flows: Flow[],
+  snapshot: RateLimitProjectionSnapshot,
+  now = Date.now(),
+): { files: FileEntry[]; flows: Flow[] } {
+  const hosts = new Map<string, { conversationId: string; engine: HostedEngine; accountId: string | null }>();
+  for (const conversation of Object.values(snapshot.conversations)) {
+    for (const generation of conversation.generations) {
+      hosts.set(generation.path, {
+        conversationId: conversation.id,
+        engine: conversation.engine,
+        accountId: generation.accountId,
+      });
+    }
+  }
+
+  const projectedFiles = files.map((file) => {
+    const host = hosts.get(file.path);
+    const observation = host?.accountId
+      ? snapshot.quotaObservations[host.engine][host.accountId]
+      : undefined;
+    const structured = file.proc === "running"
+      ? rateLimitFromQuotaObservation(observation, now)
+      : null;
+    const rateLimit = mergeRateLimits(file.rateLimit, structured, host?.accountId ?? null);
+    return {
+      ...file,
+      conversationId: file.conversationId ?? host?.conversationId,
+      rateLimit,
+    };
+  });
+  const filesByPath = new Map(projectedFiles.map((file) => [file.path, file]));
+  const implementerStates = new Set<Flow["state"]>(["waiting_ready", "relaying", "fixing"]);
+  const projectedFlows = flows.map((flow) => {
+    const implementer = filesByPath.get(flow.implementerPath);
+    const rateLimit = implementer?.rateLimit;
+    if (!rateLimit || !implementerStates.has(flow.state)) {
+      return flow.block ? { ...flow, block: null } : flow;
+    }
+    return {
+      ...flow,
+      block: {
+        reason: "rate_limited" as const,
+        conversationId: implementer.conversationId ?? flow.implementerConversationId ?? null,
+        accountId: rateLimit.accountId,
+        resetAt: rateLimit.resetAt,
+      },
+    };
+  });
+  return { files: projectedFiles, flows: projectedFlows };
+}

--- a/src/lib/rateLimit.ts
+++ b/src/lib/rateLimit.ts
@@ -39,11 +39,8 @@ export function rateLimitFromQuotaObservation(
   if (!exhausted.length) return null;
   const activeExhausted = exhausted.filter((item) => item.resetAt === null || item.resetAt * 1000 > now);
   if (!activeExhausted.length) return null;
-  const governing = activeExhausted
-    .filter((item) => item.resetAt !== null && item.resetAt * 1000 > now)
-    .sort((left, right) => right.resetAt! - left.resetAt!)[0]
-    ?? activeExhausted.find((item) => item.window === remaining.window)
-    ?? activeExhausted[0]!;
+  const governing = activeExhausted.find((item) => item.resetAt === null)
+    ?? activeExhausted.sort((left, right) => right.resetAt! - left.resetAt!)[0]!;
   return {
     source: "account",
     accountId: observation.accountId,

--- a/src/lib/scanner/index.ts
+++ b/src/lib/scanner/index.ts
@@ -119,6 +119,7 @@ async function listFilesInternal(
     entry.pendingQuestion = pending && entry.pid !== null ? { ...pending, paneTarget: await resolveTarget(entry.pid) } : pending;
     const probe = await waitingInputProbe(entry);
     entry.waitingInput = probe.waiting;
+    entry.rateLimit = probe.rateLimit;
     /* A stalled transcript whose pane sits at a plain composer was interrupted
        mid-turn (Esc leaves the turn open in the jsonl): the agent is idle, not
        blocked, so it must not wear the «interrupted or waiting for permission» state. */

--- a/src/lib/scanner/observe.ts
+++ b/src/lib/scanner/observe.ts
@@ -41,7 +41,7 @@ export async function observeFiles(): Promise<FileEntry[]> {
   await each(entries, async (entry) => {
     const pending = pendingQuestionFor(entry);
     entry.pendingQuestion = pending && entry.pid !== null ? { ...pending, paneTarget: await resolveTarget(entry.pid) } : pending;
-    const probe = await waitingInputProbe(entry); entry.waitingInput = probe.waiting;
+    const probe = await waitingInputProbe(entry); entry.waitingInput = probe.waiting; entry.rateLimit = probe.rateLimit;
     if (probe.atComposer && entry.activity === "stalled") { entry.activity = Date.now() / 1000 - entry.mtime < 900 ? "recent" : "idle"; entry.activityReason = "pane_at_composer"; }
     entry.plan = planFor(entry); entry.goal = goalFor(entry); entry.ctx = ctxFor(entry);
   });

--- a/src/lib/scanner/waitingInput.test.ts
+++ b/src/lib/scanner/waitingInput.test.ts
@@ -1,0 +1,48 @@
+import { expect, test } from "bun:test";
+
+import type { FileEntry } from "@/lib/types";
+
+import { waitingInputProbe } from "./waitingInput";
+
+const NOW = new Date(2026, 6, 10, 18, 0, 0).getTime();
+
+function entry(): FileEntry {
+  return {
+    path: "/sessions/fresh-limit.jsonl",
+    root: "codex-sessions",
+    name: "fresh-limit.jsonl",
+    project: "demo",
+    title: "Fresh limit",
+    engine: "codex",
+    kind: "session",
+    fmt: "codex",
+    parent: null,
+    mtime: NOW / 1000 - 16,
+    size: 10,
+    activity: "live",
+    proc: "running",
+    pid: 42,
+    model: null,
+    pendingQuestion: null,
+    waitingInput: null,
+  };
+}
+
+test("a live usage wall bypasses the stable-screen delay", async () => {
+  const result = await waitingInputProbe(entry(), {
+    now: () => NOW,
+    resolveTarget: async () => "agents:3.0",
+    paneScreen: async () => "You've hit your usage limit\nTry again at 7:55 PM.",
+  });
+
+  expect(result).toEqual({
+    waiting: null,
+    rateLimit: {
+      source: "pane",
+      accountId: null,
+      window: null,
+      resetAt: new Date(2026, 6, 10, 19, 55, 0).getTime() / 1000,
+    },
+    atComposer: false,
+  });
+});

--- a/src/lib/scanner/waitingInput.ts
+++ b/src/lib/scanner/waitingInput.ts
@@ -1,7 +1,7 @@
-import { parseScreenMenu, screenAtIdleComposer, screenWaitsForInput } from "@/lib/status";
+import { detectLiveRateLimit, parseScreenMenu, screenAtIdleComposer, screenWaitsForInput } from "@/lib/status";
 import { paneScreen, resolveTarget } from "@/lib/tmux";
 
-import type { FileEntry, WaitingInput } from "../types";
+import type { FileEntry, RateLimitState, WaitingInput } from "../types";
 
 const QUIET_SECONDS = 15;
 const STABLE_MS = 15_000;
@@ -28,16 +28,29 @@ function screenBlock(screen: string): string {
 
 export interface WaitingProbe {
   waiting: WaitingInput | null;
+  rateLimit: RateLimitState | null;
   /** The pane was read and shows a plain composer, no dialog: the agent is
       parked at its prompt, so a still-open turn in the transcript is an
       interrupt artifact rather than a wait on the user. */
   atComposer: boolean;
 }
 
-const NO_PROBE: WaitingProbe = { waiting: null, atComposer: false };
+const NO_PROBE: WaitingProbe = { waiting: null, rateLimit: null, atComposer: false };
 
-export async function waitingInputProbe(entry: FileEntry): Promise<WaitingProbe> {
-  const now = Date.now();
+export interface WaitingInputProbeDeps {
+  now(): number;
+  resolveTarget(pid: number): Promise<string | null>;
+  paneScreen(target: string): Promise<string>;
+}
+
+const DEFAULT_DEPS: WaitingInputProbeDeps = {
+  now: () => Date.now(),
+  resolveTarget,
+  paneScreen,
+};
+
+export async function waitingInputProbe(entry: FileEntry, deps: WaitingInputProbeDeps = DEFAULT_DEPS): Promise<WaitingProbe> {
+  const now = deps.now();
   for (const [key, value] of probes) {
     if (now - value.at > PROBE_TTL_MS) probes.delete(key);
   }
@@ -45,17 +58,26 @@ export async function waitingInputProbe(entry: FileEntry): Promise<WaitingProbe>
     probes.delete(entry.path);
     return NO_PROBE;
   }
-  if (Date.now() / 1000 - entry.mtime < QUIET_SECONDS) return NO_PROBE;
-  const target = await resolveTarget(entry.pid);
+  if (now / 1000 - entry.mtime < QUIET_SECONDS) return NO_PROBE;
+  const target = await deps.resolveTarget(entry.pid);
   if (target === null) return NO_PROBE;
-  const screen = await paneScreen(target);
+  const screen = await deps.paneScreen(target);
+  const liveRateLimit = detectLiveRateLimit(screen, now / 1000);
+  if (liveRateLimit) {
+    probes.delete(entry.path);
+    return {
+      waiting: null,
+      rateLimit: { source: "pane", accountId: null, window: null, resetAt: liveRateLimit.resetAt },
+      atComposer: false,
+    };
+  }
   if (!looksPromptLike(screen)) {
     probes.delete(entry.path);
     /* Only a positively idle composer counts: a quiet busy screen (long
        command, streamed output, no menu) must keep its stalled verdict, or
        the turn-open guard downstream (activity, STAGE_DONE detection) loses
        its meaning. */
-    return { waiting: null, atComposer: screenAtIdleComposer(screen) };
+    return { waiting: null, rateLimit: null, atComposer: screenAtIdleComposer(screen) };
   }
   const previous = probes.get(entry.path);
   if (!previous || previous.screen !== screen) {
@@ -66,6 +88,7 @@ export async function waitingInputProbe(entry: FileEntry): Promise<WaitingProbe>
   if (now / 1000 - previous.since < STABLE_MS / 1000) return NO_PROBE;
   return {
     waiting: { since: previous.since, screenTail: screenBlock(screen), target, menu: parseScreenMenu(screen) },
+    rateLimit: null,
     atComposer: false,
   };
 }

--- a/src/lib/status.test.ts
+++ b/src/lib/status.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "bun:test";
 
-import { screenAtIdleComposer } from "./status";
+import { detectLiveRateLimit, screenAtIdleComposer } from "./status";
 
 const IDLE_CLAUDE = ["● Done. The tests pass.", "", "❯ ", "  ? for shortcuts"].join("\n");
 
@@ -25,4 +25,27 @@ test("quiet streamed output without a composer never reads as at-composer", () =
 
 test("a waiting menu is a dialog, never an idle composer", () => {
   expect(screenAtIdleComposer(MENU_SCREEN)).toBe(false);
+});
+
+test("a current Codex usage wall exposes its reset timestamp", () => {
+  const now = new Date(2026, 6, 10, 18, 0, 0).getTime() / 1000;
+  const resetAt = new Date(2026, 6, 10, 19, 55, 0).getTime() / 1000;
+  const screen = [
+    "You've hit your usage limit",
+    "You can keep using Codex when your limit resets. Try again at 7:55 PM.",
+  ].join("\n");
+
+  expect(detectLiveRateLimit(screen, now)).toEqual({ resetAt });
+});
+
+test("historical usage prose above a ready composer stays clear", () => {
+  const screen = [
+    "You've hit your usage limit. Try again at 7:55 PM.",
+    "The previous attempt was rate-limited, so I resumed later.",
+    "",
+    "› ",
+    "  Context 37% used",
+  ].join("\n");
+
+  expect(detectLiveRateLimit(screen, Date.now() / 1000)).toBeNull();
 });

--- a/src/lib/status.ts
+++ b/src/lib/status.ts
@@ -105,6 +105,33 @@ export function detectBlockingGate(screen: string): BlockingGate | null {
   return null;
 }
 
+function nextLocalClockTime(now: number, hour: number, minute: number): number | null {
+  if (!Number.isFinite(now) || hour < 0 || hour > 23 || minute < 0 || minute > 59) return null;
+  const current = new Date(now * 1000);
+  const reset = new Date(current);
+  reset.setHours(hour, minute, 0, 0);
+  if (reset.getTime() <= current.getTime()) reset.setDate(reset.getDate() + 1);
+  return Math.floor(reset.getTime() / 1000);
+}
+
+function resetTimeFromRateLimitScreen(screen: string, now: number): number | null {
+  const match = /(?:try again|resets?)(?:\s+\w+){0,4}\s+(?:at\s+)?(\d{1,2})(?::(\d{2}))?\s*([ap])\.?m\.?/i.exec(screen);
+  if (!match) return null;
+  const rawHour = Number(match[1]);
+  const minute = Number(match[2] ?? "0");
+  if (rawHour < 1 || rawHour > 12) return null;
+  const hour = rawHour % 12 + (match[3]?.toLowerCase() === "p" ? 12 : 0);
+  return nextLocalClockTime(now, hour, minute);
+}
+
+/** Typed view of a current full-screen quota wall. Region-aware gate logic
+    preserves ready composers whose transcript happens to discuss limits. */
+export function detectLiveRateLimit(screen: string, now = Date.now() / 1000): { resetAt: number | null } | null {
+  if (detectBlockingGate(screen) !== "rate_limit") return null;
+  const tail = screen.split("\n").slice(-14).join("\n");
+  return { resetAt: resetTimeFromRateLimitScreen(tail, now) };
+}
+
 /* Prompt shapes of the waiting-input scrape fallback: a numbered option menu
    under a highlight cursor is how both CLIs draw questions the viewer has no
    structured record for. Anchored to the line start — menu options always

--- a/src/lib/tasks/reconcile.ts
+++ b/src/lib/tasks/reconcile.ts
@@ -12,6 +12,7 @@ export interface ReconcileEnv {
   pathForPanePid?: (panePid: number, files: FileEntry[]) => string | null;
   panePidAlive?: (panePid: number) => boolean;
   conversationIdForPath?: (pathname: string) => string | null;
+  canonicalConversationId?: (conversationId: string) => string | null;
   pathForConversationId?: (conversationId: string) => string | null;
   now?: () => string;
 }
@@ -66,6 +67,13 @@ export function pathForPanePid(
 function reconcileAssignment(assignment: TaskAssignment, files: FileEntry[], env: ReconcileEnv): { assignment: TaskAssignment; dirty: boolean } {
   let current = assignment;
   let dirty = false;
+  if (current.conversationId) {
+    const canonicalId = env.canonicalConversationId?.(current.conversationId) ?? current.conversationId;
+    if (canonicalId !== current.conversationId) {
+      current = { ...current, conversationId: canonicalId };
+      dirty = true;
+    }
+  }
   if (current.path && !current.conversationId) {
     const conversationId = env.conversationIdForPath?.(current.path)
       ?? files.find((file) => file.path === current.path)?.conversationId

--- a/src/lib/tasks/tasks.test.ts
+++ b/src/lib/tasks/tasks.test.ts
@@ -226,6 +226,23 @@ describe("task reconciliation", () => {
     });
   });
 
+  test("rewrites an escaped provisional conversation id through its durable alias", () => {
+    const tasks = [task({ assignments: [{ path: "/artifact", conversationId: "conversation_provisional", panePid: null, state: "handoff", error: null, at: "old" }] })];
+    const result = reconcileTasks([], tasks, {
+      now: () => "new",
+      canonicalConversationId: (conversationId) => conversationId === "conversation_provisional" ? "conversation_canonical" : conversationId,
+      pathForConversationId: () => "/artifact",
+    });
+
+    expect(result.dirty).toBe(true);
+    expect(result.tasks[0]?.assignments[0]).toMatchObject({
+      path: "/artifact",
+      conversationId: "conversation_canonical",
+      state: "handoff",
+      at: "old",
+    });
+  });
+
   test("fills codex spawn path from pane attribution", () => {
     const tasks = [task({ assignments: [{ path: null, panePid: 42, state: "spawning", error: null, at: "old" }] })];
     const result = reconcileTasks([], tasks, {

--- a/src/lib/tmux.ts
+++ b/src/lib/tmux.ts
@@ -380,6 +380,25 @@ export async function verifyTmuxHostEvidence(host: TmuxHostEvidence): Promise<bo
   return ancestryDistance(host.agent.pid, host.panePid.pid, readPpid) !== null;
 }
 
+/** Closes a pane after full host verification and an in-command server/pane fence. */
+export async function killTmuxHostIfMatches(host: TmuxHostEvidence): Promise<boolean> {
+  if (!await verifyTmuxHostEvidence(host)) return false;
+  const endpoint = createTmuxEndpointDescriptor(host.endpoint, process.getuid?.() ?? 0);
+  const condition = `#{&&:#{==:#{pid},${host.server.pid}},#{&&:#{==:#{pane_id},${host.paneId}},#{==:#{pane_pid},${host.panePid.pid}}}}`;
+  const mismatch = `llv-host-mismatch-${crypto.randomUUID()}`;
+  const result = await runTmux([
+    "if-shell",
+    "-t",
+    host.paneId,
+    "-F",
+    condition,
+    `kill-pane -t ${host.paneId}`,
+    `display-message -p ${mismatch}`,
+  ], undefined, endpoint);
+  if (result.code !== 0) return false;
+  return !result.stdout.includes(mismatch);
+}
+
 /** pane_pid → pane map from `tmux list-panes -a`, memoised for a few seconds.
     `fresh` bypasses the memo — a rebuild right after a kill must observe the
     pane's absence immediately, or the killed session ghosts back in. */
@@ -978,6 +997,18 @@ export async function paneInfo(paneId: string): Promise<PaneInfo | null> {
 /** Drops a transcript's resume-window record, e.g. after its pane was killed. */
 export function forgetResumePane(transcriptPath: string): void {
   if (loadResumePanes().delete(transcriptPath)) persistResumePanes();
+}
+
+/** Drops a resume record only while it still identifies the pane being retired. */
+export async function forgetResumePaneIfMatches(transcriptPath: string, host: TmuxHostEvidence): Promise<void> {
+  const endpoint = createTmuxEndpointDescriptor(host.endpoint, process.getuid?.() ?? 0);
+  const server = await tmuxServerReference(endpoint);
+  if (!server || !sameProcess(host.server, server.pid, server.startIdentity)) return;
+  const panes = resumePanesForServer(server.pid);
+  const current = panes.get(transcriptPath);
+  if (current?.paneId !== host.paneId || current.panePid !== host.panePid.pid) return;
+  panes.delete(transcriptPath);
+  persistResumePanes();
 }
 
 const SPAWN_READY_TIMEOUT_MS = 60_000;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -12,6 +12,16 @@ export type Engine = "codex" | "claude" | "shell";
 export type Activity = "live" | "recent" | "stalled" | "idle";
 export type Fmt = "codex" | "claude" | "plain";
 
+/** Current quota wall affecting a hosted conversation. Account provenance
+    joins the existing conversation identity at the read-model boundary. */
+export interface RateLimitState {
+  source: "pane" | "account";
+  accountId: string | null;
+  window: "session" | "weekly" | null;
+  /** Unix seconds when work can resume, when the engine reports it. */
+  resetAt: number | null;
+}
+
 /** One sidebar entry returned by GET /api/files. */
 export interface FileEntry {
   path: string;
@@ -57,6 +67,8 @@ export interface FileEntry {
   goal?: AgentGoal | null;
   /** Best-effort TUI scrape fallback for prompts without a transcript protocol. */
   waitingInput: WaitingInput | null;
+  /** Live pane wall or fresh structured account exhaustion. */
+  rateLimit?: RateLimitState | null;
   /** claude-tasks only: recovered originating Bash command ("" if not found). */
   cmd?: string;
   /** claude-tasks only: the Bash tool `description` field. */


### PR DESCRIPTION
## Summary

- remap committed successor paths onto predecessor board placement
- retain one stable conversation owner for source forks, target copies, and later generations
- recover board placement, held deliveries, and successor cleanup across restarts
- journal Codex successor operations so fork and copy artifacts recover without duplicate cards
- make account preview and commit use the controller inventory snapshot, removing transcript scans from UI requests
- preserve revision fencing while reducing measured local preview latency from a production timeout above 30 seconds to 9-15 milliseconds

## Root cause

Account preview and commit each launched a complete transcript scan and registry reconciliation. That duplicated expensive work, created revision races, and left the UI waiting. Codex migration also creates a source-account fork and target-account copy before registry succession commits. Scanner observations could surface those artifacts as fresh roots because board state lacked durable path continuity mapping.

## Validation

- bun test: 1185 passed, 0 failed
- ESLint: clean
- TypeScript: completed without diagnostics
- Next.js production build: completed
- focused mass-drain regression keeps a two-card board stable through 51 migrated conversations
- full-diff local review against current main found no remaining high-confidence findings across correctness, tests, comments, error handling, types, or simplification

Fixes #86
