### PR TITLE
Share transcript scans with resource snapshots (#287 phase 2)

### DIFF
--- a/src/app/api/files/route.test.ts
+++ b/src/app/api/files/route.test.ts
@@ -100,7 +100,7 @@ afterAll(() => {
   for (const [name, real] of realModules) mock.module(name, () => real as Record<string, unknown>);
 });
 
-const { cachedFileScan, resetFilesRouteCacheForTests } = await import("./scanCache");
+const { cachedFileScan, currentFileScan, resetFilesRouteCacheForTests } = await import("@/lib/scanner/scanCache");
 const { GET } = await import("./route");
 
 test("repeated files reads reuse the pure read snapshot and retain ETag behavior", async () => {
@@ -164,6 +164,37 @@ test("a restart serves the persisted completed snapshot while revalidating", asy
   await new Promise<void>((resolve) => setImmediate(resolve));
   const next = await cachedFileScan();
   expect(next.snapshot.files.map((entry) => entry.path)).toEqual(["/sessions/refreshed.jsonl"]);
+});
+
+test("a current scan joins restart revalidation before publishing transcript metadata", async () => {
+  fs.writeFileSync(path.join(stateDir, "files-scan-snapshot.json"), JSON.stringify({
+    version: 1,
+    snapshot: {
+      files: [file("/sessions/persisted-resource.jsonl")],
+      projectCatalog: [],
+      complete: true,
+    },
+  }));
+  resetFilesRouteCacheForTests();
+  let release!: () => void;
+  scanGates.push(new Promise<void>((resolve) => { release = resolve; }));
+  scannedFiles = [file("/sessions/current-resource.jsonl")];
+
+  const stale = await cachedFileScan();
+  expect(stale.snapshot.files.map((entry) => entry.path)).toEqual(["/sessions/persisted-resource.jsonl"]);
+
+  let settled = false;
+  const current = currentFileScan().then((scan) => {
+    settled = true;
+    return scan;
+  });
+
+  expect(scans).toBe(1);
+  expect(settled).toBeFalse();
+
+  release();
+  expect((await current).snapshot.files.map((entry) => entry.path)).toEqual(["/sessions/current-resource.jsonl"]);
+  expect(scans).toBe(1);
 });
 
 test("a client automatically converges from a persisted restart snapshot to its completed generation", async () => {

--- a/src/app/api/files/route.test.ts
+++ b/src/app/api/files/route.test.ts
@@ -46,17 +46,15 @@ beforeEach(() => {
 afterEach(() => {
   setAgentRegistryForTests(null);
   replaceConversationCatalog([]);
+  noteSessionTargets([]);
   if (previousState === undefined) delete process.env.LLV_STATE_DIR;
   else process.env.LLV_STATE_DIR = previousState;
   fs.rmSync(registryRoot, { recursive: true, force: true });
   fs.rmSync(stateDir, { recursive: true, force: true });
 });
 
-/* `mock.module` is process-global and outlives this file, so any suite that runs
-   afterward and imports one of these modules would otherwise see the stub — e.g.
-   the mocked `@/lib/tmux` drops the named exports `provider.ts` imports, which
-   crashes an unrelated migration suite. Capture the real namespaces first and
-   restore them in afterAll so the leak is contained to this file. */
+/* `mock.module` is process-global and outlives this file. Capture the real
+   namespaces first and restore them in afterAll so the stubs stay local. */
 const MOCKED_MODULES = [
   "@/lib/scanner",
   "@/lib/flows/store",
@@ -94,13 +92,17 @@ mock.module("@/lib/tasks/store", () => ({
 }));
 mock.module("@/lib/workflows/store", () => ({ loadWorkflows: () => [] }));
 mock.module("@/lib/workflows/visibility", () => ({ filterWorkflowsForFileScan: () => [] }));
-mock.module("@/lib/tmux", () => ({ tmuxEndpointHealth: () => tmuxHealth }));
+mock.module("@/lib/tmux", () => ({
+  ...(realModules.get("@/lib/tmux") as Record<string, unknown>),
+  tmuxEndpointHealth: () => tmuxHealth,
+}));
 
 afterAll(() => {
   for (const [name, real] of realModules) mock.module(name, () => real as Record<string, unknown>);
 });
 
 const { cachedFileScan, currentFileScan, resetFilesRouteCacheForTests } = await import("@/lib/scanner/scanCache");
+const { allowedKillTarget, buildResourceSnapshot, noteSessionTargets } = await import("@/lib/resources");
 const { GET } = await import("./route");
 
 test("repeated files reads reuse the pure read snapshot and retain ETag behavior", async () => {
@@ -195,6 +197,101 @@ test("a current scan joins restart revalidation before publishing transcript met
   release();
   expect((await current).snapshot.files.map((entry) => entry.path)).toEqual(["/sessions/current-resource.jsonl"]);
   expect(scans).toBe(1);
+});
+
+test("a fresh resource snapshot fences a pre-kill refresh before host election", async () => {
+  const now = Date.now();
+  const before = { ...file("/sessions/resource-before.jsonl"), title: "Before kill", activity: "idle" as const };
+  const after = { ...file("/sessions/resource-after.jsonl"), title: "After kill", activity: "recent" as const, mtime: 2 };
+  scannedFiles = [before];
+
+  const warm = await cachedFileScan(undefined, undefined, now);
+  expect(warm.snapshot.files.map((entry) => entry.path)).toEqual([before.path]);
+  let releasePreKillRefresh!: () => void;
+  scanGates.push(new Promise<void>((resolve) => { releasePreKillRefresh = resolve; }));
+  const revalidating = await cachedFileScan(undefined, undefined, now + 10_000);
+  expect(revalidating.snapshot.files.map((entry) => entry.path)).toEqual([before.path]);
+  expect(scans).toBe(2);
+
+  scannedFiles = [after];
+  let releasePostKillRefresh!: () => void;
+  scanGates.push(new Promise<void>((resolve) => { releasePostKillRefresh = resolve; }));
+
+  let filesFresh: boolean | undefined;
+  let hostEntries: FileEntry[] = [];
+  let resourceSettled = false;
+  const resourceRef = {
+    tmuxServerPid: 900,
+    tmuxServerStartIdentity: "900:one",
+    panePid: 100,
+    paneStartIdentity: "100:one",
+    paneId: "%1",
+  };
+  const payloadPromise = buildResourceSnapshot(true, {
+    readFiles: async (fresh) => {
+      filesFresh = fresh;
+      return (await currentFileScan({ fresh, now })).snapshot.files;
+    },
+    readHosts: async (_fresh, entries) => {
+      hostEntries = entries;
+      const selected = entries[0]!;
+      const target = selected.path === after.path ? "agents:after" : "agents:before";
+      const host = {
+        tmuxServerPid: 900,
+        paneId: "%1",
+        panePid: 100,
+        agentPid: 200,
+        display: target,
+        engine: "codex" as const,
+        cwd: "/repo",
+        agentArgv: ["codex", "resume", selected.path],
+        agentIdentity: "200:one",
+        launchId: null,
+        claimedPaths: [selected.path],
+        primaryPath: selected.path,
+      };
+      return {
+        hosts: [host],
+        observation: "available" as const,
+        conflicts: [],
+        canonicalFor: (pathname: string) => pathname === selected.path ? host : null,
+      };
+    },
+    proc: {
+      systemMemory: () => null,
+      ppidMap: () => new Map([[200, 100]]),
+      processMemory: () => new Map([[100, { rssBytes: 10, swapBytes: 0 }], [200, { rssBytes: 20, swapBytes: 0 }]]),
+    },
+    captureAttachReference: () => resourceRef,
+  }).then((payload) => {
+    resourceSettled = true;
+    return payload;
+  });
+
+  expect(filesFresh).toBeTrue();
+  expect(scans).toBe(2);
+  expect(resourceSettled).toBeFalse();
+
+  releasePreKillRefresh();
+  for (let attempt = 0; attempt < 100 && scans < 3; attempt += 1) {
+    await new Promise<void>((resolve) => setImmediate(resolve));
+  }
+  expect(scans).toBe(3);
+  expect(resourceSettled).toBeFalse();
+
+  releasePostKillRefresh();
+  const payload = await payloadPromise;
+  expect(scans).toBe(3);
+  expect(hostEntries.map((entry) => entry.path)).toEqual([after.path]);
+  expect(payload.sessions).toEqual([expect.objectContaining({
+    target: "agents:after",
+    path: after.path,
+    title: "After kill",
+    activity: "recent",
+    lastActiveAt: "1970-01-01T00:00:02.000Z",
+  })]);
+  expect(allowedKillTarget("agents:after")).toEqual(resourceRef);
+  expect(allowedKillTarget("agents:before")).toBeNull();
 });
 
 test("a client automatically converges from a persisted restart snapshot to its completed generation", async () => {

--- a/src/app/api/files/route.test.ts
+++ b/src/app/api/files/route.test.ts
@@ -19,6 +19,7 @@ let scanFileResults: FileEntry[][] = [];
 let scanPinOverlayResults: Array<string[] | undefined> = [];
 let scanCompleteResults: Array<boolean | undefined> = [];
 let scanGates: Promise<void>[] = [];
+let hydrateScannedFiles: (files: FileEntry[], options: unknown) => FileEntry[] = (files) => files;
 let registryRoot = "";
 let tmuxHealth: unknown = { status: "healthy" };
 let stateDir = "";
@@ -39,6 +40,7 @@ beforeEach(() => {
   scanPinOverlayResults = [];
   scanCompleteResults = [];
   scanGates = [];
+  hydrateScannedFiles = (files) => files;
   tmuxHealth = { status: "healthy" };
   replaceConversationCatalog([]);
 });
@@ -75,7 +77,7 @@ mock.module("@/lib/scanner", () => ({
     scans += 1;
     scanProjects.push(project);
     scanOptions = options;
-    const files = scanFileResults.shift() ?? scannedFiles;
+    const files = hydrateScannedFiles(scanFileResults.shift() ?? scannedFiles, options);
     await scanGates.shift();
     const pinOverlayPaths = scanPinOverlayResults.shift();
     const complete = scanCompleteResults.shift();
@@ -292,6 +294,122 @@ test("a fresh resource snapshot fences a pre-kill refresh before host election",
   })]);
   expect(allowedKillTarget("agents:after")).toEqual(resourceRef);
   expect(allowedKillTarget("agents:before")).toBeNull();
+});
+
+test("a fresh resource snapshot replaces stale process and pane observations before host reconciliation", async () => {
+  const sessionId = "199e8e95-0e87-4b4f-84bf-f62b3c0993a3";
+  const pathname = `/home/user/.claude/projects/-repo/${sessionId}.jsonl`;
+  const transcript = {
+    ...file(pathname),
+    root: "claude-projects" as const,
+    engine: "claude" as const,
+    fmt: "claude" as const,
+    title: "Plain Claude CLI",
+    activity: "live" as const,
+    mtime: 2,
+  };
+  const oldCli = { agentPid: 200, panePid: 100, paneId: "%1", target: "agents:old" };
+  const newCli = { agentPid: 201, panePid: 101, paneId: "%2", target: "agents:new" };
+  let processMemo = oldCli;
+  let paneMemo = oldCli;
+  const liveProcess = newCli;
+  const livePane = newCli;
+  scannedFiles = [transcript];
+  hydrateScannedFiles = (files, options) => {
+    if ((options as { fresh?: boolean }).fresh === true) {
+      processMemo = liveProcess;
+      paneMemo = livePane;
+    }
+    const owner = processMemo.agentPid === paneMemo.agentPid && processMemo.panePid === paneMemo.panePid
+      ? processMemo
+      : null;
+    return files.map((entry) => ({
+      ...entry,
+      pid: owner?.agentPid ?? null,
+      proc: owner ? "running" as const : null,
+    }));
+  };
+
+  const registry = agentRegistry();
+  const key = { engine: "claude" as const, sessionId };
+  registry.upsert({
+    key,
+    artifactPath: pathname,
+    cwd: "/repo",
+    accountId: null,
+    launchProfile: emptyLaunchProfile({ cwd: "/repo" }),
+    status: "live",
+    host: null,
+    claimEpoch: 0,
+    claimOwner: null,
+    pendingAction: null,
+  });
+
+  const resourceRef = {
+    tmuxServerPid: 900,
+    tmuxServerStartIdentity: "900:one",
+    panePid: newCli.panePid,
+    paneStartIdentity: `${newCli.panePid}:one`,
+    paneId: newCli.paneId,
+  };
+  const payload = await buildResourceSnapshot(true, {
+    readFiles: async (fresh) => (await currentFileScan({ fresh })).snapshot.files,
+    readHosts: async (fresh, entries) => {
+      if (fresh) {
+        processMemo = liveProcess;
+        paneMemo = livePane;
+      }
+      const primaryPath = entries.find((entry) => entry.pid === processMemo.agentPid)?.path ?? null;
+      const host = {
+        tmuxServerPid: 900,
+        paneId: paneMemo.paneId,
+        panePid: paneMemo.panePid,
+        agentPid: processMemo.agentPid,
+        display: paneMemo.target,
+        engine: "claude" as const,
+        cwd: "/repo",
+        agentArgv: ["claude"],
+        agentIdentity: `${processMemo.agentPid}:one`,
+        launchId: null,
+        claimedPaths: primaryPath ? [primaryPath] : [],
+        primaryPath,
+      };
+      if (primaryPath) {
+        const current = registry.snapshot().entries[`claude:${sessionId}`]!;
+        registry.upsert({ ...current, artifactPath: primaryPath, status: "live" });
+      } else {
+        registry.markUnhosted(key);
+      }
+      return {
+        hosts: [host],
+        observation: "available" as const,
+        conflicts: [],
+        canonicalFor: (candidate: string) => candidate === primaryPath ? host : null,
+      };
+    },
+    proc: {
+      systemMemory: () => null,
+      ppidMap: () => new Map([[newCli.agentPid, newCli.panePid]]),
+      processMemory: () => new Map([
+        [newCli.panePid, { rssBytes: 10, swapBytes: 0 }],
+        [newCli.agentPid, { rssBytes: 20, swapBytes: 0 }],
+      ]),
+    },
+    captureAttachReference: () => resourceRef,
+  });
+
+  expect(scans).toBe(1);
+  expect(payload.sessions).toEqual([expect.objectContaining({
+    target: newCli.target,
+    path: pathname,
+    title: "Plain Claude CLI",
+    activity: "live",
+    lastActiveAt: "1970-01-01T00:00:02.000Z",
+  })]);
+  expect(registry.snapshot().entries[`claude:${sessionId}`]).toMatchObject({
+    artifactPath: pathname,
+    status: "live",
+  });
 });
 
 test("a client automatically converges from a persisted restart snapshot to its completed generation", async () => {

--- a/src/app/api/files/route.test.ts
+++ b/src/app/api/files/route.test.ts
@@ -201,6 +201,85 @@ test("a current scan joins restart revalidation before publishing transcript met
   expect(scans).toBe(1);
 });
 
+test("concurrent fresh callers share one pending generation through failure and retry", async () => {
+  const now = Date.now();
+  const before = file("/sessions/shared-fresh-before.jsonl");
+  const after = file("/sessions/shared-fresh-after.jsonl");
+  const freshFlags: boolean[] = [];
+  hydrateScannedFiles = (files, options) => {
+    freshFlags.push((options as { fresh?: boolean }).fresh === true);
+    return files;
+  };
+  scannedFiles = [before];
+
+  await cachedFileScan(undefined, undefined, now);
+  let releaseOld!: () => void;
+  let releaseFresh!: () => void;
+  scanGates.push(
+    new Promise<void>((resolve) => { releaseOld = resolve; }),
+    new Promise<void>((resolve) => { releaseFresh = resolve; }),
+  );
+  await cachedFileScan(undefined, undefined, now + 10_000);
+  scannedFiles = [after];
+
+  let firstSettled = false;
+  let secondSettled = false;
+  const first = currentFileScan({ fresh: true }).then((scan) => {
+    firstSettled = true;
+    return scan;
+  });
+  const second = currentFileScan({ fresh: true }).then((scan) => {
+    secondSettled = true;
+    return scan;
+  });
+
+  releaseOld();
+  for (let attempt = 0; attempt < 100 && scans < 3; attempt += 1) {
+    await new Promise<void>((resolve) => setImmediate(resolve));
+  }
+  expect(scans).toBe(3);
+  expect(firstSettled).toBeFalse();
+  expect(secondSettled).toBeFalse();
+
+  releaseFresh();
+  const [firstFresh, secondFresh] = await Promise.all([first, second]);
+  expect(firstFresh.snapshot.files.map((entry) => entry.path)).toEqual([after.path]);
+  expect(secondFresh.snapshot.files.map((entry) => entry.path)).toEqual([after.path]);
+  expect(freshFlags).toEqual([false, false, true]);
+  expect(scans).toBe(3);
+
+  scanCompleteResults = [false];
+  await expect(currentFileScan({ fresh: true })).rejects.toThrow("filesystem scan incomplete");
+  const scansAfterFailure = scans;
+  expect(freshFlags.at(-1)).toBeTrue();
+
+  let releaseRetry!: () => void;
+  scanGates.push(new Promise<void>((resolve) => { releaseRetry = resolve; }));
+  let firstRetrySettled = false;
+  let secondRetrySettled = false;
+  const firstRetry = currentFileScan({ fresh: true }).then((scan) => {
+    firstRetrySettled = true;
+    return scan;
+  });
+  const secondRetry = currentFileScan({ fresh: true }).then((scan) => {
+    secondRetrySettled = true;
+    return scan;
+  });
+
+  expect(scans).toBe(scansAfterFailure + 1);
+  expect(firstRetrySettled).toBeFalse();
+  expect(secondRetrySettled).toBeFalse();
+  releaseRetry();
+  const [firstRecovered, secondRecovered] = await Promise.all([firstRetry, secondRetry]);
+  expect(firstRecovered.generation).toBe(secondRecovered.generation);
+  expect(scans).toBe(scansAfterFailure + 1);
+  expect(freshFlags).toEqual([false, false, true, true, true]);
+
+  const scansAfterRecovery = scans;
+  await currentFileScan();
+  expect(scans).toBe(scansAfterRecovery);
+});
+
 test("a fresh resource snapshot fences a pre-kill refresh before host election", async () => {
   const now = Date.now();
   const before = { ...file("/sessions/resource-before.jsonl"), title: "Before kill", activity: "idle" as const };

--- a/src/app/api/files/route.ts
+++ b/src/app/api/files/route.ts
@@ -1,5 +1,5 @@
 import { buildFilesResponse } from "./response";
-import { cachedFileScan } from "./scanCache";
+import { cachedFileScan } from "@/lib/scanner/scanCache";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";

--- a/src/app/api/files/scanCache.real.test.ts
+++ b/src/app/api/files/scanCache.real.test.ts
@@ -18,7 +18,7 @@ fs.mkdirSync(sessions, { recursive: true });
 
 const { listFilesWithProjectCatalog } = await import("@/lib/scanner");
 const { ROOTS } = await import("@/lib/scanner/roots");
-const { cachedFileScan, resetFilesRouteCacheForTests } = await import("./scanCache");
+const { cachedFileScan, resetFilesRouteCacheForTests } = await import("@/lib/scanner/scanCache");
 
 function writeSession(filename: string, cwd: string): string {
   const pathname = path.join(sessions, filename);

--- a/src/app/api/tmux/route.test.ts
+++ b/src/app/api/tmux/route.test.ts
@@ -6,6 +6,7 @@ import { afterAll, expect, mock, test } from "bun:test";
 
 import { NextRequest } from "next/server";
 
+const realResources = { ...(await import("@/lib/resources")) };
 const previousCodexHome = process.env.LLV_CODEX_HOME;
 const routeCodexHome = fs.mkdtempSync(path.join(os.tmpdir(), "llv-tmux-route-codex-"));
 const PATHNAME = path.join(routeCodexHome, "sessions", "rollout-019f4906-3f67-7b72-9fbc-9ec3b5ad1326.jsonl");
@@ -16,6 +17,7 @@ afterAll(() => {
   if (previousCodexHome === undefined) delete process.env.LLV_CODEX_HOME;
   else process.env.LLV_CODEX_HOME = previousCodexHome;
   fs.rmSync(routeCodexHome, { recursive: true, force: true });
+  mock.module("@/lib/resources", () => realResources);
 });
 
 let transcriptReads = 0;
@@ -97,8 +99,13 @@ mock.module("@/lib/delivery", () => ({
   resumeConversation: async () => ({ ok: true, target: "" }),
 }));
 mock.module("@/lib/resources", () => ({
-  allowedKillTarget: (target: string) => (target === "agents:9.0" ? resourceTarget : null),
-  consumeKillTarget: () => {},
+  ...realResources,
+  allowedKillTarget: (target: string) => target === "agents:9.0"
+    ? resourceTarget
+    : realResources.allowedKillTarget(target),
+  consumeKillTarget: (target: string) => {
+    if (target !== "agents:9.0") realResources.consumeKillTarget(target);
+  },
 }));
 mock.module("@/lib/tmux", () => ({
   captureTmuxAttachReference: (value: Record<string, unknown>) => ({ ...value, tmuxServerStartIdentity: "900:one", paneStartIdentity: "100:one" }),

--- a/src/lib/agent/transcriptHost.test.ts
+++ b/src/lib/agent/transcriptHost.test.ts
@@ -94,6 +94,7 @@ interface FakeHostState {
   launchId: string | null;
   resumeBegan: boolean;
   quarantineAfterResumeBegin: boolean;
+  listFileReads: number;
 }
 
 function fakeHost(
@@ -127,10 +128,14 @@ function fakeHost(
     launchId: null,
     resumeBegan: false,
     quarantineAfterResumeBegin: false,
+    listFileReads: 0,
   };
 
   const resolver = createTranscriptHostResolver({
-    listFiles: async () => [state.entry],
+    listFiles: async () => {
+      state.listFileReads += 1;
+      return [state.entry];
+    },
     panes: async () => {
       if (state.paneObservation === "failure") return { kind: "failure" as const, error: state.paneObservationError };
       if (state.paneObservation === "no-server") return { kind: "no-server" as const };
@@ -201,6 +206,17 @@ function fakeHost(
 }
 
 describe("transcript host resolver", () => {
+  test("elects canonical ownership from a supplied transcript snapshot without another scan", async () => {
+    const { resolver, state } = fakeHost();
+    const supplied = [{ ...state.entry, title: "Current resource title", activity: "recent" as const }];
+
+    const snapshot = await resolver.readTranscriptHosts(true, supplied);
+
+    expect(snapshot.canonicalFor(PATHNAME)?.display).toBe("agents:4.0");
+    expect(snapshot.conflicts).toEqual([]);
+    expect(state.listFileReads).toBe(0);
+  });
+
   test("carries the pane launch marker into observation reconciliation", async () => {
     const { resolver, state } = fakeHost();
     state.launchId = "019f4906-3f67-7b72-9fbc-9ec3b5ad1326";

--- a/src/lib/agent/transcriptHost.ts
+++ b/src/lib/agent/transcriptHost.ts
@@ -82,7 +82,7 @@ export type HostDeliveryOutcome =
   | { ok: false; outcome: "failed"; error: string; status: number; actuation?: "started" };
 
 export interface TranscriptHostResolver {
-  readTranscriptHosts(fresh?: boolean): Promise<TranscriptHostSnapshot>;
+  readTranscriptHosts(fresh?: boolean, entries?: FileEntry[]): Promise<TranscriptHostSnapshot>;
   deliverToTranscriptHost(input: { entry: FileEntry; spec: ResumeSpec; payload: string }): Promise<HostDeliveryOutcome>;
 }
 
@@ -288,9 +288,13 @@ export function createTranscriptHostResolver(
   decisions = new Map<string, Promise<Decision>>(),
 ): TranscriptHostResolver {
 
-  async function observe(fresh: boolean): Promise<TranscriptHostSnapshot> {
+  async function observe(fresh: boolean, suppliedEntries?: FileEntry[]): Promise<TranscriptHostSnapshot> {
     const conversationIdForPath = dependencies.conversationIdForPath ?? (() => null);
-    const [entries, paneObservation, records] = await Promise.all([dependencies.listFiles(), dependencies.panes(fresh), dependencies.resumeRecords()]);
+    const [entries, paneObservation, records] = await Promise.all([
+      suppliedEntries ?? dependencies.listFiles(),
+      dependencies.panes(fresh),
+      dependencies.resumeRecords(),
+    ]);
     const serverPid = records?.serverPid ?? (await dependencies.serverPid());
     if (paneObservation.kind === "failure" && serverPid !== null) {
       return { hosts: [], observation: "failure", observationError: paneObservation.error, conflicts: [], canonicalFor: () => null };

--- a/src/lib/resources.test.ts
+++ b/src/lib/resources.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, test } from "bun:test";
 import type { TranscriptHost } from "@/lib/agent/transcriptHost";
 import type { FileEntry } from "@/lib/types";
 
-import { allowedKillTarget, canonicalResourceEntry, conflictingResourceHost, consumeKillTarget, noteSessionTargets, parseResourcesFixture } from "./resources";
+import { allowedKillTarget, buildResourceSnapshot, canonicalResourceEntry, conflictingResourceHost, consumeKillTarget, noteSessionTargets, parseResourcesFixture } from "./resources";
 
 const PATHNAME = "/home/user/.codex/sessions/2026/07/10/rollout-2026-07-10-019f4906-3f67-7b72-9fbc-9ec3b5ad1326.jsonl";
 
@@ -61,6 +61,57 @@ function ref(tmuxServerPid: number, panePid: number, paneId: string) {
 }
 
 describe("resource observation", () => {
+  test("builds host ownership and metadata from one shared transcript generation", async () => {
+    let scans = 0;
+    let hostFresh: boolean | null = null;
+    const files = [entry];
+    const payload = await buildResourceSnapshot(true, {
+      readFiles: async () => {
+        scans += 1;
+        return files;
+      },
+      readHosts: async (fresh, entries) => {
+        hostFresh = fresh;
+        expect(entries).toBe(files);
+        return {
+          hosts: [canonical],
+          observation: "available",
+          conflicts: [],
+          canonicalFor: (pathname: string) => pathname === PATHNAME ? canonical : null,
+        };
+      },
+      proc: {
+        systemMemory: () => ({ ramTotal: 1_000, ramAvailable: 750, swapTotal: 100, swapUsed: 25 }),
+        ppidMap: () => new Map([[200, 100], [300, 200]]),
+        processMemory: () => new Map([
+          [100, { rssBytes: 10, swapBytes: 1 }],
+          [200, { rssBytes: 20, swapBytes: 2 }],
+          [300, { rssBytes: 30, swapBytes: 3 }],
+        ]),
+      },
+      captureAttachReference: () => ref(900, 100, "%1"),
+    });
+
+    expect(scans).toBe(1);
+    expect(hostFresh).toBeTrue();
+    expect(payload.sessions).toEqual([{
+      target: "agents:4.0",
+      panePid: 100,
+      path: PATHNAME,
+      engine: "codex",
+      hostConflict: false,
+      title: "Issue 31",
+      project: "live-log-viewer-next",
+      activity: "live",
+      lastActiveAt: "1970-01-01T00:00:01.000Z",
+      cwd: "/repo",
+      rssBytes: 60,
+      swapBytes: 6,
+      procCount: 3,
+    }]);
+    expect(allowedKillTarget("agents:4.0")).toEqual(ref(900, 100, "%1"));
+  });
+
   test("accepts a deterministic resource fixture", () => {
     const fixture = {
       system: {

--- a/src/lib/resources.ts
+++ b/src/lib/resources.ts
@@ -1,8 +1,9 @@
 import { procBackend } from "@/lib/proc";
+import type { ProcBackend } from "@/lib/proc";
 import { readFileSync } from "node:fs";
+import { currentFileScan } from "@/lib/scanner/scanCache";
 import { createFreshAwareCoalescer, type FreshAwareCoalescer } from "@/lib/asyncCoalescer";
 import { descendantPids } from "@/lib/proc/memory";
-import { listFiles } from "@/lib/scanner";
 import { overlaySessionTitles } from "@/lib/session/titleProjection";
 import { readTranscriptHosts, type TranscriptHost, type TranscriptHostSnapshot } from "@/lib/agent/transcriptHost";
 import { captureTmuxAttachReference, type TmuxAttachReference } from "@/lib/tmux";
@@ -47,8 +48,8 @@ export function parseResourcesFixture(raw: string): ResourcesPayload {
   return { system: system ?? null, sessions: [] };
 }
 
-function captureSystemMemory(): ResourcesPayload["system"] {
-  const system = procBackend.systemMemory();
+function captureSystemMemory(proc: Pick<ProcBackend, "systemMemory"> = procBackend): ResourcesPayload["system"] {
+  const system = proc.systemMemory();
   return system ? { ...system, capturedAt: new Date().toISOString() } : null;
 }
 
@@ -119,17 +120,34 @@ function isoFromUnix(seconds: number): string {
   return new Date(seconds * 1000).toISOString();
 }
 
+export interface ResourceSnapshotDependencies {
+  readFiles(): Promise<FileEntry[]>;
+  readHosts(fresh: boolean, entries: FileEntry[]): Promise<TranscriptHostSnapshot>;
+  proc: Pick<ProcBackend, "systemMemory" | "ppidMap" | "processMemory">;
+  captureAttachReference: typeof captureTmuxAttachReference;
+}
+
+const resourceSnapshotDependencies: ResourceSnapshotDependencies = {
+  readFiles: async () => (await currentFileScan()).snapshot.files,
+  readHosts: readTranscriptHosts,
+  proc: procBackend,
+  captureAttachReference: captureTmuxAttachReference,
+};
+
 /** `fresh` skips the pane/agent-process memos too, all the way down: a
     rebuild triggered right after a kill would otherwise read 5s-old caches
     and re-list (and re-allowlist) the session that was just killed. */
-async function buildResources(fresh: boolean): Promise<ResourcesPayload> {
-  const system = captureSystemMemory();
+export async function buildResourceSnapshot(
+  fresh: boolean,
+  dependencies: ResourceSnapshotDependencies = resourceSnapshotDependencies,
+): Promise<ResourcesPayload> {
+  const system = captureSystemMemory(dependencies.proc);
 
-  const hosts = await readTranscriptHosts(fresh);
+  const files = await dependencies.readFiles();
+  const hosts = await dependencies.readHosts(fresh, files);
   const sessions: ResourceSession[] = [];
   if (hosts.hosts.length > 0) {
-    const ppids = procBackend.ppidMap();
-    const files = await listFiles();
+    const ppids = dependencies.proc.ppidMap();
     overlaySessionTitles(files);
     const byPath = new Map(files.map((entry) => [entry.path, entry]));
     const byPane = new Map<string, TranscriptHost[]>();
@@ -149,7 +167,7 @@ async function buildResources(fresh: boolean): Promise<ResourcesPayload> {
       paneTrees.push({ host, tree, paneHosts });
       for (const pid of tree) treePids.add(pid);
     }
-    const memory = procBackend.processMemory(treePids);
+    const memory = dependencies.proc.processMemory(treePids);
 
     const killRefs: Array<{ target: string; ref: KillTargetRef }> = [];
     for (const { host, tree, paneHosts } of paneTrees) {
@@ -182,7 +200,7 @@ async function buildResources(fresh: boolean): Promise<ResourcesPayload> {
       });
       killRefs.push({
         target: host.display,
-        ref: captureTmuxAttachReference({ tmuxServerPid: host.tmuxServerPid, panePid: host.panePid, paneId: host.paneId }),
+        ref: dependencies.captureAttachReference({ tmuxServerPid: host.tmuxServerPid, panePid: host.panePid, paneId: host.paneId }),
       });
     }
     sessions.sort((a, b) => b.rssBytes + b.swapBytes - (a.rssBytes + a.swapBytes));
@@ -214,7 +232,7 @@ export async function readResources(fresh = false): Promise<ResourcesPayload> {
     return { ...cached.data, system: captureSystemMemory() };
   }
   const data = await resourceBuildCoordinator().run(fresh, async (forceFresh) => {
-    const built = await buildResources(forceFresh);
+    const built = await buildResourceSnapshot(forceFresh);
     globalStore.__llvResourcesCache = { at: Date.now(), data: built };
     return built;
   });

--- a/src/lib/resources.ts
+++ b/src/lib/resources.ts
@@ -121,29 +121,29 @@ function isoFromUnix(seconds: number): string {
 }
 
 export interface ResourceSnapshotDependencies {
-  readFiles(): Promise<FileEntry[]>;
+  readFiles(fresh: boolean): Promise<FileEntry[]>;
   readHosts(fresh: boolean, entries: FileEntry[]): Promise<TranscriptHostSnapshot>;
   proc: Pick<ProcBackend, "systemMemory" | "ppidMap" | "processMemory">;
   captureAttachReference: typeof captureTmuxAttachReference;
 }
 
 const resourceSnapshotDependencies: ResourceSnapshotDependencies = {
-  readFiles: async () => (await currentFileScan()).snapshot.files,
+  readFiles: async (fresh) => (await currentFileScan({ fresh })).snapshot.files,
   readHosts: readTranscriptHosts,
   proc: procBackend,
   captureAttachReference: captureTmuxAttachReference,
 };
 
-/** `fresh` skips the pane/agent-process memos too, all the way down: a
-    rebuild triggered right after a kill would otherwise read 5s-old caches
-    and re-list (and re-allowlist) the session that was just killed. */
+/** `fresh` advances the shared file scan and skips the pane/agent-process
+    memos. A rebuild triggered right after a kill must use one newer corpus for
+    host ownership, metadata, and the kill allowlist. */
 export async function buildResourceSnapshot(
   fresh: boolean,
   dependencies: ResourceSnapshotDependencies = resourceSnapshotDependencies,
 ): Promise<ResourcesPayload> {
   const system = captureSystemMemory(dependencies.proc);
 
-  const files = await dependencies.readFiles();
+  const files = await dependencies.readFiles(fresh);
   const hosts = await dependencies.readHosts(fresh, files);
   const sessions: ResourceSession[] = [];
   if (hosts.hosts.length > 0) {

--- a/src/lib/scanner/index.ts
+++ b/src/lib/scanner/index.ts
@@ -6,7 +6,7 @@ import { tickPipelines } from "../pipelines/engine";
 import { notifyQuestion } from "../push";
 import { overlaySessionTitles, sessionProjectProjection } from "../session/titleProjection";
 import { tickTaskInbox } from "../tasks/inboxScanner";
-import { resolveTarget } from "../tmux";
+import { panePidMap, resolveTarget } from "../tmux";
 import { tickWorkflows } from "../workflows/engine";
 import { activityVerdict } from "./activity";
 import { ctxFor } from "./context";
@@ -15,7 +15,7 @@ import { discoverFiles, discoverFilesWithProjectCatalog } from "./discover";
 import { entryEffort, entryFast } from "./effort";
 import { linkEntries } from "./links";
 import { entryModels } from "./model";
-import { outputHolders } from "./process";
+import { agentProcesses, outputHolders } from "./process";
 import { goalFor, planFor } from "./plan";
 import { pendingQuestionFor } from "./questions";
 import { pendingWakeupFor } from "./wakeup";
@@ -72,6 +72,9 @@ async function forEachEntryBatchYielding(
 
 export interface FileScanOptions {
   persist?: boolean;
+  /** Refresh process and tmux pane observations before hydrating FileEntry
+      ownership and pane-derived state. */
+  fresh?: boolean;
   /** Persist parsed per-file summaries while keeping controller mutations out
       of request-owned scans. */
   persistIndex?: boolean;
@@ -202,6 +205,11 @@ async function listFilesInternal(
     ? await discoverFilesWithProjectCatalog(undefined, selectedProject, { persist, persistIndex: options.persistIndex, demote, pin })
     : { files: await discoverFiles(undefined, demote, pin), projectCatalog: [], complete: true };
   const entries = scan.files;
+  if (options.fresh) {
+    const panes = panePidMap(true);
+    agentProcesses(true);
+    await panes;
+  }
   // The /proc fd scan is only needed to attribute background-task outputs to a
   // live pid. When the shortlist has no such entries, skip the scan entirely;
   // activity() only consults holders on the same claude-tasks/.output path.

--- a/src/lib/scanner/scanCache.ts
+++ b/src/lib/scanner/scanCache.ts
@@ -407,6 +407,20 @@ export async function cachedFileScan(
   return completedScan(slot, undefined, targetGeneration);
 }
 
+/** Returns metadata from a completed current generation. Resource snapshots
+    use this path so host ownership can share the files-route scan while still
+    waiting for stale-while-revalidate work to finish. */
+export async function currentFileScan(now = Date.now()): Promise<CachedFileScan> {
+  const scan = await cachedFileScan(undefined, undefined, now);
+  if (scan.generation >= scan.targetGeneration) return scan;
+
+  const cached = fileScanCache().get("");
+  const slot = normalizeFileScanCacheSlot(cached);
+  fileScanCache().set("", slot);
+  await refreshThroughGeneration(slot, scan.targetGeneration);
+  return completedScan(slot, undefined, scan.targetGeneration);
+}
+
 export function resetFilesRouteCacheForTests(): void {
   fileScanCache().clear();
 }

--- a/src/lib/scanner/scanCache.ts
+++ b/src/lib/scanner/scanCache.ts
@@ -301,6 +301,28 @@ function pinnedRefreshGeneration(slot: FileScanCacheSlot, pinnedPath: string): n
   return rememberPinnedGeneration(slot, pinnedPath, nextGeneration(slot));
 }
 
+function globalFileScanSlot(): FileScanCacheSlot {
+  const key = "";
+  const cache = fileScanCache();
+  const cachedSlot = cache.get(key);
+  if (cachedSlot === undefined) {
+    const slot: FileScanCacheSlot = {
+      schemaVersion: FILE_SCAN_CACHE_SCHEMA_VERSION,
+      snapshot: readPersistedFileScanSnapshot(),
+      snapshotGeneration: 0,
+      requestedGeneration: 0,
+      refreshedAt: 0,
+    };
+    cache.set(key, slot);
+    return slot;
+  }
+
+  const slot = normalizeFileScanCacheSlot(cachedSlot);
+  cache.delete(key);
+  cache.set(key, slot);
+  return slot;
+}
+
 export async function cachedFileScan(
   _selectedProject?: string,
   pinnedPath?: string,
@@ -308,25 +330,7 @@ export async function cachedFileScan(
   requiredRevision?: number,
   requiredGeneration?: number,
 ): Promise<CachedFileScan> {
-  const key = "";
-  const cache = fileScanCache();
-  const cachedSlot = cache.get(key);
-  let slot: FileScanCacheSlot;
-  if (cachedSlot === undefined) {
-    const persisted = readPersistedFileScanSnapshot();
-    slot = {
-      schemaVersion: FILE_SCAN_CACHE_SCHEMA_VERSION,
-      snapshot: persisted,
-      snapshotGeneration: 0,
-      requestedGeneration: 0,
-      refreshedAt: 0,
-    };
-    cache.set(key, slot);
-  } else {
-    slot = normalizeFileScanCacheSlot(cachedSlot);
-    cache.delete(key);
-    cache.set(key, slot);
-  }
+  const slot = globalFileScanSlot();
 
   let targetGeneration = requiredGeneration !== undefined && requiredGeneration <= slot.requestedGeneration
     ? requiredGeneration
@@ -407,16 +411,23 @@ export async function cachedFileScan(
   return completedScan(slot, undefined, targetGeneration);
 }
 
-/** Returns metadata from a completed current generation. Resource snapshots
-    use this path so host ownership can share the files-route scan while still
-    waiting for stale-while-revalidate work to finish. */
-export async function currentFileScan(now = Date.now()): Promise<CachedFileScan> {
+/** Returns metadata from a completed current generation. Fresh resource
+    snapshots reserve a generation beyond every request visible at entry. The
+    shared refresh loop completes older work before satisfying that fence. */
+export async function currentFileScan(
+  { fresh = false, now = Date.now() }: { fresh?: boolean; now?: number } = {},
+): Promise<CachedFileScan> {
+  if (fresh) {
+    const slot = globalFileScanSlot();
+    const targetGeneration = nextGeneration(slot);
+    await refreshThroughGeneration(slot, targetGeneration);
+    return completedScan(slot, undefined, targetGeneration);
+  }
+
   const scan = await cachedFileScan(undefined, undefined, now);
   if (scan.generation >= scan.targetGeneration) return scan;
 
-  const cached = fileScanCache().get("");
-  const slot = normalizeFileScanCacheSlot(cached);
-  fileScanCache().set("", slot);
+  const slot = globalFileScanSlot();
   await refreshThroughGeneration(slot, scan.targetGeneration);
   return completedScan(slot, undefined, scan.targetGeneration);
 }

--- a/src/lib/scanner/scanCache.ts
+++ b/src/lib/scanner/scanCache.ts
@@ -21,6 +21,7 @@ type FileScanCacheSlot = {
   requestedGeneration: number;
   forcedRevision?: number;
   forcedGeneration?: number;
+  freshObservationGeneration?: number;
   refreshedAt: number;
   refresh?: FileScanRefresh;
   pinnedSnapshots?: Map<string, PinnedFileScanSnapshot>;
@@ -179,20 +180,37 @@ function normalizeFileScanCacheSlot(value: unknown): FileScanCacheSlot {
 }
 
 function beginFileScanRefresh(slot: FileScanCacheSlot, generation: number): FileScanRefresh {
-  const promise = listFilesWithProjectCatalog(undefined, { persist: false, persistIndex: true }).then((snapshot) => {
+  const fresh = slot.freshObservationGeneration !== undefined
+    && generation >= slot.freshObservationGeneration;
+  const promise = listFilesWithProjectCatalog(undefined, {
+    persist: false,
+    persistIndex: true,
+    ...(fresh ? { fresh: true } : {}),
+  }).then((snapshot) => {
     if (!snapshot.complete) throw new Error("filesystem scan incomplete");
     writePersistedFileScanSnapshot(snapshot);
     slot.snapshot = snapshot;
     slot.snapshotGeneration = Math.max(slot.snapshotGeneration, generation);
     slot.refreshedAt = Date.now();
+    if (fresh && slot.freshObservationGeneration !== undefined
+      && generation >= slot.freshObservationGeneration) {
+      slot.freshObservationGeneration = undefined;
+    }
     return snapshot;
   });
   return installFileScanRefresh(slot, generation, promise);
 }
 
 function beginPinnedFileScanRefresh(slot: FileScanCacheSlot, generation: number, pinnedPath: string): FileScanRefresh {
+  const fresh = slot.freshObservationGeneration !== undefined
+    && generation >= slot.freshObservationGeneration;
   const promise = (async () => {
-    const pinnedSnapshot = await listFilesWithProjectCatalog(undefined, { persist: false, persistIndex: true, pin: pinnedPath });
+    const pinnedSnapshot = await listFilesWithProjectCatalog(undefined, {
+      persist: false,
+      persistIndex: true,
+      pin: pinnedPath,
+      ...(fresh ? { fresh: true } : {}),
+    });
     if (!pinnedSnapshot.complete) throw new Error("filesystem scan incomplete");
     const pinOverlayPaths = pinnedSnapshot.pinOverlayPaths ?? [];
     const overlayPathSet = new Set(pinOverlayPaths);
@@ -222,6 +240,10 @@ function beginPinnedFileScanRefresh(slot: FileScanCacheSlot, generation: number,
     slot.snapshot = globalSnapshot;
     slot.snapshotGeneration = Math.max(slot.snapshotGeneration, generation);
     slot.refreshedAt = Date.now();
+    if (fresh && slot.freshObservationGeneration !== undefined
+      && generation >= slot.freshObservationGeneration) {
+      slot.freshObservationGeneration = undefined;
+    }
     return globalSnapshot;
   })();
   return installFileScanRefresh(slot, generation, promise);
@@ -420,6 +442,10 @@ export async function currentFileScan(
   if (fresh) {
     const slot = globalFileScanSlot();
     const targetGeneration = nextGeneration(slot);
+    slot.freshObservationGeneration = Math.max(
+      slot.freshObservationGeneration ?? targetGeneration,
+      targetGeneration,
+    );
     await refreshThroughGeneration(slot, targetGeneration);
     return completedScan(slot, undefined, targetGeneration);
   }

--- a/src/lib/scanner/scanCache.ts
+++ b/src/lib/scanner/scanCache.ts
@@ -433,19 +433,16 @@ export async function cachedFileScan(
   return completedScan(slot, undefined, targetGeneration);
 }
 
-/** Returns metadata from a completed current generation. Fresh resource
-    snapshots reserve a generation beyond every request visible at entry. The
-    shared refresh loop completes older work before satisfying that fence. */
+/** Returns metadata from a completed current generation. The first fresh
+    caller reserves a generation beyond existing requests; concurrent fresh
+    callers join that pending fence. Older work completes before the fence. */
 export async function currentFileScan(
   { fresh = false, now = Date.now() }: { fresh?: boolean; now?: number } = {},
 ): Promise<CachedFileScan> {
   if (fresh) {
     const slot = globalFileScanSlot();
-    const targetGeneration = nextGeneration(slot);
-    slot.freshObservationGeneration = Math.max(
-      slot.freshObservationGeneration ?? targetGeneration,
-      targetGeneration,
-    );
+    const targetGeneration = slot.freshObservationGeneration ?? nextGeneration(slot);
+    slot.freshObservationGeneration = targetGeneration;
     await refreshThroughGeneration(slot, targetGeneration);
     return completedScan(slot, undefined, targetGeneration);
   }


### PR DESCRIPTION
Refs #287.

## Scope

- Move the files scan cache into the shared scanner module.
- Reuse one completed scan generation for transcript-host election and resource title/activity projection.
- Preserve pane observation, canonical/conflict election, process-memory aggregation, kill allowlist replacement, and fresh-after-kill semantics.
- Fence fresh resource reads beyond any scan already requested before the kill.
- Repair the Bun process-global resources mock leak exposed by the new integration gate.

## Evidence

- Production-shaped 505-file resource build: 16.840 s baseline → 6.542 s before deployment.
- Root review found and fixed the warm-cache post-kill race.
- Full suite: 2,846 pass, 0 fail; 15,056 assertions.
- TypeScript, focused ESLint, diff hygiene, and Next production build passed.
- Independent root gate: 81 focused tests, 0 failures.
- Exact revision ce2c14d59e9a66d99a1382ef9d1f3e6617faa6e4 deployed as deploy_3ed5ad3b-738f-4610-8464-6f2c9b6879fd.
- Post-deploy: root 0.13 s, files 0.62 s, runtime snapshot 0.13 s, resources warm 0.007 s, resources forced fresh 4.96 s.
- Isolated cold browser board-ready: 1.819 s; DOMContentLoaded 48 ms; load 167 ms; assets all HTTP 200.

Issue #287 remains open for the remaining instrumentation, 1,285-conversation browser budget, request-ownership cleanup, and worker-isolation acceptance.