### PR TITLE
Scan index: stale-while-revalidate, incremental rescan, persistent warm start (#261)

### DIFF
--- a/src/app/api/account-migration-get-purity.test.ts
+++ b/src/app/api/account-migration-get-purity.test.ts
@@ -12,7 +12,7 @@ const { buildFilesResponse } = await import("@/app/api/files/response");
 const registry = new AgentRegistry(path.join(root, "registry.json"));
 registry.beginSpawn("codex", "/repo");
 const getFiles = (request: Request) => buildFilesResponse(request, {
-  listFilesWithProjectCatalog: async () => ({ files: [], projectCatalog: [] }),
+  listFilesWithProjectCatalog: async () => ({ files: [], projectCatalog: [], complete: true }),
 });
 
 function stateBytes(): Record<string, string> {

--- a/src/app/api/files/route.test.ts
+++ b/src/app/api/files/route.test.ts
@@ -17,6 +17,7 @@ let scanProjects: Array<string | undefined> = [];
 let scannedFiles: FileEntry[] = [];
 let scanFileResults: FileEntry[][] = [];
 let scanPinOverlayResults: Array<string[] | undefined> = [];
+let scanCompleteResults: Array<boolean | undefined> = [];
 let scanGates: Promise<void>[] = [];
 let registryRoot = "";
 let tmuxHealth: unknown = { status: "healthy" };
@@ -36,6 +37,7 @@ beforeEach(() => {
   scannedFiles = [];
   scanFileResults = [];
   scanPinOverlayResults = [];
+  scanCompleteResults = [];
   scanGates = [];
   tmuxHealth = { status: "healthy" };
   replaceConversationCatalog([]);
@@ -78,7 +80,8 @@ mock.module("@/lib/scanner", () => ({
     const files = scanFileResults.shift() ?? scannedFiles;
     await scanGates.shift();
     const pinOverlayPaths = scanPinOverlayResults.shift();
-    return { files, projectCatalog: [], ...(pinOverlayPaths ? { pinOverlayPaths } : {}) };
+    const complete = scanCompleteResults.shift();
+    return { files, projectCatalog: [], ...(pinOverlayPaths ? { pinOverlayPaths } : {}), ...(complete === false ? { complete } : {}) };
   },
 }));
 let pipelinesStore: () => unknown[] = () => [];
@@ -274,8 +277,10 @@ test("snapshot publication failures preserve the canonical file, clean temps, st
     expect(fs.readFileSync(snapshotPath, "utf8")).toBe(canonical);
     expect(tempFiles()).toEqual([]);
     expect(diagnostics).toEqual([
-      expect.stringContaining("files scan snapshot publication failed"),
+      expect.stringContaining("write temporary snapshot failed"),
     ]);
+    expect(diagnostics[0]).toContain("injected snapshot write failure");
+    expect(diagnostics[0]).toContain(".files-scan-snapshot.json.");
   } finally {
     fs.writeFileSync = originalWrite;
     fs.renameSync = originalRename;
@@ -304,6 +309,24 @@ test("an expired snapshot returns stale data while one shared refresh runs", asy
   await new Promise<void>((resolve) => setImmediate(resolve));
   const next = await cachedFileScan();
   expect(next.snapshot.files.map((entry) => entry.path)).toEqual(["/sessions/project-b.jsonl"]);
+});
+
+test("an incomplete filesystem scan retains the last completed route snapshot until recovery", async () => {
+  scannedFiles = [file("/sessions/canonical.jsonl")];
+  await cachedFileScan();
+  scanFileResults = [[file("/sessions/partial.jsonl")]];
+  scanCompleteResults = [false];
+
+  const stale = await cachedFileScan(undefined, undefined, Number.MAX_SAFE_INTEGER);
+  expect(stale.snapshot.files.map((entry) => entry.path)).toEqual(["/sessions/canonical.jsonl"]);
+  await new Promise<void>((resolve) => setImmediate(resolve));
+  expect((await cachedFileScan()).snapshot.files.map((entry) => entry.path)).toEqual(["/sessions/canonical.jsonl"]);
+
+  scanFileResults = [[file("/sessions/recovered.jsonl")]];
+  const recovered = await cachedFileScan(undefined, undefined, Number.MAX_SAFE_INTEGER);
+  expect(recovered.snapshot.files.map((entry) => entry.path)).toEqual(["/sessions/canonical.jsonl"]);
+  await new Promise<void>((resolve) => setImmediate(resolve));
+  expect((await cachedFileScan()).snapshot.files.map((entry) => entry.path)).toEqual(["/sessions/recovered.jsonl"]);
 });
 
 test("concurrent reads during a blocked refresh share one scan and return within 300ms", async () => {
@@ -461,6 +484,33 @@ test("a pinned client receives stale data immediately then converges on its comp
   ]);
   expect(updates.at(-1)).toEqual(["/sessions/after-revision.jsonl", pinnedPath]);
   expect(scans).toBe(2);
+  unsubscribe();
+});
+
+test("a warm global-only incomplete response retains an out-of-cap pin until its target generation completes", async () => {
+  const global = file("/sessions/global.jsonl");
+  const pinnedPath = "/archive/warm-pinned.jsonl";
+  scanFileResults = [[global, file(pinnedPath)]];
+  scanPinOverlayResults = [[pinnedPath]];
+  const cache = createFilesClientCache((input, init) => GET(new Request(`http://127.0.0.1${input}`, init)));
+  const unsubscribe = cache.subscribe(() => {}, pinnedPath);
+  await cache.revalidate(pinnedPath);
+  expect(cache.read().files.some((entry) => entry.path === pinnedPath)).toBe(true);
+
+  resetFilesRouteCacheForTests();
+  let release!: () => void;
+  scanGates.push(new Promise<void>((resolve) => { release = resolve; }));
+  scanFileResults = [[file("/sessions/warm-global.jsonl")], [file("/sessions/completed-global.jsonl"), file(pinnedPath)]];
+  scanPinOverlayResults = [undefined, [pinnedPath]];
+  await cachedFileScan();
+  const stale = await cache.revalidate(pinnedPath, 91);
+  expect(stale.files.some((entry) => entry.path === pinnedPath)).toBe(true);
+
+  release();
+  for (let attempt = 0; attempt < 100 && cache.read().files[0]?.path !== "/sessions/completed-global.jsonl"; attempt += 1) {
+    await Bun.sleep(10);
+  }
+  expect(cache.read().files.map((entry) => entry.path)).toEqual(["/sessions/completed-global.jsonl", pinnedPath]);
   unsubscribe();
 });
 

--- a/src/app/api/files/route.test.ts
+++ b/src/app/api/files/route.test.ts
@@ -81,7 +81,7 @@ mock.module("@/lib/scanner", () => ({
     await scanGates.shift();
     const pinOverlayPaths = scanPinOverlayResults.shift();
     const complete = scanCompleteResults.shift();
-    return { files, projectCatalog: [], ...(pinOverlayPaths ? { pinOverlayPaths } : {}), ...(complete === false ? { complete } : {}) };
+    return { files, projectCatalog: [], ...(pinOverlayPaths ? { pinOverlayPaths } : {}), complete: complete ?? true };
   },
 }));
 let pipelinesStore: () => unknown[] = () => [];
@@ -147,6 +147,7 @@ test("a restart serves the persisted completed snapshot while revalidating", asy
   const persistedSnapshot = {
     files: [file("/sessions/persisted.jsonl")],
     projectCatalog: [],
+    complete: true,
   };
   fs.writeFileSync(path.join(stateDir, "files-scan-snapshot.json"), JSON.stringify({
     version: 1,
@@ -171,6 +172,7 @@ test("a client automatically converges from a persisted restart snapshot to its 
     snapshot: {
       files: [file("/sessions/persisted-client.jsonl")],
       projectCatalog: [],
+      complete: true,
     },
   }));
   resetFilesRouteCacheForTests();
@@ -202,7 +204,7 @@ test("a restart hydrates a persisted 7700-row snapshot within two seconds", asyn
   const files = Array.from({ length: 7_700 }, (_, index) => file(`/sessions/persisted-${index}.jsonl`));
   fs.writeFileSync(path.join(stateDir, "files-scan-snapshot.json"), JSON.stringify({
     version: 1,
-    snapshot: { files, projectCatalog: [] },
+    snapshot: { files, projectCatalog: [], complete: true },
   }));
   resetFilesRouteCacheForTests();
 
@@ -234,6 +236,7 @@ test("snapshot publication failures preserve the canonical file, clean temps, st
     snapshot: {
       files: [file("/sessions/canonical.jsonl")],
       projectCatalog: [],
+      complete: true,
     },
   });
   fs.writeFileSync(snapshotPath, canonical);
@@ -564,6 +567,7 @@ test("a persisted legacy cache slot serves stale data during fresh hydration", a
   const legacySnapshot = {
     files: [file("/sessions/sentinel-stale.jsonl")],
     projectCatalog: [],
+    complete: true,
   };
   const cacheStore = globalThis as typeof globalThis & {
     __llvFilesRouteScans?: Map<string, unknown>;

--- a/src/app/api/files/route.test.ts
+++ b/src/app/api/files/route.test.ts
@@ -9,6 +9,7 @@ import { agentRegistry, AgentRegistry, setAgentRegistryForTests } from "@/lib/ag
 import { replaceConversationCatalog } from "@/lib/scanner/conversationCatalog";
 import { writeSessionTitle } from "@/lib/session/titleStore";
 import type { FileEntry } from "@/lib/types";
+import { createFilesClientCache } from "@/hooks/useFiles";
 
 let scans = 0;
 let scanOptions: unknown;
@@ -161,6 +162,39 @@ test("a restart serves the persisted completed snapshot while revalidating", asy
   expect(next.snapshot.files.map((entry) => entry.path)).toEqual(["/sessions/refreshed.jsonl"]);
 });
 
+test("a client automatically converges from a persisted restart snapshot to its completed generation", async () => {
+  fs.writeFileSync(path.join(stateDir, "files-scan-snapshot.json"), JSON.stringify({
+    version: 1,
+    snapshot: {
+      files: [file("/sessions/persisted-client.jsonl")],
+      projectCatalog: [],
+    },
+  }));
+  resetFilesRouteCacheForTests();
+  let release!: () => void;
+  scanGates.push(new Promise<void>((resolve) => { release = resolve; }));
+  scannedFiles = [file("/sessions/refreshed-client.jsonl")];
+  const cache = createFilesClientCache((input, init) =>
+    GET(new Request(`http://127.0.0.1${input}`, init)));
+  const unsubscribe = cache.subscribe(() => {});
+
+  const started = performance.now();
+  const stale = await cache.revalidate();
+
+  expect(performance.now() - started).toBeLessThan(300);
+  expect(stale.files.map((entry) => entry.path)).toEqual(["/sessions/persisted-client.jsonl"]);
+  expect(scans).toBe(1);
+
+  release();
+  for (let attempt = 0; attempt < 100 && cache.read().files[0]?.path !== "/sessions/refreshed-client.jsonl"; attempt += 1) {
+    await Bun.sleep(10);
+  }
+
+  expect(cache.read().files.map((entry) => entry.path)).toEqual(["/sessions/refreshed-client.jsonl"]);
+  expect(scans).toBe(1);
+  unsubscribe();
+});
+
 test("a restart hydrates a persisted 7700-row snapshot within two seconds", async () => {
   const files = Array.from({ length: 7_700 }, (_, index) => file(`/sessions/persisted-${index}.jsonl`));
   fs.writeFileSync(path.join(stateDir, "files-scan-snapshot.json"), JSON.stringify({
@@ -279,6 +313,34 @@ test("pinned response projection cannot mutate the shared global scan rows", asy
   expect(ordinaryBody.files.find((entry) => entry.path === sharedPath)?.conversationId).toBeUndefined();
 });
 
+test("unique pinned snapshots use bounded LRU retention while recent pins stay warm", async () => {
+  const global = file("/sessions/global.jsonl");
+  scannedFiles = [global];
+  await cachedFileScan();
+  const now = Date.now();
+  const pins = Array.from({ length: 9 }, (_, index) => `/archive/pin-${index}.jsonl`);
+
+  for (const pinnedPath of pins) {
+    scanFileResults = [[global, file(pinnedPath)]];
+    scanPinOverlayResults = [[pinnedPath]];
+    await cachedFileScan(undefined, pinnedPath, now);
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    const hydrated = await cachedFileScan(undefined, pinnedPath, now);
+    expect(hydrated.snapshot.files.some((entry) => entry.path === pinnedPath)).toBe(true);
+  }
+
+  expect(scans).toBe(10);
+  await cachedFileScan(undefined, pins.at(-1), now);
+  expect(scans).toBe(10);
+
+  scanFileResults = [[global, file(pins[0]!)]];
+  scanPinOverlayResults = [[pins[0]!]];
+  const evicted = await cachedFileScan(undefined, pins[0], now);
+  expect(evicted.snapshot.files.map((entry) => entry.path)).toEqual([global.path]);
+  expect(scans).toBe(11);
+  await new Promise<void>((resolve) => setImmediate(resolve));
+});
+
 test("a files revision request returns stale data and schedules a refresh", async () => {
   scannedFiles = [file("/sessions/before-revision.jsonl")];
   await GET(new Request("http://127.0.0.1/api/files"));
@@ -295,6 +357,43 @@ test("a files revision request returns stale data and schedules a refresh", asyn
   await new Promise<void>((resolve) => setImmediate(resolve));
   const next = await GET(new Request("http://127.0.0.1/api/files"));
   expect((await next.json()).files.map((entry: FileEntry) => entry.path)).toEqual(["/sessions/after-revision.jsonl"]);
+});
+
+test("a pinned client receives stale data immediately then converges on its completed revision generation", async () => {
+  scannedFiles = [file("/sessions/before-revision.jsonl")];
+  await GET(new Request("http://127.0.0.1/api/files"));
+
+  const pinnedPath = "/archive/pinned-revision.jsonl";
+  let release!: () => void;
+  scanGates.push(new Promise<void>((resolve) => { release = resolve; }));
+  scanFileResults = [[file("/sessions/after-revision.jsonl"), file(pinnedPath)]];
+  scanPinOverlayResults = [[pinnedPath]];
+  const cache = createFilesClientCache((input, init) =>
+    GET(new Request(`http://127.0.0.1${input}`, init)));
+  const updates: string[][] = [];
+  const unsubscribe = cache.subscribe((data) => {
+    updates.push(data.files.map((entry) => entry.path));
+  }, pinnedPath);
+
+  const started = performance.now();
+  const stale = await cache.revalidate(pinnedPath, 17);
+
+  expect(performance.now() - started).toBeLessThan(300);
+  expect(stale.files.map((entry) => entry.path)).toEqual(["/sessions/before-revision.jsonl"]);
+  expect(scans).toBe(2);
+
+  release();
+  for (let attempt = 0; attempt < 100 && !cache.read().files.some((entry) => entry.path === pinnedPath); attempt += 1) {
+    await Bun.sleep(10);
+  }
+
+  expect(cache.read().files.map((entry) => entry.path)).toEqual([
+    "/sessions/after-revision.jsonl",
+    pinnedPath,
+  ]);
+  expect(updates.at(-1)).toEqual(["/sessions/after-revision.jsonl", pinnedPath]);
+  expect(scans).toBe(2);
+  unsubscribe();
 });
 
 test("concurrent requests for one files revision share one forced scan", async () => {
@@ -386,6 +485,19 @@ test("an arbitrary client revision cannot suppress a later background refresh", 
   await new Promise<void>((resolve) => setImmediate(resolve));
   const next = await GET(new Request("http://127.0.0.1/api/files"));
   expect((await next.json()).files.map((entry: FileEntry) => entry.path)).toEqual(["/sessions/genuine-revision.jsonl"]);
+});
+
+test("a client generation above the issued watermark cannot advance the server counter", async () => {
+  scannedFiles = [file("/sessions/issued-generation.jsonl")];
+  await GET(new Request("http://127.0.0.1/api/files"));
+
+  const response = await GET(new Request("http://127.0.0.1/api/files", {
+    headers: { "x-llv-files-generation": String(Number.MAX_SAFE_INTEGER) },
+  }));
+
+  expect(response.headers.get("x-llv-files-generation")).toBe("1");
+  expect(response.headers.get("x-llv-files-target-generation")).toBe("1");
+  expect(scans).toBe(1);
 });
 
 test("project query changes reuse one global scan snapshot", async () => {

--- a/src/app/api/files/route.test.ts
+++ b/src/app/api/files/route.test.ts
@@ -224,6 +224,74 @@ test("a corrupt completed snapshot falls back to a cold scan and repairs persist
   expect(persisted.version).toBe(1);
 });
 
+test("snapshot publication failures preserve the canonical file, clean temps, stay non-fatal, and recover", async () => {
+  const snapshotPath = path.join(stateDir, "files-scan-snapshot.json");
+  const canonical = JSON.stringify({
+    version: 1,
+    snapshot: {
+      files: [file("/sessions/canonical.jsonl")],
+      projectCatalog: [],
+    },
+  });
+  fs.writeFileSync(snapshotPath, canonical);
+  const originalWrite = fs.writeFileSync;
+  const originalRename = fs.renameSync;
+  const originalError = console.error;
+  const diagnostics: string[] = [];
+  let failure: "write" | "rename" | null = null;
+  fs.writeFileSync = ((filename: fs.PathOrFileDescriptor, data: string | NodeJS.ArrayBufferView, options?: fs.WriteFileOptions) => {
+    const result = originalWrite(filename, data, options);
+    if (failure === "write" && String(filename).includes(".files-scan-snapshot.json.")) {
+      throw new Error("injected snapshot write failure");
+    }
+    return result;
+  }) as typeof fs.writeFileSync;
+  fs.renameSync = ((source: fs.PathLike, target: fs.PathLike) => {
+    if (failure === "rename" && target === snapshotPath) {
+      throw new Error("injected snapshot rename failure");
+    }
+    return originalRename(source, target);
+  }) as typeof fs.renameSync;
+  console.error = (...values: unknown[]) => { diagnostics.push(values.map(String).join(" ")); };
+  const tempFiles = () => fs.readdirSync(stateDir)
+    .filter((name) => name.startsWith(".files-scan-snapshot.json.") && name.endsWith(".tmp"));
+  const attempt = async (mode: "write" | "rename", freshPath: string) => {
+    failure = mode;
+    resetFilesRouteCacheForTests();
+    scannedFiles = [file(freshPath)];
+    const response = await GET(new Request("http://127.0.0.1/api/files"));
+    expect(response.status).toBe(200);
+    expect((await response.json()).files.map((entry: FileEntry) => entry.path)).toEqual(["/sessions/canonical.jsonl"]);
+    await new Promise<void>((resolve) => setImmediate(resolve));
+  };
+
+  try {
+    await attempt("write", "/sessions/write-failed.jsonl");
+    expect(fs.readFileSync(snapshotPath, "utf8")).toBe(canonical);
+    expect(tempFiles()).toEqual([]);
+
+    await attempt("rename", "/sessions/rename-failed.jsonl");
+    expect(fs.readFileSync(snapshotPath, "utf8")).toBe(canonical);
+    expect(tempFiles()).toEqual([]);
+    expect(diagnostics).toEqual([
+      expect.stringContaining("files scan snapshot publication failed"),
+    ]);
+  } finally {
+    fs.writeFileSync = originalWrite;
+    fs.renameSync = originalRename;
+    console.error = originalError;
+  }
+
+  resetFilesRouteCacheForTests();
+  scannedFiles = [file("/sessions/recovered.jsonl")];
+  const recovery = await GET(new Request("http://127.0.0.1/api/files"));
+  expect(recovery.status).toBe(200);
+  await new Promise<void>((resolve) => setImmediate(resolve));
+  expect(JSON.parse(fs.readFileSync(snapshotPath, "utf8")).snapshot.files.map((entry: FileEntry) => entry.path))
+    .toEqual(["/sessions/recovered.jsonl"]);
+  expect(tempFiles()).toEqual([]);
+});
+
 test("an expired snapshot returns stale data while one shared refresh runs", async () => {
   scannedFiles = [file("/sessions/project-a.jsonl")];
   await cachedFileScan();

--- a/src/app/api/files/route.test.ts
+++ b/src/app/api/files/route.test.ts
@@ -229,6 +229,44 @@ test("a corrupt completed snapshot falls back to a cold scan and repairs persist
   expect(persisted.version).toBe(1);
 });
 
+test("snapshot persistence creates private state and replaces permissive files as 0600", async () => {
+  const privateStateDir = path.join(stateDir, "private-snapshot-state");
+  const snapshotPath = path.join(privateStateDir, "files-scan-snapshot.json");
+  const originalRename = fs.renameSync;
+  const previousUmask = process.umask(0);
+  const temporaryModes: number[] = [];
+  process.env.LLV_STATE_DIR = privateStateDir;
+  fs.renameSync = ((source: fs.PathLike, target: fs.PathLike) => {
+    if (target === snapshotPath) temporaryModes.push(fs.statSync(source).mode & 0o777);
+    return originalRename(source, target);
+  }) as typeof fs.renameSync;
+
+  try {
+    resetFilesRouteCacheForTests();
+    scannedFiles = [file("/sessions/private-initial.jsonl")];
+    await cachedFileScan();
+
+    expect(fs.statSync(privateStateDir).mode & 0o777).toBe(0o700);
+    expect(temporaryModes).toEqual([0o600]);
+    expect(fs.statSync(snapshotPath).mode & 0o777).toBe(0o600);
+
+    fs.chmodSync(snapshotPath, 0o666);
+    scannedFiles = [file("/sessions/private-replacement.jsonl")];
+    await cachedFileScan(undefined, undefined, Date.now(), Number.MAX_SAFE_INTEGER);
+    await new Promise<void>((resolve) => setImmediate(resolve));
+
+    expect(temporaryModes).toEqual([0o600, 0o600]);
+    expect(fs.statSync(snapshotPath).mode & 0o777).toBe(0o600);
+    expect(JSON.parse(fs.readFileSync(snapshotPath, "utf8")).snapshot.files.map((entry: FileEntry) => entry.path))
+      .toEqual(["/sessions/private-replacement.jsonl"]);
+  } finally {
+    fs.renameSync = originalRename;
+    process.umask(previousUmask);
+    process.env.LLV_STATE_DIR = stateDir;
+    resetFilesRouteCacheForTests();
+  }
+});
+
 test("snapshot publication failures preserve the canonical file, clean temps, stay non-fatal, and recover", async () => {
   const snapshotPath = path.join(stateDir, "files-scan-snapshot.json");
   const canonical = JSON.stringify({

--- a/src/app/api/files/route.test.ts
+++ b/src/app/api/files/route.test.ts
@@ -15,6 +15,7 @@ let scanOptions: unknown;
 let scanProjects: Array<string | undefined> = [];
 let scannedFiles: FileEntry[] = [];
 let scanFileResults: FileEntry[][] = [];
+let scanPinOverlayResults: Array<string[] | undefined> = [];
 let scanGates: Promise<void>[] = [];
 let registryRoot = "";
 let tmuxHealth: unknown = { status: "healthy" };
@@ -33,6 +34,7 @@ beforeEach(() => {
   scanProjects = [];
   scannedFiles = [];
   scanFileResults = [];
+  scanPinOverlayResults = [];
   scanGates = [];
   tmuxHealth = { status: "healthy" };
   replaceConversationCatalog([]);
@@ -74,7 +76,8 @@ mock.module("@/lib/scanner", () => ({
     scanOptions = options;
     const files = scanFileResults.shift() ?? scannedFiles;
     await scanGates.shift();
-    return { files, projectCatalog: [] };
+    const pinOverlayPaths = scanPinOverlayResults.shift();
+    return { files, projectCatalog: [], ...(pinOverlayPaths ? { pinOverlayPaths } : {}) };
   },
 }));
 let pipelinesStore: () => unknown[] = () => [];
@@ -105,7 +108,7 @@ test("repeated files reads reuse the pure read snapshot and retain ETag behavior
   expect(await first.json()).toEqual({ files: [], projectCatalog: [], flows: [], pipelines: [], workflows: [], tasks: [], systemHealth: { tmux: { status: "healthy" } }, conversationAliases: {} });
   expect(second.status).toBe(304);
   expect(scans).toBe(1);
-  expect(scanOptions).toEqual({ persist: false });
+  expect(scanOptions).toEqual({ persist: false, persistIndex: true });
 });
 
 test("files API surfaces degraded tmux endpoint health", async () => {
@@ -136,17 +139,94 @@ test("concurrent cold files reads share one scan", async () => {
   expect(scans).toBe(1);
 });
 
-test("an expired snapshot returns the shared fresh scan to the revalidating client", async () => {
+test("a restart serves the persisted completed snapshot while revalidating", async () => {
+  const persistedSnapshot = {
+    files: [file("/sessions/persisted.jsonl")],
+    projectCatalog: [],
+  };
+  fs.writeFileSync(path.join(stateDir, "files-scan-snapshot.json"), JSON.stringify({
+    version: 1,
+    snapshot: persistedSnapshot,
+  }));
+  resetFilesRouteCacheForTests();
+  scannedFiles = [file("/sessions/refreshed.jsonl")];
+
+  const restarted = await cachedFileScan();
+
+  expect(restarted.snapshot.files.map((entry) => entry.path)).toEqual(["/sessions/persisted.jsonl"]);
+  expect(scans).toBe(1);
+
+  await new Promise<void>((resolve) => setImmediate(resolve));
+  const next = await cachedFileScan();
+  expect(next.snapshot.files.map((entry) => entry.path)).toEqual(["/sessions/refreshed.jsonl"]);
+});
+
+test("a restart hydrates a persisted 7700-row snapshot within two seconds", async () => {
+  const files = Array.from({ length: 7_700 }, (_, index) => file(`/sessions/persisted-${index}.jsonl`));
+  fs.writeFileSync(path.join(stateDir, "files-scan-snapshot.json"), JSON.stringify({
+    version: 1,
+    snapshot: { files, projectCatalog: [] },
+  }));
+  resetFilesRouteCacheForTests();
+
+  const started = performance.now();
+  const restarted = await cachedFileScan();
+
+  expect(performance.now() - started).toBeLessThan(2_000);
+  expect(restarted.snapshot.files).toHaveLength(7_700);
+  await new Promise<void>((resolve) => setImmediate(resolve));
+});
+
+test("a corrupt completed snapshot falls back to a cold scan and repairs persistence", async () => {
+  fs.writeFileSync(path.join(stateDir, "files-scan-snapshot.json"), "{ corrupt");
+  resetFilesRouteCacheForTests();
+  scannedFiles = [file("/sessions/cold-fallback.jsonl")];
+
+  const recovered = await cachedFileScan();
+
+  expect(recovered.snapshot.files.map((entry) => entry.path)).toEqual(["/sessions/cold-fallback.jsonl"]);
+  expect(scans).toBe(1);
+  const persisted = JSON.parse(fs.readFileSync(path.join(stateDir, "files-scan-snapshot.json"), "utf8"));
+  expect(persisted.version).toBe(1);
+});
+
+test("an expired snapshot returns stale data while one shared refresh runs", async () => {
   scannedFiles = [file("/sessions/project-a.jsonl")];
   await cachedFileScan();
   scannedFiles = [file("/sessions/project-b.jsonl")];
   const refreshed = await cachedFileScan(undefined, undefined, Number.MAX_SAFE_INTEGER);
 
-  expect(refreshed.snapshot.files.map((entry) => entry.path)).toEqual(["/sessions/project-b.jsonl"]);
+  expect(refreshed.snapshot.files.map((entry) => entry.path)).toEqual(["/sessions/project-a.jsonl"]);
   expect(scans).toBe(2);
+
+  await new Promise<void>((resolve) => setImmediate(resolve));
+  const next = await cachedFileScan();
+  expect(next.snapshot.files.map((entry) => entry.path)).toEqual(["/sessions/project-b.jsonl"]);
 });
 
-test("a pinned refresh advances the shared global slot and identifies every pin-only row", async () => {
+test("concurrent reads during a blocked refresh share one scan and return within 300ms", async () => {
+  scannedFiles = [file("/sessions/complete.jsonl")];
+  await cachedFileScan();
+  let release!: () => void;
+  scanGates.push(new Promise<void>((resolve) => { release = resolve; }));
+  scannedFiles = [file("/sessions/in-flight.jsonl")];
+
+  const started = performance.now();
+  const [first, second] = await Promise.all([
+    cachedFileScan(undefined, undefined, Number.MAX_SAFE_INTEGER),
+    cachedFileScan(undefined, undefined, Number.MAX_SAFE_INTEGER),
+  ]);
+
+  expect(performance.now() - started).toBeLessThan(300);
+  expect(first.snapshot.files.map((entry) => entry.path)).toEqual(["/sessions/complete.jsonl"]);
+  expect(second.snapshot.files.map((entry) => entry.path)).toEqual(["/sessions/complete.jsonl"]);
+  expect(scans).toBe(2);
+
+  release();
+  await new Promise<void>((resolve) => setImmediate(resolve));
+});
+
+test("a pinned refresh serves stale data then advances the shared global slot with its overlay", async () => {
   scannedFiles = [file("/sessions/old-global.jsonl")];
   await GET(new Request("http://127.0.0.1/api/files"));
 
@@ -154,10 +234,15 @@ test("a pinned refresh advances the shared global slot and identifies every pin-
   const currentPath = "/sessions/current.jsonl";
   const closurePath = "/sessions/closure-parent.jsonl";
   const freshGlobal = file("/sessions/fresh-global.jsonl");
-  scanFileResults = [
-    [freshGlobal, file(pinnedPath), file(currentPath), file(closurePath)],
-    [freshGlobal],
-  ];
+  scanFileResults = [[freshGlobal, file(pinnedPath), file(currentPath), file(closurePath)]];
+  scanPinOverlayResults = [[pinnedPath, currentPath, closurePath]];
+  const stalePinned = await GET(new Request(`http://127.0.0.1/api/files?path=${encodeURIComponent(pinnedPath)}`));
+  const staleBody = await stalePinned.json() as { files: FileEntry[]; pinOverlayPaths?: string[] };
+
+  expect(staleBody.files.map((entry) => entry.path)).toEqual(["/sessions/old-global.jsonl"]);
+  expect(staleBody.pinOverlayPaths).toBeUndefined();
+
+  await new Promise<void>((resolve) => setImmediate(resolve));
   const pinned = await GET(new Request(`http://127.0.0.1/api/files?path=${encodeURIComponent(pinnedPath)}`));
   const pinnedBody = await pinned.json() as { files: FileEntry[]; pinOverlayPaths: string[] };
 
@@ -173,7 +258,7 @@ test("a pinned refresh advances the shared global slot and identifies every pin-
   const ordinary = await GET(new Request("http://127.0.0.1/api/files"));
   const ordinaryBody = await ordinary.json() as { files: FileEntry[] };
   expect(ordinaryBody.files.map((entry) => entry.path)).toEqual([freshGlobal.path]);
-  expect(scans).toBe(3);
+  expect(scans).toBe(2);
 });
 
 test("pinned response projection cannot mutate the shared global scan rows", async () => {
@@ -181,10 +266,8 @@ test("pinned response projection cannot mutate the shared global scan rows", asy
   const pinnedPath = "/archive/pin-only-row.jsonl";
   const registry = agentRegistry();
   const conversation = registry.ensureConversation("codex", sharedPath, "source");
-  scanFileResults = [
-    [file(sharedPath), file(pinnedPath)],
-    [file(sharedPath)],
-  ];
+  scanFileResults = [[file(sharedPath), file(pinnedPath)]];
+  scanPinOverlayResults = [[pinnedPath]];
 
   const pinned = await GET(new Request(`http://127.0.0.1/api/files?path=${encodeURIComponent(pinnedPath)}`));
   const pinnedBody = await pinned.json() as { files: FileEntry[] };
@@ -196,7 +279,7 @@ test("pinned response projection cannot mutate the shared global scan rows", asy
   expect(ordinaryBody.files.find((entry) => entry.path === sharedPath)?.conversationId).toBeUndefined();
 });
 
-test("a files revision request refreshes the snapshot before responding", async () => {
+test("a files revision request returns stale data and schedules a refresh", async () => {
   scannedFiles = [file("/sessions/before-revision.jsonl")];
   await GET(new Request("http://127.0.0.1/api/files"));
 
@@ -206,8 +289,12 @@ test("a files revision request refreshes the snapshot before responding", async 
   }));
   const body = await response.json() as { files: FileEntry[] };
 
-  expect(body.files.map((entry) => entry.path)).toEqual(["/sessions/after-revision.jsonl"]);
+  expect(body.files.map((entry) => entry.path)).toEqual(["/sessions/before-revision.jsonl"]);
   expect(scans).toBe(2);
+
+  await new Promise<void>((resolve) => setImmediate(resolve));
+  const next = await GET(new Request("http://127.0.0.1/api/files"));
+  expect((await next.json()).files.map((entry: FileEntry) => entry.path)).toEqual(["/sessions/after-revision.jsonl"]);
 });
 
 test("concurrent requests for one files revision share one forced scan", async () => {
@@ -256,7 +343,7 @@ test("a newer revision waits for a follow-up scan when an older scan is in fligh
   expect(scans).toBe(2);
 });
 
-test("a persisted legacy cache slot upgrades before fresh hydration", async () => {
+test("a persisted legacy cache slot serves stale data during fresh hydration", async () => {
   const legacySnapshot = {
     files: [file("/sessions/sentinel-stale.jsonl")],
     projectCatalog: [],
@@ -273,11 +360,15 @@ test("a persisted legacy cache slot upgrades before fresh hydration", async () =
 
   const result = await cachedFileScan(undefined, undefined, Date.now(), 1);
 
-  expect(result.snapshot.files.map((entry) => entry.path)).toEqual(["/sessions/upgraded-fresh.jsonl"]);
+  expect(result.snapshot.files.map((entry) => entry.path)).toEqual(["/sessions/sentinel-stale.jsonl"]);
+
+  await new Promise<void>((resolve) => setImmediate(resolve));
   expect(scans).toBe(1);
+  const next = await cachedFileScan();
+  expect(next.snapshot.files.map((entry) => entry.path)).toEqual(["/sessions/upgraded-fresh.jsonl"]);
 });
 
-test("an arbitrary client revision cannot suppress a later revision refresh", async () => {
+test("an arbitrary client revision cannot suppress a later background refresh", async () => {
   scannedFiles = [file("/sessions/untrusted-watermark.jsonl")];
   await GET(new Request("http://127.0.0.1/api/files", {
     headers: { "x-llv-files-revision": String(Number.MAX_SAFE_INTEGER) },
@@ -289,8 +380,12 @@ test("an arbitrary client revision cannot suppress a later revision refresh", as
   }));
   const body = await response.json() as { files: FileEntry[] };
 
-  expect(body.files.map((entry) => entry.path)).toEqual(["/sessions/genuine-revision.jsonl"]);
+  expect(body.files.map((entry) => entry.path)).toEqual(["/sessions/untrusted-watermark.jsonl"]);
   expect(scans).toBe(2);
+
+  await new Promise<void>((resolve) => setImmediate(resolve));
+  const next = await GET(new Request("http://127.0.0.1/api/files"));
+  expect((await next.json()).files.map((entry: FileEntry) => entry.path)).toEqual(["/sessions/genuine-revision.jsonl"]);
 });
 
 test("project query changes reuse one global scan snapshot", async () => {
@@ -511,7 +606,8 @@ test("a lineage placeholder introduced for a pinned child stays inside the pin o
     claimOwner: null,
     pendingAction: null,
   });
-  scanFileResults = [[file(childPath)], []];
+  scanFileResults = [[file(childPath)]];
+  scanPinOverlayResults = [[childPath]];
 
   const response = await GET(new Request(`http://127.0.0.1/api/files?path=${encodeURIComponent(childPath)}`));
   const body = await response.json() as { files: FileEntry[]; pinOverlayPaths: string[] };

--- a/src/app/api/files/route.test.ts
+++ b/src/app/api/files/route.test.ts
@@ -229,6 +229,26 @@ test("a corrupt completed snapshot falls back to a cold scan and repairs persist
   expect(persisted.version).toBe(1);
 });
 
+test("repeated first-ever incomplete scans stay unpublished until recovery", async () => {
+  scanFileResults = [
+    [file("/sessions/first-partial.jsonl")],
+    [file("/sessions/second-partial.jsonl")],
+    [file("/sessions/recovered-cold.jsonl")],
+  ];
+  scanCompleteResults = [false, false, true];
+  const snapshotPath = path.join(stateDir, "files-scan-snapshot.json");
+
+  await expect(cachedFileScan()).rejects.toThrow("filesystem scan incomplete");
+  expect(fs.existsSync(snapshotPath)).toBe(false);
+  await expect(cachedFileScan()).rejects.toThrow("filesystem scan incomplete");
+  expect(fs.existsSync(snapshotPath)).toBe(false);
+
+  const recovered = await cachedFileScan();
+  expect(recovered.snapshot.files.map((entry) => entry.path)).toEqual(["/sessions/recovered-cold.jsonl"]);
+  expect(JSON.parse(fs.readFileSync(snapshotPath, "utf8")).snapshot.files.map((entry: FileEntry) => entry.path))
+    .toEqual(["/sessions/recovered-cold.jsonl"]);
+});
+
 test("snapshot persistence creates private state and replaces permissive files as 0600", async () => {
   const privateStateDir = path.join(stateDir, "private-snapshot-state");
   const snapshotPath = path.join(privateStateDir, "files-scan-snapshot.json");

--- a/src/app/api/files/route.ts
+++ b/src/app/api/files/route.ts
@@ -4,14 +4,33 @@ import { cachedFileScan } from "./scanCache";
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
+function generationHeader(request: Request, name: string): number | undefined {
+  const value = request.headers.get(name);
+  if (value === null || !/^\d+$/.test(value)) return undefined;
+  const generation = Number(value);
+  return Number.isSafeInteger(generation) ? generation : undefined;
+}
+
 export async function GET(request: Request): Promise<Response> {
-  const revision = request.headers.get("x-llv-files-revision");
-  const parsedRevision = revision !== null && /^\d+$/.test(revision) ? Number(revision) : undefined;
-  const requiredRevision = parsedRevision !== undefined && Number.isSafeInteger(parsedRevision) ? parsedRevision : undefined;
-  return buildFilesResponse(request, {
+  const requiredRevision = generationHeader(request, "x-llv-files-revision");
+  const requiredGeneration = generationHeader(request, "x-llv-files-generation");
+  let responseGeneration = 0;
+  let targetGeneration = 0;
+  const response = await buildFilesResponse(request, {
     listFilesWithProjectCatalog: async (selectedProject, pinnedPath) => {
-      const scan = await cachedFileScan(selectedProject, pinnedPath, Date.now(), requiredRevision);
+      const scan = await cachedFileScan(
+        selectedProject,
+        pinnedPath,
+        Date.now(),
+        requiredRevision,
+        requiredGeneration,
+      );
+      responseGeneration = scan.generation;
+      targetGeneration = scan.targetGeneration;
       return { ...scan.snapshot, pinOverlayPaths: scan.pinOverlayPaths };
     },
   });
+  response.headers.set("x-llv-files-generation", String(responseGeneration));
+  response.headers.set("x-llv-files-target-generation", String(targetGeneration));
+  return response;
 }

--- a/src/app/api/files/scanCache.real.test.ts
+++ b/src/app/api/files/scanCache.real.test.ts
@@ -1,0 +1,90 @@
+import { afterAll, expect, test } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const sandbox = fs.mkdtempSync(path.join(os.tmpdir(), "llv-files-real-scan-"));
+const previousStateDir = process.env.LLV_STATE_DIR;
+const previousCodexHome = process.env.LLV_CODEX_HOME;
+const previousClaudeHome = process.env.LLV_CLAUDE_HOME;
+const previousTmpdir = process.env.TMPDIR;
+process.env.LLV_STATE_DIR = path.join(sandbox, "state");
+process.env.LLV_CODEX_HOME = path.join(sandbox, "codex");
+process.env.LLV_CLAUDE_HOME = path.join(sandbox, "claude");
+process.env.TMPDIR = path.join(sandbox, "tmp");
+
+const sessions = path.join(process.env.LLV_CODEX_HOME, "sessions");
+fs.mkdirSync(sessions, { recursive: true });
+
+const { listFilesWithProjectCatalog } = await import("@/lib/scanner");
+const { cachedFileScan, resetFilesRouteCacheForTests } = await import("./scanCache");
+
+function writeSession(filename: string, cwd: string): string {
+  const pathname = path.join(sessions, filename);
+  fs.writeFileSync(pathname, `${JSON.stringify({ type: "session_meta", payload: { cwd } })}\n`, "utf8");
+  return pathname;
+}
+
+async function waitForGeneration(targetGeneration: number, expectedPath: string): Promise<void> {
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    const scan = await cachedFileScan(undefined, undefined, Date.now(), undefined, targetGeneration);
+    if (scan.generation >= targetGeneration && scan.snapshot.files.some((entry) => entry.path === expectedPath)) return;
+    await new Promise<void>((resolve) => setTimeout(resolve, 5));
+  }
+  throw new Error(`files scan did not converge to ${expectedPath}`);
+}
+
+afterAll(() => {
+  resetFilesRouteCacheForTests();
+  if (previousStateDir === undefined) delete process.env.LLV_STATE_DIR;
+  else process.env.LLV_STATE_DIR = previousStateDir;
+  if (previousCodexHome === undefined) delete process.env.LLV_CODEX_HOME;
+  else process.env.LLV_CODEX_HOME = previousCodexHome;
+  if (previousClaudeHome === undefined) delete process.env.LLV_CLAUDE_HOME;
+  else process.env.LLV_CLAUDE_HOME = previousClaudeHome;
+  if (previousTmpdir === undefined) delete process.env.TMPDIR;
+  else process.env.TMPDIR = previousTmpdir;
+  fs.rmSync(sandbox, { recursive: true, force: true });
+});
+
+test("a transient real scanner failure preserves the completed route snapshot until recovery", async () => {
+  resetFilesRouteCacheForTests();
+  const canonicalPath = writeSession("canonical.jsonl", "/repo/canonical");
+  const completed = await cachedFileScan();
+  expect(completed.snapshot.complete).toBe(true);
+  expect(completed.snapshot.files.map((entry) => entry.path)).toContain(canonicalPath);
+
+  const snapshotPath = path.join(process.env.LLV_STATE_DIR!, "files-scan-snapshot.json");
+  const persistedBeforeFailure = fs.readFileSync(snapshotPath);
+  const savedSessions = `${sessions}.saved`;
+  fs.renameSync(sessions, savedSessions);
+  fs.writeFileSync(sessions, "temporary non-directory root", "utf8");
+
+  const stale = await cachedFileScan(undefined, undefined, Date.now(), Number.MAX_SAFE_INTEGER);
+  expect(stale.snapshot.files.map((entry) => entry.path)).toContain(canonicalPath);
+  await new Promise<void>((resolve) => setTimeout(resolve, 25));
+  expect(fs.readFileSync(snapshotPath)).toEqual(persistedBeforeFailure);
+
+  fs.rmSync(sessions);
+  fs.renameSync(savedSessions, sessions);
+  fs.rmSync(canonicalPath);
+  const recoveredPath = writeSession("recovered.jsonl", "/repo/recovered");
+  await waitForGeneration(stale.targetGeneration, recoveredPath);
+
+  const recovered = await cachedFileScan();
+  expect(recovered.snapshot.files.map((entry) => entry.path)).toContain(recoveredPath);
+  expect(recovered.snapshot.files.map((entry) => entry.path)).not.toContain(canonicalPath);
+  expect(fs.readFileSync(snapshotPath)).not.toEqual(persistedBeforeFailure);
+});
+
+test("a confirmed ENOENT deletion remains a complete inventory change", async () => {
+  const deletedPath = writeSession("confirmed-deletion.jsonl", "/repo/deleted");
+  const before = await listFilesWithProjectCatalog();
+  expect(before.complete).toBe(true);
+  expect(before.files.map((entry) => entry.path)).toContain(deletedPath);
+
+  fs.rmSync(deletedPath);
+  const after = await listFilesWithProjectCatalog();
+  expect(after.complete).toBe(true);
+  expect(after.files.map((entry) => entry.path)).not.toContain(deletedPath);
+});

--- a/src/app/api/files/scanCache.real.test.ts
+++ b/src/app/api/files/scanCache.real.test.ts
@@ -17,6 +17,7 @@ const sessions = path.join(process.env.LLV_CODEX_HOME, "sessions");
 fs.mkdirSync(sessions, { recursive: true });
 
 const { listFilesWithProjectCatalog } = await import("@/lib/scanner");
+const { ROOTS } = await import("@/lib/scanner/roots");
 const { cachedFileScan, resetFilesRouteCacheForTests } = await import("./scanCache");
 
 function writeSession(filename: string, cwd: string): string {
@@ -119,6 +120,63 @@ test("a transient real scanner failure preserves the completed route snapshot un
   expect(recovered.snapshot.files.map((entry) => entry.path)).toContain(recoveredPath);
   expect(recovered.snapshot.files.map((entry) => entry.path)).not.toContain(canonicalPath);
   expect(fs.readFileSync(snapshotPath)).not.toEqual(persistedBeforeFailure);
+});
+
+test("task twin EIO preserves canonical files generation and durable snapshots until recovery", async () => {
+  const previousTestStateDir = process.env.LLV_STATE_DIR;
+  const testStateDir = path.join(sandbox, "task-twin-generation-state");
+  const taskRoot = ROOTS["claude-tasks"];
+  const taskSlug = `llv-scan-test-${path.basename(sandbox)}`;
+  const taskFixtureRoot = path.join(taskRoot, taskSlug);
+  const taskPath = path.join(taskFixtureRoot, "session-a", "tasks", "task-a.output");
+  const twinPath = path.join(ROOTS["claude-projects"], taskSlug, "session-a", "subagents", "agent-task-a.jsonl");
+  const originalAccess = fs.promises.access;
+  try {
+    process.env.LLV_STATE_DIR = testStateDir;
+    resetFilesRouteCacheForTests();
+    fs.mkdirSync(path.dirname(taskPath), { recursive: true });
+    const canonicalPath = writeSession("task-twin-canonical.jsonl", "/repo/task-twin-canonical");
+    const canonical = await cachedFileScan();
+    expect(canonical.snapshot.files.map((entry) => entry.path)).toContain(canonicalPath);
+    const snapshotPath = path.join(testStateDir, "files-scan-snapshot.json");
+    const indexPath = path.join(testStateDir, "project-catalog.json");
+    const canonicalSnapshot = fs.readFileSync(snapshotPath);
+    const canonicalIndex = fs.readFileSync(indexPath);
+
+    fs.writeFileSync(taskPath, "finished\n");
+    fs.promises.access = (async (pathname, mode) => {
+      if (pathname === twinPath) {
+        const error = new Error("injected task twin EIO") as NodeJS.ErrnoException;
+        error.code = "EIO";
+        throw error;
+      }
+      return originalAccess(pathname, mode);
+    }) as typeof fs.promises.access;
+    const stale = await cachedFileScan(undefined, undefined, Date.now(), 261);
+    expect(stale.generation).toBe(canonical.generation);
+    expect(stale.targetGeneration).toBeGreaterThan(stale.generation);
+    expect(stale.snapshot.files.map((entry) => entry.path)).not.toContain(taskPath);
+    await Bun.sleep(50);
+    expect(fs.readFileSync(snapshotPath)).toEqual(canonicalSnapshot);
+    expect(fs.readFileSync(indexPath)).toEqual(canonicalIndex);
+
+    fs.promises.access = originalAccess;
+    let recovered = await cachedFileScan();
+    for (let attempt = 0; attempt < 100; attempt += 1) {
+      recovered = await cachedFileScan(undefined, undefined, Date.now(), undefined, stale.targetGeneration);
+      if (recovered.generation >= stale.targetGeneration
+        && recovered.snapshot.files.some((entry) => entry.path === taskPath)) break;
+      await Bun.sleep(10);
+    }
+    expect(recovered.generation).toBeGreaterThanOrEqual(stale.targetGeneration);
+    expect(recovered.snapshot.files.map((entry) => entry.path)).toContain(taskPath);
+  } finally {
+    fs.promises.access = originalAccess;
+    process.env.LLV_STATE_DIR = previousTestStateDir;
+    resetFilesRouteCacheForTests();
+    fs.rmSync(testStateDir, { recursive: true, force: true });
+    fs.rmSync(taskFixtureRoot, { recursive: true, force: true });
+  }
 });
 
 test("transcript metadata EIO after rewrite retains canonical snapshots until convergence", async () => {

--- a/src/app/api/files/scanCache.real.test.ts
+++ b/src/app/api/files/scanCache.real.test.ts
@@ -47,9 +47,53 @@ afterAll(() => {
   fs.rmSync(sandbox, { recursive: true, force: true });
 });
 
+test("real cached scans repair private state modes under umask 000", async () => {
+  const previousTestStateDir = process.env.LLV_STATE_DIR;
+  const privateStateDir = path.join(sandbox, "private-real-state");
+  const projectCatalogPath = path.join(privateStateDir, "project-catalog.json");
+  const scanSnapshotPath = path.join(privateStateDir, "files-scan-snapshot.json");
+  const originalRename = fs.renameSync;
+  const previousUmask = process.umask(0);
+  const projectTemporaryModes: number[] = [];
+  const snapshotTemporaryModes: number[] = [];
+  try {
+    process.env.LLV_STATE_DIR = privateStateDir;
+    fs.mkdirSync(privateStateDir, { recursive: true, mode: 0o777 });
+    fs.chmodSync(privateStateDir, 0o777);
+    fs.writeFileSync(projectCatalogPath, "permissive legacy index\n", { mode: 0o666 });
+    fs.writeFileSync(scanSnapshotPath, "permissive legacy snapshot\n", { mode: 0o666 });
+    fs.chmodSync(projectCatalogPath, 0o666);
+    fs.chmodSync(scanSnapshotPath, 0o666);
+    fs.renameSync = ((source: fs.PathLike, target: fs.PathLike) => {
+      if (target === projectCatalogPath) projectTemporaryModes.push(fs.statSync(source).mode & 0o777);
+      if (target === scanSnapshotPath) snapshotTemporaryModes.push(fs.statSync(source).mode & 0o777);
+      return originalRename(source, target);
+    }) as typeof fs.renameSync;
+    resetFilesRouteCacheForTests();
+    writeSession("private-real.jsonl", "/repo/private-real");
+
+    const scan = await cachedFileScan();
+
+    expect(scan.snapshot.complete).toBe(true);
+    expect(fs.statSync(privateStateDir).mode & 0o777).toBe(0o700);
+    expect(projectTemporaryModes).toEqual([0o600]);
+    expect(snapshotTemporaryModes).toEqual([0o600]);
+    expect(fs.statSync(projectCatalogPath).mode & 0o777).toBe(0o600);
+    expect(fs.statSync(scanSnapshotPath).mode & 0o777).toBe(0o600);
+  } finally {
+    fs.renameSync = originalRename;
+    process.umask(previousUmask);
+    process.env.LLV_STATE_DIR = previousTestStateDir;
+    resetFilesRouteCacheForTests();
+    fs.rmSync(privateStateDir, { recursive: true, force: true });
+  }
+});
+
 test("a transient real scanner failure preserves the completed route snapshot until recovery", async () => {
   resetFilesRouteCacheForTests();
   const canonicalPath = writeSession("canonical.jsonl", "/repo/canonical");
+  const initial = await cachedFileScan();
+  await waitForGeneration(initial.targetGeneration, canonicalPath);
   const completed = await cachedFileScan();
   expect(completed.snapshot.complete).toBe(true);
   expect(completed.snapshot.files.map((entry) => entry.path)).toContain(canonicalPath);
@@ -77,14 +121,124 @@ test("a transient real scanner failure preserves the completed route snapshot un
   expect(fs.readFileSync(snapshotPath)).not.toEqual(persistedBeforeFailure);
 });
 
+test("transcript metadata EIO after rewrite retains canonical snapshots until convergence", async () => {
+  resetFilesRouteCacheForTests();
+  const transcript = path.join(sessions, "metadata-rewrite.jsonl");
+  const alpha = `${JSON.stringify({ type: "session_meta", payload: { cwd: "/repo/alpha" } })}\n`;
+  const bravo = `${JSON.stringify({ type: "session_meta", payload: { cwd: "/repo/bravo" } })}\n`;
+  expect(Buffer.byteLength(alpha)).toBe(Buffer.byteLength(bravo));
+  fs.writeFileSync(transcript, alpha);
+  fs.utimesSync(transcript, 1_700_000_000, 1_700_000_000);
+  const initial = await cachedFileScan();
+  await waitForGeneration(initial.targetGeneration, transcript);
+  const completed = await cachedFileScan();
+  expect(completed.snapshot.files.find((entry) => entry.path === transcript)?.cwd).toBe("/repo/alpha");
+  const snapshotPath = path.join(process.env.LLV_STATE_DIR!, "files-scan-snapshot.json");
+  const indexPath = path.join(process.env.LLV_STATE_DIR!, "project-catalog.json");
+  const canonicalSnapshot = fs.readFileSync(snapshotPath);
+  const canonicalIndex = fs.readFileSync(indexPath);
+
+  fs.writeFileSync(transcript, bravo);
+  fs.utimesSync(transcript, 1_700_000_001, 1_700_000_001);
+  const originalOpen = fs.openSync;
+  let failures = 2;
+  fs.openSync = ((filename: fs.PathLike, flags: fs.OpenMode, mode?: fs.Mode) => {
+    if (filename === transcript && failures > 0) {
+      failures -= 1;
+      const error = new Error("injected transcript metadata EIO") as NodeJS.ErrnoException;
+      error.code = "EIO";
+      throw error;
+    }
+    return originalOpen(filename, flags, mode);
+  }) as typeof fs.openSync;
+  let targetGeneration = 0;
+  try {
+    const stale = await cachedFileScan(undefined, undefined, Date.now(), Number.MAX_SAFE_INTEGER);
+    targetGeneration = stale.targetGeneration;
+    expect(stale.snapshot.files.find((entry) => entry.path === transcript)?.cwd).toBe("/repo/alpha");
+    await Bun.sleep(50);
+  } finally {
+    fs.openSync = originalOpen;
+  }
+
+  expect(fs.readFileSync(snapshotPath)).toEqual(canonicalSnapshot);
+  expect(fs.readFileSync(indexPath)).toEqual(canonicalIndex);
+  let recovered = await cachedFileScan();
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    recovered = await cachedFileScan(undefined, undefined, Date.now(), undefined, targetGeneration);
+    if (recovered.generation >= targetGeneration
+      && recovered.snapshot.files.find((entry) => entry.path === transcript)?.cwd === "/repo/bravo") break;
+    await Bun.sleep(10);
+  }
+  expect(recovered.snapshot.files.find((entry) => entry.path === transcript)?.cwd).toBe("/repo/bravo");
+  expect(fs.readFileSync(snapshotPath)).not.toEqual(canonicalSnapshot);
+  expect(fs.readFileSync(indexPath)).not.toEqual(canonicalIndex);
+});
+
+test("sidecar metadata EIO after rewrite retains canonical snapshots until convergence", async () => {
+  resetFilesRouteCacheForTests();
+  const transcript = path.join(process.env.LLV_CLAUDE_HOME!, "projects", "sidecar", "session", "subagents", "agent-x.jsonl");
+  const sidecar = transcript.slice(0, -".jsonl".length) + ".meta.json";
+  fs.mkdirSync(path.dirname(transcript), { recursive: true });
+  fs.writeFileSync(transcript, "{}\n");
+  fs.writeFileSync(sidecar, JSON.stringify({ description: "Agent alpha" }));
+  fs.utimesSync(sidecar, 1_700_000_000, 1_700_000_000);
+  const initial = await cachedFileScan();
+  await waitForGeneration(initial.targetGeneration, transcript);
+  const completed = await cachedFileScan();
+  expect(completed.snapshot.files.find((entry) => entry.path === transcript)?.title).toBe("Agent alpha");
+  const snapshotPath = path.join(process.env.LLV_STATE_DIR!, "files-scan-snapshot.json");
+  const indexPath = path.join(process.env.LLV_STATE_DIR!, "project-catalog.json");
+  const canonicalSnapshot = fs.readFileSync(snapshotPath);
+  const canonicalIndex = fs.readFileSync(indexPath);
+
+  fs.writeFileSync(sidecar, JSON.stringify({ description: "Agent bravo" }));
+  fs.utimesSync(sidecar, 1_700_000_001, 1_700_000_001);
+  const originalRead = fs.readFileSync;
+  let failures = 1;
+  fs.readFileSync = ((filename: fs.PathOrFileDescriptor, ...args: unknown[]) => {
+    if (filename === sidecar && failures > 0) {
+      failures -= 1;
+      const error = new Error("injected sidecar metadata EIO") as NodeJS.ErrnoException;
+      error.code = "EIO";
+      throw error;
+    }
+    return (originalRead as (...inner: unknown[]) => unknown)(filename, ...args);
+  }) as typeof fs.readFileSync;
+  let targetGeneration = 0;
+  try {
+    const stale = await cachedFileScan(undefined, undefined, Date.now(), Number.MAX_SAFE_INTEGER);
+    targetGeneration = stale.targetGeneration;
+    expect(stale.snapshot.files.find((entry) => entry.path === transcript)?.title).toBe("Agent alpha");
+    await Bun.sleep(50);
+  } finally {
+    fs.readFileSync = originalRead;
+  }
+
+  expect(fs.readFileSync(snapshotPath)).toEqual(canonicalSnapshot);
+  expect(fs.readFileSync(indexPath)).toEqual(canonicalIndex);
+  let recovered = await cachedFileScan();
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    recovered = await cachedFileScan(undefined, undefined, Date.now(), undefined, targetGeneration);
+    if (recovered.generation >= targetGeneration
+      && recovered.snapshot.files.find((entry) => entry.path === transcript)?.title === "Agent bravo") break;
+    await Bun.sleep(10);
+  }
+  expect(recovered.snapshot.files.find((entry) => entry.path === transcript)?.title).toBe("Agent bravo");
+  expect(fs.readFileSync(snapshotPath)).not.toEqual(canonicalSnapshot);
+  expect(fs.readFileSync(indexPath)).not.toEqual(canonicalIndex);
+});
+
 test("a confirmed ENOENT deletion remains a complete inventory change", async () => {
   const deletedPath = writeSession("confirmed-deletion.jsonl", "/repo/deleted");
-  const before = await listFilesWithProjectCatalog();
+  const before = await listFilesWithProjectCatalog(undefined, { persist: false, persistIndex: true });
   expect(before.complete).toBe(true);
   expect(before.files.map((entry) => entry.path)).toContain(deletedPath);
 
   fs.rmSync(deletedPath);
-  const after = await listFilesWithProjectCatalog();
+  const after = await listFilesWithProjectCatalog(undefined, { persist: false, persistIndex: true });
   expect(after.complete).toBe(true);
   expect(after.files.map((entry) => entry.path)).not.toContain(deletedPath);
+  const index = JSON.parse(fs.readFileSync(path.join(process.env.LLV_STATE_DIR!, "project-catalog.json"), "utf8"));
+  expect(index.files[deletedPath]).toBeUndefined();
 });

--- a/src/app/api/files/scanCache.ts
+++ b/src/app/api/files/scanCache.ts
@@ -96,13 +96,20 @@ function readPersistedFileScanSnapshot(): FileScanSnapshot | undefined {
 
 function writePersistedFileScanSnapshot(snapshot: FileScanSnapshot): void {
   let temporary: string | undefined;
+  let operation = "create state directory";
+  let target = statePath(FILE_SCAN_SNAPSHOT_FILE);
   try {
     const filename = statePath(FILE_SCAN_SNAPSHOT_FILE);
+    target = filename;
     fs.mkdirSync(path.dirname(filename), { recursive: true });
     temporary = path.join(path.dirname(filename), `.${path.basename(filename)}.${process.pid}.${crypto.randomUUID()}.tmp`);
+    operation = "write temporary snapshot";
+    target = temporary;
     fs.writeFileSync(temporary, JSON.stringify({ version: FILE_SCAN_SNAPSHOT_VERSION, snapshot }) + "\n", "utf8");
+    operation = "rename temporary snapshot";
+    target = filename;
     fs.renameSync(temporary, filename);
-  } catch {
+  } catch (error) {
     if (temporary !== undefined) {
       try {
         fs.unlinkSync(temporary);
@@ -113,7 +120,8 @@ function writePersistedFileScanSnapshot(snapshot: FileScanSnapshot): void {
     const now = Date.now();
     if (now - lastFileScanPersistenceDiagnosticAt >= FILE_SCAN_PERSISTENCE_DIAGNOSTIC_MS) {
       lastFileScanPersistenceDiagnosticAt = now;
-      console.error("[files scan cache] files scan snapshot publication failed; a later refresh will retry");
+      const detail = error instanceof Error ? `${error.message}${"code" in error && error.code ? ` (${String(error.code)})` : ""}` : String(error);
+      console.error(`[files scan cache] ${operation} failed for ${target}: ${detail}; a later refresh will retry`);
     }
   }
 }
@@ -168,6 +176,7 @@ function normalizeFileScanCacheSlot(value: unknown): FileScanCacheSlot {
 
 function beginFileScanRefresh(slot: FileScanCacheSlot, generation: number): FileScanRefresh {
   const promise = listFilesWithProjectCatalog(undefined, { persist: false, persistIndex: true }).then((snapshot) => {
+    if (snapshot.complete === false) throw new Error("filesystem scan incomplete");
     writePersistedFileScanSnapshot(snapshot);
     slot.snapshot = snapshot;
     slot.snapshotGeneration = Math.max(slot.snapshotGeneration, generation);
@@ -180,6 +189,7 @@ function beginFileScanRefresh(slot: FileScanCacheSlot, generation: number): File
 function beginPinnedFileScanRefresh(slot: FileScanCacheSlot, generation: number, pinnedPath: string): FileScanRefresh {
   const promise = (async () => {
     const pinnedSnapshot = await listFilesWithProjectCatalog(undefined, { persist: false, persistIndex: true, pin: pinnedPath });
+    if (pinnedSnapshot.complete === false) throw new Error("filesystem scan incomplete");
     const pinOverlayPaths = pinnedSnapshot.pinOverlayPaths ?? [];
     const overlayPathSet = new Set(pinOverlayPaths);
     const globalSnapshot = {

--- a/src/app/api/files/scanCache.ts
+++ b/src/app/api/files/scanCache.ts
@@ -39,6 +39,8 @@ const FILE_SCAN_PIN_CACHE_MAX = 8;
 const FILE_SCAN_CACHE_SCHEMA_VERSION = 4 as const;
 const FILE_SCAN_SNAPSHOT_VERSION = 1 as const;
 const FILE_SCAN_SNAPSHOT_FILE = "files-scan-snapshot.json";
+const FILE_SCAN_PERSISTENCE_DIAGNOSTIC_MS = 60_000;
+let lastFileScanPersistenceDiagnosticAt = Number.NEGATIVE_INFINITY;
 const fileScanCacheStore = globalThis as typeof globalThis & {
   __llvFilesRouteScans?: Map<string, unknown>;
 };
@@ -93,14 +95,26 @@ function readPersistedFileScanSnapshot(): FileScanSnapshot | undefined {
 }
 
 function writePersistedFileScanSnapshot(snapshot: FileScanSnapshot): void {
+  let temporary: string | undefined;
   try {
     const filename = statePath(FILE_SCAN_SNAPSHOT_FILE);
     fs.mkdirSync(path.dirname(filename), { recursive: true });
-    const temporary = path.join(path.dirname(filename), `.${path.basename(filename)}.${process.pid}.${crypto.randomUUID()}.tmp`);
+    temporary = path.join(path.dirname(filename), `.${path.basename(filename)}.${process.pid}.${crypto.randomUUID()}.tmp`);
     fs.writeFileSync(temporary, JSON.stringify({ version: FILE_SCAN_SNAPSHOT_VERSION, snapshot }) + "\n", "utf8");
     fs.renameSync(temporary, filename);
   } catch {
-    // A later completed refresh can recreate the snapshot.
+    if (temporary !== undefined) {
+      try {
+        fs.unlinkSync(temporary);
+      } catch {
+        // The write may have failed before the temp file was created.
+      }
+    }
+    const now = Date.now();
+    if (now - lastFileScanPersistenceDiagnosticAt >= FILE_SCAN_PERSISTENCE_DIAGNOSTIC_MS) {
+      lastFileScanPersistenceDiagnosticAt = now;
+      console.error("[files scan cache] files scan snapshot publication failed; a later refresh will retry");
+    }
   }
 }
 

--- a/src/app/api/files/scanCache.ts
+++ b/src/app/api/files/scanCache.ts
@@ -55,7 +55,7 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 }
 
 function isFileScanSnapshot(value: unknown): value is FileScanSnapshot {
-  if (!isRecord(value) || !Array.isArray(value.files) || !Array.isArray(value.projectCatalog)) return false;
+  if (!isRecord(value) || value.complete !== true || !Array.isArray(value.files) || !Array.isArray(value.projectCatalog)) return false;
   const filesValid = value.files.every((candidate) => {
     if (!isRecord(candidate)) return false;
     return typeof candidate.path === "string"
@@ -157,7 +157,7 @@ function normalizeFileScanCacheSlot(value: unknown): FileScanCacheSlot {
   const legacy = isRecord(value) ? value : {};
   const slot: FileScanCacheSlot = {
     schemaVersion: FILE_SCAN_CACHE_SCHEMA_VERSION,
-    snapshot: legacy.snapshot as FileScanSnapshot | undefined,
+    snapshot: isFileScanSnapshot(legacy.snapshot) ? legacy.snapshot : undefined,
     snapshotGeneration: 0,
     requestedGeneration: 0,
     refreshedAt: typeof legacy.refreshedAt === "number" && Number.isFinite(legacy.refreshedAt) ? legacy.refreshedAt : 0,
@@ -165,6 +165,7 @@ function normalizeFileScanCacheSlot(value: unknown): FileScanCacheSlot {
   const pending = refreshPromise(legacy.refresh);
   if (pending) {
     const promise = pending.then((snapshot) => {
+      if (!snapshot.complete) throw new Error("filesystem scan incomplete");
       slot.snapshot = snapshot;
       slot.refreshedAt = Date.now();
       return snapshot;
@@ -176,7 +177,7 @@ function normalizeFileScanCacheSlot(value: unknown): FileScanCacheSlot {
 
 function beginFileScanRefresh(slot: FileScanCacheSlot, generation: number): FileScanRefresh {
   const promise = listFilesWithProjectCatalog(undefined, { persist: false, persistIndex: true }).then((snapshot) => {
-    if (snapshot.complete === false) throw new Error("filesystem scan incomplete");
+    if (!snapshot.complete) throw new Error("filesystem scan incomplete");
     writePersistedFileScanSnapshot(snapshot);
     slot.snapshot = snapshot;
     slot.snapshotGeneration = Math.max(slot.snapshotGeneration, generation);
@@ -189,12 +190,13 @@ function beginFileScanRefresh(slot: FileScanCacheSlot, generation: number): File
 function beginPinnedFileScanRefresh(slot: FileScanCacheSlot, generation: number, pinnedPath: string): FileScanRefresh {
   const promise = (async () => {
     const pinnedSnapshot = await listFilesWithProjectCatalog(undefined, { persist: false, persistIndex: true, pin: pinnedPath });
-    if (pinnedSnapshot.complete === false) throw new Error("filesystem scan incomplete");
+    if (!pinnedSnapshot.complete) throw new Error("filesystem scan incomplete");
     const pinOverlayPaths = pinnedSnapshot.pinOverlayPaths ?? [];
     const overlayPathSet = new Set(pinOverlayPaths);
     const globalSnapshot = {
       files: pinnedSnapshot.files.filter((file) => !overlayPathSet.has(file.path)),
       projectCatalog: pinnedSnapshot.projectCatalog,
+      complete: true,
     };
     slot.pinnedSnapshots ??= new Map();
     slot.pinnedSnapshots.delete(pinnedPath);

--- a/src/app/api/files/scanCache.ts
+++ b/src/app/api/files/scanCache.ts
@@ -101,11 +101,14 @@ function writePersistedFileScanSnapshot(snapshot: FileScanSnapshot): void {
   try {
     const filename = statePath(FILE_SCAN_SNAPSHOT_FILE);
     target = filename;
-    fs.mkdirSync(path.dirname(filename), { recursive: true });
+    fs.mkdirSync(path.dirname(filename), { recursive: true, mode: 0o700 });
     temporary = path.join(path.dirname(filename), `.${path.basename(filename)}.${process.pid}.${crypto.randomUUID()}.tmp`);
     operation = "write temporary snapshot";
     target = temporary;
-    fs.writeFileSync(temporary, JSON.stringify({ version: FILE_SCAN_SNAPSHOT_VERSION, snapshot }) + "\n", "utf8");
+    fs.writeFileSync(temporary, JSON.stringify({ version: FILE_SCAN_SNAPSHOT_VERSION, snapshot }) + "\n", {
+      encoding: "utf8",
+      mode: 0o600,
+    });
     operation = "rename temporary snapshot";
     target = filename;
     fs.renameSync(temporary, filename);

--- a/src/app/api/files/scanCache.ts
+++ b/src/app/api/files/scanCache.ts
@@ -1,9 +1,17 @@
+import crypto from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+
+import { statePath } from "@/lib/configDir";
 import { listFilesWithProjectCatalog } from "@/lib/scanner";
 
 type FileScanSnapshot = Awaited<ReturnType<typeof listFilesWithProjectCatalog>>;
 type FileScanRefresh = {
   generation: number;
   promise: Promise<FileScanSnapshot>;
+};
+type PinnedFileScanSnapshot = CachedFileScan & {
+  refreshedAt: number;
 };
 type FileScanCacheSlot = {
   schemaVersion: typeof FILE_SCAN_CACHE_SCHEMA_VERSION;
@@ -14,6 +22,7 @@ type FileScanCacheSlot = {
   forcedGeneration?: number;
   refreshedAt: number;
   refresh?: FileScanRefresh;
+  pinnedSnapshots?: Map<string, PinnedFileScanSnapshot>;
 };
 
 export type CachedFileScan = {
@@ -23,6 +32,8 @@ export type CachedFileScan = {
 
 const FILE_SCAN_FRESH_MS = 1_000;
 const FILE_SCAN_CACHE_SCHEMA_VERSION = 3 as const;
+const FILE_SCAN_SNAPSHOT_VERSION = 1 as const;
+const FILE_SCAN_SNAPSHOT_FILE = "files-scan-snapshot.json";
 const fileScanCacheStore = globalThis as typeof globalThis & {
   __llvFilesRouteScans?: Map<string, unknown>;
 };
@@ -34,6 +45,58 @@ function fileScanCache(): Map<string, unknown> {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
+}
+
+function isFileScanSnapshot(value: unknown): value is FileScanSnapshot {
+  if (!isRecord(value) || !Array.isArray(value.files) || !Array.isArray(value.projectCatalog)) return false;
+  const filesValid = value.files.every((candidate) => {
+    if (!isRecord(candidate)) return false;
+    return typeof candidate.path === "string"
+      && (candidate.root === "codex-sessions" || candidate.root === "claude-projects" || candidate.root === "claude-tasks")
+      && typeof candidate.name === "string"
+      && typeof candidate.project === "string"
+      && typeof candidate.title === "string"
+      && (candidate.engine === "codex" || candidate.engine === "claude" || candidate.engine === "shell")
+      && typeof candidate.kind === "string"
+      && (candidate.fmt === "codex" || candidate.fmt === "claude" || candidate.fmt === "plain")
+      && (candidate.parent === null || typeof candidate.parent === "string")
+      && typeof candidate.mtime === "number" && Number.isFinite(candidate.mtime)
+      && typeof candidate.size === "number" && Number.isFinite(candidate.size)
+      && (candidate.activity === "live" || candidate.activity === "recent" || candidate.activity === "stalled" || candidate.activity === "idle")
+      && (candidate.proc === null || candidate.proc === "running" || candidate.proc === "done" || candidate.proc === "killed")
+      && (candidate.pid === null || typeof candidate.pid === "number")
+      && (candidate.model === null || typeof candidate.model === "string")
+      && (candidate.pendingQuestion === null || isRecord(candidate.pendingQuestion))
+      && (candidate.waitingInput === null || isRecord(candidate.waitingInput));
+  });
+  const catalogValid = value.projectCatalog.every((candidate) => isRecord(candidate)
+    && typeof candidate.project === "string"
+    && typeof candidate.smt === "number" && Number.isFinite(candidate.smt)
+    && typeof candidate.conversations === "number" && Number.isSafeInteger(candidate.conversations)
+    && (candidate.projectRoot === undefined || typeof candidate.projectRoot === "string"));
+  return filesValid && catalogValid;
+}
+
+function readPersistedFileScanSnapshot(): FileScanSnapshot | undefined {
+  try {
+    const value = JSON.parse(fs.readFileSync(statePath(FILE_SCAN_SNAPSHOT_FILE), "utf8")) as unknown;
+    if (!isRecord(value) || value.version !== FILE_SCAN_SNAPSHOT_VERSION || !isFileScanSnapshot(value.snapshot)) return undefined;
+    return value.snapshot;
+  } catch {
+    return undefined;
+  }
+}
+
+function writePersistedFileScanSnapshot(snapshot: FileScanSnapshot): void {
+  try {
+    const filename = statePath(FILE_SCAN_SNAPSHOT_FILE);
+    fs.mkdirSync(path.dirname(filename), { recursive: true });
+    const temporary = path.join(path.dirname(filename), `.${path.basename(filename)}.${process.pid}.${crypto.randomUUID()}.tmp`);
+    fs.writeFileSync(temporary, JSON.stringify({ version: FILE_SCAN_SNAPSHOT_VERSION, snapshot }) + "\n", "utf8");
+    fs.renameSync(temporary, filename);
+  } catch {
+    // A later completed refresh can recreate the snapshot.
+  }
 }
 
 function refreshPromise(value: unknown): Promise<FileScanSnapshot> | undefined {
@@ -85,12 +148,40 @@ function normalizeFileScanCacheSlot(value: unknown): FileScanCacheSlot {
 }
 
 function beginFileScanRefresh(slot: FileScanCacheSlot, generation: number): FileScanRefresh {
-  const promise = listFilesWithProjectCatalog(undefined, { persist: false }).then((snapshot) => {
+  const promise = listFilesWithProjectCatalog(undefined, { persist: false, persistIndex: true }).then((snapshot) => {
+    writePersistedFileScanSnapshot(snapshot);
     slot.snapshot = snapshot;
     slot.snapshotGeneration = Math.max(slot.snapshotGeneration, generation);
     slot.refreshedAt = Date.now();
     return snapshot;
   });
+  return installFileScanRefresh(slot, generation, promise);
+}
+
+function beginPinnedFileScanRefresh(slot: FileScanCacheSlot, generation: number, pinnedPath: string): FileScanRefresh {
+  const promise = (async () => {
+    const pinnedSnapshot = await listFilesWithProjectCatalog(undefined, { persist: false, persistIndex: true, pin: pinnedPath });
+    const pinOverlayPaths = pinnedSnapshot.pinOverlayPaths ?? [];
+    const overlayPathSet = new Set(pinOverlayPaths);
+    const globalSnapshot = {
+      files: pinnedSnapshot.files.filter((file) => !overlayPathSet.has(file.path)),
+      projectCatalog: pinnedSnapshot.projectCatalog,
+    };
+    slot.pinnedSnapshots ??= new Map();
+    slot.pinnedSnapshots.set(pinnedPath, {
+      snapshot: {
+        ...globalSnapshot,
+        files: pinnedSnapshot.files,
+      },
+      ...(pinOverlayPaths.length ? { pinOverlayPaths } : {}),
+      refreshedAt: Date.now(),
+    });
+    writePersistedFileScanSnapshot(globalSnapshot);
+    slot.snapshot = globalSnapshot;
+    slot.snapshotGeneration = Math.max(slot.snapshotGeneration, generation);
+    slot.refreshedAt = Date.now();
+    return globalSnapshot;
+  })();
   return installFileScanRefresh(slot, generation, promise);
 }
 
@@ -116,8 +207,10 @@ export async function cachedFileScan(
   const cachedSlot = cache.get(key);
   let slot: FileScanCacheSlot;
   if (cachedSlot === undefined) {
+    const persisted = readPersistedFileScanSnapshot();
     slot = {
       schemaVersion: FILE_SCAN_CACHE_SCHEMA_VERSION,
+      snapshot: persisted,
       snapshotGeneration: 0,
       requestedGeneration: 0,
       refreshedAt: 0,
@@ -129,24 +222,26 @@ export async function cachedFileScan(
     cache.set(key, slot);
   }
 
-  /* A pin is an overlay on one global snapshot. Refresh the shared slot after
-     collecting the pinned view, then append only rows the global cap omitted.
-     The next ordinary request therefore sees the same or newer shared rows,
-     while explicit provenance lets the browser discard the whole overlay. */
+  /* A pin is an overlay on one global snapshot. The scanner marks every row
+     outside the global cap, letting one scan publish both views. A completed
+     snapshot serves while that shared refresh runs. */
   if (pinnedPath) {
-    const pinnedSnapshot = await listFilesWithProjectCatalog(undefined, { persist: false, pin: pinnedPath });
-    const requestedGeneration = slot.requestedGeneration + 1;
-    slot.requestedGeneration = requestedGeneration;
-    const globalSnapshot = await refreshThroughGeneration(slot, requestedGeneration);
-    const globalPaths = new Set(globalSnapshot.files.map((file) => file.path));
-    const overlayFiles = pinnedSnapshot.files.filter((file) => !globalPaths.has(file.path));
-    return structuredClone({
-      snapshot: {
-        ...globalSnapshot,
-        files: [...globalSnapshot.files, ...overlayFiles],
-      },
-      ...(overlayFiles.length ? { pinOverlayPaths: overlayFiles.map((file) => file.path) } : {}),
-    });
+    slot.pinnedSnapshots ??= new Map();
+    const pinned = slot.pinnedSnapshots.get(pinnedPath);
+    if (!pinned || now - pinned.refreshedAt >= FILE_SCAN_FRESH_MS) {
+      if (!slot.refresh) {
+        const requestedGeneration = slot.requestedGeneration + 1;
+        slot.requestedGeneration = requestedGeneration;
+        beginPinnedFileScanRefresh(slot, requestedGeneration, pinnedPath);
+      }
+    }
+    if (pinned) return structuredClone({ snapshot: pinned.snapshot, pinOverlayPaths: pinned.pinOverlayPaths });
+    if (slot.snapshot) return { snapshot: structuredClone(slot.snapshot) };
+    const globalSnapshot = await slot.refresh!.promise;
+    const hydrated = slot.pinnedSnapshots.get(pinnedPath);
+    return hydrated
+      ? structuredClone({ snapshot: hydrated.snapshot, pinOverlayPaths: hydrated.pinOverlayPaths })
+      : { snapshot: structuredClone(globalSnapshot) };
   }
 
   if (requiredRevision !== undefined) {
@@ -159,15 +254,23 @@ export async function cachedFileScan(
       slot.forcedRevision = requiredRevision;
       slot.forcedGeneration = requestedGeneration;
     }
-    try {
-      const snapshot = await refreshThroughGeneration(slot, requestedGeneration);
-      return { snapshot: structuredClone(snapshot) };
-    } finally {
+    const refresh = refreshThroughGeneration(slot, requestedGeneration);
+    const clearForcedGeneration = () => {
       if (slot.forcedGeneration === requestedGeneration) {
         slot.forcedRevision = undefined;
         slot.forcedGeneration = undefined;
       }
+    };
+    if (!slot.snapshot) {
+      try {
+        const snapshot = await refresh;
+        return { snapshot: structuredClone(snapshot) };
+      } finally {
+        clearForcedGeneration();
+      }
     }
+    void refresh.then(clearForcedGeneration, clearForcedGeneration);
+    return { snapshot: structuredClone(slot.snapshot) };
   }
 
   if (!slot.snapshot) {
@@ -177,9 +280,7 @@ export async function cachedFileScan(
   }
 
   if (now - slot.refreshedAt >= FILE_SCAN_FRESH_MS) {
-    const refresh = slot.refresh ?? beginFileScanRefresh(slot, slot.snapshotGeneration);
-    const snapshot = await refresh.promise;
-    return { snapshot: structuredClone(snapshot) };
+    if (!slot.refresh) beginFileScanRefresh(slot, slot.snapshotGeneration);
   }
   return { snapshot: structuredClone(slot.snapshot) };
 }

--- a/src/app/api/files/scanCache.ts
+++ b/src/app/api/files/scanCache.ts
@@ -10,7 +10,8 @@ type FileScanRefresh = {
   generation: number;
   promise: Promise<FileScanSnapshot>;
 };
-type PinnedFileScanSnapshot = CachedFileScan & {
+type PinnedFileScanSnapshot = Pick<CachedFileScan, "snapshot" | "pinOverlayPaths"> & {
+  generation: number;
   refreshedAt: number;
 };
 type FileScanCacheSlot = {
@@ -23,15 +24,19 @@ type FileScanCacheSlot = {
   refreshedAt: number;
   refresh?: FileScanRefresh;
   pinnedSnapshots?: Map<string, PinnedFileScanSnapshot>;
+  pinnedGenerations?: Map<string, number>;
 };
 
 export type CachedFileScan = {
   snapshot: FileScanSnapshot;
   pinOverlayPaths?: string[];
+  generation: number;
+  targetGeneration: number;
 };
 
 const FILE_SCAN_FRESH_MS = 1_000;
-const FILE_SCAN_CACHE_SCHEMA_VERSION = 3 as const;
+const FILE_SCAN_PIN_CACHE_MAX = 8;
+const FILE_SCAN_CACHE_SCHEMA_VERSION = 4 as const;
 const FILE_SCAN_SNAPSHOT_VERSION = 1 as const;
 const FILE_SCAN_SNAPSHOT_FILE = "files-scan-snapshot.json";
 const fileScanCacheStore = globalThis as typeof globalThis & {
@@ -168,14 +173,22 @@ function beginPinnedFileScanRefresh(slot: FileScanCacheSlot, generation: number,
       projectCatalog: pinnedSnapshot.projectCatalog,
     };
     slot.pinnedSnapshots ??= new Map();
+    slot.pinnedSnapshots.delete(pinnedPath);
     slot.pinnedSnapshots.set(pinnedPath, {
       snapshot: {
         ...globalSnapshot,
         files: pinnedSnapshot.files,
       },
       ...(pinOverlayPaths.length ? { pinOverlayPaths } : {}),
+      generation,
       refreshedAt: Date.now(),
     });
+    while (slot.pinnedSnapshots.size > FILE_SCAN_PIN_CACHE_MAX) {
+      const oldest = slot.pinnedSnapshots.keys().next().value;
+      if (oldest === undefined) break;
+      slot.pinnedSnapshots.delete(oldest);
+      slot.pinnedGenerations?.delete(oldest);
+    }
     writePersistedFileScanSnapshot(globalSnapshot);
     slot.snapshot = globalSnapshot;
     slot.snapshotGeneration = Math.max(slot.snapshotGeneration, generation);
@@ -188,12 +201,75 @@ function beginPinnedFileScanRefresh(slot: FileScanCacheSlot, generation: number,
 async function refreshThroughGeneration(
   slot: FileScanCacheSlot,
   requestedGeneration: number,
+  pinnedPath?: string,
 ): Promise<FileScanSnapshot> {
-  while (!slot.snapshot || slot.snapshotGeneration < requestedGeneration) {
-    const refresh = slot.refresh ?? beginFileScanRefresh(slot, requestedGeneration);
+  while (
+    !slot.snapshot
+    || slot.snapshotGeneration < requestedGeneration
+    || (pinnedPath !== undefined && (slot.pinnedSnapshots?.get(pinnedPath)?.generation ?? -1) < requestedGeneration)
+  ) {
+    const refresh = slot.refresh ?? (pinnedPath
+      ? beginPinnedFileScanRefresh(slot, requestedGeneration, pinnedPath)
+      : beginFileScanRefresh(slot, requestedGeneration));
     await refresh.promise;
   }
   return slot.snapshot;
+}
+
+function cachedPinnedSnapshot(slot: FileScanCacheSlot, pinnedPath: string): PinnedFileScanSnapshot | undefined {
+  const pinned = slot.pinnedSnapshots?.get(pinnedPath);
+  if (!pinned) return undefined;
+  slot.pinnedSnapshots!.delete(pinnedPath);
+  slot.pinnedSnapshots!.set(pinnedPath, pinned);
+  return pinned;
+}
+
+function completedScan(slot: FileScanCacheSlot, pinnedPath: string | undefined, targetGeneration: number): CachedFileScan {
+  const pinned = pinnedPath ? cachedPinnedSnapshot(slot, pinnedPath) : undefined;
+  if (pinned) {
+    return structuredClone({
+      snapshot: pinned.snapshot,
+      pinOverlayPaths: pinned.pinOverlayPaths,
+      generation: pinned.generation,
+      targetGeneration,
+    });
+  }
+  return {
+    snapshot: structuredClone(slot.snapshot!),
+    generation: slot.snapshotGeneration,
+    targetGeneration,
+  };
+}
+
+function nextGeneration(slot: FileScanCacheSlot): number {
+  slot.requestedGeneration += 1;
+  return slot.requestedGeneration;
+}
+
+function continueRefreshInBackground(refresh: Promise<FileScanSnapshot>): void {
+  /* The response carries an incomplete target generation. Its client retries
+     until a later scan completes, including after this attempt rejects. */
+  void refresh.catch(() => undefined);
+}
+
+function rememberPinnedGeneration(slot: FileScanCacheSlot, pinnedPath: string, generation: number): number {
+  slot.pinnedGenerations ??= new Map();
+  const remembered = Math.max(slot.pinnedGenerations.get(pinnedPath) ?? -1, generation);
+  slot.pinnedGenerations.delete(pinnedPath);
+  slot.pinnedGenerations.set(pinnedPath, remembered);
+  while (slot.pinnedGenerations.size > FILE_SCAN_PIN_CACHE_MAX) {
+    const oldest = slot.pinnedGenerations.keys().next().value;
+    if (oldest === undefined) break;
+    slot.pinnedGenerations.delete(oldest);
+  }
+  return remembered;
+}
+
+function pinnedRefreshGeneration(slot: FileScanCacheSlot, pinnedPath: string): number {
+  const pending = slot.pinnedGenerations?.get(pinnedPath);
+  const completed = slot.pinnedSnapshots?.get(pinnedPath)?.generation ?? -1;
+  if (pending !== undefined && pending > completed) return pending;
+  return rememberPinnedGeneration(slot, pinnedPath, nextGeneration(slot));
 }
 
 export async function cachedFileScan(
@@ -201,6 +277,7 @@ export async function cachedFileScan(
   pinnedPath?: string,
   now = Date.now(),
   requiredRevision?: number,
+  requiredGeneration?: number,
 ): Promise<CachedFileScan> {
   const key = "";
   const cache = fileScanCache();
@@ -222,39 +299,27 @@ export async function cachedFileScan(
     cache.set(key, slot);
   }
 
-  /* A pin is an overlay on one global snapshot. The scanner marks every row
-     outside the global cap, letting one scan publish both views. A completed
-     snapshot serves while that shared refresh runs. */
-  if (pinnedPath) {
-    slot.pinnedSnapshots ??= new Map();
-    const pinned = slot.pinnedSnapshots.get(pinnedPath);
-    if (!pinned || now - pinned.refreshedAt >= FILE_SCAN_FRESH_MS) {
-      if (!slot.refresh) {
-        const requestedGeneration = slot.requestedGeneration + 1;
-        slot.requestedGeneration = requestedGeneration;
-        beginPinnedFileScanRefresh(slot, requestedGeneration, pinnedPath);
-      }
+  let targetGeneration = requiredGeneration !== undefined && requiredGeneration <= slot.requestedGeneration
+    ? requiredGeneration
+    : undefined;
+  if (targetGeneration !== undefined) {
+    if (pinnedPath) {
+      targetGeneration = rememberPinnedGeneration(slot, pinnedPath, targetGeneration);
     }
-    if (pinned) return structuredClone({ snapshot: pinned.snapshot, pinOverlayPaths: pinned.pinOverlayPaths });
-    if (slot.snapshot) return { snapshot: structuredClone(slot.snapshot) };
-    const globalSnapshot = await slot.refresh!.promise;
-    const hydrated = slot.pinnedSnapshots.get(pinnedPath);
-    return hydrated
-      ? structuredClone({ snapshot: hydrated.snapshot, pinOverlayPaths: hydrated.pinOverlayPaths })
-      : { snapshot: structuredClone(globalSnapshot) };
-  }
-
-  if (requiredRevision !== undefined) {
+  } else if (requiredRevision !== undefined) {
     let requestedGeneration: number;
     if (slot.forcedRevision === requiredRevision && slot.forcedGeneration !== undefined) {
       requestedGeneration = slot.forcedGeneration;
     } else {
-      requestedGeneration = slot.requestedGeneration + 1;
-      slot.requestedGeneration = requestedGeneration;
+      requestedGeneration = nextGeneration(slot);
       slot.forcedRevision = requiredRevision;
       slot.forcedGeneration = requestedGeneration;
     }
-    const refresh = refreshThroughGeneration(slot, requestedGeneration);
+    targetGeneration = requestedGeneration;
+    if (pinnedPath) {
+      targetGeneration = rememberPinnedGeneration(slot, pinnedPath, requestedGeneration);
+    }
+    const refresh = refreshThroughGeneration(slot, targetGeneration, pinnedPath);
     const clearForcedGeneration = () => {
       if (slot.forcedGeneration === requestedGeneration) {
         slot.forcedRevision = undefined;
@@ -263,26 +328,54 @@ export async function cachedFileScan(
     };
     if (!slot.snapshot) {
       try {
-        const snapshot = await refresh;
-        return { snapshot: structuredClone(snapshot) };
+        await refresh;
+        return completedScan(slot, pinnedPath, targetGeneration);
       } finally {
         clearForcedGeneration();
       }
     }
     void refresh.then(clearForcedGeneration, clearForcedGeneration);
-    return { snapshot: structuredClone(slot.snapshot) };
+  }
+
+  if (targetGeneration !== undefined) {
+    const refresh = refreshThroughGeneration(slot, targetGeneration, pinnedPath);
+    if (!slot.snapshot) await refresh;
+    else continueRefreshInBackground(refresh);
+    return completedScan(slot, pinnedPath, targetGeneration);
+  }
+
+  /* A pin is an overlay on one global snapshot. The scanner marks every row
+     outside the global cap, letting one scan publish both views. A completed
+     snapshot serves while that shared refresh runs. */
+  if (pinnedPath) {
+    slot.pinnedSnapshots ??= new Map();
+    const pinned = cachedPinnedSnapshot(slot, pinnedPath);
+    if (pinned && now - pinned.refreshedAt < FILE_SCAN_FRESH_MS) {
+      return completedScan(slot, pinnedPath, pinned.generation);
+    }
+    targetGeneration = pinnedRefreshGeneration(slot, pinnedPath);
+    const refresh = refreshThroughGeneration(slot, targetGeneration, pinnedPath);
+    if (!slot.snapshot) await refresh;
+    else continueRefreshInBackground(refresh);
+    return completedScan(slot, pinnedPath, targetGeneration);
   }
 
   if (!slot.snapshot) {
-    const refresh = slot.refresh ?? beginFileScanRefresh(slot, slot.snapshotGeneration);
-    const snapshot = await refresh.promise;
-    return { snapshot: structuredClone(snapshot) };
+    targetGeneration = slot.refresh?.generation ?? nextGeneration(slot);
+    const refresh = slot.refresh ?? beginFileScanRefresh(slot, targetGeneration);
+    await refresh.promise;
+    return completedScan(slot, undefined, targetGeneration);
   }
 
-  if (now - slot.refreshedAt >= FILE_SCAN_FRESH_MS) {
-    if (!slot.refresh) beginFileScanRefresh(slot, slot.snapshotGeneration);
+  if (slot.refresh) {
+    targetGeneration = slot.refresh.generation;
+  } else if (now - slot.refreshedAt >= FILE_SCAN_FRESH_MS) {
+    targetGeneration = nextGeneration(slot);
+    beginFileScanRefresh(slot, targetGeneration);
+  } else {
+    targetGeneration = slot.snapshotGeneration;
   }
-  return { snapshot: structuredClone(slot.snapshot) };
+  return completedScan(slot, undefined, targetGeneration);
 }
 
 export function resetFilesRouteCacheForTests(): void {

--- a/src/hooks/useFiles.dom.test.tsx
+++ b/src/hooks/useFiles.dom.test.tsx
@@ -19,7 +19,12 @@ mock.module("./runtimeBus", () => ({
   }),
 }));
 
-const { resetFilesClientCacheForTests, useFiles } = await import("./useFiles");
+const {
+  applyPipelineSnapshot,
+  resetFilesClientCacheForTests,
+  revertPipelineSnapshot,
+  useFiles,
+} = await import("./useFiles");
 const dom = new Window();
 Object.assign(globalThis, {
   window: dom,
@@ -46,6 +51,77 @@ function Probe() {
   const data = useFiles();
   return <div data-loaded={String(data.loaded)}>{data.files[0]?.path ?? "empty"}</div>;
 }
+
+function ScopedProbe({ pinnedPath }: { pinnedPath?: string }) {
+  const data = useFiles(undefined, pinnedPath);
+  return <div>{JSON.stringify({
+    files: data.files.map((entry) => entry.path),
+    pins: data.pinOverlayPaths,
+    scope: data.requestScope,
+    task: data.pipelines[0]?.task ?? "",
+  })}</div>;
+}
+
+function pipelineRow(task: string) {
+  return { id: "p1", task, project: "project-a", state: "draft", stages: [], runs: [], cursor: null, hiddenAt: null };
+}
+
+test("concurrent pinned and global hooks keep their scopes through local pipeline apply and revert", async () => {
+  const pinnedPath = "/archive/dom-scoped-pin.jsonl";
+  let fetches = 0;
+  globalThis.fetch = mock(async (input: string | URL | Request) => {
+    fetches += 1;
+    const url = String(input);
+    const pinned = url !== "/api/files";
+    return new Response(JSON.stringify({
+      files: pinned ? [{ path: "/global" }, { path: pinnedPath }] : [{ path: "/global" }],
+      pinOverlayPaths: pinned ? [pinnedPath] : [],
+      pipelines: [pipelineRow("server")],
+    }));
+  }) as unknown as typeof fetch;
+
+  const host = document.createElement("div");
+  document.body.append(host);
+  const root = createRoot(host);
+  flushSync(() => {
+    root.render(<>
+      <ScopedProbe pinnedPath={pinnedPath} />
+      <ScopedProbe />
+    </>);
+  });
+  await Bun.sleep(30);
+
+  applyPipelineSnapshot(pipelineRow("patched") as never, false);
+  await Bun.sleep(0);
+  expect(fetches).toBe(2);
+  expect(host.children[0]?.textContent).toBe(JSON.stringify({
+    files: ["/global", pinnedPath],
+    pins: [pinnedPath],
+    scope: `/api/files?path=${encodeURIComponent(pinnedPath)}`,
+    task: "patched",
+  }));
+  expect(host.children[1]?.textContent).toBe(JSON.stringify({
+    files: ["/global"],
+    pins: [],
+    scope: "/api/files",
+    task: "patched",
+  }));
+
+  revertPipelineSnapshot("p1");
+  await Bun.sleep(0);
+  expect(fetches).toBe(2);
+  expect(host.children[0]?.textContent).toContain('"task":"server"');
+  expect(host.children[0]?.textContent).toContain(pinnedPath);
+  expect(host.children[1]?.textContent).toBe(JSON.stringify({
+    files: ["/global"],
+    pins: [],
+    scope: "/api/files",
+    task: "server",
+  }));
+
+  flushSync(() => { root.unmount(); });
+  host.remove();
+});
 
 test("a failed cold hydration keeps creation guarded and retries until a snapshot succeeds", async () => {
   let calls = 0;

--- a/src/hooks/useFiles.dom.test.tsx
+++ b/src/hooks/useFiles.dom.test.tsx
@@ -123,6 +123,93 @@ test("concurrent pinned and global hooks keep their scopes through local pipelin
   host.remove();
 });
 
+test("hook initialization paints only an exact request-scope cache snapshot", async () => {
+  const pinA = "/archive/pin-a.jsonl";
+  const pinB = "/archive/pin-b.jsonl";
+  let calls = 0;
+  let release!: () => void;
+  const gate = new Promise<void>((resolve) => { release = resolve; });
+  globalThis.fetch = mock(async (input: string | URL | Request) => {
+    calls += 1;
+    const url = String(input);
+    if (calls > 1) await gate;
+    const pinnedPath = new URL(url, "http://localhost").searchParams.get("path");
+    return new Response(JSON.stringify({
+      files: pinnedPath ? [{ path: "/global" }, { path: pinnedPath }] : [{ path: "/global" }],
+      pinOverlayPaths: pinnedPath ? [pinnedPath] : [],
+    }));
+  }) as unknown as typeof fetch;
+
+  const warmHost = document.createElement("div");
+  document.body.append(warmHost);
+  const warmRoot = createRoot(warmHost);
+  flushSync(() => { warmRoot.render(<ScopedProbe pinnedPath={pinA} />); });
+  await Bun.sleep(20);
+  expect(warmHost.textContent).toContain(pinA);
+  flushSync(() => { warmRoot.unmount(); });
+  warmHost.remove();
+
+  const host = document.createElement("div");
+  document.body.append(host);
+  const root = createRoot(host);
+  flushSync(() => {
+    root.render(<>
+      <ScopedProbe />
+      <ScopedProbe pinnedPath={pinB} />
+      <ScopedProbe pinnedPath={pinA} />
+    </>);
+  });
+
+  expect(host.children[0]?.textContent).toContain('"files":[]');
+  expect(host.children[1]?.textContent).toContain('"files":[]');
+  expect(host.children[2]?.textContent).toContain(pinA);
+  expect(host.children[0]?.textContent).not.toContain(pinA);
+  expect(host.children[1]?.textContent).not.toContain(pinA);
+
+  release();
+  await Bun.sleep(30);
+  flushSync(() => { root.unmount(); });
+  host.remove();
+});
+
+test("an already-mounted hook drops pin-only rows in the render that changes scope", async () => {
+  const pinA = "/archive/switch-pin-a.jsonl";
+  const pinB = "/archive/switch-pin-b.jsonl";
+  let calls = 0;
+  let release!: () => void;
+  const gate = new Promise<void>((resolve) => { release = resolve; });
+  globalThis.fetch = mock(async (input: string | URL | Request) => {
+    calls += 1;
+    const url = String(input);
+    if (calls > 1) await gate;
+    const pinnedPath = new URL(url, "http://localhost").searchParams.get("path");
+    return new Response(JSON.stringify({
+      files: pinnedPath ? [{ path: "/global" }, { path: pinnedPath }] : [{ path: "/global" }],
+      pinOverlayPaths: pinnedPath ? [pinnedPath] : [],
+    }));
+  }) as unknown as typeof fetch;
+
+  const host = document.createElement("div");
+  document.body.append(host);
+  const root = createRoot(host);
+  flushSync(() => { root.render(<ScopedProbe pinnedPath={pinA} />); });
+  await Bun.sleep(20);
+  expect(host.textContent).toContain(pinA);
+
+  flushSync(() => { root.render(<ScopedProbe pinnedPath={pinB} />); });
+  expect(host.textContent).toContain('"files":[]');
+  expect(host.textContent).not.toContain(pinA);
+
+  flushSync(() => { root.render(<ScopedProbe />); });
+  expect(host.textContent).toContain('"files":[]');
+  expect(host.textContent).not.toContain(pinA);
+
+  release();
+  await Bun.sleep(30);
+  flushSync(() => { root.unmount(); });
+  host.remove();
+});
+
 test("a failed cold hydration keeps creation guarded and retries until a snapshot succeeds", async () => {
   let calls = 0;
   globalThis.fetch = mock(async () => {

--- a/src/hooks/useFiles.test.ts
+++ b/src/hooks/useFiles.test.ts
@@ -452,6 +452,49 @@ test("multi-second generation completion uses one bounded retry chain per scope 
   unsubscribeReplacement();
 });
 
+test("a queued completion retry stays canceled after final unsubscribe and resubscribe", async () => {
+  const blockerPath = "/queue/blocker";
+  const drainPath = "/queue/drain";
+  let releaseBlocker!: () => void;
+  let markBlockerStarted!: () => void;
+  const blockerGate = new Promise<void>((resolve) => { releaseBlocker = resolve; });
+  const blockerStarted = new Promise<void>((resolve) => { markBlockerStarted = resolve; });
+  let globalCalls = 0;
+  const cache = createFilesClientCache(async (input) => {
+    if (input === filesApiUrl(undefined, blockerPath)) {
+      markBlockerStarted();
+      await blockerGate;
+      return new Response(JSON.stringify({ files: [file(blockerPath, "Blocker")] }));
+    }
+    if (input === filesApiUrl(undefined, drainPath)) {
+      return new Response(JSON.stringify({ files: [file(drainPath, "Drain")] }));
+    }
+    globalCalls += 1;
+    return new Response(JSON.stringify({ files: [file(`/global/${globalCalls}`, "Global")] }), {
+      headers: {
+        "x-llv-files-generation": globalCalls === 1 ? "0" : "1",
+        "x-llv-files-target-generation": "1",
+      },
+    });
+  });
+  const unsubscribe = cache.subscribe(() => {});
+
+  await cache.revalidate();
+  const blocker = cache.revalidate(blockerPath);
+  await blockerStarted;
+  await Bun.sleep(75);
+  unsubscribe();
+  const unsubscribeReplacement = cache.subscribe(() => {});
+  releaseBlocker();
+  await blocker;
+  await cache.revalidate(drainPath);
+
+  expect(globalCalls).toBe(1);
+  await cache.revalidate();
+  expect(globalCalls).toBe(2);
+  unsubscribeReplacement();
+});
+
 test("an unconfirmed optimistic pipeline outlives every scan until reverted", async () => {
   const cache = createFilesClientCache(async () =>
     new Response(JSON.stringify({ files: [], pipelines: [pipelineRow("p1", "server")] })));

--- a/src/hooks/useFiles.test.ts
+++ b/src/hooks/useFiles.test.ts
@@ -644,6 +644,42 @@ test("a queued completion retry stays canceled after final unsubscribe and resub
   unsubscribeReplacement();
 });
 
+test("disposing a cache aborts active completion and prevents timers and listeners from escaping", async () => {
+  let calls = 0;
+  let activeSignal: AbortSignal | undefined;
+  let markActive!: () => void;
+  const active = new Promise<void>((resolve) => { markActive = resolve; });
+  const updates: string[] = [];
+  const cache = createFilesClientCache(async (_input, init) => {
+    calls += 1;
+    if (calls === 1) {
+      return new Response(JSON.stringify({ files: [file("/stale", "Stale")] }), {
+        headers: {
+          "x-llv-files-generation": "0",
+          "x-llv-files-target-generation": "1",
+        },
+      });
+    }
+    activeSignal = init?.signal ?? undefined;
+    markActive();
+    return new Promise<Response>((_resolve, reject) => {
+      activeSignal?.addEventListener("abort", () => reject(activeSignal?.reason), { once: true });
+    });
+  });
+  cache.subscribe((data) => updates.push(data.files[0]?.path ?? ""));
+
+  await cache.revalidate();
+  await active;
+  cache.dispose();
+  const updatesAtDispose = [...updates];
+  await Bun.sleep(75);
+  cache.applyPipeline(pipelineRow("p1", "escaped") as never, false);
+
+  expect(activeSignal?.aborted).toBe(true);
+  expect(calls).toBe(2);
+  expect(updates).toEqual(updatesAtDispose);
+});
+
 test("an unconfirmed optimistic pipeline outlives every scan until reverted", async () => {
   const cache = createFilesClientCache(async () =>
     new Response(JSON.stringify({ files: [], pipelines: [pipelineRow("p1", "server")] })));

--- a/src/hooks/useFiles.test.ts
+++ b/src/hooks/useFiles.test.ts
@@ -105,6 +105,34 @@ test("URL-specific 304 responses restore the matching cached representation", as
   expect(cache.read()).toBe(restored);
 });
 
+test("client cache subscriptions receive updates only for their request scope", async () => {
+  const pinnedPath = "/archive/scoped-pin.jsonl";
+  const cache = createFilesClientCache(async (input) => {
+    const files = input === "/api/files"
+      ? [file("/global", "Global")]
+      : [file("/global", "Global"), file(pinnedPath, "Pinned")];
+    return new Response(JSON.stringify({ files }));
+  });
+  const globalUpdates: string[][] = [];
+  const pinnedUpdates: string[][] = [];
+  const unsubscribeGlobal = cache.subscribe((data) => {
+    globalUpdates.push(data.files.map((entry) => entry.path));
+  });
+  const unsubscribePinned = cache.subscribe((data) => {
+    pinnedUpdates.push(data.files.map((entry) => entry.path));
+  }, pinnedPath);
+
+  await cache.revalidate(pinnedPath);
+  expect(globalUpdates).toEqual([]);
+  expect(pinnedUpdates).toEqual([["/global", pinnedPath]]);
+
+  await cache.revalidate();
+  expect(globalUpdates).toEqual([["/global"]]);
+  expect(pinnedUpdates).toEqual([["/global", pinnedPath]]);
+  unsubscribeGlobal();
+  unsubscribePinned();
+});
+
 test("a global 304 restores its exact cached membership and values", async () => {
   let globalRequests = 0;
   const cache = createFilesClientCache(async (input, init) => {
@@ -325,6 +353,38 @@ test("a pipeline echo applies without a refetch and survives a STALE in-flight s
   /* …but a scan REQUESTED after the echo is authoritative and retires the overlay. */
   await cache.revalidate();
   expect(cache.read().pipelines[0]!.task).toBe("old task");
+});
+
+test("a generation retry preserves a pipeline echo newer than the scan it completes", async () => {
+  let call = 0;
+  let releaseStale!: () => void;
+  const staleGate = new Promise<void>((resolve) => { releaseStale = resolve; });
+  const cache = createFilesClientCache(async () => {
+    call += 1;
+    if (call === 2) await staleGate;
+    const headers = call === 2
+      ? { "x-llv-files-generation": "0", "x-llv-files-target-generation": "1" }
+      : call === 3
+        ? { "x-llv-files-generation": "1", "x-llv-files-target-generation": "1" }
+        : undefined;
+    return new Response(JSON.stringify({ files: [], pipelines: [pipelineRow("p1", "server")] }), { headers });
+  });
+  const unsubscribe = cache.subscribe(() => {});
+
+  await cache.revalidate();
+  const stale = cache.revalidate(undefined, 9);
+  await Promise.resolve();
+  await Promise.resolve();
+  cache.applyPipeline(pipelineRow("p1", "patched") as never, true);
+  releaseStale();
+  await stale;
+  await Bun.sleep(50);
+
+  expect(call).toBe(3);
+  expect(cache.read().pipelines[0]?.task).toBe("patched");
+  await cache.revalidate();
+  expect(cache.read().pipelines[0]?.task).toBe("server");
+  unsubscribe();
 });
 
 test("an unconfirmed optimistic pipeline outlives every scan until reverted", async () => {

--- a/src/hooks/useFiles.test.ts
+++ b/src/hooks/useFiles.test.ts
@@ -387,6 +387,71 @@ test("a generation retry preserves a pipeline echo newer than the scan it comple
   unsubscribe();
 });
 
+test("multi-second generation completion uses one bounded retry chain per scope and stops after unsubscribe", async () => {
+  const startedAt = performance.now();
+  const requestedTargets: string[] = [];
+  let calls = 0;
+  const cache = createFilesClientCache(async (_input, init) => {
+    calls += 1;
+    const target = new Headers(init?.headers).get("x-llv-files-generation");
+    if (target) requestedTargets.push(target);
+    const complete = performance.now() - startedAt >= 2_100;
+    return new Response(JSON.stringify({
+      files: [file(complete ? "/complete" : "/stale", complete ? "Complete" : "Stale")],
+      pipelines: [pipelineRow("p1", "server")],
+    }), {
+      headers: {
+        "x-llv-files-generation": complete ? "1" : "0",
+        "x-llv-files-target-generation": "1",
+      },
+    });
+  });
+  const firstUpdates: string[] = [];
+  const secondUpdates: string[] = [];
+  const unsubscribeFirst = cache.subscribe((data) => firstUpdates.push(data.files[0]?.path ?? ""));
+  const unsubscribeSecond = cache.subscribe((data) => secondUpdates.push(data.files[0]?.path ?? ""));
+
+  await Promise.all([
+    cache.revalidate(undefined, 31),
+    cache.revalidate(undefined, 31),
+  ]);
+  cache.applyPipeline(pipelineRow("p1", "patched") as never, true);
+  for (let attempt = 0; attempt < 80 && cache.read().files[0]?.path !== "/complete"; attempt += 1) {
+    await Bun.sleep(50);
+  }
+
+  expect(cache.read().files[0]?.path).toBe("/complete");
+  expect(cache.read().pipelines[0]?.task).toBe("patched");
+  expect(calls).toBeLessThanOrEqual(10);
+  expect(requestedTargets.length).toBeGreaterThan(0);
+  expect(new Set(requestedTargets)).toEqual(new Set(["1"]));
+  expect(firstUpdates.at(-1)).toBe("/complete");
+  expect(secondUpdates).toEqual(firstUpdates);
+
+  await cache.revalidate();
+  expect(cache.read().pipelines[0]?.task).toBe("server");
+  unsubscribeFirst();
+  unsubscribeSecond();
+
+  let callsAfterResubscribe = 0;
+  const cancellationCache = createFilesClientCache(async () => {
+    callsAfterResubscribe += 1;
+    return new Response(JSON.stringify({ files: [] }), {
+      headers: {
+        "x-llv-files-generation": "0",
+        "x-llv-files-target-generation": "1",
+      },
+    });
+  });
+  const unsubscribe = cancellationCache.subscribe(() => {});
+  await cancellationCache.revalidate();
+  unsubscribe();
+  const unsubscribeReplacement = cancellationCache.subscribe(() => {});
+  await Bun.sleep(75);
+  expect(callsAfterResubscribe).toBe(1);
+  unsubscribeReplacement();
+});
+
 test("an unconfirmed optimistic pipeline outlives every scan until reverted", async () => {
   const cache = createFilesClientCache(async () =>
     new Response(JSON.stringify({ files: [], pipelines: [pipelineRow("p1", "server")] })));

--- a/src/hooks/useFiles.test.ts
+++ b/src/hooks/useFiles.test.ts
@@ -9,7 +9,7 @@ import {
   type ActiveConversationPin,
 } from "@/components/conversationPin";
 
-import { createFilesClientCache, filesApiUrl, filesPollCadence, filesRequestHeaders } from "./useFiles";
+import { createFilesClientCache, filesApiUrl, filesPollCadence, filesRequestHeaders, type FilesData } from "./useFiles";
 
 test("filesApiUrl keeps project switches on the bounded scheme feed", () => {
   expect(filesApiUrl()).toBe("/api/files");
@@ -131,6 +131,155 @@ test("client cache subscriptions receive updates only for their request scope", 
   expect(pinnedUpdates).toEqual([["/global", pinnedPath]]);
   unsubscribeGlobal();
   unsubscribePinned();
+});
+
+test("pipeline patches publish each cached URL representation without refetching", async () => {
+  const pinnedPath = "/archive/scoped-pipeline-pin.jsonl";
+  let fetches = 0;
+  const cache = createFilesClientCache(async (input) => {
+    fetches += 1;
+    const pinned = input !== "/api/files";
+    return new Response(JSON.stringify({
+      files: pinned
+        ? [file("/global", "Global"), file(pinnedPath, "Pinned")]
+        : [file("/global", "Global")],
+      pinOverlayPaths: pinned ? [pinnedPath] : [],
+      pipelines: [pipelineRow("p1", "server")],
+    }));
+  });
+  const notifications: Array<{ listener: "pinned" | "global"; scope: string | null; files: string[]; pins: string[]; task: string }> = [];
+  const unsubscribePinned = cache.subscribe((data) => notifications.push({
+    listener: "pinned",
+    scope: data.requestScope,
+    files: data.files.map((entry) => entry.path),
+    pins: data.pinOverlayPaths,
+    task: data.pipelines[0]?.task ?? "",
+  }), pinnedPath);
+  const unsubscribeGlobal = cache.subscribe((data) => notifications.push({
+    listener: "global",
+    scope: data.requestScope,
+    files: data.files.map((entry) => entry.path),
+    pins: data.pinOverlayPaths,
+    task: data.pipelines[0]?.task ?? "",
+  }));
+
+  await cache.revalidate(pinnedPath);
+  await cache.revalidate();
+  notifications.length = 0;
+
+  cache.applyPipeline(pipelineRow("p1", "patched") as never, false);
+  expect(fetches).toBe(2);
+  expect(notifications).toEqual([
+    {
+      listener: "pinned",
+      scope: filesApiUrl(undefined, pinnedPath),
+      files: ["/global", pinnedPath],
+      pins: [pinnedPath],
+      task: "patched",
+    },
+    {
+      listener: "global",
+      scope: "/api/files",
+      files: ["/global"],
+      pins: [],
+      task: "patched",
+    },
+  ]);
+
+  notifications.length = 0;
+  cache.revertPipeline("p1");
+  expect(fetches).toBe(2);
+  expect(notifications.map(({ listener, scope, task }) => ({ listener, scope, task }))).toEqual([
+    { listener: "pinned", scope: filesApiUrl(undefined, pinnedPath), task: "server" },
+    { listener: "global", scope: "/api/files", task: "server" },
+  ]);
+
+  unsubscribePinned();
+  notifications.length = 0;
+  cache.applyPipeline(pipelineRow("p1", "patched again") as never, false);
+  expect(notifications.map(({ listener }) => listener)).toEqual(["global"]);
+  unsubscribeGlobal();
+});
+
+test("a pinned generation retry restores its ETag representation with the local pipeline overlay", async () => {
+  const pinnedPath = "/archive/retrying-pipeline-pin.jsonl";
+  const pinnedUrl = filesApiUrl(undefined, pinnedPath);
+  let pinnedRequests = 0;
+  const cache = createFilesClientCache(async (input, init) => {
+    if (input === "/api/files") {
+      return new Response(JSON.stringify({
+        files: [file("/global", "Global")],
+        pipelines: [pipelineRow("p1", "server")],
+      }), { headers: { ETag: '"global"' } });
+    }
+    pinnedRequests += 1;
+    if (pinnedRequests > 1) {
+      expect(new Headers(init?.headers).get("If-None-Match")).toBe('"pinned"');
+      expect(new Headers(init?.headers).get("x-llv-files-generation")).toBe(pinnedRequests === 2 ? null : "1");
+      return new Response(null, {
+        status: 304,
+        headers: {
+          "x-llv-files-generation": pinnedRequests === 2 ? "0" : "1",
+          "x-llv-files-target-generation": "1",
+        },
+      });
+    }
+    return new Response(JSON.stringify({
+      files: [file("/global", "Global"), file(pinnedPath, "Pinned")],
+      pinOverlayPaths: [pinnedPath],
+      pipelines: [pipelineRow("p1", "server")],
+    }), { headers: { ETag: '"pinned"' } });
+  });
+  const notifications: string[] = [];
+  const unsubscribePinned = cache.subscribe((data) => notifications.push(
+    `pinned:${data.requestScope}:${data.files.map((entry) => entry.path).join(",")}:${data.pipelines[0]?.task}`,
+  ), pinnedPath);
+  const unsubscribeGlobal = cache.subscribe((data) => notifications.push(
+    `global:${data.requestScope}:${data.files.map((entry) => entry.path).join(",")}:${data.pipelines[0]?.task}`,
+  ));
+
+  await cache.revalidate(pinnedPath);
+  await cache.revalidate();
+  cache.applyPipeline(pipelineRow("p1", "optimistic") as never, false);
+  notifications.length = 0;
+  await cache.revalidate(pinnedPath, 12);
+  await Bun.sleep(60);
+
+  expect(pinnedRequests).toBe(3);
+  expect(notifications).toEqual([
+    `pinned:${pinnedUrl}:/global,${pinnedPath}:optimistic`,
+    `pinned:${pinnedUrl}:/global,${pinnedPath}:optimistic`,
+  ]);
+  unsubscribePinned();
+  unsubscribeGlobal();
+});
+
+test("active scoped representations survive LRU pressure during a pipeline patch", async () => {
+  const pinnedPaths = Array.from({ length: 10 }, (_, index) => `/archive/active-pin-${index}.jsonl`);
+  const cache = createFilesClientCache(async (input) => {
+    const url = new URL(input, "http://127.0.0.1");
+    const pinnedPath = url.searchParams.get("path")!;
+    return new Response(JSON.stringify({
+      files: [file("/global", "Global"), file(pinnedPath, "Pinned")],
+      pinOverlayPaths: [pinnedPath],
+      pipelines: [pipelineRow("p1", "server")],
+    }));
+  });
+  const updates = new Map<string, FilesData>();
+  const unsubscribes = pinnedPaths.map((pinnedPath) => cache.subscribe((data) => {
+    updates.set(pinnedPath, data);
+  }, pinnedPath));
+  for (const pinnedPath of pinnedPaths) await cache.revalidate(pinnedPath);
+  updates.clear();
+
+  cache.applyPipeline(pipelineRow("p1", "patched") as never, false);
+
+  expect([...updates]).toHaveLength(pinnedPaths.length);
+  for (const pinnedPath of pinnedPaths) {
+    expect(updates.get(pinnedPath)?.files.map((entry) => entry.path)).toEqual(["/global", pinnedPath]);
+    expect(updates.get(pinnedPath)?.pipelines[0]?.task).toBe("patched");
+  }
+  for (const unsubscribe of unsubscribes) unsubscribe();
 });
 
 test("a global 304 restores its exact cached membership and values", async () => {

--- a/src/hooks/useFiles.ts
+++ b/src/hooks/useFiles.ts
@@ -22,6 +22,7 @@ const POLL_MS = 10_000;
 const FILES_DEBOUNCE_MS = 400;
 const FILES_REVISION_RETRY_MS = 1_000;
 const FILES_GENERATION_RETRY_MS = 25;
+const FILES_GENERATION_RETRY_MAX_MS = 1_000;
 
 export interface FilesData {
   files: FileEntry[];
@@ -55,6 +56,14 @@ export function filesApiUrl(_project?: string | null, pinnedPath?: string | null
 }
 
 type FilesFetcher = (input: string, init?: RequestInit) => Promise<Response>;
+type CompletionRetry = {
+  pinnedPath?: string | null;
+  revision?: number;
+  targetGeneration: number;
+  logicalGeneration: number;
+  attempt: number;
+  timer?: ReturnType<typeof setTimeout>;
+};
 
 export interface FilesClientCache {
   read(): FilesData;
@@ -132,12 +141,7 @@ export function createFilesClientCache(fetcher: FilesFetcher): FilesClientCache 
   let snapshot = EMPTY;
   const representations = new Map<string, { data: FilesData; etag?: string }>();
   const listeners = new Map<(data: FilesData) => void, string>();
-  const completionRetries = new Map<string, {
-    pinnedPath?: string | null;
-    revision?: number;
-    targetGeneration: number;
-    logicalGeneration: number;
-  }>();
+  const completionRetries = new Map<string, CompletionRetry>();
   let requestedGeneration = 0;
   let appliedGeneration = 0;
   let requestQueue: Promise<void> = Promise.resolve();
@@ -156,6 +160,13 @@ export function createFilesClientCache(fetcher: FilesFetcher): FilesClientCache 
 
   const hasSubscriber = (requestScope: string): boolean =>
     [...listeners.values()].some((scope) => scope === requestScope);
+
+  const cancelCompletionRetry = (requestScope: string) => {
+    const retry = completionRetries.get(requestScope);
+    if (!retry) return;
+    completionRetries.delete(requestScope);
+    if (retry.timer !== undefined) clearTimeout(retry.timer);
+  };
 
   const composePipelines = () => {
     if (!pipelineOverlays.size) {
@@ -202,6 +213,7 @@ export function createFilesClientCache(fetcher: FilesFetcher): FilesClientCache 
     revision?: number,
     requiredGeneration?: number,
     logicalGeneration?: number,
+    completionRetryAttempt = 0,
   ): Promise<FilesData> => {
     const generation = ++requestedGeneration;
     const url = filesApiUrl(undefined, pinnedPath);
@@ -222,7 +234,16 @@ export function createFilesClientCache(fetcher: FilesFetcher): FilesClientCache 
       settleServerPipelines(logicalGeneration ?? generation, !generationIncomplete);
       publish(url);
       if (generationIncomplete) {
-        scheduleCompletionRetry(url, pinnedPath, revision, targetGeneration, logicalGeneration ?? generation);
+        scheduleCompletionRetry(
+          url,
+          pinnedPath,
+          revision,
+          targetGeneration,
+          logicalGeneration ?? generation,
+          completionRetryAttempt,
+        );
+      } else {
+        cancelCompletionRetry(url);
       }
       return snapshot;
     }
@@ -237,7 +258,16 @@ export function createFilesClientCache(fetcher: FilesFetcher): FilesClientCache 
     settleServerPipelines(logicalGeneration ?? generation, !generationIncomplete);
     publish(url);
     if (generationIncomplete) {
-      scheduleCompletionRetry(url, pinnedPath, revision, targetGeneration, logicalGeneration ?? generation);
+      scheduleCompletionRetry(
+        url,
+        pinnedPath,
+        revision,
+        targetGeneration,
+        logicalGeneration ?? generation,
+        completionRetryAttempt,
+      );
+    } else {
+      cancelCompletionRetry(url);
     }
     return snapshot;
   };
@@ -247,12 +277,14 @@ export function createFilesClientCache(fetcher: FilesFetcher): FilesClientCache 
     revision?: number,
     requiredGeneration?: number,
     logicalGeneration?: number,
+    completionRetryAttempt?: number,
   ): Promise<FilesData> => {
     const result = requestQueue.then(() => performRevalidate(
       pinnedPath,
       revision,
       requiredGeneration,
       logicalGeneration,
+      completionRetryAttempt,
     ));
     requestQueue = result.then(() => undefined, () => undefined);
     return result;
@@ -264,27 +296,36 @@ export function createFilesClientCache(fetcher: FilesFetcher): FilesClientCache 
     revision: number | undefined,
     targetGeneration: number,
     logicalGeneration: number,
-    delay = FILES_GENERATION_RETRY_MS,
+    attempt: number,
   ) => {
     if (!hasSubscriber(url)) return;
     const pending = completionRetries.get(url);
     if (pending) {
       if (pending.targetGeneration < targetGeneration) {
-        completionRetries.set(url, { pinnedPath, revision, targetGeneration, logicalGeneration });
+        pending.pinnedPath = pinnedPath;
+        pending.revision = revision;
+        pending.targetGeneration = targetGeneration;
+        pending.logicalGeneration = logicalGeneration;
       }
       return;
     }
-    completionRetries.set(url, { pinnedPath, revision, targetGeneration, logicalGeneration });
-    setTimeout(() => {
-      const retry = completionRetries.get(url);
-      if (!retry) return;
+    const retry: CompletionRetry = { pinnedPath, revision, targetGeneration, logicalGeneration, attempt };
+    completionRetries.set(url, retry);
+    const delay = Math.min(
+      FILES_GENERATION_RETRY_MAX_MS,
+      FILES_GENERATION_RETRY_MS * 2 ** Math.min(attempt, 10),
+    );
+    retry.timer = setTimeout(() => {
+      if (completionRetries.get(url) !== retry) return;
       completionRetries.delete(url);
       if (!hasSubscriber(url)) return;
+      const nextAttempt = retry.attempt + 1;
       void enqueueRevalidate(
         retry.pinnedPath,
         retry.revision,
         retry.targetGeneration,
         retry.logicalGeneration,
+        nextAttempt,
       ).catch(() => {
         scheduleCompletionRetry(
           url,
@@ -292,7 +333,7 @@ export function createFilesClientCache(fetcher: FilesFetcher): FilesClientCache 
           retry.revision,
           retry.targetGeneration,
           retry.logicalGeneration,
-          FILES_REVISION_RETRY_MS,
+          nextAttempt,
         );
       });
     }, delay);
@@ -322,8 +363,12 @@ export function createFilesClientCache(fetcher: FilesFetcher): FilesClientCache 
   };
 
   const subscribe = (listener: (data: FilesData) => void, pinnedPath?: string | null) => {
-    listeners.set(listener, filesApiUrl(undefined, pinnedPath));
-    return () => { listeners.delete(listener); };
+    const requestScope = filesApiUrl(undefined, pinnedPath);
+    listeners.set(listener, requestScope);
+    return () => {
+      listeners.delete(listener);
+      if (!hasSubscriber(requestScope)) cancelCompletionRetry(requestScope);
+    };
   };
 
   return { read: () => snapshot, revalidate, subscribe, applyPipeline, revertPipeline };

--- a/src/hooks/useFiles.ts
+++ b/src/hooks/useFiles.ts
@@ -277,7 +277,15 @@ export function createFilesClientCache(fetcher: FilesFetcher): FilesClientCache 
     if (completionRetry && !ownsCompletionRetry(url, completionRetry)) return snapshot;
     if (generation < appliedGeneration) return snapshot;
     const incoming = parsedFilesData(parsed, url);
-    snapshot = patchFilesData(snapshot, incoming);
+    /* A restarted server can acknowledge a pinned target generation with its
+       global-only stale snapshot before the pin hydration resumes. Keep the
+       last URL-scoped completed representation mounted until that generation
+       supplies the target, so the deep-link owner retains its subscription. */
+    const scopedIncoming = generationIncomplete && pinnedPath
+      && representation?.data.files.some((file) => file.path === pinnedPath)
+      ? { ...representation.data, requestScope: url }
+      : incoming;
+    snapshot = patchFilesData(snapshot, scopedIncoming);
     appliedGeneration = generation;
     const etag = response.headers.get("ETag");
     rememberRepresentation(url, snapshot, etag ?? undefined);

--- a/src/hooks/useFiles.ts
+++ b/src/hooks/useFiles.ts
@@ -21,6 +21,7 @@ const POLL_MS = 10_000;
 /** Debounce after a `files.revision` event before the pure GET fires. */
 const FILES_DEBOUNCE_MS = 400;
 const FILES_REVISION_RETRY_MS = 1_000;
+const FILES_GENERATION_RETRY_MS = 25;
 
 export interface FilesData {
   files: FileEntry[];
@@ -58,6 +59,7 @@ type FilesFetcher = (input: string, init?: RequestInit) => Promise<Response>;
 export interface FilesClientCache {
   read(): FilesData;
   revalidate(pinnedPath?: string | null, revision?: number): Promise<FilesData>;
+  subscribe(listener: (data: FilesData) => void, pinnedPath?: string | null): () => void;
   /** Layer one pipeline record over the server snapshot without a refetch — an
       optimistic local mutation (`confirmed: false`, held until reverted or
       confirmed) or a PATCH/POST echo (`confirmed: true`, held only until a scan
@@ -129,6 +131,13 @@ function restoreNotModified(current: FilesData, representation: FilesData, reque
 export function createFilesClientCache(fetcher: FilesFetcher): FilesClientCache {
   let snapshot = EMPTY;
   const representations = new Map<string, { data: FilesData; etag?: string }>();
+  const listeners = new Map<(data: FilesData) => void, string>();
+  const completionRetries = new Map<string, {
+    pinnedPath?: string | null;
+    revision?: number;
+    targetGeneration: number;
+    logicalGeneration: number;
+  }>();
   let requestedGeneration = 0;
   let appliedGeneration = 0;
   let requestQueue: Promise<void> = Promise.resolve();
@@ -138,6 +147,15 @@ export function createFilesClientCache(fetcher: FilesFetcher): FilesClientCache 
      roll an applied edit back. `pipeline: null` hides a locally deleted draft. */
   const pipelineOverlays = new Map<string, { pipeline: Pipeline | null; minGeneration: number }>();
   let serverPipelines: readonly Pipeline[] = EMPTY.pipelines;
+
+  const publish = (requestScope?: string) => {
+    for (const [listener, scope] of listeners) {
+      if (requestScope === undefined || requestScope === scope) listener(snapshot);
+    }
+  };
+
+  const hasSubscriber = (requestScope: string): boolean =>
+    [...listeners.values()].some((scope) => scope === requestScope);
 
   const composePipelines = () => {
     if (!pipelineOverlays.size) {
@@ -157,12 +175,14 @@ export function createFilesClientCache(fetcher: FilesFetcher): FilesClientCache 
     snapshot = { ...snapshot, pipelines };
   };
 
-  /** The server snapshot from `generation` reflects every overlay whose
+  /** A completed server snapshot from `generation` reflects every overlay whose
       minGeneration it reaches — those overlays retire; younger ones re-apply. */
-  const settleServerPipelines = (generation: number) => {
+  const settleServerPipelines = (generation: number, complete: boolean) => {
     serverPipelines = snapshot.pipelines;
-    for (const [id, entry] of pipelineOverlays) {
-      if (entry.minGeneration <= generation) pipelineOverlays.delete(id);
+    if (complete) {
+      for (const [id, entry] of pipelineOverlays) {
+        if (entry.minGeneration <= generation) pipelineOverlays.delete(id);
+      }
     }
     if (pipelineOverlays.size) composePipelines();
   };
@@ -177,19 +197,33 @@ export function createFilesClientCache(fetcher: FilesFetcher): FilesClientCache 
     }
   };
 
-  const performRevalidate = async (pinnedPath?: string | null, revision?: number): Promise<FilesData> => {
+  const performRevalidate = async (
+    pinnedPath?: string | null,
+    revision?: number,
+    requiredGeneration?: number,
+    logicalGeneration?: number,
+  ): Promise<FilesData> => {
     const generation = ++requestedGeneration;
     const url = filesApiUrl(undefined, pinnedPath);
     const representation = representations.get(url);
-    const headers = filesRequestHeaders(representation?.etag ?? "", revision);
+    const headers = filesRequestHeaders(representation?.etag ?? "", revision, requiredGeneration);
     const response = await fetcher(url, headers ? { headers } : undefined);
+    const servedGeneration = responseGeneration(response, "x-llv-files-generation");
+    const targetGeneration = responseGeneration(response, "x-llv-files-target-generation");
+    const generationIncomplete = servedGeneration !== undefined
+      && targetGeneration !== undefined
+      && servedGeneration < targetGeneration;
     if (response.status === 304) {
       if (!representation) throw new Error("files request returned 304 without a cached representation");
       if (generation < appliedGeneration) return snapshot;
       snapshot = restoreNotModified(snapshot, representation.data, url);
       appliedGeneration = generation;
       rememberRepresentation(url, snapshot, representation.etag);
-      settleServerPipelines(generation);
+      settleServerPipelines(logicalGeneration ?? generation, !generationIncomplete);
+      publish(url);
+      if (generationIncomplete) {
+        scheduleCompletionRetry(url, pinnedPath, revision, targetGeneration, logicalGeneration ?? generation);
+      }
       return snapshot;
     }
     if (!response.ok) throw new Error(`files request failed: ${response.status}`);
@@ -200,15 +234,72 @@ export function createFilesClientCache(fetcher: FilesFetcher): FilesClientCache 
     appliedGeneration = generation;
     const etag = response.headers.get("ETag");
     rememberRepresentation(url, snapshot, etag ?? undefined);
-    settleServerPipelines(generation);
+    settleServerPipelines(logicalGeneration ?? generation, !generationIncomplete);
+    publish(url);
+    if (generationIncomplete) {
+      scheduleCompletionRetry(url, pinnedPath, revision, targetGeneration, logicalGeneration ?? generation);
+    }
     return snapshot;
   };
 
-  const revalidate = (pinnedPath?: string | null, revision?: number): Promise<FilesData> => {
-    const result = requestQueue.then(() => performRevalidate(pinnedPath, revision));
+  const enqueueRevalidate = (
+    pinnedPath?: string | null,
+    revision?: number,
+    requiredGeneration?: number,
+    logicalGeneration?: number,
+  ): Promise<FilesData> => {
+    const result = requestQueue.then(() => performRevalidate(
+      pinnedPath,
+      revision,
+      requiredGeneration,
+      logicalGeneration,
+    ));
     requestQueue = result.then(() => undefined, () => undefined);
     return result;
   };
+
+  const scheduleCompletionRetry = (
+    url: string,
+    pinnedPath: string | null | undefined,
+    revision: number | undefined,
+    targetGeneration: number,
+    logicalGeneration: number,
+    delay = FILES_GENERATION_RETRY_MS,
+  ) => {
+    if (!hasSubscriber(url)) return;
+    const pending = completionRetries.get(url);
+    if (pending) {
+      if (pending.targetGeneration < targetGeneration) {
+        completionRetries.set(url, { pinnedPath, revision, targetGeneration, logicalGeneration });
+      }
+      return;
+    }
+    completionRetries.set(url, { pinnedPath, revision, targetGeneration, logicalGeneration });
+    setTimeout(() => {
+      const retry = completionRetries.get(url);
+      if (!retry) return;
+      completionRetries.delete(url);
+      if (!hasSubscriber(url)) return;
+      void enqueueRevalidate(
+        retry.pinnedPath,
+        retry.revision,
+        retry.targetGeneration,
+        retry.logicalGeneration,
+      ).catch(() => {
+        scheduleCompletionRetry(
+          url,
+          retry.pinnedPath,
+          retry.revision,
+          retry.targetGeneration,
+          retry.logicalGeneration,
+          FILES_REVISION_RETRY_MS,
+        );
+      });
+    }, delay);
+  };
+
+  const revalidate = (pinnedPath?: string | null, revision?: number): Promise<FilesData> =>
+    enqueueRevalidate(pinnedPath, revision);
 
   const applyPipeline = (pipeline: Pipeline, confirmed: boolean) => {
     /* A deleted/closed draft echo carries hiddenAt — locally it just disappears
@@ -221,14 +312,21 @@ export function createFilesClientCache(fetcher: FilesFetcher): FilesClientCache 
       minGeneration: confirmed ? requestedGeneration + 1 : Number.POSITIVE_INFINITY,
     });
     composePipelines();
+    publish();
   };
 
   const revertPipeline = (id: string) => {
     if (!pipelineOverlays.delete(id)) return;
     composePipelines();
+    publish();
   };
 
-  return { read: () => snapshot, revalidate, applyPipeline, revertPipeline };
+  const subscribe = (listener: (data: FilesData) => void, pinnedPath?: string | null) => {
+    listeners.set(listener, filesApiUrl(undefined, pinnedPath));
+    return () => { listeners.delete(listener); };
+  };
+
+  return { read: () => snapshot, revalidate, subscribe, applyPipeline, revertPipeline };
 }
 
 const defaultFilesFetcher: FilesFetcher = (input, init) => fetch(input, init);
@@ -257,10 +355,22 @@ export function revertPipelineSnapshot(id: string): void {
   if (typeof window !== "undefined") window.dispatchEvent(new Event(PIPELINES_PATCHED_EVENT));
 }
 
-export function filesRequestHeaders(etag: string, revision?: number): Record<string, string> | undefined {
+function responseGeneration(response: Response, name: string): number | undefined {
+  const value = response.headers.get(name);
+  if (value === null || !/^\d+$/.test(value)) return undefined;
+  const generation = Number(value);
+  return Number.isSafeInteger(generation) ? generation : undefined;
+}
+
+export function filesRequestHeaders(
+  etag: string,
+  revision?: number,
+  generation?: number,
+): Record<string, string> | undefined {
   const headers: Record<string, string> = {};
   if (etag) headers["If-None-Match"] = etag;
   if (revision !== undefined) headers["x-llv-files-revision"] = String(revision);
+  if (generation !== undefined) headers["x-llv-files-generation"] = String(generation);
   return Object.keys(headers).length > 0 ? headers : undefined;
 }
 
@@ -278,6 +388,9 @@ export function useFiles(_project?: string | null, pinnedPath?: string | null): 
   const [data, setData] = useState<FilesData>(() => filesClientCache.read());
   useEffect(() => {
     let alive = true;
+    const unsubscribeCache = filesClientCache.subscribe((next) => {
+      if (alive) setData(next);
+    }, pinnedPath);
     const performLoad = async (revision?: number): Promise<boolean> => {
       if (!alive) return true;
       try {
@@ -380,6 +493,7 @@ export function useFiles(_project?: string | null, pinnedPath?: string | null): 
       if (timer) clearInterval(timer);
       if (initialRetryTimer) clearTimeout(initialRetryTimer);
       if (revisionTimer) clearTimeout(revisionTimer);
+      unsubscribeCache();
       unsubBus();
       unsubFiles();
       window.removeEventListener(PIPELINES_PATCHED_EVENT, onPatched);

--- a/src/hooks/useFiles.ts
+++ b/src/hooks/useFiles.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { flushSync } from "react-dom";
 
 import { FLOWS_CHANGED_EVENT } from "@/components/flows/flowModel";
 import { PIPELINES_CHANGED_EVENT, PIPELINES_PATCHED_EVENT } from "@/components/pipelines/pipelineEvents";
@@ -79,6 +80,8 @@ export interface FilesClientCache {
   /** Drop a local overlay (a failed optimistic mutation) — the server snapshot
       is authoritative again. */
   revertPipeline(id: string): void;
+  /** Cancel owned retries and detach subscribers. A disposed cache is inert. */
+  dispose(): void;
 }
 
 function equalValue(left: unknown, right: unknown): boolean {
@@ -141,6 +144,7 @@ function restoreNotModified(current: FilesData, representation: FilesData, reque
 /** Session-wide stale-while-revalidate cache over the global scan snapshot. */
 export function createFilesClientCache(fetcher: FilesFetcher): FilesClientCache {
   let snapshot = EMPTY;
+  let disposed = false;
   const representations = new Map<string, { data: FilesData; etag?: string }>();
   const listeners = new Map<(data: FilesData) => void, string>();
   const completionRetries = new Map<string, CompletionRetry>();
@@ -175,6 +179,7 @@ export function createFilesClientCache(fetcher: FilesFetcher): FilesClientCache 
   });
 
   const publish = (requestScope?: string) => {
+    if (disposed) return;
     for (const [listener, scope] of listeners) {
       if (requestScope !== undefined) {
         if (requestScope === scope) listener(snapshot);
@@ -241,6 +246,7 @@ export function createFilesClientCache(fetcher: FilesFetcher): FilesClientCache 
     completionRetryAttempt = 0,
     completionRetry?: CompletionRetry,
   ): Promise<FilesData> => {
+    if (disposed) return snapshot;
     const url = filesApiUrl(undefined, pinnedPath);
     if (completionRetry) {
       if (!ownsCompletionRetry(url, completionRetry)) return snapshot;
@@ -259,6 +265,7 @@ export function createFilesClientCache(fetcher: FilesFetcher): FilesClientCache 
     } finally {
       if (completionRetry) completionRetry.controller = undefined;
     }
+    if (disposed) return snapshot;
     if (completionRetry && !ownsCompletionRetry(url, completionRetry)) return snapshot;
     const servedGeneration = responseGeneration(response, "x-llv-files-generation");
     const targetGeneration = responseGeneration(response, "x-llv-files-target-generation");
@@ -331,6 +338,7 @@ export function createFilesClientCache(fetcher: FilesFetcher): FilesClientCache 
     completionRetryAttempt?: number,
     completionRetry?: CompletionRetry,
   ): Promise<FilesData> => {
+    if (disposed) return Promise.resolve(snapshot);
     const result = requestQueue.then(() => performRevalidate(
       pinnedPath,
       revision,
@@ -352,6 +360,7 @@ export function createFilesClientCache(fetcher: FilesFetcher): FilesClientCache 
     attempt: number,
     owner?: CompletionRetry,
   ) => {
+    if (disposed) return;
     if (!hasSubscriber(url)) {
       if (owner) cancelCompletionRetry(url);
       return;
@@ -420,6 +429,7 @@ export function createFilesClientCache(fetcher: FilesFetcher): FilesClientCache 
     enqueueRevalidate(pinnedPath, revision);
 
   const applyPipeline = (pipeline: Pipeline, confirmed: boolean) => {
+    if (disposed) return;
     /* A deleted/closed draft echo carries hiddenAt — locally it just disappears
        (the server's visibility filter drops it from the next scan too). */
     const hidden = Boolean(pipeline.hiddenAt) && !pipeline.restored;
@@ -434,12 +444,14 @@ export function createFilesClientCache(fetcher: FilesFetcher): FilesClientCache 
   };
 
   const revertPipeline = (id: string) => {
+    if (disposed) return;
     if (!pipelineOverlays.delete(id)) return;
     composePipelines();
     publish();
   };
 
   const subscribe = (listener: (data: FilesData) => void, pinnedPath?: string | null) => {
+    if (disposed) return () => {};
     const requestScope = filesApiUrl(undefined, pinnedPath);
     listeners.set(listener, requestScope);
     return () => {
@@ -449,13 +461,21 @@ export function createFilesClientCache(fetcher: FilesFetcher): FilesClientCache 
     };
   };
 
-  return { read: () => snapshot, revalidate, subscribe, applyPipeline, revertPipeline };
+  const dispose = () => {
+    if (disposed) return;
+    disposed = true;
+    for (const requestScope of [...completionRetries.keys()]) cancelCompletionRetry(requestScope);
+    listeners.clear();
+  };
+
+  return { read: () => snapshot, revalidate, subscribe, applyPipeline, revertPipeline, dispose };
 }
 
 const defaultFilesFetcher: FilesFetcher = (input, init) => fetch(input, init);
 let filesClientCache = createFilesClientCache(defaultFilesFetcher);
 
 export function resetFilesClientCacheForTests(): void {
+  filesClientCache.dispose();
   filesClientCache = createFilesClientCache(defaultFilesFetcher);
 }
 
@@ -468,13 +488,13 @@ export function resetFilesClientCacheForTests(): void {
  * {@link revertPipelineSnapshot}.
  */
 export function applyPipelineSnapshot(pipeline: Pipeline, confirmed: boolean): void {
-  filesClientCache.applyPipeline(pipeline, confirmed);
+  flushSync(() => filesClientCache.applyPipeline(pipeline, confirmed));
   if (typeof window !== "undefined") window.dispatchEvent(new Event(PIPELINES_PATCHED_EVENT));
 }
 
 /** Roll back a failed optimistic pipeline mutation to the server snapshot. */
 export function revertPipelineSnapshot(id: string): void {
-  filesClientCache.revertPipeline(id);
+  flushSync(() => filesClientCache.revertPipeline(id));
   if (typeof window !== "undefined") window.dispatchEvent(new Event(PIPELINES_PATCHED_EVENT));
 }
 
@@ -511,13 +531,14 @@ export function useFiles(_project?: string | null, pinnedPath?: string | null): 
   const [data, setData] = useState<FilesData>(() => filesClientCache.read());
   useEffect(() => {
     let alive = true;
-    const unsubscribeCache = filesClientCache.subscribe((next) => {
+    const cache = filesClientCache;
+    const unsubscribeCache = cache.subscribe((next) => {
       if (alive) setData(next);
     }, pinnedPath);
     const performLoad = async (revision?: number): Promise<boolean> => {
       if (!alive) return true;
       try {
-        const next = await filesClientCache.revalidate(pinnedPath, revision);
+        const next = await cache.revalidate(pinnedPath, revision);
         if (alive) setData(next);
         return true;
       } catch {

--- a/src/hooks/useFiles.ts
+++ b/src/hooks/useFiles.ts
@@ -70,6 +70,8 @@ type CompletionRetry = {
 
 export interface FilesClientCache {
   read(): FilesData;
+  /** Return only the representation previously certified for this request URL. */
+  readScope(pinnedPath?: string | null): FilesData;
   revalidate(pinnedPath?: string | null, revision?: number): Promise<FilesData>;
   subscribe(listener: (data: FilesData) => void, pinnedPath?: string | null): () => void;
   /** Layer one pipeline record over the server snapshot without a refetch — an
@@ -178,6 +180,15 @@ export function createFilesClientCache(fetcher: FilesFetcher): FilesClientCache 
     pipelines: pipelinesWithOverlays(data.pipelines),
   });
 
+  const exactScopeRepresentation = (requestScope: string): FilesData => {
+    const representation = representations.get(requestScope)?.data
+      ?? (snapshot.requestScope === requestScope ? snapshot : { ...EMPTY, requestScope });
+    return withPipelineOverlays(representation);
+  };
+
+  const exactScopeSnapshot = (pinnedPath?: string | null): FilesData =>
+    exactScopeRepresentation(filesApiUrl(undefined, pinnedPath));
+
   const publish = (requestScope?: string) => {
     if (disposed) return;
     for (const [listener, scope] of listeners) {
@@ -185,9 +196,7 @@ export function createFilesClientCache(fetcher: FilesFetcher): FilesClientCache 
         if (requestScope === scope) listener(snapshot);
         continue;
       }
-      const representation = representations.get(scope)?.data
-        ?? (snapshot.requestScope === scope ? snapshot : { ...EMPTY, requestScope: scope });
-      listener(withPipelineOverlays(representation));
+      listener(exactScopeRepresentation(scope));
     }
   };
 
@@ -468,7 +477,7 @@ export function createFilesClientCache(fetcher: FilesFetcher): FilesClientCache 
     listeners.clear();
   };
 
-  return { read: () => snapshot, revalidate, subscribe, applyPipeline, revertPipeline, dispose };
+  return { read: () => snapshot, readScope: exactScopeSnapshot, revalidate, subscribe, applyPipeline, revertPipeline, dispose };
 }
 
 const defaultFilesFetcher: FilesFetcher = (input, init) => fetch(input, init);
@@ -528,7 +537,8 @@ export function filesPollCadence(connection: "live" | "reconnecting" | "degraded
 
 /** Polls /api/files. Keeps the last good list on transient fetch errors. */
 export function useFiles(_project?: string | null, pinnedPath?: string | null): FilesData {
-  const [data, setData] = useState<FilesData>(() => filesClientCache.read());
+  const [data, setData] = useState<FilesData>(() => filesClientCache.readScope(pinnedPath));
+  const requestScope = filesApiUrl(undefined, pinnedPath);
   useEffect(() => {
     let alive = true;
     const cache = filesClientCache;
@@ -641,5 +651,5 @@ export function useFiles(_project?: string | null, pinnedPath?: string | null): 
       window.removeEventListener(SESSION_TITLES_CHANGED_EVENT, onChanged);
     };
   }, [pinnedPath]);
-  return data;
+  return data.requestScope === requestScope ? data : filesClientCache.readScope(pinnedPath);
 }

--- a/src/hooks/useFiles.ts
+++ b/src/hooks/useFiles.ts
@@ -62,7 +62,9 @@ type CompletionRetry = {
   targetGeneration: number;
   logicalGeneration: number;
   attempt: number;
+  phase: "scheduled" | "queued" | "active" | "canceled";
   timer?: ReturnType<typeof setTimeout>;
+  controller?: AbortController;
 };
 
 export interface FilesClientCache {
@@ -165,8 +167,15 @@ export function createFilesClientCache(fetcher: FilesFetcher): FilesClientCache 
     const retry = completionRetries.get(requestScope);
     if (!retry) return;
     completionRetries.delete(requestScope);
+    retry.phase = "canceled";
     if (retry.timer !== undefined) clearTimeout(retry.timer);
+    retry.controller?.abort();
   };
+
+  const ownsCompletionRetry = (requestScope: string, retry: CompletionRetry): boolean =>
+    retry.phase !== "canceled"
+    && completionRetries.get(requestScope) === retry
+    && hasSubscriber(requestScope);
 
   const composePipelines = () => {
     if (!pipelineOverlays.size) {
@@ -214,12 +223,27 @@ export function createFilesClientCache(fetcher: FilesFetcher): FilesClientCache 
     requiredGeneration?: number,
     logicalGeneration?: number,
     completionRetryAttempt = 0,
+    completionRetry?: CompletionRetry,
   ): Promise<FilesData> => {
-    const generation = ++requestedGeneration;
     const url = filesApiUrl(undefined, pinnedPath);
+    if (completionRetry) {
+      if (!ownsCompletionRetry(url, completionRetry)) return snapshot;
+      completionRetry.phase = "active";
+      completionRetry.controller = new AbortController();
+    }
+    const generation = ++requestedGeneration;
     const representation = representations.get(url);
     const headers = filesRequestHeaders(representation?.etag ?? "", revision, requiredGeneration);
-    const response = await fetcher(url, headers ? { headers } : undefined);
+    const init = headers || completionRetry?.controller
+      ? { ...(headers ? { headers } : {}), ...(completionRetry?.controller ? { signal: completionRetry.controller.signal } : {}) }
+      : undefined;
+    let response: Response;
+    try {
+      response = await fetcher(url, init);
+    } finally {
+      if (completionRetry) completionRetry.controller = undefined;
+    }
+    if (completionRetry && !ownsCompletionRetry(url, completionRetry)) return snapshot;
     const servedGeneration = responseGeneration(response, "x-llv-files-generation");
     const targetGeneration = responseGeneration(response, "x-llv-files-target-generation");
     const generationIncomplete = servedGeneration !== undefined
@@ -241,6 +265,7 @@ export function createFilesClientCache(fetcher: FilesFetcher): FilesClientCache 
           targetGeneration,
           logicalGeneration ?? generation,
           completionRetryAttempt,
+          completionRetry,
         );
       } else {
         cancelCompletionRetry(url);
@@ -249,6 +274,7 @@ export function createFilesClientCache(fetcher: FilesFetcher): FilesClientCache 
     }
     if (!response.ok) throw new Error(`files request failed: ${response.status}`);
     const parsed = JSON.parse(await response.text()) as FilesResponse | FileEntry[];
+    if (completionRetry && !ownsCompletionRetry(url, completionRetry)) return snapshot;
     if (generation < appliedGeneration) return snapshot;
     const incoming = parsedFilesData(parsed, url);
     snapshot = patchFilesData(snapshot, incoming);
@@ -265,6 +291,7 @@ export function createFilesClientCache(fetcher: FilesFetcher): FilesClientCache 
         targetGeneration,
         logicalGeneration ?? generation,
         completionRetryAttempt,
+        completionRetry,
       );
     } else {
       cancelCompletionRetry(url);
@@ -278,6 +305,7 @@ export function createFilesClientCache(fetcher: FilesFetcher): FilesClientCache 
     requiredGeneration?: number,
     logicalGeneration?: number,
     completionRetryAttempt?: number,
+    completionRetry?: CompletionRetry,
   ): Promise<FilesData> => {
     const result = requestQueue.then(() => performRevalidate(
       pinnedPath,
@@ -285,6 +313,7 @@ export function createFilesClientCache(fetcher: FilesFetcher): FilesClientCache 
       requiredGeneration,
       logicalGeneration,
       completionRetryAttempt,
+      completionRetry,
     ));
     requestQueue = result.then(() => undefined, () => undefined);
     return result;
@@ -297,10 +326,16 @@ export function createFilesClientCache(fetcher: FilesFetcher): FilesClientCache 
     targetGeneration: number,
     logicalGeneration: number,
     attempt: number,
+    owner?: CompletionRetry,
   ) => {
-    if (!hasSubscriber(url)) return;
+    if (!hasSubscriber(url)) {
+      if (owner) cancelCompletionRetry(url);
+      return;
+    }
     const pending = completionRetries.get(url);
-    if (pending) {
+    if (owner) {
+      if (pending !== owner || owner.phase === "canceled") return;
+    } else if (pending) {
       if (pending.targetGeneration < targetGeneration) {
         pending.pinnedPath = pinnedPath;
         pending.revision = revision;
@@ -309,16 +344,32 @@ export function createFilesClientCache(fetcher: FilesFetcher): FilesClientCache 
       }
       return;
     }
-    const retry: CompletionRetry = { pinnedPath, revision, targetGeneration, logicalGeneration, attempt };
-    completionRetries.set(url, retry);
+    const retry: CompletionRetry = owner ?? {
+      pinnedPath,
+      revision,
+      targetGeneration,
+      logicalGeneration,
+      attempt,
+      phase: "scheduled",
+    };
+    retry.pinnedPath = pinnedPath;
+    retry.revision = revision;
+    retry.targetGeneration = targetGeneration;
+    retry.logicalGeneration = logicalGeneration;
+    retry.attempt = attempt;
+    retry.phase = "scheduled";
+    if (!owner) completionRetries.set(url, retry);
     const delay = Math.min(
       FILES_GENERATION_RETRY_MAX_MS,
       FILES_GENERATION_RETRY_MS * 2 ** Math.min(attempt, 10),
     );
     retry.timer = setTimeout(() => {
-      if (completionRetries.get(url) !== retry) return;
-      completionRetries.delete(url);
-      if (!hasSubscriber(url)) return;
+      retry.timer = undefined;
+      if (!ownsCompletionRetry(url, retry)) {
+        cancelCompletionRetry(url);
+        return;
+      }
+      retry.phase = "queued";
       const nextAttempt = retry.attempt + 1;
       void enqueueRevalidate(
         retry.pinnedPath,
@@ -326,6 +377,7 @@ export function createFilesClientCache(fetcher: FilesFetcher): FilesClientCache 
         retry.targetGeneration,
         retry.logicalGeneration,
         nextAttempt,
+        retry,
       ).catch(() => {
         scheduleCompletionRetry(
           url,
@@ -334,6 +386,7 @@ export function createFilesClientCache(fetcher: FilesFetcher): FilesClientCache 
           retry.targetGeneration,
           retry.logicalGeneration,
           nextAttempt,
+          retry,
         );
       });
     }, delay);

--- a/src/hooks/useFiles.ts
+++ b/src/hooks/useFiles.ts
@@ -154,9 +154,35 @@ export function createFilesClientCache(fetcher: FilesFetcher): FilesClientCache 
   const pipelineOverlays = new Map<string, { pipeline: Pipeline | null; minGeneration: number }>();
   let serverPipelines: readonly Pipeline[] = EMPTY.pipelines;
 
+  const pipelinesWithOverlays = (pipelines: readonly Pipeline[]): Pipeline[] => {
+    if (!pipelineOverlays.size) return [...pipelines];
+    const seen = new Set<string>();
+    const composed = pipelines.flatMap((pipeline) => {
+      const entry = pipelineOverlays.get(pipeline.id);
+      if (!entry) return [pipeline];
+      seen.add(pipeline.id);
+      return entry.pipeline ? [entry.pipeline] : [];
+    });
+    for (const [id, entry] of pipelineOverlays) {
+      if (!seen.has(id) && entry.pipeline) composed.push(entry.pipeline);
+    }
+    return composed;
+  };
+
+  const withPipelineOverlays = (data: FilesData): FilesData => ({
+    ...data,
+    pipelines: pipelinesWithOverlays(data.pipelines),
+  });
+
   const publish = (requestScope?: string) => {
     for (const [listener, scope] of listeners) {
-      if (requestScope === undefined || requestScope === scope) listener(snapshot);
+      if (requestScope !== undefined) {
+        if (requestScope === scope) listener(snapshot);
+        continue;
+      }
+      const representation = representations.get(scope)?.data
+        ?? (snapshot.requestScope === scope ? snapshot : { ...EMPTY, requestScope: scope });
+      listener(withPipelineOverlays(representation));
     }
   };
 
@@ -178,21 +204,7 @@ export function createFilesClientCache(fetcher: FilesFetcher): FilesClientCache 
     && hasSubscriber(requestScope);
 
   const composePipelines = () => {
-    if (!pipelineOverlays.size) {
-      snapshot = { ...snapshot, pipelines: [...serverPipelines] };
-      return;
-    }
-    const seen = new Set<string>();
-    const pipelines = serverPipelines.flatMap((pipeline) => {
-      const entry = pipelineOverlays.get(pipeline.id);
-      if (!entry) return [pipeline];
-      seen.add(pipeline.id);
-      return entry.pipeline ? [entry.pipeline] : [];
-    });
-    for (const [id, entry] of pipelineOverlays) {
-      if (!seen.has(id) && entry.pipeline) pipelines.push(entry.pipeline);
-    }
-    snapshot = { ...snapshot, pipelines };
+    snapshot = { ...snapshot, pipelines: pipelinesWithOverlays(serverPipelines) };
   };
 
   /** A completed server snapshot from `generation` reflects every overlay whose
@@ -207,14 +219,18 @@ export function createFilesClientCache(fetcher: FilesFetcher): FilesClientCache 
     if (pipelineOverlays.size) composePipelines();
   };
 
+  const trimRepresentations = () => {
+    while (representations.size > 8) {
+      const evictable = [...representations.keys()].find((url) => !hasSubscriber(url));
+      if (evictable === undefined) break;
+      representations.delete(evictable);
+    }
+  };
+
   const rememberRepresentation = (url: string, data: FilesData, etag?: string) => {
     representations.delete(url);
     representations.set(url, { data, etag });
-    while (representations.size > 8) {
-      const oldest = representations.keys().next().value;
-      if (oldest === undefined) break;
-      representations.delete(oldest);
-    }
+    trimRepresentations();
   };
 
   const performRevalidate = async (
@@ -429,6 +445,7 @@ export function createFilesClientCache(fetcher: FilesFetcher): FilesClientCache 
     return () => {
       listeners.delete(listener);
       if (!hasSubscriber(requestScope)) cancelCompletionRetry(requestScope);
+      trimRepresentations();
     };
   };
 
@@ -545,12 +562,6 @@ export function useFiles(_project?: string | null, pinnedPath?: string | null): 
     /* Flow, workflow and task mutations refresh out of band: strips and
        cards must not sit on stale state for up to a full poll interval. */
     const onChanged = () => void load();
-    /* A locally-applied pipeline patch (optimistic mutation / PATCH echo) is
-       already in the cache — re-read it, never refetch. */
-    const onPatched = () => {
-      if (alive) setData(filesClientCache.read());
-    };
-    window.addEventListener(PIPELINES_PATCHED_EVENT, onPatched);
     window.addEventListener(FLOWS_CHANGED_EVENT, onChanged);
     window.addEventListener(PIPELINES_CHANGED_EVENT, onChanged);
     window.addEventListener(WORKFLOWS_CHANGED_EVENT, onChanged);
@@ -602,7 +613,6 @@ export function useFiles(_project?: string | null, pinnedPath?: string | null): 
       unsubscribeCache();
       unsubBus();
       unsubFiles();
-      window.removeEventListener(PIPELINES_PATCHED_EVENT, onPatched);
       window.removeEventListener(FLOWS_CHANGED_EVENT, onChanged);
       window.removeEventListener(PIPELINES_CHANGED_EVENT, onChanged);
       window.removeEventListener(WORKFLOWS_CHANGED_EVENT, onChanged);

--- a/src/lib/accounts/migration/controller.performance.test.ts
+++ b/src/lib/accounts/migration/controller.performance.test.ts
@@ -155,7 +155,7 @@ test("a complete initial controller cycle stays inside the event-loop budget", a
       {
         scan: async () => {
           await cooperativePhase("scan");
-          return { files, projectCatalog: [] };
+          return { files, projectCatalog: [], complete: true };
         },
         reconcileFlowOwnership: async () => cooperativePhase("flows"),
         reconcileWorkflowOwnership: async () => cooperativePhase("workflows"),

--- a/src/lib/accounts/migration/controller.test.ts
+++ b/src/lib/accounts/migration/controller.test.ts
@@ -184,6 +184,46 @@ test("controller preserves one trailing cycle when the running cycle fails", asy
   expect(cycles).toBe(2);
 });
 
+test("controller reconciliation waits for a complete scanner inventory", async () => {
+  const reconciliations: string[] = [];
+  let complete = false;
+  const registry = new AgentRegistry(path.join(stateDir, "incomplete-inventory-registry.json"));
+  const controller = new AccountMigrationController(
+    registry,
+    { tick: async () => {} } as never,
+    null,
+    {
+      scan: async () => ({ files: [], projectCatalog: [], complete }),
+      reconcileInventory: async () => { reconciliations.push("inventory"); return registry.snapshot(); },
+      reconcileFlowOwnership: async () => { reconciliations.push("flows"); },
+      reconcileWorkflowOwnership: async () => { reconciliations.push("workflows"); },
+      reconcileHandoffOwnership: async () => { reconciliations.push("handoffs"); },
+      reconcileFiles: async () => { reconciliations.push("files"); },
+      reconcileRuntime: async () => { reconciliations.push("runtime"); },
+      reconcileTaskStore: async () => { reconciliations.push("tasks"); },
+      syncRouting: async () => { reconciliations.push("routing"); },
+      reconcileMigrationCycle: async () => { reconciliations.push("migration"); },
+    },
+  );
+
+  await controller.tick();
+  expect(reconciliations).toEqual([]);
+
+  complete = true;
+  await controller.tick();
+  expect(reconciliations).toEqual([
+    "inventory",
+    "flows",
+    "workflows",
+    "handoffs",
+    "files",
+    "runtime",
+    "tasks",
+    "routing",
+    "migration",
+  ]);
+});
+
 test("quota controller cycles preserve routing and transcript ownership", async () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "llv-account-controller-auto-"));
   try {

--- a/src/lib/accounts/migration/controller.ts
+++ b/src/lib/accounts/migration/controller.ts
@@ -217,7 +217,8 @@ export class AccountMigrationController {
   }
 
   private async run(): Promise<void> {
-    const { files } = await this.ports.scan();
+    const { files, complete } = await this.ports.scan();
+    if (!complete) return;
     await yieldToRuntime();
     const inventorySnapshot = await this.ports.reconcileInventory(this.registry, files);
     await yieldToRuntime();

--- a/src/lib/scanner/describe.ts
+++ b/src/lib/scanner/describe.ts
@@ -21,30 +21,82 @@ export interface FileDescription {
   fmt: Fmt;
 }
 
+export interface FileDescriptionIdentity {
+  size: number;
+  mtimeMs: number;
+  sidecarSize: number | null;
+  sidecarMtimeMs: number | null;
+}
+
+type CachedFileDescription = {
+  identity: FileDescriptionIdentity;
+  stateKey: string;
+  description: FileDescription;
+};
+
 /* Earlier issue-171 builds retained full prompts in these global maps. Clear
    them during hot reload so the bounded scheme metadata shape takes effect
    without waiting for a process restart. */
 globalCache<unknown>("meta-v4").clear();
 globalCache<unknown>("title-v2").clear();
-const metaCache = globalCache<[number, string, FileDescription]>("meta-v5");
-// Title and codex project live in the immutable head of a growing transcript,
-// so both are keyed by path and kept for good once resolved. A live file grows
-// on every poll, so a size-keyed meta cache would re-read the whole file each
-// tick; these caches read only the head and stop reading once the answer is
-// fixed. A head that has not yet produced a title (empty/short file) is left
-// open so growth can still yield one.
+const metaCache = globalCache<CachedFileDescription>("meta-v6");
+// Title and codex project live in the immutable head of a growing transcript.
+// Resolved head values survive append-only growth, while the complete file
+// identity invalidates same-size rewrites and truncations. A head that has not
+// yet produced a title stays open so growth can still yield one.
 export type ConversationSearchText = { title: string | null; firstPrompt: string | null };
-const titleCache = globalCache<[number, string | null]>("title-v3");
+const titleCache = globalCache<[number, number, string | null]>("title-v4");
 /* Search text can be large and belongs to the list/search path. Its bounded
    cache lives with the search index; page hydration reads only its visible rows. */
 globalCache<unknown>("conversation-search-v1").clear();
-const codexProjectCache = globalCache<{ stateKey: string; project: string; worktree?: string }>("codex-project-v3");
+const codexProjectCache = globalCache<{
+  size: number;
+  mtimeMs: number;
+  stateKey: string;
+  project: string;
+  worktree?: string;
+}>("codex-project-v4");
 const repoSlugCache = globalCache<[number, string | null]>("repo-path-from-slug-v1");
-/* The cwd sits in the immutable head, so it follows the title-cache rule:
-   keyed by path, re-read only while unresolved and the head still short. */
-const cwdCache = globalCache<[number, string | null]>("claude-cwd");
+/* The cwd follows the same append-only head reuse and rewrite invalidation. */
+const cwdCache = globalCache<[number, number, string | null]>("claude-cwd-v2");
 
 const HEAD_BYTES = 131_072;
+
+function subagentSidecarPath(rootName: RootKey, pathname: string): string | null {
+  if (rootName !== "claude-projects" || !path.basename(pathname).startsWith("agent-") || !pathname.endsWith(".jsonl")) {
+    return null;
+  }
+  return pathname.slice(0, -".jsonl".length) + ".meta.json";
+}
+
+export function fileDescriptionIdentity(
+  rootName: RootKey,
+  pathname: string,
+  st: fs.Stats,
+): FileDescriptionIdentity {
+  const sidecarPath = subagentSidecarPath(rootName, pathname);
+  if (!sidecarPath) {
+    return { size: st.size, mtimeMs: st.mtimeMs, sidecarSize: null, sidecarMtimeMs: null };
+  }
+  try {
+    const sidecar = fs.statSync(sidecarPath);
+    return {
+      size: st.size,
+      mtimeMs: st.mtimeMs,
+      sidecarSize: sidecar.size,
+      sidecarMtimeMs: sidecar.mtimeMs,
+    };
+  } catch {
+    return { size: st.size, mtimeMs: st.mtimeMs, sidecarSize: null, sidecarMtimeMs: null };
+  }
+}
+
+function sameFileDescriptionIdentity(left: FileDescriptionIdentity, right: FileDescriptionIdentity): boolean {
+  return left.size === right.size
+    && left.mtimeMs === right.mtimeMs
+    && left.sidecarSize === right.sidecarSize
+    && left.sidecarMtimeMs === right.sidecarMtimeMs;
+}
 
 function readHead(pathname: string, size: number): { text: string; read: number } | null {
   try {
@@ -613,13 +665,17 @@ function conversationTextFromLines(lines: string[], wantCodex: boolean): Convers
   return { title, firstPrompt };
 }
 
-function transcriptCwd(pathname: string, size: number): string | null {
+function transcriptCwd(pathname: string, st: fs.Stats): string | null {
   const cached = cwdCache.get(pathname);
-  if (cached && (cached[1] !== null || cached[0] >= HEAD_BYTES)) return cached[1];
-  const head = readHead(pathname, size);
-  if (!head) return cached?.[1] ?? null;
+  if (cached) {
+    const sameFile = cached[0] === st.size && cached[1] === st.mtimeMs;
+    const unchangedResolvedHead = st.size > cached[0] && (cached[2] !== null || cached[0] >= HEAD_BYTES);
+    if (sameFile || unchangedResolvedHead) return cached[2];
+  }
+  const head = readHead(pathname, st.size);
+  if (!head) return cached?.[2] ?? null;
   const cwd = cwdFromLines(head.text.split("\n").slice(0, 25));
-  cwdCache.set(pathname, [head.read, cwd]);
+  cwdCache.set(pathname, [st.size, st.mtimeMs, cwd]);
   return cwd;
 }
 
@@ -631,13 +687,17 @@ function projectInfoFromSlug(slug: string): { project: string; worktree?: string
   return persistedProjects().bySlug.get(slug) ?? null;
 }
 
-function scanJsonlTitle(pathname: string, size: number, wantCodex: boolean): string | null {
+function scanJsonlTitle(pathname: string, st: fs.Stats, wantCodex: boolean): string | null {
   const cached = titleCache.get(pathname);
-  if (cached && (cached[1] !== null || cached[0] >= HEAD_BYTES)) return cached[1];
-  const head = readHead(pathname, size);
-  if (!head) return cached?.[1] ?? null;
+  if (cached) {
+    const sameFile = cached[0] === st.size && cached[1] === st.mtimeMs;
+    const unchangedResolvedHead = st.size > cached[0] && (cached[2] !== null || cached[0] >= HEAD_BYTES);
+    if (sameFile || unchangedResolvedHead) return cached[2];
+  }
+  const head = readHead(pathname, st.size);
+  if (!head) return cached?.[2] ?? null;
   const title = titleFromLines(head.text.split("\n").slice(0, 151), wantCodex);
-  titleCache.set(pathname, [head.read, title]);
+  titleCache.set(pathname, [st.size, st.mtimeMs, title]);
   return title;
 }
 
@@ -648,9 +708,18 @@ export function searchTextForTranscript(pathname: string, size: number, engine: 
   return conversationTextFromLines(head.text.split("\n").slice(0, 151), engine === "codex");
 }
 
-export function describe(rootName: RootKey, root: string, pathname: string, st: fs.Stats, stateKey = projectResolutionStateKey()): FileDescription {
+export function describe(
+  rootName: RootKey,
+  root: string,
+  pathname: string,
+  st: fs.Stats,
+  stateKey = projectResolutionStateKey(),
+  identity = fileDescriptionIdentity(rootName, pathname, st),
+): FileDescription {
   const cached = metaCache.get(pathname);
-  if (cached?.[0] === st.size && cached[1] === stateKey) return cached[2];
+  if (cached?.stateKey === stateKey && sameFileDescriptionIdentity(cached.identity, identity)) {
+    return cached.description;
+  }
   const rel = path.relative(root, pathname);
   const fn = path.basename(pathname);
   let project = "other";
@@ -661,9 +730,14 @@ export function describe(rootName: RootKey, root: string, pathname: string, st: 
   let kind = "";
   let fmt: Fmt = "plain";
   if (rootName === "codex-sessions") {
-    cwd = transcriptCwd(pathname, st.size) ?? undefined;
+    cwd = transcriptCwd(pathname, st) ?? undefined;
     const cachedProject = codexProjectCache.get(pathname);
-    if (cachedProject?.stateKey === stateKey) {
+    const cachedProjectMatches = cachedProject?.stateKey === stateKey
+      && (
+        (cachedProject.size === st.size && cachedProject.mtimeMs === st.mtimeMs)
+        || st.size > cachedProject.size
+      );
+    if (cachedProjectMatches) {
       project = cachedProject.project;
       worktree = cachedProject.worktree;
     } else {
@@ -676,13 +750,19 @@ export function describe(rootName: RootKey, root: string, pathname: string, st: 
         project = info?.project ?? "";
         worktree = info?.worktree;
       }
-      if (project) codexProjectCache.set(pathname, { stateKey, project, worktree });
+      if (project) codexProjectCache.set(pathname, {
+        size: st.size,
+        mtimeMs: st.mtimeMs,
+        stateKey,
+        project,
+        worktree,
+      });
     }
     if (!project) project = "codex";
     engine = "codex";
     kind = "session";
     fmt = "codex";
-    title = scanJsonlTitle(pathname, st.size, true) ?? "Codex session";
+    title = scanJsonlTitle(pathname, st, true) ?? "Codex session";
   } else if (rootName === "claude-projects") {
     const slug = rel.split(path.sep)[0] ?? "";
     const worktreeInfo = worktreeFromSlug(slug);
@@ -691,7 +771,7 @@ export function describe(rootName: RootKey, root: string, pathname: string, st: 
     /* The slug alone cannot tell a sibling worktree checkout from a real
        standalone project — only the cwd's git metadata can. When it proves a
        worktree, the session regroups under its main repo's project name. */
-    cwd = transcriptCwd(pathname, st.size) ?? undefined;
+    cwd = transcriptCwd(pathname, st) ?? undefined;
     const info = cwd ? projectInfoFromCwd(cwd) : projectInfoFromTranscript(pathname);
     const persistedInfo = projectInfoFromTranscript(pathname);
     if (info && (worktreeInfo || info.worktree || persistedInfo)) {
@@ -708,7 +788,7 @@ export function describe(rootName: RootKey, root: string, pathname: string, st: 
         "Subagent " + fn.slice("agent-".length).split(".")[0];
     } else {
       kind = "session";
-      title = scanJsonlTitle(pathname, st.size, false) ?? "Claude session";
+      title = scanJsonlTitle(pathname, st, false) ?? "Claude session";
     }
   } else if (rootName === "claude-tasks") {
     const slug = rel.split(path.sep)[0] ?? "";
@@ -729,6 +809,6 @@ export function describe(rootName: RootKey, root: string, pathname: string, st: 
     kind,
     fmt,
   };
-  metaCache.set(pathname, [st.size, stateKey, meta]);
+  metaCache.set(pathname, { identity, stateKey, description: meta });
   return meta;
 }

--- a/src/lib/scanner/describe.ts
+++ b/src/lib/scanner/describe.ts
@@ -10,7 +10,7 @@ import { globalCache } from "./caches";
 import { readJson, recordValue, recordsValue, stringValue } from "./json";
 import { projectResolutionStateKey } from "./projectState";
 
-interface Meta {
+export interface FileDescription {
   project: string;
   worktree?: string;
   cwd?: string;
@@ -26,7 +26,7 @@ interface Meta {
    without waiting for a process restart. */
 globalCache<unknown>("meta-v4").clear();
 globalCache<unknown>("title-v2").clear();
-const metaCache = globalCache<[number, string, Meta]>("meta-v5");
+const metaCache = globalCache<[number, string, FileDescription]>("meta-v5");
 // Title and codex project live in the immutable head of a growing transcript,
 // so both are keyed by path and kept for good once resolved. A live file grows
 // on every poll, so a size-keyed meta cache would re-read the whole file each
@@ -648,7 +648,7 @@ export function searchTextForTranscript(pathname: string, size: number, engine: 
   return conversationTextFromLines(head.text.split("\n").slice(0, 151), engine === "codex");
 }
 
-export function describe(rootName: RootKey, root: string, pathname: string, st: fs.Stats, stateKey = projectResolutionStateKey()): Meta {
+export function describe(rootName: RootKey, root: string, pathname: string, st: fs.Stats, stateKey = projectResolutionStateKey()): FileDescription {
   const cached = metaCache.get(pathname);
   if (cached?.[0] === st.size && cached[1] === stateKey) return cached[2];
   const rel = path.relative(root, pathname);

--- a/src/lib/scanner/describe.ts
+++ b/src/lib/scanner/describe.ts
@@ -7,7 +7,7 @@ import { stateDir } from "@/lib/configDir";
 import type { Engine, Fmt, RootKey } from "../types";
 import { cleanTitle } from "../title";
 import { globalCache } from "./caches";
-import { readJson, recordValue, recordsValue, stringValue } from "./json";
+import { readJsonResult, recordValue, recordsValue, stringValue } from "./json";
 import { projectResolutionStateKey } from "./projectState";
 
 export interface FileDescription {
@@ -26,6 +26,12 @@ export interface FileDescriptionIdentity {
   mtimeMs: number;
   sidecarSize: number | null;
   sidecarMtimeMs: number | null;
+  complete: boolean;
+}
+
+export interface FileDescriptionResult {
+  description: FileDescription;
+  complete: boolean;
 }
 
 type CachedFileDescription = {
@@ -55,7 +61,7 @@ const codexProjectCache = globalCache<{
   stateKey: string;
   project: string;
   worktree?: string;
-}>("codex-project-v4");
+}>("codex-project-v5");
 const repoSlugCache = globalCache<[number, string | null]>("repo-path-from-slug-v1");
 /* The cwd follows the same append-only head reuse and rewrite invalidation. */
 const cwdCache = globalCache<[number, number, string | null]>("claude-cwd-v2");
@@ -76,7 +82,7 @@ export function fileDescriptionIdentity(
 ): FileDescriptionIdentity {
   const sidecarPath = subagentSidecarPath(rootName, pathname);
   if (!sidecarPath) {
-    return { size: st.size, mtimeMs: st.mtimeMs, sidecarSize: null, sidecarMtimeMs: null };
+    return { size: st.size, mtimeMs: st.mtimeMs, sidecarSize: null, sidecarMtimeMs: null, complete: true };
   }
   try {
     const sidecar = fs.statSync(sidecarPath);
@@ -85,9 +91,16 @@ export function fileDescriptionIdentity(
       mtimeMs: st.mtimeMs,
       sidecarSize: sidecar.size,
       sidecarMtimeMs: sidecar.mtimeMs,
+      complete: true,
     };
-  } catch {
-    return { size: st.size, mtimeMs: st.mtimeMs, sidecarSize: null, sidecarMtimeMs: null };
+  } catch (error) {
+    return {
+      size: st.size,
+      mtimeMs: st.mtimeMs,
+      sidecarSize: null,
+      sidecarMtimeMs: null,
+      complete: (error as NodeJS.ErrnoException).code === "ENOENT",
+    };
   }
 }
 
@@ -98,18 +111,23 @@ function sameFileDescriptionIdentity(left: FileDescriptionIdentity, right: FileD
     && left.sidecarMtimeMs === right.sidecarMtimeMs;
 }
 
-function readHead(pathname: string, size: number): { text: string; read: number } | null {
+interface HeadReadResult {
+  value: { text: string; read: number } | null;
+  complete: boolean;
+}
+
+function readHead(pathname: string, size: number): HeadReadResult {
   try {
     const fd = fs.openSync(pathname, "r");
     try {
       const buf = Buffer.alloc(Math.min(size, HEAD_BYTES));
       const read = fs.readSync(fd, buf, 0, buf.length, 0);
-      return { text: buf.toString("utf8", 0, read), read };
+      return { value: { text: buf.toString("utf8", 0, read), read }, complete: true };
     } finally {
       fs.closeSync(fd);
     }
   } catch {
-    return null;
+    return { value: null, complete: false };
   }
 }
 
@@ -665,18 +683,23 @@ function conversationTextFromLines(lines: string[], wantCodex: boolean): Convers
   return { title, firstPrompt };
 }
 
-function transcriptCwd(pathname: string, st: fs.Stats): string | null {
+interface MetadataReadResult<T> {
+  value: T;
+  complete: boolean;
+}
+
+function transcriptCwd(pathname: string, st: fs.Stats): MetadataReadResult<string | null> {
   const cached = cwdCache.get(pathname);
   if (cached) {
     const sameFile = cached[0] === st.size && cached[1] === st.mtimeMs;
     const unchangedResolvedHead = st.size > cached[0] && (cached[2] !== null || cached[0] >= HEAD_BYTES);
-    if (sameFile || unchangedResolvedHead) return cached[2];
+    if (sameFile || unchangedResolvedHead) return { value: cached[2], complete: true };
   }
   const head = readHead(pathname, st.size);
-  if (!head) return cached?.[2] ?? null;
-  const cwd = cwdFromLines(head.text.split("\n").slice(0, 25));
+  if (!head.complete || !head.value) return { value: cached?.[2] ?? null, complete: false };
+  const cwd = cwdFromLines(head.value.text.split("\n").slice(0, 25));
   cwdCache.set(pathname, [st.size, st.mtimeMs, cwd]);
-  return cwd;
+  return { value: cwd, complete: true };
 }
 
 function projectInfoFromTranscript(pathname: string): { project: string; worktree?: string } | null {
@@ -687,18 +710,18 @@ function projectInfoFromSlug(slug: string): { project: string; worktree?: string
   return persistedProjects().bySlug.get(slug) ?? null;
 }
 
-function scanJsonlTitle(pathname: string, st: fs.Stats, wantCodex: boolean): string | null {
+function scanJsonlTitle(pathname: string, st: fs.Stats, wantCodex: boolean): MetadataReadResult<string | null> {
   const cached = titleCache.get(pathname);
   if (cached) {
     const sameFile = cached[0] === st.size && cached[1] === st.mtimeMs;
     const unchangedResolvedHead = st.size > cached[0] && (cached[2] !== null || cached[0] >= HEAD_BYTES);
-    if (sameFile || unchangedResolvedHead) return cached[2];
+    if (sameFile || unchangedResolvedHead) return { value: cached[2], complete: true };
   }
   const head = readHead(pathname, st.size);
-  if (!head) return cached?.[2] ?? null;
-  const title = titleFromLines(head.text.split("\n").slice(0, 151), wantCodex);
+  if (!head.complete || !head.value) return { value: cached?.[2] ?? null, complete: false };
+  const title = titleFromLines(head.value.text.split("\n").slice(0, 151), wantCodex);
   titleCache.set(pathname, [st.size, st.mtimeMs, title]);
-  return title;
+  return { value: title, complete: true };
 }
 
 /** Title and first-prompt hydration owned entirely by list/search requests. */
@@ -708,17 +731,17 @@ export function searchTextForTranscript(pathname: string, size: number, engine: 
   return conversationTextFromLines(head.text.split("\n").slice(0, 151), engine === "codex");
 }
 
-export function describe(
+export function describeFile(
   rootName: RootKey,
   root: string,
   pathname: string,
   st: fs.Stats,
   stateKey = projectResolutionStateKey(),
   identity = fileDescriptionIdentity(rootName, pathname, st),
-): FileDescription {
+): FileDescriptionResult {
   const cached = metaCache.get(pathname);
-  if (cached?.stateKey === stateKey && sameFileDescriptionIdentity(cached.identity, identity)) {
-    return cached.description;
+  if (identity.complete && cached?.stateKey === stateKey && sameFileDescriptionIdentity(cached.identity, identity)) {
+    return { description: cached.description, complete: true };
   }
   const rel = path.relative(root, pathname);
   const fn = path.basename(pathname);
@@ -729,10 +752,13 @@ export function describe(
   let engine: Engine = "claude";
   let kind = "";
   let fmt: Fmt = "plain";
+  let complete = identity.complete;
   if (rootName === "codex-sessions") {
-    cwd = transcriptCwd(pathname, st) ?? undefined;
+    const cwdRead = transcriptCwd(pathname, st);
+    complete &&= cwdRead.complete;
+    cwd = cwdRead.value ?? undefined;
     const cachedProject = codexProjectCache.get(pathname);
-    const cachedProjectMatches = cachedProject?.stateKey === stateKey
+    const cachedProjectMatches = cwdRead.complete && cachedProject?.stateKey === stateKey
       && (
         (cachedProject.size === st.size && cachedProject.mtimeMs === st.mtimeMs)
         || st.size > cachedProject.size
@@ -750,7 +776,7 @@ export function describe(
         project = info?.project ?? "";
         worktree = info?.worktree;
       }
-      if (project) codexProjectCache.set(pathname, {
+      if (project && cwdRead.complete) codexProjectCache.set(pathname, {
         size: st.size,
         mtimeMs: st.mtimeMs,
         stateKey,
@@ -762,7 +788,9 @@ export function describe(
     engine = "codex";
     kind = "session";
     fmt = "codex";
-    title = scanJsonlTitle(pathname, st, true) ?? "Codex session";
+    const titleRead = scanJsonlTitle(pathname, st, true);
+    complete &&= titleRead.complete;
+    title = titleRead.value ?? "Codex session";
   } else if (rootName === "claude-projects") {
     const slug = rel.split(path.sep)[0] ?? "";
     const worktreeInfo = worktreeFromSlug(slug);
@@ -771,7 +799,9 @@ export function describe(
     /* The slug alone cannot tell a sibling worktree checkout from a real
        standalone project — only the cwd's git metadata can. When it proves a
        worktree, the session regroups under its main repo's project name. */
-    cwd = transcriptCwd(pathname, st) ?? undefined;
+    const cwdRead = transcriptCwd(pathname, st);
+    complete &&= cwdRead.complete;
+    cwd = cwdRead.value ?? undefined;
     const info = cwd ? projectInfoFromCwd(cwd) : projectInfoFromTranscript(pathname);
     const persistedInfo = projectInfoFromTranscript(pathname);
     if (info && (worktreeInfo || info.worktree || persistedInfo)) {
@@ -781,14 +811,20 @@ export function describe(
     fmt = "claude";
     if (fn.startsWith("agent-")) {
       kind = "subagent";
-      const meta = readJson(pathname.slice(0, -".jsonl".length) + ".meta.json") ?? {};
+      const sidecar = identity.sidecarSize === null
+        ? { value: null, complete: identity.complete }
+        : readJsonResult(pathname.slice(0, -".jsonl".length) + ".meta.json");
+      complete &&= sidecar.complete;
+      const meta = sidecar.value ?? {};
       title =
         stringValue(meta.description) ??
         stringValue(meta.name) ??
         "Subagent " + fn.slice("agent-".length).split(".")[0];
     } else {
       kind = "session";
-      title = scanJsonlTitle(pathname, st, false) ?? "Claude session";
+      const titleRead = scanJsonlTitle(pathname, st, false);
+      complete &&= titleRead.complete;
+      title = titleRead.value ?? "Claude session";
     }
   } else if (rootName === "claude-tasks") {
     const slug = rel.split(path.sep)[0] ?? "";
@@ -809,6 +845,17 @@ export function describe(
     kind,
     fmt,
   };
-  metaCache.set(pathname, { identity, stateKey, description: meta });
-  return meta;
+  if (complete) metaCache.set(pathname, { identity, stateKey, description: meta });
+  return { description: meta, complete };
+}
+
+export function describe(
+  rootName: RootKey,
+  root: string,
+  pathname: string,
+  st: fs.Stats,
+  stateKey = projectResolutionStateKey(),
+  identity = fileDescriptionIdentity(rootName, pathname, st),
+): FileDescription {
+  return describeFile(rootName, root, pathname, st, stateKey, identity).description;
 }

--- a/src/lib/scanner/describe.ts
+++ b/src/lib/scanner/describe.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs";
+import { createHash } from "node:crypto";
 import os from "node:os";
 import path from "node:path";
 
@@ -51,7 +52,14 @@ const metaCache = globalCache<CachedFileDescription>("meta-v6");
 // identity invalidates same-size rewrites and truncations. A head that has not
 // yet produced a title stays open so growth can still yield one.
 export type ConversationSearchText = { title: string | null; firstPrompt: string | null };
-const titleCache = globalCache<[number, number, string | null]>("title-v4");
+type HeadMetadataCache<T> = {
+  size: number;
+  mtimeMs: number;
+  value: T;
+  headBytes: number;
+  headFingerprint: string;
+};
+const titleCache = globalCache<HeadMetadataCache<string | null>>("title-v5");
 /* Search text can be large and belongs to the list/search path. Its bounded
    cache lives with the search index; page hydration reads only its visible rows. */
 globalCache<unknown>("conversation-search-v1").clear();
@@ -64,7 +72,7 @@ const codexProjectCache = globalCache<{
 }>("codex-project-v5");
 const repoSlugCache = globalCache<[number, string | null]>("repo-path-from-slug-v1");
 /* The cwd follows the same append-only head reuse and rewrite invalidation. */
-const cwdCache = globalCache<[number, number, string | null]>("claude-cwd-v2");
+const cwdCache = globalCache<HeadMetadataCache<string | null>>("claude-cwd-v3");
 
 const HEAD_BYTES = 131_072;
 
@@ -112,8 +120,12 @@ function sameFileDescriptionIdentity(left: FileDescriptionIdentity, right: FileD
 }
 
 interface HeadReadResult {
-  value: { text: string; read: number } | null;
+  value: { bytes: Buffer; text: string; read: number } | null;
   complete: boolean;
+}
+
+function headFingerprint(bytes: Uint8Array): string {
+  return createHash("sha256").update(bytes).digest("base64url");
 }
 
 function readHead(pathname: string, size: number): HeadReadResult {
@@ -122,7 +134,8 @@ function readHead(pathname: string, size: number): HeadReadResult {
     try {
       const buf = Buffer.alloc(Math.min(size, HEAD_BYTES));
       const read = fs.readSync(fd, buf, 0, buf.length, 0);
-      return { value: { text: buf.toString("utf8", 0, read), read }, complete: true };
+      const bytes = buf.subarray(0, read);
+      return { value: { bytes, text: bytes.toString("utf8"), read }, complete: true };
     } finally {
       fs.closeSync(fd);
     }
@@ -686,20 +699,53 @@ function conversationTextFromLines(lines: string[], wantCodex: boolean): Convers
 interface MetadataReadResult<T> {
   value: T;
   complete: boolean;
+  headPreserved: boolean;
+}
+
+function reusableGrowingHead<T>(
+  cached: HeadMetadataCache<T>,
+  st: fs.Stats,
+  head: HeadReadResult,
+): HeadMetadataCache<T> | null {
+  if (st.size <= cached.size || !head.complete || !head.value || head.value.read < cached.headBytes) return null;
+  const preserved = headFingerprint(head.value.bytes.subarray(0, cached.headBytes)) === cached.headFingerprint;
+  if (!preserved || (cached.value === null && cached.headBytes < HEAD_BYTES)) return null;
+  return {
+    size: st.size,
+    mtimeMs: st.mtimeMs,
+    value: cached.value,
+    headBytes: head.value.read,
+    headFingerprint: headFingerprint(head.value.bytes),
+  };
+}
+
+function cacheHeadMetadata<T>(st: fs.Stats, head: NonNullable<HeadReadResult["value"]>, value: T): HeadMetadataCache<T> {
+  return {
+    size: st.size,
+    mtimeMs: st.mtimeMs,
+    value,
+    headBytes: head.read,
+    headFingerprint: headFingerprint(head.bytes),
+  };
 }
 
 function transcriptCwd(pathname: string, st: fs.Stats): MetadataReadResult<string | null> {
   const cached = cwdCache.get(pathname);
-  if (cached) {
-    const sameFile = cached[0] === st.size && cached[1] === st.mtimeMs;
-    const unchangedResolvedHead = st.size > cached[0] && (cached[2] !== null || cached[0] >= HEAD_BYTES);
-    if (sameFile || unchangedResolvedHead) return { value: cached[2], complete: true };
+  if (cached?.size === st.size && cached.mtimeMs === st.mtimeMs) {
+    return { value: cached.value, complete: true, headPreserved: true };
   }
   const head = readHead(pathname, st.size);
-  if (!head.complete || !head.value) return { value: cached?.[2] ?? null, complete: false };
+  if (!head.complete || !head.value) return { value: cached?.value ?? null, complete: false, headPreserved: false };
+  if (cached) {
+    const reused = reusableGrowingHead(cached, st, head);
+    if (reused) {
+      cwdCache.set(pathname, reused);
+      return { value: reused.value, complete: true, headPreserved: true };
+    }
+  }
   const cwd = cwdFromLines(head.value.text.split("\n").slice(0, 25));
-  cwdCache.set(pathname, [st.size, st.mtimeMs, cwd]);
-  return { value: cwd, complete: true };
+  cwdCache.set(pathname, cacheHeadMetadata(st, head.value, cwd));
+  return { value: cwd, complete: true, headPreserved: false };
 }
 
 function projectInfoFromTranscript(pathname: string): { project: string; worktree?: string } | null {
@@ -712,16 +758,21 @@ function projectInfoFromSlug(slug: string): { project: string; worktree?: string
 
 function scanJsonlTitle(pathname: string, st: fs.Stats, wantCodex: boolean): MetadataReadResult<string | null> {
   const cached = titleCache.get(pathname);
-  if (cached) {
-    const sameFile = cached[0] === st.size && cached[1] === st.mtimeMs;
-    const unchangedResolvedHead = st.size > cached[0] && (cached[2] !== null || cached[0] >= HEAD_BYTES);
-    if (sameFile || unchangedResolvedHead) return { value: cached[2], complete: true };
+  if (cached?.size === st.size && cached.mtimeMs === st.mtimeMs) {
+    return { value: cached.value, complete: true, headPreserved: true };
   }
   const head = readHead(pathname, st.size);
-  if (!head.complete || !head.value) return { value: cached?.[2] ?? null, complete: false };
+  if (!head.complete || !head.value) return { value: cached?.value ?? null, complete: false, headPreserved: false };
+  if (cached) {
+    const reused = reusableGrowingHead(cached, st, head);
+    if (reused) {
+      titleCache.set(pathname, reused);
+      return { value: reused.value, complete: true, headPreserved: true };
+    }
+  }
   const title = titleFromLines(head.value.text.split("\n").slice(0, 151), wantCodex);
-  titleCache.set(pathname, [st.size, st.mtimeMs, title]);
-  return { value: title, complete: true };
+  titleCache.set(pathname, cacheHeadMetadata(st, head.value, title));
+  return { value: title, complete: true, headPreserved: false };
 }
 
 /** Title and first-prompt hydration owned entirely by list/search requests. */
@@ -761,7 +812,7 @@ export function describeFile(
     const cachedProjectMatches = cwdRead.complete && cachedProject?.stateKey === stateKey
       && (
         (cachedProject.size === st.size && cachedProject.mtimeMs === st.mtimeMs)
-        || st.size > cachedProject.size
+        || (st.size > cachedProject.size && cwdRead.headPreserved)
       );
     if (cachedProjectMatches) {
       project = cachedProject.project;

--- a/src/lib/scanner/discover.test.ts
+++ b/src/lib/scanner/discover.test.ts
@@ -97,6 +97,48 @@ test("request refreshes persist the per-file scanner index", async () => {
   }
 });
 
+test("a non-ENOENT directory failure leaves the completed catalog index authoritative until recovery", async () => {
+  const base = await mkdtemp(path.join(os.tmpdir(), "llv-discover-incomplete-walk-"));
+  const previousStateDir = process.env.LLV_STATE_DIR;
+  process.env.LLV_STATE_DIR = path.join(base, "state");
+  const roots: Record<RootKey, string> = {
+    "codex-sessions": path.join(base, "codex-sessions"),
+    "claude-projects": path.join(base, "claude-projects"),
+    "claude-tasks": path.join(base, "claude-tasks"),
+  };
+  try {
+    await Promise.all(Object.values(roots).map((root) => mkdir(root, { recursive: true })));
+    const transcript = path.join(roots["codex-sessions"], "canonical.jsonl");
+    await writeFixture(transcript, JSON.stringify({ type: "session_meta", payload: { cwd: "/repo/canonical" } }) + "\n", 1_700_000_000);
+    await discoverFilesWithProjectCatalog(roots, undefined, { persist: false, persistIndex: true });
+    const indexPath = path.join(process.env.LLV_STATE_DIR, "project-catalog.json");
+    const canonical = await readFile(indexPath, "utf8");
+    await rm(roots["claude-projects"], { recursive: true });
+    await writeFile(roots["claude-projects"], "not a directory");
+    const diagnostics: string[] = [];
+    const originalError = console.error;
+    console.error = (...values: unknown[]) => { diagnostics.push(values.map(String).join(" ")); };
+    try {
+      const incomplete = await discoverFilesWithProjectCatalog(roots, undefined, { persist: false, persistIndex: true });
+      expect(incomplete.complete).toBe(false);
+    } finally {
+      console.error = originalError;
+    }
+    expect(await readFile(indexPath, "utf8")).toBe(canonical);
+    expect(diagnostics).toEqual([expect.stringContaining("read directory failed")]);
+    expect(diagnostics[0]).toContain(roots["claude-projects"]);
+    await rm(roots["claude-projects"], { force: true });
+    await mkdir(roots["claude-projects"]);
+    const recovered = await discoverFilesWithProjectCatalog(roots, undefined, { persist: false, persistIndex: true });
+    expect(recovered.complete).toBe(true);
+    expect(recovered.files.some((entry) => entry.path === transcript)).toBe(true);
+  } finally {
+    if (previousStateDir === undefined) delete process.env.LLV_STATE_DIR;
+    else process.env.LLV_STATE_DIR = previousStateDir;
+    await rm(base, { recursive: true, force: true });
+  }
+});
+
 test("project index publication failures preserve the canonical file, clean temps, stay non-fatal, and recover", async () => {
   const base = await mkdtemp(path.join(os.tmpdir(), "llv-discover-index-failure-"));
   const previousStateDir = process.env.LLV_STATE_DIR;
@@ -151,8 +193,10 @@ test("project index publication failures preserve the canonical file, clean temp
       expect(await readFile(indexPath, "utf8")).toBe(canonical);
       expect(tempFiles()).toEqual([]);
       expect(diagnostics).toEqual([
-        expect.stringContaining("project catalog index publication failed"),
+        expect.stringContaining("write temporary index failed"),
       ]);
+      expect(diagnostics[0]).toContain("injected project index write failure");
+      expect(diagnostics[0]).toContain(".project-catalog.json.");
     } finally {
       fs.writeFileSync = originalWrite;
       fs.renameSync = originalRename;

--- a/src/lib/scanner/discover.test.ts
+++ b/src/lib/scanner/discover.test.ts
@@ -9,7 +9,6 @@ import { emptyLaunchProfile } from "../accounts/migration/contracts";
 import { AgentRegistry, setAgentRegistryForTests } from "../agent/registry";
 import type { RootKey } from "../types";
 import { conversationCatalogSnapshot } from "./conversationCatalog";
-import { globalCache } from "./caches";
 import { discoverFiles, discoverFilesWithProjectCatalog, type RawEntry } from "./discover";
 import { projectForCwd } from "./describe";
 import { projectCatalogSnapshotFromRaw } from "./projectCatalog";
@@ -89,23 +88,90 @@ test("an append reparses its file and reuses unchanged persisted summaries", asy
     const sidecar = (pathname: string) => pathname.slice(0, -".jsonl".length) + ".meta.json";
     await writeFixture(unchanged, "{}\n", 1_700_000_000);
     await writeFixture(changed, "{}\n", 1_700_000_001);
-    await writeFile(sidecar(unchanged), JSON.stringify({ description: "Unchanged original" }));
-    await writeFile(sidecar(changed), JSON.stringify({ description: "Changed original" }));
+    await writeFixture(sidecar(unchanged), JSON.stringify({ description: "Unchanged original" }), 1_700_000_000);
+    await writeFixture(sidecar(changed), JSON.stringify({ description: "Changed original" }), 1_700_000_001);
 
     const first = await discoverFilesWithProjectCatalog(roots, undefined, { persist: false, persistIndex: true });
     expect(first.files.find((entry) => entry.path === unchanged)?.title).toBe("Unchanged original");
     expect(first.files.find((entry) => entry.path === changed)?.title).toBe("Changed original");
 
-    globalCache<unknown>("meta-v5").clear();
-    await writeFile(sidecar(unchanged), JSON.stringify({ description: "Unchanged mutated" }));
-    await writeFile(sidecar(changed), JSON.stringify({ description: "Changed reparsed" }));
+    await writeFixture(sidecar(changed), JSON.stringify({ description: "Changed reparsed" }), 1_700_000_002);
     await appendFile(changed, "{}\n");
 
     const second = await discoverFilesWithProjectCatalog(roots, undefined, { persist: false });
     expect(second.files.find((entry) => entry.path === unchanged)?.title).toBe("Unchanged original");
     expect(second.files.find((entry) => entry.path === changed)?.title).toBe("Changed reparsed");
   } finally {
-    globalCache<unknown>("meta-v5").clear();
+    if (previousStateDir === undefined) delete process.env.LLV_STATE_DIR;
+    else process.env.LLV_STATE_DIR = previousStateDir;
+    await rm(base, { recursive: true, force: true });
+  }
+});
+
+test("a same-size transcript rewrite with a newer mtime reparses cwd and project metadata", async () => {
+  const base = await mkdtemp(path.join(os.tmpdir(), "llv-discover-same-size-rewrite-"));
+  const previousStateDir = process.env.LLV_STATE_DIR;
+  process.env.LLV_STATE_DIR = path.join(base, "state");
+  try {
+    const roots: Record<RootKey, string> = {
+      "codex-sessions": path.join(base, "codex-sessions"),
+      "claude-projects": path.join(base, "claude-projects"),
+      "claude-tasks": path.join(base, "claude-tasks"),
+    };
+    await Promise.all(Object.values(roots).map((root) => mkdir(root, { recursive: true })));
+    const transcript = path.join(roots["codex-sessions"], "rewritten.jsonl");
+    const alpha = JSON.stringify({ type: "session_meta", payload: { cwd: "/repo/alpha" } }) + "\n";
+    const bravo = JSON.stringify({ type: "session_meta", payload: { cwd: "/repo/bravo" } }) + "\n";
+    expect(Buffer.byteLength(alpha)).toBe(Buffer.byteLength(bravo));
+    await writeFixture(transcript, alpha, 1_700_000_000);
+
+    const first = await discoverFilesWithProjectCatalog(roots, undefined, { persist: false, persistIndex: true });
+    expect(first.files.find((entry) => entry.path === transcript)).toMatchObject({
+      cwd: "/repo/alpha",
+      project: projectForCwd("/repo/alpha"),
+    });
+
+    await writeFixture(transcript, bravo, 1_700_000_001);
+    const second = await discoverFilesWithProjectCatalog(roots, undefined, { persist: false });
+
+    expect(second.files.find((entry) => entry.path === transcript)).toMatchObject({
+      cwd: "/repo/bravo",
+      project: projectForCwd("/repo/bravo"),
+    });
+  } finally {
+    if (previousStateDir === undefined) delete process.env.LLV_STATE_DIR;
+    else process.env.LLV_STATE_DIR = previousStateDir;
+    await rm(base, { recursive: true, force: true });
+  }
+});
+
+test("a same-size subagent sidecar rewrite with a newer mtime reparses its title", async () => {
+  const base = await mkdtemp(path.join(os.tmpdir(), "llv-discover-sidecar-rewrite-"));
+  const previousStateDir = process.env.LLV_STATE_DIR;
+  process.env.LLV_STATE_DIR = path.join(base, "state");
+  try {
+    const roots: Record<RootKey, string> = {
+      "codex-sessions": path.join(base, "codex-sessions"),
+      "claude-projects": path.join(base, "claude-projects"),
+      "claude-tasks": path.join(base, "claude-tasks"),
+    };
+    await Promise.all(Object.values(roots).map((root) => mkdir(root, { recursive: true })));
+    const transcript = path.join(roots["claude-projects"], "sidecar", "session", "subagents", "agent-rewritten.jsonl");
+    const sidecar = transcript.slice(0, -".jsonl".length) + ".meta.json";
+    const alpha = JSON.stringify({ description: "Agent alpha" });
+    const bravo = JSON.stringify({ description: "Agent bravo" });
+    expect(Buffer.byteLength(alpha)).toBe(Buffer.byteLength(bravo));
+    await writeFixture(transcript, "{}\n", 1_700_000_000);
+    await writeFixture(sidecar, alpha, 1_700_000_000);
+
+    const first = await discoverFilesWithProjectCatalog(roots, undefined, { persist: false, persistIndex: true });
+    expect(first.files.find((entry) => entry.path === transcript)?.title).toBe("Agent alpha");
+
+    await writeFixture(sidecar, bravo, 1_700_000_001);
+    const second = await discoverFilesWithProjectCatalog(roots, undefined, { persist: false });
+
+    expect(second.files.find((entry) => entry.path === transcript)?.title).toBe("Agent bravo");
+  } finally {
     if (previousStateDir === undefined) delete process.env.LLV_STATE_DIR;
     else process.env.LLV_STATE_DIR = previousStateDir;
     await rm(base, { recursive: true, force: true });
@@ -133,7 +199,7 @@ test("a corrupt per-file scanner index falls back to a full parse and repairs it
 
     expect(recovered.files.find((entry) => entry.path === transcript)?.title).toBe("Recovered summary");
     const persisted = JSON.parse(await readFile(path.join(process.env.LLV_STATE_DIR, "project-catalog.json"), "utf8"));
-    expect(persisted.files[transcript]).toMatchObject({ summaryVersion: 1, title: "Recovered summary" });
+    expect(persisted.files[transcript]).toMatchObject({ summaryVersion: 2, title: "Recovered summary" });
   } finally {
     if (previousStateDir === undefined) delete process.env.LLV_STATE_DIR;
     else process.env.LLV_STATE_DIR = previousStateDir;

--- a/src/lib/scanner/discover.test.ts
+++ b/src/lib/scanner/discover.test.ts
@@ -354,6 +354,146 @@ test("a same-size transcript rewrite with a newer mtime reparses cwd and project
   }
 });
 
+test("larger Codex and Claude rewrites replace cached head metadata", async () => {
+  const base = await mkdtemp(path.join(os.tmpdir(), "llv-discover-larger-rewrite-"));
+  const previousStateDir = process.env.LLV_STATE_DIR;
+  process.env.LLV_STATE_DIR = path.join(base, "state");
+  try {
+    const roots: Record<RootKey, string> = {
+      "codex-sessions": path.join(base, "codex-sessions"),
+      "claude-projects": path.join(base, "claude-projects"),
+      "claude-tasks": path.join(base, "claude-tasks"),
+    };
+    await Promise.all(Object.values(roots).map((root) => mkdir(root, { recursive: true })));
+    const codex = path.join(roots["codex-sessions"], "rewritten.jsonl");
+    const claude = path.join(roots["claude-projects"], "rewritten", "session.jsonl");
+    const codexTranscript = (cwd: string, title: string, padding = "") => [
+      JSON.stringify({ type: "session_meta", payload: { cwd } }),
+      JSON.stringify({ type: "event_msg", payload: { type: "user_message", message: title } }),
+      padding,
+    ].join("\n");
+    const claudeTranscript = (cwd: string, title: string, padding = "") => [
+      JSON.stringify({ type: "user", cwd, message: { content: title } }),
+      padding,
+    ].join("\n");
+    await writeFixture(codex, codexTranscript("/repo/codex-alpha", "Codex alpha"), 1_700_000_000);
+    await writeFixture(claude, claudeTranscript("/repo/claude-alpha", "Claude alpha"), 1_700_000_000);
+
+    const first = await discoverFilesWithProjectCatalog(roots, undefined, { persist: false, persistIndex: true });
+    expect(first.files.find((entry) => entry.path === codex)).toMatchObject({
+      cwd: "/repo/codex-alpha",
+      project: projectForCwd("/repo/codex-alpha"),
+      title: "Codex alpha",
+    });
+    expect(first.files.find((entry) => entry.path === claude)).toMatchObject({
+      cwd: "/repo/claude-alpha",
+      title: "Claude alpha",
+    });
+
+    await writeFixture(codex, codexTranscript("/repo/codex-bravo", "Codex bravo", "larger rewrite padding"), 1_700_000_001);
+    await writeFixture(claude, claudeTranscript("/repo/claude-bravo", "Claude bravo", "larger rewrite padding"), 1_700_000_001);
+    const second = await discoverFilesWithProjectCatalog(roots, undefined, { persist: false });
+
+    expect(second.files.find((entry) => entry.path === codex)).toMatchObject({
+      cwd: "/repo/codex-bravo",
+      project: projectForCwd("/repo/codex-bravo"),
+      title: "Codex bravo",
+    });
+    expect(second.files.find((entry) => entry.path === claude)).toMatchObject({
+      cwd: "/repo/claude-bravo",
+      title: "Claude bravo",
+    });
+  } finally {
+    if (previousStateDir === undefined) delete process.env.LLV_STATE_DIR;
+    else process.env.LLV_STATE_DIR = previousStateDir;
+    await rm(base, { recursive: true, force: true });
+  }
+});
+
+test("Codex and Claude true appends retain head metadata through repeated EIO and rewrite recovery", async () => {
+  const base = await mkdtemp(path.join(os.tmpdir(), "llv-discover-append-eio-recovery-"));
+  const previousStateDir = process.env.LLV_STATE_DIR;
+  process.env.LLV_STATE_DIR = path.join(base, "state");
+  const originalOpen = fs.openSync;
+  try {
+    const roots: Record<RootKey, string> = {
+      "codex-sessions": path.join(base, "codex-sessions"),
+      "claude-projects": path.join(base, "claude-projects"),
+      "claude-tasks": path.join(base, "claude-tasks"),
+    };
+    await Promise.all(Object.values(roots).map((root) => mkdir(root, { recursive: true })));
+    const codex = path.join(roots["codex-sessions"], "append-recovery.jsonl");
+    const claude = path.join(roots["claude-projects"], "append-recovery", "session.jsonl");
+    const codexTranscript = (cwd: string, title: string, padding = "") => [
+      JSON.stringify({ type: "session_meta", payload: { cwd } }),
+      JSON.stringify({ type: "event_msg", payload: { type: "user_message", message: title } }),
+      padding,
+    ].join("\n");
+    const claudeTranscript = (cwd: string, title: string, padding = "") => [
+      JSON.stringify({ type: "user", cwd, message: { content: title } }),
+      padding,
+    ].join("\n");
+    await writeFixture(codex, codexTranscript("/repo/codex-original", "Codex original"), 1_700_000_000);
+    await writeFixture(claude, claudeTranscript("/repo/claude-original", "Claude original"), 1_700_000_000);
+    await discoverFilesWithProjectCatalog(roots, undefined, { persist: false, persistIndex: true });
+
+    await appendFile(codex, codexTranscript("/repo/codex-appended", "Codex appended"));
+    await appendFile(claude, claudeTranscript("/repo/claude-appended", "Claude appended"));
+    const appended = await discoverFilesWithProjectCatalog(roots, undefined, { persist: false, persistIndex: true });
+    expect(appended.files.find((entry) => entry.path === codex)).toMatchObject({
+      cwd: "/repo/codex-original",
+      project: projectForCwd("/repo/codex-original"),
+      title: "Codex original",
+    });
+    expect(appended.files.find((entry) => entry.path === claude)).toMatchObject({
+      cwd: "/repo/claude-original",
+      title: "Claude original",
+    });
+    const canonicalIndex = await readFile(path.join(process.env.LLV_STATE_DIR, "project-catalog.json"), "utf8");
+    const canonicalCatalog = structuredClone(conversationCatalogSnapshot());
+
+    await writeFixture(codex, codexTranscript("/repo/codex-recovered", "Codex recovered", "larger replacement"), 1_700_000_002);
+    await writeFixture(claude, claudeTranscript("/repo/claude-recovered", "Claude recovered", "larger replacement"), 1_700_000_002);
+    const failures = new Map([[codex, 4], [claude, 4]]);
+    fs.openSync = ((filename: fs.PathLike, flags: fs.OpenMode, mode?: fs.Mode) => {
+      const remaining = failures.get(String(filename)) ?? 0;
+      if (remaining > 0) {
+        failures.set(String(filename), remaining - 1);
+        const error = new Error("injected repeated transcript EIO") as NodeJS.ErrnoException;
+        error.code = "EIO";
+        throw error;
+      }
+      return originalOpen(filename, flags, mode);
+    }) as typeof fs.openSync;
+    const firstFailure = await discoverFilesWithProjectCatalog(roots, undefined, { persist: false, persistIndex: true });
+    const secondFailure = await discoverFilesWithProjectCatalog(roots, undefined, { persist: false, persistIndex: true });
+    expect(firstFailure.complete).toBe(false);
+    expect(secondFailure.complete).toBe(false);
+    expect(firstFailure.files.find((entry) => entry.path === codex)?.cwd).toBe("/repo/codex-original");
+    expect(secondFailure.files.find((entry) => entry.path === claude)?.cwd).toBe("/repo/claude-original");
+    expect(await readFile(path.join(process.env.LLV_STATE_DIR, "project-catalog.json"), "utf8")).toBe(canonicalIndex);
+    expect(conversationCatalogSnapshot()).toEqual(canonicalCatalog);
+
+    fs.openSync = originalOpen;
+    const recovered = await discoverFilesWithProjectCatalog(roots, undefined, { persist: false, persistIndex: true });
+    expect(recovered.complete).toBe(true);
+    expect(recovered.files.find((entry) => entry.path === codex)).toMatchObject({
+      cwd: "/repo/codex-recovered",
+      project: projectForCwd("/repo/codex-recovered"),
+      title: "Codex recovered",
+    });
+    expect(recovered.files.find((entry) => entry.path === claude)).toMatchObject({
+      cwd: "/repo/claude-recovered",
+      title: "Claude recovered",
+    });
+  } finally {
+    fs.openSync = originalOpen;
+    if (previousStateDir === undefined) delete process.env.LLV_STATE_DIR;
+    else process.env.LLV_STATE_DIR = previousStateDir;
+    await rm(base, { recursive: true, force: true });
+  }
+});
+
 test("a one-shot transcript read failure stays incomplete and recovers in memory and after restart", async () => {
   const base = await mkdtemp(path.join(os.tmpdir(), "llv-discover-transcript-read-retry-"));
   const previousStateDir = process.env.LLV_STATE_DIR;
@@ -962,8 +1102,88 @@ test("project catalog omits task-only residue from a clean state", async () => {
 
     const scan = await discoverFilesWithProjectCatalog(roots);
 
+    expect(scan.complete).toBe(true);
     expect(scan.files.some((entry) => entry.path === taskPath)).toBe(true);
     expect(scan.projectCatalog).toEqual([]);
+    const persisted = JSON.parse(await readFile(path.join(process.env.LLV_STATE_DIR, "project-catalog.json"), "utf8"));
+    expect(persisted.files[taskPath]).toBeDefined();
+  } finally {
+    if (previousStateDir === undefined) delete process.env.LLV_STATE_DIR;
+    else process.env.LLV_STATE_DIR = previousStateDir;
+    await rm(base, { recursive: true, force: true });
+  }
+});
+
+test("first-ever EIO and EACCES task twin lookups publish only after recovery", async () => {
+  for (const code of ["EIO", "EACCES"] as const) {
+    const base = await mkdtemp(path.join(os.tmpdir(), `llv-discover-task-twin-${code.toLowerCase()}-`));
+    const previousStateDir = process.env.LLV_STATE_DIR;
+    process.env.LLV_STATE_DIR = path.join(base, "state");
+    const originalAccess = fs.promises.access;
+    try {
+      const roots: Record<RootKey, string> = {
+        "codex-sessions": path.join(base, "codex-sessions"),
+        "claude-projects": path.join(base, "claude-projects"),
+        "claude-tasks": path.join(base, "claude-tasks"),
+      };
+      await Promise.all(Object.values(roots).map((root) => mkdir(root, { recursive: true })));
+      const taskPath = path.join(roots["claude-tasks"], "project-a", "session-a", "tasks", "task-a.output");
+      const twinPath = path.join(roots["claude-projects"], "project-a", "session-a", "subagents", "agent-task-a.jsonl");
+      await writeFixture(taskPath, "finished\n", 1_700_000_000);
+      const publishedBefore = structuredClone(conversationCatalogSnapshot());
+      fs.promises.access = (async (pathname, mode) => {
+        if (pathname === twinPath) {
+          const error = new Error(`injected task twin ${code}`) as NodeJS.ErrnoException;
+          error.code = code;
+          throw error;
+        }
+        return originalAccess(pathname, mode);
+      }) as typeof fs.promises.access;
+
+      const failed = await discoverFilesWithProjectCatalog(roots, undefined, { persist: false, persistIndex: true });
+      expect(failed.complete).toBe(false);
+      expect(existsSync(path.join(process.env.LLV_STATE_DIR, "project-catalog.json"))).toBe(false);
+      expect(conversationCatalogSnapshot()).toEqual(publishedBefore);
+
+      fs.promises.access = originalAccess;
+      const recovered = await discoverFilesWithProjectCatalog(roots, undefined, { persist: false, persistIndex: true });
+      expect(recovered.complete).toBe(true);
+      expect(recovered.files.map((entry) => entry.path)).toContain(taskPath);
+      expect(existsSync(path.join(process.env.LLV_STATE_DIR, "project-catalog.json"))).toBe(true);
+    } finally {
+      fs.promises.access = originalAccess;
+      if (previousStateDir === undefined) delete process.env.LLV_STATE_DIR;
+      else process.env.LLV_STATE_DIR = previousStateDir;
+      await rm(base, { recursive: true, force: true });
+    }
+  }
+});
+
+test("a first-ever ENOTDIR task twin lookup stays incomplete and publishes no durable scanner state", async () => {
+  const base = await mkdtemp(path.join(os.tmpdir(), "llv-discover-task-twin-enotdir-"));
+  const previousStateDir = process.env.LLV_STATE_DIR;
+  process.env.LLV_STATE_DIR = path.join(base, "state");
+  try {
+    const roots: Record<RootKey, string> = {
+      "codex-sessions": path.join(base, "codex-sessions"),
+      "claude-projects": path.join(base, "claude-projects"),
+      "claude-tasks": path.join(base, "claude-tasks"),
+    };
+    await Promise.all(Object.values(roots).map((root) => mkdir(root, { recursive: true })));
+    const taskPath = path.join(roots["claude-tasks"], "project-a", "session-a", "tasks", "task-a.output");
+    await writeFixture(taskPath, "finished\n", 1_700_000_000);
+    await writeFixture(
+      path.join(roots["claude-projects"], "project-a", "session-a", "subagents"),
+      "blocks the expected subagents directory\n",
+      1_700_000_000,
+    );
+    const publishedBefore = structuredClone(conversationCatalogSnapshot());
+
+    const scan = await discoverFilesWithProjectCatalog(roots, undefined, { persist: false, persistIndex: true });
+
+    expect(scan.complete).toBe(false);
+    expect(existsSync(path.join(process.env.LLV_STATE_DIR, "project-catalog.json"))).toBe(false);
+    expect(conversationCatalogSnapshot()).toEqual(publishedBefore);
   } finally {
     if (previousStateDir === undefined) delete process.env.LLV_STATE_DIR;
     else process.env.LLV_STATE_DIR = previousStateDir;

--- a/src/lib/scanner/discover.test.ts
+++ b/src/lib/scanner/discover.test.ts
@@ -97,6 +97,56 @@ test("request refreshes persist the per-file scanner index", async () => {
   }
 });
 
+test("project catalog persistence repairs private modes and atomically replaces symlinks", async () => {
+  const base = await mkdtemp(path.join(os.tmpdir(), "llv-discover-private-index-"));
+  const previousStateDir = process.env.LLV_STATE_DIR;
+  const previousUmask = process.umask(0);
+  process.env.LLV_STATE_DIR = path.join(base, "state");
+  const originalRename = fs.renameSync;
+  try {
+    const roots: Record<RootKey, string> = {
+      "codex-sessions": path.join(base, "codex-sessions"),
+      "claude-projects": path.join(base, "claude-projects"),
+      "claude-tasks": path.join(base, "claude-tasks"),
+    };
+    await Promise.all(Object.values(roots).map((root) => mkdir(root, { recursive: true })));
+    const transcript = path.join(roots["codex-sessions"], "private.jsonl");
+    await writeFixture(transcript, JSON.stringify({ type: "session_meta", payload: { cwd: "/repo/private" } }) + "\n", 1_700_000_000);
+    fs.mkdirSync(process.env.LLV_STATE_DIR, { recursive: true, mode: 0o777 });
+    fs.chmodSync(process.env.LLV_STATE_DIR, 0o777);
+    const indexPath = path.join(process.env.LLV_STATE_DIR, "project-catalog.json");
+    fs.writeFileSync(indexPath, "legacy\n", { mode: 0o666 });
+    fs.chmodSync(indexPath, 0o666);
+    let temporaryMode: number | undefined;
+    fs.renameSync = ((source: fs.PathLike, target: fs.PathLike) => {
+      if (target === indexPath) temporaryMode = fs.statSync(source).mode & 0o777;
+      return originalRename(source, target);
+    }) as typeof fs.renameSync;
+
+    await discoverFilesWithProjectCatalog(roots, undefined, { persist: false, persistIndex: true });
+
+    expect(fs.statSync(process.env.LLV_STATE_DIR).mode & 0o777).toBe(0o700);
+    expect(temporaryMode).toBe(0o600);
+    expect(fs.statSync(indexPath).mode & 0o777).toBe(0o600);
+
+    const sentinelPath = path.join(base, "external-sentinel");
+    fs.writeFileSync(sentinelPath, "sentinel\n", { mode: 0o666 });
+    fs.rmSync(indexPath);
+    fs.symlinkSync(sentinelPath, indexPath);
+    await discoverFilesWithProjectCatalog(roots, undefined, { persist: false, persistIndex: true });
+
+    expect(fs.lstatSync(indexPath).isFile()).toBe(true);
+    expect(fs.statSync(indexPath).mode & 0o777).toBe(0o600);
+    expect(fs.readFileSync(sentinelPath, "utf8")).toBe("sentinel\n");
+  } finally {
+    fs.renameSync = originalRename;
+    process.umask(previousUmask);
+    if (previousStateDir === undefined) delete process.env.LLV_STATE_DIR;
+    else process.env.LLV_STATE_DIR = previousStateDir;
+    await rm(base, { recursive: true, force: true });
+  }
+});
+
 test("a non-ENOENT directory failure leaves the completed catalog index authoritative until recovery", async () => {
   const base = await mkdtemp(path.join(os.tmpdir(), "llv-discover-incomplete-walk-"));
   const previousStateDir = process.env.LLV_STATE_DIR;
@@ -322,6 +372,8 @@ test("a one-shot transcript read failure stays incomplete and recovers in memory
     expect(Buffer.byteLength(alpha)).toBe(Buffer.byteLength(bravo));
     await writeFixture(transcript, alpha, 1_700_000_000);
     await discoverFilesWithProjectCatalog(roots, undefined, { persist: false, persistIndex: true });
+    const canonicalIndex = await readFile(indexPath, "utf8");
+    const canonicalCatalog = structuredClone(conversationCatalogSnapshot());
     await writeFixture(transcript, bravo, 1_700_000_001);
 
     const originalOpen = fs.openSync;
@@ -341,7 +393,9 @@ test("a one-shot transcript read failure stays incomplete and recovers in memory
     }
 
     const failedIndex = await readFile(indexPath, "utf8");
-    const persistedAfterFailure = JSON.parse(failedIndex);
+    expect(failedScan.complete).toBe(false);
+    expect(failedIndex).toBe(canonicalIndex);
+    expect(conversationCatalogSnapshot()).toEqual(canonicalCatalog);
     const recoveredInMemory = await discoverFilesWithProjectCatalog(roots, undefined, { persist: false, persistIndex: true });
     await writeFile(indexPath, failedIndex);
     const recoveredAfterRestart = await discoverEntryInFreshProcess(roots, transcript);
@@ -350,7 +404,6 @@ test("a one-shot transcript read failure stays incomplete and recovers in memory
       cwd: "/repo/alpha",
       project: projectForCwd("/repo/alpha"),
     });
-    expect(persistedAfterFailure.files[transcript].summaryVersion).toBeUndefined();
     expect(recoveredInMemory.files.find((entry) => entry.path === transcript)).toMatchObject({
       cwd: "/repo/bravo",
       project: projectForCwd("/repo/bravo"),
@@ -358,6 +411,62 @@ test("a one-shot transcript read failure stays incomplete and recovers in memory
     expect(recoveredAfterRestart).toMatchObject({
       cwd: "/repo/bravo",
       project: projectForCwd("/repo/bravo"),
+    });
+  } finally {
+    if (previousStateDir === undefined) delete process.env.LLV_STATE_DIR;
+    else process.env.LLV_STATE_DIR = previousStateDir;
+    await rm(base, { recursive: true, force: true });
+  }
+});
+
+test("first-ever repeated transcript read failures publish and persist only after recovery", async () => {
+  const base = await mkdtemp(path.join(os.tmpdir(), "llv-discover-first-read-retry-"));
+  const previousStateDir = process.env.LLV_STATE_DIR;
+  process.env.LLV_STATE_DIR = path.join(base, "state");
+  try {
+    const roots: Record<RootKey, string> = {
+      "codex-sessions": path.join(base, "codex-sessions"),
+      "claude-projects": path.join(base, "claude-projects"),
+      "claude-tasks": path.join(base, "claude-tasks"),
+    };
+    await Promise.all(Object.values(roots).map((root) => mkdir(root, { recursive: true })));
+    const transcript = path.join(roots["codex-sessions"], "first.jsonl");
+    const indexPath = path.join(process.env.LLV_STATE_DIR, "project-catalog.json");
+    await writeFixture(transcript, JSON.stringify({ type: "session_meta", payload: { cwd: "/repo/first" } }) + "\n", 1_700_000_000);
+    const publishedBeforeFailure = structuredClone(conversationCatalogSnapshot());
+
+    const originalOpen = fs.openSync;
+    let failures = 4;
+    fs.openSync = ((filename: fs.PathLike, flags: fs.OpenMode, mode?: fs.Mode) => {
+      if (filename === transcript && failures > 0) {
+        failures -= 1;
+        const error = new Error("injected first transcript EIO") as NodeJS.ErrnoException;
+        error.code = "EIO";
+        throw error;
+      }
+      return originalOpen(filename, flags, mode);
+    }) as typeof fs.openSync;
+    let firstFailure;
+    let secondFailure;
+    try {
+      firstFailure = await discoverFilesWithProjectCatalog(roots, undefined, { persist: false, persistIndex: true });
+      secondFailure = await discoverFilesWithProjectCatalog(roots, undefined, { persist: false, persistIndex: true });
+    } finally {
+      fs.openSync = originalOpen;
+    }
+
+    expect(firstFailure.complete).toBe(false);
+    expect(secondFailure.complete).toBe(false);
+    expect(existsSync(indexPath)).toBe(false);
+    expect(conversationCatalogSnapshot()).toEqual(publishedBeforeFailure);
+
+    const recovered = await discoverFilesWithProjectCatalog(roots, undefined, { persist: false, persistIndex: true });
+    expect(recovered.complete).toBe(true);
+    expect(existsSync(indexPath)).toBe(true);
+    expect(conversationCatalogSnapshot().map((entry) => entry.path)).toContain(transcript);
+    expect(await discoverEntryInFreshProcess(roots, transcript)).toMatchObject({
+      cwd: "/repo/first",
+      project: projectForCwd("/repo/first"),
     });
   } finally {
     if (previousStateDir === undefined) delete process.env.LLV_STATE_DIR;
@@ -419,6 +528,7 @@ test("a one-shot sidecar read failure stays incomplete and recovers in memory an
     await writeFixture(transcript, "{}\n", 1_700_000_000);
     await writeFixture(sidecar, alpha, 1_700_000_000);
     await discoverFilesWithProjectCatalog(roots, undefined, { persist: false, persistIndex: true });
+    const canonicalIndex = await readFile(indexPath, "utf8");
     await writeFixture(sidecar, bravo, 1_700_000_001);
 
     const originalRead = fs.readFileSync;
@@ -438,13 +548,13 @@ test("a one-shot sidecar read failure stays incomplete and recovers in memory an
     }
 
     const failedIndex = await readFile(indexPath, "utf8");
-    const persistedAfterFailure = JSON.parse(failedIndex);
     const recoveredInMemory = await discoverFilesWithProjectCatalog(roots, undefined, { persist: false, persistIndex: true });
     await writeFile(indexPath, failedIndex);
     const recoveredAfterRestart = await discoverEntryInFreshProcess(roots, transcript);
 
     expect(failedScan.files.find((entry) => entry.path === transcript)?.title).toBe("Subagent x");
-    expect(persistedAfterFailure.files[transcript].summaryVersion).toBeUndefined();
+    expect(failedScan.complete).toBe(false);
+    expect(failedIndex).toBe(canonicalIndex);
     expect(recoveredInMemory.files.find((entry) => entry.path === transcript)?.title).toBe("Agent bravo");
     expect(recoveredAfterRestart?.title).toBe("Agent bravo");
   } finally {

--- a/src/lib/scanner/discover.test.ts
+++ b/src/lib/scanner/discover.test.ts
@@ -7,7 +7,7 @@ import { expect, test } from "bun:test";
 
 import { emptyLaunchProfile } from "../accounts/migration/contracts";
 import { AgentRegistry, setAgentRegistryForTests } from "../agent/registry";
-import type { RootKey } from "../types";
+import type { FileEntry, RootKey } from "../types";
 import { conversationCatalogSnapshot } from "./conversationCatalog";
 import { discoverFiles, discoverFilesWithProjectCatalog, type RawEntry } from "./discover";
 import { projectForCwd } from "./describe";
@@ -20,6 +20,31 @@ async function writeFixture(pathname: string, content: string, mtimeSeconds: num
   await mkdir(path.dirname(pathname), { recursive: true });
   await writeFile(pathname, content);
   await utimes(pathname, mtimeSeconds, mtimeSeconds);
+}
+
+async function discoverEntryInFreshProcess(roots: Record<RootKey, string>, pathname: string): Promise<FileEntry | undefined> {
+  const modulePath = path.join(import.meta.dir, "discover.ts");
+  const child = Bun.spawn({
+    cmd: [process.execPath, "-e", `
+      const { discoverFilesWithProjectCatalog } = await import(${JSON.stringify(modulePath)});
+      const result = await discoverFilesWithProjectCatalog(
+        ${JSON.stringify(roots)},
+        undefined,
+        { persist: false, persistIndex: true },
+      );
+      process.stdout.write(JSON.stringify(result.files.find((entry) => entry.path === ${JSON.stringify(pathname)})));
+    `],
+    env: { ...process.env, LLV_STATE_DIR: process.env.LLV_STATE_DIR! },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [exitCode, output, error] = await Promise.all([
+    child.exited,
+    new Response(child.stdout).text(),
+    new Response(child.stderr).text(),
+  ]);
+  if (exitCode !== 0) throw new Error(`fresh scanner process failed (${exitCode}): ${error}`);
+  return output ? JSON.parse(output) as FileEntry : undefined;
 }
 
 test("pure project-catalog discovery leaves the state directory unchanged", async () => {
@@ -176,9 +201,21 @@ test("an append reparses its file and reuses unchanged persisted summaries", asy
     await writeFixture(sidecar(changed), JSON.stringify({ description: "Changed reparsed" }), 1_700_000_002);
     await appendFile(changed, "{}\n");
 
-    const second = await discoverFilesWithProjectCatalog(roots, undefined, { persist: false });
+    const originalRead = fs.readFileSync;
+    let unchangedSidecarReads = 0;
+    fs.readFileSync = ((filename: fs.PathOrFileDescriptor, ...args: unknown[]) => {
+      if (filename === sidecar(unchanged)) unchangedSidecarReads += 1;
+      return (originalRead as (...inner: unknown[]) => unknown)(filename, ...args);
+    }) as typeof fs.readFileSync;
+    let second;
+    try {
+      second = await discoverFilesWithProjectCatalog(roots, undefined, { persist: false });
+    } finally {
+      fs.readFileSync = originalRead;
+    }
     expect(second.files.find((entry) => entry.path === unchanged)?.title).toBe("Unchanged original");
     expect(second.files.find((entry) => entry.path === changed)?.title).toBe("Changed reparsed");
+    expect(unchangedSidecarReads).toBe(0);
   } finally {
     if (previousStateDir === undefined) delete process.env.LLV_STATE_DIR;
     else process.env.LLV_STATE_DIR = previousStateDir;
@@ -223,6 +260,68 @@ test("a same-size transcript rewrite with a newer mtime reparses cwd and project
   }
 });
 
+test("a one-shot transcript read failure stays incomplete and recovers in memory and after restart", async () => {
+  const base = await mkdtemp(path.join(os.tmpdir(), "llv-discover-transcript-read-retry-"));
+  const previousStateDir = process.env.LLV_STATE_DIR;
+  process.env.LLV_STATE_DIR = path.join(base, "state");
+  try {
+    const roots: Record<RootKey, string> = {
+      "codex-sessions": path.join(base, "codex-sessions"),
+      "claude-projects": path.join(base, "claude-projects"),
+      "claude-tasks": path.join(base, "claude-tasks"),
+    };
+    await Promise.all(Object.values(roots).map((root) => mkdir(root, { recursive: true })));
+    const transcript = path.join(roots["codex-sessions"], "rewritten.jsonl");
+    const indexPath = path.join(process.env.LLV_STATE_DIR, "project-catalog.json");
+    const alpha = JSON.stringify({ type: "session_meta", payload: { cwd: "/repo/alpha" } }) + "\n";
+    const bravo = JSON.stringify({ type: "session_meta", payload: { cwd: "/repo/bravo" } }) + "\n";
+    expect(Buffer.byteLength(alpha)).toBe(Buffer.byteLength(bravo));
+    await writeFixture(transcript, alpha, 1_700_000_000);
+    await discoverFilesWithProjectCatalog(roots, undefined, { persist: false, persistIndex: true });
+    await writeFixture(transcript, bravo, 1_700_000_001);
+
+    const originalOpen = fs.openSync;
+    let failures = 1;
+    fs.openSync = ((filename: fs.PathLike, flags: fs.OpenMode, mode?: fs.Mode) => {
+      if (filename === transcript && failures > 0) {
+        failures -= 1;
+        throw new Error("injected transcript read failure");
+      }
+      return originalOpen(filename, flags, mode);
+    }) as typeof fs.openSync;
+    let failedScan;
+    try {
+      failedScan = await discoverFilesWithProjectCatalog(roots, undefined, { persist: false, persistIndex: true });
+    } finally {
+      fs.openSync = originalOpen;
+    }
+
+    const failedIndex = await readFile(indexPath, "utf8");
+    const persistedAfterFailure = JSON.parse(failedIndex);
+    const recoveredInMemory = await discoverFilesWithProjectCatalog(roots, undefined, { persist: false, persistIndex: true });
+    await writeFile(indexPath, failedIndex);
+    const recoveredAfterRestart = await discoverEntryInFreshProcess(roots, transcript);
+
+    expect(failedScan.files.find((entry) => entry.path === transcript)).toMatchObject({
+      cwd: "/repo/alpha",
+      project: projectForCwd("/repo/alpha"),
+    });
+    expect(persistedAfterFailure.files[transcript].summaryVersion).toBeUndefined();
+    expect(recoveredInMemory.files.find((entry) => entry.path === transcript)).toMatchObject({
+      cwd: "/repo/bravo",
+      project: projectForCwd("/repo/bravo"),
+    });
+    expect(recoveredAfterRestart).toMatchObject({
+      cwd: "/repo/bravo",
+      project: projectForCwd("/repo/bravo"),
+    });
+  } finally {
+    if (previousStateDir === undefined) delete process.env.LLV_STATE_DIR;
+    else process.env.LLV_STATE_DIR = previousStateDir;
+    await rm(base, { recursive: true, force: true });
+  }
+});
+
 test("a same-size subagent sidecar rewrite with a newer mtime reparses its title", async () => {
   const base = await mkdtemp(path.join(os.tmpdir(), "llv-discover-sidecar-rewrite-"));
   const previousStateDir = process.env.LLV_STATE_DIR;
@@ -249,6 +348,61 @@ test("a same-size subagent sidecar rewrite with a newer mtime reparses its title
     const second = await discoverFilesWithProjectCatalog(roots, undefined, { persist: false });
 
     expect(second.files.find((entry) => entry.path === transcript)?.title).toBe("Agent bravo");
+  } finally {
+    if (previousStateDir === undefined) delete process.env.LLV_STATE_DIR;
+    else process.env.LLV_STATE_DIR = previousStateDir;
+    await rm(base, { recursive: true, force: true });
+  }
+});
+
+test("a one-shot sidecar read failure stays incomplete and recovers in memory and after restart", async () => {
+  const base = await mkdtemp(path.join(os.tmpdir(), "llv-discover-sidecar-read-retry-"));
+  const previousStateDir = process.env.LLV_STATE_DIR;
+  process.env.LLV_STATE_DIR = path.join(base, "state");
+  try {
+    const roots: Record<RootKey, string> = {
+      "codex-sessions": path.join(base, "codex-sessions"),
+      "claude-projects": path.join(base, "claude-projects"),
+      "claude-tasks": path.join(base, "claude-tasks"),
+    };
+    await Promise.all(Object.values(roots).map((root) => mkdir(root, { recursive: true })));
+    const transcript = path.join(roots["claude-projects"], "sidecar", "session", "subagents", "agent-x.jsonl");
+    const sidecar = transcript.slice(0, -".jsonl".length) + ".meta.json";
+    const indexPath = path.join(process.env.LLV_STATE_DIR, "project-catalog.json");
+    const alpha = JSON.stringify({ description: "Agent alpha" });
+    const bravo = JSON.stringify({ description: "Agent bravo" });
+    expect(Buffer.byteLength(alpha)).toBe(Buffer.byteLength(bravo));
+    await writeFixture(transcript, "{}\n", 1_700_000_000);
+    await writeFixture(sidecar, alpha, 1_700_000_000);
+    await discoverFilesWithProjectCatalog(roots, undefined, { persist: false, persistIndex: true });
+    await writeFixture(sidecar, bravo, 1_700_000_001);
+
+    const originalRead = fs.readFileSync;
+    let failures = 1;
+    fs.readFileSync = ((filename: fs.PathOrFileDescriptor, ...args: unknown[]) => {
+      if (filename === sidecar && failures > 0) {
+        failures -= 1;
+        throw new Error("injected sidecar read failure");
+      }
+      return (originalRead as (...inner: unknown[]) => unknown)(filename, ...args);
+    }) as typeof fs.readFileSync;
+    let failedScan;
+    try {
+      failedScan = await discoverFilesWithProjectCatalog(roots, undefined, { persist: false, persistIndex: true });
+    } finally {
+      fs.readFileSync = originalRead;
+    }
+
+    const failedIndex = await readFile(indexPath, "utf8");
+    const persistedAfterFailure = JSON.parse(failedIndex);
+    const recoveredInMemory = await discoverFilesWithProjectCatalog(roots, undefined, { persist: false, persistIndex: true });
+    await writeFile(indexPath, failedIndex);
+    const recoveredAfterRestart = await discoverEntryInFreshProcess(roots, transcript);
+
+    expect(failedScan.files.find((entry) => entry.path === transcript)?.title).toBe("Subagent x");
+    expect(persistedAfterFailure.files[transcript].summaryVersion).toBeUndefined();
+    expect(recoveredInMemory.files.find((entry) => entry.path === transcript)?.title).toBe("Agent bravo");
+    expect(recoveredAfterRestart?.title).toBe("Agent bravo");
   } finally {
     if (previousStateDir === undefined) delete process.env.LLV_STATE_DIR;
     else process.env.LLV_STATE_DIR = previousStateDir;

--- a/src/lib/scanner/discover.test.ts
+++ b/src/lib/scanner/discover.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, mkdir, readFile, rm, stat, utimes, writeFile } from "node:fs/promises";
+import { appendFile, mkdtemp, mkdir, readFile, rm, stat, utimes, writeFile } from "node:fs/promises";
 import { existsSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -9,6 +9,7 @@ import { emptyLaunchProfile } from "../accounts/migration/contracts";
 import { AgentRegistry, setAgentRegistryForTests } from "../agent/registry";
 import type { RootKey } from "../types";
 import { conversationCatalogSnapshot } from "./conversationCatalog";
+import { globalCache } from "./caches";
 import { discoverFiles, discoverFilesWithProjectCatalog, type RawEntry } from "./discover";
 import { projectForCwd } from "./describe";
 import { projectCatalogSnapshotFromRaw } from "./projectCatalog";
@@ -38,6 +39,133 @@ test("pure project-catalog discovery leaves the state directory unchanged", asyn
   } finally {
     if (previousStateDir === undefined) delete process.env.LLV_STATE_DIR;
     else process.env.LLV_STATE_DIR = previousStateDir;
+    await rm(base, { recursive: true, force: true });
+  }
+});
+
+test("request refreshes persist the per-file scanner index", async () => {
+  const base = await mkdtemp(path.join(os.tmpdir(), "llv-discover-index-"));
+  const previousStateDir = process.env.LLV_STATE_DIR;
+  process.env.LLV_STATE_DIR = path.join(base, "state");
+  try {
+    const roots: Record<RootKey, string> = {
+      "codex-sessions": path.join(base, "codex-sessions"),
+      "claude-projects": path.join(base, "claude-projects"),
+      "claude-tasks": path.join(base, "claude-tasks"),
+    };
+    await Promise.all(Object.values(roots).map((root) => mkdir(root, { recursive: true })));
+    const transcript = path.join(roots["codex-sessions"], "indexed.jsonl");
+    await writeFixture(transcript, JSON.stringify({ type: "session_meta", payload: { cwd: "/repo/indexed" } }) + "\n", 1_700_000_000);
+
+    await discoverFilesWithProjectCatalog(roots, undefined, { persist: false, persistIndex: true });
+
+    const persisted = JSON.parse(await readFile(path.join(process.env.LLV_STATE_DIR, "project-catalog.json"), "utf8"));
+    expect(Object.keys(persisted.files)).toEqual([transcript]);
+    expect(persisted.files[transcript]).toMatchObject({
+      size: (await stat(transcript)).size,
+      project: projectForCwd("/repo/indexed"),
+      kind: "session",
+    });
+  } finally {
+    if (previousStateDir === undefined) delete process.env.LLV_STATE_DIR;
+    else process.env.LLV_STATE_DIR = previousStateDir;
+    await rm(base, { recursive: true, force: true });
+  }
+});
+
+test("an append reparses its file and reuses unchanged persisted summaries", async () => {
+  const base = await mkdtemp(path.join(os.tmpdir(), "llv-discover-incremental-"));
+  const previousStateDir = process.env.LLV_STATE_DIR;
+  process.env.LLV_STATE_DIR = path.join(base, "state");
+  try {
+    const roots: Record<RootKey, string> = {
+      "codex-sessions": path.join(base, "codex-sessions"),
+      "claude-projects": path.join(base, "claude-projects"),
+      "claude-tasks": path.join(base, "claude-tasks"),
+    };
+    await Promise.all(Object.values(roots).map((root) => mkdir(root, { recursive: true })));
+    const unchanged = path.join(roots["claude-projects"], "incremental", "session", "subagents", "agent-unchanged.jsonl");
+    const changed = path.join(roots["claude-projects"], "incremental", "session", "subagents", "agent-changed.jsonl");
+    const sidecar = (pathname: string) => pathname.slice(0, -".jsonl".length) + ".meta.json";
+    await writeFixture(unchanged, "{}\n", 1_700_000_000);
+    await writeFixture(changed, "{}\n", 1_700_000_001);
+    await writeFile(sidecar(unchanged), JSON.stringify({ description: "Unchanged original" }));
+    await writeFile(sidecar(changed), JSON.stringify({ description: "Changed original" }));
+
+    const first = await discoverFilesWithProjectCatalog(roots, undefined, { persist: false, persistIndex: true });
+    expect(first.files.find((entry) => entry.path === unchanged)?.title).toBe("Unchanged original");
+    expect(first.files.find((entry) => entry.path === changed)?.title).toBe("Changed original");
+
+    globalCache<unknown>("meta-v5").clear();
+    await writeFile(sidecar(unchanged), JSON.stringify({ description: "Unchanged mutated" }));
+    await writeFile(sidecar(changed), JSON.stringify({ description: "Changed reparsed" }));
+    await appendFile(changed, "{}\n");
+
+    const second = await discoverFilesWithProjectCatalog(roots, undefined, { persist: false });
+    expect(second.files.find((entry) => entry.path === unchanged)?.title).toBe("Unchanged original");
+    expect(second.files.find((entry) => entry.path === changed)?.title).toBe("Changed reparsed");
+  } finally {
+    globalCache<unknown>("meta-v5").clear();
+    if (previousStateDir === undefined) delete process.env.LLV_STATE_DIR;
+    else process.env.LLV_STATE_DIR = previousStateDir;
+    await rm(base, { recursive: true, force: true });
+  }
+});
+
+test("a corrupt per-file scanner index falls back to a full parse and repairs itself", async () => {
+  const base = await mkdtemp(path.join(os.tmpdir(), "llv-discover-corrupt-index-"));
+  const previousStateDir = process.env.LLV_STATE_DIR;
+  process.env.LLV_STATE_DIR = path.join(base, "state");
+  try {
+    const roots: Record<RootKey, string> = {
+      "codex-sessions": path.join(base, "codex-sessions"),
+      "claude-projects": path.join(base, "claude-projects"),
+      "claude-tasks": path.join(base, "claude-tasks"),
+    };
+    await Promise.all(Object.values(roots).map((root) => mkdir(root, { recursive: true })));
+    const transcript = path.join(roots["claude-projects"], "recovered", "session", "subagents", "agent-child.jsonl");
+    await writeFixture(transcript, "{}\n", 1_700_000_000);
+    await writeFile(transcript.slice(0, -".jsonl".length) + ".meta.json", JSON.stringify({ description: "Recovered summary" }));
+    await mkdir(process.env.LLV_STATE_DIR, { recursive: true });
+    await writeFile(path.join(process.env.LLV_STATE_DIR, "project-catalog.json"), "{ corrupt");
+
+    const recovered = await discoverFilesWithProjectCatalog(roots, undefined, { persist: false, persistIndex: true });
+
+    expect(recovered.files.find((entry) => entry.path === transcript)?.title).toBe("Recovered summary");
+    const persisted = JSON.parse(await readFile(path.join(process.env.LLV_STATE_DIR, "project-catalog.json"), "utf8"));
+    expect(persisted.files[transcript]).toMatchObject({ summaryVersion: 1, title: "Recovered summary" });
+  } finally {
+    if (previousStateDir === undefined) delete process.env.LLV_STATE_DIR;
+    else process.env.LLV_STATE_DIR = previousStateDir;
+    await rm(base, { recursive: true, force: true });
+  }
+});
+
+test("a pinned discovery identifies only rows outside the global scheme window", async () => {
+  const base = await mkdtemp(path.join(os.tmpdir(), "llv-discover-pin-overlay-"));
+  try {
+    const roots: Record<RootKey, string> = {
+      "codex-sessions": path.join(base, "codex-sessions"),
+      "claude-projects": path.join(base, "claude-projects"),
+      "claude-tasks": path.join(base, "claude-tasks"),
+    };
+    await Promise.all(Object.values(roots).map((root) => mkdir(root, { recursive: true })));
+    const transcripts: string[] = [];
+    for (let index = 0; index <= DEFAULT_SCHEME_CARDS_PER_PROJECT; index += 1) {
+      const transcript = path.join(roots["claude-projects"], "pin-overlay", `session-${index}.jsonl`);
+      transcripts.push(transcript);
+      await writeFixture(transcript, JSON.stringify({ type: "user", message: { content: `Prompt ${index}` } }) + "\n", 1_700_000_000 + index);
+    }
+    const pinnedPath = transcripts[0]!;
+
+    const scan = await discoverFilesWithProjectCatalog(roots, undefined, {
+      persist: false,
+      pin: new Set([pinnedPath]),
+    });
+
+    expect(scan.pinOverlayPaths).toEqual([pinnedPath]);
+    expect(scan.files.filter((entry) => !scan.pinOverlayPaths?.includes(entry.path))).toHaveLength(DEFAULT_SCHEME_CARDS_PER_PROJECT);
+  } finally {
     await rm(base, { recursive: true, force: true });
   }
 });

--- a/src/lib/scanner/discover.test.ts
+++ b/src/lib/scanner/discover.test.ts
@@ -1,5 +1,5 @@
 import { appendFile, mkdtemp, mkdir, readFile, rm, stat, utimes, writeFile } from "node:fs/promises";
-import { existsSync } from "node:fs";
+import fs, { existsSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
@@ -65,6 +65,84 @@ test("request refreshes persist the per-file scanner index", async () => {
       project: projectForCwd("/repo/indexed"),
       kind: "session",
     });
+  } finally {
+    if (previousStateDir === undefined) delete process.env.LLV_STATE_DIR;
+    else process.env.LLV_STATE_DIR = previousStateDir;
+    await rm(base, { recursive: true, force: true });
+  }
+});
+
+test("project index publication failures preserve the canonical file, clean temps, stay non-fatal, and recover", async () => {
+  const base = await mkdtemp(path.join(os.tmpdir(), "llv-discover-index-failure-"));
+  const previousStateDir = process.env.LLV_STATE_DIR;
+  process.env.LLV_STATE_DIR = path.join(base, "state");
+  const roots: Record<RootKey, string> = {
+    "codex-sessions": path.join(base, "codex-sessions"),
+    "claude-projects": path.join(base, "claude-projects"),
+    "claude-tasks": path.join(base, "claude-tasks"),
+  };
+  try {
+    await Promise.all(Object.values(roots).map((root) => mkdir(root, { recursive: true })));
+    const canonicalTranscript = path.join(roots["codex-sessions"], "canonical.jsonl");
+    await writeFixture(canonicalTranscript, JSON.stringify({ type: "session_meta", payload: { cwd: "/repo/canonical" } }) + "\n", 1_700_000_000);
+    await discoverFilesWithProjectCatalog(roots, undefined, { persist: false, persistIndex: true });
+    const indexPath = path.join(process.env.LLV_STATE_DIR, "project-catalog.json");
+    const canonical = await readFile(indexPath, "utf8");
+    const originalWrite = fs.writeFileSync;
+    const originalRename = fs.renameSync;
+    const originalError = console.error;
+    const diagnostics: string[] = [];
+    let failure: "write" | "rename" | null = null;
+    fs.writeFileSync = ((filename: fs.PathOrFileDescriptor, data: string | NodeJS.ArrayBufferView, options?: fs.WriteFileOptions) => {
+      const result = originalWrite(filename, data, options);
+      if (failure === "write" && String(filename).includes(".project-catalog.json.")) {
+        throw new Error("injected project index write failure");
+      }
+      return result;
+    }) as typeof fs.writeFileSync;
+    fs.renameSync = ((source: fs.PathLike, target: fs.PathLike) => {
+      if (failure === "rename" && target === indexPath) {
+        throw new Error("injected project index rename failure");
+      }
+      return originalRename(source, target);
+    }) as typeof fs.renameSync;
+    console.error = (...values: unknown[]) => { diagnostics.push(values.map(String).join(" ")); };
+    const tempFiles = () => fs.readdirSync(process.env.LLV_STATE_DIR!)
+      .filter((name) => name.startsWith(".project-catalog.json.") && name.endsWith(".tmp"));
+    const attempt = async (mode: "write" | "rename", filename: string, cwd: string, mtime: number) => {
+      const transcript = path.join(roots["codex-sessions"], filename);
+      await writeFixture(transcript, JSON.stringify({ type: "session_meta", payload: { cwd } }) + "\n", mtime);
+      failure = mode;
+      const result = await discoverFilesWithProjectCatalog(roots, undefined, { persist: false, persistIndex: true });
+      expect(result.files.some((entry) => entry.path === transcript)).toBe(true);
+    };
+
+    try {
+      await attempt("write", "write-failed.jsonl", "/repo/write-failed", 1_700_000_001);
+      expect(await readFile(indexPath, "utf8")).toBe(canonical);
+      expect(tempFiles()).toEqual([]);
+
+      await attempt("rename", "rename-failed.jsonl", "/repo/rename-failed", 1_700_000_002);
+      expect(await readFile(indexPath, "utf8")).toBe(canonical);
+      expect(tempFiles()).toEqual([]);
+      expect(diagnostics).toEqual([
+        expect.stringContaining("project catalog index publication failed"),
+      ]);
+    } finally {
+      fs.writeFileSync = originalWrite;
+      fs.renameSync = originalRename;
+      console.error = originalError;
+    }
+
+    const recovered = await discoverFilesWithProjectCatalog(roots, undefined, { persist: false, persistIndex: true });
+    expect(recovered.files).toHaveLength(3);
+    const persisted = JSON.parse(await readFile(indexPath, "utf8"));
+    expect(Object.keys(persisted.files).sort()).toEqual([
+      canonicalTranscript,
+      path.join(roots["codex-sessions"], "rename-failed.jsonl"),
+      path.join(roots["codex-sessions"], "write-failed.jsonl"),
+    ].sort());
+    expect(tempFiles()).toEqual([]);
   } finally {
     if (previousStateDir === undefined) delete process.env.LLV_STATE_DIR;
     else process.env.LLV_STATE_DIR = previousStateDir;

--- a/src/lib/scanner/discover.ts
+++ b/src/lib/scanner/discover.ts
@@ -8,7 +8,7 @@ import { sessionProjectProjection } from "../session/titleProjection";
 import { codexThreadIdFromPath, nativeCodexParentThreadId } from "./codexNative";
 import { describe } from "./describe";
 import type { ConversationCatalogEntry } from "./conversationCatalog";
-import { beginProjectCatalogScan, projectCatalogSnapshotFromRaw } from "./projectCatalog";
+import { beginProjectCatalogScan, projectCatalogSnapshotFromRaw, type ParsedFileSummary } from "./projectCatalog";
 import { projectResolutionStateKey } from "./projectState";
 import { EXTS, ROOTS, scanRootEntries } from "./roots";
 import { selectSchemeWindow } from "./schemeWindow";
@@ -160,7 +160,13 @@ async function canonicalProjectCatalog(
   };
 }
 
-async function entriesFromRaw(raw: RawEntry[], projectByPath?: ReadonlyMap<string, string>, demoted?: ReadonlySet<string>, pin?: ReadonlySet<string>): Promise<FileEntry[]> {
+async function entriesFromRaw(
+  raw: RawEntry[],
+  projectByPath?: ReadonlyMap<string, string>,
+  demoted?: ReadonlySet<string>,
+  pin?: ReadonlySet<string>,
+  summaryByPath?: ReadonlyMap<string, ParsedFileSummary>,
+): Promise<{ files: FileEntry[]; pinOverlayPaths?: string[] }> {
   const stateKey = projectResolutionStateKey();
   raw.sort((a, b) => b.st.mtimeMs - a.st.mtimeMs);
   const rawByCodexThread = new Map<string, RawEntry>();
@@ -178,7 +184,20 @@ async function entriesFromRaw(raw: RawEntry[], projectByPath?: ReadonlyMap<strin
     : raw;
   const selected = cappedEntries(ranked, projectByPath ?? new Map());
   const selectedPaths = new Set(selected.map((entry) => entry.path));
+  const globalPaths = pin?.size ? new Set(selectedPaths) : undefined;
   const rawByPath = pin?.size ? new Map(raw.map((entry) => [entry.path, entry] as const)) : null;
+  const includeNativeParents = async (entries: RawEntry[], paths: Set<string>) => {
+    await forEachCooperatively(entries, (entry) => {
+      if (entry.rootName !== "codex-sessions" || !entry.path.endsWith(".jsonl")) return;
+      const parentThreadId = nativeCodexParentThreadId(entry.path, entry.st.size);
+      const parent = parentThreadId ? rawByCodexThread.get(parentThreadId) : undefined;
+      if (parent && !paths.has(parent.path)) {
+        paths.add(parent.path);
+        entries.push(parent);
+      }
+    });
+  };
+  if (globalPaths) await includeNativeParents([...selected], globalPaths);
   /* Deep-link targets ride along even when demotion or the cap excluded
      them: the client needs the requested entry and its current generation in
      one payload to resolve the conversation id and redirect the link. */
@@ -190,17 +209,9 @@ async function entriesFromRaw(raw: RawEntry[], projectByPath?: ReadonlyMap<strin
       selected.push(pinned);
     }
   }
-  await forEachCooperatively(selected, (entry) => {
-    if (entry.rootName !== "codex-sessions" || !entry.path.endsWith(".jsonl")) return;
-    const parentThreadId = nativeCodexParentThreadId(entry.path, entry.st.size);
-    const parent = parentThreadId ? rawByCodexThread.get(parentThreadId) : undefined;
-    if (parent && !selectedPaths.has(parent.path)) {
-      selectedPaths.add(parent.path);
-      selected.push(parent);
-    }
-  });
-  return mapCooperatively(selected, (entry) => {
-    const meta = describe(entry.rootName, entry.root, entry.path, entry.st, stateKey);
+  await includeNativeParents(selected, selectedPaths);
+  const files = await mapCooperatively<RawEntry, FileEntry>(selected, (entry) => {
+    const meta = summaryByPath?.get(entry.path) ?? describe(entry.rootName, entry.root, entry.path, entry.st, stateKey);
     return {
       path: entry.path,
       root: entry.rootName,
@@ -224,21 +235,27 @@ async function entriesFromRaw(raw: RawEntry[], projectByPath?: ReadonlyMap<strin
       waitingInput: null,
     };
   });
+  const pinOverlayPaths = globalPaths
+    ? selected.filter((entry) => !globalPaths.has(entry.path)).map((entry) => entry.path)
+    : [];
+  return { files, ...(pinOverlayPaths.length ? { pinOverlayPaths } : {}) };
 }
 
 export async function discoverFilesWithProjectCatalog(
   roots: Roots | RootEntries = scanRootEntries(),
   _selectedProject?: string,
-  options: { persist?: boolean; demote?: ReadonlySet<string>; pin?: ReadonlySet<string> } = {},
+  options: { persist?: boolean; persistIndex?: boolean; demote?: ReadonlySet<string>; pin?: ReadonlySet<string> } = {},
 ): Promise<{
   files: FileEntry[];
   projectCatalog: ProjectCatalogEntry[];
+  pinOverlayPaths?: string[];
 }> {
-  const scanToken = beginProjectCatalogScan(options.persist !== false);
+  const scanToken = beginProjectCatalogScan(options.persist !== false || options.persistIndex === true);
   const limit = createLimiter(48);
   const raw = await discoverRaw(roots, limit);
   const snapshot = await projectCatalogSnapshotFromRaw(raw, {
     persist: options.persist,
+    persistIndex: options.persistIndex,
     excludedSummaryPaths: options.demote,
     scanToken,
   });
@@ -248,7 +265,8 @@ export async function discoverFilesWithProjectCatalog(
     options.demote,
     snapshot.projectCatalog,
   );
-  return { files: await entriesFromRaw(raw, projectByPath, options.demote, options.pin), projectCatalog };
+  const entries = await entriesFromRaw(raw, projectByPath, options.demote, options.pin, snapshot.summaryByPath);
+  return { ...entries, projectCatalog };
 }
 
 export async function discoverFiles(
@@ -266,7 +284,7 @@ export async function discoverFiles(
     undefined,
     snapshot.projectCatalog,
   );
-  return entriesFromRaw(raw, projectByPath, demote, pin);
+  return (await entriesFromRaw(raw, projectByPath, demote, pin, snapshot.summaryByPath)).files;
 }
 
 /** Cold-start fallback for the list/search route. It builds only lightweight

--- a/src/lib/scanner/discover.ts
+++ b/src/lib/scanner/discover.ts
@@ -31,6 +31,24 @@ export interface RawEntry {
 type Roots = Record<RootKey, string>;
 type RootEntries = [RootKey, string][];
 type Limit = <T>(work: () => Promise<T>) => Promise<T>;
+type Discovery = { raw: RawEntry[]; complete: boolean };
+const DISCOVERY_DIAGNOSTIC_MS = 60_000;
+let lastDiscoveryDiagnosticAt = Number.NEGATIVE_INFINITY;
+
+function isMissing(error: unknown): boolean {
+  return typeof error === "object" && error !== null && "code" in error && error.code === "ENOENT";
+}
+
+function discoveryFailure(operation: string, target: string, error: unknown): boolean {
+  if (isMissing(error)) return true;
+  const now = Date.now();
+  if (now - lastDiscoveryDiagnosticAt >= DISCOVERY_DIAGNOSTIC_MS) {
+    lastDiscoveryDiagnosticAt = now;
+    const detail = error instanceof Error ? `${error.message}${"code" in error && error.code ? ` (${String(error.code)})` : ""}` : String(error);
+    console.error(`[scanner discovery] ${operation} failed for ${target}: ${detail}; retaining the last completed scan`);
+  }
+  return false;
+}
 
 function createLimiter(max: number): Limit {
   let active = 0;
@@ -47,51 +65,51 @@ function createLimiter(max: number): Limit {
   };
 }
 
-async function walk(rootName: RootKey, roots: Roots, root: string, dir: string, limit: Limit): Promise<RawEntry[]> {
+async function walk(rootName: RootKey, roots: Roots, root: string, dir: string, limit: Limit): Promise<Discovery> {
   let entries: fs.Dirent[];
   try {
     entries = await limit(() => readdir(dir, { withFileTypes: true }));
-  } catch {
-    return [];
+  } catch (error) {
+    return { raw: [], complete: discoveryFailure("read directory", dir, error) };
   }
-  const chunks = await Promise.all(entries.map(async (entry): Promise<RawEntry[]> => {
+  const chunks = await Promise.all(entries.map(async (entry): Promise<Discovery> => {
     if (entry.isDirectory()) {
-      if (entry.name.startsWith(".git")) return [];
+      if (entry.name.startsWith(".git")) return { raw: [], complete: true };
       return walk(rootName, roots, root, path.join(dir, entry.name), limit);
     }
-    if (!entry.isFile() || !EXTS.some((ext) => entry.name.endsWith(ext))) return [];
+    if (!entry.isFile() || !EXTS.some((ext) => entry.name.endsWith(ext))) return { raw: [], complete: true };
     const pathname = path.join(dir, entry.name);
-    if (rootName === "claude-projects" && pathname.includes(path.sep + "tool-results" + path.sep)) return [];
+    if (rootName === "claude-projects" && pathname.includes(path.sep + "tool-results" + path.sep)) return { raw: [], complete: true };
     let st: fs.Stats;
     try {
       st = await limit(() => stat(pathname));
-    } catch {
-      return [];
+    } catch (error) {
+      return { raw: [], complete: discoveryFailure("stat file", pathname, error) };
     }
     const isTask = rootName === "claude-tasks" ? taskParts(roots["claude-tasks"], pathname) : null;
-    if (rootName === "claude-tasks" && !isTask) return [];
-    if (st.size === 0 && !isTask) return [];
+    if (rootName === "claude-tasks" && !isTask) return { raw: [], complete: true };
+    if (st.size === 0 && !isTask) return { raw: [], complete: true };
     if (isTask) {
       const [slug, sid, tid] = isTask;
       const twin = path.join(roots["claude-projects"], slug, sid, "subagents", "agent-" + tid + ".jsonl");
       try {
         await limit(() => access(twin));
-        return [];
+        return { raw: [], complete: true };
       } catch {
         /* no mirrored subagent */
       }
     }
-    return [{ rootName, root, path: pathname, st }];
+    return { raw: [{ rootName, root, path: pathname, st }], complete: true };
   }));
-  return chunks.flat();
+  return { raw: chunks.flatMap((chunk) => chunk.raw), complete: chunks.every((chunk) => chunk.complete) };
 }
 
-async function rootExists(root: string, limit: Limit): Promise<boolean> {
+async function rootExists(root: string, limit: Limit): Promise<{ exists: boolean; complete: boolean }> {
   try {
     await limit(() => access(root));
-    return true;
-  } catch {
-    return false;
+    return { exists: true, complete: true };
+  } catch (error) {
+    return { exists: false, complete: discoveryFailure("access root", root, error) };
   }
 }
 
@@ -99,12 +117,14 @@ function rootEntries(roots: Roots | RootEntries): RootEntries {
   return Array.isArray(roots) ? roots : Object.entries(roots) as RootEntries;
 }
 
-async function discoverRaw(roots: Roots | RootEntries, limit: Limit): Promise<RawEntry[]> {
+async function discoverRaw(roots: Roots | RootEntries, limit: Limit): Promise<Discovery> {
   const staticRoots = Array.isArray(roots) ? ROOTS : roots;
-  const raw = (await Promise.all(rootEntries(roots).map(async ([rootName, root]) => {
-    if (!(await rootExists(root, limit))) return [];
+  const walked = await Promise.all(rootEntries(roots).map(async ([rootName, root]) => {
+    const status = await rootExists(root, limit);
+    if (!status.exists) return { raw: [], complete: status.complete };
     return walk(rootName, staticRoots, root, root, limit);
-  }))).flat();
+  }));
+  const raw = walked.flatMap((result) => result.raw);
   /* Codex account roots follow the legacy root in registry order. A copied
      rollout therefore resolves to its managed-account copy before ranking. */
   const codexRollouts = new Map<string, RawEntry>();
@@ -121,7 +141,7 @@ async function discoverRaw(roots: Roots | RootEntries, limit: Limit): Promise<Ra
       deduplicated.push(entry);
     }
   });
-  return deduplicated;
+  return { raw: deduplicated, complete: walked.every((result) => result.complete) };
 }
 
 function cappedEntries(ranked: RawEntry[], projectByPath: ReadonlyMap<string, string>): RawEntry[] {
@@ -249,15 +269,17 @@ export async function discoverFilesWithProjectCatalog(
   files: FileEntry[];
   projectCatalog: ProjectCatalogEntry[];
   pinOverlayPaths?: string[];
+  complete: boolean;
 }> {
   const scanToken = beginProjectCatalogScan(options.persist !== false || options.persistIndex === true);
   const limit = createLimiter(48);
-  const raw = await discoverRaw(roots, limit);
-  const snapshot = await projectCatalogSnapshotFromRaw(raw, {
+  const discovery = await discoverRaw(roots, limit);
+  const snapshot = await projectCatalogSnapshotFromRaw(discovery.raw, {
     persist: options.persist,
     persistIndex: options.persistIndex,
     excludedSummaryPaths: options.demote,
     scanToken,
+    complete: discovery.complete,
   });
   const { projectCatalog, projectByPath } = await canonicalProjectCatalog(
     snapshot.projectByPath,
@@ -265,8 +287,8 @@ export async function discoverFilesWithProjectCatalog(
     options.demote,
     snapshot.projectCatalog,
   );
-  const entries = await entriesFromRaw(raw, projectByPath, options.demote, options.pin, snapshot.summaryByPath);
-  return { ...entries, projectCatalog };
+  const entries = await entriesFromRaw(discovery.raw, projectByPath, options.demote, options.pin, snapshot.summaryByPath);
+  return { ...entries, projectCatalog, complete: discovery.complete };
 }
 
 export async function discoverFiles(
@@ -276,21 +298,21 @@ export async function discoverFiles(
 ): Promise<FileEntry[]> {
   const scanToken = beginProjectCatalogScan(false);
   const limit = createLimiter(48);
-  const raw = await discoverRaw(roots, limit);
-  const snapshot = await projectCatalogSnapshotFromRaw(raw, { persist: false, scanToken });
+  const discovery = await discoverRaw(roots, limit);
+  const snapshot = await projectCatalogSnapshotFromRaw(discovery.raw, { persist: false, scanToken, complete: discovery.complete });
   const { projectByPath } = await canonicalProjectCatalog(
     snapshot.projectByPath,
     snapshot.conversationCatalog,
     undefined,
     snapshot.projectCatalog,
   );
-  return (await entriesFromRaw(raw, projectByPath, demote, pin, snapshot.summaryByPath)).files;
+  return (await entriesFromRaw(discovery.raw, projectByPath, demote, pin, snapshot.summaryByPath)).files;
 }
 
 /** Cold-start fallback for the list/search route. It builds only lightweight
  * catalog metadata and leaves the scheme processing pipeline untouched. */
 export async function refreshConversationCatalog(roots: Roots | RootEntries = scanRootEntries()): Promise<void> {
   const scanToken = beginProjectCatalogScan(false);
-  const raw = await discoverRaw(roots, createLimiter(48));
-  await projectCatalogSnapshotFromRaw(raw, { persist: false, scanToken });
+  const discovery = await discoverRaw(roots, createLimiter(48));
+  await projectCatalogSnapshotFromRaw(discovery.raw, { persist: false, scanToken, complete: discovery.complete });
 }

--- a/src/lib/scanner/discover.ts
+++ b/src/lib/scanner/discover.ts
@@ -288,7 +288,7 @@ export async function discoverFilesWithProjectCatalog(
     snapshot.projectCatalog,
   );
   const entries = await entriesFromRaw(discovery.raw, projectByPath, options.demote, options.pin, snapshot.summaryByPath);
-  return { ...entries, projectCatalog, complete: discovery.complete };
+  return { ...entries, projectCatalog, complete: snapshot.complete };
 }
 
 export async function discoverFiles(

--- a/src/lib/scanner/discover.ts
+++ b/src/lib/scanner/discover.ts
@@ -1,5 +1,5 @@
 import fs from "node:fs";
-import { access, readdir, stat } from "node:fs/promises";
+import { readdir, stat } from "node:fs/promises";
 import path from "node:path";
 
 import type { FileEntry, ProjectCatalogEntry, RootKey } from "../types";
@@ -93,10 +93,12 @@ async function walk(rootName: RootKey, roots: Roots, root: string, dir: string, 
       const [slug, sid, tid] = isTask;
       const twin = path.join(roots["claude-projects"], slug, sid, "subagents", "agent-" + tid + ".jsonl");
       try {
-        await limit(() => access(twin));
+        await limit(() => fs.promises.access(twin));
         return { raw: [], complete: true };
-      } catch {
-        /* no mirrored subagent */
+      } catch (error) {
+        if (!isMissing(error)) {
+          return { raw: [], complete: discoveryFailure("access task-output twin", twin, error) };
+        }
       }
     }
     return { raw: [{ rootName, root, path: pathname, st }], complete: true };
@@ -106,7 +108,7 @@ async function walk(rootName: RootKey, roots: Roots, root: string, dir: string, 
 
 async function rootExists(root: string, limit: Limit): Promise<{ exists: boolean; complete: boolean }> {
   try {
-    await limit(() => access(root));
+    await limit(() => fs.promises.access(root));
     return { exists: true, complete: true };
   } catch (error) {
     return { exists: false, complete: discoveryFailure("access root", root, error) };

--- a/src/lib/scanner/index.ts
+++ b/src/lib/scanner/index.ts
@@ -72,6 +72,9 @@ async function forEachEntryBatchYielding(
 
 export interface FileScanOptions {
   persist?: boolean;
+  /** Persist parsed per-file summaries while keeping controller mutations out
+      of request-owned scans. */
+  persistIndex?: boolean;
   /** Deep-link target that must survive the recency cap: a transcript path,
       or a `conversation_*` id resolved to its current generation path. */
   pin?: string;
@@ -166,7 +169,7 @@ export async function listFiles(options: FileScanOptions = {}): Promise<FileEntr
   return (await listFilesInternal(false, undefined, options)).files;
 }
 
-export async function listFilesWithProjectCatalog(selectedProject?: string, options: FileScanOptions = {}): Promise<{ files: FileEntry[]; projectCatalog: ProjectCatalogEntry[] }> {
+export async function listFilesWithProjectCatalog(selectedProject?: string, options: FileScanOptions = {}): Promise<{ files: FileEntry[]; projectCatalog: ProjectCatalogEntry[]; pinOverlayPaths?: string[] }> {
   return listFilesInternal(true, selectedProject, options);
 }
 
@@ -183,13 +186,13 @@ async function listFilesInternal(
   includeProjectCatalog: boolean,
   selectedProject?: string,
   options: FileScanOptions = {},
-): Promise<{ files: FileEntry[]; projectCatalog: ProjectCatalogEntry[] }> {
+): Promise<{ files: FileEntry[]; projectCatalog: ProjectCatalogEntry[]; pinOverlayPaths?: string[] }> {
   const persist = options.persist === true;
   const demote = archivedTranscriptPaths();
   const requestedPins = options.pins ? [...options.pins, ...(options.pin ? [options.pin] : [])] : options.pin;
   const pin = pinnedPathsFor(requestedPins);
   const scan = includeProjectCatalog
-    ? await discoverFilesWithProjectCatalog(undefined, selectedProject, { persist, demote, pin })
+    ? await discoverFilesWithProjectCatalog(undefined, selectedProject, { persist, persistIndex: options.persistIndex, demote, pin })
     : { files: await discoverFiles(undefined, demote, pin), projectCatalog: [] };
   const entries = scan.files;
   // The /proc fd scan is only needed to attribute background-task outputs to a
@@ -234,7 +237,8 @@ async function listFilesInternal(
     entry.pendingWakeup = pendingWakeupFor(entry);
   });
   await linkEntries(entries, { persist });
-  return { files: entries, projectCatalog: scan.projectCatalog };
+  const pinOverlayPaths = "pinOverlayPaths" in scan ? scan.pinOverlayPaths : undefined;
+  return { files: entries, projectCatalog: scan.projectCatalog, ...(pinOverlayPaths?.length ? { pinOverlayPaths } : {}) };
 }
 
 /** Durable controllers run outside request handlers. Flow ordering remains

--- a/src/lib/scanner/index.ts
+++ b/src/lib/scanner/index.ts
@@ -83,6 +83,13 @@ export interface FileScanOptions {
   pins?: readonly string[];
 }
 
+export interface FileCatalogScan {
+  files: FileEntry[];
+  projectCatalog: ProjectCatalogEntry[];
+  pinOverlayPaths?: string[];
+  complete: boolean;
+}
+
 /** Transcript paths a pin value requires in the feed. A conversation id is
     canonicalized through the registry's durable aliases and maps to its
     latest generation. A plain path also brings the registry-current
@@ -169,7 +176,7 @@ export async function listFiles(options: FileScanOptions = {}): Promise<FileEntr
   return (await listFilesInternal(false, undefined, options)).files;
 }
 
-export async function listFilesWithProjectCatalog(selectedProject?: string, options: FileScanOptions = {}): Promise<{ files: FileEntry[]; projectCatalog: ProjectCatalogEntry[]; pinOverlayPaths?: string[]; complete?: boolean }> {
+export async function listFilesWithProjectCatalog(selectedProject?: string, options: FileScanOptions = {}): Promise<FileCatalogScan> {
   return listFilesInternal(true, selectedProject, options);
 }
 
@@ -186,14 +193,14 @@ async function listFilesInternal(
   includeProjectCatalog: boolean,
   selectedProject?: string,
   options: FileScanOptions = {},
-): Promise<{ files: FileEntry[]; projectCatalog: ProjectCatalogEntry[]; pinOverlayPaths?: string[]; complete?: boolean }> {
+): Promise<FileCatalogScan> {
   const persist = options.persist === true;
   const demote = archivedTranscriptPaths();
   const requestedPins = options.pins ? [...options.pins, ...(options.pin ? [options.pin] : [])] : options.pin;
   const pin = pinnedPathsFor(requestedPins);
   const scan = includeProjectCatalog
     ? await discoverFilesWithProjectCatalog(undefined, selectedProject, { persist, persistIndex: options.persistIndex, demote, pin })
-    : { files: await discoverFiles(undefined, demote, pin), projectCatalog: [] };
+    : { files: await discoverFiles(undefined, demote, pin), projectCatalog: [], complete: true };
   const entries = scan.files;
   // The /proc fd scan is only needed to attribute background-task outputs to a
   // live pid. When the shortlist has no such entries, skip the scan entirely;
@@ -238,7 +245,12 @@ async function listFilesInternal(
   });
   await linkEntries(entries, { persist });
   const pinOverlayPaths = "pinOverlayPaths" in scan ? scan.pinOverlayPaths : undefined;
-  return { files: entries, projectCatalog: scan.projectCatalog, ...(pinOverlayPaths?.length ? { pinOverlayPaths } : {}) };
+  return {
+    files: entries,
+    projectCatalog: scan.projectCatalog,
+    ...(pinOverlayPaths?.length ? { pinOverlayPaths } : {}),
+    complete: scan.complete,
+  };
 }
 
 /** Durable controllers run outside request handlers. Flow ordering remains

--- a/src/lib/scanner/index.ts
+++ b/src/lib/scanner/index.ts
@@ -169,7 +169,7 @@ export async function listFiles(options: FileScanOptions = {}): Promise<FileEntr
   return (await listFilesInternal(false, undefined, options)).files;
 }
 
-export async function listFilesWithProjectCatalog(selectedProject?: string, options: FileScanOptions = {}): Promise<{ files: FileEntry[]; projectCatalog: ProjectCatalogEntry[]; pinOverlayPaths?: string[] }> {
+export async function listFilesWithProjectCatalog(selectedProject?: string, options: FileScanOptions = {}): Promise<{ files: FileEntry[]; projectCatalog: ProjectCatalogEntry[]; pinOverlayPaths?: string[]; complete?: boolean }> {
   return listFilesInternal(true, selectedProject, options);
 }
 
@@ -186,7 +186,7 @@ async function listFilesInternal(
   includeProjectCatalog: boolean,
   selectedProject?: string,
   options: FileScanOptions = {},
-): Promise<{ files: FileEntry[]; projectCatalog: ProjectCatalogEntry[]; pinOverlayPaths?: string[] }> {
+): Promise<{ files: FileEntry[]; projectCatalog: ProjectCatalogEntry[]; pinOverlayPaths?: string[]; complete?: boolean }> {
   const persist = options.persist === true;
   const demote = archivedTranscriptPaths();
   const requestedPins = options.pins ? [...options.pins, ...(options.pin ? [options.pin] : [])] : options.pin;

--- a/src/lib/scanner/json.ts
+++ b/src/lib/scanner/json.ts
@@ -2,17 +2,20 @@ import fs from "node:fs";
 
 import { globalCache } from "./caches";
 
-const jsonCache = globalCache<[number, Record<string, unknown> | null]>("json");
+const jsonCache = globalCache<[number, number, Record<string, unknown> | null]>("json-v2");
 
 export function readJson(pathname: string): Record<string, unknown> | null {
   let mtime: number;
+  let size: number;
   try {
-    mtime = fs.statSync(pathname).mtimeMs;
+    const st = fs.statSync(pathname);
+    mtime = st.mtimeMs;
+    size = st.size;
   } catch {
     return null;
   }
   const cached = jsonCache.get(pathname);
-  if (cached?.[0] === mtime) return cached[1];
+  if (cached?.[0] === size && cached[1] === mtime) return cached[2];
   let obj: unknown = null;
   try {
     obj = JSON.parse(fs.readFileSync(pathname, "utf8"));
@@ -23,7 +26,7 @@ export function readJson(pathname: string): Record<string, unknown> | null {
     obj && typeof obj === "object" && !Array.isArray(obj)
       ? (obj as Record<string, unknown>)
       : null;
-  jsonCache.set(pathname, [mtime, val]);
+  jsonCache.set(pathname, [size, mtime, val]);
   return val;
 }
 

--- a/src/lib/scanner/json.ts
+++ b/src/lib/scanner/json.ts
@@ -2,32 +2,41 @@ import fs from "node:fs";
 
 import { globalCache } from "./caches";
 
-const jsonCache = globalCache<[number, number, Record<string, unknown> | null]>("json-v2");
+const jsonCache = globalCache<[number, number, Record<string, unknown> | null]>("json-v3");
 
-export function readJson(pathname: string): Record<string, unknown> | null {
+export interface JsonReadResult {
+  value: Record<string, unknown> | null;
+  complete: boolean;
+}
+
+export function readJsonResult(pathname: string): JsonReadResult {
   let mtime: number;
   let size: number;
   try {
     const st = fs.statSync(pathname);
     mtime = st.mtimeMs;
     size = st.size;
-  } catch {
-    return null;
+  } catch (error) {
+    return { value: null, complete: (error as NodeJS.ErrnoException).code === "ENOENT" };
   }
   const cached = jsonCache.get(pathname);
-  if (cached?.[0] === size && cached[1] === mtime) return cached[2];
-  let obj: unknown = null;
+  if (cached?.[0] === size && cached[1] === mtime) return { value: cached[2], complete: true };
+  let obj: unknown;
   try {
     obj = JSON.parse(fs.readFileSync(pathname, "utf8"));
   } catch {
-    obj = null;
+    return { value: null, complete: false };
   }
   const val =
     obj && typeof obj === "object" && !Array.isArray(obj)
       ? (obj as Record<string, unknown>)
       : null;
   jsonCache.set(pathname, [size, mtime, val]);
-  return val;
+  return { value: val, complete: true };
+}
+
+export function readJson(pathname: string): Record<string, unknown> | null {
+  return readJsonResult(pathname).value;
 }
 
 export function stringValue(value: unknown): string | null {

--- a/src/lib/scanner/projectCatalog.ts
+++ b/src/lib/scanner/projectCatalog.ts
@@ -9,7 +9,7 @@ import { forEachCooperatively, mapCooperatively } from "@/lib/cooperative";
 import type { ProjectCatalogEntry } from "../types";
 import { replaceConversationCatalog, type ConversationCatalogEntry } from "./conversationCatalog";
 import {
-  describe,
+  describeFile,
   fileDescriptionIdentity,
   type FileDescription,
 } from "./describe";
@@ -18,6 +18,7 @@ import { PROJECT_RESOLUTION_VERSION, projectResolutionStateKey } from "./project
 
 type CachedProjectFile = {
   summaryVersion?: 2;
+  summaryIncomplete?: true;
   rootName: RawEntry["rootName"];
   size: number;
   mtimeMs: number;
@@ -115,6 +116,7 @@ function readState(): ProjectCatalogState {
         && sidecarMtimeMs !== undefined;
       files[pathname] = {
         summaryVersion: summaryComplete ? 2 : undefined,
+        summaryIncomplete: !summaryComplete && file.summaryIncomplete === true ? true : undefined,
         rootName: file.rootName,
         size: file.size,
         mtimeMs: file.mtimeMs,
@@ -191,6 +193,7 @@ function cachedFile(raw: RawEntry, state: ProjectCatalogState, stateKey: string)
   const identity = fileDescriptionIdentity(raw.rootName, raw.path, raw.st);
   if (
     state.resolutionVersion === PROJECT_RESOLUTION_VERSION &&
+    identity.complete &&
     cached &&
     cached.size === raw.st.size &&
     cached.mtimeMs === raw.st.mtimeMs &&
@@ -202,14 +205,21 @@ function cachedFile(raw: RawEntry, state: ProjectCatalogState, stateKey: string)
     cached.projectRoot !== undefined
   ) {
     if (cached.summaryVersion !== 2) {
-      const meta = describe(raw.rootName, raw.root, raw.path, raw.st, stateKey, identity);
+      const described = describeFile(raw.rootName, raw.root, raw.path, raw.st, stateKey, identity);
+      const meta = described.description;
+      const refreshProjectMetadata = cached.summaryIncomplete === true;
       return {
         ...cached,
-        summaryVersion: 2,
+        summaryVersion: described.complete ? 2 : undefined,
+        summaryIncomplete: refreshProjectMetadata && !described.complete ? true : undefined,
         sidecarSize: identity.sidecarSize,
         sidecarMtimeMs: identity.sidecarMtimeMs,
         path: raw.path,
-        session: isConversation(raw.rootName, cached.kind),
+        project: refreshProjectMetadata ? meta.project || "other" : cached.project,
+        projectRoot: refreshProjectMetadata ? meta.projectRoot ?? null : cached.projectRoot,
+        kind: refreshProjectMetadata ? meta.kind : cached.kind,
+        session: isConversation(raw.rootName, refreshProjectMetadata ? meta.kind : cached.kind),
+        worktree: refreshProjectMetadata ? meta.worktree : cached.worktree,
         cwd: meta.cwd,
         title: meta.title,
         titleCached: true,
@@ -228,9 +238,11 @@ function cachedFile(raw: RawEntry, state: ProjectCatalogState, stateKey: string)
       fmt: cached.fmt ?? fmtForRoot(raw.rootName),
     };
   }
-  const meta = describe(raw.rootName, raw.root, raw.path, raw.st, stateKey, identity);
+  const described = describeFile(raw.rootName, raw.root, raw.path, raw.st, stateKey, identity);
+  const meta = described.description;
   const file: ProjectCatalogFile = {
-    summaryVersion: 2,
+    summaryVersion: described.complete ? 2 : undefined,
+    summaryIncomplete: described.complete ? undefined : true,
     path: raw.path,
     rootName: raw.rootName,
     size: raw.st.size,
@@ -250,7 +262,8 @@ function cachedFile(raw: RawEntry, state: ProjectCatalogState, stateKey: string)
     fmt: meta.fmt,
   };
   state.files[raw.path] = {
-    summaryVersion: 2,
+    summaryVersion: file.summaryVersion,
+    summaryIncomplete: file.summaryIncomplete,
     rootName: file.rootName,
     size: file.size,
     mtimeMs: file.mtimeMs,
@@ -338,7 +351,8 @@ export async function projectCatalogSnapshotFromRaw(raw: RawEntry[], options: {
   const changes = new Map<string, Set<string>>();
   await forEachCooperatively(files, (file) => {
     nextFiles[file.path] = {
-      summaryVersion: 2,
+      summaryVersion: file.summaryVersion,
+      summaryIncomplete: file.summaryIncomplete,
       rootName: file.rootName,
       size: file.size,
       mtimeMs: file.mtimeMs,

--- a/src/lib/scanner/projectCatalog.ts
+++ b/src/lib/scanner/projectCatalog.ts
@@ -140,15 +140,30 @@ function readState(): ProjectCatalogState {
   }
 }
 
+function persistenceDiagnostic(operation: string, target: string, error: unknown): void {
+  const now = Date.now();
+  if (now - lastCatalogPersistenceDiagnosticAt < CATALOG_PERSISTENCE_DIAGNOSTIC_MS) return;
+  lastCatalogPersistenceDiagnosticAt = now;
+  const detail = error instanceof Error ? `${error.message}${"code" in error && error.code ? ` (${String(error.code)})` : ""}` : String(error);
+  console.error(`[project catalog] ${operation} failed for ${target}: ${detail}; a later scan will retry`);
+}
+
 function writeState(state: ProjectCatalogState): void {
   let temporary: string | undefined;
+  let operation = "create state directory";
+  let target = catalogPath();
   try {
     const filePath = catalogPath();
+    target = filePath;
     fs.mkdirSync(path.dirname(filePath), { recursive: true });
     temporary = path.join(path.dirname(filePath), `.${path.basename(filePath)}.${process.pid}.${crypto.randomUUID()}.tmp`);
+    operation = "write temporary index";
+    target = temporary;
     fs.writeFileSync(temporary, JSON.stringify(state) + "\n", "utf8");
+    operation = "rename temporary index";
+    target = filePath;
     fs.renameSync(temporary, filePath);
-  } catch {
+  } catch (error) {
     if (temporary !== undefined) {
       try {
         fs.unlinkSync(temporary);
@@ -156,11 +171,7 @@ function writeState(state: ProjectCatalogState): void {
         // The write may have failed before the temp file was created.
       }
     }
-    const now = Date.now();
-    if (now - lastCatalogPersistenceDiagnosticAt >= CATALOG_PERSISTENCE_DIAGNOSTIC_MS) {
-      lastCatalogPersistenceDiagnosticAt = now;
-      console.error("[project catalog] project catalog index publication failed; a later scan will retry");
-    }
+    persistenceDiagnostic(operation, target, error);
   }
 }
 
@@ -318,6 +329,7 @@ export async function projectCatalogSnapshotFromRaw(raw: RawEntry[], options: {
   persistIndex?: boolean;
   excludedSummaryPaths?: ReadonlySet<string>;
   scanToken?: ProjectCatalogScanToken;
+  complete?: boolean;
 } = {}): Promise<{
   projectCatalog: ProjectCatalogEntry[];
   projectByPath: Map<string, string>;
@@ -436,8 +448,8 @@ export async function projectCatalogSnapshotFromRaw(raw: RawEntry[], options: {
   const isCurrentPublication = projectCatalogRuntime.__llvProjectCatalogPublicationGeneration === scanToken.publication;
   const isCurrentPersistence = scanToken.persistence !== null
     && projectCatalogRuntime.__llvProjectCatalogPersistenceGeneration === scanToken.persistence;
-  if (isCurrentPublication) replaceConversationCatalog(conversationCatalog);
-  if (isCurrentPersistence && persistIndex) {
+  if (isCurrentPublication && options.complete !== false) replaceConversationCatalog(conversationCatalog);
+  if (isCurrentPersistence && persistIndex && options.complete !== false) {
     let boardHealed = true;
     if (options.persist !== false) {
       try {

--- a/src/lib/scanner/projectCatalog.ts
+++ b/src/lib/scanner/projectCatalog.ts
@@ -8,15 +8,21 @@ import { forEachCooperatively, mapCooperatively } from "@/lib/cooperative";
 
 import type { ProjectCatalogEntry } from "../types";
 import { replaceConversationCatalog, type ConversationCatalogEntry } from "./conversationCatalog";
-import { describe, type FileDescription } from "./describe";
+import {
+  describe,
+  fileDescriptionIdentity,
+  type FileDescription,
+} from "./describe";
 import type { RawEntry } from "./discover";
 import { PROJECT_RESOLUTION_VERSION, projectResolutionStateKey } from "./projectState";
 
 type CachedProjectFile = {
-  summaryVersion?: 1;
+  summaryVersion?: 2;
   rootName: RawEntry["rootName"];
   size: number;
   mtimeMs: number;
+  sidecarSize?: number | null;
+  sidecarMtimeMs?: number | null;
   stateKey: string;
   project: string;
   projectRoot?: string | null;
@@ -93,17 +99,25 @@ function readState(): ProjectCatalogState {
       const engine = file.engine === "codex" || file.engine === "claude" || file.engine === "shell" ? file.engine : undefined;
       const fmt = file.fmt === "codex" || file.fmt === "claude" || file.fmt === "plain" ? file.fmt : undefined;
       const cwd = typeof file.cwd === "string" ? file.cwd : file.cwd === null ? null : undefined;
-      const summaryComplete = file.summaryVersion === 1
+      const sidecarSize = typeof file.sidecarSize === "number" ? file.sidecarSize : file.sidecarSize === null ? null : undefined;
+      const sidecarMtimeMs = typeof file.sidecarMtimeMs === "number"
+        ? file.sidecarMtimeMs
+        : file.sidecarMtimeMs === null ? null : undefined;
+      const summaryComplete = file.summaryVersion === 2
         && typeof file.title === "string"
         && engine !== undefined
         && fmt !== undefined
         && cwd !== undefined
-        && file.projectRoot !== undefined;
+        && file.projectRoot !== undefined
+        && sidecarSize !== undefined
+        && sidecarMtimeMs !== undefined;
       files[pathname] = {
-        summaryVersion: summaryComplete ? 1 : undefined,
+        summaryVersion: summaryComplete ? 2 : undefined,
         rootName: file.rootName,
         size: file.size,
         mtimeMs: file.mtimeMs,
+        sidecarSize,
+        sidecarMtimeMs,
         stateKey: file.stateKey,
         project: file.project,
         projectRoot: typeof file.projectRoot === "string" ? file.projectRoot : file.projectRoot === null ? null : undefined,
@@ -160,26 +174,33 @@ function fallbackTitle(raw: RawEntry, kind: string): string {
 
 function cachedFile(raw: RawEntry, state: ProjectCatalogState, stateKey: string): ProjectCatalogFile {
   const cached = state.files[raw.path];
+  const identity = fileDescriptionIdentity(raw.rootName, raw.path, raw.st);
   if (
     state.resolutionVersion === PROJECT_RESOLUTION_VERSION &&
     cached &&
     cached.size === raw.st.size &&
     cached.mtimeMs === raw.st.mtimeMs &&
+    (cached.summaryVersion !== 2 || (
+      cached.sidecarSize === identity.sidecarSize &&
+      cached.sidecarMtimeMs === identity.sidecarMtimeMs
+    )) &&
     cached.stateKey === stateKey &&
     cached.projectRoot !== undefined
   ) {
-    if (cached.summaryVersion !== 1) {
-      const meta = describe(raw.rootName, raw.root, raw.path, raw.st, stateKey);
+    if (cached.summaryVersion !== 2) {
+      const meta = describe(raw.rootName, raw.root, raw.path, raw.st, stateKey, identity);
       return {
         ...cached,
-        summaryVersion: 1,
+        summaryVersion: 2,
+        sidecarSize: identity.sidecarSize,
+        sidecarMtimeMs: identity.sidecarMtimeMs,
         path: raw.path,
         session: isConversation(raw.rootName, cached.kind),
         cwd: meta.cwd,
-        title: cached.title ?? meta.title,
+        title: meta.title,
         titleCached: true,
-        engine: cached.engine ?? meta.engine,
-        fmt: cached.fmt ?? meta.fmt,
+        engine: meta.engine,
+        fmt: meta.fmt,
       };
     }
     return {
@@ -193,13 +214,15 @@ function cachedFile(raw: RawEntry, state: ProjectCatalogState, stateKey: string)
       fmt: cached.fmt ?? fmtForRoot(raw.rootName),
     };
   }
-  const meta = describe(raw.rootName, raw.root, raw.path, raw.st, stateKey);
+  const meta = describe(raw.rootName, raw.root, raw.path, raw.st, stateKey, identity);
   const file: ProjectCatalogFile = {
-    summaryVersion: 1,
+    summaryVersion: 2,
     path: raw.path,
     rootName: raw.rootName,
     size: raw.st.size,
     mtimeMs: raw.st.mtimeMs,
+    sidecarSize: identity.sidecarSize,
+    sidecarMtimeMs: identity.sidecarMtimeMs,
     stateKey,
     project: meta.project || "other",
     projectRoot: meta.projectRoot ?? null,
@@ -213,10 +236,12 @@ function cachedFile(raw: RawEntry, state: ProjectCatalogState, stateKey: string)
     fmt: meta.fmt,
   };
   state.files[raw.path] = {
-    summaryVersion: 1,
+    summaryVersion: 2,
     rootName: file.rootName,
     size: file.size,
     mtimeMs: file.mtimeMs,
+    sidecarSize: file.sidecarSize,
+    sidecarMtimeMs: file.sidecarMtimeMs,
     stateKey: file.stateKey,
     project: file.project,
     projectRoot: file.projectRoot,
@@ -299,10 +324,12 @@ export async function projectCatalogSnapshotFromRaw(raw: RawEntry[], options: {
   const changes = new Map<string, Set<string>>();
   await forEachCooperatively(files, (file) => {
     nextFiles[file.path] = {
-      summaryVersion: 1,
+      summaryVersion: 2,
       rootName: file.rootName,
       size: file.size,
       mtimeMs: file.mtimeMs,
+      sidecarSize: file.sidecarSize,
+      sidecarMtimeMs: file.sidecarMtimeMs,
       stateKey: file.stateKey,
       project: file.project,
       projectRoot: file.projectRoot,

--- a/src/lib/scanner/projectCatalog.ts
+++ b/src/lib/scanner/projectCatalog.ts
@@ -155,11 +155,12 @@ function writeState(state: ProjectCatalogState): void {
   try {
     const filePath = catalogPath();
     target = filePath;
-    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    fs.mkdirSync(path.dirname(filePath), { recursive: true, mode: 0o700 });
+    fs.chmodSync(path.dirname(filePath), 0o700);
     temporary = path.join(path.dirname(filePath), `.${path.basename(filePath)}.${process.pid}.${crypto.randomUUID()}.tmp`);
     operation = "write temporary index";
     target = temporary;
-    fs.writeFileSync(temporary, JSON.stringify(state) + "\n", "utf8");
+    fs.writeFileSync(temporary, JSON.stringify(state) + "\n", { encoding: "utf8", mode: 0o600 });
     operation = "rename temporary index";
     target = filePath;
     fs.renameSync(temporary, filePath);
@@ -335,6 +336,7 @@ export async function projectCatalogSnapshotFromRaw(raw: RawEntry[], options: {
   projectByPath: Map<string, string>;
   conversationCatalog: ConversationCatalogEntry[];
   summaryByPath: Map<string, ParsedFileSummary>;
+  complete: boolean;
 }> {
   const persistIndex = options.persist !== false || options.persistIndex === true;
   const scanToken = options.scanToken ?? beginProjectCatalogScan(persistIndex);
@@ -349,6 +351,7 @@ export async function projectCatalogSnapshotFromRaw(raw: RawEntry[], options: {
     previousProjects.set(entry.path, state.files[entry.path]?.project);
   });
   const files = await mapCooperatively(raw, (entry) => cachedFile(entry, state, stateKey));
+  const complete = options.complete !== false && files.every((file) => file.summaryVersion === 2);
   const claudeSessionProjects = new Map<string, string>();
   await forEachCooperatively(raw, (entry, index) => {
     const file = files[index]!;
@@ -448,8 +451,8 @@ export async function projectCatalogSnapshotFromRaw(raw: RawEntry[], options: {
   const isCurrentPublication = projectCatalogRuntime.__llvProjectCatalogPublicationGeneration === scanToken.publication;
   const isCurrentPersistence = scanToken.persistence !== null
     && projectCatalogRuntime.__llvProjectCatalogPersistenceGeneration === scanToken.persistence;
-  if (isCurrentPublication && options.complete !== false) replaceConversationCatalog(conversationCatalog);
-  if (isCurrentPersistence && persistIndex && options.complete !== false) {
+  if (isCurrentPublication && complete) replaceConversationCatalog(conversationCatalog);
+  if (isCurrentPersistence && persistIndex && complete) {
     let boardHealed = true;
     if (options.persist !== false) {
       try {
@@ -471,6 +474,7 @@ export async function projectCatalogSnapshotFromRaw(raw: RawEntry[], options: {
     projectByPath,
     conversationCatalog,
     summaryByPath,
+    complete,
   };
 }
 

--- a/src/lib/scanner/projectCatalog.ts
+++ b/src/lib/scanner/projectCatalog.ts
@@ -8,11 +8,12 @@ import { forEachCooperatively, mapCooperatively } from "@/lib/cooperative";
 
 import type { ProjectCatalogEntry } from "../types";
 import { replaceConversationCatalog, type ConversationCatalogEntry } from "./conversationCatalog";
-import { describe } from "./describe";
+import { describe, type FileDescription } from "./describe";
 import type { RawEntry } from "./discover";
 import { PROJECT_RESOLUTION_VERSION, projectResolutionStateKey } from "./projectState";
 
 type CachedProjectFile = {
+  summaryVersion?: 1;
   rootName: RawEntry["rootName"];
   size: number;
   mtimeMs: number;
@@ -22,10 +23,13 @@ type CachedProjectFile = {
   kind: string;
   session: boolean;
   worktree?: string;
+  cwd?: string | null;
   title?: string;
   engine?: "codex" | "claude" | "shell";
   fmt?: "codex" | "claude" | "plain";
 };
+
+export type ParsedFileSummary = FileDescription;
 
 type ProjectCatalogFile = CachedProjectFile & {
   path: string;
@@ -86,7 +90,17 @@ function readState(): ProjectCatalogState {
       ) {
         continue;
       }
+      const engine = file.engine === "codex" || file.engine === "claude" || file.engine === "shell" ? file.engine : undefined;
+      const fmt = file.fmt === "codex" || file.fmt === "claude" || file.fmt === "plain" ? file.fmt : undefined;
+      const cwd = typeof file.cwd === "string" ? file.cwd : file.cwd === null ? null : undefined;
+      const summaryComplete = file.summaryVersion === 1
+        && typeof file.title === "string"
+        && engine !== undefined
+        && fmt !== undefined
+        && cwd !== undefined
+        && file.projectRoot !== undefined;
       files[pathname] = {
+        summaryVersion: summaryComplete ? 1 : undefined,
         rootName: file.rootName,
         size: file.size,
         mtimeMs: file.mtimeMs,
@@ -96,9 +110,10 @@ function readState(): ProjectCatalogState {
         kind: file.kind,
         session: isConversation(file.rootName, file.kind),
         worktree: typeof file.worktree === "string" ? file.worktree : undefined,
+        cwd,
         title: typeof file.title === "string" ? file.title : undefined,
-        engine: file.engine === "codex" || file.engine === "claude" || file.engine === "shell" ? file.engine : undefined,
-        fmt: file.fmt === "codex" || file.fmt === "claude" || file.fmt === "plain" ? file.fmt : undefined,
+        engine,
+        fmt,
       };
     }
     return { version: 2, resolutionVersion: raw.resolutionVersion ?? 0, files };
@@ -112,7 +127,7 @@ function writeState(state: ProjectCatalogState): void {
     const filePath = catalogPath();
     fs.mkdirSync(path.dirname(filePath), { recursive: true });
     const tmp = path.join(path.dirname(filePath), `.${path.basename(filePath)}.${process.pid}.${crypto.randomUUID()}.tmp`);
-    fs.writeFileSync(tmp, JSON.stringify(state, null, 2) + "\n", "utf8");
+    fs.writeFileSync(tmp, JSON.stringify(state) + "\n", "utf8");
     fs.renameSync(tmp, filePath);
   } catch {
     /* A failed catalog write only costs the next scan extra metadata reads. */
@@ -153,10 +168,25 @@ function cachedFile(raw: RawEntry, state: ProjectCatalogState, stateKey: string)
     cached.stateKey === stateKey &&
     cached.projectRoot !== undefined
   ) {
+    if (cached.summaryVersion !== 1) {
+      const meta = describe(raw.rootName, raw.root, raw.path, raw.st, stateKey);
+      return {
+        ...cached,
+        summaryVersion: 1,
+        path: raw.path,
+        session: isConversation(raw.rootName, cached.kind),
+        cwd: meta.cwd,
+        title: cached.title ?? meta.title,
+        titleCached: true,
+        engine: cached.engine ?? meta.engine,
+        fmt: cached.fmt ?? meta.fmt,
+      };
+    }
     return {
       path: raw.path,
       ...cached,
       session: isConversation(raw.rootName, cached.kind),
+      cwd: cached.cwd ?? undefined,
       title: cached.title ?? fallbackTitle(raw, cached.kind),
       titleCached: typeof cached.title === "string",
       engine: cached.engine ?? engineForRoot(raw.rootName),
@@ -165,6 +195,7 @@ function cachedFile(raw: RawEntry, state: ProjectCatalogState, stateKey: string)
   }
   const meta = describe(raw.rootName, raw.root, raw.path, raw.st, stateKey);
   const file: ProjectCatalogFile = {
+    summaryVersion: 1,
     path: raw.path,
     rootName: raw.rootName,
     size: raw.st.size,
@@ -175,12 +206,14 @@ function cachedFile(raw: RawEntry, state: ProjectCatalogState, stateKey: string)
     kind: meta.kind,
     session: isConversation(raw.rootName, meta.kind),
     worktree: meta.worktree,
+    cwd: meta.cwd,
     title: meta.title,
     titleCached: true,
     engine: meta.engine,
     fmt: meta.fmt,
   };
   state.files[raw.path] = {
+    summaryVersion: 1,
     rootName: file.rootName,
     size: file.size,
     mtimeMs: file.mtimeMs,
@@ -190,6 +223,7 @@ function cachedFile(raw: RawEntry, state: ProjectCatalogState, stateKey: string)
     kind: file.kind,
     session: file.session,
     worktree: file.worktree,
+    cwd: file.cwd ?? null,
     title: file.titleCached ? file.title : undefined,
     engine: file.engine,
     fmt: file.fmt,
@@ -229,14 +263,17 @@ function unambiguousMigrations(
 
 export async function projectCatalogSnapshotFromRaw(raw: RawEntry[], options: {
   persist?: boolean;
+  persistIndex?: boolean;
   excludedSummaryPaths?: ReadonlySet<string>;
   scanToken?: ProjectCatalogScanToken;
 } = {}): Promise<{
   projectCatalog: ProjectCatalogEntry[];
   projectByPath: Map<string, string>;
   conversationCatalog: ConversationCatalogEntry[];
+  summaryByPath: Map<string, ParsedFileSummary>;
 }> {
-  const scanToken = options.scanToken ?? beginProjectCatalogScan(options.persist !== false);
+  const persistIndex = options.persist !== false || options.persistIndex === true;
+  const scanToken = options.scanToken ?? beginProjectCatalogScan(persistIndex);
   const state = readState();
   const stateKey = projectResolutionStateKey();
   const nextFiles: Record<string, CachedProjectFile> = {};
@@ -262,6 +299,7 @@ export async function projectCatalogSnapshotFromRaw(raw: RawEntry[], options: {
   const changes = new Map<string, Set<string>>();
   await forEachCooperatively(files, (file) => {
     nextFiles[file.path] = {
+      summaryVersion: 1,
       rootName: file.rootName,
       size: file.size,
       mtimeMs: file.mtimeMs,
@@ -271,6 +309,7 @@ export async function projectCatalogSnapshotFromRaw(raw: RawEntry[], options: {
       kind: file.kind,
       session: file.session,
       worktree: file.worktree,
+      cwd: file.cwd ?? null,
       title: file.titleCached ? file.title : undefined,
       engine: file.engine,
       fmt: file.fmt,
@@ -311,7 +350,18 @@ export async function projectCatalogSnapshotFromRaw(raw: RawEntry[], options: {
     if (file?.session && group && group.conversations > 0) group.conversations -= 1;
   });
   const conversationCatalog: ConversationCatalogEntry[] = [];
+  const summaryByPath = new Map<string, ParsedFileSummary>();
   await forEachCooperatively(files, (file, index) => {
+    summaryByPath.set(file.path, {
+      project: file.project || "other",
+      worktree: file.worktree,
+      cwd: file.cwd ?? undefined,
+      projectRoot: file.projectRoot,
+      title: file.title,
+      engine: file.engine,
+      kind: file.kind,
+      fmt: file.fmt,
+    });
     if (!file.session || (file.engine !== "codex" && file.engine !== "claude")) return;
     conversationCatalog.push({
       path: file.path,
@@ -332,12 +382,14 @@ export async function projectCatalogSnapshotFromRaw(raw: RawEntry[], options: {
   const isCurrentPersistence = scanToken.persistence !== null
     && projectCatalogRuntime.__llvProjectCatalogPersistenceGeneration === scanToken.persistence;
   if (isCurrentPublication) replaceConversationCatalog(conversationCatalog);
-  if (isCurrentPersistence && options.persist !== false) {
+  if (isCurrentPersistence && persistIndex) {
     let boardHealed = true;
-    try {
-      boardHealed = migrateBoardProjects(unambiguousMigrations(changes, groups));
-    } catch {
-      boardHealed = false;
+    if (options.persist !== false) {
+      try {
+        boardHealed = migrateBoardProjects(unambiguousMigrations(changes, groups));
+      } catch {
+        boardHealed = false;
+      }
     }
     if (boardHealed) {
       writeState({ version: 2, resolutionVersion: PROJECT_RESOLUTION_VERSION, files: nextFiles });
@@ -351,6 +403,7 @@ export async function projectCatalogSnapshotFromRaw(raw: RawEntry[], options: {
       .sort((a, b) => b.smt - a.smt || a.project.localeCompare(b.project)),
     projectByPath,
     conversationCatalog,
+    summaryByPath,
   };
 }
 

--- a/src/lib/scanner/projectCatalog.ts
+++ b/src/lib/scanner/projectCatalog.ts
@@ -52,6 +52,8 @@ type ProjectCatalogState = {
 };
 
 const CATALOG_FILE = "project-catalog.json";
+const CATALOG_PERSISTENCE_DIAGNOSTIC_MS = 60_000;
+let lastCatalogPersistenceDiagnosticAt = Number.NEGATIVE_INFINITY;
 const projectCatalogRuntime = globalThis as typeof globalThis & {
   __llvProjectCatalogPublicationGeneration?: number;
   __llvProjectCatalogPersistenceGeneration?: number;
@@ -137,14 +139,26 @@ function readState(): ProjectCatalogState {
 }
 
 function writeState(state: ProjectCatalogState): void {
+  let temporary: string | undefined;
   try {
     const filePath = catalogPath();
     fs.mkdirSync(path.dirname(filePath), { recursive: true });
-    const tmp = path.join(path.dirname(filePath), `.${path.basename(filePath)}.${process.pid}.${crypto.randomUUID()}.tmp`);
-    fs.writeFileSync(tmp, JSON.stringify(state) + "\n", "utf8");
-    fs.renameSync(tmp, filePath);
+    temporary = path.join(path.dirname(filePath), `.${path.basename(filePath)}.${process.pid}.${crypto.randomUUID()}.tmp`);
+    fs.writeFileSync(temporary, JSON.stringify(state) + "\n", "utf8");
+    fs.renameSync(temporary, filePath);
   } catch {
-    /* A failed catalog write only costs the next scan extra metadata reads. */
+    if (temporary !== undefined) {
+      try {
+        fs.unlinkSync(temporary);
+      } catch {
+        // The write may have failed before the temp file was created.
+      }
+    }
+    const now = Date.now();
+    if (now - lastCatalogPersistenceDiagnosticAt >= CATALOG_PERSISTENCE_DIAGNOSTIC_MS) {
+      lastCatalogPersistenceDiagnosticAt = now;
+      console.error("[project catalog] project catalog index publication failed; a later scan will retry");
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

- Serve the last completed `/api/files` snapshot immediately while one `globalThis` refresher scans in the background.
- Route TTL expiry, revision churn, and deep-link pin hydration through the shared single-flight slot.
- Extend the existing per-file catalog seam with complete parsed summaries keyed by path, size, and mtime, so unchanged transcripts reuse persisted metadata and one append reparses one file.
- Persist the last completed route snapshot for restart-time hydration, with atomic writes and silent cold-scan recovery for missing or corrupt state.
- Preserve scheme-window contents and pin overlays from one scan, including native Codex parent closure.

## Persistence choice

This uses compact JSON under `state/`: the existing `project-catalog.json` holds the per-file summary index, and `files-scan-snapshot.json` holds the last completed capped snapshot. The existing seam already owns scanner project resolution and atomic state-file behavior. Reusing it keeps worktree grouping, fixture identification, engine/kind detection, and legacy catalog migration in one module. It also removes dependence on the rollout state of the SQLite dual-write flag from #187.

Each successful refresh writes through a temporary file plus rename. Missing, partial, or corrupt state triggers the established full-parse fallback and repairs the index on the next completed scan.

## Verification

- `bunx tsc --noEmit`
- `bun test`
- Scoped ESLint across all changed files
- Focused scanner and `/api/files` suites: 84 passing
- Restart benchmark: 7,700 persisted rows hydrated in 47 ms with a 2 s regression ceiling
- Blocked-refresh benchmark: concurrent stale reads returned in 1 ms with a 300 ms regression ceiling
- Existing `describe.test.ts` worktree and deleted-checkout invariants pass unchanged

Closes #261