### PR TITLE
Fix structured message delivery correctness

### DIFF
--- a/src/components/TmuxComposer.dom.test.tsx
+++ b/src/components/TmuxComposer.dom.test.tsx
@@ -166,6 +166,8 @@ test("editing and resending a rejected receipt uses a fresh delivery key", async
 
   expect(sentKeys).toHaveLength(2);
   expect(sentKeys[1]).not.toBe(sentKeys[0]);
+  expect(host.textContent).not.toContain("Queued for durable delivery");
+  expect(host.querySelector('[data-optimistic-message="true"]')?.textContent).toContain("try this again");
   flushSync(() => root.unmount());
 });
 

--- a/src/components/TmuxComposer.dom.test.tsx
+++ b/src/components/TmuxComposer.dom.test.tsx
@@ -3,6 +3,7 @@ import { Window } from "happy-dom";
 import { flushSync } from "react-dom";
 import { createRoot } from "react-dom/client";
 
+import { setLocale, translate } from "@/lib/i18n";
 import type { FileEntry } from "@/lib/types";
 
 import { appendComposerDraft, RuntimeComposerReceipts, TmuxComposer } from "./TmuxComposer";
@@ -33,10 +34,63 @@ Object.assign(globalThis, {
 const realFetch = globalThis.fetch;
 
 afterEach(() => {
+  setLocale("en");
   globalThis.fetch = realFetch;
   document.body.replaceChildren();
   localStorage.clear();
   sessionStorage.clear();
+});
+
+function renderInterruptAutoRetry(locale: "en" | "uk") {
+  setLocale(locale);
+  const host = document.createElement("div");
+  document.body.append(host);
+  const root = createRoot(host);
+
+  flushSync(() => root.render(
+    <RuntimeComposerReceipts
+      receipts={[{
+        operationId: `op-interrupt-auto-retry-${locale}`,
+        idempotencyKey: `key-interrupt-auto-retry-${locale}`,
+        conversationId: "conv-one",
+        kind: "send",
+        status: "queued",
+        reason: "interrupt-auto-retry",
+        text: "keep going",
+        at: "2026-07-13T00:00:00.000Z",
+        revision: 3,
+      }]}
+      onRetry={() => {}}
+      onEdit={() => {}}
+    />,
+  ));
+  return { host, root };
+}
+
+function expectTransportDetailsHidden(host: HTMLElement) {
+  for (const transportText of ["thread/read", "interrupt-auto-retry", "delivery-auto-retry"]) {
+    expect(host.textContent).not.toContain(transportText);
+  }
+}
+
+test("interrupt automatic retry shows visible busy feedback in English", () => {
+  const { host, root } = renderInterruptAutoRetry("en");
+
+  const status = host.querySelector('[role="status"]');
+  expect(status?.textContent).toContain(translate("en", "runtime.receipt.busyRetry"));
+  expect(status?.querySelector(".sr-only")).toBeNull();
+  expectTransportDetailsHidden(host);
+  flushSync(() => root.unmount());
+});
+
+test("interrupt automatic retry shows visible busy feedback in Ukrainian", () => {
+  const { host, root } = renderInterruptAutoRetry("uk");
+
+  const status = host.querySelector('[role="status"]');
+  expect(status?.textContent).toContain(translate("uk", "runtime.receipt.busyRetry"));
+  expect(status?.querySelector(".sr-only")).toBeNull();
+  expectTransportDetailsHidden(host);
+  flushSync(() => root.unmount());
 });
 
 test("editing a rejected receipt does not submit the composer form", () => {

--- a/src/components/TmuxComposer.test.ts
+++ b/src/components/TmuxComposer.test.ts
@@ -51,6 +51,54 @@ test("the production runtime receipt list exposes recovery actions for failures"
   expect(html.match(/min-h-11/g)?.length).toBe(2);
 });
 
+test("a queued structured send renders as a quiet optimistic user message", () => {
+  const html = renderToStaticMarkup(
+    createElement(RuntimeComposerReceipts, {
+      receipts: [{
+        operationId: "op-pending",
+        idempotencyKey: "key-pending",
+        conversationId: "conv-one",
+        kind: "send",
+        status: "queued",
+        text: "keep going",
+        at: "2026-07-13T00:00:00.000Z",
+        revision: 1,
+      }],
+      onRetry: () => {},
+      onEdit: () => {},
+    }),
+  );
+
+  expect(html).toContain('data-optimistic-message="true"');
+  expect(html).toContain("keep going");
+  expect(html).toContain("animate-pulse");
+  expect(html).not.toContain("Queued for durable delivery");
+});
+
+test("an optimistic automatic retry stays quiet", () => {
+  const html = renderToStaticMarkup(
+    createElement(RuntimeComposerReceipts, {
+      receipts: [{
+        operationId: "op-auto-retry",
+        idempotencyKey: "key-auto-retry",
+        conversationId: "conv-one",
+        kind: "steer",
+        status: "queued",
+        reason: "delivery-auto-retry",
+        text: "keep going",
+        at: "2026-07-13T00:00:00.000Z",
+        revision: 3,
+      }],
+      onRetry: () => {},
+      onEdit: () => {},
+    }),
+  );
+
+  expect(html).toContain("animate-pulse");
+  expect(html).not.toContain("delivery-auto-retry");
+  expect(html).not.toContain("agent is busy");
+});
+
 test("a bounded receipt summary keeps retry while withholding lossy edit", () => {
   const html = renderToStaticMarkup(
     createElement(RuntimeComposerReceipts, {

--- a/src/components/TmuxComposer.test.ts
+++ b/src/components/TmuxComposer.test.ts
@@ -2,6 +2,8 @@ import { expect, test } from "bun:test";
 import { createElement } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 
+import { translate } from "@/lib/i18n";
+
 import { deliveryAttemptKey, mergeRuntimeReceipts, RuntimeComposerReceipts } from "./TmuxComposer";
 
 test("a failed durable receipt retries with its original delivery key", () => {
@@ -75,7 +77,7 @@ test("a queued structured send renders as a quiet optimistic user message", () =
   expect(html).not.toContain("Queued for durable delivery");
 });
 
-test("an optimistic automatic retry stays quiet", () => {
+test("an optimistic automatic retry shows human busy feedback", () => {
   const html = renderToStaticMarkup(
     createElement(RuntimeComposerReceipts, {
       receipts: [{
@@ -95,8 +97,11 @@ test("an optimistic automatic retry stays quiet", () => {
   );
 
   expect(html).toContain("animate-pulse");
+  expect(html).toContain("agent is busy");
+  expect(translate("en", "runtime.receipt.busyRetry")).toBe("Couldn’t deliver — agent is busy, we’ll retry");
+  expect(translate("uk", "runtime.receipt.busyRetry")).toBe("Не вдалося доставити — агент зайнятий, повторимо");
   expect(html).not.toContain("delivery-auto-retry");
-  expect(html).not.toContain("agent is busy");
+  expect(html).not.toContain("thread/read");
 });
 
 test("a bounded receipt summary keeps retry while withholding lossy edit", () => {

--- a/src/components/TmuxComposer.tsx
+++ b/src/components/TmuxComposer.tsx
@@ -22,7 +22,7 @@ import type { RuntimeReceipt } from "@/components/runtime/runtimeModel";
 import { ComposerBar } from "./ComposerBar";
 import { ImagePickerButton } from "./imageAttachments";
 import { ReceiptChip } from "./runtime/ReceiptChip";
-import { mintIdempotencyKey } from "./runtime/runtimeModel";
+import { mintIdempotencyKey, receiptIsTerminal } from "./runtime/runtimeModel";
 
 /**
  * A delivery receipt shown above the composer. `state` tracks whether the
@@ -79,16 +79,47 @@ export function RuntimeComposerReceipts({
   onRetry: (receipt: RuntimeReceipt) => void;
   onEdit: (receipt: RuntimeReceipt) => void;
 }) {
+  const { t } = useLocale();
   return receipts.map((receipt) => {
     const messageOperation = receipt.kind === "send" || receipt.kind === "steer";
     const failed = receipt.status === "failed";
+    const rejected = receipt.status === "rejected";
     // Operation receipts cap text at 240 characters. Durable retry reads the
     // complete journaled request; editing is safe only for an uncapped summary.
     const editable = messageOperation
-      && (failed || receipt.status === "rejected")
+      && (failed || rejected)
       && typeof receipt.text === "string"
       && receipt.text.length > 0
       && receipt.text.length < 240;
+    if (messageOperation && receipt.status === "delivered") return null;
+    if (messageOperation && receipt.text) {
+      const pending = !receiptIsTerminal(receipt.status);
+      const pendingLabel = t("runtime.receipt.pending");
+      return (
+        <div
+          key={receipt.operationId}
+          className="flex w-full justify-end"
+          {...(pending ? { "data-optimistic-message": "true" } : {})}
+        >
+          <div className="flex max-w-[85%] flex-col items-end gap-1 rounded-surface bg-accent/10 px-2.5 py-1.5 text-ui text-primary">
+            <span className="whitespace-pre-wrap break-words text-right">{receipt.text}</span>
+            {pending ? (
+              <span className="inline-flex items-center gap-1.5 text-caption text-muted" role="status" aria-live="polite">
+                <span className="sr-only">{pendingLabel}</span>
+                <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-muted motion-reduce:animate-none" aria-hidden />
+              </span>
+            ) : (
+              <ReceiptChip
+                receipt={receipt}
+                actionsDisabled={actionsDisabled}
+                onRetry={failed ? () => onRetry(receipt) : undefined}
+                onEdit={editable ? () => onEdit(receipt) : undefined}
+              />
+            )}
+          </div>
+        </div>
+      );
+    }
     return (
       <ReceiptChip
         key={receipt.operationId}
@@ -322,7 +353,7 @@ export function TmuxComposer({ file, pollPaused = false }: { file: FileEntry; po
               conversationId: structuredSession.session.conversationId,
               text: payloadText.trim(),
               idempotencyKey: clientMessageId,
-              policy: "steer-if-active",
+              policy: "interrupt-active",
             }).then((result) => ({
               ok: result.ok,
               structured: true,
@@ -368,7 +399,6 @@ export function TmuxComposer({ file, pollPaused = false }: { file: FileEntry; po
         idempotencyKey.current = mintIdempotencyKey();
         setText("");
         attachments.clear();
-        setStatus({ kind: "info", text: t("composer.deliveryQueued") });
         inputRef.current?.focus();
         return;
       }
@@ -425,7 +455,6 @@ export function TmuxComposer({ file, pollPaused = false }: { file: FileEntry; po
         body.receipt!,
         ...current.filter((candidate) => candidate.operationId !== body.receipt!.operationId),
       ].slice(0, 8));
-      setStatus({ kind: "info", text: t("composer.deliveryQueued") });
     } catch {
       setStatus({ kind: "err", text: t("common.serverUnavailable") });
     } finally {

--- a/src/components/TmuxComposer.tsx
+++ b/src/components/TmuxComposer.tsx
@@ -94,7 +94,8 @@ export function RuntimeComposerReceipts({
     if (messageOperation && receipt.status === "delivered") return null;
     if (messageOperation && receipt.text) {
       const pending = !receiptIsTerminal(receipt.status);
-      const pendingLabel = t("runtime.receipt.pending");
+      const busyRetry = pending && receipt.reason === "delivery-auto-retry";
+      const pendingLabel = t(busyRetry ? "runtime.receipt.busyRetry" : "runtime.receipt.pending");
       return (
         <div
           key={receipt.operationId}
@@ -105,7 +106,7 @@ export function RuntimeComposerReceipts({
             <span className="whitespace-pre-wrap break-words text-right">{receipt.text}</span>
             {pending ? (
               <span className="inline-flex items-center gap-1.5 text-caption text-muted" role="status" aria-live="polite">
-                <span className="sr-only">{pendingLabel}</span>
+                <span className={busyRetry ? undefined : "sr-only"}>{pendingLabel}</span>
                 <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-muted motion-reduce:animate-none" aria-hidden />
               </span>
             ) : (

--- a/src/components/TmuxComposer.tsx
+++ b/src/components/TmuxComposer.tsx
@@ -50,6 +50,7 @@ interface SentEntry {
 const SENT_LIMIT = 8;
 const SPAWN_TTL_MS = 90_000;
 const PANE_TTL_MS = 10 * 60_000;
+const RECOVERABLE_BUSY_RETRY_REASONS = new Set(["delivery-auto-retry", "interrupt-auto-retry"]);
 const sentKey = (id: string) => "llvSent:" + id;
 
 export function deliveryAttemptKey(current: string, stored?: string): string {
@@ -94,7 +95,9 @@ export function RuntimeComposerReceipts({
     if (messageOperation && receipt.status === "delivered") return null;
     if (messageOperation && receipt.text) {
       const pending = !receiptIsTerminal(receipt.status);
-      const busyRetry = pending && receipt.reason === "delivery-auto-retry";
+      const busyRetry = pending
+        && typeof receipt.reason === "string"
+        && RECOVERABLE_BUSY_RETRY_REASONS.has(receipt.reason);
       const pendingLabel = t(busyRetry ? "runtime.receipt.busyRetry" : "runtime.receipt.pending");
       return (
         <div

--- a/src/components/feed/parse.test.ts
+++ b/src/components/feed/parse.test.ts
@@ -90,6 +90,7 @@ const codexAssistantResponse = (timestamp: string, text: string) =>
 const codexAssistantEvent = (timestamp: string, message: string) =>
   JSON.stringify({ type: "event_msg", timestamp, payload: { type: "agent_message", phase: "commentary", message } });
 const codexUserPair = (timestamp: string, text: string) => [codexUserResponse(timestamp, [{ type: "input_text", text }]), codexUserEvent(timestamp, text)];
+const CODEX_STRUCTURED_USER_MARKER = "<!-- llv:structured-user -->\n";
 const codexReasoning = (timestamp: string) => JSON.stringify({ type: "response_item", timestamp, payload: { type: "reasoning" } });
 
 function fixtureLines(name: string): string[] {
@@ -491,6 +492,35 @@ describe("Codex user-turn coalescing", () => {
     expect(itemsOfKind(feed, "user")).toHaveLength(prefixes.length);
     expect(itemsOfKind(feed, "sysmsg")).toHaveLength(0);
     assertParity(codexFile, lines, { chunks: [1, 2, 1], cap: 5 });
+  });
+
+  test("keeps standalone structured reserved-prefix input in one user bubble across later events", () => {
+    for (const [index, text] of [
+      "# AGENTS.md instructions from the user",
+      "<permissions instructions> from the user",
+    ].entries()) {
+      const responseTs = `2026-07-14T10:00:0${index}.000Z`;
+      const startedTs = `2026-07-14T10:00:0${index}.100Z`;
+      const echoTs = `2026-07-14T10:00:0${index}.200Z`;
+      const wireText = CODEX_STRUCTURED_USER_MARKER + text;
+      const response = codexUserResponse(responseTs, [{ type: "input_text", text: wireText }]);
+      const started = JSON.stringify({ type: "event_msg", timestamp: startedTs, payload: { type: "task_started" } });
+      const echo = codexUserEvent(echoTs, wireText);
+      const lines = [response, started, echo];
+      const session = createFeedSession({ engine: "codex", fmt: "codex", showSvc: false, lineFilter: "" });
+
+      expect(session.feed([response], 0, true).items.map((entry) => entry.item)).toEqual([
+        { kind: "user", ts: responseTs, text },
+      ]);
+      expect(session.feed([response, started], 0, true).items.map((entry) => entry.item).filter((item) => item.kind === "user")).toEqual([
+        { kind: "user", ts: responseTs, text },
+      ]);
+      const complete = session.feed(lines, 0, true).items.map((entry) => entry.item);
+      expect(complete.filter((item) => item.kind === "user")).toEqual([{ kind: "user", ts: echoTs, text }]);
+      expect(complete.filter((item) => item.kind === "sysmsg")).toHaveLength(0);
+      assertParity(codexFile, lines, { chunks: [1], cap: 3, live: true });
+      assertParity(codexFile, lines, { chunks: [1], cap: 2, live: true });
+    }
   });
 
   test("collapses recognized standalone harness envelopes", () => {

--- a/src/components/feed/parse.test.ts
+++ b/src/components/feed/parse.test.ts
@@ -406,6 +406,20 @@ describe("feed session identity stability", () => {
 });
 
 describe("Codex user-turn coalescing", () => {
+  test("keeps a standalone structured user response in a user bubble", () => {
+    const lines = [
+      codexUserResponse("t1", [{ type: "input_text", text: "queued through the structured host" }]),
+      JSON.stringify({ type: "event_msg", timestamp: "t2", payload: { type: "task_started" } }),
+    ];
+    const feed = buildFeed(codexFile, lines, false, "");
+
+    expect(itemsOfKind(feed, "user")).toEqual([
+      { kind: "user", ts: "t1", text: "queued through the structured host" },
+    ]);
+    expect(itemsOfKind(feed, "sysmsg")).toHaveLength(0);
+    assertParity(codexFile, lines, { chunks: [1] });
+  });
+
   test("folds only an adjacent response/event echo and preserves two identical sends", () => {
     const lines = [...codexUserPair("t1", "same"), ...codexUserPair("t2", "same")];
     expect(itemsOfKind(buildFeed(codexFile, lines.slice(0, 2), false, ""), "user")).toEqual([{ kind: "user", ts: "t1", text: "same" }]);
@@ -479,7 +493,7 @@ describe("Codex user-turn coalescing", () => {
     assertParity(codexFile, lines, { chunks: [1, 2, 1], cap: 5 });
   });
 
-  test("uses record shape to collapse actual harness rows", () => {
+  test("collapses recognized standalone harness envelopes", () => {
     const lines = [
       codexUserResponse("t1", [{ type: "input_text", text: "<permissions instructions> injected" }]),
       JSON.stringify({ type: "event_msg", timestamp: "t2", payload: { type: "task_started" } }),
@@ -1194,6 +1208,20 @@ describe("Codex orchestration over a real rollout fixture (issue #83)", () => {
 });
 
 describe("Claude protocol and repeated prose", () => {
+  test("keeps a structured-host user record in the user role", () => {
+    const lines = [JSON.stringify({
+      type: "user",
+      message: { role: "user", content: [{ type: "text", text: "queued through the structured host" }] },
+    })];
+    const feed = buildFeed(claudeFile, lines, false, "");
+
+    expect(itemsOfKind(feed, "user")).toEqual([
+      { kind: "user", ts: undefined, text: "queued through the structured host" },
+    ]);
+    expect(itemsOfKind(feed, "sysmsg")).toHaveLength(0);
+    assertParity(claudeFile, lines, { chunks: [1] });
+  });
+
   test("keeps a queued human message in the user role beside harness records", () => {
     const lines = fixtureLines("claude-queued-mid-turn.jsonl");
     const feed = buildFeed(claudeFile, lines, false, "");

--- a/src/components/feed/parse.ts
+++ b/src/components/feed/parse.ts
@@ -241,6 +241,10 @@ function sysMsgLabel(text: string, fallback?: string): string {
   return fallback || tr("render.system");
 }
 
+function isCodexHarnessUserText(text: string): boolean {
+  return /^\s*(?:# AGENTS\.md instructions\b|<(?:environment_context|permissions instructions|multi_agent_mode|turn_aborted)\b)/.test(text);
+}
+
 function tmsgAttr(attrs: string, name: string): string {
   return attrs.match(new RegExp(`${name}="([^"]*)"`))?.[1] ?? "";
 }
@@ -1331,9 +1335,9 @@ export function createFeedSession(cfg: FeedSessionConfig): FeedSession {
     }
     for (const image of images) push({ kind: "inbox-image", name: image.name, path: image.path });
   };
-  /* Harness classification is driven by the source record, never a textual
-     prefix. A human can legitimately begin a composer message with XML or a
-     phrase that looks like a harness reminder. */
+  /* Codex stores human input and harness context in user-role response rows.
+     Known envelope markers identify harness rows. Echoed composer messages
+     keep their user classification even when their text starts similarly. */
   const addSysMsg = (text: string, fallbackLabel?: string) => {
     push({ kind: "sysmsg", label: sysMsgLabel(text, fallbackLabel), text });
   };
@@ -1358,9 +1362,10 @@ export function createFeedSession(cfg: FeedSessionConfig): FeedSession {
     const pendingUsers = pendingCodexUsers;
     pendingCodexUsers = [];
     for (const pending of pendingUsers) {
-      /* A user-role response without the immediately following event is a
-         harness/service injection in the observed Codex schema. Its content may
-         use any prefix, so record shape provides the classification. */
+      /* App-server structured input may persist without a user_message echo.
+         Preserve its declared user role. Recognized harness envelopes move to
+         the system lane. */
+      if (!isCodexHarnessUserText(pending.text)) continue;
       let converted = false;
       for (const seq of pending.entrySeqs) {
         const idx = entryIndex(seq);

--- a/src/components/feed/parse.ts
+++ b/src/components/feed/parse.ts
@@ -8,6 +8,7 @@ import {
 } from "@/lib/review";
 import { getLocale, translate } from "@/lib/i18n";
 import { inboxImageExt, MAX_INBOX_IMAGE_BYTES } from "@/lib/imagePolicy";
+import { decodeCodexStructuredUserText } from "@/lib/runtime/codexStructuredUserText";
 import type { FileEntry } from "@/lib/types";
 import { parseScheduleWakeup, refineWakeupFromResult, type WakeupInfo } from "@/lib/wakeup";
 
@@ -297,6 +298,7 @@ function inboxImagesFromPath(path: string): Extract<Item, { kind: "inbox-image" 
 interface CodexUserContent {
   text: string;
   attachments: Item[];
+  structured: boolean;
 }
 
 /* Codex has added content-part variants over time. Keep the text path broad,
@@ -331,7 +333,7 @@ function normalizeCodexUserContent(content: unknown): CodexUserContent {
       attachments.push({ kind: "note", text: codexAttachmentLabel(type) });
     }
   }
-  return { text: text.join(" ").trim(), attachments };
+  return { ...decodeCodexStructuredUserText(text.join(" ").trim()), attachments };
 }
 
 /** Responses custom tools return either plain text or typed text blocks. */
@@ -824,6 +826,7 @@ interface PendingCodexUser {
   ts: unknown;
   text: string;
   entrySeqs: number[];
+  structured: boolean;
 }
 
 type CodexAssistantShape = "event-agent" | "response-assistant";
@@ -1348,7 +1351,7 @@ export function createFeedSession(cfg: FeedSessionConfig): FeedSession {
     if (cleaned) emit({ kind: "user", ts, text: cleaned });
     for (const image of images) emit({ kind: "inbox-image", name: image.name, path: image.path });
     for (const attachment of content.attachments) emit(attachment);
-    return { src: curSrc, ts, text: content.text, entrySeqs };
+    return { src: curSrc, ts, text: content.text, entrySeqs, structured: content.structured };
   };
   const updateCodexPendingSource = (pending: PendingCodexUser, src: number) => {
     for (const seq of pending.entrySeqs) {
@@ -1360,11 +1363,12 @@ export function createFeedSession(cfg: FeedSessionConfig): FeedSession {
   };
   const finalizePendingCodexUsers = () => {
     const pendingUsers = pendingCodexUsers;
-    pendingCodexUsers = [];
+    pendingCodexUsers = pendingUsers.filter((pending) => pending.structured);
     for (const pending of pendingUsers) {
       /* App-server structured input may persist without a user_message echo.
-         Preserve its declared user role. Recognized harness envelopes move to
-         the system lane. */
+         Its transcript marker preserves the declared user role while later
+         records arrive. Recognized harness envelopes move to the system lane. */
+      if (pending.structured) continue;
       if (!isCodexHarnessUserText(pending.text)) continue;
       let converted = false;
       for (const seq of pending.entrySeqs) {
@@ -1392,14 +1396,15 @@ export function createFeedSession(cfg: FeedSessionConfig): FeedSession {
     pendingCodexUsers.push(pending);
   };
   const addCodexEventUser = (ts: unknown, text: string) => {
-    const pendingIndex = pendingCodexUsers.findIndex((pending) => sameCodexTextAtTime(pending.ts, pending.text, ts, text));
+    const decoded = decodeCodexStructuredUserText(text);
+    const pendingIndex = pendingCodexUsers.findIndex((pending) => sameCodexTextAtTime(pending.ts, pending.text, ts, decoded.text));
     if (pendingIndex < 0) {
-      emitCodexUserContent(ts, { text, attachments: [] });
+      emitCodexUserContent(ts, { ...decoded, attachments: [] });
       return;
     }
     const [pending] = pendingCodexUsers.splice(pendingIndex, 1);
     if (!pending) return;
-    const { cleaned, images } = extractInboxImages(text);
+    const { cleaned, images } = extractInboxImages(decoded.text);
     if (cleaned) {
       const userSeq = pending.entrySeqs.find((seq) => {
         const idx = entryIndex(seq);

--- a/src/components/runtime/runtimeComponents.render.test.tsx
+++ b/src/components/runtime/runtimeComponents.render.test.tsx
@@ -65,6 +65,14 @@ test("queued receipt shows its position", () => {
   expect(html).toContain(translate("en", "runtime.receipt.queuedPos", { position: 3 }));
 });
 
+test("queued automatic delivery hides its transport reason", () => {
+  const html = renderToStaticMarkup(
+    <ReceiptChip receipt={receipt({ status: "queued", reason: "delivery-auto-retry" })} />,
+  );
+  expect(html).toContain(translate("en", "runtime.receipt.queued"));
+  expect(html).not.toContain("delivery-auto-retry");
+});
+
 test("delivering receipt is localized in English and Ukrainian", () => {
   const html = renderToStaticMarkup(<ReceiptChip receipt={receipt({ status: "delivering" })} />);
   expect(html).toContain(translate("en", "runtime.receipt.delivering"));

--- a/src/hooks/useRuntime.ts
+++ b/src/hooks/useRuntime.ts
@@ -145,7 +145,7 @@ export interface SendOptions {
   conversationId: string;
   text: string;
   idempotencyKey: string;
-  policy?: "queue" | "steer-if-active";
+  policy?: "queue" | "steer-if-active" | "interrupt-active";
   images?: string[];
   kind?: OperationKind;
 }
@@ -158,7 +158,7 @@ export function sendRuntimeMessage(options: SendOptions): Promise<CommandResult>
     text: options.text,
     images: options.images,
     idempotencyKey: options.idempotencyKey,
-    policy: options.policy ?? "steer-if-active",
+    policy: options.policy ?? "interrupt-active",
   });
 }
 

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -262,7 +262,6 @@ export const en = {
   "composer.queueAria": "Queue of sent messages",
   "composer.removeFromQueue": "Remove from queue",
   "composer.deliveryHeld": "Held for «{label}» — delivers after the account switch",
-  "composer.deliveryQueued": "Queued for durable delivery",
   "composer.structured": "structured",
   "composer.structuredHost": "Structured runtime host",
   "composer.structuredImagesUnavailable": "Image delivery is unavailable for structured conversations",

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -1374,6 +1374,7 @@ export const en = {
   "runtime.drift": "drift: {evidence}",
   "runtime.driftDismiss": "Dismiss",
   "runtime.receipt.pending": "sending…",
+  "runtime.receipt.busyRetry": "Couldn’t deliver — agent is busy, we’ll retry",
   "runtime.receipt.delivering": "delivering…",
   "runtime.receipt.turn-started": "turn started",
   "runtime.receipt.steered": "steered into current turn",

--- a/src/lib/i18n/uk.ts
+++ b/src/lib/i18n/uk.ts
@@ -1332,6 +1332,7 @@ export const uk: Record<keyof typeof en, Message> = {
   "runtime.drift": "розбіжність: {evidence}",
   "runtime.driftDismiss": "Сховати",
   "runtime.receipt.pending": "надсилання…",
+  "runtime.receipt.busyRetry": "Не вдалося доставити — агент зайнятий, повторимо",
   "runtime.receipt.delivering": "доставляється…",
   "runtime.receipt.turn-started": "хід почато",
   "runtime.receipt.steered": "вкладено в поточний хід",

--- a/src/lib/i18n/uk.ts
+++ b/src/lib/i18n/uk.ts
@@ -254,7 +254,6 @@ export const uk: Record<keyof typeof en, Message> = {
   "composer.queueAria": "Черга надісланих повідомлень",
   "composer.removeFromQueue": "Прибрати з черги",
   "composer.deliveryHeld": "Притримано для «{label}» — доставиться після зміни акаунта",
-  "composer.deliveryQueued": "Додано до надійної черги доставки",
   "composer.structured": "структурований",
   "composer.structuredHost": "Структурований runtime-хост",
   "composer.structuredImagesUnavailable": "Структуровані розмови поки не підтримують картинки",

--- a/src/lib/runtime/claudeStreamBrokerHost.test.ts
+++ b/src/lib/runtime/claudeStreamBrokerHost.test.ts
@@ -191,6 +191,9 @@ describe("ClaudeStreamBrokerHost", () => {
     await Bun.sleep(0);
     expect(sendSettled).toBeFalse();
     expect(ledger.order.slice(0, 2)).toEqual(["ledger:delivery-one", "stdin:begin"]);
+    expect(child.inputs.find((input) => input.type === "user")).toMatchObject({
+      message: { role: "user" },
+    });
 
     child.emitJson({ type: "system", subtype: "init", session_id: host.identity.sessionId, apiKeySource: "none", model: "claude-test" });
     child.emitJson({ type: "user", isReplay: true, session_id: host.identity.sessionId, uuid: "user-one", message: { role: "user", content: [{ type: "text", text: "begin" }] } });

--- a/src/lib/runtime/codexAppServerHost.test.ts
+++ b/src/lib/runtime/codexAppServerHost.test.ts
@@ -224,7 +224,11 @@ describe("CodexAppServerHost", () => {
     expect(await host.send({ id: "stale", text: "wrong", expectedTurnId: "turn-old" })).toEqual({ outcome: "rejected", reason: "stale-turn" });
     expect(await host.send({ id: "delivery-two", text: "steer", expectedTurnId: "turn-1" })).toEqual({ outcome: "steered", turnId: "turn-1" });
     const steer = server.requests.find((request) => request.method === "turn/steer")!;
-    expect(steer.params).toMatchObject({ expectedTurnId: "turn-1", clientUserMessageId: "delivery-two" });
+    expect(steer.params).toMatchObject({
+      expectedTurnId: "turn-1",
+      clientUserMessageId: "delivery-two",
+      input: [{ type: "text", text: "<!-- llv:structured-user -->\nsteer" }],
+    });
 
     server.request("approval-1", "item/commandExecution/requestApproval", { command: "touch allowed" });
     await Bun.sleep(0);

--- a/src/lib/runtime/codexAppServerHost.test.ts
+++ b/src/lib/runtime/codexAppServerHost.test.ts
@@ -867,6 +867,35 @@ describe("CodexAppServerHost", () => {
     await host.release();
   });
 
+  test("a late timed-out thread/read response stays harmless after retry delivery", async () => {
+    const ignoredMethods = ["thread/read"];
+    const server = new FakeAppServer("late-read-thread", "late-read-thread", false, [], undefined, null, ignoredMethods);
+    const host = await CodexAppServerHost.start({
+      cwd: "/repo",
+      requestTimeoutMs: 5,
+      eventStore: new MemoryEventStore(),
+      spawnProcess: fakeSpawn(server),
+    });
+    const entry = { id: "late-read-retry", text: "continue" };
+
+    await expect(host.send(entry)).rejects.toThrow("thread/read timed out");
+    const firstRead = server.requests.findLast((request) => request.method === "thread/read")!;
+    ignoredMethods.splice(0);
+
+    expect(await host.send(entry)).toEqual({ outcome: "turn-started", turnId: "turn-1" });
+    server.stdout.write(`${JSON.stringify({
+      jsonrpc: "2.0",
+      id: firstRead.id,
+      result: { thread: { id: "late-read-thread", path: "/sessions/late-read-thread.jsonl", turns: [] } },
+    })}\n`);
+    await Bun.sleep(0);
+
+    expect(await host.health()).toMatchObject({ status: "active", activeTurnRef: "turn-1" });
+    expect(server.signals).not.toContain("SIGTERM");
+    expect(server.requests.filter((request) => request.method === "turn/start" || request.method === "turn/steer")).toHaveLength(1);
+    await host.release();
+  });
+
   test("ledger failures are contained, reject pending work, and close subscribers", async () => {
     const store = new FailingEventStore();
     const server = new FakeAppServer("ledger-thread", "ledger-thread", false, [], undefined, null, ["turn/start"]);

--- a/src/lib/runtime/codexAppServerHost.test.ts
+++ b/src/lib/runtime/codexAppServerHost.test.ts
@@ -835,6 +835,34 @@ describe("CodexAppServerHost", () => {
     await host.release();
   });
 
+  test("an active turn gives thread/read enough time to answer", async () => {
+    const ignoredMethods: string[] = [];
+    const server = new FakeAppServer("slow-read-thread", "slow-read-thread", false, [], undefined, null, ignoredMethods);
+    const host = await CodexAppServerHost.start({
+      cwd: "/repo",
+      requestTimeoutMs: 20,
+      eventStore: new MemoryEventStore(),
+      spawnProcess: fakeSpawn(server),
+    });
+    expect(await host.send({ id: "first", text: "begin" })).toEqual({ outcome: "turn-started", turnId: "turn-1" });
+    ignoredMethods.push("thread/read");
+
+    const pending = host.send({ id: "slow-read-follow-up", text: "continue", expectedTurnId: "turn-1" })
+      .then((value) => ({ value }), (error: Error) => ({ error }));
+    await Bun.sleep(35);
+    const read = server.requests.findLast((request) => request.method === "thread/read")!;
+    server.stdout.write(`${JSON.stringify({
+      jsonrpc: "2.0",
+      id: read.id,
+      result: { thread: { id: "slow-read-thread", path: "/sessions/slow-read-thread.jsonl", turns: [] } },
+    })}\n`);
+    const result = await pending;
+
+    if ("error" in result) throw result.error;
+    expect(result.value).toEqual({ outcome: "steered", turnId: "turn-1" });
+    await host.release();
+  });
+
   test("ledger failures are contained, reject pending work, and close subscribers", async () => {
     const store = new FailingEventStore();
     const server = new FakeAppServer("ledger-thread", "ledger-thread", false, [], undefined, null, ["turn/start"]);

--- a/src/lib/runtime/codexAppServerHost.ts
+++ b/src/lib/runtime/codexAppServerHost.ts
@@ -107,6 +107,9 @@ const CHILD_ENV_ALLOWLIST = [
 ] as const;
 const DEFAULT_TIMEOUT_MS = 30_000;
 const ACTIVE_THREAD_READ_TIMEOUT_MULTIPLIER = 3;
+const LATE_THREAD_READ_RESPONSE_TTL_MULTIPLIER = 3;
+const MIN_LATE_THREAD_READ_RESPONSE_TTL_MS = 1_000;
+const MAX_LATE_THREAD_READ_RESPONSES = 32;
 const DEFAULT_SHUTDOWN_GRACE_MS = 1_000;
 const MAX_LINE_BYTES = 4 * 1024 * 1024;
 const MUTATING_RPC_METHODS = new Set(["thread/start", "thread/resume", "turn/start", "turn/steer", "turn/interrupt"]);
@@ -229,6 +232,7 @@ export class CodexAppServerHost implements EngineHost {
   private readonly effort: string | undefined;
   private readonly signalProcess: ProcessSignal;
   private readonly pending = new Map<number, PendingRpc>();
+  private readonly lateThreadReadResponses = new Map<number, number>();
   private readonly subscribers = new Set<Subscriber>();
   private readonly events: RuntimeEvent[] = [];
   private readonly confirmedDeliveries = new Map<string, { receipt: DeliveryReceipt; text: string | null }>();
@@ -791,6 +795,7 @@ export class CodexAppServerHost implements EngineHost {
     return new Promise((resolve, reject) => {
       const timer = setTimeout(() => {
         this.pending.delete(id);
+        if (method === "thread/read") this.rememberLateThreadReadResponse(id, timeoutMs);
         const error = new Error(`${method} timed out${MUTATING_RPC_METHODS.has(method) ? "; outcome is uncertain" : ""}`);
         reject(error);
         if (MUTATING_RPC_METHODS.has(method)) this.fail(error);
@@ -798,6 +803,27 @@ export class CodexAppServerHost implements EngineHost {
       this.pending.set(id, { resolve, reject, timer });
       this.write({ jsonrpc: "2.0", id, method, params });
     });
+  }
+
+  private rememberLateThreadReadResponse(id: number, timeoutMs: number): void {
+    const now = Date.now();
+    for (const [lateId, expiresAt] of this.lateThreadReadResponses) {
+      if (expiresAt <= now) this.lateThreadReadResponses.delete(lateId);
+    }
+    const ttlMs = Math.max(timeoutMs * LATE_THREAD_READ_RESPONSE_TTL_MULTIPLIER, MIN_LATE_THREAD_READ_RESPONSE_TTL_MS);
+    this.lateThreadReadResponses.set(id, now + ttlMs);
+    while (this.lateThreadReadResponses.size > MAX_LATE_THREAD_READ_RESPONSES) {
+      const oldestId = this.lateThreadReadResponses.keys().next().value;
+      if (oldestId === undefined) break;
+      this.lateThreadReadResponses.delete(oldestId);
+    }
+  }
+
+  private consumeLateThreadReadResponse(id: number): boolean {
+    const expiresAt = this.lateThreadReadResponses.get(id);
+    if (expiresAt === undefined) return false;
+    this.lateThreadReadResponses.delete(id);
+    return expiresAt > Date.now();
   }
 
   private notify(method: string, params: JsonObject): void {
@@ -842,6 +868,7 @@ export class CodexAppServerHost implements EngineHost {
     if ((typeof id === "number" || typeof id === "string") && !method) {
       if (typeof id !== "number") return this.fail(new Error("Codex app-server response id is invalid"));
       const pending = this.pending.get(id);
+      if (!pending && this.consumeLateThreadReadResponse(id)) return;
       if (!pending) return this.fail(new Error("Codex app-server response has no matching request"));
       this.pending.delete(id);
       clearTimeout(pending.timer);

--- a/src/lib/runtime/codexAppServerHost.ts
+++ b/src/lib/runtime/codexAppServerHost.ts
@@ -105,6 +105,7 @@ const CHILD_ENV_ALLOWLIST = [
   "LLV_SPAWN_CAPABILITY",
 ] as const;
 const DEFAULT_TIMEOUT_MS = 30_000;
+const ACTIVE_THREAD_READ_TIMEOUT_MULTIPLIER = 3;
 const DEFAULT_SHUTDOWN_GRACE_MS = 1_000;
 const MAX_LINE_BYTES = 4 * 1024 * 1024;
 const MUTATING_RPC_METHODS = new Set(["thread/start", "thread/resume", "turn/start", "turn/steer", "turn/interrupt"]);
@@ -675,7 +676,10 @@ export class CodexAppServerHost implements EngineHost {
     if (known) return this.confirmedReceipt(entry, known);
     let thread: unknown;
     try {
-      thread = await this.rpc("thread/read", { threadId: this.identity.threadId, includeTurns: true });
+      const timeoutMs = this.activeTurnId
+        ? this.requestTimeoutMs * ACTIVE_THREAD_READ_TIMEOUT_MULTIPLIER
+        : this.requestTimeoutMs;
+      thread = await this.rpc("thread/read", { threadId: this.identity.threadId, includeTurns: true }, timeoutMs);
     } catch (error) {
       const message = safeError(error);
       if (/not materialized yet/i.test(message) && /before first user message/i.test(message)) return null;
@@ -779,7 +783,7 @@ export class CodexAppServerHost implements EngineHost {
     this.setSessionStatus(mapped, status.activeFlags);
   }
 
-  private rpc(method: string, params: JsonObject = {}): Promise<unknown> {
+  private rpc(method: string, params: JsonObject = {}, timeoutMs = this.requestTimeoutMs): Promise<unknown> {
     if (this.dead || this.releasing || this.released) return Promise.reject(new Error("Codex app-server host is unavailable"));
     const id = this.nextRpcId++;
     return new Promise((resolve, reject) => {
@@ -788,7 +792,7 @@ export class CodexAppServerHost implements EngineHost {
         const error = new Error(`${method} timed out${MUTATING_RPC_METHODS.has(method) ? "; outcome is uncertain" : ""}`);
         reject(error);
         if (MUTATING_RPC_METHODS.has(method)) this.fail(error);
-      }, this.requestTimeoutMs);
+      }, timeoutMs);
       this.pending.set(id, { resolve, reject, timer });
       this.write({ jsonrpc: "2.0", id, method, params });
     });

--- a/src/lib/runtime/codexAppServerHost.ts
+++ b/src/lib/runtime/codexAppServerHost.ts
@@ -5,6 +5,7 @@ import { procBackend } from "@/lib/proc";
 import { signalDetachedProcessGroup, signalProcessGroup, type ProcessSignal } from "@/lib/processGroup";
 import { headlessCodexThreadConfig } from "@/lib/codexHeadlessConfig";
 import { hardenedRedact } from "@/lib/view/compactText";
+import { decodeCodexStructuredUserText, encodeCodexStructuredUserText } from "./codexStructuredUserText";
 
 import type {
   DeliveryReceipt,
@@ -394,7 +395,7 @@ export class CodexAppServerHost implements EngineHost {
     if (entry.expectedTurnId !== undefined && entry.expectedTurnId !== currentTurn) {
       return { outcome: "rejected", reason: "stale-turn" };
     }
-    const input = [{ type: "text", text: entry.text }];
+    const input = [{ type: "text", text: encodeCodexStructuredUserText(entry.text) }];
     if (currentTurn) {
       try {
         const result = await this.rpc("turn/steer", {
@@ -733,7 +734,8 @@ export class CodexAppServerHost implements EngineHost {
     if (!item || stringField(item, "type") !== "userMessage") return;
     const clientId = stringField(item, "clientId");
     if (!clientId) return;
-    const text = userMessageText(item);
+    const wireText = userMessageText(item);
+    const text = wireText === null ? null : decodeCodexStructuredUserText(wireText).text;
     const previous = this.confirmedDeliveries.get(clientId);
     const pending = this.pendingDeliveries.get(clientId);
     const confirmed = {

--- a/src/lib/runtime/codexStructuredUserText.ts
+++ b/src/lib/runtime/codexStructuredUserText.ts
@@ -1,0 +1,10 @@
+const STRUCTURED_USER_MARKER = "<!-- llv:structured-user -->\n";
+
+export function encodeCodexStructuredUserText(text: string): string {
+  return STRUCTURED_USER_MARKER + text;
+}
+
+export function decodeCodexStructuredUserText(value: string): { text: string; structured: boolean } {
+  if (!value.startsWith(STRUCTURED_USER_MARKER)) return { text: value, structured: false };
+  return { text: value.slice(STRUCTURED_USER_MARKER.length), structured: true };
+}

--- a/src/lib/runtime/commands.test.ts
+++ b/src/lib/runtime/commands.test.ts
@@ -17,6 +17,12 @@ test("dedicated runtime command parsers freeze the Opus request bodies", () => {
     idempotencyKey: "send-one",
     policy: "steer-if-active",
   });
+  expect(parseRuntimeCommand("send", {
+    conversationId: "conv-one",
+    text: "replace the current turn",
+    idempotencyKey: "send-two",
+    policy: "interrupt-active",
+  })).toMatchObject({ policy: "interrupt-active" });
   expect(parseRuntimeCommand("interrupt", {
     conversationId: "conv-one",
     operationId: "interrupt-one",

--- a/src/lib/runtime/commands.ts
+++ b/src/lib/runtime/commands.ts
@@ -40,7 +40,9 @@ export function parseRuntimeCommand(kind: RuntimeOperationKind, value: unknown):
     const images = body.images === undefined ? undefined : body.images;
     if (images !== undefined && (!Array.isArray(images) || images.length > 16 || images.some((image) => typeof image !== "string"))) throw new Error("images are invalid");
     const policy = body.policy === undefined ? undefined : body.policy;
-    if (policy !== undefined && policy !== "queue" && policy !== "steer-if-active") throw new Error("policy is invalid");
+    if (policy !== undefined && policy !== "queue" && policy !== "steer-if-active" && policy !== "interrupt-active") {
+      throw new Error("policy is invalid");
+    }
     return {
       kind,
       conversationId,

--- a/src/lib/runtime/contracts.ts
+++ b/src/lib/runtime/contracts.ts
@@ -188,7 +188,7 @@ export interface RuntimeSendCommand extends RuntimeCommandBase {
   kind: "send" | "steer";
   text: string;
   images?: string[];
-  policy?: "queue" | "steer-if-active";
+  policy?: "queue" | "steer-if-active" | "interrupt-active";
   turnId?: string | null;
 }
 

--- a/src/lib/runtime/structuredDeliveryController.ts
+++ b/src/lib/runtime/structuredDeliveryController.ts
@@ -127,7 +127,12 @@ export async function bindStructuredDeliveryQueue(
   if (!client) return;
   const registry = dependencies.registry ?? agentRegistry();
   const hosts = new Map<string, EngineHost>();
-  const queue = new StructuredDeliveryQueue(runtimeClientDeliveryPort(client), hostResolver(registry, hosts));
+  let scheduleAutomaticRetry = () => {};
+  const queue = new StructuredDeliveryQueue(
+    runtimeClientDeliveryPort(client),
+    hostResolver(registry, hosts),
+    () => scheduleAutomaticRetry(),
+  );
   let drainTimer: ReturnType<typeof setTimeout> | null = null;
   let drainBackoffMs = DELIVERY_DRAIN_COALESCE_MS;
   let stopped = false;
@@ -162,6 +167,9 @@ export async function bindStructuredDeliveryQueue(
   };
   const requestDrain = () => {
     if (state.activeQueue === queue) scheduleDrain();
+  };
+  scheduleAutomaticRetry = () => {
+    if (state.activeQueue === queue) scheduleDrain(DELIVERY_DRAIN_MAX_BACKOFF_MS);
   };
   const registrations = new Map<string, { key: SessionKey; host: ObservableEngineHost; unsubscribe: () => void; stopEvents: () => Promise<void> }>();
   const publishChains = new Map<string, Promise<void>>();

--- a/src/lib/runtime/structuredDeliveryQueue.test.ts
+++ b/src/lib/runtime/structuredDeliveryQueue.test.ts
@@ -177,6 +177,77 @@ test("structured delivery surfaces a host actuation failure", async () => {
   ]);
 });
 
+test("a Codex thread/read timeout retries within the bounded drain", async () => {
+  const transitions: Array<[string, string, string | null | undefined]> = [];
+  let attempts = 0;
+  const slowHost = host(async () => {
+    attempts += 1;
+    if (attempts === 1) throw new Error("thread/read timed out");
+    return { outcome: "steered", turnId: "turn-slow-read" };
+  });
+  slowHost.health = async () => ({ ...idleState(), status: "active", activeTurnRef: "turn-slow-read" });
+  const queue = new StructuredDeliveryQueue({
+    effects: async () => [{
+      id: "effect:op-slow-read",
+      kind: "runtime.send",
+      eventSeq: 21,
+      payload: {
+        operationId: "op-slow-read",
+        conversationId: "conversation-slow-read",
+        text: "please keep going",
+        policy: "steer-if-active",
+      },
+    }],
+    transition: async (operationId, status, details) => {
+      transitions.push([operationId, status, details?.reason]);
+    },
+  }, () => slowHost);
+
+  await queue.drain();
+
+  expect(attempts).toBe(2);
+  expect(transitions).toEqual([
+    ["op-slow-read", "delivering", undefined],
+    ["op-slow-read", "delivered", undefined],
+  ]);
+});
+
+test("an exhausted thread/read budget stays queued for automatic delivery", async () => {
+  const transitions: Array<[string, string, string | null | undefined]> = [];
+  let attempts = 0;
+  let retries = 0;
+  const slowHost = host(async () => {
+    attempts += 1;
+    throw new Error("Codex app-server request timed out: thread/read");
+  });
+  slowHost.health = async () => ({ ...idleState(), status: "active", activeTurnRef: "turn-slow-read" });
+  const queue = new StructuredDeliveryQueue({
+    effects: async () => [{
+      id: "effect:op-slow-read-retry",
+      kind: "runtime.send",
+      eventSeq: 22,
+      payload: {
+        operationId: "op-slow-read-retry",
+        conversationId: "conversation-slow-read",
+        text: "keep this safe",
+        policy: "steer-if-active",
+      },
+    }],
+    transition: async (operationId, status, details) => {
+      transitions.push([operationId, status, details?.reason]);
+    },
+  }, () => slowHost, () => { retries += 1; });
+
+  await queue.drain();
+
+  expect(attempts).toBe(2);
+  expect(retries).toBe(1);
+  expect(transitions).toEqual([
+    ["op-slow-read-retry", "delivering", undefined],
+    ["op-slow-read-retry", "queued", "delivery-auto-retry"],
+  ]);
+});
+
 test("a host crash leaves the conversation head queued for recovery", async () => {
   const sent: string[] = [];
   const transitions: Array<[string, string, string | null | undefined]> = [];
@@ -384,6 +455,144 @@ test("an idle queue admission keeps its null turn fence when a turn starts befor
     ["op-idle-race", "delivering", null, undefined],
     ["op-idle-race", "queued", undefined, "stale-turn"],
   ]);
+});
+
+test("interrupt-active stops the current turn before starting the user message", async () => {
+  const actions: string[] = [];
+  const transitions: Array<[string, string, string | null | undefined]> = [];
+  let active = true;
+  const replacingHost = host(async (entry) => {
+    actions.push(`send:${String(entry.expectedTurnId)}`);
+    return { outcome: "turn-started", turnId: "turn-new" };
+  });
+  replacingHost.health = async () => ({
+    ...idleState(),
+    status: active ? "active" : "idle",
+    activeTurnRef: active ? "turn-current" : null,
+  });
+  replacingHost.interrupt = async (turnId) => {
+    actions.push(`interrupt:${turnId}`);
+    active = false;
+  };
+  const queue = new StructuredDeliveryQueue({
+    effects: async () => [{
+      id: "effect:op-replace",
+      kind: "runtime.send",
+      eventSeq: 31,
+      payload: {
+        operationId: "op-replace",
+        conversationId: "conversation-one",
+        text: "new direction",
+        policy: "interrupt-active",
+      },
+    }],
+    transition: async (operationId, status, details) => {
+      transitions.push([operationId, status, details?.turnId]);
+    },
+  }, () => replacingHost);
+
+  await queue.drain();
+
+  expect(actions).toEqual(["interrupt:turn-current", "send:null"]);
+  expect(transitions).toEqual([
+    ["op-replace", "delivering", "turn-current"],
+    ["op-replace", "delivered", "turn-new"],
+  ]);
+});
+
+test("interrupt-active waits for the interrupted turn to become idle before sending", async () => {
+  const actions: string[] = [];
+  const transitions: Array<[string, string, string | null | undefined]> = [];
+  const effect = {
+    id: "effect:op-wait-for-interrupt",
+    kind: "runtime.send",
+    eventSeq: 32,
+    payload: {
+      operationId: "op-wait-for-interrupt",
+      conversationId: "conversation-one",
+      text: "start after interruption",
+      policy: "interrupt-active",
+    } as Record<string, unknown>,
+  };
+  let active = true;
+  let pending = true;
+  const replacingHost = host(async (entry) => {
+    actions.push(`send:${String(entry.expectedTurnId)}`);
+    pending = false;
+    return { outcome: "turn-started", turnId: "turn-new" };
+  });
+  replacingHost.health = async () => ({
+    ...idleState(),
+    status: active ? "active" : "idle",
+    activeTurnRef: active ? "turn-current" : null,
+  });
+  replacingHost.interrupt = async (turnId) => {
+    actions.push(`interrupt:${turnId}`);
+  };
+  const queue = new StructuredDeliveryQueue({
+    effects: async () => pending ? [effect] : [],
+    transition: async (operationId, status, details) => {
+      transitions.push([operationId, status, details?.turnId]);
+      if (status === "delivering" && effect.payload.turnId === undefined) {
+        effect.payload.turnId = details?.turnId;
+      }
+    },
+  }, () => replacingHost);
+
+  await queue.drain();
+  expect(actions).toEqual(["interrupt:turn-current"]);
+
+  active = false;
+  await queue.drain();
+
+  expect(actions).toEqual(["interrupt:turn-current", "send:null"]);
+  expect(transitions).toEqual([
+    ["op-wait-for-interrupt", "delivering", "turn-current"],
+    ["op-wait-for-interrupt", "queued", undefined],
+    ["op-wait-for-interrupt", "delivering", "turn-current"],
+    ["op-wait-for-interrupt", "delivered", "turn-new"],
+  ]);
+});
+
+test("interrupt-active preserves a newer turn during ambiguous delivery recovery", async () => {
+  const actions: string[] = [];
+  let activeTurn: string | null = "turn-newer";
+  let pending = true;
+  const recoveringHost = host(async (entry) => {
+    actions.push(`send:${String(entry.expectedTurnId)}`);
+    pending = false;
+    return { outcome: "turn-started", turnId: "turn-recovered" };
+  });
+  recoveringHost.health = async () => ({
+    ...idleState(),
+    status: activeTurn ? "active" : "idle",
+    activeTurnRef: activeTurn,
+  });
+  recoveringHost.interrupt = async (turnId) => {
+    actions.push(`interrupt:${turnId}`);
+  };
+  const queue = new StructuredDeliveryQueue({
+    effects: async () => pending ? [{
+      id: "effect:op-recover-replacement",
+      kind: "runtime.send",
+      eventSeq: 33,
+      payload: {
+        operationId: "op-recover-replacement",
+        conversationId: "conversation-one",
+        text: "recover safely",
+        policy: "interrupt-active",
+        turnId: "turn-original",
+      },
+    }] : [],
+    transition: async () => {},
+  }, () => recoveringHost);
+
+  await queue.drain();
+  expect(actions).toEqual([]);
+
+  activeTurn = null;
+  await queue.drain();
+  expect(actions).toEqual(["send:null"]);
 });
 
 test("a stale steer never retries as a fresh turn after the host becomes idle", async () => {

--- a/src/lib/runtime/structuredDeliveryQueue.ts
+++ b/src/lib/runtime/structuredDeliveryQueue.ts
@@ -1,4 +1,4 @@
-import type { EngineHost, QueueEntry } from "./engineHost";
+import type { DeliveryReceipt, EngineHost, QueueEntry } from "./engineHost";
 import type { RuntimeHostClient } from "./client";
 
 export interface StructuredDeliveryEffect {
@@ -22,6 +22,7 @@ export interface StructuredDeliveryQueuePort {
 export type StructuredHostResolver = (conversationId: string) => EngineHost | null;
 
 const STRUCTURED_DELIVERY_BATCH_SIZE = 100;
+const THREAD_READ_ATTEMPTS = 2;
 
 export function runtimeClientDeliveryPort(client: RuntimeHostClient): StructuredDeliveryQueuePort {
   return {
@@ -37,7 +38,7 @@ interface SendEffect {
   conversationId: string;
   text: string;
   turnId?: string | null;
-  policy?: "queue" | "steer-if-active";
+  policy?: "queue" | "steer-if-active" | "interrupt-active";
   kind: "send" | "steer";
   hasImages: boolean;
   eventSeq: number;
@@ -68,7 +69,9 @@ function sendEffect(effect: StructuredDeliveryEffect): SendEffect | null {
   const turnId = typeof effect.payload.turnId === "string" || effect.payload.turnId === null
     ? effect.payload.turnId
     : undefined;
-  const policy = effect.payload.policy === "queue" || effect.payload.policy === "steer-if-active"
+  const policy = effect.payload.policy === "queue"
+    || effect.payload.policy === "steer-if-active"
+    || effect.payload.policy === "interrupt-active"
     ? effect.payload.policy
     : undefined;
   return {
@@ -108,13 +111,30 @@ function failureReason(error: unknown): string {
   return (message.trim() || "structured host delivery failed").slice(0, 240);
 }
 
+function isThreadReadTimeout(error: unknown): boolean {
+  return /thread\/read.*timed out|request timed out:\s*thread\/read/i.test(failureReason(error));
+}
+
+async function sendWithReadRetry(host: EngineHost, entry: QueueEntry): Promise<DeliveryReceipt> {
+  for (let attempt = 1; attempt <= THREAD_READ_ATTEMPTS; attempt += 1) {
+    try {
+      return await host.send(entry);
+    } catch (error) {
+      if (attempt === THREAD_READ_ATTEMPTS || !isThreadReadTimeout(error)) throw error;
+    }
+  }
+  throw new Error("structured delivery retry budget exhausted");
+}
+
 export class StructuredDeliveryQueue {
   private activeDrain: Promise<void> | null = null;
   private rerun = false;
+  private readonly interruptAcknowledged = new Set<string>();
 
   constructor(
     private readonly port: StructuredDeliveryQueuePort,
     private readonly resolveHost: StructuredHostResolver,
+    private readonly retrySoon: () => void = () => {},
   ) {}
 
   drain(): Promise<void> {
@@ -193,26 +213,72 @@ export class StructuredDeliveryQueue {
       }
       const maySteer = health.status === "active"
         && (effect.kind === "steer" || effect.policy === "steer-if-active");
-      if (health.status !== "idle" && !maySteer) return true;
-      const expectedTurnId = effect.turnId !== undefined ? effect.turnId : health.activeTurnRef;
+      const replacementIsActive = effect.policy === "interrupt-active"
+        && (health.status === "active" || health.status === "attention")
+        && Boolean(health.activeTurnRef);
+      const shouldInterrupt = replacementIsActive
+        && (effect.turnId === undefined || effect.turnId === health.activeTurnRef)
+        && !this.interruptAcknowledged.has(effect.operationId);
+      if (health.status !== "idle" && !maySteer && !shouldInterrupt) return true;
+      if (health.status === "idle") this.interruptAcknowledged.delete(effect.operationId);
+      const deliveryFence = shouldInterrupt
+        ? effect.turnId ?? health.activeTurnRef
+        : effect.policy === "interrupt-active"
+          ? effect.turnId ?? null
+          : effect.turnId !== undefined
+            ? effect.turnId
+            : health.activeTurnRef;
       const entry: QueueEntry = {
         id: effect.operationId,
         text: effect.text,
-        expectedTurnId,
+        expectedTurnId: effect.policy === "interrupt-active" ? null : deliveryFence,
       };
       await this.port.transition(
         effect.operationId,
         "delivering",
-        { turnId: entry.expectedTurnId },
+        { turnId: deliveryFence },
       );
+      if (shouldInterrupt) {
+        try {
+          await host.interrupt(health.activeTurnRef!);
+          this.interruptAcknowledged.add(effect.operationId);
+        } catch (error) {
+          this.interruptAcknowledged.delete(effect.operationId);
+          const reason = failureReason(error);
+          const afterFailure = await host.health().catch(() => null);
+          if (!afterFailure || afterFailure.status === "dead" || afterFailure.status === "unhosted") {
+            await this.port.transition(effect.operationId, "queued", { reason });
+            return true;
+          }
+          await this.port.transition(effect.operationId, "queued", { reason: "interrupt-auto-retry" });
+          this.retrySoon();
+          return true;
+        }
+        const afterInterrupt = await host.health();
+        if (afterInterrupt.status === "dead" || afterInterrupt.status === "unhosted") {
+          this.interruptAcknowledged.delete(effect.operationId);
+          await this.port.transition(effect.operationId, "queued", { reason: "dead-host" });
+          return true;
+        }
+        if (afterInterrupt.status !== "idle") {
+          await this.port.transition(effect.operationId, "queued", { reason: "interrupt-requested" });
+          return true;
+        }
+        this.interruptAcknowledged.delete(effect.operationId);
+      }
       let receipt;
       try {
-        receipt = await host.send(entry);
+        receipt = await sendWithReadRetry(host, entry);
       } catch (error) {
         const reason = failureReason(error);
         const afterFailure = await host.health().catch(() => null);
         if (!afterFailure || afterFailure.status === "dead" || afterFailure.status === "unhosted") {
           await this.port.transition(effect.operationId, "queued", { reason });
+          return true;
+        }
+        if (isThreadReadTimeout(error)) {
+          await this.port.transition(effect.operationId, "queued", { reason: "delivery-auto-retry" });
+          this.retrySoon();
           return true;
         }
         await this.port.transition(effect.operationId, "failed", { reason });

--- a/src/lib/runtime/structuredMessageDelivery.test.ts
+++ b/src/lib/runtime/structuredMessageDelivery.test.ts
@@ -253,7 +253,12 @@ test("structured message routing returns the durable queued receipt immediately"
     { enabled: () => true, client: () => client, registry: () => registry, kick: () => { kicked += 1; } },
   );
 
-  expect(command).toMatchObject({ conversationId: conversation.id, text: "hello", idempotencyKey: "message-one", policy: "queue" });
+  expect(command).toMatchObject({
+    conversationId: conversation.id,
+    text: "hello",
+    idempotencyKey: "message-one",
+    policy: "interrupt-active",
+  });
   expect(result).toMatchObject({ ok: true, structured: true, outcome: "queued", operationId: "op-one" });
   expect(kicked).toBe(1);
   expect(registry.pendingDeliveries(conversation.id)).toMatchObject([{
@@ -306,7 +311,7 @@ test("migration-held delivery settles through the runtime journal after EngineHo
     conversationId: conversation.id,
     idempotencyKey: "held-message-one",
     text: "after migration",
-    policy: "queue",
+    policy: "interrupt-active",
   });
   expect(outcome).toBe("delivered");
 });

--- a/src/lib/runtime/structuredMessageDelivery.ts
+++ b/src/lib/runtime/structuredMessageDelivery.ts
@@ -15,7 +15,7 @@ export interface StructuredMessageRequest {
   clientMessageId?: string | null;
   operationId?: string;
   kind?: "send" | "steer";
-  policy?: "queue" | "steer-if-active";
+  policy?: "queue" | "steer-if-active" | "interrupt-active";
   turnId?: string | null;
   text: string;
   hasImages: boolean;
@@ -112,7 +112,7 @@ export async function deliverHeldStructuredMessage(
       conversationId: request.conversationId,
       idempotencyKey: request.clientMessageId,
       text: request.text,
-      policy: "queue",
+      policy: "interrupt-active",
     });
     try {
       await (dependencies.kick ?? kickStructuredDeliveryQueue)();
@@ -190,7 +190,7 @@ export async function enqueueStructuredMessage(
       conversationId: conversation.id,
       idempotencyKey,
       text: request.text,
-      policy: request.policy ?? "queue",
+      policy: request.policy ?? "interrupt-active",
       ...(request.turnId !== undefined ? { turnId: request.turnId } : {}),
     });
     const receipt = result.receipt;


### PR DESCRIPTION
## Summary

- interrupt the current structured-host turn before dispatching a composer message as a fresh user turn
- retry slow Codex thread reads within a bounded drain and schedule automatic delivery recovery
- persist explicit Codex structured-user provenance so reserved-looking prompts keep the user role
- show localized busy automatic-retry feedback while transport strings stay hidden
- show queued sends as quiet optimistic transcript bubbles

## Verification

- `bunx tsc --noEmit`
- `bun test`: 2742 pass, 0 fail, 14475 assertions
- focused parser, Codex host, composer, and structured delivery queue suites
- `git diff --check`

Closes #254