### PR TITLE
fix(board): gate first paint on settled state to kill node flash (#172)

### DIFF
--- a/src/components/ProjectDashboard.flash.dom.test.tsx
+++ b/src/components/ProjectDashboard.flash.dom.test.tsx
@@ -1,0 +1,172 @@
+import { afterAll, afterEach, beforeAll, beforeEach, expect, mock, test } from "bun:test";
+import { Window } from "happy-dom";
+import { createRoot, type Root } from "react-dom/client";
+import { flushSync } from "react-dom";
+
+import { emptyStore } from "@/components/runtime/runtimeModel";
+
+/* No-flash regression for the board's first paint (#172). The board used to
+   paint the raw scan snapshot before the persisted board state loaded, then cull
+   it (closes/worker-collapse/caps applying late) — a visible flash of nodes. The
+   dashboard now holds a skeleton until BOTH the scan and the persisted board
+   state resolve, so the first real frame equals the settled arrangement.
+
+   This mounts the real ProjectDashboard and asserts the content region shows the
+   busy skeleton on the first frame and never any node before the board settles;
+   only after the persisted state lands does the real content render. */
+
+const actualRuntimeHooks = await import("@/hooks/useRuntime");
+const actualConversationCatalogHooks = await import("@/hooks/useConversationCatalog");
+const inertRuntime = { enabled: false, connection: "offline" as const, resyncedAt: null, store: emptyStore() };
+mock.module("@/hooks/useRuntime", () => ({
+  ...actualRuntimeHooks,
+  useRuntimeBusState: () => ({ ...inertRuntime, lastEventAt: null }),
+  useRuntime: () => inertRuntime,
+  useRuntimeSession: () => null,
+  useRuntimeReceiptsForArtifact: () => [],
+  useRuntimeFlow: () => null,
+}));
+mock.module("@/hooks/useConversationCatalog", () => ({
+  useConversationCatalog: () => ({
+    items: [],
+    nextCursor: null,
+    total: 0,
+    loading: false,
+    error: false,
+    loadMore: () => {},
+    retry: () => {},
+  }),
+}));
+
+const { ProjectDashboard } = await import("@/components/ProjectDashboard");
+
+const dom = new Window({ url: "http://localhost/" });
+const G = globalThis as Record<string, unknown>;
+
+/* Desktop surface (matchMedia never matches) so the scheme/skeleton renders in
+   the main content column rather than the phone focus view. */
+const desktopMatchMedia = (query: string) => ({
+  matches: false,
+  media: String(query),
+  onchange: null,
+  addEventListener() {},
+  removeEventListener() {},
+  addListener() {},
+  removeListener() {},
+  dispatchEvent() { return false; },
+});
+
+/* Gate the board GET so the "before settle" assertion observes the real holding
+   window; every other request resolves inert. */
+let releaseBoard = () => {};
+const boardGate = new Promise<void>((resolve) => (releaseBoard = resolve));
+const OVERRIDES: Record<string, unknown> = {
+  window: dom,
+  document: dom.document,
+  navigator: dom.navigator,
+  Node: dom.Node,
+  HTMLElement: dom.HTMLElement,
+  Event: dom.Event,
+  MouseEvent: dom.MouseEvent,
+  sessionStorage: dom.sessionStorage,
+  localStorage: dom.localStorage,
+  matchMedia: desktopMatchMedia,
+  requestAnimationFrame: (cb: (t: number) => void) => setTimeout(() => cb(0), 0) as unknown as number,
+  cancelAnimationFrame: (id: number) => clearTimeout(id),
+  ResizeObserver: class { observe() {} unobserve() {} disconnect() {} },
+  IntersectionObserver: class { observe() {} unobserve() {} disconnect() {} takeRecords() { return []; } },
+  fetch: (async (input: string | URL | Request) => {
+    const url = String(input);
+    const body = url.startsWith("/api/conversations") ? { items: [], nextCursor: null } : {};
+    if (url.startsWith("/api/board")) await boardGate;
+    return { ok: true, status: 200, json: async () => body, text: async () => JSON.stringify(body) };
+  }) as unknown as typeof fetch,
+};
+const HAS: Record<string, boolean> = {};
+const SAVED: Record<string, unknown> = {};
+
+const settle = async () => {
+  await new Promise((r) => setTimeout(r, 0));
+  await new Promise((r) => setTimeout(r, 0));
+};
+const waitFor = async (pred: () => boolean, timeoutMs = 4000): Promise<boolean> => {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    if (pred()) return true;
+    await new Promise((r) => setTimeout(r, 15));
+  }
+  return pred();
+};
+
+beforeAll(() => {
+  for (const key of Object.keys(OVERRIDES)) {
+    HAS[key] = key in G;
+    SAVED[key] = G[key];
+    G[key] = OVERRIDES[key];
+  }
+  (dom.HTMLElement.prototype as unknown as { scrollIntoView: () => void }).scrollIntoView = () => {};
+});
+afterAll(async () => {
+  releaseBoard();
+  await settle();
+  for (const key of Object.keys(OVERRIDES)) {
+    if (HAS[key]) G[key] = SAVED[key];
+    else delete G[key];
+  }
+  mock.module("@/hooks/useRuntime", () => actualRuntimeHooks);
+  mock.module("@/hooks/useConversationCatalog", () => actualConversationCatalogHooks);
+});
+
+let roots: Root[] = [];
+beforeEach(() => {
+  roots = [];
+});
+afterEach(() => {
+  for (const root of roots) flushSync(() => root.unmount());
+});
+
+const dashboardProps = (project: string) => ({
+  files: [],
+  flows: [],
+  pipelines: [],
+  workflows: [],
+  tasks: [],
+  project,
+  loaded: true,
+  openNonce: 0,
+  archived: false,
+  catalogKnown: false,
+  projectCwd: `/home/tester/Projects/${project}`,
+  catalogConversationCount: 0,
+  onArchive: () => {},
+  onUnarchive: () => {},
+});
+
+function mount(node: React.ReactElement): { root: Root; host: HTMLElement } {
+  const host = dom.document.createElement("div");
+  dom.document.body.appendChild(host);
+  const root = createRoot(host as unknown as Element);
+  flushSync(() => root.render(node));
+  roots.push(root);
+  return { root, host: host as unknown as HTMLElement };
+}
+
+const skeleton = (host: HTMLElement) => host.querySelector('[role="status"][aria-busy="true"]');
+
+test("the first frame is the busy skeleton, never a node, until the persisted board state lands (#172)", async () => {
+  const { host } = mount(<ProjectDashboard {...dashboardProps("flash-guard")} />);
+
+  /* First paint: the board GET is still gated, so the content column must hold
+     the busy skeleton and show no settled content yet. */
+  expect(skeleton(host)).not.toBeNull();
+  expect(host.textContent ?? "").not.toContain("empty for now");
+
+  /* The persisted state resolves; the skeleton clears and the real (here empty)
+     content renders. Because the skeleton preceded it, no node was ever painted
+     and then removed. */
+  releaseBoard();
+  const settled = await waitFor(() => skeleton(host) === null);
+  expect(settled).toBe(true);
+  expect(skeleton(host)).toBeNull();
+  await settle();
+});

--- a/src/components/ProjectDashboard.test.ts
+++ b/src/components/ProjectDashboard.test.ts
@@ -2,10 +2,20 @@ import { expect, test } from "bun:test";
 
 import type { FileEntry } from "@/lib/types";
 
-import { pendingFocusTarget } from "./ProjectDashboard";
+import { boardFirstPaintReady, pendingFocusTarget } from "./ProjectDashboard";
 
 test("a catalog focus waits for its pinned conversation to hydrate", () => {
   const path = "/sessions/capped-out.jsonl";
   expect(pendingFocusTarget(path, [])).toBeNull();
   expect(pendingFocusTarget(path, [{ path } as FileEntry])).toBe(path);
+});
+
+test("the board holds its skeleton until BOTH the scan and the persisted state load (#172)", () => {
+  /* The flash was painting the raw scan snapshot before the persisted board
+     state (closes, worker collapse, caps) landed, then culling it. The first
+     real frame is gated on both signals, so neither alone lets nodes paint. */
+  expect(boardFirstPaintReady(false, false)).toBe(false);
+  expect(boardFirstPaintReady(true, false)).toBe(false);
+  expect(boardFirstPaintReady(false, true)).toBe(false);
+  expect(boardFirstPaintReady(true, true)).toBe(true);
 });

--- a/src/components/ProjectDashboard.tsx
+++ b/src/components/ProjectDashboard.tsx
@@ -36,6 +36,7 @@ import { TaskToastHost, pushTaskToast } from "./tasks/taskToast";
 import { MobileFocusView } from "./mobile/MobileFocusView";
 import { canHandoff, HandoffHandle } from "./HandoffHandle";
 import { SchemeBoard } from "./scheme/SchemeBoard";
+import { SchemeSkeleton } from "./scheme/SchemeSkeleton";
 import { Switchboard } from "./Switchboard";
 import {
   buildArchiveBranchGroups,
@@ -146,6 +147,17 @@ export function pendingFocusTarget(pending: string | null, files: readonly FileE
   if (!pending) return null;
   if (pending.startsWith("draft::") || files.some((file) => file.path === pending)) return pending;
   return null;
+}
+
+/** The board may paint its real nodes only once BOTH the first full scan and the
+    persisted board state have resolved (#172). Painting before the persisted
+    state lands shows the raw scan snapshot — every card, uncollapsed and
+    uncapped — which then culls to the settled set as closes, worker-stack
+    collapse and caps apply: the first-render flash. Until both are ready the
+    dashboard holds a skeleton, so the first real frame already equals the
+    settled arrangement. */
+export function boardFirstPaintReady(scanLoaded: boolean, boardLoaded: boolean): boolean {
+  return scanLoaded && boardLoaded;
 }
 
 /* Kept outside the component: the React Compiler's immutability check flags
@@ -297,6 +309,11 @@ export function ProjectDashboard({
      one-time seed from the old per-browser localStorage (#38). Reads stay
      optimistic — a local edit shows at once, then PATCHes. */
   const board = useBoardState(project);
+  /* Gate the board's real content on the settled state (#172): hold a skeleton
+     until the scan and the persisted board arrangement have both loaded, so the
+     first painted board already reflects closes, worker-stack collapse and caps
+     instead of flashing the raw scan snapshot and culling it. */
+  const boardReady = boardFirstPaintReady(loaded, board.loaded);
   /* Per-project, device-local undo/redo log of recent board actions (issue
      #184). v1 records card closes; undo reopens the last-closed card through the
      shared restore path, redo closes it again. */
@@ -1178,7 +1195,7 @@ export function ProjectDashboard({
         </div>
       ) : null}
 
-      {dockedTasks.length ? (
+      {boardReady && dockedTasks.length ? (
         <div className="shrink-0 border-b border-border bg-sunken">
           {dockedTasks.map((task) => (
             <div
@@ -1195,7 +1212,9 @@ export function ProjectDashboard({
         <>
           {/* The scheme/list toggle moved into the header row (finding 7), so the
               phone shell is two nav rows at most: header + the focus-view strip. */}
-          {projectView === "scheme" && schemeAvailable ? (
+          {!boardReady ? (
+            <SchemeSkeleton />
+          ) : projectView === "scheme" && schemeAvailable ? (
             <MobileFocusView
               project={project}
               groups={hasNodes ? schemeGroups : archiveGroups}
@@ -1230,10 +1249,12 @@ export function ProjectDashboard({
       ) : (
         <div className="flex min-h-0 min-w-0 flex-1">
           <div className="relative flex min-h-0 min-w-0 flex-1 flex-col">
-            {viewToggle ? (
+            {boardReady && viewToggle ? (
               <ProjectViewTabs value={projectView} onChange={chooseEmptyView} floating />
             ) : null}
-            {projectView === "scheme" && schemeAvailable ? (
+            {!boardReady ? (
+              <SchemeSkeleton />
+            ) : projectView === "scheme" && schemeAvailable ? (
               <SchemeBoard
                 project={project}
                 groups={hasNodes ? schemeGroups : archiveGroups}
@@ -1318,7 +1339,7 @@ export function ProjectDashboard({
 
       {/* The corner pill would sit on the focused pane's composer; on the
           phone the strip, the map and the toast cover its job. */}
-      {isMobile ? null : <Switchboard files={files} flows={flows} project={project} loaded={loaded} onOpenFile={openSwitchboardFile} onOpenCatalogFile={openFullCatalogFile} />}
+      {!isMobile && boardReady ? <Switchboard files={files} flows={flows} project={project} loaded={loaded} onOpenFile={openSwitchboardFile} onOpenCatalogFile={openFullCatalogFile} /> : null}
 
       {/* Worker-class cards that have auto-collapsed fold into one stack per
           origin — flow / pipeline / spawner (issue #112, #136) — instead of
@@ -1331,7 +1352,7 @@ export function ProjectDashboard({
           quiet strip share one footer row (issue #177 item 5): the handoff docks
           beside a single disclosure that folds both strips. Desktop renders the
           two strips directly, side by side. */}
-      {(() => {
+      {boardReady && (() => {
         const workerTotal = workerStacks.reduce((sum, stack) => sum + stack.items.length, 0);
         const quietTotal = !hasArchiveNodes ? residual.length : 0;
         const strips = (

--- a/src/components/scheme/SchemeSkeleton.render.test.tsx
+++ b/src/components/scheme/SchemeSkeleton.render.test.tsx
@@ -1,0 +1,26 @@
+import { expect, test } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { SchemeSkeleton } from "./SchemeSkeleton";
+
+test("the board skeleton announces politely and is marked busy (#172)", () => {
+  const html = renderToStaticMarkup(<SchemeSkeleton />);
+  expect(html).toContain('role="status"');
+  expect(html).toContain('aria-busy="true"');
+  expect(html).toContain('aria-live="polite"');
+  /* A localized label rather than a leftover interpolation token. */
+  expect(html).toContain("Loading the board");
+  expect(html).not.toContain("{");
+});
+
+test("the skeleton reflows responsively and stays reduced-motion safe", () => {
+  const html = renderToStaticMarkup(<SchemeSkeleton />);
+  /* Auto-fill columns with a shared minimum keep the placeholder from jumping
+     between a 390px phone and a wide desktop, and the body never scrolls
+     sideways (overflow hidden). */
+  expect(html).toContain("auto-fill");
+  expect(html).toContain("overflow-hidden");
+  /* The pulse yields to prefers-reduced-motion. */
+  expect(html).toContain("animate-pulse");
+  expect(html).toContain("motion-reduce:animate-none");
+});

--- a/src/components/scheme/SchemeSkeleton.tsx
+++ b/src/components/scheme/SchemeSkeleton.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import { useLocale } from "@/lib/i18n";
+
+/** Placeholder shown in the board content area until the persisted board state
+    has loaded (#172). Holding this skeleton — rather than painting the raw scan
+    snapshot — keeps the first real frame equal to the settled arrangement, so
+    the board never flashes a wide node set that then culls to the pruned,
+    collapsed, capped set.
+
+    The layout is a self-sizing grid (auto-fill columns with a shared minimum),
+    so it reflows without a jump from a 390px phone to a wide desktop and never
+    forces the body to scroll horizontally. */
+export function SchemeSkeleton() {
+  const { t } = useLocale();
+  return (
+    <div
+      role="status"
+      aria-busy="true"
+      aria-live="polite"
+      className="grid flex-1 auto-rows-min content-start gap-2.5 overflow-hidden p-3"
+      style={{ gridTemplateColumns: "repeat(auto-fill, minmax(min(100%, 240px), 1fr))" }}
+    >
+      <span className="sr-only">{t("dash.loadingBoard")}</span>
+      {Array.from({ length: 6 }).map((_, index) => (
+        <div
+          key={index}
+          aria-hidden
+          className="flex animate-pulse flex-col gap-2 rounded-[10px] border border-border bg-card p-3 shadow-1 motion-reduce:animate-none"
+        >
+          <div className="flex items-center gap-2">
+            <span className="h-2 w-2 shrink-0 rounded-full bg-sunken" />
+            <span className="h-3 w-2/3 rounded bg-sunken" />
+          </div>
+          <span className="h-2.5 w-5/6 rounded bg-sunken" />
+          <span className="h-2.5 w-1/2 rounded bg-sunken" />
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/hooks/useBoardState.test.ts
+++ b/src/hooks/useBoardState.test.ts
@@ -718,3 +718,39 @@ test("schema-version skew holds the outbox and reports unavailable until it heal
   expect(store.getSnapshot().sync).toBe("current");
   store.dispose();
 });
+
+test("a project loaded once primes the next store from the settled snapshot (#172)", async () => {
+  const server = fakeServer({ proj: boardOf(4, { manual: ["/a"], hidden: ["/b"], viewMode: "scheme" }) });
+  const first = createBoardStore({ project: "proj", fetcher: server.fetcher, storage: null, scheduler: idleScheduler().scheduler });
+  await settle();
+  expect(first.getSnapshot()).toMatchObject({ loaded: true, prefs: prefsWith({ manual: ["/a"], hidden: ["/b"], viewMode: "scheme" }) });
+  first.dispose();
+
+  /* A reload/soft-nav remount starts settled from the session cache: its very
+     first snapshot already carries the pruned arrangement, so no empty frame
+     paints before the background GET revalidates — the board never flashes an
+     uncapped set and culls it (#172). */
+  const second = createBoardStore({ project: "proj", fetcher: server.fetcher, storage: null, scheduler: idleScheduler().scheduler });
+  expect(second.getSnapshot()).toMatchObject({ loaded: true, prefs: prefsWith({ manual: ["/a"], hidden: ["/b"], viewMode: "scheme" }) });
+  await settle();
+  expect(second.getSnapshot()).toMatchObject({ loaded: true, revision: 4, prefs: prefsWith({ manual: ["/a"], hidden: ["/b"], viewMode: "scheme" }) });
+  second.dispose();
+});
+
+test("an unavailable board is never cached, so a later mount still holds until it truly loads (#172)", async () => {
+  const down: Parameters<typeof createBoardStore>[0]["fetcher"] = async () => ({ ok: false, status: 500, json: async () => ({}) });
+  const first = createBoardStore({ project: "proj", fetcher: down, storage: null, scheduler: idleScheduler().scheduler });
+  await settle();
+  expect(first.getSnapshot()).toMatchObject({ loaded: true, sync: "unavailable" });
+  first.dispose();
+
+  /* The failed load must not have primed the cache with an empty/unavailable
+     board: the next mount holds `loaded: false` (the dashboard skeleton) until a
+     real GET lands, then paints the settled hidden set. */
+  const server = fakeServer({ proj: boardOf(2, { hidden: ["/b"] }) });
+  const second = createBoardStore({ project: "proj", fetcher: server.fetcher, storage: null, scheduler: idleScheduler().scheduler });
+  expect(second.getSnapshot().loaded).toBe(false);
+  await settle();
+  expect(second.getSnapshot()).toMatchObject({ loaded: true, prefs: prefsWith({ hidden: ["/b"] }) });
+  second.dispose();
+});

--- a/src/hooks/useBoardState.ts
+++ b/src/hooks/useBoardState.ts
@@ -133,6 +133,14 @@ interface PendingOpen {
 const pendingOpens = new Map<string, PendingOpen>();
 const activeStores = new Map<string, () => void>();
 
+/* Session cache of the last server-confirmed board per project (#172). A store
+   for a project already loaded this session primes from here — it renders the
+   settled arrangement on its first frame and only background-revalidates,
+   instead of starting empty and culling to the pruned set. Only confirmed
+   (non-optimistic, non-unavailable) boards are cached, so a stale entry can
+   never widen the board beyond what the server last acknowledged. */
+const confirmedBoards = new Map<string, BoardProjectStateV1>();
+
 /**
  * Pre-add a conversation to a project's board. A child conversation (`connected`
  * = isChildConversation, what the tree can nest) goes into the expand set so it
@@ -150,10 +158,12 @@ export function queueColumnOpen(project: string, path: string, connected = false
   activeStores.get(project)?.();
 }
 
-/** Test seam: clears queued cross-project opens between cases. */
+/** Test seam: clears queued cross-project opens and the session board cache
+    between cases, so a board confirmed in one test never primes the next. */
 export function resetPendingOpensForTest(): void {
   pendingOpens.clear();
   activeStores.clear();
+  confirmedBoards.clear();
 }
 
 type WriteAttempt =
@@ -249,15 +259,20 @@ export function createBoardStore(options: BoardStoreOptions): BoardStore {
     prefs: EMPTY_BOARD_PREFS,
   });
 
-  let snapshot: BoardSnapshot = { prefs: EMPTY_BOARD_PREFS, explicitManual: [], revision: 0, sync: "unavailable", loaded: false };
   /* Last board the server acknowledged, and the semantic mutations not yet
      acknowledged. The optimistic arrangement is the outbox replayed over the
-     confirmed board. */
-  let confirmed: BoardProjectStateV1 = emptyBoard();
+     confirmed board. A project loaded earlier this session primes both the
+     confirmed board and `loaded` from the cache, so the first snapshot already
+     carries the settled arrangement (#172) while a background GET revalidates. */
+  const cachedConfirmed = confirmedBoards.get(project);
+  let confirmed: BoardProjectStateV1 = cachedConfirmed ?? emptyBoard();
   let outbox: BoardMutationV1[] = [];
   let inflight = false;
-  let loaded = false;
+  let loaded = cachedConfirmed !== undefined;
   let unavailable = false;
+  let snapshot: BoardSnapshot = loaded
+    ? { prefs: confirmed.prefs, explicitManual: confirmed.explicitManual ?? [], revision: confirmed.revision, sync: "current", loaded: true }
+    : { prefs: EMPTY_BOARD_PREFS, explicitManual: [], revision: 0, sync: "unavailable", loaded: false };
   let disposed = false;
   /* Consecutive revision conflicts: each means a fresh concurrent write, so we
      retry immediately up to a cap before falling back to the backoff timer. */
@@ -280,6 +295,10 @@ export function createBoardStore(options: BoardStoreOptions): BoardStore {
   const refresh = () => {
     const board = optimisticBoard(confirmed, outbox);
     snapshot = { prefs: board.prefs, explicitManual: board.explicitManual ?? [], revision: confirmed.revision, sync: syncFor(), loaded };
+    /* Cache only a genuinely loaded, available board — never the pre-load empty
+       board or an unavailable one — so a later mount primes from the settled
+       arrangement and not from a placeholder that would paint an unpruned set. */
+    if (loaded && !unavailable) confirmedBoards.set(project, confirmed);
     emit();
   };
 
@@ -550,6 +569,19 @@ export function createBoardStore(options: BoardStoreOptions): BoardStore {
 
 const UNAVAILABLE_SNAPSHOT: BoardSnapshot = { prefs: EMPTY_BOARD_PREFS, explicitManual: [], revision: 0, sync: "unavailable", loaded: false };
 
+/** The first snapshot a project's binding renders. A project already loaded this
+    session starts settled from the session cache (#172) so its board paints the
+    pruned arrangement immediately; everything else starts unavailable and holds
+    the dashboard skeleton until the store's first load lands. Empty on the
+    server (the cache is per-request), so hydration matches the first client
+    render. */
+function initialBoardSnapshot(project: string | null): BoardSnapshot {
+  if (typeof window === "undefined" || project === null) return UNAVAILABLE_SNAPSHOT;
+  const cached = confirmedBoards.get(project);
+  if (!cached) return UNAVAILABLE_SNAPSHOT;
+  return { prefs: cached.prefs, explicitManual: cached.explicitManual ?? [], revision: cached.revision, sync: "current", loaded: true };
+}
+
 export interface BoardState extends BoardSnapshot {
   /** Dispatch a semantic mutation batch (close/restore/reconcile/remap/
       presentation). The store replays it optimistically and flushes durably. */
@@ -569,13 +601,22 @@ export interface BoardState extends BoardSnapshot {
  */
 export function useBoardState(project: string | null): BoardState {
   const storeRef = useRef<BoardStore | null>(null);
-  const [snapshot, setSnapshot] = useState<BoardSnapshot>(UNAVAILABLE_SNAPSHOT);
+  /* The snapshot is tagged with the project it describes. Selecting a new
+     project re-runs the effect below, but the render that changed `project`
+     happens first with the previous project's snapshot still in state.
+     Reporting that stale (or, for a fresh project, empty) arrangement as
+     `loaded` would paint it for one frame and then cull to the real board — the
+     flash (#172). Until the effect rebinds the store, the tag mismatches and the
+     board reports unavailable, so the dashboard keeps its skeleton. */
+  const [bound, setBound] = useState<{ project: string | null; snapshot: BoardSnapshot }>(
+    () => ({ project, snapshot: initialBoardSnapshot(project) }),
+  );
 
   useEffect(() => {
     if (typeof window === "undefined" || project === null) {
       storeRef.current = null;
       /* eslint-disable-next-line react-hooks/set-state-in-effect */
-      setSnapshot(UNAVAILABLE_SNAPSHOT);
+      setBound({ project, snapshot: UNAVAILABLE_SNAPSHOT });
       return;
     }
     let storage: Pick<Storage, "getItem"> | null = null;
@@ -586,8 +627,8 @@ export function useBoardState(project: string | null): BoardState {
     }
     const store = createBoardStore({ project, fetcher: (input, init) => fetch(input, init), storage });
     storeRef.current = store;
-    setSnapshot(store.getSnapshot());
-    const unsubscribe = store.subscribe(() => setSnapshot(store.getSnapshot()));
+    setBound({ project, snapshot: store.getSnapshot() });
+    const unsubscribe = store.subscribe(() => setBound({ project, snapshot: store.getSnapshot() }));
     return () => {
       unsubscribe();
       store.dispose();
@@ -595,8 +636,9 @@ export function useBoardState(project: string | null): BoardState {
     };
   }, [project]);
 
+  const current = bound.project === project ? bound.snapshot : UNAVAILABLE_SNAPSHOT;
   return {
-    ...snapshot,
+    ...current,
     mutate(mutations) {
       storeRef.current?.mutate(mutations);
     },

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -80,6 +80,7 @@ export const en = {
   "dash.task": "Task",
   "dash.newTask": "New task",
   "dash.pipelinesUnavailable": "Pipelines are temporarily unavailable: the pipelines state file could not be read. Other panels stay live.",
+  "dash.loadingBoard": "Loading the board…",
   "dash.emptyTitle": "The scheme is empty for now",
   "dash.emptyHint": "Open the switchboard in the bottom-right corner and click a conversation — it will appear here",
   "dash.viewScheme": "scheme",

--- a/src/lib/i18n/uk.ts
+++ b/src/lib/i18n/uk.ts
@@ -74,6 +74,7 @@ export const uk: Record<keyof typeof en, Message> = {
   "dash.task": "Задача",
   "dash.newTask": "Нова задача",
   "dash.pipelinesUnavailable": "Пайплайни тимчасово недоступні: файл стану пайплайнів не вдалося прочитати. Решта панелей працює.",
+  "dash.loadingBoard": "Завантаження дошки…",
   "dash.emptyTitle": "На схемі поки порожньо",
   "dash.emptyHint": "Відкрий пульт у правому нижньому куті і клікни розмову — вона з'явиться тут",
   "dash.viewScheme": "схема",


### PR DESCRIPTION
Closes #172.

## Problem
Reloading a project page (`#p=…`) first painted **every** scanned agent card, then most disappeared a beat later. The initial render used the raw scan snapshot; persisted closes, worker-stack collapse and scheme caps only applied after the persisted board state hydrated. Users read the flash as data loss (reported twice on 2026-07-13).

## Fix
Make the first painted board equal the **settled** state.

- **Gate first paint** on BOTH the first full scan *and* the persisted board state. Until both resolve, the content area holds a skeleton instead of painting-then-culling. Once settled, the first real frame already reflects closes, worker collapse and caps — no flash. (`boardFirstPaintReady` in `ProjectDashboard`.)
- **Render the cached settled snapshot when available.** `useBoardState` keeps a session cache of the last server-confirmed board per project, so a revisited/soft-nav project primes its store from the settled arrangement and only background-revalidates — no empty→pruned transition. Only genuinely-loaded, available boards are cached (never a placeholder or unavailable one).
- **No stale-project frame.** The snapshot is tagged with the project it describes; until the store rebinds after a project switch, the board reports unavailable so the dashboard keeps its skeleton rather than briefly showing the previous project's arrangement.
- **Skeleton** is a responsive, reduced-motion-safe `aria-busy` placeholder (auto-fill grid, `overflow-hidden`) — no layout jump at 390px or desktop. English + Ukrainian copy.

UI layer only — no changes under `src/lib/{flows,agent,runtime}`.

## Tests (no-flash regression)
- `boardFirstPaintReady` gating unit test (neither signal alone paints nodes).
- `useBoardState` cache priming: a project loaded once primes the next store from the settled snapshot; an unavailable board is never cached, so a later mount still holds until it truly loads.
- `SchemeSkeleton` a11y + responsive/reduced-motion render test.
- Mounted `ProjectDashboard` render→settle DOM test: the first frame is the busy skeleton and no node paints before the persisted board state lands.

## Gates
- `bunx tsc --noEmit` ✅
- `bun test` ✅ (2530 pass, 0 fail — includes the #215 route-export gate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)