### PR TITLE
Fix Claude spawn account health and launch verification

### DIFF
--- a/src/app/api/spawn/accountError.test.ts
+++ b/src/app/api/spawn/accountError.test.ts
@@ -1,0 +1,15 @@
+import { expect, test } from "bun:test";
+
+import { NoHealthyClaudeAccountError } from "@/lib/accounts/spawnHealth";
+
+import { spawnAccountErrorResponse } from "./accountError";
+
+test("the no-healthy-account path returns a retry-safe actionable 503", async () => {
+  const response = spawnAccountErrorResponse(new NoHealthyClaudeAccountError(["botfatherdev-2"]));
+
+  expect(response?.status).toBe(503);
+  expect(await response?.json()).toEqual({
+    error: "No healthy Claude account is available. Re-login account botfatherdev-2 in Accounts and retry.",
+    retrySafe: true,
+  });
+});

--- a/src/app/api/spawn/accountError.ts
+++ b/src/app/api/spawn/accountError.ts
@@ -1,0 +1,8 @@
+import { NextResponse } from "next/server";
+
+import { NoHealthyClaudeAccountError } from "@/lib/accounts/spawnHealth";
+
+export function spawnAccountErrorResponse(error: unknown): NextResponse<{ error: string; retrySafe: true }> | null {
+  if (!(error instanceof NoHealthyClaudeAccountError)) return null;
+  return NextResponse.json({ error: error.message, retrySafe: true }, { status: 503 });
+}

--- a/src/app/api/spawn/route.test.ts
+++ b/src/app/api/spawn/route.test.ts
@@ -113,6 +113,20 @@ test("spawn route projects a launched path-pending receipt as a truthful success
   });
 });
 
+test("a pane-bound launch verification failure returns launched false with its teaching error", () => {
+  const store = registry();
+  const begun = store.beginSpawnRequest({ engine: "claude", cwd: "/repo", accountId: "botfatherdev-2" });
+  if (begun.kind !== "created") throw new Error("expected a new receipt");
+  store.bindSpawnPane(begun.receipt.launchId, { endpoint: "/tmp", server: { pid: 9, startIdentity: "9:a" }, paneId: "%9", panePid: { pid: 99, startIdentity: "99:a" }, target: "agents:9.0" });
+  store.failSpawn(begun.receipt.launchId, "Claude account botfatherdev-2 needs re-login. Open Accounts, sign in, and retry.");
+
+  expect(spawnResponseForReceipt(store.snapshot().receipts[begun.receipt.launchId]!)).toMatchObject({
+    launched: false,
+    state: "conflict",
+    error: "Claude account botfatherdev-2 needs re-login. Open Accounts, sign in, and retry.",
+  });
+});
+
 test("spawn route accepts an explicit stable parent conversation identity", () => {
   const store = registry();
   const parentPath = "/sessions/rollout-019f4906-3f67-7b72-9fbc-9ec3b5ad1326.jsonl";

--- a/src/app/api/spawn/route.ts
+++ b/src/app/api/spawn/route.ts
@@ -6,7 +6,7 @@ import { NextRequest, NextResponse } from "next/server";
 
 import { UnknownAccountError } from "@/lib/accounts/codex";
 import { claudeSettingsPath, isManagedClaudeHome, UnknownClaudeAccountError } from "@/lib/accounts/claude";
-import { accountManager } from "@/lib/accounts/manager";
+import { accountManager, resolveHealthySpawnAccount } from "@/lib/accounts/manager";
 import { emptyLaunchProfile } from "@/lib/accounts/migration/contracts";
 import { freshSpecFor, type AgentEngine } from "@/lib/agent/cli";
 import { agentRegistry, SpawnChildLimitError } from "@/lib/agent/registry";
@@ -17,7 +17,7 @@ import { spawnContentDigest, spawnParentSelector, spawnRequestDigest } from "@/l
 import { sessionKeyFromTranscript } from "@/lib/agent/sessionKey";
 import { resolveSpawnLineage, SpawnParentError } from "@/lib/agent/spawnParent";
 import { spawnResponseForReceipt, type SpawnResponse } from "@/lib/agent/spawnResponse";
-import { applyClaudeSpawnPolicy } from "@/lib/agent/spawnPolicy";
+import { applyClaudeSpawnPolicy, prepareManagedClaudeSpawnHome } from "@/lib/agent/spawnPolicy";
 import { resolveSpawnedTranscriptPath } from "@/lib/agent/spawnedTranscript";
 import { headCwd } from "@/lib/agent/transcript";
 import { persistHandoffLineage, rememberHandoffChild } from "@/lib/handoffLineage";
@@ -33,6 +33,7 @@ import type { ApiError } from "@/lib/types";
 
 import { sourceCwdStatus } from "./sourceCwd";
 import { AGENT_SPAWN_LINEAGE_ERROR, AGENT_SPAWN_LIVE_CHILD_CAP, agentSpawnLineageError, authenticatedAgentSpawnCaller, isAgentInitiatedSpawn } from "./admission";
+import { spawnAccountErrorResponse } from "./accountError";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -159,7 +160,7 @@ export async function POST(req: NextRequest): Promise<NextResponse<SpawnResponse
   let imagePaths: string[] = [];
   let launchId: string | null = null;
   try {
-    const account = accountManager.resolveSpawn(engine, body.accountId);
+    const account = await resolveHealthySpawnAccount(engine, body.accountId);
     const lineage = resolveSpawnLineage(agentInitiated
       ? { parentConversationId: authenticatedCallerId!, role: role.value?.role, reviews: body.reviews }
       : body, registry);
@@ -217,6 +218,7 @@ export async function POST(req: NextRequest): Promise<NextResponse<SpawnResponse
     launchId = begun.receipt.launchId;
     if (engine === "claude") {
       const profileId = path.basename(spec.transcript ?? "", ".jsonl");
+      if (isManagedClaudeHome(account.home)) prepareManagedClaudeSpawnHome(account.home, cwd);
       applyClaudeSpawnPolicy(account.home, {
         allowSubagents: body.allowSubagents === true,
         baseSettingsPath: isManagedClaudeHome(account.home) ? claudeSettingsPath() : null,
@@ -313,6 +315,8 @@ export async function POST(req: NextRequest): Promise<NextResponse<SpawnResponse
     if (error instanceof SpawnParentError) return NextResponse.json({ error: error.message }, { status: error.status });
     if (error instanceof SpawnChildLimitError) return NextResponse.json({ error: error.message }, { status: 429 });
     if (error instanceof UnknownAccountError || error instanceof UnknownClaudeAccountError) return NextResponse.json({ error: error.message }, { status: 400 });
+    const accountError = spawnAccountErrorResponse(error);
+    if (accountError) return accountError;
     if (receipt?.pane) {
       if (receipt.state === "prompt-delivered" || receipt.state === "host-verified") agentRegistry().markSpawnPathPending(receipt.launchId);
       const recovered = agentRegistry().snapshot().receipts[receipt.launchId];

--- a/src/components/AccountsPanel.render.test.tsx
+++ b/src/components/AccountsPanel.render.test.tsx
@@ -72,6 +72,7 @@ test("renders a capacity chip per account and dims the stale one", () => {
 
 test("shows account ids and auth health when labels collide", () => {
   const html = render(base({
+    engine: "claude",
     accounts: [
       { id: "botfatherdev-2", label: "botfatherdev", kind: "managed", authPresent: true, authHealth: "signed_out", loginPending: false, loginState: "idle", deviceAuth: null },
       { id: "botfatherdev-3", label: "botfatherdev", kind: "managed", authPresent: true, authHealth: "authenticated", loginPending: false, loginState: "authenticated", deviceAuth: null },
@@ -83,6 +84,9 @@ test("shows account ids and auth health when labels collide", () => {
   expect(html).toContain("botfatherdev-3");
   expect(html).toContain("Signed out");
   expect(html).toContain("Authenticated");
+  expect(html).toContain("bg-danger-soft text-danger");
+  expect(html).toContain("needs sign-in");
+  expect(html).toContain(">Sign in<");
 });
 
 test("breaks out each account's session and weekly windows with reset times", () => {

--- a/src/components/AccountsPanel.tsx
+++ b/src/components/AccountsPanel.tsx
@@ -15,6 +15,7 @@ import { type TFunction, useLocale } from "@/lib/i18n";
 import { handleOverlayEscape } from "@/lib/overlay";
 
 import { Check, Loader2, X } from "./icons";
+import { Badge } from "./ui/Badge";
 import { formatResetClock, formatResetEta } from "./rateLimit";
 import { engineTintOf } from "./utils";
 
@@ -109,9 +110,13 @@ function AccountLimitsDetail({ account }: { account: AccountOption }) {
 
 type RowState = "active" | "needsLogin" | "pending" | "idle";
 
+function authHealth(account: AccountOption): AccountAuthHealth {
+  return account.authHealth ?? (account.authPresent ? "unknown" : "signed_out");
+}
+
 function rowState(account: AccountOption, activeId: string): RowState {
   if (account.loginPending) return "pending";
-  if (!account.authPresent) return "needsLogin";
+  if (!account.authPresent || authHealth(account) === "signed_out") return "needsLogin";
   if (account.id === activeId) return "active";
   return "idle";
 }
@@ -133,12 +138,12 @@ function StateChip({ state }: { state: RowState }) {
 
 function AuthIdentity({ account }: { account: AccountOption }) {
   const { t } = useLocale();
-  const health: AccountAuthHealth = account.authHealth ?? (account.authPresent ? "unknown" : "signed_out");
+  const health = authHealth(account);
+  const tone = health === "authenticated" ? "success" : health === "signed_out" || health === "error" ? "danger" : "neutral";
   return (
     <span className="flex min-w-0 items-center gap-1 text-[9.5px] font-medium text-muted">
       <code className="truncate font-mono">{account.id}</code>
-      <span aria-hidden>·</span>
-      <span className="shrink-0">{t(AUTH_HEALTH_KEY[health])}</span>
+      <Badge tone={tone} className="px-1.5 py-0 text-[9px]">{t(AUTH_HEALTH_KEY[health])}</Badge>
     </span>
   );
 }
@@ -147,7 +152,7 @@ function AccountRow({ account, engine, activeId, onSelect, onRemove, disabled }:
   const { t } = useLocale();
   const state = rowState(account, activeId);
   const isActive = account.id === activeId;
-  const selectionDisabled = disabled || !account.authPresent || account.loginPending;
+  const selectionDisabled = disabled || !account.authPresent || authHealth(account) === "signed_out" || account.loginPending;
   // Removal deletes the managed home (including its credentials) with no undo,
   // so the unblocked path arms on the first click and only executes on a
   // second, explicit confirm — mirroring the confirm step migration already
@@ -363,7 +368,7 @@ function ClaudeLoginRow({ account, state, loginBusy }: { account: AccountOption;
 
   // Managed account with no auth and no live op (covers canceled and the broken
   // production account): a Sign in affordance that restarts login in place.
-  if (account.kind === "managed" && !account.authPresent) {
+  if (account.kind === "managed" && (!account.authPresent || authHealth(account) === "signed_out")) {
     return (
       <div ref={rowRef} tabIndex={-1} className="flex items-center gap-2 px-3 pb-2 pl-[26px] focus-visible:outline-none">
         <button

--- a/src/components/DraftAgentPane.tsx
+++ b/src/components/DraftAgentPane.tsx
@@ -20,6 +20,7 @@ import {
   type SpawnAttempt,
   type SpawnResponseBody,
   applySpawnOutcome,
+  applySpawnFailure,
   classifySpawnResponse,
   classifyTransportLoss,
   createSpawnAttempt,
@@ -548,6 +549,8 @@ export function DraftAgentPane({
       const outcome = classifySpawnResponse(res.status, res.ok, json);
       if (outcome.kind === "launched") {
         setAttempt(applySpawnOutcome(candidate, outcome));
+      } else if (outcome.kind === "failed-launch") {
+        setAttempt(applySpawnFailure(candidate, outcome));
       } else if (outcome.kind === "failed-preflight") {
         /* The server proved that no pane opened. Restore the exact durable
            payload so editing and retrying cannot lose an attachment. */
@@ -761,7 +764,7 @@ export function DraftAgentPane({
                 {attempt.prompt || t("draft.imagesOnly")}
               </span>
             </div>
-            <DraftLaunchStatus ref={attentionRef} phase={phase} target={target} />
+            <DraftLaunchStatus ref={attentionRef} phase={phase} target={target} error={attempt.error ?? null} />
           </div>
         ) : (
           <div className="flex flex-1 flex-col items-center justify-center gap-2 text-center">

--- a/src/components/DraftLaunchStatus.render.test.tsx
+++ b/src/components/DraftLaunchStatus.render.test.tsx
@@ -47,3 +47,13 @@ test("attention without a known target points the user at their tmux windows", (
   expect(html).toContain("launch it again");
   expect(html).not.toContain("{target}");
 });
+
+test("a verified launch failure replaces generic attention copy with the teaching error", () => {
+  const html = renderToStaticMarkup(<DraftLaunchStatus
+    phase="attention"
+    target="sess:4.0"
+    error="Claude account botfatherdev-2 needs re-login. Open Accounts, sign in, and retry."
+  />);
+  expect(html).toContain("Claude account botfatherdev-2 needs re-login");
+  expect(html).not.toContain("launch it again");
+});

--- a/src/components/DraftLaunchStatus.tsx
+++ b/src/components/DraftLaunchStatus.tsx
@@ -18,16 +18,16 @@ import type { DraftPhase } from "./draftSpawn";
  * `attention` swaps it for a static "don't relaunch" glyph. In `attention` the
  * region is focusable (`tabIndex -1`) so the pane can move focus to the guidance.
  */
-export const DraftLaunchStatus = forwardRef<HTMLDivElement, { phase: DraftPhase; target: string }>(function DraftLaunchStatus(
-  { phase, target },
+export const DraftLaunchStatus = forwardRef<HTMLDivElement, { phase: DraftPhase; target: string; error?: string | null }>(function DraftLaunchStatus(
+  { phase, target, error },
   ref,
 ) {
   const { t } = useLocale();
   const attention = phase === "attention";
   const statusText = attention
-    ? target
+    ? error || (target
       ? t("draft.attention", { target })
-      : t("draft.attentionNoTarget")
+      : t("draft.attentionNoTarget"))
     : phase === "confirming"
       ? target
         ? t("draft.confirming", { target })

--- a/src/components/draftSpawn.test.ts
+++ b/src/components/draftSpawn.test.ts
@@ -7,6 +7,7 @@ import {
   SLOW_BOOT_MS,
   type SpawnAttempt,
   applySpawnOutcome,
+  applySpawnFailure,
   classifySpawnResponse,
   classifyTransportLoss,
   createSpawnAttempt,
@@ -120,6 +121,32 @@ describe("classifySpawnResponse — server → card outcome", () => {
     }
   });
 
+  test("verified post-launch failure stays frozen and surfaces its teaching error", () => {
+    const out = classifySpawnResponse(200, true, {
+      ok: true,
+      state: "conflict",
+      launched: false,
+      path: null,
+      conversationId: "conversation_9",
+      launchId: "launch-1",
+      target: "sess:3.0",
+      error: "Claude account botfatherdev-2 needs re-login. Open Accounts, sign in, and retry.",
+    });
+    expect(out).toEqual({
+      kind: "failed-launch",
+      message: "Claude account botfatherdev-2 needs re-login. Open Accounts, sign in, and retry.",
+      target: "sess:3.0",
+      conversationId: "conversation_9",
+      launchId: "launch-1",
+    });
+    if (out.kind !== "failed-launch") throw new Error("expected failed launch");
+    expect(applySpawnFailure(baseAttempt, out)).toMatchObject({
+      phase: "attention",
+      target: "sess:3.0",
+      error: out.message,
+    });
+  });
+
   test("400 preflight → failed-preflight, retry safe, surfaces the reason", () => {
     const out = classifySpawnResponse(400, false, { error: "directory does not exist: /nope" });
     expect(out).toEqual({ kind: "failed-preflight", message: "directory does not exist: /nope" });
@@ -141,6 +168,13 @@ describe("classifySpawnResponse — server → card outcome", () => {
   test("5xx / opaque → ambiguous (a proxy 5xx could land after launch)", () => {
     expect(classifySpawnResponse(500, false, { error: "boom" })).toEqual({ kind: "ambiguous" });
     expect(classifySpawnResponse(502, false, null)).toEqual({ kind: "ambiguous" });
+  });
+
+  test("retry-safe 503 is a visible preflight failure", () => {
+    expect(classifySpawnResponse(503, false, { error: "account needs re-login", retrySafe: true })).toEqual({
+      kind: "failed-preflight",
+      message: "account needs re-login",
+    });
   });
 
   test("transport loss → ambiguous", () => {

--- a/src/components/draftSpawn.ts
+++ b/src/components/draftSpawn.ts
@@ -83,6 +83,8 @@ export interface SpawnAttempt {
   /** Handoff source transcript, or "" for a plain draft. */
   src: string;
   phase: DurablePhase;
+  /** Teaching error for a launch that opened a pane and then failed verification. */
+  error?: string | null;
 }
 
 export function createSpawnAttempt(clientAttemptId: string, at: number, request: RecoverableSpawnRequest): SpawnAttempt & { request: RecoverableSpawnRequest } {
@@ -99,6 +101,7 @@ export function createSpawnAttempt(clientAttemptId: string, at: number, request:
     engine: request.engine,
     src: request.src,
     phase: "confirming",
+    error: null,
   };
 }
 
@@ -161,6 +164,21 @@ export function applySpawnOutcome(
     conversationId: outcome.conversationId,
     launchId: outcome.launchId,
     phase: outcome.durable,
+    error: null,
+  };
+}
+
+export function applySpawnFailure(
+  attempt: SpawnAttempt,
+  outcome: Extract<SpawnOutcome, { kind: "failed-launch" }>,
+): SpawnAttempt {
+  return {
+    ...attempt,
+    target: outcome.target,
+    conversationId: outcome.conversationId,
+    launchId: outcome.launchId,
+    phase: "attention",
+    error: outcome.message,
   };
 }
 
@@ -185,6 +203,8 @@ export type SpawnOutcome =
   /** Proven pre-launch failure: no pane opened, images cleaned up server-side.
       Safe to retry — the draft re-enables send and shows the reason. */
   | { kind: "failed-preflight"; message: string | null }
+  /** A pane opened, then positive launch verification found a terminal screen. */
+  | { kind: "failed-launch"; message: string; target: string; conversationId: string | null; launchId: string | null }
   /** The client cannot prove whether a worker exists (transport loss, opaque
       5xx, a conflicting attempt). Treated as worker-may-exist: send stays off. */
   | { kind: "ambiguous" };
@@ -207,6 +227,9 @@ export function classifySpawnResponse(status: number, ok: boolean, body: SpawnRe
     const conversationId = typeof body.conversationId === "string" ? body.conversationId : null;
     const launchId = typeof body.launchId === "string" ? body.launchId : null;
     const target = typeof body.target === "string" ? body.target : "";
+    if (body.launched === false && typeof body.error === "string" && body.error) {
+      return { kind: "failed-launch", message: body.error, target, conversationId, launchId };
+    }
     /* A settled receipt with a known path is the only deterministic match; any
        other unresolved launch receipt (path-pending, starting replay,
        conflict) becomes confirming and adopts by identity/heuristic. */
@@ -221,7 +244,7 @@ export function classifySpawnResponse(status: number, ok: boolean, body: SpawnRe
     };
   }
   /* A replay of a receipt that failed before launch is explicitly retry-safe. */
-  if (status === 409 && body?.retrySafe) return { kind: "failed-preflight", message: body?.error ?? null };
+  if (body?.retrySafe) return { kind: "failed-preflight", message: body?.error ?? null };
   /* A conflicting attempt (same key, different request) can leave the
      original worker alive. Send stays disabled. */
   if (status === 409) return { kind: "ambiguous" };

--- a/src/lib/accounts/manager.ts
+++ b/src/lib/accounts/manager.ts
@@ -7,10 +7,21 @@ import { unavailableLimits } from "./contracts";
 import { withAccountMutationLockAsync } from "./accountMutation";
 import { agentRegistry, type AgentRegistry } from "@/lib/agent/registry";
 import { selectHeadlessAccount } from "./headlessSelection";
+import { selectHealthyClaudeAccount } from "./spawnHealth";
 
 function contextForSpawn(engine: "claude" | "codex", requested?: string | null) {
   if (engine === "claude") { const item = claudeAccountForSpawn(requested); return { engine, accountId: item.id, kind: item.kind, home: item.home, transcriptRoot: item.projectsDir, env: item.kind === "managed" ? claudeManagedEnvironment(item.home) : process.env }; }
   const item = accountForSpawn(requested); return { engine, accountId: item.id, kind: item.kind, home: item.home, transcriptRoot: item.sessionsDir, env: { ...process.env, CODEX_HOME: item.home } };
+}
+
+/** Viewer-visible spawn admission performs a fresh Claude OAuth health pass. */
+export async function resolveHealthySpawnAccount(engine: "claude" | "codex", requested?: string | null) {
+  const routed = requested ?? agentRegistry().engineRouting(engine).activeAccountId ?? undefined;
+  if (engine === "codex") return contextForSpawn(engine, routed);
+  const accounts = listClaudeAccounts();
+  if (routed && !accounts.some((account) => account.id === routed)) throw new UnknownClaudeAccountError(routed);
+  const selected = await selectHealthyClaudeAccount(accounts, routed);
+  return contextForSpawn(engine, selected.id);
 }
 
 function summary(engine: "claude" | "codex", id: string): AccountSummary {

--- a/src/lib/accounts/spawnHealth.test.ts
+++ b/src/lib/accounts/spawnHealth.test.ts
@@ -1,0 +1,70 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, expect, test } from "bun:test";
+
+import type { ClaudeAccount } from "./claude";
+import { NoHealthyClaudeAccountError, selectHealthyClaudeAccount } from "./spawnHealth";
+
+const NOW = Date.parse("2026-07-14T09:00:00.000Z");
+const homes: string[] = [];
+
+afterEach(() => {
+  for (const home of homes.splice(0)) fs.rmSync(home, { recursive: true, force: true });
+});
+
+function account(id: string, expiresAt: number, authPresent = true): ClaudeAccount {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), `llv-spawn-health-${id}-`));
+  homes.push(home);
+  fs.writeFileSync(path.join(home, ".credentials.json"), JSON.stringify({
+    claudeAiOauth: { accessToken: `${id}-token`, refreshToken: `${id}-refresh`, expiresAt },
+  }), { mode: 0o600 });
+  return { id, label: id, kind: "managed", home, projectsDir: path.join(home, "projects"), authPresent, createdAt: 0 };
+}
+
+test("spawn selection skips an expired preferred Claude account and probes a healthy fallback", async () => {
+  const expired = account("expired", NOW - 1);
+  const healthy = account("healthy", NOW + 60_000);
+  const probed: string[] = [];
+
+  const selected = await selectHealthyClaudeAccount([expired, healthy], "expired", {
+    now: () => NOW,
+    probe: async (candidate) => {
+      probed.push(candidate.id);
+      return "valid";
+    },
+  });
+
+  expect(selected.id).toBe("healthy");
+  expect(probed).toEqual(["healthy"]);
+});
+
+test("spawn selection ranks a live-valid account above a transiently unverifiable preferred account", async () => {
+  const preferred = account("preferred", NOW + 60_000);
+  const confirmed = account("confirmed", NOW + 60_000);
+
+  const selected = await selectHealthyClaudeAccount([preferred, confirmed], "preferred", {
+    now: () => NOW,
+    probe: async (candidate) => candidate.id === "confirmed" ? "valid" : "unknown",
+  });
+
+  expect(selected.id).toBe("confirmed");
+});
+
+test("spawn selection reports every dead account when none can launch", async () => {
+  const expired = account("expired", NOW - 1);
+  const rejected = account("rejected", NOW + 60_000);
+
+  try {
+    await selectHealthyClaudeAccount([expired, rejected], "expired", {
+      now: () => NOW,
+      probe: async () => "invalid",
+    });
+    throw new Error("expected selection to fail");
+  } catch (error) {
+    expect(error).toBeInstanceOf(NoHealthyClaudeAccountError);
+    expect((error as Error).message).toContain("expired");
+    expect((error as Error).message).toContain("rejected");
+    expect((error as Error).message).toContain("Re-login");
+  }
+});

--- a/src/lib/accounts/spawnHealth.ts
+++ b/src/lib/accounts/spawnHealth.ts
@@ -1,0 +1,83 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import { fetchClaudeLimits } from "@/lib/limits";
+import { LIMITS_RATE_LIMITED_REASON, LIMITS_REAUTH_REQUIRED_REASON } from "@/lib/types";
+
+import type { ClaudeAccount } from "./claude";
+
+export type ClaudeValidityProbeResult = "valid" | "invalid" | "unknown";
+
+export interface ClaudeSpawnHealthDependencies {
+  now(): number;
+  probe(account: ClaudeAccount): Promise<ClaudeValidityProbeResult>;
+}
+
+export class NoHealthyClaudeAccountError extends Error {
+  readonly accountIds: string[];
+
+  constructor(accountIds: string[]) {
+    const ids = [...new Set(accountIds)].sort();
+    const target = ids.length === 1 ? `account ${ids[0]}` : ids.length > 1 ? `accounts ${ids.join(", ")}` : "a Claude account";
+    super(`No healthy Claude account is available. Re-login ${target} in Accounts and retry.`);
+    this.name = "NoHealthyClaudeAccountError";
+    this.accountIds = ids;
+  }
+}
+
+function oauthExpiresAt(account: ClaudeAccount): number | null {
+  if (!account.authPresent) return null;
+  try {
+    const credentials = JSON.parse(fs.readFileSync(path.join(account.home, ".credentials.json"), "utf8")) as {
+      claudeAiOauth?: { accessToken?: unknown; expiresAt?: unknown };
+    };
+    const oauth = credentials.claudeAiOauth;
+    return typeof oauth?.accessToken === "string" && oauth.accessToken.length > 0
+      && typeof oauth.expiresAt === "number" && Number.isFinite(oauth.expiresAt)
+      ? oauth.expiresAt
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+async function liveValidityProbe(account: ClaudeAccount): Promise<ClaudeValidityProbeResult> {
+  const result = await fetchClaudeLimits(path.join(account.home, ".credentials.json"));
+  if (result.source === "live" || result.reason === LIMITS_RATE_LIMITED_REASON) return "valid";
+  if (result.reason === LIMITS_REAUTH_REQUIRED_REASON
+    || result.reason === "credentials missing access token"
+    || result.reason?.startsWith("credentials unreadable:")) return "invalid";
+  return "unknown";
+}
+
+const productionDependencies: ClaudeSpawnHealthDependencies = {
+  now: Date.now,
+  probe: liveValidityProbe,
+};
+
+/**
+ * Chooses one launchable Claude account from a single preflight health pass.
+ * A current OAuth expiry is required before the live usage probe runs. Live
+ * validation outranks a transient probe failure; the requested/routed account
+ * breaks ties inside the same health tier.
+ */
+export async function selectHealthyClaudeAccount(
+  accounts: ClaudeAccount[],
+  preferredId: string | null | undefined,
+  dependencies: ClaudeSpawnHealthDependencies = productionDependencies,
+): Promise<ClaudeAccount> {
+  const now = dependencies.now();
+  const candidates = await Promise.all(accounts.map(async (account) => {
+    const expiresAt = oauthExpiresAt(account);
+    if (expiresAt === null || expiresAt <= now) return { account, health: "invalid" as const };
+    return { account, health: await dependencies.probe(account) };
+  }));
+  const rank = (health: ClaudeValidityProbeResult) => health === "valid" ? 2 : health === "unknown" ? 1 : 0;
+  const selected = candidates
+    .filter((candidate) => rank(candidate.health) > 0)
+    .sort((left, right) => rank(right.health) - rank(left.health)
+      || Number(right.account.id === preferredId) - Number(left.account.id === preferredId)
+      || left.account.id.localeCompare(right.account.id))[0];
+  if (selected) return selected.account;
+  throw new NoHealthyClaudeAccountError(candidates.map((candidate) => candidate.account.id));
+}

--- a/src/lib/agent/spawnPolicy.test.ts
+++ b/src/lib/agent/spawnPolicy.test.ts
@@ -3,7 +3,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
-import { applyClaudeSpawnPolicy, fenceViewerSpawnPrompt, NATIVE_SUBAGENT_DENY_MESSAGE, VIEWER_SPAWN_PROMPT_FENCE } from "./spawnPolicy";
+import { applyClaudeSpawnPolicy, fenceViewerSpawnPrompt, NATIVE_SUBAGENT_DENY_MESSAGE, prepareManagedClaudeSpawnHome, VIEWER_SPAWN_PROMPT_FENCE } from "./spawnPolicy";
 
 const homes: string[] = [];
 
@@ -106,6 +106,33 @@ test("allowSubagents uses an isolated profile while the denied profile stays enf
 
   expect(denied.hooks.PreToolUse.some((group) => group.matcher === "Task|Agent")).toBe(true);
   expect(allowed.hooks.PreToolUse).toEqual([{ matcher: "Read", hooks: [{ type: "command", command: "user-read-hook" }] }]);
+});
+
+test("managed Claude launch state accepts bypass mode and trusts the exact spawn directory", () => {
+  const accountHome = home();
+  const statePath = path.join(accountHome, ".claude.json");
+  fs.writeFileSync(statePath, JSON.stringify({
+    theme: "dark",
+    projects: { "/existing": { hasTrustDialogAccepted: true, custom: "kept" } },
+  }));
+
+  prepareManagedClaudeSpawnHome(accountHome, "/repo/worktree");
+
+  const state = JSON.parse(fs.readFileSync(statePath, "utf8")) as {
+    theme: string;
+    hasCompletedOnboarding: boolean;
+    bypassPermissionsModeAccepted: boolean;
+    projects: Record<string, Record<string, unknown>>;
+  };
+  expect(state.theme).toBe("dark");
+  expect(state.hasCompletedOnboarding).toBe(true);
+  expect(state.bypassPermissionsModeAccepted).toBe(true);
+  expect(state.projects["/existing"]).toEqual({ hasTrustDialogAccepted: true, custom: "kept" });
+  expect(state.projects["/repo/worktree"]).toMatchObject({
+    hasTrustDialogAccepted: true,
+    hasCompletedProjectOnboarding: true,
+  });
+  expect(fs.statSync(statePath).mode & 0o777).toBe(0o600);
 });
 
 test("Codex spawn prompts carry the Viewer lineage fence", () => {

--- a/src/lib/agent/spawnPolicy.ts
+++ b/src/lib/agent/spawnPolicy.ts
@@ -72,6 +72,46 @@ function readSettings(pathname: string): JsonObject {
   return settings;
 }
 
+/** Seeds the mutable Claude home state before a managed bypass launch. */
+export function prepareManagedClaudeSpawnHome(home: string, cwd: string): void {
+  const pathname = path.join(home, ".claude.json");
+  try {
+    const stat = fs.lstatSync(pathname);
+    if (stat.isSymbolicLink() || !stat.isFile()) throw new Error(`Claude state path is unsafe: ${pathname}`);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+  }
+  let state: JsonObject = {};
+  if (fs.existsSync(pathname)) {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(fs.readFileSync(pathname, "utf8"));
+    } catch {
+      throw new Error(`Claude state is invalid JSON: ${pathname}`);
+    }
+    const value = record(parsed);
+    if (!value) throw new Error(`Claude state must contain a JSON object: ${pathname}`);
+    state = value;
+  }
+  const projects = state.projects === undefined ? {} : record(state.projects);
+  if (!projects) throw new Error(`Claude state projects must contain a JSON object: ${pathname}`);
+  const existingProject = projects[cwd] === undefined ? {} : record(projects[cwd]);
+  if (!existingProject) throw new Error(`Claude project state must contain a JSON object: ${cwd}`);
+  atomicWrite(pathname, JSON.stringify({
+    ...state,
+    hasCompletedOnboarding: true,
+    bypassPermissionsModeAccepted: true,
+    projects: {
+      ...projects,
+      [cwd]: {
+        ...existingProject,
+        hasTrustDialogAccepted: true,
+        hasCompletedProjectOnboarding: true,
+      },
+    },
+  }, null, 2) + "\n", 0o600);
+}
+
 function managedCommand(command: unknown): boolean {
   return typeof command === "string" && command.startsWith(MANAGED_HOOK_PREFIX);
 }

--- a/src/lib/agent/spawnResponse.ts
+++ b/src/lib/agent/spawnResponse.ts
@@ -10,6 +10,7 @@ export interface SpawnResponse {
   launched: boolean;
   retrySafe: boolean;
   state: "settled" | "path-pending" | "starting" | "conflict";
+  error?: string;
 }
 
 export function spawnResponseForReceipt(receipt: SpawnReceipt, path = receipt.artifactPath): SpawnResponse {
@@ -28,6 +29,7 @@ export function spawnResponseForReceipt(receipt: SpawnReceipt, path = receipt.ar
     conversationId: receipt.conversationId,
     launched,
     retrySafe: receipt.state === "failed",
+    ...(receipt.error ? { error: receipt.error } : {}),
     state: conflict
       ? "conflict"
       : pending

--- a/src/lib/status.test.ts
+++ b/src/lib/status.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "bun:test";
 
-import { detectLiveRateLimit, screenAtIdleComposer } from "./status";
+import { detectLaunchFailure, detectLiveRateLimit, launchPromptLanded, screenAtIdleComposer } from "./status";
 
 const IDLE_CLAUDE = ["● Done. The tests pass.", "", "❯ ", "  ? for shortcuts"].join("\n");
 
@@ -48,4 +48,49 @@ test("historical usage prose above a ready composer stays clear", () => {
   ].join("\n");
 
   expect(detectLiveRateLimit(screen, Date.now() / 1000)).toBeNull();
+});
+
+test("Claude login and bypass-acceptance screens fail launch with teaching errors", () => {
+  expect(detectLaunchFailure("claude", [
+    "Welcome to Claude Code",
+    "Select login method",
+    "1. Claude account with subscription",
+  ].join("\n"))).toEqual({
+    code: "authentication_required",
+    message: "Claude needs account re-login. Open Accounts, sign in, and retry the launch.",
+  });
+  expect(detectLaunchFailure("claude", [
+    "Bypass Permissions mode",
+    "By proceeding, you accept all responsibility",
+    "No, exit",
+  ].join("\n"))).toEqual({
+    code: "bypass_acceptance_required",
+    message: "Claude bypass-permissions acceptance was not prepared. Retry the launch after refreshing the account.",
+  });
+});
+
+test("launch prompt verification accepts a submitted turn and rejects a login screen", () => {
+  const busy = [
+    "❯ Implement issue 178",
+    "✳ Deliberating… (esc to interrupt)",
+  ].join("\n");
+  expect(launchPromptLanded("claude", busy, "Implement issue 178")).toBe(true);
+  expect(launchPromptLanded("claude", "Select login method\n1. Claude account", "Implement issue 178")).toBe(false);
+  expect(launchPromptLanded("claude", "❯ Implement issue 178\n? for shortcuts", "Implement issue 178")).toBe(false);
+});
+
+test("login wording inside a live prompt or transcript never becomes a startup failure", () => {
+  const busy = [
+    "❯ Render the exact text Select login method",
+    "✳ Deliberating… (esc to interrupt)",
+  ].join("\n");
+  expect(detectLaunchFailure("claude", busy)).toBeNull();
+
+  const ready = [
+    "● The page now renders Select login method.",
+    "",
+    "❯ ",
+    "  ? for shortcuts",
+  ].join("\n");
+  expect(detectLaunchFailure("claude", ready)).toBeNull();
 });

--- a/src/lib/status.ts
+++ b/src/lib/status.ts
@@ -249,6 +249,45 @@ export function screenWaitsForInput(screen: string): boolean {
    screen merely lacks a menu. */
 export const BUSY_MARKERS = /esc to interrupt|ctrl\+c to (?:stop|cancel)|Interrupting/i;
 
+const CLAUDE_LOGIN_SCREEN = /Select login method|Choose (?:a|your) login method|Log in to (?:Claude|continue)|Sign in to (?:Claude|continue)/i;
+const CLAUDE_BYPASS_ACCEPTANCE_SCREEN = /Bypass Permissions mode[\s\S]*(?:accept all responsibility|No, exit)/i;
+
+export type LaunchFailure = {
+  code: "authentication_required" | "bypass_acceptance_required";
+  message: string;
+};
+
+/** Fatal startup screens that cannot receive the launch prompt. */
+export function detectLaunchFailure(engine: "claude" | "codex", screen: string): LaunchFailure | null {
+  if (engine !== "claude") return null;
+  if (BUSY_MARKERS.test(screen) || screenAtIdleComposer(screen)) return null;
+  const tail = screen.split("\n").slice(-20).join("\n");
+  if (CLAUDE_LOGIN_SCREEN.test(tail)) {
+    return {
+      code: "authentication_required",
+      message: "Claude needs account re-login. Open Accounts, sign in, and retry the launch.",
+    };
+  }
+  if (CLAUDE_BYPASS_ACCEPTANCE_SCREEN.test(tail)) {
+    return {
+      code: "bypass_acceptance_required",
+      message: "Claude bypass-permissions acceptance was not prepared. Retry the launch after refreshing the account.",
+    };
+  }
+  return null;
+}
+
+/** Positive evidence that the first prompt left the composer for a live turn. */
+export function launchPromptLanded(engine: "claude" | "codex", screen: string, prompt: string): boolean {
+  if (detectLaunchFailure(engine, screen)) return false;
+  const head = prompt.split("\n").map((line) => line.trim()).find(Boolean)?.slice(0, 32) ?? "";
+  if (!head) return screenAtIdleComposer(screen);
+  if (BUSY_MARKERS.test(screen)) return true;
+  const composer = composerLine(screen);
+  if (composer.includes(head) || composer.includes("[Pasted text")) return false;
+  return composer !== "" && READY_MARKERS.test(screen);
+}
+
 /**
  * Positive idle-composer detection: the composer prompt is drawn, the ready
  * hints are on the status bar, and no busy/interrupt hint remains. A quiet

--- a/src/lib/tmux.ts
+++ b/src/lib/tmux.ts
@@ -23,10 +23,12 @@ import { agentProcesses, isHelperArgv, pidAlive, readArgv, readPpid, type AgentP
 import {
   composerLine,
   detectBlockingGate,
+  detectLaunchFailure,
   detectStartupGate,
   isShellCommand,
+  launchPromptLanded,
   parseScreenMenu,
-  READY_MARKERS,
+  screenAtIdleComposer,
   screenTail,
 } from "@/lib/status";
 
@@ -1168,7 +1170,8 @@ export async function forgetResumePaneIfMatches(transcriptPath: string, host: Tm
 
 const SPAWN_READY_TIMEOUT_MS = 60_000;
 const SPAWN_POLL_MS = 1_000;
-const SPAWN_STABLE_ROUNDS = 3;
+const SPAWN_PROMPT_VERIFY_ROUNDS = 6;
+const SPAWN_PROMPT_VERIFY_MS = 400;
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
@@ -1251,8 +1254,6 @@ async function spawnAgentWithPromptUnchecked(spec: ResumeSpec, text: string, rec
   const deadline = Date.now() + SPAWN_READY_TIMEOUT_MS;
   let agentSeen = false;
   let answeredScreen = "";
-  let previousScreen = "";
-  let stableRounds = 0;
   while (Date.now() < deadline) {
     await sleep(SPAWN_POLL_MS);
     const current = await verifyTmuxSpawnBinding(binding, endpoint);
@@ -1267,6 +1268,8 @@ async function spawnAgentWithPromptUnchecked(spec: ResumeSpec, text: string, rec
     agentSeen = true;
 
     const screen = await paneScreen(target, endpoint);
+    const launchFailure = detectLaunchFailure(spec.engine, screen);
+    if (launchFailure) throw new Error(launchFailure.message);
     /* Startup gates (trust-folder, resume-summary picker, other option-list
        dialogs) each default to the safe option, so Enter clears them.
        Re-answering only when the screen changed avoids hammering Enter into a
@@ -1276,24 +1279,21 @@ async function spawnAgentWithPromptUnchecked(spec: ResumeSpec, text: string, rec
       logEvent("gate", { target, cwd: spec.cwd, result: "ok", reason: gate });
       await runBoundTmux(["send-keys", "-t", target, "Enter"]);
       answeredScreen = screen;
-      previousScreen = "";
-      stableRounds = 0;
       continue;
     }
-    if (READY_MARKERS.test(screen)) break;
-    if (screen === previousScreen) {
-      stableRounds += 1;
-      if (stableRounds >= SPAWN_STABLE_ROUNDS) break;
-    } else {
-      stableRounds = 0;
-      previousScreen = screen;
-    }
+    if (screenAtIdleComposer(screen)) break;
   }
 
   const finalPane = await verifyTmuxSpawnBinding(binding, endpoint);
   if (!finalPane || isShellCommand(finalPane.command)) {
     logEvent("spawn", { target, cwd: spec.cwd, result: "error", reason: "agent_exited_on_boot" });
     throw new Error(`agent did not start in the window: ${screenTail(await paneScreen(target, endpoint))}`);
+  }
+  const readyScreen = await paneScreen(target, endpoint);
+  const readyFailure = detectLaunchFailure(spec.engine, readyScreen);
+  if (readyFailure) throw new Error(readyFailure.message);
+  if (!screenAtIdleComposer(readyScreen)) {
+    throw new Error(`agent never reached a launch-ready prompt: ${screenTail(readyScreen)}`);
   }
   const agent = selectSpawnedAgentProcess(panePid, spec.engine, spec.cwd, agentProcesses(true), readPpid);
   if (!agent) throw new Error("booted agent process could not be verified beneath the created pane");
@@ -1319,7 +1319,22 @@ async function spawnAgentWithPromptUnchecked(spec: ResumeSpec, text: string, rec
     meta: { window: spec.windowName, display },
   });
   const fencedPrompt = fenceViewerSpawnPrompt(spec.engine, text);
-  if (fencedPrompt) await sendText(target, fencedPrompt);
+  if (fencedPrompt) {
+    await sendText(target, fencedPrompt);
+    let promptVerified = false;
+    let promptScreen = "";
+    for (let round = 0; round < SPAWN_PROMPT_VERIFY_ROUNDS; round += 1) {
+      promptScreen = await paneScreen(target, endpoint);
+      const promptFailure = detectLaunchFailure(spec.engine, promptScreen);
+      if (promptFailure) throw new Error(promptFailure.message);
+      if (launchPromptLanded(spec.engine, promptScreen, fencedPrompt)) {
+        promptVerified = true;
+        break;
+      }
+      await sleep(SPAWN_PROMPT_VERIFY_MS);
+    }
+    if (!promptVerified) throw new Error(`launch prompt was not accepted by the agent: ${screenTail(promptScreen)}`);
+  }
   const finalVerification = await verifyTmuxSpawnBinding(binding, endpoint);
   if (!finalVerification ||
     !pidAlive(agent.pid) ||


### PR DESCRIPTION
## Summary

- validate Claude OAuth expiry and probe the live usage endpoint before Viewer spawn selection
- rank valid accounts ahead of transiently unknown accounts, skip rejected accounts, and return an actionable retry-safe 503 when every account needs re-login
- show account authentication health with the shared badge design and preserve launch teaching errors in the draft UI
- pre-seed managed Claude onboarding, directory trust, and bypass acceptance state
- require a ready composer and verified first-prompt delivery before reporting launch success

## Root cause

Spawn admission relied on credential-file presence and routed account preference. Expired or rejected OAuth credentials could therefore reach Claude startup, where the pane stopped on a login screen while the API continued along the launch path. First-run bypass acceptance could stop the same path before prompt delivery.

## Verification

- bunx tsc --noEmit
- bun test: 2,536 passed, 0 failed
- bun test src/lib/routeExports.test.ts: 2 passed, 0 failed

Closes #178
Closes #214