### PR TITLE
Board undo/redo island: restore accidentally closed cards (#184)

### DIFF
--- a/src/components/BoardHistoryControls.dom.test.tsx
+++ b/src/components/BoardHistoryControls.dom.test.tsx
@@ -1,0 +1,107 @@
+import { afterEach, expect, test } from "bun:test";
+import { act } from "react";
+import { Window } from "happy-dom";
+import { flushSync } from "react-dom";
+import { createRoot, type Root } from "react-dom/client";
+
+import type { BoardHistoryEntry } from "@/lib/board/history";
+
+import { BoardHistoryControls } from "./BoardHistoryControls";
+
+const dom = new Window();
+Object.assign(globalThis, {
+  IS_REACT_ACT_ENVIRONMENT: true,
+  window: dom,
+  document: dom.document,
+  navigator: dom.navigator,
+  Node: dom.Node,
+  HTMLElement: dom.HTMLElement,
+  HTMLButtonElement: dom.HTMLButtonElement,
+  Event: dom.Event,
+  MouseEvent: dom.MouseEvent,
+});
+
+let root: Root | null = null;
+afterEach(() => {
+  if (root) flushSync(() => root!.unmount());
+  root = null;
+});
+
+const close = (title: string): BoardHistoryEntry => ({ kind: "close", path: `${title}.jsonl`, title });
+
+async function mount(node: React.ReactElement): Promise<{ buttons: HTMLButtonElement[]; container: HTMLElement }> {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  /* Async act flushes the useSyncExternalStore hydration re-render (locale) that
+     a bare sync render would leave uncommitted and warn about. */
+  await act(async () => root!.render(node));
+  const buttons = [...container.querySelectorAll("button")] as unknown as HTMLButtonElement[];
+  return { buttons, container };
+}
+
+test("both arrows are disabled with an empty history", async () => {
+  const { buttons } = await mount(
+    <BoardHistoryControls
+      canUndo={false}
+      canRedo={false}
+      undoEntry={null}
+      redoEntry={null}
+      onUndo={() => {}}
+      onRedo={() => {}}
+      isMobile={false}
+    />,
+  );
+  expect(buttons).toHaveLength(2);
+  const [undo, redo] = buttons;
+  expect(undo!.disabled).toBe(true);
+  expect(redo!.disabled).toBe(true);
+  /* Edge tooltips explain why the control is inert. */
+  expect(undo!.getAttribute("title")).toBe("Nothing to undo");
+  expect(redo!.getAttribute("title")).toBe("Nothing to redo");
+});
+
+test("undo enabled, tooltip names the card the next undo restores", async () => {
+  const clicks: string[] = [];
+  const { buttons } = await mount(
+    <BoardHistoryControls
+      canUndo
+      canRedo={false}
+      undoEntry={close("Alpha")}
+      redoEntry={null}
+      onUndo={() => clicks.push("undo")}
+      onRedo={() => clicks.push("redo")}
+      isMobile={false}
+    />,
+  );
+  const [undo, redo] = buttons;
+  expect(undo!.disabled).toBe(false);
+  expect(redo!.disabled).toBe(true);
+  expect(undo!.getAttribute("title")).toBe("Undo — reopen “Alpha”");
+  act(() => {
+    undo!.dispatchEvent(new dom.MouseEvent("click", { bubbles: true }) as unknown as MouseEvent);
+  });
+  /* The disabled redo swallows its click. */
+  act(() => {
+    redo!.dispatchEvent(new dom.MouseEvent("click", { bubbles: true }) as unknown as MouseEvent);
+  });
+  expect(clicks).toEqual(["undo"]);
+});
+
+test("mobile sizing meets the 44px touch target", async () => {
+  const { buttons } = await mount(
+    <BoardHistoryControls
+      canUndo
+      canRedo
+      undoEntry={close("Alpha")}
+      redoEntry={close("Beta")}
+      onUndo={() => {}}
+      onRedo={() => {}}
+      isMobile
+    />,
+  );
+  for (const btn of buttons) {
+    expect(btn.className).toContain("h-11");
+    expect(btn.className).toContain("w-11");
+  }
+});

--- a/src/components/BoardHistoryControls.tsx
+++ b/src/components/BoardHistoryControls.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+import { Redo2, Undo2 } from "lucide-react";
+
+import type { BoardHistoryEntry } from "@/lib/board/history";
+import { useLocale } from "@/lib/i18n";
+
+interface BoardHistoryControlsProps {
+  canUndo: boolean;
+  canRedo: boolean;
+  /** Next action an undo would reverse — its title drives the tooltip. */
+  undoEntry: BoardHistoryEntry | null;
+  redoEntry: BoardHistoryEntry | null;
+  onUndo: () => void;
+  onRedo: () => void;
+  /** Coarse-pointer sizing: 44px hit targets on phones, compact on desktop. */
+  isMobile: boolean;
+}
+
+/**
+ * The board undo/redo island (issue #184): two arrow buttons that step through
+ * the user's recent board actions. Undo reopens the last closed card; redo
+ * closes it again. Disabled at the edges of the history, and a hover/tap tooltip
+ * names what the next undo would restore. A small segmented pair, sitting near
+ * the other board controls in the project header.
+ */
+export function BoardHistoryControls({
+  canUndo,
+  canRedo,
+  undoEntry,
+  redoEntry,
+  onUndo,
+  onRedo,
+  isMobile,
+}: BoardHistoryControlsProps) {
+  const { t } = useLocale();
+
+  const undoTitle = undoEntry?.title.trim();
+  const redoTitle = redoEntry?.title.trim();
+  const undoTooltip = canUndo
+    ? undoTitle
+      ? t("board.undoReopen", { title: undoTitle })
+      : t("board.undo")
+    : t("board.undoNothing");
+  const redoTooltip = canRedo
+    ? redoTitle
+      ? t("board.redoReclose", { title: redoTitle })
+      : t("board.redo")
+    : t("board.redoNothing");
+
+  const button = isMobile ? "h-11 w-11" : "h-7 w-8";
+  const icon = isMobile ? "h-5 w-5" : "h-4 w-4";
+  const base =
+    "flex items-center justify-center text-primary transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 hover:text-accent disabled:cursor-default disabled:text-muted disabled:opacity-40 disabled:hover:text-muted";
+
+  return (
+    <div
+      className="inline-flex shrink-0 items-center overflow-hidden rounded-[8px] border border-border bg-card"
+      role="group"
+      aria-label={t("board.historyGroup")}
+    >
+      <button
+        type="button"
+        className={`${base} ${button} rounded-l-[7px]`}
+        onClick={onUndo}
+        disabled={!canUndo}
+        aria-label={undoTooltip}
+        title={undoTooltip}
+      >
+        <Undo2 className={icon} aria-hidden />
+      </button>
+      <span className="h-5 w-px shrink-0 bg-border" aria-hidden />
+      <button
+        type="button"
+        className={`${base} ${button} rounded-r-[7px]`}
+        onClick={onRedo}
+        disabled={!canRedo}
+        aria-label={redoTooltip}
+        title={redoTooltip}
+      >
+        <Redo2 className={icon} aria-hidden />
+      </button>
+    </div>
+  );
+}

--- a/src/components/ProjectDashboard.tsx
+++ b/src/components/ProjectDashboard.tsx
@@ -3,6 +3,7 @@
 import { List, ListTodo, Menu, MessageSquarePlus, MoreHorizontal, Network, Plus } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
 
+import { useBoardActionHistory } from "@/hooks/useBoardActionHistory";
 import { queueColumnOpen, useBoardState } from "@/hooks/useBoardState";
 import { useIsMobile } from "@/hooks/useIsMobile";
 import { viewBus } from "@/hooks/viewPresenceBus";
@@ -14,6 +15,7 @@ import type { FileEntry, ProjectCatalogEntry } from "@/lib/types";
 import { MAX_VISIBLE_PATHS } from "@/lib/view/types";
 import type { Workflow } from "@/lib/workflows/types";
 
+import { BoardHistoryControls } from "./BoardHistoryControls";
 import { TaskStrip } from "./BranchPane";
 import { ConversationList } from "./ConversationList";
 import { clearDraftStorage, draftCwd, draftParentConversationId, draftSrc, replaceUnverifiedDraftCwd, requireDraftCwdConfirmation, seedDraftCwd, setDraftCwd, setDraftSrc, setDraftText } from "./DraftAgentPane";
@@ -293,6 +295,10 @@ export function ProjectDashboard({
      one-time seed from the old per-browser localStorage (#38). Reads stay
      optimistic — a local edit shows at once, then PATCHes. */
   const board = useBoardState(project);
+  /* Per-project, device-local undo/redo log of recent board actions (issue
+     #184). v1 records card closes; undo reopens the last-closed card through the
+     shared restore path, redo closes it again. */
+  const history = useBoardActionHistory(project);
   const prefs = useMemo<ColumnPrefs>(
     () => ({ manual: board.prefs.manual, hidden: board.prefs.hidden, expanded: board.prefs.expanded }),
     [board.prefs],
@@ -753,7 +759,8 @@ export function ProjectDashboard({
     openSwitchboardFile(file);
   };
 
-  const closeNode = (path: string) => {
+  /* The raw close, shared by an explicit user close and a history redo. */
+  const applyClose = (path: string) => {
     /* Closing a chat also puts out its tmux pane; fire-and-forget, since the
        node disappears either way and a pane that survived a failed request
        just stays for the next close. Branch nodes are filtered server-side —
@@ -771,6 +778,15 @@ export function ProjectDashboard({
     board.mutate([planClose(path, ephemeral).mutation]);
     setEphemeral((prev) => planClose(path, prev).ephemeral);
     onCloseFile?.(path);
+  };
+
+  const closeNode = (path: string) => {
+    /* Record the close in the undo log before applying it, capturing the current
+       title for the undo tooltip. Redo replays through `applyClose` directly, so
+       it never re-records and the log stays a single linear trail. */
+    const title = projectCatalog.get(path)?.title ?? files.find((file) => file.path === path)?.title ?? "";
+    history.record({ kind: "close", path, title });
+    applyClose(path);
   };
 
   /* Latest manual list behind a ref so the convergence effect below reads
@@ -856,6 +872,45 @@ export function ProjectDashboard({
     pendingFocusRef.current = file.path;
   };
   const openFullCatalogFile = onOpenCatalogFile ?? openSwitchboardFile;
+
+  /* Undo a close: reopen the card through the shared restore path so #199's
+     durable membership rebinds it to its pipeline/review zone automatically. When
+     the file entry is known we go through `openSwitchboardFile` (same role-based
+     placement + focus as an explicit open); otherwise we lift the tombstone
+     directly so a card whose transcript is momentarily absent still comes back. */
+  const onUndo = () => {
+    const entry = history.undo();
+    if (entry === null || entry.kind !== "close") return;
+    const file = projectCatalog.get(entry.path) ?? files.find((item) => item.path === entry.path);
+    if (file) openSwitchboardFile(file);
+    else board.restore(entry.path, "manual");
+  };
+  const onRedo = () => {
+    const entry = history.redo();
+    if (entry === null || entry.kind !== "close") return;
+    applyClose(entry.path);
+  };
+  /* Keep the keyboard handler pointed at the latest closures without re-binding
+     the listener every render. */
+  const undoRedoRef = useRef({ onUndo, onRedo });
+  undoRedoRef.current = { onUndo, onRedo };
+  useEffect(() => {
+    if (project === null) return;
+    const onKey = (event: KeyboardEvent) => {
+      if (!(event.ctrlKey || event.metaKey) || event.altKey) return;
+      if (event.key.toLowerCase() !== "z") return;
+      /* Never steal Ctrl+Z from a text field — the composer and rename inputs own
+         their own undo. */
+      const target = event.target as HTMLElement | null;
+      const tag = target?.tagName;
+      if (tag === "INPUT" || tag === "TEXTAREA" || target?.isContentEditable) return;
+      event.preventDefault();
+      if (event.shiftKey) undoRedoRef.current.onRedo();
+      else undoRedoRef.current.onUndo();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [project]);
 
   const statusBits: string[] = [];
   if (liveCount) {
@@ -982,6 +1037,15 @@ export function ProjectDashboard({
           </button>
         ) : null}
         <h1 className={`truncate text-[13.5px] font-bold ${isMobile ? "min-w-0 flex-1" : ""}`}>{project}</h1>
+        <BoardHistoryControls
+          canUndo={history.canUndo}
+          canRedo={history.canRedo}
+          undoEntry={history.undoEntry}
+          redoEntry={history.redoEntry}
+          onUndo={onUndo}
+          onRedo={onRedo}
+          isMobile={isMobile}
+        />
         {isMobile ? (
           <>
             {/* Toolbar folds to a single row (findings 1, 7): the scheme/list

--- a/src/hooks/useBoardActionHistory.ts
+++ b/src/hooks/useBoardActionHistory.ts
@@ -1,0 +1,109 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+import {
+  canRedo as historyCanRedo,
+  canUndo as historyCanUndo,
+  emptyHistory,
+  parseHistory,
+  peekRedo,
+  peekUndo,
+  recordAction,
+  stepBack,
+  stepForward,
+  type BoardActionHistoryV1,
+  type BoardHistoryEntry,
+} from "@/lib/board/history";
+
+/* Per-project, per-browser log. The board arrangement itself moved to the
+   shared server store (#38), but the undo/redo log stays client-side (issue
+   #184): it is a personal, device-local trail of *this* user's recent actions,
+   not durable board membership. localStorage keeps it across reloads. */
+const storageKey = (project: string) => `llvBoardHistory:${project}`;
+
+function readStorage(project: string): BoardActionHistoryV1 {
+  if (typeof window === "undefined") return emptyHistory();
+  try {
+    const raw = window.localStorage.getItem(storageKey(project));
+    return raw ? parseHistory(JSON.parse(raw)) : emptyHistory();
+  } catch {
+    return emptyHistory();
+  }
+}
+
+function writeStorage(project: string, history: BoardActionHistoryV1): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(storageKey(project), JSON.stringify(history));
+  } catch {
+    /* private mode / quota: the log still works for this session, just not persisted */
+  }
+}
+
+export interface BoardActionHistory {
+  canUndo: boolean;
+  canRedo: boolean;
+  /** The entry the next undo would reverse (last close), or null at the edge. */
+  undoEntry: BoardHistoryEntry | null;
+  /** The entry the next redo would re-apply, or null at the edge. */
+  redoEntry: BoardHistoryEntry | null;
+  /** Append a freshly performed action, forking a new future. */
+  record(entry: BoardHistoryEntry): void;
+  /** Step back one action; returns the undone entry for the caller to reverse. */
+  undo(): BoardHistoryEntry | null;
+  /** Step forward one action; returns the redone entry to re-apply. */
+  redo(): BoardHistoryEntry | null;
+}
+
+/**
+ * React binding over the pure history reducer. Holds one log per project in
+ * component state, seeded from localStorage and persisted on every change.
+ * `project === null` (overview) has no board, so the log is inert.
+ *
+ * `record`/`undo`/`redo` operate on the current render's snapshot and are
+ * re-created each render; callers that need a stable handle (a global key
+ * listener) capture the latest through their own ref, so nothing here goes
+ * stale.
+ */
+export function useBoardActionHistory(project: string | null): BoardActionHistory {
+  const [history, setHistory] = useState<BoardActionHistoryV1>(emptyHistory);
+
+  /* Reload the log whenever the active project changes — the arrangement it
+     mirrors is per-project (like useBoardState's own per-project store). */
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- syncing to the per-project localStorage log
+    setHistory(project === null ? emptyHistory() : readStorage(project));
+  }, [project]);
+
+  const commit = (next: BoardActionHistoryV1) => {
+    setHistory(next);
+    if (project !== null) writeStorage(project, next);
+  };
+
+  const record = (entry: BoardHistoryEntry) => {
+    if (project !== null) commit(recordAction(history, entry));
+  };
+
+  const undo = (): BoardHistoryEntry | null => {
+    const { history: next, entry } = stepBack(history);
+    if (entry !== null) commit(next);
+    return entry;
+  };
+
+  const redo = (): BoardHistoryEntry | null => {
+    const { history: next, entry } = stepForward(history);
+    if (entry !== null) commit(next);
+    return entry;
+  };
+
+  return {
+    canUndo: historyCanUndo(history),
+    canRedo: historyCanRedo(history),
+    undoEntry: peekUndo(history),
+    redoEntry: peekRedo(history),
+    record,
+    undo,
+    redo,
+  };
+}

--- a/src/lib/board/history.test.ts
+++ b/src/lib/board/history.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  BOARD_HISTORY_LIMIT,
+  canRedo,
+  canUndo,
+  emptyHistory,
+  parseHistory,
+  peekRedo,
+  peekUndo,
+  recordAction,
+  stepBack,
+  stepForward,
+  type BoardActionHistoryV1,
+  type BoardHistoryEntry,
+} from "./history";
+
+const close = (path: string, title = path): BoardHistoryEntry => ({ kind: "close", path, title });
+
+describe("board action history reducer", () => {
+  test("empty history has nothing to undo or redo", () => {
+    const h = emptyHistory();
+    expect(canUndo(h)).toBe(false);
+    expect(canRedo(h)).toBe(false);
+    expect(peekUndo(h)).toBeNull();
+    expect(peekRedo(h)).toBeNull();
+  });
+
+  test("recording an action makes it undoable, not redoable", () => {
+    const h = recordAction(emptyHistory(), close("a.jsonl", "Alpha"));
+    expect(canUndo(h)).toBe(true);
+    expect(canRedo(h)).toBe(false);
+    expect(peekUndo(h)).toEqual(close("a.jsonl", "Alpha"));
+  });
+
+  test("undo then redo round-trips the same entry and cursor", () => {
+    const recorded = recordAction(emptyHistory(), close("a.jsonl"));
+    const back = stepBack(recorded);
+    expect(back.entry).toEqual(close("a.jsonl"));
+    expect(canUndo(back.history)).toBe(false);
+    expect(canRedo(back.history)).toBe(true);
+    expect(peekRedo(back.history)).toEqual(close("a.jsonl"));
+
+    const forward = stepForward(back.history);
+    expect(forward.entry).toEqual(close("a.jsonl"));
+    expect(forward.history).toEqual(recorded);
+  });
+
+  test("stepping past an edge is a no-op with a null entry", () => {
+    const empty = emptyHistory();
+    expect(stepBack(empty)).toEqual({ history: empty, entry: null });
+    expect(stepForward(empty)).toEqual({ history: empty, entry: null });
+  });
+
+  test("recording after an undo discards the redo branch", () => {
+    let h = recordAction(emptyHistory(), close("a.jsonl"));
+    h = recordAction(h, close("b.jsonl"));
+    h = stepBack(h).history; // b undone, cursor at 1
+    expect(canRedo(h)).toBe(true);
+    h = recordAction(h, close("c.jsonl")); // forks a new future
+    expect(canRedo(h)).toBe(false);
+    expect(h.entries.map((e) => e.path)).toEqual(["a.jsonl", "c.jsonl"]);
+    expect(h.cursor).toBe(2);
+  });
+
+  test("history is bounded, dropping the oldest entries", () => {
+    let h = emptyHistory();
+    for (let i = 0; i < BOARD_HISTORY_LIMIT + 10; i += 1) h = recordAction(h, close(`c${i}.jsonl`));
+    expect(h.entries.length).toBe(BOARD_HISTORY_LIMIT);
+    expect(h.cursor).toBe(BOARD_HISTORY_LIMIT);
+    expect(h.entries[0]!.path).toBe("c10.jsonl");
+    expect(h.entries.at(-1)!.path).toBe(`c${BOARD_HISTORY_LIMIT + 9}.jsonl`);
+  });
+
+  test("multi-step undo walks back through the log in order", () => {
+    let h = emptyHistory();
+    h = recordAction(h, close("a.jsonl"));
+    h = recordAction(h, close("b.jsonl"));
+    h = recordAction(h, close("c.jsonl"));
+    const first = stepBack(h);
+    expect(first.entry!.path).toBe("c.jsonl");
+    const second = stepBack(first.history);
+    expect(second.entry!.path).toBe("b.jsonl");
+    const third = stepBack(second.history);
+    expect(third.entry!.path).toBe("a.jsonl");
+    expect(canUndo(third.history)).toBe(false);
+  });
+});
+
+describe("parseHistory", () => {
+  test("round-trips a valid serialized log", () => {
+    const h: BoardActionHistoryV1 = { entries: [close("a.jsonl", "Alpha")], cursor: 1 };
+    expect(parseHistory(JSON.parse(JSON.stringify(h)))).toEqual(h);
+  });
+
+  test("non-objects and malformed shapes reset to empty", () => {
+    expect(parseHistory(null)).toEqual(emptyHistory());
+    expect(parseHistory("nope")).toEqual(emptyHistory());
+    expect(parseHistory({ entries: "x", cursor: 0 })).toEqual(emptyHistory());
+    expect(parseHistory({ entries: [{ kind: "move" }], cursor: 1 })).toEqual(emptyHistory());
+    expect(parseHistory({ entries: [{ kind: "close", path: 1, title: "" }], cursor: 1 })).toEqual(emptyHistory());
+  });
+
+  test("an out-of-range cursor is clamped into the entries", () => {
+    expect(parseHistory({ entries: [close("a.jsonl")], cursor: 9 })).toEqual({ entries: [close("a.jsonl")], cursor: 1 });
+    expect(parseHistory({ entries: [close("a.jsonl")], cursor: -3 })).toEqual({ entries: [close("a.jsonl")], cursor: 0 });
+  });
+});

--- a/src/lib/board/history.ts
+++ b/src/lib/board/history.ts
@@ -1,0 +1,109 @@
+/**
+ * Board action history — a bounded, generic undo/redo log for reversible board
+ * actions. v1 records conversation-card closes so an accidental close can be
+ * undone (the card reopens through the existing restore path). The entry union
+ * is discriminated on `kind` so later reversible actions (move, collapse, pin,
+ * task edits) can join the log without migrating persisted state or reshaping
+ * this reducer.
+ *
+ * The log is a single array with a `cursor`: entries in `[0, cursor)` are
+ * applied (undoable), entries in `[cursor, length)` were undone and can be
+ * redone. Recording a fresh action drops the redo branch, mirroring every
+ * editor's undo stack.
+ */
+
+export type BoardHistoryEntry = {
+  kind: "close";
+  /** Absolute conversation path the close/restore acts on. */
+  path: string;
+  /** Conversation title captured at close time, for the button tooltip. May be
+      empty when the title was unknown. */
+  title: string;
+};
+
+export interface BoardActionHistoryV1 {
+  entries: BoardHistoryEntry[];
+  /** Count of applied entries: `[0, cursor)` undoable, `[cursor, len)` redoable. */
+  cursor: number;
+}
+
+/** Bounded so the persisted log never grows without limit (issue #184). */
+export const BOARD_HISTORY_LIMIT = 50;
+
+export function emptyHistory(): BoardActionHistoryV1 {
+  return { entries: [], cursor: 0 };
+}
+
+export function canUndo(history: BoardActionHistoryV1): boolean {
+  return history.cursor > 0;
+}
+
+export function canRedo(history: BoardActionHistoryV1): boolean {
+  return history.cursor < history.entries.length;
+}
+
+/** The entry an undo would act on (the last applied action), or null. */
+export function peekUndo(history: BoardActionHistoryV1): BoardHistoryEntry | null {
+  return canUndo(history) ? history.entries[history.cursor - 1]! : null;
+}
+
+/** The entry a redo would re-apply (the first undone action), or null. */
+export function peekRedo(history: BoardActionHistoryV1): BoardHistoryEntry | null {
+  return canRedo(history) ? history.entries[history.cursor]! : null;
+}
+
+/**
+ * Append a freshly performed action. Any undone tail is discarded first — a new
+ * action forks a new future — then the log is trimmed from the oldest end to the
+ * bound. The cursor always ends at the top, so the new action is immediately
+ * undoable and nothing is redoable.
+ */
+export function recordAction(history: BoardActionHistoryV1, entry: BoardHistoryEntry): BoardActionHistoryV1 {
+  const applied = history.entries.slice(0, history.cursor);
+  const grown = [...applied, entry];
+  const overflow = Math.max(0, grown.length - BOARD_HISTORY_LIMIT);
+  const entries = overflow ? grown.slice(overflow) : grown;
+  return { entries, cursor: entries.length };
+}
+
+/** Step back one action. Returns the undone entry (to be reversed by the caller)
+    and the new history, or the same history with a null entry at the edge. */
+export function stepBack(
+  history: BoardActionHistoryV1,
+): { history: BoardActionHistoryV1; entry: BoardHistoryEntry | null } {
+  if (!canUndo(history)) return { history, entry: null };
+  const entry = history.entries[history.cursor - 1]!;
+  return { history: { entries: history.entries, cursor: history.cursor - 1 }, entry };
+}
+
+/** Step forward one action. Returns the redone entry (to be re-applied by the
+    caller) and the new history, or the same history with a null entry. */
+export function stepForward(
+  history: BoardActionHistoryV1,
+): { history: BoardActionHistoryV1; entry: BoardHistoryEntry | null } {
+  if (!canRedo(history)) return { history, entry: null };
+  const entry = history.entries[history.cursor]!;
+  return { history: { entries: history.entries, cursor: history.cursor + 1 }, entry };
+}
+
+function isEntry(value: unknown): value is BoardHistoryEntry {
+  if (typeof value !== "object" || value === null) return false;
+  const record = value as Record<string, unknown>;
+  return record.kind === "close" && typeof record.path === "string" && typeof record.title === "string";
+}
+
+/**
+ * Parse a persisted log defensively: a corrupt or foreign blob (old schema, a
+ * hand-edited value, a cursor out of range) resets to empty rather than throwing
+ * into render. Unknown entry kinds are dropped so a log written by a newer build
+ * degrades instead of crashing an older one.
+ */
+export function parseHistory(raw: unknown): BoardActionHistoryV1 {
+  if (typeof raw !== "object" || raw === null) return emptyHistory();
+  const record = raw as Record<string, unknown>;
+  if (!Array.isArray(record.entries) || typeof record.cursor !== "number") return emptyHistory();
+  const entries = record.entries.filter(isEntry);
+  if (entries.length !== record.entries.length) return emptyHistory();
+  const cursor = Number.isInteger(record.cursor) ? Math.min(Math.max(0, record.cursor), entries.length) : entries.length;
+  return { entries, cursor };
+}

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -870,6 +870,16 @@ export const en = {
 
   "dash.pipeline": "Pipeline",
   "dash.newPipeline": "New pipeline",
+
+  // Board action history (undo/redo of recent board actions, e.g. closing a card)
+  "board.historyGroup": "Undo and redo board actions",
+  "board.undo": "Undo",
+  "board.redo": "Redo",
+  "board.undoReopen": "Undo — reopen “{title}”",
+  "board.redoReclose": "Redo — close “{title}” again",
+  "board.undoNothing": "Nothing to undo",
+  "board.redoNothing": "Nothing to redo",
+
   "scheme.pipeline": "Pipeline",
   "scheme.pipelineTitle": "Start a pipeline from this conversation",
   "board.pipeline": "Pipeline",

--- a/src/lib/i18n/uk.ts
+++ b/src/lib/i18n/uk.ts
@@ -843,6 +843,16 @@ export const uk: Record<keyof typeof en, Message> = {
 
   "dash.pipeline": "Пайплайн",
   "dash.newPipeline": "Новий пайплайн",
+
+  // Історія дій дошки (скасувати/повторити нещодавні дії, напр. закриття картки)
+  "board.historyGroup": "Скасувати та повторити дії на дошці",
+  "board.undo": "Скасувати",
+  "board.redo": "Повторити",
+  "board.undoReopen": "Скасувати — знову відкрити «{title}»",
+  "board.redoReclose": "Повторити — знову закрити «{title}»",
+  "board.undoNothing": "Немає що скасовувати",
+  "board.redoNothing": "Немає що повторювати",
+
   "scheme.pipeline": "Пайплайн",
   "scheme.pipelineTitle": "Запустити пайплайн із цієї розмови",
   "board.pipeline": "Пайплайн",


### PR DESCRIPTION
Closes #184.

Two arrow buttons (↶ undo / ↷ redo) form a small island in the project header, stepping through the user's own recent board actions. **v1 records conversation-card closes** — undo reopens the last-closed card, redo closes it again. The whole motivation: *"I accidentally closed a window, I press undo and it comes back."*

## What's here
- **Generic action-log reducer** (`src/lib/board/history.ts`) — a bounded (~50 entry) log discriminated on entry `kind`. Undo/redo is a single log with a cursor; recording a fresh action forks a new future and drops the redo branch. The shape is generic so later reversible actions (move, collapse, pin, task edits) can join **without migrating persisted state**, per the issue's extensibility note.
- **`useBoardActionHistory`** — per-project, device-local log persisted to `localStorage`, surviving reloads and respecting the current project. Defensive parse resets a corrupt/foreign blob to empty.
- **Restore goes through the existing path.** Undo calls `openSwitchboardFile`, so a hidden window rebinds to its pipeline/review zone automatically via #199 durable membership — no bespoke restore logic. Falls back to `board.restore(path, "manual")` only when the transcript is momentarily absent.
- **Keyboard**: `Ctrl/⌘+Z` undo, `Ctrl/⌘+Shift+Z` redo, ignored inside inputs/textareas/contenteditable so the composer keeps its own undo.
- **UX**: buttons disabled at the history edges; hover/tap tooltip names the card the next undo would restore; 44px touch targets on mobile, compact on desktop; en+uk labels/tooltips; design tokens only.

## Scope guardrails
UI layer only — nothing under `src/lib/{flows,agent,runtime}` and no route files changed.

## Tests / gates
- `bunx tsc --noEmit` clean; `bun test` → 2472 pass / 0 fail.
- `bun run build` (production) succeeds.
- New coverage: `src/lib/board/history.test.ts` (reducer: record/undo/redo, redo-branch fork, bound, parse) and `src/components/BoardHistoryControls.dom.test.tsx` (disabled edges, tooltip copy, click routing, 44px mobile sizing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)