### PR TITLE
test: reject stray Next route exports before deploy

### DIFF
--- a/src/lib/fixtures/route-exports/invalid/route.ts
+++ b/src/lib/fixtures/route-exports/invalid/route.ts
@@ -1,0 +1,7 @@
+export const runtime = "nodejs";
+
+export function GET(): Response {
+  return new Response("ok");
+}
+
+export const strayHelper = "breaks next build";

--- a/src/lib/routeExports.test.ts
+++ b/src/lib/routeExports.test.ts
@@ -1,0 +1,28 @@
+import { expect, test } from "bun:test";
+
+import { invalidRouteExports } from "./routeExports";
+
+test("rejects a route fixture with a stray value export", async () => {
+  const fixture = new URL("./fixtures/route-exports/invalid/route.ts", import.meta.url);
+  const source = await Bun.file(fixture).text();
+
+  expect(invalidRouteExports(source, fixture.pathname)).toEqual([
+    {
+      file: fixture.pathname,
+      line: 7,
+      name: "strayHelper",
+    },
+  ]);
+});
+
+test("every application route exports only handlers and route config", async () => {
+  const routeFiles = new Bun.Glob("src/app/**/route.ts");
+  const invalid = [];
+
+  for await (const file of routeFiles.scan({ cwd: process.cwd(), onlyFiles: true })) {
+    const source = await Bun.file(file).text();
+    invalid.push(...invalidRouteExports(source, file));
+  }
+
+  expect(invalid).toEqual([]);
+});

--- a/src/lib/routeExports.ts
+++ b/src/lib/routeExports.ts
@@ -1,0 +1,94 @@
+import ts from "typescript";
+
+const ALLOWED_ROUTE_EXPORTS = new Set([
+  "GET",
+  "HEAD",
+  "OPTIONS",
+  "POST",
+  "PUT",
+  "DELETE",
+  "PATCH",
+  "config",
+  "generateStaticParams",
+  "unstable_instant",
+  "unstable_dynamicStaleTime",
+  "revalidate",
+  "dynamic",
+  "dynamicParams",
+  "fetchCache",
+  "preferredRegion",
+  "runtime",
+  "maxDuration",
+]);
+
+export type InvalidRouteExport = {
+  file: string;
+  line: number;
+  name: string;
+};
+
+function hasExportModifier(node: ts.Node): boolean {
+  return ts.canHaveModifiers(node) && ts.getModifiers(node)?.some((modifier) => modifier.kind === ts.SyntaxKind.ExportKeyword) === true;
+}
+
+function bindingNames(name: ts.BindingName): ts.Identifier[] {
+  if (ts.isIdentifier(name)) return [name];
+  return name.elements.flatMap((element) => (ts.isOmittedExpression(element) ? [] : bindingNames(element.name)));
+}
+
+export function invalidRouteExports(sourceText: string, file = "route.ts"): InvalidRouteExport[] {
+  const source = ts.createSourceFile(file, sourceText, ts.ScriptTarget.Latest, true, ts.ScriptKind.TS);
+  const invalid: InvalidRouteExport[] = [];
+
+  const report = (name: string, node: ts.Node) => {
+    if (ALLOWED_ROUTE_EXPORTS.has(name)) return;
+    invalid.push({
+      file,
+      line: source.getLineAndCharacterOfPosition(node.getStart(source)).line + 1,
+      name,
+    });
+  };
+
+  for (const statement of source.statements) {
+    if (ts.isExportDeclaration(statement)) {
+      if (statement.isTypeOnly) continue;
+      if (!statement.exportClause) {
+        report("*", statement);
+      } else if (ts.isNamespaceExport(statement.exportClause)) {
+        report(statement.exportClause.name.text, statement.exportClause.name);
+      } else {
+        for (const element of statement.exportClause.elements) {
+          if (!element.isTypeOnly) report(element.name.text, element.name);
+        }
+      }
+      continue;
+    }
+
+    if (ts.isExportAssignment(statement)) {
+      report("default", statement);
+      continue;
+    }
+
+    if (!hasExportModifier(statement) || ts.isInterfaceDeclaration(statement) || ts.isTypeAliasDeclaration(statement)) continue;
+
+    if (ts.isVariableStatement(statement)) {
+      for (const declaration of statement.declarationList.declarations) {
+        for (const name of bindingNames(declaration.name)) report(name.text, name);
+      }
+      continue;
+    }
+
+    if (ts.isFunctionDeclaration(statement) || ts.isClassDeclaration(statement)) {
+      const isDefault = ts.getModifiers(statement)?.some((modifier) => modifier.kind === ts.SyntaxKind.DefaultKeyword) === true;
+      if (isDefault) report("default", statement);
+      else if (statement.name) report(statement.name.text, statement.name);
+      continue;
+    }
+
+    if (ts.isEnumDeclaration(statement) || ts.isModuleDeclaration(statement)) {
+      report(statement.name.getText(source), statement.name);
+    }
+  }
+
+  return invalid;
+}


### PR DESCRIPTION
Closes #195

## Summary
- parse every src/app/**/route.ts export with the TypeScript compiler
- allow HTTP handlers and the route config fields accepted by Next 16.2.10
- add a fixture-backed regression test plus a repository-wide Bun test gate

## Verification
- bunx tsc --noEmit
- bun test (2524 pass, 0 fail)
- bunx eslint src/lib/routeExports.ts src/lib/routeExports.test.ts src/lib/fixtures/route-exports/invalid/route.ts
- git diff --check