### PR TITLE
Add durable Claude stream broker host

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -1,20 +1,28 @@
-# PR #152: EngineHost interface and CodexAppServerHost
+# Issue #150: Durable Claude stream broker host
 
-## Task statement
-
-Implement issue #149 from the issue #25 runtime spike: define the shared structured-host contract, add the Codex app-server adapter on ChatGPT subscription authentication, persist its mutable host state beside the durable engine thread identity, and support restart adoption through `thread/resume`.
+Productize the issue #25 Claude stream-json prototype as `ClaudeStreamBrokerHost`, an `EngineHost` adapter that owns one long-lived Claude process per hosted session and preserves queue, replay, and resume state durably.
 
 ## Acceptance criteria
 
-- AC1: `EngineHost` exposes `attach(afterSeq)`, `send`, `interrupt`, `answer`, `health`, and `release` with the spike contract semantics.
-- AC2: `CodexAppServerHost` maps the contract to app-server JSON-RPC over stdio and uses the Codex thread ID as durable session identity.
-- AC3: Structured hosting activates only when `LLV_STRUCTURED_HOSTS=1`; the default state remains disabled.
-- AC4: Existing tmux delivery paths, flow engines, and UI remain unchanged.
-- AC5: Registry state persists host kind, endpoint, PID plus process-start identity, event cursor, protocol version, writer-claim epoch, active turn reference, and pending attention.
-- AC6: Viewer restart adoption resumes every eligible Codex registry row through `thread/resume`.
-- AC7: Delivery maps queue entry IDs to `clientUserMessageId`, active turns use `expectedTurnId`, interruption stays explicit, and structured attention can be answered.
-- AC8: The real Codex CLI integration starts a thread, attaches a late client, steers the active turn, restarts the host process, and resumes the same thread on the ChatGPT subscription.
-- AC9: The real integration skips gracefully when the Codex CLI is unavailable.
-- AC10: API keys and authentication tokens never cross into the child environment or diagnostic output.
-- AC11: `bun test`, touched-file ESLint, and `bunx tsc --noEmit` pass.
-- AC12: A fresh independent review reaches a clean APPROVE verdict.
+AC1: Every runtime implementation change lives under `src/lib/runtime/`. Structured Claude hosting activates only when `LLV_STRUCTURED_HOSTS=1`; the default remains disabled and existing tmux behavior stays unchanged.
+
+AC2: Every outbound user queue entry is fsynced to the Claude delivery ledger before the first corresponding stdin write. A crash after the ledger append and before actuation leaves a safely retryable entry.
+
+AC3: A ledger entry becomes delivered only after its matching replayed user message appears on the Claude stream or in the durable Claude transcript during adoption.
+
+AC4: `ClaudeStreamBrokerHost` conforms to `EngineHost`: `attach(afterSeq)`, `send`, `interrupt`, `answer`, `health`, and `release`. Replay is monotonic and durable for late viewers, regular active-turn sends queue for the following turn, and interruption uses an explicit control request.
+
+AC5: A fresh broker resumes the same Claude session through `--resume <session_id>`. Registry adoption persists the broker process identity, event cursor, CLI version, writer epoch, active turn, and pending attention state.
+
+AC6: Claude children use the local `claude.ai` subscription login. Provider API-key and OAuth-token environment variables never cross into the child process or diagnostic output.
+
+AC7: The real CLI integration test skips cleanly when the Claude binary or subscription login is unavailable and verifies late attach plus restart resume when available.
+
+AC8: No tmux delivery, flow-engine, scanner, or UI source is changed.
+
+## Validation gates
+
+- `bun test`
+- `bunx tsc --noEmit`
+- ESLint for every changed TypeScript file
+- Real local Claude subscription integration when the authenticated CLI is available

--- a/src/lib/runtime/claudeStreamBrokerHost.integration.test.ts
+++ b/src/lib/runtime/claudeStreamBrokerHost.integration.test.ts
@@ -116,3 +116,34 @@ test.skipIf(!localSubscriptionAvailable())("real Claude subscription supports la
     await recovered?.release();
   }
 }, 180_000);
+
+test.skipIf(!localSubscriptionAvailable())("real Claude permission requests reach EngineHost.answer", async () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-claude-permission-integration-"));
+  const eventStore = new FileRuntimeEventStore(path.join(directory, "events"));
+  const deliveryLedger = new FileClaudeDeliveryLedger(path.join(directory, "deliveries"));
+  let host: ClaudeStreamBrokerHost | null = null;
+  try {
+    host = await ClaudeStreamBrokerHost.start({
+      cwd: process.cwd(),
+      model: "haiku",
+      permissionMode: "default",
+      tools: ["Bash"],
+      systemPrompt: "Follow the user request exactly and use the requested tool.",
+      eventStore,
+      deliveryLedger,
+    });
+    const events = host.attach(0)[Symbol.asyncIterator]();
+    const probePath = path.join(directory, "permission-probe");
+    const sent = await host.send({
+      id: `issue-150-permission-${crypto.randomUUID()}`,
+      text: `Use the Bash tool once to run \`touch ${probePath}\`. Do not answer before attempting the tool.`,
+    });
+    expect(sent.outcome).toBe("turn-started");
+    const attention = await waitFor(events, (event) => event.kind === "attention" && event.method === "can_use_tool");
+    if (attention.kind !== "attention") throw new Error("expected Claude permission attention");
+    await host.answer(attention.id, { behavior: "deny", message: "Denied by the runtime integration test." });
+    await waitFor(events, (event) => event.kind === "turn-ended");
+  } finally {
+    await host?.release();
+  }
+}, 180_000);

--- a/src/lib/runtime/claudeStreamBrokerHost.integration.test.ts
+++ b/src/lib/runtime/claudeStreamBrokerHost.integration.test.ts
@@ -1,0 +1,118 @@
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { expect, test } from "bun:test";
+
+import { ClaudeStreamBrokerHost, FileClaudeDeliveryLedger } from "./claudeStreamBrokerHost";
+import { FileRuntimeEventStore } from "./eventStore";
+import type { RuntimeEvent } from "./engineHost";
+
+function subscriptionEnvironment(): NodeJS.ProcessEnv {
+  const env = { ...process.env };
+  delete env.ANTHROPIC_API_KEY;
+  delete env.CLAUDE_CODE_OAUTH_TOKEN;
+  return env;
+}
+
+function localSubscriptionAvailable(): boolean {
+  const binary = process.env.LLV_CLAUDE_BINARY ?? "claude";
+  const version = spawnSync(binary, ["--version"], { env: subscriptionEnvironment(), stdio: "ignore" });
+  if (version.status !== 0) return false;
+  const auth = spawnSync(binary, ["auth", "status"], {
+    env: subscriptionEnvironment(),
+    encoding: "utf8",
+    timeout: 10_000,
+  });
+  if (auth.status !== 0) return false;
+  try {
+    const value = JSON.parse(auth.stdout) as Record<string, unknown>;
+    return value.loggedIn === true && value.authMethod === "claude.ai" && typeof value.subscriptionType === "string";
+  } catch {
+    return false;
+  }
+}
+
+async function waitFor(
+  iterator: AsyncIterator<RuntimeEvent>,
+  predicate: (event: RuntimeEvent) => boolean,
+  timeoutMs = 60_000,
+): Promise<RuntimeEvent> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      (async () => {
+        while (true) {
+          const next = await iterator.next();
+          if (next.done) throw new Error("Claude event stream ended early");
+          if (predicate(next.value)) return next.value;
+        }
+      })(),
+      new Promise<never>((_, reject) => {
+        timer = setTimeout(() => reject(new Error("Claude integration event timed out")), timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
+function containsText(event: RuntimeEvent, expected: string): boolean {
+  if (event.kind === "delta") return event.text.includes(expected);
+  if (event.kind !== "item") return false;
+  return JSON.stringify(event.item).includes(expected);
+}
+
+test.skipIf(!localSubscriptionAvailable())("real Claude subscription supports late attach and restart resume", async () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-claude-integration-"));
+  const eventStore = new FileRuntimeEventStore(path.join(directory, "events"));
+  const deliveryLedger = new FileClaudeDeliveryLedger(path.join(directory, "deliveries"));
+  let host: ClaudeStreamBrokerHost | null = null;
+  let recovered: ClaudeStreamBrokerHost | null = null;
+  try {
+    host = await ClaudeStreamBrokerHost.start({
+      cwd: process.cwd(),
+      model: "haiku",
+      permissionMode: "dontAsk",
+      tools: [],
+      systemPrompt: "Follow each user request exactly. Do not inspect files or use tools.",
+      eventStore,
+      deliveryLedger,
+    });
+    const owner = host.attach(0)[Symbol.asyncIterator]();
+    const sent = await host.send({
+      id: `issue-150-original-${crypto.randomUUID()}`,
+      text: "Remember marker ORCHID-150, then reply with exactly ACK-150.",
+    });
+    expect(sent.outcome).toBe("turn-started");
+    const late = host.attach(0)[Symbol.asyncIterator]();
+    await waitFor(owner, (event) => containsText(event, "ACK-150"));
+    await waitFor(late, (event) => containsText(event, "ACK-150"));
+    const sessionId = host.identity.sessionId;
+    await host.release();
+    const releasedCursor = (await host.health()).eventCursor;
+    host = null;
+
+    recovered = await ClaudeStreamBrokerHost.adopt(sessionId, {
+      cwd: process.cwd(),
+      model: "haiku",
+      permissionMode: "dontAsk",
+      tools: [],
+      systemPrompt: "Follow each user request exactly. Do not inspect files or use tools.",
+      initialEventCursor: releasedCursor,
+      eventStore,
+      deliveryLedger,
+    });
+    expect(recovered.identity.sessionId).toBe(sessionId);
+    const recovery = recovered.attach((await recovered.health()).eventCursor)[Symbol.asyncIterator]();
+    const recall = await recovered.send({
+      id: `issue-150-recall-${crypto.randomUUID()}`,
+      text: "Reply with only the marker I asked you to remember.",
+    });
+    expect(recall.outcome).toBe("turn-started");
+    await waitFor(recovery, (event) => containsText(event, "ORCHID-150"));
+  } finally {
+    await host?.release();
+    await recovered?.release();
+  }
+}, 180_000);

--- a/src/lib/runtime/claudeStreamBrokerHost.test.ts
+++ b/src/lib/runtime/claudeStreamBrokerHost.test.ts
@@ -4,7 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import { PassThrough } from "node:stream";
 import type { ChildProcessWithoutNullStreams, SpawnOptionsWithoutStdio } from "node:child_process";
-import { describe, expect, test } from "bun:test";
+import { describe, expect, spyOn, test } from "bun:test";
 
 import { AgentRegistry } from "@/lib/agent/registry";
 
@@ -171,7 +171,7 @@ describe("ClaudeStreamBrokerHost", () => {
     expect(ledger.order.slice(0, 2)).toEqual(["ledger:delivery-one", "stdin:begin"]);
 
     child.emitJson({ type: "system", subtype: "init", session_id: host.identity.sessionId, apiKeySource: "none", model: "claude-test" });
-    child.emitJson({ type: "user", session_id: host.identity.sessionId, uuid: "user-one", message: { role: "user", content: [{ type: "text", text: "begin" }] } });
+    child.emitJson({ type: "user", isReplay: true, session_id: host.identity.sessionId, uuid: "user-one", message: { role: "user", content: [{ type: "text", text: "begin" }] } });
     child.emitJson({ type: "assistant", session_id: host.identity.sessionId, message: { role: "assistant", content: [{ type: "text", text: "done" }] } });
     child.emitJson({ type: "result", subtype: "success", session_id: host.identity.sessionId, result: "done" });
 
@@ -191,6 +191,30 @@ describe("ClaudeStreamBrokerHost", () => {
     await host.release();
   });
 
+  test("confirms delivery only from replayed user-role frames", async () => {
+    const ledger = new RecordingDeliveryLedger();
+    const child = new FakeClaude(ledger);
+    const host = await ClaudeStreamBrokerHost.start({
+      cwd: "/repo",
+      deliveryLedger: ledger,
+      eventStore: new MemoryEventStore(),
+      readAuthStatus: () => ({ loggedIn: true, authMethod: "claude.ai", subscriptionType: "max" }),
+      spawnProcess: fakeSpawn(child, {}),
+    });
+    let settled = false;
+    const sent = host.send({ id: "replay-only", text: "match me" }).finally(() => { settled = true; });
+
+    child.emitJson({ type: "user", isReplay: false, session_id: host.identity.sessionId, uuid: "ordinary", message: { role: "user", content: [{ type: "text", text: "match me" }] } });
+    await Bun.sleep(0);
+    expect(settled).toBeFalse();
+    child.emitJson({ type: "user", isReplay: true, session_id: host.identity.sessionId, uuid: "wrong-role", message: { role: "tool", content: [{ type: "text", text: "match me" }] } });
+    await Bun.sleep(0);
+    expect(settled).toBeFalse();
+    child.emitJson({ type: "user", isReplay: true, session_id: host.identity.sessionId, uuid: "replay", message: { role: "user", content: [{ type: "text", text: "match me" }] } });
+    expect(await sent).toEqual({ outcome: "turn-started", turnId: "replay-only" });
+    await host.release();
+  });
+
   test("queues ordinary active-turn sends and resumes the same durable session", async () => {
     const ledger = new RecordingDeliveryLedger();
     const eventStore = new MemoryEventStore();
@@ -205,14 +229,14 @@ describe("ClaudeStreamBrokerHost", () => {
     });
     const sessionId = first.identity.sessionId;
     const firstSend = first.send({ id: "first", text: "one" });
-    firstChild.emitJson({ type: "user", session_id: sessionId, uuid: "user-one", message: { role: "user", content: [{ type: "text", text: "one" }] } });
+    firstChild.emitJson({ type: "user", isReplay: true, session_id: sessionId, uuid: "user-one", message: { role: "user", content: [{ type: "text", text: "one" }] } });
     expect(await firstSend).toEqual({ outcome: "turn-started", turnId: "first" });
     const secondSend = first.send({ id: "second", text: "two" });
     const duplicateSecond = first.send({ id: "second", text: "two" });
     expect(firstChild.inputs.filter((input) => input.type === "user")).toHaveLength(2);
     firstChild.emitJson({ type: "result", subtype: "success", session_id: sessionId });
     expect((await first.health()).activeTurnRef).toBe("second");
-    firstChild.emitJson({ type: "user", session_id: sessionId, uuid: "user-two", message: { role: "user", content: [{ type: "text", text: "two" }] } });
+    firstChild.emitJson({ type: "user", isReplay: true, session_id: sessionId, uuid: "user-two", message: { role: "user", content: [{ type: "text", text: "two" }] } });
     expect(await secondSend).toEqual({ outcome: "queued-next-turn", turnId: "second" });
     expect(await duplicateSecond).toEqual({ outcome: "queued-next-turn", turnId: "second" });
     firstChild.emitJson({ type: "result", subtype: "success", session_id: sessionId });
@@ -254,7 +278,7 @@ describe("ClaudeStreamBrokerHost", () => {
     });
     expect((await pending.health()).activeTurnRef).toBeNull();
     const retried = pending.send(pendingEntry);
-    pendingChild.emitJson({ type: "user", session_id: "pending-session", uuid: "retried-user", message: { role: "user", content: [{ type: "text", text: "retry me" }] } });
+    pendingChild.emitJson({ type: "user", isReplay: true, session_id: "pending-session", uuid: "retried-user", message: { role: "user", content: [{ type: "text", text: "retry me" }] } });
     expect(await retried).toEqual({ outcome: "queued-next-turn", turnId: "pending" });
     expect(pendingChild.inputs.filter((input) => input.type === "user")).toHaveLength(1);
     await pending.release();
@@ -345,7 +369,7 @@ describe("ClaudeStreamBrokerHost", () => {
     });
     const retried = replacement.send({ id: "retry-entry", text: "retry after crash" });
     expect(replacementChild.inputs.filter((input) => input.type === "user")).toHaveLength(1);
-    replacementChild.emitJson({ type: "user", session_id: "retry-session", uuid: "retry-user", message: { role: "user", content: [{ type: "text", text: "retry after crash" }] } });
+    replacementChild.emitJson({ type: "user", isReplay: true, session_id: "retry-session", uuid: "retry-user", message: { role: "user", content: [{ type: "text", text: "retry after crash" }] } });
     expect(await retried).toEqual({ outcome: "turn-started", turnId: "retry-entry" });
     await replacement.release();
   });
@@ -404,7 +428,7 @@ describe("ClaudeStreamBrokerHost", () => {
       spawnProcess: fakeSpawn(child, {}),
     });
     const sent = host.send({ id: "active", text: "work" });
-    child.emitJson({ type: "user", session_id: host.identity.sessionId, uuid: "active-user", message: { role: "user", content: [{ type: "text", text: "work" }] } });
+    child.emitJson({ type: "user", isReplay: true, session_id: host.identity.sessionId, uuid: "active-user", message: { role: "user", content: [{ type: "text", text: "work" }] } });
     await sent;
     const interrupted = host.interrupt("active");
     const request = child.inputs.find((input) => input.type === "control_request")!;
@@ -418,10 +442,56 @@ describe("ClaudeStreamBrokerHost", () => {
     child.emitJson({ type: "control_request", request_id: "permission-one", request: { subtype: "can_use_tool", tool_name: "Bash" } });
     await Bun.sleep(0);
     expect((await host.health()).pendingAttention).toEqual(["permission-one"]);
-    await host.answer("permission-one", { behavior: "deny" });
+    const answer = host.answer("permission-one", { behavior: "deny" });
     expect(child.inputs.at(-1)).toEqual({
       type: "control_response",
       response: { subtype: "success", request_id: "permission-one", response: { behavior: "deny" } },
+    });
+    expect((await host.health()).pendingAttention).toEqual(["permission-one"]);
+    child.emitJson({ type: "control_response", response: { subtype: "success", request_id: "permission-one", response: { behavior: "deny" } } });
+    await answer;
+    expect((await host.health()).pendingAttention).toEqual([]);
+    await host.release();
+  });
+
+  test("retires control attention from response acknowledgements and cancellations", async () => {
+    const ledger = new RecordingDeliveryLedger();
+    const child = new FakeClaude(ledger);
+    const host = await ClaudeStreamBrokerHost.start({
+      cwd: "/repo",
+      deliveryLedger: ledger,
+      eventStore: new MemoryEventStore(),
+      requestTimeoutMs: 1_000,
+      readAuthStatus: () => ({ loggedIn: true, authMethod: "claude.ai", subscriptionType: "max" }),
+      spawnProcess: fakeSpawn(child, {}),
+    });
+
+    child.emitJson({ type: "control_request", request_id: "answered-request", request: { subtype: "can_use_tool" } });
+    await Bun.sleep(0);
+    const answeredCursor = (await host.health()).eventCursor;
+    const answeredEvents = host.attach(answeredCursor)[Symbol.asyncIterator]();
+    const answered = host.answer("answered-request", { behavior: "deny" });
+    await Bun.sleep(0);
+    expect((await host.health()).pendingAttention).toEqual(["answered-request"]);
+    expect((await host.health()).eventCursor).toBe(answeredCursor);
+    child.emitJson({ type: "control_response", response: { subtype: "success", request_id: "answered-request", response: { behavior: "deny" } } });
+    await answered;
+    expect(await nextEvent(answeredEvents)).toMatchObject({
+      kind: "attention-resolved",
+      id: "answered-request",
+      resolution: "answered",
+    });
+
+    child.emitJson({ type: "control_request", request_id: "cancelled-request", request: { subtype: "can_use_tool" } });
+    await Bun.sleep(0);
+    const cancelledEvents = host.attach((await host.health()).eventCursor)[Symbol.asyncIterator]();
+    const cancelledAnswer = host.answer("cancelled-request", { behavior: "deny" });
+    child.emitJson({ type: "control_cancel_request", request_id: "cancelled-request" });
+    await expect(cancelledAnswer).rejects.toThrow("cancelled before answer confirmation");
+    expect(await nextEvent(cancelledEvents)).toMatchObject({
+      kind: "attention-resolved",
+      id: "cancelled-request",
+      resolution: "server-resolved",
     });
     expect((await host.health()).pendingAttention).toEqual([]);
     await host.release();
@@ -439,7 +509,7 @@ describe("ClaudeStreamBrokerHost", () => {
       spawnProcess: fakeSpawn(child, {}),
     });
     const sent = host.send({ id: "partial", text: "reply" });
-    child.emitJson({ type: "user", session_id: host.identity.sessionId, uuid: "partial-user", message: { role: "user", content: [{ type: "text", text: "reply" }] } });
+    child.emitJson({ type: "user", isReplay: true, session_id: host.identity.sessionId, uuid: "partial-user", message: { role: "user", content: [{ type: "text", text: "reply" }] } });
     await sent;
     const events = host.attach((await host.health()).eventCursor)[Symbol.asyncIterator]();
     for (const text of ["ACK", "-", "150"]) {
@@ -662,5 +732,40 @@ describe("ClaudeStreamBrokerHost", () => {
     ledger.recordQueued("durable", { id: "second", text: "world" }, "queued-next-turn");
     expect(ledger.load("durable").map((state) => state.entry.id)).toEqual(["entry", "second"]);
     expect(fs.statSync(filename).mode & 0o777).toBe(0o600);
+  });
+
+  test("file delivery ledger completes short writes before returning", () => {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-claude-short-ledger-"));
+    const originalWriteSync = fs.writeSync as unknown as (
+      fd: number,
+      buffer: Uint8Array,
+      offset: number,
+      length: number,
+      position: number | null,
+    ) => number;
+    const shortWrite = spyOn(fs, "writeSync").mockImplementation(((
+      fd: number,
+      value: string | Uint8Array,
+      offset = 0,
+      length?: number,
+      position: number | null = null,
+    ) => {
+      const buffer = typeof value === "string" ? Buffer.from(value) : value;
+      const start = typeof value === "string" || typeof offset !== "number" ? 0 : offset;
+      const requested = typeof value === "string" ? buffer.byteLength : (length ?? buffer.byteLength - start);
+      const shortLength = Math.max(1, Math.floor(requested / 2));
+      return originalWriteSync(fd, buffer, start, shortLength, position);
+    }) as typeof fs.writeSync);
+    try {
+      const ledger = new FileClaudeDeliveryLedger(directory);
+      ledger.recordQueued("short-write", { id: "entry", text: "fully durable" }, "turn-started");
+      expect(ledger.load("short-write")).toMatchObject([{
+        entry: { id: "entry", text: "fully durable" },
+        disposition: "turn-started",
+        delivered: false,
+      }]);
+    } finally {
+      shortWrite.mockRestore();
+    }
   });
 });

--- a/src/lib/runtime/claudeStreamBrokerHost.test.ts
+++ b/src/lib/runtime/claudeStreamBrokerHost.test.ts
@@ -1,0 +1,389 @@
+import { EventEmitter } from "node:events";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { PassThrough } from "node:stream";
+import type { ChildProcessWithoutNullStreams, SpawnOptionsWithoutStdio } from "node:child_process";
+import { describe, expect, test } from "bun:test";
+
+import { AgentRegistry } from "@/lib/agent/registry";
+
+import {
+  ClaudeStreamBrokerHost,
+  FileClaudeDeliveryLedger,
+  type ClaudeDeliveryLedger,
+  type ClaudeDeliveryState,
+} from "./claudeStreamBrokerHost";
+import type { RuntimeEventStore } from "./eventStore";
+import type { QueueEntry, RuntimeEvent } from "./engineHost";
+import { adoptClaudeRegistryHosts, startClaudeStructuredHost } from "./registry";
+
+class MemoryEventStore implements RuntimeEventStore {
+  private readonly events = new Map<string, RuntimeEvent[]>();
+
+  load(sessionId: string): RuntimeEvent[] {
+    return structuredClone(this.events.get(sessionId) ?? []);
+  }
+
+  append(sessionId: string, event: RuntimeEvent): void {
+    const events = this.events.get(sessionId) ?? [];
+    events.push(structuredClone(event));
+    this.events.set(sessionId, events);
+  }
+}
+
+class RecordingDeliveryLedger implements ClaudeDeliveryLedger {
+  readonly order: string[] = [];
+  private readonly states = new Map<string, ClaudeDeliveryState[]>();
+
+  load(sessionId: string): ClaudeDeliveryState[] {
+    return structuredClone(this.states.get(sessionId) ?? []);
+  }
+
+  recordQueued(sessionId: string, entry: QueueEntry, disposition: ClaudeDeliveryState["disposition"]): void {
+    this.order.push(`ledger:${entry.id}`);
+    const states = this.states.get(sessionId) ?? [];
+    states.push({ entry: structuredClone(entry), disposition, delivered: false });
+    this.states.set(sessionId, states);
+  }
+
+  confirmDelivered(sessionId: string, entryId: string, engineMessageId: string | null): void {
+    this.order.push(`confirmed:${entryId}`);
+    const state = this.states.get(sessionId)?.find((candidate) => candidate.entry.id === entryId);
+    if (state) {
+      state.delivered = true;
+      state.engineMessageId = engineMessageId;
+    }
+  }
+}
+
+class FakeClaude extends EventEmitter {
+  readonly stdin = new PassThrough();
+  readonly stdout = new PassThrough();
+  readonly stderr = new PassThrough();
+  readonly pid = 5150;
+  readonly signals: NodeJS.Signals[] = [];
+  readonly inputs: Array<Record<string, unknown>> = [];
+  sessionId = "";
+
+  constructor(private readonly ledger: RecordingDeliveryLedger) {
+    super();
+    let buffer = "";
+    this.stdin.on("data", (chunk) => {
+      buffer += String(chunk);
+      let newline = buffer.indexOf("\n");
+      while (newline >= 0) {
+        const line = buffer.slice(0, newline);
+        buffer = buffer.slice(newline + 1);
+        if (line) {
+          const input = JSON.parse(line) as Record<string, unknown>;
+          this.inputs.push(input);
+          const message = input.message as { content?: Array<{ text?: string }> } | undefined;
+          if (input.type === "user") {
+            this.ledger.order.push(`stdin:${message?.content?.[0]?.text}`);
+          }
+        }
+        newline = buffer.indexOf("\n");
+      }
+    });
+  }
+
+  emitJson(value: unknown): void {
+    this.stdout.write(`${JSON.stringify(value)}\n`);
+  }
+
+  kill(signal: NodeJS.Signals = "SIGTERM"): boolean {
+    this.signals.push(signal);
+    queueMicrotask(() => this.emit("close", 0, signal));
+    return true;
+  }
+}
+
+function fakeSpawn(
+  child: FakeClaude,
+  captured: { args?: string[]; options?: SpawnOptionsWithoutStdio },
+) {
+  return (_command: string, args: string[], options: SpawnOptionsWithoutStdio) => {
+    captured.args = args;
+    captured.options = options;
+    const sessionIndex = args.indexOf("--session-id");
+    child.sessionId = args[sessionIndex + 1] ?? "";
+    return child as unknown as ChildProcessWithoutNullStreams;
+  };
+}
+
+async function nextEvent(iterator: AsyncIterator<RuntimeEvent>): Promise<RuntimeEvent> {
+  const next = await iterator.next();
+  if (next.done) throw new Error("event stream ended");
+  return next.value;
+}
+
+describe("ClaudeStreamBrokerHost", () => {
+  test("persists sends before stdin and fans durable events to late viewers", async () => {
+    const ledger = new RecordingDeliveryLedger();
+    const child = new FakeClaude(ledger);
+    const captured: { args?: string[]; options?: SpawnOptionsWithoutStdio } = {};
+    const eventStore = new MemoryEventStore();
+    const host = await ClaudeStreamBrokerHost.start({
+      cwd: "/repo",
+      env: {
+        NODE_ENV: "test",
+        PATH: process.env.PATH,
+        ANTHROPIC_API_KEY: "must-not-cross",
+        CLAUDE_CODE_OAUTH_TOKEN: "must-not-cross",
+        PRIVATE_SERVICE_TOKEN: "must-not-cross",
+      },
+      eventStore,
+      deliveryLedger: ledger,
+      readAuthStatus: () => ({ loggedIn: true, authMethod: "claude.ai", subscriptionType: "max", version: "2.1.197" }),
+      spawnProcess: fakeSpawn(child, captured),
+    });
+
+    expect(captured.options?.env).toEqual({ NODE_ENV: "test", PATH: process.env.PATH });
+    expect(captured.args).toContain("--input-format");
+    expect(captured.args).toContain("--output-format");
+    expect(captured.args).toContain("--safe-mode");
+    expect(captured.args).toContain("--replay-user-messages");
+    expect(captured.args?.slice(-2)).toEqual(["--session-id", host.identity.sessionId]);
+    const owner = host.attach(0)[Symbol.asyncIterator]();
+    expect(await nextEvent(owner)).toEqual({ kind: "session-status", status: "idle", seq: 1 });
+
+    const receipt = await host.send({ id: "delivery-one", text: "begin" });
+    expect(receipt).toEqual({ outcome: "turn-started", turnId: "delivery-one" });
+    expect(ledger.order.slice(0, 2)).toEqual(["ledger:delivery-one", "stdin:begin"]);
+
+    child.emitJson({ type: "system", subtype: "init", session_id: host.identity.sessionId, apiKeySource: "none", model: "claude-test" });
+    child.emitJson({ type: "user", session_id: host.identity.sessionId, uuid: "user-one", message: { role: "user", content: [{ type: "text", text: "begin" }] } });
+    child.emitJson({ type: "assistant", session_id: host.identity.sessionId, message: { role: "assistant", content: [{ type: "text", text: "done" }] } });
+    child.emitJson({ type: "result", subtype: "success", session_id: host.identity.sessionId, result: "done" });
+
+    expect(await nextEvent(owner)).toEqual({ kind: "turn-started", turnId: "delivery-one", seq: 2 });
+    expect(await nextEvent(owner)).toMatchObject({ kind: "item", turnId: "delivery-one", phase: "completed" });
+    expect(await nextEvent(owner)).toEqual({ kind: "delta", turnId: "delivery-one", text: "done", seq: 4 });
+    expect(await nextEvent(owner)).toMatchObject({ kind: "item", turnId: "delivery-one", phase: "completed" });
+    expect(await nextEvent(owner)).toEqual({ kind: "turn-ended", turnId: "delivery-one", status: "completed", seq: 6 });
+    expect(await nextEvent(owner)).toEqual({ kind: "session-status", status: "idle", seq: 7 });
+    expect(ledger.order).toContain("confirmed:delivery-one");
+
+    const late = host.attach(3)[Symbol.asyncIterator]();
+    expect(await nextEvent(late)).toEqual({ kind: "delta", turnId: "delivery-one", text: "done", seq: 4 });
+    expect((await host.health()).account).toEqual({ type: "claude.ai", planType: "max" });
+    await host.release();
+  });
+
+  test("queues ordinary active-turn sends and resumes the same durable session", async () => {
+    const ledger = new RecordingDeliveryLedger();
+    const eventStore = new MemoryEventStore();
+    const firstChild = new FakeClaude(ledger);
+    const first = await ClaudeStreamBrokerHost.start({
+      cwd: "/repo",
+      eventStore,
+      deliveryLedger: ledger,
+      readAuthStatus: () => ({ loggedIn: true, authMethod: "claude.ai", subscriptionType: "max" }),
+      readTranscript: () => [],
+      spawnProcess: fakeSpawn(firstChild, {}),
+    });
+    const sessionId = first.identity.sessionId;
+    expect(await first.send({ id: "first", text: "one" })).toEqual({ outcome: "turn-started", turnId: "first" });
+    expect(await first.send({ id: "second", text: "two" })).toEqual({ outcome: "queued-next-turn", turnId: "second" });
+    expect(await first.send({ id: "second", text: "two" })).toEqual({ outcome: "queued-next-turn", turnId: "second" });
+    expect(firstChild.inputs.filter((input) => input.type === "user")).toHaveLength(2);
+    firstChild.emitJson({ type: "user", session_id: sessionId, uuid: "user-one", message: { role: "user", content: [{ type: "text", text: "one" }] } });
+    firstChild.emitJson({ type: "result", subtype: "success", session_id: sessionId });
+    expect((await first.health()).activeTurnRef).toBe("second");
+    firstChild.emitJson({ type: "user", session_id: sessionId, uuid: "user-two", message: { role: "user", content: [{ type: "text", text: "two" }] } });
+    firstChild.emitJson({ type: "result", subtype: "success", session_id: sessionId });
+    await first.release();
+
+    const replacementChild = new FakeClaude(ledger);
+    const captured: { args?: string[] } = {};
+    const replacement = await ClaudeStreamBrokerHost.adopt(sessionId, {
+      cwd: "/repo",
+      eventStore,
+      deliveryLedger: ledger,
+      readAuthStatus: () => ({ loggedIn: true, authMethod: "claude.ai", subscriptionType: "max" }),
+      readTranscript: () => [],
+      spawnProcess: fakeSpawn(replacementChild, captured),
+    });
+    expect(captured.args).toContain("--resume");
+    expect(captured.args?.at(captured.args.indexOf("--resume") + 1)).toBe(sessionId);
+    expect(await replacement.send({ id: "second", text: "two" })).toEqual({ outcome: "queued-next-turn", turnId: "second" });
+    expect(replacementChild.inputs).toHaveLength(0);
+    await replacement.release();
+  });
+
+  test("retries a ledgered pre-actuation entry and confirms an actuated entry from transcript", async () => {
+    const pendingLedger = new RecordingDeliveryLedger();
+    pendingLedger.recordQueued("pending-session", { id: "pending", text: "retry me" }, "turn-started");
+    const pendingChild = new FakeClaude(pendingLedger);
+    const pending = await ClaudeStreamBrokerHost.adopt("pending-session", {
+      cwd: "/repo",
+      deliveryLedger: pendingLedger,
+      eventStore: new MemoryEventStore(),
+      readAuthStatus: () => ({ loggedIn: true, authMethod: "claude.ai", subscriptionType: "max" }),
+      readTranscript: () => [],
+      spawnProcess: fakeSpawn(pendingChild, {}),
+    });
+    expect(await pending.send({ id: "pending", text: "retry me" })).toEqual({ outcome: "turn-started", turnId: "pending" });
+    expect(pendingChild.inputs.filter((input) => input.type === "user")).toHaveLength(1);
+    await pending.release();
+
+    const confirmedLedger = new RecordingDeliveryLedger();
+    confirmedLedger.recordQueued("confirmed-session", { id: "confirmed", text: "already sent" }, "turn-started");
+    const confirmedChild = new FakeClaude(confirmedLedger);
+    const confirmed = await ClaudeStreamBrokerHost.adopt("confirmed-session", {
+      cwd: "/repo",
+      deliveryLedger: confirmedLedger,
+      eventStore: new MemoryEventStore(),
+      readAuthStatus: () => ({ loggedIn: true, authMethod: "claude.ai", subscriptionType: "max" }),
+      readTranscript: () => [{ text: "already sent", uuid: "transcript-user", timestamp: new Date().toISOString() }],
+      spawnProcess: fakeSpawn(confirmedChild, {}),
+    });
+    expect(await confirmed.send({ id: "confirmed", text: "already sent" })).toEqual({ outcome: "turn-started", turnId: "confirmed" });
+    expect(confirmedChild.inputs).toHaveLength(0);
+    expect(confirmedLedger.order).toContain("confirmed:confirmed");
+    await confirmed.release();
+  });
+
+  test("uses explicit control messages for interrupt and attention answers", async () => {
+    const ledger = new RecordingDeliveryLedger();
+    const child = new FakeClaude(ledger);
+    const host = await ClaudeStreamBrokerHost.start({
+      cwd: "/repo",
+      deliveryLedger: ledger,
+      eventStore: new MemoryEventStore(),
+      readAuthStatus: () => ({ loggedIn: true, authMethod: "claude.ai", subscriptionType: "max" }),
+      readTranscript: () => [],
+      spawnProcess: fakeSpawn(child, {}),
+    });
+    await host.send({ id: "active", text: "work" });
+    const interrupted = host.interrupt("active");
+    const request = child.inputs.find((input) => input.type === "control_request")!;
+    expect(request.request).toEqual({ subtype: "interrupt" });
+    child.emitJson({ type: "control_response", response: { subtype: "success", request_id: request.request_id } });
+    await interrupted;
+
+    child.emitJson({ type: "control_request", request_id: "permission-one", request: { subtype: "can_use_tool", tool_name: "Bash" } });
+    await Bun.sleep(0);
+    expect((await host.health()).pendingAttention).toEqual(["permission-one"]);
+    await host.answer("permission-one", { behavior: "deny" });
+    expect(child.inputs.at(-1)).toEqual({
+      type: "control_response",
+      response: { subtype: "success", request_id: "permission-one", response: { behavior: "deny" } },
+    });
+    expect((await host.health()).pendingAttention).toEqual([]);
+    await host.release();
+  });
+
+  test("requires subscription OAuth before spawning", async () => {
+    let spawned = false;
+    await expect(ClaudeStreamBrokerHost.start({
+      cwd: "/repo",
+      readAuthStatus: () => ({ loggedIn: true, authMethod: "apiKey", subscriptionType: null }),
+      spawnProcess: () => {
+        spawned = true;
+        throw new Error("unexpected spawn");
+      },
+    })).rejects.toThrow("requires a claude.ai subscription login");
+    expect(spawned).toBeFalse();
+  });
+
+  test("requires the exact structured-host opt-in before start", async () => {
+    const ledger = new RecordingDeliveryLedger();
+    const child = new FakeClaude(ledger);
+    const options = {
+      cwd: "/repo",
+      deliveryLedger: ledger,
+      eventStore: new MemoryEventStore(),
+      readAuthStatus: () => ({ loggedIn: true, authMethod: "claude.ai", subscriptionType: "max" }),
+      readTranscript: () => [],
+      spawnProcess: fakeSpawn(child, {}),
+    };
+    await expect(startClaudeStructuredHost(options, { NODE_ENV: "test", LLV_STRUCTURED_HOSTS: "true" }))
+      .rejects.toThrow("structured hosts are disabled");
+    expect(child.sessionId).toBe("");
+    const host = await startClaudeStructuredHost(options, { NODE_ENV: "test", LLV_STRUCTURED_HOSTS: "1" });
+    expect(child.sessionId).toBe(host.identity.sessionId);
+    await host.release();
+  });
+
+  test("boot adoption resumes claimed Claude rows and persists broker columns", async () => {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-claude-adoption-"));
+    const registry = new AgentRegistry(path.join(directory, "agent-registry.json"));
+    const sessionId = "adopted-claude-session";
+    registry.upsert({
+      key: { engine: "claude", sessionId },
+      artifactPath: `/sessions/${sessionId}.jsonl`,
+      cwd: "/repo",
+      accountId: null,
+      status: "dead",
+      host: null,
+      structuredHost: {
+        kind: "claude-broker",
+        endpoint: "stdio:old",
+        process: null,
+        eventCursor: 4,
+        protocolVersion: "2.1.196",
+        writerClaimEpoch: 2,
+        activeTurnRef: null,
+        pendingAttention: [],
+        activeFlags: [],
+      },
+      claimEpoch: 2,
+      claimOwner: null,
+      pendingAction: null,
+    });
+    const ledger = new RecordingDeliveryLedger();
+    const child = new FakeClaude(ledger);
+    const captured: { args?: string[] } = {};
+    const adopted = await adoptClaudeRegistryHosts(
+      registry,
+      () => ({
+        cwd: "/repo",
+        deliveryLedger: ledger,
+        eventStore: new MemoryEventStore(),
+        readAuthStatus: () => ({ loggedIn: true, authMethod: "claude.ai", subscriptionType: "max", version: "2.1.197" }),
+        readTranscript: () => [],
+        spawnProcess: fakeSpawn(child, captured),
+      }),
+      { NODE_ENV: "test", LLV_STRUCTURED_HOSTS: "1" },
+    );
+    expect(adopted).toHaveLength(1);
+    expect(captured.args).toContain("--resume");
+    expect(registry.snapshot().entries[`claude:${sessionId}`]).toMatchObject({
+      status: "idle",
+      claimEpoch: 3,
+      structuredHost: {
+        kind: "claude-broker",
+        endpoint: "stdio:5150",
+        eventCursor: 5,
+        protocolVersion: "2.1.197",
+        writerClaimEpoch: 3,
+      },
+    });
+    await adopted[0]!.host.release();
+    expect(registry.snapshot().entries[`claude:${sessionId}`]).toMatchObject({
+      status: "unhosted",
+      claimOwner: null,
+      structuredHost: { endpoint: "stdio:released", process: null },
+    });
+  });
+
+  test("file delivery ledger survives restart and repairs a partial tail", () => {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-claude-ledger-"));
+    const ledger = new FileClaudeDeliveryLedger(directory);
+    ledger.recordQueued("durable", { id: "entry", text: "hello" }, "turn-started");
+    ledger.confirmDelivered("durable", "entry", "engine-user");
+    expect(new FileClaudeDeliveryLedger(directory).load("durable")).toMatchObject([{
+      entry: { id: "entry", text: "hello" },
+      disposition: "turn-started",
+      delivered: true,
+      engineMessageId: "engine-user",
+    }]);
+    const filename = path.join(directory, "durable.jsonl");
+    fs.appendFileSync(filename, "{partial");
+    ledger.recordQueued("durable", { id: "second", text: "world" }, "queued-next-turn");
+    expect(ledger.load("durable").map((state) => state.entry.id)).toEqual(["entry", "second"]);
+    expect(fs.statSync(filename).mode & 0o777).toBe(0o600);
+  });
+});

--- a/src/lib/runtime/claudeStreamBrokerHost.test.ts
+++ b/src/lib/runtime/claudeStreamBrokerHost.test.ts
@@ -16,7 +16,7 @@ import {
 } from "./claudeStreamBrokerHost";
 import type { RuntimeEventStore } from "./eventStore";
 import type { QueueEntry, RuntimeEvent } from "./engineHost";
-import { adoptClaudeRegistryHosts, startClaudeStructuredHost } from "./registry";
+import { adoptClaudeRegistryHosts, bindClaudeHostPersistence, startClaudeStructuredHost } from "./registry";
 
 class MemoryEventStore implements RuntimeEventStore {
   private readonly events = new Map<string, RuntimeEvent[]>();
@@ -29,6 +29,19 @@ class MemoryEventStore implements RuntimeEventStore {
     const events = this.events.get(sessionId) ?? [];
     events.push(structuredClone(event));
     this.events.set(sessionId, events);
+  }
+}
+
+class FailingEventStore implements RuntimeEventStore {
+  readonly events: RuntimeEvent[] = [];
+  appendAttempts = 0;
+
+  load(): RuntimeEvent[] { return structuredClone(this.events); }
+
+  append(_sessionId: string, event: RuntimeEvent): void {
+    this.appendAttempts += 1;
+    if (this.appendAttempts >= 2) throw new Error("ENOSPC oauth_token=must-stay-private");
+    this.events.push(structuredClone(event));
   }
 }
 
@@ -66,7 +79,7 @@ class FakeClaude extends EventEmitter {
   readonly inputs: Array<Record<string, unknown>> = [];
   sessionId = "";
 
-  constructor(private readonly ledger: RecordingDeliveryLedger) {
+  constructor(private readonly ledger: RecordingDeliveryLedger, private readonly ignoreTerm = false) {
     super();
     let buffer = "";
     this.stdin.on("data", (chunk) => {
@@ -94,6 +107,7 @@ class FakeClaude extends EventEmitter {
 
   kill(signal: NodeJS.Signals = "SIGTERM"): boolean {
     this.signals.push(signal);
+    if (signal === "SIGTERM" && this.ignoreTerm) return true;
     queueMicrotask(() => this.emit("close", 0, signal));
     return true;
   }
@@ -144,18 +158,24 @@ describe("ClaudeStreamBrokerHost", () => {
     expect(captured.args).toContain("--output-format");
     expect(captured.args).toContain("--safe-mode");
     expect(captured.args).toContain("--replay-user-messages");
+    expect(captured.args).toContain("--permission-prompt-tool");
+    expect(captured.args?.at(captured.args.indexOf("--permission-prompt-tool") + 1)).toBe("stdio");
     expect(captured.args?.slice(-2)).toEqual(["--session-id", host.identity.sessionId]);
     const owner = host.attach(0)[Symbol.asyncIterator]();
     expect(await nextEvent(owner)).toEqual({ kind: "session-status", status: "idle", seq: 1 });
 
-    const receipt = await host.send({ id: "delivery-one", text: "begin" });
-    expect(receipt).toEqual({ outcome: "turn-started", turnId: "delivery-one" });
+    let sendSettled = false;
+    const pendingReceipt = host.send({ id: "delivery-one", text: "begin" }).finally(() => { sendSettled = true; });
+    await Bun.sleep(0);
+    expect(sendSettled).toBeFalse();
     expect(ledger.order.slice(0, 2)).toEqual(["ledger:delivery-one", "stdin:begin"]);
 
     child.emitJson({ type: "system", subtype: "init", session_id: host.identity.sessionId, apiKeySource: "none", model: "claude-test" });
     child.emitJson({ type: "user", session_id: host.identity.sessionId, uuid: "user-one", message: { role: "user", content: [{ type: "text", text: "begin" }] } });
     child.emitJson({ type: "assistant", session_id: host.identity.sessionId, message: { role: "assistant", content: [{ type: "text", text: "done" }] } });
     child.emitJson({ type: "result", subtype: "success", session_id: host.identity.sessionId, result: "done" });
+
+    expect(await pendingReceipt).toEqual({ outcome: "turn-started", turnId: "delivery-one" });
 
     expect(await nextEvent(owner)).toEqual({ kind: "turn-started", turnId: "delivery-one", seq: 2 });
     expect(await nextEvent(owner)).toMatchObject({ kind: "item", turnId: "delivery-one", phase: "completed" });
@@ -184,14 +204,17 @@ describe("ClaudeStreamBrokerHost", () => {
       spawnProcess: fakeSpawn(firstChild, {}),
     });
     const sessionId = first.identity.sessionId;
-    expect(await first.send({ id: "first", text: "one" })).toEqual({ outcome: "turn-started", turnId: "first" });
-    expect(await first.send({ id: "second", text: "two" })).toEqual({ outcome: "queued-next-turn", turnId: "second" });
-    expect(await first.send({ id: "second", text: "two" })).toEqual({ outcome: "queued-next-turn", turnId: "second" });
-    expect(firstChild.inputs.filter((input) => input.type === "user")).toHaveLength(2);
+    const firstSend = first.send({ id: "first", text: "one" });
     firstChild.emitJson({ type: "user", session_id: sessionId, uuid: "user-one", message: { role: "user", content: [{ type: "text", text: "one" }] } });
+    expect(await firstSend).toEqual({ outcome: "turn-started", turnId: "first" });
+    const secondSend = first.send({ id: "second", text: "two" });
+    const duplicateSecond = first.send({ id: "second", text: "two" });
+    expect(firstChild.inputs.filter((input) => input.type === "user")).toHaveLength(2);
     firstChild.emitJson({ type: "result", subtype: "success", session_id: sessionId });
     expect((await first.health()).activeTurnRef).toBe("second");
     firstChild.emitJson({ type: "user", session_id: sessionId, uuid: "user-two", message: { role: "user", content: [{ type: "text", text: "two" }] } });
+    expect(await secondSend).toEqual({ outcome: "queued-next-turn", turnId: "second" });
+    expect(await duplicateSecond).toEqual({ outcome: "queued-next-turn", turnId: "second" });
     firstChild.emitJson({ type: "result", subtype: "success", session_id: sessionId });
     await first.release();
 
@@ -224,7 +247,9 @@ describe("ClaudeStreamBrokerHost", () => {
       readTranscript: () => [],
       spawnProcess: fakeSpawn(pendingChild, {}),
     });
-    expect(await pending.send({ id: "pending", text: "retry me" })).toEqual({ outcome: "turn-started", turnId: "pending" });
+    const retried = pending.send({ id: "pending", text: "retry me" });
+    pendingChild.emitJson({ type: "user", session_id: "pending-session", uuid: "retried-user", message: { role: "user", content: [{ type: "text", text: "retry me" }] } });
+    expect(await retried).toEqual({ outcome: "turn-started", turnId: "pending" });
     expect(pendingChild.inputs.filter((input) => input.type === "user")).toHaveLength(1);
     await pending.release();
 
@@ -245,6 +270,81 @@ describe("ClaudeStreamBrokerHost", () => {
     await confirmed.release();
   });
 
+  test("host loss rejects an unconfirmed send and leaves retry ownership for adoption", async () => {
+    const ledger = new RecordingDeliveryLedger();
+    const eventStore = new MemoryEventStore();
+    const firstChild = new FakeClaude(ledger);
+    const first = await ClaudeStreamBrokerHost.adopt("retry-session", {
+      cwd: "/repo",
+      deliveryLedger: ledger,
+      eventStore,
+      readAuthStatus: () => ({ loggedIn: true, authMethod: "claude.ai", subscriptionType: "max" }),
+      readTranscript: () => [],
+      spawnProcess: fakeSpawn(firstChild, {}),
+    });
+    const unconfirmed = first.send({ id: "retry-entry", text: "retry after crash" });
+    firstChild.emit("close", 1, null);
+    await expect(unconfirmed).rejects.toThrow("Claude child exited");
+    await first.release();
+
+    const replacementChild = new FakeClaude(ledger);
+    const replacement = await ClaudeStreamBrokerHost.adopt("retry-session", {
+      cwd: "/repo",
+      deliveryLedger: ledger,
+      eventStore,
+      readAuthStatus: () => ({ loggedIn: true, authMethod: "claude.ai", subscriptionType: "max" }),
+      readTranscript: () => [],
+      spawnProcess: fakeSpawn(replacementChild, {}),
+    });
+    const retried = replacement.send({ id: "retry-entry", text: "retry after crash" });
+    expect(replacementChild.inputs.filter((input) => input.type === "user")).toHaveLength(1);
+    replacementChild.emitJson({ type: "user", session_id: "retry-session", uuid: "retry-user", message: { role: "user", content: [{ type: "text", text: "retry after crash" }] } });
+    expect(await retried).toEqual({ outcome: "turn-started", turnId: "retry-entry" });
+    await replacement.release();
+  });
+
+  test("managed Claude adoption uses its credential home and transcript root", async () => {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-managed-claude-host-"));
+    const configDir = path.join(directory, "account");
+    const projectsDir = path.join(configDir, "projects");
+    const sessionId = "managed-session";
+    const transcript = path.join(projectsDir, "-repo", `${sessionId}.jsonl`);
+    fs.mkdirSync(path.dirname(transcript), { recursive: true });
+    fs.writeFileSync(transcript, `${JSON.stringify({
+      type: "user",
+      timestamp: new Date().toISOString(),
+      uuid: "managed-user",
+      message: { role: "user", content: [{ type: "text", text: "managed prompt" }] },
+    })}\n`);
+    const ledger = new RecordingDeliveryLedger();
+    ledger.recordQueued(sessionId, { id: "managed-entry", text: "managed prompt" }, "turn-started");
+    const child = new FakeClaude(ledger);
+    const captured: { options?: SpawnOptionsWithoutStdio } = {};
+    const host = await ClaudeStreamBrokerHost.adopt(sessionId, {
+      cwd: "/repo",
+      claudeConfigDir: configDir,
+      claudeProjectsDir: projectsDir,
+      env: {
+        NODE_ENV: "test",
+        PATH: process.env.PATH,
+        ANTHROPIC_API_KEY: "must-not-cross",
+        CLAUDE_CODE_OAUTH_TOKEN: "must-not-cross",
+      },
+      deliveryLedger: ledger,
+      eventStore: new MemoryEventStore(),
+      readAuthStatus: () => ({ loggedIn: true, authMethod: "claude.ai", subscriptionType: "max" }),
+      spawnProcess: fakeSpawn(child, captured),
+    });
+    expect(captured.options?.env).toEqual({
+      NODE_ENV: "test",
+      PATH: process.env.PATH,
+      CLAUDE_CONFIG_DIR: configDir,
+    });
+    expect(await host.send({ id: "managed-entry", text: "managed prompt" })).toEqual({ outcome: "turn-started", turnId: "managed-entry" });
+    expect(child.inputs).toHaveLength(0);
+    await host.release();
+  });
+
   test("uses explicit control messages for interrupt and attention answers", async () => {
     const ledger = new RecordingDeliveryLedger();
     const child = new FakeClaude(ledger);
@@ -256,12 +356,17 @@ describe("ClaudeStreamBrokerHost", () => {
       readTranscript: () => [],
       spawnProcess: fakeSpawn(child, {}),
     });
-    await host.send({ id: "active", text: "work" });
+    const sent = host.send({ id: "active", text: "work" });
+    child.emitJson({ type: "user", session_id: host.identity.sessionId, uuid: "active-user", message: { role: "user", content: [{ type: "text", text: "work" }] } });
+    await sent;
     const interrupted = host.interrupt("active");
     const request = child.inputs.find((input) => input.type === "control_request")!;
     expect(request.request).toEqual({ subtype: "interrupt" });
     child.emitJson({ type: "control_response", response: { subtype: "success", request_id: request.request_id } });
     await interrupted;
+    const terminalEvents = host.attach((await host.health()).eventCursor)[Symbol.asyncIterator]();
+    child.emitJson({ type: "result", subtype: "error_during_execution", session_id: host.identity.sessionId });
+    expect(await nextEvent(terminalEvents)).toMatchObject({ kind: "turn-ended", turnId: "active", status: "interrupted" });
 
     child.emitJson({ type: "control_request", request_id: "permission-one", request: { subtype: "can_use_tool", tool_name: "Bash" } });
     await Bun.sleep(0);
@@ -272,6 +377,33 @@ describe("ClaudeStreamBrokerHost", () => {
       response: { subtype: "success", request_id: "permission-one", response: { behavior: "deny" } },
     });
     expect((await host.health()).pendingAttention).toEqual([]);
+    await host.release();
+  });
+
+  test("does not repeat a completed assistant message after partial deltas", async () => {
+    const ledger = new RecordingDeliveryLedger();
+    const child = new FakeClaude(ledger);
+    const host = await ClaudeStreamBrokerHost.start({
+      cwd: "/repo",
+      deliveryLedger: ledger,
+      eventStore: new MemoryEventStore(),
+      readAuthStatus: () => ({ loggedIn: true, authMethod: "claude.ai", subscriptionType: "max" }),
+      readTranscript: () => [],
+      spawnProcess: fakeSpawn(child, {}),
+    });
+    const sent = host.send({ id: "partial", text: "reply" });
+    child.emitJson({ type: "user", session_id: host.identity.sessionId, uuid: "partial-user", message: { role: "user", content: [{ type: "text", text: "reply" }] } });
+    await sent;
+    const events = host.attach((await host.health()).eventCursor)[Symbol.asyncIterator]();
+    for (const text of ["ACK", "-", "150"]) {
+      child.emitJson({ type: "stream_event", session_id: host.identity.sessionId, event: { type: "content_block_delta", delta: { type: "text_delta", text } } });
+    }
+    child.emitJson({ type: "assistant", session_id: host.identity.sessionId, message: { role: "assistant", content: [{ type: "text", text: "ACK-150" }] } });
+    child.emitJson({ type: "result", subtype: "success", session_id: host.identity.sessionId });
+    expect(await nextEvent(events)).toMatchObject({ kind: "delta", text: "ACK" });
+    expect(await nextEvent(events)).toMatchObject({ kind: "delta", text: "-" });
+    expect(await nextEvent(events)).toMatchObject({ kind: "delta", text: "150" });
+    expect(await nextEvent(events)).toMatchObject({ kind: "item", phase: "completed" });
     await host.release();
   });
 
@@ -366,6 +498,102 @@ describe("ClaudeStreamBrokerHost", () => {
       status: "unhosted",
       claimOwner: null,
       structuredHost: { endpoint: "stdio:released", process: null },
+    });
+  });
+
+  test("protocol failure reaps a TERM-resistant child and releases its writer claim", async () => {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-claude-failure-claim-"));
+    const registry = new AgentRegistry(path.join(directory, "agent-registry.json"));
+    const ledger = new RecordingDeliveryLedger();
+    const child = new FakeClaude(ledger, true);
+    const host = await ClaudeStreamBrokerHost.start({
+      cwd: "/repo",
+      deliveryLedger: ledger,
+      eventStore: new MemoryEventStore(),
+      shutdownGraceMs: 5,
+      readAuthStatus: () => ({ loggedIn: true, authMethod: "claude.ai", subscriptionType: "max" }),
+      readTranscript: () => [],
+      spawnProcess: fakeSpawn(child, {}),
+    });
+    const key = { engine: "claude" as const, sessionId: host.identity.sessionId };
+    registry.upsert({
+      key,
+      artifactPath: `/sessions/${host.identity.sessionId}.jsonl`,
+      cwd: "/repo",
+      accountId: null,
+      status: "idle",
+      host: null,
+      structuredHost: {
+        kind: "claude-broker",
+        endpoint: "stdio:5150",
+        process: { pid: 5150, startIdentity: null },
+        eventCursor: 1,
+        protocolVersion: null,
+        writerClaimEpoch: 1,
+        activeTurnRef: null,
+        pendingAttention: [],
+        activeFlags: [],
+      },
+      claimEpoch: 1,
+      claimOwner: "failure-owner",
+      pendingAction: null,
+    });
+    await bindClaudeHostPersistence(registry, key, host, "failure-owner", 1);
+    child.stdout.write("malformed\n");
+    await Bun.sleep(20);
+    expect(child.signals).toEqual(["SIGTERM", "SIGKILL"]);
+    expect(registry.snapshot().entries[`claude:${host.identity.sessionId}`]).toMatchObject({
+      status: "dead",
+      claimOwner: null,
+      structuredHost: { process: null, endpoint: "stdio:released" },
+    });
+    await host.release();
+  });
+
+  test("shutdown ledger failure still releases its writer claim", async () => {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-claude-release-claim-"));
+    const registry = new AgentRegistry(path.join(directory, "agent-registry.json"));
+    const ledger = new RecordingDeliveryLedger();
+    const child = new FakeClaude(ledger);
+    const eventStore = new FailingEventStore();
+    const host = await ClaudeStreamBrokerHost.start({
+      cwd: "/repo",
+      deliveryLedger: ledger,
+      eventStore,
+      readAuthStatus: () => ({ loggedIn: true, authMethod: "claude.ai", subscriptionType: "max" }),
+      readTranscript: () => [],
+      spawnProcess: fakeSpawn(child, {}),
+    });
+    const key = { engine: "claude" as const, sessionId: host.identity.sessionId };
+    registry.upsert({
+      key,
+      artifactPath: `/sessions/${host.identity.sessionId}.jsonl`,
+      cwd: "/repo",
+      accountId: null,
+      status: "idle",
+      host: null,
+      structuredHost: {
+        kind: "claude-broker",
+        endpoint: "stdio:5150",
+        process: { pid: 5150, startIdentity: null },
+        eventCursor: 1,
+        protocolVersion: null,
+        writerClaimEpoch: 1,
+        activeTurnRef: null,
+        pendingAttention: [],
+        activeFlags: [],
+      },
+      claimEpoch: 1,
+      claimOwner: "release-owner",
+      pendingAction: null,
+    });
+    await bindClaudeHostPersistence(registry, key, host, "release-owner", 1);
+    await host.release();
+    expect(eventStore.appendAttempts).toBe(2);
+    expect(registry.snapshot().entries[`claude:${host.identity.sessionId}`]).toMatchObject({
+      status: "unhosted",
+      claimOwner: null,
+      structuredHost: { process: null, endpoint: "stdio:released" },
     });
   });
 

--- a/src/lib/runtime/claudeStreamBrokerHost.test.ts
+++ b/src/lib/runtime/claudeStreamBrokerHost.test.ts
@@ -237,7 +237,12 @@ describe("ClaudeStreamBrokerHost", () => {
 
   test("retries a ledgered pre-actuation entry and confirms an actuated entry from transcript", async () => {
     const pendingLedger = new RecordingDeliveryLedger();
-    pendingLedger.recordQueued("pending-session", { id: "pending", text: "retry me" }, "turn-started");
+    const pendingEntry: QueueEntry = {
+      id: "pending",
+      text: "retry me",
+      expectedTurnId: "turn-before-crash",
+    };
+    pendingLedger.recordQueued("pending-session", pendingEntry, "queued-next-turn");
     const pendingChild = new FakeClaude(pendingLedger);
     const pending = await ClaudeStreamBrokerHost.adopt("pending-session", {
       cwd: "/repo",
@@ -247,9 +252,10 @@ describe("ClaudeStreamBrokerHost", () => {
       readTranscript: () => [],
       spawnProcess: fakeSpawn(pendingChild, {}),
     });
-    const retried = pending.send({ id: "pending", text: "retry me" });
+    expect((await pending.health()).activeTurnRef).toBeNull();
+    const retried = pending.send(pendingEntry);
     pendingChild.emitJson({ type: "user", session_id: "pending-session", uuid: "retried-user", message: { role: "user", content: [{ type: "text", text: "retry me" }] } });
-    expect(await retried).toEqual({ outcome: "turn-started", turnId: "pending" });
+    expect(await retried).toEqual({ outcome: "queued-next-turn", turnId: "pending" });
     expect(pendingChild.inputs.filter((input) => input.type === "user")).toHaveLength(1);
     await pending.release();
 
@@ -268,6 +274,47 @@ describe("ClaudeStreamBrokerHost", () => {
     expect(confirmedChild.inputs).toHaveLength(0);
     expect(confirmedLedger.order).toContain("confirmed:confirmed");
     await confirmed.release();
+  });
+
+  test("rejects a changed payload before retrying an undelivered ledger entry", async () => {
+    const sessionId = "immutable-pending-session";
+    const ledger = new RecordingDeliveryLedger();
+    ledger.recordQueued(sessionId, { id: "immutable-entry", text: "original" }, "turn-started");
+    const child = new FakeClaude(ledger);
+    const host = await ClaudeStreamBrokerHost.adopt(sessionId, {
+      cwd: "/repo",
+      deliveryLedger: ledger,
+      eventStore: new MemoryEventStore(),
+      readAuthStatus: () => ({ loggedIn: true, authMethod: "claude.ai", subscriptionType: "max" }),
+      readTranscript: () => [],
+      spawnProcess: fakeSpawn(child, {}),
+    });
+
+    await expect(host.send({ id: "immutable-entry", text: "changed" })).rejects.toThrow("different payload");
+    expect(child.inputs.filter((input) => input.type === "user")).toHaveLength(0);
+    await host.release();
+  });
+
+  test("rejects changed queue fields for an entry already confirmed delivered", async () => {
+    const sessionId = "immutable-delivered-session";
+    const original: QueueEntry = { id: "immutable-entry", text: "original", expectedTurnId: null };
+    const ledger = new RecordingDeliveryLedger();
+    ledger.recordQueued(sessionId, original, "turn-started");
+    const child = new FakeClaude(ledger);
+    const host = await ClaudeStreamBrokerHost.adopt(sessionId, {
+      cwd: "/repo",
+      deliveryLedger: ledger,
+      eventStore: new MemoryEventStore(),
+      readAuthStatus: () => ({ loggedIn: true, authMethod: "claude.ai", subscriptionType: "max" }),
+      readTranscript: () => [{ text: "original", uuid: "original-user", timestamp: new Date().toISOString() }],
+      spawnProcess: fakeSpawn(child, {}),
+    });
+
+    await expect(host.send({ ...original, text: "changed" })).rejects.toThrow("different payload");
+    await expect(host.send({ ...original, expectedTurnId: "changed-turn" })).rejects.toThrow("different payload");
+    expect(await host.send(original)).toEqual({ outcome: "turn-started", turnId: "immutable-entry" });
+    expect(child.inputs).toHaveLength(0);
+    await host.release();
   });
 
   test("host loss rejects an unconfirmed send and leaves retry ownership for adoption", async () => {
@@ -602,6 +649,8 @@ describe("ClaudeStreamBrokerHost", () => {
     const ledger = new FileClaudeDeliveryLedger(directory);
     ledger.recordQueued("durable", { id: "entry", text: "hello" }, "turn-started");
     ledger.confirmDelivered("durable", "entry", "engine-user");
+    expect(() => ledger.recordQueued("durable", { id: "entry", text: "changed" }, "turn-started"))
+      .toThrow("different payload");
     expect(new FileClaudeDeliveryLedger(directory).load("durable")).toMatchObject([{
       entry: { id: "entry", text: "hello" },
       disposition: "turn-started",

--- a/src/lib/runtime/claudeStreamBrokerHost.test.ts
+++ b/src/lib/runtime/claudeStreamBrokerHost.test.ts
@@ -215,6 +215,37 @@ describe("ClaudeStreamBrokerHost", () => {
     await host.release();
   });
 
+  test("preserves split UTF-8 replay text for delivery confirmation", async () => {
+    const ledger = new RecordingDeliveryLedger();
+    const child = new FakeClaude(ledger);
+    const host = await ClaudeStreamBrokerHost.start({
+      cwd: "/repo",
+      deliveryLedger: ledger,
+      eventStore: new MemoryEventStore(),
+      readAuthStatus: () => ({ loggedIn: true, authMethod: "claude.ai", subscriptionType: "max" }),
+      spawnProcess: fakeSpawn(child, {}),
+    });
+    let receipt: Awaited<ReturnType<typeof host.send>> | undefined;
+    const sent = host.send({ id: "utf8-replay", text: "привіт" }).then((value) => { receipt = value; });
+    const frame = Buffer.from(`${JSON.stringify({
+      type: "user",
+      isReplay: true,
+      session_id: host.identity.sessionId,
+      uuid: "utf8-user",
+      message: { role: "user", content: [{ type: "text", text: "привіт" }] },
+    })}\n`);
+    const textStart = frame.indexOf(Buffer.from("привіт"));
+    expect(textStart).toBeGreaterThanOrEqual(0);
+    child.stdout.write(frame.subarray(0, textStart + 1));
+    child.stdout.write(frame.subarray(textStart + 1));
+    await Bun.sleep(0);
+    const confirmed = receipt;
+    await host.release();
+    await sent.catch(() => {});
+
+    expect(confirmed).toEqual({ outcome: "turn-started", turnId: "utf8-replay" });
+  });
+
   test("queues ordinary active-turn sends and resumes the same durable session", async () => {
     const ledger = new RecordingDeliveryLedger();
     const eventStore = new MemoryEventStore();

--- a/src/lib/runtime/claudeStreamBrokerHost.test.ts
+++ b/src/lib/runtime/claudeStreamBrokerHost.test.ts
@@ -1,4 +1,5 @@
 import { EventEmitter } from "node:events";
+import { spawn } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -7,6 +8,7 @@ import type { ChildProcessWithoutNullStreams, SpawnOptionsWithoutStdio } from "n
 import { describe, expect, spyOn, test } from "bun:test";
 
 import { AgentRegistry } from "@/lib/agent/registry";
+import { procBackend } from "@/lib/proc";
 
 import {
   ClaudeStreamBrokerHost,
@@ -648,6 +650,80 @@ describe("ClaudeStreamBrokerHost", () => {
       structuredHost: { endpoint: "stdio:released", process: null },
     });
   });
+
+  test("boot adoption reaps a surviving orphaned Claude child before resume", async () => {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-claude-orphan-adoption-"));
+    const registry = new AgentRegistry(path.join(directory, "agent-registry.json"));
+    const sessionId = "orphaned-claude-session";
+    const orphan = spawn(process.execPath, [
+      "-e",
+      "process.on('SIGTERM', () => {}); setInterval(() => {}, 1000)",
+    ], { stdio: "ignore" });
+    const orphanExit = new Promise<void>((resolve) => { orphan.once("exit", () => resolve()); });
+    let startIdentity: string | null = null;
+    for (let attempt = 0; attempt < 100 && !startIdentity; attempt += 1) {
+      startIdentity = orphan.pid ? procBackend.processIdentity(orphan.pid) : null;
+      if (!startIdentity) await Bun.sleep(2);
+    }
+    if (!orphan.pid || !startIdentity) {
+      try { orphan.kill("SIGKILL"); } catch { /* already exited */ }
+      await orphanExit;
+      throw new Error("orphan test process identity is unavailable");
+    }
+    registry.upsert({
+      key: { engine: "claude", sessionId },
+      artifactPath: `/sessions/${sessionId}.jsonl`,
+      cwd: "/repo",
+      accountId: null,
+      status: "live",
+      host: null,
+      structuredHost: {
+        kind: "claude-broker",
+        endpoint: `stdio:${orphan.pid}`,
+        process: { pid: orphan.pid, startIdentity },
+        eventCursor: 2,
+        protocolVersion: "2.1.197",
+        writerClaimEpoch: 1,
+        activeTurnRef: null,
+        pendingAttention: [],
+        activeFlags: [],
+      },
+      claimEpoch: 1,
+      claimOwner: null,
+      pendingAction: null,
+    });
+    const ledger = new RecordingDeliveryLedger();
+    const replacement = new FakeClaude(ledger);
+    let optionsCalls = 0;
+    let adopted: Awaited<ReturnType<typeof adoptClaudeRegistryHosts>> = [];
+    try {
+      adopted = await adoptClaudeRegistryHosts(
+        registry,
+        () => {
+          optionsCalls += 1;
+          return {
+            cwd: "/repo",
+            deliveryLedger: ledger,
+            eventStore: new MemoryEventStore(),
+            readAuthStatus: () => ({ loggedIn: true, authMethod: "claude.ai", subscriptionType: "max" }),
+            readTranscript: () => [],
+            spawnProcess: fakeSpawn(replacement, {}),
+          };
+        },
+        { NODE_ENV: "test", LLV_STRUCTURED_HOSTS: "1" },
+      );
+    } finally {
+      if (procBackend.processIdentity(orphan.pid) === startIdentity) {
+        try { orphan.kill("SIGKILL"); } catch { /* already exited */ }
+      }
+      await Promise.race([orphanExit, Bun.sleep(2_000)]);
+    }
+
+    expect(adopted).toHaveLength(1);
+    expect(optionsCalls).toBe(1);
+    expect(procBackend.processIdentity(orphan.pid)).not.toBe(startIdentity);
+    await adopted[0]!.host.release();
+  }, 10_000);
 
   test("protocol failure reaps a TERM-resistant child and releases its writer claim", async () => {
     const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-claude-failure-claim-"));

--- a/src/lib/runtime/claudeStreamBrokerHost.ts
+++ b/src/lib/runtime/claudeStreamBrokerHost.ts
@@ -1,0 +1,750 @@
+import { spawn, spawnSync } from "node:child_process";
+import type { ChildProcessWithoutNullStreams, SpawnOptionsWithoutStdio } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+
+import { statePath } from "@/lib/configDir";
+import { procBackend } from "@/lib/proc";
+import { hardenedRedact } from "@/lib/view/compactText";
+
+import type { DeliveryReceipt, EngineHost, HostState, QueueEntry, RuntimeEvent } from "./engineHost";
+import { RuntimeReplayGapError } from "./engineHost";
+import { FileRuntimeEventStore, type RuntimeEventStore } from "./eventStore";
+
+type JsonObject = Record<string, unknown>;
+type Subscriber = { afterSeq: number; queue: RuntimeEvent[]; wake: (() => void) | null; closed: boolean };
+type UnsequencedEvent = RuntimeEvent extends infer Event
+  ? Event extends RuntimeEvent ? Omit<Event, "seq"> : never
+  : never;
+type PendingControl = {
+  resolve(): void;
+  reject(error: Error): void;
+  timer: ReturnType<typeof setTimeout>;
+};
+
+export interface ClaudeDeliveryState {
+  entry: QueueEntry;
+  disposition: "turn-started" | "queued-next-turn";
+  delivered: boolean;
+  queuedAt?: string;
+  engineMessageId?: string | null;
+}
+
+export interface ClaudeDeliveryLedger {
+  load(sessionId: string): ClaudeDeliveryState[];
+  recordQueued(sessionId: string, entry: QueueEntry, disposition: ClaudeDeliveryState["disposition"]): void;
+  confirmDelivered(sessionId: string, entryId: string, engineMessageId: string | null): void;
+}
+
+type ClaudeDeliveryRecord =
+  | { kind: "queued"; entry: QueueEntry; disposition: ClaudeDeliveryState["disposition"]; queuedAt: string }
+  | { kind: "delivered"; entryId: string; engineMessageId: string | null; deliveredAt: string };
+
+export class FileClaudeDeliveryLedger implements ClaudeDeliveryLedger {
+  constructor(private readonly directory = statePath("claude-delivery-ledger")) {}
+
+  load(sessionId: string): ClaudeDeliveryState[] {
+    const records = this.readRecords(sessionId);
+    const states: ClaudeDeliveryState[] = [];
+    for (const record of records) {
+      if (record.kind === "queued") {
+        if (states.some((state) => state.entry.id === record.entry.id)) continue;
+        states.push({
+          entry: record.entry,
+          disposition: record.disposition,
+          queuedAt: record.queuedAt,
+          delivered: false,
+        });
+      } else {
+        const state = states.find((candidate) => candidate.entry.id === record.entryId);
+        if (state) {
+          state.delivered = true;
+          state.engineMessageId = record.engineMessageId;
+        }
+      }
+    }
+    return states;
+  }
+
+  recordQueued(sessionId: string, entry: QueueEntry, disposition: ClaudeDeliveryState["disposition"]): void {
+    if (this.load(sessionId).some((state) => state.entry.id === entry.id)) return;
+    this.append(sessionId, { kind: "queued", entry, disposition, queuedAt: new Date().toISOString() });
+  }
+
+  confirmDelivered(sessionId: string, entryId: string, engineMessageId: string | null): void {
+    const state = this.load(sessionId).find((candidate) => candidate.entry.id === entryId);
+    if (!state || state.delivered) return;
+    this.append(sessionId, { kind: "delivered", entryId, engineMessageId, deliveredAt: new Date().toISOString() });
+  }
+
+  private readRecords(sessionId: string): ClaudeDeliveryRecord[] {
+    let contents: string;
+    try { contents = fs.readFileSync(this.filename(sessionId), "utf8"); }
+    catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") return [];
+      throw error;
+    }
+    const records: ClaudeDeliveryRecord[] = [];
+    const lines = contents.split("\n");
+    const terminated = contents.endsWith("\n");
+    for (const [index, line] of lines.entries()) {
+      if (!line && index === lines.length - 1 && terminated) continue;
+      if (!line) throw new Error("Claude delivery ledger contains an empty record");
+      let value: unknown;
+      try { value = JSON.parse(line); }
+      catch {
+        if (index === lines.length - 1 && !terminated) break;
+        throw new Error("Claude delivery ledger contains malformed JSON");
+      }
+      const record = deliveryRecord(value);
+      if (!record) {
+        if (index === lines.length - 1 && !terminated) break;
+        throw new Error("Claude delivery ledger contains an invalid record");
+      }
+      records.push(record);
+    }
+    return records;
+  }
+
+  private append(sessionId: string, record: ClaudeDeliveryRecord): void {
+    fs.mkdirSync(this.directory, { recursive: true, mode: 0o700 });
+    const filename = this.filename(sessionId);
+    const fd = fs.openSync(filename, "a+", 0o600);
+    try {
+      fs.fchmodSync(fd, 0o600);
+      repairJsonlTail(fd, filename, deliveryRecord);
+      fs.writeSync(fd, `${JSON.stringify(record)}\n`);
+      fs.fsyncSync(fd);
+    } finally {
+      fs.closeSync(fd);
+    }
+  }
+
+  private filename(sessionId: string): string {
+    return path.join(this.directory, `${encodeURIComponent(sessionId)}.jsonl`);
+  }
+}
+
+export interface ClaudeAuthStatus {
+  loggedIn: boolean;
+  authMethod: string | null;
+  subscriptionType: string | null;
+  version?: string | null;
+}
+
+export interface ClaudeSessionIdentity { sessionId: string }
+
+export interface ClaudeStreamBrokerHostOptions {
+  cwd: string;
+  binary?: string;
+  model?: string;
+  effort?: string;
+  systemPrompt?: string;
+  permissionMode?: string;
+  tools?: string[];
+  env?: NodeJS.ProcessEnv;
+  requestTimeoutMs?: number;
+  shutdownGraceMs?: number;
+  initialEventCursor?: number;
+  spawnProcess?: (command: string, args: string[], options: SpawnOptionsWithoutStdio) => ChildProcessWithoutNullStreams;
+  readAuthStatus?: () => ClaudeAuthStatus | Promise<ClaudeAuthStatus>;
+  readTranscript?: (cwd: string, sessionId: string) => ClaudeTranscriptUser[];
+  eventStore?: RuntimeEventStore;
+  deliveryLedger?: ClaudeDeliveryLedger;
+}
+
+export interface ClaudeTranscriptUser {
+  text: string;
+  uuid: string | null;
+  timestamp: string | null;
+}
+
+const CHILD_ENV_ALLOWLIST = [
+  "PATH", "HOME", "USER", "LOGNAME", "SHELL", "TMPDIR", "TMP", "TEMP", "LANG",
+  "LC_ALL", "LC_CTYPE", "TERM", "COLORTERM", "NO_COLOR", "XDG_CONFIG_HOME",
+  "XDG_CACHE_HOME", "XDG_DATA_HOME", "XDG_STATE_HOME", "XDG_RUNTIME_DIR",
+  "DBUS_SESSION_BUS_ADDRESS", "SSL_CERT_FILE", "SSL_CERT_DIR",
+] as const;
+const DEFAULT_TIMEOUT_MS = 30_000;
+const DEFAULT_SHUTDOWN_GRACE_MS = 1_000;
+const MAX_LINE_BYTES = 4 * 1024 * 1024;
+
+function record(value: unknown): JsonObject | null {
+  return value && typeof value === "object" && !Array.isArray(value) ? value as JsonObject : null;
+}
+
+function stringField(value: unknown, key: string): string | null {
+  const object = record(value);
+  return object && typeof object[key] === "string" ? object[key] as string : null;
+}
+
+function deliveryRecord(value: unknown): ClaudeDeliveryRecord | null {
+  const candidate = record(value);
+  if (candidate?.kind === "queued") {
+    const entry = record(candidate.entry);
+    if (typeof entry?.id !== "string" || !entry.id || typeof entry.text !== "string" || !entry.text) return null;
+    if (candidate.disposition !== "turn-started" && candidate.disposition !== "queued-next-turn") return null;
+    if (typeof candidate.queuedAt !== "string") return null;
+    return candidate as unknown as ClaudeDeliveryRecord;
+  }
+  if (candidate?.kind === "delivered"
+    && typeof candidate.entryId === "string"
+    && (typeof candidate.engineMessageId === "string" || candidate.engineMessageId === null)
+    && typeof candidate.deliveredAt === "string") return candidate as unknown as ClaudeDeliveryRecord;
+  return null;
+}
+
+function repairJsonlTail<T>(fd: number, filename: string, validate: (value: unknown) => T | null): void {
+  const size = fs.fstatSync(fd).size;
+  if (size === 0) return;
+  const contents = fs.readFileSync(filename, "utf8");
+  if (contents.endsWith("\n")) return;
+  const boundary = contents.lastIndexOf("\n") + 1;
+  const tail = contents.slice(boundary);
+  let parsed: unknown;
+  try { parsed = JSON.parse(tail); } catch { parsed = null; }
+  if (validate(parsed)) fs.writeSync(fd, "\n");
+  else fs.ftruncateSync(fd, Buffer.byteLength(contents.slice(0, boundary)));
+}
+
+export function redactClaudeHostDiagnostic(value: unknown): string {
+  return hardenedRedact(value instanceof Error ? value.message : String(value))
+    .replace(/(["']?(?:cookie|set-cookie)["']?\s*[:=]\s*["']?)[^\s,"'}]+/gi, "$1[redacted]")
+    .slice(0, 500);
+}
+
+const safeError = redactClaudeHostDiagnostic;
+
+function subscriptionEnv(source: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = { NODE_ENV: source.NODE_ENV };
+  for (const name of CHILD_ENV_ALLOWLIST) if (source[name] !== undefined) env[name] = source[name];
+  return env;
+}
+
+function defaultAuthStatus(binary: string, env: NodeJS.ProcessEnv, cwd: string): ClaudeAuthStatus {
+  const result = spawnSync(binary, ["auth", "status"], { cwd, env, encoding: "utf8" });
+  if (result.status !== 0) throw new Error("Claude subscription authentication check failed");
+  let value: JsonObject | null = null;
+  try { value = record(JSON.parse(result.stdout)); } catch { /* handled below */ }
+  if (!value) throw new Error("Claude subscription authentication status was invalid");
+  const versionResult = spawnSync(binary, ["--version"], { cwd, env, encoding: "utf8" });
+  const version = versionResult.status === 0 ? versionResult.stdout.match(/\b\d+\.\d+\.\d+\b/)?.[0] ?? null : null;
+  return {
+    loggedIn: value.loggedIn === true,
+    authMethod: typeof value.authMethod === "string" ? value.authMethod : null,
+    subscriptionType: typeof value.subscriptionType === "string" ? value.subscriptionType : null,
+    version,
+  };
+}
+
+function textContent(value: unknown): string {
+  if (typeof value === "string") return value;
+  if (!Array.isArray(value)) return "";
+  return value.map((part) => stringField(part, "text") ?? "").join("");
+}
+
+function userText(message: JsonObject): string {
+  return textContent(record(message.message)?.content);
+}
+
+function defaultTranscriptUsers(cwd: string, sessionId: string): ClaudeTranscriptUser[] {
+  const project = cwd.replace(/[^A-Za-z0-9]/g, "-");
+  const filename = path.join(process.env.HOME ?? "", ".claude", "projects", project, `${sessionId}.jsonl`);
+  let contents: string;
+  try { contents = fs.readFileSync(filename, "utf8"); }
+  catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return [];
+    throw error;
+  }
+  const users: ClaudeTranscriptUser[] = [];
+  for (const line of contents.split("\n")) {
+    if (!line) continue;
+    let value: JsonObject | null = null;
+    try { value = record(JSON.parse(line)); } catch { continue; }
+    if (value?.type !== "user" || record(value.message)?.role !== "user") continue;
+    users.push({
+      text: userText(value),
+      uuid: stringField(value, "uuid"),
+      timestamp: stringField(value, "timestamp"),
+    });
+  }
+  return users;
+}
+
+/** One durable writer around a long-lived Claude stream-json process. */
+export class ClaudeStreamBrokerHost implements EngineHost {
+  readonly identity: ClaudeSessionIdentity;
+
+  private readonly child: ChildProcessWithoutNullStreams;
+  private readonly eventStore: RuntimeEventStore;
+  private readonly deliveryLedger: ClaudeDeliveryLedger;
+  private readonly requestTimeoutMs: number;
+  private readonly shutdownGraceMs: number;
+  private readonly subscribers = new Set<Subscriber>();
+  private readonly events: RuntimeEvent[] = [];
+  private readonly deliveries: ClaudeDeliveryState[] = [];
+  private readonly turnQueue: string[] = [];
+  private readonly attentions = new Map<string, JsonObject>();
+  private readonly pendingControls = new Map<string, PendingControl>();
+  private readonly actuatedIds = new Set<string>();
+  private readonly stateListeners = new Set<(state: HostState) => void>();
+  private stdoutBuffer = "";
+  private cursor: number;
+  private activeTurnId: string | null = null;
+  private protocolVersion: string | null;
+  private account: HostState["account"];
+  private releasing = false;
+  private released = false;
+  private dead = false;
+  private reaped = false;
+  private ledgerFailed = false;
+  private writerFence: (() => boolean) | null = null;
+  private releasePromise: Promise<void> | null = null;
+  private terminationTimer: ReturnType<typeof setTimeout> | null = null;
+  private readonly reapedPromise: Promise<void>;
+  private resolveReaped!: () => void;
+
+  private constructor(
+    child: ChildProcessWithoutNullStreams,
+    identity: ClaudeSessionIdentity,
+    auth: ClaudeAuthStatus,
+    options: ClaudeStreamBrokerHostOptions,
+  ) {
+    this.child = child;
+    this.identity = identity;
+    this.eventStore = options.eventStore ?? new FileRuntimeEventStore();
+    this.deliveryLedger = options.deliveryLedger ?? new FileClaudeDeliveryLedger();
+    this.requestTimeoutMs = options.requestTimeoutMs ?? DEFAULT_TIMEOUT_MS;
+    this.shutdownGraceMs = options.shutdownGraceMs ?? DEFAULT_SHUTDOWN_GRACE_MS;
+    this.cursor = options.initialEventCursor ?? 0;
+    this.protocolVersion = auth.version ?? null;
+    this.account = { type: auth.authMethod, planType: auth.subscriptionType };
+    this.reapedPromise = new Promise((resolve) => { this.resolveReaped = resolve; });
+    child.stdout.on("data", (chunk: Buffer | string) => this.acceptStdout(String(chunk)));
+    child.stderr.on("data", () => { /* Provider diagnostics may contain credentials. */ });
+    child.stdin.on("error", (error) => {
+      if (!this.releasing && !this.released) this.fail(new Error(`Claude stream stdin failed: ${safeError(error)}`));
+    });
+    child.on("error", (error) => this.fail(new Error(`Claude child failed: ${safeError(error)}`)));
+    child.on("close", () => {
+      this.reaped = true;
+      if (this.terminationTimer) clearTimeout(this.terminationTimer);
+      this.resolveReaped();
+      if (!this.releasing && !this.released && !this.dead) this.fail(new Error("Claude child exited"));
+    });
+  }
+
+  static async start(options: ClaudeStreamBrokerHostOptions): Promise<ClaudeStreamBrokerHost> {
+    return this.open(crypto.randomUUID(), false, options);
+  }
+
+  static async adopt(sessionId: string, options: ClaudeStreamBrokerHostOptions): Promise<ClaudeStreamBrokerHost> {
+    if (!sessionId) throw new Error("Claude session id is required for adoption");
+    return this.open(sessionId, true, options);
+  }
+
+  private static async open(
+    sessionId: string,
+    resume: boolean,
+    options: ClaudeStreamBrokerHostOptions,
+  ): Promise<ClaudeStreamBrokerHost> {
+    const binary = options.binary ?? process.env.LLV_CLAUDE_BINARY ?? "claude";
+    const env = subscriptionEnv(options.env ?? process.env);
+    const auth = await (options.readAuthStatus?.() ?? defaultAuthStatus(binary, env, options.cwd));
+    if (!auth.loggedIn || auth.authMethod !== "claude.ai" || !auth.subscriptionType) {
+      throw new Error("Claude stream hosting requires a claude.ai subscription login");
+    }
+    const args = [
+      "-p", "--input-format", "stream-json", "--output-format", "stream-json", "--verbose",
+      "--safe-mode", "--include-partial-messages", "--replay-user-messages",
+      "--permission-mode", options.permissionMode ?? "default",
+    ];
+    if (resume) args.push("--resume", sessionId);
+    else args.push("--session-id", sessionId);
+    if (options.model) args.push("--model", options.model);
+    if (options.effort) args.push("--effort", options.effort);
+    if (options.systemPrompt) args.push("--system-prompt", options.systemPrompt);
+    if (options.tools) args.push("--tools", options.tools.join(","));
+    const spawnProcess = options.spawnProcess ?? ((command, childArgs, spawnOptions) =>
+      spawn(command, childArgs, { ...spawnOptions, stdio: ["pipe", "pipe", "pipe"] }));
+    const child = spawnProcess(binary, args, { cwd: options.cwd, env });
+    const host = new ClaudeStreamBrokerHost(child, { sessionId }, auth, options);
+    try {
+      host.restore();
+      host.reconcileTranscript((options.readTranscript ?? defaultTranscriptUsers)(options.cwd, sessionId));
+      host.emit({ kind: "session-status", status: "idle" });
+      return host;
+    } catch (error) {
+      await host.release();
+      throw new Error(safeError(error));
+    }
+  }
+
+  attach(afterSeq: number): AsyncIterable<RuntimeEvent> {
+    if (!Number.isSafeInteger(afterSeq) || afterSeq < 0) throw new Error("afterSeq must be a non-negative integer");
+    const firstAvailable = this.events[0]?.seq;
+    if (firstAvailable !== undefined && afterSeq + 1 < firstAvailable) {
+      throw new RuntimeReplayGapError(afterSeq, firstAvailable);
+    }
+    const subscriber: Subscriber = { afterSeq, queue: this.events.filter((event) => event.seq > afterSeq), wake: null, closed: false };
+    this.subscribers.add(subscriber);
+    const subscribers = this.subscribers;
+    return {
+      async *[Symbol.asyncIterator]() {
+        try {
+          while (true) {
+            const event = subscriber.queue.shift();
+            if (event) {
+              if (event.seq > subscriber.afterSeq) {
+                subscriber.afterSeq = event.seq;
+                yield event;
+              }
+              continue;
+            }
+            if (subscriber.closed) break;
+            await new Promise<void>((resolve) => { subscriber.wake = resolve; });
+            subscriber.wake = null;
+          }
+        } finally {
+          subscriber.closed = true;
+          subscribers.delete(subscriber);
+        }
+      },
+    };
+  }
+
+  async send(entry: QueueEntry): Promise<DeliveryReceipt> {
+    if (this.unavailable()) return { outcome: "rejected", reason: "dead-host" };
+    if (!entry.id || !entry.text) throw new Error("queue entry id and text are required");
+    if (entry.expectedTurnId !== undefined && entry.expectedTurnId !== this.activeTurnId) {
+      return { outcome: "rejected", reason: "stale-turn" };
+    }
+    const duplicate = this.deliveries.find((state) => state.entry.id === entry.id);
+    if (duplicate?.delivered || (duplicate && this.actuatedIds.has(entry.id))) {
+      return { outcome: duplicate.disposition, turnId: duplicate.entry.id };
+    }
+    const disposition: ClaudeDeliveryState["disposition"] = duplicate?.disposition
+      ?? (this.activeTurnId ? "queued-next-turn" : "turn-started");
+    try {
+      this.deliveryLedger.recordQueued(this.identity.sessionId, entry, disposition);
+    } catch (error) {
+      this.failWithoutLedger(new Error(`Claude delivery ledger failed: ${safeError(error)}`));
+      throw new Error(`Claude delivery ledger failed: ${safeError(error)}`);
+    }
+    const delivery: ClaudeDeliveryState = duplicate
+      ?? { entry: structuredClone(entry), disposition, delivered: false };
+    if (!duplicate) this.deliveries.push(delivery);
+    this.write({
+      type: "user",
+      session_id: this.identity.sessionId,
+      message: { role: "user", content: [{ type: "text", text: entry.text }] },
+    });
+    this.actuatedIds.add(entry.id);
+    this.turnQueue.push(entry.id);
+    if (!this.activeTurnId) {
+      this.activeTurnId = entry.id;
+      this.emit({ kind: "turn-started", turnId: entry.id });
+    } else {
+      this.notifyStateListeners();
+    }
+    return { outcome: disposition, turnId: entry.id };
+  }
+
+  async interrupt(turnRef: string): Promise<void> {
+    if (this.unavailable()) throw new Error("Claude stream host is unavailable");
+    if (!turnRef || turnRef !== this.activeTurnId) throw new Error("active turn fence is stale");
+    const requestId = crypto.randomUUID();
+    await new Promise<void>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.pendingControls.delete(requestId);
+        const error = new Error("Claude interrupt timed out; outcome is uncertain");
+        reject(error);
+        this.fail(error);
+      }, this.requestTimeoutMs);
+      this.pendingControls.set(requestId, { resolve, reject, timer });
+      this.write({ type: "control_request", request_id: requestId, request: { subtype: "interrupt" } });
+    });
+  }
+
+  async answer(attentionRef: string, value: unknown): Promise<void> {
+    if (this.unavailable()) throw new Error("Claude stream host is unavailable");
+    if (!this.attentions.has(attentionRef)) throw new Error("attention request is missing or already answered");
+    this.write({
+      type: "control_response",
+      response: { subtype: "success", request_id: attentionRef, response: value ?? {} },
+    });
+    this.attentions.delete(attentionRef);
+    this.emit({ kind: "attention-resolved", id: attentionRef, resolution: "answered" });
+  }
+
+  async health(): Promise<HostState> { return this.currentState(); }
+
+  onStateChange(listener: (state: HostState) => void): () => void {
+    this.stateListeners.add(listener);
+    listener(this.currentState());
+    return () => this.stateListeners.delete(listener);
+  }
+
+  setWriterFence(fence: () => boolean): void { this.writerFence = fence; }
+
+  async release(): Promise<void> {
+    this.releasePromise ??= this.releaseAndReap();
+    return this.releasePromise;
+  }
+
+  private unavailable(): boolean {
+    if (this.dead || this.releasing || this.released) return true;
+    try { return this.writerFence?.() === false; } catch { return true; }
+  }
+
+  private currentState(): HostState {
+    const pid = this.reaped || this.released ? null : this.child.pid ?? null;
+    const status: HostState["status"] = this.dead ? "dead"
+      : this.released ? "unhosted"
+      : this.attentions.size ? "attention"
+      : this.activeTurnId ? "active"
+      : "idle";
+    return {
+      status,
+      sessionKey: this.identity.sessionId,
+      endpoint: pid ? `stdio:${pid}` : "stdio:released",
+      pid,
+      processStartIdentity: pid ? procBackend.processIdentity(pid) : null,
+      eventCursor: this.cursor,
+      protocolVersion: this.protocolVersion,
+      activeTurnRef: this.activeTurnId,
+      pendingAttention: [...this.attentions.keys()],
+      activeFlags: [],
+      account: this.account,
+    };
+  }
+
+  private restore(): void {
+    const stored = this.eventStore.load(this.identity.sessionId);
+    this.events.push(...stored);
+    this.cursor = Math.max(this.cursor, stored.at(-1)?.seq ?? 0);
+    this.deliveries.push(...this.deliveryLedger.load(this.identity.sessionId));
+    let restoredTurn: string | null = null;
+    for (const event of stored) {
+      if (event.kind === "turn-started") restoredTurn = event.turnId;
+      if (event.kind === "turn-ended" && event.turnId === restoredTurn) restoredTurn = null;
+      if (event.kind === "attention") this.attentions.set(event.id, record(event.attention) ?? {});
+      if (event.kind === "attention-resolved") this.attentions.delete(event.id);
+      if (event.kind === "session-status" && (event.status === "dead" || event.status === "unhosted")) {
+        restoredTurn = null;
+        this.attentions.clear();
+      }
+    }
+    if (restoredTurn) this.emit({ kind: "turn-ended", turnId: restoredTurn, status: "error" });
+    for (const attentionId of this.attentions.keys()) {
+      this.emit({ kind: "attention-resolved", id: attentionId, resolution: "host-restarted" });
+    }
+    this.attentions.clear();
+  }
+
+  private reconcileTranscript(users: ClaudeTranscriptUser[]): void {
+    const unmatched = [...users];
+    for (const delivery of this.deliveries) {
+      if (delivery.delivered) continue;
+      const queuedAt = delivery.queuedAt ? Date.parse(delivery.queuedAt) : Number.NEGATIVE_INFINITY;
+      const index = unmatched.findIndex((user) => {
+        const timestamp = user.timestamp ? Date.parse(user.timestamp) : Number.POSITIVE_INFINITY;
+        return user.text === delivery.entry.text && timestamp >= queuedAt;
+      });
+      if (index < 0) continue;
+      const [user] = unmatched.splice(index, 1);
+      this.deliveryLedger.confirmDelivered(this.identity.sessionId, delivery.entry.id, user?.uuid ?? null);
+      delivery.delivered = true;
+      delivery.engineMessageId = user?.uuid ?? null;
+    }
+  }
+
+  private emit(event: UnsequencedEvent): void {
+    if (this.ledgerFailed) return;
+    const sequenced = { ...event, seq: ++this.cursor } as RuntimeEvent;
+    try { this.eventStore.append(this.identity.sessionId, sequenced); }
+    catch (error) {
+      this.cursor = this.events.at(-1)?.seq ?? Math.max(0, this.cursor - 1);
+      this.ledgerFailed = true;
+      this.failWithoutLedger(new Error(`runtime event ledger failed: ${safeError(error)}`));
+      return;
+    }
+    this.events.push(sequenced);
+    for (const subscriber of this.subscribers) {
+      subscriber.queue.push(sequenced);
+      subscriber.wake?.();
+    }
+    this.notifyStateListeners();
+  }
+
+  private acceptStdout(chunk: string): void {
+    if (this.dead || this.released) return;
+    this.stdoutBuffer += chunk;
+    let newline = this.stdoutBuffer.indexOf("\n");
+    while (newline >= 0) {
+      const line = this.stdoutBuffer.slice(0, newline);
+      this.stdoutBuffer = this.stdoutBuffer.slice(newline + 1);
+      if (Buffer.byteLength(line) > MAX_LINE_BYTES) return this.fail(new Error("Claude emitted an oversized JSONL frame"));
+      if (line) this.acceptMessage(line);
+      if (this.dead) return;
+      newline = this.stdoutBuffer.indexOf("\n");
+    }
+    if (Buffer.byteLength(this.stdoutBuffer) > MAX_LINE_BYTES) this.fail(new Error("Claude emitted an oversized JSONL frame"));
+  }
+
+  private acceptMessage(line: string): void {
+    let message: JsonObject | null = null;
+    try { message = record(JSON.parse(line)); } catch { /* handled below */ }
+    if (!message) return this.fail(new Error("Claude emitted malformed stream JSON"));
+    const type = stringField(message, "type");
+    const sessionId = stringField(message, "session_id");
+    if (sessionId && sessionId !== this.identity.sessionId) return this.fail(new Error("Claude emitted a different session id"));
+    if (type === "system" && message.subtype === "init") {
+      if (message.apiKeySource !== "none") return this.fail(new Error("Claude stream process did not use subscription OAuth"));
+      return;
+    }
+    if (type === "user") {
+      const text = userText(message);
+      const delivery = this.deliveries.find((candidate) => !candidate.delivered && candidate.entry.text === text);
+      if (delivery) {
+        try {
+          this.deliveryLedger.confirmDelivered(this.identity.sessionId, delivery.entry.id, stringField(message, "uuid"));
+          delivery.delivered = true;
+          delivery.engineMessageId = stringField(message, "uuid");
+        } catch (error) {
+          return this.failWithoutLedger(new Error(`Claude delivery ledger failed: ${safeError(error)}`));
+        }
+      }
+      this.emit({ kind: "item", turnId: this.activeTurnId, item: message, phase: "completed" });
+      return;
+    }
+    if (type === "stream_event") {
+      const event = record(message.event);
+      const delta = record(event?.delta);
+      const text = stringField(delta, "text");
+      if (event?.type === "content_block_delta" && text !== null) {
+        this.emit({ kind: "delta", turnId: this.activeTurnId ?? "unknown", text });
+      }
+      return;
+    }
+    if (type === "assistant") {
+      const text = textContent(record(message.message)?.content);
+      if (text) this.emit({ kind: "delta", turnId: this.activeTurnId ?? "unknown", text });
+      this.emit({ kind: "item", turnId: this.activeTurnId, item: message, phase: "completed" });
+      return;
+    }
+    if (type === "control_request") {
+      const requestId = stringField(message, "request_id");
+      if (!requestId) return this.fail(new Error("Claude control request had no request id"));
+      const request = record(message.request) ?? {};
+      this.attentions.set(requestId, request);
+      this.emit({ kind: "attention", id: requestId, method: stringField(request, "subtype") ?? "control_request", attention: request });
+      return;
+    }
+    if (type === "control_response") {
+      const response = record(message.response) ?? message;
+      const requestId = stringField(response, "request_id");
+      if (!requestId) return;
+      const pending = this.pendingControls.get(requestId);
+      if (!pending) return;
+      clearTimeout(pending.timer);
+      this.pendingControls.delete(requestId);
+      if (response.subtype === "error") pending.reject(new Error("Claude control request failed"));
+      else pending.resolve();
+      return;
+    }
+    if (type === "result") this.acceptResult(message);
+  }
+
+  private acceptResult(message: JsonObject): void {
+    const turnId = this.turnQueue.shift() ?? this.activeTurnId;
+    if (!turnId) return;
+    const status = message.subtype === "success" ? "completed" : message.subtype === "interrupted" ? "interrupted" : "error";
+    this.emit({ kind: "turn-ended", turnId, status });
+    this.activeTurnId = this.turnQueue[0] ?? null;
+    if (this.activeTurnId) this.emit({ kind: "turn-started", turnId: this.activeTurnId });
+    else this.emit({ kind: "session-status", status: "idle" });
+  }
+
+  private write(message: JsonObject): void {
+    try { this.child.stdin.write(`${JSON.stringify(message)}\n`); }
+    catch (error) {
+      const failure = new Error(`Claude stream stdin failed: ${safeError(error)}`);
+      this.fail(failure);
+      throw failure;
+    }
+  }
+
+  private async releaseAndReap(): Promise<void> {
+    this.releasing = true;
+    this.rejectPending(new Error("Claude stream host released"));
+    try { this.child.stdin.end(); } catch { /* already closed */ }
+    try { this.child.kill("SIGTERM"); } catch { /* already closed */ }
+    if (!await this.waitForReap(this.shutdownGraceMs)) {
+      try { this.child.kill("SIGKILL"); } catch { /* already closed */ }
+      if (!await this.waitForReap(this.shutdownGraceMs)) throw new Error("Claude child could not be reaped");
+    }
+    this.released = true;
+    this.releasing = false;
+    this.activeTurnId = null;
+    this.attentions.clear();
+    this.emit({ kind: "session-status", status: "unhosted" });
+    this.closeSubscribers();
+  }
+
+  private async waitForReap(timeoutMs: number): Promise<boolean> {
+    if (this.reaped) return true;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    try {
+      return await Promise.race([
+        this.reapedPromise.then(() => true),
+        new Promise<false>((resolve) => { timer = setTimeout(() => resolve(false), timeoutMs); }),
+      ]);
+    } finally {
+      if (timer) clearTimeout(timer);
+    }
+  }
+
+  private fail(error: Error): void {
+    if (this.dead || this.released) return;
+    this.dead = true;
+    this.activeTurnId = null;
+    this.attentions.clear();
+    this.rejectPending(error);
+    this.emit({ kind: "session-status", status: "dead" });
+    this.closeSubscribers();
+    try { this.child.kill("SIGTERM"); } catch { /* already closed */ }
+  }
+
+  private failWithoutLedger(error: Error): void {
+    if (this.dead || this.released) return;
+    this.ledgerFailed = true;
+    this.dead = true;
+    this.activeTurnId = null;
+    this.attentions.clear();
+    this.rejectPending(error);
+    this.notifyStateListeners();
+    this.closeSubscribers();
+    try { this.child.kill("SIGTERM"); } catch { /* already closed */ }
+  }
+
+  private rejectPending(error: Error): void {
+    for (const pending of this.pendingControls.values()) {
+      clearTimeout(pending.timer);
+      pending.reject(new Error(safeError(error)));
+    }
+    this.pendingControls.clear();
+  }
+
+  private closeSubscribers(): void {
+    for (const subscriber of this.subscribers) {
+      subscriber.closed = true;
+      subscriber.wake?.();
+    }
+  }
+
+  private notifyStateListeners(): void {
+    const state = this.currentState();
+    for (const listener of this.stateListeners) listener(state);
+  }
+}

--- a/src/lib/runtime/claudeStreamBrokerHost.ts
+++ b/src/lib/runtime/claudeStreamBrokerHost.ts
@@ -4,6 +4,7 @@ import fs from "node:fs";
 import path from "node:path";
 
 import { statePath } from "@/lib/configDir";
+import { claudeTranscriptPath } from "@/lib/agent/transcript";
 import { procBackend } from "@/lib/proc";
 import { hardenedRedact } from "@/lib/view/compactText";
 
@@ -20,6 +21,12 @@ type PendingControl = {
   resolve(): void;
   reject(error: Error): void;
   timer: ReturnType<typeof setTimeout>;
+  interruptTurnId: string | null;
+};
+type PendingDelivery = {
+  promise: Promise<DeliveryReceipt>;
+  resolve(receipt: DeliveryReceipt): void;
+  reject(error: Error): void;
 };
 
 export interface ClaudeDeliveryState {
@@ -136,6 +143,8 @@ export interface ClaudeSessionIdentity { sessionId: string }
 
 export interface ClaudeStreamBrokerHostOptions {
   cwd: string;
+  claudeConfigDir?: string;
+  claudeProjectsDir?: string;
   binary?: string;
   model?: string;
   effort?: string;
@@ -215,9 +224,10 @@ export function redactClaudeHostDiagnostic(value: unknown): string {
 
 const safeError = redactClaudeHostDiagnostic;
 
-function subscriptionEnv(source: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+function subscriptionEnv(source: NodeJS.ProcessEnv, claudeConfigDir?: string): NodeJS.ProcessEnv {
   const env: NodeJS.ProcessEnv = { NODE_ENV: source.NODE_ENV };
   for (const name of CHILD_ENV_ALLOWLIST) if (source[name] !== undefined) env[name] = source[name];
+  if (claudeConfigDir) env.CLAUDE_CONFIG_DIR = claudeConfigDir;
   return env;
 }
 
@@ -247,9 +257,8 @@ function userText(message: JsonObject): string {
   return textContent(record(message.message)?.content);
 }
 
-function defaultTranscriptUsers(cwd: string, sessionId: string): ClaudeTranscriptUser[] {
-  const project = cwd.replace(/[^A-Za-z0-9]/g, "-");
-  const filename = path.join(process.env.HOME ?? "", ".claude", "projects", project, `${sessionId}.jsonl`);
+function defaultTranscriptUsers(cwd: string, sessionId: string, projectsRoot?: string): ClaudeTranscriptUser[] {
+  const filename = claudeTranscriptPath(cwd, sessionId, projectsRoot);
   let contents: string;
   try { contents = fs.readFileSync(filename, "utf8"); }
   catch (error) {
@@ -286,7 +295,9 @@ export class ClaudeStreamBrokerHost implements EngineHost {
   private readonly turnQueue: string[] = [];
   private readonly attentions = new Map<string, JsonObject>();
   private readonly pendingControls = new Map<string, PendingControl>();
-  private readonly actuatedIds = new Set<string>();
+  private readonly interruptedTurns = new Set<string>();
+  private readonly partialTurns = new Set<string>();
+  private readonly pendingDeliveries = new Map<string, PendingDelivery>();
   private readonly stateListeners = new Set<(state: HostState) => void>();
   private stdoutBuffer = "";
   private cursor: number;
@@ -301,6 +312,7 @@ export class ClaudeStreamBrokerHost implements EngineHost {
   private writerFence: (() => boolean) | null = null;
   private releasePromise: Promise<void> | null = null;
   private terminationTimer: ReturnType<typeof setTimeout> | null = null;
+  private terminationStarted = false;
   private readonly reapedPromise: Promise<void>;
   private resolveReaped!: () => void;
 
@@ -328,9 +340,13 @@ export class ClaudeStreamBrokerHost implements EngineHost {
     child.on("error", (error) => this.fail(new Error(`Claude child failed: ${safeError(error)}`)));
     child.on("close", () => {
       this.reaped = true;
-      if (this.terminationTimer) clearTimeout(this.terminationTimer);
+      if (this.terminationTimer) {
+        clearTimeout(this.terminationTimer);
+        this.terminationTimer = null;
+      }
       this.resolveReaped();
-      if (!this.releasing && !this.released && !this.dead) this.fail(new Error("Claude child exited"));
+      if (this.dead) this.notifyStateListeners();
+      else if (!this.releasing && !this.released) this.fail(new Error("Claude child exited"));
     });
   }
 
@@ -349,7 +365,7 @@ export class ClaudeStreamBrokerHost implements EngineHost {
     options: ClaudeStreamBrokerHostOptions,
   ): Promise<ClaudeStreamBrokerHost> {
     const binary = options.binary ?? process.env.LLV_CLAUDE_BINARY ?? "claude";
-    const env = subscriptionEnv(options.env ?? process.env);
+    const env = subscriptionEnv(options.env ?? process.env, options.claudeConfigDir);
     const auth = await (options.readAuthStatus?.() ?? defaultAuthStatus(binary, env, options.cwd));
     if (!auth.loggedIn || auth.authMethod !== "claude.ai" || !auth.subscriptionType) {
       throw new Error("Claude stream hosting requires a claude.ai subscription login");
@@ -357,6 +373,7 @@ export class ClaudeStreamBrokerHost implements EngineHost {
     const args = [
       "-p", "--input-format", "stream-json", "--output-format", "stream-json", "--verbose",
       "--safe-mode", "--include-partial-messages", "--replay-user-messages",
+      "--permission-prompt-tool", "stdio",
       "--permission-mode", options.permissionMode ?? "default",
     ];
     if (resume) args.push("--resume", sessionId);
@@ -371,7 +388,9 @@ export class ClaudeStreamBrokerHost implements EngineHost {
     const host = new ClaudeStreamBrokerHost(child, { sessionId }, auth, options);
     try {
       host.restore();
-      host.reconcileTranscript((options.readTranscript ?? defaultTranscriptUsers)(options.cwd, sessionId));
+      host.reconcileTranscript(options.readTranscript
+        ? options.readTranscript(options.cwd, sessionId)
+        : defaultTranscriptUsers(options.cwd, sessionId, options.claudeProjectsDir));
       host.emit({ kind: "session-status", status: "idle" });
       return host;
     } catch (error) {
@@ -420,9 +439,11 @@ export class ClaudeStreamBrokerHost implements EngineHost {
       return { outcome: "rejected", reason: "stale-turn" };
     }
     const duplicate = this.deliveries.find((state) => state.entry.id === entry.id);
-    if (duplicate?.delivered || (duplicate && this.actuatedIds.has(entry.id))) {
+    if (duplicate?.delivered) {
       return { outcome: duplicate.disposition, turnId: duplicate.entry.id };
     }
+    const existingPending = this.pendingDeliveries.get(entry.id);
+    if (existingPending) return existingPending.promise;
     const disposition: ClaudeDeliveryState["disposition"] = duplicate?.disposition
       ?? (this.activeTurnId ? "queued-next-turn" : "turn-started");
     try {
@@ -434,12 +455,22 @@ export class ClaudeStreamBrokerHost implements EngineHost {
     const delivery: ClaudeDeliveryState = duplicate
       ?? { entry: structuredClone(entry), disposition, delivered: false };
     if (!duplicate) this.deliveries.push(delivery);
+    let resolveDelivery!: PendingDelivery["resolve"];
+    let rejectDelivery!: PendingDelivery["reject"];
+    const pending: PendingDelivery = {
+      promise: new Promise<DeliveryReceipt>((resolve, reject) => {
+        resolveDelivery = resolve;
+        rejectDelivery = reject;
+      }),
+      resolve: (receipt) => resolveDelivery(receipt),
+      reject: (error) => rejectDelivery(error),
+    };
+    this.pendingDeliveries.set(entry.id, pending);
     this.write({
       type: "user",
       session_id: this.identity.sessionId,
       message: { role: "user", content: [{ type: "text", text: entry.text }] },
     });
-    this.actuatedIds.add(entry.id);
     this.turnQueue.push(entry.id);
     if (!this.activeTurnId) {
       this.activeTurnId = entry.id;
@@ -447,7 +478,7 @@ export class ClaudeStreamBrokerHost implements EngineHost {
     } else {
       this.notifyStateListeners();
     }
-    return { outcome: disposition, turnId: entry.id };
+    return pending.promise;
   }
 
   async interrupt(turnRef: string): Promise<void> {
@@ -461,7 +492,7 @@ export class ClaudeStreamBrokerHost implements EngineHost {
         reject(error);
         this.fail(error);
       }, this.requestTimeoutMs);
-      this.pendingControls.set(requestId, { resolve, reject, timer });
+      this.pendingControls.set(requestId, { resolve, reject, timer, interruptTurnId: turnRef });
       this.write({ type: "control_request", request_id: requestId, request: { subtype: "interrupt" } });
     });
   }
@@ -611,6 +642,11 @@ export class ClaudeStreamBrokerHost implements EngineHost {
           this.deliveryLedger.confirmDelivered(this.identity.sessionId, delivery.entry.id, stringField(message, "uuid"));
           delivery.delivered = true;
           delivery.engineMessageId = stringField(message, "uuid");
+          const pending = this.pendingDeliveries.get(delivery.entry.id);
+          if (pending) {
+            this.pendingDeliveries.delete(delivery.entry.id);
+            pending.resolve({ outcome: delivery.disposition, turnId: delivery.entry.id });
+          }
         } catch (error) {
           return this.failWithoutLedger(new Error(`Claude delivery ledger failed: ${safeError(error)}`));
         }
@@ -623,13 +659,16 @@ export class ClaudeStreamBrokerHost implements EngineHost {
       const delta = record(event?.delta);
       const text = stringField(delta, "text");
       if (event?.type === "content_block_delta" && text !== null) {
+        if (this.activeTurnId) this.partialTurns.add(this.activeTurnId);
         this.emit({ kind: "delta", turnId: this.activeTurnId ?? "unknown", text });
       }
       return;
     }
     if (type === "assistant") {
       const text = textContent(record(message.message)?.content);
-      if (text) this.emit({ kind: "delta", turnId: this.activeTurnId ?? "unknown", text });
+      if (text && (!this.activeTurnId || !this.partialTurns.has(this.activeTurnId))) {
+        this.emit({ kind: "delta", turnId: this.activeTurnId ?? "unknown", text });
+      }
       this.emit({ kind: "item", turnId: this.activeTurnId, item: message, phase: "completed" });
       return;
     }
@@ -650,7 +689,10 @@ export class ClaudeStreamBrokerHost implements EngineHost {
       clearTimeout(pending.timer);
       this.pendingControls.delete(requestId);
       if (response.subtype === "error") pending.reject(new Error("Claude control request failed"));
-      else pending.resolve();
+      else {
+        if (pending.interruptTurnId) this.interruptedTurns.add(pending.interruptTurnId);
+        pending.resolve();
+      }
       return;
     }
     if (type === "result") this.acceptResult(message);
@@ -659,7 +701,11 @@ export class ClaudeStreamBrokerHost implements EngineHost {
   private acceptResult(message: JsonObject): void {
     const turnId = this.turnQueue.shift() ?? this.activeTurnId;
     if (!turnId) return;
-    const status = message.subtype === "success" ? "completed" : message.subtype === "interrupted" ? "interrupted" : "error";
+    this.partialTurns.delete(turnId);
+    const interrupted = this.interruptedTurns.delete(turnId);
+    const status = interrupted || message.subtype === "interrupted"
+      ? "interrupted"
+      : message.subtype === "success" ? "completed" : "error";
     this.emit({ kind: "turn-ended", turnId, status });
     this.activeTurnId = this.turnQueue[0] ?? null;
     if (this.activeTurnId) this.emit({ kind: "turn-started", turnId: this.activeTurnId });
@@ -678,9 +724,8 @@ export class ClaudeStreamBrokerHost implements EngineHost {
   private async releaseAndReap(): Promise<void> {
     this.releasing = true;
     this.rejectPending(new Error("Claude stream host released"));
-    try { this.child.stdin.end(); } catch { /* already closed */ }
-    try { this.child.kill("SIGTERM"); } catch { /* already closed */ }
-    if (!await this.waitForReap(this.shutdownGraceMs)) {
+    this.startTermination();
+    if (!await this.waitForReap(this.shutdownGraceMs * 2)) {
       try { this.child.kill("SIGKILL"); } catch { /* already closed */ }
       if (!await this.waitForReap(this.shutdownGraceMs)) throw new Error("Claude child could not be reaped");
     }
@@ -713,11 +758,19 @@ export class ClaudeStreamBrokerHost implements EngineHost {
     this.rejectPending(error);
     this.emit({ kind: "session-status", status: "dead" });
     this.closeSubscribers();
-    try { this.child.kill("SIGTERM"); } catch { /* already closed */ }
+    this.startTermination();
   }
 
   private failWithoutLedger(error: Error): void {
-    if (this.dead || this.released) return;
+    if (this.released) {
+      this.notifyStateListeners();
+      this.closeSubscribers();
+      return;
+    }
+    if (this.dead) {
+      this.notifyStateListeners();
+      return;
+    }
     this.ledgerFailed = true;
     this.dead = true;
     this.activeTurnId = null;
@@ -725,10 +778,24 @@ export class ClaudeStreamBrokerHost implements EngineHost {
     this.rejectPending(error);
     this.notifyStateListeners();
     this.closeSubscribers();
+    this.startTermination();
+  }
+
+  private startTermination(): void {
+    if (this.terminationStarted || this.reaped) return;
+    this.terminationStarted = true;
+    try { this.child.stdin.end(); } catch { /* already closed */ }
     try { this.child.kill("SIGTERM"); } catch { /* already closed */ }
+    this.terminationTimer = setTimeout(() => {
+      this.terminationTimer = null;
+      if (this.reaped) return;
+      try { this.child.kill("SIGKILL"); } catch { /* already closed */ }
+    }, this.shutdownGraceMs);
   }
 
   private rejectPending(error: Error): void {
+    for (const pending of this.pendingDeliveries.values()) pending.reject(new Error(safeError(error)));
+    this.pendingDeliveries.clear();
     for (const pending of this.pendingControls.values()) {
       clearTimeout(pending.timer);
       pending.reject(new Error(safeError(error)));

--- a/src/lib/runtime/claudeStreamBrokerHost.ts
+++ b/src/lib/runtime/claudeStreamBrokerHost.ts
@@ -28,6 +28,11 @@ type PendingDelivery = {
   resolve(receipt: DeliveryReceipt): void;
   reject(error: Error): void;
 };
+type PendingAnswer = {
+  resolve(): void;
+  reject(error: Error): void;
+  timer: ReturnType<typeof setTimeout>;
+};
 
 export interface ClaudeDeliveryState {
   entry: QueueEntry;
@@ -126,7 +131,7 @@ export class FileClaudeDeliveryLedger implements ClaudeDeliveryLedger {
     try {
       fs.fchmodSync(fd, 0o600);
       repairJsonlTail(fd, filename, deliveryRecord);
-      fs.writeSync(fd, `${JSON.stringify(record)}\n`);
+      writeAllSync(fd, Buffer.from(`${JSON.stringify(record)}\n`));
       fs.fsyncSync(fd);
     } finally {
       fs.closeSync(fd);
@@ -228,6 +233,17 @@ function repairJsonlTail<T>(fd: number, filename: string, validate: (value: unkn
   else fs.ftruncateSync(fd, Buffer.byteLength(contents.slice(0, boundary)));
 }
 
+function writeAllSync(fd: number, buffer: Uint8Array): void {
+  let offset = 0;
+  while (offset < buffer.byteLength) {
+    const written = fs.writeSync(fd, buffer, offset, buffer.byteLength - offset);
+    if (!Number.isSafeInteger(written) || written <= 0) {
+      throw new Error("Claude delivery ledger write made no progress");
+    }
+    offset += written;
+  }
+}
+
 export function redactClaudeHostDiagnostic(value: unknown): string {
   return hardenedRedact(value instanceof Error ? value.message : String(value))
     .replace(/(["']?(?:cookie|set-cookie)["']?\s*[:=]\s*["']?)[^\s,"'}]+/gi, "$1[redacted]")
@@ -307,6 +323,7 @@ export class ClaudeStreamBrokerHost implements EngineHost {
   private readonly turnQueue: string[] = [];
   private readonly attentions = new Map<string, JsonObject>();
   private readonly pendingControls = new Map<string, PendingControl>();
+  private readonly pendingAnswers = new Map<string, PendingAnswer>();
   private readonly interruptedTurns = new Set<string>();
   private readonly partialTurns = new Set<string>();
   private readonly pendingDeliveries = new Map<string, PendingDelivery>();
@@ -515,12 +532,20 @@ export class ClaudeStreamBrokerHost implements EngineHost {
   async answer(attentionRef: string, value: unknown): Promise<void> {
     if (this.unavailable()) throw new Error("Claude stream host is unavailable");
     if (!this.attentions.has(attentionRef)) throw new Error("attention request is missing or already answered");
-    this.write({
-      type: "control_response",
-      response: { subtype: "success", request_id: attentionRef, response: value ?? {} },
+    if (this.pendingAnswers.has(attentionRef)) throw new Error("attention answer is already awaiting confirmation");
+    await new Promise<void>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.pendingAnswers.delete(attentionRef);
+        const error = new Error("Claude attention answer timed out; outcome is uncertain");
+        reject(error);
+        this.fail(error);
+      }, this.requestTimeoutMs);
+      this.pendingAnswers.set(attentionRef, { resolve, reject, timer });
+      this.write({
+        type: "control_response",
+        response: { subtype: "success", request_id: attentionRef, response: value ?? {} },
+      });
     });
-    this.attentions.delete(attentionRef);
-    this.emit({ kind: "attention-resolved", id: attentionRef, resolution: "answered" });
   }
 
   async health(): Promise<HostState> { return this.currentState(); }
@@ -651,7 +676,10 @@ export class ClaudeStreamBrokerHost implements EngineHost {
     }
     if (type === "user") {
       const text = userText(message);
-      const delivery = this.deliveries.find((candidate) => !candidate.delivered && candidate.entry.text === text);
+      const userRoleReplay = message.isReplay === true && stringField(message.message, "role") === "user";
+      const delivery = userRoleReplay
+        ? this.deliveries.find((candidate) => !candidate.delivered && candidate.entry.text === text)
+        : undefined;
       if (delivery) {
         try {
           this.deliveryLedger.confirmDelivered(this.identity.sessionId, delivery.entry.id, stringField(message, "uuid"));
@@ -695,10 +723,38 @@ export class ClaudeStreamBrokerHost implements EngineHost {
       this.emit({ kind: "attention", id: requestId, method: stringField(request, "subtype") ?? "control_request", attention: request });
       return;
     }
+    if (type === "control_cancel_request") {
+      const requestId = stringField(message, "request_id");
+      if (!requestId) return this.fail(new Error("Claude control cancellation had no request id"));
+      if (!this.attentions.has(requestId)) return;
+      const pending = this.pendingAnswers.get(requestId);
+      if (pending) {
+        clearTimeout(pending.timer);
+        this.pendingAnswers.delete(requestId);
+        pending.reject(new Error("Claude attention was cancelled before answer confirmation"));
+      }
+      this.attentions.delete(requestId);
+      this.emit({ kind: "attention-resolved", id: requestId, resolution: "server-resolved" });
+      return;
+    }
     if (type === "control_response") {
       const response = record(message.response) ?? message;
       const requestId = stringField(response, "request_id");
       if (!requestId) return;
+      const answer = this.pendingAnswers.get(requestId);
+      if (answer) {
+        clearTimeout(answer.timer);
+        this.pendingAnswers.delete(requestId);
+        this.attentions.delete(requestId);
+        if (response.subtype === "error") {
+          answer.reject(new Error("Claude attention answer failed"));
+          this.emit({ kind: "attention-resolved", id: requestId, resolution: "server-resolved" });
+        } else {
+          answer.resolve();
+          this.emit({ kind: "attention-resolved", id: requestId, resolution: "answered" });
+        }
+        return;
+      }
       const pending = this.pendingControls.get(requestId);
       if (!pending) return;
       clearTimeout(pending.timer);
@@ -816,6 +872,11 @@ export class ClaudeStreamBrokerHost implements EngineHost {
       pending.reject(new Error(safeError(error)));
     }
     this.pendingControls.clear();
+    for (const pending of this.pendingAnswers.values()) {
+      clearTimeout(pending.timer);
+      pending.reject(new Error(safeError(error)));
+    }
+    this.pendingAnswers.clear();
   }
 
   private closeSubscribers(): void {

--- a/src/lib/runtime/claudeStreamBrokerHost.ts
+++ b/src/lib/runtime/claudeStreamBrokerHost.ts
@@ -2,6 +2,7 @@ import { spawn, spawnSync } from "node:child_process";
 import type { ChildProcessWithoutNullStreams, SpawnOptionsWithoutStdio } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
+import { StringDecoder } from "node:string_decoder";
 
 import { statePath } from "@/lib/configDir";
 import { claudeTranscriptPath } from "@/lib/agent/transcript";
@@ -328,6 +329,7 @@ export class ClaudeStreamBrokerHost implements EngineHost {
   private readonly partialTurns = new Set<string>();
   private readonly pendingDeliveries = new Map<string, PendingDelivery>();
   private readonly stateListeners = new Set<(state: HostState) => void>();
+  private readonly stdoutDecoder = new StringDecoder("utf8");
   private stdoutBuffer = "";
   private cursor: number;
   private activeTurnId: string | null = null;
@@ -361,7 +363,13 @@ export class ClaudeStreamBrokerHost implements EngineHost {
     this.protocolVersion = auth.version ?? null;
     this.account = { type: auth.authMethod, planType: auth.subscriptionType };
     this.reapedPromise = new Promise((resolve) => { this.resolveReaped = resolve; });
-    child.stdout.on("data", (chunk: Buffer | string) => this.acceptStdout(String(chunk)));
+    child.stdout.on("data", (chunk: Buffer | string) => {
+      this.acceptStdout(typeof chunk === "string" ? chunk : this.stdoutDecoder.write(chunk));
+    });
+    child.stdout.on("end", () => {
+      const tail = this.stdoutDecoder.end();
+      if (tail) this.acceptStdout(tail);
+    });
     child.stderr.on("data", () => { /* Provider diagnostics may contain credentials. */ });
     child.stdin.on("error", (error) => {
       if (!this.releasing && !this.released) this.fail(new Error(`Claude stream stdin failed: ${safeError(error)}`));

--- a/src/lib/runtime/claudeStreamBrokerHost.ts
+++ b/src/lib/runtime/claudeStreamBrokerHost.ts
@@ -74,7 +74,13 @@ export class FileClaudeDeliveryLedger implements ClaudeDeliveryLedger {
   }
 
   recordQueued(sessionId: string, entry: QueueEntry, disposition: ClaudeDeliveryState["disposition"]): void {
-    if (this.load(sessionId).some((state) => state.entry.id === entry.id)) return;
+    const existing = this.load(sessionId).find((state) => state.entry.id === entry.id);
+    if (existing) {
+      if (!sameQueueEntry(existing.entry, entry)) {
+        throw new Error("Claude delivery ledger entry id belongs to a different payload");
+      }
+      return;
+    }
     this.append(sessionId, { kind: "queued", entry, disposition, queuedAt: new Date().toISOString() });
   }
 
@@ -185,6 +191,12 @@ function record(value: unknown): JsonObject | null {
 function stringField(value: unknown, key: string): string | null {
   const object = record(value);
   return object && typeof object[key] === "string" ? object[key] as string : null;
+}
+
+function sameQueueEntry(left: QueueEntry, right: QueueEntry): boolean {
+  return left.id === right.id
+    && left.text === right.text
+    && left.expectedTurnId === right.expectedTurnId;
 }
 
 function deliveryRecord(value: unknown): ClaudeDeliveryRecord | null {
@@ -435,10 +447,13 @@ export class ClaudeStreamBrokerHost implements EngineHost {
   async send(entry: QueueEntry): Promise<DeliveryReceipt> {
     if (this.unavailable()) return { outcome: "rejected", reason: "dead-host" };
     if (!entry.id || !entry.text) throw new Error("queue entry id and text are required");
-    if (entry.expectedTurnId !== undefined && entry.expectedTurnId !== this.activeTurnId) {
+    const duplicate = this.deliveries.find((state) => state.entry.id === entry.id);
+    if (duplicate && !sameQueueEntry(duplicate.entry, entry)) {
+      throw new Error("Claude queue entry id belongs to a different payload");
+    }
+    if (!duplicate && entry.expectedTurnId !== undefined && entry.expectedTurnId !== this.activeTurnId) {
       return { outcome: "rejected", reason: "stale-turn" };
     }
-    const duplicate = this.deliveries.find((state) => state.entry.id === entry.id);
     if (duplicate?.delivered) {
       return { outcome: duplicate.disposition, turnId: duplicate.entry.id };
     }

--- a/src/lib/runtime/engineHost.ts
+++ b/src/lib/runtime/engineHost.ts
@@ -8,6 +8,7 @@ export interface QueueEntry {
 export type DeliveryReceipt =
   | { outcome: "steered"; turnId: string }
   | { outcome: "turn-started"; turnId: string }
+  | { outcome: "queued-next-turn"; turnId: string }
   | { outcome: "rejected"; reason: "stale-turn" | "dead-host" };
 
 export type RuntimeEvent =

--- a/src/lib/runtime/index.ts
+++ b/src/lib/runtime/index.ts
@@ -1,5 +1,6 @@
 export * from "./engineHost";
 export * from "./codexAppServerHost";
+export * from "./claudeStreamBrokerHost";
 export * from "./registry";
 export * from "./eventStore";
 export * from "./startup";

--- a/src/lib/runtime/registry.ts
+++ b/src/lib/runtime/registry.ts
@@ -8,6 +8,7 @@ import type { SessionKey } from "@/lib/agent/sessionKey";
 import { procBackend } from "@/lib/proc";
 
 import { CodexAppServerHost, type CodexAppServerHostOptions } from "./codexAppServerHost";
+import { ClaudeStreamBrokerHost, type ClaudeStreamBrokerHostOptions } from "./claudeStreamBrokerHost";
 import type { HostState } from "./engineHost";
 
 export function structuredHostsEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
@@ -22,6 +23,14 @@ export async function startCodexStructuredHost(
   return CodexAppServerHost.start(options);
 }
 
+export async function startClaudeStructuredHost(
+  options: ClaudeStreamBrokerHostOptions,
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<ClaudeStreamBrokerHost> {
+  if (!structuredHostsEnabled(env)) throw new Error("structured hosts are disabled");
+  return ClaudeStreamBrokerHost.start(options);
+}
+
 function registryStatus(state: HostState): AgentHostStatus {
   if (state.status === "active" || state.status === "attention") return "live";
   if (state.status === "idle") return "idle";
@@ -32,6 +41,20 @@ function registryStatus(state: HostState): AgentHostStatus {
 export function codexHostColumns(state: HostState, writerClaimEpoch: number): StructuredHostColumns {
   return {
     kind: "codex-app-server",
+    endpoint: state.endpoint,
+    process: state.pid === null ? null : { pid: state.pid, startIdentity: state.processStartIdentity },
+    eventCursor: state.eventCursor,
+    protocolVersion: state.protocolVersion,
+    writerClaimEpoch,
+    activeTurnRef: state.activeTurnRef,
+    pendingAttention: state.pendingAttention,
+    activeFlags: state.activeFlags,
+  };
+}
+
+export function claudeHostColumns(state: HostState, writerClaimEpoch: number): StructuredHostColumns {
+  return {
+    kind: "claude-broker",
     endpoint: state.endpoint,
     process: state.pid === null ? null : { pid: state.pid, startIdentity: state.processStartIdentity },
     eventCursor: state.eventCursor,
@@ -112,9 +135,64 @@ export async function bindCodexHostPersistence(
   return stop;
 }
 
+export async function bindClaudeHostPersistence(
+  registry: AgentRegistry,
+  key: SessionKey,
+  host: ClaudeStreamBrokerHost,
+  claimOwner: string,
+  writerClaimEpoch: number,
+): Promise<() => void> {
+  host.setWriterFence(() => registry.ownsStructuredHostClaim(key, claimOwner, writerClaimEpoch));
+  const persist = (state: HostState, terminal = false) => registry.setStructuredHostClaimed(
+    key,
+    claudeHostColumns(state, writerClaimEpoch),
+    registryStatus(state),
+    claimOwner,
+    writerClaimEpoch,
+    terminal,
+  );
+  try {
+    if (!persist(await host.health())) throw new Error("structured host writer claim is stale");
+  } catch (error) {
+    await host.release();
+    throw error;
+  }
+  let failed = false;
+  let stopped = false;
+  let unsubscribe = () => {};
+  const stop = () => {
+    if (stopped) return;
+    stopped = true;
+    unsubscribe();
+    registry.releaseStructuredHostClaim(key, claimOwner, writerClaimEpoch);
+  };
+  unsubscribe = host.onStateChange((state) => {
+    if (failed || stopped) return;
+    try {
+      const terminal = state.status === "unhosted" || (state.status === "dead" && state.pid === null);
+      if (!persist(state, terminal)) throw new Error("structured host writer claim is stale");
+      if (terminal) {
+        stopped = true;
+        unsubscribe();
+      }
+    } catch {
+      failed = true;
+      stop();
+      void host.release();
+    }
+  });
+  if (stopped) unsubscribe();
+  return stop;
+}
+
 export interface AdoptedCodexHost {
   key: SessionKey;
   host: CodexAppServerHost;
+}
+
+export interface AdoptedClaudeHost {
+  key: SessionKey;
+  host: ClaudeStreamBrokerHost;
 }
 
 /** Boot seam: resume every durable Codex row when structured hosting is enabled. */
@@ -141,6 +219,50 @@ export async function adoptCodexRegistryHosts(
             initialEventCursor: claimed.structuredHost.eventCursor,
           });
           await bindCodexHostPersistence(registry, entry.key, host, claimed.claimOwner!, claimed.claimEpoch);
+          adopted.push({ key: entry.key, host });
+        } catch {
+          registry.setStructuredHostClaimed(entry.key, {
+            ...claimed.structuredHost,
+            endpoint: "stdio:released",
+            process: null,
+            activeTurnRef: null,
+            pendingAttention: [],
+            activeFlags: [],
+          }, "dead", claimed.claimOwner!, claimed.claimEpoch, true);
+        }
+      });
+    } catch (error) {
+      if (!(error instanceof Error) || error.message !== "agent registry is busy") throw error;
+    }
+  }
+  return adopted;
+}
+
+
+/** Boot seam: resume every durable Claude broker row when structured hosting is enabled. */
+export async function adoptClaudeRegistryHosts(
+  registry: AgentRegistry,
+  optionsFor: (entry: AgentRegistryEntry) => ClaudeStreamBrokerHostOptions,
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<AdoptedClaudeHost[]> {
+  if (!structuredHostsEnabled(env)) return [];
+  const rows = Object.values(registry.snapshot().entries).filter((entry) =>
+    entry.key.engine === "claude"
+    && entry.status !== "unhosted"
+    && entry.structuredHost?.kind === "claude-broker");
+  const adopted: AdoptedClaudeHost[] = [];
+  for (const entry of rows) {
+    const owner = { pid: process.pid, startIdentity: procBackend.processIdentity(process.pid) };
+    try {
+      await registry.withOperationLock(entry.key, owner, async () => {
+        const claimed = registry.claimStructuredHost(entry.key, owner);
+        if (!claimed?.structuredHost) return;
+        try {
+          const host = await ClaudeStreamBrokerHost.adopt(entry.key.sessionId, {
+            ...optionsFor(claimed),
+            initialEventCursor: claimed.structuredHost.eventCursor,
+          });
+          await bindClaudeHostPersistence(registry, entry.key, host, claimed.claimOwner!, claimed.claimEpoch);
           adopted.push({ key: entry.key, host });
         } catch {
           registry.setStructuredHostClaimed(entry.key, {

--- a/src/lib/runtime/registry.ts
+++ b/src/lib/runtime/registry.ts
@@ -2,6 +2,7 @@ import type {
   AgentHostStatus,
   AgentRegistry,
   AgentRegistryEntry,
+  ProcessIdentity,
   StructuredHostColumns,
 } from "@/lib/agent/registry";
 import type { SessionKey } from "@/lib/agent/sessionKey";
@@ -195,6 +196,48 @@ export interface AdoptedClaudeHost {
   host: ClaudeStreamBrokerHost;
 }
 
+const STRUCTURED_CLAIM_PREFIX = "structured-host:";
+const ORPHAN_TERM_GRACE_MS = 250;
+const ORPHAN_KILL_GRACE_MS = 1_000;
+
+function claimOwnerBlocksOrphanReap(claimOwner: string | null): boolean {
+  if (!claimOwner) return false;
+  if (!claimOwner.startsWith(STRUCTURED_CLAIM_PREFIX)) return true;
+  let identity: Partial<ProcessIdentity>;
+  try { identity = JSON.parse(claimOwner.slice(STRUCTURED_CLAIM_PREFIX.length)) as Partial<ProcessIdentity>; }
+  catch { return true; }
+  if (!Number.isInteger(identity.pid) || identity.pid! <= 0) return true;
+  const startIdentity = typeof identity.startIdentity === "string" ? identity.startIdentity : null;
+  return procBackend.pidAlive(identity.pid!)
+    && (startIdentity === null || procBackend.processIdentity(identity.pid!) === startIdentity);
+}
+
+function verifiedProcessAlive(processIdentity: ProcessIdentity): boolean {
+  return processIdentity.startIdentity !== null
+    && procBackend.processIdentity(processIdentity.pid) === processIdentity.startIdentity;
+}
+
+async function waitForVerifiedProcessExit(processIdentity: ProcessIdentity, timeoutMs: number): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (verifiedProcessAlive(processIdentity) && Date.now() < deadline) {
+    await new Promise<void>((resolve) => setTimeout(resolve, 10));
+  }
+  return !verifiedProcessAlive(processIdentity);
+}
+
+async function terminateVerifiedClaudeOrphan(
+  processIdentity: ProcessIdentity,
+  claimOwner: string | null,
+): Promise<boolean> {
+  if (processIdentity.pid === process.pid
+    || !verifiedProcessAlive(processIdentity)
+    || claimOwnerBlocksOrphanReap(claimOwner)) return false;
+  try { process.kill(processIdentity.pid, "SIGTERM"); } catch { /* process exited */ }
+  if (await waitForVerifiedProcessExit(processIdentity, ORPHAN_TERM_GRACE_MS)) return true;
+  try { process.kill(processIdentity.pid, "SIGKILL"); } catch { /* process exited */ }
+  return waitForVerifiedProcessExit(processIdentity, ORPHAN_KILL_GRACE_MS);
+}
+
 /** Boot seam: resume every durable Codex row when structured hosting is enabled. */
 export async function adoptCodexRegistryHosts(
   registry: AgentRegistry,
@@ -255,7 +298,16 @@ export async function adoptClaudeRegistryHosts(
     const owner = { pid: process.pid, startIdentity: procBackend.processIdentity(process.pid) };
     try {
       await registry.withOperationLock(entry.key, owner, async () => {
-        const claimed = registry.claimStructuredHost(entry.key, owner);
+        let claimed = registry.claimStructuredHost(entry.key, owner);
+        if (!claimed) {
+          const current = registry.snapshot().entries[`claude:${entry.key.sessionId}`];
+          const orphan = current?.structuredHost?.kind === "claude-broker"
+            ? current.structuredHost.process
+            : null;
+          if (orphan && await terminateVerifiedClaudeOrphan(orphan, current?.claimOwner ?? null)) {
+            claimed = registry.claimStructuredHost(entry.key, owner);
+          }
+        }
         if (!claimed?.structuredHost) return;
         try {
           const host = await ClaudeStreamBrokerHost.adopt(entry.key.sessionId, {

--- a/src/lib/runtime/startup.test.ts
+++ b/src/lib/runtime/startup.test.ts
@@ -40,6 +40,12 @@ test("server startup delegates managed rows with file credentials and their laun
   await adoptStructuredHostsAtStartup({
     registry,
     resolveCodexOwner: () => ({ home: "/managed", kind: "managed" }),
+    resolveClaudeOwner: () => ({
+      home: "/managed-claude",
+      kind: "managed",
+      transcriptRoot: "/managed-claude/projects",
+      env: { NODE_ENV: "test", CLAUDE_CONFIG_DIR: "/managed-claude" },
+    }),
     adopt: async (received, optionsFor) => {
       expect(received).toBe(registry);
       codexOptions = optionsFor(registry.snapshot().entries["codex:startup-thread"]!);
@@ -60,6 +66,9 @@ test("server startup delegates managed rows with file credentials and their laun
   });
   expect(claudeOptions).toMatchObject({
     cwd: "/repo",
+    claudeConfigDir: "/managed-claude",
+    claudeProjectsDir: "/managed-claude/projects",
+    env: { CLAUDE_CONFIG_DIR: "/managed-claude" },
     model: "gpt-5.4-mini",
     effort: "high",
   });

--- a/src/lib/runtime/startup.test.ts
+++ b/src/lib/runtime/startup.test.ts
@@ -35,20 +35,31 @@ test("server startup delegates managed rows with file credentials and their laun
     claimOwner: null,
     pendingAction: null,
   });
-  let options: unknown;
+  let codexOptions: unknown;
+  let claudeOptions: unknown;
   await adoptStructuredHostsAtStartup({
     registry,
     resolveCodexOwner: () => ({ home: "/managed", kind: "managed" }),
     adopt: async (received, optionsFor) => {
       expect(received).toBe(registry);
-      options = optionsFor(registry.snapshot().entries["codex:startup-thread"]!);
+      codexOptions = optionsFor(registry.snapshot().entries["codex:startup-thread"]!);
+      return [];
+    },
+    adoptClaude: async (received, optionsFor) => {
+      expect(received).toBe(registry);
+      claudeOptions = optionsFor(registry.snapshot().entries["codex:startup-thread"]!);
       return [];
     },
   });
-  expect(options).toMatchObject({
+  expect(codexOptions).toMatchObject({
     cwd: "/repo",
     codexHome: "/managed",
     fileAuthCredentials: true,
+    model: "gpt-5.4-mini",
+    effort: "high",
+  });
+  expect(claudeOptions).toMatchObject({
+    cwd: "/repo",
     model: "gpt-5.4-mini",
     effort: "high",
   });

--- a/src/lib/runtime/startup.ts
+++ b/src/lib/runtime/startup.ts
@@ -1,23 +1,30 @@
 import { accountManager } from "@/lib/accounts/manager";
 import { agentRegistry, type AgentRegistry, type AgentRegistryEntry } from "@/lib/agent/registry";
 
-import { adoptCodexRegistryHosts, type AdoptedCodexHost } from "./registry";
+import {
+  adoptClaudeRegistryHosts,
+  adoptCodexRegistryHosts,
+  type AdoptedClaudeHost,
+  type AdoptedCodexHost,
+} from "./registry";
 
-let adoptedHosts: AdoptedCodexHost[] = [];
+type AdoptedStructuredHost = AdoptedCodexHost | AdoptedClaudeHost;
+let adoptedHosts: AdoptedStructuredHost[] = [];
 
 export interface StructuredStartupDependencies {
   registry?: AgentRegistry;
   adopt?: typeof adoptCodexRegistryHosts;
+  adoptClaude?: typeof adoptClaudeRegistryHosts;
   resolveCodexOwner?: (entry: AgentRegistryEntry) => { home: string; kind: "legacy" | "managed" } | null;
 }
 
 /** Called once by Next instrumentation before the Node server accepts requests. */
 export async function adoptStructuredHostsAtStartup(
   dependencies: StructuredStartupDependencies = {},
-): Promise<AdoptedCodexHost[]> {
+): Promise<AdoptedStructuredHost[]> {
   const resolveCodexOwner = dependencies.resolveCodexOwner ?? ((entry: AgentRegistryEntry) =>
     accountManager.resolveTranscriptOwner("codex", entry.artifactPath));
-  adoptedHosts = await (dependencies.adopt ?? adoptCodexRegistryHosts)(
+  const codex = await (dependencies.adopt ?? adoptCodexRegistryHosts)(
     dependencies.registry ?? agentRegistry(),
     (entry) => {
       const owner = resolveCodexOwner(entry);
@@ -30,9 +37,19 @@ export async function adoptStructuredHostsAtStartup(
       };
     },
   );
+  const claude = await (dependencies.adoptClaude ?? adoptClaudeRegistryHosts)(
+    dependencies.registry ?? agentRegistry(),
+    (entry) => ({
+      cwd: entry.cwd,
+      model: entry.launchProfile?.model ?? undefined,
+      effort: entry.launchProfile?.effort ?? undefined,
+      permissionMode: entry.launchProfile?.permissionMode ?? undefined,
+    }),
+  );
+  adoptedHosts = [...codex, ...claude];
   return adoptedHosts;
 }
 
-export function structuredStartupHosts(): readonly AdoptedCodexHost[] {
+export function structuredStartupHosts(): readonly AdoptedStructuredHost[] {
   return adoptedHosts;
 }

--- a/src/lib/runtime/startup.ts
+++ b/src/lib/runtime/startup.ts
@@ -16,6 +16,12 @@ export interface StructuredStartupDependencies {
   adopt?: typeof adoptCodexRegistryHosts;
   adoptClaude?: typeof adoptClaudeRegistryHosts;
   resolveCodexOwner?: (entry: AgentRegistryEntry) => { home: string; kind: "legacy" | "managed" } | null;
+  resolveClaudeOwner?: (entry: AgentRegistryEntry) => {
+    home: string;
+    kind: "legacy" | "managed";
+    transcriptRoot: string;
+    env: NodeJS.ProcessEnv;
+  } | null;
 }
 
 /** Called once by Next instrumentation before the Node server accepts requests. */
@@ -24,6 +30,8 @@ export async function adoptStructuredHostsAtStartup(
 ): Promise<AdoptedStructuredHost[]> {
   const resolveCodexOwner = dependencies.resolveCodexOwner ?? ((entry: AgentRegistryEntry) =>
     accountManager.resolveTranscriptOwner("codex", entry.artifactPath));
+  const resolveClaudeOwner = dependencies.resolveClaudeOwner ?? ((entry: AgentRegistryEntry) =>
+    accountManager.resolveTranscriptOwner("claude", entry.artifactPath));
   const codex = await (dependencies.adopt ?? adoptCodexRegistryHosts)(
     dependencies.registry ?? agentRegistry(),
     (entry) => {
@@ -39,12 +47,18 @@ export async function adoptStructuredHostsAtStartup(
   );
   const claude = await (dependencies.adoptClaude ?? adoptClaudeRegistryHosts)(
     dependencies.registry ?? agentRegistry(),
-    (entry) => ({
-      cwd: entry.cwd,
-      model: entry.launchProfile?.model ?? undefined,
-      effort: entry.launchProfile?.effort ?? undefined,
-      permissionMode: entry.launchProfile?.permissionMode ?? undefined,
-    }),
+    (entry) => {
+      const owner = resolveClaudeOwner(entry);
+      return {
+        cwd: entry.cwd,
+        claudeConfigDir: owner?.kind === "managed" ? owner.home : undefined,
+        claudeProjectsDir: owner?.transcriptRoot,
+        env: owner?.env,
+        model: entry.launchProfile?.model ?? undefined,
+        effort: entry.launchProfile?.effort ?? undefined,
+        permissionMode: entry.launchProfile?.permissionMode ?? undefined,
+      };
+    },
   );
   adoptedHosts = [...codex, ...claude];
   return adoptedHosts;

--- a/test-preload.ts
+++ b/test-preload.ts
@@ -2,6 +2,9 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
+// Bun preserves an ambient NODE_ENV. Pin the test runtime before JSX modules load.
+Object.assign(process.env, { NODE_ENV: "test" });
+
 /*
  * Test-suite guard: force an isolated LLV_STATE_DIR before ANY module loads.
  *


### PR DESCRIPTION
## Summary

- add `ClaudeStreamBrokerHost` as an `EngineHost` adapter around one long-lived Claude stream-json process
- fsync queue entries before stdin actuation, confirm delivery from replayed user events or the persisted transcript, and retain durable event replay for late viewers
- resume durable Claude sessions with `--resume`, expose explicit interrupt and attention control messages, and persist broker state through the structured-host registry
- require subscription OAuth and the exact `LLV_STRUCTURED_HOSTS=1` opt-in

## Verification

- `bun test`
- `bunx tsc --noEmit`
- focused ESLint for changed runtime files
- real local Claude subscription integration covering late attach and restart resume

Closes #150
Related to #25