### PR TITLE
Fix structured kill reap convergence

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,9 +116,11 @@ npm start -- --port 8898 --hostname 127.0.0.1
 development, `bun dev` runs the app with hot reload (it needs a high OS
 file-watch limit for large home directories).
 
-The gated SQLite registry modes require the Viewer server to run on Bun. The
-Docker runtime and `agent-log-viewer` CLI select Bun automatically whenever
-`LLV_AGENT_REGISTRY_SQLITE` is enabled. Local source checkouts should use the
+The gated SQLite registry modes require the Viewer server to run on Bun.
+Structured host mode also requires Bun on macOS so process ownership uses the
+kernel's microsecond start token. The Docker runtime and `agent-log-viewer` CLI
+select Bun automatically whenever `LLV_AGENT_REGISTRY_SQLITE` or
+`LLV_STRUCTURED_HOSTS` is enabled. Local source checkouts should use the
 explicit `bun --bun` command above during the rollout.
 
 **Prerequisites:** Node ≥ 20.9, and bun or npm/pnpm. `tmux` is optional — see

--- a/bin/cli.mjs
+++ b/bin/cli.mjs
@@ -8,6 +8,7 @@ import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { detectTailscale, getToken, readStatus, serve as serveTailscale, TailscaleError } from "./tailscale.mjs";
+import { viewerServerBunRuntime } from "./server-runtime.mjs";
 
 const DEFAULT_PORT = 8898;
 const DEFAULT_HOSTNAME = "127.0.0.1";
@@ -211,10 +212,7 @@ function readPackageJson(packageRoot) {
 }
 
 function resolveServer(packageRoot) {
-  const sqliteMode = process.env.LLV_AGENT_REGISTRY_SQLITE ?? "off";
-  const bunRuntime = sqliteMode === "off"
-    ? null
-    : (process.versions.bun ? process.execPath : (process.env.LLV_BUN_EXECUTABLE || "bun"));
+  const bunRuntime = viewerServerBunRuntime();
   const commandFor = (command, args, bunEntry = command, bunArgs = args) => bunRuntime
     ? { command: bunRuntime, args: ["--bun", bunEntry, ...bunArgs] }
     : { command, args };

--- a/bin/server-runtime.mjs
+++ b/bin/server-runtime.mjs
@@ -1,0 +1,9 @@
+export function viewerServerBunRuntime(options = {}) {
+  const env = options.env ?? process.env;
+  const versions = options.versions ?? process.versions;
+  const execPath = options.execPath ?? process.execPath;
+  const sqliteMode = env.LLV_AGENT_REGISTRY_SQLITE ?? "off";
+  const requiresBun = sqliteMode !== "off" || env.LLV_STRUCTURED_HOSTS === "1";
+  if (!requiresBun) return null;
+  return versions.bun ? execPath : (env.LLV_BUN_EXECUTABLE || "bun");
+}

--- a/bin/server-runtime.test.ts
+++ b/bin/server-runtime.test.ts
@@ -1,0 +1,44 @@
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+import { expect, test } from "bun:test";
+
+import { viewerServerBunRuntime } from "./server-runtime.mjs";
+
+test("structured hosts select Bun for a CLI process launched by Node", () => {
+  expect(viewerServerBunRuntime({
+    env: { LLV_STRUCTURED_HOSTS: "1" },
+    versions: { node: "20.9.0" },
+    execPath: "/usr/bin/node",
+  })).toBe("bun");
+  expect(viewerServerBunRuntime({
+    env: { LLV_STRUCTURED_HOSTS: "1", LLV_BUN_EXECUTABLE: "/opt/bun/bin/bun" },
+    versions: { node: "20.9.0" },
+    execPath: "/usr/bin/node",
+  })).toBe("/opt/bun/bin/bun");
+});
+
+test("the packaged helper makes the same structured-runtime choice under Node", () => {
+  const helper = path.join(path.dirname(fileURLToPath(import.meta.url)), "server-runtime.mjs");
+  const probe = Bun.spawnSync([
+    "node",
+    "--input-type=module",
+    "--eval",
+    `import { viewerServerBunRuntime } from ${JSON.stringify(pathToFileURL(helper).href)}; process.stdout.write(String(viewerServerBunRuntime()));`,
+  ], {
+    env: { ...process.env, LLV_STRUCTURED_HOSTS: "1", LLV_BUN_EXECUTABLE: "/verified/bun" },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  expect(probe.exitCode).toBe(0);
+  expect(probe.stdout.toString()).toBe("/verified/bun");
+});
+
+test("legacy Node mode stays available when Bun-only features are disabled", () => {
+  expect(viewerServerBunRuntime({
+    env: { LLV_AGENT_REGISTRY_SQLITE: "off", LLV_STRUCTURED_HOSTS: "0" },
+    versions: { node: "20.9.0" },
+    execPath: "/usr/bin/node",
+  })).toBeNull();
+});

--- a/src/app/api/spawn/route.test.ts
+++ b/src/app/api/spawn/route.test.ts
@@ -13,6 +13,7 @@ import { rotateOperatorSpawnCapability } from "@/lib/agent/operatorCapability";
 import { spawnReplayStatus, spawnResponseForReceipt } from "@/lib/agent/spawnResponse";
 import { resolveSpawnLineage, resolveSpawnLineageParent, resolveSpawnParent, SpawnParentError } from "@/lib/agent/spawnParent";
 import type { RuntimeHostClient } from "@/lib/runtime/client";
+import { StructuredRuntimeRequirementError } from "@/lib/proc/darwinIdentity";
 import { authenticatedAgentSpawnCaller, isAgentInitiatedSpawn, spawnLineageSelectorForCaller } from "./admission";
 import { POST } from "./route";
 
@@ -31,8 +32,11 @@ function registry(): AgentRegistry {
   return new AgentRegistry(path.join(dir, "agent-registry.json"));
 }
 
-function structuredRouteDependencies(cwd: string): Parameters<typeof POST.withDependencies>[1] {
+type SpawnRouteTestDependencies = NonNullable<Parameters<typeof POST.withDependencies>[1]>;
+
+function structuredRouteDependencies(cwd: string): SpawnRouteTestDependencies {
   return {
+    assertStructuredRuntime: () => {},
     resolveHealthySpawnAccount: async () => ({
       engine: "claude",
       accountId: "claude-test",
@@ -55,6 +59,72 @@ function structuredRouteDependencies(cwd: string): Parameters<typeof POST.withDe
     }),
   };
 }
+
+test("structured spawn runtime fence preserves durable state", async () => {
+  const cwd = fs.mkdtempSync(path.join(routeSandbox, "structured-runtime-fence-"));
+  const previous = {
+    transport: process.env.LLV_SPAWN_TRANSPORT,
+    hosts: process.env.LLV_STRUCTURED_HOSTS,
+    events: process.env.LLV_RUNTIME_EVENTS,
+    socket: process.env.LLV_RUNTIME_HOST_SOCKET,
+    ui: process.env.NEXT_PUBLIC_RUNTIME_UI,
+  };
+  process.env.LLV_SPAWN_TRANSPORT = "structured";
+  process.env.LLV_STRUCTURED_HOSTS = "1";
+  process.env.LLV_RUNTIME_EVENTS = "1";
+  process.env.LLV_RUNTIME_HOST_SOCKET = path.join(cwd, "runtime.sock");
+  process.env.NEXT_PUBLIC_RUNTIME_UI = "1";
+  const store = agentRegistry();
+  const before = store.snapshot();
+  let accountLookups = 0;
+  let structuredSpawns = 0;
+  const dependencies = {
+    ...structuredRouteDependencies(cwd),
+    assertStructuredRuntime: () => {
+      throw new StructuredRuntimeRequirementError("structured hosts on macOS require the Viewer server to run with Bun");
+    },
+    resolveHealthySpawnAccount: async () => {
+      accountLookups += 1;
+      throw new Error("account lookup crossed the runtime fence");
+    },
+    spawnStructuredConversation: async () => {
+      structuredSpawns += 1;
+      throw new Error("structured spawn crossed the runtime fence");
+    },
+  } satisfies SpawnRouteTestDependencies;
+
+  try {
+    const response = await POST.withDependencies(new NextRequest("http://127.0.0.1:8898/api/spawn", {
+      method: "POST",
+      headers: {
+        host: "127.0.0.1:8898",
+        origin: "http://127.0.0.1:8898",
+        "sec-fetch-site": "same-origin",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({ engine: "codex", cwd, prompt: "must stay fenced" }),
+    }), dependencies);
+
+    expect(response.status).toBe(503);
+    expect(await response.json()).toEqual({ error: "structured hosts on macOS require the Viewer server to run with Bun" });
+    expect(accountLookups).toBe(0);
+    expect(structuredSpawns).toBe(0);
+    const after = store.snapshot();
+    expect(Object.keys(after.receipts)).toEqual(Object.keys(before.receipts));
+    expect(Object.keys(after.conversations)).toEqual(Object.keys(before.conversations));
+  } finally {
+    if (previous.transport === undefined) delete process.env.LLV_SPAWN_TRANSPORT;
+    else process.env.LLV_SPAWN_TRANSPORT = previous.transport;
+    if (previous.hosts === undefined) delete process.env.LLV_STRUCTURED_HOSTS;
+    else process.env.LLV_STRUCTURED_HOSTS = previous.hosts;
+    if (previous.events === undefined) delete process.env.LLV_RUNTIME_EVENTS;
+    else process.env.LLV_RUNTIME_EVENTS = previous.events;
+    if (previous.socket === undefined) delete process.env.LLV_RUNTIME_HOST_SOCKET;
+    else process.env.LLV_RUNTIME_HOST_SOCKET = previous.socket;
+    if (previous.ui === undefined) delete process.env.NEXT_PUBLIC_RUNTIME_UI;
+    else process.env.NEXT_PUBLIC_RUNTIME_UI = previous.ui;
+  }
+});
 
 test("agent-initiated spawn without lineage returns a teaching 400", async () => {
   const response = await POST(new NextRequest("http://127.0.0.1:8898/api/spawn", {

--- a/src/app/api/spawn/route.test.ts
+++ b/src/app/api/spawn/route.test.ts
@@ -36,6 +36,7 @@ type SpawnRouteTestDependencies = NonNullable<Parameters<typeof POST.withDepende
 
 function structuredRouteDependencies(cwd: string): SpawnRouteTestDependencies {
   return {
+    registry: agentRegistry,
     assertStructuredRuntime: () => {},
     resolveHealthySpawnAccount: async () => ({
       engine: "claude",
@@ -62,6 +63,30 @@ function structuredRouteDependencies(cwd: string): SpawnRouteTestDependencies {
 
 test("structured spawn runtime fence preserves durable state", async () => {
   const cwd = fs.mkdtempSync(path.join(routeSandbox, "structured-runtime-fence-"));
+  const registryPath = path.join(cwd, "cold-agent-registry.json");
+  const seeded = new AgentRegistry(registryPath, undefined, undefined, { sqliteMode: "off" });
+  const conversation = seeded.ensureConversation("codex", path.join(cwd, "session.jsonl"), "codex-test");
+  const snapshot = seeded.snapshot();
+  for (let index = 0; index < 101; index += 1) {
+    const id = `legacy-${String(index).padStart(3, "0")}`;
+    snapshot.heldDeliveries[id] = {
+      id,
+      conversationId: conversation.id,
+      text: `legacy body ${index}`,
+      createdAt: `2026-07-16T00:00:${String(index % 60).padStart(2, "0")}.000Z`,
+      clientMessageId: id,
+      payloadKind: "text",
+      artifactPaths: [],
+      state: "delivered",
+      generationId: conversation.generations.at(-1)!.id,
+      attempts: 1,
+      assignedAt: null,
+      deliveredAt: `2026-07-16T00:00:${String(index % 60).padStart(2, "0")}.000Z`,
+      error: null,
+    };
+  }
+  fs.writeFileSync(registryPath, JSON.stringify(snapshot));
+  const registryBytes = fs.readFileSync(registryPath);
   const previous = {
     transport: process.env.LLV_SPAWN_TRANSPORT,
     hosts: process.env.LLV_STRUCTURED_HOSTS,
@@ -74,12 +99,15 @@ test("structured spawn runtime fence preserves durable state", async () => {
   process.env.LLV_RUNTIME_EVENTS = "1";
   process.env.LLV_RUNTIME_HOST_SOCKET = path.join(cwd, "runtime.sock");
   process.env.NEXT_PUBLIC_RUNTIME_UI = "1";
-  const store = agentRegistry();
-  const before = store.snapshot();
+  let registryFactoryCalls = 0;
   let accountLookups = 0;
   let structuredSpawns = 0;
   const dependencies = {
     ...structuredRouteDependencies(cwd),
+    registry: () => {
+      registryFactoryCalls += 1;
+      return new AgentRegistry(registryPath, undefined, undefined, { sqliteMode: "off" });
+    },
     assertStructuredRuntime: () => {
       throw new StructuredRuntimeRequirementError("structured hosts on macOS require the Viewer server to run with Bun");
     },
@@ -107,11 +135,10 @@ test("structured spawn runtime fence preserves durable state", async () => {
 
     expect(response.status).toBe(503);
     expect(await response.json()).toEqual({ error: "structured hosts on macOS require the Viewer server to run with Bun" });
+    expect(registryFactoryCalls).toBe(0);
     expect(accountLookups).toBe(0);
     expect(structuredSpawns).toBe(0);
-    const after = store.snapshot();
-    expect(Object.keys(after.receipts)).toEqual(Object.keys(before.receipts));
-    expect(Object.keys(after.conversations)).toEqual(Object.keys(before.conversations));
+    expect(fs.readFileSync(registryPath)).toEqual(registryBytes);
   } finally {
     if (previous.transport === undefined) delete process.env.LLV_SPAWN_TRANSPORT;
     else process.env.LLV_SPAWN_TRANSPORT = previous.transport;

--- a/src/app/api/spawn/route.ts
+++ b/src/app/api/spawn/route.ts
@@ -45,6 +45,7 @@ const SUGGEST_SCAN_LIMIT = 80;
 const SUGGEST_MAX = 10;
 
 interface SpawnRouteDependencies {
+  registry: typeof agentRegistry;
   resolveHealthySpawnAccount: typeof resolveHealthySpawnAccount;
   runtimeHostClient: typeof runtimeHostClient;
   spawnStructuredConversation: typeof spawnStructuredConversation;
@@ -52,6 +53,7 @@ interface SpawnRouteDependencies {
 }
 
 const productionSpawnRouteDependencies: SpawnRouteDependencies = {
+  registry: agentRegistry,
   resolveHealthySpawnAccount,
   runtimeHostClient,
   spawnStructuredConversation,
@@ -119,16 +121,6 @@ async function postSpawn(
   if (body.allowSubagents !== undefined && typeof body.allowSubagents !== "boolean") {
     return NextResponse.json({ error: "allowSubagents must be a boolean" }, { status: 400 });
   }
-  const registry = agentRegistry();
-  let authenticatedCaller: AuthenticatedSpawnCaller | null = null;
-  if (agentInitiated) {
-    const caller = authenticatedAgentSpawnCaller(req, body.src, registry);
-    if ("error" in caller) return NextResponse.json({ error: caller.error }, { status: caller.status ?? 403 });
-    authenticatedCaller = caller;
-  }
-  if (agentInitiated && body.allowSubagents === true && authenticatedCaller?.kind !== "operator") {
-    return NextResponse.json({ error: "allowSubagents requires an authenticated Viewer operator spawn" }, { status: 403 });
-  }
   const role = resolveSpawnRole(body);
   if (!role.ok) return NextResponse.json({ error: role.error }, { status: 400 });
   if (role.value?.role === "reviewer" && (typeof body.reviews !== "string" || !body.reviews.trim())) {
@@ -152,19 +144,6 @@ async function postSpawn(
   const selectedModel = modelFromBody({ model: body.model === undefined ? role.value?.config.model : body.model });
   if (selectedModel.error) return NextResponse.json({ error: selectedModel.error }, { status: 400 });
 
-  const rawCwd = typeof body.cwd === "string" ? body.cwd.trim() : "";
-  if (!rawCwd) return NextResponse.json({ error: "working directory is required" }, { status: 400 });
-  const cwd = path.resolve(rawCwd === "~" || rawCwd.startsWith("~/") ? path.join(os.homedir(), rawCwd.slice(1)) : rawCwd);
-  let stat: fs.Stats;
-  try {
-    stat = fs.statSync(cwd);
-  } catch {
-    return NextResponse.json({ error: `directory does not exist: ${cwd}` }, { status: 400 });
-  }
-  if (!stat.isDirectory()) {
-    return NextResponse.json({ error: `not a directory: ${cwd}` }, { status: 400 });
-  }
-
   const userPrompt = typeof body.prompt === "string" ? body.prompt.trim() : "";
   const prompt = role.value ? [role.value.scaffold, userPrompt].filter(Boolean).join("\n\n") : userPrompt;
   const { images, error: imageError } = collectImagePayloads(body);
@@ -185,6 +164,30 @@ async function postSpawn(
     }
     const gap = structuredSpawnGap({ engine, hasImages: images.length > 0, fast: reasoning.fast });
     if (gap) return NextResponse.json({ error: gap }, { status: 409 });
+  }
+
+  const registry = dependencies.registry();
+  let authenticatedCaller: AuthenticatedSpawnCaller | null = null;
+  if (agentInitiated) {
+    const caller = authenticatedAgentSpawnCaller(req, body.src, registry);
+    if ("error" in caller) return NextResponse.json({ error: caller.error }, { status: caller.status ?? 403 });
+    authenticatedCaller = caller;
+  }
+  if (agentInitiated && body.allowSubagents === true && authenticatedCaller?.kind !== "operator") {
+    return NextResponse.json({ error: "allowSubagents requires an authenticated Viewer operator spawn" }, { status: 403 });
+  }
+
+  const rawCwd = typeof body.cwd === "string" ? body.cwd.trim() : "";
+  if (!rawCwd) return NextResponse.json({ error: "working directory is required" }, { status: 400 });
+  const cwd = path.resolve(rawCwd === "~" || rawCwd.startsWith("~/") ? path.join(os.homedir(), rawCwd.slice(1)) : rawCwd);
+  let stat: fs.Stats;
+  try {
+    stat = fs.statSync(cwd);
+  } catch {
+    return NextResponse.json({ error: `directory does not exist: ${cwd}` }, { status: 400 });
+  }
+  if (!stat.isDirectory()) {
+    return NextResponse.json({ error: `not a directory: ${cwd}` }, { status: 400 });
   }
 
   /* Saved paths stay visible to the catch. A pane-bound receipt keeps them:

--- a/src/app/api/spawn/route.ts
+++ b/src/app/api/spawn/route.ts
@@ -13,6 +13,7 @@ import { agentRegistry, SpawnChildLimitError } from "@/lib/agent/registry";
 import { reasoningFromBody } from "@/lib/agent/efforts";
 import { modelFromBody } from "@/lib/agent/models";
 import { resolveSpawnRole } from "@/lib/roles/registry";
+import { assertDarwinStructuredRuntime } from "@/lib/proc/darwinIdentity";
 import { spawnContentDigest, spawnParentSelector, spawnRequestDigest } from "@/lib/agent/spawnIdentity";
 import { sessionKeyFromTranscript, sessionKeyId } from "@/lib/agent/sessionKey";
 import { resolveSpawnLineage, SpawnParentError } from "@/lib/agent/spawnParent";
@@ -47,12 +48,14 @@ interface SpawnRouteDependencies {
   resolveHealthySpawnAccount: typeof resolveHealthySpawnAccount;
   runtimeHostClient: typeof runtimeHostClient;
   spawnStructuredConversation: typeof spawnStructuredConversation;
+  assertStructuredRuntime: typeof assertDarwinStructuredRuntime;
 }
 
 const productionSpawnRouteDependencies: SpawnRouteDependencies = {
   resolveHealthySpawnAccount,
   runtimeHostClient,
   spawnStructuredConversation,
+  assertStructuredRuntime: assertDarwinStructuredRuntime,
 };
 
 interface SuggestResponse {
@@ -175,6 +178,11 @@ async function postSpawn(
     return NextResponse.json({ error: error instanceof Error ? error.message : String(error) }, { status: 500 });
   }
   if (transport === "structured") {
+    try {
+      dependencies.assertStructuredRuntime();
+    } catch (error) {
+      return NextResponse.json({ error: error instanceof Error ? error.message : String(error) }, { status: 503 });
+    }
     const gap = structuredSpawnGap({ engine, hasImages: images.length > 0, fast: reasoning.fast });
     if (gap) return NextResponse.json({ error: gap }, { status: 409 });
   }

--- a/src/instrumentation.test.ts
+++ b/src/instrumentation.test.ts
@@ -13,6 +13,7 @@ import {
   viewerReleaseOwnsTraffic,
 } from "./instrumentation";
 import { operatorSpawnCapabilityPath } from "@/lib/agent/operatorCapability";
+import { StructuredRuntimeRequirementError } from "@/lib/proc/darwinIdentity";
 import { didStructuredHostStartupFail, markStructuredHostStartupReady } from "@/lib/runtime/startupStatus";
 
 test("account controller delay defaults to immediate startup and retains the explicit escape hatch", () => {
@@ -129,6 +130,23 @@ test("structured-host startup logs the thrown adoption error object", async () =
     await runStructuredHostStartup(async () => undefined, (...args) => { logged.push(args); });
     expect(didStructuredHostStartupFail()).toBe(false);
     expect(logged).toHaveLength(1);
+  } finally {
+    markStructuredHostStartupReady();
+  }
+});
+
+test("unsupported structured runtime aborts server startup", async () => {
+  const failure = new StructuredRuntimeRequirementError("structured hosts require Bun");
+  const logged: unknown[][] = [];
+
+  try {
+    await expect(runStructuredHostStartup(
+      async () => { throw failure; },
+      (...args) => { logged.push(args); },
+    )).rejects.toBe(failure);
+
+    expect(logged).toEqual([["[structured hosts] startup adoption failed", failure]]);
+    expect(didStructuredHostStartupFail()).toBe(true);
   } finally {
     markStructuredHostStartupReady();
   }

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 
 import { statePath } from "@/lib/configDir";
 import { markStructuredHostStartupFailed, markStructuredHostStartupReady } from "@/lib/runtime/startupStatus";
+import { StructuredRuntimeRequirementError } from "@/lib/proc/darwinIdentity";
 
 const RELEASE_ACTIVATION_POLL_MS = 250;
 
@@ -105,6 +106,7 @@ export async function runStructuredHostStartup(
   } catch (error) {
     markStructuredHostStartupFailed();
     log("[structured hosts] startup adoption failed", error);
+    if (error instanceof StructuredRuntimeRequirementError) throw error;
   }
 }
 

--- a/src/lib/proc/darwinIdentity.test.ts
+++ b/src/lib/proc/darwinIdentity.test.ts
@@ -1,0 +1,24 @@
+import { expect, test } from "bun:test";
+
+import { parseDarwinProcBsdInfoIdentity } from "./darwinIdentity";
+
+test("Darwin process identity includes the kernel microsecond start token", () => {
+  const buffer = Buffer.alloc(136);
+  buffer.writeUInt32LE(4242, 12);
+  buffer.writeBigUInt64LE(BigInt(1_721_234_567), 120);
+  buffer.writeBigUInt64LE(BigInt(12_345), 128);
+
+  expect(parseDarwinProcBsdInfoIdentity(4242, buffer, buffer.byteLength))
+    .toBe("4242:1721234567:012345");
+});
+
+test("Darwin process identity rejects incomplete or mismatched kernel records", () => {
+  const buffer = Buffer.alloc(136);
+  buffer.writeUInt32LE(4243, 12);
+  buffer.writeBigUInt64LE(BigInt(1_721_234_567), 120);
+
+  expect(parseDarwinProcBsdInfoIdentity(4242, buffer, buffer.byteLength)).toBeNull();
+  expect(parseDarwinProcBsdInfoIdentity(4243, buffer, 135)).toBeNull();
+  buffer.writeBigUInt64LE(BigInt(1_000_000), 128);
+  expect(parseDarwinProcBsdInfoIdentity(4243, buffer, buffer.byteLength)).toBeNull();
+});

--- a/src/lib/proc/darwinIdentity.test.ts
+++ b/src/lib/proc/darwinIdentity.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "bun:test";
 
-import { parseDarwinProcBsdInfoIdentity } from "./darwinIdentity";
+import { assertDarwinStructuredRuntime, parseDarwinProcBsdInfoIdentity } from "./darwinIdentity";
 
 test("Darwin process identity includes the kernel microsecond start token", () => {
   const buffer = Buffer.alloc(136);
@@ -21,4 +21,10 @@ test("Darwin process identity rejects incomplete or mismatched kernel records", 
   expect(parseDarwinProcBsdInfoIdentity(4243, buffer, 135)).toBeNull();
   buffer.writeBigUInt64LE(BigInt(1_000_000), 128);
   expect(parseDarwinProcBsdInfoIdentity(4243, buffer, buffer.byteLength)).toBeNull();
+});
+
+test("structured Darwin startup requires the Bun runtime used by the identity reader", () => {
+  expect(() => assertDarwinStructuredRuntime("darwin", {})).toThrow("require the Viewer server to run with Bun");
+  expect(() => assertDarwinStructuredRuntime("darwin", { bun: "1.3.3" })).not.toThrow();
+  expect(() => assertDarwinStructuredRuntime("linux", {})).not.toThrow();
 });

--- a/src/lib/proc/darwinIdentity.ts
+++ b/src/lib/proc/darwinIdentity.ts
@@ -19,12 +19,16 @@ interface BunFfiModule {
 
 let cachedReader: ProcPidInfoReader | null | undefined;
 
+export class StructuredRuntimeRequirementError extends Error {
+  override readonly name = "StructuredRuntimeRequirementError";
+}
+
 export function assertDarwinStructuredRuntime(
   platform = process.platform,
   versions: { bun?: string } = process.versions,
 ): void {
   if (platform === "darwin" && !versions.bun) {
-    throw new Error("structured hosts on macOS require the Viewer server to run with Bun");
+    throw new StructuredRuntimeRequirementError("structured hosts on macOS require the Viewer server to run with Bun");
   }
 }
 

--- a/src/lib/proc/darwinIdentity.ts
+++ b/src/lib/proc/darwinIdentity.ts
@@ -1,0 +1,69 @@
+import { createRequire } from "node:module";
+
+const PROC_PIDTBSDINFO = 3;
+const PROC_BSDINFO_SIZE = 136;
+const PBI_PID_OFFSET = 12;
+const PBI_START_TVSEC_OFFSET = 120;
+const PBI_START_TVUSEC_OFFSET = 128;
+const MICROSECONDS_PER_SECOND = BigInt(1_000_000);
+
+type ProcPidInfoReader = (pid: number, buffer: Buffer) => number;
+
+interface BunFfiModule {
+  FFIType: { i32: number; u64: number; ptr: number };
+  ptr(buffer: Buffer): unknown;
+  dlopen(path: string, symbols: Record<string, unknown>): {
+    symbols: { proc_pidinfo: (...args: unknown[]) => number };
+  };
+}
+
+let cachedReader: ProcPidInfoReader | null | undefined;
+
+export function parseDarwinProcBsdInfoIdentity(pid: number, buffer: Buffer, bytesRead: number): string | null {
+  if (!Number.isInteger(pid) || pid <= 0 || bytesRead < PROC_BSDINFO_SIZE || buffer.byteLength < PROC_BSDINFO_SIZE) return null;
+  if (buffer.readUInt32LE(PBI_PID_OFFSET) !== pid) return null;
+  const seconds = buffer.readBigUInt64LE(PBI_START_TVSEC_OFFSET);
+  const microseconds = buffer.readBigUInt64LE(PBI_START_TVUSEC_OFFSET);
+  if (seconds === BigInt(0) || microseconds >= MICROSECONDS_PER_SECOND) return null;
+  return `${pid}:${seconds}:${microseconds.toString().padStart(6, "0")}`;
+}
+
+function loadReader(): ProcPidInfoReader | null {
+  if (cachedReader !== undefined) return cachedReader;
+  if (process.platform !== "darwin") {
+    cachedReader = null;
+    return cachedReader;
+  }
+  try {
+    const runtimeRequire = createRequire(import.meta.url);
+    const ffi = runtimeRequire(`bun:${"ffi"}`) as BunFfiModule;
+    const library = ffi.dlopen("/usr/lib/libproc.dylib", {
+      proc_pidinfo: {
+        args: [ffi.FFIType.i32, ffi.FFIType.i32, ffi.FFIType.u64, ffi.FFIType.ptr, ffi.FFIType.i32],
+        returns: ffi.FFIType.i32,
+      },
+    });
+    cachedReader = (pid, buffer) => Number(library.symbols.proc_pidinfo(
+      pid,
+      PROC_PIDTBSDINFO,
+      BigInt(0),
+      ffi.ptr(buffer),
+      buffer.byteLength,
+    ));
+  } catch {
+    cachedReader = null;
+  }
+  return cachedReader;
+}
+
+export function darwinProcessIdentity(pid: number): string | null {
+  if (!Number.isInteger(pid) || pid <= 0) return null;
+  const reader = loadReader();
+  if (!reader) return null;
+  const buffer = Buffer.alloc(PROC_BSDINFO_SIZE);
+  try {
+    return parseDarwinProcBsdInfoIdentity(pid, buffer, reader(pid, buffer));
+  } catch {
+    return null;
+  }
+}

--- a/src/lib/proc/darwinIdentity.ts
+++ b/src/lib/proc/darwinIdentity.ts
@@ -19,6 +19,15 @@ interface BunFfiModule {
 
 let cachedReader: ProcPidInfoReader | null | undefined;
 
+export function assertDarwinStructuredRuntime(
+  platform = process.platform,
+  versions: { bun?: string } = process.versions,
+): void {
+  if (platform === "darwin" && !versions.bun) {
+    throw new Error("structured hosts on macOS require the Viewer server to run with Bun");
+  }
+}
+
 export function parseDarwinProcBsdInfoIdentity(pid: number, buffer: Buffer, bytesRead: number): string | null {
   if (!Number.isInteger(pid) || pid <= 0 || bytesRead < PROC_BSDINFO_SIZE || buffer.byteLength < PROC_BSDINFO_SIZE) return null;
   if (buffer.readUInt32LE(PBI_PID_OFFSET) !== pid) return null;

--- a/src/lib/proc/portable.test.ts
+++ b/src/lib/proc/portable.test.ts
@@ -2,10 +2,15 @@ import { expect, test } from "bun:test";
 
 import { portableBackend } from "./portable";
 
-test("portable process identity is stable for a live pid", () => {
+test("portable process identity fails closed without a high-resolution kernel token", () => {
   const first = portableBackend.processIdentity(process.pid);
   const second = portableBackend.processIdentity(process.pid);
 
-  expect(first).not.toBeNull();
-  expect(second).toBe(first);
+  if (process.platform === "darwin") {
+    expect(first).not.toBeNull();
+    expect(second).toBe(first);
+  } else {
+    expect(first).toBeNull();
+    expect(second).toBeNull();
+  }
 });

--- a/src/lib/proc/portable.ts
+++ b/src/lib/proc/portable.ts
@@ -2,6 +2,7 @@ import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 
+import { darwinProcessIdentity } from "./darwinIdentity";
 import { parsePsMemory, parseSwapUsage, parseVmStat } from "./memory";
 import type { ProcBackend, ProcessMemory, ProcSnapshotEntry, SystemMemory } from "./types";
 
@@ -177,8 +178,7 @@ function readPpid(pid: number): number | null {
 
 function processIdentity(pid: number): string | null {
   if (!Number.isInteger(pid) || pid <= 0) return null;
-  const started = runCapture("ps", ["-p", String(pid), "-o", "lstart="]).trim().replace(/\s+/g, " ");
-  return started ? `${pid}:${started}` : null;
+  return process.platform === "darwin" ? darwinProcessIdentity(pid) : null;
 }
 
 /**

--- a/src/lib/runtime/codexAppServerHost.test.ts
+++ b/src/lib/runtime/codexAppServerHost.test.ts
@@ -1377,6 +1377,36 @@ describe("CodexAppServerHost", () => {
     expect(signals).toEqual([{ pid: -4242, signal: "SIGTERM" }]);
   });
 
+  test("release retries TERM when a transient identity lookup immediately recovers", async () => {
+    const server = new FakeAppServer("immediate-identity-recovery-thread");
+    const signals: Array<{ pid: number; signal: NodeJS.Signals }> = [];
+    let failNextIdentityRead = false;
+    const host = await CodexAppServerHost.start({
+      cwd: "/repo",
+      shutdownGraceMs: 2,
+      eventStore: new MemoryEventStore(),
+      spawnProcess: fakeSpawn(server),
+      processIdentity: () => {
+        if (!failNextIdentityRead) return "4242:owned";
+        failNextIdentityRead = false;
+        return null;
+      },
+      pidAlive: () => true,
+      signalProcess: (pid, signal) => {
+        signals.push({ pid, signal });
+        if (signal === "SIGKILL") queueMicrotask(() => server.emit("close", 0, signal));
+      },
+    });
+    failNextIdentityRead = true;
+
+    await expect(host.release()).resolves.toBeUndefined();
+
+    expect(signals).toEqual([
+      { pid: -4242, signal: "SIGTERM" },
+      { pid: -4242, signal: "SIGKILL" },
+    ]);
+  });
+
   test("release skips group cleanup after the reaped leader pid is reused", async () => {
     const server = new FakeAppServer("reaped-recycled-pid-thread");
     const signals: Array<{ pid: number; signal: NodeJS.Signals }> = [];

--- a/src/lib/runtime/codexAppServerHost.test.ts
+++ b/src/lib/runtime/codexAppServerHost.test.ts
@@ -1186,7 +1186,6 @@ describe("CodexAppServerHost", () => {
     });
 
     await host.release();
-    await Bun.sleep(10);
 
     expect(signals).toEqual([
       { pid: -4242, signal: "SIGTERM" },
@@ -1374,7 +1373,10 @@ describe("CodexAppServerHost", () => {
 
     processIdentity = "4242:owned";
     await expect(host.release()).resolves.toBeUndefined();
-    expect(signals).toEqual([{ pid: -4242, signal: "SIGTERM" }]);
+    expect(signals).toEqual([
+      { pid: -4242, signal: "SIGTERM" },
+      { pid: -4242, signal: "SIGKILL" },
+    ]);
   });
 
   test("release retries TERM when a transient identity lookup immediately recovers", async () => {
@@ -1488,6 +1490,43 @@ describe("CodexAppServerHost", () => {
 
     server.stdout.write("malformed\n");
     await Bun.sleep(10);
+
+    expect(signals).toEqual([
+      { pid: -4242, signal: "SIGTERM" },
+      { pid: -4242, signal: "SIGKILL" },
+    ]);
+    expect(await host.health()).toMatchObject({ status: "dead", pid: null });
+  });
+
+  test("protocol failure keeps retrying fenced cleanup until identity recovers", async () => {
+    const server = new FakeAppServer("failed-delayed-identity-recovery-thread");
+    const signals: Array<{ pid: number; signal: NodeJS.Signals }> = [];
+    let processIdentity: string | null = "4242:owned";
+    let alive = true;
+    const host = await CodexAppServerHost.start({
+      cwd: "/repo",
+      shutdownGraceMs: 2,
+      eventStore: new MemoryEventStore(),
+      spawnProcess: fakeSpawn(server),
+      processIdentity: () => processIdentity,
+      pidAlive: () => alive,
+      signalProcess: (pid, signal) => {
+        signals.push({ pid, signal });
+        if (signal === "SIGKILL") {
+          alive = false;
+          queueMicrotask(() => server.emit("close", 0, signal));
+        }
+      },
+    });
+    processIdentity = null;
+
+    server.stdout.write("malformed\n");
+    await Bun.sleep(6);
+    expect(signals).toEqual([]);
+    expect(await host.health()).toMatchObject({ status: "dead", pid: 4242 });
+
+    processIdentity = "4242:owned";
+    await Bun.sleep(12);
 
     expect(signals).toEqual([
       { pid: -4242, signal: "SIGTERM" },

--- a/src/lib/runtime/codexAppServerHost.test.ts
+++ b/src/lib/runtime/codexAppServerHost.test.ts
@@ -1463,6 +1463,39 @@ describe("CodexAppServerHost", () => {
     await host.release();
   });
 
+  test("protocol failure retries TERM when identity recovers after one read", async () => {
+    const server = new FakeAppServer("failed-transient-identity-thread");
+    const signals: Array<{ pid: number; signal: NodeJS.Signals }> = [];
+    let failureIdentityReads = 0;
+    let injectIdentityFailure = false;
+    const host = await CodexAppServerHost.start({
+      cwd: "/repo",
+      shutdownGraceMs: 2,
+      eventStore: new MemoryEventStore(),
+      spawnProcess: fakeSpawn(server),
+      processIdentity: () => {
+        if (!injectIdentityFailure) return "4242:owned";
+        failureIdentityReads += 1;
+        return failureIdentityReads === 2 ? null : "4242:owned";
+      },
+      pidAlive: () => true,
+      signalProcess: (pid, signal) => {
+        signals.push({ pid, signal });
+        if (signal === "SIGKILL") queueMicrotask(() => server.emit("close", 0, signal));
+      },
+    });
+    injectIdentityFailure = true;
+
+    server.stdout.write("malformed\n");
+    await Bun.sleep(10);
+
+    expect(signals).toEqual([
+      { pid: -4242, signal: "SIGTERM" },
+      { pid: -4242, signal: "SIGKILL" },
+    ]);
+    expect(await host.health()).toMatchObject({ status: "dead", pid: null });
+  });
+
   test("an asynchronous stdin EPIPE fails and reaps the host", async () => {
     const server = new FakeAppServer("epipe-thread", "epipe-thread", false, [], undefined, null, ["turn/start"]);
     const host = await CodexAppServerHost.start({
@@ -1647,6 +1680,66 @@ describe("CodexAppServerHost", () => {
     expect((await stream.next()).done).toBeTrue();
     expect(server.signals).toContain("SIGTERM");
     await host.release();
+  });
+
+  test("ledger failure converges without close and releases the writer claim", async () => {
+    const store = new FailingEventStore();
+    const server = new FakeAppServer("ledger-missing-close-thread");
+    const signals: Array<{ pid: number; signal: NodeJS.Signals }> = [];
+    let alive = true;
+    const host = await CodexAppServerHost.start({
+      cwd: "/repo",
+      shutdownGraceMs: 2,
+      eventStore: store,
+      spawnProcess: fakeSpawn(server),
+      processIdentity: ownedFakeProcess.processIdentity,
+      pidAlive: () => alive,
+      signalProcess: (pid, signal) => {
+        signals.push({ pid, signal });
+        if (signal === "SIGKILL") alive = false;
+      },
+    });
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-failed-ledger-registry-"));
+    const registry = new AgentRegistry(path.join(directory, "agent-registry.json"));
+    const key = { engine: "codex" as const, sessionId: "ledger-missing-close-thread" };
+    registry.upsert({
+      key,
+      artifactPath: "/sessions/ledger-missing-close-thread.jsonl",
+      cwd: "/repo",
+      accountId: null,
+      status: "idle",
+      host: null,
+      structuredHost: {
+        kind: "codex-app-server",
+        endpoint: "stdio:4242",
+        process: { pid: 4242, startIdentity: "4242:owned" },
+        eventCursor: 1,
+        protocolVersion: "0.144.1",
+        writerClaimEpoch: 8,
+        activeTurnRef: null,
+        pendingAttention: [],
+        activeFlags: [],
+      },
+      claimEpoch: 8,
+      claimOwner: "failed-owner",
+      pendingAction: null,
+    });
+    await bindCodexHostPersistence(registry, key, host, "failed-owner", 8);
+
+    server.notify("account/rateLimits/updated", { rateLimits: {} });
+    await Bun.sleep(10);
+
+    expect(signals).toEqual([
+      { pid: -4242, signal: "SIGTERM" },
+      { pid: -4242, signal: "SIGKILL" },
+    ]);
+    expect(await host.health()).toMatchObject({ status: "dead", pid: null });
+    expect(registry.snapshot().entries["codex:ledger-missing-close-thread"]).toMatchObject({
+      status: "dead",
+      claimOwner: null,
+      structuredHost: { process: null, endpoint: "stdio:released" },
+    });
+    fs.rmSync(directory, { recursive: true, force: true });
   });
 
   test("a shutdown ledger failure still releases the bound registry claim", async () => {

--- a/src/lib/runtime/codexAppServerHost.test.ts
+++ b/src/lib/runtime/codexAppServerHost.test.ts
@@ -1227,6 +1227,53 @@ describe("CodexAppServerHost", () => {
     await expect(host.release()).resolves.toBeUndefined();
   });
 
+  test("release converges when the owned child exits without a close event", async () => {
+    const server = new FakeAppServer("missing-close-thread");
+    const signals: Array<{ pid: number; signal: NodeJS.Signals }> = [];
+    let processIdentity: string | null = "4242:owned";
+    const host = await CodexAppServerHost.start({
+      cwd: "/repo",
+      shutdownGraceMs: 2,
+      eventStore: new MemoryEventStore(),
+      spawnProcess: fakeSpawn(server),
+      processIdentity: () => processIdentity,
+      signalProcess: (pid, signal) => {
+        signals.push({ pid, signal });
+        if (signal === "SIGKILL") processIdentity = null;
+      },
+    });
+
+    await expect(host.release()).resolves.toBeUndefined();
+
+    expect(signals).toEqual([
+      { pid: -4242, signal: "SIGTERM" },
+      { pid: -4242, signal: "SIGKILL" },
+    ]);
+    expect(await host.health()).toMatchObject({ status: "unhosted", pid: null, endpoint: "stdio:released" });
+    expect(server.signals).toEqual([]);
+  });
+
+  test("release never signals a recycled child pid", async () => {
+    const server = new FakeAppServer("recycled-pid-thread");
+    const signals: Array<{ pid: number; signal: NodeJS.Signals }> = [];
+    let processIdentity = "4242:owned";
+    const host = await CodexAppServerHost.start({
+      cwd: "/repo",
+      shutdownGraceMs: 2,
+      eventStore: new MemoryEventStore(),
+      spawnProcess: fakeSpawn(server),
+      processIdentity: () => processIdentity,
+      signalProcess: (pid, signal) => { signals.push({ pid, signal }); },
+    });
+    processIdentity = "4242:recycled";
+
+    await expect(host.release()).resolves.toBeUndefined();
+
+    expect(signals).toEqual([]);
+    expect(server.signals).toEqual([]);
+    expect(await host.health()).toMatchObject({ status: "unhosted", pid: null, endpoint: "stdio:released" });
+  });
+
   test("protocol failure starts bounded TERM and KILL cleanup", async () => {
     const server = new FakeAppServer("failed-thread", "failed-thread", true);
     const host = await CodexAppServerHost.start({

--- a/src/lib/runtime/codexAppServerHost.test.ts
+++ b/src/lib/runtime/codexAppServerHost.test.ts
@@ -193,6 +193,11 @@ function fakeSpawn(server: FakeAppServer, captured?: { args?: string[]; options?
   };
 }
 
+const ownedFakeProcess = {
+  pidAlive: () => true,
+  processIdentity: () => "4242:owned",
+};
+
 async function nextEvent(iterable: AsyncIterable<unknown>): Promise<unknown> {
   return (await iterable[Symbol.asyncIterator]().next()).value;
 }
@@ -354,6 +359,7 @@ describe("CodexAppServerHost", () => {
       eventStore,
       initialEventCursor: 1,
       spawnProcess: fakeSpawn(server),
+      ...ownedFakeProcess,
     })).rejects.toThrow("thread/resume returned a different thread id");
     expect(server.signals).toContain("SIGTERM");
     expect(eventStore.load("requested-thread")).toEqual([
@@ -1150,6 +1156,7 @@ describe("CodexAppServerHost", () => {
       shutdownGraceMs: 5,
       eventStore: new MemoryEventStore(),
       spawnProcess: fakeSpawn(server),
+      ...ownedFakeProcess,
     });
     const stream = host.attach((await host.health()).eventCursor)[Symbol.asyncIterator]();
     await host.release();
@@ -1161,14 +1168,20 @@ describe("CodexAppServerHost", () => {
   test("release escalates the process group after its leader exits during grace", async () => {
     const server = new FakeAppServer("group-reap-thread");
     const signals: Array<{ pid: number; signal: NodeJS.Signals }> = [];
+    let alive = true;
     const host = await CodexAppServerHost.start({
       cwd: "/repo",
       shutdownGraceMs: 5,
       eventStore: new MemoryEventStore(),
       spawnProcess: fakeSpawn(server),
+      processIdentity: ownedFakeProcess.processIdentity,
+      pidAlive: () => alive,
       signalProcess: (pid, signal) => {
         signals.push({ pid, signal });
-        if (signal === "SIGTERM") queueMicrotask(() => server.emit("close", 0, signal));
+        if (signal === "SIGTERM") queueMicrotask(() => {
+          alive = false;
+          server.emit("close", 0, signal);
+        });
       },
     });
 
@@ -1184,17 +1197,21 @@ describe("CodexAppServerHost", () => {
   test("release cleans the detached process group after an unexpected leader exit", async () => {
     const server = new FakeAppServer("exited-group-thread");
     const signals: Array<{ pid: number; signal: NodeJS.Signals }> = [];
+    let alive = true;
     const host = await CodexAppServerHost.start({
       cwd: "/repo",
       shutdownGraceMs: 5,
       eventStore: new MemoryEventStore(),
       spawnProcess: fakeSpawn(server),
+      processIdentity: ownedFakeProcess.processIdentity,
+      pidAlive: () => alive,
       signalProcess: (pid, signal) => {
         signals.push({ pid, signal });
         if (signal === "SIGTERM") throw new Error("group exited");
       },
     });
 
+    alive = false;
     server.emit("close", 0, null);
     await host.release();
     await Bun.sleep(10);
@@ -1214,6 +1231,7 @@ describe("CodexAppServerHost", () => {
       eventStore: new MemoryEventStore(),
       spawnProcess: fakeSpawn(server),
       signalProcess: () => {},
+      ...ownedFakeProcess,
     });
     const states: HostState[] = [];
     host.onStateChange((state) => states.push(state));
@@ -1237,6 +1255,7 @@ describe("CodexAppServerHost", () => {
       eventStore: new MemoryEventStore(),
       spawnProcess: fakeSpawn(server),
       processIdentity: () => processIdentity,
+      pidAlive: () => processIdentity !== null,
       signalProcess: (pid, signal) => {
         signals.push({ pid, signal });
         if (signal === "SIGKILL") processIdentity = null;
@@ -1263,6 +1282,7 @@ describe("CodexAppServerHost", () => {
       eventStore: new MemoryEventStore(),
       spawnProcess: fakeSpawn(server),
       processIdentity: () => processIdentity,
+      pidAlive: () => true,
       signalProcess: (pid, signal) => { signals.push({ pid, signal }); },
     });
     processIdentity = "4242:recycled";
@@ -1274,6 +1294,88 @@ describe("CodexAppServerHost", () => {
     expect(await host.health()).toMatchObject({ status: "unhosted", pid: null, endpoint: "stdio:released" });
   });
 
+  test("release preserves ownership when the initial identity lookup is unknown", async () => {
+    const server = new FakeAppServer("initial-identity-unknown-thread");
+    const signals: Array<{ pid: number; signal: NodeJS.Signals }> = [];
+    let alive = true;
+    const host = await CodexAppServerHost.start({
+      cwd: "/repo",
+      shutdownGraceMs: 2,
+      eventStore: new MemoryEventStore(),
+      spawnProcess: fakeSpawn(server),
+      processIdentity: () => null,
+      pidAlive: () => alive,
+      signalProcess: (pid, signal) => { signals.push({ pid, signal }); },
+    });
+
+    await expect(host.release()).rejects.toThrow("Codex app-server child ownership is unknown");
+    expect(signals).toEqual([]);
+    expect(await host.health()).toMatchObject({ pid: 4242, processStartIdentity: null });
+
+    alive = false;
+    server.emit("close", 0, null);
+    await Bun.sleep(0);
+    await expect(host.release()).resolves.toBeUndefined();
+  });
+
+  test("release preserves ownership during a transient identity lookup failure", async () => {
+    const server = new FakeAppServer("later-identity-unknown-thread");
+    const signals: Array<{ pid: number; signal: NodeJS.Signals }> = [];
+    let processIdentity: string | null = "4242:owned";
+    let alive = true;
+    const host = await CodexAppServerHost.start({
+      cwd: "/repo",
+      shutdownGraceMs: 2,
+      eventStore: new MemoryEventStore(),
+      spawnProcess: fakeSpawn(server),
+      processIdentity: () => processIdentity,
+      pidAlive: () => alive,
+      signalProcess: (pid, signal) => {
+        signals.push({ pid, signal });
+        if (signal === "SIGTERM") queueMicrotask(() => {
+          alive = false;
+          server.emit("close", 0, signal);
+        });
+      },
+    });
+    processIdentity = null;
+
+    await expect(host.release()).rejects.toThrow("Codex app-server child ownership is unknown");
+    expect(signals).toEqual([]);
+    expect(await host.health()).toMatchObject({ pid: 4242, processStartIdentity: null });
+
+    processIdentity = "4242:owned";
+    await expect(host.release()).resolves.toBeUndefined();
+    expect(signals).toEqual([{ pid: -4242, signal: "SIGTERM" }]);
+  });
+
+  test("release skips group cleanup after the reaped leader pid is reused", async () => {
+    const server = new FakeAppServer("reaped-recycled-pid-thread");
+    const signals: Array<{ pid: number; signal: NodeJS.Signals }> = [];
+    let processIdentity = "4242:owned";
+    const host = await CodexAppServerHost.start({
+      cwd: "/repo",
+      shutdownGraceMs: 2,
+      eventStore: new MemoryEventStore(),
+      spawnProcess: fakeSpawn(server),
+      processIdentity: () => processIdentity,
+      pidAlive: () => true,
+      signalProcess: (pid, signal) => {
+        signals.push({ pid, signal });
+        if (signal === "SIGTERM") {
+          processIdentity = "4242:recycled";
+          queueMicrotask(() => server.emit("close", 0, signal));
+        }
+      },
+    });
+
+    await host.release();
+    await Bun.sleep(6);
+
+    expect(signals).toEqual([{ pid: -4242, signal: "SIGTERM" }]);
+    expect(await host.health()).toMatchObject({ status: "unhosted", pid: null });
+  });
+
   test("protocol failure starts bounded TERM and KILL cleanup", async () => {
     const server = new FakeAppServer("failed-thread", "failed-thread", true);
     const host = await CodexAppServerHost.start({
@@ -1281,6 +1383,7 @@ describe("CodexAppServerHost", () => {
       shutdownGraceMs: 5,
       eventStore: new MemoryEventStore(),
       spawnProcess: fakeSpawn(server),
+      ...ownedFakeProcess,
     });
     const stream = host.attach((await host.health()).eventCursor)[Symbol.asyncIterator]();
     server.stdout.write("malformed\n");
@@ -1309,6 +1412,7 @@ describe("CodexAppServerHost", () => {
       requestTimeoutMs: 1_000,
       eventStore: new MemoryEventStore(),
       spawnProcess: fakeSpawn(server),
+      ...ownedFakeProcess,
     });
     const pendingSend = host.send({ id: "epipe-send", text: "start" });
     const error = Object.assign(new Error("broken pipe"), { code: "EPIPE" });
@@ -1395,6 +1499,7 @@ describe("CodexAppServerHost", () => {
       requestTimeoutMs: 5,
       eventStore: new MemoryEventStore(),
       spawnProcess: fakeSpawn(server),
+      ...ownedFakeProcess,
     });
     await expect(host.send({ id: "ambiguous-send", text: "start" })).rejects.toThrow("outcome is uncertain");
     expect(await host.send({ id: "retry", text: "duplicate" })).toEqual({ outcome: "rejected", reason: "dead-host" });
@@ -1471,6 +1576,7 @@ describe("CodexAppServerHost", () => {
       requestTimeoutMs: 1_000,
       eventStore: store,
       spawnProcess: fakeSpawn(server),
+      ...ownedFakeProcess,
     });
     const stream = host.attach((await host.health()).eventCursor)[Symbol.asyncIterator]();
     const pendingSend = host.send({ id: "pending-ledger-send", text: "start" });
@@ -1801,6 +1907,7 @@ describe("CodexAppServerHost", () => {
         shutdownGraceMs: 2,
         spawnProcess: fakeSpawn(server),
         signalProcess: () => {},
+        ...ownedFakeProcess,
       }),
       { NODE_ENV: "test", LLV_STRUCTURED_HOSTS: "1" },
     );

--- a/src/lib/runtime/codexAppServerHost.test.ts
+++ b/src/lib/runtime/codexAppServerHost.test.ts
@@ -1272,6 +1272,34 @@ describe("CodexAppServerHost", () => {
     expect(server.signals).toEqual([]);
   });
 
+  test("release cleans the process group when TERM removes the leader without a close event", async () => {
+    const server = new FakeAppServer("term-missing-close-thread");
+    const signals: Array<{ pid: number; signal: NodeJS.Signals }> = [];
+    let alive = true;
+    const host = await CodexAppServerHost.start({
+      cwd: "/repo",
+      shutdownGraceMs: 2,
+      eventStore: new MemoryEventStore(),
+      spawnProcess: fakeSpawn(server),
+      processIdentity: ownedFakeProcess.processIdentity,
+      pidAlive: () => alive,
+      signalProcess: (pid, signal) => {
+        signals.push({ pid, signal });
+        if (signal === "SIGTERM") alive = false;
+      },
+    });
+
+    await expect(host.release()).resolves.toBeUndefined();
+    await Bun.sleep(6);
+
+    expect(signals).toEqual([
+      { pid: -4242, signal: "SIGTERM" },
+      { pid: -4242, signal: "SIGKILL" },
+    ]);
+    expect(server.signals).toEqual([]);
+    expect(await host.health()).toMatchObject({ status: "unhosted", pid: null, endpoint: "stdio:released" });
+  });
+
   test("release never signals a recycled child pid", async () => {
     const server = new FakeAppServer("recycled-pid-thread");
     const signals: Array<{ pid: number; signal: NodeJS.Signals }> = [];

--- a/src/lib/runtime/codexAppServerHost.ts
+++ b/src/lib/runtime/codexAppServerHost.ts
@@ -285,6 +285,9 @@ export class CodexAppServerHost implements EngineHost {
   private reaped = false;
   private terminationStarted = false;
   private terminationTimer: ReturnType<typeof setTimeout> | null = null;
+  private terminationPromise: Promise<void> | null = null;
+  private resolveTermination: (() => void) | null = null;
+  private failureCleanupTimer: ReturnType<typeof setTimeout> | null = null;
   private releasePromise: Promise<void> | null = null;
   private writerFence: (() => boolean) | null = null;
   private ledgerFailed = false;
@@ -314,9 +317,10 @@ export class CodexAppServerHost implements EngineHost {
     child.on("error", (error) => this.fail(new Error(`Codex app-server child failed: ${safeError(error)}`)));
     child.on("close", () => {
       this.reaped = true;
+      this.completeGroupCleanupAfterReap();
       this.resolveReaped();
       if (this.releasing) {
-        this.finishRelease();
+        this.startFailureCleanup();
       } else if (!this.released) {
         if (this.dead) this.notifyStateListeners();
         else this.fail(new Error("Codex app-server child exited"));
@@ -570,7 +574,7 @@ export class CodexAppServerHost implements EngineHost {
     let terminationStarted = this.startTermination();
     const initialOwnership = this.childProcessOwnership();
     if (!this.reaped && (initialOwnership === "gone" || initialOwnership === "recycled")) {
-      this.finishRelease();
+      await this.finishReleaseAfterGroupCleanup();
       return;
     }
     if (!this.reaped && initialOwnership === "owned" && !terminationStarted) {
@@ -582,7 +586,7 @@ export class CodexAppServerHost implements EngineHost {
     if (!await this.waitForReap(this.shutdownGraceMs)) {
       const ownership = this.childProcessOwnership();
       if (!this.reaped && (ownership === "gone" || ownership === "recycled")) {
-        this.finishRelease();
+        await this.finishReleaseAfterGroupCleanup();
         return;
       }
       if (!this.reaped && ownership === "unknown") {
@@ -592,7 +596,7 @@ export class CodexAppServerHost implements EngineHost {
       if (!await this.waitForReap(this.shutdownGraceMs)) {
         const escalatedOwnership = this.childProcessOwnership();
         if (!this.reaped && (escalatedOwnership === "gone" || escalatedOwnership === "recycled")) {
-          this.finishRelease();
+          await this.finishReleaseAfterGroupCleanup();
           return;
         }
         if (!this.reaped && escalatedOwnership === "unknown") {
@@ -601,11 +605,20 @@ export class CodexAppServerHost implements EngineHost {
         throw new Error("Codex app-server child could not be reaped");
       }
     }
+    await this.finishReleaseAfterGroupCleanup();
+  }
+
+  private async finishReleaseAfterGroupCleanup(): Promise<void> {
+    await this.terminationPromise;
     this.finishRelease();
   }
 
   private finishRelease(): void {
     if (this.released) return;
+    if (this.failureCleanupTimer) {
+      clearTimeout(this.failureCleanupTimer);
+      this.failureCleanupTimer = null;
+    }
     this.released = true;
     this.releasing = false;
     this.activeTurnId = null;
@@ -615,14 +628,45 @@ export class CodexAppServerHost implements EngineHost {
     this.closeSubscribers();
   }
 
+  private completeGroupCleanupAfterReap(): void {
+    if (!this.terminationStarted || !this.resolveTermination) return;
+    if (this.terminationTimer) {
+      clearTimeout(this.terminationTimer);
+      this.terminationTimer = null;
+    }
+    try {
+      if (this.childProcessOwnership() === "gone") {
+        signalProcessGroup(this.child.pid, "SIGKILL", this.signalProcess);
+      }
+    } finally {
+      this.resolveTermination();
+      this.resolveTermination = null;
+    }
+  }
+
   private startTermination(): boolean {
     if (this.terminationStarted) return true;
     try { this.child.stdin.end(); } catch { /* already closed */ }
+    const ownership = this.childProcessOwnership();
+    if (ownership === "gone") {
+      signalProcessGroup(this.child.pid, "SIGTERM", this.signalProcess);
+      signalProcessGroup(this.child.pid, "SIGKILL", this.signalProcess);
+      this.terminationStarted = true;
+      this.terminationPromise = Promise.resolve();
+      return true;
+    }
+    if (ownership !== "owned") return false;
     if (this.signalTermination("SIGTERM") === "unsafe") return false;
     this.terminationStarted = true;
+    this.terminationPromise = new Promise((resolve) => { this.resolveTermination = resolve; });
     this.terminationTimer = setTimeout(() => {
       this.terminationTimer = null;
-      this.signalTermination("SIGKILL");
+      try {
+        this.signalTermination("SIGKILL");
+      } finally {
+        this.resolveTermination?.();
+        this.resolveTermination = null;
+      }
     }, this.shutdownGraceMs);
     return true;
   }
@@ -1238,7 +1282,11 @@ export class CodexAppServerHost implements EngineHost {
 
   private startFailureCleanup(): void {
     void this.release().catch(() => {
-      // Persistent unknown ownership keeps the dead host claimed for a later fenced retry.
+      if (this.released || this.failureCleanupTimer) return;
+      this.failureCleanupTimer = setTimeout(() => {
+        this.failureCleanupTimer = null;
+        this.startFailureCleanup();
+      }, this.shutdownGraceMs);
     });
   }
 

--- a/src/lib/runtime/codexAppServerHost.ts
+++ b/src/lib/runtime/codexAppServerHost.ts
@@ -567,13 +567,16 @@ export class CodexAppServerHost implements EngineHost {
       request.reject(new Error("Codex app-server host released"));
     }
     this.pending.clear();
-    const terminationStarted = this.startTermination();
+    let terminationStarted = this.startTermination();
     const initialOwnership = this.childProcessOwnership();
     if (!this.reaped && (initialOwnership === "gone" || initialOwnership === "recycled")) {
       this.finishRelease();
       return;
     }
-    if (!this.reaped && initialOwnership === "unknown" && !terminationStarted) {
+    if (!this.reaped && initialOwnership === "owned" && !terminationStarted) {
+      terminationStarted = this.startTermination();
+    }
+    if (!this.reaped && !terminationStarted) {
       throw new Error("Codex app-server child ownership is unknown");
     }
     if (!await this.waitForReap(this.shutdownGraceMs)) {

--- a/src/lib/runtime/codexAppServerHost.ts
+++ b/src/lib/runtime/codexAppServerHost.ts
@@ -81,7 +81,11 @@ export interface CodexAppServerHostOptions {
   eventStore?: RuntimeEventStore;
   signalProcess?: ProcessSignal;
   processIdentity?: (pid: number) => string | null;
+  pidAlive?: (pid: number) => boolean;
 }
+
+type ChildProcessOwnership = "owned" | "gone" | "recycled" | "unknown";
+type TerminationSignalResult = "attempted" | "unsafe";
 
 export interface CodexThreadIdentity {
   threadId: string;
@@ -250,6 +254,7 @@ export class CodexAppServerHost implements EngineHost {
   private readonly effort: string | undefined;
   private readonly signalProcess: ProcessSignal;
   private readonly processIdentity: (pid: number) => string | null;
+  private readonly pidAlive: (pid: number) => boolean;
   private readonly childStartIdentity: string | null;
   private readonly onEventCursorRecovery: RuntimeEventCursorRecoveryReporter | undefined;
   private readonly pending = new Map<number, PendingRpc>();
@@ -296,6 +301,7 @@ export class CodexAppServerHost implements EngineHost {
     this.effort = options.effort;
     this.signalProcess = options.signalProcess ?? process.kill;
     this.processIdentity = options.processIdentity ?? ((pid) => procBackend.processIdentity(pid));
+    this.pidAlive = options.pidAlive ?? ((pid) => procBackend.pidAlive(pid));
     this.childStartIdentity = child.pid ? this.processIdentity(child.pid) : null;
     this.onEventCursorRecovery = options.onEventCursorRecovery;
     this.cursor = options.initialEventCursor ?? 0;
@@ -517,9 +523,8 @@ export class CodexAppServerHost implements EngineHost {
 
   private currentState(): HostState {
     const pid = this.reaped || this.released ? null : this.child.pid ?? null;
-    const observedIdentity = pid ? this.processIdentity(pid) : null;
-    const processStartIdentity = this.childStartIdentity === null || observedIdentity === this.childStartIdentity
-      ? observedIdentity
+    const processStartIdentity = pid && this.childProcessOwnership() === "owned"
+      ? this.childStartIdentity
       : null;
     const status: HostState["status"] = this.dead ? "dead"
       : this.released ? "unhosted"
@@ -562,17 +567,33 @@ export class CodexAppServerHost implements EngineHost {
       request.reject(new Error("Codex app-server host released"));
     }
     this.pending.clear();
-    this.startTermination();
+    const terminationStarted = this.startTermination();
+    const initialOwnership = this.childProcessOwnership();
+    if (!this.reaped && (initialOwnership === "gone" || initialOwnership === "recycled")) {
+      this.finishRelease();
+      return;
+    }
+    if (!this.reaped && initialOwnership === "unknown" && !terminationStarted) {
+      throw new Error("Codex app-server child ownership is unknown");
+    }
     if (!await this.waitForReap(this.shutdownGraceMs)) {
-      if (!this.reaped && !this.unreapedChildStillOwned()) {
+      const ownership = this.childProcessOwnership();
+      if (!this.reaped && (ownership === "gone" || ownership === "recycled")) {
         this.finishRelease();
         return;
       }
+      if (!this.reaped && ownership === "unknown") {
+        throw new Error("Codex app-server child ownership is unknown");
+      }
       this.signalTermination("SIGKILL");
       if (!await this.waitForReap(this.shutdownGraceMs)) {
-        if (!this.reaped && !this.unreapedChildStillOwned()) {
+        const escalatedOwnership = this.childProcessOwnership();
+        if (!this.reaped && (escalatedOwnership === "gone" || escalatedOwnership === "recycled")) {
           this.finishRelease();
           return;
+        }
+        if (!this.reaped && escalatedOwnership === "unknown") {
+          throw new Error("Codex app-server child ownership is unknown");
         }
         throw new Error("Codex app-server child could not be reaped");
       }
@@ -591,28 +612,36 @@ export class CodexAppServerHost implements EngineHost {
     this.closeSubscribers();
   }
 
-  private startTermination(): void {
-    if (this.terminationStarted) return;
-    this.terminationStarted = true;
+  private startTermination(): boolean {
+    if (this.terminationStarted) return true;
     try { this.child.stdin.end(); } catch { /* already closed */ }
-    this.signalTermination("SIGTERM");
+    if (this.signalTermination("SIGTERM") === "unsafe") return false;
+    this.terminationStarted = true;
     this.terminationTimer = setTimeout(() => {
       this.terminationTimer = null;
       this.signalTermination("SIGKILL");
     }, this.shutdownGraceMs);
+    return true;
   }
 
-  private unreapedChildStillOwned(): boolean {
+  private childProcessOwnership(): ChildProcessOwnership {
     const pid = this.child.pid;
-    if (this.reaped || !pid || !Number.isInteger(pid) || pid <= 0) return false;
-    if (this.childStartIdentity === null) return true;
-    return this.processIdentity(pid) === this.childStartIdentity;
+    if (!pid || !Number.isInteger(pid) || pid <= 0 || !this.pidAlive(pid)) return "gone";
+    const observedIdentity = this.processIdentity(pid);
+    if (this.childStartIdentity === null || observedIdentity === null) return "unknown";
+    return observedIdentity === this.childStartIdentity ? "owned" : "recycled";
   }
 
-  private signalTermination(signal: NodeJS.Signals): boolean {
-    if (this.reaped) return signalProcessGroup(this.child.pid, signal, this.signalProcess);
-    if (!this.unreapedChildStillOwned()) return false;
-    return signalDetachedProcessGroup(this.child, signal, this.signalProcess);
+  private signalTermination(signal: NodeJS.Signals): TerminationSignalResult {
+    const ownership = this.childProcessOwnership();
+    if (this.reaped) {
+      if (ownership !== "gone") return "unsafe";
+      signalProcessGroup(this.child.pid, signal, this.signalProcess);
+      return "attempted";
+    }
+    if (ownership !== "owned") return "unsafe";
+    signalDetachedProcessGroup(this.child, signal, this.signalProcess);
+    return "attempted";
   }
 
   private async waitForReap(timeoutMs: number): Promise<boolean> {

--- a/src/lib/runtime/codexAppServerHost.ts
+++ b/src/lib/runtime/codexAppServerHost.ts
@@ -634,12 +634,11 @@ export class CodexAppServerHost implements EngineHost {
 
   private signalTermination(signal: NodeJS.Signals): TerminationSignalResult {
     const ownership = this.childProcessOwnership();
-    if (this.reaped) {
-      if (ownership !== "gone") return "unsafe";
+    if (ownership === "gone") {
       signalProcessGroup(this.child.pid, signal, this.signalProcess);
       return "attempted";
     }
-    if (ownership !== "owned") return "unsafe";
+    if (this.reaped || ownership !== "owned") return "unsafe";
     signalDetachedProcessGroup(this.child, signal, this.signalProcess);
     return "attempted";
   }

--- a/src/lib/runtime/codexAppServerHost.ts
+++ b/src/lib/runtime/codexAppServerHost.ts
@@ -1213,7 +1213,7 @@ export class CodexAppServerHost implements EngineHost {
     this.pending.clear();
     this.setSessionStatus("dead", activeFlags);
     this.closeSubscribers();
-    this.startTermination();
+    this.startFailureCleanup();
   }
 
   private failWithoutLedger(error: Error): void {
@@ -1233,7 +1233,13 @@ export class CodexAppServerHost implements EngineHost {
     this.pending.clear();
     this.notifyStateListeners();
     this.closeSubscribers();
-    this.startTermination();
+    this.startFailureCleanup();
+  }
+
+  private startFailureCleanup(): void {
+    void this.release().catch(() => {
+      // Persistent unknown ownership keeps the dead host claimed for a later fenced retry.
+    });
   }
 
   private rejectPendingAnswers(error: Error): void {

--- a/src/lib/runtime/codexAppServerHost.ts
+++ b/src/lib/runtime/codexAppServerHost.ts
@@ -80,6 +80,7 @@ export interface CodexAppServerHostOptions {
   spawnProcess?: (command: string, args: string[], options: SpawnOptionsWithoutStdio) => ChildProcessWithoutNullStreams;
   eventStore?: RuntimeEventStore;
   signalProcess?: ProcessSignal;
+  processIdentity?: (pid: number) => string | null;
 }
 
 export interface CodexThreadIdentity {
@@ -248,6 +249,8 @@ export class CodexAppServerHost implements EngineHost {
   private readonly eventStore: RuntimeEventStore;
   private readonly effort: string | undefined;
   private readonly signalProcess: ProcessSignal;
+  private readonly processIdentity: (pid: number) => string | null;
+  private readonly childStartIdentity: string | null;
   private readonly onEventCursorRecovery: RuntimeEventCursorRecoveryReporter | undefined;
   private readonly pending = new Map<number, PendingRpc>();
   private readonly lateThreadReadResponses = new Map<number, number>();
@@ -292,6 +295,8 @@ export class CodexAppServerHost implements EngineHost {
     this.eventStore = options.eventStore ?? new FileRuntimeEventStore();
     this.effort = options.effort;
     this.signalProcess = options.signalProcess ?? process.kill;
+    this.processIdentity = options.processIdentity ?? ((pid) => procBackend.processIdentity(pid));
+    this.childStartIdentity = child.pid ? this.processIdentity(child.pid) : null;
     this.onEventCursorRecovery = options.onEventCursorRecovery;
     this.cursor = options.initialEventCursor ?? 0;
     this.reapedPromise = new Promise((resolve) => { this.resolveReaped = resolve; });
@@ -512,7 +517,10 @@ export class CodexAppServerHost implements EngineHost {
 
   private currentState(): HostState {
     const pid = this.reaped || this.released ? null : this.child.pid ?? null;
-    const processStartIdentity = pid ? procBackend.processIdentity(pid) : null;
+    const observedIdentity = pid ? this.processIdentity(pid) : null;
+    const processStartIdentity = this.childStartIdentity === null || observedIdentity === this.childStartIdentity
+      ? observedIdentity
+      : null;
     const status: HostState["status"] = this.dead ? "dead"
       : this.released ? "unhosted"
       : this.attentions.size > 0 ? "attention"
@@ -556,9 +564,16 @@ export class CodexAppServerHost implements EngineHost {
     this.pending.clear();
     this.startTermination();
     if (!await this.waitForReap(this.shutdownGraceMs)) {
-      if (this.reaped) signalProcessGroup(this.child.pid, "SIGKILL", this.signalProcess);
-      else signalDetachedProcessGroup(this.child, "SIGKILL", this.signalProcess);
+      if (!this.reaped && !this.unreapedChildStillOwned()) {
+        this.finishRelease();
+        return;
+      }
+      this.signalTermination("SIGKILL");
       if (!await this.waitForReap(this.shutdownGraceMs)) {
+        if (!this.reaped && !this.unreapedChildStillOwned()) {
+          this.finishRelease();
+          return;
+        }
         throw new Error("Codex app-server child could not be reaped");
       }
     }
@@ -580,13 +595,24 @@ export class CodexAppServerHost implements EngineHost {
     if (this.terminationStarted) return;
     this.terminationStarted = true;
     try { this.child.stdin.end(); } catch { /* already closed */ }
-    if (this.reaped) signalProcessGroup(this.child.pid, "SIGTERM", this.signalProcess);
-    else signalDetachedProcessGroup(this.child, "SIGTERM", this.signalProcess);
+    this.signalTermination("SIGTERM");
     this.terminationTimer = setTimeout(() => {
       this.terminationTimer = null;
-      if (this.reaped) signalProcessGroup(this.child.pid, "SIGKILL", this.signalProcess);
-      else signalDetachedProcessGroup(this.child, "SIGKILL", this.signalProcess);
+      this.signalTermination("SIGKILL");
     }, this.shutdownGraceMs);
+  }
+
+  private unreapedChildStillOwned(): boolean {
+    const pid = this.child.pid;
+    if (this.reaped || !pid || !Number.isInteger(pid) || pid <= 0) return false;
+    if (this.childStartIdentity === null) return true;
+    return this.processIdentity(pid) === this.childStartIdentity;
+  }
+
+  private signalTermination(signal: NodeJS.Signals): boolean {
+    if (this.reaped) return signalProcessGroup(this.child.pid, signal, this.signalProcess);
+    if (!this.unreapedChildStillOwned()) return false;
+    return signalDetachedProcessGroup(this.child, signal, this.signalProcess);
   }
 
   private async waitForReap(timeoutMs: number): Promise<boolean> {

--- a/src/lib/runtime/startup.ts
+++ b/src/lib/runtime/startup.ts
@@ -4,6 +4,7 @@ import type { ViewerConversationId } from "@/lib/accounts/migration/contracts";
 import { agentRegistry, type AgentRegistry, type AgentRegistryEntry } from "@/lib/agent/registry";
 import { sessionKeyId } from "@/lib/agent/sessionKey";
 import { VIEWER_SPAWN_CAPABILITY_ENV } from "@/lib/agent/spawnPolicy";
+import { assertDarwinStructuredRuntime } from "@/lib/proc/darwinIdentity";
 
 import {
   adoptClaudeRegistryHosts,
@@ -131,6 +132,7 @@ export interface StructuredStartupDependencies {
 export async function adoptStructuredHostsAtStartup(
   dependencies: StructuredStartupDependencies = {},
 ): Promise<AdoptedStructuredHost[]> {
+  assertDarwinStructuredRuntime();
   const registry = dependencies.registry ?? agentRegistry();
   const client = dependencies.client === undefined ? runtimeHostClient() : dependencies.client;
   const signals = await structuredStartupSignals(registry, client);

--- a/src/runtime-host/host.ts
+++ b/src/runtime-host/host.ts
@@ -106,12 +106,16 @@ export class RuntimeHost {
     catch { console.error("[runtime consumer] recovery deferred after a consumer failure"); }
   }
 
-  async handle(request: RuntimeSocketRequest): Promise<RuntimeSocketResponse> {
+  async handle(request: RuntimeSocketRequest, options: { signal?: AbortSignal } = {}): Promise<RuntimeSocketResponse> {
     try {
       let result: unknown;
       if (request.method === "snapshot") result = this.journal.snapshot();
       else if (request.method === "events") result = this.journal.replay(Number(request.params?.after ?? 0));
-      else if (request.method === "wait") result = await this.journal.waitForEvents(Number(request.params?.after ?? 0), Number(request.params?.timeoutMs ?? 15_000));
+      else if (request.method === "wait") result = await this.journal.waitForEvents(
+        Number(request.params?.after ?? 0),
+        Number(request.params?.timeoutMs ?? 15_000),
+        options.signal,
+      );
       else if (request.method === "append" || request.method === "operation") {
         const event = request.params?.event as RuntimeEventInput;
         const appended = this.journal.append(event);

--- a/src/runtime-host/journal.test.ts
+++ b/src/runtime-host/journal.test.ts
@@ -1416,6 +1416,32 @@ test("runtime socket bounds waiters and reserves command capacity", async () => 
     expect(rejected).toEqual({ id: "wait-excess", ok: false, error: "runtime wait capacity exceeded" });
     const client = new UnixRuntimeHostClient(socketPath, 250);
     expect((await client.snapshot()).snapshotSeq).toBe(0);
+
+    for (const waiter of waiters) waiter.destroy();
+    for (let attempt = 0; attempt < 100; attempt += 1) {
+      const connections = await new Promise<number>((resolve, reject) => {
+        server.getConnections((error, count) => error ? reject(error) : resolve(count));
+      });
+      if (connections === 0) break;
+      await Bun.sleep(2);
+    }
+    const replacement = net.createConnection(socketPath);
+    const replacementResponse = new Promise<Record<string, unknown>>((resolve, reject) => {
+      let response = "";
+      replacement.once("error", reject);
+      replacement.on("data", (chunk) => {
+        response += String(chunk);
+        const newline = response.indexOf("\n");
+        if (newline >= 0) resolve(JSON.parse(response.slice(0, newline)) as Record<string, unknown>);
+      });
+      replacement.once("connect", () => {
+        replacement.write(`${JSON.stringify({ id: "wait-replacement", method: "wait", params: { after: 0, timeoutMs: 5_000 } })}\n`);
+      });
+    });
+    await Bun.sleep(10);
+    journal.append({ scope: runtimeScope("system", "runtime"), kind: "files.revision", payload: { filesRevision: 1 } });
+    expect(await replacementResponse).toMatchObject({ id: "wait-replacement", ok: true });
+    replacement.destroy();
     expect(server.maxConnections).toBe(4);
   } finally {
     journal.append({ scope: runtimeScope("system", "runtime"), kind: "files.revision", payload: { filesRevision: 1 } });

--- a/src/runtime-host/journal.test.ts
+++ b/src/runtime-host/journal.test.ts
@@ -1371,6 +1371,67 @@ test("runtime socket keeps command capacity beyond 64 concurrent SSE waits", asy
   }
 });
 
+test("runtime socket bounds waiters and reserves command capacity", async () => {
+  const dir = sandbox("socket-bounded-waits");
+  const socketPath = path.join(dir, "runtime.sock");
+  const journal = new RuntimeJournal(path.join(dir, "events.sqlite"));
+  const server = serveRuntimeHost(socketPath, new RuntimeHost(journal), {
+    maxConnections: 4,
+    maxWaitConnections: 2,
+  });
+  await new Promise<void>((resolve) => server.once("listening", resolve));
+  const waiters: net.Socket[] = [];
+
+  const openWait = async (id: string): Promise<net.Socket> => await new Promise((resolve, reject) => {
+    const socket = net.createConnection(socketPath);
+    socket.once("error", reject);
+    socket.once("connect", () => {
+      socket.write(`${JSON.stringify({ id, method: "wait", params: { after: 0, timeoutMs: 5_000 } })}\n`);
+      waiters.push(socket);
+      resolve(socket);
+    });
+  });
+
+  try {
+    await openWait("wait-one");
+    await openWait("wait-two");
+    await Bun.sleep(10);
+    const rejected = await new Promise<Record<string, unknown>>((resolve, reject) => {
+      const socket = net.createConnection(socketPath);
+      let response = "";
+      socket.once("error", reject);
+      socket.on("data", (chunk) => {
+        response += String(chunk);
+        const newline = response.indexOf("\n");
+        if (newline >= 0) {
+          socket.destroy();
+          resolve(JSON.parse(response.slice(0, newline)) as Record<string, unknown>);
+        }
+      });
+      socket.once("connect", () => {
+        socket.write(`${JSON.stringify({ id: "wait-excess", method: "wait", params: { after: 0, timeoutMs: 5_000 } })}\n`);
+      });
+    });
+
+    expect(rejected).toEqual({ id: "wait-excess", ok: false, error: "runtime wait capacity exceeded" });
+    const client = new UnixRuntimeHostClient(socketPath, 250);
+    expect((await client.snapshot()).snapshotSeq).toBe(0);
+    expect(server.maxConnections).toBe(4);
+  } finally {
+    journal.append({ scope: runtimeScope("system", "runtime"), kind: "files.revision", payload: { filesRevision: 1 } });
+    for (let attempt = 0; attempt < 100; attempt += 1) {
+      const connections = await new Promise<number>((resolve, reject) => {
+        server.getConnections((error, count) => error ? reject(error) : resolve(count));
+      });
+      if (connections === 0) break;
+      await Bun.sleep(2);
+    }
+    for (const waiter of waiters) waiter.destroy();
+    await new Promise<void>((resolve, reject) => server.close((error) => error ? reject(error) : resolve()));
+    journal.close();
+  }
+});
+
 test("concurrent socket replays keep maximum-size command output byte-bounded and advancing", async () => {
   const dir = sandbox("socket-replay-burst");
   const socketPath = path.join(dir, "runtime.sock");

--- a/src/runtime-host/journal.test.ts
+++ b/src/runtime-host/journal.test.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs";
+import net from "node:net";
 import os from "node:os";
 import path from "node:path";
 
@@ -1322,6 +1323,52 @@ test("Unix socket host isolates a singleton writer and serves a fake Viewer clie
   await new Promise<void>((resolve, reject) => server.close((error) => error ? reject(error) : resolve()));
   journal.close();
   fence.release();
+});
+
+test("runtime socket keeps command capacity beyond 64 concurrent SSE waits", async () => {
+  const dir = sandbox("socket-command-capacity");
+  const socketPath = path.join(dir, "runtime.sock");
+  const journal = new RuntimeJournal(path.join(dir, "events.sqlite"));
+  const server = serveRuntimeHost(socketPath, new RuntimeHost(journal));
+  await new Promise<void>((resolve) => server.once("listening", resolve));
+  const waiters = Array.from({ length: 64 }, () => net.createConnection(socketPath));
+
+  try {
+    await Promise.all(waiters.map((socket, index) => new Promise<void>((resolve, reject) => {
+      socket.once("error", reject);
+      socket.once("connect", () => {
+        socket.write(`${JSON.stringify({
+          id: `wait-${index}`,
+          method: "wait",
+          params: { after: 0, timeoutMs: 5_000 },
+        })}\n`);
+        resolve();
+      });
+    })));
+
+    for (let attempt = 0; attempt < 100; attempt += 1) {
+      const connections = await new Promise<number>((resolve, reject) => {
+        server.getConnections((error, count) => error ? reject(error) : resolve(count));
+      });
+      if (connections >= waiters.length) break;
+      await Bun.sleep(2);
+    }
+
+    const client = new UnixRuntimeHostClient(socketPath, 250);
+    expect((await client.snapshot()).snapshotSeq).toBe(0);
+  } finally {
+    journal.append({ scope: runtimeScope("system", "runtime"), kind: "files.revision", payload: { filesRevision: 1 } });
+    for (let attempt = 0; attempt < 100; attempt += 1) {
+      const connections = await new Promise<number>((resolve, reject) => {
+        server.getConnections((error, count) => error ? reject(error) : resolve(count));
+      });
+      if (connections === 0) break;
+      await Bun.sleep(2);
+    }
+    for (const waiter of waiters) waiter.destroy();
+    await new Promise<void>((resolve, reject) => server.close((error) => error ? reject(error) : resolve()));
+    journal.close();
+  }
 });
 
 test("concurrent socket replays keep maximum-size command output byte-bounded and advancing", async () => {

--- a/src/runtime-host/journal.ts
+++ b/src/runtime-host/journal.ts
@@ -843,21 +843,37 @@ export class RuntimeJournal {
     }
   }
 
-  waitForEvents(after: number, timeoutMs = 15_000): Promise<RuntimeReplay> {
+  waitForEvents(after: number, timeoutMs = 15_000, signal?: AbortSignal): Promise<RuntimeReplay> {
     const immediate = this.replay(after);
     if (immediate.reset || immediate.events.length > 0) return Promise.resolve(immediate);
     const timeout = Math.min(Math.max(timeoutMs, 10), 30_000);
-    return new Promise((resolve) => {
+    return new Promise((resolve, reject) => {
       let settled = false;
+      let timer: ReturnType<typeof setTimeout> | null = null;
+      const cleanup = () => {
+        if (timer !== null) clearTimeout(timer);
+        this.waiters.delete(finish);
+        signal?.removeEventListener("abort", abort);
+      };
       const finish = () => {
         if (settled) return;
         settled = true;
-        clearTimeout(timer);
-        this.waiters.delete(finish);
+        cleanup();
         resolve(this.replay(after));
       };
+      const abort = () => {
+        if (settled) return;
+        settled = true;
+        cleanup();
+        reject(new Error("runtime wait aborted"));
+      };
+      signal?.addEventListener("abort", abort, { once: true });
+      if (signal?.aborted) {
+        abort();
+        return;
+      }
       this.waiters.add(finish);
-      const timer = setTimeout(finish, timeout);
+      timer = setTimeout(finish, timeout);
     });
   }
 

--- a/src/runtime-host/socket.ts
+++ b/src/runtime-host/socket.ts
@@ -35,6 +35,8 @@ export function serveRuntimeHost(socketPath: string, host: RuntimeHost, options:
   try { fs.unlinkSync(socketPath); } catch (error) { if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error; }
   let activeWaitConnections = 0;
   const server = net.createServer((socket) => {
+    const abort = new AbortController();
+    socket.once("close", () => abort.abort());
     socket.setTimeout(defaultTimeoutMs, () => socket.destroy());
     let buffer = "";
     let handled = false;
@@ -58,7 +60,7 @@ export function serveRuntimeHost(socketPath: string, host: RuntimeHost, options:
             return;
           }
           activeWaitConnections += 1;
-          void host.handle(request)
+          void host.handle(request, { signal: abort.signal })
             .then((response) => socket.end(JSON.stringify(response) + "\n"))
             .finally(() => { activeWaitConnections -= 1; });
           return;

--- a/src/runtime-host/socket.ts
+++ b/src/runtime-host/socket.ts
@@ -9,44 +9,70 @@ import { RuntimeHost } from "./host";
 const MAX_FRAME_BYTES = 512 * 1024;
 const DEFAULT_SOCKET_TIMEOUT_MS = 31_000;
 const DEPLOYMENT_SOCKET_TIMEOUT_MS = 125_000;
+const DEFAULT_MAX_CONNECTIONS = 256;
+const DEFAULT_MAX_WAIT_CONNECTIONS = 192;
 
 export interface RuntimeHostSocketOptions {
   defaultTimeoutMs?: number;
   deploymentTimeoutMs?: number;
+  maxConnections?: number;
+  maxWaitConnections?: number;
 }
 
 /** Newline-framed local protocol. It intentionally binds a Unix path only. */
 export function serveRuntimeHost(socketPath: string, host: RuntimeHost, options: RuntimeHostSocketOptions = {}): net.Server {
   const defaultTimeoutMs = options.defaultTimeoutMs ?? DEFAULT_SOCKET_TIMEOUT_MS;
   const deploymentTimeoutMs = options.deploymentTimeoutMs ?? DEPLOYMENT_SOCKET_TIMEOUT_MS;
+  const maxConnections = options.maxConnections ?? DEFAULT_MAX_CONNECTIONS;
+  const maxWaitConnections = options.maxWaitConnections ?? DEFAULT_MAX_WAIT_CONNECTIONS;
+  if (!Number.isSafeInteger(maxConnections) || maxConnections < 2) {
+    throw new Error("runtime socket maxConnections must be an integer of at least 2");
+  }
+  if (!Number.isSafeInteger(maxWaitConnections) || maxWaitConnections < 1 || maxWaitConnections >= maxConnections) {
+    throw new Error("runtime socket maxWaitConnections must reserve at least one command connection");
+  }
   fs.mkdirSync(path.dirname(socketPath), { recursive: true, mode: 0o700 });
   try { fs.unlinkSync(socketPath); } catch (error) { if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error; }
+  let activeWaitConnections = 0;
   const server = net.createServer((socket) => {
     socket.setTimeout(defaultTimeoutMs, () => socket.destroy());
     let buffer = "";
+    let handled = false;
     socket.on("data", (chunk) => {
+      if (handled) return;
       buffer += String(chunk);
       if (Buffer.byteLength(buffer) > MAX_FRAME_BYTES) return socket.destroy();
       // The client opens one connection per request, so one frame owns the
       // socket and any bytes after its delimiter are intentionally ignored.
       const newline = buffer.indexOf("\n");
       if (newline < 0) return;
+      handled = true;
       const frame = buffer.slice(0, newline);
-      buffer = buffer.slice(newline + 1);
       try {
         const request = JSON.parse(frame) as RuntimeSocketRequest;
         if (!request.id || !request.method) throw new Error("runtime request is malformed");
         if (request.method === "viewer-deployment-request") socket.setTimeout(deploymentTimeoutMs);
+        if (request.method === "wait") {
+          if (activeWaitConnections >= maxWaitConnections) {
+            socket.end(JSON.stringify({ id: request.id, ok: false, error: "runtime wait capacity exceeded" }) + "\n");
+            return;
+          }
+          activeWaitConnections += 1;
+          void host.handle(request)
+            .then((response) => socket.end(JSON.stringify(response) + "\n"))
+            .finally(() => { activeWaitConnections -= 1; });
+          return;
+        }
         void host.handle(request).then((response) => socket.end(JSON.stringify(response) + "\n"));
       } catch {
         socket.end(JSON.stringify({ id: "unknown", ok: false, error: "runtime request is malformed" }) + "\n");
       }
     });
   });
-  // Every browser tab holds one long-poll wait socket. A hard server-wide cap
-  // lets those passive waits consume all admission slots, starving snapshot,
-  // send, kill, and deployment commands. Frame and idle deadlines keep each
-  // local 0600 socket bounded while the OS backlog admits command traffic.
+  // Browser long polls receive their own ceiling below the server-wide cap.
+  // The remaining slots keep snapshot, control, and deployment traffic
+  // admissible while total file descriptors and journal waiters stay bounded.
+  server.maxConnections = maxConnections;
   server.once("listening", () => fs.chmodSync(socketPath, 0o600));
   server.listen(socketPath);
   return server;

--- a/src/runtime-host/socket.ts
+++ b/src/runtime-host/socket.ts
@@ -43,7 +43,10 @@ export function serveRuntimeHost(socketPath: string, host: RuntimeHost, options:
       }
     });
   });
-  server.maxConnections = 64;
+  // Every browser tab holds one long-poll wait socket. A hard server-wide cap
+  // lets those passive waits consume all admission slots, starving snapshot,
+  // send, kill, and deployment commands. Frame and idle deadlines keep each
+  // local 0600 socket bounded while the OS backlog admits command traffic.
   server.once("listening", () => fs.chmodSync(socketPath, 0o600));
   server.listen(socketPath);
   return server;


### PR DESCRIPTION
## Summary

- capture the Codex child start identity when its app-server host is created
- converge release after SIGKILL removes the owned child and Bun omits the close event
- fence TERM and KILL signals against PID reuse
- preserve the existing bounded late-reap retry for a child that still has the original identity

## Production evidence

A stale kill for `conversation_1e817df1-95e6-4906-a377-3ee7e1f440b5` repeatedly returned `Codex app-server child could not be reaped`. The transcript scanner showed no live PID, while the runtime projection remained hosted/running. Operation `op_e6ffce42-0a4a-41f1-af76-12102a3c0c43` reached 1,650 revisions and repeatedly filled the runtime socket with connected clients, causing structured-control `503` responses.

## Verification

- `bun test src/lib/runtime/codexAppServerHost.test.ts` — 55 passed
- `bun test src/lib/runtime/codexAppServerHost.integration.test.ts src/lib/runtime/structuredDeliveryQueue.test.ts` — 26 passed
- `bun test src/lib/runtime/structuredSpawn.integration.test.ts` — 37 passed
- `bun x tsc --noEmit`
- scoped ESLint
- `git diff --check`
- optimized production build

Relates to #308.
