### PR TITLE
feat: turn duration — live «працює N» + «Worked for N» idle caption (#231)

### DIFF
--- a/src/components/LogFeed.tsx
+++ b/src/components/LogFeed.tsx
@@ -19,6 +19,7 @@ import { QuestionCard } from "./feed/QuestionCard";
 import { speakableAnswer } from "./feed/speakableAnswer";
 import { isSubagent } from "./projectModel";
 import { TaskHeader } from "./TaskHeader";
+import { workedCaption } from "./turnDuration";
 
 /** Items rendered initially and added per «show earlier» step. */
 const RENDER_STEP = 1500;
@@ -96,6 +97,21 @@ function WorkingRow({ icon: Icon, label }: { icon: LucideIcon; label: string }) 
       </span>
       <Icon className="h-3.5 w-3.5" aria-hidden />
       {label}
+    </div>
+  );
+}
+
+/** Muted caption after the final message once the turn is complete, mirroring
+    the codex TUI's "Worked for …" line (issue #231). Renders nothing while the
+    turn is still running — `workedCaption` returns null until `endedAt` is set. */
+function WorkedSeparator({ file }: { file: FileEntry }) {
+  const caption = workedCaption(file);
+  if (!caption) return null;
+  return (
+    <div className="mt-3 flex items-center gap-2 text-[11px] font-semibold text-muted" role="note">
+      <span className="h-px flex-1 bg-border" aria-hidden />
+      <span className="tabular-nums">{caption}</span>
+      <span className="h-px flex-1 bg-border" aria-hidden />
     </div>
   );
 }
@@ -495,6 +511,7 @@ export function LogFeed({ file, showSvc, lineFilter, onStatus, paused, follow, s
                     <CornerDownRight className="h-3.5 w-3.5" aria-hidden /> {t("feed.returnedResult")}
                   </div>
                 ) : null}
+                <WorkedSeparator file={file} />
               </>
             ) : (
               <div className="mt-[14vh] text-center text-muted">

--- a/src/components/scheme/nodes.tsx
+++ b/src/components/scheme/nodes.tsx
@@ -33,6 +33,7 @@ import { canHandoff, HandoffHandle } from "@/components/HandoffHandle";
 import { isWorkflowDraftId } from "@/components/workflows/workflowModel";
 import { WorkflowDraftPane } from "@/components/workflows/WorkflowDraftPane";
 import { activityDot, cleanTitle, engineBadge, engineEdge, fmtAge } from "@/components/utils";
+import { recencyTurnInfo } from "@/components/turnDuration";
 
 import type { AgentLink } from "./agentLinks";
 import { PIPELINE_RAIL_COLOR, pipelineRailSegment } from "./agentLinks";
@@ -521,6 +522,22 @@ function PipelineEdgeBadge({ index, total, color, x, y, moveTransition }: { inde
   );
 }
 
+/** Card meta-row recency slot (issue #231). While the agent is live and the
+    turn is open it ticks the elapsed run time («працює 4 хв»); once idle it
+    reverts to the "…ago" label and parks the finished run length in the
+    tooltip («останній прогін: 12 хв»), keeping the visible row uncluttered. */
+function RecencyChip({ file, className }: { file: FileEntry; className?: string }) {
+  const info = recencyTurnInfo(file);
+  if (info.running) {
+    return <span className={`${className ?? ""} shrink-0 font-semibold tabular-nums text-success`}>{info.running}</span>;
+  }
+  return (
+    <span className={`${className ?? ""} shrink-0 tabular-nums text-muted`} title={info.idleTitle ?? undefined}>
+      {fmtAge(file.mtime)}
+    </span>
+  );
+}
+
 /** Quiet history chip inside an expanded under-deck panel. */
 function UnderRow({ file, onSelect }: { file: FileEntry; onSelect: (file: FileEntry) => void }) {
   const badge = engineBadge(file);
@@ -624,7 +641,7 @@ function LiteNodeShell({ node, ringed, dimmed, flow }: { node: SchemeNode; ringe
               map's pointer-events-none layer, so its reason disclosure works at
               390px; the chip's own guard keeps the tap from opening the pane. */}
           <WakeupChip key={wakeupChipKey(node.file.pendingWakeup)} wakeup={node.file.pendingWakeup} className="pointer-events-auto" />
-          <span className="ml-auto shrink-0 text-[11px] text-muted">{fmtAge(node.file.mtime)}</span>
+          <RecencyChip file={node.file} className="ml-auto text-[11px]" />
         </div>
         <div className="min-w-0 flex-1 px-3 py-2.5 text-[14px] font-semibold leading-snug">
           <span className="line-clamp-5">{cleanTitle(node.file.title, 180)}</span>

--- a/src/components/turnDuration.test.ts
+++ b/src/components/turnDuration.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, test } from "bun:test";
+
+import type { FileEntry } from "@/lib/types";
+import { humanizeDuration, recencyTurnInfo, turnDurationSeconds, workedCaption } from "./turnDuration";
+
+describe("humanizeDuration", () => {
+  test("seconds only", () => {
+    expect(humanizeDuration(45, "en")).toBe("45s");
+    expect(humanizeDuration(45, "uk")).toBe("45 с");
+  });
+  test("minutes and seconds, two units deep", () => {
+    expect(humanizeDuration(12 * 60 + 30, "en")).toBe("12m 30s");
+    expect(humanizeDuration(12 * 60 + 30, "uk")).toBe("12 хв 30 с");
+  });
+  test("drops a zero lower unit", () => {
+    expect(humanizeDuration(12 * 60, "en")).toBe("12m");
+    expect(humanizeDuration(3600, "uk")).toBe("1 год");
+  });
+  test("hours and minutes", () => {
+    expect(humanizeDuration(3600 + 5 * 60, "en")).toBe("1h 5m");
+    expect(humanizeDuration(3600 + 5 * 60, "uk")).toBe("1 год 5 хв");
+  });
+  test("clamps negatives to zero", () => {
+    expect(humanizeDuration(-10, "en")).toBe("0s");
+  });
+});
+
+const file = (lastTurn: FileEntry["lastTurn"], activity: FileEntry["activity"] = "idle") =>
+  ({ lastTurn, activity }) as Pick<FileEntry, "lastTurn" | "activity">;
+
+describe("turn caption + recency", () => {
+  test("workedCaption is null while running, set once idle", () => {
+    expect(workedCaption(file({ startedAt: 0, endedAt: null }), "en")).toBeNull();
+    expect(workedCaption(file({ startedAt: 0, endedAt: 90_000 }), "en")).toBe("Worked for 1m 30s");
+    expect(workedCaption(file({ startedAt: 0, endedAt: 90_000 }), "uk")).toBe("Працював 1 хв 30 с");
+  });
+
+  test("turnDurationSeconds guards missing/running turns", () => {
+    expect(turnDurationSeconds(file(null))).toBeNull();
+    expect(turnDurationSeconds(file({ startedAt: 0, endedAt: null }))).toBeNull();
+    expect(turnDurationSeconds(file({ startedAt: 0, endedAt: 5_000 }))).toBe(5);
+  });
+
+  test("live open turn shows running elapsed, no idle tooltip", () => {
+    const info = recencyTurnInfo(file({ startedAt: 0, endedAt: null }, "live"), 4 * 60 * 1000, "en");
+    expect(info.running).toBe("working 4m");
+    expect(info.idleTitle).toBeNull();
+  });
+
+  test("finished turn parks run length in the idle tooltip", () => {
+    const info = recencyTurnInfo(file({ startedAt: 0, endedAt: 12 * 60 * 1000 }, "idle"), Date.now(), "uk");
+    expect(info.running).toBeNull();
+    expect(info.idleTitle).toBe("останній прогін: 12 хв");
+  });
+
+  test("open turn on a non-live card yields neither label", () => {
+    const info = recencyTurnInfo(file({ startedAt: 0, endedAt: null }, "stalled"), Date.now(), "en");
+    expect(info).toEqual({ running: null, idleTitle: null });
+  });
+});

--- a/src/components/turnDuration.ts
+++ b/src/components/turnDuration.ts
@@ -1,0 +1,63 @@
+import { getLocale, translate, type Locale } from "@/lib/i18n";
+import type { FileEntry } from "@/lib/types";
+
+/** Humanized run length, at most two units deep, mirroring the codex TUI's
+    "Worked for …" line. uk uses с/хв/год with spaces («12 хв 30 с»), en the
+    compact "12m 30s". Sub-second and negative inputs clamp to "0 с"/"0s". */
+export function humanizeDuration(seconds: number, locale: Locale = getLocale()): string {
+  const total = Math.max(0, Math.round(seconds));
+  const units = locale === "uk"
+    ? { h: " год", m: " хв", s: " с", sep: " " }
+    : { h: "h", m: "m", s: "s", sep: " " };
+  const h = Math.floor(total / 3600);
+  const m = Math.floor((total % 3600) / 60);
+  const s = total % 60;
+  const seg: string[] = [];
+  if (h > 0) {
+    seg.push(`${h}${units.h}`);
+    if (m > 0) seg.push(`${m}${units.m}`);
+  } else if (m > 0) {
+    seg.push(`${m}${units.m}`);
+    if (s > 0) seg.push(`${s}${units.s}`);
+  } else {
+    seg.push(`${s}${units.s}`);
+  }
+  return seg.join(units.sep);
+}
+
+/** Seconds spanned by a completed turn, or null when it is still running or the
+    boundary is unavailable. */
+export function turnDurationSeconds(file: Pick<FileEntry, "lastTurn">): number | null {
+  const turn = file.lastTurn;
+  if (!turn || turn.endedAt === null) return null;
+  return Math.max(0, (turn.endedAt - turn.startedAt) / 1000);
+}
+
+/** Feed caption after a completed turn: «Працював 12 хв 30 с» / "Worked for 12m 30s".
+    null while the turn runs (the card carries the live elapsed instead). */
+export function workedCaption(file: Pick<FileEntry, "lastTurn">, locale: Locale = getLocale()): string | null {
+  const seconds = turnDurationSeconds(file);
+  if (seconds === null) return null;
+  return translate(locale, "turn.worked", { d: humanizeDuration(seconds, locale) });
+}
+
+/** Recency-slot text plus optional tooltip for a card meta row. While the agent
+    is live and the turn is open, the slot ticks the elapsed time («працює 4 хв»);
+    otherwise callers fall back to their own "…ago" label and, for a finished
+    turn, the run length is parked in the tooltip («останній прогін: 12 хв»). */
+export function recencyTurnInfo(
+  file: Pick<FileEntry, "lastTurn" | "activity">,
+  now = Date.now(),
+  locale: Locale = getLocale(),
+): { running: string | null; idleTitle: string | null } {
+  const turn = file.lastTurn;
+  if (turn && turn.endedAt === null && file.activity === "live") {
+    const elapsed = Math.max(0, (now - turn.startedAt) / 1000);
+    return { running: translate(locale, "turn.running", { d: humanizeDuration(elapsed, locale) }), idleTitle: null };
+  }
+  const seconds = turnDurationSeconds(file);
+  if (seconds !== null) {
+    return { running: null, idleTitle: translate(locale, "turn.lastRun", { d: humanizeDuration(seconds, locale) }) };
+  }
+  return { running: null, idleTitle: null };
+}

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -48,6 +48,9 @@ export const en = {
   "time.agoMin": "{n}m ago",
   "time.agoHour": "{n}h ago",
   "time.agoDay": "{n}d ago",
+  "turn.worked": "Worked for {d}",
+  "turn.running": "working {d}",
+  "turn.lastRun": "last run: {d}",
 
   // Conversation kind labels (display of file.kind discriminant)
   "kind.session": "session",

--- a/src/lib/i18n/uk.ts
+++ b/src/lib/i18n/uk.ts
@@ -45,6 +45,9 @@ export const uk: Record<keyof typeof en, Message> = {
   "time.agoMin": "{n} хв тому",
   "time.agoHour": "{n} год тому",
   "time.agoDay": "{n} д тому",
+  "turn.worked": "Працював {d}",
+  "turn.running": "працює {d}",
+  "turn.lastRun": "останній прогін: {d}",
 
   "kind.session": "сесія",
   "kind.subagent": "субагент",

--- a/src/lib/scanner/index.ts
+++ b/src/lib/scanner/index.ts
@@ -10,6 +10,7 @@ import { resolveTarget } from "../tmux";
 import { tickWorkflows } from "../workflows/engine";
 import { activityVerdict } from "./activity";
 import { ctxFor } from "./context";
+import { lastTurnFor } from "./turnDuration";
 import { discoverFiles, discoverFilesWithProjectCatalog } from "./discover";
 import { entryEffort, entryFast } from "./effort";
 import { linkEntries } from "./links";
@@ -229,6 +230,7 @@ async function listFilesInternal(
     entry.plan = planFor(entry);
     entry.goal = goalFor(entry);
     entry.ctx = ctxFor(entry);
+    entry.lastTurn = lastTurnFor(entry);
     entry.pendingWakeup = pendingWakeupFor(entry);
   });
   await linkEntries(entries, { persist });

--- a/src/lib/scanner/observe.ts
+++ b/src/lib/scanner/observe.ts
@@ -1,6 +1,7 @@
 import type { FileEntry } from "../types";
 import { resolveTarget } from "../tmux";
 import { ctxFor } from "./context";
+import { lastTurnFor } from "./turnDuration";
 import { discoverFiles } from "./discover";
 import { entryEffort, entryFast } from "./effort";
 import { linkEntries } from "./links";
@@ -45,6 +46,7 @@ export async function observeFiles(): Promise<FileEntry[]> {
     const probe = await waitingInputProbe(entry); entry.waitingInput = probe.waiting; entry.rateLimit = probe.rateLimit;
     if (probe.atComposer && entry.activity === "stalled") { entry.activity = Date.now() / 1000 - entry.mtime < 900 ? "recent" : "idle"; entry.activityReason = "pane_at_composer"; }
     entry.plan = planFor(entry); entry.goal = goalFor(entry); entry.ctx = ctxFor(entry);
+    entry.lastTurn = lastTurnFor(entry);
     entry.pendingWakeup = pendingWakeupFor(entry);
   });
   await linkEntries(entries, { persist: false });

--- a/src/lib/scanner/turnDuration.test.ts
+++ b/src/lib/scanner/turnDuration.test.ts
@@ -1,0 +1,166 @@
+import { describe, expect, test } from "bun:test";
+
+import { lastTurnFromRecords } from "./turnDuration";
+
+const ms = (iso: string) => Date.parse(iso);
+
+// ── Claude jsonl record builders ────────────────────────────────────────────
+const claudeUser = (timestamp: string, content: string) => ({
+  type: "user",
+  timestamp,
+  message: { role: "user", content },
+});
+const claudeToolResult = (timestamp: string, id: string) => ({
+  type: "user",
+  timestamp,
+  message: { role: "user", content: [{ type: "tool_result", tool_use_id: id, content: "ok" }] },
+});
+const claudeAssistantOpen = (timestamp: string) => ({
+  type: "assistant",
+  timestamp,
+  message: { role: "assistant", stop_reason: null, content: [{ type: "text", text: "…" }] },
+});
+const claudeAssistantEnd = (timestamp: string) => ({
+  type: "assistant",
+  timestamp,
+  message: { role: "assistant", stop_reason: "end_turn", content: [{ type: "text", text: "done" }] },
+});
+
+// ── Codex rollout record builders ───────────────────────────────────────────
+const codexUser = (timestamp: string, message: string) => ({
+  timestamp,
+  payload: { type: "user_message", message },
+});
+const codexTaskStarted = (timestamp: string) => ({ timestamp, payload: { type: "task_started" } });
+const codexAgentMessage = (timestamp: string) => ({ timestamp, payload: { type: "agent_message", message: "…" } });
+const codexToolCall = (timestamp: string, id: string) => ({
+  timestamp,
+  payload: { type: "function_call", call_id: id, name: "shell" },
+});
+const codexToolOutput = (timestamp: string, id: string) => ({
+  timestamp,
+  payload: { type: "function_call_output", call_id: id, output: "ok" },
+});
+const codexTaskComplete = (timestamp: string) => ({ timestamp, payload: { type: "task_complete" } });
+
+describe("lastTurnFromRecords — Claude", () => {
+  test("completed turn: prompt start to end_turn end", () => {
+    const boundary = lastTurnFromRecords(
+      [
+        claudeUser("2026-07-14T10:00:00.000Z", "hi"),
+        claudeAssistantOpen("2026-07-14T10:00:05.000Z"),
+        claudeToolResult("2026-07-14T10:00:20.000Z", "t1"),
+        claudeAssistantEnd("2026-07-14T10:02:30.000Z"),
+      ],
+      false,
+    );
+    expect(boundary).toEqual({
+      startedAt: ms("2026-07-14T10:00:00.000Z"),
+      endedAt: ms("2026-07-14T10:02:30.000Z"),
+    });
+  });
+
+  test("running turn: no end_turn yet → endedAt null", () => {
+    const boundary = lastTurnFromRecords(
+      [claudeUser("2026-07-14T10:00:00.000Z", "hi"), claudeAssistantOpen("2026-07-14T10:00:05.000Z")],
+      false,
+    );
+    expect(boundary).toEqual({ startedAt: ms("2026-07-14T10:00:00.000Z"), endedAt: null });
+  });
+
+  test("multi-turn: boundaries reflect only the most-recent turn", () => {
+    const boundary = lastTurnFromRecords(
+      [
+        claudeUser("2026-07-14T09:00:00.000Z", "first"),
+        claudeAssistantEnd("2026-07-14T09:01:00.000Z"),
+        claudeUser("2026-07-14T10:00:00.000Z", "second"),
+        claudeAssistantEnd("2026-07-14T10:00:45.000Z"),
+      ],
+      false,
+    );
+    expect(boundary).toEqual({
+      startedAt: ms("2026-07-14T10:00:00.000Z"),
+      endedAt: ms("2026-07-14T10:00:45.000Z"),
+    });
+  });
+
+  test("new prompt after a finished turn with no reply is running", () => {
+    const boundary = lastTurnFromRecords(
+      [
+        claudeUser("2026-07-14T09:00:00.000Z", "first"),
+        claudeAssistantEnd("2026-07-14T09:01:00.000Z"),
+        claudeUser("2026-07-14T10:00:00.000Z", "second"),
+      ],
+      false,
+    );
+    expect(boundary).toEqual({ startedAt: ms("2026-07-14T10:00:00.000Z"), endedAt: null });
+  });
+
+  test("tool-result user records do not count as turn starts", () => {
+    const boundary = lastTurnFromRecords(
+      [
+        claudeUser("2026-07-14T10:00:00.000Z", "hi"),
+        claudeToolResult("2026-07-14T10:00:20.000Z", "t1"),
+        claudeAssistantEnd("2026-07-14T10:00:40.000Z"),
+      ],
+      false,
+    );
+    expect(boundary?.startedAt).toBe(ms("2026-07-14T10:00:00.000Z"));
+  });
+
+  test("no prompt in the window → null", () => {
+    expect(lastTurnFromRecords([claudeAssistantEnd("2026-07-14T10:00:40.000Z")], false)).toBeNull();
+  });
+});
+
+describe("lastTurnFromRecords — Codex", () => {
+  test("completed turn: user_message start to task_complete end", () => {
+    const boundary = lastTurnFromRecords(
+      [
+        codexUser("2026-07-14T10:00:00.000Z", "hi"),
+        codexTaskStarted("2026-07-14T10:00:01.000Z"),
+        codexToolCall("2026-07-14T10:00:05.000Z", "c1"),
+        codexToolOutput("2026-07-14T10:00:12.000Z", "c1"),
+        codexAgentMessage("2026-07-14T10:03:00.000Z"),
+        codexTaskComplete("2026-07-14T10:03:10.000Z"),
+      ],
+      true,
+    );
+    expect(boundary).toEqual({
+      startedAt: ms("2026-07-14T10:00:00.000Z"),
+      endedAt: ms("2026-07-14T10:03:10.000Z"),
+    });
+  });
+
+  test("running turn: open tool call → endedAt null", () => {
+    const boundary = lastTurnFromRecords(
+      [
+        codexUser("2026-07-14T10:00:00.000Z", "hi"),
+        codexTaskStarted("2026-07-14T10:00:01.000Z"),
+        codexToolCall("2026-07-14T10:00:05.000Z", "c1"),
+      ],
+      true,
+    );
+    expect(boundary).toEqual({ startedAt: ms("2026-07-14T10:00:00.000Z"), endedAt: null });
+  });
+
+  test("multi-turn: only the most-recent turn's boundaries", () => {
+    const boundary = lastTurnFromRecords(
+      [
+        codexUser("2026-07-14T08:00:00.000Z", "first"),
+        codexTaskComplete("2026-07-14T08:01:00.000Z"),
+        codexUser("2026-07-14T10:00:00.000Z", "second"),
+        codexTaskComplete("2026-07-14T10:00:30.000Z"),
+      ],
+      true,
+    );
+    expect(boundary).toEqual({
+      startedAt: ms("2026-07-14T10:00:00.000Z"),
+      endedAt: ms("2026-07-14T10:00:30.000Z"),
+    });
+  });
+
+  test("no user message in the window → null", () => {
+    expect(lastTurnFromRecords([codexTaskComplete("2026-07-14T10:00:00.000Z")], true)).toBeNull();
+  });
+});

--- a/src/lib/scanner/turnDuration.ts
+++ b/src/lib/scanner/turnDuration.ts
@@ -1,0 +1,91 @@
+import type { FileEntry, TurnBoundary } from "../types";
+import { turnStateFromRecords as structuredTurnStateFromRecords } from "@/lib/accounts/migration/turnState";
+import { tailRecords } from "./activity";
+import { globalCache } from "./caches";
+import { recordValue, recordsValue, stringValue } from "./json";
+
+type RecordLike = Record<string, unknown>;
+
+const turnBoundaryCache = globalCache<[number, TurnBoundary | null]>("last-turn");
+
+function parseMillis(value: unknown): number | null {
+  if (typeof value !== "string") return null;
+  const millis = Date.parse(value);
+  return Number.isFinite(millis) ? millis : null;
+}
+
+/** True when a transcript record is a prompt that opens a turn — a human or
+    relayed user message, NOT a tool result echoed back as a user record. Both
+    engines are covered: Claude `type:"user"` with real text content, Codex
+    `user_message` / `message`(role user) payloads. Tool-result user records
+    carry only `tool_result`/`function_call_output` parts, so they yield no text
+    and are correctly skipped. */
+function isTurnStart(record: RecordLike, codex: boolean): boolean {
+  if (codex) {
+    const payload = recordValue(record.payload) ?? {};
+    if (stringValue(payload.type) === "user_message") {
+      return (stringValue(payload.message) ?? "").trim().length > 0;
+    }
+    if (stringValue(payload.type) === "message" && payload.role === "user") {
+      return recordsValue(payload.content).some(
+        (part) => (stringValue(part.text) ?? stringValue(part.input_text) ?? "").trim().length > 0,
+      );
+    }
+    return false;
+  }
+  if (record.type !== "user") return false;
+  const content = recordValue(record.message)?.content;
+  if (typeof content === "string") return content.trim().length > 0;
+  return recordsValue(content).some(
+    (part) => part.type === "text" && (stringValue(part.text) ?? "").trim().length > 0,
+  );
+}
+
+/** Turn boundaries for the most-recent turn from a chronological record slice.
+    The turn opens at the LAST prompt in the slice (multi-turn transcripts show
+    only the current turn) and closes at the terminal assistant/tool output —
+    but only once the turn is complete. While the agent is still working
+    `endedAt` stays null so the UI can tick live elapsed. Returns null when no
+    opening prompt survives in the tail window. Pure for testability. */
+export function lastTurnFromRecords(records: RecordLike[], codex: boolean): TurnBoundary | null {
+  let startedAt: number | null = null;
+  for (let index = records.length - 1; index >= 0; index -= 1) {
+    if (!isTurnStart(records[index]!, codex)) continue;
+    startedAt = parseMillis(records[index]!.timestamp);
+    break;
+  }
+  if (startedAt === null) return null;
+
+  const state = structuredTurnStateFromRecords(records, codex);
+  if (state.state !== "terminal") return { startedAt, endedAt: null };
+
+  // A completed turn ends at the terminal lifecycle record's timestamp (the
+  // last assistant/tool output). Fall back to the newest parseable timestamp in
+  // the slice if the terminal record carried none, and never let a clock skew
+  // push the end before the start.
+  let endedAt = parseMillis(state.terminalAt);
+  if (endedAt === null) {
+    for (let index = records.length - 1; index >= 0; index -= 1) {
+      const millis = parseMillis(records[index]!.timestamp);
+      if (millis !== null) {
+        endedAt = millis;
+        break;
+      }
+    }
+  }
+  if (endedAt === null) return { startedAt, endedAt: null };
+  return { startedAt, endedAt: Math.max(endedAt, startedAt) };
+}
+
+/** Last-turn boundaries for a transcript entry, cached by size like the sibling
+    tail derivations (context, effort). Only conversation transcripts carry the
+    per-message timestamps this needs. */
+export function lastTurnFor(entry: FileEntry): TurnBoundary | null {
+  const conversationRoot = entry.root === "claude-projects" || entry.root === "codex-sessions";
+  if (!conversationRoot || !entry.path.endsWith(".jsonl")) return null;
+  const cached = turnBoundaryCache.get(entry.path);
+  if (cached?.[0] === entry.size) return cached[1];
+  const boundary = lastTurnFromRecords(tailRecords(entry.path, entry.size), entry.root === "codex-sessions");
+  turnBoundaryCache.set(entry.path, [entry.size, boundary]);
+  return boundary;
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -102,6 +102,13 @@ export interface FileEntry {
   ctx?: CtxUsage | null;
   /** Codex only: the thread's declared goal (objective + status). */
   goal?: AgentGoal | null;
+  /** Boundaries of the most-recent turn — the prompt (or relayed message) that
+      started it and, once the agent falls idle, the last assistant/tool output
+      that closed it. `endedAt` is null while the turn is still running, so the
+      UI ticks live elapsed; when set, the feed prints a «Worked for …» caption
+      and the card meta row parks the run length in a tooltip. Absent when no
+      turn boundary can be derived from the transcript tail (issue #231). */
+  lastTurn?: TurnBoundary | null;
   /** Best-effort TUI scrape fallback for prompts without a transcript protocol. */
   waitingInput: WaitingInput | null;
   /** Live pane wall or fresh structured account exhaustion. */
@@ -227,6 +234,16 @@ export interface CtxUsage {
   registryVersion?: string;
   /** ISO timestamp of the transcript usage record, with scan time fallback. */
   observedAt: string;
+}
+
+/** Boundaries of a single conversational turn, in Unix epoch **milliseconds**.
+    `startedAt` is the timestamp of the prompt (or relayed message) that opened
+    the turn; `endedAt` is the timestamp of the last assistant/tool output once
+    the agent goes idle, or null while the turn is still running. Derived in the
+    scanner from per-message transcript timestamps for both engines (issue #231). */
+export interface TurnBoundary {
+  startedAt: number;
+  endedAt: number | null;
 }
 
 /** Codex thread goal (update_goal tool / thread_goal_updated events): the


### PR DESCRIPTION
Closes #231.

## What

Measures the **last completed turn** = timestamp of the last assistant/tool output minus the prompt (or relayed message) that started it. While the agent works the value ticks live; multi-turn conversations show the current/most-recent turn only.

## Derivation (scanner/describe layer)

`src/lib/scanner/turnDuration.ts` — pure `lastTurnFromRecords(records, codex)` walks the transcript tail:
- **startedAt** = the last user/relayed prompt (Claude `type:"user"` with real text; Codex `user_message` / `message`(role user)). Tool-result user records are correctly skipped.
- **endedAt** = the terminal assistant/tool output once the turn is complete (via the shared `turnStateFromRecords` lifecycle), or **null while the turn is still running**.

Exposed as `lastTurn: {startedAt, endedAt|null}` (Unix epoch ms) on the card payload, cached by size like the sibling tail derivations (context, effort) and wired into both the `index` and `observe` enrichment passes. **No engine/runtime changes** — `src/lib/{flows,agent,runtime}` untouched.

## UI (two spots, same derivation)

1. **Feed** — a muted caption separator after the final message once idle: «Працював 12 хв 30 с» / "Worked for 12m 30s". Renders only when the turn is finished.
2. **Card meta row** — while running, the recency slot shows live elapsed «працює 4 хв»; when idle it reverts to the "…ago" label and parks the run length in the recency chip's tooltip «останній прогін: 12 хв».

uk/en humanized formatting (с/хв/год), `tabular-nums`.

## Tests & gates

- `src/lib/scanner/turnDuration.test.ts` — boundary derivation for **both engines**, multi-turn, running vs idle, tool-result exclusion, missing-prompt.
- `src/components/turnDuration.test.ts` — humanized formatter + recency/caption helpers (uk+en).
- `bunx tsc --noEmit` ✅ · `bun test` (2610 pass) ✅ · route-export gate ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)