### PR TITLE
fix(migration): classify post-dispatch fork protocol failures as unknown outcome

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -4,6 +4,8 @@
 
 Preserve a conversation's durable board identity, placement, delivery state, and migration history while account migration creates source forks, target copies, successor generations, restarts, and partial repairs. Ensure concurrent processes and recovery scans converge on one stable conversation owner without duplicate board cards.
 
+Harden recovery after partial successor creation: definite Codex fork failures must remain retryable, uncertain transport outcomes must retain ambiguity, and Claude tmux cleanup must distinguish an absent original host from an endpoint whose state cannot be verified.
+
 ## Acceptance criteria
 
 - AC1: A committed migration successor inherits the predecessor conversation's durable board placement.
@@ -19,3 +21,7 @@ Preserve a conversation's durable board identity, placement, delivery state, and
 - AC11: `bunx tsc --noEmit` completes without diagnostics.
 - AC12: Account preview reads the controller inventory without scanning transcripts or rewriting the registry.
 - AC13: Revision-fenced migration commit performs no second inventory scan in the UI request path.
+- AC14: A definite pre-dispatch or server-rejected Codex fork failure clears the pending request marker and retries the fork on the next attempt.
+- AC15: A Codex fork failure with an uncertain transport outcome preserves the pending request marker and blocks duplicate dispatch until artifact recovery resolves it.
+- AC16: Claude cleanup treats a missing pane, replaced pane identity, or restarted original tmux server as completed cleanup.
+- AC17: Claude cleanup remains pending when its tmux endpoint cannot be queried or returns malformed evidence.

--- a/src/lib/accounts/codexAppServer.test.ts
+++ b/src/lib/accounts/codexAppServer.test.ts
@@ -186,6 +186,25 @@ test("successor thread methods use the structured fork, resume, read, name, and 
   client.close();
 });
 
+test("post-dispatch fork protocol failures have an unknown outcome", async () => {
+  const malformedFrame = clientWith((fake, message) => {
+    if (message.method === "initialize") fake.respond(requestId(message), {});
+    if (message.method === "thread/fork") fake.output("not json\n");
+  });
+  const malformedClient = await malformedFrame.start();
+  const malformedError = await malformedClient.forkThread("source-1").catch((error: unknown) => error);
+  expect(malformedError).toMatchObject({ outcome: "unknown" });
+
+  const malformedPayload = clientWith((fake, message) => {
+    if (message.method === "initialize") fake.respond(requestId(message), {});
+    if (message.method === "thread/fork") fake.respond(requestId(message), { thread: { path: "/source/fork-1.jsonl" } });
+  });
+  const payloadClient = await malformedPayload.start();
+  const payloadError = await payloadClient.forkThread("source-1").catch((error: unknown) => error);
+  expect(payloadError).toMatchObject({ outcome: "unknown" });
+  payloadClient.close();
+});
+
 test("malformed output and protocol errors reject safely with redacted details", async () => {
   const malformed = clientWith((fake, message) => {
     if (message.method === "initialize") fake.output("not json\n");

--- a/src/lib/accounts/codexAppServer.ts
+++ b/src/lib/accounts/codexAppServer.ts
@@ -107,7 +107,7 @@ function spawnCodexAppServer(home: string): CodexAppServerChild {
 
 /** Errors crossing the app-server boundary are deliberately safe for logs and routes. */
 export class CodexAppServerError extends Error {
-  constructor(message: string) {
+  constructor(message: string, readonly outcome: "definite" | "unknown" = "definite") {
     super(redactAppServerDetail(message));
     this.name = "CodexAppServerError";
   }
@@ -183,7 +183,7 @@ export class CodexAppServerClient {
     child.stderr?.on("data", (chunk: Buffer | string) => {
       this.stderrTail = redactAppServerDetail((this.stderrTail + String(chunk)).slice(-2_000));
     });
-    child.on("error", (error) => this.fail(new CodexAppServerError(`Codex app-server child error: ${error.message}`)));
+    child.on("error", (error) => this.fail(new CodexAppServerError(`Codex app-server child error: ${error.message}`, "unknown")));
     child.on("close", (code, signal) => {
       this.reaped = true;
       if (this.shutdownTimer) {
@@ -192,7 +192,7 @@ export class CodexAppServerClient {
       }
       this.emitLifecycle({ type: "reaped" });
       const detail = this.stderrTail ? `: ${this.stderrTail}` : "";
-      if (!this.closed) this.fail(new CodexAppServerError(`Codex app-server exited (code ${code ?? "none"}, signal ${signal ?? "none"})${detail}`));
+      if (!this.closed) this.fail(new CodexAppServerError(`Codex app-server exited (code ${code ?? "none"}, signal ${signal ?? "none"})${detail}`, "unknown"));
     });
   }
 
@@ -334,7 +334,7 @@ export class CodexAppServerClient {
     this.closed = true;
     for (const pending of this.pending.values()) {
       this.clock.clearTimeout(pending.timeout);
-      pending.reject(new CodexAppServerError("Codex app-server client closed"));
+      pending.reject(new CodexAppServerError("Codex app-server client closed", "unknown"));
     }
     this.pending.clear();
     this.beginShutdown();
@@ -352,7 +352,7 @@ export class CodexAppServerClient {
       const timeout = this.clock.setTimeout(() => {
         if (!this.pending.has(id)) return;
         this.pending.delete(id);
-        const error = new CodexAppServerError(`Codex app-server request timed out: ${method}`);
+        const error = new CodexAppServerError(`Codex app-server request timed out: ${method}`, "unknown");
         reject(error);
         // A timed-out JSON-RPC id cannot be safely correlated with a later reply.
         // Reap the whole stdio transport so a late response cannot affect a new call.
@@ -410,7 +410,7 @@ export class CodexAppServerClient {
       parsed = parseAppServerMessage(message);
     } catch (error) {
       const detail = error instanceof CodexAppServerProtocolError ? error.message : "received malformed JSON-RPC";
-      this.fail(new CodexAppServerError(detail));
+      this.fail(new CodexAppServerError(detail, "unknown"));
       return;
     }
     this.lastInboundEnvelope = parsed.envelope;

--- a/src/lib/accounts/codexAppServer.ts
+++ b/src/lib/accounts/codexAppServer.ts
@@ -118,7 +118,7 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 }
 
 function protocolError(message: string): CodexAppServerError {
-  return new CodexAppServerError(`Codex app-server protocol error: ${message}`);
+  return new CodexAppServerError(`Codex app-server protocol error: ${message}`, "unknown");
 }
 
 function serverError(value: { code: number; message: string }): CodexAppServerError {

--- a/src/lib/accounts/migration/provider.test.ts
+++ b/src/lib/accounts/migration/provider.test.ts
@@ -241,6 +241,26 @@ test("Claude cleanup cancels only the pane PID recorded by the losing receipt", 
     now: () => "2026-07-10T12:00:00.000Z",
   });
   await expect(providerWithoutCleanup.cleanup(receipt)).rejects.toThrow("cleanup is still pending");
+
+  const absentProvider = new RegisteredSuccessorProvider({
+    accounts: { resolveSpawn: () => target, resolveTranscriptOwner: () => source },
+    startCodex: async () => { throw new Error("unexpected Codex client"); },
+    claudeStatus: async () => ({ loggedIn: true }),
+    spawnClaude: async () => ({ paneId: "%7", panePid: 77, host: claudeHost("%7", 77) }),
+    cancelClaude: async () => "absent",
+    now: () => "2026-07-10T12:00:00.000Z",
+  });
+  await absentProvider.cleanup(receipt);
+
+  const unverifiableProvider = new RegisteredSuccessorProvider({
+    accounts: { resolveSpawn: () => target, resolveTranscriptOwner: () => source },
+    startCodex: async () => { throw new Error("unexpected Codex client"); },
+    claudeStatus: async () => ({ loggedIn: true }),
+    spawnClaude: async () => ({ paneId: "%7", panePid: 77, host: claudeHost("%7", 77) }),
+    cancelClaude: async () => "unverifiable",
+    now: () => "2026-07-10T12:00:00.000Z",
+  });
+  await expect(unverifiableProvider.cleanup(receipt)).rejects.toThrow("cleanup is still pending");
 });
 
 test("concurrent Claude creates reuse one durable migration spawn receipt", async () => {

--- a/src/lib/accounts/migration/provider.ts
+++ b/src/lib/accounts/migration/provider.ts
@@ -665,8 +665,7 @@ export class RegisteredSuccessorProvider implements SuccessorProviderPort {
         try {
           created = await sourceClient.forkThread(sourceNativeId);
         } catch (error) {
-          const uncertain = error instanceof CodexAppServerError
-            && /request timed out|app-server exited|app-server child error|protocol error|malformed JSON-RPC/i.test(error.message);
+          const uncertain = error instanceof CodexAppServerError && error.outcome === "unknown";
           if (uncertain) throw new CodexForkOutcomeUnknownError(error.message);
           journal.forkRequestedAtMs = null;
           assertLeaseOwned();

--- a/src/lib/tmux.test.ts
+++ b/src/lib/tmux.test.ts
@@ -336,4 +336,25 @@ describe("cleanupTmuxHostIfMatches", () => {
       expect(result).toBe(expected);
     }
   });
+
+  test("retries when required server or pane process identity is unavailable", async () => {
+    for (const missingIdentityPid of [900, 100]) {
+      let calls = 0;
+      const result = await cleanupTmuxHostIfMatches(host, {
+        runTmux: async () => {
+          calls += 1;
+          if (calls === 1) return { code: 0, stdout: "900\n", stderr: "" };
+          return { code: 0, stdout: "900\t%11\t100\tagents:2.0\n", stderr: "" };
+        },
+        processIdentity: (pid) => {
+          if (pid === missingIdentityPid) return null;
+          if (pid === 900) return "900:one";
+          if (pid === 100) return "100:one";
+          return null;
+        },
+      });
+      expect(result).toBe("unverifiable");
+      expect(calls).toBe(missingIdentityPid === 900 ? 1 : 2);
+    }
+  });
 });

--- a/src/lib/tmux.test.ts
+++ b/src/lib/tmux.test.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import {
   cdCommandForCwd,
   classifyTmuxAttachSnapshot,
+  cleanupTmuxHostIfMatches,
   createSpawnWindow,
   createTmuxEndpointDescriptor,
   resolveTmuxAttach,
@@ -270,6 +271,24 @@ describe("resolveTmuxAttach", () => {
     ]);
   });
 
+  test("keeps pane probe transport and generic command failures unverifiable", async () => {
+    for (const paneProbe of [
+      async () => { throw new Error("socket read failed"); },
+      async () => ({ code: 1, stdout: "", stderr: "lost server\n" }),
+    ]) {
+      let calls = 0;
+      const result = await resolveTmuxAttach(expected, endpoint, {
+        runTmux: async () => {
+          calls += 1;
+          if (calls === 1) return { code: 0, stdout: "900\n", stderr: "" };
+          return paneProbe();
+        },
+        processIdentity: (pid) => (pid === 900 ? "900:one" : null),
+      });
+      expect(result).toEqual({ ok: false, reason: "tmux-unavailable" });
+    }
+  });
+
   test("reports server-restarted before resolving a pane missing from the new server", async () => {
     const calls: Array<{ args: string[]; endpointPath: string }> = [];
     const result = await resolveTmuxAttach(expected, endpoint, {
@@ -284,5 +303,37 @@ describe("resolveTmuxAttach", () => {
     expect(calls).toEqual([
       { args: ["display-message", "-p", "#{pid}"], endpointPath: endpoint.socketPath },
     ]);
+  });
+});
+
+describe("cleanupTmuxHostIfMatches", () => {
+  const host = {
+    kind: "tmux" as const,
+    endpoint: "/run/user/1000/agent-log-viewer",
+    server: { pid: 900, startIdentity: "900:one" },
+    paneId: "%11",
+    panePid: { pid: 100, startIdentity: "100:one" },
+    windowName: "migration",
+    agent: { pid: 101, startIdentity: "101:one" },
+    argv: ["claude"],
+  };
+
+  test("confirms explicit pane absence and retries unverifiable pane probes", async () => {
+    for (const [paneProbe, expected] of [
+      [async () => ({ code: 1, stdout: "", stderr: "can't find pane: %11\n" }), "absent"],
+      [async () => { throw new Error("socket read failed"); }, "unverifiable"],
+      [async () => ({ code: 1, stdout: "", stderr: "lost server\n" }), "unverifiable"],
+    ] as const) {
+      let calls = 0;
+      const result = await cleanupTmuxHostIfMatches(host, {
+        runTmux: async () => {
+          calls += 1;
+          if (calls === 1) return { code: 0, stdout: "900\n", stderr: "" };
+          return paneProbe();
+        },
+        processIdentity: (pid) => (pid === 900 ? "900:one" : null),
+      });
+      expect(result).toBe(expected);
+    }
   });
 });

--- a/src/lib/tmux.ts
+++ b/src/lib/tmux.ts
@@ -771,6 +771,9 @@ export async function resolveTmuxAttach(
     return { ok: false, reason: "tmux-unavailable" };
   }
   const tmuxServerStartIdentity = processIdentity(tmuxServerPid);
+  if (tmuxServerPid === expected.tmuxServerPid && expected.tmuxServerStartIdentity !== null && tmuxServerStartIdentity === null) {
+    return { ok: false, reason: "tmux-unavailable" };
+  }
   if (
     tmuxServerPid !== expected.tmuxServerPid ||
     (expected.tmuxServerStartIdentity !== null && tmuxServerStartIdentity !== expected.tmuxServerStartIdentity)
@@ -798,12 +801,16 @@ export async function resolveTmuxAttach(
   if (!Number.isInteger(observedServerPid) || observedServerPid <= 0 || !paneId || !Number.isInteger(panePid) || panePid <= 0 || !target) {
     return { ok: false, reason: "tmux-unavailable" };
   }
+  const paneStartIdentity = processIdentity(panePid);
+  if (paneId === expected.paneId && panePid === expected.panePid && expected.paneStartIdentity !== null && paneStartIdentity === null) {
+    return { ok: false, reason: "tmux-unavailable" };
+  }
   const state = classifyTmuxAttachSnapshot(expected, {
     tmuxServerPid: observedServerPid,
     tmuxServerStartIdentity: observedServerPid === tmuxServerPid ? tmuxServerStartIdentity : processIdentity(observedServerPid),
     paneId,
     panePid,
-    paneStartIdentity: processIdentity(panePid),
+    paneStartIdentity,
     target,
   });
   if (state !== "ok") return { ok: false, reason: state };

--- a/src/lib/tmux.ts
+++ b/src/lib/tmux.ts
@@ -403,8 +403,12 @@ export type TmuxHostCleanupResult = "cancelled" | "absent" | "unverifiable";
 
 /** Resolves cleanup ambiguity: a missing or replaced original host is complete.
     An unreachable tmux endpoint remains retryable. */
-export async function cleanupTmuxHostIfMatches(host: TmuxHostEvidence): Promise<TmuxHostCleanupResult> {
+export async function cleanupTmuxHostIfMatches(
+  host: TmuxHostEvidence,
+  deps: Partial<ResolveTmuxAttachDeps> = {},
+): Promise<TmuxHostCleanupResult> {
   const endpoint = createTmuxEndpointDescriptor(host.endpoint, process.getuid?.() ?? 0);
+  const run = deps.runTmux ?? runTmux;
   const expected: TmuxAttachReference = {
     tmuxServerPid: host.server.pid,
     tmuxServerStartIdentity: host.server.startIdentity,
@@ -412,14 +416,14 @@ export async function cleanupTmuxHostIfMatches(host: TmuxHostEvidence): Promise<
     panePid: host.panePid.pid,
     paneStartIdentity: host.panePid.startIdentity,
   };
-  const resolved = await resolveTmuxAttach(expected, endpoint);
+  const resolved = await resolveTmuxAttach(expected, endpoint, deps);
   if (!resolved.ok) return resolved.reason === "tmux-unavailable" ? "unverifiable" : "absent";
   const condition = `#{&&:#{==:#{pid},${host.server.pid}},#{&&:#{==:#{pane_id},${host.paneId}},#{==:#{pane_pid},${host.panePid.pid}}}}`;
   const mismatch = `llv-host-mismatch-${crypto.randomUUID()}`;
-  const result = await runTmux(["if-shell", "-t", host.paneId, "-F", condition, `kill-pane -t ${host.paneId}`, `display-message -p ${mismatch}`], undefined, endpoint);
-  if (result.code !== 0) return "unverifiable";
+  const result = await run(["if-shell", "-t", host.paneId, "-F", condition, `kill-pane -t ${host.paneId}`, `display-message -p ${mismatch}`], undefined, endpoint).catch(() => null);
+  if (!result || result.code !== 0) return "unverifiable";
   if (!result.stdout.includes(mismatch)) return "cancelled";
-  const after = await resolveTmuxAttach(expected, endpoint);
+  const after = await resolveTmuxAttach(expected, endpoint, deps);
   return !after.ok && after.reason !== "tmux-unavailable" ? "absent" : "unverifiable";
 }
 
@@ -784,8 +788,9 @@ export async function resolveTmuxAttach(
     undefined,
     endpoint,
   ).catch(() => null);
-  if (!res || res.code !== 0) {
-    return { ok: false, reason: "stale-pane" };
+  if (!res) return { ok: false, reason: "tmux-unavailable" };
+  if (res.code !== 0) {
+    return { ok: false, reason: /can't find pane/i.test(`${res.stderr}\n${res.stdout}`) ? "stale-pane" : "tmux-unavailable" };
   }
   const [serverRaw = "", paneId = "", paneRaw = "", target = ""] = res.stdout.trim().split("\t");
   const observedServerPid = Number(serverRaw);


### PR DESCRIPTION
## Summary

Follow-up hardening for issue #86 after the migration board-continuity change landed.

This incorporates four review rounds:

1. Separates definite Codex fork rejections from uncertain transport outcomes so safe retries clear the operation marker while ambiguous dispatches retain it. Adds tri-state Claude tmux cleanup so an absent original host can settle while unverifiable cleanup retries.
2. Classifies post-dispatch app-server protocol failures as unknown outcomes, including malformed JSON and malformed successful fork payloads exercised through the real client boundary.
3. Preserves cleanup tracking when pane probes fail at the transport or command layer. Only explicit missing-pane evidence confirms absence.
4. Preserves cleanup tracking when required server or pane process start identities cannot be observed, preventing live workers from becoming untracked.

## Impact

Migration recovery avoids duplicate Codex successors after ambiguous fork responses and avoids discarding Claude successor tracking when tmux evidence is incomplete. Definite pre-dispatch and server-rejected fork failures remain safely retryable.

## Validation

- `bun test` — 1,189 passed
- `bunx tsc --noEmit`

Follow-up hardening for #86.
