### PR TITLE
Favorites: pinned scheme row, crown on the window's top edge, golder crown, waiting-list section (#224)

### DIFF
--- a/src/components/BranchPane.tsx
+++ b/src/components/BranchPane.tsx
@@ -14,7 +14,7 @@ import { conversationIdentity } from "@/lib/accounts/identity";
 
 import { registerLinkTarget } from "./AgentLink";
 import { DeleteFileButton } from "./DeleteFileButton";
-import { FavoriteCrown } from "./FavoriteCrown";
+import { FavoriteCrown, FavoriteCrownMarker } from "./FavoriteCrown";
 import { MigrationDivider, MigrationRibbon } from "./MigrationRibbon";
 import { EffortPills } from "./EffortPills";
 import { AgentRuntimeControls } from "./AgentRuntimeControls";
@@ -205,6 +205,9 @@ export function BranchPane({ file, tasks, isRoot, onClose, dragHandle, noCompose
       className={`relative flex min-h-0 min-w-0 flex-1 ${tone.glow ? "pane-attention" : ""}`}
       style={tone.glow ? ({ "--pane-glow": tone.glow } as React.CSSProperties) : undefined}
     >
+      {/* The favorited-state crown perched on the top edge (issue #224); lives on
+          this unclipped wrapper so it can overhang the card frame from above. */}
+      {showFavorite ? <FavoriteCrownMarker id={cardId} /> : null}
       <section
         ref={paneRef}
         /* Text inside the column must stay selectable: the canvas drag-pan skips

--- a/src/components/FavoriteCrown.tsx
+++ b/src/components/FavoriteCrown.tsx
@@ -63,10 +63,35 @@ export function FavoriteCrown({
         aria-hidden
         className={`${touch ? "h-5 w-5" : "h-4 w-4"} transition-[color,fill,filter,transform] duration-200 ${
           favorited
-            ? "fill-warning text-warning drop-shadow-[0_0_5px_color-mix(in_srgb,var(--color-warning)_65%,transparent)]"
-            : "text-muted [stroke-dasharray:2_3] group-hover/crown:fill-warning group-hover/crown:text-warning group-hover/crown:[stroke-dasharray:0]"
+            ? "fill-crown text-crown drop-shadow-[0_0_5px_color-mix(in_srgb,var(--color-crown)_65%,transparent)]"
+            : "text-muted [stroke-dasharray:2_3] group-hover/crown:fill-crown group-hover/crown:text-crown group-hover/crown:[stroke-dasharray:0]"
         }`}
       />
     </button>
+  );
+}
+
+/**
+ * The favorited-state marker (issue #224): a gold crown that sits ON the
+ * window's top-right edge, overlapping the frame from above like a crown worn by
+ * the card. Purely decorative — the header {@link FavoriteCrown} owns the toggle
+ * — so it is `aria-hidden` and click-through. Renders nothing unless this id is
+ * favorited (or outside a `FavoritesProvider`), so an unfavorited card is clean.
+ *
+ * Mount on the card's UNCLIPPED outer wrapper: the negative top offset must
+ * overhang the pane's rounded frame, which its own `overflow-hidden` section
+ * would otherwise cut.
+ */
+export function FavoriteCrownMarker({ id }: { id: string }) {
+  const favorites = useFavorites();
+  if (!favorites?.has(id)) return null;
+  return (
+    <span
+      aria-hidden
+      data-favorite-marker="on"
+      className="favorite-crown-marker pointer-events-none absolute -top-2.5 right-3 z-[3] inline-flex h-5 w-5 items-center justify-center rounded-full"
+    >
+      <Crown className="h-4 w-4 fill-crown text-crown drop-shadow-[0_1px_2px_color-mix(in_srgb,var(--color-crown)_55%,transparent)]" aria-hidden />
+    </span>
   );
 }

--- a/src/components/ProjectDashboard.tsx
+++ b/src/components/ProjectDashboard.tsx
@@ -5,8 +5,8 @@ import { useEffect, useMemo, useRef, useState } from "react";
 
 import { useBoardActionHistory } from "@/hooks/useBoardActionHistory";
 import { queueColumnOpen, useBoardState } from "@/hooks/useBoardState";
-import { conversationIdentity } from "@/lib/accounts/identity";
 import { FavoritesProvider, type FavoritesApi } from "./favorites/FavoritesContext";
+import { resolveFavoriteRows } from "./favorites/favoriteRows";
 import { useIsMobile } from "@/hooks/useIsMobile";
 import { viewBus } from "@/hooks/viewPresenceBus";
 import type { Flow } from "@/lib/flows/types";
@@ -327,6 +327,11 @@ export function ProjectDashboard({
      card through context, and the resolved rows (one live file per favorited
      id, freshest generation) the docked panel lists. */
   const favoriteIds = board.prefs.favorites;
+  /* The crowned identities as a membership set: the scheme layout lifts these
+     roots into the pinned top band (issue #224), and the set identity only moves
+     when membership does, so a poll that returns the same favorites never
+     re-lays-out the board. */
+  const favoriteIdSet = useMemo<ReadonlySet<string>>(() => new Set(favoriteIds), [favoriteIds]);
   const favoritesApi = useMemo<FavoritesApi>(
     () => ({
       has: (id) => favoriteIds.includes(id),
@@ -338,20 +343,7 @@ export function ProjectDashboard({
   /* One row per favorited id that still has a scanned transcript, keeping the
      freshest generation so a resumed conversation lists once under its current
      file. Sorted freshest-first for the panel. */
-  const favoriteRows = useMemo(() => {
-    if (favoriteIds.length === 0) return [] as { id: string; file: FileEntry; project: string }[];
-    const favoriteSet = new Set(favoriteIds);
-    const byId = new Map<string, FileEntry>();
-    for (const file of files) {
-      const id = conversationIdentity(file);
-      if (!favoriteSet.has(id)) continue;
-      const existing = byId.get(id);
-      if (!existing || file.mtime > existing.mtime) byId.set(id, file);
-    }
-    return [...byId.entries()]
-      .map(([id, file]) => ({ id, file, project: projectKey(file) }))
-      .sort((a, b) => b.file.mtime - a.file.mtime);
-  }, [files, favoriteIds]);
+  const favoriteRows = useMemo(() => resolveFavoriteRows(files, favoriteIds), [files, favoriteIds]);
   const [drafts, setDrafts] = useState<string[]>([]);
   const [pendingRestoredHandoffs, setPendingRestoredHandoffs] = useState<Set<string>>(() => new Set());
   /* The phone focus view reports its currently-focused conversation here so the
@@ -1226,6 +1218,7 @@ export function ProjectDashboard({
               workerStacks={workerStacks}
               tasks={hasNodes ? projectTasks : []}
               drafts={hasNodes ? visibleDrafts : []}
+              favorites={favoriteIdSet}
               loaded={loaded}
               focus={highlight}
               onSelect={openSwitchboardFile}
@@ -1266,6 +1259,7 @@ export function ProjectDashboard({
                 tasks={hasNodes ? projectTasks : []}
                 workerStacks={workerStacks}
                 drafts={hasNodes ? visibleDrafts : []}
+                favorites={favoriteIdSet}
                 focus={highlight}
                 attentionPaths={attentionPaths}
                 onSelect={openSwitchboardFile}

--- a/src/components/Viewer.tsx
+++ b/src/components/Viewer.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Filter, TriangleAlert, X } from "lucide-react";
+import { Crown, Filter, TriangleAlert, X } from "lucide-react";
 import { useCallback, useEffect, useMemo, useReducer, useRef, useState } from "react";
 
 import { formatConversationHash, parseConversationHash, resolveConversationTarget, withoutArchivedPredecessors, type ConversationHash } from "@/lib/accounts/identity";
@@ -8,6 +8,7 @@ import { useAgentChimes } from "@/hooks/useAgentChimes";
 import { useArchivedProjects } from "@/hooks/useArchivedProjects";
 import { useEffectiveFlows } from "@/components/flows/flowModel";
 import { useFiles } from "@/hooks/useFiles";
+import { useBoardState } from "@/hooks/useBoardState";
 import { useIsMobile } from "@/hooks/useIsMobile";
 import { useViewPresence } from "@/hooks/useViewPresence";
 import { OVERVIEW_CONTEXT, OVERVIEW_SLICE, viewBus } from "@/hooks/viewPresenceBus";
@@ -16,13 +17,14 @@ import type { FileEntry } from "@/lib/types";
 
 import { attentionId, buildAttentionQueue, nextAttention, STALLED_ATTENTION_TTL, type AttentionItem } from "./attention";
 import { ConnectionPill } from "./ConnectionPill";
+import { resolveFavoriteRows, type FavoriteRow } from "./favorites/favoriteRows";
 import { OverviewBoard } from "./OverviewBoard";
 import { ProjectDashboard, queueColumnOpen } from "./ProjectDashboard";
 import { isChildConversation, OVERVIEW, projectKey } from "./projectModel";
 import { ProjectRail } from "./ProjectRail";
 import { SupervisorHealthAlert } from "./SupervisorHealthAlert";
 import { DeploymentStatusPill } from "./runtime/DeploymentStatusPill";
-import { cleanTitle, fmtAge } from "./utils";
+import { activityDot, cleanTitle, fmtAge } from "./utils";
 
 const PROJECT_KEY = "llvProject";
 
@@ -280,6 +282,16 @@ export function Viewer() {
   const [queueOpen, setQueueOpen] = useState(false);
   const queueRef = useRef<HTMLDivElement | null>(null);
 
+  /* Crown favorites pinned atop the «Чекають» popover (issue #224): the same
+     durable board prefs the dashboard reads, scoped to the current project so
+     the section mirrors the pinned scheme row. The overview has no board, so it
+     lists nothing. */
+  const favoritesBoard = useBoardState(project === OVERVIEW ? null : project);
+  const favoriteRows = useMemo(
+    () => (project === OVERVIEW ? [] : resolveFavoriteRows(files, favoritesBoard.prefs.favorites).filter((row) => row.project === project)),
+    [files, favoritesBoard.prefs.favorites, project],
+  );
+
   useEffect(() => {
     document.title = queue.length ? `(${queue.length}) Agent Log Viewer` : "Agent Log Viewer";
   }, [queue.length]);
@@ -390,6 +402,17 @@ export function Viewer() {
     [project, selectProject, requestFocus],
   );
 
+  /* A crowned row in the popover focuses its conversation, switching project
+     first if the favorite lives elsewhere — same hand-off as an attention jump. */
+  const openFavorite = useCallback(
+    (row: FavoriteRow) => {
+      setQueueOpen(false);
+      if (row.project !== project) selectProject(row.project);
+      requestFocus(row.file.path);
+    },
+    [project, selectProject, requestFocus],
+  );
+
   useEffect(() => {
     /* Toast fires on hard-blocked signals only — a stalled id must never enter
        this seen-set, so the guard narrows before the shared derivation. */
@@ -459,6 +482,40 @@ export function Viewer() {
             isMobile ? "fixed inset-x-3 top-12" : "absolute right-0 top-[calc(100%+6px)] w-[340px] max-w-[calc(100vw-2rem)]"
           } z-50 max-h-[60vh] overflow-y-auto rounded-[10px] border border-border bg-card p-1.5 shadow-1`}
         >
+          {/* Crowned conversations pinned at the top, mirroring the scheme's
+              favorites row (issue #224). */}
+          {favoriteRows.length ? (
+            <div className="mb-1 border-b border-border pb-1">
+              <div className="flex items-center gap-1 px-2.5 pb-0.5 pt-1.5 text-label font-semibold text-secondary">
+                <Crown className="h-3 w-3 fill-crown text-crown" aria-hidden />
+                {t("favorites.sectionTitle")}
+              </div>
+              {favoriteRows.map((row) => (
+                <div key={row.id} className="flex items-center gap-1 rounded-[8px] hover:bg-canvas">
+                  <button
+                    type="button"
+                    className="flex min-w-0 flex-1 items-center gap-1.5 rounded-[8px] px-2.5 py-2 text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40"
+                    title={t("favorites.focusTitle", { title: cleanTitle(row.file.title, 60) })}
+                    onClick={() => openFavorite(row)}
+                  >
+                    <span className={`h-2 w-2 shrink-0 rounded-full ${activityDot(row.file.activity)}`} aria-hidden />
+                    <span className="min-w-0 flex-1 truncate text-[12px] font-semibold text-primary">
+                      {cleanTitle(row.file.title, 90)}
+                    </span>
+                  </button>
+                  <button
+                    type="button"
+                    className="mr-1 inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-[6px] text-crown hover:bg-crown-soft focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40"
+                    aria-label={t("branch.unfavorite")}
+                    title={t("branch.unfavorite")}
+                    onClick={() => favoritesBoard.setFavorite(row.id, false)}
+                  >
+                    <Crown className="h-3.5 w-3.5 fill-crown" aria-hidden />
+                  </button>
+                </div>
+              ))}
+            </div>
+          ) : null}
           <div className="px-2.5 pb-1 pt-1.5 text-label font-semibold text-secondary">
             {t("attention.popoverTitle")}
           </div>

--- a/src/components/favorites/favoriteRows.ts
+++ b/src/components/favorites/favoriteRows.ts
@@ -1,0 +1,34 @@
+import { conversationIdentity } from "@/lib/accounts/identity";
+import type { FileEntry } from "@/lib/types";
+
+import { projectKey } from "@/components/projectModel";
+
+/** A favorited conversation resolved to its freshest scanned generation. */
+export interface FavoriteRow {
+  /** Durable conversation identity (`conversationIdentity`). */
+  id: string;
+  file: FileEntry;
+  project: string;
+}
+
+/**
+ * Resolve the crowned ids to one row each — the freshest scanned generation of
+ * that conversation, so a resumed chat lists once under its current file — and
+ * sort freshest-first. Shared by the docked task panel, the mobile task sheet,
+ * and the attention («Чекають») popover so every favorites surface mirrors the
+ * pinned scheme row (issues #185, #224).
+ */
+export function resolveFavoriteRows(files: FileEntry[], favoriteIds: readonly string[]): FavoriteRow[] {
+  if (favoriteIds.length === 0) return [];
+  const favoriteSet = new Set(favoriteIds);
+  const byId = new Map<string, FileEntry>();
+  for (const file of files) {
+    const id = conversationIdentity(file);
+    if (!favoriteSet.has(id)) continue;
+    const existing = byId.get(id);
+    if (!existing || file.mtime > existing.mtime) byId.set(id, file);
+  }
+  return [...byId.entries()]
+    .map(([id, file]) => ({ id, file, project: projectKey(file) }))
+    .sort((a, b) => b.file.mtime - a.file.mtime);
+}

--- a/src/components/mobile/MobileFocusView.tsx
+++ b/src/components/mobile/MobileFocusView.tsx
@@ -65,6 +65,9 @@ interface Props {
   tasks: BoardTask[];
   /** Ids of not-yet-spawned conversation drafts, focusable like nodes. */
   drafts: string[];
+  /** Durable identities the user has crowned (issue #224): their roots lift into
+      the pinned top band on the map, mirroring the desktop scheme. */
+  favorites?: ReadonlySet<string>;
   loaded: boolean;
   /** Path an opener wants on screen (same signal the scheme camera gets). */
   focus: string | null;
@@ -98,7 +101,7 @@ export function pipelinesToDock(groups: SchemeGroup[]): Pipeline[] {
  * data the scheme draws — nothing on the diagram is unreachable, it is just
  * shown one pane at a time.
  */
-export function MobileFocusView({ project, groups, manual, files, flows, pipelines, surfacePipelines = [], workerStacks = [], tasks, drafts, loaded, focus, onSelect, onClose, onDraftClose, onDraftSpawned, onActiveChange, taskSheetNonce = 0 }: Props) {
+export function MobileFocusView({ project, groups, manual, files, flows, pipelines, surfacePipelines = [], workerStacks = [], tasks, drafts, favorites, loaded, focus, onSelect, onClose, onDraftClose, onDraftSpawned, onActiveChange, taskSheetNonce = 0 }: Props) {
   const { t } = useLocale();
   const [focusPath, setFocusPath] = useState<string | null>(null);
   const [mapOpen, setMapOpen] = useState(false);
@@ -122,7 +125,7 @@ export function MobileFocusView({ project, groups, manual, files, flows, pipelin
     setChipFade((prev) => (prev.left === left && prev.right === right ? prev : { left, right }));
   }, []);
 
-  const layout = useMemo(() => buildSchemeLayout(groups, manual, files, flows, drafts, pipelines, surfacePipelines), [groups, manual, files, flows, drafts, pipelines, surfacePipelines]);
+  const layout = useMemo(() => buildSchemeLayout(groups, manual, files, flows, drafts, pipelines, surfacePipelines, favorites), [groups, manual, files, flows, drafts, pipelines, surfacePipelines, favorites]);
   /* Scheme order (depth-first, groups left to right) becomes the strip order,
      so chips and the map agree on what "next" means. */
   const entries = useMemo<Entry[]>(

--- a/src/components/scheme/SchemeBoard.tsx
+++ b/src/components/scheme/SchemeBoard.tsx
@@ -78,6 +78,9 @@ interface Props {
   surfacePipelines?: Pipeline[];
   /** Ids of not-yet-spawned conversation drafts drawn as full panes. */
   drafts: string[];
+  /** Durable identities the user has crowned (issue #224): their roots lift into
+      a band pinned at the top of the scheme. */
+  favorites?: ReadonlySet<string>;
   /** Path to glide the camera to and ring briefly (set by openers). */
   focus: string | null;
   /** Path to ring without moving the camera, used by the mobile full-map overlay. */
@@ -159,6 +162,7 @@ export function SchemeBoard({
   workerStacks = [],
   surfacePipelines = [],
   drafts,
+  favorites,
   focus,
   ring,
   attentionPaths,
@@ -192,7 +196,7 @@ export function SchemeBoard({
   }, [focus]);
   /* eslint-enable react-hooks/set-state-in-effect */
 
-  const layout = useMemo(() => buildSchemeLayout(groups, manual, files, flows, drafts, pipelines, surfacePipelines), [groups, manual, files, flows, drafts, pipelines, surfacePipelines]);
+  const layout = useMemo(() => buildSchemeLayout(groups, manual, files, flows, drafts, pipelines, surfacePipelines, favorites), [groups, manual, files, flows, drafts, pipelines, surfacePipelines, favorites]);
 
   /* Selection keys are transcript paths, so the 10s poll relayout keeps the
      set for free; nodes that left the board are pruned out of the state

--- a/src/components/scheme/layout.test.ts
+++ b/src/components/scheme/layout.test.ts
@@ -452,3 +452,54 @@ describe("pipeline stage placeholder slots (issue #196)", () => {
     expect(local.slots.length).toBeGreaterThan(0);
   });
 });
+
+describe("buildSchemeLayout favorites band (issue #224)", () => {
+  const soloGroup = (path: string, mtime: number): { group: BranchGroup; file: FileEntry } => {
+    const file = entry({ path, mtime, activity: "live" });
+    return {
+      file,
+      group: { key: path, columns: [{ file, tasks: [] }], returnable: [], finished: [], smt: mtime, orphanTask: false },
+    };
+  };
+
+  test("crowned roots pin to the top band above everything else, freshest-first", () => {
+    const a = soloGroup("/fav-a", 3_000);
+    const b = soloGroup("/fav-b", 5_000);
+    const c = soloGroup("/plain-c", 4_000);
+    const files = [a.file, b.file, c.file];
+    const favorites = new Set(["/fav-a", "/fav-b"]);
+    const layout = buildSchemeLayout([a.group, b.group, c.group], [], files, [], [], [], [], favorites);
+
+    const nodeFor = (path: string) => layout.nodes.find((node) => node.file.path === path)!;
+    const favA = nodeFor("/fav-a");
+    const favB = nodeFor("/fav-b");
+    const plainC = nodeFor("/plain-c");
+
+    /* Both favorites share the top row; the plain group starts strictly below. */
+    expect(favA.y).toBe(favB.y);
+    expect(plainC.y).toBeGreaterThan(favA.y + favA.h);
+    /* Within the band, the freshest (b, mtime 5000) sits left of the older (a). */
+    expect(favB.x).toBeLessThan(favA.x);
+  });
+
+  test("no favorites lays the board out in a single band, unchanged", () => {
+    const a = soloGroup("/a", 3_000);
+    const b = soloGroup("/b", 5_000);
+    const files = [a.file, b.file];
+    const base = buildSchemeLayout([a.group, b.group], [], files, [], [], [], []);
+    const withEmpty = buildSchemeLayout([a.group, b.group], [], files, [], [], [], [], new Set());
+    const topY = (layout: ReturnType<typeof buildSchemeLayout>, path: string) =>
+      layout.nodes.find((node) => node.file.path === path)!.y;
+    expect(topY(base, "/a")).toBe(topY(base, "/b"));
+    expect(topY(withEmpty, "/a")).toBe(topY(base, "/a"));
+  });
+
+  test("a favorited manual root lifts into the band too", () => {
+    const fav = entry({ path: "/manual-fav", mtime: 9_000, activity: "live" });
+    const plain = soloGroup("/plain", 1_000);
+    const layout = buildSchemeLayout([plain.group], [fav], [fav, plain.file], [], [], [], [], new Set(["/manual-fav"]));
+    const favNode = layout.nodes.find((node) => node.file.path === "/manual-fav")!;
+    const plainNode = layout.nodes.find((node) => node.file.path === "/plain")!;
+    expect(plainNode.y).toBeGreaterThan(favNode.y + favNode.h);
+  });
+});

--- a/src/components/scheme/layout.ts
+++ b/src/components/scheme/layout.ts
@@ -20,6 +20,7 @@ import {
 } from "./agentLinks";
 import { type BranchGroup, descendantsOf, isChildConversation, kidsIndex } from "@/components/projectModel";
 import { cleanTitle, engineColor } from "@/components/utils";
+import { conversationIdentity } from "@/lib/accounts/identity";
 
 /* World geometry of the scheme canvas, in unscaled pixels. */
 export const NODE_W = 600;
@@ -35,6 +36,9 @@ const GAP_Y = 130;
 export const INDENT = 64;
 const GROUP_GAP = 150;
 const PAD = 100;
+/* Vertical corridor between the pinned favorites band and the rest of the board
+   (issue #224): wider than GAP_Y so the crowned row reads as its own region. */
+const FAV_BAND_GAP = 220;
 /* Corridor between an implementer and its reviewer deck: wide enough for the
    two cycle arcs and the ⟳ hub between the cards. Exported so the flow strip
    can span the whole pair. */
@@ -221,6 +225,11 @@ export function buildSchemeLayout(
       `deriveGroups` did not already frame gets a docked placeholder group
       carrying its plan, so a provisioning pipeline is never surfaceless. */
   surfacePipelines: Pipeline[] = [],
+  /** Durable identities (`conversationIdentity`) the user has crowned (issue
+      #224). A group/manual root whose identity is favorited is lifted into a
+      dedicated band PINNED at the very top of the scheme, ordered within the band
+      by activity recency; everything else flows below. Empty ⇒ prior behavior. */
+  favorites: ReadonlySet<string> = new Set(),
 ): SchemeLayout {
   const byAll = new Map(files.map((file) => [file.path, file]));
   const kids = kidsIndex(files);
@@ -331,6 +340,7 @@ export function buildSchemeLayout(
     stackFor: Map<string, FileEntry[]>,
     deck: Map<string, FileEntry[]>,
     rootPath: string,
+    bandTop: number,
   ) => {
     const place = (col: { file: FileEntry; tasks: FileEntry[] }, x: number, y: number, depth: number): number => {
       const h = depth === 0 ? ROOT_H : CHILD_H;
@@ -420,12 +430,12 @@ export function buildSchemeLayout(
       const subtree = used > 0 ? Math.max(NODE_W, INDENT + used) : NODE_W;
       return Math.max(subtree, flow ? NODE_W + LOOP_GAP + NODE_W : NODE_W);
     };
-    return place(top, cursor, PAD, 0);
+    return place(top, cursor, bandTop, 0);
   };
 
-  for (const group of groups) {
+  const placeGroup = (group: BranchGroup, bandTop: number) => {
     const cols = group.columns;
-    if (!cols.length) continue;
+    if (!cols.length) return;
     const topPath = cols[0]!.file.path;
     const inGroup = new Set(cols.map((col) => col.file.path));
 
@@ -467,10 +477,10 @@ export function buildSchemeLayout(
       }
     }
     const deck = new Map<string, FileEntry[]>([[topPath, deckItems]]);
-    cursor += placeTree(cols[0]!, childrenOf, stackFor, deck, group.key) + GROUP_GAP;
-  }
+    cursor += placeTree(cols[0]!, childrenOf, stackFor, deck, group.key, bandTop) + GROUP_GAP;
+  };
 
-  for (const file of manual) {
+  const placeManual = (file: FileEntry, bandTop: number) => {
     const descendants = descendantsOf(file, files)
       .map((row) => row.file)
       .filter((entry) => !claimed.has(entry.path));
@@ -483,13 +493,53 @@ export function buildSchemeLayout(
         new Map(quiet.length ? [[file.path, quiet]] : []),
         new Map([[file.path, deckItems]]),
         file.parent ? "" : file.path,
+        bandTop,
       ) + GROUP_GAP;
+  };
+
+  /* ── Favorites band (issue #224) ──────────────────────────────────────────
+     Crowned roots lift into their own row pinned at the very top, ordered
+     within the band purely by activity recency (freshest mtime first). Their
+     subtrees (edges, decks, quiet stacks) grow exactly as usual — only the row
+     they sit in is fixed. Everything else lays out in a second band below the
+     deepest favorite. With no favorites, `restTop` collapses to PAD and the
+     board is laid out in one band exactly as before. */
+  const isFavoriteRoot = (file: FileEntry) => favorites.has(conversationIdentity(file));
+  const recency = (file: FileEntry) => file.mtime;
+  const favGroups: BranchGroup[] = [];
+  const restGroups: BranchGroup[] = [];
+  for (const group of groups) {
+    const top = group.columns[0]?.file;
+    (top && isFavoriteRoot(top) ? favGroups : restGroups).push(group);
   }
+  const favManual: FileEntry[] = [];
+  const restManual: FileEntry[] = [];
+  for (const file of manual) (isFavoriteRoot(file) ? favManual : restManual).push(file);
+  favGroups.sort((a, b) => recency(b.columns[0]!.file) - recency(a.columns[0]!.file));
+  favManual.sort((a, b) => recency(b) - recency(a));
+  const hasFavorites = favGroups.length + favManual.length > 0;
+
+  for (const group of favGroups) placeGroup(group, PAD);
+  for (const file of favManual) placeManual(file, PAD);
+
+  /* The favorites band's deepest edge — the second band starts just below it. */
+  let bandBottom = PAD;
+  if (hasFavorites) {
+    for (const node of nodes) bandBottom = Math.max(bandBottom, node.y + node.h);
+    for (const deck of decks) bandBottom = Math.max(bandBottom, deck.y + deck.h);
+    for (const stack of stacks) bandBottom = Math.max(bandBottom, stack.y + stack.h);
+    for (const draft of drafts) bandBottom = Math.max(bandBottom, draft.y + draft.h);
+  }
+  const restTop = hasFavorites ? bandBottom + FAV_BAND_GAP : PAD;
+
+  cursor = PAD;
+  for (const group of restGroups) placeGroup(group, restTop);
+  for (const file of restManual) placeManual(file, restTop);
 
   /* Remaining drafts trail the row like fresh top-level nodes: root-sized, no edges. */
   for (const id of draftIds) {
     if (placedDrafts.has(id)) continue;
-    drafts.push({ key: "draft::" + id, id, x: cursor, y: PAD, w: NODE_W, h: ROOT_H });
+    drafts.push({ key: "draft::" + id, id, x: cursor, y: restTop, w: NODE_W, h: ROOT_H });
     cursor += NODE_W + GROUP_GAP;
   }
 
@@ -524,7 +574,7 @@ export function buildSchemeLayout(
       seen.add(pipeline.id);
       return true;
     });
-    let slotDockY = PAD;
+    let slotDockY = restTop;
     for (const pipeline of pool) {
       const pending = pipelinePlaceholderStages(pipeline, placedPaths, placedFlowIds);
       if (!pending.length) continue;
@@ -703,7 +753,7 @@ export function buildSchemeLayout(
   /* Fallback docked halo for an active surface pipeline with neither placed
      members nor placeholder slots (e.g. completed but its transcripts left the
      scan): a memberless plan card, as before (issue #136). */
-  let dockY = PAD;
+  let dockY = restTop;
   for (const pipeline of surfacePipelines) {
     if ((pipeline.state === "closed" && !pipeline.restored) || framedPipelineIds.has(pipeline.id)) continue;
     framedPipelineIds.add(pipeline.id);

--- a/src/components/tasks/TaskPanel.tsx
+++ b/src/components/tasks/TaskPanel.tsx
@@ -11,17 +11,13 @@ import { formatDue, isOverdue } from "@/lib/tasks/helpers";
 import type { BoardTask } from "@/lib/tasks/types";
 import type { FileEntry } from "@/lib/types";
 
+import { type FavoriteRow } from "@/components/favorites/favoriteRows";
+
 import { createTask } from "./taskApi";
 import { TaskComposer } from "./TaskComposer";
 import { TASK_TONES, taskTitle } from "./taskModel";
 
-/** A favorited conversation resolved to its freshest scanned generation. */
-export interface FavoriteRow {
-  /** Durable conversation identity (`conversationIdentity`). */
-  id: string;
-  file: FileEntry;
-  project: string;
-}
+export type { FavoriteRow };
 
 /**
  * The crown-favorites list (issue #185), docked above the task list and scoped
@@ -43,7 +39,7 @@ function FavoritesSection({
   return (
     <section className="mb-1 flex flex-col gap-0.5" aria-label={t("favorites.sectionTitle")}>
       <div className="flex items-center gap-1 px-1 pb-0.5 text-[10px] font-bold uppercase tracking-wide text-muted">
-        <Crown className="h-3 w-3 fill-warning text-warning" aria-hidden />
+        <Crown className="h-3 w-3 fill-crown text-crown" aria-hidden />
         {t("favorites.sectionTitle")}
         {rows.length ? <span className="font-semibold text-muted/70">{rows.length}</span> : null}
       </div>
@@ -67,12 +63,12 @@ function FavoritesSection({
             </button>
             <button
               type="button"
-              className="inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-[6px] text-warning hover:bg-warning-soft focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40"
+              className="inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-[6px] text-crown hover:bg-crown-soft focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40"
               aria-label={t("branch.unfavorite")}
               title={t("branch.unfavorite")}
               onClick={() => onToggle(id)}
             >
-              <Crown className="h-3.5 w-3.5 fill-warning" aria-hidden />
+              <Crown className="h-3.5 w-3.5 fill-crown" aria-hidden />
             </button>
           </div>
         ))

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -73,6 +73,11 @@
   --color-success-soft: #e5f6ea;
   --color-warning: #9a6b00;
   --color-warning-soft: #fff4dd;
+  /* Crown favorites accent (issue #224): a true gold/yellow, distinct from the
+     browny `--color-warning`, so a crowned card reads as regal, not as a
+     warning. Tuned for contrast on the light `--surface-card`. */
+  --color-crown: #e0a400;
+  --color-crown-soft: #fdf1cf;
   --color-danger: #c62828;
   --color-danger-soft: #fdeeee;
   --color-info: #0d9488; /* link / handoff teal */
@@ -145,6 +150,8 @@
     --color-success-soft: #14261a;
     --color-warning: #e0ae45;
     --color-warning-soft: #2b2312;
+    --color-crown: #f5c542;
+    --color-crown-soft: #2e2611;
     --color-danger: #f07171;
     --color-danger-soft: #2c1616;
     --color-info: #2dd4bf;
@@ -192,6 +199,8 @@
   --color-success-soft: #14261a;
   --color-warning: #e0ae45;
   --color-warning-soft: #2b2312;
+  --color-crown: #f5c542;
+  --color-crown-soft: #2e2611;
   --color-danger: #f07171;
   --color-danger-soft: #2c1616;
   --color-info: #2dd4bf;


### PR DESCRIPTION
Closes #224. Follow-up to the crown favorites shipped in #208, addressing the dictated feedback.

## What changed

**1. Dedicated favorites row, pinned at the top of the scheme.**
Crowned roots lift into their own band at the very top of the board, ordered within the row only by activity recency (freshest first). Their subtrees — edges/arrows to children, review decks, quiet-branch stacks — grow exactly as before; everything else flows in a second band below the deepest favorite. The layout change is deliberately **additive** per the note about the concurrent lane-zones rework (#223): a `favorites` set parameter on `buildSchemeLayout`, and a two-band placement extracted from the existing group/manual loops into `placeGroup`/`placeManual`. With no favorites, `restTop` collapses to `PAD` and the board lays out in a single band, byte-for-byte as before.

**2. Crown on the window's top edge.**
A new decorative `FavoriteCrownMarker` renders a gold crown sitting **on the pane's top-right edge, overlapping the frame from above** (mounted on the card's unclipped outer wrapper so the overhang isn't cut by the card's `overflow-hidden`). It's `aria-hidden` + click-through; the in-header crown stays the toggle affordance.

**3. Golder crown color — new token.**
Added `--color-crown` / `--color-crown-soft` (light `#e0a400` / dark `#f5c542`), a true gold distinct from the browny `--color-warning`. Every crown (scheme marker, header toggle, task panel, waiting list) now uses `fill-crown`/`text-crown`/`bg-crown-soft` — no raw hex in components, consistent across light + dark.

**4. Waiting list («Чекають») favorites section.**
The attention popover gains a pinned favorites section at the top, mirroring the scheme row, scoped to the current project. A row focuses the conversation (switching project if needed); its crown unfavorites in place.

A shared `resolveFavoriteRows` helper now backs the docked task panel, the mobile task sheet, and the attention popover so every favorites surface stays in sync.

## Scope / constraints
- UI layer only — **no** changes under `src/lib/{flows,agent,runtime}`.
- Design tokens only; en + uk labels (reused existing `favorites.*` / `branch.unfavorite` keys).
- 390px / 44px touch targets and desktop layout intact; mobile map mirrors the pinned band.
- Scheme changes kept minimal + additive (top band + row extraction), no broad layout refactor.

## Gates
- `bunx tsc --noEmit` ✅
- `bun test` ✅ (2577 pass; +3 new favorites-band cases: top-band pinning + freshest-first order, single-band parity with no favorites, favorited manual root lifts too)
- `next build` ✅ — crown tokens + `fill-crown`/`text-crown`/`bg-crown-soft` utilities confirmed in the compiled CSS for both themes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)