### PR TITLE
fix(board): preserve close tombstones across writers

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -1,50 +1,31 @@
-# PR #100 — Pipeline chain builder + progress UI (issue #93)
+# Issue #60 — durable board closes
 
 ## Task statement
 
-Build the front-end for agent **pipelines** (linear chains of stages) on top of the
-already-merged backend from PR #96 (`/api/pipelines`, engine, `PipelineStrip`/`PipelineHub`/
-`derivePipelineLinks`) and the role registry from PR #95 (`GET /api/roles`), following the
-approved Fable design attached to issue #93 (`ARCHITECTURE_READY` comment). Two surfaces:
-
-1. **Chain builder** — a modal to author a pipeline (ordered stages, each Run or Review-loop,
-   with role/params/access/prompt), reachable from board toolbar, dashboard header, and a node
-   action that prefills the source transcript.
-2. **Chain progress** — interactive stage strip, verdict popover, board rail with a single
-   interactive hub, control hub, and a mobile chain row.
-
-No mocks — everything wires to the real backend endpoints and existing engine types.
+Fix closed scheme cards resurfacing after reload. The server must preserve close
+tombstones across concurrent board writers and carry them across transcript
+succession paths, including clients that retry a stale whole-list `hidden` patch
+or omit a `remap-paths` mutation.
 
 ## Acceptance criteria
 
-- **AC1 — Builder dialog.** `PipelineDialog` renders a modal (patterned on `FlowDialog`) with
-  task, optional pinned spec, repository combobox, client templates, and inline validation that
-  mirrors the API. Stage `id`/`next` are derived by the dialog so the linear-chain invariant is
-  owned client-side and never shown to the user. Draft persists to
-  `sessionStorage` under `llvPipelineDraft:<project>`.
-- **AC2 — StageRow.** Each stage exposes a kind toggle (Review-loop **disabled on stage 1**),
-  role select + typed params (reusing PR #95 role UI) with runtime autofill, a collapsed runtime
-  line with `[edit]`, access radios (hidden for review-loop), and a prompt field with
-  `{{task}}`/`{{prev.output}}` insert chips (`{{prev.output}}` disabled on stage 1). Keyboard
-  `↑`/`↓` reorder and delete, delete disabled at the 2-stage floor.
-- **AC3 — Entry points.** Builder opens from board toolbar, dashboard orchestration header, and a
-  "Start pipeline from here" node action that prefills `src` from the node's transcript.
-- **AC4 — PipelineStrip v2.** Stage chips implement the §3 state matrix using glyph + tone
-  (never color alone): review-loop round counter, attempt-count suffix, verdict glyph, parked
-  first-finding summary. Chips focus the stage conversation; the verdict glyph opens the popover.
-- **AC5 — VerdictPopover.** Shows status badge, confidence bar, bounded findings (first 8 +
-  `+N more`), prior-attempt audit lines, open-transcript / open-review actions, and inline
-  Retry/Skip when parked.
-- **AC6 — Board rail + hub.** `derivePipelineLinks` carries per-edge tone keyed off the target
-  stage, marks exactly one edge (into the current stage) as the interactive hub, and badges the
-  rest. `AgentLinksLayer` draws a straight chevroned rail distinct from spawn/flow links,
-  animated on the active edge. `PipelineHub` v2 is a single control hub (pause/resume,
-  retry/skip when parked, close).
-- **AC7 — Mobile.** `MobileFocusView` shows a pipeline chain row over the focused stage pane with
-  prev/next hop.
-- **AC8 — i18n + a11y.** Full en + uk parity for all new `pipeline*` namespaces (plural forms for
-  finding counts). Real radio groups, `role="group"` + aria labels, glyph-redundant states,
-  Escape-closes-popover, disabled-with-hint affordances.
-- **AC9 — Quality gates.** `bun test` green, `bunx tsc --noEmit` clean, `bun run lint` clean.
-  New unit tests cover the state matrix, id/next derivation, template invariants, dialog render,
-  and the agentLinks tone/hub/geometry logic.
+- AC1: A legacy whole-list board PATCH retried with a current revision cannot
+  erase hidden entries committed by another writer.
+- AC2: Legacy board PATCH requests remain schema-compatible, and revision-zero
+  preference seeding continues to work.
+- AC3: Hidden tombstones take precedence over stale manual and expanded
+  membership supplied by whole-list clients.
+- AC4: Server-side board mutations derive aliases from durable conversation
+  generations and continuity paths.
+- AC5: A closed predecessor remains hidden when its successor appears and root
+  reconciliation arrives without a client-provided remap.
+- AC6: Root reconciliation preserves hidden entries when conversation identity
+  remains stable.
+- AC7: Regression tests reproduce the concurrent stale-list retry and the
+  successor-without-remap scenarios through the board route.
+- AC8: A malformed or unreadable conversation registry leaves validated board
+  mutations available and skips alias enrichment for that request.
+- AC9: `bun test` passes.
+- AC10: `bunx tsc --noEmit` passes.
+- AC11: The live board state and production Viewer on port 8898 remain
+  unchanged during implementation and verification.

--- a/spec.md
+++ b/spec.md
@@ -30,7 +30,9 @@ or omit a `remap-paths` mutation.
   committed continuity paths keep carrying tombstones during later migrations.
 - AC10: Scanner discovery, observed spawn settlement, provider persistence, and
   explicit continuity callbacks all record pending succession provenance.
-- AC11: `bun test` passes.
-- AC12: `bunx tsc --noEmit` passes.
-- AC13: The live board state and production Viewer on port 8898 remain
+- AC11: Return-to-source routing and target retirement preserve an abandoned
+  successor fence after clearing the active migration.
+- AC12: `bun test` passes.
+- AC13: `bunx tsc --noEmit` passes.
+- AC14: The live board state and production Viewer on port 8898 remain
   unchanged during implementation and verification.

--- a/spec.md
+++ b/spec.md
@@ -28,7 +28,9 @@ or omit a `remap-paths` mutation.
 - AC9: Pending continuity paths cannot create aliases from a future successor
   back to the current predecessor during initial or repeated migrations;
   committed continuity paths keep carrying tombstones during later migrations.
-- AC10: `bun test` passes.
-- AC11: `bunx tsc --noEmit` passes.
-- AC12: The live board state and production Viewer on port 8898 remain
+- AC10: Scanner discovery, observed spawn settlement, provider persistence, and
+  explicit continuity callbacks all record pending succession provenance.
+- AC11: `bun test` passes.
+- AC12: `bunx tsc --noEmit` passes.
+- AC13: The live board state and production Viewer on port 8898 remain
   unchanged during implementation and verification.

--- a/spec.md
+++ b/spec.md
@@ -26,7 +26,8 @@ or omit a `remap-paths` mutation.
 - AC8: A malformed or unreadable conversation registry leaves validated board
   mutations available and skips alias enrichment for that request.
 - AC9: Pending continuity paths cannot create aliases from a future successor
-  back to the current predecessor during initial or repeated migrations.
+  back to the current predecessor during initial or repeated migrations;
+  committed continuity paths keep carrying tombstones during later migrations.
 - AC10: `bun test` passes.
 - AC11: `bunx tsc --noEmit` passes.
 - AC12: The live board state and production Viewer on port 8898 remain

--- a/spec.md
+++ b/spec.md
@@ -32,7 +32,13 @@ or omit a `remap-paths` mutation.
   explicit continuity callbacks all record pending succession provenance.
 - AC11: Return-to-source routing and target retirement preserve an abandoned
   successor fence after clearing the active migration.
-- AC12: `bun test` passes.
-- AC13: `bunx tsc --noEmit` passes.
-- AC14: The live board state and production Viewer on port 8898 remain
+- AC12: A table-driven route regression covers commit, return-to-source,
+  target retirement, chained succession, deferred board repair, and queued
+  cleanup receipts across close-before/during/after timing and alias
+  enrichment, root reconciliation, and client remap mutations.
+- AC13: Fenced successor paths can trigger committed alias repair while
+  remaining ineligible for root reconciliation and client remaps.
+- AC14: `bun test` passes.
+- AC15: `bunx tsc --noEmit` passes.
+- AC16: The live board state and production Viewer on port 8898 remain
   unchanged during implementation and verification.

--- a/spec.md
+++ b/spec.md
@@ -25,8 +25,8 @@ or omit a `remap-paths` mutation.
   successor-without-remap scenarios through the board route.
 - AC8: A malformed or unreadable conversation registry leaves validated board
   mutations available and skips alias enrichment for that request.
-- AC9: Pre-commit continuity paths cannot create aliases from a future
-  successor back to the current predecessor.
+- AC9: Pending continuity paths cannot create aliases from a future successor
+  back to the current predecessor during initial or repeated migrations.
 - AC10: `bun test` passes.
 - AC11: `bunx tsc --noEmit` passes.
 - AC12: The live board state and production Viewer on port 8898 remain

--- a/spec.md
+++ b/spec.md
@@ -25,7 +25,9 @@ or omit a `remap-paths` mutation.
   successor-without-remap scenarios through the board route.
 - AC8: A malformed or unreadable conversation registry leaves validated board
   mutations available and skips alias enrichment for that request.
-- AC9: `bun test` passes.
-- AC10: `bunx tsc --noEmit` passes.
-- AC11: The live board state and production Viewer on port 8898 remain
+- AC9: Pre-commit continuity paths cannot create aliases from a future
+  successor back to the current predecessor.
+- AC10: `bun test` passes.
+- AC11: `bunx tsc --noEmit` passes.
+- AC12: The live board state and production Viewer on port 8898 remain
   unchanged during implementation and verification.

--- a/src/app/api/board/route.test.ts
+++ b/src/app/api/board/route.test.ts
@@ -374,6 +374,116 @@ test("a scanner-discovered repeated successor stays pending before its provider 
   });
 });
 
+test("returning to the current account keeps an abandoned successor out of board aliases", async () => {
+  const registry = new AgentRegistry(path.join(path.dirname(testFile), "agent-registry.json"));
+  setAgentRegistryForTests(registry);
+  const first = "/return-generation-a.jsonl";
+  const second = "/return-generation-b.jsonl";
+  const abandoned = "/return-abandoned-c.jsonl";
+  const conversation = registry.ensureConversation("codex", first, "account-a");
+
+  registry.commitMigrationIntent({
+    engine: "codex",
+    targetId: "account-b",
+    origin: "manual",
+    requestId: "return-first-migration",
+    expectedRevision: registry.engineRouting("codex").revision,
+  });
+  const firstRevision = registry.conversation(conversation.id)!.migration!.revision;
+  registry.transitionConversationMigration(conversation.id, firstRevision, ["requested", "waiting-turn"], { phase: "preparing" });
+  registry.transitionConversationMigration(conversation.id, firstRevision, ["preparing"], { phase: "successor-starting" });
+  registry.transitionConversationMigration(conversation.id, firstRevision, ["successor-starting"], { phase: "verifying" });
+  registry.commitSuccessor(conversation.id, { id: "return-generation-b", path: second, accountId: "account-b" }, firstRevision);
+
+  const placed = await PATCH(patch({
+    schemaVersion: 1,
+    project: "return-to-current",
+    baseRevision: 0,
+    mutations: [{ kind: "restore", path: second, placement: "manual" }],
+  }));
+  expect(placed.status).toBe(200);
+
+  registry.commitMigrationIntent({
+    engine: "codex",
+    targetId: "account-c",
+    origin: "manual",
+    requestId: "return-second-migration",
+    expectedRevision: registry.engineRouting("codex").revision,
+  });
+  registry.recordConversationContinuityPath(conversation.id, abandoned);
+  registry.commitMigrationIntent({
+    engine: "codex",
+    targetId: "account-b",
+    origin: "manual",
+    requestId: "return-to-current",
+    expectedRevision: registry.engineRouting("codex").revision,
+  });
+  expect(registry.conversation(conversation.id)?.migration).toBeNull();
+
+  const closed = await PATCH(patch({
+    schemaVersion: 1,
+    project: "return-to-current",
+    baseRevision: 1,
+    mutations: [{ kind: "close", path: second }],
+  }));
+  expect(closed.status).toBe(200);
+  const closedBody = await closed.json() as { board: { pathAliases: Record<string, string> } };
+  expect(closedBody).toMatchObject({ board: { revision: 2, prefs: { hidden: [second] } } });
+  expect(closedBody.board.pathAliases).toEqual({ [first]: second });
+});
+
+test("retiring a migration target keeps its abandoned successor out of board aliases", async () => {
+  const registry = new AgentRegistry(path.join(path.dirname(testFile), "agent-registry.json"));
+  setAgentRegistryForTests(registry);
+  const first = "/retire-generation-a.jsonl";
+  const second = "/retire-generation-b.jsonl";
+  const abandoned = "/retire-abandoned-c.jsonl";
+  const conversation = registry.ensureConversation("codex", first, "account-a");
+
+  registry.commitMigrationIntent({
+    engine: "codex",
+    targetId: "account-b",
+    origin: "manual",
+    requestId: "retire-first-migration",
+    expectedRevision: registry.engineRouting("codex").revision,
+  });
+  const firstRevision = registry.conversation(conversation.id)!.migration!.revision;
+  registry.transitionConversationMigration(conversation.id, firstRevision, ["requested", "waiting-turn"], { phase: "preparing" });
+  registry.transitionConversationMigration(conversation.id, firstRevision, ["preparing"], { phase: "successor-starting" });
+  registry.transitionConversationMigration(conversation.id, firstRevision, ["successor-starting"], { phase: "verifying" });
+  registry.commitSuccessor(conversation.id, { id: "retire-generation-b", path: second, accountId: "account-b" }, firstRevision);
+
+  const placed = await PATCH(patch({
+    schemaVersion: 1,
+    project: "retire-target",
+    baseRevision: 0,
+    mutations: [{ kind: "restore", path: second, placement: "manual" }],
+  }));
+  expect(placed.status).toBe(200);
+
+  registry.commitMigrationIntent({
+    engine: "codex",
+    targetId: "account-c",
+    origin: "manual",
+    requestId: "retire-second-migration",
+    expectedRevision: registry.engineRouting("codex").revision,
+  });
+  registry.recordConversationContinuityPath(conversation.id, abandoned);
+  registry.retireAccount("codex", "account-c", "account-b");
+  expect(registry.conversation(conversation.id)?.migration).toBeNull();
+
+  const closed = await PATCH(patch({
+    schemaVersion: 1,
+    project: "retire-target",
+    baseRevision: 1,
+    mutations: [{ kind: "close", path: second }],
+  }));
+  expect(closed.status).toBe(200);
+  const closedBody = await closed.json() as { board: { pathAliases: Record<string, string> } };
+  expect(closedBody).toMatchObject({ board: { revision: 2, prefs: { hidden: [second] } } });
+  expect(closedBody.board.pathAliases).toEqual({ [first]: second });
+});
+
 test("a pending repeated migration preserves deferred historical continuity tombstones", async () => {
   const registry = new AgentRegistry(path.join(path.dirname(testFile), "agent-registry.json"));
   setAgentRegistryForTests(registry);

--- a/src/app/api/board/route.test.ts
+++ b/src/app/api/board/route.test.ts
@@ -149,3 +149,20 @@ test("a closed conversation stays hidden when a registry successor arrives witho
     },
   });
 });
+
+test("a corrupt conversation registry cannot block a valid close", async () => {
+  fs.writeFileSync(path.join(path.dirname(testFile), "agent-registry.json"), "{ corrupt", "utf8");
+
+  const response = await PATCH(patch({
+    schemaVersion: 1,
+    project: "corrupt-registry",
+    baseRevision: 0,
+    mutations: [{ kind: "close", path: "/card" }],
+  }));
+
+  expect(response.status).toBe(200);
+  expect(await response.json()).toMatchObject({
+    ok: true,
+    board: { revision: 1, prefs: { hidden: ["/card"] } },
+  });
+});

--- a/src/app/api/board/route.test.ts
+++ b/src/app/api/board/route.test.ts
@@ -150,6 +150,64 @@ test("a closed conversation stays hidden when a registry successor arrives witho
   });
 });
 
+test("a pre-commit continuity path cannot create a reverse board alias", async () => {
+  const registry = new AgentRegistry(path.join(path.dirname(testFile), "agent-registry.json"));
+  setAgentRegistryForTests(registry);
+  const source = "/continuity-predecessor.jsonl";
+  const successor = "/continuity-successor.jsonl";
+  const conversation = registry.ensureConversation("codex", source, "account-a");
+  registry.recordConversationContinuityPath(conversation.id, successor);
+
+  const seeded = await PATCH(patch({
+    schemaVersion: 1,
+    project: "pre-commit-continuity",
+    baseRevision: 0,
+    patch: { manual: [source] },
+  }));
+  expect(seeded.status).toBe(200);
+  const closed = await PATCH(patch({
+    schemaVersion: 1,
+    project: "pre-commit-continuity",
+    baseRevision: 1,
+    mutations: [{ kind: "close", path: source }],
+  }));
+  expect(closed.status).toBe(200);
+  const closedBody = await closed.json() as { board: { pathAliases: Record<string, string> } };
+  expect(closedBody).toMatchObject({
+    board: { revision: 2, pathAliases: {}, prefs: { hidden: [source] } },
+  });
+  expect(closedBody.board.pathAliases).toEqual({});
+
+  registry.commitMigrationIntent({
+    engine: "codex",
+    targetId: "account-b",
+    origin: "manual",
+    requestId: "pre-commit-continuity",
+    expectedRevision: registry.engineRouting("codex").revision,
+  });
+  const revision = registry.conversation(conversation.id)!.migration!.revision;
+  registry.transitionConversationMigration(conversation.id, revision, ["requested", "waiting-turn"], { phase: "preparing" });
+  registry.transitionConversationMigration(conversation.id, revision, ["preparing"], { phase: "successor-starting" });
+  registry.transitionConversationMigration(conversation.id, revision, ["successor-starting"], { phase: "verifying" });
+  registry.commitSuccessor(conversation.id, { id: "continuity-successor", path: successor, accountId: "account-b" }, revision);
+
+  const reconciled = await PATCH(patch({
+    schemaVersion: 1,
+    project: "pre-commit-continuity",
+    baseRevision: 2,
+    mutations: [{ kind: "reconcile-roots", roots: [successor], removeManual: [] }],
+  }));
+  expect(reconciled.status).toBe(200);
+  expect(await reconciled.json()).toMatchObject({
+    ok: true,
+    board: {
+      revision: 3,
+      pathAliases: { [source]: successor },
+      prefs: { manual: [], hidden: [successor] },
+    },
+  });
+});
+
 test("a corrupt conversation registry cannot block a valid close", async () => {
   fs.writeFileSync(path.join(path.dirname(testFile), "agent-registry.json"), "{ corrupt", "utf8");
 

--- a/src/app/api/board/route.test.ts
+++ b/src/app/api/board/route.test.ts
@@ -285,6 +285,65 @@ test("a repeated migration cannot alias its pending successor backward", async (
   });
 });
 
+test("a pending repeated migration preserves deferred historical continuity tombstones", async () => {
+  const registry = new AgentRegistry(path.join(path.dirname(testFile), "agent-registry.json"));
+  setAgentRegistryForTests(registry);
+  const first = "/deferred-generation-a.jsonl";
+  const fork = "/deferred-fork-b.jsonl";
+  const second = "/deferred-generation-b.jsonl";
+  const conversation = registry.ensureConversation("codex", first, "account-a");
+
+  registry.commitMigrationIntent({
+    engine: "codex",
+    targetId: "account-b",
+    origin: "manual",
+    requestId: "deferred-first-migration",
+    expectedRevision: registry.engineRouting("codex").revision,
+  });
+  const firstRevision = registry.conversation(conversation.id)!.migration!.revision;
+  registry.recordConversationContinuityPath(conversation.id, fork);
+
+  const closed = await PATCH(patch({
+    schemaVersion: 1,
+    project: "deferred-continuity",
+    baseRevision: 0,
+    mutations: [{ kind: "close", path: fork }],
+  }));
+  expect(closed.status).toBe(200);
+  expect(await closed.json()).toMatchObject({
+    board: { revision: 1, pathAliases: {}, prefs: { hidden: [fork] } },
+  });
+
+  registry.transitionConversationMigration(conversation.id, firstRevision, ["requested", "waiting-turn"], { phase: "preparing" });
+  registry.transitionConversationMigration(conversation.id, firstRevision, ["preparing"], { phase: "successor-starting" });
+  registry.transitionConversationMigration(conversation.id, firstRevision, ["successor-starting"], { phase: "verifying" });
+  registry.commitSuccessor(conversation.id, { id: "deferred-generation-b", path: second, accountId: "account-b" }, firstRevision);
+
+  registry.commitMigrationIntent({
+    engine: "codex",
+    targetId: "account-c",
+    origin: "manual",
+    requestId: "deferred-second-migration",
+    expectedRevision: registry.engineRouting("codex").revision,
+  });
+
+  const reconciled = await PATCH(patch({
+    schemaVersion: 1,
+    project: "deferred-continuity",
+    baseRevision: 1,
+    mutations: [{ kind: "reconcile-roots", roots: [second], removeManual: [] }],
+  }));
+  expect(reconciled.status).toBe(200);
+  expect(await reconciled.json()).toMatchObject({
+    ok: true,
+    board: {
+      revision: 2,
+      pathAliases: { [first]: second, [fork]: second },
+      prefs: { manual: [], hidden: [second] },
+    },
+  });
+});
+
 test("a corrupt conversation registry cannot block a valid close", async () => {
   fs.writeFileSync(path.join(path.dirname(testFile), "agent-registry.json"), "{ corrupt", "utf8");
 

--- a/src/app/api/board/route.test.ts
+++ b/src/app/api/board/route.test.ts
@@ -208,6 +208,83 @@ test("a pre-commit continuity path cannot create a reverse board alias", async (
   });
 });
 
+test("a repeated migration cannot alias its pending successor backward", async () => {
+  const registry = new AgentRegistry(path.join(path.dirname(testFile), "agent-registry.json"));
+  setAgentRegistryForTests(registry);
+  const first = "/generation-one.jsonl";
+  const second = "/generation-two.jsonl";
+  const third = "/generation-three.jsonl";
+  const conversation = registry.ensureConversation("codex", first, "account-a");
+
+  registry.commitMigrationIntent({
+    engine: "codex",
+    targetId: "account-b",
+    origin: "manual",
+    requestId: "first-migration",
+    expectedRevision: registry.engineRouting("codex").revision,
+  });
+  const firstRevision = registry.conversation(conversation.id)!.migration!.revision;
+  registry.transitionConversationMigration(conversation.id, firstRevision, ["requested", "waiting-turn"], { phase: "preparing" });
+  registry.transitionConversationMigration(conversation.id, firstRevision, ["preparing"], { phase: "successor-starting" });
+  registry.transitionConversationMigration(conversation.id, firstRevision, ["successor-starting"], { phase: "verifying" });
+  registry.commitSuccessor(conversation.id, { id: "generation-two", path: second, accountId: "account-b" }, firstRevision);
+
+  const placed = await PATCH(patch({
+    schemaVersion: 1,
+    project: "repeated-migration",
+    baseRevision: 0,
+    mutations: [{ kind: "restore", path: second, placement: "manual" }],
+  }));
+  expect(placed.status).toBe(200);
+  expect(await placed.json()).toMatchObject({
+    board: { revision: 1, pathAliases: { [first]: second }, prefs: { manual: [second] } },
+  });
+
+  registry.commitMigrationIntent({
+    engine: "codex",
+    targetId: "account-c",
+    origin: "manual",
+    requestId: "second-migration",
+    expectedRevision: registry.engineRouting("codex").revision,
+  });
+  const secondRevision = registry.conversation(conversation.id)!.migration!.revision;
+  registry.recordConversationContinuityPath(conversation.id, third);
+
+  const closed = await PATCH(patch({
+    schemaVersion: 1,
+    project: "repeated-migration",
+    baseRevision: 1,
+    mutations: [{ kind: "close", path: second }],
+  }));
+  expect(closed.status).toBe(200);
+  const closedBody = await closed.json() as { board: { pathAliases: Record<string, string> } };
+  expect(closedBody).toMatchObject({
+    board: { revision: 2, prefs: { hidden: [second] } },
+  });
+  expect(closedBody.board.pathAliases).toEqual({ [first]: second });
+
+  registry.transitionConversationMigration(conversation.id, secondRevision, ["requested", "waiting-turn"], { phase: "preparing" });
+  registry.transitionConversationMigration(conversation.id, secondRevision, ["preparing"], { phase: "successor-starting" });
+  registry.transitionConversationMigration(conversation.id, secondRevision, ["successor-starting"], { phase: "verifying" });
+  registry.commitSuccessor(conversation.id, { id: "generation-three", path: third, accountId: "account-c" }, secondRevision);
+
+  const reconciled = await PATCH(patch({
+    schemaVersion: 1,
+    project: "repeated-migration",
+    baseRevision: 2,
+    mutations: [{ kind: "reconcile-roots", roots: [third], removeManual: [] }],
+  }));
+  expect(reconciled.status).toBe(200);
+  expect(await reconciled.json()).toMatchObject({
+    ok: true,
+    board: {
+      revision: 3,
+      pathAliases: { [first]: third, [second]: third },
+      prefs: { manual: [], hidden: [third] },
+    },
+  });
+});
+
 test("a corrupt conversation registry cannot block a valid close", async () => {
   fs.writeFileSync(path.join(path.dirname(testFile), "agent-registry.json"), "{ corrupt", "utf8");
 

--- a/src/app/api/board/route.test.ts
+++ b/src/app/api/board/route.test.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 
 import { NextRequest } from "next/server";
 
+import { emptyLaunchProfile } from "@/lib/accounts/migration/contracts";
 import { AgentRegistry, setAgentRegistryForTests } from "@/lib/agent/registry";
 import { setBoardFileForTests } from "@/lib/board/store";
 
@@ -271,6 +272,94 @@ test("a repeated migration cannot alias its pending successor backward", async (
   const reconciled = await PATCH(patch({
     schemaVersion: 1,
     project: "repeated-migration",
+    baseRevision: 2,
+    mutations: [{ kind: "reconcile-roots", roots: [third], removeManual: [] }],
+  }));
+  expect(reconciled.status).toBe(200);
+  expect(await reconciled.json()).toMatchObject({
+    ok: true,
+    board: {
+      revision: 3,
+      pathAliases: { [first]: third, [second]: third },
+      prefs: { manual: [], hidden: [third] },
+    },
+  });
+});
+
+test("a scanner-discovered repeated successor stays pending before its provider callback", async () => {
+  const registry = new AgentRegistry(path.join(path.dirname(testFile), "agent-registry.json"));
+  setAgentRegistryForTests(registry);
+  const first = "/scanner-generation-a.jsonl";
+  const second = "/scanner-generation-b.jsonl";
+  const third = "/scanner-generation-c.jsonl";
+  const conversation = registry.ensureConversation("codex", first, "account-a");
+
+  registry.commitMigrationIntent({
+    engine: "codex",
+    targetId: "account-b",
+    origin: "manual",
+    requestId: "scanner-first-migration",
+    expectedRevision: registry.engineRouting("codex").revision,
+  });
+  const firstRevision = registry.conversation(conversation.id)!.migration!.revision;
+  registry.transitionConversationMigration(conversation.id, firstRevision, ["requested", "waiting-turn"], { phase: "preparing" });
+  registry.transitionConversationMigration(conversation.id, firstRevision, ["preparing"], { phase: "successor-starting" });
+  registry.transitionConversationMigration(conversation.id, firstRevision, ["successor-starting"], { phase: "verifying" });
+  registry.commitSuccessor(conversation.id, { id: "scanner-generation-b", path: second, accountId: "account-b" }, firstRevision);
+
+  const placed = await PATCH(patch({
+    schemaVersion: 1,
+    project: "scanner-successor",
+    baseRevision: 0,
+    mutations: [{ kind: "restore", path: second, placement: "manual" }],
+  }));
+  expect(placed.status).toBe(200);
+
+  registry.commitMigrationIntent({
+    engine: "codex",
+    targetId: "account-c",
+    origin: "manual",
+    requestId: "scanner-second-migration",
+    expectedRevision: registry.engineRouting("codex").revision,
+  });
+  const secondRevision = registry.conversation(conversation.id)!.migration!.revision;
+  registry.beginSpawnRequest({
+    engine: "codex",
+    cwd: "/repo",
+    accountId: "account-c",
+    conversationId: conversation.id,
+    purpose: "migration-successor",
+    expectedArtifactPath: third,
+  });
+  registry.reconcileConversations([{
+    engine: "codex",
+    path: third,
+    accountId: "account-c",
+    launchProfile: emptyLaunchProfile({ cwd: "/repo" }),
+    turn: { state: "idle", source: "assistant", terminalAt: null },
+    observedAt: "2026-07-11T09:00:00.000Z",
+  }]);
+  expect(registry.conversation(conversation.id)?.migration?.pendingContinuityPaths).toEqual([third]);
+
+  const closed = await PATCH(patch({
+    schemaVersion: 1,
+    project: "scanner-successor",
+    baseRevision: 1,
+    mutations: [{ kind: "close", path: third }],
+  }));
+  expect(closed.status).toBe(200);
+  const closedBody = await closed.json() as { board: { pathAliases: Record<string, string> } };
+  expect(closedBody).toMatchObject({ board: { revision: 2, prefs: { hidden: [third] } } });
+  expect(closedBody.board.pathAliases).toEqual({ [first]: second });
+
+  registry.transitionConversationMigration(conversation.id, secondRevision, ["requested", "waiting-turn"], { phase: "preparing" });
+  registry.transitionConversationMigration(conversation.id, secondRevision, ["preparing"], { phase: "successor-starting" });
+  registry.transitionConversationMigration(conversation.id, secondRevision, ["successor-starting"], { phase: "verifying" });
+  registry.commitSuccessor(conversation.id, { id: "scanner-generation-c", path: third, accountId: "account-c" }, secondRevision);
+
+  const reconciled = await PATCH(patch({
+    schemaVersion: 1,
+    project: "scanner-successor",
     baseRevision: 2,
     mutations: [{ kind: "reconcile-roots", roots: [third], removeManual: [] }],
   }));

--- a/src/app/api/board/route.test.ts
+++ b/src/app/api/board/route.test.ts
@@ -7,7 +7,9 @@ import { NextRequest } from "next/server";
 
 import { emptyLaunchProfile } from "@/lib/accounts/migration/contracts";
 import { AgentRegistry, setAgentRegistryForTests } from "@/lib/agent/registry";
-import { setBoardFileForTests } from "@/lib/board/store";
+import type { BoardMutationV1 } from "@/lib/board/mutations";
+import { boardFor, setBoardFileForTests } from "@/lib/board/store";
+import type { BoardProjectStateV1 } from "@/lib/view/types";
 
 const sandbox = fs.mkdtempSync(path.join(os.tmpdir(), "llv-board-route-test-"));
 const { PATCH } = await import("./route");
@@ -31,6 +33,49 @@ function patch(body: unknown): NextRequest {
     headers: { host: "127.0.0.1", "content-type": "application/json" },
     body: JSON.stringify(body),
   });
+}
+
+async function mutateProject(project: string, mutations: BoardMutationV1[]): Promise<BoardProjectStateV1> {
+  const response = await PATCH(patch({
+    schemaVersion: 1,
+    project,
+    baseRevision: boardFor(project).revision,
+    mutations,
+  }));
+  expect(response.status).toBe(200);
+  const body = await response.json() as { board: BoardProjectStateV1 };
+  return body.board;
+}
+
+function beginMigration(
+  registry: AgentRegistry,
+  conversationId: Parameters<AgentRegistry["conversation"]>[0],
+  targetId: string,
+  successorPath: string,
+  requestId: string,
+): number {
+  registry.commitMigrationIntent({
+    engine: "codex",
+    targetId,
+    origin: "manual",
+    requestId,
+    expectedRevision: registry.engineRouting("codex").revision,
+  });
+  const revision = registry.conversation(conversationId)!.migration!.revision;
+  registry.recordConversationContinuityPath(conversationId, successorPath);
+  registry.transitionConversationMigration(conversationId, revision, ["requested", "waiting-turn"], { phase: "preparing" });
+  registry.transitionConversationMigration(conversationId, revision, ["preparing"], { phase: "successor-starting" });
+  return revision;
+}
+
+function commitMigration(
+  registry: AgentRegistry,
+  conversationId: Parameters<AgentRegistry["conversation"]>[0],
+  revision: number,
+  successor: { id: string; path: string; accountId: string },
+): void {
+  registry.transitionConversationMigration(conversationId, revision, ["successor-starting"], { phase: "verifying" });
+  registry.commitSuccessor(conversationId, successor, revision);
 }
 
 test("board route accepts revision-fenced mutations and converges an identical stale replay", async () => {
@@ -98,6 +143,158 @@ test("a retried legacy hidden list cannot erase a concurrent close", async () =>
     ok: true,
     board: { revision: 3, prefs: { manual: [], hidden: ["/card"], taskPanelOpen: true } },
   });
+});
+
+const lifecycleTransitions = [
+  "commit",
+  "cancel-return-to-source",
+  "target-retirement",
+  "chained-a-b-c",
+  "deferred-board-repair",
+  "queued-cleanup-receipt",
+] as const;
+const lifecycleCloseTimings = ["before", "during", "after"] as const;
+const lifecycleBoardOperations = ["alias-enrichment", "reconcile-roots", "remap-paths"] as const;
+const lifecycleMatrix = lifecycleTransitions.flatMap((lifecycle) =>
+  lifecycleCloseTimings.flatMap((closeTiming) =>
+    lifecycleBoardOperations.map((boardOperation) => [
+      `${lifecycle} / close-${closeTiming} / ${boardOperation}`,
+      lifecycle,
+      closeTiming,
+      boardOperation,
+    ] as const)));
+
+test.each(lifecycleMatrix)("migration lifecycle matrix: %s", async (_name, lifecycle, closeTiming, boardOperation) => {
+  const registry = new AgentRegistry(path.join(path.dirname(testFile), "agent-registry.json"));
+  setAgentRegistryForTests(registry);
+  const project = `lifecycle-${lifecycle}-${closeTiming}-${boardOperation}`;
+  const first = `/${project}-a.jsonl`;
+  const second = `/${project}-b.jsonl`;
+  const third = `/${project}-c.jsonl`;
+  const conversation = registry.ensureConversation("codex", first, "account-a");
+  let closedPath = first;
+  let finalPath = first;
+  let excludedPaths: string[] = [];
+  let expectedAliases: Record<string, string> = {};
+
+  await mutateProject(project, [{ kind: "restore", path: first, placement: "manual" }]);
+  const close = async (pathname: string): Promise<void> => {
+    closedPath = pathname;
+    await mutateProject(project, [{ kind: "close", path: pathname }]);
+  };
+  if (closeTiming === "before") await close(first);
+
+  if (lifecycle === "commit") {
+    const revision = beginMigration(registry, conversation.id, "account-b", second, `${project}-commit`);
+    if (closeTiming === "during") await close(second);
+    commitMigration(registry, conversation.id, revision, { id: `${project}-b`, path: second, accountId: "account-b" });
+    finalPath = second;
+    expectedAliases = { [first]: second };
+    if (closeTiming === "after") await close(second);
+  }
+
+  if (lifecycle === "cancel-return-to-source") {
+    const firstRevision = beginMigration(registry, conversation.id, "account-b", second, `${project}-first`);
+    commitMigration(registry, conversation.id, firstRevision, { id: `${project}-b`, path: second, accountId: "account-b" });
+    beginMigration(registry, conversation.id, "account-c", third, `${project}-pending`);
+    if (closeTiming === "during") await close(third);
+    registry.commitMigrationIntent({
+      engine: "codex",
+      targetId: "account-b",
+      origin: "manual",
+      requestId: `${project}-return`,
+      expectedRevision: registry.engineRouting("codex").revision,
+    });
+    finalPath = second;
+    excludedPaths = [third];
+    expectedAliases = { [first]: second };
+    if (closeTiming === "after") await close(second);
+  }
+
+  if (lifecycle === "target-retirement") {
+    const firstRevision = beginMigration(registry, conversation.id, "account-b", second, `${project}-first`);
+    commitMigration(registry, conversation.id, firstRevision, { id: `${project}-b`, path: second, accountId: "account-b" });
+    beginMigration(registry, conversation.id, "account-c", third, `${project}-pending`);
+    if (closeTiming === "during") await close(third);
+    registry.retireAccount("codex", "account-c", "account-b");
+    finalPath = second;
+    excludedPaths = [third];
+    expectedAliases = { [first]: second };
+    if (closeTiming === "after") await close(second);
+  }
+
+  if (lifecycle === "chained-a-b-c") {
+    const firstRevision = beginMigration(registry, conversation.id, "account-b", second, `${project}-first`);
+    commitMigration(registry, conversation.id, firstRevision, { id: `${project}-b`, path: second, accountId: "account-b" });
+    const secondRevision = beginMigration(registry, conversation.id, "account-c", third, `${project}-second`);
+    if (closeTiming === "during") await close(third);
+    commitMigration(registry, conversation.id, secondRevision, { id: `${project}-c`, path: third, accountId: "account-c" });
+    finalPath = third;
+    expectedAliases = { [first]: third, [second]: third };
+    if (closeTiming === "after") await close(third);
+  }
+
+  if (lifecycle === "deferred-board-repair") {
+    const firstRevision = beginMigration(registry, conversation.id, "account-b", second, `${project}-first`);
+    commitMigration(registry, conversation.id, firstRevision, { id: `${project}-b`, path: second, accountId: "account-b" });
+    beginMigration(registry, conversation.id, "account-c", third, `${project}-deferred`);
+    if (closeTiming === "during") await close(third);
+    finalPath = second;
+    excludedPaths = [third];
+    expectedAliases = { [first]: second };
+    if (closeTiming === "after") await close(second);
+  }
+
+  if (lifecycle === "queued-cleanup-receipt") {
+    const firstRevision = beginMigration(registry, conversation.id, "account-b", second, `${project}-first`);
+    commitMigration(registry, conversation.id, firstRevision, { id: `${project}-b`, path: second, accountId: "account-b" });
+    registry.recordConversationContinuityPath(conversation.id, third);
+    registry.queueSuccessorCleanup(conversation.id, {
+      operationId: `${project}-cleanup`,
+      nativeId: `${project}-c`,
+      path: third,
+      continuityPaths: [third],
+      historyHash: `${project}-history`,
+      host: {
+        kind: "codex-app-server",
+        identity: `${project}-host`,
+        epoch: 1,
+        verifiedAt: "2026-07-11T10:00:00.000Z",
+      },
+    });
+    if (closeTiming === "during") await close(third);
+    finalPath = second;
+    excludedPaths = [third];
+    expectedAliases = { [first]: second };
+    if (closeTiming === "after") await close(second);
+  }
+
+  let mutations: BoardMutationV1[];
+  if (boardOperation === "alias-enrichment") {
+    mutations = [{ kind: "close", path: closedPath }];
+  } else if (boardOperation === "reconcile-roots") {
+    mutations = [{ kind: "reconcile-roots", roots: [finalPath, ...excludedPaths], removeManual: [] }];
+  } else {
+    mutations = [{
+      kind: "remap-paths",
+      pairs: [
+        ...Object.entries(expectedAliases).map(([from, to]) => ({ from, to })),
+        ...excludedPaths.map((from) => ({ from, to: finalPath })),
+      ],
+    }];
+  }
+  const board = await mutateProject(project, mutations);
+
+  const resolveExpectedPath = (pathname: string): string => {
+    let resolved = pathname;
+    while (expectedAliases[resolved]) resolved = expectedAliases[resolved]!;
+    return resolved;
+  };
+  const expectedHidden = resolveExpectedPath(closedPath);
+  const expectedManual = resolveExpectedPath(first) === expectedHidden ? [] : [resolveExpectedPath(first)];
+  expect(board.pathAliases).toEqual(expectedAliases);
+  expect(board.prefs.hidden).toEqual([expectedHidden]);
+  expect(board.prefs.manual).toEqual(expectedManual);
 });
 
 test("a closed conversation stays hidden when a registry successor arrives without a client remap", async () => {

--- a/src/app/api/board/route.test.ts
+++ b/src/app/api/board/route.test.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 
 import { NextRequest } from "next/server";
 
+import { AgentRegistry, setAgentRegistryForTests } from "@/lib/agent/registry";
 import { setBoardFileForTests } from "@/lib/board/store";
 
 const sandbox = fs.mkdtempSync(path.join(os.tmpdir(), "llv-board-route-test-"));
@@ -12,11 +13,14 @@ const { PATCH } = await import("./route");
 
 let testFile = "";
 beforeEach(() => {
-  testFile = path.join(fs.mkdtempSync(path.join(sandbox, "state-")), "board.json");
+  const state = fs.mkdtempSync(path.join(sandbox, "state-"));
+  testFile = path.join(state, "board.json");
   setBoardFileForTests(testFile);
+  setAgentRegistryForTests(new AgentRegistry(path.join(state, "agent-registry.json")));
 });
 afterAll(() => {
   setBoardFileForTests(null);
+  setAgentRegistryForTests(null);
   fs.rmSync(sandbox, { recursive: true, force: true });
 });
 
@@ -54,4 +58,94 @@ test("board route returns the current board for a conflicting mutation and persi
   expect(conflict.status).toBe(409);
   expect(await conflict.json()).toMatchObject({ error: "BOARD_REVISION_CONFLICT", board: { revision: 1, prefs: { hidden: ["/one"] } } });
   expect(await presentation.json()).toMatchObject({ ok: true, board: { prefs: { viewMode: "scheme", taskPanelOpen: true } } });
+});
+
+test("a retried legacy hidden list cannot erase a concurrent close", async () => {
+  const seeded = await PATCH(patch({
+    schemaVersion: 1,
+    project: "legacy-close-race",
+    baseRevision: 0,
+    patch: { manual: ["/card"], hidden: [] },
+  }));
+  expect(seeded.status).toBe(200);
+
+  const closed = await PATCH(patch({
+    schemaVersion: 1,
+    project: "legacy-close-race",
+    baseRevision: 1,
+    mutations: [{ kind: "close", path: "/card" }],
+  }));
+  expect(closed.status).toBe(200);
+
+  const conflict = await PATCH(patch({
+    schemaVersion: 1,
+    project: "legacy-close-race",
+    baseRevision: 1,
+    patch: { manual: ["/card"], hidden: [], taskPanelOpen: true },
+  }));
+  expect(conflict.status).toBe(409);
+  expect(await conflict.json()).toMatchObject({ board: { revision: 2, prefs: { hidden: ["/card"] } } });
+
+  const retry = await PATCH(patch({
+    schemaVersion: 1,
+    project: "legacy-close-race",
+    baseRevision: 2,
+    patch: { manual: ["/card"], hidden: [], taskPanelOpen: true },
+  }));
+  expect(retry.status).toBe(200);
+  expect(await retry.json()).toMatchObject({
+    ok: true,
+    board: { revision: 3, prefs: { manual: [], hidden: ["/card"], taskPanelOpen: true } },
+  });
+});
+
+test("a closed conversation stays hidden when a registry successor arrives without a client remap", async () => {
+  const registry = new AgentRegistry(path.join(path.dirname(testFile), "agent-registry.json"));
+  setAgentRegistryForTests(registry);
+  const source = "/predecessor.jsonl";
+  const successor = "/successor.jsonl";
+  const conversation = registry.ensureConversation("codex", source, "account-a");
+
+  const seeded = await PATCH(patch({
+    schemaVersion: 1,
+    project: "successor-close",
+    baseRevision: 0,
+    patch: { manual: [source] },
+  }));
+  expect(seeded.status).toBe(200);
+  const closed = await PATCH(patch({
+    schemaVersion: 1,
+    project: "successor-close",
+    baseRevision: 1,
+    mutations: [{ kind: "close", path: source }],
+  }));
+  expect(closed.status).toBe(200);
+
+  registry.commitMigrationIntent({
+    engine: "codex",
+    targetId: "account-b",
+    origin: "manual",
+    requestId: "successor-close",
+    expectedRevision: registry.engineRouting("codex").revision,
+  });
+  const revision = registry.conversation(conversation.id)!.migration!.revision;
+  registry.transitionConversationMigration(conversation.id, revision, ["requested", "waiting-turn"], { phase: "preparing" });
+  registry.transitionConversationMigration(conversation.id, revision, ["preparing"], { phase: "successor-starting" });
+  registry.transitionConversationMigration(conversation.id, revision, ["successor-starting"], { phase: "verifying" });
+  registry.commitSuccessor(conversation.id, { id: "successor", path: successor, accountId: "account-b" }, revision);
+
+  const reconciled = await PATCH(patch({
+    schemaVersion: 1,
+    project: "successor-close",
+    baseRevision: 2,
+    mutations: [{ kind: "reconcile-roots", roots: [successor], removeManual: [] }],
+  }));
+  expect(reconciled.status).toBe(200);
+  expect(await reconciled.json()).toMatchObject({
+    ok: true,
+    board: {
+      pathAliases: { [source]: successor },
+      prefs: { manual: [], hidden: [successor] },
+    },
+  });
 });

--- a/src/app/api/board/route.ts
+++ b/src/app/api/board/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 
-import { agentRegistry } from "@/lib/agent/registry";
+import { agentRegistry, RegistryReadError } from "@/lib/agent/registry";
 import type { BoardMutationV1 } from "@/lib/board/mutations";
 import { boardFor, BoardStoreError, mutateBoard, patchBoard } from "@/lib/board/store";
 import { validateBoardPatchRequest } from "@/lib/board/validation";
@@ -29,9 +29,16 @@ function mutationsWithConversationAliases(mutations: readonly BoardMutationV1[])
   }
   if (mentionedPaths.size === 0) return [...mutations];
 
+  let conversations: ReturnType<ReturnType<typeof agentRegistry>["snapshot"]>["conversations"];
+  try {
+    conversations = agentRegistry().snapshot().conversations;
+  } catch (error) {
+    if (error instanceof RegistryReadError) return [...mutations];
+    throw error;
+  }
   const pairs: Array<{ from: string; to: string }> = [];
   const pairedSources = new Set(suppliedRemapSources);
-  for (const conversation of Object.values(agentRegistry().snapshot().conversations)) {
+  for (const conversation of Object.values(conversations)) {
     const paths = [
       ...conversation.generations.map((generation) => generation.path),
       ...conversation.continuityPaths,

--- a/src/app/api/board/route.ts
+++ b/src/app/api/board/route.ts
@@ -40,10 +40,11 @@ function mutationsWithConversationAliases(mutations: readonly BoardMutationV1[])
   const pairedSources = new Set(suppliedRemapSources);
   for (const conversation of Object.values(conversations)) {
     if (conversation.generations.length < 2) continue;
-    const pendingContinuityPaths = conversation.migration && conversation.migration.phase !== "committed"
-      ? new Set(conversation.migration.pendingContinuityPaths)
-      : new Set<string>();
-    const continuityPaths = conversation.continuityPaths.filter((pathname) => !pendingContinuityPaths.has(pathname));
+    const excludedContinuityPaths = new Set(conversation.abandonedContinuityPaths);
+    if (conversation.migration && conversation.migration.phase !== "committed") {
+      for (const pathname of conversation.migration.pendingContinuityPaths) excludedContinuityPaths.add(pathname);
+    }
+    const continuityPaths = conversation.continuityPaths.filter((pathname) => !excludedContinuityPaths.has(pathname));
     const paths = [
       ...conversation.generations.map((generation) => generation.path),
       ...continuityPaths,

--- a/src/app/api/board/route.ts
+++ b/src/app/api/board/route.ts
@@ -40,9 +40,12 @@ function mutationsWithConversationAliases(mutations: readonly BoardMutationV1[])
   const pairedSources = new Set(suppliedRemapSources);
   for (const conversation of Object.values(conversations)) {
     if (conversation.generations.length < 2) continue;
+    const continuityPaths = conversation.migration === null || conversation.migration.phase === "committed"
+      ? conversation.continuityPaths
+      : [];
     const paths = [
       ...conversation.generations.map((generation) => generation.path),
-      ...conversation.continuityPaths,
+      ...continuityPaths,
     ];
     if (!paths.some((pathname) => mentionedPaths.has(pathname))) continue;
     const target = conversation.generations.at(-1)?.path;

--- a/src/app/api/board/route.ts
+++ b/src/app/api/board/route.ts
@@ -13,7 +13,6 @@ const headers = { "Cache-Control": "no-store" };
 
 function mutationsWithConversationAliases(mutations: readonly BoardMutationV1[]): BoardMutationV1[] {
   const mentionedPaths = new Set<string>();
-  const suppliedRemapSources = new Set<string>();
   for (const mutation of mutations) {
     if (mutation.kind === "close" || mutation.kind === "restore") mentionedPaths.add(mutation.path);
     if (mutation.kind === "reconcile-roots") {
@@ -23,33 +22,73 @@ function mutationsWithConversationAliases(mutations: readonly BoardMutationV1[])
       for (const pair of mutation.pairs) {
         mentionedPaths.add(pair.from);
         mentionedPaths.add(pair.to);
-        suppliedRemapSources.add(pair.from);
       }
     }
   }
   if (mentionedPaths.size === 0) return [...mutations];
 
-  let conversations: ReturnType<ReturnType<typeof agentRegistry>["snapshot"]>["conversations"];
+  let snapshot: ReturnType<ReturnType<typeof agentRegistry>["snapshot"]>;
   try {
-    conversations = agentRegistry().snapshot().conversations;
+    snapshot = agentRegistry().snapshot();
   } catch (error) {
     if (error instanceof RegistryReadError) return [...mutations];
     throw error;
   }
+
+  const excludedByConversation = new Map<string, Set<string>>();
+  const excludedPaths = new Set<string>();
+  for (const conversation of Object.values(snapshot.conversations)) {
+    const excluded = new Set(conversation.abandonedContinuityPaths);
+    if (conversation.migration && conversation.migration.phase !== "committed") {
+      for (const pathname of conversation.migration.pendingContinuityPaths) excluded.add(pathname);
+    }
+    excludedByConversation.set(conversation.id, excluded);
+    for (const pathname of excluded) excludedPaths.add(pathname);
+  }
+  for (const cleanup of Object.values(snapshot.pendingSuccessorCleanups)) {
+    const excluded = excludedByConversation.get(cleanup.conversationId);
+    if (!excluded) continue;
+    for (const pathname of [...cleanup.receipt.continuityPaths, cleanup.receipt.path]) {
+      excluded.add(pathname);
+      excludedPaths.add(pathname);
+    }
+  }
+
+  const safeMutations = mutations.map((mutation): BoardMutationV1 => {
+    if (mutation.kind === "reconcile-roots") {
+      return { ...mutation, roots: mutation.roots.filter((pathname) => !excludedPaths.has(pathname)) };
+    }
+    if (mutation.kind === "remap-paths") {
+      return {
+        ...mutation,
+        pairs: mutation.pairs.filter(({ from, to }) => !excludedPaths.has(from) && !excludedPaths.has(to)),
+      };
+    }
+    return mutation;
+  });
+
+  const suppliedRemapSources = new Set<string>();
+  for (const mutation of safeMutations) {
+    if (mutation.kind === "remap-paths") {
+      for (const pair of mutation.pairs) {
+        suppliedRemapSources.add(pair.from);
+      }
+    }
+  }
+
   const pairs: Array<{ from: string; to: string }> = [];
   const pairedSources = new Set(suppliedRemapSources);
-  for (const conversation of Object.values(conversations)) {
+  for (const conversation of Object.values(snapshot.conversations)) {
     if (conversation.generations.length < 2) continue;
-    const excludedContinuityPaths = new Set(conversation.abandonedContinuityPaths);
-    if (conversation.migration && conversation.migration.phase !== "committed") {
-      for (const pathname of conversation.migration.pendingContinuityPaths) excludedContinuityPaths.add(pathname);
-    }
+    const excludedContinuityPaths = excludedByConversation.get(conversation.id) ?? new Set<string>();
     const continuityPaths = conversation.continuityPaths.filter((pathname) => !excludedContinuityPaths.has(pathname));
     const paths = [
       ...conversation.generations.map((generation) => generation.path),
       ...continuityPaths,
     ];
-    if (!paths.some((pathname) => mentionedPaths.has(pathname))) continue;
+    const conversationWasMentioned = paths.some((pathname) => mentionedPaths.has(pathname))
+      || [...excludedContinuityPaths].some((pathname) => mentionedPaths.has(pathname));
+    if (!conversationWasMentioned) continue;
     const target = conversation.generations.at(-1)?.path;
     if (!target) continue;
     for (const source of paths) {
@@ -59,8 +98,8 @@ function mutationsWithConversationAliases(mutations: readonly BoardMutationV1[])
     }
   }
   return pairs.length > 0
-    ? [{ kind: "remap-paths", pairs }, ...mutations]
-    : [...mutations];
+    ? [{ kind: "remap-paths", pairs }, ...safeMutations]
+    : safeMutations;
 }
 
 export function GET(request: NextRequest): NextResponse {

--- a/src/app/api/board/route.ts
+++ b/src/app/api/board/route.ts
@@ -1,5 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 
+import { agentRegistry } from "@/lib/agent/registry";
+import type { BoardMutationV1 } from "@/lib/board/mutations";
 import { boardFor, BoardStoreError, mutateBoard, patchBoard } from "@/lib/board/store";
 import { validateBoardPatchRequest } from "@/lib/board/validation";
 import { rejectCrossOrigin } from "@/lib/sameOrigin";
@@ -8,6 +10,45 @@ import { ViewValidationError } from "@/lib/view/validation";
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 const headers = { "Cache-Control": "no-store" };
+
+function mutationsWithConversationAliases(mutations: readonly BoardMutationV1[]): BoardMutationV1[] {
+  const mentionedPaths = new Set<string>();
+  const suppliedRemapSources = new Set<string>();
+  for (const mutation of mutations) {
+    if (mutation.kind === "close" || mutation.kind === "restore") mentionedPaths.add(mutation.path);
+    if (mutation.kind === "reconcile-roots") {
+      for (const pathname of mutation.roots) mentionedPaths.add(pathname);
+    }
+    if (mutation.kind === "remap-paths") {
+      for (const pair of mutation.pairs) {
+        mentionedPaths.add(pair.from);
+        mentionedPaths.add(pair.to);
+        suppliedRemapSources.add(pair.from);
+      }
+    }
+  }
+  if (mentionedPaths.size === 0) return [...mutations];
+
+  const pairs: Array<{ from: string; to: string }> = [];
+  const pairedSources = new Set(suppliedRemapSources);
+  for (const conversation of Object.values(agentRegistry().snapshot().conversations)) {
+    const paths = [
+      ...conversation.generations.map((generation) => generation.path),
+      ...conversation.continuityPaths,
+    ];
+    if (!paths.some((pathname) => mentionedPaths.has(pathname))) continue;
+    const target = conversation.generations.at(-1)?.path;
+    if (!target) continue;
+    for (const source of paths) {
+      if (source === target || pairedSources.has(source)) continue;
+      pairedSources.add(source);
+      pairs.push({ from: source, to: target });
+    }
+  }
+  return pairs.length > 0
+    ? [{ kind: "remap-paths", pairs }, ...mutations]
+    : [...mutations];
+}
 
 export function GET(request: NextRequest): NextResponse {
   const rejection = rejectCrossOrigin(request);
@@ -28,7 +69,7 @@ export async function PATCH(request: NextRequest): Promise<NextResponse> {
   try {
     const payload = await validateBoardPatchRequest(request);
     const result = payload.mutations
-      ? mutateBoard(payload.project, payload.baseRevision, payload.mutations)
+      ? mutateBoard(payload.project, payload.baseRevision, mutationsWithConversationAliases(payload.mutations))
       : patchBoard(payload.project, payload.baseRevision, payload.patch!);
     if (!result.ok) return NextResponse.json({ error: "BOARD_REVISION_CONFLICT", board: result.board }, { status: 409, headers });
     return NextResponse.json({ ok: true, board: result.board }, { headers });

--- a/src/app/api/board/route.ts
+++ b/src/app/api/board/route.ts
@@ -39,6 +39,7 @@ function mutationsWithConversationAliases(mutations: readonly BoardMutationV1[])
   const pairs: Array<{ from: string; to: string }> = [];
   const pairedSources = new Set(suppliedRemapSources);
   for (const conversation of Object.values(conversations)) {
+    if (conversation.generations.length < 2) continue;
     const paths = [
       ...conversation.generations.map((generation) => generation.path),
       ...conversation.continuityPaths,

--- a/src/app/api/board/route.ts
+++ b/src/app/api/board/route.ts
@@ -40,9 +40,10 @@ function mutationsWithConversationAliases(mutations: readonly BoardMutationV1[])
   const pairedSources = new Set(suppliedRemapSources);
   for (const conversation of Object.values(conversations)) {
     if (conversation.generations.length < 2) continue;
-    const continuityPaths = conversation.migration === null || conversation.migration.phase === "committed"
-      ? conversation.continuityPaths
-      : [];
+    const pendingContinuityPaths = conversation.migration && conversation.migration.phase !== "committed"
+      ? new Set(conversation.migration.pendingContinuityPaths)
+      : new Set<string>();
+    const continuityPaths = conversation.continuityPaths.filter((pathname) => !pendingContinuityPaths.has(pathname));
     const paths = [
       ...conversation.generations.map((generation) => generation.path),
       ...continuityPaths,

--- a/src/lib/accounts/migration/contracts.ts
+++ b/src/lib/accounts/migration/contracts.ts
@@ -78,6 +78,8 @@ export interface ConversationMigration {
   operationId: string;
   sourceGenerationId: string;
   providerReceipt: ProviderReceipt | null;
+  /** Continuity artifacts created by the active succession and awaiting commit. */
+  pendingContinuityPaths: string[];
   /** Canonical board project whose path aliases have converged for this generation. */
   boardProject: string | null;
   /** Migration operation whose aliases have converged in boardProject. */

--- a/src/lib/agent/registry.ts
+++ b/src/lib/agent/registry.ts
@@ -141,6 +141,8 @@ export interface RegistryConversation {
   /** Provider-created transcript artifacts that retain this conversation's
       identity while the canonical generation path advances. */
   continuityPaths: string[];
+  /** Continuity artifacts from canceled successions that must stay outside board aliases. */
+  abandonedContinuityPaths: string[];
   migration: ConversationMigration | null;
   /** Explicit Stop/Keep decision for one target at one routing revision. */
   migrationOptOut: { targetId: string; updatedAt: string } | null;
@@ -450,6 +452,9 @@ function normalizeConversation(value: RegistryConversation): RegistryConversatio
     ...(Array.isArray(legacyContinuity) ? legacyContinuity.filter((pathname): pathname is string => typeof pathname === "string") : []),
     ...(migration?.providerReceipt?.continuityPaths ?? []),
   ])];
+  const abandonedContinuityPaths = Array.isArray(value.abandonedContinuityPaths)
+    ? [...new Set(value.abandonedContinuityPaths.filter((pathname): pathname is string => typeof pathname === "string"))]
+    : [];
   const rawOptOut = (value as Partial<RegistryConversation>).migrationOptOut;
   const migrationOptOut = rawOptOut
     && typeof rawOptOut.targetId === "string"
@@ -460,6 +465,7 @@ function normalizeConversation(value: RegistryConversation): RegistryConversatio
     ...value,
     generations,
     continuityPaths,
+    abandonedContinuityPaths,
     migration,
     migrationOptOut,
     turn: value.turn && typeof value.turn === "object"
@@ -550,6 +556,12 @@ function addConversationContinuityPath(conversation: RegistryConversation, pathn
     && !conversation.migration.pendingContinuityPaths.includes(pathname)) {
     conversation.migration.pendingContinuityPaths.push(pathname);
   }
+}
+
+function abandonPendingContinuityPaths(conversation: RegistryConversation): void {
+  const pending = conversation.migration?.pendingContinuityPaths ?? [];
+  if (pending.length === 0) return;
+  conversation.abandonedContinuityPaths = [...new Set([...conversation.abandonedContinuityPaths, ...pending])];
 }
 
 function scannerAllocatedProvisionalOwner(conversation: RegistryConversation, pathname: string): boolean {
@@ -980,6 +992,7 @@ export class AgentRegistry {
       engine: receipt.engine as Extract<AgentEngine, "claude" | "codex">,
       generations: [],
       continuityPaths: [],
+      abandonedContinuityPaths: [],
       migration: null,
       migrationOptOut: null,
       turn: { state: "unknown" as const, source: "empty" as const, terminalAt: null, observedAt: null },
@@ -1217,6 +1230,7 @@ export class AgentRegistry {
           archivedAt: null,
         }],
         continuityPaths: [],
+        abandonedContinuityPaths: [],
         migration: null,
         migrationOptOut: null,
         turn: { state: "unknown", source: "empty", terminalAt: null, observedAt: null },
@@ -1268,6 +1282,7 @@ export class AgentRegistry {
               archivedAt: null,
             }],
             continuityPaths: [],
+            abandonedContinuityPaths: [],
             migration: null,
             migrationOptOut: null,
             turn: { ...observation.turn, observedAt: observation.observedAt },
@@ -1387,6 +1402,7 @@ export class AgentRegistry {
       if (retiredIntentIds.size === 0) return;
       for (const conversation of Object.values(file.conversations)) {
         if (!conversation.migration || !retiredIntentIds.has(conversation.migration.intentId)) continue;
+        abandonPendingContinuityPaths(conversation);
         queueAbandonedMigrationCleanup(file, conversation, changedAt);
         const source = conversation.generations.find((generation) => generation.id === conversation.migration?.sourceGenerationId)
           ?? conversation.generations.at(-1);
@@ -1460,6 +1476,7 @@ export class AgentRegistry {
         const source = conversation.generations.at(-1);
         if (!source || source.accountId === null || source.accountId === input.targetId) {
           if (source && conversation.migration && conversation.migration.phase !== "committed") {
+            abandonPendingContinuityPaths(conversation);
             queueAbandonedMigrationCleanup(file, conversation, changedAt);
             for (const delivery of Object.values(file.heldDeliveries)) {
               if (delivery.conversationId !== conversation.id
@@ -1743,6 +1760,10 @@ export class AgentRegistry {
       };
       conversation.generations.push(generation);
       conversation.continuityPaths = conversation.continuityPaths.filter((pathname) => pathname !== generation.path);
+      const committedContinuityPaths = new Set(conversation.migration.pendingContinuityPaths);
+      conversation.abandonedContinuityPaths = conversation.abandonedContinuityPaths.filter(
+        (pathname) => !committedContinuityPaths.has(pathname),
+      );
       conversation.migration = { ...conversation.migration, phase: "committed", updatedAt: now() };
       conversation.updatedAt = now();
       for (const delivery of Object.values(file.heldDeliveries)) {

--- a/src/lib/agent/registry.ts
+++ b/src/lib/agent/registry.ts
@@ -177,8 +177,8 @@ export interface ConversationLookup {
   conversation(id: ViewerConversationId): RegistryConversation | null;
 }
 
-type ConversationMigrationInput = Omit<ConversationMigration, "errorCode" | "operationId" | "sourceGenerationId" | "providerReceipt" | "boardProject" | "boardOperationId" | "boardPlacementProject"> &
-  Partial<Pick<ConversationMigration, "errorCode" | "operationId" | "sourceGenerationId" | "providerReceipt" | "boardProject" | "boardOperationId" | "boardPlacementProject">>;
+type ConversationMigrationInput = Omit<ConversationMigration, "errorCode" | "operationId" | "sourceGenerationId" | "providerReceipt" | "pendingContinuityPaths" | "boardProject" | "boardOperationId" | "boardPlacementProject"> &
+  Partial<Pick<ConversationMigration, "errorCode" | "operationId" | "sourceGenerationId" | "providerReceipt" | "pendingContinuityPaths" | "boardProject" | "boardOperationId" | "boardPlacementProject">>;
 type SuccessorGenerationInput = Omit<NativeGeneration, "createdAt" | "archivedAt" | "launchProfile" | "historyHash" | "host"> &
   Partial<Pick<NativeGeneration, "launchProfile" | "historyHash" | "host">>;
 
@@ -290,6 +290,9 @@ function conversationMigrationForIntent(
   changedAt: string,
 ): ConversationMigration {
   const boardProject = conversation.migration?.boardProject ?? null;
+  const pendingContinuityPaths = conversation.migration && conversation.migration.phase !== "committed"
+    ? conversation.migration.pendingContinuityPaths
+    : [];
   return {
     intentId: intent.id,
     phase,
@@ -300,6 +303,7 @@ function conversationMigrationForIntent(
     operationId: crypto.randomUUID(),
     sourceGenerationId: source.id,
     providerReceipt: null,
+    pendingContinuityPaths,
     boardProject,
     boardOperationId: conversation.migration?.boardOperationId ?? null,
     boardPlacementProject: conversation.migration?.boardPlacementProject
@@ -422,13 +426,20 @@ function normalizeConversation(value: RegistryConversation): RegistryConversatio
   const generations = Array.isArray(value.generations) ? value.generations.map(normalizeGeneration) : [];
   const current = generations.at(-1);
   const legacyContinuity = (value.migration as (ConversationMigration & { continuityPaths?: unknown }) | null)?.continuityPaths;
+  const providerReceipt = normalizeProviderReceipt(value.migration?.providerReceipt);
+  const pendingContinuityPaths = Array.isArray(value.migration?.pendingContinuityPaths)
+    ? value.migration.pendingContinuityPaths.filter((pathname): pathname is string => typeof pathname === "string")
+    : value.migration?.phase !== "committed" && providerReceipt
+      ? [...new Set([...providerReceipt.continuityPaths, providerReceipt.path])]
+      : [];
   const migration = value.migration && typeof value.migration === "object"
     ? {
       ...value.migration,
       errorCode: value.migration.errorCode ?? null,
       operationId: value.migration.operationId ?? `${value.migration.intentId}:${value.id}:${value.migration.revision}`,
       sourceGenerationId: value.migration.sourceGenerationId ?? current?.id ?? "",
-      providerReceipt: normalizeProviderReceipt(value.migration.providerReceipt),
+      providerReceipt,
+      pendingContinuityPaths,
       boardProject: typeof value.migration.boardProject === "string" ? value.migration.boardProject : null,
       boardOperationId: typeof value.migration.boardOperationId === "string" ? value.migration.boardOperationId : null,
       boardPlacementProject: typeof value.migration.boardPlacementProject === "string" ? value.migration.boardPlacementProject : null,
@@ -1008,6 +1019,7 @@ export class AgentRegistry {
         operationId: crypto.randomUUID(),
         sourceGenerationId: source.id,
         providerReceipt: null,
+        pendingContinuityPaths: [],
         boardProject: null,
         boardOperationId: null,
         boardPlacementProject: source.launchProfile.project,
@@ -1553,6 +1565,7 @@ export class AgentRegistry {
         operationId: migration.operationId ?? `${migration.intentId}:${canonicalId}:${migration.revision}`,
         sourceGenerationId: migration.sourceGenerationId ?? source?.id ?? "",
         providerReceipt: migration.providerReceipt ?? null,
+        pendingContinuityPaths: migration.pendingContinuityPaths ?? [],
         boardProject: migration.boardProject ?? null,
         boardOperationId: migration.boardOperationId ?? null,
         boardPlacementProject: migration.boardPlacementProject ?? migration.boardProject ?? null,
@@ -1593,7 +1606,17 @@ export class AgentRegistry {
         throw new Error("migration provider receipt is stale");
       }
       if (migration.phase === "successor-starting") {
-        conversation.migration = { ...migration, phase: "verifying", providerReceipt: receipt, updatedAt: now() };
+        const receiptPaths = [...new Set([...receipt.continuityPaths, receipt.path])];
+        for (const pathname of receiptPaths) {
+          if (!conversation.continuityPaths.includes(pathname)) conversation.continuityPaths.push(pathname);
+        }
+        conversation.migration = {
+          ...migration,
+          phase: "verifying",
+          providerReceipt: receipt,
+          pendingContinuityPaths: [...new Set([...migration.pendingContinuityPaths, ...receiptPaths])],
+          updatedAt: now(),
+        };
         conversation.updatedAt = now();
         return clone(conversation);
       }
@@ -1619,6 +1642,10 @@ export class AgentRegistry {
         }
       }
       if (!conversation.continuityPaths.includes(pathname)) conversation.continuityPaths.push(pathname);
+      if (conversation.migration && conversation.migration.phase !== "committed"
+        && !conversation.migration.pendingContinuityPaths.includes(pathname)) {
+        conversation.migration.pendingContinuityPaths.push(pathname);
+      }
       conversation.updatedAt = now();
       return clone(conversation);
     });
@@ -1678,6 +1705,7 @@ export class AgentRegistry {
         operationId: current.errorCode === "codex-fork-outcome-unknown" ? current.operationId : crypto.randomUUID(),
         sourceGenerationId: source.id,
         providerReceipt: null,
+        pendingContinuityPaths: current.phase === "committed" ? [] : current.pendingContinuityPaths,
         boardProject: current.boardProject,
         boardOperationId: current.boardOperationId,
         boardPlacementProject: current.boardPlacementProject,

--- a/src/lib/agent/registry.ts
+++ b/src/lib/agent/registry.ts
@@ -543,6 +543,15 @@ function conversationOwnsPath(conversation: RegistryConversation, artifactPath: 
     || conversation.continuityPaths.includes(artifactPath);
 }
 
+function addConversationContinuityPath(conversation: RegistryConversation, pathname: string): void {
+  if (conversation.generations.some((generation) => generation.path === pathname)) return;
+  if (!conversation.continuityPaths.includes(pathname)) conversation.continuityPaths.push(pathname);
+  if (conversation.migration && conversation.migration.phase !== "committed"
+    && !conversation.migration.pendingContinuityPaths.includes(pathname)) {
+    conversation.migration.pendingContinuityPaths.push(pathname);
+  }
+}
+
 function scannerAllocatedProvisionalOwner(conversation: RegistryConversation, pathname: string): boolean {
   const generation = conversation.generations[0];
   return conversation.migration === null
@@ -984,10 +993,7 @@ export class AgentRegistry {
       if (provisionalOwner && !adoptProvisionalOwner(file, provisionalOwner, conversation, entry.artifactPath)) {
         return conflict("spawn_artifact_conflict");
       }
-      if (!conversation.continuityPaths.includes(entry.artifactPath)
-        && !conversation.generations.some((generation) => generation.path === entry.artifactPath)) {
-        conversation.continuityPaths.push(entry.artifactPath);
-      }
+      addConversationContinuityPath(conversation, entry.artifactPath);
     }
     if (receipt.purpose !== "migration-successor" && !conversation.generations.some((generation) => generation.path === entry.artifactPath)) {
       conversation.generations.push({
@@ -1241,7 +1247,7 @@ export class AgentRegistry {
           const migrationOwner = migrationReceipt ? file.conversations[migrationReceipt.conversationId] : null;
           if (migrationOwner) {
             conversation = migrationOwner;
-            if (!conversation.continuityPaths.includes(observation.path)) conversation.continuityPaths.push(observation.path);
+            addConversationContinuityPath(conversation, observation.path);
             conversation.updatedAt = observation.observedAt;
             scopeChanged.add(observation.engine);
           }
@@ -1608,13 +1614,12 @@ export class AgentRegistry {
       if (migration.phase === "successor-starting") {
         const receiptPaths = [...new Set([...receipt.continuityPaths, receipt.path])];
         for (const pathname of receiptPaths) {
-          if (!conversation.continuityPaths.includes(pathname)) conversation.continuityPaths.push(pathname);
+          addConversationContinuityPath(conversation, pathname);
         }
         conversation.migration = {
           ...migration,
           phase: "verifying",
           providerReceipt: receipt,
-          pendingContinuityPaths: [...new Set([...migration.pendingContinuityPaths, ...receiptPaths])],
           updatedAt: now(),
         };
         conversation.updatedAt = now();
@@ -1641,11 +1646,7 @@ export class AgentRegistry {
           throw new Error("migration continuity path has another durable owner");
         }
       }
-      if (!conversation.continuityPaths.includes(pathname)) conversation.continuityPaths.push(pathname);
-      if (conversation.migration && conversation.migration.phase !== "committed"
-        && !conversation.migration.pendingContinuityPaths.includes(pathname)) {
-        conversation.migration.pendingContinuityPaths.push(pathname);
-      }
+      addConversationContinuityPath(conversation, pathname);
       conversation.updatedAt = now();
       return clone(conversation);
     });

--- a/src/lib/board/store.ts
+++ b/src/lib/board/store.ts
@@ -158,6 +158,16 @@ export function boardFor(project: string, filePath = boardFileForTests ?? BOARD_
 export type BoardPatch = Partial<BoardProjectStateV1["prefs"]>;
 type BoardWriteResult = { ok: true; board: BoardProjectStateV1 } | { ok: false; board: BoardProjectStateV1 };
 
+function applyLegacyPatch(current: BoardProjectStateV1, patch: BoardPatch): BoardProjectStateV1 {
+  const hidden = patch.hidden === undefined
+    ? current.prefs.hidden
+    : [...new Set([...current.prefs.hidden, ...patch.hidden])];
+  return applyBoardMutations({
+    ...current,
+    prefs: { ...current.prefs, ...patch, hidden },
+  }, []);
+}
+
 function sameReduced(left: BoardProjectStateV1, right: BoardProjectStateV1): boolean {
   return JSON.stringify({ prefs: left.prefs, pathAliases: left.pathAliases ?? {} }) === JSON.stringify({ prefs: right.prefs, pathAliases: right.pathAliases ?? {} });
 }
@@ -196,7 +206,7 @@ function writeLatest(project: string, reduce: (current: BoardProjectStateV1) => 
 }
 
 export function patchBoard(project: string, baseRevision: number, patch: BoardPatch, filePath = boardFileForTests ?? BOARD_FILE): { ok: true; board: BoardProjectStateV1 } | { ok: false; board: BoardProjectStateV1 } {
-  return writeReduced(project, baseRevision, (current) => ({ ...current, prefs: { ...current.prefs, ...patch } }), filePath);
+  return writeReduced(project, baseRevision, (current) => applyLegacyPatch(current, patch), filePath);
 }
 
 export function mutateBoard(project: string, baseRevision: number, mutations: readonly BoardMutationV1[], filePath = boardFileForTests ?? BOARD_FILE): BoardWriteResult {


### PR DESCRIPTION
## Summary

- preserve existing close tombstones when a legacy whole-list board PATCH retries after a revision conflict
- resolve durable conversation generations and continuity paths before server-side board mutations
- carry hidden placement onto successors even when a client omits `remap-paths`

## Root cause

A stale whole-list client could adopt the latest revision after a 409 and resend its earlier `hidden` array. The server treated that array as a replacement, which erased closes committed by another writer. Successor durability also depended on client-provided remap pairs, leaving a gap when a new transcript path arrived without one.

## Validation

- `bun test` — 1,383 passed
- `bunx tsc --noEmit`

Refs #60