### PR TITLE
Startup adoption: only live/pending conversations respawn hosts (#265)

### DIFF
--- a/src/lib/runtime/claudeStreamBrokerHost.test.ts
+++ b/src/lib/runtime/claudeStreamBrokerHost.test.ts
@@ -18,7 +18,12 @@ import {
 } from "./claudeStreamBrokerHost";
 import type { RuntimeEventStore } from "./eventStore";
 import type { QueueEntry, RuntimeEvent } from "./engineHost";
-import { adoptClaudeRegistryHosts, bindClaudeHostPersistence, startClaudeStructuredHost } from "./registry";
+import {
+  adoptClaudeRegistryHosts,
+  bindClaudeHostPersistence,
+  demoteSkippedStructuredRegistryHosts,
+  startClaudeStructuredHost,
+} from "./registry";
 
 class MemoryEventStore implements RuntimeEventStore {
   private readonly events = new Map<string, RuntimeEvent[]>();
@@ -972,6 +977,70 @@ describe("ClaudeStreamBrokerHost", () => {
     expect(optionsCalls).toBe(1);
     expect(procBackend.processIdentity(orphan.pid)).not.toBe(startIdentity);
     await adopted[0]!.host.release();
+  }, 10_000);
+
+  test("startup demotion reaps a surviving skipped Claude child", async () => {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-claude-skipped-orphan-"));
+    const registry = new AgentRegistry(path.join(directory, "agent-registry.json"));
+    const sessionId = "skipped-orphaned-claude-session";
+    const orphan = spawn(process.execPath, [
+      "-e",
+      "process.on('SIGTERM', () => {}); setInterval(() => {}, 1000)",
+    ], { stdio: "ignore" });
+    const orphanExit = new Promise<void>((resolve) => { orphan.once("exit", () => resolve()); });
+    let startIdentity: string | null = null;
+    for (let attempt = 0; attempt < 100 && !startIdentity; attempt += 1) {
+      startIdentity = orphan.pid ? procBackend.processIdentity(orphan.pid) : null;
+      if (!startIdentity) await Bun.sleep(2);
+    }
+    if (!orphan.pid || !startIdentity) {
+      try { orphan.kill("SIGKILL"); } catch { /* already exited */ }
+      await orphanExit;
+      throw new Error("orphan test process identity is unavailable");
+    }
+    registry.upsert({
+      key: { engine: "claude", sessionId },
+      artifactPath: `/sessions/${sessionId}.jsonl`,
+      cwd: "/repo",
+      accountId: null,
+      status: "live",
+      host: null,
+      structuredHost: {
+        kind: "claude-broker",
+        endpoint: `stdio:${orphan.pid}`,
+        process: { pid: orphan.pid, startIdentity },
+        eventCursor: 2,
+        protocolVersion: "2.1.197",
+        writerClaimEpoch: 1,
+        activeTurnRef: "stale-turn",
+        pendingAttention: ["stale-attention"],
+        activeFlags: ["working"],
+      },
+      claimEpoch: 1,
+      claimOwner: null,
+      pendingAction: null,
+    });
+
+    try {
+      await demoteSkippedStructuredRegistryHosts(registry, () => false);
+      expect(procBackend.processIdentity(orphan.pid)).not.toBe(startIdentity);
+      expect(registry.snapshot().entries[`claude:${sessionId}`]).toMatchObject({
+        status: "dead",
+        claimOwner: null,
+        structuredHost: {
+          endpoint: "stdio:released",
+          process: null,
+          activeTurnRef: null,
+          pendingAttention: [],
+          activeFlags: [],
+        },
+      });
+    } finally {
+      if (procBackend.processIdentity(orphan.pid) === startIdentity) {
+        try { orphan.kill("SIGKILL"); } catch { /* already exited */ }
+      }
+      await Promise.race([orphanExit, Bun.sleep(2_000)]);
+    }
   }, 10_000);
 
   test("protocol failure reaps a TERM-resistant child and releases its writer claim", async () => {

--- a/src/lib/runtime/codexAppServerHost.test.ts
+++ b/src/lib/runtime/codexAppServerHost.test.ts
@@ -1086,6 +1086,59 @@ describe("CodexAppServerHost", () => {
     await releasedRows[0]!.host.release();
   });
 
+  test("boot adoption starts only Codex rows admitted by its candidate filter", async () => {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-filtered-structured-adoption-"));
+    const registry = new AgentRegistry(path.join(directory, "agent-registry.json"));
+    for (const sessionId of ["unfinished-thread", "terminal-thread"]) {
+      registry.upsert({
+        key: { engine: "codex", sessionId },
+        artifactPath: `/sessions/${sessionId}.jsonl`,
+        cwd: "/repo",
+        accountId: null,
+        status: "live",
+        host: null,
+        structuredHost: {
+          kind: "codex-app-server",
+          endpoint: "stdio:old",
+          process: null,
+          eventCursor: 2,
+          protocolVersion: "0.144.1",
+          writerClaimEpoch: 1,
+          activeTurnRef: `turn-${sessionId}`,
+          pendingAttention: [],
+          activeFlags: [],
+        },
+        claimEpoch: 1,
+        claimOwner: null,
+        pendingAction: null,
+      });
+    }
+    const starts: string[] = [];
+    const adopted = await adoptCodexRegistryHosts(
+      registry,
+      (entry) => {
+        starts.push(entry.key.sessionId);
+        return {
+          cwd: "/repo",
+          eventStore: new MemoryEventStore(),
+          spawnProcess: fakeSpawn(new FakeAppServer(entry.key.sessionId)),
+        };
+      },
+      { NODE_ENV: "test", LLV_STRUCTURED_HOSTS: "1" },
+      (entry) => entry.key.sessionId === "unfinished-thread",
+    );
+
+    expect(starts).toEqual(["unfinished-thread"]);
+    expect(adopted).toHaveLength(1);
+    expect(registry.snapshot().entries["codex:terminal-thread"]).toMatchObject({
+      status: "live",
+      claimEpoch: 1,
+      claimOwner: null,
+    });
+    await adopted[0]!.host.release();
+    fs.rmSync(directory, { recursive: true, force: true });
+  });
+
   test("failed restart adoption leaves a loud dead structured host", async () => {
     const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-failed-adoption-"));
     const registryPath = path.join(directory, "agent-registry.json");

--- a/src/lib/runtime/registry.ts
+++ b/src/lib/runtime/registry.ts
@@ -5,7 +5,7 @@ import type {
   ProcessIdentity,
   StructuredHostColumns,
 } from "@/lib/agent/registry";
-import type { SessionKey } from "@/lib/agent/sessionKey";
+import { sessionKeyId, type SessionKey } from "@/lib/agent/sessionKey";
 import { procBackend } from "@/lib/proc";
 
 import { CodexAppServerHost, type CodexAppServerHostOptions } from "./codexAppServerHost";
@@ -196,6 +196,8 @@ export interface AdoptedClaudeHost {
   host: ClaudeStreamBrokerHost;
 }
 
+export type StructuredHostAdoptionFilter = (entry: AgentRegistryEntry) => boolean;
+
 const STRUCTURED_CLAIM_PREFIX = "structured-host:";
 const ORPHAN_TERM_GRACE_MS = 250;
 const ORPHAN_KILL_GRACE_MS = 1_000;
@@ -238,16 +240,58 @@ async function terminateVerifiedClaudeOrphan(
   return waitForVerifiedProcessExit(processIdentity, ORPHAN_KILL_GRACE_MS);
 }
 
-/** Boot seam: resume every durable Codex row when structured hosting is enabled. */
+/** Reconciles claimable structured ownership for rows excluded by startup adoption. */
+export async function demoteSkippedStructuredRegistryHosts(
+  registry: AgentRegistry,
+  shouldAdopt: StructuredHostAdoptionFilter,
+): Promise<void> {
+  const rows = Object.values(registry.snapshot().entries).filter((entry) =>
+    entry.structuredHost && !shouldAdopt(entry));
+  for (const entry of rows) {
+    const host = entry.structuredHost!;
+    const alreadyDead = entry.status === "dead"
+      && host.process === null
+      && entry.claimOwner === null
+      && host.endpoint === "stdio:released"
+      && host.activeTurnRef === null
+      && host.pendingAttention.length === 0
+      && host.activeFlags.length === 0;
+    if (alreadyDead) continue;
+    const owner = { pid: process.pid, startIdentity: procBackend.processIdentity(process.pid) };
+    try {
+      await registry.withOperationLock(entry.key, owner, async () => {
+        const current = registry.snapshot().entries[sessionKeyId(entry.key)];
+        if (!current?.structuredHost || shouldAdopt(current)) return;
+        const claimed = registry.claimStructuredHost(entry.key, owner, { allowUnhosted: true });
+        if (!claimed?.structuredHost || !claimed.claimOwner) return;
+        const demoted = registry.setStructuredHostClaimed(entry.key, {
+          ...claimed.structuredHost,
+          endpoint: "stdio:released",
+          process: null,
+          activeTurnRef: null,
+          pendingAttention: [],
+          activeFlags: [],
+        }, "dead", claimed.claimOwner, claimed.claimEpoch, true);
+        if (!demoted) throw new Error("structured host writer claim is stale");
+      });
+    } catch (error) {
+      if (!(error instanceof Error) || error.message !== "agent registry is busy") throw error;
+    }
+  }
+}
+
+/** Boot seam: resume selected durable Codex rows when structured hosting is enabled. */
 export async function adoptCodexRegistryHosts(
   registry: AgentRegistry,
   optionsFor: (entry: AgentRegistryEntry) => CodexAppServerHostOptions,
   env: NodeJS.ProcessEnv = process.env,
+  shouldAdopt: StructuredHostAdoptionFilter = () => true,
 ): Promise<AdoptedCodexHost[]> {
   if (!structuredHostsEnabled(env)) return [];
   const rows = Object.values(registry.snapshot().entries).filter((entry) =>
     entry.key.engine === "codex"
-    && entry.structuredHost?.kind === "codex-app-server");
+    && entry.structuredHost?.kind === "codex-app-server"
+    && shouldAdopt(entry));
   const adopted: AdoptedCodexHost[] = [];
   for (const entry of rows) {
     const owner = { pid: process.pid, startIdentity: procBackend.processIdentity(process.pid) };
@@ -281,16 +325,18 @@ export async function adoptCodexRegistryHosts(
 }
 
 
-/** Boot seam: resume every durable Claude broker row when structured hosting is enabled. */
+/** Boot seam: resume selected durable Claude broker rows when structured hosting is enabled. */
 export async function adoptClaudeRegistryHosts(
   registry: AgentRegistry,
   optionsFor: (entry: AgentRegistryEntry) => ClaudeStreamBrokerHostOptions,
   env: NodeJS.ProcessEnv = process.env,
+  shouldAdopt: StructuredHostAdoptionFilter = () => true,
 ): Promise<AdoptedClaudeHost[]> {
   if (!structuredHostsEnabled(env)) return [];
   const rows = Object.values(registry.snapshot().entries).filter((entry) =>
     entry.key.engine === "claude"
-    && entry.structuredHost?.kind === "claude-broker");
+    && entry.structuredHost?.kind === "claude-broker"
+    && shouldAdopt(entry));
   const adopted: AdoptedClaudeHost[] = [];
   for (const entry of rows) {
     const owner = { pid: process.pid, startIdentity: procBackend.processIdentity(process.pid) };

--- a/src/lib/runtime/registry.ts
+++ b/src/lib/runtime/registry.ts
@@ -262,7 +262,16 @@ export async function demoteSkippedStructuredRegistryHosts(
       await registry.withOperationLock(entry.key, owner, async () => {
         const current = registry.snapshot().entries[sessionKeyId(entry.key)];
         if (!current?.structuredHost || shouldAdopt(current)) return;
-        const claimed = registry.claimStructuredHost(entry.key, owner, { allowUnhosted: true });
+        let claimed = registry.claimStructuredHost(entry.key, owner, { allowUnhosted: true });
+        if (!claimed) {
+          const current = registry.snapshot().entries[sessionKeyId(entry.key)];
+          const orphan = current?.structuredHost?.kind === "claude-broker"
+            ? current.structuredHost.process
+            : null;
+          if (orphan && await terminateVerifiedClaudeOrphan(orphan, current?.claimOwner ?? null)) {
+            claimed = registry.claimStructuredHost(entry.key, owner, { allowUnhosted: true });
+          }
+        }
         if (!claimed?.structuredHost || !claimed.claimOwner) return;
         const demoted = registry.setStructuredHostClaimed(entry.key, {
           ...claimed.structuredHost,

--- a/src/lib/runtime/startup.test.ts
+++ b/src/lib/runtime/startup.test.ts
@@ -10,6 +10,7 @@ import { RuntimeJournal } from "@/runtime-host/journal";
 import type { RuntimeHostClient } from "./client";
 import { bindStructuredDeliveryQueue } from "./structuredDeliveryController";
 import { createFakeDeliveryLedger, FakeEngineHost } from "./fixtures/fakeEngineHost";
+import type { StructuredHostAdoptionFilter } from "./registry";
 import { enqueueStructuredMessage } from "./structuredMessageDelivery";
 import { adoptStructuredHostsAtStartup, type StructuredStartupDependencies } from "./startup";
 
@@ -404,7 +405,213 @@ test("fresh-journal startup projects a live tmux registry row for composer fallb
   fs.rmSync(directory, { recursive: true, force: true });
 });
 
-test("startup reconciles a failed spawn after host adoption fails", async () => {
+function addStructuredRestartConversation(
+  registry: AgentRegistry,
+  directory: string,
+  input: {
+    sessionId: string;
+    status: "live" | "dead";
+    turn: "busy" | "terminal";
+    activeTurnRef?: string | null;
+  },
+) {
+  const artifactPath = path.join(directory, `${input.sessionId}.jsonl`);
+  fs.writeFileSync(artifactPath, "");
+  const launchProfile = emptyLaunchProfile({ cwd: directory });
+  registry.reconcileConversations([{
+    engine: "codex",
+    path: artifactPath,
+    accountId: null,
+    launchProfile,
+    turn: {
+      state: input.turn,
+      source: "lifecycle",
+      terminalAt: input.turn === "terminal" ? "2026-07-15T06:00:00.000Z" : null,
+    },
+    observedAt: "2026-07-15T06:00:00.000Z",
+  }]);
+  const conversation = registry.conversationForPath(artifactPath)!;
+  registry.upsert({
+    key: { engine: "codex", sessionId: input.sessionId },
+    artifactPath,
+    cwd: directory,
+    accountId: null,
+    launchProfile,
+    status: input.status,
+    host: null,
+    structuredHost: {
+      kind: "codex-app-server",
+      endpoint: "stdio:retained",
+      process: null,
+      eventCursor: 8,
+      protocolVersion: "test",
+      writerClaimEpoch: 3,
+      activeTurnRef: input.activeTurnRef ?? null,
+      pendingAttention: [],
+      activeFlags: [],
+    },
+    claimEpoch: 3,
+    claimOwner: null,
+    pendingAction: null,
+  });
+  return { artifactPath, conversation };
+}
+
+async function startupAdoptionAttempts(
+  registry: AgentRegistry,
+  client: RuntimeHostClient | null = null,
+): Promise<string[]> {
+  const attempts: string[] = [];
+  const select = (
+    engine: "codex" | "claude",
+    received: AgentRegistry,
+    shouldAdopt: StructuredHostAdoptionFilter,
+  ) => {
+    for (const entry of Object.values(received.snapshot().entries)) {
+      if (entry.key.engine === engine && shouldAdopt(entry)) attempts.push(`${entry.key.engine}:${entry.key.sessionId}`);
+    }
+  };
+  await adoptStructuredHostsAtStartup({
+    registry,
+    client,
+    adopt: async (received, _optionsFor, _env, shouldAdopt = () => true) => {
+      select("codex", received, shouldAdopt);
+      return [];
+    },
+    adoptClaude: async (received, _optionsFor, _env, shouldAdopt = () => true) => {
+      select("claude", received, shouldAdopt);
+      return [];
+    },
+  });
+  return attempts;
+}
+
+test("startup adoption boots one live unfinished host across terminal history", async () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-runtime-startup-adoption-gate-"));
+  const registry = new AgentRegistry(path.join(directory, "agent-registry.json"));
+  const liveSessionId = "11111111-1111-4111-8111-111111111111";
+  addStructuredRestartConversation(registry, directory, {
+    sessionId: liveSessionId,
+    status: "live",
+    turn: "busy",
+    activeTurnRef: "turn-live",
+  });
+  for (let index = 2; index <= 8; index += 1) {
+    const digit = String(index);
+    addStructuredRestartConversation(registry, directory, {
+      sessionId: `${digit.repeat(8)}-${digit.repeat(4)}-4${digit.repeat(3)}-8${digit.repeat(3)}-${digit.repeat(12)}`,
+      status: "live",
+      turn: "terminal",
+      activeTurnRef: `stale-turn-${digit}`,
+    });
+  }
+
+  expect(await startupAdoptionAttempts(registry)).toEqual([`codex:${liveSessionId}`]);
+
+  fs.rmSync(directory, { recursive: true, force: true });
+});
+
+test("startup adoption boots a terminal host with a pending delivery", async () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-runtime-startup-pending-delivery-"));
+  const registry = new AgentRegistry(path.join(directory, "agent-registry.json"));
+  const sessionId = "99999999-9999-4999-8999-999999999999";
+  const { conversation } = addStructuredRestartConversation(registry, directory, {
+    sessionId,
+    status: "dead",
+    turn: "terminal",
+  });
+  registry.holdDelivery(conversation.id, "deliver after restart", "pending-at-restart");
+
+  expect(await startupAdoptionAttempts(registry)).toEqual([`codex:${sessionId}`]);
+
+  fs.rmSync(directory, { recursive: true, force: true });
+});
+
+test("startup adoption boots the terminal host targeted by a queued runtime operation", async () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-runtime-startup-queued-operation-"));
+  const registry = new AgentRegistry(path.join(directory, "agent-registry.json"));
+  const sessionId = "bbbbbbbb-1111-4111-8111-bbbbbbbbbbbb";
+  const { artifactPath, conversation } = addStructuredRestartConversation(registry, directory, {
+    sessionId,
+    status: "dead",
+    turn: "terminal",
+  });
+  addStructuredRestartConversation(registry, directory, {
+    sessionId: "cccccccc-1111-4111-8111-cccccccccccc",
+    status: "dead",
+    turn: "terminal",
+  });
+  const journal = new RuntimeJournal(path.join(directory, "runtime.sqlite"), { structuredHosts: true });
+  journal.append({
+    scope: { type: "session", id: conversation.id },
+    kind: "session-status",
+    payload: {
+      conversationId: conversation.id,
+      sessionKey: { engine: "codex", sessionId },
+      hostKind: "codex-app-server",
+      host: "hosted",
+      turn: "idle",
+      provenance: "structured",
+      artifactPath,
+      capabilities: { steer: true, structuredAttention: true },
+    },
+  });
+  const queued = journal.executeOperation({
+    kind: "send",
+    operationId: "queued-at-restart",
+    idempotencyKey: "queued-at-restart",
+    conversationId: conversation.id,
+    text: "continue queued work",
+    policy: "queue",
+  });
+  expect(queued.receipt.status).toBe("queued");
+
+  expect(await startupAdoptionAttempts(registry, runtimeJournalClient(journal)))
+    .toEqual([`codex:${sessionId}`]);
+
+  await bindStructuredDeliveryQueue([], { registry, client: null });
+  journal.close();
+  fs.rmSync(directory, { recursive: true, force: true });
+});
+
+test("terminal retained structured metadata stays dead and projects its finished conversation", async () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-runtime-startup-terminal-retained-"));
+  const registry = new AgentRegistry(path.join(directory, "agent-registry.json"));
+  const sessionId = "aaaaaaaa-1111-4111-8111-aaaaaaaaaaaa";
+  const { artifactPath, conversation } = addStructuredRestartConversation(registry, directory, {
+    sessionId,
+    status: "dead",
+    turn: "terminal",
+  });
+  const journal = new RuntimeJournal(path.join(directory, "runtime.sqlite"), { structuredHosts: true });
+
+  expect(await startupAdoptionAttempts(registry, runtimeJournalClient(journal))).toEqual([]);
+  expect(registry.conversation(conversation.id)?.turn).toMatchObject({ state: "terminal" });
+  expect(registry.snapshot().entries[`codex:${sessionId}`]).toMatchObject({
+    status: "dead",
+    claimOwner: null,
+    structuredHost: {
+      endpoint: "stdio:released",
+      process: null,
+      activeTurnRef: null,
+    },
+  });
+  expect(journal.snapshot().sessions).toMatchObject([{
+    conversationId: conversation.id,
+    sessionKey: { engine: "codex", sessionId },
+    hostKind: "codex-app-server",
+    host: "dead",
+    turn: "unknown",
+    artifactPath,
+    activeTurnId: null,
+  }]);
+
+  await bindStructuredDeliveryQueue([], { registry, client: null });
+  journal.close();
+  fs.rmSync(directory, { recursive: true, force: true });
+});
+
+test("startup keeps a failed spawn host dead while reconciling its receipt", async () => {
   const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-runtime-startup-failed-spawn-"));
   const sessionId = crypto.randomUUID();
   const artifactPath = path.join(directory, `${sessionId}.jsonl`);
@@ -456,9 +663,9 @@ test("startup reconciles a failed spawn after host adoption fails", async () => 
   const dependencies: StructuredStartupDependencies = {
     registry,
     client,
-    adopt: async (received) => {
+    adopt: async (received, _optionsFor, _env, shouldAdopt = () => true) => {
       const entry = received.snapshot().entries[`codex:${sessionId}`];
-      if (entry?.structuredHost) {
+      if (entry?.structuredHost && shouldAdopt(entry)) {
         failedAdoptions += 1;
         received.setStructuredHost(key, {
           ...entry.structuredHost,
@@ -477,7 +684,7 @@ test("startup reconciles a failed spawn after host adoption fails", async () => 
   expect(await adoptStructuredHostsAtStartup(dependencies)).toEqual([]);
   expect(await adoptStructuredHostsAtStartup(dependencies)).toEqual([]);
 
-  expect(failedAdoptions).toBe(1);
+  expect(failedAdoptions).toBe(0);
   expect(registry.snapshot().receipts[begun.receipt.launchId]).toMatchObject({
     state: "failed",
     error: "engine process could not resume",
@@ -510,7 +717,7 @@ test("startup reconciles a failed spawn after host adoption fails", async () => 
   fs.rmSync(directory, { recursive: true, force: true });
 });
 
-test("startup settles a delivered spawn after host adoption fails", async () => {
+test("startup keeps a delivered spawn host dead while settling its receipt", async () => {
   const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-runtime-startup-delivered-spawn-"));
   const sessionId = crypto.randomUUID();
   const artifactPath = path.join(directory, `${sessionId}.jsonl`);
@@ -570,9 +777,9 @@ test("startup settles a delivered spawn after host adoption fails", async () => 
   const dependencies: StructuredStartupDependencies = {
     registry,
     client: startupClient,
-    adopt: async (received) => {
+    adopt: async (received, _optionsFor, _env, shouldAdopt = () => true) => {
       const entry = received.snapshot().entries[`codex:${sessionId}`];
-      if (entry?.structuredHost) {
+      if (entry?.structuredHost && shouldAdopt(entry)) {
         failedAdoptions += 1;
         received.setStructuredHost(key, {
           ...entry.structuredHost,
@@ -591,7 +798,7 @@ test("startup settles a delivered spawn after host adoption fails", async () => 
   expect(await adoptStructuredHostsAtStartup(dependencies)).toEqual([]);
   expect(await adoptStructuredHostsAtStartup(dependencies)).toEqual([]);
 
-  expect(failedAdoptions).toBe(1);
+  expect(failedAdoptions).toBe(0);
   expect(registry.snapshot().receipts[begun.receipt.launchId]).toMatchObject({
     state: "completed",
     artifactPath,

--- a/src/lib/runtime/startup.test.ts
+++ b/src/lib/runtime/startup.test.ts
@@ -527,6 +527,42 @@ test("startup adoption boots a terminal host with a pending delivery", async () 
   fs.rmSync(directory, { recursive: true, force: true });
 });
 
+test.each(["text", "ephemeral-images"] as const)(
+  "startup adoption leaves a terminal host dead when its %s delivery has failed",
+  async (payloadKind) => {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), `llv-runtime-startup-failed-${payloadKind}-`));
+    const registry = new AgentRegistry(path.join(directory, "agent-registry.json"));
+    const sessionId = payloadKind === "text"
+      ? "dddddddd-1111-4111-8111-dddddddddddd"
+      : "eeeeeeee-1111-4111-8111-eeeeeeeeeeee";
+    const { conversation } = addStructuredRestartConversation(registry, directory, {
+      sessionId,
+      status: "dead",
+      turn: "terminal",
+    });
+    const delivery = registry.holdDelivery(
+      conversation.id,
+      payloadKind === "text" ? "failed before restart" : "",
+      `failed-${payloadKind}`,
+      payloadKind,
+    );
+    registry.recordDeliveryOutcome(delivery.id, "failed", "delivery failed before restart");
+
+    expect(await startupAdoptionAttempts(registry)).toEqual([]);
+    expect(registry.snapshot().entries[`codex:${sessionId}`]).toMatchObject({
+      status: "dead",
+      claimOwner: null,
+      structuredHost: {
+        endpoint: "stdio:released",
+        process: null,
+        activeTurnRef: null,
+      },
+    });
+
+    fs.rmSync(directory, { recursive: true, force: true });
+  },
+);
+
 test("startup adoption boots the terminal host targeted by a queued runtime operation", async () => {
   const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-runtime-startup-queued-operation-"));
   const registry = new AgentRegistry(path.join(directory, "agent-registry.json"));

--- a/src/lib/runtime/startup.ts
+++ b/src/lib/runtime/startup.ts
@@ -1,13 +1,17 @@
 import { accountManager } from "@/lib/accounts/manager";
 import { claudeSettingsPath } from "@/lib/accounts/claude";
+import type { ViewerConversationId } from "@/lib/accounts/migration/contracts";
 import { agentRegistry, type AgentRegistry, type AgentRegistryEntry } from "@/lib/agent/registry";
+import { sessionKeyId } from "@/lib/agent/sessionKey";
 import { VIEWER_SPAWN_CAPABILITY_ENV } from "@/lib/agent/spawnPolicy";
 
 import {
   adoptClaudeRegistryHosts,
   adoptCodexRegistryHosts,
+  demoteSkippedStructuredRegistryHosts,
   type AdoptedClaudeHost,
   type AdoptedCodexHost,
+  type StructuredHostAdoptionFilter,
 } from "./registry";
 import { runtimeHostClient, type RuntimeHostClient } from "./client";
 import { bindStructuredDeliveryQueue } from "./structuredDeliveryController";
@@ -15,6 +19,97 @@ import { recoverPendingStructuredSpawns } from "./structuredSpawn";
 
 type AdoptedStructuredHost = AdoptedCodexHost | AdoptedClaudeHost;
 let adoptedHosts: AdoptedStructuredHost[] = [];
+
+const RUNTIME_EFFECT_PAGE_SIZE = 100;
+const STRUCTURED_HOST_OPERATION_EFFECT_KINDS = [
+  "runtime.send",
+  "runtime.steer",
+  "runtime.interrupt",
+  "runtime.answer",
+  "runtime.kill",
+  "runtime.spawn",
+] as const;
+
+interface StructuredStartupSignals {
+  hostedRunningConversationIds: ReadonlySet<string>;
+  pendingOperationConversationIds: ReadonlySet<string>;
+}
+
+function canonicalConversationId(registry: AgentRegistry, conversationId: string): string {
+  return conversationId.startsWith("conversation_")
+    ? registry.canonicalConversationId(conversationId as ViewerConversationId)
+    : conversationId;
+}
+
+async function structuredStartupSignals(
+  registry: AgentRegistry,
+  client: RuntimeHostClient | null,
+): Promise<StructuredStartupSignals> {
+  if (!client) {
+    return {
+      hostedRunningConversationIds: new Set(),
+      pendingOperationConversationIds: new Set(),
+    };
+  }
+  const runtime = await client.snapshot();
+  const hostedRunningConversationIds = new Set(runtime.sessions
+    .filter((session) => session.host === "hosted"
+      && (session.turn === "running" || session.turn === "interrupt_requested"))
+    .map((session) => canonicalConversationId(registry, session.conversationId)));
+  const pendingOperationConversationIds = new Set(runtime.recentOperations
+    .filter((receipt) => receipt.status === "pending"
+      || receipt.status === "queued"
+      || receipt.status === "delivering")
+    .map((receipt) => canonicalConversationId(registry, receipt.conversationId)));
+  let afterEventSeq = 0;
+  while (true) {
+    const batch = await client.effectBatch(STRUCTURED_HOST_OPERATION_EFFECT_KINDS, afterEventSeq);
+    for (const effect of batch) {
+      const conversationId = effect.payload.conversationId;
+      if (typeof conversationId === "string") {
+        pendingOperationConversationIds.add(canonicalConversationId(registry, conversationId));
+      }
+    }
+    if (batch.length < RUNTIME_EFFECT_PAGE_SIZE) break;
+    const next = Math.max(...batch.map((effect) => effect.eventSeq));
+    if (!Number.isSafeInteger(next) || next <= afterEventSeq) {
+      throw new Error("structured startup operation page did not advance");
+    }
+    afterEventSeq = next;
+  }
+  return { hostedRunningConversationIds, pendingOperationConversationIds };
+}
+
+function structuredStartupAdoptionFilter(
+  registry: AgentRegistry,
+  signals: StructuredStartupSignals,
+): StructuredHostAdoptionFilter {
+  const snapshot = registry.snapshot();
+  const conversationsByCurrentEntry = new Map(Object.values(snapshot.conversations).flatMap((conversation) => {
+    const generation = conversation.generations.at(-1);
+    return generation
+      ? [[sessionKeyId({ engine: conversation.engine, sessionId: generation.id }), conversation] as const]
+      : [];
+  }));
+  const pendingDeliveryConversationIds = new Set(Object.values(snapshot.heldDeliveries)
+    .filter((delivery) => delivery.state !== "delivered")
+    .map((delivery) => registry.canonicalConversationId(delivery.conversationId)));
+  return (entry) => {
+    const conversation = conversationsByCurrentEntry.get(sessionKeyId(entry.key));
+    if (!conversation) return false;
+    const conversationId = registry.canonicalConversationId(conversation.id);
+    const hasPendingWork = pendingDeliveryConversationIds.has(conversationId)
+      || signals.pendingOperationConversationIds.has(conversationId);
+    if (hasPendingWork) return true;
+    if (conversation.turn.state === "terminal") return false;
+    const runtimeHostedRunning = signals.hostedRunningConversationIds.has(conversationId);
+    const unfinishedTurn = conversation.turn.state === "busy"
+      || Boolean(entry.structuredHost?.activeTurnRef)
+      || runtimeHostedRunning;
+    const liveHost = entry.status === "live" || runtimeHostedRunning;
+    return liveHost && unfinishedTurn;
+  };
+}
 
 export interface StructuredStartupDependencies {
   registry?: AgentRegistry;
@@ -35,6 +130,9 @@ export async function adoptStructuredHostsAtStartup(
   dependencies: StructuredStartupDependencies = {},
 ): Promise<AdoptedStructuredHost[]> {
   const registry = dependencies.registry ?? agentRegistry();
+  const client = dependencies.client === undefined ? runtimeHostClient() : dependencies.client;
+  const signals = await structuredStartupSignals(registry, client);
+  const shouldAdopt = structuredStartupAdoptionFilter(registry, signals);
   const resolveCodexOwner = dependencies.resolveCodexOwner ?? ((entry: AgentRegistryEntry) =>
     accountManager.resolveTranscriptOwner("codex", entry.artifactPath));
   const resolveClaudeOwner = dependencies.resolveClaudeOwner ?? ((entry: AgentRegistryEntry) =>
@@ -53,6 +151,8 @@ export async function adoptStructuredHostsAtStartup(
         ...(capability ? { env: { ...process.env, [VIEWER_SPAWN_CAPABILITY_ENV]: capability } } : {}),
       };
     },
+    process.env,
+    shouldAdopt,
   );
   const claude = await (dependencies.adoptClaude ?? adoptClaudeRegistryHosts)(
     registry,
@@ -74,9 +174,11 @@ export async function adoptStructuredHostsAtStartup(
         permissionMode: entry.launchProfile?.permissionMode ?? undefined,
       };
     },
+    process.env,
+    shouldAdopt,
   );
   adoptedHosts = [...codex, ...claude];
-  const client = dependencies.client === undefined ? runtimeHostClient() : dependencies.client;
+  await demoteSkippedStructuredRegistryHosts(registry, shouldAdopt);
   await bindStructuredDeliveryQueue(adoptedHosts, { registry: dependencies.registry, client });
   if (client) await recoverPendingStructuredSpawns(registry, client);
   return adoptedHosts;

--- a/src/lib/runtime/startup.ts
+++ b/src/lib/runtime/startup.ts
@@ -92,7 +92,9 @@ function structuredStartupAdoptionFilter(
       : [];
   }));
   const pendingDeliveryConversationIds = new Set(Object.values(snapshot.heldDeliveries)
-    .filter((delivery) => delivery.state !== "delivered")
+    .filter((delivery) => delivery.state === "held"
+      || delivery.state === "assigned"
+      || delivery.state === "delivery-uncertain")
     .map((delivery) => registry.canonicalConversationId(delivery.conversationId)));
   return (entry) => {
     const conversation = conversationsByCurrentEntry.get(sessionKeyId(entry.key));


### PR DESCRIPTION
## Summary

- admit startup host adoption from live unfinished turns, retained delivery reservations, and queued runtime operations
- fence skipped structured rows to a dead projection while preserving metadata for lazy recovery in PR #267
- reconcile failed and delivered crash-window spawn receipts with zero engine starts

## Verification

- bunx tsc --noEmit
- bun test — 2,772 pass, 0 fail across 290 files
- merge-tree composition with PR #267 head 2b9333e — clean

Closes #265