### PR TITLE
perf(runtime): debounce structured host cursor persistence

### DIFF
--- a/src/app/api/accounts/route.ts
+++ b/src/app/api/accounts/route.ts
@@ -116,7 +116,7 @@ function autoBalanceProjection(engine: MigrationEngine, snapshot: ReturnType<Ret
 /** Pure durable projection. Live auth/quota/login reconciliation runs in the controller. */
 export async function GET() {
   const registry = agentRegistry();
-  const snapshot = registry.snapshot();
+  const snapshot = registry.readOnlySnapshot();
   const now = Date.now();
   const claudeObservations = snapshot.quotaObservations.claude;
   const codexObservations = snapshot.quotaObservations.codex;

--- a/src/app/api/files/response.ts
+++ b/src/app/api/files/response.ts
@@ -77,7 +77,7 @@ export async function buildFilesResponse(request: Request, dependencies: FilesRo
   // A scan is a read model. Runtime reconciliation and notifications belong to
   // the external scheduler, keeping repeated GETs byte-stable for state files.
   const registry = agentRegistry();
-  const registrySnapshot = registry.snapshot();
+  const registrySnapshot = registry.readOnlySnapshot();
   const conversationLookup = conversationLookupFromSnapshot(registrySnapshot);
   const conversationForPath = (pathname: string) => conversationLookup.conversationForPath(pathname);
   const filesByPath = new Map(files.map((file) => [file.path, file]));

--- a/src/app/api/files/route.test.ts
+++ b/src/app/api/files/route.test.ts
@@ -1468,9 +1468,10 @@ test("lineage projection uses one registry revision during provisional parent ad
   scannedFiles = [file(parentPath), file(childPath)];
 
   const originalSnapshot = registry.snapshot.bind(registry);
+  const originalReadOnlySnapshot = registry.readOnlySnapshot.bind(registry);
   let adopted = false;
-  registry.snapshot = () => {
-    const snapshot = originalSnapshot();
+  registry.readOnlySnapshot = () => {
+    const snapshot = originalReadOnlySnapshot();
     if (!adopted) {
       adopted = true;
       registry.settleSpawn(migration.receipt.launchId, {

--- a/src/lib/agent/registry.sqlite.test.ts
+++ b/src/lib/agent/registry.sqlite.test.ts
@@ -116,6 +116,38 @@ test("dual-write keeps JSON authoritative and SQLite reads require parity", () =
   expect(() => new AgentRegistry(filename, undefined, undefined, { sqliteMode: "read" })).toThrow(RegistryParityError);
 });
 
+test("dual-write leaves both backends unchanged after a no-op mutation", () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-registry-sqlite-noop-"));
+  const filename = path.join(directory, "agent-registry.json");
+  const sqliteFilename = path.join(directory, "agent-registry.sqlite");
+  let replaceCalls = 0;
+  const dual = new AgentRegistry(filename, undefined, undefined, {
+    sqliteMode: "dual-write",
+    beforeDualWriteMutationReplace: () => { replaceCalls += 1; },
+  });
+  dual.setEngineRouting("codex", "work");
+  expect(replaceCalls).toBe(1);
+  const before = fs.statSync(filename);
+  const db = new Database(sqliteFilename);
+  const revision = () => Number(db.query<{ value: string }, [string]>(
+    "SELECT value FROM registry_meta WHERE key = ?",
+  ).get("revision")?.value ?? -1);
+  const beforeRevision = revision();
+
+  expect(dual.releaseStructuredHostClaim(
+    { engine: "codex", sessionId: "missing-session" },
+    "missing-owner",
+    99,
+  )).toBeFalse();
+
+  const after = fs.statSync(filename);
+  expect(after.ino).toBe(before.ino);
+  expect(after.mtimeMs).toBe(before.mtimeMs);
+  expect(revision()).toBe(beforeRevision);
+  expect(replaceCalls).toBe(1);
+  db.close();
+});
+
 test("dual-write fails closed when SQLite is ahead of its JSON mirror", () => {
   const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-registry-sqlite-transition-"));
   const filename = path.join(directory, "agent-registry.json");

--- a/src/lib/agent/registry.test.ts
+++ b/src/lib/agent/registry.test.ts
@@ -2,7 +2,7 @@ import fs from "node:fs";
 import crypto from "node:crypto";
 import os from "node:os";
 import path from "node:path";
-import { describe, expect, test } from "bun:test";
+import { describe, expect, spyOn, test } from "bun:test";
 
 import { AgentRegistry, conversationLookupFromSnapshot, SPAWN_STARTING_ADMISSION_LEASE_MS } from "@/lib/agent/registry";
 import { emptyLaunchProfile } from "@/lib/accounts/migration/contracts";
@@ -155,8 +155,14 @@ describe("agent registry", () => {
     store.setEngineRouting("codex", "work");
     const beforeBytes = fs.readFileSync(store.filename, "utf8");
     const before = fs.statSync(store.filename);
+    const reads = spyOn(fs, "readFileSync");
 
-    expect(store.releaseStructuredHostClaim(KEY, "missing-owner", 99)).toBeFalse();
+    try {
+      expect(store.releaseStructuredHostClaim(KEY, "missing-owner", 99)).toBeFalse();
+      expect(reads.mock.calls.filter(([filename]) => filename === store.filename)).toHaveLength(1);
+    } finally {
+      reads.mockRestore();
+    }
 
     const after = fs.statSync(store.filename);
     expect(fs.readFileSync(store.filename, "utf8")).toBe(beforeBytes);

--- a/src/lib/agent/registry.test.ts
+++ b/src/lib/agent/registry.test.ts
@@ -67,6 +67,23 @@ describe("agent registry", () => {
     expect(store.snapshot()).not.toBe(replacement);
   });
 
+  test("read helpers share one signature-fenced registry parse", () => {
+    const store = registry();
+    const conversation = store.ensureConversation("codex", "/sessions/read-helper.jsonl", "work");
+    store.setEngineRouting("codex", "work");
+    const reads = spyOn(fs, "readFileSync");
+    try {
+      expect(store.engineRouting("codex").activeAccountId).toBe("work");
+      expect(store.conversationForPath("/sessions/read-helper.jsonl")?.id).toBe(conversation.id);
+      expect(store.canonicalConversationId(conversation.id)).toBe(conversation.id);
+      expect(store.autoBalancePolicy("codex").enabled).toBeTrue();
+      expect(store.quotaObservations("codex")).toEqual([]);
+      expect(reads.mock.calls.filter(([filename]) => filename === store.filename)).toHaveLength(1);
+    } finally {
+      reads.mockRestore();
+    }
+  });
+
   test("startup compaction bounds legacy delivered reservations per conversation", () => {
     const store = registry();
     const conversation = store.ensureConversation("codex", "/legacy-deliveries.jsonl", "default");

--- a/src/lib/agent/registry.test.ts
+++ b/src/lib/agent/registry.test.ts
@@ -150,6 +150,20 @@ describe("agent registry", () => {
     expect(store.snapshot().receipts[receipt.launchId]?.state).toBe("completed");
   });
 
+  test("skips an atomic rewrite when a mutation leaves the registry unchanged", () => {
+    const store = registry();
+    store.setEngineRouting("codex", "work");
+    const beforeBytes = fs.readFileSync(store.filename, "utf8");
+    const before = fs.statSync(store.filename);
+
+    expect(store.releaseStructuredHostClaim(KEY, "missing-owner", 99)).toBeFalse();
+
+    const after = fs.statSync(store.filename);
+    expect(fs.readFileSync(store.filename, "utf8")).toBe(beforeBytes);
+    expect(after.ino).toBe(before.ino);
+    expect(after.mtimeMs).toBe(before.mtimeMs);
+  });
+
   test("route settlement recovers when observation completed the same spawn first", () => {
     const store = registry();
     const receipt = store.beginSpawn("codex", "/repo");

--- a/src/lib/agent/registry.test.ts
+++ b/src/lib/agent/registry.test.ts
@@ -44,6 +44,29 @@ describe("agent registry", () => {
     expect(lookup.conversation("conversation_alias")?.id).toBe(first.id);
   });
 
+  test("read-only snapshots reuse one parse until an atomic registry replacement", () => {
+    const store = registry();
+    store.setEngineRouting("codex", "work");
+    const reads = spyOn(fs, "readFileSync");
+    let first: ReturnType<AgentRegistry["snapshot"]>;
+    let second: ReturnType<AgentRegistry["snapshot"]>;
+    try {
+      first = store.readOnlySnapshot();
+      second = store.readOnlySnapshot();
+      expect(reads.mock.calls.filter(([filename]) => filename === store.filename)).toHaveLength(1);
+    } finally {
+      reads.mockRestore();
+    }
+    expect(second!).toBe(first!);
+
+    store.setEngineRouting("codex", "default");
+    const replacement = store.readOnlySnapshot();
+
+    expect(replacement).not.toBe(first!);
+    expect(replacement.engineRouting.codex.activeAccountId).toBe("default");
+    expect(store.snapshot()).not.toBe(replacement);
+  });
+
   test("startup compaction bounds legacy delivered reservations per conversation", () => {
     const store = registry();
     const conversation = store.ensureConversation("codex", "/legacy-deliveries.jsonl", "default");

--- a/src/lib/agent/registry.ts
+++ b/src/lib/agent/registry.ts
@@ -1308,10 +1308,9 @@ function serializeRegistry(value: RegistryFile, sqliteRevision?: number): string
   return JSON.stringify(storage) + "\n";
 }
 
-function writeAtomic(filename: string, value: RegistryFile, sqliteRevision?: number): void {
+function writeAtomicPayload(filename: string, payload: string): void {
   fs.mkdirSync(path.dirname(filename), { recursive: true, mode: 0o700 });
   const temp = `${filename}.${process.pid}.${crypto.randomUUID()}.tmp`;
-  const payload = serializeRegistry(value, sqliteRevision);
   let fd: number | null = null;
   try {
     fd = fs.openSync(temp, "w", 0o600);
@@ -1325,6 +1324,19 @@ function writeAtomic(filename: string, value: RegistryFile, sqliteRevision?: num
   } finally {
     if (fd !== null) fs.closeSync(fd);
     try { fs.unlinkSync(temp); } catch { /* rename completed */ }
+  }
+}
+
+function writeAtomic(filename: string, value: RegistryFile, sqliteRevision?: number): void {
+  writeAtomicPayload(filename, serializeRegistry(value, sqliteRevision));
+}
+
+function serializedFile(filename: string): string | null {
+  try {
+    return fs.readFileSync(filename, "utf8");
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
+    throw error;
   }
 }
 
@@ -1865,8 +1877,11 @@ export class AgentRegistry {
       }
       const file = readFile(this.filename);
       const result = fn(file);
-      writeAtomic(this.filename, file);
-      if (sqlite) {
+      const payload = serializeRegistry(file);
+      const changed = serializedFile(this.filename) !== payload;
+      if (changed) writeAtomicPayload(this.filename, payload);
+      if (sqlite && !changed) this.assertSqliteParity();
+      if (sqlite && changed) {
         this.beforeDualWriteMutationReplace?.();
         const replacement = this.sqliteStore!.replace(file, sqlite.revision);
         if (!replacement.replaced) {

--- a/src/lib/agent/registry.ts
+++ b/src/lib/agent/registry.ts
@@ -1264,14 +1264,19 @@ export function normalizeRegistry(value: unknown): RegistryFile {
   };
 }
 
-function readFile(filename: string): RegistryFile {
+function readFileWithPayload(filename: string): { file: RegistryFile; payload: string | null } {
   try {
-    return normalizeRegistry(JSON.parse(fs.readFileSync(filename, "utf8")));
+    const payload = fs.readFileSync(filename, "utf8");
+    return { file: normalizeRegistry(JSON.parse(payload)), payload };
   } catch (error) {
-    if ((error as NodeJS.ErrnoException).code === "ENOENT") return clone(EMPTY);
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return { file: clone(EMPTY), payload: null };
     if (error instanceof RegistryReadError) throw error;
     throw new RegistryReadError(`agent registry cannot be read: ${error instanceof Error ? error.message : String(error)}`);
   }
+}
+
+function readFile(filename: string): RegistryFile {
+  return readFileWithPayload(filename).file;
 }
 
 function compactLaunchProfile(profile: LaunchProfile): Partial<LaunchProfile> {
@@ -1329,15 +1334,6 @@ function writeAtomicPayload(filename: string, payload: string): void {
 
 function writeAtomic(filename: string, value: RegistryFile, sqliteRevision?: number): void {
   writeAtomicPayload(filename, serializeRegistry(value, sqliteRevision));
-}
-
-function serializedFile(filename: string): string | null {
-  try {
-    return fs.readFileSync(filename, "utf8");
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
-    throw error;
-  }
 }
 
 export type AgentRegistrySqliteMode = "off" | "dual-write" | "read" | "sqlite";
@@ -1875,10 +1871,11 @@ export class AgentRegistry {
         }
         this.assertSqliteParity(sqlite);
       }
-      const file = readFile(this.filename);
+      const original = readFileWithPayload(this.filename);
+      const file = original.file;
       const result = fn(file);
       const payload = serializeRegistry(file);
-      const changed = serializedFile(this.filename) !== payload;
+      const changed = original.payload !== payload;
       if (changed) writeAtomicPayload(this.filename, payload);
       if (sqlite && !changed) this.assertSqliteParity();
       if (sqlite && changed) {

--- a/src/lib/agent/registry.ts
+++ b/src/lib/agent/registry.ts
@@ -1931,7 +1931,7 @@ export class AgentRegistry {
 
   conversationIdForSpawnCapabilityDigest(digest: string): ViewerConversationId | null {
     if (!/^[0-9a-f]{64}$/.test(digest)) return null;
-    const file = this.snapshot();
+    const file = this.readOnlySnapshot();
     const receipt = Object.values(file.receipts).find((candidate) => candidate.spawnCapabilityDigest === digest);
     return receipt ? resolveConversationAlias(file, receipt.conversationId) : null;
   }
@@ -2814,8 +2814,10 @@ export class AgentRegistry {
   }
 
   resumePanes(serverPid: number): Map<string, ResumePaneRecord> {
-    const saved = this.snapshot().legacyResumePanes;
-    return saved.serverPid === serverPid ? new Map(Object.entries(saved.panes)) : new Map();
+    const saved = this.readOnlySnapshot().legacyResumePanes;
+    return saved.serverPid === serverPid
+      ? new Map(Object.entries(saved.panes).map(([pathname, record]) => [pathname, clone(record)]))
+      : new Map();
   }
 
   rememberResumePane(serverPid: number, pathname: string, record: ResumePaneRecord): void {
@@ -3084,20 +3086,23 @@ export class AgentRegistry {
   }
 
   conversationForPath(artifactPath: string): RegistryConversation | null {
-    return Object.values(this.snapshot().conversations).find((conversation) => conversationOwnsPath(conversation, artifactPath)) ?? null;
+    const conversation = Object.values(this.readOnlySnapshot().conversations)
+      .find((candidate) => conversationOwnsPath(candidate, artifactPath));
+    return conversation ? clone(conversation) : null;
   }
 
   canonicalConversationId(id: ViewerConversationId): ViewerConversationId {
-    return resolveConversationAlias(this.snapshot(), id);
+    return resolveConversationAlias(this.readOnlySnapshot(), id);
   }
 
   conversation(id: ViewerConversationId): RegistryConversation | null {
-    const snapshot = this.snapshot();
-    return snapshot.conversations[resolveConversationAlias(snapshot, id)] ?? null;
+    const snapshot = this.readOnlySnapshot();
+    const conversation = snapshot.conversations[resolveConversationAlias(snapshot, id)];
+    return conversation ? clone(conversation) : null;
   }
 
   launchProfileForPath(artifactPath: string): LaunchProfile | null {
-    const snapshot = this.snapshot();
+    const snapshot = this.readOnlySnapshot();
     for (const conversation of Object.values(snapshot.conversations)) {
       const generation = conversation.generations.find((item) => item.path === artifactPath);
       if (generation) return clone(generation.launchProfile);
@@ -3125,11 +3130,11 @@ export class AgentRegistry {
   }
 
   engineRouting(engine: Extract<AgentEngine, "claude" | "codex">): { activeAccountId: string | null; revision: number } {
-    return clone(this.snapshot().engineRouting[engine]);
+    return clone(this.readOnlySnapshot().engineRouting[engine]);
   }
 
   migrationScope(engine: Extract<AgentEngine, "claude" | "codex">, targetId: string): MigrationScopeCounts {
-    return migrationScopeCounts(this.snapshot(), engine, targetId);
+    return migrationScopeCounts(this.readOnlySnapshot(), engine, targetId);
   }
 
   retireAccount(engine: Extract<AgentEngine, "claude" | "codex">, accountId: string, fallbackAccountId: string): void {
@@ -3575,11 +3580,11 @@ export class AgentRegistry {
   }
 
   autoBalancePolicy(engine: Extract<AgentEngine, "claude" | "codex">): AutoBalancePolicy {
-    return clone(this.snapshot().autoBalance[engine]);
+    return clone(this.readOnlySnapshot().autoBalance[engine]);
   }
 
   quotaObservations(engine: Extract<AgentEngine, "claude" | "codex">): DurableQuotaObservation[] {
-    return clone(Object.values(this.snapshot().quotaObservations[engine]));
+    return clone(Object.values(this.readOnlySnapshot().quotaObservations[engine]));
   }
 
   recordQuotaEvaluation(input: {
@@ -3715,11 +3720,11 @@ export class AgentRegistry {
   }
 
   pendingDeliveries(conversationId: ViewerConversationId): HeldDelivery[] {
-    const snapshot = this.snapshot();
+    const snapshot = this.readOnlySnapshot();
     const canonicalId = resolveConversationAlias(snapshot, conversationId);
-    return Object.values(snapshot.heldDeliveries)
+    return clone(Object.values(snapshot.heldDeliveries)
       .filter((item) => item.conversationId === canonicalId && item.state !== "delivered")
-      .sort((left, right) => left.createdAt.localeCompare(right.createdAt) || left.id.localeCompare(right.id));
+      .sort((left, right) => left.createdAt.localeCompare(right.createdAt) || left.id.localeCompare(right.id)));
   }
 
   compactDeliveryReservations(): number {

--- a/src/lib/agent/registry.ts
+++ b/src/lib/agent/registry.ts
@@ -1279,6 +1279,16 @@ function readFile(filename: string): RegistryFile {
   return readFileWithPayload(filename).file;
 }
 
+function registryFileSignature(filename: string): string {
+  try {
+    const stat = fs.statSync(filename, { bigint: true });
+    return `${stat.dev}:${stat.ino}:${stat.size}:${stat.mtimeNs}:${stat.ctimeNs}`;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return "missing";
+    throw new RegistryReadError(`agent registry cannot be stated: ${error instanceof Error ? error.message : String(error)}`);
+  }
+}
+
 function compactLaunchProfile(profile: LaunchProfile): Partial<LaunchProfile> {
   const compact: Partial<LaunchProfile> = { ...profile };
   for (const key of Object.keys(compact) as Array<keyof LaunchProfile>) {
@@ -1384,6 +1394,7 @@ export class AgentRegistry {
   private readonly sqliteMode: AgentRegistrySqliteMode;
   private readonly sqliteStore: SqliteAgentRegistryStore | null;
   private readonly beforeDualWriteMutationReplace: (() => void) | undefined;
+  private readOnlyCache: { signature: string; snapshot: RegistryFile } | null = null;
 
   constructor(
     readonly filename = statePath("agent-registry.json"),
@@ -1899,6 +1910,23 @@ export class AgentRegistry {
     return this.sqliteMode === "read" || this.sqliteMode === "sqlite"
       ? this.sqliteStore!.snapshot().file
       : readFile(this.filename);
+  }
+
+  /** Shared process-local snapshot for projections that never mutate registry
+      objects. Atomic writers change the inode/signature, including writers in
+      the runtime-host process, so the next reader reparses immediately. */
+  readOnlySnapshot(): RegistryFile {
+    if (this.sqliteMode === "read" || this.sqliteMode === "sqlite") return this.sqliteStore!.snapshot().file;
+    for (let attempt = 0; attempt < 2; attempt += 1) {
+      const before = registryFileSignature(this.filename);
+      if (this.readOnlyCache?.signature === before) return this.readOnlyCache.snapshot;
+      const snapshot = readFile(this.filename);
+      const after = registryFileSignature(this.filename);
+      if (before !== after) continue;
+      this.readOnlyCache = { signature: after, snapshot };
+      return snapshot;
+    }
+    return readFile(this.filename);
   }
 
   conversationIdForSpawnCapabilityDigest(digest: string): ViewerConversationId | null {

--- a/src/lib/agent/transcriptHost.test.ts
+++ b/src/lib/agent/transcriptHost.test.ts
@@ -5,8 +5,8 @@ import os from "node:os";
 import path from "node:path";
 
 import { withSpawnCapability, type ResumeSpec } from "@/lib/agent/cli";
-import { AgentRegistry } from "@/lib/agent/registry";
-import { beginRegistryResume, createTranscriptHostResolver, type TranscriptHost } from "@/lib/agent/transcriptHost";
+import { AgentRegistry, type TmuxHostEvidence } from "@/lib/agent/registry";
+import { beginRegistryResume, createTranscriptHostResolver, reconcileObservedTranscriptHosts, type TranscriptHost } from "@/lib/agent/transcriptHost";
 import { TmuxDeliveryUncertainError } from "@/lib/tmux";
 import type { AgentProcess } from "@/lib/scanner/process";
 import type { PaneRef, SpawnedPane } from "@/lib/tmux";
@@ -45,6 +45,91 @@ const spec: ResumeSpec = {
   windowName: "codex-resume",
   engine: "codex",
 };
+
+test("stable tmux host reconciliation reads one snapshot without registry mutations", () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-host-reconcile-read-"));
+  class CountingRegistry extends AgentRegistry {
+    snapshotCalls = 0;
+    upsertCalls = 0;
+    markUnhostedCalls = 0;
+    reconcileSpawnReceiptCalls = 0;
+
+    override snapshot() {
+      this.snapshotCalls += 1;
+      return super.snapshot();
+    }
+
+    override upsert(value: Parameters<AgentRegistry["upsert"]>[0]) {
+      this.upsertCalls += 1;
+      return super.upsert(value);
+    }
+
+    override markUnhosted(value: Parameters<AgentRegistry["markUnhosted"]>[0]) {
+      this.markUnhostedCalls += 1;
+      return super.markUnhosted(value);
+    }
+
+    override reconcileSpawnReceipts(value: Parameters<AgentRegistry["reconcileSpawnReceipts"]>[0]) {
+      this.reconcileSpawnReceiptCalls += 1;
+      return super.reconcileSpawnReceipts(value);
+    }
+
+    resetCounts() {
+      this.snapshotCalls = 0;
+      this.upsertCalls = 0;
+      this.markUnhostedCalls = 0;
+      this.reconcileSpawnReceiptCalls = 0;
+    }
+  }
+  const registry = new CountingRegistry(path.join(directory, "registry.json"));
+  const host: TranscriptHost = {
+    tmuxServerPid: 900,
+    paneId: "%1",
+    panePid: 100,
+    agentPid: 200,
+    display: "agents:4.0",
+    windowName: "codex-resume",
+    engine: "codex",
+    cwd: "/repo",
+    agentArgv: ["codex", "resume", SESSION],
+    agentIdentity: "200:one",
+    launchId: null,
+    claimedPaths: [PATHNAME],
+    primaryPath: PATHNAME,
+  };
+  const evidence: TmuxHostEvidence = {
+    kind: "tmux",
+    endpoint: "/run/user/1000/agent-log-viewer",
+    server: { pid: 900, startIdentity: "900:one" },
+    paneId: "%1",
+    panePid: { pid: 100, startIdentity: "100:one" },
+    windowName: "codex-resume",
+    agent: { pid: 200, startIdentity: "200:one" },
+    argv: host.agentArgv,
+  };
+  registry.upsert({
+    key: { engine: "codex", sessionId: SESSION },
+    artifactPath: PATHNAME,
+    cwd: "/repo",
+    accountId: null,
+    status: "live",
+    host: evidence,
+    claimEpoch: 0,
+    claimOwner: null,
+    pendingAction: null,
+  });
+  registry.resetCounts();
+
+  reconcileObservedTranscriptHosts([host], { registry, evidenceForHost: () => evidence });
+
+  expect({
+    snapshot: registry.snapshotCalls,
+    upsert: registry.upsertCalls,
+    markUnhosted: registry.markUnhostedCalls,
+    reconcileSpawnReceipts: registry.reconcileSpawnReceiptCalls,
+  }).toEqual({ snapshot: 1, upsert: 0, markUnhosted: 0, reconcileSpawnReceipts: 0 });
+  fs.rmSync(directory, { recursive: true, force: true });
+});
 
 test("registry resume receives one conversation-bound capability at central actuation", () => {
   const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-resume-capability-"));

--- a/src/lib/agent/transcriptHost.test.ts
+++ b/src/lib/agent/transcriptHost.test.ts
@@ -59,6 +59,11 @@ test("stable tmux host reconciliation reads one snapshot without registry mutati
       return super.snapshot();
     }
 
+    override readOnlySnapshot() {
+      this.snapshotCalls += 1;
+      return super.readOnlySnapshot();
+    }
+
     override upsert(value: Parameters<AgentRegistry["upsert"]>[0]) {
       this.upsertCalls += 1;
       return super.upsert(value);

--- a/src/lib/agent/transcriptHost.test.ts
+++ b/src/lib/agent/transcriptHost.test.ts
@@ -217,6 +217,43 @@ describe("transcript host resolver", () => {
     expect(state.listFileReads).toBe(0);
   });
 
+  test("keeps the native child canonical when a launcher wrapper shares its session", async () => {
+    const reconciled: number[][] = [];
+    const { resolver, state } = fakeHost(true, (hosts) => {
+      reconciled.push(hosts.map((host) => host.agentPid));
+      return { quarantinedPaneIds: [] };
+    });
+    state.agents = [
+      { pid: 200, engine: "codex", argv: ["node", "/home/user/.bun/bin/codex", "resume", SESSION], cwd: "/repo", tty: 1 },
+      { pid: 201, engine: "codex", argv: ["/vendor/codex", "resume", SESSION], cwd: "/repo", tty: 1 },
+    ];
+    state.ppids = new Map([[200, 100], [201, 200]]);
+    state.identities = new Map([[200, "200:wrapper"], [201, "201:native"]]);
+    state.entry = { ...state.entry, pid: 200 };
+
+    const wrapperAttributed = await resolver.readTranscriptHosts(true);
+    state.entry = { ...state.entry, pid: 201 };
+    state.agents.reverse();
+    const nativeAttributed = await resolver.readTranscriptHosts(true);
+
+    expect(wrapperAttributed.hosts.map((host) => host.agentPid)).toEqual([201]);
+    expect(wrapperAttributed.canonicalFor(PATHNAME)?.agentPid).toBe(201);
+    expect(nativeAttributed.hosts.map((host) => host.agentPid)).toEqual([201]);
+    expect(nativeAttributed.canonicalFor(PATHNAME)?.agentPid).toBe(201);
+    expect(reconciled).toEqual([[201], [201]]);
+  });
+
+  test("keeps parallel same-session processes visible when neither wraps the other", async () => {
+    const { resolver, state } = fakeHost();
+    state.agents.push({ pid: 201, engine: "codex", argv: ["/vendor/codex", "resume", SESSION], cwd: "/repo", tty: 1 });
+    state.ppids.set(201, 100);
+    state.identities.set(201, "201:parallel");
+
+    const snapshot = await resolver.readTranscriptHosts(true);
+
+    expect(snapshot.hosts.map((host) => host.agentPid)).toEqual([200, 201]);
+  });
+
   test("carries the pane launch marker into observation reconciliation", async () => {
     const { resolver, state } = fakeHost();
     state.launchId = "019f4906-3f67-7b72-9fbc-9ec3b5ad1326";

--- a/src/lib/agent/transcriptHost.ts
+++ b/src/lib/agent/transcriptHost.ts
@@ -215,6 +215,49 @@ function primaryClaim(claims: HostClaim[]): HostClaim | null {
   return [...claims].sort((left, right) => CLAIM_RANK[right.source] - CLAIM_RANK[left.source] || left.pathname.localeCompare(right.pathname))[0] ?? null;
 }
 
+function ancestryDepth(pid: number, ancestor: number, ppids: Map<number, number>): number {
+  const seen = new Set<number>();
+  let cursor: number | null = pid;
+  for (let depth = 0; cursor !== null && depth < MAX_ANCESTRY_HOPS; depth += 1) {
+    if (cursor === ancestor) return depth;
+    if (seen.has(cursor)) return -1;
+    seen.add(cursor);
+    cursor = ppids.get(cursor) ?? null;
+  }
+  return -1;
+}
+
+function collapseSameSessionWrappers(hosts: ObservedHost[], ppids: Map<number, number>): ObservedHost[] {
+  const groups = new Map<string, { firstIndex: number; hosts: ObservedHost[] }>();
+  hosts.forEach((host, index) => {
+    const sessionId = argvSessionUuid(host.agentArgv);
+    const key = sessionId
+      ? `${host.paneId}:${host.engine}:${sessionId}`
+      : `${host.paneId}:${host.engine}:pid:${host.agentPid}`;
+    const group = groups.get(key) ?? { firstIndex: index, hosts: [] };
+    group.hosts.push(host);
+    groups.set(key, group);
+  });
+  return [...groups.values()]
+    .sort((left, right) => left.firstIndex - right.firstIndex)
+    .flatMap((group) => {
+      if (group.hosts.length === 1) return group.hosts;
+      const selected = [...group.hosts].sort((left, right) =>
+        ancestryDepth(right.agentPid, right.panePid, ppids) - ancestryDepth(left.agentPid, left.panePid, ppids)
+        || right.agentPid - left.agentPid)[0]!;
+      if (!group.hosts.every((host) => ancestryDepth(selected.agentPid, host.agentPid, ppids) >= 0)) return group.hosts;
+      const claims = [...new Map(group.hosts.flatMap((host) => host.claims)
+        .map((claim) => [`${claim.source}:${claim.pathname}`, claim])).values()];
+      const primary = primaryClaim(claims);
+      return [{
+        ...selected,
+        claims,
+        claimedPaths: [...new Set(claims.map((claim) => claim.pathname))],
+        primaryPath: primary?.pathname ?? null,
+      }];
+    });
+}
+
 function canonicalFrom(hosts: ObservedHost[], pathname: string): TranscriptHost | null {
   const candidates = hosts
     .map((host) => ({ host, claim: host.claims.filter((claim) => claim.pathname === pathname).sort((a, b) => CLAIM_RANK[b.source] - CLAIM_RANK[a.source])[0] }))
@@ -346,13 +389,14 @@ export function createTranscriptHostObserver(dependencies: TranscriptHostObserva
       }
     }
 
-    const reconciliation = await dependencies.reconcile?.(hosts);
+    const stableHosts = collapseSameSessionWrappers(hosts, ppids);
+    const reconciliation = await dependencies.reconcile?.(stableHosts);
     const quarantinedPaneIds = new Set(reconciliation?.quarantinedPaneIds ?? []);
-    const eligibleHosts = hosts.filter((host) => !quarantinedPaneIds.has(host.paneId));
+    const eligibleHosts = stableHosts.filter((host) => !quarantinedPaneIds.has(host.paneId));
 
-    const conflicts = hostConflicts(hosts, conversationIdForPath, quarantinedPaneIds);
+    const conflicts = hostConflicts(stableHosts, conversationIdForPath, quarantinedPaneIds);
     const snapshot: TranscriptHostSnapshot = {
-      hosts,
+      hosts: stableHosts,
       observation: "available",
       conflicts,
       canonicalFor: (pathname: string) => conflictForPath(snapshot, pathname, conversationIdForPath) ? null : canonicalFrom(eligibleHosts, pathname),

--- a/src/lib/agent/transcriptHost.ts
+++ b/src/lib/agent/transcriptHost.ts
@@ -1,5 +1,7 @@
+import { isDeepStrictEqual } from "node:util";
+
 import type { ResumeSpec } from "@/lib/agent/cli";
-import { agentRegistry, type SpawnReceipt, type TmuxHostEvidence } from "@/lib/agent/registry";
+import { agentRegistry, type AgentRegistry, type AgentRegistryEntry, type SpawnReceipt, type TmuxHostEvidence } from "@/lib/agent/registry";
 import { sessionKeyFromTranscript } from "@/lib/agent/sessionKey";
 import { procBackend } from "@/lib/proc";
 import { descendantPids } from "@/lib/proc/memory";
@@ -120,6 +122,17 @@ interface HostDependencies extends TranscriptHostObservationDependencies {
 
 interface HostReconciliation {
   quarantinedPaneIds: string[];
+}
+
+export interface TranscriptHostRegistryReconciliationDependencies {
+  registry: Pick<AgentRegistry,
+    | "snapshot"
+    | "confirmSpawnPaneAlive"
+    | "completeObservedSpawn"
+    | "upsert"
+    | "markUnhosted"
+    | "reconcileSpawnReceipts">;
+  evidenceForHost: (host: TranscriptHost) => TmuxHostEvidence;
 }
 
 interface HostClaim {
@@ -567,13 +580,54 @@ function confirmRegistryHostAlive(host: TranscriptHost): void {
   }
 }
 
-async function reconcileRegistry(hosts: TranscriptHost[]): Promise<HostReconciliation> {
-  const registry = agentRegistry();
+function upsertChangesEntry(
+  existing: AgentRegistryEntry | undefined,
+  entry: Omit<AgentRegistryEntry, "updatedAt">,
+): boolean {
+  if (!existing) return true;
+  const replacement = entry.structuredHost === undefined && existing.structuredHost !== undefined
+    ? { ...entry, structuredHost: existing.structuredHost }
+    : entry;
+  const current = { ...existing } as Partial<AgentRegistryEntry>;
+  delete current.updatedAt;
+  return !isDeepStrictEqual(current, replacement);
+}
+
+function spawnReceiptReconciliationNeeded(
+  snapshot: ReturnType<AgentRegistry["snapshot"]>,
+  liveIds: Set<string>,
+): boolean {
+  const liveArtifactPaths = new Set<string>();
+  for (const id of liveIds) {
+    const entry = snapshot.entries[id];
+    if (!entry) continue;
+    if (entry.pendingAction !== null) return true;
+    liveArtifactPaths.add(entry.artifactPath);
+  }
+  return Object.values(snapshot.receipts).some((receipt) =>
+    receipt.state === "starting"
+    && receipt.artifactPath !== null
+    && liveArtifactPaths.has(receipt.artifactPath));
+}
+
+export function reconcileObservedTranscriptHosts(
+  hosts: TranscriptHost[],
+  dependencies: TranscriptHostRegistryReconciliationDependencies = {
+    registry: agentRegistry(),
+    evidenceForHost: tmuxEvidenceForHost,
+  },
+): HostReconciliation {
+  const { registry, evidenceForHost } = dependencies;
+  let snapshot = registry.snapshot();
+  let mutated = false;
   const seen = new Set<string>();
   const quarantinedPaneIds = new Set<string>();
   for (const host of hosts) {
-    const evidence = tmuxEvidenceForHost(host);
-    if (host.launchId) registry.confirmSpawnPaneAlive(host.launchId, evidence, { engine: host.engine, cwd: host.cwd });
+    const evidence = evidenceForHost(host);
+    if (host.launchId) {
+      registry.confirmSpawnPaneAlive(host.launchId, evidence, { engine: host.engine, cwd: host.cwd });
+      mutated = true;
+    }
     if (!host.primaryPath) continue;
     const key = sessionKeyFromTranscript(host.engine, host.primaryPath);
     if (!key) continue;
@@ -589,6 +643,7 @@ async function reconcileRegistry(hosts: TranscriptHost[]): Promise<HostReconcili
         claimOwner: null,
         pendingAction: null,
       });
+      mutated = true;
       /* A mismatched pane/artifact remains quarantined. It must never fall
          through into the generic upsert and overwrite the real receipt. */
       if (settled.kind === "settled") {
@@ -598,8 +653,9 @@ async function reconcileRegistry(hosts: TranscriptHost[]): Promise<HostReconcili
       quarantinedPaneIds.add(host.paneId);
       continue;
     }
-    const existing = registry.snapshot().entries[`${key.engine}:${key.sessionId}`];
-    registry.upsert({
+    const id = `${key.engine}:${key.sessionId}`;
+    const existing = snapshot.entries[id];
+    const entry = {
       key,
       artifactPath: host.primaryPath,
       cwd: host.cwd,
@@ -609,16 +665,23 @@ async function reconcileRegistry(hosts: TranscriptHost[]): Promise<HostReconcili
       claimEpoch: existing?.claimEpoch ?? 0,
       claimOwner: existing?.claimOwner ?? null,
       pendingAction: null,
-    });
-    seen.add(`${key.engine}:${key.sessionId}`);
+    } satisfies Omit<AgentRegistryEntry, "updatedAt">;
+    if (upsertChangesEntry(existing, entry)) {
+      registry.upsert(entry);
+      mutated = true;
+    }
+    seen.add(id);
   }
-  for (const [id, entry] of Object.entries(registry.snapshot().entries)) {
+  if (mutated) snapshot = registry.snapshot();
+  for (const [id, entry] of Object.entries(snapshot.entries)) {
     if (entry.host?.kind === "tmux" && !seen.has(id)) registry.markUnhosted(entry.key);
   }
-  registry.reconcileSpawnReceipts([...seen].map((id) => {
-    const [engine, sessionId] = id.split(":");
-    return { engine: engine as "claude" | "codex", sessionId };
-  }));
+  if (spawnReceiptReconciliationNeeded(snapshot, seen)) {
+    registry.reconcileSpawnReceipts([...seen].map((id) => {
+      const [engine, sessionId] = id.split(":");
+      return { engine: engine as "claude" | "codex", sessionId };
+    }));
+  }
   return { quarantinedPaneIds: [...quarantinedPaneIds] };
 }
 
@@ -629,9 +692,19 @@ async function registryResumeRecords(): ReturnType<typeof resumePaneRecords> {
   const snapshot = registry.snapshot();
   if (!snapshot.importedResumePanes) {
     const legacy = await resumePaneRecords();
-    if (legacy) registry.importResumePanes(legacy.serverPid, legacy.records);
+    if (legacy) {
+      registry.importResumePanes(legacy.serverPid, legacy.records);
+      return {
+        serverPid,
+        records: legacy.serverPid === serverPid ? new Map(legacy.records) : new Map(),
+      };
+    }
   }
-  return { serverPid, records: registry.resumePanes(serverPid) };
+  const saved = snapshot.legacyResumePanes;
+  return {
+    serverPid,
+    records: saved.serverPid === serverPid ? new Map(Object.entries(saved.panes)) : new Map(),
+  };
 }
 
 async function rememberRegistryResume(pathname: string, spec: ResumeSpec, pane: SpawnedPane): Promise<void> {
@@ -694,7 +767,7 @@ const runtimeResolver = createTranscriptHostResolver({
   remember: rememberRegistryResume,
   deliver: sendText,
   confirmAlive: confirmRegistryHostAlive,
-  reconcile: reconcileRegistry,
+  reconcile: reconcileObservedTranscriptHosts,
   serializeDelivery: serializeRegistryDelivery,
 }, globalStore.__llvTranscriptHostDecisions ??= new Map());
 

--- a/src/lib/agent/transcriptHost.ts
+++ b/src/lib/agent/transcriptHost.ts
@@ -127,6 +127,7 @@ interface HostReconciliation {
 export interface TranscriptHostRegistryReconciliationDependencies {
   registry: Pick<AgentRegistry,
     | "snapshot"
+    | "readOnlySnapshot"
     | "confirmSpawnPaneAlive"
     | "completeObservedSpawn"
     | "upsert"
@@ -618,7 +619,7 @@ export function reconcileObservedTranscriptHosts(
   },
 ): HostReconciliation {
   const { registry, evidenceForHost } = dependencies;
-  let snapshot = registry.snapshot();
+  let snapshot = registry.readOnlySnapshot();
   let mutated = false;
   const seen = new Set<string>();
   const quarantinedPaneIds = new Set<string>();
@@ -689,7 +690,7 @@ async function registryResumeRecords(): ReturnType<typeof resumePaneRecords> {
   const serverPid = await tmuxServerPid();
   if (serverPid === null) return null;
   const registry = agentRegistry();
-  const snapshot = registry.snapshot();
+  const snapshot = registry.readOnlySnapshot();
   if (!snapshot.importedResumePanes) {
     const legacy = await resumePaneRecords();
     if (legacy) {

--- a/src/lib/reaperRuntime.ts
+++ b/src/lib/reaperRuntime.ts
@@ -539,7 +539,7 @@ async function makeInput(
   const flows = (overrides.loadFlows ?? loadFlows)();
   const processIdentity = overrides.processIdentity ?? ((pid: number) => procBackend.processIdentity(pid));
   const mergedFlowIds = await refreshMergedFlowIds(flows, overrides);
-  const snapshot = registry.snapshot();
+  const snapshot = registry.readOnlySnapshot();
   const missingTranscriptPaths = new Set(hosts.flatMap((host) =>
     host.primaryPath && !fs.existsSync(host.primaryPath) ? [host.primaryPath] : []));
   const authorship = await authorshipEvidence(snapshot, hosts, flows, files, missingTranscriptPaths, state.scannedAt);

--- a/src/lib/runtime/codexAppServerHost.test.ts
+++ b/src/lib/runtime/codexAppServerHost.test.ts
@@ -1568,9 +1568,10 @@ describe("CodexAppServerHost", () => {
     const receipt = await adopted[0]!.host.send({ id: "persist-turn", text: "start" });
     expect(receipt.outcome).toBe("turn-started");
     expect(registry.snapshot().entries["codex:adopted-thread"]?.structuredHost).toMatchObject({
-      eventCursor: 15,
+      eventCursor: 14,
       activeTurnRef: "turn-1",
     });
+    expect(eventStore.load("adopted-thread").at(-1)?.seq).toBe(15);
     server.request("persist-attention", "item/commandExecution/requestApproval", { command: "date" });
     await Bun.sleep(0);
     expect(registry.snapshot().entries["codex:adopted-thread"]?.structuredHost?.pendingAttention).toEqual([

--- a/src/lib/runtime/registry.ts
+++ b/src/lib/runtime/registry.ts
@@ -86,6 +86,153 @@ export async function persistCodexHost(
   return persisted;
 }
 
+export interface StructuredHostPersistenceOptions {
+  cursorDebounceMs?: number;
+}
+
+interface ObservableStructuredHost {
+  health(): Promise<HostState>;
+  release(): Promise<void>;
+  setWriterFence(check: () => boolean): void;
+  onStateChange(listener: (state: HostState) => void): () => void;
+}
+
+const DEFAULT_CURSOR_DEBOUNCE_MS = 1_000;
+
+function sameStrings(left: readonly string[], right: readonly string[]): boolean {
+  return left.length === right.length && left.every((value, index) => value === right[index]);
+}
+
+function sameMaterialHostState(left: HostState, right: HostState): boolean {
+  return left.status === right.status
+    && left.endpoint === right.endpoint
+    && left.pid === right.pid
+    && left.processStartIdentity === right.processStartIdentity
+    && left.protocolVersion === right.protocolVersion
+    && left.activeTurnRef === right.activeTurnRef
+    && sameStrings(left.pendingAttention, right.pendingAttention)
+    && sameStrings(left.activeFlags, right.activeFlags);
+}
+
+async function bindStructuredHostPersistence(
+  registry: AgentRegistry,
+  key: SessionKey,
+  host: ObservableStructuredHost,
+  claimOwner: string,
+  writerClaimEpoch: number,
+  releasedStatus: "unhosted" | "dead",
+  columnsFromState: (state: HostState, writerClaimEpoch: number) => StructuredHostColumns,
+  options: StructuredHostPersistenceOptions,
+): Promise<() => void> {
+  host.setWriterFence(() => registry.ownsStructuredHostClaim(key, claimOwner, writerClaimEpoch));
+  let lastPersistedState: HostState;
+  const persist = (state: HostState, terminal = false): AgentRegistryEntry => {
+    const persisted = registry.setStructuredHostClaimed(
+      key,
+      columnsFromState(state, writerClaimEpoch),
+      terminal && releasedStatus === "dead" ? "dead" : registryStatus(state),
+      claimOwner,
+      writerClaimEpoch,
+      terminal,
+    );
+    if (!persisted) throw new Error("structured host writer claim is stale");
+    lastPersistedState = structuredClone(state);
+    return persisted;
+  };
+  try {
+    persist(await host.health());
+  } catch (error) {
+    await host.release();
+    throw error;
+  }
+
+  const cursorDebounceMs = Number.isFinite(options.cursorDebounceMs)
+    ? Math.max(0, options.cursorDebounceMs!)
+    : DEFAULT_CURSOR_DEBOUNCE_MS;
+  let failed = false;
+  let stopped = false;
+  let claimReleased = false;
+  let pendingState: HostState | null = null;
+  let cursorTimer: ReturnType<typeof setTimeout> | null = null;
+  let unsubscribe = () => {};
+
+  const clearCursorTimer = () => {
+    if (cursorTimer === null) return;
+    clearTimeout(cursorTimer);
+    cursorTimer = null;
+  };
+  const releaseClaim = () => {
+    if (claimReleased) return;
+    claimReleased = true;
+    registry.releaseStructuredHostClaim(key, claimOwner, writerClaimEpoch);
+  };
+  const fail = () => {
+    if (failed) return;
+    failed = true;
+    stopped = true;
+    pendingState = null;
+    clearCursorTimer();
+    unsubscribe();
+    releaseClaim();
+    void host.release();
+  };
+  const persistPending = () => {
+    const state = pendingState;
+    pendingState = null;
+    clearCursorTimer();
+    if (state) persist(state);
+  };
+  const schedulePending = () => {
+    if (cursorTimer !== null) return;
+    cursorTimer = setTimeout(() => {
+      cursorTimer = null;
+      if (failed || stopped || pendingState === null) return;
+      try {
+        persistPending();
+      } catch {
+        fail();
+      }
+    }, cursorDebounceMs);
+    cursorTimer.unref?.();
+  };
+  const stop = () => {
+    if (stopped) return;
+    try {
+      persistPending();
+    } catch {
+      fail();
+      return;
+    }
+    stopped = true;
+    unsubscribe();
+    releaseClaim();
+  };
+
+  unsubscribe = host.onStateChange((state) => {
+    if (failed || stopped) return;
+    const terminal = state.status === "unhosted" || (state.status === "dead" && state.pid === null);
+    if (!terminal && sameMaterialHostState(lastPersistedState, state)) {
+      pendingState = structuredClone(state);
+      schedulePending();
+      return;
+    }
+    pendingState = null;
+    clearCursorTimer();
+    try {
+      persist(state, terminal);
+      if (terminal) {
+        claimReleased = true;
+        stopped = true;
+        unsubscribe();
+      }
+    } catch {
+      fail();
+    }
+  });
+  if (stopped) unsubscribe();
+  return stop;
+}
+
 export async function bindCodexHostPersistence(
   registry: AgentRegistry,
   key: SessionKey,
@@ -93,48 +240,18 @@ export async function bindCodexHostPersistence(
   claimOwner: string,
   writerClaimEpoch: number,
   releasedStatus: "unhosted" | "dead" = "unhosted",
+  options: StructuredHostPersistenceOptions = {},
 ): Promise<() => void> {
-  host.setWriterFence(() => registry.ownsStructuredHostClaim(key, claimOwner, writerClaimEpoch));
-  try {
-    await persistCodexHost(registry, key, host, claimOwner, writerClaimEpoch);
-  } catch (error) {
-    await host.release();
-    throw error;
-  }
-  let failed = false;
-  let stopped = false;
-  let unsubscribe = () => {};
-  const stop = () => {
-    if (stopped) return;
-    stopped = true;
-    unsubscribe();
-    registry.releaseStructuredHostClaim(key, claimOwner, writerClaimEpoch);
-  };
-  unsubscribe = host.onStateChange((state) => {
-    if (failed || stopped) return;
-    try {
-      const terminal = state.status === "unhosted" || (state.status === "dead" && state.pid === null);
-      const persisted = registry.setStructuredHostClaimed(
-        key,
-        codexHostColumns(state, writerClaimEpoch),
-        terminal && releasedStatus === "dead" ? "dead" : registryStatus(state),
-        claimOwner,
-        writerClaimEpoch,
-        terminal,
-      );
-      if (!persisted) throw new Error("structured host writer claim is stale");
-      if (terminal) {
-        stopped = true;
-        unsubscribe();
-      }
-    } catch {
-      failed = true;
-      stop();
-      void host.release();
-    }
-  });
-  if (stopped) unsubscribe();
-  return stop;
+  return bindStructuredHostPersistence(
+    registry,
+    key,
+    host,
+    claimOwner,
+    writerClaimEpoch,
+    releasedStatus,
+    codexHostColumns,
+    options,
+  );
 }
 
 export async function bindClaudeHostPersistence(
@@ -144,56 +261,18 @@ export async function bindClaudeHostPersistence(
   claimOwner: string,
   writerClaimEpoch: number,
   releasedStatus: "unhosted" | "dead" = "unhosted",
+  options: StructuredHostPersistenceOptions = {},
 ): Promise<() => void> {
-  host.setWriterFence(() => registry.ownsStructuredHostClaim(key, claimOwner, writerClaimEpoch));
-  const persist = (state: HostState, terminal = false) => registry.setStructuredHostClaimed(
+  return bindStructuredHostPersistence(
+    registry,
     key,
-    claudeHostColumns(state, writerClaimEpoch),
-    registryStatus(state),
+    host,
     claimOwner,
     writerClaimEpoch,
-    terminal,
+    releasedStatus,
+    claudeHostColumns,
+    options,
   );
-  try {
-    if (!persist(await host.health())) throw new Error("structured host writer claim is stale");
-  } catch (error) {
-    await host.release();
-    throw error;
-  }
-  let failed = false;
-  let stopped = false;
-  let unsubscribe = () => {};
-  const stop = () => {
-    if (stopped) return;
-    stopped = true;
-    unsubscribe();
-    registry.releaseStructuredHostClaim(key, claimOwner, writerClaimEpoch);
-  };
-  unsubscribe = host.onStateChange((state) => {
-    if (failed || stopped) return;
-    try {
-      const terminal = state.status === "unhosted" || (state.status === "dead" && state.pid === null);
-      const persisted = registry.setStructuredHostClaimed(
-        key,
-        claudeHostColumns(state, writerClaimEpoch),
-        terminal && releasedStatus === "dead" ? "dead" : registryStatus(state),
-        claimOwner,
-        writerClaimEpoch,
-        terminal,
-      );
-      if (!persisted) throw new Error("structured host writer claim is stale");
-      if (terminal) {
-        stopped = true;
-        unsubscribe();
-      }
-    } catch {
-      failed = true;
-      stop();
-      void host.release();
-    }
-  });
-  if (stopped) unsubscribe();
-  return stop;
 }
 
 export interface AdoptedCodexHost {

--- a/src/lib/runtime/registryPersistence.test.ts
+++ b/src/lib/runtime/registryPersistence.test.ts
@@ -1,0 +1,205 @@
+import { describe, expect, test } from "bun:test";
+
+import type { AgentRegistry, AgentRegistryEntry, StructuredHostColumns } from "@/lib/agent/registry";
+
+import type { ClaudeStreamBrokerHost } from "./claudeStreamBrokerHost";
+import type { CodexAppServerHost } from "./codexAppServerHost";
+import type { HostState } from "./engineHost";
+import { bindClaudeHostPersistence, bindCodexHostPersistence } from "./registry";
+
+const KEY = { engine: "codex" as const, sessionId: "coalesced-host" };
+
+function hostState(overrides: Partial<HostState> = {}): HostState {
+  return {
+    status: "idle",
+    sessionKey: KEY.sessionId,
+    endpoint: "stdio:4242",
+    pid: 4242,
+    processStartIdentity: "4242:100",
+    eventCursor: 0,
+    protocolVersion: "1.0.0",
+    activeTurnRef: null,
+    pendingAttention: [],
+    activeFlags: [],
+    account: null,
+    ...overrides,
+  };
+}
+
+class RecordingRegistry {
+  readonly writes: Array<{ columns: StructuredHostColumns; status: string; releaseClaim: boolean }> = [];
+  readonly releases: number[] = [];
+  acceptWrites = true;
+
+  ownsStructuredHostClaim(): boolean { return true; }
+
+  setStructuredHostClaimed(
+    _key: unknown,
+    columns: StructuredHostColumns,
+    status: string,
+    _claimOwner: string,
+    writerClaimEpoch: number,
+    releaseClaim = false,
+  ): AgentRegistryEntry | null {
+    this.writes.push({ columns: structuredClone(columns), status, releaseClaim });
+    if (!this.acceptWrites) return null;
+    return { structuredHost: columns, status, claimEpoch: writerClaimEpoch } as AgentRegistryEntry;
+  }
+
+  releaseStructuredHostClaim(_key: unknown, _owner: string, epoch: number): void {
+    this.releases.push(epoch);
+  }
+}
+
+class RecordingHost {
+  private readonly listeners = new Set<(state: HostState) => void>();
+  private state = hostState();
+  releaseCalls = 0;
+
+  setWriterFence(): void {}
+  async health(): Promise<HostState> { return structuredClone(this.state); }
+  onStateChange(listener: (state: HostState) => void): () => void {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  }
+  async release(): Promise<void> { this.releaseCalls += 1; }
+
+  emit(overrides: Partial<HostState>): void {
+    this.state = hostState({ ...this.state, ...overrides });
+    for (const listener of this.listeners) listener(structuredClone(this.state));
+  }
+}
+
+type Binder = (
+  registry: AgentRegistry,
+  host: RecordingHost,
+  options?: { cursorDebounceMs: number },
+) => Promise<() => void>;
+
+const binders: Array<[string, Binder]> = [
+  ["Codex", (registry, host, options) => bindCodexHostPersistence(
+    registry,
+    KEY,
+    host as unknown as CodexAppServerHost,
+    "writer",
+    7,
+    "unhosted",
+    options,
+  )],
+  ["Claude", (registry, host, options) => bindClaudeHostPersistence(
+    registry,
+    { ...KEY, engine: "claude" },
+    host as unknown as ClaudeStreamBrokerHost,
+    "writer",
+    7,
+    "unhosted",
+    options,
+  )],
+];
+
+for (const [engine, bind] of binders) {
+  describe(`${engine} structured host persistence`, () => {
+    test("bounds registry mutations across ten streaming lanes", async () => {
+      const lanes = await Promise.all(Array.from({ length: 10 }, async () => {
+        const registry = new RecordingRegistry();
+        const host = new RecordingHost();
+        const stop = await bind(registry as unknown as AgentRegistry, host, { cursorDebounceMs: 20 });
+        return { registry, host, stop };
+      }));
+
+      for (let eventCursor = 1; eventCursor <= 100; eventCursor += 1) {
+        for (const lane of lanes) lane.host.emit({ eventCursor });
+      }
+
+      expect(lanes.reduce((sum, lane) => sum + lane.registry.writes.length, 0)).toBe(10);
+      await Bun.sleep(35);
+      expect(lanes.reduce((sum, lane) => sum + lane.registry.writes.length, 0)).toBe(20);
+      expect(lanes.every((lane) => lane.registry.writes.at(-1)?.columns.eventCursor === 100)).toBeTrue();
+      for (const lane of lanes) lane.stop();
+    });
+
+    test("coalesces cursor-only events into one trailing registry mutation", async () => {
+      const registry = new RecordingRegistry();
+      const host = new RecordingHost();
+      const stop = await bind(registry as unknown as AgentRegistry, host, { cursorDebounceMs: 20 });
+
+      for (let eventCursor = 1; eventCursor <= 20; eventCursor += 1) host.emit({ eventCursor });
+
+      expect(registry.writes).toHaveLength(1);
+      await Bun.sleep(35);
+      expect(registry.writes).toHaveLength(2);
+      expect(registry.writes.at(-1)?.columns.eventCursor).toBe(20);
+      stop();
+    });
+
+    test("persists material and terminal changes immediately with the latest cursor", async () => {
+      const registry = new RecordingRegistry();
+      const host = new RecordingHost();
+      await bind(registry as unknown as AgentRegistry, host, { cursorDebounceMs: 100 });
+
+      host.emit({ eventCursor: 1 });
+      host.emit({ eventCursor: 2, status: "active", activeTurnRef: "turn-1" });
+      expect(registry.writes).toHaveLength(2);
+      expect(registry.writes.at(-1)).toMatchObject({
+        columns: { eventCursor: 2, activeTurnRef: "turn-1" },
+        status: "live",
+      });
+
+      host.emit({ eventCursor: 3, status: "attention", pendingAttention: ["approval-1"] });
+      expect(registry.writes.at(-1)).toMatchObject({
+        columns: { eventCursor: 3, pendingAttention: ["approval-1"] },
+        status: "live",
+      });
+      host.emit({ eventCursor: 4, status: "active", pendingAttention: [], activeFlags: ["waiting"] });
+      expect(registry.writes.at(-1)).toMatchObject({
+        columns: { eventCursor: 4, activeFlags: ["waiting"] },
+        status: "live",
+      });
+      host.emit({ eventCursor: 5 });
+      host.emit({
+        eventCursor: 6,
+        status: "unhosted",
+        endpoint: "stdio:released",
+        pid: null,
+        processStartIdentity: null,
+        activeTurnRef: null,
+      });
+      expect(registry.writes).toHaveLength(5);
+      expect(registry.writes.at(-1)).toMatchObject({
+        columns: { eventCursor: 6, process: null },
+        status: "unhosted",
+        releaseClaim: true,
+      });
+      await Bun.sleep(120);
+      expect(registry.writes).toHaveLength(5);
+    });
+
+    test("flushes the newest cursor before an explicit persistence stop", async () => {
+      const registry = new RecordingRegistry();
+      const host = new RecordingHost();
+      const stop = await bind(registry as unknown as AgentRegistry, host, { cursorDebounceMs: 100 });
+
+      host.emit({ eventCursor: 8 });
+      host.emit({ eventCursor: 9 });
+      stop();
+
+      expect(registry.writes.map((write) => write.columns.eventCursor)).toEqual([0, 9]);
+      expect(registry.releases).toEqual([7]);
+      await Bun.sleep(120);
+      expect(registry.writes).toHaveLength(2);
+    });
+
+    test("releases the host when a trailing write loses its claim", async () => {
+      const registry = new RecordingRegistry();
+      const host = new RecordingHost();
+      await bind(registry as unknown as AgentRegistry, host, { cursorDebounceMs: 10 });
+
+      registry.acceptWrites = false;
+      host.emit({ eventCursor: 1 });
+      await Bun.sleep(25);
+
+      expect(host.releaseCalls).toBe(1);
+      expect(registry.releases).toEqual([7]);
+    });
+  });
+}

--- a/src/lib/session/titleProjection.ts
+++ b/src/lib/session/titleProjection.ts
@@ -89,7 +89,7 @@ function registryProjection(registry: Registry, surfaceUnexpectedError = false):
   if (cached?.signature === signature) return cached;
   let snapshot: RegistrySnapshot;
   try {
-    snapshot = registry.snapshot();
+    snapshot = registry.readOnlySnapshot();
   } catch (error) {
     if (surfaceUnexpectedError && !(error instanceof RegistryReadError)) throw error;
     return null;


### PR DESCRIPTION
## Summary

Phase 1 of #312 reduces structured-host registry write amplification while PR #310 remains the safety prerequisite.

- coalesces cursor-only Codex and Claude host updates into a one-second trailing persistence window
- persists material state, attention, turn, flag, process, and terminal transitions immediately
- flushes the newest cursor during explicit stop
- preserves writer-claim fencing and releases the host after a stale trailing write
- shares one persistence binder across both structured engines

This PR is stacked on `agent/issue-308-ledger-cursor-recovery` so its diff stays limited to the resource slice. Retarget it to `main` after PR #310 lands.

## Verification

- `bun test src/lib/runtime/registryPersistence.test.ts src/lib/runtime/codexAppServerHost.test.ts src/lib/runtime/claudeStreamBrokerHost.test.ts src/lib/runtime/structuredSpawn.integration.test.ts` — 131 pass, 552 assertions
- `bun x tsc --noEmit`
- `bun x eslint src/lib/runtime/registry.ts src/lib/runtime/registryPersistence.test.ts src/lib/runtime/codexAppServerHost.test.ts`

## Live acceptance

Deploy exact SHA `25a1bd88126cf53261bee654f17c096f95807d65`, then compare registry mutation rate, process write bytes, CPU, memory, and API latency under the same active-host workload.
