### PR TITLE
fix(docker): deterministic runtime image permissions across worktrees (#76)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,14 @@ RUN env -u __NEXT_PRIVATE_STANDALONE_CONFIG \
         -u __NEXT_PRIVATE_BUILD_WORKER \
         bun run build
 
+# COPY preserves source file modes while resetting ownership to root:root, so a
+# umask-077 checkout (tsconfig.json at 0600) produces runtime files the
+# UID-1000 viewer user cannot read and `next start` crashes (#76). Normalize
+# here — the runtime stage inherits these modes via COPY --from — so image
+# permissions derive from the Dockerfile alone, identically for every
+# worktree: dirs 755, files 644, anything already executable 755.
+RUN chmod -R u=rwX,go=rX /app
+
 FROM node:22.16.0-bookworm-slim AS runtime
 WORKDIR /app
 ENV NODE_ENV=production \
@@ -181,11 +189,23 @@ COPY --from=build /app/src ./src
 COPY --from=build /app/scripts/whisper_transcribe.py ./scripts/whisper_transcribe.py
 COPY --from=build /app/node_modules ./node_modules
 
-# COPY preserves source-context modes. Agent worktrees are created with umask
-# 077, which once shipped root-owned 0600 files into an image that runs as uid
-# 1000 and crash-looped on EACCES (/app/tsconfig.json). Normalize read bits so
-# context perms can never take the runtime down again.
-RUN chmod -R a+rX /app
+# Permission gate: the compose service runs this image as a non-root user
+# (default 1000:1000 — the same UID as `node` here), so every runtime file
+# must be readable and every directory traversable by that identity. A bad
+# checkout must fail the image build, never the production health gate. The
+# build-stage normalization above makes this hold for every worktree umask;
+# this gate replaces the emergency runtime-stage `chmod -R a+rX /app`, which
+# duplicated all of /app into an extra image layer.
+RUN <<'EOF'
+set -eu
+bad=$(/usr/sbin/runuser -u node -- find /app \( -type d ! -executable \) -o \( ! -type l ! -readable \) 2>&1 | head -20 || true)
+if [ -n "$bad" ]; then
+  echo "runtime files not accessible to UID 1000:" >&2
+  printf '%s\n' "$bad" >&2
+  exit 1
+fi
+/usr/sbin/runuser -u node -- sh -c 'cat /app/tsconfig.json /app/next.config.ts /app/package.json > /dev/null'
+EOF
 
 EXPOSE 8898
 CMD ["sh", "-c", "exec node_modules/.bin/next start --port ${PORT:-8898} --hostname ${HOSTNAME:-127.0.0.1}"]

--- a/scripts/dockerfile-permissions.test.ts
+++ b/scripts/dockerfile-permissions.test.ts
@@ -1,0 +1,78 @@
+// Regression guard for #76: a umask-077 checkout tracks config files as 0600,
+// Docker COPY preserves that mode while resetting ownership to root:root, and
+// the UID-1000 runtime user then cannot read /app/tsconfig.json — `next start`
+// crashes only once the image reaches the production health gate. The
+// Dockerfile must (a) normalize modes in the build stage before the runtime
+// stage copies them and (b) verify readability as the non-root runtime
+// identity after the last COPY, so a bad checkout fails the build instead.
+import { describe, expect, test } from "bun:test";
+import { execFileSync } from "node:child_process";
+import {
+  chmodSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const dockerfile = readFileSync(join(import.meta.dir, "..", "Dockerfile"), "utf8");
+const runtimeStageStart = dockerfile.indexOf("AS runtime");
+const buildStage = dockerfile.slice(dockerfile.indexOf("AS build"), runtimeStageStart);
+const runtimeStage = dockerfile.slice(runtimeStageStart);
+
+const normalizeMatch = buildStage.match(/^RUN chmod -R (\S+) \/app$/m);
+
+const mode = (path: string) => (statSync(path).mode & 0o777).toString(8);
+
+describe("runtime image permission determinism (#76)", () => {
+  test("build stage normalizes /app modes after the build, before runtime COPY --from", () => {
+    expect(runtimeStageStart).toBeGreaterThan(-1);
+    expect(normalizeMatch).not.toBeNull();
+    const buildIndex = buildStage.indexOf("bun run build");
+    expect(buildIndex).toBeGreaterThan(-1);
+    expect(buildStage.indexOf(normalizeMatch![0])).toBeGreaterThan(buildIndex);
+  });
+
+  test("the normalization spec repairs a umask-077 checkout to deterministic modes", () => {
+    const spec = normalizeMatch![1];
+    const root = mkdtempSync(join(tmpdir(), "llv-perm-"));
+    try {
+      const dir = join(root, "src");
+      mkdirSync(dir);
+      writeFileSync(join(root, "tsconfig.json"), "{}\n");
+      writeFileSync(join(dir, "page.tsx"), "export {};\n");
+      writeFileSync(join(root, "cli.mjs"), "#!/usr/bin/env node\n");
+      // umask 077: non-executables land 0600, executables and dirs 0700
+      chmodSync(join(root, "tsconfig.json"), 0o600);
+      chmodSync(join(dir, "page.tsx"), 0o600);
+      chmodSync(join(root, "cli.mjs"), 0o700);
+      chmodSync(dir, 0o700);
+
+      execFileSync("chmod", ["-R", spec, root]);
+
+      expect(mode(join(root, "tsconfig.json"))).toBe("644");
+      expect(mode(join(dir, "page.tsx"))).toBe("644");
+      expect(mode(join(root, "cli.mjs"))).toBe("755");
+      expect(mode(dir)).toBe("755");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("runtime stage gates readability as the non-root user after the last COPY", () => {
+    const gateIndex = runtimeStage.indexOf("runuser -u node");
+    const lastCopyIndex = runtimeStage.lastIndexOf("COPY --from=build");
+    expect(gateIndex).toBeGreaterThan(-1);
+    expect(lastCopyIndex).toBeGreaterThan(-1);
+    expect(gateIndex).toBeGreaterThan(lastCopyIndex);
+    // The gate must sweep for unreadable files and untraversable directories,
+    // and prove the exact files from the incident open as UID 1000.
+    expect(runtimeStage).toContain("! -readable");
+    expect(runtimeStage).toContain("-type d ! -executable");
+    expect(runtimeStage).toContain("cat /app/tsconfig.json /app/next.config.ts");
+  });
+});

--- a/spec.md
+++ b/spec.md
@@ -1,21 +1,56 @@
-# Issue #86: Preserve board continuity across account migration
+# Task: Deterministic runtime image permissions across worktrees (issue #76)
 
-## Task statement
+## Statement
 
-Preserve a conversation's durable board identity, placement, delivery state, and migration history while account migration creates source forks, target copies, successor generations, restarts, and partial repairs. Ensure concurrent processes and recovery scans converge on one stable conversation owner without duplicate board cards.
+The #74 integration image crashed the viewer at the production health gate:
+the integration checkout was created under umask 077, so tracked config files
+sat at mode 0600. Docker `COPY` preserves the source mode while resetting
+ownership to `root:root`, and the compose service runs as UID 1000, so Next
+could not read `/app/tsconfig.json` while loading `next.config.ts`. Root
+restored the prior image manually; the external tmux supervisor stayed
+healthy throughout.
+
+Make runtime-image permissions deterministic across worktrees and host
+umasks, verify them at build time as the real non-root runtime identity, and
+add a regression test. Branch `fix/docker-runtime-permissions`, PR #104,
+rebased onto current main (which carried an emergency runtime-stage
+`chmod -R a+rX /app` hotfix this change supersedes).
 
 ## Acceptance criteria
 
-- AC1: A committed migration successor inherits the predecessor conversation's durable board placement.
-- AC2: Source forks, target copies, and later successor generations converge on one stable conversation owner.
-- AC3: Board placement and held deliveries recover after controller restarts and partial migration repairs.
-- AC4: Codex fork and copy operations are journaled so recovery can identify artifacts and avoid duplicate cards.
-- AC5: Concurrent board mutations are serialized and durably persisted across processes.
-- AC6: Migration artifacts appear as archived history in the files read model.
-- AC7: Deleted or repaired migration paths retain continuity through durable remapping.
-- AC8: Provider operations and repair flows remain idempotent under retries, crashes, and concurrent scans.
-- AC9: Existing behavior remains covered by the full test suite.
-- AC10: `bun test` passes.
-- AC11: `bunx tsc --noEmit` completes without diagnostics.
-- AC12: Account preview reads the controller inventory without scanning transcripts or rewriting the registry.
-- AC13: Revision-fenced migration commit performs no second inventory scan in the UI request path.
+Code-merge acceptance (demonstrable from this branch):
+
+- AC1: Image file permissions derive from the Dockerfile alone — a umask-077
+  checkout (0600 `tsconfig.json`/`next.config.ts`) produces the same runtime
+  modes as a umask-022 checkout (dirs 755, files 644, executables 755).
+- AC2: All runtime files are readable and all directories traversable by the
+  configured non-root viewer user (compose default `1000:1000`).
+- AC3: Executable files retain their execution bits (mode spec uses `X`).
+- AC4: No runtime write access is granted beyond the existing contract
+  (owner stays root; group/other receive no write bits).
+- AC5: Image verification runs as the actual non-root runtime identity at
+  build time and fails the build — before any deployment — on unreadable
+  config or application files, including the exact incident files.
+- AC6: A regression test under `bun test` guards both mechanisms: the
+  build-stage normalization (spec extracted from the Dockerfile, applied to a
+  umask-077 fixture, asserting deterministic 644/755/755) and the runtime
+  gate's presence after the last `COPY --from=build`.
+- AC7: The emergency runtime-stage `chmod -R a+rX /app` hotfix is removed
+  (it duplicated all of /app into an extra image layer); its guarantee is
+  preserved by AC1 + AC5.
+- AC8: `bun test` and `bunx tsc --noEmit` pass; the change's own verification
+  (scratch-tagged builds, throwaway containers) never touches the production
+  tag `agent-log-viewer:node22`, the running viewer, or the external tmux
+  supervisor.
+
+Release (cutover) acceptance — required by issue #76, executed by the
+operator via `scripts/rebuild.sh` when this image is deployed; the issue must
+not be considered fully accepted until these are demonstrated in production:
+
+- AC9: The production health check (page HTTP 200) and the CSS asset check
+  (HTML-referenced stylesheet HTTP 200) pass after container replacement on
+  127.0.0.1:8898.
+- AC10: External tmux ownership remains active throughout the cutover —
+  `agent-log-viewer-legacy-tmux.service` stays up and agent sessions stay
+  reachable (rebuild.sh already refuses a viewer-only rebuild when the
+  supervisor is inactive or the migration marker is absent).


### PR DESCRIPTION
## Summary

Part of #76 (do not auto-close: the issue's release acceptance is demonstrated at cutover, below).

A umask-077 worktree tracks config files as 0600; docker `COPY` preserves that mode while resetting ownership to `root:root`, so the UID-1000 viewer could not read `/app/tsconfig.json` and `next start` crashed at the production health gate (the #74 integration incident).

Two mechanisms, replacing the emergency runtime-stage `chmod -R a+rX /app` hotfix:

- **Build-stage normalization** — `chmod -R u=rwX,go=rX /app` after `bun run build`. The runtime stage inherits these modes via `COPY --from`, so image permissions derive from the Dockerfile alone, identically for every worktree umask: dirs 755, files 644, anything already executable 755. No write bits are granted beyond the existing contract (group/other get none; owner is root, runtime user is 1000).
- **Build-time permission gate** — after the last runtime-stage `COPY`, a `runuser -u node` sweep fails the build on any file unreadable or directory untraversable by UID 1000, and proves the exact incident files (`tsconfig.json`, `next.config.ts`, `package.json`) open as the non-root identity. A bad checkout now fails the image build, never the production health gate. Dropping the hotfix also removes the layer that duplicated all of `/app`.

## Regression test

`scripts/dockerfile-permissions.test.ts` (runs under `bun test`):
- asserts the normalization sits after the build and before the runtime stage;
- applies the exact mode spec extracted from the Dockerfile to a umask-077-shaped fixture tree (0600 file, 0700 dir, 0700 executable) and asserts deterministic 644/755/755 results;
- asserts the runtime gate exists after the last `COPY --from=build` and covers readability, directory traversal, and the incident files.

## Verification (code-merge acceptance)

- `bun test`: 1188 pass, 0 fail; `bunx tsc --noEmit` clean (branch rebased onto current main).
- End-to-end: with `tsconfig.json`/`next.config.ts` deliberately chmod-ed to 0600 (the incident checkout shape), `docker build` under a scratch tag **succeeds**, and in-image both files are `root:root 0644`, readable as `--user 1000:1000` (`fs.accessSync` R_OK passes).
- Gate negative check: chmod-ing a file to 0600 inside the built image makes the gate's `find` expression flag it, confirming the sweep catches the incident class if normalization were ever removed.
- Exec bits preserved via `X`; no new runtime write access; verification runs as the actual non-root identity at build time, before any deployment; prod tag `agent-log-viewer:node22`, the running viewer, and the external tmux supervisor were not touched by this branch's verification.

## Release (cutover) acceptance — pending, operator-executed

Issue #76 closes only after these are demonstrated in production via `scripts/rebuild.sh` when this image is deployed:

- [ ] Production health check (page HTTP 200) and CSS asset check (HTML-referenced stylesheet HTTP 200) pass after container replacement on 127.0.0.1:8898.
- [ ] External tmux ownership remains active throughout the cutover (`agent-log-viewer-legacy-tmux.service` stays up; agent sessions stay reachable). `rebuild.sh` already refuses a viewer-only rebuild when the supervisor is inactive or the migration marker is absent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)