### PR TITLE
Fix delivery recovery and launch readiness

### DIFF
--- a/src/instrumentation.test.ts
+++ b/src/instrumentation.test.ts
@@ -4,7 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import { performance } from "node:perf_hooks";
 
-import { accountControllerDelayMs, initializeOperatorSpawnCapabilityAtStartup, scheduleAccountMigrationController } from "./instrumentation";
+import { accountControllerDelayMs, initializeOperatorSpawnCapabilityAtStartup, runStructuredHostStartup, scheduleAccountMigrationController } from "./instrumentation";
 import { operatorSpawnCapabilityPath } from "@/lib/agent/operatorCapability";
 
 test("account controller delay defaults to immediate startup and retains the explicit escape hatch", () => {
@@ -48,4 +48,16 @@ test("server startup mints the operator capability and rotates it on request", a
     else process.env.LLV_STATE_DIR = previousStateDir;
     fs.rmSync(sandbox, { recursive: true, force: true });
   }
+});
+
+test("structured-host startup logs the thrown adoption error object", async () => {
+  const failure = new Error("container adoption failed");
+  const logged: unknown[][] = [];
+
+  await runStructuredHostStartup(
+    async () => { throw failure; },
+    (...args) => { logged.push(args); },
+  );
+
+  expect(logged).toEqual([["[structured hosts] startup adoption failed", failure]]);
 });

--- a/src/instrumentation.test.ts
+++ b/src/instrumentation.test.ts
@@ -6,6 +6,7 @@ import { performance } from "node:perf_hooks";
 
 import { accountControllerDelayMs, initializeOperatorSpawnCapabilityAtStartup, runStructuredHostStartup, scheduleAccountMigrationController } from "./instrumentation";
 import { operatorSpawnCapabilityPath } from "@/lib/agent/operatorCapability";
+import { didStructuredHostStartupFail, markStructuredHostStartupReady } from "@/lib/runtime/startupStatus";
 
 test("account controller delay defaults to immediate startup and retains the explicit escape hatch", () => {
   expect(accountControllerDelayMs({})).toBe(0);
@@ -54,10 +55,18 @@ test("structured-host startup logs the thrown adoption error object", async () =
   const failure = new Error("container adoption failed");
   const logged: unknown[][] = [];
 
-  await runStructuredHostStartup(
-    async () => { throw failure; },
-    (...args) => { logged.push(args); },
-  );
+  try {
+    await runStructuredHostStartup(
+      async () => { throw failure; },
+      (...args) => { logged.push(args); },
+    );
 
-  expect(logged).toEqual([["[structured hosts] startup adoption failed", failure]]);
+    expect(logged).toEqual([["[structured hosts] startup adoption failed", failure]]);
+    expect(didStructuredHostStartupFail()).toBe(true);
+    await runStructuredHostStartup(async () => undefined, (...args) => { logged.push(args); });
+    expect(didStructuredHostStartupFail()).toBe(false);
+    expect(logged).toHaveLength(1);
+  } finally {
+    markStructuredHostStartupReady();
+  }
 });

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -23,13 +23,23 @@ export async function initializeOperatorSpawnCapabilityAtStartup(
   else ensureOperatorSpawnCapability();
 }
 
+export async function runStructuredHostStartup(
+  adopt: () => Promise<unknown>,
+  log: (...args: unknown[]) => void = console.error,
+): Promise<void> {
+  try {
+    await adopt();
+  } catch (error) {
+    log("[structured hosts] startup adoption failed", error);
+  }
+}
+
 export async function register(): Promise<void> {
   if (process.env.NEXT_RUNTIME === "edge" || process.env.NEXT_PHASE?.includes("build")) return;
   await initializeOperatorSpawnCapabilityAtStartup();
   if (process.env.LLV_STRUCTURED_HOSTS === "1") {
     const { adoptStructuredHostsAtStartup } = await import("@/lib/runtime/startup");
-    try { await adoptStructuredHostsAtStartup(); }
-    catch { console.error("[structured hosts] startup adoption failed"); }
+    await runStructuredHostStartup(adoptStructuredHostsAtStartup);
   }
   if (process.env.LLV_ACCOUNT_CONTROLLER_DISABLED !== "1") {
     const { startAccountMigrationController } = await import("@/lib/accounts/migration/controller");

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -1,3 +1,5 @@
+import { markStructuredHostStartupFailed, markStructuredHostStartupReady } from "@/lib/runtime/startupStatus";
+
 export function accountControllerDelayMs(env: Readonly<Record<string, string | undefined>> = process.env): number {
   const configured = Number(env.LLV_ACCOUNT_CONTROLLER_DELAY_MS ?? 0);
   return Number.isFinite(configured) ? Math.max(0, configured) : 0;
@@ -29,7 +31,9 @@ export async function runStructuredHostStartup(
 ): Promise<void> {
   try {
     await adopt();
+    markStructuredHostStartupReady();
   } catch (error) {
+    markStructuredHostStartupFailed();
     log("[structured hosts] startup adoption failed", error);
   }
 }

--- a/src/lib/agent/registry.test.ts
+++ b/src/lib/agent/registry.test.ts
@@ -163,6 +163,52 @@ describe("agent registry", () => {
     expect(route.receipt.completionMode).toBe("route-recovered");
   });
 
+  test("an observed account-home Claude session recovers a pane-bound late-readiness failure", () => {
+    const store = registry();
+    const sessionId = "88d36d1d-d681-4dc3-ac3b-0b0c54f33c7e";
+    const artifactPath = `/home/user/.config/agent-log-viewer/accounts/claude/work/projects/-repo/${sessionId}.jsonl`;
+    const begun = store.beginSpawnRequest({
+      engine: "claude",
+      cwd: "/repo",
+      accountId: "work",
+    });
+    if (begun.kind !== "created") throw new Error("expected create");
+    const pane = {
+      endpoint: "/run/user/1000/agent-log-viewer",
+      server: { pid: 900, startIdentity: "900:one" },
+      paneId: "%25",
+      panePid: { pid: 100, startIdentity: "100:one" },
+      target: "agents:17.0",
+    };
+    store.bindSpawnPane(begun.receipt.launchId, pane);
+    store.failSpawn(begun.receipt.launchId, "agent never reached a launch-ready prompt");
+
+    const observed = store.completeObservedSpawn(begun.receipt.launchId, {
+      key: { engine: "claude", sessionId },
+      artifactPath,
+      cwd: "/repo",
+      accountId: null,
+      status: "live",
+      host: {
+        kind: "tmux",
+        ...pane,
+        windowName: "claude-new",
+        agent: { pid: 101, startIdentity: "101:one" },
+        argv: ["claude", "--session-id", sessionId],
+      },
+      claimEpoch: 0,
+      claimOwner: null,
+      pendingAction: null,
+    });
+
+    expect(observed).toMatchObject({
+      kind: "settled",
+      receipt: { state: "completed", artifactPath, key: { engine: "claude", sessionId } },
+      entry: { host: { paneId: "%25", argv: ["claude", "--session-id", sessionId] } },
+    });
+    expect(store.conversationForPath(artifactPath)?.id).toBe(begun.receipt.conversationId);
+  });
+
   test("serializes durable operations", async () => {
     const store = registry();
     store.upsert({ key: KEY, artifactPath: "/a", cwd: "/repo", accountId: null, status: "live", host: null, claimEpoch: 0, claimOwner: null, pendingAction: null });

--- a/src/lib/agent/registry.test.ts
+++ b/src/lib/agent/registry.test.ts
@@ -209,6 +209,114 @@ describe("agent registry", () => {
     expect(store.conversationForPath(artifactPath)?.id).toBe(begun.receipt.conversationId);
   });
 
+  test("live pane evidence releases a readiness quarantine and preserves hard identity fences", () => {
+    const store = registry();
+    const begun = store.beginSpawnRequest({ engine: "claude", cwd: "/repo", accountId: "work" });
+    if (begun.kind !== "created") throw new Error("expected create");
+    const binding = {
+      endpoint: "/tmp",
+      server: { pid: 900, startIdentity: null },
+      paneId: "%25",
+      panePid: { pid: 100, startIdentity: null },
+      target: "agents:17.0",
+    };
+    const host = {
+      kind: "tmux" as const,
+      endpoint: "/tmp",
+      server: { pid: 900, startIdentity: "900:observed" },
+      paneId: "%25",
+      panePid: { pid: 100, startIdentity: "100:observed" },
+      windowName: "claude-new",
+      agent: { pid: 101, startIdentity: "101:observed" },
+      argv: ["claude", "--session-id", "88d36d1d-d681-4dc3-ac3b-0b0c54f33c7e"],
+    };
+    store.bindSpawnPane(begun.receipt.launchId, binding);
+    store.failSpawn(begun.receipt.launchId, "agent never reached a launch-ready prompt");
+
+    expect(store.confirmSpawnPaneAlive(begun.receipt.launchId, host, { engine: "claude", cwd: "/repo" })).toMatchObject({
+      state: "host-verified",
+      error: null,
+      verifiedHost: host,
+    });
+
+    const fenced = store.beginSpawnRequest({ engine: "claude", cwd: "/repo", accountId: "work" });
+    if (fenced.kind !== "created") throw new Error("expected create");
+    store.bindSpawnPane(fenced.receipt.launchId, binding);
+    store.invalidateSpawnHost(fenced.receipt.launchId, "spawn_host_identity_conflict");
+    expect(store.confirmSpawnPaneAlive(fenced.receipt.launchId, host, { engine: "claude", cwd: "/repo" })).toMatchObject({
+      state: "conflicted",
+      error: "spawn_host_identity_conflict",
+    });
+
+    const authFailure = store.beginSpawnRequest({ engine: "claude", cwd: "/repo", accountId: "work" });
+    if (authFailure.kind !== "created") throw new Error("expected create");
+    store.bindSpawnPane(authFailure.receipt.launchId, binding);
+    store.failSpawn(authFailure.receipt.launchId, "Claude account work needs re-login. Open Accounts, sign in, and retry.");
+    expect(store.confirmSpawnPaneAlive(authFailure.receipt.launchId, host, { engine: "claude", cwd: "/repo" })).toMatchObject({
+      state: "conflicted",
+      error: "Claude account work needs re-login. Open Accounts, sign in, and retry.",
+    });
+
+    const changedHost = store.beginSpawnRequest({ engine: "claude", cwd: "/repo", accountId: "work" });
+    if (changedHost.kind !== "created") throw new Error("expected create");
+    store.bindSpawnPane(changedHost.receipt.launchId, binding);
+    store.failSpawn(changedHost.receipt.launchId, "spawn host identity changed before launch confirmation");
+    expect(store.confirmSpawnPaneAlive(changedHost.receipt.launchId, host, { engine: "claude", cwd: "/repo" })).toMatchObject({
+      state: "conflicted",
+      error: "spawn host identity changed before launch confirmation",
+    });
+  });
+
+  test("a verified ready-composer host stays available after prompt verification fails", () => {
+    const store = registry();
+    const begun = store.beginSpawnRequest({ engine: "claude", cwd: "/repo", accountId: "work" });
+    if (begun.kind !== "created") throw new Error("expected create");
+    const binding = {
+      endpoint: "/tmp",
+      server: { pid: 900, startIdentity: "900:one" },
+      paneId: "%25",
+      panePid: { pid: 100, startIdentity: "100:one" },
+      target: "agents:17.0",
+    };
+    const host = {
+      kind: "tmux" as const,
+      endpoint: "/tmp",
+      server: binding.server,
+      paneId: binding.paneId,
+      panePid: binding.panePid,
+      windowName: "claude-new",
+      agent: { pid: 101, startIdentity: "101:one" },
+      argv: ["claude", "--session-id", "88d36d1d-d681-4dc3-ac3b-0b0c54f33c7e"],
+    };
+    store.bindSpawnPane(begun.receipt.launchId, binding);
+    store.markSpawnHostVerified(begun.receipt.launchId, host);
+    store.failSpawn(begun.receipt.launchId, "launch prompt was not accepted by the agent: ready composer");
+
+    expect(store.snapshot().receipts[begun.receipt.launchId]).toMatchObject({
+      state: "host-verified",
+      error: "launch prompt was not accepted by the agent: ready composer",
+      verifiedHost: host,
+    });
+    store.failSpawn(begun.receipt.launchId, "tmux paste failed after ready composer");
+    expect(store.snapshot().receipts[begun.receipt.launchId]).toMatchObject({
+      state: "host-verified",
+      error: "tmux paste failed after ready composer",
+      verifiedHost: host,
+    });
+
+    const authFailure = store.beginSpawnRequest({ engine: "claude", cwd: "/repo", accountId: "work" });
+    if (authFailure.kind !== "created") throw new Error("expected create");
+    store.bindSpawnPane(authFailure.receipt.launchId, binding);
+    store.markSpawnHostVerified(authFailure.receipt.launchId, host);
+    store.invalidateSpawnHost(authFailure.receipt.launchId, "Claude account work needs re-login. Open Accounts, sign in, and retry.");
+    store.failSpawn(authFailure.receipt.launchId, "Claude account work needs re-login. Open Accounts, sign in, and retry.");
+    expect(store.snapshot().receipts[authFailure.receipt.launchId]).toMatchObject({
+      state: "conflicted",
+      error: "Claude account work needs re-login. Open Accounts, sign in, and retry.",
+      verifiedHost: null,
+    });
+  });
+
   test("serializes durable operations", async () => {
     const store = registry();
     store.upsert({ key: KEY, artifactPath: "/a", cwd: "/repo", accountId: null, status: "live", host: null, claimEpoch: 0, claimOwner: null, pendingAction: null });

--- a/src/lib/agent/registry.ts
+++ b/src/lib/agent/registry.ts
@@ -2100,6 +2100,26 @@ export class AgentRegistry {
       }
       return { kind: "conflict", receipt: clone(receipt), code };
     };
+    const observedPaneMatches = completionMode === "observed-completed"
+      && receipt.state === "conflicted"
+      && receipt.artifactPath === null
+      && receipt.key === null
+      && receipt.pane !== null
+      && entry.host?.kind === "tmux"
+      && receipt.pane.endpoint === entry.host.endpoint
+      && receipt.pane.paneId === entry.host.paneId
+      && receipt.pane.server.pid === entry.host.server.pid
+      && receipt.pane.server.startIdentity === entry.host.server.startIdentity
+      && receipt.pane.panePid.pid === entry.host.panePid.pid
+      && receipt.pane.panePid.startIdentity === entry.host.panePid.startIdentity
+      && !["spawn_artifact_conflict", "spawn_pane_conflict", "spawn_identity_conflict", "spawn_host_identity_conflict"].includes(receipt.error ?? "");
+    if (observedPaneMatches) {
+      /* A launch verification timeout can race a composer that settles late.
+         Exact pane identity plus the observed engine-native transcript
+         establishes the durable launch owner. */
+      receipt.state = "pane-bound";
+      receipt.error = null;
+    }
     if (receipt.state === "failed" || receipt.state === "conflicted") {
       return {
         kind: "conflict",

--- a/src/lib/agent/registry.ts
+++ b/src/lib/agent/registry.ts
@@ -1353,6 +1353,13 @@ function sqliteMirrorRevision(filename: string): number | null {
   }
 }
 
+function isRecoverableSpawnReadinessFailure(error: string | null): boolean {
+  return error === "agent never reached a launch-ready prompt"
+    || error?.startsWith("agent never reached a launch-ready prompt:") === true
+    || error === "launch prompt was not accepted by the agent"
+    || error?.startsWith("launch prompt was not accepted by the agent:") === true;
+}
+
 /** Durable source for identity and handoff evidence. The lock directory is
     intentionally separate from in-memory promises, so a Viewer replacement
     cannot leave an imaginary owner behind. */
@@ -2089,6 +2096,45 @@ export class AgentRegistry {
     });
   }
 
+  private confirmSpawnPaneAliveInFile(
+    file: RegistryFile,
+    launchId: string,
+    host: TmuxHostEvidence,
+    observed: { engine: Extract<AgentEngine, "claude" | "codex">; cwd: string },
+  ): SpawnReceipt | null {
+    const receipt = file.receipts[launchId];
+    if (!receipt || receipt.state !== "conflicted" || !receipt.pane) return receipt ?? null;
+    if (receipt.engine !== observed.engine || receipt.cwd !== observed.cwd) return receipt;
+    if (!isRecoverableSpawnReadinessFailure(receipt.error)) {
+      return receipt;
+    }
+    const binding = receipt.pane;
+    const serverMatches = binding.server.pid === host.server.pid
+      && (binding.server.startIdentity === null || binding.server.startIdentity === host.server.startIdentity);
+    const paneMatches = binding.paneId === host.paneId
+      && binding.panePid.pid === host.panePid.pid
+      && (binding.panePid.startIdentity === null || binding.panePid.startIdentity === host.panePid.startIdentity);
+    if (!serverMatches || !paneMatches) return receipt;
+    receipt.state = "host-verified";
+    receipt.error = null;
+    receipt.verifiedHost = host;
+    receipt.target = host.paneId;
+    return receipt;
+  }
+
+  confirmSpawnPaneAlive(
+    launchId: string,
+    host: TmuxHostEvidence,
+    observed: { engine: Extract<AgentEngine, "claude" | "codex">; cwd: string },
+  ): SpawnReceipt | null {
+    const current = this.snapshot().receipts[launchId];
+    if (!current || current.state !== "conflicted") return current ? clone(current) : null;
+    return this.mutate((file) => {
+      const receipt = this.confirmSpawnPaneAliveInFile(file, launchId, host, observed);
+      return receipt ? clone(receipt) : null;
+    });
+  }
+
   private settleSpawnInFile(file: RegistryFile, launchId: string, entry: Omit<AgentRegistryEntry, "updatedAt">, completionMode: NonNullable<SpawnReceipt["completionMode"]>): SpawnSettlement {
     const receipt = file.receipts[launchId];
     if (!receipt) throw new Error("unknown spawn receipt");
@@ -2100,25 +2146,10 @@ export class AgentRegistry {
       }
       return { kind: "conflict", receipt: clone(receipt), code };
     };
-    const observedPaneMatches = completionMode === "observed-completed"
-      && receipt.state === "conflicted"
-      && receipt.artifactPath === null
-      && receipt.key === null
-      && receipt.pane !== null
-      && entry.host?.kind === "tmux"
-      && receipt.pane.endpoint === entry.host.endpoint
-      && receipt.pane.paneId === entry.host.paneId
-      && receipt.pane.server.pid === entry.host.server.pid
-      && receipt.pane.server.startIdentity === entry.host.server.startIdentity
-      && receipt.pane.panePid.pid === entry.host.panePid.pid
-      && receipt.pane.panePid.startIdentity === entry.host.panePid.startIdentity
-      && !["spawn_artifact_conflict", "spawn_pane_conflict", "spawn_identity_conflict", "spawn_host_identity_conflict"].includes(receipt.error ?? "");
-    if (observedPaneMatches) {
-      /* A launch verification timeout can race a composer that settles late.
-         Exact pane identity plus the observed engine-native transcript
-         establishes the durable launch owner. */
-      receipt.state = "pane-bound";
-      receipt.error = null;
+    if (completionMode === "observed-completed" && entry.host?.kind === "tmux") {
+      /* Live process evidence can enrich a binding whose birth identity was
+         unavailable during launch verification. */
+      this.confirmSpawnPaneAliveInFile(file, launchId, entry.host, { engine: entry.key.engine, cwd: entry.cwd });
     }
     if (receipt.state === "failed" || receipt.state === "conflicted") {
       return {
@@ -2325,6 +2356,10 @@ export class AgentRegistry {
     this.mutate((file) => {
       const receipt = file.receipts[launchId];
       if (!receipt || receipt.state === "completed" || receipt.state === "failed" || receipt.state === "conflicted") return;
+      if (receipt.state === "host-verified" || receipt.state === "prompt-delivered") {
+        receipt.error = error;
+        return;
+      }
       receipt.state = receipt.pane ? "conflicted" : "failed";
       receipt.error = error;
       if (receipt.state === "conflicted") receipt.verifiedHost = null;

--- a/src/lib/agent/transcriptHost.test.ts
+++ b/src/lib/agent/transcriptHost.test.ts
@@ -99,6 +99,7 @@ interface FakeHostState {
 function fakeHost(
   existing = true,
   reconcile?: (hosts: TranscriptHost[]) => { quarantinedPaneIds: string[] },
+  confirmAlive?: (host: TranscriptHost) => void,
 ) {
   const state: FakeHostState = {
     entry: entry({ pid: existing ? 200 : null, proc: existing ? "running" : null }),
@@ -189,6 +190,7 @@ function fakeHost(
         ? hosts.filter((host) => host.launchId === state.launchId).map((host) => host.paneId)
         : [],
     }),
+    confirmAlive,
     deliver: async (paneId: string, text: string) => {
       state.deliverAttempts += 1;
       if (state.deliverError) throw state.deliverError;
@@ -236,6 +238,10 @@ describe("transcript host resolver", () => {
       target: "agents:4.0",
     });
     registry.failSpawn(begun.receipt.launchId, "agent never reached a launch-ready prompt");
+    expect(registry.snapshot().receipts[begun.receipt.launchId]).toMatchObject({
+      state: "conflicted",
+      error: "agent never reached a launch-ready prompt",
+    });
     const { resolver, state } = fakeHost(true, (hosts) => {
       const quarantinedPaneIds: string[] = [];
       for (const host of hosts) {
@@ -248,9 +254,9 @@ describe("transcript host resolver", () => {
           host: {
             kind: "tmux",
             endpoint: "/tmp",
-            server: { pid: host.tmuxServerPid, startIdentity: null },
+            server: { pid: host.tmuxServerPid, startIdentity: "900:observed" },
             paneId: host.paneId,
-            panePid: { pid: host.panePid, startIdentity: null },
+            panePid: { pid: host.panePid, startIdentity: "100:observed" },
             windowName: host.windowName ?? "",
             agent: { pid: host.agentPid, startIdentity: host.agentIdentity },
             argv: host.agentArgv,
@@ -276,12 +282,53 @@ describe("transcript host resolver", () => {
     state.launchId = begun.receipt.launchId;
 
     expect((await resolver.readTranscriptHosts(true)).canonicalFor(accountPath)?.paneId).toBe("%1");
+    expect(registry.snapshot().receipts[begun.receipt.launchId]).toMatchObject({
+      state: "completed",
+      error: null,
+    });
     expect(await resolver.deliverToTranscriptHost({ entry: state.entry, spec: { ...spec, engine: "claude" }, payload: "composer message" })).toMatchObject({
       ok: true,
       outcome: "delivered-to-live",
       target: "agents:4.0",
     });
     expect(state.delivered).toEqual(["%1:composer message"]);
+    fs.rmSync(directory, { recursive: true, force: true });
+  });
+
+  test("successful composer delivery releases a recoverable pane quarantine", async () => {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-delivery-quarantine-"));
+    const registry = new AgentRegistry(path.join(directory, "registry.json"));
+    const begun = registry.beginSpawnRequest({ engine: "codex", cwd: "/repo", accountId: null });
+    if (begun.kind !== "created") throw new Error("expected create");
+    registry.bindSpawnPane(begun.receipt.launchId, {
+      endpoint: "/tmp",
+      server: { pid: 900, startIdentity: null },
+      paneId: "%1",
+      panePid: { pid: 100, startIdentity: null },
+      target: "agents:4.0",
+    });
+    registry.failSpawn(begun.receipt.launchId, "agent never reached a launch-ready prompt");
+    const { resolver, state } = fakeHost(true, undefined, (host) => {
+      registry.confirmSpawnPaneAlive(begun.receipt.launchId, {
+        kind: "tmux",
+        endpoint: "/tmp",
+        server: { pid: host.tmuxServerPid, startIdentity: "900:observed" },
+        paneId: host.paneId,
+        panePid: { pid: host.panePid, startIdentity: "100:observed" },
+        windowName: host.windowName ?? "",
+        agent: { pid: host.agentPid, startIdentity: host.agentIdentity },
+        argv: host.agentArgv,
+      }, { engine: host.engine, cwd: host.cwd });
+    });
+
+    expect(await resolver.deliverToTranscriptHost({ entry: state.entry, spec, payload: "release quarantine" })).toMatchObject({
+      ok: true,
+      outcome: "delivered-to-live",
+    });
+    expect(registry.snapshot().receipts[begun.receipt.launchId]).toMatchObject({
+      state: "host-verified",
+      error: null,
+    });
     fs.rmSync(directory, { recursive: true, force: true });
   });
 

--- a/src/lib/agent/transcriptHost.test.ts
+++ b/src/lib/agent/transcriptHost.test.ts
@@ -6,7 +6,7 @@ import path from "node:path";
 
 import { withSpawnCapability, type ResumeSpec } from "@/lib/agent/cli";
 import { AgentRegistry } from "@/lib/agent/registry";
-import { beginRegistryResume, createTranscriptHostResolver } from "@/lib/agent/transcriptHost";
+import { beginRegistryResume, createTranscriptHostResolver, type TranscriptHost } from "@/lib/agent/transcriptHost";
 import { TmuxDeliveryUncertainError } from "@/lib/tmux";
 import type { AgentProcess } from "@/lib/scanner/process";
 import type { PaneRef, SpawnedPane } from "@/lib/tmux";
@@ -96,7 +96,10 @@ interface FakeHostState {
   quarantineAfterResumeBegin: boolean;
 }
 
-function fakeHost(existing = true) {
+function fakeHost(
+  existing = true,
+  reconcile?: (hosts: TranscriptHost[]) => { quarantinedPaneIds: string[] },
+) {
   const state: FakeHostState = {
     entry: entry({ pid: existing ? 200 : null, proc: existing ? "running" : null }),
     panes: existing ? new Map([[100, { paneId: "%1", target: "agents:4.0" }]]) : new Map(),
@@ -181,7 +184,7 @@ function fakeHost(existing = true) {
       if (!pane.panePid) return;
       state.records.set(pathname, { paneId: pane.paneId, panePid: pane.panePid, windowName: resumeSpec.windowName, engine: resumeSpec.engine });
     },
-    reconcile: async (hosts) => ({
+    reconcile: async (hosts) => reconcile?.(hosts) ?? ({
       quarantinedPaneIds: state.quarantineAfterResumeBegin && state.resumeBegan
         ? hosts.filter((host) => host.launchId === state.launchId).map((host) => host.paneId)
         : [],
@@ -216,6 +219,70 @@ describe("transcript host resolver", () => {
     });
     expect(state.spawnCalls).toBe(0);
     expect(state.delivered).toEqual(["%1:steer"]);
+  });
+
+  test("resolves dialog and composer delivery for an account-home Claude session after late readiness", async () => {
+    const sessionId = "88d36d1d-d681-4dc3-ac3b-0b0c54f33c7e";
+    const accountPath = `/home/user/.config/agent-log-viewer/accounts/claude/work/projects/-repo/${sessionId}.jsonl`;
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-account-home-host-"));
+    const registry = new AgentRegistry(path.join(directory, "registry.json"));
+    const begun = registry.beginSpawnRequest({ engine: "claude", cwd: "/repo", accountId: "work" });
+    if (begun.kind !== "created") throw new Error("expected create");
+    registry.bindSpawnPane(begun.receipt.launchId, {
+      endpoint: "/tmp",
+      server: { pid: 900, startIdentity: null },
+      paneId: "%1",
+      panePid: { pid: 100, startIdentity: null },
+      target: "agents:4.0",
+    });
+    registry.failSpawn(begun.receipt.launchId, "agent never reached a launch-ready prompt");
+    const { resolver, state } = fakeHost(true, (hosts) => {
+      const quarantinedPaneIds: string[] = [];
+      for (const host of hosts) {
+        const settled = registry.completeObservedSpawn(host.launchId!, {
+          key: { engine: "claude", sessionId },
+          artifactPath: accountPath,
+          cwd: host.cwd,
+          accountId: null,
+          status: "live",
+          host: {
+            kind: "tmux",
+            endpoint: "/tmp",
+            server: { pid: host.tmuxServerPid, startIdentity: null },
+            paneId: host.paneId,
+            panePid: { pid: host.panePid, startIdentity: null },
+            windowName: host.windowName ?? "",
+            agent: { pid: host.agentPid, startIdentity: host.agentIdentity },
+            argv: host.agentArgv,
+          },
+          claimEpoch: 0,
+          claimOwner: null,
+          pendingAction: null,
+        });
+        if (settled.kind === "conflict") quarantinedPaneIds.push(host.paneId);
+      }
+      return { quarantinedPaneIds };
+    });
+    state.entry = entry({
+      path: accountPath,
+      root: "claude-projects",
+      name: accountPath,
+      engine: "claude",
+      fmt: "claude",
+      pid: 200,
+      proc: "running",
+    });
+    state.agents = [{ pid: 200, engine: "claude", argv: ["claude", "--session-id", sessionId], cwd: "/repo", tty: 1 }];
+    state.launchId = begun.receipt.launchId;
+
+    expect((await resolver.readTranscriptHosts(true)).canonicalFor(accountPath)?.paneId).toBe("%1");
+    expect(await resolver.deliverToTranscriptHost({ entry: state.entry, spec: { ...spec, engine: "claude" }, payload: "composer message" })).toMatchObject({
+      ok: true,
+      outcome: "delivered-to-live",
+      target: "agents:4.0",
+    });
+    expect(state.delivered).toEqual(["%1:composer message"]);
+    fs.rmSync(directory, { recursive: true, force: true });
   });
 
   test("serializes two cold sends into one resume and delivers both payloads", async () => {

--- a/src/lib/agent/transcriptHost.ts
+++ b/src/lib/agent/transcriptHost.ts
@@ -107,6 +107,7 @@ interface HostDependencies {
   beginResume?: (entry: FileEntry, spec: ResumeSpec) => { receipt: SpawnReceipt; spec: ResumeSpec } | null;
   remember: (pathname: string, spec: ResumeSpec, pane: SpawnedPane) => Promise<void>;
   deliver: (paneId: string, text: string) => Promise<void>;
+  confirmAlive?: (host: TranscriptHost) => void | Promise<void>;
   launchId?: (paneId: string) => Promise<string | null>;
   conversationIdForPath?: (pathname: string) => string | null;
   reconcile?: (hosts: TranscriptHost[]) => HostReconciliation | void | Promise<HostReconciliation | void>;
@@ -447,6 +448,11 @@ export function createTranscriptHostResolver(
         }
         try {
           await dependencies.deliver(decision.host.paneId, input.payload);
+          try {
+            await dependencies.confirmAlive?.(decision.host);
+          } catch (error) {
+            console.error("[transcript host] live delivery registry confirmation failed", error);
+          }
           return {
             ok: true,
             outcome: owner && resumed ? "resumed" : "delivered-to-live",
@@ -476,25 +482,35 @@ export function createTranscriptHostResolver(
   };
 }
 
+function tmuxEvidenceForHost(host: TranscriptHost): TmuxHostEvidence {
+  return {
+    kind: "tmux",
+    endpoint: tmuxEndpoint(),
+    server: { pid: host.tmuxServerPid, startIdentity: procBackend.processIdentity(host.tmuxServerPid) },
+    paneId: host.paneId,
+    panePid: { pid: host.panePid, startIdentity: procBackend.processIdentity(host.panePid) },
+    windowName: host.windowName ?? "",
+    agent: { pid: host.agentPid, startIdentity: host.agentIdentity },
+    argv: host.agentArgv,
+  };
+}
+
+function confirmRegistryHostAlive(host: TranscriptHost): void {
+  if (host.launchId) {
+    agentRegistry().confirmSpawnPaneAlive(host.launchId, tmuxEvidenceForHost(host), { engine: host.engine, cwd: host.cwd });
+  }
+}
+
 async function reconcileRegistry(hosts: TranscriptHost[]): Promise<HostReconciliation> {
   const registry = agentRegistry();
   const seen = new Set<string>();
   const quarantinedPaneIds = new Set<string>();
   for (const host of hosts) {
+    const evidence = tmuxEvidenceForHost(host);
+    if (host.launchId) registry.confirmSpawnPaneAlive(host.launchId, evidence, { engine: host.engine, cwd: host.cwd });
     if (!host.primaryPath) continue;
     const key = sessionKeyFromTranscript(host.engine, host.primaryPath);
     if (!key) continue;
-    const serverStart = procBackend.processIdentity(host.tmuxServerPid);
-    const evidence: TmuxHostEvidence = {
-      kind: "tmux",
-      endpoint: tmuxEndpoint(),
-      server: { pid: host.tmuxServerPid, startIdentity: serverStart },
-      paneId: host.paneId,
-      panePid: { pid: host.panePid, startIdentity: procBackend.processIdentity(host.panePid) },
-      windowName: host.windowName ?? "",
-      agent: { pid: host.agentPid, startIdentity: host.agentIdentity },
-      argv: host.agentArgv,
-    };
     if (host.launchId) {
       const settled = registry.completeObservedSpawn(host.launchId, {
         key,
@@ -610,6 +626,7 @@ const runtimeResolver = createTranscriptHostResolver({
   spawn: spawnAgentWithPrompt,
   remember: rememberRegistryResume,
   deliver: sendText,
+  confirmAlive: confirmRegistryHostAlive,
   reconcile: reconcileRegistry,
   serializeDelivery: serializeRegistryDelivery,
 }, globalStore.__llvTranscriptHostDecisions ??= new Map());

--- a/src/lib/runtime/startupStatus.test.ts
+++ b/src/lib/runtime/startupStatus.test.ts
@@ -1,0 +1,15 @@
+import { expect, test } from "bun:test";
+
+test("separate bundle module instances share structured startup status", async () => {
+  const moduleCopy = (name: string) => `./startupStatus?${name}`;
+  const instrumentationCopy = await import(moduleCopy("instrumentation-copy"));
+  const routeCopy = await import(moduleCopy("route-copy"));
+  try {
+    instrumentationCopy.markStructuredHostStartupFailed();
+    expect(routeCopy.didStructuredHostStartupFail()).toBe(true);
+    routeCopy.markStructuredHostStartupReady();
+    expect(instrumentationCopy.didStructuredHostStartupFail()).toBe(false);
+  } finally {
+    instrumentationCopy.markStructuredHostStartupReady();
+  }
+});

--- a/src/lib/runtime/startupStatus.ts
+++ b/src/lib/runtime/startupStatus.ts
@@ -1,0 +1,15 @@
+const startupStore = globalThis as typeof globalThis & {
+  __llvStructuredHostStartupFailed?: boolean;
+};
+
+export function markStructuredHostStartupFailed(): void {
+  startupStore.__llvStructuredHostStartupFailed = true;
+}
+
+export function markStructuredHostStartupReady(): void {
+  startupStore.__llvStructuredHostStartupFailed = false;
+}
+
+export function didStructuredHostStartupFail(): boolean {
+  return startupStore.__llvStructuredHostStartupFailed === true;
+}

--- a/src/lib/runtime/structuredMessageDelivery.test.ts
+++ b/src/lib/runtime/structuredMessageDelivery.test.ts
@@ -89,10 +89,19 @@ test("structured message routing is inert while its gate is disabled", async () 
 test("structured message routing falls through after startup adoption leaves no runtime client", async () => {
   const result = await enqueueStructuredMessage(
     { path: artifactPath, text: "hello", hasImages: false },
-    { enabled: () => true, client: () => null },
+    { enabled: () => true, client: () => null, startupFailed: () => true },
   );
 
   expect(result).toBeNull();
+});
+
+test("structured message routing fences a missing runtime client without startup failure evidence", async () => {
+  const result = await enqueueStructuredMessage(
+    { path: artifactPath, text: "hello", hasImages: false },
+    { enabled: () => true, client: () => null, startupFailed: () => false },
+  );
+
+  expect(result).toMatchObject({ ok: false, structured: true, outcome: "failed", status: 503 });
 });
 
 test("structured message routing falls through when the snapshot has no owner for the session", async () => {
@@ -108,17 +117,63 @@ test("structured message routing falls through when the snapshot has no owner fo
   expect(result).toBeNull();
 });
 
-test("structured message routing falls through when the startup snapshot is unavailable", async () => {
+test("structured message routing falls through when failed startup adoption leaves the snapshot unavailable", async () => {
   const client = {
     snapshot: async () => { throw new Error("startup adoption failed"); },
   } as unknown as RuntimeHostClient;
 
   const result = await enqueueStructuredMessage(
     { path: artifactPath, text: "hello", hasImages: false },
-    { enabled: () => true, client: () => client },
+    { enabled: () => true, client: () => client, startupFailed: () => true },
   );
 
   expect(result).toBeNull();
+});
+
+test("structured message routing fences a transient snapshot failure", async () => {
+  const client = {
+    snapshot: async () => { throw new Error("runtime socket timed out"); },
+  } as unknown as RuntimeHostClient;
+
+  const result = await enqueueStructuredMessage(
+    { path: artifactPath, text: "hello", hasImages: false },
+    { enabled: () => true, client: () => client, startupFailed: () => false },
+  );
+
+  expect(result).toMatchObject({
+    ok: false,
+    structured: true,
+    outcome: "failed",
+    status: 503,
+  });
+});
+
+test("structured ownership recovery revokes startup-failure fallback authorization", async () => {
+  let startupFailed = true;
+  let snapshots = 0;
+  const client = {
+    snapshot: async () => {
+      snapshots += 1;
+      if (snapshots === 1) return snapshot();
+      throw new Error("runtime socket timed out after recovery");
+    },
+  } as unknown as RuntimeHostClient;
+  const dependencies = {
+    enabled: () => true,
+    client: () => client,
+    startupFailed: () => startupFailed,
+    startupRecovered: () => { startupFailed = false; },
+  };
+
+  expect(await enqueueStructuredMessage(
+    { path: artifactPath, text: "observe recovery", hasImages: true },
+    dependencies,
+  )).toMatchObject({ ok: false, structured: true, status: 409 });
+  expect(startupFailed).toBe(false);
+  expect(await enqueueStructuredMessage(
+    { path: artifactPath, text: "remain fenced", hasImages: false },
+    dependencies,
+  )).toMatchObject({ ok: false, structured: true, status: 503 });
 });
 
 test("structured message routing only falls through for an explicit legacy owner", async () => {
@@ -135,6 +190,24 @@ test("structured message routing only falls through for an explicit legacy owner
   );
 
   expect(result).toBeNull();
+});
+
+test("structured ownership stays fenced while its registry projection is missing", async () => {
+  const client = {
+    snapshot: async () => snapshot(),
+  } as unknown as RuntimeHostClient;
+  const { registry } = registryWithConversation("missing-projection");
+
+  const result = await enqueueStructuredMessage(
+    { path: artifactPath, conversationId, text: "stay structured", hasImages: false },
+    {
+      enabled: () => true,
+      client: () => client,
+      registry: () => new AgentRegistry(path.join(path.dirname(registry.filename), "missing.json")),
+    },
+  );
+
+  expect(result).toMatchObject({ ok: false, structured: true, outcome: "failed", status: 503 });
 });
 
 test("structured message routing falls through for an unhosted owner", async () => {
@@ -253,11 +326,44 @@ test("held delivery falls through when structured ownership is unavailable", asy
   expect(await deliverHeldStructuredMessage(request, {
     enabled: () => true,
     client: () => null,
+    startupFailed: () => true,
   })).toBeNull();
   expect(await deliverHeldStructuredMessage(request, {
     enabled: () => true,
     client: () => missingSessionClient,
   })).toBeNull();
+});
+
+test("held delivery fences a missing runtime client without startup failure evidence", async () => {
+  expect(await deliverHeldStructuredMessage({
+    conversationId,
+    path: artifactPath,
+    deliveryId: "held-missing-client",
+    clientMessageId: "held-missing-client-message",
+    text: "stay fenced",
+  }, {
+    enabled: () => true,
+    client: () => null,
+    startupFailed: () => false,
+  })).toBe("delivery-uncertain");
+});
+
+test("held delivery stays uncertain during a transient structured snapshot failure", async () => {
+  const client = {
+    snapshot: async () => { throw new Error("runtime socket timed out"); },
+  } as unknown as RuntimeHostClient;
+
+  expect(await deliverHeldStructuredMessage({
+    conversationId,
+    path: artifactPath,
+    deliveryId: "held-transient-snapshot",
+    clientMessageId: "held-transient-snapshot-message",
+    text: "stay fenced",
+  }, {
+    enabled: () => true,
+    client: () => client,
+    startupFailed: () => false,
+  })).toBe("delivery-uncertain");
 });
 
 test("structured message routing holds composer delivery when migration owns the fence", async () => {

--- a/src/lib/runtime/structuredMessageDelivery.test.ts
+++ b/src/lib/runtime/structuredMessageDelivery.test.ts
@@ -86,22 +86,16 @@ test("structured message routing is inert while its gate is disabled", async () 
   expect(called).toBe(false);
 });
 
-test("structured message routing fails closed when runtime ownership is unavailable", async () => {
+test("structured message routing falls through after startup adoption leaves no runtime client", async () => {
   const result = await enqueueStructuredMessage(
     { path: artifactPath, text: "hello", hasImages: false },
     { enabled: () => true, client: () => null },
   );
 
-  expect(result).toEqual({
-    ok: false,
-    structured: true,
-    outcome: "failed",
-    error: "structured host ownership is unavailable; retry after runtime synchronization",
-    status: 503,
-  });
+  expect(result).toBeNull();
 });
 
-test("structured message routing fails closed when the snapshot has no owner", async () => {
+test("structured message routing falls through when the snapshot has no owner for the session", async () => {
   const client = {
     snapshot: async () => ({ ...snapshot(), sessions: [] }),
   } as unknown as RuntimeHostClient;
@@ -111,13 +105,20 @@ test("structured message routing fails closed when the snapshot has no owner", a
     { enabled: () => true, client: () => client },
   );
 
-  expect(result).toEqual({
-    ok: false,
-    structured: true,
-    outcome: "failed",
-    error: "structured host ownership is unavailable; retry after runtime synchronization",
-    status: 503,
-  });
+  expect(result).toBeNull();
+});
+
+test("structured message routing falls through when the startup snapshot is unavailable", async () => {
+  const client = {
+    snapshot: async () => { throw new Error("startup adoption failed"); },
+  } as unknown as RuntimeHostClient;
+
+  const result = await enqueueStructuredMessage(
+    { path: artifactPath, text: "hello", hasImages: false },
+    { enabled: () => true, client: () => client },
+  );
+
+  expect(result).toBeNull();
 });
 
 test("structured message routing only falls through for an explicit legacy owner", async () => {
@@ -136,7 +137,7 @@ test("structured message routing only falls through for an explicit legacy owner
   expect(result).toBeNull();
 });
 
-test("structured message routing fails closed for an unhosted owner", async () => {
+test("structured message routing falls through for an unhosted owner", async () => {
   const unhostedSnapshot = snapshot();
   unhostedSnapshot.sessions[0] = { ...unhostedSnapshot.sessions[0]!, hostKind: "unhosted" };
   const client = { snapshot: async () => unhostedSnapshot } as unknown as RuntimeHostClient;
@@ -146,7 +147,7 @@ test("structured message routing fails closed for an unhosted owner", async () =
     { enabled: () => true, client: () => client },
   );
 
-  expect(result).toMatchObject({ ok: false, structured: true, status: 503 });
+  expect(result).toBeNull();
 });
 
 test("structured message routing returns the durable queued receipt immediately", async () => {
@@ -235,6 +236,28 @@ test("migration-held delivery settles through the runtime journal after EngineHo
     policy: "queue",
   });
   expect(outcome).toBe("delivered");
+});
+
+test("held delivery falls through when structured ownership is unavailable", async () => {
+  const request = {
+    conversationId: "conversation_missing",
+    path: artifactPath,
+    deliveryId: "held-missing-owner",
+    clientMessageId: "held-missing-owner-message",
+    text: "continue through tmux",
+  };
+  const missingSessionClient = {
+    snapshot: async () => ({ ...snapshot(), sessions: [] }),
+  } as unknown as RuntimeHostClient;
+
+  expect(await deliverHeldStructuredMessage(request, {
+    enabled: () => true,
+    client: () => null,
+  })).toBeNull();
+  expect(await deliverHeldStructuredMessage(request, {
+    enabled: () => true,
+    client: () => missingSessionClient,
+  })).toBeNull();
 });
 
 test("structured message routing holds composer delivery when migration owns the fence", async () => {

--- a/src/lib/runtime/structuredMessageDelivery.ts
+++ b/src/lib/runtime/structuredMessageDelivery.ts
@@ -7,6 +7,7 @@ import type { ViewerConversationId } from "@/lib/accounts/migration/contracts";
 import { runtimeHostClient, type RuntimeHostClient } from "./client";
 import type { RuntimeOperationReceipt } from "./contracts";
 import { kickStructuredDeliveryQueue } from "./structuredDeliverySignal";
+import { didStructuredHostStartupFail, markStructuredHostStartupReady } from "./startupStatus";
 
 export interface StructuredMessageRequest {
   path: string;
@@ -31,6 +32,8 @@ export interface StructuredMessageDependencies {
   registry?: () => AgentRegistry;
   kick?: () => void;
   requestMigrationTick?: () => void;
+  startupFailed?: () => boolean;
+  startupRecovered?: () => void;
 }
 
 export interface HeldStructuredMessageRequest {
@@ -45,12 +48,33 @@ export interface HeldStructuredMessageDependencies {
   enabled?: () => boolean;
   client?: () => RuntimeHostClient | null;
   kick?: () => void | Promise<void>;
+  startupFailed?: () => boolean;
+  startupRecovered?: () => void;
 }
 
 export type HeldStructuredMessageOutcome = "delivered" | "failed" | "delivery-uncertain" | null;
 
 function structuredHostsEnabled(): boolean {
   return process.env.LLV_STRUCTURED_HOSTS === "1";
+}
+
+function ownershipUnavailable(): StructuredMessageResult {
+  return {
+    ok: false,
+    structured: true,
+    outcome: "failed",
+    error: "structured host ownership is unavailable; retry after runtime synchronization",
+    status: 503,
+  };
+}
+
+function recordStructuredRuntimeRecovery(
+  snapshot: Awaited<ReturnType<RuntimeHostClient["snapshot"]>>,
+  recovered: () => void,
+): void {
+  if (snapshot.sessions.some((session) => session.hostKind === "codex-app-server" || session.hostKind === "claude-broker")) {
+    recovered();
+  }
 }
 
 function requestMigrationProgress(
@@ -68,13 +92,15 @@ export async function deliverHeldStructuredMessage(
 ): Promise<HeldStructuredMessageOutcome> {
   if (!(dependencies.enabled ?? structuredHostsEnabled)()) return null;
   const client = (dependencies.client ?? runtimeHostClient)();
-  if (!client) return null;
+  if (!client) return (dependencies.startupFailed ?? didStructuredHostStartupFail)() ? null : "delivery-uncertain";
   let snapshot: Awaited<ReturnType<RuntimeHostClient["snapshot"]>>;
   try {
     snapshot = await client.snapshot();
-  } catch {
-    return null;
+  } catch (error) {
+    console.error("[structured delivery] runtime snapshot failed", error);
+    return (dependencies.startupFailed ?? didStructuredHostStartupFail)() ? null : "delivery-uncertain";
   }
+  recordStructuredRuntimeRecovery(snapshot, dependencies.startupRecovered ?? markStructuredHostStartupReady);
   const session = snapshot.sessions.find((candidate) => candidate.conversationId === request.conversationId)
     ?? snapshot.sessions.find((candidate) => candidate.artifactPath === request.path);
   if (!session || session.hostKind === "tmux-legacy") return null;
@@ -108,13 +134,15 @@ export async function enqueueStructuredMessage(
 ): Promise<StructuredMessageResult | null> {
   if (!(dependencies.enabled ?? structuredHostsEnabled)()) return null;
   const client = (dependencies.client ?? runtimeHostClient)();
-  if (!client) return null;
+  if (!client) return (dependencies.startupFailed ?? didStructuredHostStartupFail)() ? null : ownershipUnavailable();
   let snapshot: Awaited<ReturnType<RuntimeHostClient["snapshot"]>>;
   try {
     snapshot = await client.snapshot();
-  } catch {
-    return null;
+  } catch (error) {
+    console.error("[structured delivery] runtime snapshot failed", error);
+    return (dependencies.startupFailed ?? didStructuredHostStartupFail)() ? null : ownershipUnavailable();
   }
+  recordStructuredRuntimeRecovery(snapshot, dependencies.startupRecovered ?? markStructuredHostStartupReady);
   const session = (request.conversationId
     ? snapshot.sessions.find((candidate) => candidate.conversationId === request.conversationId)
     : undefined)
@@ -124,10 +152,10 @@ export async function enqueueStructuredMessage(
   if (request.hasImages) {
     return { ok: false, structured: true, outcome: "failed", error: "structured host image delivery is unavailable", status: 409 };
   }
-  if (!session.conversationId.startsWith("conversation_")) return null;
+  if (!session.conversationId.startsWith("conversation_")) return ownershipUnavailable();
   const registry = (dependencies.registry ?? agentRegistry)();
   const conversation = registry.conversation(session.conversationId as ViewerConversationId);
-  if (!conversation) return null;
+  if (!conversation) return ownershipUnavailable();
   try {
     const idempotencyKey = request.clientMessageId?.trim() || `queue_${crypto.randomUUID()}`;
     let reservation = registry.holdDelivery(conversation.id, request.text, idempotencyKey);

--- a/src/lib/runtime/structuredMessageDelivery.ts
+++ b/src/lib/runtime/structuredMessageDelivery.ts
@@ -53,16 +53,6 @@ function structuredHostsEnabled(): boolean {
   return process.env.LLV_STRUCTURED_HOSTS === "1";
 }
 
-function ownershipUnavailable(): StructuredMessageResult {
-  return {
-    ok: false,
-    structured: true,
-    outcome: "failed",
-    error: "structured host ownership is unavailable; retry after runtime synchronization",
-    status: 503,
-  };
-}
-
 function requestMigrationProgress(
   registry: AgentRegistry,
   conversationId: ViewerConversationId,
@@ -78,15 +68,18 @@ export async function deliverHeldStructuredMessage(
 ): Promise<HeldStructuredMessageOutcome> {
   if (!(dependencies.enabled ?? structuredHostsEnabled)()) return null;
   const client = (dependencies.client ?? runtimeHostClient)();
-  if (!client) return "delivery-uncertain";
+  if (!client) return null;
+  let snapshot: Awaited<ReturnType<RuntimeHostClient["snapshot"]>>;
   try {
-    const snapshot = await client.snapshot();
-    const session = snapshot.sessions.find((candidate) => candidate.conversationId === request.conversationId)
-      ?? snapshot.sessions.find((candidate) => candidate.artifactPath === request.path);
-    if (session?.hostKind === "tmux-legacy") return null;
-    if (!session || (session.hostKind !== "codex-app-server" && session.hostKind !== "claude-broker")) {
-      return "delivery-uncertain";
-    }
+    snapshot = await client.snapshot();
+  } catch {
+    return null;
+  }
+  const session = snapshot.sessions.find((candidate) => candidate.conversationId === request.conversationId)
+    ?? snapshot.sessions.find((candidate) => candidate.artifactPath === request.path);
+  if (!session || session.hostKind === "tmux-legacy") return null;
+  if (session.hostKind !== "codex-app-server" && session.hostKind !== "claude-broker") return null;
+  try {
     const result = await client.command({
       kind: "send",
       operationId: request.deliveryId,
@@ -115,25 +108,27 @@ export async function enqueueStructuredMessage(
 ): Promise<StructuredMessageResult | null> {
   if (!(dependencies.enabled ?? structuredHostsEnabled)()) return null;
   const client = (dependencies.client ?? runtimeHostClient)();
-  if (!client) return ownershipUnavailable();
+  if (!client) return null;
+  let snapshot: Awaited<ReturnType<RuntimeHostClient["snapshot"]>>;
   try {
-    const snapshot = await client.snapshot();
-    const session = (request.conversationId
-      ? snapshot.sessions.find((candidate) => candidate.conversationId === request.conversationId)
-      : undefined)
-      ?? snapshot.sessions.find((candidate) => candidate.artifactPath === request.path);
-    if (!session) return ownershipUnavailable();
-    if (session.hostKind === "tmux-legacy") return null;
-    if (session.hostKind !== "codex-app-server" && session.hostKind !== "claude-broker") {
-      return ownershipUnavailable();
-    }
-    if (request.hasImages) {
-      return { ok: false, structured: true, outcome: "failed", error: "structured host image delivery is unavailable", status: 409 };
-    }
-    if (!session.conversationId.startsWith("conversation_")) return ownershipUnavailable();
-    const registry = (dependencies.registry ?? agentRegistry)();
-    const conversation = registry.conversation(session.conversationId as ViewerConversationId);
-    if (!conversation) return ownershipUnavailable();
+    snapshot = await client.snapshot();
+  } catch {
+    return null;
+  }
+  const session = (request.conversationId
+    ? snapshot.sessions.find((candidate) => candidate.conversationId === request.conversationId)
+    : undefined)
+    ?? snapshot.sessions.find((candidate) => candidate.artifactPath === request.path);
+  if (!session || session.hostKind === "tmux-legacy") return null;
+  if (session.hostKind !== "codex-app-server" && session.hostKind !== "claude-broker") return null;
+  if (request.hasImages) {
+    return { ok: false, structured: true, outcome: "failed", error: "structured host image delivery is unavailable", status: 409 };
+  }
+  if (!session.conversationId.startsWith("conversation_")) return null;
+  const registry = (dependencies.registry ?? agentRegistry)();
+  const conversation = registry.conversation(session.conversationId as ViewerConversationId);
+  if (!conversation) return null;
+  try {
     const idempotencyKey = request.clientMessageId?.trim() || `queue_${crypto.randomUUID()}`;
     let reservation = registry.holdDelivery(conversation.id, request.text, idempotencyKey);
     let claimedReservationId: string | null = null;

--- a/src/lib/status.test.ts
+++ b/src/lib/status.test.ts
@@ -19,6 +19,23 @@ test("a busy turn with the interrupt hint never reads as at-composer", () => {
   expect(screenAtIdleComposer(BUSY_CLAUDE)).toBe(false);
 });
 
+test("informational lines above a ready composer do not hide late launch readiness", () => {
+  const codex = [
+    "Your usage window has reset; the previous turn ended with esc to interrupt.",
+    "",
+    "› ",
+    "  Context 100% used",
+  ].join("\n");
+  const claude = [
+    "❯ Try \"fix typecheck errors\"",
+    "────────────────────────────────────────",
+    "  ⏵⏵ bypass permissions on (shift+tab to cycle)",
+  ].join("\n");
+
+  expect(screenAtIdleComposer(codex)).toBe(true);
+  expect(screenAtIdleComposer(claude)).toBe(true);
+});
+
 test("quiet streamed output without a composer never reads as at-composer", () => {
   expect(screenAtIdleComposer(QUIET_OUTPUT)).toBe(false);
 });

--- a/src/lib/status.ts
+++ b/src/lib/status.ts
@@ -296,8 +296,17 @@ export function launchPromptLanded(engine: "claude" | "codex", screen: string, p
  */
 export function screenAtIdleComposer(screen: string): boolean {
   if (screenWaitsForInput(screen)) return false;
-  const tail = screen.split("\n").slice(-14).join("\n");
-  return composerLine(screen) !== "" && READY_MARKERS.test(tail) && !BUSY_MARKERS.test(tail);
+  const lines = screen.split("\n");
+  let composerIdx = -1;
+  for (let index = lines.length - 1; index >= 0; index -= 1) {
+    if (COMPOSER_PROMPT.test(lines[index] ?? "")) {
+      composerIdx = index;
+      break;
+    }
+  }
+  if (composerIdx === -1) return false;
+  const statusRegion = lines.slice(composerIdx + 1).join("\n");
+  return READY_MARKERS.test(statusRegion) && !BUSY_MARKERS.test(statusRegion);
 }
 
 /** Short readable tail of a captured screen, for error messages and logs. */

--- a/src/lib/tmux.test.ts
+++ b/src/lib/tmux.test.ts
@@ -13,6 +13,7 @@ import {
   resolveTmuxAttach,
   resolveTmuxEndpointContract,
   selectSpawnedAgentProcess,
+  SPAWN_READY_TIMEOUT_MS,
   tmuxAttachCommands,
   tmuxEndpoint,
   verifyTmuxSpawnBinding,
@@ -171,6 +172,10 @@ describe("spawn pane fencing", () => {
     const parents = new Map([[201, 101], [202, 102], [209, 109], [101, 900], [102, 900], [109, 900]]);
     expect(selectSpawnedAgentProcess(109, "codex", "/repo", processes, (pid) => parents.get(pid) ?? null)?.pid).toBe(209);
     expect(selectSpawnedAgentProcess(110, "codex", "/repo", processes, (pid) => parents.get(pid) ?? null)).toBeNull();
+  });
+
+  test("keeps polling through account-home transcript creation latency", () => {
+    expect(SPAWN_READY_TIMEOUT_MS).toBeGreaterThanOrEqual(180_000);
   });
 });
 

--- a/src/lib/tmux.ts
+++ b/src/lib/tmux.ts
@@ -1311,6 +1311,8 @@ async function spawnAgentWithPromptUnchecked(spec: ResumeSpec, text: string, rec
     agent: { pid: agent.pid, startIdentity: agentStartIdentity },
     argv: [...agent.argv],
   };
+  const verified = agentRegistry().markSpawnHostVerified(receipt.launchId, host);
+  if (verified.state === "conflicted") throw new Error(verified.error ?? "spawn host verification conflict");
   logEvent("spawn", {
     target,
     cwd: spec.cwd,
@@ -1320,13 +1322,24 @@ async function spawnAgentWithPromptUnchecked(spec: ResumeSpec, text: string, rec
   });
   const fencedPrompt = fenceViewerSpawnPrompt(spec.engine, text);
   if (fencedPrompt) {
-    await sendText(target, fencedPrompt);
+    try {
+      await sendText(target, fencedPrompt);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      if (message.includes("pane is unavailable") || message.includes("pane identity changed during delivery")) {
+        agentRegistry().invalidateSpawnHost(receipt.launchId, "spawn_host_identity_conflict");
+      }
+      throw error;
+    }
     let promptVerified = false;
     let promptScreen = "";
     for (let round = 0; round < SPAWN_PROMPT_VERIFY_ROUNDS; round += 1) {
       promptScreen = await paneScreen(target, endpoint);
       const promptFailure = detectLaunchFailure(spec.engine, promptScreen);
-      if (promptFailure) throw new Error(promptFailure.message);
+      if (promptFailure) {
+        agentRegistry().invalidateSpawnHost(receipt.launchId, promptFailure.message);
+        throw new Error(promptFailure.message);
+      }
       if (launchPromptLanded(spec.engine, promptScreen, fencedPrompt)) {
         promptVerified = true;
         break;
@@ -1340,10 +1353,9 @@ async function spawnAgentWithPromptUnchecked(spec: ResumeSpec, text: string, rec
     !pidAlive(agent.pid) ||
     (agentStartIdentity !== null && procBackend.processIdentity(agent.pid) !== agentStartIdentity) ||
     ancestryDistance(agent.pid, panePid, readPpid) === null) {
+    agentRegistry().invalidateSpawnHost(receipt.launchId, "spawn_host_identity_conflict");
     throw new Error("spawn host identity changed before launch confirmation");
   }
-  const verified = agentRegistry().markSpawnHostVerified(receipt.launchId, host);
-  if (verified.state === "conflicted") throw new Error(verified.error ?? "spawn host verification conflict");
   agentRegistry().markSpawnPromptDelivered(receipt.launchId);
   return {
     paneId: target,

--- a/src/lib/tmux.ts
+++ b/src/lib/tmux.ts
@@ -1168,7 +1168,7 @@ export async function forgetResumePaneIfMatches(transcriptPath: string, host: Tm
   persistResumePanes();
 }
 
-const SPAWN_READY_TIMEOUT_MS = 60_000;
+export const SPAWN_READY_TIMEOUT_MS = 180_000;
 const SPAWN_POLL_MS = 1_000;
 const SPAWN_PROMPT_VERIFY_ROUNDS = 6;
 const SPAWN_PROMPT_VERIFY_MS = 400;


### PR DESCRIPTION
## Summary\n\n- recover account-home Claude pane ownership after a late launch-ready transcript appears\n- route delivery through tmux when structured startup adoption or per-session ownership is unavailable, while logging the original adoption error\n- recognize ready composers beneath informational lines and poll launch readiness for three minutes\n\n## Verification\n\n- bunx tsc --noEmit\n- bun test: 2661 passed across 283 files\n- bun test src/lib/routeExports.test.ts: 2 passed\n- issue #236 curl delivered to live pane %25 with {"ok":true,"target":"agents:17.0"}\n\nFixes #236\nFixes #235\nFixes #222