### PR TITLE
Recover structured-host ledger cursor drift and failed resume projection

### DIFF
--- a/src/lib/accounts/migration/provider.ts
+++ b/src/lib/accounts/migration/provider.ts
@@ -13,6 +13,7 @@ import { statePath } from "@/lib/configDir";
 import { procBackend } from "@/lib/proc";
 import { ClaudeStreamBrokerHost } from "@/lib/runtime/claudeStreamBrokerHost";
 import { CodexAppServerHost } from "@/lib/runtime/codexAppServerHost";
+import { StructuredHostAdoptionCleanupError } from "@/lib/runtime/engineHost";
 import { hasStructuredDeliveryHost, publishStructuredDeliveryHost, releaseStructuredDeliveryHost } from "@/lib/runtime/structuredDeliveryController";
 import { bindClaudeHostPersistence, bindCodexHostPersistence, structuredHostsEnabled } from "@/lib/runtime/registry";
 import { cleanupTmuxHostIfMatches, forgetResumePaneIfMatches, spawnAgentWithPrompt, verifyTmuxHostEvidence, type TmuxHostCleanupResult } from "@/lib/tmux";
@@ -218,6 +219,7 @@ async function publishCodexSuccessorHost(input: {
     cwd: input.profile.cwd,
     accountId: input.target.accountId,
     launchProfile: input.profile,
+    structuredHostOperationId: input.receipt.operationId,
   });
   if (!entry.structuredHost) {
     input.registry.setStructuredHost(key, {
@@ -252,6 +254,7 @@ async function publishCodexSuccessorHost(input: {
       effort: input.profile.effort ?? undefined,
       sandbox: input.profile.readOnly ? "read-only" : undefined,
       approvalPolicy,
+      initialEventCursor: claimed.structuredHost?.eventCursor,
       env: input.target.env,
     });
     stopPersistence = await bindCodexHostPersistence(
@@ -263,6 +266,21 @@ async function publishCodexSuccessorHost(input: {
     );
     unregister = await publishStructuredDeliveryHost({ key, host });
   } catch (error) {
+    if (!host && error instanceof StructuredHostAdoptionCleanupError
+      && error.host instanceof CodexAppServerHost) {
+      host = error.host;
+      stopPersistence = await bindCodexHostPersistence(
+        input.registry,
+        key,
+        host,
+        claimed.claimOwner,
+        claimed.claimEpoch,
+        "dead",
+      );
+      await host.release();
+      stopPersistence();
+      throw error;
+    }
     await unregister();
     if (host) await host.release();
     stopPersistence();
@@ -302,6 +320,7 @@ async function publishClaudeSuccessorHost(
     cwd: input.profile.cwd,
     accountId: input.target.accountId,
     launchProfile: input.profile,
+    structuredHostOperationId: input.receipt.operationId,
   });
   if (!entry.structuredHost) {
     input.registry.setStructuredHost(key, {
@@ -336,6 +355,7 @@ async function publishClaudeSuccessorHost(
       model: input.profile.model ?? undefined,
       effort: input.profile.effort ?? undefined,
       permissionMode: input.profile.permissionMode ?? undefined,
+      initialEventCursor: claimed.structuredHost?.eventCursor,
     });
     stopPersistence = await bindClaudeHostPersistence(
       input.registry,
@@ -346,6 +366,21 @@ async function publishClaudeSuccessorHost(
     );
     unregister = await publishStructuredDeliveryHost({ key, host });
   } catch (error) {
+    if (!host && error instanceof StructuredHostAdoptionCleanupError
+      && error.host instanceof ClaudeStreamBrokerHost) {
+      host = error.host;
+      stopPersistence = await bindClaudeHostPersistence(
+        input.registry,
+        key,
+        host,
+        claimed.claimOwner,
+        claimed.claimEpoch,
+        "dead",
+      );
+      await host.release();
+      stopPersistence();
+      throw error;
+    }
     await unregister();
     if (host) await host.release();
     stopPersistence();

--- a/src/lib/agent/registry.test.ts
+++ b/src/lib/agent/registry.test.ts
@@ -776,6 +776,37 @@ describe("agent registry", () => {
     expect(fs.readFileSync(store.filename, "utf8")).toBe("{ broken");
   });
 
+  test.each([1.5, Number.MAX_SAFE_INTEGER + 1])(
+    "rejects persisted non-safe structured event cursor %p without rewriting it",
+    (eventCursor) => {
+      const store = registry();
+      store.upsert({
+        ...spawnEntry("/repo/019f4906-3f67-7b72-9fbc-9ec3b5ad1326.jsonl"),
+        structuredHost: {
+          kind: "codex-app-server",
+          endpoint: "stdio:released",
+          process: null,
+          eventCursor: 0,
+          protocolVersion: "0.144.1",
+          writerClaimEpoch: 1,
+          activeTurnRef: null,
+          pendingAttention: [],
+          activeFlags: [],
+        },
+      });
+      const persisted = JSON.parse(fs.readFileSync(store.filename, "utf8")) as {
+        entries: Record<string, { structuredHost: { eventCursor: number } }>;
+      };
+      persisted.entries[`codex:${KEY.sessionId}`]!.structuredHost.eventCursor = eventCursor;
+      const invalidBytes = `${JSON.stringify(persisted)}\n`;
+      fs.writeFileSync(store.filename, invalidBytes);
+
+      const reloaded = new AgentRegistry(store.filename);
+      expect(() => reloaded.snapshot()).toThrow("structured host event cursor is invalid");
+      expect(fs.readFileSync(store.filename, "utf8")).toBe(invalidBytes);
+    },
+  );
+
   test("upgrades v1, retains stable identity, and commits an A to B to A generation chain", () => {
     const store = registry();
     fs.writeFileSync(store.filename, JSON.stringify({ version: 1, entries: {}, receipts: {}, importedResumePanes: false, legacyResumePanes: { serverPid: null, panes: {} } }));

--- a/src/lib/agent/registry.ts
+++ b/src/lib/agent/registry.ts
@@ -2612,14 +2612,16 @@ export class AgentRegistry {
       const conversation = file.conversations[conversationId];
       const keyId = sessionKeyId(key);
       const entry = file.entries[keyId];
+      const structuredProcess = entry?.structuredHost?.process ?? null;
+      const staleStructuredWrapper = structuredProcess !== null && !this.ownerAlive(structuredProcess);
       if (!conversation
         || conversation.engine !== key.engine
         || !conversation.generations.some((generation) => generation.id === key.sessionId)
         || !entry
         || entry.host
-        || entry.structuredHost?.process
-        || entry.claimOwner
-        || (entry.status !== "dead" && entry.status !== "unhosted")) return false;
+        || (structuredProcess !== null && !staleStructuredWrapper)
+        || (entry.claimOwner && !staleStructuredWrapper)
+        || (!staleStructuredWrapper && entry.status !== "dead" && entry.status !== "unhosted")) return false;
       const replacement = {
         ...entry,
         host: null,

--- a/src/lib/agent/registry.ts
+++ b/src/lib/agent/registry.ts
@@ -102,6 +102,7 @@ export interface AgentRegistryEntry {
   claimEpoch: number;
   claimOwner: string | null;
   pendingAction: "spawn" | "resume" | "handoff" | null;
+  structuredHostOperationId?: string | null;
   updatedAt: string;
 }
 
@@ -711,6 +712,10 @@ function normalizeStructuredHost(value: unknown): StructuredHostColumns | null {
   if (!value || typeof value !== "object") return null;
   const host = value as Partial<StructuredHostColumns>;
   if (host.kind !== "codex-app-server" && host.kind !== "claude-broker") return null;
+  const eventCursor = (value as Record<string, unknown>).eventCursor;
+  if (eventCursor !== undefined && (!Number.isSafeInteger(eventCursor) || (eventCursor as number) < 0)) {
+    throw new Error("structured host event cursor is invalid");
+  }
   const processIdentity = host.process && typeof host.process === "object"
     && typeof host.process.pid === "number"
     ? { pid: host.process.pid, startIdentity: typeof host.process.startIdentity === "string" ? host.process.startIdentity : null }
@@ -719,7 +724,7 @@ function normalizeStructuredHost(value: unknown): StructuredHostColumns | null {
     kind: host.kind,
     endpoint: typeof host.endpoint === "string" ? host.endpoint : "",
     process: processIdentity,
-    eventCursor: Number.isSafeInteger(host.eventCursor) && (host.eventCursor ?? -1) >= 0 ? host.eventCursor! : 0,
+    eventCursor: eventCursor === undefined ? 0 : eventCursor as number,
     protocolVersion: typeof host.protocolVersion === "string" ? host.protocolVersion : null,
     writerClaimEpoch: Number.isSafeInteger(host.writerClaimEpoch) && (host.writerClaimEpoch ?? -1) >= 0 ? host.writerClaimEpoch! : 0,
     activeTurnRef: typeof host.activeTurnRef === "string" ? host.activeTurnRef : null,
@@ -2377,7 +2382,10 @@ export class AgentRegistry {
     return this.mutate((file) => {
       const paths = new Set([entry.artifactPath]);
       const signature = migrationReadinessSignature(file, entry.key.engine, paths);
-      const staged = this.settleSpawnInFile(file, launchId, entry, "route-completed", false);
+      const staged = this.settleSpawnInFile(file, launchId, {
+        ...entry,
+        structuredHostOperationId: launchId,
+      }, "route-completed", false);
       advanceMigrationScopeRevision(file, entry.key.engine, signature, paths);
       return staged;
     });
@@ -2393,6 +2401,12 @@ export class AgentRegistry {
       if (!receipt.key || !receipt.artifactPath) throw new Error("structured spawn identity is incomplete");
       const entry = file.entries[sessionKeyId(receipt.key)];
       const conversation = file.conversations[receipt.conversationId];
+      if (entry && typeof entry.structuredHostOperationId === "string"
+        && entry.structuredHostOperationId !== launchId) {
+        receipt.state = "conflicted";
+        receipt.error = "spawn_identity_conflict";
+        return { kind: "conflict", receipt: clone(receipt), code: "spawn_identity_conflict" };
+      }
       if (!entry || !conversation
         || entry.artifactPath !== receipt.artifactPath
         || !entry.structuredHost?.process
@@ -2487,17 +2501,30 @@ export class AgentRegistry {
       if (!receipt.key || !receipt.artifactPath) return;
       const entry = file.entries[sessionKeyId(receipt.key)];
       if (!entry || entry.artifactPath !== receipt.artifactPath) return;
+      if (typeof entry.structuredHostOperationId === "string"
+        && entry.structuredHostOperationId !== launchId) return;
+      const preservesResumeCursor = receipt.purpose === "resume-successor"
+        && receipt.resumeSourcePath === receipt.artifactPath
+        && (entry.structuredHost?.eventCursor ?? 0) > 0;
+      const terminalStructuredHost = preservesResumeCursor && entry.structuredHost ? {
+        ...entry.structuredHost,
+        endpoint: "stdio:released",
+        process: null,
+        activeTurnRef: null,
+        pendingAttention: [],
+        activeFlags: [],
+      } : null;
       const changedHostPaths = activeHostPathsChangedByEntry(file, sessionKeyId(receipt.key), {
         ...entry,
         host: null,
-        structuredHost: null,
+        structuredHost: terminalStructuredHost,
         status: "dead",
         claimOwner: null,
         pendingAction: null,
       });
       const readinessBefore = migrationReadinessSignature(file, receipt.key.engine, changedHostPaths);
       entry.host = null;
-      entry.structuredHost = null;
+      entry.structuredHost = terminalStructuredHost;
       entry.status = "dead";
       entry.claimOwner = null;
       entry.pendingAction = null;

--- a/src/lib/runtime/claudeStreamBrokerHost.test.ts
+++ b/src/lib/runtime/claudeStreamBrokerHost.test.ts
@@ -17,7 +17,7 @@ import {
   type ClaudeDeliveryState,
 } from "./claudeStreamBrokerHost";
 import type { RuntimeEventStore } from "./eventStore";
-import type { QueueEntry, RuntimeEvent } from "./engineHost";
+import type { HostState, QueueEntry, RuntimeEvent } from "./engineHost";
 import {
   adoptClaudeRegistryHosts,
   bindClaudeHostPersistence,
@@ -86,7 +86,11 @@ class FakeClaude extends EventEmitter {
   readonly inputs: Array<Record<string, unknown>> = [];
   sessionId = "";
 
-  constructor(private readonly ledger: RecordingDeliveryLedger, private readonly ignoreTerm = false) {
+  constructor(
+    private readonly ledger: RecordingDeliveryLedger,
+    private readonly ignoreTerm = false,
+    private readonly ignoreKill = false,
+  ) {
     super();
     let buffer = "";
     this.stdin.on("data", (chunk) => {
@@ -115,6 +119,7 @@ class FakeClaude extends EventEmitter {
   kill(signal: NodeJS.Signals = "SIGTERM"): boolean {
     this.signals.push(signal);
     if (signal === "SIGTERM" && this.ignoreTerm) return true;
+    if (signal === "SIGKILL" && this.ignoreKill) return true;
     queueMicrotask(() => this.emit("close", 0, signal));
     return true;
   }
@@ -190,6 +195,40 @@ describe("ClaudeStreamBrokerHost", () => {
       chosenNextSeq: 2,
       action: "use-durable-tail",
     })]);
+    await host.release();
+  });
+
+  test("fails closed before Claude emission advances beyond the safe-integer cursor range", async () => {
+    const sessionId = "claude-cursor-near-safe-limit";
+    const eventStore = new MemoryEventStore();
+    const ledger = new RecordingDeliveryLedger();
+    const child = new FakeClaude(ledger);
+    const host = await ClaudeStreamBrokerHost.adopt(sessionId, {
+      cwd: "/repo",
+      eventStore,
+      deliveryLedger: ledger,
+      initialEventCursor: Number.MAX_SAFE_INTEGER - 1,
+      readAuthStatus: () => ({ loggedIn: true, authMethod: "claude.ai", subscriptionType: "max" }),
+      readTranscript: () => [],
+      spawnProcess: fakeSpawn(child, {}),
+    });
+    expect(eventStore.load(sessionId)).toEqual([
+      { kind: "session-status", status: "idle", seq: Number.MAX_SAFE_INTEGER },
+    ]);
+
+    child.emitJson({
+      type: "user",
+      isReplay: true,
+      session_id: sessionId,
+      uuid: "unsafe-cursor-user",
+      message: { role: "user", content: [{ type: "text", text: "remain bounded" }] },
+    });
+    await Bun.sleep(0);
+
+    expect(eventStore.load(sessionId)).toEqual([
+      { kind: "session-status", status: "idle", seq: Number.MAX_SAFE_INTEGER },
+    ]);
+    expect(await host.health()).toMatchObject({ status: "dead", eventCursor: Number.MAX_SAFE_INTEGER });
     await host.release();
   });
 
@@ -940,6 +979,69 @@ describe("ClaudeStreamBrokerHost", () => {
     await restarted[0]!.host.release();
   });
 
+  test("startup adoption retains an unreaped Claude child until late cleanup converges", async () => {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-uncertain-claude-adoption-"));
+    const registry = new AgentRegistry(path.join(directory, "agent-registry.json"));
+    const sessionId = "uncertain-claude-adoption";
+    registry.upsert({
+      key: { engine: "claude", sessionId },
+      artifactPath: `/sessions/${sessionId}.jsonl`,
+      cwd: "/repo",
+      accountId: null,
+      status: "dead",
+      host: null,
+      structuredHost: {
+        kind: "claude-broker",
+        endpoint: "stdio:released",
+        process: null,
+        eventCursor: 4,
+        protocolVersion: "2.1.197",
+        writerClaimEpoch: 2,
+        activeTurnRef: null,
+        pendingAttention: [],
+        activeFlags: [],
+      },
+      claimEpoch: 2,
+      claimOwner: null,
+      pendingAction: null,
+    });
+    const ledger = new RecordingDeliveryLedger();
+    const child = new FakeClaude(ledger, true, true);
+
+    const adopted = await adoptClaudeRegistryHosts(
+      registry,
+      () => ({
+        cwd: "/repo",
+        deliveryLedger: ledger,
+        eventStore: new MemoryEventStore(),
+        shutdownGraceMs: 2,
+        readAuthStatus: () => ({ loggedIn: true, authMethod: "claude.ai", subscriptionType: "max" }),
+        readTranscript: () => { throw new Error("resume transcript failed"); },
+        spawnProcess: fakeSpawn(child, {}),
+      }),
+      { NODE_ENV: "test", LLV_STRUCTURED_HOSTS: "1" },
+    );
+
+    expect(adopted).toEqual([]);
+    expect(registry.snapshot().entries[`claude:${sessionId}`]).toMatchObject({
+      status: "idle",
+      claimOwner: expect.any(String),
+      structuredHost: {
+        endpoint: "stdio:5150",
+        process: { pid: 5150 },
+        writerClaimEpoch: 3,
+      },
+    });
+
+    child.emit("close", 0, "SIGKILL");
+    await Bun.sleep(0);
+    expect(registry.snapshot().entries[`claude:${sessionId}`]).toMatchObject({
+      status: "dead",
+      claimOwner: null,
+      structuredHost: { endpoint: "stdio:released", process: null },
+    });
+  });
+
   test("boot adoption reaps a surviving orphaned Claude child before resume", async () => {
     const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-claude-orphan-adoption-"));
     const registry = new AgentRegistry(path.join(directory, "agent-registry.json"));
@@ -1077,6 +1179,90 @@ describe("ClaudeStreamBrokerHost", () => {
       await Promise.race([orphanExit, Bun.sleep(2_000)]);
     }
   }, 10_000);
+
+  test("a timed-out Claude release converges after a late child reap and permits cleanup retry", async () => {
+    const ledger = new RecordingDeliveryLedger();
+    const child = new FakeClaude(ledger, true, true);
+    const host = await ClaudeStreamBrokerHost.start({
+      cwd: "/repo",
+      deliveryLedger: ledger,
+      eventStore: new MemoryEventStore(),
+      shutdownGraceMs: 2,
+      readAuthStatus: () => ({ loggedIn: true, authMethod: "claude.ai", subscriptionType: "max" }),
+      readTranscript: () => [],
+      spawnProcess: fakeSpawn(child, {}),
+    });
+    const states: HostState[] = [];
+    host.onStateChange((state) => states.push(state));
+
+    await expect(host.release()).rejects.toThrow("Claude child could not be reaped");
+    child.emit("close", 0, "SIGKILL");
+    await Bun.sleep(0);
+
+    expect(await host.health()).toMatchObject({ status: "unhosted", pid: null, endpoint: "stdio:released" });
+    expect(states.at(-1)).toMatchObject({ status: "unhosted", pid: null });
+    await expect(host.release()).resolves.toBeUndefined();
+  });
+
+  test("a late Claude reap after ledger failure releases the persisted writer claim", async () => {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-claude-late-ledger-reap-"));
+    const registry = new AgentRegistry(path.join(directory, "agent-registry.json"));
+    const ledger = new RecordingDeliveryLedger();
+    const child = new FakeClaude(ledger, true, true);
+    const eventStore = new FailingEventStore();
+    const host = await ClaudeStreamBrokerHost.start({
+      cwd: "/repo",
+      deliveryLedger: ledger,
+      eventStore,
+      shutdownGraceMs: 2,
+      readAuthStatus: () => ({ loggedIn: true, authMethod: "claude.ai", subscriptionType: "max" }),
+      readTranscript: () => [],
+      spawnProcess: fakeSpawn(child, {}),
+    });
+    const key = { engine: "claude" as const, sessionId: host.identity.sessionId };
+    registry.upsert({
+      key,
+      artifactPath: `/sessions/${host.identity.sessionId}.jsonl`,
+      cwd: "/repo",
+      accountId: null,
+      status: "idle",
+      host: null,
+      structuredHost: {
+        kind: "claude-broker",
+        endpoint: "stdio:5150",
+        process: { pid: 5150, startIdentity: null },
+        eventCursor: 1,
+        protocolVersion: null,
+        writerClaimEpoch: 1,
+        activeTurnRef: null,
+        pendingAttention: [],
+        activeFlags: [],
+      },
+      claimEpoch: 1,
+      claimOwner: "late-ledger-reap-owner",
+      pendingAction: null,
+    });
+    await bindClaudeHostPersistence(registry, key, host, "late-ledger-reap-owner", 1);
+
+    child.emitJson({
+      type: "stream_event",
+      session_id: host.identity.sessionId,
+      event: { type: "content_block_delta", delta: { text: "fails append" } },
+    });
+    await Bun.sleep(0);
+    expect(await host.health()).toMatchObject({ status: "dead", pid: 5150 });
+    await expect(host.release()).rejects.toThrow("Claude child could not be reaped");
+
+    child.emit("close", 0, "SIGKILL");
+    await Bun.sleep(0);
+
+    expect(registry.snapshot().entries[`claude:${host.identity.sessionId}`]).toMatchObject({
+      status: "dead",
+      claimOwner: null,
+      structuredHost: { endpoint: "stdio:released", process: null },
+    });
+    await expect(host.release()).resolves.toBeUndefined();
+  });
 
   test("protocol failure reaps a TERM-resistant child and releases its writer claim", async () => {
     const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-claude-failure-claim-"));

--- a/src/lib/runtime/claudeStreamBrokerHost.test.ts
+++ b/src/lib/runtime/claudeStreamBrokerHost.test.ts
@@ -158,6 +158,41 @@ describe("ClaudeStreamBrokerHost", () => {
     await host.release();
   });
 
+  test.each([0, 2])("anchors resumed Claude emission after durable sequence 1 when the registry cursor is %i", async (registryCursor) => {
+    const sessionId = `claude-cursor-${registryCursor}`;
+    const eventStore = new MemoryEventStore();
+    eventStore.append(sessionId, { kind: "session-status", status: "idle", seq: 1 });
+    const ledger = new RecordingDeliveryLedger();
+    const child = new FakeClaude(ledger);
+    const diagnostics: unknown[] = [];
+
+    const host = await ClaudeStreamBrokerHost.adopt(sessionId, {
+      cwd: "/repo",
+      eventStore,
+      deliveryLedger: ledger,
+      initialEventCursor: registryCursor,
+      onEventCursorRecovery: (diagnostic) => diagnostics.push(diagnostic),
+      readAuthStatus: () => ({ loggedIn: true, authMethod: "claude.ai", subscriptionType: "max" }),
+      readTranscript: () => [],
+      spawnProcess: fakeSpawn(child, {}),
+    });
+
+    expect(eventStore.load(sessionId).slice(-2)).toEqual([
+      { kind: "session-status", status: "idle", seq: 1 },
+      { kind: "session-status", status: "idle", seq: 2 },
+    ]);
+    expect(await host.health()).toMatchObject({ eventCursor: 2, status: "idle" });
+    expect(diagnostics).toEqual([expect.objectContaining({
+      kind: "runtime-event-cursor-recovery",
+      sessionId,
+      durableTailSeq: 1,
+      registryCursor,
+      chosenNextSeq: 2,
+      action: "use-durable-tail",
+    })]);
+    await host.release();
+  });
+
   test("persists sends before stdin and fans durable events to late viewers", async () => {
     const ledger = new RecordingDeliveryLedger();
     const child = new FakeClaude(ledger);

--- a/src/lib/runtime/claudeStreamBrokerHost.ts
+++ b/src/lib/runtime/claudeStreamBrokerHost.ts
@@ -12,9 +12,10 @@ import { procBackend } from "@/lib/proc";
 import { hardenedRedact } from "@/lib/view/compactText";
 
 import type { DeliveryReceipt, EngineHost, HostState, QueueEntry, RuntimeEvent } from "./engineHost";
-import { RuntimeReplayGapError } from "./engineHost";
+import { RuntimeReplayGapError, StructuredHostAdoptionCleanupError } from "./engineHost";
 import {
   FileRuntimeEventStore,
+  nextRuntimeEventSequence,
   reconcileRuntimeEventCursor,
   type RuntimeEventCursorRecoveryReporter,
   type RuntimeEventStore,
@@ -397,7 +398,8 @@ export class ClaudeStreamBrokerHost implements EngineHost {
         this.terminationTimer = null;
       }
       this.resolveReaped();
-      if (this.dead) this.notifyStateListeners();
+      if (this.releasing) this.finishRelease();
+      else if (this.dead) this.notifyStateListeners();
       else if (!this.releasing && !this.released) this.fail(new Error("Claude child exited"));
     });
   }
@@ -456,7 +458,11 @@ export class ClaudeStreamBrokerHost implements EngineHost {
       host.emit({ kind: "session-status", status: "idle" });
       return host;
     } catch (error) {
-      await host.release();
+      try {
+        await host.release();
+      } catch (cleanupError) {
+        throw new StructuredHostAdoptionCleanupError(safeError(error), host, { cause: cleanupError });
+      }
       throw new Error(safeError(error));
     }
   }
@@ -603,7 +609,14 @@ export class ClaudeStreamBrokerHost implements EngineHost {
   setWriterFence(fence: () => boolean): void { this.writerFence = fence; }
 
   async release(): Promise<void> {
-    this.releasePromise ??= this.releaseAndReap();
+    if (this.released) return;
+    if (!this.releasePromise) {
+      const attempt = this.releaseAndReap();
+      this.releasePromise = attempt;
+      void attempt.catch(() => {
+        if (this.releasePromise === attempt) this.releasePromise = null;
+      });
+    }
     return this.releasePromise;
   }
 
@@ -681,7 +694,16 @@ export class ClaudeStreamBrokerHost implements EngineHost {
 
   private emit(event: UnsequencedEvent): void {
     if (this.ledgerFailed) return;
-    const sequenced = { ...event, seq: ++this.cursor } as RuntimeEvent;
+    let nextCursor: number;
+    try {
+      nextCursor = nextRuntimeEventSequence(this.cursor);
+    } catch (error) {
+      this.ledgerFailed = true;
+      this.failWithoutLedger(new Error(safeError(error)));
+      return;
+    }
+    this.cursor = nextCursor;
+    const sequenced = { ...event, seq: nextCursor } as RuntimeEvent;
     try { this.eventStore.append(this.identity.sessionId, sequenced); }
     catch (error) {
       this.cursor = this.events.at(-1)?.seq ?? Math.max(0, this.cursor - 1);
@@ -850,11 +872,17 @@ export class ClaudeStreamBrokerHost implements EngineHost {
       try { this.child.kill("SIGKILL"); } catch { /* already closed */ }
       if (!await this.waitForReap(this.shutdownGraceMs)) throw new Error("Claude child could not be reaped");
     }
+    this.finishRelease();
+  }
+
+  private finishRelease(): void {
+    if (this.released) return;
     this.released = true;
     this.releasing = false;
     this.activeTurnId = null;
     this.attentions.clear();
     this.emit({ kind: "session-status", status: "unhosted" });
+    if (this.ledgerFailed) this.notifyStateListeners();
     this.closeSubscribers();
   }
 

--- a/src/lib/runtime/claudeStreamBrokerHost.ts
+++ b/src/lib/runtime/claudeStreamBrokerHost.ts
@@ -13,7 +13,12 @@ import { hardenedRedact } from "@/lib/view/compactText";
 
 import type { DeliveryReceipt, EngineHost, HostState, QueueEntry, RuntimeEvent } from "./engineHost";
 import { RuntimeReplayGapError } from "./engineHost";
-import { FileRuntimeEventStore, type RuntimeEventStore } from "./eventStore";
+import {
+  FileRuntimeEventStore,
+  reconcileRuntimeEventCursor,
+  type RuntimeEventCursorRecoveryReporter,
+  type RuntimeEventStore,
+} from "./eventStore";
 
 type JsonObject = Record<string, unknown>;
 type Subscriber = { afterSeq: number; queue: RuntimeEvent[]; wake: (() => void) | null; closed: boolean };
@@ -173,6 +178,7 @@ export interface ClaudeStreamBrokerHostOptions {
   requestTimeoutMs?: number;
   shutdownGraceMs?: number;
   initialEventCursor?: number;
+  onEventCursorRecovery?: RuntimeEventCursorRecoveryReporter;
   spawnProcess?: (command: string, args: string[], options: SpawnOptionsWithoutStdio) => ChildProcessWithoutNullStreams;
   readAuthStatus?: () => ClaudeAuthStatus | Promise<ClaudeAuthStatus>;
   readTranscript?: (cwd: string, sessionId: string) => ClaudeTranscriptUser[];
@@ -325,6 +331,7 @@ export class ClaudeStreamBrokerHost implements EngineHost {
   private readonly deliveryLedger: ClaudeDeliveryLedger;
   private readonly requestTimeoutMs: number;
   private readonly shutdownGraceMs: number;
+  private readonly onEventCursorRecovery: RuntimeEventCursorRecoveryReporter | undefined;
   private readonly subscribers = new Set<Subscriber>();
   private readonly events: RuntimeEvent[] = [];
   private readonly deliveries: ClaudeDeliveryState[] = [];
@@ -366,6 +373,7 @@ export class ClaudeStreamBrokerHost implements EngineHost {
     this.deliveryLedger = options.deliveryLedger ?? new FileClaudeDeliveryLedger();
     this.requestTimeoutMs = options.requestTimeoutMs ?? DEFAULT_TIMEOUT_MS;
     this.shutdownGraceMs = options.shutdownGraceMs ?? DEFAULT_SHUTDOWN_GRACE_MS;
+    this.onEventCursorRecovery = options.onEventCursorRecovery;
     this.cursor = options.initialEventCursor ?? 0;
     this.protocolVersion = auth.version ?? null;
     this.account = { type: auth.authMethod, planType: auth.subscriptionType };
@@ -629,7 +637,12 @@ export class ClaudeStreamBrokerHost implements EngineHost {
   private restore(): void {
     const stored = this.eventStore.load(this.identity.sessionId);
     this.events.push(...stored);
-    this.cursor = Math.max(this.cursor, stored.at(-1)?.seq ?? 0);
+    this.cursor = reconcileRuntimeEventCursor(
+      this.identity.sessionId,
+      stored.at(-1)?.seq ?? 0,
+      this.cursor,
+      this.onEventCursorRecovery,
+    );
     this.deliveries.push(...this.deliveryLedger.load(this.identity.sessionId));
     let restoredTurn: string | null = null;
     for (const event of stored) {

--- a/src/lib/runtime/codexAppServerHost.integration.test.ts
+++ b/src/lib/runtime/codexAppServerHost.integration.test.ts
@@ -103,8 +103,11 @@ test.skipIf(!isolatedHome)("real Codex subscription supports late attach, steeri
     expect(pathIsInside(isolatedHome.codexHome, recovered.identity.path ?? "")).toBeTrue();
     const restartReplay = recovered.attach(releasedCursor - 1)[Symbol.asyncIterator]();
     expect((await restartReplay.next()).value).toEqual({ kind: "session-status", status: "unhosted", seq: releasedCursor });
-    expect((await restartReplay.next()).value).toEqual({ kind: "session-status", status: "idle", seq: releasedCursor + 1 });
-    const recoveryEvents = recovered.attach(releasedCursor + 1)[Symbol.asyncIterator]();
+    const recoveredCursor = (await recovered.health()).eventCursor;
+    const reconciledIdle = await waitFor(restartReplay, (event) => event.seq === recoveredCursor);
+    expect(reconciledIdle).toEqual({ kind: "session-status", status: "idle", seq: recoveredCursor });
+    expect(recoveredCursor).toBeGreaterThan(releasedCursor);
+    const recoveryEvents = recovered.attach(recoveredCursor)[Symbol.asyncIterator]();
     const recall = await recovered.send({
       id: `issue-149-recall-${crypto.randomUUID()}`,
       text: "Reply with only the marker I asked you to remember.",

--- a/src/lib/runtime/codexAppServerHost.test.ts
+++ b/src/lib/runtime/codexAppServerHost.test.ts
@@ -11,7 +11,7 @@ import { emptyLaunchProfile } from "@/lib/accounts/migration/contracts";
 
 import { CodexAppServerHost, redactCodexHostDiagnostic } from "./codexAppServerHost";
 import { FileRuntimeEventStore, type RuntimeEventStore } from "./eventStore";
-import type { RuntimeEvent } from "./engineHost";
+import type { HostState, RuntimeEvent } from "./engineHost";
 import { adoptCodexRegistryHosts, bindCodexHostPersistence, persistCodexHost, startCodexStructuredHost, structuredHostsEnabled } from "./registry";
 
 class MemoryEventStore implements RuntimeEventStore {
@@ -63,7 +63,9 @@ class FakeAppServer extends EventEmitter {
     private readonly ignoreTerm = false,
     private readonly turns: unknown[] = [],
     private readonly resumeStatus: unknown = undefined,
-    private readonly resumeRequest: { id: string; method: string; params: Record<string, unknown> } | null = null,
+    private readonly resumeRequest: { id?: string; method: string; params: Record<string, unknown> }
+      | Array<{ id?: string; method: string; params: Record<string, unknown> }>
+      | null = null,
     private readonly ignoredMethods: string[] = [],
   ) {
     super();
@@ -121,7 +123,10 @@ class FakeAppServer extends EventEmitter {
     if (method === "thread/start" || method === "thread/resume") {
       const id = method === "thread/resume" ? this.resumedThreadId : this.threadId;
       if (method === "thread/resume" && this.resumeRequest) {
-        this.request(this.resumeRequest.id, this.resumeRequest.method, this.resumeRequest.params);
+        for (const request of Array.isArray(this.resumeRequest) ? this.resumeRequest : [this.resumeRequest]) {
+          if (request.id) this.request(request.id, request.method, request.params);
+          else this.notify(request.method, request.params);
+        }
       }
       return this.respond(message.id, {
         thread: {
@@ -682,6 +687,346 @@ describe("CodexAppServerHost", () => {
     fs.rmSync(directory, { recursive: true, force: true });
   });
 
+  test("persists overlapping pre-restore lifecycle notifications exactly once after a 942-record ledger", async () => {
+    const threadId = "019f66b5-8694-7410-8671-fbec75484a86";
+    const turnId = "turn-after-942";
+    const item = { type: "agentMessage", id: "item-after-942", text: "resumed response" };
+    const eventStore = new MemoryEventStore();
+    for (let seq = 1; seq <= 942; seq += 1) {
+      eventStore.append(threadId, { kind: "session-status", status: "idle", seq });
+    }
+    const server = new FakeAppServer(threadId, threadId, false, [{
+      id: turnId,
+      status: "completed",
+      items: [item],
+    }], { type: "idle" }, [
+      { method: "turn/started", params: { threadId, turn: { id: turnId } } },
+      { method: "item/started", params: { threadId, turnId, item } },
+      { method: "item/completed", params: { threadId, turnId, item } },
+      { method: "turn/completed", params: { threadId, turn: { id: turnId, status: "completed" } } },
+    ]);
+
+    const host = await CodexAppServerHost.adopt(threadId, {
+      cwd: "/repo",
+      eventStore,
+      initialEventCursor: 942,
+      spawnProcess: fakeSpawn(server),
+    });
+
+    expect(eventStore.load(threadId).slice(942)).toEqual([
+      { kind: "turn-started", turnId, seq: 943 },
+      { kind: "item", turnId, item, phase: "started", seq: 944 },
+      { kind: "item", turnId, item, phase: "completed", seq: 945 },
+      { kind: "turn-ended", turnId, status: "completed", seq: 946 },
+      { kind: "session-status", status: "idle", seq: 947 },
+    ]);
+    await host.release();
+
+    const restartCursor = eventStore.load(threadId).at(-1)!.seq;
+    const replacement = await CodexAppServerHost.adopt(threadId, {
+      cwd: "/repo",
+      eventStore,
+      initialEventCursor: restartCursor,
+      spawnProcess: fakeSpawn(new FakeAppServer(threadId, threadId, false, [{
+        id: turnId,
+        status: "completed",
+        items: [item],
+      }], { type: "idle" })),
+    });
+    const lifecycle = eventStore.load(threadId).filter((event) =>
+      event.kind === "turn-started" || event.kind === "item" || event.kind === "turn-ended");
+    expect(lifecycle).toEqual([
+      { kind: "turn-started", turnId, seq: 943 },
+      { kind: "item", turnId, item, phase: "started", seq: 944 },
+      { kind: "item", turnId, item, phase: "completed", seq: 945 },
+      { kind: "turn-ended", turnId, status: "completed", seq: 946 },
+    ]);
+    await replacement.release();
+  });
+
+  test("deduplicates a buffered lifecycle overlap against the durable crash prefix", async () => {
+    const threadId = "019f66b5-8694-7410-8671-fbec75484a86-overlap";
+    const turnId = "turn-overlapping-942";
+    const item = { type: "agentMessage", id: "item-overlapping-942", text: "resumed response" };
+    const eventStore = new MemoryEventStore();
+    for (let seq = 1; seq <= 940; seq += 1) {
+      eventStore.append(threadId, { kind: "session-status", status: "idle", seq });
+    }
+    eventStore.append(threadId, { kind: "turn-started", turnId, seq: 941 });
+    eventStore.append(threadId, { kind: "item", turnId, item, phase: "started", seq: 942 });
+    const server = new FakeAppServer(threadId, threadId, false, [{
+      id: turnId,
+      status: "completed",
+      items: [item],
+    }], { type: "idle" }, [
+      { method: "turn/started", params: { threadId, turn: { id: turnId } } },
+      { method: "item/started", params: { threadId, turnId, item } },
+      { method: "item/completed", params: { threadId, turnId, item } },
+      { method: "turn/completed", params: { threadId, turn: { id: turnId, status: "completed" } } },
+    ]);
+
+    const host = await CodexAppServerHost.adopt(threadId, {
+      cwd: "/repo",
+      eventStore,
+      initialEventCursor: 942,
+      spawnProcess: fakeSpawn(server),
+    });
+
+    expect(eventStore.load(threadId).slice(942)).toEqual([
+      { kind: "item", turnId, item, phase: "completed", seq: 943 },
+      { kind: "turn-ended", turnId, status: "completed", seq: 944 },
+      { kind: "session-status", status: "idle", seq: 945 },
+    ]);
+    await host.release();
+  });
+
+  test("reconciles repeated buffered deltas by occurrence against the durable crash prefix", async () => {
+    const threadId = "buffered-delta-overlap";
+    const turnId = "buffered-delta-turn";
+    const eventStore = new MemoryEventStore();
+    eventStore.append(threadId, { kind: "turn-started", turnId, seq: 1 });
+    eventStore.append(threadId, { kind: "delta", turnId, text: "same fragment", seq: 2 });
+    const server = new FakeAppServer(threadId, threadId, false, [{
+      id: turnId,
+      status: "inProgress",
+      items: [],
+    }], { type: "active", activeFlags: ["running"] }, [
+      { method: "item/agentMessage/delta", params: { threadId, turnId, delta: "same fragment" } },
+      { method: "item/agentMessage/delta", params: { threadId, turnId, delta: "same fragment" } },
+    ]);
+
+    const host = await CodexAppServerHost.adopt(threadId, {
+      cwd: "/repo",
+      eventStore,
+      initialEventCursor: 2,
+      spawnProcess: fakeSpawn(server),
+    });
+
+    expect(eventStore.load(threadId).filter((event) => event.kind === "delta")).toEqual([
+      { kind: "delta", turnId, text: "same fragment", seq: 2 },
+      { kind: "delta", turnId, text: "same fragment", seq: 3 },
+    ]);
+    await host.release();
+  });
+
+  test("matches buffered delta overlap against the ordered durable suffix", async () => {
+    const threadId = "buffered-delta-ordered-overlap";
+    const turnId = "buffered-delta-ordered-turn";
+    const eventStore = new MemoryEventStore();
+    eventStore.append(threadId, { kind: "turn-started", turnId, seq: 1 });
+    eventStore.append(threadId, { kind: "delta", turnId, text: "first fragment", seq: 2 });
+    eventStore.append(threadId, { kind: "delta", turnId, text: "second fragment", seq: 3 });
+    const server = new FakeAppServer(threadId, threadId, false, [{
+      id: turnId,
+      status: "inProgress",
+      items: [],
+    }], { type: "active", activeFlags: ["running"] }, [
+      { method: "item/agentMessage/delta", params: { threadId, turnId, delta: "second fragment" } },
+      { method: "item/agentMessage/delta", params: { threadId, turnId, delta: "first fragment" } },
+    ]);
+
+    const host = await CodexAppServerHost.adopt(threadId, {
+      cwd: "/repo",
+      eventStore,
+      initialEventCursor: 3,
+      spawnProcess: fakeSpawn(server),
+    });
+
+    expect(eventStore.load(threadId).filter((event) => event.kind === "delta")).toEqual([
+      { kind: "delta", turnId, text: "first fragment", seq: 2 },
+      { kind: "delta", turnId, text: "second fragment", seq: 3 },
+      { kind: "delta", turnId, text: "first fragment", seq: 4 },
+    ]);
+    await host.release();
+  });
+
+  test("reactivates a dead durable turn before its buffered resumed delta", async () => {
+    const threadId = "buffered-dead-turn-reactivation";
+    const turnId = "buffered-resumed-turn";
+    const eventStore = new MemoryEventStore();
+    eventStore.append(threadId, { kind: "turn-started", turnId, seq: 1 });
+    eventStore.append(threadId, { kind: "session-status", status: "dead", seq: 2 });
+    const server = new FakeAppServer(threadId, threadId, false, [{
+      id: turnId,
+      status: "inProgress",
+      items: [],
+    }], { type: "active", activeFlags: ["running"] }, [
+      { method: "turn/started", params: { threadId, turn: { id: turnId } } },
+      { method: "item/agentMessage/delta", params: { threadId, turnId, delta: "resumed fragment" } },
+    ]);
+
+    const host = await CodexAppServerHost.adopt(threadId, {
+      cwd: "/repo",
+      eventStore,
+      initialEventCursor: 2,
+      spawnProcess: fakeSpawn(server),
+    });
+
+    expect(eventStore.load(threadId).slice(2)).toEqual([
+      { kind: "turn-started", turnId, seq: 3 },
+      { kind: "delta", turnId, text: "resumed fragment", seq: 4 },
+      { kind: "session-status", status: "active", activeFlags: ["running"], seq: 5 },
+    ]);
+    await host.release();
+  });
+
+  test("preserves buffered terminal ordering before the next resumed turn", async () => {
+    const threadId = "buffered-cross-turn-order";
+    const completedTurnId = "buffered-completed-turn";
+    const activeTurnId = "buffered-next-turn";
+    const eventStore = new MemoryEventStore();
+    const server = new FakeAppServer(threadId, threadId, false, [
+      { id: completedTurnId, status: "completed", items: [] },
+      { id: activeTurnId, status: "inProgress", items: [] },
+    ], { type: "active", activeFlags: ["running"] }, [
+      { method: "turn/completed", params: { threadId, turn: { id: completedTurnId, status: "completed" } } },
+      { method: "turn/started", params: { threadId, turn: { id: activeTurnId } } },
+      { method: "item/agentMessage/delta", params: { threadId, turnId: activeTurnId, delta: "next turn fragment" } },
+    ]);
+
+    const host = await CodexAppServerHost.adopt(threadId, {
+      cwd: "/repo",
+      eventStore,
+      spawnProcess: fakeSpawn(server),
+    });
+
+    expect(eventStore.load(threadId)).toEqual([
+      { kind: "turn-started", turnId: completedTurnId, seq: 1 },
+      { kind: "turn-ended", turnId: completedTurnId, status: "completed", seq: 2 },
+      { kind: "turn-started", turnId: activeTurnId, seq: 3 },
+      { kind: "delta", turnId: activeTurnId, text: "next turn fragment", seq: 4 },
+      { kind: "session-status", status: "active", activeFlags: ["running"], seq: 5 },
+    ]);
+    expect(await host.health()).toMatchObject({ status: "active", activeTurnRef: activeTurnId });
+    await host.release();
+  });
+
+  test("reuses a buffered approval already present in the durable crash prefix", async () => {
+    const threadId = "buffered-attention-overlap";
+    const attentionId = "item/commandExecution/requestApproval:buffered-approval";
+    const attention = { command: "date" };
+    const eventStore = new MemoryEventStore();
+    eventStore.append(threadId, {
+      kind: "attention",
+      id: attentionId,
+      method: "item/commandExecution/requestApproval",
+      attention,
+      seq: 1,
+    });
+    const server = new FakeAppServer(threadId, threadId, false, [], { type: "idle" }, {
+      id: "buffered-approval",
+      method: "item/commandExecution/requestApproval",
+      params: attention,
+    });
+
+    const host = await CodexAppServerHost.adopt(threadId, {
+      cwd: "/repo",
+      eventStore,
+      initialEventCursor: 1,
+      spawnProcess: fakeSpawn(server),
+    });
+
+    expect(eventStore.load(threadId).filter((event) => event.kind === "attention")).toEqual([{
+      kind: "attention",
+      id: attentionId,
+      method: "item/commandExecution/requestApproval",
+      attention,
+      seq: 1,
+    }]);
+    expect(await host.health()).toMatchObject({ status: "attention", pendingAttention: [attentionId] });
+    await host.answer(attentionId, { decision: "accept" });
+    await host.release();
+  });
+
+  test("orders a buffered terminal-only suffix after reconstructed resume history", async () => {
+    const threadId = "019f66b5-8694-7410-8671-fbec75484a86-terminal-suffix";
+    const turnId = "turn-terminal-suffix-942";
+    const item = { type: "agentMessage", id: "item-terminal-suffix-942", text: "resumed response" };
+    const eventStore = new MemoryEventStore();
+    for (let seq = 1; seq <= 942; seq += 1) {
+      eventStore.append(threadId, { kind: "session-status", status: "idle", seq });
+    }
+    const server = new FakeAppServer(threadId, threadId, false, [{
+      id: turnId,
+      status: "completed",
+      items: [item],
+    }], { type: "idle" }, [
+      { method: "turn/completed", params: { threadId, turn: { id: turnId, status: "completed" } } },
+    ]);
+
+    const host = await CodexAppServerHost.adopt(threadId, {
+      cwd: "/repo",
+      eventStore,
+      initialEventCursor: 942,
+      spawnProcess: fakeSpawn(server),
+    });
+
+    expect(eventStore.load(threadId).slice(942)).toEqual([
+      { kind: "turn-started", turnId, seq: 943 },
+      { kind: "item", turnId, item, phase: "completed", seq: 944 },
+      { kind: "turn-ended", turnId, status: "completed", seq: 945 },
+      { kind: "session-status", status: "idle", seq: 946 },
+    ]);
+    await host.release();
+  });
+
+  test("a deferred completed turn cannot clear the newer resumed active turn", async () => {
+    const threadId = "deferred-terminal-active-turn";
+    const completedTurnId = "turn-completed-before-resume";
+    const activeTurnId = "turn-active-after-resume";
+    const eventStore = new MemoryEventStore();
+    const server = new FakeAppServer(threadId, threadId, false, [
+      { id: completedTurnId, status: "completed", items: [] },
+      { id: activeTurnId, status: "inProgress", items: [] },
+    ], { type: "active", activeFlags: ["running"] }, [
+      { method: "turn/completed", params: { threadId, turn: { id: completedTurnId, status: "completed" } } },
+    ]);
+
+    const host = await CodexAppServerHost.adopt(threadId, {
+      cwd: "/repo",
+      eventStore,
+      spawnProcess: fakeSpawn(server),
+    });
+
+    expect(eventStore.load(threadId).filter((event) =>
+      event.kind === "turn-started" && event.turnId === activeTurnId)).toEqual([
+      { kind: "turn-started", turnId: activeTurnId, seq: 3 },
+    ]);
+    expect(await host.health()).toMatchObject({
+      status: "active",
+      activeTurnRef: activeTurnId,
+      activeFlags: ["running"],
+    });
+    await host.release();
+  });
+
+  test("fails closed before host emission advances beyond the safe-integer cursor range", async () => {
+    const threadId = "cursor-near-safe-limit";
+    const eventStore = new MemoryEventStore();
+    const server = new FakeAppServer(threadId);
+    const host = await CodexAppServerHost.adopt(threadId, {
+      cwd: "/repo",
+      eventStore,
+      initialEventCursor: Number.MAX_SAFE_INTEGER - 1,
+      spawnProcess: fakeSpawn(server),
+    });
+    expect(eventStore.load(threadId)).toEqual([
+      { kind: "session-status", status: "idle", seq: Number.MAX_SAFE_INTEGER },
+    ]);
+
+    server.notify("account/rateLimits/updated", { credits: "unchanged" });
+    await Bun.sleep(0);
+
+    expect(eventStore.load(threadId)).toEqual([
+      { kind: "session-status", status: "idle", seq: Number.MAX_SAFE_INTEGER },
+    ]);
+    expect(await host.health()).toMatchObject({
+      status: "dead",
+      eventCursor: Number.MAX_SAFE_INTEGER,
+    });
+    await host.release();
+  });
+
   test("parses generated-schema thread status notifications", async () => {
     const server = new FakeAppServer("status-thread");
     const host = await CodexAppServerHost.start({
@@ -765,6 +1110,27 @@ describe("CodexAppServerHost", () => {
       { pid: -4242, signal: "SIGKILL" },
     ]);
     expect(server.signals).toEqual([]);
+  });
+
+  test("a timed-out release converges after a late child reap and permits cleanup retry", async () => {
+    const server = new FakeAppServer("late-reap-thread");
+    const host = await CodexAppServerHost.start({
+      cwd: "/repo",
+      shutdownGraceMs: 2,
+      eventStore: new MemoryEventStore(),
+      spawnProcess: fakeSpawn(server),
+      signalProcess: () => {},
+    });
+    const states: HostState[] = [];
+    host.onStateChange((state) => states.push(state));
+
+    await expect(host.release()).rejects.toThrow("Codex app-server child could not be reaped");
+    server.emit("close", 0, "SIGKILL");
+    await Bun.sleep(0);
+
+    expect(await host.health()).toMatchObject({ status: "unhosted", pid: null, endpoint: "stdio:released" });
+    expect(states.at(-1)).toMatchObject({ status: "unhosted", pid: null });
+    await expect(host.release()).resolves.toBeUndefined();
   });
 
   test("protocol failure starts bounded TERM and KILL cleanup", async () => {
@@ -1254,6 +1620,66 @@ describe("CodexAppServerHost", () => {
         pendingAttention: [],
         activeFlags: [],
       },
+    });
+  });
+
+  test("startup adoption retains an unreaped Codex child until late cleanup converges", async () => {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-uncertain-codex-adoption-"));
+    const registry = new AgentRegistry(path.join(directory, "agent-registry.json"));
+    const sessionId = "uncertain-codex-adoption";
+    registry.upsert({
+      key: { engine: "codex", sessionId },
+      artifactPath: `/sessions/${sessionId}.jsonl`,
+      cwd: "/repo",
+      accountId: null,
+      status: "dead",
+      host: null,
+      structuredHost: {
+        kind: "codex-app-server",
+        endpoint: "stdio:released",
+        process: null,
+        eventCursor: 9,
+        protocolVersion: "0.144.1",
+        writerClaimEpoch: 2,
+        activeTurnRef: null,
+        pendingAttention: [],
+        activeFlags: [],
+      },
+      claimEpoch: 2,
+      claimOwner: null,
+      pendingAction: null,
+    });
+    const server = new FakeAppServer(sessionId, "different-thread");
+
+    const adopted = await adoptCodexRegistryHosts(
+      registry,
+      () => ({
+        cwd: "/repo",
+        eventStore: new MemoryEventStore(),
+        shutdownGraceMs: 2,
+        spawnProcess: fakeSpawn(server),
+        signalProcess: () => {},
+      }),
+      { NODE_ENV: "test", LLV_STRUCTURED_HOSTS: "1" },
+    );
+
+    expect(adopted).toEqual([]);
+    expect(registry.snapshot().entries[`codex:${sessionId}`]).toMatchObject({
+      status: "idle",
+      claimOwner: expect.any(String),
+      structuredHost: {
+        endpoint: "stdio:4242",
+        process: { pid: 4242 },
+        writerClaimEpoch: 3,
+      },
+    });
+
+    server.emit("close", 0, "SIGKILL");
+    await Bun.sleep(0);
+    expect(registry.snapshot().entries[`codex:${sessionId}`]).toMatchObject({
+      status: "dead",
+      claimOwner: null,
+      structuredHost: { endpoint: "stdio:released", process: null },
     });
   });
 

--- a/src/lib/runtime/codexAppServerHost.test.ts
+++ b/src/lib/runtime/codexAppServerHost.test.ts
@@ -10,7 +10,7 @@ import { AgentRegistry } from "@/lib/agent/registry";
 import { emptyLaunchProfile } from "@/lib/accounts/migration/contracts";
 
 import { CodexAppServerHost, redactCodexHostDiagnostic } from "./codexAppServerHost";
-import type { RuntimeEventStore } from "./eventStore";
+import { FileRuntimeEventStore, type RuntimeEventStore } from "./eventStore";
 import type { RuntimeEvent } from "./engineHost";
 import { adoptCodexRegistryHosts, bindCodexHostPersistence, persistCodexHost, startCodexStructuredHost, structuredHostsEnabled } from "./registry";
 
@@ -342,12 +342,18 @@ describe("CodexAppServerHost", () => {
 
   test("rejects a resume response for a different durable thread", async () => {
     const server = new FakeAppServer("server-default", "different-thread");
+    const eventStore = new MemoryEventStore();
+    eventStore.append("requested-thread", { kind: "session-status", status: "idle", seq: 1 });
     await expect(CodexAppServerHost.adopt("requested-thread", {
       cwd: "/repo",
-      eventStore: new MemoryEventStore(),
+      eventStore,
+      initialEventCursor: 1,
       spawnProcess: fakeSpawn(server),
     })).rejects.toThrow("thread/resume returned a different thread id");
     expect(server.signals).toContain("SIGTERM");
+    expect(eventStore.load("requested-thread")).toEqual([
+      { kind: "session-status", status: "idle", seq: 1 },
+    ]);
   });
 
   test("rebuilds replay from resume history when a legacy host has no event ledger", async () => {
@@ -620,6 +626,60 @@ describe("CodexAppServerHost", () => {
     await host.answer(attentionId, { decision: "accept" });
     expect(server.requests.at(-1)).toMatchObject({ id: "live-approval", result: { decision: "accept" } });
     await host.release();
+  });
+
+  test.each([2906, 2908])("anchors pre-restore notifications after durable sequence 2907 when the registry cursor is %i", async (registryCursor) => {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-codex-cursor-recovery-"));
+    const threadId = `cursor-recovery-${registryCursor}`;
+    const ledgerPath = path.join(directory, `${encodeURIComponent(threadId)}.jsonl`);
+    const durableEvents = Array.from({ length: 2_907 }, (_, index) => JSON.stringify({
+      kind: "session-status",
+      status: "idle",
+      seq: index + 1,
+    })).join("\n");
+    fs.writeFileSync(ledgerPath, `${durableEvents}\n`, { mode: 0o600 });
+    const eventStore = new FileRuntimeEventStore(directory);
+    const diagnostics: unknown[] = [];
+    const server = new FakeAppServer(threadId, threadId, false, [], { type: "idle" }, {
+      id: "approval-before-restore",
+      method: "item/commandExecution/requestApproval",
+      params: { command: "date" },
+    });
+
+    const host = await CodexAppServerHost.adopt(threadId, {
+      cwd: "/repo",
+      eventStore,
+      initialEventCursor: registryCursor,
+      onEventCursorRecovery: (diagnostic) => diagnostics.push(diagnostic),
+      spawnProcess: fakeSpawn(server),
+    });
+
+    expect(eventStore.load(threadId).slice(-3)).toEqual([
+      { kind: "session-status", status: "idle", seq: 2_907 },
+      {
+        kind: "attention",
+        id: "item/commandExecution/requestApproval:approval-before-restore",
+        method: "item/commandExecution/requestApproval",
+        attention: { command: "date" },
+        seq: 2_908,
+      },
+      { kind: "session-status", status: "idle", seq: 2_909 },
+    ]);
+    expect(await host.health()).toMatchObject({
+      status: "attention",
+      eventCursor: 2_909,
+      pendingAttention: ["item/commandExecution/requestApproval:approval-before-restore"],
+    });
+    expect(diagnostics).toEqual([expect.objectContaining({
+      kind: "runtime-event-cursor-recovery",
+      sessionId: threadId,
+      durableTailSeq: 2_907,
+      registryCursor,
+      chosenNextSeq: 2_908,
+      action: "use-durable-tail",
+    })]);
+    await host.release();
+    fs.rmSync(directory, { recursive: true, force: true });
   });
 
   test("parses generated-schema thread status notifications", async () => {
@@ -1201,6 +1261,12 @@ describe("CodexAppServerHost", () => {
     const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-structured-claim-"));
     const registry = new AgentRegistry(path.join(directory, "agent-registry.json"));
     const key = { engine: "codex" as const, sessionId: "claimed-thread" };
+    const eventStore = new FileRuntimeEventStore(path.join(directory, "events"));
+    fs.mkdirSync(path.join(directory, "events"), { recursive: true });
+    fs.writeFileSync(path.join(directory, "events", "claimed-thread.jsonl"), `${Array.from(
+      { length: 2_907 },
+      (_, index) => JSON.stringify({ kind: "session-status", status: "idle", seq: index + 1 }),
+    ).join("\n")}\n`, { mode: 0o600 });
     registry.upsert({
       key,
       artifactPath: "/sessions/claimed-thread.jsonl",
@@ -1212,7 +1278,7 @@ describe("CodexAppServerHost", () => {
         kind: "codex-app-server",
         endpoint: "stdio:old",
         process: null,
-        eventCursor: 2,
+        eventCursor: 2_908,
         protocolVersion: "0.144.1",
         writerClaimEpoch: 8,
         activeTurnRef: null,
@@ -1227,18 +1293,33 @@ describe("CodexAppServerHost", () => {
     const adopt = () => adoptCodexRegistryHosts(
       registry,
       () => {
-        const server = new FakeAppServer("claimed-thread");
+        const server = new FakeAppServer("claimed-thread", "claimed-thread", false, [], { type: "idle" }, {
+          id: "concurrent-approval",
+          method: "item/commandExecution/requestApproval",
+          params: { command: "date" },
+        });
         servers.push(server);
-        return { cwd: "/repo", eventStore: new MemoryEventStore(), spawnProcess: fakeSpawn(server) };
+        return {
+          cwd: "/repo",
+          eventStore,
+          onEventCursorRecovery: () => {},
+          spawnProcess: fakeSpawn(server),
+        };
       },
       { NODE_ENV: "test", LLV_STRUCTURED_HOSTS: "1" },
     );
     const [first, second] = await Promise.all([adopt(), adopt()]);
     expect(first.length + second.length).toBe(1);
     expect(servers).toHaveLength(1);
+    expect(await adopt()).toEqual([]);
+    expect(servers).toHaveLength(1);
     expect(registry.snapshot().entries["codex:claimed-thread"]).toMatchObject({
       claimEpoch: 9,
-      structuredHost: { writerClaimEpoch: 9 },
+      structuredHost: {
+        writerClaimEpoch: 9,
+        eventCursor: 2_909,
+        pendingAttention: ["item/commandExecution/requestApproval:concurrent-approval"],
+      },
     });
     await [...first, ...second][0]!.host.release();
   });

--- a/src/lib/runtime/codexAppServerHost.test.ts
+++ b/src/lib/runtime/codexAppServerHost.test.ts
@@ -744,6 +744,100 @@ describe("CodexAppServerHost", () => {
     await replacement.release();
   });
 
+  test("a buffered completion keeps a stale active resume snapshot terminal", async () => {
+    const threadId = "buffered-terminal-stale-active-snapshot";
+    const turnId = "turn-completed-during-resume";
+    const eventStore = new MemoryEventStore();
+    const server = new FakeAppServer(threadId, threadId, false, [{
+      id: turnId,
+      status: "inProgress",
+      items: [],
+    }], { type: "active", activeFlags: ["running"] }, {
+      method: "turn/completed",
+      params: { threadId, turn: { id: turnId, status: "completed" } },
+    });
+
+    const host = await CodexAppServerHost.adopt(threadId, {
+      cwd: "/repo",
+      eventStore,
+      spawnProcess: fakeSpawn(server),
+    });
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-stale-resume-registry-"));
+    const registry = new AgentRegistry(path.join(directory, "agent-registry.json"));
+    const key = { engine: "codex" as const, sessionId: threadId };
+    registry.upsert({
+      key,
+      artifactPath: `/sessions/${threadId}.jsonl`,
+      cwd: "/repo",
+      accountId: null,
+      status: "dead",
+      host: null,
+      structuredHost: {
+        kind: "codex-app-server",
+        endpoint: "stdio:released",
+        process: null,
+        eventCursor: 0,
+        protocolVersion: null,
+        writerClaimEpoch: 7,
+        activeTurnRef: null,
+        pendingAttention: [],
+        activeFlags: [],
+      },
+      claimEpoch: 7,
+      claimOwner: "viewer",
+      pendingAction: null,
+    });
+    const stopPersistence = await bindCodexHostPersistence(registry, key, host, "viewer", 7);
+
+    expect(eventStore.load(threadId)).toEqual([
+      { kind: "turn-started", turnId, seq: 1 },
+      { kind: "turn-ended", turnId, status: "completed", seq: 2 },
+      { kind: "session-status", status: "idle", seq: 3 },
+    ]);
+    expect(await host.health()).toMatchObject({ status: "idle", activeTurnRef: null });
+    expect(registry.snapshot().entries[`codex:${threadId}`]).toMatchObject({
+      status: "idle",
+      structuredHost: { eventCursor: 3, activeTurnRef: null },
+    });
+
+    stopPersistence();
+    await host.release();
+    fs.rmSync(directory, { recursive: true, force: true });
+  });
+
+  test("a newer buffered turn survives the stale snapshot of its completed predecessor", async () => {
+    const threadId = "buffered-successor-after-stale-snapshot";
+    const completedTurnId = "turn-stale-snapshot";
+    const activeTurnId = "turn-started-during-resume";
+    const eventStore = new MemoryEventStore();
+    const server = new FakeAppServer(threadId, threadId, false, [{
+      id: completedTurnId,
+      status: "inProgress",
+      items: [],
+    }], { type: "active", activeFlags: ["running"] }, [
+      {
+        method: "turn/completed",
+        params: { threadId, turn: { id: completedTurnId, status: "completed" } },
+      },
+      { method: "turn/started", params: { threadId, turn: { id: activeTurnId } } },
+    ]);
+
+    const host = await CodexAppServerHost.adopt(threadId, {
+      cwd: "/repo",
+      eventStore,
+      spawnProcess: fakeSpawn(server),
+    });
+
+    expect(eventStore.load(threadId)).toEqual([
+      { kind: "turn-started", turnId: completedTurnId, seq: 1 },
+      { kind: "turn-ended", turnId: completedTurnId, status: "completed", seq: 2 },
+      { kind: "turn-started", turnId: activeTurnId, seq: 3 },
+      { kind: "session-status", status: "active", activeFlags: ["running"], seq: 4 },
+    ]);
+    expect(await host.health()).toMatchObject({ status: "active", activeTurnRef: activeTurnId });
+    await host.release();
+  });
+
   test("deduplicates a buffered lifecycle overlap against the durable crash prefix", async () => {
     const threadId = "019f66b5-8694-7410-8671-fbec75484a86-overlap";
     const turnId = "turn-overlapping-942";

--- a/src/lib/runtime/codexAppServerHost.ts
+++ b/src/lib/runtime/codexAppServerHost.ts
@@ -14,9 +14,10 @@ import type {
   QueueEntry,
   RuntimeEvent,
 } from "./engineHost";
-import { RuntimeReplayGapError } from "./engineHost";
+import { RuntimeReplayGapError, StructuredHostAdoptionCleanupError } from "./engineHost";
 import {
   FileRuntimeEventStore,
+  nextRuntimeEventSequence,
   reconcileRuntimeEventCursor,
   type RuntimeEventCursorRecoveryReporter,
   type RuntimeEventStore,
@@ -200,6 +201,14 @@ function itemReplayKey(value: unknown): string {
   return `json:${JSON.stringify(value)}`;
 }
 
+function bufferedNotificationReplayKey(event: UnsequencedEvent | RuntimeEvent): string | null {
+  if (event.kind === "delta") return JSON.stringify([event.kind, event.turnId, event.text]);
+  if (event.kind === "attention") {
+    return JSON.stringify([event.kind, event.id, event.method, event.attention]);
+  }
+  return null;
+}
+
 function userMessageText(value: JsonObject): string | null {
   const direct = stringField(value, "text");
   if (direct !== null) return direct;
@@ -250,6 +259,7 @@ export class CodexAppServerHost implements EngineHost {
   private readonly stateListeners = new Set<(state: HostState) => void>();
   private readonly preRestoreEvents: UnsequencedEvent[] = [];
   private readonly preRestoreMessages: Array<{ message: JsonObject; bytes: number }> = [];
+  private bufferedNotificationOverlap: string[] = [];
   private nextRpcId = 1;
   private stdoutBuffer = "";
   private preRestoreBytes = 0;
@@ -293,7 +303,9 @@ export class CodexAppServerHost implements EngineHost {
     child.on("close", () => {
       this.reaped = true;
       this.resolveReaped();
-      if (!this.releasing && !this.released) {
+      if (this.releasing) {
+        this.finishRelease();
+      } else if (!this.released) {
         if (this.dead) this.notifyStateListeners();
         else this.fail(new Error("Codex app-server child exited"));
       }
@@ -357,13 +369,19 @@ export class CodexAppServerHost implements EngineHost {
       provisional.identity.path = identity.path;
       provisional.rememberConfirmedDeliveries(result);
       provisional.restoreEvents();
-      if (threadId) provisional.reconcileThreadHistory(result);
+      provisional.beginBufferedNotificationReconciliation();
       provisional.flushPreRestoreEvents();
-      provisional.flushPreRestoreMessages();
+      provisional.flushPreRestoreMessages(threadId ? result : null);
+      if (threadId) provisional.reconcileThreadHistory(result);
+      provisional.endBufferedNotificationReconciliation();
       provisional.reconcileAfterOpen(threadStatus(result), resumedActiveTurnId(result));
       return provisional;
     } catch (error) {
-      await provisional.release();
+      try {
+        await provisional.release();
+      } catch (cleanupError) {
+        throw new StructuredHostAdoptionCleanupError(safeError(error), provisional, { cause: cleanupError });
+      }
       throw new Error(safeError(error));
     }
   }
@@ -515,7 +533,14 @@ export class CodexAppServerHost implements EngineHost {
   }
 
   async release(): Promise<void> {
-    this.releasePromise ??= this.releaseAndReap();
+    if (this.released) return;
+    if (!this.releasePromise) {
+      const attempt = this.releaseAndReap();
+      this.releasePromise = attempt;
+      void attempt.catch(() => {
+        if (this.releasePromise === attempt) this.releasePromise = null;
+      });
+    }
     return this.releasePromise;
   }
 
@@ -536,12 +561,17 @@ export class CodexAppServerHost implements EngineHost {
         throw new Error("Codex app-server child could not be reaped");
       }
     }
+    this.finishRelease();
+  }
+
+  private finishRelease(): void {
+    if (this.released) return;
     this.released = true;
     this.releasing = false;
     this.activeTurnId = null;
     this.attentions.clear();
     this.setSessionStatus("unhosted", []);
-    if (this.ledgerFailed) this.notifyStateListeners();
+    if (this.ledgerFailed || !this.eventLedgerRestored) this.notifyStateListeners();
     this.closeSubscribers();
   }
 
@@ -582,7 +612,16 @@ export class CodexAppServerHost implements EngineHost {
       this.preRestoreEvents.push(event);
       return;
     }
-    const sequenced = { ...event, seq: ++this.cursor } as RuntimeEvent;
+    let nextCursor: number;
+    try {
+      nextCursor = nextRuntimeEventSequence(this.cursor);
+    } catch (error) {
+      this.ledgerFailed = true;
+      this.failWithoutLedger(new Error(safeError(error)));
+      return;
+    }
+    this.cursor = nextCursor;
+    const sequenced = { ...event, seq: nextCursor } as RuntimeEvent;
     try {
       this.eventStore.append(this.identity.threadId, sequenced);
     } catch (error) {
@@ -655,41 +694,43 @@ export class CodexAppServerHost implements EngineHost {
   }
 
   private reconcileThreadHistory(result: unknown): void {
-    for (const turn of resumedTurns(result)) {
-      const turnId = stringField(turn, "id");
-      if (!turnId) continue;
-      const turnEvents = this.events.filter((event) => "turnId" in event && event.turnId === turnId);
-      const status = stringField(turn, "status");
-      const hasStarted = turnEvents.some((event) => event.kind === "turn-started");
-      if (!hasStarted || (status === "inProgress" && this.activeTurnId !== turnId)) {
-        this.activeTurnId = turnId;
-        this.emit({ kind: "turn-started", turnId });
-      }
-      const completedItems = new Map<string, number>();
-      for (const event of turnEvents) {
-        if (event.kind !== "item" || event.phase !== "completed") continue;
-        const key = itemReplayKey(event.item);
-        completedItems.set(key, (completedItems.get(key) ?? 0) + 1);
-      }
-      if (Array.isArray(turn.items)) {
-        for (const item of turn.items) {
-          const key = itemReplayKey(item);
-          const recorded = completedItems.get(key) ?? 0;
-          if (recorded > 0) {
-            completedItems.set(key, recorded - 1);
-            continue;
-          }
-          this.emit({ kind: "item", turnId, item, phase: "completed" });
+    for (const turn of resumedTurns(result)) this.reconcileTurnHistory(turn);
+  }
+
+  private reconcileTurnHistory(turn: JsonObject): void {
+    const turnId = stringField(turn, "id");
+    if (!turnId) return;
+    const turnEvents = this.events.filter((event) => "turnId" in event && event.turnId === turnId);
+    const status = stringField(turn, "status");
+    const hasStarted = turnEvents.some((event) => event.kind === "turn-started");
+    if (!hasStarted || (status === "inProgress" && this.activeTurnId !== turnId)) {
+      this.activeTurnId = turnId;
+      this.emit({ kind: "turn-started", turnId });
+    }
+    const completedItems = new Map<string, number>();
+    for (const event of turnEvents) {
+      if (event.kind !== "item" || event.phase !== "completed") continue;
+      const key = itemReplayKey(event.item);
+      completedItems.set(key, (completedItems.get(key) ?? 0) + 1);
+    }
+    if (Array.isArray(turn.items)) {
+      for (const item of turn.items) {
+        const key = itemReplayKey(item);
+        const recorded = completedItems.get(key) ?? 0;
+        if (recorded > 0) {
+          completedItems.set(key, recorded - 1);
+          continue;
         }
+        this.emit({ kind: "item", turnId, item, phase: "completed" });
       }
-      if (status === "completed" || status === "interrupted" || status === "failed" || status === "error") {
-        const authoritativeStatus = terminalStatus(status);
-        const recordedTerminal = turnEvents.findLast((event) => event.kind === "turn-ended");
-        if (recordedTerminal?.kind !== "turn-ended" || recordedTerminal.status !== authoritativeStatus) {
-          this.emit({ kind: "turn-ended", turnId, status: authoritativeStatus });
-        }
-        if (this.activeTurnId === turnId) this.activeTurnId = null;
+    }
+    if (status === "completed" || status === "interrupted" || status === "failed" || status === "error") {
+      const authoritativeStatus = terminalStatus(status);
+      const recordedTerminal = turnEvents.findLast((event) => event.kind === "turn-ended");
+      if (recordedTerminal?.kind !== "turn-ended" || recordedTerminal.status !== authoritativeStatus) {
+        this.emit({ kind: "turn-ended", turnId, status: authoritativeStatus });
       }
+      if (this.activeTurnId === turnId) this.activeTurnId = null;
     }
   }
 
@@ -786,10 +827,82 @@ export class CodexAppServerHost implements EngineHost {
     for (const event of this.preRestoreEvents.splice(0)) this.emit(event);
   }
 
-  private flushPreRestoreMessages(): void {
+  private beginBufferedNotificationReconciliation(): void {
+    const durableKeys: string[] = [];
+    for (const event of this.events) {
+      if (event.kind === "attention" && !this.attentions.has(event.id)) continue;
+      const key = bufferedNotificationReplayKey(event);
+      if (key) durableKeys.push(key);
+    }
+    const bufferedKeys: string[] = [];
+    let activeTurnId = this.activeTurnId;
+    for (const { message } of this.preRestoreMessages) {
+      const method = typeof message.method === "string" ? message.method : null;
+      if (!method) continue;
+      const params = record(message.params) ?? {};
+      const id = message.id;
+      if (typeof id === "number" || typeof id === "string") {
+        const key = bufferedNotificationReplayKey({
+          kind: "attention",
+          id: `${method}:${String(id)}`,
+          method,
+          attention: params,
+        });
+        if (key) bufferedKeys.push(key);
+        continue;
+      }
+      const turnId = turnIdFromParams(params);
+      if (method === "turn/started" && turnId) activeTurnId = turnId;
+      if (method === "item/agentMessage/delta") {
+        const key = bufferedNotificationReplayKey({
+          kind: "delta",
+          turnId: turnId ?? activeTurnId ?? "unknown",
+          text: stringField(params, "delta") ?? "",
+        });
+        if (key) bufferedKeys.push(key);
+      }
+      if (method === "turn/completed" && turnId === activeTurnId) activeTurnId = null;
+    }
+    const maximum = Math.min(durableKeys.length, bufferedKeys.length);
+    let overlap = 0;
+    for (let length = maximum; length > 0; length -= 1) {
+      const durableStart = durableKeys.length - length;
+      if (bufferedKeys.slice(0, length).every((key, index) => key === durableKeys[durableStart + index])) {
+        overlap = length;
+        break;
+      }
+    }
+    this.bufferedNotificationOverlap = bufferedKeys.slice(0, overlap);
+  }
+
+  private consumeBufferedNotification(event: UnsequencedEvent): boolean {
+    const key = bufferedNotificationReplayKey(event);
+    if (!key || this.bufferedNotificationOverlap[0] !== key) {
+      this.bufferedNotificationOverlap = [];
+      return false;
+    }
+    this.bufferedNotificationOverlap.shift();
+    return true;
+  }
+
+  private endBufferedNotificationReconciliation(): void {
+    this.bufferedNotificationOverlap = [];
+  }
+
+  private flushPreRestoreMessages(resumeResult: unknown | null): void {
+    const turns = new Map(resumedTurns(resumeResult).flatMap((turn) => {
+      const turnId = stringField(turn, "id");
+      return turnId ? [[turnId, turn] as const] : [];
+    }));
     for (const { message, bytes } of this.preRestoreMessages.splice(0)) {
       this.preRestoreBytes -= bytes;
-      this.acceptParsedMessage(message);
+      if (message.method === "turn/completed") {
+        const params = record(message.params) ?? {};
+        const turnId = turnIdFromParams(params);
+        const turn = turnId ? turns.get(turnId) : null;
+        if (turn) this.reconcileTurnHistory(turn);
+      }
+      this.acceptParsedMessage(message, true);
       if (this.dead || this.releasing || this.released) break;
     }
     this.preRestoreBytes = 0;
@@ -911,7 +1024,7 @@ export class CodexAppServerHost implements EngineHost {
     this.acceptParsedMessage(message);
   }
 
-  private acceptParsedMessage(message: JsonObject): void {
+  private acceptParsedMessage(message: JsonObject, reconcileBufferedLifecycle = false): void {
     const id = message.id;
     const method = typeof message.method === "string" ? message.method : null;
     if ((typeof id === "number" || typeof id === "string") && !method) {
@@ -931,13 +1044,14 @@ export class CodexAppServerHost implements EngineHost {
     if (typeof id === "number" || typeof id === "string") {
       const attentionId = `${method}:${String(id)}`;
       this.attentions.set(attentionId, { rpcId: id, method, origin: "current" });
-      this.emit({ kind: "attention", id: attentionId, method, attention: params });
+      const event = { kind: "attention" as const, id: attentionId, method, attention: params };
+      if (!reconcileBufferedLifecycle || !this.consumeBufferedNotification(event)) this.emit(event);
       return;
     }
-    this.acceptNotification(method, params);
+    this.acceptNotification(method, params, reconcileBufferedLifecycle);
   }
 
-  private acceptNotification(method: string, params: JsonObject): void {
+  private acceptNotification(method: string, params: JsonObject, reconcileBufferedLifecycle = false): void {
     const turnId = turnIdFromParams(params);
     if (method === "serverRequest/resolved") {
       const requestId = params.requestId;
@@ -955,23 +1069,57 @@ export class CodexAppServerHost implements EngineHost {
       return;
     }
     if (method === "turn/started" && turnId) {
+      if (reconcileBufferedLifecycle) {
+        const historicalStart = this.events.some((event) => event.kind === "turn-started" && event.turnId === turnId);
+        const historicalTerminal = this.events.some((event) => event.kind === "turn-ended" && event.turnId === turnId);
+        if (historicalStart && (historicalTerminal || this.activeTurnId !== null)) return;
+      }
       this.activeTurnId = turnId;
       this.emit({ kind: "turn-started", turnId });
       return;
     }
     if (method === "item/agentMessage/delta") {
-      this.emit({ kind: "delta", turnId: turnId ?? this.activeTurnId ?? "unknown", text: stringField(params, "delta") ?? "" });
+      const event = {
+        kind: "delta" as const,
+        turnId: turnId ?? this.activeTurnId ?? "unknown",
+        text: stringField(params, "delta") ?? "",
+      };
+      if (!reconcileBufferedLifecycle || !this.consumeBufferedNotification(event)) this.emit(event);
       return;
     }
     if ((method === "item/started" || method === "item/completed") && "item" in params) {
       if (method === "item/completed" && turnId) this.rememberConfirmedDelivery(turnId, params.item);
-      this.emit({ kind: "item", turnId: turnId ?? this.activeTurnId, item: params.item, phase: method === "item/started" ? "started" : "completed" });
+      const eventTurnId = turnId ?? this.activeTurnId;
+      const phase = method === "item/started" ? "started" : "completed";
+      if (reconcileBufferedLifecycle && eventTurnId) {
+        const terminal = this.events.some((event) => event.kind === "turn-ended" && event.turnId === eventTurnId);
+        if (terminal) return;
+        const replayKey = itemReplayKey(params.item);
+        const duplicate = this.events.some((event) => event.kind === "item"
+          && event.turnId === eventTurnId
+          && event.phase === phase
+          && itemReplayKey(event.item) === replayKey);
+        if (duplicate) return;
+        const started = this.events.some((event) => event.kind === "turn-started" && event.turnId === eventTurnId);
+        if (!started) {
+          this.activeTurnId = eventTurnId;
+          this.emit({ kind: "turn-started", turnId: eventTurnId });
+        }
+      }
+      this.emit({ kind: "item", turnId: eventTurnId, item: params.item, phase });
       return;
     }
     if (method === "turn/completed" && turnId) {
-      this.activeTurnId = null;
       const turn = record(params.turn);
-      this.emit({ kind: "turn-ended", turnId, status: terminalStatus(turn?.status) });
+      const status = terminalStatus(turn?.status);
+      if (reconcileBufferedLifecycle
+        && this.events.some((event) => event.kind === "turn-ended" && event.turnId === turnId)) return;
+      if (this.activeTurnId === turnId) this.activeTurnId = null;
+      if (reconcileBufferedLifecycle
+        && !this.events.some((event) => event.kind === "turn-started" && event.turnId === turnId)) {
+        this.emit({ kind: "turn-started", turnId });
+      }
+      this.emit({ kind: "turn-ended", turnId, status });
       return;
     }
     if (method === "account/rateLimits/updated") {

--- a/src/lib/runtime/codexAppServerHost.ts
+++ b/src/lib/runtime/codexAppServerHost.ts
@@ -259,6 +259,7 @@ export class CodexAppServerHost implements EngineHost {
   private readonly stateListeners = new Set<(state: HostState) => void>();
   private readonly preRestoreEvents: UnsequencedEvent[] = [];
   private readonly preRestoreMessages: Array<{ message: JsonObject; bytes: number }> = [];
+  private readonly bufferedTerminalTurnIds = new Set<string>();
   private bufferedNotificationOverlap: string[] = [];
   private nextRpcId = 1;
   private stdoutBuffer = "";
@@ -373,8 +374,8 @@ export class CodexAppServerHost implements EngineHost {
       provisional.flushPreRestoreEvents();
       provisional.flushPreRestoreMessages(threadId ? result : null);
       if (threadId) provisional.reconcileThreadHistory(result);
-      provisional.endBufferedNotificationReconciliation();
       provisional.reconcileAfterOpen(threadStatus(result), resumedActiveTurnId(result));
+      provisional.endBufferedNotificationReconciliation();
       return provisional;
     } catch (error) {
       try {
@@ -675,7 +676,9 @@ export class CodexAppServerHost implements EngineHost {
     if (resumedStatus.type === "active" && !resumedTurnId) {
       throw new Error("thread/resume returned active status without an active turn id");
     }
-    if (resumedStatus.type === "active" && resumedTurnId && this.activeTurnId !== resumedTurnId) {
+    const resumedTurnTerminalized = resumedTurnId !== null && this.bufferedTerminalTurnIds.has(resumedTurnId);
+    if (resumedStatus.type === "active" && resumedTurnId && !resumedTurnTerminalized
+      && this.activeTurnId !== resumedTurnId) {
       if (this.activeTurnId) this.emit({ kind: "turn-ended", turnId: this.activeTurnId, status: "error" });
       this.activeTurnId = resumedTurnId;
       this.emit({ kind: "turn-started", turnId: resumedTurnId });
@@ -690,7 +693,9 @@ export class CodexAppServerHost implements EngineHost {
       this.attentions.delete(attentionId);
       this.emit({ kind: "attention-resolved", id: attentionId, resolution: "host-restarted" });
     }
-    this.emitThreadStatus(resumedStatus);
+    this.emitThreadStatus(resumedTurnTerminalized && !this.activeTurnId
+      ? { type: "idle", activeFlags: [] }
+      : resumedStatus);
   }
 
   private reconcileThreadHistory(result: unknown): void {
@@ -703,7 +708,8 @@ export class CodexAppServerHost implements EngineHost {
     const turnEvents = this.events.filter((event) => "turnId" in event && event.turnId === turnId);
     const status = stringField(turn, "status");
     const hasStarted = turnEvents.some((event) => event.kind === "turn-started");
-    if (!hasStarted || (status === "inProgress" && this.activeTurnId !== turnId)) {
+    if (!this.bufferedTerminalTurnIds.has(turnId)
+      && (!hasStarted || (status === "inProgress" && this.activeTurnId !== turnId))) {
       this.activeTurnId = turnId;
       this.emit({ kind: "turn-started", turnId });
     }
@@ -828,6 +834,7 @@ export class CodexAppServerHost implements EngineHost {
   }
 
   private beginBufferedNotificationReconciliation(): void {
+    this.bufferedTerminalTurnIds.clear();
     const durableKeys: string[] = [];
     for (const event of this.events) {
       if (event.kind === "attention" && !this.attentions.has(event.id)) continue;
@@ -887,6 +894,7 @@ export class CodexAppServerHost implements EngineHost {
 
   private endBufferedNotificationReconciliation(): void {
     this.bufferedNotificationOverlap = [];
+    this.bufferedTerminalTurnIds.clear();
   }
 
   private flushPreRestoreMessages(resumeResult: unknown | null): void {
@@ -1112,6 +1120,7 @@ export class CodexAppServerHost implements EngineHost {
     if (method === "turn/completed" && turnId) {
       const turn = record(params.turn);
       const status = terminalStatus(turn?.status);
+      if (reconcileBufferedLifecycle) this.bufferedTerminalTurnIds.add(turnId);
       if (reconcileBufferedLifecycle
         && this.events.some((event) => event.kind === "turn-ended" && event.turnId === turnId)) return;
       if (this.activeTurnId === turnId) this.activeTurnId = null;

--- a/src/lib/runtime/codexAppServerHost.ts
+++ b/src/lib/runtime/codexAppServerHost.ts
@@ -15,7 +15,12 @@ import type {
   RuntimeEvent,
 } from "./engineHost";
 import { RuntimeReplayGapError } from "./engineHost";
-import { FileRuntimeEventStore, type RuntimeEventStore } from "./eventStore";
+import {
+  FileRuntimeEventStore,
+  reconcileRuntimeEventCursor,
+  type RuntimeEventCursorRecoveryReporter,
+  type RuntimeEventStore,
+} from "./eventStore";
 
 type JsonObject = Record<string, unknown>;
 type PendingRpc = {
@@ -70,6 +75,7 @@ export interface CodexAppServerHostOptions {
   requestTimeoutMs?: number;
   shutdownGraceMs?: number;
   initialEventCursor?: number;
+  onEventCursorRecovery?: RuntimeEventCursorRecoveryReporter;
   spawnProcess?: (command: string, args: string[], options: SpawnOptionsWithoutStdio) => ChildProcessWithoutNullStreams;
   eventStore?: RuntimeEventStore;
   signalProcess?: ProcessSignal;
@@ -112,6 +118,8 @@ const MIN_LATE_THREAD_READ_RESPONSE_TTL_MS = 1_000;
 const MAX_LATE_THREAD_READ_RESPONSES = 32;
 const DEFAULT_SHUTDOWN_GRACE_MS = 1_000;
 const MAX_LINE_BYTES = 4 * 1024 * 1024;
+const MAX_PRE_RESTORE_FRAMES = 256;
+const MAX_PRE_RESTORE_BYTES = 4 * 1024 * 1024;
 const MUTATING_RPC_METHODS = new Set(["thread/start", "thread/resume", "turn/start", "turn/steer", "turn/interrupt"]);
 
 function record(value: unknown): JsonObject | null {
@@ -231,6 +239,7 @@ export class CodexAppServerHost implements EngineHost {
   private readonly eventStore: RuntimeEventStore;
   private readonly effort: string | undefined;
   private readonly signalProcess: ProcessSignal;
+  private readonly onEventCursorRecovery: RuntimeEventCursorRecoveryReporter | undefined;
   private readonly pending = new Map<number, PendingRpc>();
   private readonly lateThreadReadResponses = new Map<number, number>();
   private readonly subscribers = new Set<Subscriber>();
@@ -239,9 +248,12 @@ export class CodexAppServerHost implements EngineHost {
   private readonly pendingDeliveries = new Map<string, PendingDelivery>();
   private readonly attentions = new Map<string, PendingAttention>();
   private readonly stateListeners = new Set<(state: HostState) => void>();
-  private readonly preIdentityEvents: UnsequencedEvent[] = [];
+  private readonly preRestoreEvents: UnsequencedEvent[] = [];
+  private readonly preRestoreMessages: Array<{ message: JsonObject; bytes: number }> = [];
   private nextRpcId = 1;
   private stdoutBuffer = "";
+  private preRestoreBytes = 0;
+  private eventLedgerRestored = false;
   private cursor: number;
   private activeTurnId: string | null = null;
   private protocolVersion: string | null = null;
@@ -269,6 +281,7 @@ export class CodexAppServerHost implements EngineHost {
     this.eventStore = options.eventStore ?? new FileRuntimeEventStore();
     this.effort = options.effort;
     this.signalProcess = options.signalProcess ?? process.kill;
+    this.onEventCursorRecovery = options.onEventCursorRecovery;
     this.cursor = options.initialEventCursor ?? 0;
     this.reapedPromise = new Promise((resolve) => { this.resolveReaped = resolve; });
     child.stdout.on("data", (chunk: Buffer | string) => this.acceptStdout(String(chunk)));
@@ -345,7 +358,8 @@ export class CodexAppServerHost implements EngineHost {
       provisional.rememberConfirmedDeliveries(result);
       provisional.restoreEvents();
       if (threadId) provisional.reconcileThreadHistory(result);
-      provisional.flushPreIdentityEvents();
+      provisional.flushPreRestoreEvents();
+      provisional.flushPreRestoreMessages();
       provisional.reconcileAfterOpen(threadStatus(result), resumedActiveTurnId(result));
       return provisional;
     } catch (error) {
@@ -559,8 +573,13 @@ export class CodexAppServerHost implements EngineHost {
 
   private emit(event: UnsequencedEvent): void {
     if (this.ledgerFailed) return;
-    if (this.identity.threadId === "pending") {
-      this.preIdentityEvents.push(event);
+    if (!this.eventLedgerRestored) {
+      if (this.preRestoreEvents.length + this.preRestoreMessages.length >= MAX_PRE_RESTORE_FRAMES) {
+        this.ledgerFailed = true;
+        this.failWithoutLedger(new Error("Codex app-server pre-restore event buffer exceeded its bounded capacity"));
+        return;
+      }
+      this.preRestoreEvents.push(event);
       return;
     }
     const sequenced = { ...event, seq: ++this.cursor } as RuntimeEvent;
@@ -585,7 +604,12 @@ export class CodexAppServerHost implements EngineHost {
     const currentAttentions = new Map([...this.attentions].filter(([, attention]) => attention.origin === "current"));
     this.attentions.clear();
     this.events.splice(0, this.events.length, ...stored);
-    this.cursor = Math.max(this.cursor, stored.at(-1)?.seq ?? 0);
+    this.cursor = reconcileRuntimeEventCursor(
+      this.identity.threadId,
+      stored.at(-1)?.seq ?? 0,
+      this.cursor,
+      this.onEventCursorRecovery,
+    );
     for (const event of stored) {
       if (event.kind === "turn-started") this.activeTurnId = event.turnId;
       if (event.kind === "turn-ended" && event.turnId === this.activeTurnId) this.activeTurnId = null;
@@ -603,6 +627,7 @@ export class CodexAppServerHost implements EngineHost {
       }
     }
     for (const [id, attention] of currentAttentions) this.attentions.set(id, attention);
+    this.eventLedgerRestored = true;
     return stored.length;
   }
 
@@ -757,8 +782,17 @@ export class CodexAppServerHost implements EngineHost {
     }
   }
 
-  private flushPreIdentityEvents(): void {
-    for (const event of this.preIdentityEvents.splice(0)) this.emit(event);
+  private flushPreRestoreEvents(): void {
+    for (const event of this.preRestoreEvents.splice(0)) this.emit(event);
+  }
+
+  private flushPreRestoreMessages(): void {
+    for (const { message, bytes } of this.preRestoreMessages.splice(0)) {
+      this.preRestoreBytes -= bytes;
+      this.acceptParsedMessage(message);
+      if (this.dead || this.releasing || this.released) break;
+    }
+    this.preRestoreBytes = 0;
   }
 
   private notifyStateListeners(): void {
@@ -863,6 +897,21 @@ export class CodexAppServerHost implements EngineHost {
       this.fail(new Error("Codex app-server emitted malformed JSON-RPC"));
       return;
     }
+    if (typeof message.method === "string" && !this.eventLedgerRestored) {
+      const bytes = Buffer.byteLength(line);
+      if (this.preRestoreEvents.length + this.preRestoreMessages.length >= MAX_PRE_RESTORE_FRAMES
+        || this.preRestoreBytes + bytes > MAX_PRE_RESTORE_BYTES) {
+        this.fail(new Error("Codex app-server pre-restore notification buffer exceeded its bounded capacity"));
+        return;
+      }
+      this.preRestoreMessages.push({ message, bytes });
+      this.preRestoreBytes += bytes;
+      return;
+    }
+    this.acceptParsedMessage(message);
+  }
+
+  private acceptParsedMessage(message: JsonObject): void {
     const id = message.id;
     const method = typeof message.method === "string" ? message.method : null;
     if ((typeof id === "number" || typeof id === "string") && !method) {

--- a/src/lib/runtime/engineHost.ts
+++ b/src/lib/runtime/engineHost.ts
@@ -51,3 +51,10 @@ export interface EngineHost {
   health(): Promise<HostState>;
   release(): Promise<void>;
 }
+
+export class StructuredHostAdoptionCleanupError<Host extends EngineHost = EngineHost> extends Error {
+  constructor(message: string, readonly host: Host, options?: ErrorOptions) {
+    super(message, options);
+    this.name = "StructuredHostAdoptionCleanupError";
+  }
+}

--- a/src/lib/runtime/eventStore.test.ts
+++ b/src/lib/runtime/eventStore.test.ts
@@ -3,7 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import { expect, test } from "bun:test";
 
-import { FileRuntimeEventStore } from "./eventStore";
+import { FileRuntimeEventStore, reconcileRuntimeEventCursor } from "./eventStore";
 
 test("runtime event store durably replays ordered events and ignores a partial tail", () => {
   const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-runtime-events-"));
@@ -20,6 +20,28 @@ test("runtime event store durably replays ordered events and ignores a partial t
     { kind: "turn-ended", turnId: "turn-1", status: "completed", seq: 3 },
   ]);
   expect(fs.statSync(filename).mode & 0o777).toBe(0o600);
+});
+
+test("runtime event store repairs a crash tail after a production-sized contiguous prefix", () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-runtime-crash-tail-"));
+  const filename = path.join(directory, "crash-tail.jsonl");
+  const prefix = Array.from({ length: 2_907 }, (_, index) => JSON.stringify({
+    kind: "session-status",
+    status: "idle",
+    seq: index + 1,
+  })).join("\n");
+  fs.writeFileSync(filename, `${prefix}\n{\"kind\":\"session-status\",\"status\":`, { mode: 0o600 });
+  const store = new FileRuntimeEventStore(directory);
+
+  store.append("crash-tail", { kind: "turn-started", turnId: "recovered-turn", seq: 2_908 });
+
+  const restored = store.load("crash-tail");
+  expect(restored).toHaveLength(2_908);
+  expect(restored.slice(-2)).toEqual([
+    { kind: "session-status", status: "idle", seq: 2_907 },
+    { kind: "turn-started", turnId: "recovered-turn", seq: 2_908 },
+  ]);
+  expect(fs.readFileSync(filename, "utf8").endsWith("\n")).toBeTrue();
 });
 
 test("runtime event store fails closed on gaps, duplicates, and malformed middle records", () => {
@@ -51,6 +73,60 @@ test("runtime event store rejects a non-contiguous append", () => {
   expect(() => store.append("append-thread", { kind: "turn-started", turnId: "turn-3", seq: 3 }))
     .toThrow("sequence gap after 1");
   expect(store.load("append-thread")).toEqual([{ kind: "session-status", status: "idle", seq: 1 }]);
+});
+
+test.each([2_906, 2_908])("runtime cursor recovery diagnoses registry cursor %i against durable tail 2907", (registryCursor) => {
+  const diagnostics: unknown[] = [];
+  const cursor = reconcileRuntimeEventCursor(
+    "019f64a8-cfee-7b20-9a5a-259f13192ed1",
+    2_907,
+    registryCursor,
+    (diagnostic) => diagnostics.push(diagnostic),
+  );
+
+  expect(cursor).toBe(2_907);
+  expect(diagnostics).toEqual([{
+    kind: "runtime-event-cursor-recovery",
+    sessionId: "019f64a8-cfee-7b20-9a5a-259f13192ed1",
+    durableTailSeq: 2_907,
+    registryCursor,
+    chosenNextSeq: 2_908,
+    action: "use-durable-tail",
+    relation: registryCursor < 2_907 ? "registry-behind" : "registry-ahead",
+  }]);
+});
+
+test("runtime cursor recovery retains an established registry watermark when the durable ledger is empty", () => {
+  const diagnostics: unknown[] = [];
+
+  expect(reconcileRuntimeEventCursor("legacy-session", 0, 12, (diagnostic) => diagnostics.push(diagnostic))).toBe(12);
+  expect(diagnostics).toEqual([expect.objectContaining({
+    sessionId: "legacy-session",
+    durableTailSeq: 0,
+    registryCursor: 12,
+    chosenNextSeq: 13,
+    action: "use-registry-cursor",
+    relation: "durable-ledger-empty",
+  })]);
+});
+
+test("runtime cursor diagnostics stay bounded and cannot fail ledger recovery", () => {
+  const diagnostics: Array<{ sessionId: string }> = [];
+  const cursor = reconcileRuntimeEventCursor("s".repeat(500), 2_907, 2_908, (value) => {
+    diagnostics.push(value);
+    throw new Error("diagnostic sink unavailable");
+  });
+
+  expect(cursor).toBe(2_907);
+  expect(diagnostics[0]?.sessionId).toHaveLength(160);
+});
+
+test.each([
+  { durableTailSeq: Number.MAX_SAFE_INTEGER, registryCursor: Number.MAX_SAFE_INTEGER },
+  { durableTailSeq: 0, registryCursor: Number.MAX_SAFE_INTEGER },
+])("runtime cursor recovery rejects an exhausted authoritative cursor", ({ durableTailSeq, registryCursor }) => {
+  expect(() => reconcileRuntimeEventCursor("exhausted-session", durableTailSeq, registryCursor))
+    .toThrow("runtime event cursor cannot advance safely");
 });
 
 test("runtime event store rejects every structurally invalid event variant", () => {

--- a/src/lib/runtime/eventStore.test.ts
+++ b/src/lib/runtime/eventStore.test.ts
@@ -3,6 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import { expect, test } from "bun:test";
 
+import type { RuntimeEvent } from "./engineHost";
 import { FileRuntimeEventStore, reconcileRuntimeEventCursor } from "./eventStore";
 
 test("runtime event store durably replays ordered events and ignores a partial tail", () => {
@@ -22,10 +23,10 @@ test("runtime event store durably replays ordered events and ignores a partial t
   expect(fs.statSync(filename).mode & 0o777).toBe(0o600);
 });
 
-test("runtime event store repairs a crash tail after a production-sized contiguous prefix", () => {
+test("runtime event store repairs a crash tail after the production 942-record contiguous prefix", () => {
   const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-runtime-crash-tail-"));
   const filename = path.join(directory, "crash-tail.jsonl");
-  const prefix = Array.from({ length: 2_907 }, (_, index) => JSON.stringify({
+  const prefix = Array.from({ length: 942 }, (_, index) => JSON.stringify({
     kind: "session-status",
     status: "idle",
     seq: index + 1,
@@ -33,13 +34,13 @@ test("runtime event store repairs a crash tail after a production-sized contiguo
   fs.writeFileSync(filename, `${prefix}\n{\"kind\":\"session-status\",\"status\":`, { mode: 0o600 });
   const store = new FileRuntimeEventStore(directory);
 
-  store.append("crash-tail", { kind: "turn-started", turnId: "recovered-turn", seq: 2_908 });
+  store.append("crash-tail", { kind: "turn-started", turnId: "recovered-turn", seq: 943 });
 
   const restored = store.load("crash-tail");
-  expect(restored).toHaveLength(2_908);
+  expect(restored).toHaveLength(943);
   expect(restored.slice(-2)).toEqual([
-    { kind: "session-status", status: "idle", seq: 2_907 },
-    { kind: "turn-started", turnId: "recovered-turn", seq: 2_908 },
+    { kind: "session-status", status: "idle", seq: 942 },
+    { kind: "turn-started", turnId: "recovered-turn", seq: 943 },
   ]);
   expect(fs.readFileSync(filename, "utf8").endsWith("\n")).toBeTrue();
 });
@@ -127,6 +128,22 @@ test.each([
 ])("runtime cursor recovery rejects an exhausted authoritative cursor", ({ durableTailSeq, registryCursor }) => {
   expect(() => reconcileRuntimeEventCursor("exhausted-session", durableTailSeq, registryCursor))
     .toThrow("runtime event cursor cannot advance safely");
+});
+
+test.each([Number.NaN, Number.POSITIVE_INFINITY, -1, 1.5, Number.MAX_SAFE_INTEGER + 1])(
+  "runtime cursor recovery rejects invalid registry cursor %p",
+  (registryCursor) => {
+    expect(() => reconcileRuntimeEventCursor("invalid-cursor", 0, registryCursor))
+      .toThrow("runtime event registry cursor is invalid");
+  },
+);
+
+test.each([1.5, Number.MAX_SAFE_INTEGER + 1])("runtime event store rejects unsafe append sequence %p", (seq) => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-runtime-event-unsafe-append-"));
+  const store = new FileRuntimeEventStore(directory);
+  expect(() => store.append("unsafe-append", { kind: "session-status", status: "idle", seq } as RuntimeEvent))
+    .toThrow("runtime event ledger append event is invalid");
+  expect(store.load("unsafe-append")).toEqual([]);
 });
 
 test("runtime event store rejects every structurally invalid event variant", () => {

--- a/src/lib/runtime/eventStore.ts
+++ b/src/lib/runtime/eventStore.ts
@@ -10,6 +10,59 @@ export interface RuntimeEventStore {
   append(threadId: string, event: RuntimeEvent): void;
 }
 
+export interface RuntimeEventCursorRecoveryDiagnostic {
+  kind: "runtime-event-cursor-recovery";
+  sessionId: string;
+  durableTailSeq: number;
+  registryCursor: number;
+  chosenNextSeq: number;
+  action: "use-durable-tail" | "use-registry-cursor";
+  relation: "registry-behind" | "registry-ahead" | "durable-ledger-empty";
+}
+
+export type RuntimeEventCursorRecoveryReporter = (diagnostic: RuntimeEventCursorRecoveryDiagnostic) => void;
+
+const MAX_DIAGNOSTIC_SESSION_ID_LENGTH = 160;
+
+function reportRuntimeEventCursorRecovery(diagnostic: RuntimeEventCursorRecoveryDiagnostic): void {
+  console.warn("[structured host] runtime event cursor recovered", diagnostic);
+}
+
+export function reconcileRuntimeEventCursor(
+  sessionId: string,
+  durableTailSeq: number,
+  registryCursor: number,
+  report: RuntimeEventCursorRecoveryReporter = reportRuntimeEventCursorRecovery,
+): number {
+  if (!Number.isSafeInteger(durableTailSeq) || durableTailSeq < 0) {
+    throw new Error("runtime event durable tail sequence is invalid");
+  }
+  if (!Number.isSafeInteger(registryCursor) || registryCursor < 0) {
+    throw new Error("runtime event registry cursor is invalid");
+  }
+  const useRegistryCursor = durableTailSeq === 0 && registryCursor > 0;
+  const cursor = useRegistryCursor ? registryCursor : durableTailSeq;
+  if (!Number.isSafeInteger(cursor + 1)) {
+    throw new Error("runtime event cursor cannot advance safely");
+  }
+  if (registryCursor !== durableTailSeq) {
+    try {
+      report({
+        kind: "runtime-event-cursor-recovery",
+        sessionId: sessionId.slice(0, MAX_DIAGNOSTIC_SESSION_ID_LENGTH),
+        durableTailSeq,
+        registryCursor,
+        chosenNextSeq: cursor + 1,
+        action: useRegistryCursor ? "use-registry-cursor" : "use-durable-tail",
+        relation: useRegistryCursor
+          ? "durable-ledger-empty"
+          : registryCursor < durableTailSeq ? "registry-behind" : "registry-ahead",
+      });
+    } catch { /* diagnostics never fence durable recovery */ }
+  }
+  return cursor;
+}
+
 function validEvent(value: unknown): value is RuntimeEvent {
   if (!value || typeof value !== "object" || Array.isArray(value)) return false;
   const event = value as Record<string, unknown>;

--- a/src/lib/runtime/eventStore.ts
+++ b/src/lib/runtime/eventStore.ts
@@ -28,6 +28,17 @@ function reportRuntimeEventCursorRecovery(diagnostic: RuntimeEventCursorRecovery
   console.warn("[structured host] runtime event cursor recovered", diagnostic);
 }
 
+export function nextRuntimeEventSequence(cursor: number): number {
+  if (!Number.isSafeInteger(cursor) || cursor < 0) {
+    throw new Error("runtime event cursor is invalid");
+  }
+  const next = cursor + 1;
+  if (!Number.isSafeInteger(next)) {
+    throw new Error("runtime event cursor cannot advance safely");
+  }
+  return next;
+}
+
 export function reconcileRuntimeEventCursor(
   sessionId: string,
   durableTailSeq: number,
@@ -42,9 +53,7 @@ export function reconcileRuntimeEventCursor(
   }
   const useRegistryCursor = durableTailSeq === 0 && registryCursor > 0;
   const cursor = useRegistryCursor ? registryCursor : durableTailSeq;
-  if (!Number.isSafeInteger(cursor + 1)) {
-    throw new Error("runtime event cursor cannot advance safely");
-  }
+  const chosenNextSeq = nextRuntimeEventSequence(cursor);
   if (registryCursor !== durableTailSeq) {
     try {
       report({
@@ -52,7 +61,7 @@ export function reconcileRuntimeEventCursor(
         sessionId: sessionId.slice(0, MAX_DIAGNOSTIC_SESSION_ID_LENGTH),
         durableTailSeq,
         registryCursor,
-        chosenNextSeq: cursor + 1,
+        chosenNextSeq,
         action: useRegistryCursor ? "use-registry-cursor" : "use-durable-tail",
         relation: useRegistryCursor
           ? "durable-ledger-empty"
@@ -132,6 +141,7 @@ export class FileRuntimeEventStore implements RuntimeEventStore {
   }
 
   append(threadId: string, event: RuntimeEvent): void {
+    if (!validEvent(event)) throw new Error("runtime event ledger append event is invalid");
     fs.mkdirSync(this.directory, { recursive: true, mode: 0o700 });
     const filename = this.filename(threadId);
     const previous = this.load(threadId).at(-1);

--- a/src/lib/runtime/registry.ts
+++ b/src/lib/runtime/registry.ts
@@ -10,7 +10,7 @@ import { procBackend } from "@/lib/proc";
 
 import { CodexAppServerHost, type CodexAppServerHostOptions } from "./codexAppServerHost";
 import { ClaudeStreamBrokerHost, type ClaudeStreamBrokerHostOptions } from "./claudeStreamBrokerHost";
-import type { HostState } from "./engineHost";
+import { StructuredHostAdoptionCleanupError, type HostState } from "./engineHost";
 
 export function structuredHostsEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
   return env.LLV_STRUCTURED_HOSTS === "1";
@@ -92,6 +92,7 @@ export async function bindCodexHostPersistence(
   host: CodexAppServerHost,
   claimOwner: string,
   writerClaimEpoch: number,
+  releasedStatus: "unhosted" | "dead" = "unhosted",
 ): Promise<() => void> {
   host.setWriterFence(() => registry.ownsStructuredHostClaim(key, claimOwner, writerClaimEpoch));
   try {
@@ -116,7 +117,7 @@ export async function bindCodexHostPersistence(
       const persisted = registry.setStructuredHostClaimed(
         key,
         codexHostColumns(state, writerClaimEpoch),
-        registryStatus(state),
+        terminal && releasedStatus === "dead" ? "dead" : registryStatus(state),
         claimOwner,
         writerClaimEpoch,
         terminal,
@@ -142,6 +143,7 @@ export async function bindClaudeHostPersistence(
   host: ClaudeStreamBrokerHost,
   claimOwner: string,
   writerClaimEpoch: number,
+  releasedStatus: "unhosted" | "dead" = "unhosted",
 ): Promise<() => void> {
   host.setWriterFence(() => registry.ownsStructuredHostClaim(key, claimOwner, writerClaimEpoch));
   const persist = (state: HostState, terminal = false) => registry.setStructuredHostClaimed(
@@ -171,7 +173,15 @@ export async function bindClaudeHostPersistence(
     if (failed || stopped) return;
     try {
       const terminal = state.status === "unhosted" || (state.status === "dead" && state.pid === null);
-      if (!persist(state, terminal)) throw new Error("structured host writer claim is stale");
+      const persisted = registry.setStructuredHostClaimed(
+        key,
+        claudeHostColumns(state, writerClaimEpoch),
+        terminal && releasedStatus === "dead" ? "dead" : registryStatus(state),
+        claimOwner,
+        writerClaimEpoch,
+        terminal,
+      );
+      if (!persisted) throw new Error("structured host writer claim is stale");
       if (terminal) {
         stopped = true;
         unsubscribe();
@@ -315,7 +325,22 @@ export async function adoptCodexRegistryHosts(
           });
           await bindCodexHostPersistence(registry, entry.key, host, claimed.claimOwner!, claimed.claimEpoch);
           adopted.push({ key: entry.key, host });
-        } catch {
+        } catch (error) {
+          if (error instanceof StructuredHostAdoptionCleanupError
+            && error.host instanceof CodexAppServerHost) {
+            try {
+              await bindCodexHostPersistence(
+                registry,
+                entry.key,
+                error.host,
+                claimed.claimOwner!,
+                claimed.claimEpoch,
+                "dead",
+              );
+              await error.host.release();
+            } catch { /* retain the live process and claim until its late reap is observed */ }
+            return;
+          }
           registry.setStructuredHostClaimed(entry.key, {
             ...claimed.structuredHost,
             endpoint: "stdio:released",
@@ -369,7 +394,22 @@ export async function adoptClaudeRegistryHosts(
           });
           await bindClaudeHostPersistence(registry, entry.key, host, claimed.claimOwner!, claimed.claimEpoch);
           adopted.push({ key: entry.key, host });
-        } catch {
+        } catch (error) {
+          if (error instanceof StructuredHostAdoptionCleanupError
+            && error.host instanceof ClaudeStreamBrokerHost) {
+            try {
+              await bindClaudeHostPersistence(
+                registry,
+                entry.key,
+                error.host,
+                claimed.claimOwner!,
+                claimed.claimEpoch,
+                "dead",
+              );
+              await error.host.release();
+            } catch { /* retain the live process and claim until its late reap is observed */ }
+            return;
+          }
           registry.setStructuredHostClaimed(entry.key, {
             ...claimed.structuredHost,
             endpoint: "stdio:released",

--- a/src/lib/runtime/structuredSpawn.integration.test.ts
+++ b/src/lib/runtime/structuredSpawn.integration.test.ts
@@ -3,7 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import crypto from "node:crypto";
 
-import { afterAll, afterEach, describe, expect, test } from "bun:test";
+import { afterAll, afterEach, describe, expect, spyOn, test } from "bun:test";
 
 import { emptyLaunchProfile } from "@/lib/accounts/migration/contracts";
 import type { AccountContext } from "@/lib/accounts/contracts";
@@ -13,7 +13,8 @@ import { spawnResponseForReceipt } from "@/lib/agent/spawnResponse";
 import { RuntimeJournal } from "@/runtime-host/journal";
 
 import type { RuntimeHostClient } from "./client";
-import type { DeliveryReceipt, HostState, QueueEntry, RuntimeEvent } from "./engineHost";
+import { CodexAppServerHost, type CodexAppServerHostOptions } from "./codexAppServerHost";
+import { StructuredHostAdoptionCleanupError, type DeliveryReceipt, type HostState, type QueueEntry, type RuntimeEvent } from "./engineHost";
 import { bindStructuredDeliveryQueue, hasStructuredDeliveryHost } from "./structuredDeliveryController";
 import { dispatchStructuredControl } from "./structuredControls";
 import { kickStructuredDeliveryQueue } from "./structuredDeliverySignal";
@@ -245,6 +246,13 @@ class RoundTripHost implements SpawnedStructuredHost {
   }
 }
 
+class UnreapableRoundTripHost extends RoundTripHost {
+  override async release(): Promise<void> {
+    this.releaseCount += 1;
+    throw new Error("Codex app-server child could not be reaped");
+  }
+}
+
 async function waitFor(assertion: () => boolean): Promise<void> {
   for (let attempt = 0; attempt < 200; attempt += 1) {
     if (assertion()) return;
@@ -457,6 +465,1075 @@ test("a failed resume before identity staging projects dead ownership so the fol
     outcome: "queued",
     receipt: { status: "queued", reason: null },
   });
+  journal.close();
+});
+
+test("structured successor resume forwards the 942-record registry cursor into host adoption", async () => {
+  const sessionId = "019f66b5-8694-7410-8671-fbec75484a86";
+  const cwd = path.join(sandbox, `resume-cursor-${crypto.randomUUID()}`);
+  const artifactPath = path.join(cwd, `${sessionId}.jsonl`);
+  fs.mkdirSync(cwd, { recursive: true });
+  fs.writeFileSync(artifactPath, "");
+  const registry = new AgentRegistry(path.join(cwd, "registry.json"), undefined, undefined, { sqliteMode: "off" });
+  const journal = new RuntimeJournal(path.join(cwd, "runtime.sqlite"), { structuredHosts: true });
+  const client = runtimeClient(journal);
+  const launchProfile = emptyLaunchProfile({ cwd, model: "gpt-5.6-luna" });
+  const conversation = registry.ensureConversation("codex", artifactPath, "codex-subscription");
+  registry.upsert({
+    key: { engine: "codex", sessionId },
+    artifactPath,
+    cwd,
+    accountId: "codex-subscription",
+    launchProfile,
+    status: "dead",
+    host: null,
+    structuredHost: {
+      kind: "codex-app-server",
+      endpoint: "stdio:released",
+      process: null,
+      eventCursor: 942,
+      protocolVersion: "0.144.1",
+      writerClaimEpoch: 3,
+      activeTurnRef: null,
+      pendingAttention: [],
+      activeFlags: [],
+    },
+    claimEpoch: 3,
+    claimOwner: null,
+    pendingAction: null,
+  });
+  const begun = registry.beginSpawnRequest({
+    engine: "codex",
+    cwd,
+    transport: "structured",
+    accountId: "codex-subscription",
+    conversationId: conversation.id,
+    purpose: "resume-successor",
+    expectedArtifactPath: artifactPath,
+    launchProfile,
+  });
+  if (begun.kind !== "created") throw new Error("resume receipt was unavailable");
+  const seen: Array<{ sessionId: string; cursor: number | undefined }> = [];
+  const adopt = spyOn(CodexAppServerHost, "adopt").mockImplementation(async (
+    adoptedSessionId: string,
+    options: CodexAppServerHostOptions,
+  ) => {
+    seen.push({ sessionId: adoptedSessionId, cursor: options.initialEventCursor });
+    throw new Error("stop after adoption options capture");
+  });
+
+  try {
+    await expect(spawnStructuredConversation({
+      engine: "codex",
+      receipt: begun.receipt,
+      spec: { command: "codex", cwd, windowName: "resume", engine: "codex", transcript: artifactPath, launchProfile },
+      account: { engine: "codex", accountId: "codex-subscription", kind: "managed", home: cwd, transcriptRoot: cwd, env: { NODE_ENV: "test" } },
+      prompt: "",
+      registry,
+      client,
+    })).rejects.toThrow("stop after adoption options capture");
+  } finally {
+    adopt.mockRestore();
+    journal.close();
+  }
+
+  expect(seen).toEqual([{ sessionId, cursor: 942 }]);
+});
+
+test("an uncertain adoption cleanup retains the child process and writer claim", async () => {
+  const sessionId = crypto.randomUUID();
+  const cwd = path.join(sandbox, `uncertain-adoption-cleanup-${sessionId}`);
+  const artifactPath = path.join(cwd, `${sessionId}.jsonl`);
+  fs.mkdirSync(cwd, { recursive: true });
+  fs.writeFileSync(artifactPath, "");
+  const registry = new AgentRegistry(path.join(cwd, "registry.json"), undefined, undefined, { sqliteMode: "off" });
+  const journal = new RuntimeJournal(path.join(cwd, "runtime.sqlite"), { structuredHosts: true });
+  const client = runtimeClient(journal);
+  const launchProfile = emptyLaunchProfile({ cwd, model: "gpt-5.6-luna" });
+  const conversation = registry.ensureConversation("codex", artifactPath, "codex-subscription");
+  registry.upsert({
+    key: { engine: "codex", sessionId },
+    artifactPath,
+    cwd,
+    accountId: "codex-subscription",
+    launchProfile,
+    status: "dead",
+    host: null,
+    structuredHost: {
+      kind: "codex-app-server",
+      endpoint: "stdio:released",
+      process: null,
+      eventCursor: 942,
+      protocolVersion: "0.144.1",
+      writerClaimEpoch: 3,
+      activeTurnRef: null,
+      pendingAttention: [],
+      activeFlags: [],
+    },
+    claimEpoch: 3,
+    claimOwner: null,
+    pendingAction: null,
+  });
+  const begun = registry.beginSpawnRequest({
+    engine: "codex",
+    cwd,
+    transport: "structured",
+    accountId: "codex-subscription",
+    conversationId: conversation.id,
+    purpose: "resume-successor",
+    expectedArtifactPath: artifactPath,
+    launchProfile,
+  });
+  if (begun.kind !== "created") throw new Error("resume receipt was unavailable");
+  const host = new UnreapableRoundTripHost("codex", artifactPath, sessionId);
+
+  await expect(spawnStructuredConversation({
+    engine: "codex",
+    receipt: begun.receipt,
+    spec: { command: "codex", cwd, windowName: "resume", engine: "codex", transcript: artifactPath, launchProfile },
+    account: { engine: "codex", accountId: "codex-subscription", kind: "managed", home: cwd, transcriptRoot: cwd, env: { NODE_ENV: "test" } },
+    prompt: "",
+    registry,
+    client,
+  }, {
+    startHost: async () => {
+      throw new StructuredHostAdoptionCleanupError("runtime event ledger sequence gap after 942", host);
+    },
+    bindHost: async (targetRegistry, key, runningHost, claimOwner, claimEpoch) => {
+      const state = await runningHost.health();
+      const persisted = targetRegistry.setStructuredHostClaimed(key, {
+        kind: "codex-app-server",
+        endpoint: state.endpoint,
+        process: { pid: state.pid!, startIdentity: state.processStartIdentity },
+        eventCursor: state.eventCursor,
+        protocolVersion: state.protocolVersion,
+        writerClaimEpoch: claimEpoch,
+        activeTurnRef: state.activeTurnRef,
+        pendingAttention: state.pendingAttention,
+        activeFlags: state.activeFlags,
+      }, "idle", claimOwner, claimEpoch);
+      if (!persisted) throw new Error("uncertain adoption persistence failed");
+      return () => { targetRegistry.releaseStructuredHostClaim(key, claimOwner, claimEpoch); };
+    },
+    processIdentity: () => ({ pid: process.pid, startIdentity: "uncertain-adoption-owner" }),
+  })).rejects.toThrow("Codex app-server child could not be reaped");
+
+  expect(registry.snapshot().receipts[begun.receipt.launchId]).toMatchObject({ state: "starting" });
+  expect(registry.snapshot().entries[`codex:${sessionId}`]).toMatchObject({
+    status: "idle",
+    claimEpoch: 4,
+    claimOwner: expect.any(String),
+    structuredHost: {
+      endpoint: "fake:stdio",
+      process: { pid: process.pid, startIdentity: "test-process" },
+      eventCursor: 0,
+      writerClaimEpoch: 4,
+    },
+  });
+  expect(host.releaseCount).toBe(1);
+  journal.close();
+});
+
+test("failed adoption keeps dead projection retryable across an append failure and releases its claim", async () => {
+  const sessionId = crypto.randomUUID();
+  const cwd = path.join(sandbox, `resume-projection-retry-${sessionId}`);
+  const artifactPath = path.join(cwd, `${sessionId}.jsonl`);
+  fs.mkdirSync(cwd, { recursive: true });
+  fs.writeFileSync(artifactPath, "");
+  const registry = new AgentRegistry(path.join(cwd, "registry.json"), undefined, undefined, { sqliteMode: "off" });
+  const journal = new RuntimeJournal(path.join(cwd, "runtime.sqlite"), { structuredHosts: true });
+  const client = runtimeClient(journal);
+  const launchProfile = emptyLaunchProfile({ cwd, model: "gpt-5.6-luna" });
+  const conversation = registry.ensureConversation("codex", artifactPath, "codex-subscription");
+  const key = { engine: "codex" as const, sessionId };
+  registry.upsert({
+    key,
+    artifactPath,
+    cwd,
+    accountId: "codex-subscription",
+    launchProfile,
+    status: "dead",
+    host: null,
+    structuredHost: {
+      kind: "codex-app-server",
+      endpoint: "stdio:released",
+      process: null,
+      eventCursor: 942,
+      protocolVersion: "0.144.1",
+      writerClaimEpoch: 4,
+      activeTurnRef: null,
+      pendingAttention: [],
+      activeFlags: [],
+    },
+    claimEpoch: 4,
+    claimOwner: null,
+    pendingAction: null,
+  });
+  await client.append({
+    scope: { type: "session", id: conversation.id },
+    kind: "session-status",
+    payload: {
+      conversationId: conversation.id,
+      sessionKey: key,
+      hostKind: "codex-app-server",
+      host: "hosted",
+      turn: "running",
+      provenance: "structured",
+      accountId: "codex-subscription",
+      cwd,
+      artifactPath,
+      capabilities: { steer: true, structuredAttention: true },
+      activeTurnId: "stale-turn",
+    },
+  });
+  const begun = registry.beginSpawnRequest({
+    engine: "codex",
+    cwd,
+    transport: "structured",
+    accountId: "codex-subscription",
+    conversationId: conversation.id,
+    purpose: "resume-successor",
+    expectedArtifactPath: artifactPath,
+    launchProfile,
+  });
+  if (begun.kind !== "created") throw new Error("resume receipt was unavailable");
+  let failProjectionAppend = true;
+  const flakyClient = {
+    ...client,
+    append: async (...args: Parameters<RuntimeHostClient["append"]>) => {
+      const event = args[0];
+      if (failProjectionAppend && event.kind === "session-status"
+        && (event.payload as { host?: unknown }).host === "dead") {
+        failProjectionAppend = false;
+        throw new Error("simulated runtime projection append failure");
+      }
+      return client.append(...args);
+    },
+  } as RuntimeHostClient;
+
+  await expect(spawnStructuredConversation({
+    engine: "codex",
+    receipt: begun.receipt,
+    spec: { command: "codex", cwd, windowName: "resume", engine: "codex", transcript: artifactPath, launchProfile },
+    account: { engine: "codex", accountId: "codex-subscription", kind: "managed", home: cwd, transcriptRoot: cwd, env: { NODE_ENV: "test" } },
+    prompt: "",
+    registry,
+    client: flakyClient,
+  }, {
+    startHost: async () => { throw new Error("runtime event ledger sequence gap after 942"); },
+    processIdentity: () => ({ pid: 987_654, startIdentity: "failed-adoption" }),
+  })).rejects.toThrow("runtime event ledger sequence gap after 942");
+
+  expect(registry.snapshot().receipts[begun.receipt.launchId]).toMatchObject({ state: "starting" });
+  expect(registry.snapshot().entries[`codex:${sessionId}`]).toMatchObject({
+    status: "dead",
+    claimEpoch: 5,
+    claimOwner: null,
+    structuredHost: { eventCursor: 942, process: null, writerClaimEpoch: 5 },
+  });
+  expect(journal.snapshot().sessions.find((session) => session.conversationId === conversation.id)?.host).not.toBe("dead");
+
+  await recoverPendingStructuredSpawns(registry, client);
+
+  expect(registry.snapshot().receipts[begun.receipt.launchId]).toMatchObject({ state: "failed" });
+  expect(registry.snapshot().entries[`codex:${sessionId}`]).toMatchObject({
+    status: "dead",
+    claimOwner: null,
+    pendingAction: null,
+    structuredHost: { eventCursor: 942, process: null },
+  });
+  expect(journal.snapshot().sessions.find((session) => session.conversationId === conversation.id)).toMatchObject({
+    host: "dead",
+    turn: "idle",
+    activeTurnId: null,
+  });
+  journal.close();
+});
+
+test("a staged resume releases its transferred claim when failure projection is unavailable", async () => {
+  const sessionId = crypto.randomUUID();
+  const cwd = path.join(sandbox, `staged-projection-failure-${sessionId}`);
+  const artifactPath = path.join(cwd, `${sessionId}.jsonl`);
+  fs.mkdirSync(cwd, { recursive: true });
+  fs.writeFileSync(artifactPath, "");
+  const registry = new AgentRegistry(path.join(cwd, "registry.json"), undefined, undefined, { sqliteMode: "off" });
+  const journal = new RuntimeJournal(path.join(cwd, "runtime.sqlite"), { structuredHosts: true });
+  const client = runtimeClient(journal);
+  const launchProfile = emptyLaunchProfile({ cwd, model: "gpt-5.6-luna" });
+  const conversation = registry.ensureConversation("codex", artifactPath, "codex-subscription");
+  const key = { engine: "codex" as const, sessionId };
+  registry.upsert({
+    key,
+    artifactPath,
+    cwd,
+    accountId: "codex-subscription",
+    launchProfile,
+    status: "dead",
+    host: null,
+    structuredHost: {
+      kind: "codex-app-server",
+      endpoint: "stdio:released",
+      process: null,
+      eventCursor: 942,
+      protocolVersion: "0.144.1",
+      writerClaimEpoch: 5,
+      activeTurnRef: null,
+      pendingAttention: [],
+      activeFlags: [],
+    },
+    claimEpoch: 5,
+    claimOwner: null,
+    pendingAction: null,
+  });
+  const begun = registry.beginSpawnRequest({
+    engine: "codex",
+    cwd,
+    transport: "structured",
+    accountId: "codex-subscription",
+    conversationId: conversation.id,
+    purpose: "resume-successor",
+    expectedArtifactPath: artifactPath,
+    launchProfile,
+  });
+  if (begun.kind !== "created") throw new Error("resume receipt was unavailable");
+  const host = new RoundTripHost("codex", artifactPath, sessionId);
+  const flakyClient = {
+    ...client,
+    append: async (...args: Parameters<RuntimeHostClient["append"]>) => {
+      const event = args[0];
+      if (event.kind === "session-status" && (event.payload as { host?: unknown }).host === "dead") {
+        throw new Error("simulated runtime projection append failure");
+      }
+      return client.append(...args);
+    },
+  } as RuntimeHostClient;
+
+  await expect(spawnStructuredConversation({
+    engine: "codex",
+    receipt: begun.receipt,
+    spec: { command: "codex", cwd, windowName: "resume", engine: "codex", transcript: artifactPath, launchProfile },
+    account: { engine: "codex", accountId: "codex-subscription", kind: "managed", home: cwd, transcriptRoot: cwd, env: { NODE_ENV: "test" } },
+    prompt: "",
+    registry,
+    client: flakyClient,
+  }, {
+    startHost: async () => host,
+    bindHost: async () => { throw new Error("resume binding failed after identity staging"); },
+    processIdentity: () => ({ pid: 765_432, startIdentity: "staged-adoption" }),
+  })).rejects.toThrow("resume binding failed after identity staging");
+
+  expect(registry.snapshot().receipts[begun.receipt.launchId]).toMatchObject({ state: "path-pending" });
+  expect(registry.snapshot().entries[`codex:${sessionId}`]).toMatchObject({
+    claimEpoch: 6,
+    claimOwner: null,
+    structuredHost: { eventCursor: 942, process: null, writerClaimEpoch: 6 },
+  });
+  expect(host.releaseCount).toBe(1);
+  journal.close();
+});
+
+test("a projected same-session resume failure retains its terminal event cursor", async () => {
+  const sessionId = crypto.randomUUID();
+  const cwd = path.join(sandbox, `staged-projected-failure-${sessionId}`);
+  const artifactPath = path.join(cwd, `${sessionId}.jsonl`);
+  fs.mkdirSync(cwd, { recursive: true });
+  fs.writeFileSync(artifactPath, "");
+  const registry = new AgentRegistry(path.join(cwd, "registry.json"), undefined, undefined, { sqliteMode: "off" });
+  const journal = new RuntimeJournal(path.join(cwd, "runtime.sqlite"), { structuredHosts: true });
+  const client = runtimeClient(journal);
+  const launchProfile = emptyLaunchProfile({ cwd, model: "gpt-5.6-luna" });
+  const conversation = registry.ensureConversation("codex", artifactPath, "codex-subscription");
+  registry.upsert({
+    key: { engine: "codex", sessionId },
+    artifactPath,
+    cwd,
+    accountId: "codex-subscription",
+    launchProfile,
+    status: "dead",
+    host: null,
+    structuredHost: {
+      kind: "codex-app-server",
+      endpoint: "stdio:released",
+      process: null,
+      eventCursor: 942,
+      protocolVersion: "0.144.1",
+      writerClaimEpoch: 5,
+      activeTurnRef: null,
+      pendingAttention: [],
+      activeFlags: [],
+    },
+    claimEpoch: 5,
+    claimOwner: null,
+    pendingAction: null,
+  });
+  const begun = registry.beginSpawnRequest({
+    engine: "codex",
+    cwd,
+    transport: "structured",
+    accountId: "codex-subscription",
+    conversationId: conversation.id,
+    purpose: "resume-successor",
+    expectedArtifactPath: artifactPath,
+    launchProfile,
+  });
+  if (begun.kind !== "created") throw new Error("resume receipt was unavailable");
+  const host = new RoundTripHost("codex", artifactPath, sessionId);
+
+  await expect(spawnStructuredConversation({
+    engine: "codex",
+    receipt: begun.receipt,
+    spec: { command: "codex", cwd, windowName: "resume", engine: "codex", transcript: artifactPath, launchProfile },
+    account: { engine: "codex", accountId: "codex-subscription", kind: "managed", home: cwd, transcriptRoot: cwd, env: { NODE_ENV: "test" } },
+    prompt: "",
+    registry,
+    client,
+  }, {
+    startHost: async () => host,
+    bindHost: async () => { throw new Error("resume binding failed after identity staging"); },
+    processIdentity: () => ({ pid: 765_432, startIdentity: "staged-adoption" }),
+  })).rejects.toThrow("resume binding failed after identity staging");
+
+  expect(registry.snapshot().receipts[begun.receipt.launchId]).toMatchObject({ state: "failed" });
+  expect(registry.snapshot().entries[`codex:${sessionId}`]).toMatchObject({
+    status: "dead",
+    claimEpoch: 6,
+    claimOwner: null,
+    pendingAction: null,
+    structuredHost: {
+      endpoint: "stdio:released",
+      process: null,
+      eventCursor: 942,
+      writerClaimEpoch: 6,
+      activeTurnRef: null,
+      pendingAttention: [],
+      activeFlags: [],
+    },
+  });
+  expect(journal.snapshot().sessions.find((session) => session.conversationId === conversation.id)).toMatchObject({
+    host: "dead",
+    turn: "idle",
+  });
+  expect(host.releaseCount).toBe(1);
+  journal.close();
+});
+
+test("spawn failure preserves the staged writer when its child cannot be reaped", async () => {
+  const sessionId = crypto.randomUUID();
+  const cwd = path.join(sandbox, `unreaped-spawn-failure-${sessionId}`);
+  const artifactPath = path.join(cwd, `${sessionId}.jsonl`);
+  fs.mkdirSync(cwd, { recursive: true });
+  fs.writeFileSync(artifactPath, "");
+  const registry = new AgentRegistry(path.join(cwd, "registry.json"), undefined, undefined, { sqliteMode: "off" });
+  const journal = new RuntimeJournal(path.join(cwd, "runtime.sqlite"), { structuredHosts: true });
+  const client = runtimeClient(journal);
+  const launchProfile = emptyLaunchProfile({ cwd, model: "gpt-5.6-luna" });
+  const conversation = registry.ensureConversation("codex", artifactPath, "codex-subscription");
+  const begun = registry.beginSpawnRequest({
+    engine: "codex",
+    cwd,
+    transport: "structured",
+    accountId: "codex-subscription",
+    conversationId: conversation.id,
+    purpose: "resume-successor",
+    expectedArtifactPath: artifactPath,
+    launchProfile,
+  });
+  if (begun.kind !== "created") throw new Error("resume receipt was unavailable");
+  const host = new UnreapableRoundTripHost("codex", artifactPath, sessionId);
+  let published = false;
+
+  await expect(spawnStructuredConversation({
+    engine: "codex",
+    receipt: begun.receipt,
+    spec: { command: "codex", cwd, windowName: "resume", engine: "codex", transcript: artifactPath, launchProfile },
+    account: { engine: "codex", accountId: "codex-subscription", kind: "managed", home: cwd, transcriptRoot: cwd, env: { NODE_ENV: "test" } },
+    prompt: "",
+    registry,
+    client,
+  }, {
+    startHost: async () => host,
+    bindHost: async (targetRegistry, key, runningHost, claimOwner, claimEpoch) => {
+      const state = await runningHost.health();
+      const persisted = targetRegistry.setStructuredHostClaimed(key, {
+        kind: "codex-app-server",
+        endpoint: state.endpoint,
+        process: { pid: state.pid!, startIdentity: state.processStartIdentity },
+        eventCursor: state.eventCursor,
+        protocolVersion: state.protocolVersion,
+        writerClaimEpoch: claimEpoch,
+        activeTurnRef: state.activeTurnRef,
+        pendingAttention: state.pendingAttention,
+        activeFlags: state.activeFlags,
+      }, "idle", claimOwner, claimEpoch);
+      if (!persisted) throw new Error("staged writer persistence failed");
+      return () => { targetRegistry.releaseStructuredHostClaim(key, claimOwner, claimEpoch); };
+    },
+    publishHost: async () => {
+      published = true;
+      return async () => { published = false; };
+    },
+    deliverFirst: async () => { throw new Error("first message delivery failed"); },
+    processIdentity: () => ({ pid: process.pid, startIdentity: "test-process" }),
+  })).rejects.toThrow("Codex app-server child could not be reaped");
+
+  expect(registry.snapshot().receipts[begun.receipt.launchId]).toMatchObject({ state: "path-pending" });
+  expect(registry.snapshot().entries[`codex:${sessionId}`]).toMatchObject({
+    status: "idle",
+    pendingAction: "spawn",
+    structuredHostOperationId: begun.receipt.launchId,
+    claimOwner: expect.any(String),
+    structuredHost: {
+      endpoint: "fake:stdio",
+      process: { pid: process.pid, startIdentity: "test-process" },
+    },
+  });
+  expect(journal.snapshot().sessions.find((session) => session.conversationId === conversation.id)?.host).not.toBe("dead");
+  expect(host.releaseCount).toBe(1);
+  expect(published).toBeTrue();
+  journal.close();
+});
+
+test("startup recovery preserves a live adopted writer while settling its stale unstaged resume", async () => {
+  const sessionId = crypto.randomUUID();
+  const cwd = path.join(sandbox, `live-writer-recovery-${sessionId}`);
+  const artifactPath = path.join(cwd, `${sessionId}.jsonl`);
+  fs.mkdirSync(cwd, { recursive: true });
+  fs.writeFileSync(artifactPath, "");
+  const registry = new AgentRegistry(
+    path.join(cwd, "registry.json"),
+    () => true,
+    undefined,
+    { sqliteMode: "off" },
+  );
+  const journal = new RuntimeJournal(path.join(cwd, "runtime.sqlite"), { structuredHosts: true });
+  const client = runtimeClient(journal);
+  const launchProfile = emptyLaunchProfile({ cwd, model: "gpt-5.6-luna" });
+  const conversation = registry.ensureConversation("codex", artifactPath, "codex-subscription");
+  const key = { engine: "codex" as const, sessionId };
+  registry.upsert({
+    key,
+    artifactPath,
+    cwd,
+    accountId: "codex-subscription",
+    launchProfile,
+    status: "idle",
+    host: null,
+    structuredHost: {
+      kind: "codex-app-server",
+      endpoint: "stdio:live",
+      process: { pid: 4321, startIdentity: "live-adopter" },
+      eventCursor: 942,
+      protocolVersion: "0.144.1",
+      writerClaimEpoch: 7,
+      activeTurnRef: null,
+      pendingAttention: [],
+      activeFlags: [],
+    },
+    claimEpoch: 7,
+    claimOwner: 'structured-host:{"pid":4321,"startIdentity":"live-adopter"}',
+    pendingAction: null,
+  });
+  await client.append({
+    scope: { type: "session", id: conversation.id },
+    kind: "session-status",
+    payload: {
+      conversationId: conversation.id,
+      sessionKey: key,
+      hostKind: "codex-app-server",
+      host: "hosted",
+      turn: "idle",
+      provenance: "structured",
+      accountId: "codex-subscription",
+      cwd,
+      artifactPath,
+      capabilities: { steer: true, structuredAttention: true },
+      activeTurnId: null,
+    },
+  });
+  const begun = registry.beginSpawnRequest({
+    engine: "codex",
+    cwd,
+    transport: "structured",
+    accountId: "codex-subscription",
+    conversationId: conversation.id,
+    purpose: "resume-successor",
+    expectedArtifactPath: artifactPath,
+    launchProfile,
+  });
+  if (begun.kind !== "created") throw new Error("resume receipt was unavailable");
+  await client.command({
+    kind: "spawn",
+    operationId: begun.receipt.launchId,
+    idempotencyKey: begun.receipt.launchId,
+    conversationId: conversation.id,
+    engine: "codex",
+    cwd,
+    prompt: "",
+    accountId: "codex-subscription",
+  });
+  await client.append({
+    scope: { type: "session", id: conversation.id },
+    kind: "session-status",
+    payload: {
+      conversationId: conversation.id,
+      sessionKey: key,
+      hostKind: "codex-app-server",
+      host: "hosted",
+      turn: "idle",
+      provenance: "structured",
+      accountId: "codex-subscription",
+      cwd,
+      artifactPath,
+      capabilities: { steer: true, structuredAttention: true },
+      activeTurnId: null,
+    },
+  });
+
+  await recoverPendingStructuredSpawns(registry, client);
+
+  expect(registry.snapshot().receipts[begun.receipt.launchId]).toMatchObject({ state: "failed" });
+  expect(registry.snapshot().entries[`codex:${sessionId}`]).toMatchObject({
+    status: "idle",
+    claimEpoch: 7,
+    claimOwner: 'structured-host:{"pid":4321,"startIdentity":"live-adopter"}',
+    structuredHost: {
+      endpoint: "stdio:live",
+      eventCursor: 942,
+      process: { pid: 4321, startIdentity: "live-adopter" },
+      writerClaimEpoch: 7,
+    },
+  });
+  expect(journal.snapshot().sessions.find((session) => session.conversationId === conversation.id)?.host).not.toBe("dead");
+  journal.close();
+});
+
+test("startup recovery preserves a live adopted writer while settling its stale staged resume", async () => {
+  const sessionId = crypto.randomUUID();
+  const cwd = path.join(sandbox, `live-staged-writer-recovery-${sessionId}`);
+  const artifactPath = path.join(cwd, `${sessionId}.jsonl`);
+  fs.mkdirSync(cwd, { recursive: true });
+  fs.writeFileSync(artifactPath, "");
+  const registry = new AgentRegistry(
+    path.join(cwd, "registry.json"),
+    () => true,
+    undefined,
+    { sqliteMode: "off" },
+  );
+  const journal = new RuntimeJournal(path.join(cwd, "runtime.sqlite"), { structuredHosts: true });
+  const client = runtimeClient(journal);
+  const launchProfile = emptyLaunchProfile({ cwd, model: "gpt-5.6-luna" });
+  const conversation = registry.ensureConversation("codex", artifactPath, "codex-subscription");
+  const key = { engine: "codex" as const, sessionId };
+  const begun = registry.beginSpawnRequest({
+    engine: "codex",
+    cwd,
+    transport: "structured",
+    accountId: "codex-subscription",
+    conversationId: conversation.id,
+    purpose: "resume-successor",
+    expectedArtifactPath: artifactPath,
+    launchProfile,
+  });
+  if (begun.kind !== "created") throw new Error("resume receipt was unavailable");
+  const staged = registry.stageStructuredSpawn(begun.receipt.launchId, {
+    key,
+    artifactPath,
+    cwd,
+    accountId: "codex-subscription",
+    launchProfile,
+    status: "idle",
+    host: null,
+    structuredHost: {
+      kind: "codex-app-server",
+      endpoint: "stdio:live-staged",
+      process: { pid: 5432, startIdentity: "live-staged-adopter" },
+      eventCursor: 942,
+      protocolVersion: "0.144.1",
+      writerClaimEpoch: 11,
+      activeTurnRef: null,
+      pendingAttention: [],
+      activeFlags: [],
+    },
+    claimEpoch: 11,
+    claimOwner: 'structured-host:{"pid":5432,"startIdentity":"live-staged-adopter"}',
+    pendingAction: "spawn",
+  });
+  if (staged.kind !== "settled") throw new Error("resume identity was unavailable");
+  registry.upsert({
+    ...staged.entry,
+    structuredHostOperationId: "winning-resume-operation",
+  });
+  await client.command({
+    kind: "spawn",
+    operationId: begun.receipt.launchId,
+    idempotencyKey: begun.receipt.launchId,
+    conversationId: conversation.id,
+    engine: "codex",
+    cwd,
+    prompt: "",
+    accountId: "codex-subscription",
+  });
+  await client.transitionOperation(begun.receipt.launchId, "failed", { reason: "stale staged resume failed" });
+  await client.append({
+    scope: { type: "session", id: conversation.id },
+    kind: "session-status",
+    payload: {
+      conversationId: conversation.id,
+      sessionKey: key,
+      hostKind: "codex-app-server",
+      host: "hosted",
+      turn: "idle",
+      provenance: "structured",
+      accountId: "codex-subscription",
+      cwd,
+      artifactPath,
+      capabilities: { steer: true, structuredAttention: true },
+      activeTurnId: null,
+    },
+  });
+
+  await recoverPendingStructuredSpawns(registry, client);
+
+  expect(registry.snapshot().receipts[begun.receipt.launchId]).toMatchObject({ state: "failed" });
+  expect(registry.snapshot().entries[`codex:${sessionId}`]).toMatchObject({
+    status: "idle",
+    claimEpoch: 11,
+    claimOwner: 'structured-host:{"pid":5432,"startIdentity":"live-staged-adopter"}',
+    structuredHost: {
+      endpoint: "stdio:live-staged",
+      eventCursor: 942,
+      process: { pid: 5432, startIdentity: "live-staged-adopter" },
+      writerClaimEpoch: 11,
+    },
+  });
+  expect(journal.snapshot().sessions.find((session) => session.conversationId === conversation.id)).toMatchObject({
+    host: "hosted",
+    turn: "idle",
+  });
+  journal.close();
+});
+
+function stagedOwnershipRace(label: string) {
+  const sessionId = crypto.randomUUID();
+  const cwd = path.join(sandbox, `${label}-${sessionId}`);
+  const artifactPath = path.join(cwd, `${sessionId}.jsonl`);
+  fs.mkdirSync(cwd, { recursive: true });
+  fs.writeFileSync(artifactPath, "");
+  const registry = new AgentRegistry(path.join(cwd, "registry.json"), undefined, undefined, { sqliteMode: "off" });
+  const launchProfile = emptyLaunchProfile({ cwd, model: "gpt-5.6-luna" });
+  const conversation = registry.ensureConversation("codex", artifactPath, "codex-subscription");
+  const key = { engine: "codex" as const, sessionId };
+  const begun = registry.beginSpawnRequest({
+    engine: "codex",
+    cwd,
+    transport: "structured",
+    accountId: "codex-subscription",
+    conversationId: conversation.id,
+    purpose: "resume-successor",
+    expectedArtifactPath: artifactPath,
+    launchProfile,
+  });
+  if (begun.kind !== "created") throw new Error("resume receipt was unavailable");
+  const staged = registry.stageStructuredSpawn(begun.receipt.launchId, {
+    key,
+    artifactPath,
+    cwd,
+    accountId: "codex-subscription",
+    launchProfile,
+    status: "idle",
+    host: null,
+    structuredHost: {
+      kind: "codex-app-server",
+      endpoint: "stdio:older",
+      process: { pid: 6543, startIdentity: "older-adopter" },
+      eventCursor: 942,
+      protocolVersion: "0.144.1",
+      writerClaimEpoch: 13,
+      activeTurnRef: null,
+      pendingAttention: [],
+      activeFlags: [],
+    },
+    claimEpoch: 13,
+    claimOwner: 'structured-host:{"pid":6543,"startIdentity":"older-adopter"}',
+    pendingAction: "spawn",
+  });
+  if (staged.kind !== "settled") throw new Error("resume identity was unavailable");
+  registry.upsert({
+    ...staged.entry,
+    structuredHostOperationId: "newer-resume-operation",
+    structuredHost: {
+      ...staged.entry.structuredHost!,
+      endpoint: "stdio:newer",
+      process: { pid: 7654, startIdentity: "newer-adopter" },
+      writerClaimEpoch: 14,
+    },
+    claimEpoch: 14,
+    claimOwner: 'structured-host:{"pid":7654,"startIdentity":"newer-adopter"}',
+  });
+  return { registry, begun, sessionId };
+}
+
+test("an older failed spawn cannot erase a newer structured host owner", () => {
+  const { registry, begun, sessionId } = stagedOwnershipRace("failed-operation-fence");
+
+  registry.failStructuredSpawn(begun.receipt.launchId, "older operation failed");
+
+  expect(registry.snapshot().receipts[begun.receipt.launchId]).toMatchObject({
+    state: "failed",
+    error: "older operation failed",
+  });
+  expect(registry.snapshot().entries[`codex:${sessionId}`]).toMatchObject({
+    status: "idle",
+    structuredHostOperationId: "newer-resume-operation",
+    claimEpoch: 14,
+    claimOwner: 'structured-host:{"pid":7654,"startIdentity":"newer-adopter"}',
+    structuredHost: {
+      endpoint: "stdio:newer",
+      process: { pid: 7654, startIdentity: "newer-adopter" },
+      writerClaimEpoch: 14,
+    },
+  });
+});
+
+test("an older finalize cannot settle across a newer structured host owner", () => {
+  const { registry, begun, sessionId } = stagedOwnershipRace("finalize-operation-fence");
+
+  expect(registry.finalizeStructuredSpawn(begun.receipt.launchId)).toMatchObject({
+    kind: "conflict",
+    code: "spawn_identity_conflict",
+  });
+
+  expect(registry.snapshot().receipts[begun.receipt.launchId]).toMatchObject({
+    state: "conflicted",
+    error: "spawn_identity_conflict",
+  });
+  expect(registry.snapshot().entries[`codex:${sessionId}`]).toMatchObject({
+    status: "idle",
+    pendingAction: "spawn",
+    structuredHostOperationId: "newer-resume-operation",
+    claimEpoch: 14,
+    claimOwner: 'structured-host:{"pid":7654,"startIdentity":"newer-adopter"}',
+  });
+});
+
+test("a stale finalize cannot project the newer structured owner dead", async () => {
+  const sessionId = crypto.randomUUID();
+  const cwd = path.join(sandbox, `stale-finalize-projection-${sessionId}`);
+  const artifactPath = path.join(cwd, `${sessionId}.jsonl`);
+  fs.mkdirSync(cwd, { recursive: true });
+  fs.writeFileSync(artifactPath, "");
+  const registry = new AgentRegistry(path.join(cwd, "registry.json"), undefined, undefined, { sqliteMode: "off" });
+  const journal = new RuntimeJournal(path.join(cwd, "runtime.sqlite"), { structuredHosts: true });
+  const client = runtimeClient(journal);
+  const launchProfile = emptyLaunchProfile({ cwd, model: "gpt-5.6-luna" });
+  const conversation = registry.ensureConversation("codex", artifactPath, "codex-subscription");
+  const key = { engine: "codex" as const, sessionId };
+  registry.upsert({
+    key,
+    artifactPath,
+    cwd,
+    accountId: "codex-subscription",
+    launchProfile,
+    status: "dead",
+    host: null,
+    structuredHost: {
+      kind: "codex-app-server",
+      endpoint: "stdio:released",
+      process: null,
+      eventCursor: 942,
+      protocolVersion: "0.144.1",
+      writerClaimEpoch: 2,
+      activeTurnRef: null,
+      pendingAttention: [],
+      activeFlags: [],
+    },
+    claimEpoch: 2,
+    claimOwner: null,
+    pendingAction: null,
+  });
+  const begun = registry.beginSpawnRequest({
+    engine: "codex",
+    cwd,
+    transport: "structured",
+    accountId: "codex-subscription",
+    conversationId: conversation.id,
+    purpose: "resume-successor",
+    expectedArtifactPath: artifactPath,
+    launchProfile,
+  });
+  if (begun.kind !== "created") throw new Error("resume receipt was unavailable");
+  const host = new RoundTripHost("codex", artifactPath, sessionId);
+
+  await expect(spawnStructuredConversation({
+    engine: "codex",
+    receipt: begun.receipt,
+    spec: { command: "codex", cwd, windowName: "resume", engine: "codex", transcript: artifactPath, launchProfile },
+    account: { engine: "codex", accountId: "codex-subscription", kind: "managed", home: cwd, transcriptRoot: cwd, env: { NODE_ENV: "test" } },
+    prompt: "",
+    registry,
+    client,
+  }, {
+    startHost: async () => host,
+    bindHost: async (targetRegistry, hostKey, runningHost, claimOwner, claimEpoch) => {
+      const state = await runningHost.health();
+      const persisted = targetRegistry.setStructuredHostClaimed(hostKey, {
+        kind: "codex-app-server",
+        endpoint: state.endpoint,
+        process: { pid: state.pid!, startIdentity: state.processStartIdentity },
+        eventCursor: state.eventCursor,
+        protocolVersion: state.protocolVersion,
+        writerClaimEpoch: claimEpoch,
+        activeTurnRef: state.activeTurnRef,
+        pendingAttention: state.pendingAttention,
+        activeFlags: state.activeFlags,
+      }, "idle", claimOwner, claimEpoch);
+      if (!persisted) throw new Error("older writer persistence failed");
+      return () => { targetRegistry.releaseStructuredHostClaim(hostKey, claimOwner, claimEpoch); };
+    },
+    publishHost: async () => async () => {},
+    deliverFirst: async () => {
+      const current = registry.snapshot().entries[`codex:${sessionId}`];
+      registry.upsert({
+        ...current,
+        status: "idle",
+        structuredHostOperationId: "newer-resume-operation",
+        structuredHost: {
+          ...current.structuredHost!,
+          endpoint: "stdio:newer",
+          process: { pid: 86_420, startIdentity: "newer-writer" },
+          writerClaimEpoch: current.claimEpoch + 1,
+        },
+        claimEpoch: current.claimEpoch + 1,
+        claimOwner: 'structured-host:{"pid":86420,"startIdentity":"newer-writer"}',
+      });
+      await client.append({
+        scope: { type: "session", id: conversation.id },
+        kind: "session-status",
+        payload: {
+          conversationId: conversation.id,
+          sessionKey: key,
+          hostKind: "codex-app-server",
+          host: "hosted",
+          turn: "idle",
+          provenance: "structured",
+          accountId: "codex-subscription",
+          cwd,
+          artifactPath,
+          capabilities: { steer: true, structuredAttention: true },
+          activeTurnId: null,
+        },
+      });
+    },
+    processIdentity: () => ({ pid: 75_310, startIdentity: "older-writer" }),
+  })).rejects.toThrow("structured spawn registry conflict: spawn_identity_conflict");
+
+  expect(registry.snapshot().entries[`codex:${sessionId}`]).toMatchObject({
+    status: "idle",
+    structuredHostOperationId: "newer-resume-operation",
+    claimOwner: 'structured-host:{"pid":86420,"startIdentity":"newer-writer"}',
+    structuredHost: { endpoint: "stdio:newer", process: { pid: 86_420, startIdentity: "newer-writer" } },
+  });
+  expect(journal.snapshot().sessions.find((session) => session.conversationId === conversation.id)).toMatchObject({
+    host: "hosted",
+    turn: "idle",
+  });
+  journal.close();
+});
+
+test("a resume claim loser leaves the winning writer projection and ownership intact", async () => {
+  const sessionId = crypto.randomUUID();
+  const cwd = path.join(sandbox, `resume-claim-loser-${sessionId}`);
+  const artifactPath = path.join(cwd, `${sessionId}.jsonl`);
+  fs.mkdirSync(cwd, { recursive: true });
+  fs.writeFileSync(artifactPath, "");
+  const registry = new AgentRegistry(
+    path.join(cwd, "registry.json"),
+    () => true,
+    undefined,
+    { sqliteMode: "off" },
+  );
+  const journal = new RuntimeJournal(path.join(cwd, "runtime.sqlite"), { structuredHosts: true });
+  const client = runtimeClient(journal);
+  const launchProfile = emptyLaunchProfile({ cwd, model: "gpt-5.6-luna" });
+  const conversation = registry.ensureConversation("codex", artifactPath, "codex-subscription");
+  const key = { engine: "codex" as const, sessionId };
+  registry.upsert({
+    key,
+    artifactPath,
+    cwd,
+    accountId: "codex-subscription",
+    launchProfile,
+    status: "idle",
+    host: null,
+    structuredHost: {
+      kind: "codex-app-server",
+      endpoint: "stdio:winner",
+      process: { pid: 8765, startIdentity: "winning-adopter" },
+      eventCursor: 942,
+      protocolVersion: "0.144.1",
+      writerClaimEpoch: 9,
+      activeTurnRef: null,
+      pendingAttention: [],
+      activeFlags: [],
+    },
+    claimEpoch: 9,
+    claimOwner: 'structured-host:{"pid":8765,"startIdentity":"winning-adopter"}',
+    pendingAction: null,
+  });
+  await client.append({
+    scope: { type: "session", id: conversation.id },
+    kind: "session-status",
+    payload: {
+      conversationId: conversation.id,
+      sessionKey: key,
+      hostKind: "codex-app-server",
+      host: "hosted",
+      turn: "idle",
+      provenance: "structured",
+      accountId: "codex-subscription",
+      cwd,
+      artifactPath,
+      capabilities: { steer: true, structuredAttention: true },
+      activeTurnId: null,
+    },
+  });
+  const begun = registry.beginSpawnRequest({
+    engine: "codex",
+    cwd,
+    transport: "structured",
+    accountId: "codex-subscription",
+    conversationId: conversation.id,
+    purpose: "resume-successor",
+    expectedArtifactPath: artifactPath,
+    launchProfile,
+  });
+  if (begun.kind !== "created") throw new Error("resume receipt was unavailable");
+
+  await expect(spawnStructuredConversation({
+    engine: "codex",
+    receipt: begun.receipt,
+    spec: { command: "codex", cwd, windowName: "resume", engine: "codex", transcript: artifactPath, launchProfile },
+    account: { engine: "codex", accountId: "codex-subscription", kind: "managed", home: cwd, transcriptRoot: cwd, env: { NODE_ENV: "test" } },
+    prompt: "",
+    registry,
+    client,
+  }, {
+    startHost: async () => { throw new Error("claim loser reached host adoption"); },
+  })).rejects.toThrow("structured resume host claim is unavailable");
+
+  expect(registry.snapshot().receipts[begun.receipt.launchId]).toMatchObject({ state: "failed" });
+  expect(registry.snapshot().entries[`codex:${sessionId}`]).toMatchObject({
+    status: "idle",
+    claimEpoch: 9,
+    claimOwner: 'structured-host:{"pid":8765,"startIdentity":"winning-adopter"}',
+    structuredHost: {
+      endpoint: "stdio:winner",
+      eventCursor: 942,
+      process: { pid: 8765, startIdentity: "winning-adopter" },
+      writerClaimEpoch: 9,
+    },
+  });
+  expect(journal.snapshot().sessions.find((session) => session.conversationId === conversation.id)?.host).not.toBe("dead");
   journal.close();
 });
 
@@ -825,6 +1902,77 @@ test("startup recovery cleans a staged host whose spawn operation already failed
   });
 });
 
+test("startup recovery retains a failed staged writer when its child cannot be reaped", async () => {
+  const id = crypto.randomUUID();
+  const cwd = path.join(sandbox, `unreaped-failed-recovery-${id}`);
+  fs.mkdirSync(cwd, { recursive: true });
+  const artifactPath = path.join(cwd, `${id}.jsonl`);
+  const registry = new AgentRegistry(path.join(cwd, "registry.json"), undefined, undefined, { sqliteMode: "off" });
+  const journal = new RuntimeJournal(path.join(cwd, "runtime.sqlite"), { structuredHosts: true });
+  const client = runtimeClient(journal);
+  const launchProfile = emptyLaunchProfile({ cwd, model: "gpt-5.6-luna" });
+  const begun = registry.beginSpawnRequest({ engine: "codex", cwd, accountId: "codex-subscription", launchProfile });
+  if (begun.kind !== "created") throw new Error("spawn receipt was unavailable");
+  await client.command({
+    kind: "spawn",
+    operationId: begun.receipt.launchId,
+    idempotencyKey: begun.receipt.launchId,
+    conversationId: begun.receipt.conversationId,
+    engine: "codex",
+    cwd,
+    prompt: "crash-window prompt",
+    accountId: "codex-subscription",
+    parentConversationId: null,
+  });
+  const key = { engine: "codex" as const, sessionId: id };
+  const staged = registry.stageStructuredSpawn(begun.receipt.launchId, {
+    key,
+    artifactPath,
+    cwd,
+    accountId: "codex-subscription",
+    launchProfile,
+    status: "idle",
+    host: null,
+    structuredHost: {
+      kind: "codex-app-server",
+      endpoint: "fake:stdio",
+      process: { pid: process.pid, startIdentity: "test-process" },
+      eventCursor: 0,
+      protocolVersion: "fake-v1",
+      writerClaimEpoch: 1,
+      activeTurnRef: null,
+      pendingAttention: [],
+      activeFlags: [],
+    },
+    claimEpoch: 1,
+    claimOwner: "structured-host:test",
+    pendingAction: "spawn",
+  });
+  if (staged.kind !== "settled") throw new Error("spawn identity was unavailable");
+  const host = new UnreapableRoundTripHost("codex", artifactPath, id);
+  await bindStructuredDeliveryQueue([{ key, host }], { registry, client });
+  await client.transitionOperation(begun.receipt.launchId, "failed", { reason: "engine child failed" });
+
+  await expect(recoverPendingStructuredSpawns(registry, client))
+    .rejects.toThrow("Codex app-server child could not be reaped");
+
+  expect(registry.snapshot().receipts[begun.receipt.launchId]).toMatchObject({ state: "path-pending" });
+  expect(registry.snapshot().entries[`codex:${id}`]).toMatchObject({
+    status: "idle",
+    pendingAction: "spawn",
+    structuredHostOperationId: begun.receipt.launchId,
+    claimOwner: "structured-host:test",
+    structuredHost: {
+      endpoint: "fake:stdio",
+      process: { pid: process.pid, startIdentity: "test-process" },
+    },
+  });
+  expect(hasStructuredDeliveryHost(key)).toBeFalse();
+  expect(host.releaseCount).toBe(1);
+  expect(journal.snapshot().sessions.find((session) => session.conversationId === begun.receipt.conversationId)?.host).not.toBe("dead");
+  journal.close();
+});
+
 test("startup recovery completes an intentionally empty spawn prompt without a host send", async () => {
   const id = crypto.randomUUID();
   const cwd = path.join(sandbox, `empty-prompt-recovery-${id}`);
@@ -901,7 +2049,17 @@ test("a queued kill terminalizes after restart when its generation is confirmed 
     accountId: "codex-subscription",
     status: "dead",
     host: null,
-    structuredHost: null,
+    structuredHost: {
+      kind: "codex-app-server",
+      endpoint: "stdio:released",
+      process: null,
+      eventCursor: 942,
+      protocolVersion: "0.144.1",
+      writerClaimEpoch: 1,
+      activeTurnRef: null,
+      pendingAttention: [],
+      activeFlags: [],
+    },
     claimEpoch: 1,
     claimOwner: null,
     pendingAction: null,
@@ -926,6 +2084,7 @@ test("a queued kill terminalizes after restart when its generation is confirmed 
   });
   expect(journal.snapshot().sessions.find((session) => session.conversationId === conversation.id)?.host).toBe("hosted");
   const operationId = `kill_${id}`;
+  const deliveringOperationId = `kill_delivering_${id}`;
   await client.command({
     kind: "kill",
     operationId,
@@ -933,10 +2092,22 @@ test("a queued kill terminalizes after restart when its generation is confirmed 
     conversationId: conversation.id,
     sessionKey: key,
   });
+  await client.command({
+    kind: "kill",
+    operationId: deliveringOperationId,
+    idempotencyKey: deliveringOperationId,
+    conversationId: conversation.id,
+    sessionKey: key,
+  });
+  await client.transitionOperation(deliveringOperationId, "delivering");
 
   await bindStructuredDeliveryQueue([], { registry, client });
 
   expect((await client.operationStatus(operationId))?.receipt).toMatchObject({
+    kind: "kill",
+    status: "delivered",
+  });
+  expect((await client.operationStatus(deliveringOperationId))?.receipt).toMatchObject({
     kind: "kill",
     status: "delivered",
   });
@@ -952,16 +2123,22 @@ test("a queued kill terminalizes after restart when its generation is confirmed 
     host: "dead",
     activeTurnId: null,
   });
-  const sendOperationId = `send_after_${id}`;
-  const sent = await client.command({
-    kind: "send",
-    operationId: sendOperationId,
-    idempotencyKey: sendOperationId,
-    conversationId: conversation.id,
-    text: "must reject after kill",
-    policy: "queue",
-  });
-  expect(sent.receipt).toMatchObject({ status: "rejected", reason: "dead-host" });
+  const rejected = await Promise.all(Array.from({ length: 3 }, async (_, index) => {
+    const sendOperationId = `send_after_${index}_${id}`;
+    return client.command({
+      kind: "send",
+      operationId: sendOperationId,
+      idempotencyKey: sendOperationId,
+      conversationId: conversation.id,
+      text: "same visible text after failed adoption",
+      policy: "queue",
+    });
+  }));
+  expect(rejected.map((result) => result.receipt)).toEqual([
+    expect.objectContaining({ status: "rejected", reason: "dead-host" }),
+    expect.objectContaining({ status: "rejected", reason: "dead-host" }),
+    expect.objectContaining({ status: "rejected", reason: "dead-host" }),
+  ]);
 });
 
 test("a dead predecessor kill terminalizes without touching its live successor", async () => {

--- a/src/lib/runtime/structuredSpawn.integration.test.ts
+++ b/src/lib/runtime/structuredSpawn.integration.test.ts
@@ -344,6 +344,122 @@ test("a concurrent structured spawn replay stays pending until durable host setu
     .toEqual([expect.objectContaining({ parentConversationId: parent.id })]);
 });
 
+test("a failed resume before identity staging projects dead ownership so the following send recovers", async () => {
+  const sessionId = crypto.randomUUID();
+  const cwd = path.join(sandbox, `resume-before-identity-${sessionId}`);
+  const artifactPath = path.join(cwd, `${sessionId}.jsonl`);
+  fs.mkdirSync(cwd, { recursive: true });
+  fs.writeFileSync(artifactPath, "");
+  const registry = new AgentRegistry(path.join(cwd, "registry.json"), undefined, undefined, { sqliteMode: "off" });
+  const journal = new RuntimeJournal(path.join(cwd, "runtime.sqlite"), { structuredHosts: true });
+  const client = runtimeClient(journal);
+  const launchProfile = emptyLaunchProfile({ cwd, model: "gpt-5.6-luna" });
+  const conversation = registry.ensureConversation("codex", artifactPath, "codex-subscription");
+  const key = { engine: "codex" as const, sessionId };
+  registry.upsert({
+    key,
+    artifactPath,
+    cwd,
+    accountId: "codex-subscription",
+    launchProfile,
+    status: "dead",
+    host: null,
+    structuredHost: {
+      kind: "codex-app-server",
+      endpoint: "stdio:released",
+      process: null,
+      eventCursor: 2_907,
+      protocolVersion: "0.144.1",
+      writerClaimEpoch: 4,
+      activeTurnRef: null,
+      pendingAttention: [],
+      activeFlags: [],
+    },
+    claimEpoch: 4,
+    claimOwner: null,
+    pendingAction: null,
+  });
+  const begun = registry.beginSpawnRequest({
+    engine: "codex",
+    cwd,
+    transport: "structured",
+    accountId: "codex-subscription",
+    conversationId: conversation.id,
+    purpose: "resume-successor",
+    expectedArtifactPath: artifactPath,
+    launchProfile,
+  });
+  if (begun.kind !== "created") throw new Error("resume receipt was unavailable");
+
+  await expect(spawnStructuredConversation({
+    engine: "codex",
+    receipt: begun.receipt,
+    spec: { command: "codex", cwd, windowName: "resume", engine: "codex", transcript: artifactPath, launchProfile },
+    account: { engine: "codex", accountId: "codex-subscription", kind: "managed", home: cwd, transcriptRoot: cwd, env: { NODE_ENV: "test" } },
+    prompt: "",
+    registry,
+    client,
+  }, {
+    startHost: async () => { throw new Error("runtime event ledger sequence gap after 2907"); },
+  })).rejects.toThrow("runtime event ledger sequence gap after 2907");
+
+  expect(registry.snapshot().entries[`codex:${sessionId}`]).toMatchObject({
+    status: "dead",
+    claimOwner: null,
+    pendingAction: null,
+    structuredHost: { eventCursor: 2_907, process: null },
+  });
+  expect(journal.snapshot().sessions.find((session) => session.conversationId === conversation.id)).toMatchObject({
+    host: "dead",
+    sessionKey: key,
+    artifactPath,
+  });
+
+  let recoveryCalls = 0;
+  const delivery = await enqueueStructuredMessage({
+    path: artifactPath,
+    conversationId: conversation.id,
+    clientMessageId: "send-after-failed-adoption",
+    text: "continue after failed adoption",
+    hasImages: false,
+  }, {
+    enabled: () => true,
+    client: () => client,
+    registry: () => registry,
+    recover: async () => {
+      recoveryCalls += 1;
+      await client.append({
+        scope: { type: "session", id: conversation.id },
+        kind: "session-status",
+        payload: {
+          conversationId: conversation.id,
+          sessionKey: key,
+          hostKind: "codex-app-server",
+          host: "hosted",
+          turn: "idle",
+          provenance: "structured",
+          accountId: "codex-subscription",
+          cwd,
+          artifactPath,
+          capabilities: { steer: true, structuredAttention: true },
+        },
+      });
+      return { target: null, path: artifactPath, conversationId: conversation.id, spawned: true };
+    },
+    kick: () => {},
+  });
+
+  expect(recoveryCalls).toBe(1);
+  expect(delivery).toMatchObject({
+    ok: true,
+    structured: true,
+    spawned: true,
+    outcome: "queued",
+    receipt: { status: "queued", reason: null },
+  });
+  journal.close();
+});
+
 describe.each(["bind", "publish", "first-message"] as const)("structured spawn %s failure", (barrier) => {
   test("a concurrent replay never observes success", async () => {
     const id = crypto.randomUUID();

--- a/src/lib/runtime/structuredSpawn.integration.test.ts
+++ b/src/lib/runtime/structuredSpawn.integration.test.ts
@@ -129,6 +129,10 @@ class RoundTripHost implements SpawnedStructuredHost {
     this.identity = engine === "codex" ? { threadId: sessionId, path: artifactPath } : { sessionId };
   }
 
+  setWriterFence(fence: () => boolean): void {
+    void fence;
+  }
+
   onStateChange(listener: (state: HostState) => void): () => void {
     this.listeners.add(listener);
     return () => this.listeners.delete(listener);
@@ -250,6 +254,42 @@ class UnreapableRoundTripHost extends RoundTripHost {
   override async release(): Promise<void> {
     this.releaseCount += 1;
     throw new Error("Codex app-server child could not be reaped");
+  }
+}
+
+class LateReapingRoundTripHost extends RoundTripHost {
+  private readonly lateReapListeners = new Set<(state: HostState) => void>();
+  private reaped = false;
+
+  override onStateChange(listener: (state: HostState) => void): () => void {
+    this.lateReapListeners.add(listener);
+    return () => this.lateReapListeners.delete(listener);
+  }
+
+  override async health(): Promise<HostState> {
+    const state = await super.health();
+    return {
+      ...state,
+      status: this.reaped ? "unhosted" : "idle",
+      endpoint: this.reaped ? "stdio:released" : state.endpoint,
+      pid: this.reaped ? null : state.pid,
+      processStartIdentity: this.reaped ? null : state.processStartIdentity,
+      eventCursor: 942,
+      activeTurnRef: null,
+      pendingAttention: [],
+      activeFlags: [],
+    };
+  }
+
+  override async release(): Promise<void> {
+    this.releaseCount += 1;
+    throw new Error("Codex app-server child could not be reaped");
+  }
+
+  async completeLateReap(): Promise<void> {
+    this.reaped = true;
+    const state = await this.health();
+    for (const listener of this.lateReapListeners) listener(state);
   }
 }
 
@@ -616,7 +656,7 @@ test("an uncertain adoption cleanup retains the child process and writer claim",
       return () => { targetRegistry.releaseStructuredHostClaim(key, claimOwner, claimEpoch); };
     },
     processIdentity: () => ({ pid: process.pid, startIdentity: "uncertain-adoption-owner" }),
-  })).rejects.toThrow("Codex app-server child could not be reaped");
+  })).rejects.toThrow("runtime event ledger sequence gap after 942");
 
   expect(registry.snapshot().receipts[begun.receipt.launchId]).toMatchObject({ state: "starting" });
   expect(registry.snapshot().entries[`codex:${sessionId}`]).toMatchObject({
@@ -630,6 +670,94 @@ test("an uncertain adoption cleanup retains the child process and writer claim",
       writerClaimEpoch: 4,
     },
   });
+  expect(host.releaseCount).toBe(1);
+  journal.close();
+});
+
+test("late adoption cleanup preserves the open failure and terminalizes the released source", async () => {
+  const sessionId = crypto.randomUUID();
+  const cwd = path.join(sandbox, `late-adoption-cleanup-${sessionId}`);
+  const artifactPath = path.join(cwd, `${sessionId}.jsonl`);
+  fs.mkdirSync(cwd, { recursive: true });
+  fs.writeFileSync(artifactPath, "");
+  const registry = new AgentRegistry(path.join(cwd, "registry.json"), undefined, undefined, { sqliteMode: "off" });
+  const journal = new RuntimeJournal(path.join(cwd, "runtime.sqlite"), { structuredHosts: true });
+  const client = runtimeClient(journal);
+  const launchProfile = emptyLaunchProfile({ cwd, model: "gpt-5.6-luna" });
+  const conversation = registry.ensureConversation("codex", artifactPath, "codex-subscription");
+  registry.upsert({
+    key: { engine: "codex", sessionId },
+    artifactPath,
+    cwd,
+    accountId: "codex-subscription",
+    launchProfile,
+    status: "dead",
+    host: null,
+    structuredHost: {
+      kind: "codex-app-server",
+      endpoint: "stdio:released",
+      process: null,
+      eventCursor: 942,
+      protocolVersion: "0.144.1",
+      writerClaimEpoch: 3,
+      activeTurnRef: null,
+      pendingAttention: [],
+      activeFlags: [],
+    },
+    claimEpoch: 3,
+    claimOwner: null,
+    pendingAction: null,
+  });
+  const begun = registry.beginSpawnRequest({
+    engine: "codex",
+    cwd,
+    transport: "structured",
+    accountId: "codex-subscription",
+    conversationId: conversation.id,
+    purpose: "resume-successor",
+    expectedArtifactPath: artifactPath,
+    launchProfile,
+  });
+  if (begun.kind !== "created") throw new Error("resume receipt was unavailable");
+  const host = new LateReapingRoundTripHost("codex", artifactPath, sessionId);
+  const openFailure = new StructuredHostAdoptionCleanupError(
+    "runtime event ledger sequence gap after 942",
+    host,
+  );
+  let surfaced: unknown;
+
+  try {
+    await spawnStructuredConversation({
+      engine: "codex",
+      receipt: begun.receipt,
+      spec: { command: "codex", cwd, windowName: "resume", engine: "codex", transcript: artifactPath, launchProfile },
+      account: { engine: "codex", accountId: "codex-subscription", kind: "managed", home: cwd, transcriptRoot: cwd, env: { NODE_ENV: "test" } },
+      prompt: "",
+      registry,
+      client,
+    }, {
+      startHost: async () => { throw openFailure; },
+      processIdentity: () => ({ pid: process.pid, startIdentity: "late-adoption-owner" }),
+    });
+  } catch (error) {
+    surfaced = error;
+  }
+
+  await host.completeLateReap();
+
+  expect(registry.snapshot().receipts[begun.receipt.launchId]).toMatchObject({ state: "starting" });
+  expect(registry.snapshot().entries[`codex:${sessionId}`]).toMatchObject({
+    status: "dead",
+    claimEpoch: 4,
+    claimOwner: null,
+    structuredHost: {
+      endpoint: "stdio:released",
+      process: null,
+      eventCursor: 942,
+      writerClaimEpoch: 4,
+    },
+  });
+  expect(surfaced).toBe(openFailure);
   expect(host.releaseCount).toBe(1);
   journal.close();
 });
@@ -974,7 +1102,7 @@ test("spawn failure preserves the staged writer when its child cannot be reaped"
     },
     deliverFirst: async () => { throw new Error("first message delivery failed"); },
     processIdentity: () => ({ pid: process.pid, startIdentity: "test-process" }),
-  })).rejects.toThrow("Codex app-server child could not be reaped");
+  })).rejects.toThrow("first message delivery failed");
 
   expect(registry.snapshot().receipts[begun.receipt.launchId]).toMatchObject({ state: "path-pending" });
   expect(registry.snapshot().entries[`codex:${sessionId}`]).toMatchObject({
@@ -2141,6 +2269,89 @@ test("a queued kill terminalizes after restart when its generation is confirmed 
   ]);
 });
 
+test("a delivering kill terminalizes a stale structured wrapper owned by the live Viewer", async () => {
+  const id = crypto.randomUUID();
+  const cwd = path.join(sandbox, `absent-wrapper-kill-${id}`);
+  fs.mkdirSync(cwd, { recursive: true });
+  const artifactPath = path.join(cwd, `${id}.jsonl`);
+  const registry = new AgentRegistry(path.join(cwd, "registry.json"), undefined, undefined, { sqliteMode: "off" });
+  const journal = new RuntimeJournal(path.join(cwd, "runtime.sqlite"), { structuredHosts: true });
+  const client = runtimeClient(journal);
+  const conversation = registry.ensureConversation("claude", artifactPath, "default");
+  const key = { engine: "claude" as const, sessionId: id };
+  registry.upsert({
+    key,
+    artifactPath,
+    cwd,
+    accountId: "default",
+    status: "live",
+    host: null,
+    structuredHost: {
+      kind: "claude-broker",
+      endpoint: "stdio:2000000000",
+      process: { pid: 2_000_000_000, startIdentity: "missing-wrapper" },
+      eventCursor: 17,
+      protocolVersion: "2.1.209",
+      writerClaimEpoch: 4,
+      activeTurnRef: "completed-review-turn",
+      pendingAttention: [],
+      activeFlags: [],
+    },
+    claimEpoch: 4,
+    claimOwner: `structured-host:${JSON.stringify({
+      pid: process.pid,
+      startIdentity: null,
+    })}`,
+    pendingAction: null,
+  });
+  await client.append({
+    scope: { type: "session", id: conversation.id },
+    kind: "session-status",
+    payload: {
+      conversationId: conversation.id,
+      sessionKey: key,
+      hostKind: "claude-broker",
+      host: "hosted",
+      turn: "running",
+      provenance: "structured",
+      accountId: "default",
+      parentConversationId: null,
+      cwd,
+      artifactPath,
+      capabilities: { steer: false, structuredAttention: true },
+      activeTurnId: "completed-review-turn",
+    },
+  });
+  const operationId = `kill_absent_wrapper_${id}`;
+  await client.command({
+    kind: "kill",
+    operationId,
+    idempotencyKey: operationId,
+    conversationId: conversation.id,
+    sessionKey: key,
+  });
+  await client.transitionOperation(operationId, "delivering");
+
+  await bindStructuredDeliveryQueue([], { registry, client });
+
+  expect((await client.operationStatus(operationId))?.receipt).toMatchObject({
+    kind: "kill",
+    status: "delivered",
+  });
+  expect(registry.snapshot().entries[`claude:${id}`]).toMatchObject({
+    status: "dead",
+    structuredHost: null,
+    claimOwner: null,
+    pendingAction: null,
+  });
+  expect(journal.snapshot().sessions.find((session) => session.conversationId === conversation.id)).toMatchObject({
+    host: "dead",
+    turn: "unknown",
+    activeTurnId: null,
+  });
+  expect(await client.effectBatch(["runtime.kill"], 0)).toEqual([]);
+});
+
 test("a dead predecessor kill terminalizes without touching its live successor", async () => {
   const predecessorId = crypto.randomUUID();
   const successorId = crypto.randomUUID();
@@ -2242,7 +2453,7 @@ test("a queued kill waits when an unadopted structured process may still be live
     structuredHost: {
       kind: "codex-app-server",
       endpoint: "fake:unadopted",
-      process: { pid: process.pid, startIdentity: "potentially-live" },
+      process: { pid: process.pid, startIdentity: null },
       eventCursor: 1,
       protocolVersion: "fake-v1",
       writerClaimEpoch: 1,

--- a/src/lib/runtime/structuredSpawn.ts
+++ b/src/lib/runtime/structuredSpawn.ts
@@ -114,7 +114,14 @@ function releaseAdoptionClaim(
 
 export interface StructuredSpawnDependencies {
   startHost?(input: StructuredSpawnInput, capability: string): Promise<SpawnedStructuredHost>;
-  bindHost?(registry: AgentRegistry, key: SessionKey, host: SpawnedStructuredHost, claimOwner: string, claimEpoch: number): Promise<() => void>;
+  bindHost?(
+    registry: AgentRegistry,
+    key: SessionKey,
+    host: SpawnedStructuredHost,
+    claimOwner: string,
+    claimEpoch: number,
+    releasedStatus?: "unhosted" | "dead",
+  ): Promise<() => void>;
   publishHost?(key: SessionKey, host: SpawnedStructuredHost): Promise<() => Promise<void>>;
   deliverFirst?(input: StructuredSpawnInput, artifactPath: string): Promise<void>;
   processIdentity?(): { pid: number; startIdentity: string | null };
@@ -407,10 +414,11 @@ async function defaultBindHost(
   host: SpawnedStructuredHost,
   claimOwner: string,
   claimEpoch: number,
+  releasedStatus: "unhosted" | "dead" = "unhosted",
 ): Promise<() => void> {
   return key.engine === "codex"
-    ? await bindCodexHostPersistence(registry, key, host as CodexAppServerHost, claimOwner, claimEpoch)
-    : await bindClaudeHostPersistence(registry, key, host as ClaudeStreamBrokerHost, claimOwner, claimEpoch);
+    ? await bindCodexHostPersistence(registry, key, host as CodexAppServerHost, claimOwner, claimEpoch, releasedStatus)
+    : await bindClaudeHostPersistence(registry, key, host as ClaudeStreamBrokerHost, claimOwner, claimEpoch, releasedStatus);
 }
 
 async function defaultDeliverFirst(input: StructuredSpawnInput, artifactPath: string): Promise<void> {
@@ -548,10 +556,15 @@ export async function spawnStructuredConversation(
           host,
           adoptionClaim.claimOwner,
           adoptionClaim.claimEpoch,
+          "dead",
         );
       }
     }
-    await cleanupHost(host, binding);
+    try {
+      await cleanupHost(host, binding);
+    } catch {
+      throw error;
+    }
     let failedEntry: AgentRegistryEntry | null = null;
     let failedIdentity = resumeIdentity;
     if (key) {

--- a/src/lib/runtime/structuredSpawn.ts
+++ b/src/lib/runtime/structuredSpawn.ts
@@ -341,6 +341,11 @@ export async function spawnStructuredConversation(
   const deliverFirst = dependencies.deliverFirst ?? defaultDeliverFirst;
   const processIdentity = dependencies.processIdentity ?? (() => ({ pid: process.pid, startIdentity: procBackend.processIdentity(process.pid) }));
   const operationId = input.receipt.launchId;
+  const resumeSessionId = structuredResumeSessionId(input);
+  const resumeKey = resumeSessionId ? sessionKey(input.engine, resumeSessionId) : null;
+  const resumeIdentity = resumeKey && input.spec.transcript
+    ? { key: resumeKey, artifactPath: input.spec.transcript }
+    : null;
   let host: SpawnedStructuredHost | null = null;
   const binding: HostBinding = { stopPersistence: () => {}, unregister: async () => {} };
   let key: SessionKey | null = null;
@@ -401,20 +406,30 @@ export async function spawnStructuredConversation(
       reason: error instanceof Error ? error.message.slice(0, 240) : "structured spawn failed",
     }).catch(() => {});
     await cleanupHost(host, binding);
+    let failedEntry: { accountId: string | null; cwd: string } | null = null;
+    let failedIdentity = resumeIdentity;
     if (key) {
       input.registry.failStructuredSpawn(input.receipt.launchId, error instanceof Error ? error.message : "structured spawn failed");
       const entry = input.registry.snapshot().entries[sessionKeyId(key)];
       if (entry) {
-        await projectDeadStructuredSpawn(
-          input.client,
-          input.receipt,
-          entry,
-          `structured-spawn-failed:${input.receipt.launchId}`,
-          { key, artifactPath: entry.artifactPath },
-        ).catch(() => {});
+        failedEntry = entry;
+        failedIdentity = { key, artifactPath: entry.artifactPath };
+      }
+    } else {
+      input.registry.failSpawn(input.receipt.launchId, "structured spawn failed before host binding");
+      if (resumeIdentity) {
+        failedEntry = input.registry.snapshot().entries[sessionKeyId(resumeIdentity.key)] ?? null;
       }
     }
-    else input.registry.failSpawn(input.receipt.launchId, "structured spawn failed before host binding");
+    if (failedIdentity) {
+      await projectDeadStructuredSpawn(
+        input.client,
+        input.receipt,
+        failedEntry ?? { accountId: input.account.accountId, cwd: input.spec.cwd },
+        `structured-spawn-failed:${input.receipt.launchId}`,
+        failedIdentity,
+      ).catch(() => {});
+    }
     throw error;
   }
 }

--- a/src/lib/runtime/structuredSpawn.ts
+++ b/src/lib/runtime/structuredSpawn.ts
@@ -4,7 +4,7 @@ import type { AccountContext } from "@/lib/accounts/contracts";
 import { claudeSettingsPath } from "@/lib/accounts/claude";
 import type { LaunchProfile } from "@/lib/accounts/migration/contracts";
 import type { AgentEngine, ResumeSpec } from "@/lib/agent/cli";
-import type { AgentRegistry, SpawnReceipt, StructuredHostColumns } from "@/lib/agent/registry";
+import type { AgentRegistry, AgentRegistryEntry, SpawnReceipt, StructuredHostColumns } from "@/lib/agent/registry";
 import { sessionKey, sessionKeyId, type SessionKey } from "@/lib/agent/sessionKey";
 import type { SpawnResponse } from "@/lib/agent/spawnResponse";
 import { claudeTranscriptPath } from "@/lib/agent/transcript";
@@ -13,7 +13,7 @@ import { procBackend } from "@/lib/proc";
 import { ClaudeStreamBrokerHost } from "./claudeStreamBrokerHost";
 import { CodexAppServerHost } from "./codexAppServerHost";
 import type { RuntimeHostClient } from "./client";
-import type { EngineHost, HostState } from "./engineHost";
+import { StructuredHostAdoptionCleanupError, type EngineHost, type HostState } from "./engineHost";
 import { bindClaudeHostPersistence, bindCodexHostPersistence } from "./registry";
 import { publishStructuredDeliveryHost, releaseStructuredDeliveryHost } from "./structuredDeliveryController";
 
@@ -81,6 +81,37 @@ async function projectDeadStructuredSpawn(
   });
 }
 
+function resumeIdentityForReceipt(
+  registry: AgentRegistry,
+  receipt: SpawnReceipt,
+): { key: SessionKey; artifactPath: string } | null {
+  if (receipt.purpose !== "resume-successor") return null;
+  const conversation = registry.conversation(receipt.conversationId);
+  const source = conversation?.generations.find((generation) => generation.path === receipt.resumeSourcePath)
+    ?? conversation?.generations.at(-1);
+  return source ? { key: { engine: receipt.engine, sessionId: source.id }, artifactPath: source.path } : null;
+}
+
+function releaseAdoptionClaim(
+  registry: AgentRegistry,
+  claimed: AgentRegistryEntry,
+  terminal: boolean,
+): void {
+  if (!claimed.claimOwner || !claimed.structuredHost) return;
+  if (terminal) {
+    const projected = registry.setStructuredHostClaimed(claimed.key, {
+      ...claimed.structuredHost,
+      endpoint: "stdio:released",
+      process: null,
+      activeTurnRef: null,
+      pendingAttention: [],
+      activeFlags: [],
+    }, "dead", claimed.claimOwner, claimed.claimEpoch, true);
+    if (projected) return;
+  }
+  registry.releaseStructuredHostClaim(claimed.key, claimed.claimOwner, claimed.claimEpoch);
+}
+
 export interface StructuredSpawnDependencies {
   startHost?(input: StructuredSpawnInput, capability: string): Promise<SpawnedStructuredHost>;
   bindHost?(registry: AgentRegistry, key: SessionKey, host: SpawnedStructuredHost, claimOwner: string, claimEpoch: number): Promise<() => void>;
@@ -123,6 +154,34 @@ export async function recoverPendingStructuredSpawns(
         reason = operation.receipt.reason
           ?? `structured spawn operation ended as ${operation.receipt.status} before identity staging`;
       }
+      const identity = resumeIdentityForReceipt(registry, receipt);
+      let claimed: AgentRegistryEntry | null = null;
+      if (identity) {
+        const entry = registry.snapshot().entries[sessionKeyId(identity.key)];
+        if (entry?.structuredHost) {
+          claimed = registry.claimStructuredHost(identity.key, {
+            pid: process.pid,
+            startIdentity: procBackend.processIdentity(process.pid),
+          }, { allowUnhosted: true });
+          if (!claimed?.claimOwner) {
+            registry.failStructuredSpawn(receipt.launchId, reason);
+            continue;
+          }
+        }
+        try {
+          await projectDeadStructuredSpawn(
+            client,
+            receipt,
+            entry ?? { accountId: receipt.accountId, cwd: receipt.cwd },
+            `structured-spawn-failed:${receipt.launchId}`,
+            identity,
+          );
+        } catch (error) {
+          if (claimed) releaseAdoptionClaim(registry, claimed, false);
+          throw error;
+        }
+        if (claimed) releaseAdoptionClaim(registry, claimed, true);
+      }
       registry.failStructuredSpawn(receipt.launchId, reason);
       continue;
     }
@@ -131,17 +190,59 @@ export async function recoverPendingStructuredSpawns(
     const operation = await client.operationStatus(receipt.launchId);
     const status = operation?.receipt.status;
     if (status && FAILED_SPAWN_OPERATION_STATUSES.has(status)) {
-      if (entry) await projectDeadStructuredSpawn(
-        client,
-        receipt,
-        entry,
-        `structured-spawn-failed:${receipt.launchId}`,
-      );
+      const stagedByAnotherOperation = typeof entry?.structuredHostOperationId === "string"
+        && entry.structuredHostOperationId !== receipt.launchId;
+      if (stagedByAnotherOperation) {
+        registry.failSpawn(
+          receipt.launchId,
+          operation?.receipt.reason ?? `structured spawn operation ended as ${status}`,
+        );
+        continue;
+      }
+      const ownedByFailedOperation = entry?.structuredHostOperationId === receipt.launchId
+        || (entry?.structuredHostOperationId === undefined && entry?.pendingAction === "spawn");
+      let recoveryClaim: AgentRegistryEntry | null = null;
+      let releasedOwnedHost = false;
+      if (entry?.structuredHost && !ownedByFailedOperation) {
+        recoveryClaim = registry.claimStructuredHost(receipt.key, {
+          pid: process.pid,
+          startIdentity: procBackend.processIdentity(process.pid),
+        }, { allowUnhosted: true });
+        if (!recoveryClaim?.claimOwner) {
+          registry.failSpawn(
+            receipt.launchId,
+            operation?.receipt.reason ?? `structured spawn operation ended as ${status}`,
+          );
+          continue;
+        }
+      }
+      try {
+        const releasedHost = await releaseStructuredDeliveryHost(receipt.key);
+        releasedOwnedHost = ownedByFailedOperation && releasedHost;
+        if (entry?.structuredHost && ownedByFailedOperation && !releasedHost) {
+          recoveryClaim = registry.claimStructuredHost(receipt.key, {
+            pid: process.pid,
+            startIdentity: procBackend.processIdentity(process.pid),
+          }, { allowUnhosted: true });
+          if (!recoveryClaim?.claimOwner) {
+            throw new Error(`structured spawn failed host is still owned for ${receipt.launchId}`);
+          }
+        }
+        if (entry) await projectDeadStructuredSpawn(
+          client,
+          receipt,
+          entry,
+          `structured-spawn-failed:${receipt.launchId}`,
+        );
+      } catch (error) {
+        const failedClaim = recoveryClaim ?? (releasedOwnedHost ? entry : null);
+        if (failedClaim) releaseAdoptionClaim(registry, failedClaim, false);
+        throw error;
+      }
       registry.failStructuredSpawn(
         receipt.launchId,
         operation?.receipt.reason ?? `structured spawn operation ended as ${status}`,
       );
-      await releaseStructuredDeliveryHost(receipt.key).catch(() => false);
       continue;
     }
     if (status === "delivered") {
@@ -154,6 +255,7 @@ export async function recoverPendingStructuredSpawns(
         if (finalized.kind === "conflict") throw new Error(`structured spawn recovery conflict: ${finalized.code}`);
       } else {
         if (!entry) throw new Error(`structured spawn recovery identity is unavailable for ${receipt.launchId}`);
+        await releaseStructuredDeliveryHost(receipt.key);
         await projectDeadStructuredSpawn(
           client,
           receipt,
@@ -162,7 +264,6 @@ export async function recoverPendingStructuredSpawns(
         );
         const settled = registry.recoverDeliveredStructuredSpawn(receipt.launchId);
         if (settled.kind === "conflict") throw new Error(`structured spawn recovery conflict: ${settled.code}`);
-        await releaseStructuredDeliveryHost(receipt.key).catch(() => false);
       }
       continue;
     }
@@ -193,14 +294,14 @@ export async function recoverPendingStructuredSpawns(
   }
 }
 
-function pendingColumns(engine: AgentEngine): StructuredHostColumns {
+function pendingColumns(engine: AgentEngine, eventCursor = 0, writerClaimEpoch = 0): StructuredHostColumns {
   return {
     kind: engine === "codex" ? "codex-app-server" : "claude-broker",
     endpoint: "stdio:pending",
     process: null,
-    eventCursor: 0,
+    eventCursor,
     protocolVersion: null,
-    writerClaimEpoch: 0,
+    writerClaimEpoch,
     activeTurnRef: null,
     pendingAttention: [],
     activeFlags: [],
@@ -252,6 +353,13 @@ async function defaultStartHost(input: StructuredSpawnInput, capability: string)
   const profile = input.spec.launchProfile ?? {} as LaunchProfile;
   const env = { ...input.account.env, LLV_SPAWN_CAPABILITY: capability };
   const resumeSessionId = structuredResumeSessionId(input);
+  const initialEventCursor = resumeSessionId
+    ? input.registry.snapshot().entries[sessionKeyId({ engine: input.engine, sessionId: resumeSessionId })]?.structuredHost?.eventCursor
+    : undefined;
+  if (initialEventCursor !== undefined
+    && (!Number.isSafeInteger(initialEventCursor) || initialEventCursor < 0)) {
+    throw new Error("structured resume event cursor is invalid");
+  }
   if (input.engine === "codex") {
     const options = {
       cwd: input.spec.cwd,
@@ -262,6 +370,7 @@ async function defaultStartHost(input: StructuredSpawnInput, capability: string)
       allowSubagents: profile.allowSubagents,
       sandbox: profile.readOnly ? "read-only" : "danger-full-access",
       approvalPolicy: profile.permissionMode ?? undefined,
+      initialEventCursor,
       env,
     };
     return resumeSessionId
@@ -278,6 +387,7 @@ async function defaultStartHost(input: StructuredSpawnInput, capability: string)
     model: profile.model ?? undefined,
     effort: profile.effort ?? undefined,
     permissionMode: profile.permissionMode ?? "default",
+    initialEventCursor,
     env,
   };
   return resumeSessionId
@@ -288,11 +398,7 @@ async function defaultStartHost(input: StructuredSpawnInput, capability: string)
 export function structuredResumeSessionId(
   input: Pick<StructuredSpawnInput, "receipt" | "registry">,
 ): string | null {
-  if (input.receipt.purpose !== "resume-successor") return null;
-  const conversation = input.registry.conversation(input.receipt.conversationId);
-  const source = conversation?.generations.find((generation) => generation.path === input.receipt.resumeSourcePath)
-    ?? conversation?.generations.at(-1);
-  return source?.id ?? null;
+  return resumeIdentityForReceipt(input.registry, input.receipt)?.key.sessionId ?? null;
 }
 
 async function defaultBindHost(
@@ -326,9 +432,15 @@ async function defaultDeliverFirst(input: StructuredSpawnInput, artifactPath: st
 }
 
 async function cleanupHost(host: SpawnedStructuredHost | null, binding: HostBinding): Promise<void> {
-  await binding.unregister().catch(() => {});
+  await host?.release();
+  let unregisterError: unknown = null;
+  try {
+    await binding.unregister();
+  } catch (error) {
+    unregisterError = error;
+  }
   binding.stopPersistence();
-  await host?.release().catch(() => {});
+  if (unregisterError) throw unregisterError;
 }
 
 export async function spawnStructuredConversation(
@@ -343,12 +455,13 @@ export async function spawnStructuredConversation(
   const operationId = input.receipt.launchId;
   const resumeSessionId = structuredResumeSessionId(input);
   const resumeKey = resumeSessionId ? sessionKey(input.engine, resumeSessionId) : null;
-  const resumeIdentity = resumeKey && input.spec.transcript
-    ? { key: resumeKey, artifactPath: input.spec.transcript }
-    : null;
+  const resumeIdentity = resumeIdentityForReceipt(input.registry, input.receipt);
   let host: SpawnedStructuredHost | null = null;
   const binding: HostBinding = { stopPersistence: () => {}, unregister: async () => {} };
   let key: SessionKey | null = null;
+  let adoptionClaim: AgentRegistryEntry | null = null;
+  let adoptionClaimTransferred = false;
+  let adoptionClaimContended = false;
   try {
     await input.client.command({
       kind: "spawn",
@@ -363,9 +476,22 @@ export async function spawnStructuredConversation(
       ...(input.receipt.purpose === "resume-successor" ? { sessionId: structuredResumeSessionId(input) } : {}),
     });
     const capability = input.registry.rotateSpawnCapabilityForReceipt(input.receipt.launchId);
+    const resumeEntry = resumeKey ? input.registry.snapshot().entries[sessionKeyId(resumeKey)] : null;
+    if (resumeEntry?.structuredHost) {
+      adoptionClaim = input.registry.claimStructuredHost(resumeKey!, processIdentity(), { allowUnhosted: true });
+      if (!adoptionClaim?.claimOwner) {
+        adoptionClaimContended = true;
+        throw new Error("structured resume host claim is unavailable");
+      }
+    }
     host = await startHost(input, capability);
     const identity = hostIdentity(input.engine, host, input);
     key = identity.key;
+    if (resumeKey && sessionKeyId(key) !== sessionKeyId(resumeKey)) {
+      throw new Error("structured resume returned a different session identity");
+    }
+    const stagedClaimEpoch = adoptionClaim?.claimEpoch ?? 0;
+    const stagedClaimOwner = adoptionClaim?.claimOwner ?? null;
     const staged = input.registry.stageStructuredSpawn(input.receipt.launchId, {
       key,
       artifactPath: identity.path,
@@ -374,14 +500,21 @@ export async function spawnStructuredConversation(
       launchProfile: input.spec.launchProfile,
       status: "unhosted",
       host: null,
-      structuredHost: pendingColumns(input.engine),
-      claimEpoch: 0,
-      claimOwner: null,
+      structuredHost: pendingColumns(
+        input.engine,
+        adoptionClaim?.structuredHost?.eventCursor ?? 0,
+        stagedClaimEpoch,
+      ),
+      claimEpoch: stagedClaimEpoch,
+      claimOwner: stagedClaimOwner,
       pendingAction: "spawn",
     });
     if (staged.kind === "conflict") throw new Error(`structured spawn registry conflict: ${staged.code}`);
-    const claimed = input.registry.claimStructuredHost(key, processIdentity(), { allowUnhosted: true });
+    const claimed = adoptionClaim
+      ? staged.entry
+      : input.registry.claimStructuredHost(key, processIdentity(), { allowUnhosted: true });
     if (!claimed?.claimOwner) throw new Error("structured spawn host claim is unavailable");
+    adoptionClaimTransferred = adoptionClaim !== null;
     binding.stopPersistence = await bindHost(input.registry, key, host, claimed.claimOwner, claimed.claimEpoch);
     binding.unregister = await publishHost(key, host);
     await deliverFirst(input, identity.path);
@@ -405,30 +538,60 @@ export async function spawnStructuredConversation(
     await input.client.transitionOperation(operationId, "failed", {
       reason: error instanceof Error ? error.message.slice(0, 240) : "structured spawn failed",
     }).catch(() => {});
+    if (!host && error instanceof StructuredHostAdoptionCleanupError) {
+      host = error.host as SpawnedStructuredHost;
+      if (resumeKey && adoptionClaim?.claimOwner) {
+        key = resumeKey;
+        binding.stopPersistence = await bindHost(
+          input.registry,
+          resumeKey,
+          host,
+          adoptionClaim.claimOwner,
+          adoptionClaim.claimEpoch,
+        );
+      }
+    }
     await cleanupHost(host, binding);
-    let failedEntry: { accountId: string | null; cwd: string } | null = null;
+    let failedEntry: AgentRegistryEntry | null = null;
     let failedIdentity = resumeIdentity;
     if (key) {
-      input.registry.failStructuredSpawn(input.receipt.launchId, error instanceof Error ? error.message : "structured spawn failed");
       const entry = input.registry.snapshot().entries[sessionKeyId(key)];
       if (entry) {
         failedEntry = entry;
         failedIdentity = { key, artifactPath: entry.artifactPath };
       }
     } else {
-      input.registry.failSpawn(input.receipt.launchId, "structured spawn failed before host binding");
       if (resumeIdentity) {
         failedEntry = input.registry.snapshot().entries[sessionKeyId(resumeIdentity.key)] ?? null;
       }
     }
-    if (failedIdentity) {
-      await projectDeadStructuredSpawn(
-        input.client,
-        input.receipt,
-        failedEntry ?? { accountId: input.account.accountId, cwd: input.spec.cwd },
-        `structured-spawn-failed:${input.receipt.launchId}`,
-        failedIdentity,
-      ).catch(() => {});
+    if (typeof failedEntry?.structuredHostOperationId === "string"
+      && failedEntry.structuredHostOperationId !== input.receipt.launchId) {
+      failedIdentity = null;
+    }
+    let projectionSucceeded = true;
+    if (failedIdentity && !adoptionClaimContended) {
+      try {
+        await projectDeadStructuredSpawn(
+          input.client,
+          input.receipt,
+          failedEntry ?? { accountId: input.account.accountId, cwd: input.spec.cwd },
+          `structured-spawn-failed:${input.receipt.launchId}`,
+          failedIdentity,
+        );
+      } catch {
+        projectionSucceeded = false;
+      }
+    }
+    if (adoptionClaim && (!adoptionClaimTransferred || !projectionSucceeded)) {
+      releaseAdoptionClaim(input.registry, adoptionClaim, projectionSucceeded);
+    }
+    if (projectionSucceeded) {
+      if (key) {
+        input.registry.failStructuredSpawn(input.receipt.launchId, error instanceof Error ? error.message : "structured spawn failed");
+      } else {
+        input.registry.failSpawn(input.receipt.launchId, "structured spawn failed before host binding");
+      }
     }
     throw error;
   }


### PR DESCRIPTION
## Summary

- Selects the durable event-ledger tail as authoritative whenever durable records exist, with legacy registry watermark support for empty ledgers.
- Buffers bounded Codex JSON-RPC notifications until ledger restore and history reconciliation finish.
- Projects failed pre-identity resume attempts as dead, releases ownership, and lets the next send enter normal recovery.
- Emits bounded typed cursor recovery diagnostics and rejects unrepresentable successor sequences.

## Root cause

Codex could emit approval and status notifications while initialization and thread resume were still running. The host sequenced those notifications from the registry cursor before loading the durable ledger. Registry and disk drift around durable sequence 2907 could append a gap. The early spawn failure had no staged host key, leaving the runtime projection in registering state and causing the next send to observe no claim.

## Verification

- Focused runtime, registry, and journal matrix: 328 passed, 3 Claude environment skips, 0 failures.
- Full repository suite: 2,891 passed, 3 Claude environment skips, 0 failures.
- Real Codex subscription late-attach, steer, and restart-resume integration passed.
- TypeScript no-emit check passed.
- Changed-file ESLint passed.
- Production build passed.
- Diff whitespace and no-UI path checks passed.
- Lifecycle, concurrency, crash-tail, and security self-review passed.

Closes #308