### PR TITLE
Make scanner cap fair across projects

### DIFF
--- a/src/lib/scanner/describe.ts
+++ b/src/lib/scanner/describe.ts
@@ -503,8 +503,7 @@ function scanJsonlTitle(pathname: string, size: number, wantCodex: boolean): str
   return title;
 }
 
-export function describe(rootName: RootKey, root: string, pathname: string, st: fs.Stats): Meta {
-  const stateKey = projectResolutionStateKey();
+export function describe(rootName: RootKey, root: string, pathname: string, st: fs.Stats, stateKey = projectResolutionStateKey()): Meta {
   const cached = metaCache.get(pathname);
   if (cached?.[0] === st.size && cached[1] === stateKey) return cached[2];
   const rel = path.relative(root, pathname);

--- a/src/lib/scanner/discover.test.ts
+++ b/src/lib/scanner/discover.test.ts
@@ -9,7 +9,7 @@ import type { RootKey } from "../types";
 import { discoverFiles, discoverFilesWithProjectCatalog } from "./discover";
 import { projectForCwd } from "./describe";
 import { projectResolutionStateKey } from "./projectState";
-import { FILE_CAP } from "./roots";
+import { FILE_CAP, PROJECT_FILE_FLOOR } from "./roots";
 
 async function writeFixture(pathname: string, content: string, mtimeSeconds: number): Promise<void> {
   await mkdir(path.dirname(pathname), { recursive: true });
@@ -112,19 +112,60 @@ test("discoverFiles preserves scanner filters, mtime ordering, and the cap", asy
 
     expect(entries).toHaveLength(FILE_CAP);
     expect(entries[0]?.path).toBe(taskPath);
-    expect(entries.slice(1).map((entry) => entry.name)).toEqual(
-      Array.from({ length: FILE_CAP - 1 }, (_, offset) => {
+    expect(entries.slice(1, -1).map((entry) => entry.name)).toEqual(
+      Array.from({ length: FILE_CAP - 2 }, (_, offset) => {
         const index = FILE_CAP - 1 - offset;
         return `session-${String(index).padStart(3, "0")}.jsonl`;
       }),
     );
+    expect(entries.at(-1)?.name).toBe(path.join("project-a", "sid-a", "subagents", "agent-mirrored.jsonl"));
     expect(entries.some((entry) => entry.name === "session-000.jsonl")).toBe(false);
+    expect(entries.some((entry) => entry.name === "session-001.jsonl")).toBe(false);
     expect(entries.map((entry) => entry.path)).toEqual([...entries].sort((a, b) => b.mtime - a.mtime).map((entry) => entry.path));
     expect(entries.every((entry) => entry.path !== path.join(roots["codex-sessions"], "too-new.bin"))).toBe(true);
     expect(entries.every((entry) => entry.path !== path.join(roots["codex-sessions"], "empty.jsonl"))).toBe(true);
     expect(entries.every((entry) => !entry.path.includes(path.sep + "tool-results" + path.sep))).toBe(true);
     expect(entries.every((entry) => !entry.path.endsWith("scratchpad.txt"))).toBe(true);
     expect(entries.every((entry) => !entry.path.endsWith("mirrored.output"))).toBe(true);
+  } finally {
+    await rm(base, { recursive: true, force: true });
+  }
+});
+
+test("discoverFiles reserves each project's newest files before the global recency fill", async () => {
+  const base = await mkdtemp(path.join(os.tmpdir(), "llv-discover-fair-cap-"));
+  try {
+    const roots: Record<RootKey, string> = {
+      "codex-sessions": path.join(base, "codex-sessions"),
+      "claude-projects": path.join(base, "claude-projects"),
+      "claude-tasks": path.join(base, "claude-tasks"),
+    };
+    await Promise.all(Object.values(roots).map((root) => mkdir(root, { recursive: true })));
+
+    const startedAt = 1_700_000_000;
+    for (let index = 0; index < FILE_CAP; index += 1) {
+      await writeFixture(
+        path.join(roots["codex-sessions"], `flood-${String(index).padStart(3, "0")}.jsonl`),
+        JSON.stringify({ type: "session_meta", payload: { cwd: path.join(os.homedir(), "Projects", "project-a") } }) + "\n",
+        startedAt + index,
+      );
+    }
+    const quietPaths: string[] = [];
+    for (let index = 0; index < PROJECT_FILE_FLOOR + 2; index += 1) {
+      const pathname = path.join(roots["codex-sessions"], `quiet-${String(index).padStart(3, "0")}.jsonl`);
+      quietPaths.push(pathname);
+      await writeFixture(
+        pathname,
+        JSON.stringify({ type: "session_meta", payload: { cwd: path.join(os.homedir(), "Projects", "project-b") } }) + "\n",
+        startedAt - 100 + index,
+      );
+    }
+
+    const entries = await discoverFiles(roots);
+    const visibleQuietPaths = entries.filter((entry) => entry.project === "project-b").map((entry) => entry.path);
+
+    expect(entries).toHaveLength(FILE_CAP);
+    expect(visibleQuietPaths).toEqual(quietPaths.slice(-PROJECT_FILE_FLOOR).reverse());
   } finally {
     await rm(base, { recursive: true, force: true });
   }
@@ -151,6 +192,47 @@ test("discoverFiles merges multiple Codex session roots without duplicate paths"
     ]);
 
     expect(entries.map((entry) => entry.path)).toEqual([secondFile, firstFile]);
+  } finally {
+    await rm(base, { recursive: true, force: true });
+  }
+});
+
+test("discoverFiles counts a dual-root Codex rollout once and prefers the account copy", async () => {
+  const base = await mkdtemp(path.join(os.tmpdir(), "llv-discover-codex-duplicate-"));
+  try {
+    const defaultRoot = path.join(base, "codex-default");
+    const accountRoot = path.join(base, "codex-account");
+    const claudeProjects = path.join(base, "claude-projects");
+    const claudeTasks = path.join(base, "claude-tasks");
+    await Promise.all([defaultRoot, accountRoot, claudeProjects, claudeTasks].map((root) => mkdir(root, { recursive: true })));
+    const rolloutName = "rollout-2026-07-13T10-00-00-019fa123-4567-7890-abcd-ef0123456789.jsonl";
+    const defaultFile = path.join(defaultRoot, "2026", "07", "13", rolloutName);
+    const accountFile = path.join(accountRoot, "2026", "07", "13", rolloutName);
+    await writeFixture(
+      defaultFile,
+      JSON.stringify({ type: "session_meta", payload: { cwd: path.join(os.homedir(), "Projects", "default-project") } }) + "\n",
+      20,
+    );
+    await writeFixture(
+      accountFile,
+      JSON.stringify({ type: "session_meta", payload: { cwd: path.join(os.homedir(), "Projects", "account-project") } }) + "\n",
+      10,
+    );
+
+    const scan = await discoverFilesWithProjectCatalog(
+      [
+        ["codex-sessions", defaultRoot],
+        ["codex-sessions", accountRoot],
+        ["claude-projects", claudeProjects],
+        ["claude-tasks", claudeTasks],
+      ],
+      undefined,
+      { persist: false },
+    );
+
+    expect(scan.files).toHaveLength(1);
+    expect(scan.files[0]).toMatchObject({ path: accountFile, project: "account-project" });
+    expect(scan.projectCatalog).toContainEqual({ project: "account-project", conversations: 1, smt: 10 });
   } finally {
     await rm(base, { recursive: true, force: true });
   }
@@ -192,7 +274,7 @@ test("discoverFiles keeps native Codex spawn parents outside the recent cap", as
   }
 });
 
-test("discoverFilesWithProjectCatalog keeps projects outside the recent cap", async () => {
+test("discoverFilesWithProjectCatalog keeps quiet projects in the recent cap", async () => {
   const base = await mkdtemp(path.join(os.tmpdir(), "llv-discover-catalog-"));
   const previousStateDir = process.env.LLV_STATE_DIR;
   try {
@@ -219,7 +301,7 @@ test("discoverFilesWithProjectCatalog keeps projects outside the recent cap", as
 
     const scan = await discoverFilesWithProjectCatalog(roots);
 
-    expect(scan.files.some((entry) => entry.path === oldPath)).toBe(false);
+    expect(scan.files.some((entry) => entry.path === oldPath)).toBe(true);
     expect(scan.projectCatalog.find((entry) => entry.project === "Pr-Gram")).toEqual({
       project: "Pr-Gram",
       conversations: 1,
@@ -232,7 +314,7 @@ test("discoverFilesWithProjectCatalog keeps projects outside the recent cap", as
   }
 });
 
-test("discoverFilesWithProjectCatalog hydrates a selected project outside the recent cap", async () => {
+test("discoverFilesWithProjectCatalog hydrates a selected project beyond its fair share", async () => {
   const base = await mkdtemp(path.join(os.tmpdir(), "llv-discover-selected-project-"));
   const previousStateDir = process.env.LLV_STATE_DIR;
   try {
@@ -246,8 +328,12 @@ test("discoverFilesWithProjectCatalog hydrates a selected project outside the re
 
     const startedAt = 1_700_025_000;
     const projectSlug = "-" + path.join(os.homedir(), "Projects", "stikon-dispatcher").split(path.sep).filter(Boolean).join("-");
-    const quietPath = path.join(roots["claude-projects"], projectSlug, "quiet-session.jsonl");
-    await writeFixture(quietPath, JSON.stringify({ type: "user", message: { content: "Quiet project" } }) + "\n", startedAt - 10);
+    const quietPaths: string[] = [];
+    for (let index = 0; index < PROJECT_FILE_FLOOR + 2; index += 1) {
+      const quietPath = path.join(roots["claude-projects"], projectSlug, `quiet-session-${index}.jsonl`);
+      quietPaths.push(quietPath);
+      await writeFixture(quietPath, JSON.stringify({ type: "user", message: { content: "Quiet project" } }) + "\n", startedAt - 20 + index);
+    }
     for (let index = 0; index < FILE_CAP; index += 1) {
       const pathname = path.join(roots["codex-sessions"], `fresh-${String(index).padStart(3, "0")}.jsonl`);
       await writeFixture(
@@ -260,13 +346,15 @@ test("discoverFilesWithProjectCatalog hydrates a selected project outside the re
     const overviewScan = await discoverFilesWithProjectCatalog(roots);
     const selectedScan = await discoverFilesWithProjectCatalog(roots, "stikon-dispatcher");
 
-    expect(overviewScan.files.some((entry) => entry.path === quietPath)).toBe(false);
+    expect(overviewScan.files.filter((entry) => entry.project === "stikon-dispatcher")).toHaveLength(PROJECT_FILE_FLOOR);
     expect(selectedScan.projectCatalog.find((entry) => entry.project === "stikon-dispatcher")).toEqual({
       project: "stikon-dispatcher",
-      conversations: 1,
-      smt: startedAt - 10,
+      conversations: PROJECT_FILE_FLOOR + 2,
+      smt: startedAt - 9,
     });
-    expect(selectedScan.files.some((entry) => entry.path === quietPath && entry.project === "stikon-dispatcher")).toBe(true);
+    expect(selectedScan.files.filter((entry) => entry.project === "stikon-dispatcher").map((entry) => entry.path)).toEqual(
+      quietPaths.reverse(),
+    );
   } finally {
     if (previousStateDir === undefined) delete process.env.LLV_STATE_DIR;
     else process.env.LLV_STATE_DIR = previousStateDir;
@@ -304,7 +392,7 @@ test("discoverFilesWithProjectCatalog refreshes cached projects when flow state 
     }
 
     const first = await discoverFilesWithProjectCatalog(roots);
-    expect(first.files.some((entry) => entry.path === sessionPath)).toBe(false);
+    expect(first.files.some((entry) => entry.path === sessionPath)).toBe(true);
     expect(first.projectCatalog.some((entry) => entry.project === staleProject)).toBe(true);
 
     await mkdir(stateDir, { recursive: true });

--- a/src/lib/scanner/discover.ts
+++ b/src/lib/scanner/discover.ts
@@ -6,7 +6,8 @@ import type { FileEntry, ProjectCatalogEntry, RootKey } from "../types";
 import { codexThreadIdFromPath, nativeCodexParentThreadId } from "./codexNative";
 import { describe } from "./describe";
 import { projectCatalogSnapshotFromRaw } from "./projectCatalog";
-import { EXTS, FILE_CAP, ROOTS, scanRootEntries } from "./roots";
+import { projectResolutionStateKey } from "./projectState";
+import { EXTS, FILE_CAP, PROJECT_FILE_FLOOR, ROOTS, scanRootEntries } from "./roots";
 
 export function taskParts(root: string, pathname: string): [string, string, string] | null {
   const parts = path.relative(root, pathname).split(path.sep);
@@ -96,13 +97,49 @@ function rootEntries(roots: Roots | RootEntries): RootEntries {
 
 async function discoverRaw(roots: Roots | RootEntries, limit: Limit): Promise<RawEntry[]> {
   const staticRoots = Array.isArray(roots) ? ROOTS : roots;
-  return (await Promise.all(rootEntries(roots).map(async ([rootName, root]) => {
+  const raw = (await Promise.all(rootEntries(roots).map(async ([rootName, root]) => {
     if (!(await rootExists(root, limit))) return [];
     return walk(rootName, staticRoots, root, root, limit);
   }))).flat();
+  /* Codex account roots follow the legacy root in registry order. A copied
+     rollout therefore resolves to its managed-account copy before ranking. */
+  const codexRollouts = new Map<string, RawEntry>();
+  for (const entry of raw) {
+    const filename = path.basename(entry.path);
+    if (entry.rootName !== "codex-sessions" || !filename.startsWith("rollout-") || !filename.endsWith(".jsonl")) continue;
+    const current = codexRollouts.get(filename);
+    if (!current || current.root !== entry.root) codexRollouts.set(filename, entry);
+  }
+  return raw.filter((entry) => {
+    const filename = path.basename(entry.path);
+    if (entry.rootName !== "codex-sessions" || !filename.startsWith("rollout-") || !filename.endsWith(".jsonl")) return true;
+    return codexRollouts.get(filename) === entry;
+  });
+}
+
+function cappedEntries(ranked: RawEntry[], projectByPath: ReadonlyMap<string, string>): RawEntry[] {
+  /* The per-project floor can exceed the base cap when the project count is
+     unusually large. Keeping every project represented takes precedence;
+     parent closure and selected-project hydration already make the cap a base
+     target. */
+  const selectedPaths = new Set<string>();
+  const projectCounts = new Map<string, number>();
+  for (const entry of ranked) {
+    const project = projectByPath.get(entry.path) ?? "other";
+    const count = projectCounts.get(project) ?? 0;
+    if (count >= PROJECT_FILE_FLOOR) continue;
+    projectCounts.set(project, count + 1);
+    selectedPaths.add(entry.path);
+  }
+  for (const entry of ranked) {
+    if (selectedPaths.size >= FILE_CAP) break;
+    selectedPaths.add(entry.path);
+  }
+  return ranked.filter((entry) => selectedPaths.has(entry.path));
 }
 
 function entriesFromRaw(raw: RawEntry[], selectedProject?: string, projectByPath?: ReadonlyMap<string, string>, demoted?: ReadonlySet<string>, pin?: ReadonlySet<string>): FileEntry[] {
+  const stateKey = projectResolutionStateKey();
   raw.sort((a, b) => b.st.mtimeMs - a.st.mtimeMs);
   const rawByCodexThread = new Map<string, RawEntry>();
   for (const entry of raw) {
@@ -117,7 +154,7 @@ function entriesFromRaw(raw: RawEntry[], selectedProject?: string, projectByPath
   const ranked = demoted?.size
     ? [...raw.filter((entry) => !demoted.has(entry.path)), ...raw.filter((entry) => demoted.has(entry.path))]
     : raw;
-  const selected = ranked.slice(0, FILE_CAP);
+  const selected = cappedEntries(ranked, projectByPath ?? new Map());
   const selectedPaths = new Set(selected.map((entry) => entry.path));
   /* Selected-project hydration deliberately ignores demotion: legacy `#f=`
      deep links resolve an archived predecessor from the hydrated feed to
@@ -126,7 +163,7 @@ function entriesFromRaw(raw: RawEntry[], selectedProject?: string, projectByPath
   if (selectedProject) {
     for (const entry of raw) {
       if (selectedPaths.has(entry.path)) continue;
-      const project = projectByPath?.get(entry.path) ?? (describe(entry.rootName, entry.root, entry.path, entry.st).project || "other");
+      const project = projectByPath?.get(entry.path) ?? (describe(entry.rootName, entry.root, entry.path, entry.st, stateKey).project || "other");
       if (project !== selectedProject) continue;
       selectedPaths.add(entry.path);
       selected.push(entry);
@@ -154,7 +191,7 @@ function entriesFromRaw(raw: RawEntry[], selectedProject?: string, projectByPath
     }
   }
   return selected.map((entry) => {
-    const meta = describe(entry.rootName, entry.root, entry.path, entry.st);
+    const meta = describe(entry.rootName, entry.root, entry.path, entry.st, stateKey);
     return {
       path: entry.path,
       root: entry.rootName,
@@ -195,7 +232,6 @@ export async function discoverFilesWithProjectCatalog(
 export async function discoverFiles(roots: Roots | RootEntries = scanRootEntries(), demote?: ReadonlySet<string>): Promise<FileEntry[]> {
   const limit = createLimiter(48);
   const raw = await discoverRaw(roots, limit);
-  // describe() reads file heads, so it runs only on the capped shortlist plus
-  // parent closure; the walk stays a cheap stat pass over every candidate.
-  return entriesFromRaw(raw, undefined, undefined, demote);
+  const { projectByPath } = projectCatalogSnapshotFromRaw(raw, { persist: false });
+  return entriesFromRaw(raw, undefined, projectByPath, demote);
 }

--- a/src/lib/scanner/index.ts
+++ b/src/lib/scanner/index.ts
@@ -38,7 +38,8 @@ function applyProcessState(entry: FileEntry, holders: Map<string, number>) {
  *  1. discover.ts  — walk ROOTS, filter EXTS, skip `tool-results/` and
  *     everything in claude-tasks that is not `<slug>/<sid>/tasks/*.output`,
  *     skip a-prefixed task outputs that mirror subagents/agent-<id>.jsonl,
- *     stat each file, sort by mtime desc, cap at FILE_CAP.
+ *     stat each file, dedupe copied Codex rollouts, reserve each project's
+ *     recent entries, then fill the FILE_CAP target by global mtime.
  *  2. describe.ts  — project/title/kind/engine/fmt per root (port `describe`,
  *     `_scan_jsonl_title`, `_project_from_slug`), size-keyed cache.
  *  3. activity.ts  — port `_tail_records`, `_jsonl_turn_state`, `_activity`

--- a/src/lib/scanner/projectCatalog.ts
+++ b/src/lib/scanner/projectCatalog.ts
@@ -98,7 +98,7 @@ function cachedFile(raw: RawEntry, state: ProjectCatalogState, stateKey: string)
   ) {
     return { path: raw.path, ...cached };
   }
-  const meta = describe(raw.rootName, raw.root, raw.path, raw.st);
+  const meta = describe(raw.rootName, raw.root, raw.path, raw.st, stateKey);
   const file: ProjectCatalogFile = {
     path: raw.path,
     rootName: raw.rootName,

--- a/src/lib/scanner/roots.ts
+++ b/src/lib/scanner/roots.ts
@@ -57,8 +57,11 @@ export const EXTS = [".log", ".jsonl", ".output", ".txt"] as const;
 
 export const MAX_CHUNK = 768 * 1024;
 
-/** Max entries returned by /api/files (most recent first). */
-export const FILE_CAP = 400;
+/** Base target for entries returned by /api/files (most recent first). */
+export const FILE_CAP = 800;
+
+/** Recent entries reserved for every project before the global recency fill. */
+export const PROJECT_FILE_FLOOR = 10;
 
 function realpathSafe(p: string): string | null {
   try {


### PR DESCRIPTION
## Summary

- reserve each project’s 10 newest scanner entries before filling the global recency target
- coalesce copied Codex rollout filenames across session roots and give the managed account copy precedence
- raise the base file target from 400 to 800
- reuse one project-resolution state key per scan to keep warm discovery latency low
- cover flooding fairness, dual-root deduplication, project hydration, and the existing grouping contract

## Verification

- `bun install`
- `bunx tsc --noEmit`
- `bun test` — 2,185 passed
- `bun test src/lib/scanner/describe.test.ts` — 16 passed
- real-root discovery at 800 files — 4.4 s cold cache, 89–107 ms warm

Closes #169