### PR TITLE
Fence candidate startup and replace unhealthy releases

### DIFF
--- a/scripts/runtime-host-viewer-adapter.test.ts
+++ b/scripts/runtime-host-viewer-adapter.test.ts
@@ -1,0 +1,76 @@
+import { expect, test } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const root = path.resolve(import.meta.dir, "..");
+const adapter = path.join(root, "scripts", "runtime-host-viewer-adapter.ts");
+const release = {
+  container: "viewer-current",
+  endpoint: "http://127.0.0.1:19892",
+  image: "viewer:test",
+  revision: "a".repeat(40),
+};
+
+async function currentRelease(options: { target: string; containerState?: "running" | "exited"; timeoutMs?: number }) {
+  const sandbox = fs.mkdtempSync(path.join(os.tmpdir(), "llv-current-release-adapter-"));
+  const state = path.join(sandbox, "state");
+  const bin = path.join(sandbox, "bin");
+  fs.mkdirSync(state, { recursive: true });
+  fs.mkdirSync(bin, { recursive: true });
+  fs.writeFileSync(path.join(state, "viewer-release.json"), options.target);
+  const docker = path.join(bin, "docker");
+  fs.writeFileSync(docker, `#!/bin/sh
+if [ "$1" = "container" ] && [ "$2" = "inspect" ]; then exit 0; fi
+if [ "$1" = "inspect" ] && [ "$2" = "--format" ]; then printf '%s\\n' "$FAKE_DOCKER_STATE"; exit 0; fi
+exit 1
+`, { mode: 0o755 });
+
+  const child = Bun.spawn([process.execPath, adapter, "current-release"], {
+    cwd: root,
+    env: {
+      ...process.env,
+      PATH: `${bin}:${process.env.PATH ?? ""}`,
+      FAKE_DOCKER_STATE: options.containerState ?? "running",
+      LLV_DEPLOYMENT_ADAPTER_PROTOCOL: "1",
+      LLV_STATE_DIR: state,
+      LLV_VIEWER_PORT: "1",
+    },
+    stdin: "pipe",
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  child.stdin.write("{}\n");
+  child.stdin.end();
+  const timeout = Symbol("timeout");
+  const result = await Promise.race([
+    child.exited,
+    Bun.sleep(options.timeoutMs ?? 1_500).then(() => timeout),
+  ]);
+  if (result === timeout) {
+    child.kill("SIGKILL");
+    await child.exited;
+  }
+  const stdout = await new Response(child.stdout).text();
+  const stderr = await new Response(child.stderr).text();
+  fs.rmSync(sandbox, { recursive: true, force: true });
+  return { code: result === timeout ? 124 : result, stdout, stderr };
+}
+
+test("running rollback target remains available while its HTTP application is unhealthy", async () => {
+  const result = await currentRelease({ target: JSON.stringify(release) });
+  expect(result.code).toBe(0);
+  expect(JSON.parse(result.stdout)).toEqual(release);
+});
+
+test("stopped rollback target blocks promotion with container evidence", async () => {
+  const result = await currentRelease({ target: JSON.stringify(release), containerState: "exited" });
+  expect(result.code).not.toBe(0);
+  expect(result.stderr).toContain("current release container is exited");
+});
+
+test("malformed rollback target blocks promotion with a durable-target error", async () => {
+  const result = await currentRelease({ target: "{broken" });
+  expect(result.code).not.toBe(0);
+  expect(result.stderr).toContain("current release target is invalid");
+});

--- a/scripts/runtime-host-viewer-adapter.ts
+++ b/scripts/runtime-host-viewer-adapter.ts
@@ -255,8 +255,18 @@ function releasesEqual(left: ViewerReleaseIdentity, right: ViewerReleaseIdentity
 }
 
 function readCurrentRelease(): ViewerReleaseIdentity | null {
-  try { return readTarget(); }
-  catch { return null; }
+  let raw: string;
+  try {
+    raw = fs.readFileSync(targetFile, "utf8");
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
+    throw new Error("current release target is unreadable", { cause: error });
+  }
+  try {
+    return release(JSON.parse(raw));
+  } catch (error) {
+    throw new Error("current release target is invalid", { cause: error });
+  }
 }
 
 function switchTarget(target: ViewerReleaseIdentity): void {
@@ -296,8 +306,8 @@ async function main(): Promise<unknown> {
   if (action === "current-release") {
     const current = readCurrentRelease();
     if (current === null) return null;
-    const health = await verify(current, stableEndpoint, current.endpoint);
-    if (!health.ok) throw new Error("current release health verification failed");
+    const state = await containerState(current.container);
+    if (state !== "running") throw new Error(`current release container is ${state}`);
     return current;
   }
   if (action === "verify-candidate") { const candidate = release(input.candidate); return verify(candidate, candidate.endpoint); }

--- a/src/instrumentation.test.ts
+++ b/src/instrumentation.test.ts
@@ -4,7 +4,14 @@ import os from "node:os";
 import path from "node:path";
 import { performance } from "node:perf_hooks";
 
-import { accountControllerDelayMs, initializeOperatorSpawnCapabilityAtStartup, runStructuredHostStartup, scheduleAccountMigrationController } from "./instrumentation";
+import {
+  accountControllerDelayMs,
+  activateViewerRuntimeWhenCurrent,
+  initializeOperatorSpawnCapabilityAtStartup,
+  runStructuredHostStartup,
+  scheduleAccountMigrationController,
+  viewerReleaseOwnsTraffic,
+} from "./instrumentation";
 import { operatorSpawnCapabilityPath } from "@/lib/agent/operatorCapability";
 import { didStructuredHostStartupFail, markStructuredHostStartupReady } from "@/lib/runtime/startupStatus";
 
@@ -12,6 +19,62 @@ test("account controller delay defaults to immediate startup and retains the exp
   expect(accountControllerDelayMs({})).toBe(0);
   expect(accountControllerDelayMs({ LLV_ACCOUNT_CONTROLLER_DELAY_MS: "250" })).toBe(250);
   expect(accountControllerDelayMs({ LLV_ACCOUNT_CONTROLLER_DELAY_MS: "invalid" })).toBe(0);
+});
+
+test("deployment candidates stay passive until their endpoint owns the durable release target", () => {
+  const target = JSON.stringify({ endpoint: "http://127.0.0.1:19892" });
+  expect(viewerReleaseOwnsTraffic({ PORT: "19892" }, () => target)).toBe(true);
+  expect(viewerReleaseOwnsTraffic({ PORT: "19115" }, () => target)).toBe(false);
+});
+
+test("release ownership keeps local boot active and fails closed on an unreadable durable target", () => {
+  const missing = Object.assign(new Error("missing"), { code: "ENOENT" });
+  expect(viewerReleaseOwnsTraffic({}, () => { throw missing; })).toBe(true);
+  expect(viewerReleaseOwnsTraffic({ PORT: "8898" }, () => { throw missing; })).toBe(true);
+  expect(viewerReleaseOwnsTraffic({ PORT: "19115" }, () => "{broken")).toBe(false);
+  expect(viewerReleaseOwnsTraffic({ PORT: "19115" }, () => JSON.stringify({ endpoint: "invalid" }))).toBe(false);
+});
+
+test("passive candidate activates runtime startup exactly once after promotion", async () => {
+  let current = false;
+  let activations = 0;
+  const scheduled: Array<() => void> = [];
+  const schedule = (callback: () => void) => {
+    scheduled.push(callback);
+    return { unref() {} };
+  };
+
+  await activateViewerRuntimeWhenCurrent(
+    async () => { activations += 1; },
+    () => current,
+    { pollMs: 1, schedule },
+  );
+  expect(activations).toBe(0);
+  expect(scheduled).toHaveLength(1);
+
+  scheduled.shift()!();
+  await Promise.resolve();
+  expect(activations).toBe(0);
+  expect(scheduled).toHaveLength(1);
+
+  current = true;
+  scheduled.shift()!();
+  await Promise.resolve();
+  await Promise.resolve();
+  expect(activations).toBe(1);
+  expect(scheduled).toHaveLength(0);
+});
+
+test("a restarted current release activates before register returns", async () => {
+  let activations = 0;
+  const scheduled: Array<() => void> = [];
+  await activateViewerRuntimeWhenCurrent(
+    async () => { activations += 1; },
+    () => true,
+    { schedule: (callback) => { scheduled.push(callback); return { unref() {} }; } },
+  );
+  expect(activations).toBe(1);
+  expect(scheduled).toHaveLength(0);
 });
 
 test("cold boot enables the controller while readiness receives the first runtime turn", async () => {

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -1,4 +1,74 @@
+import fs from "node:fs";
+
+import { statePath } from "@/lib/configDir";
 import { markStructuredHostStartupFailed, markStructuredHostStartupReady } from "@/lib/runtime/startupStatus";
+
+const RELEASE_ACTIVATION_POLL_MS = 250;
+
+interface ActivationTimer {
+  unref?(): unknown;
+}
+
+interface ViewerReleaseActivationOptions {
+  pollMs?: number;
+  schedule?: (callback: () => void, delayMs: number) => ActivationTimer;
+  log?: (...args: unknown[]) => void;
+}
+
+/** Candidate containers share production state while their health gate runs.
+ * The durable proxy target grants authority to the endpoint currently serving
+ * traffic. A missing target keeps local development and first boot active. */
+export function viewerReleaseOwnsTraffic(
+  env: Readonly<Record<string, string | undefined>> = process.env,
+  readTarget: () => string = () => fs.readFileSync(statePath("viewer-release.json"), "utf8"),
+): boolean {
+  const port = env.PORT?.trim();
+  if (!port) return true;
+  let raw: string;
+  try {
+    raw = readTarget();
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code === "ENOENT";
+  }
+  try {
+    const target = JSON.parse(raw) as { endpoint?: unknown };
+    if (typeof target.endpoint !== "string") return false;
+    return new URL(target.endpoint).port === port;
+  } catch {
+    return false;
+  }
+}
+
+/** Run stateful startup immediately for the current release. A deployment
+ * candidate polls the durable target and activates once promotion appoints it. */
+export async function activateViewerRuntimeWhenCurrent(
+  activate: () => Promise<void>,
+  isCurrent: () => boolean,
+  options: ViewerReleaseActivationOptions = {},
+): Promise<void> {
+  const pollMs = options.pollMs ?? RELEASE_ACTIVATION_POLL_MS;
+  const schedule = options.schedule ?? ((callback, delayMs) => setTimeout(callback, delayMs));
+  const log = options.log ?? console.error;
+  let started = false;
+  const start = async () => {
+    if (started) return;
+    started = true;
+    await activate();
+  };
+  if (isCurrent()) {
+    await start();
+    return;
+  }
+  const poll = () => {
+    if (started) return;
+    if (!isCurrent()) {
+      schedule(poll, pollMs).unref?.();
+      return;
+    }
+    void start().catch((error) => log("[viewer release] deferred runtime activation failed", error));
+  };
+  schedule(poll, pollMs).unref?.();
+}
 
 export function accountControllerDelayMs(env: Readonly<Record<string, string | undefined>> = process.env): number {
   const configured = Number(env.LLV_ACCOUNT_CONTROLLER_DELAY_MS ?? 0);
@@ -40,13 +110,15 @@ export async function runStructuredHostStartup(
 
 export async function register(): Promise<void> {
   if (process.env.NEXT_RUNTIME === "edge" || process.env.NEXT_PHASE?.includes("build")) return;
-  await initializeOperatorSpawnCapabilityAtStartup();
-  if (process.env.LLV_STRUCTURED_HOSTS === "1") {
-    const { adoptStructuredHostsAtStartup } = await import("@/lib/runtime/startup");
-    await runStructuredHostStartup(adoptStructuredHostsAtStartup);
-  }
-  if (process.env.LLV_ACCOUNT_CONTROLLER_DISABLED !== "1") {
-    const { startAccountMigrationController } = await import("@/lib/accounts/migration/controller");
-    scheduleAccountMigrationController(startAccountMigrationController, accountControllerDelayMs());
-  }
+  await activateViewerRuntimeWhenCurrent(async () => {
+    await initializeOperatorSpawnCapabilityAtStartup();
+    if (process.env.LLV_STRUCTURED_HOSTS === "1") {
+      const { adoptStructuredHostsAtStartup } = await import("@/lib/runtime/startup");
+      await runStructuredHostStartup(adoptStructuredHostsAtStartup);
+    }
+    if (process.env.LLV_ACCOUNT_CONTROLLER_DISABLED !== "1") {
+      const { startAccountMigrationController } = await import("@/lib/accounts/migration/controller");
+      scheduleAccountMigrationController(startAccountMigrationController, accountControllerDelayMs());
+    }
+  }, () => viewerReleaseOwnsTraffic());
 }


### PR DESCRIPTION
## Summary

- keep pre-promotion Viewer candidates passive while the durable release target points at another endpoint
- activate operator capability, structured-host adoption, and account migration startup once promotion appoints the candidate
- capture rollback identity from the durable target and running-container evidence so an unhealthy current HTTP service cannot block replacement
- preserve full candidate and post-promotion root, auth, capability, and referenced-asset gates

## Production incidents

Deployment `deploy_4d2956a7-b78b-4ccf-9db4-e4f73dc3a393` started seven Codex app-server hosts inside a health-check candidate before promotion. The candidate reached 351 PIDs and timed out on root health. It was stopped before promotion; the serving release and its live agents remained running.

Deployment `deploy_2177b9ac-1eb1-4933-820e-88f4e9eef975` then produced a passive candidate with zero agent hosts, 36 PIDs, 105 MiB RSS, root in 103 ms, and every referenced asset at HTTP 200. Promotion was blocked by a 90-second `current-release` health timeout against the old overloaded Viewer.

## Validation

- focused instrumentation, startup, deployment, health, adapter, and production-adapter tests — 45 passed, 145 assertions
- `bunx eslint scripts/runtime-host-viewer-adapter.ts scripts/runtime-host-viewer-adapter.test.ts src/instrumentation.ts src/instrumentation.test.ts`
- `bunx tsc --noEmit`
- `bun run build`
- `git diff --check`

## Stack

This PR targets the open #306 branch because production currently runs revision `18dd70f1fcf593015a8babda5a601e4e4956b0e9` from that line. Retarget to `main` after #306 lands.

Closes #317.
Closes #319.
