### PR TITLE
fix(runtime): preserve trusted Claude permission mode

### DIFF
--- a/src/app/api/spawn/route.test.ts
+++ b/src/app/api/spawn/route.test.ts
@@ -7,11 +7,12 @@ import { NextRequest } from "next/server";
 
 import { agentRegistry, AgentRegistry } from "@/lib/agent/registry";
 import { emptyLaunchProfile } from "@/lib/accounts/migration/contracts";
-import { codexSessionRoots } from "@/lib/accounts/codex";
+import { codexSessionRoots, createManagedCodexAccount } from "@/lib/accounts/codex";
 import { spawnParentSelector, spawnRequestDigest } from "@/lib/agent/spawnIdentity";
 import { rotateOperatorSpawnCapability } from "@/lib/agent/operatorCapability";
 import { spawnReplayStatus, spawnResponseForReceipt } from "@/lib/agent/spawnResponse";
 import { resolveSpawnLineage, resolveSpawnLineageParent, resolveSpawnParent, SpawnParentError } from "@/lib/agent/spawnParent";
+import type { RuntimeHostClient } from "@/lib/runtime/client";
 import { authenticatedAgentSpawnCaller, isAgentInitiatedSpawn, spawnLineageSelectorForCaller } from "./admission";
 import { POST } from "./route";
 
@@ -28,6 +29,31 @@ afterAll(() => {
 function registry(): AgentRegistry {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "llv-spawn-route-"));
   return new AgentRegistry(path.join(dir, "agent-registry.json"));
+}
+
+function structuredRouteDependencies(cwd: string): Parameters<typeof POST.withDependencies>[1] {
+  return {
+    resolveHealthySpawnAccount: async () => ({
+      engine: "claude",
+      accountId: "claude-test",
+      kind: "managed",
+      home: path.join(cwd, "account"),
+      transcriptRoot: path.join(cwd, "projects"),
+      env: { NODE_ENV: "test" },
+    }),
+    runtimeHostClient: () => ({} as RuntimeHostClient),
+    spawnStructuredConversation: async (input) => ({
+      ok: true,
+      target: null,
+      path: null,
+      effectivePermissionMode: input.spec.launchProfile?.permissionMode ?? "default",
+      launchId: input.receipt.launchId,
+      conversationId: input.receipt.conversationId,
+      launched: true,
+      retrySafe: false,
+      state: "settled",
+    }),
+  };
 }
 
 test("agent-initiated spawn without lineage returns a teaching 400", async () => {
@@ -220,6 +246,79 @@ test("operator callers may grant native sub-agent permission", async () => {
 
   expect(response.status).toBe(400);
   expect(await response.json()).toEqual({ error: "working directory is required" });
+});
+
+test("operator structured Claude retries retain bypass and agent reuse conflicts", async () => {
+  const cwd = fs.mkdtempSync(path.join(routeSandbox, "operator-permission-"));
+  const store = agentRegistry();
+  const callerSessionId = crypto.randomUUID();
+  const callerAccount = createManagedCodexAccount(`route-caller-${callerSessionId}`);
+  const callerPath = path.join(callerAccount.sessionsDir, `${callerSessionId}.jsonl`);
+  fs.mkdirSync(path.dirname(callerPath), { recursive: true });
+  fs.writeFileSync(callerPath, "{}\n");
+  const caller = store.beginSpawnRequest({ engine: "codex", cwd, accountId: "caller" });
+  if (caller.kind !== "created") throw new Error("expected caller reservation");
+  const settledCaller = store.settleSpawn(caller.receipt.launchId, {
+    key: { engine: "codex", sessionId: callerSessionId },
+    artifactPath: callerPath,
+    cwd,
+    accountId: "caller",
+    status: "idle",
+    host: null,
+    claimEpoch: 0,
+    claimOwner: null,
+    pendingAction: null,
+  });
+  if (settledCaller.kind !== "settled") throw new Error(`caller settlement failed: ${settledCaller.code}`);
+  expect(store.conversationForPath(callerPath)?.id).toBe(caller.receipt.conversationId);
+  const agentCapability = store.rotateSpawnCapabilityForReceipt(caller.receipt.launchId);
+  const operatorCapability = rotateOperatorSpawnCapability();
+  const attemptId = `attempt_${crypto.randomUUID()}`;
+  const request = (capability: string, clientAttemptId = attemptId) => new NextRequest("http://127.0.0.1:8898/api/spawn", {
+    method: "POST",
+    headers: { host: "127.0.0.1:8898", "content-type": "application/json", "x-llv-spawn-capability": capability },
+    body: JSON.stringify({ engine: "claude", model: "claude-sonnet-4-6", cwd, prompt: "build", src: callerPath, role: "builder", clientAttemptId }),
+  });
+  const previousTransport = process.env.LLV_SPAWN_TRANSPORT;
+  const previousHosts = process.env.LLV_STRUCTURED_HOSTS;
+  const previousEvents = process.env.LLV_RUNTIME_EVENTS;
+  const previousSocket = process.env.LLV_RUNTIME_HOST_SOCKET;
+  const previousUi = process.env.NEXT_PUBLIC_RUNTIME_UI;
+  process.env.LLV_SPAWN_TRANSPORT = "structured";
+  process.env.LLV_STRUCTURED_HOSTS = "1";
+  process.env.LLV_RUNTIME_EVENTS = "1";
+  process.env.LLV_RUNTIME_HOST_SOCKET = path.join(cwd, "runtime.sock");
+  process.env.NEXT_PUBLIC_RUNTIME_UI = "1";
+  try {
+    const launched = await POST.withDependencies(request(operatorCapability), structuredRouteDependencies(cwd));
+    expect(await launched.json()).toMatchObject({ effectivePermissionMode: "bypassPermissions" });
+
+    const replay = await POST.withDependencies(request(operatorCapability), structuredRouteDependencies(cwd));
+    expect(replay.status).toBe(202);
+    expect(await replay.json()).toMatchObject({ state: "starting", effectivePermissionMode: "bypassPermissions" });
+
+    const conflict = await POST.withDependencies(request(agentCapability), structuredRouteDependencies(cwd));
+    expect(conflict.status).toBe(409);
+    expect(await conflict.json()).toEqual({ error: "spawn attempt conflicts with its original request" });
+
+    const agentAttemptId = `attempt_${crypto.randomUUID()}`;
+    const agentLaunch = await POST.withDependencies(request(agentCapability, agentAttemptId), structuredRouteDependencies(cwd));
+    expect(await agentLaunch.json()).toMatchObject({ effectivePermissionMode: "default" });
+    const agentReplay = await POST.withDependencies(request(agentCapability, agentAttemptId), structuredRouteDependencies(cwd));
+    expect(agentReplay.status).toBe(202);
+    expect(await agentReplay.json()).toMatchObject({ state: "starting", effectivePermissionMode: "default" });
+  } finally {
+    if (previousTransport === undefined) delete process.env.LLV_SPAWN_TRANSPORT;
+    else process.env.LLV_SPAWN_TRANSPORT = previousTransport;
+    if (previousHosts === undefined) delete process.env.LLV_STRUCTURED_HOSTS;
+    else process.env.LLV_STRUCTURED_HOSTS = previousHosts;
+    if (previousEvents === undefined) delete process.env.LLV_RUNTIME_EVENTS;
+    else process.env.LLV_RUNTIME_EVENTS = previousEvents;
+    if (previousSocket === undefined) delete process.env.LLV_RUNTIME_HOST_SOCKET;
+    else process.env.LLV_RUNTIME_HOST_SOCKET = previousSocket;
+    if (previousUi === undefined) delete process.env.NEXT_PUBLIC_RUNTIME_UI;
+    else process.env.NEXT_PUBLIC_RUNTIME_UI = previousUi;
+  }
 });
 
 test("structured spawn flag reaches the pane-less capability gate", async () => {

--- a/src/app/api/spawn/route.ts
+++ b/src/app/api/spawn/route.ts
@@ -25,7 +25,7 @@ import { rejectCrossOrigin } from "@/lib/sameOrigin";
 import { runtimeHostClient } from "@/lib/runtime/client";
 import { runtimeScope } from "@/lib/runtime/contracts";
 import { runtimeEventsEnabled } from "@/lib/runtime/flags";
-import { spawnStructuredConversation } from "@/lib/runtime/structuredSpawn";
+import { spawnStructuredConversation, structuredClaudePermissionMode } from "@/lib/runtime/structuredSpawn";
 import { structuredSpawnGap, spawnTransport } from "@/lib/runtime/spawnTransport";
 import { listFiles } from "@/lib/scanner";
 import { projectForCwd } from "@/lib/scanner/describe";
@@ -204,7 +204,23 @@ export async function POST(req: NextRequest): Promise<NextResponse<SpawnResponse
       allowSubagents: body.allowSubagents === true,
       deferClaudeSpawnPolicy: true,
     });
-    const spec = { ...specBase, launchProfile: emptyLaunchProfile({ ...(specBase.launchProfile ?? {}), cwd, parentConversationId, allowSubagents: body.allowSubagents === true }) };
+    const permissionMode = engine === "claude" && transport === "structured"
+      ? structuredClaudePermissionMode(specBase.launchProfile?.permissionMode, {
+        agentInitiated,
+        operatorAuthenticated: authenticatedCaller?.kind === "operator",
+        roleSpawn: Boolean(role.value),
+      })
+      : specBase.launchProfile?.permissionMode;
+    const spec = {
+      ...specBase,
+      launchProfile: emptyLaunchProfile({
+        ...(specBase.launchProfile ?? {}),
+        cwd,
+        parentConversationId,
+        allowSubagents: body.allowSubagents === true,
+        permissionMode,
+      }),
+    };
     const begun = registry.beginSpawnRequest({
       engine,
       cwd,

--- a/src/app/api/spawn/route.ts
+++ b/src/app/api/spawn/route.ts
@@ -43,6 +43,18 @@ export const dynamic = "force-dynamic";
 const SUGGEST_SCAN_LIMIT = 80;
 const SUGGEST_MAX = 10;
 
+interface SpawnRouteDependencies {
+  resolveHealthySpawnAccount: typeof resolveHealthySpawnAccount;
+  runtimeHostClient: typeof runtimeHostClient;
+  spawnStructuredConversation: typeof spawnStructuredConversation;
+}
+
+const productionSpawnRouteDependencies: SpawnRouteDependencies = {
+  resolveHealthySpawnAccount,
+  runtimeHostClient,
+  spawnStructuredConversation,
+};
+
 interface SuggestResponse {
   dirs: string[];
   /** Working directory of the `src` transcript when one was requested. */
@@ -84,7 +96,10 @@ export async function GET(req: NextRequest): Promise<NextResponse<SuggestRespons
   return NextResponse.json({ dirs, cwd: srcCwd, cwdExists });
 }
 
-export async function POST(req: NextRequest): Promise<NextResponse<SpawnResponse | ApiError>> {
+async function postSpawn(
+  req: NextRequest,
+  dependencies: SpawnRouteDependencies = productionSpawnRouteDependencies,
+): Promise<NextResponse<SpawnResponse | ApiError>> {
   const rejection = rejectCrossOrigin(req);
   if (rejection) return rejection;
 
@@ -169,7 +184,7 @@ export async function POST(req: NextRequest): Promise<NextResponse<SpawnResponse
   let imagePaths: string[] = [];
   let launchId: string | null = null;
   try {
-    const account = await resolveHealthySpawnAccount(engine, body.accountId);
+    const account = await dependencies.resolveHealthySpawnAccount(engine, body.accountId);
     const lineage = resolveSpawnLineage(spawnLineageSelectorForCaller(authenticatedCaller, {
       ...body,
       role: role.value?.role,
@@ -224,6 +239,7 @@ export async function POST(req: NextRequest): Promise<NextResponse<SpawnResponse
     const begun = registry.beginSpawnRequest({
       engine,
       cwd,
+      transport,
       accountId: account.accountId,
       parentConversationId,
       parentSessionKey,
@@ -237,7 +253,9 @@ export async function POST(req: NextRequest): Promise<NextResponse<SpawnResponse
     });
     if (begun.kind === "conflict") return NextResponse.json({ error: "spawn attempt conflicts with its original request" }, { status: 409 });
     if (begun.kind === "replay") {
-      const structured = Boolean(begun.receipt.key && registry.snapshot().entries[sessionKeyId(begun.receipt.key)]?.structuredHost);
+      const structured = begun.receipt.transport === "structured"
+        || (begun.receipt.transport === null
+          && Boolean(begun.receipt.key && registry.snapshot().entries[sessionKeyId(begun.receipt.key)]?.structuredHost));
       const response = spawnResponseForReceipt(begun.receipt, begun.receipt.artifactPath, { structured });
       if (begun.receipt.state === "failed") return NextResponse.json({ error: "original spawn failed before launch", retrySafe: true }, { status: 409 });
       return NextResponse.json(response, { status: spawnReplayStatus(response, structured) });
@@ -253,9 +271,9 @@ export async function POST(req: NextRequest): Promise<NextResponse<SpawnResponse
       });
     }
     if (transport === "structured") {
-      const runtimeClient = runtimeHostClient();
+      const runtimeClient = dependencies.runtimeHostClient();
       if (!runtimeClient) throw new Error("structured spawn runtime host is unavailable");
-      const response = await spawnStructuredConversation({
+      const response = await dependencies.spawnStructuredConversation({
         engine,
         receipt: begun.receipt,
         spec,
@@ -274,7 +292,7 @@ export async function POST(req: NextRequest): Promise<NextResponse<SpawnResponse
        appended to its first prompt — the same contract the pane composer uses. */
     const bundle = buildImagePayload(prompt, images);
     imagePaths = bundle.imagePaths;
-    let runtimeClient = runtimeEventsEnabled() ? runtimeHostClient() : null;
+    let runtimeClient = runtimeEventsEnabled() ? dependencies.runtimeHostClient() : null;
     /* The durable launch receipt owns the runtime idempotency key too. A
        recovered route cannot create a second logical lineage edge. */
     const operationId = runtimeClient ? begun.receipt.launchId : null;
@@ -370,3 +388,8 @@ export async function POST(req: NextRequest): Promise<NextResponse<SpawnResponse
     return NextResponse.json({ error: error instanceof Error ? error.message : String(error) }, { status: 500 });
   }
 }
+
+export const POST = Object.assign(
+  async (req: NextRequest): Promise<NextResponse<SpawnResponse | ApiError>> => await postSpawn(req),
+  { withDependencies: postSpawn },
+);

--- a/src/lib/agent/registry.test.ts
+++ b/src/lib/agent/registry.test.ts
@@ -1009,6 +1009,31 @@ describe("agent registry", () => {
     expect(conflict.kind).toBe("conflict");
   });
 
+  test("spawn idempotency includes effective permission mode and reserved transport", () => {
+    const store = registry();
+    const request = {
+      engine: "claude" as const,
+      cwd: "/repo",
+      accountId: "work",
+      clientAttemptId: "attempt_permission_mode",
+      requestDigest: "same-public-shape",
+      transport: "structured" as const,
+      launchProfile: emptyLaunchProfile({ cwd: "/repo", permissionMode: "bypassPermissions" }),
+    };
+    const first = store.beginSpawnRequest(request);
+    if (first.kind !== "created") throw new Error("expected create");
+
+    expect(store.beginSpawnRequest(request)).toMatchObject({
+      kind: "replay",
+      receipt: { launchId: first.receipt.launchId },
+    });
+    expect(store.beginSpawnRequest({
+      ...request,
+      launchProfile: emptyLaunchProfile({ cwd: "/repo", permissionMode: "default" }),
+    }).kind).toBe("conflict");
+    expect(store.beginSpawnRequest({ ...request, transport: "tmux" }).kind).toBe("conflict");
+  });
+
   test("spawn capability digest durably resolves its reserved conversation", () => {
     const store = registry();
     const digest = "a".repeat(64);

--- a/src/lib/agent/registry.ts
+++ b/src/lib/agent/registry.ts
@@ -111,6 +111,8 @@ export interface SpawnReceipt {
   clientAttemptId: string | null;
   /** SHA-256 of the public launch shape. Prompt/image contents never persist. */
   requestDigest: string | null;
+  /** Launch transport fixed when the idempotent reservation is created. */
+  transport: "tmux" | "structured" | null;
   /** One-way binding for the caller credential injected into this worker. */
   spawnCapabilityDigest: string | null;
   /** Reserved at receipt birth so path discovery cannot choose the identity. */
@@ -174,6 +176,7 @@ export type DurableMembershipInput = Omit<DurableConversationMembership, "conver
 export interface SpawnRequest {
   engine: AgentEngine;
   cwd: string;
+  transport?: "tmux" | "structured" | null;
   launchProfile?: Partial<LaunchProfile>;
   clientAttemptId?: string | null;
   requestDigest?: string | null;
@@ -1160,6 +1163,7 @@ function normalizeReceipt(value: SpawnReceipt): SpawnReceipt {
     ...value,
     clientAttemptId: typeof value.clientAttemptId === "string" ? value.clientAttemptId : null,
     requestDigest: typeof value.requestDigest === "string" ? value.requestDigest : null,
+    transport: value.transport === "tmux" || value.transport === "structured" ? value.transport : null,
     spawnCapabilityDigest: typeof value.spawnCapabilityDigest === "string" && /^[0-9a-f]{64}$/.test(value.spawnCapabilityDigest)
       ? value.spawnCapabilityDigest
       : null,
@@ -1947,7 +1951,11 @@ export class AgentRegistry {
       if (input.clientAttemptId) {
         const existing = Object.values(file.receipts).find((receipt) => receipt.clientAttemptId === input.clientAttemptId);
         if (existing) {
-          const compatible = existing.requestDigest === (input.requestDigest ?? null) && existing.engine === input.engine && existing.cwd === input.cwd;
+          const compatible = existing.requestDigest === (input.requestDigest ?? null)
+            && existing.engine === input.engine
+            && existing.cwd === input.cwd
+            && existing.transport === (input.transport ?? null)
+            && existing.launchProfile.permissionMode === profile.permissionMode;
           return { kind: compatible ? "replay" : "conflict", receipt: clone(existing) };
         }
       }
@@ -1970,6 +1978,7 @@ export class AgentRegistry {
         launchId: crypto.randomUUID(),
         clientAttemptId: input.clientAttemptId ?? null,
         requestDigest: input.requestDigest ?? null,
+        transport: input.transport ?? null,
         spawnCapabilityDigest: typeof input.spawnCapabilityDigest === "string" && /^[0-9a-f]{64}$/.test(input.spawnCapabilityDigest)
           ? input.spawnCapabilityDigest
           : null,

--- a/src/lib/agent/spawnResponse.ts
+++ b/src/lib/agent/spawnResponse.ts
@@ -5,6 +5,8 @@ export interface SpawnResponse {
   target: string | null;
   /** Transcript path the fresh session will write, when knowable. */
   path: string | null;
+  /** Effective Claude permission mode for pane-less launches. */
+  effectivePermissionMode?: string;
   launchId: string;
   conversationId: string;
   launched: boolean;
@@ -35,6 +37,9 @@ export function spawnResponseForReceipt(
     ok: true,
     target: receipt.pane?.paneId ?? receipt.target ?? null,
     path,
+    ...(options.structured === true && receipt.engine === "claude"
+      ? { effectivePermissionMode: receipt.launchProfile.permissionMode ?? "default" }
+      : {}),
     launchId: receipt.launchId,
     conversationId: receipt.conversationId,
     launched,

--- a/src/lib/agent/spawnResponse.ts
+++ b/src/lib/agent/spawnResponse.ts
@@ -24,6 +24,8 @@ export function spawnResponseForReceipt(
   path = receipt.artifactPath,
   options: { structured?: boolean } = {},
 ): SpawnResponse {
+  const structured = receipt.transport === "structured"
+    || (receipt.transport === null && options.structured === true);
   const conflict = receipt.state === "conflicted";
   const pending = receipt.state === "starting"
     || receipt.state === "pane-bound"
@@ -37,7 +39,7 @@ export function spawnResponseForReceipt(
     ok: true,
     target: receipt.pane?.paneId ?? receipt.target ?? null,
     path,
-    ...(options.structured === true && receipt.engine === "claude"
+    ...(structured && receipt.engine === "claude"
       ? { effectivePermissionMode: receipt.launchProfile.permissionMode ?? "default" }
       : {}),
     launchId: receipt.launchId,

--- a/src/lib/runtime/claudeStreamBrokerHost.integration.test.ts
+++ b/src/lib/runtime/claudeStreamBrokerHost.integration.test.ts
@@ -11,10 +11,12 @@ import { pathIsInside, prepareClaudeIntegrationTestHome } from "./integrationTes
 const claudeBinary = process.env.LLV_CLAUDE_BINARY ?? "claude";
 const resumeHome = prepareClaudeIntegrationTestHome(claudeBinary);
 const permissionHome = prepareClaudeIntegrationTestHome(claudeBinary);
+const bypassHome = prepareClaudeIntegrationTestHome(claudeBinary);
 
 afterAll(() => {
   resumeHome?.cleanup();
   permissionHome?.cleanup();
+  bypassHome?.cleanup();
 });
 
 async function waitFor(
@@ -151,5 +153,46 @@ test.skipIf(!permissionHome)("real Claude permission requests reach EngineHost.a
   } finally {
     await host?.release();
     permissionHome.cleanup();
+  }
+}, 180_000);
+
+test.skipIf(!bypassHome)("real Claude bypass executes Bash without pending attention", async () => {
+  if (!bypassHome) throw new Error("isolated Claude subscription home is unavailable");
+  const directory = bypassHome.directory;
+  const eventStore = new FileRuntimeEventStore(path.join(directory, "events"));
+  const deliveryLedger = new FileClaudeDeliveryLedger(path.join(directory, "deliveries"));
+  let host: ClaudeStreamBrokerHost | null = null;
+  try {
+    host = await ClaudeStreamBrokerHost.start({
+      cwd: directory,
+      binary: claudeBinary,
+      claudeConfigDir: bypassHome.claudeConfigDir,
+      claudeProjectsDir: bypassHome.claudeProjectsDir,
+      env: bypassHome.env,
+      model: "haiku",
+      permissionMode: "bypassPermissions",
+      tools: ["Bash"],
+      systemPrompt: "Follow the user request exactly and use the requested tool.",
+      eventStore,
+      deliveryLedger,
+    });
+    const events = host.attach(0)[Symbol.asyncIterator]();
+    const probePath = path.join(directory, "bypass-probe");
+    const sent = await host.send({
+      id: `issue-243-bypass-${crypto.randomUUID()}`,
+      text: `Use the Bash tool once to run \`touch ${probePath}\`. Reply after the tool completes.`,
+    });
+    expect(sent.outcome).toBe("turn-started");
+    let sawAttention = false;
+    await waitFor(events, (event) => {
+      if (event.kind === "attention") sawAttention = true;
+      return event.kind === "turn-ended";
+    });
+    expect(fs.existsSync(probePath)).toBeTrue();
+    expect(sawAttention).toBeFalse();
+    expect((await host.health()).pendingAttention).toEqual([]);
+  } finally {
+    await host?.release();
+    bypassHome.cleanup();
   }
 }, 180_000);

--- a/src/lib/runtime/claudeStreamBrokerHost.test.ts
+++ b/src/lib/runtime/claudeStreamBrokerHost.test.ts
@@ -135,6 +135,24 @@ async function nextEvent(iterator: AsyncIterator<RuntimeEvent>): Promise<Runtime
 }
 
 describe("ClaudeStreamBrokerHost", () => {
+  test("passes bypassPermissions to the pane-less Claude process", async () => {
+    const ledger = new RecordingDeliveryLedger();
+    const child = new FakeClaude(ledger);
+    const captured: { args?: string[]; options?: SpawnOptionsWithoutStdio } = {};
+    const host = await ClaudeStreamBrokerHost.start({
+      cwd: "/repo",
+      permissionMode: "bypassPermissions",
+      eventStore: new MemoryEventStore(),
+      deliveryLedger: ledger,
+      readAuthStatus: () => ({ loggedIn: true, authMethod: "claude.ai", subscriptionType: "max" }),
+      spawnProcess: fakeSpawn(child, captured),
+    });
+
+    const modeIndex = captured.args!.indexOf("--permission-mode");
+    expect(captured.args?.slice(modeIndex, modeIndex + 2)).toEqual(["--permission-mode", "bypassPermissions"]);
+    await host.release();
+  });
+
   test("persists sends before stdin and fans durable events to late viewers", async () => {
     const ledger = new RecordingDeliveryLedger();
     const child = new FakeClaude(ledger);

--- a/src/lib/runtime/structuredSpawn.integration.test.ts
+++ b/src/lib/runtime/structuredSpawn.integration.test.ts
@@ -28,9 +28,54 @@ const sandbox = fs.mkdtempSync(path.join(os.tmpdir(), "llv-structured-spawn-"));
 afterAll(() => fs.rmSync(sandbox, { recursive: true, force: true }));
 afterEach(async () => { await bindStructuredDeliveryQueue([]); });
 
-test("structured Claude fresh sessions use the permission channel", () => {
-  expect(structuredClaudePermissionMode("bypassPermissions")).toBe("default");
-  expect(structuredClaudePermissionMode("plan")).toBe("plan");
+test("structured Claude permission mapping distinguishes trusted autonomous spawn paths", () => {
+  expect(structuredClaudePermissionMode("bypassPermissions", {
+    agentInitiated: true,
+    operatorAuthenticated: true,
+    roleSpawn: true,
+  })).toBe("bypassPermissions");
+  expect(structuredClaudePermissionMode("bypassPermissions", {
+    agentInitiated: false,
+    operatorAuthenticated: false,
+    roleSpawn: true,
+  })).toBe("bypassPermissions");
+  expect(structuredClaudePermissionMode("bypassPermissions", {
+    agentInitiated: true,
+    operatorAuthenticated: false,
+    roleSpawn: true,
+  })).toBe("default");
+  expect(structuredClaudePermissionMode("bypassPermissions", {
+    agentInitiated: false,
+    operatorAuthenticated: false,
+    roleSpawn: false,
+  })).toBe("default");
+  expect(structuredClaudePermissionMode("plan", {
+    agentInitiated: true,
+    operatorAuthenticated: false,
+    roleSpawn: true,
+  })).toBe("plan");
+});
+
+test("structured Claude receipts expose the effective permission mode", () => {
+  const store = new AgentRegistry(path.join(sandbox, `permission-receipt-${crypto.randomUUID()}.json`), undefined, undefined, { sqliteMode: "off" });
+  const trusted = store.beginSpawnRequest({
+    engine: "claude",
+    cwd: "/repo",
+    launchProfile: emptyLaunchProfile({ cwd: "/repo", permissionMode: "bypassPermissions" }),
+  });
+  const downgraded = store.beginSpawnRequest({
+    engine: "claude",
+    cwd: "/repo",
+    launchProfile: emptyLaunchProfile({ cwd: "/repo", permissionMode: "default" }),
+  });
+  if (trusted.kind !== "created" || downgraded.kind !== "created") throw new Error("spawn receipt was unavailable");
+
+  expect(spawnResponseForReceipt(trusted.receipt, null, { structured: true })).toMatchObject({
+    effectivePermissionMode: "bypassPermissions",
+  });
+  expect(spawnResponseForReceipt(downgraded.receipt, null, { structured: true })).toMatchObject({
+    effectivePermissionMode: "default",
+  });
 });
 
 test("fresh managed Claude structured spawns select the shared settings snapshot", () => {
@@ -490,6 +535,7 @@ describe.each(["codex", "claude"] as const)("%s structured spawn round trip", (e
     });
 
     expect(response).toMatchObject({ launched: true, target: null, path: artifactPath, state: "settled" });
+    if (engine === "claude") expect(response).toMatchObject({ effectivePermissionMode: "default" });
     expect(registry.snapshot().receipts[begun.receipt.launchId]?.pane).toBeNull();
     const registryBeforeAttach = registry.snapshot();
     let terminalCommand = "";

--- a/src/lib/runtime/structuredSpawn.integration.test.ts
+++ b/src/lib/runtime/structuredSpawn.integration.test.ts
@@ -61,19 +61,23 @@ test("structured Claude receipts expose the effective permission mode", () => {
   const trusted = store.beginSpawnRequest({
     engine: "claude",
     cwd: "/repo",
+    transport: "structured",
     launchProfile: emptyLaunchProfile({ cwd: "/repo", permissionMode: "bypassPermissions" }),
   });
   const downgraded = store.beginSpawnRequest({
     engine: "claude",
     cwd: "/repo",
+    transport: "structured",
     launchProfile: emptyLaunchProfile({ cwd: "/repo", permissionMode: "default" }),
   });
   if (trusted.kind !== "created" || downgraded.kind !== "created") throw new Error("spawn receipt was unavailable");
 
-  expect(spawnResponseForReceipt(trusted.receipt, null, { structured: true })).toMatchObject({
+  expect(spawnResponseForReceipt(trusted.receipt, null)).toMatchObject({
+    state: "starting",
     effectivePermissionMode: "bypassPermissions",
   });
-  expect(spawnResponseForReceipt(downgraded.receipt, null, { structured: true })).toMatchObject({
+  expect(spawnResponseForReceipt(downgraded.receipt, null)).toMatchObject({
+    state: "starting",
     effectivePermissionMode: "default",
   });
 });

--- a/src/lib/runtime/structuredSpawn.ts
+++ b/src/lib/runtime/structuredSpawn.ts
@@ -129,8 +129,19 @@ function hostIdentity(engine: AgentEngine, host: SpawnedStructuredHost, input: S
   };
 }
 
-export function structuredClaudePermissionMode(mode: string | null | undefined): string {
-  return !mode || mode === "bypassPermissions" ? "default" : mode;
+export interface StructuredClaudePermissionContext {
+  agentInitiated: boolean;
+  operatorAuthenticated: boolean;
+  roleSpawn: boolean;
+}
+
+export function structuredClaudePermissionMode(
+  mode: string | null | undefined,
+  context: StructuredClaudePermissionContext,
+): string {
+  if (!mode) return "default";
+  if (mode !== "bypassPermissions") return mode;
+  return context.operatorAuthenticated || (context.roleSpawn && !context.agentInitiated) ? mode : "default";
 }
 
 export function structuredClaudeSpawnPolicyBaseSettingsPath(
@@ -166,7 +177,7 @@ async function defaultStartHost(input: StructuredSpawnInput, capability: string)
     allowSubagents: profile.allowSubagents,
     model: profile.model ?? undefined,
     effort: profile.effort ?? undefined,
-    permissionMode: structuredClaudePermissionMode(profile.permissionMode),
+    permissionMode: profile.permissionMode ?? "default",
     env,
   });
 }
@@ -261,6 +272,9 @@ export async function spawnStructuredConversation(
       ok: true,
       target: null,
       path: identity.path,
+      ...(input.engine === "claude"
+        ? { effectivePermissionMode: input.spec.launchProfile?.permissionMode ?? "default" }
+        : {}),
       launchId: input.receipt.launchId,
       conversationId: settled.conversation.id,
       launched: true,


### PR DESCRIPTION
## Summary

- Preserve bypassPermissions for operator-capability structured Claude spawns and same-origin role-registry lanes.
- Resolve plain agent-capability and unprivileged Viewer lanes to default.
- Expose effectivePermissionMode in immediate and replayed structured Claude spawn responses.
- Cover authority mapping, durable receipts, pane-less response projection, and Claude process arguments.

## Verification

- bunx tsc --noEmit
- bun test — 2,717 passed
- Focused route/runtime suites — 55 passed
- Self-review and git diff --check — clean

Closes [#243](https://github.com/Latand/live-log-viewer-next/issues/243)