### PR TITLE
Migrate agent registry to gated SQLite WAL storage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -225,4 +225,4 @@ fi
 EOF
 
 EXPOSE 8898
-CMD ["sh", "-c", "exec node_modules/.bin/next start --port ${PORT:-8898} --hostname ${HOSTNAME:-127.0.0.1}"]
+CMD ["sh", "-c", "exec bun-container --bun node_modules/.bin/next start --port ${PORT:-8898} --hostname ${HOSTNAME:-127.0.0.1}"]

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ With bun:
 ```bash
 bun install
 bun run build
-bun start --port 8898 --hostname 127.0.0.1
+bun --bun node_modules/.bin/next start --port 8898 --hostname 127.0.0.1
 # open http://127.0.0.1:8898/
 ```
 
@@ -115,6 +115,11 @@ npm start -- --port 8898 --hostname 127.0.0.1
 `start` serves the output of the last `build`, so run `build` first. For
 development, `bun dev` runs the app with hot reload (it needs a high OS
 file-watch limit for large home directories).
+
+The gated SQLite registry modes require the Viewer server to run on Bun. The
+Docker runtime and `agent-log-viewer` CLI select Bun automatically whenever
+`LLV_AGENT_REGISTRY_SQLITE` is enabled. Local source checkouts should use the
+explicit `bun --bun` command above during the rollout.
 
 **Prerequisites:** Node ≥ 20.9, and bun or npm/pnpm. `tmux` is optional — see
 [Platform support](#platform-support).

--- a/bin/cli.mjs
+++ b/bin/cli.mjs
@@ -211,11 +211,18 @@ function readPackageJson(packageRoot) {
 }
 
 function resolveServer(packageRoot) {
+  const sqliteMode = process.env.LLV_AGENT_REGISTRY_SQLITE ?? "off";
+  const bunRuntime = sqliteMode === "off"
+    ? null
+    : (process.versions.bun ? process.execPath : (process.env.LLV_BUN_EXECUTABLE || "bun"));
+  const commandFor = (command, args, bunEntry = command, bunArgs = args) => bunRuntime
+    ? { command: bunRuntime, args: ["--bun", bunEntry, ...bunArgs] }
+    : { command, args };
   const publishedStandalone = join(packageRoot, "dist", "standalone", "server.js");
   if (existsSync(publishedStandalone)) {
+    const launch = commandFor(process.execPath, [publishedStandalone], publishedStandalone, []);
     return {
-      command: process.execPath,
-      args: [publishedStandalone],
+      ...launch,
       cwd: join(packageRoot, "dist", "standalone"),
       label: "server.js",
     };
@@ -223,9 +230,9 @@ function resolveServer(packageRoot) {
 
   const repoStandalone = join(packageRoot, ".next", "standalone", "server.js");
   if (existsSync(repoStandalone)) {
+    const launch = commandFor(process.execPath, [repoStandalone], repoStandalone, []);
     return {
-      command: process.execPath,
-      args: [repoStandalone],
+      ...launch,
       cwd: join(packageRoot, ".next", "standalone"),
       label: "server.js",
     };
@@ -237,8 +244,7 @@ function resolveServer(packageRoot) {
   }
 
   return {
-    command: nextBin,
-    args: ["start"],
+    ...commandFor(nextBin, ["start"]),
     cwd: packageRoot,
     label: "next start",
   };

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -84,7 +84,7 @@ services:
           echo "legacy Viewer launch requires LLV_ALLOW_LEGACY_VIEWER=1 and profile legacy-viewer-migration" >&2
           exit 78
         fi
-        exec node_modules/.bin/next start --port "$${PORT:-8898}" --hostname "$${HOSTNAME:-127.0.0.1}"
+        exec bun-container --bun node_modules/.bin/next start --port "$${PORT:-8898}" --hostname "$${HOSTNAME:-127.0.0.1}"
     environment:
       HOME: /home/latand
       HOSTNAME: 127.0.0.1

--- a/docs/agent-registry-sqlite.md
+++ b/docs/agent-registry-sqlite.md
@@ -9,10 +9,12 @@ The registry supports four values for `LLV_AGENT_REGISTRY_SQLITE`:
 
 The first process that opens any gated SQLite mode creates `agent-registry.sqlite` and imports the normalized contents of `agent-registry.json` in one transaction. An interrupted import has no migration marker, so the next boot retries the complete import. Durable memberships, spawn receipts, capability digests, lineage, conversation generations, migration state, delivery receipts, and routing policy all migrate through the same snapshot.
 
+Every process with an enabled SQLite mode must run on Bun. The Docker Viewer uses `bun-container --bun`, and the published CLI selects Bun automatically when the gate is enabled. For a source checkout, launch Next with `bun --bun node_modules/.bin/next start`.
+
 ## Rollout
 
 1. Preserve a copy of the current state directory.
-2. Start every Viewer and runtime-host process with `LLV_AGENT_REGISTRY_SQLITE=dual-write`.
+2. Start every Bun-hosted Viewer and runtime-host process with `LLV_AGENT_REGISTRY_SQLITE=dual-write`.
 3. Treat `RegistryParityError` as a rollout stop. Keep JSON authoritative while investigating any mismatch.
 4. Restart every registry writer with `LLV_AGENT_REGISTRY_SQLITE=read` for an SQLite-read burn-in with a continuously refreshed JSON rollback mirror.
 5. After that burn-in, restart every writer with `LLV_AGENT_REGISTRY_SQLITE=sqlite` to remove JSON rewrites from the operation path.
@@ -26,6 +28,8 @@ The `read` and `sqlite` paths bypass the whole-registry writer lock, its retry/b
 2. Preserve the JSON and SQLite files together for diagnosis.
 3. When rolling back from `sqlite`, start one process with `LLV_AGENT_REGISTRY_SQLITE=read` and stop it after startup. Startup refreshes the JSON mirror to the current SQLite revision.
 4. Restart all processes with `LLV_AGENT_REGISTRY_SQLITE=off`. The JSON mirror is the authoritative rollback source.
-5. To resume the rollout, use `dual-write` first. That mode imports the current JSON snapshot into SQLite and verifies parity before serving registry operations.
+5. A rollback with no subsequent `off`-mode mutations can resume directly in `dual-write`. It admits an existing backend pair only when the revisions and normalized snapshots agree, preserving both files and throwing `RegistryParityError` on any drift.
+6. After any `off`-mode mutation, stop every writer again and archive `agent-registry.sqlite`, `agent-registry.sqlite-wal`, and `agent-registry.sqlite-shm` together under distinct names. Keep that archived trio with the pre-rebaseline JSON for diagnosis.
+7. With the active SQLite paths clear and the current JSON retained, start exactly one Bun process in `dual-write`. First boot creates a fresh database and imports the authoritative JSON in one transaction. Stop that process after initialization, preserve a fresh state-directory copy, then restart every writer in `dual-write`.
 
 Keep the SQLite files until the rollback has been validated. The database and WAL artifacts preserve evidence for diagnosing storage failures and caller-level state changes.

--- a/docs/agent-registry-sqlite.md
+++ b/docs/agent-registry-sqlite.md
@@ -1,0 +1,31 @@
+# Agent registry SQLite rollout
+
+The registry supports four values for `LLV_AGENT_REGISTRY_SQLITE`:
+
+- `off` keeps `agent-registry.json` authoritative. This is the default.
+- `dual-write` reads JSON, writes JSON and SQLite under the existing JSON writer lock, and verifies parity after every mutation.
+- `read` reads and transacts through `agent-registry.sqlite` in WAL mode, then refreshes `agent-registry.json` as the rollback mirror.
+- `sqlite` uses SQLite for reads and writes after the parity burn-in. It refreshes the JSON mirror at process start and removes JSON serialization from registry operations.
+
+The first process that opens any gated SQLite mode creates `agent-registry.sqlite` and imports the normalized contents of `agent-registry.json` in one transaction. An interrupted import has no migration marker, so the next boot retries the complete import. Durable memberships, spawn receipts, capability digests, lineage, conversation generations, migration state, delivery receipts, and routing policy all migrate through the same snapshot.
+
+## Rollout
+
+1. Preserve a copy of the current state directory.
+2. Start every Viewer and runtime-host process with `LLV_AGENT_REGISTRY_SQLITE=dual-write`.
+3. Treat `RegistryParityError` as a rollout stop. Keep JSON authoritative while investigating any mismatch.
+4. Restart every registry writer with `LLV_AGENT_REGISTRY_SQLITE=read` for an SQLite-read burn-in with a continuously refreshed JSON rollback mirror.
+5. After that burn-in, restart every writer with `LLV_AGENT_REGISTRY_SQLITE=sqlite` to remove JSON rewrites from the operation path.
+6. Retain `agent-registry.json`, `agent-registry.sqlite`, and the SQLite WAL files throughout both burn-ins.
+
+The `read` and `sqlite` paths bypass the whole-registry writer lock, its retry/backoff loop, stale-lock recovery, temp-file cleanup, and startup JSON compaction. Per-session operation locks remain active. They serialize host actuation independently of registry persistence.
+
+## Rollback
+
+1. Stop every process that can mutate the registry.
+2. Preserve the JSON and SQLite files together for diagnosis.
+3. When rolling back from `sqlite`, start one process with `LLV_AGENT_REGISTRY_SQLITE=read` and stop it after startup. Startup refreshes the JSON mirror to the current SQLite revision.
+4. Restart all processes with `LLV_AGENT_REGISTRY_SQLITE=off`. The JSON mirror is the authoritative rollback source.
+5. To resume the rollout, use `dual-write` first. That mode imports the current JSON snapshot into SQLite and verifies parity before serving registry operations.
+
+Keep the SQLite files until the rollback has been validated. The database and WAL artifacts preserve evidence for diagnosing storage failures and caller-level state changes.

--- a/scripts/dockerfile-permissions.test.ts
+++ b/scripts/dockerfile-permissions.test.ts
@@ -90,3 +90,10 @@ describe("runtime-host Docker credentials (#102)", () => {
     expect(wrapper).not.toContain("--setuid");
   });
 });
+
+describe("SQLite registry Viewer runtime (#187)", () => {
+  test("Docker launches every Viewer through the in-container Bun runtime", () => {
+    expect(runtimeStage).toContain("CMD [\"sh\", \"-c\", \"exec bun-container --bun node_modules/.bin/next start");
+    expect(compose).toContain("exec bun-container --bun node_modules/.bin/next start");
+  });
+});

--- a/src/lib/agent/registry.sqlite.test.ts
+++ b/src/lib/agent/registry.sqlite.test.ts
@@ -64,6 +64,33 @@ test("SQLite first boot imports JSON and preserves membership and capability dig
   expect(new AgentRegistry(filename).snapshot()).toEqual(sqlite.snapshot());
 });
 
+for (const version of [1, 2]) {
+  test(`dual-write migration normalizes a legacy v${version} registry deterministically across processes`, async () => {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), `llv-registry-sqlite-legacy-v${version}-`));
+    const filename = path.join(directory, "agent-registry.json");
+    fs.writeFileSync(filename, JSON.stringify({ version, entries: {}, receipts: {} }));
+
+    const first = new AgentRegistry(filename, undefined, undefined, { sqliteMode: "dual-write" });
+    expect(first.snapshot().autoBalance.claude.restartedAt).toBe(first.snapshot().autoBalance.codex.restartedAt);
+
+    const ready = path.join(directory, "restart.ready");
+    const release = path.join(directory, "restart.release");
+    const restarted = Bun.spawn([
+      process.execPath,
+      CHILD,
+      "dual-writer",
+      filename,
+      ready,
+      release,
+      `legacy-v${version}-restart`,
+    ], { cwd: process.cwd(), stdout: "pipe", stderr: "pipe" });
+    waitFor(ready);
+    fs.writeFileSync(release, "start");
+    expect(await restarted.exited).toBe(0);
+    expect(await new Response(restarted.stderr).text()).toBe("");
+  });
+}
+
 test("dual-write keeps JSON authoritative and SQLite reads require parity", () => {
   const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-registry-sqlite-parity-"));
   const filename = path.join(directory, "agent-registry.json");
@@ -87,6 +114,221 @@ test("dual-write keeps JSON authoritative and SQLite reads require parity", () =
   db.close();
 
   expect(() => new AgentRegistry(filename, undefined, undefined, { sqliteMode: "read" })).toThrow(RegistryParityError);
+});
+
+test("dual-write fails closed when SQLite is ahead of its JSON mirror", () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-registry-sqlite-transition-"));
+  const filename = path.join(directory, "agent-registry.json");
+  const sqlite = new AgentRegistry(filename, undefined, undefined, { sqliteMode: "sqlite" });
+  const conversation = sqlite.ensureConversation("codex", "/sessions/sqlite-only.jsonl", "sqlite-only");
+  const staleMirror = fs.readFileSync(filename, "utf8");
+
+  expect(() => new AgentRegistry(filename, undefined, undefined, { sqliteMode: "dual-write" })).toThrow(RegistryParityError);
+  expect(fs.readFileSync(filename, "utf8")).toBe(staleMirror);
+
+  const recovered = new AgentRegistry(filename, undefined, undefined, { sqliteMode: "sqlite" });
+  expect(recovered.snapshot().conversations[conversation.id]).toBeDefined();
+  expect(new AgentRegistry(filename).snapshot().conversations[conversation.id]).toBeDefined();
+});
+
+test("dual-write startup serializes SQLite replacement with a concurrent writer", async () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-registry-dual-startup-"));
+  const filename = path.join(directory, "agent-registry.json");
+  new AgentRegistry(filename, undefined, undefined, { sqliteMode: "dual-write" });
+  const startupReady = path.join(directory, "startup.ready");
+  const releaseStartup = path.join(directory, "startup.release");
+  const startup = Bun.spawn([process.execPath, CHILD, "dual-startup", filename, startupReady, releaseStartup], {
+    cwd: process.cwd(),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  waitFor(startupReady);
+
+  const writerReady = path.join(directory, "writer.ready");
+  const startWriter = path.join(directory, "writer.start");
+  const attempted = path.join(directory, "writer.attempted");
+  const writer = Bun.spawn([
+    process.execPath,
+    CHILD,
+    "dual-writer",
+    filename,
+    writerReady,
+    startWriter,
+    "concurrent-dual-writer",
+    "0",
+    attempted,
+  ], { cwd: process.cwd(), stdout: "pipe", stderr: "pipe" });
+  waitFor(writerReady);
+  fs.writeFileSync(startWriter, "start");
+  waitFor(attempted);
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 50);
+  expect(fs.existsSync(`${attempted}.done`)).toBeFalse();
+
+  fs.writeFileSync(releaseStartup, "release");
+  expect(await Promise.all([startup.exited, writer.exited])).toEqual([0, 0]);
+  expect(await Promise.all([
+    new Response(startup.stderr).text(),
+    new Response(writer.stderr).text(),
+  ])).toEqual(["", ""]);
+
+  const dual = new AgentRegistry(filename, undefined, undefined, { sqliteMode: "dual-write" });
+  expect(Object.values(dual.snapshot().conversations).some((conversation) =>
+    conversation.generations.some((generation) => generation.path === "/sessions/concurrent-dual-writer.jsonl"))).toBeTrue();
+});
+
+for (const mode of ["read", "sqlite"] as const) {
+  test(`dual-write startup fails closed across a concurrent ${mode} writer`, async () => {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), `llv-registry-${mode}-transition-`));
+    const filename = path.join(directory, "agent-registry.json");
+    new AgentRegistry(filename, undefined, undefined, { sqliteMode: "dual-write" });
+    const startupReady = path.join(directory, "startup.ready");
+    const releaseStartup = path.join(directory, "startup.release");
+    const startup = Bun.spawn([process.execPath, CHILD, "dual-startup", filename, startupReady, releaseStartup], {
+      cwd: process.cwd(),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    waitFor(startupReady);
+
+    const writerReady = path.join(directory, "writer.ready");
+    const startWriter = path.join(directory, "writer.start");
+    const writerDone = path.join(directory, "writer.done");
+    const writer = Bun.spawn([
+      process.execPath,
+      CHILD,
+      "transition-writer",
+      filename,
+      writerReady,
+      startWriter,
+      mode,
+      "0",
+      writerDone,
+    ], { cwd: process.cwd(), stdout: "pipe", stderr: "pipe" });
+    waitFor(writerReady);
+    fs.writeFileSync(startWriter, "start");
+    expect(await writer.exited).toBe(0);
+    expect(await new Response(writer.stderr).text()).toBe("");
+
+    fs.writeFileSync(releaseStartup, "release");
+    expect(await startup.exited).not.toBe(0);
+    expect(await new Response(startup.stderr).text()).toContain("RegistryParityError");
+
+    const sqlite = new AgentRegistry(filename, undefined, undefined, { sqliteMode: "sqlite" });
+    expect(Object.values(sqlite.snapshot().conversations).some((conversation) =>
+      conversation.generations.some((generation) => generation.path === `/sessions/${mode}.jsonl`))).toBeTrue();
+    expect(new AgentRegistry(filename).snapshot()).toEqual(sqlite.snapshot());
+    expect(new AgentRegistry(filename, undefined, undefined, { sqliteMode: "dual-write" })
+      .conversationForPath(`/sessions/${mode}.jsonl`)).toBeDefined();
+  });
+}
+
+test("dual-write mutation fails closed across a concurrent SQLite writer", async () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-registry-dual-mutation-transition-"));
+  const filename = path.join(directory, "agent-registry.json");
+  new AgentRegistry(filename, undefined, undefined, { sqliteMode: "dual-write" });
+  const writerReady = path.join(directory, "writer.ready");
+  const startWriter = path.join(directory, "writer.start");
+  const writerDone = path.join(directory, "writer.done");
+  const writer = Bun.spawn([
+    process.execPath,
+    CHILD,
+    "transition-writer",
+    filename,
+    writerReady,
+    startWriter,
+    "sqlite",
+    "0",
+    writerDone,
+  ], { cwd: process.cwd(), stdout: "pipe", stderr: "pipe" });
+  waitFor(writerReady);
+  const dual = new AgentRegistry(filename, undefined, undefined, {
+    sqliteMode: "dual-write",
+    beforeDualWriteMutationReplace: () => {
+      fs.writeFileSync(startWriter, "start");
+      waitFor(`${writerDone}.done`);
+    },
+  });
+
+  expect(() => dual.ensureConversation("codex", "/sessions/dual.jsonl", "dual")).toThrow(RegistryParityError);
+  expect(await writer.exited).toBe(0);
+  expect(await new Response(writer.stderr).text()).toBe("");
+
+  const recovered = new AgentRegistry(filename, undefined, undefined, { sqliteMode: "read" });
+  expect(recovered.conversationForPath("/sessions/sqlite.jsonl")).toBeDefined();
+  expect(recovered.conversationForPath("/sessions/dual.jsonl")).toBeNull();
+  expect(new AgentRegistry(filename).snapshot()).toEqual(recovered.snapshot());
+});
+
+test("SQLite restart preserves first-owner insertion order for shared paths", () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-registry-sqlite-order-"));
+  const filename = path.join(directory, "agent-registry.json");
+  const sqlite = new AgentRegistry(filename, undefined, undefined, { sqliteMode: "sqlite" });
+  const first = sqlite.ensureConversation("codex", "/sessions/first-owner.jsonl", "first");
+  let later = sqlite.ensureConversation("codex", "/sessions/later-owner-0.jsonl", "later");
+  for (let attempt = 1; first.id < later.id && attempt < 100; attempt += 1) {
+    later = sqlite.ensureConversation("codex", `/sessions/later-owner-${attempt}.jsonl`, "later");
+  }
+  if (first.id < later.id) throw new Error("failed to create reverse-lexical conversation ids");
+  const db = new Database(path.join(directory, "agent-registry.sqlite"));
+  const stored = db.query<{ value_json: string }, [string, string]>(
+    "SELECT value_json FROM registry_rows WHERE collection = ? AND row_key = ?",
+  ).get("conversations", later.id);
+  if (!stored) throw new Error("expected the later SQLite conversation");
+  const duplicateOwner = JSON.parse(stored.value_json) as { continuityPaths: string[] };
+  duplicateOwner.continuityPaths.push("/sessions/first-owner.jsonl");
+  db.query("UPDATE registry_rows SET value_json = ? WHERE collection = ? AND row_key = ?")
+    .run(JSON.stringify(duplicateOwner), "conversations", later.id);
+  db.close();
+
+  const restarted = new AgentRegistry(filename, undefined, undefined, { sqliteMode: "sqlite" });
+
+  expect(restarted.conversationForPath("/sessions/first-owner.jsonl")?.id).toBe(first.id);
+});
+
+test("rollback rebaseline imports off-mode writes into a fresh SQLite database", async () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-registry-rollback-rebaseline-"));
+  const filename = path.join(directory, "agent-registry.json");
+  const dualReady = path.join(directory, "dual.ready");
+  const startDual = path.join(directory, "dual.start");
+  const dual = Bun.spawn([
+    process.execPath,
+    CHILD,
+    "dual-writer",
+    filename,
+    dualReady,
+    startDual,
+    "before-rollback",
+  ], { cwd: process.cwd(), stdout: "pipe", stderr: "pipe" });
+  waitFor(dualReady);
+  fs.writeFileSync(startDual, "start");
+  expect(await dual.exited).toBe(0);
+
+  const offReady = path.join(directory, "off.ready");
+  const startOff = path.join(directory, "off.start");
+  const off = Bun.spawn([
+    process.execPath,
+    CHILD,
+    "writer-json",
+    filename,
+    offReady,
+    startOff,
+    "after-rollback",
+    "1",
+  ], { cwd: process.cwd(), stdout: "pipe", stderr: "pipe" });
+  waitFor(offReady);
+  fs.writeFileSync(startOff, "start");
+  expect(await off.exited).toBe(0);
+
+  const sqliteFilename = path.join(directory, "agent-registry.sqlite");
+  for (const suffix of ["", "-wal", "-shm"]) {
+    const active = `${sqliteFilename}${suffix}`;
+    if (fs.existsSync(active)) fs.renameSync(active, `${active}.rollback-evidence`);
+  }
+
+  const resumed = new AgentRegistry(filename, undefined, undefined, { sqliteMode: "dual-write" });
+  expect(resumed.conversationForPath("/sessions/after-rollback-000.jsonl")).toBeDefined();
+  expect(new AgentRegistry(filename, undefined, undefined, { sqliteMode: "sqlite" })
+    .conversationForPath("/sessions/after-rollback-000.jsonl")).toBeDefined();
 });
 
 test("two SQLite registry processes preserve every concurrent write without registry locks", async () => {
@@ -249,7 +491,10 @@ test("SQLite adoption keeps structured-host writer epochs fenced across restarts
 });
 
 test("synthetic ten-lane load records JSON and SQLite registry operation p95", async () => {
-  async function measure(mode: "json" | "sqlite"): Promise<number> {
+  async function measure(mode: "json" | "sqlite"): Promise<{
+    operationP95: number;
+    writerWaitP95: number | null;
+  }> {
     const directory = fs.mkdtempSync(path.join(os.tmpdir(), `llv-registry-${mode}-ten-lane-`));
     const filename = path.join(directory, "agent-registry.json");
     const seed = new AgentRegistry(filename);
@@ -283,15 +528,28 @@ test("synthetic ten-lane load records JSON and SQLite registry operation p95", a
     fs.writeFileSync(start, "start");
     expect(await Promise.all(children.map(({ child }) => child.exited))).toEqual(Array(10).fill(0));
     expect(await Promise.all(children.map(({ child }) => new Response(child.stderr).text()))).toEqual(Array(10).fill(""));
-    const durations = children.flatMap(({ result }) => JSON.parse(fs.readFileSync(result, "utf8")) as number[]);
+    const measurements = children.map(({ result }) => JSON.parse(fs.readFileSync(result, "utf8")) as {
+      durations: number[];
+      writerWaits: number[];
+    });
+    const durations = measurements.flatMap((measurement) => measurement.durations);
     expect(durations).toHaveLength(120);
-    return percentile(durations, 0.95);
+    const writerWaits = measurements.flatMap((measurement) => measurement.writerWaits);
+    if (mode === "sqlite") expect(writerWaits.length).toBeGreaterThanOrEqual(durations.length);
+    return {
+      operationP95: percentile(durations, 0.95),
+      writerWaitP95: writerWaits.length > 0 ? percentile(writerWaits, 0.95) : null,
+    };
   }
 
-  const jsonP95 = await measure("json");
-  const sqliteP95 = await measure("sqlite");
-  console.info(`[agent registry benchmark] ten-lane operation p95: JSON=${jsonP95.toFixed(1)}ms SQLite=${sqliteP95.toFixed(1)}ms`);
-  expect(jsonP95).toBeGreaterThan(0);
-  expect(sqliteP95).toBeGreaterThan(0);
-  expect(sqliteP95).toBeLessThan(5_000);
+  const json = await measure("json");
+  const sqlite = await measure("sqlite");
+  console.info(
+    `[agent registry benchmark] ten-lane p95: operation JSON=${json.operationP95.toFixed(1)}ms `
+    + `SQLite=${sqlite.operationP95.toFixed(1)}ms; SQLite writer wait=${sqlite.writerWaitP95?.toFixed(1)}ms`,
+  );
+  expect(json.operationP95).toBeGreaterThan(0);
+  expect(sqlite.operationP95).toBeGreaterThan(0);
+  expect(sqlite.writerWaitP95).not.toBeNull();
+  expect(sqlite.operationP95).toBeLessThan(json.operationP95);
 }, 30_000);

--- a/src/lib/agent/registry.sqlite.test.ts
+++ b/src/lib/agent/registry.sqlite.test.ts
@@ -1,0 +1,297 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { expect, test } from "bun:test";
+import { Database } from "bun:sqlite";
+
+import { AgentRegistry, RegistryParityError } from "./registry";
+
+const CHILD = path.join(import.meta.dir, "registry.sqliteChild.ts");
+
+function waitFor(pathname: string): void {
+  while (!fs.existsSync(pathname)) Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 1);
+}
+
+function percentile(values: number[], quantile: number): number {
+  const ordered = [...values].sort((left, right) => left - right);
+  return ordered[Math.min(ordered.length - 1, Math.ceil(ordered.length * quantile) - 1)]!;
+}
+
+test("SQLite first boot imports JSON and preserves membership and capability digest paths", () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-registry-sqlite-import-"));
+  const filename = path.join(directory, "agent-registry.json");
+  const digest = "a".repeat(64);
+  const legacy = new AgentRegistry(filename);
+  const begun = legacy.beginSpawnRequest({
+    engine: "codex",
+    cwd: "/repo",
+    spawnCapabilityDigest: digest,
+    memberships: [{
+      kind: "flow",
+      containerId: "flow-187",
+      role: "builder",
+      slot: "builder:0",
+      stageId: null,
+      stageOrder: null,
+      round: null,
+      parentConversationId: null,
+    }],
+  });
+  if (begun.kind !== "created") throw new Error("expected a new receipt");
+  const expected = legacy.snapshot();
+
+  const sqlite = new AgentRegistry(filename, undefined, undefined, { sqliteMode: "read" });
+
+  expect(fs.existsSync(path.join(directory, "agent-registry.sqlite"))).toBeTrue();
+  expect(sqlite.snapshot()).toEqual(expected);
+  expect(sqlite.conversationIdForSpawnCapabilityDigest(digest)).toBe(begun.receipt.conversationId);
+  expect(sqlite.snapshot().memberships[begun.receipt.conversationId]).toEqual([
+    expect.objectContaining({ containerId: "flow-187", slot: "builder:0" }),
+  ]);
+
+  sqlite.rememberMembership(begun.receipt.conversationId, {
+    kind: "pipeline",
+    containerId: "pipeline-187",
+    role: "builder",
+    slot: "stage:build",
+    stageId: "build",
+    stageOrder: 1,
+    round: null,
+    parentConversationId: null,
+  });
+
+  expect(new AgentRegistry(filename).snapshot()).toEqual(sqlite.snapshot());
+});
+
+test("dual-write keeps JSON authoritative and SQLite reads require parity", () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-registry-sqlite-parity-"));
+  const filename = path.join(directory, "agent-registry.json");
+  const sqliteFilename = path.join(directory, "agent-registry.sqlite");
+  const dual = new AgentRegistry(filename, undefined, undefined, { sqliteMode: "dual-write" });
+  const receipt = dual.beginSpawn("codex", "/parity");
+
+  expect(new AgentRegistry(filename).snapshot().receipts[receipt.launchId]).toEqual(
+    new AgentRegistry(filename, undefined, undefined, { sqliteMode: "read" }).snapshot().receipts[receipt.launchId],
+  );
+
+  const db = new Database(sqliteFilename);
+  const stored = db.query<{ value_json: string }, [string, string]>(
+    "SELECT value_json FROM registry_rows WHERE collection = ? AND row_key = ?",
+  ).get("receipts", receipt.launchId);
+  if (!stored) throw new Error("expected SQLite receipt");
+  const changed = JSON.parse(stored.value_json) as { cwd: string };
+  changed.cwd = "/drifted";
+  db.query("UPDATE registry_rows SET value_json = ? WHERE collection = ? AND row_key = ?")
+    .run(JSON.stringify(changed), "receipts", receipt.launchId);
+  db.close();
+
+  expect(() => new AgentRegistry(filename, undefined, undefined, { sqliteMode: "read" })).toThrow(RegistryParityError);
+});
+
+test("two SQLite registry processes preserve every concurrent write without registry locks", async () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-registry-sqlite-writers-"));
+  const filename = path.join(directory, "agent-registry.json");
+  const seed = new AgentRegistry(filename, undefined, undefined, { sqliteMode: "read" });
+  seed.ensureConversation("codex", "/sessions/seed.jsonl", "seed");
+  const start = path.join(directory, "start");
+  const count = 40;
+  const children = ["alpha", "beta"].map((label) => {
+    const ready = path.join(directory, `${label}.ready`);
+    const child = Bun.spawn([process.execPath, CHILD, "writer", filename, ready, start, label, String(count)], {
+      cwd: process.cwd(),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    return { child, ready };
+  });
+  for (const { ready } of children) waitFor(ready);
+  fs.writeFileSync(start, "start");
+
+  const exits = await Promise.all(children.map(({ child }) => child.exited));
+  const errors = await Promise.all(children.map(({ child }) => new Response(child.stderr).text()));
+  expect(exits).toEqual([0, 0]);
+  expect(errors).toEqual(["", ""]);
+
+  const snapshot = seed.snapshot();
+  const written = Object.values(snapshot.conversations).filter((conversation) =>
+    conversation.generations.some((generation) => /\/(?:alpha|beta)-\d+\.jsonl$/.test(generation.path)));
+  expect(written).toHaveLength(count * 2);
+  expect(new AgentRegistry(filename, undefined, undefined, { sqliteMode: "read" }).snapshot()).toEqual(snapshot);
+  expect(fs.existsSync(`${filename}.write-lock`)).toBeFalse();
+});
+
+test("WAL readers stay available during a writer transaction", async () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-registry-sqlite-reader-"));
+  const filename = path.join(directory, "agent-registry.json");
+  const registry = new AgentRegistry(filename, undefined, undefined, { sqliteMode: "read" });
+  const existing = registry.ensureConversation("codex", "/sessions/reader-seed.jsonl", "seed");
+  const ready = path.join(directory, "ready");
+  const release = path.join(directory, "release");
+  const child = Bun.spawn([process.execPath, CHILD, "hold", filename, ready, release], {
+    cwd: process.cwd(),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  waitFor(ready);
+
+  expect(registry.snapshot().conversations[existing.id]).toBeDefined();
+  expect(registry.snapshot().conversations.conversation_crash_mid_write).toBeUndefined();
+
+  fs.writeFileSync(release, "release");
+  expect(await child.exited).toBe(0);
+  expect(await new Response(child.stderr).text()).toBe("");
+  expect(registry.snapshot().conversations.conversation_crash_mid_write).toBeDefined();
+});
+
+test("a process exit inside a SQLite transaction rolls the registry back", async () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-registry-sqlite-crash-"));
+  const filename = path.join(directory, "agent-registry.json");
+  const registry = new AgentRegistry(filename, undefined, undefined, { sqliteMode: "read" });
+  const existing = registry.ensureConversation("codex", "/sessions/crash-seed.jsonl", "seed");
+  const ready = path.join(directory, "ready");
+  const unusedRelease = path.join(directory, "unused-release");
+  const child = Bun.spawn([process.execPath, CHILD, "crash", filename, ready, unusedRelease], {
+    cwd: process.cwd(),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  waitFor(ready);
+
+  expect(await child.exited).toBe(73);
+  expect(await new Response(child.stderr).text()).toBe("");
+  const recovered = new AgentRegistry(filename, undefined, undefined, { sqliteMode: "read" }).snapshot();
+  expect(recovered.conversations[existing.id]).toBeDefined();
+  expect(recovered.conversations.conversation_crash_mid_write).toBeUndefined();
+});
+
+test("restart refreshes the JSON rollback mirror after a post-commit process exit", async () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-registry-sqlite-post-commit-"));
+  const filename = path.join(directory, "agent-registry.json");
+  const registry = new AgentRegistry(filename, undefined, undefined, { sqliteMode: "read" });
+  registry.ensureConversation("codex", "/sessions/post-commit-seed.jsonl", "seed");
+  const ready = path.join(directory, "ready");
+  const unusedRelease = path.join(directory, "unused-release");
+  const child = Bun.spawn([process.execPath, CHILD, "commit-crash", filename, ready, unusedRelease], {
+    cwd: process.cwd(),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  waitFor(ready);
+
+  expect(await child.exited).toBe(74);
+  expect(await new Response(child.stderr).text()).toBe("");
+  const recovered = new AgentRegistry(filename, undefined, undefined, { sqliteMode: "read" }).snapshot();
+  expect(recovered.conversations.conversation_crash_mid_write).toBeDefined();
+  expect(new AgentRegistry(filename).snapshot()).toEqual(recovered);
+});
+
+test("SQLite-only operations avoid JSON rewrites and the read mode prepares rollback", () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-registry-sqlite-only-"));
+  const filename = path.join(directory, "agent-registry.json");
+  const sqlite = new AgentRegistry(filename, undefined, undefined, { sqliteMode: "sqlite" });
+  const before = fs.readFileSync(filename, "utf8");
+
+  const conversation = sqlite.ensureConversation("codex", "/sessions/sqlite-only.jsonl", "work");
+
+  expect(sqlite.snapshot().conversations[conversation.id]).toBeDefined();
+  expect(fs.readFileSync(filename, "utf8")).toBe(before);
+  const rollback = new AgentRegistry(filename, undefined, undefined, { sqliteMode: "read" }).snapshot();
+  expect(new AgentRegistry(filename).snapshot()).toEqual(rollback);
+  expect(rollback.conversations[conversation.id]).toBeDefined();
+});
+
+test("SQLite adoption keeps structured-host writer epochs fenced across restarts", () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-registry-sqlite-adoption-"));
+  const filename = path.join(directory, "agent-registry.json");
+  const key = { engine: "codex" as const, sessionId: "sqlite-adoption" };
+  const structuredHost = {
+    kind: "codex-app-server" as const,
+    endpoint: "stdio:released",
+    process: null,
+    eventCursor: 4,
+    protocolVersion: "1",
+    writerClaimEpoch: 0,
+    activeTurnRef: null,
+    pendingAttention: [],
+    activeFlags: [],
+  };
+  const first = new AgentRegistry(filename, () => false, undefined, { sqliteMode: "read" });
+  first.upsert({
+    key,
+    artifactPath: "/sessions/sqlite-adoption.jsonl",
+    cwd: "/repo",
+    accountId: "work",
+    status: "unhosted",
+    host: null,
+    structuredHost,
+    claimEpoch: 0,
+    claimOwner: null,
+    pendingAction: null,
+  });
+  const firstClaim = first.claimStructuredHost(key, { pid: 41, startIdentity: "41:first" }, { allowUnhosted: true });
+  if (!firstClaim?.claimOwner) throw new Error("expected the first writer claim");
+
+  const restarted = new AgentRegistry(filename, () => false, undefined, { sqliteMode: "read" });
+  const replacement = restarted.claimStructuredHost(key, { pid: 42, startIdentity: "42:replacement" }, { allowUnhosted: true });
+  if (!replacement?.claimOwner) throw new Error("expected the replacement writer claim");
+
+  expect(replacement.claimEpoch).toBe(firstClaim.claimEpoch + 1);
+  expect(first.setStructuredHostClaimed(key, structuredHost, "idle", firstClaim.claimOwner, firstClaim.claimEpoch)).toBeNull();
+  expect(restarted.setStructuredHostClaimed(
+    key,
+    { ...structuredHost, writerClaimEpoch: replacement.claimEpoch, eventCursor: 5 },
+    "idle",
+    replacement.claimOwner,
+    replacement.claimEpoch,
+    true,
+  )).toMatchObject({ status: "idle", claimOwner: null, structuredHost: { eventCursor: 5 } });
+});
+
+test("synthetic ten-lane load records JSON and SQLite registry operation p95", async () => {
+  async function measure(mode: "json" | "sqlite"): Promise<number> {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), `llv-registry-${mode}-ten-lane-`));
+    const filename = path.join(directory, "agent-registry.json");
+    const seed = new AgentRegistry(filename);
+    const template = seed.beginSpawn("codex", "/benchmark-seed");
+    const productionShape = seed.snapshot();
+    for (let index = 1; index < 5_000; index += 1) {
+      const launchId = `benchmark-seed-${String(index).padStart(5, "0")}`;
+      productionShape.receipts[launchId] = { ...structuredClone(template), launchId };
+    }
+    fs.writeFileSync(filename, JSON.stringify(productionShape));
+    if (mode === "sqlite") new AgentRegistry(filename, undefined, undefined, { sqliteMode: "sqlite" });
+    const start = path.join(directory, "start");
+    const children = Array.from({ length: 10 }, (_, lane) => {
+      const label = `${mode}-lane-${lane}`;
+      const ready = path.join(directory, `${label}.ready`);
+      const result = path.join(directory, `${label}.json`);
+      const child = Bun.spawn([
+        process.execPath,
+        CHILD,
+        mode === "sqlite" ? "writer-sqlite" : "writer-json",
+        filename,
+        ready,
+        start,
+        label,
+        "12",
+        result,
+      ], { cwd: process.cwd(), stdout: "pipe", stderr: "pipe" });
+      return { child, ready, result };
+    });
+    for (const { ready } of children) waitFor(ready);
+    fs.writeFileSync(start, "start");
+    expect(await Promise.all(children.map(({ child }) => child.exited))).toEqual(Array(10).fill(0));
+    expect(await Promise.all(children.map(({ child }) => new Response(child.stderr).text()))).toEqual(Array(10).fill(""));
+    const durations = children.flatMap(({ result }) => JSON.parse(fs.readFileSync(result, "utf8")) as number[]);
+    expect(durations).toHaveLength(120);
+    return percentile(durations, 0.95);
+  }
+
+  const jsonP95 = await measure("json");
+  const sqliteP95 = await measure("sqlite");
+  console.info(`[agent registry benchmark] ten-lane operation p95: JSON=${jsonP95.toFixed(1)}ms SQLite=${sqliteP95.toFixed(1)}ms`);
+  expect(jsonP95).toBeGreaterThan(0);
+  expect(sqliteP95).toBeGreaterThan(0);
+  expect(sqliteP95).toBeLessThan(5_000);
+}, 30_000);

--- a/src/lib/agent/registry.sqliteChild.ts
+++ b/src/lib/agent/registry.sqliteChild.ts
@@ -1,0 +1,52 @@
+import fs from "node:fs";
+
+import { Database } from "bun:sqlite";
+
+import { AgentRegistry } from "./registry";
+
+const [action, filename, ready, release, label = "writer", countText = "0", resultFile] = process.argv.slice(2);
+if (!action || !filename || !ready || !release) throw new Error("registry child arguments are required");
+
+function waitFor(pathname: string): void {
+  while (!fs.existsSync(pathname)) Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 1);
+}
+
+if (action === "writer" || action === "writer-json" || action === "writer-sqlite") {
+  const sqliteMode = action === "writer-json" ? "off" : action === "writer-sqlite" ? "sqlite" : "read";
+  const registry = new AgentRegistry(filename, undefined, undefined, { sqliteMode });
+  fs.writeFileSync(ready, "ready");
+  waitFor(release);
+  const durations: number[] = [];
+  for (let index = 0; index < Number(countText); index += 1) {
+    const suffix = `${label}-${String(index).padStart(3, "0")}`;
+    const startedAt = performance.now();
+    registry.ensureConversation("codex", `/sessions/${suffix}.jsonl`, label);
+    durations.push(performance.now() - startedAt);
+  }
+  if (resultFile) fs.writeFileSync(resultFile, JSON.stringify(durations));
+  process.exit(0);
+}
+
+const sqliteFilename = filename.endsWith(".json") ? `${filename.slice(0, -5)}.sqlite` : `${filename}.sqlite`;
+const db = new Database(sqliteFilename, { strict: true });
+db.exec("PRAGMA journal_mode = WAL; PRAGMA synchronous = FULL; PRAGMA busy_timeout = 5000; BEGIN IMMEDIATE;");
+const source = db.query<{ value_json: string }, []>(
+  "SELECT value_json FROM registry_rows WHERE collection = 'conversations' LIMIT 1",
+).get();
+if (!source) throw new Error("a source conversation is required");
+const injected = JSON.parse(source.value_json) as { id: string; generations: Array<{ path: string }> };
+injected.id = "conversation_crash_mid_write";
+for (const generation of injected.generations) generation.path = "/sessions/crash-mid-write.jsonl";
+db.query("INSERT INTO registry_rows(collection, row_key, value_json) VALUES ('conversations', ?, ?)")
+  .run(injected.id, JSON.stringify(injected));
+fs.writeFileSync(ready, "ready");
+
+if (action === "crash") process.exit(73);
+if (action === "commit-crash") {
+  db.query("UPDATE registry_meta SET value = CAST(value AS INTEGER) + 1 WHERE key = 'revision'").run();
+  db.exec("COMMIT");
+  process.exit(74);
+}
+waitFor(release);
+db.exec("COMMIT");
+db.close();

--- a/src/lib/agent/registry.sqliteChild.ts
+++ b/src/lib/agent/registry.sqliteChild.ts
@@ -11,9 +11,46 @@ function waitFor(pathname: string): void {
   while (!fs.existsSync(pathname)) Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 1);
 }
 
+if (action === "dual-startup") {
+  new AgentRegistry(filename, undefined, undefined, {
+    sqliteMode: "dual-write",
+    beforeDualWriteStartupReplace: () => {
+      fs.writeFileSync(ready, "ready");
+      waitFor(release);
+    },
+  });
+  process.exit(0);
+}
+
+if (action === "transition-writer") {
+  const registry = new AgentRegistry(filename, undefined, undefined, {
+    sqliteMode: label as "read" | "sqlite",
+  });
+  fs.writeFileSync(ready, "ready");
+  waitFor(release);
+  if (resultFile) fs.writeFileSync(resultFile, "attempted");
+  registry.ensureConversation("codex", `/sessions/${label}.jsonl`, label);
+  if (resultFile) fs.writeFileSync(`${resultFile}.done`, "done");
+  process.exit(0);
+}
+
+if (action === "dual-writer") {
+  fs.writeFileSync(ready, "ready");
+  waitFor(release);
+  if (resultFile) fs.writeFileSync(resultFile, "attempted");
+  const registry = new AgentRegistry(filename, undefined, undefined, { sqliteMode: "dual-write" });
+  registry.ensureConversation("codex", `/sessions/${label}.jsonl`, label);
+  if (resultFile) fs.writeFileSync(`${resultFile}.done`, "done");
+  process.exit(0);
+}
+
 if (action === "writer" || action === "writer-json" || action === "writer-sqlite") {
   const sqliteMode = action === "writer-json" ? "off" : action === "writer-sqlite" ? "sqlite" : "read";
-  const registry = new AgentRegistry(filename, undefined, undefined, { sqliteMode });
+  const writerWaits: number[] = [];
+  const registry = new AgentRegistry(filename, undefined, undefined, {
+    sqliteMode,
+    onSqliteWriterWait: (durationMs) => writerWaits.push(durationMs),
+  });
   fs.writeFileSync(ready, "ready");
   waitFor(release);
   const durations: number[] = [];
@@ -23,7 +60,7 @@ if (action === "writer" || action === "writer-json" || action === "writer-sqlite
     registry.ensureConversation("codex", `/sessions/${suffix}.jsonl`, label);
     durations.push(performance.now() - startedAt);
   }
-  if (resultFile) fs.writeFileSync(resultFile, JSON.stringify(durations));
+  if (resultFile) fs.writeFileSync(resultFile, JSON.stringify({ durations, writerWaits }));
   process.exit(0);
 }
 
@@ -37,8 +74,11 @@ if (!source) throw new Error("a source conversation is required");
 const injected = JSON.parse(source.value_json) as { id: string; generations: Array<{ path: string }> };
 injected.id = "conversation_crash_mid_write";
 for (const generation of injected.generations) generation.path = "/sessions/crash-mid-write.jsonl";
-db.query("INSERT INTO registry_rows(collection, row_key, value_json) VALUES ('conversations', ?, ?)")
-  .run(injected.id, JSON.stringify(injected));
+db.query(`
+  INSERT INTO registry_rows(collection, row_key, value_json, row_order)
+  SELECT 'conversations', ?, ?, COALESCE(MAX(row_order) + 1, 0)
+  FROM registry_rows WHERE collection = 'conversations'
+`).run(injected.id, JSON.stringify(injected));
 fs.writeFileSync(ready, "ready");
 
 if (action === "crash") process.exit(73);

--- a/src/lib/agent/registry.ts
+++ b/src/lib/agent/registry.ts
@@ -23,6 +23,7 @@ import {
 
 import type { AgentEngine } from "./cli";
 import { sessionKeyFromTranscript, sessionKeyId, type SessionKey } from "./sessionKey";
+import { SqliteAgentRegistryStore, type SqliteRegistrySnapshot } from "./sqliteRegistryStore";
 import type { ResumePaneRecord } from "@/lib/resumePanesFile";
 
 export type AgentHostStatus = "starting" | "live" | "idle" | "handoff" | "unhosted" | "dead";
@@ -1197,17 +1198,16 @@ function upgradeV1(parsed: Omit<Partial<RegistryFile>, "version">): RegistryFile
   };
 }
 
-function readFile(filename: string): RegistryFile {
-  try {
-    const parsed = JSON.parse(fs.readFileSync(filename, "utf8")) as Omit<Partial<RegistryFile>, "version"> & { version?: unknown };
-    if (parsed.version === 1 && parsed.entries && parsed.receipts && typeof parsed.entries === "object" && typeof parsed.receipts === "object") {
-      return upgradeV1(parsed);
-    }
-    if (parsed.version !== 2 || !parsed.entries || !parsed.receipts || typeof parsed.entries !== "object" || typeof parsed.receipts !== "object") {
-      throw new RegistryReadError("agent registry schema is unsupported");
-    }
-    const legacy = parsed.legacyResumePanes;
-    return {
+export function normalizeRegistry(value: unknown): RegistryFile {
+  const parsed = value as Omit<Partial<RegistryFile>, "version"> & { version?: unknown };
+  if (parsed.version === 1 && parsed.entries && parsed.receipts && typeof parsed.entries === "object" && typeof parsed.receipts === "object") {
+    return upgradeV1(parsed);
+  }
+  if (parsed.version !== 2 || !parsed.entries || !parsed.receipts || typeof parsed.entries !== "object" || typeof parsed.receipts !== "object") {
+    throw new RegistryReadError("agent registry schema is unsupported");
+  }
+  const legacy = parsed.legacyResumePanes;
+  return {
       version: 2,
       entries: Object.fromEntries(Object.entries(parsed.entries).map(([id, entry]) => [id, normalizeEntry(entry)])),
       receipts: Object.fromEntries(Object.entries(parsed.receipts).map(([id, receipt]) => [id, normalizeReceipt(receipt)])),
@@ -1242,7 +1242,12 @@ function readFile(filename: string): RegistryFile {
       pendingSuccessorCleanups: parsed.pendingSuccessorCleanups && typeof parsed.pendingSuccessorCleanups === "object"
         ? parsed.pendingSuccessorCleanups
         : {},
-    };
+  };
+}
+
+function readFile(filename: string): RegistryFile {
+  try {
+    return normalizeRegistry(JSON.parse(fs.readFileSync(filename, "utf8")));
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code === "ENOENT") return clone(EMPTY);
     if (error instanceof RegistryReadError) throw error;
@@ -1261,9 +1266,10 @@ function compactLaunchProfile(profile: LaunchProfile): Partial<LaunchProfile> {
   return compact;
 }
 
-function serializeRegistry(value: RegistryFile): string {
+function serializeRegistry(value: RegistryFile, sqliteRevision?: number): string {
   const storage = {
     ...value,
+    ...(sqliteRevision === undefined ? {} : { _sqliteRevision: sqliteRevision }),
     entries: Object.fromEntries(Object.entries(value.entries).map(([id, entry]) => [id, {
       ...entry,
       ...(entry.launchProfile ? { launchProfile: compactLaunchProfile(entry.launchProfile) } : {}),
@@ -1283,10 +1289,10 @@ function serializeRegistry(value: RegistryFile): string {
   return JSON.stringify(storage) + "\n";
 }
 
-function writeAtomic(filename: string, value: RegistryFile): void {
+function writeAtomic(filename: string, value: RegistryFile, sqliteRevision?: number): void {
   fs.mkdirSync(path.dirname(filename), { recursive: true, mode: 0o700 });
   const temp = `${filename}.${process.pid}.${crypto.randomUUID()}.tmp`;
-  const payload = serializeRegistry(value);
+  const payload = serializeRegistry(value, sqliteRevision);
   let fd: number | null = null;
   try {
     fd = fs.openSync(temp, "w", 0o600);
@@ -1303,18 +1309,92 @@ function writeAtomic(filename: string, value: RegistryFile): void {
   }
 }
 
+export type AgentRegistrySqliteMode = "off" | "dual-write" | "read" | "sqlite";
+
+export interface AgentRegistryStorageOptions {
+  sqliteMode?: AgentRegistrySqliteMode;
+  sqliteFilename?: string;
+}
+
+export class RegistryParityError extends Error {
+  override name = "RegistryParityError";
+}
+
+function sqliteModeFromEnvironment(): AgentRegistrySqliteMode {
+  const configured = process.env.LLV_AGENT_REGISTRY_SQLITE ?? "off";
+  if (configured === "off" || configured === "dual-write" || configured === "read" || configured === "sqlite") return configured;
+  throw new Error("LLV_AGENT_REGISTRY_SQLITE must be off, dual-write, read, or sqlite");
+}
+
+function defaultSqliteFilename(jsonFilename: string): string {
+  return jsonFilename.endsWith(".json") ? `${jsonFilename.slice(0, -5)}.sqlite` : `${jsonFilename}.sqlite`;
+}
+
+function sqliteMirrorRevision(filename: string): number | null {
+  try {
+    const revision = (JSON.parse(fs.readFileSync(filename, "utf8")) as { _sqliteRevision?: unknown })._sqliteRevision;
+    return Number.isInteger(revision) && Number(revision) >= 0 ? Number(revision) : null;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
+    throw error;
+  }
+}
+
 /** Durable source for identity and handoff evidence. The lock directory is
     intentionally separate from in-memory promises, so a Viewer replacement
     cannot leave an imaginary owner behind. */
 export class AgentRegistry {
+  private readonly sqliteMode: AgentRegistrySqliteMode;
+  private readonly sqliteStore: SqliteAgentRegistryStore | null;
+
   constructor(
     readonly filename = statePath("agent-registry.json"),
     private readonly ownerAlive: (owner: ProcessIdentity) => boolean = (owner) =>
       procBackend.pidAlive(owner.pid) && (owner.startIdentity === null || procBackend.processIdentity(owner.pid) === owner.startIdentity),
     private readonly lockTiming: RegistryLockTiming = SYSTEM_LOCK_TIMING,
+    storage: AgentRegistryStorageOptions = {},
   ) {
-    this.cleanupStaleTempFiles();
-    this.compactAtStartup();
+    this.sqliteMode = storage.sqliteMode ?? sqliteModeFromEnvironment();
+    this.sqliteStore = this.sqliteMode === "off"
+      ? null
+      : new SqliteAgentRegistryStore(storage.sqliteFilename ?? defaultSqliteFilename(filename), {
+          initialSnapshot: readFile(filename),
+          normalize: normalizeRegistry,
+        });
+    if (this.sqliteMode === "off" || this.sqliteMode === "dual-write") {
+      this.cleanupStaleTempFiles();
+      this.compactAtStartup();
+    }
+    if (this.sqliteMode === "dual-write") {
+      this.sqliteStore!.replace(readFile(this.filename));
+      this.assertSqliteParity();
+    }
+    if (this.sqliteMode === "read" || this.sqliteMode === "sqlite") {
+      const sqlite = this.sqliteStore!.snapshot();
+      const mirrorRevision = sqliteMirrorRevision(this.filename);
+      if (mirrorRevision === null || mirrorRevision === sqlite.revision) this.assertSqliteParity(sqlite);
+      if (mirrorRevision !== null && mirrorRevision > sqlite.revision) {
+        throw new RegistryParityError("agent registry JSON mirror revision is ahead of SQLite");
+      }
+      this.mirrorSqliteSnapshot(sqlite);
+    }
+  }
+
+  private assertSqliteParity(snapshot: SqliteRegistrySnapshot = this.sqliteStore!.snapshot()): void {
+    const json = readFile(this.filename);
+    if (serializeRegistry(snapshot.file) !== serializeRegistry(json)) {
+      throw new RegistryParityError("agent registry JSON and SQLite snapshots differ");
+    }
+  }
+
+  private mirrorSqliteSnapshot(initial: SqliteRegistrySnapshot): void {
+    let snapshot = initial;
+    for (;;) {
+      writeAtomic(this.filename, snapshot.file, snapshot.revision);
+      const latest = this.sqliteStore!.snapshot();
+      if (latest.revision <= snapshot.revision) return;
+      snapshot = latest;
+    }
   }
 
   private cleanupStaleTempFiles(): void {
@@ -1692,23 +1772,36 @@ export class AgentRegistry {
   }
 
   private mutate<T>(fn: (file: RegistryFile) => T): T {
+    if (this.sqliteMode === "read" || this.sqliteMode === "sqlite") {
+      const mutation = this.sqliteStore!.mutate(fn);
+      if (this.sqliteMode === "read") this.mirrorSqliteSnapshot(mutation);
+      return mutation.result;
+    }
     const lock = `${this.filename}.write-lock`;
     const claim = this.acquireLock(lock, { pid: process.pid, startIdentity: procBackend.processIdentity(process.pid) });
     try {
       const file = readFile(this.filename);
       const result = fn(file);
       writeAtomic(this.filename, file);
+      if (this.sqliteMode === "dual-write") {
+        this.sqliteStore!.replace(file);
+        this.assertSqliteParity();
+      }
       return result;
     } finally {
       this.releaseLock(claim);
     }
   }
 
-  snapshot(): RegistryFile { return readFile(this.filename); }
+  snapshot(): RegistryFile {
+    return this.sqliteMode === "read" || this.sqliteMode === "sqlite"
+      ? this.sqliteStore!.snapshot().file
+      : readFile(this.filename);
+  }
 
   conversationIdForSpawnCapabilityDigest(digest: string): ViewerConversationId | null {
     if (!/^[0-9a-f]{64}$/.test(digest)) return null;
-    const file = readFile(this.filename);
+    const file = this.snapshot();
     const receipt = Object.values(file.receipts).find((candidate) => candidate.spawnCapabilityDigest === digest);
     return receipt ? resolveConversationAlias(file, receipt.conversationId) : null;
   }

--- a/src/lib/agent/registry.ts
+++ b/src/lib/agent/registry.ts
@@ -1,6 +1,7 @@
 import crypto from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
+import { isDeepStrictEqual } from "node:util";
 
 import { statePath } from "@/lib/configDir";
 import { procBackend } from "@/lib/proc";
@@ -562,7 +563,9 @@ export class MigrationRevisionError extends Error {
   }
 }
 
-function emptyPolicy(): AutoBalancePolicy {
+const LEGACY_POLICY_RESTARTED_AT = "1970-01-01T00:00:00.000Z";
+
+function emptyPolicy(restartedAt = now()): AutoBalancePolicy {
   return {
     enabled: true,
     revision: 0,
@@ -572,7 +575,7 @@ function emptyPolicy(): AutoBalancePolicy {
     lastTrigger: null,
     lastCheckAt: null,
     sustain: null,
-    restartedAt: now(),
+    restartedAt,
   };
 }
 
@@ -841,7 +844,7 @@ function normalizeConversation(value: RegistryConversation): RegistryConversatio
 }
 
 function normalizePolicy(value: AutoBalancePolicy | undefined): AutoBalancePolicy {
-  const fallback = emptyPolicy();
+  const fallback = emptyPolicy(LEGACY_POLICY_RESTARTED_AT);
   if (!value || typeof value !== "object") return fallback;
   return {
     ...fallback,
@@ -1188,6 +1191,10 @@ function upgradeV1(parsed: Omit<Partial<RegistryFile>, "version">): RegistryFile
   const legacy = parsed.legacyResumePanes;
   return {
     ...clone(EMPTY),
+    autoBalance: {
+      claude: emptyPolicy(LEGACY_POLICY_RESTARTED_AT),
+      codex: emptyPolicy(LEGACY_POLICY_RESTARTED_AT),
+    },
     entries: (parsed.entries as RegistryFile["entries"]) ?? {},
     receipts: Object.fromEntries(Object.entries((parsed.receipts as RegistryFile["receipts"]) ?? {}).map(([id, receipt]) => [id, normalizeReceipt(receipt)])),
     conversationAliases: {},
@@ -1232,7 +1239,10 @@ export function normalizeRegistry(value: unknown): RegistryFile {
       engineRouting: parsed.engineRouting && typeof parsed.engineRouting === "object" ? { ...EMPTY.engineRouting, ...parsed.engineRouting } : clone(EMPTY.engineRouting),
       autoBalance: parsed.autoBalance && typeof parsed.autoBalance === "object"
         ? { claude: normalizePolicy(parsed.autoBalance.claude), codex: normalizePolicy(parsed.autoBalance.codex) }
-        : { claude: emptyPolicy(), codex: emptyPolicy() },
+        : {
+            claude: emptyPolicy(LEGACY_POLICY_RESTARTED_AT),
+            codex: emptyPolicy(LEGACY_POLICY_RESTARTED_AT),
+          },
       quotaObservations: parsed.quotaObservations && typeof parsed.quotaObservations === "object"
         ? { ...EMPTY.quotaObservations, ...parsed.quotaObservations }
         : clone(EMPTY.quotaObservations),
@@ -1314,6 +1324,9 @@ export type AgentRegistrySqliteMode = "off" | "dual-write" | "read" | "sqlite";
 export interface AgentRegistryStorageOptions {
   sqliteMode?: AgentRegistrySqliteMode;
   sqliteFilename?: string;
+  onSqliteWriterWait?: (durationMs: number) => void;
+  beforeDualWriteStartupReplace?: () => void;
+  beforeDualWriteMutationReplace?: () => void;
 }
 
 export class RegistryParityError extends Error {
@@ -1346,6 +1359,7 @@ function sqliteMirrorRevision(filename: string): number | null {
 export class AgentRegistry {
   private readonly sqliteMode: AgentRegistrySqliteMode;
   private readonly sqliteStore: SqliteAgentRegistryStore | null;
+  private readonly beforeDualWriteMutationReplace: (() => void) | undefined;
 
   constructor(
     readonly filename = statePath("agent-registry.json"),
@@ -1355,19 +1369,21 @@ export class AgentRegistry {
     storage: AgentRegistryStorageOptions = {},
   ) {
     this.sqliteMode = storage.sqliteMode ?? sqliteModeFromEnvironment();
+    this.beforeDualWriteMutationReplace = storage.beforeDualWriteMutationReplace;
     this.sqliteStore = this.sqliteMode === "off"
       ? null
       : new SqliteAgentRegistryStore(storage.sqliteFilename ?? defaultSqliteFilename(filename), {
           initialSnapshot: readFile(filename),
           normalize: normalizeRegistry,
+          onWriterWait: storage.onSqliteWriterWait,
         });
-    if (this.sqliteMode === "off" || this.sqliteMode === "dual-write") {
+    if (this.sqliteMode === "off") {
       this.cleanupStaleTempFiles();
       this.compactAtStartup();
     }
     if (this.sqliteMode === "dual-write") {
-      this.sqliteStore!.replace(readFile(this.filename));
-      this.assertSqliteParity();
+      this.cleanupStaleTempFiles();
+      this.synchronizeDualWriteStartup(storage.beforeDualWriteStartupReplace);
     }
     if (this.sqliteMode === "read" || this.sqliteMode === "sqlite") {
       const sqlite = this.sqliteStore!.snapshot();
@@ -1382,8 +1398,13 @@ export class AgentRegistry {
 
   private assertSqliteParity(snapshot: SqliteRegistrySnapshot = this.sqliteStore!.snapshot()): void {
     const json = readFile(this.filename);
-    if (serializeRegistry(snapshot.file) !== serializeRegistry(json)) {
-      throw new RegistryParityError("agent registry JSON and SQLite snapshots differ");
+    if (!isDeepStrictEqual(snapshot.file, json)) {
+      const fields = [...new Set([...Object.keys(snapshot.file), ...Object.keys(json)])]
+        .filter((field) => !isDeepStrictEqual(
+          snapshot.file[field as keyof RegistryFile],
+          json[field as keyof RegistryFile],
+        ));
+      throw new RegistryParityError(`agent registry JSON and SQLite snapshots differ: ${fields.join(", ")}`);
     }
   }
 
@@ -1427,25 +1448,58 @@ export class AgentRegistry {
     const lock = `${this.filename}.write-lock`;
     const claim = this.acquireLock(lock, { pid: process.pid, startIdentity: procBackend.processIdentity(process.pid) });
     try {
-      let original: string;
-      try {
-        original = fs.readFileSync(this.filename, "utf8");
-      } catch (error) {
-        if ((error as NodeJS.ErrnoException).code === "ENOENT") return;
-        throw error;
+      this.compactAtStartupLocked();
+    } finally {
+      this.releaseLock(claim);
+    }
+  }
+
+  private compactAtStartupLocked(): void {
+    let original: string;
+    try {
+      original = fs.readFileSync(this.filename, "utf8");
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") return;
+      throw error;
+    }
+    let file: RegistryFile;
+    try {
+      file = readFile(this.filename);
+    } catch (error) {
+      if (error instanceof RegistryReadError) {
+        console.error("agent registry startup compaction skipped:", error);
+        return;
       }
-      let file: RegistryFile;
-      try {
-        file = readFile(this.filename);
-      } catch (error) {
-        if (error instanceof RegistryReadError) {
-          console.error("agent registry startup compaction skipped:", error);
-          return;
-        }
-        throw error;
+      throw error;
+    }
+    compactDeliveryReservations(file);
+    if (serializeRegistry(file) !== original) writeAtomic(this.filename, file);
+  }
+
+  private synchronizeDualWriteStartup(beforeReplace: (() => void) | undefined): void {
+    const lock = `${this.filename}.write-lock`;
+    const claim = this.acquireLock(lock, { pid: process.pid, startIdentity: procBackend.processIdentity(process.pid) });
+    try {
+      const sqlite = this.sqliteStore!.snapshot();
+      if (!fs.existsSync(this.filename)) writeAtomic(this.filename, sqlite.file);
+      const mirrorRevision = sqliteMirrorRevision(this.filename);
+      if (mirrorRevision !== null && mirrorRevision !== sqlite.revision) {
+        throw new RegistryParityError(
+          `agent registry backend revisions differ: JSON ${mirrorRevision}, SQLite ${sqlite.revision}`,
+        );
       }
-      compactDeliveryReservations(file);
-      if (serializeRegistry(file) !== original) writeAtomic(this.filename, file);
+      this.assertSqliteParity(sqlite);
+      this.compactAtStartupLocked();
+      const file = readFile(this.filename);
+      beforeReplace?.();
+      const replacement = this.sqliteStore!.replace(file, sqlite.revision);
+      if (!replacement.replaced) {
+        this.mirrorSqliteSnapshot(replacement);
+        throw new RegistryParityError(
+          `agent registry SQLite revision changed during dual-write startup: expected ${sqlite.revision}, current ${replacement.revision}`,
+        );
+      }
+      this.assertSqliteParity();
     } finally {
       this.releaseLock(claim);
     }
@@ -1773,18 +1827,38 @@ export class AgentRegistry {
 
   private mutate<T>(fn: (file: RegistryFile) => T): T {
     if (this.sqliteMode === "read" || this.sqliteMode === "sqlite") {
-      const mutation = this.sqliteStore!.mutate(fn);
-      if (this.sqliteMode === "read") this.mirrorSqliteSnapshot(mutation);
+      const mutation = this.sqliteStore!.mutate(fn, this.sqliteMode === "read");
+      if (this.sqliteMode === "read") {
+        if (!mutation.file) throw new Error("SQLite read mode mutation is missing its rollback snapshot");
+        this.mirrorSqliteSnapshot({ file: mutation.file, revision: mutation.revision });
+      }
       return mutation.result;
     }
     const lock = `${this.filename}.write-lock`;
     const claim = this.acquireLock(lock, { pid: process.pid, startIdentity: procBackend.processIdentity(process.pid) });
     try {
+      const sqlite = this.sqliteMode === "dual-write" ? this.sqliteStore!.snapshot() : null;
+      if (sqlite) {
+        const mirrorRevision = sqliteMirrorRevision(this.filename);
+        if (mirrorRevision !== null && mirrorRevision !== sqlite.revision) {
+          throw new RegistryParityError(
+            `agent registry backend revisions differ: JSON ${mirrorRevision}, SQLite ${sqlite.revision}`,
+          );
+        }
+        this.assertSqliteParity(sqlite);
+      }
       const file = readFile(this.filename);
       const result = fn(file);
       writeAtomic(this.filename, file);
-      if (this.sqliteMode === "dual-write") {
-        this.sqliteStore!.replace(file);
+      if (sqlite) {
+        this.beforeDualWriteMutationReplace?.();
+        const replacement = this.sqliteStore!.replace(file, sqlite.revision);
+        if (!replacement.replaced) {
+          this.mirrorSqliteSnapshot(replacement);
+          throw new RegistryParityError(
+            `agent registry SQLite revision changed during dual-write mutation: expected ${sqlite.revision}, current ${replacement.revision}`,
+          );
+        }
         this.assertSqliteParity();
       }
       return result;

--- a/src/lib/agent/sqliteRegistryStore.ts
+++ b/src/lib/agent/sqliteRegistryStore.ts
@@ -1,7 +1,8 @@
 import fs from "node:fs";
 import path from "node:path";
+import { isDeepStrictEqual } from "node:util";
 
-import { Database } from "bun:sqlite";
+import type { Database as BunDatabase } from "bun:sqlite";
 
 import type { RegistryFile } from "./registry";
 
@@ -27,72 +28,13 @@ const META_FIELDS = [
 ] as const satisfies ReadonlyArray<keyof RegistryFile>;
 
 type RowCollection = (typeof ROW_COLLECTIONS)[number];
-type StoredRow = { collection: string; row_key: string; value_json: string };
+type StoredRow = { collection: string; row_key: string; value_json: string; row_order: number };
 type MetaRow = { key: string; value: string };
 
 interface RegistryChanges {
   rows: Map<RowCollection, Set<string>>;
   meta: Set<(typeof META_FIELDS)[number]>;
-}
-
-function trackedRegistry(file: RegistryFile): { file: RegistryFile; changes: RegistryChanges } {
-  const changes: RegistryChanges = { rows: new Map(), meta: new Set() };
-  const proxies = new WeakMap<object, object>();
-  const rowCollections = new Set<string>(ROW_COLLECTIONS);
-  const metaFields = new Set<string>(META_FIELDS);
-  const markRow = (collection: RowCollection, key: PropertyKey) => {
-    if (typeof key !== "string") return;
-    let keys = changes.rows.get(collection);
-    if (!keys) {
-      keys = new Set();
-      changes.rows.set(collection, keys);
-    }
-    keys.add(key);
-  };
-  const wrap = (value: unknown, path: string[]): unknown => {
-    if (!value || typeof value !== "object") return value;
-    const cached = proxies.get(value);
-    if (cached) return cached;
-    const proxy = new Proxy(value, {
-      get(target, property, receiver) {
-        return wrap(Reflect.get(target, property, receiver), [...path, String(property)]);
-      },
-      set(target, property, next, receiver) {
-        const root = path[0] ?? String(property);
-        if (rowCollections.has(root)) {
-          if (path.length === 0) {
-            const previousRows = Reflect.get(target, property, receiver) as Record<string, unknown> | undefined;
-            for (const key of Object.keys(previousRows ?? {})) markRow(root as RowCollection, key);
-            if (next && typeof next === "object") {
-              for (const key of Object.keys(next as object)) markRow(root as RowCollection, key);
-            }
-          } else {
-            markRow(root as RowCollection, path.length === 1 ? property : path[1]!);
-          }
-        } else if (metaFields.has(root)) {
-          changes.meta.add(root as (typeof META_FIELDS)[number]);
-        }
-        return Reflect.set(target, property, next, receiver);
-      },
-      deleteProperty(target, property) {
-        const root = path[0] ?? String(property);
-        if (rowCollections.has(root)) {
-          if (path.length === 0) {
-            const previousRows = Reflect.get(target, property) as Record<string, unknown> | undefined;
-            for (const key of Object.keys(previousRows ?? {})) markRow(root as RowCollection, key);
-          } else {
-            markRow(root as RowCollection, path.length === 1 ? property : path[1]!);
-          }
-        } else if (metaFields.has(root)) {
-          changes.meta.add(root as (typeof META_FIELDS)[number]);
-        }
-        return Reflect.deleteProperty(target, property);
-      },
-    });
-    proxies.set(value, proxy);
-    return proxy;
-  };
-  return { file: wrap(file, []) as RegistryFile, changes };
+  order: Set<RowCollection>;
 }
 
 export interface SqliteRegistrySnapshot {
@@ -100,23 +42,39 @@ export interface SqliteRegistrySnapshot {
   revision: number;
 }
 
-export interface SqliteRegistryMutation<T> extends SqliteRegistrySnapshot {
+export interface SqliteRegistryReplacement extends SqliteRegistrySnapshot {
+  replaced: boolean;
+}
+
+export interface SqliteRegistryMutation<T> {
   result: T;
+  file: RegistryFile | null;
+  revision: number;
 }
 
 export interface SqliteRegistryStoreOptions {
   initialSnapshot: RegistryFile;
   normalize(value: unknown): RegistryFile;
+  onWriterWait?(durationMs: number): void;
+}
+
+interface LazyRegistrySnapshot extends SqliteRegistrySnapshot {
+  changes(): RegistryChanges;
 }
 
 export class SqliteAgentRegistryStore {
-  private readonly db: Database;
+  private readonly db: BunDatabase;
   private readonly normalize: (value: unknown) => RegistryFile;
+  private readonly onWriterWait: ((durationMs: number) => void) | undefined;
 
   constructor(readonly filename: string, options: SqliteRegistryStoreOptions) {
     fs.mkdirSync(path.dirname(filename), { recursive: true, mode: 0o700 });
+    const sqlite = process.getBuiltinModule?.("bun:sqlite") as typeof import("bun:sqlite") | undefined;
+    if (!sqlite) throw new Error("SQLite registry modes require the Bun runtime");
+    const { Database } = sqlite;
     this.db = new Database(filename, { create: true, strict: true });
     this.normalize = options.normalize;
+    this.onWriterWait = options.onWriterWait;
     this.db.exec("PRAGMA busy_timeout = 5000; PRAGMA journal_mode = WAL; PRAGMA synchronous = FULL; PRAGMA foreign_keys = ON; PRAGMA auto_vacuum = INCREMENTAL;");
     this.db.exec(`
       CREATE TABLE IF NOT EXISTS registry_meta (
@@ -127,9 +85,26 @@ export class SqliteAgentRegistryStore {
         collection TEXT NOT NULL,
         row_key TEXT NOT NULL,
         value_json TEXT NOT NULL,
+        row_order INTEGER NOT NULL,
         PRIMARY KEY(collection, row_key)
       );
     `);
+    const columns = this.db.query<{ name: string }, []>("PRAGMA table_info(registry_rows)").all();
+    if (!columns.some((column) => column.name === "row_order")) {
+      this.db.exec(`
+        BEGIN IMMEDIATE;
+        ALTER TABLE registry_rows ADD COLUMN row_order INTEGER NOT NULL DEFAULT 0;
+        WITH ordered AS (
+          SELECT rowid, ROW_NUMBER() OVER (PARTITION BY collection ORDER BY rowid) - 1 AS position
+          FROM registry_rows
+        )
+        UPDATE registry_rows
+        SET row_order = (SELECT position FROM ordered WHERE ordered.rowid = registry_rows.rowid);
+        INSERT INTO registry_meta(key, value) VALUES ('schema_version', '2')
+        ON CONFLICT(key) DO UPDATE SET value = excluded.value;
+        COMMIT;
+      `);
+    }
     this.secureFiles();
     this.importFirstBoot(options.initialSnapshot);
   }
@@ -146,32 +121,59 @@ export class SqliteAgentRegistryStore {
     }
   }
 
-  mutate<T>(operation: (file: RegistryFile) => T): SqliteRegistryMutation<T> {
-    this.db.exec("BEGIN IMMEDIATE");
-    try {
-      const current = this.loadInTransaction();
-      const tracked = trackedRegistry(current.file);
-      const result = operation(tracked.file);
-      const revision = current.revision + 1;
-      this.persistChanges(current.file, tracked.changes, revision);
-      this.db.exec("COMMIT");
+  mutate<T>(operation: (file: RegistryFile) => T, includeSnapshot = true): SqliteRegistryMutation<T> {
+    for (;;) {
+      this.db.exec("BEGIN");
+      let current: LazyRegistrySnapshot;
+      let changes: RegistryChanges;
+      let result: T;
+      try {
+        current = this.loadLazyInTransaction();
+        result = operation(current.file);
+        changes = current.changes();
+        this.db.exec("COMMIT");
+      } catch (error) {
+        try { this.db.exec("ROLLBACK"); } catch { /* transaction already closed */ }
+        throw error;
+      }
+      const waitStartedAt = performance.now();
+      this.db.exec("BEGIN IMMEDIATE");
+      let revision: number;
+      try {
+        this.onWriterWait?.(performance.now() - waitStartedAt);
+        if (Number(this.meta("revision") ?? 0) !== current.revision) {
+          this.db.exec("ROLLBACK");
+          continue;
+        }
+        revision = current.revision + 1;
+        this.persistChanges(current.file, changes, revision);
+        this.db.exec("COMMIT");
+      } catch (error) {
+        try { this.db.exec("ROLLBACK"); } catch { /* transaction already closed */ }
+        throw error;
+      }
       this.secureFiles();
-      return { result, file: current.file, revision };
-    } catch (error) {
-      try { this.db.exec("ROLLBACK"); } catch { /* transaction already closed */ }
-      throw error;
+      if (includeSnapshot) {
+        const committed = this.snapshot();
+        return { result, file: committed.file, revision: committed.revision };
+      }
+      return { result, file: null, revision };
     }
   }
 
-  replace(file: RegistryFile): SqliteRegistrySnapshot {
+  replace(file: RegistryFile, expectedRevision?: number): SqliteRegistryReplacement {
     this.db.exec("BEGIN IMMEDIATE");
     try {
       const current = this.loadInTransaction();
+      if (expectedRevision !== undefined && current.revision !== expectedRevision) {
+        this.db.exec("ROLLBACK");
+        return { ...current, replaced: false };
+      }
       const revision = current.revision + 1;
       this.persistDiff(current.file, file, revision);
       this.db.exec("COMMIT");
       this.secureFiles();
-      return { file, revision };
+      return { file, revision, replaced: true };
     } catch (error) {
       try { this.db.exec("ROLLBACK"); } catch { /* transaction already closed */ }
       throw error;
@@ -184,7 +186,7 @@ export class SqliteAgentRegistryStore {
       const complete = this.meta("migration_complete");
       if (complete !== "1") {
         this.persistAll(initialSnapshot, 1);
-        this.setMeta("schema_version", "1");
+        this.setMeta("schema_version", "2");
         this.setMeta("migration_complete", "1");
       }
       this.db.exec("COMMIT");
@@ -196,26 +198,104 @@ export class SqliteAgentRegistryStore {
   }
 
   private loadInTransaction(): SqliteRegistrySnapshot {
-    const raw: Record<string, unknown> = { version: 2, entries: {}, receipts: {} };
-    for (const collection of ROW_COLLECTIONS) raw[collection] = {};
-    for (const row of this.db.query<StoredRow, []>("SELECT collection, row_key, value_json FROM registry_rows").all()) {
-      if (!ROW_COLLECTIONS.includes(row.collection as RowCollection)) continue;
-      (raw[row.collection] as Record<string, unknown>)[row.row_key] = JSON.parse(row.value_json);
+    const snapshot = this.loadLazyInTransaction();
+    for (const collection of ROW_COLLECTIONS) void snapshot.file[collection];
+    for (const field of META_FIELDS) void snapshot.file[field];
+    return snapshot;
+  }
+
+  private loadLazyInTransaction(): LazyRegistrySnapshot {
+    const file = this.normalize({ version: 2, entries: {}, receipts: {} });
+    const loadedCollections = new Map<RowCollection, RegistryFile[RowCollection]>();
+    const baselineCollections = new Map<RowCollection, RegistryFile[RowCollection]>();
+    const reorderedCollections = new Set<RowCollection>();
+    for (const collection of ROW_COLLECTIONS) {
+      let loaded = false;
+      let value = file[collection];
+      const load = () => {
+        if (loaded) return;
+        value = {} as typeof value;
+        for (const row of this.db.query<StoredRow, [string]>(
+          "SELECT collection, row_key, value_json, row_order FROM registry_rows WHERE collection = ? ORDER BY row_order",
+        ).all(collection)) {
+          (value as Record<string, unknown>)[row.row_key] = JSON.parse(row.value_json);
+        }
+        loaded = true;
+        loadedCollections.set(collection, value);
+        baselineCollections.set(collection, structuredClone(value));
+      };
+      Object.defineProperty(file, collection, {
+        configurable: true,
+        enumerable: true,
+        get: () => {
+          load();
+          return value;
+        },
+        set: (next: typeof value) => {
+          load();
+          value = next;
+          loadedCollections.set(collection, value);
+          reorderedCollections.add(collection);
+        },
+      });
     }
+    const loadedMeta = new Map<(typeof META_FIELDS)[number], RegistryFile[(typeof META_FIELDS)[number]]>();
+    const baselineMeta = new Map<(typeof META_FIELDS)[number], RegistryFile[(typeof META_FIELDS)[number]]>();
     for (const field of META_FIELDS) {
-      const value = this.meta(field);
-      if (value !== null) raw[field] = JSON.parse(value);
+      let loaded = false;
+      let value = file[field];
+      const load = () => {
+        if (loaded) return;
+        const stored = this.meta(field);
+        if (stored !== null) value = JSON.parse(stored) as typeof value;
+        loaded = true;
+        loadedMeta.set(field, value);
+        baselineMeta.set(field, structuredClone(value));
+      };
+      Object.defineProperty(file, field, {
+        configurable: true,
+        enumerable: true,
+        get: () => {
+          load();
+          return value;
+        },
+        set: (next: typeof value) => {
+          load();
+          value = next;
+          loadedMeta.set(field, value);
+        },
+      });
     }
     return {
-      file: this.normalize(raw),
+      file,
       revision: Number(this.meta("revision") ?? 0),
+      changes: () => {
+        const changes: RegistryChanges = { rows: new Map(), meta: new Set(), order: new Set() };
+        for (const [collection, value] of loadedCollections) {
+          const baseline = baselineCollections.get(collection)! as Record<string, unknown>;
+          const current = value as Record<string, unknown>;
+          const keys = new Set([...Object.keys(baseline), ...Object.keys(current)]);
+          const changed = new Set([...keys].filter((key) => !isDeepStrictEqual(baseline[key], current[key])));
+          if (changed.size > 0) changes.rows.set(collection, changed);
+          if (reorderedCollections.has(collection)) {
+            changes.rows.set(collection, new Set([...Object.keys(baseline), ...Object.keys(current)]));
+            changes.order.add(collection);
+          }
+        }
+        for (const [field, value] of loadedMeta) {
+          if (!isDeepStrictEqual(baselineMeta.get(field), value)) changes.meta.add(field);
+        }
+        return changes;
+      },
     };
   }
 
   private persistAll(file: RegistryFile, revision: number): void {
     this.db.exec("DELETE FROM registry_rows");
     for (const collection of ROW_COLLECTIONS) {
-      for (const [key, value] of Object.entries(file[collection])) this.upsertRow(collection, key, value);
+      for (const [order, [key, value]] of Object.entries(file[collection]).entries()) {
+        this.upsertRow(collection, key, value, order);
+      }
     }
     for (const field of META_FIELDS) this.setMeta(field, JSON.stringify(file[field]));
     this.setMeta("revision", String(revision));
@@ -231,12 +311,13 @@ export class SqliteAgentRegistryStore {
           this.db.query("DELETE FROM registry_rows WHERE collection = ? AND row_key = ?").run(collection, key);
           continue;
         }
-        if (key in previous && JSON.stringify(previous[key]) === JSON.stringify(next[key])) continue;
+        if (key in previous && isDeepStrictEqual(previous[key], next[key])) continue;
         this.upsertRow(collection, key, next[key]);
       }
+      this.persistRowOrder(collection, Object.keys(next));
     }
     for (const field of META_FIELDS) {
-      if (JSON.stringify(before[field]) === JSON.stringify(after[field])) continue;
+      if (isDeepStrictEqual(before[field], after[field])) continue;
       this.setMeta(field, JSON.stringify(after[field]));
     }
     this.setMeta("revision", String(revision));
@@ -250,15 +331,31 @@ export class SqliteAgentRegistryStore {
         else this.db.query("DELETE FROM registry_rows WHERE collection = ? AND row_key = ?").run(collection, key);
       }
     }
+    for (const collection of changes.order) this.persistRowOrder(collection, Object.keys(file[collection]));
     for (const field of changes.meta) this.setMeta(field, JSON.stringify(file[field]));
     this.setMeta("revision", String(revision));
   }
 
-  private upsertRow(collection: RowCollection, key: string, value: unknown): void {
+  private upsertRow(collection: RowCollection, key: string, value: unknown, order?: number): void {
+    if (order !== undefined) {
+      this.db.query(`
+        INSERT INTO registry_rows(collection, row_key, value_json, row_order) VALUES (?, ?, ?, ?)
+        ON CONFLICT(collection, row_key) DO UPDATE SET value_json = excluded.value_json, row_order = excluded.row_order
+      `).run(collection, key, JSON.stringify(value), order);
+      return;
+    }
     this.db.query(`
-      INSERT INTO registry_rows(collection, row_key, value_json) VALUES (?, ?, ?)
+      INSERT INTO registry_rows(collection, row_key, value_json, row_order)
+      SELECT ?, ?, ?, COALESCE(MAX(row_order) + 1, 0) FROM registry_rows WHERE collection = ?
       ON CONFLICT(collection, row_key) DO UPDATE SET value_json = excluded.value_json
-    `).run(collection, key, JSON.stringify(value));
+    `).run(collection, key, JSON.stringify(value), collection);
+  }
+
+  private persistRowOrder(collection: RowCollection, keys: string[]): void {
+    for (const [order, key] of keys.entries()) {
+      this.db.query("UPDATE registry_rows SET row_order = ? WHERE collection = ? AND row_key = ?")
+        .run(order, collection, key);
+    }
   }
 
   private meta(key: string): string | null {

--- a/src/lib/agent/sqliteRegistryStore.ts
+++ b/src/lib/agent/sqliteRegistryStore.ts
@@ -1,0 +1,280 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import { Database } from "bun:sqlite";
+
+import type { RegistryFile } from "./registry";
+
+const ROW_COLLECTIONS = [
+  "entries",
+  "receipts",
+  "lineageEdges",
+  "memberships",
+  "conversations",
+  "conversationAliases",
+  "migrationIntents",
+  "heldDeliveries",
+  "pendingSuccessorCleanups",
+] as const satisfies ReadonlyArray<keyof RegistryFile>;
+
+const META_FIELDS = [
+  "importedResumePanes",
+  "legacyResumePanes",
+  "conversationRevision",
+  "engineRouting",
+  "autoBalance",
+  "quotaObservations",
+] as const satisfies ReadonlyArray<keyof RegistryFile>;
+
+type RowCollection = (typeof ROW_COLLECTIONS)[number];
+type StoredRow = { collection: string; row_key: string; value_json: string };
+type MetaRow = { key: string; value: string };
+
+interface RegistryChanges {
+  rows: Map<RowCollection, Set<string>>;
+  meta: Set<(typeof META_FIELDS)[number]>;
+}
+
+function trackedRegistry(file: RegistryFile): { file: RegistryFile; changes: RegistryChanges } {
+  const changes: RegistryChanges = { rows: new Map(), meta: new Set() };
+  const proxies = new WeakMap<object, object>();
+  const rowCollections = new Set<string>(ROW_COLLECTIONS);
+  const metaFields = new Set<string>(META_FIELDS);
+  const markRow = (collection: RowCollection, key: PropertyKey) => {
+    if (typeof key !== "string") return;
+    let keys = changes.rows.get(collection);
+    if (!keys) {
+      keys = new Set();
+      changes.rows.set(collection, keys);
+    }
+    keys.add(key);
+  };
+  const wrap = (value: unknown, path: string[]): unknown => {
+    if (!value || typeof value !== "object") return value;
+    const cached = proxies.get(value);
+    if (cached) return cached;
+    const proxy = new Proxy(value, {
+      get(target, property, receiver) {
+        return wrap(Reflect.get(target, property, receiver), [...path, String(property)]);
+      },
+      set(target, property, next, receiver) {
+        const root = path[0] ?? String(property);
+        if (rowCollections.has(root)) {
+          if (path.length === 0) {
+            const previousRows = Reflect.get(target, property, receiver) as Record<string, unknown> | undefined;
+            for (const key of Object.keys(previousRows ?? {})) markRow(root as RowCollection, key);
+            if (next && typeof next === "object") {
+              for (const key of Object.keys(next as object)) markRow(root as RowCollection, key);
+            }
+          } else {
+            markRow(root as RowCollection, path.length === 1 ? property : path[1]!);
+          }
+        } else if (metaFields.has(root)) {
+          changes.meta.add(root as (typeof META_FIELDS)[number]);
+        }
+        return Reflect.set(target, property, next, receiver);
+      },
+      deleteProperty(target, property) {
+        const root = path[0] ?? String(property);
+        if (rowCollections.has(root)) {
+          if (path.length === 0) {
+            const previousRows = Reflect.get(target, property) as Record<string, unknown> | undefined;
+            for (const key of Object.keys(previousRows ?? {})) markRow(root as RowCollection, key);
+          } else {
+            markRow(root as RowCollection, path.length === 1 ? property : path[1]!);
+          }
+        } else if (metaFields.has(root)) {
+          changes.meta.add(root as (typeof META_FIELDS)[number]);
+        }
+        return Reflect.deleteProperty(target, property);
+      },
+    });
+    proxies.set(value, proxy);
+    return proxy;
+  };
+  return { file: wrap(file, []) as RegistryFile, changes };
+}
+
+export interface SqliteRegistrySnapshot {
+  file: RegistryFile;
+  revision: number;
+}
+
+export interface SqliteRegistryMutation<T> extends SqliteRegistrySnapshot {
+  result: T;
+}
+
+export interface SqliteRegistryStoreOptions {
+  initialSnapshot: RegistryFile;
+  normalize(value: unknown): RegistryFile;
+}
+
+export class SqliteAgentRegistryStore {
+  private readonly db: Database;
+  private readonly normalize: (value: unknown) => RegistryFile;
+
+  constructor(readonly filename: string, options: SqliteRegistryStoreOptions) {
+    fs.mkdirSync(path.dirname(filename), { recursive: true, mode: 0o700 });
+    this.db = new Database(filename, { create: true, strict: true });
+    this.normalize = options.normalize;
+    this.db.exec("PRAGMA busy_timeout = 5000; PRAGMA journal_mode = WAL; PRAGMA synchronous = FULL; PRAGMA foreign_keys = ON; PRAGMA auto_vacuum = INCREMENTAL;");
+    this.db.exec(`
+      CREATE TABLE IF NOT EXISTS registry_meta (
+        key TEXT PRIMARY KEY,
+        value TEXT NOT NULL
+      );
+      CREATE TABLE IF NOT EXISTS registry_rows (
+        collection TEXT NOT NULL,
+        row_key TEXT NOT NULL,
+        value_json TEXT NOT NULL,
+        PRIMARY KEY(collection, row_key)
+      );
+    `);
+    this.secureFiles();
+    this.importFirstBoot(options.initialSnapshot);
+  }
+
+  snapshot(): SqliteRegistrySnapshot {
+    this.db.exec("BEGIN");
+    try {
+      const snapshot = this.loadInTransaction();
+      this.db.exec("COMMIT");
+      return snapshot;
+    } catch (error) {
+      try { this.db.exec("ROLLBACK"); } catch { /* transaction already closed */ }
+      throw error;
+    }
+  }
+
+  mutate<T>(operation: (file: RegistryFile) => T): SqliteRegistryMutation<T> {
+    this.db.exec("BEGIN IMMEDIATE");
+    try {
+      const current = this.loadInTransaction();
+      const tracked = trackedRegistry(current.file);
+      const result = operation(tracked.file);
+      const revision = current.revision + 1;
+      this.persistChanges(current.file, tracked.changes, revision);
+      this.db.exec("COMMIT");
+      this.secureFiles();
+      return { result, file: current.file, revision };
+    } catch (error) {
+      try { this.db.exec("ROLLBACK"); } catch { /* transaction already closed */ }
+      throw error;
+    }
+  }
+
+  replace(file: RegistryFile): SqliteRegistrySnapshot {
+    this.db.exec("BEGIN IMMEDIATE");
+    try {
+      const current = this.loadInTransaction();
+      const revision = current.revision + 1;
+      this.persistDiff(current.file, file, revision);
+      this.db.exec("COMMIT");
+      this.secureFiles();
+      return { file, revision };
+    } catch (error) {
+      try { this.db.exec("ROLLBACK"); } catch { /* transaction already closed */ }
+      throw error;
+    }
+  }
+
+  private importFirstBoot(initialSnapshot: RegistryFile): void {
+    this.db.exec("BEGIN IMMEDIATE");
+    try {
+      const complete = this.meta("migration_complete");
+      if (complete !== "1") {
+        this.persistAll(initialSnapshot, 1);
+        this.setMeta("schema_version", "1");
+        this.setMeta("migration_complete", "1");
+      }
+      this.db.exec("COMMIT");
+      this.secureFiles();
+    } catch (error) {
+      try { this.db.exec("ROLLBACK"); } catch { /* transaction already closed */ }
+      throw error;
+    }
+  }
+
+  private loadInTransaction(): SqliteRegistrySnapshot {
+    const raw: Record<string, unknown> = { version: 2, entries: {}, receipts: {} };
+    for (const collection of ROW_COLLECTIONS) raw[collection] = {};
+    for (const row of this.db.query<StoredRow, []>("SELECT collection, row_key, value_json FROM registry_rows").all()) {
+      if (!ROW_COLLECTIONS.includes(row.collection as RowCollection)) continue;
+      (raw[row.collection] as Record<string, unknown>)[row.row_key] = JSON.parse(row.value_json);
+    }
+    for (const field of META_FIELDS) {
+      const value = this.meta(field);
+      if (value !== null) raw[field] = JSON.parse(value);
+    }
+    return {
+      file: this.normalize(raw),
+      revision: Number(this.meta("revision") ?? 0),
+    };
+  }
+
+  private persistAll(file: RegistryFile, revision: number): void {
+    this.db.exec("DELETE FROM registry_rows");
+    for (const collection of ROW_COLLECTIONS) {
+      for (const [key, value] of Object.entries(file[collection])) this.upsertRow(collection, key, value);
+    }
+    for (const field of META_FIELDS) this.setMeta(field, JSON.stringify(file[field]));
+    this.setMeta("revision", String(revision));
+  }
+
+  private persistDiff(before: RegistryFile, after: RegistryFile, revision: number): void {
+    for (const collection of ROW_COLLECTIONS) {
+      const previous = before[collection] as Record<string, unknown>;
+      const next = after[collection] as Record<string, unknown>;
+      const keys = new Set([...Object.keys(previous), ...Object.keys(next)]);
+      for (const key of keys) {
+        if (!(key in next)) {
+          this.db.query("DELETE FROM registry_rows WHERE collection = ? AND row_key = ?").run(collection, key);
+          continue;
+        }
+        if (key in previous && JSON.stringify(previous[key]) === JSON.stringify(next[key])) continue;
+        this.upsertRow(collection, key, next[key]);
+      }
+    }
+    for (const field of META_FIELDS) {
+      if (JSON.stringify(before[field]) === JSON.stringify(after[field])) continue;
+      this.setMeta(field, JSON.stringify(after[field]));
+    }
+    this.setMeta("revision", String(revision));
+  }
+
+  private persistChanges(file: RegistryFile, changes: RegistryChanges, revision: number): void {
+    for (const [collection, keys] of changes.rows) {
+      const rows = file[collection] as Record<string, unknown>;
+      for (const key of keys) {
+        if (key in rows) this.upsertRow(collection, key, rows[key]);
+        else this.db.query("DELETE FROM registry_rows WHERE collection = ? AND row_key = ?").run(collection, key);
+      }
+    }
+    for (const field of changes.meta) this.setMeta(field, JSON.stringify(file[field]));
+    this.setMeta("revision", String(revision));
+  }
+
+  private upsertRow(collection: RowCollection, key: string, value: unknown): void {
+    this.db.query(`
+      INSERT INTO registry_rows(collection, row_key, value_json) VALUES (?, ?, ?)
+      ON CONFLICT(collection, row_key) DO UPDATE SET value_json = excluded.value_json
+    `).run(collection, key, JSON.stringify(value));
+  }
+
+  private meta(key: string): string | null {
+    return this.db.query<MetaRow, [string]>("SELECT key, value FROM registry_meta WHERE key = ?").get(key)?.value ?? null;
+  }
+
+  private setMeta(key: string, value: string): void {
+    this.db.query(`
+      INSERT INTO registry_meta(key, value) VALUES (?, ?)
+      ON CONFLICT(key) DO UPDATE SET value = excluded.value
+    `).run(key, value);
+  }
+
+  private secureFiles(): void {
+    for (const candidate of [this.filename, `${this.filename}-wal`, `${this.filename}-shm`]) {
+      if (fs.existsSync(candidate)) fs.chmodSync(candidate, 0o600);
+    }
+  }
+}

--- a/src/runtime-host/candidateContainer.test.ts
+++ b/src/runtime-host/candidateContainer.test.ts
@@ -200,9 +200,11 @@ test("candidate executes the Compose guard with its runtime launch grant", () =>
   const next = path.join(sandbox, "node_modules", ".bin", "next");
   fs.mkdirSync(path.dirname(next), { recursive: true });
   fs.writeFileSync(next, "#!/bin/sh\nexit 0\n", { mode: 0o755 });
+  const bunContainer = path.join(sandbox, "bun-container");
+  fs.writeFileSync(bunContainer, "#!/bin/sh\nshift\nexec \"$@\"\n", { mode: 0o755 });
   const result = Bun.spawnSync(command, {
     cwd: sandbox,
-    env: { ...process.env, ...environmentFromArgs(args) },
+    env: { ...process.env, ...environmentFromArgs(args), PATH: `${sandbox}:${process.env.PATH ?? ""}` },
     stdout: "pipe",
     stderr: "pipe",
   });


### PR DESCRIPTION
## Summary

- add a row-oriented `bun:sqlite` registry store with WAL, FULL synchronization, a busy timeout, transactional first-boot JSON import, and touched-row updates
- add gated `off`, `dual-write`, `read`, and `sqlite` rollout phases with parity checks, revisioned JSON mirrors, and a documented rollback sequence
- preserve the existing registry interface and lease/adoption semantics, including durable memberships from #199 and spawn capability digests from #220
- bypass whole-registry lock recovery, backoff, temp cleanup, startup compaction, and JSON serialization on the SQLite-only operation path

## DATA evidence

- two independent writer processes preserve all 80 overlapping writes with no whole-registry lock file
- WAL readers remain available during an open writer transaction
- a process exit inside a transaction rolls back cleanly; a post-commit exit refreshes the rollback mirror on restart
- structured-host writer epochs remain fenced across restart adoption
- the production-shaped 5,000-receipt, ten-lane gate records 120 operation samples; the final full-suite run reported JSON p95 868.6 ms and SQLite p95 1057.9 ms, with whole-file lock wait removed from the SQLite path

## Gates

- `bunx tsc --noEmit`
- `bun test` — 2,583 passed
- `bun test src/lib/routeExports.test.ts` — 2 passed
- ten unchanged registry lifecycle tests executed directly with `LLV_AGENT_REGISTRY_SQLITE=sqlite` — 10 passed

Closes #187