### PR TITLE
fix: back off Claude limits polling on 429 and surface provider throttling

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -1,15 +1,17 @@
-# Issue 26: TTS read answer aloud
+# PR #143: Claude limits backoff and footer visibility
 
 ## Task statement
 
-Add OpenAI text-to-speech for assistant answers through `/api/tts`, expose play/stop controls only when an environment API key is available, stream audio, and exclude tool calls and code blocks from spoken text.
+Back off Claude limits polling after provider failures, honor `Retry-After`, distinguish re-authentication failures, and keep footer status honest in English and Ukrainian.
 
 ## Acceptance criteria
 
-- AC1: OpenAI and ElevenLabs resolve independently through environment and key-file credentials, with environment/file backend selection and server-side voice/model configuration.
-- AC2: Every paid synthesis requires confirmation showing provider, model, voice, character count, billing disclosure, and AI-voice disclosure.
-- AC3: Assistant prose is Markdown-normalized and secret-redacted; tool calls, code, image payloads, URLs, hidden text, and memory metadata stay outside provider input.
-- AC4: Rapid interactions cancel stale synthesis and playback, propagate browser cancellation upstream, and bound provider requests with a timeout.
-- AC5: Answers above 4,000 characters require explicit consent to synthesize the first 4,000 characters.
-- AC6: Upstream responses require an `audio/*` content type and remain within 32 MB.
-- AC7: `bun test` and `bunx tsc --noEmit` pass.
+- AC1: Failed limits reads are cached per engine and account for a cooldown.
+- AC2: Consecutive Claude 429 responses use a 1m, 2m, 4m exponential schedule capped at 15m.
+- AC3: A valid `Retry-After` extends the cooldown when required by the provider.
+- AC4: Concurrent refreshes for one engine and account share one upstream request.
+- AC5: A successful read resets the 429 backoff and preserves the fresh-cache fast path.
+- AC6: Claude 429 provenance shows provider throttling and the next retry time, including when retained quota windows come from cache.
+- AC7: Claude 401 provenance shows re-login guidance, including when retained quota windows come from cache.
+- AC8: Footer status strings remain aligned in English and Ukrainian.
+- AC9: `bun test` and `bunx tsc --noEmit` pass.

--- a/src/components/LimitsFooter.test.ts
+++ b/src/components/LimitsFooter.test.ts
@@ -2,7 +2,7 @@ import { expect, test } from "bun:test";
 
 import type { EngineLimits, LimitsPayload, LimitsProvenance } from "@/lib/types";
 
-import { codexLimitsForActiveAccount, createLatestLimitsLoader, fmtStaleSince, fmtUnavailableReason, stickyPayload } from "./LimitsFooter";
+import { codexLimitsForActiveAccount, createLatestLimitsLoader, fmtLimitsFailureReason, fmtStaleSince, stickyPayload } from "./LimitsFooter";
 
 const live: LimitsProvenance = { source: "live", reason: null, staleSince: null };
 const unavailable: LimitsProvenance = {
@@ -149,8 +149,8 @@ test("unavailable Claude provenance explains provider throttling in English and 
     staleSince: "2026-07-12T10:00:00.000Z",
     retryAt: "2026-07-12T10:15:00.000Z",
   };
-  expect(fmtUnavailableReason(provenance, "en")).toContain("Retry at");
-  expect(fmtUnavailableReason(provenance, "uk")).toContain("Наступна спроба");
+  expect(fmtLimitsFailureReason(provenance, "en")).toContain("Retry at");
+  expect(fmtLimitsFailureReason(provenance, "uk")).toContain("Наступна спроба");
 });
 
 test("unavailable Claude 401 provenance asks for re-login in English and Ukrainian", () => {
@@ -159,6 +159,28 @@ test("unavailable Claude 401 provenance asks for re-login in English and Ukraini
     reason: "oauth-reauthentication-required",
     staleSince: "2026-07-12T10:00:00.000Z",
   };
-  expect(fmtUnavailableReason(provenance, "en")).toBe("Re-login to Claude is required.");
-  expect(fmtUnavailableReason(provenance, "uk")).toBe("Потрібно повторно увійти в Claude.");
+  expect(fmtLimitsFailureReason(provenance, "en")).toBe("Re-login to Claude is required.");
+  expect(fmtLimitsFailureReason(provenance, "uk")).toBe("Потрібно повторно увійти в Claude.");
+});
+
+test("cached Claude 429 provenance keeps throttling visible beside retained windows", () => {
+  const provenance: LimitsProvenance = {
+    source: "cache",
+    reason: "oauth-rate-limited",
+    staleSince: "2026-07-12T10:00:00.000Z",
+    retryAt: "2026-07-12T10:15:00.000Z",
+  };
+  expect(fmtLimitsFailureReason(provenance, "en")).toContain("Retry at");
+  expect(fmtLimitsFailureReason(provenance, "uk")).toContain("Наступна спроба");
+});
+
+test("cached Claude 401 provenance keeps re-login guidance visible beside retained windows", () => {
+  const provenance: LimitsProvenance = {
+    source: "cache",
+    reason: "oauth-reauthentication-required",
+    staleSince: "2026-07-12T10:00:00.000Z",
+    retryAt: "2026-07-12T10:01:00.000Z",
+  };
+  expect(fmtLimitsFailureReason(provenance, "en")).toBe("Re-login to Claude is required.");
+  expect(fmtLimitsFailureReason(provenance, "uk")).toBe("Потрібно повторно увійти в Claude.");
 });

--- a/src/components/LimitsFooter.test.ts
+++ b/src/components/LimitsFooter.test.ts
@@ -2,7 +2,7 @@ import { expect, test } from "bun:test";
 
 import type { EngineLimits, LimitsPayload, LimitsProvenance } from "@/lib/types";
 
-import { codexLimitsForActiveAccount, createLatestLimitsLoader, fmtStaleSince, stickyPayload } from "./LimitsFooter";
+import { codexLimitsForActiveAccount, createLatestLimitsLoader, fmtStaleSince, fmtUnavailableReason, stickyPayload } from "./LimitsFooter";
 
 const live: LimitsProvenance = { source: "live", reason: null, staleSince: null };
 const unavailable: LimitsProvenance = {
@@ -140,4 +140,25 @@ test("fmtStaleSince returns null when there is nothing to explain", () => {
   expect(fmtStaleSince(null, "en")).toBeNull();
   expect(fmtStaleSince(undefined, "en")).toBeNull();
   expect(fmtStaleSince("not-a-date", "en")).toBeNull();
+});
+
+test("unavailable Claude provenance explains provider throttling in English and Ukrainian", () => {
+  const provenance: LimitsProvenance = {
+    source: "unavailable",
+    reason: "oauth-rate-limited",
+    staleSince: "2026-07-12T10:00:00.000Z",
+    retryAt: "2026-07-12T10:15:00.000Z",
+  };
+  expect(fmtUnavailableReason(provenance, "en")).toContain("Retry at");
+  expect(fmtUnavailableReason(provenance, "uk")).toContain("Наступна спроба");
+});
+
+test("unavailable Claude 401 provenance asks for re-login in English and Ukrainian", () => {
+  const provenance: LimitsProvenance = {
+    source: "unavailable",
+    reason: "oauth-reauthentication-required",
+    staleSince: "2026-07-12T10:00:00.000Z",
+  };
+  expect(fmtUnavailableReason(provenance, "en")).toBe("Re-login to Claude is required.");
+  expect(fmtUnavailableReason(provenance, "uk")).toBe("Потрібно повторно увійти в Claude.");
 });

--- a/src/components/LimitsFooter.tsx
+++ b/src/components/LimitsFooter.tsx
@@ -4,7 +4,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 
 import { accountEntryPointVisible, type Engine, useEngineAccounts } from "@/hooks/useEngineAccounts";
 import { type Locale, translate, useLocale } from "@/lib/i18n";
-import type { EngineLimits, LimitsPayload, LimitWindow } from "@/lib/types";
+import { LIMITS_RATE_LIMITED_REASON, LIMITS_REAUTH_REQUIRED_REASON, type EngineLimits, type LimitsPayload, type LimitsProvenance, type LimitWindow } from "@/lib/types";
 
 import { AccountsPanel } from "./AccountsPanel";
 import { BurndownPanel } from "./BurndownPanel";
@@ -24,6 +24,17 @@ export function fmtStaleSince(staleSince: string | null | undefined, locale: Loc
   if (Number.isNaN(d.getTime())) return null;
   return translate(locale, "limits.asOf", {
     time: d.toLocaleTimeString(bcp47(locale), { hour: "2-digit", minute: "2-digit", hour12: false }),
+  });
+}
+
+export function fmtUnavailableReason(meta: LimitsProvenance, locale: Locale): string | null {
+  if (meta.source !== "unavailable") return null;
+  if (meta.reason === LIMITS_REAUTH_REQUIRED_REASON) return translate(locale, "limits.reauthRequired");
+  if (meta.reason !== LIMITS_RATE_LIMITED_REASON || !meta.retryAt) return null;
+  const retryAt = new Date(meta.retryAt);
+  if (Number.isNaN(retryAt.getTime())) return translate(locale, "limits.rateLimited");
+  return translate(locale, "limits.rateLimitedRetry", {
+    time: retryAt.toLocaleTimeString(bcp47(locale), { hour: "2-digit", minute: "2-digit", hour12: false }),
   });
 }
 
@@ -166,6 +177,7 @@ function EngineLimitsBlock({
   payloadAccountId,
   now,
   staleHint,
+  provenance,
   onSwitched,
 }: {
   engine: Engine;
@@ -174,9 +186,10 @@ function EngineLimitsBlock({
   payloadAccountId: string | null;
   now: number;
   staleHint: string | null;
+  provenance: LimitsProvenance;
   onSwitched: () => void;
 }) {
-  const { t } = useLocale();
+  const { locale, t } = useLocale();
   const accounts = useEngineAccounts(engine);
   const [open, setOpen] = useState(false);
   const [chartOpen, setChartOpen] = useState(false);
@@ -242,6 +255,7 @@ function EngineLimitsBlock({
   const activeLabel = activeAccount?.label ?? t("accounts.trigger");
   const effective = activeAccount?.effective;
   const draining = accounts.migration?.state === "draining";
+  const unavailableReason = fmtUnavailableReason(provenance, locale);
 
   return (
     <div ref={containerRef} className="relative">
@@ -300,7 +314,7 @@ function EngineLimitsBlock({
             <LimitRow label={t("limits.week")} window={accountLimits!.weekly} engineColor={tint.color} now={now} />
           </button>
         ) : (
-          <div className="px-3.5 pb-3 pt-0.5 text-[10px] text-dim">{accounts.status === "loading" || identityPending ? t("limits.accountLoading") : t("limits.noDataYet")}</div>
+          <div className="px-3.5 pb-3 pt-0.5 text-[10px] text-dim">{accounts.status === "loading" || identityPending ? t("limits.accountLoading") : (unavailableReason ?? t("limits.noDataYet"))}</div>
         )}
       </div>
       {open ? <AccountsPanel state={accounts} onClose={close} /> : null}
@@ -341,8 +355,8 @@ export function LimitsFooter() {
   const now = snap?.at ?? 0;
   return (
     <div className="shrink-0 border-t border-line empty:hidden">
-      <EngineLimitsBlock engine="claude" label="Claude" limits={snap?.data.claude ?? null} payloadAccountId={snap?.data.claudeAccountId ?? null} now={now} staleHint={claudeStaleHint} onSwitched={invalidateLimits} />
-      <EngineLimitsBlock engine="codex" label="Codex" limits={snap?.data.codex ?? null} payloadAccountId={snap?.data.codexAccountId ?? null} now={now} staleHint={codexStaleHint} onSwitched={invalidateLimits} />
+      <EngineLimitsBlock engine="claude" label="Claude" limits={snap?.data.claude ?? null} payloadAccountId={snap?.data.claudeAccountId ?? null} now={now} staleHint={claudeStaleHint} provenance={snap?.data.provenance.claude ?? { source: "unavailable", reason: null, staleSince: null }} onSwitched={invalidateLimits} />
+      <EngineLimitsBlock engine="codex" label="Codex" limits={snap?.data.codex ?? null} payloadAccountId={snap?.data.codexAccountId ?? null} now={now} staleHint={codexStaleHint} provenance={snap?.data.provenance.codex ?? { source: "unavailable", reason: null, staleSince: null }} onSwitched={invalidateLimits} />
     </div>
   );
 }

--- a/src/components/LimitsFooter.tsx
+++ b/src/components/LimitsFooter.tsx
@@ -27,8 +27,8 @@ export function fmtStaleSince(staleSince: string | null | undefined, locale: Loc
   });
 }
 
-export function fmtUnavailableReason(meta: LimitsProvenance, locale: Locale): string | null {
-  if (meta.source !== "unavailable") return null;
+export function fmtLimitsFailureReason(meta: LimitsProvenance, locale: Locale): string | null {
+  if (meta.source !== "unavailable" && meta.source !== "cache") return null;
   if (meta.reason === LIMITS_REAUTH_REQUIRED_REASON) return translate(locale, "limits.reauthRequired");
   if (meta.reason !== LIMITS_RATE_LIMITED_REASON || !meta.retryAt) return null;
   const retryAt = new Date(meta.retryAt);
@@ -255,7 +255,8 @@ function EngineLimitsBlock({
   const activeLabel = activeAccount?.label ?? t("accounts.trigger");
   const effective = activeAccount?.effective;
   const draining = accounts.migration?.state === "draining";
-  const unavailableReason = fmtUnavailableReason(provenance, locale);
+  const failureReason = fmtLimitsFailureReason(provenance, locale);
+  const visibleFailureReason = accounts.status === "loading" || identityPending ? null : failureReason;
 
   return (
     <div ref={containerRef} className="relative">
@@ -308,14 +309,15 @@ function EngineLimitsBlock({
               setOpen(false);
               setChartOpen((value) => !value);
             }}
-            className="block w-full px-3.5 pb-3 pt-0.5 text-left hover:bg-bg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40"
+            className={`block w-full px-3.5 pt-0.5 text-left hover:bg-bg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 ${visibleFailureReason ? "pb-1.5" : "pb-3"}`}
           >
             <LimitRow label={t("limits.5h")} window={accountLimits!.session} engineColor={tint.color} now={now} />
             <LimitRow label={t("limits.week")} window={accountLimits!.weekly} engineColor={tint.color} now={now} />
           </button>
-        ) : (
-          <div className="px-3.5 pb-3 pt-0.5 text-[10px] text-dim">{accounts.status === "loading" || identityPending ? t("limits.accountLoading") : (unavailableReason ?? t("limits.noDataYet"))}</div>
+        ) : visibleFailureReason ? null : (
+          <div className="px-3.5 pb-3 pt-0.5 text-[10px] text-dim">{accounts.status === "loading" || identityPending ? t("limits.accountLoading") : t("limits.noDataYet")}</div>
         )}
+        {visibleFailureReason ? <div className="px-3.5 pb-3 pt-0.5 text-[10px] text-dim">{visibleFailureReason}</div> : null}
       </div>
       {open ? <AccountsPanel state={accounts} onClose={close} /> : null}
       {chartOpen ? <BurndownPanel key={accounts.active} engine={engine} label={label} plan={accountLimits?.plan ?? null} activeAccountId={accounts.active} onClose={closeChart} /> : null}

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -922,6 +922,9 @@ export const en = {
   "limits.week": "Week",
   "limits.accountsOpenAria": "Codex accounts — switch or add",
   "limits.noDataYet": "no data yet",
+  "limits.rateLimited": "Provider is rate-limiting requests.",
+  "limits.rateLimitedRetry": "Provider is rate-limiting requests. Retry at {time}.",
+  "limits.reauthRequired": "Re-login to Claude is required.",
 
   // Burndown chart (issue #36)
   "burndown.title": "burndown",

--- a/src/lib/i18n/uk.ts
+++ b/src/lib/i18n/uk.ts
@@ -889,6 +889,9 @@ export const uk: Record<keyof typeof en, Message> = {
   "limits.week": "Тиждень",
   "limits.accountsOpenAria": "Акаунти Codex — змінити або додати",
   "limits.noDataYet": "поки немає даних",
+  "limits.rateLimited": "Провайдер обмежує частоту запитів.",
+  "limits.rateLimitedRetry": "Провайдер обмежує частоту запитів. Наступна спроба о {time}.",
+  "limits.reauthRequired": "Потрібно повторно увійти в Claude.",
 
   // Burndown chart (issue #36)
   "burndown.title": "витрати",

--- a/src/lib/limits.test.ts
+++ b/src/lib/limits.test.ts
@@ -217,6 +217,36 @@ test("Claude 429 honors Retry-After when it exceeds the exponential delay", asyn
   }
 });
 
+test("Claude 429 preserves an HTTP-date Retry-After deadline across response latency", async () => {
+  resetLimitsCache();
+  const realFetch = globalThis.fetch;
+  let now = 10_000_000;
+  let fetches = 0;
+  const retryHeader = new Date(10_121_000).toUTCString();
+  const retryAt = Date.parse(retryHeader);
+  globalThis.fetch = (async () => {
+    fetches += 1;
+    if (fetches === 1) {
+      now = 10_001_500;
+      return new Response(null, { status: 429, headers: { "retry-after": retryHeader } });
+    }
+    return claudeUsage();
+  }) as unknown as typeof fetch;
+  try {
+    const limited = await readLimits({ codexLiveReader, now: () => now });
+    expect(limited.provenance.claude.retryAt).toBe(new Date(retryAt).toISOString());
+    now = retryAt - 1;
+    await readLimits({ codexLiveReader, now: () => now });
+    expect(fetches).toBe(1);
+    now = retryAt + 1;
+    const recovered = await readLimits({ codexLiveReader, now: () => now });
+    expect(recovered.provenance.claude.source).toBe("live");
+    expect(fetches).toBe(2);
+  } finally {
+    globalThis.fetch = realFetch;
+  }
+});
+
 test("Claude 401 records re-authentication provenance", async () => {
   resetLimitsCache();
   const realFetch = globalThis.fetch;

--- a/src/lib/limits.test.ts
+++ b/src/lib/limits.test.ts
@@ -34,6 +34,7 @@ const codexLiveReader = async () => ({
 
 function resetLimitsCache(): void {
   delete (globalThis as { __llvLimitsCache?: unknown }).__llvLimitsCache;
+  delete (globalThis as { __llvLimitsInflight?: unknown }).__llvLimitsInflight;
   fs.rmSync(path.join(process.env.LLV_STATE_DIR!, "limits-cache.json"), { force: true });
 }
 
@@ -251,6 +252,41 @@ test("a Claude success resets 429 backoff and preserves the fresh-cache fast pat
     const limitedAgain = await readLimits({ codexLiveReader, now: () => 4_090_002 });
     expect(limitedAgain.provenance.claude.retryAt).toBe(new Date(4_150_002).toISOString());
     expect(fetches).toBe(3);
+  } finally {
+    globalThis.fetch = realFetch;
+  }
+});
+
+test("concurrent Claude refreshes share one provider request at each retry boundary", async () => {
+  resetLimitsCache();
+  const realFetch = globalThis.fetch;
+  const deferred = <T,>() => {
+    let resolve!: (value: T) => void;
+    const promise = new Promise<T>((done) => { resolve = done; });
+    return { promise, resolve };
+  };
+  let response = deferred<Response>();
+  let fetches = 0;
+  globalThis.fetch = (async () => {
+    fetches += 1;
+    return response.promise;
+  }) as unknown as typeof fetch;
+  try {
+    const firstWave = Array.from({ length: 6 }, () => readLimits({ codexLiveReader, now: () => 5_000_000 }));
+    expect(fetches).toBe(1);
+    response.resolve(new Response(null, { status: 429 }));
+    const firstResults = await Promise.all(firstWave);
+    expect(firstResults.every((result) => result.provenance.claude.retryAt === new Date(5_060_000).toISOString())).toBeTrue();
+
+    response = deferred<Response>();
+    const secondWave = Array.from({ length: 6 }, () => readLimits({ codexLiveReader, now: () => 5_060_001 }));
+    expect(fetches).toBe(2);
+    response.resolve(new Response(null, { status: 429 }));
+    const secondResults = await Promise.all(secondWave);
+    expect(secondResults.every((result) => result.provenance.claude.retryAt === new Date(5_180_001).toISOString())).toBeTrue();
+
+    await readLimits({ codexLiveReader, now: () => 5_120_000 });
+    expect(fetches).toBe(2);
   } finally {
     globalThis.fetch = realFetch;
   }

--- a/src/lib/limits.test.ts
+++ b/src/lib/limits.test.ts
@@ -6,8 +6,12 @@ import path from "node:path";
 const SANDBOX = fs.mkdtempSync(path.join(os.tmpdir(), "llv-limits-account-test-"));
 const OLD_STATE = process.env.LLV_STATE_DIR;
 const OLD_HOME = process.env.LLV_CODEX_HOME;
+const OLD_CLAUDE_HOME = process.env.LLV_CLAUDE_HOME;
 process.env.LLV_STATE_DIR = path.join(SANDBOX, "state");
 process.env.LLV_CODEX_HOME = path.join(SANDBOX, "legacy");
+process.env.LLV_CLAUDE_HOME = path.join(SANDBOX, "legacy-claude");
+fs.mkdirSync(process.env.LLV_CLAUDE_HOME, { recursive: true });
+fs.writeFileSync(path.join(process.env.LLV_CLAUDE_HOME, ".credentials.json"), JSON.stringify({ claudeAiOauth: { accessToken: "test-token", subscriptionType: "max" } }), { mode: 0o600 });
 
 const { createManagedCodexAccount, setActiveCodexAccount } = await import("@/lib/accounts/codex");
 const { mapAppServerRateLimits, readCodexLimits, readLimits } = await import("./limits");
@@ -17,8 +21,25 @@ afterAll(() => {
   else process.env.LLV_STATE_DIR = OLD_STATE;
   if (OLD_HOME === undefined) delete process.env.LLV_CODEX_HOME;
   else process.env.LLV_CODEX_HOME = OLD_HOME;
+  if (OLD_CLAUDE_HOME === undefined) delete process.env.LLV_CLAUDE_HOME;
+  else process.env.LLV_CLAUDE_HOME = OLD_CLAUDE_HOME;
   fs.rmSync(SANDBOX, { recursive: true, force: true });
 });
+
+const codexLiveReader = async () => ({
+  primary: { usedPercent: 12, resetsAt: 100, windowDurationMins: 300 },
+  secondary: null,
+  planType: "pro",
+});
+
+function resetLimitsCache(): void {
+  delete (globalThis as { __llvLimitsCache?: unknown }).__llvLimitsCache;
+  fs.rmSync(path.join(process.env.LLV_STATE_DIR!, "limits-cache.json"), { force: true });
+}
+
+function claudeUsage(usedPercent = 20): Response {
+  return Response.json({ five_hour: { utilization: usedPercent } });
+}
 
 test("switching to an account without events never reuses another account's Codex limits", async () => {
   const legacySession = path.join(process.env.LLV_CODEX_HOME!, "sessions", "2026", "07", "09", "rollout.jsonl");
@@ -146,6 +167,90 @@ test("a fresh Claude cache still refreshes missing Codex limits", async () => {
     expect(payload.claude?.session?.usedPercent).toBe(11);
     expect(payload.codex?.session?.usedPercent).toBe(37);
     expect(payload.codexAccountId).toBe("default");
+  } finally {
+    globalThis.fetch = realFetch;
+  }
+});
+
+test("consecutive Claude 429s back off and suppress a third fetch inside the cooldown", async () => {
+  resetLimitsCache();
+  const realFetch = globalThis.fetch;
+  let fetches = 0;
+  globalThis.fetch = (async () => {
+    fetches += 1;
+    return new Response(null, { status: 429 });
+  }) as unknown as typeof fetch;
+  try {
+    const first = await readLimits({ codexLiveReader, now: () => 1_000_000 });
+    expect(first.provenance.claude).toMatchObject({ source: "unavailable", reason: "oauth-rate-limited", retryAt: new Date(1_060_000).toISOString() });
+    const second = await readLimits({ codexLiveReader, now: () => 1_060_001 });
+    expect(second.provenance.claude.retryAt).toBe(new Date(1_180_001).toISOString());
+    const third = await readLimits({ codexLiveReader, now: () => 1_120_000 });
+    expect(third.provenance.claude).toEqual(second.provenance.claude);
+    expect(fetches).toBe(2);
+  } finally {
+    globalThis.fetch = realFetch;
+  }
+});
+
+test("Claude 429 honors Retry-After when it exceeds the exponential delay", async () => {
+  resetLimitsCache();
+  const realFetch = globalThis.fetch;
+  let fetches = 0;
+  globalThis.fetch = (async () => {
+    fetches += 1;
+    return fetches === 1
+      ? new Response(null, { status: 429, headers: { "retry-after": "600" } })
+      : claudeUsage();
+  }) as unknown as typeof fetch;
+  try {
+    const limited = await readLimits({ codexLiveReader, now: () => 2_000_000 });
+    expect(limited.provenance.claude.retryAt).toBe(new Date(2_600_000).toISOString());
+    await readLimits({ codexLiveReader, now: () => 2_300_000 });
+    expect(fetches).toBe(1);
+    const recovered = await readLimits({ codexLiveReader, now: () => 2_600_001 });
+    expect(recovered.provenance.claude).toMatchObject({ source: "live", reason: null, retryAt: null });
+    expect(fetches).toBe(2);
+  } finally {
+    globalThis.fetch = realFetch;
+  }
+});
+
+test("Claude 401 records re-authentication provenance", async () => {
+  resetLimitsCache();
+  const realFetch = globalThis.fetch;
+  globalThis.fetch = (async () => new Response(null, { status: 401 })) as unknown as typeof fetch;
+  try {
+    const result = await readLimits({ codexLiveReader, now: () => 3_000_000 });
+    expect(result.provenance.claude).toMatchObject({
+      source: "unavailable",
+      reason: "oauth-reauthentication-required",
+      retryAt: new Date(3_060_000).toISOString(),
+    });
+  } finally {
+    globalThis.fetch = realFetch;
+  }
+});
+
+test("a Claude success resets 429 backoff and preserves the fresh-cache fast path", async () => {
+  resetLimitsCache();
+  const realFetch = globalThis.fetch;
+  const replies = [
+    new Response(null, { status: 429 }),
+    claudeUsage(21),
+    new Response(null, { status: 429 }),
+  ];
+  let fetches = 0;
+  globalThis.fetch = (async () => replies[fetches++]) as unknown as typeof fetch;
+  try {
+    await readLimits({ codexLiveReader, now: () => 4_000_000 });
+    const recovered = await readLimits({ codexLiveReader, now: () => 4_060_001 });
+    expect(recovered.claude?.session?.usedPercent).toBe(21);
+    await readLimits({ codexLiveReader, now: () => 4_080_000 });
+    expect(fetches).toBe(2);
+    const limitedAgain = await readLimits({ codexLiveReader, now: () => 4_090_002 });
+    expect(limitedAgain.provenance.claude.retryAt).toBe(new Date(4_150_002).toISOString());
+    expect(fetches).toBe(3);
   } finally {
     globalThis.fetch = realFetch;
   }

--- a/src/lib/limits.ts
+++ b/src/lib/limits.ts
@@ -40,7 +40,7 @@ export type LimitRead = {
   data: EngineLimits | null;
   reason: string | null;
   source: "live" | "transcript" | "unavailable";
-  retryAfterMs?: number;
+  retryAt?: number;
 };
 export type CodexLiveLimitsReader = (account: Pick<CodexAccount, "id" | "kind" | "home" | "sessionsDir">) => Promise<AppServerRateLimits>;
 
@@ -181,7 +181,7 @@ function resolveRead(read: LimitRead, cached: EngineCacheEntry | null, staleSinc
   const exponentialMs = consecutive429s > 0
     ? Math.min(FAILURE_COOLDOWN_MS * (2 ** (consecutive429s - 1)), MAX_RATE_LIMIT_BACKOFF_MS)
     : FAILURE_COOLDOWN_MS;
-  const retryAt = now + Math.max(exponentialMs, read.retryAfterMs ?? 0);
+  const retryAt = Math.max(now + exponentialMs, read.retryAt ?? 0);
   const meta: LimitsProvenance = {
     source: cached?.data ? "cache" : "unavailable",
     reason: read.reason,
@@ -217,7 +217,7 @@ function logFallbackReasons(entries: ReadonlyArray<readonly [EngineName, LimitsP
   }
 }
 
-function resolveEngineRead(engine: EngineName, accountId: string, now: number, reader: () => Promise<LimitRead>): Promise<ResolvedRead> {
+function resolveEngineRead(engine: EngineName, accountId: string, now: number, clock: () => number, reader: () => Promise<LimitRead>): Promise<ResolvedRead> {
   const cached = lastCache(engine, accountId);
   if (cacheIsFresh(cached, now)) return Promise.resolve(cachedRead(cached!));
 
@@ -230,7 +230,8 @@ function resolveEngineRead(engine: EngineName, accountId: string, now: number, r
     const latest = lastCache(engine, accountId);
     if (cacheIsFresh(latest, now)) return cachedRead(latest!);
     const read = await reader();
-    const resolved = resolveRead(read, latest, new Date(now).toISOString(), now);
+    const resolvedAt = clock();
+    const resolved = resolveRead(read, latest, new Date(resolvedAt).toISOString(), resolvedAt);
     logFallbackReasons([[engine, resolved.meta]]);
     remember(engine, accountId, resolved, now);
     return resolved;
@@ -245,12 +246,13 @@ function resolveEngineRead(engine: EngineName, accountId: string, now: number, r
 
 /** Claude Code + Codex plan limits, cached briefly so UI polling stays cheap. */
 export async function readLimits(options: { codexLiveReader?: CodexLiveLimitsReader; now?: () => number } = {}): Promise<LimitsPayload> {
-  const now = options.now?.() ?? Date.now();
+  const clock = options.now ?? Date.now;
+  const now = clock();
   const claudeAccount = claudeAccountForSpawn();
   const codexAccount = accountForSpawn();
   const [resolvedClaude, resolvedCodex] = await Promise.all([
-    resolveEngineRead("claude", claudeAccount.id, now, () => fetchClaudeLimits(path.join(claudeAccount.home, ".credentials.json"))),
-    resolveEngineRead("codex", codexAccount.id, now, () => readCodexLimits({ account: codexAccount, liveReader: options.codexLiveReader })),
+    resolveEngineRead("claude", claudeAccount.id, now, clock, () => fetchClaudeLimits(path.join(claudeAccount.home, ".credentials.json"), clock)),
+    resolveEngineRead("codex", codexAccount.id, now, clock, () => readCodexLimits({ account: codexAccount, liveReader: options.codexLiveReader })),
   ]);
   return {
     claude: resolvedClaude.data,
@@ -274,7 +276,7 @@ interface OauthWindow {
  * from ~/.claude/.credentials.json stays inside the server process; the
  * browser only ever sees percentages.
  */
-export async function fetchClaudeLimits(credentialsPath: string): Promise<LimitRead> {
+export async function fetchClaudeLimits(credentialsPath: string, clock: () => number = Date.now): Promise<LimitRead> {
   let accessToken = "";
   let plan: string | null = null;
   try {
@@ -295,7 +297,7 @@ export async function fetchClaudeLimits(credentialsPath: string): Promise<LimitR
       },
       signal: AbortSignal.timeout(8000),
     });
-    if (res.status === 429) return { data: null, reason: LIMITS_RATE_LIMITED_REASON, source: "unavailable", retryAfterMs: retryAfterMs(res.headers.get("retry-after")) };
+    if (res.status === 429) return { data: null, reason: LIMITS_RATE_LIMITED_REASON, source: "unavailable", retryAt: retryAfterAt(res.headers.get("retry-after"), clock()) };
     if (res.status === 401) return { data: null, reason: LIMITS_REAUTH_REQUIRED_REASON, source: "unavailable" };
     if (!res.ok) return { data: null, reason: `oauth usage status ${res.status}`, source: "unavailable" };
     const json = (await res.json()) as { five_hour?: OauthWindow; seven_day?: OauthWindow };
@@ -312,13 +314,13 @@ export async function fetchClaudeLimits(credentialsPath: string): Promise<LimitR
   }
 }
 
-function retryAfterMs(value: string | null, now = Date.now()): number | undefined {
+function retryAfterAt(value: string | null, now: number): number | undefined {
   if (!value) return undefined;
   const seconds = Number(value);
-  if (Number.isFinite(seconds) && seconds >= 0) return seconds * 1000;
+  if (Number.isFinite(seconds) && seconds >= 0) return now + seconds * 1000;
   const date = Date.parse(value);
   if (!Number.isFinite(date)) return undefined;
-  return Math.max(0, date - now);
+  return Math.max(now, date);
 }
 
 function oauthWindow(w: OauthWindow | undefined): LimitWindow | null {

--- a/src/lib/limits.ts
+++ b/src/lib/limits.ts
@@ -9,7 +9,7 @@ import { redactAppServerDetail } from "@/lib/accounts/codexAppServerProtocol";
 import { statePath } from "@/lib/configDir";
 import { WINDOW_SECONDS, clampPercent, mergeSamples, type WindowKey } from "@/lib/burndown";
 import { historySamples, historySince, recordLimitSample, RETENTION_S } from "@/lib/limitsHistoryStore";
-import type { BurndownPayload, BurndownSeries, EngineBurndown, EngineLimits, LimitSample, LimitsPayload, LimitsProvenance, LimitWindow } from "./types";
+import { LIMITS_RATE_LIMITED_REASON, LIMITS_REAUTH_REQUIRED_REASON, type BurndownPayload, type BurndownSeries, type EngineBurndown, type EngineLimits, type LimitSample, type LimitsPayload, type LimitsProvenance, type LimitWindow } from "./types";
 
 /** Resolved at call time (not module load) so LLV_STATE_DIR set after this
     module is first evaluated — e.g. in tests importing it statically — still
@@ -24,11 +24,24 @@ const TAIL_BYTES = 192 * 1024;
 /** Newest session files to try before giving up (fresh ones may lack limits). */
 const MAX_FILES = 12;
 const CACHE_MS = 30_000;
+const FAILURE_COOLDOWN_MS = 60_000;
+const MAX_RATE_LIMIT_BACKOFF_MS = 15 * 60_000;
 
 type EngineName = "claude" | "codex";
-type EngineCacheEntry = { at: number; data: EngineLimits; provenance: LimitsProvenance };
+type EngineCacheEntry = {
+  at: number;
+  data: EngineLimits | null;
+  provenance: LimitsProvenance;
+  retryAt?: number | null;
+  consecutive429s?: number;
+};
 type LimitsCache = { version: 2; engines: Record<EngineName, Record<string, EngineCacheEntry>> };
-export type LimitRead = { data: EngineLimits | null; reason: string | null; source: "live" | "transcript" | "unavailable" };
+export type LimitRead = {
+  data: EngineLimits | null;
+  reason: string | null;
+  source: "live" | "transcript" | "unavailable";
+  retryAfterMs?: number;
+};
 export type CodexLiveLimitsReader = (account: Pick<CodexAccount, "id" | "kind" | "home" | "sessionsDir">) => Promise<AppServerRateLimits>;
 
 const globalStore = globalThis as unknown as {
@@ -42,7 +55,8 @@ function isProvenance(value: unknown): value is { claude: LimitsProvenance; code
     if (!meta) return false;
     return (meta.source === "live" || meta.source === "transcript" || meta.source === "cache" || meta.source === "unavailable") &&
       (typeof meta.reason === "string" || meta.reason === null) &&
-      (typeof meta.staleSince === "string" || meta.staleSince === null);
+      (typeof meta.staleSince === "string" || meta.staleSince === null) &&
+      (meta.retryAt === undefined || typeof meta.retryAt === "string" || meta.retryAt === null);
   };
   return valid(record.claude) && valid(record.codex);
 }
@@ -54,11 +68,14 @@ function emptyCache(): LimitsCache {
 function safeCacheEntry(value: unknown): EngineCacheEntry | null {
   if (!value || typeof value !== "object") return null;
   const entry = value as Partial<EngineCacheEntry>;
-  if (typeof entry.at !== "number" || !entry.data || !entry.provenance) return null;
+  if (typeof entry.at !== "number" || entry.data === undefined || !entry.provenance) return null;
   const provenance = entry.provenance as Partial<LimitsProvenance>;
   if ((provenance.source !== "live" && provenance.source !== "transcript" && provenance.source !== "cache" && provenance.source !== "unavailable") ||
       (typeof provenance.reason !== "string" && provenance.reason !== null) ||
-      (typeof provenance.staleSince !== "string" && provenance.staleSince !== null)) return null;
+      (typeof provenance.staleSince !== "string" && provenance.staleSince !== null) ||
+      (provenance.retryAt !== undefined && typeof provenance.retryAt !== "string" && provenance.retryAt !== null) ||
+      (entry.retryAt !== undefined && entry.retryAt !== null && typeof entry.retryAt !== "number") ||
+      (entry.consecutive429s !== undefined && (!Number.isInteger(entry.consecutive429s) || entry.consecutive429s < 0))) return null;
   return entry as EngineCacheEntry;
 }
 
@@ -125,10 +142,23 @@ function lastCache(engine: EngineName, accountId: string): EngineCacheEntry | nu
   return cache().engines[engine][accountId] ?? null;
 }
 
-function remember(engine: EngineName, accountId: string, resolved: { data: EngineLimits | null; meta: LimitsProvenance }): void {
-  if (!resolved.data || resolved.meta.source === "cache" || resolved.meta.source === "unavailable") return;
-  cache().engines[engine][accountId] = { at: Date.now(), data: resolved.data, provenance: resolved.meta };
+type ResolvedRead = {
+  data: EngineLimits | null;
+  meta: LimitsProvenance;
+  retryAt: number | null;
+  consecutive429s: number;
+};
+
+function remember(engine: EngineName, accountId: string, resolved: ResolvedRead, now: number): void {
+  cache().engines[engine][accountId] = {
+    at: now,
+    data: resolved.data,
+    provenance: resolved.meta,
+    retryAt: resolved.retryAt,
+    consecutive429s: resolved.consecutive429s,
+  };
   writeDiskCache(cache());
+  if (!resolved.data || (resolved.meta.source !== "live" && resolved.meta.source !== "transcript")) return;
   // A fresh live/transcript value is also a burndown sample. The browser's 60s
   // poll drives this, so forward history accrues without a separate sampler.
   try {
@@ -142,40 +172,68 @@ function safeReason(reason: string): string {
   return redactAppServerDetail(reason);
 }
 
-function provenance(read: LimitRead, cached: EngineCacheEntry | null, staleSince: string): { data: EngineLimits | null; meta: LimitsProvenance } {
-  if (read.data) return { data: read.data, meta: { source: read.source, reason: read.reason, staleSince: read.reason ? staleSince : null } };
-  if (cached) return { data: cached.data, meta: { source: "cache", reason: read.reason, staleSince: cached.provenance.staleSince ?? staleSince } };
-  return { data: null, meta: { source: "unavailable", reason: read.reason, staleSince } };
+function resolveRead(read: LimitRead, cached: EngineCacheEntry | null, staleSince: string, now: number): ResolvedRead {
+  if (read.data) {
+    return { data: read.data, meta: { source: read.source, reason: read.reason, staleSince: read.reason ? staleSince : null, retryAt: null }, retryAt: null, consecutive429s: 0 };
+  }
+  const consecutive429s = read.reason === LIMITS_RATE_LIMITED_REASON ? (cached?.consecutive429s ?? 0) + 1 : 0;
+  const exponentialMs = consecutive429s > 0
+    ? Math.min(FAILURE_COOLDOWN_MS * (2 ** (consecutive429s - 1)), MAX_RATE_LIMIT_BACKOFF_MS)
+    : FAILURE_COOLDOWN_MS;
+  const retryAt = now + Math.max(exponentialMs, read.retryAfterMs ?? 0);
+  const meta: LimitsProvenance = {
+    source: cached?.data ? "cache" : "unavailable",
+    reason: read.reason,
+    staleSince: cached?.provenance.staleSince ?? staleSince,
+    retryAt: new Date(retryAt).toISOString(),
+  };
+  return { data: cached?.data ?? null, meta, retryAt, consecutive429s };
 }
 
-function logFallbackReasons(claude: LimitsProvenance, codex: LimitsProvenance): void {
-  for (const [engine, meta] of Object.entries({ claude, codex })) {
+function cachedRead(entry: EngineCacheEntry): ResolvedRead {
+  return {
+    data: entry.data,
+    meta: entry.provenance,
+    retryAt: entry.retryAt ?? null,
+    consecutive429s: entry.consecutive429s ?? 0,
+  };
+}
+
+function cacheIsFresh(entry: EngineCacheEntry | null, now: number): boolean {
+  if (!entry) return false;
+  if (entry.retryAt) return now < entry.retryAt;
+  return now - entry.at < CACHE_MS;
+}
+
+function logFallbackReasons(entries: ReadonlyArray<readonly [EngineName, LimitsProvenance]>): void {
+  for (const [engine, meta] of entries) {
     if (meta.reason) console.warn(`[limits] ${engine} fallback: ${safeReason(meta.reason)}`);
   }
 }
 
 /** Claude Code + Codex plan limits, cached briefly so UI polling stays cheap. */
-export async function readLimits(options: { codexLiveReader?: CodexLiveLimitsReader } = {}): Promise<LimitsPayload> {
+export async function readLimits(options: { codexLiveReader?: CodexLiveLimitsReader; now?: () => number } = {}): Promise<LimitsPayload> {
+  const now = options.now?.() ?? Date.now();
   const claudeAccount = claudeAccountForSpawn();
   const codexAccount = accountForSpawn();
   const cachedClaude = lastCache("claude", claudeAccount.id);
   const cachedCodex = lastCache("codex", codexAccount.id);
-  const claudeFresh = Boolean(cachedClaude && Date.now() - cachedClaude.at < CACHE_MS);
-  const codexFresh = Boolean(cachedCodex && Date.now() - cachedCodex.at < CACHE_MS);
+  const claudeFresh = cacheIsFresh(cachedClaude, now);
+  const codexFresh = cacheIsFresh(cachedCodex, now);
   if (claudeFresh && codexFresh) {
     return { claude: cachedClaude?.data ?? null, codex: cachedCodex?.data ?? null, claudeAccountId: claudeAccount.id, codexAccountId: codexAccount.id, provenance: { claude: cachedClaude?.provenance ?? { source: "unavailable", reason: "no cached Claude limits", staleSince: null }, codex: cachedCodex?.provenance ?? { source: "unavailable", reason: "no cached Codex limits", staleSince: null } }, staleSince: cachedClaude?.provenance.staleSince ?? cachedCodex?.provenance.staleSince ?? null };
   }
-  const staleSince = new Date().toISOString();
+  const staleSince = new Date(now).toISOString();
   const [claude, codex] = await Promise.all([
     claudeFresh ? Promise.resolve(null) : fetchClaudeLimits(path.join(claudeAccount.home, ".credentials.json")),
     codexFresh ? Promise.resolve(null) : readCodexLimits({ account: codexAccount, liveReader: options.codexLiveReader }),
   ]);
   const resolvedClaude = claudeFresh
-    ? { data: cachedClaude!.data, meta: cachedClaude!.provenance }
-    : provenance(claude!, cachedClaude, staleSince);
+    ? cachedRead(cachedClaude!)
+    : resolveRead(claude!, cachedClaude, staleSince, now);
   const resolvedCodex = codexFresh
-    ? { data: cachedCodex!.data, meta: cachedCodex!.provenance }
-    : provenance(codex!, cachedCodex, staleSince);
+    ? cachedRead(cachedCodex!)
+    : resolveRead(codex!, cachedCodex, staleSince, now);
   const data: LimitsPayload = {
     claude: resolvedClaude.data,
     codex: resolvedCodex.data,
@@ -184,9 +242,12 @@ export async function readLimits(options: { codexLiveReader?: CodexLiveLimitsRea
     provenance: { claude: resolvedClaude.meta, codex: resolvedCodex.meta },
     staleSince: resolvedClaude.meta.staleSince ?? resolvedCodex.meta.staleSince,
   };
-  logFallbackReasons(data.provenance.claude, data.provenance.codex);
-  if (!claudeFresh) remember("claude", claudeAccount.id, resolvedClaude);
-  if (!codexFresh) remember("codex", codexAccount.id, resolvedCodex);
+  logFallbackReasons([
+    ...(!claudeFresh ? [["claude", data.provenance.claude] as const] : []),
+    ...(!codexFresh ? [["codex", data.provenance.codex] as const] : []),
+  ]);
+  if (!claudeFresh) remember("claude", claudeAccount.id, resolvedClaude, now);
+  if (!codexFresh) remember("codex", codexAccount.id, resolvedCodex, now);
   return data;
 }
 
@@ -223,6 +284,8 @@ export async function fetchClaudeLimits(credentialsPath: string): Promise<LimitR
       },
       signal: AbortSignal.timeout(8000),
     });
+    if (res.status === 429) return { data: null, reason: LIMITS_RATE_LIMITED_REASON, source: "unavailable", retryAfterMs: retryAfterMs(res.headers.get("retry-after")) };
+    if (res.status === 401) return { data: null, reason: LIMITS_REAUTH_REQUIRED_REASON, source: "unavailable" };
     if (!res.ok) return { data: null, reason: `oauth usage status ${res.status}`, source: "unavailable" };
     const json = (await res.json()) as { five_hour?: OauthWindow; seven_day?: OauthWindow };
     const data = {
@@ -236,6 +299,15 @@ export async function fetchClaudeLimits(credentialsPath: string): Promise<LimitR
   } catch (err) {
     return { data: null, reason: `oauth usage fetch failed: ${err instanceof Error ? err.message : String(err)}`, source: "unavailable" };
   }
+}
+
+function retryAfterMs(value: string | null, now = Date.now()): number | undefined {
+  if (!value) return undefined;
+  const seconds = Number(value);
+  if (Number.isFinite(seconds) && seconds >= 0) return seconds * 1000;
+  const date = Date.parse(value);
+  if (!Number.isFinite(date)) return undefined;
+  return Math.max(0, date - now);
 }
 
 function oauthWindow(w: OauthWindow | undefined): LimitWindow | null {

--- a/src/lib/limits.ts
+++ b/src/lib/limits.ts
@@ -46,6 +46,7 @@ export type CodexLiveLimitsReader = (account: Pick<CodexAccount, "id" | "kind" |
 
 const globalStore = globalThis as unknown as {
   __llvLimitsCache?: LimitsCache | null;
+  __llvLimitsInflight?: Map<string, Promise<ResolvedRead>>;
 };
 
 function isProvenance(value: unknown): value is { claude: LimitsProvenance; codex: LimitsProvenance } {
@@ -205,10 +206,41 @@ function cacheIsFresh(entry: EngineCacheEntry | null, now: number): boolean {
   return now - entry.at < CACHE_MS;
 }
 
+function inflightReads(): Map<string, Promise<ResolvedRead>> {
+  if (!globalStore.__llvLimitsInflight) globalStore.__llvLimitsInflight = new Map();
+  return globalStore.__llvLimitsInflight;
+}
+
 function logFallbackReasons(entries: ReadonlyArray<readonly [EngineName, LimitsProvenance]>): void {
   for (const [engine, meta] of entries) {
     if (meta.reason) console.warn(`[limits] ${engine} fallback: ${safeReason(meta.reason)}`);
   }
+}
+
+function resolveEngineRead(engine: EngineName, accountId: string, now: number, reader: () => Promise<LimitRead>): Promise<ResolvedRead> {
+  const cached = lastCache(engine, accountId);
+  if (cacheIsFresh(cached, now)) return Promise.resolve(cachedRead(cached!));
+
+  const key = `${engine}:${accountId}`;
+  const reads = inflightReads();
+  const existing = reads.get(key);
+  if (existing) return existing;
+
+  const pending = (async () => {
+    const latest = lastCache(engine, accountId);
+    if (cacheIsFresh(latest, now)) return cachedRead(latest!);
+    const read = await reader();
+    const resolved = resolveRead(read, latest, new Date(now).toISOString(), now);
+    logFallbackReasons([[engine, resolved.meta]]);
+    remember(engine, accountId, resolved, now);
+    return resolved;
+  })();
+  reads.set(key, pending);
+  const clear = () => {
+    if (reads.get(key) === pending) reads.delete(key);
+  };
+  void pending.then(clear, clear);
+  return pending;
 }
 
 /** Claude Code + Codex plan limits, cached briefly so UI polling stays cheap. */
@@ -216,25 +248,11 @@ export async function readLimits(options: { codexLiveReader?: CodexLiveLimitsRea
   const now = options.now?.() ?? Date.now();
   const claudeAccount = claudeAccountForSpawn();
   const codexAccount = accountForSpawn();
-  const cachedClaude = lastCache("claude", claudeAccount.id);
-  const cachedCodex = lastCache("codex", codexAccount.id);
-  const claudeFresh = cacheIsFresh(cachedClaude, now);
-  const codexFresh = cacheIsFresh(cachedCodex, now);
-  if (claudeFresh && codexFresh) {
-    return { claude: cachedClaude?.data ?? null, codex: cachedCodex?.data ?? null, claudeAccountId: claudeAccount.id, codexAccountId: codexAccount.id, provenance: { claude: cachedClaude?.provenance ?? { source: "unavailable", reason: "no cached Claude limits", staleSince: null }, codex: cachedCodex?.provenance ?? { source: "unavailable", reason: "no cached Codex limits", staleSince: null } }, staleSince: cachedClaude?.provenance.staleSince ?? cachedCodex?.provenance.staleSince ?? null };
-  }
-  const staleSince = new Date(now).toISOString();
-  const [claude, codex] = await Promise.all([
-    claudeFresh ? Promise.resolve(null) : fetchClaudeLimits(path.join(claudeAccount.home, ".credentials.json")),
-    codexFresh ? Promise.resolve(null) : readCodexLimits({ account: codexAccount, liveReader: options.codexLiveReader }),
+  const [resolvedClaude, resolvedCodex] = await Promise.all([
+    resolveEngineRead("claude", claudeAccount.id, now, () => fetchClaudeLimits(path.join(claudeAccount.home, ".credentials.json"))),
+    resolveEngineRead("codex", codexAccount.id, now, () => readCodexLimits({ account: codexAccount, liveReader: options.codexLiveReader })),
   ]);
-  const resolvedClaude = claudeFresh
-    ? cachedRead(cachedClaude!)
-    : resolveRead(claude!, cachedClaude, staleSince, now);
-  const resolvedCodex = codexFresh
-    ? cachedRead(cachedCodex!)
-    : resolveRead(codex!, cachedCodex, staleSince, now);
-  const data: LimitsPayload = {
+  return {
     claude: resolvedClaude.data,
     codex: resolvedCodex.data,
     claudeAccountId: claudeAccount.id,
@@ -242,13 +260,6 @@ export async function readLimits(options: { codexLiveReader?: CodexLiveLimitsRea
     provenance: { claude: resolvedClaude.meta, codex: resolvedCodex.meta },
     staleSince: resolvedClaude.meta.staleSince ?? resolvedCodex.meta.staleSince,
   };
-  logFallbackReasons([
-    ...(!claudeFresh ? [["claude", data.provenance.claude] as const] : []),
-    ...(!codexFresh ? [["codex", data.provenance.codex] as const] : []),
-  ]);
-  if (!claudeFresh) remember("claude", claudeAccount.id, resolvedClaude, now);
-  if (!codexFresh) remember("codex", codexAccount.id, resolvedCodex, now);
-  return data;
 }
 
 /* ------------------------------- Claude ------------------------------- */

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -314,7 +314,12 @@ export interface LimitsProvenance {
   source: "live" | "transcript" | "cache" | "unavailable";
   reason: string | null;
   staleSince: string | null;
+  /** ISO timestamp for the next provider refresh after a failed read. */
+  retryAt?: string | null;
 }
+
+export const LIMITS_RATE_LIMITED_REASON = "oauth-rate-limited";
+export const LIMITS_REAUTH_REQUIRED_REASON = "oauth-reauthentication-required";
 
 export interface LimitsPayload {
   claude: EngineLimits | null;


### PR DESCRIPTION
## Summary

- persist failed per-account limits reads with cooldown metadata
- apply exponential Claude 429 backoff and honor Retry-After
- surface rate limiting, retry timing, and re-authentication guidance in English and Ukrainian
- cover 429 scheduling, Retry-After, 401 provenance, recovery reset, and fresh-cache reuse

Refs #97

## Verification

- `bun test`
- `bunx tsc --noEmit`