### PR TITLE
fix(runtime): retire terminal hosts before startup adoption

### DIFF
--- a/src/lib/runtime/startup.test.ts
+++ b/src/lib/runtime/startup.test.ts
@@ -416,14 +416,15 @@ function addStructuredRestartConversation(
     activeTurnRef?: string | null;
     transcriptRecords?: Record<string, unknown>[];
     transcriptSuffix?: string;
+    alignFirstRecordToTailBoundary?: boolean;
   },
 ) {
   const engine = input.engine ?? "codex";
   const artifactPath = path.join(directory, `${input.sessionId}.jsonl`);
-  fs.writeFileSync(
-    artifactPath,
-    (input.transcriptRecords ?? []).map((record) => JSON.stringify(record)).join("\n") + (input.transcriptSuffix ?? ""),
-  );
+  const transcript = (input.transcriptRecords ?? []).map((record) => JSON.stringify(record)).join("\n") + (input.transcriptSuffix ?? "");
+  fs.writeFileSync(artifactPath, input.alignFirstRecordToTailBoundary
+    ? `${JSON.stringify({ padding: "before-window" })}\n${transcript}${" ".repeat(128 * 1024 - Buffer.byteLength(transcript))}`
+    : transcript);
   const launchProfile = emptyLaunchProfile({ cwd: directory });
   registry.reconcileConversations([{
     engine,
@@ -567,6 +568,33 @@ test.each(["codex", "claude"] as const)(
       transcriptRecords: engine === "codex"
         ? [{ timestamp: "2026-07-15T10:00:00.000Z", payload: { type: "task_complete" } }]
         : [{ type: "result", timestamp: "2026-07-15T10:00:00.000Z", subtype: "success" }],
+    });
+
+    expect(await startupAdoptionAttempts(registry)).toEqual([]);
+    expect(registry.conversation(conversation.id)?.turn.state).toBe("terminal");
+    expect(await startupAdoptionAttempts(registry)).toEqual([]);
+    expect(registry.conversation(conversation.id)?.turn.state).toBe("terminal");
+
+    fs.rmSync(directory, { recursive: true, force: true });
+  },
+);
+
+test.each(["codex", "claude"] as const)(
+  "a 128 KiB-aligned terminal %s transcript stays retired across repeated startup",
+  async (engine) => {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), `llv-runtime-startup-repeat-aligned-terminal-${engine}-`));
+    const registry = new AgentRegistry(path.join(directory, "agent-registry.json"));
+    const sessionId = `${engine === "codex" ? "4" : "5"}0000000-0000-4000-8000-000000000001`;
+    const { conversation } = addStructuredRestartConversation(registry, directory, {
+      engine,
+      sessionId,
+      status: "live",
+      turn: "busy",
+      activeTurnRef: `stale-${engine}`,
+      transcriptRecords: engine === "codex"
+        ? [{ timestamp: "2026-07-15T10:00:00.000Z", payload: { type: "task_complete" } }]
+        : [{ type: "result", timestamp: "2026-07-15T10:00:00.000Z", subtype: "success" }],
+      alignFirstRecordToTailBoundary: true,
     });
 
     expect(await startupAdoptionAttempts(registry)).toEqual([]);

--- a/src/lib/runtime/startup.test.ts
+++ b/src/lib/runtime/startup.test.ts
@@ -494,6 +494,14 @@ async function startupAdoptionAttempts(
   return attempts;
 }
 
+function claudeTerminalRecord() {
+  return {
+    type: "assistant",
+    timestamp: "2026-07-15T10:00:00.000Z",
+    message: { role: "assistant", content: [], stop_reason: "end_turn" },
+  };
+}
+
 test("startup adoption boots one live unfinished host across terminal history", async () => {
   const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-runtime-startup-adoption-gate-"));
   const registry = new AgentRegistry(path.join(directory, "agent-registry.json"));
@@ -541,7 +549,7 @@ test("startup adoption reads terminal transcripts before booting production-shap
         activeTurnRef: `stale-${engine}-${index}`,
         transcriptRecords: engine === "codex"
           ? [{ timestamp: "2026-07-15T10:00:00.000Z", payload: { type: "task_complete" } }]
-          : [{ type: "result", timestamp: "2026-07-15T10:00:00.000Z", subtype: "success" }],
+          : [claudeTerminalRecord()],
       });
     }
   }
@@ -567,7 +575,7 @@ test.each(["codex", "claude"] as const)(
       activeTurnRef: `stale-${engine}`,
       transcriptRecords: engine === "codex"
         ? [{ timestamp: "2026-07-15T10:00:00.000Z", payload: { type: "task_complete" } }]
-        : [{ type: "result", timestamp: "2026-07-15T10:00:00.000Z", subtype: "success" }],
+        : [claudeTerminalRecord()],
     });
 
     expect(await startupAdoptionAttempts(registry)).toEqual([]);
@@ -578,6 +586,44 @@ test.each(["codex", "claude"] as const)(
     fs.rmSync(directory, { recursive: true, force: true });
   },
 );
+
+test("a production-shaped Claude broker transcript ending in end_turn stays retired across repeated startup", async () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-runtime-startup-repeat-broker-terminal-"));
+  const registry = new AgentRegistry(path.join(directory, "agent-registry.json"));
+  const sessionId = "10000000-0000-4000-8000-000000000002";
+  const { conversation } = addStructuredRestartConversation(registry, directory, {
+    engine: "claude",
+    sessionId,
+    status: "live",
+    turn: "busy",
+    activeTurnRef: "stale-claude-broker-turn",
+    transcriptRecords: [
+      {
+        type: "user",
+        uuid: "20000000-0000-4000-8000-000000000001",
+        parentUuid: null,
+        sessionId,
+        timestamp: "2026-07-15T10:00:00.000Z",
+        message: { role: "user", content: [] },
+      },
+      {
+        type: "assistant",
+        uuid: "20000000-0000-4000-8000-000000000002",
+        parentUuid: "20000000-0000-4000-8000-000000000001",
+        sessionId,
+        timestamp: "2026-07-15T10:00:01.000Z",
+        message: { role: "assistant", content: [], stop_reason: "end_turn" },
+      },
+    ],
+  });
+
+  expect(await startupAdoptionAttempts(registry)).toEqual([]);
+  expect(registry.conversation(conversation.id)?.turn.state).toBe("terminal");
+  expect(await startupAdoptionAttempts(registry)).toEqual([]);
+  expect(registry.conversation(conversation.id)?.turn.state).toBe("terminal");
+
+  fs.rmSync(directory, { recursive: true, force: true });
+});
 
 test.each(["codex", "claude"] as const)(
   "a 128 KiB-aligned terminal %s transcript stays retired across repeated startup",
@@ -593,7 +639,7 @@ test.each(["codex", "claude"] as const)(
       activeTurnRef: `stale-${engine}`,
       transcriptRecords: engine === "codex"
         ? [{ timestamp: "2026-07-15T10:00:00.000Z", payload: { type: "task_complete" } }]
-        : [{ type: "result", timestamp: "2026-07-15T10:00:00.000Z", subtype: "success" }],
+        : [claudeTerminalRecord()],
       alignFirstRecordToTailBoundary: true,
     });
 
@@ -620,7 +666,7 @@ test.each(["codex", "claude"] as const)(
       activeTurnRef: `active-${engine}`,
       transcriptRecords: engine === "codex"
         ? [{ timestamp: "2026-07-15T10:00:00.000Z", payload: { type: "task_complete" } }]
-        : [{ type: "result", timestamp: "2026-07-15T10:00:00.000Z", subtype: "success" }],
+        : [claudeTerminalRecord()],
       transcriptSuffix: "\n{corrupt",
     });
 
@@ -644,7 +690,7 @@ test.each(["codex", "claude"] as const)(
       activeTurnRef: `active-${engine}`,
       transcriptRecords: engine === "codex"
         ? [{ timestamp: "2026-07-15T10:00:00.000Z", payload: { type: "task_complete" } }]
-        : [{ type: "result", timestamp: "2026-07-15T10:00:00.000Z", subtype: "success" }],
+        : [claudeTerminalRecord()],
       transcriptSuffix: '\n{"next_turn":',
     });
 
@@ -668,7 +714,7 @@ test.each(["codex", "claude"] as const)(
       activeTurnRef: `active-${engine}`,
       transcriptRecords: engine === "codex"
         ? [{ timestamp: "2026-07-15T10:00:00.000Z", payload: { type: "task_complete" } }]
-        : [{ type: "result", timestamp: "2026-07-15T10:00:00.000Z", subtype: "success" }],
+        : [claudeTerminalRecord()],
     });
     const realOpen = fs.promises.open.bind(fs.promises);
     const open = spyOn(fs.promises, "open").mockImplementation(async (...args) => {
@@ -715,7 +761,7 @@ test.each([
       activeTurnRef: `active-${engine}`,
       transcriptRecords: engine === "codex"
         ? [{ timestamp: "2026-07-15T10:00:00.000Z", payload: { type: "task_complete" } }]
-        : [{ type: "result", timestamp: "2026-07-15T10:00:00.000Z", subtype: "success" }],
+        : [claudeTerminalRecord()],
     });
     if (condition === "missing") fs.rmSync(artifactPath);
     else fs.chmodSync(artifactPath, 0o000);
@@ -875,7 +921,7 @@ test.each(["codex", "claude"] as const)(
       activeTurnRef: "stale-terminal-turn",
       transcriptRecords: engine === "codex"
         ? [{ timestamp: "2026-07-15T10:00:00.000Z", payload: { type: "task_complete" } }]
-        : [{ type: "result", timestamp: "2026-07-15T10:00:00.000Z", subtype: "success" }],
+        : [claudeTerminalRecord()],
     });
     const journal = new RuntimeJournal(path.join(directory, "runtime.sqlite"), { structuredHosts: true });
     journal.append({

--- a/src/lib/runtime/startup.test.ts
+++ b/src/lib/runtime/startup.test.ts
@@ -409,17 +409,20 @@ function addStructuredRestartConversation(
   registry: AgentRegistry,
   directory: string,
   input: {
+    engine?: "codex" | "claude";
     sessionId: string;
     status: "live" | "dead";
     turn: "busy" | "terminal";
     activeTurnRef?: string | null;
+    transcriptRecords?: Record<string, unknown>[];
   },
 ) {
+  const engine = input.engine ?? "codex";
   const artifactPath = path.join(directory, `${input.sessionId}.jsonl`);
-  fs.writeFileSync(artifactPath, "");
+  fs.writeFileSync(artifactPath, (input.transcriptRecords ?? []).map((record) => JSON.stringify(record)).join("\n"));
   const launchProfile = emptyLaunchProfile({ cwd: directory });
   registry.reconcileConversations([{
-    engine: "codex",
+    engine,
     path: artifactPath,
     accountId: null,
     launchProfile,
@@ -432,7 +435,7 @@ function addStructuredRestartConversation(
   }]);
   const conversation = registry.conversationForPath(artifactPath)!;
   registry.upsert({
-    key: { engine: "codex", sessionId: input.sessionId },
+    key: { engine, sessionId: input.sessionId },
     artifactPath,
     cwd: directory,
     accountId: null,
@@ -440,7 +443,7 @@ function addStructuredRestartConversation(
     status: input.status,
     host: null,
     structuredHost: {
-      kind: "codex-app-server",
+      kind: engine === "codex" ? "codex-app-server" : "claude-broker",
       endpoint: "stdio:retained",
       process: null,
       eventCursor: 8,
@@ -511,6 +514,73 @@ test("startup adoption boots one live unfinished host across terminal history", 
   fs.rmSync(directory, { recursive: true, force: true });
 });
 
+test("startup adoption reads terminal transcripts before booting production-shaped stale registry rows", async () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-runtime-startup-transcript-gate-"));
+  const registry = new AgentRegistry(path.join(directory, "agent-registry.json"));
+  const activeSessionId = "11111111-aaaa-4111-8111-111111111111";
+  addStructuredRestartConversation(registry, directory, {
+    sessionId: activeSessionId,
+    status: "live",
+    turn: "busy",
+    activeTurnRef: "turn-active",
+    transcriptRecords: [{ timestamp: "2026-07-15T10:00:00.000Z", payload: { type: "task_started" } }],
+  });
+  for (const engine of ["codex", "claude"] as const) {
+    for (let index = 0; index < 10; index += 1) {
+      const sessionId = `${engine === "codex" ? "2" : "3"}0000000-0000-4000-8000-${String(index).padStart(12, "0")}`;
+      addStructuredRestartConversation(registry, directory, {
+        engine,
+        sessionId,
+        status: "live",
+        turn: "busy",
+        activeTurnRef: `stale-${engine}-${index}`,
+        transcriptRecords: engine === "codex"
+          ? [{ timestamp: "2026-07-15T10:00:00.000Z", payload: { type: "task_complete" } }]
+          : [{ type: "result", timestamp: "2026-07-15T10:00:00.000Z", subtype: "success" }],
+      });
+    }
+  }
+
+  expect(await startupAdoptionAttempts(registry)).toEqual([`codex:${activeSessionId}`]);
+
+  fs.rmSync(directory, { recursive: true, force: true });
+});
+
+test("an explicit terminal transcript outranks a stale running runtime projection", async () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-runtime-startup-terminal-runtime-"));
+  const registry = new AgentRegistry(path.join(directory, "agent-registry.json"));
+  const sessionId = "60000000-0000-4000-8000-000000000000";
+  const { artifactPath, conversation } = addStructuredRestartConversation(registry, directory, {
+    sessionId,
+    status: "live",
+    turn: "busy",
+    activeTurnRef: "stale-running-turn",
+    transcriptRecords: [{ timestamp: "2026-07-15T10:00:00.000Z", payload: { type: "task_complete" } }],
+  });
+  const journal = new RuntimeJournal(path.join(directory, "runtime.sqlite"), { structuredHosts: true });
+  journal.append({
+    scope: { type: "session", id: conversation.id },
+    kind: "session-status",
+    payload: {
+      conversationId: conversation.id,
+      sessionKey: { engine: "codex", sessionId },
+      hostKind: "codex-app-server",
+      host: "hosted",
+      turn: "running",
+      activeTurnId: "stale-running-turn",
+      provenance: "structured",
+      artifactPath,
+      capabilities: { steer: true, structuredAttention: true },
+    },
+  });
+
+  expect(await startupAdoptionAttempts(registry, runtimeJournalClient(journal))).toEqual([]);
+
+  await bindStructuredDeliveryQueue([], { registry, client: null });
+  journal.close();
+  fs.rmSync(directory, { recursive: true, force: true });
+});
+
 test("startup adoption boots a terminal host with a pending delivery", async () => {
   const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-runtime-startup-pending-delivery-"));
   const registry = new AgentRegistry(path.join(directory, "agent-registry.json"));
@@ -563,7 +633,7 @@ test.each(["text", "ephemeral-images"] as const)(
   },
 );
 
-test("startup adoption boots the terminal host targeted by a queued runtime operation", async () => {
+test("startup adoption boots the terminal host targeted by a queued runtime send", async () => {
   const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-runtime-startup-queued-operation-"));
   const registry = new AgentRegistry(path.join(directory, "agent-registry.json"));
   const sessionId = "bbbbbbbb-1111-4111-8111-bbbbbbbbbbbb";
@@ -609,6 +679,61 @@ test("startup adoption boots the terminal host targeted by a queued runtime oper
   journal.close();
   fs.rmSync(directory, { recursive: true, force: true });
 });
+
+test.each(["codex", "claude"] as const)(
+  "startup drains a queued %s terminal kill without adopting its host across repeated restarts",
+  async (engine) => {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), `llv-runtime-startup-terminal-kill-${engine}-`));
+    const registry = new AgentRegistry(path.join(directory, "agent-registry.json"));
+    const sessionId = `${engine === "codex" ? "4" : "5"}0000000-0000-4000-8000-000000000000`;
+    const { artifactPath, conversation } = addStructuredRestartConversation(registry, directory, {
+      engine,
+      sessionId,
+      status: "live",
+      turn: "busy",
+      activeTurnRef: "stale-terminal-turn",
+      transcriptRecords: engine === "codex"
+        ? [{ timestamp: "2026-07-15T10:00:00.000Z", payload: { type: "task_complete" } }]
+        : [{ type: "result", timestamp: "2026-07-15T10:00:00.000Z", subtype: "success" }],
+    });
+    const journal = new RuntimeJournal(path.join(directory, "runtime.sqlite"), { structuredHosts: true });
+    journal.append({
+      scope: { type: "session", id: conversation.id },
+      kind: "session-status",
+      payload: {
+        conversationId: conversation.id,
+        sessionKey: { engine, sessionId },
+        hostKind: engine === "codex" ? "codex-app-server" : "claude-broker",
+        host: "hosted",
+        turn: "idle",
+        provenance: "structured",
+        artifactPath,
+        capabilities: { steer: engine === "codex", structuredAttention: true },
+      },
+    });
+    journal.executeOperation({
+      kind: "kill",
+      operationId: `terminal-kill-${engine}`,
+      idempotencyKey: `terminal-kill-${engine}`,
+      conversationId: conversation.id,
+      sessionKey: { engine, sessionId },
+    });
+    const client = runtimeJournalClient(journal);
+
+    expect(await startupAdoptionAttempts(registry, client)).toEqual([]);
+    expect(journal.operationResult(`terminal-kill-${engine}`)?.receipt.status).toBe("delivered");
+    expect(registry.snapshot().entries[`${engine}:${sessionId}`]).toMatchObject({
+      status: "dead",
+      structuredHost: null,
+      claimOwner: null,
+    });
+    expect(await startupAdoptionAttempts(registry, client)).toEqual([]);
+
+    await bindStructuredDeliveryQueue([], { registry, client: null });
+    journal.close();
+    fs.rmSync(directory, { recursive: true, force: true });
+  },
+);
 
 test("terminal retained structured metadata stays dead and projects its finished conversation", async () => {
   const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-runtime-startup-terminal-retained-"));

--- a/src/lib/runtime/startup.test.ts
+++ b/src/lib/runtime/startup.test.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { expect, test } from "bun:test";
+import { expect, spyOn, test } from "bun:test";
 
 import { emptyLaunchProfile } from "@/lib/accounts/migration/contracts";
 import { AgentRegistry } from "@/lib/agent/registry";
@@ -415,11 +415,15 @@ function addStructuredRestartConversation(
     turn: "busy" | "terminal";
     activeTurnRef?: string | null;
     transcriptRecords?: Record<string, unknown>[];
+    transcriptSuffix?: string;
   },
 ) {
   const engine = input.engine ?? "codex";
   const artifactPath = path.join(directory, `${input.sessionId}.jsonl`);
-  fs.writeFileSync(artifactPath, (input.transcriptRecords ?? []).map((record) => JSON.stringify(record)).join("\n"));
+  fs.writeFileSync(
+    artifactPath,
+    (input.transcriptRecords ?? []).map((record) => JSON.stringify(record)).join("\n") + (input.transcriptSuffix ?? ""),
+  );
   const launchProfile = emptyLaunchProfile({ cwd: directory });
   registry.reconcileConversations([{
     engine,
@@ -541,10 +545,159 @@ test("startup adoption reads terminal transcripts before booting production-shap
     }
   }
 
+  const startedAt = performance.now();
   expect(await startupAdoptionAttempts(registry)).toEqual([`codex:${activeSessionId}`]);
+  expect(performance.now() - startedAt).toBeLessThan(1_000);
 
   fs.rmSync(directory, { recursive: true, force: true });
 });
+
+test.each(["codex", "claude"] as const)(
+  "a clean terminal %s transcript stays retired across repeated startup",
+  async (engine) => {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), `llv-runtime-startup-repeat-terminal-${engine}-`));
+    const registry = new AgentRegistry(path.join(directory, "agent-registry.json"));
+    const sessionId = `${engine === "codex" ? "f" : "1"}0000000-0000-4000-8000-000000000001`;
+    const { conversation } = addStructuredRestartConversation(registry, directory, {
+      engine,
+      sessionId,
+      status: "live",
+      turn: "busy",
+      activeTurnRef: `stale-${engine}`,
+      transcriptRecords: engine === "codex"
+        ? [{ timestamp: "2026-07-15T10:00:00.000Z", payload: { type: "task_complete" } }]
+        : [{ type: "result", timestamp: "2026-07-15T10:00:00.000Z", subtype: "success" }],
+    });
+
+    expect(await startupAdoptionAttempts(registry)).toEqual([]);
+    expect(registry.conversation(conversation.id)?.turn.state).toBe("terminal");
+    expect(await startupAdoptionAttempts(registry)).toEqual([]);
+    expect(registry.conversation(conversation.id)?.turn.state).toBe("terminal");
+
+    fs.rmSync(directory, { recursive: true, force: true });
+  },
+);
+
+test.each(["codex", "claude"] as const)(
+  "startup keeps a %s host adoption-eligible when malformed JSON follows a terminal marker",
+  async (engine) => {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), `llv-runtime-startup-corrupt-tail-${engine}-`));
+    const registry = new AgentRegistry(path.join(directory, "agent-registry.json"));
+    const sessionId = `${engine === "codex" ? "7" : "8"}0000000-0000-4000-8000-000000000000`;
+    addStructuredRestartConversation(registry, directory, {
+      engine,
+      sessionId,
+      status: "live",
+      turn: "busy",
+      activeTurnRef: `active-${engine}`,
+      transcriptRecords: engine === "codex"
+        ? [{ timestamp: "2026-07-15T10:00:00.000Z", payload: { type: "task_complete" } }]
+        : [{ type: "result", timestamp: "2026-07-15T10:00:00.000Z", subtype: "success" }],
+      transcriptSuffix: "\n{corrupt",
+    });
+
+    expect(await startupAdoptionAttempts(registry)).toEqual([`${engine}:${sessionId}`]);
+
+    fs.rmSync(directory, { recursive: true, force: true });
+  },
+);
+
+test.each(["codex", "claude"] as const)(
+  "startup keeps a %s host adoption-eligible when a truncated record follows a terminal marker",
+  async (engine) => {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), `llv-runtime-startup-truncated-tail-${engine}-`));
+    const registry = new AgentRegistry(path.join(directory, "agent-registry.json"));
+    const sessionId = `${engine === "codex" ? "9" : "a"}0000000-0000-4000-8000-000000000000`;
+    addStructuredRestartConversation(registry, directory, {
+      engine,
+      sessionId,
+      status: "live",
+      turn: "busy",
+      activeTurnRef: `active-${engine}`,
+      transcriptRecords: engine === "codex"
+        ? [{ timestamp: "2026-07-15T10:00:00.000Z", payload: { type: "task_complete" } }]
+        : [{ type: "result", timestamp: "2026-07-15T10:00:00.000Z", subtype: "success" }],
+      transcriptSuffix: '\n{"next_turn":',
+    });
+
+    expect(await startupAdoptionAttempts(registry)).toEqual([`${engine}:${sessionId}`]);
+
+    fs.rmSync(directory, { recursive: true, force: true });
+  },
+);
+
+test.each(["codex", "claude"] as const)(
+  "startup keeps a %s host adoption-eligible while its transcript grows during the tail read",
+  async (engine) => {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), `llv-runtime-startup-growing-tail-${engine}-`));
+    const registry = new AgentRegistry(path.join(directory, "agent-registry.json"));
+    const sessionId = `${engine === "codex" ? "b" : "c"}0000000-0000-4000-8000-000000000000`;
+    const { artifactPath } = addStructuredRestartConversation(registry, directory, {
+      engine,
+      sessionId,
+      status: "live",
+      turn: "busy",
+      activeTurnRef: `active-${engine}`,
+      transcriptRecords: engine === "codex"
+        ? [{ timestamp: "2026-07-15T10:00:00.000Z", payload: { type: "task_complete" } }]
+        : [{ type: "result", timestamp: "2026-07-15T10:00:00.000Z", subtype: "success" }],
+    });
+    const realOpen = fs.promises.open.bind(fs.promises);
+    const open = spyOn(fs.promises, "open").mockImplementation(async (...args) => {
+      const handle = await realOpen(...args);
+      if (String(args[0]) !== artifactPath) return handle;
+      const realRead = handle.read.bind(handle);
+      let appended = false;
+      handle.read = (async (...readArgs: Parameters<typeof handle.read>) => {
+        const result = await realRead(...readArgs);
+        if (!appended) {
+          appended = true;
+          fs.appendFileSync(artifactPath, '\n{"type":"user"}');
+        }
+        return result;
+      }) as typeof handle.read;
+      return handle;
+    });
+
+    try {
+      expect(await startupAdoptionAttempts(registry)).toEqual([`${engine}:${sessionId}`]);
+    } finally {
+      open.mockRestore();
+      fs.rmSync(directory, { recursive: true, force: true });
+    }
+  },
+);
+
+test.each([
+  ["codex", "missing"],
+  ["codex", "unreadable"],
+  ["claude", "missing"],
+  ["claude", "unreadable"],
+] as const)(
+  "startup keeps a %s host adoption-eligible when its transcript path is %s",
+  async (engine, condition) => {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), `llv-runtime-startup-${condition}-${engine}-`));
+    const registry = new AgentRegistry(path.join(directory, "agent-registry.json"));
+    const sessionId = `${engine === "codex" ? "d" : "e"}0000000-0000-4000-8000-000000000000`;
+    const { artifactPath } = addStructuredRestartConversation(registry, directory, {
+      engine,
+      sessionId,
+      status: "live",
+      turn: "busy",
+      activeTurnRef: `active-${engine}`,
+      transcriptRecords: engine === "codex"
+        ? [{ timestamp: "2026-07-15T10:00:00.000Z", payload: { type: "task_complete" } }]
+        : [{ type: "result", timestamp: "2026-07-15T10:00:00.000Z", subtype: "success" }],
+    });
+    if (condition === "missing") fs.rmSync(artifactPath);
+    else fs.chmodSync(artifactPath, 0o000);
+
+    expect(await startupAdoptionAttempts(registry)).toEqual([`${engine}:${sessionId}`]);
+
+    if (condition === "unreadable") fs.chmodSync(artifactPath, 0o600);
+    fs.rmSync(directory, { recursive: true, force: true });
+  },
+);
 
 test("an explicit terminal transcript outranks a stale running runtime projection", async () => {
   const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-runtime-startup-terminal-runtime-"));

--- a/src/lib/runtime/startup.test.ts
+++ b/src/lib/runtime/startup.test.ts
@@ -5,6 +5,7 @@ import { expect, spyOn, test } from "bun:test";
 
 import { emptyLaunchProfile } from "@/lib/accounts/migration/contracts";
 import { AgentRegistry } from "@/lib/agent/registry";
+import { turnStateFromRecords } from "@/lib/scanner/activity";
 import { RuntimeJournal } from "@/runtime-host/journal";
 
 import type { RuntimeHostClient } from "./client";
@@ -562,6 +563,56 @@ test("startup adoption reads terminal transcripts before booting production-shap
 });
 
 test.each(["codex", "claude"] as const)(
+  "startup adopts a persisted terminal %s conversation whose transcript starts a new turn before restart",
+  async (engine) => {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), `llv-runtime-startup-reopened-${engine}-`));
+    const registry = new AgentRegistry(path.join(directory, "agent-registry.json"));
+    const sessionId = `${engine === "codex" ? "2" : "3"}1000000-0000-4000-8000-000000000001`;
+    const { conversation } = addStructuredRestartConversation(registry, directory, {
+      engine,
+      sessionId,
+      status: "live",
+      turn: "terminal",
+      activeTurnRef: `fresh-${engine}-turn`,
+      transcriptRecords: engine === "codex"
+        ? [{ timestamp: "2026-07-15T10:01:00.000Z", payload: { type: "task_started" } }]
+        : [{ type: "user", timestamp: "2026-07-15T10:01:00.000Z", message: { role: "user", content: [] } }],
+    });
+
+    expect(await startupAdoptionAttempts(registry)).toEqual([`${engine}:${sessionId}`]);
+    expect(registry.conversation(conversation.id)?.turn.state).toBe("busy");
+
+    fs.rmSync(directory, { recursive: true, force: true });
+  },
+);
+
+test("startup keeps a Codex host eligible when the bounded tail cuts off an unmatched tool call", async () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-runtime-startup-cutoff-tool-"));
+  const registry = new AgentRegistry(path.join(directory, "agent-registry.json"));
+  const sessionId = "41000000-0000-4000-8000-000000000001";
+  const transcriptRecords = [
+    { timestamp: "2026-07-15T10:00:00.000Z", payload: { type: "task_started", turn_id: "turn-1" } },
+    {
+      timestamp: "2026-07-15T10:00:01.000Z",
+      payload: { type: "function_call", call_id: "tool-before-cutoff", arguments: "x".repeat(128 * 1024) },
+    },
+    { timestamp: "2026-07-15T10:00:02.000Z", payload: { type: "task_complete", turn_id: "turn-1" } },
+  ];
+  expect(turnStateFromRecords(transcriptRecords, true)).toBe("busy");
+  addStructuredRestartConversation(registry, directory, {
+    sessionId,
+    status: "live",
+    turn: "busy",
+    activeTurnRef: "turn-1",
+    transcriptRecords,
+  });
+
+  expect(await startupAdoptionAttempts(registry)).toEqual([`codex:${sessionId}`]);
+
+  fs.rmSync(directory, { recursive: true, force: true });
+});
+
+test.each(["codex", "claude"] as const)(
   "a clean terminal %s transcript stays retired across repeated startup",
   async (engine) => {
     const directory = fs.mkdtempSync(path.join(os.tmpdir(), `llv-runtime-startup-repeat-terminal-${engine}-`));
@@ -574,7 +625,12 @@ test.each(["codex", "claude"] as const)(
       turn: "busy",
       activeTurnRef: `stale-${engine}`,
       transcriptRecords: engine === "codex"
-        ? [{ timestamp: "2026-07-15T10:00:00.000Z", payload: { type: "task_complete" } }]
+        ? [
+            { timestamp: "2026-07-15T10:00:00.000Z", payload: { type: "task_started", turn_id: "turn-1" } },
+            { timestamp: "2026-07-15T10:00:01.000Z", payload: { type: "function_call", call_id: "tool-1" } },
+            { timestamp: "2026-07-15T10:00:02.000Z", payload: { type: "function_call_output", call_id: "tool-1" } },
+            { timestamp: "2026-07-15T10:00:03.000Z", payload: { type: "task_complete", turn_id: "turn-1" } },
+          ]
         : [claudeTerminalRecord()],
     });
 
@@ -638,7 +694,12 @@ test.each(["codex", "claude"] as const)(
       turn: "busy",
       activeTurnRef: `stale-${engine}`,
       transcriptRecords: engine === "codex"
-        ? [{ timestamp: "2026-07-15T10:00:00.000Z", payload: { type: "task_complete" } }]
+        ? [
+            { timestamp: "2026-07-15T10:00:00.000Z", payload: { type: "task_started", turn_id: "turn-1" } },
+            { timestamp: "2026-07-15T10:00:01.000Z", payload: { type: "function_call", call_id: "tool-1" } },
+            { timestamp: "2026-07-15T10:00:02.000Z", payload: { type: "function_call_output", call_id: "tool-1" } },
+            { timestamp: "2026-07-15T10:00:03.000Z", payload: { type: "task_complete", turn_id: "turn-1" } },
+          ]
         : [claudeTerminalRecord()],
       alignFirstRecordToTailBoundary: true,
     });

--- a/src/lib/runtime/startup.ts
+++ b/src/lib/runtime/startup.ts
@@ -38,6 +38,15 @@ interface StructuredStartupSignals {
 
 const TRANSCRIPT_REFRESH_CONCURRENCY = 16;
 
+function persistedTurnState(
+  records: Record<string, unknown>[],
+  engine: "codex" | "claude",
+) {
+  return engine === "claude"
+    ? turnStateFromRecords(records, false)
+    : turnStateFromRecords(records, true, true);
+}
+
 async function refreshTerminalTranscriptState(registry: AgentRegistry): Promise<void> {
   const snapshot = registry.snapshot();
   const observedAt = new Date().toISOString();
@@ -58,7 +67,7 @@ async function refreshTerminalTranscriptState(registry: AgentRegistry): Promise<
         const { conversation, generation } = candidate;
         const tail = await readStableTailRecords(generation.path);
         if (tail.integrity !== "complete") continue;
-        const turn = turnStateFromRecords(tail.records, conversation.engine === "codex", true);
+        const turn = persistedTurnState(tail.records, conversation.engine);
         if (turn.state !== "terminal") continue;
         observations.push({
           engine: conversation.engine,

--- a/src/lib/runtime/startup.ts
+++ b/src/lib/runtime/startup.ts
@@ -41,18 +41,32 @@ const TRANSCRIPT_REFRESH_CONCURRENCY = 16;
 function persistedTurnState(
   records: Record<string, unknown>[],
   engine: "codex" | "claude",
+  prefixTruncated: boolean,
 ) {
-  return engine === "claude"
-    ? turnStateFromRecords(records, false)
-    : turnStateFromRecords(records, true, true);
+  if (engine === "claude") return turnStateFromRecords(records, false);
+  if (!prefixTruncated) return turnStateFromRecords(records, true, true);
+
+  const turnStartIndex = records.findLastIndex((record) => {
+    const payload = record.payload;
+    if (!payload || typeof payload !== "object" || Array.isArray(payload)) return false;
+    const type = (payload as Record<string, unknown>).type;
+    return type === "task_started" || type === "turn_started" || type === "user_message";
+  });
+  if (turnStartIndex < 0) {
+    const turn = turnStateFromRecords(records, true, true);
+    return turn.state === "terminal"
+      ? { state: "unknown" as const, source: "empty" as const, terminalAt: null }
+      : turn;
+  }
+  return turnStateFromRecords(records.slice(turnStartIndex), true, true);
 }
 
-async function refreshTerminalTranscriptState(registry: AgentRegistry): Promise<void> {
+async function refreshStructuredTranscriptState(registry: AgentRegistry): Promise<void> {
   const snapshot = registry.snapshot();
   const observedAt = new Date().toISOString();
   const candidates = Object.values(snapshot.conversations).flatMap((conversation) => {
     const generation = conversation.generations.at(-1);
-    if (!generation || conversation.turn.state === "terminal") return [];
+    if (!generation) return [];
     const entry = snapshot.entries[sessionKeyId({ engine: conversation.engine, sessionId: generation.id })];
     return entry?.structuredHost ? [{ conversation, generation }] : [];
   });
@@ -67,8 +81,8 @@ async function refreshTerminalTranscriptState(registry: AgentRegistry): Promise<
         const { conversation, generation } = candidate;
         const tail = await readStableTailRecords(generation.path);
         if (tail.integrity !== "complete") continue;
-        const turn = persistedTurnState(tail.records, conversation.engine);
-        if (turn.state !== "terminal") continue;
+        const turn = persistedTurnState(tail.records, conversation.engine, tail.prefixTruncated);
+        if (turn.state !== "busy" && turn.state !== "terminal") continue;
         observations.push({
           engine: conversation.engine,
           path: generation.path,
@@ -183,7 +197,7 @@ export async function adoptStructuredHostsAtStartup(
   dependencies: StructuredStartupDependencies = {},
 ): Promise<AdoptedStructuredHost[]> {
   const registry = dependencies.registry ?? agentRegistry();
-  await refreshTerminalTranscriptState(registry);
+  await refreshStructuredTranscriptState(registry);
   const client = dependencies.client === undefined ? runtimeHostClient() : dependencies.client;
   const signals = await structuredStartupSignals(registry, client);
   const shouldAdopt = structuredStartupAdoptionFilter(registry, signals);

--- a/src/lib/runtime/startup.ts
+++ b/src/lib/runtime/startup.ts
@@ -1,9 +1,13 @@
+import fs from "node:fs";
+
 import { accountManager } from "@/lib/accounts/manager";
 import { claudeSettingsPath } from "@/lib/accounts/claude";
+import { turnStateFromRecords } from "@/lib/accounts/migration/turnState";
 import type { ViewerConversationId } from "@/lib/accounts/migration/contracts";
 import { agentRegistry, type AgentRegistry, type AgentRegistryEntry } from "@/lib/agent/registry";
 import { sessionKeyId } from "@/lib/agent/sessionKey";
 import { VIEWER_SPAWN_CAPABILITY_ENV } from "@/lib/agent/spawnPolicy";
+import { tailRecords } from "@/lib/scanner/activity";
 
 import {
   adoptClaudeRegistryHosts,
@@ -26,13 +30,39 @@ const STRUCTURED_HOST_OPERATION_EFFECT_KINDS = [
   "runtime.steer",
   "runtime.interrupt",
   "runtime.answer",
-  "runtime.kill",
   "runtime.spawn",
 ] as const;
 
 interface StructuredStartupSignals {
   hostedRunningConversationIds: ReadonlySet<string>;
   pendingOperationConversationIds: ReadonlySet<string>;
+}
+
+function refreshTerminalTranscriptState(registry: AgentRegistry): void {
+  const snapshot = registry.snapshot();
+  const observedAt = new Date().toISOString();
+  const observations = [];
+  for (const conversation of Object.values(snapshot.conversations)) {
+    const generation = conversation.generations.at(-1);
+    if (!generation) continue;
+    const entry = snapshot.entries[sessionKeyId({ engine: conversation.engine, sessionId: generation.id })];
+    if (!entry?.structuredHost) continue;
+    let size: number;
+    try { size = fs.statSync(generation.path).size; }
+    catch { continue; }
+    const turn = turnStateFromRecords(tailRecords(generation.path, size), conversation.engine === "codex", true);
+    if (turn.state !== "terminal" || conversation.turn.state === "terminal") continue;
+    observations.push({
+      engine: conversation.engine,
+      path: generation.path,
+      accountId: generation.accountId,
+      launchProfile: generation.launchProfile,
+      turn,
+      expectedTurnObservedAt: conversation.turn.observedAt,
+      observedAt,
+    });
+  }
+  if (observations.length > 0) registry.reconcileConversations(observations);
 }
 
 function canonicalConversationId(registry: AgentRegistry, conversationId: string): string {
@@ -60,6 +90,7 @@ async function structuredStartupSignals(
     .filter((receipt) => receipt.status === "pending"
       || receipt.status === "queued"
       || receipt.status === "delivering")
+    .filter((receipt) => receipt.kind !== "kill")
     .map((receipt) => canonicalConversationId(registry, receipt.conversationId)));
   let afterEventSeq = 0;
   while (true) {
@@ -132,6 +163,7 @@ export async function adoptStructuredHostsAtStartup(
   dependencies: StructuredStartupDependencies = {},
 ): Promise<AdoptedStructuredHost[]> {
   const registry = dependencies.registry ?? agentRegistry();
+  refreshTerminalTranscriptState(registry);
   const client = dependencies.client === undefined ? runtimeHostClient() : dependencies.client;
   const signals = await structuredStartupSignals(registry, client);
   const shouldAdopt = structuredStartupAdoptionFilter(registry, signals);

--- a/src/lib/runtime/startup.ts
+++ b/src/lib/runtime/startup.ts
@@ -1,5 +1,3 @@
-import fs from "node:fs";
-
 import { accountManager } from "@/lib/accounts/manager";
 import { claudeSettingsPath } from "@/lib/accounts/claude";
 import { turnStateFromRecords } from "@/lib/accounts/migration/turnState";
@@ -7,7 +5,7 @@ import type { ViewerConversationId } from "@/lib/accounts/migration/contracts";
 import { agentRegistry, type AgentRegistry, type AgentRegistryEntry } from "@/lib/agent/registry";
 import { sessionKeyId } from "@/lib/agent/sessionKey";
 import { VIEWER_SPAWN_CAPABILITY_ENV } from "@/lib/agent/spawnPolicy";
-import { tailRecords } from "@/lib/scanner/activity";
+import { readStableTailRecords } from "@/lib/scanner/activity";
 
 import {
   adoptClaudeRegistryHosts,
@@ -38,30 +36,43 @@ interface StructuredStartupSignals {
   pendingOperationConversationIds: ReadonlySet<string>;
 }
 
-function refreshTerminalTranscriptState(registry: AgentRegistry): void {
+const TRANSCRIPT_REFRESH_CONCURRENCY = 16;
+
+async function refreshTerminalTranscriptState(registry: AgentRegistry): Promise<void> {
   const snapshot = registry.snapshot();
   const observedAt = new Date().toISOString();
-  const observations = [];
-  for (const conversation of Object.values(snapshot.conversations)) {
+  const candidates = Object.values(snapshot.conversations).flatMap((conversation) => {
     const generation = conversation.generations.at(-1);
-    if (!generation) continue;
+    if (!generation || conversation.turn.state === "terminal") return [];
     const entry = snapshot.entries[sessionKeyId({ engine: conversation.engine, sessionId: generation.id })];
-    if (!entry?.structuredHost) continue;
-    let size: number;
-    try { size = fs.statSync(generation.path).size; }
-    catch { continue; }
-    const turn = turnStateFromRecords(tailRecords(generation.path, size), conversation.engine === "codex", true);
-    if (turn.state !== "terminal" || conversation.turn.state === "terminal") continue;
-    observations.push({
-      engine: conversation.engine,
-      path: generation.path,
-      accountId: generation.accountId,
-      launchProfile: generation.launchProfile,
-      turn,
-      expectedTurnObservedAt: conversation.turn.observedAt,
-      observedAt,
-    });
-  }
+    return entry?.structuredHost ? [{ conversation, generation }] : [];
+  });
+  const observations: Parameters<AgentRegistry["reconcileConversations"]>[0] = [];
+  let nextCandidate = 0;
+  const workers = Array.from(
+    { length: Math.min(TRANSCRIPT_REFRESH_CONCURRENCY, candidates.length) },
+    async () => {
+      while (nextCandidate < candidates.length) {
+        const candidate = candidates[nextCandidate++];
+        if (!candidate) continue;
+        const { conversation, generation } = candidate;
+        const tail = await readStableTailRecords(generation.path);
+        if (tail.integrity !== "complete") continue;
+        const turn = turnStateFromRecords(tail.records, conversation.engine === "codex", true);
+        if (turn.state !== "terminal") continue;
+        observations.push({
+          engine: conversation.engine,
+          path: generation.path,
+          accountId: generation.accountId,
+          launchProfile: generation.launchProfile,
+          turn,
+          expectedTurnObservedAt: conversation.turn.observedAt,
+          observedAt,
+        });
+      }
+    },
+  );
+  await Promise.all(workers);
   if (observations.length > 0) registry.reconcileConversations(observations);
 }
 
@@ -163,7 +174,7 @@ export async function adoptStructuredHostsAtStartup(
   dependencies: StructuredStartupDependencies = {},
 ): Promise<AdoptedStructuredHost[]> {
   const registry = dependencies.registry ?? agentRegistry();
-  refreshTerminalTranscriptState(registry);
+  await refreshTerminalTranscriptState(registry);
   const client = dependencies.client === undefined ? runtimeHostClient() : dependencies.client;
   const signals = await structuredStartupSignals(registry, client);
   const shouldAdopt = structuredStartupAdoptionFilter(registry, signals);

--- a/src/lib/scanner/activity.test.ts
+++ b/src/lib/scanner/activity.test.ts
@@ -64,6 +64,32 @@ describe("turnStateFromRecords (codex)", () => {
 });
 
 describe("readStableTailRecords", () => {
+  test("preserves a Codex terminal record aligned to the 128 KiB tail boundary", async () => {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-stable-tail-aligned-codex-"));
+    const transcript = path.join(directory, "transcript.jsonl");
+    const record = { timestamp: "2026-07-15T10:00:00.000Z", payload: { type: "task_complete" } };
+    const line = JSON.stringify(record);
+    const tailBytes = 128 * 1024;
+    fs.writeFileSync(transcript, `${JSON.stringify({ padding: "before-window" })}\n${line}${" ".repeat(tailBytes - line.length)}`);
+
+    expect(await readStableTailRecords(transcript)).toEqual({ integrity: "complete", records: [record] });
+
+    fs.rmSync(directory, { recursive: true, force: true });
+  });
+
+  test("preserves a Claude terminal record aligned to the 128 KiB tail boundary", async () => {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-stable-tail-aligned-claude-"));
+    const transcript = path.join(directory, "transcript.jsonl");
+    const record = { type: "result", timestamp: "2026-07-15T10:00:00.000Z", subtype: "success" };
+    const line = JSON.stringify(record);
+    const tailBytes = 128 * 1024;
+    fs.writeFileSync(transcript, `${JSON.stringify({ padding: "before-window" })}\n${line}${" ".repeat(tailBytes - line.length)}`);
+
+    expect(await readStableTailRecords(transcript)).toEqual({ integrity: "complete", records: [record] });
+
+    fs.rmSync(directory, { recursive: true, force: true });
+  });
+
   test("rejects corrupt and truncated JSONL rows", async () => {
     const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-stable-tail-invalid-"));
     const corrupt = path.join(directory, "corrupt.jsonl");

--- a/src/lib/scanner/activity.test.ts
+++ b/src/lib/scanner/activity.test.ts
@@ -72,7 +72,7 @@ describe("readStableTailRecords", () => {
     const tailBytes = 128 * 1024;
     fs.writeFileSync(transcript, `${JSON.stringify({ padding: "before-window" })}\n${line}${" ".repeat(tailBytes - line.length)}`);
 
-    expect(await readStableTailRecords(transcript)).toEqual({ integrity: "complete", records: [record] });
+    expect(await readStableTailRecords(transcript)).toEqual({ integrity: "complete", prefixTruncated: true, records: [record] });
 
     fs.rmSync(directory, { recursive: true, force: true });
   });
@@ -85,7 +85,7 @@ describe("readStableTailRecords", () => {
     const tailBytes = 128 * 1024;
     fs.writeFileSync(transcript, `${JSON.stringify({ padding: "before-window" })}\n${line}${" ".repeat(tailBytes - line.length)}`);
 
-    expect(await readStableTailRecords(transcript)).toEqual({ integrity: "complete", records: [record] });
+    expect(await readStableTailRecords(transcript)).toEqual({ integrity: "complete", prefixTruncated: true, records: [record] });
 
     fs.rmSync(directory, { recursive: true, force: true });
   });
@@ -109,7 +109,7 @@ describe("readStableTailRecords", () => {
     const record = { type: "result", subtype: "success" };
     fs.writeFileSync(transcript, JSON.stringify(record));
 
-    expect(await readStableTailRecords(transcript)).toEqual({ integrity: "complete", records: [record] });
+    expect(await readStableTailRecords(transcript)).toEqual({ integrity: "complete", prefixTruncated: false, records: [record] });
 
     fs.rmSync(directory, { recursive: true, force: true });
   });
@@ -123,6 +123,7 @@ describe("readStableTailRecords", () => {
 
     expect(await readStableTailRecords(transcript, finalLine.length + 12)).toEqual({
       integrity: "complete",
+      prefixTruncated: true,
       records: [finalRecord],
     });
 
@@ -140,6 +141,7 @@ describe("readStableTailRecords", () => {
 
     expect(await readStableTailRecords(transcript, content.length - seek)).toEqual({
       integrity: "complete",
+      prefixTruncated: true,
       records: [finalRecord],
     });
 
@@ -172,7 +174,7 @@ describe("readStableTailRecords", () => {
     expect(tailRecords(transcript, terminalText.length)).toEqual([terminal]);
     fs.writeFileSync(transcript, activeText);
 
-    expect(await readStableTailRecords(transcript)).toEqual({ integrity: "complete", records: [active] });
+    expect(await readStableTailRecords(transcript)).toEqual({ integrity: "complete", prefixTruncated: false, records: [active] });
     expect(tailRecords(transcript, activeText.length)).toEqual([terminal]);
 
     fs.rmSync(directory, { recursive: true, force: true });

--- a/src/lib/scanner/activity.test.ts
+++ b/src/lib/scanner/activity.test.ts
@@ -1,6 +1,9 @@
-import { describe, expect, test } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, spyOn, test } from "bun:test";
 
-import { turnStateFromRecords } from "./activity";
+import { readStableTailRecords, tailRecords, turnStateFromRecords } from "./activity";
 
 const assistant = (stop: string | null, ...kinds: string[]) => ({
   type: "assistant",
@@ -58,4 +61,127 @@ describe("turnStateFromRecords (codex)", () => {
     const records = [payload("task_complete"), payload("token_count"), payload("reasoning")];
     expect(turnStateFromRecords(records, true)).toBe("done");
   });
+});
+
+describe("readStableTailRecords", () => {
+  test("rejects corrupt and truncated JSONL rows", async () => {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-stable-tail-invalid-"));
+    const corrupt = path.join(directory, "corrupt.jsonl");
+    const truncated = path.join(directory, "truncated.jsonl");
+    fs.writeFileSync(corrupt, '{"type":"result"}\nnot-json\n');
+    fs.writeFileSync(truncated, '{"type":"result"}\n{"type":');
+
+    expect(await readStableTailRecords(corrupt)).toEqual({ integrity: "uncertain", records: [] });
+    expect(await readStableTailRecords(truncated)).toEqual({ integrity: "uncertain", records: [] });
+
+    fs.rmSync(directory, { recursive: true, force: true });
+  });
+
+  test("accepts a valid final JSON record without a trailing newline", async () => {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-stable-tail-final-record-"));
+    const transcript = path.join(directory, "transcript.jsonl");
+    const record = { type: "result", subtype: "success" };
+    fs.writeFileSync(transcript, JSON.stringify(record));
+
+    expect(await readStableTailRecords(transcript)).toEqual({ integrity: "complete", records: [record] });
+
+    fs.rmSync(directory, { recursive: true, force: true });
+  });
+
+  test("discards only the first partial line created by a bounded tail seek", async () => {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-stable-tail-bounded-"));
+    const transcript = path.join(directory, "transcript.jsonl");
+    const finalRecord = { type: "result", subtype: "success" };
+    const finalLine = JSON.stringify(finalRecord);
+    fs.writeFileSync(transcript, `${JSON.stringify({ padding: "x".repeat(256) })}\n${finalLine}`);
+
+    expect(await readStableTailRecords(transcript, finalLine.length + 12)).toEqual({
+      integrity: "complete",
+      records: [finalRecord],
+    });
+
+    fs.rmSync(directory, { recursive: true, force: true });
+  });
+
+  test("discards an incomplete UTF-8 character inside the bounded seek prefix", async () => {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-stable-tail-utf8-prefix-"));
+    const transcript = path.join(directory, "transcript.jsonl");
+    const prefix = JSON.stringify({ padding: "😀".repeat(64) });
+    const finalRecord = { type: "result", subtype: "success" };
+    const content = Buffer.from(`${prefix}\n${JSON.stringify(finalRecord)}`);
+    const seek = content.indexOf(Buffer.from("😀")) + 1;
+    fs.writeFileSync(transcript, content);
+
+    expect(await readStableTailRecords(transcript, content.length - seek)).toEqual({
+      integrity: "complete",
+      records: [finalRecord],
+    });
+
+    fs.rmSync(directory, { recursive: true, force: true });
+  });
+
+  test("reports missing and unreadable transcript paths as uncertain", async () => {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-stable-tail-unreadable-"));
+    const missing = path.join(directory, "missing.jsonl");
+    const unreadable = path.join(directory, "unreadable.jsonl");
+    fs.writeFileSync(unreadable, '{"type":"result"}');
+    fs.chmodSync(unreadable, 0o000);
+
+    expect(await readStableTailRecords(missing)).toEqual({ integrity: "uncertain", records: [] });
+    expect(await readStableTailRecords(unreadable)).toEqual({ integrity: "uncertain", records: [] });
+
+    fs.chmodSync(unreadable, 0o600);
+    fs.rmSync(directory, { recursive: true, force: true });
+  });
+
+  test("bypasses size-keyed scanner cache entries after a same-size rewrite", async () => {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-stable-tail-cache-"));
+    const transcript = path.join(directory, "transcript.jsonl");
+    const terminal = { payload: { type: "task_complete" } };
+    const active = { payload: { type: "task_started_" } };
+    const terminalText = JSON.stringify(terminal);
+    const activeText = JSON.stringify(active);
+    expect(activeText.length).toBe(terminalText.length);
+    fs.writeFileSync(transcript, terminalText);
+    expect(tailRecords(transcript, terminalText.length)).toEqual([terminal]);
+    fs.writeFileSync(transcript, activeText);
+
+    expect(await readStableTailRecords(transcript)).toEqual({ integrity: "complete", records: [active] });
+    expect(tailRecords(transcript, activeText.length)).toEqual([terminal]);
+
+    fs.rmSync(directory, { recursive: true, force: true });
+  });
+
+  test.each(["replace", "truncate"] as const)(
+    "reports a transcript %s during the bounded read as uncertain",
+    async (mutation) => {
+      const directory = fs.mkdtempSync(path.join(os.tmpdir(), `llv-stable-tail-${mutation}-`));
+      const transcript = path.join(directory, "transcript.jsonl");
+      const replacement = path.join(directory, "replacement.jsonl");
+      fs.writeFileSync(transcript, '{"type":"result","subtype":"success"}');
+      const realOpen = fs.promises.open.bind(fs.promises);
+      const open = spyOn(fs.promises, "open").mockImplementation(async (...args) => {
+        const handle = await realOpen(...args);
+        const realRead = handle.read.bind(handle);
+        handle.read = (async (...readArgs: Parameters<typeof handle.read>) => {
+          const result = await realRead(...readArgs);
+          if (mutation === "replace") {
+            fs.writeFileSync(replacement, '{"type":"user"}');
+            fs.renameSync(replacement, transcript);
+          } else {
+            fs.truncateSync(transcript, 0);
+          }
+          return result;
+        }) as typeof handle.read;
+        return handle;
+      });
+
+      try {
+        expect(await readStableTailRecords(transcript)).toEqual({ integrity: "uncertain", records: [] });
+      } finally {
+        open.mockRestore();
+        fs.rmSync(directory, { recursive: true, force: true });
+      }
+    },
+  );
 });

--- a/src/lib/scanner/activity.ts
+++ b/src/lib/scanner/activity.ts
@@ -42,10 +42,12 @@ export async function readStableTailRecords(pathname: string, nbytes = 131_072):
     if (!Number.isSafeInteger(size)) return { integrity: "uncertain", records: [] };
     const length = Math.min(size, nbytes);
     const seek = size - length;
-    const buffer = Buffer.alloc(length);
+    const boundaryBytes = seek > 0 ? 1 : 0;
+    const readSeek = seek - boundaryBytes;
+    const buffer = Buffer.alloc(length + boundaryBytes);
     let offset = 0;
-    while (offset < length) {
-      const read = await handle.read(buffer, offset, length - offset, seek + offset);
+    while (offset < buffer.length) {
+      const read = await handle.read(buffer, offset, buffer.length - offset, readSeek + offset);
       if (read.bytesRead === 0) return { integrity: "uncertain", records: [] };
       offset += read.bytesRead;
     }
@@ -57,9 +59,12 @@ export async function readStableTailRecords(pathname: string, nbytes = 131_072):
 
     let jsonBuffer = buffer;
     if (seek > 0) {
-      const firstNewline = buffer.indexOf(0x0a);
-      if (firstNewline < 0) return { integrity: "complete", records: [] };
-      jsonBuffer = buffer.subarray(firstNewline + 1);
+      if (buffer[0] === 0x0a) jsonBuffer = buffer.subarray(1);
+      else {
+        const firstNewline = buffer.indexOf(0x0a);
+        if (firstNewline < 0) return { integrity: "complete", records: [] };
+        jsonBuffer = buffer.subarray(firstNewline + 1);
+      }
     }
     let data: string;
     try {

--- a/src/lib/scanner/activity.ts
+++ b/src/lib/scanner/activity.ts
@@ -17,6 +17,80 @@ const turnCache = globalCache<[number, string | null]>("turn");
 const tailCache = globalCache<[number, number, Record<string, unknown>[]]>("tail");
 const TAIL_CACHE_CAP = 64;
 
+export type StableTailRead =
+  | { integrity: "complete"; records: Record<string, unknown>[] }
+  | { integrity: "uncertain"; records: [] };
+
+function sameFileState(left: fs.BigIntStats, right: fs.BigIntStats): boolean {
+  return left.dev === right.dev
+    && left.ino === right.ino
+    && left.size === right.size
+    && left.mtimeNs === right.mtimeNs
+    && left.ctimeNs === right.ctimeNs;
+}
+
+/** Reads a bounded JSONL tail whose records are safe to use for durable state.
+ * The scanner's permissive, size-keyed cache serves display derivations; this
+ * uncached path verifies every row and the open file's identity around I/O. */
+export async function readStableTailRecords(pathname: string, nbytes = 131_072): Promise<StableTailRead> {
+  let handle: fs.promises.FileHandle | null = null;
+  try {
+    handle = await fs.promises.open(pathname, "r");
+    const before = await handle.stat({ bigint: true });
+    if (!before.isFile()) return { integrity: "uncertain", records: [] };
+    const size = Number(before.size);
+    if (!Number.isSafeInteger(size)) return { integrity: "uncertain", records: [] };
+    const length = Math.min(size, nbytes);
+    const seek = size - length;
+    const buffer = Buffer.alloc(length);
+    let offset = 0;
+    while (offset < length) {
+      const read = await handle.read(buffer, offset, length - offset, seek + offset);
+      if (read.bytesRead === 0) return { integrity: "uncertain", records: [] };
+      offset += read.bytesRead;
+    }
+    const after = await handle.stat({ bigint: true });
+    const pathAfter = await fs.promises.stat(pathname, { bigint: true });
+    if (!sameFileState(before, after) || !sameFileState(after, pathAfter)) {
+      return { integrity: "uncertain", records: [] };
+    }
+
+    let jsonBuffer = buffer;
+    if (seek > 0) {
+      const firstNewline = buffer.indexOf(0x0a);
+      if (firstNewline < 0) return { integrity: "complete", records: [] };
+      jsonBuffer = buffer.subarray(firstNewline + 1);
+    }
+    let data: string;
+    try {
+      data = new TextDecoder("utf-8", { fatal: true }).decode(jsonBuffer);
+    } catch {
+      return { integrity: "uncertain", records: [] };
+    }
+    const lines = data.split("\n");
+    const records: Record<string, unknown>[] = [];
+    for (const line of lines) {
+      const text = line.trim();
+      if (!text) continue;
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(text);
+      } catch {
+        return { integrity: "uncertain", records: [] };
+      }
+      if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+        return { integrity: "uncertain", records: [] };
+      }
+      records.push(parsed as Record<string, unknown>);
+    }
+    return { integrity: "complete", records };
+  } catch {
+    return { integrity: "uncertain", records: [] };
+  } finally {
+    await handle?.close().catch(() => undefined);
+  }
+}
+
 export function tailRecords(pathname: string, size: number, nbytes = 131_072) {
   const cached = tailCache.get(pathname);
   if (cached && cached[0] === size && cached[1] === nbytes) return cached[2].slice();

--- a/src/lib/scanner/activity.ts
+++ b/src/lib/scanner/activity.ts
@@ -18,7 +18,7 @@ const tailCache = globalCache<[number, number, Record<string, unknown>[]]>("tail
 const TAIL_CACHE_CAP = 64;
 
 export type StableTailRead =
-  | { integrity: "complete"; records: Record<string, unknown>[] }
+  | { integrity: "complete"; prefixTruncated: boolean; records: Record<string, unknown>[] }
   | { integrity: "uncertain"; records: [] };
 
 function sameFileState(left: fs.BigIntStats, right: fs.BigIntStats): boolean {
@@ -62,7 +62,7 @@ export async function readStableTailRecords(pathname: string, nbytes = 131_072):
       if (buffer[0] === 0x0a) jsonBuffer = buffer.subarray(1);
       else {
         const firstNewline = buffer.indexOf(0x0a);
-        if (firstNewline < 0) return { integrity: "complete", records: [] };
+        if (firstNewline < 0) return { integrity: "complete", prefixTruncated: true, records: [] };
         jsonBuffer = buffer.subarray(firstNewline + 1);
       }
     }
@@ -88,7 +88,7 @@ export async function readStableTailRecords(pathname: string, nbytes = 131_072):
       }
       records.push(parsed as Record<string, unknown>);
     }
-    return { integrity: "complete", records };
+    return { integrity: "complete", prefixTruncated: seek > 0, records };
   } catch {
     return { integrity: "uncertain", records: [] };
   } finally {


### PR DESCRIPTION
## Summary

- refresh persisted Codex and Claude terminal conversations before startup retirement so a newly started turn remains adoptable
- expose bounded-tail prefix truncation and require a retained Codex turn-start boundary before terminalizing a cut window
- preserve verified terminal retirement, pending delivery, terminal kill drainage, migration behavior, and structured host recovery

## Reproductions

- persisted terminal Codex and Claude rows with a newly appended active turn produced zero adoption attempts before this fix
- a Codex function-call row larger than 128 KiB followed by task_complete was busy under full parsing and terminal under the old startup tail

## Verification

- focused startup suite: 38 pass
- scanner activity suite: 19 pass
- focused startup, activity, turn parsing, queue, migration, structured delivery, structured spawn, host, and integration gates: 298 pass across 19 files
- real Codex late-attach, steering, and restart-resume gate: pass
- all real Claude late-attach/resume, permission-answer, and bypass gates: pass
- full Bun suite: 2807 pass, 0 fail across 290 files
- TypeScript: bunx tsc --noEmit
- scoped ESLint: startup and scanner activity source/tests
- production-shaped 1-active-plus-20-terminal startup case: 72 ms focused, 73 ms full-suite run
- exact composition with PR #267 head 650819c5a7fb69f98ad740fec97691677a44fef7: clean merge tree ebc820db50e0b8af44eef2b7c950fd72ac55f90f
- protected components, styles, locales, and public assets: zero diff from the PR base
- fix head: 5a0024cc218320f997bdf8abba10ce5bcbcfe528

## Links

- Reopened issue: [#265](https://github.com/Latand/live-log-viewer-next/issues/265)
- Prior merged fix: [#274](https://github.com/Latand/live-log-viewer-next/pull/274)
- Recovery composition target: [#267](https://github.com/Latand/live-log-viewer-next/pull/267)

Fixes #265