### PR TITLE
test: lock verification sweep regressions

### DIFF
--- a/src/components/DraftAgentPane.dom.test.tsx
+++ b/src/components/DraftAgentPane.dom.test.tsx
@@ -59,9 +59,18 @@ afterEach(() => {
   globalThis.fetch = realFetch;
 });
 
-test("Reviewer role exposes and persists the reviewed conversation selection", async () => {
-  globalThis.fetch = (async (input) => {
+test("Reviewer role persists and submits the reviewed conversation", async () => {
+  const posts: Record<string, unknown>[] = [];
+  globalThis.fetch = (async (input, init) => {
     const url = String(input);
+    if (url === "/api/spawn" && init?.method === "POST") {
+      posts.push(JSON.parse(String(init.body)) as Record<string, unknown>);
+      return {
+        ok: true,
+        status: 202,
+        json: async () => ({ ok: true, state: "starting", launched: false, path: null, launchId: "launch-reviewer" }),
+      } as Response;
+    }
     if (url.startsWith("/api/spawn?")) return { ok: true, json: async () => ({ dirs: ["/repo"] }) } as Response;
     if (url === "/api/accounts") return { ok: true, json: async () => ({ codex: { active: "terra", accounts: [] } }) } as Response;
     if (url === "/api/roles") return {
@@ -100,4 +109,18 @@ test("Reviewer role exposes and persists the reviewed conversation selection", a
   reviews.value = implementer.conversationId;
   flushSync(() => reviews.dispatchEvent(new dom.Event("change", { bubbles: true }) as unknown as Event));
   expect(sessionStorage.getItem("llvDraftPane:review-draft:reviews")).toBe(implementer.conversationId);
+
+  const textarea = host.querySelector("textarea") as HTMLTextAreaElement;
+  const propsKey = Object.keys(textarea).find((key) => key.startsWith("__reactProps$"))!;
+  const props = (textarea as unknown as Record<string, { onChange: (event: unknown) => void }>)[propsKey]!;
+  flushSync(() => props.onChange({ target: { value: "Review the durable membership work" } }));
+  flushSync(() => host.querySelector("form")!.dispatchEvent(new dom.Event("submit", { bubbles: true, cancelable: true }) as unknown as Event));
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  expect(posts).toHaveLength(1);
+  expect(posts[0]).toMatchObject({
+    role: "reviewer",
+    reviews: implementer.conversationId,
+    prompt: "Review the durable membership work",
+  });
 });

--- a/src/components/scheme/layout.test.ts
+++ b/src/components/scheme/layout.test.ts
@@ -389,7 +389,7 @@ describe("pipeline stage placeholder slots (issue #196)", () => {
   });
 
   test("a materialized stage dissolves exactly its slot; the next slot sits where the tree drops the tip's child (attach IN PLACE)", () => {
-    const root = entry({ path: "/arch" });
+    const root = entry({ path: "/arch", activity: "live" });
     const group: BranchGroup = { key: "/arch", columns: [{ file: root, tasks: [] }], returnable: [], finished: [], smt: root.mtime, orphanTask: false };
     const running = staged({
       state: "running",
@@ -407,20 +407,12 @@ describe("pipeline stage placeholder slots (issue #196)", () => {
     const next = layout.slots[0]!;
     expect(next.x).toBe(node.x + INDENT);
     expect(next.y).toBeGreaterThanOrEqual(node.y + node.h);
+    const builder = entry({ path: "/builder", parent: "/arch", kind: "subagent" });
+    const attachedFiles = [root, builder];
     const attached = buildSchemeLayout(
-      [
-        group,
-        {
-          key: "/builder",
-          columns: [{ file: entry({ path: "/builder", parent: "/arch" }), tasks: [] }],
-          returnable: [],
-          finished: [],
-          smt: 1_000,
-          orphanTask: false,
-        },
-      ],
+      buildBranchGroups(attachedFiles, "demo"),
       [],
-      [root, entry({ path: "/builder", parent: "/arch" })],
+      attachedFiles,
       [],
       [],
       [staged({
@@ -433,10 +425,9 @@ describe("pipeline stage placeholder slots (issue #196)", () => {
       })],
       [],
     );
-    /* Note: whether the builder lands as /arch's tree child or its own column,
-       the invariant under test is positional: its window must take the slot's
-       coordinates from the previous poll's layout when the topology matches
-       (child-of-tip), which the INDENT/GAP_Y anchor above encodes. */
+    const attachedBuilder = attached.nodes.find((candidate) => candidate.file.path === builder.path)!;
+    expect({ x: attachedBuilder.x, y: attachedBuilder.y, w: attachedBuilder.w })
+      .toEqual({ x: next.x, y: next.y, w: next.w });
     expect(attached.slots.map((slot) => slot.stage.id)).toEqual(["review"]);
     /* Exactly one halo encloses both the live node and the remaining slots. */
     const halos = layout.groups.filter((candidate) => candidate.kind === "pipeline" && candidate.id === "p9");

--- a/src/lib/pipelines/visibility.test.ts
+++ b/src/lib/pipelines/visibility.test.ts
@@ -3,8 +3,35 @@ import { expect, test } from "bun:test";
 import type { DurableConversationMembership } from "@/lib/agent/registry";
 import type { FileEntry } from "@/lib/types";
 
+import { buildBranchGroups } from "@/components/projectModel";
+import { stageOpenTarget } from "@/components/pipelines/pipelineModel";
+import { buildSchemeLayout } from "@/components/scheme/layout";
+
 import { filterPipelinesForFileScan } from "./visibility";
 import type { Pipeline } from "./types";
+
+function file(path: string, over: Partial<FileEntry> = {}): FileEntry {
+  return {
+    path,
+    root: "codex-sessions",
+    name: path,
+    project: "repo",
+    title: path,
+    engine: "codex",
+    kind: "session",
+    fmt: "codex",
+    parent: null,
+    mtime: 1,
+    size: 1,
+    activity: "idle",
+    proc: null,
+    pid: null,
+    model: null,
+    pendingQuestion: null,
+    waitingInput: null,
+    ...over,
+  };
+}
 
 function hiddenPipeline(conversationId: string): Pipeline {
   return {
@@ -61,4 +88,50 @@ test("a pinned resumed member restores its hidden pipeline read model", () => {
     restored: true,
     runs: [{ attempts: [{ conversationId, agentPath: "/resumed.jsonl" }] }],
   });
+});
+
+test("a resumed member keeps its pipeline rail, halo, and open target on the current transcript", () => {
+  const sourceId = "conversation_019f4906-3f67-7b72-9fbc-9ec3b5ad1325";
+  const memberId = "conversation_019f4906-3f67-7b72-9fbc-9ec3b5ad1326";
+  const source = file("/source.jsonl", { conversationId: sourceId, activity: "live" });
+  const resumed = file("/new.jsonl", { conversationId: memberId, parent: source.path, kind: "subagent" });
+  const archived = file("/old.jsonl", { conversationId: memberId, migratedTo: resumed.path });
+  const pipeline = {
+    ...hiddenPipeline(memberId),
+    hiddenAt: undefined,
+    state: "running",
+    cursor: { stageId: "verify", state: "running" },
+    stages: [
+      { id: "build", kind: "run", prompt: "build", next: "verify" },
+      { id: "verify", kind: "run", prompt: "verify", next: null },
+    ],
+    runs: [
+      { stageId: "build", attempts: [{ n: 1, state: "passed", conversationId: sourceId, agentPath: source.path }] },
+      { stageId: "verify", attempts: [{ n: 1, state: "running", conversationId: memberId, agentPath: archived.path }] },
+    ],
+  } as Pipeline;
+
+  const projected = filterPipelinesForFileScan([pipeline], [source, archived, resumed])[0]!;
+  const currentFiles = [source, resumed];
+  const layout = buildSchemeLayout(
+    buildBranchGroups(currentFiles, "repo"),
+    [],
+    currentFiles,
+    [],
+    [],
+    [projected],
+    [projected],
+  );
+  const currentAttempt = projected.runs[1]!.attempts[0]!;
+
+  expect(currentAttempt.agentPath).toBe(resumed.path);
+  expect(layout.links).toContainEqual(expect.objectContaining({
+    kind: "pipeline",
+    from: source.path,
+    to: resumed.path,
+  }));
+  expect(layout.groups.find((group) => group.pipeline?.id === projected.id)?.members)
+    .toEqual(expect.arrayContaining([source.path, resumed.path]));
+  expect(stageOpenTarget(projected.stages[1]!, currentAttempt, undefined, new Set(currentFiles.map((entry) => entry.path))))
+    .toEqual({ kind: "path", path: resumed.path });
 });


### PR DESCRIPTION
## Summary

- assert Reviewer-role composer launches carry the reviewed conversation into the durable spawn request
- verify resumed pipeline members retain their rail, halo, and current-transcript open target
- pin placeholder-to-live-window coordinates across stage attachment

## Context

Tests retained from the verification sweep in #201. The sweep filed the remaining product failure as #205. This PR is test-only.

## Verification

- `bunx tsc --noEmit`
- `bun test`
- focused regression files: 17 passed
- fresh-context diff review: zero findings

Refs #201