### PR TITLE
refactor(pipelines): finish typography/radius token swap (#205)

### DIFF
--- a/src/components/pipelines/PipelineStrip.tsx
+++ b/src/components/pipelines/PipelineStrip.tsx
@@ -181,13 +181,13 @@ function StageChip({
 
   return (
     <span ref={chipRef} className="relative flex shrink-0 items-center gap-1.5">
-      {index ? <span className="text-[10px] font-bold text-strong" aria-hidden>→</span> : null}
+      {index ? <span className="text-caption font-bold text-strong" aria-hidden>→</span> : null}
       <span className="inline-flex items-center">
         <button
           type="button"
           disabled={!canOpen}
           onClick={openStage}
-          className={`inline-flex h-6 max-w-[180px] items-center gap-1 truncate rounded-l-full ${evidence ? "" : "rounded-r-full"} px-2 text-[10.5px] font-bold focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 disabled:cursor-default ${pulse ? "animate-pulse" : ""}`}
+          className={`inline-flex h-6 max-w-[180px] items-center gap-1 truncate rounded-l-full ${evidence ? "" : "rounded-r-full"} px-2 text-label font-bold focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 disabled:cursor-default ${pulse ? "animate-pulse" : ""}`}
           style={{ backgroundColor: tone.soft, color: tone.color }}
           title={title}
           aria-label={t("pipelineStrip.chipAria", { label, state: chipState })}
@@ -204,7 +204,7 @@ function StageChip({
             onClick={onToggleVerdict}
             aria-expanded={open}
             aria-label={t("pipelineStrip.openVerdict", { label })}
-            className="inline-flex h-6 items-center rounded-r-full border-l border-card/60 px-1 text-[10.5px] font-bold focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40"
+            className="inline-flex h-6 items-center rounded-r-full border-l border-card/60 px-1 text-label font-bold focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40"
             style={{ backgroundColor: tone.soft, color: tone.color }}
           >
             <span aria-hidden>{attempt!.verdict ? (attempt!.verdict.status === "pass" ? "✓" : attempt!.verdict.status === "fail" ? "✕" : "●") : "!"}</span>
@@ -294,7 +294,7 @@ export function PipelineStrip({
           aria-hidden
         />
         {draft ? (
-          <span className="shrink-0 rounded-full border border-dashed border-warning bg-warning-soft px-2 py-0.5 text-caption font-semibold tracking-[0.06em] text-warning">
+          <span className="shrink-0 rounded-full border border-dashed border-warning bg-warning-soft px-2 py-0.5 text-caption font-semibold text-warning">
             {t("pipelineStrip.draftBadge")}
           </span>
         ) : null}

--- a/src/components/pipelines/PipelineTemplatePicker.tsx
+++ b/src/components/pipelines/PipelineTemplatePicker.tsx
@@ -47,18 +47,18 @@ export function PipelineTemplatePicker({
         role="dialog"
         aria-modal="true"
         aria-label={t("pipelineTemplates.title")}
-        className="w-full max-w-[460px] rounded-t-[16px] bg-card p-3 pb-[max(0.75rem,env(safe-area-inset-bottom))] shadow-2 sm:rounded-[12px] sm:pb-3"
+        className="w-full max-w-[460px] rounded-t-surface bg-card p-3 pb-[max(0.75rem,env(safe-area-inset-bottom))] shadow-2 sm:rounded-surface sm:pb-3"
       >
         <div className="mb-1 flex items-center gap-2">
           <div className="min-w-0 flex-1">
-            <div className="text-[15px] font-bold text-primary">{t("pipelineTemplates.title")}</div>
-            <div className="text-[12px] text-muted">{t("pipelineTemplates.subtitle")}</div>
+            <div className="text-title font-bold text-primary">{t("pipelineTemplates.title")}</div>
+            <div className="text-ui text-muted">{t("pipelineTemplates.subtitle")}</div>
           </div>
           <button
             type="button"
             onClick={onClose}
             aria-label={t("common.close")}
-            className="flex h-11 w-11 shrink-0 items-center justify-center rounded-[8px] border border-border bg-canvas text-muted hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40"
+            className="flex h-11 w-11 shrink-0 items-center justify-center rounded-control border border-border bg-canvas text-muted hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40"
           >
             <X className="h-4 w-4" aria-hidden />
           </button>
@@ -70,15 +70,15 @@ export function PipelineTemplatePicker({
               type="button"
               disabled={busy}
               onClick={() => onPick(template)}
-              className="flex min-h-11 w-full flex-col justify-center gap-1 rounded-[8px] px-3 py-2 text-left hover:bg-sunken focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 disabled:opacity-50"
+              className="flex min-h-11 w-full flex-col justify-center gap-1 rounded-control px-3 py-2 text-left hover:bg-sunken focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 disabled:opacity-50"
             >
-              <span className="text-[13px] font-semibold text-primary">{t(template.labelKey)}</span>
+              <span className="text-body font-semibold text-primary">{t(template.labelKey)}</span>
               <span className="flex flex-wrap items-center gap-1" aria-hidden>
                 {template.stages.map((stage, index) => (
                   <span key={index} className="flex items-center gap-1">
-                    {index ? <span className="text-[11px] font-bold text-strong">→</span> : null}
+                    {index ? <span className="text-label font-bold text-strong">→</span> : null}
                     <span
-                      className={`rounded-full px-2 py-0.5 text-[10px] font-semibold ${
+                      className={`rounded-full px-2 py-0.5 text-caption font-semibold ${
                         stage.kind === "review-loop" ? "bg-accent-soft text-accent" : "bg-sunken text-secondary"
                       }`}
                     >
@@ -94,10 +94,10 @@ export function PipelineTemplatePicker({
             type="button"
             disabled={busy}
             onClick={() => onPick(null)}
-            className="flex min-h-11 w-full flex-col justify-center gap-0.5 rounded-[8px] border border-dashed border-strong px-3 py-2 text-left hover:bg-sunken focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 disabled:opacity-50"
+            className="flex min-h-11 w-full flex-col justify-center gap-0.5 rounded-control border border-dashed border-strong px-3 py-2 text-left hover:bg-sunken focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 disabled:opacity-50"
           >
-            <span className="text-[13px] font-semibold text-primary">{t("pipelineTemplates.blank")}</span>
-            <span className="text-[11px] text-muted">{t("pipelineTemplates.blankHint")}</span>
+            <span className="text-body font-semibold text-primary">{t("pipelineTemplates.blank")}</span>
+            <span className="text-label text-muted">{t("pipelineTemplates.blankHint")}</span>
           </button>
         </div>
       </div>

--- a/src/components/pipelines/StagePlaceholderPane.tsx
+++ b/src/components/pipelines/StagePlaceholderPane.tsx
@@ -206,7 +206,7 @@ export function StagePlaceholderPane({ slot, interactive }: { slot: StageSlot; i
     <section
       data-pan-ignore
       aria-label={t("pipelineSlot.paneAria", { role: label })}
-      className="relative flex h-full min-h-0 min-w-0 flex-1 flex-col overflow-hidden rounded-[10px] border-2 border-dashed bg-card shadow-1"
+      className="relative flex h-full min-h-0 min-w-0 flex-1 flex-col overflow-hidden rounded-control border-2 border-dashed bg-card shadow-1"
       style={{ borderColor: active ? tone.color : "var(--border-strong)" }}
     >
       <span aria-hidden className="h-1 w-full shrink-0 opacity-60" style={{ backgroundColor: tint.color }} />
@@ -217,15 +217,15 @@ export function StagePlaceholderPane({ slot, interactive }: { slot: StageSlot; i
           title={t(`pipelineChipState.${state}`)}
         />
         <EngineRadioGroup engine={engine as "claude" | "codex"} disabled={!editable || busy} onChange={changeEngine} />
-        <span className="min-w-0 flex-1 truncate text-[12px] font-semibold text-muted" title={label}>
+        <span className="min-w-0 flex-1 truncate text-ui font-semibold text-muted" title={label}>
           {label} · {t("pipelineSlot.stageOf", { k: slot.index + 1, n: slot.total })}
         </span>
-        <span className="shrink-0 rounded-full border border-border bg-card/70 px-1.5 py-0.5 text-[9px] font-bold uppercase tracking-wide text-muted">
+        <span className="shrink-0 rounded-full border border-border bg-card/70 px-1.5 py-0.5 text-caption font-bold uppercase tracking-wide text-muted">
           {review ? `⟳ ${t("groupOverride.reviewKind")}` : t("groupOverride.runKind")}
         </span>
         {canRemove ? (
           <button
-            className="inline-flex shrink-0 items-center rounded-[8px] border border-border bg-canvas px-1.5 py-0.5 text-muted hover:border-danger/40 hover:text-danger focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 disabled:opacity-40"
+            className="inline-flex shrink-0 items-center rounded-control border border-border bg-canvas px-1.5 py-0.5 text-muted hover:border-danger/40 hover:text-danger focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 disabled:opacity-40"
             aria-label={t("groupOverride.removeStage")}
             disabled={busy}
             onClick={removeStage}
@@ -250,7 +250,7 @@ export function StagePlaceholderPane({ slot, interactive }: { slot: StageSlot; i
       ) : null}
 
       <div className="flex shrink-0 flex-wrap items-center gap-1.5 border-b border-border bg-sunken px-2.5 py-1.5">
-        <span className="shrink-0 text-[10px] font-semibold text-muted">{t("draft.reasoning")}</span>
+        <span className="shrink-0 text-caption font-semibold text-muted">{t("draft.reasoning")}</span>
         {interactive ? (
           <>
             <RuntimeControlsView
@@ -274,26 +274,26 @@ export function StagePlaceholderPane({ slot, interactive }: { slot: StageSlot; i
             ) : null}
           </>
         ) : (
-          <span className="min-w-0 truncate text-[11px] font-semibold text-muted">
+          <span className="min-w-0 truncate text-label font-semibold text-muted">
             {observedModelLabel}
             {effectiveEffort ? ` · ${effectiveEffort}` : ""}
           </span>
         )}
       </div>
       {error ? (
-        <div className="shrink-0 px-2.5 py-1 text-[10.5px] font-semibold text-danger" role="alert">
+        <div className="shrink-0 px-2.5 py-1 text-label font-semibold text-danger" role="alert">
           {error}
         </div>
       ) : null}
       {interactive && !editable ? (
-        <div className="shrink-0 px-2.5 py-1 text-[10.5px] font-semibold text-muted">{t("pipelineSlot.frozen")}</div>
+        <div className="shrink-0 px-2.5 py-1 text-label font-semibold text-muted">{t("pipelineSlot.frozen")}</div>
       ) : null}
 
       <div className="flex min-h-0 flex-1 flex-col items-center justify-center gap-2 overflow-y-auto px-4 py-3 text-center">
-        <span className="rounded-full px-3 py-1 text-[13px] font-bold" style={{ backgroundColor: tone.soft, color: tone.color }}>
+        <span className="rounded-full px-3 py-1 text-body font-bold" style={{ backgroundColor: tone.soft, color: tone.color }}>
           {label}
         </span>
-        <span className="max-w-[380px] text-[12px] leading-5 text-muted">{hint}</span>
+        <span className="max-w-[380px] text-ui leading-5 text-muted">{hint}</span>
       </div>
 
       {interactive ? (
@@ -305,7 +305,7 @@ export function StagePlaceholderPane({ slot, interactive }: { slot: StageSlot; i
           className="flex shrink-0 flex-col gap-1 border-t border-border bg-card px-2.5 py-2"
           aria-label={t("pipelineSlot.promptAria")}
         >
-          <label className="text-[10px] font-semibold text-muted" htmlFor={`slot-prompt-${slot.key}`}>
+          <label className="text-caption font-semibold text-muted" htmlFor={`slot-prompt-${slot.key}`}>
             {t("pipelineSlot.promptLabel")}
           </label>
           <textarea
@@ -315,14 +315,14 @@ export function StagePlaceholderPane({ slot, interactive }: { slot: StageSlot; i
             onChange={(event) => setPrompt(event.target.value)}
             onBlur={savePrompt}
             placeholder={t("pipelineSlot.noPrompt")}
-            className="min-h-[52px] w-full resize-y rounded-[8px] border border-border bg-canvas px-2 py-1.5 text-[11.5px] text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 disabled:opacity-60"
+            className="min-h-[52px] w-full resize-y rounded-control border border-border bg-canvas px-2 py-1.5 text-ui text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 disabled:opacity-60"
           />
           {promptDirty ? (
             <div className="flex items-center justify-end">
               <button
                 type="submit"
                 disabled={!editable || busy || !prompt.trim()}
-                className="inline-flex h-7 items-center gap-1 rounded-[8px] border border-accent bg-accent px-2.5 text-[10.5px] font-bold text-white hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/50 disabled:opacity-40"
+                className="inline-flex h-7 items-center gap-1 rounded-control border border-accent bg-accent px-2.5 text-label font-bold text-white hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/50 disabled:opacity-40"
               >
                 {t("pipelineSlot.savePrompt")}
               </button>


### PR DESCRIPTION
Closes #205.

## What

`PipelineStrip.tsx` retained four ad-hoc typography utilities after the #198 cleanup — `text-[10px]`, two `text-[10.5px]`, and `tracking-[0.06em]`. This swaps them for the design-system tokens in `docs/design/viewer-design-system.md`:

- `text-[10px]` → `text-caption` (§1.1: 9/9.5/10 → caption)
- `text-[10.5px]` → `text-label` (§1.1: 10.5/11 → label)
- `tracking-[0.06em]` dropped from the draft badge (§3.6: no letter-spacing)

While there, the same audit over `src/components/pipelines/` found the other two modules **introduced by the same pipeline-UX merge (#196/#198)** carrying identical raw values, so they get the same token swap:

- **StagePlaceholderPane.tsx** — `text-[9|10|10.5|11|11.5|12|13px]` → `text-caption/label/ui/body`; `rounded-[8|10px]` → `rounded-control`
- **PipelineTemplatePicker.tsx** — `text-[10|11|12|13|15px]` → `text-caption/label/ui/body/title`; `rounded-[8|12|16px]` → `rounded-control` / `rounded-surface` (incl. the directional `rounded-t-surface` on the bottom sheet)

Radius mapping follows §1.3 (3–10 → control, 12–16 → surface). Layout dimensions (`max-w-[180px]`, `min-h-[52px]`, `w-[460px]`, safe-area padding) are deliberately untouched — this is typography/radius tokens only, no behavior, layout, or font-weight changes.

## Verification

Issue repro now returns zero matches:

```
$ rg -n 'rounded-\[|text-\[|tracking-\[|leading-\[' src/components/pipelines/PipelineStrip.tsx
(no output)
```

Gates:

- `bunx tsc --noEmit` — clean
- `bun test` — 2481 pass / 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)