### PR TITLE
Built-in Orchestrator: board chat button + phase-1 design doc (#182)

### DIFF
--- a/docs/design/orchestrator-agent.md
+++ b/docs/design/orchestrator-agent.md
@@ -1,0 +1,150 @@
+# Built-in Orchestrator agent — issue #182, Phase 1
+
+Design + skeleton for the viewer's resident Orchestrator: one long-lived agent
+conversation the user talks to, which drives everything else through the
+viewer's own API surface. Grounded in the code as of `main` (post-#212/#215):
+`src/app/api/spawn`, `src/app/api/pipelines`, `src/app/api/flows`,
+`src/lib/roles/defaults.ts` (the #35 role registry), `Viewer.tsx` hash
+deep-links, `OverviewBoard.tsx`.
+
+Related vision, explicitly NOT in scope here: #183 semantic-zoom scheme (the
+orchestrator's on-scheme node placement lands with that work).
+
+## Chat surface
+
+**Placement**: a persistent button in the overview board header
+(`OverviewBoard.tsx`), next to the board title — the board is the one screen
+every session starts on, so the orchestrator is always one tap away. On the
+phone the same header row hosts it with a ≥44px tap target.
+
+**What opens**: the orchestrator is a *normal viewer conversation* — a Claude
+session spawned into a tmux pane, whose transcript renders through the existing
+conversation surface (`BranchPane` → `LogFeed` + `TmuxComposer`). No bespoke
+chat widget: the button resolves the orchestrator conversation and navigates to
+its canonical deep link (`#c=<conversationId>`), which `Viewer.tsx` already
+knows how to resolve, pin, and open. Reusing the pane means images, dictation,
+composer relays, activity states, and attention all work day one.
+
+**Persistence / single instance**: a small state record
+(`state/orchestrator.json`, via `statePath`) stores the orchestrator's
+`conversationId` + transcript path. The button's flow:
+
+1. `GET /api/orchestrator` → `{ record, exists, defaultCwd }`.
+2. Record exists and its transcript is still on disk → navigate to
+   `#c=<conversationId>` (Viewer resumes the same conversation — this is what
+   survives viewer restarts).
+3. No record (or transcript deleted) → `POST /api/spawn` with the orchestrator
+   preset (below), then `POST /api/orchestrator` to adopt the new conversation.
+   Adoption is first-write-wins: if another tab adopted a different
+   conversation meanwhile, the server returns the canonical record and the
+   button navigates there instead.
+
+## Runtime identity
+
+- **Engine/model/effort**: Claude **Fable**, reasoning **low** (issue default;
+  configurable later via the role registry overrides). Fable-low keeps the
+  always-on brain cheap; it escalates by *spawning* higher-effort workers, not
+  by thinking harder itself.
+- **Role preset**: the `orchestrator` role from the #35 registry
+  (`src/lib/roles/defaults.ts`), `mode: standard`. The spawn route prepends the
+  role scaffold; the button appends the built-in system prompt
+  (`src/lib/orchestrator/prompt.ts`) that encodes the conveyor rules and the
+  draft-only contract.
+- **Working directory**: the viewer's own checkout (`process.cwd()` of the
+  server, reported by `GET /api/orchestrator` as `defaultCwd`) — the
+  orchestrator lives inside the viewer and finds the `llv-conveyor` skill
+  there.
+- **Spawn path**: the browser POSTs `/api/spawn` same-origin, i.e. an
+  authenticated Viewer operator spawn (#212) — no capability header needed.
+  Once running, the orchestrator's *own* API calls are agent-initiated and
+  follow the #212/#213 spawn-capability rules encoded in its prompt.
+
+## Viewer APIs it drives
+
+| API | Use |
+| --- | --- |
+| `POST /api/spawn` | Spawn implementers/reviewers with `src` = its own transcript (lineage draws the diagram edges) and `role`/`reviews` per the role table. |
+| `POST /api/flows`, `PATCH /api/flows/[id]` | Start and drive implement→review flows (rounds, verdict relays). |
+| `POST /api/pipelines` (**`autoStart: false` always**) | Compose multi-stage pipelines as **drafts** — see the contract below. |
+| `GET /api/files`, `GET /api/agent/snapshot` | Observe board state: conversations, activity, lineage, receipts. |
+| `POST /api/tmux` | Relay messages into worker panes (verdict summaries, nudges). |
+| `/api/tasks` | Keep task cards updated as work moves through the conveyor. |
+
+Fences: it never touches `src/lib/runtime` internals and never bypasses the
+public HTTP APIs above — it holds no in-process references; it IS an API
+client that happens to be spawned by the product.
+
+## The DRAFT-only pipeline contract (#189 comment on #182)
+
+The orchestrator **NEVER auto-starts pipelines**:
+
+- "Агент, побудуй мені пайплайн" → it assesses complexity, composes
+  stages/roles, `POST /api/pipelines` with `autoStart: false`, and replies in
+  chat with the draft id/link.
+- The user reviews the draft on the board (editable via the #136 builder) and
+  presses **Start** himself (`PATCH /api/pipelines/[id]` `action: start`).
+- Auto-start is opt-in per request only — the user must have explicitly asked
+  ("і запусти") in the same message.
+
+This contract is written into the system prompt verbatim
+(`src/lib/orchestrator/prompt.ts`) and covered by a test asserting the prompt
+carries it.
+
+## Conveyor rules in the system prompt
+
+The prompt encodes the `llv-conveyor` loop the resident agent runs:
+
+**issues → worktree lanes → implementer agents → review flows → merge bars
+(merge on APPROVE only) → batched deploy → cleanup**, with:
+
+- one lane per issue, one file owner at a time across active worktrees;
+- fresh reviewer per round, `REVIEW_READY:` / `VERDICT:` contracts;
+- merge bar: green gates (tsc + tests) and an APPROVE verdict before merge;
+- status reporting: concise chat replies to the user + task-card updates; it
+  reports what it *did* (links, ids, verdicts), not plans.
+
+## How it reports status
+
+Chat-first: the user reads the orchestrator's pane like any conversation.
+Every action closes with a compact status line (spawned X → link, draft Y →
+id, flow Z round N verdict). Board-native signals stay authoritative:
+spawned workers appear with lineage edges under the orchestrator node, flows
+show rounds, drafts sit on the scheme awaiting Start. Later phases add the
+dedicated scheme node (#183) and push notifications for decision points.
+
+## Implemented in this PR (minimal slice)
+
+- `src/lib/orchestrator/prompt.ts` — spawn config (fable/low/`orchestrator`
+  role) + system prompt with conveyor rules and the draft-only contract.
+- `src/lib/orchestrator/store.ts` — the single-instance record
+  (`state/orchestrator.json`), first-write-wins adoption, replace-when-deleted.
+- `src/app/api/orchestrator/route.ts` — `GET` (record + liveness + default
+  cwd), `POST` (adopt).
+- `src/components/OrchestratorChatButton.tsx` — the board-header button:
+  resolve → (spawn + adopt) → navigate to `#c=…`. en+uk strings, 44px tap
+  target on mobile, tokens only.
+- Wired into `OverviewBoard.tsx`.
+
+## Follow-up issues (out of scope here)
+
+1. **Durable claim lock for spawn races** — a pending-claim token with TTL in
+   the orchestrator store so two tabs pressing the button concurrently cannot
+   spawn two panes (today the loser's pane is visible and killable, but it is
+   an orphan).
+2. **Resume-on-restart** — supervisor-side check that re-attaches or respawns
+   the orchestrator session (`claude --resume`) after a viewer/host restart,
+   instead of waiting for the next button press.
+3. **On-scheme presence** — the orchestrator as a first-class node on the
+   scheme (wedge-in placement near the viewed area or a reserved spot), its
+   spawned agents/pipelines visually linked; coordinate with #183 semantic
+   zoom.
+4. **Configurable identity** — surface model/effort/mode overrides through the
+   role-registry overrides UI instead of the hardcoded fable/low.
+5. **Spawn capability for its own children (#213)** — once the orchestrator
+   holds `LLV_SPAWN_CAPABILITY`, drop the same-origin-header workaround from
+   the conveyor skill and prompt.
+6. **All-projects task sync** — the triage loop that watches every project,
+   creates GitHub issues, and binds them to pipelines (requirement 3 of #182)
+   — needs the #189 draft flow plus task-card write APIs exercised end to end.
+7. **Orchestrator health surface** — board indicator when the orchestrator
+   pane died or its transcript went stale, with a one-tap respawn.

--- a/src/app/api/orchestrator/route.test.ts
+++ b/src/app/api/orchestrator/route.test.ts
@@ -1,0 +1,75 @@
+import { afterEach, beforeEach, expect, test } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { NextRequest } from "next/server";
+
+import { GET, POST } from "./route";
+
+let sandbox = "";
+let previousStateDir: string | undefined;
+
+beforeEach(() => {
+  previousStateDir = process.env.LLV_STATE_DIR;
+  sandbox = fs.mkdtempSync(path.join(os.tmpdir(), "llv-orchestrator-route-"));
+  process.env.LLV_STATE_DIR = sandbox;
+});
+
+afterEach(() => {
+  if (previousStateDir === undefined) delete process.env.LLV_STATE_DIR;
+  else process.env.LLV_STATE_DIR = previousStateDir;
+  fs.rmSync(sandbox, { recursive: true, force: true });
+});
+
+function adoptRequest(body: unknown): NextRequest {
+  return new NextRequest("http://127.0.0.1/api/orchestrator", {
+    method: "POST",
+    headers: { host: "127.0.0.1", "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+test("GET reports the empty slot with the viewer checkout as spawn cwd", async () => {
+  const body = await (await GET()).json();
+  expect(body).toEqual({ record: null, exists: false, defaultCwd: process.cwd() });
+});
+
+test("POST adopts the first conversation and echoes the winner to losers", async () => {
+  const transcript = path.join(sandbox, "orchestrator.jsonl");
+  fs.writeFileSync(transcript, "", "utf8");
+  const first = await (await POST(adoptRequest({ conversationId: "conv-1", path: transcript }))).json();
+  expect(first).toMatchObject({ ok: true, adopted: true, record: { conversationId: "conv-1", path: transcript } });
+
+  const loser = await (await POST(adoptRequest({ conversationId: "conv-2", path: null }))).json();
+  expect(loser).toMatchObject({ ok: true, adopted: false, record: { conversationId: "conv-1" } });
+
+  const status = await (await GET()).json();
+  expect(status).toMatchObject({ record: { conversationId: "conv-1", path: transcript }, exists: true });
+});
+
+test("GET flags a deleted transcript so the button respawns", async () => {
+  const transcript = path.join(sandbox, "orchestrator.jsonl");
+  fs.writeFileSync(transcript, "", "utf8");
+  await POST(adoptRequest({ conversationId: "conv-1", path: transcript }));
+  fs.rmSync(transcript);
+  const status = await (await GET()).json();
+  expect(status).toMatchObject({ record: { conversationId: "conv-1" }, exists: false });
+});
+
+test("POST validates its body", async () => {
+  expect((await POST(adoptRequest({}))).status).toBe(400);
+  expect((await POST(adoptRequest({ conversationId: "  " }))).status).toBe(400);
+  expect((await POST(adoptRequest({ conversationId: "conv-1", path: 7 }))).status).toBe(400);
+  const invalid = new NextRequest("http://127.0.0.1/api/orchestrator", { method: "POST", headers: { host: "127.0.0.1" }, body: "{" });
+  expect((await POST(invalid)).status).toBe(400);
+});
+
+test("POST rejects cross-origin browsers", async () => {
+  const request = new NextRequest("http://127.0.0.1/api/orchestrator", {
+    method: "POST",
+    headers: { host: "127.0.0.1", origin: "https://evil.example", "sec-fetch-site": "cross-site", "content-type": "application/json" },
+    body: JSON.stringify({ conversationId: "conv-1" }),
+  });
+  expect((await POST(request)).status).toBe(403);
+});

--- a/src/app/api/orchestrator/route.ts
+++ b/src/app/api/orchestrator/route.ts
@@ -1,0 +1,49 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { adoptOrchestratorRecord, orchestratorRecordExists, readOrchestratorRecord, type OrchestratorRecord } from "@/lib/orchestrator/store";
+import { rejectCrossOrigin } from "@/lib/sameOrigin";
+import type { ApiError } from "@/lib/types";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+interface OrchestratorStatus {
+  record: OrchestratorRecord | null;
+  /** Whether the recorded transcript is still on disk; false invites a respawn. */
+  exists: boolean;
+  /** Where a fresh orchestrator spawns: the viewer's own checkout, so the
+      llv-conveyor skill and the repo context are in reach. */
+  defaultCwd: string;
+}
+
+export async function GET(): Promise<NextResponse<OrchestratorStatus>> {
+  const record = readOrchestratorRecord();
+  return NextResponse.json({
+    record,
+    exists: record !== null && orchestratorRecordExists(record),
+    defaultCwd: process.cwd(),
+  });
+}
+
+export async function POST(req: NextRequest): Promise<NextResponse<{ ok: true; record: OrchestratorRecord; adopted: boolean } | ApiError>> {
+  const rejection = rejectCrossOrigin(req);
+  if (rejection) return rejection;
+  let body: { conversationId?: unknown; path?: unknown };
+  try {
+    body = (await req.json()) as typeof body;
+  } catch {
+    return NextResponse.json({ error: "invalid JSON" }, { status: 400 });
+  }
+  if (typeof body.conversationId !== "string" || !body.conversationId.trim()) {
+    return NextResponse.json({ error: "conversationId is required" }, { status: 400 });
+  }
+  if (body.path !== undefined && body.path !== null && typeof body.path !== "string") {
+    return NextResponse.json({ error: "path must be a string or null" }, { status: 400 });
+  }
+  const { record, adopted } = adoptOrchestratorRecord({
+    conversationId: body.conversationId.trim(),
+    path: typeof body.path === "string" && body.path ? body.path : null,
+    createdAt: new Date().toISOString(),
+  });
+  return NextResponse.json({ ok: true, record, adopted });
+}

--- a/src/components/OrchestratorChatButton.dom.test.tsx
+++ b/src/components/OrchestratorChatButton.dom.test.tsx
@@ -1,0 +1,68 @@
+import { afterEach, expect, test } from "bun:test";
+import { Window } from "happy-dom";
+import { flushSync } from "react-dom";
+import { createRoot, type Root } from "react-dom/client";
+
+import { OrchestratorChatButton } from "./OrchestratorChatButton";
+
+const dom = new Window({ url: "http://127.0.0.1/" });
+Object.assign(globalThis, {
+  window: dom,
+  document: dom.document,
+  navigator: dom.navigator,
+  Node: dom.Node,
+  HTMLElement: dom.HTMLElement,
+  HTMLButtonElement: dom.HTMLButtonElement,
+  Event: dom.Event,
+  MouseEvent: dom.MouseEvent,
+});
+
+let root: Root | null = null;
+const realFetch = globalThis.fetch;
+afterEach(() => {
+  if (root) flushSync(() => root!.unmount());
+  root = null;
+  globalThis.fetch = realFetch;
+  dom.window.location.hash = "";
+});
+
+function render(node: React.ReactElement): HTMLElement {
+  const container = dom.document.createElement("div");
+  dom.document.body.appendChild(container);
+  root = createRoot(container as unknown as Element);
+  flushSync(() => root!.render(node));
+  return container as unknown as HTMLElement;
+}
+
+function settle(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+test("a click on a live record navigates to the orchestrator deep link", async () => {
+  globalThis.fetch = (async () =>
+    new Response(JSON.stringify({ record: { conversationId: "conv-1", path: "/t.jsonl" }, exists: true, defaultCwd: "/repo" }), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    })) as unknown as typeof fetch;
+  const container = render(<OrchestratorChatButton />);
+  const button = container.querySelector("button")!;
+  expect(button.getAttribute("aria-label")).toBe("Open the orchestrator chat");
+
+  flushSync(() => button.click());
+  await settle();
+  expect(dom.window.location.hash).toBe("#c=conv-1");
+  expect(button.hasAttribute("disabled")).toBe(false);
+});
+
+test("a failed resolve flips the button into the retryable error state", async () => {
+  globalThis.fetch = (async () => new Response("{}", { status: 500 })) as unknown as typeof fetch;
+  const container = render(<OrchestratorChatButton />);
+  const button = container.querySelector("button")!;
+
+  flushSync(() => button.click());
+  await settle();
+  flushSync(() => {});
+  expect(button.textContent).toContain("Couldn't open the orchestrator");
+  expect(button.hasAttribute("disabled")).toBe(false);
+  expect(dom.window.location.hash).toBe("");
+});

--- a/src/components/OrchestratorChatButton.tsx
+++ b/src/components/OrchestratorChatButton.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import { Bot } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+
+import { useIsMobile } from "@/hooks/useIsMobile";
+import { useLocale } from "@/lib/i18n";
+
+import { openOrchestratorConversation, orchestratorHash } from "./orchestratorChat";
+
+type Phase = "idle" | "busy" | "error";
+
+/** Board-header entry to the built-in Orchestrator (issue #182): resolves the
+    persistent orchestrator conversation (spawning it on first use) and
+    navigates to its `#c=` deep link, which the Viewer resolves and opens. */
+export function OrchestratorChatButton() {
+  const { t } = useLocale();
+  const isMobile = useIsMobile();
+  const [phase, setPhase] = useState<Phase>("idle");
+  const mountedRef = useRef(true);
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
+  /* Ref-level re-entrancy guard: a double click lands before the busy render
+     commits, and two concurrent resolves could spawn two orchestrators. */
+  const busyRef = useRef(false);
+  const open = async () => {
+    if (busyRef.current) return;
+    busyRef.current = true;
+    setPhase("busy");
+    try {
+      const conversationId = await openOrchestratorConversation();
+      window.location.hash = orchestratorHash(conversationId);
+      if (mountedRef.current) setPhase("idle");
+    } catch {
+      if (mountedRef.current) setPhase("error");
+    } finally {
+      busyRef.current = false;
+    }
+  };
+
+  const label = phase === "busy" ? t("orch.starting") : phase === "error" ? t("orch.error") : t("orch.chat");
+  return (
+    <button
+      type="button"
+      disabled={phase === "busy"}
+      aria-label={t("orch.open")}
+      title={phase === "error" ? t("orch.error") : t("orch.open")}
+      className={`flex shrink-0 items-center gap-1.5 rounded-full border px-3 text-[12px] font-bold focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 disabled:opacity-60 ${
+        phase === "error"
+          ? "border-warning/45 bg-warning-soft text-warning hover:bg-warning/15"
+          : "border-accent/40 bg-accent-soft text-accent hover:bg-accent/15"
+      } ${isMobile ? "min-h-11" : "py-1"}`}
+      onClick={open}
+    >
+      <Bot className="h-3.5 w-3.5" aria-hidden />
+      {label}
+    </button>
+  );
+}

--- a/src/components/OverviewBoard.tsx
+++ b/src/components/OverviewBoard.tsx
@@ -9,6 +9,7 @@ import type { FileEntry, ProjectCatalogEntry } from "@/lib/types";
 import type { Pipeline } from "@/lib/pipelines/types";
 import type { Workflow } from "@/lib/workflows/types";
 
+import { OrchestratorChatButton } from "./OrchestratorChatButton";
 import { buildBranchGroups, buildProjectSummaries, projectKey } from "./projectModel";
 import { activityDot, cleanTitle, engineBadge, fmtAge } from "./utils";
 
@@ -78,7 +79,10 @@ export function OverviewBoard({ files, projectCatalog, pipelines, workflows, arc
             : t("common.nothingRunning")}
           {archivedCount ? ` ${t("overview.archived", { count: archivedCount })}` : ""}
         </span>
-        {attention ? <span className="ml-auto flex shrink-0 items-center">{attention}</span> : null}
+        <span className="ml-auto flex shrink-0 items-center gap-2">
+          <OrchestratorChatButton />
+          {attention}
+        </span>
       </div>
       <div
         className="grid flex-1 auto-rows-min gap-2.5 overflow-y-auto p-3"

--- a/src/components/orchestratorChat.test.ts
+++ b/src/components/orchestratorChat.test.ts
@@ -1,0 +1,68 @@
+import { expect, test } from "bun:test";
+
+import { openOrchestratorConversation, orchestratorHash, orchestratorSpawnBody, type OrchestratorStatusBody } from "./orchestratorChat";
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), { status, headers: { "content-type": "application/json" } });
+}
+
+function fetchStub(handlers: Record<string, (init?: RequestInit) => Response>): { calls: { url: string; init?: RequestInit }[]; fetch: typeof fetch } {
+  const calls: { url: string; init?: RequestInit }[] = [];
+  const stub = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = String(input);
+    calls.push({ url, init });
+    const key = `${init?.method ?? "GET"} ${url}`;
+    const handler = handlers[key];
+    if (!handler) throw new Error(`unexpected fetch: ${key}`);
+    return handler(init);
+  }) as typeof fetch;
+  return { calls, fetch: stub };
+}
+
+test("spawn body carries the fable-low orchestrator preset and the system prompt", () => {
+  const body = orchestratorSpawnBody("/repo");
+  expect(body).toMatchObject({ engine: "claude", model: "fable", effort: "low", role: "orchestrator", cwd: "/repo" });
+  expect(String(body.prompt)).toContain("NEVER auto-start pipelines");
+});
+
+test("hash targets the canonical #c= deep link", () => {
+  expect(orchestratorHash("conv/1")).toBe("#c=conv%2F1");
+});
+
+test("a live record opens without spawning", async () => {
+  const status: OrchestratorStatusBody = { record: { conversationId: "conv-1", path: "/t.jsonl" }, exists: true, defaultCwd: "/repo" };
+  const { calls, fetch } = fetchStub({ "GET /api/orchestrator": () => jsonResponse(status) });
+  expect(await openOrchestratorConversation(fetch)).toBe("conv-1");
+  expect(calls).toHaveLength(1);
+});
+
+test("an empty slot spawns, adopts, and returns the canonical winner", async () => {
+  const { calls, fetch } = fetchStub({
+    "GET /api/orchestrator": () => jsonResponse({ record: null, exists: false, defaultCwd: "/repo" }),
+    "POST /api/spawn": () => jsonResponse({ ok: true, conversationId: "conv-new", path: "/new.jsonl", state: "settled" }),
+    "POST /api/orchestrator": () => jsonResponse({ ok: true, adopted: false, record: { conversationId: "conv-winner", path: null } }),
+  });
+  expect(await openOrchestratorConversation(fetch)).toBe("conv-winner");
+  const spawnBody = JSON.parse(String(calls[1]!.init?.body)) as Record<string, unknown>;
+  expect(spawnBody).toMatchObject({ role: "orchestrator", cwd: "/repo", effort: "low" });
+  const adoptBody = JSON.parse(String(calls[2]!.init?.body)) as Record<string, unknown>;
+  expect(adoptBody).toEqual({ conversationId: "conv-new", path: "/new.jsonl" });
+});
+
+test("a dead transcript respawns instead of navigating to the tombstone", async () => {
+  const { calls, fetch } = fetchStub({
+    "GET /api/orchestrator": () => jsonResponse({ record: { conversationId: "conv-old", path: "/gone.jsonl" }, exists: false, defaultCwd: "/repo" }),
+    "POST /api/spawn": () => jsonResponse({ ok: true, conversationId: "conv-new", path: null }),
+    "POST /api/orchestrator": () => jsonResponse({ ok: true, adopted: true, record: { conversationId: "conv-new", path: null } }),
+  });
+  expect(await openOrchestratorConversation(fetch)).toBe("conv-new");
+  expect(calls).toHaveLength(3);
+});
+
+test("spawn failures surface the server error", async () => {
+  const { fetch } = fetchStub({
+    "GET /api/orchestrator": () => jsonResponse({ record: null, exists: false, defaultCwd: "/repo" }),
+    "POST /api/spawn": () => jsonResponse({ error: "directory does not exist: /repo" }, 400),
+  });
+  await expect(openOrchestratorConversation(fetch)).rejects.toThrow("directory does not exist: /repo");
+});

--- a/src/components/orchestratorChat.ts
+++ b/src/components/orchestratorChat.ts
@@ -1,0 +1,63 @@
+import { ORCHESTRATOR_SPAWN_CONFIG, ORCHESTRATOR_SYSTEM_PROMPT } from "@/lib/orchestrator/prompt";
+
+/* The chat button's resolve-or-spawn flow (issue #182), as a pure module the
+ * button renders from: GET the single-instance record, spawn a fresh
+ * orchestrator only when none is live, adopt it first-write-wins, and hand
+ * back the canonical conversation id to navigate to. */
+
+export interface OrchestratorStatusBody {
+  record: { conversationId: string; path: string | null } | null;
+  exists: boolean;
+  defaultCwd: string;
+}
+
+/** The exact /api/spawn body a fresh orchestrator launches with. */
+export function orchestratorSpawnBody(cwd: string): Record<string, unknown> {
+  return { ...ORCHESTRATOR_SPAWN_CONFIG, cwd, prompt: ORCHESTRATOR_SYSTEM_PROMPT };
+}
+
+/** Canonical deep link the Viewer hash router resolves and pins. */
+export function orchestratorHash(conversationId: string): string {
+  return "#c=" + encodeURIComponent(conversationId);
+}
+
+const JSON_HEADERS = { "content-type": "application/json" };
+
+async function bodyOf<T>(response: Response): Promise<T | null> {
+  try {
+    return (await response.json()) as T;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Resolve THE orchestrator conversation, spawning one when needed. Returns the
+ * canonical conversation id — when another tab won the adoption race, that is
+ * the winner's id, so every button lands on the same conversation.
+ */
+export async function openOrchestratorConversation(fetchFn: typeof fetch = fetch): Promise<string> {
+  const statusResponse = await fetchFn("/api/orchestrator");
+  const status = await bodyOf<OrchestratorStatusBody>(statusResponse);
+  if (!statusResponse.ok || !status) throw new Error("orchestrator status unavailable");
+  if (status.record && status.exists) return status.record.conversationId;
+
+  const spawnResponse = await fetchFn("/api/spawn", {
+    method: "POST",
+    headers: JSON_HEADERS,
+    body: JSON.stringify(orchestratorSpawnBody(status.defaultCwd)),
+  });
+  const spawn = await bodyOf<{ ok?: boolean; conversationId?: string; path?: string | null; error?: string }>(spawnResponse);
+  if (!spawnResponse.ok || !spawn?.ok || typeof spawn.conversationId !== "string") {
+    throw new Error(spawn?.error || "orchestrator spawn failed");
+  }
+
+  const adoptResponse = await fetchFn("/api/orchestrator", {
+    method: "POST",
+    headers: JSON_HEADERS,
+    body: JSON.stringify({ conversationId: spawn.conversationId, path: spawn.path ?? null }),
+  });
+  const adopt = await bodyOf<{ ok?: boolean; record?: { conversationId: string } }>(adoptResponse);
+  if (!adoptResponse.ok || !adopt?.ok || !adopt.record) throw new Error("orchestrator adoption failed");
+  return adopt.record.conversationId;
+}

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -1090,6 +1090,12 @@ export const en = {
   "overview.quiet": "quiet · last activity {age}",
   "overview.empty": "No logs yet",
 
+  // OrchestratorChatButton
+  "orch.chat": "Orchestrator",
+  "orch.open": "Open the orchestrator chat",
+  "orch.starting": "Starting…",
+  "orch.error": "Couldn't open the orchestrator — tap to retry",
+
   // BranchPane
   "branch.live": "working",
   "branch.waiting": "finished the turn — waiting for a reply",

--- a/src/lib/i18n/uk.ts
+++ b/src/lib/i18n/uk.ts
@@ -1058,6 +1058,11 @@ export const uk: Record<keyof typeof en, Message> = {
   "overview.quiet": "тихо · остання активність {age}",
   "overview.empty": "Логів поки нема",
 
+  "orch.chat": "Оркестратор",
+  "orch.open": "Відкрити чат оркестратора",
+  "orch.starting": "Запускаю…",
+  "orch.error": "Не вдалося відкрити оркестратора — торкніться, щоб повторити",
+
   "branch.live": "працює",
   "branch.waiting": "закінчив хід — чекає відповіді",
   "branch.returned": "повернувся з результатом",

--- a/src/lib/orchestrator/prompt.test.ts
+++ b/src/lib/orchestrator/prompt.test.ts
@@ -1,0 +1,21 @@
+import { expect, test } from "bun:test";
+
+import { ORCHESTRATOR_SPAWN_CONFIG, ORCHESTRATOR_SYSTEM_PROMPT } from "./prompt";
+
+test("orchestrator spawns as claude fable on low effort through the #35 role preset", () => {
+  expect(ORCHESTRATOR_SPAWN_CONFIG).toMatchObject({ engine: "claude", model: "fable", effort: "low", role: "orchestrator" });
+});
+
+test("system prompt carries the draft-only pipeline contract", () => {
+  expect(ORCHESTRATOR_SYSTEM_PROMPT).toContain("NEVER auto-start pipelines");
+  expect(ORCHESTRATOR_SYSTEM_PROMPT).toContain("autoStart: false");
+  expect(ORCHESTRATOR_SYSTEM_PROMPT).toContain("presses Start himself");
+  expect(ORCHESTRATOR_SYSTEM_PROMPT).toContain("explicitly asked to start it in the same request");
+});
+
+test("system prompt encodes the conveyor loop and its bars", () => {
+  expect(ORCHESTRATOR_SYSTEM_PROMPT).toContain("GitHub issue -> worktree lane -> implementer agent -> review flow -> merge bar");
+  expect(ORCHESTRATOR_SYSTEM_PROMPT).toContain("merge only on an APPROVE verdict");
+  expect(ORCHESTRATOR_SYSTEM_PROMPT).toContain("REVIEW_READY:");
+  expect(ORCHESTRATOR_SYSTEM_PROMPT).toContain("src = YOUR transcript path");
+});

--- a/src/lib/orchestrator/prompt.ts
+++ b/src/lib/orchestrator/prompt.ts
@@ -1,0 +1,34 @@
+/* The built-in Orchestrator's spawn identity (issue #182, phase 1).
+ *
+ * The chat button POSTs /api/spawn with this config; the spawn route prepends
+ * the `orchestrator` role scaffold from the #35 registry and this prompt
+ * follows as the built-in system directive. Shared by the client button and
+ * the API layer, so it must stay a pure-constant module. */
+
+/** Fixed spawn identity: the resident brain runs cheap (fable/low) and
+    escalates by spawning higher-effort workers, never by thinking harder. */
+export const ORCHESTRATOR_SPAWN_CONFIG = {
+  engine: "claude",
+  model: "fable",
+  effort: "low",
+  role: "orchestrator",
+  roleParams: { mode: "standard" },
+} as const;
+
+export const ORCHESTRATOR_SYSTEM_PROMPT = `You are the viewer's built-in Orchestrator (issue #182) — the resident agent the user talks to in this chat. You run the whole conveyor through the viewer's own HTTP API and never act outside it.
+
+## Conveyor rules
+Drive every accepted piece of work through: GitHub issue -> worktree lane -> implementer agent -> review flow -> merge bar -> batched deploy -> cleanup.
+- One lane (worktree + branch) per issue; one owner per file across active worktrees.
+- Spawn implementers via POST /api/spawn with src = YOUR transcript path (lineage draws the diagram edges) and role per the role table; workers end with "REVIEW_READY: <PR url>".
+- Reviews run as flows (POST /api/flows) or fresh reviewer spawns (role: "reviewer", reviews: <implementer ref>) — a fresh reviewer every round, verdict contract "VERDICT: APPROVE|REQUEST_CHANGES".
+- Merge bar: merge only on an APPROVE verdict with green gates (tsc + tests). Never merge red.
+- Report status in this chat after every action: what you did, with ids/links (spawned agent, draft id, flow round, verdict). Keep task cards updated via /api/tasks.
+
+## Draft-only pipeline contract
+You NEVER auto-start pipelines. When the user asks you to build a pipeline: assess complexity, compose stages/roles, POST /api/pipelines with autoStart: false, and reply here with the draft id/link. The user reviews the draft on the board and presses Start himself. Auto-start is allowed only when the user explicitly asked to start it in the same request.
+
+## Fences
+- Operate exclusively through the viewer API (spawn, flows, pipelines, tasks, files, agent/snapshot, tmux). No direct process or runtime manipulation.
+- The llv-conveyor skill in this checkout is your playbook; follow its spawn-auth notes for agent-initiated calls.
+- Replacing manual spawns is a non-goal: the user's own agents keep working; you coordinate, you do not take over.`;

--- a/src/lib/orchestrator/store.test.ts
+++ b/src/lib/orchestrator/store.test.ts
@@ -1,0 +1,71 @@
+import { afterEach, beforeEach, expect, test } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { adoptOrchestratorRecord, ORCHESTRATOR_SCHEMA_VERSION, orchestratorRecordExists, readOrchestratorRecord, type OrchestratorRecord } from "./store";
+
+let sandbox = "";
+let previousStateDir: string | undefined;
+
+beforeEach(() => {
+  previousStateDir = process.env.LLV_STATE_DIR;
+  sandbox = fs.mkdtempSync(path.join(os.tmpdir(), "llv-orchestrator-store-"));
+  process.env.LLV_STATE_DIR = sandbox;
+});
+
+afterEach(() => {
+  if (previousStateDir === undefined) delete process.env.LLV_STATE_DIR;
+  else process.env.LLV_STATE_DIR = previousStateDir;
+  fs.rmSync(sandbox, { recursive: true, force: true });
+});
+
+function record(conversationId: string, transcriptPath: string | null): OrchestratorRecord {
+  return { conversationId, path: transcriptPath, createdAt: "2026-07-14T00:00:00.000Z" };
+}
+
+test("first adoption wins and round-trips through the state file", () => {
+  expect(readOrchestratorRecord()).toBeNull();
+  const first = adoptOrchestratorRecord(record("conv-1", null));
+  expect(first).toEqual({ record: record("conv-1", null), adopted: true });
+  expect(JSON.parse(fs.readFileSync(path.join(sandbox, "orchestrator.json"), "utf8"))).toMatchObject({ schemaVersion: ORCHESTRATOR_SCHEMA_VERSION });
+  expect(readOrchestratorRecord()).toEqual(record("conv-1", null));
+
+  const loser = adoptOrchestratorRecord(record("conv-2", null));
+  expect(loser).toEqual({ record: record("conv-1", null), adopted: false });
+});
+
+test("re-adopting the same conversation refreshes its record", () => {
+  adoptOrchestratorRecord(record("conv-1", null));
+  const transcript = path.join(sandbox, "conv-1.jsonl");
+  fs.writeFileSync(transcript, "", "utf8");
+  const again = adoptOrchestratorRecord(record("conv-1", transcript));
+  expect(again).toEqual({ record: record("conv-1", transcript), adopted: true });
+});
+
+test("a deleted transcript releases the single-instance slot", () => {
+  const transcript = path.join(sandbox, "orchestrator.jsonl");
+  fs.writeFileSync(transcript, "", "utf8");
+  adoptOrchestratorRecord(record("conv-1", transcript));
+  expect(orchestratorRecordExists(record("conv-1", transcript))).toBe(true);
+
+  fs.rmSync(transcript);
+  expect(orchestratorRecordExists(record("conv-1", transcript))).toBe(false);
+  const replacement = adoptOrchestratorRecord(record("conv-2", null));
+  expect(replacement).toEqual({ record: record("conv-2", null), adopted: true });
+});
+
+test("a record without a settled transcript path counts as live", () => {
+  expect(orchestratorRecordExists(record("conv-1", null))).toBe(true);
+});
+
+test("malformed and future-schema files read as absent so adoption recovers", () => {
+  const file = path.join(sandbox, "orchestrator.json");
+  for (const content of ["{", JSON.stringify({ schemaVersion: ORCHESTRATOR_SCHEMA_VERSION + 1, record: record("conv-1", null) })]) {
+    fs.writeFileSync(file, content, "utf8");
+    expect(readOrchestratorRecord()).toBeNull();
+  }
+  const recovered = adoptOrchestratorRecord(record("conv-2", null));
+  expect(recovered.adopted).toBe(true);
+  expect(readOrchestratorRecord()).toEqual(record("conv-2", null));
+});

--- a/src/lib/orchestrator/store.ts
+++ b/src/lib/orchestrator/store.ts
@@ -1,0 +1,81 @@
+import crypto from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+
+import { statePath } from "@/lib/configDir";
+
+/* The single-instance record for the built-in Orchestrator (issue #182).
+ * One conversation is THE orchestrator; the chat button resolves it here and
+ * only spawns a fresh one when no live record exists. */
+
+export const ORCHESTRATOR_SCHEMA_VERSION = 1;
+
+export interface OrchestratorRecord {
+  /** Stable viewer conversation id of the orchestrator session. */
+  conversationId: string;
+  /** Transcript path when the spawn settled one; null while path-pending. */
+  path: string | null;
+  /** ISO timestamp of the adopting spawn. */
+  createdAt: string;
+}
+
+type OrchestratorFile = { schemaVersion: number; record: OrchestratorRecord };
+
+const orchestratorFile = () => statePath("orchestrator.json");
+
+function atomicWriteJson(filePath: string, value: unknown): void {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  const temp = path.join(path.dirname(filePath), `.${path.basename(filePath)}.${process.pid}.${crypto.randomUUID()}.tmp`);
+  fs.writeFileSync(temp, JSON.stringify(value, null, 2) + "\n", "utf8");
+  fs.renameSync(temp, filePath);
+}
+
+function isRecord(value: unknown): value is OrchestratorRecord {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  const record = value as Partial<OrchestratorRecord>;
+  return (
+    typeof record.conversationId === "string" && record.conversationId.length > 0 &&
+    (record.path === null || typeof record.path === "string") &&
+    typeof record.createdAt === "string"
+  );
+}
+
+/** The current record, or null when none was adopted yet. A malformed or
+    future-schema file reads as absent — adoption then overwrites it, which is
+    the recovery path for a corrupt state file. */
+export function readOrchestratorRecord(): OrchestratorRecord | null {
+  let raw: string;
+  try {
+    raw = fs.readFileSync(orchestratorFile(), "utf8");
+  } catch {
+    return null;
+  }
+  try {
+    const parsed = JSON.parse(raw) as Partial<OrchestratorFile>;
+    if (parsed.schemaVersion !== ORCHESTRATOR_SCHEMA_VERSION || !isRecord(parsed.record)) return null;
+    return parsed.record;
+  } catch {
+    return null;
+  }
+}
+
+/** Whether the recorded conversation still exists on disk. A record without a
+    settled transcript path cannot be checked and counts as live. */
+export function orchestratorRecordExists(record: OrchestratorRecord): boolean {
+  return record.path === null || fs.existsSync(record.path);
+}
+
+/**
+ * First-write-wins adoption: the candidate becomes THE orchestrator only when
+ * no live record exists (none yet, or the recorded transcript was deleted).
+ * Losers get the canonical record back and navigate to it instead — the
+ * one-instance invariant lives here, not in the button.
+ */
+export function adoptOrchestratorRecord(candidate: OrchestratorRecord): { record: OrchestratorRecord; adopted: boolean } {
+  const current = readOrchestratorRecord();
+  if (current && orchestratorRecordExists(current) && current.conversationId !== candidate.conversationId) {
+    return { record: current, adopted: false };
+  }
+  atomicWriteJson(orchestratorFile(), { schemaVersion: ORCHESTRATOR_SCHEMA_VERSION, record: candidate } satisfies OrchestratorFile);
+  return { record: candidate, adopted: true };
+}


### PR DESCRIPTION
Phase 1 of #182: design + the minimal working slice of the built-in Orchestrator agent.

## Design doc

`docs/design/orchestrator-agent.md` covers:
- **Chat surface**: a persistent button in the overview-board header that opens the orchestrator as a normal viewer conversation (existing `BranchPane`/`LogFeed`/`TmuxComposer` surface, via the canonical `#c=` deep link) — no bespoke chat widget.
- **Viewer APIs it drives**: `/api/spawn` with `src` lineage, `/api/flows`, `/api/pipelines` (**drafts only, `autoStart:false`** — the user approves on the board, per the #189 contract comment), `/api/tasks`, `/api/agent/snapshot`, `/api/tmux`.
- **Identity**: Claude Fable, effort **low**, the #35 `orchestrator` role preset, cwd = the viewer checkout.
- **Status reporting**: chat-first with ids/links; board-native signals (lineage edges, flow rounds, drafts) stay authoritative.
- A scoped follow-up issues list at the end (claim lock, resume-on-restart, on-scheme presence, #213 capability, all-projects triage, health surface).

## Implemented slice

- `src/lib/orchestrator/prompt.ts` — fable/low spawn config + system prompt encoding the conveyor rules (issues → lanes → review → merge bars) and the DRAFT-only contract.
- `src/lib/orchestrator/store.ts` — single-instance record in `state/orchestrator.json`; first-write-wins adoption, released when the transcript is deleted.
- `src/app/api/orchestrator/route.ts` — `GET` (record + liveness + default cwd), `POST` (adopt), same-origin-guarded.
- `src/components/orchestratorChat.ts` + `OrchestratorChatButton.tsx` — resolve → (spawn + adopt) → navigate; wired into `OverviewBoard`'s header. en+uk strings, tokens only, ≥44px tap target on mobile.

Related vision #183 (semantic zoom) is intentionally untouched; `src/lib/runtime` untouched; flows/drafts go through the existing public APIs only.

## Verification

- `bunx tsc --noEmit` — clean.
- `bun test` — 2545 pass, 0 fail (incl. 21 new tests: prompt contract, store adoption semantics, route validation/CSRF, client flow, button DOM states).
- Route-export gate (`routeExports.test.ts`) passes; the new route exports only `GET`/`POST`/`runtime`/`dynamic`.
- `eslint` clean on all touched files.

Closes nothing yet — phase 1 of #182.

🤖 Generated with [Claude Code](https://claude.com/claude-code)