### PR TITLE
Keep cross-project lineage on each owning board

### DIFF
--- a/src/components/projectModel.test.ts
+++ b/src/components/projectModel.test.ts
@@ -144,6 +144,58 @@ describe("draftWorkingDirectory", () => {
 });
 
 describe("buildBranchGroups", () => {
+  test("keeps a foreign-parent lineage on each conversation's own project board", () => {
+    const foreignRoot = entry({ path: "/latand-root", project: "latand", activity: "live" });
+    const viewerBuilder = entry({
+      path: "/viewer-builder",
+      project: "viewer",
+      root: "codex-sessions",
+      engine: "codex",
+      fmt: "codex",
+      parent: foreignRoot.path,
+      activity: "live",
+    });
+    const viewerReviewer = entry({
+      path: "/viewer-reviewer",
+      project: "viewer",
+      root: "codex-sessions",
+      engine: "codex",
+      fmt: "codex",
+      parent: viewerBuilder.path,
+      activity: "recent",
+    });
+    const latandFollowup = entry({
+      path: "/latand-followup",
+      project: "latand",
+      root: "codex-sessions",
+      engine: "codex",
+      fmt: "codex",
+      parent: viewerBuilder.path,
+      activity: "live",
+    });
+    const files = [foreignRoot, viewerBuilder, viewerReviewer, latandFollowup];
+
+    const viewerGroups = buildBranchGroups(files, "viewer");
+    expect(viewerGroups).toHaveLength(1);
+    expect(viewerGroups[0]!.key).toBe(viewerBuilder.path);
+    expect(viewerGroups[0]!.columns.map((column) => column.file.path)).toEqual([
+      viewerBuilder.path,
+      viewerReviewer.path,
+    ]);
+
+    const latandGroups = buildBranchGroups(files, "latand");
+    expect(latandGroups.map((group) => group.key).sort()).toEqual([
+      foreignRoot.path,
+      latandFollowup.path,
+    ].sort());
+    expect(latandGroups.find((group) => group.key === foreignRoot.path)!.columns.map((column) => column.file.path)).toEqual([
+      foreignRoot.path,
+    ]);
+    expect(latandGroups.find((group) => group.key === latandFollowup.path)!.columns.map((column) => column.file.path)).toEqual([
+      latandFollowup.path,
+    ]);
+  });
+
   test("a live root promotes its live-owned subagents to connected columns", () => {
     const groups = buildBranchGroups(TREE, "demo");
     expect(groups).toHaveLength(1);

--- a/src/components/projectModel.test.ts
+++ b/src/components/projectModel.test.ts
@@ -196,6 +196,43 @@ describe("buildBranchGroups", () => {
     ]);
   });
 
+  test("keeps a project segment visible when its foreign-parent child becomes idle", () => {
+    const projectRoot = entry({ path: "/project-root", project: "viewer", activity: "live" });
+    const foreignParent = entry({
+      path: "/foreign-parent",
+      project: "latand",
+      root: "codex-sessions",
+      engine: "codex",
+      fmt: "codex",
+      parent: projectRoot.path,
+      activity: "live",
+    });
+    const segment = entry({
+      path: "/project-segment",
+      project: "viewer",
+      root: "codex-sessions",
+      engine: "codex",
+      fmt: "codex",
+      parent: foreignParent.path,
+      activity: "live",
+    });
+
+    expect(buildBranchGroups([projectRoot, foreignParent, segment], "viewer").map((group) => group.key).sort()).toEqual([
+      projectRoot.path,
+      segment.path,
+    ].sort());
+
+    const idleSegment = { ...segment, activity: "idle" as const };
+    const afterTurn = buildBranchGroups([projectRoot, foreignParent, idleSegment], "viewer");
+    expect(afterTurn.map((group) => group.key).sort()).toEqual([
+      projectRoot.path,
+      segment.path,
+    ].sort());
+    expect(afterTurn.find((group) => group.key === segment.path)!.columns.map((column) => column.file.path)).toEqual([
+      segment.path,
+    ]);
+  });
+
   test("a live root promotes its live-owned subagents to connected columns", () => {
     const groups = buildBranchGroups(TREE, "demo");
     expect(groups).toHaveLength(1);
@@ -306,6 +343,39 @@ describe("buildArchiveBranchGroups", () => {
     expect(groups).toHaveLength(100);
     expect(groups.some((group) => group.key === "/root-0")).toBe(false);
     expect(groups.some((group) => group.key === "/root-104")).toBe(true);
+  });
+
+  test("archives each project segment once across a foreign lineage", () => {
+    const projectRoot = entry({ path: "/archive-root", project: "viewer", mtime: 30 });
+    const foreignParent = entry({
+      path: "/archive-foreign",
+      project: "latand",
+      root: "codex-sessions",
+      engine: "codex",
+      fmt: "codex",
+      parent: projectRoot.path,
+      mtime: 20,
+    });
+    const projectLeaf = entry({
+      path: "/archive-leaf",
+      project: "viewer",
+      root: "codex-sessions",
+      engine: "codex",
+      fmt: "codex",
+      parent: foreignParent.path,
+      mtime: 10,
+    });
+
+    const groups = buildArchiveBranchGroups([projectRoot, foreignParent, projectLeaf], "viewer", 100);
+    expect(groups.map((group) => group.key).sort()).toEqual([projectRoot.path, projectLeaf.path].sort());
+    const occurrences = groups.flatMap((group) => [
+      ...group.columns.map((column) => column.file.path),
+      ...group.finished.map((file) => file.path),
+    ]);
+    expect(occurrences.filter((path) => path === projectLeaf.path)).toHaveLength(1);
+    expect(groups.find((group) => group.key === projectRoot.path)!.columns.map((column) => column.file.path)).toEqual([
+      projectRoot.path,
+    ]);
   });
 });
 

--- a/src/components/projectModel.ts
+++ b/src/components/projectModel.ts
@@ -209,6 +209,12 @@ function rootOf(file: FileEntry, byPath: Map<string, FileEntry>): FileEntry {
     seen.add(cur.path);
     const parent = byPath.get(cur.parent);
     if (!parent) break;
+    /* Lineage can deliberately cross project ownership (for example, an LLV
+       builder spawned by a home-root orchestrator). Each project board owns
+       its own visual root; following the foreign parent would duplicate the
+       complete tree on both boards. The durable parent pointer remains on the
+       file for explicit cross-project navigation. */
+    if (projectKey(parent) !== projectKey(file)) break;
     cur = parent;
   }
   return cur;
@@ -233,6 +239,23 @@ export function subtree(root: FileEntry, kids: Map<string, FileEntry[]>): FileEn
     const node = stack.pop()!;
     if (seen.has(node.path)) continue;
     seen.add(node.path);
+    out.push(node);
+    stack.push(...(kids.get(node.path) ?? []));
+  }
+  return out;
+}
+
+/** Descendants reachable without crossing the root's project boundary. */
+function projectSubtree(root: FileEntry, kids: Map<string, FileEntry[]>): FileEntry[] {
+  const out: FileEntry[] = [];
+  const stack = [...(kids.get(root.path) ?? [])];
+  const seen = new Set<string>([root.path]);
+  const project = projectKey(root);
+  while (stack.length) {
+    const node = stack.pop()!;
+    if (seen.has(node.path)) continue;
+    seen.add(node.path);
+    if (projectKey(node) !== project) continue;
     out.push(node);
     stack.push(...(kids.get(node.path) ?? []));
   }
@@ -267,7 +290,9 @@ function assembleGroup(
   kids: Map<string, FileEntry[]>,
   expandedConversationPaths?: ReadonlySet<string>,
 ): BranchGroup {
-  const descendants = subtree(root, kids);
+  /* Stop traversal at the first foreign owner so a later same-project node
+     cannot leak through that foreign branch and appear twice. */
+  const descendants = projectSubtree(root, kids);
   const liveRank = (file: FileEntry) => (file.activity === "live" ? 0 : 1);
   /* Every child conversation in an active group renders as a connected node
      below its parent — a claude subagent, a codex child session, a reviewer

--- a/src/components/projectModel.ts
+++ b/src/components/projectModel.ts
@@ -564,8 +564,11 @@ export interface DescendantRow {
   depth: number;
 }
 
-/** Depth-first subtree of a node: children stay under their parent, siblings ordered by state then recency. */
-export function descendantsOf(file: FileEntry | null, files: FileEntry[]): DescendantRow[] {
+function collectDescendants(
+  file: FileEntry | null,
+  files: FileEntry[],
+  include: (child: FileEntry) => boolean,
+): DescendantRow[] {
   if (!file) return [];
   const kids = kidsIndex(files);
   const out: DescendantRow[] = [];
@@ -576,10 +579,23 @@ export function descendantsOf(file: FileEntry | null, files: FileEntry[]): Desce
       .sort((a, b) => activityBand(a) - activityBand(b) || b.mtime - a.mtime);
     for (const child of children) {
       seen.add(child.path);
+      if (!include(child)) continue;
       out.push({ file: child, depth });
       walk(child, depth + 1);
     }
   };
   walk(file, 1);
   return out;
+}
+
+/** Depth-first subtree of a node: children stay under their parent, siblings ordered by state then recency. */
+export function descendantsOf(file: FileEntry | null, files: FileEntry[]): DescendantRow[] {
+  return collectDescendants(file, files, () => true);
+}
+
+/** Descendants owned by the root's project, stopping traversal at every foreign boundary. */
+export function projectDescendantsOf(file: FileEntry | null, files: FileEntry[]): DescendantRow[] {
+  if (!file) return [];
+  const project = projectKey(file);
+  return collectDescendants(file, files, (child) => projectKey(child) === project);
 }

--- a/src/components/projectModel.ts
+++ b/src/components/projectModel.ts
@@ -220,6 +220,12 @@ function rootOf(file: FileEntry, byPath: Map<string, FileEntry>): FileEntry {
   return cur;
 }
 
+function beginsProjectSegment(file: FileEntry, byPath: Map<string, FileEntry>): boolean {
+  if (!file.parent || !isChildConversation(file)) return false;
+  const parent = byPath.get(file.parent);
+  return Boolean(parent && projectKey(parent) !== projectKey(file));
+}
+
 export function kidsIndex(files: FileEntry[]): Map<string, FileEntry[]> {
   const map = new Map<string, FileEntry[]>();
   for (const file of files) {
@@ -349,6 +355,13 @@ export function buildBranchGroups(files: FileEntry[], project: string, options: 
   const { expandedConversationPaths } = options;
   for (const file of files) {
     if (projectKey(file) !== project) continue;
+    /* A cross-project child starts an independently owned visual segment. Keep
+       its root card after the child becomes quiet while the durable parent
+       pointer continues to support explicit cross-project navigation. */
+    if (beginsProjectSegment(file, byPath)) {
+      roots.set(file.path, file);
+      continue;
+    }
     const expanded = expandedConversationPaths?.has(file.path) === true;
     if (
       file.activity === "live" ||
@@ -419,7 +432,7 @@ export function buildArchiveBranchGroups(files: FileEntry[], project: string, li
 
   const groups: BranchGroup[] = [];
   for (const root of roots.values()) {
-    const descendants = subtree(root, kids)
+    const descendants = projectSubtree(root, kids)
       .filter((file) => keep.has(file.path) && projectKey(file) === project)
       .sort((a, b) => activityBand(a) - activityBand(b) || b.mtime - a.mtime || a.path.localeCompare(b.path));
     const fullNodes = descendants.filter((file) => !isAuxTask(file) && isChildConversation(file));

--- a/src/components/scheme/layout.test.ts
+++ b/src/components/scheme/layout.test.ts
@@ -3,8 +3,11 @@ import { describe, expect, test } from "bun:test";
 import type { Flow } from "@/lib/flows/types";
 import type { Pipeline } from "@/lib/pipelines/types";
 import type { FileEntry } from "@/lib/types";
+import type { BoardProjectStateV1 } from "@/lib/view/types";
 
 import { type BranchGroup, buildBranchGroups } from "@/components/projectModel";
+import { planRootReconciliation } from "@/components/projectBoardMutations";
+import { applyBoardMutations } from "@/lib/board/mutations";
 
 import { deckKey, flowLinkKey } from "./agentLinks";
 import { INDENT, buildSchemeLayout } from "./layout";
@@ -32,6 +35,14 @@ function entry(overrides: Partial<FileEntry> & { path: string }): FileEntry {
 }
 
 const roleConfig = { engine: "claude" as const, model: null, effort: null };
+
+const boardOf = (manual: string[] = []): BoardProjectStateV1 => ({
+  schemaVersion: 1,
+  revision: 1,
+  updatedAt: new Date(0).toISOString(),
+  pathAliases: {},
+  prefs: { manual, hidden: [], expanded: [], favorites: [], viewMode: null, taskPanelOpen: false },
+});
 
 function flow(overrides: Partial<Flow> & { id: string; implementerPath: string }): Flow {
   return {
@@ -68,6 +79,55 @@ function flow(overrides: Partial<Flow> & { id: string; implementerPath: string }
 }
 
 describe("buildSchemeLayout byPath", () => {
+  test("an idle reconciled root excludes every descendant beyond a foreign project boundary", () => {
+    const root = entry({ path: "/a-root", project: "project-a", activity: "live" });
+    const foreignChild = entry({
+      path: "/b-child",
+      project: "project-b",
+      parent: root.path,
+      kind: "subagent",
+      activity: "live",
+    });
+    const localLeaf = entry({
+      path: "/a-leaf",
+      project: "project-a",
+      parent: foreignChild.path,
+      kind: "subagent",
+      activity: "idle",
+    });
+    const activeFiles = [root, foreignChild, localLeaf];
+    const activeGroups = buildBranchGroups(activeFiles, "project-a");
+    const catalog = new Map(activeFiles.map((file) => [file.path, file]));
+    const activeBoard = applyBoardMutations(boardOf(), [planRootReconciliation({
+      groups: activeGroups,
+      manual: [],
+      catalog,
+    })]);
+    expect(activeBoard.prefs.manual).toContain(root.path);
+
+    const idleRoot = { ...root, activity: "idle" as const };
+    const idleFiles = [idleRoot, foreignChild, localLeaf];
+    const idleGroups = buildBranchGroups(idleFiles, "project-a");
+    expect(idleGroups.map((group) => group.key)).toEqual([localLeaf.path]);
+    const idleBoard = applyBoardMutations(activeBoard, [planRootReconciliation({
+      groups: idleGroups,
+      manual: activeBoard.prefs.manual,
+      catalog: new Map(idleFiles.map((file) => [file.path, file])),
+    })]);
+    const autoPaths = new Set(idleGroups.flatMap((group) => group.columns.map((column) => column.file.path)));
+    const manual = idleBoard.prefs.manual
+      .filter((path) => !autoPaths.has(path))
+      .flatMap((path) => idleFiles.filter((file) => file.path === path));
+    const layout = buildSchemeLayout(idleGroups, manual, idleFiles);
+
+    expect(layout.nodes.map((node) => node.file.path).sort()).toEqual([localLeaf.path, root.path].sort());
+    const stackedPaths = layout.stacks.flatMap((stack) => stack.items.map((item) => item.file.path));
+    expect(stackedPaths).toEqual([]);
+    expect(layout.byPath.has(foreignChild.path)).toBeFalse();
+    expect(layout.nodes.filter((node) => node.file.path === localLeaf.path)).toHaveLength(1);
+    expect(stackedPaths.filter((path) => path === localLeaf.path)).toHaveLength(0);
+  });
+
   test("carries stacks and decks as glide/edge targets alongside nodes", () => {
     const root = entry({ path: "/root", activity: "live" });
     const quiet = entry({ path: "/root/quiet", parent: "/root", kind: "subagent" });

--- a/src/components/scheme/layout.ts
+++ b/src/components/scheme/layout.ts
@@ -18,7 +18,7 @@ import {
   type AgentLink,
   type SchemeGroupSpec,
 } from "./agentLinks";
-import { type BranchGroup, descendantsOf, isChildConversation, kidsIndex } from "@/components/projectModel";
+import { type BranchGroup, descendantsOf, isChildConversation, kidsIndex, projectDescendantsOf } from "@/components/projectModel";
 import { cleanTitle, engineColor } from "@/components/utils";
 import { conversationIdentity } from "@/lib/accounts/identity";
 
@@ -481,7 +481,7 @@ export function buildSchemeLayout(
   };
 
   const placeManual = (file: FileEntry, bandTop: number) => {
-    const descendants = descendantsOf(file, files)
+    const descendants = projectDescendantsOf(file, files)
       .map((row) => row.file)
       .filter((entry) => !claimed.has(entry.path));
     const quiet = descendants.filter((entry) => isChildConversation(entry));


### PR DESCRIPTION
## Summary

- bound active branch-root discovery to the selected project
- prune descendant traversal at the first foreign project boundary
- preserve durable lineage pointers for later cross-project navigation
- cover a production-shaped `latand → viewer → latand` lineage without duplicate cards

## Verification

- `bun test src/components/projectModel.test.ts src/components/scheme/layout.test.ts` — 50 passed
- `bun x eslint src/components/projectModel.ts src/components/projectModel.test.ts`
- `bun x tsc --noEmit`
- `git diff --check`

This is a deployable P0 slice of #315. Durable explicit project ownership and safe conversation relocation remain tracked in #315.
