### PR TITLE
fix(runtime): re-adopt structured hosts after viewer restart

### DIFF
--- a/src/lib/runtime/claudeStreamBrokerHost.test.ts
+++ b/src/lib/runtime/claudeStreamBrokerHost.test.ts
@@ -807,7 +807,8 @@ describe("ClaudeStreamBrokerHost", () => {
 
   test("boot adoption resumes claimed Claude rows and persists broker columns", async () => {
     const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-claude-adoption-"));
-    const registry = new AgentRegistry(path.join(directory, "agent-registry.json"));
+    const registryPath = path.join(directory, "agent-registry.json");
+    const registry = new AgentRegistry(registryPath);
     const sessionId = "adopted-claude-session";
     registry.upsert({
       key: { engine: "claude", sessionId },
@@ -865,6 +866,35 @@ describe("ClaudeStreamBrokerHost", () => {
       claimOwner: null,
       structuredHost: { endpoint: "stdio:released", process: null },
     });
+
+    const restartedRegistry = new AgentRegistry(registryPath);
+    const replacement = new FakeClaude(ledger);
+    const restartCaptured: { args?: string[] } = {};
+    const restarted = await adoptClaudeRegistryHosts(
+      restartedRegistry,
+      () => ({
+        cwd: "/repo",
+        deliveryLedger: ledger,
+        eventStore: new MemoryEventStore(),
+        readAuthStatus: () => ({ loggedIn: true, authMethod: "claude.ai", subscriptionType: "max", version: "2.1.197" }),
+        readTranscript: () => [],
+        spawnProcess: fakeSpawn(replacement, restartCaptured),
+      }),
+      { NODE_ENV: "test", LLV_STRUCTURED_HOSTS: "1" },
+    );
+    expect(restarted).toHaveLength(1);
+    expect(restartCaptured.args).toContain("--resume");
+    expect(restartedRegistry.snapshot().entries[`claude:${sessionId}`]).toMatchObject({
+      status: "idle",
+      host: null,
+      claimEpoch: 4,
+      structuredHost: {
+        kind: "claude-broker",
+        endpoint: "stdio:5150",
+        writerClaimEpoch: 4,
+      },
+    });
+    await restarted[0]!.host.release();
   });
 
   test("boot adoption reaps a surviving orphaned Claude child before resume", async () => {

--- a/src/lib/runtime/codexAppServerHost.test.ts
+++ b/src/lib/runtime/codexAppServerHost.test.ts
@@ -938,7 +938,8 @@ describe("CodexAppServerHost", () => {
 
   test("boot adoption resumes every flagged Codex registry row", async () => {
     const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-structured-adoption-"));
-    const registry = new AgentRegistry(path.join(directory, "agent-registry.json"));
+    const registryPath = path.join(directory, "agent-registry.json");
+    const registry = new AgentRegistry(registryPath);
     const key = { engine: "codex" as const, sessionId: "adopted-thread" };
     registry.upsert({
       key,
@@ -1002,33 +1003,39 @@ describe("CodexAppServerHost", () => {
       claimOwner: null,
       structuredHost: { eventCursor: 18, process: null, activeTurnRef: null, pendingAttention: [] },
     });
-    let restarted = false;
+    const restartedRegistry = new AgentRegistry(registryPath);
+    const replacement = new FakeAppServer("adopted-thread");
     const releasedRows = await adoptCodexRegistryHosts(
-      registry,
-      () => {
-        restarted = true;
-        return { cwd: "/repo", eventStore: new MemoryEventStore(), spawnProcess: fakeSpawn(new FakeAppServer("adopted-thread")) };
-      },
+      restartedRegistry,
+      () => ({ cwd: "/repo", eventStore: new MemoryEventStore(), spawnProcess: fakeSpawn(replacement) }),
       { NODE_ENV: "test", LLV_STRUCTURED_HOSTS: "1" },
     );
-    expect(releasedRows).toEqual([]);
-    expect(restarted).toBeFalse();
-    const replacementOwner = { pid: process.pid, startIdentity: "replacement-viewer" };
-    expect(registry.claimStructuredHost(key, replacementOwner)).toBeNull();
-    const reclaimed = registry.claimStructuredHost(key, replacementOwner, { allowUnhosted: true });
-    expect(reclaimed?.claimEpoch).toBe(5);
+    expect(releasedRows).toHaveLength(1);
+    expect(replacement.requests.some((request) => request.method === "thread/resume")).toBeTrue();
+    expect(restartedRegistry.snapshot().entries["codex:adopted-thread"]).toMatchObject({
+      status: "idle",
+      host: null,
+      claimEpoch: 5,
+      structuredHost: {
+        kind: "codex-app-server",
+        endpoint: "stdio:4242",
+        writerClaimEpoch: 5,
+      },
+    });
+    await releasedRows[0]!.host.release();
   });
 
-  test("failed adoption clears connection-scoped attention and activity", async () => {
+  test("failed restart adoption leaves a loud dead structured host", async () => {
     const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-failed-adoption-"));
-    const registry = new AgentRegistry(path.join(directory, "agent-registry.json"));
+    const registryPath = path.join(directory, "agent-registry.json");
+    const registry = new AgentRegistry(registryPath);
     const key = { engine: "codex" as const, sessionId: "failed-adoption-thread" };
     registry.upsert({
       key,
       artifactPath: "/sessions/failed-adoption-thread.jsonl",
       cwd: "/repo",
       accountId: null,
-      status: "dead",
+      status: "unhosted",
       host: null,
       structuredHost: {
         kind: "codex-app-server",
@@ -1045,20 +1052,29 @@ describe("CodexAppServerHost", () => {
       claimOwner: null,
       pendingAction: null,
     });
+    const restartedRegistry = new AgentRegistry(registryPath);
+    let adoptionAttempted = false;
     const adopted = await adoptCodexRegistryHosts(
-      registry,
-      () => ({
-        cwd: "/repo",
-        eventStore: new MemoryEventStore(),
-        spawnProcess: fakeSpawn(new FakeAppServer("failed-adoption-thread", "different-thread")),
-      }),
+      restartedRegistry,
+      () => {
+        adoptionAttempted = true;
+        return {
+          cwd: "/repo",
+          eventStore: new MemoryEventStore(),
+          spawnProcess: fakeSpawn(new FakeAppServer("failed-adoption-thread", "different-thread")),
+        };
+      },
       { NODE_ENV: "test", LLV_STRUCTURED_HOSTS: "1" },
     );
     expect(adopted).toEqual([]);
-    expect(registry.snapshot().entries["codex:failed-adoption-thread"]).toMatchObject({
+    expect(adoptionAttempted).toBeTrue();
+    expect(restartedRegistry.snapshot().entries["codex:failed-adoption-thread"]).toMatchObject({
       status: "dead",
+      host: null,
       claimOwner: null,
       structuredHost: {
+        kind: "codex-app-server",
+        endpoint: "stdio:released",
         process: null,
         activeTurnRef: null,
         pendingAttention: [],

--- a/src/lib/runtime/registry.ts
+++ b/src/lib/runtime/registry.ts
@@ -247,14 +247,13 @@ export async function adoptCodexRegistryHosts(
   if (!structuredHostsEnabled(env)) return [];
   const rows = Object.values(registry.snapshot().entries).filter((entry) =>
     entry.key.engine === "codex"
-    && entry.status !== "unhosted"
     && entry.structuredHost?.kind === "codex-app-server");
   const adopted: AdoptedCodexHost[] = [];
   for (const entry of rows) {
     const owner = { pid: process.pid, startIdentity: procBackend.processIdentity(process.pid) };
     try {
       await registry.withOperationLock(entry.key, owner, async () => {
-        const claimed = registry.claimStructuredHost(entry.key, owner);
+        const claimed = registry.claimStructuredHost(entry.key, owner, { allowUnhosted: true });
         if (!claimed?.structuredHost) return;
         try {
           const host = await CodexAppServerHost.adopt(entry.key.sessionId, {
@@ -291,21 +290,20 @@ export async function adoptClaudeRegistryHosts(
   if (!structuredHostsEnabled(env)) return [];
   const rows = Object.values(registry.snapshot().entries).filter((entry) =>
     entry.key.engine === "claude"
-    && entry.status !== "unhosted"
     && entry.structuredHost?.kind === "claude-broker");
   const adopted: AdoptedClaudeHost[] = [];
   for (const entry of rows) {
     const owner = { pid: process.pid, startIdentity: procBackend.processIdentity(process.pid) };
     try {
       await registry.withOperationLock(entry.key, owner, async () => {
-        let claimed = registry.claimStructuredHost(entry.key, owner);
+        let claimed = registry.claimStructuredHost(entry.key, owner, { allowUnhosted: true });
         if (!claimed) {
           const current = registry.snapshot().entries[`claude:${entry.key.sessionId}`];
           const orphan = current?.structuredHost?.kind === "claude-broker"
             ? current.structuredHost.process
             : null;
           if (orphan && await terminateVerifiedClaudeOrphan(orphan, current?.claimOwner ?? null)) {
-            claimed = registry.claimStructuredHost(entry.key, owner);
+            claimed = registry.claimStructuredHost(entry.key, owner, { allowUnhosted: true });
           }
         }
         if (!claimed?.structuredHost) return;

--- a/src/lib/runtime/startup.test.ts
+++ b/src/lib/runtime/startup.test.ts
@@ -9,6 +9,7 @@ import { RuntimeJournal } from "@/runtime-host/journal";
 
 import type { RuntimeHostClient } from "./client";
 import { bindStructuredDeliveryQueue } from "./structuredDeliveryController";
+import { createFakeDeliveryLedger, FakeEngineHost } from "./fixtures/fakeEngineHost";
 import { enqueueStructuredMessage } from "./structuredMessageDelivery";
 import { adoptStructuredHostsAtStartup, type StructuredStartupDependencies } from "./startup";
 
@@ -93,6 +94,230 @@ test("server startup delegates managed rows with file credentials and their laun
   });
 });
 
+function runtimeJournalClient(journal: RuntimeJournal): RuntimeHostClient {
+  return {
+    snapshot: async () => journal.snapshot(),
+    append: async (event) => journal.append(event),
+    command: async (command) => journal.executeOperation(command),
+    operationStatus: async (operationId) => journal.operationResult(operationId),
+    effectBatch: async (kinds, afterEventSeq) => journal.effectBatch(100, kinds, afterEventSeq),
+    transitionOperation: async (operationId, status, details) => journal.transitionOperation(operationId, status, details),
+  } as RuntimeHostClient;
+}
+
+function structuredRestartFixture(
+  directory: string,
+  engine: "codex" | "claude",
+  status: "dead" | "unhosted" = "dead",
+  structured = true,
+) {
+  const sessionId = engine === "codex"
+    ? "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"
+    : "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
+  const artifactPath = path.join(directory, `${sessionId}.jsonl`);
+  fs.writeFileSync(artifactPath, "");
+  const registry = new AgentRegistry(path.join(directory, "agent-registry.json"));
+  const conversation = registry.ensureConversation(engine, artifactPath, null);
+  registry.upsert({
+    key: { engine, sessionId },
+    artifactPath,
+    cwd: directory,
+    accountId: null,
+    launchProfile: emptyLaunchProfile({ cwd: directory }),
+    status,
+    host: null,
+    structuredHost: structured ? {
+      kind: engine === "codex" ? "codex-app-server" : "claude-broker",
+      endpoint: "stdio:released",
+      process: null,
+      eventCursor: 4,
+      protocolVersion: "test",
+      writerClaimEpoch: 2,
+      activeTurnRef: null,
+      pendingAttention: [],
+      activeFlags: [],
+    } : null,
+    claimEpoch: 2,
+    claimOwner: null,
+    pendingAction: null,
+  });
+  return { artifactPath, conversation, registry, sessionId };
+}
+
+async function waitFor(predicate: () => boolean): Promise<void> {
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    if (predicate()) return;
+    await Bun.sleep(1);
+  }
+  throw new Error("startup delivery did not settle");
+}
+
+test.each(["codex", "claude"] as const)("failed %s restart adoption projects dead structured ownership and fences legacy delivery", async (engine) => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), `llv-runtime-startup-dead-${engine}-`));
+  const { artifactPath, conversation, registry, sessionId } = structuredRestartFixture(directory, engine);
+  const journal = new RuntimeJournal(path.join(directory, "runtime.sqlite"), { structuredHosts: true });
+  const client = runtimeJournalClient(journal);
+
+  await adoptStructuredHostsAtStartup({
+    registry,
+    client,
+    adopt: async () => [],
+    adoptClaude: async () => [],
+  });
+
+  expect(journal.snapshot().sessions).toMatchObject([{
+    conversationId: conversation.id,
+    sessionKey: { engine, sessionId },
+    hostKind: engine === "codex" ? "codex-app-server" : "claude-broker",
+    host: "dead",
+    artifactPath,
+  }]);
+  let legacyCalls = 0;
+  const delivery = await enqueueStructuredMessage({
+    path: artifactPath,
+    text: "must stay structured",
+    clientMessageId: `failed-${engine}-restart-message`,
+    hasImages: false,
+  }, {
+    enabled: () => true,
+    client: () => client,
+    registry: () => registry,
+  });
+  if (delivery === null) legacyCalls += 1;
+  expect(delivery).toMatchObject({
+    ok: false,
+    structured: true,
+    outcome: "failed",
+    error: "dead-host",
+    status: 409,
+    receipt: { status: "rejected", reason: "dead-host" },
+  });
+  expect(legacyCalls).toBe(0);
+
+  await bindStructuredDeliveryQueue([], { registry, client: null });
+  journal.close();
+  fs.rmSync(directory, { recursive: true, force: true });
+});
+
+test("failed restart adoption replaces a stale hosted projection before delivery", async () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-runtime-startup-stale-hosted-"));
+  const { artifactPath, conversation, registry, sessionId } = structuredRestartFixture(directory, "codex");
+  const journal = new RuntimeJournal(path.join(directory, "runtime.sqlite"), { structuredHosts: true });
+  const client = runtimeJournalClient(journal);
+  journal.append({
+    scope: { type: "session", id: conversation.id },
+    kind: "session-status",
+    payload: {
+      conversationId: conversation.id,
+      sessionKey: { engine: "codex", sessionId },
+      hostKind: "codex-app-server",
+      host: "hosted",
+      turn: "idle",
+      provenance: "structured",
+      artifactPath,
+      capabilities: { steer: true, structuredAttention: true },
+    },
+  });
+
+  await adoptStructuredHostsAtStartup({
+    registry,
+    client,
+    adopt: async () => [],
+    adoptClaude: async () => [],
+  });
+
+  expect(journal.snapshot().sessions).toMatchObject([{
+    conversationId: conversation.id,
+    hostKind: "codex-app-server",
+    host: "dead",
+  }]);
+  const delivery = await enqueueStructuredMessage({
+    path: artifactPath,
+    text: "reject stale hosted delivery",
+    clientMessageId: "failed-stale-restart-message",
+    hasImages: false,
+  }, {
+    enabled: () => true,
+    client: () => client,
+    registry: () => registry,
+  });
+  expect(delivery).toMatchObject({
+    ok: false,
+    structured: true,
+    error: "dead-host",
+    receipt: { status: "rejected", reason: "dead-host" },
+  });
+
+  await bindStructuredDeliveryQueue([], { registry, client: null });
+  journal.close();
+  fs.rmSync(directory, { recursive: true, force: true });
+});
+
+test.each(["codex", "claude"] as const)("successful %s restart adoption publishes hosted ownership and delivers through EngineHost", async (engine) => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), `llv-runtime-startup-hosted-${engine}-`));
+  const { artifactPath, conversation, registry, sessionId } = structuredRestartFixture(directory, engine, "unhosted");
+  const journal = new RuntimeJournal(path.join(directory, "runtime.sqlite"), { structuredHosts: true });
+  const client = runtimeJournalClient(journal);
+  const ledger = createFakeDeliveryLedger();
+  const host = Object.assign(new FakeEngineHost(ledger), { onStateChange: () => () => {} });
+  const key = { engine, sessionId } as const;
+
+  await adoptStructuredHostsAtStartup({
+    registry,
+    client,
+    adopt: async () => engine === "codex" ? [{ key, host: host as never }] : [],
+    adoptClaude: async () => engine === "claude" ? [{ key, host: host as never }] : [],
+  });
+
+  expect(journal.snapshot().sessions).toMatchObject([{
+    conversationId: conversation.id,
+    sessionKey: key,
+    hostKind: engine === "codex" ? "codex-app-server" : "claude-broker",
+    host: "hosted",
+    artifactPath,
+  }]);
+  let legacyCalls = 0;
+  const delivery = await enqueueStructuredMessage({
+    path: artifactPath,
+    text: `deliver through ${engine}`,
+    clientMessageId: `hosted-${engine}-restart-message`,
+    hasImages: false,
+  }, {
+    enabled: () => true,
+    client: () => client,
+    registry: () => registry,
+  });
+  if (delivery === null) legacyCalls += 1;
+  expect(delivery).toMatchObject({ ok: true, structured: true, outcome: "queued" });
+  await waitFor(() => ledger.writes.length === 1);
+  expect(ledger.writes).toEqual([expect.objectContaining({ text: `deliver through ${engine}` })]);
+  expect(legacyCalls).toBe(0);
+
+  await bindStructuredDeliveryQueue([], { registry, client: null });
+  journal.close();
+  fs.rmSync(directory, { recursive: true, force: true });
+});
+
+test("terminal structured row with a cleared ownership marker stays outside startup adoption", async () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-runtime-startup-terminal-"));
+  const { registry } = structuredRestartFixture(directory, "codex", "dead", false);
+  const journal = new RuntimeJournal(path.join(directory, "runtime.sqlite"), { structuredHosts: true });
+  const client = runtimeJournalClient(journal);
+
+  await adoptStructuredHostsAtStartup({
+    registry,
+    client,
+    adopt: async () => [],
+    adoptClaude: async () => [],
+  });
+
+  expect(journal.snapshot().sessions).toEqual([]);
+
+  await bindStructuredDeliveryQueue([], { registry, client: null });
+  journal.close();
+  fs.rmSync(directory, { recursive: true, force: true });
+});
+
 test("fresh-journal startup projects a live tmux registry row for composer fallback", async () => {
   const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-runtime-startup-legacy-"));
   const sourceId = "dddddddd-dddd-4ddd-8ddd-dddddddddddd";
@@ -131,14 +356,7 @@ test("fresh-journal startup projects a live tmux registry row for composer fallb
     pendingAction: null,
   });
   const journal = new RuntimeJournal(path.join(directory, "runtime.sqlite"), { structuredHosts: true });
-  const client = {
-    snapshot: async () => journal.snapshot(),
-    append: async (event: Parameters<RuntimeHostClient["append"]>[0]) => journal.append(event),
-    command: async (command: Parameters<RuntimeHostClient["command"]>[0]) => journal.executeOperation(command),
-    operationStatus: async (operationId: string) => journal.operationResult(operationId),
-    effectBatch: async (kinds?: readonly string[], afterEventSeq?: number) => journal.effectBatch(100, kinds, afterEventSeq),
-    transitionOperation: async (...args: Parameters<RuntimeHostClient["transitionOperation"]>) => journal.transitionOperation(...args),
-  } as RuntimeHostClient;
+  const client = runtimeJournalClient(journal);
 
   await adoptStructuredHostsAtStartup({
     registry,

--- a/src/lib/runtime/structuredDeliveryController.ts
+++ b/src/lib/runtime/structuredDeliveryController.ts
@@ -160,21 +160,23 @@ export async function bindStructuredDeliveryQueue(
       scope: { type: "session", id: conversationId },
       kind: "session-status",
       producer: {
-        kind: "structured-delivery-controller",
+        kind: entry?.structuredHost?.kind ?? "structured-delivery-controller",
         eventKey: `projection:${projectionEpoch}:${projectionRevision}`,
       },
       payload: {
         conversationId,
         sessionKey: key,
-        hostKind: legacy ? "tmux-legacy" : "unhosted",
-        host,
+        hostKind: entry?.structuredHost?.kind ?? (legacy ? "tmux-legacy" : "unhosted"),
+        host: entry?.structuredHost && entry.status === "dead" ? "dead" : host,
         turn,
-        provenance: "derived",
+        provenance: entry?.structuredHost ? "structured" : "derived",
         accountId: entry?.accountId ?? generation.accountId,
         parentConversationId: generation.launchProfile.parentConversationId,
         cwd: entry?.cwd ?? generation.launchProfile.cwd,
         artifactPath: generation.path,
-        capabilities: { steer: false, structuredAttention: false },
+        capabilities: entry?.structuredHost
+          ? { steer: entry.structuredHost.kind === "codex-app-server", structuredAttention: true }
+          : { steer: false, structuredAttention: false },
         activeTurnId: null,
       },
     });
@@ -276,7 +278,8 @@ export async function bindStructuredDeliveryQueue(
     if (!generation) continue;
     const id = sessionKeyId({ engine: conversation.engine, sessionId: generation.id });
     if (registrations.has(id)) continue;
-    if (startupSnapshot.entries[id]?.host?.kind !== "tmux") continue;
+    const entry = startupSnapshot.entries[id];
+    if (!entry?.structuredHost && entry?.host?.kind !== "tmux") continue;
     await publishCurrentFallback(conversation.id);
   }
   state.activeQueue = queue;


### PR DESCRIPTION
Closes #246

## Summary
- re-enable startup claims for durable Codex and Claude structured rows whose previous host release left them unhosted
- preserve structured ownership with a loud dead status when engine resume rejects the artifact
- cover fresh-registry restart fixtures for both engines, including successful structured resume and failed Codex resume

## Production evidence
- a read-only registry query found 26 pane-less idle/live structured entries
- 23 entries still carried writer claims from a dead prior Viewer PID, matching the restart skip and later demotion shape

## Coordination
- composes with [PR #242](https://github.com/Latand/live-log-viewer-next/pull/242), whose terminal-operation path clears structured ownership before startup adoption
- source changes stay inside the adoption filters; adjacent spawn recovery remains untouched

## Verification
- `bunx tsc --noEmit`
- `bun test` — 2,721 passed across 290 files
- focused Codex and Claude host suites — 58 passed