### PR TITLE
feat(header): account badge — third meta-chip with deterministic account hue (#229)

### DIFF
--- a/src/components/AccountBadge.render.test.tsx
+++ b/src/components/AccountBadge.render.test.tsx
@@ -1,0 +1,33 @@
+import { expect, test } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { AccountBadge } from "./AccountBadge";
+
+// Server render assumes desktop (useIsMobile → false), so these exercise the
+// chip variant; the account store has no accounts server-side, so the Hint
+// falls back to the health-free label.
+
+test("desktop chip shows the @-prefixed account id and a deterministic hue dot", () => {
+  const html = renderToStaticMarkup(<AccountBadge engine="claude" accountId="botfatherdev-2" />);
+  expect(html).toContain("@ botfatherdev-2");
+  // The leading dot's fill is a color-mix over a theme token — never a raw hex.
+  expect(html).toContain("color-mix(in srgb, hsl(");
+  expect(html).not.toMatch(/background-color:\s*#/i);
+});
+
+test("the full id, engine, and open affordance ride in the Hint / aria label", () => {
+  const html = renderToStaticMarkup(<AccountBadge engine="codex" accountId="terra" />);
+  expect(html).toContain("Account terra · Codex");
+  expect(html).toContain("Open accounts for terra");
+});
+
+test("a long account id truncates to ~14ch with an ellipsis", () => {
+  const html = renderToStaticMarkup(<AccountBadge engine="claude" accountId="an-extremely-long-account-id" />);
+  expect(html).toContain("an-extremely-…");
+  expect(html).not.toContain("an-extremely-long-account-id<");
+});
+
+test("the default home renders @ default", () => {
+  const html = renderToStaticMarkup(<AccountBadge engine="claude" accountId="default" />);
+  expect(html).toContain("@ default");
+});

--- a/src/components/AccountBadge.tsx
+++ b/src/components/AccountBadge.tsx
@@ -1,0 +1,108 @@
+"use client";
+
+import { type AccountAuthHealth, useEngineAccounts } from "@/hooks/useEngineAccounts";
+import { useIsMobile } from "@/hooks/useIsMobile";
+import { accountIdFromPath } from "@/lib/accounts/badge";
+import { requestAccountPanel } from "@/lib/accounts/openPanel";
+import { type MessageKey, type TFunction, useLocale } from "@/lib/i18n";
+
+import { Hint } from "./Hint";
+import { hueFromId } from "./scheme/agentLinks";
+
+/** Engine-agnostic account id → its transcript-derived id, exported for the
+    caller so the badge stays a leaf that only paints. */
+export { accountIdFromPath };
+
+const AUTH_HEALTH_KEY: Record<AccountAuthHealth, MessageKey> = {
+  authenticated: "accounts.auth.authenticated",
+  signed_out: "accounts.auth.signedOut",
+  unknown: "accounts.auth.unknown",
+  error: "accounts.auth.error",
+};
+
+const ENGINE_LABEL: Record<"claude" | "codex", string> = { claude: "Claude", codex: "Codex" };
+
+/** Deterministic, theme-adaptive tint for an account id: a fixed hue from the
+    id with pinned saturation/lightness, mixed against a theme surface token so
+    it reads in both light and dark with no raw hex. The dot on the chip and the
+    circle fill on mobile share the hue, so grouping reads across many windows. */
+function accountTint(accountId: string): { dot: string; circleBg: string } {
+  const hue = hueFromId(accountId);
+  return {
+    dot: `color-mix(in srgb, hsl(${hue} 60% 50%) 85%, var(--color-card))`,
+    circleBg: `color-mix(in srgb, hsl(${hue} 62% 50%) 20%, var(--color-card))`,
+  };
+}
+
+/** ~14ch cap so the id never crowds the meta row; the full id lives in the Hint. */
+function truncateId(id: string, max = 14): string {
+  return id.length > max ? `${id.slice(0, max - 1)}…` : id;
+}
+
+function healthOf(account: { authHealth?: AccountAuthHealth; authPresent?: boolean } | undefined): AccountAuthHealth | null {
+  if (!account) return null;
+  return account.authHealth ?? (account.authPresent ? "unknown" : "signed_out");
+}
+
+/**
+ * Account badge — the third meta-chip on an agent window header, after the ctx
+ * and branch chips (issue #229). Shows `@ <accountId>` with a deterministic hue
+ * dot; the styled Hint carries the full id, engine, and live account health.
+ * Clicking opens the existing accounts panel focused on this account. On the
+ * phone the chip collapses to a 20px hue circle inside a 44px tap target.
+ *
+ * The account health is read from the live per-engine registry projection, so a
+ * conversation that migrates accounts (issue #40) reflects its current account.
+ */
+export function AccountBadge({ engine, accountId }: { engine: "claude" | "codex"; accountId: string }) {
+  const { t } = useLocale();
+  const isMobile = useIsMobile();
+  const accounts = useEngineAccounts(engine);
+  const tint = accountTint(accountId);
+  const health = healthOf(accounts.accounts.find((account) => account.id === accountId));
+  const label = hintLabel(t, accountId, engine, health);
+  const open = () => requestAccountPanel(engine, accountId);
+  const aria = t("branch.accountAria", { id: accountId });
+
+  if (isMobile) {
+    return (
+      <Hint label={label}>
+        <button
+          type="button"
+          onClick={open}
+          aria-label={aria}
+          className="inline-flex h-11 w-11 shrink-0 items-center justify-center rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40"
+        >
+          <span
+            className="flex h-5 w-5 items-center justify-center rounded-full font-mono text-[10px] font-bold uppercase"
+            style={{ backgroundColor: tint.circleBg, color: tint.dot }}
+            aria-hidden
+          >
+            {accountId.charAt(0)}
+          </span>
+        </button>
+      </Hint>
+    );
+  }
+
+  return (
+    <Hint label={label}>
+      <button
+        type="button"
+        onClick={open}
+        aria-label={aria}
+        className="inline-flex shrink-0 items-center gap-1 rounded-full border border-border/80 px-1.5 py-0.5 font-mono text-[9.5px] text-muted hover:border-accent/45 hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40"
+      >
+        <span className="h-1.5 w-1.5 shrink-0 rounded-full" style={{ backgroundColor: tint.dot }} aria-hidden />
+        <span>@ {truncateId(accountId)}</span>
+      </button>
+    </Hint>
+  );
+}
+
+function hintLabel(t: TFunction, accountId: string, engine: "claude" | "codex", health: AccountAuthHealth | null): string {
+  const engineName = ENGINE_LABEL[engine];
+  return health
+    ? t("branch.accountTip", { id: accountId, engine: engineName, health: t(AUTH_HEALTH_KEY[health]) })
+    : t("branch.accountTipPlain", { id: accountId, engine: engineName });
+}

--- a/src/components/AccountsPanel.tsx
+++ b/src/components/AccountsPanel.tsx
@@ -148,7 +148,7 @@ function AuthIdentity({ account }: { account: AccountOption }) {
   );
 }
 
-function AccountRow({ account, engine, activeId, onSelect, onRemove, disabled }: { account: AccountOption; engine: "claude" | "codex"; activeId: string; onSelect: () => void; onRemove: () => void; disabled: boolean }) {
+function AccountRow({ account, engine, activeId, onSelect, onRemove, disabled, focused = false }: { account: AccountOption; engine: "claude" | "codex"; activeId: string; onSelect: () => void; onRemove: () => void; disabled: boolean; focused?: boolean }) {
   const { t } = useLocale();
   const state = rowState(account, activeId);
   const isActive = account.id === activeId;
@@ -158,14 +158,21 @@ function AccountRow({ account, engine, activeId, onSelect, onRemove, disabled }:
   // second, explicit confirm — mirroring the confirm step migration already
   // requires for its far less destructive account switch.
   const [confirmingRemove, setConfirmingRemove] = useState(false);
+  // A badge-driven open (issue #229) focuses one account: scroll it into view
+  // and ring it so the panel lands on the conversation's account, not the top.
+  const selectRef = useRef<HTMLButtonElement>(null);
+  useEffect(() => {
+    if (focused) selectRef.current?.scrollIntoView({ block: "nearest" });
+  }, [focused]);
   return (
     <div>
       <button
+        ref={selectRef}
         type="button"
         aria-current={isActive ? "true" : undefined}
         disabled={selectionDisabled}
         onClick={onSelect}
-        className="flex min-h-[44px] w-full items-center gap-2 px-3 py-1.5 text-left hover:bg-canvas disabled:cursor-wait disabled:opacity-60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 sm:min-h-0"
+        className={`flex min-h-[44px] w-full items-center gap-2 px-3 py-1.5 text-left hover:bg-canvas disabled:cursor-wait disabled:opacity-60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 sm:min-h-0 ${focused ? "bg-accent/5 ring-2 ring-inset ring-accent/50" : ""}`}
       >
         <span className="flex h-3.5 w-3.5 shrink-0 items-center justify-center">{isActive ? <Check className="h-3.5 w-3.5 text-accent" aria-hidden /> : null}</span>
         <span className="min-w-0 flex-1">
@@ -427,10 +434,14 @@ export function AccountsPanel({
   state,
   onClose,
   placement = "footer",
+  focusAccountId = null,
 }: {
   state: EngineAccountsState;
   onClose: () => void;
   placement?: "footer" | "header";
+  /** When set, the panel opens scrolled to and highlighting this account
+      (issue #229 — a header account badge steers here). */
+  focusAccountId?: string | null;
 }) {
   const { t } = useLocale();
   const { accounts, active, status, notice, mutation, engine } = state;
@@ -518,7 +529,7 @@ export function AccountsPanel({
               {status === "error" && accounts.length === 0 ? <div className="px-3 py-2 text-[11px] text-muted">{t("accounts.noAccounts")}</div> : null}
               {accounts.map((account) => (
                 <Fragment key={account.id}>
-                  <AccountRow account={account} engine={engine} activeId={active} disabled={mutation !== null} onSelect={() => void onSelect(account.id)} onRemove={() => void state.remove(account.id)} />
+                  <AccountRow account={account} engine={engine} activeId={active} disabled={mutation !== null} focused={account.id === focusAccountId} onSelect={() => void onSelect(account.id)} onRemove={() => void state.remove(account.id)} />
                   <AccountLimitsDetail account={account} />
                   {engine === "claude" ? <ClaudeLoginRow key={account.login?.operationId ?? account.id} account={account} state={state} loginBusy={loginBusy} /> : null}
                 </Fragment>

--- a/src/components/BranchPane.tsx
+++ b/src/components/BranchPane.tsx
@@ -11,7 +11,9 @@ import type { FileEntry } from "@/lib/types";
 
 import { cardMigrationState, postConversationMigration } from "@/lib/accounts/migration";
 import { conversationIdentity } from "@/lib/accounts/identity";
+import { accountIdFromPath } from "@/lib/accounts/badge";
 
+import { AccountBadge } from "./AccountBadge";
 import { registerLinkTarget } from "./AgentLink";
 import { DeleteFileButton } from "./DeleteFileButton";
 import { FavoriteCrown, FavoriteCrownMarker } from "./FavoriteCrown";
@@ -348,6 +350,11 @@ export function BranchPane({ file, tasks, isRoot, onClose, dragHandle, noCompose
                   <GitBranch className="h-2.5 w-2.5" aria-hidden /> {file.worktree}
                 </span>
               ) : null}
+              {/* Account badge (issue #229): the third meta-chip, after ctx and
+                  the branch chip. Shell tasks carry no account, so they skip it;
+                  the id is read from the live transcript path so a migrated
+                  conversation reflects its current account. */}
+              {file.engine === "shell" ? null : <AccountBadge engine={file.engine} accountId={accountIdFromPath(file.path)} />}
               {file.plan ? <PlanChip plan={file.plan} /> : null}
               {file.goal ? <GoalChip goal={file.goal} /> : null}
               {isRoot || isMobile ? null : (

--- a/src/components/LimitsFooter.tsx
+++ b/src/components/LimitsFooter.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 
 import { accountEntryPointVisible, type Engine, useEngineAccounts } from "@/hooks/useEngineAccounts";
+import { consumePendingAccountPanel, onAccountPanelRequest } from "@/lib/accounts/openPanel";
 import { type Locale, translate, useLocale } from "@/lib/i18n";
 import { LIMITS_RATE_LIMITED_REASON, LIMITS_REAUTH_REQUIRED_REASON, type EngineLimits, type LimitsPayload, type LimitsProvenance, type LimitWindow } from "@/lib/types";
 
@@ -193,6 +194,7 @@ function EngineLimitsBlock({
   const accounts = useEngineAccounts(engine);
   const [open, setOpen] = useState(false);
   const [chartOpen, setChartOpen] = useState(false);
+  const [focusAccountId, setFocusAccountId] = useState<string | null>(null);
   const containerRef = useRef<HTMLDivElement>(null);
   const triggerRef = useRef<HTMLButtonElement>(null);
   const chartTriggerRef = useRef<HTMLButtonElement>(null);
@@ -200,8 +202,26 @@ function EngineLimitsBlock({
 
   const close = () => {
     setOpen(false);
+    setFocusAccountId(null);
     triggerRef.current?.focus();
   };
+
+  // A tapped account badge (issue #229) asks this engine's panel to open focused
+  // on one account. Desktop: this block is always mounted, so the window event
+  // lands directly. Mobile: it mounts with the project drawer, so a request
+  // dispatched a moment earlier is claimed from the retained pending slot here.
+  useEffect(() => {
+    const openFocused = (accountId: string) => {
+      setChartOpen(false);
+      setFocusAccountId(accountId);
+      setOpen(true);
+    };
+    const pending = consumePendingAccountPanel(engine);
+    if (pending) openFocused(pending.accountId);
+    return onAccountPanelRequest((request) => {
+      if (request.engine === engine) openFocused(request.accountId);
+    });
+  }, [engine]);
 
   const closeChart = () => {
     setChartOpen(false);
@@ -319,7 +339,7 @@ function EngineLimitsBlock({
         )}
         {visibleFailureReason ? <div className="px-3.5 pb-3 pt-0.5 text-[10px] text-muted">{visibleFailureReason}</div> : null}
       </div>
-      {open ? <AccountsPanel state={accounts} onClose={close} /> : null}
+      {open ? <AccountsPanel state={accounts} onClose={close} focusAccountId={focusAccountId} /> : null}
       {chartOpen ? <BurndownPanel key={accounts.active} engine={engine} label={label} plan={accountLimits?.plan ?? null} activeAccountId={accounts.active} onClose={closeChart} /> : null}
     </div>
   );

--- a/src/components/Viewer.tsx
+++ b/src/components/Viewer.tsx
@@ -4,6 +4,7 @@ import { Crown, Filter, TriangleAlert, X } from "lucide-react";
 import { useCallback, useEffect, useMemo, useReducer, useRef, useState } from "react";
 
 import { formatConversationHash, parseConversationHash, resolveConversationTarget, withoutArchivedPredecessors, type ConversationHash } from "@/lib/accounts/identity";
+import { onAccountPanelRequest } from "@/lib/accounts/openPanel";
 import { useAgentChimes } from "@/hooks/useAgentChimes";
 import { useArchivedProjects } from "@/hooks/useArchivedProjects";
 import { useEffectiveFlows } from "@/components/flows/flowModel";
@@ -189,6 +190,14 @@ export function Viewer() {
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
   }, [drawerOpen]);
+
+  // A tapped account badge (issue #229) opens the accounts surface. On mobile
+  // the limits footer lives inside the project drawer, so the drawer must open
+  // first; its per-engine block then claims the retained request on mount.
+  useEffect(() => {
+    if (!isMobile) return;
+    return onAccountPanelRequest(() => setDrawerOpen(true));
+  }, [isMobile]);
 
   /* A file open (overview card, deep link) becomes a column of its project. */
   const openFile = useCallback(

--- a/src/lib/accounts/badge.test.ts
+++ b/src/lib/accounts/badge.test.ts
@@ -1,0 +1,30 @@
+import { expect, test } from "bun:test";
+
+import { accountIdFromPath, DEFAULT_ACCOUNT_ID } from "./badge";
+
+test("reads the managed Claude account id from a transcript path", () => {
+  expect(
+    accountIdFromPath("/home/u/.config/agent-log-viewer/accounts/claude/botfatherdev-2/projects/-x/session.jsonl"),
+  ).toBe("botfatherdev-2");
+});
+
+test("reads the managed Codex account id from a session path", () => {
+  expect(
+    accountIdFromPath("/home/u/.config/agent-log-viewer/accounts/codex/terra/sessions/2026/07/x.jsonl"),
+  ).toBe("terra");
+});
+
+test("the legacy home (no accounts segment) maps to the default account", () => {
+  expect(accountIdFromPath("/home/u/.claude/projects/-x/session.jsonl")).toBe(DEFAULT_ACCOUNT_ID);
+  expect(accountIdFromPath("/home/u/.codex/sessions/2026/07/x.jsonl")).toBe(DEFAULT_ACCOUNT_ID);
+});
+
+test("missing/empty path falls back to the default account", () => {
+  expect(accountIdFromPath(null)).toBe(DEFAULT_ACCOUNT_ID);
+  expect(accountIdFromPath(undefined)).toBe(DEFAULT_ACCOUNT_ID);
+  expect(accountIdFromPath("")).toBe(DEFAULT_ACCOUNT_ID);
+});
+
+test("a foreign engine folder under accounts is not matched", () => {
+  expect(accountIdFromPath("/x/accounts/gemini/acct/projects/s.jsonl")).toBe(DEFAULT_ACCOUNT_ID);
+});

--- a/src/lib/accounts/badge.ts
+++ b/src/lib/accounts/badge.ts
@@ -1,0 +1,23 @@
+/**
+ * Which account a conversation currently runs under, for the header account
+ * badge (issue #229).
+ *
+ * Managed accounts nest their transcripts under `…/accounts/<engine>/<id>/…`
+ * (see `claudeAccountsRoot` / `codexAccountsRoot`); the legacy home has no such
+ * segment and maps to the default account. This reads the *live* transcript
+ * path, so when a migration commits (issue #40) and the transcript rotates onto
+ * the target account's home, the derived id follows — no spawn-time snapshot is
+ * cached, and the badge updates with the projection.
+ */
+
+/** The legacy (default) home carries no managed-account path segment. */
+export const DEFAULT_ACCOUNT_ID = "default";
+
+const ACCOUNT_PATH = /[/\\]accounts[/\\](?:claude|codex)[/\\]([^/\\]+)[/\\]/;
+
+/** The account id owning a transcript path, or {@link DEFAULT_ACCOUNT_ID}. */
+export function accountIdFromPath(path: string | null | undefined): string {
+  if (!path) return DEFAULT_ACCOUNT_ID;
+  const match = ACCOUNT_PATH.exec(path);
+  return match ? match[1]! : DEFAULT_ACCOUNT_ID;
+}

--- a/src/lib/accounts/openPanel.ts
+++ b/src/lib/accounts/openPanel.ts
@@ -1,0 +1,54 @@
+/**
+ * Cross-surface request to open the existing Accounts panel focused on one
+ * account (issue #229). A header account badge dispatches it; the limits
+ * footer's per-engine block answers by opening its panel scrolled to that
+ * account. No new menu is introduced — this only steers the existing surface.
+ *
+ * Desktop: the limits footer is always mounted, so the window event lands
+ * synchronously. Mobile: the footer mounts only once the project drawer opens,
+ * so the most recent request is also retained briefly and claimed by that
+ * late-mounting block on mount.
+ */
+
+export interface AccountPanelRequest {
+  engine: "claude" | "codex";
+  accountId: string;
+}
+
+const EVENT = "llv:open-accounts";
+/** How long a request stays claimable by a late-mounting listener. */
+const PENDING_TTL_MS = 5_000;
+
+let pending: (AccountPanelRequest & { at: number }) | null = null;
+
+/** Ask `engine`'s accounts surface to open, focused on `accountId`. */
+export function requestAccountPanel(engine: "claude" | "codex", accountId: string): void {
+  pending = { engine, accountId, at: Date.now() };
+  if (typeof window !== "undefined") {
+    window.dispatchEvent(new CustomEvent<AccountPanelRequest>(EVENT, { detail: { engine, accountId } }));
+  }
+}
+
+/** Claim a request dispatched just before this engine's block mounted (mobile
+    drawer). Returns and clears it only while fresh and engine-matched. */
+export function consumePendingAccountPanel(engine: "claude" | "codex"): AccountPanelRequest | null {
+  if (!pending || pending.engine !== engine) return null;
+  if (Date.now() - pending.at > PENDING_TTL_MS) {
+    pending = null;
+    return null;
+  }
+  const { accountId } = pending;
+  pending = null;
+  return { engine, accountId };
+}
+
+/** Subscribe to open requests. Returns an unsubscribe function. */
+export function onAccountPanelRequest(handler: (request: AccountPanelRequest) => void): () => void {
+  if (typeof window === "undefined") return () => {};
+  const listener = (event: Event) => {
+    const detail = (event as CustomEvent<AccountPanelRequest>).detail;
+    if (detail) handler(detail);
+  };
+  window.addEventListener(EVENT, listener);
+  return () => window.removeEventListener(EVENT, listener);
+}

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -1205,6 +1205,10 @@ export const en = {
   "branch.lastActivityQuiet": "Marked active, but the transcript is quiet: last activity {age}",
   "branch.handoffTitle": "agent spawned by this conversation's handoff",
   "branch.branchTitle": "branch of this conversation",
+  // Account badge (issue #229)
+  "branch.accountTip": "Account {id} · {engine} · {health}",
+  "branch.accountTipPlain": "Account {id} · {engine}",
+  "branch.accountAria": "Open accounts for {id}",
   "lineage.parentRemoved": "parent removed",
   "lineage.parentRemovedTitle": "The parent conversation transcript was removed",
   "branch.removeColumn": "Remove column {title}",

--- a/src/lib/i18n/uk.ts
+++ b/src/lib/i18n/uk.ts
@@ -1171,6 +1171,10 @@ export const uk: Record<keyof typeof en, Message> = {
   "branch.lastActivityQuiet": "Позначений активним, але транскрипт мовчить: остання активність {age}",
   "branch.handoffTitle": "агент, породжений хендоффом цієї розмови",
   "branch.branchTitle": "гілка цієї розмови",
+  // Account badge (issue #229)
+  "branch.accountTip": "Акаунт {id} · {engine} · {health}",
+  "branch.accountTipPlain": "Акаунт {id} · {engine}",
+  "branch.accountAria": "Відкрити акаунти для {id}",
   "lineage.parentRemoved": "батьківську розмову видалено",
   "lineage.parentRemovedTitle": "Транскрипт батьківської розмови видалено",
   "branch.removeColumn": "Прибрати колонку {title}",


### PR DESCRIPTION
Implements #229 (design pre-approved by Fable — built exactly as specified).

## What

A third meta-chip on the agent window header, after the ctx and branch chips: it shows **which account** an agent runs on.

- **Content:** `@ <accountId>` (e.g. `@ botfatherdev-2`), truncated ~14ch with an ellipsis; the full id + engine + live account health ride in the styled `Hint` tooltip (not a native `title`). The default home renders `@ default`.
- **Recipe:** the branch chip's exact classes — muted bg, caption size (`text-[9.5px]`), hairline `border-border/80`, `font-mono`, design tokens only.
- **Scanability:** a leading dot gets a **deterministic hue** from a stable hash of the account id (reuses `hueFromId`), with fixed saturation/lightness mixed against a theme surface token via `color-mix` — light + dark, **no raw hex**.
- **Mobile (390px):** the chip collapses to a **20px hue circle** with the account's first letter, inside a **44px tap target**, same `Hint`.
- **Interaction:** clicking opens the existing accounts panel **focused on that account** (scrolled + ringed). No new menus.
- **Data:** `accountId` is read from the **live transcript path** (`…/accounts/<engine>/<id>/…`, else `default`), so a conversation that migrates accounts (#40) reflects its **current** account — no spawn-time snapshot. Health comes from the live per-engine registry projection.

## How the click reaches the panel

A small window-event coordinator (`src/lib/accounts/openPanel.ts`): the badge dispatches a request; the limits footer's per-engine block opens focused on that account. Desktop lands synchronously (footer always mounted); on mobile the badge also opens the project drawer, and the footer claims the retained request on mount.

## Scope / constraints honored

- UI only — no `src/lib/{flows,agent,runtime}`.
- en + uk keys added (parity test green); tokens only, no raw hex.
- Shell tasks carry no account and skip the badge.

## Gates

- `bunx tsc --noEmit` — clean
- `bun test` — 2595 pass / 0 fail (adds `badge.test.ts`, `AccountBadge.render.test.tsx`)
- route-export gate — green
- eslint on changed files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)