### PR TITLE
Index account migration startup inventory

### DIFF
--- a/src/lib/accounts/migration/coordinator.test.ts
+++ b/src/lib/accounts/migration/coordinator.test.ts
@@ -5,8 +5,9 @@ import path from "node:path";
 
 import { AgentRegistry, MigrationRevisionError, type ConversationObservation } from "@/lib/agent/registry";
 import { boardFor, mutateBoard, setBoardFileForTests } from "@/lib/board/store";
+import type { FileEntry } from "@/lib/types";
 
-import { advanceConversationMigration, createMigrationIntent, drainHeldDeliveries, previewMigration, reconcileMigrations } from "./coordinator";
+import { advanceConversationMigration, createMigrationIntent, drainHeldDeliveries, previewMigration, reconcileMigrationInventory, reconcileMigrations } from "./coordinator";
 import { emptyLaunchProfile, type ProviderReceipt, type SuccessorProviderPort } from "./contracts";
 import { CodexForkOutcomeUnknownError, SuccessorPendingError } from "./provider";
 
@@ -73,6 +74,43 @@ afterEach(() => {
 });
 
 describe("durable account migration coordinator", () => {
+  test("inventory builds path ownership from one registry snapshot", async () => {
+    const store = registry();
+    const firstPath = path.join(path.dirname(store.filename), "first.jsonl");
+    const secondPath = path.join(path.dirname(store.filename), "second.jsonl");
+    fs.writeFileSync(firstPath, JSON.stringify({ type: "event_msg", timestamp: "2026-07-11T00:00:00.000Z", payload: { type: "task_complete" } }) + "\n");
+    fs.writeFileSync(secondPath, JSON.stringify({ type: "event_msg", timestamp: "2026-07-11T00:00:00.000Z", payload: { type: "task_complete" } }) + "\n");
+    store.reconcileConversations([observation(firstPath, "default", "idle")]);
+    let snapshotCalls = 0;
+    const originalSnapshot = store.snapshot.bind(store);
+    store.snapshot = (() => { snapshotCalls += 1; return originalSnapshot(); }) as typeof store.snapshot;
+    store.conversationForPath = (() => { throw new Error("inventory must use its snapshot index"); }) as typeof store.conversationForPath;
+    store.launchProfileForPath = (() => { throw new Error("inventory must use its snapshot index"); }) as typeof store.launchProfileForPath;
+    const files = [firstPath, secondPath].map((pathname): FileEntry => ({
+      path: pathname,
+      root: "codex-sessions",
+      name: path.basename(pathname),
+      project: "repo",
+      title: path.basename(pathname),
+      engine: "codex",
+      kind: "session",
+      fmt: "codex",
+      parent: null,
+      mtime: Date.now() / 1000,
+      size: fs.statSync(pathname).size,
+      activity: "idle",
+      proc: null,
+      pid: null,
+      model: null,
+      pendingQuestion: null,
+      waitingInput: null,
+    }));
+
+    await reconcileMigrationInventory(store, files);
+
+    expect(snapshotCalls).toBe(1);
+  });
+
   test("a standard account switch migrates active conversations and defers inactive history", async () => {
     const store = registry();
     store.reconcileConversations([

--- a/src/lib/accounts/migration/coordinator.ts
+++ b/src/lib/accounts/migration/coordinator.ts
@@ -47,17 +47,36 @@ function engineOf(entry: FileEntry): MigrationEngine | null {
 }
 
 function inventory(files: FileEntry[], registry: AgentRegistry): ConversationObservation[] {
+  const snapshot = registry.snapshot();
+  const conversationByPath = new Map<string, RegistryConversation>();
+  const launchProfileByPath = new Map<string, RegistryConversation["generations"][number]["launchProfile"]>();
+  for (const conversation of Object.values(snapshot.conversations)) {
+    for (const generation of conversation.generations) {
+      if (!conversationByPath.has(generation.path)) conversationByPath.set(generation.path, conversation);
+      if (!launchProfileByPath.has(generation.path)) launchProfileByPath.set(generation.path, generation.launchProfile);
+    }
+    const current = conversation.generations.at(-1);
+    for (const pathname of conversation.continuityPaths) {
+      if (!conversationByPath.has(pathname)) conversationByPath.set(pathname, conversation);
+      if (current && !launchProfileByPath.has(pathname)) launchProfileByPath.set(pathname, current.launchProfile);
+    }
+  }
+  for (const receipt of Object.values(snapshot.receipts)) {
+    if (receipt.artifactPath && !launchProfileByPath.has(receipt.artifactPath)) {
+      launchProfileByPath.set(receipt.artifactPath, receipt.launchProfile);
+    }
+  }
   return files.flatMap((entry) => {
     const engine = engineOf(entry);
     if (!engine) return [];
-    const existing = registry.conversationForPath(entry.path);
-    const parentConversation = entry.parent ? registry.conversationForPath(entry.parent) : null;
+    const existing = conversationByPath.get(entry.path) ?? null;
+    const parentConversation = entry.parent ? conversationByPath.get(entry.parent) ?? null : null;
     const owner = accountManager.resolveTranscriptOwner(engine, entry.path);
     const parsed = turnStateFromRecords(tailRecords(entry.path, entry.size), engine === "codex", true);
     const turn = parsed.state !== "terminal" && (entry.activity === "idle" || entry.activity === "recent")
       ? { state: "idle" as const, source: "empty" as const, terminalAt: null }
       : parsed;
-    const currentProfile = registry.launchProfileForPath(entry.path)
+    const currentProfile = launchProfileByPath.get(entry.path)
       ?? existing?.generations.find((generation) => generation.path === entry.path)?.launchProfile;
     const configuredRoot = process.env.LLV_ROOT_CONVERSATION_ID;
     return [{


### PR DESCRIPTION
## Summary

- read the durable registry once per migration inventory cycle
- index conversation ownership, continuity paths, and launch profiles in memory
- preserve generation, continuity, receipt, and parent lookup precedence
- add a regression test that rejects per-file registry reads

## Production evidence

- startup previously pinned one CPU core and starved HTTP with a 2.9 MB registry containing 924 conversations

## Verification

- 56 focused tests passed
- TypeScript and ESLint clean
- production build passed
- fresh read-only review: CLEAN