### PR TITLE
Accounts UI tail: per-account session/weekly limits with reset times (#40)

### DIFF
--- a/src/components/AccountsPanel.render.test.tsx
+++ b/src/components/AccountsPanel.render.test.tsx
@@ -102,7 +102,9 @@ test("dims and labels a stale account limits read and omits a missing reset time
   }));
   const detail = html.match(/<dl[^>]*Quota windows[^>]*>[\s\S]*?<\/dl>/)?.[0] ?? "";
   expect(detail).not.toBe("");
-  expect(detail).toContain("opacity-55"); // stale read is dimmed
+  // Freshness is a visible, AT-readable caption, not opacity/title alone.
+  expect(detail).toContain("Last known values");
+  expect(detail).toContain("opacity-70"); // values stay legible; text carries the meaning
   expect(html).toContain('title="Last known values — not a live read"');
   expect(detail).toContain("80%"); // 100 − 20 with no reset line
   expect(detail).not.toContain("reset"); // resetsAt null → no reset text

--- a/src/components/AccountsPanel.render.test.tsx
+++ b/src/components/AccountsPanel.render.test.tsx
@@ -70,6 +70,44 @@ test("renders a capacity chip per account and dims the stale one", () => {
   expect(html).toContain("opacity-55"); // the stale Work chip
 });
 
+test("breaks out each account's session and weekly windows with reset times", () => {
+  const nowS = Math.floor(Date.now() / 1000);
+  const html = render(base({
+    accounts: [
+      {
+        id: "main", label: "Main", kind: "legacy", authPresent: true, loginPending: false, loginState: "authenticated", deviceAuth: null,
+        effective: { percent: 45, window: "session", freshness: "fresh" },
+        limits: { freshness: "fresh", session: { usedPercent: 55, resetsAt: nowS + 7200 }, weekly: { usedPercent: 8, resetsAt: nowS + 259200 } },
+      },
+    ],
+    active: "main",
+  }));
+  expect(html).toContain('aria-label="Quota windows for Main"');
+  expect(html).toContain(translate("en", "limits.5h"));
+  expect(html).toContain(translate("en", "limits.week"));
+  expect(html).toContain("45%"); // session remaining (100 − 55)
+  expect(html).toContain("92%"); // weekly remaining (100 − 8)
+  expect(html).toContain("reset"); // both windows carry a reset time
+});
+
+test("dims and labels a stale account limits read and omits a missing reset time", () => {
+  const html = render(base({
+    accounts: [
+      {
+        id: "main", label: "Main", kind: "legacy", authPresent: true, loginPending: false, loginState: "authenticated", deviceAuth: null,
+        limits: { freshness: "stale", session: { usedPercent: 20, resetsAt: null }, weekly: null },
+      },
+    ],
+    active: "main",
+  }));
+  const detail = html.match(/<dl[^>]*Quota windows[^>]*>[\s\S]*?<\/dl>/)?.[0] ?? "";
+  expect(detail).not.toBe("");
+  expect(detail).toContain("opacity-55"); // stale read is dimmed
+  expect(html).toContain('title="Last known values — not a live read"');
+  expect(detail).toContain("80%"); // 100 − 20 with no reset line
+  expect(detail).not.toContain("reset"); // resetsAt null → no reset text
+});
+
 test("automatic transcript migration controls stay outside the account panel", () => {
   const withAuto = render(base({ autoBalance: { enabled: true, thresholdPercent: 25, state: "idle", cooldownUntil: null, lastCheckAt: "2026-07-10T14:32:00.000Z", lastOutcome: null } }));
   expect(withAuto).not.toContain('role="switch"');

--- a/src/components/AccountsPanel.tsx
+++ b/src/components/AccountsPanel.tsx
@@ -75,8 +75,12 @@ function AccountLimitsDetail({ account }: { account: AccountOption }) {
     <dl
       aria-label={t("accounts.limitsAria", { label: account.label })}
       title={stale ? t("accounts.limitsStaleTip") : undefined}
-      className={`flex flex-col gap-0.5 px-3 pb-1.5 pl-[26px] ${stale ? "opacity-55" : ""}`}
+      className={`flex flex-col gap-0.5 px-3 pb-1.5 pl-[26px] ${stale ? "opacity-70" : ""}`}
     >
+      {/* Freshness is a visible, screen-reader-readable line — not opacity or a
+          title tooltip alone (touch has no hover, and `title` AT support is
+          spotty), so historical numbers never read as current. */}
+      {stale ? <div className="text-[9.5px] font-semibold uppercase tracking-wide text-dim">{t("accounts.limitsStale")}</div> : null}
       {windows.map(({ key, label, window: w }) => {
         const left = Math.max(0, Math.min(100, 100 - w.usedPercent));
         return (

--- a/src/components/AccountsPanel.tsx
+++ b/src/components/AccountsPanel.tsx
@@ -14,6 +14,7 @@ import { type TFunction, useLocale } from "@/lib/i18n";
 import { handleOverlayEscape } from "@/lib/overlay";
 
 import { Check, Loader2, X } from "./icons";
+import { formatResetClock, formatResetEta } from "./rateLimit";
 import { engineTintOf } from "./utils";
 
 /** Amber that clears contrast on the panel background — state legibility never
@@ -48,6 +49,50 @@ function CapacityChip({ account, engine }: { account: AccountOption; engine: "cl
     >
       {t("accounts.effective", { pct: Math.round(effective.percent) })}
     </span>
+  );
+}
+
+/** Per-account quota detail (issue #40): the session and weekly windows with
+    remaining capacity and reset times, so the switch decision reads without
+    leaving the panel. The collapsed {@link CapacityChip} is the min-window
+    summary of this; here both windows are broken out. Renders nothing when no
+    live/stale read exists; a stale read is dimmed and labeled. Time formatting is
+    shared with the limits footer so both read identically. */
+function AccountLimitsDetail({ account }: { account: AccountOption }) {
+  const { t } = useLocale();
+  // A single reference `now` for the open panel keeps the two windows' reset
+  // ETAs consistent and stable across re-renders (they don't tick live here).
+  const [now] = useState(() => Math.floor(Date.now() / 1000));
+  const limits = account.limits;
+  if (!limits) return null;
+  const windows = [
+    { key: "session", label: t("limits.5h"), window: limits.session },
+    { key: "weekly", label: t("limits.week"), window: limits.weekly },
+  ].filter((row): row is { key: string; label: string; window: NonNullable<typeof row.window> } => row.window != null);
+  if (windows.length === 0) return null;
+  const stale = limits.freshness === "stale";
+  return (
+    <dl
+      aria-label={t("accounts.limitsAria", { label: account.label })}
+      title={stale ? t("accounts.limitsStaleTip") : undefined}
+      className={`flex flex-col gap-0.5 px-3 pb-1.5 pl-[26px] ${stale ? "opacity-55" : ""}`}
+    >
+      {windows.map(({ key, label, window: w }) => {
+        const left = Math.max(0, Math.min(100, 100 - w.usedPercent));
+        return (
+          <div key={key} className="flex items-baseline gap-1.5 text-[10px] leading-snug text-dim">
+            <dt className="w-8 shrink-0 font-semibold">{label}</dt>
+            <dd className="flex min-w-0 flex-1 items-baseline gap-1">
+              <span className="font-bold tabular-nums text-ink">{Math.round(left)}%</span>
+              <span>{t("limits.left")}</span>
+              {w.resetsAt ? (
+                <span className="truncate">· {t("limits.reset", { eta: formatResetEta(w.resetsAt, now), at: formatResetClock(w.resetsAt, now) })}</span>
+              ) : null}
+            </dd>
+          </div>
+        );
+      })}
+    </dl>
   );
 }
 
@@ -443,6 +488,7 @@ export function AccountsPanel({
               {accounts.map((account) => (
                 <Fragment key={account.id}>
                   <AccountRow account={account} engine={engine} activeId={active} disabled={mutation !== null} onSelect={() => void onSelect(account.id)} onRemove={() => void state.remove(account.id)} />
+                  <AccountLimitsDetail account={account} />
                   {engine === "claude" ? <ClaudeLoginRow key={account.login?.operationId ?? account.id} account={account} state={state} loginBusy={loginBusy} /> : null}
                 </Fragment>
               ))}

--- a/src/components/LimitsFooter.tsx
+++ b/src/components/LimitsFooter.tsx
@@ -3,35 +3,17 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 
 import { accountEntryPointVisible, type Engine, useEngineAccounts } from "@/hooks/useEngineAccounts";
-import { getLocale, type Locale, translate, useLocale } from "@/lib/i18n";
+import { type Locale, translate, useLocale } from "@/lib/i18n";
 import type { EngineLimits, LimitsPayload, LimitWindow } from "@/lib/types";
 
 import { AccountsPanel } from "./AccountsPanel";
 import { ChevronDown, Loader2 } from "./icons";
+import { formatResetClock as fmtResetAt, formatResetEta as fmtEta, localeBcp47 as bcp47 } from "./rateLimit";
 import { engineTintOf, fmtAge } from "./utils";
 
 const POLL_MS = 60_000;
 /** Codex numbers come from the last transcript event; flag them past this age. */
 const STALE_S = 20 * 60;
-
-const bcp47 = (locale = getLocale()) => (locale === "uk" ? "uk-UA" : "en-US");
-
-function fmtEta(resetsAt: number, now: number): string {
-  const locale = getLocale();
-  const s = resetsAt - now;
-  if (s <= 60) return translate(locale, "limits.now");
-  if (s < 5400) return translate(locale, "limits.inMin", { n: Math.round(s / 60) });
-  if (s < 129600) return translate(locale, "limits.inHour", { n: Math.round(s / 3600) });
-  return translate(locale, "limits.inDay", { n: Math.round(s / 86400) });
-}
-
-/** Absolute reset moment: today's resets show the hour, later ones the date too. */
-function fmtResetAt(resetsAt: number, now: number): string {
-  const d = new Date(resetsAt * 1000);
-  const time = d.toLocaleTimeString(bcp47(), { hour: "2-digit", minute: "2-digit", hour12: false });
-  if (resetsAt - now < 86400) return time;
-  return d.toLocaleDateString(bcp47(), { day: "numeric", month: "short" }) + " " + time;
-}
 
 /** Human "as of HH:MM" hint for a stale snapshot. The Codex block renders this
     text alongside the dimming, giving that state a readable reason. */

--- a/src/components/rateLimit.ts
+++ b/src/components/rateLimit.ts
@@ -1,8 +1,11 @@
-import type { TFunction, Locale } from "@/lib/i18n";
+import { getLocale, translate, type TFunction, type Locale } from "@/lib/i18n";
 import type { RateLimitState } from "@/lib/types";
 
+/** BCP-47 tag for the two supported locales, used by every time formatter here. */
+export const localeBcp47 = (locale: Locale = getLocale()): string => (locale === "uk" ? "uk-UA" : "en-US");
+
 export function formatRateLimitTime(resetAt: number, locale: Locale): string {
-  return new Date(resetAt * 1000).toLocaleTimeString(locale === "uk" ? "uk-UA" : "en-US", {
+  return new Date(resetAt * 1000).toLocaleTimeString(localeBcp47(locale), {
     hour: "2-digit",
     minute: "2-digit",
     hour12: false,
@@ -13,4 +16,24 @@ export function rateLimitText(t: TFunction, locale: Locale, rateLimit: Pick<Rate
   return rateLimit.resetAt
     ? t("rateLimit.badgeUntil", { time: formatRateLimitTime(rateLimit.resetAt, locale) })
     : t("rateLimit.badge");
+}
+
+/** Relative "resets in …" phrasing for a quota window, coarsened as the horizon
+    grows (minutes → hours → days). Shared by the limits footer and the per-account
+    limits detail so both read the same. `resetsAt`/`now` are Unix seconds. */
+export function formatResetEta(resetsAt: number, now: number): string {
+  const locale = getLocale();
+  const s = resetsAt - now;
+  if (s <= 60) return translate(locale, "limits.now");
+  if (s < 5400) return translate(locale, "limits.inMin", { n: Math.round(s / 60) });
+  if (s < 129600) return translate(locale, "limits.inHour", { n: Math.round(s / 3600) });
+  return translate(locale, "limits.inDay", { n: Math.round(s / 86400) });
+}
+
+/** Absolute reset moment: today's resets show the hour, later ones the date too. */
+export function formatResetClock(resetsAt: number, now: number): string {
+  const d = new Date(resetsAt * 1000);
+  const time = d.toLocaleTimeString(localeBcp47(), { hour: "2-digit", minute: "2-digit", hour12: false });
+  if (resetsAt - now < 86400) return time;
+  return d.toLocaleDateString(localeBcp47(), { day: "numeric", month: "short" }) + " " + time;
 }

--- a/src/hooks/useEngineAccounts.test.ts
+++ b/src/hooks/useEngineAccounts.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "bun:test";
 
-import { claudeLoginErrKey, createEngineAccountsStore, NONTERMINAL_CLAUDE_LOGIN_PHASES, parseClaudeLogin, type ClaudeLoginPhase } from "./useEngineAccounts";
+import { claudeLoginErrKey, createEngineAccountsStore, NONTERMINAL_CLAUDE_LOGIN_PHASES, parseAccountLimits, parseClaudeLogin, type ClaudeLoginPhase } from "./useEngineAccounts";
 
 const advance = async () => {
   for (let tick = 0; tick < 8; tick += 1) await Promise.resolve();
@@ -51,6 +51,45 @@ test("a claude store reads body.claude, its engine endpoints, and parses migrati
   expect(store.accounts[0]?.effective).toEqual({ percent: 12, window: "session", freshness: "fresh" });
   expect(store.migration).toMatchObject({ intentId: "i1", origin: "auto", state: "draining", counts: { done: 1, total: 3 } });
   expect(store.autoBalance).toMatchObject({ enabled: true, state: "draining" });
+  unsub();
+});
+
+test("parseAccountLimits keeps fresh/stale reads with their windows and drops the rest", () => {
+  // Unavailable, absent, and non-object reads carry no window to show.
+  expect(parseAccountLimits(null)).toBeNull();
+  expect(parseAccountLimits({ state: "unavailable", session: null, weekly: null })).toBeNull();
+  expect(parseAccountLimits({ state: "fresh", session: null, weekly: null })).toBeNull();
+  // A malformed window is dropped; a valid sibling survives. resetsAt is optional.
+  expect(parseAccountLimits({ state: "fresh", session: { usedPercent: "nope" }, weekly: { usedPercent: 40, resetsAt: 1_700_000_000 } }))
+    .toEqual({ freshness: "fresh", session: null, weekly: { usedPercent: 40, resetsAt: 1_700_000_000 } });
+  expect(parseAccountLimits({ state: "stale", session: { usedPercent: 88, resetsAt: null }, weekly: null }))
+    .toEqual({ freshness: "stale", session: { usedPercent: 88, resetsAt: null }, weekly: null });
+});
+
+test("a store parses per-account session/weekly limit windows for the panel", async () => {
+  const { fetcher } = scripted((url) => {
+    if (url === "/api/accounts") {
+      return claudePayload({
+        accounts: [
+          {
+            id: "main", label: "Main", authPresent: true, loginPending: false, loginState: "authenticated", deviceAuth: null,
+            effective: { percent: 12, window: "session", freshness: "fresh" },
+            limits: { state: "fresh", session: { usedPercent: 88, resetsAt: 1_700_000_000 }, weekly: { usedPercent: 30, resetsAt: 1_700_500_000 } },
+          },
+          {
+            id: "work", label: "Work", authPresent: true, loginPending: false, loginState: "authenticated", deviceAuth: null,
+            limits: { state: "unavailable", session: null, weekly: null },
+          },
+        ],
+      });
+    }
+    return new Response(null, { status: 204 });
+  });
+  const store = createEngineAccountsStore("claude", { fetcher });
+  const unsub = store.subscribe(() => {});
+  await advance();
+  expect(store.accounts[0]?.limits).toEqual({ freshness: "fresh", session: { usedPercent: 88, resetsAt: 1_700_000_000 }, weekly: { usedPercent: 30, resetsAt: 1_700_500_000 } });
+  expect(store.accounts[1]?.limits).toBeNull();
   unsub();
 });
 

--- a/src/hooks/useEngineAccounts.ts
+++ b/src/hooks/useEngineAccounts.ts
@@ -92,6 +92,20 @@ export function claudeLoginErrKey(code: string | null | undefined): ClaudeLoginE
   }
 }
 
+/** One quota window (5h session or weekly) of an account, projected for the
+    Accounts panel: how much is spent and when it resets. `resetsAt` is Unix
+    seconds, or null when the engine did not report it. */
+export type AccountLimitWindow = { usedPercent: number; resetsAt: number | null };
+
+/** Per-account quota detail surfaced in the Accounts panel (issue #40): the
+    session and weekly windows with reset times, plus how fresh the read is. The
+    combined {@link AccountEffective} chip is the collapsed summary of this. */
+export type AccountLimits = {
+  freshness: "fresh" | "stale";
+  session: AccountLimitWindow | null;
+  weekly: AccountLimitWindow | null;
+};
+
 export type AccountOption = {
   id: string;
   label: string;
@@ -106,7 +120,33 @@ export type AccountOption = {
   login?: ClaudeLoginView | null;
   /** Effective remaining capacity chip (min across quota windows), when known. */
   effective?: AccountEffective | null;
+  /** Session/weekly quota windows with reset times, when a read exists (issue #40). */
+  limits?: AccountLimits | null;
 };
+
+/** Crash-safe validation of one quota window. A malformed shape yields `null` so
+    a stray payload never breaks the account row. */
+function parseLimitWindow(raw: unknown): AccountLimitWindow | null {
+  if (typeof raw !== "object" || raw === null) return null;
+  const record = raw as Record<string, unknown>;
+  if (typeof record.usedPercent !== "number" || !Number.isFinite(record.usedPercent)) return null;
+  const resetsAt = typeof record.resetsAt === "number" && Number.isFinite(record.resetsAt) ? record.resetsAt : null;
+  return { usedPercent: record.usedPercent, resetsAt };
+}
+
+/** Crash-safe projection of the route's per-account `limits` block. An `unavailable`
+    (or absent) read yields `null` so the row shows no limits detail at all; a
+    fresh/stale read keeps whichever windows validated. */
+export function parseAccountLimits(raw: unknown): AccountLimits | null {
+  if (typeof raw !== "object" || raw === null) return null;
+  const record = raw as Record<string, unknown>;
+  const freshness = record.state === "fresh" ? "fresh" : record.state === "stale" ? "stale" : null;
+  if (!freshness) return null;
+  const session = parseLimitWindow(record.session);
+  const weekly = parseLimitWindow(record.weekly);
+  if (!session && !weekly) return null;
+  return { freshness, session, weekly };
+}
 export type AccountLoadState = "loading" | "ready" | "error";
 export type AccountOperation = "refresh" | "add" | "switch" | "login" | "remove";
 
@@ -233,12 +273,12 @@ function accountResponse(body: unknown, engine: Engine): EngineResponse {
   const section = (body as Record<string, unknown> | null)?.[engine] as { active?: unknown; accounts?: unknown; migration?: unknown; autoBalance?: unknown } | undefined;
   if (typeof section?.active !== "string" || !Array.isArray(section.accounts)) throw new Error("accounts response invalid");
   const accounts = section.accounts.map((raw): AccountOption => {
-    const account = raw as AccountOption & { effective?: unknown; login?: unknown };
+    const account = raw as AccountOption & { effective?: unknown; login?: unknown; limits?: unknown };
     const login = engine === "claude" ? parseClaudeLogin(account.login) : null;
     // The phase is authoritative for pending state (C3): a nonterminal login
     // keeps the row pending even when the server's raw `loginPending` lags.
     const loginPending = login ? NONTERMINAL_CLAUDE_LOGIN_PHASES.has(login.phase) : account.loginPending === true;
-    return { ...account, login, loginPending, effective: parseEffective(account.effective) };
+    return { ...account, login, loginPending, effective: parseEffective(account.effective), limits: parseAccountLimits(account.limits) };
   });
   return {
     active: section.active,

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -146,6 +146,7 @@ export const en = {
   "accounts.effectiveTip": "{window} binds",
   "accounts.effectiveStale": "{window} binds · stale",
   "accounts.limitsAria": "Quota windows for {label}",
+  "accounts.limitsStale": "Last known values",
   "accounts.limitsStaleTip": "Last known values — not a live read",
   // Claude sign-in slice (#61)
   "accounts.claudeLoginStarted": "Sign-in started for {label}",

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -145,6 +145,8 @@ export const en = {
   "accounts.effective": "{pct}%",
   "accounts.effectiveTip": "{window} binds",
   "accounts.effectiveStale": "{window} binds · stale",
+  "accounts.limitsAria": "Quota windows for {label}",
+  "accounts.limitsStaleTip": "Last known values — not a live read",
   // Claude sign-in slice (#61)
   "accounts.claudeLoginStarted": "Sign-in started for {label}",
   "accounts.claudeLogin.starting": "Starting sign-in…",

--- a/src/lib/i18n/uk.ts
+++ b/src/lib/i18n/uk.ts
@@ -140,6 +140,7 @@ export const uk: Record<keyof typeof en, Message> = {
   "accounts.effectiveTip": "{window} обмежує",
   "accounts.effectiveStale": "{window} обмежує · застаріло",
   "accounts.limitsAria": "Вікна лімітів для {label}",
+  "accounts.limitsStale": "Останні відомі значення",
   "accounts.limitsStaleTip": "Останні відомі значення — не наживо",
   // Claude sign-in slice (#61)
   "accounts.claudeLoginStarted": "Вхід для {label} розпочато",

--- a/src/lib/i18n/uk.ts
+++ b/src/lib/i18n/uk.ts
@@ -139,6 +139,8 @@ export const uk: Record<keyof typeof en, Message> = {
   "accounts.effective": "{pct}%",
   "accounts.effectiveTip": "{window} обмежує",
   "accounts.effectiveStale": "{window} обмежує · застаріло",
+  "accounts.limitsAria": "Вікна лімітів для {label}",
+  "accounts.limitsStaleTip": "Останні відомі значення — не наживо",
   // Claude sign-in slice (#61)
   "accounts.claudeLoginStarted": "Вхід для {label} розпочато",
   "accounts.claudeLogin.starting": "Починаємо вхід…",


### PR DESCRIPTION
## Summary

Finishes the Accounts UI tail of #40 (switch mechanism shipped in #110). The panel previously showed only a single combined **effective-remaining** chip per account. This surfaces each account's **session and weekly quota windows** with **remaining capacity and reset times**, so "which account has headroom, and when does it come back" reads at a glance — right where you switch.

## What changed

- **Per-account limits parsing** — the `/api/accounts` route already emits a per-account `limits` block (`session`/`weekly` with `usedPercent` + `resetsAt`), but the client dropped it. A crash-safe `parseAccountLimits` now projects it onto `AccountOption`, discarding `unavailable`/malformed reads.
- **Compact limits detail per row** — a two-line breakdown under each account: `5h  45% left · reset in 2h · 13:13` / `Week 92% left · reset in 3d · Jul 15 11:13`. Stale reads are dimmed and titled "Last known values"; a window with no reset time omits the reset line. The collapsed effective chip stays as the min-window summary.
- **Shared reset-time formatters** — `formatResetEta` / `formatResetClock` moved into `rateLimit.ts` so the limits footer and the accounts panel format reset times identically (no duplication).
- **English/Ukrainian parity** — two new keys (`accounts.limitsAria`, `accounts.limitsStaleTip`) added to both locales; the rest reuse existing `limits.*` copy.

Accessible semantics: the detail is a `<dl>` with a per-account `aria-label`; capacity/reset never lean on color alone.

## Issue #61 (Claude Add Account 503) — already resolved on this branch

The `LLV_ENABLE_CLAUDE_LOGIN` / `LLV_CLAUDE_LOGIN_POLICY_ACCEPTED` gates are gone. `POST /api/accounts/claude` returns **202** with a login operation; the remaining 503s are genuine child-process start-failure paths that carry sanitized copy + a Retry action (criterion #4). No change required.

## Verification

- `bun test` — **1534 pass**, 0 fail (169 files)
- `bunx tsc --noEmit` — clean
- `eslint` — clean
- SSR render spot-check confirms the detail, stale dimming, and missing-reset omission

New tests: `parseAccountLimits` unit cases + store parsing (`useEngineAccounts.test.ts`); fresh/stale render cases (`AccountsPanel.render.test.tsx`).

Refs #40, #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)