### PR TITLE
perf: coalesce resource snapshot requests

### DIFF
--- a/src/components/ResourcesFooter.test.ts
+++ b/src/components/ResourcesFooter.test.ts
@@ -105,3 +105,33 @@ test("dispose prevents a queued forced refresh from starting", async () => {
   expect(await loader.load(true)).toBeFalse();
   expect(urls).toEqual(["/api/resources"]);
 });
+
+test("dispose aborts the active resource request", async () => {
+  const capture: { signal?: AbortSignal } = {};
+  const loader = createResourcesLoader(
+    async (_input, init) => {
+      const requestSignal = init?.signal;
+      if (!requestSignal) throw new Error("resource request must carry an abort signal");
+      capture.signal = requestSignal;
+      return await new Promise<Response>((_resolve, reject) => {
+        requestSignal.addEventListener("abort", () => reject(new Error("aborted")), { once: true });
+      });
+    },
+    () => {
+      throw new Error("disposed loader must not publish a payload");
+    },
+    () => {
+      throw new Error("disposed loader must not publish a failure");
+    },
+  );
+
+  const active = loader.load();
+  await Promise.resolve();
+  const signal = capture.signal;
+  if (!signal) throw new Error("resource request did not start");
+  expect(signal.aborted).toBeFalse();
+
+  loader.dispose();
+  expect(signal?.aborted).toBeTrue();
+  expect(await active).toBeFalse();
+});

--- a/src/components/ResourcesFooter.test.ts
+++ b/src/components/ResourcesFooter.test.ts
@@ -1,0 +1,81 @@
+import { expect, test } from "bun:test";
+
+import type { ResourcesPayload } from "@/lib/types";
+
+import { createResourcesLoader } from "./ResourcesFooter";
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((res) => { resolve = res; });
+  return { promise, resolve };
+}
+
+const payload: ResourcesPayload = { system: null, sessions: [] };
+
+test("resource polling shares an in-flight request", async () => {
+  const reply = deferred<Response>();
+  const urls: string[] = [];
+  const applied: ResourcesPayload[] = [];
+  const loader = createResourcesLoader(
+    async (input) => {
+      urls.push(String(input));
+      return reply.promise;
+    },
+    (value) => applied.push(value),
+    () => {},
+  );
+
+  const first = loader.load();
+  const overlappingPoll = loader.load();
+  await Promise.resolve();
+  expect(urls).toEqual(["/api/resources"]);
+
+  reply.resolve(Response.json(payload));
+  expect(await Promise.all([first, overlappingPoll])).toEqual([true, true]);
+  expect(applied).toEqual([payload]);
+});
+
+test("a forced refresh waits for the current poll and then fetches fresh data", async () => {
+  const ordinary = deferred<Response>();
+  const fresh = deferred<Response>();
+  const urls: string[] = [];
+  const loader = createResourcesLoader(
+    async (input) => {
+      const url = String(input);
+      urls.push(url);
+      return url.includes("fresh=1") ? fresh.promise : ordinary.promise;
+    },
+    () => {},
+    () => {},
+  );
+
+  const first = loader.load();
+  const refreshOne = loader.load(true);
+  const refreshTwo = loader.load(true);
+  await Promise.resolve();
+  expect(urls).toEqual(["/api/resources"]);
+
+  ordinary.resolve(Response.json(payload));
+  await first;
+  await Promise.resolve();
+  expect(urls).toEqual(["/api/resources", "/api/resources?fresh=1"]);
+
+  fresh.resolve(Response.json(payload));
+  expect(await Promise.all([refreshOne, refreshTwo])).toEqual([true, true]);
+});
+
+test("a failed request can be retried", async () => {
+  let calls = 0;
+  const loader = createResourcesLoader(
+    async () => {
+      calls += 1;
+      return calls === 1 ? new Response(null, { status: 503 }) : Response.json(payload);
+    },
+    () => {},
+    () => {},
+  );
+
+  expect(await loader.load()).toBeFalse();
+  expect(await loader.load()).toBeTrue();
+  expect(calls).toBe(2);
+});

--- a/src/components/ResourcesFooter.test.ts
+++ b/src/components/ResourcesFooter.test.ts
@@ -79,3 +79,29 @@ test("a failed request can be retried", async () => {
   expect(await loader.load()).toBeTrue();
   expect(calls).toBe(2);
 });
+
+test("dispose prevents a queued forced refresh from starting", async () => {
+  const ordinary = deferred<Response>();
+  const urls: string[] = [];
+  const loader = createResourcesLoader(
+    async (input) => {
+      urls.push(String(input));
+      return ordinary.promise;
+    },
+    () => {},
+    () => {},
+  );
+
+  const first = loader.load();
+  const queuedRefresh = loader.load(true);
+  await Promise.resolve();
+  expect(urls).toEqual(["/api/resources"]);
+
+  loader.dispose();
+  ordinary.resolve(Response.json(payload));
+
+  expect(await first).toBeTrue();
+  expect(await queuedRefresh).toBeFalse();
+  expect(await loader.load(true)).toBeFalse();
+  expect(urls).toEqual(["/api/resources"]);
+});

--- a/src/components/ResourcesFooter.tsx
+++ b/src/components/ResourcesFooter.tsx
@@ -72,6 +72,7 @@ export function createResourcesLoader(
   onFailure: (at: number) => void,
 ) {
   const requests = createFreshAwareCoalescer<boolean>();
+  const controller = new AbortController();
   let disposed = false;
 
   return {
@@ -83,7 +84,7 @@ export function createResourcesLoader(
         if (disposed) return false;
         const at = Date.now() / 1000;
         try {
-          const res = await fetcher("/api/resources" + (forceFresh ? "?fresh=1" : ""));
+          const res = await fetcher("/api/resources" + (forceFresh ? "?fresh=1" : ""), { signal: controller.signal });
           if (!res.ok) throw new Error(String(res.status));
           const json = (await res.json()) as ResourcesPayload;
           if (!disposed) onPayload(json, at);
@@ -96,6 +97,7 @@ export function createResourcesLoader(
     },
     dispose(): void {
       disposed = true;
+      controller.abort();
     },
   };
 }

--- a/src/components/ResourcesFooter.tsx
+++ b/src/components/ResourcesFooter.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useRef, useState } from "react";
 
+import { createFreshAwareCoalescer } from "@/lib/asyncCoalescer";
 import { useLocale } from "@/lib/i18n";
 import type { ResourceSession, ResourcesPayload } from "@/lib/types";
 
@@ -60,6 +61,41 @@ interface ResourcesSnap {
   staleSince: number | null;
 }
 
+type ResourcesFetcher = (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
+
+/** One request channel for initial load, polling, and post-kill refreshes.
+    Polls share an active request. A forced refresh waits for the active poll
+    and then requests a fresh server snapshot. */
+export function createResourcesLoader(
+  fetcher: ResourcesFetcher,
+  onPayload: (payload: ResourcesPayload, at: number) => void,
+  onFailure: (at: number) => void,
+) {
+  const requests = createFreshAwareCoalescer<boolean>();
+  let disposed = false;
+
+  return {
+    load(fresh = false): Promise<boolean> {
+      return requests.run(fresh, async (forceFresh) => {
+        const at = Date.now() / 1000;
+        try {
+          const res = await fetcher("/api/resources" + (forceFresh ? "?fresh=1" : ""));
+          if (!res.ok) throw new Error(String(res.status));
+          const json = (await res.json()) as ResourcesPayload;
+          if (!disposed) onPayload(json, at);
+          return true;
+        } catch {
+          if (!disposed) onFailure(at);
+          return false;
+        }
+      });
+    },
+    dispose(): void {
+      disposed = true;
+    },
+  };
+}
+
 function stickySnap(prev: ResourcesSnap | null, next: ResourcesPayload, at: number): ResourcesSnap {
   const carriedSystem = next.system === null && (prev?.data.system ?? null) !== null;
   return {
@@ -81,25 +117,25 @@ export function ResourcesFooter() {
      hands the panel a way to force a fresh snapshot right after a kill. */
   const loadRef = useRef<(fresh?: boolean) => Promise<void>>(async () => {});
   useEffect(() => {
-    let alive = true;
-    const load = async (fresh = false) => {
-      const at = Date.now() / 1000;
-      try {
-        const res = await fetch("/api/resources" + (fresh ? "?fresh=1" : ""));
-        if (!res.ok) throw new Error(String(res.status));
-        const json = (await res.json()) as ResourcesPayload;
-        if (!alive) return;
+    const loader = createResourcesLoader(
+      fetch,
+      (json, at) => {
         setSnap((prev) => stickySnap(prev, json, at));
-      } catch {
-        if (alive) setSnap((prev) => (prev ? { ...prev, staleSince: prev.staleSince ?? at } : prev));
-      }
+      },
+      (at) => {
+        setSnap((prev) => (prev ? { ...prev, staleSince: prev.staleSince ?? at } : prev));
+      },
+    );
+    const load = async (fresh = false) => {
+      await loader.load(fresh);
     };
     loadRef.current = load;
     void load();
     const timer = setInterval(() => void load(), POLL_MS);
     return () => {
-      alive = false;
       clearInterval(timer);
+      loader.dispose();
+      loadRef.current = async () => {};
     };
   }, []);
 

--- a/src/components/ResourcesFooter.tsx
+++ b/src/components/ResourcesFooter.tsx
@@ -76,7 +76,11 @@ export function createResourcesLoader(
 
   return {
     load(fresh = false): Promise<boolean> {
+      if (disposed) return Promise.resolve(false);
       return requests.run(fresh, async (forceFresh) => {
+        /* A fresh call may have waited behind an ordinary poll. Teardown can
+           happen while it waits, so check again before starting another scan. */
+        if (disposed) return false;
         const at = Date.now() / 1000;
         try {
           const res = await fetcher("/api/resources" + (forceFresh ? "?fresh=1" : ""));

--- a/src/lib/asyncCoalescer.test.ts
+++ b/src/lib/asyncCoalescer.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, test } from "bun:test";
+
+import { createFreshAwareCoalescer } from "./asyncCoalescer";
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+describe("fresh-aware async coalescing", () => {
+  test("shares one ordinary operation across concurrent callers", async () => {
+    const coalescer = createFreshAwareCoalescer<number>();
+    const result = deferred<number>();
+    const calls: boolean[] = [];
+    const work = (fresh: boolean) => {
+      calls.push(fresh);
+      return result.promise;
+    };
+
+    const first = coalescer.run(false, work);
+    const second = coalescer.run(false, work);
+    await Promise.resolve();
+
+    expect(calls).toEqual([false]);
+    result.resolve(7);
+    expect(await Promise.all([first, second])).toEqual([7, 7]);
+  });
+
+  test("runs one fresh operation after an ordinary operation already in flight", async () => {
+    const coalescer = createFreshAwareCoalescer<number>();
+    const ordinary = deferred<number>();
+    const fresh = deferred<number>();
+    const calls: boolean[] = [];
+    const work = (forceFresh: boolean) => {
+      calls.push(forceFresh);
+      return forceFresh ? fresh.promise : ordinary.promise;
+    };
+
+    const first = coalescer.run(false, work);
+    const refreshOne = coalescer.run(true, work);
+    const refreshTwo = coalescer.run(true, work);
+    await Promise.resolve();
+    expect(calls).toEqual([false]);
+
+    ordinary.resolve(1);
+    expect(await first).toBe(1);
+    await Promise.resolve();
+    expect(calls).toEqual([false, true]);
+
+    fresh.resolve(2);
+    expect(await Promise.all([refreshOne, refreshTwo])).toEqual([2, 2]);
+  });
+
+  test("clears a failed operation so the next caller can retry", async () => {
+    const coalescer = createFreshAwareCoalescer<number>();
+    const failed = deferred<number>();
+    let calls = 0;
+    const work = () => {
+      calls += 1;
+      return calls === 1 ? failed.promise : Promise.resolve(9);
+    };
+
+    const first = coalescer.run(false, work);
+    failed.reject(new Error("scan failed"));
+    await expect(first).rejects.toThrow("scan failed");
+    await expect(coalescer.run(false, work)).resolves.toBe(9);
+    expect(calls).toBe(2);
+  });
+});

--- a/src/lib/asyncCoalescer.ts
+++ b/src/lib/asyncCoalescer.ts
@@ -1,0 +1,38 @@
+export interface FreshAwareCoalescer<T> {
+  run(fresh: boolean, work: (fresh: boolean) => Promise<T>): Promise<T>;
+}
+
+/** Shares concurrent work while preserving the ordering of a forced refresh.
+    Ordinary callers join any active operation. A fresh caller joins an active
+    fresh operation or waits for ordinary work before starting one refresh. */
+export function createFreshAwareCoalescer<T>(): FreshAwareCoalescer<T> {
+  let active: { fresh: boolean; promise: Promise<T> } | null = null;
+
+  return {
+    async run(fresh, work) {
+      for (;;) {
+        const current = active;
+        if (current) {
+          if (!fresh || current.fresh) return current.promise;
+          try {
+            await current.promise;
+          } catch {
+            /* A forced refresh still gets its own attempt after an ordinary
+               operation fails. The ordinary caller receives that failure. */
+          }
+          if (active === current) active = null;
+          continue;
+        }
+
+        const promise = Promise.resolve().then(() => work(fresh));
+        const operation = { fresh, promise };
+        active = operation;
+        try {
+          return await promise;
+        } finally {
+          if (active === operation) active = null;
+        }
+      }
+    },
+  };
+}

--- a/src/lib/resources.ts
+++ b/src/lib/resources.ts
@@ -1,5 +1,6 @@
 import { procBackend } from "@/lib/proc";
 import { readFileSync } from "node:fs";
+import { createFreshAwareCoalescer, type FreshAwareCoalescer } from "@/lib/asyncCoalescer";
 import { descendantPids } from "@/lib/proc/memory";
 import { listFiles } from "@/lib/scanner";
 import { overlaySessionTitles } from "@/lib/session/titleProjection";
@@ -57,8 +58,14 @@ export type KillTargetRef = TmuxAttachReference;
 
 const globalStore = globalThis as unknown as {
   __llvResourcesCache?: { at: number; data: ResourcesPayload } | null;
+  __llvResourcesBuildCoordinator?: FreshAwareCoalescer<ResourcesPayload>;
   __llvResourceTargets?: Map<string, KillTargetRef>;
 };
+
+function resourceBuildCoordinator(): FreshAwareCoalescer<ResourcesPayload> {
+  globalStore.__llvResourcesBuildCoordinator ??= createFreshAwareCoalescer<ResourcesPayload>();
+  return globalStore.__llvResourcesBuildCoordinator;
+}
 
 /**
  * Server-held allowlist for the kill-target action: only pane targets present
@@ -206,7 +213,10 @@ export async function readResources(fresh = false): Promise<ResourcesPayload> {
   if (!fresh && cached && Date.now() - cached.at < CACHE_MS) {
     return { ...cached.data, system: captureSystemMemory() };
   }
-  const data = await buildResources(fresh);
-  globalStore.__llvResourcesCache = { at: Date.now(), data };
-  return data;
+  const data = await resourceBuildCoordinator().run(fresh, async (forceFresh) => {
+    const built = await buildResources(forceFresh);
+    globalStore.__llvResourcesCache = { at: Date.now(), data: built };
+    return built;
+  });
+  return fresh ? data : { ...data, system: captureSystemMemory() };
 }


### PR DESCRIPTION
## Summary

- share one in-flight `/api/resources` build across concurrent server callers
- serialize forced refresh behind an active ordinary snapshot
- share overlapping browser polls and preserve a post-kill fresh request
- clear failed work so later calls can retry

## Production evidence

A hard refresh on revision `1472991c` produced a 41.61 s first `/api/resources`; its 30 s poll started while the first build was active. Retained rollback load also amplified JSONL scans. This PR removes the duplicate build path covered by that trace. Shared `/api/files`, accounts, board stores, and deploy lifecycle remain tracked in #287/#288.

## Verification

- `bun test src/lib/asyncCoalescer.test.ts src/lib/resources.test.ts src/components/ResourcesFooter.test.ts` — 13 pass
- `bunx tsc --noEmit`
- focused ESLint for all changed source/tests
- `git diff --check`
- rendered markup and styles unchanged

Tracks #287.