### PR TITLE
Fix reading pane jump during activity reorder

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -1,15 +1,15 @@
-# Issue 121: deployment proxy request forwarding
+# Issue 24: preserve reading-pane state during activity reordering
 
 ## Task statement
 
-Investigate the first managed Viewer cutover failure where `serveViewerDeploymentProxy` accepted connections on the stable listener while returning zero response bytes. Repair request forwarding for the production `bun-container` runtime, preserve the target-file listener-switch design, cover the failure with a real TCP regression test, and remove the public-repository SSH bootstrap papercut.
+Fix the reading-pane scroll jump that occurs when scheme activity changes pane ordering. Keep pane hosts stable in the DOM while allowing their visual positions to update, so browser-owned reading state survives an overtake.
 
 ## Acceptance criteria
 
-- AC1: The deployment proxy forwards a request sent immediately after downstream TCP connection and returns the candidate Viewer response.
-- AC2: The proxy preserves request bytes while its upstream connection is being established under production-image Bun 1.2.18.
-- AC3: A regression test drives an external TCP client through an in-process proxy and upstream listener.
-- AC4: Missing, invalid, or recursive release targets continue to receive the existing `503 Service Unavailable` response.
-- AC5: The default canonical remote for the public repository uses HTTPS and remains configurable through `LLV_VIEWER_CANONICAL_REMOTE`.
-- AC6: `bun test` and `bunx tsc --noEmit` pass.
-- AC7: Investigation and verification use unused high ports and leave the production listener, runtime-host, legacy Viewer, and managed candidate lifecycle unchanged.
+- AC1: Scheme pane hosts retain stable DOM order while freshness changes their visual order.
+- AC2: An activity overtake preserves the reading pane's scroll position.
+- AC3: An activity overtake preserves focus, text selection, and selected state.
+- AC4: Pane identity and existing scheme ordering behavior remain unchanged outside DOM placement.
+- AC5: A deterministic DOM regression test covers an overtake while a pane is being read.
+- AC6: `bun test` passes.
+- AC7: `bunx tsc --noEmit` passes.

--- a/src/components/LogFeed.tsx
+++ b/src/components/LogFeed.tsx
@@ -46,6 +46,7 @@ const GLUE_SETTLE_MS = 300;
 /* Scroll state per stable conversation, surviving pane remounts and native
    generation changes during account migration. */
 interface ViewportAnchor {
+  path: string;
   key: string;
   offset: number;
 }
@@ -72,11 +73,11 @@ function feedRows(scroller: HTMLElement): HTMLElement[] {
   return Array.from(scroller.querySelectorAll<HTMLElement>("[data-feed-key]"));
 }
 
-function viewportAnchor(scroller: HTMLElement): ViewportAnchor | null {
+function viewportAnchor(scroller: HTMLElement, path: string): ViewportAnchor | null {
   const viewportTop = scroller.getBoundingClientRect().top;
   const row = feedRows(scroller).find((candidate) => candidate.getBoundingClientRect().bottom > viewportTop);
   const key = row?.dataset.feedKey;
-  return row && key ? { key, offset: row.getBoundingClientRect().top - viewportTop } : null;
+  return row && key ? { path, key, offset: row.getBoundingClientRect().top - viewportTop } : null;
 }
 
 function rowForAnchor(scroller: HTMLElement, key: string): HTMLElement | null {
@@ -181,12 +182,13 @@ export function LogFeed({ file, showSvc, lineFilter, onStatus, paused, follow, s
       pendingRestoreRef.current = null;
       return false;
     }
-    if (pending.anchor) {
-      const row = rowForAnchor(el, pending.anchor.key);
+    const anchor = pending.anchor?.path === pending.path ? pending.anchor : null;
+    if (anchor) {
+      const row = rowForAnchor(el, anchor.key);
       if (row) {
         const currentOffset = row.getBoundingClientRect().top - el.getBoundingClientRect().top;
         glueAtRef.current = Date.now();
-        el.scrollTop += currentOffset - pending.anchor.offset;
+        el.scrollTop += currentOffset - anchor.offset;
         pending.applied = true;
         return true;
       }
@@ -196,7 +198,7 @@ export function LogFeed({ file, showSvc, lineFilter, onStatus, paused, follow, s
     el.scrollTop = Math.max(0, maxScroll - pending.fromBottom);
     if (maxScroll < pending.fromBottom) return false;
     pending.applied = true;
-    if (!pending.anchor) pendingRestoreRef.current = null;
+    if (!anchor) pendingRestoreRef.current = null;
     return true;
   };
 
@@ -416,11 +418,11 @@ export function LogFeed({ file, showSvc, lineFilter, onStatus, paused, follow, s
             if (settling) glue();
             else setMagnet(false);
           }
-          if (memoryKey && !settling) {
+          if (memoryKey && file && !settling) {
             rememberScroll(memoryKey, {
               magnet: magnetRef.current,
               fromBottom: Math.max(0, el.scrollHeight - el.clientHeight - el.scrollTop),
-              anchor: magnetRef.current ? null : viewportAnchor(el),
+              anchor: magnetRef.current ? null : viewportAnchor(el, file.path),
             });
           }
           if (el.scrollTop < 120 && canRevealOlder && !tail.loadingOlder && !tail.loading) revealOlder();
@@ -465,11 +467,11 @@ export function LogFeed({ file, showSvc, lineFilter, onStatus, paused, follow, s
             {compact ? null : <TaskHeader file={file} />}
             {feed.items.length ? (
               <>
-                {visibleItems.map(({ key, item }) =>
+                {visibleItems.map(({ anchorKey, key, item }) =>
                   /* Session-stable keys: a row keeps its DOM node while the
                      window slides. Compact panes live on the zoomable canvas:
                      off-screen rows skip layout/paint via content-visibility. */
-                  <div key={key} data-feed-key={key} className={compact ? "feed-cv" : undefined}>
+                  <div key={key} data-feed-key={anchorKey ?? undefined} className={compact ? "feed-cv" : undefined}>
                     <FeedItem item={item} />
                   </div>,
                 )}

--- a/src/components/LogFeed.tsx
+++ b/src/components/LogFeed.tsx
@@ -103,9 +103,14 @@ export function LogFeed({ file, showSvc, lineFilter, onStatus, paused, follow, s
   const lastPrependRef = useRef(0);
   const pulseTimer = useRef<number | null>(null);
   const glueAtRef = useRef(0);
-  const restoredPathRef = useRef<string | null>(null);
+  const restoreInitializedPathRef = useRef<string | null>(null);
+  const pendingRestoreRef = useRef<{ path: string; fromBottom: number } | null>(null);
+  const filePathRef = useRef(file?.path ?? null);
+  const controlledFollowRef = useRef(follow);
+  filePathRef.current = file?.path ?? null;
 
   const setMagnet = (value: boolean, withPulse = false) => {
+    pendingRestoreRef.current = null;
     magnetRef.current = value;
     setMagnetState(value);
     setFollow(value);
@@ -128,20 +133,43 @@ export function LogFeed({ file, showSvc, lineFilter, onStatus, paused, follow, s
     el.scrollTop = el.scrollHeight;
   };
 
+  /* A released pane can mount before its full content has measurable height.
+     Apply the best reachable position and keep retrying until the remembered
+     distance from the tail fits inside the current scroll range. */
+  const restorePendingPosition = () => {
+    const el = scroller.current;
+    const pending = pendingRestoreRef.current;
+    if (!el || !pending || magnetRef.current) return false;
+    if (pending.path !== filePathRef.current) {
+      pendingRestoreRef.current = null;
+      return false;
+    }
+    const maxScroll = Math.max(0, el.scrollHeight - el.clientHeight);
+    glueAtRef.current = Date.now();
+    el.scrollTop = Math.max(0, maxScroll - pending.fromBottom);
+    if (maxScroll < pending.fromBottom) return false;
+    pendingRestoreRef.current = null;
+    return true;
+  };
+
   // eslint-disable-next-line react-hooks/set-state-in-effect
   useEffect(() => setVisibleCount(initialCount), [file?.path, initialCount]);
   /* Same instance, new transcript: pick up that transcript's remembered state. */
   useEffect(() => {
     if (!file) return;
-    const remembered = scrollMemory.get(file.path)?.magnet ?? true;
+    const remembered = scrollMemory.get(file.path)?.magnet ?? follow;
     if (remembered !== magnetRef.current) {
       magnetRef.current = remembered;
        
       setMagnetState(remembered);
     }
   }, [file?.path]); // eslint-disable-line react-hooks/exhaustive-deps
-  /* External Follow toggle (focus header) drives the same magnet. */
+  /* External Follow transitions from the focus header drive the same magnet.
+     A compact pane's constant true value leaves remount memory authoritative. */
   useEffect(() => {
+    if (follow === controlledFollowRef.current) return;
+    controlledFollowRef.current = follow;
+    pendingRestoreRef.current = null;
     if (follow !== magnetRef.current) {
       magnetRef.current = follow;
       setMagnetState(follow);
@@ -209,6 +237,11 @@ export function LogFeed({ file, showSvc, lineFilter, onStatus, paused, follow, s
     else onStatus("");
   }, [tail.error, tail.size, tail.tickTime, file, onStatus]);
 
+  useLayoutEffect(() => {
+    restoreInitializedPathRef.current = null;
+    pendingRestoreRef.current = null;
+  }, [file?.path]);
+
   /* Older history grows the content above the viewport; keep what the user
      was reading in place by compensating the scroll offset. */
   useLayoutEffect(() => {
@@ -231,17 +264,18 @@ export function LogFeed({ file, showSvc, lineFilter, onStatus, paused, follow, s
     lastPrependRef.current = tail.prependGen;
     const delta = len - lastLenRef.current;
     lastLenRef.current = len;
-    /* First non-empty render of a released pane after a remount: return to
-       the remembered distance from the tail rather than the top. */
-    if (file && len && restoredPathRef.current !== file.path) {
-      restoredPathRef.current = file.path;
+    /* First non-empty render of a released pane after a remount: stage the
+       remembered distance from the tail for immediate and resize retries. */
+    if (file && len && restoreInitializedPathRef.current !== file.path) {
+      restoreInitializedPathRef.current = file.path;
       const remembered = scrollMemory.get(file.path);
-      if (!magnet && remembered && remembered.fromBottom > 0 && scroller.current) {
-        const el = scroller.current;
-        glueAtRef.current = Date.now();
-        el.scrollTop = Math.max(0, el.scrollHeight - el.clientHeight - remembered.fromBottom);
-        return;
-      }
+      pendingRestoreRef.current = !magnet && remembered && remembered.fromBottom > 0
+        ? { path: file.path, fromBottom: remembered.fromBottom }
+        : null;
+    }
+    if (pendingRestoreRef.current) {
+      restorePendingPosition();
+      return;
     }
     if (magnet) {
       glue();
@@ -258,6 +292,7 @@ export function LogFeed({ file, showSvc, lineFilter, onStatus, paused, follow, s
     if (!el || !inner) return;
     const observer = new ResizeObserver(() => {
       if (magnetRef.current) glue();
+      else restorePendingPosition();
     });
     observer.observe(inner);
     observer.observe(el);
@@ -320,6 +355,7 @@ export function LogFeed({ file, showSvc, lineFilter, onStatus, paused, follow, s
           const el = event.currentTarget;
           const atBottom = el.scrollTop + el.clientHeight >= el.scrollHeight - 50;
           const settling = Date.now() - glueAtRef.current < GLUE_SETTLE_MS;
+          if (!settling) pendingRestoreRef.current = null;
           if (atBottom && !magnetRef.current) setMagnet(true, true);
           else if (!atBottom && magnetRef.current) {
             /* Off-bottom right after a programmatic glue is layout settling

--- a/src/components/LogFeed.tsx
+++ b/src/components/LogFeed.tsx
@@ -5,6 +5,7 @@ import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 
 import { ArrowDown, ChevronUp, Sparkle } from "@/components/icons";
 import { useLogTail } from "@/hooks/useLogTail";
+import { conversationIdentity } from "@/lib/accounts/identity";
 import { getLocale, translate, useLocale } from "@/lib/i18n";
 import type { FileEntry } from "@/lib/types";
 
@@ -13,6 +14,7 @@ import { isAwaitingUser } from "@/hooks/useSwitchboardData";
 import { createFeedSession, type FeedSession, type FeedSnapshot } from "./feed/parse";
 import { FeedItem } from "./feed/FeedItem";
 import { RawLineProvider, type RawLineLookup } from "./feed/rawLine";
+import { BoundedLru } from "./feed/scrollMemory";
 import { QuestionCard } from "./feed/QuestionCard";
 import { isSubagent } from "./projectModel";
 import { TaskHeader } from "./TaskHeader";
@@ -41,16 +43,44 @@ const EMPTY_FEED: FeedSnapshot = { items: [], hiddenServiceCount: 0 };
     again. User releases are real scrolls that arrive outside this window. */
 const GLUE_SETTLE_MS = 300;
 
-/* Scroll state per transcript, surviving pane remounts: layout reshuffles can
-   unmount a pane (a conversation moves between shell kinds), and a fresh
-   instance used to start at the top as if unread. Glued panes re-glue, and
-   released panes return to the same distance from the tail. */
-const scrollMemory = new Map<string, { magnet: boolean; fromBottom: number }>();
-const SCROLL_MEMORY_CAP = 300;
+/* Scroll state per stable conversation, surviving pane remounts and native
+   generation changes during account migration. */
+interface ViewportAnchor {
+  key: string;
+  offset: number;
+}
 
-function rememberScroll(path: string, magnet: boolean, fromBottom: number): void {
-  if (scrollMemory.size > SCROLL_MEMORY_CAP && !scrollMemory.has(path)) scrollMemory.clear();
-  scrollMemory.set(path, { magnet, fromBottom });
+interface ScrollMemory {
+  magnet: boolean;
+  fromBottom: number;
+  anchor: ViewportAnchor | null;
+}
+
+interface PendingRestore extends ScrollMemory {
+  path: string;
+  applied: boolean;
+}
+
+const SCROLL_MEMORY_CAP = 300;
+const scrollMemory = new BoundedLru<ScrollMemory>(SCROLL_MEMORY_CAP);
+
+function rememberScroll(key: string, memory: ScrollMemory): void {
+  scrollMemory.set(key, memory);
+}
+
+function feedRows(scroller: HTMLElement): HTMLElement[] {
+  return Array.from(scroller.querySelectorAll<HTMLElement>("[data-feed-key]"));
+}
+
+function viewportAnchor(scroller: HTMLElement): ViewportAnchor | null {
+  const viewportTop = scroller.getBoundingClientRect().top;
+  const row = feedRows(scroller).find((candidate) => candidate.getBoundingClientRect().bottom > viewportTop);
+  const key = row?.dataset.feedKey;
+  return row && key ? { key, offset: row.getBoundingClientRect().top - viewportTop } : null;
+}
+
+function rowForAnchor(scroller: HTMLElement, key: string): HTMLElement | null {
+  return feedRows(scroller).find((row) => row.dataset.feedKey === key) ?? null;
 }
 
 /** Animated presence row: the agent of a live transcript is mid-turn right now. */
@@ -81,10 +111,11 @@ interface Props {
 
 export function LogFeed({ file, showSvc, lineFilter, onStatus, paused, follow, setFollow, compact = false }: Props) {
   const { locale, t } = useLocale();
+  const memoryKey = file ? conversationIdentity(file) : null;
   /* The scroll magnet lives per feed instance, so each column remembers its
      own state across polls: glued to the live tail, or released by the user.
      A remount inherits the transcript's remembered state. */
-  const [magnet, setMagnetState] = useState(() => (file ? (scrollMemory.get(file.path)?.magnet ?? follow) : follow));
+  const [magnet, setMagnetState] = useState(() => (memoryKey ? (scrollMemory.get(memoryKey)?.magnet ?? follow) : follow));
   /* Released reader must never lose lines above the viewport: the tail cap
      applies only while the magnet holds the bottom in view anyway. */
   const tail = useLogTail(file, paused, magnet ? (compact ? TAIL_CAP : FOCUS_CAP) : 0);
@@ -104,7 +135,7 @@ export function LogFeed({ file, showSvc, lineFilter, onStatus, paused, follow, s
   const pulseTimer = useRef<number | null>(null);
   const glueAtRef = useRef(0);
   const restoreInitializedPathRef = useRef<string | null>(null);
-  const pendingRestoreRef = useRef<{ path: string; fromBottom: number } | null>(null);
+  const pendingRestoreRef = useRef<PendingRestore | null>(null);
   const filePathRef = useRef(file?.path ?? null);
   const controlledFollowRef = useRef(follow);
 
@@ -114,7 +145,14 @@ export function LogFeed({ file, showSvc, lineFilter, onStatus, paused, follow, s
     setMagnetState(value);
     setFollow(value);
     if (value) setNewCount(0);
-    if (file) rememberScroll(file.path, value, scrollMemory.get(file.path)?.fromBottom ?? 0);
+    if (memoryKey) {
+      const remembered = scrollMemory.get(memoryKey);
+      rememberScroll(memoryKey, {
+        magnet: value,
+        fromBottom: remembered?.fromBottom ?? 0,
+        anchor: value ? null : (remembered?.anchor ?? null),
+      });
+    }
     if (withPulse) {
       setPulse(true);
       if (pulseTimer.current) window.clearTimeout(pulseTimer.current);
@@ -143,11 +181,22 @@ export function LogFeed({ file, showSvc, lineFilter, onStatus, paused, follow, s
       pendingRestoreRef.current = null;
       return false;
     }
+    if (pending.anchor) {
+      const row = rowForAnchor(el, pending.anchor.key);
+      if (row) {
+        const currentOffset = row.getBoundingClientRect().top - el.getBoundingClientRect().top;
+        glueAtRef.current = Date.now();
+        el.scrollTop += currentOffset - pending.anchor.offset;
+        pending.applied = true;
+        return true;
+      }
+    }
     const maxScroll = Math.max(0, el.scrollHeight - el.clientHeight);
     glueAtRef.current = Date.now();
     el.scrollTop = Math.max(0, maxScroll - pending.fromBottom);
     if (maxScroll < pending.fromBottom) return false;
-    pendingRestoreRef.current = null;
+    pending.applied = true;
+    if (!pending.anchor) pendingRestoreRef.current = null;
     return true;
   };
 
@@ -155,14 +204,14 @@ export function LogFeed({ file, showSvc, lineFilter, onStatus, paused, follow, s
   useEffect(() => setVisibleCount(initialCount), [file?.path, initialCount]);
   /* Same instance, new transcript: pick up that transcript's remembered state. */
   useEffect(() => {
-    if (!file) return;
-    const remembered = scrollMemory.get(file.path)?.magnet ?? follow;
+    if (!memoryKey) return;
+    const remembered = scrollMemory.get(memoryKey)?.magnet ?? follow;
     if (remembered !== magnetRef.current) {
       magnetRef.current = remembered;
        
       setMagnetState(remembered);
     }
-  }, [file?.path]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [file?.path, memoryKey]); // eslint-disable-line react-hooks/exhaustive-deps
   /* External Follow transitions from the focus header drive the same magnet.
      A compact pane's constant true value leaves remount memory authoritative. */
   useEffect(() => {
@@ -266,16 +315,18 @@ export function LogFeed({ file, showSvc, lineFilter, onStatus, paused, follow, s
     lastLenRef.current = len;
     /* First non-empty render of a released pane after a remount: stage the
        remembered distance from the tail for immediate and resize retries. */
+    let initializedRestore = false;
     if (file && len && restoreInitializedPathRef.current !== file.path) {
       restoreInitializedPathRef.current = file.path;
-      const remembered = scrollMemory.get(file.path);
-      pendingRestoreRef.current = !magnet && remembered && remembered.fromBottom > 0
-        ? { path: file.path, fromBottom: remembered.fromBottom }
+      const remembered = memoryKey ? scrollMemory.get(memoryKey) : undefined;
+      pendingRestoreRef.current = !magnet && remembered && (remembered.fromBottom > 0 || remembered.anchor)
+        ? { path: file.path, ...remembered, applied: false }
         : null;
+      initializedRestore = true;
     }
     if (pendingRestoreRef.current) {
       restorePendingPosition();
-      return;
+      if (initializedRestore || !pendingRestoreRef.current?.applied) return;
     }
     if (magnet) {
       glue();
@@ -365,8 +416,12 @@ export function LogFeed({ file, showSvc, lineFilter, onStatus, paused, follow, s
             if (settling) glue();
             else setMagnet(false);
           }
-          if (file && !settling) {
-            rememberScroll(file.path, magnetRef.current, Math.max(0, el.scrollHeight - el.clientHeight - el.scrollTop));
+          if (memoryKey && !settling) {
+            rememberScroll(memoryKey, {
+              magnet: magnetRef.current,
+              fromBottom: Math.max(0, el.scrollHeight - el.clientHeight - el.scrollTop),
+              anchor: magnetRef.current ? null : viewportAnchor(el),
+            });
           }
           if (el.scrollTop < 120 && canRevealOlder && !tail.loadingOlder && !tail.loading) revealOlder();
         }}
@@ -414,13 +469,9 @@ export function LogFeed({ file, showSvc, lineFilter, onStatus, paused, follow, s
                   /* Session-stable keys: a row keeps its DOM node while the
                      window slides. Compact panes live on the zoomable canvas:
                      off-screen rows skip layout/paint via content-visibility. */
-                  compact ? (
-                    <div key={key} className="feed-cv">
-                      <FeedItem item={item} />
-                    </div>
-                  ) : (
-                    <FeedItem key={key} item={item} />
-                  ),
+                  <div key={key} data-feed-key={key} className={compact ? "feed-cv" : undefined}>
+                    <FeedItem item={item} />
+                  </div>,
                 )}
                 {file.pendingQuestion || file.waitingInput ? <QuestionCard key={file.pendingQuestion?.toolUseId ?? "waiting"} file={file} /> : null}
                 {!file.pendingQuestion && !file.waitingInput && endedQuestion ? (

--- a/src/components/LogFeed.tsx
+++ b/src/components/LogFeed.tsx
@@ -107,7 +107,6 @@ export function LogFeed({ file, showSvc, lineFilter, onStatus, paused, follow, s
   const pendingRestoreRef = useRef<{ path: string; fromBottom: number } | null>(null);
   const filePathRef = useRef(file?.path ?? null);
   const controlledFollowRef = useRef(follow);
-  filePathRef.current = file?.path ?? null;
 
   const setMagnet = (value: boolean, withPulse = false) => {
     pendingRestoreRef.current = null;
@@ -238,6 +237,7 @@ export function LogFeed({ file, showSvc, lineFilter, onStatus, paused, follow, s
   }, [tail.error, tail.size, tail.tickTime, file, onStatus]);
 
   useLayoutEffect(() => {
+    filePathRef.current = file?.path ?? null;
     restoreInitializedPathRef.current = null;
     pendingRestoreRef.current = null;
   }, [file?.path]);

--- a/src/components/feed/parse.ts
+++ b/src/components/feed/parse.ts
@@ -129,6 +129,8 @@ export type Item =
 /** One rendered feed row: `key` is stable across incremental re-feeds, so a
     row keeps its DOM node (and its memoized render) while the tail grows. */
 export interface FeedEntry {
+  /** Source-position identity for viewport restoration across parser resets. */
+  anchorKey: string | null;
   key: string;
   item: Item;
 }
@@ -1525,11 +1527,18 @@ export function createFeedSession(cfg: FeedSessionConfig): FeedSession {
   const buildSnapshot = (isLive: boolean): FeedSnapshot => {
     const out: FeedEntry[] = [];
     const nextGroups = new Map<number, CmdGroupItem>();
+    const anchorOrdinals = new Map<string, number>();
+    const anchorKey = (entry: StoredEntry, prefix: "row" | "group") => {
+      const source = `${prefix}:${entry.src}`;
+      const ordinal = anchorOrdinals.get(source) ?? 0;
+      anchorOrdinals.set(source, ordinal + 1);
+      return `${source}:${ordinal}`;
+    };
     let i = 0;
     while (i < entries.length) {
       const head = entries[i];
       if (!foldableTool(head.item)) {
-        out.push({ key: String(head.seq), item: head.item });
+        out.push({ anchorKey: anchorKey(head, "row"), key: String(head.seq), item: head.item });
         i += 1;
         continue;
       }
@@ -1571,15 +1580,15 @@ export function createFeedSession(cfg: FeedSessionConfig): FeedSession {
           };
         }
         nextGroups.set(gkey, group);
-        out.push({ key: "g" + gkey, item: group });
+        out.push({ anchorKey: anchorKey(head, "group"), key: "g" + gkey, item: group });
         i = j;
       } else {
-        out.push({ key: String(head.seq), item: head.item });
+        out.push({ anchorKey: anchorKey(head, "row"), key: String(head.seq), item: head.item });
         i += 1;
       }
     }
     prevGroups = nextGroups;
-    pendingPlainItems().forEach((item, idx) => out.push({ key: "pb" + idx, item }));
+    pendingPlainItems().forEach((item, idx) => out.push({ anchorKey: null, key: "pb" + idx, item }));
     return { items: out, hiddenServiceCount };
   };
 

--- a/src/components/feed/scrollMemory.test.ts
+++ b/src/components/feed/scrollMemory.test.ts
@@ -1,0 +1,18 @@
+import { expect, test } from "bun:test";
+
+import { BoundedLru } from "./scrollMemory";
+
+test("the scroll-memory boundary evicts one least-recently-used reader", () => {
+  const memory = new BoundedLru<number>(300);
+  memory.set("active-reader", 0);
+  for (let index = 1; index < 300; index += 1) memory.set(`reader-${index}`, index);
+
+  expect(memory.get("active-reader")).toBe(0);
+  memory.set("reader-300", 300);
+
+  expect(memory.size).toBe(300);
+  expect(memory.get("active-reader")).toBe(0);
+  expect(memory.get("reader-1")).toBeUndefined();
+  expect(memory.get("reader-299")).toBe(299);
+  expect(memory.get("reader-300")).toBe(300);
+});

--- a/src/components/feed/scrollMemory.ts
+++ b/src/components/feed/scrollMemory.ts
@@ -1,0 +1,30 @@
+/** A fixed-size recency map for lightweight per-conversation UI memory. */
+export class BoundedLru<Value> {
+  private readonly values = new Map<string, Value>();
+
+  constructor(private readonly limit: number) {
+    if (!Number.isInteger(limit) || limit < 1) throw new Error("BoundedLru limit must be a positive integer");
+  }
+
+  get size(): number {
+    return this.values.size;
+  }
+
+  get(key: string): Value | undefined {
+    const value = this.values.get(key);
+    if (value === undefined) return undefined;
+    this.values.delete(key);
+    this.values.set(key, value);
+    return value;
+  }
+
+  set(key: string, value: Value): void {
+    this.values.delete(key);
+    this.values.set(key, value);
+    while (this.values.size > this.limit) {
+      const oldest = this.values.keys().next().value;
+      if (oldest === undefined) return;
+      this.values.delete(oldest);
+    }
+  }
+}

--- a/src/components/scheme/domOrder.ts
+++ b/src/components/scheme/domOrder.ts
@@ -1,0 +1,6 @@
+import type { SchemeNode } from "./layout";
+
+/** Keep live pane hosts attached while activity changes their visual position. */
+export function stableNodeDomOrder(nodes: readonly SchemeNode[]): SchemeNode[] {
+  return [...nodes].sort((a, b) => a.file.path.localeCompare(b.file.path));
+}

--- a/src/components/scheme/domOrder.ts
+++ b/src/components/scheme/domOrder.ts
@@ -1,6 +1,10 @@
 import type { SchemeNode } from "./layout";
 
-/** Keep live pane hosts attached while activity changes their visual position. */
+/** Keep keyed hosts attached while layout activity changes visual positions. */
+export function stableDomOrder<T>(items: readonly T[], keyOf: (item: T) => string): T[] {
+  return [...items].sort((a, b) => keyOf(a).localeCompare(keyOf(b)));
+}
+
 export function stableNodeDomOrder(nodes: readonly SchemeNode[]): SchemeNode[] {
-  return [...nodes].sort((a, b) => a.file.path.localeCompare(b.file.path));
+  return stableDomOrder(nodes, (node) => node.file.path);
 }

--- a/src/components/scheme/nodes.dom.test.tsx
+++ b/src/components/scheme/nodes.dom.test.tsx
@@ -1,0 +1,109 @@
+import { afterEach, expect, test } from "bun:test";
+import { Window as HappyWindow } from "happy-dom";
+import { createRoot, type Root } from "react-dom/client";
+import { flushSync } from "react-dom";
+
+import type { FileEntry } from "@/lib/types";
+
+import { stableNodeDomOrder } from "./domOrder";
+import type { SchemeNode } from "./layout";
+
+const dom = new HappyWindow();
+const testDocument = dom.document as unknown as Document;
+const testWindow = dom as unknown as Window;
+
+function file(path: string, title: string): FileEntry {
+  return {
+    path,
+    root: "codex-sessions",
+    name: path,
+    project: "project",
+    title,
+    engine: "codex",
+    kind: "session",
+    fmt: "codex",
+    parent: null,
+    mtime: 1,
+    size: 1,
+    activity: "recent",
+    proc: "running",
+    pid: 1,
+    model: null,
+    pendingQuestion: null,
+    waitingInput: null,
+  };
+}
+
+function node(entry: FileEntry, x: number): SchemeNode {
+  return { file: entry, tasks: [], under: [], isRoot: true, x, y: 0, w: 600, h: 780 };
+}
+
+function PaneList({ nodes, selected }: { nodes: SchemeNode[]; selected: string }) {
+  return (
+    <div>
+      {stableNodeDomOrder(nodes).map((item) => (
+        <div
+          key={item.file.path}
+          data-scheme-node={item.file.path}
+          style={{ transform: `translate(${item.x}px, ${item.y}px)` }}
+        >
+          <div className={selected === item.file.path ? "ring-2" : undefined}>
+            <span data-reader-title>{item.file.title}</span>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+afterEach(() => testDocument.body.replaceChildren());
+
+test("a reading pane keeps its DOM state when a more active pane overtakes it", () => {
+  Object.assign(globalThis, {
+    window: dom,
+    document: dom.document,
+    navigator: dom.navigator,
+    Node: dom.Node,
+    HTMLElement: dom.HTMLElement,
+    Event: dom.Event,
+  });
+  const readerFile = file("/reader", "Reader pane");
+  const overtakerFile = file("/overtaker", "Overtaker pane");
+  const initial = [node(readerFile, 0), node(overtakerFile, 600)];
+  const overtaken = [node(overtakerFile, 0), node(readerFile, 600)];
+  const host = testDocument.createElement("div");
+  testDocument.body.append(host);
+  const root: Root = createRoot(host);
+  const render = (next: SchemeNode[]) => {
+    flushSync(() => {
+      root.render(<PaneList nodes={next} selected="/reader" />);
+    });
+  };
+
+  render(initial);
+  const initialPaneOrder = Array.from(host.querySelectorAll<HTMLElement>("[data-scheme-node]"), (pane) => pane.dataset.schemeNode);
+  const reader = host.querySelector('[data-scheme-node="/reader"]') as HTMLElement;
+  const title = reader.querySelector("[data-reader-title]") as HTMLElement;
+  reader.scrollTop = 240;
+  reader.tabIndex = 0;
+  reader.focus();
+  const range = testDocument.createRange();
+  range.selectNodeContents(title);
+  const selection = testWindow.getSelection()!;
+  selection.removeAllRanges();
+  selection.addRange(range);
+
+  render(overtaken);
+
+  const panes = Array.from(host.querySelectorAll<HTMLElement>("[data-scheme-node]"));
+  expect(host.querySelector('[data-scheme-node="/reader"]')).toBe(reader);
+  expect(reader.scrollTop).toBe(240);
+  expect(testDocument.activeElement).toBe(reader);
+  expect(selection.toString()).toBe("Reader pane");
+  expect(reader.querySelector(".ring-2")).toBeTruthy();
+  expect(reader.style.transform).toContain("600px");
+  expect(panes.map((pane) => pane.dataset.schemeNode)).toEqual(initialPaneOrder);
+
+  flushSync(() => root.unmount());
+  host.remove();
+});

--- a/src/components/scheme/nodes.dom.test.tsx
+++ b/src/components/scheme/nodes.dom.test.tsx
@@ -271,6 +271,27 @@ function assistantLine(text: string): string {
   });
 }
 
+function rect(top: number, height: number): DOMRect {
+  return {
+    x: 0,
+    y: top,
+    top,
+    left: 0,
+    width: 600,
+    height,
+    right: 600,
+    bottom: top + height,
+    toJSON: () => ({}),
+  } as DOMRect;
+}
+
+function setViewportRects(scroller: HTMLElement, rows: Map<HTMLElement, { top: number; height: number }>, viewport = 200) {
+  scroller.getBoundingClientRect = () => rect(0, viewport);
+  for (const [row, box] of rows) {
+    row.getBoundingClientRect = () => rect(box.top - scroller.scrollTop, box.height);
+  }
+}
+
 test("every scheme host collection keeps stable DOM siblings while geometry changes", () => {
   const nodeA = node(file("/node-a", "Node A"), 100);
   const nodeB = node(file("/node-b", "Node B"), 700);
@@ -343,6 +364,101 @@ test("an anchored production feed survives overtakes and a short remount window"
   triggerResize();
   expect(remountedGeometry.fromBottom()).toBe(400);
   expect(host.querySelector('[data-scheme-node="/reader"]')?.textContent).toContain("Reader anchor");
+});
+
+test("an account-migration successor inherits its conversation scroll state", async () => {
+  let now = 5_000;
+  Date.now = () => now;
+  tails.set("/predecessor", [assistantLine("Shared history")]);
+  tails.set("/successor", [assistantLine("Shared history")]);
+  const predecessor = { ...file("/predecessor", "Predecessor"), conversationId: "conversation-stable" };
+  const successor = {
+    ...file("/successor", "Successor"),
+    conversationId: "conversation-stable",
+    predecessorPath: "/predecessor",
+  };
+  const { host, root } = mountHost();
+
+  renderLayer(root, layout({ nodes: [node(predecessor, 100)] }));
+  await settle();
+  const predecessorScroller = scrollerFor(host, "/predecessor");
+  const predecessorGeometry = setScrollerGeometry(predecessorScroller, 1_000, 200);
+  triggerResize();
+  now += 1_000;
+  predecessorGeometry.setTop(400);
+  flushSync(() => predecessorScroller.dispatchEvent(new dom.Event("scroll", { bubbles: true }) as unknown as Event));
+  expect(predecessorGeometry.fromBottom()).toBe(400);
+
+  renderLayer(root, layout());
+  renderLayer(root, layout({ nodes: [node(successor, 100)] }));
+  await settle();
+  const successorScroller = scrollerFor(host, "/successor");
+  const successorGeometry = setScrollerGeometry(successorScroller, 1_000, 200);
+  triggerResize();
+
+  expect(successorGeometry.fromBottom()).toBe(400);
+  expect(host.querySelector('[data-scheme-node="/successor"]')?.textContent).toContain("Shared history");
+});
+
+test("an anchored feed item keeps its viewport offset while the transcript grows during remount", async () => {
+  let now = 8_000;
+  Date.now = () => now;
+  const path = "/anchor-growth";
+  const initialLines = [
+    assistantLine("Before anchor"),
+    assistantLine("Visible anchor row"),
+    assistantLine("Existing tail row"),
+  ];
+  tails.set(path, initialLines);
+  const entry = file(path, "Growing transcript");
+  const { host, root } = mountHost();
+
+  renderLayer(root, layout({ nodes: [node(entry, 100)] }));
+  await settle();
+  const scroller = scrollerFor(host, path);
+  const geometry = setScrollerGeometry(scroller, 1_000, 200);
+  const rows = Array.from(host.querySelectorAll<HTMLElement>(`[data-scheme-node="${path}"] [data-feed-key]`));
+  const before = rows.find((row) => row.textContent?.includes("Before anchor"));
+  const anchor = rows.find((row) => row.textContent?.includes("Visible anchor row"));
+  const tail = rows.find((row) => row.textContent?.includes("Existing tail row"));
+  expect(before).toBeTruthy();
+  expect(anchor).toBeTruthy();
+  expect(tail).toBeTruthy();
+  setViewportRects(scroller, new Map([
+    [before!, { top: 300, height: 80 }],
+    [anchor!, { top: 380, height: 80 }],
+    [tail!, { top: 500, height: 80 }],
+  ]));
+  geometry.setTop(400);
+  now += 1_000;
+  flushSync(() => scroller.dispatchEvent(new dom.Event("scroll", { bubbles: true }) as unknown as Event));
+  expect(anchor!.getBoundingClientRect().top).toBe(-20);
+
+  renderLayer(root, layout());
+  tails.set(path, initialLines.concat([
+    assistantLine("Arrived while unmounted one"),
+    assistantLine("Arrived while unmounted two"),
+  ]));
+  renderLayer(root, layout({ nodes: [node(entry, 100)] }));
+  await settle();
+
+  const remountedScroller = scrollerFor(host, path);
+  const remountedGeometry = setScrollerGeometry(remountedScroller, 1_400, 200);
+  const remountedRows = Array.from(host.querySelectorAll<HTMLElement>(`[data-scheme-node="${path}"] [data-feed-key]`));
+  const remountedBefore = remountedRows.find((row) => row.textContent?.includes("Before anchor"));
+  const remountedAnchor = remountedRows.find((row) => row.textContent?.includes("Visible anchor row"));
+  const remountedTail = remountedRows.find((row) => row.textContent?.includes("Existing tail row"));
+  expect(remountedAnchor).toBeTruthy();
+  setViewportRects(remountedScroller, new Map([
+    [remountedBefore!, { top: 300, height: 80 }],
+    [remountedAnchor!, { top: 380, height: 80 }],
+    [remountedTail!, { top: 500, height: 80 }],
+  ]));
+  triggerResize();
+
+  expect(remountedScroller.scrollTop).toBe(400);
+  expect(remountedAnchor!.getBoundingClientRect().top).toBe(-20);
+  expect(remountedGeometry.fromBottom()).toBe(800);
 });
 
 test("a bottom-following production feed returns to the tail after remount", async () => {

--- a/src/components/scheme/nodes.dom.test.tsx
+++ b/src/components/scheme/nodes.dom.test.tsx
@@ -61,10 +61,11 @@ mock.module("@/hooks/useRuntime", () => ({
 }));
 
 const tails = new Map<string, string[]>();
+const tailStarts = new Map<string, number>();
 mock.module("@/hooks/useLogTail", () => ({
   useLogTail: (entry: FileEntry | null) => ({
     lines: entry ? (tails.get(entry.path) ?? []) : [],
-    linesStart: 0,
+    linesStart: entry ? (tailStarts.get(entry.path) ?? 0) : 0,
     size: entry?.size ?? 0,
     loading: false,
     error: null,
@@ -96,6 +97,7 @@ afterEach(() => {
   roots.clear();
   resizeCallbacks.clear();
   tails.clear();
+  tailStarts.clear();
   Date.now = realNow;
   dom.document.body.replaceChildren();
   dom.sessionStorage.clear();
@@ -369,8 +371,16 @@ test("an anchored production feed survives overtakes and a short remount window"
 test("an account-migration successor inherits its conversation scroll state", async () => {
   let now = 5_000;
   Date.now = () => now;
-  tails.set("/predecessor", [assistantLine("Shared history")]);
-  tails.set("/successor", [assistantLine("Shared history")]);
+  tails.set("/predecessor", [
+    assistantLine("Predecessor before"),
+    assistantLine("Predecessor visible anchor"),
+    assistantLine("Predecessor tail"),
+  ]);
+  tails.set("/successor", [
+    assistantLine("Successor unrelated first"),
+    assistantLine("Successor unrelated second"),
+    assistantLine("Successor unrelated third"),
+  ]);
   const predecessor = { ...file("/predecessor", "Predecessor"), conversationId: "conversation-stable" };
   const successor = {
     ...file("/successor", "Successor"),
@@ -383,21 +393,33 @@ test("an account-migration successor inherits its conversation scroll state", as
   await settle();
   const predecessorScroller = scrollerFor(host, "/predecessor");
   const predecessorGeometry = setScrollerGeometry(predecessorScroller, 1_000, 200);
-  triggerResize();
-  now += 1_000;
+  const predecessorRows = Array.from(host.querySelectorAll<HTMLElement>('[data-scheme-node="/predecessor"] [data-feed-key]'));
+  const predecessorBefore = predecessorRows.find((row) => row.textContent?.includes("Predecessor before"));
+  const predecessorAnchor = predecessorRows.find((row) => row.textContent?.includes("Predecessor visible anchor"));
+  const predecessorTail = predecessorRows.find((row) => row.textContent?.includes("Predecessor tail"));
+  setViewportRects(predecessorScroller, new Map([
+    [predecessorBefore!, { top: 300, height: 80 }],
+    [predecessorAnchor!, { top: 380, height: 80 }],
+    [predecessorTail!, { top: 500, height: 80 }],
+  ]));
   predecessorGeometry.setTop(400);
+  now += 1_000;
   flushSync(() => predecessorScroller.dispatchEvent(new dom.Event("scroll", { bubbles: true }) as unknown as Event));
   expect(predecessorGeometry.fromBottom()).toBe(400);
+  expect(predecessorAnchor!.getBoundingClientRect().top).toBe(-20);
 
   renderLayer(root, layout());
   renderLayer(root, layout({ nodes: [node(successor, 100)] }));
   await settle();
   const successorScroller = scrollerFor(host, "/successor");
   const successorGeometry = setScrollerGeometry(successorScroller, 1_000, 200);
+  const successorRows = Array.from(host.querySelectorAll<HTMLElement>('[data-scheme-node="/successor"] [data-feed-key]'));
+  setViewportRects(successorScroller, new Map(successorRows.map((row, index) => [row, { top: 100 + index * 80, height: 70 }])));
   triggerResize();
 
   expect(successorGeometry.fromBottom()).toBe(400);
-  expect(host.querySelector('[data-scheme-node="/successor"]')?.textContent).toContain("Shared history");
+  expect(successorScroller.scrollTop).toBe(400);
+  expect(host.querySelector('[data-scheme-node="/successor"]')?.textContent).toContain("Successor unrelated second");
 });
 
 test("an anchored feed item keeps its viewport offset while the transcript grows during remount", async () => {
@@ -459,6 +481,68 @@ test("an anchored feed item keeps its viewport offset while the transcript grows
   expect(remountedScroller.scrollTop).toBe(400);
   expect(remountedAnchor!.getBoundingClientRect().top).toBe(-20);
   expect(remountedGeometry.fromBottom()).toBe(800);
+});
+
+test("an anchored feed item survives parser reset after history is prepended", async () => {
+  let now = 12_000;
+  Date.now = () => now;
+  const path = "/prepend-anchor";
+  const initialLines = [
+    assistantLine("Original before"),
+    assistantLine("Original visible anchor"),
+    assistantLine("Original tail"),
+  ];
+  tails.set(path, initialLines);
+  const entry = file(path, "Prepended transcript");
+  const { host, root } = mountHost();
+
+  renderLayer(root, layout({ nodes: [node(entry, 100)] }));
+  await settle();
+  const scroller = scrollerFor(host, path);
+  const geometry = setScrollerGeometry(scroller, 1_000, 200);
+  const rows = Array.from(host.querySelectorAll<HTMLElement>(`[data-scheme-node="${path}"] [data-feed-key]`));
+  const before = rows.find((row) => row.textContent?.includes("Original before"));
+  const anchor = rows.find((row) => row.textContent?.includes("Original visible anchor"));
+  const tail = rows.find((row) => row.textContent?.includes("Original tail"));
+  setViewportRects(scroller, new Map([
+    [before!, { top: 300, height: 80 }],
+    [anchor!, { top: 380, height: 80 }],
+    [tail!, { top: 500, height: 80 }],
+  ]));
+  geometry.setTop(400);
+  now += 1_000;
+  flushSync(() => scroller.dispatchEvent(new dom.Event("scroll", { bubbles: true }) as unknown as Event));
+  expect(anchor!.getBoundingClientRect().top).toBe(-20);
+
+  renderLayer(root, layout());
+  tails.set(path, [assistantLine("Older one"), assistantLine("Older two"), ...initialLines]);
+  tailStarts.set(path, -2);
+  renderLayer(root, layout({ nodes: [node(entry, 100)] }));
+  await settle();
+
+  const remountedScroller = scrollerFor(host, path);
+  const remountedGeometry = setScrollerGeometry(remountedScroller, 1_160, 200);
+  const remountedRows = Array.from(host.querySelectorAll<HTMLElement>(`[data-scheme-node="${path}"] [data-feed-key]`));
+  const boxes = new Map<HTMLElement, { top: number; height: number }>();
+  const positions = new Map([
+    ["Older one", 100],
+    ["Older two", 180],
+    ["Original before", 460],
+    ["Original visible anchor", 540],
+    ["Original tail", 660],
+  ]);
+  for (const row of remountedRows) {
+    const match = [...positions].find(([text]) => row.textContent?.includes(text));
+    if (match) boxes.set(row, { top: match[1], height: 80 });
+  }
+  const remountedAnchor = remountedRows.find((row) => row.textContent?.includes("Original visible anchor"));
+  expect(remountedAnchor).toBeTruthy();
+  setViewportRects(remountedScroller, boxes);
+  triggerResize();
+
+  expect(remountedScroller.scrollTop).toBe(560);
+  expect(remountedAnchor!.getBoundingClientRect().top).toBe(-20);
+  expect(remountedGeometry.fromBottom()).toBe(400);
 });
 
 test("a bottom-following production feed returns to the tail after remount", async () => {

--- a/src/components/scheme/nodes.dom.test.tsx
+++ b/src/components/scheme/nodes.dom.test.tsx
@@ -1,16 +1,105 @@
-import { afterEach, expect, test } from "bun:test";
+import { afterAll, afterEach, beforeEach, expect, mock, test } from "bun:test";
 import { Window as HappyWindow } from "happy-dom";
-import { createRoot, type Root } from "react-dom/client";
 import { flushSync } from "react-dom";
+import { createRoot, type Root } from "react-dom/client";
 
+import type { Flow } from "@/lib/flows/types";
 import type { FileEntry } from "@/lib/types";
+import { emptyStore } from "@/components/runtime/runtimeModel";
 
-import { stableNodeDomOrder } from "./domOrder";
-import type { SchemeNode } from "./layout";
+import type { DeckNode, DraftNode, MiniStack, SchemeLayout, SchemeNode } from "./layout";
 
 const dom = new HappyWindow();
-const testDocument = dom.document as unknown as Document;
-const testWindow = dom as unknown as Window;
+const resizeCallbacks = new Set<() => void>();
+
+class TestResizeObserver {
+  private readonly notify: () => void;
+
+  constructor(callback: ResizeObserverCallback) {
+    this.notify = () => callback([], this as unknown as ResizeObserver);
+    resizeCallbacks.add(this.notify);
+  }
+
+  observe() {}
+  unobserve() {}
+  disconnect() {
+    resizeCallbacks.delete(this.notify);
+  }
+}
+
+function bindDomGlobals() {
+  Object.assign(globalThis, {
+    window: dom,
+    document: dom.document,
+    navigator: dom.navigator,
+    Node: dom.Node,
+    HTMLElement: dom.HTMLElement,
+    HTMLButtonElement: dom.HTMLButtonElement,
+    HTMLInputElement: dom.HTMLInputElement,
+    Event: dom.Event,
+    CustomEvent: dom.CustomEvent,
+    MouseEvent: dom.MouseEvent,
+    sessionStorage: dom.sessionStorage,
+    localStorage: dom.localStorage,
+    ResizeObserver: TestResizeObserver,
+    IntersectionObserver: undefined,
+  });
+}
+
+bindDomGlobals();
+
+const actualRuntimeHooks = await import("@/hooks/useRuntime");
+const actualLogTail = await import("@/hooks/useLogTail");
+const inertRuntime = { enabled: false, connection: "offline" as const, resyncedAt: null, store: emptyStore() };
+mock.module("@/hooks/useRuntime", () => ({
+  ...actualRuntimeHooks,
+  useRuntimeBusState: () => ({ ...inertRuntime, lastEventAt: null }),
+  useRuntime: () => inertRuntime,
+  useRuntimeSession: () => null,
+  useRuntimeReceiptsForArtifact: () => [],
+  useRuntimeFlow: () => null,
+}));
+
+const tails = new Map<string, string[]>();
+mock.module("@/hooks/useLogTail", () => ({
+  useLogTail: (entry: FileEntry | null) => ({
+    lines: entry ? (tails.get(entry.path) ?? []) : [],
+    linesStart: 0,
+    size: entry?.size ?? 0,
+    loading: false,
+    error: null,
+    tickTime: null,
+    paused: false,
+    setPaused: () => undefined,
+    clear: () => undefined,
+    hasMore: false,
+    loadingOlder: false,
+    loadOlder: async () => 0,
+    prependGen: 0,
+  }),
+}));
+
+const { NodesLayer } = await import("./nodes");
+
+const roots = new Set<Root>();
+const realNow = Date.now;
+
+beforeEach(bindDomGlobals);
+
+afterAll(() => {
+  mock.module("@/hooks/useRuntime", () => actualRuntimeHooks);
+  mock.module("@/hooks/useLogTail", () => actualLogTail);
+});
+
+afterEach(() => {
+  for (const root of roots) flushSync(() => root.unmount());
+  roots.clear();
+  resizeCallbacks.clear();
+  tails.clear();
+  Date.now = realNow;
+  dom.document.body.replaceChildren();
+  dom.sessionStorage.clear();
+});
 
 function file(path: string, title: string): FileEntry {
   return {
@@ -38,72 +127,248 @@ function node(entry: FileEntry, x: number): SchemeNode {
   return { file: entry, tasks: [], under: [], isRoot: true, x, y: 0, w: 600, h: 780 };
 }
 
-function PaneList({ nodes, selected }: { nodes: SchemeNode[]; selected: string }) {
-  return (
-    <div>
-      {stableNodeDomOrder(nodes).map((item) => (
-        <div
-          key={item.file.path}
-          data-scheme-node={item.file.path}
-          style={{ transform: `translate(${item.x}px, ${item.y}px)` }}
-        >
-          <div className={selected === item.file.path ? "ring-2" : undefined}>
-            <span data-reader-title>{item.file.title}</span>
-          </div>
-        </div>
-      ))}
-    </div>
-  );
+function flow(id: string, implementerPath: string): Flow {
+  return {
+    id,
+    template: "implement-review-loop",
+    project: "project",
+    cwd: "/project",
+    implementerPath,
+    roles: {
+      implementer: { engine: "codex", model: null, effort: null },
+      reviewer: { engine: "codex", model: null, effort: null },
+    },
+    baseRef: "base",
+    baseMode: "head",
+    mode: "auto",
+    reviewerMode: "headless",
+    roundLimit: 5,
+    state: "waiting_ready",
+    stateDetail: null,
+    rounds: [],
+    createdAt: "2026-07-12T00:00:00Z",
+    closedAt: null,
+  };
 }
 
-afterEach(() => testDocument.body.replaceChildren());
+function stack(key: string, x: number): MiniStack {
+  return { key, parent: "/parent", items: [{ file: file(`${key}/item`, key), branches: 0 }], x, y: 0, w: 360, h: 70 };
+}
 
-test("a reading pane keeps its DOM state when a more active pane overtakes it", () => {
-  Object.assign(globalThis, {
-    window: dom,
-    document: dom.document,
-    navigator: dom.navigator,
-    Node: dom.Node,
-    HTMLElement: dom.HTMLElement,
-    Event: dom.Event,
-  });
-  const readerFile = file("/reader", "Reader pane");
-  const overtakerFile = file("/overtaker", "Overtaker pane");
-  const initial = [node(readerFile, 0), node(overtakerFile, 600)];
-  const overtaken = [node(overtakerFile, 0), node(readerFile, 600)];
-  const host = testDocument.createElement("div");
-  testDocument.body.append(host);
-  const root: Root = createRoot(host);
-  const render = (next: SchemeNode[]) => {
-    flushSync(() => {
-      root.render(<PaneList nodes={next} selected="/reader" />);
-    });
+function deck(key: string, x: number): DeckNode {
+  return { key, flow: flow(`flow-${key}`, "/node-a"), rounds: [], x, y: 0, w: 600, h: 780 };
+}
+
+function draft(key: string, x: number): DraftNode {
+  return { key, id: key, x, y: 0, w: 600, h: 780 };
+}
+
+function layout(parts: Partial<SchemeLayout> = {}): SchemeLayout {
+  return {
+    nodes: [],
+    edges: [],
+    stacks: [],
+    decks: [],
+    loops: [],
+    links: [],
+    drafts: [],
+    byPath: new Map(),
+    width: 2000,
+    height: 1000,
+    ...parts,
   };
+}
 
-  render(initial);
-  const initialPaneOrder = Array.from(host.querySelectorAll<HTMLElement>("[data-scheme-node]"), (pane) => pane.dataset.schemeNode);
-  const reader = host.querySelector('[data-scheme-node="/reader"]') as HTMLElement;
-  const title = reader.querySelector("[data-reader-title]") as HTMLElement;
-  reader.scrollTop = 240;
-  reader.tabIndex = 0;
-  reader.focus();
-  const range = testDocument.createRange();
-  range.selectNodeContents(title);
-  const selection = testWindow.getSelection()!;
-  selection.removeAllRanges();
-  selection.addRange(range);
+function mountHost(): { host: HTMLElement; root: Root } {
+  const element = dom.document.createElement("div");
+  dom.document.body.append(element);
+  const host = element as unknown as HTMLElement;
+  const root = createRoot(host);
+  roots.add(root);
+  return { host, root };
+}
 
-  render(overtaken);
+function renderLayer(root: Root, next: SchemeLayout, options: { lite?: boolean; dormant?: boolean; selected?: string } = {}) {
+  const flows = next.decks.map((item) => item.flow);
+  flushSync(() => {
+    root.render(
+      <NodesLayer
+        layout={next}
+        project="project"
+        files={next.nodes.map((item) => item.file)}
+        interactive
+        lite={options.lite ?? false}
+        dormant={options.dormant ?? true}
+        selected={options.selected ?? null}
+        multi={new Set()}
+        session={false}
+        focus={null}
+        attentionPaths={null}
+        flowsByImpl={new Map()}
+        flows={flows}
+        pipelineStrips={new Map()}
+        deckFocus={null}
+        onSelect={() => undefined}
+        onClose={() => undefined}
+        onFocusRound={() => undefined}
+        onDraftClose={() => undefined}
+        onDraftSpawned={() => undefined}
+        onExpand={() => undefined}
+      />,
+    );
+  });
+}
 
-  const panes = Array.from(host.querySelectorAll<HTMLElement>("[data-scheme-node]"));
-  expect(host.querySelector('[data-scheme-node="/reader"]')).toBe(reader);
-  expect(reader.scrollTop).toBe(240);
-  expect(testDocument.activeElement).toBe(reader);
-  expect(selection.toString()).toBe("Reader pane");
-  expect(reader.querySelector(".ring-2")).toBeTruthy();
-  expect(reader.style.transform).toContain("600px");
-  expect(panes.map((pane) => pane.dataset.schemeNode)).toEqual(initialPaneOrder);
+async function settle() {
+  await Bun.sleep(0);
+  await Bun.sleep(0);
+}
 
-  flushSync(() => root.unmount());
-  host.remove();
+function triggerResize() {
+  for (const callback of [...resizeCallbacks]) callback();
+}
+
+function scrollerFor(host: HTMLElement, path: string): HTMLElement {
+  const scroller = host.querySelector(`[data-scheme-node="${path}"] .overflow-y-auto`);
+  expect(scroller).toBeTruthy();
+  return scroller as HTMLElement;
+}
+
+function setScrollerGeometry(element: HTMLElement, initialHeight: number, viewport: number) {
+  let height = initialHeight;
+  let client = viewport;
+  let top = 0;
+  Object.defineProperties(element, {
+    scrollHeight: { configurable: true, get: () => height },
+    clientHeight: { configurable: true, get: () => client },
+    scrollTop: {
+      configurable: true,
+      get: () => top,
+      set: (value: number) => {
+        top = Math.max(0, Math.min(Number(value), Math.max(0, height - client)));
+      },
+    },
+  });
+  return {
+    resize(nextHeight: number, nextViewport = client) {
+      height = nextHeight;
+      client = nextViewport;
+    },
+    setTop(value: number) {
+      element.scrollTop = value;
+    },
+    fromBottom() {
+      return Math.max(0, height - client - top);
+    },
+  };
+}
+
+function assistantLine(text: string): string {
+  return JSON.stringify({
+    type: "response_item",
+    timestamp: "2026-07-12T00:00:00Z",
+    payload: { type: "message", role: "assistant", content: [{ type: "output_text", text }] },
+  });
+}
+
+test("every scheme host collection keeps stable DOM siblings while geometry changes", () => {
+  const nodeA = node(file("/node-a", "Node A"), 100);
+  const nodeB = node(file("/node-b", "Node B"), 700);
+  const initial = layout({
+    stacks: [stack("stack::b", 700), stack("stack::a", 100)],
+    decks: [deck("deck::b", 700), deck("deck::a", 100)],
+    drafts: [draft("draft::b", 700), draft("draft::a", 100)],
+    nodes: [nodeB, nodeA],
+  });
+  const overtaken = layout({
+    stacks: [stack("stack::a", 900), stack("stack::b", 300)],
+    decks: [deck("deck::a", 900), deck("deck::b", 300)],
+    drafts: [draft("draft::a", 900), draft("draft::b", 300)],
+    nodes: [node(file("/node-a", "Node A"), 900), node(file("/node-b", "Node B"), 300)],
+  });
+  const { host, root } = mountHost();
+
+  renderLayer(root, initial, { lite: true });
+  const keys = ["stack::a", "stack::b", "deck::a", "deck::b", "draft::a", "draft::b", "/node-a", "/node-b"];
+  const originalHosts = new Map(keys.map((key) => [key, host.querySelector(`[data-scheme-node="${key}"]`)]));
+  const originalOrder = Array.from(host.querySelectorAll<HTMLElement>("[data-scheme-node]"), (item) => item.dataset.schemeNode);
+
+  renderLayer(root, overtaken, { lite: true });
+
+  expect(Array.from(host.querySelectorAll<HTMLElement>("[data-scheme-node]"), (item) => item.dataset.schemeNode)).toEqual(originalOrder);
+  for (const key of keys) expect(host.querySelector(`[data-scheme-node="${key}"]`)).toBe(originalHosts.get(key) ?? null);
+  expect((host.querySelector('[data-scheme-node="stack::a"]') as HTMLElement).style.transform).toContain("900px");
+  expect((host.querySelector('[data-scheme-node="/node-a"]') as HTMLElement).style.transform).toContain("900px");
+});
+
+test("an anchored production feed survives overtakes and a short remount window", async () => {
+  let now = 1_000;
+  Date.now = () => now;
+  tails.set("/reader", [assistantLine("Reader anchor")]);
+  tails.set("/overtaker", [assistantLine("Overtaker tail")]);
+  const reader = file("/reader", "Reader pane");
+  const overtaker = file("/overtaker", "Overtaker pane");
+  const initial = layout({ nodes: [node(reader, 100), node(overtaker, 700)] });
+  const overtaken = layout({ nodes: [node(overtaker, 100), node(reader, 700)] });
+  const { host, root } = mountHost();
+
+  renderLayer(root, initial, { selected: "/reader" });
+  await settle();
+  const readerHost = host.querySelector('[data-scheme-node="/reader"]');
+  const scroller = scrollerFor(host, "/reader");
+  const geometry = setScrollerGeometry(scroller, 1_000, 200);
+  triggerResize();
+  expect(geometry.fromBottom()).toBe(0);
+  expect(readerHost?.textContent).toContain("Reader anchor");
+
+  now += 1_000;
+  geometry.setTop(400);
+  flushSync(() => scroller.dispatchEvent(new dom.Event("scroll", { bubbles: true }) as unknown as Event));
+  expect(geometry.fromBottom()).toBe(400);
+
+  renderLayer(root, overtaken, { selected: "/reader" });
+  expect(host.querySelector('[data-scheme-node="/reader"]')).toBe(readerHost);
+  expect(scrollerFor(host, "/reader")).toBe(scroller);
+  expect(geometry.fromBottom()).toBe(400);
+
+  renderLayer(root, layout());
+  renderLayer(root, overtaken, { selected: "/reader" });
+  await settle();
+  const remountedScroller = scrollerFor(host, "/reader");
+  const remountedGeometry = setScrollerGeometry(remountedScroller, 220, 200);
+  triggerResize();
+  expect(remountedScroller.scrollTop).toBe(0);
+
+  remountedGeometry.resize(1_000);
+  triggerResize();
+  expect(remountedGeometry.fromBottom()).toBe(400);
+  expect(host.querySelector('[data-scheme-node="/reader"]')?.textContent).toContain("Reader anchor");
+});
+
+test("a bottom-following production feed returns to the tail after remount", async () => {
+  let now = 10_000;
+  Date.now = () => now;
+  tails.set("/follower", [assistantLine("Follower tail")]);
+  const followerLayout = layout({ nodes: [node(file("/follower", "Follower pane"), 100)] });
+  const { host, root } = mountHost();
+
+  renderLayer(root, followerLayout);
+  await settle();
+  const scroller = scrollerFor(host, "/follower");
+  const geometry = setScrollerGeometry(scroller, 1_000, 200);
+  triggerResize();
+  expect(geometry.fromBottom()).toBe(0);
+  expect(host.textContent).toContain("Follower tail");
+
+  now += 1_000;
+  flushSync(() => scroller.dispatchEvent(new dom.Event("scroll", { bubbles: true }) as unknown as Event));
+  renderLayer(root, layout());
+  renderLayer(root, followerLayout);
+  await settle();
+
+  const remountedScroller = scrollerFor(host, "/follower");
+  const remountedGeometry = setScrollerGeometry(remountedScroller, 1_600, 200);
+  triggerResize();
+  expect(remountedGeometry.fromBottom()).toBe(0);
+  expect(host.textContent).toContain("Follower tail");
 });

--- a/src/components/scheme/nodes.tsx
+++ b/src/components/scheme/nodes.tsx
@@ -33,6 +33,7 @@ import { activityDot, cleanTitle, engineBadge, engineEdge, fmtAge } from "@/comp
 
 import type { AgentLink } from "./agentLinks";
 import { PIPELINE_RAIL_COLOR, pipelineRailSegment } from "./agentLinks";
+import { stableNodeDomOrder } from "./domOrder";
 import {
   LOOP_GAP,
   NODE_W,
@@ -847,6 +848,13 @@ export const NodesLayer = memo(function NodesLayer({
   /* Paths still in the scan; a run stage action is disabled once its transcript
      leaves the file set (AC4). */
   const renderablePaths = useMemo(() => new Set(files.map((entry) => entry.path)), [files]);
+  /* Activity ranking already reaches the screen through each node's x/y
+     transform. A path-stable sibling order keeps React from moving an existing
+     pane host in the DOM, preserving its scroll, focus, and text selection. */
+  const nodesInDomOrder = useMemo(
+    () => stableNodeDomOrder(layout.nodes),
+    [layout.nodes],
+  );
   /* Flow ids with a rendered deck: a deck exists only for a placed implementer
      node, so derive from the layout's nodes to disable review actions whose
      implementer is unplaced. */
@@ -907,7 +915,7 @@ export const NodesLayer = memo(function NodesLayer({
           />
         ),
       )}
-      {layout.nodes.map((rawNode) => {
+      {nodesInDomOrder.map((rawNode) => {
         const node = withRuntimeActivity(rawNode);
         return lite ? (
           <LiteNodeShell

--- a/src/components/scheme/nodes.tsx
+++ b/src/components/scheme/nodes.tsx
@@ -33,7 +33,7 @@ import { activityDot, cleanTitle, engineBadge, engineEdge, fmtAge } from "@/comp
 
 import type { AgentLink } from "./agentLinks";
 import { PIPELINE_RAIL_COLOR, pipelineRailSegment } from "./agentLinks";
-import { stableNodeDomOrder } from "./domOrder";
+import { stableDomOrder, stableNodeDomOrder } from "./domOrder";
 import {
   LOOP_GAP,
   NODE_W,
@@ -848,9 +848,12 @@ export const NodesLayer = memo(function NodesLayer({
   /* Paths still in the scan; a run stage action is disabled once its transcript
      leaves the file set (AC4). */
   const renderablePaths = useMemo(() => new Set(files.map((entry) => entry.path)), [files]);
-  /* Activity ranking already reaches the screen through each node's x/y
-     transform. A path-stable sibling order keeps React from moving an existing
-     pane host in the DOM, preserving its scroll, focus, and text selection. */
+  /* Activity ranking reaches the screen through each host's x/y transform.
+     Stable sibling order keeps React from moving stateful hosts in the DOM,
+     preserving scroll, focus, selection, and draft/deck state. */
+  const stacksInDomOrder = useMemo(() => stableDomOrder(layout.stacks, (stack) => stack.key), [layout.stacks]);
+  const decksInDomOrder = useMemo(() => stableDomOrder(layout.decks, (deck) => deck.key), [layout.decks]);
+  const draftsInDomOrder = useMemo(() => stableDomOrder(layout.drafts, (draft) => draft.key), [layout.drafts]);
   const nodesInDomOrder = useMemo(
     () => stableNodeDomOrder(layout.nodes),
     [layout.nodes],
@@ -878,10 +881,10 @@ export const NodesLayer = memo(function NodesLayer({
     <div
       className={`${interactive ? "" : "pointer-events-none select-none"} ${session ? "scheme-session" : ""}`.trim() || undefined}
     >
-      {layout.stacks.map((stack) => (
+      {stacksInDomOrder.map((stack) => (
         <MiniStackShell key={stack.key} stack={stack} dimmed={stackDimmed(stack)} onSelect={onSelect} />
       ))}
-      {layout.decks.map((deck) =>
+      {decksInDomOrder.map((deck) =>
         lite ? (
           <LiteDeckShell key={deck.key} deck={deck} dimmed={deckDimmed(deck)} />
         ) : (
@@ -894,7 +897,7 @@ export const NodesLayer = memo(function NodesLayer({
           />
         ),
       )}
-      {layout.drafts.map((draft) =>
+      {draftsInDomOrder.map((draft) =>
         lite ? (
           <LiteDraftShell
             key={draft.key}


### PR DESCRIPTION
## Summary

- keep scheme pane hosts in stable DOM order while activity changes their visual transforms
- preserve scroll, focus, text selection, and selected state during an overtake
- add a deterministic DOM regression for overtake-during-read

## Root cause

The scheme node render loop reused stable keys while JSX sibling order followed freshness. React moved the existing pane host in the DOM, detaching browser-owned reader state.

## Verification

- bun test — 1531 pass, 0 fail
- bunx tsc --noEmit — passed

Closes #24