### PR TITLE
fix(ui): correct reasoning-effort bar scale per engine and model

### DIFF
--- a/src/components/EffortPills.tsx
+++ b/src/components/EffortPills.tsx
@@ -1,17 +1,18 @@
 import type { FileEntry } from "@/lib/types";
 
-import { EFFORT_LEVEL_MAX, effortLevel, effortTint, effortTitle } from "./utils";
+import { effortMeter, effortTint, effortTitle } from "./utils";
 
 /**
- * Six slim vertical pills next to a model chip, filled up to the entry's
- * reasoning-effort level (minimal=1 through max=6). The filled bars carry the same
+ * Slim vertical pills next to a model chip — one slot per tier of the entry's
+ * own engine+model reasoning scale, filled up to the recorded tier (lowest
+ * tier = one bar, top tier fills the meter). The filled bars carry the same
  * effort-shifted tint as the chip so the two read as one identity unit; empty
  * slots stay faint. Renders nothing when no reliable effort exists, keeping the
  * chip exactly as it looks today. The tier reads out through the shared
  * `util.effortTitle` tooltip with no visible label.
  */
 export function EffortPills({ file }: { file: FileEntry }) {
-  const level = effortLevel(file);
+  const { level, slots } = effortMeter(file);
   if (!level) return null;
   const { color } = effortTint(file);
   const title = effortTitle(file);
@@ -23,7 +24,7 @@ export function EffortPills({ file }: { file: FileEntry }) {
       title={title}
       style={{ transform: "scale(clamp(1, var(--inv-z, 1), 5))", transformOrigin: "left bottom" }}
     >
-      {Array.from({ length: EFFORT_LEVEL_MAX }, (_, i) => (
+      {Array.from({ length: slots }, (_, i) => (
         <span
           key={i}
           aria-hidden

--- a/src/components/effort.test.ts
+++ b/src/components/effort.test.ts
@@ -2,9 +2,9 @@ import { describe, expect, test } from "bun:test";
 
 import type { FileEntry } from "@/lib/types";
 
-import { EFFORT_LEVEL_MAX, effortLevel } from "./utils";
+import { effortMeter } from "./utils";
 
-function entry(effort: string | null | undefined): FileEntry {
+function entry(overrides: Partial<FileEntry>): FileEntry {
   return {
     path: "/x.jsonl",
     root: "codex-sessions",
@@ -20,28 +20,29 @@ function entry(effort: string | null | undefined): FileEntry {
     activity: "idle",
     proc: null,
     pid: null,
-    model: "gpt-5.6",
-    effort,
+    model: "gpt-5.6-sol",
+    effort: null,
     pendingQuestion: null,
     waitingInput: null,
+    ...overrides,
   };
 }
 
-describe("effortLevel", () => {
-  test("maps the full minimal through max scale onto 1 through 6", () => {
-    expect(effortLevel(entry("minimal"))).toBe(1);
-    expect(effortLevel(entry("low"))).toBe(2);
-    expect(effortLevel(entry("medium"))).toBe(3);
-    expect(effortLevel(entry("high"))).toBe(4);
-    expect(effortLevel(entry("xhigh"))).toBe(5);
-    expect(effortLevel(entry("max"))).toBe(6);
-    expect(EFFORT_LEVEL_MAX).toBe(6);
+describe("effortMeter", () => {
+  test("reads the entry's engine and model, so claude low is one bar of five", () => {
+    const meter = effortMeter(entry({ root: "claude-projects", engine: "claude", fmt: "claude", model: "fable-5", effort: "low" }));
+    expect(meter).toEqual({ level: 1, slots: 5 });
   });
 
-  test("returns 0 for unknown, empty, or absent effort so the indicator hides", () => {
-    expect(effortLevel(entry(null))).toBe(0);
-    expect(effortLevel(entry(undefined))).toBe(0);
-    expect(effortLevel(entry(""))).toBe(0);
-    expect(effortLevel(entry("bogus"))).toBe(0);
+  test("codex tiers position within the model's own scale", () => {
+    expect(effortMeter(entry({ model: "gpt-5.6-sol", effort: "xhigh" }))).toEqual({ level: 4, slots: 6 });
+    expect(effortMeter(entry({ model: "gpt-5.5", effort: "xhigh" }))).toEqual({ level: 4, slots: 4 });
+  });
+
+  test("returns level 0 for unknown, empty, or absent effort so the indicator hides", () => {
+    expect(effortMeter(entry({ effort: null })).level).toBe(0);
+    expect(effortMeter(entry({ effort: undefined })).level).toBe(0);
+    expect(effortMeter(entry({ effort: "" })).level).toBe(0);
+    expect(effortMeter(entry({ effort: "bogus" })).level).toBe(0);
   });
 });

--- a/src/components/utils.ts
+++ b/src/components/utils.ts
@@ -1,3 +1,4 @@
+import { effortMeter as meterOf } from "@/lib/agent/efforts";
 import { getLocale, translate } from "@/lib/i18n";
 import type { FileEntry } from "@/lib/types";
 import { cleanTitle } from "@/lib/title";
@@ -77,6 +78,7 @@ const EFFORT_RAMP: Record<string, { dl: number; ds: number }> = {
   high: { dl: -8, ds: 12 },
   xhigh: { dl: -14, ds: 22 },
   max: { dl: -19, ds: 30 },
+  ultra: { dl: -24, ds: 36 },
 };
 
 function hexToHsl(hex: string): [number, number, number] {
@@ -118,25 +120,12 @@ export function effortTitle(file: FileEntry): string | undefined {
   return file.effort ? translate(getLocale(), "util.effortTitle", { effort: file.effort }) : undefined;
 }
 
-/* Both CLI scales share this order, minimal through max, so the six-slot meter reads
-   the same regardless of engine. */
-const EFFORT_LEVELS: Record<string, number> = {
-  minimal: 1,
-  low: 2,
-  medium: 3,
-  high: 4,
-  xhigh: 5,
-  max: 6,
-};
-
-/** Reasoning tier of an entry as a 1-6 meter level. Callers hide the indicator
-    entirely on 0. */
-export function effortLevel(file: FileEntry): number {
-  return EFFORT_LEVELS[file.effort ?? ""] ?? 0;
+/** Meter reading of the entry's reasoning tier within its own engine+model
+    scale: lowest tier = 1 bar, top tier fills all `slots`. Callers hide the
+    indicator entirely on level 0. */
+export function effortMeter(file: FileEntry): { level: number; slots: number } {
+  return meterOf(file.engine, file.model, file.effort);
 }
-
-/** The full meter height, so pill renderers agree on how many slots to draw. */
-export const EFFORT_LEVEL_MAX = 6;
 
 /** Engine base tint for UI that has no FileEntry yet (e.g. the spawn dialog). */
 export function engineTintOf(engine: string): ModelTint {

--- a/src/lib/agent/efforts.test.ts
+++ b/src/lib/agent/efforts.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, test } from "bun:test";
+
+import { effortMeter, effortScale } from "./efforts";
+
+describe("effortScale", () => {
+  test("claude models all share the CLI scale low through max", () => {
+    for (const model of ["fable-5", "opus-4-8", "sonnet-5", "haiku-4-5", null]) {
+      expect(effortScale("claude", model)).toEqual(["low", "medium", "high", "xhigh", "max"]);
+    }
+  });
+
+  test("codex gpt-5.6 sol/terra carry the max and ultra tiers", () => {
+    expect(effortScale("codex", "gpt-5.6-sol")).toEqual(["low", "medium", "high", "xhigh", "max", "ultra"]);
+    expect(effortScale("codex", "gpt-5.6-terra")).toEqual(["low", "medium", "high", "xhigh", "max", "ultra"]);
+  });
+
+  test("other gpt-5.6 models top out at max", () => {
+    expect(effortScale("codex", "gpt-5.6-luna")).toEqual(["low", "medium", "high", "xhigh", "max"]);
+    expect(effortScale("codex", "gpt-5.6")).toEqual(["low", "medium", "high", "xhigh", "max"]);
+  });
+
+  test("older and unknown codex models run the classic low through xhigh", () => {
+    for (const model of ["gpt-5.5", "gpt-5.4-mini", "gpt-5.3-codex-spark", "codex-auto-review", null]) {
+      expect(effortScale("codex", model)).toEqual(["low", "medium", "high", "xhigh"]);
+    }
+  });
+
+  test("engines without a reasoning dial have no scale", () => {
+    expect(effortScale("shell", null)).toBeNull();
+  });
+});
+
+describe("effortMeter", () => {
+  test("claude low is the single lowest bar of a five-slot meter", () => {
+    expect(effortMeter("claude", "fable-5", "low")).toEqual({ level: 1, slots: 5 });
+  });
+
+  test("claude walks low through max onto 1..5", () => {
+    expect(effortMeter("claude", "fable-5", "medium")).toEqual({ level: 2, slots: 5 });
+    expect(effortMeter("claude", "opus-4-8", "high")).toEqual({ level: 3, slots: 5 });
+    expect(effortMeter("claude", "sonnet-5", "xhigh")).toEqual({ level: 4, slots: 5 });
+    expect(effortMeter("claude", "fable-5", "max")).toEqual({ level: 5, slots: 5 });
+  });
+
+  test("codex xhigh fills the whole meter on the classic four-tier models", () => {
+    expect(effortMeter("codex", "gpt-5.5", "xhigh")).toEqual({ level: 4, slots: 4 });
+    expect(effortMeter("codex", null, "xhigh")).toEqual({ level: 4, slots: 4 });
+  });
+
+  test("codex xhigh sits below max and ultra on gpt-5.6 sol/terra", () => {
+    expect(effortMeter("codex", "gpt-5.6-sol", "xhigh")).toEqual({ level: 4, slots: 6 });
+    expect(effortMeter("codex", "gpt-5.6-sol", "max")).toEqual({ level: 5, slots: 6 });
+    expect(effortMeter("codex", "gpt-5.6-terra", "ultra")).toEqual({ level: 6, slots: 6 });
+    expect(effortMeter("codex", "gpt-5.6-sol", "low")).toEqual({ level: 1, slots: 6 });
+  });
+
+  test("recognized tiers outside the model's scale clamp to the nearest end", () => {
+    // A legacy transcript recording `minimal` still shows the lowest bar.
+    expect(effortMeter("codex", "gpt-5.5", "minimal")).toEqual({ level: 1, slots: 4 });
+    // A tier above the known scale reads as the top rather than disappearing.
+    expect(effortMeter("codex", "gpt-5.5", "max")).toEqual({ level: 4, slots: 4 });
+    expect(effortMeter("codex", "gpt-5.6-luna", "ultra")).toEqual({ level: 5, slots: 5 });
+  });
+
+  test("hides on unknown, absent, or unscaled input", () => {
+    expect(effortMeter("claude", "fable-5", null)).toEqual({ level: 0, slots: 0 });
+    expect(effortMeter("claude", "fable-5", undefined)).toEqual({ level: 0, slots: 0 });
+    expect(effortMeter("codex", "gpt-5.6-sol", "")).toEqual({ level: 0, slots: 0 });
+    expect(effortMeter("codex", "gpt-5.6-sol", "bogus")).toEqual({ level: 0, slots: 0 });
+    expect(effortMeter("shell", null, "high")).toEqual({ level: 0, slots: 0 });
+  });
+});

--- a/src/lib/agent/efforts.ts
+++ b/src/lib/agent/efforts.ts
@@ -18,6 +18,56 @@ export function isEngineEffort(engine: AgentEngineName, value: string): boolean 
   return (ENGINE_EFFORTS[engine] as readonly string[]).includes(value);
 }
 
+/** Canonical low→high ordering across every tier either CLI has ever recorded. */
+const EFFORT_ORDER: readonly string[] = ["minimal", "low", "medium", "high", "xhigh", "max", "ultra"];
+
+/* Codex reasoning scales vary per model (`supported_reasoning_levels` in
+   ~/.codex/models_cache.json): gpt-5.6 sol/terra add max+ultra above xhigh,
+   the rest of the 5.6 family adds max, and everything older (or unknown) runs
+   the classic low…xhigh. First matching prefix wins. */
+const CODEX_MODEL_SCALES: readonly (readonly [RegExp, readonly string[]])[] = [
+  [/^gpt-5\.6-(sol|terra)\b/, ["low", "medium", "high", "xhigh", "max", "ultra"]],
+  [/^gpt-5\.6\b/, ["low", "medium", "high", "xhigh", "max"]],
+];
+
+/** Reasoning tiers a given engine+model pair can run at, lowest first; null
+    for engines without a reasoning dial (shell). Model may be the viewer's
+    display-shortened id — matching is prefix-based on the codex slug, and
+    claude models all share one CLI scale. */
+export function effortScale(engine: string, model: string | null | undefined): readonly string[] | null {
+  if (engine === "claude") return ENGINE_EFFORTS.claude;
+  if (engine !== "codex") return null;
+  const id = (model ?? "").trim().toLowerCase();
+  for (const [re, scale] of CODEX_MODEL_SCALES) {
+    if (re.test(id)) return scale;
+  }
+  return ENGINE_EFFORTS.codex;
+}
+
+/**
+ * Meter reading of a recorded tier within its own engine+model scale: `slots`
+ * is the scale length, `level` the 1-based position (lowest tier = 1, top tier
+ * fills the meter). A recognized tier missing from the scale — a transcript
+ * from an older or newer CLI than the table knows — clamps to the nearest end
+ * instead of vanishing. level 0 means "hide the indicator".
+ */
+export function effortMeter(
+  engine: string,
+  model: string | null | undefined,
+  effort: string | null | undefined,
+): { level: number; slots: number } {
+  const scale = effortScale(engine, model);
+  const tier = (effort ?? "").trim().toLowerCase();
+  if (!scale || !tier) return { level: 0, slots: 0 };
+  const slots = scale.length;
+  const idx = scale.indexOf(tier);
+  if (idx >= 0) return { level: idx + 1, slots };
+  const rank = EFFORT_ORDER.indexOf(tier);
+  if (rank < 0) return { level: 0, slots: 0 };
+  const below = scale.filter((s) => EFFORT_ORDER.indexOf(s) < rank).length;
+  return { level: Math.min(Math.max(below, 1), slots), slots };
+}
+
 /** Validates the optional effort/fast fields of a spawn request body. An
     invalid effort is a client error, not something to drop silently; fast is
     meaningful for codex only and stays unset elsewhere. */

--- a/src/lib/scanner/effort.ts
+++ b/src/lib/scanner/effort.ts
@@ -8,8 +8,8 @@ import { readArgv } from "./process";
 
 const effortCache = globalCache<[number, string | null]>("effort");
 
-/** Union of both CLI scales: codex minimal…xhigh, claude low…max. */
-const TIERS = new Set(["minimal", "low", "medium", "high", "xhigh", "max"]);
+/** Union of both CLI scales: codex minimal…ultra, claude low…max. */
+const TIERS = new Set(["minimal", "low", "medium", "high", "xhigh", "max", "ultra"]);
 
 function normalizeEffort(value: string | null | undefined): string | null {
   const tier = value?.trim().toLowerCase() ?? "";

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -54,8 +54,8 @@ export interface FileEntry {
       display-normalized `model` because resuming a pinned Claude model needs
       the original identifier. */
   launchModel?: string | null;
-  /** Reasoning-effort tier (minimal|low|medium|high|xhigh|max) or null when
-      no reliable source exists (claude transcripts carry none). */
+  /** Reasoning-effort tier (minimal|low|medium|high|xhigh|max|ultra) or null
+      when no reliable source exists (claude transcripts carry none). */
   effort?: string | null;
   /** Structured Claude prompt that is currently blocking the live agent. */
   pendingQuestion: PendingQuestion | null;


### PR DESCRIPTION
## Problem

The effort pills next to a model chip mapped every recorded tier onto one global six-slot union scale (`minimal=1 … max=6`), regardless of engine or model. Observed consequences:

- A **Claude Fable 5 session launched at `low`** showed **2 of 6 bars** (the `minimal` slot below it belongs to Codex only — Claude's scale starts at `low`).
- A **Codex gpt-5.5-class session at `xhigh`** — the top tier that model supports — showed **5 of 6 bars**, reading as "one below max" when it was actually maxed out.

## Fix

`effortScale`/`effortMeter` in `src/lib/agent/efforts.ts` (client-safe, next to the existing `ENGINE_EFFORTS`) now resolve the scale for the specific engine+model, and the meter fills to the tier's **position within that scale**: lowest tier = 1 bar, top tier = full meter. `EffortPills` draws one slot per tier of that scale, so both render sites (`SwitchCard` badge and `BranchPane` row) stay consistent automatically.

## Authoritative effort matrix (from code + `~/.codex/models_cache.json` + `claude --help`)

| Engine | Model | Scale (lowest → top) | Bars |
|---|---|---|---|
| claude | fable, opus, sonnet, haiku (all — one CLI flag `--effort`) | low · medium · high · xhigh · max | 1 / 2 / 3 / 4 / 5 of **5** |
| codex | gpt-5.6-sol, gpt-5.6-terra | low · medium · high · xhigh · max · ultra | 1 / 2 / 3 / 4 / 5 / 6 of **6** |
| codex | gpt-5.6-luna (and other gpt-5.6) | low · medium · high · xhigh · max | 1 / 2 / 3 / 4 / 5 of **5** |
| codex | gpt-5.5, gpt-5.4, gpt-5.4-mini, gpt-5.3-codex-spark, codex-auto-review, unknown | low · medium · high · xhigh | 1 / 2 / 3 / 4 of **4** |

So to the owner's question: **Codex `xhigh` is the full meter (4/4) on gpt-5.5-class models, and position 4 of 6 on gpt-5.6-sol/terra**, which genuinely carry `max` and `ultra` above it — it is never conflated with `high`.

Effort sources stay as before: Codex from `turn_context` (`payload.effort` / `collaboration_mode.settings.reasoning_effort`) or `-c model_reasoning_effort=X` argv; Claude from `--effort X` argv with the thinking-block fallback.

## Graceful handling

- Unknown/absent/bogus effort → meter hidden (level 0), as before.
- A recognized tier missing from the model's known scale clamps to the nearest end instead of vanishing: legacy `minimal` renders as the lowest bar; a tier above the table's knowledge (e.g. `max` recorded by a future 4-tier model) renders as a full meter.
- Unknown Codex models fall back to the classic 4-tier scale; unknown engines (shell) never show a meter.

## Also fixed while building the matrix

- The scanner's tier whitelist was missing `ultra` — a gpt-5.6-sol/terra session run at ultra would have shown no indicator at all. Added to `TIERS` and to the tint ramp.
- Note (out of scope, left as-is): the spawn selector's `ENGINE_EFFORTS.codex` still tops out at `xhigh`, while the models cache says sol/terra accept `max`/`ultra`; happy to extend that in a follow-up if desired.

## Verification

- `bun test` — 1262 pass, 0 fail (includes new regression suites `src/lib/agent/efforts.test.ts` and reworked `src/components/effort.test.ts`).
- `bunx tsc --noEmit` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)