### PR TITLE
fix: harden headless reviewer launches

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -1,15 +1,20 @@
-# Issue 121: deployment proxy request forwarding
+# Issue 117: reliable headless reviewer spawning
 
 ## Task statement
 
-Investigate the first managed Viewer cutover failure where `serveViewerDeploymentProxy` accepted connections on the stable listener while returning zero response bytes. Repair request forwarding for the production `bun-container` runtime, preserve the target-file listener-switch design, cover the failure with a real TCP regression test, and remove the public-repository SSH bootstrap papercut.
+Repair headless review rounds started by the flow engine so Codex receives its prompt with a deterministic EOF, reviewer launches avoid exhausted accounts, a configured Claude/Fable reviewer can take over when Codex quota is exhausted, and transient no-verdict exits recover without manual retry-round babysitting.
 
 ## Acceptance criteria
 
-- AC1: The deployment proxy forwards a request sent immediately after downstream TCP connection and returns the candidate Viewer response.
-- AC2: The proxy preserves request bytes while its upstream connection is being established under production-image Bun 1.2.18.
-- AC3: A regression test drives an external TCP client through an in-process proxy and upstream listener.
-- AC4: Missing, invalid, or recursive release targets continue to receive the existing `503 Service Unavailable` response.
-- AC5: The default canonical remote for the public repository uses HTTPS and remains configurable through `LLV_VIEWER_CANONICAL_REMOTE`.
-- AC6: `bun test` and `bunx tsc --noEmit` pass.
-- AC7: Investigation and verification use unused high ports and leave the production listener, runtime-host, legacy Viewer, and managed candidate lifecycle unchanged.
+- AC1: `codex exec` receives the complete reviewer prompt through stdin and observes EOF after the payload flushes.
+- AC2: Headless Codex launches select an authenticated account with fresh session and weekly headroom when one is available.
+- AC3: A retry prefers an untried eligible account, then the configured Claude/Fable fallback, before reusing a failed account.
+- AC4: Effective reviewer role and account identity are persisted before process launch.
+- AC5: PID, session id, and reviewer transcript receipt are persisted immediately after launch.
+- AC6: Restart recovery interprets file-backed output with the persisted effective reviewer engine, including Claude fallback attempts.
+- AC7: A headless reviewer exit without a verdict triggers one automatic retry inside the logical round.
+- AC8: Repeated no-verdict failure parks in `needs_decision` with captured diagnostics.
+- AC9: Confirmed exhaustion across primary and fallback reviewer accounts parks with a dedicated rate-limit `stateDetail` that surfaces `resetsAt`.
+- AC10: Legacy persisted flows load with compatible defaults for fallback and retry fields.
+- AC11: `bun test` and `bunx tsc --noEmit` pass before each review-ready push.
+- AC12: Work remains inside this checkout and leaves production services on port 8898 unchanged.

--- a/src/lib/accounts/contracts.ts
+++ b/src/lib/accounts/contracts.ts
@@ -50,6 +50,11 @@ export type AccountContext = {
   env: NodeJS.ProcessEnv;
 };
 
+export type HeadlessSpawnAvailability =
+  | { kind: "available"; account: AccountContext }
+  | { kind: "exhausted"; resetsAt: number | null }
+  | { kind: "unavailable" };
+
 export interface AccountManager {
   list(): Promise<AccountCatalog>;
   add(engine: "claude" | "codex", label: string): Promise<AccountSummary>;
@@ -58,6 +63,7 @@ export interface AccountManager {
   submitLoginInput(operationId: string, code: string): Promise<LoginOperationSummary>;
   cancelLogin(operationId: string): Promise<LoginOperationSummary>;
   resolveSpawn(engine: "claude" | "codex", requestedId?: string | null): AccountContext;
+  resolveHeadlessSpawn(engine: "claude" | "codex", requestedId?: string | null, excludedIds?: string[]): HeadlessSpawnAvailability;
   resolveTranscriptOwner(engine: "claude" | "codex", transcript: string): AccountContext | null;
 }
 

--- a/src/lib/accounts/headlessSelection.test.ts
+++ b/src/lib/accounts/headlessSelection.test.ts
@@ -1,0 +1,63 @@
+import { expect, test } from "bun:test";
+
+import type { DurableQuotaObservation } from "./migration/contracts";
+import { selectHeadlessAccount } from "./headlessSelection";
+
+const NOW = Date.parse("2026-07-12T10:00:00.000Z");
+
+function observation(accountId: string, usedPercent: number, resetsAt: number | null = null): DurableQuotaObservation {
+  return {
+    engine: "codex",
+    accountId,
+    authenticated: true,
+    authCheckedAt: new Date(NOW - 1_000).toISOString(),
+    limits: {
+      session: { usedPercent, resetsAt },
+      weekly: null,
+      plan: "pro",
+      capturedAt: Math.floor((NOW - 1_000) / 1_000),
+    },
+    provenance: { source: "live", reason: null, staleSince: null },
+    observedAt: new Date(NOW - 1_000).toISOString(),
+    bootId: "00000000-0000-4000-8000-000000000117",
+  };
+}
+
+const accounts = [
+  { id: "default", authPresent: true },
+  { id: "spare", authPresent: true },
+];
+
+test("headless selection chooses the authenticated account with the most fresh quota headroom", () => {
+  expect(selectHeadlessAccount(accounts, [observation("default", 100), observation("spare", 25)], "default", [], NOW)).toEqual({
+    kind: "available",
+    accountId: "spare",
+  });
+});
+
+test("headless selection uses an unobserved account before declaring confirmed exhaustion", () => {
+  expect(selectHeadlessAccount(accounts, [observation("default", 100)], "default", [], NOW)).toEqual({
+    kind: "available",
+    accountId: "spare",
+  });
+});
+
+test("headless selection reports the earliest account recovery when every account is exhausted", () => {
+  const firstReset = Math.floor(NOW / 1_000) + 900;
+  const secondReset = Math.floor(NOW / 1_000) + 1_800;
+  expect(selectHeadlessAccount(accounts, [observation("default", 100, secondReset), observation("spare", 100, firstReset)], null, [], NOW)).toEqual({
+    kind: "exhausted",
+    resetsAt: firstReset,
+  });
+});
+
+test("headless retry prefers an eligible account that has not already failed", () => {
+  expect(selectHeadlessAccount(accounts, [observation("default", 20), observation("spare", 30)], "default", ["default"], NOW)).toEqual({
+    kind: "available",
+    accountId: "spare",
+  });
+});
+
+test("headless selection distinguishes missing authentication from exhausted quota", () => {
+  expect(selectHeadlessAccount([{ id: "default", authPresent: false }], [], "default", [], NOW)).toEqual({ kind: "unavailable" });
+});

--- a/src/lib/accounts/headlessSelection.test.ts
+++ b/src/lib/accounts/headlessSelection.test.ts
@@ -76,6 +76,13 @@ test("headless retry prefers an eligible account that has not already failed", (
   });
 });
 
+test("headless retry chooses an untried unknown-capacity account before a tried account with known headroom", () => {
+  expect(selectHeadlessAccount(accounts, [observation("default", 20)], "default", ["default"], NOW)).toEqual({
+    kind: "available",
+    accountId: "spare",
+  });
+});
+
 test("headless selection distinguishes missing authentication from exhausted quota", () => {
   expect(selectHeadlessAccount([{ id: "default", authPresent: false }], [], "default", [], NOW)).toEqual({ kind: "unavailable" });
 });

--- a/src/lib/accounts/headlessSelection.test.ts
+++ b/src/lib/accounts/headlessSelection.test.ts
@@ -51,6 +51,24 @@ test("headless selection reports the earliest account recovery when every accoun
   });
 });
 
+test("headless selection keeps reset unknown when any exhausted governing window lacks a reset", () => {
+  const reset = Math.floor(NOW / 1_000) + 900;
+  const mixedReset = observation("default", 100, reset);
+  mixedReset.limits!.weekly = { usedPercent: 100, resetsAt: null };
+  expect(selectHeadlessAccount([accounts[0]!], [mixedReset], "default", [], NOW)).toEqual({
+    kind: "exhausted",
+    resetsAt: null,
+  });
+});
+
+test("headless selection keeps reset unknown when exhausted evidence names an expired reset", () => {
+  const expiredReset = Math.floor(NOW / 1_000) - 1;
+  expect(selectHeadlessAccount([accounts[0]!], [observation("default", 100, expiredReset)], "default", [], NOW)).toEqual({
+    kind: "exhausted",
+    resetsAt: null,
+  });
+});
+
 test("headless retry prefers an eligible account that has not already failed", () => {
   expect(selectHeadlessAccount(accounts, [observation("default", 20), observation("spare", 30)], "default", ["default"], NOW)).toEqual({
     kind: "available",

--- a/src/lib/accounts/headlessSelection.test.ts
+++ b/src/lib/accounts/headlessSelection.test.ts
@@ -61,3 +61,11 @@ test("headless retry prefers an eligible account that has not already failed", (
 test("headless selection distinguishes missing authentication from exhausted quota", () => {
   expect(selectHeadlessAccount([{ id: "default", authPresent: false }], [], "default", [], NOW)).toEqual({ kind: "unavailable" });
 });
+
+test("headless selection excludes fresh live signed-out evidence even when credentials remain on disk", () => {
+  const signedOut = { ...observation("default", 20), authenticated: false };
+  expect(selectHeadlessAccount(accounts, [signedOut], "default", [], NOW)).toEqual({
+    kind: "available",
+    accountId: "spare",
+  });
+});

--- a/src/lib/accounts/headlessSelection.ts
+++ b/src/lib/accounts/headlessSelection.ts
@@ -1,0 +1,63 @@
+import type { DurableQuotaObservation } from "./migration/contracts";
+
+const FRESH_QUOTA_MS = 5 * 60 * 1_000;
+
+export type HeadlessAccountSelection =
+  | { kind: "available"; accountId: string }
+  | { kind: "exhausted"; resetsAt: number | null }
+  | { kind: "unavailable" };
+
+type SelectableAccount = { id: string; authPresent: boolean };
+
+type Capacity =
+  | { kind: "available"; remaining: number }
+  | { kind: "exhausted"; resetsAt: number | null }
+  | { kind: "unknown" };
+
+function capacity(observation: DurableQuotaObservation | undefined, now: number): Capacity {
+  if (!observation || !observation.authenticated || observation.provenance.source !== "live" || !observation.limits) return { kind: "unknown" };
+  const observedAt = Date.parse(observation.observedAt);
+  const authCheckedAt = Date.parse(observation.authCheckedAt);
+  if (!Number.isFinite(observedAt) || !Number.isFinite(authCheckedAt) || now < observedAt || now < authCheckedAt || now - observedAt > FRESH_QUOTA_MS || now - authCheckedAt > FRESH_QUOTA_MS) {
+    return { kind: "unknown" };
+  }
+  const windows = [observation.limits.session, observation.limits.weekly].filter((window) => window !== null);
+  if (!windows.length || windows.some((window) => !Number.isFinite(window.usedPercent) || window.usedPercent < 0 || window.usedPercent > 100 || (window.resetsAt !== null && (!Number.isSafeInteger(window.resetsAt) || window.resetsAt < 0)))) {
+    return { kind: "unknown" };
+  }
+  const remaining = Math.min(...windows.map((window) => 100 - window.usedPercent));
+  if (remaining > 0) return { kind: "available", remaining };
+  const knownResets = windows.flatMap((window) => window.usedPercent >= 100 && window.resetsAt !== null ? [window.resetsAt] : []);
+  return { kind: "exhausted", resetsAt: knownResets.length ? Math.max(...knownResets) : null };
+}
+
+/**
+ * Selects an authenticated account for an unattended spawn. Confirmed fresh
+ * headroom wins, then an account whose quota is unknown. Exhaustion is only
+ * reported when every authenticated account has a fresh zero-capacity sample.
+ */
+export function selectHeadlessAccount(
+  accounts: SelectableAccount[],
+  observations: DurableQuotaObservation[],
+  preferredId: string | null | undefined,
+  excludedIds: string[],
+  now = Date.now(),
+): HeadlessAccountSelection {
+  const byAccount = new Map(observations.map((observation) => [observation.accountId, observation]));
+  const excluded = new Set(excludedIds);
+  const candidates = accounts
+    .filter((account) => account.authPresent)
+    .map((account) => ({ account, capacity: capacity(byAccount.get(account.id), now) }));
+  if (!candidates.length) return { kind: "unavailable" };
+  const rank = (accountId: string): number => excluded.has(accountId) ? 1 : 0;
+  const available = candidates
+    .flatMap((candidate) => candidate.capacity.kind === "available" ? [{ ...candidate, remaining: candidate.capacity.remaining }] : [])
+    .sort((left, right) => rank(left.account.id) - rank(right.account.id) || right.remaining - left.remaining || Number(right.account.id === preferredId) - Number(left.account.id === preferredId) || left.account.id.localeCompare(right.account.id));
+  if (available[0]) return { kind: "available", accountId: available[0].account.id };
+  const unknown = candidates
+    .filter((candidate) => candidate.capacity.kind === "unknown")
+    .sort((left, right) => rank(left.account.id) - rank(right.account.id) || Number(right.account.id === preferredId) - Number(left.account.id === preferredId) || left.account.id.localeCompare(right.account.id));
+  if (unknown[0]) return { kind: "available", accountId: unknown[0].account.id };
+  const resets = candidates.flatMap((candidate) => candidate.capacity.kind === "exhausted" && candidate.capacity.resetsAt !== null ? [candidate.capacity.resetsAt] : []);
+  return { kind: "exhausted", resetsAt: resets.length ? Math.min(...resets) : null };
+}

--- a/src/lib/accounts/headlessSelection.ts
+++ b/src/lib/accounts/headlessSelection.ts
@@ -30,8 +30,10 @@ function capacity(observation: DurableQuotaObservation | undefined, now: number)
   }
   const remaining = Math.min(...windows.map((window) => 100 - window.usedPercent));
   if (remaining > 0) return { kind: "available", remaining };
-  const knownResets = windows.flatMap((window) => window.usedPercent >= 100 && window.resetsAt !== null ? [window.resetsAt] : []);
-  return { kind: "exhausted", resetsAt: knownResets.length ? Math.max(...knownResets) : null };
+  const exhaustedWindows = windows.filter((window) => window.usedPercent >= 100);
+  const nowSeconds = Math.floor(now / 1_000);
+  if (exhaustedWindows.some((window) => window.resetsAt === null || window.resetsAt <= nowSeconds)) return { kind: "exhausted", resetsAt: null };
+  return { kind: "exhausted", resetsAt: Math.max(...exhaustedWindows.map((window) => window.resetsAt!)) };
 }
 
 /**

--- a/src/lib/accounts/headlessSelection.ts
+++ b/src/lib/accounts/headlessSelection.ts
@@ -12,15 +12,18 @@ type SelectableAccount = { id: string; authPresent: boolean };
 type Capacity =
   | { kind: "available"; remaining: number }
   | { kind: "exhausted"; resetsAt: number | null }
+  | { kind: "unavailable" }
   | { kind: "unknown" };
 
 function capacity(observation: DurableQuotaObservation | undefined, now: number): Capacity {
-  if (!observation || !observation.authenticated || observation.provenance.source !== "live" || !observation.limits) return { kind: "unknown" };
+  if (!observation || observation.provenance.source !== "live") return { kind: "unknown" };
   const observedAt = Date.parse(observation.observedAt);
   const authCheckedAt = Date.parse(observation.authCheckedAt);
   if (!Number.isFinite(observedAt) || !Number.isFinite(authCheckedAt) || now < observedAt || now < authCheckedAt || now - observedAt > FRESH_QUOTA_MS || now - authCheckedAt > FRESH_QUOTA_MS) {
     return { kind: "unknown" };
   }
+  if (!observation.authenticated) return { kind: "unavailable" };
+  if (!observation.limits) return { kind: "unknown" };
   const windows = [observation.limits.session, observation.limits.weekly].filter((window) => window !== null);
   if (!windows.length || windows.some((window) => !Number.isFinite(window.usedPercent) || window.usedPercent < 0 || window.usedPercent > 100 || (window.resetsAt !== null && (!Number.isSafeInteger(window.resetsAt) || window.resetsAt < 0)))) {
     return { kind: "unknown" };
@@ -47,7 +50,8 @@ export function selectHeadlessAccount(
   const excluded = new Set(excludedIds);
   const candidates = accounts
     .filter((account) => account.authPresent)
-    .map((account) => ({ account, capacity: capacity(byAccount.get(account.id), now) }));
+    .map((account) => ({ account, capacity: capacity(byAccount.get(account.id), now) }))
+    .filter((candidate) => candidate.capacity.kind !== "unavailable");
   if (!candidates.length) return { kind: "unavailable" };
   const rank = (accountId: string): number => excluded.has(accountId) ? 1 : 0;
   const available = candidates

--- a/src/lib/accounts/headlessSelection.ts
+++ b/src/lib/accounts/headlessSelection.ts
@@ -55,15 +55,17 @@ export function selectHeadlessAccount(
     .map((account) => ({ account, capacity: capacity(byAccount.get(account.id), now) }))
     .filter((candidate) => candidate.capacity.kind !== "unavailable");
   if (!candidates.length) return { kind: "unavailable" };
-  const rank = (accountId: string): number => excluded.has(accountId) ? 1 : 0;
-  const available = candidates
-    .flatMap((candidate) => candidate.capacity.kind === "available" ? [{ ...candidate, remaining: candidate.capacity.remaining }] : [])
-    .sort((left, right) => rank(left.account.id) - rank(right.account.id) || right.remaining - left.remaining || Number(right.account.id === preferredId) - Number(left.account.id === preferredId) || left.account.id.localeCompare(right.account.id));
-  if (available[0]) return { kind: "available", accountId: available[0].account.id };
-  const unknown = candidates
-    .filter((candidate) => candidate.capacity.kind === "unknown")
-    .sort((left, right) => rank(left.account.id) - rank(right.account.id) || Number(right.account.id === preferredId) - Number(left.account.id === preferredId) || left.account.id.localeCompare(right.account.id));
-  if (unknown[0]) return { kind: "available", accountId: unknown[0].account.id };
+  for (const attempted of [false, true]) {
+    const tier = candidates.filter((candidate) => excluded.has(candidate.account.id) === attempted);
+    const available = tier
+      .flatMap((candidate) => candidate.capacity.kind === "available" ? [{ ...candidate, remaining: candidate.capacity.remaining }] : [])
+      .sort((left, right) => right.remaining - left.remaining || Number(right.account.id === preferredId) - Number(left.account.id === preferredId) || left.account.id.localeCompare(right.account.id));
+    if (available[0]) return { kind: "available", accountId: available[0].account.id };
+    const unknown = tier
+      .filter((candidate) => candidate.capacity.kind === "unknown")
+      .sort((left, right) => Number(right.account.id === preferredId) - Number(left.account.id === preferredId) || left.account.id.localeCompare(right.account.id));
+    if (unknown[0]) return { kind: "available", accountId: unknown[0].account.id };
+  }
   const resets = candidates.flatMap((candidate) => candidate.capacity.kind === "exhausted" && candidate.capacity.resetsAt !== null ? [candidate.capacity.resetsAt] : []);
   return { kind: "exhausted", resetsAt: resets.length ? Math.min(...resets) : null };
 }

--- a/src/lib/accounts/manager.ts
+++ b/src/lib/accounts/manager.ts
@@ -6,6 +6,12 @@ import type { AccountManager, AccountSummary } from "./contracts";
 import { unavailableLimits } from "./contracts";
 import { withAccountMutationLockAsync } from "./accountMutation";
 import { agentRegistry, type AgentRegistry } from "@/lib/agent/registry";
+import { selectHeadlessAccount } from "./headlessSelection";
+
+function contextForSpawn(engine: "claude" | "codex", requested?: string | null) {
+  if (engine === "claude") { const item = claudeAccountForSpawn(requested); return { engine, accountId: item.id, kind: item.kind, home: item.home, transcriptRoot: item.projectsDir, env: item.kind === "managed" ? claudeManagedEnvironment(item.home) : process.env }; }
+  const item = accountForSpawn(requested); return { engine, accountId: item.id, kind: item.kind, home: item.home, transcriptRoot: item.sessionsDir, env: { ...process.env, CODEX_HOME: item.home } };
+}
 
 function summary(engine: "claude" | "codex", id: string): AccountSummary {
   const account = (engine === "claude" ? listClaudeAccounts() : listCodexAccounts()).find((item) => item.id === id);
@@ -94,10 +100,13 @@ export const accountManager: AccountManager = {
   async status(engine, id) { return summary(engine, id); },
   async submitLoginInput() { throw new Error("login input is Claude-operation specific"); },
   async cancelLogin() { throw new Error("login cancellation is Claude-operation specific"); },
-  resolveSpawn(engine, requested) {
-    const routed = requested ?? agentRegistry().engineRouting(engine).activeAccountId ?? undefined;
-    if (engine === "claude") { const item = claudeAccountForSpawn(routed); return { engine, accountId: item.id, kind: item.kind, home: item.home, transcriptRoot: item.projectsDir, env: item.kind === "managed" ? claudeManagedEnvironment(item.home) : process.env }; }
-    const item = accountForSpawn(routed); return { engine, accountId: item.id, kind: item.kind, home: item.home, transcriptRoot: item.sessionsDir, env: { ...process.env, CODEX_HOME: item.home } };
+  resolveSpawn(engine, requested) { return contextForSpawn(engine, requested ?? agentRegistry().engineRouting(engine).activeAccountId ?? undefined); },
+  resolveHeadlessSpawn(engine, requested, excludedIds = []) {
+    const accounts = engine === "claude" ? listClaudeAccounts() : listCodexAccounts();
+    const selected = selectHeadlessAccount(accounts, agentRegistry().quotaObservations(engine), requested ?? agentRegistry().engineRouting(engine).activeAccountId, excludedIds);
+    return selected.kind === "available"
+      ? { kind: "available", account: contextForSpawn(engine, selected.accountId) }
+      : selected;
   },
   resolveTranscriptOwner(engine, transcript) {
     if (engine === "claude") { const home = claudeHomeOwningTranscript(transcript); if (!home) return null; const item = listClaudeAccounts().find((candidate) => candidate.home === home); return item ? { engine, accountId: item.id, kind: item.kind, home, transcriptRoot: item.projectsDir, env: item.kind === "managed" ? claudeManagedEnvironment(home) : process.env } : null; }

--- a/src/lib/flows/commands.ts
+++ b/src/lib/flows/commands.ts
@@ -11,7 +11,7 @@ import { isoNow, lastRound, newRound, sendToImplementer } from "./engine";
 import { forgetHeadlessReview } from "./exec";
 import { resolveBaseRef } from "./git";
 import { kickoffPrompt } from "./prompts";
-import { loadFlows, loadPresets, saveFlows } from "./store";
+import { configuredReviewerFallback, loadFlows, loadPresets, saveFlows } from "./store";
 import type { CreateFlowRequest, Flow, PatchFlowRequest, RoleConfig, Round } from "./types";
 
 /**
@@ -82,6 +82,7 @@ export async function createFlowFromRequest(req: CreateFlowRequest, entries: Fil
     implementerPath: entry.path,
     implementerConversationId: entry.conversationId ?? null,
     roles,
+    reviewerFallback: roles.reviewer.engine === "codex" ? configuredReviewerFallback() : null,
     baseRef: base.sha,
     ...(normalizedSpec.spec ? { spec: normalizedSpec.spec } : {}),
     baseMode,
@@ -224,6 +225,11 @@ export function patchFlow(id: string, req: PatchFlowRequest): { flow?: Flow; err
     forgetHeadlessReview(flow.id, round.n, round.reviewerPid ?? null);
     Object.assign(round, {
       reviewerPath: null,
+      reviewerConversationId: null,
+      reviewerRole: null,
+      accountId: null,
+      attemptedAccounts: [],
+      autoRetryCount: 0,
       sessionId: null,
       reviewerPid: null,
       reviewerPane: null,

--- a/src/lib/flows/commands.ts
+++ b/src/lib/flows/commands.ts
@@ -8,7 +8,7 @@ import { killPane, paneInfo } from "@/lib/tmux";
 import type { FileEntry } from "@/lib/types";
 
 import { isoNow, lastRound, newRound, sendToImplementer } from "./engine";
-import { forgetHeadlessReview } from "./exec";
+import { clearHeadlessReviewArtifacts, forgetHeadlessReview } from "./exec";
 import { resolveBaseRef } from "./git";
 import { kickoffPrompt } from "./prompts";
 import { configuredReviewerFallback, loadFlows, loadPresets, saveFlows } from "./store";
@@ -223,6 +223,7 @@ export function patchFlow(id: string, req: PatchFlowRequest): { flow?: Flow; err
   } else if (req.action === "retry-round") {
     if (flow.state !== "needs_decision" || !round) return { error: "flow cannot retry from its current state", status: 409 };
     forgetHeadlessReview(flow.id, round.n, round.reviewerPid ?? null);
+    clearHeadlessReviewArtifacts(flow.id, round.n);
     Object.assign(round, {
       reviewerPath: null,
       reviewerConversationId: null,

--- a/src/lib/flows/engine.test.ts
+++ b/src/lib/flows/engine.test.ts
@@ -9,7 +9,7 @@ import type { Flow } from "./types";
 
 process.env.LLV_STATE_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "llv-flow-engine-test-"));
 const { tickFlows } = await import("./engine");
-const { loadFlows, saveFlows, stdoutPathFor } = await import("./store");
+const { loadFlows, outputPathFor, saveFlows, stderrPathFor, stdoutPathFor } = await import("./store");
 
 afterAll(() => {
   fs.rmSync(process.env.LLV_STATE_DIR!, { recursive: true, force: true });
@@ -162,6 +162,8 @@ test("headless review retries once after an exit without a verdict, then parks o
   };
   fs.mkdirSync(path.dirname(stdoutPathFor(flow.id, 1)), { recursive: true });
   fs.writeFileSync(stdoutPathFor(flow.id, 1), "reviewer exited before producing a verdict\n");
+  fs.writeFileSync(stderrPathFor(flow.id, 1), "stale stderr\n");
+  fs.writeFileSync(outputPathFor(flow.id, 1), "stale last message without verdict\n");
   saveFlows([flow]);
 
   await tickFlows([implementer]);
@@ -169,11 +171,21 @@ test("headless review retries once after an exit without a verdict, then parks o
   expect(retrying.state).toBe("spawning");
   expect(retrying.stateDetail).toContain("retrying automatically");
   expect(retrying.rounds[0]).toMatchObject({ autoRetryCount: 1, accountId: null, reviewerRole: null, attemptedAccounts: ["codex:default"], error: null });
+  expect(fs.existsSync(stdoutPathFor(flow.id, 1))).toBeFalse();
+  expect(fs.existsSync(stderrPathFor(flow.id, 1))).toBeFalse();
+  expect(fs.existsSync(outputPathFor(flow.id, 1))).toBeFalse();
 
-  retrying.state = "reviewing";
-  retrying.rounds[0]!.reviewerPid = 999_999_999;
   retrying.rounds[0]!.spawnStartedAt = startedAt;
   saveFlows([retrying]);
+  await tickFlows([implementer]);
+  const interrupted = loadFlows()[0]!;
+  expect(interrupted.state).toBe("needs_decision");
+  expect(interrupted.stateDetail).toBe("reviewer spawn was interrupted by a restart");
+
+  interrupted.state = "reviewing";
+  interrupted.rounds[0]!.reviewerPid = 999_999_999;
+  interrupted.rounds[0]!.spawnStartedAt = startedAt;
+  saveFlows([interrupted]);
   fs.writeFileSync(stdoutPathFor(flow.id, 1), "reviewer exited again\n");
 
   await tickFlows([implementer]);

--- a/src/lib/flows/engine.test.ts
+++ b/src/lib/flows/engine.test.ts
@@ -9,7 +9,7 @@ import type { Flow } from "./types";
 
 process.env.LLV_STATE_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "llv-flow-engine-test-"));
 const { tickFlows } = await import("./engine");
-const { loadFlows, saveFlows } = await import("./store");
+const { loadFlows, saveFlows, stdoutPathFor } = await import("./store");
 
 afterAll(() => {
   fs.rmSync(process.env.LLV_STATE_DIR!, { recursive: true, force: true });
@@ -110,4 +110,74 @@ test("review-flow heuristic claim skips a newer native Codex subagent", async ()
   const after = loadFlows()[0]!;
 
   expect(after.rounds[0]!.reviewerPath).toBe(root.path);
+});
+
+test("headless review retries once after an exit without a verdict, then parks on a repeated failure", async () => {
+  const startedAt = new Date().toISOString();
+  const cwd = "/repo";
+  const implementer = writeCodexEntry("retry-implementer.jsonl", { id: "019f421e-02e1-73e0-9b77-bebde063f117", cwd }, Date.now() / 1_000);
+  const flow: Flow = {
+    id: "flow-retry",
+    template: "implement-review-loop",
+    project: "repo",
+    cwd,
+    implementerPath: implementer.path,
+    roles: {
+      implementer: { engine: "codex", model: null, effort: "high" },
+      reviewer: { engine: "codex", model: null, effort: "xhigh" },
+    },
+    reviewerFallback: { engine: "claude", model: "fable", effort: "high" },
+    baseRef: "base",
+    baseMode: "head",
+    mode: "auto",
+    reviewerMode: "headless",
+    roundLimit: 5,
+    state: "reviewing",
+    pausedState: null,
+    stateDetail: null,
+    rounds: [{
+      n: 1,
+      reviewerPath: null,
+      reviewerRole: { engine: "codex", model: null, effort: "xhigh" },
+      accountId: "default",
+      attemptedAccounts: ["codex:default"],
+      autoRetryCount: 0,
+      sessionId: null,
+      reviewerPid: 999_999_999,
+      reviewerPane: null,
+      findingsPath: null,
+      triggeredBy: "marker",
+      readyNote: null,
+      verdict: null,
+      findingsCount: null,
+      startedAt,
+      spawnStartedAt: startedAt,
+      relayStartedAt: null,
+      reviewedAt: null,
+      relayedAt: null,
+      error: null,
+    }],
+    createdAt: startedAt,
+    closedAt: null,
+  };
+  fs.mkdirSync(path.dirname(stdoutPathFor(flow.id, 1)), { recursive: true });
+  fs.writeFileSync(stdoutPathFor(flow.id, 1), "reviewer exited before producing a verdict\n");
+  saveFlows([flow]);
+
+  await tickFlows([implementer]);
+  const retrying = loadFlows()[0]!;
+  expect(retrying.state).toBe("spawning");
+  expect(retrying.stateDetail).toContain("retrying automatically");
+  expect(retrying.rounds[0]).toMatchObject({ autoRetryCount: 1, accountId: null, reviewerRole: null, attemptedAccounts: ["codex:default"], error: null });
+
+  retrying.state = "reviewing";
+  retrying.rounds[0]!.reviewerPid = 999_999_999;
+  retrying.rounds[0]!.spawnStartedAt = startedAt;
+  saveFlows([retrying]);
+  fs.writeFileSync(stdoutPathFor(flow.id, 1), "reviewer exited again\n");
+
+  await tickFlows([implementer]);
+  const parked = loadFlows()[0]!;
+  expect(parked.state).toBe("needs_decision");
+  expect(parked.stateDetail).toContain("reviewer verdict was unparseable");
 });

--- a/src/lib/flows/engine.test.ts
+++ b/src/lib/flows/engine.test.ts
@@ -181,3 +181,68 @@ test("headless review retries once after an exit without a verdict, then parks o
   expect(parked.state).toBe("needs_decision");
   expect(parked.stateDetail).toContain("reviewer verdict was unparseable");
 });
+
+test("restart recovery keeps a launched Claude fallback bound to its persisted effective role", async () => {
+  const startedAt = new Date().toISOString();
+  const cwd = "/repo";
+  const implementer = writeCodexEntry("fallback-restart-implementer.jsonl", { id: "019f421e-02e1-73e0-9b77-bebde063f118", cwd }, Date.now() / 1_000);
+  const flow: Flow = {
+    id: "flow-fallback-restart",
+    template: "implement-review-loop",
+    project: "repo",
+    cwd,
+    implementerPath: implementer.path,
+    roles: {
+      implementer: { engine: "codex", model: null, effort: "high" },
+      reviewer: { engine: "codex", model: "gpt-5.6-sol", effort: "xhigh" },
+    },
+    reviewerFallback: { engine: "claude", model: "fable", effort: "high" },
+    baseRef: "base",
+    baseMode: "head",
+    mode: "auto",
+    reviewerMode: "headless",
+    roundLimit: 5,
+    state: "spawning",
+    pausedState: null,
+    stateDetail: null,
+    rounds: [{
+      n: 1,
+      reviewerPath: null,
+      reviewerRole: { engine: "claude", model: "fable", effort: "high" },
+      accountId: "fable-main",
+      attemptedAccounts: ["codex:default", "claude:fable-main"],
+      autoRetryCount: 1,
+      sessionId: null,
+      reviewerPid: 999_999_999,
+      reviewerPane: null,
+      findingsPath: null,
+      triggeredBy: "marker",
+      readyNote: null,
+      verdict: null,
+      findingsCount: null,
+      startedAt,
+      spawnStartedAt: startedAt,
+      relayStartedAt: null,
+      reviewedAt: null,
+      relayedAt: null,
+      error: null,
+    }],
+    createdAt: startedAt,
+    closedAt: null,
+  };
+  fs.mkdirSync(path.dirname(stdoutPathFor(flow.id, 1)), { recursive: true });
+  fs.writeFileSync(stdoutPathFor(flow.id, 1), "VERDICT: APPROVE\n\nFallback review completed.\n");
+  saveFlows([flow]);
+
+  await tickFlows([implementer]);
+  expect(loadFlows()[0]).toMatchObject({
+    state: "reviewing",
+    rounds: [{ reviewerRole: { engine: "claude", model: "fable", effort: "high" }, accountId: "fable-main" }],
+  });
+
+  await tickFlows([implementer]);
+  expect(loadFlows()[0]).toMatchObject({
+    state: "relaying",
+    rounds: [{ verdict: "APPROVE", reviewerRole: { engine: "claude" } }],
+  });
+});

--- a/src/lib/flows/engine.ts
+++ b/src/lib/flows/engine.ts
@@ -22,12 +22,21 @@ import {
 import { relayPrompt, reviewerPrompt } from "./prompts";
 import { atomicWriteText, findingsPathFor, loadFlows, loadPresets, saveFlows } from "./store";
 import type { Flow, FlowPreset, FlowState, Round } from "./types";
+import { chooseHeadlessReviewer, rateLimitStateDetail } from "./reviewerPolicy";
 
 const TERMINAL_STATES = new Set<FlowState>(["approved", "done_comment", "needs_decision", "closed"]);
 const READY_RE = /^REVIEW_READY:\s*(.*)$/m;
 const UUID_RE = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/i;
 const store = globalThis as unknown as { __llvFlowTick?: boolean };
 const relayStartedThisProcess = new Set<string>();
+const MAX_HEADLESS_NO_VERDICT_RETRIES = 1;
+
+class ReviewerAccountsExhaustedError extends Error {
+  constructor(readonly resetsAt: number | null) {
+    super("reviewer rate limited; all accounts exhausted");
+    this.name = "ReviewerAccountsExhaustedError";
+  }
+}
 
 interface TickResult {
   flows: Flow[];
@@ -51,7 +60,12 @@ function cloneFlows(flows: Flow[]): Flow[] {
       implementer: { ...flow.roles.implementer },
       reviewer: { ...flow.roles.reviewer },
     },
-    rounds: flow.rounds.map((round) => ({ ...round })),
+    reviewerFallback: flow.reviewerFallback ? { ...flow.reviewerFallback } : null,
+    rounds: flow.rounds.map((round) => ({
+      ...round,
+      reviewerRole: round.reviewerRole ? { ...round.reviewerRole } : null,
+      attemptedAccounts: [...(round.attemptedAccounts ?? [])],
+    })),
   }));
 }
 
@@ -78,6 +92,9 @@ export function newRound(flow: Flow, triggeredBy: Round["triggeredBy"], readyNot
     n: flow.rounds.length + 1,
     reviewerPath: null,
     accountId: null,
+    reviewerRole: null,
+    attemptedAccounts: [],
+    autoRetryCount: 0,
     sessionId: null,
     reviewerPane: null,
     findingsPath: null,
@@ -140,7 +157,7 @@ function isNativeCodexSubagentEntry(entry: FileEntry): boolean {
 function maybeClaimReviewerPathByHeuristic(flow: Flow, entries: FileEntry[], round: Round): boolean {
   if (round.reviewerPath) return false;
   const started = unixMs(round.startedAt) / 1000 - 5;
-  const engine = flow.roles.reviewer.engine;
+  const engine = round.reviewerRole?.engine ?? flow.roles.reviewer.engine;
   const candidates = entries
     .filter(
       (entry) =>
@@ -174,14 +191,16 @@ function applyVerdict(flow: Flow, round: Round, parsed: ParsedFindings): void {
 
 async function launchReviewer(flow: Flow, round: Round): Promise<void> {
   const prompt = reviewerPrompt(flow, round);
-  const account = accountManager.resolveSpawn(flow.roles.reviewer.engine, round.accountId);
-  round.accountId ??= account.accountId;
   flow.state = "reviewing";
   flow.stateDetail = null;
   if (flow.reviewerMode === "pane") {
-    const spec = freshSpecFor(flow.roles.reviewer.engine, flow.cwd, {
-      model: flow.roles.reviewer.model,
-      effort: flow.roles.reviewer.effort,
+    const role = flow.roles.reviewer;
+    const account = accountManager.resolveSpawn(role.engine, round.accountId);
+    round.accountId ??= account.accountId;
+    round.reviewerRole = role;
+    const spec = freshSpecFor(role.engine, flow.cwd, {
+      model: role.model,
+      effort: role.effort,
       codexHome: account.engine === "codex" ? account.home : null,
       claudeConfigDir: account.engine === "claude" ? account.home : null,
       claudeProjectsDir: account.engine === "claude" ? account.transcriptRoot : null,
@@ -192,7 +211,7 @@ async function launchReviewer(flow: Flow, round: Round): Promise<void> {
        transcript is still unattributed (codex, or an early stop click). */
     round.reviewerPane = { paneId: pane.paneId, windowName: spec.windowName };
     const transcript = await resolveSpawnedTranscriptPath({
-      engine: flow.roles.reviewer.engine,
+      engine: role.engine,
       knownTranscript: spec.transcript ?? null,
       panePid: pane.panePid ?? null,
       cwd: flow.cwd,
@@ -203,10 +222,23 @@ async function launchReviewer(flow: Flow, round: Round): Promise<void> {
     if (!round.reviewerPath && pane.panePid) round.error = null;
     return;
   }
+  const decision = chooseHeadlessReviewer(
+    flow.roles.reviewer,
+    flow.reviewerFallback,
+    round.attemptedAccounts ?? [],
+    (engine, requestedId, excludedIds) => accountManager.resolveHeadlessSpawn(engine, requestedId, excludedIds),
+  );
+  if (decision.kind === "exhausted") throw new ReviewerAccountsExhaustedError(decision.resetsAt);
+  if (decision.kind === "unavailable") throw new Error("no authenticated reviewer account is available");
+  const { role, account } = decision;
+  round.reviewerRole = { ...role };
+  round.accountId = account.accountId;
+  const accountKey = `${account.engine}:${account.accountId}`;
+  round.attemptedAccounts = [...new Set([...(round.attemptedAccounts ?? []), accountKey])];
   const launched = startHeadlessReview(
     flow.id,
     round.n,
-    flow.roles.reviewer,
+    role,
     flow.cwd,
     prompt,
     undefined,
@@ -216,6 +248,31 @@ async function launchReviewer(flow: Flow, round: Round): Promise<void> {
   if (launched.pid) round.reviewerPid = launched.pid;
   if (launched.sessionId) round.sessionId = launched.sessionId;
   if (launched.reviewerPath) round.reviewerPath = launched.reviewerPath;
+}
+
+function retryHeadlessRound(flow: Flow, round: Round): void {
+  forgetHeadlessReview(flow.id, round.n, round.reviewerPid ?? null);
+  Object.assign(round, {
+    reviewerPath: null,
+    reviewerConversationId: null,
+    reviewerRole: null,
+    accountId: null,
+    sessionId: null,
+    reviewerPid: null,
+    reviewerPane: null,
+    findingsPath: null,
+    verdict: null,
+    findingsCount: null,
+    autoRetryCount: (round.autoRetryCount ?? 0) + 1,
+    startedAt: isoNow(),
+    spawnStartedAt: null,
+    relayStartedAt: null,
+    reviewedAt: null,
+    relayedAt: null,
+    error: null,
+  });
+  flow.state = "spawning";
+  flow.stateDetail = `reviewer produced no verdict; retrying automatically (${round.autoRetryCount}/${MAX_HEADLESS_NO_VERDICT_RETRIES})`;
 }
 
 async function relayFindings(flow: Flow, entriesByPath: Map<string, FileEntry>, round: Round): Promise<void> {
@@ -272,7 +329,7 @@ async function tickFlow(
   if (!round) return JSON.stringify(flow) !== before;
 
   if (flow.state === "spawning") {
-    const status = headlessReviewStatus(flow.id, round.n, round, flow.roles.reviewer.engine);
+    const status = headlessReviewStatus(flow.id, round.n, round, round.reviewerRole?.engine ?? flow.roles.reviewer.engine);
     /* A restart can land here with the round already launched (state was
        persisted before launchReviewer finished). The detached reviewer is
        still out there — adopt it instead of spawning a duplicate. */
@@ -290,8 +347,13 @@ async function tickFlow(
       persistCheckpoint();
       await launchReviewer(flow, round);
     } catch (error) {
-      round.error = error instanceof Error ? error.message : String(error);
-      markNeedsDecision(flow, round.error);
+      if (error instanceof ReviewerAccountsExhaustedError) {
+        round.error = null;
+        markNeedsDecision(flow, rateLimitStateDetail(error.resetsAt));
+      } else {
+        round.error = error instanceof Error ? error.message : String(error);
+        markNeedsDecision(flow, round.error);
+      }
     }
     return JSON.stringify(flow) !== before;
   }
@@ -303,7 +365,7 @@ async function tickFlow(
       return JSON.stringify(flow) !== before;
     }
     if (flow.reviewerMode === "headless") {
-      const status = headlessReviewStatus(flow.id, round.n, round, flow.roles.reviewer.engine);
+      const status = headlessReviewStatus(flow.id, round.n, round, round.reviewerRole?.engine ?? flow.roles.reviewer.engine);
       /* Persist the id the moment any source yields it (the JSON.stringify
          diff in tickFlow flushes it to flows.json): after that the transcript
          claim is deterministic and survives restarts. The banner parse stays
@@ -320,6 +382,8 @@ async function tickFlow(
         const parsed = parseFindings(status.finalOutput);
         if (parsed) {
           applyVerdict(flow, round, parsed);
+        } else if ((round.autoRetryCount ?? 0) < MAX_HEADLESS_NO_VERDICT_RETRIES) {
+          retryHeadlessRound(flow, round);
         } else {
           const rawPath = round.findingsPath ?? findingsPathFor(flow.id, round.n);
           atomicWriteText(rawPath, status.finalOutput || status.stdout || status.stderr);

--- a/src/lib/flows/engine.ts
+++ b/src/lib/flows/engine.ts
@@ -12,7 +12,7 @@ import { isNativeCodexSubagentTranscript } from "@/lib/scanner/codexNative";
 import { spawnAgentWithPrompt } from "@/lib/tmux";
 import type { FileEntry } from "@/lib/types";
 
-import { forgetHeadlessReview, headlessReviewStatus, startHeadlessReview } from "./exec";
+import { clearHeadlessReviewArtifacts, forgetHeadlessReview, headlessReviewStatus, startHeadlessReview } from "./exec";
 import {
   fallbackReviewFromTranscript,
   lastAssistantMessage,
@@ -266,6 +266,7 @@ async function launchReviewer(flow: Flow, round: Round, prepared: PreparedReview
 
 function retryHeadlessRound(flow: Flow, round: Round): void {
   forgetHeadlessReview(flow.id, round.n, round.reviewerPid ?? null);
+  clearHeadlessReviewArtifacts(flow.id, round.n);
   Object.assign(round, {
     reviewerPath: null,
     reviewerConversationId: null,

--- a/src/lib/flows/engine.ts
+++ b/src/lib/flows/engine.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 
 import { freshSpecFor, resumeSpecFor } from "@/lib/agent/cli";
 import { accountManager } from "@/lib/accounts/manager";
+import type { AccountContext } from "@/lib/accounts/contracts";
 import { deliverToTranscriptHost } from "@/lib/agent/transcriptHost";
 import { agentRegistry } from "@/lib/agent/registry";
 import { resolveSpawnedTranscriptPath } from "@/lib/agent/spawnedTranscript";
@@ -189,15 +190,41 @@ function applyVerdict(flow: Flow, round: Round, parsed: ParsedFindings): void {
   flow.stateDetail = null;
 }
 
-async function launchReviewer(flow: Flow, round: Round): Promise<void> {
-  const prompt = reviewerPrompt(flow, round);
-  flow.state = "reviewing";
-  flow.stateDetail = null;
+interface PreparedReviewerLaunch {
+  role: Flow["roles"]["reviewer"];
+  account: AccountContext;
+}
+
+function prepareReviewerLaunch(flow: Flow, round: Round): PreparedReviewerLaunch {
   if (flow.reviewerMode === "pane") {
     const role = flow.roles.reviewer;
     const account = accountManager.resolveSpawn(role.engine, round.accountId);
-    round.accountId ??= account.accountId;
-    round.reviewerRole = role;
+    round.accountId = account.accountId;
+    round.reviewerRole = { ...role };
+    return { role, account };
+  }
+  const decision = chooseHeadlessReviewer(
+    flow.roles.reviewer,
+    flow.reviewerFallback,
+    round.attemptedAccounts ?? [],
+    (engine, requestedId, excludedIds) => accountManager.resolveHeadlessSpawn(engine, requestedId, excludedIds),
+  );
+  if (decision.kind === "exhausted") throw new ReviewerAccountsExhaustedError(decision.resetsAt);
+  if (decision.kind === "unavailable") throw new Error("no authenticated reviewer account is available");
+  const { role, account } = decision;
+  round.reviewerRole = { ...role };
+  round.accountId = account.accountId;
+  const accountKey = `${account.engine}:${account.accountId}`;
+  round.attemptedAccounts = [...new Set([...(round.attemptedAccounts ?? []), accountKey])];
+  return { role, account };
+}
+
+async function launchReviewer(flow: Flow, round: Round, prepared: PreparedReviewerLaunch): Promise<void> {
+  const prompt = reviewerPrompt(flow, round);
+  const { role, account } = prepared;
+  flow.state = "reviewing";
+  flow.stateDetail = null;
+  if (flow.reviewerMode === "pane") {
     const spec = freshSpecFor(role.engine, flow.cwd, {
       model: role.model,
       effort: role.effort,
@@ -222,19 +249,6 @@ async function launchReviewer(flow: Flow, round: Round): Promise<void> {
     if (!round.reviewerPath && pane.panePid) round.error = null;
     return;
   }
-  const decision = chooseHeadlessReviewer(
-    flow.roles.reviewer,
-    flow.reviewerFallback,
-    round.attemptedAccounts ?? [],
-    (engine, requestedId, excludedIds) => accountManager.resolveHeadlessSpawn(engine, requestedId, excludedIds),
-  );
-  if (decision.kind === "exhausted") throw new ReviewerAccountsExhaustedError(decision.resetsAt);
-  if (decision.kind === "unavailable") throw new Error("no authenticated reviewer account is available");
-  const { role, account } = decision;
-  round.reviewerRole = { ...role };
-  round.accountId = account.accountId;
-  const accountKey = `${account.engine}:${account.accountId}`;
-  round.attemptedAccounts = [...new Set([...(round.attemptedAccounts ?? []), accountKey])];
   const launched = startHeadlessReview(
     flow.id,
     round.n,
@@ -343,9 +357,11 @@ async function tickFlow(
       return JSON.stringify(flow) !== before;
     }
     try {
+      const prepared = prepareReviewerLaunch(flow, round);
       round.spawnStartedAt = isoNow();
       persistCheckpoint();
-      await launchReviewer(flow, round);
+      await launchReviewer(flow, round, prepared);
+      persistCheckpoint();
     } catch (error) {
       if (error instanceof ReviewerAccountsExhaustedError) {
         round.error = null;

--- a/src/lib/flows/exec.test.ts
+++ b/src/lib/flows/exec.test.ts
@@ -57,6 +57,9 @@ test("headless codex reviewer launches without CLI sandbox blocking", () => {
   const built = reviewerCommand({ engine: "codex", model: null, effort: "xhigh" }, "review prompt", "/out/review.md", "/repo");
 
   expect(built.args).toContain("--dangerously-bypass-approvals-and-sandbox");
+  expect(built.args).toContain("-");
+  expect(built.args).not.toContain("review prompt");
+  expect(built.stdin).toBe("review prompt");
   expect(built.args).not.toContain("--sandbox");
   expect(built.args).not.toContain("read-only");
 });

--- a/src/lib/flows/exec.test.ts
+++ b/src/lib/flows/exec.test.ts
@@ -7,7 +7,7 @@ import path from "node:path";
 /* The state dir must point at a sandbox before store.ts computes its
    module-level constants, so exec/store load dynamically after the env set. */
 process.env.LLV_STATE_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "llv-exec-test-"));
-const { headlessReviewStatus, reviewerCommand, scanEventStream } = await import("./exec");
+const { forgetHeadlessReview, headlessReviewStatus, reviewerCommand, scanEventStream, startHeadlessReview } = await import("./exec");
 const { reviewerPrompt } = await import("./prompts");
 const { outputPathFor, stdoutPathFor } = await import("./store");
 
@@ -47,6 +47,14 @@ async function waitForDeath(pid: number): Promise<void> {
   throw new Error(`pid ${pid} refused to die`);
 }
 
+async function waitForFile(filePath: string): Promise<void> {
+  for (let i = 0; i < 200; i++) {
+    if (fs.existsSync(filePath)) return;
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  throw new Error(`file ${filePath} was not created`);
+}
+
 test("scanEventStream extracts session id and last agent message", () => {
   const scanned = scanEventStream(EVENTS);
   expect(scanned.sessionId).toBe("11111111-2222-3333-4444-555555555555");
@@ -62,6 +70,33 @@ test("headless codex reviewer launches without CLI sandbox blocking", () => {
   expect(built.stdin).toBe("review prompt");
   expect(built.args).not.toContain("--sandbox");
   expect(built.args).not.toContain("read-only");
+});
+
+test("headless Codex launch flushes the complete prompt and closes stdin", async () => {
+  const capturePath = path.join(process.env.LLV_STATE_DIR!, "stdin-capture.json");
+  const executablePath = path.join(process.env.LLV_STATE_DIR!, "fake-codex");
+  const prompt = "Review line one.\nReview line two with unicode: Привіт.\n";
+  fs.writeFileSync(
+    executablePath,
+    `#!${process.execPath}\nconst prompt = await Bun.stdin.text();\nawait Bun.write(${JSON.stringify(capturePath)}, JSON.stringify({ prompt, eof: true }));\n`,
+    { mode: 0o700 },
+  );
+
+  startHeadlessReview(
+    "flow-stdin-eof",
+    1,
+    { engine: "codex", model: null, effort: null },
+    process.cwd(),
+    prompt,
+    5_000,
+    null,
+    null,
+    { command: executablePath },
+  );
+  await waitForFile(capturePath);
+
+  expect(JSON.parse(fs.readFileSync(capturePath, "utf8"))).toEqual({ prompt, eof: true });
+  forgetHeadlessReview("flow-stdin-eof", 1);
 });
 
 test("headless managed Codex reviewer fixes its account home and file credential store at launch", () => {

--- a/src/lib/flows/exec.ts
+++ b/src/lib/flows/exec.ts
@@ -145,7 +145,7 @@ export function reviewerCommand(
   cwd: string,
   codexAccount?: HeadlessCodexAccount | null,
   claudeAccount?: HeadlessClaudeAccount | null,
-): { command: string; args: string[]; env: NodeJS.ProcessEnv; outputPath: string | null; sessionId: string | null; reviewerPath: string | null } {
+): { command: string; args: string[]; env: NodeJS.ProcessEnv; stdin: string | null; outputPath: string | null; sessionId: string | null; reviewerPath: string | null } {
   if (role.engine === "claude") {
     const sessionId = crypto.randomUUID();
     /* Headless reviewers need approval-free command access for tests, builds,
@@ -161,12 +161,12 @@ export function reviewerCommand(
     if (role.effort) args.push("--effort", role.effort);
     const settings = claudeAccount?.managed ? claudeSettingsPath() : null;
     if (settings) args.push("--settings", settings);
-    return { command: resolveBinary("claude"), args, env: claudeAccount?.managed ? claudeManagedEnvironment(claudeAccount.home) : process.env, outputPath: null, sessionId, reviewerPath: claudeTranscriptPath(cwd, sessionId, claudeAccount?.projectsDir) };
+    return { command: resolveBinary("claude"), args, env: claudeAccount?.managed ? claudeManagedEnvironment(claudeAccount.home) : process.env, stdin: null, outputPath: null, sessionId, reviewerPath: claudeTranscriptPath(cwd, sessionId, claudeAccount?.projectsDir) };
   }
   /* --json turns stdout into a JSONL event stream whose first events carry
      the session/thread id — a structured contract instead of parsing the
      human banner. The verdict itself still arrives via --output-last-message. */
-  const args = ["exec", prompt, "--json", "--output-last-message", outputPath, "--dangerously-bypass-approvals-and-sandbox"];
+  const args = ["exec", "-", "--json", "--output-last-message", outputPath, "--dangerously-bypass-approvals-and-sandbox"];
   if (codexAccount?.managed) args.unshift("-c", "cli_auth_credentials_store=file");
   if (role.model) args.push("-m", role.model);
   if (role.effort) args.push("-c", `model_reasoning_effort=${role.effort}`);
@@ -174,6 +174,7 @@ export function reviewerCommand(
     command: resolveBinary("codex"),
     args,
     env: codexAccount?.home ? { ...process.env, CODEX_HOME: codexAccount.home } : process.env,
+    stdin: prompt,
     outputPath,
     sessionId: null,
     reviewerPath: null,
@@ -194,6 +195,7 @@ export function startHeadlessReview(
   if (runs.has(key)) return { pid: null, sessionId: null, reviewerPath: null };
   const outputPath = outputPathFor(flowId, round);
   fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+  fs.rmSync(outputPath, { force: true });
   const built = reviewerCommand(role, prompt, outputPath, cwd, codexAccount, claudeAccount);
   /* Detached + file-backed stdio: the reviewer must not die with the viewer.
      A plain child shares the dev server's process group, so Ctrl+C on the
@@ -207,8 +209,12 @@ export function startHeadlessReview(
       cwd,
       env: built.env,
       detached: true,
-      stdio: ["ignore", stdoutFd, stderrFd],
+      stdio: [built.stdin === null ? "ignore" : "pipe", stdoutFd, stderrFd],
     });
+    if (built.stdin !== null && child.stdin) {
+      child.stdin.on("error", () => {});
+      child.stdin.end(built.stdin, "utf8");
+    }
   } finally {
     fs.closeSync(stdoutFd);
     fs.closeSync(stderrFd);

--- a/src/lib/flows/exec.ts
+++ b/src/lib/flows/exec.ts
@@ -197,7 +197,7 @@ export function startHeadlessReview(
   if (runs.has(key)) return { pid: null, sessionId: null, reviewerPath: null };
   const outputPath = outputPathFor(flowId, round);
   fs.mkdirSync(path.dirname(outputPath), { recursive: true });
-  fs.rmSync(outputPath, { force: true });
+  clearHeadlessReviewArtifacts(flowId, round);
   const built = reviewerCommand(role, prompt, outputPath, cwd, codexAccount, claudeAccount);
   /* Detached + file-backed stdio: the reviewer must not die with the viewer.
      A plain child shares the dev server's process group, so Ctrl+C on the
@@ -241,6 +241,13 @@ export function startHeadlessReview(
     run.exit = { code, signal };
   });
   return { pid: child.pid ?? null, sessionId: built.sessionId, reviewerPath: built.reviewerPath };
+}
+
+/** Removes attempt-scoped process output before a logical round is relaunched. */
+export function clearHeadlessReviewArtifacts(flowId: string, round: number): void {
+  for (const artifact of [outputPathFor(flowId, round), stdoutPathFor(flowId, round), stderrPathFor(flowId, round)]) {
+    fs.rmSync(artifact, { force: true });
+  }
 }
 
 function readOptional(filePath: string | null): string {

--- a/src/lib/flows/exec.ts
+++ b/src/lib/flows/exec.ts
@@ -34,6 +34,7 @@ export interface HeadlessCodexAccount {
   managed: boolean;
 }
 export interface HeadlessClaudeAccount { home: string; projectsDir: string; managed: boolean; }
+export interface HeadlessReviewRuntime { command?: string; }
 
 /* The reviewer runs detached with file-backed stdio, so it survives a viewer
    restart. This in-memory record only adds what disk cannot know: the exact
@@ -190,6 +191,7 @@ export function startHeadlessReview(
   timeoutMs = DEFAULT_TIMEOUT_MS,
   codexAccount?: HeadlessCodexAccount | null,
   claudeAccount?: HeadlessClaudeAccount | null,
+  runtime?: HeadlessReviewRuntime,
 ): HeadlessReviewLaunch {
   const key = runKey(flowId, round);
   if (runs.has(key)) return { pid: null, sessionId: null, reviewerPath: null };
@@ -205,7 +207,7 @@ export function startHeadlessReview(
   const stderrFd = fs.openSync(stderrPathFor(flowId, round), "w");
   let child: ChildProcess;
   try {
-    child = spawn(built.command, built.args, {
+    child = spawn(runtime?.command ?? built.command, built.args, {
       cwd,
       env: built.env,
       detached: true,

--- a/src/lib/flows/reviewerPolicy.test.ts
+++ b/src/lib/flows/reviewerPolicy.test.ts
@@ -1,0 +1,40 @@
+import { expect, test } from "bun:test";
+
+import type { AccountContext, HeadlessSpawnAvailability } from "@/lib/accounts/contracts";
+
+import { chooseHeadlessReviewer, rateLimitStateDetail } from "./reviewerPolicy";
+import type { RoleConfig } from "./types";
+
+const codex: RoleConfig = { engine: "codex", model: "gpt-5.6-sol", effort: "xhigh" };
+const fable: RoleConfig = { engine: "claude", model: "fable", effort: "high" };
+
+function account(engine: "claude" | "codex", accountId: string): AccountContext {
+  return { engine, accountId, kind: "managed", home: `/accounts/${accountId}`, transcriptRoot: `/accounts/${accountId}/sessions`, env: { NODE_ENV: "test" } };
+}
+
+test("headless reviewer falls back to the configured Fable role when Codex accounts are exhausted", () => {
+  const resolve = (engine: "claude" | "codex"): HeadlessSpawnAvailability => engine === "codex"
+    ? { kind: "exhausted", resetsAt: 1_800 }
+    : { kind: "available", account: account("claude", "fable-main") };
+
+  expect(chooseHeadlessReviewer(codex, fable, [], resolve)).toEqual({
+    kind: "available",
+    role: fable,
+    account: account("claude", "fable-main"),
+  });
+});
+
+test("headless reviewer reports the earliest reset when primary and fallback accounts are exhausted", () => {
+  const resolve = (engine: "claude" | "codex"): HeadlessSpawnAvailability => ({
+    kind: "exhausted",
+    resetsAt: engine === "codex" ? 1_800 : 900,
+  });
+
+  expect(chooseHeadlessReviewer(codex, fable, [], resolve)).toEqual({ kind: "exhausted", resetsAt: 900 });
+  expect(rateLimitStateDetail(900)).toBe("reviewer rate limited; all accounts exhausted; resetsAt=1970-01-01T00:15:00.000Z");
+});
+
+test("headless reviewer keeps missing authentication distinct from quota exhaustion", () => {
+  const resolve = (): HeadlessSpawnAvailability => ({ kind: "unavailable" });
+  expect(chooseHeadlessReviewer(codex, fable, [], resolve)).toEqual({ kind: "unavailable" });
+});

--- a/src/lib/flows/reviewerPolicy.test.ts
+++ b/src/lib/flows/reviewerPolicy.test.ts
@@ -24,6 +24,18 @@ test("headless reviewer falls back to the configured Fable role when Codex accou
   });
 });
 
+test("headless retry chooses Fable before reusing its only failed Codex account", () => {
+  const resolve = (engine: "claude" | "codex"): HeadlessSpawnAvailability => engine === "codex"
+    ? { kind: "available", account: account("codex", "default") }
+    : { kind: "available", account: account("claude", "fable-main") };
+
+  expect(chooseHeadlessReviewer(codex, fable, ["codex:default"], resolve)).toEqual({
+    kind: "available",
+    role: fable,
+    account: account("claude", "fable-main"),
+  });
+});
+
 test("headless reviewer reports the earliest reset when primary and fallback accounts are exhausted", () => {
   const resolve = (engine: "claude" | "codex"): HeadlessSpawnAvailability => ({
     kind: "exhausted",

--- a/src/lib/flows/reviewerPolicy.ts
+++ b/src/lib/flows/reviewerPolicy.ts
@@ -1,0 +1,43 @@
+import type { AccountContext, HeadlessSpawnAvailability } from "@/lib/accounts/contracts";
+
+import type { RoleConfig } from "./types";
+
+export type HeadlessReviewerDecision =
+  | { kind: "available"; role: RoleConfig; account: AccountContext }
+  | { kind: "exhausted"; resetsAt: number | null }
+  | { kind: "unavailable" };
+
+type AvailabilityResolver = (
+  engine: RoleConfig["engine"],
+  requestedId?: string | null,
+  excludedIds?: string[],
+) => HeadlessSpawnAvailability;
+
+/** Chooses the primary reviewer when capacity exists, then its configured fallback. */
+export function chooseHeadlessReviewer(
+  primary: RoleConfig,
+  fallback: RoleConfig | null | undefined,
+  attemptedAccounts: string[],
+  resolve: AvailabilityResolver,
+): HeadlessReviewerDecision {
+  const roles = [primary, ...(fallback && fallback.engine !== primary.engine ? [fallback] : [])];
+  const exhaustedResets: number[] = [];
+  let exhausted = 0;
+  for (const role of roles) {
+    const prefix = `${role.engine}:`;
+    const excludedIds = attemptedAccounts.filter((key) => key.startsWith(prefix)).map((key) => key.slice(prefix.length));
+    const availability = resolve(role.engine, null, excludedIds);
+    if (availability.kind === "available") return { kind: "available", role, account: availability.account };
+    if (availability.kind === "exhausted") {
+      exhausted += 1;
+      if (availability.resetsAt !== null) exhaustedResets.push(availability.resetsAt);
+    }
+  }
+  if (exhausted !== roles.length) return { kind: "unavailable" };
+  return { kind: "exhausted", resetsAt: exhaustedResets.length ? Math.min(...exhaustedResets) : null };
+}
+
+export function rateLimitStateDetail(resetsAt: number | null): string {
+  const reset = resetsAt === null ? "unknown" : new Date(resetsAt * 1_000).toISOString();
+  return `reviewer rate limited; all accounts exhausted; resetsAt=${reset}`;
+}

--- a/src/lib/flows/reviewerPolicy.ts
+++ b/src/lib/flows/reviewerPolicy.ts
@@ -22,17 +22,24 @@ export function chooseHeadlessReviewer(
 ): HeadlessReviewerDecision {
   const roles = [primary, ...(fallback && fallback.engine !== primary.engine ? [fallback] : [])];
   const exhaustedResets: number[] = [];
+  let attemptedChoice: Extract<HeadlessReviewerDecision, { kind: "available" }> | null = null;
   let exhausted = 0;
   for (const role of roles) {
     const prefix = `${role.engine}:`;
     const excludedIds = attemptedAccounts.filter((key) => key.startsWith(prefix)).map((key) => key.slice(prefix.length));
     const availability = resolve(role.engine, null, excludedIds);
-    if (availability.kind === "available") return { kind: "available", role, account: availability.account };
+    if (availability.kind === "available") {
+      const choice = { kind: "available" as const, role, account: availability.account };
+      if (!attemptedAccounts.includes(`${availability.account.engine}:${availability.account.accountId}`)) return choice;
+      attemptedChoice ??= choice;
+      continue;
+    }
     if (availability.kind === "exhausted") {
       exhausted += 1;
       if (availability.resetsAt !== null) exhaustedResets.push(availability.resetsAt);
     }
   }
+  if (attemptedChoice) return attemptedChoice;
   if (exhausted !== roles.length) return { kind: "unavailable" };
   return { kind: "exhausted", resetsAt: exhaustedResets.length ? Math.min(...exhaustedResets) : null };
 }

--- a/src/lib/flows/store.test.ts
+++ b/src/lib/flows/store.test.ts
@@ -6,7 +6,7 @@ import path from "node:path";
 import { AgentRegistry } from "@/lib/agent/registry";
 import { CODEX_SOL_MODEL, CODEX_TERRA_MODEL } from "@/lib/agent/models";
 
-import { FLOWS_SCHEMA_VERSION, loadFlows, mergeSeededPresets, reconcileFlowConversationOwnership, saveFlows, seededPresetsFromRoles } from "./store";
+import { configuredReviewerFallback, FLOWS_SCHEMA_VERSION, loadFlows, mergeSeededPresets, reconcileFlowConversationOwnership, saveFlows, seededPresetsFromRoles } from "./store";
 import type { Flow, FlowPreset } from "./types";
 
 const LEGACY_DEFAULT: FlowPreset = {
@@ -118,7 +118,12 @@ test("flow specs persist in the versioned state file and legacy flow entries loa
     });
 
     fs.writeFileSync(path.join(sandbox, "flows.json"), JSON.stringify({ flows: [flow] }));
-    expect(loadFlows()).toEqual([{ ...flow, implementerConversationId: null, pausedState: null }]);
+    expect(loadFlows()).toEqual([{
+      ...flow,
+      implementerConversationId: null,
+      reviewerFallback: configuredReviewerFallback(),
+      pausedState: null,
+    }]);
   } finally {
     if (previousState === undefined) delete process.env.LLV_STATE_DIR;
     else process.env.LLV_STATE_DIR = previousState;

--- a/src/lib/flows/store.ts
+++ b/src/lib/flows/store.ts
@@ -84,10 +84,15 @@ export function seededPresetsFromRoles(): FlowPreset[] {
   return presets.map((preset) => ({ ...preset, managed: "role-registry" }));
 }
 
+/** The role-registry-backed fallback captured into new and legacy Codex flows. */
+export function configuredReviewerFallback(): FlowPreset["reviewer"] {
+  return flowRole(loadRoleDefinitionsOrDefaults(), "architect");
+}
+
 /** Compatibility export for consumers that render the initial seed list. */
 export const SEEDED_PRESETS: FlowPreset[] = seededPresetsFromRoles();
 
-export const FLOWS_SCHEMA_VERSION = 2;
+export const FLOWS_SCHEMA_VERSION = 3;
 
 type FlowFile = { schemaVersion?: unknown; flows?: unknown };
 type PresetFile = { presets?: unknown };
@@ -166,10 +171,16 @@ export function loadFlows(): Flow[] {
   return flows.map((flow) => ({
     ...flow,
     implementerConversationId: flow.implementerConversationId ?? null,
+    reviewerFallback: flow.reviewerFallback === undefined && flow.roles.reviewer.engine === "codex"
+      ? configuredReviewerFallback()
+      : flow.reviewerFallback ?? null,
     pausedState: flow.pausedState ?? null,
     rounds: flow.rounds.map((round) => ({
       ...round,
       reviewerConversationId: round.reviewerConversationId ?? null,
+      reviewerRole: round.reviewerRole ?? null,
+      attemptedAccounts: round.attemptedAccounts ?? [],
+      autoRetryCount: round.autoRetryCount ?? 0,
       sessionId: round.sessionId ?? null,
       reviewerPid: round.reviewerPid ?? null,
       spawnStartedAt: round.spawnStartedAt ?? null,

--- a/src/lib/flows/types.ts
+++ b/src/lib/flows/types.ts
@@ -46,6 +46,13 @@ export type Round = {
   /** Engine account frozen when this round starts; subsequent polling and retry
       must never silently adopt a newly selected active account. */
   accountId?: string | null;
+  /** Effective role for this attempt. A Codex-configured flow may persist its
+      configured Claude fallback here when every Codex account is exhausted. */
+  reviewerRole?: RoleConfig | null;
+  /** Engine-qualified accounts already tried for this logical round. */
+  attemptedAccounts?: string[];
+  /** Automatic no-verdict retries already consumed by this logical round. */
+  autoRetryCount?: number;
   /** Reviewer session/thread id, persisted as soon as it is known: claude
       pre-chooses it at spawn, codex reports it in the first `--json` event.
       Survives viewer restarts so the transcript claim stays deterministic. */
@@ -80,6 +87,8 @@ export type Flow = {
   implementerPath: string; // transcript path of the attached session
   implementerConversationId?: string | null;
   roles: Record<FlowRoleKey, RoleConfig>;
+  /** Configured cross-engine fallback for unattended reviewer launches. */
+  reviewerFallback?: RoleConfig | null;
   baseRef: string; // resolved git SHA captured at creation
   /** Pinned task specification and acceptance criteria shown to every reviewer. */
   spec?: string;


### PR DESCRIPTION
## Summary

- Deliver Codex reviewer prompts through a stdin pipe with an explicit EOF, keeping large prompts out of argv and guaranteeing stream closure.
- Select authenticated accounts from fresh quota observations, prefer maximum headroom, and route exhausted Codex launches through the configured Fable fallback.
- Retry one no-verdict reviewer exit automatically within the logical round, preferring an untried account for the retry.
- Park confirmed cross-engine exhaustion with a dedicated rate-limit detail containing `resetsAt`.

## Root cause

Headless reviewer launches used account routing without quota awareness. A 100% session account could therefore receive concurrent `codex exec` runs, whose observed failure mode was an indefinite stdin wait and an empty verdict artifact. The engine treated that empty exit as a terminal decision request, creating repeated manual retry-round work.

## Prompt delivery choice

`codex exec -` reads the prompt from stdin. `child.stdin.end(prompt)` queues the complete payload and closes the stream after the write flushes. This avoids argv length limits and process-list prompt exposure while preserving detached execution after EOF.

## Verification

- `bun test` — 1,539 passed
- `bunx tsc --noEmit`

Closes #117