### PR TITLE
runtime: add Codex structured host adapter

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -1,17 +1,20 @@
-# PR #143: Claude limits backoff and footer visibility
+# PR #152: EngineHost interface and CodexAppServerHost
 
 ## Task statement
 
-Back off Claude limits polling after provider failures, honor `Retry-After`, distinguish re-authentication failures, and keep footer status honest in English and Ukrainian.
+Implement issue #149 from the issue #25 runtime spike: define the shared structured-host contract, add the Codex app-server adapter on ChatGPT subscription authentication, persist its mutable host state beside the durable engine thread identity, and support restart adoption through `thread/resume`.
 
 ## Acceptance criteria
 
-- AC1: Failed limits reads are cached per engine and account for a cooldown.
-- AC2: Consecutive Claude 429 responses use a 1m, 2m, 4m exponential schedule capped at 15m.
-- AC3: A valid `Retry-After` extends the cooldown when required by the provider.
-- AC4: Concurrent refreshes for one engine and account share one upstream request.
-- AC5: A successful read resets the 429 backoff and preserves the fresh-cache fast path.
-- AC6: Claude 429 provenance shows provider throttling and the next retry time, including when retained quota windows come from cache.
-- AC7: Claude 401 provenance shows re-login guidance, including when retained quota windows come from cache.
-- AC8: Footer status strings remain aligned in English and Ukrainian.
-- AC9: `bun test` and `bunx tsc --noEmit` pass.
+- AC1: `EngineHost` exposes `attach(afterSeq)`, `send`, `interrupt`, `answer`, `health`, and `release` with the spike contract semantics.
+- AC2: `CodexAppServerHost` maps the contract to app-server JSON-RPC over stdio and uses the Codex thread ID as durable session identity.
+- AC3: Structured hosting activates only when `LLV_STRUCTURED_HOSTS=1`; the default state remains disabled.
+- AC4: Existing tmux delivery paths, flow engines, and UI remain unchanged.
+- AC5: Registry state persists host kind, endpoint, PID plus process-start identity, event cursor, protocol version, writer-claim epoch, active turn reference, and pending attention.
+- AC6: Viewer restart adoption resumes every eligible Codex registry row through `thread/resume`.
+- AC7: Delivery maps queue entry IDs to `clientUserMessageId`, active turns use `expectedTurnId`, interruption stays explicit, and structured attention can be answered.
+- AC8: The real Codex CLI integration starts a thread, attaches a late client, steers the active turn, restarts the host process, and resumes the same thread on the ChatGPT subscription.
+- AC9: The real integration skips gracefully when the Codex CLI is unavailable.
+- AC10: API keys and authentication tokens never cross into the child environment or diagnostic output.
+- AC11: `bun test`, touched-file ESLint, and `bunx tsc --noEmit` pass.
+- AC12: A fresh independent review reaches a clean APPROVE verdict.

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -1,7 +1,13 @@
 export async function register(): Promise<void> {
   if (process.env.NEXT_RUNTIME === "edge" || process.env.NEXT_PHASE?.includes("build")) return;
-  if (process.env.LLV_ACCOUNT_CONTROLLER_DISABLED === "1") return;
-  const { startAccountMigrationController } = await import("@/lib/accounts/migration/controller");
-  try { await startAccountMigrationController(); }
-  catch { console.error("[account migration controller] initial durable reconciliation failed"); }
+  if (process.env.LLV_STRUCTURED_HOSTS === "1") {
+    const { adoptStructuredHostsAtStartup } = await import("@/lib/runtime/startup");
+    try { await adoptStructuredHostsAtStartup(); }
+    catch { console.error("[structured hosts] startup adoption failed"); }
+  }
+  if (process.env.LLV_ACCOUNT_CONTROLLER_DISABLED !== "1") {
+    const { startAccountMigrationController } = await import("@/lib/accounts/migration/controller");
+    try { await startAccountMigrationController(); }
+    catch { console.error("[account migration controller] initial durable reconciliation failed"); }
+  }
 }

--- a/src/lib/agent/registry.ts
+++ b/src/lib/agent/registry.ts
@@ -43,6 +43,17 @@ export interface TmuxHostEvidence {
   argv: string[];
 }
 
+export interface StructuredHostColumns {
+  kind: "codex-app-server" | "claude-broker";
+  endpoint: string;
+  process: ProcessIdentity | null;
+  eventCursor: number;
+  protocolVersion: string | null;
+  writerClaimEpoch: number;
+  activeTurnRef: string | null;
+  pendingAttention: string[];
+}
+
 /** Immutable tmux facts captured before readiness polling can expose a new
     pane to the observer. They are the only durable correlation between a
     launch receipt and an externally observed host. */
@@ -65,6 +76,8 @@ export interface AgentRegistryEntry {
   launchProfile?: LaunchProfile;
   status: AgentHostStatus;
   host: TmuxHostEvidence | null;
+  /** Structured hosting metadata lives beside legacy tmux evidence during migration. */
+  structuredHost?: StructuredHostColumns | null;
   claimEpoch: number;
   claimOwner: string | null;
   pendingAction: "spawn" | "resume" | "handoff" | null;
@@ -548,6 +561,36 @@ function normalizeGeneration(value: NativeGeneration): NativeGeneration {
   };
 }
 
+function normalizeStructuredHost(value: unknown): StructuredHostColumns | null {
+  if (!value || typeof value !== "object") return null;
+  const host = value as Partial<StructuredHostColumns>;
+  if (host.kind !== "codex-app-server" && host.kind !== "claude-broker") return null;
+  const processIdentity = host.process && typeof host.process === "object"
+    && typeof host.process.pid === "number"
+    ? { pid: host.process.pid, startIdentity: typeof host.process.startIdentity === "string" ? host.process.startIdentity : null }
+    : null;
+  return {
+    kind: host.kind,
+    endpoint: typeof host.endpoint === "string" ? host.endpoint : "",
+    process: processIdentity,
+    eventCursor: Number.isSafeInteger(host.eventCursor) && (host.eventCursor ?? -1) >= 0 ? host.eventCursor! : 0,
+    protocolVersion: typeof host.protocolVersion === "string" ? host.protocolVersion : null,
+    writerClaimEpoch: Number.isSafeInteger(host.writerClaimEpoch) && (host.writerClaimEpoch ?? -1) >= 0 ? host.writerClaimEpoch! : 0,
+    activeTurnRef: typeof host.activeTurnRef === "string" ? host.activeTurnRef : null,
+    pendingAttention: Array.isArray(host.pendingAttention)
+      ? host.pendingAttention.filter((item): item is string => typeof item === "string")
+      : [],
+  };
+}
+
+function normalizeEntry(value: AgentRegistryEntry): AgentRegistryEntry {
+  return {
+    ...value,
+    host: value.host && typeof value.host === "object" && value.host.kind === "tmux" ? value.host : null,
+    structuredHost: normalizeStructuredHost(value.structuredHost),
+  };
+}
+
 function normalizeProviderReceipt(value: ProviderReceipt | null | undefined): ProviderReceipt | null {
   if (!value || typeof value !== "object") return null;
   return {
@@ -908,7 +951,7 @@ function readFile(filename: string): RegistryFile {
     const legacy = parsed.legacyResumePanes;
     return {
       version: 2,
-      entries: parsed.entries,
+      entries: Object.fromEntries(Object.entries(parsed.entries).map(([id, entry]) => [id, normalizeEntry(entry)])),
       receipts: Object.fromEntries(Object.entries(parsed.receipts).map(([id, receipt]) => [id, normalizeReceipt(receipt)])),
       lineageEdges: parsed.lineageEdges && typeof parsed.lineageEdges === "object" ? parsed.lineageEdges : {},
       importedResumePanes: parsed.importedResumePanes === true,
@@ -1401,6 +1444,21 @@ export class AgentRegistry {
       file.entries[keyId] = full;
       advanceMigrationScopeRevision(file, entry.key.engine, readinessBefore, changedHostPaths);
       return clone(full);
+    });
+  }
+
+  setStructuredHost(
+    key: SessionKey,
+    structuredHost: StructuredHostColumns | null,
+    status?: AgentHostStatus,
+  ): AgentRegistryEntry {
+    return this.mutate((file) => {
+      const entry = file.entries[sessionKeyId(key)];
+      if (!entry) throw new Error("agent registry entry is missing");
+      entry.structuredHost = structuredHost ? normalizeStructuredHost(structuredHost) : null;
+      if (status) entry.status = status;
+      entry.updatedAt = now();
+      return clone(entry);
     });
   }
 

--- a/src/lib/agent/registry.ts
+++ b/src/lib/agent/registry.ts
@@ -54,6 +54,24 @@ export interface StructuredHostColumns {
   pendingAttention: string[];
 }
 
+const STRUCTURED_CLAIM_PREFIX = "structured-host:";
+
+function structuredClaimOwner(identity: ProcessIdentity): string {
+  return `${STRUCTURED_CLAIM_PREFIX}${JSON.stringify(identity)}`;
+}
+
+function structuredClaimIdentity(owner: string): ProcessIdentity | null {
+  if (!owner.startsWith(STRUCTURED_CLAIM_PREFIX)) return null;
+  try {
+    const identity = JSON.parse(owner.slice(STRUCTURED_CLAIM_PREFIX.length)) as Partial<ProcessIdentity>;
+    return Number.isInteger(identity.pid) && identity.pid! > 0
+      ? { pid: identity.pid!, startIdentity: typeof identity.startIdentity === "string" ? identity.startIdentity : null }
+      : null;
+  } catch {
+    return null;
+  }
+}
+
 /** Immutable tmux facts captured before readiness polling can expose a new
     pane to the observer. They are the only durable correlation between a
     launch receipt and an externally observed host. */
@@ -1453,10 +1471,39 @@ export class AgentRegistry {
     status?: AgentHostStatus,
   ): AgentRegistryEntry {
     return this.mutate((file) => {
-      const entry = file.entries[sessionKeyId(key)];
+      const keyId = sessionKeyId(key);
+      const entry = file.entries[keyId];
       if (!entry) throw new Error("agent registry entry is missing");
+      const replacement = {
+        ...entry,
+        structuredHost: structuredHost ? normalizeStructuredHost(structuredHost) : null,
+        status: status ?? entry.status,
+      };
+      const changedHostPaths = activeHostPathsChangedByEntry(file, keyId, replacement);
+      const readinessBefore = migrationReadinessSignature(file, key.engine, changedHostPaths);
       entry.structuredHost = structuredHost ? normalizeStructuredHost(structuredHost) : null;
       if (status) entry.status = status;
+      entry.updatedAt = now();
+      advanceMigrationScopeRevision(file, key.engine, readinessBefore, changedHostPaths);
+      return clone(entry);
+    });
+  }
+
+  /** Atomically claims a stale structured row and advances its writer fence. */
+  claimStructuredHost(key: SessionKey, owner: ProcessIdentity): AgentRegistryEntry | null {
+    return this.mutate((file) => {
+      const entry = file.entries[sessionKeyId(key)];
+      if (!entry?.structuredHost) return null;
+      const liveHost = entry.structuredHost.process;
+      if (liveHost && this.ownerAlive(liveHost)) return null;
+      const requestedOwner = structuredClaimOwner(owner);
+      if (entry.claimOwner && entry.claimOwner !== requestedOwner) {
+        const priorOwner = structuredClaimIdentity(entry.claimOwner);
+        if (!priorOwner || this.ownerAlive(priorOwner)) return null;
+      }
+      entry.claimOwner = requestedOwner;
+      entry.claimEpoch += 1;
+      entry.structuredHost.writerClaimEpoch = entry.claimEpoch;
       entry.updatedAt = now();
       return clone(entry);
     });

--- a/src/lib/agent/registry.ts
+++ b/src/lib/agent/registry.ts
@@ -1460,9 +1460,13 @@ export class AgentRegistry {
   upsert(entry: Omit<AgentRegistryEntry, "updatedAt">): AgentRegistryEntry {
     return this.mutate((file) => {
       const keyId = sessionKeyId(entry.key);
-      const changedHostPaths = activeHostPathsChangedByEntry(file, keyId, entry);
+      const existing = file.entries[keyId];
+      const replacement = entry.structuredHost === undefined && existing?.structuredHost !== undefined
+        ? { ...entry, structuredHost: existing.structuredHost }
+        : entry;
+      const changedHostPaths = activeHostPathsChangedByEntry(file, keyId, replacement);
       const readinessBefore = migrationReadinessSignature(file, entry.key.engine, changedHostPaths);
-      const full = { ...entry, updatedAt: now() };
+      const full = { ...replacement, updatedAt: now() };
       file.entries[keyId] = full;
       advanceMigrationScopeRevision(file, entry.key.engine, readinessBefore, changedHostPaths);
       return clone(full);
@@ -1523,6 +1527,13 @@ export class AgentRegistry {
       advanceMigrationScopeRevision(file, key.engine, readinessBefore, changedHostPaths);
       return clone(entry);
     });
+  }
+
+  ownsStructuredHostClaim(key: SessionKey, claimOwner: string, claimEpoch: number): boolean {
+    const entry = this.snapshot().entries[sessionKeyId(key)];
+    return entry?.claimOwner === claimOwner
+      && entry.claimEpoch === claimEpoch
+      && entry.structuredHost?.writerClaimEpoch === claimEpoch;
   }
 
   /** Atomically claims a stale structured row and advances its writer fence. */

--- a/src/lib/agent/registry.ts
+++ b/src/lib/agent/registry.ts
@@ -1526,10 +1526,15 @@ export class AgentRegistry {
   }
 
   /** Atomically claims a stale structured row and advances its writer fence. */
-  claimStructuredHost(key: SessionKey, owner: ProcessIdentity): AgentRegistryEntry | null {
+  claimStructuredHost(
+    key: SessionKey,
+    owner: ProcessIdentity,
+    options: { allowUnhosted?: boolean } = {},
+  ): AgentRegistryEntry | null {
     return this.mutate((file) => {
       const entry = file.entries[sessionKeyId(key)];
       if (!entry?.structuredHost) return null;
+      if (entry.status === "unhosted" && options.allowUnhosted !== true) return null;
       const liveHost = entry.structuredHost.process;
       if (liveHost && this.ownerAlive(liveHost)) return null;
       const requestedOwner = structuredClaimOwner(owner);

--- a/src/lib/agent/registry.ts
+++ b/src/lib/agent/registry.ts
@@ -1565,11 +1565,12 @@ export class AgentRegistry {
     this.mutate((file) => {
       const entry = file.entries[sessionKeyId(key)];
       if (!entry) return;
-      const replacement = { ...entry, host: null, status: "unhosted" as const };
+      const status = entry.structuredHost?.process ? entry.status : "unhosted";
+      const replacement = { ...entry, host: null, status };
       const changedHostPaths = activeHostPathsChangedByEntry(file, sessionKeyId(key), replacement);
       const readinessBefore = migrationReadinessSignature(file, key.engine, changedHostPaths);
       entry.host = null;
-      entry.status = "unhosted";
+      entry.status = status;
       entry.updatedAt = now();
       advanceMigrationScopeRevision(file, key.engine, readinessBefore, changedHostPaths);
     });

--- a/src/lib/agent/registry.ts
+++ b/src/lib/agent/registry.ts
@@ -1500,6 +1500,7 @@ export class AgentRegistry {
     status: AgentHostStatus,
     claimOwner: string,
     claimEpoch: number,
+    releaseClaim = false,
   ): AgentRegistryEntry | null {
     return this.mutate((file) => {
       const keyId = sessionKeyId(key);
@@ -1517,6 +1518,7 @@ export class AgentRegistry {
       const readinessBefore = migrationReadinessSignature(file, key.engine, changedHostPaths);
       entry.structuredHost = replacement.structuredHost;
       entry.status = status;
+      if (releaseClaim) entry.claimOwner = null;
       entry.updatedAt = now();
       advanceMigrationScopeRevision(file, key.engine, readinessBefore, changedHostPaths);
       return clone(entry);
@@ -1576,6 +1578,20 @@ export class AgentRegistry {
         entry.claimOwner = null;
         entry.updatedAt = now();
       }
+    });
+  }
+
+  /** Releases a structured writer only while both ownership fences still match. */
+  releaseStructuredHostClaim(key: SessionKey, owner: string, claimEpoch: number): boolean {
+    return this.mutate((file) => {
+      const entry = file.entries[sessionKeyId(key)];
+      if (!entry?.structuredHost
+        || entry.claimOwner !== owner
+        || entry.claimEpoch !== claimEpoch
+        || entry.structuredHost.writerClaimEpoch !== claimEpoch) return false;
+      entry.claimOwner = null;
+      entry.updatedAt = now();
+      return true;
     });
   }
 

--- a/src/lib/agent/registry.ts
+++ b/src/lib/agent/registry.ts
@@ -52,6 +52,7 @@ export interface StructuredHostColumns {
   writerClaimEpoch: number;
   activeTurnRef: string | null;
   pendingAttention: string[];
+  activeFlags: string[];
 }
 
 const STRUCTURED_CLAIM_PREFIX = "structured-host:";
@@ -597,6 +598,9 @@ function normalizeStructuredHost(value: unknown): StructuredHostColumns | null {
     activeTurnRef: typeof host.activeTurnRef === "string" ? host.activeTurnRef : null,
     pendingAttention: Array.isArray(host.pendingAttention)
       ? host.pendingAttention.filter((item): item is string => typeof item === "string")
+      : [],
+    activeFlags: Array.isArray(host.activeFlags)
+      ? host.activeFlags.filter((item): item is string => typeof item === "string")
       : [],
   };
 }
@@ -1483,6 +1487,36 @@ export class AgentRegistry {
       const readinessBefore = migrationReadinessSignature(file, key.engine, changedHostPaths);
       entry.structuredHost = structuredHost ? normalizeStructuredHost(structuredHost) : null;
       if (status) entry.status = status;
+      entry.updatedAt = now();
+      advanceMigrationScopeRevision(file, key.engine, readinessBefore, changedHostPaths);
+      return clone(entry);
+    });
+  }
+
+  /** Writes mutable host state only while the caller still owns its writer fence. */
+  setStructuredHostClaimed(
+    key: SessionKey,
+    structuredHost: StructuredHostColumns,
+    status: AgentHostStatus,
+    claimOwner: string,
+    claimEpoch: number,
+  ): AgentRegistryEntry | null {
+    return this.mutate((file) => {
+      const keyId = sessionKeyId(key);
+      const entry = file.entries[keyId];
+      if (!entry?.structuredHost
+        || entry.claimOwner !== claimOwner
+        || entry.claimEpoch !== claimEpoch
+        || entry.structuredHost.writerClaimEpoch !== claimEpoch) return null;
+      const replacement = {
+        ...entry,
+        structuredHost: normalizeStructuredHost(structuredHost),
+        status,
+      };
+      const changedHostPaths = activeHostPathsChangedByEntry(file, keyId, replacement);
+      const readinessBefore = migrationReadinessSignature(file, key.engine, changedHostPaths);
+      entry.structuredHost = replacement.structuredHost;
+      entry.status = status;
       entry.updatedAt = now();
       advanceMigrationScopeRevision(file, key.engine, readinessBefore, changedHostPaths);
       return clone(entry);

--- a/src/lib/runtime/codexAppServerHost.integration.test.ts
+++ b/src/lib/runtime/codexAppServerHost.integration.test.ts
@@ -1,0 +1,89 @@
+import { spawnSync } from "node:child_process";
+import { test, expect } from "bun:test";
+
+import { CodexAppServerHost } from "./codexAppServerHost";
+import type { RuntimeEvent } from "./engineHost";
+
+const codexPresent = spawnSync(process.env.LLV_CODEX_BINARY ?? "codex", ["--version"], { stdio: "ignore" }).status === 0;
+
+async function waitFor(
+  iterator: AsyncIterator<RuntimeEvent>,
+  predicate: (event: RuntimeEvent) => boolean,
+  timeoutMs = 60_000,
+): Promise<RuntimeEvent> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      (async () => {
+      while (true) {
+        const next = await iterator.next();
+        if (next.done) throw new Error("Codex event stream ended early");
+        if (predicate(next.value)) return next.value;
+      }
+      })(),
+      new Promise<never>((_, reject) => { timer = setTimeout(() => reject(new Error("Codex integration event timed out")), timeoutMs); }),
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
+function containsText(event: RuntimeEvent, expected: string): boolean {
+  if (event.kind === "delta") return event.text.includes(expected);
+  if (event.kind !== "item") return false;
+  const item = event.item as { type?: string; text?: string } | null;
+  return item?.type === "agentMessage" && item.text?.includes(expected) === true;
+}
+
+test.skipIf(!codexPresent)("real Codex subscription supports late attach, steering, and restart resume", async () => {
+  let host: CodexAppServerHost | null = null;
+  let recovered: CodexAppServerHost | null = null;
+  try {
+    host = await CodexAppServerHost.start({
+      cwd: process.cwd(),
+      model: "gpt-5.4-mini",
+      sandbox: "read-only",
+      approvalPolicy: "never",
+      requestTimeoutMs: 60_000,
+    });
+    const owner = host.attach(0)[Symbol.asyncIterator]();
+    const started = await host.send({
+      id: `issue-149-original-${crypto.randomUUID()}`,
+      text: "Remember marker ZEBRA-149. Run the shell command `sleep 4`, then reply with exactly ORIGINAL-149. Follow steering received while the command runs.",
+    });
+    expect(started.outcome).toBe("turn-started");
+    const turnId = started.outcome === "turn-started" ? started.turnId : "";
+    await waitFor(owner, (event) => event.kind === "item" && event.phase === "started" && (event.item as { type?: string })?.type === "commandExecution");
+
+    const lateClient = host.attach(0)[Symbol.asyncIterator]();
+    const steered = await host.send({
+      id: `issue-149-steer-${crypto.randomUUID()}`,
+      text: "Replace the final response with exactly STEERED-149.",
+      expectedTurnId: turnId,
+    });
+    expect(steered).toEqual({ outcome: "steered", turnId });
+    await waitFor(lateClient, (event) => containsText(event, "STEERED-149"));
+    await waitFor(owner, (event) => event.kind === "turn-ended" && event.turnId === turnId && event.status === "completed");
+
+    const threadId = host.identity.threadId;
+    await host.release();
+    host = null;
+    recovered = await CodexAppServerHost.adopt(threadId, {
+      cwd: process.cwd(),
+      model: "gpt-5.4-mini",
+      sandbox: "read-only",
+      approvalPolicy: "never",
+      requestTimeoutMs: 60_000,
+    });
+    const recoveryEvents = recovered.attach(0)[Symbol.asyncIterator]();
+    const recall = await recovered.send({
+      id: `issue-149-recall-${crypto.randomUUID()}`,
+      text: "Reply with only the marker I asked you to remember.",
+    });
+    expect(recall.outcome).toBe("turn-started");
+    await waitFor(recoveryEvents, (event) => containsText(event, "ZEBRA-149"));
+  } finally {
+    await host?.release();
+    await recovered?.release();
+  }
+}, 180_000);

--- a/src/lib/runtime/codexAppServerHost.integration.test.ts
+++ b/src/lib/runtime/codexAppServerHost.integration.test.ts
@@ -67,6 +67,7 @@ test.skipIf(!codexPresent)("real Codex subscription supports late attach, steeri
 
     const threadId = host.identity.threadId;
     await host.release();
+    const releasedCursor = (await host.health()).eventCursor;
     host = null;
     recovered = await CodexAppServerHost.adopt(threadId, {
       cwd: process.cwd(),
@@ -74,8 +75,12 @@ test.skipIf(!codexPresent)("real Codex subscription supports late attach, steeri
       sandbox: "read-only",
       approvalPolicy: "never",
       requestTimeoutMs: 60_000,
+      initialEventCursor: releasedCursor,
     });
-    const recoveryEvents = recovered.attach(0)[Symbol.asyncIterator]();
+    const restartReplay = recovered.attach(releasedCursor - 1)[Symbol.asyncIterator]();
+    expect((await restartReplay.next()).value).toEqual({ kind: "session-status", status: "unhosted", seq: releasedCursor });
+    expect((await restartReplay.next()).value).toEqual({ kind: "session-status", status: "idle", seq: releasedCursor + 1 });
+    const recoveryEvents = recovered.attach(releasedCursor + 1)[Symbol.asyncIterator]();
     const recall = await recovered.send({
       id: `issue-149-recall-${crypto.randomUUID()}`,
       text: "Reply with only the marker I asked you to remember.",

--- a/src/lib/runtime/codexAppServerHost.test.ts
+++ b/src/lib/runtime/codexAppServerHost.test.ts
@@ -50,6 +50,8 @@ class FakeAppServer extends EventEmitter {
   readonly pid = 4242;
   readonly requests: Array<Record<string, unknown>> = [];
   readonly signals: NodeJS.Signals[] = [];
+  autoResolveServerRequests = true;
+  private readonly serverRequestIds = new Set<string | number>();
   private turn = 0;
 
   constructor(
@@ -87,11 +89,19 @@ class FakeAppServer extends EventEmitter {
   }
 
   request(id: string, method: string, params: Record<string, unknown>): void {
+    this.serverRequestIds.add(id);
     this.stdout.write(`${JSON.stringify({ jsonrpc: "2.0", id, method, params })}\n`);
   }
 
   private accept(message: Record<string, unknown>): void {
     this.requests.push(message);
+    if ((typeof message.id === "string" || typeof message.id === "number")
+      && this.serverRequestIds.delete(message.id)) {
+      if (this.autoResolveServerRequests) {
+        this.notify("serverRequest/resolved", { threadId: this.threadId, requestId: message.id });
+      }
+      return;
+    }
     if (typeof message.id !== "number") return;
     const method = message.method;
     if (typeof method === "string" && this.ignoredMethods.includes(method)) return;
@@ -545,6 +555,75 @@ describe("CodexAppServerHost", () => {
     await expect(pendingSend).rejects.toThrow("stdin failed: broken pipe");
     expect(await host.health()).toMatchObject({ status: "dead", activeTurnRef: null, pendingAttention: [] });
     expect(server.signals).toContain("SIGTERM");
+    await host.release();
+  });
+
+  test("keeps an answer pending until the app-server confirms resolution", async () => {
+    const server = new FakeAppServer("confirmed-answer-thread");
+    server.autoResolveServerRequests = false;
+    const store = new MemoryEventStore();
+    const host = await CodexAppServerHost.start({
+      cwd: "/repo",
+      eventStore: store,
+      spawnProcess: fakeSpawn(server),
+    });
+    server.request("confirmed-answer", "item/commandExecution/requestApproval", { command: "date" });
+    await Bun.sleep(0);
+    const attentionId = "item/commandExecution/requestApproval:confirmed-answer";
+    let settled = false;
+    const answer = host.answer(attentionId, { decision: "accept" }).finally(() => { settled = true; });
+    await Bun.sleep(0);
+    expect(settled).toBeFalse();
+    expect((await host.health()).pendingAttention).toEqual([attentionId]);
+    expect(store.load("confirmed-answer-thread").some((event) => event.kind === "attention-resolved")).toBeFalse();
+    server.notify("serverRequest/resolved", { threadId: "confirmed-answer-thread", requestId: "confirmed-answer" });
+    await answer;
+    expect((await host.health()).pendingAttention).toEqual([]);
+    expect(store.load("confirmed-answer-thread").at(-1)).toMatchObject({
+      kind: "attention-resolved",
+      id: attentionId,
+      resolution: "answered",
+    });
+    await host.release();
+  });
+
+  test("a synchronous answer write failure preserves no false resolution", async () => {
+    const server = new FakeAppServer("sync-answer-failure");
+    server.autoResolveServerRequests = false;
+    const store = new MemoryEventStore();
+    const host = await CodexAppServerHost.start({
+      cwd: "/repo",
+      eventStore: store,
+      spawnProcess: fakeSpawn(server),
+    });
+    server.request("sync-answer", "item/commandExecution/requestApproval", { command: "date" });
+    await Bun.sleep(0);
+    server.stdin.write = (() => {
+      throw Object.assign(new Error("broken pipe"), { code: "EPIPE" });
+    }) as typeof server.stdin.write;
+    await expect(host.answer("item/commandExecution/requestApproval:sync-answer", { decision: "accept" }))
+      .rejects.toThrow("stdin failed: broken pipe");
+    expect(store.load("sync-answer-failure").some((event) => event.kind === "attention-resolved")).toBeFalse();
+    expect(await host.health()).toMatchObject({ status: "dead", pendingAttention: [] });
+    await host.release();
+  });
+
+  test("an asynchronous answer write failure preserves no false resolution", async () => {
+    const server = new FakeAppServer("async-answer-failure");
+    server.autoResolveServerRequests = false;
+    const store = new MemoryEventStore();
+    const host = await CodexAppServerHost.start({
+      cwd: "/repo",
+      eventStore: store,
+      spawnProcess: fakeSpawn(server),
+    });
+    server.request("async-answer", "item/commandExecution/requestApproval", { command: "date" });
+    await Bun.sleep(0);
+    const answer = host.answer("item/commandExecution/requestApproval:async-answer", { decision: "accept" });
+    server.stdin.emit("error", Object.assign(new Error("broken pipe"), { code: "EPIPE" }));
+    await expect(answer).rejects.toThrow("stdin failed: broken pipe");
+    expect(store.load("async-answer-failure").some((event) => event.kind === "attention-resolved")).toBeFalse();
+    expect(await host.health()).toMatchObject({ status: "dead", pendingAttention: [] });
     await host.release();
   });
 

--- a/src/lib/runtime/codexAppServerHost.test.ts
+++ b/src/lib/runtime/codexAppServerHost.test.ts
@@ -304,6 +304,40 @@ describe("CodexAppServerHost", () => {
     await host.release();
   });
 
+  test("completes partially recorded ledger history from the resume response", async () => {
+    const eventStore = new MemoryEventStore();
+    eventStore.append("completed-after-crash", { kind: "turn-started", turnId: "crashed-turn", seq: 1 });
+    const persistedItem = { type: "agentMessage", id: "response-item", text: "persisted response" };
+    const server = new FakeAppServer("completed-after-crash", "completed-after-crash", false, [{
+      id: "crashed-turn",
+      status: "completed",
+      items: [persistedItem],
+    }], { type: "idle" });
+    const host = await CodexAppServerHost.adopt("completed-after-crash", {
+      cwd: "/repo",
+      eventStore,
+      initialEventCursor: 1,
+      spawnProcess: fakeSpawn(server),
+    });
+    const replay = host.attach(1)[Symbol.asyncIterator]();
+    expect((await replay.next()).value).toEqual({
+      kind: "item",
+      turnId: "crashed-turn",
+      item: persistedItem,
+      phase: "completed",
+      seq: 2,
+    });
+    expect((await replay.next()).value).toEqual({
+      kind: "turn-ended",
+      turnId: "crashed-turn",
+      status: "completed",
+      seq: 3,
+    });
+    expect((await replay.next()).value).toEqual({ kind: "session-status", status: "idle", seq: 4 });
+    expect(await host.health()).toMatchObject({ status: "idle", activeTurnRef: null });
+    await host.release();
+  });
+
   test("restores the resumed active turn after a dead ledger", async () => {
     const eventStore = new MemoryEventStore();
     eventStore.append("active-after-crash", { kind: "turn-started", turnId: "stale-turn", seq: 1 });
@@ -515,6 +549,17 @@ describe("CodexAppServerHost", () => {
       claimOwner: null,
       structuredHost: { eventCursor: 17, process: null, activeTurnRef: null, pendingAttention: [] },
     });
+    let restarted = false;
+    const releasedRows = await adoptCodexRegistryHosts(
+      registry,
+      () => {
+        restarted = true;
+        return { cwd: "/repo", eventStore: new MemoryEventStore(), spawnProcess: fakeSpawn(new FakeAppServer("adopted-thread")) };
+      },
+      { NODE_ENV: "test", LLV_STRUCTURED_HOSTS: "1" },
+    );
+    expect(releasedRows).toEqual([]);
+    expect(restarted).toBeFalse();
     const reclaimed = registry.claimStructuredHost(key, { pid: process.pid, startIdentity: "replacement-viewer" });
     expect(reclaimed?.claimEpoch).toBe(5);
   });

--- a/src/lib/runtime/codexAppServerHost.test.ts
+++ b/src/lib/runtime/codexAppServerHost.test.ts
@@ -7,6 +7,7 @@ import type { ChildProcessWithoutNullStreams, SpawnOptionsWithoutStdio } from "n
 import { describe, expect, test } from "bun:test";
 
 import { AgentRegistry } from "@/lib/agent/registry";
+import { emptyLaunchProfile } from "@/lib/accounts/migration/contracts";
 
 import { CodexAppServerHost } from "./codexAppServerHost";
 import { adoptCodexRegistryHosts, persistCodexHost, startCodexStructuredHost, structuredHostsEnabled } from "./registry";
@@ -17,9 +18,14 @@ class FakeAppServer extends EventEmitter {
   readonly stderr = new PassThrough();
   readonly pid = 4242;
   readonly requests: Array<Record<string, unknown>> = [];
+  readonly signals: NodeJS.Signals[] = [];
   private turn = 0;
 
-  constructor(private readonly threadId = "thread-149") {
+  constructor(
+    private readonly threadId = "thread-149",
+    private readonly resumedThreadId = threadId,
+    private readonly ignoreTerm = false,
+  ) {
     super();
     let buffer = "";
     this.stdin.on("data", (chunk) => {
@@ -34,8 +40,10 @@ class FakeAppServer extends EventEmitter {
     });
   }
 
-  kill(): boolean {
-    queueMicrotask(() => this.emit("close", 0, "SIGTERM"));
+  kill(signal: NodeJS.Signals = "SIGTERM"): boolean {
+    this.signals.push(signal);
+    if (signal === "SIGTERM" && this.ignoreTerm) return true;
+    queueMicrotask(() => this.emit("close", signal === "SIGKILL" ? null : 0, signal));
     return true;
   }
 
@@ -53,7 +61,10 @@ class FakeAppServer extends EventEmitter {
     const method = message.method;
     if (method === "initialize") return this.respond(message.id, { userAgent: "codex_desktop_app/0.144.1 (Linux)" });
     if (method === "account/read") return this.respond(message.id, { account: { type: "chatgpt", planType: "pro" }, requiresOpenaiAuth: false });
-    if (method === "thread/start" || method === "thread/resume") return this.respond(message.id, { thread: { id: this.threadId, path: `/sessions/${this.threadId}.jsonl` } });
+    if (method === "thread/start" || method === "thread/resume") {
+      const id = method === "thread/resume" ? this.resumedThreadId : this.threadId;
+      return this.respond(message.id, { thread: { id, path: `/sessions/${id}.jsonl` } });
+    }
     if (method === "turn/start") {
       const turnId = `turn-${++this.turn}`;
       this.respond(message.id, { turn: { id: turnId } });
@@ -148,6 +159,39 @@ describe("CodexAppServerHost", () => {
     await replacement.release();
   });
 
+  test("rejects a resume response for a different durable thread", async () => {
+    const server = new FakeAppServer("server-default", "different-thread");
+    await expect(CodexAppServerHost.adopt("requested-thread", {
+      cwd: "/repo",
+      spawnProcess: fakeSpawn(server),
+    })).rejects.toThrow("thread/resume returned a different thread id");
+    expect(server.signals).toContain("SIGTERM");
+  });
+
+  test("release awaits TERM and escalates to KILL before resolving", async () => {
+    const server = new FakeAppServer("reap-thread", "reap-thread", true);
+    const host = await CodexAppServerHost.start({
+      cwd: "/repo",
+      shutdownGraceMs: 5,
+      spawnProcess: fakeSpawn(server),
+    });
+    await host.release();
+    expect(server.signals).toEqual(["SIGTERM", "SIGKILL"]);
+  });
+
+  test("protocol failure starts bounded TERM and KILL cleanup", async () => {
+    const server = new FakeAppServer("failed-thread", "failed-thread", true);
+    const host = await CodexAppServerHost.start({
+      cwd: "/repo",
+      shutdownGraceMs: 5,
+      spawnProcess: fakeSpawn(server),
+    });
+    server.stdout.write("malformed\n");
+    await Bun.sleep(10);
+    expect(server.signals).toEqual(["SIGTERM", "SIGKILL"]);
+    await host.release();
+  });
+
   test("requires an exact opt-in value", async () => {
     expect(structuredHostsEnabled({ NODE_ENV: "test" })).toBeFalse();
     expect(structuredHostsEnabled({ NODE_ENV: "test", LLV_STRUCTURED_HOSTS: "true" })).toBeFalse();
@@ -180,7 +224,7 @@ describe("CodexAppServerHost", () => {
         pendingAttention: [],
       },
       claimEpoch: 3,
-      claimOwner: "viewer",
+      claimOwner: null,
       pendingAction: null,
     });
     const disabled = await adoptCodexRegistryHosts(
@@ -200,9 +244,94 @@ describe("CodexAppServerHost", () => {
     expect(server.requests.some((request) => request.method === "thread/resume")).toBeTrue();
     expect(registry.snapshot().entries["codex:adopted-thread"]?.structuredHost).toMatchObject({
       eventCursor: 13,
-      writerClaimEpoch: 3,
+      writerClaimEpoch: 4,
       endpoint: "stdio:4242",
     });
     await adopted[0]!.host.release();
+  });
+
+  test("concurrent startup adoption creates one writer and advances its claim epoch", async () => {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-structured-claim-"));
+    const registry = new AgentRegistry(path.join(directory, "agent-registry.json"));
+    const key = { engine: "codex" as const, sessionId: "claimed-thread" };
+    registry.upsert({
+      key,
+      artifactPath: "/sessions/claimed-thread.jsonl",
+      cwd: "/repo",
+      accountId: null,
+      status: "dead",
+      host: null,
+      structuredHost: {
+        kind: "codex-app-server",
+        endpoint: "stdio:old",
+        process: null,
+        eventCursor: 2,
+        protocolVersion: "0.144.1",
+        writerClaimEpoch: 8,
+        activeTurnRef: null,
+        pendingAttention: [],
+      },
+      claimEpoch: 8,
+      claimOwner: null,
+      pendingAction: null,
+    });
+    const servers: FakeAppServer[] = [];
+    const adopt = () => adoptCodexRegistryHosts(
+      registry,
+      () => {
+        const server = new FakeAppServer("claimed-thread");
+        servers.push(server);
+        return { cwd: "/repo", spawnProcess: fakeSpawn(server) };
+      },
+      { NODE_ENV: "test", LLV_STRUCTURED_HOSTS: "1" },
+    );
+    const [first, second] = await Promise.all([adopt(), adopt()]);
+    expect(first.length + second.length).toBe(1);
+    expect(servers).toHaveLength(1);
+    expect(registry.snapshot().entries["codex:claimed-thread"]).toMatchObject({
+      claimEpoch: 9,
+      structuredHost: { writerClaimEpoch: 9 },
+    });
+    await [...first, ...second][0]!.host.release();
+  });
+
+  test("structured status transitions advance migration readiness revisions", () => {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-structured-revision-"));
+    const registry = new AgentRegistry(path.join(directory, "agent-registry.json"));
+    const artifactPath = "/sessions/revision-thread.jsonl";
+    registry.reconcileConversations([{
+      engine: "codex",
+      path: artifactPath,
+      accountId: null,
+      launchProfile: emptyLaunchProfile({ cwd: "/repo" }),
+      turn: { state: "idle", source: "empty", terminalAt: null },
+      observedAt: "2026-07-12T20:00:00.000Z",
+    }]);
+    const key = { engine: "codex" as const, sessionId: "revision-thread" };
+    registry.upsert({
+      key,
+      artifactPath,
+      cwd: "/repo",
+      accountId: null,
+      status: "dead",
+      host: null,
+      claimEpoch: 0,
+      claimOwner: null,
+      pendingAction: null,
+    });
+    const before = registry.snapshot();
+    registry.setStructuredHost(key, {
+      kind: "codex-app-server",
+      endpoint: "stdio:42",
+      process: { pid: 42, startIdentity: "42:start" },
+      eventCursor: 1,
+      protocolVersion: "0.144.1",
+      writerClaimEpoch: 1,
+      activeTurnRef: null,
+      pendingAttention: [],
+    }, "idle");
+    const after = registry.snapshot();
+    expect(after.conversationRevision.codex).toBe(before.conversationRevision.codex + 1);
+    expect(after.engineRouting.codex.revision).toBe(before.engineRouting.codex.revision + 1);
   });
 });

--- a/src/lib/runtime/codexAppServerHost.test.ts
+++ b/src/lib/runtime/codexAppServerHost.test.ts
@@ -1,0 +1,208 @@
+import { EventEmitter } from "node:events";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { PassThrough } from "node:stream";
+import type { ChildProcessWithoutNullStreams, SpawnOptionsWithoutStdio } from "node:child_process";
+import { describe, expect, test } from "bun:test";
+
+import { AgentRegistry } from "@/lib/agent/registry";
+
+import { CodexAppServerHost } from "./codexAppServerHost";
+import { adoptCodexRegistryHosts, persistCodexHost, startCodexStructuredHost, structuredHostsEnabled } from "./registry";
+
+class FakeAppServer extends EventEmitter {
+  readonly stdin = new PassThrough();
+  readonly stdout = new PassThrough();
+  readonly stderr = new PassThrough();
+  readonly pid = 4242;
+  readonly requests: Array<Record<string, unknown>> = [];
+  private turn = 0;
+
+  constructor(private readonly threadId = "thread-149") {
+    super();
+    let buffer = "";
+    this.stdin.on("data", (chunk) => {
+      buffer += String(chunk);
+      let newline = buffer.indexOf("\n");
+      while (newline >= 0) {
+        const line = buffer.slice(0, newline);
+        buffer = buffer.slice(newline + 1);
+        if (line) this.accept(JSON.parse(line) as Record<string, unknown>);
+        newline = buffer.indexOf("\n");
+      }
+    });
+  }
+
+  kill(): boolean {
+    queueMicrotask(() => this.emit("close", 0, "SIGTERM"));
+    return true;
+  }
+
+  notify(method: string, params: Record<string, unknown>): void {
+    this.stdout.write(`${JSON.stringify({ jsonrpc: "2.0", method, params })}\n`);
+  }
+
+  request(id: string, method: string, params: Record<string, unknown>): void {
+    this.stdout.write(`${JSON.stringify({ jsonrpc: "2.0", id, method, params })}\n`);
+  }
+
+  private accept(message: Record<string, unknown>): void {
+    this.requests.push(message);
+    if (typeof message.id !== "number") return;
+    const method = message.method;
+    if (method === "initialize") return this.respond(message.id, { userAgent: "codex_desktop_app/0.144.1 (Linux)" });
+    if (method === "account/read") return this.respond(message.id, { account: { type: "chatgpt", planType: "pro" }, requiresOpenaiAuth: false });
+    if (method === "thread/start" || method === "thread/resume") return this.respond(message.id, { thread: { id: this.threadId, path: `/sessions/${this.threadId}.jsonl` } });
+    if (method === "turn/start") {
+      const turnId = `turn-${++this.turn}`;
+      this.respond(message.id, { turn: { id: turnId } });
+      this.notify("turn/started", { threadId: this.threadId, turn: { id: turnId } });
+      return;
+    }
+    if (method === "turn/steer") return this.respond(message.id, { turnId: (message.params as { expectedTurnId: string }).expectedTurnId });
+    if (method === "turn/interrupt") return this.respond(message.id, {});
+  }
+
+  private respond(id: number, result: unknown): void {
+    this.stdout.write(`${JSON.stringify({ jsonrpc: "2.0", id, result })}\n`);
+  }
+}
+
+function fakeSpawn(server: FakeAppServer, captured?: { options?: SpawnOptionsWithoutStdio }) {
+  return (_command: string, _args: string[], options: SpawnOptionsWithoutStdio) => {
+    if (captured) captured.options = options;
+    return server as unknown as ChildProcessWithoutNullStreams;
+  };
+}
+
+async function nextEvent(iterable: AsyncIterable<unknown>): Promise<unknown> {
+  return (await iterable[Symbol.asyncIterator]().next()).value;
+}
+
+describe("CodexAppServerHost", () => {
+  test("fans out replay, fences steering, answers attention, and persists host columns", async () => {
+    const server = new FakeAppServer();
+    const captured: { options?: SpawnOptionsWithoutStdio } = {};
+    const host = await CodexAppServerHost.start({
+      cwd: "/repo",
+      env: { NODE_ENV: "test", PATH: process.env.PATH, OPENAI_API_KEY: "must-not-cross" },
+      spawnProcess: fakeSpawn(server, captured),
+    });
+    expect((captured.options?.env as NodeJS.ProcessEnv).OPENAI_API_KEY).toBeUndefined();
+    expect(host.identity).toEqual({ threadId: "thread-149", path: "/sessions/thread-149.jsonl" });
+
+    const first = host.attach(0);
+    const second = host.attach(0);
+    expect(await nextEvent(first)).toEqual({ kind: "session-status", status: "idle", seq: 1 });
+    expect(await nextEvent(second)).toEqual({ kind: "session-status", status: "idle", seq: 1 });
+
+    const started = await host.send({ id: "delivery-one", text: "begin" });
+    expect(started).toEqual({ outcome: "turn-started", turnId: "turn-1" });
+    expect(await host.send({ id: "stale", text: "wrong", expectedTurnId: "turn-old" })).toEqual({ outcome: "rejected", reason: "stale-turn" });
+    expect(await host.send({ id: "delivery-two", text: "steer", expectedTurnId: "turn-1" })).toEqual({ outcome: "steered", turnId: "turn-1" });
+    const steer = server.requests.find((request) => request.method === "turn/steer")!;
+    expect(steer.params).toMatchObject({ expectedTurnId: "turn-1", clientUserMessageId: "delivery-two" });
+
+    server.request("approval-1", "item/commandExecution/requestApproval", { command: "touch allowed" });
+    await Bun.sleep(0);
+    const attention = (await host.health()).pendingAttention[0]!;
+    expect(attention).toBe("item/commandExecution/requestApproval:approval-1");
+    await host.answer(attention, { decision: "accept" });
+    expect(server.requests.at(-1)).toMatchObject({ id: "approval-1", result: { decision: "accept" } });
+
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-structured-registry-"));
+    const registry = new AgentRegistry(path.join(directory, "agent-registry.json"));
+    const key = { engine: "codex" as const, sessionId: host.identity.threadId };
+    registry.upsert({
+      key,
+      artifactPath: host.identity.path!,
+      cwd: "/repo",
+      accountId: null,
+      status: "live",
+      host: null,
+      claimEpoch: 7,
+      claimOwner: "viewer",
+      pendingAction: null,
+    });
+    await persistCodexHost(registry, key, host, 7);
+    expect(registry.snapshot().entries["codex:thread-149"]?.structuredHost).toMatchObject({
+      kind: "codex-app-server",
+      endpoint: "stdio:4242",
+      eventCursor: 3,
+      protocolVersion: "0.144.1",
+      writerClaimEpoch: 7,
+      activeTurnRef: "turn-1",
+      pendingAttention: [],
+    });
+    await host.release();
+  });
+
+  test("resumes the same engine thread after a host-process replacement", async () => {
+    const first = await CodexAppServerHost.start({ cwd: "/repo", spawnProcess: fakeSpawn(new FakeAppServer("durable-thread")) });
+    await first.release();
+    const replacementServer = new FakeAppServer("durable-thread");
+    const replacement = await CodexAppServerHost.adopt("durable-thread", { cwd: "/repo", spawnProcess: fakeSpawn(replacementServer) });
+    expect(replacement.identity.threadId).toBe("durable-thread");
+    expect(replacementServer.requests.some((request) => request.method === "thread/resume")).toBeTrue();
+    await replacement.release();
+  });
+
+  test("requires an exact opt-in value", async () => {
+    expect(structuredHostsEnabled({ NODE_ENV: "test" })).toBeFalse();
+    expect(structuredHostsEnabled({ NODE_ENV: "test", LLV_STRUCTURED_HOSTS: "true" })).toBeFalse();
+    expect(structuredHostsEnabled({ NODE_ENV: "test", LLV_STRUCTURED_HOSTS: "1" })).toBeTrue();
+    await expect(startCodexStructuredHost(
+      { cwd: "/repo", spawnProcess: fakeSpawn(new FakeAppServer()) },
+      { NODE_ENV: "test" },
+    )).rejects.toThrow("structured hosts are disabled");
+  });
+
+  test("boot adoption resumes every flagged Codex registry row", async () => {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-structured-adoption-"));
+    const registry = new AgentRegistry(path.join(directory, "agent-registry.json"));
+    const key = { engine: "codex" as const, sessionId: "adopted-thread" };
+    registry.upsert({
+      key,
+      artifactPath: "/sessions/adopted-thread.jsonl",
+      cwd: "/repo",
+      accountId: null,
+      status: "dead",
+      host: null,
+      structuredHost: {
+        kind: "codex-app-server",
+        endpoint: "stdio:old",
+        process: null,
+        eventCursor: 12,
+        protocolVersion: "0.144.1",
+        writerClaimEpoch: 3,
+        activeTurnRef: null,
+        pendingAttention: [],
+      },
+      claimEpoch: 3,
+      claimOwner: "viewer",
+      pendingAction: null,
+    });
+    const disabled = await adoptCodexRegistryHosts(
+      registry,
+      () => ({ cwd: "/repo", spawnProcess: fakeSpawn(new FakeAppServer("adopted-thread")) }),
+      { NODE_ENV: "test" },
+    );
+    expect(disabled).toEqual([]);
+
+    const server = new FakeAppServer("adopted-thread");
+    const adopted = await adoptCodexRegistryHosts(
+      registry,
+      () => ({ cwd: "/repo", spawnProcess: fakeSpawn(server) }),
+      { NODE_ENV: "test", LLV_STRUCTURED_HOSTS: "1" },
+    );
+    expect(adopted).toHaveLength(1);
+    expect(server.requests.some((request) => request.method === "thread/resume")).toBeTrue();
+    expect(registry.snapshot().entries["codex:adopted-thread"]?.structuredHost).toMatchObject({
+      eventCursor: 13,
+      writerClaimEpoch: 3,
+      endpoint: "stdio:4242",
+    });
+    await adopted[0]!.host.release();
+  });
+});

--- a/src/lib/runtime/codexAppServerHost.test.ts
+++ b/src/lib/runtime/codexAppServerHost.test.ts
@@ -12,7 +12,7 @@ import { emptyLaunchProfile } from "@/lib/accounts/migration/contracts";
 import { CodexAppServerHost } from "./codexAppServerHost";
 import type { RuntimeEventStore } from "./eventStore";
 import type { RuntimeEvent } from "./engineHost";
-import { adoptCodexRegistryHosts, persistCodexHost, startCodexStructuredHost, structuredHostsEnabled } from "./registry";
+import { adoptCodexRegistryHosts, bindCodexHostPersistence, persistCodexHost, startCodexStructuredHost, structuredHostsEnabled } from "./registry";
 
 class MemoryEventStore implements RuntimeEventStore {
   private readonly events = new Map<string, RuntimeEvent[]>();
@@ -42,6 +42,7 @@ class FakeAppServer extends EventEmitter {
     private readonly resumedThreadId = threadId,
     private readonly ignoreTerm = false,
     private readonly turns: unknown[] = [],
+    private readonly resumeStatus: unknown = undefined,
   ) {
     super();
     let buffer = "";
@@ -80,7 +81,14 @@ class FakeAppServer extends EventEmitter {
     if (method === "account/read") return this.respond(message.id, { account: { type: "chatgpt", planType: "pro" }, requiresOpenaiAuth: false });
     if (method === "thread/start" || method === "thread/resume") {
       const id = method === "thread/resume" ? this.resumedThreadId : this.threadId;
-      return this.respond(message.id, { thread: { id, path: `/sessions/${id}.jsonl`, turns: this.turns } });
+      return this.respond(message.id, {
+        thread: {
+          id,
+          path: `/sessions/${id}.jsonl`,
+          turns: this.turns,
+          ...(this.resumeStatus ? { status: this.resumeStatus } : {}),
+        },
+      });
     }
     if (method === "turn/start") {
       const turnId = `turn-${++this.turn}`;
@@ -159,15 +167,26 @@ describe("CodexAppServerHost", () => {
       accountId: null,
       status: "live",
       host: null,
+      structuredHost: {
+        kind: "codex-app-server",
+        endpoint: "stdio:pending",
+        process: null,
+        eventCursor: 0,
+        protocolVersion: null,
+        writerClaimEpoch: 7,
+        activeTurnRef: null,
+        pendingAttention: [],
+        activeFlags: [],
+      },
       claimEpoch: 7,
       claimOwner: "viewer",
       pendingAction: null,
     });
-    await persistCodexHost(registry, key, host, 7);
+    await persistCodexHost(registry, key, host, "viewer", 7);
     expect(registry.snapshot().entries["codex:thread-149"]?.structuredHost).toMatchObject({
       kind: "codex-app-server",
       endpoint: "stdio:4242",
-      eventCursor: 3,
+      eventCursor: 4,
       protocolVersion: "0.144.1",
       writerClaimEpoch: 7,
       activeTurnRef: "turn-1",
@@ -233,6 +252,86 @@ describe("CodexAppServerHost", () => {
     await host.release();
   });
 
+  test("closes an unresolved ledger turn when resume reports idle", async () => {
+    const eventStore = new MemoryEventStore();
+    eventStore.append("crashed-turn", { kind: "turn-started", turnId: "turn-active", seq: 1 });
+    eventStore.append("crashed-turn", { kind: "session-status", status: "active", seq: 2 });
+    const server = new FakeAppServer("crashed-turn", "crashed-turn", false, [], { type: "idle" });
+    const host = await CodexAppServerHost.adopt("crashed-turn", {
+      cwd: "/repo",
+      eventStore,
+      initialEventCursor: 2,
+      spawnProcess: fakeSpawn(server),
+    });
+    const replay = host.attach(2)[Symbol.asyncIterator]();
+    expect((await replay.next()).value).toEqual({ kind: "turn-ended", turnId: "turn-active", status: "error", seq: 3 });
+    expect((await replay.next()).value).toEqual({ kind: "session-status", status: "idle", seq: 4 });
+    expect(await host.health()).toMatchObject({ status: "idle", activeTurnRef: null });
+    await host.release();
+  });
+
+  test("resolves ledger attention during adoption and preserves resumed active flags", async () => {
+    const eventStore = new MemoryEventStore();
+    eventStore.append("crashed-attention", {
+      kind: "attention",
+      id: "item/commandExecution/requestApproval:approval-crash",
+      method: "item/commandExecution/requestApproval",
+      attention: { command: "date" },
+      seq: 1,
+    });
+    const server = new FakeAppServer("crashed-attention", "crashed-attention", false, [], {
+      type: "active",
+      activeFlags: ["waitingForApproval"],
+    });
+    const host = await CodexAppServerHost.adopt("crashed-attention", {
+      cwd: "/repo",
+      eventStore,
+      initialEventCursor: 1,
+      spawnProcess: fakeSpawn(server),
+    });
+    const replay = host.attach(1)[Symbol.asyncIterator]();
+    expect((await replay.next()).value).toEqual({
+      kind: "attention-resolved",
+      id: "item/commandExecution/requestApproval:approval-crash",
+      resolution: "host-restarted",
+      seq: 2,
+    });
+    expect((await replay.next()).value).toEqual({
+      kind: "session-status",
+      status: "active",
+      activeFlags: ["waitingForApproval"],
+      seq: 3,
+    });
+    expect(await host.health()).toMatchObject({
+      status: "active",
+      pendingAttention: [],
+      activeFlags: ["waitingForApproval"],
+    });
+    await host.release();
+  });
+
+  test("parses generated-schema thread status notifications", async () => {
+    const server = new FakeAppServer("status-thread");
+    const host = await CodexAppServerHost.start({
+      cwd: "/repo",
+      eventStore: new MemoryEventStore(),
+      spawnProcess: fakeSpawn(server),
+    });
+    const stream = host.attach((await host.health()).eventCursor)[Symbol.asyncIterator]();
+    const fixtures = fs.readFileSync(path.join(import.meta.dir, "fixtures/codex-thread-status-v0.144.1.jsonl"), "utf8")
+      .trim().split("\n");
+    for (const [index, fixture] of fixtures.entries()) {
+      server.stdout.write(`${fixture}\n`);
+      const event = (await stream.next()).value as RuntimeEvent;
+      if (index === 0) expect(event).toMatchObject({ kind: "session-status", status: "active", activeFlags: ["waitingForApproval"] });
+      if (index === 1) expect(event).toMatchObject({ kind: "session-status", status: "idle" });
+      if (index === 2) expect(event).toMatchObject({ kind: "session-status", status: "unhosted" });
+      if (index === 3) expect(event).toMatchObject({ kind: "session-status", status: "dead", activeFlags: ["recovering"] });
+    }
+    expect((await stream.next()).done).toBeTrue();
+    await host.release();
+  });
+
   test("release awaits TERM and escalates to KILL before resolving", async () => {
     const server = new FakeAppServer("reap-thread", "reap-thread", true);
     const host = await CodexAppServerHost.start({
@@ -241,8 +340,11 @@ describe("CodexAppServerHost", () => {
       eventStore: new MemoryEventStore(),
       spawnProcess: fakeSpawn(server),
     });
+    const stream = host.attach((await host.health()).eventCursor)[Symbol.asyncIterator]();
     await host.release();
     expect(server.signals).toEqual(["SIGTERM", "SIGKILL"]);
+    expect((await stream.next()).value).toMatchObject({ kind: "session-status", status: "unhosted" });
+    expect((await stream.next()).done).toBeTrue();
   });
 
   test("protocol failure starts bounded TERM and KILL cleanup", async () => {
@@ -253,9 +355,12 @@ describe("CodexAppServerHost", () => {
       eventStore: new MemoryEventStore(),
       spawnProcess: fakeSpawn(server),
     });
+    const stream = host.attach((await host.health()).eventCursor)[Symbol.asyncIterator]();
     server.stdout.write("malformed\n");
     await Bun.sleep(10);
     expect(server.signals).toEqual(["SIGTERM", "SIGKILL"]);
+    expect((await stream.next()).value).toMatchObject({ kind: "session-status", status: "dead" });
+    expect((await stream.next()).done).toBeTrue();
     await host.release();
   });
 
@@ -289,6 +394,7 @@ describe("CodexAppServerHost", () => {
         writerClaimEpoch: 3,
         activeTurnRef: null,
         pendingAttention: [],
+        activeFlags: [],
       },
       claimEpoch: 3,
       claimOwner: null,
@@ -331,7 +437,7 @@ describe("CodexAppServerHost", () => {
     await adopted[0]!.host.release();
     expect(registry.snapshot().entries["codex:adopted-thread"]).toMatchObject({
       status: "unhosted",
-      structuredHost: { eventCursor: 16, process: null, activeTurnRef: null, pendingAttention: [] },
+      structuredHost: { eventCursor: 17, process: null, activeTurnRef: null, pendingAttention: [] },
     });
   });
 
@@ -355,6 +461,7 @@ describe("CodexAppServerHost", () => {
         writerClaimEpoch: 8,
         activeTurnRef: null,
         pendingAttention: [],
+        activeFlags: [],
       },
       claimEpoch: 8,
       claimOwner: null,
@@ -378,6 +485,61 @@ describe("CodexAppServerHost", () => {
       structuredHost: { writerClaimEpoch: 9 },
     });
     await [...first, ...second][0]!.host.release();
+  });
+
+  test("late state from an old host cannot cross an advanced writer epoch", async () => {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-structured-fence-"));
+    const registry = new AgentRegistry(path.join(directory, "agent-registry.json"));
+    const key = { engine: "codex" as const, sessionId: "fenced-thread" };
+    registry.upsert({
+      key,
+      artifactPath: "/sessions/fenced-thread.jsonl",
+      cwd: "/repo",
+      accountId: null,
+      status: "idle",
+      host: null,
+      structuredHost: {
+        kind: "codex-app-server",
+        endpoint: "stdio:old",
+        process: null,
+        eventCursor: 0,
+        protocolVersion: "0.144.1",
+        writerClaimEpoch: 1,
+        activeTurnRef: null,
+        pendingAttention: [],
+        activeFlags: [],
+      },
+      claimEpoch: 1,
+      claimOwner: "old-owner",
+      pendingAction: null,
+    });
+    const server = new FakeAppServer("fenced-thread");
+    const host = await CodexAppServerHost.adopt("fenced-thread", {
+      cwd: "/repo",
+      eventStore: new MemoryEventStore(),
+      spawnProcess: fakeSpawn(server),
+    });
+    await bindCodexHostPersistence(registry, key, host, "old-owner", 1);
+    const current = registry.snapshot().entries["codex:fenced-thread"]!;
+    registry.upsert({
+      ...current,
+      structuredHost: {
+        ...current.structuredHost!,
+        endpoint: "stdio:new",
+        eventCursor: 99,
+        writerClaimEpoch: 2,
+      },
+      claimEpoch: 2,
+      claimOwner: "new-owner",
+    });
+    server.notify("thread/status/changed", { threadId: "fenced-thread", status: { type: "active", activeFlags: ["running"] } });
+    await Bun.sleep(0);
+    expect(registry.snapshot().entries["codex:fenced-thread"]).toMatchObject({
+      claimEpoch: 2,
+      claimOwner: "new-owner",
+      structuredHost: { endpoint: "stdio:new", eventCursor: 99, writerClaimEpoch: 2 },
+    });
+    await host.release();
   });
 
   test("structured status transitions advance migration readiness revisions", () => {
@@ -414,6 +576,7 @@ describe("CodexAppServerHost", () => {
       writerClaimEpoch: 1,
       activeTurnRef: null,
       pendingAttention: [],
+      activeFlags: [],
     }, "idle");
     const after = registry.snapshot();
     expect(after.conversationRevision.codex).toBe(before.conversationRevision.codex + 1);

--- a/src/lib/runtime/codexAppServerHost.test.ts
+++ b/src/lib/runtime/codexAppServerHost.test.ts
@@ -560,7 +560,9 @@ describe("CodexAppServerHost", () => {
     );
     expect(releasedRows).toEqual([]);
     expect(restarted).toBeFalse();
-    const reclaimed = registry.claimStructuredHost(key, { pid: process.pid, startIdentity: "replacement-viewer" });
+    const replacementOwner = { pid: process.pid, startIdentity: "replacement-viewer" };
+    expect(registry.claimStructuredHost(key, replacementOwner)).toBeNull();
+    const reclaimed = registry.claimStructuredHost(key, replacementOwner, { allowUnhosted: true });
     expect(reclaimed?.claimEpoch).toBe(5);
   });
 

--- a/src/lib/runtime/codexAppServerHost.test.ts
+++ b/src/lib/runtime/codexAppServerHost.test.ts
@@ -9,7 +9,7 @@ import { describe, expect, test } from "bun:test";
 import { AgentRegistry } from "@/lib/agent/registry";
 import { emptyLaunchProfile } from "@/lib/accounts/migration/contracts";
 
-import { CodexAppServerHost } from "./codexAppServerHost";
+import { CodexAppServerHost, redactCodexHostDiagnostic } from "./codexAppServerHost";
 import type { RuntimeEventStore } from "./eventStore";
 import type { RuntimeEvent } from "./engineHost";
 import { adoptCodexRegistryHosts, bindCodexHostPersistence, persistCodexHost, startCodexStructuredHost, structuredHostsEnabled } from "./registry";
@@ -25,6 +25,21 @@ class MemoryEventStore implements RuntimeEventStore {
     const events = this.events.get(threadId) ?? [];
     events.push(structuredClone(event));
     this.events.set(threadId, events);
+  }
+}
+
+class FailingEventStore implements RuntimeEventStore {
+  readonly stored: RuntimeEvent[] = [];
+  appendAttempts = 0;
+
+  load(): RuntimeEvent[] {
+    return structuredClone(this.stored);
+  }
+
+  append(_threadId: string, event: RuntimeEvent): void {
+    this.appendAttempts += 1;
+    if (this.appendAttempts >= 2) throw new Error("ENOSPC oauth_token=must-stay-private");
+    this.stored.push(structuredClone(event));
   }
 }
 
@@ -44,6 +59,7 @@ class FakeAppServer extends EventEmitter {
     private readonly turns: unknown[] = [],
     private readonly resumeStatus: unknown = undefined,
     private readonly resumeRequest: { id: string; method: string; params: Record<string, unknown> } | null = null,
+    private readonly ignoredMethods: string[] = [],
   ) {
     super();
     let buffer = "";
@@ -78,6 +94,7 @@ class FakeAppServer extends EventEmitter {
     this.requests.push(message);
     if (typeof message.id !== "number") return;
     const method = message.method;
+    if (typeof method === "string" && this.ignoredMethods.includes(method)) return;
     if (method === "initialize") return this.respond(message.id, { userAgent: "codex_desktop_app/0.144.1 (Linux)" });
     if (method === "account/read") return this.respond(message.id, { account: { type: "chatgpt", planType: "pro" }, requiresOpenaiAuth: false });
     if (method === "thread/start" || method === "thread/resume") {
@@ -501,6 +518,69 @@ describe("CodexAppServerHost", () => {
     expect((await stream.next()).value).toMatchObject({ kind: "session-status", status: "dead" });
     expect((await stream.next()).done).toBeTrue();
     await host.release();
+  });
+
+  test("a mutating RPC timeout poisons the writer before retry", async () => {
+    const server = new FakeAppServer("timeout-thread", "timeout-thread", false, [], undefined, null, ["turn/start"]);
+    const host = await CodexAppServerHost.start({
+      cwd: "/repo",
+      requestTimeoutMs: 5,
+      eventStore: new MemoryEventStore(),
+      spawnProcess: fakeSpawn(server),
+    });
+    await expect(host.send({ id: "ambiguous-send", text: "start" })).rejects.toThrow("outcome is uncertain");
+    expect(await host.send({ id: "retry", text: "duplicate" })).toEqual({ outcome: "rejected", reason: "dead-host" });
+    expect(server.requests.filter((request) => request.method === "turn/start")).toHaveLength(1);
+    expect(server.signals).toContain("SIGTERM");
+    await host.release();
+  });
+
+  test("ledger failures are contained, reject pending work, and close subscribers", async () => {
+    const store = new FailingEventStore();
+    const server = new FakeAppServer("ledger-thread", "ledger-thread", false, [], undefined, null, ["turn/start"]);
+    const host = await CodexAppServerHost.start({
+      cwd: "/repo",
+      requestTimeoutMs: 1_000,
+      eventStore: store,
+      spawnProcess: fakeSpawn(server),
+    });
+    const stream = host.attach((await host.health()).eventCursor)[Symbol.asyncIterator]();
+    const pendingSend = host.send({ id: "pending-ledger-send", text: "start" });
+    server.notify("account/rateLimits/updated", { rateLimits: {} });
+    await expect(pendingSend).rejects.toThrow("runtime event ledger failed");
+    expect(await host.health()).toMatchObject({ status: "dead", eventCursor: 1 });
+    expect(store.appendAttempts).toBe(2);
+    server.notify("account/rateLimits/updated", { rateLimits: { retry: true } });
+    expect(store.appendAttempts).toBe(2);
+    expect((await stream.next()).done).toBeTrue();
+    expect(server.signals).toContain("SIGTERM");
+    await host.release();
+  });
+
+  test("diagnostics redact credential labels, cookies, JWTs, and provider key prefixes", () => {
+    const secrets = [
+      "oauth-secret-value",
+      "auth-secret-value",
+      "session-secret-value",
+      "client-secret-value",
+      "cookie-secret-value",
+      "generic-secret-value",
+      "eyJabcdefghijk.abcdefghijk.abcdefghijk",
+      "sk-ant-abcdefghijklmnopqrstuvwxyz",
+      "ghp_abcdefghijklmnopqrstuvwxyz1234567890",
+    ];
+    const redacted = redactCodexHostDiagnostic([
+      `oauth_token=${secrets[0]}`,
+      `auth_token=${secrets[1]}`,
+      `session_token=${secrets[2]}`,
+      `client_secret=${secrets[3]}`,
+      `cookie=${secrets[4]}`,
+      `token=${secrets[5]}`,
+      secrets[6],
+      secrets[7],
+      secrets[8],
+    ].join(" "));
+    for (const secret of secrets) expect(redacted).not.toContain(secret);
   });
 
   test("requires an exact opt-in value", async () => {

--- a/src/lib/runtime/codexAppServerHost.test.ts
+++ b/src/lib/runtime/codexAppServerHost.test.ts
@@ -105,9 +105,12 @@ class FakeAppServer extends EventEmitter {
   }
 }
 
-function fakeSpawn(server: FakeAppServer, captured?: { options?: SpawnOptionsWithoutStdio }) {
-  return (_command: string, _args: string[], options: SpawnOptionsWithoutStdio) => {
-    if (captured) captured.options = options;
+function fakeSpawn(server: FakeAppServer, captured?: { args?: string[]; options?: SpawnOptionsWithoutStdio }) {
+  return (_command: string, args: string[], options: SpawnOptionsWithoutStdio) => {
+    if (captured) {
+      captured.args = args;
+      captured.options = options;
+    }
     return server as unknown as ChildProcessWithoutNullStreams;
   };
 }
@@ -207,12 +210,15 @@ describe("CodexAppServerHost", () => {
 
   test("resumes the same engine thread after a host-process replacement", async () => {
     const eventStore = new MemoryEventStore();
-    const first = await CodexAppServerHost.start({ cwd: "/repo", eventStore, spawnProcess: fakeSpawn(new FakeAppServer("durable-thread")) });
+    const firstServer = new FakeAppServer("durable-thread");
+    const first = await CodexAppServerHost.start({ cwd: "/repo", effort: "xhigh", eventStore, spawnProcess: fakeSpawn(firstServer) });
     await first.send({ id: "before-restart", text: "remember" });
+    expect(firstServer.requests.find((request) => request.method === "turn/start")?.params).toMatchObject({ effort: "xhigh" });
     await first.release();
     const replacementServer = new FakeAppServer("durable-thread");
     const replacement = await CodexAppServerHost.adopt("durable-thread", {
       cwd: "/repo",
+      effort: "xhigh",
       eventStore,
       initialEventCursor: 3,
       spawnProcess: fakeSpawn(replacementServer),
@@ -223,7 +229,25 @@ describe("CodexAppServerHost", () => {
     expect((await replay.next()).value).toEqual({ kind: "turn-started", turnId: "turn-1", seq: 2 });
     expect((await replay.next()).value).toEqual({ kind: "session-status", status: "unhosted", seq: 3 });
     expect((await replay.next()).value).toEqual({ kind: "session-status", status: "idle", seq: 4 });
+    await replacement.send({ id: "after-restart", text: "recall" });
+    expect(replacementServer.requests.find((request) => request.method === "turn/start")?.params).toMatchObject({ effort: "xhigh" });
     await replacement.release();
+  });
+
+  test("managed-home adoption pins file-backed Codex credentials", async () => {
+    const server = new FakeAppServer("managed-thread");
+    const captured: { args?: string[]; options?: SpawnOptionsWithoutStdio } = {};
+    const host = await CodexAppServerHost.adopt("managed-thread", {
+      cwd: "/repo",
+      codexHome: "/managed-codex-home",
+      fileAuthCredentials: true,
+      eventStore: new MemoryEventStore(),
+      spawnProcess: fakeSpawn(server, captured),
+    });
+    expect(captured.args).toEqual(["-c", "cli_auth_credentials_store=file", "app-server"]);
+    expect(captured.options?.env?.CODEX_HOME).toBe("/managed-codex-home");
+    expect(server.requests.some((request) => request.method === "thread/resume")).toBeTrue();
+    await host.release();
   });
 
   test("rejects a resume response for a different durable thread", async () => {

--- a/src/lib/runtime/codexAppServerHost.test.ts
+++ b/src/lib/runtime/codexAppServerHost.test.ts
@@ -517,6 +517,34 @@ describe("CodexAppServerHost", () => {
     expect(server.signals).toEqual(["SIGTERM", "SIGKILL"]);
     expect((await stream.next()).value).toMatchObject({ kind: "session-status", status: "dead" });
     expect((await stream.next()).done).toBeTrue();
+    const terminal = await host.health();
+    server.notify("turn/started", { threadId: "failed-thread", turn: { id: "late-turn" } });
+    server.request("late-approval", "item/commandExecution/requestApproval", { command: "date" });
+    server.notify("thread/status/changed", { threadId: "failed-thread", status: { type: "active", activeFlags: ["running"] } });
+    expect(await host.health()).toMatchObject({
+      status: "dead",
+      eventCursor: terminal.eventCursor,
+      activeTurnRef: null,
+      pendingAttention: [],
+      activeFlags: [],
+    });
+    await host.release();
+  });
+
+  test("an asynchronous stdin EPIPE fails and reaps the host", async () => {
+    const server = new FakeAppServer("epipe-thread", "epipe-thread", false, [], undefined, null, ["turn/start"]);
+    const host = await CodexAppServerHost.start({
+      cwd: "/repo",
+      requestTimeoutMs: 1_000,
+      eventStore: new MemoryEventStore(),
+      spawnProcess: fakeSpawn(server),
+    });
+    const pendingSend = host.send({ id: "epipe-send", text: "start" });
+    const error = Object.assign(new Error("broken pipe"), { code: "EPIPE" });
+    server.stdin.emit("error", error);
+    await expect(pendingSend).rejects.toThrow("stdin failed: broken pipe");
+    expect(await host.health()).toMatchObject({ status: "dead", activeTurnRef: null, pendingAttention: [] });
+    expect(server.signals).toContain("SIGTERM");
     await host.release();
   });
 
@@ -532,6 +560,9 @@ describe("CodexAppServerHost", () => {
     expect(await host.send({ id: "retry", text: "duplicate" })).toEqual({ outcome: "rejected", reason: "dead-host" });
     expect(server.requests.filter((request) => request.method === "turn/start")).toHaveLength(1);
     expect(server.signals).toContain("SIGTERM");
+    const terminal = await host.health();
+    server.notify("turn/started", { threadId: "timeout-thread", turn: { id: "late-timeout-turn" } });
+    expect(await host.health()).toMatchObject({ status: "dead", eventCursor: terminal.eventCursor, activeTurnRef: null });
     await host.release();
   });
 

--- a/src/lib/runtime/codexAppServerHost.test.ts
+++ b/src/lib/runtime/codexAppServerHost.test.ts
@@ -43,6 +43,7 @@ class FakeAppServer extends EventEmitter {
     private readonly ignoreTerm = false,
     private readonly turns: unknown[] = [],
     private readonly resumeStatus: unknown = undefined,
+    private readonly resumeRequest: { id: string; method: string; params: Record<string, unknown> } | null = null,
   ) {
     super();
     let buffer = "";
@@ -81,6 +82,9 @@ class FakeAppServer extends EventEmitter {
     if (method === "account/read") return this.respond(message.id, { account: { type: "chatgpt", planType: "pro" }, requiresOpenaiAuth: false });
     if (method === "thread/start" || method === "thread/resume") {
       const id = method === "thread/resume" ? this.resumedThreadId : this.threadId;
+      if (method === "thread/resume" && this.resumeRequest) {
+        this.request(this.resumeRequest.id, this.resumeRequest.method, this.resumeRequest.params);
+      }
       return this.respond(message.id, {
         thread: {
           id,
@@ -419,6 +423,32 @@ describe("CodexAppServerHost", () => {
     await host.release();
   });
 
+  test("preserves a live approval delivered by the resumed process", async () => {
+    const attentionId = "item/commandExecution/requestApproval:live-approval";
+    const server = new FakeAppServer("live-attention", "live-attention", false, [{
+      id: "live-turn",
+      status: "inProgress",
+      items: [],
+    }], { type: "active", activeFlags: ["waitingForApproval"] }, {
+      id: "live-approval",
+      method: "item/commandExecution/requestApproval",
+      params: { command: "date" },
+    });
+    const host = await CodexAppServerHost.adopt("live-attention", {
+      cwd: "/repo",
+      eventStore: new MemoryEventStore(),
+      spawnProcess: fakeSpawn(server),
+    });
+    expect(await host.health()).toMatchObject({
+      status: "attention",
+      activeTurnRef: "live-turn",
+      pendingAttention: [attentionId],
+    });
+    await host.answer(attentionId, { decision: "accept" });
+    expect(server.requests.at(-1)).toMatchObject({ id: "live-approval", result: { decision: "accept" } });
+    await host.release();
+  });
+
   test("parses generated-schema thread status notifications", async () => {
     const server = new FakeAppServer("status-thread");
     const host = await CodexAppServerHost.start({
@@ -645,6 +675,10 @@ describe("CodexAppServerHost", () => {
       spawnProcess: fakeSpawn(server),
     });
     await bindCodexHostPersistence(registry, key, host, "old-owner", 1);
+    const started = await host.send({ id: "before-fence", text: "start" });
+    expect(started).toEqual({ outcome: "turn-started", turnId: "turn-1" });
+    server.request("stale-approval", "item/commandExecution/requestApproval", { command: "date" });
+    await Bun.sleep(0);
     const current = registry.snapshot().entries["codex:fenced-thread"]!;
     registry.upsert({
       ...current,
@@ -657,6 +691,13 @@ describe("CodexAppServerHost", () => {
       claimEpoch: 2,
       claimOwner: "new-owner",
     });
+    const requestCount = server.requests.length;
+    expect(await host.send({ id: "stale-send", text: "blocked", expectedTurnId: "turn-1" }))
+      .toEqual({ outcome: "rejected", reason: "dead-host" });
+    await expect(host.interrupt("turn-1")).rejects.toThrow("unavailable");
+    await expect(host.answer("item/commandExecution/requestApproval:stale-approval", { decision: "accept" }))
+      .rejects.toThrow("unavailable");
+    expect(server.requests).toHaveLength(requestCount);
     server.notify("thread/status/changed", { threadId: "fenced-thread", status: { type: "active", activeFlags: ["running"] } });
     await Bun.sleep(0);
     expect(registry.snapshot().entries["codex:fenced-thread"]).toMatchObject({
@@ -706,5 +747,56 @@ describe("CodexAppServerHost", () => {
     const after = registry.snapshot();
     expect(after.conversationRevision.codex).toBe(before.conversationRevision.codex + 1);
     expect(after.engineRouting.codex.revision).toBe(before.engineRouting.codex.revision + 1);
+  });
+
+  test("legacy host upserts preserve coexisting structured columns", () => {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-structured-coexistence-"));
+    const registry = new AgentRegistry(path.join(directory, "agent-registry.json"));
+    const key = { engine: "codex" as const, sessionId: "coexisting-thread" };
+    const structuredHost = {
+      kind: "codex-app-server" as const,
+      endpoint: "stdio:42",
+      process: { pid: 42, startIdentity: "42:start" },
+      eventCursor: 8,
+      protocolVersion: "0.144.1",
+      writerClaimEpoch: 3,
+      activeTurnRef: "turn-live",
+      pendingAttention: ["approval-live"],
+      activeFlags: ["running"],
+    };
+    registry.upsert({
+      key,
+      artifactPath: "/sessions/coexisting-thread.jsonl",
+      cwd: "/repo",
+      accountId: null,
+      status: "live",
+      host: null,
+      structuredHost,
+      claimEpoch: 3,
+      claimOwner: "structured-owner",
+      pendingAction: null,
+    });
+    registry.upsert({
+      key,
+      artifactPath: "/sessions/coexisting-thread.jsonl",
+      cwd: "/repo",
+      accountId: null,
+      status: "live",
+      host: {
+        kind: "tmux",
+        endpoint: "/tmp/tmux.sock",
+        server: { pid: 10, startIdentity: "10:start" },
+        paneId: "%1",
+        panePid: { pid: 11, startIdentity: "11:start" },
+        windowName: "codex",
+        agent: { pid: 12, startIdentity: "12:start" },
+        argv: ["codex"],
+      },
+      claimEpoch: 3,
+      claimOwner: "structured-owner",
+      pendingAction: null,
+    });
+    expect(registry.snapshot().entries["codex:coexisting-thread"]?.structuredHost).toEqual(structuredHost);
+    expect(registry.ownsStructuredHostClaim(key, "structured-owner", 3)).toBeTrue();
   });
 });

--- a/src/lib/runtime/codexAppServerHost.test.ts
+++ b/src/lib/runtime/codexAppServerHost.test.ts
@@ -10,7 +10,23 @@ import { AgentRegistry } from "@/lib/agent/registry";
 import { emptyLaunchProfile } from "@/lib/accounts/migration/contracts";
 
 import { CodexAppServerHost } from "./codexAppServerHost";
+import type { RuntimeEventStore } from "./eventStore";
+import type { RuntimeEvent } from "./engineHost";
 import { adoptCodexRegistryHosts, persistCodexHost, startCodexStructuredHost, structuredHostsEnabled } from "./registry";
+
+class MemoryEventStore implements RuntimeEventStore {
+  private readonly events = new Map<string, RuntimeEvent[]>();
+
+  load(threadId: string): RuntimeEvent[] {
+    return structuredClone(this.events.get(threadId) ?? []);
+  }
+
+  append(threadId: string, event: RuntimeEvent): void {
+    const events = this.events.get(threadId) ?? [];
+    events.push(structuredClone(event));
+    this.events.set(threadId, events);
+  }
+}
 
 class FakeAppServer extends EventEmitter {
   readonly stdin = new PassThrough();
@@ -25,6 +41,7 @@ class FakeAppServer extends EventEmitter {
     private readonly threadId = "thread-149",
     private readonly resumedThreadId = threadId,
     private readonly ignoreTerm = false,
+    private readonly turns: unknown[] = [],
   ) {
     super();
     let buffer = "";
@@ -63,7 +80,7 @@ class FakeAppServer extends EventEmitter {
     if (method === "account/read") return this.respond(message.id, { account: { type: "chatgpt", planType: "pro" }, requiresOpenaiAuth: false });
     if (method === "thread/start" || method === "thread/resume") {
       const id = method === "thread/resume" ? this.resumedThreadId : this.threadId;
-      return this.respond(message.id, { thread: { id, path: `/sessions/${id}.jsonl` } });
+      return this.respond(message.id, { thread: { id, path: `/sessions/${id}.jsonl`, turns: this.turns } });
     }
     if (method === "turn/start") {
       const turnId = `turn-${++this.turn}`;
@@ -97,10 +114,20 @@ describe("CodexAppServerHost", () => {
     const captured: { options?: SpawnOptionsWithoutStdio } = {};
     const host = await CodexAppServerHost.start({
       cwd: "/repo",
-      env: { NODE_ENV: "test", PATH: process.env.PATH, OPENAI_API_KEY: "must-not-cross" },
+      codexHome: "/codex-home",
+      env: {
+        NODE_ENV: "test",
+        PATH: process.env.PATH,
+        OPENAI_API_KEY: "must-not-cross",
+        LLV_TOKEN: "must-not-cross",
+        ANTHROPIC_AUTH_TOKEN: "must-not-cross",
+        AWS_SESSION_TOKEN: "must-not-cross",
+        PRIVATE_SERVICE_API_KEY: "must-not-cross",
+      },
+      eventStore: new MemoryEventStore(),
       spawnProcess: fakeSpawn(server, captured),
     });
-    expect((captured.options?.env as NodeJS.ProcessEnv).OPENAI_API_KEY).toBeUndefined();
+    expect(captured.options?.env).toEqual({ NODE_ENV: "test", PATH: process.env.PATH, CODEX_HOME: "/codex-home" });
     expect(host.identity).toEqual({ threadId: "thread-149", path: "/sessions/thread-149.jsonl" });
 
     const first = host.attach(0);
@@ -150,12 +177,23 @@ describe("CodexAppServerHost", () => {
   });
 
   test("resumes the same engine thread after a host-process replacement", async () => {
-    const first = await CodexAppServerHost.start({ cwd: "/repo", spawnProcess: fakeSpawn(new FakeAppServer("durable-thread")) });
+    const eventStore = new MemoryEventStore();
+    const first = await CodexAppServerHost.start({ cwd: "/repo", eventStore, spawnProcess: fakeSpawn(new FakeAppServer("durable-thread")) });
+    await first.send({ id: "before-restart", text: "remember" });
     await first.release();
     const replacementServer = new FakeAppServer("durable-thread");
-    const replacement = await CodexAppServerHost.adopt("durable-thread", { cwd: "/repo", spawnProcess: fakeSpawn(replacementServer) });
+    const replacement = await CodexAppServerHost.adopt("durable-thread", {
+      cwd: "/repo",
+      eventStore,
+      initialEventCursor: 3,
+      spawnProcess: fakeSpawn(replacementServer),
+    });
     expect(replacement.identity.threadId).toBe("durable-thread");
     expect(replacementServer.requests.some((request) => request.method === "thread/resume")).toBeTrue();
+    const replay = replacement.attach(1)[Symbol.asyncIterator]();
+    expect((await replay.next()).value).toEqual({ kind: "turn-started", turnId: "turn-1", seq: 2 });
+    expect((await replay.next()).value).toEqual({ kind: "session-status", status: "unhosted", seq: 3 });
+    expect((await replay.next()).value).toEqual({ kind: "session-status", status: "idle", seq: 4 });
     await replacement.release();
   });
 
@@ -163,9 +201,36 @@ describe("CodexAppServerHost", () => {
     const server = new FakeAppServer("server-default", "different-thread");
     await expect(CodexAppServerHost.adopt("requested-thread", {
       cwd: "/repo",
+      eventStore: new MemoryEventStore(),
       spawnProcess: fakeSpawn(server),
     })).rejects.toThrow("thread/resume returned a different thread id");
     expect(server.signals).toContain("SIGTERM");
+  });
+
+  test("rebuilds replay from resume history when a legacy host has no event ledger", async () => {
+    const server = new FakeAppServer("history-thread", "history-thread", false, [{
+      id: "history-turn",
+      status: "completed",
+      items: [{ type: "agentMessage", text: "persisted" }],
+    }]);
+    const host = await CodexAppServerHost.adopt("history-thread", {
+      cwd: "/repo",
+      initialEventCursor: 5,
+      eventStore: new MemoryEventStore(),
+      spawnProcess: fakeSpawn(server),
+    });
+    const replay = host.attach(5)[Symbol.asyncIterator]();
+    expect((await replay.next()).value).toEqual({ kind: "turn-started", turnId: "history-turn", seq: 6 });
+    expect((await replay.next()).value).toEqual({
+      kind: "item",
+      turnId: "history-turn",
+      item: { type: "agentMessage", text: "persisted" },
+      phase: "completed",
+      seq: 7,
+    });
+    expect((await replay.next()).value).toEqual({ kind: "turn-ended", turnId: "history-turn", status: "completed", seq: 8 });
+    expect(() => host.attach(0)).toThrow("runtime replay begins at sequence 6");
+    await host.release();
   });
 
   test("release awaits TERM and escalates to KILL before resolving", async () => {
@@ -173,6 +238,7 @@ describe("CodexAppServerHost", () => {
     const host = await CodexAppServerHost.start({
       cwd: "/repo",
       shutdownGraceMs: 5,
+      eventStore: new MemoryEventStore(),
       spawnProcess: fakeSpawn(server),
     });
     await host.release();
@@ -184,6 +250,7 @@ describe("CodexAppServerHost", () => {
     const host = await CodexAppServerHost.start({
       cwd: "/repo",
       shutdownGraceMs: 5,
+      eventStore: new MemoryEventStore(),
       spawnProcess: fakeSpawn(server),
     });
     server.stdout.write("malformed\n");
@@ -197,7 +264,7 @@ describe("CodexAppServerHost", () => {
     expect(structuredHostsEnabled({ NODE_ENV: "test", LLV_STRUCTURED_HOSTS: "true" })).toBeFalse();
     expect(structuredHostsEnabled({ NODE_ENV: "test", LLV_STRUCTURED_HOSTS: "1" })).toBeTrue();
     await expect(startCodexStructuredHost(
-      { cwd: "/repo", spawnProcess: fakeSpawn(new FakeAppServer()) },
+      { cwd: "/repo", eventStore: new MemoryEventStore(), spawnProcess: fakeSpawn(new FakeAppServer()) },
       { NODE_ENV: "test" },
     )).rejects.toThrow("structured hosts are disabled");
   });
@@ -229,15 +296,16 @@ describe("CodexAppServerHost", () => {
     });
     const disabled = await adoptCodexRegistryHosts(
       registry,
-      () => ({ cwd: "/repo", spawnProcess: fakeSpawn(new FakeAppServer("adopted-thread")) }),
+      () => ({ cwd: "/repo", eventStore: new MemoryEventStore(), spawnProcess: fakeSpawn(new FakeAppServer("adopted-thread")) }),
       { NODE_ENV: "test" },
     );
     expect(disabled).toEqual([]);
 
     const server = new FakeAppServer("adopted-thread");
+    const eventStore = new MemoryEventStore();
     const adopted = await adoptCodexRegistryHosts(
       registry,
-      () => ({ cwd: "/repo", spawnProcess: fakeSpawn(server) }),
+      () => ({ cwd: "/repo", eventStore, spawnProcess: fakeSpawn(server) }),
       { NODE_ENV: "test", LLV_STRUCTURED_HOSTS: "1" },
     );
     expect(adopted).toHaveLength(1);
@@ -247,7 +315,24 @@ describe("CodexAppServerHost", () => {
       writerClaimEpoch: 4,
       endpoint: "stdio:4242",
     });
+    const receipt = await adopted[0]!.host.send({ id: "persist-turn", text: "start" });
+    expect(receipt.outcome).toBe("turn-started");
+    expect(registry.snapshot().entries["codex:adopted-thread"]?.structuredHost).toMatchObject({
+      eventCursor: 14,
+      activeTurnRef: "turn-1",
+    });
+    server.request("persist-attention", "item/commandExecution/requestApproval", { command: "date" });
+    await Bun.sleep(0);
+    expect(registry.snapshot().entries["codex:adopted-thread"]?.structuredHost?.pendingAttention).toEqual([
+      "item/commandExecution/requestApproval:persist-attention",
+    ]);
+    await adopted[0]!.host.answer("item/commandExecution/requestApproval:persist-attention", { decision: "decline" });
+    expect(registry.snapshot().entries["codex:adopted-thread"]?.structuredHost?.pendingAttention).toEqual([]);
     await adopted[0]!.host.release();
+    expect(registry.snapshot().entries["codex:adopted-thread"]).toMatchObject({
+      status: "unhosted",
+      structuredHost: { eventCursor: 16, process: null, activeTurnRef: null, pendingAttention: [] },
+    });
   });
 
   test("concurrent startup adoption creates one writer and advances its claim epoch", async () => {
@@ -281,7 +366,7 @@ describe("CodexAppServerHost", () => {
       () => {
         const server = new FakeAppServer("claimed-thread");
         servers.push(server);
-        return { cwd: "/repo", spawnProcess: fakeSpawn(server) };
+        return { cwd: "/repo", eventStore: new MemoryEventStore(), spawnProcess: fakeSpawn(server) };
       },
       { NODE_ENV: "test", LLV_STRUCTURED_HOSTS: "1" },
     );

--- a/src/lib/runtime/codexAppServerHost.test.ts
+++ b/src/lib/runtime/codexAppServerHost.test.ts
@@ -557,6 +557,49 @@ describe("CodexAppServerHost", () => {
     await host.release();
   });
 
+  test("a shutdown ledger failure still releases the bound registry claim", async () => {
+    const store = new FailingEventStore();
+    const server = new FakeAppServer("release-ledger-thread");
+    const host = await CodexAppServerHost.start({
+      cwd: "/repo",
+      eventStore: store,
+      spawnProcess: fakeSpawn(server),
+    });
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-release-ledger-"));
+    const registry = new AgentRegistry(path.join(directory, "agent-registry.json"));
+    const key = { engine: "codex" as const, sessionId: "release-ledger-thread" };
+    registry.upsert({
+      key,
+      artifactPath: "/sessions/release-ledger-thread.jsonl",
+      cwd: "/repo",
+      accountId: null,
+      status: "idle",
+      host: null,
+      structuredHost: {
+        kind: "codex-app-server",
+        endpoint: "stdio:4242",
+        process: { pid: 4242, startIdentity: null },
+        eventCursor: 1,
+        protocolVersion: "0.144.1",
+        writerClaimEpoch: 4,
+        activeTurnRef: null,
+        pendingAttention: [],
+        activeFlags: [],
+      },
+      claimEpoch: 4,
+      claimOwner: "release-owner",
+      pendingAction: null,
+    });
+    await bindCodexHostPersistence(registry, key, host, "release-owner", 4);
+    await host.release();
+    expect(store.appendAttempts).toBe(2);
+    expect(registry.snapshot().entries["codex:release-ledger-thread"]).toMatchObject({
+      status: "unhosted",
+      claimOwner: null,
+      structuredHost: { process: null, endpoint: "stdio:released", activeTurnRef: null, pendingAttention: [], activeFlags: [] },
+    });
+  });
+
   test("diagnostics redact credential labels, cookies, JWTs, and provider key prefixes", () => {
     const secrets = [
       "oauth-secret-value",
@@ -674,6 +717,54 @@ describe("CodexAppServerHost", () => {
     expect(registry.claimStructuredHost(key, replacementOwner)).toBeNull();
     const reclaimed = registry.claimStructuredHost(key, replacementOwner, { allowUnhosted: true });
     expect(reclaimed?.claimEpoch).toBe(5);
+  });
+
+  test("failed adoption clears connection-scoped attention and activity", async () => {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-failed-adoption-"));
+    const registry = new AgentRegistry(path.join(directory, "agent-registry.json"));
+    const key = { engine: "codex" as const, sessionId: "failed-adoption-thread" };
+    registry.upsert({
+      key,
+      artifactPath: "/sessions/failed-adoption-thread.jsonl",
+      cwd: "/repo",
+      accountId: null,
+      status: "dead",
+      host: null,
+      structuredHost: {
+        kind: "codex-app-server",
+        endpoint: "stdio:old",
+        process: null,
+        eventCursor: 9,
+        protocolVersion: "0.144.1",
+        writerClaimEpoch: 2,
+        activeTurnRef: "turn-old",
+        pendingAttention: ["approval-old"],
+        activeFlags: ["waitingForApproval"],
+      },
+      claimEpoch: 2,
+      claimOwner: null,
+      pendingAction: null,
+    });
+    const adopted = await adoptCodexRegistryHosts(
+      registry,
+      () => ({
+        cwd: "/repo",
+        eventStore: new MemoryEventStore(),
+        spawnProcess: fakeSpawn(new FakeAppServer("failed-adoption-thread", "different-thread")),
+      }),
+      { NODE_ENV: "test", LLV_STRUCTURED_HOSTS: "1" },
+    );
+    expect(adopted).toEqual([]);
+    expect(registry.snapshot().entries["codex:failed-adoption-thread"]).toMatchObject({
+      status: "dead",
+      claimOwner: null,
+      structuredHost: {
+        process: null,
+        activeTurnRef: null,
+        pendingAttention: [],
+        activeFlags: [],
+      },
+    });
   });
 
   test("concurrent startup adoption creates one writer and advances its claim epoch", async () => {
@@ -878,5 +969,11 @@ describe("CodexAppServerHost", () => {
     });
     expect(registry.snapshot().entries["codex:coexisting-thread"]?.structuredHost).toEqual(structuredHost);
     expect(registry.ownsStructuredHostClaim(key, "structured-owner", 3)).toBeTrue();
+    registry.markUnhosted(key);
+    expect(registry.snapshot().entries["codex:coexisting-thread"]).toMatchObject({
+      status: "live",
+      host: null,
+      structuredHost,
+    });
   });
 });

--- a/src/lib/runtime/codexAppServerHost.test.ts
+++ b/src/lib/runtime/codexAppServerHost.test.ts
@@ -304,6 +304,41 @@ describe("CodexAppServerHost", () => {
     await host.release();
   });
 
+  test("restores the resumed active turn after a dead ledger", async () => {
+    const eventStore = new MemoryEventStore();
+    eventStore.append("active-after-crash", { kind: "turn-started", turnId: "stale-turn", seq: 1 });
+    eventStore.append("active-after-crash", { kind: "session-status", status: "dead", seq: 2 });
+    const server = new FakeAppServer("active-after-crash", "active-after-crash", false, [{
+      id: "resumed-turn",
+      status: "inProgress",
+      items: [],
+    }], { type: "active", activeFlags: ["running"] });
+    const host = await CodexAppServerHost.adopt("active-after-crash", {
+      cwd: "/repo",
+      eventStore,
+      initialEventCursor: 2,
+      spawnProcess: fakeSpawn(server),
+    });
+    const replay = host.attach(2)[Symbol.asyncIterator]();
+    expect((await replay.next()).value).toEqual({ kind: "turn-started", turnId: "resumed-turn", seq: 3 });
+    expect((await replay.next()).value).toEqual({
+      kind: "session-status",
+      status: "active",
+      activeFlags: ["running"],
+      seq: 4,
+    });
+    expect(await host.health()).toMatchObject({ status: "active", activeTurnRef: "resumed-turn" });
+    expect(await host.send({ id: "steer-resumed", text: "continue", expectedTurnId: "resumed-turn" }))
+      .toEqual({ outcome: "steered", turnId: "resumed-turn" });
+    await host.interrupt("resumed-turn");
+    expect(server.requests.some((request) => request.method === "turn/start")).toBeFalse();
+    expect(server.requests.find((request) => request.method === "turn/steer")?.params)
+      .toMatchObject({ expectedTurnId: "resumed-turn" });
+    expect(server.requests.find((request) => request.method === "turn/interrupt")?.params)
+      .toMatchObject({ turnId: "resumed-turn" });
+    await host.release();
+  });
+
   test("resolves ledger attention during adoption and preserves resumed active flags", async () => {
     const eventStore = new MemoryEventStore();
     eventStore.append("crashed-attention", {
@@ -313,7 +348,11 @@ describe("CodexAppServerHost", () => {
       attention: { command: "date" },
       seq: 1,
     });
-    const server = new FakeAppServer("crashed-attention", "crashed-attention", false, [], {
+    const server = new FakeAppServer("crashed-attention", "crashed-attention", false, [{
+      id: "approval-turn",
+      status: "inProgress",
+      items: [],
+    }], {
       type: "active",
       activeFlags: ["waitingForApproval"],
     });
@@ -324,20 +363,22 @@ describe("CodexAppServerHost", () => {
       spawnProcess: fakeSpawn(server),
     });
     const replay = host.attach(1)[Symbol.asyncIterator]();
+    expect((await replay.next()).value).toEqual({ kind: "turn-started", turnId: "approval-turn", seq: 2 });
     expect((await replay.next()).value).toEqual({
       kind: "attention-resolved",
       id: "item/commandExecution/requestApproval:approval-crash",
       resolution: "host-restarted",
-      seq: 2,
+      seq: 3,
     });
     expect((await replay.next()).value).toEqual({
       kind: "session-status",
       status: "active",
       activeFlags: ["waitingForApproval"],
-      seq: 3,
+      seq: 4,
     });
     expect(await host.health()).toMatchObject({
       status: "active",
+      activeTurnRef: "approval-turn",
       pendingAttention: [],
       activeFlags: ["waitingForApproval"],
     });

--- a/src/lib/runtime/codexAppServerHost.test.ts
+++ b/src/lib/runtime/codexAppServerHost.test.ts
@@ -156,6 +156,16 @@ describe("CodexAppServerHost", () => {
     expect(attention).toBe("item/commandExecution/requestApproval:approval-1");
     await host.answer(attention, { decision: "accept" });
     expect(server.requests.at(-1)).toMatchObject({ id: "approval-1", result: { decision: "accept" } });
+    server.request("approval-2", "item/commandExecution/requestApproval", { command: "echo resolved" });
+    await Bun.sleep(0);
+    const resolvedStream = host.attach((await host.health()).eventCursor)[Symbol.asyncIterator]();
+    server.notify("serverRequest/resolved", { threadId: "thread-149", requestId: "approval-2" });
+    expect((await resolvedStream.next()).value).toMatchObject({
+      kind: "attention-resolved",
+      id: "item/commandExecution/requestApproval:approval-2",
+      resolution: "server-resolved",
+    });
+    expect((await host.health()).pendingAttention).toEqual([]);
 
     const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-structured-registry-"));
     const registry = new AgentRegistry(path.join(directory, "agent-registry.json"));
@@ -186,7 +196,7 @@ describe("CodexAppServerHost", () => {
     expect(registry.snapshot().entries["codex:thread-149"]?.structuredHost).toMatchObject({
       kind: "codex-app-server",
       endpoint: "stdio:4242",
-      eventCursor: 4,
+      eventCursor: 6,
       protocolVersion: "0.144.1",
       writerClaimEpoch: 7,
       activeTurnRef: "turn-1",
@@ -437,8 +447,11 @@ describe("CodexAppServerHost", () => {
     await adopted[0]!.host.release();
     expect(registry.snapshot().entries["codex:adopted-thread"]).toMatchObject({
       status: "unhosted",
+      claimOwner: null,
       structuredHost: { eventCursor: 17, process: null, activeTurnRef: null, pendingAttention: [] },
     });
+    const reclaimed = registry.claimStructuredHost(key, { pid: process.pid, startIdentity: "replacement-viewer" });
+    expect(reclaimed?.claimEpoch).toBe(5);
   });
 
   test("concurrent startup adoption creates one writer and advances its claim epoch", async () => {

--- a/src/lib/runtime/codexAppServerHost.ts
+++ b/src/lib/runtime/codexAppServerHost.ts
@@ -1,0 +1,434 @@
+import { spawn } from "node:child_process";
+import type { ChildProcessWithoutNullStreams, SpawnOptionsWithoutStdio } from "node:child_process";
+
+import { procBackend } from "@/lib/proc";
+
+import type {
+  DeliveryReceipt,
+  EngineHost,
+  HostState,
+  QueueEntry,
+  RuntimeEvent,
+} from "./engineHost";
+
+type JsonObject = Record<string, unknown>;
+type PendingRpc = {
+  resolve(value: unknown): void;
+  reject(error: Error): void;
+  timer: ReturnType<typeof setTimeout>;
+};
+type Subscriber = {
+  afterSeq: number;
+  queue: RuntimeEvent[];
+  wake: (() => void) | null;
+  closed: boolean;
+};
+type PendingAttention = { rpcId: string | number; method: string };
+type UnsequencedEvent = RuntimeEvent extends infer Event
+  ? Event extends RuntimeEvent ? Omit<Event, "seq"> : never
+  : never;
+
+export interface CodexAppServerHostOptions {
+  cwd: string;
+  codexHome?: string;
+  binary?: string;
+  model?: string;
+  effort?: string;
+  sandbox?: string;
+  approvalPolicy?: string;
+  env?: NodeJS.ProcessEnv;
+  requestTimeoutMs?: number;
+  initialEventCursor?: number;
+  spawnProcess?: (command: string, args: string[], options: SpawnOptionsWithoutStdio) => ChildProcessWithoutNullStreams;
+}
+
+export interface CodexThreadIdentity {
+  threadId: string;
+  path: string | null;
+}
+
+const SECRET_ENV_NAMES = [
+  "OPENAI_API_KEY",
+  "ANTHROPIC_API_KEY",
+  "CLAUDE_CODE_OAUTH_TOKEN",
+] as const;
+const DEFAULT_TIMEOUT_MS = 30_000;
+const MAX_LINE_BYTES = 4 * 1024 * 1024;
+
+function record(value: unknown): JsonObject | null {
+  return value && typeof value === "object" && !Array.isArray(value) ? value as JsonObject : null;
+}
+
+function stringField(value: unknown, key: string): string | null {
+  const object = record(value);
+  return object && typeof object[key] === "string" ? object[key] as string : null;
+}
+
+function safeError(value: unknown): string {
+  const message = value instanceof Error ? value.message : String(value);
+  return message
+    .replace(/(bearer\s+)[^\s,;]+/gi, "$1[REDACTED]")
+    .replace(/(["']?(?:access|refresh|id)[_-]?token["']?\s*[:=]\s*["']?)[^\s,"'}]+/gi, "$1[REDACTED]")
+    .replace(/(["']?(?:api[_-]?key|authorization)["']?\s*[:=]\s*["']?)[^\s,"'}]+/gi, "$1[REDACTED]")
+    .slice(0, 500);
+}
+
+function subscriptionEnv(source: NodeJS.ProcessEnv, codexHome?: string): NodeJS.ProcessEnv {
+  const env = { ...source };
+  for (const name of SECRET_ENV_NAMES) delete env[name];
+  if (codexHome) env.CODEX_HOME = codexHome;
+  return env;
+}
+
+function threadFromResult(value: unknown, method: string): CodexThreadIdentity {
+  const outer = record(value);
+  const thread = record(outer?.thread) ?? outer;
+  const threadId = stringField(thread, "id");
+  if (!threadId) throw new Error(`${method} returned no thread id`);
+  return { threadId, path: stringField(thread, "path") };
+}
+
+function turnIdFromResult(value: unknown, method: string): string {
+  const outer = record(value);
+  const turn = record(outer?.turn);
+  const turnId = stringField(turn, "id") ?? stringField(outer, "turnId");
+  if (!turnId) throw new Error(`${method} returned no turn id`);
+  return turnId;
+}
+
+function turnIdFromParams(params: JsonObject): string | null {
+  return stringField(params.turn, "id") ?? stringField(params, "turnId");
+}
+
+function protocolVersionFromInitialize(value: JsonObject | null): string | null {
+  const direct = stringField(value, "appServerVersion")
+    ?? stringField(value, "serverVersion")
+    ?? stringField(value, "version");
+  if (direct) return direct;
+  return stringField(value, "userAgent")?.match(/^[^/]+\/([^\s]+)/)?.[1] ?? null;
+}
+
+function terminalStatus(value: unknown): "completed" | "interrupted" | "error" {
+  return value === "completed" ? "completed" : value === "interrupted" ? "interrupted" : "error";
+}
+
+/** One stdio app-server owner with replayable, multi-subscriber event fan-out. */
+export class CodexAppServerHost implements EngineHost {
+  readonly identity: CodexThreadIdentity;
+
+  private readonly child: ChildProcessWithoutNullStreams;
+  private readonly requestTimeoutMs: number;
+  private readonly pending = new Map<number, PendingRpc>();
+  private readonly subscribers = new Set<Subscriber>();
+  private readonly events: RuntimeEvent[] = [];
+  private readonly attentions = new Map<string, PendingAttention>();
+  private nextRpcId = 1;
+  private stdoutBuffer = "";
+  private cursor: number;
+  private activeTurnId: string | null = null;
+  private protocolVersion: string | null = null;
+  private account: HostState["account"] = null;
+  private released = false;
+  private dead = false;
+
+  private constructor(child: ChildProcessWithoutNullStreams, identity: CodexThreadIdentity, options: CodexAppServerHostOptions) {
+    this.child = child;
+    this.identity = identity;
+    this.requestTimeoutMs = options.requestTimeoutMs ?? DEFAULT_TIMEOUT_MS;
+    this.cursor = options.initialEventCursor ?? 0;
+    child.stdout.on("data", (chunk: Buffer | string) => this.acceptStdout(String(chunk)));
+    child.stderr.on("data", () => { /* stderr can contain authentication details; keep it out of output */ });
+    child.on("error", (error) => this.fail(new Error(`Codex app-server child failed: ${safeError(error)}`)));
+    child.on("close", () => {
+      if (!this.released) this.fail(new Error("Codex app-server child exited"));
+    });
+  }
+
+  static async start(options: CodexAppServerHostOptions): Promise<CodexAppServerHost> {
+    return this.open(options, null);
+  }
+
+  static async adopt(threadId: string, options: CodexAppServerHostOptions): Promise<CodexAppServerHost> {
+    if (!threadId) throw new Error("Codex thread id is required for adoption");
+    return this.open(options, threadId);
+  }
+
+  private static async open(options: CodexAppServerHostOptions, threadId: string | null): Promise<CodexAppServerHost> {
+    const spawnProcess = options.spawnProcess ?? ((command, args, spawnOptions) =>
+      spawn(command, args, { ...spawnOptions, stdio: ["pipe", "pipe", "pipe"] }));
+    const child = spawnProcess(options.binary ?? process.env.LLV_CODEX_BINARY ?? "codex", ["app-server"], {
+      cwd: options.cwd,
+      env: subscriptionEnv(options.env ?? process.env, options.codexHome),
+    });
+    const provisional = new CodexAppServerHost(child, { threadId: threadId ?? "pending", path: null }, options);
+    try {
+      const initialized = record(await provisional.rpc("initialize", {
+        clientInfo: { name: "llv-structured-host", title: "Live Log Viewer", version: "0.11.7" },
+        capabilities: { experimentalApi: true },
+      }));
+      provisional.protocolVersion = protocolVersionFromInitialize(initialized);
+      provisional.notify("initialized", {});
+      const accountResult = record(await provisional.rpc("account/read", { refreshToken: false }));
+      const account = record(accountResult?.account);
+      const accountType = stringField(account, "type");
+      if (accountType !== "chatgpt") throw new Error("Codex app-server requires a ChatGPT subscription login");
+      provisional.account = { type: accountType, planType: stringField(account, "planType") };
+      const result = threadId
+        ? await provisional.rpc("thread/resume", { threadId })
+        : await provisional.rpc("thread/start", {
+          cwd: options.cwd,
+          ...(options.model ? { model: options.model } : {}),
+          sandbox: options.sandbox ?? "read-only",
+          approvalPolicy: options.approvalPolicy ?? "never",
+        });
+      const identity = threadFromResult(result, threadId ? "thread/resume" : "thread/start");
+      provisional.identity.threadId = identity.threadId;
+      provisional.identity.path = identity.path;
+      provisional.emit({ kind: "session-status", status: "idle" });
+      return provisional;
+    } catch (error) {
+      await provisional.release();
+      throw new Error(safeError(error));
+    }
+  }
+
+  attach(afterSeq: number): AsyncIterable<RuntimeEvent> {
+    if (!Number.isSafeInteger(afterSeq) || afterSeq < 0) throw new Error("afterSeq must be a non-negative integer");
+    const subscriber: Subscriber = { afterSeq, queue: [], wake: null, closed: false };
+    for (const event of this.events) if (event.seq > afterSeq) subscriber.queue.push(event);
+    this.subscribers.add(subscriber);
+    const host = this;
+    return {
+      async *[Symbol.asyncIterator]() {
+        try {
+          while (!subscriber.closed) {
+            const event = subscriber.queue.shift();
+            if (event) {
+              if (event.seq > subscriber.afterSeq) {
+                subscriber.afterSeq = event.seq;
+                yield event;
+              }
+              continue;
+            }
+            await new Promise<void>((resolve) => { subscriber.wake = resolve; });
+            subscriber.wake = null;
+          }
+        } finally {
+          subscriber.closed = true;
+          host.subscribers.delete(subscriber);
+        }
+      },
+    };
+  }
+
+  async send(entry: QueueEntry): Promise<DeliveryReceipt> {
+    if (this.dead || this.released) return { outcome: "rejected", reason: "dead-host" };
+    if (!entry.id || !entry.text) throw new Error("queue entry id and text are required");
+    const currentTurn = this.activeTurnId;
+    if (entry.expectedTurnId !== undefined && entry.expectedTurnId !== currentTurn) {
+      return { outcome: "rejected", reason: "stale-turn" };
+    }
+    const input = [{ type: "text", text: entry.text }];
+    if (currentTurn) {
+      try {
+        const result = await this.rpc("turn/steer", {
+          threadId: this.identity.threadId,
+          expectedTurnId: currentTurn,
+          input,
+          clientUserMessageId: entry.id,
+        });
+        return { outcome: "steered", turnId: turnIdFromResult(result, "turn/steer") };
+      } catch (error) {
+        if (/expectedTurnId|active turn|stale/i.test(safeError(error))) {
+          return { outcome: "rejected", reason: "stale-turn" };
+        }
+        throw error;
+      }
+    }
+    const result = await this.rpc("turn/start", {
+      threadId: this.identity.threadId,
+      input,
+      clientUserMessageId: entry.id,
+    });
+    const turnId = turnIdFromResult(result, "turn/start");
+    this.activeTurnId = turnId;
+    return { outcome: "turn-started", turnId };
+  }
+
+  async interrupt(turnRef: string): Promise<void> {
+    if (this.dead || this.released) throw new Error("Codex app-server host is unavailable");
+    if (!turnRef || this.activeTurnId !== turnRef) throw new Error("active turn fence is stale");
+    await this.rpc("turn/interrupt", { threadId: this.identity.threadId, turnId: turnRef });
+  }
+
+  async answer(attentionRef: string, value: unknown): Promise<void> {
+    if (this.dead || this.released) throw new Error("Codex app-server host is unavailable");
+    const attention = this.attentions.get(attentionRef);
+    if (!attention) throw new Error("attention request is missing or already answered");
+    this.write({ jsonrpc: "2.0", id: attention.rpcId, result: value ?? {} });
+    this.attentions.delete(attentionRef);
+  }
+
+  async health(): Promise<HostState> {
+    const pid = this.dead || this.released ? null : this.child.pid ?? null;
+    const processStartIdentity = pid ? procBackend.processIdentity(pid) : null;
+    const status: HostState["status"] = this.dead ? "dead"
+      : this.released ? "unhosted"
+      : this.attentions.size > 0 ? "attention"
+      : this.activeTurnId ? "active"
+      : "idle";
+    return {
+      status,
+      sessionKey: this.identity.threadId,
+      endpoint: pid ? `stdio:${pid}` : "stdio:released",
+      pid,
+      processStartIdentity,
+      eventCursor: this.cursor,
+      protocolVersion: this.protocolVersion,
+      activeTurnRef: this.activeTurnId,
+      pendingAttention: [...this.attentions.keys()],
+      account: this.account,
+    };
+  }
+
+  async release(): Promise<void> {
+    if (this.released) return;
+    this.released = true;
+    for (const request of this.pending.values()) {
+      clearTimeout(request.timer);
+      request.reject(new Error("Codex app-server host released"));
+    }
+    this.pending.clear();
+    try { this.child.stdin.end(); } catch { /* already closed */ }
+    try { this.child.kill("SIGTERM"); } catch { /* already closed */ }
+    this.closeSubscribers();
+  }
+
+  private emit(event: UnsequencedEvent): void {
+    const sequenced = { ...event, seq: ++this.cursor } as RuntimeEvent;
+    this.events.push(sequenced);
+    for (const subscriber of this.subscribers) {
+      subscriber.queue.push(sequenced);
+      subscriber.wake?.();
+    }
+  }
+
+  private closeSubscribers(): void {
+    for (const subscriber of this.subscribers) {
+      subscriber.closed = true;
+      subscriber.wake?.();
+    }
+    this.subscribers.clear();
+  }
+
+  private rpc(method: string, params: JsonObject = {}): Promise<unknown> {
+    if (this.dead || this.released) return Promise.reject(new Error("Codex app-server host is unavailable"));
+    const id = this.nextRpcId++;
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.pending.delete(id);
+        reject(new Error(`${method} timed out`));
+      }, this.requestTimeoutMs);
+      this.pending.set(id, { resolve, reject, timer });
+      this.write({ jsonrpc: "2.0", id, method, params });
+    });
+  }
+
+  private notify(method: string, params: JsonObject): void {
+    this.write({ jsonrpc: "2.0", method, params });
+  }
+
+  private write(message: JsonObject): void {
+    this.child.stdin.write(`${JSON.stringify(message)}\n`);
+  }
+
+  private acceptStdout(chunk: string): void {
+    this.stdoutBuffer += chunk;
+    let newline = this.stdoutBuffer.indexOf("\n");
+    while (newline >= 0) {
+      const line = this.stdoutBuffer.slice(0, newline).trim();
+      this.stdoutBuffer = this.stdoutBuffer.slice(newline + 1);
+      if (Buffer.byteLength(line) > MAX_LINE_BYTES) {
+        this.fail(new Error("Codex app-server emitted an oversized JSONL frame"));
+        return;
+      }
+      if (line) this.acceptMessage(line);
+      newline = this.stdoutBuffer.indexOf("\n");
+    }
+    if (Buffer.byteLength(this.stdoutBuffer) > MAX_LINE_BYTES) this.fail(new Error("Codex app-server emitted an oversized JSONL frame"));
+  }
+
+  private acceptMessage(line: string): void {
+    let message: JsonObject | null;
+    try { message = record(JSON.parse(line)); } catch { message = null; }
+    if (!message) {
+      this.fail(new Error("Codex app-server emitted malformed JSON-RPC"));
+      return;
+    }
+    const id = message.id;
+    const method = typeof message.method === "string" ? message.method : null;
+    if ((typeof id === "number" || typeof id === "string") && !method) {
+      if (typeof id !== "number") return this.fail(new Error("Codex app-server response id is invalid"));
+      const pending = this.pending.get(id);
+      if (!pending) return this.fail(new Error("Codex app-server response has no matching request"));
+      this.pending.delete(id);
+      clearTimeout(pending.timer);
+      const error = record(message.error);
+      if (error) pending.reject(new Error(`Codex app-server request failed: ${safeError(error.message ?? "unknown error")}`));
+      else pending.resolve(message.result);
+      return;
+    }
+    if (!method) return this.fail(new Error("Codex app-server message has no method"));
+    const params = record(message.params) ?? {};
+    if (typeof id === "number" || typeof id === "string") {
+      const attentionId = `${method}:${String(id)}`;
+      this.attentions.set(attentionId, { rpcId: id, method });
+      this.emit({ kind: "attention", id: attentionId, method, attention: params });
+      return;
+    }
+    this.acceptNotification(method, params);
+  }
+
+  private acceptNotification(method: string, params: JsonObject): void {
+    const turnId = turnIdFromParams(params);
+    if (method === "turn/started" && turnId) {
+      this.activeTurnId = turnId;
+      this.emit({ kind: "turn-started", turnId });
+      return;
+    }
+    if (method === "item/agentMessage/delta") {
+      this.emit({ kind: "delta", turnId: turnId ?? this.activeTurnId ?? "unknown", text: stringField(params, "delta") ?? "" });
+      return;
+    }
+    if ((method === "item/started" || method === "item/completed") && "item" in params) {
+      this.emit({ kind: "item", turnId: turnId ?? this.activeTurnId, item: params.item, phase: method === "item/started" ? "started" : "completed" });
+      return;
+    }
+    if (method === "turn/completed" && turnId) {
+      this.activeTurnId = null;
+      const turn = record(params.turn);
+      this.emit({ kind: "turn-ended", turnId, status: terminalStatus(turn?.status) });
+      return;
+    }
+    if (method === "account/rateLimits/updated") {
+      this.emit({ kind: "limits", snapshot: params });
+      return;
+    }
+    if (method === "thread/status/changed") {
+      const status = stringField(params, "status") ?? stringField(record(params.thread), "status");
+      this.emit({ kind: "session-status", status: status === "active" ? "active" : "idle" });
+    }
+  }
+
+  private fail(error: Error): void {
+    if (this.dead || this.released) return;
+    this.dead = true;
+    for (const request of this.pending.values()) {
+      clearTimeout(request.timer);
+      request.reject(new Error(safeError(error)));
+    }
+    this.pending.clear();
+    this.emit({ kind: "session-status", status: "dead" });
+    this.closeSubscribers();
+  }
+}

--- a/src/lib/runtime/codexAppServerHost.ts
+++ b/src/lib/runtime/codexAppServerHost.ts
@@ -38,6 +38,7 @@ export interface CodexAppServerHostOptions {
   approvalPolicy?: string;
   env?: NodeJS.ProcessEnv;
   requestTimeoutMs?: number;
+  shutdownGraceMs?: number;
   initialEventCursor?: number;
   spawnProcess?: (command: string, args: string[], options: SpawnOptionsWithoutStdio) => ChildProcessWithoutNullStreams;
 }
@@ -53,6 +54,7 @@ const SECRET_ENV_NAMES = [
   "CLAUDE_CODE_OAUTH_TOKEN",
 ] as const;
 const DEFAULT_TIMEOUT_MS = 30_000;
+const DEFAULT_SHUTDOWN_GRACE_MS = 1_000;
 const MAX_LINE_BYTES = 4 * 1024 * 1024;
 
 function record(value: unknown): JsonObject | null {
@@ -118,6 +120,7 @@ export class CodexAppServerHost implements EngineHost {
 
   private readonly child: ChildProcessWithoutNullStreams;
   private readonly requestTimeoutMs: number;
+  private readonly shutdownGraceMs: number;
   private readonly pending = new Map<number, PendingRpc>();
   private readonly subscribers = new Set<Subscriber>();
   private readonly events: RuntimeEvent[] = [];
@@ -130,16 +133,30 @@ export class CodexAppServerHost implements EngineHost {
   private account: HostState["account"] = null;
   private released = false;
   private dead = false;
+  private reaped = false;
+  private terminationStarted = false;
+  private terminationTimer: ReturnType<typeof setTimeout> | null = null;
+  private releasePromise: Promise<void> | null = null;
+  private readonly reapedPromise: Promise<void>;
+  private resolveReaped!: () => void;
 
   private constructor(child: ChildProcessWithoutNullStreams, identity: CodexThreadIdentity, options: CodexAppServerHostOptions) {
     this.child = child;
     this.identity = identity;
     this.requestTimeoutMs = options.requestTimeoutMs ?? DEFAULT_TIMEOUT_MS;
+    this.shutdownGraceMs = options.shutdownGraceMs ?? DEFAULT_SHUTDOWN_GRACE_MS;
     this.cursor = options.initialEventCursor ?? 0;
+    this.reapedPromise = new Promise((resolve) => { this.resolveReaped = resolve; });
     child.stdout.on("data", (chunk: Buffer | string) => this.acceptStdout(String(chunk)));
     child.stderr.on("data", () => { /* stderr can contain authentication details; keep it out of output */ });
     child.on("error", (error) => this.fail(new Error(`Codex app-server child failed: ${safeError(error)}`)));
     child.on("close", () => {
+      this.reaped = true;
+      if (this.terminationTimer) {
+        clearTimeout(this.terminationTimer);
+        this.terminationTimer = null;
+      }
+      this.resolveReaped();
       if (!this.released) this.fail(new Error("Codex app-server child exited"));
     });
   }
@@ -182,6 +199,9 @@ export class CodexAppServerHost implements EngineHost {
           approvalPolicy: options.approvalPolicy ?? "never",
         });
       const identity = threadFromResult(result, threadId ? "thread/resume" : "thread/start");
+      if (threadId && identity.threadId !== threadId) {
+        throw new Error("thread/resume returned a different thread id");
+      }
       provisional.identity.threadId = identity.threadId;
       provisional.identity.path = identity.path;
       provisional.emit({ kind: "session-status", status: "idle" });
@@ -197,7 +217,7 @@ export class CodexAppServerHost implements EngineHost {
     const subscriber: Subscriber = { afterSeq, queue: [], wake: null, closed: false };
     for (const event of this.events) if (event.seq > afterSeq) subscriber.queue.push(event);
     this.subscribers.add(subscriber);
-    const host = this;
+    const subscribers = this.subscribers;
     return {
       async *[Symbol.asyncIterator]() {
         try {
@@ -215,7 +235,7 @@ export class CodexAppServerHost implements EngineHost {
           }
         } finally {
           subscriber.closed = true;
-          host.subscribers.delete(subscriber);
+          subscribers.delete(subscriber);
         }
       },
     };
@@ -292,16 +312,49 @@ export class CodexAppServerHost implements EngineHost {
   }
 
   async release(): Promise<void> {
-    if (this.released) return;
+    this.releasePromise ??= this.releaseAndReap();
+    return this.releasePromise;
+  }
+
+  private async releaseAndReap(): Promise<void> {
     this.released = true;
     for (const request of this.pending.values()) {
       clearTimeout(request.timer);
       request.reject(new Error("Codex app-server host released"));
     }
     this.pending.clear();
+    this.closeSubscribers();
+    this.startTermination();
+    if (await this.waitForReap(this.shutdownGraceMs)) return;
+    try { this.child.kill("SIGKILL"); } catch { /* already closed */ }
+    if (!await this.waitForReap(this.shutdownGraceMs)) {
+      throw new Error("Codex app-server child could not be reaped");
+    }
+  }
+
+  private startTermination(): void {
+    if (this.terminationStarted || this.reaped) return;
+    this.terminationStarted = true;
     try { this.child.stdin.end(); } catch { /* already closed */ }
     try { this.child.kill("SIGTERM"); } catch { /* already closed */ }
-    this.closeSubscribers();
+    this.terminationTimer = setTimeout(() => {
+      this.terminationTimer = null;
+      if (this.reaped) return;
+      try { this.child.kill("SIGKILL"); } catch { /* already closed */ }
+    }, this.shutdownGraceMs);
+  }
+
+  private async waitForReap(timeoutMs: number): Promise<boolean> {
+    if (this.reaped) return true;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    try {
+      return await Promise.race([
+        this.reapedPromise.then(() => true),
+        new Promise<false>((resolve) => { timer = setTimeout(() => resolve(false), timeoutMs); }),
+      ]);
+    } finally {
+      if (timer) clearTimeout(timer);
+    }
   }
 
   private emit(event: UnsequencedEvent): void {
@@ -430,5 +483,6 @@ export class CodexAppServerHost implements EngineHost {
     this.pending.clear();
     this.emit({ kind: "session-status", status: "dead" });
     this.closeSubscribers();
+    this.startTermination();
   }
 }

--- a/src/lib/runtime/codexAppServerHost.ts
+++ b/src/lib/runtime/codexAppServerHost.ts
@@ -26,7 +26,17 @@ type Subscriber = {
   wake: (() => void) | null;
   closed: boolean;
 };
-type PendingAttention = { rpcId: string | number; method: string; origin: "current" | "restored" };
+type PendingAnswer = {
+  resolve(): void;
+  reject(error: Error): void;
+  timer: ReturnType<typeof setTimeout>;
+};
+type PendingAttention = {
+  rpcId: string | number;
+  method: string;
+  origin: "current" | "restored";
+  answer?: PendingAnswer;
+};
 type ThreadStatus = {
   type: "active" | "idle" | "notLoaded" | "systemError";
   activeFlags: string[];
@@ -383,9 +393,17 @@ export class CodexAppServerHost implements EngineHost {
     }
     const attention = this.attentions.get(attentionRef);
     if (!attention) throw new Error("attention request is missing or already answered");
-    this.write({ jsonrpc: "2.0", id: attention.rpcId, result: value ?? {} });
-    this.attentions.delete(attentionRef);
-    this.emit({ kind: "attention-resolved", id: attentionRef, resolution: "answered" });
+    if (attention.answer) throw new Error("attention answer is already awaiting confirmation");
+    await new Promise<void>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        attention.answer = undefined;
+        const error = new Error("attention answer timed out; outcome is uncertain");
+        reject(error);
+        this.fail(error);
+      }, this.requestTimeoutMs);
+      attention.answer = { resolve, reject, timer };
+      this.write({ jsonrpc: "2.0", id: attention.rpcId, result: value ?? {} });
+    });
   }
 
   async health(): Promise<HostState> {
@@ -437,6 +455,7 @@ export class CodexAppServerHost implements EngineHost {
 
   private async releaseAndReap(): Promise<void> {
     this.releasing = true;
+    this.rejectPendingAnswers(new Error("Codex app-server host released"));
     for (const request of this.pending.values()) {
       clearTimeout(request.timer);
       request.reject(new Error("Codex app-server host released"));
@@ -710,8 +729,13 @@ export class CodexAppServerHost implements EngineHost {
       const resolved = [...this.attentions.entries()].find(([, attention]) =>
         String(attention.rpcId) === String(requestId));
       if (!resolved) return;
+      const answer = resolved[1].answer;
+      if (answer) {
+        clearTimeout(answer.timer);
+        answer.resolve();
+      }
       this.attentions.delete(resolved[0]);
-      this.emit({ kind: "attention-resolved", id: resolved[0], resolution: "server-resolved" });
+      this.emit({ kind: "attention-resolved", id: resolved[0], resolution: answer ? "answered" : "server-resolved" });
       return;
     }
     if (method === "turn/started" && turnId) {
@@ -747,6 +771,7 @@ export class CodexAppServerHost implements EngineHost {
     if (this.dead || this.released) return;
     this.dead = true;
     this.activeTurnId = null;
+    this.rejectPendingAnswers(error);
     this.attentions.clear();
     for (const request of this.pending.values()) {
       clearTimeout(request.timer);
@@ -764,6 +789,7 @@ export class CodexAppServerHost implements EngineHost {
     this.engineStatus = "dead";
     this.activeFlags = [];
     this.activeTurnId = null;
+    this.rejectPendingAnswers(error);
     this.attentions.clear();
     for (const request of this.pending.values()) {
       clearTimeout(request.timer);
@@ -773,5 +799,15 @@ export class CodexAppServerHost implements EngineHost {
     this.notifyStateListeners();
     this.closeSubscribers();
     this.startTermination();
+  }
+
+  private rejectPendingAnswers(error: Error): void {
+    const rejection = new Error(safeError(error));
+    for (const attention of this.attentions.values()) {
+      if (!attention.answer) continue;
+      clearTimeout(attention.answer.timer);
+      attention.answer.reject(rejection);
+      attention.answer = undefined;
+    }
   }
 }

--- a/src/lib/runtime/codexAppServerHost.ts
+++ b/src/lib/runtime/codexAppServerHost.ts
@@ -156,6 +156,12 @@ function resumedActiveTurnId(value: unknown): string | null {
   return activeTurn ? stringField(activeTurn, "id") : null;
 }
 
+function itemReplayKey(value: unknown): string {
+  const id = stringField(value, "id");
+  if (id) return `id:${id}`;
+  return `json:${JSON.stringify(value)}`;
+}
+
 function threadStatus(value: unknown): ThreadStatus | null {
   const outer = record(value);
   const thread = record(outer?.thread);
@@ -273,8 +279,8 @@ export class CodexAppServerHost implements EngineHost {
       }
       provisional.identity.threadId = identity.threadId;
       provisional.identity.path = identity.path;
-      const restored = provisional.restoreEvents();
-      if (threadId && restored === 0) provisional.restoreThreadHistory(result);
+      provisional.restoreEvents();
+      if (threadId) provisional.reconcileThreadHistory(result);
       provisional.flushPreIdentityEvents();
       provisional.reconcileAfterOpen(threadStatus(result), resumedActiveTurnId(result));
       return provisional;
@@ -519,19 +525,41 @@ export class CodexAppServerHost implements EngineHost {
     this.emitThreadStatus(resumedStatus);
   }
 
-  private restoreThreadHistory(result: unknown): void {
+  private reconcileThreadHistory(result: unknown): void {
     for (const turn of resumedTurns(result)) {
       const turnId = stringField(turn, "id");
       if (!turnId) continue;
-      this.activeTurnId = turnId;
-      this.emit({ kind: "turn-started", turnId });
-      if (Array.isArray(turn.items)) {
-        for (const item of turn.items) this.emit({ kind: "item", turnId, item, phase: "completed" });
-      }
+      const turnEvents = this.events.filter((event) => "turnId" in event && event.turnId === turnId);
       const status = stringField(turn, "status");
+      const hasStarted = turnEvents.some((event) => event.kind === "turn-started");
+      if (!hasStarted || (status === "inProgress" && this.activeTurnId !== turnId)) {
+        this.activeTurnId = turnId;
+        this.emit({ kind: "turn-started", turnId });
+      }
+      const completedItems = new Map<string, number>();
+      for (const event of turnEvents) {
+        if (event.kind !== "item" || event.phase !== "completed") continue;
+        const key = itemReplayKey(event.item);
+        completedItems.set(key, (completedItems.get(key) ?? 0) + 1);
+      }
+      if (Array.isArray(turn.items)) {
+        for (const item of turn.items) {
+          const key = itemReplayKey(item);
+          const recorded = completedItems.get(key) ?? 0;
+          if (recorded > 0) {
+            completedItems.set(key, recorded - 1);
+            continue;
+          }
+          this.emit({ kind: "item", turnId, item, phase: "completed" });
+        }
+      }
       if (status === "completed" || status === "interrupted" || status === "failed" || status === "error") {
-        this.activeTurnId = null;
-        this.emit({ kind: "turn-ended", turnId, status: terminalStatus(status) });
+        const authoritativeStatus = terminalStatus(status);
+        const recordedTerminal = turnEvents.findLast((event) => event.kind === "turn-ended");
+        if (recordedTerminal?.kind !== "turn-ended" || recordedTerminal.status !== authoritativeStatus) {
+          this.emit({ kind: "turn-ended", turnId, status: authoritativeStatus });
+        }
+        if (this.activeTurnId === turnId) this.activeTurnId = null;
       }
     }
   }

--- a/src/lib/runtime/codexAppServerHost.ts
+++ b/src/lib/runtime/codexAppServerHost.ts
@@ -10,6 +10,8 @@ import type {
   QueueEntry,
   RuntimeEvent,
 } from "./engineHost";
+import { RuntimeReplayGapError } from "./engineHost";
+import { FileRuntimeEventStore, type RuntimeEventStore } from "./eventStore";
 
 type JsonObject = Record<string, unknown>;
 type PendingRpc = {
@@ -41,6 +43,7 @@ export interface CodexAppServerHostOptions {
   shutdownGraceMs?: number;
   initialEventCursor?: number;
   spawnProcess?: (command: string, args: string[], options: SpawnOptionsWithoutStdio) => ChildProcessWithoutNullStreams;
+  eventStore?: RuntimeEventStore;
 }
 
 export interface CodexThreadIdentity {
@@ -48,10 +51,29 @@ export interface CodexThreadIdentity {
   path: string | null;
 }
 
-const SECRET_ENV_NAMES = [
-  "OPENAI_API_KEY",
-  "ANTHROPIC_API_KEY",
-  "CLAUDE_CODE_OAUTH_TOKEN",
+const CHILD_ENV_ALLOWLIST = [
+  "PATH",
+  "HOME",
+  "USER",
+  "LOGNAME",
+  "SHELL",
+  "TMPDIR",
+  "TMP",
+  "TEMP",
+  "LANG",
+  "LC_ALL",
+  "LC_CTYPE",
+  "TERM",
+  "COLORTERM",
+  "NO_COLOR",
+  "XDG_CONFIG_HOME",
+  "XDG_CACHE_HOME",
+  "XDG_DATA_HOME",
+  "XDG_STATE_HOME",
+  "XDG_RUNTIME_DIR",
+  "DBUS_SESSION_BUS_ADDRESS",
+  "SSL_CERT_FILE",
+  "SSL_CERT_DIR",
 ] as const;
 const DEFAULT_TIMEOUT_MS = 30_000;
 const DEFAULT_SHUTDOWN_GRACE_MS = 1_000;
@@ -76,8 +98,10 @@ function safeError(value: unknown): string {
 }
 
 function subscriptionEnv(source: NodeJS.ProcessEnv, codexHome?: string): NodeJS.ProcessEnv {
-  const env = { ...source };
-  for (const name of SECRET_ENV_NAMES) delete env[name];
+  const env: NodeJS.ProcessEnv = { NODE_ENV: source.NODE_ENV };
+  for (const name of CHILD_ENV_ALLOWLIST) {
+    if (source[name] !== undefined) env[name] = source[name];
+  }
   if (codexHome) env.CODEX_HOME = codexHome;
   return env;
 }
@@ -114,6 +138,14 @@ function terminalStatus(value: unknown): "completed" | "interrupted" | "error" {
   return value === "completed" ? "completed" : value === "interrupted" ? "interrupted" : "error";
 }
 
+function resumedTurns(value: unknown): JsonObject[] {
+  const outer = record(value);
+  const thread = record(outer?.thread) ?? outer;
+  if (Array.isArray(thread?.turns)) return thread.turns.map(record).filter((turn): turn is JsonObject => turn !== null);
+  const page = record(thread?.initialTurnsPage);
+  return Array.isArray(page?.data) ? page.data.map(record).filter((turn): turn is JsonObject => turn !== null) : [];
+}
+
 /** One stdio app-server owner with replayable, multi-subscriber event fan-out. */
 export class CodexAppServerHost implements EngineHost {
   readonly identity: CodexThreadIdentity;
@@ -121,16 +153,20 @@ export class CodexAppServerHost implements EngineHost {
   private readonly child: ChildProcessWithoutNullStreams;
   private readonly requestTimeoutMs: number;
   private readonly shutdownGraceMs: number;
+  private readonly eventStore: RuntimeEventStore;
   private readonly pending = new Map<number, PendingRpc>();
   private readonly subscribers = new Set<Subscriber>();
   private readonly events: RuntimeEvent[] = [];
   private readonly attentions = new Map<string, PendingAttention>();
+  private readonly stateListeners = new Set<(state: HostState) => void>();
+  private readonly preIdentityEvents: UnsequencedEvent[] = [];
   private nextRpcId = 1;
   private stdoutBuffer = "";
   private cursor: number;
   private activeTurnId: string | null = null;
   private protocolVersion: string | null = null;
   private account: HostState["account"] = null;
+  private releasing = false;
   private released = false;
   private dead = false;
   private reaped = false;
@@ -145,6 +181,7 @@ export class CodexAppServerHost implements EngineHost {
     this.identity = identity;
     this.requestTimeoutMs = options.requestTimeoutMs ?? DEFAULT_TIMEOUT_MS;
     this.shutdownGraceMs = options.shutdownGraceMs ?? DEFAULT_SHUTDOWN_GRACE_MS;
+    this.eventStore = options.eventStore ?? new FileRuntimeEventStore();
     this.cursor = options.initialEventCursor ?? 0;
     this.reapedPromise = new Promise((resolve) => { this.resolveReaped = resolve; });
     child.stdout.on("data", (chunk: Buffer | string) => this.acceptStdout(String(chunk)));
@@ -157,7 +194,10 @@ export class CodexAppServerHost implements EngineHost {
         this.terminationTimer = null;
       }
       this.resolveReaped();
-      if (!this.released) this.fail(new Error("Codex app-server child exited"));
+      if (!this.releasing && !this.released) {
+        if (this.dead) this.notifyStateListeners();
+        else this.fail(new Error("Codex app-server child exited"));
+      }
     });
   }
 
@@ -204,6 +244,9 @@ export class CodexAppServerHost implements EngineHost {
       }
       provisional.identity.threadId = identity.threadId;
       provisional.identity.path = identity.path;
+      const restored = provisional.restoreEvents();
+      if (threadId && restored === 0) provisional.restoreThreadHistory(result);
+      provisional.flushPreIdentityEvents();
       provisional.emit({ kind: "session-status", status: "idle" });
       return provisional;
     } catch (error) {
@@ -215,6 +258,10 @@ export class CodexAppServerHost implements EngineHost {
   attach(afterSeq: number): AsyncIterable<RuntimeEvent> {
     if (!Number.isSafeInteger(afterSeq) || afterSeq < 0) throw new Error("afterSeq must be a non-negative integer");
     const subscriber: Subscriber = { afterSeq, queue: [], wake: null, closed: false };
+    const firstAvailable = this.events[0]?.seq;
+    if (firstAvailable !== undefined && afterSeq + 1 < firstAvailable) {
+      throw new RuntimeReplayGapError(afterSeq, firstAvailable);
+    }
     for (const event of this.events) if (event.seq > afterSeq) subscriber.queue.push(event);
     this.subscribers.add(subscriber);
     const subscribers = this.subscribers;
@@ -242,7 +289,7 @@ export class CodexAppServerHost implements EngineHost {
   }
 
   async send(entry: QueueEntry): Promise<DeliveryReceipt> {
-    if (this.dead || this.released) return { outcome: "rejected", reason: "dead-host" };
+    if (this.dead || this.releasing || this.released) return { outcome: "rejected", reason: "dead-host" };
     if (!entry.id || !entry.text) throw new Error("queue entry id and text are required");
     const currentTurn = this.activeTurnId;
     if (entry.expectedTurnId !== undefined && entry.expectedTurnId !== currentTurn) {
@@ -272,25 +319,37 @@ export class CodexAppServerHost implements EngineHost {
     });
     const turnId = turnIdFromResult(result, "turn/start");
     this.activeTurnId = turnId;
+    this.notifyStateListeners();
     return { outcome: "turn-started", turnId };
   }
 
   async interrupt(turnRef: string): Promise<void> {
-    if (this.dead || this.released) throw new Error("Codex app-server host is unavailable");
+    if (this.dead || this.releasing || this.released) throw new Error("Codex app-server host is unavailable");
     if (!turnRef || this.activeTurnId !== turnRef) throw new Error("active turn fence is stale");
     await this.rpc("turn/interrupt", { threadId: this.identity.threadId, turnId: turnRef });
   }
 
   async answer(attentionRef: string, value: unknown): Promise<void> {
-    if (this.dead || this.released) throw new Error("Codex app-server host is unavailable");
+    if (this.dead || this.releasing || this.released) throw new Error("Codex app-server host is unavailable");
     const attention = this.attentions.get(attentionRef);
     if (!attention) throw new Error("attention request is missing or already answered");
     this.write({ jsonrpc: "2.0", id: attention.rpcId, result: value ?? {} });
     this.attentions.delete(attentionRef);
+    this.notifyStateListeners();
   }
 
   async health(): Promise<HostState> {
-    const pid = this.dead || this.released ? null : this.child.pid ?? null;
+    return this.currentState();
+  }
+
+  onStateChange(listener: (state: HostState) => void): () => void {
+    this.stateListeners.add(listener);
+    listener(this.currentState());
+    return () => this.stateListeners.delete(listener);
+  }
+
+  private currentState(): HostState {
+    const pid = this.reaped || this.released ? null : this.child.pid ?? null;
     const processStartIdentity = pid ? procBackend.processIdentity(pid) : null;
     const status: HostState["status"] = this.dead ? "dead"
       : this.released ? "unhosted"
@@ -317,7 +376,7 @@ export class CodexAppServerHost implements EngineHost {
   }
 
   private async releaseAndReap(): Promise<void> {
-    this.released = true;
+    this.releasing = true;
     for (const request of this.pending.values()) {
       clearTimeout(request.timer);
       request.reject(new Error("Codex app-server host released"));
@@ -325,11 +384,17 @@ export class CodexAppServerHost implements EngineHost {
     this.pending.clear();
     this.closeSubscribers();
     this.startTermination();
-    if (await this.waitForReap(this.shutdownGraceMs)) return;
-    try { this.child.kill("SIGKILL"); } catch { /* already closed */ }
     if (!await this.waitForReap(this.shutdownGraceMs)) {
-      throw new Error("Codex app-server child could not be reaped");
+      try { this.child.kill("SIGKILL"); } catch { /* already closed */ }
+      if (!await this.waitForReap(this.shutdownGraceMs)) {
+        throw new Error("Codex app-server child could not be reaped");
+      }
     }
+    this.released = true;
+    this.releasing = false;
+    this.activeTurnId = null;
+    this.attentions.clear();
+    this.emit({ kind: "session-status", status: "unhosted" });
   }
 
   private startTermination(): void {
@@ -358,12 +423,56 @@ export class CodexAppServerHost implements EngineHost {
   }
 
   private emit(event: UnsequencedEvent): void {
+    if (this.identity.threadId === "pending") {
+      this.preIdentityEvents.push(event);
+      return;
+    }
     const sequenced = { ...event, seq: ++this.cursor } as RuntimeEvent;
+    try {
+      this.eventStore.append(this.identity.threadId, sequenced);
+    } catch (error) {
+      this.startTermination();
+      throw error;
+    }
     this.events.push(sequenced);
     for (const subscriber of this.subscribers) {
       subscriber.queue.push(sequenced);
       subscriber.wake?.();
     }
+    this.notifyStateListeners();
+  }
+
+  private restoreEvents(): number {
+    const stored = this.eventStore.load(this.identity.threadId);
+    this.events.splice(0, this.events.length, ...stored);
+    this.cursor = Math.max(this.cursor, stored.at(-1)?.seq ?? 0);
+    return stored.length;
+  }
+
+  private restoreThreadHistory(result: unknown): void {
+    for (const turn of resumedTurns(result)) {
+      const turnId = stringField(turn, "id");
+      if (!turnId) continue;
+      this.activeTurnId = turnId;
+      this.emit({ kind: "turn-started", turnId });
+      if (Array.isArray(turn.items)) {
+        for (const item of turn.items) this.emit({ kind: "item", turnId, item, phase: "completed" });
+      }
+      const status = stringField(turn, "status");
+      if (status === "completed" || status === "interrupted" || status === "failed" || status === "error") {
+        this.activeTurnId = null;
+        this.emit({ kind: "turn-ended", turnId, status: terminalStatus(status) });
+      }
+    }
+  }
+
+  private flushPreIdentityEvents(): void {
+    for (const event of this.preIdentityEvents.splice(0)) this.emit(event);
+  }
+
+  private notifyStateListeners(): void {
+    const state = this.currentState();
+    for (const listener of this.stateListeners) listener(state);
   }
 
   private closeSubscribers(): void {
@@ -375,7 +484,7 @@ export class CodexAppServerHost implements EngineHost {
   }
 
   private rpc(method: string, params: JsonObject = {}): Promise<unknown> {
-    if (this.dead || this.released) return Promise.reject(new Error("Codex app-server host is unavailable"));
+    if (this.dead || this.releasing || this.released) return Promise.reject(new Error("Codex app-server host is unavailable"));
     const id = this.nextRpcId++;
     return new Promise((resolve, reject) => {
       const timer = setTimeout(() => {

--- a/src/lib/runtime/codexAppServerHost.ts
+++ b/src/lib/runtime/codexAppServerHost.ts
@@ -25,7 +25,7 @@ type Subscriber = {
   wake: (() => void) | null;
   closed: boolean;
 };
-type PendingAttention = { rpcId: string | number; method: string };
+type PendingAttention = { rpcId: string | number; method: string; origin: "current" | "restored" };
 type ThreadStatus = {
   type: "active" | "idle" | "notLoaded" | "systemError";
   activeFlags: string[];
@@ -204,6 +204,7 @@ export class CodexAppServerHost implements EngineHost {
   private terminationStarted = false;
   private terminationTimer: ReturnType<typeof setTimeout> | null = null;
   private releasePromise: Promise<void> | null = null;
+  private writerFence: (() => boolean) | null = null;
   private readonly reapedPromise: Promise<void>;
   private resolveReaped!: () => void;
 
@@ -325,7 +326,9 @@ export class CodexAppServerHost implements EngineHost {
   }
 
   async send(entry: QueueEntry): Promise<DeliveryReceipt> {
-    if (this.dead || this.releasing || this.released) return { outcome: "rejected", reason: "dead-host" };
+    if (this.dead || this.releasing || this.released || !this.writerFenceAllowsActuation()) {
+      return { outcome: "rejected", reason: "dead-host" };
+    }
     if (!entry.id || !entry.text) throw new Error("queue entry id and text are required");
     const currentTurn = this.activeTurnId;
     if (entry.expectedTurnId !== undefined && entry.expectedTurnId !== currentTurn) {
@@ -361,13 +364,17 @@ export class CodexAppServerHost implements EngineHost {
   }
 
   async interrupt(turnRef: string): Promise<void> {
-    if (this.dead || this.releasing || this.released) throw new Error("Codex app-server host is unavailable");
+    if (this.dead || this.releasing || this.released || !this.writerFenceAllowsActuation()) {
+      throw new Error("Codex app-server host is unavailable");
+    }
     if (!turnRef || this.activeTurnId !== turnRef) throw new Error("active turn fence is stale");
     await this.rpc("turn/interrupt", { threadId: this.identity.threadId, turnId: turnRef });
   }
 
   async answer(attentionRef: string, value: unknown): Promise<void> {
-    if (this.dead || this.releasing || this.released) throw new Error("Codex app-server host is unavailable");
+    if (this.dead || this.releasing || this.released || !this.writerFenceAllowsActuation()) {
+      throw new Error("Codex app-server host is unavailable");
+    }
     const attention = this.attentions.get(attentionRef);
     if (!attention) throw new Error("attention request is missing or already answered");
     this.write({ jsonrpc: "2.0", id: attention.rpcId, result: value ?? {} });
@@ -383,6 +390,15 @@ export class CodexAppServerHost implements EngineHost {
     this.stateListeners.add(listener);
     listener(this.currentState());
     return () => this.stateListeners.delete(listener);
+  }
+
+  setWriterFence(fence: () => boolean): void {
+    this.writerFence = fence;
+  }
+
+  private writerFenceAllowsActuation(): boolean {
+    try { return this.writerFence?.() ?? true; }
+    catch { return false; }
   }
 
   private currentState(): HostState {
@@ -482,13 +498,15 @@ export class CodexAppServerHost implements EngineHost {
 
   private restoreEvents(): number {
     const stored = this.eventStore.load(this.identity.threadId);
+    const currentAttentions = new Map([...this.attentions].filter(([, attention]) => attention.origin === "current"));
+    this.attentions.clear();
     this.events.splice(0, this.events.length, ...stored);
     this.cursor = Math.max(this.cursor, stored.at(-1)?.seq ?? 0);
     for (const event of stored) {
       if (event.kind === "turn-started") this.activeTurnId = event.turnId;
       if (event.kind === "turn-ended" && event.turnId === this.activeTurnId) this.activeTurnId = null;
       if (event.kind === "attention") {
-        this.attentions.set(event.id, { rpcId: "restored", method: event.method });
+        this.attentions.set(event.id, { rpcId: "restored", method: event.method, origin: "restored" });
       }
       if (event.kind === "attention-resolved") this.attentions.delete(event.id);
       if (event.kind === "session-status") {
@@ -500,6 +518,7 @@ export class CodexAppServerHost implements EngineHost {
         }
       }
     }
+    for (const [id, attention] of currentAttentions) this.attentions.set(id, attention);
     return stored.length;
   }
 
@@ -518,7 +537,8 @@ export class CodexAppServerHost implements EngineHost {
       this.activeTurnId = null;
       this.emit({ kind: "turn-ended", turnId, status: "error" });
     }
-    for (const attentionId of [...this.attentions.keys()]) {
+    for (const [attentionId, attention] of [...this.attentions]) {
+      if (attention.origin !== "restored") continue;
       this.attentions.delete(attentionId);
       this.emit({ kind: "attention-resolved", id: attentionId, resolution: "host-restarted" });
     }
@@ -657,7 +677,7 @@ export class CodexAppServerHost implements EngineHost {
     const params = record(message.params) ?? {};
     if (typeof id === "number" || typeof id === "string") {
       const attentionId = `${method}:${String(id)}`;
-      this.attentions.set(attentionId, { rpcId: id, method });
+      this.attentions.set(attentionId, { rpcId: id, method, origin: "current" });
       this.emit({ kind: "attention", id: attentionId, method, attention: params });
       return;
     }

--- a/src/lib/runtime/codexAppServerHost.ts
+++ b/src/lib/runtime/codexAppServerHost.ts
@@ -2,6 +2,7 @@ import { spawn } from "node:child_process";
 import type { ChildProcessWithoutNullStreams, SpawnOptionsWithoutStdio } from "node:child_process";
 
 import { procBackend } from "@/lib/proc";
+import { hardenedRedact } from "@/lib/view/compactText";
 
 import type {
   DeliveryReceipt,
@@ -83,6 +84,7 @@ const CHILD_ENV_ALLOWLIST = [
 const DEFAULT_TIMEOUT_MS = 30_000;
 const DEFAULT_SHUTDOWN_GRACE_MS = 1_000;
 const MAX_LINE_BYTES = 4 * 1024 * 1024;
+const MUTATING_RPC_METHODS = new Set(["thread/start", "thread/resume", "turn/start", "turn/steer", "turn/interrupt"]);
 
 function record(value: unknown): JsonObject | null {
   return value && typeof value === "object" && !Array.isArray(value) ? value as JsonObject : null;
@@ -93,14 +95,14 @@ function stringField(value: unknown, key: string): string | null {
   return object && typeof object[key] === "string" ? object[key] as string : null;
 }
 
-function safeError(value: unknown): string {
+export function redactCodexHostDiagnostic(value: unknown): string {
   const message = value instanceof Error ? value.message : String(value);
-  return message
-    .replace(/(bearer\s+)[^\s,;]+/gi, "$1[REDACTED]")
-    .replace(/(["']?(?:access|refresh|id)[_-]?token["']?\s*[:=]\s*["']?)[^\s,"'}]+/gi, "$1[REDACTED]")
-    .replace(/(["']?(?:api[_-]?key|authorization)["']?\s*[:=]\s*["']?)[^\s,"'}]+/gi, "$1[REDACTED]")
+  return hardenedRedact(message)
+    .replace(/(["']?(?:cookie|set-cookie)["']?\s*[:=]\s*["']?)[^\s,"'}]+/gi, "$1[redacted]")
     .slice(0, 500);
 }
+
+const safeError = redactCodexHostDiagnostic;
 
 function subscriptionEnv(source: NodeJS.ProcessEnv, codexHome?: string): NodeJS.ProcessEnv {
   const env: NodeJS.ProcessEnv = { NODE_ENV: source.NODE_ENV };
@@ -205,6 +207,7 @@ export class CodexAppServerHost implements EngineHost {
   private terminationTimer: ReturnType<typeof setTimeout> | null = null;
   private releasePromise: Promise<void> | null = null;
   private writerFence: (() => boolean) | null = null;
+  private ledgerFailed = false;
   private readonly reapedPromise: Promise<void>;
   private resolveReaped!: () => void;
 
@@ -477,6 +480,7 @@ export class CodexAppServerHost implements EngineHost {
   }
 
   private emit(event: UnsequencedEvent): void {
+    if (this.ledgerFailed) return;
     if (this.identity.threadId === "pending") {
       this.preIdentityEvents.push(event);
       return;
@@ -485,8 +489,10 @@ export class CodexAppServerHost implements EngineHost {
     try {
       this.eventStore.append(this.identity.threadId, sequenced);
     } catch (error) {
-      this.startTermination();
-      throw error;
+      this.ledgerFailed = true;
+      this.cursor = this.events.at(-1)?.seq ?? Math.max(0, this.cursor - 1);
+      this.failWithoutLedger(new Error(`runtime event ledger failed: ${safeError(error)}`));
+      return;
     }
     this.events.push(sequenced);
     for (const subscriber of this.subscribers) {
@@ -622,7 +628,9 @@ export class CodexAppServerHost implements EngineHost {
     return new Promise((resolve, reject) => {
       const timer = setTimeout(() => {
         this.pending.delete(id);
-        reject(new Error(`${method} timed out`));
+        const error = new Error(`${method} timed out${MUTATING_RPC_METHODS.has(method) ? "; outcome is uncertain" : ""}`);
+        reject(error);
+        if (MUTATING_RPC_METHODS.has(method)) this.fail(error);
       }, this.requestTimeoutMs);
       this.pending.set(id, { resolve, reject, timer });
       this.write({ jsonrpc: "2.0", id, method, params });
@@ -734,6 +742,21 @@ export class CodexAppServerHost implements EngineHost {
     }
     this.pending.clear();
     this.setSessionStatus("dead", activeFlags);
+    this.closeSubscribers();
+    this.startTermination();
+  }
+
+  private failWithoutLedger(error: Error): void {
+    if (this.dead || this.released) return;
+    this.dead = true;
+    this.engineStatus = "dead";
+    this.activeFlags = [];
+    for (const request of this.pending.values()) {
+      clearTimeout(request.timer);
+      request.reject(new Error(safeError(error)));
+    }
+    this.pending.clear();
+    this.notifyStateListeners();
     this.closeSubscribers();
     this.startTermination();
   }

--- a/src/lib/runtime/codexAppServerHost.ts
+++ b/src/lib/runtime/codexAppServerHost.ts
@@ -451,6 +451,7 @@ export class CodexAppServerHost implements EngineHost {
     this.activeTurnId = null;
     this.attentions.clear();
     this.setSessionStatus("unhosted", []);
+    if (this.ledgerFailed) this.notifyStateListeners();
     this.closeSubscribers();
   }
 

--- a/src/lib/runtime/codexAppServerHost.ts
+++ b/src/lib/runtime/codexAppServerHost.ts
@@ -151,6 +151,11 @@ function resumedTurns(value: unknown): JsonObject[] {
   return Array.isArray(page?.data) ? page.data.map(record).filter((turn): turn is JsonObject => turn !== null) : [];
 }
 
+function resumedActiveTurnId(value: unknown): string | null {
+  const activeTurn = resumedTurns(value).findLast((turn) => stringField(turn, "status") === "inProgress");
+  return activeTurn ? stringField(activeTurn, "id") : null;
+}
+
 function threadStatus(value: unknown): ThreadStatus | null {
   const outer = record(value);
   const thread = record(outer?.thread);
@@ -271,7 +276,7 @@ export class CodexAppServerHost implements EngineHost {
       const restored = provisional.restoreEvents();
       if (threadId && restored === 0) provisional.restoreThreadHistory(result);
       provisional.flushPreIdentityEvents();
-      provisional.reconcileAfterOpen(threadStatus(result));
+      provisional.reconcileAfterOpen(threadStatus(result), resumedActiveTurnId(result));
       return provisional;
     } catch (error) {
       await provisional.release();
@@ -492,8 +497,16 @@ export class CodexAppServerHost implements EngineHost {
     return stored.length;
   }
 
-  private reconcileAfterOpen(status: ThreadStatus | null): void {
+  private reconcileAfterOpen(status: ThreadStatus | null, resumedTurnId: string | null): void {
     const resumedStatus = status ?? { type: "idle" as const, activeFlags: [] };
+    if (resumedStatus.type === "active" && !resumedTurnId) {
+      throw new Error("thread/resume returned active status without an active turn id");
+    }
+    if (resumedStatus.type === "active" && resumedTurnId && this.activeTurnId !== resumedTurnId) {
+      if (this.activeTurnId) this.emit({ kind: "turn-ended", turnId: this.activeTurnId, status: "error" });
+      this.activeTurnId = resumedTurnId;
+      this.emit({ kind: "turn-started", turnId: resumedTurnId });
+    }
     if (this.activeTurnId && resumedStatus.type !== "active") {
       const turnId = this.activeTurnId;
       this.activeTurnId = null;

--- a/src/lib/runtime/codexAppServerHost.ts
+++ b/src/lib/runtime/codexAppServerHost.ts
@@ -618,6 +618,16 @@ export class CodexAppServerHost implements EngineHost {
 
   private acceptNotification(method: string, params: JsonObject): void {
     const turnId = turnIdFromParams(params);
+    if (method === "serverRequest/resolved") {
+      const requestId = params.requestId;
+      if (typeof requestId !== "number" && typeof requestId !== "string") return;
+      const resolved = [...this.attentions.entries()].find(([, attention]) =>
+        String(attention.rpcId) === String(requestId));
+      if (!resolved) return;
+      this.attentions.delete(resolved[0]);
+      this.emit({ kind: "attention-resolved", id: resolved[0], resolution: "server-resolved" });
+      return;
+    }
     if (method === "turn/started" && turnId) {
       this.activeTurnId = turnId;
       this.emit({ kind: "turn-started", turnId });

--- a/src/lib/runtime/codexAppServerHost.ts
+++ b/src/lib/runtime/codexAppServerHost.ts
@@ -26,6 +26,10 @@ type Subscriber = {
   closed: boolean;
 };
 type PendingAttention = { rpcId: string | number; method: string };
+type ThreadStatus = {
+  type: "active" | "idle" | "notLoaded" | "systemError";
+  activeFlags: string[];
+};
 type UnsequencedEvent = RuntimeEvent extends infer Event
   ? Event extends RuntimeEvent ? Omit<Event, "seq"> : never
   : never;
@@ -146,6 +150,18 @@ function resumedTurns(value: unknown): JsonObject[] {
   return Array.isArray(page?.data) ? page.data.map(record).filter((turn): turn is JsonObject => turn !== null) : [];
 }
 
+function threadStatus(value: unknown): ThreadStatus | null {
+  const outer = record(value);
+  const thread = record(outer?.thread);
+  const status = record(outer?.status) ?? record(thread?.status);
+  const type = stringField(status, "type");
+  if (type !== "active" && type !== "idle" && type !== "notLoaded" && type !== "systemError") return null;
+  const activeFlags = Array.isArray(status?.activeFlags)
+    ? status.activeFlags.filter((flag): flag is string => typeof flag === "string")
+    : [];
+  return { type, activeFlags };
+}
+
 /** One stdio app-server owner with replayable, multi-subscriber event fan-out. */
 export class CodexAppServerHost implements EngineHost {
   readonly identity: CodexThreadIdentity;
@@ -166,6 +182,8 @@ export class CodexAppServerHost implements EngineHost {
   private activeTurnId: string | null = null;
   private protocolVersion: string | null = null;
   private account: HostState["account"] = null;
+  private engineStatus: "active" | "idle" | "unhosted" | "dead" = "idle";
+  private activeFlags: string[] = [];
   private releasing = false;
   private released = false;
   private dead = false;
@@ -247,7 +265,7 @@ export class CodexAppServerHost implements EngineHost {
       const restored = provisional.restoreEvents();
       if (threadId && restored === 0) provisional.restoreThreadHistory(result);
       provisional.flushPreIdentityEvents();
-      provisional.emit({ kind: "session-status", status: "idle" });
+      provisional.reconcileAfterOpen(threadStatus(result));
       return provisional;
     } catch (error) {
       await provisional.release();
@@ -268,7 +286,7 @@ export class CodexAppServerHost implements EngineHost {
     return {
       async *[Symbol.asyncIterator]() {
         try {
-          while (!subscriber.closed) {
+          while (true) {
             const event = subscriber.queue.shift();
             if (event) {
               if (event.seq > subscriber.afterSeq) {
@@ -277,6 +295,7 @@ export class CodexAppServerHost implements EngineHost {
               }
               continue;
             }
+            if (subscriber.closed) break;
             await new Promise<void>((resolve) => { subscriber.wake = resolve; });
             subscriber.wake = null;
           }
@@ -335,7 +354,7 @@ export class CodexAppServerHost implements EngineHost {
     if (!attention) throw new Error("attention request is missing or already answered");
     this.write({ jsonrpc: "2.0", id: attention.rpcId, result: value ?? {} });
     this.attentions.delete(attentionRef);
-    this.notifyStateListeners();
+    this.emit({ kind: "attention-resolved", id: attentionRef, resolution: "answered" });
   }
 
   async health(): Promise<HostState> {
@@ -355,7 +374,7 @@ export class CodexAppServerHost implements EngineHost {
       : this.released ? "unhosted"
       : this.attentions.size > 0 ? "attention"
       : this.activeTurnId ? "active"
-      : "idle";
+      : this.engineStatus;
     return {
       status,
       sessionKey: this.identity.threadId,
@@ -366,6 +385,7 @@ export class CodexAppServerHost implements EngineHost {
       protocolVersion: this.protocolVersion,
       activeTurnRef: this.activeTurnId,
       pendingAttention: [...this.attentions.keys()],
+      activeFlags: [...this.activeFlags],
       account: this.account,
     };
   }
@@ -382,7 +402,6 @@ export class CodexAppServerHost implements EngineHost {
       request.reject(new Error("Codex app-server host released"));
     }
     this.pending.clear();
-    this.closeSubscribers();
     this.startTermination();
     if (!await this.waitForReap(this.shutdownGraceMs)) {
       try { this.child.kill("SIGKILL"); } catch { /* already closed */ }
@@ -394,7 +413,8 @@ export class CodexAppServerHost implements EngineHost {
     this.releasing = false;
     this.activeTurnId = null;
     this.attentions.clear();
-    this.emit({ kind: "session-status", status: "unhosted" });
+    this.setSessionStatus("unhosted", []);
+    this.closeSubscribers();
   }
 
   private startTermination(): void {
@@ -446,7 +466,37 @@ export class CodexAppServerHost implements EngineHost {
     const stored = this.eventStore.load(this.identity.threadId);
     this.events.splice(0, this.events.length, ...stored);
     this.cursor = Math.max(this.cursor, stored.at(-1)?.seq ?? 0);
+    for (const event of stored) {
+      if (event.kind === "turn-started") this.activeTurnId = event.turnId;
+      if (event.kind === "turn-ended" && event.turnId === this.activeTurnId) this.activeTurnId = null;
+      if (event.kind === "attention") {
+        this.attentions.set(event.id, { rpcId: "restored", method: event.method });
+      }
+      if (event.kind === "attention-resolved") this.attentions.delete(event.id);
+      if (event.kind === "session-status") {
+        this.engineStatus = event.status;
+        this.activeFlags = [...(event.activeFlags ?? [])];
+        if (event.status === "unhosted" || event.status === "dead") {
+          this.activeTurnId = null;
+          this.attentions.clear();
+        }
+      }
+    }
     return stored.length;
+  }
+
+  private reconcileAfterOpen(status: ThreadStatus | null): void {
+    const resumedStatus = status ?? { type: "idle" as const, activeFlags: [] };
+    if (this.activeTurnId && resumedStatus.type !== "active") {
+      const turnId = this.activeTurnId;
+      this.activeTurnId = null;
+      this.emit({ kind: "turn-ended", turnId, status: "error" });
+    }
+    for (const attentionId of [...this.attentions.keys()]) {
+      this.attentions.delete(attentionId);
+      this.emit({ kind: "attention-resolved", id: attentionId, resolution: "host-restarted" });
+    }
+    this.emitThreadStatus(resumedStatus);
   }
 
   private restoreThreadHistory(result: unknown): void {
@@ -481,6 +531,21 @@ export class CodexAppServerHost implements EngineHost {
       subscriber.wake?.();
     }
     this.subscribers.clear();
+  }
+
+  private setSessionStatus(status: "active" | "idle" | "unhosted" | "dead", activeFlags: string[]): void {
+    this.engineStatus = status;
+    this.activeFlags = [...activeFlags];
+    this.emit({ kind: "session-status", status, ...(activeFlags.length > 0 ? { activeFlags: [...activeFlags] } : {}) });
+  }
+
+  private emitThreadStatus(status: ThreadStatus): void {
+    if (status.type === "systemError") {
+      this.fail(new Error("Codex app-server reported a system error"), status.activeFlags);
+      return;
+    }
+    const mapped = status.type === "notLoaded" ? "unhosted" : status.type;
+    this.setSessionStatus(mapped, status.activeFlags);
   }
 
   private rpc(method: string, params: JsonObject = {}): Promise<unknown> {
@@ -577,12 +642,12 @@ export class CodexAppServerHost implements EngineHost {
       return;
     }
     if (method === "thread/status/changed") {
-      const status = stringField(params, "status") ?? stringField(record(params.thread), "status");
-      this.emit({ kind: "session-status", status: status === "active" ? "active" : "idle" });
+      const status = threadStatus(params);
+      if (status) this.emitThreadStatus(status);
     }
   }
 
-  private fail(error: Error): void {
+  private fail(error: Error, activeFlags: string[] = []): void {
     if (this.dead || this.released) return;
     this.dead = true;
     for (const request of this.pending.values()) {
@@ -590,7 +655,7 @@ export class CodexAppServerHost implements EngineHost {
       request.reject(new Error(safeError(error)));
     }
     this.pending.clear();
-    this.emit({ kind: "session-status", status: "dead" });
+    this.setSessionStatus("dead", activeFlags);
     this.closeSubscribers();
     this.startTermination();
   }

--- a/src/lib/runtime/codexAppServerHost.ts
+++ b/src/lib/runtime/codexAppServerHost.ts
@@ -40,6 +40,7 @@ export interface CodexAppServerHostOptions {
   binary?: string;
   model?: string;
   effort?: string;
+  fileAuthCredentials?: boolean;
   sandbox?: string;
   approvalPolicy?: string;
   env?: NodeJS.ProcessEnv;
@@ -170,6 +171,7 @@ export class CodexAppServerHost implements EngineHost {
   private readonly requestTimeoutMs: number;
   private readonly shutdownGraceMs: number;
   private readonly eventStore: RuntimeEventStore;
+  private readonly effort: string | undefined;
   private readonly pending = new Map<number, PendingRpc>();
   private readonly subscribers = new Set<Subscriber>();
   private readonly events: RuntimeEvent[] = [];
@@ -200,6 +202,7 @@ export class CodexAppServerHost implements EngineHost {
     this.requestTimeoutMs = options.requestTimeoutMs ?? DEFAULT_TIMEOUT_MS;
     this.shutdownGraceMs = options.shutdownGraceMs ?? DEFAULT_SHUTDOWN_GRACE_MS;
     this.eventStore = options.eventStore ?? new FileRuntimeEventStore();
+    this.effort = options.effort;
     this.cursor = options.initialEventCursor ?? 0;
     this.reapedPromise = new Promise((resolve) => { this.resolveReaped = resolve; });
     child.stdout.on("data", (chunk: Buffer | string) => this.acceptStdout(String(chunk)));
@@ -231,7 +234,10 @@ export class CodexAppServerHost implements EngineHost {
   private static async open(options: CodexAppServerHostOptions, threadId: string | null): Promise<CodexAppServerHost> {
     const spawnProcess = options.spawnProcess ?? ((command, args, spawnOptions) =>
       spawn(command, args, { ...spawnOptions, stdio: ["pipe", "pipe", "pipe"] }));
-    const child = spawnProcess(options.binary ?? process.env.LLV_CODEX_BINARY ?? "codex", ["app-server"], {
+    const args = options.fileAuthCredentials
+      ? ["-c", "cli_auth_credentials_store=file", "app-server"]
+      : ["app-server"];
+    const child = spawnProcess(options.binary ?? process.env.LLV_CODEX_BINARY ?? "codex", args, {
       cwd: options.cwd,
       env: subscriptionEnv(options.env ?? process.env, options.codexHome),
     });
@@ -333,6 +339,7 @@ export class CodexAppServerHost implements EngineHost {
     }
     const result = await this.rpc("turn/start", {
       threadId: this.identity.threadId,
+      ...(this.effort ? { effort: this.effort } : {}),
       input,
       clientUserMessageId: entry.id,
     });

--- a/src/lib/runtime/codexAppServerHost.ts
+++ b/src/lib/runtime/codexAppServerHost.ts
@@ -222,6 +222,9 @@ export class CodexAppServerHost implements EngineHost {
     this.reapedPromise = new Promise((resolve) => { this.resolveReaped = resolve; });
     child.stdout.on("data", (chunk: Buffer | string) => this.acceptStdout(String(chunk)));
     child.stderr.on("data", () => { /* stderr can contain authentication details; keep it out of output */ });
+    child.stdin.on("error", (error) => {
+      if (!this.releasing && !this.released) this.fail(new Error(`Codex app-server stdin failed: ${safeError(error)}`));
+    });
     child.on("error", (error) => this.fail(new Error(`Codex app-server child failed: ${safeError(error)}`)));
     child.on("close", () => {
       this.reaped = true;
@@ -643,10 +646,12 @@ export class CodexAppServerHost implements EngineHost {
   }
 
   private write(message: JsonObject): void {
-    this.child.stdin.write(`${JSON.stringify(message)}\n`);
+    try { this.child.stdin.write(`${JSON.stringify(message)}\n`); }
+    catch (error) { this.fail(new Error(`Codex app-server stdin failed: ${safeError(error)}`)); }
   }
 
   private acceptStdout(chunk: string): void {
+    if (this.dead || this.releasing || this.released) return;
     this.stdoutBuffer += chunk;
     let newline = this.stdoutBuffer.indexOf("\n");
     while (newline >= 0) {
@@ -657,6 +662,10 @@ export class CodexAppServerHost implements EngineHost {
         return;
       }
       if (line) this.acceptMessage(line);
+      if (this.dead || this.releasing || this.released) {
+        this.stdoutBuffer = "";
+        return;
+      }
       newline = this.stdoutBuffer.indexOf("\n");
     }
     if (Buffer.byteLength(this.stdoutBuffer) > MAX_LINE_BYTES) this.fail(new Error("Codex app-server emitted an oversized JSONL frame"));
@@ -737,6 +746,8 @@ export class CodexAppServerHost implements EngineHost {
   private fail(error: Error, activeFlags: string[] = []): void {
     if (this.dead || this.released) return;
     this.dead = true;
+    this.activeTurnId = null;
+    this.attentions.clear();
     for (const request of this.pending.values()) {
       clearTimeout(request.timer);
       request.reject(new Error(safeError(error)));
@@ -752,6 +763,8 @@ export class CodexAppServerHost implements EngineHost {
     this.dead = true;
     this.engineStatus = "dead";
     this.activeFlags = [];
+    this.activeTurnId = null;
+    this.attentions.clear();
     for (const request of this.pending.values()) {
       clearTimeout(request.timer);
       request.reject(new Error(safeError(error)));

--- a/src/lib/runtime/engineHost.ts
+++ b/src/lib/runtime/engineHost.ts
@@ -1,0 +1,43 @@
+export interface QueueEntry {
+  id: string;
+  text: string;
+  /** Optional caller fence. A mismatch is rejected before any engine write. */
+  expectedTurnId?: string | null;
+}
+
+export type DeliveryReceipt =
+  | { outcome: "steered"; turnId: string }
+  | { outcome: "turn-started"; turnId: string }
+  | { outcome: "rejected"; reason: "stale-turn" | "dead-host" };
+
+export type RuntimeEvent =
+  | { kind: "turn-started"; turnId: string; seq: number }
+  | { kind: "delta"; turnId: string; text: string; seq: number }
+  | { kind: "item"; turnId: string | null; item: unknown; phase: "started" | "completed"; seq: number }
+  | { kind: "turn-ended"; turnId: string; status: "completed" | "interrupted" | "error"; seq: number }
+  | { kind: "attention"; id: string; method: string; attention: unknown; seq: number }
+  | { kind: "limits"; snapshot: unknown; seq: number }
+  | { kind: "session-status"; status: "active" | "idle" | "unhosted" | "dead"; seq: number };
+
+export interface HostState {
+  status: "active" | "attention" | "idle" | "unhosted" | "dead";
+  sessionKey: string;
+  endpoint: string;
+  pid: number | null;
+  processStartIdentity: string | null;
+  eventCursor: number;
+  protocolVersion: string | null;
+  activeTurnRef: string | null;
+  pendingAttention: string[];
+  account: { type: string | null; planType: string | null } | null;
+}
+
+/** Shared structured-host boundary from the issue 25 spike. */
+export interface EngineHost {
+  attach(afterSeq: number): AsyncIterable<RuntimeEvent>;
+  send(entry: QueueEntry): Promise<DeliveryReceipt>;
+  interrupt(turnRef: string): Promise<void>;
+  answer(attentionRef: string, value: unknown): Promise<void>;
+  health(): Promise<HostState>;
+  release(): Promise<void>;
+}

--- a/src/lib/runtime/engineHost.ts
+++ b/src/lib/runtime/engineHost.ts
@@ -16,8 +16,9 @@ export type RuntimeEvent =
   | { kind: "item"; turnId: string | null; item: unknown; phase: "started" | "completed"; seq: number }
   | { kind: "turn-ended"; turnId: string; status: "completed" | "interrupted" | "error"; seq: number }
   | { kind: "attention"; id: string; method: string; attention: unknown; seq: number }
+  | { kind: "attention-resolved"; id: string; resolution: "answered" | "host-restarted"; seq: number }
   | { kind: "limits"; snapshot: unknown; seq: number }
-  | { kind: "session-status"; status: "active" | "idle" | "unhosted" | "dead"; seq: number };
+  | { kind: "session-status"; status: "active" | "idle" | "unhosted" | "dead"; activeFlags?: string[]; seq: number };
 
 export interface HostState {
   status: "active" | "attention" | "idle" | "unhosted" | "dead";
@@ -29,6 +30,7 @@ export interface HostState {
   protocolVersion: string | null;
   activeTurnRef: string | null;
   pendingAttention: string[];
+  activeFlags: string[];
   account: { type: string | null; planType: string | null } | null;
 }
 

--- a/src/lib/runtime/engineHost.ts
+++ b/src/lib/runtime/engineHost.ts
@@ -32,6 +32,13 @@ export interface HostState {
   account: { type: string | null; planType: string | null } | null;
 }
 
+export class RuntimeReplayGapError extends Error {
+  constructor(readonly requestedAfterSeq: number, readonly firstAvailableSeq: number) {
+    super(`runtime replay begins at sequence ${firstAvailableSeq}; requested after ${requestedAfterSeq}`);
+    this.name = "RuntimeReplayGapError";
+  }
+}
+
 /** Shared structured-host boundary from the issue 25 spike. */
 export interface EngineHost {
   attach(afterSeq: number): AsyncIterable<RuntimeEvent>;

--- a/src/lib/runtime/engineHost.ts
+++ b/src/lib/runtime/engineHost.ts
@@ -16,7 +16,7 @@ export type RuntimeEvent =
   | { kind: "item"; turnId: string | null; item: unknown; phase: "started" | "completed"; seq: number }
   | { kind: "turn-ended"; turnId: string; status: "completed" | "interrupted" | "error"; seq: number }
   | { kind: "attention"; id: string; method: string; attention: unknown; seq: number }
-  | { kind: "attention-resolved"; id: string; resolution: "answered" | "host-restarted"; seq: number }
+  | { kind: "attention-resolved"; id: string; resolution: "answered" | "host-restarted" | "server-resolved"; seq: number }
   | { kind: "limits"; snapshot: unknown; seq: number }
   | { kind: "session-status"; status: "active" | "idle" | "unhosted" | "dead"; activeFlags?: string[]; seq: number };
 

--- a/src/lib/runtime/eventStore.test.ts
+++ b/src/lib/runtime/eventStore.test.ts
@@ -52,3 +52,24 @@ test("runtime event store rejects a non-contiguous append", () => {
     .toThrow("sequence gap after 1");
   expect(store.load("append-thread")).toEqual([{ kind: "session-status", status: "idle", seq: 1 }]);
 });
+
+test("runtime event store rejects every structurally invalid event variant", () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-runtime-event-shapes-"));
+  const filename = path.join(directory, "shape-thread.jsonl");
+  const store = new FileRuntimeEventStore(directory);
+  const invalid = [
+    { kind: "unknown", seq: 1 },
+    { kind: "turn-started", seq: 1 },
+    { kind: "delta", turnId: "turn-1", seq: 1 },
+    { kind: "item", turnId: "turn-1", phase: "completed", seq: 1 },
+    { kind: "turn-ended", turnId: "turn-1", status: "success", seq: 1 },
+    { kind: "attention", id: "approval-1", attention: {}, seq: 1 },
+    { kind: "attention-resolved", id: "approval-1", resolution: "unknown", seq: 1 },
+    { kind: "limits", seq: 1 },
+    { kind: "session-status", status: "active", activeFlags: [42], seq: 1 },
+  ];
+  for (const event of invalid) {
+    fs.writeFileSync(filename, `${JSON.stringify(event)}\n`);
+    expect(() => store.load("shape-thread")).toThrow("invalid event");
+  }
+});

--- a/src/lib/runtime/eventStore.test.ts
+++ b/src/lib/runtime/eventStore.test.ts
@@ -60,13 +60,18 @@ test("runtime event store rejects every structurally invalid event variant", () 
   const invalid = [
     { kind: "unknown", seq: 1 },
     { kind: "turn-started", seq: 1 },
+    { kind: "turn-started", turnId: "", seq: 1 },
     { kind: "delta", turnId: "turn-1", seq: 1 },
+    { kind: "delta", turnId: "", text: "chunk", seq: 1 },
     { kind: "item", turnId: "turn-1", phase: "completed", seq: 1 },
+    { kind: "item", turnId: "", item: {}, phase: "completed", seq: 1 },
     { kind: "turn-ended", turnId: "turn-1", status: "success", seq: 1 },
     { kind: "attention", id: "approval-1", attention: {}, seq: 1 },
+    { kind: "attention", id: "", method: "approval", attention: {}, seq: 1 },
     { kind: "attention-resolved", id: "approval-1", resolution: "unknown", seq: 1 },
     { kind: "limits", seq: 1 },
     { kind: "session-status", status: "active", activeFlags: [42], seq: 1 },
+    { kind: "session-status", status: "active", activeFlags: [""], seq: 1 },
   ];
   for (const event of invalid) {
     fs.writeFileSync(filename, `${JSON.stringify(event)}\n`);

--- a/src/lib/runtime/eventStore.test.ts
+++ b/src/lib/runtime/eventStore.test.ts
@@ -1,0 +1,23 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { expect, test } from "bun:test";
+
+import { FileRuntimeEventStore } from "./eventStore";
+
+test("runtime event store durably replays ordered events and ignores a partial tail", () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-runtime-events-"));
+  const store = new FileRuntimeEventStore(directory);
+  store.append("thread/unsafe", { kind: "session-status", status: "idle", seq: 1 });
+  store.append("thread/unsafe", { kind: "turn-started", turnId: "turn-1", seq: 2 });
+  const filename = path.join(directory, "thread%2Funsafe.jsonl");
+  fs.appendFileSync(filename, "{partial");
+  store.append("thread/unsafe", { kind: "turn-ended", turnId: "turn-1", status: "completed", seq: 3 });
+
+  expect(store.load("thread/unsafe")).toEqual([
+    { kind: "session-status", status: "idle", seq: 1 },
+    { kind: "turn-started", turnId: "turn-1", seq: 2 },
+    { kind: "turn-ended", turnId: "turn-1", status: "completed", seq: 3 },
+  ]);
+  expect(fs.statSync(filename).mode & 0o777).toBe(0o600);
+});

--- a/src/lib/runtime/eventStore.test.ts
+++ b/src/lib/runtime/eventStore.test.ts
@@ -21,3 +21,34 @@ test("runtime event store durably replays ordered events and ignores a partial t
   ]);
   expect(fs.statSync(filename).mode & 0o777).toBe(0o600);
 });
+
+test("runtime event store fails closed on gaps, duplicates, and malformed middle records", () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-runtime-event-gaps-"));
+  const filename = path.join(directory, "gap-thread.jsonl");
+  fs.writeFileSync(filename, [
+    JSON.stringify({ kind: "session-status", status: "idle", seq: 1 }),
+    JSON.stringify({ kind: "turn-ended", turnId: "turn-1", status: "completed", seq: 3 }),
+    "",
+  ].join("\n"));
+  const store = new FileRuntimeEventStore(directory);
+  expect(() => store.load("gap-thread")).toThrow("sequence gap after 1");
+
+  fs.writeFileSync(filename, [
+    JSON.stringify({ kind: "session-status", status: "idle", seq: 1 }),
+    JSON.stringify({ kind: "session-status", status: "active", seq: 1 }),
+    "",
+  ].join("\n"));
+  expect(() => store.load("gap-thread")).toThrow("sequence gap after 1");
+
+  fs.writeFileSync(filename, `${JSON.stringify({ kind: "session-status", status: "idle", seq: 1 })}\n{broken}\n`);
+  expect(() => store.load("gap-thread")).toThrow("malformed JSON");
+});
+
+test("runtime event store rejects a non-contiguous append", () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-runtime-event-append-"));
+  const store = new FileRuntimeEventStore(directory);
+  store.append("append-thread", { kind: "session-status", status: "idle", seq: 1 });
+  expect(() => store.append("append-thread", { kind: "turn-started", turnId: "turn-3", seq: 3 }))
+    .toThrow("sequence gap after 1");
+  expect(store.load("append-thread")).toEqual([{ kind: "session-status", status: "idle", seq: 1 }]);
+});

--- a/src/lib/runtime/eventStore.ts
+++ b/src/lib/runtime/eventStore.ts
@@ -11,9 +11,35 @@ export interface RuntimeEventStore {
 }
 
 function validEvent(value: unknown): value is RuntimeEvent {
-  if (!value || typeof value !== "object") return false;
-  const event = value as Partial<RuntimeEvent>;
-  return Number.isSafeInteger(event.seq) && event.seq! > 0 && typeof event.kind === "string";
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  const event = value as Record<string, unknown>;
+  if (!Number.isSafeInteger(event.seq) || (event.seq as number) <= 0) return false;
+  switch (event.kind) {
+    case "turn-started":
+      return typeof event.turnId === "string";
+    case "delta":
+      return typeof event.turnId === "string" && typeof event.text === "string";
+    case "item":
+      return (typeof event.turnId === "string" || event.turnId === null)
+        && (event.phase === "started" || event.phase === "completed")
+        && Object.hasOwn(event, "item");
+    case "turn-ended":
+      return typeof event.turnId === "string"
+        && (event.status === "completed" || event.status === "interrupted" || event.status === "error");
+    case "attention":
+      return typeof event.id === "string" && typeof event.method === "string" && Object.hasOwn(event, "attention");
+    case "attention-resolved":
+      return typeof event.id === "string"
+        && (event.resolution === "answered" || event.resolution === "host-restarted" || event.resolution === "server-resolved");
+    case "limits":
+      return Object.hasOwn(event, "snapshot");
+    case "session-status":
+      return (event.status === "active" || event.status === "idle" || event.status === "unhosted" || event.status === "dead")
+        && (event.activeFlags === undefined
+          || (Array.isArray(event.activeFlags) && event.activeFlags.every((flag) => typeof flag === "string")));
+    default:
+      return false;
+  }
 }
 
 export class FileRuntimeEventStore implements RuntimeEventStore {

--- a/src/lib/runtime/eventStore.ts
+++ b/src/lib/runtime/eventStore.ts
@@ -28,13 +28,24 @@ export class FileRuntimeEventStore implements RuntimeEventStore {
       throw error;
     }
     const events: RuntimeEvent[] = [];
-    for (const line of contents.split("\n")) {
-      if (!line) continue;
+    const lines = contents.split("\n");
+    const hasTerminatingNewline = contents.endsWith("\n");
+    for (const [index, line] of lines.entries()) {
+      if (!line && index === lines.length - 1 && hasTerminatingNewline) continue;
+      if (!line) throw new Error("runtime event ledger contains an empty record");
       let parsed: unknown;
-      try { parsed = JSON.parse(line); } catch { continue; }
-      if (!validEvent(parsed)) continue;
+      try { parsed = JSON.parse(line); } catch {
+        if (index === lines.length - 1 && !hasTerminatingNewline) break;
+        throw new Error("runtime event ledger contains malformed JSON");
+      }
+      if (!validEvent(parsed)) {
+        if (index === lines.length - 1 && !hasTerminatingNewline) break;
+        throw new Error("runtime event ledger contains an invalid event");
+      }
       const previous = events.at(-1);
-      if (previous && parsed.seq <= previous.seq) continue;
+      if (previous && parsed.seq !== previous.seq + 1) {
+        throw new Error(`runtime event ledger sequence gap after ${previous.seq}`);
+      }
       events.push(parsed);
     }
     return events;
@@ -42,14 +53,25 @@ export class FileRuntimeEventStore implements RuntimeEventStore {
 
   append(threadId: string, event: RuntimeEvent): void {
     fs.mkdirSync(this.directory, { recursive: true, mode: 0o700 });
-    const fd = fs.openSync(this.filename(threadId), "a+", 0o600);
+    const filename = this.filename(threadId);
+    const previous = this.load(threadId).at(-1);
+    if (previous && event.seq !== previous.seq + 1) {
+      throw new Error(`runtime event ledger sequence gap after ${previous.seq}`);
+    }
+    const fd = fs.openSync(filename, "a+", 0o600);
     try {
       fs.fchmodSync(fd, 0o600);
       const size = fs.fstatSync(fd).size;
       if (size > 0) {
-        const tail = Buffer.alloc(1);
-        fs.readSync(fd, tail, 0, 1, size - 1);
-        if (tail[0] !== 0x0a) fs.writeSync(fd, "\n");
+        const contents = fs.readFileSync(filename, "utf8");
+        if (!contents.endsWith("\n")) {
+          const boundary = contents.lastIndexOf("\n") + 1;
+          const tail = contents.slice(boundary);
+          let parsed: unknown;
+          try { parsed = JSON.parse(tail); } catch { parsed = null; }
+          if (validEvent(parsed)) fs.writeSync(fd, "\n");
+          else fs.ftruncateSync(fd, Buffer.byteLength(contents.slice(0, boundary)));
+        }
       }
       fs.writeSync(fd, `${JSON.stringify(event)}\n`);
       fs.fsyncSync(fd);

--- a/src/lib/runtime/eventStore.ts
+++ b/src/lib/runtime/eventStore.ts
@@ -14,29 +14,30 @@ function validEvent(value: unknown): value is RuntimeEvent {
   if (!value || typeof value !== "object" || Array.isArray(value)) return false;
   const event = value as Record<string, unknown>;
   if (!Number.isSafeInteger(event.seq) || (event.seq as number) <= 0) return false;
+  const nonEmptyString = (field: unknown): field is string => typeof field === "string" && field.length > 0;
   switch (event.kind) {
     case "turn-started":
-      return typeof event.turnId === "string";
+      return nonEmptyString(event.turnId);
     case "delta":
-      return typeof event.turnId === "string" && typeof event.text === "string";
+      return nonEmptyString(event.turnId) && typeof event.text === "string";
     case "item":
-      return (typeof event.turnId === "string" || event.turnId === null)
+      return (nonEmptyString(event.turnId) || event.turnId === null)
         && (event.phase === "started" || event.phase === "completed")
         && Object.hasOwn(event, "item");
     case "turn-ended":
-      return typeof event.turnId === "string"
+      return nonEmptyString(event.turnId)
         && (event.status === "completed" || event.status === "interrupted" || event.status === "error");
     case "attention":
-      return typeof event.id === "string" && typeof event.method === "string" && Object.hasOwn(event, "attention");
+      return nonEmptyString(event.id) && nonEmptyString(event.method) && Object.hasOwn(event, "attention");
     case "attention-resolved":
-      return typeof event.id === "string"
+      return nonEmptyString(event.id)
         && (event.resolution === "answered" || event.resolution === "host-restarted" || event.resolution === "server-resolved");
     case "limits":
       return Object.hasOwn(event, "snapshot");
     case "session-status":
       return (event.status === "active" || event.status === "idle" || event.status === "unhosted" || event.status === "dead")
         && (event.activeFlags === undefined
-          || (Array.isArray(event.activeFlags) && event.activeFlags.every((flag) => typeof flag === "string")));
+          || (Array.isArray(event.activeFlags) && event.activeFlags.every(nonEmptyString)));
     default:
       return false;
   }

--- a/src/lib/runtime/eventStore.ts
+++ b/src/lib/runtime/eventStore.ts
@@ -1,0 +1,64 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import { statePath } from "@/lib/configDir";
+
+import type { RuntimeEvent } from "./engineHost";
+
+export interface RuntimeEventStore {
+  load(threadId: string): RuntimeEvent[];
+  append(threadId: string, event: RuntimeEvent): void;
+}
+
+function validEvent(value: unknown): value is RuntimeEvent {
+  if (!value || typeof value !== "object") return false;
+  const event = value as Partial<RuntimeEvent>;
+  return Number.isSafeInteger(event.seq) && event.seq! > 0 && typeof event.kind === "string";
+}
+
+export class FileRuntimeEventStore implements RuntimeEventStore {
+  constructor(private readonly directory = statePath("structured-host-events")) {}
+
+  load(threadId: string): RuntimeEvent[] {
+    const filename = this.filename(threadId);
+    let contents: string;
+    try { contents = fs.readFileSync(filename, "utf8"); }
+    catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") return [];
+      throw error;
+    }
+    const events: RuntimeEvent[] = [];
+    for (const line of contents.split("\n")) {
+      if (!line) continue;
+      let parsed: unknown;
+      try { parsed = JSON.parse(line); } catch { continue; }
+      if (!validEvent(parsed)) continue;
+      const previous = events.at(-1);
+      if (previous && parsed.seq <= previous.seq) continue;
+      events.push(parsed);
+    }
+    return events;
+  }
+
+  append(threadId: string, event: RuntimeEvent): void {
+    fs.mkdirSync(this.directory, { recursive: true, mode: 0o700 });
+    const fd = fs.openSync(this.filename(threadId), "a+", 0o600);
+    try {
+      fs.fchmodSync(fd, 0o600);
+      const size = fs.fstatSync(fd).size;
+      if (size > 0) {
+        const tail = Buffer.alloc(1);
+        fs.readSync(fd, tail, 0, 1, size - 1);
+        if (tail[0] !== 0x0a) fs.writeSync(fd, "\n");
+      }
+      fs.writeSync(fd, `${JSON.stringify(event)}\n`);
+      fs.fsyncSync(fd);
+    } finally {
+      fs.closeSync(fd);
+    }
+  }
+
+  private filename(threadId: string): string {
+    return path.join(this.directory, `${encodeURIComponent(threadId)}.jsonl`);
+  }
+}

--- a/src/lib/runtime/fixtures/codex-thread-status-v0.144.1.jsonl
+++ b/src/lib/runtime/fixtures/codex-thread-status-v0.144.1.jsonl
@@ -1,0 +1,4 @@
+{"jsonrpc":"2.0","method":"thread/status/changed","params":{"threadId":"status-thread","status":{"type":"active","activeFlags":["waitingForApproval"]}}}
+{"jsonrpc":"2.0","method":"thread/status/changed","params":{"threadId":"status-thread","status":{"type":"idle"}}}
+{"jsonrpc":"2.0","method":"thread/status/changed","params":{"threadId":"status-thread","status":{"type":"notLoaded"}}}
+{"jsonrpc":"2.0","method":"thread/status/changed","params":{"threadId":"status-thread","status":{"type":"systemError","activeFlags":["recovering"]}}}

--- a/src/lib/runtime/index.ts
+++ b/src/lib/runtime/index.ts
@@ -1,0 +1,3 @@
+export * from "./engineHost";
+export * from "./codexAppServerHost";
+export * from "./registry";

--- a/src/lib/runtime/index.ts
+++ b/src/lib/runtime/index.ts
@@ -1,3 +1,5 @@
 export * from "./engineHost";
 export * from "./codexAppServerHost";
 export * from "./registry";
+export * from "./eventStore";
+export * from "./startup";

--- a/src/lib/runtime/registry.ts
+++ b/src/lib/runtime/registry.ts
@@ -1,0 +1,83 @@
+import type {
+  AgentHostStatus,
+  AgentRegistry,
+  AgentRegistryEntry,
+  StructuredHostColumns,
+} from "@/lib/agent/registry";
+import type { SessionKey } from "@/lib/agent/sessionKey";
+
+import { CodexAppServerHost, type CodexAppServerHostOptions } from "./codexAppServerHost";
+import type { HostState } from "./engineHost";
+
+export function structuredHostsEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
+  return env.LLV_STRUCTURED_HOSTS === "1";
+}
+
+export async function startCodexStructuredHost(
+  options: CodexAppServerHostOptions,
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<CodexAppServerHost> {
+  if (!structuredHostsEnabled(env)) throw new Error("structured hosts are disabled");
+  return CodexAppServerHost.start(options);
+}
+
+function registryStatus(state: HostState): AgentHostStatus {
+  if (state.status === "active" || state.status === "attention") return "live";
+  if (state.status === "idle") return "idle";
+  if (state.status === "unhosted") return "unhosted";
+  return "dead";
+}
+
+export function codexHostColumns(state: HostState, writerClaimEpoch: number): StructuredHostColumns {
+  return {
+    kind: "codex-app-server",
+    endpoint: state.endpoint,
+    process: state.pid === null ? null : { pid: state.pid, startIdentity: state.processStartIdentity },
+    eventCursor: state.eventCursor,
+    protocolVersion: state.protocolVersion,
+    writerClaimEpoch,
+    activeTurnRef: state.activeTurnRef,
+    pendingAttention: state.pendingAttention,
+  };
+}
+
+export async function persistCodexHost(
+  registry: AgentRegistry,
+  key: SessionKey,
+  host: CodexAppServerHost,
+  writerClaimEpoch: number,
+): Promise<AgentRegistryEntry> {
+  const state = await host.health();
+  return registry.setStructuredHost(key, codexHostColumns(state, writerClaimEpoch), registryStatus(state));
+}
+
+export interface AdoptedCodexHost {
+  key: SessionKey;
+  host: CodexAppServerHost;
+}
+
+/** Boot seam: resume every durable Codex row when structured hosting is enabled. */
+export async function adoptCodexRegistryHosts(
+  registry: AgentRegistry,
+  optionsFor: (entry: AgentRegistryEntry) => CodexAppServerHostOptions,
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<AdoptedCodexHost[]> {
+  if (!structuredHostsEnabled(env)) return [];
+  const rows = Object.values(registry.snapshot().entries).filter((entry) =>
+    entry.key.engine === "codex" && entry.structuredHost?.kind === "codex-app-server");
+  const adopted: AdoptedCodexHost[] = [];
+  for (const entry of rows) {
+    try {
+      const host = await CodexAppServerHost.adopt(entry.key.sessionId, {
+        ...optionsFor(entry),
+        initialEventCursor: entry.structuredHost?.eventCursor ?? 0,
+      });
+      await persistCodexHost(registry, entry.key, host, entry.structuredHost?.writerClaimEpoch ?? entry.claimEpoch);
+      adopted.push({ key: entry.key, host });
+    } catch {
+      const prior = entry.structuredHost!;
+      registry.setStructuredHost(entry.key, { ...prior, endpoint: "stdio:released", process: null, activeTurnRef: null }, "dead");
+    }
+  }
+  return adopted;
+}

--- a/src/lib/runtime/registry.ts
+++ b/src/lib/runtime/registry.ts
@@ -5,6 +5,7 @@ import type {
   StructuredHostColumns,
 } from "@/lib/agent/registry";
 import type { SessionKey } from "@/lib/agent/sessionKey";
+import { procBackend } from "@/lib/proc";
 
 import { CodexAppServerHost, type CodexAppServerHostOptions } from "./codexAppServerHost";
 import type { HostState } from "./engineHost";
@@ -67,16 +68,30 @@ export async function adoptCodexRegistryHosts(
     entry.key.engine === "codex" && entry.structuredHost?.kind === "codex-app-server");
   const adopted: AdoptedCodexHost[] = [];
   for (const entry of rows) {
+    const owner = { pid: process.pid, startIdentity: procBackend.processIdentity(process.pid) };
     try {
-      const host = await CodexAppServerHost.adopt(entry.key.sessionId, {
-        ...optionsFor(entry),
-        initialEventCursor: entry.structuredHost?.eventCursor ?? 0,
+      await registry.withOperationLock(entry.key, owner, async () => {
+        const claimed = registry.claimStructuredHost(entry.key, owner);
+        if (!claimed?.structuredHost) return;
+        try {
+          const host = await CodexAppServerHost.adopt(entry.key.sessionId, {
+            ...optionsFor(claimed),
+            initialEventCursor: claimed.structuredHost.eventCursor,
+          });
+          await persistCodexHost(registry, entry.key, host, claimed.claimEpoch);
+          adopted.push({ key: entry.key, host });
+        } catch {
+          registry.setStructuredHost(entry.key, {
+            ...claimed.structuredHost,
+            endpoint: "stdio:released",
+            process: null,
+            activeTurnRef: null,
+          }, "dead");
+          registry.releaseClaim(entry.key, claimed.claimOwner!);
+        }
       });
-      await persistCodexHost(registry, entry.key, host, entry.structuredHost?.writerClaimEpoch ?? entry.claimEpoch);
-      adopted.push({ key: entry.key, host });
-    } catch {
-      const prior = entry.structuredHost!;
-      registry.setStructuredHost(entry.key, { ...prior, endpoint: "stdio:released", process: null, activeTurnRef: null }, "dead");
+    } catch (error) {
+      if (!(error instanceof Error) || error.message !== "agent registry is busy") throw error;
     }
   }
   return adopted;

--- a/src/lib/runtime/registry.ts
+++ b/src/lib/runtime/registry.ts
@@ -124,7 +124,9 @@ export async function adoptCodexRegistryHosts(
 ): Promise<AdoptedCodexHost[]> {
   if (!structuredHostsEnabled(env)) return [];
   const rows = Object.values(registry.snapshot().entries).filter((entry) =>
-    entry.key.engine === "codex" && entry.structuredHost?.kind === "codex-app-server");
+    entry.key.engine === "codex"
+    && entry.status !== "unhosted"
+    && entry.structuredHost?.kind === "codex-app-server");
   const adopted: AdoptedCodexHost[] = [];
   for (const entry of rows) {
     const owner = { pid: process.pid, startIdentity: procBackend.processIdentity(process.pid) };

--- a/src/lib/runtime/registry.ts
+++ b/src/lib/runtime/registry.ts
@@ -39,6 +39,7 @@ export function codexHostColumns(state: HostState, writerClaimEpoch: number): St
     writerClaimEpoch,
     activeTurnRef: state.activeTurnRef,
     pendingAttention: state.pendingAttention,
+    activeFlags: state.activeFlags,
   };
 }
 
@@ -46,25 +47,47 @@ export async function persistCodexHost(
   registry: AgentRegistry,
   key: SessionKey,
   host: CodexAppServerHost,
+  claimOwner: string,
   writerClaimEpoch: number,
 ): Promise<AgentRegistryEntry> {
   const state = await host.health();
-  return registry.setStructuredHost(key, codexHostColumns(state, writerClaimEpoch), registryStatus(state));
+  const persisted = registry.setStructuredHostClaimed(
+    key,
+    codexHostColumns(state, writerClaimEpoch),
+    registryStatus(state),
+    claimOwner,
+    writerClaimEpoch,
+  );
+  if (!persisted) throw new Error("structured host writer claim is stale");
+  return persisted;
 }
 
 export async function bindCodexHostPersistence(
   registry: AgentRegistry,
   key: SessionKey,
   host: CodexAppServerHost,
+  claimOwner: string,
   writerClaimEpoch: number,
 ): Promise<() => void> {
-  await persistCodexHost(registry, key, host, writerClaimEpoch);
+  try {
+    await persistCodexHost(registry, key, host, claimOwner, writerClaimEpoch);
+  } catch (error) {
+    await host.release();
+    throw error;
+  }
   let failed = false;
   let unsubscribe = () => {};
   unsubscribe = host.onStateChange((state) => {
     if (failed) return;
     try {
-      registry.setStructuredHost(key, codexHostColumns(state, writerClaimEpoch), registryStatus(state));
+      const persisted = registry.setStructuredHostClaimed(
+        key,
+        codexHostColumns(state, writerClaimEpoch),
+        registryStatus(state),
+        claimOwner,
+        writerClaimEpoch,
+      );
+      if (!persisted) throw new Error("structured host writer claim is stale");
     } catch {
       failed = true;
       unsubscribe();
@@ -100,15 +123,15 @@ export async function adoptCodexRegistryHosts(
             ...optionsFor(claimed),
             initialEventCursor: claimed.structuredHost.eventCursor,
           });
-          await bindCodexHostPersistence(registry, entry.key, host, claimed.claimEpoch);
+          await bindCodexHostPersistence(registry, entry.key, host, claimed.claimOwner!, claimed.claimEpoch);
           adopted.push({ key: entry.key, host });
         } catch {
-          registry.setStructuredHost(entry.key, {
+          registry.setStructuredHostClaimed(entry.key, {
             ...claimed.structuredHost,
             endpoint: "stdio:released",
             process: null,
             activeTurnRef: null,
-          }, "dead");
+          }, "dead", claimed.claimOwner!, claimed.claimEpoch);
           registry.releaseClaim(entry.key, claimed.claimOwner!);
         }
       });

--- a/src/lib/runtime/registry.ts
+++ b/src/lib/runtime/registry.ts
@@ -76,25 +76,39 @@ export async function bindCodexHostPersistence(
     throw error;
   }
   let failed = false;
+  let stopped = false;
   let unsubscribe = () => {};
+  const stop = () => {
+    if (stopped) return;
+    stopped = true;
+    unsubscribe();
+    registry.releaseStructuredHostClaim(key, claimOwner, writerClaimEpoch);
+  };
   unsubscribe = host.onStateChange((state) => {
-    if (failed) return;
+    if (failed || stopped) return;
     try {
+      const terminal = state.status === "unhosted" || (state.status === "dead" && state.pid === null);
       const persisted = registry.setStructuredHostClaimed(
         key,
         codexHostColumns(state, writerClaimEpoch),
         registryStatus(state),
         claimOwner,
         writerClaimEpoch,
+        terminal,
       );
       if (!persisted) throw new Error("structured host writer claim is stale");
+      if (terminal) {
+        stopped = true;
+        unsubscribe();
+      }
     } catch {
       failed = true;
-      unsubscribe();
+      stop();
       void host.release();
     }
   });
-  return unsubscribe;
+  if (stopped) unsubscribe();
+  return stop;
 }
 
 export interface AdoptedCodexHost {
@@ -131,8 +145,7 @@ export async function adoptCodexRegistryHosts(
             endpoint: "stdio:released",
             process: null,
             activeTurnRef: null,
-          }, "dead", claimed.claimOwner!, claimed.claimEpoch);
-          registry.releaseClaim(entry.key, claimed.claimOwner!);
+          }, "dead", claimed.claimOwner!, claimed.claimEpoch, true);
         }
       });
     } catch (error) {

--- a/src/lib/runtime/registry.ts
+++ b/src/lib/runtime/registry.ts
@@ -148,6 +148,8 @@ export async function adoptCodexRegistryHosts(
             endpoint: "stdio:released",
             process: null,
             activeTurnRef: null,
+            pendingAttention: [],
+            activeFlags: [],
           }, "dead", claimed.claimOwner!, claimed.claimEpoch, true);
         }
       });

--- a/src/lib/runtime/registry.ts
+++ b/src/lib/runtime/registry.ts
@@ -52,6 +52,28 @@ export async function persistCodexHost(
   return registry.setStructuredHost(key, codexHostColumns(state, writerClaimEpoch), registryStatus(state));
 }
 
+export async function bindCodexHostPersistence(
+  registry: AgentRegistry,
+  key: SessionKey,
+  host: CodexAppServerHost,
+  writerClaimEpoch: number,
+): Promise<() => void> {
+  await persistCodexHost(registry, key, host, writerClaimEpoch);
+  let failed = false;
+  let unsubscribe = () => {};
+  unsubscribe = host.onStateChange((state) => {
+    if (failed) return;
+    try {
+      registry.setStructuredHost(key, codexHostColumns(state, writerClaimEpoch), registryStatus(state));
+    } catch {
+      failed = true;
+      unsubscribe();
+      void host.release();
+    }
+  });
+  return unsubscribe;
+}
+
 export interface AdoptedCodexHost {
   key: SessionKey;
   host: CodexAppServerHost;
@@ -78,7 +100,7 @@ export async function adoptCodexRegistryHosts(
             ...optionsFor(claimed),
             initialEventCursor: claimed.structuredHost.eventCursor,
           });
-          await persistCodexHost(registry, entry.key, host, claimed.claimEpoch);
+          await bindCodexHostPersistence(registry, entry.key, host, claimed.claimEpoch);
           adopted.push({ key: entry.key, host });
         } catch {
           registry.setStructuredHost(entry.key, {

--- a/src/lib/runtime/registry.ts
+++ b/src/lib/runtime/registry.ts
@@ -69,6 +69,7 @@ export async function bindCodexHostPersistence(
   claimOwner: string,
   writerClaimEpoch: number,
 ): Promise<() => void> {
+  host.setWriterFence(() => registry.ownsStructuredHostClaim(key, claimOwner, writerClaimEpoch));
   try {
     await persistCodexHost(registry, key, host, claimOwner, writerClaimEpoch);
   } catch (error) {

--- a/src/lib/runtime/startup.test.ts
+++ b/src/lib/runtime/startup.test.ts
@@ -7,7 +7,7 @@ import { AgentRegistry } from "@/lib/agent/registry";
 
 import { adoptStructuredHostsAtStartup } from "./startup";
 
-test("server startup delegates registry rows to structured adoption with the owning Codex home", async () => {
+test("server startup delegates managed rows with file credentials and their launch profile", async () => {
   const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-runtime-startup-"));
   const registry = new AgentRegistry(path.join(directory, "agent-registry.json"));
   registry.upsert({
@@ -15,6 +15,20 @@ test("server startup delegates registry rows to structured adoption with the own
     artifactPath: "/managed/sessions/startup-thread.jsonl",
     cwd: "/repo",
     accountId: "managed",
+    launchProfile: {
+      cwd: "/repo",
+      model: "gpt-5.4-mini",
+      effort: "high",
+      fast: null,
+      permissionMode: null,
+      readOnly: true,
+      title: null,
+      project: null,
+      parentConversationId: null,
+      role: "worker",
+      goal: null,
+      plan: null,
+    },
     status: "dead",
     host: null,
     claimEpoch: 1,
@@ -24,12 +38,18 @@ test("server startup delegates registry rows to structured adoption with the own
   let options: unknown;
   await adoptStructuredHostsAtStartup({
     registry,
-    resolveCodexHome: () => "/managed",
+    resolveCodexOwner: () => ({ home: "/managed", kind: "managed" }),
     adopt: async (received, optionsFor) => {
       expect(received).toBe(registry);
       options = optionsFor(registry.snapshot().entries["codex:startup-thread"]!);
       return [];
     },
   });
-  expect(options).toMatchObject({ cwd: "/repo", codexHome: "/managed" });
+  expect(options).toMatchObject({
+    cwd: "/repo",
+    codexHome: "/managed",
+    fileAuthCredentials: true,
+    model: "gpt-5.4-mini",
+    effort: "high",
+  });
 });

--- a/src/lib/runtime/startup.test.ts
+++ b/src/lib/runtime/startup.test.ts
@@ -1,0 +1,35 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { expect, test } from "bun:test";
+
+import { AgentRegistry } from "@/lib/agent/registry";
+
+import { adoptStructuredHostsAtStartup } from "./startup";
+
+test("server startup delegates registry rows to structured adoption with the owning Codex home", async () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-runtime-startup-"));
+  const registry = new AgentRegistry(path.join(directory, "agent-registry.json"));
+  registry.upsert({
+    key: { engine: "codex", sessionId: "startup-thread" },
+    artifactPath: "/managed/sessions/startup-thread.jsonl",
+    cwd: "/repo",
+    accountId: "managed",
+    status: "dead",
+    host: null,
+    claimEpoch: 1,
+    claimOwner: null,
+    pendingAction: null,
+  });
+  let options: unknown;
+  await adoptStructuredHostsAtStartup({
+    registry,
+    resolveCodexHome: () => "/managed",
+    adopt: async (received, optionsFor) => {
+      expect(received).toBe(registry);
+      options = optionsFor(registry.snapshot().entries["codex:startup-thread"]!);
+      return [];
+    },
+  });
+  expect(options).toMatchObject({ cwd: "/repo", codexHome: "/managed" });
+});

--- a/src/lib/runtime/startup.ts
+++ b/src/lib/runtime/startup.ts
@@ -1,0 +1,34 @@
+import { accountManager } from "@/lib/accounts/manager";
+import { agentRegistry, type AgentRegistry, type AgentRegistryEntry } from "@/lib/agent/registry";
+
+import { adoptCodexRegistryHosts, type AdoptedCodexHost } from "./registry";
+
+let adoptedHosts: AdoptedCodexHost[] = [];
+
+export interface StructuredStartupDependencies {
+  registry?: AgentRegistry;
+  adopt?: typeof adoptCodexRegistryHosts;
+  resolveCodexHome?: (entry: AgentRegistryEntry) => string | undefined;
+}
+
+/** Called once by Next instrumentation before the Node server accepts requests. */
+export async function adoptStructuredHostsAtStartup(
+  dependencies: StructuredStartupDependencies = {},
+): Promise<AdoptedCodexHost[]> {
+  const resolveCodexHome = dependencies.resolveCodexHome ?? ((entry: AgentRegistryEntry) =>
+    accountManager.resolveTranscriptOwner("codex", entry.artifactPath)?.home);
+  adoptedHosts = await (dependencies.adopt ?? adoptCodexRegistryHosts)(
+    dependencies.registry ?? agentRegistry(),
+    (entry) => ({
+      cwd: entry.cwd,
+      codexHome: resolveCodexHome(entry),
+      model: entry.launchProfile?.model ?? undefined,
+      effort: entry.launchProfile?.effort ?? undefined,
+    }),
+  );
+  return adoptedHosts;
+}
+
+export function structuredStartupHosts(): readonly AdoptedCodexHost[] {
+  return adoptedHosts;
+}

--- a/src/lib/runtime/startup.ts
+++ b/src/lib/runtime/startup.ts
@@ -8,23 +8,27 @@ let adoptedHosts: AdoptedCodexHost[] = [];
 export interface StructuredStartupDependencies {
   registry?: AgentRegistry;
   adopt?: typeof adoptCodexRegistryHosts;
-  resolveCodexHome?: (entry: AgentRegistryEntry) => string | undefined;
+  resolveCodexOwner?: (entry: AgentRegistryEntry) => { home: string; kind: "legacy" | "managed" } | null;
 }
 
 /** Called once by Next instrumentation before the Node server accepts requests. */
 export async function adoptStructuredHostsAtStartup(
   dependencies: StructuredStartupDependencies = {},
 ): Promise<AdoptedCodexHost[]> {
-  const resolveCodexHome = dependencies.resolveCodexHome ?? ((entry: AgentRegistryEntry) =>
-    accountManager.resolveTranscriptOwner("codex", entry.artifactPath)?.home);
+  const resolveCodexOwner = dependencies.resolveCodexOwner ?? ((entry: AgentRegistryEntry) =>
+    accountManager.resolveTranscriptOwner("codex", entry.artifactPath));
   adoptedHosts = await (dependencies.adopt ?? adoptCodexRegistryHosts)(
     dependencies.registry ?? agentRegistry(),
-    (entry) => ({
-      cwd: entry.cwd,
-      codexHome: resolveCodexHome(entry),
-      model: entry.launchProfile?.model ?? undefined,
-      effort: entry.launchProfile?.effort ?? undefined,
-    }),
+    (entry) => {
+      const owner = resolveCodexOwner(entry);
+      return {
+        cwd: entry.cwd,
+        codexHome: owner?.home,
+        fileAuthCredentials: owner?.kind === "managed",
+        model: entry.launchProfile?.model ?? undefined,
+        effort: entry.launchProfile?.effort ?? undefined,
+      };
+    },
   );
   return adoptedHosts;
 }


### PR DESCRIPTION
## Summary

- add the shared `EngineHost` contract and normalized runtime events
- implement a ChatGPT-subscription Codex app-server stdio host with replay fan-out, delivery IDs, active-turn fencing, interruption, and structured attention responses
- persist structured host endpoint, process identity, cursor, protocol version, claim epoch, active turn, and pending attention in the agent registry
- serialize startup adoption through durable writer claims and `thread/resume` when `LLV_STRUCTURED_HOSTS=1`
- preserve replay sequence continuity in a private fsynced per-thread event ledger, with resume-history recovery for legacy rows
- synchronize registry host state across runtime events, attention resolution, process death, and release
- launch app-server children from a narrow environment allowlist that excludes credential-shaped variables

## Verification

- `bun test` (`2068` pass)
- `bunx tsc --noEmit`
- touched-file ESLint
- `bun run build`
- live Codex CLI integration covering late attach, same-turn steering, durable replay, app-server process restart, and thread resume

Closes #149
Refs #25
