### PR TITLE
Proximity crown favorites for conversation cards (#185)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -149,6 +149,39 @@ body {
   contain-intrinsic-size: auto 44px;
 }
 
+/* Proximity crown favorites (issue #185): the reveal and the commit both glide
+   — opacity/scale on show, a one-shot pop on the transition to lit — so a
+   favorite lights up beautifully without any layout shift. */
+.favorite-crown {
+  transition: opacity 200ms var(--ease-standard, ease-out), transform 200ms var(--ease-standard, ease-out);
+}
+.favorite-crown.opacity-0 {
+  transform: scale(0.85);
+}
+@keyframes crown-pop {
+  0% {
+    transform: scale(1);
+  }
+  45% {
+    transform: scale(1.28);
+  }
+  100% {
+    transform: scale(1);
+  }
+}
+.favorite-crown.is-favorite {
+  animation: crown-pop 320ms var(--ease-standard, ease-out);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .favorite-crown,
+  .favorite-crown.is-favorite {
+    animation: none;
+    transition: opacity 200ms linear;
+    transform: none;
+  }
+}
+
 /* A node entering the scheme canvas fades in instead of popping. */
 @keyframes scheme-in {
   from {

--- a/src/components/BranchPane.tsx
+++ b/src/components/BranchPane.tsx
@@ -14,6 +14,7 @@ import { conversationIdentity } from "@/lib/accounts/identity";
 
 import { registerLinkTarget } from "./AgentLink";
 import { DeleteFileButton } from "./DeleteFileButton";
+import { FavoriteCrown } from "./FavoriteCrown";
 import { MigrationDivider, MigrationRibbon } from "./MigrationRibbon";
 import { EffortPills } from "./EffortPills";
 import { AgentRuntimeControls } from "./AgentRuntimeControls";
@@ -111,9 +112,13 @@ interface Props {
   /** Bumped to open this pane's rename editor (scheme-board F2 targets the
       expanded overlay, not the node's board pane). */
   autoEditToken?: number;
+  /** Shows the proximity crown favorite control in the header (issue #185).
+      Only the board node and the mobile focus pane opt in — reviewer decks,
+      pipeline placeholders and other embeds render the pane without it. */
+  showFavorite?: boolean;
 }
 
-export function BranchPane({ file, tasks, isRoot, onClose, dragHandle, noComposer, banner, onToggleExpand, expanded, dormant, autoEditToken }: Props) {
+export function BranchPane({ file, tasks, isRoot, onClose, dragHandle, noComposer, banner, onToggleExpand, expanded, dormant, autoEditToken, showFavorite }: Props) {
   const { t } = useLocale();
   const isMobile = useIsMobile();
   const paneRef = useRef<HTMLElement | null>(null);
@@ -231,6 +236,7 @@ export function BranchPane({ file, tasks, isRoot, onClose, dragHandle, noCompose
               </span>
             )}
             <ProcessStatusControls file={file} compact hideChip={isMobile} />
+            {showFavorite ? <FavoriteCrown id={cardId} cardRef={paneRef} touch={isMobile} /> : null}
             {onToggleExpand ? (
               <button
                 className={`inline-flex shrink-0 items-center justify-center rounded-[8px] border border-border bg-canvas text-muted hover:border-accent/45 hover:text-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 ${

--- a/src/components/FavoriteCrown.dom.test.tsx
+++ b/src/components/FavoriteCrown.dom.test.tsx
@@ -1,0 +1,73 @@
+import { afterEach, expect, test } from "bun:test";
+import { Window } from "happy-dom";
+import { useState } from "react";
+import { flushSync } from "react-dom";
+import { createRoot, type Root } from "react-dom/client";
+
+import { FavoriteCrown } from "./FavoriteCrown";
+import { FavoritesProvider, type FavoritesApi } from "./favorites/FavoritesContext";
+
+const dom = new Window();
+Object.assign(globalThis, {
+  window: dom,
+  document: dom.document,
+  navigator: dom.navigator,
+  Node: dom.Node,
+  HTMLElement: dom.HTMLElement,
+  HTMLButtonElement: dom.HTMLButtonElement,
+  Event: dom.Event,
+  MouseEvent: dom.MouseEvent,
+});
+
+let root: Root | null = null;
+afterEach(() => {
+  if (root) flushSync(() => root!.unmount());
+  root = null;
+});
+
+/** A stateful stand-in for the board-backed favorites store, so a click that
+    toggles through the crown actually persists in this harness's state. */
+function Harness({ id }: { id: string }) {
+  const [favorites, setFavorites] = useState<string[]>([]);
+  const api: FavoritesApi = {
+    has: (candidate) => favorites.includes(candidate),
+    toggle: (candidate) =>
+      setFavorites((current) => (current.includes(candidate) ? current.filter((x) => x !== candidate) : [...current, candidate])),
+  };
+  const ref = { current: dom.document.body as unknown as HTMLElement };
+  return (
+    <FavoritesProvider value={api}>
+      <FavoriteCrown id={id} cardRef={ref} touch />
+    </FavoritesProvider>
+  );
+}
+
+function render(node: React.ReactElement): HTMLElement {
+  const container = dom.document.createElement("div");
+  dom.document.body.appendChild(container);
+  root = createRoot(container as unknown as Element);
+  flushSync(() => root!.render(node));
+  return container as unknown as HTMLElement;
+}
+
+test("renders nothing without a favorites provider", () => {
+  const ref = { current: null };
+  const container = render(<FavoriteCrown id="c1" cardRef={ref} touch />);
+  expect(container.querySelector("button")).toBeNull();
+});
+
+test("a touch crown starts unlit and a click toggles it to favorited and back", () => {
+  const container = render(<Harness id="conv-42" />);
+  const button = () => container.querySelector("button")!;
+  expect(button().getAttribute("aria-pressed")).toBe("false");
+  expect(button().getAttribute("data-favorite-crown")).toBe("off");
+
+  flushSync(() => button().click());
+  expect(button().getAttribute("aria-pressed")).toBe("true");
+  expect(button().getAttribute("data-favorite-crown")).toBe("on");
+  expect(button().className).toContain("is-favorite");
+
+  flushSync(() => button().click());
+  expect(button().getAttribute("aria-pressed")).toBe("false");
+  expect(button().getAttribute("data-favorite-crown")).toBe("off");
+});

--- a/src/components/FavoriteCrown.tsx
+++ b/src/components/FavoriteCrown.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import { Crown } from "lucide-react";
+
+import { useProximity } from "@/hooks/useProximity";
+import { useLocale } from "@/lib/i18n";
+
+import { useFavorites } from "./favorites/FavoritesContext";
+
+/* How close (screen px) the pointer must come to the card before the dashed
+   crown fades in. Generous on purpose — the issue asks for a proximity zone
+   around the whole card, not a hover on the icon itself. */
+export const PROXIMITY_RADIUS = 88;
+
+/**
+ * The crown favorite control (issue #185). Idle it is invisible; the pointer
+ * nearing the card fades in a dashed gray outline; hovering the crown previews
+ * a filled state; a click commits the favorite (a lit gold crown that stays
+ * lit, proximity-independent). On touch it is always visible at a 44px target.
+ *
+ * Renders nothing outside a `FavoritesProvider` (no board to persist to) or
+ * without a stable id.
+ */
+export function FavoriteCrown({
+  id,
+  cardRef,
+  touch = false,
+}: {
+  /** Durable conversation identity — `conversationIdentity(file)`. */
+  id: string;
+  /** The card element the proximity zone measures from. */
+  cardRef: React.RefObject<HTMLElement | null>;
+  /** Touch device: always-visible crown, 44px hit target, no hover preview. */
+  touch?: boolean;
+}) {
+  const favorites = useFavorites();
+  const { t } = useLocale();
+  const favorited = favorites?.has(id) ?? false;
+  /* Only pay for a proximity subscription while the crown is hidden and could
+     reveal — a favorited or touch crown is already shown. */
+  const near = useProximity(cardRef, PROXIMITY_RADIUS, !touch && !favorited);
+  if (!favorites) return null;
+
+  const visible = favorited || touch || near;
+  const label = t(favorited ? "branch.unfavorite" : "branch.favorite");
+  return (
+    <button
+      type="button"
+      data-scheme-ui
+      data-favorite-crown={favorited ? "on" : "off"}
+      aria-pressed={favorited}
+      aria-label={label}
+      title={label}
+      onClick={(event) => {
+        event.stopPropagation();
+        favorites.toggle(id);
+      }}
+      className={`favorite-crown group/crown inline-flex shrink-0 items-center justify-center rounded-[8px] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 ${
+        touch ? "h-11 w-11" : "h-6 w-6"
+      } ${visible ? "opacity-100" : "pointer-events-none opacity-0"} ${favorited ? "is-favorite" : ""}`}
+    >
+      <Crown
+        aria-hidden
+        className={`${touch ? "h-5 w-5" : "h-4 w-4"} transition-[color,fill,filter,transform] duration-200 ${
+          favorited
+            ? "fill-warning text-warning drop-shadow-[0_0_5px_color-mix(in_srgb,var(--color-warning)_65%,transparent)]"
+            : "text-muted [stroke-dasharray:2_3] group-hover/crown:fill-warning group-hover/crown:text-warning group-hover/crown:[stroke-dasharray:0]"
+        }`}
+      />
+    </button>
+  );
+}

--- a/src/components/ProjectDashboard.tsx
+++ b/src/components/ProjectDashboard.tsx
@@ -4,6 +4,8 @@ import { List, ListTodo, Menu, MessageSquarePlus, MoreHorizontal, Network, Plus 
 import { useEffect, useMemo, useRef, useState } from "react";
 
 import { queueColumnOpen, useBoardState } from "@/hooks/useBoardState";
+import { conversationIdentity } from "@/lib/accounts/identity";
+import { FavoritesProvider, type FavoritesApi } from "./favorites/FavoritesContext";
 import { useIsMobile } from "@/hooks/useIsMobile";
 import { viewBus } from "@/hooks/viewPresenceBus";
 import type { Flow } from "@/lib/flows/types";
@@ -298,6 +300,35 @@ export function ProjectDashboard({
     [board.prefs],
   );
   const taskPanelOpen = board.prefs.taskPanelOpen;
+  /* Crown favorites (issue #185): the durable id set, an API handed to every
+     card through context, and the resolved rows (one live file per favorited
+     id, freshest generation) the docked panel lists. */
+  const favoriteIds = board.prefs.favorites;
+  const favoritesApi = useMemo<FavoritesApi>(
+    () => ({
+      has: (id) => favoriteIds.includes(id),
+      toggle: (id) => board.setFavorite(id, !favoriteIds.includes(id)),
+    }),
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- board.setFavorite is a stable hook setter
+    [favoriteIds],
+  );
+  /* One row per favorited id that still has a scanned transcript, keeping the
+     freshest generation so a resumed conversation lists once under its current
+     file. Sorted freshest-first for the panel. */
+  const favoriteRows = useMemo(() => {
+    if (favoriteIds.length === 0) return [] as { id: string; file: FileEntry; project: string }[];
+    const favoriteSet = new Set(favoriteIds);
+    const byId = new Map<string, FileEntry>();
+    for (const file of files) {
+      const id = conversationIdentity(file);
+      if (!favoriteSet.has(id)) continue;
+      const existing = byId.get(id);
+      if (!existing || file.mtime > existing.mtime) byId.set(id, file);
+    }
+    return [...byId.entries()]
+      .map(([id, file]) => ({ id, file, project: projectKey(file) }))
+      .sort((a, b) => b.file.mtime - a.file.mtime);
+  }, [files, favoriteIds]);
   const [drafts, setDrafts] = useState<string[]>([]);
   const [pendingRestoredHandoffs, setPendingRestoredHandoffs] = useState<Set<string>>(() => new Set());
   /* The phone focus view reports its currently-focused conversation here so the
@@ -961,6 +992,7 @@ export function ProjectDashboard({
   }, [projectView, schemeAvailable, listAvailable, historyRows, isMobile]);
 
   return (
+    <FavoritesProvider value={favoritesApi}>
     <div className="relative flex min-h-0 min-w-0 flex-1 flex-col">
       <div
         className={
@@ -1206,7 +1238,16 @@ export function ProjectDashboard({
             </div>
           </div>
           {taskPanelOpen ? (
-            <TaskPanel tasks={tasks} project={project} onOpenTask={openTask} onPlaceOnMap={placeOnMap} onClose={toggleTaskPanel} />
+            <TaskPanel
+              tasks={tasks}
+              project={project}
+              favorites={favoriteRows}
+              onOpenFavorite={openSwitchboardFile}
+              onToggleFavorite={(id) => board.setFavorite(id, false)}
+              onOpenTask={openTask}
+              onPlaceOnMap={placeOnMap}
+              onClose={toggleTaskPanel}
+            />
           ) : null}
         </div>
       )}
@@ -1251,5 +1292,6 @@ export function ProjectDashboard({
 
       <TaskToastHost />
     </div>
+    </FavoritesProvider>
   );
 }

--- a/src/components/favorites/FavoritesContext.tsx
+++ b/src/components/favorites/FavoritesContext.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import { createContext, useContext } from "react";
+
+/** Per-project crown favorites, exposed to any conversation card without
+    threading board state through the scheme/node layers (issue #185). Backed by
+    the durable board prefs in `ProjectDashboard`; ids are `conversationIdentity`
+    values so a favorite survives a resume that changes the transcript path. */
+export interface FavoritesApi {
+  has(id: string): boolean;
+  toggle(id: string): void;
+}
+
+const FavoritesContext = createContext<FavoritesApi | null>(null);
+
+export const FavoritesProvider = FavoritesContext.Provider;
+
+/** The favorites API for the enclosing project, or null outside a provider
+    (e.g. a BranchPane rendered in a context with no board). */
+export function useFavorites(): FavoritesApi | null {
+  return useContext(FavoritesContext);
+}

--- a/src/components/mobile/MobileFocusView.tsx
+++ b/src/components/mobile/MobileFocusView.tsx
@@ -382,6 +382,7 @@ export function MobileFocusView({ project, groups, manual, files, flows, pipelin
               file={activeNode.file}
               tasks={activeNode.tasks}
               isRoot={activeNode.isRoot}
+              showFavorite
               onClose={() => onClose(activeNode.file.path)}
               dragHandle={swipeHandle}
             />

--- a/src/components/projectBoardMutations.test.ts
+++ b/src/components/projectBoardMutations.test.ts
@@ -33,7 +33,7 @@ const boardOf = (prefs: Partial<BoardProjectStateV1["prefs"]>, pathAliases: Reco
   revision: 1,
   updatedAt: new Date(0).toISOString(),
   pathAliases,
-  prefs: { manual: [], hidden: [], expanded: [], viewMode: null, taskPanelOpen: false, ...prefs },
+  prefs: { manual: [], hidden: [], expanded: [], favorites: [], viewMode: null, taskPanelOpen: false, ...prefs },
 });
 
 const catalogOf = (files: FileEntry[]): Map<string, FileEntry> => new Map(files.map((file) => [file.path, file]));

--- a/src/components/scheme/nodes.tsx
+++ b/src/components/scheme/nodes.tsx
@@ -914,6 +914,7 @@ function NodeShell({
           tasks={node.tasks}
           isRoot={node.isRoot}
           dormant={dormant}
+          showFavorite
           onClose={() => onClose(node.file.path)}
           onToggleExpand={() => onExpand(node.file.path)}
         />

--- a/src/components/tasks/TaskPanel.tsx
+++ b/src/components/tasks/TaskPanel.tsx
@@ -1,18 +1,87 @@
 "use client";
 
-import { MapPin } from "lucide-react";
+import { Crown, MapPin } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
 
 import { Link2, X } from "@/components/icons";
-import { fmtAge } from "@/components/utils";
+import { activityDot, cleanTitle, fmtAge } from "@/components/utils";
 import { useTaskDraft } from "@/hooks/useTaskDraft";
 import { getLocale, useLocale } from "@/lib/i18n";
 import { formatDue, isOverdue } from "@/lib/tasks/helpers";
 import type { BoardTask } from "@/lib/tasks/types";
+import type { FileEntry } from "@/lib/types";
 
 import { createTask } from "./taskApi";
 import { TaskComposer } from "./TaskComposer";
 import { TASK_TONES, taskTitle } from "./taskModel";
+
+/** A favorited conversation resolved to its freshest scanned generation. */
+export interface FavoriteRow {
+  /** Durable conversation identity (`conversationIdentity`). */
+  id: string;
+  file: FileEntry;
+  project: string;
+}
+
+/**
+ * The crown-favorites list (issue #185), docked above the task list and scoped
+ * by the same project/all toggle. A row click focuses/pins the conversation on
+ * the board; its crown unfavorites in place.
+ */
+function FavoritesSection({
+  rows,
+  scopeAll,
+  onOpen,
+  onToggle,
+}: {
+  rows: FavoriteRow[];
+  scopeAll: boolean;
+  onOpen: (file: FileEntry) => void;
+  onToggle: (id: string) => void;
+}) {
+  const { t } = useLocale();
+  return (
+    <section className="mb-1 flex flex-col gap-0.5" aria-label={t("favorites.sectionTitle")}>
+      <div className="flex items-center gap-1 px-1 pb-0.5 text-[10px] font-bold uppercase tracking-wide text-muted">
+        <Crown className="h-3 w-3 fill-warning text-warning" aria-hidden />
+        {t("favorites.sectionTitle")}
+        {rows.length ? <span className="font-semibold text-muted/70">{rows.length}</span> : null}
+      </div>
+      {rows.length ? (
+        rows.map(({ id, file, project }) => (
+          <div
+            key={id}
+            className="flex items-center gap-1 rounded-[8px] border border-border bg-card px-2 py-1.5 shadow-1 hover:border-accent/40"
+          >
+            <button
+              type="button"
+              className="flex min-w-0 flex-1 items-center gap-1.5 text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40"
+              title={t("favorites.focusTitle", { title: cleanTitle(file.title, 60) })}
+              onClick={() => onOpen(file)}
+            >
+              <span className={`h-2 w-2 shrink-0 rounded-full ${activityDot(file.activity)}`} aria-hidden />
+              <span className="min-w-0 flex-1 truncate text-[11.5px] font-semibold">
+                {cleanTitle(file.title, 90) || t("tasks.untitled")}
+              </span>
+              {scopeAll ? <span className="max-w-[90px] shrink-0 truncate text-[10px] text-muted">{project}</span> : null}
+            </button>
+            <button
+              type="button"
+              className="inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-[6px] text-warning hover:bg-warning-soft focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40"
+              aria-label={t("branch.unfavorite")}
+              title={t("branch.unfavorite")}
+              onClick={() => onToggle(id)}
+            >
+              <Crown className="h-3.5 w-3.5 fill-warning" aria-hidden />
+            </button>
+          </div>
+        ))
+      ) : (
+        <div className="px-2 py-1.5 text-[10.5px] text-muted">{t("favorites.empty")}</div>
+      )}
+    </section>
+  );
+}
 
 /** Freshest work first; done tasks sink to the bottom of the list. */
 function panelOrder(a: BoardTask, b: BoardTask): number {
@@ -92,6 +161,9 @@ function PanelNewTask({ project, onDone }: { project: string; onDone: () => void
 export function TaskPanel({
   tasks,
   project,
+  favorites,
+  onOpenFavorite,
+  onToggleFavorite,
   onOpenTask,
   onPlaceOnMap,
   onClose,
@@ -99,6 +171,12 @@ export function TaskPanel({
   /** Every project's tasks; the header toggle filters. */
   tasks: BoardTask[];
   project: string;
+  /** Favorited conversations across every project; the toggle scopes them (#185). */
+  favorites: FavoriteRow[];
+  /** Focus/pin a favorited conversation on the board. */
+  onOpenFavorite: (file: FileEntry) => void;
+  /** Unfavorite by durable id. */
+  onToggleFavorite: (id: string) => void;
   onOpenTask: (task: BoardTask) => void;
   /** Arms board placement mode for an unplaced task; absent hides the action. */
   onPlaceOnMap?: (task: BoardTask) => void;
@@ -110,6 +188,10 @@ export function TaskPanel({
   const rows = useMemo(
     () => (scope === "project" ? tasks.filter((task) => task.project === project) : [...tasks]).sort(panelOrder),
     [tasks, project, scope],
+  );
+  const favoriteRows = useMemo(
+    () => (scope === "project" ? favorites.filter((row) => row.project === project) : favorites),
+    [favorites, project, scope],
   );
 
   return (
@@ -141,6 +223,7 @@ export function TaskPanel({
         </button>
       </div>
       <div className="flex min-h-0 flex-1 flex-col gap-0.5 overflow-y-auto p-1.5">
+        <FavoritesSection rows={favoriteRows} scopeAll={scope === "all"} onOpen={onOpenFavorite} onToggle={onToggleFavorite} />
         {composing ? (
           <PanelNewTask project={project} onDone={() => setComposing(false)} />
         ) : (

--- a/src/hooks/useBoardState.test.ts
+++ b/src/hooks/useBoardState.test.ts
@@ -138,8 +138,8 @@ test("readLegacyPrefs reconstructs the three old localStorage tiers", () => {
     ["llvTaskPanel", "1"],
   ]);
   const storage = { getItem: (key: string) => map.get(key) ?? null };
-  expect(readLegacyPrefs("proj", storage)).toEqual({ manual: ["/a"], hidden: ["/b"], expanded: ["/c"], viewMode: "list", taskPanelOpen: true });
-  expect(readLegacyPrefs("other", storage)).toEqual({ manual: [], hidden: [], expanded: [], viewMode: null, taskPanelOpen: true });
+  expect(readLegacyPrefs("proj", storage)).toEqual({ manual: ["/a"], hidden: ["/b"], expanded: ["/c"], favorites: [], viewMode: "list", taskPanelOpen: true });
+  expect(readLegacyPrefs("other", storage)).toEqual({ manual: [], hidden: [], expanded: [], favorites: [], viewMode: null, taskPanelOpen: true });
   expect(readLegacyPrefs("proj", { getItem: () => null })).toBeNull();
 });
 

--- a/src/hooks/useBoardState.ts
+++ b/src/hooks/useBoardState.ts
@@ -57,7 +57,7 @@ export function patchPrefix(outbox: readonly BoardMutationV1[], maxCount = MAX_M
   return prefix;
 }
 
-export const EMPTY_BOARD_PREFS: BoardPrefs = { manual: [], hidden: [], expanded: [], viewMode: null, taskPanelOpen: false };
+export const EMPTY_BOARD_PREFS: BoardPrefs = { manual: [], hidden: [], expanded: [], favorites: [], viewMode: null, taskPanelOpen: false };
 
 /* Legacy per-browser keys #38 migrates off of. `llvTaskPanel` is global today;
    it seeds every project's per-project panel state and is left intact so a
@@ -78,7 +78,7 @@ export interface BoardSnapshot {
 }
 
 export function isEmptyPrefs(prefs: BoardPrefs): boolean {
-  return prefs.manual.length === 0 && prefs.hidden.length === 0 && prefs.expanded.length === 0 && prefs.viewMode === null && !prefs.taskPanelOpen;
+  return prefs.manual.length === 0 && prefs.hidden.length === 0 && prefs.expanded.length === 0 && prefs.favorites.length === 0 && prefs.viewMode === null && !prefs.taskPanelOpen;
 }
 
 /** Worth seeding the server with: anything a user actually arranged. Empty
@@ -111,7 +111,9 @@ export function readLegacyPrefs(project: string, storage: Pick<Storage, "getItem
   const viewMode: BoardViewMode = savedView === "scheme" || savedView === "list" ? savedView : null;
   const taskPanelOpen = storage.getItem(LEGACY_TASK_PANEL_KEY) === "1";
   if (!hadColumns && viewMode === null && !taskPanelOpen) return null;
-  return { ...columns, viewMode, taskPanelOpen };
+  /* Favorites are server-only (issue #185) — no legacy per-browser tier feeds
+     them, so the migration seed always carries an empty list. */
+  return { ...columns, favorites: [], viewMode, taskPanelOpen };
 }
 
 /** Coalesce two partial patches: later keys win, so a burst of edits collapses
@@ -556,6 +558,8 @@ export interface BoardState extends BoardSnapshot {
   restore(path: string, placement: "auto" | "manual" | "expanded"): void;
   setViewMode(viewMode: BoardViewMode): void;
   setTaskPanelOpen(open: boolean): void;
+  /** Toggle a durable conversation id in the per-project favorites set (#185). */
+  setFavorite(id: string, favorite: boolean): void;
 }
 
 /**
@@ -607,6 +611,9 @@ export function useBoardState(project: string | null): BoardState {
     },
     setTaskPanelOpen(open) {
       storeRef.current?.mutate([{ kind: "set-presentation", taskPanelOpen: open }]);
+    },
+    setFavorite(id, favorite) {
+      storeRef.current?.mutate([{ kind: "set-favorite", id, favorite }]);
     },
   };
 }

--- a/src/hooks/useProximity.test.ts
+++ b/src/hooks/useProximity.test.ts
@@ -1,0 +1,23 @@
+import { expect, test } from "bun:test";
+
+import { pointerNearRect } from "./useProximity";
+
+const rect = { left: 100, top: 100, right: 200, bottom: 160 };
+
+test("a pointer inside the rect is always near", () => {
+  expect(pointerNearRect(rect, 150, 130, 40)).toBe(true);
+});
+
+test("proximity extends the rect by the radius on every edge", () => {
+  // 30px left of the edge, within a 40px radius.
+  expect(pointerNearRect(rect, 70, 130, 40)).toBe(true);
+  // 50px left of the edge, outside a 40px radius.
+  expect(pointerNearRect(rect, 50, 130, 40)).toBe(false);
+});
+
+test("corners measure true euclidean distance, not a bounding box", () => {
+  // (40, 40) past the top-left corner: distance √3200 ≈ 56.6 > 50.
+  expect(pointerNearRect(rect, 60, 60, 50)).toBe(false);
+  // Same offset, larger radius clears it.
+  expect(pointerNearRect(rect, 60, 60, 60)).toBe(true);
+});

--- a/src/hooks/useProximity.ts
+++ b/src/hooks/useProximity.ts
@@ -1,0 +1,95 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+/** True when the point (px, py) lies within `radius` screen-pixels of the
+    rectangle — distance to the nearest edge, so a point inside the rect is
+    always near. Pure and screen-space, so it works unchanged under the
+    board's camera zoom (both the rect and the pointer are in client coords). */
+export function pointerNearRect(
+  rect: { left: number; top: number; right: number; bottom: number },
+  px: number,
+  py: number,
+  radius: number,
+): boolean {
+  const dx = Math.max(rect.left - px, 0, px - rect.right);
+  const dy = Math.max(rect.top - py, 0, py - rect.bottom);
+  return dx * dx + dy * dy <= radius * radius;
+}
+
+interface Sub {
+  el: HTMLElement;
+  radius: number;
+  near: boolean;
+  notify: (near: boolean) => void;
+}
+
+/* One window pointer listener drives every crown: subscribers each hold their
+   own rect + threshold and flip only when the pointer crosses their proximity
+   boundary, so a card re-renders on enter/leave rather than on every move. The
+   distance sweep is rAF-throttled to at most one layout read per frame. */
+const subscribers = new Set<Sub>();
+let pointerX = Number.NEGATIVE_INFINITY;
+let pointerY = Number.NEGATIVE_INFINITY;
+let frame = 0;
+let listening = false;
+
+function evaluate(): void {
+  frame = 0;
+  for (const sub of subscribers) {
+    const near = pointerNearRect(sub.el.getBoundingClientRect(), pointerX, pointerY, sub.radius);
+    if (near !== sub.near) {
+      sub.near = near;
+      sub.notify(near);
+    }
+  }
+}
+
+function onPointerMove(event: PointerEvent): void {
+  pointerX = event.clientX;
+  pointerY = event.clientY;
+  if (frame === 0) frame = requestAnimationFrame(evaluate);
+}
+
+function ensureListening(): void {
+  if (listening || typeof window === "undefined") return;
+  listening = true;
+  window.addEventListener("pointermove", onPointerMove, { passive: true });
+}
+
+function stopListeningIfIdle(): void {
+  if (subscribers.size > 0 || !listening) return;
+  listening = false;
+  window.removeEventListener("pointermove", onPointerMove);
+  if (frame !== 0) {
+    cancelAnimationFrame(frame);
+    frame = 0;
+  }
+}
+
+/** Reveal-by-proximity: true once the pointer comes within `radius` px of the
+    element, false again when it leaves. A null ref (offscreen pane, disabled)
+    opts out and always reports false, so favorited/always-visible callers never
+    pay for a listener. */
+export function useProximity(
+  ref: React.RefObject<HTMLElement | null>,
+  radius: number,
+  enabled = true,
+): boolean {
+  const [near, setNear] = useState(false);
+  useEffect(() => {
+    const el = enabled ? ref.current : null;
+    if (!el) {
+      setNear(false);
+      return;
+    }
+    const sub: Sub = { el, radius, near: false, notify: setNear };
+    subscribers.add(sub);
+    ensureListening();
+    return () => {
+      subscribers.delete(sub);
+      stopListeningIfIdle();
+    };
+  }, [ref, radius, enabled]);
+  return near;
+}

--- a/src/lib/board/mutations.test.ts
+++ b/src/lib/board/mutations.test.ts
@@ -2,12 +2,12 @@ import { describe, expect, test } from "bun:test";
 
 import { applyBoardMutations } from "./mutations";
 
-const board = (prefs: Partial<{ manual: string[]; hidden: string[]; expanded: string[] }> = {}) => ({
+const board = (prefs: Partial<{ manual: string[]; hidden: string[]; expanded: string[]; favorites: string[] }> = {}) => ({
   schemaVersion: 1 as const,
   revision: 7,
   updatedAt: "2026-07-10T00:00:00.000Z",
   pathAliases: {},
-  prefs: { manual: [], hidden: [], expanded: [], viewMode: null, taskPanelOpen: false, ...prefs },
+  prefs: { manual: [], hidden: [], expanded: [], favorites: [], viewMode: null, taskPanelOpen: false, ...prefs },
 });
 
 describe("board mutations", () => {
@@ -90,5 +90,27 @@ describe("board mutations", () => {
     expect(restored.prefs).toMatchObject({ hidden: [], manual: [], expanded: ["/root"] });
     const reconciled = applyBoardMutations(restored, [{ kind: "reconcile-roots", roots: ["/root"], removeManual: [] }]);
     expect(reconciled.prefs).toMatchObject({ manual: ["/root"], expanded: ["/root"] });
+  });
+
+  test("set-favorite adds and removes durable ids idempotently", () => {
+    const on = applyBoardMutations(board(), [{ kind: "set-favorite", id: "conv-1", favorite: true }]);
+    expect(on.prefs.favorites).toEqual(["conv-1"]);
+    // A second add is a no-op (deduped), not a duplicate.
+    expect(applyBoardMutations(on, [{ kind: "set-favorite", id: "conv-1", favorite: true }]).prefs.favorites).toEqual(["conv-1"]);
+    const off = applyBoardMutations(on, [{ kind: "set-favorite", id: "conv-1", favorite: false }]);
+    expect(off.prefs.favorites).toEqual([]);
+    // Removing an absent id leaves the set untouched.
+    expect(applyBoardMutations(off, [{ kind: "set-favorite", id: "conv-1", favorite: false }]).prefs.favorites).toEqual([]);
+  });
+
+  test("favorites are durable ids kept out of the path alias/hidden machinery", () => {
+    /* A favorite keyed on a conversation id must survive a resume that remaps
+       the transcript path and a close that hides that path — neither should
+       touch the favorites set. */
+    const seeded = applyBoardMutations(board({ manual: ["/old"] }), [{ kind: "set-favorite", id: "conv-9", favorite: true }]);
+    const remapped = applyBoardMutations(seeded, [{ kind: "remap-paths", pairs: [{ from: "/old", to: "/new" }] }]);
+    expect(remapped.prefs.favorites).toEqual(["conv-9"]);
+    const closed = applyBoardMutations(remapped, [{ kind: "close", path: "/new" }]);
+    expect(closed.prefs).toMatchObject({ hidden: ["/new"], favorites: ["conv-9"] });
   });
 });

--- a/src/lib/board/mutations.ts
+++ b/src/lib/board/mutations.ts
@@ -5,7 +5,13 @@ export type BoardMutationV1 =
   | { kind: "restore"; path: string; placement: "auto" | "manual" | "expanded" }
   | { kind: "reconcile-roots"; roots: string[]; removeManual: string[] }
   | { kind: "remap-paths"; pairs: Array<{ from: string; to: string }> }
-  | { kind: "set-presentation"; viewMode?: "scheme" | "list" | null; taskPanelOpen?: boolean };
+  | { kind: "set-presentation"; viewMode?: "scheme" | "list" | null; taskPanelOpen?: boolean }
+  /* Crown favorites (issue #185): `id` is a durable conversation identity
+     (`conversationId` when the backend supplies one, else the transcript path),
+     kept apart from the path-keyed membership lists so it never passes through
+     `resolvePath`/`pathAliases` — a favorite must survive a resume that mints a
+     new transcript path, which the alias graph would otherwise rewrite. */
+  | { kind: "set-favorite"; id: string; favorite: boolean };
 
 function unique(paths: readonly string[]): string[] {
   return [...new Set(paths)];
@@ -46,7 +52,10 @@ function normalize(board: BoardProjectStateV1, aliases = aliasesOf(board)): Boar
     ...board,
     pathAliases: canonicalAliases,
     explicitManual: visible(board.explicitManual ?? []).filter((item) => manualSet.has(item)),
-    prefs: { ...board.prefs, manual, hidden, expanded: visible(board.prefs.expanded) },
+    /* Favorites are durable conversation ids, not transcript paths: dedupe them
+       but keep them out of the alias/hidden machinery so favoriting survives a
+       resume and a favorited-then-closed card stays favorited. */
+    prefs: { ...board.prefs, manual, hidden, expanded: visible(board.prefs.expanded), favorites: unique(board.prefs.favorites ?? []) },
   };
 }
 
@@ -119,6 +128,13 @@ export function applyBoardMutations(board: BoardProjectStateV1, mutations: reado
     }
     if (mutation.kind === "restore") {
       next = restore(next, resolvePath(mutation.path, aliasesOf(next)), mutation.placement);
+      continue;
+    }
+    if (mutation.kind === "set-favorite") {
+      const favorites = mutation.favorite
+        ? unique([...next.prefs.favorites, mutation.id])
+        : next.prefs.favorites.filter((item) => item !== mutation.id);
+      next = normalize({ ...next, prefs: { ...next.prefs, favorites } });
       continue;
     }
     if (mutation.kind === "set-presentation") {

--- a/src/lib/board/store.test.ts
+++ b/src/lib/board/store.test.ts
@@ -18,6 +18,22 @@ describe("board store", () => {
     expect(stale).toMatchObject({ ok: false, board: { revision: 1 } });
     expect(boardFor("viewer", file).prefs.manual).toEqual(["/a"]);
   });
+  test("favorites persist across a reload and survive a legacy board with no favorites field", () => {
+    const file = temporaryFile();
+    const added = mutateBoard("viewer", 0, [{ kind: "set-favorite", id: "conv-1", favorite: true }], file);
+    expect(added).toMatchObject({ ok: true, board: { revision: 1 } });
+    // Survives a fresh read of the persisted file (a reload/deploy).
+    expect(boardFor("viewer", file).prefs.favorites).toEqual(["conv-1"]);
+    // A board written before favorites existed reads back with an empty list.
+    fs.writeFileSync(file, JSON.stringify({ projects: { viewer: {
+      schemaVersion: 1, revision: 5, updatedAt: "2026-07-10T00:00:00.000Z",
+      prefs: { manual: [], hidden: [], expanded: [], viewMode: null, taskPanelOpen: false },
+    } } }), "utf8");
+    expect(boardFor("viewer", file).prefs.favorites).toEqual([]);
+    const seeded = mutateBoard("viewer", 5, [{ kind: "set-favorite", id: "conv-2", favorite: true }], file);
+    expect(seeded).toMatchObject({ ok: true, board: { revision: 6 } });
+    expect(boardFor("viewer", file).prefs.favorites).toEqual(["conv-2"]);
+  });
   test("durable writes fsync the board file and parent directory", async () => {
     const file = temporaryFile();
     const modulePath = path.join(import.meta.dir, "store.ts");
@@ -290,7 +306,7 @@ describe("board store", () => {
     expect(forward.older).toBeUndefined();
     expect(forward.newest).toBeUndefined();
     expect(forward.canonical.prefs).toEqual({
-      manual: ["/a"], hidden: [], expanded: ["/base", "/b"], viewMode: "list", taskPanelOpen: true,
+      manual: ["/a"], hidden: [], expanded: ["/base", "/b"], favorites: [], viewMode: "list", taskPanelOpen: true,
     });
     expect(forward.canonical.pathAliases).toEqual({ "/alias": "/new" });
     expect(reverse.canonical.prefs).toEqual(forward.canonical.prefs);

--- a/src/lib/board/store.ts
+++ b/src/lib/board/store.ts
@@ -9,7 +9,7 @@ import { applyBoardMutations, type BoardMutationV1 } from "@/lib/board/mutations
 import type { BoardFileV1, BoardProjectStateV1 } from "@/lib/view/types";
 
 export const BOARD_FILE = statePath("board.json");
-const EMPTY_PREFS: BoardProjectStateV1["prefs"] = { manual: [], hidden: [], expanded: [], viewMode: null, taskPanelOpen: false };
+const EMPTY_PREFS: BoardProjectStateV1["prefs"] = { manual: [], hidden: [], expanded: [], favorites: [], viewMode: null, taskPanelOpen: false };
 const BOARD_LOCK_ATTEMPTS = 1_000;
 const BOARD_LOCK_WAIT_MS = 5;
 const BOARD_LOCK_STALE_MS = 30_000;
@@ -34,6 +34,7 @@ function projectState(value: unknown): value is BoardProjectStateV1 {
   const prefs = state.prefs;
   return state.schemaVersion === 1 && Number.isInteger(state.revision) && state.revision! >= 0 && typeof state.updatedAt === "string" && Boolean(prefs) &&
     stringArray(prefs!.manual) && stringArray(prefs!.hidden) && stringArray(prefs!.expanded) &&
+    (prefs!.favorites === undefined || stringArray(prefs!.favorites)) &&
     (state.explicitManual === undefined || stringArray(state.explicitManual)) &&
     (state.pathAliases === undefined || aliases(state.pathAliases)) &&
     (prefs!.viewMode === null || prefs!.viewMode === "scheme" || prefs!.viewMode === "list") && typeof prefs!.taskPanelOpen === "boolean";
@@ -52,6 +53,9 @@ function read(filePath: string): BoardFileV1 {
       ...state,
       pathAliases: state.pathAliases ?? {},
       explicitManual: state.explicitManual ?? state.prefs.manual,
+      /* Boards written before favorites existed lack the field; default it so
+         every GET response and reducer input carries the durable-id list. */
+      prefs: { ...state.prefs, favorites: state.prefs.favorites ?? [] },
     }])) };
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code === "ENOENT") return { projects: {} };
@@ -378,6 +382,10 @@ function mergedBoards(states: readonly BoardProjectStateV1[]): BoardProjectState
     manual: [] as string[],
     hidden: [] as string[],
     expanded: [] as string[],
+    /* Durable-id favorites union across the merged project states — they carry
+       no path role, so they merge independently of the manual/hidden/expanded
+       reconciliation. */
+    favorites: [...new Set(ordered.flatMap((state) => state.prefs.favorites ?? []))],
     viewMode,
     taskPanelOpen,
   };

--- a/src/lib/board/validation.test.ts
+++ b/src/lib/board/validation.test.ts
@@ -49,3 +49,20 @@ test("the body cap admits the maximal validator-legal legacy-seed patch", async 
   const parsed = await validateBoardPatchRequest(patchRequest(body));
   expect(parsed.patch?.manual).toHaveLength(512);
 });
+
+test("accepts a well-formed set-favorite mutation and rejects malformed ones", async () => {
+  const ok = await validateBoardPatchRequest(
+    patchRequest({ schemaVersion: 1, project: "proj", baseRevision: 3, mutations: [{ kind: "set-favorite", id: "conv-1", favorite: true }] }),
+  );
+  expect(ok.mutations).toEqual([{ kind: "set-favorite", id: "conv-1", favorite: true }]);
+
+  await expect(
+    validateBoardPatchRequest(patchRequest({ schemaVersion: 1, project: "proj", baseRevision: 3, mutations: [{ kind: "set-favorite", id: "conv-1" }] })),
+  ).rejects.toThrow();
+  await expect(
+    validateBoardPatchRequest(patchRequest({ schemaVersion: 1, project: "proj", baseRevision: 3, mutations: [{ kind: "set-favorite", id: "", favorite: true }] })),
+  ).rejects.toThrow();
+  await expect(
+    validateBoardPatchRequest(patchRequest({ schemaVersion: 1, project: "proj", baseRevision: 3, mutations: [{ kind: "set-favorite", id: "conv-1", favorite: "yes" }] })),
+  ).rejects.toThrow();
+});

--- a/src/lib/board/validation.ts
+++ b/src/lib/board/validation.ts
@@ -72,6 +72,11 @@ function mutation(value: unknown, index: number): BoardMutationV1 {
     }
     return { kind: "remap-paths", pairs };
   }
+  if (raw.kind === "set-favorite") {
+    exact(raw, ["kind", "id", "favorite"], `mutations[${index}]`);
+    if (typeof raw.favorite !== "boolean") throw new ViewValidationError("INVALID_REQUEST", `invalid mutations[${index}].favorite`);
+    return { kind: "set-favorite", id: validPath(raw.id, `mutations[${index}].id`), favorite: raw.favorite };
+  }
   if (raw.kind === "set-presentation") {
     exact(raw, ["kind", "viewMode", "taskPanelOpen"], `mutations[${index}]`);
     if (raw.viewMode === undefined && raw.taskPanelOpen === undefined) throw new ViewValidationError("INVALID_REQUEST", `empty mutations[${index}]`);
@@ -110,12 +115,13 @@ export async function validateBoardPatchRequest(request: Request): Promise<{ pro
     rejectMutationAliasCycles(mutations);
     return { project: body.project, baseRevision: body.baseRevision as number, mutations };
   }
-  const rawPatch = record(body.patch, "patch"); exact(rawPatch, ["manual", "hidden", "expanded", "viewMode", "taskPanelOpen"], "patch");
+  const rawPatch = record(body.patch, "patch"); exact(rawPatch, ["manual", "hidden", "expanded", "favorites", "viewMode", "taskPanelOpen"], "patch");
   if (Object.keys(rawPatch).length === 0) throw new ViewValidationError("INVALID_REQUEST", "empty patch");
   const patch: BoardPatch = {};
   if (rawPatch.manual !== undefined) patch.manual = pathList(rawPatch.manual, "patch.manual");
   if (rawPatch.hidden !== undefined) patch.hidden = pathList(rawPatch.hidden, "patch.hidden");
   if (rawPatch.expanded !== undefined) patch.expanded = pathList(rawPatch.expanded, "patch.expanded");
+  if (rawPatch.favorites !== undefined) patch.favorites = pathList(rawPatch.favorites, "patch.favorites");
   if (rawPatch.viewMode !== undefined) {
     if (rawPatch.viewMode !== null && rawPatch.viewMode !== "scheme" && rawPatch.viewMode !== "list") throw new ViewValidationError("INVALID_REQUEST", "invalid patch.viewMode");
     patch.viewMode = rawPatch.viewMode;

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -1099,6 +1099,9 @@ export const en = {
   "branch.expand": "Expand",
   "branch.expandFull": "Expand conversation {title} to the full window",
   "branch.collapseFull": "Back to the canvas (Esc)",
+  // Crown favorites (issue #185)
+  "branch.favorite": "Mark as favorite",
+  "branch.unfavorite": "Remove from favorites",
 
   // TreeAside
   "tree.quiet": "Quiet conversations and tasks",
@@ -1207,6 +1210,14 @@ export const en = {
   "tasks.panelAll": "all",
   "tasks.panelEmpty": "no tasks yet — drop one with the board's task tool (T)",
   "tasks.panelClose": "Close the task panel",
+  // Favorites section in the docked panel (issue #185)
+  "favorites.sectionTitle": "Favorites",
+  "favorites.empty": "no favorites yet — hover a card and tap its crown",
+  "favorites.focusTitle": "Focus {title} on the board",
+  "favorites.count": {
+    one: "{count} favorite",
+    other: "{count} favorites",
+  },
   "tasks.sheetNew": "new task",
   "tasks.sheetCreate": "Create the task",
   "tasks.sheetBack": "Back to the task list",

--- a/src/lib/i18n/uk.ts
+++ b/src/lib/i18n/uk.ts
@@ -1066,6 +1066,9 @@ export const uk: Record<keyof typeof en, Message> = {
   "branch.expand": "Розгорнути",
   "branch.expandFull": "Розгорнути розмову {title} на все вікно",
   "branch.collapseFull": "Повернутися до полотна (Esc)",
+  // Crown favorites (issue #185)
+  "branch.favorite": "Додати в обране",
+  "branch.unfavorite": "Прибрати з обраного",
 
   "tree.quiet": "Тихі розмови й задачі",
 
@@ -1166,6 +1169,16 @@ export const uk: Record<keyof typeof en, Message> = {
   "tasks.panelAll": "всі",
   "tasks.panelEmpty": "задач поки нема — кинь картку інструментом «задача» (T)",
   "tasks.panelClose": "Закрити панель задач",
+  // Favorites section in the docked panel (issue #185)
+  "favorites.sectionTitle": "Обране",
+  "favorites.empty": "обраного поки нема — наведи на картку й тапни корону",
+  "favorites.focusTitle": "Показати {title} на дошці",
+  "favorites.count": {
+    one: "{count} обране",
+    few: "{count} обраних",
+    many: "{count} обраних",
+    other: "{count} обраних",
+  },
   "tasks.sheetNew": "нова задача",
   "tasks.sheetCreate": "Створити задачу",
   "tasks.sheetBack": "Назад до списку задач",

--- a/src/lib/view/types.ts
+++ b/src/lib/view/types.ts
@@ -89,7 +89,7 @@ export interface BoardProjectStateV1 {
   updatedAt: string;
   pathAliases?: Record<string, string>;
   explicitManual?: string[];
-  prefs: { manual: string[]; hidden: string[]; expanded: string[]; viewMode: "scheme" | "list" | null; taskPanelOpen: boolean };
+  prefs: { manual: string[]; hidden: string[]; expanded: string[]; favorites: string[]; viewMode: "scheme" | "list" | null; taskPanelOpen: boolean };
 }
 
 export interface BoardFileV1 { projects: Record<string, BoardProjectStateV1> }


### PR DESCRIPTION
Closes #185.

Mark conversations as favorites with a crown that reveals itself by mouse proximity.

## Interaction
- **Idle** → no crown; cards stay clean.
- **Pointer near the card** (generous ~88px screen-space proximity zone, not a hover on the icon) → a **dashed gray outline crown** fades in at the card's top-right.
- **Hover the crown** → filled gold preview.
- **Click** → the crown commits to a **lit gold crown** (favorite) with a smooth fill + pop and **no layout shift**; it stays lit regardless of proximity. Click again unfavorites.
- **Touch / 390px** → the crown is always visible at a **44px** target (no hover), on both the scheme node and the mobile focus pane.

## Favorites surface
A **Favorites** section in the docked task panel, scoped by the existing project/all toggle. A row click focuses/pins the conversation on the board; its crown unfavorites in place.

## Persistence
Favorites persist per project through the **existing durable board store** (`/api/board`), survive reloads/deploys, and are keyed by **durable conversation identity** (`conversationId`, else path) so they outlive transcript-path changes and resumes. They are kept out of the path-alias/hidden machinery (they are conversation ids, not paths), merge on project-key migration, and default to `[]` for boards written before the field existed.

## Scope / constraints
- UI layer only — **no** changes under `src/lib/{flows,agent,runtime}`.
- Persistence goes through the existing client prefs/API pattern (`useBoardState` → `set-favorite` mutation).
- Design tokens only; en + uk labels.
- Crown sits in the header control row, laid out beside the existing controls (no overlap).

## Architecture
- New `set-favorite` board mutation + `favorites` pref threaded through `mutations` / `store` / `validation` / `useBoardState`.
- `FavoriteCrown` + a shared window-level `useProximity` reveal (one pointer listener, rAF-throttled, per-crown threshold crossing), mounted via a `FavoritesProvider` context so no state is threaded through the scheme/node layers (keeps `NodesLayer` memoization intact).

## Gates
- `bunx tsc --noEmit` ✅
- `bun test` ✅ (2468 pass; +9 new: reducer add/remove/dedupe + durability across remap/close, store round-trip incl. legacy-board default, validation, proximity geometry, and a crown toggle/persistence DOM test)
- `next build` ✅
- No new API routes added (favorites ride the existing `/api/board` route), so the route-export convention is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)