### PR TITLE
Restore scheme minimap and camera gestures with runtime UI

### DIFF
--- a/src/components/runtime/AttentionCard.tsx
+++ b/src/components/runtime/AttentionCard.tsx
@@ -48,7 +48,7 @@ export function AttentionCard({ attention, onApprove, onDeny, onAnswerQuestion, 
     const node = cardRef.current;
     if (!node) return;
     const focusables = () => Array.from(node.querySelectorAll<HTMLElement>('button,[href],input,select,textarea,[tabindex]:not([tabindex="-1"])')).filter((el) => !el.hasAttribute("disabled"));
-    focusables()[0]?.focus();
+    focusables()[0]?.focus({ preventScroll: true });
     const onKey = (event: KeyboardEvent) => {
       if (event.key === "Escape" && onDeny) {
         event.preventDefault();
@@ -67,10 +67,10 @@ export function AttentionCard({ attention, onApprove, onDeny, onAnswerQuestion, 
       const last = items[items.length - 1]!;
       if (event.shiftKey && document.activeElement === first) {
         event.preventDefault();
-        last.focus();
+        last.focus({ preventScroll: true });
       } else if (!event.shiftKey && document.activeElement === last) {
         event.preventDefault();
-        first.focus();
+        first.focus({ preventScroll: true });
       }
     };
     node.addEventListener("keydown", onKey);

--- a/src/components/scheme/SchemeBoard.camera.dom.test.tsx
+++ b/src/components/scheme/SchemeBoard.camera.dom.test.tsx
@@ -1,0 +1,167 @@
+import { afterEach, expect, test } from "bun:test";
+import { Window } from "happy-dom";
+import { flushSync } from "react-dom";
+import { createRoot, type Root } from "react-dom/client";
+
+import { SchemeBoard } from "./SchemeBoard";
+
+const dom = new Window();
+class TestResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+(dom as unknown as { matchMedia: (query: string) => unknown }).matchMedia = () => ({
+  matches: false,
+  media: "",
+  addEventListener() {},
+  removeEventListener() {},
+  addListener() {},
+  removeListener() {},
+  onchange: null,
+  dispatchEvent: () => false,
+});
+
+const requestFrame = (callback: FrameRequestCallback) => dom.setTimeout(() => callback(0), 0);
+Object.assign(globalThis, {
+  window: dom,
+  document: dom.document,
+  navigator: dom.navigator,
+  Node: dom.Node,
+  HTMLElement: dom.HTMLElement,
+  HTMLButtonElement: dom.HTMLButtonElement,
+  HTMLDivElement: dom.HTMLDivElement,
+  Event: dom.Event,
+  CustomEvent: dom.CustomEvent,
+  MouseEvent: dom.MouseEvent,
+  PointerEvent: dom.PointerEvent,
+  WheelEvent: dom.WheelEvent,
+  sessionStorage: dom.sessionStorage,
+  localStorage: dom.localStorage,
+  ResizeObserver: TestResizeObserver,
+  IntersectionObserver: undefined,
+  requestAnimationFrame: requestFrame,
+  cancelAnimationFrame: (id: number) => dom.clearTimeout(id as never),
+});
+
+const roots = new Set<Root>();
+afterEach(() => {
+  for (const root of roots) flushSync(() => root.unmount());
+  roots.clear();
+  document.body.replaceChildren();
+  dom.sessionStorage.clear();
+  dom.localStorage.clear();
+});
+
+const settle = async () => {
+  for (let index = 0; index < 3; index += 1) await new Promise((resolve) => setTimeout(resolve, 0));
+  flushSync(() => undefined);
+};
+
+test("the scheme viewport keeps its minimap and camera gestures after descendant focus scrolling", async () => {
+  const host = document.createElement("div");
+  document.body.append(host);
+  const root = createRoot(host);
+  roots.add(root);
+  flushSync(() => {
+    root.render(
+      <SchemeBoard
+        project="camera-regression"
+        groups={[]}
+        manual={[]}
+        files={[]}
+        flows={[]}
+        tasks={[]}
+        drafts={[]}
+        focus={null}
+        onSelect={() => {}}
+        onClose={() => {}}
+        onDraftClose={() => {}}
+        onDraftSpawned={() => {}}
+      />,
+    );
+  });
+  await settle();
+
+  const viewport = host.querySelector('[aria-label^="Agent board"]') as HTMLDivElement;
+  const minimap = host.querySelector('[title^="Minimap"]');
+  const world = Array.from(viewport.children).find((child) =>
+    (child as HTMLElement).style.transform.includes("scale("),
+  ) as HTMLElement;
+  expect(viewport).toBeTruthy();
+  expect(minimap).toBeTruthy();
+  expect(world).toBeTruthy();
+
+  /* A focused runtime control in a distant card can scroll an overflow-clipped
+     ancestor. The camera viewport owns a fixed scroll origin. */
+  viewport.scrollLeft = 180;
+  viewport.scrollTop = 90;
+  flushSync(() =>
+    viewport.dispatchEvent(new dom.Event("scroll", { bubbles: true }) as unknown as Event),
+  );
+  expect({ left: viewport.scrollLeft, top: viewport.scrollTop }).toEqual({ left: 0, top: 0 });
+
+  const beforeWheel = world.style.transform;
+  const wheel = new dom.WheelEvent("wheel", {
+    bubbles: true,
+    cancelable: true,
+    deltaY: -100,
+  });
+  Object.defineProperties(wheel, {
+    clientX: { value: 400 },
+    clientY: { value: 300 },
+    ctrlKey: { value: true },
+  });
+  flushSync(() => viewport.dispatchEvent(wheel as unknown as Event));
+  await settle();
+  expect(world.style.transform).not.toBe(beforeWheel);
+
+  const hand = Array.from(host.querySelectorAll("button")).find((button) =>
+    button.title.startsWith("Hand"),
+  ) as HTMLButtonElement;
+  flushSync(() =>
+    hand.dispatchEvent(new dom.MouseEvent("click", { bubbles: true }) as unknown as Event),
+  );
+  await settle();
+  expect(hand.getAttribute("aria-pressed")).toBe("true");
+
+  const beforeDrag = world.style.transform;
+  flushSync(() =>
+    viewport.dispatchEvent(new dom.PointerEvent("pointerdown", {
+      bubbles: true,
+      isPrimary: true,
+      pointerId: 7,
+      pointerType: "mouse",
+      button: 0,
+      clientX: 400,
+      clientY: 300,
+    }) as unknown as Event),
+  );
+  await settle();
+  expect(viewport.className).toContain("cursor-grabbing");
+  flushSync(() =>
+    viewport.dispatchEvent(new dom.PointerEvent("pointermove", {
+      bubbles: true,
+      isPrimary: true,
+      pointerId: 7,
+      pointerType: "mouse",
+      button: 0,
+      clientX: 340,
+      clientY: 300,
+    }) as unknown as Event),
+  );
+  await settle();
+  flushSync(() =>
+    window.dispatchEvent(new dom.PointerEvent("pointerup", {
+      bubbles: true,
+      isPrimary: true,
+      pointerId: 7,
+      pointerType: "mouse",
+      button: 0,
+      clientX: 340,
+      clientY: 300,
+    }) as unknown as Event),
+  );
+  await settle();
+  expect(world.style.transform).not.toBe(beforeDrag);
+});

--- a/src/components/scheme/SchemeBoard.tsx
+++ b/src/components/scheme/SchemeBoard.tsx
@@ -831,7 +831,7 @@ export function SchemeBoard({
     <>
     <div
       ref={viewportRef}
-      className={`relative min-h-0 flex-1 overflow-hidden ${
+      className={`relative min-h-0 flex-1 overflow-clip ${
         panning ? "cursor-grabbing select-none" : taskTool ? "cursor-crosshair" : handLike ? "cursor-grab" : ""
       } ${handLike ? "touch-none" : ""}`}
       tabIndex={mapMode ? undefined : 0}
@@ -840,6 +840,13 @@ export function SchemeBoard({
       onPointerMove={onPointerMove}
       onDoubleClick={onDoubleClick}
       onClick={onClick}
+      /* Focusable controls live inside world-space panes. Browser focus can
+         scroll a clipped ancestor to reveal one, which would offset every
+         camera coordinate and carry the minimap away from its corner. */
+      onScroll={(event) => {
+        event.currentTarget.scrollLeft = 0;
+        event.currentTarget.scrollTop = 0;
+      }}
     >
       {/* Announces the window the arrow keys just landed on, for screen readers. */}
       <div className="sr-only" aria-live="polite" role="status">


### PR DESCRIPTION
## Summary

- keep runtime attention autofocus and focus trapping from scrolling transformed scheme panes
- clip the scheme viewport and reassert its zero scroll origin when descendant focus attempts a programmatic scroll
- cover minimap presence, scroll-origin recovery, ctrl-wheel zoom, and hand-drag panning in a DOM regression test

## Root cause

Runtime attention controls autofocus their first action. When an attention card lived in a distant transformed pane, browser focus scrolled the overflow-hidden scheme viewport to reveal it. The absolute minimap moved with that hidden scroll offset, while camera math continued using the viewport origin. This displaced the minimap and broke camera interactions near the clipped top edge.

## Verification

- `bunx tsc --noEmit`
- `bun test` — 2716 pass, 0 fail
- `NEXT_PUBLIC_RUNTIME_UI=1 bun run build`
- targeted ESLint on all changed files
- runtime-enabled browser replay: minimap anchored 12px from the board edges; forced scroll recovered to `(0, 0)`; ctrl-wheel and hand drag each changed the world transform

Closes #249