### PR TITLE
fix(runtime): bound SSE burst subscriber updates

### DIFF
--- a/src/hooks/runtimeBus.dom.test.tsx
+++ b/src/hooks/runtimeBus.dom.test.tsx
@@ -1,0 +1,222 @@
+import { afterAll, beforeAll, expect, test } from "bun:test";
+import { Window } from "happy-dom";
+import { act, useEffect, useSyncExternalStore } from "react";
+import { createRoot } from "react-dom/client";
+
+import type { RuntimeSnapshot } from "@/components/runtime/runtimeModel";
+
+import { createRuntimeBus, type EventSourceLike, type RuntimeBus } from "./runtimeBus";
+
+class FakeEventSource implements EventSourceLike {
+  onopen: ((this: unknown, ev: unknown) => void) | null = null;
+  onerror: ((this: unknown, ev: unknown) => void) | null = null;
+  onmessage: ((this: unknown, ev: { data: string; lastEventId?: string }) => void) | null = null;
+  private readonly listeners = new Map<string, Array<(ev: { data: string }) => void>>();
+
+  constructor(readonly url: string) {}
+
+  addEventListener(type: string, listener: (ev: { data: string }) => void): void {
+    const listeners = this.listeners.get(type) ?? [];
+    listeners.push(listener);
+    this.listeners.set(type, listeners);
+  }
+
+  close(): void {}
+
+  open(): void {
+    this.onopen?.(null);
+  }
+
+  message(envelope: unknown): void {
+    this.onmessage?.({ data: JSON.stringify(envelope) });
+  }
+}
+
+const dom = new Window({ url: "http://localhost/" });
+const globals = globalThis as Record<string, unknown>;
+const overrides: Record<string, unknown> = {
+  window: dom,
+  document: dom.document,
+  navigator: dom.navigator,
+  Node: dom.Node,
+  HTMLElement: dom.HTMLElement,
+  Event: dom.Event,
+  IS_REACT_ACT_ENVIRONMENT: true,
+};
+const savedGlobals = new Map<string, { present: boolean; value: unknown }>();
+
+beforeAll(() => {
+  for (const [key, value] of Object.entries(overrides)) {
+    savedGlobals.set(key, { present: key in globals, value: globals[key] });
+    globals[key] = value;
+  }
+});
+
+afterAll(() => {
+  for (const [key, saved] of savedGlobals) {
+    if (saved.present) globals[key] = saved.value;
+    else delete globals[key];
+  }
+  dom.close();
+});
+
+function productionSnapshot(): RuntimeSnapshot & { transportPadding: string } {
+  const session = {
+    conversationId: "codex-one",
+    sessionKey: { engine: "codex" as const, sessionId: "codex-session" },
+    hostKind: "codex-app-server" as const,
+    host: "hosted" as const,
+    turn: "idle" as const,
+    provenance: "structured" as const,
+    revision: 1,
+    attentionIds: [],
+    recentReceipts: [],
+    accountId: "codex-account",
+    parentConversationId: null,
+    flowId: null,
+    workflowId: null,
+    cwd: "/repo",
+    artifactPath: "/sessions/codex.jsonl",
+    capabilities: { steer: true, structuredAttention: true },
+    activeTurnId: null,
+    drift: null,
+  };
+  const sessions = [
+    session,
+    {
+      ...session,
+      conversationId: "claude-one",
+      sessionKey: { engine: "claude" as const, sessionId: "claude-session" },
+      hostKind: "claude-broker" as const,
+      accountId: "claude-account",
+      artifactPath: "/sessions/claude.jsonl",
+    },
+  ];
+  for (let index = 0; index < 800; index += 1) {
+    sessions.push({
+      ...session,
+      conversationId: `background-${index}`,
+      sessionKey: { engine: "codex", sessionId: `background-session-${index}` },
+      accountId: `background-account-${index % 4}`,
+      artifactPath: `/sessions/background-${index}.jsonl`,
+    });
+  }
+  const snapshot: RuntimeSnapshot & { transportPadding: string } = {
+    schemaVersion: 1,
+    snapshotSeq: 100,
+    retentionFloorSeq: 0,
+    structuredHostsEnabled: true,
+    runtime: { hostEpoch: 1, health: "ready" },
+    filesRevision: 1,
+    sessions,
+    attentions: [],
+    recentOperations: [],
+    edges: [],
+    flows: [],
+    workflows: [],
+    tasks: [],
+    deployments: [],
+    transportPadding: "",
+  };
+  snapshot.transportPadding = "x".repeat(Math.max(0, 477 * 1024 - Buffer.byteLength(JSON.stringify(snapshot))));
+  return snapshot;
+}
+
+function RuntimeProbe({ bus, onCommit }: { bus: RuntimeBus; onCommit: () => void }) {
+  const state = useSyncExternalStore(bus.subscribe, bus.getState, bus.getState);
+  useEffect(onCommit);
+  return (
+    <output data-connection={state.connection}>
+      {state.store.cursor}:{state.store.sessions["codex-one"]?.sessionKey.engine},{state.store.sessions["claude-one"]?.sessionKey.engine}:{Object.keys(state.store.sessions).length}
+    </output>
+  );
+}
+
+test("a production-sized React join stays warm and bounded through Codex and Claude bursts", async () => {
+  const sources: FakeEventSource[] = [];
+  let snapshotFetches = 0;
+  const encodedSnapshot = JSON.stringify(productionSnapshot());
+  const bus = createRuntimeBus({
+    fetch: async () => {
+      snapshotFetches += 1;
+      return new Response(encodedSnapshot, { headers: { "content-type": "application/json" } });
+    },
+    createEventSource: (url) => {
+      const source = new FakeEventSource(url);
+      sources.push(source);
+      return source;
+    },
+    now: () => Date.now(),
+    setTimeout: (fn, ms) => setTimeout(fn, ms),
+    clearTimeout: (handle) => clearTimeout(handle),
+    setInterval: (fn, ms) => setInterval(fn, ms),
+    clearInterval: (handle) => clearInterval(handle),
+  });
+  const host = document.createElement("div");
+  document.body.append(host);
+  const root = createRoot(host);
+  const depthErrors: string[] = [];
+  const originalConsoleError = console.error;
+  console.error = (...args: unknown[]) => {
+    const message = args.map(String).join(" ");
+    if (message.includes("Maximum update depth exceeded") || message.includes("#185")) depthErrors.push(message);
+    else originalConsoleError(...args);
+  };
+
+  try {
+    let committedRenders = 0;
+    const warmStartedAt = performance.now();
+    await act(async () => {
+      root.render(<RuntimeProbe bus={bus} onCommit={() => { committedRenders += 1; }} />);
+      bus.start();
+      await Bun.sleep(25);
+    });
+    const warmElapsedMs = performance.now() - warmStartedAt;
+    expect(Buffer.byteLength(encodedSnapshot)).toBeGreaterThanOrEqual(477 * 1024);
+    expect(host.textContent).toBe("100:codex,claude:802");
+    expect(warmElapsedMs).toBeLessThan(500);
+    expect(snapshotFetches).toBe(1);
+    expect(sources).toHaveLength(1);
+
+    await act(async () => {
+      sources[0]!.open();
+      await Bun.sleep(20);
+    });
+    committedRenders = 0;
+    let subscriberNotifications = 0;
+    const unsubscribe = bus.subscribe(() => { subscriberNotifications += 1; });
+    let seq = 100;
+    await act(async () => {
+      for (const conversationId of ["codex-one", "claude-one"]) {
+        for (let index = 0; index < 64; index += 1) {
+          seq += 1;
+          sources[0]!.message({
+            schemaVersion: 1,
+            seq,
+            eventId: `event-${seq}`,
+            scope: { type: "session", id: conversationId },
+            revision: index + 2,
+            kind: "item",
+            payload: { phase: "delta", text: `token-${index}` },
+          });
+          await Promise.resolve();
+        }
+      }
+      await Bun.sleep(20);
+    });
+    unsubscribe();
+
+    expect(host.textContent).toBe("228:codex,claude:802");
+    expect(bus.getState().store.cursor).toBe(228);
+    expect(snapshotFetches).toBe(1);
+    expect(sources).toHaveLength(1);
+    expect(subscriberNotifications).toBe(1);
+    expect(committedRenders).toBe(1);
+    expect(depthErrors).toEqual([]);
+  } finally {
+    console.error = originalConsoleError;
+    await act(async () => { root.unmount(); });
+    bus.stop();
+    host.remove();
+  }
+});

--- a/src/hooks/runtimeBus.test.ts
+++ b/src/hooks/runtimeBus.test.ts
@@ -389,6 +389,103 @@ describe("runtimeBus reconnect", () => {
   let h: Harness;
   beforeEach(() => (h = harness()));
 
+  test("a persistent runtime-host fault preserves backoff and reaches degraded fallback", async () => {
+    h.bus.start();
+    await flush();
+
+    let faultedSources = 0;
+    for (let elapsed = 0; elapsed < 20_000; elapsed += 100) {
+      const current = h.sources[faultedSources];
+      if (current) {
+        current.open();
+        current.named("fault", { code: "runtime-host-unavailable" });
+        current.error();
+        faultedSources += 1;
+      }
+      h.clock.advance(100);
+      await flush();
+    }
+
+    expect(h.fetchCalls()).toBe(7);
+    expect(h.sources).toHaveLength(6);
+    expect(h.bus.getState().connection).toBe("degraded");
+    expect(h.sources.filter((source) => !source.closed)).toHaveLength(0);
+  });
+
+  test("a named fault followed by EventSource error schedules one reconnect", async () => {
+    h.bus.start();
+    await flush();
+    const first = h.sources[0]!;
+    first.open();
+    first.named("fault", { code: "runtime-host-unavailable" });
+    expect(h.bus.getState().connection).toBe("reconnecting");
+    expect(first.closed).toBeTrue();
+    first.error();
+
+    h.clock.advance(500);
+    await flush();
+
+    expect(h.fetchCalls()).toBe(2);
+    expect(h.sources).toHaveLength(2);
+    expect(h.sources.filter((source) => !source.closed)).toHaveLength(1);
+  });
+
+  test("opening a replacement stream leaves its accumulated failure budget intact", async () => {
+    h.bus.start();
+    await flush();
+    h.sources[0]!.open();
+    h.sources[0]!.error();
+    h.clock.advance(500);
+    await flush();
+
+    h.sources[1]!.open();
+    expect(h.bus.getState().connection).toBe("reconnecting");
+    h.sources[1]!.error();
+    h.clock.advance(500);
+    await flush();
+    expect(h.sources).toHaveLength(2);
+
+    h.clock.advance(500);
+    await flush();
+    expect(h.sources).toHaveLength(3);
+  });
+
+  test("a heartbeat on a replacement stream restores the initial retry budget", async () => {
+    h.bus.start();
+    await flush();
+    h.sources[0]!.open();
+    h.sources[0]!.error();
+    h.clock.advance(500);
+    await flush();
+
+    h.sources[1]!.open();
+    h.sources[1]!.named("heartbeat", { publishedSeq: 100 });
+    h.sources[1]!.error();
+    h.clock.advance(500);
+    await flush();
+
+    expect(h.sources).toHaveLength(3);
+    expect(h.bus.getState().connection).toBe("reconnecting");
+  });
+
+  test("a valid runtime envelope restores health and resumes from its cursor", async () => {
+    h.bus.start();
+    await flush();
+    h.sources[0]!.open();
+    h.sources[0]!.error();
+    h.clock.advance(500);
+    await flush();
+
+    h.sources[1]!.open();
+    h.sources[1]!.message(sessionEvent(101, 2, "running", "t1"));
+    h.sources[1]!.error();
+    h.clock.advance(500);
+    await flush();
+
+    expect(h.sources).toHaveLength(3);
+    expect(h.sources[2]!.url).toContain("after=101");
+  });
+
   test("transport blip refreshes deployment state and resumes from the cursor", async () => {
     h.bus.start();
     await flush();
@@ -404,6 +501,8 @@ describe("runtimeBus reconnect", () => {
     expect(h.sources.length).toBe(2);
     expect(h.sources[1]!.url).toContain("after=101");
     h.sources[1]!.open();
+    expect(h.bus.getState().connection).toBe("reconnecting");
+    h.sources[1]!.named("heartbeat", { publishedSeq: 101 });
     expect(h.bus.getState().connection).toBe("live");
   });
 
@@ -599,9 +698,13 @@ describe("runtimeBus stop", () => {
     h.bus.start();
     await flush();
     h.sources[0]!.open();
+    h.sources[0]!.named("fault", { code: "runtime-host-unavailable" });
     h.bus.stop();
+    h.clock.advance(20_000);
+    await flush();
     expect(h.bus.getState().enabled).toBe(false);
     expect(h.bus.getState().connection).toBe("offline");
     expect(h.sources[0]!.closed).toBe(true);
+    expect(h.sources).toHaveLength(1);
   });
 });

--- a/src/hooks/runtimeBus.test.ts
+++ b/src/hooks/runtimeBus.test.ts
@@ -255,6 +255,134 @@ describe("runtimeBus join", () => {
     expect(s?.activeTurnId).toBe("t1");
     expect(h.bus.getState().store.cursor).toBe(101);
   });
+
+  test("a 128-event replay converges synchronously with one subscriber publication", async () => {
+    h.bus.start();
+    await flush();
+    h.sources[0]!.open();
+    await flush();
+    h.clock.advance(16);
+    await flush();
+
+    let notifications = 0;
+    h.bus.subscribe(() => { notifications += 1; });
+    for (let index = 0; index < 128; index += 1) {
+      h.sources[0]!.message({
+        schemaVersion: 1,
+        seq: 101 + index,
+        eventId: `evt_${101 + index}`,
+        scope: { type: "session", id: "conv_a" },
+        revision: 2 + index,
+        kind: "item",
+        payload: { phase: "delta", text: `token-${index}` },
+      });
+      await Promise.resolve();
+    }
+
+    expect(h.bus.getState().store.cursor).toBe(228);
+    expect(h.bus.getState().store.scopeHeads["session:conv_a"]).toBe(129);
+    expect(notifications).toBe(0);
+    h.clock.advance(16);
+    await flush();
+    expect(notifications).toBe(1);
+  });
+
+  test("Codex and Claude bursts keep one warm SSE join with bounded publications", async () => {
+    const initial = snapshot(100);
+    const codex = initial.sessions[0]!;
+    const claude = {
+      ...codex,
+      conversationId: "conv_b",
+      sessionKey: { engine: "claude" as const, sessionId: "s2" },
+      hostKind: "claude-broker" as const,
+    };
+    h.setSnapshot({ ...initial, sessions: [codex, claude] });
+
+    const warmStartedAt = performance.now();
+    h.bus.start();
+    await flush();
+    expect(performance.now() - warmStartedAt).toBeLessThan(250);
+    expect(h.bus.getState().store.sessions.conv_a?.sessionKey.engine).toBe("codex");
+    expect(h.bus.getState().store.sessions.conv_b?.sessionKey.engine).toBe("claude");
+    h.sources[0]!.open();
+    await flush();
+    h.clock.advance(16);
+    await flush();
+
+    let notifications = 0;
+    let filesNotifications = 0;
+    h.bus.subscribe(() => { notifications += 1; });
+    h.bus.subscribeFilesRevision(() => { filesNotifications += 1; });
+    let seq = 100;
+    for (const conversationId of ["conv_a", "conv_b"]) {
+      for (let index = 0; index < 64; index += 1) {
+        seq += 1;
+        h.sources[0]!.message({
+          schemaVersion: 1,
+          seq,
+          eventId: `evt_${seq}`,
+          scope: { type: "session", id: conversationId },
+          revision: 2 + index,
+          kind: "item",
+          payload: { phase: "delta", text: `token-${conversationId}-${index}` },
+        });
+        await Promise.resolve();
+      }
+    }
+    for (const conversationId of ["conv_a", "conv_b"]) {
+      seq += 1;
+      h.sources[0]!.message({
+        ...sessionEvent(seq, 66, "running", `turn-${conversationId}`),
+        scope: { type: "session", id: conversationId },
+        payload: { conversationId, turnId: `turn-${conversationId}` },
+      });
+    }
+    seq += 1;
+    h.sources[0]!.message({
+      schemaVersion: 1,
+      seq,
+      eventId: `evt_${seq}`,
+      scope: { type: "system", id: "files" },
+      kind: "files.revision",
+      payload: { filesRevision: 7 },
+    });
+    const finalEnvelope = {
+      schemaVersion: 1,
+      seq: ++seq,
+      eventId: `evt_${seq}`,
+      scope: { type: "operation", id: "op-one" },
+      revision: 1,
+      kind: "receipt",
+      payload: {
+        operationId: "op-one",
+        idempotencyKey: "key-one",
+        conversationId: "conv_a",
+        kind: "send",
+        status: "delivered",
+        at: "2026-07-15T00:00:00.000Z",
+        revision: 1,
+      },
+    };
+    h.sources[0]!.message(finalEnvelope);
+    h.sources[0]!.message(finalEnvelope);
+
+    expect(h.bus.getState().store).toMatchObject({
+      cursor: seq,
+      filesRevision: 7,
+      sessions: {
+        conv_a: { turn: "running", revision: 66 },
+        conv_b: { turn: "running", revision: 66 },
+      },
+      operations: { "op-one": { status: "delivered" } },
+    });
+    expect(h.fetchCalls()).toBe(1);
+    expect(h.sources).toHaveLength(1);
+    expect(filesNotifications).toBe(1);
+    expect(notifications).toBe(0);
+    h.clock.advance(16);
+    await flush();
+    expect(notifications).toBe(1);
+  });
 });
 
 describe("runtimeBus reconnect", () => {

--- a/src/hooks/runtimeBus.ts
+++ b/src/hooks/runtimeBus.ts
@@ -170,11 +170,15 @@ export function createRuntimeBus(deps: RuntimeBusDeps): RuntimeBus {
     }, HEARTBEAT_TIMEOUT_MS);
   }
 
-  function markLive(): void {
+  function markOpen(): void {
+    if (firstFailureAt === null && state.connection !== "live") setState({ connection: "live" });
+    armHeartbeat();
+  }
+
+  function confirmHealthy(): void {
     reconnectAttempts = 0;
     firstFailureAt = null;
-    if (state.connection !== "live") setState({ connection: "live" });
-    armHeartbeat();
+    markOpen();
   }
 
   function noteResynced(): void {
@@ -227,7 +231,7 @@ export function createRuntimeBus(deps: RuntimeBusDeps): RuntimeBus {
 
     es.onopen = () => {
       if (myGen !== generation) return;
-      markLive();
+      markOpen();
     };
     es.onmessage = (ev) => {
       if (myGen !== generation) return;
@@ -241,7 +245,17 @@ export function createRuntimeBus(deps: RuntimeBusDeps): RuntimeBus {
     es.addEventListener("heartbeat", () => {
       if (myGen !== generation) return;
       setState({ lastEventAt: deps.now() });
-      markLive();
+      confirmHealthy();
+    });
+    es.addEventListener("fault", (ev) => {
+      if (myGen !== generation) return;
+      try {
+        const fault = JSON.parse(ev.data) as { code?: unknown };
+        if (fault.code !== "runtime-host-unavailable") return;
+      } catch {
+        return;
+      }
+      onTransportLost();
     });
     es.addEventListener("reset", () => {
       if (myGen !== generation) return;
@@ -261,12 +275,12 @@ export function createRuntimeBus(deps: RuntimeBusDeps): RuntimeBus {
     const result = applyEvent(state.store, env);
     if (result.outcome === "applied") {
       setState({ store: result.store });
-      markLive();
+      confirmHealthy();
       if (result.filesBumped) {
         for (const listener of filesListeners) listener(result.store.filesRevision);
       }
     } else if (result.outcome === "duplicate") {
-      markLive();
+      confirmHealthy();
     } else {
       // Revision gap: the reducer never mutated. Resnapshot to converge.
       void join(true);

--- a/src/hooks/runtimeBus.ts
+++ b/src/hooks/runtimeBus.ts
@@ -45,6 +45,8 @@ const SSE_RETRY_MS = 60_000;
 const OFFLINE_AFTER_MS = 60_000;
 /** How long the transient "resynced" note stays up. */
 const RESYNCED_NOTE_MS = 6_000;
+/** Publish accumulated store changes at most once per display frame. */
+const SUBSCRIBER_NOTIFY_MS = 16;
 
 export interface RuntimeBusState {
   store: RuntimeStore;
@@ -103,6 +105,7 @@ export function createRuntimeBus(deps: RuntimeBusDeps): RuntimeBus {
 
   const listeners = new Set<() => void>();
   const filesListeners = new Set<(revision: number) => void>();
+  let emitQueued = false;
 
   let source: EventSourceLike | null = null;
   let generation = 0; // bumps on every teardown so stale callbacks no-op
@@ -121,7 +124,12 @@ export function createRuntimeBus(deps: RuntimeBusDeps): RuntimeBus {
   let fallbackAppliedSerial = 0;
 
   function emit(): void {
-    for (const listener of listeners) listener();
+    if (emitQueued || listeners.size === 0) return;
+    emitQueued = true;
+    deps.setTimeout(() => {
+      emitQueued = false;
+      for (const listener of listeners) listener();
+    }, SUBSCRIBER_NOTIFY_MS);
   }
 
   function setState(patch: Partial<RuntimeBusState>): void {

--- a/src/lib/runtime/sse.test.ts
+++ b/src/lib/runtime/sse.test.ts
@@ -59,3 +59,48 @@ test("SSE resumes from the larger valid query or Last-Event-ID cursor", () => {
   expect(runtimeCursor(null, "7")).toBe(7);
   expect(() => runtimeCursor("bad", null)).toThrow("cursor must be a non-negative sequence");
 });
+
+test("SSE drains a 128-event replay in strict page order on one stream", async () => {
+  const events = Array.from({ length: 128 }, (_, index) => event(index + 1));
+  const waits: number[] = [];
+  const client = {
+    waitEvents: async (after: number) => {
+      waits.push(after);
+      return { reset: false, floorSeq: 0, events: events.slice(after, after + 64) };
+    },
+  } as unknown as RuntimeHostClient;
+  const abort = new AbortController();
+  const reader = runtimeEventStream(client, 0, abort.signal).getReader();
+  const first = new TextDecoder().decode((await reader.read()).value);
+  const second = new TextDecoder().decode((await reader.read()).value);
+  abort.abort();
+  await reader.cancel();
+
+  const ids = `${first}${second}`.match(/^id: (\d+)$/gm)?.map((line) => Number(line.slice(4)));
+  expect(ids).toEqual(Array.from({ length: 128 }, (_, index) => index + 1));
+  expect(waits.slice(0, 2)).toEqual([0, 64]);
+});
+
+test("SSE exposes runtime host failures as a reconnectable fault frame", async () => {
+  const client = {
+    waitEvents: async () => { throw new Error("socket unavailable"); },
+  } as unknown as RuntimeHostClient;
+  const reader = runtimeEventStream(client, 44, new AbortController().signal).getReader();
+  const fault = new TextDecoder().decode((await reader.read()).value);
+  expect(fault).toContain("event: fault");
+  expect(fault).toContain('"code":"runtime-host-unavailable"');
+  expect((await reader.read()).done).toBeTrue();
+});
+
+test("SSE emits a heartbeat while the journal cursor is quiet", async () => {
+  const client = {
+    waitEvents: async () => ({ reset: false, floorSeq: 0, events: [] }),
+  } as unknown as RuntimeHostClient;
+  const abort = new AbortController();
+  const reader = runtimeEventStream(client, 44, abort.signal).getReader();
+  const heartbeat = new TextDecoder().decode((await reader.read()).value);
+  abort.abort();
+  await reader.cancel();
+  expect(heartbeat).toContain("event: heartbeat");
+  expect(heartbeat).toContain('"publishedSeq":44');
+});

--- a/src/runtime-host/journal.test.ts
+++ b/src/runtime-host/journal.test.ts
@@ -900,6 +900,42 @@ test("Unix socket host isolates a singleton writer and serves a fake Viewer clie
   fence.release();
 });
 
+test("concurrent socket replays keep maximum-size command output byte-bounded and advancing", async () => {
+  const dir = sandbox("socket-replay-burst");
+  const socketPath = path.join(dir, "runtime.sock");
+  const journal = new RuntimeJournal(path.join(dir, "events.sqlite"), { maxEvents: 256 });
+  for (let index = 0; index < 128; index += 1) {
+    journal.append({
+      scope: runtimeScope("session", "burst"),
+      kind: "item",
+      payload: { phase: "completed", commandOutput: "x".repeat(15_500), index },
+    });
+  }
+  const server = serveRuntimeHost(socketPath, new RuntimeHost(journal));
+  await new Promise<void>((resolve) => server.once("listening", resolve));
+  const client = new UnixRuntimeHostClient(socketPath);
+
+  const concurrent = await Promise.all(Array.from({ length: 32 }, () => client.waitEvents(0, 1_000)));
+  expect(concurrent.every((replay) => replay.reset === false && replay.events[0]?.seq === 1)).toBeTrue();
+  expect(concurrent.every((replay) => Buffer.byteLength(JSON.stringify(replay.events)) <= 256 * 1024)).toBeTrue();
+
+  let cursor = 0;
+  let pages = 0;
+  while (cursor < 128) {
+    const replay = await client.waitEvents(cursor, 1_000);
+    expect(replay.reset).toBeFalse();
+    expect(replay.events.length).toBeGreaterThan(0);
+    expect(replay.events[0]!.seq).toBe(cursor + 1);
+    cursor = replay.events.at(-1)!.seq;
+    pages += 1;
+  }
+  expect(cursor).toBe(128);
+  expect(pages).toBeGreaterThan(1);
+
+  await new Promise<void>((resolve, reject) => server.close((error) => error ? reject(error) : resolve()));
+  journal.close();
+});
+
 test("structured queue controls cross the local runtime socket", async () => {
   const dir = sandbox("structured-socket");
   const socketPath = path.join(dir, "runtime.sock");


### PR DESCRIPTION
## Summary

- Batch RuntimeBus subscriber publication into a 16 ms window while cursor, revision, and projection state continue to apply immediately.
- Add a React integration/performance gate with a ~477 KiB, 802-session snapshot and mixed Codex/Claude token bursts.
- Lock down 128-event SSE ordering, heartbeat, retention reset, reconnectable fault framing, and Unix replay forward progress.
- Preserve the existing journal payload and replay byte contracts after a 32-waiter maximum-valid command-output probe.

## Diagnosis

The confirmed production cause was synchronous store publication: one runtime envelope emitted for timestamp state and again for applied store state. The strengthened red test measured 128 subscriber notifications for 128 microtask-separated token events. The fix reduced that burst to one publication while final cursor and scope revisions remained synchronous.

The transport-size probe falsified a new framing defect on this baseline. Valid event payloads are capped at 16 KiB, replay pages are capped near 240 KiB, and the client accepts 8 MiB response frames. Thirty-two concurrent waiters replayed 128 maximum-valid command-output events in bounded pages and reached sequence 128.

## Verification

- `bun test`: 2,829 passed across 292 files; 0 failed; 14,986 assertions.
- Focused runtime model/bus/SSE/client/journal gate: 69 passed; 0 failed; 304 assertions.
- React integration gate: 105 ms observed test duration; warm hydration target under 500 ms.
- Burst measurements: 128 events -> 1 general subscriber notification, 1 committed React render, 0 React #185-equivalent errors, 1 snapshot fetch, 1 SSE source.
- Mixed projection gate: 132 unique runtime events plus one duplicate delivery, 1 general notification, 1 files-revision notification, 1 snapshot fetch, 1 SSE source.
- Unix replay probe: 128 maximum-valid command-output events, 32 concurrent waiters, every page <= 256 KiB, continuous progress through sequence 128.
- `bunx tsc --noEmit`: passed.
- Scoped ESLint for all changed files: passed.
- `git diff --check`: passed.
- Components, layout, CSS/styles, public assets, and i18n paths are byte-identical to `34bfd52a79d512b3fe29f097cbee01ee488d3e3f`.
- Final fresh read-only full-diff review: `NO FINDINGS`.

Closes #283