### PR TITLE
Quota burndown chart: ideal-pace vs actual consumption (Claude + Codex) (#36)

### DIFF
--- a/src/app/api/limits/history/route.ts
+++ b/src/app/api/limits/history/route.ts
@@ -1,0 +1,12 @@
+import { NextResponse } from "next/server";
+
+import { readBurndown } from "@/lib/limits";
+import type { BurndownPayload } from "@/lib/types";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+/** Burndown history for the quota chart: GET /api/limits/history */
+export async function GET(): Promise<NextResponse<BurndownPayload>> {
+  return NextResponse.json(await readBurndown());
+}

--- a/src/components/BurndownPanel.tsx
+++ b/src/components/BurndownPanel.tsx
@@ -4,6 +4,7 @@ import { useEffect, useRef, useState } from "react";
 
 import { computePace, idealRemaining, type WindowKey } from "@/lib/burndown";
 import { getLocale, useLocale } from "@/lib/i18n";
+import { handleOverlayEscape } from "@/lib/overlay";
 import type { BurndownPayload, BurndownSeries } from "@/lib/types";
 
 import { X } from "./icons";
@@ -136,7 +137,14 @@ export function BurndownPanel({
       : null;
 
   return (
-    <div className="fixed bottom-3 left-1/2 z-50 flex w-[min(430px,calc(100vw-16px))] -translate-x-1/2 flex-col rounded-[12px] border border-line bg-panel shadow-[0_8px_28px_rgba(20,20,30,0.14)] sm:absolute sm:bottom-1 sm:left-full sm:ml-2 sm:translate-x-0">
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label={t("burndown.openAria", { engine: label })}
+      tabIndex={-1}
+      onKeyDown={(event) => handleOverlayEscape(event, onClose)}
+      className="fixed bottom-3 left-1/2 z-50 flex w-[min(430px,calc(100vw-16px))] -translate-x-1/2 flex-col rounded-[12px] border border-line bg-panel shadow-[0_8px_28px_rgba(20,20,30,0.14)] sm:absolute sm:bottom-1 sm:left-full sm:ml-2 sm:translate-x-0"
+    >
       <header className="flex items-center gap-2 border-b border-line px-3 py-2">
         <span className="text-[12.5px] font-bold" style={{ color: tint }}>{label}</span>
         <span className="text-[11px] text-dim">{t("burndown.title")}</span>

--- a/src/components/BurndownPanel.tsx
+++ b/src/components/BurndownPanel.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useRef, useState } from "react";
 
-import { computePace, idealRemaining, type WindowKey } from "@/lib/burndown";
+import { burndownForActiveAccount, computePace, idealRemaining, type WindowKey } from "@/lib/burndown";
 import { getLocale, useLocale } from "@/lib/i18n";
 import { handleOverlayEscape } from "@/lib/overlay";
 import type { BurndownPayload, BurndownSeries } from "@/lib/types";
@@ -85,11 +85,15 @@ export function BurndownPanel({
   engine,
   label,
   plan,
+  activeAccountId,
   onClose,
 }: {
   engine: "claude" | "codex";
   label: string;
   plan: string | null;
+  /** The account the footer block is showing; a history response for any other
+      account is discarded so a switch never charts the previous account. */
+  activeAccountId: string;
   onClose: () => void;
 }) {
   const { t, locale } = useLocale();
@@ -103,6 +107,10 @@ export function BurndownPanel({
     closeRef.current?.focus();
   }, []);
 
+  // One fetch per mount. LimitsFooter keys this panel by the active account, so a
+  // switch remounts it and re-fetches with fresh state; the cleanup's `alive`
+  // flag drops a response that arrives after that switch. The render-time
+  // ownership gate below is the second guard for an in-flight account race.
   useEffect(() => {
     let alive = true;
     fetch("/api/limits/history")
@@ -118,7 +126,10 @@ export function BurndownPanel({
     };
   }, []);
 
-  const engineData = engine === "claude" ? data?.claude ?? null : data?.codex ?? null;
+  const engineData = burndownForActiveAccount(data, engine, activeAccountId);
+  // A response whose account stamp no longer matches is treated as not-yet-loaded
+  // so a stale-account curve never shows; the effect above will refetch.
+  const ownershipPending = Boolean(data && !engineData);
   const series = engineData ? engineData[window] : null;
   const tint = engineTintOf(engine).color;
   const hasData = Boolean(series && series.samples.length > 0);
@@ -178,7 +189,7 @@ export function BurndownPanel({
       <div className="px-3 py-2.5">
         {failed ? (
           <div className="py-6 text-center text-[12px] text-dim">{t("burndown.failed")}</div>
-        ) : !data ? (
+        ) : !data || ownershipPending ? (
           <div className="py-6 text-center text-[12px] text-dim">{t("burndown.loading")}</div>
         ) : hasData && series ? (
           <>

--- a/src/components/BurndownPanel.tsx
+++ b/src/components/BurndownPanel.tsx
@@ -1,0 +1,204 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+import { computePace, idealRemaining, type WindowKey } from "@/lib/burndown";
+import { getLocale, useLocale } from "@/lib/i18n";
+import type { BurndownPayload, BurndownSeries } from "@/lib/types";
+
+import { X } from "./icons";
+import { engineTintOf } from "./utils";
+
+const VB_W = 320;
+const VB_H = 150;
+const PAD = { l: 4, r: 4, t: 8, b: 4 };
+const PW = VB_W - PAD.l - PAD.r;
+const PH = VB_H - PAD.t - PAD.b;
+
+/** Same amber-<30% / red-<10% thresholds the footer bars use; above that the
+    curve keeps the engine's identity tint. */
+function paceColor(remaining: number, tint: string): string {
+  if (remaining <= 10) return "#c62828";
+  if (remaining <= 30) return "#d29a2f";
+  return tint;
+}
+
+function bcp47(): string {
+  return getLocale() === "uk" ? "uk-UA" : "en-US";
+}
+
+/** Short absolute moment for the depletion projection: hour today, else + date. */
+function fmtMoment(unix: number, now: number): string {
+  const d = new Date(unix * 1000);
+  const time = d.toLocaleTimeString(bcp47(), { hour: "2-digit", minute: "2-digit", hour12: false });
+  if (Math.abs(unix - now) < 86400) return time;
+  return d.toLocaleDateString(bcp47(), { day: "numeric", month: "short" }) + " " + time;
+}
+
+/** The SVG plot: ideal even-pace diagonal (dashed, muted) vs the actual
+    remaining-quota curve (solid, engine-tinted), with a "now" marker. Stretches
+    to the panel width; non-scaling strokes keep the lines crisp. */
+function BurndownChart({ series, tint, now }: { series: BurndownSeries; tint: string; now: number }) {
+  const { windowStart, resetsAt, windowSeconds, samples } = series;
+  const x0 = windowStart ?? samples[0]?.t ?? now - windowSeconds;
+  const x1 = resetsAt ?? Math.max(now, samples[samples.length - 1]?.t ?? now);
+  const span = x1 > x0 ? x1 - x0 : 1;
+  const xScale = (t: number) => PAD.l + (Math.max(x0, Math.min(x1, t)) - x0) / span * PW;
+  const yScale = (pct: number) => PAD.t + (100 - Math.max(0, Math.min(100, pct))) / 100 * PH;
+
+  const idealPath =
+    windowStart !== null && resetsAt !== null
+      ? `M ${xScale(windowStart).toFixed(2)},${yScale(idealRemaining(windowStart, resetsAt, x0)).toFixed(2)} L ${xScale(resetsAt).toFixed(2)},${yScale(idealRemaining(windowStart, resetsAt, x1)).toFixed(2)}`
+      : null;
+  const actualPath = samples.length
+    ? samples.map((s, i) => `${i === 0 ? "M" : "L"} ${xScale(s.t).toFixed(2)},${yScale(s.remaining).toFixed(2)}`).join(" ")
+    : null;
+  const latest = samples[samples.length - 1] ?? null;
+  const curveColor = latest ? paceColor(latest.remaining, tint) : tint;
+  const nowX = xScale(now);
+
+  return (
+    <svg viewBox={`0 0 ${VB_W} ${VB_H}`} preserveAspectRatio="none" className="h-[150px] w-full" role="img">
+      {/* Plot frame + 50% guide */}
+      <rect x={PAD.l} y={PAD.t} width={PW} height={PH} className="fill-none stroke-line" strokeWidth={1} vectorEffect="non-scaling-stroke" />
+      <line x1={PAD.l} y1={yScale(50)} x2={PAD.l + PW} y2={yScale(50)} className="stroke-line" strokeWidth={1} strokeDasharray="2 3" vectorEffect="non-scaling-stroke" opacity={0.6} />
+      {idealPath ? (
+        <path d={idealPath} className="fill-none stroke-dim" strokeWidth={1.5} strokeDasharray="4 3" vectorEffect="non-scaling-stroke" opacity={0.7} />
+      ) : null}
+      {actualPath ? (
+        <path d={actualPath} fill="none" stroke={curveColor} strokeWidth={2} strokeLinejoin="round" strokeLinecap="round" vectorEffect="non-scaling-stroke" />
+      ) : null}
+      {latest ? <circle cx={xScale(latest.t)} cy={yScale(latest.remaining)} r={2.5} fill={curveColor} vectorEffect="non-scaling-stroke" /> : null}
+      {now > x0 && now < x1 ? (
+        <line x1={nowX} y1={PAD.t} x2={nowX} y2={PAD.t + PH} className="stroke-accent" strokeWidth={1} strokeDasharray="1 2" vectorEffect="non-scaling-stroke" opacity={0.7} />
+      ) : null}
+    </svg>
+  );
+}
+
+/** Floating burndown panel for one engine, anchored off the rail like the
+    cleanup panel: ideal-pace vs actual-consumption for the 5h and weekly
+    windows. Opened from {@link LimitsFooter}; closed via ✕/Esc/outside click
+    (owned by the caller). */
+export function BurndownPanel({
+  engine,
+  label,
+  plan,
+  onClose,
+}: {
+  engine: "claude" | "codex";
+  label: string;
+  plan: string | null;
+  onClose: () => void;
+}) {
+  const { t, locale } = useLocale();
+  const [data, setData] = useState<BurndownPayload | null>(null);
+  const [failed, setFailed] = useState(false);
+  const [window, setWindow] = useState<WindowKey>("weekly");
+  const [now] = useState(() => Math.round(Date.now() / 1000));
+  const closeRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    closeRef.current?.focus();
+  }, []);
+
+  useEffect(() => {
+    let alive = true;
+    fetch("/api/limits/history")
+      .then((res) => (res.ok ? (res.json() as Promise<BurndownPayload>) : Promise.reject(new Error(String(res.status)))))
+      .then((json) => {
+        if (alive) setData(json);
+      })
+      .catch(() => {
+        if (alive) setFailed(true);
+      });
+    return () => {
+      alive = false;
+    };
+  }, []);
+
+  const engineData = engine === "claude" ? data?.claude ?? null : data?.codex ?? null;
+  const series = engineData ? engineData[window] : null;
+  const tint = engineTintOf(engine).color;
+  const hasData = Boolean(series && series.samples.length > 0);
+  const pace = series ? computePace(series, now) : null;
+
+  const paceText = (() => {
+    if (!pace) return null;
+    if (pace.delta < -2) return t("burndown.fast", { pct: Math.round(-pace.delta) });
+    if (pace.delta > 2) return t("burndown.slow", { pct: Math.round(pace.delta) });
+    return t("burndown.even");
+  })();
+  const projectText = pace?.zeroCrossing ? t("burndown.emptyBy", { at: fmtMoment(pace.zeroCrossing, now) }) : null;
+  const sinceText =
+    engine === "claude" && !hasData && data?.historySince
+      ? t("burndown.buildsFrom", { date: new Date(data.historySince).toLocaleDateString(locale === "uk" ? "uk-UA" : "en-US", { day: "numeric", month: "short" }) })
+      : null;
+
+  return (
+    <div className="fixed bottom-3 left-1/2 z-50 flex w-[min(430px,calc(100vw-16px))] -translate-x-1/2 flex-col rounded-[12px] border border-line bg-panel shadow-[0_8px_28px_rgba(20,20,30,0.14)] sm:absolute sm:bottom-1 sm:left-full sm:ml-2 sm:translate-x-0">
+      <header className="flex items-center gap-2 border-b border-line px-3 py-2">
+        <span className="text-[12.5px] font-bold" style={{ color: tint }}>{label}</span>
+        <span className="text-[11px] text-dim">{t("burndown.title")}</span>
+        {plan ? <span className="truncate text-[10px] text-dim">{plan}</span> : null}
+        <div className="ml-auto flex items-center gap-1">
+          <div className="flex rounded-[8px] border border-line p-0.5" role="tablist" aria-label={t("burndown.windowAria")}>
+            {(["weekly", "session"] as const).map((key) => (
+              <button
+                key={key}
+                type="button"
+                role="tab"
+                aria-selected={window === key}
+                onClick={() => setWindow(key)}
+                className={`rounded-[6px] px-2 py-0.5 text-[10.5px] font-semibold focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 ${window === key ? "bg-chip text-ink" : "text-dim hover:text-ink"}`}
+              >
+                {t(key === "weekly" ? "limits.week" : "limits.5h")}
+              </button>
+            ))}
+          </div>
+          <button
+            ref={closeRef}
+            type="button"
+            aria-label={t("burndown.close")}
+            onClick={onClose}
+            className="rounded-[6px] p-1 text-dim hover:bg-bg hover:text-ink focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40"
+          >
+            <X className="h-3.5 w-3.5" aria-hidden />
+          </button>
+        </div>
+      </header>
+      <div className="px-3 py-2.5">
+        {failed ? (
+          <div className="py-6 text-center text-[12px] text-dim">{t("burndown.failed")}</div>
+        ) : !data ? (
+          <div className="py-6 text-center text-[12px] text-dim">{t("burndown.loading")}</div>
+        ) : hasData && series ? (
+          <>
+            <BurndownChart series={series} tint={tint} now={now} />
+            <div className="mt-1.5 flex items-center justify-between text-[10px] text-dim">
+              <span className="flex items-center gap-1">
+                <span className="inline-block h-0 w-3 border-t-2 border-dashed border-dim" aria-hidden />
+                {t("burndown.ideal")}
+              </span>
+              <span className="flex items-center gap-1">
+                <span className="inline-block h-0 w-3 border-t-2" style={{ borderColor: tint }} aria-hidden />
+                {t("burndown.actual")}
+              </span>
+            </div>
+            {paceText ? (
+              <div className="mt-2 text-[11.5px] font-semibold text-ink">
+                {paceText}
+                {projectText ? <span className="ml-1 font-normal text-dim">· {projectText}</span> : null}
+              </div>
+            ) : null}
+          </>
+        ) : (
+          <div className="py-6 text-center text-[12px] text-dim">
+            {t("burndown.empty")}
+            {sinceText ? <div className="mt-1 text-[11px]">{sinceText}</div> : null}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/LimitsFooter.tsx
+++ b/src/components/LimitsFooter.tsx
@@ -7,6 +7,7 @@ import { getLocale, type Locale, translate, useLocale } from "@/lib/i18n";
 import type { EngineLimits, LimitsPayload, LimitWindow } from "@/lib/types";
 
 import { AccountsPanel } from "./AccountsPanel";
+import { BurndownPanel } from "./BurndownPanel";
 import { ChevronDown, Loader2 } from "./icons";
 import { engineTintOf, fmtAge } from "./utils";
 
@@ -196,6 +197,7 @@ function EngineLimitsBlock({
   const { t } = useLocale();
   const accounts = useEngineAccounts(engine);
   const [open, setOpen] = useState(false);
+  const [chartOpen, setChartOpen] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
   const triggerRef = useRef<HTMLButtonElement>(null);
   const identityVersion = useRef(accounts.identityVersion);
@@ -217,6 +219,25 @@ function EngineLimitsBlock({
     window.addEventListener("pointerdown", onDown);
     return () => window.removeEventListener("pointerdown", onDown);
   }, [open]);
+
+  // The burndown chart owns its own dismissal (Esc + outside pointer), mirroring
+  // ResourcesFooter's cleanup panel. It renders inside containerRef, so clicks
+  // inside the chart are "contained" and never self-close it.
+  useEffect(() => {
+    if (!chartOpen) return;
+    const onKey = (event: KeyboardEvent) => {
+      if (event.key === "Escape") setChartOpen(false);
+    };
+    const onDown = (event: PointerEvent) => {
+      if (containerRef.current && !containerRef.current.contains(event.target as Node)) setChartOpen(false);
+    };
+    window.addEventListener("keydown", onKey);
+    window.addEventListener("pointerdown", onDown);
+    return () => {
+      window.removeEventListener("keydown", onKey);
+      window.removeEventListener("pointerdown", onDown);
+    };
+  }, [chartOpen]);
 
   // Every mounted account surface of this engine shares one store. A version
   // bump arrives for both the compact Switchboard selector and the footer panel,
@@ -241,49 +262,65 @@ function EngineLimitsBlock({
 
   return (
     <div ref={containerRef} className="relative">
-      <button
-        ref={triggerRef}
-        type="button"
-        aria-expanded={open}
-        aria-haspopup="dialog"
-        aria-label={t("accounts.triggerAria", { engine: label })}
-        onClick={() => setOpen((value) => !value)}
-        className={`block w-full px-3.5 pb-3 pt-2.5 text-left hover:bg-bg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 ${staleHint ? "opacity-60" : ""}`}
-      >
-        <div className="flex items-center gap-1.5">
-          <span className="text-[11.5px] font-bold" style={{ color: tint.color }}>{label}</span>
-          {accountLimits?.plan ? <span className="truncate text-[10px] text-dim">{accountLimits.plan}</span> : null}
-          {staleHint ? <span className="truncate text-[10px] text-dim">{staleHint}</span> : null}
-          {stale ? <span className="h-1.5 w-1.5 shrink-0 self-center rounded-full bg-[#d29a2f]" title={t("limits.stale", { stale })} /> : null}
-          <span className="ml-auto flex shrink-0 items-center gap-1">
-            {effective && effective.freshness !== "unavailable" ? (
-              <span
-                className={`rounded-full border border-line bg-bg px-1.5 py-0.5 text-[9.5px] font-bold tabular-nums ${effective.freshness === "stale" ? "opacity-55" : ""}`}
-                style={{ color: barColor(effective.percent, tint.color) }}
-              >
-                {t("accounts.effective", { pct: Math.round(effective.percent) })}
+      <div className={staleHint ? "opacity-60" : ""}>
+        <button
+          ref={triggerRef}
+          type="button"
+          aria-expanded={open}
+          aria-haspopup="dialog"
+          aria-label={t("accounts.triggerAria", { engine: label })}
+          onClick={() => {
+            setChartOpen(false);
+            setOpen((value) => !value);
+          }}
+          className="block w-full px-3.5 pb-1.5 pt-2.5 text-left hover:bg-bg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40"
+        >
+          <div className="flex items-center gap-1.5">
+            <span className="text-[11.5px] font-bold" style={{ color: tint.color }}>{label}</span>
+            {accountLimits?.plan ? <span className="truncate text-[10px] text-dim">{accountLimits.plan}</span> : null}
+            {staleHint ? <span className="truncate text-[10px] text-dim">{staleHint}</span> : null}
+            {stale ? <span className="h-1.5 w-1.5 shrink-0 self-center rounded-full bg-[#d29a2f]" title={t("limits.stale", { stale })} /> : null}
+            <span className="ml-auto flex shrink-0 items-center gap-1">
+              {effective && effective.freshness !== "unavailable" ? (
+                <span
+                  className={`rounded-full border border-line bg-bg px-1.5 py-0.5 text-[9.5px] font-bold tabular-nums ${effective.freshness === "stale" ? "opacity-55" : ""}`}
+                  style={{ color: barColor(effective.percent, tint.color) }}
+                >
+                  {t("accounts.effective", { pct: Math.round(effective.percent) })}
+                </span>
+              ) : null}
+              <span className="flex items-center gap-0.5 rounded-full border border-line bg-bg px-1.5 py-0.5 text-[10px] font-semibold text-ink">
+                <span className="max-w-24 truncate">{activeLabel}</span>
+                {draining ? (
+                  <Loader2 className="h-3 w-3 animate-spin motion-reduce:animate-none text-accent" aria-hidden />
+                ) : (
+                  <ChevronDown className="h-3 w-3 text-dim" aria-hidden />
+                )}
               </span>
-            ) : null}
-            <span className="flex items-center gap-0.5 rounded-full border border-line bg-bg px-1.5 py-0.5 text-[10px] font-semibold text-ink">
-              <span className="max-w-24 truncate">{activeLabel}</span>
-              {draining ? (
-                <Loader2 className="h-3 w-3 animate-spin motion-reduce:animate-none text-accent" aria-hidden />
-              ) : (
-                <ChevronDown className="h-3 w-3 text-dim" aria-hidden />
-              )}
             </span>
-          </span>
-        </div>
+          </div>
+        </button>
         {hasWindows ? (
-          <>
+          <button
+            type="button"
+            aria-expanded={chartOpen}
+            aria-haspopup="dialog"
+            aria-label={t("burndown.openAria", { engine: label })}
+            onClick={() => {
+              setOpen(false);
+              setChartOpen((value) => !value);
+            }}
+            className="block w-full px-3.5 pb-3 pt-0.5 text-left hover:bg-bg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40"
+          >
             <LimitRow label={t("limits.5h")} window={accountLimits!.session} engineColor={tint.color} now={now} />
             <LimitRow label={t("limits.week")} window={accountLimits!.weekly} engineColor={tint.color} now={now} />
-          </>
+          </button>
         ) : (
-          <div className="mt-1.5 text-[10px] text-dim">{accounts.status === "loading" || identityPending ? t("limits.accountLoading") : t("limits.noDataYet")}</div>
+          <div className="px-3.5 pb-3 pt-0.5 text-[10px] text-dim">{accounts.status === "loading" || identityPending ? t("limits.accountLoading") : t("limits.noDataYet")}</div>
         )}
-      </button>
+      </div>
       {open ? <AccountsPanel state={accounts} onClose={close} /> : null}
+      {chartOpen ? <BurndownPanel engine={engine} label={label} plan={accountLimits?.plan ?? null} onClose={() => setChartOpen(false)} /> : null}
     </div>
   );
 }

--- a/src/components/LimitsFooter.tsx
+++ b/src/components/LimitsFooter.tsx
@@ -200,11 +200,17 @@ function EngineLimitsBlock({
   const [chartOpen, setChartOpen] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
   const triggerRef = useRef<HTMLButtonElement>(null);
+  const chartTriggerRef = useRef<HTMLButtonElement>(null);
   const identityVersion = useRef(accounts.identityVersion);
 
   const close = () => {
     setOpen(false);
     triggerRef.current?.focus();
+  };
+
+  const closeChart = () => {
+    setChartOpen(false);
+    chartTriggerRef.current?.focus();
   };
 
   // Outside-pointer close only. Escape is owned by the panel's dialog subtree
@@ -220,23 +226,18 @@ function EngineLimitsBlock({
     return () => window.removeEventListener("pointerdown", onDown);
   }, [open]);
 
-  // The burndown chart owns its own dismissal (Esc + outside pointer), mirroring
-  // ResourcesFooter's cleanup panel. It renders inside containerRef, so clicks
-  // inside the chart are "contained" and never self-close it.
+  // Outside-pointer close only. Escape is owned by the chart's own dialog subtree
+  // (BurndownPanel routes it through handleOverlayEscape), so it never races the
+  // project drawer's window Escape handler — one press closes only the chart.
+  // The panel renders inside containerRef, so clicks inside it are "contained"
+  // and never self-close it.
   useEffect(() => {
     if (!chartOpen) return;
-    const onKey = (event: KeyboardEvent) => {
-      if (event.key === "Escape") setChartOpen(false);
-    };
     const onDown = (event: PointerEvent) => {
       if (containerRef.current && !containerRef.current.contains(event.target as Node)) setChartOpen(false);
     };
-    window.addEventListener("keydown", onKey);
     window.addEventListener("pointerdown", onDown);
-    return () => {
-      window.removeEventListener("keydown", onKey);
-      window.removeEventListener("pointerdown", onDown);
-    };
+    return () => window.removeEventListener("pointerdown", onDown);
   }, [chartOpen]);
 
   // Every mounted account surface of this engine shares one store. A version
@@ -302,6 +303,7 @@ function EngineLimitsBlock({
         </button>
         {hasWindows ? (
           <button
+            ref={chartTriggerRef}
             type="button"
             aria-expanded={chartOpen}
             aria-haspopup="dialog"
@@ -320,7 +322,7 @@ function EngineLimitsBlock({
         )}
       </div>
       {open ? <AccountsPanel state={accounts} onClose={close} /> : null}
-      {chartOpen ? <BurndownPanel engine={engine} label={label} plan={accountLimits?.plan ?? null} onClose={() => setChartOpen(false)} /> : null}
+      {chartOpen ? <BurndownPanel engine={engine} label={label} plan={accountLimits?.plan ?? null} onClose={closeChart} /> : null}
     </div>
   );
 }

--- a/src/components/LimitsFooter.tsx
+++ b/src/components/LimitsFooter.tsx
@@ -322,7 +322,7 @@ function EngineLimitsBlock({
         )}
       </div>
       {open ? <AccountsPanel state={accounts} onClose={close} /> : null}
-      {chartOpen ? <BurndownPanel engine={engine} label={label} plan={accountLimits?.plan ?? null} onClose={closeChart} /> : null}
+      {chartOpen ? <BurndownPanel key={accounts.active} engine={engine} label={label} plan={accountLimits?.plan ?? null} activeAccountId={accounts.active} onClose={closeChart} /> : null}
     </div>
   );
 }

--- a/src/lib/burndown.test.ts
+++ b/src/lib/burndown.test.ts
@@ -80,6 +80,34 @@ test("computePace suppresses the projection when the quota is climbing (a refill
   expect(pace!.zeroCrossing).toBeNull();
 });
 
+test("computePace suppresses the projection for a mid-window refill even when it ends below the start", () => {
+  const third = week / 3;
+  // 80 → 20 → 60: net drop is positive, but the 20 → 60 rise is a refill.
+  const pace = computePace(
+    series([
+      { t: start, remaining: 80 },
+      { t: start + third, remaining: 20 },
+      { t: start + 2 * third, remaining: 60 },
+    ]),
+    start + 2 * third,
+  );
+  expect(pace!.zeroCrossing).toBeNull();
+});
+
+test("computePace tolerates sub-epsilon sampling jitter on a draining series", () => {
+  const day = 86_400;
+  const pace = computePace(
+    series([
+      { t: start, remaining: 60 },
+      { t: start + day, remaining: 39.8 },
+      { t: start + 2 * day, remaining: 40.1 }, // +0.3 rise, within jitter tolerance
+      { t: start + 3 * day, remaining: 39.5 },
+    ]),
+    start + 3 * day,
+  );
+  expect(pace!.zeroCrossing).not.toBeNull();
+});
+
 test("computePace projects from the observed slope, not an assumed full start", () => {
   // Never hit 100%: 60% → 40% over a day → 2%/half-day, so ~20 half-days to 0.
   const day = 86_400;

--- a/src/lib/burndown.test.ts
+++ b/src/lib/burndown.test.ts
@@ -1,11 +1,43 @@
 import { expect, test } from "bun:test";
 
-import { computePace, idealRemaining, mergeSamples, WINDOW_SECONDS } from "./burndown";
-import type { BurndownSeries } from "./types";
+import { burndownForActiveAccount, computePace, idealRemaining, mergeSamples, WINDOW_SECONDS } from "./burndown";
+import type { BurndownPayload, BurndownSeries, EngineBurndown } from "./types";
 
 const start = 1_000_000;
 const week = WINDOW_SECONDS.weekly;
 const reset = start + week;
+
+const emptyEngine = (): EngineBurndown => ({
+  session: { windowStart: null, resetsAt: null, windowSeconds: WINDOW_SECONDS.session, samples: [] },
+  weekly: { windowStart: null, resetsAt: null, windowSeconds: WINDOW_SECONDS.weekly, samples: [] },
+});
+
+const burndownPayload = (over: Partial<BurndownPayload> = {}): BurndownPayload => ({
+  claude: emptyEngine(),
+  codex: emptyEngine(),
+  claudeAccountId: "claude-a",
+  codexAccountId: "codex-a",
+  historySince: null,
+  ...over,
+});
+
+test("burndownForActiveAccount returns the engine series when the account stamp matches", () => {
+  const payload = burndownPayload();
+  expect(burndownForActiveAccount(payload, "claude", "claude-a")).toBe(payload.claude);
+  expect(burndownForActiveAccount(payload, "codex", "codex-a")).toBe(payload.codex);
+});
+
+test("burndownForActiveAccount masks a response whose account stamp changed (post-switch race)", () => {
+  const payload = burndownPayload();
+  expect(burndownForActiveAccount(payload, "claude", "claude-b")).toBeNull();
+  expect(burndownForActiveAccount(payload, "codex", "codex-b")).toBeNull();
+});
+
+test("burndownForActiveAccount masks on a null payload or empty active id", () => {
+  expect(burndownForActiveAccount(null, "claude", "claude-a")).toBeNull();
+  expect(burndownForActiveAccount(burndownPayload({ claudeAccountId: null }), "claude", "claude-a")).toBeNull();
+  expect(burndownForActiveAccount(burndownPayload(), "claude", "")).toBeNull();
+});
 
 test("idealRemaining runs a straight 100→0 line across the window", () => {
   expect(idealRemaining(start, reset, start)).toBe(100);

--- a/src/lib/burndown.test.ts
+++ b/src/lib/burndown.test.ts
@@ -1,0 +1,69 @@
+import { expect, test } from "bun:test";
+
+import { computePace, idealRemaining, mergeSamples, WINDOW_SECONDS } from "./burndown";
+import type { BurndownSeries } from "./types";
+
+const start = 1_000_000;
+const week = WINDOW_SECONDS.weekly;
+const reset = start + week;
+
+test("idealRemaining runs a straight 100→0 line across the window", () => {
+  expect(idealRemaining(start, reset, start)).toBe(100);
+  expect(idealRemaining(start, reset, reset)).toBe(0);
+  expect(idealRemaining(start, reset, start + week / 2)).toBeCloseTo(50, 5);
+});
+
+test("idealRemaining clamps outside the window and guards a zero-length window", () => {
+  expect(idealRemaining(start, reset, start - 999)).toBe(100);
+  expect(idealRemaining(start, reset, reset + 999)).toBe(0);
+  expect(idealRemaining(start, start, start)).toBe(0);
+});
+
+test("mergeSamples dedupes by second, keeping the last value, and sorts ascending", () => {
+  const merged = mergeSamples(
+    [{ t: 30, remaining: 90 }, { t: 10, remaining: 100 }],
+    [{ t: 30, remaining: 80 }, { t: 20, remaining: 95 }],
+  );
+  expect(merged).toEqual([
+    { t: 10, remaining: 100 },
+    { t: 20, remaining: 95 },
+    { t: 30, remaining: 80 },
+  ]);
+});
+
+const series = (samples: BurndownSeries["samples"]): BurndownSeries => ({
+  windowStart: start,
+  resetsAt: reset,
+  windowSeconds: week,
+  samples,
+});
+
+test("computePace flags burning ahead of pace when the curve sits below the diagonal", () => {
+  // Halfway through the window the ideal says 50% left; the user has 30%.
+  const now = start + week / 2;
+  const pace = computePace(series([{ t: start, remaining: 100 }, { t: now, remaining: 30 }]), now);
+  expect(pace).not.toBeNull();
+  expect(pace!.ideal).toBeCloseTo(50, 5);
+  expect(pace!.actual).toBe(30);
+  expect(pace!.delta).toBeCloseTo(-20, 5);
+  // Consumed 70% over half a week → hits 0 well before the reset.
+  expect(pace!.zeroCrossing).not.toBeNull();
+  expect(pace!.zeroCrossing! - now).toBeCloseTo((30 / 70) * (week / 2), 0);
+  expect(pace!.zeroCrossing!).toBeLessThan(reset);
+});
+
+test("computePace reports underuse when the curve sits above the diagonal", () => {
+  const now = start + week / 2;
+  const pace = computePace(series([{ t: start, remaining: 100 }, { t: now, remaining: 80 }]), now);
+  expect(pace!.delta).toBeCloseTo(30, 5);
+});
+
+test("computePace returns null without a defined window or any samples", () => {
+  expect(computePace({ windowStart: null, resetsAt: reset, windowSeconds: week, samples: [{ t: 1, remaining: 5 }] }, 1)).toBeNull();
+  expect(computePace(series([]), start)).toBeNull();
+});
+
+test("computePace leaves zeroCrossing null when nothing has been consumed", () => {
+  const pace = computePace(series([{ t: start, remaining: 100 }]), start);
+  expect(pace!.zeroCrossing).toBeNull();
+});

--- a/src/lib/burndown.test.ts
+++ b/src/lib/burndown.test.ts
@@ -67,3 +67,23 @@ test("computePace leaves zeroCrossing null when nothing has been consumed", () =
   const pace = computePace(series([{ t: start, remaining: 100 }]), start);
   expect(pace!.zeroCrossing).toBeNull();
 });
+
+test("computePace suppresses the projection for a flat series", () => {
+  const now = start + week / 2;
+  const pace = computePace(series([{ t: start, remaining: 50 }, { t: now, remaining: 50 }]), now);
+  expect(pace!.zeroCrossing).toBeNull();
+});
+
+test("computePace suppresses the projection when the quota is climbing (a refill)", () => {
+  const now = start + week / 2;
+  const pace = computePace(series([{ t: start, remaining: 30 }, { t: now, remaining: 60 }]), now);
+  expect(pace!.zeroCrossing).toBeNull();
+});
+
+test("computePace projects from the observed slope, not an assumed full start", () => {
+  // Never hit 100%: 60% → 40% over a day → 2%/half-day, so ~20 half-days to 0.
+  const day = 86_400;
+  const pace = computePace(series([{ t: start, remaining: 60 }, { t: start + day, remaining: 40 }]), start + day);
+  // 40% remaining at 20%/day → 2 more days.
+  expect(pace!.zeroCrossing! - (start + day)).toBeCloseTo(2 * day, 0);
+});

--- a/src/lib/burndown.ts
+++ b/src/lib/burndown.ts
@@ -46,12 +46,20 @@ export interface PaceSummary {
   zeroCrossing: number | null;
 }
 
+/** A consecutive rise beyond this (percentage points) counts as a refill rather
+    than sampling jitter on an otherwise draining series. */
+const REFILL_EPSILON = 0.5;
+
 /** Projects when the quota hits 0% from the slope of the *observed* samples
     (first → latest of the window), not an assumed full start. Returns null when
-    the series is flat or the quota is climbing (a refill), so a steady 50%→50%
-    or a mid-window reset never produces a bogus "empty by …" forecast. */
+    the series is flat, ends higher than it started, or contains any mid-series
+    rise (a refill / window reset), so neither a steady 50%→50% nor an
+    80→20→60 replenishment ever produces a bogus "empty by …" forecast. */
 function projectZeroCrossing(samples: LimitSample[], actual: number): number | null {
   if (samples.length < 2) return null;
+  for (let i = 1; i < samples.length; i++) {
+    if (samples[i].remaining > samples[i - 1].remaining + REFILL_EPSILON) return null;
+  }
   const first = samples[0];
   const last = samples[samples.length - 1];
   const dt = last.t - first.t;

--- a/src/lib/burndown.ts
+++ b/src/lib/burndown.ts
@@ -46,8 +46,22 @@ export interface PaceSummary {
   zeroCrossing: number | null;
 }
 
+/** Projects when the quota hits 0% from the slope of the *observed* samples
+    (first → latest of the window), not an assumed full start. Returns null when
+    the series is flat or the quota is climbing (a refill), so a steady 50%→50%
+    or a mid-window reset never produces a bogus "empty by …" forecast. */
+function projectZeroCrossing(samples: LimitSample[], actual: number): number | null {
+  if (samples.length < 2) return null;
+  const first = samples[0];
+  const last = samples[samples.length - 1];
+  const dt = last.t - first.t;
+  const drop = first.remaining - last.remaining; // positive = quota being spent
+  if (dt <= 0 || drop <= 0) return null;
+  return last.t + actual / (drop / dt);
+}
+
 /** Pace read for the current window: compares the latest actual sample against
-    the ideal diagonal and projects the observed slope to zero. */
+    the ideal diagonal and projects the observed consumption slope to zero. */
 export function computePace(series: BurndownSeries, now: number): PaceSummary | null {
   const { windowStart, resetsAt, samples } = series;
   if (windowStart === null || resetsAt === null || samples.length === 0) return null;
@@ -55,12 +69,5 @@ export function computePace(series: BurndownSeries, now: number): PaceSummary | 
   const actual = clampPercent(latest.remaining);
   const clampedNow = Math.min(Math.max(now, windowStart), resetsAt);
   const ideal = idealRemaining(windowStart, resetsAt, clampedNow);
-  const elapsed = latest.t - windowStart;
-  const consumed = 100 - actual;
-  let zeroCrossing: number | null = null;
-  if (elapsed > 0 && consumed > 0) {
-    const ratePerSecond = consumed / elapsed;
-    zeroCrossing = latest.t + actual / ratePerSecond;
-  }
-  return { ideal, actual, delta: actual - ideal, zeroCrossing };
+  return { ideal, actual, delta: actual - ideal, zeroCrossing: projectZeroCrossing(samples, actual) };
 }

--- a/src/lib/burndown.ts
+++ b/src/lib/burndown.ts
@@ -1,0 +1,66 @@
+import type { BurndownSeries, LimitSample } from "./types";
+
+/** Standard window lengths in seconds. Codex transcripts can carry an exact
+    `window_minutes`, which overrides these when present. */
+export const WINDOW_SECONDS = { session: 5 * 3600, weekly: 7 * 24 * 3600 } as const;
+
+export type WindowKey = keyof typeof WINDOW_SECONDS;
+
+/** Clamp a percentage into the drawable 0–100 range. */
+export function clampPercent(value: number): number {
+  return Math.max(0, Math.min(100, value));
+}
+
+/** Ideal even-pace remaining % at time `t`: 100 at `windowStart`, 0 at
+    `resetsAt`. Spending exactly this fast lands on empty right at the reset. */
+export function idealRemaining(windowStart: number, resetsAt: number, t: number): number {
+  if (resetsAt <= windowStart) return 0;
+  const frac = (resetsAt - t) / (resetsAt - windowStart);
+  return clampPercent(frac * 100);
+}
+
+/** Merge two sample streams into one oldest-first series, collapsing points
+    that share the same second (the live "now" point coincides with a forward
+    sample, forward polls can coincide with a transcript event). */
+export function mergeSamples(...streams: LimitSample[][]): LimitSample[] {
+  const byT = new Map<number, number>();
+  for (const stream of streams) {
+    for (const sample of stream) {
+      if (!Number.isFinite(sample.t) || !Number.isFinite(sample.remaining)) continue;
+      byT.set(sample.t, clampPercent(sample.remaining));
+    }
+  }
+  return [...byT.entries()].map(([t, remaining]) => ({ t, remaining })).sort((a, b) => a.t - b.t);
+}
+
+export interface PaceSummary {
+  /** Where even pace says the user should be right now (% remaining). */
+  ideal: number;
+  /** Where the user actually is (latest sample, % remaining). */
+  actual: number;
+  /** actual − ideal. Positive = above the diagonal (underusing / safe);
+      negative = below it (burning ahead of pace). */
+  delta: number;
+  /** Unix seconds the current slope projects quota to hit 0%, or null when the
+      window is not depleting (flat or refilled) or the start is unknown. */
+  zeroCrossing: number | null;
+}
+
+/** Pace read for the current window: compares the latest actual sample against
+    the ideal diagonal and projects the observed slope to zero. */
+export function computePace(series: BurndownSeries, now: number): PaceSummary | null {
+  const { windowStart, resetsAt, samples } = series;
+  if (windowStart === null || resetsAt === null || samples.length === 0) return null;
+  const latest = samples[samples.length - 1];
+  const actual = clampPercent(latest.remaining);
+  const clampedNow = Math.min(Math.max(now, windowStart), resetsAt);
+  const ideal = idealRemaining(windowStart, resetsAt, clampedNow);
+  const elapsed = latest.t - windowStart;
+  const consumed = 100 - actual;
+  let zeroCrossing: number | null = null;
+  if (elapsed > 0 && consumed > 0) {
+    const ratePerSecond = consumed / elapsed;
+    zeroCrossing = latest.t + actual / ratePerSecond;
+  }
+  return { ideal, actual, delta: actual - ideal, zeroCrossing };
+}

--- a/src/lib/burndown.ts
+++ b/src/lib/burndown.ts
@@ -1,10 +1,22 @@
-import type { BurndownSeries, LimitSample } from "./types";
+import type { BurndownPayload, BurndownSeries, EngineBurndown, LimitSample } from "./types";
 
 /** Standard window lengths in seconds. Codex transcripts can carry an exact
     `window_minutes`, which overrides these when present. */
 export const WINDOW_SECONDS = { session: 5 * 3600, weekly: 7 * 24 * 3600 } as const;
 
 export type WindowKey = keyof typeof WINDOW_SECONDS;
+
+/** Ownership gate for the burndown chart, mirroring LimitsFooter's
+    `limitsForActiveAccount`: an account switch can let a history request started
+    for the previous account resolve after the switch, so its series is used only
+    when the payload's account stamp still matches the active account. A mismatch
+    (or a null/empty stamp) masks the data instead of charting the wrong account. */
+export function burndownForActiveAccount(payload: BurndownPayload | null, engine: "claude" | "codex", activeAccountId: string): EngineBurndown | null {
+  if (!payload || !activeAccountId) return null;
+  const payloadAccountId = engine === "claude" ? payload.claudeAccountId : payload.codexAccountId;
+  if (payloadAccountId !== activeAccountId) return null;
+  return engine === "claude" ? payload.claude : payload.codex;
+}
 
 /** Clamp a percentage into the drawable 0–100 range. */
 export function clampPercent(value: number): number {

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -840,6 +840,22 @@ export const en = {
   "limits.accountsOpenAria": "Codex accounts — switch or add",
   "limits.noDataYet": "no data yet",
 
+  // Burndown chart (issue #36)
+  "burndown.title": "burndown",
+  "burndown.openAria": "Open {engine} burndown chart",
+  "burndown.close": "Close chart",
+  "burndown.windowAria": "Chart window",
+  "burndown.ideal": "even pace",
+  "burndown.actual": "remaining",
+  "burndown.loading": "Loading history…",
+  "burndown.failed": "Couldn't load history.",
+  "burndown.empty": "No history yet — the chart fills in as quota is sampled.",
+  "burndown.buildsFrom": "history builds from {date}",
+  "burndown.fast": "{pct}% ahead of pace — burning fast",
+  "burndown.slow": "{pct}% under pace — room to spare",
+  "burndown.even": "on even pace",
+  "burndown.emptyBy": "at this rate, 0% by {at}",
+
   // ResourcesFooter
   "resources.ram": "RAM",
   "resources.swap": "Swap",

--- a/src/lib/i18n/uk.ts
+++ b/src/lib/i18n/uk.ts
@@ -807,6 +807,22 @@ export const uk: Record<keyof typeof en, Message> = {
   "limits.accountsOpenAria": "Акаунти Codex — змінити або додати",
   "limits.noDataYet": "поки немає даних",
 
+  // Burndown chart (issue #36)
+  "burndown.title": "витрати",
+  "burndown.openAria": "Відкрити графік витрати квоти {engine}",
+  "burndown.close": "Закрити графік",
+  "burndown.windowAria": "Вікно графіка",
+  "burndown.ideal": "рівний темп",
+  "burndown.actual": "лишок",
+  "burndown.loading": "Завантаження історії…",
+  "burndown.failed": "Не вдалося завантажити історію.",
+  "burndown.empty": "Історії ще немає — графік заповнюється в міру збору даних.",
+  "burndown.buildsFrom": "історія від {date}",
+  "burndown.fast": "на {pct}% швидше за рівний темп — витрачаєте зашвидко",
+  "burndown.slow": "на {pct}% повільніше за рівний темп — є запас",
+  "burndown.even": "рівний темп",
+  "burndown.emptyBy": "за таким темпом 0% до {at}",
+
   // ResourcesFooter
   "resources.ram": "RAM",
   "resources.swap": "Swap",

--- a/src/lib/limits.ts
+++ b/src/lib/limits.ts
@@ -475,8 +475,9 @@ export function collectCodexRateLimitSeries(sessionsDir: string, sinceUnix: numb
 }
 
 /** Assemble one window's burndown from forward poll samples, an optional
-    transcript backfill and the current live value, scoped to the current window. */
-function buildSeries(
+    transcript backfill and the current live value, scoped to the current window.
+    Exported for the window-scoping regression test. */
+export function buildSeries(
   forward: LimitSample[],
   backfill: LimitSample[],
   live: LimitWindow | null,
@@ -488,8 +489,12 @@ function buildSeries(
   const windowStart = resetsAt !== null ? resetsAt - windowSeconds : null;
   const livePoint: LimitSample[] = live && typeof live.usedPercent === "number" ? [{ t: now, remaining: clampPercent(100 - live.usedPercent) }] : [];
   const merged = mergeSamples(forward, backfill, livePoint);
-  // A 60s grace before windowStart keeps the point that straddles the reset.
-  const samples = windowStart !== null ? merged.filter((s) => s.t >= windowStart - 60) : merged;
+  // Strictly scope to the current window: a sample from before windowStart
+  // belongs to the previous window, and after a rollover it would sit in the
+  // series as a low pre-reset value ahead of the ~100% post-reset point. That
+  // boundary rise reads as a refill and would suppress the pace projection for
+  // the whole new window, so those pre-window samples are dropped here.
+  const samples = windowStart !== null ? merged.filter((s) => s.t >= windowStart) : merged;
   return { windowStart, resetsAt, windowSeconds, samples };
 }
 

--- a/src/lib/limits.ts
+++ b/src/lib/limits.ts
@@ -7,9 +7,16 @@ import { managedCodexRuntime } from "@/lib/accounts/codexRuntime";
 import type { AppServerRateLimits } from "@/lib/accounts/codexAppServer";
 import { redactAppServerDetail } from "@/lib/accounts/codexAppServerProtocol";
 import { statePath } from "@/lib/configDir";
-import type { EngineLimits, LimitsPayload, LimitsProvenance, LimitWindow } from "./types";
+import { WINDOW_SECONDS, clampPercent, mergeSamples, type WindowKey } from "@/lib/burndown";
+import { historySamples, historySince, recordLimitSample, RETENTION_S } from "@/lib/limitsHistoryStore";
+import type { BurndownPayload, BurndownSeries, EngineBurndown, EngineLimits, LimitSample, LimitsPayload, LimitsProvenance, LimitWindow } from "./types";
 
-const LIMITS_CACHE_FILE = statePath("limits-cache.json");
+/** Resolved at call time (not module load) so LLV_STATE_DIR set after this
+    module is first evaluated — e.g. in tests importing it statically — still
+    points reads and writes at the right state dir. */
+function limitsCacheFile(): string {
+  return statePath("limits-cache.json");
+}
 const OAUTH_USAGE_URL = "https://api.anthropic.com/api/oauth/usage";
 
 /** How far back into a session file to look for the last rate-limit event. */
@@ -57,7 +64,7 @@ function safeCacheEntry(value: unknown): EngineCacheEntry | null {
 
 function readDiskCache(): LimitsCache {
   try {
-    const raw = JSON.parse(fs.readFileSync(LIMITS_CACHE_FILE, "utf8")) as Partial<LimitsCache> & { at?: unknown; accountId?: unknown; data?: LimitsPayload };
+    const raw = JSON.parse(fs.readFileSync(limitsCacheFile(), "utf8")) as Partial<LimitsCache> & { at?: unknown; accountId?: unknown; data?: LimitsPayload };
     if (raw.version === 2 && raw.engines && typeof raw.engines === "object") {
       const cache = emptyCache();
       for (const engine of ["claude", "codex"] as const) {
@@ -88,7 +95,7 @@ function cache(): LimitsCache {
 
 function writeDiskCache(value: LimitsCache): void {
   try {
-    fs.mkdirSync(path.dirname(LIMITS_CACHE_FILE), { recursive: true });
+    fs.mkdirSync(path.dirname(limitsCacheFile()), { recursive: true });
     const latest = (engine: EngineName): [string, EngineCacheEntry] | null => Object.entries(value.engines[engine]).sort(([, a], [, b]) => b.at - a.at)[0] ?? null;
     const claude = latest("claude"); const codex = latest("codex");
     // Keep a read-only v1 projection during the cache migration so a rolling
@@ -108,7 +115,7 @@ function writeDiskCache(value: LimitsCache): void {
         staleSince: claude?.[1].provenance.staleSince ?? codex[1].provenance.staleSince,
       },
     } : {};
-    fs.writeFileSync(LIMITS_CACHE_FILE, JSON.stringify({ ...value, ...projection }, null, 2) + "\n", "utf8");
+    fs.writeFileSync(limitsCacheFile(), JSON.stringify({ ...value, ...projection }, null, 2) + "\n", "utf8");
   } catch (err) {
     console.warn("[limits] failed to persist cache", err);
   }
@@ -122,6 +129,13 @@ function remember(engine: EngineName, accountId: string, resolved: { data: Engin
   if (!resolved.data || resolved.meta.source === "cache" || resolved.meta.source === "unavailable") return;
   cache().engines[engine][accountId] = { at: Date.now(), data: resolved.data, provenance: resolved.meta };
   writeDiskCache(cache());
+  // A fresh live/transcript value is also a burndown sample. The browser's 60s
+  // poll drives this, so forward history accrues without a separate sampler.
+  try {
+    recordLimitSample(engine, accountId, resolved.data);
+  } catch (err) {
+    console.warn("[limits] failed to record burndown sample", err);
+  }
 }
 
 function safeReason(reason: string): string {
@@ -236,6 +250,7 @@ interface CodexWindow {
   used_percent?: unknown;
   resets_at?: unknown;
   resets_in_seconds?: unknown;
+  window_minutes?: unknown;
 }
 
 interface CodexRateLimits {
@@ -294,8 +309,9 @@ function listDesc(dir: string): string[] {
   }
 }
 
-/** Session transcripts for one Codex account home, newest first. */
-function* latestSessionFiles(sessionsDir: string): Generator<string> {
+/** Session transcripts for one Codex account home, newest first, each with its
+    mtime so callers can stop once files fall outside their window. */
+function* sessionFiles(sessionsDir: string, max: number): Generator<{ p: string; m: number }> {
   let yielded = 0;
   for (const year of listDesc(sessionsDir)) {
     for (const month of listDesc(path.join(sessionsDir, year))) {
@@ -313,12 +329,16 @@ function* latestSessionFiles(sessionsDir: string): Generator<string> {
         }
         entries.sort((a, b) => b.m - a.m);
         for (const entry of entries) {
-          yield entry.p;
-          if (++yielded >= MAX_FILES) return;
+          yield entry;
+          if (++yielded >= max) return;
         }
       }
     }
   }
+}
+
+function* latestSessionFiles(sessionsDir: string): Generator<string> {
+  for (const entry of sessionFiles(sessionsDir, MAX_FILES)) yield entry.p;
 }
 
 function readTail(file: string, bytes: number): string | null {
@@ -373,4 +393,154 @@ function codexWindow(w: CodexWindow | undefined, capturedAt: number | null): Lim
   if (typeof w.resets_at === "number") resetsAt = w.resets_at;
   else if (typeof w.resets_in_seconds === "number" && capturedAt !== null) resetsAt = capturedAt + w.resets_in_seconds;
   return { usedPercent: w.used_percent, resetsAt };
+}
+
+/* ----------------------------- Burndown series ----------------------------- */
+
+/** Newest files to scan for the weekly series — a backstop far above a normal
+    week's worth of Codex sessions. */
+const SERIES_MAX_FILES = 400;
+/** Whole-file read cap; larger transcripts fall back to a tail read. */
+const SERIES_MAX_BYTES = 8 * 1024 * 1024;
+
+function windowSecondsOf(w: CodexWindow | undefined): number | null {
+  if (w && typeof w.window_minutes === "number" && w.window_minutes > 0) return Math.round(w.window_minutes * 60);
+  return null;
+}
+
+function readAll(file: string): string | null {
+  try {
+    if (fs.statSync(file).size > SERIES_MAX_BYTES) return readTail(file, SERIES_MAX_BYTES);
+    return fs.readFileSync(file, "utf8");
+  } catch {
+    return readTail(file, SERIES_MAX_BYTES);
+  }
+}
+
+export interface CodexTranscriptSeries {
+  session: LimitSample[];
+  weekly: LimitSample[];
+  /** Window definition from the newest event, for the ideal diagonal. */
+  sessionWindowSeconds: number | null;
+  weeklyWindowSeconds: number | null;
+  sessionResetsAt: number | null;
+  weeklyResetsAt: number | null;
+}
+
+/** All `rate_limits` events across the Codex session transcripts touched since
+    `sinceUnix`, reconstructing the weekly/5h remaining-quota curves retroactively
+    so the chart is populated on first open. Files whose mtime predates the
+    window are skipped unread; the newest event fixes each window's diagonal. */
+export function collectCodexRateLimitSeries(sessionsDir: string, sinceUnix: number): CodexTranscriptSeries {
+  const session: LimitSample[] = [];
+  const weekly: LimitSample[] = [];
+  const seen = new Set<number>();
+  let latestT = -Infinity;
+  let sessionWindowSeconds: number | null = null;
+  let weeklyWindowSeconds: number | null = null;
+  let sessionResetsAt: number | null = null;
+  let weeklyResetsAt: number | null = null;
+  for (const { p, m } of sessionFiles(sessionsDir, SERIES_MAX_FILES)) {
+    if (m / 1000 < sinceUnix) continue;
+    const text = readAll(p);
+    if (!text) continue;
+    for (const line of text.split("\n")) {
+      if (!line.includes('"rate_limits"')) continue;
+      try {
+        const row = JSON.parse(line) as { timestamp?: unknown; payload?: { rate_limits?: CodexRateLimits } };
+        const rl = row.payload?.rate_limits;
+        if (!rl) continue;
+        const ts = typeof row.timestamp === "string" ? Date.parse(row.timestamp) : NaN;
+        if (!Number.isFinite(ts)) continue;
+        const t = Math.round(ts / 1000);
+        if (t < sinceUnix || seen.has(t)) continue;
+        seen.add(t);
+        const prim = codexWindow(rl.primary, t);
+        const sec = codexWindow(rl.secondary, t);
+        if (prim) session.push({ t, remaining: clampPercent(100 - prim.usedPercent) });
+        if (sec) weekly.push({ t, remaining: clampPercent(100 - sec.usedPercent) });
+        if (t > latestT) {
+          latestT = t;
+          if (prim) { sessionResetsAt = prim.resetsAt; sessionWindowSeconds = windowSecondsOf(rl.primary); }
+          if (sec) { weeklyResetsAt = sec.resetsAt; weeklyWindowSeconds = windowSecondsOf(rl.secondary); }
+        }
+      } catch {
+        /* partial or non-JSON line */
+      }
+    }
+  }
+  session.sort((a, b) => a.t - b.t);
+  weekly.sort((a, b) => a.t - b.t);
+  return { session, weekly, sessionWindowSeconds, weeklyWindowSeconds, sessionResetsAt, weeklyResetsAt };
+}
+
+/** Assemble one window's burndown from forward poll samples, an optional
+    transcript backfill and the current live value, scoped to the current window. */
+function buildSeries(
+  forward: LimitSample[],
+  backfill: LimitSample[],
+  live: LimitWindow | null,
+  now: number,
+  windowSeconds: number,
+  backfillResetsAt: number | null,
+): BurndownSeries {
+  const resetsAt = live?.resetsAt ?? backfillResetsAt ?? null;
+  const windowStart = resetsAt !== null ? resetsAt - windowSeconds : null;
+  const livePoint: LimitSample[] = live && typeof live.usedPercent === "number" ? [{ t: now, remaining: clampPercent(100 - live.usedPercent) }] : [];
+  const merged = mergeSamples(forward, backfill, livePoint);
+  // A 60s grace before windowStart keeps the point that straddles the reset.
+  const samples = windowStart !== null ? merged.filter((s) => s.t >= windowStart - 60) : merged;
+  return { windowStart, resetsAt, windowSeconds, samples };
+}
+
+function buildEngineBurndown(
+  engine: EngineName,
+  accountId: string,
+  limits: EngineLimits | null,
+  now: number,
+  since: number,
+  backfill: CodexTranscriptSeries | null,
+): EngineBurndown {
+  const forward = (window: WindowKey) => historySamples(engine, accountId, window, now);
+  const session = buildSeries(
+    forward("session"),
+    backfill?.session ?? [],
+    limits?.session ?? null,
+    now,
+    backfill?.sessionWindowSeconds ?? WINDOW_SECONDS.session,
+    backfill?.sessionResetsAt ?? null,
+  );
+  const weekly = buildSeries(
+    forward("weekly"),
+    backfill?.weekly ?? [],
+    limits?.weekly ?? null,
+    now,
+    backfill?.weeklyWindowSeconds ?? WINDOW_SECONDS.weekly,
+    backfill?.weeklyResetsAt ?? null,
+  );
+  return { session, weekly };
+}
+
+/** Burndown history for both engines. Reads the current live snapshot (which
+    also records a forward sample), merges the persisted poll history, and
+    backfills the Codex curve from transcripts so it is never empty. */
+export async function readBurndown(options: { codexLiveReader?: CodexLiveLimitsReader } = {}): Promise<BurndownPayload> {
+  const payload = await readLimits(options);
+  const now = Math.round(Date.now() / 1000);
+  const since = now - RETENTION_S;
+  const claude = payload.claudeAccountId
+    ? buildEngineBurndown("claude", payload.claudeAccountId, payload.claude, now, since, null)
+    : null;
+  let codex: EngineBurndown | null = null;
+  if (payload.codexAccountId) {
+    const backfill = collectCodexRateLimitSeries(accountForSpawn().sessionsDir, since);
+    codex = buildEngineBurndown("codex", payload.codexAccountId, payload.codex, now, since, backfill);
+  }
+  return {
+    claude,
+    codex,
+    claudeAccountId: payload.claudeAccountId,
+    codexAccountId: payload.codexAccountId,
+    historySince: historySince(),
+  };
 }

--- a/src/lib/limits.ts
+++ b/src/lib/limits.ts
@@ -498,7 +498,6 @@ function buildEngineBurndown(
   accountId: string,
   limits: EngineLimits | null,
   now: number,
-  since: number,
   backfill: CodexTranscriptSeries | null,
 ): EngineBurndown {
   const forward = (window: WindowKey) => historySamples(engine, accountId, window, now);
@@ -529,12 +528,12 @@ export async function readBurndown(options: { codexLiveReader?: CodexLiveLimitsR
   const now = Math.round(Date.now() / 1000);
   const since = now - RETENTION_S;
   const claude = payload.claudeAccountId
-    ? buildEngineBurndown("claude", payload.claudeAccountId, payload.claude, now, since, null)
+    ? buildEngineBurndown("claude", payload.claudeAccountId, payload.claude, now, null)
     : null;
   let codex: EngineBurndown | null = null;
   if (payload.codexAccountId) {
     const backfill = collectCodexRateLimitSeries(accountForSpawn().sessionsDir, since);
-    codex = buildEngineBurndown("codex", payload.codexAccountId, payload.codex, now, since, backfill);
+    codex = buildEngineBurndown("codex", payload.codexAccountId, payload.codex, now, backfill);
   }
   return {
     claude,

--- a/src/lib/limitsBurndown.test.ts
+++ b/src/lib/limitsBurndown.test.ts
@@ -3,7 +3,8 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
-import { collectCodexRateLimitSeries } from "./limits";
+import { computePace } from "./burndown";
+import { buildSeries, collectCodexRateLimitSeries } from "./limits";
 
 let root: string;
 
@@ -68,4 +69,23 @@ test("returns empty series for a sessions dir with no transcripts", () => {
   expect(series.session).toEqual([]);
   expect(series.weekly).toEqual([]);
   expect(series.sessionResetsAt).toBeNull();
+});
+
+test("buildSeries drops pre-reset samples so a draining window after a rollover still projects", () => {
+  const windowSeconds = 18_000; // 5h
+  const now = 10_000_000;
+  const resetsAt = now + 9_000;
+  const windowStart = resetsAt - windowSeconds; // now - 9000
+  // A low pre-reset sample inside the old 60s grace, then a normal rollover to
+  // ~100% and a draining new window.
+  const forward = [
+    { t: windowStart - 30, remaining: 5 }, // previous window — must be excluded
+    { t: windowStart + 100, remaining: 100 },
+    { t: windowStart + 4_500, remaining: 90 },
+  ];
+  const series = buildSeries(forward, [], { usedPercent: 15, resetsAt }, now, windowSeconds, null);
+  // The pre-reset value is gone, so there is no boundary rise.
+  expect(series.samples.some((s) => s.remaining === 5)).toBe(false);
+  expect(series.samples[0].remaining).toBe(100);
+  expect(computePace(series, now)!.zeroCrossing).not.toBeNull();
 });

--- a/src/lib/limitsBurndown.test.ts
+++ b/src/lib/limitsBurndown.test.ts
@@ -1,0 +1,71 @@
+import { afterEach, beforeEach, expect, test } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { collectCodexRateLimitSeries } from "./limits";
+
+let root: string;
+
+beforeEach(() => {
+  root = fs.mkdtempSync(path.join(os.tmpdir(), "llv-codex-series-"));
+});
+
+afterEach(() => {
+  fs.rmSync(root, { recursive: true, force: true });
+});
+
+/** Write a Codex session JSONL under YYYY/MM/DD derived from `day`. */
+function writeSession(name: string, day: string, events: { ts: string; primary?: [number, number, number]; secondary?: [number, number, number] }[]): void {
+  const [y, m, d] = day.split("-");
+  const dir = path.join(root, y, m, d);
+  fs.mkdirSync(dir, { recursive: true });
+  const win = (w?: [number, number, number]) =>
+    w ? { used_percent: w[0], window_minutes: w[1], resets_at: w[2] } : undefined;
+  const lines = events.map((e) =>
+    JSON.stringify({
+      timestamp: e.ts,
+      payload: { rate_limits: { primary: win(e.primary), secondary: win(e.secondary), plan_type: "pro" } },
+    }),
+  );
+  fs.writeFileSync(path.join(dir, name), lines.join("\n") + "\n", "utf8");
+}
+
+test("reconstructs primary/secondary curves across events with window metadata", () => {
+  const reset5h = 1_783_544_991;
+  const resetWeek = 1_783_994_379;
+  writeSession("s.jsonl", "2026-07-08", [
+    { ts: "2026-07-08T15:00:00.000Z", primary: [10, 300, reset5h], secondary: [40, 10080, resetWeek] },
+    { ts: "2026-07-08T17:28:49.000Z", primary: [35, 300, reset5h], secondary: [58, 10080, resetWeek] },
+  ]);
+  const series = collectCodexRateLimitSeries(root, 0);
+  expect(series.session).toEqual([
+    { t: Math.round(Date.parse("2026-07-08T15:00:00.000Z") / 1000), remaining: 90 },
+    { t: Math.round(Date.parse("2026-07-08T17:28:49.000Z") / 1000), remaining: 65 },
+  ]);
+  expect(series.weekly.map((s) => s.remaining)).toEqual([60, 42]);
+  // Newest event fixes each window definition.
+  expect(series.sessionWindowSeconds).toBe(300 * 60);
+  expect(series.weeklyWindowSeconds).toBe(10080 * 60);
+  expect(series.sessionResetsAt).toBe(reset5h);
+  expect(series.weeklyResetsAt).toBe(resetWeek);
+});
+
+test("drops events older than the cutoff and dedupes identical timestamps", () => {
+  const reset = 1_783_544_991;
+  writeSession("a.jsonl", "2026-07-08", [
+    { ts: "2026-07-08T10:00:00.000Z", primary: [10, 300, reset] },
+    { ts: "2026-07-08T12:00:00.000Z", primary: [20, 300, reset] },
+    { ts: "2026-07-08T12:00:00.000Z", primary: [99, 300, reset] }, // duplicate second → ignored
+  ]);
+  const cutoff = Math.round(Date.parse("2026-07-08T11:00:00.000Z") / 1000);
+  const series = collectCodexRateLimitSeries(root, cutoff);
+  expect(series.session).toEqual([{ t: Math.round(Date.parse("2026-07-08T12:00:00.000Z") / 1000), remaining: 80 }]);
+});
+
+test("returns empty series for a sessions dir with no transcripts", () => {
+  const series = collectCodexRateLimitSeries(path.join(root, "missing"), 0);
+  expect(series.session).toEqual([]);
+  expect(series.weekly).toEqual([]);
+  expect(series.sessionResetsAt).toBeNull();
+});

--- a/src/lib/limitsHistoryStore.test.ts
+++ b/src/lib/limitsHistoryStore.test.ts
@@ -1,0 +1,73 @@
+import { afterEach, beforeEach, expect, test } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { historySamples, historySince, readHistory, recordLimitSample, RETENTION_S } from "./limitsHistoryStore";
+import type { EngineLimits } from "./types";
+
+let dir: string;
+const prev = process.env.LLV_STATE_DIR;
+
+beforeEach(() => {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), "llv-history-"));
+  process.env.LLV_STATE_DIR = dir;
+});
+
+afterEach(() => {
+  if (prev === undefined) delete process.env.LLV_STATE_DIR;
+  else process.env.LLV_STATE_DIR = prev;
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+const limits = (session: number, weekly: number): EngineLimits => ({
+  session: { usedPercent: session, resetsAt: null },
+  weekly: { usedPercent: weekly, resetsAt: null },
+  plan: "pro",
+  capturedAt: null,
+});
+
+test("records a remaining-quota sample per window and persists it", () => {
+  const t0 = 1_700_000_000_000;
+  recordLimitSample("claude", "acct", limits(20, 40), t0);
+  expect(historySamples("claude", "acct", "session", t0 / 1000)).toEqual([{ t: t0 / 1000, remaining: 80 }]);
+  expect(historySamples("claude", "acct", "weekly", t0 / 1000)).toEqual([{ t: t0 / 1000, remaining: 60 }]);
+  expect(historySince()).toBe(new Date(t0).toISOString());
+  // Survives a fresh read of the file.
+  expect(readHistory().series["claude|acct|session"]).toHaveLength(1);
+});
+
+test("downsamples samples closer than five minutes apart", () => {
+  const t0 = 1_700_000_000_000;
+  recordLimitSample("codex", "acct", limits(10, 10), t0);
+  recordLimitSample("codex", "acct", limits(11, 11), t0 + 60_000); // +1 min → dropped
+  recordLimitSample("codex", "acct", limits(12, 12), t0 + 6 * 60_000); // +6 min → kept
+  expect(historySamples("codex", "acct", "session", (t0 + 6 * 60_000) / 1000)).toEqual([
+    { t: t0 / 1000, remaining: 90 },
+    { t: (t0 + 6 * 60_000) / 1000, remaining: 88 },
+  ]);
+});
+
+test("prunes samples older than the retention window on write", () => {
+  const old = 1_700_000_000; // seconds
+  const now = old + RETENTION_S + 3600; // just past retention
+  recordLimitSample("claude", "acct", limits(50, 50), old * 1000);
+  recordLimitSample("claude", "acct", limits(60, 60), now * 1000);
+  const kept = readHistory().series["claude|acct|session"];
+  expect(kept).toEqual([{ t: now, remaining: 40 }]);
+});
+
+test("keeps per-account series separate", () => {
+  const t0 = 1_700_000_000_000;
+  recordLimitSample("codex", "a", limits(10, 10), t0);
+  recordLimitSample("codex", "b", limits(20, 20), t0);
+  expect(historySamples("codex", "a", "session", t0 / 1000)).toEqual([{ t: t0 / 1000, remaining: 90 }]);
+  expect(historySamples("codex", "b", "session", t0 / 1000)).toEqual([{ t: t0 / 1000, remaining: 80 }]);
+});
+
+test("skips windows with no numeric usage", () => {
+  const t0 = 1_700_000_000_000;
+  recordLimitSample("claude", "acct", { session: null, weekly: { usedPercent: 25, resetsAt: null }, plan: null, capturedAt: null }, t0);
+  expect(historySamples("claude", "acct", "session", t0 / 1000)).toEqual([]);
+  expect(historySamples("claude", "acct", "weekly", t0 / 1000)).toEqual([{ t: t0 / 1000, remaining: 75 }]);
+});

--- a/src/lib/limitsHistoryStore.ts
+++ b/src/lib/limitsHistoryStore.ts
@@ -1,0 +1,110 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import { statePath } from "@/lib/configDir";
+import { clampPercent, type WindowKey } from "@/lib/burndown";
+import type { EngineLimits, LimitSample } from "@/lib/types";
+
+/** Forward poll history for the burndown chart. Claude quota is a live-only
+    snapshot with no transcript record, so its curve can only be built by
+    persisting each poll here; the Codex curve is additionally backfilled from
+    transcripts (see limits.ts). The prod viewer polls every 60s continuously,
+    so this doubles as the sampler — no separate daemon. */
+
+/** Keep just over a week so the weekly window is always fully covered. */
+export const RETENTION_S = 8 * 24 * 3600;
+/** One sample per engine/window per 5 minutes is plenty for the chart. */
+const MIN_GAP_S = 5 * 60;
+/** Hard cap per series so a stuck poller can never grow the file unbounded. */
+const MAX_POINTS = 4000;
+
+type EngineName = "claude" | "codex";
+const WINDOWS: WindowKey[] = ["session", "weekly"];
+
+interface HistoryFile {
+  version: 1;
+  /** ISO of the first sample ever recorded — the "history builds from" hint. */
+  since: string | null;
+  /** `${engine}|${accountId}|${window}` → samples, oldest first. */
+  series: Record<string, LimitSample[]>;
+}
+
+function historyFile(): string {
+  return statePath("limits-history.json");
+}
+
+function seriesKey(engine: EngineName, accountId: string, window: WindowKey): string {
+  return `${engine}|${accountId}|${window}`;
+}
+
+function emptyHistory(): HistoryFile {
+  return { version: 1, since: null, series: {} };
+}
+
+function isSample(value: unknown): value is LimitSample {
+  if (!value || typeof value !== "object") return false;
+  const s = value as Partial<LimitSample>;
+  return typeof s.t === "number" && Number.isFinite(s.t) && typeof s.remaining === "number" && Number.isFinite(s.remaining);
+}
+
+export function readHistory(): HistoryFile {
+  try {
+    const raw = JSON.parse(fs.readFileSync(historyFile(), "utf8")) as Partial<HistoryFile>;
+    if (raw.version !== 1 || !raw.series || typeof raw.series !== "object") return emptyHistory();
+    const series: Record<string, LimitSample[]> = {};
+    for (const [key, value] of Object.entries(raw.series)) {
+      if (Array.isArray(value)) series[key] = value.filter(isSample);
+    }
+    return { version: 1, since: typeof raw.since === "string" ? raw.since : null, series };
+  } catch {
+    // A missing or unreadable history file is simply an empty series.
+    return emptyHistory();
+  }
+}
+
+function writeHistory(history: HistoryFile): void {
+  try {
+    fs.mkdirSync(path.dirname(historyFile()), { recursive: true });
+    fs.writeFileSync(historyFile(), JSON.stringify(history, null, 2) + "\n", "utf8");
+  } catch (err) {
+    console.warn("[limits] failed to persist history", err);
+  }
+}
+
+/** Read one engine/account/window series, pruned to the retention window. */
+export function historySamples(engine: EngineName, accountId: string, window: WindowKey, now = Math.round(Date.now() / 1000)): LimitSample[] {
+  const arr = readHistory().series[seriesKey(engine, accountId, window)] ?? [];
+  const cutoff = now - RETENTION_S;
+  return arr.filter((s) => s.t >= cutoff);
+}
+
+/** Append the current live remaining-quota values for an engine/account, one
+    point per window. Downsampled to {@link MIN_GAP_S}, pruned to the retention
+    window and capped, so the file stays small across a long-running viewer. */
+export function recordLimitSample(engine: EngineName, accountId: string, limits: EngineLimits, nowMs = Date.now()): void {
+  const nowS = Math.round(nowMs / 1000);
+  const history = readHistory();
+  let changed = false;
+  for (const window of WINDOWS) {
+    const win = limits[window];
+    if (!win || typeof win.usedPercent !== "number") continue;
+    const key = seriesKey(engine, accountId, window);
+    const arr = history.series[key] ?? (history.series[key] = []);
+    const last = arr[arr.length - 1];
+    if (last && nowS - last.t < MIN_GAP_S) continue;
+    arr.push({ t: nowS, remaining: clampPercent(100 - win.usedPercent) });
+    const cutoff = nowS - RETENTION_S;
+    let pruned = arr.filter((s) => s.t >= cutoff);
+    if (pruned.length > MAX_POINTS) pruned = pruned.slice(pruned.length - MAX_POINTS);
+    history.series[key] = pruned;
+    changed = true;
+  }
+  if (!changed) return;
+  if (!history.since) history.since = new Date(nowMs).toISOString();
+  writeHistory(history);
+}
+
+/** ISO time the forward history began (for the sparse-state hint), or null. */
+export function historySince(): string | null {
+  return readHistory().since;
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -305,6 +305,45 @@ export interface LimitsPayload {
   staleSince?: string | null;
 }
 
+/** One remaining-quota sample of the burndown series: `remaining` is the
+    percent of quota left (0–100 = 100 − usedPercent) at unix second `t`. */
+export interface LimitSample {
+  t: number;
+  remaining: number;
+}
+
+/** A burndown series for one engine window (5h session or weekly). The ideal
+    even-pace diagonal runs 100% at `windowStart` → 0% at `resetsAt`; the actual
+    curve is `samples`, filtered to the current window. */
+export interface BurndownSeries {
+  /** Unix seconds at the window's opening (resetsAt − windowSeconds), or null
+      when the reset moment is unknown. */
+  windowStart: number | null;
+  /** Unix seconds when the window resets, or null when unknown. */
+  resetsAt: number | null;
+  /** Window length in seconds (5h = 18000, weekly = 604800; Codex may differ). */
+  windowSeconds: number;
+  /** Remaining-quota samples inside the current window, oldest first. */
+  samples: LimitSample[];
+}
+
+/** Both windows' burndown series for one engine. */
+export interface EngineBurndown {
+  session: BurndownSeries;
+  weekly: BurndownSeries;
+}
+
+/** Burndown history for both engines, returned by GET /api/limits/history. */
+export interface BurndownPayload {
+  claude: EngineBurndown | null;
+  codex: EngineBurndown | null;
+  claudeAccountId: string | null;
+  codexAccountId: string | null;
+  /** ISO time the forward poll history began accruing, for the sparse-state
+      hint on engines (Claude) that can only be sampled going forward. */
+  historySince: string | null;
+}
+
 /** Host memory pressure for the rail block, all byte fields absolute.
     swapTotal 0 means "no swap (or the swap probe failed)" — hide the row. */
 export interface ResourcesSystem {


### PR DESCRIPTION
Closes #36.

Each engine's limit **bars** in the sidebar footer are now a button. Clicking opens a **burndown panel** that overlays:

- **Ideal even-pace line** — a dashed diagonal from 100% at the window's start to 0% at `resets_at` ("spend evenly").
- **Actual remaining-quota curve** — solid, in the engine tint, reusing the amber-<30% / red-<10% thresholds from the footer bars.

Below/above the diagonal reads as burning ahead of / behind pace. A **Week / 5h** toggle (Week default) switches windows; both work for Claude and Codex. A pace caption states whether you're ahead of or under even pace and projects the zero-crossing.

## The data problem
`limits-cache.json` was overwritten every refresh — no history. The two engines differ:

- **Codex** is reconstructable: every turn appends a `rate_limits` event to its session JSONL. `collectCodexRateLimitSeries` scans the last ~8 days of transcripts and rebuilds a dense weekly + 5h curve **retroactively on first open**, using each event's `window_minutes` + `resets_at` for the exact diagonal.
- **Claude** is live-only (OAuth usage endpoint), so its curve is **sampled forward**: each poll's fresh value is appended to `state/limits-history.json` from `remember()`. The prod viewer's 60s poll doubles as the sampler — no daemon. Sparse right after ship; a "history builds from {date}" hint covers that. (A dedicated server-side interval sampler is noted as a follow-up.)

## What's here
- `src/lib/limitsHistoryStore.ts` — append-only forward history via `statePath`, downsampled to one point / 5 min per engine·account·window, pruned to ~8 days, capped.
- `src/lib/limits.ts` — `remember()` records a sample; `collectCodexRateLimitSeries` + `readBurndown()` assemble the series; the cache path is now resolved lazily.
- `src/app/api/limits/history/route.ts` — `GET /api/limits/history`.
- `src/lib/burndown.ts` — pure ideal-line / pace / merge math (isomorphic).
- `src/components/BurndownPanel.tsx` — inline SVG chart (no new deps), ✕/Esc/outside-click close, `sm:left-full` off the rail like `ResourcesFooter`.
- `src/components/LimitsFooter.tsx` — split the block into an account-switch header button + a chart-trigger bars button (no nested buttons).
- i18n en + uk `burndown.*` strings.

No secrets reach the browser (percentages only, as before). Works in light + dark.

## Verification
- `bun test` — 1545 pass / 0 fail (added burndown math, history prune/downsample, Codex series rebuild tests).
- `bunx tsc --noEmit` — clean.
- `bun run build` — compiles; `/api/limits/history` registered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
