### PR TITLE
Show admitted spawns immediately and reconcile launch retries

### DIFF
--- a/src/app/api/conversations/route.test.ts
+++ b/src/app/api/conversations/route.test.ts
@@ -6,6 +6,7 @@ import path from "node:path";
 import { emptyLaunchProfile } from "@/lib/accounts/migration/contracts";
 import { AgentRegistry, setAgentRegistryForTests } from "@/lib/agent/registry";
 import { replaceConversationCatalog } from "@/lib/scanner/conversationCatalog";
+import { projectForCwd } from "@/lib/scanner/describe";
 import { writeSessionTitle } from "@/lib/session/titleStore";
 
 import { GET } from "./route";
@@ -144,11 +145,11 @@ test("search finds a capped-out conversation by its registry launch title", asyn
   expect(body.items).toEqual([expect.objectContaining({
     path: transcript,
     title: "Launch amber orchard",
-    project: "launch-project",
+    project: projectForCwd(sandbox),
   })]);
 });
 
-test("an empty-query project list uses the registry launch project", async () => {
+test("an empty-query project list uses the registry launch cwd", async () => {
   const transcript = path.join(sandbox, "launch-project.jsonl");
   fs.writeFileSync(transcript, JSON.stringify({ type: "user", message: { content: "Launch project prompt" } }) + "\n");
   const stat = fs.statSync(transcript);
@@ -174,14 +175,15 @@ test("an empty-query project list uses the registry launch project", async () =>
     observedAt: "2026-07-13T00:00:00.000Z",
   }]);
 
-  const response = await GET(new Request("http://127.0.0.1/api/conversations?project=launch-project"));
+  const canonicalProject = projectForCwd(sandbox)!;
+  const response = await GET(new Request(`http://127.0.0.1/api/conversations?project=${encodeURIComponent(canonicalProject)}`));
   const body = await response.json() as { items: Array<{ path: string; title: string; project: string }> };
 
   expect(response.status).toBe(200);
   expect(body.items).toEqual([expect.objectContaining({
     path: transcript,
     title: "Launch title",
-    project: "launch-project",
+    project: canonicalProject,
   })]);
 });
 

--- a/src/app/api/files/response.ts
+++ b/src/app/api/files/response.ts
@@ -6,6 +6,7 @@ import { NextResponse } from "next/server";
 
 import { listFilesWithProjectCatalog, pinnedPathsFor } from "@/lib/scanner";
 import { agentRegistry, conversationLookupFromSnapshot } from "@/lib/agent/registry";
+import { preallocatedStructuredSpawnCards } from "@/lib/agent/spawnProjection";
 import { conversationCatalogSnapshot } from "@/lib/scanner/conversationCatalog";
 import { pidAlive, readPpid } from "@/lib/scanner/process";
 import { loadFlows } from "@/lib/flows/store";
@@ -22,7 +23,7 @@ import { readAuthorshipEvidence } from "@/lib/reaperAuthorship";
 import { overlaySessionTitles } from "@/lib/session/titleProjection";
 import { tmuxEndpointHealth } from "@/lib/tmux";
 import { claudeProjectRootFor, codexSessionRootFor } from "@/lib/scanner/roots";
-import { projectRootForCwd } from "@/lib/scanner/describe";
+import { projectInfoFromCwd, projectRootForCwd } from "@/lib/scanner/describe";
 import { projectDirectoryFallbacks } from "@/lib/scanner/projectDirectories";
 import type { FilesResponse, ProjectCatalogEntry } from "@/lib/types";
 
@@ -44,7 +45,8 @@ function projectedProjectCatalog(
   for (const conversation of Object.values(snapshot.conversations)) {
     const latest = conversation.generations.at(-1);
     if (!latest) continue;
-    if (latest.launchProfile.project) projectByPath.set(latest.path, latest.launchProfile.project);
+    const project = projectInfoFromCwd(latest.launchProfile.cwd)?.project ?? latest.launchProfile.project;
+    if (project) projectByPath.set(latest.path, project);
     for (const generation of conversation.generations) {
       if (generation.path !== latest.path) archivedPaths.add(generation.path);
     }
@@ -78,6 +80,7 @@ export async function buildFilesResponse(request: Request, dependencies: FilesRo
   // the external scheduler, keeping repeated GETs byte-stable for state files.
   const registry = agentRegistry();
   const registrySnapshot = registry.snapshot();
+  files.push(...preallocatedStructuredSpawnCards(files, registrySnapshot));
   const conversationLookup = conversationLookupFromSnapshot(registrySnapshot);
   const conversationForPath = (pathname: string) => conversationLookup.conversationForPath(pathname);
   const filesByPath = new Map(files.map((file) => [file.path, file]));
@@ -108,7 +111,9 @@ export async function buildFilesResponse(request: Request, dependencies: FilesRo
       path: parentPath,
       root: parentConversation.engine === "codex" ? "codex-sessions" as const : "claude-projects" as const,
       name: rootPath ? path.relative(rootPath, parentPath) : path.basename(parentPath),
-      project: parentGeneration.launchProfile.project ?? child.project,
+      project: projectInfoFromCwd(parentGeneration.launchProfile.cwd)?.project
+        ?? parentGeneration.launchProfile.project
+        ?? child.project,
       cwd: parentGeneration.launchProfile.cwd,
       projectRoot: parentGeneration.launchProfile.cwd ? projectRootForCwd(parentGeneration.launchProfile.cwd) : null,
       title: parentGeneration.launchProfile.title ?? path.basename(parentPath, path.extname(parentPath)),
@@ -140,6 +145,7 @@ export async function buildFilesResponse(request: Request, dependencies: FilesRo
     || conversation.continuityPaths.includes(pathname);
   for (const file of files) {
     if (file.engine !== "claude" && file.engine !== "codex") continue;
+    if (file.spawn) continue;
     const conversation = Object.values(registrySnapshot.conversations).find((candidate) =>
       candidate.engine === file.engine && ownsPath(candidate, file.path));
     if (!conversation) continue;
@@ -158,7 +164,7 @@ export async function buildFilesResponse(request: Request, dependencies: FilesRo
     if (latest?.path === file.path) {
       const profile = latest.launchProfile;
       file.title = profile.title ?? file.title;
-      file.project = profile.project ?? file.project;
+      file.project = projectInfoFromCwd(profile.cwd)?.project ?? profile.project ?? file.project;
       file.launchModel = profile.model ?? file.launchModel;
       file.effort = profile.effort ?? file.effort;
       file.goal = profile.goal ?? file.goal;

--- a/src/app/api/files/route.test.ts
+++ b/src/app/api/files/route.test.ts
@@ -7,6 +7,7 @@ import { emptyLaunchProfile } from "@/lib/accounts/migration/contracts";
 import { withoutArchivedPredecessors } from "@/lib/accounts/identity";
 import { agentRegistry, AgentRegistry, setAgentRegistryForTests } from "@/lib/agent/registry";
 import { replaceConversationCatalog } from "@/lib/scanner/conversationCatalog";
+import { projectInfoFromCwd } from "@/lib/scanner/describe";
 import { writeSessionTitle } from "@/lib/session/titleStore";
 import type { FileEntry } from "@/lib/types";
 import { createFilesClientCache } from "@/hooks/useFiles";
@@ -1035,6 +1036,160 @@ function file(path: string): FileEntry {
   };
 }
 
+test("a no-transcript structured reservation projects its card from canonical cwd truth", async () => {
+  const registry = agentRegistry();
+  const cwd = process.cwd();
+  const begun = registry.beginSpawnRequest({
+    engine: "codex",
+    cwd,
+    transport: "structured",
+    accountId: "terra",
+    clientAttemptId: "attempt_93c42855_stikon",
+    requestDigest: "9".repeat(64),
+    launchProfile: emptyLaunchProfile({ cwd, model: "gpt-5.6-sol", effort: "xhigh" }),
+  });
+  if (begun.kind !== "created") throw new Error("expected a structured reservation");
+  scannedFiles = [];
+
+  const response = await GET(new Request("http://127.0.0.1/api/files?project=latand"));
+  const body = await response.json() as { files: Array<FileEntry & { spawn?: Record<string, unknown> }> };
+  const card = body.files.find((entry) => entry.conversationId === begun.receipt.conversationId);
+
+  expect(card).toMatchObject({
+    path: `spawn:${begun.receipt.launchId}`,
+    project: projectInfoFromCwd(cwd)?.project,
+    cwd,
+    projectRoot: path.resolve(cwd, "../.."),
+    engine: "codex",
+    kind: "session",
+    activity: "live",
+    proc: null,
+    renamable: false,
+    conversationId: begun.receipt.conversationId,
+    launchModel: "gpt-5.6-sol",
+    effort: "xhigh",
+    spawn: {
+      launchId: begun.receipt.launchId,
+      clientAttemptId: "attempt_93c42855_stikon",
+      state: "starting",
+      initialMessage: "pending",
+      retrySafe: false,
+      error: null,
+    },
+  });
+  expect(card?.project).not.toBe("latand");
+});
+
+test("a selected sidebar project cannot replace canonical cwd attribution after transcript discovery", async () => {
+  const registry = agentRegistry();
+  const cwd = process.cwd();
+  const artifactPath = path.join(stateDir, "cwd-attribution-9173e9a2.jsonl");
+  const begun = registry.beginSpawnRequest({
+    engine: "codex",
+    cwd,
+    transport: "structured",
+    accountId: "terra",
+    launchProfile: emptyLaunchProfile({ cwd, project: "latand" }),
+  });
+  if (begun.kind !== "created") throw new Error("expected a structured reservation");
+  registry.settleSpawn(begun.receipt.launchId, {
+    key: { engine: "codex", sessionId: "cwd-attribution-9173e9a2" },
+    artifactPath,
+    cwd,
+    accountId: "terra",
+    launchProfile: emptyLaunchProfile({ cwd, project: "latand" }),
+    status: "idle",
+    host: null,
+    claimEpoch: 0,
+    claimOwner: null,
+    pendingAction: null,
+  });
+  const scanned = file(artifactPath);
+  scanned.project = "latand";
+  scanned.cwd = cwd;
+  scannedFiles = [scanned];
+
+  const response = await GET(new Request("http://127.0.0.1/api/files?project=latand"));
+  const body = await response.json() as { files: FileEntry[] };
+  const entry = body.files.find((candidate) => candidate.conversationId === begun.receipt.conversationId);
+
+  expect(entry?.project).toBe(projectInfoFromCwd(cwd)?.project);
+  expect(entry?.project).not.toBe("latand");
+});
+
+test("a staged structured card stays binding until its initial message is admitted", async () => {
+  const registry = agentRegistry();
+  const cwd = process.cwd();
+  const artifactPath = path.join(stateDir, "e9e8a4b4.jsonl");
+  const begun = registry.beginSpawnRequest({
+    engine: "codex",
+    cwd,
+    transport: "structured",
+    accountId: "stikon",
+    clientAttemptId: "attempt_e9e8a4b4_stikon",
+  });
+  if (begun.kind !== "created") throw new Error("expected a structured reservation");
+  registry.stageStructuredSpawn(begun.receipt.launchId, {
+    key: { engine: "codex", sessionId: "e9e8a4b4" },
+    artifactPath,
+    cwd,
+    accountId: "stikon",
+    status: "unhosted",
+    host: null,
+    structuredHost: null,
+    claimEpoch: 0,
+    claimOwner: null,
+    pendingAction: "spawn",
+  });
+  scannedFiles = [];
+
+  const bindingResponse = await GET(new Request("http://127.0.0.1/api/files"));
+  const bindingBody = await bindingResponse.json() as { files: FileEntry[] };
+  expect(bindingBody.files.find((entry) => entry.conversationId === begun.receipt.conversationId)?.spawn)
+    .toMatchObject({ state: "binding", initialMessage: "pending" });
+
+  registry.holdDelivery(begun.receipt.conversationId, "Own issue #282", `spawn_${begun.receipt.launchId}`);
+  const queuedResponse = await GET(new Request("http://127.0.0.1/api/files"));
+  const queuedBody = await queuedResponse.json() as { files: FileEntry[] };
+  expect(queuedBody.files.find((entry) => entry.conversationId === begun.receipt.conversationId)?.spawn)
+    .toMatchObject({ state: "queued", initialMessage: "queued" });
+});
+
+test("transcript discovery suppresses the preallocated card for the same conversation", async () => {
+  const registry = agentRegistry();
+  const cwd = process.cwd();
+  const artifactPath = path.join(stateDir, "9173e9a2.jsonl");
+  const begun = registry.beginSpawnRequest({
+    engine: "codex",
+    cwd,
+    transport: "structured",
+    accountId: "terra",
+    clientAttemptId: "p0_282_duplicate_suppression_20260716_a1",
+  });
+  if (begun.kind !== "created") throw new Error("expected a structured reservation");
+  registry.stageStructuredSpawn(begun.receipt.launchId, {
+    key: { engine: "codex", sessionId: "9173e9a2" },
+    artifactPath,
+    cwd,
+    accountId: "terra",
+    status: "idle",
+    host: null,
+    structuredHost: null,
+    claimEpoch: 0,
+    claimOwner: null,
+    pendingAction: null,
+  });
+  scannedFiles = [file(artifactPath)];
+
+  const response = await GET(new Request("http://127.0.0.1/api/files"));
+  const body = await response.json() as { files: FileEntry[] };
+  const matches = body.files.filter((entry) => entry.conversationId === begun.receipt.conversationId);
+
+  expect(matches).toHaveLength(1);
+  expect(matches[0]?.path).toBe(artifactPath);
+  expect(matches[0]?.spawn).toBeUndefined();
+});
+
 test("a provisional Codex fork projects as archived history of its stable conversation", async () => {
   const registry = agentRegistry();
   const sourcePath = "/sessions/source-019f4906-3f67-7b72-9fbc-9ec3b5ad1301.jsonl";
@@ -1326,7 +1481,7 @@ test("a custom session title (issue #33) overrides the derived title and keeps i
   expect(entry?.renamable).toBe(true);
 });
 
-test("the files rail reaggregates uncapped conversations under registry launch projects", async () => {
+test("the files rail reaggregates uncapped conversations under canonical cwd projects", async () => {
   const registry = agentRegistry();
   const transcript = path.join(stateDir, "capped-out-launch-project.jsonl");
   fs.writeFileSync(transcript, JSON.stringify({ type: "user", message: { content: "Catalog prompt" } }) + "\n");
@@ -1357,7 +1512,9 @@ test("the files rail reaggregates uncapped conversations under registry launch p
   const response = await GET(new Request("http://127.0.0.1/api/files"));
   const body = await response.json() as { projectCatalog: Array<{ project: string; conversations: number }> };
 
-  expect(body.projectCatalog).toEqual([expect.objectContaining({ project: "effective-project", conversations: 1 })]);
+  expect(body.projectCatalog).toEqual([
+    expect.objectContaining({ project: projectInfoFromCwd(stateDir)?.project, conversations: 1 }),
+  ]);
 });
 
 test("an unreadable pipelines store degrades to pipelinesError without failing the poll", async () => {

--- a/src/app/api/spawn/route.test.ts
+++ b/src/app/api/spawn/route.test.ts
@@ -42,6 +42,7 @@ function structuredRouteDependencies(cwd: string): Parameters<typeof POST.withDe
       env: { NODE_ENV: "test" },
     }),
     runtimeHostClient: () => ({} as RuntimeHostClient),
+    defer: (work) => { void work(); },
     spawnStructuredConversation: async (input) => ({
       ok: true,
       target: null,
@@ -51,9 +52,14 @@ function structuredRouteDependencies(cwd: string): Parameters<typeof POST.withDe
       conversationId: input.receipt.conversationId,
       launched: true,
       retrySafe: false,
+      initialMessage: "delivered",
       state: "settled",
     }),
   };
+}
+
+async function runDeferred(work: (() => Promise<void>) | null): Promise<void> {
+  if (work) await work();
 }
 
 test("agent-initiated spawn without lineage returns a teaching 400", async () => {
@@ -349,6 +355,271 @@ test("structured spawn flag reaches the pane-less capability gate", async () => 
   }
 });
 
+test("admitted structured spawn returns its reserved card identity while host binding is delayed", async () => {
+  const cwd = fs.mkdtempSync(path.join(routeSandbox, "p0-282-delayed-binding-"));
+  const previousTransport = process.env.LLV_SPAWN_TRANSPORT;
+  const previousHosts = process.env.LLV_STRUCTURED_HOSTS;
+  const previousEvents = process.env.LLV_RUNTIME_EVENTS;
+  const previousSocket = process.env.LLV_RUNTIME_HOST_SOCKET;
+  const previousUi = process.env.NEXT_PUBLIC_RUNTIME_UI;
+  process.env.LLV_SPAWN_TRANSPORT = "structured";
+  process.env.LLV_STRUCTURED_HOSTS = "1";
+  process.env.LLV_RUNTIME_EVENTS = "1";
+  process.env.LLV_RUNTIME_HOST_SOCKET = path.join(cwd, "runtime.sock");
+  process.env.NEXT_PUBLIC_RUNTIME_UI = "1";
+  let deferred: (() => Promise<void>) | null = null;
+  let releaseBinding!: () => void;
+  const binding = new Promise<void>((resolve) => { releaseBinding = resolve; });
+  let launchStarted = false;
+  const dependencies = {
+    ...structuredRouteDependencies(cwd),
+    defer: (work: () => Promise<void>) => { deferred = work; },
+    spawnStructuredConversation: async (input: Parameters<NonNullable<Parameters<typeof POST.withDependencies>[1]>["spawnStructuredConversation"]>[0]) => {
+      launchStarted = true;
+      await binding;
+      return {
+        ok: true as const,
+        target: null,
+        path: path.join(cwd, "delayed.jsonl"),
+        launchId: input.receipt.launchId,
+        conversationId: input.receipt.conversationId,
+        launched: true,
+        retrySafe: false,
+        initialMessage: "delivered" as const,
+        state: "settled" as const,
+      };
+    },
+  } as Parameters<typeof POST.withDependencies>[1];
+  try {
+    const responsePromise = POST.withDependencies(new NextRequest("http://127.0.0.1:8898/api/spawn", {
+      method: "POST",
+      headers: {
+        host: "127.0.0.1:8898",
+        origin: "http://127.0.0.1:8898",
+        "sec-fetch-site": "same-origin",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        engine: "claude",
+        cwd,
+        prompt: "Own issue #282",
+        clientAttemptId: "p0_282_spawn_visibility_20260716_a1",
+      }),
+    }), dependencies);
+    const response = await Promise.race([
+      responsePromise,
+      new Promise<null>((resolve) => setTimeout(() => resolve(null), 25)),
+    ]);
+
+    releaseBinding();
+    if (!response) await responsePromise;
+
+    expect(response).not.toBeNull();
+    expect(response?.status).toBe(202);
+    expect(await response?.json()).toMatchObject({
+      ok: true,
+      state: "starting",
+      launched: false,
+      retrySafe: false,
+      launchId: expect.any(String),
+      conversationId: expect.stringMatching(/^conversation_/),
+      initialMessage: "pending",
+    });
+    expect(launchStarted).toBeFalse();
+    expect(deferred).not.toBeNull();
+    await runDeferred(deferred);
+    expect(launchStarted).toBeTrue();
+  } finally {
+    releaseBinding();
+    if (previousTransport === undefined) delete process.env.LLV_SPAWN_TRANSPORT;
+    else process.env.LLV_SPAWN_TRANSPORT = previousTransport;
+    if (previousHosts === undefined) delete process.env.LLV_STRUCTURED_HOSTS;
+    else process.env.LLV_STRUCTURED_HOSTS = previousHosts;
+    if (previousEvents === undefined) delete process.env.LLV_RUNTIME_EVENTS;
+    else process.env.LLV_RUNTIME_EVENTS = previousEvents;
+    if (previousSocket === undefined) delete process.env.LLV_RUNTIME_HOST_SOCKET;
+    else process.env.LLV_RUNTIME_HOST_SOCKET = previousSocket;
+    if (previousUi === undefined) delete process.env.NEXT_PUBLIC_RUNTIME_UI;
+    else process.env.NEXT_PUBLIC_RUNTIME_UI = previousUi;
+  }
+});
+
+test("a terminal structured replay returns its reserved identity and retry-safe message outcome", async () => {
+  const cwd = fs.mkdtempSync(path.join(routeSandbox, "p0-282-terminal-replay-"));
+  const previousTransport = process.env.LLV_SPAWN_TRANSPORT;
+  const previousHosts = process.env.LLV_STRUCTURED_HOSTS;
+  const previousEvents = process.env.LLV_RUNTIME_EVENTS;
+  const previousSocket = process.env.LLV_RUNTIME_HOST_SOCKET;
+  const previousUi = process.env.NEXT_PUBLIC_RUNTIME_UI;
+  process.env.LLV_SPAWN_TRANSPORT = "structured";
+  process.env.LLV_STRUCTURED_HOSTS = "1";
+  process.env.LLV_RUNTIME_EVENTS = "1";
+  process.env.LLV_RUNTIME_HOST_SOCKET = path.join(cwd, "runtime.sock");
+  process.env.NEXT_PUBLIC_RUNTIME_UI = "1";
+  let deferred: (() => Promise<void>) | null = null;
+  const dependencies = {
+    ...structuredRouteDependencies(cwd),
+    defer: (work: () => Promise<void>) => { deferred = work; },
+    spawnStructuredConversation: async (input: Parameters<NonNullable<Parameters<typeof POST.withDependencies>[1]>["spawnStructuredConversation"]>[0]) => {
+      input.registry.failStructuredSpawn(input.receipt.launchId, "structured host ownership is unavailable");
+      throw new Error("structured host ownership is unavailable");
+    },
+  } as Parameters<typeof POST.withDependencies>[1];
+  const request = () => new NextRequest("http://127.0.0.1:8898/api/spawn", {
+    method: "POST",
+    headers: {
+      host: "127.0.0.1:8898",
+      origin: "http://127.0.0.1:8898",
+      "sec-fetch-site": "same-origin",
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({
+      engine: "claude",
+      cwd,
+      prompt: "Own issue #282",
+      clientAttemptId: "p0_282_terminal_replay_20260716_a1",
+    }),
+  });
+  try {
+    const admitted = await POST.withDependencies(request(), dependencies);
+    const admittedBody = await admitted.json();
+    await runDeferred(deferred);
+
+    const replay = await POST.withDependencies(request(), dependencies);
+    expect(replay.status).toBe(200);
+    expect(await replay.json()).toEqual({
+      ok: true,
+      target: null,
+      path: null,
+      effectivePermissionMode: "default",
+      launchId: admittedBody.launchId,
+      conversationId: admittedBody.conversationId,
+      launched: false,
+      retrySafe: true,
+      initialMessage: "failed",
+      state: "failed",
+      error: "structured host ownership is unavailable",
+    });
+  } finally {
+    if (previousTransport === undefined) delete process.env.LLV_SPAWN_TRANSPORT;
+    else process.env.LLV_SPAWN_TRANSPORT = previousTransport;
+    if (previousHosts === undefined) delete process.env.LLV_STRUCTURED_HOSTS;
+    else process.env.LLV_STRUCTURED_HOSTS = previousHosts;
+    if (previousEvents === undefined) delete process.env.LLV_RUNTIME_EVENTS;
+    else process.env.LLV_RUNTIME_EVENTS = previousEvents;
+    if (previousSocket === undefined) delete process.env.LLV_RUNTIME_HOST_SOCKET;
+    else process.env.LLV_RUNTIME_HOST_SOCKET = previousSocket;
+    if (previousUi === undefined) delete process.env.NEXT_PUBLIC_RUNTIME_UI;
+    else process.env.NEXT_PUBLIC_RUNTIME_UI = previousUi;
+  }
+});
+
+test("a clientAttemptId replay recovers the reserved card from runtime evidence", async () => {
+  const cwd = fs.mkdtempSync(path.join(routeSandbox, "p0-282-runtime-replay-"));
+  const previousTransport = process.env.LLV_SPAWN_TRANSPORT;
+  const previousHosts = process.env.LLV_STRUCTURED_HOSTS;
+  const previousEvents = process.env.LLV_RUNTIME_EVENTS;
+  const previousSocket = process.env.LLV_RUNTIME_HOST_SOCKET;
+  const previousUi = process.env.NEXT_PUBLIC_RUNTIME_UI;
+  process.env.LLV_SPAWN_TRANSPORT = "structured";
+  process.env.LLV_STRUCTURED_HOSTS = "1";
+  process.env.LLV_RUNTIME_EVENTS = "1";
+  process.env.LLV_RUNTIME_HOST_SOCKET = path.join(cwd, "runtime.sock");
+  process.env.NEXT_PUBLIC_RUNTIME_UI = "1";
+  const sessionId = crypto.randomUUID();
+  const artifactPath = path.join(cwd, `${sessionId}.jsonl`);
+  let deferred: (() => Promise<void>) | null = null;
+  let admittedReceipt: Parameters<NonNullable<Parameters<typeof POST.withDependencies>[1]>["spawnStructuredConversation"]>[0]["receipt"] | null = null;
+  const runtimeClient = {
+    operationStatus: async (operationId: string) => admittedReceipt && operationId === `spawn_message_${admittedReceipt.launchId}` ? {
+      receipt: {
+        operationId,
+        idempotencyKey: `spawn_${admittedReceipt.launchId}`,
+        conversationId: admittedReceipt.conversationId,
+        kind: "send" as const,
+        status: "delivered" as const,
+        at: new Date().toISOString(),
+        revision: 2,
+      },
+      replayed: true,
+    } : null,
+    snapshot: async () => ({
+      sessions: admittedReceipt ? [{
+        conversationId: admittedReceipt.conversationId,
+        sessionKey: { engine: "claude" as const, sessionId },
+        hostKind: "claude-broker" as const,
+        host: "hosted" as const,
+        turn: "running" as const,
+        provenance: "structured" as const,
+        revision: 2,
+        attentionIds: [],
+        recentReceipts: [],
+        accountId: "claude-test",
+        parentConversationId: null,
+        flowId: null,
+        workflowId: null,
+        cwd,
+        artifactPath,
+        capabilities: { steer: false, structuredAttention: true },
+        activeTurnId: "turn-initial",
+      }] : [],
+    }),
+  } as unknown as RuntimeHostClient;
+  const dependencies = {
+    ...structuredRouteDependencies(cwd),
+    runtimeHostClient: () => runtimeClient,
+    defer: (work: () => Promise<void>) => { deferred = work; },
+    spawnStructuredConversation: async (input: Parameters<NonNullable<Parameters<typeof POST.withDependencies>[1]>["spawnStructuredConversation"]>[0]) => {
+      admittedReceipt = input.receipt;
+      input.registry.failStructuredSpawn(input.receipt.launchId, "host binding timed out");
+      throw new Error("host binding timed out");
+    },
+  } as Parameters<typeof POST.withDependencies>[1];
+  const request = () => new NextRequest("http://127.0.0.1:8898/api/spawn", {
+    method: "POST",
+    headers: {
+      host: "127.0.0.1:8898",
+      origin: "http://127.0.0.1:8898",
+      "sec-fetch-site": "same-origin",
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({
+      engine: "claude",
+      cwd,
+      prompt: "Own issue #282",
+      clientAttemptId: "p0_282_runtime_route_replay_20260716_a1",
+    }),
+  });
+  try {
+    const admitted = await POST.withDependencies(request(), dependencies);
+    const admittedBody = await admitted.json();
+    await runDeferred(deferred);
+
+    const replay = await POST.withDependencies(request(), dependencies);
+    expect(replay.status).toBe(200);
+    expect(await replay.json()).toMatchObject({
+      launchId: admittedBody.launchId,
+      conversationId: admittedBody.conversationId,
+      path: artifactPath,
+      state: "settled",
+      launched: true,
+      retrySafe: false,
+      initialMessage: "delivered",
+    });
+  } finally {
+    if (previousTransport === undefined) delete process.env.LLV_SPAWN_TRANSPORT;
+    else process.env.LLV_SPAWN_TRANSPORT = previousTransport;
+    if (previousHosts === undefined) delete process.env.LLV_STRUCTURED_HOSTS;
+    else process.env.LLV_STRUCTURED_HOSTS = previousHosts;
+    if (previousEvents === undefined) delete process.env.LLV_RUNTIME_EVENTS;
+    else process.env.LLV_RUNTIME_EVENTS = previousEvents;
+    if (previousSocket === undefined) delete process.env.LLV_RUNTIME_HOST_SOCKET;
+    else process.env.LLV_RUNTIME_HOST_SOCKET = previousSocket;
+    if (previousUi === undefined) delete process.env.NEXT_PUBLIC_RUNTIME_UI;
+    else process.env.NEXT_PUBLIC_RUNTIME_UI = previousUi;
+  }
+});
+
 test("spawn route projects a launched path-pending receipt as a truthful success", () => {
   const store = registry();
   const begun = store.beginSpawnRequest({ engine: "codex", cwd: "/repo", accountId: "terra", clientAttemptId: "attempt_path_pending", requestDigest: "digest" });
@@ -421,6 +692,7 @@ test("a staged pane-less receipt replays with accepted status", () => {
     conversationId: "conversation_pending",
     launched: false,
     retrySafe: false,
+    initialMessage: "queued" as const,
     state: "path-pending" as const,
   };
 

--- a/src/app/api/spawn/route.ts
+++ b/src/app/api/spawn/route.ts
@@ -2,7 +2,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
-import { NextRequest, NextResponse } from "next/server";
+import { after, NextRequest, NextResponse } from "next/server";
 
 import { UnknownAccountError } from "@/lib/accounts/codex";
 import { claudeSettingsPath, isManagedClaudeHome, UnknownClaudeAccountError } from "@/lib/accounts/claude";
@@ -25,7 +25,7 @@ import { rejectCrossOrigin } from "@/lib/sameOrigin";
 import { runtimeHostClient } from "@/lib/runtime/client";
 import { runtimeScope } from "@/lib/runtime/contracts";
 import { runtimeEventsEnabled } from "@/lib/runtime/flags";
-import { spawnStructuredConversation, structuredClaudePermissionMode } from "@/lib/runtime/structuredSpawn";
+import { reconcileStructuredSpawnReplay, spawnStructuredConversation, structuredClaudePermissionMode } from "@/lib/runtime/structuredSpawn";
 import { structuredSpawnGap, spawnTransport } from "@/lib/runtime/spawnTransport";
 import { listFiles } from "@/lib/scanner";
 import { projectForCwd } from "@/lib/scanner/describe";
@@ -47,12 +47,14 @@ interface SpawnRouteDependencies {
   resolveHealthySpawnAccount: typeof resolveHealthySpawnAccount;
   runtimeHostClient: typeof runtimeHostClient;
   spawnStructuredConversation: typeof spawnStructuredConversation;
+  defer(work: () => Promise<void>): void;
 }
 
 const productionSpawnRouteDependencies: SpawnRouteDependencies = {
   resolveHealthySpawnAccount,
   runtimeHostClient,
   spawnStructuredConversation,
+  defer: (work) => after(work),
 };
 
 interface SuggestResponse {
@@ -256,8 +258,19 @@ async function postSpawn(
       const structured = begun.receipt.transport === "structured"
         || (begun.receipt.transport === null
           && Boolean(begun.receipt.key && registry.snapshot().entries[sessionKeyId(begun.receipt.key)]?.structuredHost));
-      const response = spawnResponseForReceipt(begun.receipt, begun.receipt.artifactPath, { structured });
-      if (begun.receipt.state === "failed") return NextResponse.json({ error: "original spawn failed before launch", retrySafe: true }, { status: 409 });
+      let receipt = begun.receipt;
+      let initialMessage: SpawnResponse["initialMessage"] | undefined;
+      const runtimeClient = structured ? dependencies.runtimeHostClient() : null;
+      if (runtimeClient) {
+        try {
+          const reconciled = await reconcileStructuredSpawnReplay(receipt.launchId, registry, runtimeClient);
+          receipt = reconciled;
+          initialMessage = reconciled.initialMessage;
+        } catch {
+          /* The durable registry receipt remains available during runtime resynchronization. */
+        }
+      }
+      const response = spawnResponseForReceipt(receipt, receipt.artifactPath, { structured, initialMessage });
       return NextResponse.json(response, { status: spawnReplayStatus(response, structured) });
     }
     launchId = begun.receipt.launchId;
@@ -273,20 +286,45 @@ async function postSpawn(
     if (transport === "structured") {
       const runtimeClient = dependencies.runtimeHostClient();
       if (!runtimeClient) throw new Error("structured spawn runtime host is unavailable");
-      const response = await dependencies.spawnStructuredConversation({
-        engine,
-        receipt: begun.receipt,
-        spec,
-        account,
-        prompt,
-        registry,
-        client: runtimeClient,
+      dependencies.defer(async () => {
+        let response: SpawnResponse;
+        try {
+          response = await dependencies.spawnStructuredConversation({
+            engine,
+            receipt: begun.receipt,
+            spec,
+            account,
+            prompt,
+            registry,
+            client: runtimeClient,
+          });
+        } catch (error) {
+          console.error("[spawn] structured launch failed", {
+            launchId: begun.receipt.launchId,
+            conversationId: begun.receipt.conversationId,
+            error,
+          });
+          return;
+        }
+        if (parentArtifactPath && response.path) {
+          try {
+            rememberHandoffChild(response.path, parentArtifactPath);
+            persistHandoffLineage();
+          } catch (error) {
+            console.error("[spawn] handoff lineage persistence failed", {
+              launchId: begun.receipt.launchId,
+              conversationId: begun.receipt.conversationId,
+              childArtifactPath: response.path,
+              parentArtifactPath,
+              error,
+            });
+          }
+        }
       });
-      if (parentArtifactPath && response.path) {
-        rememberHandoffChild(response.path, parentArtifactPath);
-        persistHandoffLineage();
-      }
-      return NextResponse.json(response);
+      return NextResponse.json(
+        spawnResponseForReceipt(begun.receipt, begun.receipt.artifactPath, { structured: true }),
+        { status: 202 },
+      );
     }
     /* Pasted images land in the inbox and reach the fresh agent as file paths
        appended to its first prompt — the same contract the pane composer uses. */

--- a/src/app/api/tasks/[id]/spawn/route.test.ts
+++ b/src/app/api/tasks/[id]/spawn/route.test.ts
@@ -1,0 +1,119 @@
+import crypto from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { expect, test } from "bun:test";
+import { NextRequest } from "next/server";
+
+import { AgentRegistry, type SpawnReceipt } from "@/lib/agent/registry";
+import type { BoardTask } from "@/lib/tasks/types";
+
+import { POST } from "./route";
+
+test("task attribution failure replays one launched pane into one durable assignment", async () => {
+  const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "llv-task-spawn-282-"));
+  const registry = new AgentRegistry(path.join(cwd, "registry.json"), undefined, undefined, { sqliteMode: "off" });
+  const sessionId = crypto.randomUUID();
+  const artifactPath = path.join(cwd, `${sessionId}.jsonl`);
+  let tasks: BoardTask[] = [{
+    id: "08b5e4ec-89c5-4064-9118-51661c4f080b",
+    project: "live-log-viewer-next",
+    status: "inbox",
+    text: "Own issue #282",
+    placement: "pinned",
+    pos: { x: 0, y: 0 },
+    assignments: [],
+    createdAt: "2026-07-15T18:06:00.000Z",
+    updatedAt: "2026-07-15T18:06:00.000Z",
+  }];
+  let writes = 0;
+  let spawnCalls = 0;
+  const dependencies = {
+    registry: () => registry,
+    loadTasks: () => tasks,
+    mutateTasks: (mutator: (current: BoardTask[]) => { tasks?: BoardTask[]; result: unknown }) => {
+      writes += 1;
+      if (writes === 2) throw new Error("task assignment write failed after launch");
+      const mutation = mutator(tasks);
+      if (mutation.tasks) tasks = mutation.tasks;
+      return mutation.result;
+    },
+    resolveSpawnAccount: () => ({
+      engine: "claude" as const,
+      accountId: "claude-work",
+      kind: "managed" as const,
+      home: cwd,
+      transcriptRoot: cwd,
+      env: { NODE_ENV: "test" },
+    }),
+    resolveSpawnedTranscriptPath: async () => artifactPath,
+    spawnAgentWithPrompt: async (_spec: unknown, _prompt: string, receipt: SpawnReceipt) => {
+      spawnCalls += 1;
+      const binding = {
+        endpoint: "/tmp",
+        server: { pid: 90, startIdentity: "90:one" },
+        paneId: "%18",
+        panePid: { pid: 3627416, startIdentity: "3627416:one" },
+        target: "agents:18.0",
+      };
+      registry.bindSpawnPane(receipt.launchId, binding);
+      const host = {
+        kind: "tmux" as const,
+        ...binding,
+        windowName: "claude-builder",
+        agent: { pid: 3627417, startIdentity: "3627417:one" },
+        argv: ["claude"],
+      };
+      registry.markSpawnHostVerified(receipt.launchId, host);
+      registry.markSpawnPromptDelivered(receipt.launchId);
+      fs.writeFileSync(artifactPath, `${JSON.stringify({ type: "user", message: { content: "Own issue #282" } })}\n`);
+      return { paneId: "%18", display: "agents:18.0", panePid: 3627416, host, receipt };
+    },
+  } as Parameters<typeof POST.withDependencies>[2];
+  const request = () => new NextRequest("http://127.0.0.1/api/tasks/08b5e4ec-89c5-4064-9118-51661c4f080b/spawn", {
+    method: "POST",
+    headers: { origin: "http://127.0.0.1", host: "127.0.0.1", "content-type": "application/json" },
+    body: JSON.stringify({
+      engine: "claude",
+      model: "opus",
+      effort: "high",
+      cwd,
+      clientAttemptId: "task_282_post_launch_write_20260715_a1",
+    }),
+  });
+  const context = { params: Promise.resolve({ id: tasks[0]!.id }) };
+
+  const uncertain = await POST.withDependencies(request(), context, dependencies);
+  const uncertainBody = await uncertain.json();
+  expect(uncertain.status).toBe(202);
+  expect(uncertainBody).toMatchObject({
+    ok: true,
+    launchId: expect.any(String),
+    conversationId: expect.stringMatching(/^conversation_/),
+    path: artifactPath,
+    panePid: 3627416,
+    assignment: "spawning",
+    initialMessage: "delivered",
+    error: "task assignment write failed after launch",
+  });
+
+  const replay = await POST.withDependencies(request(), context, dependencies);
+  const replayBody = await replay.json();
+  expect(replay.status).toBe(200);
+  expect(replayBody).toMatchObject({
+    launchId: uncertainBody.launchId,
+    conversationId: uncertainBody.conversationId,
+    path: artifactPath,
+    assignment: "delivered",
+    initialMessage: "delivered",
+  });
+  expect(spawnCalls).toBe(1);
+  expect(tasks[0]?.assignments).toEqual([expect.objectContaining({
+    launchId: uncertainBody.launchId,
+    clientAttemptId: "task_282_post_launch_write_20260715_a1",
+    conversationId: uncertainBody.conversationId,
+    path: artifactPath,
+    panePid: 3627416,
+    state: "delivered",
+  })]);
+});

--- a/src/app/api/tasks/[id]/spawn/route.ts
+++ b/src/app/api/tasks/[id]/spawn/route.ts
@@ -1,3 +1,4 @@
+import crypto from "node:crypto";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -5,17 +6,23 @@ import path from "node:path";
 import { NextRequest, NextResponse } from "next/server";
 
 import { accountManager } from "@/lib/accounts/manager";
+import { emptyLaunchProfile } from "@/lib/accounts/migration/contracts";
+import type { AccountContext } from "@/lib/accounts/contracts";
 import { freshSpecFor, type AgentEngine } from "@/lib/agent/cli";
 import { reasoningFromBody } from "@/lib/agent/efforts";
 import { modelFromBody } from "@/lib/agent/models";
+import { agentRegistry, type AgentRegistry, type SpawnReceipt } from "@/lib/agent/registry";
+import { sessionKeyFromTranscript } from "@/lib/agent/sessionKey";
+import { spawnResponseForReceipt, type SpawnResponse as AgentSpawnResponse } from "@/lib/agent/spawnResponse";
 import { resolveSpawnedTranscriptPath } from "@/lib/agent/spawnedTranscript";
 import { rejectCrossOrigin } from "@/lib/sameOrigin";
+import { projectInfoFromCwd } from "@/lib/scanner/describe";
 import { attachmentPath } from "@/lib/tasks/attachments";
-import { applyAssignmentPatches, pinnedAccountId, type AssignmentPatch } from "@/lib/tasks/commands";
+import { applyAssignmentPatches, pinnedAccountId, type AssignmentPatch, type TaskCommandResult } from "@/lib/tasks/commands";
 import { isoNow } from "@/lib/tasks/helpers";
 import { loadTasks, mutateTasks } from "@/lib/tasks/store";
-import type { BoardTask } from "@/lib/tasks/types";
-import { spawnAgentWithPrompt } from "@/lib/tmux";
+import type { BoardTask, TaskAssignment } from "@/lib/tasks/types";
+import { spawnAgentWithPrompt, type SpawnedPane } from "@/lib/tmux";
 import type { ApiError } from "@/lib/types";
 
 export const runtime = "nodejs";
@@ -25,13 +32,38 @@ type TaskRouteContext = {
   params: Promise<{ id: string }>;
 };
 
-interface SpawnResponse {
+interface TaskSpawnResponse {
   ok: true;
   task: BoardTask;
-  target: string;
+  target: string | null;
   path: string | null;
   panePid: number | null;
+  launchId: string;
+  conversationId: string;
+  initialMessage: AgentSpawnResponse["initialMessage"];
+  state: AgentSpawnResponse["state"];
+  retrySafe: boolean;
+  assignment: TaskAssignment["state"];
+  error?: string;
 }
+
+interface TaskSpawnDependencies {
+  registry(): AgentRegistry;
+  loadTasks: typeof loadTasks;
+  mutateTasks: typeof mutateTasks;
+  resolveSpawnAccount(engine: AgentEngine, accountId: string | null): AccountContext;
+  spawnAgentWithPrompt: typeof spawnAgentWithPrompt;
+  resolveSpawnedTranscriptPath: typeof resolveSpawnedTranscriptPath;
+}
+
+const productionDependencies: TaskSpawnDependencies = {
+  registry: agentRegistry,
+  loadTasks,
+  mutateTasks,
+  resolveSpawnAccount: (engine, accountId) => accountManager.resolveSpawn(engine, accountId),
+  spawnAgentWithPrompt,
+  resolveSpawnedTranscriptPath,
+};
 
 function cwdFromBody(value: unknown): { cwd?: string; error?: string; status?: number } {
   const raw = typeof value === "string" ? value.trim() : "";
@@ -47,11 +79,88 @@ function cwdFromBody(value: unknown): { cwd?: string; error?: string; status?: n
   return { cwd };
 }
 
-export async function POST(req: NextRequest, ctx: TaskRouteContext): Promise<NextResponse<SpawnResponse | ApiError>> {
+function stableTaskAttemptId(task: BoardTask, shape: Record<string, unknown>): string {
+  const digest = crypto.createHash("sha256").update(JSON.stringify({ taskId: task.id, text: task.text, shape })).digest("hex");
+  return `task_${digest.slice(0, 48)}`;
+}
+
+function taskRequestDigest(task: BoardTask, shape: Record<string, unknown>): string {
+  return crypto.createHash("sha256").update(JSON.stringify({ taskId: task.id, text: task.text, shape })).digest("hex");
+}
+
+function assignmentPatch(receipt: SpawnReceipt, at: string, accountId: string, engine: AgentEngine): AssignmentPatch {
+  const failed = receipt.state === "failed" || receipt.state === "conflicted";
+  let state: TaskAssignment["state"] = "spawning";
+  if (failed) state = "failed";
+  else if (receipt.state === "completed" && receipt.artifactPath) state = "delivered";
+  return {
+    launchId: receipt.launchId,
+    clientAttemptId: receipt.clientAttemptId,
+    conversationId: receipt.conversationId,
+    path: receipt.artifactPath,
+    panePid: receipt.pane?.panePid.pid ?? null,
+    state,
+    error: failed ? receipt.error ?? "agent did not start" : null,
+    at,
+    accountId,
+    engine,
+  };
+}
+
+function taskInitialMessage(receipt: SpawnReceipt): AgentSpawnResponse["initialMessage"] {
+  if (receipt.state === "failed" || receipt.state === "conflicted") return "failed";
+  if (receipt.state === "completed" || receipt.state === "prompt-delivered" || receipt.state === "path-pending") {
+    return "delivered";
+  }
+  return "pending";
+}
+
+function persistAssignment(
+  dependencies: TaskSpawnDependencies,
+  taskId: string,
+  patch: AssignmentPatch,
+  at: string,
+): TaskCommandResult {
+  return dependencies.mutateTasks((tasks) => {
+    const outcome = applyAssignmentPatches(tasks, taskId, [patch], at);
+    return { tasks: outcome.ok ? outcome.tasks : undefined, result: outcome };
+  });
+}
+
+function taskSpawnResponse(
+  receipt: SpawnReceipt,
+  task: BoardTask,
+  patch: AssignmentPatch,
+  options: { error?: string } = {},
+): TaskSpawnResponse {
+  const spawn = spawnResponseForReceipt(receipt, receipt.artifactPath, {
+    initialMessage: taskInitialMessage(receipt),
+  });
+  return {
+    ok: true,
+    task,
+    target: receipt.pane?.display ?? receipt.target ?? null,
+    path: receipt.artifactPath,
+    panePid: receipt.pane?.panePid.pid ?? null,
+    launchId: receipt.launchId,
+    conversationId: receipt.conversationId,
+    initialMessage: spawn.initialMessage,
+    state: spawn.state,
+    retrySafe: spawn.retrySafe,
+    assignment: patch.state,
+    ...(options.error ? { error: options.error } : {}),
+  };
+}
+
+async function postTaskSpawn(
+  req: NextRequest,
+  ctx: TaskRouteContext,
+  dependencies: TaskSpawnDependencies = productionDependencies,
+): Promise<NextResponse<TaskSpawnResponse | ApiError>> {
   const rejection = rejectCrossOrigin(req);
   if (rejection) return rejection;
 
-  let body: { engine?: unknown; model?: unknown; cwd?: unknown; effort?: unknown; fast?: unknown };
+  let body: { engine?: unknown; model?: unknown; cwd?: unknown; effort?: unknown; fast?: unknown; clientAttemptId?: unknown };
   try {
     body = (await req.json()) as typeof body;
   } catch {
@@ -60,6 +169,10 @@ export async function POST(req: NextRequest, ctx: TaskRouteContext): Promise<Nex
 
   const engine = body.engine === "claude" || body.engine === "codex" ? (body.engine as AgentEngine) : null;
   if (!engine) return NextResponse.json({ error: "engine must be claude or codex" }, { status: 400 });
+  if (body.clientAttemptId !== undefined
+    && (typeof body.clientAttemptId !== "string" || !/^[A-Za-z0-9_-]{8,128}$/.test(body.clientAttemptId))) {
+    return NextResponse.json({ error: "clientAttemptId must be 8-128 URL-safe characters" }, { status: 400 });
+  }
 
   const reasoning = reasoningFromBody(engine, body);
   if (reasoning.error) return NextResponse.json({ error: reasoning.error }, { status: 400 });
@@ -69,20 +182,99 @@ export async function POST(req: NextRequest, ctx: TaskRouteContext): Promise<Nex
   if (!cwdResult.cwd) return NextResponse.json({ error: cwdResult.error ?? "invalid working directory" }, { status: cwdResult.status ?? 400 });
 
   const { id } = await ctx.params;
-  const task = loadTasks().find((item) => item.id === id);
+  const task = dependencies.loadTasks().find((item) => item.id === id);
   if (!task) return NextResponse.json({ error: "task not found" }, { status: 404 });
 
+  const previous = pinnedAccountId(task.assignments, engine);
+  let account: AccountContext;
   try {
-    const previous = pinnedAccountId(task.assignments, engine);
-    const account = accountManager.resolveSpawn(engine, previous);
-    const spec = freshSpecFor(engine, cwdResult.cwd, { model: selectedModel.model, effort: reasoning.effort, fast: reasoning.fast, codexHome: engine === "codex" ? account.home : null, claudeConfigDir: engine === "claude" ? account.home : null, claudeProjectsDir: engine === "claude" ? account.transcriptRoot : null });
-    const startedAtMs = Date.now();
-    /* The brief carries the task's durable attachment paths (one per line), so
-       a spawned agent receives the images the same way a send does. */
-    const attachmentPaths = (task.attachments ?? []).map((att) => attachmentPath(att));
-    const prompt = [task.text, ...attachmentPaths].join("\n");
-    const pane = await spawnAgentWithPrompt(spec, prompt);
-    const transcript = await resolveSpawnedTranscriptPath({
+    account = dependencies.resolveSpawnAccount(engine, previous);
+  } catch (error) {
+    return NextResponse.json({ error: error instanceof Error ? error.message : String(error) }, { status: 400 });
+  }
+  const shape = {
+    engine,
+    cwd: cwdResult.cwd,
+    model: selectedModel.model,
+    effort: reasoning.effort,
+    fast: reasoning.fast,
+    accountId: account.accountId,
+  };
+  const clientAttemptId = typeof body.clientAttemptId === "string"
+    ? body.clientAttemptId
+    : stableTaskAttemptId(task, shape);
+  const specBase = freshSpecFor(engine, cwdResult.cwd, {
+    model: selectedModel.model,
+    effort: reasoning.effort,
+    fast: reasoning.fast,
+    codexHome: engine === "codex" ? account.home : null,
+    claudeConfigDir: engine === "claude" ? account.home : null,
+    claudeProjectsDir: engine === "claude" ? account.transcriptRoot : null,
+  });
+  const project = projectInfoFromCwd(cwdResult.cwd)?.project ?? task.project;
+  const spec = {
+    ...specBase,
+    launchProfile: emptyLaunchProfile({
+      ...(specBase.launchProfile ?? {}),
+      cwd: cwdResult.cwd,
+      project,
+      title: task.text.split("\n")[0]?.trim() || null,
+    }),
+  };
+  const registry = dependencies.registry();
+  const begun = registry.beginSpawnRequest({
+    engine,
+    cwd: cwdResult.cwd,
+    transport: "tmux",
+    accountId: account.accountId,
+    launchProfile: spec.launchProfile,
+    clientAttemptId,
+    requestDigest: taskRequestDigest(task, shape),
+  });
+  if (begun.kind === "conflict") {
+    return NextResponse.json({ error: "task spawn attempt conflicts with its original request" }, { status: 409 });
+  }
+
+  if (begun.kind === "replay") {
+    const at = isoNow();
+    const patch = assignmentPatch(begun.receipt, at, account.accountId, engine);
+    try {
+      const result = persistAssignment(dependencies, id, patch, at);
+      if (!result.ok) return NextResponse.json({ error: result.error }, { status: result.status });
+      const response = taskSpawnResponse(begun.receipt, result.task, patch);
+      const status = patch.state === "spawning" ? 202 : 200;
+      return NextResponse.json(response, { status });
+    } catch (error) {
+      return NextResponse.json(taskSpawnResponse(begun.receipt, task, { ...patch, state: "spawning" }, {
+        error: error instanceof Error ? error.message : "task assignment write failed",
+      }), { status: 202 });
+    }
+  }
+
+  const admittedAt = isoNow();
+  const admittedPatch = assignmentPatch(begun.receipt, admittedAt, account.accountId, engine);
+  let admittedTask = task;
+  try {
+    const admitted = persistAssignment(dependencies, id, admittedPatch, admittedAt);
+    if (!admitted.ok) {
+      registry.failSpawn(begun.receipt.launchId, admitted.error);
+      return NextResponse.json({ error: admitted.error }, { status: admitted.status });
+    }
+    admittedTask = admitted.task;
+  } catch (error) {
+    registry.failSpawn(begun.receipt.launchId, "task admission could not be persisted");
+    const failed = registry.snapshot().receipts[begun.receipt.launchId] ?? begun.receipt;
+    return NextResponse.json(taskSpawnResponse(failed, task, { ...admittedPatch, state: "failed" }, {
+      error: error instanceof Error ? error.message : "task admission could not be persisted",
+    }), { status: 500 });
+  }
+
+  const attachmentPaths = (task.attachments ?? []).map((attachment) => attachmentPath(attachment));
+  const prompt = [task.text, ...attachmentPaths].join("\n");
+  const startedAtMs = Date.now();
+  try {
+    const pane: SpawnedPane = await dependencies.spawnAgentWithPrompt(spec, prompt, begun.receipt);
+    const transcript = await dependencies.resolveSpawnedTranscriptPath({
       engine,
       knownTranscript: spec.transcript ?? null,
       panePid: pane.panePid ?? null,
@@ -90,28 +282,74 @@ export async function POST(req: NextRequest, ctx: TaskRouteContext): Promise<Nex
       startedAtMs,
       codexSessionsDir: engine === "codex" ? account.transcriptRoot : null,
     });
-    const at = isoNow();
-    let patch: AssignmentPatch;
-    if (transcript) {
-      patch = { path: transcript, panePid: pane.panePid ?? null, state: "delivered", error: null, at, accountId: account.accountId, engine };
-    } else if (pane.panePid) {
-      patch = { path: null, panePid: pane.panePid, state: "spawning", error: null, at, accountId: account.accountId, engine };
+    const key = transcript ? sessionKeyFromTranscript(engine, transcript) : null;
+    if (transcript && key) {
+      const settled = registry.settleSpawn(begun.receipt.launchId, {
+        key,
+        artifactPath: transcript,
+        cwd: cwdResult.cwd,
+        accountId: account.accountId,
+        launchProfile: spec.launchProfile,
+        status: "starting",
+        host: pane.host ?? null,
+        claimEpoch: 0,
+        claimOwner: null,
+        pendingAction: "spawn",
+      });
+      if (settled.kind === "conflict") throw new Error(settled.code);
     } else {
-      patch = { path: null, panePid: null, state: "failed", error: "tmux did not return the pane pid", at, accountId: account.accountId, engine };
+      registry.markSpawnPathPending(begun.receipt.launchId);
     }
-    const result = mutateTasks((tasks) => {
-      const outcome = applyAssignmentPatches(tasks, id, [patch], at);
-      return { tasks: outcome.ok ? outcome.tasks : undefined, result: outcome };
-    });
-    if (!result.ok) return NextResponse.json({ error: result.error }, { status: result.status });
-    return NextResponse.json({
-      ok: true,
-      task: result.task,
-      target: pane.display,
-      path: patch.path,
-      panePid: patch.panePid,
-    });
   } catch (error) {
-    return NextResponse.json({ error: error instanceof Error ? error.message : String(error) }, { status: 500 });
+    const observed = registry.snapshot().receipts[begun.receipt.launchId] ?? begun.receipt;
+    if (observed.pane) {
+      if (observed.state === "prompt-delivered" || observed.state === "host-verified") {
+        registry.markSpawnPathPending(observed.launchId);
+      }
+      const pending = registry.snapshot().receipts[observed.launchId] ?? observed;
+      const at = isoNow();
+      const patch = assignmentPatch(pending, at, account.accountId, engine);
+      let taskAfterRecovery = admittedTask;
+      try {
+        const persisted = persistAssignment(dependencies, id, patch, at);
+        if (persisted.ok) taskAfterRecovery = persisted.task;
+      } catch {
+        /* The replay path will fold this same launch identity into the task. */
+      }
+      return NextResponse.json(taskSpawnResponse(pending, taskAfterRecovery, { ...patch, state: "spawning" }, {
+        error: error instanceof Error ? error.message : "task spawn attribution is pending",
+      }), { status: 202 });
+    }
+    registry.failSpawn(begun.receipt.launchId, error instanceof Error ? error.message : "task spawn failed");
+    const failed = registry.snapshot().receipts[begun.receipt.launchId] ?? observed;
+    const at = isoNow();
+    const patch = assignmentPatch(failed, at, account.accountId, engine);
+    try {
+      const persisted = persistAssignment(dependencies, id, patch, at);
+      if (persisted.ok) admittedTask = persisted.task;
+    } catch {
+      /* The failed receipt remains queryable by clientAttemptId. */
+    }
+    return NextResponse.json(taskSpawnResponse(failed, admittedTask, patch, {
+      error: failed.error ?? "task spawn failed",
+    }), { status: 500 });
+  }
+
+  const completed = registry.snapshot().receipts[begun.receipt.launchId] ?? begun.receipt;
+  const completedAt = isoNow();
+  const completedPatch = assignmentPatch(completed, completedAt, account.accountId, engine);
+  try {
+    const result = persistAssignment(dependencies, id, completedPatch, completedAt);
+    if (!result.ok) return NextResponse.json({ error: result.error }, { status: result.status });
+    return NextResponse.json(taskSpawnResponse(completed, result.task, completedPatch));
+  } catch (error) {
+    return NextResponse.json(taskSpawnResponse(completed, admittedTask, { ...completedPatch, state: "spawning" }, {
+      error: error instanceof Error ? error.message : "task assignment write failed after launch",
+    }), { status: 202 });
   }
 }
+
+export const POST = Object.assign(
+  async (req: NextRequest, ctx: TaskRouteContext): Promise<NextResponse<TaskSpawnResponse | ApiError>> => await postTaskSpawn(req, ctx),
+  { withDependencies: postTaskSpawn },
+);

--- a/src/components/BranchPane.spawn.render.test.tsx
+++ b/src/components/BranchPane.spawn.render.test.tsx
@@ -1,0 +1,45 @@
+import { expect, test } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import type { FileEntry } from "@/lib/types";
+
+import { BranchPane } from "./BranchPane";
+
+const file: FileEntry = {
+  path: "spawn:9173e9a2-2f14-4a70-818a-bd4052a1ad4a",
+  root: "codex-sessions",
+  name: "spawn:9173e9a2-2f14-4a70-818a-bd4052a1ad4a",
+  project: "live-log-viewer-next",
+  title: "Builder",
+  engine: "codex",
+  kind: "session",
+  fmt: "codex",
+  parent: null,
+  mtime: 1,
+  size: 0,
+  activity: "live",
+  proc: null,
+  pid: null,
+  model: "gpt-5.4",
+  pendingQuestion: null,
+  waitingInput: null,
+  conversationId: "conversation_ac6029b9",
+  spawn: {
+    launchId: "9173e9a2-2f14-4a70-818a-bd4052a1ad4a",
+    clientAttemptId: "p0_282_spawn_visibility_20260716_a1",
+    accountId: "terra",
+    state: "queued",
+    initialMessage: "queued",
+    retrySafe: false,
+    error: null,
+  },
+};
+
+test("a preallocated branch pane shows launch status without transcript actions", () => {
+  const html = renderToStaticMarkup(<BranchPane file={file} tasks={[]} isRoot />);
+
+  expect(html).toContain('data-spawn-state="queued"');
+  expect(html).toContain("@ terra");
+  expect(html).not.toContain("Delete the conversation from disk");
+  expect(html).not.toContain("textarea");
+});

--- a/src/components/BranchPane.tsx
+++ b/src/components/BranchPane.tsx
@@ -28,6 +28,7 @@ import { SessionTitle } from "./session/SessionTitle";
 import { ProcessStatusControls } from "./TaskHeader";
 import { TmuxComposer } from "./TmuxComposer";
 import { RateLimitBadge } from "./RateLimitBadge";
+import { StructuredSpawnStatus } from "./StructuredSpawnStatus";
 import { WakeupChip, wakeupChipKey } from "./WakeupChip";
 import { activityDot, cleanTitle, effortTint, effortTitle, engineBadge, engineEdge, fmtAge } from "./utils";
 
@@ -134,7 +135,7 @@ export function BranchPane({ file, tasks, isRoot, onClose, dragHandle, noCompose
      reasoning into one compact read-only chip below, so the card carries exactly
      one model·reasoning element in all states. Desktop keeps its own chip +
      effort-bar pair. */
-  const showRuntimeControls = file.proc === "running" && !file.parent && (file.engine === "claude" || file.engine === "codex");
+  const showRuntimeControls = !file.spawn && file.proc === "running" && !file.parent && (file.engine === "claude" || file.engine === "codex");
   const migState = cardMigrationState(file.migration);
   /* The phone metadata row scrolls horizontally to stay one line (issue #177
      item 4); this tracks whether more is clipped to the right so a fade
@@ -196,7 +197,7 @@ export function BranchPane({ file, tasks, isRoot, onClose, dragHandle, noCompose
   }, [cardId, expanded]);
   /* Link-arrow drop target; re-registers each poll so the pid stays current. */
   useEffect(() => {
-    if (noComposer || expanded) return;
+    if (file.spawn || noComposer || expanded) return;
     if (paneRef.current) return registerLinkTarget(file, paneRef.current);
   }, [file, noComposer, expanded]);
   return (
@@ -254,7 +255,7 @@ export function BranchPane({ file, tasks, isRoot, onClose, dragHandle, noCompose
                 {expanded ? <Minimize2 className={isMobile ? "h-4 w-4" : "h-3 w-3"} aria-hidden /> : <Maximize2 className={isMobile ? "h-4 w-4" : "h-3 w-3"} aria-hidden />}
               </button>
             ) : null}
-            <DeleteFileButton file={file} onDeleted={onClose} />
+            {file.spawn ? null : <DeleteFileButton file={file} onDeleted={onClose} />}
             {onClose ? (
               <button
                 className={`inline-flex shrink-0 items-center justify-center rounded-[8px] border border-border bg-canvas text-muted hover:border-danger/40 hover:text-danger focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 ${
@@ -354,7 +355,7 @@ export function BranchPane({ file, tasks, isRoot, onClose, dragHandle, noCompose
                   the branch chip. Shell tasks carry no account, so they skip it;
                   the id is read from the live transcript path so a migrated
                   conversation reflects its current account. */}
-              {file.engine === "shell" ? null : <AccountBadge engine={file.engine} accountId={accountIdFromPath(file.path)} />}
+              {file.engine === "shell" ? null : <AccountBadge engine={file.engine} accountId={file.spawn?.accountId ?? accountIdFromPath(file.path)} />}
               {file.plan ? <PlanChip plan={file.plan} /> : null}
               {file.goal ? <GoalChip goal={file.goal} /> : null}
               {isRoot || isMobile ? null : (
@@ -392,20 +393,26 @@ export function BranchPane({ file, tasks, isRoot, onClose, dragHandle, noCompose
             ))}
           </FlipRow>
         ) : null}
-        {/* The "done" seam of a committed migration: a divider naming the
-            account this conversation continued from, above its transcript. */}
-        <MigrationDivider predecessorLabel={file.predecessorLabel} />
-        <LogFeed
-          file={file}
-          showSvc={false}
-          lineFilter=""
-          onStatus={noop}
-          paused={feedPaused}
-          follow
-          setFollow={noop}
-          compact
-        />
-        {noComposer ? null : <TmuxComposer file={file} pollPaused={feedPaused} />}
+        {file.spawn ? (
+          <StructuredSpawnStatus spawn={file.spawn} />
+        ) : (
+          <>
+            {/* The "done" seam of a committed migration names the account this
+                conversation continued from, above its transcript. */}
+            <MigrationDivider predecessorLabel={file.predecessorLabel} />
+            <LogFeed
+              file={file}
+              showSvc={false}
+              lineFilter=""
+              onStatus={noop}
+              paused={feedPaused}
+              follow
+              setFollow={noop}
+              compact
+            />
+            {noComposer ? null : <TmuxComposer file={file} pollPaused={feedPaused} />}
+          </>
+        )}
       </section>
     </div>
   );

--- a/src/components/DraftAgentPane.dom.test.tsx
+++ b/src/components/DraftAgentPane.dom.test.tsx
@@ -4,6 +4,7 @@ import { flushSync } from "react-dom";
 import { createRoot, type Root } from "react-dom/client";
 
 import type { FileEntry } from "@/lib/types";
+import { FILES_CHANGED_EVENT } from "@/lib/filesEvents";
 
 import { DraftAgentPane } from "./DraftAgentPane";
 
@@ -61,6 +62,9 @@ afterEach(() => {
 
 test("Reviewer role persists and submits the reviewed conversation", async () => {
   const posts: Record<string, unknown>[] = [];
+  let filesRefreshes = 0;
+  const onFilesChanged = () => { filesRefreshes += 1; };
+  window.addEventListener(FILES_CHANGED_EVENT, onFilesChanged);
   globalThis.fetch = (async (input, init) => {
     const url = String(input);
     if (url === "/api/spawn" && init?.method === "POST") {
@@ -68,7 +72,7 @@ test("Reviewer role persists and submits the reviewed conversation", async () =>
       return {
         ok: true,
         status: 202,
-        json: async () => ({ ok: true, state: "starting", launched: false, path: null, launchId: "launch-reviewer" }),
+        json: async () => ({ ok: true, state: "starting", launched: false, path: null, launchId: "launch-reviewer", conversationId: "conversation_reviewer" }),
       } as Response;
     }
     if (url.startsWith("/api/spawn?")) return { ok: true, json: async () => ({ dirs: ["/repo"] }) } as Response;
@@ -123,4 +127,6 @@ test("Reviewer role persists and submits the reviewed conversation", async () =>
     reviews: implementer.conversationId,
     prompt: "Review the durable membership work",
   });
+  expect(filesRefreshes).toBe(1);
+  window.removeEventListener(FILES_CHANGED_EVENT, onFilesChanged);
 });

--- a/src/components/DraftAgentPane.tsx
+++ b/src/components/DraftAgentPane.tsx
@@ -9,6 +9,7 @@ import { useComposer } from "@/hooks/useComposer";
 import { isEngineEffort } from "@/lib/agent/efforts";
 import { defaultModelFor } from "@/lib/agent/models";
 import { useLocale } from "@/lib/i18n";
+import { requestFilesRefresh } from "@/lib/filesEvents";
 import { BUILDER_APPLY_FIXES_CONFIG, BUILDER_FRONTEND_CONFIG } from "@/lib/roles/paramConfig";
 import type { RoleDefinition } from "@/lib/roles/types";
 import type { FileEntry } from "@/lib/types";
@@ -583,12 +584,13 @@ export function DraftAgentPane({
         json = null;
       }
       const outcome = classifySpawnResponse(res.status, res.ok, json);
+      if (typeof json?.launchId === "string" && typeof json.conversationId === "string") requestFilesRefresh();
       if (outcome.kind === "launched") {
         setAttempt(applySpawnOutcome(candidate, outcome));
       } else if (outcome.kind === "failed-launch") {
         setAttempt(applySpawnFailure(candidate, outcome));
       } else if (outcome.kind === "failed-preflight") {
-        /* The server proved that no pane opened. Restore the exact durable
+        /* The server released worker ownership. Restore the exact durable
            payload so editing and retrying cannot lose an attachment. */
         setAttempt(null);
         setText(candidate.request.prompt);
@@ -650,9 +652,7 @@ export function DraftAgentPane({
       }
     }
     if (!payloadText.trim() && !attachments.images.length) return;
-    /* eslint-disable-next-line react-hooks/purity -- `send` only runs from
-       user events (submit/keydown), never during render; the id and timestamp
-       must be minted at click time. */
+    /* Mint attempt identity when the user submits the draft. */
     const candidate = createSpawnAttempt(newAttemptId(), Date.now(), {
       engine,
       model,

--- a/src/components/StructuredSpawnStatus.render.test.tsx
+++ b/src/components/StructuredSpawnStatus.render.test.tsx
@@ -1,0 +1,42 @@
+import { expect, test } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { translate } from "@/lib/i18n";
+import type { StructuredSpawnCardState } from "@/lib/types";
+
+import { StructuredSpawnStatusView } from "./StructuredSpawnStatus";
+
+const base: StructuredSpawnCardState = {
+  launchId: "9173e9a2-2f14-4a70-818a-bd4052a1ad4a",
+  clientAttemptId: "p0_282_spawn_visibility_20260716_a1",
+  accountId: "terra",
+  state: "starting",
+  initialMessage: "pending",
+  retrySafe: false,
+  error: null,
+};
+
+test("structured spawn card renders every durable launch state in English and Ukrainian", () => {
+  for (const locale of ["en", "uk"] as const) {
+    const t = (key: Parameters<typeof translate>[1], params?: Parameters<typeof translate>[2]) => translate(locale, key, params);
+    for (const state of ["starting", "binding", "queued", "failed", "recovered"] as const) {
+      const spawn = {
+        ...base,
+        state,
+        initialMessage: state === "queued" ? "queued" as const : state === "recovered" ? "delivered" as const : state === "failed" ? "failed" as const : "pending" as const,
+        retrySafe: state === "failed",
+        error: state === "failed" ? "structured host ownership is unavailable" : null,
+      };
+      const html = renderToStaticMarkup(<StructuredSpawnStatusView spawn={spawn} t={t} />);
+
+      expect(html).toContain(`data-spawn-state="${state}"`);
+      expect(html).toContain(t(`spawnCard.${state}`));
+      expect(html).toContain(t(`spawnCard.initial.${spawn.initialMessage}`));
+      expect(html).toContain(spawn.launchId.slice(0, 8));
+      if (state === "failed") {
+        expect(html).toContain("structured host ownership is unavailable");
+        expect(html).toContain(t("spawnCard.retrySafe"));
+      }
+    }
+  }
+});

--- a/src/components/StructuredSpawnStatus.tsx
+++ b/src/components/StructuredSpawnStatus.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { CircleCheck, CircleX, Clock3, LoaderCircle } from "lucide-react";
+
+import { type TFunction, useLocale } from "@/lib/i18n";
+import type { StructuredSpawnCardState } from "@/lib/types";
+
+const stateIcon = {
+  starting: LoaderCircle,
+  binding: LoaderCircle,
+  queued: Clock3,
+  failed: CircleX,
+  recovered: CircleCheck,
+} as const;
+
+function iconTone(state: StructuredSpawnCardState["state"]): string {
+  if (state === "starting" || state === "binding") return "animate-spin text-accent";
+  if (state === "failed") return "text-danger";
+  return "text-success";
+}
+
+export function StructuredSpawnStatusView({ spawn, t }: { spawn: StructuredSpawnCardState; t: TFunction }) {
+  const Icon = stateIcon[spawn.state];
+
+  return (
+    <section
+      className="flex min-h-56 flex-1 items-center justify-center px-6 py-10"
+      data-spawn-state={spawn.state}
+      role="status"
+      aria-live={spawn.state === "failed" ? "assertive" : "polite"}
+    >
+      <div className="w-full max-w-md rounded-2xl border border-border/70 bg-surface-raised/45 px-5 py-6 text-center shadow-sm">
+        <Icon
+          aria-hidden="true"
+          className={`mx-auto mb-3 size-6 ${iconTone(spawn.state)}`}
+        />
+        <p className="text-sm font-medium text-foreground">{t(`spawnCard.${spawn.state}`)}</p>
+        <p className="mt-2 text-xs text-muted-foreground">{t(`spawnCard.initial.${spawn.initialMessage}`)}</p>
+        {spawn.error && <p className="mt-3 break-words text-xs text-danger">{spawn.error}</p>}
+        {spawn.retrySafe && <p className="mt-3 text-xs text-muted-foreground">{t("spawnCard.retrySafe")}</p>}
+        <p className="mt-4 font-mono text-[10px] text-muted-foreground/70">
+          {t("spawnCard.launch", { id: spawn.launchId.slice(0, 8) })}
+        </p>
+      </div>
+    </section>
+  );
+}
+
+export function StructuredSpawnStatus({ spawn }: { spawn: StructuredSpawnCardState }) {
+  const { t } = useLocale();
+  return <StructuredSpawnStatusView spawn={spawn} t={t} />;
+}

--- a/src/components/draftSpawn.test.ts
+++ b/src/components/draftSpawn.test.ts
@@ -161,6 +161,22 @@ describe("classifySpawnResponse — server → card outcome", () => {
     expect(classifySpawnResponse(409, false, { error: "original spawn failed before launch", retrySafe: true }).kind).toBe("failed-preflight");
   });
 
+  test("terminal replay with reserved identity releases the stale draft guard", () => {
+    expect(classifySpawnResponse(200, true, {
+      ok: true,
+      state: "failed",
+      launched: false,
+      retrySafe: true,
+      initialMessage: "failed",
+      launchId: "9173e9a2",
+      conversationId: "conversation_ac6029b9",
+      error: "structured host ownership is unavailable",
+    })).toEqual({
+      kind: "failed-preflight",
+      message: "structured host ownership is unavailable",
+    });
+  });
+
   test("409 without retrySafe (conflicting attempt) → ambiguous, keeps the card frozen", () => {
     expect(classifySpawnResponse(409, false, { error: "spawn attempt conflicts with its original request" })).toEqual({ kind: "ambiguous" });
   });

--- a/src/components/draftSpawn.ts
+++ b/src/components/draftSpawn.ts
@@ -191,7 +191,8 @@ export interface SpawnResponseBody {
   conversationId?: string;
   launched?: boolean;
   retrySafe?: boolean;
-  state?: "settled" | "path-pending" | "starting" | "conflict";
+  initialMessage?: "pending" | "queued" | "delivered" | "failed";
+  state?: "settled" | "path-pending" | "starting" | "failed" | "conflict";
   error?: string;
 }
 
@@ -200,8 +201,8 @@ export type SpawnOutcome =
   /** A worker exists (or very likely does). `durable` picks booting when the
       exact transcript path is known, else confirming. */
   | { kind: "launched"; durable: "booting" | "confirming"; target: string; path: string | null; conversationId: string | null; launchId: string | null }
-  /** Proven pre-launch failure: no pane opened, images cleaned up server-side.
-      Safe to retry — the draft re-enables send and shows the reason. */
+  /** Proven retry-safe failure: the server has released worker ownership, so
+      the draft re-enables send and shows the reason. */
   | { kind: "failed-preflight"; message: string | null }
   /** A pane opened, then positive launch verification found a terminal screen. */
   | { kind: "failed-launch"; message: string; target: string; conversationId: string | null; launchId: string | null }
@@ -217,11 +218,14 @@ export const CONFIRM_ATTENTION_MS = 90_000;
 
 /**
  * Map the spawn POST result to a card outcome. The duplicate-prevention
- * invariant lives here: only an outcome the client can *prove* is pre-launch
- * (`failed-preflight`) re-enables send; every uncertain result is `ambiguous`
- * and keeps the card frozen. A `200 {ok:true}` is always trusted as launched.
+ * invariant lives here: only an outcome the server marks retry-safe re-enables
+ * send; every uncertain result is `ambiguous` and keeps the card frozen. A
+ * `200 {ok:true}` is trusted as a durable launch receipt.
  */
 export function classifySpawnResponse(status: number, ok: boolean, body: SpawnResponseBody | null): SpawnOutcome {
+  /* A terminal replay retains its durable card identity while releasing the
+     draft guard for a fresh clientAttemptId. */
+  if (body?.retrySafe) return { kind: "failed-preflight", message: body.error ?? null };
   if (ok && body?.ok) {
     const path = typeof body.path === "string" ? body.path : null;
     const conversationId = typeof body.conversationId === "string" ? body.conversationId : null;
@@ -243,8 +247,6 @@ export function classifySpawnResponse(status: number, ok: boolean, body: SpawnRe
       launchId,
     };
   }
-  /* A replay of a receipt that failed before launch is explicitly retry-safe. */
-  if (body?.retrySafe) return { kind: "failed-preflight", message: body?.error ?? null };
   /* A conflicting attempt (same key, different request) can leave the
      original worker alive. Send stays disabled. */
   if (status === 409) return { kind: "ambiguous" };

--- a/src/components/tasks/taskApi.ts
+++ b/src/components/tasks/taskApi.ts
@@ -27,9 +27,16 @@ export interface TaskSendResult {
 
 export interface TaskSpawnResult {
   task: BoardTask;
-  target: string;
+  target: string | null;
   path: string | null;
   panePid: number | null;
+  launchId: string;
+  conversationId: string;
+  initialMessage: "pending" | "queued" | "delivered" | "failed";
+  state: "starting" | "path-pending" | "settled" | "failed" | "conflict";
+  retrySafe: boolean;
+  assignment: "delivered" | "failed" | "spawning" | "handoff";
+  error?: string;
 }
 
 type ApiResult<T> = { ok: true; data: T } | { ok: false; error: string; status: number };
@@ -208,6 +215,7 @@ export interface SpawnAgentInput {
   cwd: string;
   effort?: string;
   fast?: boolean;
+  clientAttemptId?: string;
 }
 
 /** Spawns an agent with the task text as the brief; same stale-text guard

--- a/src/hooks/useFiles.ts
+++ b/src/hooks/useFiles.ts
@@ -8,6 +8,7 @@ import { PIPELINES_CHANGED_EVENT, PIPELINES_PATCHED_EVENT } from "@/components/p
 import { SESSION_TITLES_CHANGED_EVENT } from "@/components/session/sessionTitleApi";
 import { TASKS_CHANGED_EVENT } from "@/components/tasks/taskApi";
 import { WORKFLOWS_CHANGED_EVENT } from "@/components/workflows/workflowModel";
+import { FILES_CHANGED_EVENT } from "@/lib/filesEvents";
 import type { Flow } from "@/lib/flows/types";
 import type { Pipeline } from "@/lib/pipelines/types";
 import type { BoardTask } from "@/lib/tasks/types";
@@ -598,6 +599,7 @@ export function useFiles(_project?: string | null, pinnedPath?: string | null): 
     window.addEventListener(WORKFLOWS_CHANGED_EVENT, onChanged);
     window.addEventListener(TASKS_CHANGED_EVENT, onChanged);
     window.addEventListener(SESSION_TITLES_CHANGED_EVENT, onChanged);
+    window.addEventListener(FILES_CHANGED_EVENT, onChanged);
 
     let unsubBus = () => {};
     let unsubFiles = () => {};
@@ -649,6 +651,7 @@ export function useFiles(_project?: string | null, pinnedPath?: string | null): 
       window.removeEventListener(WORKFLOWS_CHANGED_EVENT, onChanged);
       window.removeEventListener(TASKS_CHANGED_EVENT, onChanged);
       window.removeEventListener(SESSION_TITLES_CHANGED_EVENT, onChanged);
+      window.removeEventListener(FILES_CHANGED_EVENT, onChanged);
     };
   }, [pinnedPath]);
   return data.requestScope === requestScope ? data : filesClientCache.readScope(pinnedPath);

--- a/src/lib/agent/registry.ts
+++ b/src/lib/agent/registry.ts
@@ -1035,7 +1035,10 @@ function recordMembership(
   const rows = file.memberships[canonicalConversationId] ?? [];
   const existing = rows.find((row) => row.kind === membership.kind && row.containerId === membership.containerId && row.slot === membership.slot);
   if (existing) {
-    const immutableShape = ({ createdAt: _createdAt, ...row }: DurableConversationMembership) => row;
+    const immutableShape = ({ createdAt, ...row }: DurableConversationMembership) => {
+      void createdAt;
+      return row;
+    };
     if (JSON.stringify(immutableShape(existing)) !== JSON.stringify(immutableShape(membership))) {
       throw new Error("durable membership is immutable");
     }
@@ -2445,6 +2448,40 @@ export class AgentRegistry {
       receipt.completionMode = receipt.completionMode ?? "route-recovered";
       advanceMigrationScopeRevision(file, receipt.key.engine, readinessBefore, changedHostPaths);
       return { kind: "settled", receipt: clone(receipt), entry: clone(entry), conversation: clone(conversation) };
+    });
+  }
+
+  /** Strong runtime or transcript evidence may arrive after host cleanup marks
+      a structured launch failed. Restore the same reserved conversation and
+      generation while preserving its launch identity. */
+  recoverStructuredSpawnFromEvidence(
+    launchId: string,
+    evidence?: Omit<AgentRegistryEntry, "updatedAt">,
+  ): SpawnSettlement {
+    return this.mutate((file) => {
+      const receipt = file.receipts[launchId];
+      if (!receipt) throw new Error("unknown spawn receipt");
+      if (receipt.state === "conflicted") {
+        return { kind: "conflict", receipt: clone(receipt), code: "spawn_identity_conflict" };
+      }
+      const stored = receipt.key ? file.entries[sessionKeyId(receipt.key)] : null;
+      let storedEvidence: Omit<AgentRegistryEntry, "updatedAt"> | null = null;
+      if (stored) {
+        const { updatedAt, ...entry } = stored;
+        void updatedAt;
+        storedEvidence = entry;
+      }
+      const candidate = evidence ?? storedEvidence;
+      if (!candidate
+        || (receipt.key && sessionKeyId(receipt.key) !== sessionKeyId(candidate.key))
+        || (receipt.artifactPath && receipt.artifactPath !== candidate.artifactPath)) {
+        return { kind: "conflict", receipt: clone(receipt), code: "spawn_identity_conflict" };
+      }
+      if (receipt.state === "failed") {
+        receipt.state = receipt.key ? "path-pending" : "starting";
+        receipt.error = null;
+      }
+      return this.settleSpawnInFile(file, launchId, candidate, "route-recovered");
     });
   }
 

--- a/src/lib/agent/spawnProjection.ts
+++ b/src/lib/agent/spawnProjection.ts
@@ -1,0 +1,125 @@
+import path from "node:path";
+
+import type { RegistryFile, SpawnReceipt } from "./registry";
+import { projectInfoFromCwd, projectRootForCwd } from "@/lib/scanner/describe";
+import type { FileEntry, StructuredSpawnCardState } from "@/lib/types";
+
+function initialDelivery(snapshot: RegistryFile, receipt: SpawnReceipt) {
+  return Object.values(snapshot.heldDeliveries).find((delivery) =>
+    delivery.conversationId === receipt.conversationId
+      && delivery.clientMessageId === `spawn_${receipt.launchId}`) ?? null;
+}
+
+function cardState(snapshot: RegistryFile, receipt: SpawnReceipt): StructuredSpawnCardState {
+  const delivery = initialDelivery(snapshot, receipt);
+  const failed = receipt.state === "failed" || receipt.state === "conflicted";
+  const delivered = delivery?.state === "delivered" || receipt.state === "completed";
+  const queued = Boolean(delivery)
+    || receipt.state === "prompt-delivered";
+  const binding = receipt.state === "pane-bound"
+    || receipt.state === "host-verified"
+    || Boolean(receipt.key || receipt.artifactPath);
+  let state: StructuredSpawnCardState["state"] = "starting";
+  let initialMessage: StructuredSpawnCardState["initialMessage"] = "pending";
+  if (failed) {
+    state = "failed";
+    initialMessage = "failed";
+  } else if (delivered) {
+    state = "recovered";
+    initialMessage = "delivered";
+  } else if (queued) {
+    state = "queued";
+    initialMessage = "queued";
+  } else if (binding) {
+    state = "binding";
+  }
+  return {
+    launchId: receipt.launchId,
+    clientAttemptId: receipt.clientAttemptId,
+    accountId: receipt.accountId,
+    state,
+    initialMessage,
+    retrySafe: receipt.state === "failed",
+    error: receipt.error,
+  };
+}
+
+function newestUnscannedReceipts(files: readonly FileEntry[], snapshot: RegistryFile): SpawnReceipt[] {
+  const scannedConversations = new Set(files.flatMap((file) => file.conversationId ? [file.conversationId] : []));
+  const scannedPaths = new Set(files.map((file) => file.path));
+  const byConversation = new Map<string, SpawnReceipt>();
+  for (const receipt of Object.values(snapshot.receipts)) {
+    if (receipt.transport !== "structured" || receipt.purpose !== "launch") continue;
+    if (scannedConversations.has(receipt.conversationId)) continue;
+    if (receipt.artifactPath && scannedPaths.has(receipt.artifactPath)) continue;
+    const current = byConversation.get(receipt.conversationId);
+    if (!current || current.createdAt < receipt.createdAt) byConversation.set(receipt.conversationId, receipt);
+  }
+  return [...byConversation.values()];
+}
+
+export function preallocatedStructuredSpawnCards(
+  files: readonly FileEntry[],
+  snapshot: RegistryFile,
+): FileEntry[] {
+  const scannedPaths = new Set(files.map((file) => file.path));
+  return newestUnscannedReceipts(files, snapshot).map((receipt) => {
+    const spawn = cardState(snapshot, receipt);
+    const project = projectInfoFromCwd(receipt.cwd);
+    const edge = snapshot.lineageEdges[receipt.conversationId];
+    const parentConversationId = edge?.parentConversationId ?? receipt.parentConversationId;
+    const parentPath = parentConversationId
+      ? snapshot.conversations[parentConversationId]?.generations.at(-1)?.path ?? null
+      : null;
+    const memberships = snapshot.memberships[receipt.conversationId] ?? [];
+    return {
+      path: `spawn:${receipt.launchId}`,
+      root: receipt.engine === "codex" ? "codex-sessions" : "claude-projects",
+      name: `spawn:${receipt.launchId}`,
+      project: project?.project ?? path.basename(receipt.cwd),
+      cwd: receipt.cwd,
+      projectRoot: projectRootForCwd(receipt.cwd) ?? null,
+      ...(project?.worktree ? { worktree: project.worktree } : {}),
+      title: receipt.launchProfile.title ?? (receipt.engine === "codex" ? "Codex" : "Claude"),
+      engine: receipt.engine,
+      kind: "session",
+      fmt: receipt.engine,
+      parent: parentPath && scannedPaths.has(parentPath) ? parentPath : null,
+      ...(parentPath && scannedPaths.has(parentPath) ? { handoff: true } : {}),
+      mtime: Date.parse(receipt.createdAt) / 1000,
+      size: 0,
+      activity: spawn.state === "failed" ? "stalled" : spawn.state === "recovered" ? "recent" : "live",
+      activityReason: `structured_spawn_${spawn.state}`,
+      proc: null,
+      pid: null,
+      model: receipt.launchProfile.model,
+      launchModel: receipt.launchProfile.model,
+      effort: receipt.launchProfile.effort,
+      fast: receipt.launchProfile.fast,
+      pendingQuestion: null,
+      plan: receipt.launchProfile.plan,
+      goal: receipt.launchProfile.goal,
+      waitingInput: null,
+      conversationId: receipt.conversationId,
+      ...(edge || memberships.length ? {
+        durableLineage: {
+          kind: edge?.kind ?? "spawn",
+          role: edge?.role ?? null,
+          parentConversationId: edge?.parentConversationId ?? receipt.parentConversationId,
+          reviewsConversationId: edge?.reviewsConversationId ?? null,
+          memberships: memberships.map((membership) => ({
+            kind: membership.kind,
+            containerId: membership.containerId,
+            role: membership.role,
+            slot: membership.slot,
+            stageId: membership.stageId,
+            stageOrder: membership.stageOrder,
+            round: membership.round,
+            parentConversationId: membership.parentConversationId,
+          })),
+        },
+      } : {}),
+      spawn,
+    };
+  });
+}

--- a/src/lib/agent/spawnResponse.ts
+++ b/src/lib/agent/spawnResponse.ts
@@ -11,7 +11,8 @@ export interface SpawnResponse {
   conversationId: string;
   launched: boolean;
   retrySafe: boolean;
-  state: "settled" | "path-pending" | "starting" | "conflict";
+  initialMessage: "pending" | "queued" | "delivered" | "failed";
+  state: "settled" | "path-pending" | "starting" | "failed" | "conflict";
   error?: string;
 }
 
@@ -19,19 +20,30 @@ export function spawnReplayStatus(response: SpawnResponse, structured: boolean):
   return response.state === "starting" || (structured && response.state === "path-pending") ? 202 : 200;
 }
 
+function initialMessageForReceipt(receipt: SpawnReceipt, structured: boolean): SpawnResponse["initialMessage"] {
+  if (receipt.state === "failed" || receipt.state === "conflicted") return "failed";
+  if (receipt.state === "completed" || receipt.state === "prompt-delivered") return "delivered";
+  if (structured && receipt.state === "path-pending") return "queued";
+  return "pending";
+}
+
+function responseStateForReceipt(receipt: SpawnReceipt): SpawnResponse["state"] {
+  if (receipt.state === "conflicted") return "conflict";
+  if (receipt.state === "failed") return "failed";
+  if (receipt.state === "starting" || receipt.state === "pane-bound") return "starting";
+  if (receipt.state === "host-verified" || receipt.state === "prompt-delivered" || receipt.state === "path-pending") {
+    return "path-pending";
+  }
+  return "settled";
+}
+
 export function spawnResponseForReceipt(
   receipt: SpawnReceipt,
   path = receipt.artifactPath,
-  options: { structured?: boolean } = {},
+  options: { structured?: boolean; initialMessage?: SpawnResponse["initialMessage"] } = {},
 ): SpawnResponse {
   const structured = receipt.transport === "structured"
     || (receipt.transport === null && options.structured === true);
-  const conflict = receipt.state === "conflicted";
-  const pending = receipt.state === "starting"
-    || receipt.state === "pane-bound"
-    || receipt.state === "host-verified"
-    || receipt.state === "prompt-delivered"
-    || receipt.state === "path-pending";
   const launched = (receipt.verifiedHost !== null || (options.structured === true && receipt.state === "completed"))
     && receipt.state !== "failed"
     && receipt.state !== "conflicted";
@@ -46,11 +58,8 @@ export function spawnResponseForReceipt(
     conversationId: receipt.conversationId,
     launched,
     retrySafe: receipt.state === "failed",
+    initialMessage: options.initialMessage ?? initialMessageForReceipt(receipt, structured),
     ...(receipt.error ? { error: receipt.error } : {}),
-    state: conflict
-      ? "conflict"
-      : pending
-        ? (receipt.state === "path-pending" || receipt.state === "prompt-delivered" || receipt.state === "host-verified" ? "path-pending" : "starting")
-        : "settled",
+    state: responseStateForReceipt(receipt),
   };
 }

--- a/src/lib/delivery.test.ts
+++ b/src/lib/delivery.test.ts
@@ -350,6 +350,7 @@ test.each(["codex", "claude"] as const)("%s send follows verified tmux rollback 
         conversationId: begun.receipt.conversationId,
         launched: true,
         retrySafe: false,
+        initialMessage: "delivered" as const,
         state: "settled",
       };
     },

--- a/src/lib/filesEvents.ts
+++ b/src/lib/filesEvents.ts
@@ -1,0 +1,5 @@
+export const FILES_CHANGED_EVENT = "llv:files-changed";
+
+export function requestFilesRefresh(): void {
+  if (typeof window !== "undefined") window.dispatchEvent(new Event(FILES_CHANGED_EVENT));
+}

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -301,6 +301,18 @@ export const en = {
   "composer.quickAckTitle": "Quick reply — yes, continue",
 
   // DraftAgentPane
+  "spawnCard.starting": "Launch admitted. Starting the agent.",
+  "spawnCard.binding": "Agent identity allocated. Binding the structured host.",
+  "spawnCard.queued": "The structured host is ready. The initial message is queued.",
+  "spawnCard.failed": "The launch ended with an error.",
+  "spawnCard.recovered": "Durable evidence recovered this launch.",
+  "spawnCard.initial.pending": "Initial message: waiting for host binding",
+  "spawnCard.initial.queued": "Initial message: queued",
+  "spawnCard.initial.delivered": "Initial message: delivered",
+  "spawnCard.initial.failed": "Initial message: failed",
+  "spawnCard.retrySafe": "This launch is closed. You can start a new attempt.",
+  "spawnCard.launch": "Launch {id}",
+
   "draft.readPrompt": "Read the agent conversation in file {src} and continue from there: ",
   "draft.needDir": "specify a working directory",
   "draft.launchFailed": "couldn't launch",

--- a/src/lib/i18n/uk.ts
+++ b/src/lib/i18n/uk.ts
@@ -292,6 +292,18 @@ export const uk: Record<keyof typeof en, Message> = {
   "composer.quickAckAria": "Надіслати агенту швидке «Так, продовжуй»",
   "composer.quickAckTitle": "Швидка відповідь — так, продовжуй",
 
+  "spawnCard.starting": "Запуск прийнято. Агент запускається.",
+  "spawnCard.binding": "Ідентифікатор агента створено. Під’єднуємо структурований хост.",
+  "spawnCard.queued": "Структурований хост готовий. Перше повідомлення в черзі.",
+  "spawnCard.failed": "Запуск завершився з помилкою.",
+  "spawnCard.recovered": "Запуск відновлено за збереженими даними.",
+  "spawnCard.initial.pending": "Перше повідомлення: очікує на під’єднання хоста",
+  "spawnCard.initial.queued": "Перше повідомлення: у черзі",
+  "spawnCard.initial.delivered": "Перше повідомлення: доставлено",
+  "spawnCard.initial.failed": "Перше повідомлення: помилка доставки",
+  "spawnCard.retrySafe": "Цей запуск завершено. Можна створити нову спробу.",
+  "spawnCard.launch": "Запуск {id}",
+
   "draft.readPrompt": "Прочитай розмову агента у файлі {src} і продовж роботу звідти: ",
   "draft.needDir": "вкажи робочу директорію",
   "draft.launchFailed": "не вдалося запустити",

--- a/src/lib/runtime/structuredRecovery.test.ts
+++ b/src/lib/runtime/structuredRecovery.test.ts
@@ -192,6 +192,7 @@ test("dead Codex structured recovery retains ownership and starts a pane-less re
         conversationId: conversation.id,
         launched: true,
         retrySafe: false,
+        initialMessage: "delivered" as const,
         state: "settled",
       };
     },
@@ -321,6 +322,7 @@ test("dead Claude structured recovery retains ownership and starts a pane-less r
         conversationId: conversation.id,
         launched: true,
         retrySafe: false,
+        initialMessage: "delivered" as const,
         state: "settled",
       };
     },
@@ -420,6 +422,7 @@ test("Codex and Claude worker and root recovery retain their original lineage sh
           conversationId: conversation.id,
           launched: true,
           retrySafe: false,
+          initialMessage: "delivered" as const,
           state: "settled",
         }),
       });
@@ -623,6 +626,7 @@ test.each(["codex", "claude"] as const)("concurrent %s sends wait for recovery p
           conversationId: conversation.id,
           launched: true,
           retrySafe: false,
+          initialMessage: "delivered" as const,
           state: "settled",
         };
       },

--- a/src/lib/runtime/structuredSpawn.integration.test.ts
+++ b/src/lib/runtime/structuredSpawn.integration.test.ts
@@ -18,7 +18,7 @@ import { bindStructuredDeliveryQueue, hasStructuredDeliveryHost } from "./struct
 import { dispatchStructuredControl } from "./structuredControls";
 import { kickStructuredDeliveryQueue } from "./structuredDeliverySignal";
 import { enqueueStructuredMessage } from "./structuredMessageDelivery";
-import { recoverPendingStructuredSpawns, spawnStructuredConversation, structuredClaudePermissionMode, structuredClaudeSpawnPolicyBaseSettingsPath, type SpawnedStructuredHost } from "./structuredSpawn";
+import { INITIAL_MESSAGE_TIMEOUT_MS, reconcileStructuredSpawnReplay, recoverPendingStructuredSpawns, spawnStructuredConversation, structuredClaudePermissionMode, structuredClaudeSpawnPolicyBaseSettingsPath, waitForStructuredInitialMessage, type SpawnedStructuredHost } from "./structuredSpawn";
 import { materializeStructuredTerminal } from "./structuredTerminal";
 
 type UnsequencedEvent = RuntimeEvent extends infer Event
@@ -91,6 +91,238 @@ test("fresh managed Claude structured spawns select the shared settings snapshot
     .toBe("/shared/claude/settings.json");
   expect(structuredClaudeSpawnPolicyBaseSettingsPath(legacy, () => "/shared/claude/settings.json"))
     .toBeNull();
+});
+
+test("attempt e9e8a4b4 terminalizes a queued initial message after the bounded host timeout", async () => {
+  let now = 0;
+  let polls = 0;
+  const client = {
+    operationStatus: async () => {
+      polls += 1;
+      return {
+        receipt: {
+          operationId: "spawn_message_e9e8a4b4",
+          idempotencyKey: "spawn_e9e8a4b4",
+          conversationId: "conversation_e9e8a4b4",
+          kind: "send" as const,
+          status: "queued" as const,
+          at: new Date(0).toISOString(),
+          revision: polls,
+        },
+        replayed: polls > 1,
+      };
+    },
+  } as unknown as RuntimeHostClient;
+
+  await expect(waitForStructuredInitialMessage(client, "spawn_message_e9e8a4b4", {
+    now: () => now,
+    sleep: async (ms) => { now += ms; },
+  })).rejects.toThrow(`initial message remained queued for ${INITIAL_MESSAGE_TIMEOUT_MS}ms`);
+  expect(now).toBe(INITIAL_MESSAGE_TIMEOUT_MS);
+  expect(polls).toBeGreaterThan(1);
+});
+
+test("initial-message confirmation survives a transient runtime status read", async () => {
+  let now = 0;
+  let polls = 0;
+  const client = {
+    operationStatus: async () => {
+      polls += 1;
+      if (polls === 1) throw new Error("runtime socket is resynchronizing");
+      return {
+        receipt: {
+          operationId: "spawn_message_transient",
+          idempotencyKey: "spawn_transient",
+          conversationId: "conversation_transient",
+          kind: "send" as const,
+          status: "delivered" as const,
+          at: new Date(0).toISOString(),
+          revision: polls,
+        },
+        replayed: true,
+      };
+    },
+  } as unknown as RuntimeHostClient;
+
+  await waitForStructuredInitialMessage(client, "spawn_message_transient", {
+    now: () => now,
+    sleep: async (ms) => { now += ms; },
+  });
+
+  expect(polls).toBe(2);
+  expect(now).toBe(250);
+});
+
+test("attempt 93c42855 recovers a failed registry receipt from transcript evidence", async () => {
+  const id = crypto.randomUUID();
+  const cwd = path.join(sandbox, `transcript-replay-${id}`);
+  fs.mkdirSync(cwd, { recursive: true });
+  const artifactPath = path.join(cwd, `${id}.jsonl`);
+  const registry = new AgentRegistry(path.join(cwd, "registry.json"), undefined, undefined, { sqliteMode: "off" });
+  const journal = new RuntimeJournal(path.join(cwd, "runtime.sqlite"), { structuredHosts: true });
+  const begun = registry.beginSpawnRequest({
+    engine: "codex",
+    cwd,
+    transport: "structured",
+    accountId: "stikon",
+    clientAttemptId: "attempt_93c42855_stikon",
+  });
+  if (begun.kind !== "created") throw new Error("spawn receipt was unavailable");
+  registry.stageStructuredSpawn(begun.receipt.launchId, {
+    key: { engine: "codex", sessionId: id },
+    artifactPath,
+    cwd,
+    accountId: "stikon",
+    status: "unhosted",
+    host: null,
+    structuredHost: null,
+    claimEpoch: 0,
+    claimOwner: null,
+    pendingAction: "spawn",
+  });
+  registry.failStructuredSpawn(begun.receipt.launchId, "structured host ownership is unavailable");
+  fs.writeFileSync(artifactPath, `${JSON.stringify({ type: "event_msg", payload: { type: "user_message", message: "Own issue #282" } })}\n`);
+
+  const reconciled = await reconcileStructuredSpawnReplay(begun.receipt.launchId, registry, runtimeClient(journal));
+
+  expect(reconciled).toMatchObject({ state: "completed", initialMessage: "delivered" });
+  expect(registry.snapshot().receipts[begun.receipt.launchId]).toMatchObject({
+    state: "completed",
+    completionMode: "route-recovered",
+    error: null,
+  });
+});
+
+test("clientAttemptId replay materializes its reserved conversation from runtime evidence", async () => {
+  const id = crypto.randomUUID();
+  const cwd = path.join(sandbox, `runtime-replay-${id}`);
+  fs.mkdirSync(cwd, { recursive: true });
+  const artifactPath = path.join(cwd, `${id}.jsonl`);
+  const registry = new AgentRegistry(path.join(cwd, "registry.json"), undefined, undefined, { sqliteMode: "off" });
+  const begun = registry.beginSpawnRequest({
+    engine: "codex",
+    cwd,
+    transport: "structured",
+    accountId: "terra",
+    clientAttemptId: "p0_282_runtime_replay_20260716_a1",
+  });
+  if (begun.kind !== "created") throw new Error("spawn receipt was unavailable");
+  const client = {
+    snapshot: async () => ({
+      schemaVersion: 1,
+      snapshotSeq: 4,
+      retentionFloorSeq: 0,
+      serverTime: new Date().toISOString(),
+      runtime: { hostEpoch: 1, health: "ready" },
+      filesRevision: 0,
+      sessions: [{
+        conversationId: begun.receipt.conversationId,
+        sessionKey: { engine: "codex" as const, sessionId: id },
+        hostKind: "codex-app-server" as const,
+        host: "hosted" as const,
+        turn: "running" as const,
+        provenance: "structured" as const,
+        revision: 4,
+        attentionIds: [],
+        recentReceipts: [],
+        accountId: "terra",
+        parentConversationId: null,
+        flowId: null,
+        workflowId: null,
+        cwd,
+        artifactPath,
+        capabilities: { steer: true, structuredAttention: true },
+        activeTurnId: "turn-initial",
+      }],
+      attentions: [],
+      recentOperations: [],
+      edges: [],
+      flows: [],
+      workflows: [],
+      tasks: [],
+      deployments: [],
+    }),
+    operationStatus: async (operationId: string) => operationId === `spawn_message_${begun.receipt.launchId}` ? {
+      receipt: {
+        operationId,
+        idempotencyKey: `spawn_${begun.receipt.launchId}`,
+        conversationId: begun.receipt.conversationId,
+        kind: "send" as const,
+        status: "delivered" as const,
+        at: new Date().toISOString(),
+        revision: 2,
+      },
+      replayed: true,
+    } : null,
+  } as unknown as RuntimeHostClient;
+
+  const reconciled = await reconcileStructuredSpawnReplay(begun.receipt.launchId, registry, client);
+
+  expect(reconciled).toMatchObject({
+    state: "completed",
+    conversationId: begun.receipt.conversationId,
+    artifactPath,
+    key: { engine: "codex", sessionId: id },
+    initialMessage: "delivered",
+  });
+  expect(registry.snapshot().conversations[begun.receipt.conversationId]?.generations).toHaveLength(1);
+});
+
+test("p0_282 empty-host replay terminalizes the receipt and releases its stale guard", async () => {
+  const id = crypto.randomUUID();
+  const cwd = path.join(sandbox, `empty-host-replay-${id}`);
+  fs.mkdirSync(cwd, { recursive: true });
+  const artifactPath = path.join(cwd, `${id}.jsonl`);
+  const registry = new AgentRegistry(path.join(cwd, "registry.json"), undefined, undefined, { sqliteMode: "off" });
+  const begun = registry.beginSpawnRequest({
+    engine: "codex",
+    cwd,
+    transport: "structured",
+    accountId: "terra",
+    clientAttemptId: "p0_282_spawn_visibility_20260716_a1",
+  });
+  if (begun.kind !== "created") throw new Error("spawn receipt was unavailable");
+  registry.stageStructuredSpawn(begun.receipt.launchId, {
+    key: { engine: "codex", sessionId: id },
+    artifactPath,
+    cwd,
+    accountId: "terra",
+    status: "unhosted",
+    host: null,
+    structuredHost: null,
+    claimEpoch: 0,
+    claimOwner: null,
+    pendingAction: "spawn",
+  });
+  const client = {
+    snapshot: async () => ({ sessions: [] }),
+    operationStatus: async (operationId: string) => ({
+      receipt: {
+        operationId,
+        idempotencyKey: operationId,
+        conversationId: begun.receipt.conversationId,
+        kind: operationId === begun.receipt.launchId ? "spawn" as const : "send" as const,
+        status: operationId === begun.receipt.launchId ? "delivered" as const : "queued" as const,
+        at: begun.receipt.createdAt,
+        revision: 1,
+      },
+      replayed: true,
+    }),
+  } as unknown as RuntimeHostClient;
+  let released = 0;
+
+  const reconciled = await reconcileStructuredSpawnReplay(begun.receipt.launchId, registry, client, {
+    now: () => Date.parse(begun.receipt.createdAt) + INITIAL_MESSAGE_TIMEOUT_MS,
+    releaseHost: async () => { released += 1; return true; },
+  });
+
+  expect(reconciled).toMatchObject({ state: "failed", initialMessage: "failed" });
+  expect(registry.snapshot().entries[`codex:${id}`]).toMatchObject({
+    status: "dead",
+    claimOwner: null,
+    pendingAction: null,
+  });
+  expect(released).toBe(1);
 });
 
 function runtimeClient(journal: RuntimeJournal): RuntimeHostClient {

--- a/src/lib/runtime/structuredSpawn.ts
+++ b/src/lib/runtime/structuredSpawn.ts
@@ -9,10 +9,12 @@ import { sessionKey, sessionKeyId, type SessionKey } from "@/lib/agent/sessionKe
 import type { SpawnResponse } from "@/lib/agent/spawnResponse";
 import { claudeTranscriptPath } from "@/lib/agent/transcript";
 import { procBackend } from "@/lib/proc";
+import { hasUserAuthoredMessage } from "@/lib/session/reader";
 
 import { ClaudeStreamBrokerHost } from "./claudeStreamBrokerHost";
 import { CodexAppServerHost } from "./codexAppServerHost";
 import type { RuntimeHostClient } from "./client";
+import type { RuntimeOperationResult, RuntimeSession } from "./contracts";
 import type { EngineHost, HostState } from "./engineHost";
 import { bindClaudeHostPersistence, bindCodexHostPersistence } from "./registry";
 import { publishStructuredDeliveryHost, releaseStructuredDeliveryHost } from "./structuredDeliveryController";
@@ -21,6 +23,165 @@ export type SpawnedStructuredHost = EngineHost & {
   identity: { threadId: string; path: string | null } | { sessionId: string };
   onStateChange(listener: (state: HostState) => void): () => void;
 };
+
+export const INITIAL_MESSAGE_TIMEOUT_MS = 30_000;
+const INITIAL_MESSAGE_POLL_MS = 250;
+const INITIAL_MESSAGE_DELIVERED = new Set(["delivered", "turn-started", "steered"]);
+const INITIAL_MESSAGE_FAILED = new Set(["failed", "rejected", "uncertain", "interrupted"]);
+
+function runtimeEntryStatus(session: RuntimeSession): "dead" | "live" | "idle" {
+  if (session.host === "dead" || session.host === "unhosted") return "dead";
+  if (session.turn === "running") return "live";
+  return "idle";
+}
+
+function failedOperationReason(operation: RuntimeOperationResult | null, subject: string): string | null {
+  const status = operation?.receipt.status;
+  if (!status || !INITIAL_MESSAGE_FAILED.has(status)) return null;
+  return operation.receipt.reason ?? `${subject} ended as ${status}`;
+}
+
+function reconciledInitialMessage(
+  receipt: SpawnReceipt,
+  status: string | undefined,
+  runtimeDelivered: boolean,
+): "pending" | "queued" | "delivered" | "failed" {
+  if (receipt.state === "failed" || (status !== undefined && INITIAL_MESSAGE_FAILED.has(status))) return "failed";
+  if (runtimeDelivered || receipt.state === "completed") return "delivered";
+  if (status === "queued" || status === "pending" || status === "delivering") return "queued";
+  return "pending";
+}
+
+export async function waitForStructuredInitialMessage(
+  client: RuntimeHostClient,
+  operationId: string,
+  options: {
+    now?: () => number;
+    sleep?: (ms: number) => Promise<void>;
+    timeoutMs?: number;
+    pollMs?: number;
+  } = {},
+): Promise<void> {
+  const now = options.now ?? Date.now;
+  const sleep = options.sleep ?? ((ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms)));
+  const timeoutMs = options.timeoutMs ?? INITIAL_MESSAGE_TIMEOUT_MS;
+  const pollMs = options.pollMs ?? INITIAL_MESSAGE_POLL_MS;
+  const deadline = now() + timeoutMs;
+  let lastStatus: string | undefined;
+  let lastReadError: string | null = null;
+  for (;;) {
+    let operation: Awaited<ReturnType<RuntimeHostClient["operationStatus"]>> = null;
+    try {
+      operation = await client.operationStatus(operationId, { currentRetryLeaf: true });
+      lastStatus = operation?.receipt.status ?? lastStatus;
+      lastReadError = null;
+    } catch (error) {
+      lastReadError = error instanceof Error ? error.message : "runtime status read failed";
+    }
+    const status = operation?.receipt.status ?? lastStatus;
+    if (status && INITIAL_MESSAGE_DELIVERED.has(status)) return;
+    if (status && INITIAL_MESSAGE_FAILED.has(status)) {
+      throw new Error(operation?.receipt.reason ?? `structured initial message ended as ${status}`);
+    }
+    if (now() >= deadline) {
+      if (lastReadError) {
+        throw new Error(`structured initial message status remained unavailable for ${timeoutMs}ms: ${lastReadError}`);
+      }
+      throw new Error(`structured initial message remained ${status ?? "pending"} for ${timeoutMs}ms`);
+    }
+    await sleep(Math.min(pollMs, deadline - now()));
+  }
+}
+
+export async function reconcileStructuredSpawnReplay(
+  launchId: string,
+  registry: AgentRegistry,
+  client: RuntimeHostClient,
+  options: {
+    now?: () => number;
+    timeoutMs?: number;
+    releaseHost?: (key: SessionKey) => Promise<boolean>;
+  } = {},
+): Promise<SpawnReceipt & { initialMessage: "pending" | "queued" | "delivered" | "failed" }> {
+  const current = registry.snapshot().receipts[launchId];
+  if (!current) throw new Error("unknown spawn receipt");
+  const [operation, spawnOperation, runtime] = await Promise.all([
+    client.operationStatus(`spawn_message_${launchId}`, { currentRetryLeaf: true }).catch(() => null),
+    client.operationStatus(launchId, { currentRetryLeaf: true }).catch(() => null),
+    client.snapshot().catch(() => null),
+  ]);
+  const runtimeDelivered = Boolean(operation
+    && operation.receipt.conversationId === current.conversationId
+    && INITIAL_MESSAGE_DELIVERED.has(operation.receipt.status));
+  const transcriptDelivered = Boolean(current.artifactPath
+    && hasUserAuthoredMessage(current.artifactPath, current.engine));
+  if (runtimeDelivered || transcriptDelivered) {
+    const session = runtime?.sessions.find((candidate) => candidate.conversationId === current.conversationId);
+    const sessionMatches = session
+      && session.sessionKey.engine === current.engine
+      && session.cwd === current.cwd
+      && typeof session.artifactPath === "string"
+      ? session
+      : null;
+    const evidence = sessionMatches ? {
+      key: sessionMatches.sessionKey,
+      artifactPath: sessionMatches.artifactPath!,
+      cwd: current.cwd,
+      accountId: current.accountId,
+      launchProfile: current.launchProfile,
+      status: runtimeEntryStatus(sessionMatches),
+      host: null,
+      structuredHost: sessionMatches.hostKind === "codex-app-server" || sessionMatches.hostKind === "claude-broker"
+        ? {
+          kind: sessionMatches.hostKind,
+          endpoint: "runtime:reconciled",
+          process: null,
+          eventCursor: sessionMatches.revision,
+          protocolVersion: null,
+          writerClaimEpoch: 0,
+          activeTurnRef: sessionMatches.activeTurnId,
+          pendingAttention: sessionMatches.attentionIds,
+          activeFlags: [],
+        }
+        : null,
+      claimEpoch: 0,
+      claimOwner: null,
+      pendingAction: null,
+    } : undefined;
+    const recovered = registry.recoverStructuredSpawnFromEvidence(launchId, evidence);
+    if (recovered.kind === "settled") {
+      return { ...recovered.receipt, initialMessage: "delivered" };
+    }
+  }
+  const messageStatus = operation?.receipt.status;
+  const runtimeSession = runtime?.sessions.find((candidate) => candidate.conversationId === current.conversationId) ?? null;
+  const ageMs = (options.now ?? Date.now)() - Date.parse(current.createdAt);
+  const timeoutMs = options.timeoutMs ?? INITIAL_MESSAGE_TIMEOUT_MS;
+  let terminalReason = failedOperationReason(operation, "structured initial message")
+    ?? failedOperationReason(spawnOperation, "structured spawn");
+  if (!terminalReason
+    && current.state !== "completed"
+    && current.state !== "failed"
+    && runtime
+    && ageMs >= timeoutMs) {
+    terminalReason = runtimeSession
+      ? `structured initial message remained ${messageStatus ?? "pending"} for ${timeoutMs}ms`
+      : `structured spawn runtime snapshot has no session after ${timeoutMs}ms`;
+  }
+  if (terminalReason) {
+    registry.failStructuredSpawn(launchId, terminalReason.slice(0, 240));
+    if (current.key) {
+      await (options.releaseHost ?? releaseStructuredDeliveryHost)(current.key).catch(() => false);
+    }
+    const failed = registry.snapshot().receipts[launchId] ?? current;
+    return { ...failed, initialMessage: "failed" };
+  }
+  const receipt = registry.snapshot().receipts[launchId] ?? current;
+  return {
+    ...receipt,
+    initialMessage: reconciledInitialMessage(receipt, messageStatus, runtimeDelivered),
+  };
+}
 
 export interface StructuredSpawnInput {
   engine: AgentEngine;
@@ -323,6 +484,10 @@ async function defaultDeliverFirst(input: StructuredSpawnInput, artifactPath: st
     enabled: () => true,
   });
   if (!delivered?.ok) throw new Error(delivered?.error ?? "structured spawn first-message delivery was unavailable");
+  if (delivered.outcome === "held") throw new Error("structured spawn first message entered a migration hold");
+  if (delivered.outcome !== "delivered") {
+    await waitForStructuredInitialMessage(input.client, delivered.operationId);
+  }
 }
 
 async function cleanupHost(host: SpawnedStructuredHost | null, binding: HostBinding): Promise<void> {
@@ -394,6 +559,7 @@ export async function spawnStructuredConversation(
       conversationId: settled.conversation.id,
       launched: true,
       retrySafe: false,
+      initialMessage: "delivered",
       state: "settled",
     };
   } catch (error) {

--- a/src/lib/scanner/describe.test.ts
+++ b/src/lib/scanner/describe.test.ts
@@ -46,6 +46,11 @@ test("parseWorktreeGitdir rejects gitdirs that are not linked worktrees", () => 
   expect(parseWorktreeGitdir("/home/u/sub", "gitdir: /home/u/worktrees/x")).toBeNull();
 });
 
+test("an absent cwd cannot inherit the Viewer process project", () => {
+  expect(projectForCwd("")).toBeNull();
+  expect(projectForCwd("   ")).toBeNull();
+});
+
 test("search text hydration retries after a transient filesystem failure", () => {
   const transcript = path.join(SANDBOX, "transient-search.jsonl");
   fs.writeFileSync(transcript, JSON.stringify({ type: "user", message: { content: "Recovered search prompt" } }) + "\n");

--- a/src/lib/scanner/describe.ts
+++ b/src/lib/scanner/describe.ts
@@ -499,7 +499,8 @@ function persistedProjects(): {
     slugs name it (`projectFromSlug` of the dashed path). One naming scheme
     means a codex session, a claude session, and any worktree of the same repo
     all land in the SAME sidebar group instead of lookalike neighbors. */
-function projectInfoFromCwd(cwd: string): { project: string; worktree?: string; repo?: string } | null {
+export function projectInfoFromCwd(cwd: string): { project: string; worktree?: string; repo?: string } | null {
+  if (!cwd.trim()) return null;
   const scratchpad = projectInfoFromClaudeTaskCwd(cwd);
   if (scratchpad) return scratchpad;
   let worktree =

--- a/src/lib/scanner/discover.test.ts
+++ b/src/lib/scanner/discover.test.ts
@@ -1469,7 +1469,7 @@ test("discoverFilesWithProjectCatalog keeps quiet projects in the recent cap", a
   }
 });
 
-test("registry launch projects govern scheme caps and the uncapped project catalog", async () => {
+test("registry launch cwd governs scheme caps and the uncapped project catalog", async () => {
   const base = await mkdtemp(path.join(os.tmpdir(), "llv-discover-launch-project-cap-"));
   const previousStateDir = process.env.LLV_STATE_DIR;
   process.env.LLV_STATE_DIR = path.join(base, "state");
@@ -1483,6 +1483,7 @@ test("registry launch projects govern scheme caps and the uncapped project catal
     };
     await Promise.all(Object.values(roots).map((root) => mkdir(root, { recursive: true })));
     const paths: string[] = [];
+    const canonicalProject = projectForCwd(base)!;
     for (let index = 0; index < DEFAULT_SCHEME_CARDS_PER_PROJECT * 2; index += 1) {
       const scannerProject = index % 2 === 0 ? "scanner-a" : "scanner-b";
       const pathname = path.join(roots["claude-projects"], scannerProject, `session-${index}.jsonl`);
@@ -1500,9 +1501,9 @@ test("registry launch projects govern scheme caps and the uncapped project catal
 
     const scan = await discoverFilesWithProjectCatalog(roots);
 
-    expect(scan.files.filter((entry) => entry.project === "effective-project")).toHaveLength(DEFAULT_SCHEME_CARDS_PER_PROJECT);
+    expect(scan.files.filter((entry) => entry.project === canonicalProject)).toHaveLength(DEFAULT_SCHEME_CARDS_PER_PROJECT);
     expect(scan.projectCatalog).toEqual([{
-      project: "effective-project",
+      project: canonicalProject,
       conversations: DEFAULT_SCHEME_CARDS_PER_PROJECT * 2,
       smt: 1_700_030_000 + DEFAULT_SCHEME_CARDS_PER_PROJECT * 2 - 1,
     }]);

--- a/src/lib/session/titleProjection.ts
+++ b/src/lib/session/titleProjection.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 
 import { agentRegistry, RegistryReadError } from "@/lib/agent/registry";
 import type { ViewerConversationId } from "@/lib/accounts/migration/contracts";
+import { projectInfoFromCwd } from "@/lib/scanner/describe";
 import type { FileEntry } from "@/lib/types";
 
 import { isRenameableSessionEntry } from "./renameEligibility";
@@ -65,7 +66,8 @@ function registryProjection(registry: Registry, surfaceUnexpectedError = false):
     for (const pathname of owned) if (!conversationByPath.has(pathname)) conversationByPath.set(pathname, conversation.id);
     const latest = conversation.generations.at(-1);
     if (!latest) continue;
-    if (latest.launchProfile.project) projectByPath.set(latest.path, latest.launchProfile.project);
+    const project = projectInfoFromCwd(latest.launchProfile.cwd)?.project ?? latest.launchProfile.project;
+    if (project) projectByPath.set(latest.path, project);
     for (const generation of conversation.generations) {
       if (generation.path !== latest.path) archivedPaths.add(generation.path);
     }
@@ -120,6 +122,10 @@ function sessionTitleProjector(): (entry: FileEntry) => void {
 
   return (entry) => {
     if (entry.engine !== "claude" && entry.engine !== "codex") return;
+    if (entry.spawn) {
+      entry.renamable = false;
+      return;
+    }
     const owner = conversationByPath.get(entry.path);
     if (!entry.conversationId) {
       if (owner) entry.conversationId = owner;
@@ -128,7 +134,9 @@ function sessionTitleProjector(): (entry: FileEntry) => void {
     const latest = conversation?.generations.at(-1);
     if (latest?.path === entry.path) {
       entry.title = latest.launchProfile.title ?? entry.title;
-      entry.project = latest.launchProfile.project ?? entry.project;
+      entry.project = projectInfoFromCwd(latest.launchProfile.cwd)?.project
+        ?? latest.launchProfile.project
+        ?? entry.project;
     }
     entry.renamable = isRenameableSessionEntry(entry);
     if (index.size > 0) {

--- a/src/lib/tasks/commands.ts
+++ b/src/lib/tasks/commands.ts
@@ -307,6 +307,9 @@ export function removeAssignment(existing: BoardTask[], id: string, path: string
 }
 
 export interface AssignmentPatch {
+  launchId?: string | null;
+  clientAttemptId?: string | null;
+  conversationId?: string | null;
   path: string | null;
   panePid: number | null;
   state: TaskAssignment["state"];
@@ -325,12 +328,19 @@ export function mergeAssignments(assignments: TaskAssignment[], patches: Assignm
   let next = assignments.slice();
   for (const patch of patches) {
     const index = next.findIndex((assignment) => {
+      if (patch.launchId && assignment.launchId === patch.launchId) return true;
       if (patch.path !== null && assignment.path === patch.path) return true;
       return patch.path === null && patch.panePid !== null && assignment.path === null && assignment.panePid === patch.panePid;
-    });
+      });
+    const previous = index >= 0 ? next[index] : undefined;
+    const launchId = patch.launchId !== undefined ? patch.launchId : previous?.launchId;
+    const clientAttemptId = patch.clientAttemptId !== undefined ? patch.clientAttemptId : previous?.clientAttemptId;
+    const conversationId = patch.conversationId !== undefined ? patch.conversationId : previous?.conversationId;
     const merged: TaskAssignment = {
+      ...(launchId !== undefined ? { launchId } : {}),
+      ...(clientAttemptId !== undefined ? { clientAttemptId } : {}),
       path: patch.path,
-      ...(index >= 0 && next[index]?.conversationId ? { conversationId: next[index]?.conversationId } : {}),
+      ...(conversationId !== undefined ? { conversationId } : {}),
       panePid: patch.panePid,
       state: patch.state,
       error: patch.error,

--- a/src/lib/tasks/store.ts
+++ b/src/lib/tasks/store.ts
@@ -52,6 +52,8 @@ export function isTaskAssignment(value: unknown): value is TaskAssignment {
   const assignment = value as Partial<TaskAssignment>;
   return (
     (typeof assignment.path === "string" || assignment.path === null) &&
+    (assignment.launchId === undefined || typeof assignment.launchId === "string" || assignment.launchId === null) &&
+    (assignment.clientAttemptId === undefined || typeof assignment.clientAttemptId === "string" || assignment.clientAttemptId === null) &&
     (assignment.conversationId === undefined || typeof assignment.conversationId === "string" || assignment.conversationId === null) &&
     (typeof assignment.panePid === "number" || assignment.panePid === null) &&
     (assignment.panePid === null || (Number.isInteger(assignment.panePid) && assignment.panePid > 0)) &&

--- a/src/lib/tasks/tasks.test.ts
+++ b/src/lib/tasks/tasks.test.ts
@@ -320,6 +320,42 @@ describe("task delivery assembly", () => {
     expect(result.task.assignments).toEqual([{ path: "/one", panePid: null, state: "delivered", error: null, at: "new" }]);
   });
 
+  test("task launch replay updates one assignment by durable launch identity", () => {
+    const launchId = "9173e9a2-2f14-4a70-818a-bd4052a1ad4a";
+    const conversationId = "conversation_ac6029b9";
+    const pending = mergeAssignments([], [{
+      launchId,
+      clientAttemptId: "task_282_post_launch_write",
+      conversationId,
+      path: null,
+      panePid: null,
+      state: "spawning",
+      error: null,
+      at: "admitted",
+    }]);
+    const attributed = mergeAssignments(pending, [{
+      launchId,
+      clientAttemptId: "task_282_post_launch_write",
+      conversationId,
+      path: "/sessions/recovered.jsonl",
+      panePid: 3627416,
+      state: "delivered",
+      error: null,
+      at: "replayed",
+    }]);
+
+    expect(attributed).toEqual([{
+      launchId,
+      clientAttemptId: "task_282_post_launch_write",
+      conversationId,
+      path: "/sessions/recovered.jsonl",
+      panePid: 3627416,
+      state: "delivered",
+      error: null,
+      at: "replayed",
+    }]);
+  });
+
   test("pins retries to the account owned by the requested engine", () => {
     const assignments = [
       { path: "/claude", panePid: 1, state: "failed" as const, error: "retry", at: "now", engine: "claude" as const, accountId: "claude-work" },

--- a/src/lib/tasks/types.ts
+++ b/src/lib/tasks/types.ts
@@ -3,6 +3,10 @@ export type TaskStatus = "inbox" | "assigned" | "blocked" | "done";
 export type AssignmentState = "delivered" | "failed" | "spawning" | "handoff";
 
 export interface TaskAssignment {
+  /** Durable Viewer launch identity used to replay attribution safely. */
+  launchId?: string | null;
+  /** Client idempotency key paired with launchId. */
+  clientAttemptId?: string | null;
   /** Transcript path; null while a codex spawn awaits scanner attribution. */
   path: string | null;
   /** Stable Viewer owner; paths remain native-generation provenance. */

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -13,6 +13,16 @@ export type Engine = "codex" | "claude" | "shell";
 export type Activity = "live" | "recent" | "stalled" | "idle";
 export type Fmt = "codex" | "claude" | "plain";
 
+export interface StructuredSpawnCardState {
+  launchId: string;
+  clientAttemptId: string | null;
+  accountId: string | null;
+  state: "starting" | "binding" | "queued" | "failed" | "recovered";
+  initialMessage: "pending" | "queued" | "delivered" | "failed";
+  retrySafe: boolean;
+  error: string | null;
+}
+
 /** Current quota wall affecting a hosted conversation. Account provenance
     joins the existing conversation identity at the read-model boundary. */
 export interface RateLimitState {
@@ -158,6 +168,8 @@ export interface FileEntry {
   /** Live per-session migration annotation while an intent drains. Absent for
       every session not currently migrating. */
   migration?: ConversationMigration;
+  /** Durable launch projection shown before its transcript enters the scan. */
+  spawn?: StructuredSpawnCardState;
 }
 
 /** Per-session migration annotation carried on a {@link FileEntry} while an


### PR DESCRIPTION
## Summary

- project durable structured launch receipts into the board before transcript discovery
- render starting, binding, queued, failed, and recovered launch outcomes in English and Ukrainian
- reconcile client attempts across registry, runtime, and transcript evidence while releasing terminal guards
- preserve task attribution across post-launch write failures and suppress duplicate cards
- derive project ownership from canonical cwd resolution throughout scanner and registry projections

## Verification

- Full Bun suite: 2,902 passed, 15,389 assertions
- Production-shaped issue #282 focused suites: 225 passed, 3,352 assertions
- TypeScript: bun x tsc --noEmit
- Changed-file ESLint: zero warnings
- Locale parity: 7 passed, 2,585 assertions
- Production build: Next.js 16.2.10 compiled and generated successfully
- Isolated production browser QA: five desktop states; English and Ukrainian mobile states; zero provisional composers, rename actions, or horizontal overflow
- Staged diff check and post-fix self-review: clean

Closes #282