### PR TITLE
perf: isolate and coalesce recurring resource collection

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -9,6 +9,19 @@ const nextConfig: NextConfig = {
   outputFileTracingExcludes: {
     "*": ["node_modules/@img/**", "node_modules/sharp/**"],
   },
+  outputFileTracingIncludes: {
+    "/*": [".next/server/resource-collector-worker.js"],
+  },
+  webpack(config, { isServer, nextRuntime }) {
+    if (isServer && nextRuntime === "nodejs") {
+      const originalEntry = config.entry;
+      config.entry = async () => ({
+        ...(typeof originalEntry === "function" ? await originalEntry() : originalEntry),
+        "resource-collector-worker": "./src/lib/resourceCollector.worker.ts",
+      });
+    }
+    return config;
+  },
 };
 
 export default nextConfig;

--- a/src/app/api/files/route.test.ts
+++ b/src/app/api/files/route.test.ts
@@ -104,7 +104,7 @@ afterAll(() => {
 });
 
 const { cachedFileScan, currentFileScan, resetFilesRouteCacheForTests } = await import("@/lib/scanner/scanCache");
-const { allowedKillTarget, buildResourceSnapshot, noteSessionTargets } = await import("@/lib/resources");
+const { allowedKillTarget, buildResourceSnapshot, noteSessionTargets, readResourceFileSnapshot } = await import("@/lib/resources");
 const { GET } = await import("./route");
 
 test("repeated files reads reuse the pure read snapshot and retain ETag behavior", async () => {
@@ -208,6 +208,36 @@ test("a current scan joins restart revalidation before publishing transcript met
   release();
   expect((await current).snapshot.files.map((entry) => entry.path)).toEqual(["/sessions/current-resource.jsonl"]);
   expect(scans).toBe(1);
+});
+
+test("an ordinary resource snapshot reuses the completed scanner generation", async () => {
+  const before = file("/sessions/completed-resource.jsonl");
+  const after = file("/sessions/gated-resource-refresh.jsonl");
+  scannedFiles = [before];
+  await cachedFileScan();
+  const cacheStore = globalThis as typeof globalThis & {
+    __llvFilesRouteScans?: Map<string, { refreshedAt: number }>;
+  };
+  cacheStore.__llvFilesRouteScans!.get("")!.refreshedAt = 0;
+
+  let release!: () => void;
+  scanGates.push(new Promise<void>((resolve) => { release = resolve; }));
+  scannedFiles = [after];
+  let settled = false;
+  const resourceFiles = readResourceFileSnapshot(false).then((files) => {
+    settled = true;
+    return files;
+  });
+
+  await new Promise<void>((resolve) => setImmediate(resolve));
+  const scansBeforeRelease = scans;
+  const settledBeforeRelease = settled;
+  release();
+  const files = await resourceFiles;
+
+  expect(scansBeforeRelease).toBe(1);
+  expect(settledBeforeRelease).toBeTrue();
+  expect(files.map((entry) => entry.path)).toEqual([before.path]);
 });
 
 test("concurrent fresh callers share one pending generation through failure and retry", async () => {
@@ -320,7 +350,7 @@ test("a fresh resource snapshot fences a pre-kill refresh before host election",
   const payloadPromise = buildResourceSnapshot(true, {
     readFiles: async (fresh) => {
       filesFresh = fresh;
-      return (await currentFileScan({ fresh, now })).snapshot.files;
+      return readResourceFileSnapshot(fresh);
     },
     readHosts: async (_fresh, entries) => {
       hostEntries = entries;

--- a/src/app/api/files/route.test.ts
+++ b/src/app/api/files/route.test.ts
@@ -117,6 +117,12 @@ test("repeated files reads reuse the pure read snapshot and retain ETag behavior
   expect(second.status).toBe(304);
   expect(scans).toBe(1);
   expect(scanOptions).toEqual({ persist: false, persistIndex: true });
+  expect(first.headers.get("x-llv-files-cache")).toBe("miss");
+  expect(second.headers.get("x-llv-files-cache")).toBe("hit");
+  expect(first.headers.get("x-llv-files-cache-requests")).toBe("1");
+  expect(second.headers.get("x-llv-files-cache-requests")).toBe("2");
+  expect(first.headers.get("server-timing")).toMatch(/files-clone;dur=\d+(?:\.\d+)?/);
+  expect(first.headers.get("server-timing")).toMatch(/files-scan;dur=\d+(?:\.\d+)?;desc="cold generation 1"/);
 });
 
 test("files API surfaces degraded tmux endpoint health", async () => {
@@ -163,9 +169,10 @@ test("a restart serves the persisted completed snapshot while revalidating", asy
   const restarted = await cachedFileScan();
 
   expect(restarted.snapshot.files.map((entry) => entry.path)).toEqual(["/sessions/persisted.jsonl"]);
-  expect(scans).toBe(1);
+  expect(scans).toBe(0);
 
   await new Promise<void>((resolve) => setImmediate(resolve));
+  expect(scans).toBe(1);
   const next = await cachedFileScan();
   expect(next.snapshot.files.map((entry) => entry.path)).toEqual(["/sessions/refreshed.jsonl"]);
 });
@@ -193,9 +200,11 @@ test("a current scan joins restart revalidation before publishing transcript met
     return scan;
   });
 
-  expect(scans).toBe(1);
+  expect(scans).toBe(0);
   expect(settled).toBeFalse();
 
+  await new Promise<void>((resolve) => setImmediate(resolve));
+  expect(scans).toBe(1);
   release();
   expect((await current).snapshot.files.map((entry) => entry.path)).toEqual(["/sessions/current-resource.jsonl"]);
   expect(scans).toBe(1);
@@ -219,7 +228,7 @@ test("concurrent fresh callers share one pending generation through failure and 
     new Promise<void>((resolve) => { releaseOld = resolve; }),
     new Promise<void>((resolve) => { releaseFresh = resolve; }),
   );
-  await cachedFileScan(undefined, undefined, now + 10_000);
+  await cachedFileScan(undefined, undefined, now + 10_100);
   scannedFiles = [after];
 
   let firstSettled = false;
@@ -290,9 +299,9 @@ test("a fresh resource snapshot fences a pre-kill refresh before host election",
   expect(warm.snapshot.files.map((entry) => entry.path)).toEqual([before.path]);
   let releasePreKillRefresh!: () => void;
   scanGates.push(new Promise<void>((resolve) => { releasePreKillRefresh = resolve; }));
-  const revalidating = await cachedFileScan(undefined, undefined, now + 10_000);
+  const revalidating = await cachedFileScan(undefined, undefined, now + 10_100);
   expect(revalidating.snapshot.files.map((entry) => entry.path)).toEqual([before.path]);
-  expect(scans).toBe(2);
+  expect(scans).toBe(1);
 
   scannedFiles = [after];
   let releasePostKillRefresh!: () => void;
@@ -350,7 +359,7 @@ test("a fresh resource snapshot fences a pre-kill refresh before host election",
   });
 
   expect(filesFresh).toBeTrue();
-  expect(scans).toBe(2);
+  expect(scans).toBe(1);
   expect(resourceSettled).toBeFalse();
 
   releasePreKillRefresh();
@@ -513,8 +522,10 @@ test("a client automatically converges from a persisted restart snapshot to its 
 
   expect(performance.now() - started).toBeLessThan(300);
   expect(stale.files.map((entry) => entry.path)).toEqual(["/sessions/persisted-client.jsonl"]);
-  expect(scans).toBe(1);
+  expect(scans).toBe(0);
 
+  await new Promise<void>((resolve) => setImmediate(resolve));
+  expect(scans).toBe(1);
   release();
   for (let attempt = 0; attempt < 100 && cache.read().files[0]?.path !== "/sessions/refreshed-client.jsonl"; attempt += 1) {
     await Bun.sleep(10);
@@ -690,26 +701,85 @@ test("an expired snapshot returns stale data while one shared refresh runs", asy
   const refreshed = await cachedFileScan(undefined, undefined, Number.MAX_SAFE_INTEGER);
 
   expect(refreshed.snapshot.files.map((entry) => entry.path)).toEqual(["/sessions/project-a.jsonl"]);
-  expect(scans).toBe(2);
+  expect(scans).toBe(1);
 
   await new Promise<void>((resolve) => setImmediate(resolve));
+  expect(scans).toBe(2);
   const next = await cachedFileScan();
   expect(next.snapshot.files.map((entry) => entry.path)).toEqual(["/sessions/project-b.jsonl"]);
 });
 
+test("ordinary reads defer one shared refresh to the bounded fallback cadence", async () => {
+  const now = Date.now();
+  const before = file("/sessions/ordinary-before.jsonl");
+  const after = file("/sessions/ordinary-after.jsonl");
+  scannedFiles = [before];
+  await cachedFileScan(undefined, undefined, now);
+
+  let release!: () => void;
+  scanGates.push(new Promise<void>((resolve) => { release = resolve; }));
+  scannedFiles = [after];
+  const frequentReads = await Promise.all(Array.from({ length: 24 }, (_, index) =>
+    cachedFileScan(undefined, undefined, now + 1_000 + index * 375)));
+
+  expect(frequentReads.every((scan) => scan.snapshot.files[0]?.path === before.path)).toBeTrue();
+  expect(scans).toBe(1);
+
+  const stale = await cachedFileScan(undefined, undefined, now + 10_100);
+  expect(stale.snapshot.files.map((entry) => entry.path)).toEqual([before.path]);
+  expect(stale.cacheStatus).toBe("stale");
+  expect(scans).toBe(1);
+
+  await new Promise<void>((resolve) => setImmediate(resolve));
+  expect(scans).toBe(2);
+
+  const completed = currentFileScan();
+  release();
+  expect((await completed).snapshot.files.map((entry) => entry.path)).toEqual([after.path]);
+
+  const completedAt = Date.now();
+  const nextFrequentReads = await Promise.all(Array.from({ length: 24 }, (_, index) =>
+    cachedFileScan(undefined, undefined, completedAt + index * 375)));
+  expect(nextFrequentReads.every((scan) => scan.snapshot.files[0]?.path === after.path)).toBeTrue();
+  expect(scans).toBe(2);
+});
+
+test("a failed ordinary refresh keeps retry traffic on the bounded cadence", async () => {
+  const now = Date.now();
+  scannedFiles = [file("/sessions/ordinary-retry.jsonl")];
+  await cachedFileScan(undefined, undefined, now);
+
+  scanCompleteResults = [false];
+  await cachedFileScan(undefined, undefined, now + 10_100);
+  await new Promise<void>((resolve) => setImmediate(resolve));
+  expect(scans).toBe(2);
+
+  const retryTraffic = await Promise.all(Array.from({ length: 24 }, (_, index) =>
+    cachedFileScan(undefined, undefined, now + 11_000 + index * 375)));
+  expect(retryTraffic.every((scan) => scan.snapshot.files[0]?.path === "/sessions/ordinary-retry.jsonl")).toBeTrue();
+  expect(retryTraffic.every((scan) => scan.cacheStatus === "hit" && scan.targetGeneration === scan.generation)).toBeTrue();
+  expect(scans).toBe(2);
+
+  await cachedFileScan(undefined, undefined, now + 20_200);
+  expect(scans).toBe(2);
+  await new Promise<void>((resolve) => setImmediate(resolve));
+  expect(scans).toBe(3);
+});
+
 test("an incomplete filesystem scan retains the last completed route snapshot until recovery", async () => {
+  const now = Date.now();
   scannedFiles = [file("/sessions/canonical.jsonl")];
-  await cachedFileScan();
+  await cachedFileScan(undefined, undefined, now);
   scanFileResults = [[file("/sessions/partial.jsonl")]];
   scanCompleteResults = [false];
 
-  const stale = await cachedFileScan(undefined, undefined, Number.MAX_SAFE_INTEGER);
+  const stale = await cachedFileScan(undefined, undefined, now + 10_100);
   expect(stale.snapshot.files.map((entry) => entry.path)).toEqual(["/sessions/canonical.jsonl"]);
   await new Promise<void>((resolve) => setImmediate(resolve));
   expect((await cachedFileScan()).snapshot.files.map((entry) => entry.path)).toEqual(["/sessions/canonical.jsonl"]);
 
   scanFileResults = [[file("/sessions/recovered.jsonl")]];
-  const recovered = await cachedFileScan(undefined, undefined, Number.MAX_SAFE_INTEGER);
+  const recovered = await cachedFileScan(undefined, undefined, now + 20_200);
   expect(recovered.snapshot.files.map((entry) => entry.path)).toEqual(["/sessions/canonical.jsonl"]);
   await new Promise<void>((resolve) => setImmediate(resolve));
   expect((await cachedFileScan()).snapshot.files.map((entry) => entry.path)).toEqual(["/sessions/recovered.jsonl"]);
@@ -731,8 +801,10 @@ test("concurrent reads during a blocked refresh share one scan and return within
   expect(performance.now() - started).toBeLessThan(300);
   expect(first.snapshot.files.map((entry) => entry.path)).toEqual(["/sessions/complete.jsonl"]);
   expect(second.snapshot.files.map((entry) => entry.path)).toEqual(["/sessions/complete.jsonl"]);
-  expect(scans).toBe(2);
+  expect(scans).toBe(1);
 
+  await new Promise<void>((resolve) => setImmediate(resolve));
+  expect(scans).toBe(2);
   release();
   await new Promise<void>((resolve) => setImmediate(resolve));
 });

--- a/src/app/api/files/route.test.ts
+++ b/src/app/api/files/route.test.ts
@@ -104,7 +104,7 @@ afterAll(() => {
 });
 
 const { cachedFileScan, currentFileScan, resetFilesRouteCacheForTests } = await import("@/lib/scanner/scanCache");
-const { allowedKillTarget, buildResourceSnapshot, noteSessionTargets, readResourceFileSnapshot } = await import("@/lib/resources");
+const { allowedKillTarget, buildResourceSnapshot, lastResourceTargetRefs, noteSessionTargets, readResourceFileSnapshot } = await import("@/lib/resources");
 const { GET } = await import("./route");
 
 test("repeated files reads reuse the pure read snapshot and retain ETag behavior", async () => {
@@ -410,7 +410,8 @@ test("a fresh resource snapshot fences a pre-kill refresh before host election",
     activity: "recent",
     lastActiveAt: "1970-01-01T00:00:02.000Z",
   })]);
-  expect(allowedKillTarget("agents:after")).toEqual(resourceRef);
+  expect(lastResourceTargetRefs()).toEqual([{ target: "agents:after", ref: resourceRef }]);
+  expect(allowedKillTarget("agents:after")).toBeNull();
   expect(allowedKillTarget("agents:before")).toBeNull();
 });
 

--- a/src/app/api/files/route.test.ts
+++ b/src/app/api/files/route.test.ts
@@ -235,7 +235,7 @@ test("an ordinary resource snapshot reuses the completed scanner generation", as
   release();
   const files = await resourceFiles;
 
-  expect(scansBeforeRelease).toBe(1);
+  expect(scansBeforeRelease).toBe(2);
   expect(settledBeforeRelease).toBeTrue();
   expect(files.map((entry) => entry.path)).toEqual([before.path]);
 });
@@ -382,7 +382,7 @@ test("a fresh resource snapshot fences a pre-kill refresh before host election",
       ppidMap: () => new Map([[200, 100]]),
       processMemory: () => new Map([[100, { rssBytes: 10, swapBytes: 0 }], [200, { rssBytes: 20, swapBytes: 0 }]]),
     },
-    captureAttachReference: () => resourceRef,
+    captureAttachReferences: () => new Map([[resourceRef.paneId, resourceRef]]),
   }).then((payload) => {
     resourceSettled = true;
     return payload;
@@ -513,7 +513,7 @@ test("a fresh resource snapshot replaces stale process and pane observations bef
         [newCli.agentPid, { rssBytes: 20, swapBytes: 0 }],
       ]),
     },
-    captureAttachReference: () => resourceRef,
+    captureAttachReferences: () => new Map([[resourceRef.paneId, resourceRef]]),
   });
 
   expect(scans).toBe(1);

--- a/src/app/api/files/route.test.ts
+++ b/src/app/api/files/route.test.ts
@@ -338,7 +338,7 @@ test("a fresh resource snapshot fences a pre-kill refresh before host election",
   scanGates.push(new Promise<void>((resolve) => { releasePostKillRefresh = resolve; }));
 
   let filesFresh: boolean | undefined;
-  let hostEntries: FileEntry[] = [];
+  let hostEntries: Array<{ path: string }> = [];
   let resourceSettled = false;
   const resourceRef = {
     tmuxServerPid: 900,

--- a/src/app/api/files/route.test.ts
+++ b/src/app/api/files/route.test.ts
@@ -78,6 +78,8 @@ mock.module("@/lib/scanner", () => ({
     scanProjects.push(project);
     scanOptions = options;
     const files = hydrateScannedFiles(scanFileResults.shift() ?? scannedFiles, options);
+    const resourceSnapshot = { files, projectCatalog: [], complete: true };
+    (options as { onResourceSnapshot?: (snapshot: typeof resourceSnapshot) => void }).onResourceSnapshot?.(resourceSnapshot);
     await scanGates.shift();
     const pinOverlayPaths = scanPinOverlayResults.shift();
     const complete = scanCompleteResults.shift();
@@ -116,7 +118,11 @@ test("repeated files reads reuse the pure read snapshot and retain ETag behavior
   expect(await first.json()).toEqual({ files: [], projectCatalog: [], flows: [], pipelines: [], workflows: [], tasks: [], systemHealth: { tmux: { status: "healthy" } }, conversationAliases: {} });
   expect(second.status).toBe(304);
   expect(scans).toBe(1);
-  expect(scanOptions).toEqual({ persist: false, persistIndex: true });
+  expect(scanOptions).toEqual(expect.objectContaining({
+    persist: false,
+    persistIndex: true,
+    onResourceSnapshot: expect.any(Function),
+  }));
   expect(first.headers.get("x-llv-files-cache")).toBe("miss");
   expect(second.headers.get("x-llv-files-cache")).toBe("hit");
   expect(first.headers.get("x-llv-files-cache-requests")).toBe("1");
@@ -240,6 +246,97 @@ test("an ordinary resource snapshot reuses the completed scanner generation", as
   expect(files.map((entry) => entry.path)).toEqual([before.path]);
 });
 
+test("a fresh resource handoff publishes the exact scan scope before full file enrichment settles", async () => {
+  const before = file("/sessions/resource-stage-before.jsonl");
+  const after = file("/sessions/resource-stage-after.jsonl");
+  scannedFiles = [before];
+  await cachedFileScan();
+
+  let release!: () => void;
+  scanGates.push(new Promise<void>((resolve) => { release = resolve; }));
+  scannedFiles = [after];
+  let settled = false;
+  const handoff = readResourceFileSnapshot(true).then((files) => {
+    settled = true;
+    return files;
+  });
+
+  await new Promise<void>((resolve) => setImmediate(resolve));
+  const settledBeforeFullScan = settled;
+  release();
+  const files = await handoff;
+
+  expect(settledBeforeFullScan).toBeTrue();
+  expect(files.map((entry) => entry.path)).toEqual([after.path]);
+  expect(scans).toBe(2);
+});
+
+test("a fresh resource handoff replaces deferred ordinary work without a duplicate scan", async () => {
+  const now = Date.now();
+  const before = file("/sessions/resource-promote-before.jsonl");
+  const after = file("/sessions/resource-promote-after.jsonl");
+  const freshFlags: boolean[] = [];
+  hydrateScannedFiles = (files, options) => {
+    freshFlags.push((options as { fresh?: boolean }).fresh === true);
+    return files;
+  };
+  scannedFiles = [before];
+  await cachedFileScan(undefined, undefined, now);
+
+  let release!: () => void;
+  scanGates.push(new Promise<void>((resolve) => { release = resolve; }));
+  scannedFiles = [after];
+  await cachedFileScan(undefined, undefined, now + 10_100);
+  let settled = false;
+  const handoff = readResourceFileSnapshot(true).then((files) => {
+    settled = true;
+    return files;
+  });
+
+  await new Promise<void>((resolve) => setImmediate(resolve));
+  const settledBeforeFullScan = settled;
+  const scansBeforeFullScan = scans;
+  release();
+  const files = await handoff;
+
+  expect(settledBeforeFullScan).toBeTrue();
+  expect(scansBeforeFullScan).toBe(2);
+  expect(files.map((entry) => entry.path)).toEqual([after.path]);
+  expect(freshFlags).toEqual([false, true]);
+  expect(scans).toBe(2);
+});
+
+test("a fresh resource handoff joins an ordinary generation that already started", async () => {
+  const now = Date.now();
+  const before = file("/sessions/resource-running-before.jsonl");
+  const after = file("/sessions/resource-running-after.jsonl");
+  scannedFiles = [before];
+  await cachedFileScan(undefined, undefined, now);
+
+  let release!: () => void;
+  scanGates.push(new Promise<void>((resolve) => { release = resolve; }));
+  scannedFiles = [after];
+  await cachedFileScan(undefined, undefined, now + 10_100);
+  await new Promise<void>((resolve) => setImmediate(resolve));
+  expect(scans).toBe(2);
+
+  let settled = false;
+  const handoff = readResourceFileSnapshot(true).then((files) => {
+    settled = true;
+    return files;
+  });
+  await new Promise<void>((resolve) => setImmediate(resolve));
+  const settledBeforeFullScan = settled;
+  const scansBeforeFullScan = scans;
+  release();
+  const files = await handoff;
+
+  expect(settledBeforeFullScan).toBeTrue();
+  expect(scansBeforeFullScan).toBe(2);
+  expect(files.map((entry) => entry.path)).toEqual([after.path]);
+  expect(scans).toBe(2);
+});
+
 test("concurrent fresh callers share one pending generation through failure and retry", async () => {
   const now = Date.now();
   const before = file("/sessions/shared-fresh-before.jsonl");
@@ -334,8 +431,6 @@ test("a fresh resource snapshot fences a pre-kill refresh before host election",
   expect(scans).toBe(1);
 
   scannedFiles = [after];
-  let releasePostKillRefresh!: () => void;
-  scanGates.push(new Promise<void>((resolve) => { releasePostKillRefresh = resolve; }));
 
   let filesFresh: boolean | undefined;
   let hostEntries: Array<{ path: string }> = [];
@@ -389,19 +484,10 @@ test("a fresh resource snapshot fences a pre-kill refresh before host election",
   });
 
   expect(filesFresh).toBeTrue();
-  expect(scans).toBe(1);
-  expect(resourceSettled).toBeFalse();
-
-  releasePreKillRefresh();
-  for (let attempt = 0; attempt < 100 && scans < 3; attempt += 1) {
-    await new Promise<void>((resolve) => setImmediate(resolve));
-  }
-  expect(scans).toBe(3);
-  expect(resourceSettled).toBeFalse();
-
-  releasePostKillRefresh();
+  expect(scans).toBe(2);
   const payload = await payloadPromise;
-  expect(scans).toBe(3);
+  expect(resourceSettled).toBeTrue();
+  expect(scans).toBe(2);
   expect(hostEntries.map((entry) => entry.path)).toEqual([after.path]);
   expect(payload.sessions).toEqual([expect.objectContaining({
     target: "agents:after",
@@ -413,6 +499,7 @@ test("a fresh resource snapshot fences a pre-kill refresh before host election",
   expect(lastResourceTargetRefs()).toEqual([{ target: "agents:after", ref: resourceRef }]);
   expect(allowedKillTarget("agents:after")).toBeNull();
   expect(allowedKillTarget("agents:before")).toBeNull();
+  releasePreKillRefresh();
 });
 
 test("a fresh resource snapshot replaces stale process and pane observations before host reconciliation", async () => {

--- a/src/app/api/files/route.ts
+++ b/src/app/api/files/route.ts
@@ -16,6 +16,10 @@ export async function GET(request: Request): Promise<Response> {
   const requiredGeneration = generationHeader(request, "x-llv-files-generation");
   let responseGeneration = 0;
   let targetGeneration = 0;
+  let cacheStatus: "hit" | "stale" | "miss" = "miss";
+  let requestCount = 0;
+  let cloneDurationMs = 0;
+  let lastScan: Awaited<ReturnType<typeof cachedFileScan>>["lastScan"];
   const response = await buildFilesResponse(request, {
     listFilesWithProjectCatalog: async (selectedProject, pinnedPath) => {
       const scan = await cachedFileScan(
@@ -27,10 +31,22 @@ export async function GET(request: Request): Promise<Response> {
       );
       responseGeneration = scan.generation;
       targetGeneration = scan.targetGeneration;
+      cacheStatus = scan.cacheStatus;
+      requestCount = scan.requestCount;
+      cloneDurationMs = scan.cloneDurationMs;
+      lastScan = scan.lastScan;
       return { ...scan.snapshot, pinOverlayPaths: scan.pinOverlayPaths };
     },
   });
   response.headers.set("x-llv-files-generation", String(responseGeneration));
   response.headers.set("x-llv-files-target-generation", String(targetGeneration));
+  response.headers.set("x-llv-files-cache", cacheStatus);
+  response.headers.set("x-llv-files-cache-requests", String(requestCount));
+  const serverTiming = [`files-clone;dur=${cloneDurationMs.toFixed(1)}`];
+  if (lastScan) {
+    const failure = lastScan.status === "failed" ? " failed" : "";
+    serverTiming.push(`files-scan;dur=${lastScan.durationMs.toFixed(1)};desc="${lastScan.reason} generation ${lastScan.generation}${failure}"`);
+  }
+  response.headers.set("server-timing", serverTiming.join(", "));
   return response;
 }

--- a/src/app/api/files/scanCache.real.test.ts
+++ b/src/app/api/files/scanCache.real.test.ts
@@ -18,7 +18,7 @@ fs.mkdirSync(sessions, { recursive: true });
 
 const { listFilesWithProjectCatalog } = await import("@/lib/scanner");
 const { ROOTS } = await import("@/lib/scanner/roots");
-const { cachedFileScan, resetFilesRouteCacheForTests } = await import("@/lib/scanner/scanCache");
+const { cachedFileScan, currentFileScan, resetFilesRouteCacheForTests } = await import("@/lib/scanner/scanCache");
 
 function writeSession(filename: string, cwd: string): string {
   const pathname = path.join(sessions, filename);
@@ -89,6 +89,146 @@ test("real cached scans repair private state modes under umask 000", async () =>
     fs.rmSync(privateStateDir, { recursive: true, force: true });
   }
 });
+
+test("a persisted completed generation avoids cold tail rereads for unchanged transcripts", async () => {
+  const previousTestStateDir = process.env.LLV_STATE_DIR;
+  const testStateDir = path.join(sandbox, "durable-tail-reuse-state");
+  const transcript = path.join(sessions, "durable-tail-reuse.jsonl");
+  const originalOpen = fs.openSync;
+  const originalClose = fs.closeSync;
+  const originalRead = fs.readSync;
+  const tracked = new Set<number>();
+  let tailReads = 0;
+  try {
+    process.env.LLV_STATE_DIR = testStateDir;
+    resetFilesRouteCacheForTests();
+    fs.writeFileSync(transcript, [
+      JSON.stringify({ type: "session_meta", payload: { cwd: "/repo/durable-tail", model: "gpt-5" } }),
+      "x".repeat(600_000),
+      JSON.stringify({ type: "event_msg", payload: { type: "task_complete" } }),
+      "",
+    ].join("\n"));
+    const initial = await currentFileScan({ fresh: true });
+    expect(initial.snapshot.files.find((entry) => entry.path === transcript)).toBeDefined();
+
+    const cacheStore = globalThis as typeof globalThis & { __llvCaches?: Record<string, Map<string, unknown>> };
+    for (const cache of Object.values(cacheStore.__llvCaches ?? {})) cache.clear();
+    resetFilesRouteCacheForTests();
+    fs.openSync = ((filename: fs.PathLike, flags: fs.OpenMode, mode?: fs.Mode) => {
+      const fd = originalOpen(filename, flags, mode);
+      if (filename === transcript) tracked.add(fd);
+      return fd;
+    }) as typeof fs.openSync;
+    fs.readSync = ((fd: number, buffer: NodeJS.ArrayBufferView, offset: number, length: number, position: fs.ReadPosition) => {
+      if (tracked.has(fd) && typeof position === "number" && position > 0) tailReads += 1;
+      return originalRead(fd, buffer, offset, length, position);
+    }) as typeof fs.readSync;
+    fs.closeSync = ((fd: number) => {
+      tracked.delete(fd);
+      return originalClose(fd);
+    }) as typeof fs.closeSync;
+
+    const restarted = await currentFileScan({ fresh: true });
+
+    expect(restarted.snapshot.files.find((entry) => entry.path === transcript)).toBeDefined();
+    expect(tailReads).toBe(0);
+  } finally {
+    fs.openSync = originalOpen;
+    fs.closeSync = originalClose;
+    fs.readSync = originalRead;
+    fs.rmSync(transcript, { force: true });
+    process.env.LLV_STATE_DIR = previousTestStateDir;
+    resetFilesRouteCacheForTests();
+    fs.rmSync(testStateDir, { recursive: true, force: true });
+  }
+}, 20_000);
+
+test("a same-size rewrite after restart invalidates persisted tail derivations", async () => {
+  const previousTestStateDir = process.env.LLV_STATE_DIR;
+  const testStateDir = path.join(sandbox, "durable-tail-rewrite-state");
+  const transcript = path.join(sessions, "durable-tail-rewrite.jsonl");
+  try {
+    process.env.LLV_STATE_DIR = testStateDir;
+    resetFilesRouteCacheForTests();
+    const completed = JSON.stringify({ type: "event_msg", payload: { type: "task_complete" } });
+    const started = `${JSON.stringify({ type: "event_msg", payload: { type: "task_started" } })} `;
+    expect(started).toHaveLength(completed.length);
+    fs.writeFileSync(transcript, `${JSON.stringify({ type: "session_meta", payload: { cwd: "/repo/durable-tail-rewrite" } })}\n${completed}\n`);
+    const initial = await currentFileScan({ fresh: true });
+    expect(initial.snapshot.files.find((entry) => entry.path === transcript)?.activityReason).toBe("jsonl_turn_completed");
+
+    const cacheStore = globalThis as typeof globalThis & { __llvCaches?: Record<string, Map<string, unknown>> };
+    for (const cache of Object.values(cacheStore.__llvCaches ?? {})) cache.clear();
+    resetFilesRouteCacheForTests();
+    const before = fs.statSync(transcript);
+    fs.writeFileSync(transcript, `${JSON.stringify({ type: "session_meta", payload: { cwd: "/repo/durable-tail-rewrite" } })}\n${started}\n`);
+    fs.utimesSync(transcript, before.atime, new Date(before.mtimeMs + 1_000));
+
+    const restarted = await currentFileScan({ fresh: true });
+
+    expect(restarted.snapshot.files.find((entry) => entry.path === transcript)?.activityReason).toBe("jsonl_turn_open");
+  } finally {
+    fs.rmSync(transcript, { force: true });
+    process.env.LLV_STATE_DIR = previousTestStateDir;
+    resetFilesRouteCacheForTests();
+    fs.rmSync(testStateDir, { recursive: true, force: true });
+  }
+}, 20_000);
+
+test("one file generation reads each transcript tail once beyond the tail-cache cap", async () => {
+  const previousTestStateDir = process.env.LLV_STATE_DIR;
+  const testStateDir = path.join(sandbox, "single-tail-read-state");
+  const fixtureDir = path.join(sessions, "single-tail-read");
+  const originalOpen = fs.openSync;
+  const originalClose = fs.closeSync;
+  const originalRead = fs.readSync;
+  const tracked = new Set<number>();
+  let tailReads = 0;
+  try {
+    process.env.LLV_STATE_DIR = testStateDir;
+    fs.mkdirSync(fixtureDir, { recursive: true });
+    for (let index = 0; index < 65; index += 1) {
+      fs.writeFileSync(path.join(fixtureDir, `rollout-${String(index).padStart(3, "0")}.jsonl`), [
+        JSON.stringify({ type: "session_meta", payload: { cwd: "/repo/tail-cache" } }),
+        "x".repeat(140_000),
+        JSON.stringify({ type: "turn_context", payload: { model: "gpt-5", effort: "high" } }),
+        JSON.stringify({ type: "event_msg", payload: { type: "task_complete" } }),
+        "",
+      ].join("\n"));
+    }
+    const cacheStore = globalThis as typeof globalThis & { __llvCaches?: Record<string, Map<string, unknown>> };
+    for (const cache of Object.values(cacheStore.__llvCaches ?? {})) cache.clear();
+    resetFilesRouteCacheForTests();
+    fs.openSync = ((filename: fs.PathLike, flags: fs.OpenMode, mode?: fs.Mode) => {
+      const fd = originalOpen(filename, flags, mode);
+      if (typeof filename === "string" && filename.startsWith(fixtureDir + path.sep)) tracked.add(fd);
+      return fd;
+    }) as typeof fs.openSync;
+    fs.readSync = ((fd: number, buffer: NodeJS.ArrayBufferView, offset: number, length: number, position: fs.ReadPosition) => {
+      if (tracked.has(fd) && typeof position === "number" && position > 0) tailReads += 1;
+      return originalRead(fd, buffer, offset, length, position);
+    }) as typeof fs.readSync;
+    fs.closeSync = ((fd: number) => {
+      tracked.delete(fd);
+      return originalClose(fd);
+    }) as typeof fs.closeSync;
+
+    const scan = await currentFileScan({ fresh: true });
+
+    expect(scan.snapshot.files.filter((entry) => entry.path.startsWith(fixtureDir + path.sep))).toHaveLength(65);
+    expect(tailReads).toBe(65);
+  } finally {
+    fs.openSync = originalOpen;
+    fs.closeSync = originalClose;
+    fs.readSync = originalRead;
+    fs.rmSync(fixtureDir, { recursive: true, force: true });
+    process.env.LLV_STATE_DIR = previousTestStateDir;
+    resetFilesRouteCacheForTests();
+    fs.rmSync(testStateDir, { recursive: true, force: true });
+    const cacheStore = globalThis as typeof globalThis & { __llvCaches?: Record<string, Map<string, unknown>> };
+    for (const cache of Object.values(cacheStore.__llvCaches ?? {})) cache.clear();
+  }
+}, 30_000);
 
 test("a transient real scanner failure preserves the completed route snapshot until recovery", async () => {
   resetFilesRouteCacheForTests();

--- a/src/app/api/resources/route.ts
+++ b/src/app/api/resources/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 
-import { readResources } from "@/lib/resources";
+import { lastResourceBuildDiagnostic, noteResourceSerialization, readResources } from "@/lib/resources";
 import { rejectCrossOrigin } from "@/lib/sameOrigin";
 import type { ApiError, ResourcesPayload } from "@/lib/types";
 
@@ -13,5 +13,11 @@ export async function GET(req: NextRequest): Promise<NextResponse<ResourcesPaylo
   const rejection = rejectCrossOrigin(req);
   if (rejection) return rejection;
   const fresh = req.nextUrl.searchParams.get("fresh") === "1";
-  return NextResponse.json(await readResources(fresh));
+  const payload = await readResources(fresh);
+  const serializationStartedAt = performance.now();
+  const response = NextResponse.json(payload);
+  noteResourceSerialization(performance.now() - serializationStartedAt);
+  const diagnostic = lastResourceBuildDiagnostic();
+  if (diagnostic) response.headers.set("x-llv-resource-phases", JSON.stringify(diagnostic));
+  return response;
 }

--- a/src/app/api/resources/route.ts
+++ b/src/app/api/resources/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 
-import { readResourcesWithDiagnostic } from "@/lib/resources";
+import { readResourcesWithDiagnostic, resourceDiagnosticHeader } from "@/lib/resources";
 import { rejectCrossOrigin } from "@/lib/sameOrigin";
 import type { ApiError, ResourcesPayload } from "@/lib/types";
 
@@ -20,6 +20,6 @@ export async function GET(req: NextRequest): Promise<NextResponse<ResourcesPaylo
     ...diagnostic,
     phases: { ...diagnostic.phases, serialization: performance.now() - serializationStartedAt },
   };
-  response.headers.set("x-llv-resource-phases", JSON.stringify(servedDiagnostic));
+  response.headers.set("x-llv-resource-phases", resourceDiagnosticHeader(servedDiagnostic));
   return response;
 }

--- a/src/app/api/resources/route.ts
+++ b/src/app/api/resources/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 
-import { noteResourceSerialization, readResourcesWithDiagnostic } from "@/lib/resources";
+import { readResourcesWithDiagnostic } from "@/lib/resources";
 import { rejectCrossOrigin } from "@/lib/sameOrigin";
 import type { ApiError, ResourcesPayload } from "@/lib/types";
 
@@ -16,7 +16,10 @@ export async function GET(req: NextRequest): Promise<NextResponse<ResourcesPaylo
   const { payload, diagnostic } = await readResourcesWithDiagnostic(fresh);
   const serializationStartedAt = performance.now();
   const response = NextResponse.json(payload);
-  noteResourceSerialization(performance.now() - serializationStartedAt);
-  response.headers.set("x-llv-resource-phases", JSON.stringify(diagnostic));
+  const servedDiagnostic = {
+    ...diagnostic,
+    phases: { ...diagnostic.phases, serialization: performance.now() - serializationStartedAt },
+  };
+  response.headers.set("x-llv-resource-phases", JSON.stringify(servedDiagnostic));
   return response;
 }

--- a/src/app/api/resources/route.ts
+++ b/src/app/api/resources/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 
-import { lastResourceBuildDiagnostic, noteResourceSerialization, readResources } from "@/lib/resources";
+import { noteResourceSerialization, readResourcesWithDiagnostic } from "@/lib/resources";
 import { rejectCrossOrigin } from "@/lib/sameOrigin";
 import type { ApiError, ResourcesPayload } from "@/lib/types";
 
@@ -13,11 +13,10 @@ export async function GET(req: NextRequest): Promise<NextResponse<ResourcesPaylo
   const rejection = rejectCrossOrigin(req);
   if (rejection) return rejection;
   const fresh = req.nextUrl.searchParams.get("fresh") === "1";
-  const payload = await readResources(fresh);
+  const { payload, diagnostic } = await readResourcesWithDiagnostic(fresh);
   const serializationStartedAt = performance.now();
   const response = NextResponse.json(payload);
   noteResourceSerialization(performance.now() - serializationStartedAt);
-  const diagnostic = lastResourceBuildDiagnostic();
-  if (diagnostic) response.headers.set("x-llv-resource-phases", JSON.stringify(diagnostic));
+  response.headers.set("x-llv-resource-phases", JSON.stringify(diagnostic));
   return response;
 }

--- a/src/lib/agent/transcriptHost.test.ts
+++ b/src/lib/agent/transcriptHost.test.ts
@@ -424,6 +424,24 @@ describe("transcript host resolver", () => {
     expect(state.spawnCalls).toBe(0);
   });
 
+  test("a recycled scanner pid stays orphaned while current argv ownership remains canonical", async () => {
+    const { resolver, state } = fakeHost();
+    state.agents[0] = {
+      ...state.agents[0]!,
+      argv: ["codex", "resume", "00000000-0000-0000-0000-000000000000"],
+    };
+    state.panes.set(101, { paneId: "%2", target: "agents:6.0" });
+    state.agents.push({ pid: 201, engine: "codex", argv: ["codex", "resume", SESSION], cwd: "/repo", tty: 1 });
+    state.ppids.set(201, 101);
+    state.identities.set(201, "201:one");
+
+    const snapshot = await resolver.readTranscriptHosts(true);
+
+    expect(snapshot.hosts.find((host) => host.agentPid === 200)?.primaryPath).toBeNull();
+    expect(snapshot.canonicalFor(PATHNAME)?.agentPid).toBe(201);
+    expect(snapshot.conflicts).toEqual([]);
+  });
+
   test("reports resumed to a joined sender that owns recovery after the live host exits", async () => {
     const { resolver, state } = fakeHost();
     /* decide() validates once, then each concurrent sender validates again.

--- a/src/lib/agent/transcriptHost.ts
+++ b/src/lib/agent/transcriptHost.ts
@@ -647,7 +647,9 @@ const observationResolver = createTranscriptHostResolver({
   ppidMap: () => procBackend.ppidMap(),
   agents: agentProcesses,
   serverPid: tmuxServerPid,
-  resumeRecords: registryResumeRecords,
+  /* Importing resume records repairs registry state. Observation only reads
+     live process and pane evidence, so a collector child stays read-only. */
+  resumeRecords: async () => null,
   panePid: panePidOf,
   paneWindowName: async (paneId) => (await paneInfo(paneId))?.windowName ?? null,
   alive: pidAlive,

--- a/src/lib/agent/transcriptHost.ts
+++ b/src/lib/agent/transcriptHost.ts
@@ -90,27 +90,30 @@ const globalStore = globalThis as unknown as {
   __llvTranscriptHostDecisions?: Map<string, Promise<Decision>>;
 };
 
-interface HostDependencies {
+export interface TranscriptHostObservationDependencies {
   listFiles: () => Promise<FileEntry[]>;
   panes: (fresh: boolean) => Promise<PaneObservation>;
   ppidMap: () => Map<number, number>;
   agents: (fresh: boolean) => AgentProcess[];
   serverPid: () => Promise<number | null>;
   resumeRecords: () => ReturnType<typeof resumePaneRecords>;
+  identity: (pid: number) => string | null;
+  launchId?: (paneId: string) => Promise<string | null>;
+  conversationIdForPath?: (pathname: string) => string | null;
+  reconcile?: (hosts: TranscriptHost[]) => HostReconciliation | void | Promise<HostReconciliation | void>;
+}
+
+interface HostDependencies extends TranscriptHostObservationDependencies {
   panePid: (paneId: string) => Promise<number | null>;
   paneWindowName?: (paneId: string) => Promise<string | null>;
   alive: (pid: number) => boolean;
   argv: (pid: number) => string[];
   parentPid: (pid: number) => number | null;
-  identity: (pid: number) => string | null;
   spawn: (spec: ResumeSpec, text: string, receipt?: SpawnReceipt) => Promise<SpawnedPane>;
   beginResume?: (entry: FileEntry, spec: ResumeSpec) => { receipt: SpawnReceipt; spec: ResumeSpec } | null;
   remember: (pathname: string, spec: ResumeSpec, pane: SpawnedPane) => Promise<void>;
   deliver: (paneId: string, text: string) => Promise<void>;
   confirmAlive?: (host: TranscriptHost) => void | Promise<void>;
-  launchId?: (paneId: string) => Promise<string | null>;
-  conversationIdForPath?: (pathname: string) => string | null;
-  reconcile?: (hosts: TranscriptHost[]) => HostReconciliation | void | Promise<HostReconciliation | void>;
   serializeDelivery?: (entry: FileEntry, task: () => Promise<HostDeliveryOutcome>) => Promise<HostDeliveryOutcome>;
 }
 
@@ -278,17 +281,8 @@ function failure(error: unknown, status = 500, actuation?: "started"): HostDeliv
   return { ok: false, outcome: "failed", error: error instanceof Error ? error.message : String(error), status: resolvedStatus, ...(actuation ? { actuation } : {}) };
 }
 
-/**
- * Creates the deep transcript-host module. The optional dependencies form a
- * test seam; production callers use the singleton below and only learn the
- * two operational methods exported at the end of this file.
- */
-export function createTranscriptHostResolver(
-  dependencies: HostDependencies,
-  decisions = new Map<string, Promise<Decision>>(),
-): TranscriptHostResolver {
-
-  async function observe(
+export function createTranscriptHostObserver(dependencies: TranscriptHostObservationDependencies) {
+  return async function observe(
     fresh: boolean,
     suppliedEntries?: FileEntry[],
     suppliedPpids?: Map<number, number>,
@@ -356,7 +350,19 @@ export function createTranscriptHostResolver(
       canonicalFor: (pathname: string) => conflictForPath(snapshot, pathname, conversationIdForPath) ? null : canonicalFrom(eligibleHosts, pathname),
     };
     return snapshot;
-  }
+  };
+}
+
+/**
+ * Creates the deep transcript-host module. The optional dependencies form a
+ * test seam; production callers use the singleton below and only learn the
+ * two operational methods exported at the end of this file.
+ */
+export function createTranscriptHostResolver(
+  dependencies: HostDependencies,
+  decisions = new Map<string, Promise<Decision>>(),
+): TranscriptHostResolver {
+  const observe = createTranscriptHostObserver(dependencies);
 
   async function revalidate(host: TranscriptHost, entry: FileEntry): Promise<boolean> {
     if (host.engine !== entry.engine || (await dependencies.serverPid()) !== host.tmuxServerPid) return false;
@@ -639,30 +645,5 @@ const runtimeResolver = createTranscriptHostResolver({
   serializeDelivery: serializeRegistryDelivery,
 }, globalStore.__llvTranscriptHostDecisions ??= new Map());
 
-/* Resource observation intentionally avoids reconciliation, spawn confirmation,
-   and per-pane launch-id reads. The Viewer main runtime owns those writes. */
-const observationResolver = createTranscriptHostResolver({
-  listFiles,
-  panes: panePidMap,
-  ppidMap: () => procBackend.ppidMap(),
-  agents: agentProcesses,
-  serverPid: tmuxServerPid,
-  /* Importing resume records repairs registry state. Observation only reads
-     live process and pane evidence, so a collector child stays read-only. */
-  resumeRecords: async () => null,
-  panePid: panePidOf,
-  paneWindowName: async (paneId) => (await paneInfo(paneId))?.windowName ?? null,
-  alive: pidAlive,
-  argv: readArgv,
-  parentPid: readPpid,
-  identity: procBackend.processIdentity,
-  conversationIdForPath: (pathname) => agentRegistry().conversationForPath(pathname)?.id ?? null,
-  beginResume: beginRegistryResume,
-  spawn: spawnAgentWithPrompt,
-  remember: rememberRegistryResume,
-  deliver: sendText,
-}, new Map());
-
 export const readTranscriptHosts = runtimeResolver.readTranscriptHosts;
-export const readTranscriptHostsObservation = observationResolver.readTranscriptHosts;
 export const deliverToTranscriptHost = runtimeResolver.deliverToTranscriptHost;

--- a/src/lib/agent/transcriptHost.ts
+++ b/src/lib/agent/transcriptHost.ts
@@ -4,7 +4,7 @@ import { sessionKeyFromTranscript } from "@/lib/agent/sessionKey";
 import { procBackend } from "@/lib/proc";
 import { descendantPids } from "@/lib/proc/memory";
 import { listFiles } from "@/lib/scanner";
-import { agentProcesses, argvEngine, pidAlive, readArgv, readPpid, type AgentProcess } from "@/lib/scanner/process";
+import { agentProcesses, argvEngine, pidAlive, pidHoldsPath, readArgv, readPpid, type AgentProcess } from "@/lib/scanner/process";
 import {
   panePidMap,
   panePidOf,
@@ -98,6 +98,7 @@ export interface TranscriptHostObservationDependencies {
   serverPid: () => Promise<number | null>;
   resumeRecords: () => ReturnType<typeof resumePaneRecords>;
   identity: (pid: number) => string | null;
+  holdsPath?: (pid: number, pathname: string) => boolean;
   launchId?: (paneId: string) => Promise<string | null>;
   conversationIdForPath?: (pathname: string) => string | null;
   reconcile?: (hosts: TranscriptHost[]) => HostReconciliation | void | Promise<HostReconciliation | void>;
@@ -180,10 +181,18 @@ function claimsForAgent(
   entriesByPid: Map<number, FileEntry>,
   entriesByUuid: Map<string, FileEntry>,
   records: Awaited<ReturnType<typeof resumePaneRecords>>,
+  holdsPath: (pid: number, pathname: string) => boolean,
 ): HostClaim[] {
   const claims: HostClaim[] = [];
   const direct = entriesByPid.get(agent.pid);
-  if (direct?.engine === agent.engine) claims.push({ pathname: direct.path, source: "scanner" });
+  const argvUuid = argvSessionUuid(agent.argv);
+  const directUuid = direct ? sessionUuid(direct.path) : null;
+  if (direct?.engine === agent.engine && (
+    (argvUuid !== null && directUuid !== null && argvUuid === directUuid)
+    || holdsPath(agent.pid, direct.path)
+  )) {
+    claims.push({ pathname: direct.path, source: "scanner" });
+  }
 
   if (records) {
     for (const [pathname, record] of records.records) {
@@ -197,8 +206,7 @@ function claimsForAgent(
     }
   }
 
-  const byArgv = argvSessionUuid(agent.argv);
-  const matched = byArgv ? entriesByUuid.get(byArgv) : undefined;
+  const matched = argvUuid ? entriesByUuid.get(argvUuid) : undefined;
   if (matched?.engine === agent.engine) claims.push({ pathname: matched.path, source: "argv" });
   return claims;
 }
@@ -317,7 +325,7 @@ export function createTranscriptHostObserver(dependencies: TranscriptHostObserva
       const tree = new Set(descendantPids(panePid, ppids));
       for (const agent of agents) {
         if (!tree.has(agent.pid)) continue;
-        const claims = claimsForAgent(agent, pane, panePid, byPid, byUuid, records);
+        const claims = claimsForAgent(agent, pane, panePid, byPid, byUuid, records, dependencies.holdsPath ?? (() => false));
         const primary = primaryClaim(claims);
         hosts.push({
           tmuxServerPid: serverPid,
@@ -634,6 +642,7 @@ const runtimeResolver = createTranscriptHostResolver({
   argv: readArgv,
   parentPid: readPpid,
   identity: procBackend.processIdentity,
+  holdsPath: pidHoldsPath,
   launchId: paneLaunchId,
   conversationIdForPath: (pathname) => agentRegistry().conversationForPath(pathname)?.id ?? null,
   beginResume: beginRegistryResume,

--- a/src/lib/agent/transcriptHost.ts
+++ b/src/lib/agent/transcriptHost.ts
@@ -82,7 +82,7 @@ export type HostDeliveryOutcome =
   | { ok: false; outcome: "failed"; error: string; status: number; actuation?: "started" };
 
 export interface TranscriptHostResolver {
-  readTranscriptHosts(fresh?: boolean, entries?: FileEntry[]): Promise<TranscriptHostSnapshot>;
+  readTranscriptHosts(fresh?: boolean, entries?: FileEntry[], ppids?: Map<number, number>): Promise<TranscriptHostSnapshot>;
   deliverToTranscriptHost(input: { entry: FileEntry; spec: ResumeSpec; payload: string }): Promise<HostDeliveryOutcome>;
 }
 
@@ -288,7 +288,11 @@ export function createTranscriptHostResolver(
   decisions = new Map<string, Promise<Decision>>(),
 ): TranscriptHostResolver {
 
-  async function observe(fresh: boolean, suppliedEntries?: FileEntry[]): Promise<TranscriptHostSnapshot> {
+  async function observe(
+    fresh: boolean,
+    suppliedEntries?: FileEntry[],
+    suppliedPpids?: Map<number, number>,
+  ): Promise<TranscriptHostSnapshot> {
     const conversationIdForPath = dependencies.conversationIdForPath ?? (() => null);
     const [entries, paneObservation, records] = await Promise.all([
       suppliedEntries ?? dependencies.listFiles(),
@@ -309,7 +313,7 @@ export function createTranscriptHostResolver(
     }
     const { panes } = paneObservation;
 
-    const ppids = dependencies.ppidMap();
+    const ppids = suppliedPpids ?? dependencies.ppidMap();
     const agents = dependencies.agents(fresh);
     const byPid = rootEntryByPid(entries);
     const byUuid = rootEntryByUuid(entries);
@@ -635,5 +639,28 @@ const runtimeResolver = createTranscriptHostResolver({
   serializeDelivery: serializeRegistryDelivery,
 }, globalStore.__llvTranscriptHostDecisions ??= new Map());
 
+/* Resource observation intentionally avoids reconciliation, spawn confirmation,
+   and per-pane launch-id reads. The Viewer main runtime owns those writes. */
+const observationResolver = createTranscriptHostResolver({
+  listFiles,
+  panes: panePidMap,
+  ppidMap: () => procBackend.ppidMap(),
+  agents: agentProcesses,
+  serverPid: tmuxServerPid,
+  resumeRecords: registryResumeRecords,
+  panePid: panePidOf,
+  paneWindowName: async (paneId) => (await paneInfo(paneId))?.windowName ?? null,
+  alive: pidAlive,
+  argv: readArgv,
+  parentPid: readPpid,
+  identity: procBackend.processIdentity,
+  conversationIdForPath: (pathname) => agentRegistry().conversationForPath(pathname)?.id ?? null,
+  beginResume: beginRegistryResume,
+  spawn: spawnAgentWithPrompt,
+  remember: rememberRegistryResume,
+  deliver: sendText,
+}, new Map());
+
 export const readTranscriptHosts = runtimeResolver.readTranscriptHosts;
+export const readTranscriptHostsObservation = observationResolver.readTranscriptHosts;
 export const deliverToTranscriptHost = runtimeResolver.deliverToTranscriptHost;

--- a/src/lib/configDir.ts
+++ b/src/lib/configDir.ts
@@ -65,6 +65,7 @@ const MIGRATED_SENTINEL = ".migrated-from-legacy";
  * next call retries instead of silently accepting an empty state dir.
  */
 export function migrateLegacyDir(target: string, legacy: string): void {
+  if (process.env.LLV_RESOURCE_OBSERVATION_WORKER === "1") return;
   if (migrated.has(target)) return;
   const sentinel = path.join(target, MIGRATED_SENTINEL);
   const stamp = () => `${new Date().toISOString()} ${legacy}\n`;

--- a/src/lib/resourceCollector.test.ts
+++ b/src/lib/resourceCollector.test.ts
@@ -324,6 +324,102 @@ describe("resource collector", () => {
     expect(Buffer.byteLength(diagnostic)).toBeLessThanOrEqual(RESOURCE_FAILURE_STDERR_MAX_BYTES);
   });
 
+  test("static and streaming diagnostics redact quoted Authorization keys and quoted Bearer values", async () => {
+    const cases = [
+      {
+        name: "quoted JSON Basic",
+        input: '{"Authorization":"Basic QUOTED_JSON_BASIC_LEAK","safe":"SAFE_JSON_FIELD"}',
+        safe: "SAFE_JSON_FIELD",
+        secrets: ["QUOTED_JSON_BASIC_LEAK"],
+      },
+      {
+        name: "single-quoted Digest",
+        input: "{'Authorization':'Digest username=\"DIGEST_USER_LEAK\" response=\"DIGEST_RESPONSE_LEAK\"','safe':'SAFE_DIGEST_FIELD'}",
+        safe: "SAFE_DIGEST_FIELD",
+        secrets: ["DIGEST_USER_LEAK", "DIGEST_RESPONSE_LEAK"],
+      },
+      {
+        name: "quoted JSON Negotiate",
+        input: '{"Authorization":"Negotiate NEGOTIATE_LEAK FIRST_TAIL SECOND_TAIL","safe":"SAFE_NEGOTIATE_FIELD"}',
+        safe: "SAFE_NEGOTIATE_FIELD",
+        secrets: ["NEGOTIATE_LEAK", "FIRST_TAIL", "SECOND_TAIL"],
+      },
+      {
+        name: "quoted JSON custom scheme",
+        input: '{"Authorization":"Custom scheme=CUSTOM_LEAK quoted=\\\"CUSTOM_TAIL VALUE\\\"","safe":"SAFE_CUSTOM_FIELD"}',
+        safe: "SAFE_CUSTOM_FIELD",
+        secrets: ["CUSTOM_LEAK", "CUSTOM_TAIL"],
+      },
+      {
+        name: "double-quoted Bearer value",
+        input: 'Bearer "PART_A_LEAK PART_B_LEAK"\r\nX-Safe-After: SAFE_BEARER_FIELD',
+        safe: "SAFE_BEARER_FIELD",
+        secrets: ["PART_A_LEAK", "PART_B_LEAK"],
+      },
+      {
+        name: "single-quoted Bearer value",
+        input: "Bearer 'SINGLE_PART_A_LEAK SINGLE_PART_B_LEAK'\nX-Safe-After: SAFE_SINGLE_BEARER_FIELD",
+        safe: "SAFE_SINGLE_BEARER_FIELD",
+        secrets: ["SINGLE_PART_A_LEAK", "SINGLE_PART_B_LEAK"],
+      },
+    ];
+
+    for (const fixture of cases) {
+      for (let split = 0; split <= fixture.input.length; split += 1) {
+        const tail = createResourceDiagnosticTail();
+        tail.append(fixture.input.slice(0, split));
+        tail.append(fixture.input.slice(split));
+        const streamed = tail.value();
+        const label = `${fixture.name} split ${split}`;
+
+        expect(streamed.includes("<redacted>"), label).toBeTrue();
+        expect(streamed.includes(fixture.safe), label).toBeTrue();
+        expect(streamed.includes("\uFFFD"), label).toBeFalse();
+        expect(Buffer.byteLength(streamed), label).toBeLessThanOrEqual(RESOURCE_FAILURE_STDERR_MAX_BYTES);
+        for (const secret of fixture.secrets) {
+          expect(streamed.includes(secret), `${label} secret ${secret}`).toBeFalse();
+        }
+      }
+
+      const collector = createResourceCollector({
+        collectorId: `quoted-static-${fixture.name}`,
+        collect: async () => {
+          throw new ResourceCollectorFailureError(
+            "collector-crash",
+            "collector-error",
+            "resource collection failed",
+            { cause: new Error(fixture.input), stderr: fixture.input },
+          );
+        },
+      });
+      const result = await collector.observe(0, 1_000);
+      const cause = result.failure?.diagnostic.causes[0] ?? "";
+      const stderr = result.failure?.diagnostic.stderr ?? "";
+
+      expect(cause.includes(fixture.safe), `${fixture.name} static cause safe field`).toBeTrue();
+      expect(stderr.includes(fixture.safe), `${fixture.name} static stderr safe field`).toBeTrue();
+      for (const secret of fixture.secrets) {
+        expect(cause.includes(secret), `${fixture.name} static cause secret ${secret}`).toBeFalse();
+        expect(stderr.includes(secret), `${fixture.name} static stderr secret ${secret}`).toBeFalse();
+      }
+    }
+
+    const longSecret = "LONG_QUOTED_BEARER_LEAK ".repeat(1_000);
+    const longTail = createResourceDiagnosticTail();
+    longTail.append('Bearer "');
+    for (let offset = 0; offset < longSecret.length; offset += 61) {
+      longTail.append(longSecret.slice(offset, offset + 61));
+    }
+    longTail.append('"\r\nX-Safe-After: LONG_SAFE_SUFFIX 😀');
+    const longDiagnostic = longTail.value();
+
+    expect(longDiagnostic).toContain("Bearer <redacted>");
+    expect(longDiagnostic).toContain("LONG_SAFE_SUFFIX 😀");
+    expect(longDiagnostic).not.toContain("LONG_QUOTED_BEARER_LEAK");
+    expect(longDiagnostic).not.toContain("\uFFFD");
+    expect(Buffer.byteLength(longDiagnostic)).toBeLessThanOrEqual(RESOURCE_FAILURE_STDERR_MAX_BYTES);
+  });
+
   test("stderr tail truncation preserves every UTF-8 boundary", async () => {
     for (const character of ["é", "€", "😀"]) {
       const width = Buffer.byteLength(character);

--- a/src/lib/resourceCollector.test.ts
+++ b/src/lib/resourceCollector.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 
-import { createResourceCollector, ResourceCollectorFailureError, RESOURCE_FAILURE_STDERR_MAX_BYTES } from "./resourceCollector";
+import { createResourceCollector, createResourceDiagnosticTail, ResourceCollectorFailureError, RESOURCE_FAILURE_STDERR_MAX_BYTES } from "./resourceCollector";
 
 function deferred<T>() {
   let resolve!: (value: T) => void;
@@ -98,6 +98,133 @@ describe("resource collector", () => {
     expect(Buffer.byteLength(stderr)).toBe(RESOURCE_FAILURE_STDERR_MAX_BYTES);
     expect(stderr).toContain("API_TOKEN=<redacted>");
     expect(stderr).not.toContain("stderr-secret");
+  });
+
+  test("streaming diagnostics fully redact a bare Bearer credential", () => {
+    const tail = createResourceDiagnosticTail();
+    tail.append("Bearer bare-secret-sentinel\nsafe suffix");
+
+    expect(tail.value()).toContain("Bearer <redacted>");
+    expect(tail.value()).toContain("safe suffix");
+    expect(tail.value()).not.toContain("bare-secret-sentinel");
+  });
+
+  test("streaming diagnostics retain keyed Authorization Bearer state across chunks", () => {
+    const tail = createResourceDiagnosticTail();
+    tail.append("Authorization: Bear");
+    tail.append("er keyed-secret-sentinel\nsafe suffix");
+
+    expect(tail.value()).toContain("Authorization=<redacted>");
+    expect(tail.value()).toContain("safe suffix");
+    expect(tail.value()).not.toContain("keyed-secret-sentinel");
+  });
+
+  test("streaming diagnostics fully redact a single-quoted Bearer credential", () => {
+    const tail = createResourceDiagnosticTail();
+    const fragments = ["SINGLELEAK", "QUOTEDLEAK", "SECRETLEAK"];
+    tail.append(`Authorization: Bearer '${fragments.join(" ")}'\nsafe suffix`);
+
+    expect(tail.value()).toContain("Authorization=<redacted>");
+    expect(tail.value()).toContain("safe suffix");
+    for (const fragment of fragments) expect(tail.value()).not.toContain(fragment);
+  });
+
+  test("streaming diagnostics fully redact a double-quoted Bearer credential", () => {
+    const tail = createResourceDiagnosticTail();
+    const fragments = ["DOUBLELEAK", "QUOTEDLEAK", "SECRETLEAK"];
+    tail.append(`Authorization: Bearer "${fragments.join(" ")}"\nsafe suffix`);
+
+    expect(tail.value()).toContain("Authorization=<redacted>");
+    expect(tail.value()).toContain("safe suffix");
+    for (const fragment of fragments) expect(tail.value()).not.toContain(fragment);
+  });
+
+  test("streaming diagnostics bound long Bearer credentials while retaining a safe suffix", async () => {
+    const tail = createResourceDiagnosticTail();
+    const credential = "LONGLEAK!".repeat(1_000);
+    tail.append("discarded-safe-prefix\n".repeat(300));
+    tail.append("Authorization: Bearer ");
+    for (let offset = 0; offset < credential.length; offset += 137) {
+      tail.append(credential.slice(offset, offset + 137));
+    }
+    tail.append("\nsafe diagnostic suffix 😀");
+    const streamed = tail.value();
+    const collector = createResourceCollector({
+      collectorId: "long-bearer",
+      collect: async () => {
+        throw new ResourceCollectorFailureError(
+          "collector-crash",
+          "collector-error",
+          "resource collection failed",
+          { stderr: streamed },
+        );
+      },
+    });
+    const result = await collector.observe(0, 1_000);
+    const diagnostic = result.failure?.diagnostic.stderr ?? "";
+
+    expect(Buffer.byteLength(streamed)).toBeLessThanOrEqual((RESOURCE_FAILURE_STDERR_MAX_BYTES * 2) + (256 * 4));
+    expect(diagnostic).toContain("Authorization=<redacted>");
+    expect(diagnostic).toContain("safe diagnostic suffix 😀");
+    expect(diagnostic).not.toContain("LONGLEAK");
+    expect(diagnostic).not.toContain("\uFFFD");
+    expect(Buffer.byteLength(diagnostic)).toBeLessThanOrEqual(RESOURCE_FAILURE_STDERR_MAX_BYTES);
+  });
+
+  test("streaming diagnostics retain Authorization Bearer state through prefix eviction", () => {
+    const tail = createResourceDiagnosticTail();
+    tail.append(`Authorization:${" ".repeat(600)}`);
+    tail.append(`Bearer${" ".repeat(600)}`);
+    tail.append("EVICTIONLEAK!\nsafe suffix");
+    const diagnostic = tail.value();
+
+    expect(diagnostic).toContain("<redacted>");
+    expect(diagnostic).toContain("safe suffix");
+    expect(diagnostic).not.toContain("EVICTIONLEAK");
+    expect(Buffer.byteLength(diagnostic)).toBeLessThanOrEqual((RESOURCE_FAILURE_STDERR_MAX_BYTES * 2) + (256 * 4));
+  });
+
+  test("streaming diagnostics retain an evicted Authorization key before its delimiter", () => {
+    const tail = createResourceDiagnosticTail();
+    tail.append(`Authorization${" ".repeat(600)}`);
+    tail.append(`:${" ".repeat(600)}`);
+    tail.append("Bearer DELIMITERLEAK!\nsafe suffix");
+    const diagnostic = tail.value();
+
+    expect(diagnostic).toContain("<redacted>");
+    expect(diagnostic).toContain("safe suffix");
+    expect(diagnostic).not.toContain("DELIMITERLEAK");
+    expect(Buffer.byteLength(diagnostic)).toBeLessThanOrEqual((RESOURCE_FAILURE_STDERR_MAX_BYTES * 2) + (256 * 4));
+  });
+
+  test("streaming Bearer redaction covers every split position and quote form", () => {
+    const safeSuffix = "safe suffix é € 😀";
+    const cases = [
+      { name: "bare", input: `prefix é€😀\nBearer BARELEAK-FRAGMENT\n${safeSuffix}`, fragments: ["BARELEAK", "FRAGMENT"] },
+      { name: "keyed", input: `prefix é€😀\nAuthorization: Bearer KEYEDLEAK-FRAGMENT\n${safeSuffix}`, fragments: ["KEYEDLEAK", "FRAGMENT"] },
+      { name: "single-quoted credential", input: `prefix é€😀\nAuthorization: Bearer 'SINGLELEAK FRAGMENT'\n${safeSuffix}`, fragments: ["SINGLELEAK", "FRAGMENT"] },
+      { name: "double-quoted credential", input: `prefix é€😀\nAuthorization: Bearer "DOUBLELEAK FRAGMENT"\n${safeSuffix}`, fragments: ["DOUBLELEAK", "FRAGMENT"] },
+      { name: "single-quoted value", input: `prefix é€😀\nAuthorization: 'Bearer OUTERSINGLELEAK FRAGMENT'\n${safeSuffix}`, fragments: ["OUTERSINGLELEAK", "FRAGMENT"] },
+      { name: "double-quoted value", input: `prefix é€😀\nAuthorization: "Bearer OUTERDOUBLELEAK FRAGMENT"\n${safeSuffix}`, fragments: ["OUTERDOUBLELEAK", "FRAGMENT"] },
+    ];
+
+    for (const fixture of cases) {
+      for (let split = 0; split <= fixture.input.length; split += 1) {
+        const tail = createResourceDiagnosticTail();
+        tail.append(fixture.input.slice(0, split));
+        tail.append(fixture.input.slice(split));
+        const diagnostic = tail.value();
+        const label = `${fixture.name} split ${split}`;
+
+        expect(diagnostic.includes("<redacted>"), label).toBeTrue();
+        expect(diagnostic.includes(safeSuffix), label).toBeTrue();
+        expect(diagnostic.includes("\uFFFD"), label).toBeFalse();
+        expect(Buffer.byteLength(diagnostic), label).toBeLessThanOrEqual(RESOURCE_FAILURE_STDERR_MAX_BYTES);
+        for (const fragment of fixture.fragments) {
+          expect(diagnostic.includes(fragment), `${label} fragment ${fragment}`).toBeFalse();
+        }
+      }
+    }
   });
 
   test("stderr tail truncation preserves every UTF-8 boundary", async () => {

--- a/src/lib/resourceCollector.test.ts
+++ b/src/lib/resourceCollector.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, test } from "bun:test";
+
+import { createResourceCollector } from "./resourceCollector";
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((res) => { resolve = res; });
+  return { promise, resolve };
+}
+
+describe("resource collector", () => {
+  test("a fresh fence waits for an observation that started after the request", async () => {
+    let now = 0;
+    const first = deferred<string>();
+    const second = deferred<string>();
+    let calls = 0;
+    const collector = createResourceCollector({
+      collectorId: "test-collector",
+      collect: async () => (++calls === 1 ? first.promise : second.promise),
+      now: () => now,
+    });
+
+    const stale = collector.observe(0, 1_000);
+    await Promise.resolve();
+    const requestFence = collector.fence();
+    const fresh = collector.observe(requestFence, 1_000);
+    first.resolve("first");
+    await expect(stale).resolves.toMatchObject({ generation: 1, value: "first" });
+    now = 1;
+    second.resolve("second");
+    await expect(fresh).resolves.toMatchObject({ generation: 2, value: "second" });
+  });
+
+  test("a bounded wait returns the immutable previous observation with a timeout diagnostic", async () => {
+    const first = deferred<string>();
+    const never = deferred<string>();
+    let calls = 0;
+    const collector = createResourceCollector({
+      collectorId: "test-collector",
+      collect: async () => (++calls === 1 ? first.promise : never.promise),
+    });
+
+    const initial = collector.observe(0, 1_000);
+    first.resolve("prior");
+    await initial;
+    const timedOut = await collector.observe(collector.fence(), 1);
+
+    expect(timedOut).toMatchObject({ generation: 1, value: "prior", degradedReason: "timeout" });
+    expect(Object.isFrozen(timedOut)).toBeTrue();
+  });
+
+  test("concurrent callers coalesce only when their fences are already satisfied", async () => {
+    const first = deferred<string>();
+    const second = deferred<string>();
+    let calls = 0;
+    const collector = createResourceCollector({
+      collectorId: "test-collector",
+      collect: async () => (++calls === 1 ? first.promise : second.promise),
+    });
+
+    const one = collector.observe(0, 1_000);
+    const two = collector.observe(0, 1_000);
+    await Promise.resolve();
+    expect(calls).toBe(1);
+    first.resolve("one");
+    await Promise.all([one, two]);
+
+    const fence = collector.fence();
+    const three = collector.observe(fence, 1_000);
+    const four = collector.observe(fence, 1_000);
+    await Promise.resolve();
+    expect(calls).toBe(2);
+    second.resolve("two");
+    await expect(Promise.all([three, four])).resolves.toEqual([
+      expect.objectContaining({ generation: 2, value: "two" }),
+      expect.objectContaining({ generation: 2, value: "two" }),
+    ]);
+  });
+});

--- a/src/lib/resourceCollector.test.ts
+++ b/src/lib/resourceCollector.test.ts
@@ -76,4 +76,19 @@ describe("resource collector", () => {
       expect.objectContaining({ generation: 2, value: "two" }),
     ]);
   });
+
+  test("a durable completed observation serves before any new collection starts", async () => {
+    let calls = 0;
+    const collector = createResourceCollector({
+      collectorId: "test-collector",
+      collect: async () => {
+        calls += 1;
+        return "new";
+      },
+      initial: Object.freeze({ generation: 7, startedAt: 1, completedAt: 2, collectorId: "prior", value: "durable" }),
+    });
+
+    expect(collector.latest()).toMatchObject({ generation: 7, value: "durable" });
+    expect(calls).toBe(0);
+  });
 });

--- a/src/lib/resourceCollector.test.ts
+++ b/src/lib/resourceCollector.test.ts
@@ -100,6 +100,36 @@ describe("resource collector", () => {
     expect(stderr).not.toContain("stderr-secret");
   });
 
+  test("stderr tail truncation preserves every UTF-8 boundary", async () => {
+    for (const character of ["é", "€", "😀"]) {
+      const width = Buffer.byteLength(character);
+      for (let offset = 0; offset < width; offset += 1) {
+        const marker = `\ntail-${width}-${offset}`;
+        const suffixBytes = RESOURCE_FAILURE_STDERR_MAX_BYTES - width + offset;
+        const fillerBytes = suffixBytes - Buffer.byteLength(marker);
+        const filler = "s ".repeat(Math.floor(fillerBytes / 2)) + "s".repeat(fillerBytes % 2);
+        const stderrInput = `prefix${character}${filler}${marker}`;
+        const collector = createResourceCollector({
+          collectorId: `utf8-${width}-${offset}`,
+          collect: async () => {
+            throw new ResourceCollectorFailureError(
+              "collector-crash",
+              "collector-error",
+              "resource collection failed",
+              { stderr: stderrInput },
+            );
+          },
+        });
+
+        const result = await collector.observe(0, 1_000);
+        const stderr = result.failure?.diagnostic.stderr ?? "";
+        expect(Buffer.byteLength(stderr), `width ${width}, offset ${offset}`).toBeLessThanOrEqual(RESOURCE_FAILURE_STDERR_MAX_BYTES);
+        expect(stderr.includes("\uFFFD"), `width ${width}, offset ${offset}`).toBeFalse();
+        expect(stderr.endsWith(marker), `width ${width}, offset ${offset}`).toBeTrue();
+      }
+    }
+  });
+
   test("concurrent callers coalesce only when their fences are already satisfied", async () => {
     const first = deferred<string>();
     const second = deferred<string>();

--- a/src/lib/resourceCollector.test.ts
+++ b/src/lib/resourceCollector.test.ts
@@ -420,6 +420,119 @@ describe("resource collector", () => {
     expect(Buffer.byteLength(longDiagnostic)).toBeLessThanOrEqual(RESOURCE_FAILURE_STDERR_MAX_BYTES);
   });
 
+  test("stringified Authorization diagnostics redact every scheme and multi-token Bearer value", async () => {
+    const stringifiedAuthorization = (authorization: string, safe: string) => JSON.stringify(JSON.stringify({ Authorization: authorization, safe }));
+    const cases = [
+      {
+        name: "Basic",
+        input: stringifiedAuthorization("Basic BASIC_STRINGIFIED_LEAK==", "SAFE_BASIC_é€😀"),
+        safe: "SAFE_BASIC_é€😀",
+        secrets: ["BASIC_STRINGIFIED_LEAK"],
+      },
+      {
+        name: "Digest",
+        input: stringifiedAuthorization('Digest username="DIGEST_USER_LEAK", response="DIGEST_RESPONSE_LEAK"', "SAFE_DIGEST_é€😀"),
+        safe: "SAFE_DIGEST_é€😀",
+        secrets: ["DIGEST_USER_LEAK", "DIGEST_RESPONSE_LEAK"],
+      },
+      {
+        name: "Negotiate",
+        input: stringifiedAuthorization("Negotiate NEGOTIATE_LEAK FIRST_TAIL SECOND_TAIL", "SAFE_NEGOTIATE_é€😀"),
+        safe: "SAFE_NEGOTIATE_é€😀",
+        secrets: ["NEGOTIATE_LEAK", "FIRST_TAIL", "SECOND_TAIL"],
+      },
+      {
+        name: "custom",
+        input: stringifiedAuthorization("Custom scheme=CUSTOM_LEAK tail=CUSTOM_TAIL", "SAFE_CUSTOM_é€😀"),
+        safe: "SAFE_CUSTOM_é€😀",
+        secrets: ["CUSTOM_LEAK", "CUSTOM_TAIL"],
+      },
+      {
+        name: "Bearer",
+        input: stringifiedAuthorization('Bearer "BEARER_FIRST_LEAK BEARER_SECOND_LEAK"', "SAFE_BEARER_é€😀"),
+        safe: "SAFE_BEARER_é€😀",
+        secrets: ["BEARER_FIRST_LEAK", "BEARER_SECOND_LEAK"],
+      },
+      {
+        name: "bare multi-token Bearer",
+        input: "Bearer BARE_FIRST_LEAK BARE_SECOND_LEAK\nSAFE_BARE_é€😀",
+        safe: "SAFE_BARE_é€😀",
+        secrets: ["BARE_FIRST_LEAK", "BARE_SECOND_LEAK"],
+      },
+    ];
+
+    for (const fixture of cases) {
+      for (let split = 0; split <= fixture.input.length; split += 1) {
+        const tail = createResourceDiagnosticTail();
+        tail.append(fixture.input.slice(0, split));
+        tail.append(fixture.input.slice(split));
+        const diagnostic = tail.value();
+        const label = `${fixture.name} split ${split}`;
+
+        expect(diagnostic.includes("<redacted>"), label).toBeTrue();
+        expect(diagnostic.includes(fixture.safe), `${label} safe`).toBeTrue();
+        expect(diagnostic.includes("\uFFFD"), `${label} UTF-8`).toBeFalse();
+        expect(Buffer.byteLength(diagnostic), `${label} size`).toBeLessThanOrEqual(RESOURCE_FAILURE_STDERR_MAX_BYTES);
+        for (const secret of fixture.secrets) {
+          expect(diagnostic.includes(secret), `${label} secret ${secret}`).toBeFalse();
+        }
+      }
+
+      const collector = createResourceCollector({
+        collectorId: `stringified-static-${fixture.name}`,
+        collect: async () => {
+          throw new ResourceCollectorFailureError(
+            "collector-crash",
+            "collector-error",
+            "resource collection failed",
+            { cause: new Error(fixture.input), stderr: fixture.input },
+          );
+        },
+      });
+      const result = await collector.observe(0, 1_000);
+      const cause = result.failure?.diagnostic.causes[0] ?? "";
+      const stderr = result.failure?.diagnostic.stderr ?? "";
+
+      expect(cause.includes(fixture.safe), `${fixture.name} static cause safe`).toBeTrue();
+      expect(stderr.includes(fixture.safe), `${fixture.name} static stderr safe`).toBeTrue();
+      for (const secret of fixture.secrets) {
+        expect(cause.includes(secret), `${fixture.name} static cause ${secret}`).toBeFalse();
+        expect(stderr.includes(secret), `${fixture.name} static stderr ${secret}`).toBeFalse();
+      }
+    }
+
+    const evicted = createResourceDiagnosticTail();
+    evicted.append("old safe prefix é€😀\n".repeat(300));
+    const longSecret = "LONG_STRINGIFIED_BEARER_LEAK ".repeat(1_000);
+    const serialized = stringifiedAuthorization(`Bearer "${longSecret}"`, "SAFE_EVICTION_é€😀");
+    const secretAt = serialized.indexOf(longSecret);
+    evicted.append(serialized.slice(0, secretAt));
+    for (let offset = 0; offset < longSecret.length; offset += 67) {
+      evicted.append(longSecret.slice(offset, offset + 67));
+    }
+    evicted.append(serialized.slice(secretAt + longSecret.length));
+    const diagnostic = evicted.value();
+
+    expect(diagnostic).toContain("<redacted>");
+    expect(diagnostic).toContain("SAFE_EVICTION_é€😀");
+    expect(diagnostic).not.toContain("LONG_STRINGIFIED_BEARER_LEAK");
+    expect(diagnostic).not.toContain("\uFFFD");
+    expect(Buffer.byteLength(diagnostic)).toBeLessThanOrEqual(RESOURCE_FAILURE_STDERR_MAX_BYTES);
+
+    const keyEvicted = createResourceDiagnosticTail();
+    const encoded = stringifiedAuthorization("Basic EVICTED_KEY_LEAK==", "SAFE_KEY_EVICTION_é€😀");
+    const delimiterAt = encoded.indexOf(":");
+    keyEvicted.append(encoded.slice(0, delimiterAt) + " ".repeat(5_000));
+    keyEvicted.append(encoded.slice(delimiterAt));
+    const keyEvictedDiagnostic = keyEvicted.value();
+
+    expect(keyEvictedDiagnostic).toContain("<redacted>");
+    expect(keyEvictedDiagnostic).toContain("SAFE_KEY_EVICTION_é€😀");
+    expect(keyEvictedDiagnostic).not.toContain("EVICTED_KEY_LEAK");
+    expect(keyEvictedDiagnostic).not.toContain("\uFFFD");
+    expect(Buffer.byteLength(keyEvictedDiagnostic)).toBeLessThanOrEqual(RESOURCE_FAILURE_STDERR_MAX_BYTES);
+  });
+
   test("stderr tail truncation preserves every UTF-8 boundary", async () => {
     for (const character of ["é", "€", "😀"]) {
       const width = Buffer.byteLength(character);

--- a/src/lib/resourceCollector.test.ts
+++ b/src/lib/resourceCollector.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 
-import { createResourceCollector } from "./resourceCollector";
+import { createResourceCollector, ResourceCollectorFailureError, RESOURCE_FAILURE_STDERR_MAX_BYTES } from "./resourceCollector";
 
 function deferred<T>() {
   let resolve!: (value: T) => void;
@@ -25,10 +25,10 @@ describe("resource collector", () => {
     const requestFence = collector.fence();
     const fresh = collector.observe(requestFence, 1_000);
     first.resolve("first");
-    await expect(stale).resolves.toMatchObject({ generation: 1, value: "first" });
+    await expect(stale).resolves.toMatchObject({ observation: { generation: 1, value: "first" } });
     now = 1;
     second.resolve("second");
-    await expect(fresh).resolves.toMatchObject({ generation: 2, value: "second" });
+    await expect(fresh).resolves.toMatchObject({ observation: { generation: 2, value: "second" } });
   });
 
   test("a bounded wait returns the immutable previous observation with a timeout diagnostic", async () => {
@@ -45,8 +45,59 @@ describe("resource collector", () => {
     await initial;
     const timedOut = await collector.observe(collector.fence(), 1);
 
-    expect(timedOut).toMatchObject({ generation: 1, value: "prior", degradedReason: "timeout" });
+    expect(timedOut).toMatchObject({
+      observation: { generation: 1, value: "prior" },
+      failure: { reason: "timeout", diagnostic: { cause: "observation-timeout" } },
+    });
     expect(Object.isFrozen(timedOut)).toBeTrue();
+  });
+
+  test("a zero-wait observation reports a typed busy result", async () => {
+    const pending = deferred<string>();
+    const collector = createResourceCollector({
+      collectorId: "busy-collector",
+      collect: async () => pending.promise,
+    });
+
+    const result = await collector.observe(0, 0);
+    expect(result).toMatchObject({
+      observation: null,
+      collectorId: "busy-collector",
+      failure: { reason: "collector-busy", diagnostic: { cause: "collection-active" } },
+    });
+    pending.resolve("complete");
+  });
+
+  test("failure diagnostics preserve bounded redacted nested causes and stderr", async () => {
+    const nested = new Error("PASSWORD=inner-secret");
+    const outer = new Error("Bearer outer-secret", { cause: nested });
+    const collector = createResourceCollector({
+      collectorId: "failed-collector",
+      collect: async () => {
+        throw new ResourceCollectorFailureError(
+          "collector-crash",
+          "collector-error",
+          "resource collection failed",
+          {
+            cause: outer,
+            stderr: `${"safe ".repeat(RESOURCE_FAILURE_STDERR_MAX_BYTES)}\nAPI_TOKEN=stderr-secret`,
+          },
+        );
+      },
+    });
+
+    const result = await collector.observe(0, 1_000);
+    expect(result.failure).toMatchObject({
+      reason: "collector-crash",
+      diagnostic: {
+        cause: "collector-error",
+        causes: ["Bearer <redacted>", "PASSWORD=<redacted>"],
+      },
+    });
+    const stderr = result.failure?.diagnostic.stderr ?? "";
+    expect(Buffer.byteLength(stderr)).toBe(RESOURCE_FAILURE_STDERR_MAX_BYTES);
+    expect(stderr).toContain("API_TOKEN=<redacted>");
+    expect(stderr).not.toContain("stderr-secret");
   });
 
   test("concurrent callers coalesce only when their fences are already satisfied", async () => {
@@ -72,8 +123,8 @@ describe("resource collector", () => {
     expect(calls).toBe(2);
     second.resolve("two");
     await expect(Promise.all([three, four])).resolves.toEqual([
-      expect.objectContaining({ generation: 2, value: "two" }),
-      expect.objectContaining({ generation: 2, value: "two" }),
+      expect.objectContaining({ observation: expect.objectContaining({ generation: 2, value: "two" }) }),
+      expect.objectContaining({ observation: expect.objectContaining({ generation: 2, value: "two" }) }),
     ]);
   });
 

--- a/src/lib/resourceCollector.test.ts
+++ b/src/lib/resourceCollector.test.ts
@@ -227,6 +227,103 @@ describe("resource collector", () => {
     }
   });
 
+  test("streaming Authorization redaction covers every scheme, field boundary, split, and terminal flush", async () => {
+    const safeLine = "X-Safe-After: preserved é € 😀";
+    const cases = [
+      {
+        name: "Basic",
+        input: `Authorization: Basic BASICLEAK==\r\n${safeLine}`,
+        fragments: ["BASICLEAK"],
+      },
+      {
+        name: "Digest",
+        input: `Authorization: Digest username="DIGESTUSER", realm="DIGESTREALM", response="DIGESTRESPONSE"\n${safeLine}`,
+        fragments: ["DIGESTUSER", "DIGESTREALM", "DIGESTRESPONSE"],
+      },
+      {
+        name: "Negotiate",
+        input: `Authorization: Negotiate NEGOTIATELEAK FIRSTTAIL SECONDTAIL\r${safeLine}`,
+        fragments: ["NEGOTIATELEAK", "FIRSTTAIL", "SECONDTAIL"],
+      },
+      {
+        name: "custom",
+        input: `Authorization=Custom scheme=CUSTOMLEAK quoted="CUSTOMTAIL VALUE"\n${safeLine}`,
+        fragments: ["CUSTOMLEAK", "CUSTOMTAIL"],
+      },
+      {
+        name: "embedded key",
+        input: `proxy.AUTHORIZATION_trace: Custom EMBEDDEDLEAK tail=EMBEDDEDTAIL\n${safeLine}`,
+        fragments: ["EMBEDDEDLEAK", "EMBEDDEDTAIL"],
+      },
+      {
+        name: "quoted field",
+        input: `Authorization: "Digest username=QUOTEDLEAK response=QUOTEDTAIL" trailing=FIELDTAIL\n${safeLine}`,
+        fragments: ["QUOTEDLEAK", "QUOTEDTAIL", "FIELDTAIL"],
+      },
+    ];
+
+    for (const fixture of cases) {
+      for (let split = 0; split <= fixture.input.length; split += 1) {
+        const tail = createResourceDiagnosticTail();
+        tail.append(fixture.input.slice(0, split));
+        tail.append(fixture.input.slice(split));
+        const diagnostic = tail.value();
+        const label = `${fixture.name} split ${split}`;
+
+        expect(diagnostic.includes("<redacted>"), label).toBeTrue();
+        expect(diagnostic.includes(safeLine), label).toBeTrue();
+        expect(diagnostic.includes("\uFFFD"), label).toBeFalse();
+        expect(Buffer.byteLength(diagnostic), label).toBeLessThanOrEqual(RESOURCE_FAILURE_STDERR_MAX_BYTES);
+        for (const fragment of fixture.fragments) {
+          expect(diagnostic.includes(fragment), `${label} fragment ${fragment}`).toBeFalse();
+        }
+      }
+
+      const fieldEnd = fixture.input.search(/[\r\n]/);
+      const terminalInput = fieldEnd < 0 ? fixture.input : fixture.input.slice(0, fieldEnd);
+      for (let split = 0; split <= terminalInput.length; split += 1) {
+        const terminal = createResourceDiagnosticTail();
+        terminal.append(terminalInput.slice(0, split));
+        terminal.append(terminalInput.slice(split));
+        const diagnostic = terminal.value();
+        const label = `${fixture.name} terminal split ${split}`;
+
+        expect(diagnostic.includes("<redacted>"), label).toBeTrue();
+        for (const fragment of fixture.fragments) {
+          expect(diagnostic.includes(fragment), `${label} fragment ${fragment}`).toBeFalse();
+        }
+      }
+    }
+
+    const longCredential = "LONG-AUTHORIZATION-LEAK ".repeat(1_000);
+    const streamed = createResourceDiagnosticTail();
+    streamed.append("discarded safe prefix\n".repeat(300));
+    streamed.append("Authorization: Custom ");
+    for (let offset = 0; offset < longCredential.length; offset += 73) {
+      streamed.append(longCredential.slice(offset, offset + 73));
+    }
+    streamed.append(`\r\n${safeLine}`);
+    const collector = createResourceCollector({
+      collectorId: "long-authorization",
+      collect: async () => {
+        throw new ResourceCollectorFailureError(
+          "collector-crash",
+          "collector-error",
+          "resource collection failed",
+          { stderr: streamed.value() },
+        );
+      },
+    });
+    const result = await collector.observe(0, 1_000);
+    const diagnostic = result.failure?.diagnostic.stderr ?? "";
+
+    expect(diagnostic).toContain("Authorization=<redacted>");
+    expect(diagnostic).toContain(safeLine);
+    expect(diagnostic).not.toContain("LONG-AUTHORIZATION-LEAK");
+    expect(diagnostic).not.toContain("\uFFFD");
+    expect(Buffer.byteLength(diagnostic)).toBeLessThanOrEqual(RESOURCE_FAILURE_STDERR_MAX_BYTES);
+  });
+
   test("stderr tail truncation preserves every UTF-8 boundary", async () => {
     for (const character of ["é", "€", "😀"]) {
       const width = Buffer.byteLength(character);

--- a/src/lib/resourceCollector.ts
+++ b/src/lib/resourceCollector.ts
@@ -77,6 +77,8 @@ type SensitiveTextMatch = {
   length: number;
   replacement: string;
   quote: "\"" | "'" | null;
+  authorization: boolean;
+  bearer: boolean;
 };
 
 function sensitiveTextMatch(value: string): SensitiveTextMatch | null {
@@ -90,6 +92,8 @@ function sensitiveTextMatch(value: string): SensitiveTextMatch | null {
       length: keyed[0].length,
       replacement: `${keyed[1]}=<redacted>`,
       quote: keyed[2] === "\"" || keyed[2] === "'" ? keyed[2] : null,
+      authorization: /AUTHORIZATION/i.test(keyed[1]),
+      bearer: false,
     });
   }
   if (bearer) {
@@ -98,6 +102,8 @@ function sensitiveTextMatch(value: string): SensitiveTextMatch | null {
       length: bearer[0].length,
       replacement: `${bearer[1]} <redacted>`,
       quote: null,
+      authorization: false,
+      bearer: true,
     });
   }
   if (standalone) {
@@ -106,6 +112,8 @@ function sensitiveTextMatch(value: string): SensitiveTextMatch | null {
       length: standalone[0].length,
       replacement: "<redacted>",
       quote: null,
+      authorization: false,
+      bearer: false,
     });
   }
   return matches.sort((left, right) => left.index - right.index)[0] ?? null;
@@ -142,7 +150,7 @@ export function createResourceDiagnosticTail(maxBytes = RESOURCE_FAILURE_STDERR_
   let sanitizedTail = "";
   let pending = "";
   let redacting: "unquoted" | "\"" | "'" | null = null;
-  let carriedCredential: "key" | "value" | null = null;
+  let carriedCredential: "key" | "authorization-key" | "value" | "authorization" | "bearer" | null = null;
   const appendSanitized = (value: string) => {
     sanitizedTail += value;
     let start = sanitizedTail.length - (maxBytes * 2);
@@ -152,7 +160,46 @@ export function createResourceDiagnosticTail(maxBytes = RESOURCE_FAILURE_STDERR_
     sanitizedTail = sanitizedTail.slice(start);
   };
   const sanitizePending = () => {
+    const beginCredentialRedaction = () => {
+      const quote = pending[0];
+      if (quote === "\"" || quote === "'") pending = pending.slice(1);
+      redacting = quote === "\"" || quote === "'" ? quote : "unquoted";
+      carriedCredential = null;
+    };
     while (pending) {
+      if (carriedCredential === "authorization") {
+        const valueStart = pending.search(/\S/);
+        if (valueStart < 0) {
+          pending = "";
+          return;
+        }
+        pending = pending.slice(valueStart);
+        const bearer = /^(Bearer)\s+(?=\S)/i.exec(pending);
+        if (bearer) {
+          pending = pending.slice(bearer[0].length);
+          beginCredentialRedaction();
+          continue;
+        }
+        if ("bearer".startsWith(pending.toLowerCase())) return;
+        if (/^Bearer\s*$/i.test(pending)) {
+          pending = "";
+          carriedCredential = "bearer";
+          return;
+        }
+        redacting = "unquoted";
+        carriedCredential = null;
+        continue;
+      }
+      if (carriedCredential === "bearer") {
+        const valueStart = pending.search(/\S/);
+        if (valueStart < 0) {
+          pending = "";
+          return;
+        }
+        pending = pending.slice(valueStart);
+        beginCredentialRedaction();
+        continue;
+      }
       if (carriedCredential === "value") {
         const valueStart = pending.search(/\S/);
         if (valueStart < 0) {
@@ -165,20 +212,24 @@ export function createResourceDiagnosticTail(maxBytes = RESOURCE_FAILURE_STDERR_
         carriedCredential = null;
         continue;
       }
-      if (carriedCredential === "key") {
+      if (carriedCredential === "key" || carriedCredential === "authorization-key") {
+        const authorizationKey = carriedCredential === "authorization-key";
         const completedKey = /^[A-Z0-9_.-]*\s*[:=]\s*(?:(["'])|(?=[^"'\s]))/i.exec(pending);
         if (completedKey) {
           appendSanitized("<redacted>");
           pending = pending.slice(completedKey[0].length);
-          redacting = completedKey[1] === "\"" || completedKey[1] === "'" ? completedKey[1] : "unquoted";
-          carriedCredential = null;
+          if (authorizationKey && completedKey[1] === undefined) carriedCredential = "authorization";
+          else {
+            redacting = completedKey[1] === "\"" || completedKey[1] === "'" ? completedKey[1] : "unquoted";
+            carriedCredential = null;
+          }
           continue;
         }
         const delimiter = /^[A-Z0-9_.-]*\s*[:=]\s*$/i.exec(pending);
         if (delimiter) {
           appendSanitized("<redacted>");
           pending = "";
-          carriedCredential = "value";
+          carriedCredential = authorizationKey ? "authorization" : "value";
           return;
         }
         if (/^[A-Z0-9_.-]*\s*$/i.test(pending)) {
@@ -201,6 +252,14 @@ export function createResourceDiagnosticTail(maxBytes = RESOURCE_FAILURE_STDERR_
       if (match) {
         appendSanitized(pending.slice(0, match.index) + match.replacement);
         pending = pending.slice(match.index + match.length);
+        if (match.authorization && match.quote === null) {
+          carriedCredential = "authorization";
+          continue;
+        }
+        if (match.bearer) {
+          carriedCredential = "bearer";
+          continue;
+        }
         redacting = match.quote ?? "unquoted";
         continue;
       }
@@ -212,7 +271,7 @@ export function createResourceDiagnosticTail(maxBytes = RESOURCE_FAILURE_STDERR_
         if (bearerStart < pending.length - DIAGNOSTIC_REDACTION_CONTEXT_CHARS) {
           appendSanitized(pending.slice(0, bearerStart) + `${carriedBearer[1]} <redacted>`);
           pending = "";
-          carriedCredential = "value";
+          carriedCredential = "bearer";
           return;
         }
       }
@@ -225,10 +284,10 @@ export function createResourceDiagnosticTail(maxBytes = RESOURCE_FAILURE_STDERR_
           if (carriedKey[3]) {
             appendSanitized("<redacted>");
             pending = "";
-            carriedCredential = "value";
+            carriedCredential = /AUTHORIZATION/i.test(carriedKey[1]) ? "authorization" : "value";
           } else {
             pending = (carriedKey[1] + carriedKey[2]).slice(-DIAGNOSTIC_REDACTION_CONTEXT_CHARS);
-            carriedCredential = "key";
+            carriedCredential = /AUTHORIZATION/i.test(carriedKey[1]) ? "authorization-key" : "key";
           }
           return;
         }

--- a/src/lib/resourceCollector.ts
+++ b/src/lib/resourceCollector.ts
@@ -70,6 +70,46 @@ const FAILURE_MESSAGE_MAX_BYTES = 512;
 export const RESOURCE_FAILURE_STDERR_MAX_BYTES = 2_048;
 const FAILURE_CAUSE_MAX_BYTES = 512;
 const FAILURE_CAUSE_MAX_DEPTH = 4;
+const DIAGNOSTIC_REDACTION_CONTEXT_CHARS = 256;
+
+type SensitiveTextMatch = {
+  index: number;
+  length: number;
+  replacement: string;
+  quote: "\"" | "'" | null;
+};
+
+function sensitiveTextMatch(value: string): SensitiveTextMatch | null {
+  const keyed = /\b([A-Z0-9_.-]*(?:TOKEN|SECRET|PASSWORD|PASSWD|API[_-]?KEY|AUTHORIZATION|COOKIE)[A-Z0-9_.-]*)\s*[:=]\s*(?:(["'])|(?=[^"'\s]))/i.exec(value);
+  const bearer = /\b(Bearer)\s+(?=\S)/i.exec(value);
+  const standalone = /\b(?:(?:sk|ghp|github_pat|xox[baprs])[-_A-Za-z0-9]{16,}|[A-Za-z0-9+/_=-]{48,})/i.exec(value);
+  const matches: SensitiveTextMatch[] = [];
+  if (keyed) {
+    matches.push({
+      index: keyed.index,
+      length: keyed[0].length,
+      replacement: `${keyed[1]}=<redacted>`,
+      quote: keyed[2] === "\"" || keyed[2] === "'" ? keyed[2] : null,
+    });
+  }
+  if (bearer) {
+    matches.push({
+      index: bearer.index,
+      length: bearer[0].length,
+      replacement: `${bearer[1]} <redacted>`,
+      quote: null,
+    });
+  }
+  if (standalone) {
+    matches.push({
+      index: standalone.index,
+      length: standalone[0].length,
+      replacement: "<redacted>",
+      quote: null,
+    });
+  }
+  return matches.sort((left, right) => left.index - right.index)[0] ?? null;
+}
 
 function redactDiagnosticText(value: string): string {
   return value
@@ -93,6 +133,122 @@ function boundedDiagnosticText(value: string, maxBytes: number, tail = false): s
   let end = maxBytes;
   while (end > 0 && (bytes[end] & 0xc0) === 0x80) end -= 1;
   return bytes.subarray(0, end).toString("utf8");
+}
+
+export function createResourceDiagnosticTail(maxBytes = RESOURCE_FAILURE_STDERR_MAX_BYTES): {
+  append(value: string): void;
+  value(): string;
+} {
+  let sanitizedTail = "";
+  let pending = "";
+  let redacting: "unquoted" | "\"" | "'" | null = null;
+  let carriedCredential: "key" | "value" | null = null;
+  const appendSanitized = (value: string) => {
+    sanitizedTail += value;
+    let start = sanitizedTail.length - (maxBytes * 2);
+    if (start <= 0) return;
+    const first = sanitizedTail.charCodeAt(start);
+    if (first >= 0xdc00 && first <= 0xdfff) start += 1;
+    sanitizedTail = sanitizedTail.slice(start);
+  };
+  const sanitizePending = () => {
+    while (pending) {
+      if (carriedCredential === "value") {
+        const valueStart = pending.search(/\S/);
+        if (valueStart < 0) {
+          pending = "";
+          return;
+        }
+        const quote = pending[valueStart];
+        pending = pending.slice(valueStart + (quote === "\"" || quote === "'" ? 1 : 0));
+        redacting = quote === "\"" || quote === "'" ? quote : "unquoted";
+        carriedCredential = null;
+        continue;
+      }
+      if (carriedCredential === "key") {
+        const completedKey = /^[A-Z0-9_.-]*\s*[:=]\s*(?:(["'])|(?=[^"'\s]))/i.exec(pending);
+        if (completedKey) {
+          appendSanitized("<redacted>");
+          pending = pending.slice(completedKey[0].length);
+          redacting = completedKey[1] === "\"" || completedKey[1] === "'" ? completedKey[1] : "unquoted";
+          carriedCredential = null;
+          continue;
+        }
+        const delimiter = /^[A-Z0-9_.-]*\s*[:=]\s*$/i.exec(pending);
+        if (delimiter) {
+          appendSanitized("<redacted>");
+          pending = "";
+          carriedCredential = "value";
+          return;
+        }
+        if (/^[A-Z0-9_.-]*\s*$/i.test(pending)) {
+          pending = pending.slice(-DIAGNOSTIC_REDACTION_CONTEXT_CHARS);
+          return;
+        }
+        carriedCredential = null;
+      }
+      if (redacting) {
+        const end = redacting === "unquoted" ? pending.search(/\s/) : pending.indexOf(redacting);
+        if (end < 0) {
+          pending = "";
+          return;
+        }
+        pending = pending.slice(end + (redacting === "unquoted" ? 0 : 1));
+        redacting = null;
+        continue;
+      }
+      const match = sensitiveTextMatch(pending);
+      if (match) {
+        appendSanitized(pending.slice(0, match.index) + match.replacement);
+        pending = pending.slice(match.index + match.length);
+        redacting = match.quote ?? "unquoted";
+        continue;
+      }
+      if (pending.length <= DIAGNOSTIC_REDACTION_CONTEXT_CHARS) return;
+      const carriedBearer = /(?:^|[^A-Z0-9_])(Bearer)(\s+)$/i.exec(pending);
+      if (carriedBearer) {
+        const bearerStart = carriedBearer.index + carriedBearer[0].length
+          - carriedBearer[1].length - carriedBearer[2].length;
+        if (bearerStart < pending.length - DIAGNOSTIC_REDACTION_CONTEXT_CHARS) {
+          appendSanitized(pending.slice(0, bearerStart) + `${carriedBearer[1]} <redacted>`);
+          pending = "";
+          carriedCredential = "value";
+          return;
+        }
+      }
+      const carriedKey = /(?:^|[^A-Z0-9_.-])([A-Z0-9_.-]*(?:TOKEN|SECRET|PASSWORD|PASSWD|API[_-]?KEY|AUTHORIZATION|COOKIE)[A-Z0-9_.-]*)(\s*)(?:([:=])(\s*))?$/i.exec(pending);
+      if (carriedKey) {
+        const keyStart = carriedKey.index + carriedKey[0].length
+          - carriedKey.slice(1).reduce((length, part) => length + (part?.length ?? 0), 0);
+        if (keyStart < pending.length - DIAGNOSTIC_REDACTION_CONTEXT_CHARS) {
+          appendSanitized(pending.slice(0, keyStart));
+          if (carriedKey[3]) {
+            appendSanitized("<redacted>");
+            pending = "";
+            carriedCredential = "value";
+          } else {
+            pending = (carriedKey[1] + carriedKey[2]).slice(-DIAGNOSTIC_REDACTION_CONTEXT_CHARS);
+            carriedCredential = "key";
+          }
+          return;
+        }
+      }
+      appendSanitized(pending.slice(0, -DIAGNOSTIC_REDACTION_CONTEXT_CHARS));
+      pending = pending.slice(-DIAGNOSTIC_REDACTION_CONTEXT_CHARS);
+      return;
+    }
+  };
+
+  return {
+    append(value) {
+      pending += value;
+      sanitizePending();
+    },
+    value() {
+      const suffix = redacting ? "" : pending;
+      return redactDiagnosticText(sanitizedTail + suffix);
+    },
+  };
 }
 
 function diagnosticCauses(error: unknown): string[] {

--- a/src/lib/resourceCollector.ts
+++ b/src/lib/resourceCollector.ts
@@ -84,22 +84,24 @@ type SensitiveTextMatch = {
   length: number;
   replacement: string;
   quote: "\"" | "'" | null;
+  quotedKey: boolean;
   authorization: boolean;
   bearer: boolean;
 };
 
 function sensitiveTextMatch(value: string): SensitiveTextMatch | null {
-  const keyed = /\b([A-Z0-9_.-]*(?:TOKEN|SECRET|PASSWORD|PASSWD|API[_-]?KEY|AUTHORIZATION|COOKIE)[A-Z0-9_.-]*)\s*[:=]\s*(?:(["'])|(?=[^"'\s]))/i.exec(value);
-  const bearer = /\b(Bearer)\s+(?=\S)/i.exec(value);
+  const keyed = /(^|[^A-Z0-9_.-])(["']?)([A-Z0-9_.-]*(?:TOKEN|SECRET|PASSWORD|PASSWD|API[_-]?KEY|AUTHORIZATION|COOKIE)[A-Z0-9_.-]*)\2\s*[:=]\s*(?!<redacted>(?:$|[\s,}\]]))(?:(['"])|(?=[^"'\s]))/i.exec(value);
+  const bearer = /\b(Bearer)\s+(?:(["'])|(?=\S))/i.exec(value);
   const standalone = /\b(?:(?:sk|ghp|github_pat|xox[baprs])[-_A-Za-z0-9]{16,}|[A-Za-z0-9+/_=-]{48,})/i.exec(value);
   const matches: SensitiveTextMatch[] = [];
   if (keyed) {
     matches.push({
-      index: keyed.index,
-      length: keyed[0].length,
-      replacement: `${keyed[1]}=<redacted>`,
-      quote: keyed[2] === "\"" || keyed[2] === "'" ? keyed[2] : null,
-      authorization: /AUTHORIZATION/i.test(keyed[1]),
+      index: keyed.index + keyed[1].length,
+      length: keyed[0].length - keyed[1].length,
+      replacement: `${keyed[3]}=<redacted>`,
+      quote: keyed[4] === "\"" || keyed[4] === "'" ? keyed[4] : null,
+      quotedKey: keyed[2] === "\"" || keyed[2] === "'",
+      authorization: /AUTHORIZATION/i.test(keyed[3]),
       bearer: false,
     });
   }
@@ -108,7 +110,8 @@ function sensitiveTextMatch(value: string): SensitiveTextMatch | null {
       index: bearer.index,
       length: bearer[0].length,
       replacement: `${bearer[1]} <redacted>`,
-      quote: null,
+      quote: bearer[2] === "\"" || bearer[2] === "'" ? bearer[2] : null,
+      quotedKey: false,
       authorization: false,
       bearer: true,
     });
@@ -119,6 +122,7 @@ function sensitiveTextMatch(value: string): SensitiveTextMatch | null {
       length: standalone[0].length,
       replacement: "<redacted>",
       quote: null,
+      quotedKey: false,
       authorization: false,
       bearer: false,
     });
@@ -126,13 +130,50 @@ function sensitiveTextMatch(value: string): SensitiveTextMatch | null {
   return matches.sort((left, right) => left.index - right.index)[0] ?? null;
 }
 
+function quotedValueEnd(value: string, quote: "\"" | "'", start = 0): number {
+  let escaped = false;
+  for (let index = start; index < value.length; index += 1) {
+    const character = value[index];
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (character === "\\") {
+      escaped = true;
+      continue;
+    }
+    if (character === quote) return index;
+  }
+  return -1;
+}
+
 function redactDiagnosticText(value: string): string {
-  return value
-    .replace(/\b([A-Z0-9_.-]*AUTHORIZATION[A-Z0-9_.-]*)\s*[:=][^\r\n]*/gi, "$1=<redacted>")
-    .replace(/\b(Bearer)\s+[^\s]+/gi, "$1 <redacted>")
-    .replace(/\b([A-Z0-9_.-]*(?:TOKEN|SECRET|PASSWORD|PASSWD|API[_-]?KEY|AUTHORIZATION|COOKIE)[A-Z0-9_.-]*)\s*[:=]\s*(?:"[^"]*"|'[^']*'|[^\s]+)/gi, "$1=<redacted>")
-    .replace(/\b(?:sk|ghp|github_pat|xox[baprs])[-_A-Za-z0-9]{16,}\b/gi, "<redacted>")
-    .replace(/\b[A-Za-z0-9+/_=-]{48,}\b/g, "<redacted>")
+  let redacted = "";
+  let pending = value;
+  while (pending) {
+    const match = sensitiveTextMatch(pending);
+    if (!match) {
+      redacted += pending;
+      break;
+    }
+    redacted += pending.slice(0, match.index) + match.replacement;
+    pending = pending.slice(match.index + match.length);
+    if (match.authorization && !(match.quotedKey && match.quote)) {
+      const end = pending.search(/[\r\n]/);
+      pending = end < 0 ? "" : pending.slice(end);
+      continue;
+    }
+    if (match.quote) {
+      const end = quotedValueEnd(pending, match.quote);
+      pending = end < 0 ? "" : pending.slice(end + 1);
+      continue;
+    }
+    if (match.bearer || !match.authorization) {
+      const end = pending.search(/\s/);
+      pending = end < 0 ? "" : pending.slice(end);
+    }
+  }
+  return redacted
     .replace(/[\u0000-\u0008\u000B\u000C\u000E-\u001F\u007F]/g, "")
     .trim();
 }
@@ -158,6 +199,7 @@ export function createResourceDiagnosticTail(maxBytes = RESOURCE_FAILURE_STDERR_
   let sanitizedTail = "";
   let pending = "";
   let redacting: "unquoted" | "line" | "\"" | "'" | null = null;
+  let redactionEscape = false;
   let carriedCredential: "key" | "authorization-key" | "value" | "authorization" | "bearer" | null = null;
   const appendSanitized = (value: string) => {
     sanitizedTail += value;
@@ -232,15 +274,34 @@ export function createResourceDiagnosticTail(maxBytes = RESOURCE_FAILURE_STDERR_
         carriedCredential = null;
       }
       if (redacting) {
-        const end = redacting === "line"
-          ? pending.search(/[\r\n]/)
-          : redacting === "unquoted" ? pending.search(/\s/) : pending.indexOf(redacting);
+        let end: number;
+        if (redacting === "line") end = pending.search(/[\r\n]/);
+        else if (redacting === "unquoted") end = pending.search(/\s/);
+        else {
+          end = -1;
+          for (let index = 0; index < pending.length; index += 1) {
+            const character = pending[index];
+            if (redactionEscape) {
+              redactionEscape = false;
+              continue;
+            }
+            if (character === "\\") {
+              redactionEscape = true;
+              continue;
+            }
+            if (character === redacting) {
+              end = index;
+              break;
+            }
+          }
+        }
         if (end < 0) {
           pending = "";
           return;
         }
         pending = pending.slice(end + (redacting === "unquoted" || redacting === "line" ? 0 : 1));
         redacting = null;
+        redactionEscape = false;
         continue;
       }
       const match = sensitiveTextMatch(pending);
@@ -248,11 +309,11 @@ export function createResourceDiagnosticTail(maxBytes = RESOURCE_FAILURE_STDERR_
         appendSanitized(pending.slice(0, match.index) + match.replacement);
         pending = pending.slice(match.index + match.length);
         if (match.authorization) {
-          redacting = "line";
+          redacting = match.quotedKey && match.quote ? match.quote : "line";
           continue;
         }
         if (match.bearer) {
-          carriedCredential = "bearer";
+          redacting = match.quote ?? "unquoted";
           continue;
         }
         redacting = match.quote ?? "unquoted";

--- a/src/lib/resourceCollector.ts
+++ b/src/lib/resourceCollector.ts
@@ -19,6 +19,7 @@ export type ResourceCollectorOptions<T> = {
   collectorId: string;
   collect(): Promise<T>;
   now?(): number;
+  initial?: ResourceObservation<T> | null;
 };
 
 function freeze<T>(value: T): T {
@@ -43,8 +44,8 @@ function withDegradedReason<T>(
  */
 export function createResourceCollector<T>(options: ResourceCollectorOptions<T>): ResourceCollector<T> {
   const now = options.now ?? Date.now;
-  let startedGeneration = 0;
-  let latest: ResourceObservation<T> | null = null;
+  let startedGeneration = options.initial?.generation ?? 0;
+  let latest: ResourceObservation<T> | null = options.initial ?? null;
   let active: { generation: number; promise: Promise<ResourceObservation<T>> } | null = null;
 
   const launch = (): Promise<ResourceObservation<T>> => {

--- a/src/lib/resourceCollector.ts
+++ b/src/lib/resourceCollector.ts
@@ -85,8 +85,14 @@ function boundedDiagnosticText(value: string, maxBytes: number, tail = false): s
   const redacted = redactDiagnosticText(value);
   const bytes = Buffer.from(redacted);
   if (bytes.length <= maxBytes) return redacted;
-  const bounded = tail ? bytes.subarray(bytes.length - maxBytes) : bytes.subarray(0, maxBytes);
-  return bounded.toString("utf8").replace(/^\uFFFD|\uFFFD$/g, "");
+  if (tail) {
+    let start = bytes.length - maxBytes;
+    while (start < bytes.length && (bytes[start] & 0xc0) === 0x80) start += 1;
+    return bytes.subarray(start).toString("utf8");
+  }
+  let end = maxBytes;
+  while (end > 0 && (bytes[end] & 0xc0) === 0x80) end -= 1;
+  return bytes.subarray(0, end).toString("utf8");
 }
 
 function diagnosticCauses(error: unknown): string[] {

--- a/src/lib/resourceCollector.ts
+++ b/src/lib/resourceCollector.ts
@@ -9,15 +9,15 @@ export type ResourceObservation<T> = Readonly<{
   degradedReason?: ResourceDegradedReason;
 }>;
 
-export interface ResourceCollector<T> {
+export interface ResourceCollector<T, Input = void> {
   latest(): ResourceObservation<T> | null;
   fence(): number;
-  observe(fence: number, timeoutMs: number): Promise<ResourceObservation<T> | null>;
+  observe(fence: number, timeoutMs: number, input?: Input): Promise<ResourceObservation<T> | null>;
 }
 
-export type ResourceCollectorOptions<T> = {
+export type ResourceCollectorOptions<T, Input = void> = {
   collectorId: string;
-  collect(): Promise<T>;
+  collect(input?: Input): Promise<T>;
   now?(): number;
   initial?: ResourceObservation<T> | null;
 };
@@ -42,17 +42,17 @@ function withDegradedReason<T>(
  * independent of collection mechanics: an adapter may gather in-process for
  * rollback or isolate the same work in a worker.
  */
-export function createResourceCollector<T>(options: ResourceCollectorOptions<T>): ResourceCollector<T> {
+export function createResourceCollector<T, Input = void>(options: ResourceCollectorOptions<T, Input>): ResourceCollector<T, Input> {
   const now = options.now ?? Date.now;
   let startedGeneration = options.initial?.generation ?? 0;
   let latest: ResourceObservation<T> | null = options.initial ?? null;
   let active: { generation: number; promise: Promise<ResourceObservation<T>> } | null = null;
 
-  const launch = (): Promise<ResourceObservation<T>> => {
+  const launch = (input?: Input): Promise<ResourceObservation<T>> => {
     const generation = ++startedGeneration;
     const startedAt = now();
     const promise = Promise.resolve()
-      .then(options.collect)
+      .then(() => options.collect(input))
       .then((value) => freeze({
         generation,
         startedAt,
@@ -74,21 +74,21 @@ export function createResourceCollector<T>(options: ResourceCollectorOptions<T>)
     return promise;
   };
 
-  const afterFence = (fence: number): Promise<ResourceObservation<T>> => {
+  const afterFence = (fence: number, input?: Input): Promise<ResourceObservation<T>> => {
     const current = active;
-    if (!current) return launch();
+    if (!current) return launch(input);
     if (current.generation > fence) return current.promise;
     return current.promise.catch(() => undefined).then(() => {
       const next = active;
-      return next && next.generation > fence ? next.promise : launch();
+      return next && next.generation > fence ? next.promise : launch(input);
     });
   };
 
   return {
     latest: () => latest,
     fence: () => startedGeneration,
-    async observe(fence, timeoutMs) {
-      const observation = afterFence(fence);
+    async observe(fence, timeoutMs, input) {
+      const observation = afterFence(fence, input);
       const bounded = Math.max(0, timeoutMs);
       if (bounded === 0) {
         void observation.catch(() => undefined);

--- a/src/lib/resourceCollector.ts
+++ b/src/lib/resourceCollector.ts
@@ -1,0 +1,111 @@
+export type ResourceDegradedReason = "collector-busy" | "timeout" | "collector-crash";
+
+export type ResourceObservation<T> = Readonly<{
+  generation: number;
+  startedAt: number;
+  completedAt: number;
+  collectorId: string;
+  value: T;
+  degradedReason?: ResourceDegradedReason;
+}>;
+
+export interface ResourceCollector<T> {
+  latest(): ResourceObservation<T> | null;
+  fence(): number;
+  observe(fence: number, timeoutMs: number): Promise<ResourceObservation<T> | null>;
+}
+
+export type ResourceCollectorOptions<T> = {
+  collectorId: string;
+  collect(): Promise<T>;
+  now?(): number;
+};
+
+function freeze<T>(value: T): T {
+  if (value && typeof value === "object" && !Object.isFrozen(value)) {
+    Object.freeze(value);
+    for (const child of Object.values(value as Record<string, unknown>)) freeze(child);
+  }
+  return value;
+}
+
+function withDegradedReason<T>(
+  observation: ResourceObservation<T>,
+  degradedReason: ResourceDegradedReason,
+): ResourceObservation<T> {
+  return freeze({ ...observation, degradedReason });
+}
+
+/**
+ * Generation-fenced observation collector. Its interface keeps request paths
+ * independent of collection mechanics: an adapter may gather in-process for
+ * rollback or isolate the same work in a worker.
+ */
+export function createResourceCollector<T>(options: ResourceCollectorOptions<T>): ResourceCollector<T> {
+  const now = options.now ?? Date.now;
+  let startedGeneration = 0;
+  let latest: ResourceObservation<T> | null = null;
+  let active: { generation: number; promise: Promise<ResourceObservation<T>> } | null = null;
+
+  const launch = (): Promise<ResourceObservation<T>> => {
+    const generation = ++startedGeneration;
+    const startedAt = now();
+    const promise = Promise.resolve()
+      .then(options.collect)
+      .then((value) => freeze({
+        generation,
+        startedAt,
+        completedAt: now(),
+        collectorId: options.collectorId,
+        value: freeze(value),
+      }));
+    const operation = { generation, promise };
+    active = operation;
+    void promise.then(
+      (observation) => {
+        if (active === operation) active = null;
+        if (!latest || observation.generation > latest.generation) latest = observation;
+      },
+      () => {
+        if (active === operation) active = null;
+      },
+    );
+    return promise;
+  };
+
+  const afterFence = (fence: number): Promise<ResourceObservation<T>> => {
+    const current = active;
+    if (!current) return launch();
+    if (current.generation > fence) return current.promise;
+    return current.promise.catch(() => undefined).then(() => {
+      const next = active;
+      return next && next.generation > fence ? next.promise : launch();
+    });
+  };
+
+  return {
+    latest: () => latest,
+    fence: () => startedGeneration,
+    async observe(fence, timeoutMs) {
+      const observation = afterFence(fence);
+      const bounded = Math.max(0, timeoutMs);
+      if (bounded === 0) {
+        void observation.catch(() => undefined);
+        return latest ? withDegradedReason(latest, "collector-busy") : null;
+      }
+      let timer: ReturnType<typeof setTimeout> | undefined;
+      try {
+        return await Promise.race([
+          observation,
+          new Promise<ResourceObservation<T> | null>((resolve) => {
+            timer = setTimeout(() => resolve(latest ? withDegradedReason(latest, "timeout") : null), bounded);
+          }),
+        ]);
+      } catch {
+        return latest ? withDegradedReason(latest, "collector-crash") : null;
+      } finally {
+        if (timer) clearTimeout(timer);
+      }
+    },
+  };
+}

--- a/src/lib/resourceCollector.ts
+++ b/src/lib/resourceCollector.ts
@@ -84,33 +84,40 @@ type SensitiveTextMatch = {
   length: number;
   replacement: string;
   quote: "\"" | "'" | null;
+  quoteEscapeDepth: number;
   quotedKey: boolean;
   authorization: boolean;
   bearer: boolean;
 };
 
 function sensitiveTextMatch(value: string): SensitiveTextMatch | null {
-  const keyed = /(^|[^A-Z0-9_.-])(["']?)([A-Z0-9_.-]*(?:TOKEN|SECRET|PASSWORD|PASSWD|API[_-]?KEY|AUTHORIZATION|COOKIE)[A-Z0-9_.-]*)\2\s*[:=]\s*(?!<redacted>(?:$|[\s,}\]]))(?:(['"])|(?=[^"'\s]))/i.exec(value);
-  const bearer = /\b(Bearer)\s+(?:(["'])|(?=\S))/i.exec(value);
+  const keyed = /(^|[^A-Z0-9_.-])((?:\\+)?["']?)([A-Z0-9_.-]*(?:TOKEN|SECRET|PASSWORD|PASSWD|API[_-]?KEY|AUTHORIZATION|COOKIE)[A-Z0-9_.-]*)\2\s*[:=]\s*(?!<redacted>(?:$|[\s,}\]]))(?:((?:\\+)?["'])|(?=[^"'\\\s]))/i.exec(value);
+  const bearer = /\b(Bearer)\s+(?:((?:\\+)?["'])|(?=\S))/i.exec(value);
   const standalone = /\b(?:(?:sk|ghp|github_pat|xox[baprs])[-_A-Za-z0-9]{16,}|[A-Za-z0-9+/_=-]{48,})/i.exec(value);
   const matches: SensitiveTextMatch[] = [];
   if (keyed) {
+    const quoteToken = keyed[4] ?? "";
+    const quote = quoteToken.at(-1);
     matches.push({
       index: keyed.index + keyed[1].length,
       length: keyed[0].length - keyed[1].length,
       replacement: `${keyed[3]}=<redacted>`,
-      quote: keyed[4] === "\"" || keyed[4] === "'" ? keyed[4] : null,
-      quotedKey: keyed[2] === "\"" || keyed[2] === "'",
+      quote: quote === "\"" || quote === "'" ? quote : null,
+      quoteEscapeDepth: Math.max(0, quoteToken.length - 1),
+      quotedKey: keyed[2].endsWith("\"") || keyed[2].endsWith("'"),
       authorization: /AUTHORIZATION/i.test(keyed[3]),
       bearer: false,
     });
   }
   if (bearer) {
+    const quoteToken = bearer[2] ?? "";
+    const quote = quoteToken.at(-1);
     matches.push({
       index: bearer.index,
       length: bearer[0].length,
       replacement: `${bearer[1]} <redacted>`,
-      quote: bearer[2] === "\"" || bearer[2] === "'" ? bearer[2] : null,
+      quote: quote === "\"" || quote === "'" ? quote : null,
+      quoteEscapeDepth: Math.max(0, quoteToken.length - 1),
       quotedKey: false,
       authorization: false,
       bearer: true,
@@ -122,6 +129,7 @@ function sensitiveTextMatch(value: string): SensitiveTextMatch | null {
       length: standalone[0].length,
       replacement: "<redacted>",
       quote: null,
+      quoteEscapeDepth: 0,
       quotedKey: false,
       authorization: false,
       bearer: false,
@@ -130,19 +138,16 @@ function sensitiveTextMatch(value: string): SensitiveTextMatch | null {
   return matches.sort((left, right) => left.index - right.index)[0] ?? null;
 }
 
-function quotedValueEnd(value: string, quote: "\"" | "'", start = 0): number {
-  let escaped = false;
+function quotedValueEnd(value: string, quote: "\"" | "'", escapeDepth: number, start = 0): number {
+  let backslashes = 0;
   for (let index = start; index < value.length; index += 1) {
     const character = value[index];
-    if (escaped) {
-      escaped = false;
-      continue;
-    }
     if (character === "\\") {
-      escaped = true;
+      backslashes += 1;
       continue;
     }
-    if (character === quote) return index;
+    if (character === quote && backslashes === escapeDepth) return index + 1;
+    backslashes = 0;
   }
   return -1;
 }
@@ -164,11 +169,16 @@ function redactDiagnosticText(value: string): string {
       continue;
     }
     if (match.quote) {
-      const end = quotedValueEnd(pending, match.quote);
-      pending = end < 0 ? "" : pending.slice(end + 1);
+      const end = quotedValueEnd(pending, match.quote, match.quoteEscapeDepth);
+      pending = end < 0 ? "" : pending.slice(end);
       continue;
     }
-    if (match.bearer || !match.authorization) {
+    if (match.bearer) {
+      const end = pending.search(/[\r\n]/);
+      pending = end < 0 ? "" : pending.slice(end);
+      continue;
+    }
+    if (!match.authorization) {
       const end = pending.search(/\s/);
       pending = end < 0 ? "" : pending.slice(end);
     }
@@ -178,18 +188,22 @@ function redactDiagnosticText(value: string): string {
     .trim();
 }
 
-function boundedDiagnosticText(value: string, maxBytes: number, tail = false): string {
-  const redacted = redactDiagnosticText(value);
-  const bytes = Buffer.from(redacted);
-  if (bytes.length <= maxBytes) return redacted;
+function boundedUtf8Text(value: string, maxBytes: number, tail = false): string {
+  const bytes = Buffer.from(value);
+  if (bytes.length <= maxBytes) return value;
   if (tail) {
-    let start = bytes.length - maxBytes;
+    const marker = "...";
+    let start = bytes.length - Math.max(0, maxBytes - Buffer.byteLength(marker));
     while (start < bytes.length && (bytes[start] & 0xc0) === 0x80) start += 1;
-    return bytes.subarray(start).toString("utf8");
+    return marker.slice(0, maxBytes) + bytes.subarray(start).toString("utf8");
   }
   let end = maxBytes;
   while (end > 0 && (bytes[end] & 0xc0) === 0x80) end -= 1;
   return bytes.subarray(0, end).toString("utf8");
+}
+
+function boundedDiagnosticText(value: string, maxBytes: number, tail = false): string {
+  return boundedUtf8Text(redactDiagnosticText(value), maxBytes, tail);
 }
 
 export function createResourceDiagnosticTail(maxBytes = RESOURCE_FAILURE_STDERR_MAX_BYTES): {
@@ -199,7 +213,8 @@ export function createResourceDiagnosticTail(maxBytes = RESOURCE_FAILURE_STDERR_
   let sanitizedTail = "";
   let pending = "";
   let redacting: "unquoted" | "line" | "\"" | "'" | null = null;
-  let redactionEscape = false;
+  let redactionQuoteEscapeDepth = 0;
+  let redactionTrailingBackslashes = 0;
   let carriedCredential: "key" | "authorization-key" | "value" | "authorization" | "bearer" | null = null;
   const appendSanitized = (value: string) => {
     sanitizedTail += value;
@@ -210,10 +225,17 @@ export function createResourceDiagnosticTail(maxBytes = RESOURCE_FAILURE_STDERR_
     sanitizedTail = sanitizedTail.slice(start);
   };
   const sanitizePending = () => {
-    const beginCredentialRedaction = () => {
-      const quote = pending[0];
-      if (quote === "\"" || quote === "'") pending = pending.slice(1);
-      redacting = quote === "\"" || quote === "'" ? quote : "unquoted";
+    const beginCredentialRedaction = (lineWhenUnquoted = false) => {
+      const quoteToken = /^((?:\\+)?["'])/.exec(pending)?.[1] ?? "";
+      const quote = quoteToken.at(-1);
+      if (quote === "\"" || quote === "'") {
+        pending = pending.slice(quoteToken.length);
+        redacting = quote;
+        redactionQuoteEscapeDepth = quoteToken.length - 1;
+        redactionTrailingBackslashes = 0;
+      } else {
+        redacting = lineWhenUnquoted ? "line" : "unquoted";
+      }
       carriedCredential = null;
     };
     while (pending) {
@@ -229,7 +251,7 @@ export function createResourceDiagnosticTail(maxBytes = RESOURCE_FAILURE_STDERR_
           return;
         }
         pending = pending.slice(valueStart);
-        beginCredentialRedaction();
+        beginCredentialRedaction(true);
         continue;
       }
       if (carriedCredential === "value") {
@@ -238,26 +260,24 @@ export function createResourceDiagnosticTail(maxBytes = RESOURCE_FAILURE_STDERR_
           pending = "";
           return;
         }
-        const quote = pending[valueStart];
-        pending = pending.slice(valueStart + (quote === "\"" || quote === "'" ? 1 : 0));
-        redacting = quote === "\"" || quote === "'" ? quote : "unquoted";
+        pending = pending.slice(valueStart);
+        beginCredentialRedaction();
         carriedCredential = null;
         continue;
       }
       if (carriedCredential === "key" || carriedCredential === "authorization-key") {
         const authorizationKey = carriedCredential === "authorization-key";
-        const completedKey = /^[A-Z0-9_.-]*\s*[:=]\s*(?:(["'])|(?=[^"'\s]))/i.exec(pending);
+        const completedKey = /^[A-Z0-9_.-]*\s*[:=]\s*(?:((?:\\+)?["'])|(?=[^"'\\\s]))/i.exec(pending);
         if (completedKey) {
           appendSanitized("<redacted>");
           pending = pending.slice(completedKey[0].length);
-          if (authorizationKey) {
-            redacting = "line";
-            carriedCredential = null;
-          }
-          else {
-            redacting = completedKey[1] === "\"" || completedKey[1] === "'" ? completedKey[1] : "unquoted";
-            carriedCredential = null;
-          }
+          const quoteToken = completedKey[1] ?? "";
+          const quote = quoteToken.at(-1);
+          if (quote === "\"" || quote === "'") redacting = quote;
+          else redacting = authorizationKey ? "line" : "unquoted";
+          redactionQuoteEscapeDepth = quoteToken.length > 0 ? quoteToken.length - 1 : 0;
+          redactionTrailingBackslashes = 0;
+          carriedCredential = null;
           continue;
         }
         const delimiter = /^[A-Z0-9_.-]*\s*[:=]\s*$/i.exec(pending);
@@ -279,21 +299,20 @@ export function createResourceDiagnosticTail(maxBytes = RESOURCE_FAILURE_STDERR_
         else if (redacting === "unquoted") end = pending.search(/\s/);
         else {
           end = -1;
+          let backslashes = redactionTrailingBackslashes;
           for (let index = 0; index < pending.length; index += 1) {
             const character = pending[index];
-            if (redactionEscape) {
-              redactionEscape = false;
-              continue;
-            }
             if (character === "\\") {
-              redactionEscape = true;
+              backslashes += 1;
               continue;
             }
-            if (character === redacting) {
+            if (character === redacting && backslashes === redactionQuoteEscapeDepth) {
               end = index;
               break;
             }
+            backslashes = 0;
           }
+          redactionTrailingBackslashes = backslashes;
         }
         if (end < 0) {
           pending = "";
@@ -301,7 +320,8 @@ export function createResourceDiagnosticTail(maxBytes = RESOURCE_FAILURE_STDERR_
         }
         pending = pending.slice(end + (redacting === "unquoted" || redacting === "line" ? 0 : 1));
         redacting = null;
-        redactionEscape = false;
+        redactionQuoteEscapeDepth = 0;
+        redactionTrailingBackslashes = 0;
         continue;
       }
       const match = sensitiveTextMatch(pending);
@@ -310,13 +330,16 @@ export function createResourceDiagnosticTail(maxBytes = RESOURCE_FAILURE_STDERR_
         pending = pending.slice(match.index + match.length);
         if (match.authorization) {
           redacting = match.quotedKey && match.quote ? match.quote : "line";
+          redactionQuoteEscapeDepth = match.quoteEscapeDepth;
           continue;
         }
         if (match.bearer) {
-          redacting = match.quote ?? "unquoted";
+          redacting = match.quote ?? "line";
+          redactionQuoteEscapeDepth = match.quoteEscapeDepth;
           continue;
         }
         redacting = match.quote ?? "unquoted";
+        redactionQuoteEscapeDepth = match.quoteEscapeDepth;
         continue;
       }
       if (pending.length <= DIAGNOSTIC_REDACTION_CONTEXT_CHARS) return;
@@ -331,19 +354,18 @@ export function createResourceDiagnosticTail(maxBytes = RESOURCE_FAILURE_STDERR_
           return;
         }
       }
-      const carriedKey = /(?:^|[^A-Z0-9_.-])([A-Z0-9_.-]*(?:TOKEN|SECRET|PASSWORD|PASSWD|API[_-]?KEY|AUTHORIZATION|COOKIE)[A-Z0-9_.-]*)(\s*)(?:([:=])(\s*))?$/i.exec(pending);
+      const carriedKey = /(^|[^A-Z0-9_.-])((?:\\+)?["']?)([A-Z0-9_.-]*(?:TOKEN|SECRET|PASSWORD|PASSWD|API[_-]?KEY|AUTHORIZATION|COOKIE)[A-Z0-9_.-]*)\2(\s*)(?:([:=])(\s*))?$/i.exec(pending);
       if (carriedKey) {
-        const keyStart = carriedKey.index + carriedKey[0].length
-          - carriedKey.slice(1).reduce((length, part) => length + (part?.length ?? 0), 0);
+        const keyStart = carriedKey.index + carriedKey[1].length;
         if (keyStart < pending.length - DIAGNOSTIC_REDACTION_CONTEXT_CHARS) {
           appendSanitized(pending.slice(0, keyStart));
-          if (carriedKey[3]) {
+          if (carriedKey[5]) {
             appendSanitized("<redacted>");
             pending = "";
-            carriedCredential = /AUTHORIZATION/i.test(carriedKey[1]) ? "authorization" : "value";
+            carriedCredential = /AUTHORIZATION/i.test(carriedKey[3]) ? "authorization" : "value";
           } else {
-            pending = (carriedKey[1] + carriedKey[2]).slice(-DIAGNOSTIC_REDACTION_CONTEXT_CHARS);
-            carriedCredential = /AUTHORIZATION/i.test(carriedKey[1]) ? "authorization-key" : "key";
+            pending = (carriedKey[3] + carriedKey[4]).slice(-DIAGNOSTIC_REDACTION_CONTEXT_CHARS);
+            carriedCredential = /AUTHORIZATION/i.test(carriedKey[3]) ? "authorization-key" : "key";
           }
           return;
         }
@@ -361,7 +383,7 @@ export function createResourceDiagnosticTail(maxBytes = RESOURCE_FAILURE_STDERR_
     },
     value() {
       const suffix = redacting ? "" : pending;
-      return redactDiagnosticText(sanitizedTail + suffix);
+      return boundedDiagnosticText(sanitizedTail + suffix, maxBytes, true);
     },
   };
 }

--- a/src/lib/resourceCollector.ts
+++ b/src/lib/resourceCollector.ts
@@ -1,5 +1,31 @@
 export type ResourceDegradedReason = "collector-busy" | "timeout" | "collector-crash";
 
+export type ResourceFailureCause =
+  | "collection-active"
+  | "observation-timeout"
+  | "file-handoff-timeout"
+  | "collector-error"
+  | "observation-limit"
+  | "worker-timeout"
+  | "worker-spawn"
+  | "worker-exit"
+  | "worker-input"
+  | "worker-output-limit"
+  | "worker-output-invalid"
+  | "worker-failure";
+
+export type ResourceFailureDiagnostic = Readonly<{
+  cause: ResourceFailureCause;
+  message: string;
+  causes: readonly string[];
+  stderr?: string;
+}>;
+
+export type ResourceCollectorFailure = Readonly<{
+  reason: ResourceDegradedReason;
+  diagnostic: ResourceFailureDiagnostic;
+}>;
+
 export type ResourceObservation<T> = Readonly<{
   generation: number;
   startedAt: number;
@@ -9,15 +35,25 @@ export type ResourceObservation<T> = Readonly<{
   degradedReason?: ResourceDegradedReason;
 }>;
 
+export type ResourceCollectorResult<T> = Readonly<{
+  observation: ResourceObservation<T> | null;
+  generation: number;
+  startedAt: number;
+  completedAt: number;
+  collectorId: string;
+  failure?: ResourceCollectorFailure;
+}>;
+
 export interface ResourceCollector<T, Input = void> {
   latest(): ResourceObservation<T> | null;
   fence(): number;
-  observe(fence: number, timeoutMs: number, input?: Input): Promise<ResourceObservation<T> | null>;
+  observe(fence: number, timeoutMs: number, input?: Input): Promise<ResourceCollectorResult<T>>;
 }
 
 export type ResourceCollectorOptions<T, Input = void> = {
   collectorId: string;
   collect(input?: Input): Promise<T>;
+  validateObservation?(observation: ResourceObservation<T>): void;
   now?(): number;
   initial?: ResourceObservation<T> | null;
 };
@@ -30,11 +66,84 @@ function freeze<T>(value: T): T {
   return value;
 }
 
-function withDegradedReason<T>(
-  observation: ResourceObservation<T>,
-  degradedReason: ResourceDegradedReason,
-): ResourceObservation<T> {
-  return freeze({ ...observation, degradedReason });
+const FAILURE_MESSAGE_MAX_BYTES = 512;
+export const RESOURCE_FAILURE_STDERR_MAX_BYTES = 2_048;
+const FAILURE_CAUSE_MAX_BYTES = 512;
+const FAILURE_CAUSE_MAX_DEPTH = 4;
+
+function redactDiagnosticText(value: string): string {
+  return value
+    .replace(/\b(Bearer)\s+[^\s]+/gi, "$1 <redacted>")
+    .replace(/\b([A-Z0-9_.-]*(?:TOKEN|SECRET|PASSWORD|PASSWD|API[_-]?KEY|AUTHORIZATION|COOKIE)[A-Z0-9_.-]*)\s*[:=]\s*(?:"[^"]*"|'[^']*'|[^\s]+)/gi, "$1=<redacted>")
+    .replace(/\b(?:sk|ghp|github_pat|xox[baprs])[-_A-Za-z0-9]{16,}\b/gi, "<redacted>")
+    .replace(/\b[A-Za-z0-9+/_=-]{48,}\b/g, "<redacted>")
+    .replace(/[\u0000-\u0008\u000B\u000C\u000E-\u001F\u007F]/g, "")
+    .trim();
+}
+
+function boundedDiagnosticText(value: string, maxBytes: number, tail = false): string {
+  const redacted = redactDiagnosticText(value);
+  const bytes = Buffer.from(redacted);
+  if (bytes.length <= maxBytes) return redacted;
+  const bounded = tail ? bytes.subarray(bytes.length - maxBytes) : bytes.subarray(0, maxBytes);
+  return bounded.toString("utf8").replace(/^\uFFFD|\uFFFD$/g, "");
+}
+
+function diagnosticCauses(error: unknown): string[] {
+  const causes: string[] = [];
+  let current = error;
+  for (let depth = 0; depth < FAILURE_CAUSE_MAX_DEPTH && current !== undefined; depth += 1) {
+    if (current instanceof Error) {
+      const message = boundedDiagnosticText(current.message, FAILURE_CAUSE_MAX_BYTES);
+      if (message) causes.push(message);
+      current = current.cause;
+      continue;
+    }
+    const message = boundedDiagnosticText(String(current), FAILURE_CAUSE_MAX_BYTES);
+    if (message) causes.push(message);
+    break;
+  }
+  return causes;
+}
+
+function resourceCollectorFailure(
+  reason: ResourceDegradedReason,
+  cause: ResourceFailureCause,
+  message: string,
+  options: { cause?: unknown; stderr?: string } = {},
+): ResourceCollectorFailure {
+  const stderr = options.stderr === undefined
+    ? undefined
+    : boundedDiagnosticText(options.stderr, RESOURCE_FAILURE_STDERR_MAX_BYTES, true);
+  return freeze({
+    reason,
+    diagnostic: {
+      cause,
+      message: boundedDiagnosticText(message, FAILURE_MESSAGE_MAX_BYTES),
+      causes: diagnosticCauses(options.cause),
+      ...(stderr ? { stderr } : {}),
+    },
+  });
+}
+
+export class ResourceCollectorFailureError extends Error {
+  readonly failure: ResourceCollectorFailure;
+
+  constructor(
+    reason: ResourceDegradedReason,
+    cause: ResourceFailureCause,
+    message: string,
+    options: { cause?: unknown; stderr?: string } = {},
+  ) {
+    super(message, options.cause === undefined ? undefined : { cause: options.cause });
+    this.name = "ResourceCollectorFailureError";
+    this.failure = resourceCollectorFailure(reason, cause, message, options);
+  }
+}
+
+function failureFromError(error: unknown): ResourceCollectorFailure {
+  if (error instanceof ResourceCollectorFailureError) return error.failure;
+  return resourceCollectorFailure("collector-crash", "collector-error", "resource collection failed", { cause: error });
 }
 
 /**
@@ -53,13 +162,17 @@ export function createResourceCollector<T, Input = void>(options: ResourceCollec
     const startedAt = now();
     const promise = Promise.resolve()
       .then(() => options.collect(input))
-      .then((value) => freeze({
-        generation,
-        startedAt,
-        completedAt: now(),
-        collectorId: options.collectorId,
-        value: freeze(value),
-      }));
+      .then((value) => {
+        const observation = {
+          generation,
+          startedAt,
+          completedAt: now(),
+          collectorId: options.collectorId,
+          value: freeze(value),
+        };
+        options.validateObservation?.(observation);
+        return freeze(observation);
+      });
     const operation = { generation, promise };
     active = operation;
     void promise.then(
@@ -88,22 +201,44 @@ export function createResourceCollector<T, Input = void>(options: ResourceCollec
     latest: () => latest,
     fence: () => startedGeneration,
     async observe(fence, timeoutMs, input) {
+      const requestedAt = now();
       const observation = afterFence(fence, input);
+      const result = (value: ResourceObservation<T> | null, failure?: ResourceCollectorFailure): ResourceCollectorResult<T> => freeze({
+        observation: value,
+        generation: failure ? Math.max(startedGeneration, value?.generation ?? 0) : (value?.generation ?? startedGeneration),
+        startedAt: requestedAt,
+        completedAt: now(),
+        collectorId: options.collectorId,
+        ...(failure ? { failure } : {}),
+      });
       const bounded = Math.max(0, timeoutMs);
       if (bounded === 0) {
         void observation.catch(() => undefined);
-        return latest ? withDegradedReason(latest, "collector-busy") : null;
+        return result(latest, resourceCollectorFailure(
+          "collector-busy",
+          "collection-active",
+          "resource collection is still active",
+        ));
       }
       let timer: ReturnType<typeof setTimeout> | undefined;
+      const timeout = Symbol("resource-observation-timeout");
       try {
-        return await Promise.race([
+        const value = await Promise.race([
           observation,
-          new Promise<ResourceObservation<T> | null>((resolve) => {
-            timer = setTimeout(() => resolve(latest ? withDegradedReason(latest, "timeout") : null), bounded);
+          new Promise<typeof timeout>((resolve) => {
+            timer = setTimeout(() => resolve(timeout), bounded);
           }),
         ]);
-      } catch {
-        return latest ? withDegradedReason(latest, "collector-crash") : null;
+        if (value === timeout) {
+          return result(latest, resourceCollectorFailure(
+            "timeout",
+            "observation-timeout",
+            "resource collection observation timed out",
+          ));
+        }
+        return result(value);
+      } catch (error) {
+        return result(latest, failureFromError(error));
       } finally {
         if (timer) clearTimeout(timer);
       }

--- a/src/lib/resourceCollector.ts
+++ b/src/lib/resourceCollector.ts
@@ -12,7 +12,8 @@ export type ResourceFailureCause =
   | "worker-input"
   | "worker-output-limit"
   | "worker-output-invalid"
-  | "worker-failure";
+  | "worker-failure"
+  | "worker-cleanup";
 
 export type ResourceFailureDiagnostic = Readonly<{
   cause: ResourceFailureCause;
@@ -72,6 +73,12 @@ const FAILURE_CAUSE_MAX_BYTES = 512;
 const FAILURE_CAUSE_MAX_DEPTH = 4;
 const DIAGNOSTIC_REDACTION_CONTEXT_CHARS = 256;
 
+type ResourceFailureOptions = {
+  cause?: unknown;
+  stderr?: string;
+  secondaryCauses?: readonly unknown[];
+};
+
 type SensitiveTextMatch = {
   index: number;
   length: number;
@@ -121,6 +128,7 @@ function sensitiveTextMatch(value: string): SensitiveTextMatch | null {
 
 function redactDiagnosticText(value: string): string {
   return value
+    .replace(/\b([A-Z0-9_.-]*AUTHORIZATION[A-Z0-9_.-]*)\s*[:=][^\r\n]*/gi, "$1=<redacted>")
     .replace(/\b(Bearer)\s+[^\s]+/gi, "$1 <redacted>")
     .replace(/\b([A-Z0-9_.-]*(?:TOKEN|SECRET|PASSWORD|PASSWD|API[_-]?KEY|AUTHORIZATION|COOKIE)[A-Z0-9_.-]*)\s*[:=]\s*(?:"[^"]*"|'[^']*'|[^\s]+)/gi, "$1=<redacted>")
     .replace(/\b(?:sk|ghp|github_pat|xox[baprs])[-_A-Za-z0-9]{16,}\b/gi, "<redacted>")
@@ -149,7 +157,7 @@ export function createResourceDiagnosticTail(maxBytes = RESOURCE_FAILURE_STDERR_
 } {
   let sanitizedTail = "";
   let pending = "";
-  let redacting: "unquoted" | "\"" | "'" | null = null;
+  let redacting: "unquoted" | "line" | "\"" | "'" | null = null;
   let carriedCredential: "key" | "authorization-key" | "value" | "authorization" | "bearer" | null = null;
   const appendSanitized = (value: string) => {
     sanitizedTail += value;
@@ -168,25 +176,7 @@ export function createResourceDiagnosticTail(maxBytes = RESOURCE_FAILURE_STDERR_
     };
     while (pending) {
       if (carriedCredential === "authorization") {
-        const valueStart = pending.search(/\S/);
-        if (valueStart < 0) {
-          pending = "";
-          return;
-        }
-        pending = pending.slice(valueStart);
-        const bearer = /^(Bearer)\s+(?=\S)/i.exec(pending);
-        if (bearer) {
-          pending = pending.slice(bearer[0].length);
-          beginCredentialRedaction();
-          continue;
-        }
-        if ("bearer".startsWith(pending.toLowerCase())) return;
-        if (/^Bearer\s*$/i.test(pending)) {
-          pending = "";
-          carriedCredential = "bearer";
-          return;
-        }
-        redacting = "unquoted";
+        redacting = "line";
         carriedCredential = null;
         continue;
       }
@@ -218,7 +208,10 @@ export function createResourceDiagnosticTail(maxBytes = RESOURCE_FAILURE_STDERR_
         if (completedKey) {
           appendSanitized("<redacted>");
           pending = pending.slice(completedKey[0].length);
-          if (authorizationKey && completedKey[1] === undefined) carriedCredential = "authorization";
+          if (authorizationKey) {
+            redacting = "line";
+            carriedCredential = null;
+          }
           else {
             redacting = completedKey[1] === "\"" || completedKey[1] === "'" ? completedKey[1] : "unquoted";
             carriedCredential = null;
@@ -239,12 +232,14 @@ export function createResourceDiagnosticTail(maxBytes = RESOURCE_FAILURE_STDERR_
         carriedCredential = null;
       }
       if (redacting) {
-        const end = redacting === "unquoted" ? pending.search(/\s/) : pending.indexOf(redacting);
+        const end = redacting === "line"
+          ? pending.search(/[\r\n]/)
+          : redacting === "unquoted" ? pending.search(/\s/) : pending.indexOf(redacting);
         if (end < 0) {
           pending = "";
           return;
         }
-        pending = pending.slice(end + (redacting === "unquoted" ? 0 : 1));
+        pending = pending.slice(end + (redacting === "unquoted" || redacting === "line" ? 0 : 1));
         redacting = null;
         continue;
       }
@@ -252,8 +247,8 @@ export function createResourceDiagnosticTail(maxBytes = RESOURCE_FAILURE_STDERR_
       if (match) {
         appendSanitized(pending.slice(0, match.index) + match.replacement);
         pending = pending.slice(match.index + match.length);
-        if (match.authorization && match.quote === null) {
-          carriedCredential = "authorization";
+        if (match.authorization) {
+          redacting = "line";
           continue;
         }
         if (match.bearer) {
@@ -327,11 +322,22 @@ function diagnosticCauses(error: unknown): string[] {
   return causes;
 }
 
+function combinedDiagnosticCauses(primary: unknown, secondary: readonly unknown[] = []): string[] {
+  const causes: string[] = [];
+  for (const error of [primary, ...secondary]) {
+    for (const cause of diagnosticCauses(error)) {
+      causes.push(cause);
+      if (causes.length === FAILURE_CAUSE_MAX_DEPTH) return causes;
+    }
+  }
+  return causes;
+}
+
 function resourceCollectorFailure(
   reason: ResourceDegradedReason,
   cause: ResourceFailureCause,
   message: string,
-  options: { cause?: unknown; stderr?: string } = {},
+  options: ResourceFailureOptions = {},
 ): ResourceCollectorFailure {
   const stderr = options.stderr === undefined
     ? undefined
@@ -341,7 +347,7 @@ function resourceCollectorFailure(
     diagnostic: {
       cause,
       message: boundedDiagnosticText(message, FAILURE_MESSAGE_MAX_BYTES),
-      causes: diagnosticCauses(options.cause),
+      causes: combinedDiagnosticCauses(options.cause, options.secondaryCauses),
       ...(stderr ? { stderr } : {}),
     },
   });
@@ -354,7 +360,7 @@ export class ResourceCollectorFailureError extends Error {
     reason: ResourceDegradedReason,
     cause: ResourceFailureCause,
     message: string,
-    options: { cause?: unknown; stderr?: string } = {},
+    options: ResourceFailureOptions = {},
   ) {
     super(message, options.cause === undefined ? undefined : { cause: options.cause });
     this.name = "ResourceCollectorFailureError";

--- a/src/lib/resourceCollector.worker.ts
+++ b/src/lib/resourceCollector.worker.ts
@@ -5,6 +5,8 @@ import { procBackend } from "./proc";
 import { buildResourceSnapshot, lastResourceBuildDiagnostic, lastResourceTargetRefs, readResourceFileSnapshot } from "./resources";
 import { captureTmuxAttachReferences } from "./tmux";
 
+process.env.LLV_RESOURCE_OBSERVATION_WORKER = "1";
+
 function send(message: unknown): void {
   if (parentPort) {
     parentPort.postMessage(message);

--- a/src/lib/resourceCollector.worker.ts
+++ b/src/lib/resourceCollector.worker.ts
@@ -74,6 +74,7 @@ async function collect(message: unknown): Promise<void> {
       serverPid: tmuxServerPid,
       resumeRecords: async () => null,
       identity: procBackend.processIdentity,
+      holdsPath: procBackend.pidHoldsPath,
       conversationIdForPath: (pathname) => conversationByPath.get(pathname) ?? null,
     });
     const payload = await buildResourceSnapshot(request.fresh, {

--- a/src/lib/resourceCollector.worker.ts
+++ b/src/lib/resourceCollector.worker.ts
@@ -6,6 +6,7 @@ import { createTranscriptHostObserver } from "./agent/transcriptHost";
 import { procBackend } from "./proc";
 import { agentProcesses } from "./scanner/process";
 import { buildResourceSnapshot, lastResourceBuildDiagnostic, lastResourceTargetRefs, RESOURCE_WORKER_OUTPUT_MAX_BYTES, type ResourceWorkerFileObservation } from "./resources";
+import { overlayResourceSessionTitles } from "./session/titleProjection";
 import { captureTmuxAttachReferences, panePidMap, tmuxServerPid } from "./tmux";
 import type { FileEntry } from "./types";
 
@@ -65,6 +66,7 @@ async function collect(message: unknown): Promise<void> {
     return;
   }
   try {
+    overlayResourceSessionTitles(request.files as FileEntry[]);
     const conversationByPath = new Map(request.files.flatMap((entry) => entry.conversationId ? [[entry.path, entry.conversationId] as const] : []));
     const readHosts = createTranscriptHostObserver({
       listFiles: async () => request.files as FileEntry[],

--- a/src/lib/resourceCollector.worker.ts
+++ b/src/lib/resourceCollector.worker.ts
@@ -1,9 +1,11 @@
 import { parentPort } from "node:worker_threads";
 
-import { readTranscriptHostsObservation } from "./agent/transcriptHost";
+import { createTranscriptHostObserver } from "./agent/transcriptHost";
 import { procBackend } from "./proc";
-import { buildResourceSnapshot, lastResourceBuildDiagnostic, lastResourceTargetRefs, readResourceFileSnapshot } from "./resources";
-import { captureTmuxAttachReferences } from "./tmux";
+import { agentProcesses } from "./scanner/process";
+import { buildResourceSnapshot, lastResourceBuildDiagnostic, lastResourceTargetRefs, RESOURCE_WORKER_OUTPUT_MAX_BYTES, type ResourceWorkerFileObservation } from "./resources";
+import { captureTmuxAttachReferences, panePidMap, tmuxServerPid } from "./tmux";
+import type { FileEntry } from "./types";
 
 process.env.LLV_RESOURCE_OBSERVATION_WORKER = "1";
 
@@ -15,12 +17,68 @@ function send(message: unknown): void {
   process.stdout.write(JSON.stringify(message) + "\n");
 }
 
+type ResourceWorkerRequest = {
+  type: "collect";
+  fresh: boolean;
+  files: ResourceWorkerFileObservation[];
+};
+
+function record(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function nullableString(value: unknown): value is string | null {
+  return value === null || typeof value === "string";
+}
+
+function resourceFileObservation(value: unknown): value is ResourceWorkerFileObservation {
+  if (!record(value)) return false;
+  const keys = ["path", "parent", "title", "project", "activity", "mtime", "engine", "pid", "proc", "conversationId"];
+  if (Object.keys(value).length !== keys.length || keys.some((key) => !Object.hasOwn(value, key))) return false;
+  return typeof value.path === "string" && value.path.length > 0
+    && nullableString(value.parent)
+    && typeof value.title === "string"
+    && typeof value.project === "string"
+    && (value.activity === "live" || value.activity === "recent" || value.activity === "stalled" || value.activity === "idle")
+    && typeof value.mtime === "number" && Number.isFinite(value.mtime) && value.mtime >= 0
+    && (value.engine === "claude" || value.engine === "codex" || value.engine === "shell")
+    && (value.pid === null || (Number.isSafeInteger(value.pid) && (value.pid as number) > 0))
+    && (value.proc === "running" || value.proc === "done" || value.proc === "killed" || value.proc === null)
+    && nullableString(value.conversationId);
+}
+
+function resourceWorkerRequest(value: unknown): ResourceWorkerRequest | null {
+  if (!record(value)
+    || Object.keys(value).length !== 3
+    || value.type !== "collect"
+    || typeof value.fresh !== "boolean"
+    || !Array.isArray(value.files)
+    || value.files.length > 10_000
+    || !value.files.every(resourceFileObservation)) return null;
+  return value as ResourceWorkerRequest;
+}
+
 async function collect(message: unknown): Promise<void> {
-  if (!message || typeof message !== "object" || !("type" in message) || message.type !== "collect") return;
+  const request = resourceWorkerRequest(message);
+  if (!request) {
+    send({ type: "failure", error: "resource collector received an invalid request" });
+    return;
+  }
   try {
-    const payload = await buildResourceSnapshot(true, {
-      readFiles: readResourceFileSnapshot,
-      readHosts: readTranscriptHostsObservation,
+    const conversationByPath = new Map(request.files.flatMap((entry) => entry.conversationId ? [[entry.path, entry.conversationId] as const] : []));
+    const readHosts = createTranscriptHostObserver({
+      listFiles: async () => request.files as FileEntry[],
+      panes: panePidMap,
+      ppidMap: () => procBackend.ppidMap(),
+      agents: agentProcesses,
+      serverPid: tmuxServerPid,
+      resumeRecords: async () => null,
+      identity: procBackend.processIdentity,
+      conversationIdForPath: (pathname) => conversationByPath.get(pathname) ?? null,
+    });
+    const payload = await buildResourceSnapshot(request.fresh, {
+      readFiles: async () => request.files,
+      readHosts: (fresh, entries, ppids) => readHosts(fresh, entries as FileEntry[], ppids),
       proc: procBackend,
       captureAttachReferences: captureTmuxAttachReferences,
     });
@@ -36,9 +94,17 @@ if (parentPort) {
   parentPort.on("message", (message: unknown) => { void collect(message); });
 } else {
   let input = "";
+  let inputBytes = 0;
   process.stdin.setEncoding("utf8");
-  process.stdin.on("data", (chunk: string) => { input += chunk; });
+  process.stdin.on("data", (chunk: string) => {
+    inputBytes += Buffer.byteLength(chunk);
+    if (inputBytes <= RESOURCE_WORKER_OUTPUT_MAX_BYTES) input += chunk;
+  });
   process.stdin.on("end", () => {
+    if (inputBytes > RESOURCE_WORKER_OUTPUT_MAX_BYTES) {
+      send({ type: "failure", error: "resource collector input exceeded transport limit" });
+      return;
+    }
     try {
       void collect(JSON.parse(input));
     } catch (error) {

--- a/src/lib/resourceCollector.worker.ts
+++ b/src/lib/resourceCollector.worker.ts
@@ -1,0 +1,38 @@
+import { parentPort } from "node:worker_threads";
+
+import { buildResourceSnapshot, lastResourceBuildDiagnostic, lastResourceTargetRefs } from "./resources";
+
+function send(message: unknown): void {
+  if (parentPort) {
+    parentPort.postMessage(message);
+    return;
+  }
+  process.stdout.write(JSON.stringify(message) + "\n");
+}
+
+async function collect(message: unknown): Promise<void> {
+  if (!message || typeof message !== "object" || !("type" in message) || message.type !== "collect") return;
+  try {
+    const payload = await buildResourceSnapshot(true);
+    const diagnostic = lastResourceBuildDiagnostic();
+    if (!diagnostic) throw new Error("resource worker completed without diagnostics");
+    send({ type: "observation", payload, diagnostic, targets: lastResourceTargetRefs() });
+  } catch (error) {
+    send({ type: "failure", error: error instanceof Error ? error.message : String(error) });
+  }
+}
+
+if (parentPort) {
+  parentPort.on("message", (message: unknown) => { void collect(message); });
+} else {
+  let input = "";
+  process.stdin.setEncoding("utf8");
+  process.stdin.on("data", (chunk: string) => { input += chunk; });
+  process.stdin.on("end", () => {
+    try {
+      void collect(JSON.parse(input));
+    } catch (error) {
+      send({ type: "failure", error: error instanceof Error ? error.message : String(error) });
+    }
+  });
+}

--- a/src/lib/resourceCollector.worker.ts
+++ b/src/lib/resourceCollector.worker.ts
@@ -1,3 +1,5 @@
+import "./resourceCollector.workerMode";
+
 import { parentPort } from "node:worker_threads";
 
 import { createTranscriptHostObserver } from "./agent/transcriptHost";
@@ -6,8 +8,6 @@ import { agentProcesses } from "./scanner/process";
 import { buildResourceSnapshot, lastResourceBuildDiagnostic, lastResourceTargetRefs, RESOURCE_WORKER_OUTPUT_MAX_BYTES, type ResourceWorkerFileObservation } from "./resources";
 import { captureTmuxAttachReferences, panePidMap, tmuxServerPid } from "./tmux";
 import type { FileEntry } from "./types";
-
-process.env.LLV_RESOURCE_OBSERVATION_WORKER = "1";
 
 function send(message: unknown): void {
   if (parentPort) {

--- a/src/lib/resourceCollector.worker.ts
+++ b/src/lib/resourceCollector.worker.ts
@@ -1,6 +1,9 @@
 import { parentPort } from "node:worker_threads";
 
-import { buildResourceSnapshot, lastResourceBuildDiagnostic, lastResourceTargetRefs } from "./resources";
+import { readTranscriptHostsObservation } from "./agent/transcriptHost";
+import { procBackend } from "./proc";
+import { buildResourceSnapshot, lastResourceBuildDiagnostic, lastResourceTargetRefs, readResourceFileSnapshot } from "./resources";
+import { captureTmuxAttachReferences } from "./tmux";
 
 function send(message: unknown): void {
   if (parentPort) {
@@ -13,7 +16,12 @@ function send(message: unknown): void {
 async function collect(message: unknown): Promise<void> {
   if (!message || typeof message !== "object" || !("type" in message) || message.type !== "collect") return;
   try {
-    const payload = await buildResourceSnapshot(true);
+    const payload = await buildResourceSnapshot(true, {
+      readFiles: readResourceFileSnapshot,
+      readHosts: readTranscriptHostsObservation,
+      proc: procBackend,
+      captureAttachReferences: captureTmuxAttachReferences,
+    });
     const diagnostic = lastResourceBuildDiagnostic();
     if (!diagnostic) throw new Error("resource worker completed without diagnostics");
     send({ type: "observation", payload, diagnostic, targets: lastResourceTargetRefs() });

--- a/src/lib/resourceCollector.workerMode.ts
+++ b/src/lib/resourceCollector.workerMode.ts
@@ -1,0 +1,3 @@
+process.env.LLV_RESOURCE_OBSERVATION_WORKER = "1";
+
+export {};

--- a/src/lib/resources.test.ts
+++ b/src/lib/resources.test.ts
@@ -7,7 +7,7 @@ import { createTranscriptHostObserver, type TranscriptHost } from "@/lib/agent/t
 import { RESOURCE_FAILURE_STDERR_MAX_BYTES } from "@/lib/resourceCollector";
 import type { FileEntry, ResourcesPayload } from "@/lib/types";
 
-import { allowedKillTarget, applyResourceTargets, buildResourceSnapshot, canonicalResourceEntry, conflictingResourceHost, consumeKillTarget, createResourcesReader, lastResourceBuildDiagnostic, lastResourceTargetRefs, noteSessionTargets, parsePersistedResourceObservation, parseResourcesFixture, resetResourcesForTests, resolveResourceWorkerLaunch, resourceWorkerFileSnapshot, RESOURCE_OBSERVATION_MAX_BYTES, RESOURCE_WORKER_OUTPUT_MAX_BYTES } from "./resources";
+import { allowedKillTarget, applyResourceTargets, buildResourceSnapshot, canonicalResourceEntry, conflictingResourceHost, consumeKillTarget, createResourcesReader, lastResourceBuildDiagnostic, lastResourceTargetRefs, noteSessionTargets, parsePersistedResourceObservation, parseResourcesFixture, resetResourcesForTests, resolveResourceWorkerLaunch, resourceDiagnosticHeader, resourceWorkerFileSnapshot, RESOURCE_OBSERVATION_MAX_BYTES, RESOURCE_WORKER_OUTPUT_MAX_BYTES } from "./resources";
 
 const PATHNAME = "/home/user/.codex/sessions/2026/07/10/rollout-2026-07-10-019f4906-3f67-7b72-9fbc-9ec3b5ad1326.jsonl";
 const EMPTY_WORKER_MESSAGE = JSON.stringify({
@@ -161,6 +161,39 @@ async function withResourceWorkerScript<T>(
   const executable = path.join(directory, "fixture-worker");
   const body = typeof lines === "function" ? lines(directory) : lines;
   writeFileSync(executable, ["#!/bin/sh", ...body, ""].join("\n"));
+  chmodSync(executable, 0o700);
+  const previousExecutable = process.env.LLV_RESOURCE_COLLECTOR_EXECUTABLE;
+  process.env.LLV_RESOURCE_COLLECTOR_EXECUTABLE = executable;
+  try {
+    return await task(directory);
+  } finally {
+    if (previousExecutable === undefined) delete process.env.LLV_RESOURCE_COLLECTOR_EXECUTABLE;
+    else process.env.LLV_RESOURCE_COLLECTOR_EXECUTABLE = previousExecutable;
+    rmSync(directory, { recursive: true, force: true });
+  }
+}
+
+async function withResourceWorkerChunks<T>(
+  chunks: Buffer[],
+  task: (directory: string) => Promise<T>,
+): Promise<T> {
+  const directory = mkdtempSync(path.join(os.tmpdir(), "llv-resource-worker-chunks-"));
+  const executable = path.join(directory, "fixture-worker");
+  const pidFile = path.join(directory, "pid");
+  const encodedChunks = JSON.stringify(chunks.map((chunk) => chunk.toString("base64")));
+  writeFileSync(executable, [
+    "#!/usr/bin/env node",
+    'const { writeFileSync } = require("node:fs");',
+    `writeFileSync(${JSON.stringify(pidFile)}, String(process.pid));`,
+    `const chunks = ${encodedChunks}.map((chunk) => Buffer.from(chunk, "base64"));`,
+    "let index = 0;",
+    "const writeNext = () => {",
+    "  if (index === chunks.length) { process.exitCode = 7; return; }",
+    "  process.stderr.write(chunks[index], () => { index += 1; setTimeout(writeNext, 20); });",
+    "};",
+    "writeNext();",
+    "",
+  ].join("\n"));
   chmodSync(executable, 0o700);
   const previousExecutable = process.env.LLV_RESOURCE_COLLECTOR_EXECUTABLE;
   process.env.LLV_RESOURCE_COLLECTOR_EXECUTABLE = executable;
@@ -953,6 +986,55 @@ describe("resource recurring reads", () => {
       expect(stderr).toContain("PASSWORD=<redacted>");
       expect(stderr).not.toContain("fresh-secret");
     });
+  });
+
+  test("stderr pipe decoding preserves UTF-8 split at every byte boundary", async () => {
+    const chunks = [Buffer.from("discarded-prefix\n".repeat(300))];
+    const expected: string[] = [];
+    for (const character of ["é", "€", "😀"]) {
+      const encoded = Buffer.from(character);
+      for (let split = 1; split < encoded.length; split += 1) {
+        const label = `${encoded.length}-byte-${split}+${encoded.length - split}:`;
+        expected.push(`${label}${character}`);
+        chunks.push(Buffer.concat([Buffer.from(label), encoded.subarray(0, split)]));
+        chunks.push(Buffer.concat([encoded.subarray(split), Buffer.from("\n")]));
+      }
+    }
+    chunks.push(Buffer.from("API_TOKEN=split-secret\ncollector-tail-complete"));
+    const rawOutputBytes = chunks.reduce((total, chunk) => total + chunk.length, 0);
+
+    await withResourceWorkerChunks(chunks, async (directory) => {
+      const outcome = await Promise.race([
+        workerTestReader({ initial: null, workerLimits: { outputMaxBytes: rawOutputBytes } }).read(),
+        new Promise<"hung">((resolve) => setTimeout(() => resolve("hung"), 2_000)),
+      ]);
+
+      expect(outcome === "hung").toBeFalse();
+      if (outcome === "hung") return;
+      expect(outcome).toMatchObject({ diagnostic: {
+        degradedReason: "collector-crash",
+        failure: { cause: "worker-exit" },
+      } });
+      const stderr = outcome.diagnostic.failure?.stderr ?? "";
+      expect(Buffer.byteLength(stderr)).toBeLessThanOrEqual(RESOURCE_FAILURE_STDERR_MAX_BYTES);
+      expect(stderr).not.toContain("\uFFFD");
+      for (const value of expected) expect(stderr).toContain(value);
+      expect(stderr).toContain("API_TOKEN=<redacted>");
+      expect(stderr).not.toContain("split-secret");
+      expect(stderr.endsWith("collector-tail-complete")).toBeTrue();
+      await expectProcessAbsentAfterQuietInterval(Number(readFileSync(path.join(directory, "pid"), "utf8")), "split stderr worker");
+    });
+  });
+
+  test("the resources route preserves split UTF-8 diagnostics in a header-safe value", async () => {
+    const diagnostic = {
+      status: "failed",
+      failure: { stderr: "2-byte:é\n3-byte:€\n4-byte:😀\ncollector-tail-complete" },
+    };
+    const header = resourceDiagnosticHeader(diagnostic);
+
+    expect([...header].every((character) => character.charCodeAt(0) <= 0x7e)).toBeTrue();
+    expect(JSON.parse(header)).toEqual(diagnostic);
   });
 
   test("malformed, oversized, crash, timeout, and immediate-exit paths release complete worker trees", async () => {

--- a/src/lib/resources.test.ts
+++ b/src/lib/resources.test.ts
@@ -115,6 +115,15 @@ function processExists(pid: number): boolean {
   }
 }
 
+function processGroupExists(pid: number): boolean {
+  try {
+    process.kill(-pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 function directorySnapshot(root: string): Array<readonly [string, "directory" | "file", number, string?]> {
   const snapshot: Array<readonly [string, "directory" | "file", number, string?]> = [];
   const visit = (directory: string, relative: string) => {
@@ -889,15 +898,87 @@ describe("resource recurring reads", () => {
       const startedAt = performance.now();
       const outcome = await workerTestReader({ workerLimits: { timeoutMs: 500, closeTimeoutMs: 25 } }).read(true);
       const elapsedMs = performance.now() - startedAt;
+      const workerPid = Number(readFileSync(path.join(directory, "pid"), "utf8"));
+      const descendantPid = Number(readFileSync(path.join(directory, "descendant-pid"), "utf8"));
 
       expect(outcome).toMatchObject({ diagnostic: {
         degradedReason: "collector-crash",
         failure: { cause: "worker-exit" },
       } });
       expect(elapsedMs).toBeLessThan(250);
-      await expectProcessAbsentAfterQuietInterval(Number(readFileSync(path.join(directory, "pid"), "utf8")), "exited leader");
-      await expectProcessAbsentAfterQuietInterval(Number(readFileSync(path.join(directory, "descendant-pid"), "utf8")), "pipe-holding descendant");
+      expect(processGroupExists(workerPid)).toBeFalse();
+      expect(processExists(descendantPid)).toBeFalse();
+      await expectProcessAbsentAfterQuietInterval(workerPid, "exited leader");
+      await expectProcessAbsentAfterQuietInterval(descendantPid, "pipe-holding descendant");
     });
+  });
+
+  test("a successful read settles after a TERM-resistant redirected process group is absent", async () => {
+    await withResourceWorkerScript((directory) => {
+      const descendantPid = path.join(directory, "redirected-descendant-pid");
+      const ready = path.join(directory, "redirected-descendant-ready");
+      return [
+        `printf '%s' "$$" > "${path.join(directory, "pid")}"`,
+        "trap 'exit 0' TERM INT",
+        `sh -c 'trap "" TERM INT; printf "%s" "$$" > "$1"; : > "$2"; while :; do sleep 1; done' sh "${descendantPid}" "${ready}" </dev/null >/dev/null 2>&1 &`,
+        `while [ ! -e "${ready}" ]; do sleep 0.01; done`,
+        `printf '%s\n' '${EMPTY_FRESH_WORKER_MESSAGE}'`,
+        "while :; do sleep 0.01; done",
+      ];
+    }, async (directory) => {
+      const outcome = await workerTestReader({
+        initial: null,
+        workerLimits: { timeoutMs: 500, closeTimeoutMs: 150 },
+      }).read(true);
+      const workerPid = Number(readFileSync(path.join(directory, "pid"), "utf8"));
+      const descendantPid = Number(readFileSync(path.join(directory, "redirected-descendant-pid"), "utf8"));
+      const groupPresentAtSettlement = processGroupExists(workerPid);
+
+      if (groupPresentAtSettlement) process.kill(-workerPid, "SIGKILL");
+      expect(outcome.diagnostic.degradedReason).toBeUndefined();
+      expect(groupPresentAtSettlement).toBeFalse();
+      await expectProcessAbsentAfterQuietInterval(descendantPid, "redirected descendant");
+    });
+  });
+
+  test("success, failure, and timeout settle after redirected and inherited process groups are absent", async () => {
+    const fixtures = [
+      { name: "success", output: `printf '%s\\n' '${EMPTY_FRESH_WORKER_MESSAGE}'`, expected: { fresh: true, status: "complete" } },
+      { name: "failure", output: "printf '{invalid}\\n'", expected: { degradedReason: "collector-crash", failure: { cause: "worker-output-invalid" } } },
+      { name: "timeout", output: "", expected: { degradedReason: "timeout", failure: { cause: "worker-timeout" } } },
+    ] as const;
+
+    for (const pipes of ["redirected", "inherited"] as const) {
+      for (const fixture of fixtures) {
+        await withResourceWorkerScript((directory) => {
+          const descendantPid = path.join(directory, "matrix-descendant-pid");
+          const ready = path.join(directory, "matrix-descendant-ready");
+          const redirect = pipes === "redirected" ? " </dev/null >/dev/null 2>&1" : "";
+          return [
+            `printf '%s' "$$" > "${path.join(directory, "pid")}"`,
+            "trap 'exit 0' TERM INT",
+            `sh -c 'trap "" TERM INT; printf "%s" "$$" > "$1"; : > "$2"; while :; do sleep 1; done' sh "${descendantPid}" "${ready}"${redirect} &`,
+            `while [ ! -e "${ready}" ]; do sleep 0.01; done`,
+            fixture.output,
+            "while :; do sleep 0.01; done",
+          ];
+        }, async (directory) => {
+          const outcome = await workerTestReader({
+            initial: null,
+            workerLimits: { timeoutMs: 50, closeTimeoutMs: 50 },
+          }).read(true);
+          const workerPid = Number(readFileSync(path.join(directory, "pid"), "utf8"));
+          const descendantPid = Number(readFileSync(path.join(directory, "matrix-descendant-pid"), "utf8"));
+          const label = `${pipes} ${fixture.name}`;
+          const groupPresentAtSettlement = processGroupExists(workerPid);
+
+          if (groupPresentAtSettlement) process.kill(-workerPid, "SIGKILL");
+          expect(outcome.diagnostic, label).toMatchObject(fixture.expected);
+          expect(groupPresentAtSettlement, label).toBeFalse();
+          expect(processExists(descendantPid), label).toBeFalse();
+        });
+      }
+    }
   });
 
   test("a near-limit handoff to an immediately exiting worker keeps the parent alive and releases the worker", async () => {
@@ -1019,6 +1100,20 @@ describe("resource recurring reads", () => {
     });
   });
 
+  test("a keyed Authorization Bearer credential is fully redacted from worker stderr", async () => {
+    await withResourceWorkerScript([
+      "printf 'Authorization: Bearer tracer-secret-sentinel\\nsafe diagnostic suffix\\n' >&2",
+      "exit 7",
+    ], async () => {
+      const outcome = await workerTestReader({ initial: null }).read();
+      const stderr = outcome.diagnostic.failure?.stderr ?? "";
+
+      expect(stderr).toContain("Authorization=<redacted>");
+      expect(stderr).toContain("safe diagnostic suffix");
+      expect(stderr).not.toContain("tracer-secret-sentinel");
+    });
+  });
+
   test("a fresh worker crash attributes its durable cache and bounds redacted stderr", async () => {
     await withResourceWorkerScript([
       "yes 'safe stderr line' | head -c 4096 >&2",
@@ -1053,7 +1148,7 @@ describe("resource recurring reads", () => {
         chunks.push(Buffer.concat([encoded.subarray(split), Buffer.from("\n")]));
       }
     }
-    chunks.push(Buffer.from("API_TOKEN=split-secret\ncollector-tail-complete"));
+    chunks.push(Buffer.from("Authorization: Bearer split-secret\ncollector-tail-complete"));
     const rawOutputBytes = chunks.reduce((total, chunk) => total + chunk.length, 0);
 
     await withResourceWorkerChunks(chunks, async (directory) => {
@@ -1072,7 +1167,7 @@ describe("resource recurring reads", () => {
       expect(Buffer.byteLength(stderr)).toBeLessThanOrEqual(RESOURCE_FAILURE_STDERR_MAX_BYTES);
       expect(stderr).not.toContain("\uFFFD");
       for (const value of expected) expect(stderr).toContain(value);
-      expect(stderr).toContain("API_TOKEN=<redacted>");
+      expect(stderr).toContain("Authorization=<redacted>");
       expect(stderr).not.toContain("split-secret");
       expect(stderr.endsWith("collector-tail-complete")).toBeTrue();
       await expectProcessAbsentAfterQuietInterval(Number(readFileSync(path.join(directory, "pid"), "utf8")), "split stderr worker");

--- a/src/lib/resources.test.ts
+++ b/src/lib/resources.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, spyOn, test } from "bun:test";
-import { chmodSync, existsSync, lstatSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, readlinkSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, closeSync, existsSync, lstatSync, mkdirSync, mkdtempSync, openSync, readFileSync, readdirSync, readlinkSync, rmSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
@@ -116,6 +116,14 @@ function processExists(pid: number): boolean {
   }
 }
 
+function fileHasText(filename: string): boolean {
+  try {
+    return readFileSync(filename, "utf8").trim().length > 0;
+  } catch {
+    return false;
+  }
+}
+
 interface FixtureProcessGroup {
   pgid: number;
   authorizerPid: number;
@@ -147,6 +155,24 @@ function pidNamespaceMembers(namespaceId: string): number[] {
     } catch {}
   }
   return members;
+}
+
+function retainedPidNamespaceReferences(namespaceId: string): number {
+  let references = 0;
+  for (const name of readdirSync(`/proc/${process.pid}/fd`)) {
+    try {
+      if (readlinkSync(`/proc/${process.pid}/fd/${name}`) === namespaceId) references += 1;
+    } catch {}
+  }
+  return references;
+}
+
+function retainPidNamespaceReference(pid: number, namespaceId: string): number {
+  const fd = openSync(`/proc/${pid}/ns/pid`, "r");
+  const actualNamespaceId = readlinkSync(`/proc/self/fd/${fd}`);
+  if (actualNamespaceId === namespaceId) return fd;
+  closeSync(fd);
+  throw new Error(`PID ${pid} changed namespace from ${namespaceId} to ${actualNamespaceId} before the test reference was retained`);
 }
 
 function confirmedFixtureProcessGroups(executable: string): FixtureProcessGroup[] {
@@ -1452,7 +1478,6 @@ describe("resource recurring reads", () => {
             'const fs = require("node:fs");',
             'const { spawn } = require("node:child_process");',
             'const [escapedScript, escapedPid, escapedReady, memberReady, pipes] = process.argv.slice(2);',
-            'fs.writeFileSync(memberReady, "ready");',
             'let handled = false;',
             'process.on("SIGTERM", () => {',
             '  if (handled) return;',
@@ -1462,6 +1487,7 @@ describe("resource recurring reads", () => {
             '  child.unref();',
             '  process.exit(0);',
             '});',
+            'fs.writeFileSync(memberReady, "ready");',
             'setInterval(() => {}, 1_000);',
             '',
           ].join("\n"));
@@ -1474,6 +1500,8 @@ describe("resource recurring reads", () => {
             "sleep 0.08",
             fixture.name === "crash"
               ? `kill -TERM "$member_pid"; while [ ! -e "${escapedReady}" ]; do sleep 0.005; done; exit 7`
+              : fixture.name === "timeout"
+                ? `kill -TERM "$member_pid"; while [ ! -e "${escapedReady}" ]; do sleep 0.005; done`
               : fixture.output,
             "while :; do sleep 0.01; done",
           ];
@@ -1528,25 +1556,25 @@ describe("resource recurring reads", () => {
       {
         name: "success",
         output: `printf '%s\\n' '${EMPTY_FRESH_WORKER_MESSAGE}'`,
-        timeoutMs: 500,
+        timeoutMs: 1_200,
         expected: { status: "complete" },
       },
       {
         name: "malformed output",
         output: "printf '{invalid}\\n'",
-        timeoutMs: 500,
+        timeoutMs: 1_200,
         expected: { degradedReason: "collector-crash", failure: { cause: "worker-output-invalid" } },
       },
       {
         name: "crash",
         output: "exit 7",
-        timeoutMs: 500,
+        timeoutMs: 1_200,
         expected: { degradedReason: "collector-crash", failure: { cause: "worker-exit" } },
       },
       {
         name: "timeout",
         output: ":",
-        timeoutMs: 180,
+        timeoutMs: 650,
         expected: { degradedReason: "timeout", failure: { cause: "worker-timeout" } },
       },
     ] as const;
@@ -1584,7 +1612,6 @@ describe("resource recurring reads", () => {
             'const fs = require("node:fs");',
             'const { spawn } = require("node:child_process");',
             'const [escapedScript, escapedPid, escapedNamespace, escapedReady, memberReady, ownerMode] = process.argv.slice(2);',
-            'fs.writeFileSync(memberReady, "ready");',
             'let handled = false;',
             'process.on("SIGTERM", () => {',
             '  if (handled) return;',
@@ -1598,15 +1625,18 @@ describe("resource recurring reads", () => {
             '  child.unref();',
             '  process.exit(0);',
             '});',
+            'fs.writeFileSync(memberReady, "ready");',
             'setInterval(() => {}, 1_000);',
             '',
           ].join("\n"));
           return [
             `read host_pid _ < /proc/self/stat; printf '%s' "$host_pid" > "${path.join(directory, "pid")}"`,
+            `readlink /proc/self/ns/pid > "${path.join(directory, "root-namespace")}"`,
             "trap 'exit 0' TERM INT",
             `/usr/bin/node "${memberScript}" "${escapedScript}" "${escapedPid}" "${escapedNamespace}" "${escapedReady}" "${memberReady}" "${owner}" &`,
             "member_pid=$!",
             `while [ ! -e "${memberReady}" ]; do sleep 0.005; done`,
+            `while [ ! -e "${path.join(directory, "release")}" ]; do sleep 0.005; done`,
             "sleep 0.08",
             fixture.name === "crash"
               ? `kill -TERM "$member_pid"; while [ ! -e "${escapedReady}" ]; do sleep 0.005; done; exit 7`
@@ -1616,34 +1646,55 @@ describe("resource recurring reads", () => {
         }, async (directory) => {
           const escapedPidFile = path.join(directory, "owner-escaped-pid");
           const escapedNamespaceFile = path.join(directory, "owner-escaped-namespace");
-          const diagnostic = (await workerTestReader({
+          const read = workerTestReader({
             initial: null,
             workerLimits: {
-              observeTimeoutMs: 900,
+              observeTimeoutMs: 3_000,
               inputTimeoutMs: 10,
               timeoutMs: fixture.timeoutMs,
-              closeTimeoutMs: 40,
-              cleanupTimeoutMs: 150,
-              headroomMs: 250,
+              closeTimeoutMs: 250,
+              cleanupTimeoutMs: 600,
+              headroomMs: 900,
             },
-          }).read(true)).diagnostic;
-          for (let attempt = 0; attempt < 20 && !existsSync(escapedPidFile); attempt += 1) {
+          }).read(true);
+          const rootPidFile = path.join(directory, "pid");
+          const rootNamespaceFile = path.join(directory, "root-namespace");
+          for (let attempt = 0; attempt < 100
+            && (!fileHasText(rootPidFile) || !fileHasText(rootNamespaceFile)); attempt += 1) {
             await new Promise((resolve) => setTimeout(resolve, 5));
           }
-          expect(existsSync(escapedPidFile), `${owner} ${fixture.name} spawn: ${JSON.stringify(diagnostic)}`).toBeTrue();
-          const escapedPid = Number(readFileSync(escapedPidFile, "utf8"));
-          const namespaceId = readFileSync(escapedNamespaceFile, "utf8");
-          const descendantAliveAtSettlement = processExists(escapedPid);
-          results.push({ owner, outcome: fixture.name, diagnostic, descendantAliveAtSettlement });
-          if (descendantAliveAtSettlement) process.kill(escapedPid, "SIGKILL");
-          await expectProcessAbsentAfterQuietInterval(escapedPid, `${owner} ${fixture.name} RED cleanup`);
+          const rootPid = Number(readFileSync(rootPidFile, "utf8"));
+          const rootNamespaceId = readFileSync(rootNamespaceFile, "utf8").trim();
+          const namespaceReference = retainPidNamespaceReference(rootPid, rootNamespaceId);
+          writeFileSync(path.join(directory, "release"), "release");
+          let namespaceId = rootNamespaceId;
+          try {
+            const diagnostic = (await read).diagnostic;
+            for (let attempt = 0; attempt < 40
+              && (!fileHasText(escapedPidFile) || !fileHasText(escapedNamespaceFile)); attempt += 1) {
+              await new Promise((resolve) => setTimeout(resolve, 5));
+            }
+            expect(fileHasText(escapedPidFile) && fileHasText(escapedNamespaceFile),
+              `${owner} ${fixture.name} spawn: ${JSON.stringify(diagnostic)}`).toBeTrue();
+            const escapedPid = Number(readFileSync(escapedPidFile, "utf8"));
+            namespaceId = readFileSync(escapedNamespaceFile, "utf8").trim();
+            const descendantAliveAtSettlement = processExists(escapedPid);
+            results.push({ owner, outcome: fixture.name, diagnostic, descendantAliveAtSettlement });
+            if (descendantAliveAtSettlement) process.kill(escapedPid, "SIGKILL");
+            await expectProcessAbsentAfterQuietInterval(escapedPid, `${owner} ${fixture.name} RED cleanup`);
 
-          expect(diagnostic, `${owner} ${fixture.name} primary outcome`).toMatchObject(fixture.expected);
-          expect(confirmedFixtureProcessGroups(path.join(directory, "fixture-worker")), `${owner} ${fixture.name} groups`).toEqual([]);
-          expect(pidNamespaceMembers(namespaceId), `${owner} ${fixture.name} namespace`).toEqual([]);
-          await new Promise((resolve) => setTimeout(resolve, 30));
-          expect(processExists(escapedPid), `${owner} ${fixture.name} sustained identity`).toBeFalse();
-          expect(pidNamespaceMembers(namespaceId), `${owner} ${fixture.name} sustained namespace`).toEqual([]);
+            expect(namespaceId, `${owner} ${fixture.name} namespace identity`).toBe(rootNamespaceId);
+            expect(diagnostic, `${owner} ${fixture.name} primary outcome`).toMatchObject(fixture.expected);
+            expect(confirmedFixtureProcessGroups(path.join(directory, "fixture-worker")), `${owner} ${fixture.name} groups`).toEqual([]);
+            expect(pidNamespaceMembers(namespaceId), `${owner} ${fixture.name} namespace`).toEqual([]);
+            expect(retainedPidNamespaceReferences(namespaceId), `${owner} ${fixture.name} production namespace references`).toBe(1);
+            await new Promise((resolve) => setTimeout(resolve, 30));
+            expect(processExists(escapedPid), `${owner} ${fixture.name} sustained identity`).toBeFalse();
+            expect(pidNamespaceMembers(namespaceId), `${owner} ${fixture.name} sustained namespace`).toEqual([]);
+          } finally {
+            closeSync(namespaceReference);
+          }
+          expect(retainedPidNamespaceReferences(namespaceId), `${owner} ${fixture.name} namespace references`).toBe(0);
         });
       }
     }
@@ -1660,6 +1711,95 @@ describe("resource recurring reads", () => {
     )), `uncontained outcomes: ${JSON.stringify(results)}`).toEqual([]);
   });
 
+  test("retains PID namespace membership authority through init disappearance", async () => {
+    await withResourceWorkerScript((directory) => {
+      const escapedScript = path.join(directory, "retained-namespace-child.cjs");
+      const memberScript = path.join(directory, "retained-namespace-member.cjs");
+      writeFileSync(escapedScript, [
+        '#!/usr/bin/node',
+        'const fs = require("node:fs");',
+        'const [pidFile, namespaceFile, readyFile] = process.argv.slice(2);',
+        'process.on("SIGTERM", () => {});',
+        'process.on("SIGINT", () => {});',
+        'fs.writeFileSync(pidFile, fs.readFileSync("/proc/self/stat", "utf8").split(" ", 1)[0]);',
+        'fs.writeFileSync(namespaceFile, fs.readlinkSync("/proc/self/ns/pid"));',
+        'fs.writeFileSync(readyFile, "ready");',
+        'setInterval(() => {}, 1_000);',
+        '',
+      ].join("\n"));
+      writeFileSync(memberScript, [
+        '#!/usr/bin/node',
+        'const fs = require("node:fs");',
+        'const { spawn } = require("node:child_process");',
+        'const [escapedScript, pidFile, namespaceFile, readyFile, memberReady] = process.argv.slice(2);',
+        'process.once("SIGTERM", () => {',
+        '  const env = { ...process.env };',
+        '  delete env.LLV_RESOURCE_COLLECTOR_OWNER;',
+        '  const child = spawn(process.execPath, [escapedScript, pidFile, namespaceFile, readyFile], {',
+        '    detached: true, stdio: "ignore", env,',
+        '  });',
+        '  child.unref();',
+        '  process.exit(0);',
+        '});',
+        'fs.writeFileSync(memberReady, "ready");',
+        'setInterval(() => {}, 1_000);',
+        '',
+      ].join("\n"));
+      return [
+        `readlink /proc/self/ns/pid > "${path.join(directory, "root-namespace")}"`,
+        "trap 'exit 0' TERM INT",
+        `/usr/bin/node "${memberScript}" "${escapedScript}" "${path.join(directory, "escaped-pid")}" "${path.join(directory, "escaped-namespace")}" "${path.join(directory, "escaped-ready")}" "${path.join(directory, "member-ready")}" &`,
+        `while [ ! -e "${path.join(directory, "member-ready")}" ]; do sleep 0.005; done`,
+        `while [ ! -e "${path.join(directory, "release")}" ]; do sleep 0.005; done`,
+        `printf '%s\n' '${EMPTY_FRESH_WORKER_MESSAGE}'`,
+        "while :; do sleep 0.01; done",
+      ];
+    }, async (directory) => {
+      const baseline = referencedHandles();
+      const read = workerTestReader({
+        initial: null,
+        workerLimits: {
+          observeTimeoutMs: 2_000,
+          inputTimeoutMs: 10,
+          timeoutMs: 1_200,
+          closeTimeoutMs: 250,
+          cleanupTimeoutMs: 600,
+          headroomMs: 700,
+        },
+      }).read(true);
+      const rootNamespaceFile = path.join(directory, "root-namespace");
+      for (let attempt = 0; attempt < 100 && !fileHasText(rootNamespaceFile); attempt += 1) {
+        await new Promise((resolve) => setTimeout(resolve, 5));
+      }
+      expect(fileHasText(rootNamespaceFile)).toBeTrue();
+      const namespaceId = readFileSync(rootNamespaceFile, "utf8").trim();
+      const retainedReferences = retainedPidNamespaceReferences(namespaceId);
+      writeFileSync(path.join(directory, "release"), "release");
+      const outcome = await read;
+      const escapedPidFile = path.join(directory, "escaped-pid");
+      const escapedNamespaceFile = path.join(directory, "escaped-namespace");
+      for (let attempt = 0; attempt < 40
+        && (!fileHasText(escapedPidFile) || !fileHasText(escapedNamespaceFile)); attempt += 1) {
+        await new Promise((resolve) => setTimeout(resolve, 5));
+      }
+      const escapedPid = fileHasText(escapedPidFile) ? Number(readFileSync(escapedPidFile, "utf8")) : 0;
+      const escapedAliveAtSettlement = escapedPid > 0 && processExists(escapedPid);
+      const namespaceMembersAtSettlement = pidNamespaceMembers(namespaceId);
+      const referencesAtSettlement = retainedPidNamespaceReferences(namespaceId);
+      if (escapedAliveAtSettlement) process.kill(escapedPid, "SIGKILL");
+      await new Promise((resolve) => setTimeout(resolve, 30));
+      await new Promise<void>((resolve) => setImmediate(resolve));
+
+      expect(retainedReferences).toBeGreaterThan(0);
+      expect(outcome.diagnostic.degradedReason).toBeUndefined();
+      expect(escapedPid).toBeGreaterThan(0);
+      expect(escapedAliveAtSettlement).toBeFalse();
+      expect(namespaceMembersAtSettlement).toEqual([]);
+      expect(referencesAtSettlement).toBe(0);
+      expect(newReferencedHandleCount(baseline)).toBe(0);
+    });
+  });
+
   test("concurrent containment verification reaches exact zero for every TERM descendant", async () => {
     await withResourceWorkerScript((directory) => {
       const memberScript = path.join(directory, "concurrent-term-member.cjs");
@@ -1668,7 +1808,6 @@ describe("resource recurring reads", () => {
         'const fs = require("node:fs");',
         'const { spawn } = require("node:child_process");',
         'const [directory, key] = process.argv.slice(2);',
-        'fs.writeFileSync(`${directory}/${key}.member`, "ready");',
         'let handled = false;',
         'process.on("SIGTERM", () => {',
         '  if (handled) return;',
@@ -1687,54 +1826,83 @@ describe("resource recurring reads", () => {
         '  child.unref();',
         '  process.exit(0);',
         '});',
+        'fs.writeFileSync(`${directory}/${key}.member`, "ready");',
         'setInterval(() => {}, 1_000);',
         '',
       ].join("\n"));
       return [
         "read host_pid _ < /proc/self/stat",
         `printf '%s' "$host_pid" > "${path.join(directory, "pid")}"`,
+        `readlink /proc/self/ns/pid > "${directory}/$host_pid.root-namespace"`,
         "trap 'exit 0' TERM INT",
         `/usr/bin/node "${memberScript}" "${directory}" "$host_pid" &`,
         `while [ ! -e "${directory}/$host_pid.member" ]; do sleep 0.005; done`,
+        `while [ ! -e "${directory}/$host_pid.release" ]; do sleep 0.005; done`,
         `printf '%s\\n' '${EMPTY_FRESH_WORKER_MESSAGE}'`,
         "while :; do sleep 0.01; done",
       ];
     }, async (directory) => {
       const baseline = referencedHandles();
-      const outcomes = await Promise.all(Array.from({ length: 6 }, () => workerTestReader({
+      const reads = Array.from({ length: 6 }, () => workerTestReader({
         initial: null,
         workerLimits: {
-          observeTimeoutMs: 1_200,
+          observeTimeoutMs: 3_000,
           inputTimeoutMs: 10,
-          timeoutMs: 700,
-          closeTimeoutMs: 50,
-          cleanupTimeoutMs: 300,
-          headroomMs: 300,
+          timeoutMs: 1_200,
+          closeTimeoutMs: 250,
+          cleanupTimeoutMs: 600,
+          headroomMs: 900,
         },
-      }).read(true)));
-      const pidFiles = readdirSync(directory).filter((name) => /^\d+\.pid$/.test(name));
-      expect(outcomes).toHaveLength(6);
-      expect(outcomes.every((outcome) => (
-        (outcome.diagnostic.status === "complete" && outcome.diagnostic.degradedReason === undefined)
-        || outcome.diagnostic.failure?.cause === "worker-cleanup"
-      )), JSON.stringify(outcomes.map((outcome) => outcome.diagnostic))).toBeTrue();
-      expect(outcomes.some((outcome) => outcome.diagnostic.status === "complete")).toBeTrue();
-      expect(pidFiles).toHaveLength(6);
-      for (const pidFile of pidFiles) {
-        const key = pidFile.slice(0, -4);
-        const escapedPid = Number(readFileSync(path.join(directory, pidFile), "utf8"));
-        const namespaceId = readFileSync(path.join(directory, `${key}.namespace`), "utf8").trim();
-        expect(processExists(escapedPid), `${key} identity`).toBeFalse();
-        expect(pidNamespaceMembers(namespaceId), `${key} namespace`).toEqual([]);
+      }).read(true));
+      for (let attempt = 0; attempt < 200
+        && readdirSync(directory).filter((name) => /^\d+\.root-namespace$/.test(name)
+          && fileHasText(path.join(directory, name))).length < 6; attempt += 1) {
+        await new Promise((resolve) => setTimeout(resolve, 5));
       }
-      expect(confirmedFixtureProcessGroups(path.join(directory, "fixture-worker"))).toEqual([]);
-      await new Promise((resolve) => setTimeout(resolve, 30));
-      for (const pidFile of pidFiles) {
-        const key = pidFile.slice(0, -4);
-        const escapedPid = Number(readFileSync(path.join(directory, pidFile), "utf8"));
-        const namespaceId = readFileSync(path.join(directory, `${key}.namespace`), "utf8").trim();
-        expect(processExists(escapedPid), `${key} sustained identity`).toBeFalse();
-        expect(pidNamespaceMembers(namespaceId), `${key} sustained namespace`).toEqual([]);
+      const rootNamespaceFiles = readdirSync(directory).filter((name) => /^\d+\.root-namespace$/.test(name)
+        && fileHasText(path.join(directory, name)));
+      expect(rootNamespaceFiles).toHaveLength(6);
+      const namespaceReferences = rootNamespaceFiles.map((filename) => {
+        const key = filename.slice(0, -".root-namespace".length);
+        const namespaceId = readFileSync(path.join(directory, filename), "utf8").trim();
+        return { key, namespaceId, fd: retainPidNamespaceReference(Number(key), namespaceId) };
+      });
+      for (const { key } of namespaceReferences) writeFileSync(path.join(directory, `${key}.release`), "release");
+      try {
+        const outcomes = await Promise.all(reads);
+        const pidFiles = readdirSync(directory).filter((name) => /^\d+\.pid$/.test(name));
+        expect(outcomes).toHaveLength(6);
+        expect(outcomes.every((outcome) => (
+          (outcome.diagnostic.status === "complete" && outcome.diagnostic.degradedReason === undefined)
+          || outcome.diagnostic.failure?.cause === "worker-cleanup"
+        )), JSON.stringify(outcomes.map((outcome) => outcome.diagnostic))).toBeTrue();
+        expect(outcomes.some((outcome) => outcome.diagnostic.status === "complete")).toBeTrue();
+        expect(pidFiles).toHaveLength(6);
+        for (const pidFile of pidFiles) {
+          const key = pidFile.slice(0, -4);
+          const escapedPid = Number(readFileSync(path.join(directory, pidFile), "utf8"));
+          const namespaceId = readFileSync(path.join(directory, `${key}.namespace`), "utf8").trim();
+          expect(namespaceId, `${key} namespace identity`).toBe(
+            namespaceReferences.find((item) => item.key === key)?.namespaceId ?? "missing namespace reference",
+          );
+          expect(processExists(escapedPid), `${key} identity`).toBeFalse();
+          expect(pidNamespaceMembers(namespaceId), `${key} namespace`).toEqual([]);
+          expect(retainedPidNamespaceReferences(namespaceId), `${key} production namespace references`).toBe(1);
+        }
+        expect(confirmedFixtureProcessGroups(path.join(directory, "fixture-worker"))).toEqual([]);
+        await new Promise((resolve) => setTimeout(resolve, 30));
+        for (const pidFile of pidFiles) {
+          const key = pidFile.slice(0, -4);
+          const escapedPid = Number(readFileSync(path.join(directory, pidFile), "utf8"));
+          const namespaceId = readFileSync(path.join(directory, `${key}.namespace`), "utf8").trim();
+          expect(processExists(escapedPid), `${key} sustained identity`).toBeFalse();
+          expect(pidNamespaceMembers(namespaceId), `${key} sustained namespace`).toEqual([]);
+        }
+      } finally {
+        for (const reference of namespaceReferences) closeSync(reference.fd);
+      }
+      for (const { key, namespaceId } of namespaceReferences) {
+        expect(retainedPidNamespaceReferences(namespaceId), `${key} namespace references`).toBe(0);
       }
       await new Promise<void>((resolve) => setImmediate(resolve));
       expect(newReferencedHandleCount(baseline)).toBe(0);

--- a/src/lib/resources.test.ts
+++ b/src/lib/resources.test.ts
@@ -822,6 +822,59 @@ describe("kill-target allowlist", () => {
 });
 
 describe("resource recurring reads", () => {
+  test("the full scaled deadline settles after maximum handoff and TERM-resistant group cleanup", async () => {
+    const scale = 0.04;
+    const observeTimeoutMs = 30_000 * scale;
+    const inputTimeoutMs = 500 * scale;
+    const timeoutMs = 29_500 * scale;
+    const closeTimeoutMs = 1_000 * scale;
+    const headroomMs = 500 * scale;
+
+    await withResourceWorkerScript((directory) => {
+      const descendantPid = path.join(directory, "deadline-descendant-pid");
+      const ready = path.join(directory, "deadline-descendant-ready");
+      return [
+        `printf '%s' "$$" > "${path.join(directory, "pid")}"`,
+        "trap 'exit 0' TERM INT",
+        `sh -c 'trap "" TERM INT; printf "%s" "$$" > "$1"; : > "$2"; while :; do sleep 1; done' sh "${descendantPid}" "${ready}" &`,
+        `while [ ! -e "${ready}" ]; do sleep 0.01; done`,
+        "while :; do sleep 0.01; done",
+      ];
+    }, async (directory) => {
+      const startedAt = performance.now();
+      const read = workerTestReader({
+        readFiles: async () => {
+          await new Promise((resolve) => setTimeout(resolve, inputTimeoutMs));
+          return [];
+        },
+        workerLimits: { observeTimeoutMs, inputTimeoutMs, timeoutMs, closeTimeoutMs, headroomMs },
+      }).read(true);
+      const outerDeadline = Symbol("outer-deadline");
+      let deadlineTimer: ReturnType<typeof setTimeout> | undefined;
+      const first = await Promise.race([
+        read,
+        new Promise<typeof outerDeadline>((resolve) => {
+          deadlineTimer = setTimeout(() => resolve(outerDeadline), observeTimeoutMs);
+        }),
+      ]);
+      const outcome = first === outerDeadline ? await read : first;
+      if (deadlineTimer) clearTimeout(deadlineTimer);
+      const elapsedMs = performance.now() - startedAt;
+      const workerPid = Number(readFileSync(path.join(directory, "pid"), "utf8"));
+      const descendantPid = Number(readFileSync(path.join(directory, "deadline-descendant-pid"), "utf8"));
+
+      expect(first === outerDeadline).toBeFalse();
+      expect(elapsedMs).toBeLessThan(observeTimeoutMs);
+      expect(outcome).toMatchObject({ diagnostic: {
+        degradedReason: "timeout",
+        failure: { cause: "worker-timeout" },
+      } });
+      expect(processExists(workerPid)).toBeFalse();
+      expect(processExists(descendantPid)).toBeFalse();
+      expect(() => process.kill(-workerPid, 0)).toThrow();
+    });
+  });
+
   test("an exited leader cleans up a TERM-resistant descendant that holds both output pipes", async () => {
     await withResourceWorkerScript((directory) => {
       const descendantPid = path.join(directory, "descendant-pid");
@@ -1023,6 +1076,74 @@ describe("resource recurring reads", () => {
       expect(stderr).not.toContain("split-secret");
       expect(stderr.endsWith("collector-tail-complete")).toBeTrue();
       await expectProcessAbsentAfterQuietInterval(Number(readFileSync(path.join(directory, "pid"), "utf8")), "split stderr worker");
+    });
+  });
+
+  test("a credential longer than the retained stderr window leaks no punctuated value bytes", async () => {
+    const secret = Array.from({ length: 1_000 }, (_, index) => `LEAK${index.toString().padStart(4, "0")}!`).join("");
+    const chunks = [
+      Buffer.from("API_TOKEN="),
+      Buffer.from(secret),
+      Buffer.from("\nsafe diagnostic suffix"),
+    ];
+    const rawOutputBytes = chunks.reduce((total, chunk) => total + chunk.length, 0);
+
+    await withResourceWorkerChunks(chunks, async () => {
+      const outcome = await workerTestReader({
+        initial: null,
+        workerLimits: { outputMaxBytes: rawOutputBytes },
+      }).read();
+      const stderr = outcome.diagnostic.failure?.stderr ?? "";
+
+      expect(stderr).toContain("API_TOKEN=<redacted>");
+      expect(stderr).toContain("safe diagnostic suffix");
+      expect(stderr).not.toMatch(/LEAK\d{4}/);
+      expect(Buffer.byteLength(stderr)).toBeLessThanOrEqual(RESOURCE_FAILURE_STDERR_MAX_BYTES);
+    });
+  });
+
+  test("split and evicted credential prefixes retain redaction state across stderr chunks", async () => {
+    const splitSecret = "SPLITLEAK!".repeat(700);
+    const evictedKey = `TOKEN${".A".repeat(300)}`;
+    const evictedSecret = "EVICTEDLEAK?".repeat(700);
+    const spacedSecret = "SPACEDLEAK;".repeat(700);
+    const bearerSecret = "BEARERLEAK:".repeat(700);
+    const quotedSecret = "QUOTEDLEAK; ".repeat(700);
+    const chunks = [
+      Buffer.from("AUTHORI"),
+      Buffer.from("ZATION = "),
+      Buffer.from(splitSecret),
+      Buffer.from("\n"),
+      Buffer.from(`${evictedKey}=`),
+      Buffer.from(evictedSecret),
+      Buffer.from("\nPASSWORD" + " ".repeat(600)),
+      Buffer.from("="),
+      Buffer.from(spacedSecret),
+      Buffer.from("\nBearer" + " ".repeat(600)),
+      Buffer.from(bearerSecret),
+      Buffer.from("\nCOOKIE=\""),
+      Buffer.from(quotedSecret),
+      Buffer.from("\""),
+      Buffer.from("\nsafe suffix after all credentials"),
+    ];
+    const rawOutputBytes = chunks.reduce((total, chunk) => total + chunk.length, 0);
+
+    await withResourceWorkerChunks(chunks, async () => {
+      const outcome = await workerTestReader({
+        initial: null,
+        workerLimits: { outputMaxBytes: rawOutputBytes },
+      }).read();
+      const stderr = outcome.diagnostic.failure?.stderr ?? "";
+
+      expect(stderr).toContain("AUTHORIZATION=<redacted>");
+      expect(stderr).toContain("<redacted>");
+      expect(stderr).toContain("safe suffix after all credentials");
+      expect(stderr).not.toContain("SPLITLEAK");
+      expect(stderr).not.toContain("EVICTEDLEAK");
+      expect(stderr).not.toContain("SPACEDLEAK");
+      expect(stderr).not.toContain("BEARERLEAK");
+      expect(stderr).not.toContain("QUOTEDLEAK");
+      expect(Buffer.byteLength(stderr)).toBeLessThanOrEqual(RESOURCE_FAILURE_STDERR_MAX_BYTES);
     });
   });
 

--- a/src/lib/resources.test.ts
+++ b/src/lib/resources.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, test } from "bun:test";
 
 import type { TranscriptHost } from "@/lib/agent/transcriptHost";
-import type { FileEntry } from "@/lib/types";
+import type { FileEntry, ResourcesPayload } from "@/lib/types";
 
-import { allowedKillTarget, buildResourceSnapshot, canonicalResourceEntry, conflictingResourceHost, consumeKillTarget, noteSessionTargets, parseResourcesFixture } from "./resources";
+import { allowedKillTarget, buildResourceSnapshot, canonicalResourceEntry, conflictingResourceHost, consumeKillTarget, createResourcesReader, lastResourceBuildDiagnostic, noteSessionTargets, parseResourcesFixture } from "./resources";
 
 const PATHNAME = "/home/user/.codex/sessions/2026/07/10/rollout-2026-07-10-019f4906-3f67-7b72-9fbc-9ec3b5ad1326.jsonl";
 
@@ -60,6 +60,16 @@ function ref(tmuxServerPid: number, panePid: number, paneId: string) {
   };
 }
 
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
 describe("resource observation", () => {
   test("builds host ownership and metadata from one shared transcript generation", async () => {
     let scans = 0;
@@ -110,6 +120,18 @@ describe("resource observation", () => {
       procCount: 3,
     }]);
     expect(allowedKillTarget("agents:4.0")).toEqual(ref(900, 100, "%1"));
+    expect(lastResourceBuildDiagnostic()).toEqual(expect.objectContaining({
+      fresh: true,
+      status: "complete",
+      phases: expect.objectContaining({
+        readFiles: expect.any(Number),
+        readHosts: expect.any(Number),
+        ppidMap: expect.any(Number),
+        processMemory: expect.any(Number),
+        attach: expect.any(Number),
+        serialization: expect.any(Number),
+      }),
+    }));
   });
 
   test("accepts a deterministic resource fixture", () => {
@@ -181,5 +203,62 @@ describe("kill-target allowlist", () => {
     consumeKillTarget("agents:1.0");
     expect(allowedKillTarget("agents:1.0")).toBeNull();
     expect(allowedKillTarget("agents:2.0")).toEqual(ref(900, 222, "%22"));
+  });
+});
+
+describe("resource recurring reads", () => {
+  test("expired ordinary reads return the cached snapshot while one rebuild runs, and fresh waits for a newer build", async () => {
+    let now = 0;
+    let builds = 0;
+    const ordinary = deferred<ResourcesPayload>();
+    const fresh = deferred<ResourcesPayload>();
+    const cached: ResourcesPayload = { system: null, sessions: [] };
+    const ordinaryResult: ResourcesPayload = { system: null, sessions: [{ target: "agents:2.0", panePid: 2, path: null, engine: "codex", hostConflict: false, title: null, project: null, activity: null, lastActiveAt: null, cwd: "/repo", rssBytes: 2, swapBytes: 0, procCount: 1 }] };
+    const freshResult: ResourcesPayload = { system: null, sessions: [{ target: "agents:3.0", panePid: 3, path: null, engine: "codex", hostConflict: false, title: null, project: null, activity: null, lastActiveAt: null, cwd: "/repo", rssBytes: 3, swapBytes: 0, procCount: 1 }] };
+    const reader = createResourcesReader(async (forceFresh) => {
+      builds += 1;
+      if (builds === 1) return cached;
+      return forceFresh ? fresh.promise : ordinary.promise;
+    }, () => null, () => now);
+
+    expect(await reader.read()).toEqual(cached);
+    now = 10_000;
+    expect(await reader.read()).toEqual(cached);
+    await Promise.resolve();
+    expect(builds).toBe(2);
+    expect(await reader.read()).toEqual(cached);
+    expect(builds).toBe(2);
+
+    const forced = reader.read(true);
+    ordinary.resolve(ordinaryResult);
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    expect(builds).toBe(3);
+    fresh.resolve(freshResult);
+    expect(await forced).toEqual(freshResult);
+  });
+
+  test("a failed ordinary rebuild leaves the cached snapshot available and later polls retry", async () => {
+    let now = 0;
+    let builds = 0;
+    const recovered = deferred<ResourcesPayload>();
+    const cached: ResourcesPayload = { system: null, sessions: [] };
+    const reader = createResourcesReader(async () => {
+      builds += 1;
+      if (builds === 1) return cached;
+      if (builds === 2) throw new Error("transient resource build failure");
+      return recovered.promise;
+    }, () => null, () => now);
+
+    await reader.read();
+    now = 10_000;
+    expect(await reader.read()).toEqual(cached);
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    await Promise.resolve();
+    expect(builds).toBe(2);
+    expect(await reader.read()).toEqual(cached);
+    await Promise.resolve();
+    expect(builds).toBe(3);
+    recovered.resolve(cached);
+    await Promise.resolve();
   });
 });

--- a/src/lib/resources.test.ts
+++ b/src/lib/resources.test.ts
@@ -5,7 +5,7 @@ import path from "node:path";
 
 import { createTranscriptHostObserver, type TranscriptHost } from "@/lib/agent/transcriptHost";
 import { procBackend } from "@/lib/proc";
-import { RESOURCE_FAILURE_STDERR_MAX_BYTES } from "@/lib/resourceCollector";
+import { createResourceDiagnosticTail, RESOURCE_FAILURE_STDERR_MAX_BYTES } from "@/lib/resourceCollector";
 import type { FileEntry, ResourcesPayload } from "@/lib/types";
 
 import { allowedKillTarget, applyResourceTargets, buildResourceSnapshot, canonicalResourceEntry, conflictingResourceHost, consumeKillTarget, createResourcesReader, lastResourceBuildDiagnostic, lastResourceTargetRefs, noteSessionTargets, parsePersistedResourceObservation, parseResourcesFixture, resetResourcesForTests, resolveResourceWorkerLaunch, resourceDiagnosticHeader, resourceWorkerFileSnapshot, RESOURCE_OBSERVATION_MAX_BYTES, RESOURCE_WORKER_OUTPUT_MAX_BYTES } from "./resources";
@@ -116,12 +116,82 @@ function processExists(pid: number): boolean {
   }
 }
 
-function processGroupExists(pid: number): boolean {
+interface FixtureProcessGroup {
+  pgid: number;
+  authorizerPid: number;
+  authorizerIdentity: string;
+}
+
+function processGroupId(pid: number): number | null {
   try {
-    process.kill(-pid, 0);
-    return true;
+    const stat = readFileSync(`/proc/${pid}/stat`, "utf8");
+    const fields = stat.slice(stat.lastIndexOf(")") + 2).trim().split(/\s+/);
+    const pgid = Number(fields[2]);
+    return Number.isInteger(pgid) && pgid > 0 ? pgid : null;
   } catch {
-    return false;
+    return null;
+  }
+}
+
+function confirmedFixtureProcessGroups(executable: string): FixtureProcessGroup[] {
+  const fixtureRoot = path.dirname(executable) + path.sep;
+  const processes = procBackend.listProcesses().flatMap((process) => {
+    const pgid = processGroupId(process.pid);
+    const identity = procBackend.processIdentity(process.pid);
+    return pgid === null || identity === null ? [] : [{ ...process, pgid, identity, ppid: procBackend.readPpid(process.pid) }];
+  });
+  const byPid = new Map(processes.map((process) => [process.pid, process]));
+  const fixtureProcesses = processes.filter((process) => process.argv.some(
+    (argument) => argument === executable || argument.startsWith(fixtureRoot),
+  ));
+  const pgids = new Set(fixtureProcesses.map((process) => process.pgid));
+
+  const confirmed: FixtureProcessGroup[] = [];
+  for (const pgid of pgids) {
+    const members = processes.filter((process) => process.pgid === pgid);
+    const fixturePids = new Set(fixtureProcesses.filter((process) => process.pgid === pgid).map((process) => process.pid));
+    const contained = members.every((member) => {
+      let current: typeof member | undefined = member;
+      const visited = new Set<number>();
+      while (current && !visited.has(current.pid)) {
+        if (fixturePids.has(current.pid)) return true;
+        visited.add(current.pid);
+        current = current.ppid === null ? undefined : byPid.get(current.ppid);
+      }
+      return false;
+    });
+    if (!contained) continue;
+    const authorizer = fixtureProcesses.find((process) => process.pgid === pgid);
+    if (!authorizer || procBackend.processIdentity(authorizer.pid) !== authorizer.identity) continue;
+    if (!procBackend.readArgv(authorizer.pid).some(
+      (argument) => argument === executable || argument.startsWith(fixtureRoot),
+    )) continue;
+    confirmed.push({ pgid, authorizerPid: authorizer.pid, authorizerIdentity: authorizer.identity });
+  }
+  return confirmed;
+}
+
+async function fixtureProcessGroupsAfterQuietInterval(executable: string): Promise<FixtureProcessGroup[]> {
+  let groups: FixtureProcessGroup[] = [];
+  for (let attempt = 0; attempt < 20; attempt += 1) {
+    groups = confirmedFixtureProcessGroups(executable);
+    if (groups.length === 0) return [];
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  return groups;
+}
+
+function killConfirmedFixtureProcessGroups(executable: string, groups: FixtureProcessGroup[]): void {
+  for (const group of groups) {
+    const current = confirmedFixtureProcessGroups(executable).find((candidate) => (
+      candidate.pgid === group.pgid
+      && candidate.authorizerPid === group.authorizerPid
+      && candidate.authorizerIdentity === group.authorizerIdentity
+    ));
+    if (!current) continue;
+    try {
+      process.kill(-group.pgid, "SIGKILL");
+    } catch {}
   }
 }
 
@@ -213,7 +283,12 @@ async function withResourceWorkerScript<T>(
   } finally {
     if (previousExecutable === undefined) delete process.env.LLV_RESOURCE_COLLECTOR_EXECUTABLE;
     else process.env.LLV_RESOURCE_COLLECTOR_EXECUTABLE = previousExecutable;
+    const leakedGroups = await fixtureProcessGroupsAfterQuietInterval(executable);
+    killConfirmedFixtureProcessGroups(executable, leakedGroups);
+    const survivingGroups = await fixtureProcessGroupsAfterQuietInterval(executable);
     rmSync(directory, { recursive: true, force: true });
+    expect(survivingGroups, `fixture process groups still present after cleanup: ${leakedGroups.map((group) => group.pgid).join(",")}`).toEqual([]);
+    expect(leakedGroups, "fixture process groups present after test settlement").toEqual([]);
   }
 }
 
@@ -915,7 +990,7 @@ describe("resource recurring reads", () => {
       } });
       expect(processExists(workerPid)).toBeFalse();
       expect(processExists(descendantPid)).toBeFalse();
-      expect(() => process.kill(-workerPid, 0)).toThrow();
+      expect(confirmedFixtureProcessGroups(path.join(directory, "fixture-worker"))).toEqual([]);
     });
   });
 
@@ -941,7 +1016,7 @@ describe("resource recurring reads", () => {
         failure: { cause: "worker-exit" },
       } });
       expect(elapsedMs).toBeLessThan(250);
-      expect(processGroupExists(workerPid)).toBeFalse();
+      expect(confirmedFixtureProcessGroups(path.join(directory, "fixture-worker"))).toEqual([]);
       expect(processExists(descendantPid)).toBeFalse();
       await expectProcessAbsentAfterQuietInterval(workerPid, "exited leader");
       await expectProcessAbsentAfterQuietInterval(descendantPid, "pipe-holding descendant");
@@ -988,11 +1063,11 @@ describe("resource recurring reads", () => {
         initial: null,
         workerLimits: { timeoutMs: 500, closeTimeoutMs: 150 },
       }).read(true);
-      const workerPid = Number(readFileSync(path.join(directory, "pid"), "utf8"));
       const descendantPid = Number(readFileSync(path.join(directory, "redirected-descendant-pid"), "utf8"));
-      const groupPresentAtSettlement = processGroupExists(workerPid);
+      const fixtureGroups = confirmedFixtureProcessGroups(path.join(directory, "fixture-worker"));
+      const groupPresentAtSettlement = fixtureGroups.length > 0;
 
-      if (groupPresentAtSettlement) process.kill(-workerPid, "SIGKILL");
+      killConfirmedFixtureProcessGroups(path.join(directory, "fixture-worker"), fixtureGroups);
       expect(outcome.diagnostic.degradedReason).toBeUndefined();
       expect(groupPresentAtSettlement).toBeFalse();
       await expectProcessAbsentAfterQuietInterval(descendantPid, "redirected descendant");
@@ -1025,12 +1100,12 @@ describe("resource recurring reads", () => {
             initial: null,
             workerLimits: { timeoutMs: 50, closeTimeoutMs: 50 },
           }).read(true);
-          const workerPid = Number(readFileSync(path.join(directory, "pid"), "utf8"));
           const descendantPid = Number(readFileSync(path.join(directory, "matrix-descendant-pid"), "utf8"));
           const label = `${pipes} ${fixture.name}`;
-          const groupPresentAtSettlement = processGroupExists(workerPid);
+          const fixtureGroups = confirmedFixtureProcessGroups(path.join(directory, "fixture-worker"));
+          const groupPresentAtSettlement = fixtureGroups.length > 0;
 
-          if (groupPresentAtSettlement) process.kill(-workerPid, "SIGKILL");
+          killConfirmedFixtureProcessGroups(path.join(directory, "fixture-worker"), fixtureGroups);
           expect(outcome.diagnostic, label).toMatchObject(fixture.expected);
           expect(groupPresentAtSettlement, label).toBeFalse();
           expect(processExists(descendantPid), label).toBeFalse();
@@ -1093,10 +1168,10 @@ describe("resource recurring reads", () => {
         } finally {
           kill.mockRestore();
         }
-        const workerPid = Number(readFileSync(path.join(directory, "pid"), "utf8"));
-        try {
-          realKill(-workerPid, "SIGKILL");
-        } catch {}
+        killConfirmedFixtureProcessGroups(
+          path.join(directory, "fixture-worker"),
+          confirmedFixtureProcessGroups(path.join(directory, "fixture-worker")),
+        );
         const final = await settleWithin(read, 300);
         await new Promise<void>((resolve) => setImmediate(resolve));
         const handles = newReferencedHandleCount(baseline);
@@ -1143,10 +1218,10 @@ describe("resource recurring reads", () => {
       } finally {
         kill.mockRestore();
       }
-      const workerPid = Number(readFileSync(path.join(directory, "pid"), "utf8"));
-      try {
-        realKill(-workerPid, "SIGKILL");
-      } catch {}
+      killConfirmedFixtureProcessGroups(
+        path.join(directory, "fixture-worker"),
+        confirmedFixtureProcessGroups(path.join(directory, "fixture-worker")),
+      );
       await settleWithin(read, 300);
 
       expect(initial === CLEANUP_DEADLINE).toBeFalse();
@@ -1208,15 +1283,15 @@ describe("resource recurring reads", () => {
         workerLimits: { observeTimeoutMs: 400, inputTimeoutMs: 10, timeoutMs: 100, closeTimeoutMs: 30, headroomMs: 80 },
       }).read(true);
       const initial = await settleWithin(read, 250);
-      const workerPid = Number(readFileSync(path.join(directory, "pid"), "utf8"));
       const descendantPid = Number(readFileSync(path.join(directory, "escaped-descendant-pid"), "utf8"));
       if (initial === CLEANUP_DEADLINE) {
         try {
           process.kill(descendantPid, "SIGKILL");
         } catch {}
-        try {
-          process.kill(-workerPid, "SIGKILL");
-        } catch {}
+        killConfirmedFixtureProcessGroups(
+          path.join(directory, "fixture-worker"),
+          confirmedFixtureProcessGroups(path.join(directory, "fixture-worker")),
+        );
         await settleWithin(read, 300);
       }
       await new Promise<void>((resolve) => setImmediate(resolve));
@@ -1228,6 +1303,152 @@ describe("resource recurring reads", () => {
       expect(processExists(descendantPid)).toBeFalse();
       expect(handles).toBe(0);
     });
+  });
+
+  test("TERM-handler escaped descendants are absent before every worker outcome settles", async () => {
+    const fixtures = [
+      {
+        name: "success",
+        output: `printf '%s\\n' '${EMPTY_FRESH_WORKER_MESSAGE}'`,
+        expected: { fresh: true, status: "complete" },
+        denyEscaped: false,
+        escapedAtSettlement: false,
+      },
+      {
+        name: "malformed output",
+        output: "printf '{invalid}\\n'",
+        expected: { degradedReason: "collector-crash", failure: { cause: "worker-output-invalid" } },
+        denyEscaped: false,
+        escapedAtSettlement: false,
+      },
+      {
+        name: "crash",
+        output: "exit 7",
+        expected: { degradedReason: "collector-crash", failure: { cause: "worker-exit" } },
+        denyEscaped: false,
+        escapedAtSettlement: false,
+      },
+      {
+        name: "timeout",
+        output: ":",
+        expected: { degradedReason: "timeout", failure: { cause: "worker-timeout" } },
+        denyEscaped: false,
+        escapedAtSettlement: false,
+      },
+      {
+        name: "denied success cleanup",
+        output: `printf '%s\\n' '${EMPTY_FRESH_WORKER_MESSAGE}'`,
+        expected: { degradedReason: "collector-crash", failure: { cause: "worker-cleanup" } },
+        denyEscaped: true,
+        escapedAtSettlement: true,
+      },
+      {
+        name: "denied malformed cleanup",
+        output: "printf '{invalid}\\n'",
+        expected: {
+          degradedReason: "collector-crash",
+          failure: {
+            cause: "worker-output-invalid",
+            causes: expect.arrayContaining(["resource collector worker cleanup deadline expired"]),
+          },
+        },
+        denyEscaped: true,
+        escapedAtSettlement: true,
+      },
+    ] as const;
+
+    for (const pipes of ["inherited", "redirected"] as const) {
+      for (const fixture of fixtures) {
+        await withResourceWorkerScript((directory) => {
+          const escapedScript = path.join(directory, "escaped-child.cjs");
+          const memberScript = path.join(directory, "term-member.cjs");
+          const escapedPid = path.join(directory, "term-escaped-pid");
+          const escapedReady = path.join(directory, "term-escaped-ready");
+          const memberReady = path.join(directory, "term-member-ready");
+          writeFileSync(escapedScript, [
+            '#!/usr/bin/node',
+            'const fs = require("node:fs");',
+            'const [pidFile, readyFile] = process.argv.slice(2);',
+            'process.on("SIGTERM", () => {});',
+            'process.on("SIGINT", () => {});',
+            'fs.writeFileSync(pidFile, String(process.pid));',
+            'fs.writeFileSync(readyFile, "ready");',
+            'setInterval(() => {}, 1_000);',
+            '',
+          ].join("\n"));
+          writeFileSync(memberScript, [
+            '#!/usr/bin/node',
+            'const fs = require("node:fs");',
+            'const { spawn } = require("node:child_process");',
+            'const [escapedScript, escapedPid, escapedReady, memberReady, pipes] = process.argv.slice(2);',
+            'fs.writeFileSync(memberReady, "ready");',
+            'let handled = false;',
+            'process.on("SIGTERM", () => {',
+            '  if (handled) return;',
+            '  handled = true;',
+            '  const stdio = pipes === "inherited" ? ["ignore", "inherit", "inherit"] : "ignore";',
+            '  const child = spawn(process.execPath, [escapedScript, escapedPid, escapedReady], { detached: true, stdio });',
+            '  child.unref();',
+            '  const deadline = Date.now() + 100;',
+            '  while (!fs.existsSync(escapedReady) && Date.now() < deadline) {}',
+            '  setTimeout(() => process.exit(0), 20);',
+            '});',
+            'setInterval(() => {}, 1_000);',
+            '',
+          ].join("\n"));
+          return [
+            `printf '%s' "$$" > "${path.join(directory, "pid")}"`,
+            `trap 'exit 0' TERM INT`,
+            `/usr/bin/node "${memberScript}" "${escapedScript}" "${escapedPid}" "${escapedReady}" "${memberReady}" "${pipes}" &`,
+            `while [ ! -e "${memberReady}" ]; do sleep 0.005; done`,
+            "sleep 0.08",
+            fixture.output,
+            "while :; do sleep 0.01; done",
+          ];
+        }, async (directory) => {
+          const baseline = referencedHandles();
+          const escapedPidFile = path.join(directory, "term-escaped-pid");
+          const realKill = process.kill.bind(process);
+          const kill = fixture.denyEscaped
+            ? spyOn(process, "kill").mockImplementation(((pid: number, signal?: string | number) => {
+                if (pid > 0 && signal !== 0 && existsSync(escapedPidFile)
+                  && pid === Number(readFileSync(escapedPidFile, "utf8"))) throw errno("EPERM");
+                return realKill(pid, signal as NodeJS.Signals | number | undefined);
+              }) as typeof process.kill)
+            : null;
+          let escapedPid = 0;
+          let leaked = false;
+          let outcome: Awaited<ReturnType<ReturnType<typeof workerTestReader>["read"]>>;
+          try {
+            outcome = await workerTestReader({
+              initial: null,
+              workerLimits: {
+                observeTimeoutMs: 900,
+                inputTimeoutMs: 10,
+                timeoutMs: fixture.name === "timeout" ? 180 : 500,
+                closeTimeoutMs: 40,
+                cleanupTimeoutMs: 150,
+                headroomMs: 250,
+              },
+            }).read(true);
+            for (let attempt = 0; attempt < 20 && !existsSync(escapedPidFile); attempt += 1) {
+              await new Promise((resolve) => setTimeout(resolve, 5));
+            }
+            escapedPid = Number(readFileSync(escapedPidFile, "utf8"));
+            leaked = processExists(escapedPid);
+          } finally {
+            kill?.mockRestore();
+            if (escapedPid > 0 && processExists(escapedPid)) realKill(escapedPid, "SIGKILL");
+          }
+          await new Promise<void>((resolve) => setImmediate(resolve));
+          const label = `${pipes} ${fixture.name}`;
+
+          expect(outcome.diagnostic, label).toMatchObject(fixture.expected);
+          expect(leaked, `${label} escaped descendant`).toBe(fixture.escapedAtSettlement);
+          expect(newReferencedHandleCount(baseline), `${label} referenced handles`).toBe(0);
+        });
+      }
+    }
   });
 
   test("leader-first cleanup sends no signals to recycled or null-identity groups", async () => {
@@ -1269,11 +1490,212 @@ describe("resource recurring reads", () => {
     }
   });
 
+  test("cleanup never adopts a recycled process group after the original leader exits", async () => {
+    await withResourceWorkerScript([
+      "exit 0",
+    ], async () => {
+      let leaderPid = 0;
+      let leaderIdentityReads = 0;
+      let groupPresent = true;
+      let unrelatedPresent = true;
+      const groupSignals: NodeJS.Signals[] = [];
+      const individualSignals: NodeJS.Signals[] = [];
+      const outcome = await workerTestReader({
+        initial: null,
+        workerLimits: { observeTimeoutMs: 300, inputTimeoutMs: 10, timeoutMs: 80, closeTimeoutMs: 5, headroomMs: 30 },
+        workerProcessRuntime: {
+          pidAlive: (pid) => pid === leaderPid ? false : unrelatedPresent,
+          processIdentity: (pid) => {
+            if (leaderPid === 0) leaderPid = pid;
+            if (pid === leaderPid) {
+              leaderIdentityReads += 1;
+              return leaderIdentityReads <= 2 ? `${pid}:owned` : null;
+            }
+            return unrelatedPresent ? `${pid}:unrelated` : null;
+          },
+          descendants: (pid) => [pid],
+          processGroupId: () => leaderPid,
+          processGroupMembers: () => [leaderPid + 1],
+          signal: (pid, signal) => {
+            if (pid < 0 && signal === 0) {
+              if (!groupPresent) throw errno("ESRCH");
+              return;
+            }
+            if (pid < 0) {
+              groupSignals.push(signal as NodeJS.Signals);
+              groupPresent = false;
+              return;
+            }
+            individualSignals.push(signal as NodeJS.Signals);
+            unrelatedPresent = false;
+          },
+        },
+      }).read(true);
+
+      expect(groupSignals).toEqual([]);
+      expect(individualSignals).toEqual([]);
+      expect(outcome.diagnostic).toMatchObject({
+        degradedReason: "collector-crash",
+        failure: {
+          cause: "worker-exit",
+          causes: expect.arrayContaining(["resource collector worker cleanup deadline expired"]),
+        },
+      });
+    });
+  });
+
+  test("a previously absent process group never becomes cleanup authority", async () => {
+    await withResourceWorkerScript([
+      `printf '%s\n' '${EMPTY_FRESH_WORKER_MESSAGE}'`,
+      "while :; do sleep 0.01; done",
+    ], async () => {
+      const realKill = process.kill.bind(process);
+      let leaderPid = 0;
+      let active = true;
+      let groupPresent = true;
+      const groupSignals: NodeJS.Signals[] = [];
+      const outcome = await workerTestReader({
+        initial: null,
+        workerLimits: { observeTimeoutMs: 300, inputTimeoutMs: 10, timeoutMs: 80, closeTimeoutMs: 5, headroomMs: 30 },
+        workerProcessRuntime: {
+          pidAlive: () => active,
+          processIdentity: (pid) => {
+            if (leaderPid === 0) leaderPid = pid;
+            return active ? `${pid}:owned` : null;
+          },
+          descendants: (pid) => [pid],
+          processGroupId: () => leaderPid,
+          processGroupMembers: () => [],
+          signal: (pid, signal) => {
+            if (pid < 0 && signal === 0) {
+              if (!groupPresent) throw errno("ESRCH");
+              return;
+            }
+            if (pid < 0) groupSignals.push(signal as NodeJS.Signals);
+            realKill(pid, signal as NodeJS.Signals);
+            active = false;
+            groupPresent = false;
+          },
+        },
+      }).read(true);
+
+      expect(groupSignals).toEqual([]);
+      expect(outcome.diagnostic).toMatchObject({
+        degradedReason: "collector-crash",
+        failure: { cause: "worker-cleanup" },
+      });
+    });
+  });
+
+  test("group cleanup revalidates an authorizing identity after processGroupId", async () => {
+    await withResourceWorkerScript([
+      `printf '%s\n' '${EMPTY_FRESH_WORKER_MESSAGE}'`,
+      "exit 0",
+    ], async () => {
+      let leaderPid = 0;
+      let groupIdReads = 0;
+      let identityChanged = false;
+      let groupPresent = true;
+      const groupSignals: NodeJS.Signals[] = [];
+      const individualSignals: NodeJS.Signals[] = [];
+      const outcome = await workerTestReader({
+        initial: null,
+        workerLimits: { observeTimeoutMs: 300, inputTimeoutMs: 10, timeoutMs: 80, closeTimeoutMs: 5, headroomMs: 30 },
+        workerProcessRuntime: {
+          pidAlive: () => groupPresent,
+          processIdentity: (pid) => {
+            if (leaderPid === 0) leaderPid = pid;
+            return `${pid}:${identityChanged ? "recycled" : "owned"}`;
+          },
+          descendants: (pid) => [pid],
+          processGroupId: () => {
+            groupIdReads += 1;
+            if (groupIdReads > 1) identityChanged = true;
+            return leaderPid;
+          },
+          processGroupMembers: () => [leaderPid],
+          signal: (pid, signal) => {
+            if (pid < 0 && signal === 0) {
+              if (!groupPresent) throw errno("ESRCH");
+              return;
+            }
+            if (pid < 0) {
+              groupSignals.push(signal as NodeJS.Signals);
+              groupPresent = false;
+              return;
+            }
+            individualSignals.push(signal as NodeJS.Signals);
+          },
+        },
+      }).read(true);
+
+      expect(groupSignals).toEqual([]);
+      expect(individualSignals).toEqual([]);
+      expect(outcome.diagnostic).toMatchObject({
+        degradedReason: "collector-crash",
+        failure: {
+          cause: "worker-cleanup",
+          causes: expect.arrayContaining(["resource collector worker cleanup deadline expired"]),
+        },
+      });
+    });
+  });
+
+  test("continuously owned process groups retain bounded TERM and KILL cleanup", async () => {
+    await withResourceWorkerScript([
+      "trap '' TERM INT",
+      "while :; do sleep 0.01; done",
+    ], async () => {
+      const realKill = process.kill.bind(process);
+      let leaderPid = 0;
+      let owned = true;
+      let groupPresent = true;
+      const groupSignals: NodeJS.Signals[] = [];
+      const outcome = await workerTestReader({
+        initial: null,
+        workerLimits: { observeTimeoutMs: 300, inputTimeoutMs: 10, timeoutMs: 20, closeTimeoutMs: 10, headroomMs: 60 },
+        workerProcessRuntime: {
+          pidAlive: () => owned,
+          processIdentity: (pid) => {
+            if (leaderPid === 0) leaderPid = pid;
+            return owned ? `${pid}:owned` : null;
+          },
+          descendants: (pid) => [pid],
+          processGroupId: () => leaderPid,
+          processGroupMembers: () => owned ? [leaderPid] : [],
+          signal: (pid, signal) => {
+            if (pid < 0 && signal === 0) {
+              if (!groupPresent) throw errno("ESRCH");
+              return;
+            }
+            if (pid < 0) {
+              groupSignals.push(signal as NodeJS.Signals);
+              realKill(pid, signal as NodeJS.Signals);
+              if (signal === "SIGKILL") {
+                owned = false;
+                groupPresent = false;
+              }
+              return;
+            }
+            if (owned) realKill(pid, signal as NodeJS.Signals);
+          },
+        },
+      }).read(true);
+
+      expect(groupSignals).toEqual(["SIGTERM", "SIGKILL"]);
+      expect(outcome.diagnostic).toMatchObject({
+        degradedReason: "timeout",
+        failure: { cause: "worker-timeout" },
+      });
+    });
+  });
+
   test("individual cleanup revalidates identity after a verified group signal", async () => {
     await withResourceWorkerScript([
       `printf '%s\n' '${EMPTY_FRESH_WORKER_MESSAGE}'`,
       "exit 0",
     ], async () => {
+      let leaderPid = 0;
       let recycled = false;
       const groupSignals: NodeJS.Signals[] = [];
       const individualSignals: NodeJS.Signals[] = [];
@@ -1282,10 +1704,13 @@ describe("resource recurring reads", () => {
         workerLimits: { observeTimeoutMs: 300, inputTimeoutMs: 10, timeoutMs: 80, closeTimeoutMs: 10, headroomMs: 40 },
         workerProcessRuntime: {
           pidAlive: () => !recycled,
-          processIdentity: (pid) => `${pid}:${recycled ? "recycled" : "owned"}`,
+          processIdentity: (pid) => {
+            if (leaderPid === 0) leaderPid = pid;
+            return `${pid}:${recycled ? "recycled" : "owned"}`;
+          },
           descendants: (pid) => [pid],
           processGroupId: (pid) => pid,
-          processGroupMembers: () => [],
+          processGroupMembers: () => [leaderPid],
           signal: (pid, signal) => {
             if (pid < 0 && signal === 0) {
               if (recycled) throw errno("ESRCH");
@@ -1579,6 +2004,29 @@ describe("resource recurring reads", () => {
     expect(JSON.parse(header)).toEqual(diagnostic);
   });
 
+  test("streaming quoted Authorization diagnostics stay redacted through resource header serialization", () => {
+    const input = '{"Authorization":"Basic QUOTED_HEADER_LEAK","safe":"SAFE_HEADER_FIELD"}\r\n'
+      + 'Bearer "QUOTED_BEARER_PART_A QUOTED_BEARER_PART_B"\n'
+      + "X-Safe-After: HEADER_TAIL_COMPLETE 😀";
+
+    for (let split = 0; split <= input.length; split += 1) {
+      const tail = createResourceDiagnosticTail();
+      tail.append(input.slice(0, split));
+      tail.append(input.slice(split));
+      const header = resourceDiagnosticHeader({ failure: { stderr: tail.value() } });
+      const stderr = (JSON.parse(header) as { failure: { stderr: string } }).failure.stderr;
+      const label = `header split ${split}`;
+
+      expect(stderr.includes("SAFE_HEADER_FIELD"), label).toBeTrue();
+      expect(stderr.includes("HEADER_TAIL_COMPLETE 😀"), label).toBeTrue();
+      expect(stderr.includes("QUOTED_HEADER_LEAK"), label).toBeFalse();
+      expect(stderr.includes("QUOTED_BEARER_PART_A"), label).toBeFalse();
+      expect(stderr.includes("QUOTED_BEARER_PART_B"), label).toBeFalse();
+      expect(stderr.includes("\uFFFD"), label).toBeFalse();
+      expect([...header].every((character) => character.charCodeAt(0) <= 0x7e), label).toBeTrue();
+    }
+  });
+
   test("malformed, oversized, crash, timeout, and immediate-exit paths release complete worker trees", async () => {
     const withGrandchild = (directory: string, lines: string[]) => [
       `printf '%s' "$$" > "${path.join(directory, "pid")}"`,
@@ -1664,6 +2112,20 @@ describe("resource recurring reads", () => {
       if (previousExecutable === undefined) delete process.env.LLV_RESOURCE_COLLECTOR_EXECUTABLE;
       else process.env.LLV_RESOURCE_COLLECTOR_EXECUTABLE = previousExecutable;
     }
+  });
+
+  test("an existing non-executable worker preserves the spawn failure cause", async () => {
+    await withResourceWorkerScript([
+      `printf '%s\n' '${EMPTY_FRESH_WORKER_MESSAGE}'`,
+    ], async (directory) => {
+      chmodSync(path.join(directory, "fixture-worker"), 0o600);
+      const outcome = await workerTestReader({ initial: null }).read(true);
+
+      expect(outcome.diagnostic).toMatchObject({
+        degradedReason: "collector-crash",
+        failure: { cause: "worker-spawn" },
+      });
+    });
   });
 
   test("persists each completed generation once across ordinary reads", async () => {

--- a/src/lib/resources.test.ts
+++ b/src/lib/resources.test.ts
@@ -1,9 +1,10 @@
-import { describe, expect, test } from "bun:test";
+import { describe, expect, spyOn, test } from "bun:test";
 import { chmodSync, existsSync, lstatSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
 import { createTranscriptHostObserver, type TranscriptHost } from "@/lib/agent/transcriptHost";
+import { procBackend } from "@/lib/proc";
 import { RESOURCE_FAILURE_STDERR_MAX_BYTES } from "@/lib/resourceCollector";
 import type { FileEntry, ResourcesPayload } from "@/lib/types";
 
@@ -160,6 +161,40 @@ function deferred<T>() {
     reject = rej;
   });
   return { promise, resolve, reject };
+}
+
+const CLEANUP_DEADLINE = Symbol("cleanup-deadline");
+
+async function settleWithin<T>(promise: Promise<T>, timeoutMs: number): Promise<T | typeof CLEANUP_DEADLINE> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<typeof CLEANUP_DEADLINE>((resolve) => {
+        timer = setTimeout(() => resolve(CLEANUP_DEADLINE), timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
+function errno(code: string): NodeJS.ErrnoException {
+  const error = new Error(code) as NodeJS.ErrnoException;
+  error.code = code;
+  return error;
+}
+
+function referencedHandles(): Set<unknown> {
+  const active = (process as NodeJS.Process & { _getActiveHandles(): unknown[] })._getActiveHandles();
+  return new Set(active.filter((handle) => {
+    const ref = (handle as { hasRef?: () => boolean }).hasRef;
+    return typeof ref !== "function" || ref.call(handle);
+  }));
+}
+
+function newReferencedHandleCount(baseline: Set<unknown>): number {
+  return [...referencedHandles()].filter((handle) => !baseline.has(handle)).length;
 }
 
 async function withResourceWorkerScript<T>(
@@ -913,6 +948,29 @@ describe("resource recurring reads", () => {
     });
   });
 
+  test("a complete observation arriving from inherited stdout after leader exit still wins before close", async () => {
+    await withResourceWorkerScript((directory) => {
+      const writerPid = path.join(directory, "late-writer-pid");
+      return [
+        `printf '%s' "$$" > "${path.join(directory, "pid")}"`,
+        `sh -c 'trap "" TERM INT; printf "%s" "$$" > "$1"; sleep 0.02; printf "%s\\n" "$2"' sh "${writerPid}" '${EMPTY_FRESH_WORKER_MESSAGE}' &`,
+        "exit 0",
+      ];
+    }, async (directory) => {
+      const outcome = await settleWithin(workerTestReader({
+        initial: null,
+        workerLimits: { observeTimeoutMs: 400, inputTimeoutMs: 10, timeoutMs: 200, closeTimeoutMs: 100, headroomMs: 100 },
+      }).read(true), 300);
+      const writerPid = Number(readFileSync(path.join(directory, "late-writer-pid"), "utf8"));
+
+      expect(outcome === CLEANUP_DEADLINE).toBeFalse();
+      if (outcome === CLEANUP_DEADLINE) return;
+      expect(outcome.diagnostic.degradedReason).toBeUndefined();
+      expect(outcome.diagnostic.status).toBe("complete");
+      expect(processExists(writerPid)).toBeFalse();
+    });
+  });
+
   test("a successful read settles after a TERM-resistant redirected process group is absent", async () => {
     await withResourceWorkerScript((directory) => {
       const descendantPid = path.join(directory, "redirected-descendant-pid");
@@ -979,6 +1037,274 @@ describe("resource recurring reads", () => {
         });
       }
     }
+  });
+
+  test("cleanup has a terminal deadline and preserves every primary failure through persistent EPERM", async () => {
+    const fixtures = [
+      {
+        name: "parse",
+        lines: ["printf 'parse-trace\\n' >&2", "printf '{invalid}\\n'", "while :; do sleep 0.01; done"],
+        expectedCause: "worker-output-invalid",
+        expectedStderr: "parse-trace",
+        limits: { timeoutMs: 80, outputMaxBytes: 256 },
+      },
+      {
+        name: "crash",
+        lines: ["printf 'crash-trace\\n' >&2", "exit 7"],
+        expectedCause: "worker-exit",
+        expectedStderr: "crash-trace",
+        limits: { timeoutMs: 80, outputMaxBytes: 256 },
+      },
+      {
+        name: "output",
+        lines: ["printf 'output-trace\\n' >&2", "printf 'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx\\n'", "while :; do sleep 0.01; done"],
+        expectedCause: "worker-output-limit",
+        expectedStderr: "output-trace",
+        limits: { timeoutMs: 80, outputMaxBytes: 24 },
+      },
+      {
+        name: "timeout",
+        lines: ["printf 'timeout-trace\\n' >&2", "while :; do sleep 0.01; done"],
+        expectedCause: "worker-timeout",
+        expectedStderr: "timeout-trace",
+        limits: { timeoutMs: 20, outputMaxBytes: 256 },
+      },
+    ] as const;
+
+    for (const fixture of fixtures) {
+      await withResourceWorkerScript((directory) => [
+        `printf '%s' "$$" > "${path.join(directory, "pid")}"`,
+        "trap 'exit 0' TERM INT",
+        ...fixture.lines,
+      ], async (directory) => {
+        const realKill = process.kill.bind(process);
+        const kill = spyOn(process, "kill").mockImplementation(((pid: number, signal?: string | number) => {
+          if (pid < 0) throw errno("EPERM");
+          return realKill(pid, signal as NodeJS.Signals | number | undefined);
+        }) as typeof process.kill);
+        const baseline = referencedHandles();
+        const read = workerTestReader({
+          initial: null,
+          workerLimits: { observeTimeoutMs: 300, inputTimeoutMs: 10, closeTimeoutMs: 10, headroomMs: 40, ...fixture.limits },
+        }).read(true);
+        let initial: Awaited<typeof read> | typeof CLEANUP_DEADLINE;
+        try {
+          initial = await settleWithin(read, 120);
+        } finally {
+          kill.mockRestore();
+        }
+        const workerPid = Number(readFileSync(path.join(directory, "pid"), "utf8"));
+        try {
+          realKill(-workerPid, "SIGKILL");
+        } catch {}
+        const final = await settleWithin(read, 300);
+        await new Promise<void>((resolve) => setImmediate(resolve));
+        const handles = newReferencedHandleCount(baseline);
+
+        expect(initial === CLEANUP_DEADLINE, fixture.name).toBeFalse();
+        if (initial === CLEANUP_DEADLINE) return;
+        expect(initial.diagnostic.failure, fixture.name).toMatchObject({
+          cause: fixture.expectedCause,
+          stderr: expect.stringContaining(fixture.expectedStderr),
+          causes: expect.arrayContaining(["resource collector worker cleanup deadline expired"]),
+        });
+        expect(final === CLEANUP_DEADLINE, `${fixture.name} final settlement`).toBeFalse();
+        expect(handles, `${fixture.name} referenced handles`).toBe(0);
+      });
+    }
+  });
+
+  test("ineffective TERM and SIGKILL settle once with cleanup failure and zero referenced handles", async () => {
+    await withResourceWorkerScript((directory) => [
+      `printf '%s' "$$" > "${path.join(directory, "pid")}"`,
+      "trap '' TERM INT",
+      "printf 'ineffective-signal-trace\\n' >&2",
+      `printf '%s\\n' '${EMPTY_FRESH_WORKER_MESSAGE}'`,
+      "while :; do sleep 0.01; done",
+    ], async (directory) => {
+      const realKill = process.kill.bind(process);
+      const kill = spyOn(process, "kill").mockImplementation(((pid: number, signal?: string | number) => {
+        if (pid !== process.pid) return true;
+        return realKill(pid, signal as NodeJS.Signals | number | undefined);
+      }) as typeof process.kill);
+      const baseline = referencedHandles();
+      const read = workerTestReader({
+        initial: null,
+        workerLimits: { observeTimeoutMs: 300, inputTimeoutMs: 10, timeoutMs: 80, closeTimeoutMs: 10, headroomMs: 40 },
+      }).read(true);
+      let initial: Awaited<typeof read> | typeof CLEANUP_DEADLINE;
+      let handles = -1;
+      try {
+        initial = await settleWithin(read, 120);
+        if (initial !== CLEANUP_DEADLINE) {
+          await new Promise<void>((resolve) => setImmediate(resolve));
+          handles = newReferencedHandleCount(baseline);
+        }
+      } finally {
+        kill.mockRestore();
+      }
+      const workerPid = Number(readFileSync(path.join(directory, "pid"), "utf8"));
+      try {
+        realKill(-workerPid, "SIGKILL");
+      } catch {}
+      await settleWithin(read, 300);
+
+      expect(initial === CLEANUP_DEADLINE).toBeFalse();
+      if (initial === CLEANUP_DEADLINE) return;
+      expect(initial.diagnostic).toMatchObject({
+        degradedReason: "collector-crash",
+        failure: {
+          cause: "worker-cleanup",
+          stderr: expect.stringContaining("ineffective-signal-trace"),
+          causes: expect.arrayContaining(["resource collector worker cleanup deadline expired"]),
+        },
+      });
+      expect(handles).toBe(0);
+    });
+  });
+
+  test("ESRCH cleanup settles without a secondary failure or referenced handles", async () => {
+    await withResourceWorkerScript((directory) => [
+      `printf '%s' "$$" > "${path.join(directory, "pid")}"`,
+      `printf '%s\\n' '${EMPTY_FRESH_WORKER_MESSAGE}'`,
+      "exit 0",
+    ], async () => {
+      const realKill = process.kill.bind(process);
+      const kill = spyOn(process, "kill").mockImplementation(((pid: number, signal?: string | number) => {
+        if (pid < 0) throw errno("ESRCH");
+        return realKill(pid, signal as NodeJS.Signals | number | undefined);
+      }) as typeof process.kill);
+      const baseline = referencedHandles();
+      let outcome: Awaited<ReturnType<ReturnType<typeof workerTestReader>["read"]>> | typeof CLEANUP_DEADLINE;
+      try {
+        outcome = await settleWithin(workerTestReader({ initial: null }).read(true), 200);
+      } finally {
+        kill.mockRestore();
+      }
+      await new Promise<void>((resolve) => setImmediate(resolve));
+
+      expect(outcome === CLEANUP_DEADLINE).toBeFalse();
+      if (outcome === CLEANUP_DEADLINE) return;
+      expect(outcome.diagnostic.degradedReason).toBeUndefined();
+      expect(newReferencedHandleCount(baseline)).toBe(0);
+    });
+  });
+
+  test("an owned escaped descendant retaining inherited pipes is supervised to bounded completion", async () => {
+    await withResourceWorkerScript((directory) => {
+      const descendantPid = path.join(directory, "escaped-descendant-pid");
+      const ready = path.join(directory, "escaped-descendant-ready");
+      return [
+        `printf '%s' "$$" > "${path.join(directory, "pid")}"`,
+        `setsid sh -c 'trap "" TERM INT; printf "%s" "$$" > "$1"; : > "$2"; while :; do sleep 1; done' sh "${descendantPid}" "${ready}" &`,
+        `while [ ! -e "${ready}" ]; do sleep 0.01; done`,
+        `printf '%s\\n' '${EMPTY_FRESH_WORKER_MESSAGE}'`,
+        "exit 0",
+      ];
+    }, async (directory) => {
+      const baseline = referencedHandles();
+      const read = workerTestReader({
+        initial: null,
+        workerLimits: { observeTimeoutMs: 400, inputTimeoutMs: 10, timeoutMs: 100, closeTimeoutMs: 30, headroomMs: 80 },
+      }).read(true);
+      const initial = await settleWithin(read, 250);
+      const workerPid = Number(readFileSync(path.join(directory, "pid"), "utf8"));
+      const descendantPid = Number(readFileSync(path.join(directory, "escaped-descendant-pid"), "utf8"));
+      if (initial === CLEANUP_DEADLINE) {
+        try {
+          process.kill(descendantPid, "SIGKILL");
+        } catch {}
+        try {
+          process.kill(-workerPid, "SIGKILL");
+        } catch {}
+        await settleWithin(read, 300);
+      }
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      const handles = newReferencedHandleCount(baseline);
+
+      expect(initial === CLEANUP_DEADLINE).toBeFalse();
+      if (initial === CLEANUP_DEADLINE) return;
+      expect(initial.diagnostic.degradedReason).toBeUndefined();
+      expect(processExists(descendantPid)).toBeFalse();
+      expect(handles).toBe(0);
+    });
+  });
+
+  test("leader-first cleanup sends no signals to recycled or null-identity groups", async () => {
+    for (const identity of ["recycled", "null"] as const) {
+      await withResourceWorkerScript((directory) => [
+        `printf '%s' "$$" > "${path.join(directory, "pid")}"`,
+        "exit 0",
+      ], async () => {
+        const realKill = process.kill.bind(process);
+        let identityReads = 0;
+        const processIdentity = spyOn(procBackend, "processIdentity").mockImplementation((pid) => {
+          if (identity === "null") return null;
+          identityReads += 1;
+          return identityReads === 1 ? `${pid}:owned` : `${pid}:recycled`;
+        });
+        const signals: Array<string | number | undefined> = [];
+        const kill = spyOn(process, "kill").mockImplementation(((pid: number, signal?: string | number) => {
+          if (pid < 0 && signal !== 0 && signal !== undefined) {
+            signals.push(signal);
+            return true;
+          }
+          if (pid < 0) throw errno("ESRCH");
+          return realKill(pid, signal as NodeJS.Signals | number | undefined);
+        }) as typeof process.kill);
+        let outcome: Awaited<ReturnType<ReturnType<typeof workerTestReader>["read"]>> | typeof CLEANUP_DEADLINE;
+        try {
+          outcome = await settleWithin(workerTestReader({
+            initial: null,
+            workerLimits: { observeTimeoutMs: 300, inputTimeoutMs: 10, timeoutMs: 80, closeTimeoutMs: 10, headroomMs: 40 },
+          }).read(true), 150);
+        } finally {
+          kill.mockRestore();
+          processIdentity.mockRestore();
+        }
+
+        expect(outcome === CLEANUP_DEADLINE, identity).toBeFalse();
+        expect(signals, identity).toEqual([]);
+      });
+    }
+  });
+
+  test("individual cleanup revalidates identity after a verified group signal", async () => {
+    await withResourceWorkerScript([
+      `printf '%s\n' '${EMPTY_FRESH_WORKER_MESSAGE}'`,
+      "exit 0",
+    ], async () => {
+      let recycled = false;
+      const groupSignals: NodeJS.Signals[] = [];
+      const individualSignals: NodeJS.Signals[] = [];
+      const outcome = await workerTestReader({
+        initial: null,
+        workerLimits: { observeTimeoutMs: 300, inputTimeoutMs: 10, timeoutMs: 80, closeTimeoutMs: 10, headroomMs: 40 },
+        workerProcessRuntime: {
+          pidAlive: () => !recycled,
+          processIdentity: (pid) => `${pid}:${recycled ? "recycled" : "owned"}`,
+          descendants: (pid) => [pid],
+          processGroupId: (pid) => pid,
+          processGroupMembers: () => [],
+          signal: (pid, signal) => {
+            if (pid < 0 && signal === 0) {
+              if (recycled) throw errno("ESRCH");
+              return;
+            }
+            if (pid < 0) {
+              groupSignals.push(signal as NodeJS.Signals);
+              recycled = true;
+              return;
+            }
+            individualSignals.push(signal as NodeJS.Signals);
+          },
+        },
+      }).read(true);
+
+      expect(outcome.diagnostic.degradedReason).toBeUndefined();
+      expect(groupSignals).toEqual(["SIGTERM"]);
+      expect(individualSignals).toEqual([]);
+    });
   });
 
   test("a near-limit handoff to an immediately exiting worker keeps the parent alive and releases the worker", async () => {

--- a/src/lib/resources.test.ts
+++ b/src/lib/resources.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, spyOn, test } from "bun:test";
-import { chmodSync, existsSync, lstatSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, lstatSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, readlinkSync, rmSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
@@ -131,6 +131,22 @@ function processGroupId(pid: number): number | null {
   } catch {
     return null;
   }
+}
+
+function pidNamespaceMembers(namespaceId: string): number[] {
+  const members: number[] = [];
+  for (const name of readdirSync("/proc")) {
+    const pid = Number(name);
+    if (!Number.isInteger(pid) || pid <= 0) continue;
+    const identity = procBackend.processIdentity(pid);
+    if (identity === null) continue;
+    try {
+      if (readlinkSync(`/proc/${pid}/ns/pid`) === namespaceId
+        && procBackend.processIdentity(pid) === identity
+        && readlinkSync(`/proc/${pid}/ns/pid`) === namespaceId) members.push(pid);
+    } catch {}
+  }
+  return members;
 }
 
 function confirmedFixtureProcessGroups(executable: string): FixtureProcessGroup[] {
@@ -302,8 +318,8 @@ async function withResourceWorkerChunks<T>(
   const encodedChunks = JSON.stringify(chunks.map((chunk) => chunk.toString("base64")));
   writeFileSync(executable, [
     "#!/usr/bin/env node",
-    'const { writeFileSync } = require("node:fs");',
-    `writeFileSync(${JSON.stringify(pidFile)}, String(process.pid));`,
+    'const { readFileSync, writeFileSync } = require("node:fs");',
+    `writeFileSync(${JSON.stringify(pidFile)}, readFileSync("/proc/self/stat", "utf8").split(" ", 1)[0]);`,
     `const chunks = ${encodedChunks}.map((chunk) => Buffer.from(chunk, "base64"));`,
     "let index = 0;",
     "const writeNext = () => {",
@@ -974,9 +990,9 @@ describe("resource recurring reads", () => {
       const descendantPid = path.join(directory, "deadline-descendant-pid");
       const ready = path.join(directory, "deadline-descendant-ready");
       return [
-        `printf '%s' "$$" > "${path.join(directory, "pid")}"`,
+        `read host_pid _ < /proc/self/stat; printf '%s' "$host_pid" > "${path.join(directory, "pid")}"`,
         "trap 'exit 0' TERM INT",
-        `sh -c 'trap "" TERM INT; printf "%s" "$$" > "$1"; : > "$2"; while :; do sleep 1; done' sh "${descendantPid}" "${ready}" &`,
+        `sh -c 'trap "" TERM INT; read host_pid _ < /proc/self/stat; printf "%s" "$host_pid" > "$1"; : > "$2"; while :; do sleep 1; done' sh "${descendantPid}" "${ready}" &`,
         `while [ ! -e "${ready}" ]; do sleep 0.01; done`,
         "while :; do sleep 0.01; done",
       ];
@@ -1020,8 +1036,8 @@ describe("resource recurring reads", () => {
       const descendantPid = path.join(directory, "descendant-pid");
       const ready = path.join(directory, "descendant-ready");
       return [
-        `printf '%s' "$$" > "${path.join(directory, "pid")}"`,
-        `sh -c 'trap "" TERM INT; printf "%s" "$$" > "$1"; : > "$2"; while :; do sleep 1; done' sh "${descendantPid}" "${ready}" &`,
+        `read host_pid _ < /proc/self/stat; printf '%s' "$host_pid" > "${path.join(directory, "pid")}"`,
+        `sh -c 'trap "" TERM INT; read host_pid _ < /proc/self/stat; printf "%s" "$host_pid" > "$1"; : > "$2"; while :; do sleep 1; done' sh "${descendantPid}" "${ready}" &`,
         `while [ ! -e "${ready}" ]; do sleep 0.01; done`,
         "exit 0",
       ];
@@ -1048,8 +1064,8 @@ describe("resource recurring reads", () => {
     await withResourceWorkerScript((directory) => {
       const writerPid = path.join(directory, "late-writer-pid");
       return [
-        `printf '%s' "$$" > "${path.join(directory, "pid")}"`,
-        `sh -c 'trap "" TERM INT; printf "%s" "$$" > "$1"; sleep 0.02; printf "%s\\n" "$2"' sh "${writerPid}" '${EMPTY_FRESH_WORKER_MESSAGE}' &`,
+        `read host_pid _ < /proc/self/stat; printf '%s' "$host_pid" > "${path.join(directory, "pid")}"`,
+        `sh -c 'trap "" TERM INT; read host_pid _ < /proc/self/stat; printf "%s" "$host_pid" > "$1"; sleep 0.02; printf "%s\\n" "$2"' sh "${writerPid}" '${EMPTY_FRESH_WORKER_MESSAGE}' &`,
         "exit 0",
       ];
     }, async (directory) => {
@@ -1072,9 +1088,9 @@ describe("resource recurring reads", () => {
       const descendantPid = path.join(directory, "redirected-descendant-pid");
       const ready = path.join(directory, "redirected-descendant-ready");
       return [
-        `printf '%s' "$$" > "${path.join(directory, "pid")}"`,
+        `read host_pid _ < /proc/self/stat; printf '%s' "$host_pid" > "${path.join(directory, "pid")}"`,
         "trap 'exit 0' TERM INT",
-        `sh -c 'trap "" TERM INT; printf "%s" "$$" > "$1"; : > "$2"; while :; do sleep 1; done' sh "${descendantPid}" "${ready}" </dev/null >/dev/null 2>&1 &`,
+        `sh -c 'trap "" TERM INT; read host_pid _ < /proc/self/stat; printf "%s" "$host_pid" > "$1"; : > "$2"; while :; do sleep 1; done' sh "${descendantPid}" "${ready}" </dev/null >/dev/null 2>&1 &`,
         `while [ ! -e "${ready}" ]; do sleep 0.01; done`,
         `printf '%s\n' '${EMPTY_FRESH_WORKER_MESSAGE}'`,
         "while :; do sleep 0.01; done",
@@ -1109,9 +1125,9 @@ describe("resource recurring reads", () => {
           const ready = path.join(directory, "matrix-descendant-ready");
           const redirect = pipes === "redirected" ? " </dev/null >/dev/null 2>&1" : "";
           return [
-            `printf '%s' "$$" > "${path.join(directory, "pid")}"`,
+            `read host_pid _ < /proc/self/stat; printf '%s' "$host_pid" > "${path.join(directory, "pid")}"`,
             "trap 'exit 0' TERM INT",
-            `sh -c 'trap "" TERM INT; printf "%s" "$$" > "$1"; : > "$2"; while :; do sleep 1; done' sh "${descendantPid}" "${ready}"${redirect} &`,
+            `sh -c 'trap "" TERM INT; read host_pid _ < /proc/self/stat; printf "%s" "$host_pid" > "$1"; : > "$2"; while :; do sleep 1; done' sh "${descendantPid}" "${ready}"${redirect} &`,
             `while [ ! -e "${ready}" ]; do sleep 0.01; done`,
             fixture.output,
             "while :; do sleep 0.01; done",
@@ -1169,7 +1185,7 @@ describe("resource recurring reads", () => {
 
     for (const fixture of fixtures) {
       await withResourceWorkerScript((directory) => [
-        `printf '%s' "$$" > "${path.join(directory, "pid")}"`,
+        `read host_pid _ < /proc/self/stat; printf '%s' "$host_pid" > "${path.join(directory, "pid")}"`,
         "trap 'exit 0' TERM INT",
         ...fixture.lines,
       ], async (directory) => {
@@ -1212,7 +1228,7 @@ describe("resource recurring reads", () => {
 
   test("ineffective TERM and SIGKILL settle once with cleanup failure and zero referenced handles", async () => {
     await withResourceWorkerScript((directory) => [
-      `printf '%s' "$$" > "${path.join(directory, "pid")}"`,
+      `read host_pid _ < /proc/self/stat; printf '%s' "$host_pid" > "${path.join(directory, "pid")}"`,
       "trap '' TERM INT",
       "printf 'ineffective-signal-trace\\n' >&2",
       `printf '%s\\n' '${EMPTY_FRESH_WORKER_MESSAGE}'`,
@@ -1261,7 +1277,7 @@ describe("resource recurring reads", () => {
 
   test("ESRCH cleanup settles without a secondary failure or referenced handles", async () => {
     await withResourceWorkerScript((directory) => [
-      `printf '%s' "$$" > "${path.join(directory, "pid")}"`,
+      `read host_pid _ < /proc/self/stat; printf '%s' "$host_pid" > "${path.join(directory, "pid")}"`,
       `printf '%s\\n' '${EMPTY_FRESH_WORKER_MESSAGE}'`,
       "exit 0",
     ], async () => {
@@ -1286,13 +1302,47 @@ describe("resource recurring reads", () => {
     });
   });
 
+  test("a portable runtime without kernel containment fails closed after bounded cleanup", async () => {
+    await withResourceWorkerScript([
+      "trap 'exit 0' TERM INT",
+      `printf '%s\\n' '${EMPTY_FRESH_WORKER_MESSAGE}'`,
+      "while :; do sleep 0.01; done",
+    ], async (directory) => {
+      const baseline = referencedHandles();
+      const outcome = await workerTestReader({
+        initial: null,
+        workerLimits: { observeTimeoutMs: 300, inputTimeoutMs: 10, timeoutMs: 80, closeTimeoutMs: 10, headroomMs: 40 },
+        workerProcessRuntime: {
+          kernelContainment: "unavailable",
+          pidAlive: processExists,
+          processIdentity: (pid) => procBackend.processIdentity(pid),
+          descendants: (pid) => [pid],
+          processGroupId,
+          processGroupMembers: (groupId) => [groupId],
+          signal: (pid, signal) => process.kill(pid, signal),
+        },
+      }).read(true);
+      await new Promise<void>((resolve) => setImmediate(resolve));
+
+      expect(outcome.diagnostic).toMatchObject({
+        degradedReason: "collector-crash",
+        failure: {
+          cause: "worker-cleanup",
+          causes: expect.arrayContaining(["resource collector kernel containment is unavailable"]),
+        },
+      });
+      expect(confirmedFixtureProcessGroups(path.join(directory, "fixture-worker"))).toEqual([]);
+      expect(newReferencedHandleCount(baseline)).toBe(0);
+    });
+  });
+
   test("an owned escaped descendant retaining inherited pipes is supervised to bounded completion", async () => {
     await withResourceWorkerScript((directory) => {
       const descendantPid = path.join(directory, "escaped-descendant-pid");
       const ready = path.join(directory, "escaped-descendant-ready");
       return [
-        `printf '%s' "$$" > "${path.join(directory, "pid")}"`,
-        `setsid sh -c 'trap "" TERM INT; printf "%s" "$$" > "$1"; : > "$2"; while :; do sleep 1; done' sh "${descendantPid}" "${ready}" &`,
+        `read host_pid _ < /proc/self/stat; printf '%s' "$host_pid" > "${path.join(directory, "pid")}"`,
+        `setsid sh -c 'trap "" TERM INT; read host_pid _ < /proc/self/stat; printf "%s" "$host_pid" > "$1"; : > "$2"; while :; do sleep 1; done' sh "${descendantPid}" "${ready}" &`,
         `while [ ! -e "${ready}" ]; do sleep 0.01; done`,
         `printf '%s\\n' '${EMPTY_FRESH_WORKER_MESSAGE}'`,
         "exit 0",
@@ -1344,7 +1394,7 @@ describe("resource recurring reads", () => {
       },
       {
         name: "crash",
-        output: "exit 7",
+        output: "",
         expected: { degradedReason: "collector-crash", failure: { cause: "worker-exit" } },
         denyEscaped: false,
         escapedAtSettlement: false,
@@ -1359,9 +1409,9 @@ describe("resource recurring reads", () => {
       {
         name: "denied success cleanup",
         output: `printf '%s\\n' '${EMPTY_FRESH_WORKER_MESSAGE}'`,
-        expected: { degradedReason: "collector-crash", failure: { cause: "worker-cleanup" } },
+        expected: { fresh: true, status: "complete" },
         denyEscaped: true,
-        escapedAtSettlement: true,
+        escapedAtSettlement: false,
       },
       {
         name: "denied malformed cleanup",
@@ -1370,11 +1420,10 @@ describe("resource recurring reads", () => {
           degradedReason: "collector-crash",
           failure: {
             cause: "worker-output-invalid",
-            causes: expect.arrayContaining(["resource collector worker cleanup deadline expired"]),
           },
         },
         denyEscaped: true,
-        escapedAtSettlement: true,
+        escapedAtSettlement: false,
       },
     ] as const;
 
@@ -1392,7 +1441,8 @@ describe("resource recurring reads", () => {
             'const [pidFile, readyFile] = process.argv.slice(2);',
             'process.on("SIGTERM", () => {});',
             'process.on("SIGINT", () => {});',
-            'fs.writeFileSync(pidFile, String(process.pid));',
+            'const hostPid = fs.readFileSync("/proc/self/stat", "utf8").split(" ", 1)[0];',
+            'fs.writeFileSync(pidFile, hostPid);',
             'fs.writeFileSync(readyFile, "ready");',
             'setInterval(() => {}, 1_000);',
             '',
@@ -1416,12 +1466,15 @@ describe("resource recurring reads", () => {
             '',
           ].join("\n"));
           return [
-            `printf '%s' "$$" > "${path.join(directory, "pid")}"`,
+            `read host_pid _ < /proc/self/stat; printf '%s' "$host_pid" > "${path.join(directory, "pid")}"`,
             `trap 'exit 0' TERM INT`,
             `/usr/bin/node "${memberScript}" "${escapedScript}" "${escapedPid}" "${escapedReady}" "${memberReady}" "${pipes}" &`,
+            "member_pid=$!",
             `while [ ! -e "${memberReady}" ]; do sleep 0.005; done`,
             "sleep 0.08",
-            fixture.output,
+            fixture.name === "crash"
+              ? `kill -TERM "$member_pid"; while [ ! -e "${escapedReady}" ]; do sleep 0.005; done; exit 7`
+              : fixture.output,
             "while :; do sleep 0.01; done",
           ];
         }, async (directory) => {
@@ -1470,10 +1523,228 @@ describe("resource recurring reads", () => {
     }
   });
 
+  test("owner-mutating TERM descendants cannot escape settlement", async () => {
+    const fixtures = [
+      {
+        name: "success",
+        output: `printf '%s\\n' '${EMPTY_FRESH_WORKER_MESSAGE}'`,
+        timeoutMs: 500,
+        expected: { status: "complete" },
+      },
+      {
+        name: "malformed output",
+        output: "printf '{invalid}\\n'",
+        timeoutMs: 500,
+        expected: { degradedReason: "collector-crash", failure: { cause: "worker-output-invalid" } },
+      },
+      {
+        name: "crash",
+        output: "exit 7",
+        timeoutMs: 500,
+        expected: { degradedReason: "collector-crash", failure: { cause: "worker-exit" } },
+      },
+      {
+        name: "timeout",
+        output: ":",
+        timeoutMs: 180,
+        expected: { degradedReason: "timeout", failure: { cause: "worker-timeout" } },
+      },
+    ] as const;
+    const results: Array<{
+      owner: "deleted" | "changed";
+      outcome: string;
+      diagnostic: Awaited<ReturnType<ReturnType<typeof workerTestReader>["read"]>>["diagnostic"];
+      descendantAliveAtSettlement: boolean;
+    }> = [];
+
+    for (const owner of ["deleted", "changed"] as const) {
+      for (const fixture of fixtures) {
+        await withResourceWorkerScript((directory) => {
+          const escapedScript = path.join(directory, "owner-escaped-child.cjs");
+          const memberScript = path.join(directory, "owner-term-member.cjs");
+          const escapedPid = path.join(directory, "owner-escaped-pid");
+          const escapedNamespace = path.join(directory, "owner-escaped-namespace");
+          const escapedReady = path.join(directory, "owner-escaped-ready");
+          const memberReady = path.join(directory, "owner-member-ready");
+          writeFileSync(escapedScript, [
+            '#!/usr/bin/node',
+            'const fs = require("node:fs");',
+            'const [pidFile, namespaceFile, readyFile] = process.argv.slice(2);',
+            'process.on("SIGTERM", () => {});',
+            'process.on("SIGINT", () => {});',
+            'const hostPid = fs.readFileSync("/proc/self/stat", "utf8").split(" ", 1)[0];',
+            'fs.writeFileSync(pidFile, hostPid);',
+            'fs.writeFileSync(namespaceFile, fs.readlinkSync("/proc/self/ns/pid"));',
+            'fs.writeFileSync(readyFile, "ready");',
+            'setInterval(() => {}, 1_000);',
+            '',
+          ].join("\n"));
+          writeFileSync(memberScript, [
+            '#!/usr/bin/node',
+            'const fs = require("node:fs");',
+            'const { spawn } = require("node:child_process");',
+            'const [escapedScript, escapedPid, escapedNamespace, escapedReady, memberReady, ownerMode] = process.argv.slice(2);',
+            'fs.writeFileSync(memberReady, "ready");',
+            'let handled = false;',
+            'process.on("SIGTERM", () => {',
+            '  if (handled) return;',
+            '  handled = true;',
+            '  const env = { ...process.env };',
+            '  if (ownerMode === "deleted") delete env.LLV_RESOURCE_COLLECTOR_OWNER;',
+            '  else env.LLV_RESOURCE_COLLECTOR_OWNER = "changed-owner";',
+            '  const child = spawn(process.execPath, [escapedScript, escapedPid, escapedNamespace, escapedReady], {',
+            '    detached: true, stdio: "ignore", env,',
+            '  });',
+            '  child.unref();',
+            '  process.exit(0);',
+            '});',
+            'setInterval(() => {}, 1_000);',
+            '',
+          ].join("\n"));
+          return [
+            `read host_pid _ < /proc/self/stat; printf '%s' "$host_pid" > "${path.join(directory, "pid")}"`,
+            "trap 'exit 0' TERM INT",
+            `/usr/bin/node "${memberScript}" "${escapedScript}" "${escapedPid}" "${escapedNamespace}" "${escapedReady}" "${memberReady}" "${owner}" &`,
+            "member_pid=$!",
+            `while [ ! -e "${memberReady}" ]; do sleep 0.005; done`,
+            "sleep 0.08",
+            fixture.name === "crash"
+              ? `kill -TERM "$member_pid"; while [ ! -e "${escapedReady}" ]; do sleep 0.005; done; exit 7`
+              : fixture.output,
+            "while :; do sleep 0.01; done",
+          ];
+        }, async (directory) => {
+          const escapedPidFile = path.join(directory, "owner-escaped-pid");
+          const escapedNamespaceFile = path.join(directory, "owner-escaped-namespace");
+          const diagnostic = (await workerTestReader({
+            initial: null,
+            workerLimits: {
+              observeTimeoutMs: 900,
+              inputTimeoutMs: 10,
+              timeoutMs: fixture.timeoutMs,
+              closeTimeoutMs: 40,
+              cleanupTimeoutMs: 150,
+              headroomMs: 250,
+            },
+          }).read(true)).diagnostic;
+          for (let attempt = 0; attempt < 20 && !existsSync(escapedPidFile); attempt += 1) {
+            await new Promise((resolve) => setTimeout(resolve, 5));
+          }
+          expect(existsSync(escapedPidFile), `${owner} ${fixture.name} spawn: ${JSON.stringify(diagnostic)}`).toBeTrue();
+          const escapedPid = Number(readFileSync(escapedPidFile, "utf8"));
+          const namespaceId = readFileSync(escapedNamespaceFile, "utf8");
+          const descendantAliveAtSettlement = processExists(escapedPid);
+          results.push({ owner, outcome: fixture.name, diagnostic, descendantAliveAtSettlement });
+          if (descendantAliveAtSettlement) process.kill(escapedPid, "SIGKILL");
+          await expectProcessAbsentAfterQuietInterval(escapedPid, `${owner} ${fixture.name} RED cleanup`);
+
+          expect(diagnostic, `${owner} ${fixture.name} primary outcome`).toMatchObject(fixture.expected);
+          expect(confirmedFixtureProcessGroups(path.join(directory, "fixture-worker")), `${owner} ${fixture.name} groups`).toEqual([]);
+          expect(pidNamespaceMembers(namespaceId), `${owner} ${fixture.name} namespace`).toEqual([]);
+          await new Promise((resolve) => setTimeout(resolve, 30));
+          expect(processExists(escapedPid), `${owner} ${fixture.name} sustained identity`).toBeFalse();
+          expect(pidNamespaceMembers(namespaceId), `${owner} ${fixture.name} sustained namespace`).toEqual([]);
+        });
+      }
+    }
+
+    const healthySuccesses = results.filter((result) => (
+      result.outcome === "success"
+      && result.diagnostic.status === "complete"
+      && result.diagnostic.degradedReason === undefined
+    ));
+    expect(healthySuccesses).toHaveLength(2);
+    expect(results.filter((result) => (
+      result.descendantAliveAtSettlement
+      && result.diagnostic.failure?.cause !== "worker-cleanup"
+    )), `uncontained outcomes: ${JSON.stringify(results)}`).toEqual([]);
+  });
+
+  test("concurrent containment verification reaches exact zero for every TERM descendant", async () => {
+    await withResourceWorkerScript((directory) => {
+      const memberScript = path.join(directory, "concurrent-term-member.cjs");
+      writeFileSync(memberScript, [
+        '#!/usr/bin/node',
+        'const fs = require("node:fs");',
+        'const { spawn } = require("node:child_process");',
+        'const [directory, key] = process.argv.slice(2);',
+        'fs.writeFileSync(`${directory}/${key}.member`, "ready");',
+        'let handled = false;',
+        'process.on("SIGTERM", () => {',
+        '  if (handled) return;',
+        '  handled = true;',
+        '  const env = { ...process.env };',
+        '  delete env.LLV_RESOURCE_COLLECTOR_OWNER;',
+        '  const script = [',
+        '    "trap \\\"\\\" TERM INT",',
+        '    "read host_pid _ < /proc/self/stat",',
+        '    `printf \'%s\' \\\"$host_pid\\\" > \\\"$1/${key}.pid\\\"`,',
+        '    `readlink /proc/self/ns/pid > \\\"$1/${key}.namespace\\\"`,',
+        '    `: > \\\"$1/${key}.ready\\\"`,',
+        '    "while :; do sleep 1; done",',
+        '  ].join("; ");',
+        '  const child = spawn("/bin/sh", ["-c", script, "sh", directory], { detached: true, stdio: "ignore", env });',
+        '  child.unref();',
+        '  process.exit(0);',
+        '});',
+        'setInterval(() => {}, 1_000);',
+        '',
+      ].join("\n"));
+      return [
+        "read host_pid _ < /proc/self/stat",
+        `printf '%s' "$host_pid" > "${path.join(directory, "pid")}"`,
+        "trap 'exit 0' TERM INT",
+        `/usr/bin/node "${memberScript}" "${directory}" "$host_pid" &`,
+        `while [ ! -e "${directory}/$host_pid.member" ]; do sleep 0.005; done`,
+        `printf '%s\\n' '${EMPTY_FRESH_WORKER_MESSAGE}'`,
+        "while :; do sleep 0.01; done",
+      ];
+    }, async (directory) => {
+      const baseline = referencedHandles();
+      const outcomes = await Promise.all(Array.from({ length: 6 }, () => workerTestReader({
+        initial: null,
+        workerLimits: {
+          observeTimeoutMs: 1_200,
+          inputTimeoutMs: 10,
+          timeoutMs: 700,
+          closeTimeoutMs: 50,
+          cleanupTimeoutMs: 300,
+          headroomMs: 300,
+        },
+      }).read(true)));
+      const pidFiles = readdirSync(directory).filter((name) => /^\d+\.pid$/.test(name));
+      expect(outcomes).toHaveLength(6);
+      expect(outcomes.every((outcome) => (
+        (outcome.diagnostic.status === "complete" && outcome.diagnostic.degradedReason === undefined)
+        || outcome.diagnostic.failure?.cause === "worker-cleanup"
+      )), JSON.stringify(outcomes.map((outcome) => outcome.diagnostic))).toBeTrue();
+      expect(outcomes.some((outcome) => outcome.diagnostic.status === "complete")).toBeTrue();
+      expect(pidFiles).toHaveLength(6);
+      for (const pidFile of pidFiles) {
+        const key = pidFile.slice(0, -4);
+        const escapedPid = Number(readFileSync(path.join(directory, pidFile), "utf8"));
+        const namespaceId = readFileSync(path.join(directory, `${key}.namespace`), "utf8").trim();
+        expect(processExists(escapedPid), `${key} identity`).toBeFalse();
+        expect(pidNamespaceMembers(namespaceId), `${key} namespace`).toEqual([]);
+      }
+      expect(confirmedFixtureProcessGroups(path.join(directory, "fixture-worker"))).toEqual([]);
+      await new Promise((resolve) => setTimeout(resolve, 30));
+      for (const pidFile of pidFiles) {
+        const key = pidFile.slice(0, -4);
+        const escapedPid = Number(readFileSync(path.join(directory, pidFile), "utf8"));
+        const namespaceId = readFileSync(path.join(directory, `${key}.namespace`), "utf8").trim();
+        expect(processExists(escapedPid), `${key} sustained identity`).toBeFalse();
+        expect(pidNamespaceMembers(namespaceId), `${key} sustained namespace`).toEqual([]);
+      }
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      expect(newReferencedHandleCount(baseline)).toBe(0);
+    });
+  });
+
   test("leader-first cleanup sends no signals to recycled or null-identity groups", async () => {
     for (const identity of ["recycled", "null"] as const) {
       await withResourceWorkerScript((directory) => [
-        `printf '%s' "$$" > "${path.join(directory, "pid")}"`,
+        `read host_pid _ < /proc/self/stat; printf '%s' "$host_pid" > "${path.join(directory, "pid")}"`,
         "exit 0",
       ], async () => {
         const realKill = process.kill.bind(process);
@@ -1753,7 +2024,7 @@ describe("resource recurring reads", () => {
 
   test("a near-limit handoff to an immediately exiting worker keeps the parent alive and releases the worker", async () => {
     await withResourceWorkerScript((directory) => [
-      `printf '%s' "$$" > "${path.join(directory, "pid")}"`,
+      `read host_pid _ < /proc/self/stat; printf '%s' "$host_pid" > "${path.join(directory, "pid")}"`,
       "exit 0",
     ], async (directory) => {
       const entrypoint = path.join(directory, "node-parent.ts");
@@ -2048,9 +2319,9 @@ describe("resource recurring reads", () => {
 
   test("malformed, oversized, crash, timeout, and immediate-exit paths release complete worker trees", async () => {
     const withGrandchild = (directory: string, lines: string[]) => [
-      `printf '%s' "$$" > "${path.join(directory, "pid")}"`,
-      "sleep 60 </dev/null >/dev/null 2>&1 &",
-      `printf '%s' "$!" > "${path.join(directory, "grandchild-pid")}"`,
+      `read host_pid _ < /proc/self/stat; printf '%s' "$host_pid" > "${path.join(directory, "pid")}"`,
+      `sh -c 'read host_pid _ < /proc/self/stat; printf "%s" "$host_pid" > "$1"; exec sleep 60' sh "${path.join(directory, "grandchild-pid")}" </dev/null >/dev/null 2>&1 &`,
+      `while [ ! -e "${path.join(directory, "grandchild-pid")}" ]; do sleep 0.005; done`,
       ...lines,
     ];
     const cases: Array<{ name: string; reason: "collector-crash" | "timeout"; cause: string; lines: (directory: string) => string[]; limits?: { timeoutMs?: number; closeTimeoutMs?: number; outputMaxBytes?: number } }> = [

--- a/src/lib/resources.test.ts
+++ b/src/lib/resources.test.ts
@@ -73,6 +73,8 @@ function deferred<T>() {
 describe("resource observation", () => {
   test("builds host ownership and metadata from one shared transcript generation", async () => {
     let scans = 0;
+    let processTableReads = 0;
+    let attachBatches = 0;
     let hostFresh: boolean | null = null;
     const files = [entry];
     const payload = await buildResourceSnapshot(true, {
@@ -80,9 +82,10 @@ describe("resource observation", () => {
         scans += 1;
         return files;
       },
-      readHosts: async (fresh, entries) => {
+      readHosts: async (fresh, entries, ppids) => {
         hostFresh = fresh;
         expect(entries).toBe(files);
+        expect(ppids).toEqual(new Map([[200, 100], [300, 200]]));
         return {
           hosts: [canonical],
           observation: "available",
@@ -92,17 +95,26 @@ describe("resource observation", () => {
       },
       proc: {
         systemMemory: () => ({ ramTotal: 1_000, ramAvailable: 750, swapTotal: 100, swapUsed: 25 }),
-        ppidMap: () => new Map([[200, 100], [300, 200]]),
+        ppidMap: () => {
+          processTableReads += 1;
+          return new Map([[200, 100], [300, 200]]);
+        },
         processMemory: () => new Map([
           [100, { rssBytes: 10, swapBytes: 1 }],
           [200, { rssBytes: 20, swapBytes: 2 }],
           [300, { rssBytes: 30, swapBytes: 3 }],
         ]),
       },
-      captureAttachReference: () => ref(900, 100, "%1"),
+      captureAttachReferences: (refs) => {
+        attachBatches += 1;
+        expect(refs).toEqual([{ tmuxServerPid: 900, panePid: 100, paneId: "%1" }]);
+        return new Map([["%1", ref(900, 100, "%1")]]);
+      },
     });
 
     expect(scans).toBe(1);
+    expect(processTableReads).toBe(1);
+    expect(attachBatches).toBe(1);
     expect(hostFresh).toBeTrue();
     expect(payload.sessions).toEqual([{
       target: "agents:4.0",

--- a/src/lib/resources.test.ts
+++ b/src/lib/resources.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, lstatSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
@@ -115,6 +115,23 @@ function processExists(pid: number): boolean {
   }
 }
 
+function directorySnapshot(root: string): Array<readonly [string, "directory" | "file", number, string?]> {
+  const snapshot: Array<readonly [string, "directory" | "file", number, string?]> = [];
+  const visit = (directory: string, relative: string) => {
+    const stat = lstatSync(directory);
+    snapshot.push([relative || ".", "directory", stat.mode & 0o777]);
+    for (const name of readdirSync(directory).sort()) {
+      const pathname = path.join(directory, name);
+      const childRelative = relative ? path.join(relative, name) : name;
+      const child = lstatSync(pathname);
+      if (child.isDirectory()) visit(pathname, childRelative);
+      else snapshot.push([childRelative, "file", child.mode & 0o777, readFileSync(pathname).toString("base64")]);
+    }
+  };
+  visit(root, "");
+  return snapshot;
+}
+
 async function expectProcessAbsentAfterQuietInterval(pid: number, label: string): Promise<void> {
   for (let attempt = 0; attempt < 20 && processExists(pid); attempt += 1) {
     await new Promise((resolve) => setTimeout(resolve, 10));
@@ -175,6 +192,70 @@ function workerTestReader(options: Parameters<typeof createResourcesReader>[4] =
 }
 
 describe("resource observation", () => {
+  test("the packaged worker leaves writable and read-only homes and state trees byte-identical", async () => {
+    const directory = mkdtempSync(path.join(os.tmpdir(), "llv-resource-package-purity-"));
+    const bundleName = "packaged-resource-worker.mjs";
+    try {
+      const built = await Bun.build({
+        entrypoints: [path.join(import.meta.dir, "resourceCollector.worker.ts")],
+        outdir: directory,
+        target: "node",
+        format: "esm",
+        naming: bundleName,
+      });
+      expect(built.success).toBeTrue();
+
+      for (const writable of [true, false]) {
+        const caseDirectory = path.join(directory, writable ? "writable" : "read-only");
+        const home = path.join(caseDirectory, "home");
+        const state = path.join(caseDirectory, "state");
+        mkdirSync(home, { recursive: true });
+        mkdirSync(state, { recursive: true });
+        writeFileSync(path.join(state, "sentinel"), "state-bytes\n");
+        if (!writable) chmodSync(home, 0o500);
+        const homeBefore = directorySnapshot(home);
+        const stateBefore = directorySnapshot(state);
+        const env: Record<string, string | undefined> = {
+          ...process.env,
+          HOME: home,
+          LLV_STATE_DIR: state,
+          LLV_AGENT_REGISTRY_SQLITE: "off",
+          PATH: "/usr/bin:/bin",
+        };
+        delete env.XDG_CONFIG_HOME;
+        delete env.XDG_CACHE_HOME;
+        delete env.LLV_RESOURCE_COLLECTOR_IN_PROCESS;
+        delete env.LLV_RESOURCE_OBSERVATION_WORKER;
+        const child = Bun.spawn(["/usr/bin/node", path.join(directory, bundleName)], {
+          cwd: process.cwd(),
+          env,
+          stdin: new Blob(["{\"type\":\"collect\",\"fresh\":false,\"files\":[]}\n"]),
+          stdout: "pipe",
+          stderr: "pipe",
+        });
+        const [exit, stdout, stderr] = await Promise.all([
+          child.exited,
+          new Response(child.stdout).text(),
+          new Response(child.stderr).text(),
+        ]);
+
+        expect(exit, writable ? "writable home" : "read-only home").toBe(0);
+        expect(stderr, writable ? "writable home" : "read-only home").toBe("");
+        expect(JSON.parse(stdout), writable ? "writable home" : "read-only home").toMatchObject({
+          type: "observation",
+          diagnostic: { status: "complete", fresh: false },
+        });
+        expect(directorySnapshot(home), writable ? "writable home" : "read-only home").toEqual(homeBefore);
+        expect(directorySnapshot(state), writable ? "writable state" : "read-only state").toEqual(stateBefore);
+        if (!writable) chmodSync(home, 0o700);
+      }
+    } finally {
+      const readOnlyHome = path.join(directory, "read-only", "home");
+      if (existsSync(readOnlyHome)) chmodSync(readOnlyHome, 0o700);
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
   test("the collector child leaves shared state byte-identical", async () => {
     const directory = mkdtempSync(path.join(os.tmpdir(), "llv-resource-purity-"));
     const home = path.join(directory, "home");
@@ -196,12 +277,24 @@ describe("resource observation", () => {
       stderr: "pipe",
     });
     try {
-      const exit = await Promise.race([
+      let timedOut = false;
+      const timer = setTimeout(() => {
+        timedOut = true;
+        child.kill("SIGKILL");
+      }, 5_000);
+      const [exit, stdout, stderr] = await Promise.all([
         child.exited,
-        new Promise<"timeout">((resolve) => setTimeout(() => resolve("timeout"), 5_000)),
+        new Response(child.stdout).text(),
+        new Response(child.stderr).text(),
       ]);
-      if (exit === "timeout") child.kill("SIGKILL");
+      clearTimeout(timer);
+      expect(timedOut).toBeFalse();
       expect(exit).toBe(0);
+      expect(stderr).toBe("");
+      expect(JSON.parse(stdout)).toMatchObject({
+        type: "observation",
+        diagnostic: { status: "complete", fresh: false },
+      });
       expect(existsSync(staleRegistryTemp)).toBeTrue();
       expect(readFileSync(scanSentinel)).toEqual(before);
     } finally {
@@ -696,6 +789,31 @@ describe("kill-target allowlist", () => {
 });
 
 describe("resource recurring reads", () => {
+  test("an exited leader cleans up a TERM-resistant descendant that holds both output pipes", async () => {
+    await withResourceWorkerScript((directory) => {
+      const descendantPid = path.join(directory, "descendant-pid");
+      const ready = path.join(directory, "descendant-ready");
+      return [
+        `printf '%s' "$$" > "${path.join(directory, "pid")}"`,
+        `sh -c 'trap "" TERM INT; printf "%s" "$$" > "$1"; : > "$2"; while :; do sleep 1; done' sh "${descendantPid}" "${ready}" &`,
+        `while [ ! -e "${ready}" ]; do sleep 0.01; done`,
+        "exit 0",
+      ];
+    }, async (directory) => {
+      const startedAt = performance.now();
+      const outcome = await workerTestReader({ workerLimits: { timeoutMs: 500, closeTimeoutMs: 25 } }).read(true);
+      const elapsedMs = performance.now() - startedAt;
+
+      expect(outcome).toMatchObject({ diagnostic: {
+        degradedReason: "collector-crash",
+        failure: { cause: "worker-exit" },
+      } });
+      expect(elapsedMs).toBeLessThan(250);
+      await expectProcessAbsentAfterQuietInterval(Number(readFileSync(path.join(directory, "pid"), "utf8")), "exited leader");
+      await expectProcessAbsentAfterQuietInterval(Number(readFileSync(path.join(directory, "descendant-pid"), "utf8")), "pipe-holding descendant");
+    });
+  });
+
   test("a near-limit handoff to an immediately exiting worker keeps the parent alive and releases the worker", async () => {
     await withResourceWorkerScript((directory) => [
       `printf '%s' "$$" > "${path.join(directory, "pid")}"`,

--- a/src/lib/resources.test.ts
+++ b/src/lib/resources.test.ts
@@ -1109,6 +1109,129 @@ describe("resource recurring reads", () => {
     });
   });
 
+  test("a delayed post-observation stdout flood overrides provisional success with zero residue", async () => {
+    await withResourceWorkerScript((directory) => [
+      `read host_pid _ < /proc/self/stat; printf '%s' "$host_pid" > "${path.join(directory, "pid")}"`,
+      `readlink /proc/self/ns/pid > "${path.join(directory, "namespace")}"`,
+      "trap '' TERM INT",
+      `while [ ! -e "${path.join(directory, "release")}" ]; do sleep 0.005; done`,
+      `printf '%s\n' '${EMPTY_FRESH_WORKER_MESSAGE}'`,
+      "sleep 0.03",
+      "printf '%2048s' ''",
+      "while :; do sleep 0.01; done",
+    ], async (directory) => {
+      const baseline = referencedHandles();
+      const read = workerTestReader({
+        initial: null,
+        workerLimits: {
+          observeTimeoutMs: 1_000,
+          inputTimeoutMs: 10,
+          timeoutMs: 500,
+          closeTimeoutMs: 150,
+          cleanupTimeoutMs: 350,
+          headroomMs: 500,
+          outputMaxBytes: 1_024,
+        },
+      }).read(true);
+      const pidFile = path.join(directory, "pid");
+      const namespaceFile = path.join(directory, "namespace");
+      for (let attempt = 0; attempt < 100
+        && (!fileHasText(pidFile) || !fileHasText(namespaceFile)); attempt += 1) {
+        await new Promise((resolve) => setTimeout(resolve, 5));
+      }
+      const workerPid = Number(readFileSync(pidFile, "utf8"));
+      const namespaceId = readFileSync(namespaceFile, "utf8").trim();
+      const namespaceReference = retainPidNamespaceReference(workerPid, namespaceId);
+      writeFileSync(path.join(directory, "release"), "release");
+      try {
+        const outcome = await read;
+
+        expect(outcome.diagnostic).toMatchObject({
+          degradedReason: "collector-crash",
+          failure: { cause: "worker-output-limit" },
+        });
+        expect(Buffer.byteLength(outcome.diagnostic.failure?.stderr ?? "")).toBeLessThanOrEqual(
+          RESOURCE_FAILURE_STDERR_MAX_BYTES,
+        );
+        expect(processExists(workerPid), "worker identity").toBeFalse();
+        expect(confirmedFixtureProcessGroups(path.join(directory, "fixture-worker")), "worker groups").toEqual([]);
+        expect(pidNamespaceMembers(namespaceId), "PID namespace members").toEqual([]);
+        expect(retainedPidNamespaceReferences(namespaceId), "production namespace references").toBe(1);
+        await new Promise((resolve) => setTimeout(resolve, 30));
+        expect(processExists(workerPid), "sustained worker identity").toBeFalse();
+        expect(pidNamespaceMembers(namespaceId), "sustained PID namespace members").toEqual([]);
+      } finally {
+        closeSync(namespaceReference);
+      }
+      expect(retainedPidNamespaceReferences(namespaceId), "namespace references").toBe(0);
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      expect(newReferencedHandleCount(baseline), "referenced handles").toBe(0);
+    });
+  });
+
+  test("a delayed post-observation stderr flood overrides provisional success with bounded diagnostics", async () => {
+    await withResourceWorkerScript((directory) => [
+      `read host_pid _ < /proc/self/stat; printf '%s' "$host_pid" > "${path.join(directory, "pid")}"`,
+      `readlink /proc/self/ns/pid > "${path.join(directory, "namespace")}"`,
+      "trap '' TERM INT",
+      `while [ ! -e "${path.join(directory, "release")}" ]; do sleep 0.005; done`,
+      `printf '%s\n' '${EMPTY_FRESH_WORKER_MESSAGE}'`,
+      "sleep 0.03",
+      "printf '%2048s' '' >&2",
+      "printf '\nPASSWORD=post-frame-secret\nsafe post-frame suffix\n' >&2",
+      "while :; do sleep 0.01; done",
+    ], async (directory) => {
+      const baseline = referencedHandles();
+      const read = workerTestReader({
+        initial: null,
+        workerLimits: {
+          observeTimeoutMs: 1_000,
+          inputTimeoutMs: 10,
+          timeoutMs: 500,
+          closeTimeoutMs: 150,
+          cleanupTimeoutMs: 350,
+          headroomMs: 500,
+          outputMaxBytes: 1_024,
+        },
+      }).read(true);
+      const pidFile = path.join(directory, "pid");
+      const namespaceFile = path.join(directory, "namespace");
+      for (let attempt = 0; attempt < 100
+        && (!fileHasText(pidFile) || !fileHasText(namespaceFile)); attempt += 1) {
+        await new Promise((resolve) => setTimeout(resolve, 5));
+      }
+      const workerPid = Number(readFileSync(pidFile, "utf8"));
+      const namespaceId = readFileSync(namespaceFile, "utf8").trim();
+      const namespaceReference = retainPidNamespaceReference(workerPid, namespaceId);
+      writeFileSync(path.join(directory, "release"), "release");
+      try {
+        const outcome = await read;
+        const stderr = outcome.diagnostic.failure?.stderr ?? "";
+
+        expect(outcome.diagnostic).toMatchObject({
+          degradedReason: "collector-crash",
+          failure: { cause: "worker-output-limit" },
+        });
+        expect(Buffer.byteLength(stderr)).toBeLessThanOrEqual(RESOURCE_FAILURE_STDERR_MAX_BYTES);
+        expect(stderr).toContain("PASSWORD=<redacted>");
+        expect(stderr).toContain("safe post-frame suffix");
+        expect(stderr).not.toContain("post-frame-secret");
+        expect(processExists(workerPid), "worker identity").toBeFalse();
+        expect(confirmedFixtureProcessGroups(path.join(directory, "fixture-worker")), "worker groups").toEqual([]);
+        expect(pidNamespaceMembers(namespaceId), "PID namespace members").toEqual([]);
+        expect(retainedPidNamespaceReferences(namespaceId), "production namespace references").toBe(1);
+        await new Promise((resolve) => setTimeout(resolve, 30));
+        expect(processExists(workerPid), "sustained worker identity").toBeFalse();
+        expect(pidNamespaceMembers(namespaceId), "sustained PID namespace members").toEqual([]);
+      } finally {
+        closeSync(namespaceReference);
+      }
+      expect(retainedPidNamespaceReferences(namespaceId), "namespace references").toBe(0);
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      expect(newReferencedHandleCount(baseline), "referenced handles").toBe(0);
+    });
+  });
+
   test("a successful read settles after a TERM-resistant redirected process group is absent", async () => {
     await withResourceWorkerScript((directory) => {
       const descendantPid = path.join(directory, "redirected-descendant-pid");
@@ -1551,7 +1674,7 @@ describe("resource recurring reads", () => {
     }
   });
 
-  test("owner-mutating TERM descendants cannot escape settlement", async () => {
+  test("pre-armed owner-mutating TERM descendants observe member-before-root cleanup", async () => {
     const fixtures = [
       {
         name: "success",
@@ -1594,6 +1717,8 @@ describe("resource recurring reads", () => {
           const escapedNamespace = path.join(directory, "owner-escaped-namespace");
           const escapedReady = path.join(directory, "owner-escaped-ready");
           const memberReady = path.join(directory, "owner-member-ready");
+          const transitionArmed = path.join(directory, "owner-transition-armed");
+          const transitionOrder = path.join(directory, "owner-transition-order");
           writeFileSync(escapedScript, [
             '#!/usr/bin/node',
             'const fs = require("node:fs");',
@@ -1611,11 +1736,12 @@ describe("resource recurring reads", () => {
             '#!/usr/bin/node',
             'const fs = require("node:fs");',
             'const { spawn } = require("node:child_process");',
-            'const [escapedScript, escapedPid, escapedNamespace, escapedReady, memberReady, ownerMode] = process.argv.slice(2);',
+            'const [escapedScript, escapedPid, escapedNamespace, escapedReady, memberReady, ownerMode, transitionOrder] = process.argv.slice(2);',
             'let handled = false;',
             'process.on("SIGTERM", () => {',
             '  if (handled) return;',
             '  handled = true;',
+            '  fs.appendFileSync(transitionOrder, "member\\n");',
             '  const env = { ...process.env };',
             '  if (ownerMode === "deleted") delete env.LLV_RESOURCE_COLLECTOR_OWNER;',
             '  else env.LLV_RESOURCE_COLLECTOR_OWNER = "changed-owner";',
@@ -1632,10 +1758,11 @@ describe("resource recurring reads", () => {
           return [
             `read host_pid _ < /proc/self/stat; printf '%s' "$host_pid" > "${path.join(directory, "pid")}"`,
             `readlink /proc/self/ns/pid > "${path.join(directory, "root-namespace")}"`,
-            "trap 'exit 0' TERM INT",
-            `/usr/bin/node "${memberScript}" "${escapedScript}" "${escapedPid}" "${escapedNamespace}" "${escapedReady}" "${memberReady}" "${owner}" &`,
+            `trap 'printf "root\\n" >> "${transitionOrder}"; exit 0' TERM INT`,
+            `/usr/bin/node "${memberScript}" "${escapedScript}" "${escapedPid}" "${escapedNamespace}" "${escapedReady}" "${memberReady}" "${owner}" "${transitionOrder}" &`,
             "member_pid=$!",
             `while [ ! -e "${memberReady}" ]; do sleep 0.005; done`,
+            `: > "${transitionArmed}"`,
             `while [ ! -e "${path.join(directory, "release")}" ]; do sleep 0.005; done`,
             "sleep 0.08",
             fixture.name === "crash"
@@ -1659,10 +1786,14 @@ describe("resource recurring reads", () => {
           }).read(true);
           const rootPidFile = path.join(directory, "pid");
           const rootNamespaceFile = path.join(directory, "root-namespace");
+          const transitionArmedFile = path.join(directory, "owner-transition-armed");
+          const transitionOrderFile = path.join(directory, "owner-transition-order");
           for (let attempt = 0; attempt < 100
-            && (!fileHasText(rootPidFile) || !fileHasText(rootNamespaceFile)); attempt += 1) {
+            && (!fileHasText(rootPidFile) || !fileHasText(rootNamespaceFile)
+              || !existsSync(transitionArmedFile)); attempt += 1) {
             await new Promise((resolve) => setTimeout(resolve, 5));
           }
+          expect(existsSync(transitionArmedFile), `${owner} ${fixture.name} owner transition armed`).toBeTrue();
           const rootPid = Number(readFileSync(rootPidFile, "utf8"));
           const rootNamespaceId = readFileSync(rootNamespaceFile, "utf8").trim();
           const namespaceReference = retainPidNamespaceReference(rootPid, rootNamespaceId);
@@ -1676,6 +1807,10 @@ describe("resource recurring reads", () => {
             }
             expect(fileHasText(escapedPidFile) && fileHasText(escapedNamespaceFile),
               `${owner} ${fixture.name} spawn: ${JSON.stringify(diagnostic)}`).toBeTrue();
+            expect(readFileSync(transitionOrderFile, "utf8").trim().split("\n"),
+              `${owner} ${fixture.name} transition order`).toEqual(
+              fixture.name === "crash" ? ["member"] : ["member", "root"],
+            );
             const escapedPid = Number(readFileSync(escapedPidFile, "utf8"));
             namespaceId = readFileSync(escapedNamespaceFile, "utf8").trim();
             const descendantAliveAtSettlement = processExists(escapedPid);
@@ -1709,7 +1844,7 @@ describe("resource recurring reads", () => {
       result.descendantAliveAtSettlement
       && result.diagnostic.failure?.cause !== "worker-cleanup"
     )), `uncontained outcomes: ${JSON.stringify(results)}`).toEqual([]);
-  });
+  }, 15_000);
 
   test("retains PID namespace membership authority through init disappearance", async () => {
     await withResourceWorkerScript((directory) => {
@@ -1800,7 +1935,7 @@ describe("resource recurring reads", () => {
     });
   });
 
-  test("concurrent containment verification reaches exact zero for every TERM descendant", async () => {
+  test("six pre-armed concurrent containment cleanups stay healthy and reach exact zero", async () => {
     await withResourceWorkerScript((directory) => {
       const memberScript = path.join(directory, "concurrent-term-member.cjs");
       writeFileSync(memberScript, [
@@ -1856,11 +1991,13 @@ describe("resource recurring reads", () => {
       }).read(true));
       for (let attempt = 0; attempt < 200
         && readdirSync(directory).filter((name) => /^\d+\.root-namespace$/.test(name)
-          && fileHasText(path.join(directory, name))).length < 6; attempt += 1) {
+          && fileHasText(path.join(directory, name))
+          && fileHasText(path.join(directory, name.replace(".root-namespace", ".member")))).length < 6; attempt += 1) {
         await new Promise((resolve) => setTimeout(resolve, 5));
       }
       const rootNamespaceFiles = readdirSync(directory).filter((name) => /^\d+\.root-namespace$/.test(name)
-        && fileHasText(path.join(directory, name)));
+        && fileHasText(path.join(directory, name))
+        && fileHasText(path.join(directory, name.replace(".root-namespace", ".member"))));
       expect(rootNamespaceFiles).toHaveLength(6);
       const namespaceReferences = rootNamespaceFiles.map((filename) => {
         const key = filename.slice(0, -".root-namespace".length);
@@ -1873,10 +2010,8 @@ describe("resource recurring reads", () => {
         const pidFiles = readdirSync(directory).filter((name) => /^\d+\.pid$/.test(name));
         expect(outcomes).toHaveLength(6);
         expect(outcomes.every((outcome) => (
-          (outcome.diagnostic.status === "complete" && outcome.diagnostic.degradedReason === undefined)
-          || outcome.diagnostic.failure?.cause === "worker-cleanup"
+          outcome.diagnostic.status === "complete" && outcome.diagnostic.degradedReason === undefined
         )), JSON.stringify(outcomes.map((outcome) => outcome.diagnostic))).toBeTrue();
-        expect(outcomes.some((outcome) => outcome.diagnostic.status === "complete")).toBeTrue();
         expect(pidFiles).toHaveLength(6);
         for (const pidFile of pidFiles) {
           const key = pidFile.slice(0, -4);
@@ -1907,7 +2042,7 @@ describe("resource recurring reads", () => {
       await new Promise<void>((resolve) => setImmediate(resolve));
       expect(newReferencedHandleCount(baseline)).toBe(0);
     });
-  });
+  }, 15_000);
 
   test("leader-first cleanup sends no signals to recycled or null-identity groups", async () => {
     for (const identity of ["recycled", "null"] as const) {

--- a/src/lib/resources.test.ts
+++ b/src/lib/resources.test.ts
@@ -131,7 +131,7 @@ describe("resource observation", () => {
       swapBytes: 6,
       procCount: 3,
     }]);
-    expect(allowedKillTarget("agents:4.0")).toEqual(ref(900, 100, "%1"));
+    expect(allowedKillTarget("agents:4.0")).toBeNull();
     expect(lastResourceBuildDiagnostic()).toEqual(expect.objectContaining({
       fresh: true,
       status: "complete",
@@ -233,6 +233,31 @@ describe("kill-target allowlist", () => {
 });
 
 describe("resource recurring reads", () => {
+  test("persists each completed generation once across ordinary reads", async () => {
+    let now = 0;
+    let builds = 0;
+    const persisted: number[] = [];
+    const reader = createResourcesReader(async () => {
+      builds += 1;
+      return { system: null, sessions: [] };
+    }, () => null, () => now, () => ({ fresh: true, status: "complete", durationMs: 0, phases: {
+      systemMemory: 0, readFiles: 0, readHosts: 0, ppidMap: 0, processMemory: 0, attach: 0, serialization: 0,
+    } }), { inProcess: true, persist: (observation) => persisted.push(observation.generation) });
+
+    await reader.read();
+    await reader.read();
+    await reader.read();
+    await reader.read();
+    expect(persisted).toEqual([1]);
+
+    now = 10_000;
+    await reader.read();
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    await reader.read(true);
+    expect(persisted).toEqual([1, 3]);
+    expect(builds).toBe(3);
+  });
+
   test("expired ordinary reads return the cached snapshot while one rebuild runs, and fresh waits for a newer build", async () => {
     let now = 0;
     let builds = 0;
@@ -259,6 +284,7 @@ describe("resource recurring reads", () => {
     await new Promise<void>((resolve) => setImmediate(resolve));
     fresh.resolve(freshResult);
     expect((await forced).payload).toEqual(freshResult);
+    expect(builds).toBe(3);
   });
 
   test("a failed ordinary rebuild leaves the cached snapshot available and later polls retry", async () => {

--- a/src/lib/resources.test.ts
+++ b/src/lib/resources.test.ts
@@ -3,10 +3,11 @@ import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, wr
 import os from "node:os";
 import path from "node:path";
 
-import type { TranscriptHost } from "@/lib/agent/transcriptHost";
+import { createTranscriptHostObserver, type TranscriptHost } from "@/lib/agent/transcriptHost";
+import { RESOURCE_FAILURE_STDERR_MAX_BYTES } from "@/lib/resourceCollector";
 import type { FileEntry, ResourcesPayload } from "@/lib/types";
 
-import { allowedKillTarget, applyResourceTargets, buildResourceSnapshot, canonicalResourceEntry, conflictingResourceHost, consumeKillTarget, createResourcesReader, lastResourceBuildDiagnostic, noteSessionTargets, parsePersistedResourceObservation, parseResourcesFixture, resetResourcesForTests, RESOURCE_OBSERVATION_MAX_BYTES, RESOURCE_WORKER_OUTPUT_MAX_BYTES } from "./resources";
+import { allowedKillTarget, applyResourceTargets, buildResourceSnapshot, canonicalResourceEntry, conflictingResourceHost, consumeKillTarget, createResourcesReader, lastResourceBuildDiagnostic, lastResourceTargetRefs, noteSessionTargets, parsePersistedResourceObservation, parseResourcesFixture, resetResourcesForTests, resolveResourceWorkerLaunch, resourceWorkerFileSnapshot, RESOURCE_OBSERVATION_MAX_BYTES, RESOURCE_WORKER_OUTPUT_MAX_BYTES } from "./resources";
 
 const PATHNAME = "/home/user/.codex/sessions/2026/07/10/rollout-2026-07-10-019f4906-3f67-7b72-9fbc-9ec3b5ad1326.jsonl";
 const EMPTY_WORKER_MESSAGE = JSON.stringify({
@@ -103,6 +104,26 @@ function ref(tmuxServerPid: number, panePid: number, paneId: string) {
     paneStartIdentity: `${panePid}:one`,
     paneId,
   };
+}
+
+function processExists(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function expectProcessAbsentAfterQuietInterval(pid: number, label: string): Promise<void> {
+  for (let attempt = 0; attempt < 20 && processExists(pid); attempt += 1) {
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  const leaked = processExists(pid);
+  if (leaked) process.kill(pid, "SIGKILL");
+  expect(leaked, label).toBeFalse();
+  await new Promise((resolve) => setTimeout(resolve, 30));
+  expect(processExists(pid), label).toBeFalse();
 }
 
 function deferred<T>() {
@@ -250,7 +271,8 @@ describe("resource observation", () => {
       swapBytes: 6,
       procCount: 3,
     }]);
-    expect(allowedKillTarget("agents:4.0")).toEqual(ref(900, 100, "%1"));
+    expect(allowedKillTarget("agents:4.0")).toBeNull();
+    expect(lastResourceTargetRefs()).toEqual([{ target: "agents:4.0", ref: ref(900, 100, "%1") }]);
     expect(lastResourceBuildDiagnostic()).toEqual(expect.objectContaining({
       fresh: true,
       status: "complete",
@@ -325,6 +347,79 @@ describe("resource observation", () => {
     expect(parsePersistedResourceObservation(overLimit)).toBeNull();
   });
 
+  test("the exact durable boundary publishes once and one extra byte fails before publication", async () => {
+    const collectorId = "worker:boundary";
+    const diagnostic = {
+      fresh: true,
+      status: "complete" as const,
+      durationMs: 0,
+      phases: { systemMemory: 0, readFiles: 0, readHosts: 0, ppidMap: 0, processMemory: 0, attach: 0, serialization: 0 },
+    };
+    const session = {
+      target: "agents:1.0", panePid: 100, path: null, engine: "codex" as const, hostConflict: false,
+      title: "", project: null, activity: null, lastActiveAt: null, cwd: "/repo", rssBytes: 1, swapBytes: 0, procCount: 1,
+    };
+    const value = {
+      payload: { system: null, sessions: [session] },
+      diagnostic,
+      hostCount: 1,
+      treeCount: 1,
+      targets: [],
+      targetEpoch: 0,
+    };
+    const observation = { generation: 1, startedAt: 1, completedAt: 1, collectorId, value };
+    const emptyEnvelope = JSON.stringify({ version: 1, observation }) + "\n";
+    session.title = "x".repeat(RESOURCE_OBSERVATION_MAX_BYTES - Buffer.byteLength(emptyEnvelope));
+    const workerMessage = () => JSON.stringify({
+      type: "observation",
+      payload: value.payload,
+      diagnostic,
+      targets: [],
+    });
+
+    const persisted: string[] = [];
+    await withResourceWorkerScript((directory) => {
+      writeFileSync(path.join(directory, "message"), workerMessage() + "\n");
+      return [`cat "${path.join(directory, "message")}"`];
+    }, async () => {
+      const reader = createResourcesReader(async () => value.payload, () => null, () => 1, () => diagnostic, {
+        collectorId,
+        readFiles: async () => [],
+        persist: (candidate) => {
+          persisted.push(JSON.stringify({ version: 1, observation: candidate }) + "\n");
+          return true;
+        },
+      });
+      expect((await reader.read(true)).payload.sessions).toHaveLength(1);
+      await reader.read();
+    });
+    expect(persisted).toHaveLength(1);
+    expect(Buffer.byteLength(persisted[0]!)).toBe(RESOURCE_OBSERVATION_MAX_BYTES);
+
+    session.title += "x";
+    let overLimitPersistAttempts = 0;
+    await withResourceWorkerScript((directory) => {
+      writeFileSync(path.join(directory, "message"), workerMessage() + "\n");
+      return [
+        `printf x >> "${path.join(directory, "workers")}"`,
+        `cat "${path.join(directory, "message")}"`,
+      ];
+    }, async (directory) => {
+      const reader = createResourcesReader(async () => value.payload, () => null, () => 1, () => diagnostic, {
+        collectorId,
+        readFiles: async () => [],
+        persist: () => {
+          overLimitPersistAttempts += 1;
+          return false;
+        },
+      });
+      expect((await reader.read(true)).payload.sessions).toHaveLength(0);
+      await new Promise((resolve) => setTimeout(resolve, 30));
+      expect(readFileSync(path.join(directory, "workers"), "utf8")).toBe("x");
+    });
+    expect(overLimitPersistAttempts).toBe(0);
+  });
+
   test("attributes a duplicated transcript only to the shared canonical host", () => {
     const snapshot = { hosts: [duplicate, canonical], observation: "available" as const, canonicalFor: (pathname: string) => (pathname === PATHNAME ? canonical : null) };
 
@@ -343,9 +438,214 @@ describe("resource observation", () => {
     expect(conflictingResourceHost(snapshot, duplicate)).toBeTrue();
     expect(conflictingResourceHost(snapshot, canonical)).toBeTrue();
   });
+
+  test("two handoff paths for one stable conversation form one conflict", async () => {
+    const secondPath = "/home/user/.codex/sessions/2026/07/10/rollout-2026-07-10-029f4906-3f67-7b72-9fbc-9ec3b5ad1326.jsonl";
+    const files = resourceWorkerFileSnapshot([
+      entry,
+      { ...entry, path: secondPath, name: secondPath, pid: 201 },
+    ], () => "conversation_test");
+    const conversationByPath = new Map(files.map((file) => [file.path, file.conversationId]));
+    const observe = createTranscriptHostObserver({
+      listFiles: async () => files as FileEntry[],
+      panes: async () => ({
+        kind: "available",
+        panes: new Map([
+          [100, { paneId: "%1", target: "agents:4.0" }],
+          [101, { paneId: "%2", target: "agents:5.0" }],
+        ]),
+      }),
+      ppidMap: () => new Map([[200, 100], [201, 101]]),
+      agents: () => [
+        { pid: 200, engine: "codex", argv: ["codex", "resume", "019f4906-3f67-7b72-9fbc-9ec3b5ad1326"], cwd: "/repo", tty: 1 },
+        { pid: 201, engine: "codex", argv: ["codex", "resume", "029f4906-3f67-7b72-9fbc-9ec3b5ad1326"], cwd: "/repo", tty: 1 },
+      ],
+      serverPid: async () => 900,
+      resumeRecords: async () => null,
+      identity: (pid) => `${pid}:one`,
+      conversationIdForPath: (pathname) => conversationByPath.get(pathname) ?? null,
+    });
+
+    const snapshot = await observe(true, files as FileEntry[]);
+
+    expect(snapshot.conflicts).toEqual([{
+      conversationId: "conversation_test",
+      paths: [PATHNAME, secondPath],
+      paneIds: ["%1", "%2"],
+    }]);
+    expect(snapshot.canonicalFor(PATHNAME)).toBeNull();
+    expect(snapshot.canonicalFor(secondPath)).toBeNull();
+  });
+
+  test("worker launch selection preserves Docker Bun and supports a Node-only bundle", () => {
+    const cwd = "/package";
+    const sourceWorker = "/package/src/lib/resourceCollector.worker.ts";
+    const bundledWorker = "/package/.next/server/resource-collector-worker.js";
+    const bunContainer = "/usr/local/bin/bun-container";
+
+    expect(resolveResourceWorkerLaunch({
+      cwd,
+      env: { NODE_ENV: "test", LLV_RESOURCE_COLLECTOR_EXECUTABLE: "/fixture/worker" },
+      execPath: "/usr/bin/node",
+      exists: () => false,
+    })).toEqual({ executable: "/fixture/worker", workerPath: sourceWorker });
+    expect(resolveResourceWorkerLaunch({
+      cwd,
+      env: { NODE_ENV: "test" },
+      execPath: "/usr/bin/node",
+      exists: (pathname) => pathname === bunContainer || pathname === bundledWorker,
+    })).toEqual({ executable: bunContainer, workerPath: sourceWorker });
+    expect(resolveResourceWorkerLaunch({
+      cwd,
+      env: { NODE_ENV: "test" },
+      execPath: "/usr/bin/node",
+      exists: (pathname) => pathname === bundledWorker,
+    })).toEqual({ executable: "/usr/bin/node", workerPath: bundledWorker });
+  });
 });
 
 describe("kill-target allowlist", () => {
+  test("durable display hydration grants no kill capability until a current observation", async () => {
+    const targetRef = ref(900, 111, "%11");
+    const session = {
+      target: "agents:1.0",
+      panePid: 111,
+      path: null,
+      engine: "codex" as const,
+      hostConflict: false,
+      title: null,
+      project: null,
+      activity: null,
+      lastActiveAt: null,
+      cwd: "/repo",
+      rssBytes: 1,
+      swapBytes: 0,
+      procCount: 1,
+    };
+    const diagnostic = {
+      fresh: true,
+      status: "complete" as const,
+      durationMs: 0,
+      phases: { systemMemory: 0, readFiles: 0, readHosts: 0, ppidMap: 0, processMemory: 0, attach: 0, serialization: 0 },
+    };
+    const message = JSON.stringify({
+      type: "observation",
+      payload: { system: null, sessions: [session] },
+      diagnostic,
+      targets: [{ target: session.target, ref: targetRef }],
+    });
+
+    await withResourceWorkerScript([`printf '%s\\n' '${message}'`], async () => {
+      resetResourcesForTests();
+      const reader = workerTestReader({
+        initial: {
+          generation: 7,
+          startedAt: 1,
+          completedAt: 2,
+          collectorId: "prior-runtime",
+          value: {
+            payload: { system: null, sessions: [session] },
+            diagnostic,
+            hostCount: 1,
+            treeCount: 1,
+            targets: [{ target: session.target, ref: targetRef }],
+          },
+        },
+      });
+
+      expect((await reader.read()).payload.sessions).toHaveLength(1);
+      expect(allowedKillTarget(session.target)).toBeNull();
+      await reader.read(true);
+      expect(allowedKillTarget(session.target)).toEqual(targetRef);
+    });
+  });
+
+  test("a worker collection started before target consumption cannot restore it", async () => {
+    const targetRef = ref(900, 111, "%11");
+    const session = {
+      target: "agents:1.0", panePid: 111, path: null, engine: "codex" as const, hostConflict: false,
+      title: null, project: null, activity: null, lastActiveAt: null, cwd: "/repo", rssBytes: 1, swapBytes: 0, procCount: 1,
+    };
+    const message = JSON.stringify({
+      type: "observation",
+      payload: { system: null, sessions: [session] },
+      diagnostic: {
+        fresh: true, status: "complete", durationMs: 0,
+        phases: { systemMemory: 0, readFiles: 0, readHosts: 0, ppidMap: 0, processMemory: 0, attach: 0, serialization: 0 },
+      },
+      targets: [{ target: session.target, ref: targetRef }],
+    });
+
+    await withResourceWorkerScript([`printf '%s\\n' '${message}'`], async () => {
+      resetResourcesForTests();
+      noteSessionTargets([{ target: session.target, ref: targetRef }]);
+      const started = deferred<void>();
+      const release = deferred<never[]>();
+      let handoffs = 0;
+      const reader = workerTestReader({
+        readFiles: async () => {
+          handoffs += 1;
+          if (handoffs === 1) {
+            started.resolve();
+            return release.promise;
+          }
+          return [];
+        },
+      });
+
+      const stale = reader.read(true);
+      await started.promise;
+      consumeKillTarget(session.target);
+      release.resolve([]);
+      await stale;
+      expect(allowedKillTarget(session.target)).toBeNull();
+
+      await reader.read(true);
+      expect(allowedKillTarget(session.target)).toEqual(targetRef);
+    });
+  });
+
+  test("an in-process collection started before target consumption cannot restore it", async () => {
+    resetResourcesForTests();
+    const targetRef = ref(900, 100, "%1");
+    noteSessionTargets([{ target: canonical.display, ref: targetRef }]);
+    const started = deferred<void>();
+    const release = deferred<void>();
+    let builds = 0;
+    const reader = createResourcesReader((fresh) => buildResourceSnapshot(fresh, {
+      readFiles: async () => {
+        builds += 1;
+        if (builds === 1) {
+          started.resolve();
+          await release.promise;
+        }
+        return [entry];
+      },
+      readHosts: async () => ({
+        hosts: [canonical],
+        observation: "available",
+        conflicts: [],
+        canonicalFor: (pathname) => pathname === PATHNAME ? canonical : null,
+      }),
+      proc: {
+        systemMemory: () => null,
+        ppidMap: () => new Map([[200, 100]]),
+        processMemory: () => new Map([[100, { rssBytes: 1, swapBytes: 0 }], [200, { rssBytes: 1, swapBytes: 0 }]]),
+      },
+      captureAttachReferences: () => new Map([["%1", targetRef]]),
+    }), () => null, Date.now, lastResourceBuildDiagnostic, { inProcess: true });
+
+    const stale = reader.read(true);
+    await started.promise;
+    consumeKillTarget(canonical.display);
+    release.resolve();
+    await stale;
+    expect(allowedKillTarget(canonical.display)).toBeNull();
+
+    await reader.read(true);
+    expect(allowedKillTarget(canonical.display)).toEqual(targetRef);
+  });
+
   test("nothing is killable before a snapshot exists", () => {
     noteSessionTargets([]);
     expect(allowedKillTarget("agents:1.0")).toBeNull();
@@ -396,6 +696,48 @@ describe("kill-target allowlist", () => {
 });
 
 describe("resource recurring reads", () => {
+  test("a near-limit handoff to an immediately exiting worker keeps the parent alive and releases the worker", async () => {
+    await withResourceWorkerScript((directory) => [
+      `printf '%s' "$$" > "${path.join(directory, "pid")}"`,
+      "exit 0",
+    ], async (directory) => {
+      const entrypoint = path.join(directory, "node-parent.ts");
+      const bundle = path.join(directory, "node-parent.mjs");
+      writeFileSync(entrypoint, `
+        import { createResourcesReader } from ${JSON.stringify(path.join(import.meta.dir, "resources.ts"))};
+        const diagnostic = { fresh: true, status: "complete", durationMs: 0, phases: {
+          systemMemory: 0, readFiles: 0, readHosts: 0, ppidMap: 0, processMemory: 0, attach: 0, serialization: 0,
+        } };
+        const reader = createResourcesReader(async () => ({ system: null, sessions: [] }), () => null, Date.now, () => diagnostic, {
+          readFiles: async () => [{
+            path: "/sessions/large-handoff.jsonl", parent: null, title: "x".repeat(15 * 1024 * 1024), project: "project",
+            activity: "live", mtime: 1, engine: "codex", pid: 200, proc: "running", conversationId: null,
+          }],
+          initial: {
+            generation: 1, startedAt: 1, completedAt: 2, collectorId: "durable",
+            value: { payload: { system: null, sessions: [] }, diagnostic, hostCount: 0, treeCount: 0, targets: [] },
+          },
+        });
+        const result = await reader.read(true);
+        process.stdout.write(JSON.stringify(result.diagnostic) + "\\n");
+      `);
+      const built = await Bun.build({ entrypoints: [entrypoint], outdir: directory, target: "node", format: "esm", naming: path.basename(bundle) });
+      expect(built.success).toBeTrue();
+      const child = Bun.spawn(["node", bundle], {
+        cwd: process.cwd(),
+        env: { ...process.env, LLV_RESOURCE_COLLECTOR_EXECUTABLE: path.join(directory, "fixture-worker"), PATH: "/usr/bin:/bin" },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [exit, stdout] = await Promise.all([child.exited, new Response(child.stdout).text()]);
+
+      expect(exit).toBe(0);
+      expect(JSON.parse(stdout)).toMatchObject({ degradedReason: "collector-crash" });
+      const pid = Number(readFileSync(path.join(directory, "pid"), "utf8"));
+      expect(() => process.kill(pid, 0)).toThrow();
+    });
+  });
+
   test("an incomplete observation message settles promptly with a degraded response", async () => {
     await withResourceWorkerScript([
       "trap 'exit 0' TERM INT",
@@ -453,43 +795,98 @@ describe("resource recurring reads", () => {
     });
   });
 
-  test("truncated, oversized, crash, timeout, close, and spawn errors settle and release workers", async () => {
-    const cases: Array<{ name: string; lines: (directory: string) => string[]; limits?: { timeoutMs?: number; closeTimeoutMs?: number; outputMaxBytes?: number } }> = [
+  test("an ordinary worker crash reports its typed cause, requested freshness, identity, and safe stderr", async () => {
+    await withResourceWorkerScript([
+      "printf 'API_TOKEN=super-secret\\n' >&2",
+      "exit 7",
+    ], async () => {
+      const outcome = await workerTestReader({ initial: null, collectorId: "worker:test" }).read();
+      expect(outcome.diagnostic).toMatchObject({
+        fresh: false,
+        status: "failed",
+        collectorId: "worker:test",
+        degradedReason: "collector-crash",
+        cache: { status: "miss" },
+        failure: {
+          cause: "worker-exit",
+          stderr: "API_TOKEN=<redacted>",
+        },
+      });
+    });
+  });
+
+  test("a fresh worker crash attributes its durable cache and bounds redacted stderr", async () => {
+    await withResourceWorkerScript([
+      "yes 'safe stderr line' | head -c 4096 >&2",
+      "printf '\\nPASSWORD=fresh-secret\\n' >&2",
+      "exit 7",
+    ], async () => {
+      const outcome = await workerTestReader({ collectorId: "worker:fresh-test" }).read(true);
+      expect(outcome.diagnostic).toMatchObject({
+        fresh: true,
+        status: "failed",
+        collectorId: "worker:fresh-test",
+        degradedReason: "collector-crash",
+        cache: { status: "durable", collectorId: "durable", generation: 1 },
+        failure: { cause: "worker-exit" },
+      });
+      const stderr = outcome.diagnostic.failure?.stderr ?? "";
+      expect(Buffer.byteLength(stderr)).toBe(RESOURCE_FAILURE_STDERR_MAX_BYTES);
+      expect(stderr).toContain("PASSWORD=<redacted>");
+      expect(stderr).not.toContain("fresh-secret");
+    });
+  });
+
+  test("malformed, oversized, crash, timeout, and immediate-exit paths release complete worker trees", async () => {
+    const withGrandchild = (directory: string, lines: string[]) => [
+      `printf '%s' "$$" > "${path.join(directory, "pid")}"`,
+      "sleep 60 </dev/null >/dev/null 2>&1 &",
+      `printf '%s' "$!" > "${path.join(directory, "grandchild-pid")}"`,
+      ...lines,
+    ];
+    const cases: Array<{ name: string; reason: "collector-crash" | "timeout"; cause: string; lines: (directory: string) => string[]; limits?: { timeoutMs?: number; closeTimeoutMs?: number; outputMaxBytes?: number } }> = [
       {
-        name: "truncated",
-        lines: (directory) => [
-          `printf '%s' \"$$\" > \"${path.join(directory, "pid")}\"`,
+        name: "malformed",
+        reason: "collector-crash",
+        cause: "worker-output-invalid",
+        lines: (directory) => withGrandchild(directory, [
           "trap 'exit 0' TERM INT",
-          "printf '{\"type\":\"observation\"\\n'",
+          "printf '{invalid}\\n'",
           "while :; do :; done",
-        ],
+        ]),
       },
       {
         name: "oversized",
-        lines: (directory) => [
-          `printf '%s' \"$$\" > \"${path.join(directory, "pid")}\"`,
+        reason: "collector-crash",
+        cause: "worker-output-limit",
+        lines: (directory) => withGrandchild(directory, [
           "trap 'exit 0' TERM INT",
           `printf '%s\\n' '${OVERSIZED_WORKER_MESSAGE}'`,
           "while :; do :; done",
-        ],
+        ]),
         limits: { outputMaxBytes: 1_024 },
       },
       {
         name: "crash",
-        lines: (directory) => [`printf '%s' \"$$\" > \"${path.join(directory, "pid")}\"`, "exit 7"],
+        reason: "collector-crash",
+        cause: "worker-exit",
+        lines: (directory) => withGrandchild(directory, ["exit 7"]),
       },
       {
         name: "timeout",
-        lines: (directory) => [
-          `printf '%s' \"$$\" > \"${path.join(directory, "pid")}\"`,
+        reason: "timeout",
+        cause: "worker-timeout",
+        lines: (directory) => withGrandchild(directory, [
           "trap 'exit 0' TERM INT",
           "while :; do :; done",
-        ],
+        ]),
         limits: { timeoutMs: 20, closeTimeoutMs: 20 },
       },
       {
-        name: "close",
-        lines: (directory) => [`printf '%s' \"$$\" > \"${path.join(directory, "pid")}\"`, "exit 0"],
+        name: "immediate-exit",
+        reason: "collector-crash",
+        cause: "worker-exit",
+        lines: (directory) => withGrandchild(directory, ["exit 0"]),
       },
     ];
 
@@ -500,11 +897,12 @@ describe("resource recurring reads", () => {
           new Promise<"hung">((resolve) => setTimeout(() => resolve("hung"), 500)),
         ]);
         expect(outcome === "hung", fixture.name).toBeFalse();
-        expect(outcome, fixture.name).toMatchObject({ diagnostic: { degradedReason: "collector-crash" } });
-        const pid = Number(readFileSync(path.join(directory, "pid"), "utf8"));
-        let alive = true;
-        try { process.kill(pid, 0); } catch { alive = false; }
-        expect(alive, fixture.name).toBeFalse();
+        expect(outcome, fixture.name).toMatchObject({ diagnostic: {
+          degradedReason: fixture.reason,
+          failure: { cause: fixture.cause },
+        } });
+        await expectProcessAbsentAfterQuietInterval(Number(readFileSync(path.join(directory, "pid"), "utf8")), `${fixture.name} worker`);
+        await expectProcessAbsentAfterQuietInterval(Number(readFileSync(path.join(directory, "grandchild-pid"), "utf8")), `${fixture.name} grandchild`);
       });
     }
 
@@ -516,7 +914,10 @@ describe("resource recurring reads", () => {
         new Promise<"hung">((resolve) => setTimeout(() => resolve("hung"), 500)),
       ]);
       expect(outcome === "hung").toBeFalse();
-      expect(outcome).toMatchObject({ diagnostic: { degradedReason: "collector-crash" } });
+      expect(outcome).toMatchObject({ diagnostic: {
+        degradedReason: "collector-crash",
+        failure: { cause: "worker-spawn" },
+      } });
     } finally {
       if (previousExecutable === undefined) delete process.env.LLV_RESOURCE_COLLECTOR_EXECUTABLE;
       else process.env.LLV_RESOURCE_COLLECTOR_EXECUTABLE = previousExecutable;
@@ -684,8 +1085,38 @@ describe("resource recurring reads", () => {
       ]);
 
       expect(outcome === "hung").toBeFalse();
-      expect(outcome).toMatchObject({ diagnostic: { degradedReason: "collector-busy" } });
+      expect(outcome).toMatchObject({ diagnostic: { degradedReason: "timeout", failure: { cause: "file-handoff-timeout" } } });
       expect(existsSync(path.join(directory, "workers"))).toBeFalse();
+    });
+  });
+
+  test("an expired fresh handoff recovers on the next request without spawning late work", async () => {
+    await withResourceWorkerScript((directory) => [
+      `printf x >> "${path.join(directory, "workers")}"`,
+      `printf '%s\\n' '${EMPTY_FRESH_WORKER_MESSAGE}'`,
+    ], async (directory) => {
+      const first = deferred<never[]>();
+      let handoffs = 0;
+      const reader = workerTestReader({
+        readFiles: async () => {
+          handoffs += 1;
+          return handoffs === 1 ? first.promise : [];
+        },
+        workerLimits: { inputTimeoutMs: 20 },
+      });
+
+      const expired = await Promise.race([
+        reader.read(true),
+        new Promise<"hung">((resolve) => setTimeout(() => resolve("hung"), 100)),
+      ]);
+      expect(expired === "hung").toBeFalse();
+      expect(expired).toMatchObject({ diagnostic: { degradedReason: "timeout", failure: { cause: "file-handoff-timeout" } } });
+
+      await reader.read(true);
+      expect(readFileSync(path.join(directory, "workers"), "utf8")).toBe("x");
+      first.resolve([]);
+      await new Promise((resolve) => setTimeout(resolve, 30));
+      expect(readFileSync(path.join(directory, "workers"), "utf8")).toBe("x");
     });
   });
 

--- a/src/lib/resources.test.ts
+++ b/src/lib/resources.test.ts
@@ -1,11 +1,56 @@
 import { describe, expect, test } from "bun:test";
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
 
 import type { TranscriptHost } from "@/lib/agent/transcriptHost";
 import type { FileEntry, ResourcesPayload } from "@/lib/types";
 
-import { allowedKillTarget, applyResourceTargets, buildResourceSnapshot, canonicalResourceEntry, conflictingResourceHost, consumeKillTarget, createResourcesReader, lastResourceBuildDiagnostic, noteSessionTargets, parseResourcesFixture, resetResourcesForTests } from "./resources";
+import { allowedKillTarget, applyResourceTargets, buildResourceSnapshot, canonicalResourceEntry, conflictingResourceHost, consumeKillTarget, createResourcesReader, lastResourceBuildDiagnostic, noteSessionTargets, parsePersistedResourceObservation, parseResourcesFixture, resetResourcesForTests, RESOURCE_OBSERVATION_MAX_BYTES, RESOURCE_WORKER_OUTPUT_MAX_BYTES } from "./resources";
 
 const PATHNAME = "/home/user/.codex/sessions/2026/07/10/rollout-2026-07-10-019f4906-3f67-7b72-9fbc-9ec3b5ad1326.jsonl";
+const EMPTY_WORKER_MESSAGE = JSON.stringify({
+  type: "observation",
+  payload: { system: null, sessions: [] },
+  diagnostic: {
+    fresh: false,
+    status: "complete",
+    durationMs: 0,
+    phases: { systemMemory: 0, readFiles: 0, readHosts: 0, ppidMap: 0, processMemory: 0, attach: 0, serialization: 0 },
+  },
+  targets: [],
+});
+const EMPTY_FRESH_WORKER_MESSAGE = EMPTY_WORKER_MESSAGE.replace('"fresh":false', '"fresh":true');
+const FAILED_FRESH_WORKER_MESSAGE = EMPTY_FRESH_WORKER_MESSAGE.replace('"status":"complete"', '"status":"failed"');
+const UNBOUND_TARGET_WORKER_MESSAGE = JSON.stringify({
+  ...JSON.parse(EMPTY_FRESH_WORKER_MESSAGE),
+  targets: [{ target: "agents:9.0", ref: ref(900, 999, "%9") }],
+});
+const OVERSIZED_WORKER_MESSAGE = JSON.stringify({
+  type: "observation",
+  payload: { system: null, sessions: [{
+    target: "agents:1.0",
+    panePid: 100,
+    path: null,
+    engine: "codex",
+    hostConflict: false,
+    title: "x".repeat(2_048),
+    project: null,
+    activity: null,
+    lastActiveAt: null,
+    cwd: "/repo",
+    rssBytes: 1,
+    swapBytes: 0,
+    procCount: 1,
+  }] },
+  diagnostic: {
+    fresh: true,
+    status: "complete",
+    durationMs: 0,
+    phases: { systemMemory: 0, readFiles: 0, readHosts: 0, ppidMap: 0, processMemory: 0, attach: 0, serialization: 0 },
+  },
+  targets: [],
+});
 
 const entry: FileEntry = {
   path: PATHNAME,
@@ -70,7 +115,81 @@ function deferred<T>() {
   return { promise, resolve, reject };
 }
 
+async function withResourceWorkerScript<T>(
+  lines: string[] | ((directory: string) => string[]),
+  task: (directory: string) => Promise<T>,
+): Promise<T> {
+  const directory = mkdtempSync(path.join(os.tmpdir(), "llv-resource-worker-"));
+  const executable = path.join(directory, "fixture-worker");
+  const body = typeof lines === "function" ? lines(directory) : lines;
+  writeFileSync(executable, ["#!/bin/sh", ...body, ""].join("\n"));
+  chmodSync(executable, 0o700);
+  const previousExecutable = process.env.LLV_RESOURCE_COLLECTOR_EXECUTABLE;
+  process.env.LLV_RESOURCE_COLLECTOR_EXECUTABLE = executable;
+  try {
+    return await task(directory);
+  } finally {
+    if (previousExecutable === undefined) delete process.env.LLV_RESOURCE_COLLECTOR_EXECUTABLE;
+    else process.env.LLV_RESOURCE_COLLECTOR_EXECUTABLE = previousExecutable;
+    rmSync(directory, { recursive: true, force: true });
+  }
+}
+
+function workerTestReader(options: Parameters<typeof createResourcesReader>[4] = {}) {
+  const payload: ResourcesPayload = { system: null, sessions: [] };
+  const diagnostic = { fresh: true, status: "complete" as const, durationMs: 0, phases: {
+    systemMemory: 0, readFiles: 0, readHosts: 0, ppidMap: 0, processMemory: 0, attach: 0, serialization: 0,
+  } };
+  return createResourcesReader(async () => payload, () => null, Date.now, () => diagnostic, {
+    readFiles: async () => [],
+    initial: {
+      generation: 1,
+      startedAt: 1,
+      completedAt: 2,
+      collectorId: "durable",
+      value: { payload, diagnostic, hostCount: 0, treeCount: 0, targets: [] },
+    },
+    ...options,
+  });
+}
+
 describe("resource observation", () => {
+  test("the collector child leaves shared state byte-identical", async () => {
+    const directory = mkdtempSync(path.join(os.tmpdir(), "llv-resource-purity-"));
+    const home = path.join(directory, "home");
+    const state = path.join(directory, "state");
+    mkdirSync(home, { recursive: true });
+    mkdirSync(state, { recursive: true });
+    const staleRegistryTemp = path.join(state, "agent-registry.json.99999999.00000000-0000-4000-8000-000000000000.tmp");
+    const scanSentinel = path.join(state, "files-scan-snapshot.json");
+    writeFileSync(staleRegistryTemp, "stale-temp-sentinel\n");
+    writeFileSync(scanSentinel, "scan-byte-sentinel\n");
+    const before = readFileSync(scanSentinel);
+    const env: Record<string, string | undefined> = { ...process.env, HOME: home, LLV_STATE_DIR: state, LLV_AGENT_REGISTRY_SQLITE: "off" };
+    delete env.LLV_RESOURCE_COLLECTOR_IN_PROCESS;
+    const child = Bun.spawn([process.execPath, path.join(process.cwd(), "src/lib/resourceCollector.worker.ts")], {
+      cwd: process.cwd(),
+      env,
+      stdin: new Blob(["{\"type\":\"collect\",\"fresh\":false,\"files\":[]}\n"]),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    try {
+      const exit = await Promise.race([
+        child.exited,
+        new Promise<"timeout">((resolve) => setTimeout(() => resolve("timeout"), 5_000)),
+      ]);
+      if (exit === "timeout") child.kill("SIGKILL");
+      expect(exit).toBe(0);
+      expect(existsSync(staleRegistryTemp)).toBeTrue();
+      expect(readFileSync(scanSentinel)).toEqual(before);
+    } finally {
+      child.kill("SIGKILL");
+      await child.exited;
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
   test("builds host ownership and metadata from one shared transcript generation", async () => {
     let scans = 0;
     let processTableReads = 0;
@@ -131,7 +250,7 @@ describe("resource observation", () => {
       swapBytes: 6,
       procCount: 3,
     }]);
-    expect(allowedKillTarget("agents:4.0")).toBeNull();
+    expect(allowedKillTarget("agents:4.0")).toEqual(ref(900, 100, "%1"));
     expect(lastResourceBuildDiagnostic()).toEqual(expect.objectContaining({
       fresh: true,
       status: "complete",
@@ -160,6 +279,50 @@ describe("resource observation", () => {
 
     expect(parseResourcesFixture(JSON.stringify(fixture))).toEqual(fixture);
     expect(() => parseResourcesFixture('{"system":{"ramTotal":-1},"sessions":[]}')).toThrow("invalid resources fixture");
+  });
+
+  test("durable and worker framing bounds align at the exact declared limit", () => {
+    const session = {
+      target: "agents:1.0",
+      panePid: 100,
+      path: null,
+      engine: "codex" as const,
+      hostConflict: false,
+      title: "",
+      project: null,
+      activity: null,
+      lastActiveAt: null,
+      cwd: "/repo",
+      rssBytes: 1,
+      swapBytes: 0,
+      procCount: 1,
+    };
+    const diagnostic = {
+      fresh: false,
+      status: "complete" as const,
+      durationMs: 0,
+      phases: { systemMemory: 0, readFiles: 0, readHosts: 0, ppidMap: 0, processMemory: 0, attach: 0, serialization: 0 },
+    };
+    const observation = {
+      generation: 1,
+      startedAt: 1,
+      completedAt: 2,
+      collectorId: "worker:1",
+      value: { payload: { system: null, sessions: [session] }, diagnostic, hostCount: 1, treeCount: 1, targets: [] },
+    };
+    const base = JSON.stringify({ version: 1, observation }) + "\n";
+    session.title = "x".repeat(RESOURCE_OBSERVATION_MAX_BYTES - Buffer.byteLength(base));
+    const boundary = JSON.stringify({ version: 1, observation }) + "\n";
+    const workerFrame = JSON.stringify({ type: "observation", payload: observation.value.payload, diagnostic, targets: [] }) + "\n";
+
+    expect(Buffer.byteLength(boundary)).toBe(RESOURCE_OBSERVATION_MAX_BYTES);
+    expect(parsePersistedResourceObservation(boundary)).toMatchObject({ generation: 1 });
+    expect(Buffer.byteLength(workerFrame) <= RESOURCE_WORKER_OUTPUT_MAX_BYTES).toBeTrue();
+
+    session.title += "x";
+    const overLimit = JSON.stringify({ version: 1, observation }) + "\n";
+    expect(Buffer.byteLength(overLimit)).toBe(RESOURCE_OBSERVATION_MAX_BYTES + 1);
+    expect(parsePersistedResourceObservation(overLimit)).toBeNull();
   });
 
   test("attributes a duplicated transcript only to the shared canonical host", () => {
@@ -233,6 +396,133 @@ describe("kill-target allowlist", () => {
 });
 
 describe("resource recurring reads", () => {
+  test("an incomplete observation message settles promptly with a degraded response", async () => {
+    await withResourceWorkerScript([
+      "trap 'exit 0' TERM INT",
+      "printf '{\"type\":\"observation\"}\\n'",
+      "while :; do sleep 0.01; done",
+    ], async () => {
+      const reader = workerTestReader();
+      const outcome = await Promise.race([
+        reader.read(true),
+        new Promise<"hung">((resolve) => setTimeout(() => resolve("hung"), 250)),
+      ]);
+
+      expect(outcome === "hung").toBeFalse();
+      expect(outcome).toMatchObject({
+        payload: { system: null, sessions: [] },
+        diagnostic: { degradedReason: "collector-crash" },
+      });
+    });
+  });
+
+  test("an observation with invalid nested types settles promptly with a degraded response", async () => {
+    await withResourceWorkerScript([
+      "trap 'exit 0' TERM INT",
+      "printf '{\"type\":\"observation\",\"payload\":{\"system\":null,\"sessions\":\"invalid\"},\"diagnostic\":{},\"targets\":[]}\\n'",
+      "while :; do sleep 0.01; done",
+    ], async () => {
+      const reader = workerTestReader();
+      const outcome = await Promise.race([
+        reader.read(true),
+        new Promise<"hung">((resolve) => setTimeout(() => resolve("hung"), 250)),
+      ]);
+
+      expect(outcome === "hung").toBeFalse();
+      expect(outcome).toMatchObject({ diagnostic: { degradedReason: "collector-crash" } });
+    });
+  });
+
+  test("semantically invalid observations cannot publish kill targets or failed builds", async () => {
+    for (const message of [UNBOUND_TARGET_WORKER_MESSAGE, FAILED_FRESH_WORKER_MESSAGE]) {
+      await withResourceWorkerScript([
+        `printf '%s\\n' '${message}'`,
+      ], async () => {
+        const outcome = await workerTestReader().read(true);
+        expect(outcome).toMatchObject({ diagnostic: { degradedReason: "collector-crash" } });
+      });
+    }
+  });
+
+  test("a fresh request rejects an observation labeled as ordinary", async () => {
+    await withResourceWorkerScript([
+      `printf '%s\\n' '${EMPTY_WORKER_MESSAGE}'`,
+    ], async () => {
+      const outcome = await workerTestReader().read(true);
+      expect(outcome).toMatchObject({ diagnostic: { degradedReason: "collector-crash" } });
+    });
+  });
+
+  test("truncated, oversized, crash, timeout, close, and spawn errors settle and release workers", async () => {
+    const cases: Array<{ name: string; lines: (directory: string) => string[]; limits?: { timeoutMs?: number; closeTimeoutMs?: number; outputMaxBytes?: number } }> = [
+      {
+        name: "truncated",
+        lines: (directory) => [
+          `printf '%s' \"$$\" > \"${path.join(directory, "pid")}\"`,
+          "trap 'exit 0' TERM INT",
+          "printf '{\"type\":\"observation\"\\n'",
+          "while :; do :; done",
+        ],
+      },
+      {
+        name: "oversized",
+        lines: (directory) => [
+          `printf '%s' \"$$\" > \"${path.join(directory, "pid")}\"`,
+          "trap 'exit 0' TERM INT",
+          `printf '%s\\n' '${OVERSIZED_WORKER_MESSAGE}'`,
+          "while :; do :; done",
+        ],
+        limits: { outputMaxBytes: 1_024 },
+      },
+      {
+        name: "crash",
+        lines: (directory) => [`printf '%s' \"$$\" > \"${path.join(directory, "pid")}\"`, "exit 7"],
+      },
+      {
+        name: "timeout",
+        lines: (directory) => [
+          `printf '%s' \"$$\" > \"${path.join(directory, "pid")}\"`,
+          "trap 'exit 0' TERM INT",
+          "while :; do :; done",
+        ],
+        limits: { timeoutMs: 20, closeTimeoutMs: 20 },
+      },
+      {
+        name: "close",
+        lines: (directory) => [`printf '%s' \"$$\" > \"${path.join(directory, "pid")}\"`, "exit 0"],
+      },
+    ];
+
+    for (const fixture of cases) {
+      await withResourceWorkerScript(fixture.lines, async (directory) => {
+        const outcome = await Promise.race([
+          workerTestReader({ workerLimits: fixture.limits }).read(true),
+          new Promise<"hung">((resolve) => setTimeout(() => resolve("hung"), 500)),
+        ]);
+        expect(outcome === "hung", fixture.name).toBeFalse();
+        expect(outcome, fixture.name).toMatchObject({ diagnostic: { degradedReason: "collector-crash" } });
+        const pid = Number(readFileSync(path.join(directory, "pid"), "utf8"));
+        let alive = true;
+        try { process.kill(pid, 0); } catch { alive = false; }
+        expect(alive, fixture.name).toBeFalse();
+      });
+    }
+
+    const previousExecutable = process.env.LLV_RESOURCE_COLLECTOR_EXECUTABLE;
+    process.env.LLV_RESOURCE_COLLECTOR_EXECUTABLE = path.join(os.tmpdir(), "missing-resource-worker-executable");
+    try {
+      const outcome = await Promise.race([
+        workerTestReader().read(true),
+        new Promise<"hung">((resolve) => setTimeout(() => resolve("hung"), 500)),
+      ]);
+      expect(outcome === "hung").toBeFalse();
+      expect(outcome).toMatchObject({ diagnostic: { degradedReason: "collector-crash" } });
+    } finally {
+      if (previousExecutable === undefined) delete process.env.LLV_RESOURCE_COLLECTOR_EXECUTABLE;
+      else process.env.LLV_RESOURCE_COLLECTOR_EXECUTABLE = previousExecutable;
+    }
+  });
+
   test("persists each completed generation once across ordinary reads", async () => {
     let now = 0;
     let builds = 0;
@@ -242,7 +532,10 @@ describe("resource recurring reads", () => {
       return { system: null, sessions: [] };
     }, () => null, () => now, () => ({ fresh: true, status: "complete", durationMs: 0, phases: {
       systemMemory: 0, readFiles: 0, readHosts: 0, ppidMap: 0, processMemory: 0, attach: 0, serialization: 0,
-    } }), { inProcess: true, persist: (observation) => persisted.push(observation.generation) });
+    } }), { inProcess: true, persist: (observation) => {
+      persisted.push(observation.generation);
+      return true;
+    } });
 
     await reader.read();
     await reader.read();
@@ -256,6 +549,181 @@ describe("resource recurring reads", () => {
     await reader.read(true);
     expect(persisted).toEqual([1, 3]);
     expect(builds).toBe(3);
+  });
+
+  test("a failed durable write retries on a later read of the same generation", async () => {
+    let attempts = 0;
+    const reader = createResourcesReader(async () => ({ system: null, sessions: [] }), () => null, Date.now, () => ({
+      fresh: true,
+      status: "complete",
+      durationMs: 0,
+      phases: { systemMemory: 0, readFiles: 0, readHosts: 0, ppidMap: 0, processMemory: 0, attach: 0, serialization: 0 },
+    }), {
+      inProcess: true,
+      persist: () => {
+        attempts += 1;
+        return attempts > 1;
+      },
+    });
+
+    await reader.read();
+    expect(attempts).toBe(1);
+    await reader.read();
+    expect(attempts).toBe(2);
+  });
+
+  test("an initial durable observation seeds the persistence guard", async () => {
+    let attempts = 0;
+    const reader = workerTestReader({
+      inProcess: true,
+      persist: () => {
+        attempts += 1;
+        return true;
+      },
+    });
+
+    await reader.read();
+    expect(attempts).toBe(0);
+  });
+
+  test("twelve concurrent cold ordinary polls share one collection", async () => {
+    const collection = deferred<ResourcesPayload>();
+    let builds = 0;
+    const reader = createResourcesReader(async () => {
+      builds += 1;
+      return collection.promise;
+    }, () => null, Date.now, () => ({ fresh: true, status: "complete", durationMs: 0, phases: {
+      systemMemory: 0, readFiles: 0, readHosts: 0, ppidMap: 0, processMemory: 0, attach: 0, serialization: 0,
+    } }), { inProcess: true });
+
+    const polls = Array.from({ length: 12 }, () => reader.read());
+    await Promise.resolve();
+    expect(builds).toBe(1);
+    collection.resolve({ system: null, sessions: [] });
+    await Promise.all(polls);
+    expect(builds).toBe(1);
+  });
+
+  test("twelve concurrent off-process polls share one worker and one Viewer-main file handoff", async () => {
+    await withResourceWorkerScript((directory) => [
+      `printf x >> "${path.join(directory, "workers")}\"`,
+      `printf '%s\\n' '${EMPTY_WORKER_MESSAGE}'`,
+    ], async (directory) => {
+      const fileFreshness: boolean[] = [];
+      const reader = createResourcesReader(async () => ({ system: null, sessions: [] }), () => null, Date.now, () => null, {
+        readFiles: async (fresh) => {
+          fileFreshness.push(fresh);
+          return [];
+        },
+      });
+
+      const reads = await Promise.all(Array.from({ length: 12 }, () => reader.read()));
+      expect(readFileSync(path.join(directory, "workers"), "utf8")).toBe("x");
+      expect(fileFreshness).toEqual([false]);
+      expect(reads.every((read) => read.diagnostic.degradedReason === undefined)).toBeTrue();
+    });
+  });
+
+  test("duplicate bundled resource modules share one versioned reader", async () => {
+    await withResourceWorkerScript((directory) => [
+      `printf x >> "${path.join(directory, "workers")}\"`,
+      `printf '%s\\n' '${EMPTY_WORKER_MESSAGE}'`,
+    ], async (directory) => {
+      const previousHome = process.env.HOME;
+      const previousState = process.env.LLV_STATE_DIR;
+      const home = path.join(directory, "home");
+      const state = path.join(directory, "state");
+      mkdirSync(home, { recursive: true });
+      mkdirSync(state, { recursive: true });
+      writeFileSync(path.join(state, "files-scan-snapshot.json"), JSON.stringify({
+        version: 1,
+        snapshot: { complete: true, files: [], projectCatalog: [] },
+      }));
+      process.env.HOME = home;
+      process.env.LLV_STATE_DIR = state;
+      const scanCache = await import("./scanner/scanCache");
+      let first: typeof import("./resources") | undefined;
+      try {
+        scanCache.resetFilesRouteCacheForTests();
+        const modulePath = path.join(import.meta.dir, "resources.ts");
+        first = await import(`${modulePath}?reader-copy=first-${Date.now()}`) as typeof import("./resources");
+        const second = await import(`${modulePath}?reader-copy=second-${Date.now()}`) as typeof import("./resources");
+        first.resetResourcesForTests();
+        const [left, right] = await Promise.all([
+          first.readResourcesWithDiagnostic(),
+          second.readResourcesWithDiagnostic(),
+        ]);
+
+        expect(readFileSync(path.join(directory, "workers"), "utf8")).toBe("x");
+        expect(left.diagnostic.collectorId).toBe(right.diagnostic.collectorId);
+        expect(left.diagnostic.generation).toBe(right.diagnostic.generation);
+      } finally {
+        first?.resetResourcesForTests();
+        scanCache.resetFilesRouteCacheForTests();
+        if (previousHome === undefined) delete process.env.HOME;
+        else process.env.HOME = previousHome;
+        if (previousState === undefined) delete process.env.LLV_STATE_DIR;
+        else process.env.LLV_STATE_DIR = previousState;
+      }
+    });
+  });
+
+  test("a missing ordinary Viewer-main file handoff degrades within its bound without spawning a worker", async () => {
+    await withResourceWorkerScript((directory) => [
+      `printf x >> "${path.join(directory, "workers")}\"`,
+      `printf '%s\\n' '${EMPTY_WORKER_MESSAGE}'`,
+    ], async (directory) => {
+      const missing = deferred<never>();
+      const reader = createResourcesReader(async () => ({ system: null, sessions: [] }), () => null, Date.now, () => null, {
+        readFiles: async () => missing.promise,
+        workerLimits: { inputTimeoutMs: 20 },
+      });
+      const outcome = await Promise.race([
+        reader.read(),
+        new Promise<"hung">((resolve) => setTimeout(() => resolve("hung"), 100)),
+      ]);
+
+      expect(outcome === "hung").toBeFalse();
+      expect(outcome).toMatchObject({ diagnostic: { degradedReason: "collector-busy" } });
+      expect(existsSync(path.join(directory, "workers"))).toBeFalse();
+    });
+  });
+
+  test("overlapping fresh polls share one post-fence collection", async () => {
+    const collection = deferred<ResourcesPayload>();
+    let builds = 0;
+    const reader = createResourcesReader(async () => {
+      builds += 1;
+      return collection.promise;
+    }, () => null, Date.now, () => ({ fresh: true, status: "complete", durationMs: 0, phases: {
+      systemMemory: 0, readFiles: 0, readHosts: 0, ppidMap: 0, processMemory: 0, attach: 0, serialization: 0,
+    } }), { inProcess: true });
+
+    const polls = Array.from({ length: 12 }, () => reader.read(true));
+    await Promise.resolve();
+    expect(builds).toBe(1);
+    collection.resolve({ system: null, sessions: [] });
+    await Promise.all(polls);
+    expect(builds).toBe(1);
+  });
+
+  test("overlapping fresh off-process polls share one worker and preserve the fresh handoff", async () => {
+    await withResourceWorkerScript((directory) => [
+      `printf x >> "${path.join(directory, "workers")}\"`,
+      `printf '%s\\n' '${EMPTY_FRESH_WORKER_MESSAGE}'`,
+    ], async (directory) => {
+      const fileFreshness: boolean[] = [];
+      const reader = workerTestReader({
+        readFiles: async (fresh) => {
+          fileFreshness.push(fresh);
+          return [];
+        },
+      });
+
+      await Promise.all(Array.from({ length: 12 }, () => reader.read(true)));
+      expect(readFileSync(path.join(directory, "workers"), "utf8")).toBe("x");
+      expect(fileFreshness).toEqual([true]);
+    });
   });
 
   test("expired ordinary reads return the cached snapshot while one rebuild runs, and fresh waits for a newer build", async () => {

--- a/src/lib/resources.test.ts
+++ b/src/lib/resources.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, test } from "bun:test";
 import type { TranscriptHost } from "@/lib/agent/transcriptHost";
 import type { FileEntry, ResourcesPayload } from "@/lib/types";
 
-import { allowedKillTarget, buildResourceSnapshot, canonicalResourceEntry, conflictingResourceHost, consumeKillTarget, createResourcesReader, lastResourceBuildDiagnostic, noteSessionTargets, parseResourcesFixture } from "./resources";
+import { allowedKillTarget, applyResourceTargets, buildResourceSnapshot, canonicalResourceEntry, conflictingResourceHost, consumeKillTarget, createResourcesReader, lastResourceBuildDiagnostic, noteSessionTargets, parseResourcesFixture, resetResourcesForTests } from "./resources";
 
 const PATHNAME = "/home/user/.codex/sessions/2026/07/10/rollout-2026-07-10-019f4906-3f67-7b72-9fbc-9ec3b5ad1326.jsonl";
 
@@ -204,37 +204,49 @@ describe("kill-target allowlist", () => {
     expect(allowedKillTarget("agents:1.0")).toBeNull();
     expect(allowedKillTarget("agents:2.0")).toEqual(ref(900, 222, "%22"));
   });
+
+  test("an older observation cannot re-arm a concurrently consumed target", () => {
+    applyResourceTargets(2, [{ target: "agents:1.0", ref: ref(900, 111, "%11") }]);
+    consumeKillTarget("agents:1.0");
+    applyResourceTargets(1, [{ target: "agents:1.0", ref: ref(900, 111, "%11") }]);
+    expect(allowedKillTarget("agents:1.0")).toBeNull();
+  });
+
+  test("a reset drops the global reader, diagnostics, and allowlist", () => {
+    noteSessionTargets([{ target: "agents:1.0", ref: ref(900, 111, "%11") }]);
+    resetResourcesForTests();
+    expect(allowedKillTarget("agents:1.0")).toBeNull();
+    expect(lastResourceBuildDiagnostic()).toBeNull();
+  });
 });
 
 describe("resource recurring reads", () => {
   test("expired ordinary reads return the cached snapshot while one rebuild runs, and fresh waits for a newer build", async () => {
     let now = 0;
     let builds = 0;
-    const ordinary = deferred<ResourcesPayload>();
     const fresh = deferred<ResourcesPayload>();
     const cached: ResourcesPayload = { system: null, sessions: [] };
-    const ordinaryResult: ResourcesPayload = { system: null, sessions: [{ target: "agents:2.0", panePid: 2, path: null, engine: "codex", hostConflict: false, title: null, project: null, activity: null, lastActiveAt: null, cwd: "/repo", rssBytes: 2, swapBytes: 0, procCount: 1 }] };
     const freshResult: ResourcesPayload = { system: null, sessions: [{ target: "agents:3.0", panePid: 3, path: null, engine: "codex", hostConflict: false, title: null, project: null, activity: null, lastActiveAt: null, cwd: "/repo", rssBytes: 3, swapBytes: 0, procCount: 1 }] };
-    const reader = createResourcesReader(async (forceFresh) => {
+    const reader = createResourcesReader(async () => {
       builds += 1;
       if (builds === 1) return cached;
-      return forceFresh ? fresh.promise : ordinary.promise;
-    }, () => null, () => now);
+      return fresh.promise;
+    }, () => null, () => now, () => ({ fresh: true, status: "complete", durationMs: 0, phases: {
+      systemMemory: 0, readFiles: 0, readHosts: 0, ppidMap: 0, processMemory: 0, attach: 0, serialization: 0,
+    } }), { inProcess: true });
 
-    expect(await reader.read()).toEqual(cached);
+    expect((await reader.read()).payload).toEqual(cached);
     now = 10_000;
-    expect(await reader.read()).toEqual(cached);
+    expect((await reader.read()).payload).toEqual(cached);
     await Promise.resolve();
     expect(builds).toBe(2);
-    expect(await reader.read()).toEqual(cached);
+    expect((await reader.read()).payload).toEqual(cached);
     expect(builds).toBe(2);
 
     const forced = reader.read(true);
-    ordinary.resolve(ordinaryResult);
     await new Promise<void>((resolve) => setImmediate(resolve));
-    expect(builds).toBe(3);
     fresh.resolve(freshResult);
-    expect(await forced).toEqual(freshResult);
+    expect((await forced).payload).toEqual(freshResult);
   });
 
   test("a failed ordinary rebuild leaves the cached snapshot available and later polls retry", async () => {
@@ -247,15 +259,17 @@ describe("resource recurring reads", () => {
       if (builds === 1) return cached;
       if (builds === 2) throw new Error("transient resource build failure");
       return recovered.promise;
-    }, () => null, () => now);
+    }, () => null, () => now, () => ({ fresh: true, status: "complete", durationMs: 0, phases: {
+      systemMemory: 0, readFiles: 0, readHosts: 0, ppidMap: 0, processMemory: 0, attach: 0, serialization: 0,
+    } }), { inProcess: true });
 
     await reader.read();
     now = 10_000;
-    expect(await reader.read()).toEqual(cached);
+    expect((await reader.read()).payload).toEqual(cached);
     await new Promise<void>((resolve) => setImmediate(resolve));
     await Promise.resolve();
     expect(builds).toBe(2);
-    expect(await reader.read()).toEqual(cached);
+    expect((await reader.read()).payload).toEqual(cached);
     await Promise.resolve();
     expect(builds).toBe(3);
     recovered.resolve(cached);

--- a/src/lib/resources.test.ts
+++ b/src/lib/resources.test.ts
@@ -722,30 +722,51 @@ describe("resource observation", () => {
     expect(snapshot.canonicalFor(secondPath)).toBeNull();
   });
 
-  test("worker launch selection preserves Docker Bun and supports a Node-only bundle", () => {
-    const cwd = "/package";
-    const sourceWorker = "/package/src/lib/resourceCollector.worker.ts";
-    const bundledWorker = "/package/.next/server/resource-collector-worker.js";
+  test("worker launch selection pairs existing workers with source, standalone, and prepack runtimes", () => {
+    const sourceCwd = "/checkout";
+    const standaloneCwd = "/checkout/.next/standalone";
+    const prepackCwd = "/extracted/dist/standalone";
+    const sourceWorker = `${sourceCwd}/src/lib/resourceCollector.worker.ts`;
+    const sourceBundle = `${sourceCwd}/.next/server/resource-collector-worker.js`;
+    const standaloneBundle = `${standaloneCwd}/.next/server/resource-collector-worker.js`;
+    const prepackBundle = `${prepackCwd}/.next/server/resource-collector-worker.js`;
     const bunContainer = "/usr/local/bin/bun-container";
+    const resolve = (cwd: string, present: string[], env: NodeJS.ProcessEnv = { NODE_ENV: "test" }) => resolveResourceWorkerLaunch({
+      cwd,
+      env,
+      execPath: "/usr/bin/node",
+      exists: (pathname) => present.includes(pathname),
+    });
 
-    expect(resolveResourceWorkerLaunch({
-      cwd,
-      env: { NODE_ENV: "test", LLV_RESOURCE_COLLECTOR_EXECUTABLE: "/fixture/worker" },
-      execPath: "/usr/bin/node",
-      exists: () => false,
+    expect(resolve(sourceCwd, [sourceWorker, sourceBundle, bunContainer])).toEqual({ executable: bunContainer, workerPath: sourceWorker });
+    expect(resolve(sourceCwd, [sourceWorker, sourceBundle])).toEqual({ executable: "/usr/bin/node", workerPath: sourceBundle });
+    expect(resolve(sourceCwd, [sourceWorker])).toEqual({ executable: "bun", workerPath: sourceWorker });
+    expect(resolve(sourceCwd, [sourceWorker], {
+      NODE_ENV: "test",
+      LLV_RESOURCE_COLLECTOR_EXECUTABLE: "/fixture/worker",
     })).toEqual({ executable: "/fixture/worker", workerPath: sourceWorker });
-    expect(resolveResourceWorkerLaunch({
-      cwd,
-      env: { NODE_ENV: "test" },
-      execPath: "/usr/bin/node",
-      exists: (pathname) => pathname === bunContainer || pathname === bundledWorker,
-    })).toEqual({ executable: bunContainer, workerPath: sourceWorker });
-    expect(resolveResourceWorkerLaunch({
-      cwd,
-      env: { NODE_ENV: "test" },
-      execPath: "/usr/bin/node",
-      exists: (pathname) => pathname === bundledWorker,
-    })).toEqual({ executable: "/usr/bin/node", workerPath: bundledWorker });
+    expect(resolve(sourceCwd, [sourceWorker, sourceBundle], {
+      NODE_ENV: "test",
+      LLV_RESOURCE_COLLECTOR_EXECUTABLE: "/usr/bin/node",
+    })).toEqual({ executable: "/usr/bin/node", workerPath: sourceBundle });
+
+    for (const [layout, cwd, bundle] of [
+      ["standalone", standaloneCwd, standaloneBundle],
+      ["prepack", prepackCwd, prepackBundle],
+    ] as const) {
+      expect(resolve(cwd, [bundle, bunContainer]), `${layout} with bun-container`).toEqual({
+        executable: "/usr/bin/node",
+        workerPath: bundle,
+      });
+      expect(resolve(cwd, [bundle]), `${layout} without bun-container`).toEqual({
+        executable: "/usr/bin/node",
+        workerPath: bundle,
+      });
+      expect(resolve(cwd, [bundle], {
+        NODE_ENV: "test",
+        LLV_RESOURCE_COLLECTOR_EXECUTABLE: "/fixture/worker",
+      }), `${layout} executable override`).toEqual({ executable: "/fixture/worker", workerPath: bundle });
+    }
   });
 });
 
@@ -1389,9 +1410,7 @@ describe("resource recurring reads", () => {
             '  const stdio = pipes === "inherited" ? ["ignore", "inherit", "inherit"] : "ignore";',
             '  const child = spawn(process.execPath, [escapedScript, escapedPid, escapedReady], { detached: true, stdio });',
             '  child.unref();',
-            '  const deadline = Date.now() + 100;',
-            '  while (!fs.existsSync(escapedReady) && Date.now() < deadline) {}',
-            '  setTimeout(() => process.exit(0), 20);',
+            '  process.exit(0);',
             '});',
             'setInterval(() => {}, 1_000);',
             '',
@@ -2390,15 +2409,20 @@ describe("resource recurring reads", () => {
     expect(builds).toBe(3);
   });
 
-  test("a failed ordinary rebuild leaves the cached snapshot available and later polls retry", async () => {
+  test("failed ordinary rebuilds retain their latest sanitized diagnostic until recovery", async () => {
     let now = 0;
     let builds = 0;
     const recovered = deferred<ResourcesPayload>();
     const cached: ResourcesPayload = { system: null, sessions: [] };
+    const recoveredPayload: ResourcesPayload = {
+      system: null,
+      sessions: [{ target: "agents:4.0", panePid: 4, path: null, engine: "codex", hostConflict: false, title: null, project: null, activity: null, lastActiveAt: null, cwd: "/repo", rssBytes: 4, swapBytes: 0, procCount: 1 }],
+    };
     const reader = createResourcesReader(async () => {
       builds += 1;
       if (builds === 1) return cached;
-      if (builds === 2) throw new Error("transient resource build failure");
+      if (builds === 2) throw new Error("Authorization: Bearer FIRST_BACKGROUND_LEAK FIRST_TAIL");
+      if (builds === 3) throw new Error("PASSWORD=SECOND_BACKGROUND_LEAK");
       return recovered.promise;
     }, () => null, () => now, () => ({ fresh: true, status: "complete", durationMs: 0, phases: {
       systemMemory: 0, readFiles: 0, readHosts: 0, ppidMap: 0, processMemory: 0, attach: 0, serialization: 0,
@@ -2410,10 +2434,43 @@ describe("resource recurring reads", () => {
     await new Promise<void>((resolve) => setImmediate(resolve));
     await Promise.resolve();
     expect(builds).toBe(2);
-    expect((await reader.read()).payload).toEqual(cached);
+
+    const firstFailure = await reader.read();
+    expect(firstFailure.payload).toEqual(cached);
+    expect(firstFailure.diagnostic).toMatchObject({
+      fresh: false,
+      status: "failed",
+      degradedReason: "collector-crash",
+      cache: { status: "memory", generation: 1 },
+      failure: { cause: "collector-error", causes: ["Authorization=<redacted>"] },
+    });
+    expect(JSON.stringify(firstFailure.diagnostic)).not.toContain("FIRST_BACKGROUND_LEAK");
+    expect(JSON.stringify(firstFailure.diagnostic)).not.toContain("FIRST_TAIL");
+    await new Promise<void>((resolve) => setImmediate(resolve));
     await Promise.resolve();
     expect(builds).toBe(3);
-    recovered.resolve(cached);
+
+    const secondFailure = await reader.read();
+    expect(secondFailure.payload).toEqual(cached);
+    expect(secondFailure.diagnostic).toMatchObject({
+      fresh: false,
+      status: "failed",
+      degradedReason: "collector-crash",
+      failure: { cause: "collector-error", causes: ["PASSWORD=<redacted>"] },
+    });
+    expect(JSON.stringify(secondFailure.diagnostic)).not.toContain("SECOND_BACKGROUND_LEAK");
+    const overlapping = await reader.read();
+    expect(overlapping.diagnostic.failure).toEqual(secondFailure.diagnostic.failure);
+    expect(builds).toBe(4);
+
+    recovered.resolve(recoveredPayload);
+    await new Promise<void>((resolve) => setImmediate(resolve));
     await Promise.resolve();
+    const healthy = await reader.read();
+    expect(healthy.payload).toEqual(recoveredPayload);
+    expect(healthy.diagnostic.status).toBe("complete");
+    expect(healthy.diagnostic.degradedReason).toBeUndefined();
+    expect(healthy.diagnostic.failure).toBeUndefined();
+    expect(builds).toBe(4);
   });
 });

--- a/src/lib/resources.ts
+++ b/src/lib/resources.ts
@@ -399,9 +399,34 @@ const RESOURCE_OBSERVATION_SCHEMA_VERSION = 1;
 const RESOURCE_OBSERVATION_FILE = "resources-observation.json";
 export const RESOURCE_OBSERVATION_MAX_BYTES = 16 * 1024 * 1024;
 export const RESOURCE_WORKER_OUTPUT_MAX_BYTES = RESOURCE_OBSERVATION_MAX_BYTES + RESOURCE_WORKER_FRAME_HEADROOM_BYTES;
+const RESOURCE_WORKER_SUPERVISOR_EXIT_GRACE_MS = 50;
+const RESOURCE_WORKER_SUPERVISOR = `
+const { spawn } = require("node:child_process");
+const child = spawn(process.argv[1], process.argv.slice(2), { stdio: "inherit" });
+let finished = false;
+const finish = (code, signal) => {
+  if (finished) return;
+  finished = true;
+  setTimeout(() => {
+    if (signal) process.kill(process.pid, signal);
+    else process.exit(code ?? 1);
+  }, ${RESOURCE_WORKER_SUPERVISOR_EXIT_GRACE_MS});
+};
+child.once("error", () => finish(127, null));
+child.once("exit", finish);
+`;
 const RESOURCE_OBSERVATION_MAX_SESSIONS = 10_000;
 const RESOURCE_OBSERVATION_MAX_TARGETS = 10_000;
 const RESOURCE_READER_VERSION = 2;
+
+function resourceWorkerExecutableCanBeSupervised(executable: string): boolean {
+  try {
+    const stat = statSync(executable);
+    return stat.isFile() && (stat.mode & 0o111) !== 0;
+  } catch {
+    return false;
+  }
+}
 
 type ResourceWorkerLimits = Partial<{
   observeTimeoutMs: number;
@@ -777,9 +802,13 @@ async function collectResourcesInWorker(
     closeTimeoutMs,
     limits.cleanupTimeoutMs ?? closeTimeoutMs + Math.floor(headroomMs / 2),
   );
+  const cleanupAbsenceConfirmationMs = Math.min(25, Math.max(5, closeTimeoutMs));
   const settlementHeadroomMs = Math.max(
-    0,
-    headroomMs - Math.max(0, cleanupTimeoutMs - closeTimeoutMs),
+    Math.min(250, Math.ceil(observeTimeoutMs * 0.2)),
+    RESOURCE_WORKER_SUPERVISOR_EXIT_GRACE_MS + cleanupAbsenceConfirmationMs + Math.max(
+      0,
+      headroomMs - Math.max(0, cleanupTimeoutMs - closeTimeoutMs),
+    ),
   );
   const workerBudgetMs = Math.max(
     0,
@@ -809,17 +838,24 @@ async function collectResourcesInWorker(
       "resource collector input exceeded transport limit",
     );
   }
-  const worker = spawn(launch.executable, [launch.workerPath], {
-    cwd: process.cwd(),
-    detached: true,
-    stdio: ["pipe", "pipe", "pipe"],
-  });
+  const superviseWorker = processRuntime === defaultResourceWorkerProcessRuntime
+    && resourceWorkerExecutableCanBeSupervised(launch.executable);
+  const worker = spawn(
+    superviseWorker ? process.execPath : launch.executable,
+    superviseWorker ? ["-e", RESOURCE_WORKER_SUPERVISOR, launch.executable, launch.workerPath] : [launch.workerPath],
+    {
+      cwd: process.cwd(),
+      detached: true,
+      stdio: ["pipe", "pipe", "pipe"],
+    },
+  );
   return new Promise<CollectedResources>((resolve, reject) => {
     const pid = worker.pid;
     const expectedIdentity = typeof pid === "number" ? processRuntime.processIdentity(pid) : null;
     const groupEstablished = typeof pid === "number"
       && expectedIdentity !== null
-      && processRuntime.processGroupId(pid) === pid;
+      && processRuntime.processGroupId(pid) === pid
+      && processRuntime.processIdentity(pid) === expectedIdentity;
     type WorkerOutcome =
       | { type: "success"; value: CollectedResources }
       | {
@@ -840,10 +876,14 @@ async function collectResourcesInWorker(
     let killTimer: ReturnType<typeof setTimeout> | undefined;
     let cleanupDeadlineTimer: ReturnType<typeof setTimeout> | undefined;
     let cleanupPoll: ReturnType<typeof setTimeout> | undefined;
+    let cleanupAbsentSince: number | null = null;
     let cleanupStarted = false;
     let cleanupComplete = false;
     let cleanupIssue: unknown;
     let cleanupFailure: Error | null = null;
+    let cleanupVerificationFailed = false;
+    let groupContinuityLost = false;
+    let groupSignalSent = false;
     let leaderExited = false;
     let workerClosed = false;
     let streamsDetached = false;
@@ -862,6 +902,10 @@ async function collectResourcesInWorker(
     const rememberCleanupIssue = (error: unknown) => {
       cleanupIssue ??= error;
     };
+    const failCleanupVerification = (message: string) => {
+      cleanupVerificationFailed = true;
+      rememberCleanupIssue(new Error(message));
+    };
     const finishStderr = () => {
       if (stderrEnded) return;
       stderrEnded = true;
@@ -871,40 +915,90 @@ async function collectResourcesInWorker(
       for (const timer of ownershipTimers) clearTimeout(timer);
       ownershipTimers.length = 0;
     };
-    const refreshOwnedProcesses = () => {
-      if (typeof pid !== "number" || expectedIdentity === null) return;
-      if (processRuntime.processIdentity(pid) !== expectedIdentity) return;
-      try {
-        for (const descendant of processRuntime.descendants(pid)) {
-          if (ownedProcesses.has(descendant)) continue;
-          const identity = processRuntime.processIdentity(descendant);
-          if (identity !== null) ownedProcesses.set(descendant, identity);
-        }
-      } catch (error) {
-        rememberCleanupIssue(error);
+    const retainLiveGroupMembers = () => {
+      if (!groupEstablished || groupContinuityLost || groupSignalSent || leaderExited
+        || typeof pid !== "number" || expectedIdentity === null) return;
+      if (processRuntime.processIdentity(pid) !== expectedIdentity) {
+        groupContinuityLost = true;
+        failCleanupVerification("resource collector worker group leader identity changed");
+        return;
       }
-    };
-    const retainContinuousGroupMembers = () => {
-      if (!leaderExited || !groupEstablished || typeof pid !== "number" || expectedIdentity === null) return;
       let members: number[];
       try {
         members = processRuntime.processGroupMembers(pid);
       } catch (error) {
+        groupContinuityLost = true;
+        failCleanupVerification("resource collector worker group membership could not be inspected");
         rememberCleanupIssue(error);
         return;
       }
-      if (members.includes(pid) && processRuntime.processIdentity(pid) !== expectedIdentity) {
-        rememberCleanupIssue(new Error("resource collector worker group leader identity changed"));
+      if (!members.includes(pid)) {
+        groupContinuityLost = true;
+        failCleanupVerification("resource collector worker group continuity was lost");
         return;
       }
-      const identities = members.map((member) => [member, processRuntime.processIdentity(member)] as const);
-      if (identities.some(([, identity]) => identity === null)) {
-        rememberCleanupIssue(new Error("resource collector worker group member identity is unavailable"));
+      const observed: Array<readonly [number, string]> = [];
+      for (const member of members) {
+        const identity = processRuntime.processIdentity(member);
+        if (identity === null || processRuntime.processGroupId(member) !== pid
+          || processRuntime.processIdentity(member) !== identity) {
+          continue;
+        }
+        observed.push([member, identity]);
+      }
+      if (processRuntime.processIdentity(pid) !== expectedIdentity) {
+        groupContinuityLost = true;
+        failCleanupVerification("resource collector worker group leader identity changed");
         return;
       }
-      for (const [member, identity] of identities) {
-        if (!ownedProcesses.has(member)) ownedProcesses.set(member, identity!);
+      for (const [member, identity] of observed) {
+        const prior = ownedProcesses.get(member);
+        if (prior !== undefined && prior !== identity) {
+          groupContinuityLost = true;
+          failCleanupVerification("resource collector worker group member identity changed");
+          return;
+        }
+        ownedProcesses.set(member, identity);
       }
+    };
+    const refreshOwnedProcesses = (): boolean => {
+      let discovered = false;
+      const pending = [...ownedProcesses.keys()];
+      const inspected = new Set<number>();
+      while (pending.length > 0) {
+        const root = pending.pop()!;
+        if (inspected.has(root)) continue;
+        inspected.add(root);
+        const rootIdentity = ownedProcesses.get(root);
+        if (rootIdentity === undefined || processRuntime.processIdentity(root) !== rootIdentity) continue;
+        let descendants: number[];
+        try {
+          descendants = processRuntime.descendants(root);
+        } catch (error) {
+          rememberCleanupIssue(error);
+          continue;
+        }
+        if (processRuntime.processIdentity(root) !== rootIdentity) continue;
+        for (const descendant of descendants) {
+          if (descendant === root) continue;
+          const identity = processRuntime.processIdentity(descendant);
+          if (identity === null
+            || processRuntime.processIdentity(root) !== rootIdentity
+            || processRuntime.processIdentity(descendant) !== identity) continue;
+          const prior = ownedProcesses.get(descendant);
+          if (prior !== undefined && prior !== identity) {
+            failCleanupVerification("resource collector descendant identity was recycled");
+            continue;
+          }
+          if (prior === undefined) {
+            ownedProcesses.set(descendant, identity);
+            discovered = true;
+          }
+          pending.push(descendant);
+        }
+      }
+      retainLiveGroupMembers();
+      return discovered;
     };
     const ownedProcessState = () => {
       const active: number[] = [];
@@ -926,38 +1020,52 @@ async function collectResourcesInWorker(
         return "present";
       } catch (error) {
         const code = (error as NodeJS.ErrnoException).code;
-        if (code === "ESRCH") return "absent";
+        if (code === "ESRCH") {
+          if (!groupSignalSent) groupContinuityLost = true;
+          return "absent";
+        }
         if (code === "EPERM") return "present";
         rememberCleanupIssue(error);
         return "unknown";
       }
     };
-    const workerGroupOwned = (active: readonly number[]): boolean => {
-      if (typeof pid !== "number" || expectedIdentity === null) return false;
-      for (const ownedPid of active) {
-        if (processRuntime.processGroupId(ownedPid) === pid) return true;
+    const workerGroupOwned = (): boolean => {
+      if (!groupEstablished || groupContinuityLost || typeof pid !== "number" || expectedIdentity === null) return false;
+      for (const [member, identity] of ownedProcesses) {
+        if (processRuntime.processIdentity(member) === identity
+          && processRuntime.processGroupId(member) === pid
+          && processRuntime.processIdentity(member) === identity) return true;
       }
       return false;
     };
     const signalOwnedCleanup = (signal: NodeJS.Signals) => {
       refreshOwnedProcesses();
-      retainContinuousGroupMembers();
       const state = ownedProcessState();
       const group = probeWorkerGroup();
       if (group === "present") {
-        if (workerGroupOwned(state.active)) {
+        if (workerGroupOwned()) {
           try {
             processRuntime.signal(-pid!, signal);
+            groupSignalSent = true;
           } catch (error) {
             if ((error as NodeJS.ErrnoException).code !== "ESRCH") rememberCleanupIssue(error);
           }
         } else {
-          rememberCleanupIssue(new Error("resource collector worker group ownership could not be verified"));
+          if (groupSignalSent) {
+            rememberCleanupIssue(new Error("resource collector worker group ownership could not be verified"));
+          } else {
+            failCleanupVerification("resource collector worker group ownership could not be verified");
+          }
         }
       }
       for (const ownedPid of state.active) {
         const identity = ownedProcesses.get(ownedPid);
-        if (identity === undefined || processRuntime.processIdentity(ownedPid) !== identity) continue;
+        if (identity === undefined || processRuntime.processIdentity(ownedPid) !== identity) {
+          if (!groupSignalSent) {
+            failCleanupVerification("resource collector worker identity changed before individual cleanup");
+          }
+          continue;
+        }
         try {
           processRuntime.signal(ownedPid, signal);
         } catch (error) {
@@ -967,7 +1075,14 @@ async function collectResourcesInWorker(
     };
     const cleanupIsAbsent = (): boolean => {
       const state = ownedProcessState();
-      return probeWorkerGroup() === "absent" && state.active.length === 0 && !state.uncertain;
+      const absent = probeWorkerGroup() === "absent" && state.active.length === 0 && !state.uncertain;
+      if (absent && cleanupVerificationFailed && cleanupFailure === null) {
+        cleanupFailure = new Error(
+          "resource collector worker cleanup ownership verification failed",
+          cleanupIssue === undefined ? undefined : { cause: cleanupIssue },
+        );
+      }
+      return absent;
     };
     const releaseWorkerHandles = () => {
       if (streamsDetached) return;
@@ -1016,7 +1131,11 @@ async function collectResourcesInWorker(
     };
     const confirmCleanup = () => {
       if (!cleanupStarted || cleanupComplete) return;
-      if (cleanupIsAbsent()) {
+      if (refreshOwnedProcesses()) cleanupAbsentSince = null;
+      const absent = cleanupIsAbsent();
+      if (!absent) cleanupAbsentSince = null;
+      else if (cleanupAbsentSince === null) cleanupAbsentSince = Date.now();
+      if (absent && Date.now() - cleanupAbsentSince! >= cleanupAbsenceConfirmationMs) {
         cleanupComplete = true;
         if (killTimer) clearTimeout(killTimer);
         if (cleanupPoll) clearTimeout(cleanupPoll);
@@ -1057,7 +1176,7 @@ async function collectResourcesInWorker(
       terminate();
     };
     refreshOwnedProcesses();
-    for (const delay of [0, 5, 20]) {
+    for (const delay of [0, 5, 20, 40]) {
       const timer = setTimeout(() => {
         if (!cleanupStarted && !leaderExited) refreshOwnedProcesses();
       }, delay);

--- a/src/lib/resources.ts
+++ b/src/lib/resources.ts
@@ -708,8 +708,12 @@ async function collectResourcesInWorker(
     const stderrTail = createResourceDiagnosticTail();
     const stderrDecoder = new StringDecoder("utf8");
     let closeTimer: ReturnType<typeof setTimeout> | undefined;
+    let cleanupPoll: ReturnType<typeof setTimeout> | undefined;
     let cleanupStarted = false;
+    let cleanupComplete = false;
     let leaderExited = false;
+    let workerClosed = false;
+    let settled = false;
     const workerFailure = (
       reason: ResourceDegradedReason,
       cause: ResourceFailureCause,
@@ -737,12 +741,35 @@ async function collectResourcesInWorker(
       }
       return true;
     };
+    const settleIfReady = () => {
+      if (settled || !outcome || !workerClosed || !cleanupComplete) return;
+      settled = true;
+      outcome();
+    };
+    const confirmWorkerGroupAbsent = () => {
+      if (!cleanupStarted || cleanupComplete) return;
+      if (!workerGroupExists()) {
+        cleanupComplete = true;
+        if (closeTimer) clearTimeout(closeTimer);
+        if (cleanupPoll) clearTimeout(cleanupPoll);
+        settleIfReady();
+        return;
+      }
+      cleanupPoll = setTimeout(confirmWorkerGroupAbsent, 5);
+    };
     const terminate = () => {
-      if (cleanupStarted || !signalWorkerGroup("SIGTERM")) return;
+      if (cleanupStarted) return;
       cleanupStarted = true;
+      if (!signalWorkerGroup("SIGTERM")) {
+        cleanupComplete = true;
+        settleIfReady();
+        return;
+      }
       closeTimer = setTimeout(() => {
         if (workerGroupExists()) signalWorkerGroup("SIGKILL");
+        confirmWorkerGroupAbsent();
       }, closeTimeoutMs);
+      confirmWorkerGroupAbsent();
     };
     const finish = (next: () => void) => {
       if (outcome) return;
@@ -769,6 +796,7 @@ async function collectResourcesInWorker(
     worker.once("close", (code, signal) => {
       clearTimeout(timeout);
       stderrTail.append(stderrDecoder.end());
+      workerClosed = true;
       if (!outcome) {
         outcome = () => reject(workerFailure(
           "collector-crash",
@@ -777,8 +805,8 @@ async function collectResourcesInWorker(
         ));
         terminate();
       }
-      if (closeTimer && !workerGroupExists()) clearTimeout(closeTimer);
-      outcome();
+      confirmWorkerGroupAbsent();
+      settleIfReady();
     });
     let output = "";
     worker.stdout.setEncoding("utf8");

--- a/src/lib/resources.ts
+++ b/src/lib/resources.ts
@@ -1,7 +1,7 @@
 import { procBackend } from "@/lib/proc";
 import type { ProcBackend } from "@/lib/proc";
 import { readFileSync } from "node:fs";
-import { currentFileScan } from "@/lib/scanner/scanCache";
+import { completedFileScan, currentFileScan } from "@/lib/scanner/scanCache";
 import { createFreshAwareCoalescer, type FreshAwareCoalescer } from "@/lib/asyncCoalescer";
 import { descendantPids } from "@/lib/proc/memory";
 import { overlaySessionTitles } from "@/lib/session/titleProjection";
@@ -128,11 +128,16 @@ export interface ResourceSnapshotDependencies {
 }
 
 const resourceSnapshotDependencies: ResourceSnapshotDependencies = {
-  readFiles: async (fresh) => (await currentFileScan({ fresh })).snapshot.files,
+  readFiles: readResourceFileSnapshot,
   readHosts: readTranscriptHosts,
   proc: procBackend,
   captureAttachReference: captureTmuxAttachReference,
 };
+
+export async function readResourceFileSnapshot(fresh: boolean): Promise<FileEntry[]> {
+  const scan = fresh ? await currentFileScan({ fresh: true }) : await completedFileScan();
+  return scan.snapshot.files;
+}
 
 /** `fresh` advances the shared file scan and skips the pane/agent-process
     memos. A rebuild triggered right after a kill must use one newer corpus for

--- a/src/lib/resources.ts
+++ b/src/lib/resources.ts
@@ -8,8 +8,8 @@ import { StringDecoder } from "node:string_decoder";
 import { completedFileScan, currentFileScan } from "@/lib/scanner/scanCache";
 import {
   createResourceCollector,
+  createResourceDiagnosticTail,
   ResourceCollectorFailureError,
-  RESOURCE_FAILURE_STDERR_MAX_BYTES,
   type ResourceCollectorResult,
   type ResourceDegradedReason,
   type ResourceFailureCause,
@@ -387,9 +387,13 @@ export type CollectedResources = {
 };
 
 const RESOURCE_OBSERVE_TIMEOUT_MS = 30_000;
-const RESOURCE_WORKER_TIMEOUT_MS = 29_500;
-const RESOURCE_WORKER_CLOSE_TIMEOUT_MS = 1_000;
 const RESOURCE_FILE_HANDOFF_TIMEOUT_MS = 500;
+const RESOURCE_WORKER_CLOSE_TIMEOUT_MS = 1_000;
+const RESOURCE_OBSERVE_HEADROOM_MS = 500;
+const RESOURCE_WORKER_TIMEOUT_MS = RESOURCE_OBSERVE_TIMEOUT_MS
+  - RESOURCE_FILE_HANDOFF_TIMEOUT_MS
+  - RESOURCE_WORKER_CLOSE_TIMEOUT_MS
+  - RESOURCE_OBSERVE_HEADROOM_MS;
 const RESOURCE_WORKER_FRAME_HEADROOM_BYTES = 64 * 1_024;
 const RESOURCE_OBSERVATION_SCHEMA_VERSION = 1;
 const RESOURCE_OBSERVATION_FILE = "resources-observation.json";
@@ -400,9 +404,11 @@ const RESOURCE_OBSERVATION_MAX_TARGETS = 10_000;
 const RESOURCE_READER_VERSION = 2;
 
 type ResourceWorkerLimits = Partial<{
+  observeTimeoutMs: number;
   inputTimeoutMs: number;
   timeoutMs: number;
   closeTimeoutMs: number;
+  headroomMs: number;
   outputMaxBytes: number;
 }>;
 
@@ -660,6 +666,12 @@ async function collectResourcesInWorker(
   targetEpoch = globalStore.__llvResourceTargetEpoch ?? 0,
 ): Promise<CollectedResources> {
   const launch = resolveResourceWorkerLaunch();
+  const observeTimeoutMs = limits.observeTimeoutMs ?? RESOURCE_OBSERVE_TIMEOUT_MS;
+  const inputTimeoutMs = limits.inputTimeoutMs ?? RESOURCE_FILE_HANDOFF_TIMEOUT_MS;
+  const closeTimeoutMs = limits.closeTimeoutMs ?? RESOURCE_WORKER_CLOSE_TIMEOUT_MS;
+  const headroomMs = limits.headroomMs ?? RESOURCE_OBSERVE_HEADROOM_MS;
+  const workerBudgetMs = Math.max(0, observeTimeoutMs - inputTimeoutMs - closeTimeoutMs - headroomMs);
+  const timeoutMs = Math.min(limits.timeoutMs ?? RESOURCE_WORKER_TIMEOUT_MS, workerBudgetMs);
   const filesTask = readFiles(fresh);
   let inputTimer: ReturnType<typeof setTimeout> | undefined;
   const files = await Promise.race([
@@ -669,15 +681,13 @@ async function collectResourcesInWorker(
         "timeout",
         "file-handoff-timeout",
         "resource collector file handoff timed out",
-      )), limits.inputTimeoutMs ?? RESOURCE_FILE_HANDOFF_TIMEOUT_MS);
+      )), inputTimeoutMs);
     }),
   ]).finally(() => {
     if (inputTimer) clearTimeout(inputTimer);
   });
   const request = JSON.stringify({ type: "collect", fresh, files }) + "\n";
   const outputMaxBytes = limits.outputMaxBytes ?? RESOURCE_WORKER_OUTPUT_MAX_BYTES;
-  const timeoutMs = limits.timeoutMs ?? RESOURCE_WORKER_TIMEOUT_MS;
-  const closeTimeoutMs = limits.closeTimeoutMs ?? RESOURCE_WORKER_CLOSE_TIMEOUT_MS;
   if (Buffer.byteLength(request) > RESOURCE_WORKER_OUTPUT_MAX_BYTES) {
     throw new ResourceCollectorFailureError(
       "collector-crash",
@@ -695,25 +705,17 @@ async function collectResourcesInWorker(
     const expectedIdentity = typeof pid === "number" ? procBackend.processIdentity(pid) : null;
     let outcome: (() => void) | null = null;
     let outputBytes = 0;
-    let stderrTail = "";
+    const stderrTail = createResourceDiagnosticTail();
     const stderrDecoder = new StringDecoder("utf8");
     let closeTimer: ReturnType<typeof setTimeout> | undefined;
     let cleanupStarted = false;
     let leaderExited = false;
-    const appendStderr = (value: string) => {
-      stderrTail += value;
-      let start = stderrTail.length - (RESOURCE_FAILURE_STDERR_MAX_BYTES * 2);
-      if (start <= 0) return;
-      const first = stderrTail.charCodeAt(start);
-      if (first >= 0xdc00 && first <= 0xdfff) start += 1;
-      stderrTail = stderrTail.slice(start);
-    };
     const workerFailure = (
       reason: ResourceDegradedReason,
       cause: ResourceFailureCause,
       message: string,
       error?: unknown,
-    ) => new ResourceCollectorFailureError(reason, cause, message, { cause: error, stderr: stderrTail });
+    ) => new ResourceCollectorFailureError(reason, cause, message, { cause: error, stderr: stderrTail.value() });
     const sameWorker = () => typeof pid === "number"
       && (expectedIdentity === null || procBackend.processIdentity(pid) === expectedIdentity);
     const workerGroupExists = () => {
@@ -766,7 +768,7 @@ async function collectResourcesInWorker(
     });
     worker.once("close", (code, signal) => {
       clearTimeout(timeout);
-      appendStderr(stderrDecoder.end());
+      stderrTail.append(stderrDecoder.end());
       if (!outcome) {
         outcome = () => reject(workerFailure(
           "collector-crash",
@@ -838,7 +840,7 @@ async function collectResourcesInWorker(
     });
     worker.stderr.on("data", (chunk: Buffer) => {
       outputBytes += chunk.length;
-      appendStderr(stderrDecoder.write(chunk));
+      stderrTail.append(stderrDecoder.write(chunk));
       if (outputBytes > outputMaxBytes) {
         finish(() => reject(workerFailure(
           "collector-crash",
@@ -1009,7 +1011,11 @@ export function createResourcesReader(
       }, captureSystem, false, true);
     }
     const fence = fresh ? collector.fence() : -1;
-    const result = await collector.observe(fence, RESOURCE_OBSERVE_TIMEOUT_MS, fresh);
+    const result = await collector.observe(
+      fence,
+      options.workerLimits?.observeTimeoutMs ?? RESOURCE_OBSERVE_TIMEOUT_MS,
+      fresh,
+    );
     if (result.observation && !result.failure) persist(result.observation);
     return resourceReadFromResult(result, captureSystem, fresh);
   };

--- a/src/lib/resources.ts
+++ b/src/lib/resources.ts
@@ -2,7 +2,7 @@ import { procBackend } from "@/lib/proc";
 import type { ProcBackend } from "@/lib/proc";
 import { readFileSync } from "node:fs";
 import { completedFileScan, currentFileScan } from "@/lib/scanner/scanCache";
-import { createFreshAwareCoalescer, type FreshAwareCoalescer } from "@/lib/asyncCoalescer";
+import { createFreshAwareCoalescer } from "@/lib/asyncCoalescer";
 import { descendantPids } from "@/lib/proc/memory";
 import { overlaySessionTitles } from "@/lib/session/titleProjection";
 import { readTranscriptHosts, type TranscriptHost, type TranscriptHostSnapshot } from "@/lib/agent/transcriptHost";
@@ -19,6 +19,46 @@ import type { FileEntry, ResourceSession, ResourcesPayload } from "./types";
  */
 
 const CACHE_MS = 10_000;
+
+type ResourceBuildPhase = "systemMemory" | "readFiles" | "readHosts" | "ppidMap" | "processMemory" | "attach" | "serialization";
+type ResourceBuildPhases = Record<ResourceBuildPhase, number>;
+
+export type ResourceBuildDiagnostic = {
+  fresh: boolean;
+  status: "complete" | "failed";
+  durationMs: number;
+  phases: ResourceBuildPhases;
+};
+
+function emptyResourceBuildPhases(): ResourceBuildPhases {
+  return {
+    systemMemory: 0,
+    readFiles: 0,
+    readHosts: 0,
+    ppidMap: 0,
+    processMemory: 0,
+    attach: 0,
+    serialization: 0,
+  };
+}
+
+function measureResourcePhase<T>(phases: ResourceBuildPhases, phase: ResourceBuildPhase, work: () => T): T {
+  const startedAt = performance.now();
+  try {
+    return work();
+  } finally {
+    phases[phase] += performance.now() - startedAt;
+  }
+}
+
+async function measureResourcePhaseAsync<T>(phases: ResourceBuildPhases, phase: ResourceBuildPhase, work: () => Promise<T>): Promise<T> {
+  const startedAt = performance.now();
+  try {
+    return await work();
+  } finally {
+    phases[phase] += performance.now() - startedAt;
+  }
+}
 
 function finiteNonNegative(value: unknown): value is number {
   return typeof value === "number" && Number.isFinite(value) && value >= 0;
@@ -58,14 +98,22 @@ function captureSystemMemory(proc: Pick<ProcBackend, "systemMemory"> = procBacke
 export type KillTargetRef = TmuxAttachReference;
 
 const globalStore = globalThis as unknown as {
-  __llvResourcesCache?: { at: number; data: ResourcesPayload } | null;
-  __llvResourcesBuildCoordinator?: FreshAwareCoalescer<ResourcesPayload>;
+  __llvResourcesReader?: ResourcesReader;
   __llvResourceTargets?: Map<string, KillTargetRef>;
+  __llvLastResourceBuild?: ResourceBuildDiagnostic;
 };
 
-function resourceBuildCoordinator(): FreshAwareCoalescer<ResourcesPayload> {
-  globalStore.__llvResourcesBuildCoordinator ??= createFreshAwareCoalescer<ResourcesPayload>();
-  return globalStore.__llvResourcesBuildCoordinator;
+export function lastResourceBuildDiagnostic(): ResourceBuildDiagnostic | null {
+  const diagnostic = globalStore.__llvLastResourceBuild;
+  return diagnostic ? { ...diagnostic, phases: { ...diagnostic.phases } } : null;
+}
+
+/** Captures JSON response construction separately from the expensive resource
+    build phases, keeping response serialization visible in live diagnostics. */
+export function noteResourceSerialization(durationMs: number): void {
+  if (globalStore.__llvLastResourceBuild) {
+    globalStore.__llvLastResourceBuild.phases.serialization = durationMs;
+  }
 }
 
 /**
@@ -146,78 +194,126 @@ export async function buildResourceSnapshot(
   fresh: boolean,
   dependencies: ResourceSnapshotDependencies = resourceSnapshotDependencies,
 ): Promise<ResourcesPayload> {
-  const system = captureSystemMemory(dependencies.proc);
-
-  const files = await dependencies.readFiles(fresh);
-  const hosts = await dependencies.readHosts(fresh, files);
-  const sessions: ResourceSession[] = [];
-  if (hosts.hosts.length > 0) {
-    const ppids = dependencies.proc.ppidMap();
-    overlaySessionTitles(files);
-    const byPath = new Map(files.map((entry) => [entry.path, entry]));
-    const byPane = new Map<string, TranscriptHost[]>();
-    for (const host of hosts.hosts) {
-      const paneHosts = byPane.get(host.paneId);
-      if (paneHosts) paneHosts.push(host);
-      else byPane.set(host.paneId, [host]);
-    }
-
-    /* Trees first, memory second: one processMemory() batch over the union
-       keeps the portable backend at a single `ps` spawn for all panes. */
-    const paneTrees: Array<{ host: TranscriptHost; tree: number[]; paneHosts: TranscriptHost[] }> = [];
-    const treePids = new Set<number>();
-    for (const paneHosts of byPane.values()) {
-      const host = paneHosts[0]!;
-      const tree = descendantPids(host.panePid, ppids);
-      paneTrees.push({ host, tree, paneHosts });
-      for (const pid of tree) treePids.add(pid);
-    }
-    const memory = dependencies.proc.processMemory(treePids);
-
-    const killRefs: Array<{ target: string; ref: KillTargetRef }> = [];
-    for (const { host, tree, paneHosts } of paneTrees) {
-      let rssBytes = 0;
-      let swapBytes = 0;
-      for (const pid of tree) {
-        const mem = memory.get(pid);
-        if (!mem) continue;
-        rssBytes += mem.rssBytes;
-        swapBytes += mem.swapBytes;
+  const startedAt = performance.now();
+  const phases = emptyResourceBuildPhases();
+  try {
+    const system = measureResourcePhase(phases, "systemMemory", () => captureSystemMemory(dependencies.proc));
+    const files = await measureResourcePhaseAsync(phases, "readFiles", () => dependencies.readFiles(fresh));
+    const hosts = await measureResourcePhaseAsync(phases, "readHosts", () => dependencies.readHosts(fresh, files));
+    const sessions: ResourceSession[] = [];
+    if (hosts.hosts.length > 0) {
+      const ppids = measureResourcePhase(phases, "ppidMap", () => dependencies.proc.ppidMap());
+      overlaySessionTitles(files);
+      const byPath = new Map(files.map((entry) => [entry.path, entry]));
+      const byPane = new Map<string, TranscriptHost[]>();
+      for (const host of hosts.hosts) {
+        const paneHosts = byPane.get(host.paneId);
+        if (paneHosts) paneHosts.push(host);
+        else byPane.set(host.paneId, [host]);
       }
-      /* The resolver elects one canonical host for every transcript. A
-         duplicate pane stays visible for cleanup, though it carries no path
-         and cannot disagree with path-addressed delivery. */
-      const entry = canonicalResourceEntry(hosts, paneHosts, byPath);
-      sessions.push({
-        target: host.display,
-        panePid: host.panePid,
-        path: entry?.path ?? null,
-        engine: host.engine,
-        hostConflict: conflictingResourceHost(hosts, host),
-        title: entry?.title ?? null,
-        project: entry?.project || null,
-        activity: entry?.activity ?? null,
-        lastActiveAt: entry ? isoFromUnix(entry.mtime) : null,
-        cwd: host.cwd,
-        rssBytes,
-        swapBytes,
-        procCount: tree.length,
+
+      /* Trees first, memory second: one processMemory() batch over the union
+         keeps the portable backend at a single `ps` spawn for all panes. */
+      const paneTrees: Array<{ host: TranscriptHost; tree: number[]; paneHosts: TranscriptHost[] }> = [];
+      const treePids = new Set<number>();
+      for (const paneHosts of byPane.values()) {
+        const host = paneHosts[0]!;
+        const tree = descendantPids(host.panePid, ppids);
+        paneTrees.push({ host, tree, paneHosts });
+        for (const pid of tree) treePids.add(pid);
+      }
+      const memory = measureResourcePhase(phases, "processMemory", () => dependencies.proc.processMemory(treePids));
+
+      const killRefs: Array<{ target: string; ref: KillTargetRef }> = [];
+      measureResourcePhase(phases, "attach", () => {
+        for (const { host, tree, paneHosts } of paneTrees) {
+          let rssBytes = 0;
+          let swapBytes = 0;
+          for (const pid of tree) {
+            const mem = memory.get(pid);
+            if (!mem) continue;
+            rssBytes += mem.rssBytes;
+            swapBytes += mem.swapBytes;
+          }
+          /* The resolver elects one canonical host for every transcript. A
+             duplicate pane stays visible for cleanup, though it carries no path
+             and cannot disagree with path-addressed delivery. */
+          const entry = canonicalResourceEntry(hosts, paneHosts, byPath);
+          sessions.push({
+            target: host.display,
+            panePid: host.panePid,
+            path: entry?.path ?? null,
+            engine: host.engine,
+            hostConflict: conflictingResourceHost(hosts, host),
+            title: entry?.title ?? null,
+            project: entry?.project || null,
+            activity: entry?.activity ?? null,
+            lastActiveAt: entry ? isoFromUnix(entry.mtime) : null,
+            cwd: host.cwd,
+            rssBytes,
+            swapBytes,
+            procCount: tree.length,
+          });
+          killRefs.push({
+            target: host.display,
+            ref: dependencies.captureAttachReference({ tmuxServerPid: host.tmuxServerPid, panePid: host.panePid, paneId: host.paneId }),
+          });
+        }
       });
-      killRefs.push({
-        target: host.display,
-        ref: dependencies.captureAttachReference({ tmuxServerPid: host.tmuxServerPid, panePid: host.panePid, paneId: host.paneId }),
-      });
+      sessions.sort((a, b) => b.rssBytes + b.swapBytes - (a.rssBytes + a.swapBytes));
+      noteSessionTargets(killRefs);
+    } else {
+      noteSessionTargets([]);
     }
-    sessions.sort((a, b) => b.rssBytes + b.swapBytes - (a.rssBytes + a.swapBytes));
-    noteSessionTargets(killRefs);
-  } else {
-    noteSessionTargets([]);
+
+    globalStore.__llvLastResourceBuild = { fresh, status: "complete", durationMs: performance.now() - startedAt, phases };
+    return { system, sessions };
+  } catch (error) {
+    globalStore.__llvLastResourceBuild = { fresh, status: "failed", durationMs: performance.now() - startedAt, phases };
+    throw error;
   }
+}
+
+export interface ResourcesReader {
+  read(fresh?: boolean): Promise<ResourcesPayload>;
+}
+
+export function createResourcesReader(
+  build: (fresh: boolean) => Promise<ResourcesPayload>,
+  captureSystem: () => ResourcesPayload["system"],
+  now: () => number = Date.now,
+): ResourcesReader {
+  let cached: { at: number; data: ResourcesPayload } | null = null;
+  const coordinator = createFreshAwareCoalescer<ResourcesPayload>();
+  const rebuild = async (fresh: boolean): Promise<ResourcesPayload> => {
+    const data = await build(fresh);
+    cached = { at: now(), data };
+    return data;
+  };
 
   return {
-    system,
-    sessions,
+    async read(fresh = false): Promise<ResourcesPayload> {
+      if (!fresh && cached) {
+        if (now() - cached.at >= CACHE_MS) {
+          /* A stale resource poll only starts the shared rebuild. The cached
+             session snapshot stays available while filesystem, process, and
+             tmux observations run off the request path. */
+          void coordinator.run(false, rebuild).catch(() => undefined);
+        }
+        return { ...cached.data, system: captureSystem() };
+      }
+      const data = await coordinator.run(fresh, rebuild);
+      return fresh ? data : { ...data, system: captureSystem() };
+    },
   };
+}
+
+function resourcesReader(): ResourcesReader {
+  globalStore.__llvResourcesReader ??= createResourcesReader(
+    buildResourceSnapshot,
+    () => captureSystemMemory(),
+  );
+  return globalStore.__llvResourcesReader;
 }
 
 /** Snapshot for GET /api/resources, cached briefly so UI polling stays cheap.
@@ -229,17 +325,5 @@ export async function readResources(fresh = false): Promise<ResourcesPayload> {
     noteSessionTargets([]);
     return parseResourcesFixture(readFileSync(fixturePath, "utf8"));
   }
-  const cached = globalStore.__llvResourcesCache;
-  /* Pane discovery is the expensive cached half. Host pressure comes from a
-     new /proc/meminfo snapshot on every request, so RAM and swap never inherit
-     the age of a pane/session snapshot. */
-  if (!fresh && cached && Date.now() - cached.at < CACHE_MS) {
-    return { ...cached.data, system: captureSystemMemory() };
-  }
-  const data = await resourceBuildCoordinator().run(fresh, async (forceFresh) => {
-    const built = await buildResourceSnapshot(forceFresh);
-    globalStore.__llvResourcesCache = { at: Date.now(), data: built };
-    return built;
-  });
-  return fresh ? data : { ...data, system: captureSystemMemory() };
+  return resourcesReader().read(fresh);
 }

--- a/src/lib/resources.ts
+++ b/src/lib/resources.ts
@@ -1,7 +1,7 @@
 import { procBackend } from "@/lib/proc";
 import type { ProcBackend } from "@/lib/proc";
 import crypto from "node:crypto";
-import { chmodSync, existsSync, mkdirSync, readFileSync, readdirSync, readlinkSync, renameSync, statSync, unlinkSync, writeFileSync } from "node:fs";
+import { chmodSync, closeSync, existsSync, fstatSync, mkdirSync, openSync, readFileSync, readdirSync, readlinkSync, renameSync, statSync, unlinkSync, writeFileSync } from "node:fs";
 import { spawn, spawnSync } from "node:child_process";
 import path from "node:path";
 import { StringDecoder } from "node:string_decoder";
@@ -452,6 +452,11 @@ type ResourceWorkerLimits = Partial<{
   outputMaxBytes: number;
 }>;
 
+type ResourceWorkerNamespaceReference = Readonly<{
+  members(): number[] | null;
+  close(): void;
+}>;
+
 type ResourceWorkerProcessRuntime = Readonly<{
   kernelContainment?: "proven" | "unavailable";
   pidAlive(pid: number): boolean;
@@ -462,7 +467,7 @@ type ResourceWorkerProcessRuntime = Readonly<{
   namespaceMembers?(owner: string): number[] | null;
   processNamespaceId?(pid: number): string | null;
   processNamespacePid?(pid: number): number | null;
-  containmentMembers?(namespaceId: string): number[] | null;
+  openNamespaceReference?(pid: number, namespaceId: string): ResourceWorkerNamespaceReference | null;
   signal(pid: number, signal: NodeJS.Signals | 0): void;
 }>;
 
@@ -618,23 +623,51 @@ function linuxProcessNamespacePid(pid: number): number | null {
   }
 }
 
-function linuxProcessNamespaceMembers(namespaceId: string): number[] | null {
-  let names: string[];
+function openLinuxProcessNamespaceReference(pid: number, namespaceId: string): ResourceWorkerNamespaceReference | null {
+  let fd: number;
   try {
-    names = readdirSync("/proc");
+    fd = openSync(`/proc/${pid}/ns/pid`, "r");
   } catch {
     return null;
   }
-  const members: number[] = [];
-  for (const name of names) {
-    const pid = Number(name);
-    if (!Number.isInteger(pid) || pid <= 0) continue;
-    const identity = procBackend.processIdentity(pid);
-    if (identity === null || linuxProcessNamespaceId(pid) !== namespaceId) continue;
-    if (procBackend.processIdentity(pid) === identity
-      && linuxProcessNamespaceId(pid) === namespaceId) members.push(pid);
+  try {
+    if (readlinkSync(`/proc/self/fd/${fd}`) !== namespaceId) {
+      closeSync(fd);
+      return null;
+    }
+    const namespace = fstatSync(fd, { bigint: true });
+    let closed = false;
+    return {
+      members: () => {
+        let names: string[];
+        try {
+          names = readdirSync("/proc");
+        } catch {
+          return null;
+        }
+        const members: number[] = [];
+        for (const name of names) {
+          const member = Number(name);
+          if (!Number.isInteger(member) || member <= 0) continue;
+          try {
+            const candidate = statSync(`/proc/${member}/ns/pid`, { bigint: true });
+            if (candidate.dev === namespace.dev && candidate.ino === namespace.ino) members.push(member);
+          } catch {
+            // Processes may exit between the /proc directory scan and namespace inspection.
+          }
+        }
+        return members;
+      },
+      close: () => {
+        if (closed) return;
+        closed = true;
+        closeSync(fd);
+      },
+    };
+  } catch {
+    closeSync(fd);
+    return null;
   }
-  return members;
 }
 
 const defaultResourceWorkerProcessRuntime: ResourceWorkerProcessRuntime = {
@@ -650,8 +683,8 @@ const defaultResourceWorkerProcessRuntime: ResourceWorkerProcessRuntime = {
     : portableWorkerNamespaceMembers(owner),
   processNamespaceId: (pid) => procBackend.name === "linux" ? linuxProcessNamespaceId(pid) : null,
   processNamespacePid: (pid) => procBackend.name === "linux" ? linuxProcessNamespacePid(pid) : null,
-  containmentMembers: (namespaceId) => procBackend.name === "linux"
-    ? linuxProcessNamespaceMembers(namespaceId)
+  openNamespaceReference: (pid, namespaceId) => procBackend.name === "linux"
+    ? openLinuxProcessNamespaceReference(pid, namespaceId)
     : null,
   signal: (pid, signal) => process.kill(pid, signal),
 };
@@ -1041,9 +1074,12 @@ async function collectResourcesInWorker(
     let containmentNamespaceId: string | null = null;
     let containmentRootPid: number | null = null;
     let containmentRootIdentity: string | null = null;
+    let containmentReference: ResourceWorkerNamespaceReference | null = null;
+    let containmentRootRetired = false;
     const injectedContainmentProven = processRuntime !== defaultResourceWorkerProcessRuntime
       && processRuntime.kernelContainment !== "unavailable";
     let containmentScanComplete = injectedContainmentProven;
+    let containmentMembershipEmpty = injectedContainmentProven;
     let containmentProven = injectedContainmentProven;
     let groupContinuityLost = false;
     let groupSignalSent = false;
@@ -1079,35 +1115,34 @@ async function collectResourcesInWorker(
       ownershipTimers.length = 0;
     };
     const retainLiveContainmentMembers = (): boolean => {
-      if (!containmentProven || containmentNamespaceId === null || !processRuntime.containmentMembers) {
+      if (!containmentProven || containmentNamespaceId === null || containmentReference === null) {
         return false;
       }
       let members: number[] | null;
       try {
-        const currentRootIdentity = containmentRootPid === null
-          ? null
-          : processRuntime.processIdentity(containmentRootPid);
-        const rootIsLive = containmentRootPid !== null
-          && containmentRootIdentity !== null
-          && currentRootIdentity === containmentRootIdentity
-          && processRuntime.processNamespaceId?.(containmentRootPid) === containmentNamespaceId
-          && processRuntime.processNamespacePid?.(containmentRootPid) === 1;
-        const rootIsAbsent = containmentRootPid !== null
-          && containmentRootIdentity !== null
-          && currentRootIdentity === null
-          && !processRuntime.pidAlive(containmentRootPid);
-        if (!rootIsLive && !rootIsAbsent && currentRootIdentity !== null) {
-          failCleanupVerification("resource collector PID namespace root identity changed");
+        if (!containmentRootRetired && containmentRootPid !== null && containmentRootIdentity !== null) {
+          const currentRootIdentity = processRuntime.processIdentity(containmentRootPid);
+          if (currentRootIdentity === containmentRootIdentity) {
+            const namespaceId = processRuntime.processNamespaceId?.(containmentRootPid);
+            const namespacePid = processRuntime.processNamespacePid?.(containmentRootPid);
+            const confirmedIdentity = processRuntime.processIdentity(containmentRootPid);
+            if (confirmedIdentity !== currentRootIdentity) containmentRootRetired = true;
+            else if (namespaceId !== containmentNamespaceId || namespacePid !== 1) {
+              failCleanupVerification("resource collector PID namespace root identity changed");
+            }
+          } else if (currentRootIdentity !== null || !processRuntime.pidAlive(containmentRootPid)) {
+            containmentRootRetired = true;
+          }
         }
-        if (rootIsLive) members = processRuntime.descendants(containmentRootPid!);
-        else if (rootIsAbsent) members = [];
-        else members = processRuntime.containmentMembers(containmentNamespaceId);
+        members = containmentReference.members();
       } catch (error) {
         containmentScanComplete = false;
+        containmentMembershipEmpty = false;
         rememberCleanupIssue(error);
         return false;
       }
       containmentScanComplete = members !== null;
+      containmentMembershipEmpty = members?.length === 0;
       if (members === null) {
         rememberCleanupIssue(new Error("resource collector PID namespace could not be inspected"));
         return false;
@@ -1312,10 +1347,17 @@ async function collectResourcesInWorker(
             if ((error as NodeJS.ErrnoException).code !== "ESRCH") rememberCleanupIssue(error);
           }
         }
+        if (containmentRootRetired) return;
         const currentIdentity = processRuntime.processIdentity(containmentRootPid);
-        if (currentIdentity === null) return;
-        if (currentIdentity !== containmentRootIdentity
-          || processRuntime.processNamespaceId?.(containmentRootPid) !== containmentNamespaceId
+        if (currentIdentity === null) {
+          if (!processRuntime.pidAlive(containmentRootPid)) containmentRootRetired = true;
+          return;
+        }
+        if (currentIdentity !== containmentRootIdentity) {
+          containmentRootRetired = true;
+          return;
+        }
+        if (processRuntime.processNamespaceId?.(containmentRootPid) !== containmentNamespaceId
           || processRuntime.processNamespacePid?.(containmentRootPid) !== 1
           || processRuntime.processIdentity(containmentRootPid) !== currentIdentity) {
           failCleanupVerification("resource collector PID namespace root identity changed before cleanup");
@@ -1367,7 +1409,7 @@ async function collectResourcesInWorker(
         && probeWorkerGroup() === "absent"
         && state.active.length === 0
         && !state.uncertain;
-      const absent = processChecksAbsent && containmentScanComplete;
+      const absent = processChecksAbsent && containmentScanComplete && containmentMembershipEmpty;
       if (processChecksAbsent && !containmentProven && cleanupFailure === null) {
         cleanupVerificationFailed = true;
         cleanupFailure = new Error("resource collector kernel containment could not be established");
@@ -1384,6 +1426,13 @@ async function collectResourcesInWorker(
     const releaseWorkerHandles = () => {
       if (streamsDetached) return;
       streamsDetached = true;
+      try {
+        containmentReference?.close();
+      } catch (error) {
+        rememberCleanupIssue(error);
+        cleanupFailure ??= new Error("resource collector PID namespace reference could not be closed", { cause: error });
+      }
+      containmentReference = null;
       finishStderr();
       worker.removeAllListeners();
       for (const stream of [worker.stdin, worker.stdout, worker.stderr]) {
@@ -1399,7 +1448,7 @@ async function collectResourcesInWorker(
       const rootPid = Number(rawRootPid);
       if (line.length > 512 || token !== containmentToken || !Number.isInteger(rootPid) || rootPid <= 0
         || !/^pid:\[\d+\]$/.test(namespaceId) || extra.length > 0
-        || !processRuntime.containmentMembers || !processRuntime.processNamespaceId
+        || !processRuntime.openNamespaceReference || !processRuntime.processNamespaceId
         || !processRuntime.processNamespacePid) {
         failCleanupVerification("resource collector PID namespace handshake was invalid");
         return true;
@@ -1409,16 +1458,26 @@ async function collectResourcesInWorker(
         && processRuntime.processNamespaceId(rootPid) === namespaceId
         && processRuntime.processNamespacePid(rootPid) === 1
         && processRuntime.processIdentity(rootPid) === rootIdentity;
-      const members = liveRootIsValid ? null : processRuntime.containmentMembers(namespaceId);
-      if (!liveRootIsValid && (members === null || members.length > 0)) {
+      const reference = liveRootIsValid
+        ? processRuntime.openNamespaceReference(rootPid, namespaceId)
+        : null;
+      const liveRootRemainsValid = reference !== null
+        && processRuntime.processIdentity(rootPid) === rootIdentity
+        && processRuntime.processNamespaceId(rootPid) === namespaceId
+        && processRuntime.processNamespacePid(rootPid) === 1
+        && processRuntime.processIdentity(rootPid) === rootIdentity;
+      if (!liveRootRemainsValid) {
+        reference?.close();
         failCleanupVerification("resource collector PID namespace root could not be verified");
         return true;
       }
       containmentNamespaceId = namespaceId;
       containmentRootPid = rootPid;
       containmentRootIdentity = rootIdentity;
+      containmentReference = reference;
       containmentProven = true;
-      containmentScanComplete = members?.length === 0;
+      containmentScanComplete = false;
+      containmentMembershipEmpty = false;
       namespaceScanComplete = true;
       retainLiveContainmentMembers();
       return true;
@@ -1523,6 +1582,7 @@ async function collectResourcesInWorker(
       if (typeof pid !== "number") {
         containmentProven = true;
         containmentScanComplete = true;
+        containmentMembershipEmpty = true;
         namespaceScanComplete = true;
       }
       finish({

--- a/src/lib/resources.ts
+++ b/src/lib/resources.ts
@@ -4,6 +4,7 @@ import crypto from "node:crypto";
 import { chmodSync, existsSync, mkdirSync, readFileSync, renameSync, statSync, unlinkSync, writeFileSync } from "node:fs";
 import { spawn } from "node:child_process";
 import path from "node:path";
+import { StringDecoder } from "node:string_decoder";
 import { completedFileScan, currentFileScan } from "@/lib/scanner/scanCache";
 import {
   createResourceCollector,
@@ -64,6 +65,14 @@ export type ResourcesRead = {
   payload: ResourcesPayload;
   diagnostic: ServedResourceDiagnostic;
 };
+
+export function resourceDiagnosticHeader(value: unknown): string {
+  const json = JSON.stringify(value);
+  if (json === undefined) throw new TypeError("resource diagnostic cannot be serialized");
+  return json.replace(/[\u007f-\uffff]/g, (character) => (
+    `\\u${character.charCodeAt(0).toString(16).padStart(4, "0")}`
+  ));
+}
 
 function emptyResourceBuildPhases(): ResourceBuildPhases {
   return {
@@ -687,9 +696,18 @@ async function collectResourcesInWorker(
     let outcome: (() => void) | null = null;
     let outputBytes = 0;
     let stderrTail = "";
+    const stderrDecoder = new StringDecoder("utf8");
     let closeTimer: ReturnType<typeof setTimeout> | undefined;
     let cleanupStarted = false;
     let leaderExited = false;
+    const appendStderr = (value: string) => {
+      stderrTail += value;
+      let start = stderrTail.length - (RESOURCE_FAILURE_STDERR_MAX_BYTES * 2);
+      if (start <= 0) return;
+      const first = stderrTail.charCodeAt(start);
+      if (first >= 0xdc00 && first <= 0xdfff) start += 1;
+      stderrTail = stderrTail.slice(start);
+    };
     const workerFailure = (
       reason: ResourceDegradedReason,
       cause: ResourceFailureCause,
@@ -748,6 +766,7 @@ async function collectResourcesInWorker(
     });
     worker.once("close", (code, signal) => {
       clearTimeout(timeout);
+      appendStderr(stderrDecoder.end());
       if (!outcome) {
         outcome = () => reject(workerFailure(
           "collector-crash",
@@ -819,7 +838,7 @@ async function collectResourcesInWorker(
     });
     worker.stderr.on("data", (chunk: Buffer) => {
       outputBytes += chunk.length;
-      stderrTail = (stderrTail + chunk.toString("utf8")).slice(-(RESOURCE_FAILURE_STDERR_MAX_BYTES * 2));
+      appendStderr(stderrDecoder.write(chunk));
       if (outputBytes > outputMaxBytes) {
         finish(() => reject(workerFailure(
           "collector-crash",

--- a/src/lib/resources.ts
+++ b/src/lib/resources.ts
@@ -5,10 +5,20 @@ import { chmodSync, existsSync, mkdirSync, readFileSync, renameSync, statSync, u
 import { spawn } from "node:child_process";
 import path from "node:path";
 import { completedFileScan, currentFileScan } from "@/lib/scanner/scanCache";
-import { createResourceCollector, type ResourceCollector, type ResourceDegradedReason, type ResourceObservation } from "@/lib/resourceCollector";
+import {
+  createResourceCollector,
+  ResourceCollectorFailureError,
+  RESOURCE_FAILURE_STDERR_MAX_BYTES,
+  type ResourceCollectorResult,
+  type ResourceDegradedReason,
+  type ResourceFailureCause,
+  type ResourceFailureDiagnostic,
+  type ResourceObservation,
+} from "@/lib/resourceCollector";
 import { descendantPids } from "@/lib/proc/memory";
 import { overlaySessionTitles } from "@/lib/session/titleProjection";
 import { readTranscriptHosts, type TranscriptHost, type TranscriptHostSnapshot } from "@/lib/agent/transcriptHost";
+import { agentRegistry } from "@/lib/agent/registry";
 import { captureTmuxAttachReferences, type TmuxAttachReference } from "@/lib/tmux";
 import { statePath } from "@/lib/configDir";
 
@@ -39,8 +49,16 @@ export type ServedResourceDiagnostic = ResourceBuildDiagnostic & {
   startedAt: string;
   completedAt: string;
   collectorId: string;
+  cache: ResourceCacheAttribution;
   degradedReason?: ResourceDegradedReason;
+  failure?: ResourceFailureDiagnostic;
 };
+
+export type ResourceCacheAttribution = Readonly<{
+  status: "miss" | "memory" | "durable";
+  collectorId?: string;
+  generation?: number;
+}>;
 
 export type ResourcesRead = {
   payload: ResourcesPayload;
@@ -120,6 +138,7 @@ const globalStore = globalThis as unknown as {
   __llvResourceTargets?: Map<string, KillTargetRef>;
   __llvLastResourceTargets?: Array<{ target: string; ref: KillTargetRef }>;
   __llvResourceTargetsGeneration?: number;
+  __llvResourceTargetEpoch?: number;
   __llvLastResourceBuild?: ResourceBuildDiagnostic;
 };
 
@@ -152,7 +171,9 @@ function rememberResourceTargets(sessions: Iterable<{ target: string; ref: KillT
 export function applyResourceTargets(
   generation: number,
   sessions: Iterable<{ target: string; ref: KillTargetRef }>,
+  collectionEpoch = globalStore.__llvResourceTargetEpoch ?? 0,
 ): void {
+  if (collectionEpoch !== (globalStore.__llvResourceTargetEpoch ?? 0)) return;
   if (generation <= (globalStore.__llvResourceTargetsGeneration ?? 0)) return;
   noteSessionTargets(sessions);
   globalStore.__llvResourceTargetsGeneration = generation;
@@ -174,7 +195,9 @@ export function allowedKillTarget(target: string): KillTargetRef | null {
 /** Drops `target` from the allowlist after a kill: the coordinates are free
     for tmux to reuse, so a repeated POST must not pass the gate again. */
 export function consumeKillTarget(target: string): void {
-  globalStore.__llvResourceTargets?.delete(target);
+  if (globalStore.__llvResourceTargets?.delete(target)) {
+    globalStore.__llvResourceTargetEpoch = (globalStore.__llvResourceTargetEpoch ?? 0) + 1;
+  }
 }
 
 /** The resources rail may list duplicate panes for cleanup. Only the host
@@ -222,10 +245,11 @@ export type ResourceFileObservation = Readonly<Pick<FileEntry,
 > & { conversationId?: string | null }>;
 export type ResourceWorkerFileObservation = ResourceFileObservation & { conversationId: string | null };
 
-export async function readResourceFileSnapshot(fresh: boolean): Promise<ResourceWorkerFileObservation[]> {
-  const scan = fresh ? await currentFileScan({ fresh: true }) : await completedFileScan();
-  overlaySessionTitles(scan.snapshot.files);
-  return scan.snapshot.files.map((entry) => ({
+export function resourceWorkerFileSnapshot(
+  entries: ResourceFileObservation[],
+  conversationIdForPath: (pathname: string) => string | null,
+): ResourceWorkerFileObservation[] {
+  return entries.map((entry) => ({
     path: entry.path,
     parent: entry.parent,
     title: entry.title,
@@ -235,8 +259,20 @@ export async function readResourceFileSnapshot(fresh: boolean): Promise<Resource
     engine: entry.engine,
     pid: entry.pid,
     proc: entry.proc,
-    conversationId: entry.conversationId ?? null,
+    conversationId: conversationIdForPath(entry.path) ?? entry.conversationId ?? null,
   }));
+}
+
+export async function readResourceFileSnapshot(fresh: boolean): Promise<ResourceWorkerFileObservation[]> {
+  const scan = fresh ? await currentFileScan({ fresh: true }) : await completedFileScan();
+  const registrySnapshot = agentRegistry().snapshot();
+  const conversationIdByPath = new Map<string, string>();
+  for (const conversation of Object.values(registrySnapshot.conversations)) {
+    for (const generation of conversation.generations) conversationIdByPath.set(generation.path, conversation.id);
+    for (const pathname of conversation.continuityPaths) conversationIdByPath.set(pathname, conversation.id);
+  }
+  overlaySessionTitles(scan.snapshot.files);
+  return resourceWorkerFileSnapshot(scan.snapshot.files, (pathname) => conversationIdByPath.get(pathname) ?? null);
 }
 
 /** `fresh` advances the shared file scan and skips the pane/agent-process
@@ -315,9 +351,9 @@ export async function buildResourceSnapshot(
         }
       });
       sessions.sort((a, b) => b.rssBytes + b.swapBytes - (a.rssBytes + a.swapBytes));
-      noteSessionTargets(killRefs);
+      rememberResourceTargets(killRefs);
     } else {
-      noteSessionTargets([]);
+      rememberResourceTargets([]);
     }
 
     globalStore.__llvLastResourceBuild = { fresh, status: "complete", durationMs: performance.now() - startedAt, phases };
@@ -338,6 +374,7 @@ export type CollectedResources = {
   hostCount: number;
   treeCount: number;
   targets: Array<{ target: string; ref: KillTargetRef }>;
+  targetEpoch?: number;
 };
 
 const RESOURCE_OBSERVE_TIMEOUT_MS = 30_000;
@@ -360,10 +397,38 @@ type ResourceWorkerLimits = Partial<{
   outputMaxBytes: number;
 }>;
 
+type ResourceWorkerLaunchOptions = {
+  cwd?: string;
+  env?: NodeJS.ProcessEnv;
+  execPath?: string;
+  exists?: (pathname: string) => boolean;
+};
+
+export function resolveResourceWorkerLaunch(options: ResourceWorkerLaunchOptions = {}): {
+  executable: string;
+  workerPath: string;
+} {
+  const cwd = options.cwd ?? process.cwd();
+  const env = options.env ?? process.env;
+  const exists = options.exists ?? existsSync;
+  const sourceWorker = path.join(cwd, "src/lib/resourceCollector.worker.ts");
+  if (env.LLV_RESOURCE_COLLECTOR_EXECUTABLE) {
+    return { executable: env.LLV_RESOURCE_COLLECTOR_EXECUTABLE, workerPath: sourceWorker };
+  }
+  const bunContainer = "/usr/local/bin/bun-container";
+  if (exists(bunContainer)) return { executable: bunContainer, workerPath: sourceWorker };
+  const bundledWorker = path.join(cwd, ".next/server/resource-collector-worker.js");
+  if (exists(bundledWorker)) {
+    return { executable: options.execPath ?? process.execPath, workerPath: bundledWorker };
+  }
+  return { executable: "bun", workerPath: sourceWorker };
+}
+
 function collectedResources(
   payload: ResourcesPayload,
   diagnostic: ResourceBuildDiagnostic,
   targets: Array<{ target: string; ref: KillTargetRef }> = [],
+  targetEpoch = globalStore.__llvResourceTargetEpoch ?? 0,
 ): CollectedResources {
   return {
     payload,
@@ -371,6 +436,7 @@ function collectedResources(
     hostCount: payload.sessions.length,
     treeCount: payload.sessions.reduce((total, session) => total + session.procCount, 0),
     targets,
+    targetEpoch,
   };
 }
 
@@ -474,11 +540,12 @@ function resourceTargetsMatchPayload(
 }
 
 function validCollectedResources(value: unknown): value is CollectedResources {
-  if (!record(value) || !exactKeys(value, ["payload", "diagnostic", "hostCount", "treeCount", "targets"])
+  if (!record(value) || !exactKeys(value, ["payload", "diagnostic", "hostCount", "treeCount", "targets"], ["targetEpoch"])
     || !validResourcesPayload(value.payload)
     || !validResourceDiagnostic(value.diagnostic)
     || !Number.isSafeInteger(value.hostCount) || (value.hostCount as number) < 0
     || !Number.isSafeInteger(value.treeCount) || (value.treeCount as number) < 0
+    || (value.targetEpoch !== undefined && (!Number.isSafeInteger(value.targetEpoch) || (value.targetEpoch as number) < 0))
     || !Array.isArray(value.targets)
     || value.targets.length > RESOURCE_OBSERVATION_MAX_TARGETS
     || !value.targets.every(validResourceTarget)) return false;
@@ -564,55 +631,95 @@ function persistObservation(observation: ResourceObservation<CollectedResources>
   }
 }
 
+function validateDurableResourceObservation(observation: ResourceObservation<CollectedResources>): void {
+  const serialized = JSON.stringify({ version: RESOURCE_OBSERVATION_SCHEMA_VERSION, observation }) + "\n";
+  if (Buffer.byteLength(serialized) > RESOURCE_OBSERVATION_MAX_BYTES) {
+    throw new ResourceCollectorFailureError(
+      "collector-crash",
+      "observation-limit",
+      "resource observation exceeded durable size limit",
+    );
+  }
+}
+
 /** One bounded worker owns one observation. Terminating after either outcome
     prevents a crashed or wedged collection from surviving a request timeout. */
 async function collectResourcesInWorker(
   fresh: boolean,
   readFiles: (fresh: boolean) => Promise<ResourceWorkerFileObservation[]> = readResourceFileSnapshot,
   limits: ResourceWorkerLimits = {},
+  targetEpoch = globalStore.__llvResourceTargetEpoch ?? 0,
 ): Promise<CollectedResources> {
-  /* The production image ships src/ and Bun. A process adapter keeps the
-     worker independent from Next's route bundle and works when Next itself is
-     hosted by Node. The explicit in-process flag remains the rollback path. */
-  const executable = process.env.LLV_RESOURCE_COLLECTOR_EXECUTABLE
-    ?? (existsSync("/usr/local/bin/bun-container") ? "/usr/local/bin/bun-container" : "bun");
+  const launch = resolveResourceWorkerLaunch();
   const filesTask = readFiles(fresh);
   let inputTimer: ReturnType<typeof setTimeout> | undefined;
-  const files = fresh
-    ? await filesTask
-    : await Promise.race([
-        filesTask,
-        new Promise<ResourceWorkerFileObservation[]>((_, reject) => {
-          inputTimer = setTimeout(() => reject(new Error("resource collector file handoff timed out")), limits.inputTimeoutMs ?? RESOURCE_FILE_HANDOFF_TIMEOUT_MS);
-        }),
-      ]).finally(() => {
-        if (inputTimer) clearTimeout(inputTimer);
-      });
+  const files = await Promise.race([
+    filesTask,
+    new Promise<ResourceWorkerFileObservation[]>((_, reject) => {
+      inputTimer = setTimeout(() => reject(new ResourceCollectorFailureError(
+        "timeout",
+        "file-handoff-timeout",
+        "resource collector file handoff timed out",
+      )), limits.inputTimeoutMs ?? RESOURCE_FILE_HANDOFF_TIMEOUT_MS);
+    }),
+  ]).finally(() => {
+    if (inputTimer) clearTimeout(inputTimer);
+  });
   const request = JSON.stringify({ type: "collect", fresh, files }) + "\n";
   const outputMaxBytes = limits.outputMaxBytes ?? RESOURCE_WORKER_OUTPUT_MAX_BYTES;
   const timeoutMs = limits.timeoutMs ?? RESOURCE_WORKER_TIMEOUT_MS;
   const closeTimeoutMs = limits.closeTimeoutMs ?? RESOURCE_WORKER_CLOSE_TIMEOUT_MS;
   if (Buffer.byteLength(request) > RESOURCE_WORKER_OUTPUT_MAX_BYTES) {
-    throw new Error("resource collector input exceeded transport limit");
+    throw new ResourceCollectorFailureError(
+      "collector-crash",
+      "worker-input",
+      "resource collector input exceeded transport limit",
+    );
   }
-  const worker = spawn(executable, [path.join(process.cwd(), "src/lib/resourceCollector.worker.ts")], {
+  const worker = spawn(launch.executable, [launch.workerPath], {
     cwd: process.cwd(),
+    detached: true,
     stdio: ["pipe", "pipe", "pipe"],
   });
   return new Promise<CollectedResources>((resolve, reject) => {
     const pid = worker.pid;
     const expectedIdentity = typeof pid === "number" ? procBackend.processIdentity(pid) : null;
     let outcome: (() => void) | null = null;
-    let closed = false;
     let outputBytes = 0;
+    let stderrTail = "";
     let closeTimer: ReturnType<typeof setTimeout> | undefined;
+    const workerFailure = (
+      reason: ResourceDegradedReason,
+      cause: ResourceFailureCause,
+      message: string,
+      error?: unknown,
+    ) => new ResourceCollectorFailureError(reason, cause, message, { cause: error, stderr: stderrTail });
     const sameWorker = () => typeof pid === "number"
       && (expectedIdentity === null || procBackend.processIdentity(pid) === expectedIdentity);
+    const workerGroupExists = () => {
+      if (typeof pid !== "number") return false;
+      try {
+        process.kill(-pid, 0);
+        return true;
+      } catch (error) {
+        return (error as NodeJS.ErrnoException).code !== "ESRCH";
+      }
+    };
+    const signalWorkerGroup = (signal: NodeJS.Signals) => {
+      if (typeof pid !== "number") return;
+      const workerExited = worker.exitCode !== null || worker.signalCode !== null;
+      if (!workerExited && !sameWorker()) return;
+      try {
+        process.kill(-pid, signal);
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== "ESRCH" && !workerExited) worker.kill(signal);
+      }
+    };
     const terminate = () => {
-      if (worker.exitCode !== null || worker.signalCode !== null || !sameWorker()) return;
-      worker.kill("SIGTERM");
+      signalWorkerGroup("SIGTERM");
+      if (closeTimer) return;
       closeTimer = setTimeout(() => {
-        if (!closed && sameWorker()) worker.kill("SIGKILL");
+        if (workerGroupExists()) signalWorkerGroup("SIGKILL");
       }, closeTimeoutMs);
     };
     const finish = (next: () => void) => {
@@ -621,24 +728,40 @@ async function collectResourcesInWorker(
       clearTimeout(timeout);
       terminate();
     };
-    const timeout = setTimeout(() => finish(() => reject(new Error("resource collector worker timed out"))), timeoutMs);
-    worker.once("error", (error) => finish(() => reject(error)));
+    const timeout = setTimeout(() => finish(() => reject(workerFailure(
+      "timeout",
+      "worker-timeout",
+      "resource collector worker timed out",
+    ))), timeoutMs);
+    worker.once("error", (error) => finish(() => reject(workerFailure(
+      "collector-crash",
+      "worker-spawn",
+      "resource collector worker failed to start",
+      error,
+    ))));
     worker.once("close", (code, signal) => {
-      closed = true;
       clearTimeout(timeout);
-      if (closeTimer) clearTimeout(closeTimer);
-      if (outcome) {
-        outcome();
-        return;
+      if (!outcome) {
+        outcome = () => reject(workerFailure(
+          "collector-crash",
+          "worker-exit",
+          `resource collector worker closed before observation (${signal ?? code ?? "unknown"})`,
+        ));
+        terminate();
       }
-      reject(new Error(`resource collector worker closed before observation (${signal ?? code ?? "unknown"})`));
+      if (closeTimer && !workerGroupExists()) clearTimeout(closeTimer);
+      outcome();
     });
     let output = "";
     worker.stdout.setEncoding("utf8");
     worker.stdout.on("data", (chunk: string) => {
       outputBytes += Buffer.byteLength(chunk);
       if (outputBytes > outputMaxBytes) {
-        finish(() => reject(new Error("resource collector worker exceeded stdout limit")));
+        finish(() => reject(workerFailure(
+          "collector-crash",
+          "worker-output-limit",
+          "resource collector worker exceeded stdout limit",
+        )));
         return;
       }
       output += chunk;
@@ -650,78 +773,154 @@ async function collectResourcesInWorker(
       try {
         parsed = JSON.parse(raw);
       } catch {
-        finish(() => reject(new Error("resource collector worker emitted invalid JSON")));
+        finish(() => reject(workerFailure(
+          "collector-crash",
+          "worker-output-invalid",
+          "resource collector worker emitted invalid JSON",
+        )));
         return;
       }
       const message = resourceWorkerMessage(parsed);
       if (!message) {
-        finish(() => reject(new Error("resource collector worker emitted an invalid message")));
+        finish(() => reject(workerFailure(
+          "collector-crash",
+          "worker-output-invalid",
+          "resource collector worker emitted an invalid message",
+        )));
         return;
       }
       if (message.type === "observation" && message.diagnostic.fresh !== fresh) {
-        finish(() => reject(new Error("resource collector worker returned mismatched freshness")));
+        finish(() => reject(workerFailure(
+          "collector-crash",
+          "worker-output-invalid",
+          "resource collector worker returned mismatched freshness",
+        )));
         return;
       }
       if (message.type === "failure") {
-        finish(() => reject(new Error(message.error)));
+        finish(() => reject(workerFailure(
+          "collector-crash",
+          "worker-failure",
+          "resource collector worker reported a failure",
+          new Error(message.error),
+        )));
         return;
       }
       finish(() => {
-        resolve(collectedResources(message.payload, message.diagnostic, message.targets));
+        resolve(collectedResources(message.payload, message.diagnostic, message.targets, targetEpoch));
       });
     });
     worker.stderr.on("data", (chunk: Buffer) => {
       outputBytes += chunk.length;
+      stderrTail = (stderrTail + chunk.toString("utf8")).slice(-(RESOURCE_FAILURE_STDERR_MAX_BYTES * 2));
       if (outputBytes > outputMaxBytes) {
-        finish(() => reject(new Error("resource collector worker exceeded output limit")));
+        finish(() => reject(workerFailure(
+          "collector-crash",
+          "worker-output-limit",
+          "resource collector worker exceeded output limit",
+        )));
       }
     });
+    worker.stdin.once("error", (error) => finish(() => reject(workerFailure(
+      "collector-crash",
+      "worker-input",
+      "resource collector worker input failed",
+      error,
+    ))));
     worker.stdin.end(request);
   });
 }
 
-function fallbackRead(
-  payload: ResourcesPayload,
-  reason: ResourceDegradedReason,
-  collectorId: string,
-): ResourcesRead {
-  const capturedAt = new Date().toISOString();
+function fixtureRead(payload: ResourcesPayload, fresh: boolean): ResourcesRead {
+  const capturedAt = Date.now();
   return {
     payload,
     diagnostic: {
-      fresh: true,
-      status: "failed",
+      fresh,
+      status: "complete",
       durationMs: 0,
       phases: emptyResourceBuildPhases(),
       generation: 0,
-      startedAt: capturedAt,
-      completedAt: capturedAt,
-      collectorId,
-      degradedReason: reason,
+      startedAt: new Date(capturedAt).toISOString(),
+      completedAt: new Date(capturedAt).toISOString(),
+      collectorId: "fixture",
+      cache: { status: "miss" },
     },
   };
 }
 
-function resourceReadFromObservation(
-  observation: Awaited<ReturnType<ResourceCollector<CollectedResources>["observe"]>>,
+function resourceCacheAttribution(
+  observation: ResourceObservation<CollectedResources> | null,
+  collectorId: string,
+  servedFromCache: boolean,
+): ResourceCacheAttribution {
+  if (!observation || !servedFromCache) return { status: "miss" };
+  return {
+    status: observation.collectorId === collectorId ? "memory" : "durable",
+    collectorId: observation.collectorId,
+    generation: observation.generation,
+  };
+}
+
+function resourceReadFromResult(
+  result: ResourceCollectorResult<CollectedResources>,
   captureSystem: () => ResourcesPayload["system"],
   fresh: boolean,
-  collectorId: string,
+  servedFromCache = false,
 ): ResourcesRead {
+  const { observation, failure } = result;
+  const cache = resourceCacheAttribution(observation, result.collectorId, servedFromCache || failure !== undefined);
   if (!observation) {
-    return fallbackRead({ system: captureSystem(), sessions: [] }, "collector-busy", collectorId);
+    if (!failure) throw new Error("resource collector returned no observation or failure");
+    return {
+      payload: { system: captureSystem(), sessions: [] },
+      diagnostic: {
+        fresh,
+        status: "failed",
+        durationMs: Math.max(0, result.completedAt - result.startedAt),
+        phases: emptyResourceBuildPhases(),
+        generation: result.generation,
+        startedAt: new Date(result.startedAt).toISOString(),
+        completedAt: new Date(result.completedAt).toISOString(),
+        collectorId: result.collectorId,
+        cache,
+        degradedReason: failure.reason,
+        failure: failure.diagnostic,
+      },
+    };
   }
   const { payload, diagnostic } = observation.value;
-  applyResourceTargets(observation.generation, observation.value.targets);
+  if (!failure && observation.collectorId === result.collectorId && observation.value.targetEpoch !== undefined) {
+    applyResourceTargets(observation.generation, observation.value.targets, observation.value.targetEpoch);
+  }
+  if (failure) {
+    return {
+      payload: fresh ? payload : { ...payload, system: captureSystem() },
+      diagnostic: {
+        fresh,
+        status: "failed",
+        durationMs: Math.max(0, result.completedAt - result.startedAt),
+        phases: emptyResourceBuildPhases(),
+        generation: result.generation,
+        startedAt: new Date(result.startedAt).toISOString(),
+        completedAt: new Date(result.completedAt).toISOString(),
+        collectorId: result.collectorId,
+        cache,
+        degradedReason: failure.reason,
+        failure: failure.diagnostic,
+      },
+    };
+  }
   return {
     payload: fresh ? payload : { ...payload, system: captureSystem() },
     diagnostic: {
       ...diagnostic,
+      fresh,
       generation: observation.generation,
       startedAt: new Date(observation.startedAt).toISOString(),
       completedAt: new Date(observation.completedAt).toISOString(),
-      collectorId: observation.collectorId,
-      ...(observation.degradedReason ? { degradedReason: observation.degradedReason } : {}),
+      collectorId: result.collectorId,
+      cache,
     },
   };
 }
@@ -733,6 +932,7 @@ export function createResourcesReader(
   diagnosticForBuild: () => ResourceBuildDiagnostic | null = lastResourceBuildDiagnostic,
   options: {
     inProcess?: boolean;
+    collectorId?: string;
     initial?: ResourceObservation<CollectedResources> | null;
     persist?: (observation: ResourceObservation<CollectedResources>) => boolean;
     readFiles?: (fresh: boolean) => Promise<ResourceWorkerFileObservation[]>;
@@ -740,18 +940,20 @@ export function createResourcesReader(
   } = {},
 ): ResourcesReader {
   const inProcess = options.inProcess ?? process.env.LLV_RESOURCE_COLLECTOR_IN_PROCESS === "1";
-  const collectorId = inProcess
-    ? `in-process:${process.pid}`
-    : `worker:${process.pid}`;
+  const collectorId = options.collectorId ?? (inProcess
+    ? `in-process:${process.pid}:${crypto.randomUUID()}`
+    : `worker:${process.pid}:${crypto.randomUUID()}`);
   const collector = createResourceCollector<CollectedResources, boolean>({
     collectorId,
     now,
     initial: options.initial,
+    validateObservation: validateDurableResourceObservation,
     collect: inProcess ? async (fresh = false) => {
+      const targetEpoch = globalStore.__llvResourceTargetEpoch ?? 0;
       const payload = await build(fresh);
       const diagnostic = diagnosticForBuild();
       if (!diagnostic) throw new Error("resource build completed without diagnostics");
-      return collectedResources(payload, diagnostic, lastResourceTargetRefs());
+      return collectedResources(payload, diagnostic, lastResourceTargetRefs(), targetEpoch);
     } : (fresh = false) => collectResourcesInWorker(fresh, options.readFiles, options.workerLimits),
   });
   let lastPersistedGeneration = options.initial?.generation ?? 0;
@@ -772,12 +974,18 @@ export function createResourcesReader(
         void collector.observe(latest.generation, 0, false);
       }
       persist(latest);
-      return resourceReadFromObservation(latest, captureSystem, false, collectorId);
+      return resourceReadFromResult({
+        observation: latest,
+        generation: latest.generation,
+        startedAt: latest.startedAt,
+        completedAt: latest.completedAt,
+        collectorId,
+      }, captureSystem, false, true);
     }
     const fence = fresh ? collector.fence() : -1;
-    const observation = await collector.observe(fence, RESOURCE_OBSERVE_TIMEOUT_MS, fresh);
-    if (observation) persist(observation);
-    return resourceReadFromObservation(observation, captureSystem, fresh, collectorId);
+    const result = await collector.observe(fence, RESOURCE_OBSERVE_TIMEOUT_MS, fresh);
+    if (result.observation && !result.failure) persist(result.observation);
+    return resourceReadFromResult(result, captureSystem, fresh);
   };
 
   return {
@@ -817,6 +1025,7 @@ export function resetResourcesForTests(): void {
   globalStore.__llvResourceTargets = undefined;
   globalStore.__llvLastResourceTargets = undefined;
   globalStore.__llvResourceTargetsGeneration = undefined;
+  globalStore.__llvResourceTargetEpoch = undefined;
   globalStore.__llvLastResourceBuild = undefined;
 }
 
@@ -836,7 +1045,7 @@ export async function readResourcesWithDiagnostic(fresh = false): Promise<Resour
   const fixturePath = process.env.LLV_RESOURCES_FIXTURE;
   if (fixturePath) {
     noteSessionTargets([]);
-    return fallbackRead(parseResourcesFixture(readFileSync(fixturePath, "utf8")), "collector-busy", "fixture");
+    return fixtureRead(parseResourcesFixture(readFileSync(fixturePath, "utf8")), fresh);
   }
   return resourcesReader().read(fresh);
 }

--- a/src/lib/resources.ts
+++ b/src/lib/resources.ts
@@ -688,6 +688,8 @@ async function collectResourcesInWorker(
     let outputBytes = 0;
     let stderrTail = "";
     let closeTimer: ReturnType<typeof setTimeout> | undefined;
+    let cleanupStarted = false;
+    let leaderExited = false;
     const workerFailure = (
       reason: ResourceDegradedReason,
       cause: ResourceFailureCause,
@@ -705,19 +707,19 @@ async function collectResourcesInWorker(
         return (error as NodeJS.ErrnoException).code !== "ESRCH";
       }
     };
-    const signalWorkerGroup = (signal: NodeJS.Signals) => {
-      if (typeof pid !== "number") return;
-      const workerExited = worker.exitCode !== null || worker.signalCode !== null;
-      if (!workerExited && !sameWorker()) return;
+    const signalWorkerGroup = (signal: NodeJS.Signals): boolean => {
+      if (typeof pid !== "number") return false;
+      if (!leaderExited && !sameWorker()) return false;
       try {
         process.kill(-pid, signal);
       } catch (error) {
-        if ((error as NodeJS.ErrnoException).code !== "ESRCH" && !workerExited) worker.kill(signal);
+        if ((error as NodeJS.ErrnoException).code !== "ESRCH" && !leaderExited) worker.kill(signal);
       }
+      return true;
     };
     const terminate = () => {
-      signalWorkerGroup("SIGTERM");
-      if (closeTimer) return;
+      if (cleanupStarted || !signalWorkerGroup("SIGTERM")) return;
+      cleanupStarted = true;
       closeTimer = setTimeout(() => {
         if (workerGroupExists()) signalWorkerGroup("SIGKILL");
       }, closeTimeoutMs);
@@ -739,6 +741,11 @@ async function collectResourcesInWorker(
       "resource collector worker failed to start",
       error,
     ))));
+    worker.once("exit", () => {
+      leaderExited = true;
+      clearTimeout(timeout);
+      terminate();
+    });
     worker.once("close", (code, signal) => {
       clearTimeout(timeout);
       if (!outcome) {

--- a/src/lib/resources.ts
+++ b/src/lib/resources.ts
@@ -461,6 +461,7 @@ type ResourceWorkerProcessRuntime = Readonly<{
   kernelContainment?: "proven" | "unavailable";
   pidAlive(pid: number): boolean;
   processIdentity(pid: number): string | null;
+  processExited?(pid: number): boolean;
   descendants(pid: number): number[];
   processGroupId(pid: number): number | null;
   processGroupMembers(groupId: number): number[];
@@ -623,6 +624,16 @@ function linuxProcessNamespacePid(pid: number): number | null {
   }
 }
 
+function linuxProcessExited(pid: number): boolean {
+  try {
+    const stat = readFileSync(`/proc/${pid}/stat`, "utf8");
+    const state = stat.slice(stat.lastIndexOf(")") + 2).trim().split(/\s+/, 1)[0];
+    return state === "Z" || state === "X" || state === "x";
+  } catch {
+    return false;
+  }
+}
+
 function openLinuxProcessNamespaceReference(pid: number, namespaceId: string): ResourceWorkerNamespaceReference | null {
   let fd: number;
   try {
@@ -673,6 +684,7 @@ function openLinuxProcessNamespaceReference(pid: number, namespaceId: string): R
 const defaultResourceWorkerProcessRuntime: ResourceWorkerProcessRuntime = {
   pidAlive: (pid) => procBackend.pidAlive(pid),
   processIdentity: (pid) => procBackend.processIdentity(pid),
+  processExited: (pid) => procBackend.name === "linux" && linuxProcessExited(pid),
   descendants: workerDescendants,
   processGroupId: (pid) => procBackend.name === "linux" ? linuxProcessGroupId(pid) : portableProcessGroupId(pid),
   processGroupMembers: (groupId) => procBackend.name === "linux"
@@ -953,6 +965,7 @@ async function collectResourcesInWorker(
   const observeTimeoutMs = limits.observeTimeoutMs ?? RESOURCE_OBSERVE_TIMEOUT_MS;
   const inputTimeoutMs = limits.inputTimeoutMs ?? RESOURCE_FILE_HANDOFF_TIMEOUT_MS;
   const closeTimeoutMs = limits.closeTimeoutMs ?? RESOURCE_WORKER_CLOSE_TIMEOUT_MS;
+  const memberCleanupPhaseMs = Math.max(0, Math.min(100, Math.floor(closeTimeoutMs * 0.75)));
   const headroomMs = limits.headroomMs ?? RESOURCE_OBSERVE_HEADROOM_MS;
   const cleanupAbsenceConfirmationMs = Math.min(25, Math.max(5, closeTimeoutMs));
   const cleanupTimeoutMs = Math.max(
@@ -1061,6 +1074,7 @@ async function collectResourcesInWorker(
     const ownedProcesses = new Map<number, string>();
     if (typeof pid === "number" && expectedIdentity !== null) ownedProcesses.set(pid, expectedIdentity);
     const ownershipTimers: Array<ReturnType<typeof setTimeout>> = [];
+    let rootCleanupTimer: ReturnType<typeof setTimeout> | undefined;
     let killTimer: ReturnType<typeof setTimeout> | undefined;
     let cleanupDeadlineTimer: ReturnType<typeof setTimeout> | undefined;
     let cleanupPoll: ReturnType<typeof setTimeout> | undefined;
@@ -1105,6 +1119,14 @@ async function collectResourcesInWorker(
       cleanupVerificationFailed = true;
       rememberCleanupIssue(new Error(message));
     };
+    const processExitVerified = (ownedPid: number, identity: string): boolean => {
+      const currentIdentity = processRuntime.processIdentity(ownedPid);
+      if (currentIdentity === null) return !processRuntime.pidAlive(ownedPid);
+      if (currentIdentity !== identity || !processRuntime.processExited?.(ownedPid)) return false;
+      const confirmedIdentity = processRuntime.processIdentity(ownedPid);
+      return confirmedIdentity === currentIdentity
+        || (confirmedIdentity === null && !processRuntime.pidAlive(ownedPid));
+    };
     const finishStderr = () => {
       if (stderrEnded) return;
       stderrEnded = true;
@@ -1123,14 +1145,21 @@ async function collectResourcesInWorker(
         if (!containmentRootRetired && containmentRootPid !== null && containmentRootIdentity !== null) {
           const currentRootIdentity = processRuntime.processIdentity(containmentRootPid);
           if (currentRootIdentity === containmentRootIdentity) {
-            const namespaceId = processRuntime.processNamespaceId?.(containmentRootPid);
-            const namespacePid = processRuntime.processNamespacePid?.(containmentRootPid);
-            const confirmedIdentity = processRuntime.processIdentity(containmentRootPid);
-            if (confirmedIdentity !== currentRootIdentity) containmentRootRetired = true;
-            else if (namespaceId !== containmentNamespaceId || namespacePid !== 1) {
-              failCleanupVerification("resource collector PID namespace root identity changed");
+            if (processExitVerified(containmentRootPid, containmentRootIdentity)) {
+              containmentRootRetired = true;
+            } else {
+              const namespaceId = processRuntime.processNamespaceId?.(containmentRootPid);
+              const namespacePid = processRuntime.processNamespacePid?.(containmentRootPid);
+              const confirmedIdentity = processRuntime.processIdentity(containmentRootPid);
+              if (confirmedIdentity !== currentRootIdentity) containmentRootRetired = true;
+              else if (namespaceId !== containmentNamespaceId || namespacePid !== 1) {
+                failCleanupVerification("resource collector PID namespace root identity changed");
+              }
             }
-          } else if (currentRootIdentity !== null || !processRuntime.pidAlive(containmentRootPid)) {
+          } else if (currentRootIdentity !== null) {
+            containmentRootRetired = true;
+            failCleanupVerification("resource collector PID namespace root identity was recycled");
+          } else if (!processRuntime.pidAlive(containmentRootPid)) {
             containmentRootRetired = true;
           }
         }
@@ -1291,14 +1320,23 @@ async function collectResourcesInWorker(
       for (const [ownedPid, identity] of ownedProcesses) {
         const currentIdentity = processRuntime.processIdentity(ownedPid);
         if (currentIdentity === identity) {
-          active.push(ownedPid);
+          if (processExitVerified(ownedPid, identity)) continue;
+          const confirmedIdentity = processRuntime.processIdentity(ownedPid);
+          if (confirmedIdentity === identity) active.push(ownedPid);
+          else if (confirmedIdentity === null && processRuntime.pidAlive(ownedPid)) uncertain = true;
+          else if (confirmedIdentity !== null && containmentNamespaceId !== null) {
+            failCleanupVerification("resource collector contained process identity was recycled");
+          }
           continue;
         }
         if (currentIdentity === null && processRuntime.pidAlive(ownedPid)) uncertain = true;
+        else if (currentIdentity !== null && containmentNamespaceId !== null) {
+          failCleanupVerification("resource collector contained process identity was recycled");
+        }
       }
       return { active, uncertain };
     };
-    const probeWorkerGroup = (): "absent" | "present" | "unknown" => {
+    const probeWorkerGroup = (): "absent" | "present" | "denied" | "unknown" => {
       if (typeof pid !== "number") return "absent";
       try {
         processRuntime.signal(-pid, 0);
@@ -1309,7 +1347,7 @@ async function collectResourcesInWorker(
           if (!groupSignalSent) groupContinuityLost = true;
           return "absent";
         }
-        if (code === "EPERM") return "present";
+        if (code === "EPERM") return "denied";
         rememberCleanupIssue(error);
         return "unknown";
       }
@@ -1323,13 +1361,33 @@ async function collectResourcesInWorker(
       }
       return false;
     };
-    const signalOwnedCleanup = (signal: NodeJS.Signals, includeNamespace = true) => {
+    const signalOwnedCleanup = (
+      signal: NodeJS.Signals,
+      includeNamespace = true,
+      containmentPhase: "members" | "root" | "all" = "all",
+    ) => {
       refreshOwnedProcesses(includeNamespace);
       if (containmentNamespaceId !== null && containmentRootPid !== null && containmentRootIdentity !== null) {
-        const containmentTargets = signal === "SIGTERM"
-          ? ownedProcessState().active.filter((ownedPid) => ownedPid !== containmentRootPid
-            && processRuntime.processNamespaceId?.(ownedPid) === containmentNamespaceId)
-          : [];
+        const containmentMembers = ownedProcessState().active.filter((ownedPid) => ownedPid !== containmentRootPid
+          && processRuntime.processNamespaceId?.(ownedPid) === containmentNamespaceId);
+        const containmentMemberSet = new Set(containmentMembers);
+        let containmentTargets = signal === "SIGTERM" ? containmentMembers : [];
+        if (signal === "SIGTERM" && containmentPhase === "members") {
+          containmentTargets = containmentMembers.filter((ownedPid) => {
+            const identity = ownedProcesses.get(ownedPid);
+            if (identity === undefined || processRuntime.processIdentity(ownedPid) !== identity) return false;
+            let descendants: number[];
+            try {
+              descendants = processRuntime.descendants(ownedPid);
+            } catch (error) {
+              rememberCleanupIssue(error);
+              return false;
+            }
+            if (processRuntime.processIdentity(ownedPid) !== identity) return false;
+            return !descendants.some((descendant) => descendant !== ownedPid
+              && containmentMemberSet.has(descendant));
+          });
+        }
         for (const ownedPid of containmentTargets) {
           const identity = ownedProcesses.get(ownedPid);
           if (identity === undefined) continue;
@@ -1347,20 +1405,48 @@ async function collectResourcesInWorker(
             if ((error as NodeJS.ErrnoException).code !== "ESRCH") rememberCleanupIssue(error);
           }
         }
-        if (containmentRootRetired) return;
+        if (containmentPhase === "members") return;
+        const signalWorkerWrapper = () => {
+          if (typeof pid !== "number" || expectedIdentity === null || pid === containmentRootPid) return;
+          const wrapperIdentity = processRuntime.processIdentity(pid);
+          if (wrapperIdentity === null) return;
+          if (wrapperIdentity !== expectedIdentity || processRuntime.processIdentity(pid) !== wrapperIdentity) {
+            failCleanupVerification("resource collector worker wrapper identity changed before cleanup");
+            return;
+          }
+          if (processExitVerified(pid, expectedIdentity)) return;
+          try {
+            processRuntime.signal(pid, signal);
+          } catch (error) {
+            if ((error as NodeJS.ErrnoException).code !== "ESRCH") rememberCleanupIssue(error);
+          }
+        };
+        if (containmentRootRetired) {
+          signalWorkerWrapper();
+          return;
+        }
         const currentIdentity = processRuntime.processIdentity(containmentRootPid);
         if (currentIdentity === null) {
           if (!processRuntime.pidAlive(containmentRootPid)) containmentRootRetired = true;
+          signalWorkerWrapper();
+          return;
+        }
+        if (processExitVerified(containmentRootPid, containmentRootIdentity)) {
+          containmentRootRetired = true;
+          signalWorkerWrapper();
           return;
         }
         if (currentIdentity !== containmentRootIdentity) {
           containmentRootRetired = true;
+          failCleanupVerification("resource collector PID namespace root identity changed before cleanup");
+          signalWorkerWrapper();
           return;
         }
         if (processRuntime.processNamespaceId?.(containmentRootPid) !== containmentNamespaceId
           || processRuntime.processNamespacePid?.(containmentRootPid) !== 1
           || processRuntime.processIdentity(containmentRootPid) !== currentIdentity) {
           failCleanupVerification("resource collector PID namespace root identity changed before cleanup");
+          signalWorkerWrapper();
           return;
         }
         try {
@@ -1368,6 +1454,7 @@ async function collectResourcesInWorker(
         } catch (error) {
           if ((error as NodeJS.ErrnoException).code !== "ESRCH") rememberCleanupIssue(error);
         }
+        signalWorkerWrapper();
         return;
       }
       const state = ownedProcessState();
@@ -1405,8 +1492,17 @@ async function collectResourcesInWorker(
     };
     const cleanupIsAbsent = (): boolean => {
       const state = ownedProcessState();
+      const wrapperExited = typeof pid === "number" && expectedIdentity !== null
+        && processExitVerified(pid, expectedIdentity);
+      let group = probeWorkerGroup();
+      if (containmentNamespaceId !== null
+        && containmentMembershipEmpty
+        && wrapperExited
+        && group === "present") {
+        group = "absent";
+      }
       const processChecksAbsent = namespaceScanComplete
-        && probeWorkerGroup() === "absent"
+        && group === "absent"
         && state.active.length === 0
         && !state.uncertain;
       const absent = processChecksAbsent && containmentScanComplete && containmentMembershipEmpty;
@@ -1487,6 +1583,7 @@ async function collectResourcesInWorker(
     }
     const clearLifecycleTimers = () => {
       clearTimeout(workerTimer);
+      if (rootCleanupTimer) clearTimeout(rootCleanupTimer);
       if (killTimer) clearTimeout(killTimer);
       if (cleanupDeadlineTimer) clearTimeout(cleanupDeadlineTimer);
       if (cleanupPoll) clearTimeout(cleanupPoll);
@@ -1540,6 +1637,14 @@ async function collectResourcesInWorker(
       clearOwnershipTimers();
       const cleanupDeadlineMs = outcome?.type === "success" ? successCleanupTimeoutMs : cleanupTimeoutMs;
       cleanupDeadlineTimer = setTimeout(() => {
+        refreshOwnedProcesses();
+        const absentAtDeadline = cleanupIsAbsent();
+        if (absentAtDeadline && cleanupIssue === undefined) {
+          cleanupComplete = true;
+          releaseWorkerHandles();
+          settleIfReady();
+          return;
+        }
         if (!outcome && exitFailure) outcome = exitFailure;
         cleanupFailure = new Error(
           "resource collector worker cleanup deadline expired",
@@ -1550,7 +1655,17 @@ async function collectResourcesInWorker(
         settleIfReady();
       }, cleanupDeadlineMs);
       cleanupDeadlineTimer.unref();
-      signalOwnedCleanup("SIGTERM", false);
+      if (containmentNamespaceId === null) {
+        signalOwnedCleanup("SIGTERM", false);
+      } else {
+        signalOwnedCleanup("SIGTERM", false, "members");
+        rootCleanupTimer = setTimeout(() => {
+          if (cleanupComplete) return;
+          signalOwnedCleanup("SIGTERM", false, "root");
+          confirmCleanup();
+        }, memberCleanupPhaseMs);
+        rootCleanupTimer.unref();
+      }
       killTimer = setTimeout(() => {
         signalOwnedCleanup("SIGKILL");
         confirmCleanup();
@@ -1559,7 +1674,12 @@ async function collectResourcesInWorker(
       confirmCleanup();
     };
     const finish = (next: WorkerOutcome) => {
-      if (outcome) return;
+      if (outcome) {
+        if (outcome.type === "success" && next.type === "failure" && next.cause === "worker-output-limit") {
+          outcome = next;
+        }
+        return;
+      }
       outcome = next;
       clearTimeout(workerTimer);
       terminate();
@@ -1637,6 +1757,7 @@ async function collectResourcesInWorker(
         });
         return;
       }
+      if (outcome) return;
       output += chunk;
       while (!outcome) {
         const newline = output.indexOf("\n");
@@ -1709,6 +1830,7 @@ async function collectResourcesInWorker(
           type: "success",
           value: collectedResources(message.payload, message.diagnostic, message.targets, targetEpoch),
         });
+        output = "";
       }
     };
     const onStderr = (chunk: Buffer) => {

--- a/src/lib/resources.ts
+++ b/src/lib/resources.ts
@@ -444,6 +444,7 @@ type ResourceWorkerProcessRuntime = Readonly<{
   descendants(pid: number): number[];
   processGroupId(pid: number): number | null;
   processGroupMembers(groupId: number): number[];
+  namespaceMembers?(owner: string): number[] | null;
   signal(pid: number, signal: NodeJS.Signals | 0): void;
 }>;
 
@@ -528,6 +529,57 @@ function portableProcessGroupMembers(groupId: number): number[] {
   return members;
 }
 
+const RESOURCE_WORKER_OWNER_ENV = "LLV_RESOURCE_COLLECTOR_OWNER";
+
+function linuxWorkerNamespaceMembers(owner: string): number[] | null {
+  let names: string[];
+  try {
+    names = readdirSync("/proc");
+  } catch {
+    return null;
+  }
+  const marker = `${RESOURCE_WORKER_OWNER_ENV}=${owner}`;
+  const members: number[] = [];
+  for (const name of names) {
+    const pid = Number(name);
+    if (!Number.isInteger(pid) || pid <= 0) continue;
+    let environment: string;
+    try {
+      environment = readFileSync(`/proc/${pid}/environ`, "utf8");
+    } catch {
+      continue;
+    }
+    if (!environment.split("\0").includes(marker)) continue;
+    const identity = procBackend.processIdentity(pid);
+    if (identity === null) continue;
+    try {
+      environment = readFileSync(`/proc/${pid}/environ`, "utf8");
+    } catch {
+      continue;
+    }
+    if (environment.split("\0").includes(marker)
+      && procBackend.processIdentity(pid) === identity) members.push(pid);
+  }
+  return members;
+}
+
+function portableWorkerNamespaceMembers(owner: string): number[] | null {
+  const marker = `${RESOURCE_WORKER_OWNER_ENV}=${owner}`;
+  const result = spawnSync("ps", ["eww", "-axo", "pid=,command="], {
+    encoding: "utf8",
+    timeout: 1_000,
+    windowsHide: true,
+    maxBuffer: 16 * 1024 * 1024,
+  });
+  if (result.status !== 0) return null;
+  const members: number[] = [];
+  for (const line of result.stdout.split("\n")) {
+    const match = /^\s*(\d+)\s+/.exec(line);
+    if (match && line.includes(marker)) members.push(Number(match[1]));
+  }
+  return members;
+}
+
 const defaultResourceWorkerProcessRuntime: ResourceWorkerProcessRuntime = {
   pidAlive: (pid) => procBackend.pidAlive(pid),
   processIdentity: (pid) => procBackend.processIdentity(pid),
@@ -536,6 +588,9 @@ const defaultResourceWorkerProcessRuntime: ResourceWorkerProcessRuntime = {
   processGroupMembers: (groupId) => procBackend.name === "linux"
     ? linuxProcessGroupMembers(groupId)
     : portableProcessGroupMembers(groupId),
+  namespaceMembers: (owner) => procBackend.name === "linux"
+    ? linuxWorkerNamespaceMembers(owner)
+    : portableWorkerNamespaceMembers(owner),
   signal: (pid, signal) => process.kill(pid, signal),
 };
 
@@ -554,13 +609,19 @@ export function resolveResourceWorkerLaunch(options: ResourceWorkerLaunchOptions
   const env = options.env ?? process.env;
   const exists = options.exists ?? existsSync;
   const sourceWorker = path.join(cwd, "src/lib/resourceCollector.worker.ts");
+  const bundledWorker = path.join(cwd, ".next/server/resource-collector-worker.js");
+  const sourceWorkerExists = exists(sourceWorker);
+  const bundledWorkerExists = exists(bundledWorker);
+  const availableWorker = sourceWorkerExists || !bundledWorkerExists ? sourceWorker : bundledWorker;
   if (env.LLV_RESOURCE_COLLECTOR_EXECUTABLE) {
-    return { executable: env.LLV_RESOURCE_COLLECTOR_EXECUTABLE, workerPath: sourceWorker };
+    return {
+      executable: env.LLV_RESOURCE_COLLECTOR_EXECUTABLE,
+      workerPath: bundledWorkerExists ? bundledWorker : availableWorker,
+    };
   }
   const bunContainer = "/usr/local/bin/bun-container";
-  if (exists(bunContainer)) return { executable: bunContainer, workerPath: sourceWorker };
-  const bundledWorker = path.join(cwd, ".next/server/resource-collector-worker.js");
-  if (exists(bundledWorker)) {
+  if (sourceWorkerExists && exists(bunContainer)) return { executable: bunContainer, workerPath: sourceWorker };
+  if (bundledWorkerExists) {
     return { executable: options.execPath ?? process.execPath, workerPath: bundledWorker };
   }
   return { executable: "bun", workerPath: sourceWorker };
@@ -798,21 +859,25 @@ async function collectResourcesInWorker(
   const inputTimeoutMs = limits.inputTimeoutMs ?? RESOURCE_FILE_HANDOFF_TIMEOUT_MS;
   const closeTimeoutMs = limits.closeTimeoutMs ?? RESOURCE_WORKER_CLOSE_TIMEOUT_MS;
   const headroomMs = limits.headroomMs ?? RESOURCE_OBSERVE_HEADROOM_MS;
+  const cleanupAbsenceConfirmationMs = Math.min(25, Math.max(5, closeTimeoutMs));
   const cleanupTimeoutMs = Math.max(
-    closeTimeoutMs,
+    closeTimeoutMs + cleanupAbsenceConfirmationMs + 5,
     limits.cleanupTimeoutMs ?? closeTimeoutMs + Math.floor(headroomMs / 2),
   );
-  const cleanupAbsenceConfirmationMs = Math.min(25, Math.max(5, closeTimeoutMs));
+  const successCleanupTimeoutMs = Math.max(
+    cleanupTimeoutMs,
+    closeTimeoutMs + cleanupAbsenceConfirmationMs + 60,
+  );
   const settlementHeadroomMs = Math.max(
     Math.min(250, Math.ceil(observeTimeoutMs * 0.2)),
     RESOURCE_WORKER_SUPERVISOR_EXIT_GRACE_MS + cleanupAbsenceConfirmationMs + Math.max(
       0,
-      headroomMs - Math.max(0, cleanupTimeoutMs - closeTimeoutMs),
+      headroomMs - Math.max(0, successCleanupTimeoutMs - closeTimeoutMs),
     ),
   );
   const workerBudgetMs = Math.max(
     0,
-    observeTimeoutMs - inputTimeoutMs - cleanupTimeoutMs - settlementHeadroomMs,
+    observeTimeoutMs - inputTimeoutMs - successCleanupTimeoutMs - settlementHeadroomMs,
   );
   const timeoutMs = Math.min(limits.timeoutMs ?? RESOURCE_WORKER_TIMEOUT_MS, workerBudgetMs);
   const filesTask = readFiles(fresh);
@@ -840,6 +905,7 @@ async function collectResourcesInWorker(
   }
   const superviseWorker = processRuntime === defaultResourceWorkerProcessRuntime
     && resourceWorkerExecutableCanBeSupervised(launch.executable);
+  const workerOwner = crypto.randomUUID();
   const worker = spawn(
     superviseWorker ? process.execPath : launch.executable,
     superviseWorker ? ["-e", RESOURCE_WORKER_SUPERVISOR, launch.executable, launch.workerPath] : [launch.workerPath],
@@ -847,6 +913,7 @@ async function collectResourcesInWorker(
       cwd: process.cwd(),
       detached: true,
       stdio: ["pipe", "pipe", "pipe"],
+      env: { ...process.env, [RESOURCE_WORKER_OWNER_ENV]: workerOwner },
     },
   );
   return new Promise<CollectedResources>((resolve, reject) => {
@@ -882,6 +949,7 @@ async function collectResourcesInWorker(
     let cleanupIssue: unknown;
     let cleanupFailure: Error | null = null;
     let cleanupVerificationFailed = false;
+    let namespaceScanComplete = processRuntime.namespaceMembers === undefined;
     let groupContinuityLost = false;
     let groupSignalSent = false;
     let leaderExited = false;
@@ -961,7 +1029,38 @@ async function collectResourcesInWorker(
         ownedProcesses.set(member, identity);
       }
     };
-    const refreshOwnedProcesses = (): boolean => {
+    const retainLiveNamespaceMembers = (): boolean => {
+      if (!processRuntime.namespaceMembers) return false;
+      let members: number[] | null;
+      try {
+        members = processRuntime.namespaceMembers(workerOwner);
+      } catch (error) {
+        namespaceScanComplete = false;
+        rememberCleanupIssue(error);
+        return false;
+      }
+      namespaceScanComplete = members !== null;
+      if (members === null) {
+        rememberCleanupIssue(new Error("resource collector worker namespace could not be inspected"));
+        return false;
+      }
+      let discovered = false;
+      for (const member of members) {
+        const identity = processRuntime.processIdentity(member);
+        if (identity === null || processRuntime.processIdentity(member) !== identity) continue;
+        const prior = ownedProcesses.get(member);
+        if (prior !== undefined && prior !== identity) {
+          failCleanupVerification("resource collector namespace member identity was recycled");
+          continue;
+        }
+        if (prior === undefined) {
+          ownedProcesses.set(member, identity);
+          discovered = true;
+        }
+      }
+      return discovered;
+    };
+    const refreshOwnedProcesses = (includeNamespace = true): boolean => {
       let discovered = false;
       const pending = [...ownedProcesses.keys()];
       const inspected = new Set<number>();
@@ -998,7 +1097,7 @@ async function collectResourcesInWorker(
         }
       }
       retainLiveGroupMembers();
-      return discovered;
+      return (includeNamespace && retainLiveNamespaceMembers()) || discovered;
     };
     const ownedProcessState = () => {
       const active: number[] = [];
@@ -1038,8 +1137,8 @@ async function collectResourcesInWorker(
       }
       return false;
     };
-    const signalOwnedCleanup = (signal: NodeJS.Signals) => {
-      refreshOwnedProcesses();
+    const signalOwnedCleanup = (signal: NodeJS.Signals, includeNamespace = true) => {
+      refreshOwnedProcesses(includeNamespace);
       const state = ownedProcessState();
       const group = probeWorkerGroup();
       if (group === "present") {
@@ -1075,7 +1174,10 @@ async function collectResourcesInWorker(
     };
     const cleanupIsAbsent = (): boolean => {
       const state = ownedProcessState();
-      const absent = probeWorkerGroup() === "absent" && state.active.length === 0 && !state.uncertain;
+      const absent = namespaceScanComplete
+        && probeWorkerGroup() === "absent"
+        && state.active.length === 0
+        && !state.uncertain;
       if (absent && cleanupVerificationFailed && cleanupFailure === null) {
         cleanupFailure = new Error(
           "resource collector worker cleanup ownership verification failed",
@@ -1148,14 +1250,8 @@ async function collectResourcesInWorker(
     const terminate = () => {
       if (cleanupStarted) return;
       cleanupStarted = true;
-      refreshOwnedProcesses();
       clearOwnershipTimers();
-      signalOwnedCleanup("SIGTERM");
-      killTimer = setTimeout(() => {
-        signalOwnedCleanup("SIGKILL");
-        confirmCleanup();
-      }, closeTimeoutMs);
-      killTimer.unref();
+      const cleanupDeadlineMs = outcome?.type === "success" ? successCleanupTimeoutMs : cleanupTimeoutMs;
       cleanupDeadlineTimer = setTimeout(() => {
         if (!outcome && exitFailure) outcome = exitFailure;
         cleanupFailure = new Error(
@@ -1165,8 +1261,14 @@ async function collectResourcesInWorker(
         cleanupComplete = true;
         releaseWorkerHandles();
         settleIfReady();
-      }, cleanupTimeoutMs);
+      }, cleanupDeadlineMs);
       cleanupDeadlineTimer.unref();
+      signalOwnedCleanup("SIGTERM", false);
+      killTimer = setTimeout(() => {
+        signalOwnedCleanup("SIGKILL");
+        confirmCleanup();
+      }, closeTimeoutMs);
+      killTimer.unref();
       confirmCleanup();
     };
     const finish = (next: WorkerOutcome) => {
@@ -1456,6 +1558,33 @@ export function createResourcesReader(
     if (succeeded) lastPersistedGeneration = observation.generation;
   };
   let freshFlight: Promise<ResourcesRead> | null = null;
+  let backgroundFlight: Promise<void> | null = null;
+  let latestBackgroundFailure: ResourceCollectorResult<CollectedResources> | null = null;
+  const observeTimeoutMs = options.workerLimits?.observeTimeoutMs ?? RESOURCE_OBSERVE_TIMEOUT_MS;
+
+  const clearBackgroundFailure = (observation: ResourceObservation<CollectedResources>) => {
+    if (latestBackgroundFailure && observation.generation >= latestBackgroundFailure.generation) {
+      latestBackgroundFailure = null;
+    }
+  };
+
+  const revalidateInBackground = (latest: ResourceObservation<CollectedResources>) => {
+    if (backgroundFlight) return;
+    const task = collector.observe(latest.generation, observeTimeoutMs, false)
+      .then((result) => {
+        if (result.failure) {
+          latestBackgroundFailure = result;
+          return;
+        }
+        if (result.observation) {
+          clearBackgroundFailure(result.observation);
+        }
+      })
+      .finally(() => {
+        if (backgroundFlight === task) backgroundFlight = null;
+      });
+    backgroundFlight = task;
+  };
 
   const readOnce = async (fresh: boolean): Promise<ResourcesRead> => {
     const latest = collector.latest();
@@ -1464,9 +1593,12 @@ export function createResourcesReader(
         /* The completed file snapshot remains the response while a bounded
            current scan revalidates in the collector. Its rejection is held
            by the collector, so polling never leaks an unhandled rejection. */
-        void collector.observe(latest.generation, 0, false);
+        revalidateInBackground(latest);
       }
       persist(latest);
+      if (latestBackgroundFailure) {
+        return resourceReadFromResult(latestBackgroundFailure, captureSystem, false, true);
+      }
       return resourceReadFromResult({
         observation: latest,
         generation: latest.generation,
@@ -1478,10 +1610,13 @@ export function createResourcesReader(
     const fence = fresh ? collector.fence() : -1;
     const result = await collector.observe(
       fence,
-      options.workerLimits?.observeTimeoutMs ?? RESOURCE_OBSERVE_TIMEOUT_MS,
+      observeTimeoutMs,
       fresh,
     );
-    if (result.observation && !result.failure) persist(result.observation);
+    if (result.observation && !result.failure) {
+      persist(result.observation);
+      clearBackgroundFailure(result.observation);
+    }
     return resourceReadFromResult(result, captureSystem, fresh);
   };
 

--- a/src/lib/resources.ts
+++ b/src/lib/resources.ts
@@ -140,7 +140,11 @@ export function noteSessionTargets(sessions: Iterable<{ target: string; ref: Kil
   const map = new Map<string, KillTargetRef>();
   for (const { target, ref } of sessions) map.set(target, ref);
   globalStore.__llvResourceTargets = map;
-  globalStore.__llvLastResourceTargets = [...map].map(([target, ref]) => ({ target, ref }));
+  rememberResourceTargets([...map].map(([target, ref]) => ({ target, ref })));
+}
+
+function rememberResourceTargets(sessions: Iterable<{ target: string; ref: KillTargetRef }>): void {
+  globalStore.__llvLastResourceTargets = [...sessions].map(({ target, ref }) => ({ target, ref }));
 }
 
 /** Applies a served observation exactly once in generation order. A consumed
@@ -295,9 +299,9 @@ export async function buildResourceSnapshot(
         }
       });
       sessions.sort((a, b) => b.rssBytes + b.swapBytes - (a.rssBytes + a.swapBytes));
-      noteSessionTargets(killRefs);
+      rememberResourceTargets(killRefs);
     } else {
-      noteSessionTargets([]);
+      rememberResourceTargets([]);
     }
 
     globalStore.__llvLastResourceBuild = { fresh, status: "complete", durationMs: performance.now() - startedAt, phases };
@@ -500,14 +504,13 @@ function resourceReadFromObservation(
   captureSystem: () => ResourcesPayload["system"],
   fresh: boolean,
   collectorId: string,
-  persist = false,
+  persist?: (observation: ResourceObservation<CollectedResources>) => void,
 ): ResourcesRead {
   if (!observation) {
     return fallbackRead({ system: captureSystem(), sessions: [] }, "collector-busy", collectorId);
   }
   const { payload, diagnostic } = observation.value;
   applyResourceTargets(observation.generation, observation.value.targets);
-  if (persist && !observation.degradedReason) persistObservation(observation);
   return {
     payload: fresh ? payload : { ...payload, system: captureSystem() },
     diagnostic: {
@@ -526,7 +529,7 @@ export function createResourcesReader(
   captureSystem: () => ResourcesPayload["system"],
   now: () => number = Date.now,
   diagnosticForBuild: () => ResourceBuildDiagnostic | null = lastResourceBuildDiagnostic,
-  options: { inProcess?: boolean; initial?: ResourceObservation<CollectedResources> | null; persist?: boolean } = {},
+  options: { inProcess?: boolean; initial?: ResourceObservation<CollectedResources> | null; persist?: (observation: ResourceObservation<CollectedResources>) => void } = {},
 ): ResourcesReader {
   const inProcess = options.inProcess ?? process.env.LLV_RESOURCE_COLLECTOR_IN_PROCESS === "1";
   const collectorId = inProcess
@@ -543,6 +546,12 @@ export function createResourcesReader(
       return collectedResources(payload, diagnostic, lastResourceTargetRefs());
     } : collectResourcesInWorker,
   });
+  let lastPersistedGeneration = 0;
+  const persist = (observation: ResourceObservation<CollectedResources>) => {
+    if (observation.degradedReason || observation.generation <= lastPersistedGeneration) return;
+    options.persist?.(observation);
+    lastPersistedGeneration = observation.generation;
+  };
 
   return {
     async read(fresh = false): Promise<ResourcesRead> {
@@ -552,13 +561,15 @@ export function createResourcesReader(
           /* The completed file snapshot remains the response while a bounded
              current scan revalidates in the collector. Its rejection is held
              by the collector, so polling never leaks an unhandled rejection. */
-          void collector.observe(collector.fence(), 0);
+          void collector.observe(latest.generation, 0);
         }
-        return resourceReadFromObservation(latest, captureSystem, false, collectorId, options.persist);
+        persist(latest);
+        return resourceReadFromObservation(latest, captureSystem, false, collectorId);
       }
       const fence = collector.fence();
       const observation = await collector.observe(fence, RESOURCE_OBSERVE_TIMEOUT_MS);
-      return resourceReadFromObservation(observation, captureSystem, fresh, collectorId, options.persist);
+      if (observation) persist(observation);
+      return resourceReadFromObservation(observation, captureSystem, fresh, collectorId);
     },
   };
 }
@@ -573,7 +584,7 @@ function resourcesReader(): ResourcesReader {
       () => captureSystemMemory(),
       Date.now,
       lastResourceBuildDiagnostic,
-      { initial: persistedObservation(), persist: true },
+      { initial: persistedObservation(), persist: persistObservation },
     );
     globalStore.__llvResourcesReader = reader;
   }

--- a/src/lib/resources.ts
+++ b/src/lib/resources.ts
@@ -1,8 +1,8 @@
 import { procBackend } from "@/lib/proc";
 import type { ProcBackend } from "@/lib/proc";
 import crypto from "node:crypto";
-import { chmodSync, existsSync, mkdirSync, readFileSync, renameSync, statSync, unlinkSync, writeFileSync } from "node:fs";
-import { spawn } from "node:child_process";
+import { chmodSync, existsSync, mkdirSync, readFileSync, readdirSync, renameSync, statSync, unlinkSync, writeFileSync } from "node:fs";
+import { spawn, spawnSync } from "node:child_process";
 import path from "node:path";
 import { StringDecoder } from "node:string_decoder";
 import { completedFileScan, currentFileScan } from "@/lib/scanner/scanCache";
@@ -408,9 +408,111 @@ type ResourceWorkerLimits = Partial<{
   inputTimeoutMs: number;
   timeoutMs: number;
   closeTimeoutMs: number;
+  cleanupTimeoutMs: number;
   headroomMs: number;
   outputMaxBytes: number;
 }>;
+
+type ResourceWorkerProcessRuntime = Readonly<{
+  pidAlive(pid: number): boolean;
+  processIdentity(pid: number): string | null;
+  descendants(pid: number): number[];
+  processGroupId(pid: number): number | null;
+  processGroupMembers(groupId: number): number[];
+  signal(pid: number, signal: NodeJS.Signals | 0): void;
+}>;
+
+function linuxWorkerDescendants(root: number): number[] {
+  const descendants: number[] = [];
+  const seen = new Set<number>([root]);
+  const pending = [root];
+  while (pending.length > 0) {
+    const pid = pending.pop()!;
+    descendants.push(pid);
+    let children: string;
+    try {
+      children = readFileSync(`/proc/${pid}/task/${pid}/children`, "utf8");
+    } catch {
+      continue;
+    }
+    for (const raw of children.trim().split(/\s+/)) {
+      const child = Number(raw);
+      if (!Number.isInteger(child) || child <= 0 || seen.has(child)) continue;
+      seen.add(child);
+      pending.push(child);
+    }
+  }
+  return descendants;
+}
+
+function workerDescendants(root: number): number[] {
+  if (procBackend.name === "linux") return linuxWorkerDescendants(root);
+  return descendantPids(root, procBackend.ppidMap());
+}
+
+function linuxProcessGroupId(pid: number): number | null {
+  try {
+    const stat = readFileSync(`/proc/${pid}/stat`, "utf8");
+    const close = stat.lastIndexOf(")");
+    if (close < 0) return null;
+    const group = Number(stat.slice(close + 2).trim().split(/\s+/)[2]);
+    return Number.isInteger(group) && group > 0 ? group : null;
+  } catch {
+    return null;
+  }
+}
+
+function portableProcessGroupId(pid: number): number | null {
+  const result = spawnSync("ps", ["-p", String(pid), "-o", "pgid="], {
+    encoding: "utf8",
+    timeout: 1_000,
+    windowsHide: true,
+  });
+  const group = Number(result.status === 0 ? result.stdout.trim() : "");
+  return Number.isInteger(group) && group > 0 ? group : null;
+}
+
+function linuxProcessGroupMembers(groupId: number): number[] {
+  const members: number[] = [];
+  let names: string[];
+  try {
+    names = readdirSync("/proc");
+  } catch {
+    return members;
+  }
+  for (const name of names) {
+    const pid = Number(name);
+    if (!Number.isInteger(pid) || pid <= 0) continue;
+    if (linuxProcessGroupId(pid) === groupId) members.push(pid);
+  }
+  return members;
+}
+
+function portableProcessGroupMembers(groupId: number): number[] {
+  const result = spawnSync("ps", ["-axo", "pid=,pgid="], {
+    encoding: "utf8",
+    timeout: 1_000,
+    windowsHide: true,
+  });
+  if (result.status !== 0) return [];
+  const members: number[] = [];
+  for (const line of result.stdout.split("\n")) {
+    const match = /^\s*(\d+)\s+(\d+)\s*$/.exec(line);
+    if (match && Number(match[2]) === groupId) members.push(Number(match[1]));
+  }
+  return members;
+}
+
+const defaultResourceWorkerProcessRuntime: ResourceWorkerProcessRuntime = {
+  pidAlive: (pid) => procBackend.pidAlive(pid),
+  processIdentity: (pid) => procBackend.processIdentity(pid),
+  descendants: workerDescendants,
+  processGroupId: (pid) => procBackend.name === "linux" ? linuxProcessGroupId(pid) : portableProcessGroupId(pid),
+  processGroupMembers: (groupId) => procBackend.name === "linux"
+    ? linuxProcessGroupMembers(groupId)
+    : portableProcessGroupMembers(groupId),
+  signal: (pid, signal) => process.kill(pid, signal),
+};
 
 type ResourceWorkerLaunchOptions = {
   cwd?: string;
@@ -664,13 +766,25 @@ async function collectResourcesInWorker(
   readFiles: (fresh: boolean) => Promise<ResourceWorkerFileObservation[]> = readResourceFileSnapshot,
   limits: ResourceWorkerLimits = {},
   targetEpoch = globalStore.__llvResourceTargetEpoch ?? 0,
+  processRuntime: ResourceWorkerProcessRuntime = defaultResourceWorkerProcessRuntime,
 ): Promise<CollectedResources> {
   const launch = resolveResourceWorkerLaunch();
   const observeTimeoutMs = limits.observeTimeoutMs ?? RESOURCE_OBSERVE_TIMEOUT_MS;
   const inputTimeoutMs = limits.inputTimeoutMs ?? RESOURCE_FILE_HANDOFF_TIMEOUT_MS;
   const closeTimeoutMs = limits.closeTimeoutMs ?? RESOURCE_WORKER_CLOSE_TIMEOUT_MS;
   const headroomMs = limits.headroomMs ?? RESOURCE_OBSERVE_HEADROOM_MS;
-  const workerBudgetMs = Math.max(0, observeTimeoutMs - inputTimeoutMs - closeTimeoutMs - headroomMs);
+  const cleanupTimeoutMs = Math.max(
+    closeTimeoutMs,
+    limits.cleanupTimeoutMs ?? closeTimeoutMs + Math.floor(headroomMs / 2),
+  );
+  const settlementHeadroomMs = Math.max(
+    0,
+    headroomMs - Math.max(0, cleanupTimeoutMs - closeTimeoutMs),
+  );
+  const workerBudgetMs = Math.max(
+    0,
+    observeTimeoutMs - inputTimeoutMs - cleanupTimeoutMs - settlementHeadroomMs,
+  );
   const timeoutMs = Math.min(limits.timeoutMs ?? RESOURCE_WORKER_TIMEOUT_MS, workerBudgetMs);
   const filesTask = readFiles(fresh);
   let inputTimer: ReturnType<typeof setTimeout> | undefined;
@@ -702,122 +816,309 @@ async function collectResourcesInWorker(
   });
   return new Promise<CollectedResources>((resolve, reject) => {
     const pid = worker.pid;
-    const expectedIdentity = typeof pid === "number" ? procBackend.processIdentity(pid) : null;
-    let outcome: (() => void) | null = null;
+    const expectedIdentity = typeof pid === "number" ? processRuntime.processIdentity(pid) : null;
+    const groupEstablished = typeof pid === "number"
+      && expectedIdentity !== null
+      && processRuntime.processGroupId(pid) === pid;
+    type WorkerOutcome =
+      | { type: "success"; value: CollectedResources }
+      | {
+          type: "failure";
+          reason: ResourceDegradedReason;
+          cause: ResourceFailureCause;
+          message: string;
+          error?: unknown;
+        };
+    let outcome: WorkerOutcome | null = null;
+    let exitFailure: Extract<WorkerOutcome, { type: "failure" }> | null = null;
     let outputBytes = 0;
     const stderrTail = createResourceDiagnosticTail();
     const stderrDecoder = new StringDecoder("utf8");
-    let closeTimer: ReturnType<typeof setTimeout> | undefined;
+    const ownedProcesses = new Map<number, string>();
+    if (typeof pid === "number" && expectedIdentity !== null) ownedProcesses.set(pid, expectedIdentity);
+    const ownershipTimers: Array<ReturnType<typeof setTimeout>> = [];
+    let killTimer: ReturnType<typeof setTimeout> | undefined;
+    let cleanupDeadlineTimer: ReturnType<typeof setTimeout> | undefined;
     let cleanupPoll: ReturnType<typeof setTimeout> | undefined;
     let cleanupStarted = false;
     let cleanupComplete = false;
+    let cleanupIssue: unknown;
+    let cleanupFailure: Error | null = null;
     let leaderExited = false;
     let workerClosed = false;
+    let streamsDetached = false;
+    let stderrEnded = false;
     let settled = false;
     const workerFailure = (
       reason: ResourceDegradedReason,
       cause: ResourceFailureCause,
       message: string,
       error?: unknown,
-    ) => new ResourceCollectorFailureError(reason, cause, message, { cause: error, stderr: stderrTail.value() });
-    const sameWorker = () => typeof pid === "number"
-      && (expectedIdentity === null || procBackend.processIdentity(pid) === expectedIdentity);
-    const workerGroupExists = () => {
-      if (typeof pid !== "number") return false;
+    ) => new ResourceCollectorFailureError(reason, cause, message, {
+      cause: error,
+      stderr: stderrTail.value(),
+      secondaryCauses: cleanupFailure ? [cleanupFailure] : [],
+    });
+    const rememberCleanupIssue = (error: unknown) => {
+      cleanupIssue ??= error;
+    };
+    const finishStderr = () => {
+      if (stderrEnded) return;
+      stderrEnded = true;
+      stderrTail.append(stderrDecoder.end());
+    };
+    const clearOwnershipTimers = () => {
+      for (const timer of ownershipTimers) clearTimeout(timer);
+      ownershipTimers.length = 0;
+    };
+    const refreshOwnedProcesses = () => {
+      if (typeof pid !== "number" || expectedIdentity === null) return;
+      if (processRuntime.processIdentity(pid) !== expectedIdentity) return;
       try {
-        process.kill(-pid, 0);
-        return true;
+        for (const descendant of processRuntime.descendants(pid)) {
+          if (ownedProcesses.has(descendant)) continue;
+          const identity = processRuntime.processIdentity(descendant);
+          if (identity !== null) ownedProcesses.set(descendant, identity);
+        }
       } catch (error) {
-        return (error as NodeJS.ErrnoException).code !== "ESRCH";
+        rememberCleanupIssue(error);
       }
     };
-    const signalWorkerGroup = (signal: NodeJS.Signals): boolean => {
-      if (typeof pid !== "number") return false;
-      if (!leaderExited && !sameWorker()) return false;
+    const retainContinuousGroupMembers = () => {
+      if (!leaderExited || !groupEstablished || typeof pid !== "number" || expectedIdentity === null) return;
+      let members: number[];
       try {
-        process.kill(-pid, signal);
+        members = processRuntime.processGroupMembers(pid);
       } catch (error) {
-        if ((error as NodeJS.ErrnoException).code !== "ESRCH" && !leaderExited) worker.kill(signal);
+        rememberCleanupIssue(error);
+        return;
       }
-      return true;
+      if (members.includes(pid) && processRuntime.processIdentity(pid) !== expectedIdentity) {
+        rememberCleanupIssue(new Error("resource collector worker group leader identity changed"));
+        return;
+      }
+      const identities = members.map((member) => [member, processRuntime.processIdentity(member)] as const);
+      if (identities.some(([, identity]) => identity === null)) {
+        rememberCleanupIssue(new Error("resource collector worker group member identity is unavailable"));
+        return;
+      }
+      for (const [member, identity] of identities) {
+        if (!ownedProcesses.has(member)) ownedProcesses.set(member, identity!);
+      }
+    };
+    const ownedProcessState = () => {
+      const active: number[] = [];
+      let uncertain = false;
+      for (const [ownedPid, identity] of ownedProcesses) {
+        const currentIdentity = processRuntime.processIdentity(ownedPid);
+        if (currentIdentity === identity) {
+          active.push(ownedPid);
+          continue;
+        }
+        if (currentIdentity === null && processRuntime.pidAlive(ownedPid)) uncertain = true;
+      }
+      return { active, uncertain };
+    };
+    const probeWorkerGroup = (): "absent" | "present" | "unknown" => {
+      if (typeof pid !== "number") return "absent";
+      try {
+        processRuntime.signal(-pid, 0);
+        return "present";
+      } catch (error) {
+        const code = (error as NodeJS.ErrnoException).code;
+        if (code === "ESRCH") return "absent";
+        if (code === "EPERM") return "present";
+        rememberCleanupIssue(error);
+        return "unknown";
+      }
+    };
+    const workerGroupOwned = (active: readonly number[]): boolean => {
+      if (typeof pid !== "number" || expectedIdentity === null) return false;
+      for (const ownedPid of active) {
+        if (processRuntime.processGroupId(ownedPid) === pid) return true;
+      }
+      return false;
+    };
+    const signalOwnedCleanup = (signal: NodeJS.Signals) => {
+      refreshOwnedProcesses();
+      retainContinuousGroupMembers();
+      const state = ownedProcessState();
+      const group = probeWorkerGroup();
+      if (group === "present") {
+        if (workerGroupOwned(state.active)) {
+          try {
+            processRuntime.signal(-pid!, signal);
+          } catch (error) {
+            if ((error as NodeJS.ErrnoException).code !== "ESRCH") rememberCleanupIssue(error);
+          }
+        } else {
+          rememberCleanupIssue(new Error("resource collector worker group ownership could not be verified"));
+        }
+      }
+      for (const ownedPid of state.active) {
+        const identity = ownedProcesses.get(ownedPid);
+        if (identity === undefined || processRuntime.processIdentity(ownedPid) !== identity) continue;
+        try {
+          processRuntime.signal(ownedPid, signal);
+        } catch (error) {
+          if ((error as NodeJS.ErrnoException).code !== "ESRCH") rememberCleanupIssue(error);
+        }
+      }
+    };
+    const cleanupIsAbsent = (): boolean => {
+      const state = ownedProcessState();
+      return probeWorkerGroup() === "absent" && state.active.length === 0 && !state.uncertain;
+    };
+    const releaseWorkerHandles = () => {
+      if (streamsDetached) return;
+      streamsDetached = true;
+      finishStderr();
+      worker.removeAllListeners();
+      for (const stream of [worker.stdin, worker.stdout, worker.stderr]) {
+        stream.removeAllListeners();
+        stream.destroy();
+        (stream as typeof stream & { unref?: () => void }).unref?.();
+      }
+      worker.unref();
+    };
+    const clearLifecycleTimers = () => {
+      clearTimeout(workerTimer);
+      if (killTimer) clearTimeout(killTimer);
+      if (cleanupDeadlineTimer) clearTimeout(cleanupDeadlineTimer);
+      if (cleanupPoll) clearTimeout(cleanupPoll);
+      clearOwnershipTimers();
     };
     const settleIfReady = () => {
-      if (settled || !outcome || !workerClosed || !cleanupComplete) return;
+      if (settled || !outcome || (!workerClosed && !streamsDetached) || !cleanupComplete) return;
       settled = true;
-      outcome();
+      const completed = outcome;
+      clearLifecycleTimers();
+      releaseWorkerHandles();
+      if (cleanupFailure) {
+        if (completed.type === "success") {
+          reject(workerFailure(
+            "collector-crash",
+            "worker-cleanup",
+            "resource collector worker cleanup failed",
+          ));
+        } else {
+          reject(workerFailure(
+            completed.reason,
+            completed.cause,
+            completed.message,
+            completed.error,
+          ));
+        }
+        return;
+      }
+      if (completed.type === "success") resolve(completed.value);
+      else reject(workerFailure(completed.reason, completed.cause, completed.message, completed.error));
     };
-    const confirmWorkerGroupAbsent = () => {
+    const confirmCleanup = () => {
       if (!cleanupStarted || cleanupComplete) return;
-      if (!workerGroupExists()) {
+      if (cleanupIsAbsent()) {
         cleanupComplete = true;
-        if (closeTimer) clearTimeout(closeTimer);
+        if (killTimer) clearTimeout(killTimer);
         if (cleanupPoll) clearTimeout(cleanupPoll);
         settleIfReady();
         return;
       }
-      cleanupPoll = setTimeout(confirmWorkerGroupAbsent, 5);
+      cleanupPoll = setTimeout(confirmCleanup, 5);
+      cleanupPoll.unref();
     };
     const terminate = () => {
       if (cleanupStarted) return;
       cleanupStarted = true;
-      if (!signalWorkerGroup("SIGTERM")) {
-        cleanupComplete = true;
-        settleIfReady();
-        return;
-      }
-      closeTimer = setTimeout(() => {
-        if (workerGroupExists()) signalWorkerGroup("SIGKILL");
-        confirmWorkerGroupAbsent();
+      refreshOwnedProcesses();
+      clearOwnershipTimers();
+      signalOwnedCleanup("SIGTERM");
+      killTimer = setTimeout(() => {
+        signalOwnedCleanup("SIGKILL");
+        confirmCleanup();
       }, closeTimeoutMs);
-      confirmWorkerGroupAbsent();
+      killTimer.unref();
+      cleanupDeadlineTimer = setTimeout(() => {
+        if (!outcome && exitFailure) outcome = exitFailure;
+        cleanupFailure = new Error(
+          "resource collector worker cleanup deadline expired",
+          cleanupIssue === undefined ? undefined : { cause: cleanupIssue },
+        );
+        cleanupComplete = true;
+        releaseWorkerHandles();
+        settleIfReady();
+      }, cleanupTimeoutMs);
+      cleanupDeadlineTimer.unref();
+      confirmCleanup();
     };
-    const finish = (next: () => void) => {
+    const finish = (next: WorkerOutcome) => {
       if (outcome) return;
       outcome = next;
-      clearTimeout(timeout);
+      clearTimeout(workerTimer);
       terminate();
     };
-    const timeout = setTimeout(() => finish(() => reject(workerFailure(
-      "timeout",
-      "worker-timeout",
-      "resource collector worker timed out",
-    ))), timeoutMs);
-    worker.once("error", (error) => finish(() => reject(workerFailure(
-      "collector-crash",
-      "worker-spawn",
-      "resource collector worker failed to start",
+    refreshOwnedProcesses();
+    for (const delay of [0, 5, 20]) {
+      const timer = setTimeout(() => {
+        if (!cleanupStarted && !leaderExited) refreshOwnedProcesses();
+      }, delay);
+      timer.unref();
+      ownershipTimers.push(timer);
+    }
+    const workerTimer = setTimeout(() => finish({
+      type: "failure",
+      reason: "timeout",
+      cause: "worker-timeout",
+      message: "resource collector worker timed out",
+    }), timeoutMs);
+    const onWorkerError = (error: Error) => finish({
+      type: "failure",
+      reason: "collector-crash",
+      cause: "worker-spawn",
+      message: "resource collector worker failed to start",
       error,
-    ))));
-    worker.once("exit", () => {
-      leaderExited = true;
-      clearTimeout(timeout);
-      terminate();
     });
-    worker.once("close", (code, signal) => {
-      clearTimeout(timeout);
-      stderrTail.append(stderrDecoder.end());
+    const onWorkerExit = (code: number | null, signal: NodeJS.Signals | null) => {
+      leaderExited = true;
+      clearOwnershipTimers();
+      clearTimeout(workerTimer);
+      exitFailure = {
+        type: "failure",
+        reason: "collector-crash",
+        cause: "worker-exit",
+        message: `resource collector worker exited before observation (${signal ?? code ?? "unknown"})`,
+      };
+      terminate();
+    };
+    const onWorkerClose = (code: number | null, signal: NodeJS.Signals | null) => {
+      clearTimeout(workerTimer);
+      finishStderr();
       workerClosed = true;
       if (!outcome) {
-        outcome = () => reject(workerFailure(
-          "collector-crash",
-          "worker-exit",
-          `resource collector worker closed before observation (${signal ?? code ?? "unknown"})`,
-        ));
+        outcome = exitFailure ?? {
+          type: "failure",
+          reason: "collector-crash",
+          cause: "worker-exit",
+          message: `resource collector worker closed before observation (${signal ?? code ?? "unknown"})`,
+        };
         terminate();
       }
-      confirmWorkerGroupAbsent();
+      confirmCleanup();
       settleIfReady();
-    });
+    };
+    worker.once("error", onWorkerError);
+    worker.once("exit", onWorkerExit);
+    worker.once("close", onWorkerClose);
     let output = "";
     worker.stdout.setEncoding("utf8");
-    worker.stdout.on("data", (chunk: string) => {
+    const onStdout = (chunk: string) => {
       outputBytes += Buffer.byteLength(chunk);
       if (outputBytes > outputMaxBytes) {
-        finish(() => reject(workerFailure(
-          "collector-crash",
-          "worker-output-limit",
-          "resource collector worker exceeded stdout limit",
-        )));
+        finish({
+          type: "failure",
+          reason: "collector-crash",
+          cause: "worker-output-limit",
+          message: "resource collector worker exceeded stdout limit",
+        });
         return;
       }
       output += chunk;
@@ -829,60 +1130,70 @@ async function collectResourcesInWorker(
       try {
         parsed = JSON.parse(raw);
       } catch {
-        finish(() => reject(workerFailure(
-          "collector-crash",
-          "worker-output-invalid",
-          "resource collector worker emitted invalid JSON",
-        )));
+        finish({
+          type: "failure",
+          reason: "collector-crash",
+          cause: "worker-output-invalid",
+          message: "resource collector worker emitted invalid JSON",
+        });
         return;
       }
       const message = resourceWorkerMessage(parsed);
       if (!message) {
-        finish(() => reject(workerFailure(
-          "collector-crash",
-          "worker-output-invalid",
-          "resource collector worker emitted an invalid message",
-        )));
+        finish({
+          type: "failure",
+          reason: "collector-crash",
+          cause: "worker-output-invalid",
+          message: "resource collector worker emitted an invalid message",
+        });
         return;
       }
       if (message.type === "observation" && message.diagnostic.fresh !== fresh) {
-        finish(() => reject(workerFailure(
-          "collector-crash",
-          "worker-output-invalid",
-          "resource collector worker returned mismatched freshness",
-        )));
+        finish({
+          type: "failure",
+          reason: "collector-crash",
+          cause: "worker-output-invalid",
+          message: "resource collector worker returned mismatched freshness",
+        });
         return;
       }
       if (message.type === "failure") {
-        finish(() => reject(workerFailure(
-          "collector-crash",
-          "worker-failure",
-          "resource collector worker reported a failure",
-          new Error(message.error),
-        )));
+        finish({
+          type: "failure",
+          reason: "collector-crash",
+          cause: "worker-failure",
+          message: "resource collector worker reported a failure",
+          error: new Error(message.error),
+        });
         return;
       }
-      finish(() => {
-        resolve(collectedResources(message.payload, message.diagnostic, message.targets, targetEpoch));
+      finish({
+        type: "success",
+        value: collectedResources(message.payload, message.diagnostic, message.targets, targetEpoch),
       });
-    });
-    worker.stderr.on("data", (chunk: Buffer) => {
+    };
+    const onStderr = (chunk: Buffer) => {
       outputBytes += chunk.length;
       stderrTail.append(stderrDecoder.write(chunk));
       if (outputBytes > outputMaxBytes) {
-        finish(() => reject(workerFailure(
-          "collector-crash",
-          "worker-output-limit",
-          "resource collector worker exceeded output limit",
-        )));
+        finish({
+          type: "failure",
+          reason: "collector-crash",
+          cause: "worker-output-limit",
+          message: "resource collector worker exceeded output limit",
+        });
       }
-    });
-    worker.stdin.once("error", (error) => finish(() => reject(workerFailure(
-      "collector-crash",
-      "worker-input",
-      "resource collector worker input failed",
+    };
+    const onStdinError = (error: Error) => finish({
+      type: "failure",
+      reason: "collector-crash",
+      cause: "worker-input",
+      message: "resource collector worker input failed",
       error,
-    ))));
+    });
+    worker.stdout.on("data", onStdout);
+    worker.stderr.on("data", onStderr);
+    worker.stdin.once("error", onStdinError);
     worker.stdin.end(request);
   });
 }
@@ -993,6 +1304,7 @@ export function createResourcesReader(
     persist?: (observation: ResourceObservation<CollectedResources>) => boolean;
     readFiles?: (fresh: boolean) => Promise<ResourceWorkerFileObservation[]>;
     workerLimits?: ResourceWorkerLimits;
+    workerProcessRuntime?: ResourceWorkerProcessRuntime;
   } = {},
 ): ResourcesReader {
   const inProcess = options.inProcess ?? process.env.LLV_RESOURCE_COLLECTOR_IN_PROCESS === "1";
@@ -1010,7 +1322,13 @@ export function createResourcesReader(
       const diagnostic = diagnosticForBuild();
       if (!diagnostic) throw new Error("resource build completed without diagnostics");
       return collectedResources(payload, diagnostic, lastResourceTargetRefs(), targetEpoch);
-    } : (fresh = false) => collectResourcesInWorker(fresh, options.readFiles, options.workerLimits),
+    } : (fresh = false) => collectResourcesInWorker(
+      fresh,
+      options.readFiles,
+      options.workerLimits,
+      globalStore.__llvResourceTargetEpoch ?? 0,
+      options.workerProcessRuntime,
+    ),
   });
   let lastPersistedGeneration = options.initial?.generation ?? 0;
   const persist = (observation: ResourceObservation<CollectedResources>) => {

--- a/src/lib/resources.ts
+++ b/src/lib/resources.ts
@@ -116,7 +116,7 @@ export type KillTargetRef = TmuxAttachReference;
 
 const globalStore = globalThis as unknown as {
   __llvResourcesReader?: ResourcesReader;
-  __llvResourcesReaderFactory?: unknown;
+  __llvResourcesReaderVersion?: number;
   __llvResourceTargets?: Map<string, KillTargetRef>;
   __llvLastResourceTargets?: Array<{ target: string; ref: KillTargetRef }>;
   __llvResourceTargetsGeneration?: number;
@@ -183,8 +183,8 @@ export function consumeKillTarget(target: string): void {
 export function canonicalResourceEntry(
   snapshot: TranscriptHostSnapshot,
   paneHosts: TranscriptHost[],
-  entriesByPath: Map<string, FileEntry>,
-): FileEntry | null {
+  entriesByPath: Map<string, ResourceFileObservation>,
+): ResourceFileObservation | null {
   for (const candidate of paneHosts) {
     if (!candidate.primaryPath) continue;
     const canonical = snapshot.canonicalFor(candidate.primaryPath);
@@ -204,22 +204,39 @@ function isoFromUnix(seconds: number): string {
 }
 
 export interface ResourceSnapshotDependencies {
-  readFiles(fresh: boolean): Promise<FileEntry[]>;
-  readHosts(fresh: boolean, entries: FileEntry[], ppids: Map<number, number>): Promise<TranscriptHostSnapshot>;
+  readFiles(fresh: boolean): Promise<ResourceFileObservation[]>;
+  readHosts(fresh: boolean, entries: ResourceFileObservation[], ppids: Map<number, number>): Promise<TranscriptHostSnapshot>;
   proc: Pick<ProcBackend, "systemMemory" | "ppidMap" | "processMemory">;
   captureAttachReferences(refs: ReadonlyArray<Pick<TmuxAttachReference, "tmuxServerPid" | "paneId" | "panePid">>): Map<string, TmuxAttachReference>;
 }
 
 const resourceSnapshotDependencies: ResourceSnapshotDependencies = {
   readFiles: readResourceFileSnapshot,
-  readHosts: readTranscriptHosts,
+  readHosts: (fresh, entries, ppids) => readTranscriptHosts(fresh, entries as FileEntry[], ppids),
   proc: procBackend,
   captureAttachReferences: captureTmuxAttachReferences,
 };
 
-export async function readResourceFileSnapshot(fresh: boolean): Promise<FileEntry[]> {
+export type ResourceFileObservation = Readonly<Pick<FileEntry,
+  "path" | "parent" | "title" | "project" | "activity" | "mtime" | "engine" | "pid" | "proc"
+> & { conversationId?: string | null }>;
+export type ResourceWorkerFileObservation = ResourceFileObservation & { conversationId: string | null };
+
+export async function readResourceFileSnapshot(fresh: boolean): Promise<ResourceWorkerFileObservation[]> {
   const scan = fresh ? await currentFileScan({ fresh: true }) : await completedFileScan();
-  return scan.snapshot.files;
+  overlaySessionTitles(scan.snapshot.files);
+  return scan.snapshot.files.map((entry) => ({
+    path: entry.path,
+    parent: entry.parent,
+    title: entry.title,
+    project: entry.project,
+    activity: entry.activity,
+    mtime: entry.mtime,
+    engine: entry.engine,
+    pid: entry.pid,
+    proc: entry.proc,
+    conversationId: entry.conversationId ?? null,
+  }));
 }
 
 /** `fresh` advances the shared file scan and skips the pane/agent-process
@@ -238,7 +255,6 @@ export async function buildResourceSnapshot(
     const hosts = await measureResourcePhaseAsync(phases, "readHosts", () => dependencies.readHosts(fresh, files, ppids));
     const sessions: ResourceSession[] = [];
     if (hosts.hosts.length > 0) {
-      overlaySessionTitles(files);
       const byPath = new Map(files.map((entry) => [entry.path, entry]));
       const byPane = new Map<string, TranscriptHost[]>();
       for (const host of hosts.hosts) {
@@ -299,9 +315,9 @@ export async function buildResourceSnapshot(
         }
       });
       sessions.sort((a, b) => b.rssBytes + b.swapBytes - (a.rssBytes + a.swapBytes));
-      rememberResourceTargets(killRefs);
+      noteSessionTargets(killRefs);
     } else {
-      rememberResourceTargets([]);
+      noteSessionTargets([]);
     }
 
     globalStore.__llvLastResourceBuild = { fresh, status: "complete", durationMs: performance.now() - startedAt, phases };
@@ -316,7 +332,7 @@ export interface ResourcesReader {
   read(fresh?: boolean): Promise<ResourcesRead>;
 }
 
-type CollectedResources = {
+export type CollectedResources = {
   payload: ResourcesPayload;
   diagnostic: ResourceBuildDiagnostic;
   hostCount: number;
@@ -327,12 +343,22 @@ type CollectedResources = {
 const RESOURCE_OBSERVE_TIMEOUT_MS = 30_000;
 const RESOURCE_WORKER_TIMEOUT_MS = 29_500;
 const RESOURCE_WORKER_CLOSE_TIMEOUT_MS = 1_000;
-const RESOURCE_WORKER_OUTPUT_MAX_BYTES = 1_024 * 1_024;
+const RESOURCE_FILE_HANDOFF_TIMEOUT_MS = 500;
+const RESOURCE_WORKER_FRAME_HEADROOM_BYTES = 64 * 1_024;
 const RESOURCE_OBSERVATION_SCHEMA_VERSION = 1;
 const RESOURCE_OBSERVATION_FILE = "resources-observation.json";
-const RESOURCE_OBSERVATION_MAX_BYTES = 16 * 1024 * 1024;
+export const RESOURCE_OBSERVATION_MAX_BYTES = 16 * 1024 * 1024;
+export const RESOURCE_WORKER_OUTPUT_MAX_BYTES = RESOURCE_OBSERVATION_MAX_BYTES + RESOURCE_WORKER_FRAME_HEADROOM_BYTES;
 const RESOURCE_OBSERVATION_MAX_SESSIONS = 10_000;
 const RESOURCE_OBSERVATION_MAX_TARGETS = 10_000;
+const RESOURCE_READER_VERSION = 2;
+
+type ResourceWorkerLimits = Partial<{
+  inputTimeoutMs: number;
+  timeoutMs: number;
+  closeTimeoutMs: number;
+  outputMaxBytes: number;
+}>;
 
 function collectedResources(
   payload: ResourcesPayload,
@@ -352,55 +378,223 @@ type ResourceWorkerMessage =
   | { type: "observation"; payload: ResourcesPayload; diagnostic: ResourceBuildDiagnostic; targets: Array<{ target: string; ref: KillTargetRef }> }
   | { type: "failure"; error: string };
 
-function persistedObservation(): ResourceObservation<CollectedResources> | null {
+function record(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function exactKeys(value: Record<string, unknown>, required: string[], optional: string[] = []): boolean {
+  const allowed = new Set([...required, ...optional]);
+  return required.every((key) => Object.hasOwn(value, key))
+    && Object.keys(value).every((key) => allowed.has(key));
+}
+
+function nullableString(value: unknown): value is string | null {
+  return value === null || typeof value === "string";
+}
+
+function validResourceSystem(value: unknown): boolean {
+  if (value === null) return true;
+  if (!record(value) || !exactKeys(value, ["ramTotal", "ramAvailable", "swapTotal", "swapUsed", "capturedAt"])) return false;
+  return finiteNonNegative(value.ramTotal)
+    && finiteNonNegative(value.ramAvailable)
+    && finiteNonNegative(value.swapTotal)
+    && finiteNonNegative(value.swapUsed)
+    && typeof value.capturedAt === "string"
+    && Number.isFinite(Date.parse(value.capturedAt));
+}
+
+function validResourceSession(value: unknown): boolean {
+  if (!record(value) || !exactKeys(value, [
+    "target", "panePid", "path", "engine", "title", "project", "activity", "lastActiveAt", "cwd", "rssBytes", "swapBytes", "procCount",
+  ], ["hostConflict"])) return false;
+  return typeof value.target === "string" && value.target.length > 0
+    && Number.isSafeInteger(value.panePid) && (value.panePid as number) > 0
+    && nullableString(value.path)
+    && (value.engine === "claude" || value.engine === "codex" || value.engine === null)
+    && nullableString(value.title)
+    && nullableString(value.project)
+    && (value.activity === "live" || value.activity === "recent" || value.activity === "stalled" || value.activity === "idle" || value.activity === null)
+    && nullableString(value.lastActiveAt)
+    && (value.lastActiveAt === null || Number.isFinite(Date.parse(value.lastActiveAt)))
+    && nullableString(value.cwd)
+    && finiteNonNegative(value.rssBytes)
+    && finiteNonNegative(value.swapBytes)
+    && Number.isSafeInteger(value.procCount) && (value.procCount as number) >= 0
+    && (value.hostConflict === undefined || typeof value.hostConflict === "boolean");
+}
+
+function validResourcesPayload(value: unknown): value is ResourcesPayload {
+  if (!record(value) || !exactKeys(value, ["system", "sessions"]) || !validResourceSystem(value.system) || !Array.isArray(value.sessions)) return false;
+  return value.sessions.length <= RESOURCE_OBSERVATION_MAX_SESSIONS && value.sessions.every(validResourceSession);
+}
+
+function validResourceDiagnostic(value: unknown): value is ResourceBuildDiagnostic {
+  if (!record(value) || !exactKeys(value, ["fresh", "status", "durationMs", "phases"]) || !record(value.phases)) return false;
+  const phases = value.phases;
+  const phaseNames: ResourceBuildPhase[] = ["systemMemory", "readFiles", "readHosts", "ppidMap", "processMemory", "attach", "serialization"];
+  return typeof value.fresh === "boolean"
+    && (value.status === "complete" || value.status === "failed")
+    && finiteNonNegative(value.durationMs)
+    && exactKeys(phases, phaseNames)
+    && phaseNames.every((phase) => finiteNonNegative(phases[phase]));
+}
+
+function validKillTargetRef(value: unknown): value is KillTargetRef {
+  if (!record(value) || !exactKeys(value, ["tmuxServerPid", "tmuxServerStartIdentity", "paneId", "panePid", "paneStartIdentity"])) return false;
+  return Number.isSafeInteger(value.tmuxServerPid) && (value.tmuxServerPid as number) > 0
+    && nullableString(value.tmuxServerStartIdentity)
+    && typeof value.paneId === "string" && /^%\d+$/.test(value.paneId)
+    && Number.isSafeInteger(value.panePid) && (value.panePid as number) > 0
+    && nullableString(value.paneStartIdentity);
+}
+
+function validResourceTarget(value: unknown): value is { target: string; ref: KillTargetRef } {
+  return record(value)
+    && exactKeys(value, ["target", "ref"])
+    && typeof value.target === "string"
+    && value.target.length > 0
+    && validKillTargetRef(value.ref);
+}
+
+function resourceTargetsMatchPayload(
+  payload: ResourcesPayload,
+  targets: Array<{ target: string; ref: KillTargetRef }>,
+): boolean {
+  const sessionsByTarget = new Map<string, ResourceSession>();
+  for (const session of payload.sessions) {
+    if (sessionsByTarget.has(session.target)) return false;
+    sessionsByTarget.set(session.target, session);
+  }
+  const seen = new Set<string>();
+  return targets.every(({ target, ref }) => {
+    if (seen.has(target)) return false;
+    seen.add(target);
+    return sessionsByTarget.get(target)?.panePid === ref.panePid;
+  });
+}
+
+function validCollectedResources(value: unknown): value is CollectedResources {
+  if (!record(value) || !exactKeys(value, ["payload", "diagnostic", "hostCount", "treeCount", "targets"])
+    || !validResourcesPayload(value.payload)
+    || !validResourceDiagnostic(value.diagnostic)
+    || !Number.isSafeInteger(value.hostCount) || (value.hostCount as number) < 0
+    || !Number.isSafeInteger(value.treeCount) || (value.treeCount as number) < 0
+    || !Array.isArray(value.targets)
+    || value.targets.length > RESOURCE_OBSERVATION_MAX_TARGETS
+    || !value.targets.every(validResourceTarget)) return false;
+  return value.diagnostic.status === "complete"
+    && resourceTargetsMatchPayload(value.payload, value.targets)
+    && value.hostCount === value.payload.sessions.length
+    && value.treeCount === value.payload.sessions.reduce((total, session) => total + session.procCount, 0);
+}
+
+function resourceWorkerMessage(value: unknown): ResourceWorkerMessage | null {
+  if (!record(value)) return null;
+  const candidate = value;
+  if (candidate.type === "failure") {
+    return exactKeys(candidate, ["type", "error"])
+      && typeof candidate.error === "string"
+      && candidate.error.length <= 4_096
+      ? candidate as ResourceWorkerMessage
+      : null;
+  }
+  if (candidate.type !== "observation" || !exactKeys(candidate, ["type", "payload", "diagnostic", "targets"])
+    || !validResourcesPayload(candidate.payload)
+    || !validResourceDiagnostic(candidate.diagnostic)
+    || !Array.isArray(candidate.targets)
+    || candidate.targets.length > RESOURCE_OBSERVATION_MAX_TARGETS
+    || !candidate.targets.every(validResourceTarget)) return null;
+  if (candidate.diagnostic.status !== "complete" || !resourceTargetsMatchPayload(candidate.payload, candidate.targets)) return null;
+  return candidate as ResourceWorkerMessage;
+}
+
+export function parsePersistedResourceObservation(raw: string): ResourceObservation<CollectedResources> | null {
+  if (Buffer.byteLength(raw) <= 0 || Buffer.byteLength(raw) > RESOURCE_OBSERVATION_MAX_BYTES) return null;
   try {
-    const filename = statePath(RESOURCE_OBSERVATION_FILE);
-    const size = statSync(filename).size;
-    if (size <= 0 || size > RESOURCE_OBSERVATION_MAX_BYTES) return null;
-    const candidate = JSON.parse(readFileSync(filename, "utf8")) as { version?: unknown; observation?: unknown };
-    const observation = candidate.observation as Partial<ResourceObservation<CollectedResources>> | undefined;
-    if (candidate.version !== RESOURCE_OBSERVATION_SCHEMA_VERSION || !observation
-      || !Number.isSafeInteger(observation.generation) || (observation.generation ?? -1) < 0
+    const candidate = JSON.parse(raw) as unknown;
+    if (!record(candidate) || !exactKeys(candidate, ["version", "observation"])
+      || candidate.version !== RESOURCE_OBSERVATION_SCHEMA_VERSION
+      || !record(candidate.observation)) return null;
+    const observation = candidate.observation;
+    if (!exactKeys(observation, ["generation", "startedAt", "completedAt", "collectorId", "value"], ["degradedReason"])
+      || !Number.isSafeInteger(observation.generation) || (observation.generation as number) < 0
       || !finiteNonNegative(observation.startedAt) || !finiteNonNegative(observation.completedAt)
       || observation.completedAt < observation.startedAt
       || typeof observation.collectorId !== "string" || observation.collectorId.length === 0 || observation.collectorId.length > 256
-      || !observation.value || !observation.value.payload || !Array.isArray(observation.value.payload.sessions)
-      || observation.value.payload.sessions.length > RESOURCE_OBSERVATION_MAX_SESSIONS
-      || !Array.isArray(observation.value.targets) || observation.value.targets.length > RESOURCE_OBSERVATION_MAX_TARGETS
-      || !observation.value.targets.every(({ target, ref }) => typeof target === "string" && target.length > 0
-        && typeof ref === "object" && ref !== null && Number.isSafeInteger(ref.tmuxServerPid)
-        && Number.isSafeInteger(ref.panePid) && typeof ref.paneId === "string" && ref.paneId.startsWith("%"))) return null;
+      || (observation.degradedReason !== undefined
+        && observation.degradedReason !== "collector-busy"
+        && observation.degradedReason !== "timeout"
+        && observation.degradedReason !== "collector-crash")
+      || !validCollectedResources(observation.value)) return null;
     return observation as ResourceObservation<CollectedResources>;
   } catch {
     return null;
   }
 }
 
-function persistObservation(observation: ResourceObservation<CollectedResources>): void {
+function persistedObservation(): ResourceObservation<CollectedResources> | null {
+  try {
+    const filename = statePath(RESOURCE_OBSERVATION_FILE);
+    const size = statSync(filename).size;
+    if (size <= 0 || size > RESOURCE_OBSERVATION_MAX_BYTES) return null;
+    return parsePersistedResourceObservation(readFileSync(filename, "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+function persistObservation(observation: ResourceObservation<CollectedResources>): boolean {
   const filename = statePath(RESOURCE_OBSERVATION_FILE);
   let temporary: string | undefined;
   try {
     mkdirSync(path.dirname(filename), { recursive: true, mode: 0o700 });
     temporary = path.join(path.dirname(filename), `.${path.basename(filename)}.${process.pid}.${crypto.randomUUID()}.tmp`);
-    writeFileSync(temporary, JSON.stringify({ version: RESOURCE_OBSERVATION_SCHEMA_VERSION, observation }) + "\n", { mode: 0o600 });
+    const serialized = JSON.stringify({ version: RESOURCE_OBSERVATION_SCHEMA_VERSION, observation }) + "\n";
+    if (Buffer.byteLength(serialized) > RESOURCE_OBSERVATION_MAX_BYTES) throw new Error("resource observation exceeded durable size limit");
+    writeFileSync(temporary, serialized, { mode: 0o600 });
     renameSync(temporary, filename);
     chmodSync(filename, 0o600);
+    return true;
   } catch (error) {
     if (temporary) {
       try { unlinkSync(temporary); } catch { /* temporary write never completed */ }
     }
     console.error(`[resources] observation persistence failed: ${error instanceof Error ? error.message : String(error)}`);
+    return false;
   }
 }
 
 /** One bounded worker owns one observation. Terminating after either outcome
     prevents a crashed or wedged collection from surviving a request timeout. */
-async function collectResourcesInWorker(): Promise<CollectedResources> {
+async function collectResourcesInWorker(
+  fresh: boolean,
+  readFiles: (fresh: boolean) => Promise<ResourceWorkerFileObservation[]> = readResourceFileSnapshot,
+  limits: ResourceWorkerLimits = {},
+): Promise<CollectedResources> {
   /* The production image ships src/ and Bun. A process adapter keeps the
      worker independent from Next's route bundle and works when Next itself is
      hosted by Node. The explicit in-process flag remains the rollback path. */
   const executable = process.env.LLV_RESOURCE_COLLECTOR_EXECUTABLE
     ?? (existsSync("/usr/local/bin/bun-container") ? "/usr/local/bin/bun-container" : "bun");
+  const filesTask = readFiles(fresh);
+  let inputTimer: ReturnType<typeof setTimeout> | undefined;
+  const files = fresh
+    ? await filesTask
+    : await Promise.race([
+        filesTask,
+        new Promise<ResourceWorkerFileObservation[]>((_, reject) => {
+          inputTimer = setTimeout(() => reject(new Error("resource collector file handoff timed out")), limits.inputTimeoutMs ?? RESOURCE_FILE_HANDOFF_TIMEOUT_MS);
+        }),
+      ]).finally(() => {
+        if (inputTimer) clearTimeout(inputTimer);
+      });
+  const request = JSON.stringify({ type: "collect", fresh, files }) + "\n";
+  const outputMaxBytes = limits.outputMaxBytes ?? RESOURCE_WORKER_OUTPUT_MAX_BYTES;
+  const timeoutMs = limits.timeoutMs ?? RESOURCE_WORKER_TIMEOUT_MS;
+  const closeTimeoutMs = limits.closeTimeoutMs ?? RESOURCE_WORKER_CLOSE_TIMEOUT_MS;
+  if (Buffer.byteLength(request) > RESOURCE_WORKER_OUTPUT_MAX_BYTES) {
+    throw new Error("resource collector input exceeded transport limit");
+  }
   const worker = spawn(executable, [path.join(process.cwd(), "src/lib/resourceCollector.worker.ts")], {
     cwd: process.cwd(),
     stdio: ["pipe", "pipe", "pipe"],
@@ -419,7 +613,7 @@ async function collectResourcesInWorker(): Promise<CollectedResources> {
       worker.kill("SIGTERM");
       closeTimer = setTimeout(() => {
         if (!closed && sameWorker()) worker.kill("SIGKILL");
-      }, RESOURCE_WORKER_CLOSE_TIMEOUT_MS);
+      }, closeTimeoutMs);
     };
     const finish = (next: () => void) => {
       if (outcome) return;
@@ -427,7 +621,7 @@ async function collectResourcesInWorker(): Promise<CollectedResources> {
       clearTimeout(timeout);
       terminate();
     };
-    const timeout = setTimeout(() => finish(() => reject(new Error("resource collector worker timed out"))), RESOURCE_WORKER_TIMEOUT_MS);
+    const timeout = setTimeout(() => finish(() => reject(new Error("resource collector worker timed out"))), timeoutMs);
     worker.once("error", (error) => finish(() => reject(error)));
     worker.once("close", (code, signal) => {
       closed = true;
@@ -443,7 +637,7 @@ async function collectResourcesInWorker(): Promise<CollectedResources> {
     worker.stdout.setEncoding("utf8");
     worker.stdout.on("data", (chunk: string) => {
       outputBytes += Buffer.byteLength(chunk);
-      if (outputBytes > RESOURCE_WORKER_OUTPUT_MAX_BYTES) {
+      if (outputBytes > outputMaxBytes) {
         finish(() => reject(new Error("resource collector worker exceeded stdout limit")));
         return;
       }
@@ -452,11 +646,20 @@ async function collectResourcesInWorker(): Promise<CollectedResources> {
       if (newline < 0) return;
       const raw = output.slice(0, newline);
       output = output.slice(newline + 1);
-      let message: ResourceWorkerMessage;
+      let parsed: unknown;
       try {
-        message = JSON.parse(raw) as ResourceWorkerMessage;
+        parsed = JSON.parse(raw);
       } catch {
         finish(() => reject(new Error("resource collector worker emitted invalid JSON")));
+        return;
+      }
+      const message = resourceWorkerMessage(parsed);
+      if (!message) {
+        finish(() => reject(new Error("resource collector worker emitted an invalid message")));
+        return;
+      }
+      if (message.type === "observation" && message.diagnostic.fresh !== fresh) {
+        finish(() => reject(new Error("resource collector worker returned mismatched freshness")));
         return;
       }
       if (message.type === "failure") {
@@ -469,11 +672,11 @@ async function collectResourcesInWorker(): Promise<CollectedResources> {
     });
     worker.stderr.on("data", (chunk: Buffer) => {
       outputBytes += chunk.length;
-      if (outputBytes > RESOURCE_WORKER_OUTPUT_MAX_BYTES) {
+      if (outputBytes > outputMaxBytes) {
         finish(() => reject(new Error("resource collector worker exceeded output limit")));
       }
     });
-    worker.stdin.end("{\"type\":\"collect\"}\n");
+    worker.stdin.end(request);
   });
 }
 
@@ -528,56 +731,74 @@ export function createResourcesReader(
   captureSystem: () => ResourcesPayload["system"],
   now: () => number = Date.now,
   diagnosticForBuild: () => ResourceBuildDiagnostic | null = lastResourceBuildDiagnostic,
-  options: { inProcess?: boolean; initial?: ResourceObservation<CollectedResources> | null; persist?: (observation: ResourceObservation<CollectedResources>) => void } = {},
+  options: {
+    inProcess?: boolean;
+    initial?: ResourceObservation<CollectedResources> | null;
+    persist?: (observation: ResourceObservation<CollectedResources>) => boolean;
+    readFiles?: (fresh: boolean) => Promise<ResourceWorkerFileObservation[]>;
+    workerLimits?: ResourceWorkerLimits;
+  } = {},
 ): ResourcesReader {
   const inProcess = options.inProcess ?? process.env.LLV_RESOURCE_COLLECTOR_IN_PROCESS === "1";
   const collectorId = inProcess
     ? `in-process:${process.pid}`
     : `worker:${process.pid}`;
-  const collector = createResourceCollector<CollectedResources>({
+  const collector = createResourceCollector<CollectedResources, boolean>({
     collectorId,
     now,
     initial: options.initial,
-    collect: inProcess ? async () => {
-      const payload = await build(true);
+    collect: inProcess ? async (fresh = false) => {
+      const payload = await build(fresh);
       const diagnostic = diagnosticForBuild();
       if (!diagnostic) throw new Error("resource build completed without diagnostics");
       return collectedResources(payload, diagnostic, lastResourceTargetRefs());
-    } : collectResourcesInWorker,
+    } : (fresh = false) => collectResourcesInWorker(fresh, options.readFiles, options.workerLimits),
   });
-  let lastPersistedGeneration = 0;
+  let lastPersistedGeneration = options.initial?.generation ?? 0;
   const persist = (observation: ResourceObservation<CollectedResources>) => {
     if (observation.degradedReason || observation.generation <= lastPersistedGeneration) return;
-    options.persist?.(observation);
-    lastPersistedGeneration = observation.generation;
+    const succeeded = options.persist?.(observation) ?? true;
+    if (succeeded) lastPersistedGeneration = observation.generation;
+  };
+  let freshFlight: Promise<ResourcesRead> | null = null;
+
+  const readOnce = async (fresh: boolean): Promise<ResourcesRead> => {
+    const latest = collector.latest();
+    if (!fresh && latest) {
+      if (now() - latest.completedAt >= CACHE_MS) {
+        /* The completed file snapshot remains the response while a bounded
+           current scan revalidates in the collector. Its rejection is held
+           by the collector, so polling never leaks an unhandled rejection. */
+        void collector.observe(latest.generation, 0, false);
+      }
+      persist(latest);
+      return resourceReadFromObservation(latest, captureSystem, false, collectorId);
+    }
+    const fence = fresh ? collector.fence() : -1;
+    const observation = await collector.observe(fence, RESOURCE_OBSERVE_TIMEOUT_MS, fresh);
+    if (observation) persist(observation);
+    return resourceReadFromObservation(observation, captureSystem, fresh, collectorId);
   };
 
   return {
     async read(fresh = false): Promise<ResourcesRead> {
-      const latest = collector.latest();
-      if (!fresh && latest) {
-        if (now() - latest.completedAt >= CACHE_MS) {
-          /* The completed file snapshot remains the response while a bounded
-             current scan revalidates in the collector. Its rejection is held
-             by the collector, so polling never leaks an unhandled rejection. */
-          void collector.observe(latest.generation, 0);
-        }
-        persist(latest);
-        return resourceReadFromObservation(latest, captureSystem, false, collectorId);
+      if (!fresh) return readOnce(false);
+      if (freshFlight) return freshFlight;
+      const task = readOnce(true);
+      freshFlight = task;
+      try {
+        return await task;
+      } finally {
+        if (freshFlight === task) freshFlight = null;
       }
-      const fence = collector.fence();
-      const observation = await collector.observe(fence, RESOURCE_OBSERVE_TIMEOUT_MS);
-      if (observation) persist(observation);
-      return resourceReadFromObservation(observation, captureSystem, fresh, collectorId);
     },
   };
 }
 
 function resourcesReader(): ResourcesReader {
-  const factory = resourcesReader;
   let reader = globalStore.__llvResourcesReader;
-  if (globalStore.__llvResourcesReaderFactory !== factory || !reader) {
-    globalStore.__llvResourcesReaderFactory = factory;
+  if (globalStore.__llvResourcesReaderVersion !== RESOURCE_READER_VERSION || !reader) {
+    globalStore.__llvResourcesReaderVersion = RESOURCE_READER_VERSION;
     reader = createResourcesReader(
       buildResourceSnapshot,
       () => captureSystemMemory(),
@@ -592,7 +813,7 @@ function resourcesReader(): ResourcesReader {
 
 export function resetResourcesForTests(): void {
   globalStore.__llvResourcesReader = undefined;
-  globalStore.__llvResourcesReaderFactory = undefined;
+  globalStore.__llvResourcesReaderVersion = undefined;
   globalStore.__llvResourceTargets = undefined;
   globalStore.__llvLastResourceTargets = undefined;
   globalStore.__llvResourceTargetsGeneration = undefined;

--- a/src/lib/resources.ts
+++ b/src/lib/resources.ts
@@ -504,7 +504,6 @@ function resourceReadFromObservation(
   captureSystem: () => ResourcesPayload["system"],
   fresh: boolean,
   collectorId: string,
-  persist?: (observation: ResourceObservation<CollectedResources>) => void,
 ): ResourcesRead {
   if (!observation) {
     return fallbackRead({ system: captureSystem(), sessions: [] }, "collector-busy", collectorId);

--- a/src/lib/resources.ts
+++ b/src/lib/resources.ts
@@ -1,7 +1,7 @@
 import { procBackend } from "@/lib/proc";
 import type { ProcBackend } from "@/lib/proc";
 import crypto from "node:crypto";
-import { chmodSync, existsSync, mkdirSync, readFileSync, readdirSync, renameSync, statSync, unlinkSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, mkdirSync, readFileSync, readdirSync, readlinkSync, renameSync, statSync, unlinkSync, writeFileSync } from "node:fs";
 import { spawn, spawnSync } from "node:child_process";
 import path from "node:path";
 import { StringDecoder } from "node:string_decoder";
@@ -404,16 +404,30 @@ const RESOURCE_WORKER_SUPERVISOR = `
 const { spawn } = require("node:child_process");
 const child = spawn(process.argv[1], process.argv.slice(2), { stdio: "inherit" });
 let finished = false;
+let terminationRequested = false;
 const finish = (code, signal) => {
   if (finished) return;
   finished = true;
   setTimeout(() => {
     if (signal) process.kill(process.pid, signal);
     else process.exit(code ?? 1);
-  }, ${RESOURCE_WORKER_SUPERVISOR_EXIT_GRACE_MS});
+  }, terminationRequested
+    ? ${RESOURCE_WORKER_SUPERVISOR_EXIT_GRACE_MS}
+    : ${Math.ceil(RESOURCE_WORKER_SUPERVISOR_EXIT_GRACE_MS / 2)});
 };
 child.once("error", () => finish(127, null));
 child.once("exit", finish);
+process.on("SIGTERM", () => { terminationRequested = true; });
+process.on("SIGINT", () => { terminationRequested = true; });
+`;
+/** The worker runs as PID 1 in a private namespace. Its brief TERM grace lets
+    child handlers finish while the kernel retains authority over every fork. */
+const RESOURCE_WORKER_PID_NAMESPACE_ENTRYPOINT = `
+token="$1"
+shift
+read host_pid _ < /proc/self/stat
+printf '%s %s %s\n' "$token" "$host_pid" "$(readlink /proc/self/ns/pid)"
+exec "$@"
 `;
 const RESOURCE_OBSERVATION_MAX_SESSIONS = 10_000;
 const RESOURCE_OBSERVATION_MAX_TARGETS = 10_000;
@@ -439,12 +453,16 @@ type ResourceWorkerLimits = Partial<{
 }>;
 
 type ResourceWorkerProcessRuntime = Readonly<{
+  kernelContainment?: "proven" | "unavailable";
   pidAlive(pid: number): boolean;
   processIdentity(pid: number): string | null;
   descendants(pid: number): number[];
   processGroupId(pid: number): number | null;
   processGroupMembers(groupId: number): number[];
   namespaceMembers?(owner: string): number[] | null;
+  processNamespaceId?(pid: number): string | null;
+  processNamespacePid?(pid: number): number | null;
+  containmentMembers?(namespaceId: string): number[] | null;
   signal(pid: number, signal: NodeJS.Signals | 0): void;
 }>;
 
@@ -580,6 +598,45 @@ function portableWorkerNamespaceMembers(owner: string): number[] | null {
   return members;
 }
 
+function linuxProcessNamespaceId(pid: number): string | null {
+  try {
+    const namespaceId = readlinkSync(`/proc/${pid}/ns/pid`);
+    return /^pid:\[\d+\]$/.test(namespaceId) ? namespaceId : null;
+  } catch {
+    return null;
+  }
+}
+
+function linuxProcessNamespacePid(pid: number): number | null {
+  try {
+    const status = readFileSync(`/proc/${pid}/status`, "utf8");
+    const line = status.split("\n").find((candidate) => candidate.startsWith("NSpid:"));
+    const namespacePid = Number(line?.trim().split(/\s+/).at(-1));
+    return Number.isInteger(namespacePid) && namespacePid > 0 ? namespacePid : null;
+  } catch {
+    return null;
+  }
+}
+
+function linuxProcessNamespaceMembers(namespaceId: string): number[] | null {
+  let names: string[];
+  try {
+    names = readdirSync("/proc");
+  } catch {
+    return null;
+  }
+  const members: number[] = [];
+  for (const name of names) {
+    const pid = Number(name);
+    if (!Number.isInteger(pid) || pid <= 0) continue;
+    const identity = procBackend.processIdentity(pid);
+    if (identity === null || linuxProcessNamespaceId(pid) !== namespaceId) continue;
+    if (procBackend.processIdentity(pid) === identity
+      && linuxProcessNamespaceId(pid) === namespaceId) members.push(pid);
+  }
+  return members;
+}
+
 const defaultResourceWorkerProcessRuntime: ResourceWorkerProcessRuntime = {
   pidAlive: (pid) => procBackend.pidAlive(pid),
   processIdentity: (pid) => procBackend.processIdentity(pid),
@@ -591,6 +648,11 @@ const defaultResourceWorkerProcessRuntime: ResourceWorkerProcessRuntime = {
   namespaceMembers: (owner) => procBackend.name === "linux"
     ? linuxWorkerNamespaceMembers(owner)
     : portableWorkerNamespaceMembers(owner),
+  processNamespaceId: (pid) => procBackend.name === "linux" ? linuxProcessNamespaceId(pid) : null,
+  processNamespacePid: (pid) => procBackend.name === "linux" ? linuxProcessNamespacePid(pid) : null,
+  containmentMembers: (namespaceId) => procBackend.name === "linux"
+    ? linuxProcessNamespaceMembers(namespaceId)
+    : null,
   signal: (pid, signal) => process.kill(pid, signal),
 };
 
@@ -866,7 +928,7 @@ async function collectResourcesInWorker(
   );
   const successCleanupTimeoutMs = Math.max(
     cleanupTimeoutMs,
-    closeTimeoutMs + cleanupAbsenceConfirmationMs + 60,
+    closeTimeoutMs + cleanupAbsenceConfirmationMs + RESOURCE_WORKER_SUPERVISOR_EXIT_GRACE_MS,
   );
   const settlementHeadroomMs = Math.max(
     Math.min(250, Math.ceil(observeTimeoutMs * 0.2)),
@@ -906,9 +968,35 @@ async function collectResourcesInWorker(
   const superviseWorker = processRuntime === defaultResourceWorkerProcessRuntime
     && resourceWorkerExecutableCanBeSupervised(launch.executable);
   const workerOwner = crypto.randomUUID();
+  const workerExecutable = superviseWorker ? process.execPath : launch.executable;
+  const workerArguments = superviseWorker
+    ? ["-e", RESOURCE_WORKER_SUPERVISOR, launch.executable, launch.workerPath]
+    : [launch.workerPath];
+  const namespaceExecutable = ["/usr/bin/unshare", "/bin/unshare"].find(existsSync);
+  const invalidAbsoluteExecutable = launch.executable.includes(path.sep)
+    && !resourceWorkerExecutableCanBeSupervised(launch.executable);
+  const containmentRequested = processRuntime === defaultResourceWorkerProcessRuntime
+    && process.platform === "linux"
+    && namespaceExecutable !== undefined
+    && !invalidAbsoluteExecutable;
+  const containmentToken = crypto.randomUUID();
   const worker = spawn(
-    superviseWorker ? process.execPath : launch.executable,
-    superviseWorker ? ["-e", RESOURCE_WORKER_SUPERVISOR, launch.executable, launch.workerPath] : [launch.workerPath],
+    containmentRequested ? namespaceExecutable : workerExecutable,
+    containmentRequested
+      ? [
+          "--user",
+          "--map-root-user",
+          "--pid",
+          "--fork",
+          "/bin/sh",
+          "-c",
+          RESOURCE_WORKER_PID_NAMESPACE_ENTRYPOINT,
+          "llv-resource-worker",
+          containmentToken,
+          workerExecutable,
+          ...workerArguments,
+        ]
+      : workerArguments,
     {
       cwd: process.cwd(),
       detached: true,
@@ -950,6 +1038,13 @@ async function collectResourcesInWorker(
     let cleanupFailure: Error | null = null;
     let cleanupVerificationFailed = false;
     let namespaceScanComplete = processRuntime.namespaceMembers === undefined;
+    let containmentNamespaceId: string | null = null;
+    let containmentRootPid: number | null = null;
+    let containmentRootIdentity: string | null = null;
+    const injectedContainmentProven = processRuntime !== defaultResourceWorkerProcessRuntime
+      && processRuntime.kernelContainment !== "unavailable";
+    let containmentScanComplete = injectedContainmentProven;
+    let containmentProven = injectedContainmentProven;
     let groupContinuityLost = false;
     let groupSignalSent = false;
     let leaderExited = false;
@@ -983,8 +1078,60 @@ async function collectResourcesInWorker(
       for (const timer of ownershipTimers) clearTimeout(timer);
       ownershipTimers.length = 0;
     };
+    const retainLiveContainmentMembers = (): boolean => {
+      if (!containmentProven || containmentNamespaceId === null || !processRuntime.containmentMembers) {
+        return false;
+      }
+      let members: number[] | null;
+      try {
+        const currentRootIdentity = containmentRootPid === null
+          ? null
+          : processRuntime.processIdentity(containmentRootPid);
+        const rootIsLive = containmentRootPid !== null
+          && containmentRootIdentity !== null
+          && currentRootIdentity === containmentRootIdentity
+          && processRuntime.processNamespaceId?.(containmentRootPid) === containmentNamespaceId
+          && processRuntime.processNamespacePid?.(containmentRootPid) === 1;
+        const rootIsAbsent = containmentRootPid !== null
+          && containmentRootIdentity !== null
+          && currentRootIdentity === null
+          && !processRuntime.pidAlive(containmentRootPid);
+        if (!rootIsLive && !rootIsAbsent && currentRootIdentity !== null) {
+          failCleanupVerification("resource collector PID namespace root identity changed");
+        }
+        if (rootIsLive) members = processRuntime.descendants(containmentRootPid!);
+        else if (rootIsAbsent) members = [];
+        else members = processRuntime.containmentMembers(containmentNamespaceId);
+      } catch (error) {
+        containmentScanComplete = false;
+        rememberCleanupIssue(error);
+        return false;
+      }
+      containmentScanComplete = members !== null;
+      if (members === null) {
+        rememberCleanupIssue(new Error("resource collector PID namespace could not be inspected"));
+        return false;
+      }
+      let discovered = false;
+      for (const member of members) {
+        const identity = processRuntime.processIdentity(member);
+        if (identity === null
+          || processRuntime.processNamespaceId?.(member) !== containmentNamespaceId
+          || processRuntime.processIdentity(member) !== identity) continue;
+        const prior = ownedProcesses.get(member);
+        if (prior !== undefined && prior !== identity) {
+          failCleanupVerification("resource collector PID namespace member identity was recycled");
+          continue;
+        }
+        if (prior === undefined) {
+          ownedProcesses.set(member, identity);
+          discovered = true;
+        }
+      }
+      return discovered;
+    };
     const retainLiveGroupMembers = () => {
-      if (!groupEstablished || groupContinuityLost || groupSignalSent || leaderExited
+      if (containmentNamespaceId !== null || !groupEstablished || groupContinuityLost || groupSignalSent || leaderExited
         || typeof pid !== "number" || expectedIdentity === null) return;
       if (processRuntime.processIdentity(pid) !== expectedIdentity) {
         groupContinuityLost = true;
@@ -1097,7 +1244,11 @@ async function collectResourcesInWorker(
         }
       }
       retainLiveGroupMembers();
-      return (includeNamespace && retainLiveNamespaceMembers()) || discovered;
+      const containmentDiscovered = retainLiveContainmentMembers();
+      const namespaceDiscovered = includeNamespace && containmentNamespaceId === null
+        ? retainLiveNamespaceMembers()
+        : false;
+      return namespaceDiscovered || containmentDiscovered || discovered;
     };
     const ownedProcessState = () => {
       const active: number[] = [];
@@ -1139,6 +1290,44 @@ async function collectResourcesInWorker(
     };
     const signalOwnedCleanup = (signal: NodeJS.Signals, includeNamespace = true) => {
       refreshOwnedProcesses(includeNamespace);
+      if (containmentNamespaceId !== null && containmentRootPid !== null && containmentRootIdentity !== null) {
+        const containmentTargets = signal === "SIGTERM"
+          ? ownedProcessState().active.filter((ownedPid) => ownedPid !== containmentRootPid
+            && processRuntime.processNamespaceId?.(ownedPid) === containmentNamespaceId)
+          : [];
+        for (const ownedPid of containmentTargets) {
+          const identity = ownedProcesses.get(ownedPid);
+          if (identity === undefined) continue;
+          const currentIdentity = processRuntime.processIdentity(ownedPid);
+          if (currentIdentity === null) continue;
+          if (currentIdentity !== identity
+            || processRuntime.processNamespaceId?.(ownedPid) !== containmentNamespaceId
+            || processRuntime.processIdentity(ownedPid) !== currentIdentity) {
+            failCleanupVerification("resource collector PID namespace member identity changed before cleanup");
+            continue;
+          }
+          try {
+            processRuntime.signal(ownedPid, signal);
+          } catch (error) {
+            if ((error as NodeJS.ErrnoException).code !== "ESRCH") rememberCleanupIssue(error);
+          }
+        }
+        const currentIdentity = processRuntime.processIdentity(containmentRootPid);
+        if (currentIdentity === null) return;
+        if (currentIdentity !== containmentRootIdentity
+          || processRuntime.processNamespaceId?.(containmentRootPid) !== containmentNamespaceId
+          || processRuntime.processNamespacePid?.(containmentRootPid) !== 1
+          || processRuntime.processIdentity(containmentRootPid) !== currentIdentity) {
+          failCleanupVerification("resource collector PID namespace root identity changed before cleanup");
+          return;
+        }
+        try {
+          processRuntime.signal(containmentRootPid, signal);
+        } catch (error) {
+          if ((error as NodeJS.ErrnoException).code !== "ESRCH") rememberCleanupIssue(error);
+        }
+        return;
+      }
       const state = ownedProcessState();
       const group = probeWorkerGroup();
       if (group === "present") {
@@ -1174,10 +1363,16 @@ async function collectResourcesInWorker(
     };
     const cleanupIsAbsent = (): boolean => {
       const state = ownedProcessState();
-      const absent = namespaceScanComplete
+      const processChecksAbsent = namespaceScanComplete
         && probeWorkerGroup() === "absent"
         && state.active.length === 0
         && !state.uncertain;
+      const absent = processChecksAbsent && containmentScanComplete;
+      if (processChecksAbsent && !containmentProven && cleanupFailure === null) {
+        cleanupVerificationFailed = true;
+        cleanupFailure = new Error("resource collector kernel containment could not be established");
+        return true;
+      }
       if (absent && cleanupVerificationFailed && cleanupFailure === null) {
         cleanupFailure = new Error(
           "resource collector worker cleanup ownership verification failed",
@@ -1198,6 +1393,39 @@ async function collectResourcesInWorker(
       }
       worker.unref();
     };
+    const acceptContainmentHandshake = (line: string): boolean => {
+      if (!containmentRequested || !line.startsWith(`${containmentToken} `)) return false;
+      const [token, rawRootPid, namespaceId, ...extra] = line.split(" ");
+      const rootPid = Number(rawRootPid);
+      if (line.length > 512 || token !== containmentToken || !Number.isInteger(rootPid) || rootPid <= 0
+        || !/^pid:\[\d+\]$/.test(namespaceId) || extra.length > 0
+        || !processRuntime.containmentMembers || !processRuntime.processNamespaceId
+        || !processRuntime.processNamespacePid) {
+        failCleanupVerification("resource collector PID namespace handshake was invalid");
+        return true;
+      }
+      const rootIdentity = processRuntime.processIdentity(rootPid);
+      const liveRootIsValid = rootIdentity !== null
+        && processRuntime.processNamespaceId(rootPid) === namespaceId
+        && processRuntime.processNamespacePid(rootPid) === 1
+        && processRuntime.processIdentity(rootPid) === rootIdentity;
+      const members = liveRootIsValid ? null : processRuntime.containmentMembers(namespaceId);
+      if (!liveRootIsValid && (members === null || members.length > 0)) {
+        failCleanupVerification("resource collector PID namespace root could not be verified");
+        return true;
+      }
+      containmentNamespaceId = namespaceId;
+      containmentRootPid = rootPid;
+      containmentRootIdentity = rootIdentity;
+      containmentProven = true;
+      containmentScanComplete = members?.length === 0;
+      namespaceScanComplete = true;
+      retainLiveContainmentMembers();
+      return true;
+    };
+    if (!containmentRequested && !containmentProven) {
+      failCleanupVerification("resource collector kernel containment is unavailable");
+    }
     const clearLifecycleTimers = () => {
       clearTimeout(workerTimer);
       if (killTimer) clearTimeout(killTimer);
@@ -1291,13 +1519,20 @@ async function collectResourcesInWorker(
       cause: "worker-timeout",
       message: "resource collector worker timed out",
     }), timeoutMs);
-    const onWorkerError = (error: Error) => finish({
-      type: "failure",
-      reason: "collector-crash",
-      cause: "worker-spawn",
-      message: "resource collector worker failed to start",
-      error,
-    });
+    const onWorkerError = (error: Error) => {
+      if (typeof pid !== "number") {
+        containmentProven = true;
+        containmentScanComplete = true;
+        namespaceScanComplete = true;
+      }
+      finish({
+        type: "failure",
+        reason: "collector-crash",
+        cause: "worker-spawn",
+        message: "resource collector worker failed to start",
+        error,
+      });
+    };
     const onWorkerExit = (code: number | null, signal: NodeJS.Signals | null) => {
       leaderExited = true;
       clearOwnershipTimers();
@@ -1333,7 +1568,7 @@ async function collectResourcesInWorker(
     worker.stdout.setEncoding("utf8");
     const onStdout = (chunk: string) => {
       outputBytes += Buffer.byteLength(chunk);
-      if (outputBytes > outputMaxBytes) {
+      if (outputBytes > outputMaxBytes + (containmentRequested && !containmentProven ? 512 : 0)) {
         finish({
           type: "failure",
           reason: "collector-crash",
@@ -1343,60 +1578,83 @@ async function collectResourcesInWorker(
         return;
       }
       output += chunk;
-      const newline = output.indexOf("\n");
-      if (newline < 0) return;
-      const raw = output.slice(0, newline);
-      output = output.slice(newline + 1);
-      let parsed: unknown;
-      try {
-        parsed = JSON.parse(raw);
-      } catch {
+      while (!outcome) {
+        const newline = output.indexOf("\n");
+        if (newline < 0) return;
+        const raw = output.slice(0, newline);
+        output = output.slice(newline + 1);
+        if (acceptContainmentHandshake(raw)) {
+          outputBytes -= Buffer.byteLength(raw) + 1;
+          if (outputBytes > outputMaxBytes) {
+            finish({
+              type: "failure",
+              reason: "collector-crash",
+              cause: "worker-output-limit",
+              message: "resource collector worker exceeded stdout limit",
+            });
+          }
+          continue;
+        }
+        if (outputBytes > outputMaxBytes) {
+          finish({
+            type: "failure",
+            reason: "collector-crash",
+            cause: "worker-output-limit",
+            message: "resource collector worker exceeded stdout limit",
+          });
+          return;
+        }
+        let parsed: unknown;
+        try {
+          parsed = JSON.parse(raw);
+        } catch {
+          finish({
+            type: "failure",
+            reason: "collector-crash",
+            cause: "worker-output-invalid",
+            message: "resource collector worker emitted invalid JSON",
+          });
+          return;
+        }
+        const message = resourceWorkerMessage(parsed);
+        if (!message) {
+          finish({
+            type: "failure",
+            reason: "collector-crash",
+            cause: "worker-output-invalid",
+            message: "resource collector worker emitted an invalid message",
+          });
+          return;
+        }
+        if (message.type === "observation" && message.diagnostic.fresh !== fresh) {
+          finish({
+            type: "failure",
+            reason: "collector-crash",
+            cause: "worker-output-invalid",
+            message: "resource collector worker returned mismatched freshness",
+          });
+          return;
+        }
+        if (message.type === "failure") {
+          finish({
+            type: "failure",
+            reason: "collector-crash",
+            cause: "worker-failure",
+            message: "resource collector worker reported a failure",
+            error: new Error(message.error),
+          });
+          return;
+        }
         finish({
-          type: "failure",
-          reason: "collector-crash",
-          cause: "worker-output-invalid",
-          message: "resource collector worker emitted invalid JSON",
+          type: "success",
+          value: collectedResources(message.payload, message.diagnostic, message.targets, targetEpoch),
         });
-        return;
       }
-      const message = resourceWorkerMessage(parsed);
-      if (!message) {
-        finish({
-          type: "failure",
-          reason: "collector-crash",
-          cause: "worker-output-invalid",
-          message: "resource collector worker emitted an invalid message",
-        });
-        return;
-      }
-      if (message.type === "observation" && message.diagnostic.fresh !== fresh) {
-        finish({
-          type: "failure",
-          reason: "collector-crash",
-          cause: "worker-output-invalid",
-          message: "resource collector worker returned mismatched freshness",
-        });
-        return;
-      }
-      if (message.type === "failure") {
-        finish({
-          type: "failure",
-          reason: "collector-crash",
-          cause: "worker-failure",
-          message: "resource collector worker reported a failure",
-          error: new Error(message.error),
-        });
-        return;
-      }
-      finish({
-        type: "success",
-        value: collectedResources(message.payload, message.diagnostic, message.targets, targetEpoch),
-      });
     };
     const onStderr = (chunk: Buffer) => {
       outputBytes += chunk.length;
       stderrTail.append(stderrDecoder.write(chunk));
-      if (outputBytes > outputMaxBytes) {
+      if (outputBytes > outputMaxBytes + (containmentRequested && !containmentProven ? 512 : 0)) {
         finish({
           type: "failure",
           reason: "collector-crash",

--- a/src/lib/resources.ts
+++ b/src/lib/resources.ts
@@ -5,7 +5,7 @@ import { chmodSync, closeSync, existsSync, fstatSync, mkdirSync, openSync, readF
 import { spawn, spawnSync } from "node:child_process";
 import path from "node:path";
 import { StringDecoder } from "node:string_decoder";
-import { completedFileScan, currentFileScan } from "@/lib/scanner/scanCache";
+import { completedFileScan, currentResourceFileScan } from "@/lib/scanner/scanCache";
 import {
   createResourceCollector,
   createResourceDiagnosticTail,
@@ -17,9 +17,8 @@ import {
   type ResourceObservation,
 } from "@/lib/resourceCollector";
 import { descendantPids } from "@/lib/proc/memory";
-import { overlaySessionTitles } from "@/lib/session/titleProjection";
+import { overlayResourceSessionTitles } from "@/lib/session/titleProjection";
 import { readTranscriptHosts, type TranscriptHost, type TranscriptHostSnapshot } from "@/lib/agent/transcriptHost";
-import { agentRegistry } from "@/lib/agent/registry";
 import { captureTmuxAttachReferences, type TmuxAttachReference } from "@/lib/tmux";
 import { statePath } from "@/lib/configDir";
 
@@ -243,7 +242,11 @@ export interface ResourceSnapshotDependencies {
 }
 
 const resourceSnapshotDependencies: ResourceSnapshotDependencies = {
-  readFiles: readResourceFileSnapshot,
+  readFiles: async (fresh) => {
+    const files = await readResourceFileSnapshot(fresh);
+    overlayResourceSessionTitles(files as FileEntry[]);
+    return files;
+  },
   readHosts: (fresh, entries, ppids) => readTranscriptHosts(fresh, entries as FileEntry[], ppids),
   proc: procBackend,
   captureAttachReferences: captureTmuxAttachReferences,
@@ -273,15 +276,8 @@ export function resourceWorkerFileSnapshot(
 }
 
 export async function readResourceFileSnapshot(fresh: boolean): Promise<ResourceWorkerFileObservation[]> {
-  const scan = fresh ? await currentFileScan({ fresh: true }) : await completedFileScan();
-  const registrySnapshot = agentRegistry().snapshot();
-  const conversationIdByPath = new Map<string, string>();
-  for (const conversation of Object.values(registrySnapshot.conversations)) {
-    for (const generation of conversation.generations) conversationIdByPath.set(generation.path, conversation.id);
-    for (const pathname of conversation.continuityPaths) conversationIdByPath.set(pathname, conversation.id);
-  }
-  overlaySessionTitles(scan.snapshot.files);
-  return resourceWorkerFileSnapshot(scan.snapshot.files, (pathname) => conversationIdByPath.get(pathname) ?? null);
+  const scan = fresh ? await currentResourceFileScan() : await completedFileScan();
+  return resourceWorkerFileSnapshot(scan.snapshot.files, () => null);
 }
 
 /** `fresh` advances the shared file scan and skips the pane/agent-process
@@ -387,7 +383,8 @@ export type CollectedResources = {
 };
 
 const RESOURCE_OBSERVE_TIMEOUT_MS = 30_000;
-const RESOURCE_FILE_HANDOFF_TIMEOUT_MS = 500;
+/** Exact path discovery stays bounded through high-pressure scheduler turns. */
+const RESOURCE_FILE_HANDOFF_TIMEOUT_MS = 5_000;
 const RESOURCE_WORKER_CLOSE_TIMEOUT_MS = 1_000;
 const RESOURCE_OBSERVE_HEADROOM_MS = 500;
 const RESOURCE_WORKER_TIMEOUT_MS = RESOURCE_OBSERVE_TIMEOUT_MS
@@ -431,7 +428,7 @@ exec "$@"
 `;
 const RESOURCE_OBSERVATION_MAX_SESSIONS = 10_000;
 const RESOURCE_OBSERVATION_MAX_TARGETS = 10_000;
-const RESOURCE_READER_VERSION = 2;
+const RESOURCE_READER_VERSION = 3;
 
 function resourceWorkerExecutableCanBeSupervised(executable: string): boolean {
   try {

--- a/src/lib/resources.ts
+++ b/src/lib/resources.ts
@@ -1,15 +1,16 @@
 import { procBackend } from "@/lib/proc";
 import type { ProcBackend } from "@/lib/proc";
-import { readFileSync } from "node:fs";
+import crypto from "node:crypto";
+import { chmodSync, existsSync, mkdirSync, readFileSync, renameSync, statSync, unlinkSync, writeFileSync } from "node:fs";
 import { spawn } from "node:child_process";
-import { existsSync } from "node:fs";
 import path from "node:path";
 import { completedFileScan, currentFileScan } from "@/lib/scanner/scanCache";
-import { createResourceCollector, type ResourceCollector, type ResourceDegradedReason } from "@/lib/resourceCollector";
+import { createResourceCollector, type ResourceCollector, type ResourceDegradedReason, type ResourceObservation } from "@/lib/resourceCollector";
 import { descendantPids } from "@/lib/proc/memory";
 import { overlaySessionTitles } from "@/lib/session/titleProjection";
 import { readTranscriptHosts, type TranscriptHost, type TranscriptHostSnapshot } from "@/lib/agent/transcriptHost";
-import { captureTmuxAttachReference, type TmuxAttachReference } from "@/lib/tmux";
+import { captureTmuxAttachReferences, type TmuxAttachReference } from "@/lib/tmux";
+import { statePath } from "@/lib/configDir";
 
 import type { FileEntry, ResourceSession, ResourcesPayload } from "./types";
 
@@ -127,14 +128,6 @@ export function lastResourceBuildDiagnostic(): ResourceBuildDiagnostic | null {
   return diagnostic ? { ...diagnostic, phases: { ...diagnostic.phases } } : null;
 }
 
-/** Captures JSON response construction separately from the expensive resource
-    build phases, keeping response serialization visible in live diagnostics. */
-export function noteResourceSerialization(durationMs: number): void {
-  if (globalStore.__llvLastResourceBuild) {
-    globalStore.__llvLastResourceBuild.phases.serialization = durationMs;
-  }
-}
-
 /**
  * Server-held allowlist for the kill-target action: only pane targets present
  * in the last resources snapshot may be killed. A client-supplied arbitrary
@@ -208,16 +201,16 @@ function isoFromUnix(seconds: number): string {
 
 export interface ResourceSnapshotDependencies {
   readFiles(fresh: boolean): Promise<FileEntry[]>;
-  readHosts(fresh: boolean, entries: FileEntry[]): Promise<TranscriptHostSnapshot>;
+  readHosts(fresh: boolean, entries: FileEntry[], ppids: Map<number, number>): Promise<TranscriptHostSnapshot>;
   proc: Pick<ProcBackend, "systemMemory" | "ppidMap" | "processMemory">;
-  captureAttachReference: typeof captureTmuxAttachReference;
+  captureAttachReferences(refs: ReadonlyArray<Pick<TmuxAttachReference, "tmuxServerPid" | "paneId" | "panePid">>): Map<string, TmuxAttachReference>;
 }
 
 const resourceSnapshotDependencies: ResourceSnapshotDependencies = {
   readFiles: readResourceFileSnapshot,
   readHosts: readTranscriptHosts,
   proc: procBackend,
-  captureAttachReference: captureTmuxAttachReference,
+  captureAttachReferences: captureTmuxAttachReferences,
 };
 
 export async function readResourceFileSnapshot(fresh: boolean): Promise<FileEntry[]> {
@@ -237,10 +230,10 @@ export async function buildResourceSnapshot(
   try {
     const system = measureResourcePhase(phases, "systemMemory", () => captureSystemMemory(dependencies.proc));
     const files = await measureResourcePhaseAsync(phases, "readFiles", () => dependencies.readFiles(fresh));
-    const hosts = await measureResourcePhaseAsync(phases, "readHosts", () => dependencies.readHosts(fresh, files));
+    const ppids = measureResourcePhase(phases, "ppidMap", () => dependencies.proc.ppidMap());
+    const hosts = await measureResourcePhaseAsync(phases, "readHosts", () => dependencies.readHosts(fresh, files, ppids));
     const sessions: ResourceSession[] = [];
     if (hosts.hosts.length > 0) {
-      const ppids = measureResourcePhase(phases, "ppidMap", () => dependencies.proc.ppidMap());
       overlaySessionTitles(files);
       const byPath = new Map(files.map((entry) => [entry.path, entry]));
       const byPane = new Map<string, TranscriptHost[]>();
@@ -264,6 +257,11 @@ export async function buildResourceSnapshot(
 
       const killRefs: Array<{ target: string; ref: KillTargetRef }> = [];
       measureResourcePhase(phases, "attach", () => {
+        const attachRefs = dependencies.captureAttachReferences(paneTrees.map(({ host }) => ({
+          tmuxServerPid: host.tmuxServerPid,
+          panePid: host.panePid,
+          paneId: host.paneId,
+        })));
         for (const { host, tree, paneHosts } of paneTrees) {
           let rssBytes = 0;
           let swapBytes = 0;
@@ -292,10 +290,8 @@ export async function buildResourceSnapshot(
             swapBytes,
             procCount: tree.length,
           });
-          killRefs.push({
-            target: host.display,
-            ref: dependencies.captureAttachReference({ tmuxServerPid: host.tmuxServerPid, panePid: host.panePid, paneId: host.paneId }),
-          });
+          const ref = attachRefs.get(host.paneId);
+          if (ref) killRefs.push({ target: host.display, ref });
         }
       });
       sessions.sort((a, b) => b.rssBytes + b.swapBytes - (a.rssBytes + a.swapBytes));
@@ -326,6 +322,13 @@ type CollectedResources = {
 
 const RESOURCE_OBSERVE_TIMEOUT_MS = 30_000;
 const RESOURCE_WORKER_TIMEOUT_MS = 29_500;
+const RESOURCE_WORKER_CLOSE_TIMEOUT_MS = 1_000;
+const RESOURCE_WORKER_OUTPUT_MAX_BYTES = 1_024 * 1_024;
+const RESOURCE_OBSERVATION_SCHEMA_VERSION = 1;
+const RESOURCE_OBSERVATION_FILE = "resources-observation.json";
+const RESOURCE_OBSERVATION_MAX_BYTES = 16 * 1024 * 1024;
+const RESOURCE_OBSERVATION_MAX_SESSIONS = 10_000;
+const RESOURCE_OBSERVATION_MAX_TARGETS = 10_000;
 
 function collectedResources(
   payload: ResourcesPayload,
@@ -345,6 +348,47 @@ type ResourceWorkerMessage =
   | { type: "observation"; payload: ResourcesPayload; diagnostic: ResourceBuildDiagnostic; targets: Array<{ target: string; ref: KillTargetRef }> }
   | { type: "failure"; error: string };
 
+function persistedObservation(): ResourceObservation<CollectedResources> | null {
+  try {
+    const filename = statePath(RESOURCE_OBSERVATION_FILE);
+    const size = statSync(filename).size;
+    if (size <= 0 || size > RESOURCE_OBSERVATION_MAX_BYTES) return null;
+    const candidate = JSON.parse(readFileSync(filename, "utf8")) as { version?: unknown; observation?: unknown };
+    const observation = candidate.observation as Partial<ResourceObservation<CollectedResources>> | undefined;
+    if (candidate.version !== RESOURCE_OBSERVATION_SCHEMA_VERSION || !observation
+      || !Number.isSafeInteger(observation.generation) || (observation.generation ?? -1) < 0
+      || !finiteNonNegative(observation.startedAt) || !finiteNonNegative(observation.completedAt)
+      || observation.completedAt < observation.startedAt
+      || typeof observation.collectorId !== "string" || observation.collectorId.length === 0 || observation.collectorId.length > 256
+      || !observation.value || !observation.value.payload || !Array.isArray(observation.value.payload.sessions)
+      || observation.value.payload.sessions.length > RESOURCE_OBSERVATION_MAX_SESSIONS
+      || !Array.isArray(observation.value.targets) || observation.value.targets.length > RESOURCE_OBSERVATION_MAX_TARGETS
+      || !observation.value.targets.every(({ target, ref }) => typeof target === "string" && target.length > 0
+        && typeof ref === "object" && ref !== null && Number.isSafeInteger(ref.tmuxServerPid)
+        && Number.isSafeInteger(ref.panePid) && typeof ref.paneId === "string" && ref.paneId.startsWith("%"))) return null;
+    return observation as ResourceObservation<CollectedResources>;
+  } catch {
+    return null;
+  }
+}
+
+function persistObservation(observation: ResourceObservation<CollectedResources>): void {
+  const filename = statePath(RESOURCE_OBSERVATION_FILE);
+  let temporary: string | undefined;
+  try {
+    mkdirSync(path.dirname(filename), { recursive: true, mode: 0o700 });
+    temporary = path.join(path.dirname(filename), `.${path.basename(filename)}.${process.pid}.${crypto.randomUUID()}.tmp`);
+    writeFileSync(temporary, JSON.stringify({ version: RESOURCE_OBSERVATION_SCHEMA_VERSION, observation }) + "\n", { mode: 0o600 });
+    renameSync(temporary, filename);
+    chmodSync(filename, 0o600);
+  } catch (error) {
+    if (temporary) {
+      try { unlinkSync(temporary); } catch { /* temporary write never completed */ }
+    }
+    console.error(`[resources] observation persistence failed: ${error instanceof Error ? error.message : String(error)}`);
+  }
+}
+
 /** One bounded worker owns one observation. Terminating after either outcome
     prevents a crashed or wedged collection from surviving a request timeout. */
 async function collectResourcesInWorker(): Promise<CollectedResources> {
@@ -358,22 +402,47 @@ async function collectResourcesInWorker(): Promise<CollectedResources> {
     stdio: ["pipe", "pipe", "pipe"],
   });
   return new Promise<CollectedResources>((resolve, reject) => {
-    let settled = false;
-    const finish = (outcome: () => void) => {
-      if (settled) return;
-      settled = true;
+    const pid = worker.pid;
+    const expectedIdentity = typeof pid === "number" ? procBackend.processIdentity(pid) : null;
+    let outcome: (() => void) | null = null;
+    let closed = false;
+    let outputBytes = 0;
+    let closeTimer: ReturnType<typeof setTimeout> | undefined;
+    const sameWorker = () => typeof pid === "number"
+      && (expectedIdentity === null || procBackend.processIdentity(pid) === expectedIdentity);
+    const terminate = () => {
+      if (worker.exitCode !== null || worker.signalCode !== null || !sameWorker()) return;
+      worker.kill("SIGTERM");
+      closeTimer = setTimeout(() => {
+        if (!closed && sameWorker()) worker.kill("SIGKILL");
+      }, RESOURCE_WORKER_CLOSE_TIMEOUT_MS);
+    };
+    const finish = (next: () => void) => {
+      if (outcome) return;
+      outcome = next;
       clearTimeout(timeout);
-      worker.kill();
-      outcome();
+      terminate();
     };
     const timeout = setTimeout(() => finish(() => reject(new Error("resource collector worker timed out"))), RESOURCE_WORKER_TIMEOUT_MS);
     worker.once("error", (error) => finish(() => reject(error)));
-    worker.once("exit", (code) => {
-      if (code !== 0) finish(() => reject(new Error(`resource collector worker exited with ${code}`)));
+    worker.once("close", (code, signal) => {
+      closed = true;
+      clearTimeout(timeout);
+      if (closeTimer) clearTimeout(closeTimer);
+      if (outcome) {
+        outcome();
+        return;
+      }
+      reject(new Error(`resource collector worker closed before observation (${signal ?? code ?? "unknown"})`));
     });
     let output = "";
     worker.stdout.setEncoding("utf8");
     worker.stdout.on("data", (chunk: string) => {
+      outputBytes += Buffer.byteLength(chunk);
+      if (outputBytes > RESOURCE_WORKER_OUTPUT_MAX_BYTES) {
+        finish(() => reject(new Error("resource collector worker exceeded stdout limit")));
+        return;
+      }
       output += chunk;
       const newline = output.indexOf("\n");
       if (newline < 0) return;
@@ -393,6 +462,12 @@ async function collectResourcesInWorker(): Promise<CollectedResources> {
       finish(() => {
         resolve(collectedResources(message.payload, message.diagnostic, message.targets));
       });
+    });
+    worker.stderr.on("data", (chunk: Buffer) => {
+      outputBytes += chunk.length;
+      if (outputBytes > RESOURCE_WORKER_OUTPUT_MAX_BYTES) {
+        finish(() => reject(new Error("resource collector worker exceeded output limit")));
+      }
     });
     worker.stdin.end("{\"type\":\"collect\"}\n");
   });
@@ -425,12 +500,14 @@ function resourceReadFromObservation(
   captureSystem: () => ResourcesPayload["system"],
   fresh: boolean,
   collectorId: string,
+  persist = false,
 ): ResourcesRead {
   if (!observation) {
     return fallbackRead({ system: captureSystem(), sessions: [] }, "collector-busy", collectorId);
   }
   const { payload, diagnostic } = observation.value;
   applyResourceTargets(observation.generation, observation.value.targets);
+  if (persist && !observation.degradedReason) persistObservation(observation);
   return {
     payload: fresh ? payload : { ...payload, system: captureSystem() },
     diagnostic: {
@@ -449,7 +526,7 @@ export function createResourcesReader(
   captureSystem: () => ResourcesPayload["system"],
   now: () => number = Date.now,
   diagnosticForBuild: () => ResourceBuildDiagnostic | null = lastResourceBuildDiagnostic,
-  options: { inProcess?: boolean } = {},
+  options: { inProcess?: boolean; initial?: ResourceObservation<CollectedResources> | null; persist?: boolean } = {},
 ): ResourcesReader {
   const inProcess = options.inProcess ?? process.env.LLV_RESOURCE_COLLECTOR_IN_PROCESS === "1";
   const collectorId = inProcess
@@ -458,6 +535,7 @@ export function createResourcesReader(
   const collector = createResourceCollector<CollectedResources>({
     collectorId,
     now,
+    initial: options.initial,
     collect: inProcess ? async () => {
       const payload = await build(true);
       const diagnostic = diagnosticForBuild();
@@ -476,11 +554,11 @@ export function createResourcesReader(
              by the collector, so polling never leaks an unhandled rejection. */
           void collector.observe(collector.fence(), 0);
         }
-        return resourceReadFromObservation(latest, captureSystem, false, collectorId);
+        return resourceReadFromObservation(latest, captureSystem, false, collectorId, options.persist);
       }
       const fence = collector.fence();
       const observation = await collector.observe(fence, RESOURCE_OBSERVE_TIMEOUT_MS);
-      return resourceReadFromObservation(observation, captureSystem, fresh, collectorId);
+      return resourceReadFromObservation(observation, captureSystem, fresh, collectorId, options.persist);
     },
   };
 }
@@ -493,6 +571,9 @@ function resourcesReader(): ResourcesReader {
     reader = createResourcesReader(
       buildResourceSnapshot,
       () => captureSystemMemory(),
+      Date.now,
+      lastResourceBuildDiagnostic,
+      { initial: persistedObservation(), persist: true },
     );
     globalStore.__llvResourcesReader = reader;
   }

--- a/src/lib/resources.ts
+++ b/src/lib/resources.ts
@@ -1,8 +1,11 @@
 import { procBackend } from "@/lib/proc";
 import type { ProcBackend } from "@/lib/proc";
 import { readFileSync } from "node:fs";
+import { spawn } from "node:child_process";
+import { existsSync } from "node:fs";
+import path from "node:path";
 import { completedFileScan, currentFileScan } from "@/lib/scanner/scanCache";
-import { createFreshAwareCoalescer } from "@/lib/asyncCoalescer";
+import { createResourceCollector, type ResourceCollector, type ResourceDegradedReason } from "@/lib/resourceCollector";
 import { descendantPids } from "@/lib/proc/memory";
 import { overlaySessionTitles } from "@/lib/session/titleProjection";
 import { readTranscriptHosts, type TranscriptHost, type TranscriptHostSnapshot } from "@/lib/agent/transcriptHost";
@@ -28,6 +31,19 @@ export type ResourceBuildDiagnostic = {
   status: "complete" | "failed";
   durationMs: number;
   phases: ResourceBuildPhases;
+};
+
+export type ServedResourceDiagnostic = ResourceBuildDiagnostic & {
+  generation: number;
+  startedAt: string;
+  completedAt: string;
+  collectorId: string;
+  degradedReason?: ResourceDegradedReason;
+};
+
+export type ResourcesRead = {
+  payload: ResourcesPayload;
+  diagnostic: ServedResourceDiagnostic;
 };
 
 function emptyResourceBuildPhases(): ResourceBuildPhases {
@@ -99,7 +115,10 @@ export type KillTargetRef = TmuxAttachReference;
 
 const globalStore = globalThis as unknown as {
   __llvResourcesReader?: ResourcesReader;
+  __llvResourcesReaderFactory?: unknown;
   __llvResourceTargets?: Map<string, KillTargetRef>;
+  __llvLastResourceTargets?: Array<{ target: string; ref: KillTargetRef }>;
+  __llvResourceTargetsGeneration?: number;
   __llvLastResourceBuild?: ResourceBuildDiagnostic;
 };
 
@@ -128,6 +147,25 @@ export function noteSessionTargets(sessions: Iterable<{ target: string; ref: Kil
   const map = new Map<string, KillTargetRef>();
   for (const { target, ref } of sessions) map.set(target, ref);
   globalStore.__llvResourceTargets = map;
+  globalStore.__llvLastResourceTargets = [...map].map(([target, ref]) => ({ target, ref }));
+}
+
+/** Applies a served observation exactly once in generation order. A consumed
+    target therefore cannot return through a late observation. */
+export function applyResourceTargets(
+  generation: number,
+  sessions: Iterable<{ target: string; ref: KillTargetRef }>,
+): void {
+  if (generation <= (globalStore.__llvResourceTargetsGeneration ?? 0)) return;
+  noteSessionTargets(sessions);
+  globalStore.__llvResourceTargetsGeneration = generation;
+}
+
+/** Serializable target refs from the observation most recently derived in
+    this runtime. Worker adapters return these to the viewer, which remains
+    the only runtime that applies the kill allowlist. */
+export function lastResourceTargetRefs(): Array<{ target: string; ref: KillTargetRef }> {
+  return globalStore.__llvLastResourceTargets?.map(({ target, ref }) => ({ target, ref: { ...ref } })) ?? [];
 }
 
 /** Snapshot pane ref recorded for `target`, or null when it was never listed. */
@@ -275,45 +313,199 @@ export async function buildResourceSnapshot(
 }
 
 export interface ResourcesReader {
-  read(fresh?: boolean): Promise<ResourcesPayload>;
+  read(fresh?: boolean): Promise<ResourcesRead>;
+}
+
+type CollectedResources = {
+  payload: ResourcesPayload;
+  diagnostic: ResourceBuildDiagnostic;
+  hostCount: number;
+  treeCount: number;
+  targets: Array<{ target: string; ref: KillTargetRef }>;
+};
+
+const RESOURCE_OBSERVE_TIMEOUT_MS = 30_000;
+const RESOURCE_WORKER_TIMEOUT_MS = 29_500;
+
+function collectedResources(
+  payload: ResourcesPayload,
+  diagnostic: ResourceBuildDiagnostic,
+  targets: Array<{ target: string; ref: KillTargetRef }> = [],
+): CollectedResources {
+  return {
+    payload,
+    diagnostic,
+    hostCount: payload.sessions.length,
+    treeCount: payload.sessions.reduce((total, session) => total + session.procCount, 0),
+    targets,
+  };
+}
+
+type ResourceWorkerMessage =
+  | { type: "observation"; payload: ResourcesPayload; diagnostic: ResourceBuildDiagnostic; targets: Array<{ target: string; ref: KillTargetRef }> }
+  | { type: "failure"; error: string };
+
+/** One bounded worker owns one observation. Terminating after either outcome
+    prevents a crashed or wedged collection from surviving a request timeout. */
+async function collectResourcesInWorker(): Promise<CollectedResources> {
+  /* The production image ships src/ and Bun. A process adapter keeps the
+     worker independent from Next's route bundle and works when Next itself is
+     hosted by Node. The explicit in-process flag remains the rollback path. */
+  const executable = process.env.LLV_RESOURCE_COLLECTOR_EXECUTABLE
+    ?? (existsSync("/usr/local/bin/bun-container") ? "/usr/local/bin/bun-container" : "bun");
+  const worker = spawn(executable, [path.join(process.cwd(), "src/lib/resourceCollector.worker.ts")], {
+    cwd: process.cwd(),
+    stdio: ["pipe", "pipe", "pipe"],
+  });
+  return new Promise<CollectedResources>((resolve, reject) => {
+    let settled = false;
+    const finish = (outcome: () => void) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeout);
+      worker.kill();
+      outcome();
+    };
+    const timeout = setTimeout(() => finish(() => reject(new Error("resource collector worker timed out"))), RESOURCE_WORKER_TIMEOUT_MS);
+    worker.once("error", (error) => finish(() => reject(error)));
+    worker.once("exit", (code) => {
+      if (code !== 0) finish(() => reject(new Error(`resource collector worker exited with ${code}`)));
+    });
+    let output = "";
+    worker.stdout.setEncoding("utf8");
+    worker.stdout.on("data", (chunk: string) => {
+      output += chunk;
+      const newline = output.indexOf("\n");
+      if (newline < 0) return;
+      const raw = output.slice(0, newline);
+      output = output.slice(newline + 1);
+      let message: ResourceWorkerMessage;
+      try {
+        message = JSON.parse(raw) as ResourceWorkerMessage;
+      } catch {
+        finish(() => reject(new Error("resource collector worker emitted invalid JSON")));
+        return;
+      }
+      if (message.type === "failure") {
+        finish(() => reject(new Error(message.error)));
+        return;
+      }
+      finish(() => {
+        resolve(collectedResources(message.payload, message.diagnostic, message.targets));
+      });
+    });
+    worker.stdin.end("{\"type\":\"collect\"}\n");
+  });
+}
+
+function fallbackRead(
+  payload: ResourcesPayload,
+  reason: ResourceDegradedReason,
+  collectorId: string,
+): ResourcesRead {
+  const capturedAt = new Date().toISOString();
+  return {
+    payload,
+    diagnostic: {
+      fresh: true,
+      status: "failed",
+      durationMs: 0,
+      phases: emptyResourceBuildPhases(),
+      generation: 0,
+      startedAt: capturedAt,
+      completedAt: capturedAt,
+      collectorId,
+      degradedReason: reason,
+    },
+  };
+}
+
+function resourceReadFromObservation(
+  observation: Awaited<ReturnType<ResourceCollector<CollectedResources>["observe"]>>,
+  captureSystem: () => ResourcesPayload["system"],
+  fresh: boolean,
+  collectorId: string,
+): ResourcesRead {
+  if (!observation) {
+    return fallbackRead({ system: captureSystem(), sessions: [] }, "collector-busy", collectorId);
+  }
+  const { payload, diagnostic } = observation.value;
+  applyResourceTargets(observation.generation, observation.value.targets);
+  return {
+    payload: fresh ? payload : { ...payload, system: captureSystem() },
+    diagnostic: {
+      ...diagnostic,
+      generation: observation.generation,
+      startedAt: new Date(observation.startedAt).toISOString(),
+      completedAt: new Date(observation.completedAt).toISOString(),
+      collectorId: observation.collectorId,
+      ...(observation.degradedReason ? { degradedReason: observation.degradedReason } : {}),
+    },
+  };
 }
 
 export function createResourcesReader(
   build: (fresh: boolean) => Promise<ResourcesPayload>,
   captureSystem: () => ResourcesPayload["system"],
   now: () => number = Date.now,
+  diagnosticForBuild: () => ResourceBuildDiagnostic | null = lastResourceBuildDiagnostic,
+  options: { inProcess?: boolean } = {},
 ): ResourcesReader {
-  let cached: { at: number; data: ResourcesPayload } | null = null;
-  const coordinator = createFreshAwareCoalescer<ResourcesPayload>();
-  const rebuild = async (fresh: boolean): Promise<ResourcesPayload> => {
-    const data = await build(fresh);
-    cached = { at: now(), data };
-    return data;
-  };
+  const inProcess = options.inProcess ?? process.env.LLV_RESOURCE_COLLECTOR_IN_PROCESS === "1";
+  const collectorId = inProcess
+    ? `in-process:${process.pid}`
+    : `worker:${process.pid}`;
+  const collector = createResourceCollector<CollectedResources>({
+    collectorId,
+    now,
+    collect: inProcess ? async () => {
+      const payload = await build(true);
+      const diagnostic = diagnosticForBuild();
+      if (!diagnostic) throw new Error("resource build completed without diagnostics");
+      return collectedResources(payload, diagnostic, lastResourceTargetRefs());
+    } : collectResourcesInWorker,
+  });
 
   return {
-    async read(fresh = false): Promise<ResourcesPayload> {
-      if (!fresh && cached) {
-        if (now() - cached.at >= CACHE_MS) {
-          /* A stale resource poll only starts the shared rebuild. The cached
-             session snapshot stays available while filesystem, process, and
-             tmux observations run off the request path. */
-          void coordinator.run(false, rebuild).catch(() => undefined);
+    async read(fresh = false): Promise<ResourcesRead> {
+      const latest = collector.latest();
+      if (!fresh && latest) {
+        if (now() - latest.completedAt >= CACHE_MS) {
+          /* The completed file snapshot remains the response while a bounded
+             current scan revalidates in the collector. Its rejection is held
+             by the collector, so polling never leaks an unhandled rejection. */
+          void collector.observe(collector.fence(), 0);
         }
-        return { ...cached.data, system: captureSystem() };
+        return resourceReadFromObservation(latest, captureSystem, false, collectorId);
       }
-      const data = await coordinator.run(fresh, rebuild);
-      return fresh ? data : { ...data, system: captureSystem() };
+      const fence = collector.fence();
+      const observation = await collector.observe(fence, RESOURCE_OBSERVE_TIMEOUT_MS);
+      return resourceReadFromObservation(observation, captureSystem, fresh, collectorId);
     },
   };
 }
 
 function resourcesReader(): ResourcesReader {
-  globalStore.__llvResourcesReader ??= createResourcesReader(
-    buildResourceSnapshot,
-    () => captureSystemMemory(),
-  );
-  return globalStore.__llvResourcesReader;
+  const factory = resourcesReader;
+  let reader = globalStore.__llvResourcesReader;
+  if (globalStore.__llvResourcesReaderFactory !== factory || !reader) {
+    globalStore.__llvResourcesReaderFactory = factory;
+    reader = createResourcesReader(
+      buildResourceSnapshot,
+      () => captureSystemMemory(),
+    );
+    globalStore.__llvResourcesReader = reader;
+  }
+  return reader;
+}
+
+export function resetResourcesForTests(): void {
+  globalStore.__llvResourcesReader = undefined;
+  globalStore.__llvResourcesReaderFactory = undefined;
+  globalStore.__llvResourceTargets = undefined;
+  globalStore.__llvLastResourceTargets = undefined;
+  globalStore.__llvResourceTargetsGeneration = undefined;
+  globalStore.__llvLastResourceBuild = undefined;
 }
 
 /** Snapshot for GET /api/resources, cached briefly so UI polling stays cheap.
@@ -324,6 +516,15 @@ export async function readResources(fresh = false): Promise<ResourcesPayload> {
   if (fixturePath) {
     noteSessionTargets([]);
     return parseResourcesFixture(readFileSync(fixturePath, "utf8"));
+  }
+  return (await resourcesReader().read(fresh)).payload;
+}
+
+export async function readResourcesWithDiagnostic(fresh = false): Promise<ResourcesRead> {
+  const fixturePath = process.env.LLV_RESOURCES_FIXTURE;
+  if (fixturePath) {
+    noteSessionTargets([]);
+    return fallbackRead(parseResourcesFixture(readFileSync(fixturePath, "utf8")), "collector-busy", "fixture");
   }
   return resourcesReader().read(fresh);
 }

--- a/src/lib/scanner/discover.ts
+++ b/src/lib/scanner/discover.ts
@@ -28,10 +28,18 @@ export interface RawEntry {
   st: fs.Stats;
 }
 
+type RawPath = Omit<RawEntry, "st">;
+
 type Roots = Record<RootKey, string>;
 type RootEntries = [RootKey, string][];
 type Limit = <T>(work: () => Promise<T>) => Promise<T>;
 type Discovery = { raw: RawEntry[]; complete: boolean };
+type PathDiscovery = { paths: RawPath[]; complete: boolean };
+type ResourceScopeSnapshot = {
+  files: FileEntry[];
+  projectCatalog: ProjectCatalogEntry[];
+  complete: boolean;
+};
 const DISCOVERY_DIAGNOSTIC_MS = 60_000;
 let lastDiscoveryDiagnosticAt = Number.NEGATIVE_INFINITY;
 
@@ -65,45 +73,69 @@ function createLimiter(max: number): Limit {
   };
 }
 
-async function walk(rootName: RootKey, roots: Roots, root: string, dir: string, limit: Limit): Promise<Discovery> {
+async function walkPaths(rootName: RootKey, root: string, dir: string, limit: Limit): Promise<PathDiscovery> {
   let entries: fs.Dirent[];
   try {
     entries = await limit(() => readdir(dir, { withFileTypes: true }));
   } catch (error) {
-    return { raw: [], complete: discoveryFailure("read directory", dir, error) };
+    return { paths: [], complete: discoveryFailure("read directory", dir, error) };
   }
-  const chunks = await Promise.all(entries.map(async (entry): Promise<Discovery> => {
+  const chunks = await Promise.all(entries.map(async (entry): Promise<PathDiscovery> => {
     if (entry.isDirectory()) {
-      if (entry.name.startsWith(".git")) return { raw: [], complete: true };
-      return walk(rootName, roots, root, path.join(dir, entry.name), limit);
+      if (entry.name.startsWith(".git")) return { paths: [], complete: true };
+      if (rootName === "claude-projects" && entry.name === "tool-results") return { paths: [], complete: true };
+      return walkPaths(rootName, root, path.join(dir, entry.name), limit);
     }
-    if (!entry.isFile() || !EXTS.some((ext) => entry.name.endsWith(ext))) return { raw: [], complete: true };
-    const pathname = path.join(dir, entry.name);
-    if (rootName === "claude-projects" && pathname.includes(path.sep + "tool-results" + path.sep)) return { raw: [], complete: true };
-    let st: fs.Stats;
+    if (!entry.isFile() || !EXTS.some((ext) => entry.name.endsWith(ext))) return { paths: [], complete: true };
+    return { paths: [{ rootName, root, path: path.join(dir, entry.name) }], complete: true };
+  }));
+  return {
+    paths: chunks.flatMap((chunk) => chunk.paths),
+    complete: chunks.every((chunk) => chunk.complete),
+  };
+}
+
+async function hydrateRawPath(entry: RawPath, roots: Roots, limit: Limit): Promise<Discovery> {
+  const pathname = entry.path;
+  let st: fs.Stats;
+  try {
+    st = await limit(() => stat(pathname));
+  } catch (error) {
+    return { raw: [], complete: discoveryFailure("stat file", pathname, error) };
+  }
+  const isTask = entry.rootName === "claude-tasks" ? taskParts(roots["claude-tasks"], pathname) : null;
+  if (entry.rootName === "claude-tasks" && !isTask) return { raw: [], complete: true };
+  if (st.size === 0 && !isTask) return { raw: [], complete: true };
+  if (isTask) {
+    const [slug, sid, tid] = isTask;
+    const twin = path.join(roots["claude-projects"], slug, sid, "subagents", "agent-" + tid + ".jsonl");
     try {
-      st = await limit(() => stat(pathname));
+      await limit(() => fs.promises.access(twin));
+      return { raw: [], complete: true };
     } catch (error) {
-      return { raw: [], complete: discoveryFailure("stat file", pathname, error) };
-    }
-    const isTask = rootName === "claude-tasks" ? taskParts(roots["claude-tasks"], pathname) : null;
-    if (rootName === "claude-tasks" && !isTask) return { raw: [], complete: true };
-    if (st.size === 0 && !isTask) return { raw: [], complete: true };
-    if (isTask) {
-      const [slug, sid, tid] = isTask;
-      const twin = path.join(roots["claude-projects"], slug, sid, "subagents", "agent-" + tid + ".jsonl");
-      try {
-        await limit(() => fs.promises.access(twin));
-        return { raw: [], complete: true };
-      } catch (error) {
-        if (!isMissing(error)) {
-          return { raw: [], complete: discoveryFailure("access task-output twin", twin, error) };
-        }
+      if (!isMissing(error)) {
+        return { raw: [], complete: discoveryFailure("access task-output twin", twin, error) };
       }
     }
-    return { raw: [{ rootName, root, path: pathname, st }], complete: true };
-  }));
-  return { raw: chunks.flatMap((chunk) => chunk.raw), complete: chunks.every((chunk) => chunk.complete) };
+  }
+  return { raw: [{ ...entry, st }], complete: true };
+}
+
+function deduplicateCodexRollouts<T extends RawPath>(entries: T[]): T[] {
+  const codexRollouts = new Map<string, T>();
+  for (const entry of entries) {
+    const filename = path.basename(entry.path);
+    if (entry.rootName !== "codex-sessions" || !filename.startsWith("rollout-") || !filename.endsWith(".jsonl")) continue;
+    const current = codexRollouts.get(filename);
+    if (!current || current.root !== entry.root) codexRollouts.set(filename, entry);
+  }
+  return entries.filter((entry) => {
+    const filename = path.basename(entry.path);
+    return entry.rootName !== "codex-sessions"
+      || !filename.startsWith("rollout-")
+      || !filename.endsWith(".jsonl")
+      || codexRollouts.get(filename) === entry;
+  });
 }
 
 async function rootExists(root: string, limit: Limit): Promise<{ exists: boolean; complete: boolean }> {
@@ -119,35 +151,103 @@ function rootEntries(roots: Roots | RootEntries): RootEntries {
   return Array.isArray(roots) ? roots : Object.entries(roots) as RootEntries;
 }
 
-async function discoverRaw(roots: Roots | RootEntries, limit: Limit): Promise<Discovery> {
+async function discoverRaw(
+  roots: Roots | RootEntries,
+  limit: Limit,
+  onResourcePaths?: (paths: RawPath[]) => void,
+): Promise<Discovery> {
+  const inventory = await discoverPathInventory(roots, limit);
   const staticRoots = Array.isArray(roots) ? ROOTS : roots;
-  const walked = await Promise.all(rootEntries(roots).map(async ([rootName, root]) => {
-    const status = await rootExists(root, limit);
-    if (!status.exists) return { raw: [], complete: status.complete };
-    return walk(rootName, staticRoots, root, root, limit);
-  }));
-  const raw = walked.flatMap((result) => result.raw);
+  if (onResourcePaths && inventory.complete) {
+    onResourcePaths(deduplicateCodexRollouts(inventory.paths));
+    await new Promise<void>((resolve) => setImmediate(resolve));
+  }
+  const hydrated = await Promise.all(inventory.paths.map((entry) => hydrateRawPath(entry, staticRoots, limit)));
+  const raw = hydrated.flatMap((result) => result.raw);
   /* Codex account roots follow the legacy root in registry order. A copied
      rollout therefore resolves to its managed-account copy before ranking. */
-  const codexRollouts = new Map<string, RawEntry>();
-  await forEachCooperatively(raw, (entry) => {
-    const filename = path.basename(entry.path);
-    if (entry.rootName !== "codex-sessions" || !filename.startsWith("rollout-") || !filename.endsWith(".jsonl")) return;
-    const current = codexRollouts.get(filename);
-    if (!current || current.root !== entry.root) codexRollouts.set(filename, entry);
-  });
-  const deduplicated: RawEntry[] = [];
-  await forEachCooperatively(raw, (entry) => {
-    const filename = path.basename(entry.path);
-    if (entry.rootName !== "codex-sessions" || !filename.startsWith("rollout-") || !filename.endsWith(".jsonl") || codexRollouts.get(filename) === entry) {
-      deduplicated.push(entry);
-    }
-  });
-  return { raw: deduplicated, complete: walked.every((result) => result.complete) };
+  return {
+    raw: deduplicateCodexRollouts(raw),
+    complete: inventory.complete && hydrated.every((result) => result.complete),
+  };
+}
+
+async function discoverPathInventory(
+  roots: Roots | RootEntries,
+  limit: Limit,
+): Promise<PathDiscovery> {
+  const walked = await Promise.all(rootEntries(roots).map(async ([rootName, root]) => {
+    const status = await rootExists(root, limit);
+    if (!status.exists) return { paths: [], complete: status.complete };
+    return walkPaths(rootName, root, root, limit);
+  }));
+  return {
+    paths: walked.flatMap((result) => result.paths),
+    complete: walked.every((result) => result.complete),
+  };
 }
 
 function cappedEntries(ranked: RawEntry[], projectByPath: ReadonlyMap<string, string>): RawEntry[] {
   return selectSchemeWindow(ranked, (entry) => projectByPath.get(entry.path) ?? "other");
+}
+
+function resourceActivity(previous: FileEntry | undefined, mtime: number, size: number): Pick<FileEntry, "activity" | "activityReason"> {
+  const age = Date.now() / 1000 - mtime;
+  if (previous?.size === size && previous.mtime === mtime) {
+    if (previous.activityReason === "jsonl_turn_open" || previous.activityReason === "jsonl_turn_stalled") {
+      return age < 180
+        ? { activity: "live", activityReason: "jsonl_turn_open" }
+        : { activity: "stalled", activityReason: "jsonl_turn_stalled" };
+    }
+    if (previous.activityReason === "jsonl_turn_completed") {
+      return age < 900
+        ? { activity: "recent", activityReason: "jsonl_turn_completed" }
+        : { activity: "idle", activityReason: "jsonl_turn_completed" };
+    }
+  }
+  if (age < 20) return { activity: "live", activityReason: "mtime_fresh" };
+  if (age < 900) return { activity: "recent", activityReason: "mtime_recent" };
+  return { activity: "idle", activityReason: "mtime_old" };
+}
+
+function resourceScopeFromPaths(raw: RawPath[], baseline?: ResourceScopeSnapshot): ResourceScopeSnapshot {
+  const previousByPath = new Map((baseline?.files ?? []).map((entry) => [entry.path, entry] as const));
+  const conversations = raw.filter((entry) => entry.rootName !== "claude-tasks" && entry.path.endsWith(".jsonl"));
+  const files = conversations.map((entry): FileEntry => {
+    const previous = previousByPath.get(entry.path);
+    const engine = entry.rootName === "codex-sessions" ? "codex" as const : "claude" as const;
+    const mtime = previous?.mtime ?? Date.now() / 1000;
+    const size = previous?.size ?? 1;
+    const activity = resourceActivity(previous, mtime, size);
+    const filename = path.basename(entry.path);
+    return {
+      path: entry.path,
+      root: entry.rootName,
+      name: path.relative(entry.root, entry.path),
+      project: previous?.project ?? "other",
+      cwd: previous?.cwd,
+      projectRoot: previous?.projectRoot,
+      worktree: previous?.worktree,
+      title: previous?.title ?? (filename.startsWith("agent-") ? `Subagent ${filename.slice(6).split(".")[0]}` : `${engine === "codex" ? "Codex" : "Claude"} session`),
+      engine,
+      kind: previous?.kind ?? (filename.startsWith("agent-") ? "subagent" : "session"),
+      fmt: engine,
+      parent: previous?.parent ?? null,
+      mtime,
+      size,
+      ...activity,
+      proc: previous?.proc ?? null,
+      pid: previous?.pid ?? null,
+      model: null,
+      pendingQuestion: null,
+      waitingInput: null,
+    };
+  });
+  return {
+    files,
+    projectCatalog: baseline?.projectCatalog ?? [],
+    complete: true,
+  };
 }
 
 async function canonicalProjectCatalog(
@@ -266,7 +366,15 @@ async function entriesFromRaw(
 export async function discoverFilesWithProjectCatalog(
   roots: Roots | RootEntries = scanRootEntries(),
   _selectedProject?: string,
-  options: { persist?: boolean; persistIndex?: boolean; demote?: ReadonlySet<string>; pin?: ReadonlySet<string> } = {},
+  options: {
+    persist?: boolean;
+    persistIndex?: boolean;
+    demote?: ReadonlySet<string>;
+    loadDemote?: () => ReadonlySet<string>;
+    pin?: ReadonlySet<string>;
+    resourceBaseline?: ResourceScopeSnapshot;
+    onResourceSnapshot?: (snapshot: ResourceScopeSnapshot) => void;
+  } = {},
 ): Promise<{
   files: FileEntry[];
   projectCatalog: ProjectCatalogEntry[];
@@ -275,21 +383,28 @@ export async function discoverFilesWithProjectCatalog(
 }> {
   const scanToken = beginProjectCatalogScan(options.persist !== false || options.persistIndex === true);
   const limit = createLimiter(48);
-  const discovery = await discoverRaw(roots, limit);
+  const discovery = await discoverRaw(
+    roots,
+    limit,
+    options.onResourceSnapshot
+      ? (paths) => options.onResourceSnapshot!(resourceScopeFromPaths(paths, options.resourceBaseline))
+      : undefined,
+  );
+  const demote = options.demote ?? options.loadDemote?.();
   const snapshot = await projectCatalogSnapshotFromRaw(discovery.raw, {
     persist: options.persist,
     persistIndex: options.persistIndex,
-    excludedSummaryPaths: options.demote,
+    excludedSummaryPaths: demote,
     scanToken,
     complete: discovery.complete,
   });
   const { projectCatalog, projectByPath } = await canonicalProjectCatalog(
     snapshot.projectByPath,
     snapshot.conversationCatalog,
-    options.demote,
+    demote,
     snapshot.projectCatalog,
   );
-  const entries = await entriesFromRaw(discovery.raw, projectByPath, options.demote, options.pin, snapshot.summaryByPath);
+  const entries = await entriesFromRaw(discovery.raw, projectByPath, demote, options.pin, snapshot.summaryByPath);
   return { ...entries, projectCatalog, complete: snapshot.complete };
 }
 

--- a/src/lib/scanner/index.ts
+++ b/src/lib/scanner/index.ts
@@ -84,6 +84,12 @@ export interface FileScanOptions {
   /** Batch of transcript paths that must survive the recency cap. Used by
       operations that need one activity snapshot for a complete target set. */
   pins?: readonly string[];
+  /** Publishes the current filesystem scope for resource observation. Sidebar
+      metadata and lineage enrichment continue within the same generation. */
+  onResourceSnapshot?: (snapshot: FileCatalogScan) => void;
+  /** Last validated completed generation used only to label current resource
+      paths while the catalog projection for this generation continues. */
+  resourceBaseline?: FileCatalogScan;
 }
 
 export interface FileCatalogScan {
@@ -198,12 +204,23 @@ async function listFilesInternal(
   options: FileScanOptions = {},
 ): Promise<FileCatalogScan> {
   const persist = options.persist === true;
-  const demote = archivedTranscriptPaths();
+  const stagedResourceScope = options.onResourceSnapshot !== undefined;
+  const demote = stagedResourceScope
+    ? undefined
+    : archivedTranscriptPaths();
   const requestedPins = options.pins ? [...options.pins, ...(options.pin ? [options.pin] : [])] : options.pin;
   const pin = pinnedPathsFor(requestedPins);
   const scan = includeProjectCatalog
-    ? await discoverFilesWithProjectCatalog(undefined, selectedProject, { persist, persistIndex: options.persistIndex, demote, pin })
-    : { files: await discoverFiles(undefined, demote, pin), projectCatalog: [], complete: true };
+    ? await discoverFilesWithProjectCatalog(undefined, selectedProject, {
+        persist,
+        persistIndex: options.persistIndex,
+        demote,
+        loadDemote: stagedResourceScope ? archivedTranscriptPaths : undefined,
+        pin,
+        resourceBaseline: options.resourceBaseline,
+        onResourceSnapshot: options.onResourceSnapshot,
+      })
+    : { files: await discoverFiles(undefined, demote ?? archivedTranscriptPaths(), pin), projectCatalog: [], complete: true };
   const entries = scan.files;
   if (options.fresh) {
     const panes = panePidMap(true);
@@ -222,19 +239,26 @@ async function listFilesInternal(
     const models = entryModels(entry);
     entry.model = models.display;
     entry.launchModel = models.launch;
+    entry.effort = entryEffort(entry);
+    entry.plan = planFor(entry);
+    entry.goal = goalFor(entry);
+    entry.ctx = ctxFor(entry);
+    entry.lastTurn = lastTurnFor(entry);
+    entry.pendingWakeup = pendingWakeupFor(entry);
+    pendingQuestionFor(entry);
   });
   await forEachEntryYielding(entries, (entry) => {
     applyProcessState(entry, holders);
   });
   assignTranscriptPids(entries);
   // After pid assignment: the claude effort source is the live process argv.
-  await forEachEntryYielding(entries, (entry) => {
+  await forEachEntryBatchYielding(entries, async (entry) => {
     entry.effort = entryEffort(entry);
     entry.fast = entryFast(entry);
-  });
-  await forEachEntryBatchYielding(entries, async (entry) => {
     const pending = pendingQuestionFor(entry);
-    entry.pendingQuestion = pending && entry.pid !== null ? { ...pending, paneTarget: await resolveTarget(entry.pid) } : pending;
+    entry.pendingQuestion = pending && entry.pid !== null
+      ? { ...pending, paneTarget: await resolveTarget(entry.pid) }
+      : pending;
     const probe = await waitingInputProbe(entry);
     entry.waitingInput = probe.waiting;
     entry.rateLimit = probe.rateLimit;
@@ -245,11 +269,6 @@ async function listFilesInternal(
       entry.activity = Date.now() / 1000 - entry.mtime < 900 ? "recent" : "idle";
       entry.activityReason = "pane_at_composer";
     }
-    entry.plan = planFor(entry);
-    entry.goal = goalFor(entry);
-    entry.ctx = ctxFor(entry);
-    entry.lastTurn = lastTurnFor(entry);
-    entry.pendingWakeup = pendingWakeupFor(entry);
   });
   await linkEntries(entries, { persist });
   const pinOverlayPaths = "pinOverlayPaths" in scan ? scan.pinOverlayPaths : undefined;

--- a/src/lib/scanner/questions.ts
+++ b/src/lib/scanner/questions.ts
@@ -3,7 +3,10 @@ import { tailRecords } from "./activity";
 import { globalCache } from "./caches";
 import { recordValue, recordsValue, stringValue } from "./json";
 
-const questionCache = globalCache<[number, PendingQuestion | null]>("questions");
+type PendingQuestionDraft = Omit<PendingQuestion, "pid" | "paneTarget">;
+
+globalCache<unknown>("questions").clear();
+const questionCache = globalCache<[number, PendingQuestionDraft | null]>("questions-v2");
 
 function timestampOf(obj: Record<string, unknown>): string {
   return stringValue(obj.timestamp) ?? stringValue(obj.created_at) ?? new Date().toISOString();
@@ -84,49 +87,46 @@ export function recordedToolResult(pathname: string, size: number, toolUseId: st
 }
 
 export function pendingQuestionFor(entry: FileEntry): PendingQuestion | null {
-  if (entry.root !== "claude-projects" || !entry.path.endsWith(".jsonl") || entry.proc !== "running" || entry.pid === null) {
-    return null;
-  }
+  if (entry.root !== "claude-projects" || !entry.path.endsWith(".jsonl")) return null;
   const cached = questionCache.get(entry.path);
-  if (cached?.[0] === entry.size) return cached[1];
+  let draft = cached?.[0] === entry.size ? cached[1] : undefined;
 
-  let pending: PendingQuestion | null = null;
-  const answered = new Set<string>();
-  for (const obj of tailRecords(entry.path, entry.size).reverse()) {
-    const result = toolResultId(obj);
-    if (result) {
-      answered.add(result);
-      continue;
-    }
-    const use = assistantToolUse(obj);
-    if (!use || answered.has(use.id)) break;
-    if (use.name === "AskUserQuestion") {
-      const questions = recordsValue(use.input.questions).map(normalizeQuestion).filter((item): item is PendingQuestionItem => item !== null);
-      if (!questions.length) break;
-      pending = {
-        kind: "question",
+  if (draft === undefined) {
+    draft = null;
+    const answered = new Set<string>();
+    for (const obj of tailRecords(entry.path, entry.size).reverse()) {
+      const result = toolResultId(obj);
+      if (result) {
+        answered.add(result);
+        continue;
+      }
+      const use = assistantToolUse(obj);
+      if (!use || answered.has(use.id)) break;
+      if (use.name === "AskUserQuestion") {
+        const questions = recordsValue(use.input.questions).map(normalizeQuestion).filter((item): item is PendingQuestionItem => item !== null);
+        if (!questions.length) break;
+        draft = {
+          kind: "question",
+          toolUseId: use.id,
+          transcriptPath: entry.path,
+          askedAt: timestampOf(obj),
+          questions,
+        };
+        break;
+      }
+      const plan = stringValue(use.input.plan)?.trim();
+      if (!plan) break;
+      draft = {
+        kind: "plan",
         toolUseId: use.id,
         transcriptPath: entry.path,
-        pid: entry.pid,
-        paneTarget: null,
         askedAt: timestampOf(obj),
-        questions,
+        plan,
       };
       break;
     }
-    const plan = stringValue(use.input.plan)?.trim();
-    if (!plan) break;
-    pending = {
-      kind: "plan",
-      toolUseId: use.id,
-      transcriptPath: entry.path,
-      pid: entry.pid,
-      paneTarget: null,
-      askedAt: timestampOf(obj),
-      plan,
-    };
-    break;
+    questionCache.set(entry.path, [entry.size, draft]);
   }
-  questionCache.set(entry.path, [entry.size, pending]);
-  return pending;
+  if (!draft || entry.proc !== "running" || entry.pid === null) return null;
+  return { ...draft, pid: entry.pid, paneTarget: null };
 }

--- a/src/lib/scanner/scanCache.ts
+++ b/src/lib/scanner/scanCache.ts
@@ -508,6 +508,21 @@ export async function cachedFileScan(
   return completedScan(slot, undefined, targetGeneration);
 }
 
+/** Returns the latest completed global generation. A missing snapshot joins
+    or starts the shared cold generation so every consumer receives a corpus. */
+export async function completedFileScan(): Promise<CachedFileScan> {
+  const slot = globalFileScanSlot();
+  slot.requestCount = (slot.requestCount ?? 0) + 1;
+  if (slot.snapshot) {
+    return completedScan(slot, undefined, slot.snapshotGeneration);
+  }
+
+  const targetGeneration = slot.refresh?.generation ?? nextGeneration(slot);
+  const refresh = slot.refresh ?? beginFileScanRefresh(slot, targetGeneration, "cold");
+  await refresh.promise;
+  return completedScan(slot, undefined, targetGeneration, "miss");
+}
+
 /** Returns metadata from a completed current generation. The first fresh
     caller reserves a generation beyond existing requests; concurrent fresh
     callers join that pending fence. Older work completes before the fence. */

--- a/src/lib/scanner/scanCache.ts
+++ b/src/lib/scanner/scanCache.ts
@@ -10,6 +10,13 @@ type FileScanRefresh = {
   generation: number;
   promise: Promise<FileScanSnapshot>;
 };
+type FileScanReason = "cold" | "ordinary" | "pinned" | "revision" | "generation" | "fresh" | "current";
+type FileScanDiagnostic = {
+  generation: number;
+  reason: FileScanReason;
+  status: "complete" | "failed";
+  durationMs: number;
+};
 type PinnedFileScanSnapshot = Pick<CachedFileScan, "snapshot" | "pinOverlayPaths"> & {
   generation: number;
   refreshedAt: number;
@@ -26,6 +33,9 @@ type FileScanCacheSlot = {
   refresh?: FileScanRefresh;
   pinnedSnapshots?: Map<string, PinnedFileScanSnapshot>;
   pinnedGenerations?: Map<string, number>;
+  requestCount?: number;
+  lastScan?: FileScanDiagnostic;
+  ordinaryRefreshRequestedAt?: number;
 };
 
 export type CachedFileScan = {
@@ -33,9 +43,15 @@ export type CachedFileScan = {
   pinOverlayPaths?: string[];
   generation: number;
   targetGeneration: number;
+  cacheStatus: "hit" | "stale" | "miss";
+  requestCount: number;
+  cloneDurationMs: number;
+  lastScan?: FileScanDiagnostic;
 };
 
 const FILE_SCAN_FRESH_MS = 1_000;
+/** Poll-driven attempts share the client's fallback cadence, including failures. */
+const FILE_SCAN_ORDINARY_REFRESH_MS = 10_000;
 const FILE_SCAN_PIN_CACHE_MAX = 8;
 const FILE_SCAN_CACHE_SCHEMA_VERSION = 4 as const;
 const FILE_SCAN_SNAPSHOT_VERSION = 1 as const;
@@ -179,14 +195,36 @@ function normalizeFileScanCacheSlot(value: unknown): FileScanCacheSlot {
   return slot;
 }
 
-function beginFileScanRefresh(slot: FileScanCacheSlot, generation: number): FileScanRefresh {
+async function instrumentFileScan(
+  slot: FileScanCacheSlot,
+  generation: number,
+  reason: FileScanReason,
+  task: () => Promise<FileScanSnapshot>,
+): Promise<FileScanSnapshot> {
+  const startedAt = performance.now();
+  try {
+    const snapshot = await task();
+    slot.lastScan = { generation, reason, status: "complete", durationMs: performance.now() - startedAt };
+    return snapshot;
+  } catch (error) {
+    slot.lastScan = { generation, reason, status: "failed", durationMs: performance.now() - startedAt };
+    throw error;
+  }
+}
+
+function fileScanRefreshPromise(
+  slot: FileScanCacheSlot,
+  generation: number,
+  reason: FileScanReason,
+): Promise<FileScanSnapshot> {
   const fresh = slot.freshObservationGeneration !== undefined
     && generation >= slot.freshObservationGeneration;
-  const promise = listFilesWithProjectCatalog(undefined, {
-    persist: false,
-    persistIndex: true,
-    ...(fresh ? { fresh: true } : {}),
-  }).then((snapshot) => {
+  return instrumentFileScan(slot, generation, reason, async () => {
+    const snapshot = await listFilesWithProjectCatalog(undefined, {
+      persist: false,
+      persistIndex: true,
+      ...(fresh ? { fresh: true } : {}),
+    });
     if (!snapshot.complete) throw new Error("filesystem scan incomplete");
     writePersistedFileScanSnapshot(snapshot);
     slot.snapshot = snapshot;
@@ -198,13 +236,27 @@ function beginFileScanRefresh(slot: FileScanCacheSlot, generation: number): File
     }
     return snapshot;
   });
+}
+
+function beginFileScanRefresh(slot: FileScanCacheSlot, generation: number, reason: FileScanReason): FileScanRefresh {
+  return installFileScanRefresh(slot, generation, fileScanRefreshPromise(slot, generation, reason));
+}
+
+function beginDeferredFileScanRefresh(slot: FileScanCacheSlot, generation: number): FileScanRefresh {
+  const promise = new Promise<void>((resolve) => setImmediate(resolve))
+    .then(() => fileScanRefreshPromise(slot, generation, "ordinary"));
   return installFileScanRefresh(slot, generation, promise);
 }
 
-function beginPinnedFileScanRefresh(slot: FileScanCacheSlot, generation: number, pinnedPath: string): FileScanRefresh {
+function beginPinnedFileScanRefresh(
+  slot: FileScanCacheSlot,
+  generation: number,
+  pinnedPath: string,
+  reason: FileScanReason,
+): FileScanRefresh {
   const fresh = slot.freshObservationGeneration !== undefined
     && generation >= slot.freshObservationGeneration;
-  const promise = (async () => {
+  const promise = instrumentFileScan(slot, generation, reason, async () => {
     const pinnedSnapshot = await listFilesWithProjectCatalog(undefined, {
       persist: false,
       persistIndex: true,
@@ -245,7 +297,7 @@ function beginPinnedFileScanRefresh(slot: FileScanCacheSlot, generation: number,
       slot.freshObservationGeneration = undefined;
     }
     return globalSnapshot;
-  })();
+  });
   return installFileScanRefresh(slot, generation, promise);
 }
 
@@ -253,6 +305,7 @@ async function refreshThroughGeneration(
   slot: FileScanCacheSlot,
   requestedGeneration: number,
   pinnedPath?: string,
+  reason: FileScanReason = "generation",
 ): Promise<FileScanSnapshot> {
   while (
     !slot.snapshot
@@ -260,8 +313,8 @@ async function refreshThroughGeneration(
     || (pinnedPath !== undefined && (slot.pinnedSnapshots?.get(pinnedPath)?.generation ?? -1) < requestedGeneration)
   ) {
     const refresh = slot.refresh ?? (pinnedPath
-      ? beginPinnedFileScanRefresh(slot, requestedGeneration, pinnedPath)
-      : beginFileScanRefresh(slot, requestedGeneration));
+      ? beginPinnedFileScanRefresh(slot, requestedGeneration, pinnedPath, reason)
+      : beginFileScanRefresh(slot, requestedGeneration, reason));
     await refresh.promise;
   }
   return slot.snapshot;
@@ -275,20 +328,38 @@ function cachedPinnedSnapshot(slot: FileScanCacheSlot, pinnedPath: string): Pinn
   return pinned;
 }
 
-function completedScan(slot: FileScanCacheSlot, pinnedPath: string | undefined, targetGeneration: number): CachedFileScan {
+function completedScan(
+  slot: FileScanCacheSlot,
+  pinnedPath: string | undefined,
+  targetGeneration: number,
+  cacheStatus?: CachedFileScan["cacheStatus"],
+): CachedFileScan {
+  const cloneStartedAt = performance.now();
   const pinned = pinnedPath ? cachedPinnedSnapshot(slot, pinnedPath) : undefined;
   if (pinned) {
-    return structuredClone({
+    const completed = structuredClone({
       snapshot: pinned.snapshot,
       pinOverlayPaths: pinned.pinOverlayPaths,
       generation: pinned.generation,
       targetGeneration,
     });
+    return {
+      ...completed,
+      cacheStatus: cacheStatus ?? (completed.generation < targetGeneration ? "stale" : "hit"),
+      requestCount: slot.requestCount ?? 0,
+      cloneDurationMs: performance.now() - cloneStartedAt,
+      ...(slot.lastScan ? { lastScan: { ...slot.lastScan } } : {}),
+    };
   }
+  const snapshot = structuredClone(slot.snapshot!);
   return {
-    snapshot: structuredClone(slot.snapshot!),
+    snapshot,
     generation: slot.snapshotGeneration,
     targetGeneration,
+    cacheStatus: cacheStatus ?? (slot.snapshotGeneration < targetGeneration ? "stale" : "hit"),
+    requestCount: slot.requestCount ?? 0,
+    cloneDurationMs: performance.now() - cloneStartedAt,
+    ...(slot.lastScan ? { lastScan: { ...slot.lastScan } } : {}),
   };
 }
 
@@ -353,6 +424,7 @@ export async function cachedFileScan(
   requiredGeneration?: number,
 ): Promise<CachedFileScan> {
   const slot = globalFileScanSlot();
+  slot.requestCount = (slot.requestCount ?? 0) + 1;
 
   let targetGeneration = requiredGeneration !== undefined && requiredGeneration <= slot.requestedGeneration
     ? requiredGeneration
@@ -374,7 +446,7 @@ export async function cachedFileScan(
     if (pinnedPath) {
       targetGeneration = rememberPinnedGeneration(slot, pinnedPath, requestedGeneration);
     }
-    const refresh = refreshThroughGeneration(slot, targetGeneration, pinnedPath);
+    const refresh = refreshThroughGeneration(slot, targetGeneration, pinnedPath, "revision");
     const clearForcedGeneration = () => {
       if (slot.forcedGeneration === requestedGeneration) {
         slot.forcedRevision = undefined;
@@ -384,7 +456,7 @@ export async function cachedFileScan(
     if (!slot.snapshot) {
       try {
         await refresh;
-        return completedScan(slot, pinnedPath, targetGeneration);
+        return completedScan(slot, pinnedPath, targetGeneration, "miss");
       } finally {
         clearForcedGeneration();
       }
@@ -393,10 +465,11 @@ export async function cachedFileScan(
   }
 
   if (targetGeneration !== undefined) {
-    const refresh = refreshThroughGeneration(slot, targetGeneration, pinnedPath);
-    if (!slot.snapshot) await refresh;
+    const refresh = refreshThroughGeneration(slot, targetGeneration, pinnedPath, "generation");
+    const missesSnapshot = !slot.snapshot;
+    if (missesSnapshot) await refresh;
     else continueRefreshInBackground(refresh);
-    return completedScan(slot, pinnedPath, targetGeneration);
+    return completedScan(slot, pinnedPath, targetGeneration, missesSnapshot ? "miss" : undefined);
   }
 
   /* A pin is an overlay on one global snapshot. The scanner marks every row
@@ -409,24 +482,26 @@ export async function cachedFileScan(
       return completedScan(slot, pinnedPath, pinned.generation);
     }
     targetGeneration = pinnedRefreshGeneration(slot, pinnedPath);
-    const refresh = refreshThroughGeneration(slot, targetGeneration, pinnedPath);
-    if (!slot.snapshot) await refresh;
+    const refresh = refreshThroughGeneration(slot, targetGeneration, pinnedPath, "pinned");
+    const missesSnapshot = !slot.snapshot;
+    if (missesSnapshot) await refresh;
     else continueRefreshInBackground(refresh);
-    return completedScan(slot, pinnedPath, targetGeneration);
+    return completedScan(slot, pinnedPath, targetGeneration, missesSnapshot ? "miss" : undefined);
   }
 
   if (!slot.snapshot) {
     targetGeneration = slot.refresh?.generation ?? nextGeneration(slot);
-    const refresh = slot.refresh ?? beginFileScanRefresh(slot, targetGeneration);
+    const refresh = slot.refresh ?? beginFileScanRefresh(slot, targetGeneration, "cold");
     await refresh.promise;
-    return completedScan(slot, undefined, targetGeneration);
+    return completedScan(slot, undefined, targetGeneration, "miss");
   }
 
   if (slot.refresh) {
     targetGeneration = slot.refresh.generation;
-  } else if (now - slot.refreshedAt >= FILE_SCAN_FRESH_MS) {
+  } else if (now - Math.max(slot.refreshedAt, slot.ordinaryRefreshRequestedAt ?? 0) >= FILE_SCAN_ORDINARY_REFRESH_MS) {
     targetGeneration = nextGeneration(slot);
-    beginFileScanRefresh(slot, targetGeneration);
+    slot.ordinaryRefreshRequestedAt = now;
+    beginDeferredFileScanRefresh(slot, targetGeneration);
   } else {
     targetGeneration = slot.snapshotGeneration;
   }
@@ -443,7 +518,7 @@ export async function currentFileScan(
     const slot = globalFileScanSlot();
     const targetGeneration = slot.freshObservationGeneration ?? nextGeneration(slot);
     slot.freshObservationGeneration = targetGeneration;
-    await refreshThroughGeneration(slot, targetGeneration);
+    await refreshThroughGeneration(slot, targetGeneration, undefined, "fresh");
     return completedScan(slot, undefined, targetGeneration);
   }
 
@@ -451,7 +526,7 @@ export async function currentFileScan(
   if (scan.generation >= scan.targetGeneration) return scan;
 
   const slot = globalFileScanSlot();
-  await refreshThroughGeneration(slot, scan.targetGeneration);
+  await refreshThroughGeneration(slot, scan.targetGeneration, undefined, "current");
   return completedScan(slot, undefined, scan.targetGeneration);
 }
 

--- a/src/lib/scanner/scanCache.ts
+++ b/src/lib/scanner/scanCache.ts
@@ -4,11 +4,15 @@ import path from "node:path";
 
 import { statePath } from "@/lib/configDir";
 import { listFilesWithProjectCatalog } from "@/lib/scanner";
+import { globalCache } from "@/lib/scanner/caches";
+import type { FileEntry } from "@/lib/types";
 
 type FileScanSnapshot = Awaited<ReturnType<typeof listFilesWithProjectCatalog>>;
 type FileScanRefresh = {
   generation: number;
   promise: Promise<FileScanSnapshot>;
+  resourcePromise: Promise<FileScanSnapshot>;
+  cancelBeforeStart?: () => boolean;
 };
 type FileScanReason = "cold" | "ordinary" | "pinned" | "revision" | "generation" | "fresh" | "current";
 type FileScanDiagnostic = {
@@ -53,7 +57,7 @@ const FILE_SCAN_FRESH_MS = 1_000;
 /** Poll-driven attempts share the client's fallback cadence, including failures. */
 const FILE_SCAN_ORDINARY_REFRESH_MS = 10_000;
 const FILE_SCAN_PIN_CACHE_MAX = 8;
-const FILE_SCAN_CACHE_SCHEMA_VERSION = 4 as const;
+const FILE_SCAN_CACHE_SCHEMA_VERSION = 5 as const;
 const FILE_SCAN_SNAPSHOT_VERSION = 1 as const;
 const FILE_SCAN_SNAPSHOT_FILE = "files-scan-snapshot.json";
 const FILE_SCAN_PERSISTENCE_DIAGNOSTIC_MS = 60_000;
@@ -99,6 +103,43 @@ function isFileScanSnapshot(value: unknown): value is FileScanSnapshot {
     && typeof candidate.conversations === "number" && Number.isSafeInteger(candidate.conversations)
     && (candidate.projectRoot === undefined || typeof candidate.projectRoot === "string"));
   return filesValid && catalogValid;
+}
+
+function persistedTurnState(entry: FileEntry): string | null | undefined {
+  if (entry.activityReason === "jsonl_turn_open" || entry.activityReason === "jsonl_turn_stalled") return "busy";
+  if (entry.activityReason === "jsonl_turn_completed") return "done";
+  if (entry.activityReason === "mtime_fresh" || entry.activityReason === "mtime_recent" || entry.activityReason === "mtime_old") return null;
+  return undefined;
+}
+
+function primePersistedFileDerivations(snapshot: FileScanSnapshot): void {
+  for (const entry of snapshot.files) {
+    let current: fs.Stats;
+    try {
+      current = fs.statSync(entry.path);
+    } catch {
+      continue;
+    }
+    if (current.size !== entry.size || current.mtimeMs / 1000 !== entry.mtime) continue;
+    const turnState = persistedTurnState(entry);
+    if (turnState !== undefined) globalCache<[number, string | null]>("turn").set(entry.path, [entry.size, turnState]);
+    if (!(entry.root === "claude-projects" && entry.path.includes(`${path.sep}subagents${path.sep}`))) {
+      globalCache<[number, { display: string | null; launch: string | null }]>("model")
+        .set(entry.path, [entry.size, { display: entry.model, launch: entry.launchModel ?? null }]);
+    }
+    if (Object.hasOwn(entry, "effort") && !(entry.engine === "claude" && entry.proc === "running")) {
+      globalCache<[number, string | null]>("effort").set(entry.path, [entry.size, entry.effort ?? null]);
+    }
+    if (Object.hasOwn(entry, "plan")) globalCache<[number, FileEntry["plan"]]>("plan").set(entry.path, [entry.size, entry.plan]);
+    if (Object.hasOwn(entry, "goal")) globalCache<[number, FileEntry["goal"]]>("goal").set(entry.path, [entry.size, entry.goal]);
+    if (Object.hasOwn(entry, "ctx")) globalCache<[number, FileEntry["ctx"]]>("ctx").set(entry.path, [entry.size, entry.ctx]);
+    if (Object.hasOwn(entry, "lastTurn")) {
+      globalCache<[number, FileEntry["lastTurn"]]>("last-turn").set(entry.path, [entry.size, entry.lastTurn]);
+    }
+    if (Object.hasOwn(entry, "pendingWakeup")) {
+      globalCache<[number, FileEntry["pendingWakeup"]]>("wakeup").set(entry.path, [entry.size, entry.pendingWakeup]);
+    }
+  }
 }
 
 function readPersistedFileScanSnapshot(): FileScanSnapshot | undefined {
@@ -154,14 +195,44 @@ function refreshPromise(value: unknown): Promise<FileScanSnapshot> | undefined {
   return undefined;
 }
 
-function installFileScanRefresh(slot: FileScanCacheSlot, generation: number, promise: Promise<FileScanSnapshot>): FileScanRefresh {
-  const refresh = { generation, promise };
+function installFileScanRefresh(
+  slot: FileScanCacheSlot,
+  generation: number,
+  promise: Promise<FileScanSnapshot>,
+  resourcePromise: Promise<FileScanSnapshot> = promise,
+): FileScanRefresh {
+  const refresh = { generation, promise, resourcePromise };
   slot.refresh = refresh;
   const clear = () => {
     if (slot.refresh === refresh) slot.refresh = undefined;
   };
   void promise.then(clear, clear);
   return refresh;
+}
+
+function installStagedFileScanRefresh(
+  slot: FileScanCacheSlot,
+  generation: number,
+  start: (publish: (snapshot: FileScanSnapshot) => void) => Promise<FileScanSnapshot>,
+): FileScanRefresh {
+  let publishResource!: (snapshot: FileScanSnapshot) => void;
+  let rejectResource!: (error: unknown) => void;
+  let published = false;
+  const resourcePromise = new Promise<FileScanSnapshot>((resolve, reject) => {
+    publishResource = resolve;
+    rejectResource = reject;
+  });
+  void resourcePromise.catch(() => {});
+  const publish = (snapshot: FileScanSnapshot) => {
+    if (published) return;
+    published = true;
+    publishResource(snapshot);
+  };
+  const promise = start(publish);
+  void promise.then(publish, (error) => {
+    if (!published) rejectResource(error);
+  });
+  return installFileScanRefresh(slot, generation, promise, resourcePromise);
 }
 
 function normalizeFileScanCacheSlot(value: unknown): FileScanCacheSlot {
@@ -216,6 +287,7 @@ function fileScanRefreshPromise(
   slot: FileScanCacheSlot,
   generation: number,
   reason: FileScanReason,
+  onResourceSnapshot?: (snapshot: FileScanSnapshot) => void,
 ): Promise<FileScanSnapshot> {
   const fresh = slot.freshObservationGeneration !== undefined
     && generation >= slot.freshObservationGeneration;
@@ -224,6 +296,7 @@ function fileScanRefreshPromise(
       persist: false,
       persistIndex: process.env.LLV_RESOURCE_OBSERVATION_WORKER !== "1",
       ...(fresh ? { fresh: true } : {}),
+      ...(onResourceSnapshot ? { onResourceSnapshot, resourceBaseline: slot.snapshot } : {}),
     });
     if (!snapshot.complete) throw new Error("filesystem scan incomplete");
     if (process.env.LLV_RESOURCE_OBSERVATION_WORKER !== "1") writePersistedFileScanSnapshot(snapshot);
@@ -238,14 +311,52 @@ function fileScanRefreshPromise(
   });
 }
 
-function beginFileScanRefresh(slot: FileScanCacheSlot, generation: number, reason: FileScanReason): FileScanRefresh {
-  return installFileScanRefresh(slot, generation, fileScanRefreshPromise(slot, generation, reason));
+function beginFileScanRefresh(
+  slot: FileScanCacheSlot,
+  generation: number,
+  reason: FileScanReason,
+): FileScanRefresh {
+  return installStagedFileScanRefresh(
+    slot,
+    generation,
+    (publish) => fileScanRefreshPromise(slot, generation, reason, publish),
+  );
 }
 
 function beginDeferredFileScanRefresh(slot: FileScanCacheSlot, generation: number): FileScanRefresh {
-  const promise = new Promise<void>((resolve) => setImmediate(resolve))
-    .then(() => fileScanRefreshPromise(slot, generation, "ordinary"));
-  return installFileScanRefresh(slot, generation, promise);
+  let started = false;
+  let canceled = false;
+  let publishResource!: (snapshot: FileScanSnapshot) => void;
+  let rejectResource!: (error: unknown) => void;
+  let published = false;
+  const resourcePromise = new Promise<FileScanSnapshot>((resolve, reject) => {
+    publishResource = resolve;
+    rejectResource = reject;
+  });
+  void resourcePromise.catch(() => {});
+  const publish = (snapshot: FileScanSnapshot) => {
+    if (published) return;
+    published = true;
+    publishResource(snapshot);
+  };
+  const promise = new Promise<void>((resolve) => setImmediate(resolve)).then(() => {
+    started = true;
+    if (canceled) {
+      if (!slot.snapshot) throw new Error("deferred file scan canceled without a completed snapshot");
+      return slot.snapshot;
+    }
+    return fileScanRefreshPromise(slot, generation, "ordinary", publish);
+  });
+  void promise.then(publish, (error) => {
+    if (!published) rejectResource(error);
+  });
+  const refresh = installFileScanRefresh(slot, generation, promise, resourcePromise);
+  refresh.cancelBeforeStart = () => {
+    if (started) return false;
+    canceled = true;
+    return true;
+  };
+  return refresh;
 }
 
 function beginPinnedFileScanRefresh(
@@ -256,12 +367,14 @@ function beginPinnedFileScanRefresh(
 ): FileScanRefresh {
   const fresh = slot.freshObservationGeneration !== undefined
     && generation >= slot.freshObservationGeneration;
-  const promise = instrumentFileScan(slot, generation, reason, async () => {
+  return installStagedFileScanRefresh(slot, generation, (publish) => instrumentFileScan(slot, generation, reason, async () => {
     const pinnedSnapshot = await listFilesWithProjectCatalog(undefined, {
       persist: false,
       persistIndex: process.env.LLV_RESOURCE_OBSERVATION_WORKER !== "1",
       pin: pinnedPath,
       ...(fresh ? { fresh: true } : {}),
+      onResourceSnapshot: publish,
+      resourceBaseline: slot.snapshot,
     });
     if (!pinnedSnapshot.complete) throw new Error("filesystem scan incomplete");
     const pinOverlayPaths = pinnedSnapshot.pinOverlayPaths ?? [];
@@ -297,8 +410,7 @@ function beginPinnedFileScanRefresh(
       slot.freshObservationGeneration = undefined;
     }
     return globalSnapshot;
-  });
-  return installFileScanRefresh(slot, generation, promise);
+  }));
 }
 
 async function refreshThroughGeneration(
@@ -363,6 +475,23 @@ function completedScan(
   };
 }
 
+function resourceScan(
+  slot: FileScanCacheSlot,
+  snapshot: FileScanSnapshot,
+  generation: number,
+  targetGeneration: number,
+): CachedFileScan {
+  return {
+    snapshot,
+    generation,
+    targetGeneration,
+    cacheStatus: "miss",
+    requestCount: slot.requestCount ?? 0,
+    cloneDurationMs: 0,
+    ...(slot.lastScan ? { lastScan: { ...slot.lastScan } } : {}),
+  };
+}
+
 function nextGeneration(slot: FileScanCacheSlot): number {
   slot.requestedGeneration += 1;
   return slot.requestedGeneration;
@@ -399,9 +528,11 @@ function globalFileScanSlot(): FileScanCacheSlot {
   const cache = fileScanCache();
   const cachedSlot = cache.get(key);
   if (cachedSlot === undefined) {
+    const snapshot = readPersistedFileScanSnapshot();
+    if (snapshot) primePersistedFileDerivations(snapshot);
     const slot: FileScanCacheSlot = {
       schemaVersion: FILE_SCAN_CACHE_SCHEMA_VERSION,
-      snapshot: readPersistedFileScanSnapshot(),
+      snapshot,
       snapshotGeneration: 0,
       requestedGeneration: 0,
       refreshedAt: 0,
@@ -549,6 +680,38 @@ export async function currentFileScan(
   const slot = globalFileScanSlot();
   await refreshThroughGeneration(slot, scan.targetGeneration, undefined, "current");
   return completedScan(slot, undefined, scan.targetGeneration);
+}
+
+/** Returns the fresh resource projection as soon as its file generation has
+    current filesystem scope. The worker performs fresh ownership observation;
+    sidebar enrichment continues through the completed-generation seam. */
+export async function currentResourceFileScan(): Promise<CachedFileScan> {
+  const slot = globalFileScanSlot();
+  slot.requestCount = (slot.requestCount ?? 0) + 1;
+  let targetGeneration = slot.freshObservationGeneration;
+  let requestedRefresh: FileScanRefresh | undefined;
+  if (targetGeneration === undefined) {
+    const pending = slot.refresh;
+    if (pending?.cancelBeforeStart?.()) {
+      targetGeneration = nextGeneration(slot);
+      slot.freshObservationGeneration = targetGeneration;
+      requestedRefresh = beginFileScanRefresh(slot, targetGeneration, "fresh");
+    } else if (pending) {
+      targetGeneration = pending.generation;
+    } else {
+      targetGeneration = nextGeneration(slot);
+      slot.freshObservationGeneration = targetGeneration;
+    }
+  }
+  while (true) {
+    const refresh = requestedRefresh ?? slot.refresh ?? beginFileScanRefresh(slot, targetGeneration, "fresh");
+    requestedRefresh = undefined;
+    const snapshot = await refresh.resourcePromise;
+    if (refresh.generation >= targetGeneration) {
+      return resourceScan(slot, snapshot, refresh.generation, targetGeneration);
+    }
+    await refresh.promise;
+  }
 }
 
 export function resetFilesRouteCacheForTests(): void {

--- a/src/lib/scanner/scanCache.ts
+++ b/src/lib/scanner/scanCache.ts
@@ -514,6 +514,12 @@ export async function completedFileScan(): Promise<CachedFileScan> {
   const slot = globalFileScanSlot();
   slot.requestCount = (slot.requestCount ?? 0) + 1;
   if (slot.snapshot) {
+    const now = Date.now();
+    if (!slot.refresh && now - Math.max(slot.refreshedAt, slot.ordinaryRefreshRequestedAt ?? 0) >= FILE_SCAN_ORDINARY_REFRESH_MS) {
+      const targetGeneration = nextGeneration(slot);
+      slot.ordinaryRefreshRequestedAt = now;
+      beginDeferredFileScanRefresh(slot, targetGeneration);
+    }
     return completedScan(slot, undefined, slot.snapshotGeneration);
   }
 

--- a/src/lib/scanner/scanCache.ts
+++ b/src/lib/scanner/scanCache.ts
@@ -222,11 +222,11 @@ function fileScanRefreshPromise(
   return instrumentFileScan(slot, generation, reason, async () => {
     const snapshot = await listFilesWithProjectCatalog(undefined, {
       persist: false,
-      persistIndex: true,
+      persistIndex: process.env.LLV_RESOURCE_OBSERVATION_WORKER !== "1",
       ...(fresh ? { fresh: true } : {}),
     });
     if (!snapshot.complete) throw new Error("filesystem scan incomplete");
-    writePersistedFileScanSnapshot(snapshot);
+    if (process.env.LLV_RESOURCE_OBSERVATION_WORKER !== "1") writePersistedFileScanSnapshot(snapshot);
     slot.snapshot = snapshot;
     slot.snapshotGeneration = Math.max(slot.snapshotGeneration, generation);
     slot.refreshedAt = Date.now();
@@ -259,7 +259,7 @@ function beginPinnedFileScanRefresh(
   const promise = instrumentFileScan(slot, generation, reason, async () => {
     const pinnedSnapshot = await listFilesWithProjectCatalog(undefined, {
       persist: false,
-      persistIndex: true,
+      persistIndex: process.env.LLV_RESOURCE_OBSERVATION_WORKER !== "1",
       pin: pinnedPath,
       ...(fresh ? { fresh: true } : {}),
     });
@@ -288,7 +288,7 @@ function beginPinnedFileScanRefresh(
       slot.pinnedSnapshots.delete(oldest);
       slot.pinnedGenerations?.delete(oldest);
     }
-    writePersistedFileScanSnapshot(globalSnapshot);
+    if (process.env.LLV_RESOURCE_OBSERVATION_WORKER !== "1") writePersistedFileScanSnapshot(globalSnapshot);
     slot.snapshot = globalSnapshot;
     slot.snapshotGeneration = Math.max(slot.snapshotGeneration, generation);
     slot.refreshedAt = Date.now();

--- a/src/lib/session/titleProjection.test.ts
+++ b/src/lib/session/titleProjection.test.ts
@@ -6,7 +6,7 @@ import path from "node:path";
 import { AgentRegistry, setAgentRegistryForTests } from "@/lib/agent/registry";
 import type { FileEntry } from "@/lib/types";
 
-import { overlaySessionTitles } from "./titleProjection";
+import { overlayResourceSessionTitles, overlaySessionTitles } from "./titleProjection";
 import { writeSessionTitle } from "./titleStore";
 
 const UUID = "11111111-2222-4333-8444-555555555555";
@@ -100,6 +100,36 @@ test("a subagent is not renamable and receives no override affordance", () => {
   const file = entry({ path: subPath, kind: "subagent" });
   overlaySessionTitles([file]);
   expect(file.renamable).toBe(false);
+});
+
+test("the resource projection applies identity and titles without transcript-head eligibility reads", () => {
+  const pathname = `/home/u/.codex/sessions/2026/07/16/rollout-${UUID}.jsonl`;
+  const registry = new AgentRegistry(path.join(stateDir, "agent-registry.json"));
+  const resourceConversation = registry.ensureConversation("codex", pathname, null);
+  setAgentRegistryForTests(registry);
+  writeSessionTitle(
+    [`conversation:${resourceConversation.id}`],
+    `conversation:${resourceConversation.id}`,
+    "Resource name",
+    undefined,
+    "t1",
+  );
+  const originalOpen = fs.openSync;
+  let transcriptReads = 0;
+  fs.openSync = ((...args: Parameters<typeof fs.openSync>) => {
+    if (args[0] === pathname) transcriptReads += 1;
+    return originalOpen(...args);
+  }) as typeof fs.openSync;
+  try {
+    const file = entry({ path: pathname, root: "codex-sessions", engine: "codex", fmt: "codex", size: 1024 });
+    overlayResourceSessionTitles([file]);
+    expect(file.conversationId).toBe(resourceConversation.id);
+    expect(file.title).toBe("Resource name");
+    expect(file.renamable).toBeUndefined();
+    expect(transcriptReads).toBe(0);
+  } finally {
+    fs.openSync = originalOpen;
+  }
 });
 
 function setRegistryConversation() {

--- a/src/lib/session/titleProjection.ts
+++ b/src/lib/session/titleProjection.ts
@@ -1,7 +1,8 @@
 import fs from "node:fs";
 
-import { agentRegistry, RegistryReadError } from "@/lib/agent/registry";
+import { agentRegistry, normalizeRegistry, RegistryReadError } from "@/lib/agent/registry";
 import type { ViewerConversationId } from "@/lib/accounts/migration/contracts";
+import { statePath } from "@/lib/configDir";
 import type { FileEntry } from "@/lib/types";
 
 import { isRenameableSessionEntry } from "./renameEligibility";
@@ -21,6 +22,7 @@ interface RegistryProjection {
 }
 
 const registryProjectionCache = new WeakMap<Registry, RegistryProjection>();
+let readOnlyRegistryProjectionCache: RegistryProjection | null = null;
 
 function registrySignature(registry: Registry): string {
   try {
@@ -43,17 +45,7 @@ function canonicalConversationId(snapshot: RegistrySnapshot, alias: string): str
   return current;
 }
 
-function registryProjection(registry: Registry, surfaceUnexpectedError = false): RegistryProjection | null {
-  const signature = registrySignature(registry);
-  const cached = registryProjectionCache.get(registry);
-  if (cached?.signature === signature) return cached;
-  let snapshot: RegistrySnapshot;
-  try {
-    snapshot = registry.snapshot();
-  } catch (error) {
-    if (surfaceUnexpectedError && !(error instanceof RegistryReadError)) throw error;
-    return null;
-  }
+function projectRegistrySnapshot(snapshot: RegistrySnapshot, signature: string): RegistryProjection {
   const conversationByPath = new Map<string, ViewerConversationId>();
   const aliasesByCanonical = new Map<string, string[]>();
   const ownedPathsByConversation = new Map<string, string[]>();
@@ -88,8 +80,42 @@ function registryProjection(registry: Registry, surfaceUnexpectedError = false):
     projectByPath,
     archivedPaths,
   };
+  return projection;
+}
+
+function registryProjection(registry: Registry, surfaceUnexpectedError = false): RegistryProjection | null {
+  const signature = registrySignature(registry);
+  const cached = registryProjectionCache.get(registry);
+  if (cached?.signature === signature) return cached;
+  let snapshot: RegistrySnapshot;
+  try {
+    snapshot = registry.snapshot();
+  } catch (error) {
+    if (surfaceUnexpectedError && !(error instanceof RegistryReadError)) throw error;
+    return null;
+  }
+  const projection = projectRegistrySnapshot(snapshot, signature);
   registryProjectionCache.set(registry, projection);
   return projection;
+}
+
+function readOnlyRegistryProjection(): RegistryProjection | null {
+  const filename = statePath("agent-registry.json");
+  let signature: string;
+  try {
+    const stat = fs.statSync(filename, { bigint: true });
+    signature = `${filename}:${stat.mtimeNs}:${stat.size}`;
+  } catch {
+    return null;
+  }
+  if (readOnlyRegistryProjectionCache?.signature === signature) return readOnlyRegistryProjectionCache;
+  try {
+    const snapshot = normalizeRegistry(JSON.parse(fs.readFileSync(filename, "utf8")));
+    readOnlyRegistryProjectionCache = projectRegistrySnapshot(snapshot, signature);
+    return readOnlyRegistryProjectionCache;
+  } catch {
+    return null;
+  }
 }
 
 /**
@@ -109,10 +135,19 @@ export function overlaySessionTitles(entries: FileEntry[]): void {
   for (const entry of entries) project(entry);
 }
 
-function sessionTitleProjector(): (entry: FileEntry) => void {
+/** Applies resource-facing identity and titles while leaving the files-route
+ * rename eligibility pass to its regular bounded shortlist. */
+export function overlayResourceSessionTitles(entries: FileEntry[]): void {
+  const project = sessionTitleProjector(false, readOnlyRegistryProjection());
+  for (const entry of entries) project(entry);
+}
+
+function sessionTitleProjector(
+  includeRenameEligibility = true,
+  suppliedProjection?: RegistryProjection | null,
+): (entry: FileEntry) => void {
   const index = indexSessionTitles(loadSessionTitles());
-  const registry = agentRegistry();
-  const projection = registryProjection(registry);
+  const projection = suppliedProjection === undefined ? registryProjection(agentRegistry()) : suppliedProjection;
   const snapshot = projection?.snapshot ?? null;
   const conversationByPath = projection?.conversationByPath ?? new Map<string, ViewerConversationId>();
   const aliasesByCanonical = projection?.aliasesByCanonical ?? new Map<string, string[]>();
@@ -130,7 +165,7 @@ function sessionTitleProjector(): (entry: FileEntry) => void {
       entry.title = latest.launchProfile.title ?? entry.title;
       entry.project = latest.launchProfile.project ?? entry.project;
     }
-    entry.renamable = isRenameableSessionEntry(entry);
+    if (includeRenameEligibility) entry.renamable = isRenameableSessionEntry(entry);
     if (index.size > 0) {
       const aliases = entry.conversationId ? aliasesByCanonical.get(entry.conversationId) ?? [] : [];
       const ownedPaths = entry.conversationId ? ownedPathsByConversation.get(entry.conversationId) ?? [] : [];

--- a/src/lib/tmux.ts
+++ b/src/lib/tmux.ts
@@ -826,6 +826,29 @@ export function captureTmuxAttachReference(ref: Pick<TmuxAttachReference, "tmuxS
   };
 }
 
+/** Captures every identity needed by a resource observation in one batch.
+    The collector already receives all pane rows from one `list-panes` call;
+    keeping the identity pass here prevents callers from launching a per-pane
+    subprocess or re-observing tmux while deriving kill references. */
+export function captureTmuxAttachReferences(
+  refs: ReadonlyArray<Pick<TmuxAttachReference, "tmuxServerPid" | "paneId" | "panePid">>,
+): Map<string, TmuxAttachReference> {
+  const identities = new Map<number, string | null>();
+  const identity = (pid: number): string | null => {
+    /* The portable backend obtains one identity through `ps` per pid. Resource
+       observation intentionally keeps this batch subprocess-free; kill still
+       verifies its stable tmux pane id and pid when a start token is absent. */
+    if (procBackend.name === "portable") return null;
+    if (!identities.has(pid)) identities.set(pid, procBackend.processIdentity(pid));
+    return identities.get(pid) ?? null;
+  };
+  return new Map(refs.map((ref) => [ref.paneId, {
+    ...ref,
+    tmuxServerStartIdentity: identity(ref.tmuxServerPid),
+    paneStartIdentity: identity(ref.panePid),
+  }]));
+}
+
 interface TmuxAttachSnapshot {
   tmuxServerPid: number;
   paneId: string;


### PR DESCRIPTION
## Summary

- Move recurring resource collection behind a bounded off-process worker.
- Share one versioned reader across duplicate Next bundle module instances.
- Feed the worker one immutable Viewer-main file snapshot.
- Keep child observation read-only and isolate it from shared registry mutation.
- Validate worker messages, payloads, freshness labels, targets, pane ids, and pane pids before publication.
- Preserve post-kill generation fences, host election, kill allowlisting, ordinary cached responses, and the rollback flag.
- Persist successful observations with retryable durable writes and corrupt-snapshot recovery.

## Candidate

Commit: `acedb7559df41e06515efd407c05f404d2c29e52`

Initial implementation verification:

- 2,875 tests passed, 0 failed, with 15,185 assertions across 295 files.
- TypeScript, changed-file ESLint, production build, and diff check passed.
- Twelve ordinary resource polls shared one collector and one worker; zero burst workers remained after 100 ms.
- Concurrent root, files, board, and task probes returned HTTP 200 in 115.10–139.32 ms in the isolated candidate environment.

## Fresh Sol review

Verdict: **REQUEST CHANGES**

Confirmed release blockers:

1. Critical: unhandled worker stdin `EPIPE` can terminate the Node server.
2. High: stale scanner PID ownership can attach old transcript metadata to an unrelated live process.
3. High: stable conversation identity disappears at the worker boundary.
4. High: persisted observations can re-authorize stale kill capabilities after restart.
5. High: pre-consumption observations can re-arm consumed targets.
6. High: an unbounded fresh handoff can poison later generations and create a late worker.
7. High: the Node-only npm CLI path cannot execute the TypeScript collector worker.
8. High: a transport-valid worker frame can exceed the durable observation envelope.
9. High: timeout cleanup can leave worker descendants alive.
10. Medium: failure diagnostics can report incorrect freshness and discard the underlying cause.

Review verification also passed TypeScript, changed-file ESLint, production and standalone builds, 540 focused and cross-regression tests, and an isolated single-flight runtime probe.

## Release status

A Sol-only TDD remediation round is required before deployment. A fresh Sol reviewer will inspect the cumulative diff after the fix commit. Production remains on safe SHA `47eaeae52733667c86bc76c799af6e0a76db9972`.

## Follow-up

Issue #287 remains open for client-side duplicate-request ownership, detailed parse/read instrumentation, and the full production browser budget trace.