### PR TITLE
fix(runtime): harden structured host follow-ups

### DIFF
--- a/src/app/api/runtime/snapshot/route.ts
+++ b/src/app/api/runtime/snapshot/route.ts
@@ -11,7 +11,10 @@ export async function GET(): Promise<NextResponse> {
   const client = runtimeHostClient();
   if (!client) return NextResponse.json({ error: "runtime host socket is unavailable" }, { status: 503 });
   try {
-    return NextResponse.json(await client.snapshot(), { headers: { "cache-control": "no-store" } });
+    return NextResponse.json({
+      ...await client.snapshot(),
+      structuredHostsEnabled: process.env.LLV_STRUCTURED_HOSTS === "1",
+    }, { headers: { "cache-control": "no-store" } });
   } catch (error) {
     return NextResponse.json({ error: error instanceof Error ? error.message : "runtime host is unavailable" }, { status: 503 });
   }

--- a/src/app/api/tmux/route.test.ts
+++ b/src/app/api/tmux/route.test.ts
@@ -42,6 +42,7 @@ let delivery: (message: unknown) => Promise<{ ok: true; outcome: "delivered-to-l
 });
 let killOutcome: { ok: true; target: string } | { ok: false; outcome: "failed"; error: string; status: number } = { ok: true, target: "agents:4.0" };
 let structuredControlCalls = 0;
+let interruptCalls = 0;
 let structuredControlResult:
   | { status: 202; body: { ok: true; structured: true; target: string; operationId: string; receipt: { operationId: string; status: string } } }
   | { status: 409; body: { error: string } }
@@ -86,7 +87,10 @@ mock.module("@/lib/delivery", () => ({
   answerDialogKey: async () => ({ ok: true, target: "" }),
   compactConversation: async () => ({ ok: true, target: "" }),
   deliverConversationMessage: (message: unknown) => delivery(message),
-  interruptConversation: async () => ({ ok: true, target: "" }),
+  interruptConversation: async () => {
+    interruptCalls += 1;
+    return { ok: true, target: "" };
+  },
   killConversation: async () => killOutcome,
   livePaneTarget: async () => null,
   reconfigureConversation: async () => ({ ok: true, outcome: "reconfigured", target: "agents:4.0" }),
@@ -227,13 +231,25 @@ test("/api/tmux POST carries concurrent sends through the delivery seam", async 
 
 test("/api/tmux bypasses persisted structured control state when hosting is disabled", async () => {
   const previous = process.env.LLV_STRUCTURED_HOSTS;
+  const legacyDeliveries: unknown[] = [];
   structuredControlCalls = 0;
+  interruptCalls = 0;
   structuredControlResult = { status: 409, body: { error: "stale structured projection" } };
+  delivery = async (message: unknown) => {
+    legacyDeliveries.push(message);
+    return { ok: true, outcome: "delivered-to-live", target: "agents:4.0" };
+  };
   try {
     process.env.LLV_STRUCTURED_HOSTS = "0";
     const legacy = await POST(post({ path: PATHNAME, action: "resume" }));
+    const send = await POST(post({ path: PATHNAME, text: "continue after rollback" }));
+    const interrupt = await POST(post({ path: PATHNAME, action: "interrupt" }));
     expect(legacy.status).toBe(200);
+    expect(send.status).toBe(200);
+    expect(interrupt.status).toBe(200);
     expect(structuredControlCalls).toBe(0);
+    expect(legacyDeliveries).toHaveLength(1);
+    expect(interruptCalls).toBe(1);
 
     process.env.LLV_STRUCTURED_HOSTS = "1";
     const structured = await POST(post({ path: PATHNAME, action: "resume" }));
@@ -241,6 +257,7 @@ test("/api/tmux bypasses persisted structured control state when hosting is disa
     expect(await structured.json()).toEqual({ error: "stale structured projection" });
     expect(structuredControlCalls).toBe(1);
   } finally {
+    delivery = async () => ({ ok: true, outcome: "delivered-to-live", target: "agents:4.0" });
     structuredControlResult = null;
     if (previous === undefined) delete process.env.LLV_STRUCTURED_HOSTS;
     else process.env.LLV_STRUCTURED_HOSTS = previous;

--- a/src/app/api/tmux/route.test.ts
+++ b/src/app/api/tmux/route.test.ts
@@ -41,6 +41,11 @@ let delivery: (message: unknown) => Promise<{ ok: true; outcome: "delivered-to-l
   target: "agents:4.0",
 });
 let killOutcome: { ok: true; target: string } | { ok: false; outcome: "failed"; error: string; status: number } = { ok: true, target: "agents:4.0" };
+let structuredControlCalls = 0;
+let structuredControlResult:
+  | { status: 202; body: { ok: true; structured: true; target: string; operationId: string; receipt: { operationId: string; status: string } } }
+  | { status: 409; body: { error: string } }
+  | null = null;
 
 const host = {
   paneId: "%1",
@@ -71,7 +76,12 @@ mock.module("@/lib/agent/transcriptHost", () => ({
     return snapshot;
   },
 }));
-mock.module("@/lib/runtime/structuredControls", () => ({ dispatchStructuredControl: async () => null }));
+mock.module("@/lib/runtime/structuredControls", () => ({
+  dispatchStructuredControl: async () => {
+    structuredControlCalls += 1;
+    return structuredControlResult;
+  },
+}));
 mock.module("@/lib/delivery", () => ({
   answerDialogKey: async () => ({ ok: true, target: "" }),
   compactConversation: async () => ({ ok: true, target: "" }),
@@ -90,6 +100,7 @@ mock.module("@/lib/tmux", () => ({
   captureTmuxAttachReference: (value: Record<string, unknown>) => ({ ...value, tmuxServerStartIdentity: "900:one", paneStartIdentity: "100:one" }),
   collectImagePayloads: () => ({ images: [], error: null }),
   killPane: async () => {},
+  paneScreen: async () => "",
   panePidOf: async () => null,
   resolveRequestedTmuxTarget: async (pid: number | null) => (pid === null ? null : pidTargets.get(pid) ?? null),
   resolveTarget: async (pid: number) => pidTargets.get(pid) ?? null,
@@ -212,6 +223,59 @@ test("/api/tmux POST carries concurrent sends through the delivery seam", async 
     { pid: null, path: PATHNAME, text: "first", images: [] },
     { pid: null, path: PATHNAME, text: "second", images: [] },
   ]);
+});
+
+test("/api/tmux bypasses persisted structured control state when hosting is disabled", async () => {
+  const previous = process.env.LLV_STRUCTURED_HOSTS;
+  structuredControlCalls = 0;
+  structuredControlResult = { status: 409, body: { error: "stale structured projection" } };
+  try {
+    process.env.LLV_STRUCTURED_HOSTS = "0";
+    const legacy = await POST(post({ path: PATHNAME, action: "resume" }));
+    expect(legacy.status).toBe(200);
+    expect(structuredControlCalls).toBe(0);
+
+    process.env.LLV_STRUCTURED_HOSTS = "1";
+    const structured = await POST(post({ path: PATHNAME, action: "resume" }));
+    expect(structured.status).toBe(409);
+    expect(await structured.json()).toEqual({ error: "stale structured projection" });
+    expect(structuredControlCalls).toBe(1);
+  } finally {
+    structuredControlResult = null;
+    if (previous === undefined) delete process.env.LLV_STRUCTURED_HOSTS;
+    else process.env.LLV_STRUCTURED_HOSTS = previous;
+  }
+});
+
+test("/api/tmux admits pane-less kill through the structured control path", async () => {
+  const previous = process.env.LLV_STRUCTURED_HOSTS;
+  structuredControlCalls = 0;
+  structuredControlResult = {
+    status: 202,
+    body: {
+      ok: true,
+      structured: true,
+      target: "conversation-kill",
+      operationId: "kill-one",
+      receipt: { operationId: "kill-one", status: "queued" },
+    },
+  };
+  try {
+    process.env.LLV_STRUCTURED_HOSTS = "1";
+    const response = await POST(post({ path: PATHNAME, action: "kill" }));
+    expect(response.status).toBe(202);
+    expect(await response.json()).toMatchObject({
+      ok: true,
+      structured: true,
+      operationId: "kill-one",
+      receipt: { status: "queued" },
+    });
+    expect(structuredControlCalls).toBe(1);
+  } finally {
+    structuredControlResult = null;
+    if (previous === undefined) delete process.env.LLV_STRUCTURED_HOSTS;
+    else process.env.LLV_STRUCTURED_HOSTS = previous;
+  }
 });
 
 test("/api/tmux POST kill never reports success with an empty target", async () => {

--- a/src/app/api/tmux/route.ts
+++ b/src/app/api/tmux/route.ts
@@ -204,7 +204,9 @@ export async function POST(req: NextRequest): Promise<NextResponse<SendResponse 
   }
 
   const explicitAction = typeof body.action === "string" ? body.action : "";
-  const structuredControl = await dispatchStructuredControl({ path: filePath, conversationId, action: explicitAction });
+  const structuredControl = process.env.LLV_STRUCTURED_HOSTS === "1"
+    ? await dispatchStructuredControl({ path: filePath, conversationId, action: explicitAction })
+    : null;
   if (structuredControl) return NextResponse.json(structuredControl.body, { status: structuredControl.status });
 
   if (body.action === "interrupt") return respond(await interruptConversation(filePath));

--- a/src/components/TmuxComposer.test.ts
+++ b/src/components/TmuxComposer.test.ts
@@ -36,9 +36,11 @@ function runtimeSession(structuredControlsEnabled: boolean): RuntimeSessionView 
   };
 }
 
-test("the composer ignores stale structured projections while hosting is disabled", () => {
-  expect(structuredComposerSession(runtimeSession(false))).toBeNull();
-  expect(structuredComposerSession(runtimeSession(true))?.session.conversationId).toBe("conv-one");
+test("the composer follows structured-host gate transitions", () => {
+  const session = runtimeSession(true);
+  expect(structuredComposerSession(session)?.session.conversationId).toBe("conv-one");
+  session.structuredControlsEnabled = false;
+  expect(structuredComposerSession(session)).toBeNull();
 });
 
 test("a failed durable receipt retries with its original delivery key", () => {

--- a/src/components/TmuxComposer.test.ts
+++ b/src/components/TmuxComposer.test.ts
@@ -2,7 +2,44 @@ import { expect, test } from "bun:test";
 import { createElement } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 
-import { deliveryAttemptKey, mergeRuntimeReceipts, RuntimeComposerReceipts } from "./TmuxComposer";
+import type { RuntimeSessionView } from "@/hooks/useRuntime";
+
+import { deliveryAttemptKey, mergeRuntimeReceipts, RuntimeComposerReceipts, structuredComposerSession } from "./TmuxComposer";
+
+function runtimeSession(structuredControlsEnabled: boolean): RuntimeSessionView {
+  return {
+    structuredControlsEnabled,
+    legacy: false,
+    uiState: "idle",
+    attentions: [],
+    receipts: [],
+    session: {
+      conversationId: "conv-one",
+      sessionKey: { engine: "codex", sessionId: "thread-one" },
+      hostKind: "codex-app-server",
+      host: "hosted",
+      turn: "idle",
+      provenance: "structured",
+      revision: 1,
+      attentionIds: [],
+      recentReceipts: [],
+      accountId: "account-one",
+      parentConversationId: null,
+      flowId: null,
+      workflowId: null,
+      cwd: "/repo",
+      artifactPath: "/repo/thread-one.jsonl",
+      capabilities: { steer: true, structuredAttention: true },
+      activeTurnId: null,
+      drift: null,
+    },
+  };
+}
+
+test("the composer ignores stale structured projections while hosting is disabled", () => {
+  expect(structuredComposerSession(runtimeSession(false))).toBeNull();
+  expect(structuredComposerSession(runtimeSession(true))?.session.conversationId).toBe("conv-one");
+});
 
 test("a failed durable receipt retries with its original delivery key", () => {
   expect(deliveryAttemptKey("fresh-key", "held-key")).toBe("held-key");

--- a/src/components/TmuxComposer.tsx
+++ b/src/components/TmuxComposer.tsx
@@ -11,7 +11,7 @@ import { Hint } from "@/components/Hint";
 import { Badge, type BadgeTone } from "@/components/ui/Badge";
 import { useComposer } from "@/hooks/useComposer";
 import { useIsMobile } from "@/hooks/useIsMobile";
-import { interruptRuntime, sendRuntimeMessage, useRuntimeReceiptsForArtifact, useRuntimeSession } from "@/hooks/useRuntime";
+import { interruptRuntime, sendRuntimeMessage, useRuntimeReceiptsForArtifact, useRuntimeSession, type RuntimeSessionView } from "@/hooks/useRuntime";
 import { useTmuxTarget } from "@/hooks/useTmuxTarget";
 import { conversationIdentity } from "@/lib/accounts/identity";
 import { cardMigrationState, migrationHoldsSends } from "@/lib/accounts/migration";
@@ -170,6 +170,13 @@ function nowMs(): number {
   return Date.now();
 }
 
+export function structuredComposerSession(runtimeSession: RuntimeSessionView | null): RuntimeSessionView | null {
+  if (!runtimeSession?.structuredControlsEnabled || runtimeSession.legacy) return null;
+  return runtimeSession.session.hostKind === "codex-app-server" || runtimeSession.session.hostKind === "claude-broker"
+    ? runtimeSession
+    : null;
+}
+
 /**
  * Chat-style composer pinned under the feed. A live pane gets the text typed
  * straight into its tmux pane; a finished resumable conversation boots a new
@@ -184,10 +191,7 @@ export function TmuxComposer({ file, pollPaused = false }: { file: FileEntry; po
      (falls back to path pre-migration). */
   const cardId = conversationIdentity(file);
   const runtimeSession = useRuntimeSession(cardId);
-  const structuredSession = runtimeSession && !runtimeSession.legacy
-    && (runtimeSession.session.hostKind === "codex-app-server" || runtimeSession.session.hostKind === "claude-broker")
-    ? runtimeSession
-    : null;
+  const structuredSession = structuredComposerSession(runtimeSession);
   /* While a card is switching accounts its next send is held for the successor
      (Sol delivery fence): the composer shows the held affordance instead of
      pretending the text reached the live predecessor pane. */

--- a/src/components/runtime/runtimeModel.ts
+++ b/src/components/runtime/runtimeModel.ts
@@ -88,7 +88,7 @@ export type ReceiptStatus =
   | "failed"
   | "uncertain";
 
-export type OperationKind = "send" | "steer" | "interrupt" | "answer" | "spawn";
+export type OperationKind = "send" | "steer" | "interrupt" | "answer" | "kill" | "spawn";
 
 /** Client connection state (Fable §2). `resynced` is a transient note, not a state. */
 export type ConnectionState = "live" | "reconnecting" | "degraded" | "offline";
@@ -258,6 +258,7 @@ export interface RuntimeSnapshot {
   schemaVersion: number;
   snapshotSeq: number;
   retentionFloorSeq: number;
+  structuredHostsEnabled?: boolean;
   serverTime?: string;
   runtime: { hostEpoch: number; health: string };
   filesRevision: number;

--- a/src/hooks/runtimeBus.test.ts
+++ b/src/hooks/runtimeBus.test.ts
@@ -161,6 +161,7 @@ interface Harness {
   clock: Clock;
   sources: FakeEventSource[];
   setSnapshot: (s: RuntimeSnapshot) => void;
+  deferNextFetch: () => { resolveSnapshot: (s: RuntimeSnapshot) => void };
   failFetch: (fail: boolean) => void;
   fetchCalls: () => number;
 }
@@ -171,10 +172,16 @@ function harness(): Harness {
   let currentSnapshot = snapshot(100);
   let shouldFail = false;
   let calls = 0;
+  let deferredFetch: Promise<Response> | null = null;
   const deps: RuntimeBusDeps = {
     fetch: (() => {
       calls += 1;
       if (shouldFail) return Promise.reject(new Error("network"));
+      if (deferredFetch) {
+        const pending = deferredFetch;
+        deferredFetch = null;
+        return pending;
+      }
       return Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve(currentSnapshot) } as unknown as Response);
     }) as FetchLike,
     createEventSource: (url) => {
@@ -193,6 +200,15 @@ function harness(): Harness {
     clock,
     sources,
     setSnapshot: (s) => (currentSnapshot = s),
+    deferNextFetch: () => {
+      let resolveFetch!: (response: Response) => void;
+      deferredFetch = new Promise((resolve) => {
+        resolveFetch = resolve;
+      });
+      return {
+        resolveSnapshot: (s) => resolveFetch({ ok: true, status: 200, json: () => Promise.resolve(s) } as unknown as Response),
+      };
+    },
     failFetch: (fail) => (shouldFail = fail),
     fetchCalls: () => calls,
   };
@@ -373,6 +389,56 @@ describe("runtimeBus degraded fallback", () => {
       live = h.bus.getState().connection === "live";
     }
     expect(live).toBe(true);
+  });
+
+  test("old fallback responses cannot overwrite newer rollback snapshots", async () => {
+    h.bus.start();
+    await flush();
+    h.sources[0]!.open();
+
+    h.sources[0]!.error();
+    h.clock.advance(9_000);
+    await flush();
+    h.sources[h.sources.length - 1]!.error();
+    h.clock.advance(9_000);
+    await flush();
+
+    const oldPoll = h.deferNextFetch();
+    h.sources[h.sources.length - 1]!.error();
+    expect(h.bus.getState().connection).toBe("degraded");
+
+    h.setSnapshot(snapshot(200, { structuredHostsEnabled: false }));
+    h.clock.advance(10_000);
+    await flush();
+
+    oldPoll.resolveSnapshot(snapshot(200, { structuredHostsEnabled: true }));
+    await flush();
+    expect(h.bus.getState()).toMatchObject({
+      connection: "degraded",
+      structuredHostsEnabled: false,
+      store: { cursor: 200 },
+    });
+
+    const teardownPoll = h.deferNextFetch();
+    h.clock.advance(10_000);
+    await flush();
+    h.clock.advance(40_000);
+    await flush();
+    h.sources[h.sources.length - 1]!.open();
+    expect(h.bus.getState()).toMatchObject({
+      connection: "live",
+      structuredHostsEnabled: false,
+      store: { cursor: 200 },
+    });
+
+    teardownPoll.resolveSnapshot(snapshot(150, { structuredHostsEnabled: true }));
+    await flush();
+
+    expect(h.bus.getState()).toMatchObject({
+      connection: "live",
+      structuredHostsEnabled: false,
+      store: { cursor: 200 },
+    });
   });
 
   test("files.revision applied on the stream notifies files subscribers", async () => {

--- a/src/hooks/runtimeBus.test.ts
+++ b/src/hooks/runtimeBus.test.ts
@@ -112,6 +112,7 @@ function snapshot(seq: number, overrides: Partial<RuntimeSnapshot> = {}): Runtim
     snapshotSeq: seq,
     retentionFloorSeq: 0,
     runtime: { hostEpoch: 1, health: "ready" },
+    structuredHostsEnabled: true,
     filesRevision: 1,
     sessions: [
       {
@@ -144,6 +145,16 @@ function snapshot(seq: number, overrides: Partial<RuntimeSnapshot> = {}): Runtim
     ...overrides,
   };
 }
+
+test("the snapshot carries the runtime structured-host gate into client state", async () => {
+  const h = harness();
+  h.setSnapshot(snapshot(101, { structuredHostsEnabled: false }));
+  h.bus.start();
+  await flush();
+
+  expect(h.bus.getState().structuredHostsEnabled).toBeFalse();
+  expect(h.bus.getState().store.sessions.conv_a?.hostKind).toBe("codex-app-server");
+});
 
 interface Harness {
   bus: RuntimeBus;

--- a/src/hooks/runtimeBus.test.ts
+++ b/src/hooks/runtimeBus.test.ts
@@ -245,7 +245,7 @@ describe("runtimeBus reconnect", () => {
   let h: Harness;
   beforeEach(() => (h = harness()));
 
-  test("transport blip reconnects and resumes from the cursor, no new snapshot fetch", async () => {
+  test("transport blip refreshes deployment state and resumes from the cursor", async () => {
     h.bus.start();
     await flush();
     h.sources[0]!.open();
@@ -256,12 +256,26 @@ describe("runtimeBus reconnect", () => {
     expect(h.bus.getState().connection).toBe("reconnecting");
     h.clock.advance(600); // past the first backoff
     await flush();
-    // resumed by reopening the stream from the cursor, not by re-snapshotting
-    expect(h.fetchCalls()).toBe(fetchesBefore);
+    expect(h.fetchCalls()).toBe(fetchesBefore + 1);
     expect(h.sources.length).toBe(2);
     expect(h.sources[1]!.url).toContain("after=101");
     h.sources[1]!.open();
     expect(h.bus.getState().connection).toBe("live");
+  });
+
+  test("a tab refreshes the structured-host gate after a server restart", async () => {
+    h.bus.start();
+    await flush();
+    h.sources[0]!.open();
+    expect(h.bus.getState().structuredHostsEnabled).toBeTrue();
+
+    h.setSnapshot(snapshot(100, { structuredHostsEnabled: false }));
+    h.sources[0]!.error();
+    h.clock.advance(600);
+    await flush();
+
+    expect(h.bus.getState().structuredHostsEnabled).toBeFalse();
+    expect(h.sources[1]!.url).toContain("after=100");
   });
 
   test("heartbeat timeout is treated as a lost transport", async () => {
@@ -340,11 +354,12 @@ describe("runtimeBus degraded fallback", () => {
 
     // The fallback poll refreshes the snapshot every 10s.
     const fetchesBefore = h.fetchCalls();
-    h.setSnapshot(snapshot(120));
+    h.setSnapshot(snapshot(120, { structuredHostsEnabled: false }));
     h.clock.advance(10_000);
     await flush();
     expect(h.fetchCalls()).toBeGreaterThan(fetchesBefore);
     expect(h.bus.getState().store.cursor).toBe(120);
+    expect(h.bus.getState().structuredHostsEnabled).toBeFalse();
 
     // After the SSE retry window, a live stream is attempted again. Open any
     // freshly-created stream promptly (a real EventSource opens on its own),

--- a/src/hooks/runtimeBus.ts
+++ b/src/hooks/runtimeBus.ts
@@ -287,11 +287,29 @@ export function createRuntimeBus(deps: RuntimeBusDeps): RuntimeBus {
   }
 
   /** Resume the live stream: reopen from the cursor so the server replays only
-   *  missing revisions (A3). Fall back to a full snapshot if we never had one,
-   *  or if the cursor turns out to predate retention (server sends `reset`). */
+   *  missing revisions (A3). Refresh the deployment gate before reopening so
+   *  a tab converges after a server restart. */
   function resume(): void {
-    if (hasSnapshot) openStream(state.store.cursor);
-    else void join(false);
+    if (!hasSnapshot) {
+      void join(false);
+      return;
+    }
+    void refreshGateAndResume();
+  }
+
+  async function refreshGateAndResume(): Promise<void> {
+    const myGen = generation;
+    try {
+      const res = await deps.fetch(SNAPSHOT_URL, { headers: { accept: "application/json" } });
+      if (!res.ok) throw new Error(`snapshot ${res.status}`);
+      const snapshot = (await res.json()) as RuntimeSnapshot;
+      if (myGen !== generation) return;
+      setState({ structuredHostsEnabled: snapshot.structuredHostsEnabled === true });
+      openStream(state.store.cursor);
+    } catch {
+      if (myGen !== generation) return;
+      onTransportLost();
+    }
   }
 
   /** Bounded poll fallback: refresh the snapshot every 10s and periodically retry SSE. */
@@ -316,7 +334,12 @@ export function createRuntimeBus(deps: RuntimeBusDeps): RuntimeBus {
       if (!res.ok) throw new Error(`snapshot ${res.status}`);
       const snapshot = (await res.json()) as RuntimeSnapshot;
       const prevFiles = state.store.filesRevision;
-      setState({ store: installSnapshot(snapshot), lastEventAt: deps.now(), connection: "degraded" });
+      setState({
+        store: installSnapshot(snapshot),
+        lastEventAt: deps.now(),
+        connection: "degraded",
+        structuredHostsEnabled: snapshot.structuredHostsEnabled === true,
+      });
       if (snapshot.filesRevision > prevFiles) {
         for (const listener of filesListeners) listener(snapshot.filesRevision);
       }

--- a/src/hooks/runtimeBus.ts
+++ b/src/hooks/runtimeBus.ts
@@ -116,6 +116,9 @@ export function createRuntimeBus(deps: RuntimeBusDeps): RuntimeBus {
   let resyncedTimer: ReturnType<typeof setTimeout> | null = null;
   let fallbackTimer: ReturnType<typeof setInterval> | null = null;
   let sseRetryTimer: ReturnType<typeof setTimeout> | null = null;
+  let fallbackEpoch = 0;
+  let fallbackPollSerial = 0;
+  let fallbackAppliedSerial = 0;
 
   function emit(): void {
     for (const listener of listeners) listener();
@@ -132,6 +135,7 @@ export function createRuntimeBus(deps: RuntimeBusDeps): RuntimeBus {
   }
 
   function clearFallback(): void {
+    fallbackEpoch += 1;
     if (fallbackTimer) deps.clearInterval(fallbackTimer);
     fallbackTimer = null;
     sseRetryTimer = clearTimer(sseRetryTimer);
@@ -316,9 +320,10 @@ export function createRuntimeBus(deps: RuntimeBusDeps): RuntimeBus {
   function startFallback(): void {
     closeSource();
     clearFallback();
+    const myEpoch = fallbackEpoch;
     setState({ connection: "degraded" });
-    void pollFallback();
-    fallbackTimer = deps.setInterval(() => void pollFallback(), FALLBACK_POLL_MS);
+    void pollFallback(myEpoch);
+    fallbackTimer = deps.setInterval(() => void pollFallback(myEpoch), FALLBACK_POLL_MS);
     sseRetryTimer = deps.setTimeout(() => {
       sseRetryTimer = null;
       clearFallback();
@@ -328,11 +333,18 @@ export function createRuntimeBus(deps: RuntimeBusDeps): RuntimeBus {
     }, SSE_RETRY_MS);
   }
 
-  async function pollFallback(): Promise<void> {
+  async function pollFallback(myEpoch: number): Promise<void> {
+    const myPollSerial = ++fallbackPollSerial;
     try {
       const res = await deps.fetch(SNAPSHOT_URL, { headers: { accept: "application/json" } });
       if (!res.ok) throw new Error(`snapshot ${res.status}`);
       const snapshot = (await res.json()) as RuntimeSnapshot;
+      if (
+        myEpoch !== fallbackEpoch
+        || snapshot.snapshotSeq < state.store.cursor
+        || (snapshot.snapshotSeq === state.store.cursor && myPollSerial < fallbackAppliedSerial)
+      ) return;
+      fallbackAppliedSerial = Math.max(fallbackAppliedSerial, myPollSerial);
       const prevFiles = state.store.filesRevision;
       setState({
         store: installSnapshot(snapshot),
@@ -344,6 +356,7 @@ export function createRuntimeBus(deps: RuntimeBusDeps): RuntimeBus {
         for (const listener of filesListeners) listener(snapshot.filesRevision);
       }
     } catch {
+      if (myEpoch !== fallbackEpoch) return;
       // Still down. If nothing has been served for long enough, go offline.
       const last = state.lastEventAt;
       if (last !== null && deps.now() - last >= OFFLINE_AFTER_MS && state.connection !== "offline") {

--- a/src/hooks/runtimeBus.ts
+++ b/src/hooks/runtimeBus.ts
@@ -55,6 +55,7 @@ export interface RuntimeBusState {
   lastEventAt: number | null;
   /** False until start() runs with the flag on — the UI shows nothing live. */
   enabled: boolean;
+  structuredHostsEnabled: boolean;
 }
 
 /** Minimal EventSource surface so tests can inject a fake. */
@@ -97,6 +98,7 @@ export function createRuntimeBus(deps: RuntimeBusDeps): RuntimeBus {
     resyncedAt: null,
     lastEventAt: null,
     enabled: false,
+    structuredHostsEnabled: false,
   };
 
   const listeners = new Set<() => void>();
@@ -183,7 +185,11 @@ export function createRuntimeBus(deps: RuntimeBusDeps): RuntimeBus {
       const snapshot = (await res.json()) as RuntimeSnapshot;
       if (myGen !== generation) return; // superseded while awaiting
       hasSnapshot = true;
-      setState({ store: installSnapshot(snapshot), lastEventAt: deps.now() });
+      setState({
+        store: installSnapshot(snapshot),
+        lastEventAt: deps.now(),
+        structuredHostsEnabled: snapshot.structuredHostsEnabled === true,
+      });
       if (afterCursorReset) noteResynced();
       openStream(snapshot.snapshotSeq);
     } catch {
@@ -346,7 +352,14 @@ export function createRuntimeBus(deps: RuntimeBusDeps): RuntimeBus {
       hasSnapshot = false;
       reconnectAttempts = 0;
       firstFailureAt = null;
-      state = { store: emptyStore(), connection: "offline", resyncedAt: null, lastEventAt: null, enabled: false };
+      state = {
+        store: emptyStore(),
+        connection: "offline",
+        resyncedAt: null,
+        lastEventAt: null,
+        enabled: false,
+        structuredHostsEnabled: false,
+      };
       emit();
     },
   };

--- a/src/hooks/useRuntime.ts
+++ b/src/hooks/useRuntime.ts
@@ -26,6 +26,7 @@ const INERT: RuntimeBusState = {
   resyncedAt: null,
   lastEventAt: null,
   enabled: false,
+  structuredHostsEnabled: false,
 };
 
 /**
@@ -52,6 +53,7 @@ export function useRuntimeBusState(): RuntimeBusState {
 
 export interface RuntimeView {
   enabled: boolean;
+  structuredHostsEnabled: boolean;
   connection: ConnectionState;
   resyncedAt: number | null;
   store: RuntimeStore;
@@ -59,7 +61,13 @@ export interface RuntimeView {
 
 export function useRuntime(): RuntimeView {
   const state = useRuntimeBusState();
-  return { enabled: state.enabled, connection: state.connection, resyncedAt: state.resyncedAt, store: state.store };
+  return {
+    enabled: state.enabled,
+    structuredHostsEnabled: state.structuredHostsEnabled,
+    connection: state.connection,
+    resyncedAt: state.resyncedAt,
+    store: state.store,
+  };
 }
 
 export interface RuntimeSessionView {
@@ -68,11 +76,12 @@ export interface RuntimeSessionView {
   attentions: RuntimeAttention[];
   receipts: RuntimeReceipt[];
   legacy: boolean;
+  structuredControlsEnabled: boolean;
 }
 
 /** Derived view for one hosted session, or null when the bus doesn't carry it. */
 export function useRuntimeSession(conversationId: string | null): RuntimeSessionView | null {
-  const { store } = useRuntime();
+  const { store, structuredHostsEnabled } = useRuntime();
   return useMemo(() => {
     if (!conversationId) return null;
     const session = store.sessions[conversationId];
@@ -84,8 +93,9 @@ export function useRuntimeSession(conversationId: string | null): RuntimeSession
       attentions,
       receipts: session.recentReceipts,
       legacy: session.hostKind === "tmux-legacy",
+      structuredControlsEnabled: structuredHostsEnabled,
     };
-  }, [store, conversationId]);
+  }, [store, structuredHostsEnabled, conversationId]);
 }
 
 /**

--- a/src/lib/agent/registry.ts
+++ b/src/lib/agent/registry.ts
@@ -2489,6 +2489,27 @@ export class AgentRegistry {
     });
   }
 
+  terminateStructuredHost(key: SessionKey): boolean {
+    return this.mutate((file) => {
+      const keyId = sessionKeyId(key);
+      const entry = file.entries[keyId];
+      if (!entry) return false;
+      const replacement = {
+        ...entry,
+        host: null,
+        structuredHost: null,
+        status: "dead" as const,
+        claimOwner: null,
+        pendingAction: null,
+      };
+      const changedHostPaths = activeHostPathsChangedByEntry(file, keyId, replacement);
+      const readinessBefore = migrationReadinessSignature(file, key.engine, changedHostPaths);
+      Object.assign(entry, replacement, { updatedAt: now() });
+      advanceMigrationScopeRevision(file, key.engine, readinessBefore, changedHostPaths);
+      return true;
+    });
+  }
+
   /** Writes mutable host state only while the caller still owns its writer fence. */
   setStructuredHostClaimed(
     key: SessionKey,

--- a/src/lib/agent/registry.ts
+++ b/src/lib/agent/registry.ts
@@ -2557,7 +2557,10 @@ export class AgentRegistry {
     });
   }
 
-  terminateInactiveStructuredHost(conversationId: ViewerConversationId, key: SessionKey): boolean {
+  terminateInactiveStructuredHost(
+    conversationId: ViewerConversationId,
+    key: SessionKey,
+  ): false | "current" | "predecessor" {
     return this.mutate((file) => {
       const conversation = file.conversations[conversationId];
       const keyId = sessionKeyId(key);
@@ -2582,7 +2585,7 @@ export class AgentRegistry {
       const readinessBefore = migrationReadinessSignature(file, key.engine, changedHostPaths);
       Object.assign(entry, replacement, { updatedAt: now() });
       advanceMigrationScopeRevision(file, key.engine, readinessBefore, changedHostPaths);
-      return true;
+      return conversation.generations.at(-1)?.id === key.sessionId ? "current" : "predecessor";
     });
   }
 

--- a/src/lib/agent/registry.ts
+++ b/src/lib/agent/registry.ts
@@ -2557,6 +2557,35 @@ export class AgentRegistry {
     });
   }
 
+  terminateInactiveStructuredHost(conversationId: ViewerConversationId, key: SessionKey): boolean {
+    return this.mutate((file) => {
+      const conversation = file.conversations[conversationId];
+      const keyId = sessionKeyId(key);
+      const entry = file.entries[keyId];
+      if (!conversation
+        || conversation.engine !== key.engine
+        || !conversation.generations.some((generation) => generation.id === key.sessionId)
+        || !entry
+        || entry.host
+        || entry.structuredHost?.process
+        || entry.claimOwner
+        || (entry.status !== "dead" && entry.status !== "unhosted")) return false;
+      const replacement = {
+        ...entry,
+        host: null,
+        structuredHost: null,
+        status: "dead" as const,
+        claimOwner: null,
+        pendingAction: null,
+      };
+      const changedHostPaths = activeHostPathsChangedByEntry(file, keyId, replacement);
+      const readinessBefore = migrationReadinessSignature(file, key.engine, changedHostPaths);
+      Object.assign(entry, replacement, { updatedAt: now() });
+      advanceMigrationScopeRevision(file, key.engine, readinessBefore, changedHostPaths);
+      return true;
+    });
+  }
+
   /** Writes mutable host state only while the caller still owns its writer fence. */
   setStructuredHostClaimed(
     key: SessionKey,

--- a/src/lib/agent/registry.ts
+++ b/src/lib/agent/registry.ts
@@ -2381,6 +2381,44 @@ export class AgentRegistry {
     });
   }
 
+  recoverDeliveredStructuredSpawn(launchId: string): SpawnSettlement {
+    return this.mutate((file) => {
+      const receipt = file.receipts[launchId];
+      if (!receipt) throw new Error("unknown spawn receipt");
+      if (receipt.state === "failed" || receipt.state === "conflicted") {
+        return { kind: "conflict", receipt: clone(receipt), code: "spawn_identity_conflict" };
+      }
+      if (receipt.state !== "path-pending" || !receipt.key || !receipt.artifactPath) {
+        throw new Error("structured spawn recovery identity is incomplete");
+      }
+      const entry = file.entries[sessionKeyId(receipt.key)];
+      const conversation = file.conversations[receipt.conversationId];
+      if (!entry || !conversation || entry.artifactPath !== receipt.artifactPath) {
+        throw new Error("structured spawn recovery identity is unavailable");
+      }
+      if (entry.host || entry.structuredHost?.process || entry.claimOwner
+        || (entry.status !== "dead" && entry.status !== "unhosted")) {
+        throw new Error("structured spawn host loss is unconfirmed");
+      }
+      const replacement = {
+        ...entry,
+        host: null,
+        structuredHost: null,
+        status: "dead" as const,
+        claimOwner: null,
+        pendingAction: null,
+      };
+      const changedHostPaths = activeHostPathsChangedByEntry(file, sessionKeyId(receipt.key), replacement);
+      const readinessBefore = migrationReadinessSignature(file, receipt.key.engine, changedHostPaths);
+      Object.assign(entry, replacement, { updatedAt: now() });
+      receipt.state = "completed";
+      receipt.error = null;
+      receipt.completionMode = receipt.completionMode ?? "route-recovered";
+      advanceMigrationScopeRevision(file, receipt.key.engine, readinessBefore, changedHostPaths);
+      return { kind: "settled", receipt: clone(receipt), entry: clone(entry), conversation: clone(conversation) };
+    });
+  }
+
   settleSpawn(launchId: string, entry: Omit<AgentRegistryEntry, "updatedAt">, completionMode: NonNullable<SpawnReceipt["completionMode"]> = "route-completed"): SpawnSettlement {
     return this.mutate((file) => {
       const paths = new Set([entry.artifactPath]);

--- a/src/lib/runtime/commands.test.ts
+++ b/src/lib/runtime/commands.test.ts
@@ -39,6 +39,21 @@ test("dedicated runtime command parsers freeze the Opus request bodies", () => {
     operationId: "answer-one",
     idempotencyKey: "answer-one",
   });
+  expect(parseRuntimeCommand("spawn", {
+    conversationId: "conv-empty",
+    operationId: "spawn-empty",
+    engine: "codex",
+    cwd: "/repo",
+    prompt: "",
+  })).toMatchObject({ kind: "spawn", cwd: "/repo", prompt: "" });
+  expect(parseRuntimeCommand("kill", {
+    conversationId: "conv-kill",
+    operationId: "kill-one",
+    sessionKey: { engine: "codex", sessionId: "thread-one" },
+  })).toMatchObject({
+    kind: "kill",
+    sessionKey: { engine: "codex", sessionId: "thread-one" },
+  });
 });
 
 test("runtime command parsing rejects malformed and oversized bodies", () => {
@@ -46,5 +61,7 @@ test("runtime command parsing rejects malformed and oversized bodies", () => {
   expect(() => parseRuntimeCommand("interrupt", { conversationId: "conv one", operationId: "interrupt-one" })).toThrow("conversationId is invalid");
   expect(() => parseRuntimeCommand("interrupt", { conversationId: "conv-one", operationId: "interrupt-one", turnId: 42 })).toThrow("turnId is invalid");
   expect(() => parseRuntimeCommand("spawn", { conversationId: "conv-one", operationId: "spawn-one", engine: "codex", cwd: "/repo", prompt: "go", accountId: 42 })).toThrow("accountId is invalid");
+  expect(() => parseRuntimeCommand("spawn", { conversationId: "conv-one", operationId: "spawn-missing", engine: "codex", cwd: "/repo" })).toThrow("prompt is required");
+  expect(() => parseRuntimeCommand("kill", { conversationId: "conv-one", operationId: "kill-missing" })).toThrow("sessionKey is invalid");
   expect(() => parseRuntimeCommand("send", { conversationId: "conv-one", text: "x".repeat(256 * 1024), idempotencyKey: "send-one" })).toThrow("request body exceeds 256 KiB");
 });

--- a/src/lib/runtime/commands.ts
+++ b/src/lib/runtime/commands.ts
@@ -63,6 +63,22 @@ export function parseRuntimeCommand(kind: RuntimeOperationKind, value: unknown):
     };
   }
 
+  if (kind === "kill") {
+    const key = body.sessionKey;
+    if (!key || typeof key !== "object" || Array.isArray(key)) throw new Error("sessionKey is invalid");
+    const candidate = key as Record<string, unknown>;
+    const engine = candidate.engine === "codex" || candidate.engine === "claude" ? candidate.engine : null;
+    const sessionId = typeof candidate.sessionId === "string" ? candidate.sessionId.trim() : "";
+    if (!engine || !sessionId || sessionId.includes(":") || /\s/.test(sessionId)) throw new Error("sessionKey is invalid");
+    return {
+      kind,
+      conversationId,
+      ...(operationId ? { operationId } : {}),
+      idempotencyKey,
+      sessionKey: { engine, sessionId },
+    };
+  }
+
   if (kind === "answer") {
     if (!("resolution" in body)) throw new Error("resolution is required");
     return {
@@ -78,8 +94,9 @@ export function parseRuntimeCommand(kind: RuntimeOperationKind, value: unknown):
   const engine = body.engine === "codex" || body.engine === "claude" ? body.engine : null;
   if (!engine) throw new Error("engine is invalid");
   const cwd = typeof body.cwd === "string" ? body.cwd.trim() : "";
-  const prompt = typeof body.prompt === "string" ? body.prompt.trim() : "";
-  if (!cwd || !prompt) throw new Error("spawn cwd and prompt are required");
+  if (!cwd) throw new Error("spawn cwd is required");
+  if (typeof body.prompt !== "string") throw new Error("prompt is required");
+  const prompt = body.prompt.trim();
   const accountId = optionalNullableId(body.accountId, "accountId");
   const parentConversationId = optionalNullableId(body.parentConversationId, "parentConversationId");
   const sessionId = optionalNullableId(body.sessionId, "sessionId");

--- a/src/lib/runtime/contracts.ts
+++ b/src/lib/runtime/contracts.ts
@@ -38,7 +38,7 @@ export interface RuntimeSessionAxes {
 
 export type RuntimeAttentionKind = "approval" | "permission" | "question" | "waiting_heuristic";
 export type RuntimeAttentionState = "open" | "resolving" | "resolved" | "expired-confirmed" | "cancelled" | "resolution-unknown";
-export type RuntimeOperationKind = "send" | "steer" | "interrupt" | "answer" | "spawn";
+export type RuntimeOperationKind = "send" | "steer" | "interrupt" | "answer" | "kill" | "spawn";
 export type RuntimeReceiptStatus =
   | "pending"
   | "delivering"
@@ -197,6 +197,11 @@ export interface RuntimeInterruptCommand extends RuntimeCommandBase {
   turnId?: string | null;
 }
 
+export interface RuntimeKillCommand extends RuntimeCommandBase {
+  kind: "kill";
+  sessionKey: { engine: RuntimeEngine; sessionId: string };
+}
+
 export interface RuntimeAnswerCommand extends RuntimeCommandBase {
   kind: "answer";
   attentionId: string;
@@ -213,7 +218,7 @@ export interface RuntimeSpawnCommand extends RuntimeCommandBase {
   sessionId?: string | null;
 }
 
-export type RuntimeOperationCommand = RuntimeSendCommand | RuntimeInterruptCommand | RuntimeAnswerCommand | RuntimeSpawnCommand;
+export type RuntimeOperationCommand = RuntimeSendCommand | RuntimeInterruptCommand | RuntimeAnswerCommand | RuntimeKillCommand | RuntimeSpawnCommand;
 
 export interface RuntimeOperationResult {
   operationId: string;

--- a/src/lib/runtime/http.test.ts
+++ b/src/lib/runtime/http.test.ts
@@ -45,7 +45,7 @@ test("runtime command HTTP handling preserves validation, CSRF, status, and conf
       };
     },
   } as unknown as RuntimeHostClient;
-  const deps = { enabled: () => true, client: () => client };
+  const deps = { enabled: () => true, structuredEnabled: () => true, client: () => client };
 
   const accepted = await handleRuntimeCommand(request({ conversationId: "conv-one", text: "continue", idempotencyKey: "send-one" }), "send", deps);
   expect(accepted.status).toBe(202);
@@ -59,7 +59,7 @@ test("runtime command HTTP handling preserves validation, CSRF, status, and conf
   expect(forbidden.status).toBe(403);
 
   const conflictClient = { command: async () => { throw new RuntimeHostUnavailableError("conflict", "idempotency-conflict"); } } as unknown as RuntimeHostClient;
-  const conflict = await handleRuntimeCommand(request({ conversationId: "conv-one", text: "continue", idempotencyKey: "send-one" }), "send", { enabled: () => true, client: () => conflictClient });
+  const conflict = await handleRuntimeCommand(request({ conversationId: "conv-one", text: "continue", idempotencyKey: "send-one" }), "send", { enabled: () => true, structuredEnabled: () => true, client: () => conflictClient });
   expect(conflict.status).toBe(409);
 });
 
@@ -71,6 +71,38 @@ test("runtime command routes fail closed while activation is disabled", async ()
   );
   expect(response.status).toBe(503);
   expect(await response.json()).toEqual({ error: "runtime events are disabled" });
+});
+
+test("direct structured commands stop before runtime admission when hosting is disabled", async () => {
+  const commands: unknown[] = [];
+  const client = {
+    command: async (command: unknown) => {
+      commands.push(command);
+      throw new Error("disabled command reached the runtime host");
+    },
+  } as unknown as RuntimeHostClient;
+  const dependencies: RuntimeHttpDependencies = {
+    enabled: () => true,
+    structuredEnabled: () => false,
+    client: () => client,
+  };
+
+  const send = await handleRuntimeCommand(
+    request({ conversationId: "conv-one", text: "continue", idempotencyKey: "send-disabled" }),
+    "send",
+    dependencies,
+  );
+  const interrupt = await handleRuntimeCommand(
+    request({ conversationId: "conv-one", operationId: "interrupt-disabled" }),
+    "interrupt",
+    dependencies,
+  );
+
+  expect(send.status).toBe(503);
+  expect(interrupt.status).toBe(503);
+  expect(await send.json()).toEqual({ error: "structured hosts are disabled" });
+  expect(await interrupt.json()).toEqual({ error: "structured hosts are disabled" });
+  expect(commands).toEqual([]);
 });
 
 test("direct runtime send and steer commands kick queued delivery for an idle host", async () => {
@@ -100,7 +132,7 @@ test("direct runtime send and steer commands kick queued delivery for an idle ho
     const response = await handleRuntimeCommand(
       request({ conversationId: "conv-one", text: `${kind} message`, idempotencyKey: `${kind}-one` }),
       kind,
-      { enabled: () => true, client: () => client, kick: () => { kicks += 1; } },
+      { enabled: () => true, structuredEnabled: () => true, client: () => client, kick: () => { kicks += 1; } },
     );
     expect(response.status).toBe(202);
   }
@@ -126,7 +158,7 @@ test("answer and interrupt commands kick their queued host controls", async () =
       },
     }),
   } as unknown as RuntimeHostClient;
-  const dependencies = { enabled: () => true, client: () => client, kick: () => { kicks += 1; } };
+  const dependencies = { enabled: () => true, structuredEnabled: () => true, client: () => client, kick: () => { kicks += 1; } };
 
   const answer = await handleRuntimeCommand(request({
     conversationId: "conversation-one",

--- a/src/lib/runtime/http.ts
+++ b/src/lib/runtime/http.ts
@@ -46,6 +46,9 @@ export async function handleRuntimeCommand(
   const rejection = rejectCrossOrigin(request);
   if (rejection) return rejection;
   if (!dependencies.enabled()) return NextResponse.json({ error: "runtime events are disabled" }, { status: 503 });
+  if (!(dependencies.structuredEnabled ?? (() => process.env.LLV_STRUCTURED_HOSTS === "1"))()) {
+    return NextResponse.json({ error: "structured hosts are disabled" }, { status: 503 });
+  }
   let value: unknown;
   try {
     value = await request.json();

--- a/src/lib/runtime/startup.test.ts
+++ b/src/lib/runtime/startup.test.ts
@@ -291,3 +291,113 @@ test("startup reconciles a failed spawn after host adoption fails", async () => 
   journal.close();
   fs.rmSync(directory, { recursive: true, force: true });
 });
+
+test("startup settles a delivered spawn after host adoption fails", async () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-runtime-startup-delivered-spawn-"));
+  const sessionId = crypto.randomUUID();
+  const artifactPath = path.join(directory, `${sessionId}.jsonl`);
+  const registry = new AgentRegistry(path.join(directory, "agent-registry.json"), undefined, undefined, { sqliteMode: "off" });
+  const journal = new RuntimeJournal(path.join(directory, "runtime.sqlite"), { structuredHosts: true });
+  const client = runtimeClient(journal);
+  const profile = emptyLaunchProfile({ cwd: directory });
+  const begun = registry.beginSpawnRequest({ engine: "codex", cwd: directory, accountId: "managed", launchProfile: profile });
+  if (begun.kind !== "created") throw new Error("spawn receipt was unavailable");
+  await client.command({
+    kind: "spawn",
+    operationId: begun.receipt.launchId,
+    idempotencyKey: begun.receipt.launchId,
+    conversationId: begun.receipt.conversationId,
+    engine: "codex",
+    cwd: directory,
+    prompt: "already delivered prompt",
+    accountId: "managed",
+    parentConversationId: null,
+  });
+  const key = { engine: "codex" as const, sessionId };
+  const staged = registry.stageStructuredSpawn(begun.receipt.launchId, {
+    key,
+    artifactPath,
+    cwd: directory,
+    accountId: "managed",
+    launchProfile: profile,
+    status: "idle",
+    host: null,
+    structuredHost: {
+      kind: "codex-app-server",
+      endpoint: "stdio:staged",
+      process: null,
+      eventCursor: 0,
+      protocolVersion: "test-v1",
+      writerClaimEpoch: 0,
+      activeTurnRef: null,
+      pendingAttention: [],
+      activeFlags: [],
+    },
+    claimEpoch: 0,
+    claimOwner: null,
+    pendingAction: "spawn",
+  });
+  if (staged.kind !== "settled") throw new Error("spawn identity was unavailable");
+  await client.transitionOperation(begun.receipt.launchId, "delivered");
+
+  let failedAdoptions = 0;
+  let recoverySendCommands = 0;
+  const startupClient = {
+    ...client,
+    command: async (command: Parameters<RuntimeHostClient["command"]>[0]) => {
+      if (command.kind === "send" || command.kind === "steer") recoverySendCommands += 1;
+      return client.command(command);
+    },
+  } as RuntimeHostClient;
+  const dependencies: StructuredStartupDependencies = {
+    registry,
+    client: startupClient,
+    adopt: async (received) => {
+      const entry = received.snapshot().entries[`codex:${sessionId}`];
+      if (entry?.structuredHost) {
+        failedAdoptions += 1;
+        received.setStructuredHost(key, {
+          ...entry.structuredHost,
+          endpoint: "stdio:released",
+          process: null,
+          activeTurnRef: null,
+          pendingAttention: [],
+          activeFlags: [],
+        }, "dead");
+      }
+      return [];
+    },
+    adoptClaude: async () => [],
+  };
+
+  expect(await adoptStructuredHostsAtStartup(dependencies)).toEqual([]);
+  expect(await adoptStructuredHostsAtStartup(dependencies)).toEqual([]);
+
+  expect(failedAdoptions).toBe(1);
+  expect(registry.snapshot().receipts[begun.receipt.launchId]).toMatchObject({
+    state: "completed",
+    artifactPath,
+    completionMode: "route-recovered",
+  });
+  expect(registry.snapshot().entries[`codex:${sessionId}`]).toMatchObject({
+    status: "dead",
+    structuredHost: null,
+    claimOwner: null,
+    pendingAction: null,
+  });
+  expect((await client.operationStatus(begun.receipt.launchId))?.receipt).toMatchObject({
+    status: "delivered",
+    reason: null,
+  });
+  await expect(client.retryOperation(begun.receipt.launchId)).rejects.toThrow("only failed runtime operations can retry");
+  expect(journal.snapshot().sessions.find((session) => session.conversationId === begun.receipt.conversationId)).toMatchObject({
+    host: "dead",
+    activeTurnId: null,
+  });
+  expect(recoverySendCommands).toBe(0);
+  expect(await client.effectBatch(["runtime.send", "runtime.steer"])).toEqual([]);
+
+  await bindStructuredDeliveryQueue([], { registry, client: null });
+  journal.close();
+  fs.rmSync(directory, { recursive: true, force: true });
+});

--- a/src/lib/runtime/startup.test.ts
+++ b/src/lib/runtime/startup.test.ts
@@ -12,6 +12,21 @@ import { bindStructuredDeliveryQueue } from "./structuredDeliveryController";
 import { enqueueStructuredMessage } from "./structuredMessageDelivery";
 import { adoptStructuredHostsAtStartup, type StructuredStartupDependencies } from "./startup";
 
+function runtimeClient(journal: RuntimeJournal): RuntimeHostClient {
+  return {
+    snapshot: async () => journal.snapshot(),
+    events: async (after) => journal.replay(after),
+    waitEvents: async (after) => journal.replay(after),
+    append: async (event) => journal.append(event),
+    operation: async (event) => journal.append(event),
+    command: async (command) => journal.executeOperation(command),
+    operationStatus: async (operationId) => journal.operationResult(operationId),
+    retryOperation: async (operationId) => journal.retryOperation(operationId),
+    effectBatch: async (kinds, afterEventSeq) => journal.effectBatch(100, kinds, afterEventSeq),
+    transitionOperation: async (operationId, status, details) => journal.transitionOperation(operationId, status, details),
+  } as RuntimeHostClient;
+}
+
 test("server startup delegates managed rows with file credentials and their launch profile", async () => {
   const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-runtime-startup-"));
   const registry = new AgentRegistry(path.join(directory, "agent-registry.json"));
@@ -165,6 +180,112 @@ test("fresh-journal startup projects a live tmux registry row for composer fallb
     registry: () => registry,
   });
   expect(delivery).toBeNull();
+
+  await bindStructuredDeliveryQueue([], { registry, client: null });
+  journal.close();
+  fs.rmSync(directory, { recursive: true, force: true });
+});
+
+test("startup reconciles a failed spawn after host adoption fails", async () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-runtime-startup-failed-spawn-"));
+  const sessionId = crypto.randomUUID();
+  const artifactPath = path.join(directory, `${sessionId}.jsonl`);
+  const registry = new AgentRegistry(path.join(directory, "agent-registry.json"), undefined, undefined, { sqliteMode: "off" });
+  const journal = new RuntimeJournal(path.join(directory, "runtime.sqlite"), { structuredHosts: true });
+  const client = runtimeClient(journal);
+  const profile = emptyLaunchProfile({ cwd: directory });
+  const begun = registry.beginSpawnRequest({ engine: "codex", cwd: directory, accountId: "managed", launchProfile: profile });
+  if (begun.kind !== "created") throw new Error("spawn receipt was unavailable");
+  await client.command({
+    kind: "spawn",
+    operationId: begun.receipt.launchId,
+    idempotencyKey: begun.receipt.launchId,
+    conversationId: begun.receipt.conversationId,
+    engine: "codex",
+    cwd: directory,
+    prompt: "recover after failed adoption",
+    accountId: "managed",
+    parentConversationId: null,
+  });
+  const key = { engine: "codex" as const, sessionId };
+  const staged = registry.stageStructuredSpawn(begun.receipt.launchId, {
+    key,
+    artifactPath,
+    cwd: directory,
+    accountId: "managed",
+    launchProfile: profile,
+    status: "idle",
+    host: null,
+    structuredHost: {
+      kind: "codex-app-server",
+      endpoint: "stdio:staged",
+      process: null,
+      eventCursor: 0,
+      protocolVersion: "test-v1",
+      writerClaimEpoch: 0,
+      activeTurnRef: null,
+      pendingAttention: [],
+      activeFlags: [],
+    },
+    claimEpoch: 0,
+    claimOwner: null,
+    pendingAction: "spawn",
+  });
+  if (staged.kind !== "settled") throw new Error("spawn identity was unavailable");
+  await client.transitionOperation(begun.receipt.launchId, "failed", { reason: "engine process could not resume" });
+
+  let failedAdoptions = 0;
+  const dependencies: StructuredStartupDependencies = {
+    registry,
+    client,
+    adopt: async (received) => {
+      const entry = received.snapshot().entries[`codex:${sessionId}`];
+      if (entry?.structuredHost) {
+        failedAdoptions += 1;
+        received.setStructuredHost(key, {
+          ...entry.structuredHost,
+          endpoint: "stdio:released",
+          process: null,
+          activeTurnRef: null,
+          pendingAttention: [],
+          activeFlags: [],
+        }, "dead");
+      }
+      return [];
+    },
+    adoptClaude: async () => [],
+  };
+
+  expect(await adoptStructuredHostsAtStartup(dependencies)).toEqual([]);
+  expect(await adoptStructuredHostsAtStartup(dependencies)).toEqual([]);
+
+  expect(failedAdoptions).toBe(1);
+  expect(registry.snapshot().receipts[begun.receipt.launchId]).toMatchObject({
+    state: "failed",
+    error: "engine process could not resume",
+  });
+  expect(registry.snapshot().entries[`codex:${sessionId}`]).toMatchObject({
+    status: "dead",
+    structuredHost: null,
+    claimOwner: null,
+    pendingAction: null,
+  });
+  expect((await client.operationStatus(begun.receipt.launchId))?.receipt).toMatchObject({
+    status: "failed",
+    reason: "engine process could not resume",
+  });
+  expect(journal.snapshot().sessions.find((session) => session.conversationId === begun.receipt.conversationId)).toMatchObject({
+    host: "dead",
+    activeTurnId: null,
+  });
+  expect((await client.events(0)).events).toContainEqual(expect.objectContaining({
+    kind: "session-status",
+    payload: expect.objectContaining({
+      conversationId: begun.receipt.conversationId,
+      host: "dead",
+      artifactPath,
+    }),
+  }));
 
   await bindStructuredDeliveryQueue([], { registry, client: null });
   journal.close();

--- a/src/lib/runtime/structuredControls.test.ts
+++ b/src/lib/runtime/structuredControls.test.ts
@@ -45,13 +45,14 @@ function structuredConversation(): { registry: AgentRegistry; path: string; conv
   return { registry, path: pathname, conversationId: begun.receipt.conversationId };
 }
 
-test.each(["compact", "dialog-key", "kill", "reconfigure", "resume"])(
+test.each(["compact", "dialog-key", "reconfigure", "resume"])(
   "structured ownership fences the %s control before legacy routing",
   async (action) => {
     const fixture = structuredConversation();
     const result = await dispatchStructuredControl({ path: fixture.path, conversationId: "", action }, {
       registry: fixture.registry,
       client: null,
+      enabled: () => true,
     });
 
     expect(result).toEqual({ status: 409, body: { error: `structured host does not support the ${action} control` } });
@@ -63,6 +64,7 @@ test("structured ownership resolves from conversation identity", async () => {
   const result = await dispatchStructuredControl({ path: "", conversationId: fixture.conversationId, action: "resume" }, {
     registry: fixture.registry,
     client: null,
+    enabled: () => true,
   });
 
   expect(result).toEqual({ status: 409, body: { error: "structured host does not support the resume control" } });
@@ -76,7 +78,7 @@ test("structured interrupt uses the runtime command channel", async () => {
       commands.push(command);
       return { operationId: "interrupt-one", receipt: { operationId: "interrupt-one", status: "pending" }, replayed: false };
     },
-  } as RuntimeHostClient;
+  } as unknown as RuntimeHostClient;
   let kicks = 0;
 
   const result = await dispatchStructuredControl({ path: fixture.path, conversationId: "", action: "interrupt" }, {
@@ -84,6 +86,7 @@ test("structured interrupt uses the runtime command channel", async () => {
     client,
     operationId: () => "interrupt-one",
     kick: () => { kicks += 1; },
+    enabled: () => true,
   });
 
   expect(result).toMatchObject({ status: 202, body: { ok: true, structured: true, target: fixture.conversationId } });
@@ -97,8 +100,58 @@ test("structured interrupt uses the runtime command channel", async () => {
   expect(kicks).toBe(1);
 });
 
+test("structured kill enters the durable runtime command channel", async () => {
+  const fixture = structuredConversation();
+  const commands: unknown[] = [];
+  const client = {
+    command: async (command: unknown) => {
+      commands.push(command);
+      return { operationId: "kill-one", receipt: { operationId: "kill-one", status: "pending" }, replayed: false };
+    },
+  } as unknown as RuntimeHostClient;
+  let kicks = 0;
+
+  const result = await dispatchStructuredControl({ path: fixture.path, conversationId: "", action: "kill" }, {
+    registry: fixture.registry,
+    client,
+    operationId: () => "kill-one",
+    kick: () => { kicks += 1; },
+    enabled: () => true,
+  });
+
+  expect(result).toMatchObject({ status: 202, body: { ok: true, structured: true, target: fixture.conversationId } });
+  expect(commands).toEqual([{
+    kind: "kill",
+    operationId: "kill-one",
+    idempotencyKey: "kill-one",
+    conversationId: fixture.conversationId,
+    sessionKey: { engine: "codex", sessionId: expect.any(String) },
+  }]);
+  expect(kicks).toBe(1);
+});
+
+test("disabled structured hosting leaves persisted ownership on the legacy control path", async () => {
+  const fixture = structuredConversation();
+  const commands: unknown[] = [];
+  const client = {
+    command: async (command: unknown) => {
+      commands.push(command);
+      throw new Error("disabled structured control reached the runtime host");
+    },
+  } as unknown as RuntimeHostClient;
+
+  const result = await dispatchStructuredControl({ path: fixture.path, conversationId: "", action: "interrupt" }, {
+    registry: fixture.registry,
+    client,
+    enabled: () => false,
+  });
+
+  expect(result).toBeNull();
+  expect(commands).toEqual([]);
+});
+
 test("ordinary message routing remains outside the explicit-control module", async () => {
   const fixture = structuredConversation();
-  expect(await dispatchStructuredControl({ path: fixture.path, conversationId: "", action: "" }, { registry: fixture.registry }))
+  expect(await dispatchStructuredControl({ path: fixture.path, conversationId: "", action: "" }, { registry: fixture.registry, enabled: () => true }))
     .toBeNull();
 });

--- a/src/lib/runtime/structuredControls.ts
+++ b/src/lib/runtime/structuredControls.ts
@@ -22,9 +22,11 @@ export async function dispatchStructuredControl(
     client?: RuntimeHostClient | null;
     operationId?: () => string;
     kick?: () => void;
+    enabled?: () => boolean;
   } = {},
 ): Promise<StructuredControlResult | null> {
   if (!request.action) return null;
+  if (!(dependencies.enabled ?? (() => process.env.LLV_STRUCTURED_HOSTS === "1"))()) return null;
   const registry = dependencies.registry ?? agentRegistry();
   const conversation = request.path
     ? registry.conversationForPath(request.path)
@@ -36,7 +38,7 @@ export async function dispatchStructuredControl(
   const entry = registry.snapshot().entries[sessionKeyId({ engine: conversation.engine, sessionId: generation.id })];
   if (!entry?.structuredHost) return null;
 
-  if (request.action !== "interrupt") {
+  if (request.action !== "interrupt" && request.action !== "kill") {
     const label = ["compact", "dialog-key", "kill", "reconfigure", "resume"].includes(request.action)
       ? request.action
       : "requested";
@@ -47,13 +49,21 @@ export async function dispatchStructuredControl(
   if (!client) return { status: 503, body: { error: "structured runtime host is unavailable" } };
   try {
     const operationId = (dependencies.operationId ?? newOperationId)();
-    const result = await client.command({
-      kind: "interrupt",
-      operationId,
-      idempotencyKey: operationId,
-      conversationId: conversation.id,
-      turnId: entry.structuredHost.activeTurnRef,
-    });
+    const result = await client.command(request.action === "kill"
+      ? {
+          kind: "kill",
+          operationId,
+          idempotencyKey: operationId,
+          conversationId: conversation.id,
+          sessionKey: { engine: conversation.engine, sessionId: generation.id },
+        }
+      : {
+          kind: "interrupt",
+          operationId,
+          idempotencyKey: operationId,
+          conversationId: conversation.id,
+          turnId: entry.structuredHost.activeTurnRef,
+        });
     (dependencies.kick ?? kickStructuredDeliveryQueue)();
     return {
       status: 202,

--- a/src/lib/runtime/structuredDeliveryController.ts
+++ b/src/lib/runtime/structuredDeliveryController.ts
@@ -226,10 +226,17 @@ export async function bindStructuredDeliveryQueue(
     const observable = item.host as ObservableEngineHost;
     const unsubscribe = observable.onStateChange((state) => {
       const previous = publishChains.get(key) ?? Promise.resolve();
-      const next = previous
-        .then(() => publishHostState(client, registry, item, state))
-        .then(() => queue.drain())
-        .catch(() => { console.error("[structured delivery] host state sync failed"); });
+      const next = previous.then(async () => {
+        try {
+          await publishHostState(client, registry, item, state);
+        } catch {
+          console.error("[structured delivery] host state sync failed");
+          return;
+        }
+        void queue.drain().catch(() => {
+          console.error("[structured delivery] host state drain failed");
+        });
+      });
       publishChains.set(key, next);
     });
     const entry = entryForHost(registry, item);

--- a/src/lib/runtime/structuredDeliveryController.ts
+++ b/src/lib/runtime/structuredDeliveryController.ts
@@ -24,6 +24,7 @@ interface ControllerState {
   activeHosts: Map<string, EngineHost> | null;
   registerActiveHost: ((item: StructuredDeliveryHost) => Promise<() => Promise<void>>) | null;
   releaseActiveHost: ((key: SessionKey) => Promise<boolean>) | null;
+  terminateActiveHost: ((key: SessionKey) => Promise<boolean>) | null;
   stopActive: () => void;
 }
 const controllerStore = globalThis as typeof globalThis & { __llvStructuredDeliveryController?: ControllerState };
@@ -32,6 +33,7 @@ const state: ControllerState = controllerStore.__llvStructuredDeliveryController
   activeHosts: null,
   registerActiveHost: null,
   releaseActiveHost: null,
+  terminateActiveHost: null,
   stopActive: () => {},
 };
 
@@ -111,12 +113,24 @@ export async function bindStructuredDeliveryQueue(
   state.activeHosts = null;
   state.registerActiveHost = null;
   state.releaseActiveHost = null;
+  state.terminateActiveHost = null;
   setStructuredDeliveryKick(null);
   const client = dependencies.client === undefined ? runtimeHostClient() : dependencies.client;
   if (!client) return;
   const registry = dependencies.registry ?? agentRegistry();
   const hosts = new Map<string, EngineHost>();
-  const queue = new StructuredDeliveryQueue(runtimeClientDeliveryPort(client), hostResolver(registry, hosts));
+  const queue = new StructuredDeliveryQueue(
+    runtimeClientDeliveryPort(client),
+    hostResolver(registry, hosts),
+    async (conversationId, expectedKey) => {
+      const conversation = registry.conversation(conversationId as `conversation_${string}`);
+      const generation = conversation?.generations.at(-1);
+      if (!conversation || !generation) return false;
+      const currentKey = { engine: conversation.engine, sessionId: generation.id } as const;
+      if (sessionKeyId(currentKey) !== sessionKeyId(expectedKey)) return false;
+      return await state.terminateActiveHost?.(currentKey) ?? false;
+    },
+  );
   const registrations = new Map<string, { key: SessionKey; host: ObservableEngineHost; unsubscribe: () => void; stopEvents: () => Promise<void> }>();
   const publishChains = new Map<string, Promise<void>>();
   const projectionEpoch = crypto.randomUUID();
@@ -151,9 +165,11 @@ export async function bindStructuredDeliveryQueue(
     const key = { engine: conversation.engine, sessionId: generation.id } as const;
     const entry = registry.snapshot().entries[sessionKeyId(key)] ?? null;
     const legacy = entry?.host?.kind === "tmux";
-    const host = legacy
-      ? entry.status === "dead" ? "dead" : entry.status === "unhosted" ? "unhosted" : "hosted"
-      : "unhosted";
+    const host = entry?.status === "dead"
+      ? "dead"
+      : legacy && entry?.status !== "unhosted"
+        ? "hosted"
+        : "unhosted";
     const turn = entry?.status === "live" ? "running" : entry?.status === "idle" ? "idle" : "unknown";
     projectionRevision += 1;
     await client.append({
@@ -267,6 +283,15 @@ export async function bindStructuredDeliveryQueue(
     }
     return true;
   };
+  state.terminateActiveHost = async (key) => {
+    const id = sessionKeyId(key);
+    const registered = registrations.get(id);
+    if (!registered) return false;
+    await registered.host.release();
+    registry.terminateStructuredHost(key);
+    await unregisterHost(id, registered.host);
+    return true;
+  };
   for (const item of adopted) {
     await register(item);
   }
@@ -295,6 +320,7 @@ export async function bindStructuredDeliveryQueue(
       state.activeHosts = null;
       state.registerActiveHost = null;
       state.releaseActiveHost = null;
+      state.terminateActiveHost = null;
       setStructuredDeliveryKick(null);
     }
   };

--- a/src/lib/runtime/structuredDeliveryController.ts
+++ b/src/lib/runtime/structuredDeliveryController.ts
@@ -124,10 +124,13 @@ export async function bindStructuredDeliveryQueue(
     hostResolver(registry, hosts),
     async (conversationId, expectedKey) => {
       if (await state.terminateActiveHost?.(expectedKey)) return true;
-      return registry.terminateInactiveStructuredHost(
+      const terminated = registry.terminateInactiveStructuredHost(
         conversationId as `conversation_${string}`,
         expectedKey,
       );
+      if (!terminated) return false;
+      if (terminated === "current") await refreshCurrentProjection(conversationId);
+      return true;
     },
   );
   const registrations = new Map<string, { key: SessionKey; host: ObservableEngineHost; unsubscribe: () => void; stopEvents: () => Promise<void> }>();

--- a/src/lib/runtime/structuredDeliveryController.ts
+++ b/src/lib/runtime/structuredDeliveryController.ts
@@ -123,12 +123,11 @@ export async function bindStructuredDeliveryQueue(
     runtimeClientDeliveryPort(client),
     hostResolver(registry, hosts),
     async (conversationId, expectedKey) => {
-      const conversation = registry.conversation(conversationId as `conversation_${string}`);
-      const generation = conversation?.generations.at(-1);
-      if (!conversation || !generation) return false;
-      const currentKey = { engine: conversation.engine, sessionId: generation.id } as const;
-      if (sessionKeyId(currentKey) !== sessionKeyId(expectedKey)) return false;
-      return await state.terminateActiveHost?.(currentKey) ?? false;
+      if (await state.terminateActiveHost?.(expectedKey)) return true;
+      return registry.terminateInactiveStructuredHost(
+        conversationId as `conversation_${string}`,
+        expectedKey,
+      );
     },
   );
   const registrations = new Map<string, { key: SessionKey; host: ObservableEngineHost; unsubscribe: () => void; stopEvents: () => Promise<void> }>();

--- a/src/lib/runtime/structuredDeliveryQueue.test.ts
+++ b/src/lib/runtime/structuredDeliveryQueue.test.ts
@@ -624,3 +624,42 @@ test("a structured kill terminates its host and completes its receipt", async ()
     ["kill-one", "delivered"],
   ]);
 });
+
+test("concurrent kills finish after the first kill removes the host", async () => {
+  const pending = new Set(["kill-one", "kill-two"]);
+  const transitions: Array<[string, string]> = [];
+  let hosted = true;
+  let terminations = 0;
+  const target = host(async () => ({ outcome: "turn-started", turnId: "unexpected" }));
+  const queue = new StructuredDeliveryQueue({
+    effects: async () => [...pending].map((operationId, index) => ({
+      id: operationId,
+      kind: "runtime.kill",
+      eventSeq: index + 1,
+      payload: {
+        operationId,
+        conversationId: "conversation-one",
+        sessionKey: { engine: "codex", sessionId: "thread-one" },
+      },
+    })),
+    transition: async (operationId, status) => {
+      transitions.push([operationId, status]);
+      if (status === "delivered" || status === "failed") pending.delete(operationId);
+    },
+  }, () => hosted ? target : null, async () => {
+    terminations += 1;
+    hosted = false;
+    return true;
+  });
+
+  await queue.drain();
+
+  expect(terminations).toBe(2);
+  expect(transitions).toEqual([
+    ["kill-one", "delivering"],
+    ["kill-one", "delivered"],
+    ["kill-two", "delivering"],
+    ["kill-two", "delivered"],
+  ]);
+  expect(pending.size).toBe(0);
+});

--- a/src/lib/runtime/structuredDeliveryQueue.test.ts
+++ b/src/lib/runtime/structuredDeliveryQueue.test.ts
@@ -663,3 +663,90 @@ test("concurrent kills finish after the first kill removes the host", async () =
   ]);
   expect(pending.size).toBe(0);
 });
+
+test("an absent-host kill retries after terminal projection fails", async () => {
+  let pending = true;
+  let attempts = 0;
+  const transitions: Array<[string, string, string | null | undefined]> = [];
+  const queue = new StructuredDeliveryQueue({
+    effects: async () => pending ? [{
+      id: "kill-retry",
+      kind: "runtime.kill",
+      eventSeq: 1,
+      payload: {
+        operationId: "kill-retry",
+        conversationId: "conversation-one",
+        sessionKey: { engine: "codex", sessionId: "thread-one" },
+      },
+    }] : [],
+    transition: async (operationId, status, details) => {
+      transitions.push([operationId, status, details?.reason]);
+      if (status === "delivered" || status === "failed") pending = false;
+    },
+  }, () => null, async () => {
+    attempts += 1;
+    if (attempts === 1) throw new Error("dead projection unavailable");
+    return true;
+  });
+
+  await queue.drain();
+
+  expect(pending).toBeTrue();
+  expect(transitions).toEqual([
+    ["kill-retry", "queued", "dead projection unavailable"],
+  ]);
+
+  await queue.drain();
+
+  expect(pending).toBeFalse();
+  expect(transitions).toEqual([
+    ["kill-retry", "queued", "dead projection unavailable"],
+    ["kill-retry", "delivering", undefined],
+    ["kill-retry", "delivered", undefined],
+  ]);
+});
+
+test("an active-host kill retries after terminal projection fails", async () => {
+  let pending = true;
+  let attempts = 0;
+  const transitions: Array<[string, string, string | null | undefined]> = [];
+  const target = host(async () => ({ outcome: "turn-started", turnId: "unexpected" }));
+  const queue = new StructuredDeliveryQueue({
+    effects: async () => pending ? [{
+      id: "kill-active-retry",
+      kind: "runtime.kill",
+      eventSeq: 1,
+      payload: {
+        operationId: "kill-active-retry",
+        conversationId: "conversation-one",
+        sessionKey: { engine: "codex", sessionId: "thread-one" },
+      },
+    }] : [],
+    transition: async (operationId, status, details) => {
+      transitions.push([operationId, status, details?.reason]);
+      if (status === "delivered" || status === "failed") pending = false;
+    },
+  }, () => target, async () => {
+    attempts += 1;
+    if (attempts === 1) throw new Error("dead projection unavailable");
+    return true;
+  });
+
+  await queue.drain();
+
+  expect(pending).toBeTrue();
+  expect(transitions).toEqual([
+    ["kill-active-retry", "delivering", undefined],
+    ["kill-active-retry", "queued", "dead projection unavailable"],
+  ]);
+
+  await queue.drain();
+
+  expect(pending).toBeFalse();
+  expect(transitions).toEqual([
+    ["kill-active-retry", "delivering", undefined],
+    ["kill-active-retry", "queued", "dead projection unavailable"],
+    ["kill-active-retry", "delivering", undefined],
+    ["kill-active-retry", "delivered", undefined],
+  ]);
+});

--- a/src/lib/runtime/structuredDeliveryQueue.test.ts
+++ b/src/lib/runtime/structuredDeliveryQueue.test.ts
@@ -98,7 +98,7 @@ test("unrelated outbox effects cannot starve structured message delivery", async
 
   await queue.drain();
 
-  expect(requestedKinds).toEqual([["runtime.send", "runtime.steer", "runtime.answer", "runtime.interrupt"]]);
+  expect(requestedKinds).toEqual([["runtime.send", "runtime.steer", "runtime.answer", "runtime.interrupt", "runtime.kill"]]);
   expect(sent).toEqual(["op-after-spawns"]);
 });
 
@@ -593,4 +593,34 @@ test("a control operation behind a full message page still reaches the active ho
   await queue.drain();
 
   expect(interrupts).toEqual(["turn-held"]);
+});
+
+test("a structured kill terminates its host and completes its receipt", async () => {
+  const transitions: Array<[string, string]> = [];
+  const terminated: string[] = [];
+  const target = host(async () => ({ outcome: "turn-started", turnId: "unexpected" }));
+  const queue = new StructuredDeliveryQueue({
+    effects: async () => [{
+      id: "kill-one",
+      kind: "runtime.kill",
+      eventSeq: 1,
+      payload: {
+        operationId: "kill-one",
+        conversationId: "conversation-one",
+        sessionKey: { engine: "codex", sessionId: "thread-one" },
+      },
+    }],
+    transition: async (operationId, status) => { transitions.push([operationId, status]); },
+  }, () => target, async (conversationId, sessionKey) => {
+    terminated.push(`${conversationId}:${sessionKey.engine}:${sessionKey.sessionId}`);
+    return true;
+  });
+
+  await queue.drain();
+
+  expect(terminated).toEqual(["conversation-one:codex:thread-one"]);
+  expect(transitions).toEqual([
+    ["kill-one", "delivering"],
+    ["kill-one", "delivered"],
+  ]);
 });

--- a/src/lib/runtime/structuredDeliveryQueue.ts
+++ b/src/lib/runtime/structuredDeliveryQueue.ts
@@ -255,11 +255,25 @@ export class StructuredDeliveryQueue {
 
   private async drainControl(effect: ControlEffect): Promise<boolean> {
     const host = this.resolveHost(effect.conversationId);
-    if (!host) return true;
     if (effect.kind === "kill") {
+      if (!effect.sessionKey) {
+        await this.port.transition(effect.operationId, "failed", { reason: "structured host termination target is unavailable" });
+        return false;
+      }
+      if (!host) {
+        try {
+          if (!await this.terminateHost(effect.conversationId, effect.sessionKey)) return true;
+          await this.port.transition(effect.operationId, "delivering");
+          await this.port.transition(effect.operationId, "delivered");
+          return false;
+        } catch (error) {
+          await this.port.transition(effect.operationId, "failed", { reason: failureReason(error) });
+          return false;
+        }
+      }
       await this.port.transition(effect.operationId, "delivering");
       try {
-        if (!effect.sessionKey || !await this.terminateHost(effect.conversationId, effect.sessionKey)) {
+        if (!await this.terminateHost(effect.conversationId, effect.sessionKey)) {
           await this.port.transition(effect.operationId, "failed", { reason: "structured host termination is unavailable" });
           return false;
         }
@@ -270,6 +284,7 @@ export class StructuredDeliveryQueue {
         return false;
       }
     }
+    if (!host) return true;
     const health = await host.health();
     if (health.status === "dead" || health.status === "unhosted") {
       await this.port.transition(effect.operationId, "queued", { reason: "dead-host" });

--- a/src/lib/runtime/structuredDeliveryQueue.ts
+++ b/src/lib/runtime/structuredDeliveryQueue.ts
@@ -46,17 +46,18 @@ interface SendEffect {
 interface ControlEffect {
   operationId: string;
   conversationId: string;
-  kind: "answer" | "interrupt";
+  kind: "answer" | "interrupt" | "kill";
   attentionId?: string;
   resolution?: unknown;
   turnId?: string | null;
+  sessionKey?: { engine: "codex" | "claude"; sessionId: string };
   eventSeq: number;
 }
 
 type DeliveryEffect = SendEffect | ControlEffect;
 
 function isControlEffect(effect: DeliveryEffect): effect is ControlEffect {
-  return effect.kind === "answer" || effect.kind === "interrupt";
+  return effect.kind === "answer" || effect.kind === "interrupt" || effect.kind === "kill";
 }
 
 function sendEffect(effect: StructuredDeliveryEffect): SendEffect | null {
@@ -84,7 +85,7 @@ function sendEffect(effect: StructuredDeliveryEffect): SendEffect | null {
 }
 
 function controlEffect(effect: StructuredDeliveryEffect): ControlEffect | null {
-  if (effect.kind !== "runtime.answer" && effect.kind !== "runtime.interrupt") return null;
+  if (effect.kind !== "runtime.answer" && effect.kind !== "runtime.interrupt" && effect.kind !== "runtime.kill") return null;
   const operationId = typeof effect.payload.operationId === "string" ? effect.payload.operationId : "";
   const conversationId = typeof effect.payload.conversationId === "string" ? effect.payload.conversationId : "";
   if (!operationId || !conversationId) return null;
@@ -92,6 +93,19 @@ function controlEffect(effect: StructuredDeliveryEffect): ControlEffect | null {
     const attentionId = typeof effect.payload.attentionId === "string" ? effect.payload.attentionId : "";
     if (!attentionId || !("resolution" in effect.payload)) return null;
     return { operationId, conversationId, kind: "answer", attentionId, resolution: effect.payload.resolution, eventSeq: effect.eventSeq };
+  }
+  if (effect.kind === "runtime.kill") {
+    const key = effect.payload.sessionKey;
+    if (!key || typeof key !== "object" || Array.isArray(key)) return null;
+    const candidate = key as Record<string, unknown>;
+    if ((candidate.engine !== "codex" && candidate.engine !== "claude") || typeof candidate.sessionId !== "string") return null;
+    return {
+      operationId,
+      conversationId,
+      kind: "kill",
+      sessionKey: { engine: candidate.engine, sessionId: candidate.sessionId },
+      eventSeq: effect.eventSeq,
+    };
   }
   const turnId = typeof effect.payload.turnId === "string" || effect.payload.turnId === null
     ? effect.payload.turnId
@@ -115,6 +129,10 @@ export class StructuredDeliveryQueue {
   constructor(
     private readonly port: StructuredDeliveryQueuePort,
     private readonly resolveHost: StructuredHostResolver,
+    private readonly terminateHost: (
+      conversationId: string,
+      sessionKey: { engine: "codex" | "claude"; sessionId: string },
+    ) => Promise<boolean> = async () => false,
   ) {}
 
   drain(): Promise<void> {
@@ -140,7 +158,7 @@ export class StructuredDeliveryQueue {
     let afterEventSeq = 0;
     while (true) {
       const rawEffects = await this.port.effects(
-        ["runtime.send", "runtime.steer", "runtime.answer", "runtime.interrupt"],
+        ["runtime.send", "runtime.steer", "runtime.answer", "runtime.interrupt", "runtime.kill"],
         afterEventSeq,
       );
       if (rawEffects.length === 0) return;
@@ -238,6 +256,20 @@ export class StructuredDeliveryQueue {
   private async drainControl(effect: ControlEffect): Promise<boolean> {
     const host = this.resolveHost(effect.conversationId);
     if (!host) return true;
+    if (effect.kind === "kill") {
+      await this.port.transition(effect.operationId, "delivering");
+      try {
+        if (!effect.sessionKey || !await this.terminateHost(effect.conversationId, effect.sessionKey)) {
+          await this.port.transition(effect.operationId, "failed", { reason: "structured host termination is unavailable" });
+          return false;
+        }
+        await this.port.transition(effect.operationId, "delivered");
+        return false;
+      } catch (error) {
+        await this.port.transition(effect.operationId, "failed", { reason: failureReason(error) });
+        return false;
+      }
+    }
     const health = await host.health();
     if (health.status === "dead" || health.status === "unhosted") {
       await this.port.transition(effect.operationId, "queued", { reason: "dead-host" });

--- a/src/lib/runtime/structuredDeliveryQueue.ts
+++ b/src/lib/runtime/structuredDeliveryQueue.ts
@@ -267,8 +267,8 @@ export class StructuredDeliveryQueue {
           await this.port.transition(effect.operationId, "delivered");
           return false;
         } catch (error) {
-          await this.port.transition(effect.operationId, "failed", { reason: failureReason(error) });
-          return false;
+          await this.port.transition(effect.operationId, "queued", { reason: failureReason(error) });
+          return true;
         }
       }
       await this.port.transition(effect.operationId, "delivering");
@@ -280,8 +280,8 @@ export class StructuredDeliveryQueue {
         await this.port.transition(effect.operationId, "delivered");
         return false;
       } catch (error) {
-        await this.port.transition(effect.operationId, "failed", { reason: failureReason(error) });
-        return false;
+        await this.port.transition(effect.operationId, "queued", { reason: failureReason(error) });
+        return true;
       }
     }
     if (!host) return true;

--- a/src/lib/runtime/structuredSpawn.integration.test.ts
+++ b/src/lib/runtime/structuredSpawn.integration.test.ts
@@ -14,7 +14,8 @@ import { RuntimeJournal } from "@/runtime-host/journal";
 
 import type { RuntimeHostClient } from "./client";
 import type { DeliveryReceipt, HostState, QueueEntry, RuntimeEvent } from "./engineHost";
-import { bindStructuredDeliveryQueue } from "./structuredDeliveryController";
+import { bindStructuredDeliveryQueue, hasStructuredDeliveryHost } from "./structuredDeliveryController";
+import { dispatchStructuredControl } from "./structuredControls";
 import { kickStructuredDeliveryQueue } from "./structuredDeliverySignal";
 import { enqueueStructuredMessage } from "./structuredMessageDelivery";
 import { recoverPendingStructuredSpawns, spawnStructuredConversation, structuredClaudePermissionMode, structuredClaudeSpawnPolicyBaseSettingsPath, type SpawnedStructuredHost } from "./structuredSpawn";
@@ -71,6 +72,7 @@ class RoundTripHost implements SpawnedStructuredHost {
   private activeTurnRef: string | null = null;
   private pendingAttention: string[] = [];
   private released = false;
+  releaseCount = 0;
 
   constructor(readonly engine: "codex" | "claude", readonly artifactPath: string, sessionId: string) {
     this.identity = engine === "codex" ? { threadId: sessionId, path: artifactPath } : { sessionId };
@@ -165,6 +167,7 @@ class RoundTripHost implements SpawnedStructuredHost {
   }
 
   async release(): Promise<void> {
+    this.releaseCount += 1;
     this.released = true;
     for (const wake of this.waiters) wake();
     this.waiters.clear();
@@ -426,6 +429,138 @@ test("startup recovery finalizes a staged spawn without duplicating its admitted
   expect((await client.operationStatus(begun.receipt.launchId))?.receipt.status).toBe("delivered");
 });
 
+test("startup recovery cleans a staged host whose spawn operation already failed", async () => {
+  const id = crypto.randomUUID();
+  const cwd = path.join(sandbox, `failed-recovery-${id}`);
+  fs.mkdirSync(cwd, { recursive: true });
+  const artifactPath = path.join(cwd, `${id}.jsonl`);
+  const registry = new AgentRegistry(path.join(cwd, "registry.json"), undefined, undefined, { sqliteMode: "off" });
+  const journal = new RuntimeJournal(path.join(cwd, "runtime.sqlite"), { structuredHosts: true });
+  const client = runtimeClient(journal);
+  const launchProfile = emptyLaunchProfile({ cwd, model: "gpt-5.6-luna" });
+  const begun = registry.beginSpawnRequest({ engine: "codex", cwd, accountId: "codex-subscription", launchProfile });
+  if (begun.kind !== "created") throw new Error("spawn receipt was unavailable");
+  await client.command({
+    kind: "spawn",
+    operationId: begun.receipt.launchId,
+    idempotencyKey: begun.receipt.launchId,
+    conversationId: begun.receipt.conversationId,
+    engine: "codex",
+    cwd,
+    prompt: "crash-window prompt",
+    accountId: "codex-subscription",
+    parentConversationId: null,
+  });
+  const key = { engine: "codex" as const, sessionId: id };
+  const staged = registry.stageStructuredSpawn(begun.receipt.launchId, {
+    key,
+    artifactPath,
+    cwd,
+    accountId: "codex-subscription",
+    launchProfile,
+    status: "idle",
+    host: null,
+    structuredHost: {
+      kind: "codex-app-server",
+      endpoint: "fake:stdio",
+      process: { pid: process.pid, startIdentity: "test-process" },
+      eventCursor: 0,
+      protocolVersion: "fake-v1",
+      writerClaimEpoch: 1,
+      activeTurnRef: null,
+      pendingAttention: [],
+      activeFlags: [],
+    },
+    claimEpoch: 1,
+    claimOwner: "structured-host:test",
+    pendingAction: "spawn",
+  });
+  if (staged.kind !== "settled") throw new Error("spawn identity was unavailable");
+  const host = new RoundTripHost("codex", artifactPath, id);
+  await bindStructuredDeliveryQueue([{ key, host }], { registry, client });
+  await client.transitionOperation(begun.receipt.launchId, "failed", { reason: "engine child failed" });
+
+  await recoverPendingStructuredSpawns(registry, client);
+  await recoverPendingStructuredSpawns(registry, client);
+
+  expect(registry.snapshot().receipts[begun.receipt.launchId]).toMatchObject({
+    state: "failed",
+    error: "engine child failed",
+  });
+  expect(registry.snapshot().entries[`codex:${id}`]).toMatchObject({
+    status: "dead",
+    structuredHost: null,
+    claimOwner: null,
+    pendingAction: null,
+  });
+  expect(hasStructuredDeliveryHost(key)).toBeFalse();
+  expect(host.releaseCount).toBe(1);
+  expect((await client.operationStatus(begun.receipt.launchId))?.receipt).toMatchObject({
+    status: "failed",
+    reason: "engine child failed",
+  });
+  expect(journal.snapshot().sessions.find((session) => session.conversationId === begun.receipt.conversationId)).toMatchObject({
+    host: "dead",
+  });
+});
+
+test("startup recovery completes an intentionally empty spawn prompt without a host send", async () => {
+  const id = crypto.randomUUID();
+  const cwd = path.join(sandbox, `empty-prompt-recovery-${id}`);
+  fs.mkdirSync(cwd, { recursive: true });
+  const artifactPath = path.join(cwd, `${id}.jsonl`);
+  const registry = new AgentRegistry(path.join(cwd, "registry.json"), undefined, undefined, { sqliteMode: "off" });
+  const journal = new RuntimeJournal(path.join(cwd, "runtime.sqlite"), { structuredHosts: true });
+  const client = runtimeClient(journal);
+  const launchProfile = emptyLaunchProfile({ cwd, model: "gpt-5.6-luna" });
+  const begun = registry.beginSpawnRequest({ engine: "codex", cwd, accountId: "codex-subscription", launchProfile });
+  if (begun.kind !== "created") throw new Error("spawn receipt was unavailable");
+  await client.command({
+    kind: "spawn",
+    operationId: begun.receipt.launchId,
+    idempotencyKey: begun.receipt.launchId,
+    conversationId: begun.receipt.conversationId,
+    engine: "codex",
+    cwd,
+    prompt: "",
+    accountId: "codex-subscription",
+    parentConversationId: null,
+  });
+  const key = { engine: "codex" as const, sessionId: id };
+  const staged = registry.stageStructuredSpawn(begun.receipt.launchId, {
+    key,
+    artifactPath,
+    cwd,
+    accountId: "codex-subscription",
+    launchProfile,
+    status: "idle",
+    host: null,
+    structuredHost: {
+      kind: "codex-app-server",
+      endpoint: "fake:stdio",
+      process: { pid: process.pid, startIdentity: "test-process" },
+      eventCursor: 0,
+      protocolVersion: "fake-v1",
+      writerClaimEpoch: 1,
+      activeTurnRef: null,
+      pendingAttention: [],
+      activeFlags: [],
+    },
+    claimEpoch: 1,
+    claimOwner: "structured-host:test",
+    pendingAction: "spawn",
+  });
+  if (staged.kind !== "settled") throw new Error("spawn identity was unavailable");
+  const host = new RoundTripHost("codex", artifactPath, id);
+  await bindStructuredDeliveryQueue([{ key, host }], { registry, client });
+
+  await recoverPendingStructuredSpawns(registry, client);
+
+  expect(host.sent).toEqual([]);
+  expect(registry.snapshot().receipts[begun.receipt.launchId]).toMatchObject({ state: "completed", artifactPath });
+  expect((await client.operationStatus(begun.receipt.launchId))?.receipt.status).toBe("delivered");
+});
+
 describe.each(["codex", "claude"] as const)("%s structured spawn round trip", (engine) => {
   test("spawn, send, question, answer, interrupt, and resume use one pane-less host", async () => {
     const id = crypto.randomUUID();
@@ -574,6 +709,34 @@ describe.each(["codex", "claude"] as const)("%s structured spawn round trip", (e
       "deliberately slow fake-host turn",
       "resume after interrupt",
     ]);
+
+    const killOperationId = `kill_${id}`;
+    const kill = await dispatchStructuredControl({ path: artifactPath, conversationId: response.conversationId, action: "kill" }, {
+      registry,
+      client,
+      operationId: () => killOperationId,
+      kick: () => {},
+      enabled: () => true,
+    });
+    expect(kill).toMatchObject({ status: 202, body: { ok: true, structured: true, operationId: killOperationId } });
+    await kickStructuredDeliveryQueue();
+    await waitFor(() => host.releaseCount === 1);
+
+    expect(hasStructuredDeliveryHost({ engine, sessionId: id })).toBeFalse();
+    expect(registry.snapshot().entries[`${engine}:${id}`]).toMatchObject({
+      status: "dead",
+      host: null,
+      structuredHost: null,
+      claimOwner: null,
+      pendingAction: null,
+    });
+    expect((await client.operationStatus(killOperationId))?.receipt).toMatchObject({
+      kind: "kill",
+      status: "delivered",
+    });
+    expect(journal.snapshot().sessions.find((session) => session.conversationId === response.conversationId)).toMatchObject({
+      host: "dead",
+    });
   });
 });
 

--- a/src/lib/runtime/structuredSpawn.integration.test.ts
+++ b/src/lib/runtime/structuredSpawn.integration.test.ts
@@ -630,6 +630,229 @@ test("startup recovery completes an intentionally empty spawn prompt without a h
   expect((await client.operationStatus(begun.receipt.launchId))?.receipt.status).toBe("delivered");
 });
 
+test("a queued kill terminalizes after restart when its generation is confirmed dead", async () => {
+  const id = crypto.randomUUID();
+  const cwd = path.join(sandbox, `dead-kill-recovery-${id}`);
+  fs.mkdirSync(cwd, { recursive: true });
+  const artifactPath = path.join(cwd, `${id}.jsonl`);
+  const registry = new AgentRegistry(path.join(cwd, "registry.json"), undefined, undefined, { sqliteMode: "off" });
+  const journal = new RuntimeJournal(path.join(cwd, "runtime.sqlite"), { structuredHosts: true });
+  const client = runtimeClient(journal);
+  const conversation = registry.ensureConversation("codex", artifactPath, "codex-subscription");
+  const generation = conversation.generations.at(-1);
+  if (!generation) throw new Error("structured generation was unavailable");
+  const key = { engine: "codex" as const, sessionId: generation.id };
+  registry.upsert({
+    key,
+    artifactPath,
+    cwd,
+    accountId: "codex-subscription",
+    status: "dead",
+    host: null,
+    structuredHost: null,
+    claimEpoch: 1,
+    claimOwner: null,
+    pendingAction: null,
+  });
+  const operationId = `kill_${id}`;
+  await client.command({
+    kind: "kill",
+    operationId,
+    idempotencyKey: operationId,
+    conversationId: conversation.id,
+    sessionKey: key,
+  });
+
+  await bindStructuredDeliveryQueue([], { registry, client });
+
+  expect((await client.operationStatus(operationId))?.receipt).toMatchObject({
+    kind: "kill",
+    status: "delivered",
+  });
+  expect(registry.snapshot().entries[`codex:${generation.id}`]).toMatchObject({
+    status: "dead",
+    host: null,
+    structuredHost: null,
+    claimOwner: null,
+    pendingAction: null,
+  });
+  expect(await client.effectBatch(["runtime.kill"], 0)).toEqual([]);
+});
+
+test("a dead predecessor kill terminalizes without touching its live successor", async () => {
+  const predecessorId = crypto.randomUUID();
+  const successorId = crypto.randomUUID();
+  const cwd = path.join(sandbox, `successor-kill-${predecessorId}`);
+  fs.mkdirSync(cwd, { recursive: true });
+  const predecessorPath = path.join(cwd, `${predecessorId}.jsonl`);
+  const successorPath = path.join(cwd, `${successorId}.jsonl`);
+  const registry = new AgentRegistry(path.join(cwd, "registry.json"), undefined, undefined, { sqliteMode: "off" });
+  const journal = new RuntimeJournal(path.join(cwd, "runtime.sqlite"), { structuredHosts: true });
+  const client = runtimeClient(journal);
+  const conversation = registry.ensureConversation("codex", predecessorPath, "codex-subscription");
+  const predecessorKey = { engine: "codex" as const, sessionId: predecessorId };
+  registry.upsert({
+    key: predecessorKey,
+    artifactPath: predecessorPath,
+    cwd,
+    accountId: "codex-subscription",
+    status: "dead",
+    host: null,
+    structuredHost: null,
+    claimEpoch: 1,
+    claimOwner: null,
+    pendingAction: null,
+  });
+  const resumed = registry.beginSpawnRequest({
+    engine: "codex",
+    cwd,
+    accountId: "codex-subscription",
+    conversationId: conversation.id,
+    purpose: "resume-successor",
+  });
+  if (resumed.kind !== "created") throw new Error("successor receipt was unavailable");
+  const successorKey = { engine: "codex" as const, sessionId: successorId };
+  const settled = registry.settleSpawn(resumed.receipt.launchId, {
+    key: successorKey,
+    artifactPath: successorPath,
+    cwd,
+    accountId: "codex-subscription",
+    status: "live",
+    host: null,
+    structuredHost: {
+      kind: "codex-app-server",
+      endpoint: "fake:successor",
+      process: { pid: process.pid, startIdentity: "successor-process" },
+      eventCursor: 1,
+      protocolVersion: "fake-v1",
+      writerClaimEpoch: 2,
+      activeTurnRef: "successor-turn",
+      pendingAttention: [],
+      activeFlags: [],
+    },
+    claimEpoch: 2,
+    claimOwner: "structured-host:successor",
+    pendingAction: null,
+  });
+  if (settled.kind !== "settled") throw new Error("successor settlement failed");
+  const successorBefore = registry.snapshot().entries[`codex:${successorId}`];
+  const operationId = `kill_${predecessorId}`;
+  await client.command({
+    kind: "kill",
+    operationId,
+    idempotencyKey: operationId,
+    conversationId: conversation.id,
+    sessionKey: predecessorKey,
+  });
+  const successorHost = new RoundTripHost("codex", successorPath, successorId);
+
+  await bindStructuredDeliveryQueue([{ key: successorKey, host: successorHost }], { registry, client });
+
+  expect((await client.operationStatus(operationId))?.receipt.status).toBe("delivered");
+  expect(registry.snapshot().entries[`codex:${successorId}`]).toEqual(successorBefore);
+  expect(successorHost.releaseCount).toBe(0);
+  expect(hasStructuredDeliveryHost(successorKey)).toBeTrue();
+  expect(await client.effectBatch(["runtime.kill"], 0)).toEqual([]);
+});
+
+test("a queued kill waits when an unadopted structured process may still be live", async () => {
+  const id = crypto.randomUUID();
+  const cwd = path.join(sandbox, `live-kill-recovery-${id}`);
+  fs.mkdirSync(cwd, { recursive: true });
+  const artifactPath = path.join(cwd, `${id}.jsonl`);
+  const registry = new AgentRegistry(path.join(cwd, "registry.json"), undefined, undefined, { sqliteMode: "off" });
+  const journal = new RuntimeJournal(path.join(cwd, "runtime.sqlite"), { structuredHosts: true });
+  const client = runtimeClient(journal);
+  const conversation = registry.ensureConversation("codex", artifactPath, "codex-subscription");
+  const key = { engine: "codex" as const, sessionId: id };
+  registry.upsert({
+    key,
+    artifactPath,
+    cwd,
+    accountId: "codex-subscription",
+    status: "live",
+    host: null,
+    structuredHost: {
+      kind: "codex-app-server",
+      endpoint: "fake:unadopted",
+      process: { pid: process.pid, startIdentity: "potentially-live" },
+      eventCursor: 1,
+      protocolVersion: "fake-v1",
+      writerClaimEpoch: 1,
+      activeTurnRef: null,
+      pendingAttention: [],
+      activeFlags: [],
+    },
+    claimEpoch: 1,
+    claimOwner: "structured-host:unadopted",
+    pendingAction: null,
+  });
+  const entryBefore = registry.snapshot().entries[`codex:${id}`];
+  const operationId = `kill_${id}`;
+  await client.command({
+    kind: "kill",
+    operationId,
+    idempotencyKey: operationId,
+    conversationId: conversation.id,
+    sessionKey: key,
+  });
+
+  await bindStructuredDeliveryQueue([], { registry, client });
+
+  expect((await client.operationStatus(operationId))?.receipt.status).toBe("queued");
+  expect(registry.snapshot().entries[`codex:${id}`]).toEqual(entryBefore);
+  expect(await client.effectBatch(["runtime.kill"], 0)).toHaveLength(1);
+});
+
+test("a queued kill waits through a processless structured adoption claim", async () => {
+  const id = crypto.randomUUID();
+  const cwd = path.join(sandbox, `claimed-kill-recovery-${id}`);
+  fs.mkdirSync(cwd, { recursive: true });
+  const artifactPath = path.join(cwd, `${id}.jsonl`);
+  const registry = new AgentRegistry(path.join(cwd, "registry.json"), undefined, undefined, { sqliteMode: "off" });
+  const journal = new RuntimeJournal(path.join(cwd, "runtime.sqlite"), { structuredHosts: true });
+  const client = runtimeClient(journal);
+  const conversation = registry.ensureConversation("codex", artifactPath, "codex-subscription");
+  const key = { engine: "codex" as const, sessionId: id };
+  registry.upsert({
+    key,
+    artifactPath,
+    cwd,
+    accountId: "codex-subscription",
+    status: "unhosted",
+    host: null,
+    structuredHost: {
+      kind: "codex-app-server",
+      endpoint: "stdio:pending",
+      process: null,
+      eventCursor: 0,
+      protocolVersion: null,
+      writerClaimEpoch: 1,
+      activeTurnRef: null,
+      pendingAttention: [],
+      activeFlags: [],
+    },
+    claimEpoch: 1,
+    claimOwner: "structured-host:adopting",
+    pendingAction: null,
+  });
+  const entryBefore = registry.snapshot().entries[`codex:${id}`];
+  const operationId = `kill_${id}`;
+  await client.command({
+    kind: "kill",
+    operationId,
+    idempotencyKey: operationId,
+    conversationId: conversation.id,
+    sessionKey: key,
+  });
+
+  await bindStructuredDeliveryQueue([], { registry, client });
+
+  expect((await client.operationStatus(operationId))?.receipt.status).toBe("queued");
+  expect(registry.snapshot().entries[`codex:${id}`]).toEqual(entryBefore);
+  expect(await client.effectBatch(["runtime.kill"], 0)).toHaveLength(1);
+});
+
 describe.each(["codex", "claude"] as const)("%s structured spawn round trip", (engine) => {
   test("spawn, send, question, answer, interrupt, resume, and kill use one pane-less host", async () => {
     const id = crypto.randomUUID();
@@ -791,6 +1014,7 @@ describe.each(["codex", "claude"] as const)("%s structured spawn round trip", (e
     expect(host.sent.some((entry) => entry.text === "must stay queued after kill")).toBeFalse();
 
     const killOperationId = `kill_${id}`;
+    const secondKillOperationId = `kill_again_${id}`;
     const kill = await dispatchStructuredControl({ path: artifactPath, conversationId: response.conversationId, action: "kill" }, {
       registry,
       client,
@@ -799,6 +1023,14 @@ describe.each(["codex", "claude"] as const)("%s structured spawn round trip", (e
       enabled: () => true,
     });
     expect(kill).toMatchObject({ status: 202, body: { ok: true, structured: true, operationId: killOperationId } });
+    const secondKill = await dispatchStructuredControl({ path: artifactPath, conversationId: response.conversationId, action: "kill" }, {
+      registry,
+      client,
+      operationId: () => secondKillOperationId,
+      kick: () => {},
+      enabled: () => true,
+    });
+    expect(secondKill).toMatchObject({ status: 202, body: { ok: true, structured: true, operationId: secondKillOperationId } });
     await completesWithin(kickStructuredDeliveryQueue(), "structured kill did not complete");
     await waitFor(() => host.releaseCount === 1);
 
@@ -814,6 +1046,11 @@ describe.each(["codex", "claude"] as const)("%s structured spawn round trip", (e
       kind: "kill",
       status: "delivered",
     });
+    expect((await client.operationStatus(secondKillOperationId))?.receipt).toMatchObject({
+      kind: "kill",
+      status: "delivered",
+    });
+    expect(await client.effectBatch(["runtime.kill"], 0)).toEqual([]);
     expect(journal.snapshot().sessions.find((session) => session.conversationId === response.conversationId)).toMatchObject({
       host: "dead",
     });

--- a/src/lib/runtime/structuredSpawn.integration.test.ts
+++ b/src/lib/runtime/structuredSpawn.integration.test.ts
@@ -218,6 +218,12 @@ class RoundTripHost implements SpawnedStructuredHost {
   async release(): Promise<void> {
     this.releaseCount += 1;
     this.released = true;
+    this.status = "unhosted";
+    this.activeTurnRef = null;
+    this.pendingAttention = [];
+    this.emit({ kind: "session-status", status: "unhosted" });
+    const state = await this.health();
+    for (const listener of this.listeners) listener(state);
     for (const wake of this.waiters) wake();
     this.waiters.clear();
   }
@@ -242,6 +248,20 @@ async function waitFor(assertion: () => boolean): Promise<void> {
     await Bun.sleep(5);
   }
   throw new Error("round-trip condition did not settle");
+}
+
+async function completesWithin<T>(operation: T | PromiseLike<T>, message: string): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      Promise.resolve(operation),
+      new Promise<never>((_, reject) => {
+        timer = setTimeout(() => reject(new Error(message)), 1_000);
+      }),
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
 }
 
 function deferred(): { promise: Promise<void>; resolve(): void } {
@@ -611,7 +631,7 @@ test("startup recovery completes an intentionally empty spawn prompt without a h
 });
 
 describe.each(["codex", "claude"] as const)("%s structured spawn round trip", (engine) => {
-  test("spawn, send, question, answer, interrupt, and resume use one pane-less host", async () => {
+  test("spawn, send, question, answer, interrupt, resume, and kill use one pane-less host", async () => {
     const id = crypto.randomUUID();
     const cwd = path.join(sandbox, `${engine}-${id}`);
     fs.mkdirSync(cwd, { recursive: true });
@@ -760,6 +780,16 @@ describe.each(["codex", "claude"] as const)("%s structured spawn round trip", (e
       "resume after interrupt",
     ]);
 
+    const pendingAfterKillId = `pending_after_kill_${id}`;
+    await enqueueStructuredMessage({
+      path: artifactPath,
+      conversationId: response.conversationId,
+      clientMessageId: pendingAfterKillId,
+      text: "must stay queued after kill",
+      hasImages: false,
+    }, { client: () => client, registry: () => registry, enabled: () => true });
+    expect(host.sent.some((entry) => entry.text === "must stay queued after kill")).toBeFalse();
+
     const killOperationId = `kill_${id}`;
     const kill = await dispatchStructuredControl({ path: artifactPath, conversationId: response.conversationId, action: "kill" }, {
       registry,
@@ -769,7 +799,7 @@ describe.each(["codex", "claude"] as const)("%s structured spawn round trip", (e
       enabled: () => true,
     });
     expect(kill).toMatchObject({ status: 202, body: { ok: true, structured: true, operationId: killOperationId } });
-    await kickStructuredDeliveryQueue();
+    await completesWithin(kickStructuredDeliveryQueue(), "structured kill did not complete");
     await waitFor(() => host.releaseCount === 1);
 
     expect(hasStructuredDeliveryHost({ engine, sessionId: id })).toBeFalse();
@@ -787,6 +817,8 @@ describe.each(["codex", "claude"] as const)("%s structured spawn round trip", (e
     expect(journal.snapshot().sessions.find((session) => session.conversationId === response.conversationId)).toMatchObject({
       host: "dead",
     });
+    await completesWithin(kickStructuredDeliveryQueue(), "structured delivery queue stayed wedged after kill");
+    expect(host.sent.some((entry) => entry.text === "must stay queued after kill")).toBeFalse();
   });
 });
 

--- a/src/lib/runtime/structuredSpawn.integration.test.ts
+++ b/src/lib/runtime/structuredSpawn.integration.test.ts
@@ -654,6 +654,25 @@ test("a queued kill terminalizes after restart when its generation is confirmed 
     claimOwner: null,
     pendingAction: null,
   });
+  await client.append({
+    scope: { type: "session", id: conversation.id },
+    kind: "session-status",
+    payload: {
+      conversationId: conversation.id,
+      sessionKey: key,
+      hostKind: "codex-app-server",
+      host: "hosted",
+      turn: "idle",
+      provenance: "structured",
+      accountId: "codex-subscription",
+      parentConversationId: null,
+      cwd,
+      artifactPath,
+      capabilities: { steer: true, structuredAttention: true },
+      activeTurnId: null,
+    },
+  });
+  expect(journal.snapshot().sessions.find((session) => session.conversationId === conversation.id)?.host).toBe("hosted");
   const operationId = `kill_${id}`;
   await client.command({
     kind: "kill",
@@ -677,6 +696,20 @@ test("a queued kill terminalizes after restart when its generation is confirmed 
     pendingAction: null,
   });
   expect(await client.effectBatch(["runtime.kill"], 0)).toEqual([]);
+  expect(journal.snapshot().sessions.find((session) => session.conversationId === conversation.id)).toMatchObject({
+    host: "dead",
+    activeTurnId: null,
+  });
+  const sendOperationId = `send_after_${id}`;
+  const sent = await client.command({
+    kind: "send",
+    operationId: sendOperationId,
+    idempotencyKey: sendOperationId,
+    conversationId: conversation.id,
+    text: "must reject after kill",
+    policy: "queue",
+  });
+  expect(sent.receipt).toMatchObject({ status: "rejected", reason: "dead-host" });
 });
 
 test("a dead predecessor kill terminalizes without touching its live successor", async () => {
@@ -752,6 +785,11 @@ test("a dead predecessor kill terminalizes without touching its live successor",
   expect(registry.snapshot().entries[`codex:${successorId}`]).toEqual(successorBefore);
   expect(successorHost.releaseCount).toBe(0);
   expect(hasStructuredDeliveryHost(successorKey)).toBeTrue();
+  expect(journal.snapshot().sessions.find((session) => session.conversationId === conversation.id)).toMatchObject({
+    sessionKey: successorKey,
+    host: "hosted",
+    hostKind: "codex-app-server",
+  });
   expect(await client.effectBatch(["runtime.kill"], 0)).toEqual([]);
 });
 

--- a/src/lib/runtime/structuredSpawn.ts
+++ b/src/lib/runtime/structuredSpawn.ts
@@ -38,6 +38,49 @@ interface HostBinding {
   unregister(): Promise<void>;
 }
 
+const FAILED_SPAWN_OPERATION_STATUSES = new Set([
+  "failed",
+  "rejected",
+  "uncertain",
+  "turn-started",
+  "steered",
+  "interrupted",
+  "answered",
+]);
+
+async function projectStructuredSpawnFailure(
+  client: RuntimeHostClient,
+  receipt: SpawnReceipt,
+  entry: { accountId: string | null; cwd: string },
+  identity?: { key: SessionKey; artifactPath: string },
+): Promise<void> {
+  const key = identity?.key ?? receipt.key;
+  const artifactPath = identity?.artifactPath ?? receipt.artifactPath;
+  if (!key || !artifactPath) return;
+  await client.append({
+    scope: { type: "session", id: receipt.conversationId },
+    kind: "session-status",
+    producer: {
+      kind: key.engine === "codex" ? "codex-app-server" : "claude-broker",
+      eventKey: `structured-spawn-failed:${receipt.launchId}`,
+    },
+    payload: {
+      conversationId: receipt.conversationId,
+      sessionKey: key,
+      hostKind: key.engine === "codex" ? "codex-app-server" : "claude-broker",
+      host: "dead",
+      turn: "idle",
+      provenance: "structured",
+      accountId: entry.accountId,
+      parentConversationId: receipt.parentConversationId,
+      cwd: entry.cwd,
+      artifactPath,
+      capabilities: { steer: key.engine === "codex", structuredAttention: true },
+      activeTurnId: null,
+    },
+  });
+}
+
 export interface StructuredSpawnDependencies {
   startHost?(input: StructuredSpawnInput, capability: string): Promise<SpawnedStructuredHost>;
   bindHost?(registry: AgentRegistry, key: SessionKey, host: SpawnedStructuredHost, claimOwner: string, claimEpoch: number): Promise<() => void>;
@@ -68,16 +111,10 @@ export async function recoverPendingStructuredSpawns(
   for (const receipt of Object.values(snapshot.receipts)) {
     if (receipt.state !== "path-pending" || !receipt.key || !receipt.artifactPath) continue;
     const entry = snapshot.entries[sessionKeyId(receipt.key)];
-    if (!entry?.structuredHost || entry.status === "dead" || entry.status === "unhosted") continue;
     const operation = await client.operationStatus(receipt.launchId);
     const status = operation?.receipt.status;
-    if (status === "failed"
-      || status === "rejected"
-      || status === "uncertain"
-      || status === "turn-started"
-      || status === "steered"
-      || status === "interrupted"
-      || status === "answered") {
+    if (status && FAILED_SPAWN_OPERATION_STATUSES.has(status)) {
+      if (entry) await projectStructuredSpawnFailure(client, receipt, entry);
       registry.failStructuredSpawn(
         receipt.launchId,
         operation?.receipt.reason ?? `structured spawn operation ended as ${status}`,
@@ -85,6 +122,7 @@ export async function recoverPendingStructuredSpawns(
       await releaseStructuredDeliveryHost(receipt.key).catch(() => false);
       continue;
     }
+    if (!entry?.structuredHost || entry.status === "dead" || entry.status === "unhosted") continue;
     if (status !== "delivered") {
       const effect = spawnEffects.get(receipt.launchId);
       const prompt = typeof effect?.prompt === "string" ? effect.prompt : null;
@@ -293,27 +331,9 @@ export async function spawnStructuredConversation(
       input.registry.failStructuredSpawn(input.receipt.launchId, error instanceof Error ? error.message : "structured spawn failed");
       const entry = input.registry.snapshot().entries[sessionKeyId(key)];
       if (entry) {
-        await input.client.append({
-          scope: { type: "session", id: input.receipt.conversationId },
-          kind: "session-status",
-          producer: {
-            kind: key.engine === "codex" ? "codex-app-server" : "claude-broker",
-            eventKey: `structured-spawn-failed:${input.receipt.launchId}`,
-          },
-          payload: {
-            conversationId: input.receipt.conversationId,
-            sessionKey: key,
-            hostKind: key.engine === "codex" ? "codex-app-server" : "claude-broker",
-            host: "dead",
-            turn: "idle",
-            provenance: "structured",
-            accountId: entry.accountId,
-            parentConversationId: input.receipt.parentConversationId,
-            cwd: entry.cwd,
-            artifactPath: entry.artifactPath,
-            capabilities: { steer: key.engine === "codex", structuredAttention: true },
-            activeTurnId: null,
-          },
+        await projectStructuredSpawnFailure(input.client, input.receipt, entry, {
+          key,
+          artifactPath: entry.artifactPath,
         }).catch(() => {});
       }
     }

--- a/src/lib/runtime/structuredSpawn.ts
+++ b/src/lib/runtime/structuredSpawn.ts
@@ -48,10 +48,11 @@ const FAILED_SPAWN_OPERATION_STATUSES = new Set([
   "answered",
 ]);
 
-async function projectStructuredSpawnFailure(
+async function projectDeadStructuredSpawn(
   client: RuntimeHostClient,
   receipt: SpawnReceipt,
   entry: { accountId: string | null; cwd: string },
+  eventKey: string,
   identity?: { key: SessionKey; artifactPath: string },
 ): Promise<void> {
   const key = identity?.key ?? receipt.key;
@@ -62,7 +63,7 @@ async function projectStructuredSpawnFailure(
     kind: "session-status",
     producer: {
       kind: key.engine === "codex" ? "codex-app-server" : "claude-broker",
-      eventKey: `structured-spawn-failed:${receipt.launchId}`,
+      eventKey,
     },
     payload: {
       conversationId: receipt.conversationId,
@@ -114,7 +115,12 @@ export async function recoverPendingStructuredSpawns(
     const operation = await client.operationStatus(receipt.launchId);
     const status = operation?.receipt.status;
     if (status && FAILED_SPAWN_OPERATION_STATUSES.has(status)) {
-      if (entry) await projectStructuredSpawnFailure(client, receipt, entry);
+      if (entry) await projectDeadStructuredSpawn(
+        client,
+        receipt,
+        entry,
+        `structured-spawn-failed:${receipt.launchId}`,
+      );
       registry.failStructuredSpawn(
         receipt.launchId,
         operation?.receipt.reason ?? `structured spawn operation ended as ${status}`,
@@ -122,30 +128,50 @@ export async function recoverPendingStructuredSpawns(
       await releaseStructuredDeliveryHost(receipt.key).catch(() => false);
       continue;
     }
-    if (!entry?.structuredHost || entry.status === "dead" || entry.status === "unhosted") continue;
-    if (status !== "delivered") {
-      const effect = spawnEffects.get(receipt.launchId);
-      const prompt = typeof effect?.prompt === "string" ? effect.prompt : null;
-      if (prompt === null || effect?.conversationId !== receipt.conversationId || effect?.cwd !== receipt.cwd) {
-        throw new Error(`structured spawn recovery is missing durable prompt admission for ${receipt.launchId}`);
+    if (status === "delivered") {
+      const hostReady = entry?.structuredHost?.process
+        && entry.claimOwner
+        && entry.status !== "dead"
+        && entry.status !== "unhosted";
+      if (hostReady) {
+        const finalized = registry.finalizeStructuredSpawn(receipt.launchId);
+        if (finalized.kind === "conflict") throw new Error(`structured spawn recovery conflict: ${finalized.code}`);
+      } else {
+        if (!entry) throw new Error(`structured spawn recovery identity is unavailable for ${receipt.launchId}`);
+        await projectDeadStructuredSpawn(
+          client,
+          receipt,
+          entry,
+          `structured-spawn-delivered-host-dead:${receipt.launchId}`,
+        );
+        const settled = registry.recoverDeliveredStructuredSpawn(receipt.launchId);
+        if (settled.kind === "conflict") throw new Error(`structured spawn recovery conflict: ${settled.code}`);
+        await releaseStructuredDeliveryHost(receipt.key).catch(() => false);
       }
-      if (prompt.trim()) {
-        const delivered = await enqueueStructuredMessage({
-          path: receipt.artifactPath,
-          conversationId: receipt.conversationId,
-          clientMessageId: `spawn_${receipt.launchId}`,
-          operationId: `spawn_message_${receipt.launchId}`,
-          text: prompt,
-          hasImages: false,
-        }, {
-          client: () => client,
-          registry: () => registry,
-          enabled: () => true,
-        });
-        if (!delivered?.ok) throw new Error(delivered?.error ?? `structured spawn recovery could not admit ${receipt.launchId}`);
-      }
-      await client.transitionOperation(receipt.launchId, "delivered");
+      continue;
     }
+    if (!entry?.structuredHost || entry.status === "dead" || entry.status === "unhosted") continue;
+    const effect = spawnEffects.get(receipt.launchId);
+    const prompt = typeof effect?.prompt === "string" ? effect.prompt : null;
+    if (prompt === null || effect?.conversationId !== receipt.conversationId || effect?.cwd !== receipt.cwd) {
+      throw new Error(`structured spawn recovery is missing durable prompt admission for ${receipt.launchId}`);
+    }
+    if (prompt.trim()) {
+      const delivered = await enqueueStructuredMessage({
+        path: receipt.artifactPath,
+        conversationId: receipt.conversationId,
+        clientMessageId: `spawn_${receipt.launchId}`,
+        operationId: `spawn_message_${receipt.launchId}`,
+        text: prompt,
+        hasImages: false,
+      }, {
+        client: () => client,
+        registry: () => registry,
+        enabled: () => true,
+      });
+      if (!delivered?.ok) throw new Error(delivered?.error ?? `structured spawn recovery could not admit ${receipt.launchId}`);
+    }
+    await client.transitionOperation(receipt.launchId, "delivered");
     const finalized = registry.finalizeStructuredSpawn(receipt.launchId);
     if (finalized.kind === "conflict") throw new Error(`structured spawn recovery conflict: ${finalized.code}`);
   }
@@ -331,10 +357,13 @@ export async function spawnStructuredConversation(
       input.registry.failStructuredSpawn(input.receipt.launchId, error instanceof Error ? error.message : "structured spawn failed");
       const entry = input.registry.snapshot().entries[sessionKeyId(key)];
       if (entry) {
-        await projectStructuredSpawnFailure(input.client, input.receipt, entry, {
-          key,
-          artifactPath: entry.artifactPath,
-        }).catch(() => {});
+        await projectDeadStructuredSpawn(
+          input.client,
+          input.receipt,
+          entry,
+          `structured-spawn-failed:${input.receipt.launchId}`,
+          { key, artifactPath: entry.artifactPath },
+        ).catch(() => {});
       }
     }
     else input.registry.failSpawn(input.receipt.launchId, "structured spawn failed before host binding");

--- a/src/lib/runtime/structuredSpawn.ts
+++ b/src/lib/runtime/structuredSpawn.ts
@@ -15,7 +15,7 @@ import { CodexAppServerHost } from "./codexAppServerHost";
 import type { RuntimeHostClient } from "./client";
 import type { EngineHost, HostState } from "./engineHost";
 import { bindClaudeHostPersistence, bindCodexHostPersistence } from "./registry";
-import { publishStructuredDeliveryHost } from "./structuredDeliveryController";
+import { publishStructuredDeliveryHost, releaseStructuredDeliveryHost } from "./structuredDeliveryController";
 import { enqueueStructuredMessage } from "./structuredMessageDelivery";
 
 export type SpawnedStructuredHost = EngineHost & {
@@ -70,25 +70,42 @@ export async function recoverPendingStructuredSpawns(
     const entry = snapshot.entries[sessionKeyId(receipt.key)];
     if (!entry?.structuredHost || entry.status === "dead" || entry.status === "unhosted") continue;
     const operation = await client.operationStatus(receipt.launchId);
-    if (operation?.receipt.status !== "delivered") {
+    const status = operation?.receipt.status;
+    if (status === "failed"
+      || status === "rejected"
+      || status === "uncertain"
+      || status === "turn-started"
+      || status === "steered"
+      || status === "interrupted"
+      || status === "answered") {
+      registry.failStructuredSpawn(
+        receipt.launchId,
+        operation?.receipt.reason ?? `structured spawn operation ended as ${status}`,
+      );
+      await releaseStructuredDeliveryHost(receipt.key).catch(() => false);
+      continue;
+    }
+    if (status !== "delivered") {
       const effect = spawnEffects.get(receipt.launchId);
       const prompt = typeof effect?.prompt === "string" ? effect.prompt : null;
-      if (!prompt || effect?.conversationId !== receipt.conversationId || effect?.cwd !== receipt.cwd) {
+      if (prompt === null || effect?.conversationId !== receipt.conversationId || effect?.cwd !== receipt.cwd) {
         throw new Error(`structured spawn recovery is missing durable prompt admission for ${receipt.launchId}`);
       }
-      const delivered = await enqueueStructuredMessage({
-        path: receipt.artifactPath,
-        conversationId: receipt.conversationId,
-        clientMessageId: `spawn_${receipt.launchId}`,
-        operationId: `spawn_message_${receipt.launchId}`,
-        text: prompt,
-        hasImages: false,
-      }, {
-        client: () => client,
-        registry: () => registry,
-        enabled: () => true,
-      });
-      if (!delivered?.ok) throw new Error(delivered?.error ?? `structured spawn recovery could not admit ${receipt.launchId}`);
+      if (prompt.trim()) {
+        const delivered = await enqueueStructuredMessage({
+          path: receipt.artifactPath,
+          conversationId: receipt.conversationId,
+          clientMessageId: `spawn_${receipt.launchId}`,
+          operationId: `spawn_message_${receipt.launchId}`,
+          text: prompt,
+          hasImages: false,
+        }, {
+          client: () => client,
+          registry: () => registry,
+          enabled: () => true,
+        });
+        if (!delivered?.ok) throw new Error(delivered?.error ?? `structured spawn recovery could not admit ${receipt.launchId}`);
+      }
       await client.transitionOperation(receipt.launchId, "delivered");
     }
     const finalized = registry.finalizeStructuredSpawn(receipt.launchId);

--- a/src/runtime-host/journal.ts
+++ b/src/runtime-host/journal.ts
@@ -810,7 +810,15 @@ export class RuntimeJournal {
       if (command.images !== undefined && (!Array.isArray(command.images) || command.images.length > 16 || command.images.some((image) => typeof image !== "string"))) throw new Error("message images are invalid");
     }
     if (command.kind === "answer" && !command.attentionId.trim()) throw new Error("attentionId is required");
-    if (command.kind === "spawn" && (!command.cwd.trim() || !command.prompt.trim())) throw new Error("spawn cwd and prompt are required");
+    if (command.kind === "kill"
+      && ((!command.sessionKey || (command.sessionKey.engine !== "codex" && command.sessionKey.engine !== "claude"))
+        || !command.sessionKey.sessionId?.trim())) {
+      throw new Error("kill sessionKey is invalid");
+    }
+    if (command.kind === "spawn"
+      && (typeof command.cwd !== "string" || !command.cwd.trim() || typeof command.prompt !== "string")) {
+      throw new Error("spawn cwd and prompt are required");
+    }
   }
 
   private operationReceipt(command: RuntimeOperationCommand, operationId: string): RuntimeOperationReceipt {
@@ -886,6 +894,9 @@ export class RuntimeJournal {
         status = "pending";
         turnId = attention.turnId ?? turnId;
       }
+    } else if (command.kind === "kill") {
+      status = "queued";
+      turnId = null;
     } else {
       status = "queued";
     }


### PR DESCRIPTION
## Summary

- honor structured-host rollback gates in tmux routing, runtime admission, composer transport selection, reconnects, and degraded polling
- reconcile failed and empty-prompt structured spawns during startup recovery, including failed host adoption
- settle delivered structured spawns after failed adoption while preserving delivery truth and preventing prompt replay
- add durable, generation-fenced kill operations for pane-less Codex and Claude hosts
- prevent release-driven state publication from self-waiting on the active structured kill drain
- defer production-calibrated first-Claude cold-start mitigation to #248 with explicit measurement and failure-recovery acceptance criteria
- integrate current main through #244 and #250

## Verification

- `bunx tsc --noEmit`
- `bun test` (2,733 passed, 0 failed)
- focused startup, structured-spawn integration, delivery-queue, and registry regression suites
- release-time `unhosted` regression covers terminal kill receipt, host cleanup, dead projection, post-kill drain, and queued-message fencing for Codex and Claude
- full diff self-review: clean

Closes #240