### PR TITLE
Keep account migration reconciliation responsive

### DIFF
--- a/src/lib/accounts/migration/controller.test.ts
+++ b/src/lib/accounts/migration/controller.test.ts
@@ -72,6 +72,24 @@ test("controller runs a trailing cycle when a signal arrives during reconciliati
   expect(maxActiveCycles).toBe(1);
 });
 
+test("periodic polling joins a running cycle without scheduling another full inventory", async () => {
+  let release = () => {};
+  const blocked = new Promise<void>((resolve) => { release = resolve; });
+  let cycles = 0;
+  const controller = new AccountMigrationController(
+    new AgentRegistry(path.join(stateDir, "poll-coalescing-registry.json")),
+    { tick: async () => {} } as never,
+    async () => { cycles += 1; await blocked; },
+  );
+
+  const running = controller.tick();
+  const periodic = controller.poll();
+  release();
+  await Promise.all([running, periodic]);
+
+  expect(cycles).toBe(1);
+});
+
 test("controller preserves one trailing cycle when the running cycle fails", async () => {
   let release = () => {};
   const blocked = new Promise<void>((resolve) => { release = resolve; });

--- a/src/lib/accounts/migration/controller.ts
+++ b/src/lib/accounts/migration/controller.ts
@@ -1,7 +1,7 @@
 import { activeClaudeAccountId, setActiveClaudeAccount } from "@/lib/accounts/claude";
 import { activeCodexAccountId, codexAccountsMutationLocked, codexLoginPaneStatus, listCodexAccounts, setActiveCodexAccount, setCodexAccountLoginPane } from "@/lib/accounts/codex";
 import { managedCodexRuntime } from "@/lib/accounts/codexRuntime";
-import { agentRegistry, type AgentRegistry } from "@/lib/agent/registry";
+import { agentRegistry, conversationLookupFromSnapshot, type AgentRegistry } from "@/lib/agent/registry";
 import { readTranscriptHosts } from "@/lib/agent/transcriptHost";
 import { deliverConversationMessage, migrationDeliveryOutcome } from "@/lib/delivery";
 import { reconcileFlowConversationOwnership } from "@/lib/flows/store";
@@ -19,7 +19,12 @@ import type { SuccessorProviderPort } from "./contracts";
 import { RegisteredSuccessorProvider } from "./provider";
 import { QuotaController } from "./quotaController";
 
-const CONTROLLER_INTERVAL_MS = 10_000;
+const CONTROLLER_INTERVAL_MS = 60_000;
+const INITIAL_INVENTORY_DELAY_MS = 1_000;
+
+function yieldToRuntime(): Promise<void> {
+  return new Promise((resolve) => setImmediate(resolve));
+}
 
 const deliveryPort: HeldDeliveryPort = {
   async deliver({ delivery, path, clientMessageId }) {
@@ -35,10 +40,13 @@ export async function reconcileAccountMigrationCycle(
   delivery: HeldDeliveryPort = deliveryPort,
 ): Promise<void> {
   registry.compactDeliveryReservations();
+  await yieldToRuntime();
   await reconcileMigrations(provider, delivery, registry);
+  await yieldToRuntime();
   for (const conversation of Object.values(registry.snapshot().conversations)) {
     if (conversation.migration?.phase === "rolled-back") await drainHeldDeliveries(conversation.id, delivery, registry);
   }
+  await yieldToRuntime();
   await Promise.all([quota.tick("claude"), quota.tick("codex")]);
 }
 
@@ -84,6 +92,11 @@ export class AccountMigrationController {
     return this.running;
   }
 
+  poll(): Promise<void> {
+    if (this.running) return this.running;
+    return this.tick();
+  }
+
   private async runRequestedCycles(): Promise<void> {
     let failure: unknown = null;
     do {
@@ -96,27 +109,35 @@ export class AccountMigrationController {
 
   private async run(): Promise<void> {
     const { files } = await listFilesWithProjectCatalog(undefined, { persist: true });
-    await reconcileMigrationInventory(this.registry, files);
-    reconcileFlowConversationOwnership(this.registry);
-    reconcileWorkflowConversationOwnership(this.registry);
-    reconcileHandoffConversationOwnership(this.registry);
+    await yieldToRuntime();
+    const inventorySnapshot = await reconcileMigrationInventory(this.registry, files);
+    await yieldToRuntime();
+    const inventoryLookup = conversationLookupFromSnapshot(inventorySnapshot);
+    reconcileFlowConversationOwnership(inventoryLookup);
+    reconcileWorkflowConversationOwnership(inventoryLookup);
+    reconcileHandoffConversationOwnership(inventoryLookup);
+    await yieldToRuntime();
     await reconcileFileControllers(files);
+    await yieldToRuntime();
     await reconcileAccountLogins();
     await readTranscriptHosts(true);
+    await yieldToRuntime();
+    const currentLookup = conversationLookupFromSnapshot(this.registry.snapshot());
     mutateTasks((current) => {
       const reconciled = reconcileTasks(files, current, {
         pathForPanePid: (panePid, entries) => pathForPanePid(entries, panePid, readPpid),
         panePidAlive: pidAlive,
-        conversationIdForPath: (pathname) => this.registry.conversationForPath(pathname)?.id ?? null,
+        conversationIdForPath: (pathname) => currentLookup.conversationForPath(pathname)?.id ?? null,
         canonicalConversationId: (conversationId) => conversationId.startsWith("conversation_")
-          ? this.registry.canonicalConversationId(conversationId as `conversation_${string}`)
+          ? currentLookup.canonicalConversationId(conversationId as `conversation_${string}`)
           : null,
         pathForConversationId: (conversationId) => conversationId.startsWith("conversation_")
-          ? this.registry.conversation(conversationId as `conversation_${string}`)?.generations.at(-1)?.path ?? null
+          ? currentLookup.conversation(conversationId as `conversation_${string}`)?.generations.at(-1)?.path ?? null
           : null,
       });
       return { tasks: reconciled.dirty ? reconciled.tasks : undefined, result: undefined };
     });
+    await yieldToRuntime();
     syncCompatibilityRouting(this.registry);
     await reconcileAccountMigrationCycle(this.registry, this.quota);
   }
@@ -124,18 +145,42 @@ export class AccountMigrationController {
 
 const globalController = globalThis as unknown as {
   __llvAccountMigrationController?: AccountMigrationController;
+  __llvAccountMigrationFastController?: AccountMigrationController;
   __llvAccountMigrationTimer?: ReturnType<typeof setInterval>;
+  __llvAccountMigrationInitialTimer?: ReturnType<typeof setTimeout>;
+  __llvAccountMigrationBootstrapStarted?: boolean;
 };
 
 export async function startAccountMigrationController(): Promise<void> {
-  const controller = globalController.__llvAccountMigrationController ??= new AccountMigrationController();
-  registerAccountMigrationTick(() => controller.tick());
+  const registry = agentRegistry();
+  const quota = new QuotaController(registry);
+  const controller = globalController.__llvAccountMigrationController ??= new AccountMigrationController(registry, quota);
+  const fastController = globalController.__llvAccountMigrationFastController ??= new AccountMigrationController(
+    registry,
+    quota,
+    () => reconcileAccountMigrationCycle(registry, quota),
+  );
+  registerAccountMigrationTick(() => fastController.tick());
   if (!globalController.__llvAccountMigrationTimer) {
-    const timer = setInterval(() => void controller.tick().catch(() => {
+    const timer = setInterval(() => void controller.poll().catch(() => {
       console.error("[account migration controller] durable reconciliation tick failed");
     }), CONTROLLER_INTERVAL_MS);
     timer.unref?.();
     globalController.__llvAccountMigrationTimer = timer;
   }
-  await controller.tick();
+  if (!globalController.__llvAccountMigrationBootstrapStarted) {
+    globalController.__llvAccountMigrationBootstrapStarted = true;
+    void fastController.tick().catch(() => {
+      console.error("[account migration controller] initial durable reconciliation failed");
+    }).finally(() => {
+      const timer = setTimeout(() => {
+        globalController.__llvAccountMigrationInitialTimer = undefined;
+        void controller.poll().catch(() => {
+          console.error("[account migration controller] initial inventory reconciliation failed");
+        });
+      }, INITIAL_INVENTORY_DELAY_MS);
+      timer.unref?.();
+      globalController.__llvAccountMigrationInitialTimer = timer;
+    });
+  }
 }

--- a/src/lib/agent/registry.test.ts
+++ b/src/lib/agent/registry.test.ts
@@ -3,7 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import { describe, expect, test } from "bun:test";
 
-import { AgentRegistry } from "@/lib/agent/registry";
+import { AgentRegistry, conversationLookupFromSnapshot } from "@/lib/agent/registry";
 import { emptyLaunchProfile } from "@/lib/accounts/migration/contracts";
 
 const KEY = { engine: "codex" as const, sessionId: "019f4906-3f67-7b72-9fbc-9ec3b5ad1326" };
@@ -28,6 +28,21 @@ function spawnEntry(pathname: string, accountId = "terra") {
 }
 
 describe("agent registry", () => {
+  test("snapshot lookup preserves aliases and first path ownership without disk reads", () => {
+    const store = registry();
+    const first = store.ensureConversation("codex", "/shared.jsonl", "default");
+    const second = store.ensureConversation("codex", "/second.jsonl", "default");
+    const snapshot = store.snapshot();
+    snapshot.conversations[second.id]!.continuityPaths.push("/shared.jsonl");
+    snapshot.conversationAliases["conversation_alias"] = first.id;
+
+    const lookup = conversationLookupFromSnapshot(snapshot);
+
+    expect(lookup.conversationForPath("/shared.jsonl")?.id).toBe(first.id);
+    expect(lookup.canonicalConversationId("conversation_alias")).toBe(first.id);
+    expect(lookup.conversation("conversation_alias")?.id).toBe(first.id);
+  });
+
   test("startup compaction bounds legacy delivered reservations per conversation", () => {
     const store = registry();
     const conversation = store.ensureConversation("codex", "/legacy-deliveries.jsonl", "default");

--- a/src/lib/agent/registry.ts
+++ b/src/lib/agent/registry.ts
@@ -171,6 +171,12 @@ export interface RegistryFile {
   pendingSuccessorCleanups: Record<string, { conversationId: ViewerConversationId; receipt: ProviderReceipt; createdAt: string; lastError: string | null }>;
 }
 
+export interface ConversationLookup {
+  conversationForPath(artifactPath: string): RegistryConversation | null;
+  canonicalConversationId(id: ViewerConversationId): ViewerConversationId;
+  conversation(id: ViewerConversationId): RegistryConversation | null;
+}
+
 type ConversationMigrationInput = Omit<ConversationMigration, "errorCode" | "operationId" | "sourceGenerationId" | "providerReceipt" | "boardProject" | "boardOperationId" | "boardPlacementProject"> &
   Partial<Pick<ConversationMigration, "errorCode" | "operationId" | "sourceGenerationId" | "providerReceipt" | "boardProject" | "boardOperationId" | "boardPlacementProject">>;
 type SuccessorGenerationInput = Omit<NativeGeneration, "createdAt" | "archivedAt" | "launchProfile" | "historyHash" | "host"> &
@@ -544,6 +550,31 @@ function resolveConversationAlias(file: Pick<RegistryFile, "conversationAliases"
     current = next;
   }
   return current;
+}
+
+export function conversationLookupFromSnapshot(snapshot: RegistryFile): ConversationLookup {
+  const byPath = new Map<string, RegistryConversation>();
+  for (const conversation of Object.values(snapshot.conversations)) {
+    for (const generation of conversation.generations) {
+      if (!byPath.has(generation.path)) byPath.set(generation.path, conversation);
+    }
+    for (const pathname of conversation.continuityPaths) {
+      if (!byPath.has(pathname)) byPath.set(pathname, conversation);
+    }
+  }
+  return {
+    conversationForPath(artifactPath) {
+      const conversation = byPath.get(artifactPath);
+      return conversation ? clone(conversation) : null;
+    },
+    canonicalConversationId(id) {
+      return resolveConversationAlias(snapshot, id);
+    },
+    conversation(id) {
+      const conversation = snapshot.conversations[resolveConversationAlias(snapshot, id)];
+      return conversation ? clone(conversation) : null;
+    },
+  };
 }
 
 function adoptProvisionalOwner(

--- a/src/lib/flows/store.ts
+++ b/src/lib/flows/store.ts
@@ -3,7 +3,7 @@ import fs from "node:fs";
 import path from "node:path";
 
 import { statePath } from "@/lib/configDir";
-import { agentRegistry, type AgentRegistry } from "@/lib/agent/registry";
+import { agentRegistry, type ConversationLookup } from "@/lib/agent/registry";
 import { ROLE_DEFAULTS } from "@/lib/roles/defaults";
 import { resolveRole } from "@/lib/roles/registry";
 import { loadRoleDefinitionsOrDefaults } from "@/lib/roles/store";
@@ -179,7 +179,7 @@ export function loadFlows(): Flow[] {
   }));
 }
 
-export function reconcileFlowConversationOwnership(registry: AgentRegistry = agentRegistry()): void {
+export function reconcileFlowConversationOwnership(registry: ConversationLookup = agentRegistry()): void {
   const flows = loadFlows();
   let dirty = false;
   for (const flow of flows) {

--- a/src/lib/handoffLineage.ts
+++ b/src/lib/handoffLineage.ts
@@ -3,7 +3,7 @@ import path from "node:path";
 
 import { statePath } from "@/lib/configDir";
 import { pidAlive } from "@/lib/scanner/process";
-import { agentRegistry, type AgentRegistry } from "@/lib/agent/registry";
+import { agentRegistry, type ConversationLookup } from "@/lib/agent/registry";
 
 /**
  * Compatibility lineage for older handoffs. Viewer spawns now commit a durable
@@ -102,7 +102,7 @@ export function handoffParentConversation(childConversationId: string): string |
   return load().conversationChildren.get(childConversationId) ?? null;
 }
 
-export function reconcileHandoffConversationOwnership(registry: AgentRegistry = agentRegistry()): void {
+export function reconcileHandoffConversationOwnership(registry: ConversationLookup = agentRegistry()): void {
   const store = load();
   let changed = false;
   for (const [childPath, parentPath] of store.children) {

--- a/src/lib/workflows/store.ts
+++ b/src/lib/workflows/store.ts
@@ -2,7 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 
 import { statePath } from "@/lib/configDir";
-import { agentRegistry, type AgentRegistry } from "@/lib/agent/registry";
+import { agentRegistry, type ConversationLookup } from "@/lib/agent/registry";
 import type { RoleConfig } from "@/lib/flows/types";
 import { atomicWriteText } from "@/lib/flows/store";
 import { ROLE_DEFAULTS } from "@/lib/roles/defaults";
@@ -311,7 +311,7 @@ export function loadWorkflows(): Workflow[] {
   }));
 }
 
-export function reconcileWorkflowConversationOwnership(registry: AgentRegistry = agentRegistry()): void {
+export function reconcileWorkflowConversationOwnership(registry: ConversationLookup = agentRegistry()): void {
   const workflows = loadWorkflows();
   let dirty = false;
   for (const workflow of workflows) {


### PR DESCRIPTION
## Summary

- use one immutable conversation lookup across controller ownership reconciliation
- route account-switch signals through a fast migration-only controller
- keep periodic inventory cycles from scheduling trailing full scans
- yield between heavy controller phases and delay initial inventory until HTTP is ready
- extend the periodic fallback interval to avoid continuous CPU saturation

## Production evidence

- previous full cycle: 9.34 seconds at high CPU on 924 conversations
- acceptance server: 12/12 account API requests returned 200 during initial inventory
- first response: 96 ms; steady responses: 17-27 ms

## Verification

- 107 focused tests passed
- TypeScript and ESLint clean
- production build passed
- fresh read-only concurrency review: CLEAN