### PR TITLE
Fix context-window usage and refresh memory snapshots

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -1,24 +1,20 @@
-# Issues 31 and 113: deterministic agent reaping and verified tmux kills
+# Issue #22: provenance-aware context windows and current memory snapshots
 
 ## Task statement
 
-Implement deterministic lifecycle cleanup for stale agent conversations and a reliable conversation-kill primitive. Resolve kills through registry-owned tmux pane identities, verify termination of the pane shell and recorded agent processes, apply policy TTLs to eligible automated conversations, protect active or user-managed conversations, schedule cleanup through the durable controller, journal active attempts, and expose a dry-run lifecycle report.
+Resolve context capacity from in-band runtime metadata or a versioned exact-model registry, preserve raw usage when capacity is unknown, expose provenance in the shared context chip, and keep RAM/swap snapshots current and timestamped.
 
 ## Acceptance criteria
 
-- AC1: Conversation kills resolve the target from registry-owned pane IDs and return a clear error when the target cannot be resolved.
-- AC2: A successful kill carries the original complete tmux evidence through both re-observations and requires exact endpoint, server identity, pane identity, window name, agent identity, argv, and transcript path equality through actuation and post-kill registry cleanup.
-- AC3: Reaper classification covers flow workers, headless reviewers, Viewer-launched probes, resume duplicates, and agents whose transcripts are missing, using the policy TTL assigned to each class.
-- AC4: Automatic cleanup durably remembers positive human authorship, discounts path-bound Viewer deliveries and known Claude system task notifications, protects unverifiable live transcripts, and allows unknown missing transcripts to age through the explicit dead-transcript TTL.
-- AC5: Reaper evaluation runs through the durable controller and journals active reap attempts.
-- AC6: `GET /api/lifecycle/reaper` exposes the dry-run report without actuating cleanup.
-- AC7: Automatic reap actuation requires `LLV_REAPER_ENABLED=1`.
-- AC8: Focused tests cover pane and detached-process kill resolution, process-death verification, classification, protection rules, scheduling, journaling, and the lifecycle API.
-- AC9: `bun test` and `bunx tsc --noEmit` pass.
-- AC10: Flow cleanup captures and checkpoints the clean commit SHA immediately before reviewer launch, binds merge evidence to that immutable SHA, fails closed for dirty, changed, detached, remote-less, or otherwise unverifiable live checkouts, and preserves verified evidence after checkout deletion.
-- AC11: One candidate actuation failure is journaled and leaves later eligible candidates available for the same sweep.
-- AC12: Conversation kill acquires the per-session operation lock, refreshes registry host evidence inside the lock, and marks the entry unhosted only when artifact path and complete endpoint/server/pane/window/agent/argv evidence remain unchanged after termination.
-- AC13: GitHub merge probes run asynchronously with a per-probe timeout and bounded concurrency so a stalled lookup cannot freeze the Viewer or delay independent flows indefinitely.
-- AC14: Merge-probe results update only merge evidence in a freshly loaded flow store and are discarded when the flow transition revision changed during the probe.
-- AC15: Reap actuation refreshes scanner lifecycle signals and registry turn state inside the session lock after asynchronous probes, then rejects busy, questioning, waiting, or delivery-revised candidates immediately before actuation.
-- AC16: Reviewer verdicts and terminal errors persist a terminal timestamp; legacy errored rounds use their latest durable activity timestamp for the headless-reviewer TTL.
+- AC1: Codex uses `token_count.info.model_context_window` as exact runtime capacity; records without that field preserve the prior hidden-chip behavior.
+- AC2: Claude model aliases normalize provider prefixes, dates, Bedrock versions, Vertex versions, and explicit `[1m]` mode before exact registry lookup.
+- AC3: The bundled registry is versioned `2026-07-10`; unknown and future model keys stay unresolved.
+- AC4: Every visible context result carries `source`, `confidence`, `observedAt`, and registry-derived results carry `registryVersion`.
+- AC5: Runtime percentages may reach 100; registry percentages cap at 99; registry overflow demotes to unknown capacity with raw usage retained.
+- AC6: Unknown capacity renders `ctx <used>` with a neutral tone, no denominator, withheld percentage copy, and stays hidden in mobile pane headers.
+- AC7: Known tooltips show the actual window and its runtime or registry provenance; registry tooltips disclose the registry version.
+- AC8: Capacity resolves from the same transcript record as usage, so model changes and post-compaction usage select the current record.
+- AC9: Context scanning remains synchronous and performs no provider/network polling.
+- AC10: RAM uses `MemAvailable`, swap uses `SwapTotal - SwapFree`, host memory is captured on every resources request, and the sidebar labels capture age.
+- AC11: Regression tests cover provenance math, registry overflow, exact aliases, future ids, Codex suppression, compaction/model change, and known/unknown chip rendering.
+- AC12: `bun test`, `bunx tsc --noEmit`, and `git diff --check` pass before push.

--- a/src/components/BranchPane.tsx
+++ b/src/components/BranchPane.tsx
@@ -237,7 +237,7 @@ export function BranchPane({ file, tasks, isRoot, onClose, dragHandle, noCompose
             {/* The phone header keeps only actionable or alarming chips: ctx
                 appears once it nears the limit, the worktree name and the
                 branch-kind label yield their room to the rest of the row. */}
-            {file.ctx && (!isMobile || file.ctx.pct === null || file.ctx.pct >= 70) ? <CtxChip ctx={file.ctx} /> : null}
+            {file.ctx && (!isMobile || (file.ctx.pct !== null && file.ctx.pct >= 70)) ? <CtxChip ctx={file.ctx} /> : null}
             {file.worktree && !isMobile ? (
               <span
                 className="inline-flex shrink-0 items-center gap-0.5 rounded-full border border-line/80 px-1.5 py-0.5 font-mono text-[9.5px] text-dim"

--- a/src/components/BranchPane.tsx
+++ b/src/components/BranchPane.tsx
@@ -237,7 +237,7 @@ export function BranchPane({ file, tasks, isRoot, onClose, dragHandle, noCompose
             {/* The phone header keeps only actionable or alarming chips: ctx
                 appears once it nears the limit, the worktree name and the
                 branch-kind label yield their room to the rest of the row. */}
-            {file.ctx && (!isMobile || file.ctx.pct >= 70) ? <CtxChip ctx={file.ctx} /> : null}
+            {file.ctx && (!isMobile || file.ctx.pct === null || file.ctx.pct >= 70) ? <CtxChip ctx={file.ctx} /> : null}
             {file.worktree && !isMobile ? (
               <span
                 className="inline-flex shrink-0 items-center gap-0.5 rounded-full border border-line/80 px-1.5 py-0.5 font-mono text-[9.5px] text-dim"

--- a/src/components/PlanChip.render.test.tsx
+++ b/src/components/PlanChip.render.test.tsx
@@ -1,0 +1,29 @@
+import { expect, test } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import type { CtxUsage } from "@/lib/types";
+import { CtxChip } from "./PlanChip";
+
+const observedAt = "2026-07-12T10:00:00.000Z";
+
+test("known registry context shows its denominator and registry provenance", () => {
+  const ctx: CtxUsage = {
+    usedTokens: 176_000, windowTokens: 200_000, pct: 88, source: "registry",
+    confidence: "approximate", registryVersion: "2026-07-10", observedAt,
+  };
+  const html = renderToStaticMarkup(<CtxChip ctx={ctx} />);
+  expect(html).toContain("ctx 176K");
+  expect(html).toContain("200K");
+  expect(html).toContain("bundled model registry (2026-07-10) — approximate");
+});
+
+test("unknown context renders raw tokens with no denominator", () => {
+  const ctx: CtxUsage = {
+    usedTokens: 176_000, windowTokens: null, pct: null, source: "unknown",
+    confidence: "unknown", observedAt,
+  };
+  const html = renderToStaticMarkup(<CtxChip ctx={ctx} />);
+  expect(html).toContain(">ctx 176K<");
+  expect(html).not.toContain("176K<!-- -->/<");
+  expect(html).toContain("percentage withheld");
+});

--- a/src/components/PlanChip.tsx
+++ b/src/components/PlanChip.tsx
@@ -53,7 +53,8 @@ function goalTooltip(goal: AgentGoal): string {
 }
 
 /* Same escalation points as the sidebar limit bars: calm, then amber, then red. */
-function ctxTone(pct: number): string {
+function ctxTone(pct: number | null): string {
+  if (pct === null) return "bg-chip text-dim";
   if (pct >= 90) return "bg-[#fbeaea] text-err";
   if (pct >= 70) return "bg-[#fff7e6] text-[#b07d18]";
   return "bg-chip text-dim";
@@ -75,15 +76,21 @@ function fmtTokens(n: number): string {
     tooltip. Rendered wherever the agent is shown (pane header, switch cards). */
 export function CtxChip({ ctx }: { ctx: CtxUsage }) {
   const { t } = useLocale();
+  const used = ctx.usedTokens.toLocaleString(bcp47());
+  const known = ctx.windowTokens !== null && ctx.pct !== null;
+  const title = known
+    ? t("plan.ctxTitle", { pct: ctx.pct!, used, window: ctx.windowTokens!.toLocaleString(bcp47()) })
+    : t("plan.ctxUnknownTitle", { used });
+  const ariaLabel = known ? t("plan.ctxAria", { pct: ctx.pct! }) : t("plan.ctxUnknownAria", { used });
   return (
     <span
       className={`inline-flex shrink-0 items-center gap-0.5 rounded-full px-1.5 py-0.5 font-mono text-[9.5px] font-semibold ${ctxTone(ctx.pct)}`}
-      title={t("plan.ctxTitle", { pct: ctx.pct, used: ctx.usedTokens.toLocaleString(bcp47()), window: ctx.windowTokens.toLocaleString(bcp47()) })}
-      aria-label={t("plan.ctxAria", { pct: ctx.pct })}
+      title={title}
+      aria-label={ariaLabel}
     >
       ctx {fmtTokens(ctx.usedTokens)}
       <span className="opacity-50">/</span>
-      {fmtTokens(ctx.windowTokens)}
+      {ctx.windowTokens === null ? "?" : fmtTokens(ctx.windowTokens)}
     </span>
   );
 }

--- a/src/components/PlanChip.tsx
+++ b/src/components/PlanChip.tsx
@@ -77,11 +77,18 @@ function fmtTokens(n: number): string {
 export function CtxChip({ ctx }: { ctx: CtxUsage }) {
   const { t } = useLocale();
   const used = ctx.usedTokens.toLocaleString(bcp47());
-  const known = ctx.windowTokens !== null && ctx.pct !== null;
-  const title = known
-    ? t("plan.ctxTitle", { pct: ctx.pct!, used, window: ctx.windowTokens!.toLocaleString(bcp47()) })
-    : t("plan.ctxUnknownTitle", { used });
-  const ariaLabel = known ? t("plan.ctxAria", { pct: ctx.pct! }) : t("plan.ctxUnknownAria", { used });
+  let title: string;
+  let ariaLabel: string;
+  if (ctx.windowTokens !== null && ctx.pct !== null) {
+    const source = ctx.source === "registry"
+      ? t("plan.ctxSourceRegistry", { version: ctx.registryVersion ?? "?" })
+      : t("plan.ctxSourceRuntime");
+    title = `${t("plan.ctxTitle", { pct: ctx.pct, used, window: ctx.windowTokens.toLocaleString(bcp47()) })}\n${source}`;
+    ariaLabel = t("plan.ctxAria", { pct: ctx.pct });
+  } else {
+    title = t("plan.ctxTitleUnknown", { used });
+    ariaLabel = t("plan.ctxAriaUnknown", { used });
+  }
   return (
     <span
       className={`inline-flex shrink-0 items-center gap-0.5 rounded-full px-1.5 py-0.5 font-mono text-[9.5px] font-semibold ${ctxTone(ctx.pct)}`}
@@ -89,8 +96,12 @@ export function CtxChip({ ctx }: { ctx: CtxUsage }) {
       aria-label={ariaLabel}
     >
       ctx {fmtTokens(ctx.usedTokens)}
-      <span className="opacity-50">/</span>
-      {ctx.windowTokens === null ? "?" : fmtTokens(ctx.windowTokens)}
+      {ctx.windowTokens === null ? null : (
+        <>
+          <span className="opacity-50">/</span>
+          {fmtTokens(ctx.windowTokens)}
+        </>
+      )}
     </span>
   );
 }

--- a/src/components/ResourcesFooter.tsx
+++ b/src/components/ResourcesFooter.tsx
@@ -159,6 +159,9 @@ export function ResourcesFooter() {
                 note={t("resources.used", { amount: fmtBytes(system.swapUsed) })}
               />
             ) : null}
+            <span className="mt-1.5 block text-right text-[9.5px] tabular-nums text-dim">
+              {t("resources.captured", { age: fmtAge(Date.parse(system.capturedAt) / 1000) })}
+            </span>
           </>
         ) : (
           <span className="text-[11px] font-semibold text-ink">{t("resources.title")}</span>

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -865,9 +865,11 @@ export const en = {
   "plan.tokens": "tokens: {n}",
   "plan.time": "time: {n} min",
   "plan.ctxTitle": "Context window: {pct}% used\n{used} of {window} tokens",
+  "plan.ctxSourceRuntime": "Window reported by the agent runtime",
+  "plan.ctxSourceRegistry": "Window from the bundled model registry ({version}) — approximate",
+  "plan.ctxTitleUnknown": "Context usage: {used} tokens\nWindow unknown for this model — percentage withheld",
   "plan.ctxAria": "Context: {pct} percent of the window used",
-  "plan.ctxUnknownTitle": "Context window: unknown\n{used} tokens used",
-  "plan.ctxUnknownAria": "Context: {used} tokens used; window unknown",
+  "plan.ctxAriaUnknown": "Context: {used} tokens used, window size unknown",
   "plan.goalAria": "Session goal: {status}",
 
   // LimitsFooter

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -866,6 +866,8 @@ export const en = {
   "plan.time": "time: {n} min",
   "plan.ctxTitle": "Context window: {pct}% used\n{used} of {window} tokens",
   "plan.ctxAria": "Context: {pct} percent of the window used",
+  "plan.ctxUnknownTitle": "Context window: unknown\n{used} tokens used",
+  "plan.ctxUnknownAria": "Context: {used} tokens used; window unknown",
   "plan.goalAria": "Session goal: {status}",
 
   // LimitsFooter
@@ -888,6 +890,7 @@ export const en = {
   "resources.free": "{amount} free",
   "resources.used": "{amount} used",
   "resources.stale": "resource data is stale: {stale}",
+  "resources.captured": "captured {age}",
   "resources.openAria": "Agent sessions and memory",
   "resources.title": "Agent sessions",
   "resources.total": "Σ {amount}",

--- a/src/lib/i18n/uk.ts
+++ b/src/lib/i18n/uk.ts
@@ -833,9 +833,11 @@ export const uk: Record<keyof typeof en, Message> = {
   "plan.tokens": "токенів: {n}",
   "plan.time": "часу: {n} хв",
   "plan.ctxTitle": "Контекстне вікно: використано {pct}%\n{used} з {window} токенів",
+  "plan.ctxSourceRuntime": "Розмір вікна повідомлений середовищем агента",
+  "plan.ctxSourceRegistry": "Розмір вікна з вбудованого реєстру моделей ({version}) — приблизно",
+  "plan.ctxTitleUnknown": "Використання контексту: {used} токенів\nРозмір вікна для цієї моделі невідомий — відсоток не показується",
   "plan.ctxAria": "Контекст: використано {pct} відсотків вікна",
-  "plan.ctxUnknownTitle": "Контекстне вікно: невідоме\nВикористано {used} токенів",
-  "plan.ctxUnknownAria": "Контекст: використано {used} токенів; розмір вікна невідомий",
+  "plan.ctxAriaUnknown": "Контекст: використано {used} токенів, розмір вікна невідомий",
   "plan.goalAria": "Ціль сесії: {status}",
 
   "limits.now": "зараз",

--- a/src/lib/i18n/uk.ts
+++ b/src/lib/i18n/uk.ts
@@ -834,6 +834,8 @@ export const uk: Record<keyof typeof en, Message> = {
   "plan.time": "часу: {n} хв",
   "plan.ctxTitle": "Контекстне вікно: використано {pct}%\n{used} з {window} токенів",
   "plan.ctxAria": "Контекст: використано {pct} відсотків вікна",
+  "plan.ctxUnknownTitle": "Контекстне вікно: невідоме\nВикористано {used} токенів",
+  "plan.ctxUnknownAria": "Контекст: використано {used} токенів; розмір вікна невідомий",
   "plan.goalAria": "Ціль сесії: {status}",
 
   "limits.now": "зараз",
@@ -855,6 +857,7 @@ export const uk: Record<keyof typeof en, Message> = {
   "resources.free": "{amount} вільно",
   "resources.used": "{amount} зайнято",
   "resources.stale": "дані про ресурси застарілі: {stale}",
+  "resources.captured": "знято {age}",
   "resources.openAria": "Сесії агентів і пам'ять",
   "resources.title": "Сесії агентів",
   "resources.total": "Σ {amount}",

--- a/src/lib/resources.ts
+++ b/src/lib/resources.ts
@@ -17,6 +17,11 @@ import type { FileEntry, ResourceSession, ResourcesPayload } from "./types";
 
 const CACHE_MS = 10_000;
 
+function captureSystemMemory(): ResourcesPayload["system"] {
+  const system = procBackend.systemMemory();
+  return system ? { ...system, capturedAt: new Date().toISOString() } : null;
+}
+
 /** What the kill path needs to take a snapshot session down safely: the
     stable `%N` pane id to address, and the pane pid to verify it against. */
 export type KillTargetRef = TmuxAttachReference;
@@ -78,8 +83,7 @@ function isoFromUnix(seconds: number): string {
     rebuild triggered right after a kill would otherwise read 5s-old caches
     and re-list (and re-allowlist) the session that was just killed. */
 async function buildResources(fresh: boolean): Promise<ResourcesPayload> {
-  const capturedAt = new Date().toISOString();
-  const system = procBackend.systemMemory();
+  const system = captureSystemMemory();
 
   const hosts = await readTranscriptHosts(fresh);
   const sessions: ResourceSession[] = [];
@@ -147,7 +151,7 @@ async function buildResources(fresh: boolean): Promise<ResourcesPayload> {
   }
 
   return {
-    system: system ? { ...system, capturedAt } : null,
+    system,
     sessions,
   };
 }
@@ -157,7 +161,12 @@ async function buildResources(fresh: boolean): Promise<ResourcesPayload> {
     the shorter session list show up immediately. */
 export async function readResources(fresh = false): Promise<ResourcesPayload> {
   const cached = globalStore.__llvResourcesCache;
-  if (!fresh && cached && Date.now() - cached.at < CACHE_MS) return cached.data;
+  /* Pane discovery is the expensive cached half. Host pressure comes from a
+     new /proc/meminfo snapshot on every request, so RAM and swap never inherit
+     the age of a pane/session snapshot. */
+  if (!fresh && cached && Date.now() - cached.at < CACHE_MS) {
+    return { ...cached.data, system: captureSystemMemory() };
+  }
   const data = await buildResources(fresh);
   globalStore.__llvResourcesCache = { at: Date.now(), data };
   return data;

--- a/src/lib/scanner/context.test.ts
+++ b/src/lib/scanner/context.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, test } from "bun:test";
+
+import { contextUsage, resolveContextWindow } from "./context";
+
+describe("resolveContextWindow", () => {
+  test("uses the window reported by a Codex rollout", () => {
+    expect(resolveContextWindow({ engine: "codex", model: "gpt-5.6-sol", reportedWindow: 353_000 })).toBe(353_000);
+  });
+
+  test("does not guess a Codex window when the rollout omits it", () => {
+    expect(resolveContextWindow({ engine: "codex", model: "gpt-5.6-sol" })).toBeNull();
+  });
+
+  test("resolves current Claude models from their documented defaults", () => {
+    expect(resolveContextWindow({ engine: "claude", model: "claude-opus-4-8" })).toBe(1_000_000);
+    expect(resolveContextWindow({ engine: "claude", model: "claude-sonnet-4-6" })).toBe(1_000_000);
+    expect(resolveContextWindow({ engine: "claude", model: "claude-fable-5" })).toBe(1_000_000);
+    expect(resolveContextWindow({ engine: "claude", model: "claude-haiku-4-5-20251001" })).toBe(200_000);
+    expect(resolveContextWindow({ engine: "claude", model: "claude-sonnet-4-5-20250929" })).toBe(200_000);
+    expect(resolveContextWindow({ engine: "claude", model: "claude-3-5-sonnet-20241022" })).toBe(200_000);
+    expect(resolveContextWindow({ engine: "claude", model: "claude-3-opus-20240229" })).toBe(200_000);
+  });
+
+  test("recognizes explicit 1M modes on historical Claude models", () => {
+    expect(resolveContextWindow({ engine: "claude", model: "claude-sonnet-4-5[1m]" })).toBe(1_000_000);
+    expect(resolveContextWindow({ engine: "claude", model: "claude-sonnet-4-5", modes: ["context-1m-2025-08-07"] })).toBe(1_000_000);
+  });
+
+  test("leaves an unrecognized Claude model unresolved", () => {
+    expect(resolveContextWindow({ engine: "claude", model: "claude-future-9" })).toBeNull();
+    expect(resolveContextWindow({ engine: "claude", model: null })).toBeNull();
+  });
+});
+
+describe("contextUsage", () => {
+  test("rounds usage against the resolved window", () => {
+    expect(contextUsage(176_000, 353_000)).toEqual({ usedTokens: 176_000, windowTokens: 353_000, pct: 50 });
+  });
+
+  test("keeps usage visible while the window and percent are unknown", () => {
+    expect(contextUsage(176_000, null)).toEqual({ usedTokens: 176_000, windowTokens: null, pct: null });
+  });
+
+  test("rejects empty usage and invalid windows", () => {
+    expect(contextUsage(0, 200_000)).toBeNull();
+    expect(contextUsage(100, 0)).toEqual({ usedTokens: 100, windowTokens: null, pct: null });
+  });
+});

--- a/src/lib/scanner/context.test.ts
+++ b/src/lib/scanner/context.test.ts
@@ -1,48 +1,70 @@
-import { describe, expect, test } from "bun:test";
+import { afterAll, describe, expect, test } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 
-import { contextUsage, resolveContextWindow } from "./context";
+import type { FileEntry } from "../types";
+import { contextUsage, ctxFor } from "./context";
 
-describe("resolveContextWindow", () => {
-  test("uses the window reported by a Codex rollout", () => {
-    expect(resolveContextWindow({ engine: "codex", model: "gpt-5.6-sol", reportedWindow: 353_000 })).toBe(353_000);
+const OBSERVED_AT = "2026-07-12T10:00:00.000Z";
+const SANDBOX = fs.mkdtempSync(path.join(os.tmpdir(), "llv-context-test-"));
+afterAll(() => fs.rmSync(SANDBOX, { recursive: true, force: true }));
+
+function entry(records: unknown[], root: FileEntry["root"]): FileEntry {
+  const pathname = path.join(SANDBOX, `${crypto.randomUUID()}.jsonl`);
+  fs.writeFileSync(pathname, records.map((record) => JSON.stringify(record)).join("\n") + "\n");
+  const stat = fs.statSync(pathname);
+  return {
+    path: pathname, root, name: path.basename(pathname), project: "proj", title: "session",
+    engine: root === "codex-sessions" ? "codex" : "claude", kind: "session",
+    fmt: root === "codex-sessions" ? "codex" : "claude", parent: null,
+    mtime: stat.mtimeMs / 1000, size: stat.size, activity: "idle", proc: null,
+    pid: null, model: null, pendingQuestion: null, waitingInput: null,
+  };
+}
+
+describe("contextUsage", () => {
+  test("allows runtime metadata to report an exact 100 percent", () => {
+    expect(contextUsage(353_000, { windowTokens: 353_000, source: "runtime", confidence: "exact" }, OBSERVED_AT)).toEqual({
+      usedTokens: 353_000, windowTokens: 353_000, pct: 100, source: "runtime", confidence: "exact", observedAt: OBSERVED_AT,
+    });
   });
 
-  test("does not guess a Codex window when the rollout omits it", () => {
-    expect(resolveContextWindow({ engine: "codex", model: "gpt-5.6-sol" })).toBeNull();
+  test("caps registry percentages at 99 and carries registry provenance", () => {
+    expect(contextUsage(999_000, { windowTokens: 1_000_000, source: "registry", confidence: "approximate", registryVersion: "2026-07-10" }, OBSERVED_AT)).toEqual({
+      usedTokens: 999_000, windowTokens: 1_000_000, pct: 99, source: "registry", confidence: "approximate",
+      registryVersion: "2026-07-10", observedAt: OBSERVED_AT,
+    });
   });
 
-  test("resolves current Claude models from their documented defaults", () => {
-    expect(resolveContextWindow({ engine: "claude", model: "claude-opus-4-8" })).toBe(1_000_000);
-    expect(resolveContextWindow({ engine: "claude", model: "claude-sonnet-4-6" })).toBe(1_000_000);
-    expect(resolveContextWindow({ engine: "claude", model: "claude-fable-5" })).toBe(1_000_000);
-    expect(resolveContextWindow({ engine: "claude", model: "claude-haiku-4-5-20251001" })).toBe(200_000);
-    expect(resolveContextWindow({ engine: "claude", model: "claude-sonnet-4-5-20250929" })).toBe(200_000);
-    expect(resolveContextWindow({ engine: "claude", model: "claude-3-5-sonnet-20241022" })).toBe(200_000);
-    expect(resolveContextWindow({ engine: "claude", model: "claude-3-opus-20240229" })).toBe(200_000);
-  });
-
-  test("recognizes explicit 1M modes on historical Claude models", () => {
-    expect(resolveContextWindow({ engine: "claude", model: "claude-sonnet-4-5[1m]" })).toBe(1_000_000);
-    expect(resolveContextWindow({ engine: "claude", model: "claude-sonnet-4-5", modes: ["context-1m-2025-08-07"] })).toBe(1_000_000);
-  });
-
-  test("leaves an unrecognized Claude model unresolved", () => {
-    expect(resolveContextWindow({ engine: "claude", model: "claude-future-9" })).toBeNull();
-    expect(resolveContextWindow({ engine: "claude", model: null })).toBeNull();
+  test("demotes registry overflow to raw unknown usage", () => {
+    expect(contextUsage(1_000_001, { windowTokens: 1_000_000, source: "registry", confidence: "approximate", registryVersion: "2026-07-10" }, OBSERVED_AT)).toEqual({
+      usedTokens: 1_000_001, windowTokens: null, pct: null, source: "unknown", confidence: "unknown", observedAt: OBSERVED_AT,
+    });
   });
 });
 
-describe("contextUsage", () => {
-  test("rounds usage against the resolved window", () => {
-    expect(contextUsage(176_000, 353_000)).toEqual({ usedTokens: 176_000, windowTokens: 353_000, pct: 50 });
+describe("ctxFor", () => {
+  test("uses Codex runtime metadata and suppresses usage missing its window", () => {
+    const usage = { total_tokens: 176_000 };
+    const withWindow = entry([{ timestamp: OBSERVED_AT, type: "event_msg", payload: { type: "token_count", info: { last_token_usage: usage, model_context_window: 353_000 } } }], "codex-sessions");
+    const withoutWindow = entry([{ timestamp: OBSERVED_AT, type: "event_msg", payload: { type: "token_count", info: { last_token_usage: usage } } }], "codex-sessions");
+    expect(ctxFor(withWindow)).toMatchObject({ usedTokens: 176_000, windowTokens: 353_000, pct: 50, source: "runtime", confidence: "exact", observedAt: OBSERVED_AT });
+    expect(ctxFor(withoutWindow)).toBeNull();
   });
 
-  test("keeps usage visible while the window and percent are unknown", () => {
-    expect(contextUsage(176_000, null)).toEqual({ usedTokens: 176_000, windowTokens: null, pct: null });
+  test("resolves the model on each Claude usage record and keeps the post-compaction usage", () => {
+    const assistant = (model: string, input_tokens: number, timestamp: string) => ({ type: "assistant", timestamp, message: { model, usage: { input_tokens, cache_read_input_tokens: 0, cache_creation_input_tokens: 0 } } });
+    const file = entry([
+      assistant("claude-sonnet-4-5-20250929", 180_000, "2026-07-12T09:00:00.000Z"),
+      { type: "system", subtype: "compact_boundary", compactMetadata: { preTokens: 180_000 } },
+      assistant("claude-opus-4-8", 12_000, OBSERVED_AT),
+    ], "claude-projects");
+    expect(ctxFor(file)).toMatchObject({ usedTokens: 12_000, windowTokens: 1_000_000, pct: 1, source: "registry", registryVersion: "2026-07-10", observedAt: OBSERVED_AT });
   });
 
-  test("rejects empty usage and invalid windows", () => {
-    expect(contextUsage(0, 200_000)).toBeNull();
-    expect(contextUsage(100, 0)).toEqual({ usedTokens: 100, windowTokens: null, pct: null });
+  test("preserves raw tokens for an unknown Claude model", () => {
+    const file = entry([{ type: "assistant", timestamp: OBSERVED_AT, message: { model: "claude-newthing-9", usage: { input_tokens: 42_000 } } }], "claude-projects");
+    expect(ctxFor(file)).toEqual({ usedTokens: 42_000, windowTokens: null, pct: null, source: "unknown", confidence: "unknown", observedAt: OBSERVED_AT });
   });
 });

--- a/src/lib/scanner/context.ts
+++ b/src/lib/scanner/context.ts
@@ -5,16 +5,59 @@ import { numberValue, recordValue, stringValue } from "./json";
 
 const ctxCache = globalCache<[number, CtxUsage | null]>("ctx");
 
-/** Claude context windows. The map is deliberately tiny: "[1m]"-suffixed
-    model ids and Fable run the 1M-token window, everything else ships the
-    standard 200k. Transcripts do not record the window, so a usage total that
-    exceeds the assumed window proves the session runs the larger one. */
+/** Claude API defaults documented at
+    https://platform.claude.com/docs/en/build-with-claude/context-windows.
+    Keep this allowlist versioned: an unknown future id must remain unknown. */
 const CLAUDE_WINDOW = 200_000;
 const CLAUDE_WINDOW_1M = 1_000_000;
 
-function buildCtx(usedTokens: number | null, windowTokens: number | null): CtxUsage | null {
-  if (usedTokens === null || usedTokens <= 0 || windowTokens === null || windowTokens <= 0) return null;
-  return { usedTokens, windowTokens, pct: Math.min(100, Math.round((usedTokens / windowTokens) * 100)) };
+const CLAUDE_1M_MODE = "context-1m-2025-08-07";
+const CLAUDE_1M_MODELS = [
+  /(?:^|-)fable(?:-|$)/,
+  /(?:^|-)mythos(?:-|$)/,
+  /(?:^|-)opus-4-(?:6|7|8)(?:-|$)/,
+  /(?:^|-)sonnet-(?:5|4-6)(?:-|$)/,
+] as const;
+const CLAUDE_200K_MODELS = [
+  /(?:^|-)haiku-(?:3|3-5|4-5)(?:-|$)/,
+  /(?:^|-)opus-(?:3|3-5|4|4-0|4-1|4-5)(?:-|$)/,
+  /(?:^|-)sonnet-(?:3|3-5|3-7|4|4-0|4-5)(?:-|$)/,
+  /(?:^|-)3(?:-5|-7)?-haiku(?:-|$)/,
+  /(?:^|-)3(?:-5)?-opus(?:-|$)/,
+  /(?:^|-)3(?:-5|-7)?-sonnet(?:-|$)/,
+] as const;
+
+export interface ContextWindowQuery {
+  engine: "claude" | "codex";
+  model: string | null;
+  /** Engine-reported value. Codex token_count rollouts populate this. */
+  reportedWindow?: number | null;
+  /** Explicit request/transcript modes, including Anthropic beta names. */
+  modes?: readonly string[];
+}
+
+export function resolveContextWindow(query: ContextWindowQuery): number | null {
+  if (query.reportedWindow && query.reportedWindow > 0) return query.reportedWindow;
+  if (query.engine === "codex") return null;
+  const model = query.model?.toLowerCase().trim();
+  if (!model) return null;
+  if (model.includes("[1m]") || query.modes?.some((mode) => mode.toLowerCase().includes(CLAUDE_1M_MODE))) {
+    return CLAUDE_WINDOW_1M;
+  }
+  const normalized = model.replaceAll("[1m]", "");
+  if (CLAUDE_1M_MODELS.some((pattern) => pattern.test(normalized))) return CLAUDE_WINDOW_1M;
+  if (CLAUDE_200K_MODELS.some((pattern) => pattern.test(normalized))) return CLAUDE_WINDOW;
+  return null;
+}
+
+export function contextUsage(usedTokens: number | null, windowTokens: number | null): CtxUsage | null {
+  if (usedTokens === null || usedTokens <= 0) return null;
+  const window = windowTokens !== null && windowTokens > 0 ? windowTokens : null;
+  return {
+    usedTokens,
+    windowTokens: window,
+    pct: window === null ? null : Math.min(100, Math.round((usedTokens / window) * 100)),
+  };
 }
 
 /** Codex: token_count events carry per-request usage plus the model context
@@ -28,7 +71,12 @@ function codexCtx(obj: Record<string, unknown>): CtxUsage | null {
   if (!info) return null;
   const usage = recordValue(info.last_token_usage) ?? recordValue(info.total_token_usage);
   if (!usage) return null;
-  return buildCtx(numberValue(usage.total_tokens), numberValue(info.model_context_window));
+  const window = resolveContextWindow({
+    engine: "codex",
+    model: null,
+    reportedWindow: numberValue(info.model_context_window),
+  });
+  return contextUsage(numberValue(usage.total_tokens), window);
 }
 
 /** Claude: the newest assistant record's message.usage. Context size is the
@@ -44,9 +92,11 @@ function claudeCtx(obj: Record<string, unknown>): CtxUsage | null {
     (numberValue(usage.input_tokens) ?? 0) +
     (numberValue(usage.cache_read_input_tokens) ?? 0) +
     (numberValue(usage.cache_creation_input_tokens) ?? 0);
-  let window = model?.includes("[1m]") || model?.includes("fable") ? CLAUDE_WINDOW_1M : CLAUDE_WINDOW;
-  if (used > window) window = CLAUDE_WINDOW_1M;
-  return buildCtx(used, window);
+  const modes = [obj.beta, obj.betas, message.beta, message.betas]
+    .flatMap((value) => (Array.isArray(value) ? value : [value]))
+    .filter((value): value is string => typeof value === "string");
+  const window = resolveContextWindow({ engine: "claude", model: model ?? null, modes });
+  return contextUsage(used, window);
 }
 
 /**

--- a/src/lib/scanner/context.ts
+++ b/src/lib/scanner/context.ts
@@ -1,91 +1,79 @@
-import type { CtxUsage, FileEntry } from "../types";
+import type { CtxConfidence, CtxSource, CtxUsage, FileEntry } from "../types";
 import { tailRecords } from "./activity";
 import { globalCache } from "./caches";
 import { numberValue, recordValue, stringValue } from "./json";
+import { MODEL_REGISTRY_VERSION, normalizeModelKey, registryWindow } from "./modelRegistry";
 
 const ctxCache = globalCache<[number, CtxUsage | null]>("ctx");
-
-/** Claude API defaults documented at
-    https://platform.claude.com/docs/en/build-with-claude/context-windows.
-    Keep this allowlist versioned: an unknown future id must remain unknown. */
-const CLAUDE_WINDOW = 200_000;
-const CLAUDE_WINDOW_1M = 1_000_000;
-
 const CLAUDE_1M_MODE = "context-1m-2025-08-07";
-const CLAUDE_1M_MODELS = [
-  /(?:^|-)fable(?:-|$)/,
-  /(?:^|-)mythos(?:-|$)/,
-  /(?:^|-)opus-4-(?:6|7|8)(?:-|$)/,
-  /(?:^|-)sonnet-(?:5|4-6)(?:-|$)/,
-] as const;
-const CLAUDE_200K_MODELS = [
-  /(?:^|-)haiku-(?:3|3-5|4-5)(?:-|$)/,
-  /(?:^|-)opus-(?:3|3-5|4|4-0|4-1|4-5)(?:-|$)/,
-  /(?:^|-)sonnet-(?:3|3-5|3-7|4|4-0|4-5)(?:-|$)/,
-  /(?:^|-)3(?:-5|-7)?-haiku(?:-|$)/,
-  /(?:^|-)3(?:-5)?-opus(?:-|$)/,
-  /(?:^|-)3(?:-5|-7)?-sonnet(?:-|$)/,
-] as const;
 
-export interface ContextWindowQuery {
-  engine: "claude" | "codex";
-  model: string | null;
-  /** Engine-reported value. Codex token_count rollouts populate this. */
-  reportedWindow?: number | null;
-  /** Explicit request/transcript modes, including Anthropic beta names. */
-  modes?: readonly string[];
+interface ContextCapacity {
+  windowTokens: number;
+  source: Exclude<CtxSource, "unknown">;
+  confidence: Exclude<CtxConfidence, "unknown">;
+  registryVersion?: string;
 }
 
-export function resolveContextWindow(query: ContextWindowQuery): number | null {
-  if (query.reportedWindow && query.reportedWindow > 0) return query.reportedWindow;
-  if (query.engine === "codex") return null;
-  const model = query.model?.toLowerCase().trim();
-  if (!model) return null;
-  if (model.includes("[1m]") || query.modes?.some((mode) => mode.toLowerCase().includes(CLAUDE_1M_MODE))) {
-    return CLAUDE_WINDOW_1M;
-  }
-  const normalized = model.replaceAll("[1m]", "");
-  if (CLAUDE_1M_MODELS.some((pattern) => pattern.test(normalized))) return CLAUDE_WINDOW_1M;
-  if (CLAUDE_200K_MODELS.some((pattern) => pattern.test(normalized))) return CLAUDE_WINDOW;
-  return null;
+function unknownUsage(usedTokens: number, observedAt: string): CtxUsage {
+  return { usedTokens, windowTokens: null, pct: null, source: "unknown", confidence: "unknown", observedAt };
 }
 
-export function contextUsage(usedTokens: number | null, windowTokens: number | null): CtxUsage | null {
+export function contextUsage(usedTokens: number | null, capacity: ContextCapacity | null, observedAt: string): CtxUsage | null {
   if (usedTokens === null || usedTokens <= 0) return null;
-  const window = windowTokens !== null && windowTokens > 0 ? windowTokens : null;
+  if (!capacity || capacity.windowTokens <= 0) return unknownUsage(usedTokens, observedAt);
+  if (capacity.source !== "runtime" && usedTokens > capacity.windowTokens) return unknownUsage(usedTokens, observedAt);
+  const cap = capacity.source === "registry" ? 99 : 100;
   return {
     usedTokens,
-    windowTokens: window,
-    pct: window === null ? null : Math.min(100, Math.round((usedTokens / window) * 100)),
+    windowTokens: capacity.windowTokens,
+    pct: Math.min(cap, Math.round((usedTokens / capacity.windowTokens) * 100)),
+    source: capacity.source,
+    confidence: capacity.confidence,
+    ...(capacity.registryVersion ? { registryVersion: capacity.registryVersion } : {}),
+    observedAt,
   };
 }
 
-/** Codex: token_count events carry per-request usage plus the model context
-    window — the numbers behind the TUI footer «Context N% used». The last
-    request's total (prompt incl. cache reads + output) is the current context
-    size; the cumulative total_token_usage overshoots across turns. */
-function codexCtx(obj: Record<string, unknown>): CtxUsage | null {
+function recordObservedAt(obj: Record<string, unknown>, fallback: string): string {
+  const raw = stringValue(obj.timestamp);
+  const millis = raw ? Date.parse(raw) : Number.NaN;
+  return Number.isFinite(millis) ? new Date(millis).toISOString() : fallback;
+}
+
+function codexCtx(obj: Record<string, unknown>, fallbackObservedAt: string): CtxUsage | null {
   const payload = recordValue(obj.payload);
   if (!payload || stringValue(payload.type) !== "token_count") return null;
   const info = recordValue(payload.info);
   if (!info) return null;
   const usage = recordValue(info.last_token_usage) ?? recordValue(info.total_token_usage);
-  if (!usage) return null;
-  const window = resolveContextWindow({
-    engine: "codex",
-    model: null,
-    reportedWindow: numberValue(info.model_context_window),
-  });
-  return contextUsage(numberValue(usage.total_tokens), window);
+  const windowTokens = numberValue(info.model_context_window);
+  if (!usage || windowTokens === null || windowTokens <= 0) return null;
+  return contextUsage(
+    numberValue(usage.total_tokens),
+    { windowTokens, source: "runtime", confidence: "exact" },
+    recordObservedAt(obj, fallbackObservedAt),
+  );
 }
 
-/** Claude: the newest assistant record's message.usage. Context size is the
-    full prompt of that call: fresh input + cache reads + cache writes. */
-function claudeCtx(obj: Record<string, unknown>): CtxUsage | null {
+function claudeCapacity(message: Record<string, unknown>, model: string, modes: readonly string[]): ContextCapacity | null {
+  const runtimeWindow = numberValue(message.context_window) ?? numberValue(message.model_context_window);
+  if (runtimeWindow !== null && runtimeWindow > 0) {
+    return { windowTokens: runtimeWindow, source: "runtime", confidence: "exact" };
+  }
+  const normalized = normalizeModelKey(model);
+  if (!normalized) return null;
+  const mode = modes.some((value) => value.toLowerCase().includes(CLAUDE_1M_MODE)) ? "1m" : normalized.mode;
+  const windowTokens = registryWindow(normalized.key, mode);
+  return windowTokens === null
+    ? null
+    : { windowTokens, source: "registry", confidence: "approximate", registryVersion: MODEL_REGISTRY_VERSION };
+}
+
+function claudeCtx(obj: Record<string, unknown>, fallbackObservedAt: string): CtxUsage | null {
   if (obj.type !== "assistant") return null;
   const message = recordValue(obj.message);
   const model = stringValue(message?.model);
-  if (!message || model === "<synthetic>") return null;
+  if (!message || !model || model === "<synthetic>") return null;
   const usage = recordValue(message.usage);
   if (!usage) return null;
   const used =
@@ -95,25 +83,21 @@ function claudeCtx(obj: Record<string, unknown>): CtxUsage | null {
   const modes = [obj.beta, obj.betas, message.beta, message.betas]
     .flatMap((value) => (Array.isArray(value) ? value : [value]))
     .filter((value): value is string => typeof value === "string");
-  const window = resolveContextWindow({ engine: "claude", model: model ?? null, modes });
-  return contextUsage(used, window);
+  return contextUsage(used, claudeCapacity(message, model, modes), recordObservedAt(obj, fallbackObservedAt));
 }
 
-/**
- * Context-window fullness from the newest usage record in the transcript
- * tail. Size-keyed cache like turn state — no reads beyond the tail, and an
- * unchanged file costs nothing. Tails with no usage record return null (the
- * chip disappears rather than showing a stale number).
- */
+/** Context usage from the newest in-band usage record. Capacity resolution is
+    synchronous and stays bound to the same record as its token count. */
 export function ctxFor(entry: FileEntry): CtxUsage | null {
   const conversationRoot = entry.root === "claude-projects" || entry.root === "codex-sessions";
   if (!conversationRoot || !entry.path.endsWith(".jsonl")) return null;
   const cached = ctxCache.get(entry.path);
   if (cached?.[0] === entry.size) return cached[1];
 
+  const fallbackObservedAt = new Date().toISOString();
   let ctx: CtxUsage | null = null;
   for (const obj of tailRecords(entry.path, entry.size).reverse()) {
-    ctx = entry.root === "codex-sessions" ? codexCtx(obj) : claudeCtx(obj);
+    ctx = entry.root === "codex-sessions" ? codexCtx(obj, fallbackObservedAt) : claudeCtx(obj, fallbackObservedAt);
     if (ctx) break;
   }
   ctxCache.set(entry.path, [entry.size, ctx]);

--- a/src/lib/scanner/modelRegistry.test.ts
+++ b/src/lib/scanner/modelRegistry.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from "bun:test";
+
+import { MODEL_REGISTRY_VERSION, normalizeModelKey, registryWindow } from "./modelRegistry";
+
+describe("normalizeModelKey", () => {
+  test("normalizes exact API, Bedrock, Vertex, dated, and 1M aliases", () => {
+    expect(normalizeModelKey(" claude-opus-4-8 ")).toEqual({ key: "opus-4-8", mode: "standard" });
+    expect(normalizeModelKey("us.anthropic.claude-opus-4-8-v1:0")).toEqual({ key: "opus-4-8", mode: "standard" });
+    expect(normalizeModelKey("claude-opus-4-8@20251101")).toEqual({ key: "opus-4-8", mode: "standard" });
+    expect(normalizeModelKey("claude-sonnet-4-5-20250929[1m]")).toEqual({ key: "sonnet-4-5", mode: "1m" });
+  });
+
+  test("keeps future versions exact so they miss the registry", () => {
+    expect(normalizeModelKey("claude-opus-4-9")).toEqual({ key: "opus-4-9", mode: "standard" });
+    expect(registryWindow("opus-4-9", "standard")).toBeNull();
+    expect(registryWindow("sonnet-4-9", "standard")).toBeNull();
+  });
+});
+
+describe("registryWindow", () => {
+  test("contains the frozen documented registry seed", () => {
+    expect(MODEL_REGISTRY_VERSION).toBe("2026-07-10");
+    expect(registryWindow("fable-5", "standard")).toBe(1_000_000);
+    expect(registryWindow("opus-4-8", "standard")).toBe(1_000_000);
+    expect(registryWindow("sonnet-4-5", "standard")).toBe(200_000);
+    expect(registryWindow("sonnet-4-5", "1m")).toBe(1_000_000);
+    expect(registryWindow("haiku-4-5", "standard")).toBe(200_000);
+  });
+});

--- a/src/lib/scanner/modelRegistry.ts
+++ b/src/lib/scanner/modelRegistry.ts
@@ -1,0 +1,50 @@
+export const MODEL_REGISTRY_VERSION = "2026-07-10";
+
+interface RegistryEntry {
+  standard: number;
+  extended?: number;
+}
+
+const ONE_MILLION = 1_000_000;
+const TWO_HUNDRED_THOUSAND = 200_000;
+
+/** Official-doc snapshot. Exact keys keep future model revisions unknown until
+    the registry is deliberately updated and its version is bumped. */
+const MODEL_REGISTRY: Readonly<Record<string, RegistryEntry>> = {
+  "fable-5": { standard: ONE_MILLION },
+  "mythos-5": { standard: ONE_MILLION },
+  "mythos-preview": { standard: ONE_MILLION },
+  "opus-4-8": { standard: ONE_MILLION },
+  "opus-4-7": { standard: ONE_MILLION },
+  "opus-4-6": { standard: ONE_MILLION },
+  "sonnet-5": { standard: ONE_MILLION },
+  "sonnet-4-6": { standard: ONE_MILLION },
+  "haiku-4-5": { standard: TWO_HUNDRED_THOUSAND },
+  "opus-4-5": { standard: TWO_HUNDRED_THOUSAND },
+  "opus-4-1": { standard: TWO_HUNDRED_THOUSAND },
+  "sonnet-4-5": { standard: TWO_HUNDRED_THOUSAND, extended: ONE_MILLION },
+  "sonnet-4-0": { standard: TWO_HUNDRED_THOUSAND, extended: ONE_MILLION },
+};
+
+export type ModelContextMode = "standard" | "1m";
+
+export function normalizeModelKey(raw: string): { key: string; mode: ModelContextMode } | null {
+  let value = raw.toLowerCase().trim();
+  if (!value || value === "<synthetic>") return null;
+
+  const tagged1m = /\[1m\]$/.test(value);
+  if (tagged1m) value = value.replace(/\[1m\]$/, "");
+  value = value.replace(/^(?:us\.|eu\.)?anthropic\./, "");
+  value = value.replace(/@20\d{6}$/, "");
+  value = value.replace(/-v\d+(?::\d+)?$/, "");
+  value = value.replace(/-20\d{6}$/, "");
+  value = value.replace(/^claude-/, "");
+  if (!value) return null;
+  return { key: value, mode: tagged1m ? "1m" : "standard" };
+}
+
+export function registryWindow(key: string, mode: ModelContextMode): number | null {
+  const entry = MODEL_REGISTRY[key];
+  if (!entry) return null;
+  return mode === "1m" ? (entry.extended ?? ONE_MILLION) : entry.standard;
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -166,12 +166,21 @@ export type PlanStepStatus = "pending" | "in_progress" | "completed";
 
 /** How full an agent's context window is (codex token_count events; claude
     assistant usage vs the model's window). */
+export type CtxSource = "runtime" | "provider" | "registry" | "unknown";
+export type CtxConfidence = "exact" | "approximate" | "unknown";
+
 export interface CtxUsage {
   usedTokens: number;
   /** Null when the transcript and known-model table cannot establish it. */
   windowTokens: number | null;
   /** Rounded 0–100, or null along with an unknown window. */
   pct: number | null;
+  source: CtxSource;
+  confidence: CtxConfidence;
+  /** Bundled snapshot id, present for registry-derived capacity. */
+  registryVersion?: string;
+  /** ISO timestamp of the transcript usage record, with scan time fallback. */
+  observedAt: string;
 }
 
 /** Codex thread goal (update_goal tool / thread_goal_updated events): the

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -168,9 +168,10 @@ export type PlanStepStatus = "pending" | "in_progress" | "completed";
     assistant usage vs the model's window). */
 export interface CtxUsage {
   usedTokens: number;
-  windowTokens: number;
-  /** Rounded 0–100. */
-  pct: number;
+  /** Null when the transcript and known-model table cannot establish it. */
+  windowTokens: number | null;
+  /** Rounded 0–100, or null along with an unknown window. */
+  pct: number | null;
 }
 
 /** Codex thread goal (update_goal tool / thread_goal_updated events): the


### PR DESCRIPTION
Closes #22

## Summary
- resolve Codex context windows from rollout token-count metadata, including model-specific values such as 353K
- resolve Claude windows through documented per-model defaults plus explicit 1M transcript modes; preserve unknown windows as unknown usage
- render exact window sizes in shared context-chip tooltips across pane headers and switch cards
- refresh RAM and swap from each current system-memory snapshot, retain MemAvailable and SwapTotal-SwapFree semantics, and label capture age
- add regression coverage for model resolution and percentage math

Claude context-window matrix: https://platform.claude.com/docs/en/build-with-claude/context-windows

## Verification
- `bun test` (1757 pass)
- `bunx tsc --noEmit`
- `git diff --check`