### PR TITLE
fix(runtime): stop structured delivery CPU burn

### DIFF
--- a/src/lib/runtime/client.ts
+++ b/src/lib/runtime/client.ts
@@ -21,6 +21,7 @@ export interface RuntimeHostClient {
   command(command: RuntimeOperationCommand): Promise<RuntimeOperationResult>;
   operationStatus(operationId: string): Promise<RuntimeOperationResult | null>;
   retryOperation(operationId: string): Promise<RuntimeOperationResult>;
+  producerCursor(producerKind: string, eventKeyPrefix: string): Promise<number>;
   effectBatch(kinds?: readonly string[], afterEventSeq?: number): Promise<RuntimePendingEffect[]>;
   transitionOperation(
     operationId: string,
@@ -46,6 +47,7 @@ export class UnixRuntimeHostClient implements RuntimeHostClient {
   command(command: RuntimeOperationCommand): Promise<RuntimeOperationResult> { return this.call("command", { command }) as Promise<RuntimeOperationResult>; }
   operationStatus(operationId: string): Promise<RuntimeOperationResult | null> { return this.call("operation-status", { operationId }) as Promise<RuntimeOperationResult | null>; }
   retryOperation(operationId: string): Promise<RuntimeOperationResult> { return this.call("operation-retry", { operationId }) as Promise<RuntimeOperationResult>; }
+  producerCursor(producerKind: string, eventKeyPrefix: string): Promise<number> { return this.call("producer-cursor", { producerKind, eventKeyPrefix }) as Promise<number>; }
   effectBatch(kinds?: readonly string[], afterEventSeq = 0): Promise<RuntimePendingEffect[]> {
     const params = {
       ...(kinds ? { kinds: [...kinds] } : {}),

--- a/src/lib/runtime/contracts.ts
+++ b/src/lib/runtime/contracts.ts
@@ -354,7 +354,7 @@ export interface RuntimeReplay {
 
 export interface RuntimeSocketRequest {
   id: string;
-  method: "snapshot" | "events" | "wait" | "append" | "operation" | "command" | "operation-status" | "operation-retry" | "effect-batch" | "operation-transition" | "viewer-deployment-request" | "viewer-deployment-read";
+  method: "snapshot" | "events" | "wait" | "append" | "operation" | "command" | "operation-status" | "operation-retry" | "effect-batch" | "operation-transition" | "producer-cursor" | "viewer-deployment-request" | "viewer-deployment-read";
   params?: Record<string, unknown>;
 }
 

--- a/src/lib/runtime/structuredDelivery.integration.test.ts
+++ b/src/lib/runtime/structuredDelivery.integration.test.ts
@@ -11,7 +11,7 @@ import { RegisteredSuccessorProvider } from "@/lib/accounts/migration/provider";
 import { RuntimeJournal } from "@/runtime-host/journal";
 
 import type { RuntimeHostClient } from "./client";
-import type { EngineHost, HostState, QueueEntry } from "./engineHost";
+import type { EngineHost, HostState, QueueEntry, RuntimeEvent } from "./engineHost";
 import { FakeEngineHost, createFakeDeliveryLedger } from "./fixtures/fakeEngineHost";
 import { bindStructuredDeliveryQueue, publishStructuredDeliveryHost } from "./structuredDeliveryController";
 import { StructuredDeliveryQueue, type StructuredDeliveryQueuePort } from "./structuredDeliveryQueue";
@@ -35,12 +35,86 @@ function observableFakeHost(host: FakeEngineHost): FakeEngineHost & { onStateCha
   return Object.assign(host, { onStateChange: () => () => {} });
 }
 
+function burstyObservableHost(): {
+  host: EngineHost & { onStateChange(listener: (state: HostState) => void): () => void };
+  emit(event: RuntimeEvent): void;
+  attachedAfter(): number | null;
+} {
+  let state: HostState = {
+    status: "active",
+    sessionKey: "burst-session",
+    endpoint: "fake:burst-host",
+    pid: 1,
+    processStartIdentity: "fake:1",
+    eventCursor: 0,
+    protocolVersion: "fake-v1",
+    activeTurnRef: "turn:burst",
+    pendingAttention: [],
+    activeFlags: [],
+    account: null,
+  };
+  const listeners = new Set<(state: HostState) => void>();
+  const queued: RuntimeEvent[] = [];
+  const waiters: Array<(result: IteratorResult<RuntimeEvent>) => void> = [];
+  let attachedAfter: number | null = null;
+  let closed = false;
+  const iterator: AsyncIterator<RuntimeEvent> = {
+    next: async () => {
+      const event = queued.shift();
+      if (event) return { value: event, done: false };
+      if (closed) return { value: undefined, done: true };
+      return await new Promise<IteratorResult<RuntimeEvent>>((resolve) => waiters.push(resolve));
+    },
+    return: async () => {
+      closed = true;
+      for (const resolve of waiters.splice(0)) resolve({ value: undefined, done: true });
+      return { value: undefined, done: true };
+    },
+  };
+  const host = {
+    attach: (afterSeq: number) => {
+      attachedAfter = afterSeq;
+      return { [Symbol.asyncIterator]: () => iterator };
+    },
+    send: async (entry: QueueEntry) => ({ outcome: "turn-started" as const, turnId: `turn:${entry.id}` }),
+    interrupt: async () => {},
+    answer: async () => {},
+    health: async () => ({ ...state }),
+    release: async () => {},
+    onStateChange(listener: (next: HostState) => void) {
+      listeners.add(listener);
+      listener({ ...state });
+      return () => listeners.delete(listener);
+    },
+  } satisfies EngineHost & { onStateChange(listener: (state: HostState) => void): () => void };
+  return {
+    host,
+    emit(event) {
+      state = { ...state, eventCursor: event.seq };
+      for (const listener of listeners) listener({ ...state });
+      const resolve = waiters.shift();
+      if (resolve) resolve({ value: event, done: false });
+      else queued.push(event);
+    },
+    attachedAfter: () => attachedAfter,
+  };
+}
+
+async function waitForCondition(assertion: () => boolean): Promise<void> {
+  for (let attempt = 0; attempt < 200; attempt += 1) {
+    if (assertion()) return;
+    await Bun.sleep(5);
+  }
+  throw new Error("structured delivery condition did not settle");
+}
+
 function runtimeJournalClient(journal: RuntimeJournal): RuntimeHostClient {
   return {
     snapshot: async () => journal.snapshot(),
     append: async (event) => journal.append(event),
     command: async (command) => journal.executeOperation(command),
     operationStatus: async (operationId) => journal.operationResult(operationId),
+    producerCursor: async (producerKind, eventKeyPrefix) => journal.producerCursor(producerKind, eventKeyPrefix),
     effectBatch: async (kinds, afterEventSeq) => journal.effectBatch(100, kinds, afterEventSeq),
     transitionOperation: async (operationId, status, details) => journal.transitionOperation(operationId, status, details),
   } as RuntimeHostClient;
@@ -58,6 +132,80 @@ function cleanupOnlyProvider(): RegisteredSuccessorProvider {
     now: () => "2026-07-13T12:01:00.000Z",
   });
 }
+
+test("an engine event burst preserves every projection without polling the delivery queue per event", async () => {
+  const directory = path.join(sandbox, "controller-event-burst");
+  const registry = new AgentRegistry(path.join(directory, "agent-registry.json"));
+  const artifactPath = path.join(directory, "burst-session.jsonl");
+  const profile = emptyLaunchProfile({ cwd: directory });
+  registry.reconcileConversations([{
+    engine: "codex",
+    path: artifactPath,
+    accountId: "burst-account",
+    launchProfile: profile,
+    turn: { state: "busy", source: "assistant", terminalAt: null },
+    observedAt: "2026-07-14T12:00:00.000Z",
+  }]);
+  registry.upsert({
+    key: { engine: "codex", sessionId: "burst-session" },
+    artifactPath,
+    cwd: directory,
+    accountId: "burst-account",
+    launchProfile: profile,
+    status: "live",
+    host: null,
+    structuredHost: {
+      kind: "codex-app-server",
+      endpoint: "fake:burst-host",
+      process: null,
+      eventCursor: 0,
+      protocolVersion: "fake-v1",
+      writerClaimEpoch: 0,
+      activeTurnRef: "turn:burst",
+      pendingAttention: [],
+      activeFlags: [],
+    },
+    claimEpoch: 0,
+    claimOwner: null,
+    pendingAction: null,
+  });
+  let effectBatchCalls = 0;
+  let deltaProjections = 0;
+  let sessionStatusProjections = 0;
+  const client = {
+    append: async (event: { kind: string }) => {
+      if (event.kind === "delta") deltaProjections += 1;
+      if (event.kind === "session-status") sessionStatusProjections += 1;
+    },
+    producerCursor: async () => 17,
+    effectBatch: async () => { effectBatchCalls += 1; return []; },
+    transitionOperation: async () => { throw new Error("unexpected operation transition"); },
+  } as unknown as RuntimeHostClient;
+  const burst = burstyObservableHost();
+
+  try {
+    await bindStructuredDeliveryQueue([{
+      key: { engine: "codex", sessionId: "burst-session" },
+      host: burst.host,
+    }], { registry, client });
+    await Bun.sleep(50);
+    expect(burst.attachedAfter()).toBe(17);
+    const baselineEffects = effectBatchCalls;
+    const baselineStatuses = sessionStatusProjections;
+
+    for (let index = 18; index <= 57; index += 1) {
+      burst.emit({ kind: "delta", turnId: "turn:burst", text: `delta ${index}`, seq: index });
+    }
+
+    await waitForCondition(() => deltaProjections === 40);
+    await Bun.sleep(50);
+    expect(deltaProjections).toBe(40);
+    expect(sessionStatusProjections - baselineStatuses).toBeLessThanOrEqual(1);
+    expect(effectBatchCalls - baselineEffects).toBeLessThanOrEqual(1);
+  } finally {
+    await bindStructuredDeliveryQueue([], { registry, client: null });
+  }
+});
 
 test("a delivering entry resumes after restart through the host ledger without a second engine write", async () => {
   const filename = path.join(sandbox, "events.sqlite");

--- a/src/lib/runtime/structuredDelivery.integration.test.ts
+++ b/src/lib/runtime/structuredDelivery.integration.test.ts
@@ -207,6 +207,169 @@ test("an engine event burst preserves every projection without polling the deliv
   }
 });
 
+test("a failed route kick retries queued controls and messages without a host-state notification", async () => {
+  const directory = path.join(sandbox, "controller-route-kick-retry");
+  const registry = new AgentRegistry(path.join(directory, "agent-registry.json"));
+  const sessionId = "c012d11e-1854-4157-aede-75eae7bde18c";
+  const artifactPath = path.join(directory, `${sessionId}.jsonl`);
+  const profile = emptyLaunchProfile({ cwd: directory });
+  registry.reconcileConversations([{
+    engine: "codex",
+    path: artifactPath,
+    accountId: "route-kick-account",
+    launchProfile: profile,
+    turn: { state: "busy", source: "assistant", terminalAt: null },
+    observedAt: "2026-07-14T12:00:00.000Z",
+  }]);
+  const conversationId = Object.keys(registry.snapshot().conversations)[0]!;
+  registry.upsert({
+    key: { engine: "codex", sessionId },
+    artifactPath,
+    cwd: directory,
+    accountId: "route-kick-account",
+    launchProfile: profile,
+    status: "live",
+    host: null,
+    structuredHost: {
+      kind: "codex-app-server",
+      endpoint: "fake:route-kick-host",
+      process: null,
+      eventCursor: 0,
+      protocolVersion: "fake-v1",
+      writerClaimEpoch: 0,
+      activeTurnRef: "turn:route-kick",
+      pendingAttention: ["attention-route-kick"],
+      activeFlags: [],
+    },
+    claimEpoch: 0,
+    claimOwner: null,
+    pendingAction: null,
+  });
+  const journal = new RuntimeJournal(path.join(directory, "events.sqlite"), { structuredHosts: true });
+  const baseClient = runtimeJournalClient(journal);
+  const transitions: Array<[string, string]> = [];
+  let effectBatchCalls = 0;
+  let failNextEffectBatch = false;
+  const client = {
+    ...baseClient,
+    effectBatch: async (...args: Parameters<RuntimeHostClient["effectBatch"]>) => {
+      effectBatchCalls += 1;
+      if (failNextEffectBatch) {
+        failNextEffectBatch = false;
+        throw new Error("transient route-kick effect-batch failure");
+      }
+      return await baseClient.effectBatch(...args);
+    },
+    transitionOperation: async (...args: Parameters<RuntimeHostClient["transitionOperation"]>) => {
+      transitions.push([args[0], args[1]]);
+      return await baseClient.transitionOperation(...args);
+    },
+  } satisfies RuntimeHostClient;
+  const hostCalls: string[] = [];
+  let hostState: HostState = {
+    status: "active",
+    sessionKey: "route-kick-session",
+    endpoint: "fake:route-kick-host",
+    pid: 1,
+    processStartIdentity: "fake:1",
+    eventCursor: 0,
+    protocolVersion: "fake-v1",
+    activeTurnRef: "turn:route-kick",
+    pendingAttention: ["attention-route-kick"],
+    activeFlags: [],
+    account: null,
+  };
+  const host = {
+    async *attach(): AsyncIterableIterator<RuntimeEvent> {},
+    send: async (entry: QueueEntry) => {
+      hostCalls.push(`send:${entry.id}`);
+      return { outcome: "turn-started" as const, turnId: `turn:${entry.id}` };
+    },
+    answer: async (attentionId: string) => { hostCalls.push(`answer:${attentionId}`); },
+    interrupt: async (turnId: string) => {
+      hostCalls.push(`interrupt:${turnId}`);
+      hostState = { ...hostState, status: "idle", activeTurnRef: null };
+    },
+    health: async () => ({ ...hostState }),
+    release: async () => {},
+    onStateChange(listener: (state: HostState) => void) {
+      listener({ ...hostState });
+      return () => {};
+    },
+  } satisfies EngineHost & { onStateChange(listener: (state: HostState) => void): () => void };
+
+  try {
+    await bindStructuredDeliveryQueue([{
+      key: { engine: "codex", sessionId },
+      host,
+    }], { registry, client });
+    journal.append({
+      scope: { type: "session", id: conversationId },
+      kind: "attention",
+      payload: {
+        id: "attention-route-kick",
+        conversationId,
+        kind: "question",
+        state: "open",
+        unowned: false,
+        createdAt: "2026-07-14T12:00:00.000Z",
+        request: { question: { prompt: "Proceed?" } },
+        turnId: "turn:route-kick",
+      },
+    });
+    journal.executeOperation({
+      kind: "send",
+      operationId: "operation-route-send",
+      idempotencyKey: "route-send",
+      conversationId,
+      text: "continue after controls",
+      policy: "queue",
+    });
+    journal.executeOperation({
+      kind: "answer",
+      operationId: "operation-route-answer",
+      idempotencyKey: "route-answer",
+      conversationId,
+      attentionId: "attention-route-kick",
+      resolution: { answer: "yes" },
+    });
+    journal.executeOperation({
+      kind: "interrupt",
+      operationId: "operation-route-interrupt",
+      idempotencyKey: "route-interrupt",
+      conversationId,
+      turnId: "turn:route-kick",
+    });
+    const baselineEffectBatchCalls = effectBatchCalls;
+    failNextEffectBatch = true;
+
+    await kickStructuredDeliveryQueue();
+    expect(effectBatchCalls - baselineEffectBatchCalls).toBe(1);
+    await waitForCondition(() => journal.operationResult("operation-route-send")?.receipt.status === "delivered");
+
+    expect(journal.operationResult("operation-route-answer")?.receipt.status).toBe("answered");
+    expect(journal.operationResult("operation-route-interrupt")?.receipt.status).toBe("interrupted");
+    expect(journal.operationResult("operation-route-send")?.receipt.status).toBe("delivered");
+    expect(effectBatchCalls - baselineEffectBatchCalls).toBe(2);
+    expect(hostCalls).toEqual([
+      "answer:attention-route-kick",
+      "interrupt:turn:route-kick",
+      "send:operation-route-send",
+    ]);
+    expect(transitions).toEqual([
+      ["operation-route-answer", "delivering"],
+      ["operation-route-answer", "answered"],
+      ["operation-route-interrupt", "delivering"],
+      ["operation-route-interrupt", "interrupted"],
+      ["operation-route-send", "delivering"],
+      ["operation-route-send", "delivered"],
+    ]);
+  } finally {
+    await bindStructuredDeliveryQueue([], { registry, client: null });
+    journal.close();
+  }
+});
+
 test("a delivering entry resumes after restart through the host ledger without a second engine write", async () => {
   const filename = path.join(sandbox, "events.sqlite");
   const ledger = createFakeDeliveryLedger();

--- a/src/lib/runtime/structuredDeliveryController.ts
+++ b/src/lib/runtime/structuredDeliveryController.ts
@@ -15,6 +15,9 @@ export interface StructuredDeliveryHost {
   host: ObservableEngineHost;
 }
 
+const DELIVERY_DRAIN_COALESCE_MS = 25;
+const DELIVERY_DRAIN_MAX_BACKOFF_MS = 1_000;
+
 /* Next standalone bundles instrumentation and route handlers separately, so a
    module-level `let` written by startup adoption is invisible to routes. The
    controller registration must live on `globalThis`, like every other
@@ -41,6 +44,14 @@ function entryForHost(registry: AgentRegistry, adopted: StructuredDeliveryHost):
 
 function conversationIdForEntry(registry: AgentRegistry, entry: AgentRegistryEntry): string | null {
   return registry.conversationForPath(entry.artifactPath)?.id ?? null;
+}
+
+function deliveryStateKey(state: HostState): string {
+  return JSON.stringify([state.status, state.activeTurnRef]);
+}
+
+function hostProjectionKey(state: HostState): string {
+  return JSON.stringify([state.status, state.activeTurnRef, state.pendingAttention]);
 }
 
 function hostResolver(
@@ -117,6 +128,29 @@ export async function bindStructuredDeliveryQueue(
   const registry = dependencies.registry ?? agentRegistry();
   const hosts = new Map<string, EngineHost>();
   const queue = new StructuredDeliveryQueue(runtimeClientDeliveryPort(client), hostResolver(registry, hosts));
+  let drainTimer: ReturnType<typeof setTimeout> | null = null;
+  let drainBackoffMs = DELIVERY_DRAIN_COALESCE_MS;
+  let stopped = false;
+  const scheduleDrain = (delayMs = DELIVERY_DRAIN_COALESCE_MS) => {
+    if (stopped || drainTimer) return;
+    drainTimer = setTimeout(() => {
+      drainTimer = null;
+      if (stopped) return;
+      void queue.drain().then(
+        () => { drainBackoffMs = DELIVERY_DRAIN_COALESCE_MS; },
+        () => {
+          console.error("[structured delivery] scheduled queue drain failed");
+          const retryMs = drainBackoffMs;
+          drainBackoffMs = Math.min(drainBackoffMs * 2, DELIVERY_DRAIN_MAX_BACKOFF_MS);
+          scheduleDrain(retryMs);
+        },
+      );
+    }, delayMs);
+    drainTimer.unref?.();
+  };
+  const requestDrain = () => {
+    if (state.activeQueue === queue) scheduleDrain();
+  };
   const registrations = new Map<string, { key: SessionKey; host: ObservableEngineHost; unsubscribe: () => void; stopEvents: () => Promise<void> }>();
   const publishChains = new Map<string, Promise<void>>();
   const projectionEpoch = crypto.randomUUID();
@@ -204,23 +238,49 @@ export async function bindStructuredDeliveryQueue(
     const current = registrations.get(key);
     if (current?.host === item.host) return async () => {};
     if (current) await unregisterHost(key, current.host);
-    const state = await item.host.health();
-    await publishHostState(client, registry, item, state);
+    const initialState = await item.host.health();
+    await publishHostState(client, registry, item, initialState);
     hosts.set(key, item.host);
+    requestDrain();
     const observable = item.host as ObservableEngineHost;
+    let deliveryState = deliveryStateKey(initialState);
+    let projectedState = hostProjectionKey(initialState);
     const unsubscribe = observable.onStateChange((state) => {
+      const nextDeliveryState = deliveryStateKey(state);
+      const nextProjectedState = hostProjectionKey(state);
       const previous = publishChains.get(key) ?? Promise.resolve();
       const next = previous
-        .then(() => publishHostState(client, registry, item, state))
-        .then(() => queue.drain())
+        .then(async () => {
+          if (nextProjectedState !== projectedState) {
+            await publishHostState(client, registry, item, state);
+            projectedState = nextProjectedState;
+          }
+          if (nextDeliveryState === deliveryState) return;
+          deliveryState = nextDeliveryState;
+          requestDrain();
+        })
         .catch(() => { console.error("[structured delivery] host state sync failed"); });
       publishChains.set(key, next);
     });
     const entry = entryForHost(registry, item);
     const conversationId = entry ? conversationIdForEntry(registry, entry) : null;
-    const events = item.host.attach(0)[Symbol.asyncIterator]();
+    let acknowledgedEventCursor = 0;
+    if (conversationId) {
+      /* Runtime-host producer receipts advance after the projected event commits.
+         Registry cursors track the engine ledger and can lead this acknowledgement
+         during a crash, so they cannot safely skip replay here. */
+      try {
+        acknowledgedEventCursor = await client.producerCursor(
+          item.key.engine === "codex" ? "codex-app-server" : "claude-broker",
+          `engine-host:${key}:`,
+        );
+      } catch {
+        console.error("[structured delivery] producer cursor unavailable; replaying host events");
+      }
+    }
+    const events = item.host.attach(acknowledgedEventCursor)[Symbol.asyncIterator]();
     let eventsStopped = false;
-    const eventPump = (async () => {
+    void (async () => {
       if (!conversationId) return;
       while (!eventsStopped) {
         const next = await events.next();
@@ -235,9 +295,6 @@ export async function bindStructuredDeliveryQueue(
             await new Promise<void>((resolve) => setTimeout(resolve, 100));
           }
         }
-        if (!eventsStopped) await queue.drain().catch(() => {
-          console.error("[structured delivery] engine event drain failed");
-        });
       }
     })().catch(() => {
       if (!eventsStopped) console.error("[structured delivery] engine event sync failed");
@@ -284,6 +341,9 @@ export async function bindStructuredDeliveryQueue(
     console.error("[structured delivery] queue drain failed");
   }));
   state.stopActive = () => {
+    stopped = true;
+    if (drainTimer) clearTimeout(drainTimer);
+    drainTimer = null;
     for (const registration of registrations.values()) {
       registration.unsubscribe();
       void registration.stopEvents();

--- a/src/lib/runtime/structuredDeliveryController.ts
+++ b/src/lib/runtime/structuredDeliveryController.ts
@@ -131,22 +131,34 @@ export async function bindStructuredDeliveryQueue(
   let drainTimer: ReturnType<typeof setTimeout> | null = null;
   let drainBackoffMs = DELIVERY_DRAIN_COALESCE_MS;
   let stopped = false;
-  const scheduleDrain = (delayMs = DELIVERY_DRAIN_COALESCE_MS) => {
-    if (stopped || drainTimer) return;
+  const scheduleDrain = (delayMs = DELIVERY_DRAIN_COALESCE_MS): boolean => {
+    if (stopped || drainTimer) return false;
     drainTimer = setTimeout(() => {
       drainTimer = null;
       if (stopped) return;
-      void queue.drain().then(
-        () => { drainBackoffMs = DELIVERY_DRAIN_COALESCE_MS; },
-        () => {
-          console.error("[structured delivery] scheduled queue drain failed");
-          const retryMs = drainBackoffMs;
-          drainBackoffMs = Math.min(drainBackoffMs * 2, DELIVERY_DRAIN_MAX_BACKOFF_MS);
-          scheduleDrain(retryMs);
-        },
-      );
+      void drainWithRetry();
     }, delayMs);
     drainTimer.unref?.();
+    return true;
+  };
+  const drainWithRetry = async (): Promise<void> => {
+    try {
+      await queue.drain();
+      drainBackoffMs = DELIVERY_DRAIN_COALESCE_MS;
+    } catch (error) {
+      if (stopped) return;
+      const retryMs = drainBackoffMs;
+      const retryScheduled = scheduleDrain(retryMs);
+      if (retryScheduled) {
+        drainBackoffMs = Math.min(retryMs * 2, DELIVERY_DRAIN_MAX_BACKOFF_MS);
+      }
+      console.error(
+        retryScheduled
+          ? "[structured delivery] queue drain failed; retry scheduled"
+          : "[structured delivery] queue drain failed; retry already pending",
+        error,
+      );
+    }
   };
   const requestDrain = () => {
     if (state.activeQueue === queue) scheduleDrain();
@@ -337,9 +349,12 @@ export async function bindStructuredDeliveryQueue(
     await publishCurrentFallback(conversation.id);
   }
   state.activeQueue = queue;
-  setStructuredDeliveryKick(() => queue.drain().catch(() => {
-    console.error("[structured delivery] queue drain failed");
-  }));
+  setStructuredDeliveryKick(() => {
+    if (stopped) return;
+    if (drainTimer) clearTimeout(drainTimer);
+    drainTimer = null;
+    return drainWithRetry();
+  });
   state.stopActive = () => {
     stopped = true;
     if (drainTimer) clearTimeout(drainTimer);

--- a/src/lib/runtime/structuredSpawn.integration.test.ts
+++ b/src/lib/runtime/structuredSpawn.integration.test.ts
@@ -102,6 +102,7 @@ function runtimeClient(journal: RuntimeJournal): RuntimeHostClient {
     command: async (command) => journal.executeOperation(command),
     operationStatus: async (operationId) => journal.operationResult(operationId),
     retryOperation: async (operationId) => journal.retryOperation(operationId),
+    producerCursor: async (producerKind, eventKeyPrefix) => journal.producerCursor(producerKind, eventKeyPrefix),
     effectBatch: async (kinds, afterEventSeq) => journal.effectBatch(100, kinds, afterEventSeq),
     transitionOperation: async (operationId, status, details) => journal.transitionOperation(operationId, status, details),
   } as RuntimeHostClient;

--- a/src/runtime-host/host.ts
+++ b/src/runtime-host/host.ts
@@ -139,6 +139,14 @@ export class RuntimeHost {
           throw new Error("runtime effect cursor is invalid");
         }
         result = this.journal.effectBatch(100, kinds as string[] | undefined, afterEventSeq);
+      } else if (request.method === "producer-cursor") {
+        const producerKind = request.params?.producerKind;
+        const eventKeyPrefix = request.params?.eventKeyPrefix;
+        if (typeof producerKind !== "string" || !producerKind || producerKind.length > 128
+          || typeof eventKeyPrefix !== "string" || !eventKeyPrefix || eventKeyPrefix.length > 512) {
+          throw new Error("runtime producer cursor is invalid");
+        }
+        result = this.journal.producerCursor(producerKind, eventKeyPrefix);
       } else if (request.method === "operation-transition") {
         if (!this.structuredHosts) throw new Error("structured hosts are disabled");
         const status = request.params?.status;

--- a/src/runtime-host/journal.test.ts
+++ b/src/runtime-host/journal.test.ts
@@ -56,6 +56,24 @@ test("producer dedupe keys are isolated by producer identity", () => {
   journal.close();
 });
 
+test("producer cursor reports the highest durably acknowledged engine event", () => {
+  const dir = sandbox("producer-cursor");
+  const journal = new RuntimeJournal(path.join(dir, "events.sqlite"), { maxEvents: 1, now: () => 100 });
+  for (const sequence of [1, 2, 3]) {
+    journal.append({
+      scope: runtimeScope("session", "one"),
+      kind: "delta",
+      payload: { conversationId: "one", turnId: "turn-one", text: `delta ${sequence}` },
+      producer: { kind: "codex-app-server", eventKey: `engine-host:codex:thread-one:${sequence}` },
+    });
+  }
+  journal.compact(1);
+
+  expect(journal.producerCursor("codex-app-server", "engine-host:codex:thread-one:")).toBe(3);
+  expect(journal.producerCursor("claude-broker", "engine-host:claude:thread-one:")).toBe(0);
+  journal.close();
+});
+
 test("snapshot exposes the canonical projected runtime model", () => {
   const dir = sandbox("canonical-snapshot");
   const journal = new RuntimeJournal(path.join(dir, "events.sqlite"), { maxEvents: 100, now: () => 100 });
@@ -899,6 +917,13 @@ test("structured queue controls cross the local runtime socket", async () => {
   const server = serveRuntimeHost(socketPath, new RuntimeHost(journal, undefined, undefined, true));
   await new Promise<void>((resolve) => server.once("listening", resolve));
   const client = new UnixRuntimeHostClient(socketPath);
+  await client.append({
+    scope: runtimeScope("session", "one"),
+    kind: "limits",
+    payload: { conversationId: "one", snapshot: {} },
+    producer: { kind: "codex-app-server", eventKey: "engine-host:codex:thread-one:7" },
+  });
+  expect(await client.producerCursor("codex-app-server", "engine-host:codex:thread-one:")).toBe(7);
   const operation = await client.command({
     kind: "send",
     conversationId: "one",

--- a/src/runtime-host/journal.ts
+++ b/src/runtime-host/journal.ts
@@ -699,6 +699,20 @@ export class RuntimeJournal {
     });
   }
 
+  producerCursor(producerKind: string, eventKeyPrefix: string): number {
+    if (!producerKind || !eventKeyPrefix) throw new Error("runtime producer cursor is invalid");
+    const rows = this.db.query<{ producer_key: string }, [string, string, string]>(
+      "SELECT producer_key FROM producer_receipts WHERE producer_kind = ? AND producer_key >= ? AND producer_key < ?",
+    ).all(producerKind, eventKeyPrefix, `${eventKeyPrefix}\uffff`);
+    let cursor = 0;
+    for (const row of rows) {
+      if (!row.producer_key.startsWith(eventKeyPrefix)) continue;
+      const sequence = Number(row.producer_key.slice(eventKeyPrefix.length));
+      if (Number.isSafeInteger(sequence) && sequence > cursor) cursor = sequence;
+    }
+    return cursor;
+  }
+
   effectBatch(limit = 100, kinds?: readonly string[], afterEventSeq = 0): Array<RuntimeEffect & { eventSeq: number }> {
     if (kinds?.length === 0) return [];
     if (!Number.isSafeInteger(afterEventSeq) || afterEventSeq < 0) throw new Error("runtime effect cursor is invalid");


### PR DESCRIPTION
## Summary

- coalesce delivery drains around delivery-readiness transitions with bounded retry backoff
- deduplicate unchanged host-state projections while preserving canonical engine events
- resume adopted host streams from runtime-journal producer acknowledgements that survive compaction
- run route kicks immediately and send transient failures through the shared bounded retry scheduler

## Profile evidence

Reproduced with a copied 474-entry registry containing 27 adoptable structured hosts, an isolated runtime socket and journal, LLV_STRUCTURED_HOSTS=1, LLV_RUNTIME_EVENTS=1, and the account controller disabled.

Before:

- Viewer main CPU: 20.0% over 10 seconds
- context switches: 622.3/s
- first root request during replay: 12.045s
- Bun ScriptProfiler: drainPass appeared in 50/60 samples; runtime-host socket call appeared in 31/60; doConnect led leaf samples at 17/60
- regression harness: 40 engine deltas caused 41 effect-batch calls and 40 redundant session-status publications

After:

- settled Viewer main CPU: 0.1% over 10 seconds
- context switches: 8.7/s
- root p95 across 20 requests: 6.1ms; maximum 6.4ms
- settled 10-second inspector sample: zero CPU samples
- regression harness: all 40 delta projections retained, at most one drain and status coalescing pass, and attach resumed at durable producer cursor 17

The copied live state changed during capture, so cold adoption timing included concurrent engine-child startup. The settled measurement and deterministic burst guard isolate the Viewer control-plane change.

## Review round 2

Commit [b1da4af](https://github.com/Latand/live-log-viewer-next/commit/b1da4af) closes the route-kick liveness gap:

- a route kick starts its drain immediately and supersedes any pending timer
- one transient effect-batch failure arms the shared retry with 25ms exponential backoff capped at 1 second
- the regression emits no later host-state notification and observes exactly two post-admission effect-batch reads
- answer, interrupt, and send receipts reach answered, interrupted, and delivered in the existing control-first order
- shutdown cancels the timer and prevents rescheduling after controller stop

## Data safety

The resume cursor comes from runtime-host producer receipts committed with each projected event. Registry host cursors can lead the runtime journal during a crash window, so the controller uses full replay whenever producer-cursor lookup is unavailable.

## Verification

- bunx tsc --noEmit
- bun test: 2724 pass, 0 fail, 14383 expectations across 290 files
- focused runtime and startup suite: 35 pass
- touched production, delivery, and journal ESLint checks clean
- clean full-diff review: no findings
- git diff --check

Closes #245