### PR TITLE
fix: chime loop on project switch + limits no-data state for uncached accounts

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -1,17 +1,25 @@
-# PR #143: Claude limits backoff and footer visibility
+# PR #154: Chime loop on project switch and limits no-data UI state
 
 ## Task statement
 
-Back off Claude limits polling after provider failures, honor `Retry-After`, distinguish re-authentication failures, and keep footer status honest in English and Ukrainian.
+Stop the lifecycle-chime cascade triggered by selected-project hydration, preserve real question and push notifications, and verify the limits footer explains throttling for a never-cached Claude account.
 
 ## Acceptance criteria
 
-- AC1: Failed limits reads are cached per engine and account for a cooldown.
-- AC2: Consecutive Claude 429 responses use a 1m, 2m, 4m exponential schedule capped at 15m.
-- AC3: A valid `Retry-After` extends the cooldown when required by the provider.
-- AC4: Concurrent refreshes for one engine and account share one upstream request.
-- AC5: A successful read resets the 429 backoff and preserves the fresh-cache fast path.
-- AC6: Claude 429 provenance shows provider throttling and the next retry time, including when retained quota windows come from cache.
-- AC7: Claude 401 provenance shows re-login guidance, including when retained quota windows come from cache.
-- AC8: Footer status strings remain aligned in English and Ukrainian.
-- AC9: `bun test` and `bunx tsc --noEmit` pass.
+- AC1: Production browser evidence identifies the lifecycle Web Audio path and reports the measured firing volume and rate.
+- AC2: Switching projects seeds previously unseen historical attention entries silently.
+- AC3: Conversation transition history survives project switches and repeated polls.
+- AC4: A known live-to-waiting transition during hydration remains audible, and a genuinely new same-scope question rings once.
+- AC5: Scanner `notifyQuestion` web push delivery remains unchanged and keeps its persisted attention-id guard.
+- AC6: A regression test covers the production-sized 464-entry project hydration batch.
+- AC7: A never-cached Claude account with `oauth-rate-limited` provenance shows the throttled state and next retry time in the limits footer.
+- AC8: The diff contains no engine or tmux changes.
+- AC9: The patched browser replay records zero lifecycle chimes for the reproduced project switch.
+- AC10: `bun test` and `bunx tsc --noEmit` pass.
+
+## Validation gates
+
+- Headless Puppeteer production baseline and patched local replay.
+- `bun test`.
+- `bunx tsc --noEmit`.
+- Non-draft PR with a clean merge state.

--- a/src/components/Viewer.tsx
+++ b/src/components/Viewer.tsx
@@ -78,7 +78,7 @@ export function Viewer() {
   useViewPresence();
   const [project, setProject] = useState<string>(() => initialProject());
   const [pendingHash, setPendingHash] = useState<ConversationHash | null>(null);
-  const { files: allFiles, projectCatalog, flows: polledFlows, pipelines, pipelinesError, workflows, tasks, systemHealth, conversationAliases, loaded } = useFiles(project === OVERVIEW ? null : project, pendingHash?.filePath ?? pendingHash?.conversationId ?? null);
+  const { files: allFiles, requestScope, projectCatalog, flows: polledFlows, pipelines, pipelinesError, workflows, tasks, systemHealth, conversationAliases, loaded } = useFiles(project === OVERVIEW ? null : project, pendingHash?.filePath ?? pendingHash?.conversationId ?? null);
   /* A committed account migration keeps the archived predecessor entry in the
      payload (for chain history) but it must never render as a second standalone
      card — every surface below sees only current generations. A no-op (same
@@ -87,7 +87,7 @@ export function Viewer() {
   /* This tab's optimistic flow closes apply before anything renders: the X
      on a flow strip clears the reviewer side of the scheme instantly. */
   const flows = useEffectiveFlows(polledFlows);
-  useAgentChimes(files);
+  useAgentChimes(files, requestScope);
   const { archivedProjects, archiveProject, unarchiveProject } = useArchivedProjects(files);
   const catalogProjects = useMemo(() => new Set(projectCatalog.map((entry) => entry.project)), [projectCatalog]);
   const isMobile = useIsMobile();

--- a/src/hooks/useAgentChimes.test.ts
+++ b/src/hooks/useAgentChimes.test.ts
@@ -2,7 +2,7 @@ import { expect, test } from "bun:test";
 
 import type { FileEntry } from "@/lib/types";
 
-import { MAX_TRACKED_IDENTITIES, planAgentChimes, type TrackedConversation } from "./useAgentChimes";
+import { MAX_TRACKED_IDENTITIES, planAgentChimes, planScopedAgentChimes, type TrackedConversation } from "./useAgentChimes";
 
 /* Deterministic fixtures: `waitingInput` forces paneState "waiting" without
    touching the wall clock; `activity: "live"` forces "live"; everything else
@@ -62,6 +62,28 @@ test("a genuinely new conversation that appears already finished rings", () => {
   const seed = planAgentChimes([live("/a")], null, new Set());
   const plan = planAgentChimes([live("/a"), waiting("/new")], seed.tracked, seed.linked);
   expect(plan.chimes).toEqual([{ kind: "question", id: "/new" }]);
+});
+
+test("project hydration seeds unseen finished conversations without queuing a chime cascade", () => {
+  const seed = planScopedAgentChimes([live("/project-a")], null, "/api/files?project=project-a");
+  const hydrated = Array.from({ length: 464 }, (_, index) => waiting(`/project-b-${index}`));
+  const switched = planScopedAgentChimes(hydrated, seed, "/api/files?project=project-b");
+  expect(switched.chimes).toEqual([]);
+
+  const settled = planScopedAgentChimes(hydrated, switched, "/api/files?project=project-b");
+  expect(settled.chimes).toEqual([]);
+  const newQuestion = planScopedAgentChimes([...hydrated, waiting("/project-b-new")], settled, "/api/files?project=project-b");
+  expect(newQuestion.chimes).toEqual([{ kind: "question", id: "/project-b-new" }]);
+});
+
+test("project hydration keeps a known live to waiting transition audible", () => {
+  const seed = planScopedAgentChimes([live("/shared")], null, "/api/files?project=project-a");
+  const switched = planScopedAgentChimes(
+    [waiting("/shared"), waiting("/already-finished")],
+    seed,
+    "/api/files?project=project-b",
+  );
+  expect(switched.chimes).toEqual([{ kind: "question", id: "/shared" }]);
 });
 
 test("archived migration predecessors neither ring nor clobber the successor's state", () => {

--- a/src/hooks/useAgentChimes.ts
+++ b/src/hooks/useAgentChimes.ts
@@ -52,6 +52,11 @@ export interface ChimePlan {
   chimes: PlannedChime[];
 }
 
+export interface ScopedChimePlan extends ChimePlan {
+  /** The successful /api/files request that produced this payload. */
+  scope: string;
+}
+
 /**
  * Pure transition scan behind {@link useAgentChimes}: compares the current
  * poll against the accumulated baseline and plans which chimes to ring.
@@ -62,6 +67,7 @@ export function planAgentChimes(
   files: readonly FileEntry[],
   prev: ReadonlyMap<string, TrackedConversation> | null,
   linked: ReadonlySet<string>,
+  options: { suppressUnseen?: boolean } = {},
 ): ChimePlan {
   /* Keyed by the stable conversation identity (with the path as the
      pre-migration fallback): a committed account migration swaps the path
@@ -90,14 +96,15 @@ export function planAgentChimes(
   }
   for (const [id, cur] of next) {
     const was = prev.get(id);
+    const suppressUnseen = options.suppressUnseen === true && was === undefined;
     const finished = cur.kind !== undefined && (was?.state === "live" || was === undefined);
-    if (cur.kind !== undefined && finished) chimes.push({ kind: cur.kind, id });
+    if (cur.kind !== undefined && finished && !suppressUnseen) chimes.push({ kind: cur.kind, id });
     if (cur.parent && !nextLinked.has(id)) {
       nextLinked.add(id);
       /* Skip the blip when a finish chime just announced this same
          conversation — a subagent that lived its whole life between polls
          rings once. */
-      if (!finished) chimes.push({ kind: "spawned", id });
+      if (!finished && !suppressUnseen) chimes.push({ kind: "spawned", id });
     }
   }
   /* Last-seen (LRU) order: entries present in this poll are re-inserted at
@@ -122,6 +129,26 @@ export function planAgentChimes(
 }
 
 /**
+ * Applies the request-scope boundary around the transition scan. A project
+ * switch hydrates historical entries that this tab has never observed; those
+ * entries seed the retained history silently. Conversations already tracked
+ * still announce a real lifecycle transition during the same hydration.
+ */
+export function planScopedAgentChimes(
+  files: readonly FileEntry[],
+  previous: ScopedChimePlan | null,
+  scope: string,
+): ScopedChimePlan {
+  const plan = planAgentChimes(
+    files,
+    previous?.tracked ?? null,
+    previous?.linked ?? new Set(),
+    { suppressUnseen: previous !== null && previous.scope !== scope },
+  );
+  return { ...plan, scope };
+}
+
+/**
  * Watches the polled file list for lifecycle transitions and rings a chime
  * when an agent finishes its turn: left `live` into an attention state, or
  * appeared already finished (a branch that ran its whole life between polls).
@@ -131,19 +158,15 @@ export function planAgentChimes(
  * The first poll after page load only seeds the baseline — reloading over
  * finished work stays silent.
  */
-export function useAgentChimes(files: FileEntry[]) {
-  const prevRef = useRef<Map<string, TrackedConversation> | null>(null);
-  /* Children that already rang their spawn blip; a parent link that flaps
-     null → set → null in the scanner must not re-announce the same agent. */
-  const linkedRef = useRef<Set<string>>(new Set());
+export function useAgentChimes(files: FileEntry[], scope: string | null) {
+  const historyRef = useRef<ScopedChimePlan | null>(null);
 
   useEffect(() => primeAudio(), []);
 
   useEffect(() => {
-    if (!files.length) return;
-    const plan = planAgentChimes(files, prevRef.current, linkedRef.current);
-    prevRef.current = plan.tracked;
-    linkedRef.current = plan.linked;
+    if (!files.length || !scope) return;
+    const plan = planScopedAgentChimes(files, historyRef.current, scope);
+    historyRef.current = plan;
     plan.chimes.forEach((planned, voice) => chime(planned.kind, panForPane(planned.id), voice * STAGGER_MS));
-  }, [files]);
+  }, [files, scope]);
 }

--- a/src/hooks/useFiles.ts
+++ b/src/hooks/useFiles.ts
@@ -24,6 +24,8 @@ const FILES_REVISION_RETRY_MS = 1_000;
 
 export interface FilesData {
   files: FileEntry[];
+  /** Successful request URL that produced `files`; used for scope-aware effects. */
+  requestScope: string | null;
   projectCatalog: ProjectCatalogEntry[];
   flows: Flow[];
   pipelines: Pipeline[];
@@ -37,7 +39,7 @@ export interface FilesData {
 }
 
 const HEALTHY_SYSTEM = { tmux: { status: "healthy" as const } };
-const EMPTY: FilesData = { files: [], projectCatalog: [], flows: [], pipelines: [], workflows: [], tasks: [], systemHealth: HEALTHY_SYSTEM, conversationAliases: {}, loaded: false };
+const EMPTY: FilesData = { files: [], requestScope: null, projectCatalog: [], flows: [], pipelines: [], workflows: [], tasks: [], systemHealth: HEALTHY_SYSTEM, conversationAliases: {}, loaded: false };
 
 export function filesApiUrl(project?: string | null, pinnedPath?: string | null): string {
   const params: string[] = [];
@@ -89,10 +91,11 @@ export function useFiles(project?: string | null, pinnedPath?: string | null): F
         /* The flows rollout changes the payload from a bare array to
            {files, flows}; accept both so client and server can deploy in
            either order. */
-        if (Array.isArray(parsed)) setData({ files: parsed, projectCatalog: [], flows: [], pipelines: [], workflows: [], tasks: [], systemHealth: HEALTHY_SYSTEM, conversationAliases: {}, loaded: true });
+        if (Array.isArray(parsed)) setData({ files: parsed, requestScope: url, projectCatalog: [], flows: [], pipelines: [], workflows: [], tasks: [], systemHealth: HEALTHY_SYSTEM, conversationAliases: {}, loaded: true });
         else {
           setData({
             files: parsed.files ?? [],
+            requestScope: url,
             projectCatalog: parsed.projectCatalog ?? [],
             flows: parsed.flows ?? [],
             pipelines: parsed.pipelines ?? [],


### PR DESCRIPTION
## Summary

- stamp each successful `/api/files` payload with its request scope
- seed previously unseen historical conversations silently when the request scope changes
- keep known lifecycle transitions and later same-scope questions audible
- add a production-sized 464-entry regression for project hydration

## Root cause and production measurement

PR #116 retained conversation identities across capped-feed churn. Selected-project hydration still introduced every historical attention entry as a new identity. `useAgentChimes` treated each unseen finished entry as a fresh completion and queued the whole batch with a 220 ms stagger.

A headless Puppeteer run against production switched from `forgedemy` to `-agents-tools-live-log-viewer-next` and observed for 61.97 seconds:

- 464 `chime()` calls from one switch
- 1,856 Web Audio oscillator starts
- 0 `Audio.play()` calls
- about 273 audible chime onsets during the first minute, with the queue spanning about 102 seconds

The captured stack was `useAgentChimes` effect → `chime` → `AudioContext.createStereoPanner` → oscillator scheduling.

The sound-path audit also covered the sound-toggle preview, dictation warning/stop cues, user-triggered answer TTS playback, and scanner `notifyQuestion` web push delivery. The observed project-switch cascade came from the lifecycle Web Audio path. Push delivery remains guarded by its persisted attention id.

## Claude limits diagnosis

The active Claude account is `botfatherdev-2`. `GET /api/limits?claudeAccountId=botfatherdev-2` returned:

- `source: unavailable`
- `reason: oauth-rate-limited`
- `retryAt: 2026-07-12T21:39:28.113Z`

The deployed footer rendered `Provider is rate-limiting requests. Retry at 00:39.` for the uncached account. The throttled state and next retry are already visible, so this PR carries no limits UI change.

## Validation

- patched browser replay: 0 lifecycle chimes, 0 oscillator starts, 0 `Audio.play()` calls
- `bun test` — 2,057 passed
- `bunx tsc --noEmit`
