### PR TITLE
fix(design): Fable critique polish — undo/redo island + crown favorites (#228)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -155,7 +155,7 @@ body {
 .favorite-crown {
   transition: opacity 200ms var(--ease-standard, ease-out), transform 200ms var(--ease-standard, ease-out);
 }
-.favorite-crown.opacity-0 {
+.favorite-crown[data-crown-hidden] {
   transform: scale(0.85);
 }
 @keyframes crown-pop {

--- a/src/components/BoardHistoryControls.dom.test.tsx
+++ b/src/components/BoardHistoryControls.dom.test.tsx
@@ -40,7 +40,7 @@ async function mount(node: React.ReactElement): Promise<{ buttons: HTMLButtonEle
   return { buttons, container };
 }
 
-test("both arrows are disabled with an empty history", async () => {
+test("desktop: the island stays hidden until the log has something to act on", async () => {
   const { buttons } = await mount(
     <BoardHistoryControls
       canUndo={false}
@@ -52,16 +52,12 @@ test("both arrows are disabled with an empty history", async () => {
       isMobile={false}
     />,
   );
-  expect(buttons).toHaveLength(2);
-  const [undo, redo] = buttons;
-  expect(undo!.disabled).toBe(true);
-  expect(redo!.disabled).toBe(true);
-  /* Edge tooltips explain why the control is inert. */
-  expect(undo!.getAttribute("title")).toBe("Nothing to undo");
-  expect(redo!.getAttribute("title")).toBe("Nothing to redo");
+  /* Resting chrome hygiene (finding 2): no disabled two-button box before the
+     first close. */
+  expect(buttons).toHaveLength(0);
 });
 
-test("undo enabled, tooltip names the card the next undo restores", async () => {
+test("desktop: undo enabled, the label names the card and discloses the shortcut", async () => {
   const clicks: string[] = [];
   const { buttons } = await mount(
     <BoardHistoryControls
@@ -74,10 +70,15 @@ test("undo enabled, tooltip names the card the next undo restores", async () => 
       isMobile={false}
     />,
   );
+  expect(buttons).toHaveLength(2);
   const [undo, redo] = buttons;
   expect(undo!.disabled).toBe(false);
   expect(redo!.disabled).toBe(true);
-  expect(undo!.getAttribute("title")).toBe("Undo — reopen “Alpha”");
+  /* Styled Hint (finding 4): the label rides aria-label, not a native title,
+     and names the shortcut the feature ships. */
+  expect(undo!.getAttribute("title")).toBeNull();
+  expect(undo!.getAttribute("aria-label")).toBe("Undo — reopen “Alpha” (Ctrl+Z)");
+  expect(redo!.getAttribute("aria-label")).toBe("Nothing to redo");
   act(() => {
     undo!.dispatchEvent(new dom.MouseEvent("click", { bubbles: true }) as unknown as MouseEvent);
   });
@@ -88,20 +89,43 @@ test("undo enabled, tooltip names the card the next undo restores", async () => 
   expect(clicks).toEqual(["undo"]);
 });
 
-test("mobile sizing meets the 44px touch target", async () => {
+test("mobile: a single undo button, only while an undo is possible, at a 44px target", async () => {
+  const clicks: string[] = [];
   const { buttons } = await mount(
     <BoardHistoryControls
       canUndo
       canRedo
       undoEntry={close("Alpha")}
       redoEntry={close("Beta")}
+      onUndo={() => clicks.push("undo")}
+      onRedo={() => clicks.push("redo")}
+      isMobile
+    />,
+  );
+  /* Finding 1: redo lives on Ctrl+Shift+Z / the «⋯» menu, so the toolbar spends
+     one 44px slot, not two. */
+  expect(buttons).toHaveLength(1);
+  const [undo] = buttons;
+  expect(undo!.className).toContain("h-11");
+  expect(undo!.className).toContain("w-11");
+  expect(undo!.getAttribute("aria-label")).toBe("Undo — reopen “Alpha” (Ctrl+Z)");
+  act(() => {
+    undo!.dispatchEvent(new dom.MouseEvent("click", { bubbles: true }) as unknown as MouseEvent);
+  });
+  expect(clicks).toEqual(["undo"]);
+});
+
+test("mobile: nothing renders when there is no undo", async () => {
+  const { buttons } = await mount(
+    <BoardHistoryControls
+      canUndo={false}
+      canRedo
+      undoEntry={null}
+      redoEntry={close("Beta")}
       onUndo={() => {}}
       onRedo={() => {}}
       isMobile
     />,
   );
-  for (const btn of buttons) {
-    expect(btn.className).toContain("h-11");
-    expect(btn.className).toContain("w-11");
-  }
+  expect(buttons).toHaveLength(0);
 });

--- a/src/components/BoardHistoryControls.tsx
+++ b/src/components/BoardHistoryControls.tsx
@@ -2,8 +2,15 @@
 
 import { Redo2, Undo2 } from "lucide-react";
 
+import { Hint } from "@/components/Hint";
 import type { BoardHistoryEntry } from "@/lib/board/history";
 import { useLocale } from "@/lib/i18n";
+
+/* The keyboard shortcuts the island discloses on its labels — the feature ships
+   them (ProjectDashboard's global Ctrl+Z / Ctrl+Shift+Z handler) but the UI
+   never named them before (finding 4). Plain key names, not localized prose. */
+const UNDO_SHORTCUT = "Ctrl+Z";
+const REDO_SHORTCUT = "Ctrl+Shift+Z";
 
 interface BoardHistoryControlsProps {
   canUndo: boolean;
@@ -18,11 +25,15 @@ interface BoardHistoryControlsProps {
 }
 
 /**
- * The board undo/redo island (issue #184): two arrow buttons that step through
- * the user's recent board actions. Undo reopens the last closed card; redo
- * closes it again. Disabled at the edges of the history, and a hover/tap tooltip
- * names what the next undo would restore. A small segmented pair, sitting near
- * the other board controls in the project header.
+ * The board undo/redo island (issue #184): steps through the user's recent
+ * board actions. Undo reopens the last closed card; redo closes it again.
+ *
+ * Presence is deliberate resting-chrome hygiene (findings 1, 2): on desktop the
+ * island stays hidden until the log has something to act on (it appears on the
+ * first close — the teachable moment), and on mobile only a single undo button
+ * shows, and only while an undo is possible, so it never spends the 390px
+ * toolbar budget on a disabled control. Redo on mobile lives on Ctrl+Shift+Z
+ * and in the «⋯» menu. The keyboard shortcuts stay active regardless.
  */
 export function BoardHistoryControls({
   canUndo,
@@ -37,49 +48,72 @@ export function BoardHistoryControls({
 
   const undoTitle = undoEntry?.title.trim();
   const redoTitle = redoEntry?.title.trim();
-  const undoTooltip = canUndo
-    ? undoTitle
-      ? t("board.undoReopen", { title: undoTitle })
-      : t("board.undo")
+  const undoLabel = canUndo
+    ? withShortcut(undoTitle ? t("board.undoReopen", { title: undoTitle }) : t("board.undo"), UNDO_SHORTCUT)
     : t("board.undoNothing");
-  const redoTooltip = canRedo
-    ? redoTitle
-      ? t("board.redoReclose", { title: redoTitle })
-      : t("board.redo")
+  const redoLabel = canRedo
+    ? withShortcut(redoTitle ? t("board.redoReclose", { title: redoTitle }) : t("board.redo"), REDO_SHORTCUT)
     : t("board.redoNothing");
 
-  const button = isMobile ? "h-11 w-11" : "h-7 w-8";
   const icon = isMobile ? "h-5 w-5" : "h-4 w-4";
   const base =
     "flex items-center justify-center text-primary transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 hover:text-accent disabled:cursor-default disabled:text-muted disabled:opacity-40 disabled:hover:text-muted";
 
+  if (isMobile) {
+    /* One undo button, present only while an undo is possible (finding 1). */
+    if (!canUndo) return null;
+    return (
+      <Hint label={undoLabel}>
+        <button
+          type="button"
+          className={`${base} h-11 w-11 shrink-0 rounded-control border border-border bg-card`}
+          onClick={onUndo}
+          aria-label={undoLabel}
+        >
+          <Undo2 className={icon} aria-hidden />
+        </button>
+      </Hint>
+    );
+  }
+
+  /* Desktop: the segmented pair, hidden until the log is non-empty (finding 2).
+     No overflow-hidden clip so the Hint bubbles can escape; the transparent
+     buttons need no inner radius (finding 3). */
+  if (!canUndo && !canRedo) return null;
   return (
     <div
-      className="inline-flex shrink-0 items-center overflow-hidden rounded-[8px] border border-border bg-card"
+      className="inline-flex shrink-0 items-center rounded-control border border-border bg-card"
       role="group"
       aria-label={t("board.historyGroup")}
     >
-      <button
-        type="button"
-        className={`${base} ${button} rounded-l-[7px]`}
-        onClick={onUndo}
-        disabled={!canUndo}
-        aria-label={undoTooltip}
-        title={undoTooltip}
-      >
-        <Undo2 className={icon} aria-hidden />
-      </button>
+      <Hint label={undoLabel}>
+        <button
+          type="button"
+          className={`${base} h-7 w-8`}
+          onClick={onUndo}
+          disabled={!canUndo}
+          aria-label={undoLabel}
+        >
+          <Undo2 className={icon} aria-hidden />
+        </button>
+      </Hint>
       <span className="h-5 w-px shrink-0 bg-border" aria-hidden />
-      <button
-        type="button"
-        className={`${base} ${button} rounded-r-[7px]`}
-        onClick={onRedo}
-        disabled={!canRedo}
-        aria-label={redoTooltip}
-        title={redoTooltip}
-      >
-        <Redo2 className={icon} aria-hidden />
-      </button>
+      <Hint label={redoLabel}>
+        <button
+          type="button"
+          className={`${base} h-7 w-8`}
+          onClick={onRedo}
+          disabled={!canRedo}
+          aria-label={redoLabel}
+        >
+          <Redo2 className={icon} aria-hidden />
+        </button>
+      </Hint>
     </div>
   );
+}
+
+/** «Скасувати (Ctrl+Z)» — the label names what it does and how to reach it. */
+function withShortcut(label: string, shortcut: string): string {
+  return `${label} (${shortcut})`;
 }

--- a/src/components/FavoriteCrown.tsx
+++ b/src/components/FavoriteCrown.tsx
@@ -48,6 +48,10 @@ export function FavoriteCrown({
       type="button"
       data-scheme-ui
       data-favorite-crown={favorited ? "on" : "off"}
+      /* Drives the hidden-state scale in globals.css off a data attribute, so a
+         refactor of the `opacity-0` utility can't silently kill the reveal
+         (finding 6). `data-favorite-crown` is favorited-state, not visibility. */
+      data-crown-hidden={visible ? undefined : "true"}
       aria-pressed={favorited}
       aria-label={label}
       title={label}

--- a/src/components/MicButton.tsx
+++ b/src/components/MicButton.tsx
@@ -256,7 +256,7 @@ export function MicButtonView({
           aria-label={t("mic.stopRecognize")}
           title={warn ? t("mic.timeLeft", { time: fmtElapsed(remaining) }) : undefined}
           onClick={handleMain}
-          className={`flex items-center gap-1.5 rounded-[8px] border px-2 text-[11px] font-bold tabular-nums focus-visible:outline-none focus-visible:ring-2 ${
+          className={`flex items-center gap-1.5 rounded-control border px-2 text-label font-bold tabular-nums focus-visible:outline-none focus-visible:ring-2 ${
             isMobile ? "min-h-11" : "py-2"
           } ${
             warn
@@ -271,7 +271,7 @@ export function MicButtonView({
           type="button"
           aria-label={t("mic.cancel")}
           onClick={discard}
-          className={`inline-flex items-center justify-center rounded-[8px] border border-border bg-card text-muted hover:text-danger focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 ${
+          className={`inline-flex items-center justify-center rounded-control border border-border bg-card text-muted hover:text-danger focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 ${
             isMobile ? "h-11 w-11" : "p-2"
           }`}
         >
@@ -287,7 +287,7 @@ export function MicButtonView({
     return (
       <span className="flex shrink-0 items-center gap-1">
         {srRegion}
-        <span className="flex items-center gap-1.5 rounded-[8px] border border-warning/70 bg-warning-soft px-2 py-2 text-[11px] font-bold text-warning">
+        <span className="flex items-center gap-1.5 rounded-control border border-warning/70 bg-warning-soft px-2 py-2 text-label font-bold text-warning">
           {phase === "busy" ? (
             <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden />
           ) : (

--- a/src/components/ProjectDashboard.tsx
+++ b/src/components/ProjectDashboard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { List, ListTodo, Menu, MessageSquarePlus, MoreHorizontal, Network, Plus } from "lucide-react";
+import { List, ListTodo, Menu, MessageSquarePlus, MoreHorizontal, Network, Plus, Redo2 } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
 
 import { useBoardActionHistory } from "@/hooks/useBoardActionHistory";
@@ -1105,8 +1105,14 @@ export function ProjectDashboard({
               )}
             </HeaderMenu>
             <HeaderMenu triggerLabel={t("dash.moreMenu")} icon={<MoreHorizontal className="h-5 w-5" aria-hidden />}>
-              {() => (
+              {(close) => (
                 <>
+                  {/* Redo lives here on mobile — the header shows only a single
+                      undo button, so its counterpart rides the «⋯» menu (and
+                      Ctrl+Shift+Z), shown only while a redo is possible. */}
+                  {history.canRedo ? (
+                    <HeaderMenuItem icon={<Redo2 className="h-4 w-4" aria-hidden />} label={t("board.redo")} onSelect={() => { close(); onRedo(); }} />
+                  ) : null}
                   <div className="flex min-h-11 items-center gap-2 px-1.5"><span className="text-[13px] font-semibold text-primary">{t("dash.soundMenu")}</span><SoundToggle /></div>
                   <div className="flex min-h-11 items-center px-1.5">
                     {archived ? (

--- a/src/components/scheme/SchemeBoard.tsx
+++ b/src/components/scheme/SchemeBoard.tsx
@@ -1052,6 +1052,7 @@ export function SchemeBoard({
           tasks={expandedNode.tasks}
           isRoot={expandedNode.isRoot}
           expanded
+          showFavorite
           onToggleExpand={() => setExpanded(null)}
           autoEditToken={autoEditTokenFor(renameRequest, expandedNode.file.path)}
         />

--- a/src/components/tasks/TaskPanel.tsx
+++ b/src/components/tasks/TaskPanel.tsx
@@ -38,16 +38,19 @@ function FavoritesSection({
   const { t } = useLocale();
   return (
     <section className="mb-1 flex flex-col gap-0.5" aria-label={t("favorites.sectionTitle")}>
-      <div className="flex items-center gap-1 px-1 pb-0.5 text-[10px] font-bold uppercase tracking-wide text-muted">
+      {/* SectionHeader recipe (design doc §3.6): sentence-case label + `· counter`,
+          no uppercase/tracking. §1.4: rows inside this card get a hairline border,
+          no shadow. */}
+      <div className="flex items-center gap-1 px-1 pb-0.5 text-label font-semibold text-secondary">
         <Crown className="h-3 w-3 fill-crown text-crown" aria-hidden />
         {t("favorites.sectionTitle")}
-        {rows.length ? <span className="font-semibold text-muted/70">{rows.length}</span> : null}
+        {rows.length ? <span className="text-caption font-normal tabular-nums text-muted">· {rows.length}</span> : null}
       </div>
       {rows.length ? (
         rows.map(({ id, file, project }) => (
           <div
             key={id}
-            className="flex items-center gap-1 rounded-[8px] border border-border bg-card px-2 py-1.5 shadow-1 hover:border-accent/40"
+            className="flex items-center gap-1 rounded-control border border-border bg-card px-2 py-1.5 hover:border-accent/40"
           >
             <button
               type="button"
@@ -56,14 +59,14 @@ function FavoritesSection({
               onClick={() => onOpen(file)}
             >
               <span className={`h-2 w-2 shrink-0 rounded-full ${activityDot(file.activity)}`} aria-hidden />
-              <span className="min-w-0 flex-1 truncate text-[11.5px] font-semibold">
+              <span className="min-w-0 flex-1 truncate text-ui font-semibold">
                 {cleanTitle(file.title, 90) || t("tasks.untitled")}
               </span>
-              {scopeAll ? <span className="max-w-[90px] shrink-0 truncate text-[10px] text-muted">{project}</span> : null}
+              {scopeAll ? <span className="max-w-[90px] shrink-0 truncate text-caption text-muted">{project}</span> : null}
             </button>
             <button
               type="button"
-              className="inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-[6px] text-crown hover:bg-crown-soft focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40"
+              className="inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-control text-crown hover:bg-crown-soft focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40"
               aria-label={t("branch.unfavorite")}
               title={t("branch.unfavorite")}
               onClick={() => onToggle(id)}
@@ -73,7 +76,7 @@ function FavoritesSection({
           </div>
         ))
       ) : (
-        <div className="px-2 py-1.5 text-[10.5px] text-muted">{t("favorites.empty")}</div>
+        <div className="px-2 py-1.5 text-caption text-muted">{t("favorites.empty")}</div>
       )}
     </section>
   );
@@ -239,7 +242,7 @@ export function TaskPanel({
             return (
               <div
                 key={task.id}
-                className={`flex w-full min-w-0 flex-col gap-0.5 rounded-[8px] border border-border bg-card px-2 py-1.5 shadow-1 hover:border-accent/40 ${
+                className={`flex w-full min-w-0 flex-col gap-0.5 rounded-[8px] border border-border bg-card px-2 py-1.5 hover:border-accent/40 ${
                   task.status === "done" ? "opacity-60" : ""
                 }`}
               >

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -1328,10 +1328,6 @@ export const en = {
   "favorites.sectionTitle": "Favorites",
   "favorites.empty": "no favorites yet — hover a card and tap its crown",
   "favorites.focusTitle": "Focus {title} on the board",
-  "favorites.count": {
-    one: "{count} favorite",
-    other: "{count} favorites",
-  },
   "tasks.sheetNew": "new task",
   "tasks.sheetCreate": "Create the task",
   "tasks.sheetBack": "Back to the task list",

--- a/src/lib/i18n/uk.ts
+++ b/src/lib/i18n/uk.ts
@@ -1286,12 +1286,6 @@ export const uk: Record<keyof typeof en, Message> = {
   "favorites.sectionTitle": "Обране",
   "favorites.empty": "обраного поки нема — наведи на картку й тапни корону",
   "favorites.focusTitle": "Показати {title} на дошці",
-  "favorites.count": {
-    one: "{count} обране",
-    few: "{count} обраних",
-    many: "{count} обраних",
-    other: "{count} обраних",
-  },
   "tasks.sheetNew": "нова задача",
   "tasks.sheetCreate": "Створити задачу",
   "tasks.sheetBack": "Назад до списку задач",


### PR DESCRIPTION
Post-hoc Fable design pass on the merged Opus PRs #207/#208/#216, implementing the fixes exactly as directed in #228. Built on current `main` (includes the #226 favorites row).

## PR #207 — board undo/redo island
- **Mobile (finding 1):** the header now shows a **single undo button, only while an undo is possible**; redo moves to `Ctrl+Shift+Z` and the «⋯» menu. The island no longer spends ~91px of the 390px toolbar budget on a mostly-disabled control.
- **Desktop (finding 2):** the island stays **hidden until the log is non-empty** — it appears on the first close (the teachable moment) and disappears when there's nothing to undo or redo. Shortcuts stay active regardless.
- **Tokens (finding 3):** `rounded-control` instead of raw `rounded-[8px]`/`rounded-l-[7px]`/`rounded-r-[7px]`; the transparent buttons drop their inner radii.
- **Tooltips (finding 4):** the styled `Hint` component instead of native `title`, and labels disclose the shortcut («Undo — reopen "…" (Ctrl+Z)»).

## PR #208 — proximity crown favorites
- **Finding 1:** pass `showFavorite` to the **expanded-overlay `BranchPane`** (`SchemeBoard.tsx`) so a just-crowned card keeps its favorited state and toggle on expand.
- **Finding 2:** favorites section header lands on the **§3.6 SectionHeader recipe** — sentence-case `text-label`/600 `text-secondary` + `· counter` in muted tabular caption. No uppercase, no tracking.
- **Finding 3:** drop `shadow-1` on the in-panel favorite **and** task rows (§1.4: card-on-card rows get a hairline border, no shadow).
- **Finding 4:** token type sizes/radii in `TaskPanel` (`text-ui`/`text-caption`, `rounded-control`).
- **Finding 5:** delete the dead `favorites.count` i18n keys (en + uk).
- **Finding 6:** key the crown hidden-state transform off a **data attribute** (`data-crown-hidden`) instead of the `.opacity-0` utility class, so a class refactor can't silently kill the reveal. (`data-favorite-crown` encodes favorited-state, not visibility, so a dedicated visibility hook keeps the opacity+scale reveal intact.)

## PR #216 note
- Migrate the recording-chip `rounded-[8px]`/`text-[11px]` in `MicButton.tsx` (they predate #216) to `rounded-control`/`text-label`.

## Gates
- `bunx tsc --noEmit` — clean
- `bun test` — 2591 pass, 0 fail (route-export gate included)
- `eslint` on touched files — clean
- `BoardHistoryControls.dom.test.tsx` rewritten to cover the new visibility rules, Hint labels, and mobile single-button behavior.

Closes #228.

🤖 Generated with [Claude Code](https://claude.com/claude-code)