### PR TITLE
fix(runtime): hold structured sends during synchronization

### DIFF
--- a/src/app/api/account-migrations/[intentId]/action.ts
+++ b/src/app/api/account-migrations/[intentId]/action.ts
@@ -2,16 +2,11 @@ import { NextRequest, NextResponse } from "next/server";
 
 import { agentRegistry, type AgentRegistry } from "@/lib/agent/registry";
 import { drainHeldDeliveries } from "@/lib/accounts/migration/coordinator";
+import { createMigrationDeliveryPort } from "@/lib/accounts/migration/deliveryPort";
 import { requestAccountMigrationTick } from "@/lib/accounts/migration/controllerSignal";
-import { deliverConversationMessage, migrationDeliveryOutcome } from "@/lib/delivery";
 import { rejectCrossOrigin } from "@/lib/sameOrigin";
 
-const deliveryPort = {
-  async deliver({ delivery, path, clientMessageId }: { delivery: { id: string; text: string }; path: string; clientMessageId: string }) {
-    const result = await deliverConversationMessage({ pid: null, path, text: delivery.text, images: [], clientMessageId, reservedDeliveryId: delivery.id });
-    return migrationDeliveryOutcome(result);
-  },
-};
+const deliveryPort = createMigrationDeliveryPort();
 
 export async function updateMigrationAction(
   req: NextRequest,

--- a/src/app/api/conversations/[conversationId]/migration/route.ts
+++ b/src/app/api/conversations/[conversationId]/migration/route.ts
@@ -2,20 +2,15 @@ import { NextRequest, NextResponse } from "next/server";
 
 import { agentRegistry } from "@/lib/agent/registry";
 import { advanceConversationMigration, drainHeldDeliveries } from "@/lib/accounts/migration/coordinator";
+import { createMigrationDeliveryPort } from "@/lib/accounts/migration/deliveryPort";
 import { RegisteredSuccessorProvider } from "@/lib/accounts/migration/provider";
-import { deliverConversationMessage, migrationDeliveryOutcome } from "@/lib/delivery";
 import { rejectCrossOrigin } from "@/lib/sameOrigin";
 import type { ViewerConversationId } from "@/lib/accounts/migration/contracts";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
-const deliveryPort = {
-  async deliver({ delivery, path, clientMessageId }: { delivery: { id: string; text: string }; path: string; clientMessageId: string }) {
-    const result = await deliverConversationMessage({ pid: null, path, text: delivery.text, images: [], clientMessageId, reservedDeliveryId: delivery.id });
-    return migrationDeliveryOutcome(result);
-  },
-};
+const deliveryPort = createMigrationDeliveryPort();
 
 export async function POST(req: NextRequest, { params }: { params: Promise<{ conversationId: string }> }) {
   const rejected = rejectCrossOrigin(req); if (rejected) return rejected;

--- a/src/app/api/spawn/route.test.ts
+++ b/src/app/api/spawn/route.test.ts
@@ -83,7 +83,7 @@ test("structured spawn runtime fence preserves durable state", async () => {
       assignedAt: null,
       deliveredAt: `2026-07-16T00:00:${String(index % 60).padStart(2, "0")}.000Z`,
       error: null,
-    };
+    } as unknown as (typeof snapshot.heldDeliveries)[string];
   }
   fs.writeFileSync(registryPath, JSON.stringify(snapshot));
   const registryBytes = fs.readFileSync(registryPath);

--- a/src/instrumentation.test.ts
+++ b/src/instrumentation.test.ts
@@ -14,6 +14,7 @@ import {
 } from "./instrumentation";
 import { operatorSpawnCapabilityPath } from "@/lib/agent/operatorCapability";
 import { StructuredRuntimeRequirementError } from "@/lib/proc/darwinIdentity";
+import { RuntimeHostUnavailableError } from "@/lib/runtime/client";
 import { didStructuredHostStartupFail, markStructuredHostStartupReady } from "@/lib/runtime/startupStatus";
 
 test("account controller delay defaults to immediate startup and retains the explicit escape hatch", () => {
@@ -130,6 +131,100 @@ test("structured-host startup logs the thrown adoption error object", async () =
     await runStructuredHostStartup(async () => undefined, (...args) => { logged.push(args); });
     expect(didStructuredHostStartupFail()).toBe(false);
     expect(logged).toHaveLength(1);
+  } finally {
+    markStructuredHostStartupReady();
+  }
+});
+
+test("structured-host startup self-heals after the runtime socket becomes ready", async () => {
+  const scheduled: Array<{ callback: () => void; delayMs: number }> = [];
+  const logged: unknown[][] = [];
+  let attempts = 0;
+
+  try {
+    await runStructuredHostStartup(
+      async () => {
+        attempts += 1;
+        if (attempts === 1) throw new RuntimeHostUnavailableError("runtime host is unavailable");
+      },
+      (...args) => { logged.push(args); },
+      {
+        schedule: (callback, delayMs) => {
+          scheduled.push({ callback, delayMs });
+          return { unref() {} };
+        },
+      },
+    );
+
+    expect(attempts).toBe(1);
+    expect(didStructuredHostStartupFail()).toBe(true);
+    expect(scheduled).toHaveLength(1);
+    expect(scheduled[0]!.delayMs).toBe(100);
+
+    scheduled.shift()!.callback();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(attempts).toBe(2);
+    expect(didStructuredHostStartupFail()).toBe(false);
+    expect(scheduled).toHaveLength(0);
+    expect(logged).toEqual([
+      [
+        "[structured hosts] startup adoption failed; retry scheduled",
+        expect.any(RuntimeHostUnavailableError),
+      ],
+      ["[structured hosts] startup adoption recovered", { attempts: 2 }],
+    ]);
+  } finally {
+    markStructuredHostStartupReady();
+  }
+});
+
+test("structured-host startup uses bounded backoff with one pending retry", async () => {
+  const scheduled: Array<{ callback: () => void; delayMs: number }> = [];
+  const logged: unknown[][] = [];
+  let attempts = 0;
+
+  try {
+    await runStructuredHostStartup(
+      async () => {
+        attempts += 1;
+        if (attempts < 5) throw new RuntimeHostUnavailableError("runtime host is unavailable");
+      },
+      (...args) => { logged.push(args); },
+      {
+        initialRetryMs: 25,
+        maxRetryMs: 50,
+        schedule: (callback, delayMs) => {
+          scheduled.push({ callback, delayMs });
+          return { unref() {} };
+        },
+      },
+    );
+
+    expect(scheduled.map(({ delayMs }) => delayMs)).toEqual([25]);
+    for (const expectedDelay of [50, 50, 50]) {
+      scheduled.shift()!.callback();
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(scheduled).toHaveLength(1);
+      expect(scheduled[0]!.delayMs).toBe(expectedDelay);
+    }
+
+    scheduled.shift()!.callback();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(attempts).toBe(5);
+    expect(scheduled).toHaveLength(0);
+    expect(didStructuredHostStartupFail()).toBe(false);
+    expect(logged).toEqual([
+      [
+        "[structured hosts] startup adoption failed; retry scheduled",
+        expect.any(RuntimeHostUnavailableError),
+      ],
+      ["[structured hosts] startup adoption recovered", { attempts: 5 }],
+    ]);
   } finally {
     markStructuredHostStartupReady();
   }

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 
 import { statePath } from "@/lib/configDir";
+import { RuntimeHostUnavailableError } from "@/lib/runtime/client";
 import { markStructuredHostStartupFailed, markStructuredHostStartupReady } from "@/lib/runtime/startupStatus";
 import { StructuredRuntimeRequirementError } from "@/lib/proc/darwinIdentity";
 
@@ -8,6 +9,12 @@ const RELEASE_ACTIVATION_POLL_MS = 250;
 
 interface ActivationTimer {
   unref?(): unknown;
+}
+
+interface StructuredHostStartupOptions {
+  schedule?: (callback: () => void, delayMs: number) => ActivationTimer;
+  initialRetryMs?: number;
+  maxRetryMs?: number;
 }
 
 interface ViewerReleaseActivationOptions {
@@ -99,15 +106,45 @@ export async function initializeOperatorSpawnCapabilityAtStartup(
 export async function runStructuredHostStartup(
   adopt: () => Promise<unknown>,
   log: (...args: unknown[]) => void = console.error,
+  options: StructuredHostStartupOptions = {},
 ): Promise<void> {
-  try {
-    await adopt();
-    markStructuredHostStartupReady();
-  } catch (error) {
-    markStructuredHostStartupFailed();
-    log("[structured hosts] startup adoption failed", error);
-    if (error instanceof StructuredRuntimeRequirementError) throw error;
-  }
+  const schedule = options.schedule ?? ((callback, delayMs) => setTimeout(callback, delayMs));
+  const maxRetryMs = options.maxRetryMs ?? 1_000;
+  let retryMs = options.initialRetryMs ?? 100;
+  let retryPending = false;
+  let attempts = 0;
+
+  const attempt = async (): Promise<void> => {
+    attempts += 1;
+    try {
+      await adopt();
+      markStructuredHostStartupReady();
+      if (attempts > 1) log("[structured hosts] startup adoption recovered", { attempts });
+    } catch (error) {
+      markStructuredHostStartupFailed();
+      if (error instanceof StructuredRuntimeRequirementError) {
+        log("[structured hosts] startup adoption failed", error);
+        throw error;
+      }
+      if (!(error instanceof RuntimeHostUnavailableError)) {
+        log("[structured hosts] startup adoption failed", error);
+        return;
+      }
+      if (retryPending) return;
+      const delayMs = retryMs;
+      retryMs = Math.min(retryMs * 2, maxRetryMs);
+      retryPending = true;
+      if (attempts === 1) log("[structured hosts] startup adoption failed; retry scheduled", error);
+      schedule(() => {
+        retryPending = false;
+        void attempt().catch((retryError) => {
+          log("[structured hosts] startup adoption retry aborted", retryError);
+        });
+      }, delayMs).unref?.();
+    }
+  };
+
+  await attempt();
 }
 
 export async function register(): Promise<void> {

--- a/src/lib/accounts/migration/contracts.ts
+++ b/src/lib/accounts/migration/contracts.ts
@@ -196,6 +196,20 @@ export interface DurableQuotaObservation {
   bootId: string;
 }
 
+export interface HeldDeliveryCommand {
+  operationId: string;
+  kind: "send" | "steer";
+  policy: "queue" | "steer-if-active" | "interrupt-active";
+  turnId?: string | null;
+}
+
+export interface HeldDeliveryCommandInput {
+  operationId?: string;
+  kind?: HeldDeliveryCommand["kind"];
+  policy?: HeldDeliveryCommand["policy"];
+  turnId?: string | null;
+}
+
 export interface HeldDelivery {
   id: string;
   conversationId: ViewerConversationId;
@@ -206,6 +220,8 @@ export interface HeldDelivery {
   payloadKind: "text" | "ephemeral-images" | "ephemeral-text";
   /** Inbox files already materialized for an ambiguous request-local attempt. */
   artifactPaths: string[];
+  command: HeldDeliveryCommand;
+  requestDigest: string | null;
   state: "held" | "assigned" | "delivered" | "failed" | "delivery-uncertain";
   generationId: string | null;
   attempts: number;

--- a/src/lib/accounts/migration/contracts.ts
+++ b/src/lib/accounts/migration/contracts.ts
@@ -213,6 +213,7 @@ export interface HeldDeliveryCommandInput {
 export interface HeldDelivery {
   id: string;
   conversationId: ViewerConversationId;
+  runtimeConversationId: ViewerConversationId;
   text: string;
   createdAt: string;
   clientMessageId: string | null;

--- a/src/lib/accounts/migration/controller.test.ts
+++ b/src/lib/accounts/migration/controller.test.ts
@@ -79,6 +79,7 @@ test("controller drains a migration-held structured message through the runtime 
     deliveryId: claimed.id,
     clientMessageId: "migration-message",
     text: "continue",
+    command: claimed.command,
   }]);
   expect(legacyCalls).toBe(0);
 });
@@ -100,6 +101,12 @@ test("controller keeps an uncertain structured claim fenced when ownership canno
     clientMessageId: "migration-message",
     payloadKind: "text" as const,
     artifactPaths: [],
+    command: {
+      operationId: "held-one",
+      kind: "send" as const,
+      policy: "interrupt-active" as const,
+    },
+    requestDigest: "held-one-request-digest",
     state: "delivery-uncertain" as const,
     generationId: "generation-one",
     attempts: 1,

--- a/src/lib/accounts/migration/controller.test.ts
+++ b/src/lib/accounts/migration/controller.test.ts
@@ -75,6 +75,7 @@ test("controller drains a migration-held structured message through the runtime 
   expect(outcome).toBe("delivered");
   expect(structured).toEqual([{
     conversationId: conversation.id,
+    runtimeConversationId: conversation.id,
     path: "/structured-successor.jsonl",
     deliveryId: claimed.id,
     clientMessageId: "migration-message",
@@ -96,6 +97,7 @@ test("controller keeps an uncertain structured claim fenced when ownership canno
   const delivery = {
     id: "held-one",
     conversationId: "conversation_11111111-1111-4111-8111-111111111111" as const,
+    runtimeConversationId: "conversation_11111111-1111-4111-8111-111111111111" as const,
     text: "continue",
     createdAt: "2026-07-13T00:00:00.000Z",
     clientMessageId: "migration-message",

--- a/src/lib/accounts/migration/controller.ts
+++ b/src/lib/accounts/migration/controller.ts
@@ -48,6 +48,7 @@ export function createMigrationDeliveryPort(
     deliveryId: delivery.id,
     clientMessageId,
     text: delivery.text,
+    command: delivery.command,
   });
   return {
     async deliver(input) {

--- a/src/lib/accounts/migration/controller.ts
+++ b/src/lib/accounts/migration/controller.ts
@@ -5,20 +5,19 @@ import { withAccountMutationLock } from "@/lib/accounts/accountMutation";
 import { agentRegistry, conversationLookupFromSnapshot, type AgentRegistry } from "@/lib/agent/registry";
 import { readTranscriptHosts } from "@/lib/agent/transcriptHost";
 import { forEachCooperatively, yieldToRuntime } from "@/lib/cooperative";
-import { deliverConversationMessage, migrationDeliveryOutcome } from "@/lib/delivery";
 import { loadFlows, reconcileFlowConversationOwnershipCooperatively } from "@/lib/flows/store";
 import { reconcileHandoffConversationOwnershipCooperatively } from "@/lib/handoffLineage";
 import { listFilesWithProjectCatalog, reconcileFileControllers } from "@/lib/scanner";
 import { pidAlive, readPpid } from "@/lib/scanner/process";
 import { runReaperCycle } from "@/lib/reaperRuntime";
 import { runHeadlessProcessReaper } from "@/lib/headlessProcessReaper";
-import { deliverHeldStructuredMessage, type HeldStructuredMessageOutcome } from "@/lib/runtime/structuredMessageDelivery";
 import { pathForPanePid, reconcileTasks } from "@/lib/tasks/reconcile";
 import { mutateTasks } from "@/lib/tasks/store";
 import { reconcileWorkflowConversationOwnershipCooperatively } from "@/lib/workflows/store";
 import { paneInfo } from "@/lib/tmux";
 
 import { drainHeldDeliveries, reconcileMigrationInventory, reconcileMigrations, type HeldDeliveryPort } from "./coordinator";
+import { createMigrationDeliveryPort } from "./deliveryPort";
 import { registerAccountMigrationTick } from "./controllerSignal";
 import type { SuccessorProviderPort } from "./contracts";
 import { RegisteredSuccessorProvider } from "./provider";
@@ -27,39 +26,7 @@ import { QuotaController } from "./quotaController";
 const CONTROLLER_INTERVAL_MS = 60_000;
 const INITIAL_INVENTORY_DELAY_MS = 1_000;
 
-type HeldDeliveryInput = Parameters<HeldDeliveryPort["deliver"]>[0];
-
-export interface MigrationDeliveryPortDependencies {
-  structuredDelivery?: typeof deliverHeldStructuredMessage;
-  legacyDelivery?: (input: HeldDeliveryInput) => Promise<Exclude<HeldStructuredMessageOutcome, null> | "held">;
-}
-
-export function createMigrationDeliveryPort(
-  dependencies: MigrationDeliveryPortDependencies = {},
-): HeldDeliveryPort {
-  const structuredDelivery = dependencies.structuredDelivery ?? deliverHeldStructuredMessage;
-  const legacyDelivery = dependencies.legacyDelivery ?? (async ({ delivery, path, clientMessageId }) => {
-    const result = await deliverConversationMessage({ pid: null, path, text: delivery.text, images: [], clientMessageId, reservedDeliveryId: delivery.id });
-    return migrationDeliveryOutcome(result);
-  });
-  const deliverStructured = ({ delivery, path, clientMessageId }: HeldDeliveryInput) => structuredDelivery({
-    conversationId: delivery.conversationId,
-    path,
-    deliveryId: delivery.id,
-    clientMessageId,
-    text: delivery.text,
-    command: delivery.command,
-  });
-  return {
-    async deliver(input) {
-      const outcome = await deliverStructured(input);
-      return outcome ?? legacyDelivery(input);
-    },
-    async reconcileUncertain(input) {
-      return await deliverStructured(input) ?? "delivery-uncertain";
-    },
-  };
-}
+export { createMigrationDeliveryPort } from "./deliveryPort";
 
 const deliveryPort = createMigrationDeliveryPort();
 

--- a/src/lib/accounts/migration/deliveryPort.ts
+++ b/src/lib/accounts/migration/deliveryPort.ts
@@ -1,0 +1,48 @@
+import { deliverConversationMessage, migrationDeliveryOutcome } from "@/lib/delivery";
+import {
+  deliverHeldStructuredMessage,
+  type HeldStructuredMessageOutcome,
+} from "@/lib/runtime/structuredMessageDelivery";
+
+import type { HeldDeliveryPort } from "./coordinator";
+
+type HeldDeliveryInput = Parameters<HeldDeliveryPort["deliver"]>[0];
+
+export interface MigrationDeliveryPortDependencies {
+  structuredDelivery?: typeof deliverHeldStructuredMessage;
+  legacyDelivery?: (input: HeldDeliveryInput) => Promise<Exclude<HeldStructuredMessageOutcome, null> | "held">;
+}
+
+export function createMigrationDeliveryPort(
+  dependencies: MigrationDeliveryPortDependencies = {},
+): HeldDeliveryPort {
+  const structuredDelivery = dependencies.structuredDelivery ?? deliverHeldStructuredMessage;
+  const legacyDelivery = dependencies.legacyDelivery ?? (async ({ delivery, path, clientMessageId }) => {
+    const result = await deliverConversationMessage({
+      pid: null,
+      path,
+      text: delivery.text,
+      images: [],
+      clientMessageId,
+      reservedDeliveryId: delivery.id,
+    });
+    return migrationDeliveryOutcome(result);
+  });
+  const deliverStructured = ({ delivery, path, clientMessageId }: HeldDeliveryInput) => structuredDelivery({
+    conversationId: delivery.conversationId,
+    path,
+    deliveryId: delivery.id,
+    clientMessageId,
+    text: delivery.text,
+    command: delivery.command,
+  });
+  return {
+    async deliver(input) {
+      const outcome = await deliverStructured(input);
+      return outcome ?? legacyDelivery(input);
+    },
+    async reconcileUncertain(input) {
+      return await deliverStructured(input) ?? "delivery-uncertain";
+    },
+  };
+}

--- a/src/lib/accounts/migration/deliveryPort.ts
+++ b/src/lib/accounts/migration/deliveryPort.ts
@@ -30,6 +30,7 @@ export function createMigrationDeliveryPort(
   });
   const deliverStructured = ({ delivery, path, clientMessageId }: HeldDeliveryInput) => structuredDelivery({
     conversationId: delivery.conversationId,
+    runtimeConversationId: delivery.runtimeConversationId,
     path,
     deliveryId: delivery.id,
     clientMessageId,

--- a/src/lib/agent/registry.sqlite.test.ts
+++ b/src/lib/agent/registry.sqlite.test.ts
@@ -192,6 +192,11 @@ test("SQLite restart derives and persists explicit operation ownership before to
   ).get("deliveryOperationOwners", command.operationId)?.count).toBe(1);
   persistedDb.close();
   const reopened = new AgentRegistry(filename, undefined, undefined, { sqliteMode: "sqlite" });
+  expect(reopened.snapshot().deliveryOperationOwners[command.operationId]).toMatchObject({
+    terminalState: "delivered",
+    requestDigest: original.requestDigest,
+  });
+  expect(reopened.snapshot().deliveryOperationOwners[command.operationId]).not.toHaveProperty("settledDelivery");
   expect(() => reopened.holdDelivery(
     conversation.id,
     "retain SQLite operation ownership",
@@ -205,7 +210,104 @@ test("SQLite restart derives and persists explicit operation ownership before to
     "sqlite-operation-owner-client",
     "text",
     command,
-  )).toMatchObject({ id: original.id, state: "delivered", attempts: claimed!.attempts, command });
+  )).toMatchObject({ id: original.id, state: "delivered", command });
+});
+
+test("terminal operation ownership stays bounded and payload-free in JSON and SQLite", () => {
+  for (const backend of ["json", "sqlite"] as const) {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), `llv-registry-bounded-owners-${backend}-`));
+    const filename = path.join(directory, "agent-registry.json");
+    const sqliteFilename = path.join(directory, "agent-registry.sqlite");
+    const storage = { sqliteMode: backend === "sqlite" ? "sqlite" as const : "off" as const };
+    let store = new AgentRegistry(filename, undefined, undefined, storage);
+    const conversation = store.ensureConversation("codex", `/sessions/bounded-owners-${backend}.jsonl`, "default");
+    const writeFailures = (start: number, end: number) => {
+      for (let index = start; index < end; index += 1) {
+        const suffix = String(index).padStart(3, "0");
+        const delivery = store.holdDelivery(
+          conversation.id,
+          `sensitive failed payload ${backend} ${suffix}`,
+          `bounded-owner-client-${backend}-${suffix}`,
+          "text",
+          {
+            operationId: `bounded-owner-operation-${backend}-${suffix}`,
+            kind: "send",
+            policy: "queue",
+          },
+        );
+        if (!store.beginDeliveryAttempt(delivery.id, delivery.generationId!)) {
+          throw new Error("expected explicit operation delivery attempt");
+        }
+        store.recordDeliveryOutcome(delivery.id, "failed", "host unavailable");
+      }
+    };
+    const sqliteOwnerStats = () => {
+      const db = new Database(sqliteFilename, { readonly: true });
+      const stats = db.query<{ count: number; bytes: number }, [string]>(
+        "SELECT COUNT(*) AS count, COALESCE(SUM(LENGTH(value_json)), 0) AS bytes FROM registry_rows WHERE collection = ?",
+      ).get("deliveryOperationOwners")!;
+      const payload = db.query<{ value_json: string }, [string]>(
+        "SELECT value_json FROM registry_rows WHERE collection = ? ORDER BY row_order",
+      ).all("deliveryOperationOwners").map((row) => row.value_json).join("\n");
+      db.close();
+      return { ...stats, payload };
+    };
+
+    writeFailures(0, 220);
+    const firstJsonBytes = fs.statSync(filename).size;
+    const firstSqliteStats = backend === "sqlite" ? sqliteOwnerStats() : null;
+    writeFailures(220, 440);
+    store.compactDeliveryReservations();
+
+    const snapshot = store.snapshot();
+    expect(Object.keys(snapshot.deliveryOperationOwners)).toHaveLength(200);
+    expect(Object.values(snapshot.deliveryOperationOwners).every((owner) =>
+      owner.terminalState === "failed" && !("settledDelivery" in owner))).toBeTrue();
+    const retainedIndex = "250";
+    const retainedOperationId = `bounded-owner-operation-${backend}-${retainedIndex}`;
+    const retainedText = `sensitive failed payload ${backend} ${retainedIndex}`;
+    const retainedClientId = `bounded-owner-client-${backend}-${retainedIndex}`;
+    expect(snapshot.deliveryOperationOwners[retainedOperationId]).toMatchObject({
+      terminalState: "failed",
+      requestDigest: expect.any(String),
+    });
+    expect(Object.values(snapshot.heldDeliveries)
+      .some((delivery) => delivery.command.operationId === retainedOperationId)).toBeFalse();
+    expect(fs.readFileSync(filename, "utf8")).not.toContain(retainedText);
+    expect(fs.statSync(filename).size).toBeLessThanOrEqual(firstJsonBytes + 16_384);
+    if (backend === "sqlite") {
+      const secondSqliteStats = sqliteOwnerStats();
+      expect(secondSqliteStats.count).toBe(200);
+      expect(secondSqliteStats.bytes).toBeLessThanOrEqual(firstSqliteStats!.bytes + 4_096);
+      expect(secondSqliteStats.payload).not.toContain(retainedText);
+    }
+
+    store = new AgentRegistry(filename, undefined, undefined, storage);
+    expect(store.holdDelivery(
+      conversation.id,
+      retainedText,
+      retainedClientId,
+      "text",
+      { operationId: retainedOperationId, kind: "send", policy: "queue" },
+    )).toMatchObject({ state: "failed", text: retainedText });
+    expect(Object.values(store.snapshot().heldDeliveries)
+      .some((delivery) => delivery.command.operationId === retainedOperationId)).toBeFalse();
+    expect(() => store.holdDelivery(
+      conversation.id,
+      `${retainedText} changed`,
+      retainedClientId,
+      "text",
+      { operationId: retainedOperationId, kind: "send", policy: "queue" },
+    )).toThrow("operation id is already reserved for another client message");
+    const unrelated = store.ensureConversation("codex", `/sessions/unrelated-${backend}.jsonl`, "default");
+    expect(() => store.holdDelivery(
+      unrelated.id,
+      retainedText,
+      retainedClientId,
+      "text",
+      { operationId: retainedOperationId, kind: "send", policy: "queue" },
+    )).toThrow("operation id is already reserved for another client message");
+  }
 });
 
 test("dual-write leaves both backends unchanged after a no-op mutation", () => {

--- a/src/lib/agent/registry.sqlite.test.ts
+++ b/src/lib/agent/registry.sqlite.test.ts
@@ -116,6 +116,38 @@ test("dual-write keeps JSON authoritative and SQLite reads require parity", () =
   expect(() => new AgentRegistry(filename, undefined, undefined, { sqliteMode: "read" })).toThrow(RegistryParityError);
 });
 
+test("SQLite restart normalizes legacy held-delivery rows before parity", () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-registry-sqlite-held-upgrade-"));
+  const filename = path.join(directory, "agent-registry.json");
+  const sqliteFilename = path.join(directory, "agent-registry.sqlite");
+  const sqlite = new AgentRegistry(filename, undefined, undefined, { sqliteMode: "sqlite" });
+  const conversation = sqlite.ensureConversation("codex", "/sessions/legacy-held.jsonl", "default");
+  const reserved = sqlite.holdDelivery(conversation.id, "continue after SQLite upgrade", "legacy-sqlite-held");
+
+  const db = new Database(sqliteFilename);
+  const stored = db.query<{ value_json: string }, [string, string]>(
+    "SELECT value_json FROM registry_rows WHERE collection = ? AND row_key = ?",
+  ).get("heldDeliveries", reserved.id);
+  if (!stored) throw new Error("expected the held-delivery SQLite row");
+  const legacy = JSON.parse(stored.value_json) as Partial<typeof reserved>;
+  delete legacy.command;
+  delete legacy.requestDigest;
+  db.query("UPDATE registry_rows SET value_json = ? WHERE collection = ? AND row_key = ?")
+    .run(JSON.stringify(legacy), "heldDeliveries", reserved.id);
+  db.close();
+
+  const restarted = new AgentRegistry(filename, undefined, undefined, { sqliteMode: "sqlite" });
+  expect(restarted.pendingDeliveries(conversation.id)[0]).toMatchObject({
+    id: reserved.id,
+    command: {
+      operationId: reserved.id,
+      kind: "send",
+      policy: "interrupt-active",
+    },
+    requestDigest: expect.any(String),
+  });
+});
+
 test("dual-write leaves both backends unchanged after a no-op mutation", () => {
   const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-registry-sqlite-noop-"));
   const filename = path.join(directory, "agent-registry.json");

--- a/src/lib/agent/registry.sqlite.test.ts
+++ b/src/lib/agent/registry.sqlite.test.ts
@@ -148,6 +148,66 @@ test("SQLite restart normalizes legacy held-delivery rows before parity", () => 
   });
 });
 
+test("SQLite restart derives and persists explicit operation ownership before tombstone compaction", () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-registry-sqlite-operation-owner-"));
+  const filename = path.join(directory, "agent-registry.json");
+  const sqliteFilename = path.join(directory, "agent-registry.sqlite");
+  const sqlite = new AgentRegistry(filename, undefined, undefined, { sqliteMode: "sqlite" });
+  const conversation = sqlite.ensureConversation("codex", "/sessions/sqlite-operation-owner.jsonl", "default");
+  const command = { operationId: "sqlite-operation-owner", kind: "send" as const, policy: "queue" as const };
+  const original = sqlite.holdDelivery(
+    conversation.id,
+    "retain SQLite operation ownership",
+    "sqlite-operation-owner-client",
+    "text",
+    command,
+  );
+  const claimed = sqlite.beginDeliveryAttempt(original.id, original.generationId!);
+  expect(claimed).not.toBeNull();
+  sqlite.recordDeliveryOutcome(original.id, "delivered");
+
+  const legacyDb = new Database(sqliteFilename);
+  legacyDb.query("DELETE FROM registry_rows WHERE collection = ?").run("deliveryOperationOwners");
+  legacyDb.close();
+
+  const restarted = new AgentRegistry(filename, undefined, undefined, { sqliteMode: "sqlite" });
+  expect(restarted.snapshot().deliveryOperationOwners[command.operationId]).toMatchObject({
+    clientMessageId: "sqlite-operation-owner-client",
+    deliveryId: original.id,
+    command,
+  });
+  for (let index = 0; index < 101; index += 1) {
+    const delivery = restarted.holdDelivery(
+      conversation.id,
+      `later SQLite delivery ${index}`,
+      `later-sqlite-delivery-${index}`,
+    );
+    restarted.recordDeliveryOutcome(delivery.id, "delivered");
+  }
+  expect(restarted.snapshot().heldDeliveries[original.id]).toBeUndefined();
+
+  const persistedDb = new Database(sqliteFilename, { readonly: true });
+  expect(persistedDb.query<{ count: number }, [string, string]>(
+    "SELECT COUNT(*) AS count FROM registry_rows WHERE collection = ? AND row_key = ?",
+  ).get("deliveryOperationOwners", command.operationId)?.count).toBe(1);
+  persistedDb.close();
+  const reopened = new AgentRegistry(filename, undefined, undefined, { sqliteMode: "sqlite" });
+  expect(() => reopened.holdDelivery(
+    conversation.id,
+    "retain SQLite operation ownership",
+    "second-sqlite-operation-owner-client",
+    "text",
+    command,
+  )).toThrow("operation id is already reserved for another client message");
+  expect(reopened.holdDelivery(
+    conversation.id,
+    "retain SQLite operation ownership",
+    "sqlite-operation-owner-client",
+    "text",
+    command,
+  )).toMatchObject({ id: original.id, state: "delivered", attempts: claimed!.attempts, command });
+});
+
 test("dual-write leaves both backends unchanged after a no-op mutation", () => {
   const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-registry-sqlite-noop-"));
   const filename = path.join(directory, "agent-registry.json");

--- a/src/lib/agent/registry.test.ts
+++ b/src/lib/agent/registry.test.ts
@@ -104,7 +104,7 @@ describe("agent registry", () => {
         assignedAt: null,
         deliveredAt: `2026-07-11T00:${String(Math.floor(index / 60)).padStart(2, "0")}:${String(index % 60).padStart(2, "0")}.000Z`,
         error: null,
-      };
+      } as unknown as (typeof snapshot.heldDeliveries)[string];
     }
     fs.writeFileSync(store.filename, JSON.stringify(snapshot));
 
@@ -116,6 +116,36 @@ describe("agent registry", () => {
     expect(retained.every((delivery) => delivery.text === "")).toBe(true);
     expect(retained.map((delivery) => delivery.id)).not.toContain("legacy-000");
     expect(retained.map((delivery) => delivery.id)).toContain("legacy-104");
+  });
+
+  test("reopening an old text-only reservation applies safe command defaults", () => {
+    const store = registry();
+    const conversation = store.ensureConversation("codex", "/legacy-text-only-delivery.jsonl", "default");
+    const reserved = store.holdDelivery(conversation.id, "continue after upgrade", "legacy-text-only-message");
+    const snapshot = store.snapshot();
+    const legacy = snapshot.heldDeliveries[reserved.id]! as Partial<typeof reserved>;
+    delete legacy.command;
+    delete legacy.requestDigest;
+    fs.writeFileSync(store.filename, JSON.stringify(snapshot));
+
+    const reopened = new AgentRegistry(store.filename);
+    const normalized = reopened.pendingDeliveries(conversation.id)[0]!;
+
+    expect(normalized).toMatchObject({
+      id: reserved.id,
+      text: "continue after upgrade",
+      command: {
+        operationId: reserved.id,
+        kind: "send",
+        policy: "interrupt-active",
+      },
+      requestDigest: expect.any(String),
+    });
+    expect(reopened.holdDelivery(
+      conversation.id,
+      "continue after upgrade",
+      "legacy-text-only-message",
+    ).id).toBe(reserved.id);
   });
 
   test("startup compaction bounds abandoned failed reservations and leaves capacity", () => {
@@ -2519,7 +2549,7 @@ describe("agent registry", () => {
       role: "reviewer",
       reviewsConversationId: provisional.id,
     });
-    const held = store.holdDelivery(provisional.id, "deliver after migration");
+    const held = store.holdDelivery(provisional.id, "deliver after migration", "provisional-migration-message");
     store.reconcileConversations([{
       engine: "claude",
       path: "/child.jsonl",
@@ -2561,6 +2591,7 @@ describe("agent registry", () => {
       reviewsConversationId: original.id,
     });
     expect(snapshot.heldDeliveries[held.id]).toMatchObject({ conversationId: original.id });
+    expect(store.holdDelivery(original.id, "deliver after migration", "provisional-migration-message").id).toBe(held.id);
     expect(store.conversationForPath("/child.jsonl")?.generations[0]?.launchProfile.parentConversationId).toBe(original.id);
     expect(snapshot.conversationAliases[provisional.id]).toBe(original.id);
     expect(store.canonicalConversationId(provisional.id)).toBe(original.id);

--- a/src/lib/agent/registry.test.ts
+++ b/src/lib/agent/registry.test.ts
@@ -213,6 +213,41 @@ describe("agent registry", () => {
     )).toMatchObject({ id: original.id, state: "assigned" });
   });
 
+  test("retrying a failed explicit operation restores active ownership across compaction and restart", () => {
+    const store = registry();
+    const conversation = store.ensureConversation("codex", "/operation-owner-failed-retry.jsonl", "default");
+    const command = { operationId: "operation-owner-failed-retry", kind: "send" as const, policy: "queue" as const };
+    const original = store.holdDelivery(
+      conversation.id,
+      "retry this operation",
+      "operation-owner-failed-retry-client",
+      "text",
+      command,
+    );
+    expect(store.beginDeliveryAttempt(original.id, original.generationId!)).not.toBeNull();
+    store.recordDeliveryOutcome(original.id, "failed", "host unavailable");
+    expect(store.snapshot().deliveryOperationOwners[command.operationId]?.terminalState).toBe("failed");
+
+    expect(store.holdDelivery(
+      conversation.id,
+      "retry this operation",
+      "operation-owner-failed-retry-client",
+      "text",
+      command,
+    )).toMatchObject({ id: original.id, state: "assigned" });
+    store.compactDeliveryReservations();
+
+    expect(store.snapshot().deliveryOperationOwners[command.operationId]).toMatchObject({
+      deliveryId: original.id,
+      terminalState: null,
+    });
+    const reopened = new AgentRegistry(store.filename);
+    expect(reopened.snapshot().deliveryOperationOwners[command.operationId]).toMatchObject({
+      deliveryId: original.id,
+      terminalState: null,
+    });
+  });
+
   test("discarding an unactuated explicit reservation releases its operation ownership", () => {
     const store = registry();
     const conversation = store.ensureConversation("codex", "/operation-owner-discard.jsonl", "default");

--- a/src/lib/agent/registry.test.ts
+++ b/src/lib/agent/registry.test.ts
@@ -146,6 +146,11 @@ describe("agent registry", () => {
       store.recordDeliveryOutcome(delivery.id, "delivered");
     }
     expect(store.snapshot().heldDeliveries[original.id]).toBeUndefined();
+    expect(store.snapshot().deliveryOperationOwners[command.operationId]).toMatchObject({
+      terminalState: "delivered",
+      requestDigest: original.requestDigest,
+    });
+    expect(store.snapshot().deliveryOperationOwners[command.operationId]).not.toHaveProperty("settledDelivery");
 
     const reopened = new AgentRegistry(store.filename);
     expect(() => reopened.holdDelivery(
@@ -166,8 +171,46 @@ describe("agent registry", () => {
       command,
       requestDigest: original.requestDigest,
       state: "delivered",
-      attempts: claimed!.attempts,
     });
+  });
+
+  test("legacy terminal owner normalization rejects a mismatched settled snapshot", () => {
+    const store = registry();
+    const conversation = store.ensureConversation("codex", "/operation-owner-legacy-mismatch.jsonl", "default");
+    const command = { operationId: "operation-owner-legacy-mismatch", kind: "send" as const, policy: "queue" as const };
+    const original = store.holdDelivery(
+      conversation.id,
+      "keep this operation active",
+      "operation-owner-legacy-mismatch-client",
+      "text",
+      command,
+    );
+    const unrelated = store.holdDelivery(conversation.id, "unrelated terminal payload", "unrelated-terminal-client");
+    store.recordDeliveryOutcome(unrelated.id, "delivered");
+    const snapshot = store.snapshot();
+    const legacyOwner = snapshot.deliveryOperationOwners[command.operationId] as unknown as {
+      createdAt?: string;
+      terminalState?: string | null;
+      settledDelivery?: typeof unrelated;
+    };
+    delete legacyOwner.createdAt;
+    delete legacyOwner.terminalState;
+    legacyOwner.settledDelivery = snapshot.heldDeliveries[unrelated.id];
+    fs.writeFileSync(store.filename, JSON.stringify(snapshot));
+
+    const reopened = new AgentRegistry(store.filename);
+
+    expect(reopened.snapshot().deliveryOperationOwners[command.operationId]).toMatchObject({
+      deliveryId: original.id,
+      terminalState: null,
+    });
+    expect(reopened.holdDelivery(
+      conversation.id,
+      "keep this operation active",
+      "operation-owner-legacy-mismatch-client",
+      "text",
+      command,
+    )).toMatchObject({ id: original.id, state: "assigned" });
   });
 
   test("discarding an unactuated explicit reservation releases its operation ownership", () => {

--- a/src/lib/agent/registry.test.ts
+++ b/src/lib/agent/registry.test.ts
@@ -2549,7 +2549,18 @@ describe("agent registry", () => {
       role: "reviewer",
       reviewsConversationId: provisional.id,
     });
-    const held = store.holdDelivery(provisional.id, "deliver after migration", "provisional-migration-message");
+    const held = store.holdDelivery(
+      provisional.id,
+      "deliver after migration",
+      "provisional-migration-message",
+      "text",
+      {
+        operationId: "operation-provisional-migration-message",
+        kind: "steer",
+        policy: "steer-if-active",
+        turnId: "turn-before-provisional-adoption",
+      },
+    );
     store.reconcileConversations([{
       engine: "claude",
       path: "/child.jsonl",
@@ -2590,13 +2601,39 @@ describe("agent registry", () => {
       parentConversationId: caller.id,
       reviewsConversationId: original.id,
     });
-    expect(snapshot.heldDeliveries[held.id]).toMatchObject({ conversationId: original.id });
-    expect(store.holdDelivery(original.id, "deliver after migration", "provisional-migration-message").id).toBe(held.id);
+    expect(snapshot.heldDeliveries[held.id]).toMatchObject({
+      conversationId: original.id,
+      command: held.command,
+      requestDigest: held.requestDigest,
+    });
+    const matchingRetry = store.holdDelivery(
+      provisional.id,
+      "deliver after migration",
+      "provisional-migration-message",
+      "text",
+      { ...held.command, operationId: "operation-from-matching-alias-retry" },
+    );
+    expect(matchingRetry).toMatchObject({ id: held.id, command: held.command, requestDigest: held.requestDigest });
+    expect(() => store.holdDelivery(
+      original.id,
+      "deliver after migration",
+      "second-client-provisional-migration-message",
+      "text",
+      held.command,
+    )).toThrow("operation id is already reserved for another client message");
     expect(store.conversationForPath("/child.jsonl")?.generations[0]?.launchProfile.parentConversationId).toBe(original.id);
     expect(snapshot.conversationAliases[provisional.id]).toBe(original.id);
     expect(store.canonicalConversationId(provisional.id)).toBe(original.id);
     expect(store.conversation(provisional.id)?.id).toBe(original.id);
-    expect(new AgentRegistry(store.filename).conversation(provisional.id)?.id).toBe(original.id);
+    const reopened = new AgentRegistry(store.filename);
+    expect(reopened.conversation(provisional.id)?.id).toBe(original.id);
+    expect(() => reopened.holdDelivery(
+      provisional.id,
+      "deliver after migration",
+      "third-client-provisional-migration-message",
+      "text",
+      held.command,
+    )).toThrow("operation id is already reserved for another client message");
   });
 
   test("normalizes a legacy receipt after restart without changing its schema version", () => {

--- a/src/lib/agent/registry.test.ts
+++ b/src/lib/agent/registry.test.ts
@@ -118,6 +118,87 @@ describe("agent registry", () => {
     expect(retained.map((delivery) => delivery.id)).toContain("legacy-104");
   });
 
+  test("compaction retains explicit operation ownership after its delivery tombstone expires", () => {
+    const store = registry();
+    const conversation = store.ensureConversation("codex", "/operation-owner-compaction.jsonl", "default");
+    const command = {
+      operationId: "operation-owner-before-compaction",
+      kind: "steer" as const,
+      policy: "steer-if-active" as const,
+      turnId: "turn-before-compaction",
+    };
+    const original = store.holdDelivery(
+      conversation.id,
+      "retain operation ownership",
+      "operation-owner-client",
+      "text",
+      command,
+    );
+    const claimed = store.beginDeliveryAttempt(original.id, original.generationId!);
+    expect(claimed).not.toBeNull();
+    store.recordDeliveryOutcome(original.id, "delivered");
+    for (let index = 0; index < 101; index += 1) {
+      const delivery = store.holdDelivery(
+        conversation.id,
+        `later delivery ${index}`,
+        `later-delivery-${index}`,
+      );
+      store.recordDeliveryOutcome(delivery.id, "delivered");
+    }
+    expect(store.snapshot().heldDeliveries[original.id]).toBeUndefined();
+
+    const reopened = new AgentRegistry(store.filename);
+    expect(() => reopened.holdDelivery(
+      conversation.id,
+      "retain operation ownership",
+      "second-operation-owner-client",
+      "text",
+      command,
+    )).toThrow("operation id is already reserved for another client message");
+    expect(reopened.holdDelivery(
+      conversation.id,
+      "retain operation ownership",
+      "operation-owner-client",
+      "text",
+      command,
+    )).toMatchObject({
+      id: original.id,
+      command,
+      requestDigest: original.requestDigest,
+      state: "delivered",
+      attempts: claimed!.attempts,
+    });
+  });
+
+  test("discarding an unactuated explicit reservation releases its operation ownership", () => {
+    const store = registry();
+    const conversation = store.ensureConversation("codex", "/operation-owner-discard.jsonl", "default");
+    const command = { operationId: "operation-owner-before-discard", kind: "send" as const, policy: "queue" as const };
+    const original = store.holdDelivery(
+      conversation.id,
+      "discard before actuation",
+      "operation-owner-before-discard-client",
+      "text",
+      command,
+    );
+    expect(store.snapshot().deliveryOperationOwners[command.operationId]?.deliveryId).toBe(original.id);
+
+    store.discardDelivery(original.id);
+
+    expect(store.snapshot().deliveryOperationOwners[command.operationId]).toBeUndefined();
+    const replacement = store.holdDelivery(
+      conversation.id,
+      "reuse after discard",
+      "operation-owner-after-discard-client",
+      "text",
+      command,
+    );
+    expect(replacement).toMatchObject({ clientMessageId: "operation-owner-after-discard-client", command });
+    expect(store.beginDeliveryAttempt(replacement.id, replacement.generationId!)).not.toBeNull();
+    store.discardDelivery(replacement.id);
+    expect(store.snapshot().deliveryOperationOwners[command.operationId]?.deliveryId).toBe(replacement.id);
+  });
+
   test("reopening an old text-only reservation applies safe command defaults", () => {
     const store = registry();
     const conversation = store.ensureConversation("codex", "/legacy-text-only-delivery.jsonl", "default");

--- a/src/lib/agent/registry.ts
+++ b/src/lib/agent/registry.ts
@@ -12,6 +12,8 @@ import {
   type ConversationMigration,
   type DurableQuotaObservation,
   type HeldDelivery,
+  type HeldDeliveryCommand,
+  type HeldDeliveryCommandInput,
   type LaunchProfile,
   type MigrationIntent,
   type MigrationOrigin,
@@ -567,6 +569,13 @@ export class MigrationRevisionError extends Error {
   }
 }
 
+export class DeliveryReservationConflictError extends Error {
+  constructor() {
+    super("client message id is already reserved for another request");
+    this.name = "DeliveryReservationConflictError";
+  }
+}
+
 const LEGACY_POLICY_RESTARTED_AT = "1970-01-01T00:00:00.000Z";
 
 function emptyPolicy(restartedAt = now()): AutoBalancePolicy {
@@ -863,16 +872,69 @@ function normalizePolicy(value: AutoBalancePolicy | undefined): AutoBalancePolic
   };
 }
 
+function canonicalHeldDeliveryCommand(
+  value: HeldDeliveryCommandInput | HeldDeliveryCommand | undefined,
+  deliveryId: string,
+): HeldDeliveryCommand {
+  const command: HeldDeliveryCommand = {
+    operationId: value?.operationId || deliveryId,
+    kind: value?.kind === "steer" ? "steer" : "send",
+    policy: value?.policy === "queue" || value?.policy === "steer-if-active"
+      ? value.policy
+      : "interrupt-active",
+  };
+  if (value?.turnId === null || typeof value?.turnId === "string") command.turnId = value.turnId;
+  return command;
+}
+
+function heldDeliveryRequestDigest(
+  conversationId: ViewerConversationId,
+  text: string,
+  command: Pick<HeldDeliveryCommand, "kind" | "policy" | "turnId">,
+): string {
+  const turnFence = command.turnId === undefined
+    ? ["absent"]
+    : ["present", command.turnId];
+  return crypto.createHash("sha256").update(JSON.stringify([
+    "held-delivery-request-v1",
+    conversationId,
+    text,
+    command.kind,
+    command.policy,
+    turnFence,
+  ])).digest("hex");
+}
+
+function heldDeliveryRequestDigests(
+  file: RegistryFile,
+  conversationId: ViewerConversationId,
+  text: string,
+  command: Pick<HeldDeliveryCommand, "kind" | "policy" | "turnId">,
+): Set<string> {
+  const identities = new Set<ViewerConversationId>([conversationId]);
+  for (const alias of Object.keys(file.conversationAliases) as ViewerConversationId[]) {
+    if (resolveConversationAlias(file, alias) === conversationId) identities.add(alias);
+  }
+  return new Set([...identities].map((identity) => heldDeliveryRequestDigest(identity, text, command)));
+}
+
 function normalizeHeldDelivery(value: HeldDelivery): HeldDelivery {
   const state = value.state ?? "held";
+  const text = typeof value.text === "string" ? value.text : "";
+  const command = canonicalHeldDeliveryCommand(value.command, value.id);
+  const legacyDigest = text
+    ? heldDeliveryRequestDigest(value.conversationId, text, command)
+    : null;
   return {
     ...value,
-    text: state === "delivered" ? "" : value.text,
+    text: state === "delivered" ? "" : text,
     clientMessageId: value.clientMessageId ?? null,
     payloadKind: value.payloadKind ?? "text",
     artifactPaths: Array.isArray(value.artifactPaths)
       ? value.artifactPaths.filter((pathname): pathname is string => typeof pathname === "string")
       : [],
+    command,
+    requestDigest: typeof value.requestDigest === "string" ? value.requestDigest : legacyDigest,
     state,
     generationId: value.generationId ?? null,
     attempts: Number.isInteger(value.attempts) ? value.attempts : 0,
@@ -3663,11 +3725,17 @@ export class AgentRegistry {
     text: string,
     clientMessageId: string | null = null,
     payloadKind: HeldDelivery["payloadKind"] = "text",
+    commandInput: HeldDeliveryCommandInput = {},
   ): HeldDelivery {
     if (payloadKind === "text" && (!text || text.length > 32_000)) throw new Error("held delivery must contain at most 32000 characters");
     return this.mutate((file) => {
       const canonicalId = resolveConversationAlias(file, conversationId);
       const existing = clientMessageId ? Object.values(file.heldDeliveries).find((item) => item.conversationId === canonicalId && item.clientMessageId === clientMessageId) : undefined;
+      const requestedCommand = canonicalHeldDeliveryCommand(commandInput, existing?.id ?? "pending-delivery");
+      const requestDigest = heldDeliveryRequestDigest(canonicalId, text, requestedCommand);
+      if (existing && !heldDeliveryRequestDigests(file, canonicalId, text, requestedCommand).has(existing.requestDigest ?? "")) {
+        throw new DeliveryReservationConflictError();
+      }
       const conversation = file.conversations[canonicalId];
       const paths = new Set([conversation?.generations.at(-1)?.path].filter((pathname): pathname is string => Boolean(pathname)));
       const signature = conversation ? migrationReadinessSignature(file, conversation.engine, paths) : "";
@@ -3696,14 +3764,17 @@ export class AgentRegistry {
         return clone(delivery);
       };
       if (existing) return place(existing);
+      const deliveryId = crypto.randomUUID();
       const held: HeldDelivery = {
-        id: crypto.randomUUID(),
+        id: deliveryId,
         conversationId: canonicalId,
         text,
         createdAt: now(),
         clientMessageId,
         payloadKind,
         artifactPaths: [],
+        command: canonicalHeldDeliveryCommand(commandInput, deliveryId),
+        requestDigest,
         state: "held",
         generationId: null,
         attempts: 0,

--- a/src/lib/agent/registry.ts
+++ b/src/lib/agent/registry.ts
@@ -238,7 +238,8 @@ export interface DeliveryOperationOwner {
   deliveryId: string;
   command: HeldDeliveryCommand;
   requestDigest: string;
-  settledDelivery?: HeldDelivery;
+  createdAt: string;
+  terminalState: Extract<HeldDelivery["state"], "delivered" | "failed"> | null;
 }
 
 export interface RegistryFile {
@@ -959,6 +960,12 @@ function normalizeHeldDelivery(value: HeldDelivery): HeldDelivery {
   };
 }
 
+function terminalDeliveryState(
+  delivery: HeldDelivery | null | undefined,
+): Extract<HeldDelivery["state"], "delivered" | "failed"> | null {
+  return delivery?.state === "delivered" || delivery?.state === "failed" ? delivery.state : null;
+}
+
 function normalizeDeliveryOperationOwners(
   value: unknown,
   heldDeliveries: RegistryFile["heldDeliveries"],
@@ -967,11 +974,24 @@ function normalizeDeliveryOperationOwners(
   if (value && typeof value === "object" && !Array.isArray(value)) {
     for (const [operationId, candidate] of Object.entries(value)) {
       if (!operationId || !candidate || typeof candidate !== "object" || Array.isArray(candidate)) continue;
-      const owner = candidate as Partial<DeliveryOperationOwner>;
+      const owner = candidate as Partial<DeliveryOperationOwner> & { settledDelivery?: HeldDelivery };
       if (typeof owner.conversationId !== "string" || !owner.conversationId.startsWith("conversation_")
         || (owner.clientMessageId !== null && typeof owner.clientMessageId !== "string")
         || typeof owner.deliveryId !== "string" || !owner.deliveryId
         || typeof owner.requestDigest !== "string" || !owner.requestDigest) continue;
+      const settledCandidate = owner.settledDelivery && typeof owner.settledDelivery === "object"
+        ? normalizeHeldDelivery(owner.settledDelivery)
+        : null;
+      const settledDelivery = settledCandidate?.id === owner.deliveryId
+        && settledCandidate.command.operationId === operationId
+        && settledCandidate.requestDigest === owner.requestDigest
+        && terminalDeliveryState(settledCandidate) !== null
+        ? settledCandidate
+        : null;
+      const referencedDelivery = heldDeliveries[owner.deliveryId];
+      const terminalState = owner.terminalState === "delivered" || owner.terminalState === "failed"
+        ? owner.terminalState
+        : terminalDeliveryState(settledDelivery) ?? terminalDeliveryState(referencedDelivery);
       owners[operationId] = {
         conversationId: owner.conversationId as ViewerConversationId,
         runtimeConversationId: typeof owner.runtimeConversationId === "string" && owner.runtimeConversationId.startsWith("conversation_")
@@ -981,16 +1001,11 @@ function normalizeDeliveryOperationOwners(
         deliveryId: owner.deliveryId,
         command: { ...canonicalHeldDeliveryCommand(owner.command, operationId), operationId },
         requestDigest: owner.requestDigest,
+        createdAt: typeof owner.createdAt === "string"
+          ? owner.createdAt
+          : referencedDelivery?.createdAt ?? settledDelivery?.createdAt ?? LEGACY_POLICY_RESTARTED_AT,
+        terminalState,
       };
-      if (owner.settledDelivery && typeof owner.settledDelivery === "object") {
-        const settledDelivery = normalizeHeldDelivery(owner.settledDelivery);
-        if (settledDelivery.id === owner.deliveryId
-          && settledDelivery.command.operationId === operationId
-          && settledDelivery.requestDigest === owner.requestDigest
-          && ["delivered", "failed"].includes(settledDelivery.state)) {
-          owners[operationId].settledDelivery = settledDelivery;
-        }
-      }
     }
   }
   for (const delivery of Object.values(heldDeliveries)) {
@@ -1002,22 +1017,50 @@ function normalizeDeliveryOperationOwners(
       deliveryId: delivery.id,
       command: delivery.command,
       requestDigest: delivery.requestDigest,
+      createdAt: delivery.createdAt,
+      terminalState: terminalDeliveryState(delivery),
     };
   }
   return owners;
 }
 
+const DELIVERY_OPERATION_OWNER_TERMINAL_LIMIT = 200;
+
+function compactDeliveryOperationOwners(file: RegistryFile, onlyConversationId?: ViewerConversationId): void {
+  const terminalGroups = new Map<ViewerConversationId, Array<[string, DeliveryOperationOwner]>>();
+  for (const [operationId, owner] of Object.entries(file.deliveryOperationOwners)) {
+    if (owner.terminalState === null) continue;
+    const canonicalId = resolveConversationAlias(file, owner.conversationId);
+    if (onlyConversationId && canonicalId !== resolveConversationAlias(file, onlyConversationId)) continue;
+    const group = terminalGroups.get(canonicalId) ?? [];
+    group.push([operationId, owner]);
+    terminalGroups.set(canonicalId, group);
+  }
+  for (const owners of terminalGroups.values()) {
+    owners.sort(([leftId, left], [rightId, right]) =>
+      right.createdAt.localeCompare(left.createdAt) || rightId.localeCompare(leftId));
+    for (const [operationId] of owners.slice(DELIVERY_OPERATION_OWNER_TERMINAL_LIMIT)) {
+      delete file.deliveryOperationOwners[operationId];
+    }
+  }
+}
+
 function compactDeliveryReservations(file: RegistryFile, onlyConversationId?: ViewerConversationId): number {
   for (const delivery of Object.values(file.heldDeliveries)) {
     if (delivery.command.operationId === delivery.id || !delivery.requestDigest) continue;
-    file.deliveryOperationOwners[delivery.command.operationId] ??= {
+    const owner = file.deliveryOperationOwners[delivery.command.operationId] ??= {
       conversationId: delivery.conversationId,
       runtimeConversationId: delivery.runtimeConversationId,
       clientMessageId: delivery.clientMessageId,
       deliveryId: delivery.id,
       command: delivery.command,
       requestDigest: delivery.requestDigest,
+      createdAt: delivery.createdAt,
+      terminalState: null,
     };
+    if (owner.deliveryId === delivery.id && (delivery.state === "delivered" || delivery.state === "failed")) {
+      owner.terminalState = delivery.state;
+    }
   }
   const deliveredGroups = new Map<ViewerConversationId, HeldDelivery[]>();
   const failedGroups = new Map<ViewerConversationId, HeldDelivery[]>();
@@ -1036,14 +1079,9 @@ function compactDeliveryReservations(file: RegistryFile, onlyConversationId?: Vi
     }
   }
   let removed = 0;
-  const retainSettledOwner = (delivery: HeldDelivery): void => {
-    const owner = file.deliveryOperationOwners[delivery.command.operationId];
-    if (owner?.deliveryId === delivery.id) owner.settledDelivery = clone(delivery);
-  };
   for (const deliveries of deliveredGroups.values()) {
     deliveries.sort((left, right) => (right.deliveredAt ?? right.createdAt).localeCompare(left.deliveredAt ?? left.createdAt) || right.id.localeCompare(left.id));
     for (const expired of deliveries.slice(100)) {
-      retainSettledOwner(expired);
       delete file.heldDeliveries[expired.id];
       removed += 1;
     }
@@ -1055,11 +1093,11 @@ function compactDeliveryReservations(file: RegistryFile, onlyConversationId?: Vi
     const retainedFailed = Math.max(0, Math.min(50, 99 - activeCount));
     deliveries.sort((left, right) => right.createdAt.localeCompare(left.createdAt) || right.id.localeCompare(left.id));
     for (const expired of deliveries.slice(retainedFailed)) {
-      retainSettledOwner(expired);
       delete file.heldDeliveries[expired.id];
       removed += 1;
     }
   }
+  compactDeliveryOperationOwners(file, onlyConversationId);
   return removed;
 }
 
@@ -1273,7 +1311,6 @@ function adoptProvisionalOwner(
   for (const operationOwner of Object.values(file.deliveryOperationOwners)) {
     if (operationOwner.conversationId === owner.id) {
       operationOwner.conversationId = target.id;
-      if (operationOwner.settledDelivery) operationOwner.settledDelivery.conversationId = target.id;
     }
   }
   for (const entry of Object.values(file.entries)) {
@@ -3825,7 +3862,7 @@ export class AgentRegistry {
       const requestedCommand = canonicalHeldDeliveryCommand(commandInput, existing?.id ?? "pending-delivery");
       const requestDigest = heldDeliveryRequestDigest(canonicalId, text, requestedCommand);
       const requestedDigests = heldDeliveryRequestDigests(file, canonicalId, text, requestedCommand);
-      let settledOperationRetry: HeldDelivery | null = null;
+      let terminalOperationRetry: DeliveryOperationOwner | null = null;
       if (existing && !requestedDigests.has(existing.requestDigest ?? "")) {
         throw new DeliveryReservationConflictError();
       }
@@ -3840,6 +3877,8 @@ export class AgentRegistry {
             deliveryId: ownedDelivery.id,
             command: ownedDelivery.command,
             requestDigest: ownedDelivery.requestDigest,
+            createdAt: ownedDelivery.createdAt,
+            terminalState: terminalDeliveryState(ownedDelivery),
           } : null);
         const matchingOwner = operationOwner
           && resolveConversationAlias(file, operationOwner.conversationId) === canonicalId
@@ -3848,9 +3887,7 @@ export class AgentRegistry {
         if (operationOwner && !matchingOwner) {
           throw new DeliveryReservationConflictError("operation id is already reserved for another client message");
         }
-        if (matchingOwner && operationOwner.settledDelivery) {
-          settledOperationRetry = clone(operationOwner.settledDelivery);
-        }
+        if (matchingOwner && operationOwner.terminalState) terminalOperationRetry = clone(operationOwner);
       }
       const conversation = file.conversations[canonicalId];
       const paths = new Set([conversation?.generations.at(-1)?.path].filter((pathname): pathname is string => Boolean(pathname)));
@@ -3880,9 +3917,27 @@ export class AgentRegistry {
         return clone(delivery);
       };
       if (existing) return place(existing);
-      if (settledOperationRetry) {
-        file.heldDeliveries[settledOperationRetry.id] = settledOperationRetry;
-        return place(settledOperationRetry);
+      if (terminalOperationRetry) {
+        const terminalState = terminalOperationRetry.terminalState;
+        if (terminalState === null) throw new Error("terminal operation replay state is missing");
+        return {
+          id: terminalOperationRetry.deliveryId,
+          conversationId: canonicalId,
+          runtimeConversationId: terminalOperationRetry.runtimeConversationId,
+          text,
+          createdAt: terminalOperationRetry.createdAt,
+          clientMessageId,
+          payloadKind,
+          artifactPaths: [],
+          command: terminalOperationRetry.command,
+          requestDigest: terminalOperationRetry.requestDigest,
+          state: terminalState,
+          generationId: null,
+          attempts: 0,
+          assignedAt: null,
+          deliveredAt: terminalState === "delivered" ? terminalOperationRetry.createdAt : null,
+          error: terminalState === "failed" ? "delivery failed" : null,
+        };
       }
       const deliveryId = crypto.randomUUID();
       const held: HeldDelivery = {
@@ -3915,6 +3970,8 @@ export class AgentRegistry {
           deliveryId: held.id,
           command: held.command,
           requestDigest: held.requestDigest!,
+          createdAt: held.createdAt,
+          terminalState: null,
         };
       }
       return place(held);

--- a/src/lib/agent/registry.ts
+++ b/src/lib/agent/registry.ts
@@ -233,6 +233,7 @@ export interface RegistryConversation {
 
 export interface DeliveryOperationOwner {
   conversationId: ViewerConversationId;
+  runtimeConversationId: ViewerConversationId;
   clientMessageId: string | null;
   deliveryId: string;
   command: HeldDeliveryCommand;
@@ -938,6 +939,9 @@ function normalizeHeldDelivery(value: HeldDelivery): HeldDelivery {
     : null;
   return {
     ...value,
+    runtimeConversationId: typeof value.runtimeConversationId === "string" && value.runtimeConversationId.startsWith("conversation_")
+      ? value.runtimeConversationId as ViewerConversationId
+      : value.conversationId,
     text: state === "delivered" ? "" : text,
     clientMessageId: value.clientMessageId ?? null,
     payloadKind: value.payloadKind ?? "text",
@@ -970,6 +974,9 @@ function normalizeDeliveryOperationOwners(
         || typeof owner.requestDigest !== "string" || !owner.requestDigest) continue;
       owners[operationId] = {
         conversationId: owner.conversationId as ViewerConversationId,
+        runtimeConversationId: typeof owner.runtimeConversationId === "string" && owner.runtimeConversationId.startsWith("conversation_")
+          ? owner.runtimeConversationId as ViewerConversationId
+          : heldDeliveries[owner.deliveryId]?.runtimeConversationId ?? owner.conversationId as ViewerConversationId,
         clientMessageId: owner.clientMessageId,
         deliveryId: owner.deliveryId,
         command: { ...canonicalHeldDeliveryCommand(owner.command, operationId), operationId },
@@ -990,6 +997,7 @@ function normalizeDeliveryOperationOwners(
     if (delivery.command.operationId === delivery.id || !delivery.requestDigest) continue;
     owners[delivery.command.operationId] ??= {
       conversationId: delivery.conversationId,
+      runtimeConversationId: delivery.runtimeConversationId,
       clientMessageId: delivery.clientMessageId,
       deliveryId: delivery.id,
       command: delivery.command,
@@ -1004,6 +1012,7 @@ function compactDeliveryReservations(file: RegistryFile, onlyConversationId?: Vi
     if (delivery.command.operationId === delivery.id || !delivery.requestDigest) continue;
     file.deliveryOperationOwners[delivery.command.operationId] ??= {
       conversationId: delivery.conversationId,
+      runtimeConversationId: delivery.runtimeConversationId,
       clientMessageId: delivery.clientMessageId,
       deliveryId: delivery.id,
       command: delivery.command,
@@ -3826,6 +3835,7 @@ export class AgentRegistry {
         const operationOwner = file.deliveryOperationOwners[requestedCommand.operationId]
           ?? (ownedDelivery?.requestDigest ? {
             conversationId: ownedDelivery.conversationId,
+            runtimeConversationId: ownedDelivery.runtimeConversationId,
             clientMessageId: ownedDelivery.clientMessageId,
             deliveryId: ownedDelivery.id,
             command: ownedDelivery.command,
@@ -3878,6 +3888,7 @@ export class AgentRegistry {
       const held: HeldDelivery = {
         id: deliveryId,
         conversationId: canonicalId,
+        runtimeConversationId: canonicalId,
         text,
         createdAt: now(),
         clientMessageId,
@@ -3899,6 +3910,7 @@ export class AgentRegistry {
       if (commandInput.operationId) {
         file.deliveryOperationOwners[held.command.operationId] ??= {
           conversationId: canonicalId,
+          runtimeConversationId: held.runtimeConversationId,
           clientMessageId,
           deliveryId: held.id,
           command: held.command,

--- a/src/lib/agent/registry.ts
+++ b/src/lib/agent/registry.ts
@@ -570,8 +570,8 @@ export class MigrationRevisionError extends Error {
 }
 
 export class DeliveryReservationConflictError extends Error {
-  constructor() {
-    super("client message id is already reserved for another request");
+  constructor(message = "client message id is already reserved for another request") {
+    super(message);
     this.name = "DeliveryReservationConflictError";
   }
 }
@@ -3730,11 +3730,20 @@ export class AgentRegistry {
     if (payloadKind === "text" && (!text || text.length > 32_000)) throw new Error("held delivery must contain at most 32000 characters");
     return this.mutate((file) => {
       const canonicalId = resolveConversationAlias(file, conversationId);
-      const existing = clientMessageId ? Object.values(file.heldDeliveries).find((item) => item.conversationId === canonicalId && item.clientMessageId === clientMessageId) : undefined;
+      const existing = clientMessageId ? Object.values(file.heldDeliveries).find((item) =>
+        resolveConversationAlias(file, item.conversationId) === canonicalId
+        && item.clientMessageId === clientMessageId) : undefined;
       const requestedCommand = canonicalHeldDeliveryCommand(commandInput, existing?.id ?? "pending-delivery");
       const requestDigest = heldDeliveryRequestDigest(canonicalId, text, requestedCommand);
       if (existing && !heldDeliveryRequestDigests(file, canonicalId, text, requestedCommand).has(existing.requestDigest ?? "")) {
         throw new DeliveryReservationConflictError();
+      }
+      if (!existing && commandInput.operationId) {
+        const operationOwner = Object.values(file.heldDeliveries).find((item) =>
+          item.command.operationId === requestedCommand.operationId);
+        if (operationOwner) {
+          throw new DeliveryReservationConflictError("operation id is already reserved for another client message");
+        }
       }
       const conversation = file.conversations[canonicalId];
       const paths = new Set([conversation?.generations.at(-1)?.path].filter((pathname): pathname is string => Boolean(pathname)));

--- a/src/lib/agent/registry.ts
+++ b/src/lib/agent/registry.ts
@@ -966,6 +966,11 @@ function terminalDeliveryState(
   return delivery?.state === "delivered" || delivery?.state === "failed" ? delivery.state : null;
 }
 
+function syncDeliveryOperationOwnerState(file: RegistryFile, delivery: HeldDelivery): void {
+  const owner = file.deliveryOperationOwners[delivery.command.operationId];
+  if (owner?.deliveryId === delivery.id) owner.terminalState = terminalDeliveryState(delivery);
+}
+
 function normalizeDeliveryOperationOwners(
   value: unknown,
   heldDeliveries: RegistryFile["heldDeliveries"],
@@ -988,10 +993,16 @@ function normalizeDeliveryOperationOwners(
         && terminalDeliveryState(settledCandidate) !== null
         ? settledCandidate
         : null;
-      const referencedDelivery = heldDeliveries[owner.deliveryId];
-      const terminalState = owner.terminalState === "delivered" || owner.terminalState === "failed"
-        ? owner.terminalState
-        : terminalDeliveryState(settledDelivery) ?? terminalDeliveryState(referencedDelivery);
+      const referencedCandidate = heldDeliveries[owner.deliveryId];
+      const referencedDelivery = referencedCandidate?.command.operationId === operationId
+        && referencedCandidate.requestDigest === owner.requestDigest
+        ? referencedCandidate
+        : null;
+      const terminalState = referencedDelivery
+        ? terminalDeliveryState(referencedDelivery)
+        : owner.terminalState === "delivered" || owner.terminalState === "failed"
+          ? owner.terminalState
+          : terminalDeliveryState(settledDelivery);
       owners[operationId] = {
         conversationId: owner.conversationId as ViewerConversationId,
         runtimeConversationId: typeof owner.runtimeConversationId === "string" && owner.runtimeConversationId.startsWith("conversation_")
@@ -1048,7 +1059,7 @@ function compactDeliveryOperationOwners(file: RegistryFile, onlyConversationId?:
 function compactDeliveryReservations(file: RegistryFile, onlyConversationId?: ViewerConversationId): number {
   for (const delivery of Object.values(file.heldDeliveries)) {
     if (delivery.command.operationId === delivery.id || !delivery.requestDigest) continue;
-    const owner = file.deliveryOperationOwners[delivery.command.operationId] ??= {
+    file.deliveryOperationOwners[delivery.command.operationId] ??= {
       conversationId: delivery.conversationId,
       runtimeConversationId: delivery.runtimeConversationId,
       clientMessageId: delivery.clientMessageId,
@@ -1058,9 +1069,7 @@ function compactDeliveryReservations(file: RegistryFile, onlyConversationId?: Vi
       createdAt: delivery.createdAt,
       terminalState: null,
     };
-    if (owner.deliveryId === delivery.id && (delivery.state === "delivered" || delivery.state === "failed")) {
-      owner.terminalState = delivery.state;
-    }
+    syncDeliveryOperationOwnerState(file, delivery);
   }
   const deliveredGroups = new Map<ViewerConversationId, HeldDelivery[]>();
   const failedGroups = new Map<ViewerConversationId, HeldDelivery[]>();
@@ -3360,6 +3369,7 @@ export class AgentRegistry {
             delivery.generationId = source.id;
             delivery.assignedAt = changedAt;
             delivery.error = null;
+            syncDeliveryOperationOwnerState(file, delivery);
           }
         }
         conversation.migration = null;
@@ -3433,6 +3443,7 @@ export class AgentRegistry {
               delivery.generationId = source.id;
               delivery.assignedAt = changedAt;
               delivery.error = null;
+              syncDeliveryOperationOwnerState(file, delivery);
             }
             conversation.migration = null;
             conversation.updatedAt = changedAt;
@@ -3719,6 +3730,7 @@ export class AgentRegistry {
         delivery.generationId = generation.id;
         delivery.assignedAt = committedAt;
         delivery.error = null;
+        syncDeliveryOperationOwnerState(file, delivery);
       }
       file.conversationRevision[conversation.engine] += 1;
       file.engineRouting[conversation.engine].revision += 1;
@@ -3759,6 +3771,7 @@ export class AgentRegistry {
             delivery.generationId = source.id;
             delivery.assignedAt = intent.updatedAt;
             delivery.error = null;
+            syncDeliveryOperationOwnerState(file, delivery);
           }
         }
       }
@@ -3896,7 +3909,10 @@ export class AgentRegistry {
         && ["requested", "preparing", "successor-starting", "verifying"].includes(conversation.migration.phase);
       const current = conversation?.generations.at(-1);
       const place = (delivery: HeldDelivery): HeldDelivery => {
-        if (delivery.state === "delivered" || delivery.state === "delivery-uncertain") return clone(delivery);
+        if (delivery.state === "delivered" || delivery.state === "delivery-uncertain") {
+          syncDeliveryOperationOwnerState(file, delivery);
+          return clone(delivery);
+        }
         delivery.deliveredAt = null;
         delivery.error = null;
         if (migrationBlocksDelivery) {
@@ -3913,6 +3929,7 @@ export class AgentRegistry {
           delivery.assignedAt = null;
           delivery.error = "delivery target is unavailable and remains recoverable";
         }
+        syncDeliveryOperationOwnerState(file, delivery);
         if (conversation) advanceMigrationScopeRevision(file, conversation.engine, signature, paths);
         return clone(delivery);
       };
@@ -4023,6 +4040,7 @@ export class AgentRegistry {
       delivery.state = "delivery-uncertain";
       delivery.attempts += 1;
       delivery.error = "delivery started; recovery requires an explicit outcome";
+      syncDeliveryOperationOwnerState(file, delivery);
       if (conversation) advanceMigrationScopeRevision(file, conversation.engine, signature, paths);
       return clone(delivery);
     });
@@ -4118,6 +4136,7 @@ export class AgentRegistry {
         delivery.assignedAt = null;
         delivery.deliveredAt = null;
         delivery.error = null;
+        syncDeliveryOperationOwnerState(file, delivery);
         if (conversation) advanceMigrationScopeRevision(file, conversation.engine, signature, paths);
         return clone(delivery);
       }
@@ -4126,6 +4145,7 @@ export class AgentRegistry {
         delivery.state = "failed";
         delivery.deliveredAt = null;
         delivery.error = "delivery target is unavailable and remains recoverable";
+        syncDeliveryOperationOwnerState(file, delivery);
         if (conversation) advanceMigrationScopeRevision(file, conversation.engine, signature, paths);
         return clone(delivery);
       }
@@ -4134,6 +4154,7 @@ export class AgentRegistry {
       delivery.assignedAt = now();
       delivery.deliveredAt = null;
       delivery.error = null;
+      syncDeliveryOperationOwnerState(file, delivery);
       if (conversation) advanceMigrationScopeRevision(file, conversation.engine, signature, paths);
       return clone(delivery);
     });
@@ -4165,6 +4186,7 @@ export class AgentRegistry {
         delivery.generationId = source.id;
         delivery.assignedAt = rolledAt;
         delivery.error = null;
+        syncDeliveryOperationOwnerState(file, delivery);
       }
       conversation.migration = { ...conversation.migration, phase: "rolled-back", error: null, errorCode: null, updatedAt: rolledAt };
       conversation.updatedAt = rolledAt;

--- a/src/lib/agent/registry.ts
+++ b/src/lib/agent/registry.ts
@@ -231,6 +231,15 @@ export interface RegistryConversation {
   updatedAt: string;
 }
 
+export interface DeliveryOperationOwner {
+  conversationId: ViewerConversationId;
+  clientMessageId: string | null;
+  deliveryId: string;
+  command: HeldDeliveryCommand;
+  requestDigest: string;
+  settledDelivery?: HeldDelivery;
+}
+
 export interface RegistryFile {
   version: 2;
   entries: Record<string, AgentRegistryEntry>;
@@ -251,6 +260,7 @@ export interface RegistryFile {
   autoBalance: Record<Extract<AgentEngine, "claude" | "codex">, AutoBalancePolicy>;
   quotaObservations: Record<Extract<AgentEngine, "claude" | "codex">, Record<string, DurableQuotaObservation>>;
   heldDeliveries: Record<string, HeldDelivery>;
+  deliveryOperationOwners: Record<string, DeliveryOperationOwner>;
   pendingSuccessorCleanups: Record<string, { conversationId: ViewerConversationId; receipt: ProviderReceipt; createdAt: string; lastError: string | null }>;
 }
 
@@ -608,6 +618,7 @@ const EMPTY: RegistryFile = {
   autoBalance: { claude: emptyPolicy(), codex: emptyPolicy() },
   quotaObservations: { claude: {}, codex: {} },
   heldDeliveries: {},
+  deliveryOperationOwners: {},
   pendingSuccessorCleanups: {},
 };
 
@@ -944,7 +955,61 @@ function normalizeHeldDelivery(value: HeldDelivery): HeldDelivery {
   };
 }
 
+function normalizeDeliveryOperationOwners(
+  value: unknown,
+  heldDeliveries: RegistryFile["heldDeliveries"],
+): RegistryFile["deliveryOperationOwners"] {
+  const owners: RegistryFile["deliveryOperationOwners"] = {};
+  if (value && typeof value === "object" && !Array.isArray(value)) {
+    for (const [operationId, candidate] of Object.entries(value)) {
+      if (!operationId || !candidate || typeof candidate !== "object" || Array.isArray(candidate)) continue;
+      const owner = candidate as Partial<DeliveryOperationOwner>;
+      if (typeof owner.conversationId !== "string" || !owner.conversationId.startsWith("conversation_")
+        || (owner.clientMessageId !== null && typeof owner.clientMessageId !== "string")
+        || typeof owner.deliveryId !== "string" || !owner.deliveryId
+        || typeof owner.requestDigest !== "string" || !owner.requestDigest) continue;
+      owners[operationId] = {
+        conversationId: owner.conversationId as ViewerConversationId,
+        clientMessageId: owner.clientMessageId,
+        deliveryId: owner.deliveryId,
+        command: { ...canonicalHeldDeliveryCommand(owner.command, operationId), operationId },
+        requestDigest: owner.requestDigest,
+      };
+      if (owner.settledDelivery && typeof owner.settledDelivery === "object") {
+        const settledDelivery = normalizeHeldDelivery(owner.settledDelivery);
+        if (settledDelivery.id === owner.deliveryId
+          && settledDelivery.command.operationId === operationId
+          && settledDelivery.requestDigest === owner.requestDigest
+          && ["delivered", "failed"].includes(settledDelivery.state)) {
+          owners[operationId].settledDelivery = settledDelivery;
+        }
+      }
+    }
+  }
+  for (const delivery of Object.values(heldDeliveries)) {
+    if (delivery.command.operationId === delivery.id || !delivery.requestDigest) continue;
+    owners[delivery.command.operationId] ??= {
+      conversationId: delivery.conversationId,
+      clientMessageId: delivery.clientMessageId,
+      deliveryId: delivery.id,
+      command: delivery.command,
+      requestDigest: delivery.requestDigest,
+    };
+  }
+  return owners;
+}
+
 function compactDeliveryReservations(file: RegistryFile, onlyConversationId?: ViewerConversationId): number {
+  for (const delivery of Object.values(file.heldDeliveries)) {
+    if (delivery.command.operationId === delivery.id || !delivery.requestDigest) continue;
+    file.deliveryOperationOwners[delivery.command.operationId] ??= {
+      conversationId: delivery.conversationId,
+      clientMessageId: delivery.clientMessageId,
+      deliveryId: delivery.id,
+      command: delivery.command,
+      requestDigest: delivery.requestDigest,
+    };
+  }
   const deliveredGroups = new Map<ViewerConversationId, HeldDelivery[]>();
   const failedGroups = new Map<ViewerConversationId, HeldDelivery[]>();
   for (const delivery of Object.values(file.heldDeliveries)) {
@@ -962,9 +1027,14 @@ function compactDeliveryReservations(file: RegistryFile, onlyConversationId?: Vi
     }
   }
   let removed = 0;
+  const retainSettledOwner = (delivery: HeldDelivery): void => {
+    const owner = file.deliveryOperationOwners[delivery.command.operationId];
+    if (owner?.deliveryId === delivery.id) owner.settledDelivery = clone(delivery);
+  };
   for (const deliveries of deliveredGroups.values()) {
     deliveries.sort((left, right) => (right.deliveredAt ?? right.createdAt).localeCompare(left.deliveredAt ?? left.createdAt) || right.id.localeCompare(left.id));
     for (const expired of deliveries.slice(100)) {
+      retainSettledOwner(expired);
       delete file.heldDeliveries[expired.id];
       removed += 1;
     }
@@ -976,6 +1046,7 @@ function compactDeliveryReservations(file: RegistryFile, onlyConversationId?: Vi
     const retainedFailed = Math.max(0, Math.min(50, 99 - activeCount));
     deliveries.sort((left, right) => right.createdAt.localeCompare(left.createdAt) || right.id.localeCompare(left.id));
     for (const expired of deliveries.slice(retainedFailed)) {
+      retainSettledOwner(expired);
       delete file.heldDeliveries[expired.id];
       removed += 1;
     }
@@ -1021,6 +1092,7 @@ function conversationDurabilityScore(file: RegistryFile, conversation: RegistryC
   for (const edge of Object.values(file.lineageEdges)) if (edge.parentConversationId === conversation.id) score += 5;
   if (file.memberships[conversation.id]?.length) score += 10;
   for (const delivery of Object.values(file.heldDeliveries)) if (delivery.conversationId === conversation.id) score += 5;
+  for (const owner of Object.values(file.deliveryOperationOwners)) if (owner.conversationId === conversation.id) score += 5;
   return score;
 }
 
@@ -1189,6 +1261,12 @@ function adoptProvisionalOwner(
   for (const delivery of Object.values(file.heldDeliveries)) {
     if (delivery.conversationId === owner.id) delivery.conversationId = target.id;
   }
+  for (const operationOwner of Object.values(file.deliveryOperationOwners)) {
+    if (operationOwner.conversationId === owner.id) {
+      operationOwner.conversationId = target.id;
+      if (operationOwner.settledDelivery) operationOwner.settledDelivery.conversationId = target.id;
+    }
+  }
   for (const entry of Object.values(file.entries)) {
     if (entry.launchProfile?.parentConversationId === owner.id) {
       entry.launchProfile = { ...entry.launchProfile, parentConversationId: target.id };
@@ -1285,6 +1363,9 @@ export function normalizeRegistry(value: unknown): RegistryFile {
     throw new RegistryReadError("agent registry schema is unsupported");
   }
   const legacy = parsed.legacyResumePanes;
+  const heldDeliveries = parsed.heldDeliveries && typeof parsed.heldDeliveries === "object"
+    ? Object.fromEntries(Object.entries(parsed.heldDeliveries).map(([id, delivery]) => [id, normalizeHeldDelivery(delivery)]))
+    : {};
   return {
       version: 2,
       entries: Object.fromEntries(Object.entries(parsed.entries).map(([id, entry]) => [id, normalizeEntry(entry)])),
@@ -1317,9 +1398,8 @@ export function normalizeRegistry(value: unknown): RegistryFile {
       quotaObservations: parsed.quotaObservations && typeof parsed.quotaObservations === "object"
         ? { ...EMPTY.quotaObservations, ...parsed.quotaObservations }
         : clone(EMPTY.quotaObservations),
-      heldDeliveries: parsed.heldDeliveries && typeof parsed.heldDeliveries === "object"
-        ? Object.fromEntries(Object.entries(parsed.heldDeliveries).map(([id, delivery]) => [id, normalizeHeldDelivery(delivery)]))
-        : {},
+      heldDeliveries,
+      deliveryOperationOwners: normalizeDeliveryOperationOwners(parsed.deliveryOperationOwners, heldDeliveries),
       pendingSuccessorCleanups: parsed.pendingSuccessorCleanups && typeof parsed.pendingSuccessorCleanups === "object"
         ? parsed.pendingSuccessorCleanups
         : {},
@@ -3735,14 +3815,31 @@ export class AgentRegistry {
         && item.clientMessageId === clientMessageId) : undefined;
       const requestedCommand = canonicalHeldDeliveryCommand(commandInput, existing?.id ?? "pending-delivery");
       const requestDigest = heldDeliveryRequestDigest(canonicalId, text, requestedCommand);
-      if (existing && !heldDeliveryRequestDigests(file, canonicalId, text, requestedCommand).has(existing.requestDigest ?? "")) {
+      const requestedDigests = heldDeliveryRequestDigests(file, canonicalId, text, requestedCommand);
+      let settledOperationRetry: HeldDelivery | null = null;
+      if (existing && !requestedDigests.has(existing.requestDigest ?? "")) {
         throw new DeliveryReservationConflictError();
       }
       if (!existing && commandInput.operationId) {
-        const operationOwner = Object.values(file.heldDeliveries).find((item) =>
+        const ownedDelivery = Object.values(file.heldDeliveries).find((item) =>
           item.command.operationId === requestedCommand.operationId);
-        if (operationOwner) {
+        const operationOwner = file.deliveryOperationOwners[requestedCommand.operationId]
+          ?? (ownedDelivery?.requestDigest ? {
+            conversationId: ownedDelivery.conversationId,
+            clientMessageId: ownedDelivery.clientMessageId,
+            deliveryId: ownedDelivery.id,
+            command: ownedDelivery.command,
+            requestDigest: ownedDelivery.requestDigest,
+          } : null);
+        const matchingOwner = operationOwner
+          && resolveConversationAlias(file, operationOwner.conversationId) === canonicalId
+          && operationOwner.clientMessageId === clientMessageId
+          && requestedDigests.has(operationOwner.requestDigest);
+        if (operationOwner && !matchingOwner) {
           throw new DeliveryReservationConflictError("operation id is already reserved for another client message");
+        }
+        if (matchingOwner && operationOwner.settledDelivery) {
+          settledOperationRetry = clone(operationOwner.settledDelivery);
         }
       }
       const conversation = file.conversations[canonicalId];
@@ -3773,6 +3870,10 @@ export class AgentRegistry {
         return clone(delivery);
       };
       if (existing) return place(existing);
+      if (settledOperationRetry) {
+        file.heldDeliveries[settledOperationRetry.id] = settledOperationRetry;
+        return place(settledOperationRetry);
+      }
       const deliveryId = crypto.randomUUID();
       const held: HeldDelivery = {
         id: deliveryId,
@@ -3795,6 +3896,15 @@ export class AgentRegistry {
       const count = Object.values(file.heldDeliveries).filter((item) => item.conversationId === canonicalId && item.state !== "delivered").length;
       if (count >= 100) throw new Error("held delivery limit reached for conversation");
       file.heldDeliveries[held.id] = held;
+      if (commandInput.operationId) {
+        file.deliveryOperationOwners[held.command.operationId] ??= {
+          conversationId: canonicalId,
+          clientMessageId,
+          deliveryId: held.id,
+          command: held.command,
+          requestDigest: held.requestDigest!,
+        };
+      }
       return place(held);
     });
   }
@@ -3894,6 +4004,12 @@ export class AgentRegistry {
       const conversation = delivery ? file.conversations[resolveConversationAlias(file, delivery.conversationId)] : undefined;
       const paths = new Set([conversation?.generations.at(-1)?.path].filter((pathname): pathname is string => Boolean(pathname)));
       const signature = conversation ? migrationReadinessSignature(file, conversation.engine, paths) : "";
+      if (delivery) {
+        const operationOwner = file.deliveryOperationOwners[delivery.command.operationId];
+        if (delivery.attempts === 0 && operationOwner?.deliveryId === delivery.id) {
+          delete file.deliveryOperationOwners[delivery.command.operationId];
+        }
+      }
       delete file.heldDeliveries[id];
       if (conversation) advanceMigrationScopeRevision(file, conversation.engine, signature, paths);
     });

--- a/src/lib/agent/sqliteRegistryStore.ts
+++ b/src/lib/agent/sqliteRegistryStore.ts
@@ -15,6 +15,7 @@ const ROW_COLLECTIONS = [
   "conversationAliases",
   "migrationIntents",
   "heldDeliveries",
+  "deliveryOperationOwners",
   "pendingSuccessorCleanups",
 ] as const satisfies ReadonlyArray<keyof RegistryFile>;
 
@@ -222,10 +223,13 @@ export class SqliteAgentRegistryStore {
         }
         const input: Record<string, unknown> = { version: 2, entries: {}, receipts: {} };
         input[collection] = storedValue;
+        if (collection === "deliveryOperationOwners") input.heldDeliveries = file.heldDeliveries;
         value = this.normalize(input)[collection] as typeof value;
         loaded = true;
         loadedCollections.set(collection, value);
-        baselineCollections.set(collection, structuredClone(value));
+        baselineCollections.set(collection, structuredClone(
+          collection === "deliveryOperationOwners" ? storedValue : value,
+        ) as typeof value);
       };
       Object.defineProperty(file, collection, {
         configurable: true,

--- a/src/lib/agent/sqliteRegistryStore.ts
+++ b/src/lib/agent/sqliteRegistryStore.ts
@@ -214,12 +214,15 @@ export class SqliteAgentRegistryStore {
       let value = file[collection];
       const load = () => {
         if (loaded) return;
-        value = {} as typeof value;
+        const storedValue = {} as typeof value;
         for (const row of this.db.query<StoredRow, [string]>(
           "SELECT collection, row_key, value_json, row_order FROM registry_rows WHERE collection = ? ORDER BY row_order",
         ).all(collection)) {
-          (value as Record<string, unknown>)[row.row_key] = JSON.parse(row.value_json);
+          (storedValue as Record<string, unknown>)[row.row_key] = JSON.parse(row.value_json);
         }
+        const input: Record<string, unknown> = { version: 2, entries: {}, receipts: {} };
+        input[collection] = storedValue;
+        value = this.normalize(input)[collection] as typeof value;
         loaded = true;
         loadedCollections.set(collection, value);
         baselineCollections.set(collection, structuredClone(value));

--- a/src/lib/delivery.test.ts
+++ b/src/lib/delivery.test.ts
@@ -713,7 +713,9 @@ test("delivered reservations retain only a bounded idempotency window", () => {
   const tombstones = Object.values(registry.snapshot().heldDeliveries);
   expect(tombstones).toHaveLength(100);
   expect(tombstones.every((delivery) => delivery.state === "delivered" && delivery.text === "")).toBe(true);
-  expect(registry.holdDelivery(conversation.id, "replayed body", "message-104")).toMatchObject({ state: "delivered", text: "" });
+  expect(registry.holdDelivery(conversation.id, "message body 104", "message-104")).toMatchObject({ state: "delivered", text: "" });
+  expect(() => registry.holdDelivery(conversation.id, "changed body", "message-104"))
+    .toThrow("client message id is already reserved for another request");
 });
 
 test("an image-only migration race stays recoverable without an orphan reservation", async () => {

--- a/src/lib/runtime/http.test.ts
+++ b/src/lib/runtime/http.test.ts
@@ -74,6 +74,41 @@ test("runtime command routes fail closed while activation is disabled", async ()
   expect(await response.json()).toEqual({ error: "runtime events are disabled" });
 });
 
+test("direct runtime send reaches durable admission while the runtime socket synchronizes", async () => {
+  const admissions: unknown[] = [];
+  const response = await handleRuntimeCommand(
+    request({
+      conversationId: "conversation_sync_window",
+      text: "retain this first message",
+      idempotencyKey: "sync-window-send",
+    }),
+    "send",
+    {
+      enabled: () => true,
+      structuredEnabled: () => true,
+      client: () => null,
+      enqueue: async (input) => {
+        admissions.push(input);
+        return {
+          ok: true,
+          structured: true,
+          target: "conversation_sync_window",
+          outcome: "held",
+        };
+      },
+    },
+  );
+
+  expect(response.status).toBe(202);
+  expect(await response.json()).toEqual({ held: true });
+  expect(admissions).toMatchObject([{
+    conversationId: "conversation_sync_window",
+    clientMessageId: "sync-window-send",
+    kind: "send",
+    text: "retain this first message",
+  }]);
+});
+
 test("direct structured commands stop before runtime admission when hosting is disabled", async () => {
   const commands: unknown[] = [];
   const client = {

--- a/src/lib/runtime/http.ts
+++ b/src/lib/runtime/http.ts
@@ -70,7 +70,6 @@ export async function handleRuntimeCommand(
     return NextResponse.json({ error: error instanceof Error ? error.message : "runtime command is invalid" }, { status: 400 });
   }
   const client = dependencies.client();
-  if (!client) return NextResponse.json({ error: "runtime host socket is unavailable" }, { status: 503 });
   try {
     if ((command.kind === "send" || command.kind === "steer") && dependencies.enqueue) {
       const admitted = await dependencies.enqueue({
@@ -102,6 +101,7 @@ export async function handleRuntimeCommand(
         return NextResponse.json({ operationId: admitted.operationId, receipt: admitted.receipt }, { status });
       }
     }
+    if (!client) return NextResponse.json({ error: "runtime host socket is unavailable" }, { status: 503 });
     const result = await client.command(command);
     if (result.receipt.status === "pending" || result.receipt.status === "queued") {
       dependencies.kick?.();

--- a/src/lib/runtime/startup.test.ts
+++ b/src/lib/runtime/startup.test.ts
@@ -4,15 +4,18 @@ import path from "node:path";
 import { expect, test } from "bun:test";
 
 import { emptyLaunchProfile } from "@/lib/accounts/migration/contracts";
+import { drainHeldDeliveries } from "@/lib/accounts/migration/coordinator";
 import { AgentRegistry } from "@/lib/agent/registry";
 import { RuntimeJournal } from "@/runtime-host/journal";
+import { runStructuredHostStartup } from "@/instrumentation";
 
-import type { RuntimeHostClient } from "./client";
-import { bindStructuredDeliveryQueue } from "./structuredDeliveryController";
+import { RuntimeHostUnavailableError, type RuntimeHostClient } from "./client";
+import { bindStructuredDeliveryQueue, hasStructuredDeliveryHost } from "./structuredDeliveryController";
 import { createFakeDeliveryLedger, FakeEngineHost } from "./fixtures/fakeEngineHost";
 import type { StructuredHostAdoptionFilter } from "./registry";
-import { enqueueStructuredMessage } from "./structuredMessageDelivery";
-import { adoptStructuredHostsAtStartup, type StructuredStartupDependencies } from "./startup";
+import { deliverHeldStructuredMessage, enqueueStructuredMessage } from "./structuredMessageDelivery";
+import { didStructuredHostStartupFail } from "./startupStatus";
+import { adoptStructuredHostsAtStartup, structuredStartupHosts, type StructuredStartupDependencies } from "./startup";
 
 function runtimeClient(journal: RuntimeJournal): RuntimeHostClient {
   return {
@@ -357,6 +360,125 @@ test.each(["codex", "claude"] as const)("successful %s restart adoption publishe
   await bindStructuredDeliveryQueue([], { registry, client: null });
   journal.close();
   fs.rmSync(directory, { recursive: true, force: true });
+});
+
+test("startup socket recovery retains a partially adopted host and drains its held send once", async () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-runtime-startup-partial-adoption-"));
+  const { artifactPath, conversation, registry, sessionId } = structuredRestartFixture(directory, "codex", "unhosted");
+  const journal = new RuntimeJournal(path.join(directory, "runtime.sqlite"), { structuredHosts: true });
+  const client = runtimeJournalClient(journal);
+  const key = { engine: "codex" as const, sessionId };
+  const operationId = "operation-partial-adoption-held-send";
+  const held = registry.holdDelivery(
+    conversation.id,
+    "deliver after partial startup adoption",
+    "partial-adoption-held-send",
+    "text",
+    { operationId, kind: "send", policy: "queue", turnId: null },
+  );
+  const ledger = createFakeDeliveryLedger();
+  const listeners = new Set<() => void>();
+  const host = Object.assign(new FakeEngineHost(ledger), {
+    onStateChange: () => {
+      const listener = () => {};
+      listeners.add(listener);
+      return () => { listeners.delete(listener); };
+    },
+  });
+  const scheduled: Array<() => void> = [];
+  let adoptedProcesses = 0;
+  let effectCalls = 0;
+  const startupClient = {
+    ...client,
+    producerCursor: async (producerKind: string, eventKeyPrefix: string) =>
+      journal.producerCursor(producerKind, eventKeyPrefix),
+    effectBatch: async (kinds?: readonly string[], afterEventSeq?: number) => {
+      effectCalls += 1;
+      if (effectCalls === 2) {
+        throw new RuntimeHostUnavailableError("runtime socket failed after host adoption");
+      }
+      return journal.effectBatch(100, kinds, afterEventSeq);
+    },
+  } as RuntimeHostClient;
+  const dependencies: StructuredStartupDependencies = {
+    registry,
+    client: startupClient,
+    adopt: async (received, _optionsFor, _env, shouldAdopt = () => true) => {
+      const entry = received.snapshot().entries[`codex:${sessionId}`];
+      if (!entry || !shouldAdopt(entry) || adoptedProcesses > 0) return [];
+      const processIdentity = { pid: process.pid, startIdentity: "partial-adoption-process" };
+      const claimed = received.claimStructuredHost(key, processIdentity, { allowUnhosted: true });
+      if (!claimed?.structuredHost || !claimed.claimOwner) throw new Error("partial adoption claim was unavailable");
+      const persisted = received.setStructuredHostClaimed(key, {
+        ...claimed.structuredHost,
+        endpoint: "fake:partial-adoption",
+        process: processIdentity,
+      }, "idle", claimed.claimOwner, claimed.claimEpoch);
+      if (!persisted) throw new Error("partial adoption writer claim was lost");
+      adoptedProcesses += 1;
+      return [{ key, host: host as never }];
+    },
+    adoptClaude: async () => [],
+  };
+
+  try {
+    await runStructuredHostStartup(
+      () => adoptStructuredHostsAtStartup(dependencies),
+      () => {},
+      {
+        schedule: (callback) => {
+          scheduled.push(callback);
+          return { unref() {} };
+        },
+      },
+    );
+
+    expect(adoptedProcesses).toBe(1);
+    expect(scheduled).toHaveLength(1);
+    scheduled.shift()!();
+    await waitFor(() => !didStructuredHostStartupFail());
+    expect(hasStructuredDeliveryHost(key)).toBe(true);
+
+    await drainHeldDeliveries(conversation.id, {
+      deliver: async ({ delivery, path: deliveryPath, clientMessageId }) =>
+        await deliverHeldStructuredMessage({
+          conversationId: conversation.id,
+          path: deliveryPath,
+          deliveryId: delivery.id,
+          clientMessageId,
+          text: delivery.text,
+          command: delivery.command,
+        }, {
+          enabled: () => true,
+          client: () => startupClient,
+          registry: () => registry,
+        }) ?? "delivery-uncertain",
+    }, registry);
+    await drainHeldDeliveries(conversation.id, {
+      deliver: async () => { throw new Error("delivered hold must not drain twice"); },
+    }, registry);
+
+    expect(structuredStartupHosts()).toMatchObject([{ key, host }]);
+    expect(ledger.writes).toEqual([{
+      id: operationId,
+      text: "deliver after partial startup adoption",
+      expectedTurnId: null,
+    }]);
+    expect(registry.snapshot().heldDeliveries[held.id]).toMatchObject({ state: "delivered", text: "" });
+    expect(listeners.size).toBe(1);
+    expect(adoptedProcesses).toBe(1);
+    expect(registry.snapshot().entries[`codex:${sessionId}`]).toMatchObject({
+      claimOwner: expect.any(String),
+      structuredHost: {
+        process: { pid: process.pid, startIdentity: "partial-adoption-process" },
+        writerClaimEpoch: expect.any(Number),
+      },
+    });
+  } finally {
+    await bindStructuredDeliveryQueue([], { registry, client: null });
+    journal.close();
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
 });
 
 test("terminal structured row with a cleared ownership marker stays outside startup adoption", async () => {

--- a/src/lib/runtime/startup.test.ts
+++ b/src/lib/runtime/startup.test.ts
@@ -364,7 +364,7 @@ test.each(["codex", "claude"] as const)("successful %s restart adoption publishe
 
 test("startup socket recovery retains a partially adopted host and drains its held send once", async () => {
   const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-runtime-startup-partial-adoption-"));
-  const { artifactPath, conversation, registry, sessionId } = structuredRestartFixture(directory, "codex", "unhosted");
+  const { conversation, registry, sessionId } = structuredRestartFixture(directory, "codex", "unhosted");
   const journal = new RuntimeJournal(path.join(directory, "runtime.sqlite"), { structuredHosts: true });
   const client = runtimeJournalClient(journal);
   const key = { engine: "codex" as const, sessionId };

--- a/src/lib/runtime/startup.ts
+++ b/src/lib/runtime/startup.ts
@@ -20,6 +20,19 @@ import { recoverPendingStructuredSpawns } from "./structuredSpawn";
 
 type AdoptedStructuredHost = AdoptedCodexHost | AdoptedClaudeHost;
 let adoptedHosts: AdoptedStructuredHost[] = [];
+let retryAdoptedHosts: AdoptedStructuredHost[] = [];
+
+function retainAdoptedHosts(
+  retained: readonly AdoptedStructuredHost[],
+  adopted: readonly AdoptedStructuredHost[],
+): AdoptedStructuredHost[] {
+  const hosts = new Map(retained.map((item) => [sessionKeyId(item.key), item]));
+  for (const item of adopted) {
+    const key = sessionKeyId(item.key);
+    if (!hosts.has(key)) hosts.set(key, item);
+  }
+  return [...hosts.values()];
+}
 
 const RUNTIME_EFFECT_PAGE_SIZE = 100;
 const STRUCTURED_HOST_OPERATION_EFFECT_KINDS = [
@@ -133,6 +146,7 @@ export async function adoptStructuredHostsAtStartup(
   dependencies: StructuredStartupDependencies = {},
 ): Promise<AdoptedStructuredHost[]> {
   assertDarwinStructuredRuntime();
+  let nextAdoptedHosts = retryAdoptedHosts;
   const registry = dependencies.registry ?? agentRegistry();
   const client = dependencies.client === undefined ? runtimeHostClient() : dependencies.client;
   const signals = await structuredStartupSignals(registry, client);
@@ -158,6 +172,8 @@ export async function adoptStructuredHostsAtStartup(
     process.env,
     shouldAdopt,
   );
+  nextAdoptedHosts = retainAdoptedHosts(nextAdoptedHosts, codex);
+  retryAdoptedHosts = nextAdoptedHosts;
   const claude = await (dependencies.adoptClaude ?? adoptClaudeRegistryHosts)(
     registry,
     (entry) => {
@@ -181,10 +197,13 @@ export async function adoptStructuredHostsAtStartup(
     process.env,
     shouldAdopt,
   );
-  adoptedHosts = [...codex, ...claude];
+  nextAdoptedHosts = retainAdoptedHosts(nextAdoptedHosts, claude);
+  retryAdoptedHosts = nextAdoptedHosts;
   await demoteSkippedStructuredRegistryHosts(registry, shouldAdopt);
-  await bindStructuredDeliveryQueue(adoptedHosts, { registry: dependencies.registry, client });
+  await bindStructuredDeliveryQueue(nextAdoptedHosts, { registry: dependencies.registry, client });
   if (client) await recoverPendingStructuredSpawns(registry, client);
+  adoptedHosts = nextAdoptedHosts;
+  retryAdoptedHosts = [];
   return adoptedHosts;
 }
 

--- a/src/lib/runtime/structuredDelivery.integration.test.ts
+++ b/src/lib/runtime/structuredDelivery.integration.test.ts
@@ -5,7 +5,7 @@ import path from "node:path";
 import { afterAll, expect, test } from "bun:test";
 
 import { AgentRegistry } from "@/lib/agent/registry";
-import { reconcileMigrations } from "@/lib/accounts/migration/coordinator";
+import { drainHeldDeliveries, reconcileMigrations, type HeldDeliveryPort } from "@/lib/accounts/migration/coordinator";
 import { emptyLaunchProfile, type ProviderReceipt, type SuccessorProviderPort } from "@/lib/accounts/migration/contracts";
 import { RegisteredSuccessorProvider } from "@/lib/accounts/migration/provider";
 import { RuntimeJournal } from "@/runtime-host/journal";
@@ -872,6 +872,153 @@ test("a failed idle send retry keeps its null turn fence when another turn start
     turnId: null,
     reason: "stale-turn",
   });
+  journal.close();
+});
+
+test("runtime recovery drains one durable synchronization hold into one engine command", async () => {
+  const sessionId = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+  const directory = path.join(sandbox, "runtime-synchronization-hold");
+  const artifactPath = path.join(directory, `${sessionId}.jsonl`);
+  const registry = new AgentRegistry(path.join(directory, "agent-registry.json"));
+  const profile = emptyLaunchProfile({ cwd: directory });
+  registry.reconcileConversations([{
+    engine: "codex",
+    path: artifactPath,
+    accountId: "default",
+    launchProfile: profile,
+    turn: { state: "idle", source: "empty", terminalAt: null },
+    observedAt: "2026-07-16T20:07:01.000Z",
+  }]);
+  const conversation = registry.conversationForPath(artifactPath)!;
+  registry.upsert({
+    key: { engine: "codex", sessionId },
+    artifactPath,
+    cwd: directory,
+    accountId: "default",
+    launchProfile: profile,
+    status: "idle",
+    host: null,
+    structuredHost: {
+      kind: "codex-app-server",
+      endpoint: "stdio:runtime-before-restart",
+      process: null,
+      eventCursor: 42,
+      protocolVersion: "v2",
+      writerClaimEpoch: 5,
+      activeTurnRef: null,
+      pendingAttention: [],
+      activeFlags: [],
+    },
+    claimEpoch: 5,
+    claimOwner: null,
+    pendingAction: null,
+  });
+  const request = {
+    path: artifactPath,
+    conversationId: conversation.id,
+    clientMessageId: "runtime-sync-held-message",
+    text: "deliver exactly once after runtime recovery",
+    hasImages: false,
+  };
+  let requestedDrains = 0;
+
+  const first = await enqueueStructuredMessage(request, {
+    enabled: () => true,
+    client: () => null,
+    registry: () => registry,
+    requestMigrationTick: () => { requestedDrains += 1; },
+  });
+  const refreshedRegistry = new AgentRegistry(registry.filename);
+  const duplicate = await enqueueStructuredMessage(request, {
+    enabled: () => true,
+    client: () => null,
+    registry: () => refreshedRegistry,
+    requestMigrationTick: () => { requestedDrains += 1; },
+  });
+  const held = Object.values(registry.snapshot().heldDeliveries)
+    .filter((delivery) => delivery.clientMessageId === request.clientMessageId);
+
+  expect(first).toMatchObject({ ok: true, structured: true, outcome: "held" });
+  expect(duplicate).toMatchObject({ ok: true, structured: true, outcome: "held" });
+  expect(requestedDrains).toBe(2);
+  expect(held).toMatchObject([{
+    text: request.text,
+    state: "assigned",
+    generationId: sessionId,
+  }]);
+
+  await drainHeldDeliveries(conversation.id, {
+    async deliver({ delivery, path: deliveryPath, clientMessageId }) {
+      return await deliverHeldStructuredMessage({
+        conversationId: conversation.id,
+        path: deliveryPath,
+        deliveryId: delivery.id,
+        clientMessageId,
+        text: delivery.text,
+      }, {
+        enabled: () => true,
+        client: () => null,
+        registry: () => registry,
+        startupFailed: () => true,
+      }) ?? "delivery-uncertain";
+    },
+  }, registry);
+  expect(registry.snapshot().heldDeliveries[held[0]!.id]).toMatchObject({
+    state: "delivery-uncertain",
+    clientMessageId: request.clientMessageId,
+    text: request.text,
+  });
+
+  const journal = new RuntimeJournal(path.join(directory, "runtime.sqlite"), { structuredHosts: true });
+  const client = runtimeJournalClient(journal);
+  const ledger = createFakeDeliveryLedger();
+  await bindStructuredDeliveryQueue([{
+    key: { engine: "codex", sessionId },
+    host: observableFakeHost(new FakeEngineHost(ledger)),
+  }], { registry, client });
+
+  const deliverAfterRecovery = async ({ delivery, path: deliveryPath, clientMessageId }: Parameters<HeldDeliveryPort["deliver"]>[0]) => {
+    return await deliverHeldStructuredMessage({
+      conversationId: conversation.id,
+      path: deliveryPath,
+      deliveryId: delivery.id,
+      clientMessageId,
+      text: delivery.text,
+    }, {
+      enabled: () => true,
+      client: () => client,
+      kick: kickStructuredDeliveryQueue,
+    }) ?? "delivery-uncertain";
+  };
+  await drainHeldDeliveries(conversation.id, {
+    deliver: deliverAfterRecovery,
+    reconcileUncertain: deliverAfterRecovery,
+  }, registry);
+
+  expect(ledger.writes).toEqual([{
+    id: held[0]!.id,
+    text: request.text,
+    expectedTurnId: null,
+  }]);
+  expect(registry.snapshot().heldDeliveries[held[0]!.id]).toMatchObject({
+    state: "delivered",
+    clientMessageId: request.clientMessageId,
+    text: "",
+  });
+  expect(journal.operationResult(held[0]!.id)?.receipt.status).toBe("delivered");
+
+  const afterDeliveryDuplicate = await enqueueStructuredMessage(request, {
+    enabled: () => true,
+    client: () => null,
+    registry: () => registry,
+    requestMigrationTick: () => { requestedDrains += 1; },
+  });
+  expect(afterDeliveryDuplicate).toMatchObject({ ok: true, structured: true, outcome: "held" });
+  expect(ledger.writes).toHaveLength(1);
+  expect(Object.values(registry.snapshot().heldDeliveries)
+    .filter((delivery) => delivery.clientMessageId === request.clientMessageId)).toHaveLength(1);
+
+  await bindStructuredDeliveryQueue([], { registry, client: null });
   journal.close();
 });
 

--- a/src/lib/runtime/structuredDelivery.integration.test.ts
+++ b/src/lib/runtime/structuredDelivery.integration.test.ts
@@ -1044,7 +1044,7 @@ test("runtime recovery drains one durable synchronization hold into one engine c
   journal.close();
 });
 
-test("explicit operation ownership rejects a second client and recovers without an uncertain tombstone", async () => {
+test("terminal operation replay survives registry and runtime journal compaction", async () => {
   const sessionId = "dddddddd-dddd-4ddd-8ddd-dddddddddddd";
   const directory = path.join(sandbox, "durable-operation-ownership");
   const artifactPath = path.join(directory, `${sessionId}.jsonl`);
@@ -1082,7 +1082,8 @@ test("explicit operation ownership rejects a second client and recovers without 
     claimOwner: null,
     pendingAction: null,
   });
-  const journal = new RuntimeJournal(path.join(directory, "runtime.sqlite"), { structuredHosts: true });
+  const runtimeFilename = path.join(directory, "runtime.sqlite");
+  let journal = new RuntimeJournal(runtimeFilename, { structuredHosts: true });
   journal.append({
     scope: { type: "session", id: conversation.id },
     kind: "session-status",
@@ -1152,20 +1153,47 @@ test("explicit operation ownership rejects a second client and recovers without 
     })).toMatchObject({ ok: true, structured: true, outcome: "delivered" });
     expect(ledger.writes).toHaveLength(1);
 
-    const reopened = new AgentRegistry(registry.filename);
-    expect(reopened.pendingDeliveries(conversation.id)).toEqual([]);
-    expect(Object.values(reopened.snapshot().heldDeliveries)).toMatchObject([{
-      clientMessageId: original.clientMessageId,
-      command: {
-        operationId: original.operationId,
-        kind: original.kind,
-        policy: original.policy,
-        turnId: original.turnId,
-      },
-      state: "delivered",
-      text: "",
-    }]);
+    for (let index = 0; index < 101; index += 1) {
+      const later = registry.holdDelivery(
+        conversation.id,
+        `later terminal delivery ${index}`,
+        `later-terminal-delivery-${index}`,
+      );
+      registry.recordDeliveryOutcome(later.id, "delivered");
+    }
+    expect(Object.values(registry.snapshot().heldDeliveries)
+      .some((delivery) => delivery.command.operationId === original.operationId)).toBeFalse();
+    journal.append({ scope: { type: "system", id: "runtime" }, kind: "files.revision", payload: { filesRevision: 1 } });
+    journal.append({ scope: { type: "system", id: "runtime" }, kind: "files.revision", payload: { filesRevision: 2 } });
+    journal.compact(1);
+    expect(journal.operationResult(original.operationId)).toBeNull();
     expect(journal.effectBatch()).toEqual([]);
+    journal.close();
+
+    const reopened = new AgentRegistry(registry.filename);
+    journal = new RuntimeJournal(runtimeFilename, { structuredHosts: true });
+    const restartedClient = runtimeJournalClient(journal);
+    expect(await enqueueStructuredMessage(original, {
+      enabled: () => true,
+      client: () => restartedClient,
+      registry: () => reopened,
+      kick: () => {},
+    })).toMatchObject({
+      ok: true,
+      structured: true,
+      outcome: "delivered",
+      operationId: original.operationId,
+      receipt: { status: "delivered" },
+    });
+    expect(await enqueueStructuredMessage({ ...original, text: "changed after compaction" }, {
+      enabled: () => true,
+      client: () => restartedClient,
+      registry: () => reopened,
+      kick: () => {},
+    })).toMatchObject({ ok: false, structured: true, outcome: "failed", status: 409 });
+    expect(reopened.pendingDeliveries(conversation.id)).toEqual([]);
+    expect(journal.effectBatch()).toEqual([]);
+    expect(ledger.writes).toHaveLength(1);
   } finally {
     await bindStructuredDeliveryQueue([], { registry, client: null });
     journal.close();

--- a/src/lib/runtime/structuredDelivery.integration.test.ts
+++ b/src/lib/runtime/structuredDelivery.integration.test.ts
@@ -1044,6 +1044,134 @@ test("runtime recovery drains one durable synchronization hold into one engine c
   journal.close();
 });
 
+test("explicit operation ownership rejects a second client and recovers without an uncertain tombstone", async () => {
+  const sessionId = "dddddddd-dddd-4ddd-8ddd-dddddddddddd";
+  const directory = path.join(sandbox, "durable-operation-ownership");
+  const artifactPath = path.join(directory, `${sessionId}.jsonl`);
+  const registry = new AgentRegistry(path.join(directory, "agent-registry.json"));
+  const profile = emptyLaunchProfile({ cwd: directory });
+  registry.reconcileConversations([{
+    engine: "codex",
+    path: artifactPath,
+    accountId: "default",
+    launchProfile: profile,
+    turn: { state: "idle", source: "empty", terminalAt: null },
+    observedAt: "2026-07-17T00:00:00.000Z",
+  }]);
+  const conversation = registry.conversationForPath(artifactPath)!;
+  registry.upsert({
+    key: { engine: "codex", sessionId },
+    artifactPath,
+    cwd: directory,
+    accountId: "default",
+    launchProfile: profile,
+    status: "idle",
+    host: null,
+    structuredHost: {
+      kind: "codex-app-server",
+      endpoint: "fake:operation-owner",
+      process: null,
+      eventCursor: 0,
+      protocolVersion: "v2",
+      writerClaimEpoch: 4,
+      activeTurnRef: null,
+      pendingAttention: [],
+      activeFlags: [],
+    },
+    claimEpoch: 4,
+    claimOwner: null,
+    pendingAction: null,
+  });
+  const journal = new RuntimeJournal(path.join(directory, "runtime.sqlite"), { structuredHosts: true });
+  journal.append({
+    scope: { type: "session", id: conversation.id },
+    kind: "session-status",
+    payload: {
+      conversationId: conversation.id,
+      sessionKey: { engine: "codex", sessionId },
+      hostKind: "codex-app-server",
+      host: "hosted",
+      turn: "idle",
+      provenance: "structured",
+      artifactPath,
+      capabilities: { steer: true, structuredAttention: true },
+    },
+  });
+  const client = runtimeJournalClient(journal);
+  const ledger = createFakeDeliveryLedger();
+  await bindStructuredDeliveryQueue([{
+    key: { engine: "codex", sessionId },
+    host: observableFakeHost(new FakeEngineHost(ledger)),
+  }], { registry, client });
+  const original = {
+    path: artifactPath,
+    conversationId: conversation.id,
+    clientMessageId: "operation-owner-client-one",
+    operationId: "operation-owned-by-client-one",
+    kind: "send" as const,
+    policy: "queue" as const,
+    turnId: null,
+    text: "actuate this command once",
+    hasImages: false,
+  };
+
+  try {
+    expect(await enqueueStructuredMessage(original, {
+      enabled: () => true,
+      client: () => client,
+      registry: () => registry,
+      kick: () => {},
+    })).toMatchObject({ ok: true, structured: true, outcome: "queued" });
+    await kickStructuredDeliveryQueue();
+    expect(ledger.writes).toEqual([{
+      id: original.operationId,
+      text: original.text,
+      expectedTurnId: original.turnId,
+    }]);
+
+    expect(await enqueueStructuredMessage({
+      ...original,
+      clientMessageId: "operation-owner-client-two",
+    }, {
+      enabled: () => true,
+      client: () => client,
+      registry: () => registry,
+      kick: () => {},
+    })).toMatchObject({
+      ok: false,
+      structured: true,
+      outcome: "failed",
+      status: 409,
+    });
+
+    expect(await enqueueStructuredMessage(original, {
+      enabled: () => true,
+      client: () => client,
+      registry: () => registry,
+      kick: () => {},
+    })).toMatchObject({ ok: true, structured: true, outcome: "delivered" });
+    expect(ledger.writes).toHaveLength(1);
+
+    const reopened = new AgentRegistry(registry.filename);
+    expect(reopened.pendingDeliveries(conversation.id)).toEqual([]);
+    expect(Object.values(reopened.snapshot().heldDeliveries)).toMatchObject([{
+      clientMessageId: original.clientMessageId,
+      command: {
+        operationId: original.operationId,
+        kind: original.kind,
+        policy: original.policy,
+        turnId: original.turnId,
+      },
+      state: "delivered",
+      text: "",
+    }]);
+    expect(journal.effectBatch()).toEqual([]);
+  } finally {
+    await bindStructuredDeliveryQueue([], { registry, client: null });
+    journal.close();
+  }
+});
+
 test("a stale synchronization-held steer fails safely across Codex and Claude recovery", async () => {
   const cases = [
     {

--- a/src/lib/runtime/structuredDelivery.integration.test.ts
+++ b/src/lib/runtime/structuredDelivery.integration.test.ts
@@ -917,6 +917,10 @@ test("runtime recovery drains one durable synchronization hold into one engine c
     path: artifactPath,
     conversationId: conversation.id,
     clientMessageId: "runtime-sync-held-message",
+    operationId: "operation-runtime-sync-held-message",
+    kind: "send" as const,
+    policy: "queue" as const,
+    turnId: null,
     text: "deliver exactly once after runtime recovery",
     hasImages: false,
   };
@@ -943,6 +947,13 @@ test("runtime recovery drains one durable synchronization hold into one engine c
   expect(requestedDrains).toBe(2);
   expect(held).toMatchObject([{
     text: request.text,
+    command: {
+      operationId: request.operationId,
+      kind: request.kind,
+      policy: request.policy,
+      turnId: request.turnId,
+    },
+    requestDigest: expect.any(String),
     state: "assigned",
     generationId: sessionId,
   }]);
@@ -955,6 +966,7 @@ test("runtime recovery drains one durable synchronization hold into one engine c
         deliveryId: delivery.id,
         clientMessageId,
         text: delivery.text,
+        command: delivery.command,
       }, {
         enabled: () => true,
         client: () => null,
@@ -984,6 +996,7 @@ test("runtime recovery drains one durable synchronization hold into one engine c
       deliveryId: delivery.id,
       clientMessageId,
       text: delivery.text,
+      command: delivery.command,
     }, {
       enabled: () => true,
       client: () => client,
@@ -996,7 +1009,7 @@ test("runtime recovery drains one durable synchronization hold into one engine c
   }, registry);
 
   expect(ledger.writes).toEqual([{
-    id: held[0]!.id,
+    id: request.operationId,
     text: request.text,
     expectedTurnId: null,
   }]);
@@ -1005,7 +1018,16 @@ test("runtime recovery drains one durable synchronization hold into one engine c
     clientMessageId: request.clientMessageId,
     text: "",
   });
-  expect(journal.operationResult(held[0]!.id)?.receipt.status).toBe("delivered");
+  expect(journal.operationResult(request.operationId)?.receipt.status).toBe("delivered");
+
+  const recoveredDuplicate = await enqueueStructuredMessage(request, {
+    enabled: () => true,
+    client: () => client,
+    registry: () => registry,
+    kick: kickStructuredDeliveryQueue,
+  });
+  expect(recoveredDuplicate).toMatchObject({ ok: true, structured: true, outcome: "delivered" });
+  expect(ledger.writes).toHaveLength(1);
 
   const afterDeliveryDuplicate = await enqueueStructuredMessage(request, {
     enabled: () => true,
@@ -1020,6 +1042,129 @@ test("runtime recovery drains one durable synchronization hold into one engine c
 
   await bindStructuredDeliveryQueue([], { registry, client: null });
   journal.close();
+});
+
+test("a stale synchronization-held steer fails safely across Codex and Claude recovery", async () => {
+  const cases = [
+    {
+      engine: "codex" as const,
+      hostKind: "codex-app-server" as const,
+      sessionId: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+    },
+    {
+      engine: "claude" as const,
+      hostKind: "claude-broker" as const,
+      sessionId: "cccccccc-cccc-4ccc-8ccc-cccccccccccc",
+    },
+  ];
+
+  for (const scenario of cases) {
+    const directory = path.join(sandbox, `stale-synchronization-hold-${scenario.engine}`);
+    const artifactPath = path.join(directory, `${scenario.sessionId}.jsonl`);
+    const registry = new AgentRegistry(path.join(directory, "agent-registry.json"));
+    const profile = emptyLaunchProfile({ cwd: directory });
+    registry.reconcileConversations([{
+      engine: scenario.engine,
+      path: artifactPath,
+      accountId: "default",
+      launchProfile: profile,
+      turn: { state: "busy", source: "assistant", terminalAt: null },
+      observedAt: "2026-07-16T20:07:01.000Z",
+    }]);
+    const conversation = registry.conversationForPath(artifactPath)!;
+    registry.upsert({
+      key: { engine: scenario.engine, sessionId: scenario.sessionId },
+      artifactPath,
+      cwd: directory,
+      accountId: "default",
+      launchProfile: profile,
+      status: "live",
+      host: null,
+      structuredHost: {
+        kind: scenario.hostKind,
+        endpoint: `stdio:${scenario.engine}-before-restart`,
+        process: null,
+        eventCursor: 23,
+        protocolVersion: "v2",
+        writerClaimEpoch: 3,
+        activeTurnRef: "turn-before-restart",
+        pendingAttention: [],
+        activeFlags: [],
+      },
+      claimEpoch: 3,
+      claimOwner: null,
+      pendingAction: null,
+    });
+    const request = {
+      path: artifactPath,
+      conversationId: conversation.id,
+      clientMessageId: `stale-held-steer-${scenario.engine}`,
+      operationId: `operation-stale-held-steer-${scenario.engine}`,
+      kind: "steer" as const,
+      policy: "steer-if-active" as const,
+      turnId: "turn-before-restart",
+      text: `retain the ${scenario.engine} turn fence`,
+      hasImages: false,
+    };
+
+    expect(await enqueueStructuredMessage(request, {
+      enabled: () => true,
+      client: () => null,
+      registry: () => registry,
+      requestMigrationTick: () => {},
+    })).toMatchObject({ ok: true, structured: true, outcome: "held" });
+
+    const reopened = new AgentRegistry(registry.filename);
+    const held = reopened.pendingDeliveries(conversation.id)[0]!;
+    const journal = new RuntimeJournal(path.join(directory, "runtime.sqlite"), { structuredHosts: true });
+    journal.append({
+      scope: { type: "session", id: conversation.id },
+      kind: "session-status",
+      payload: {
+        conversationId: conversation.id,
+        sessionKey: { engine: scenario.engine, sessionId: scenario.sessionId },
+        hostKind: scenario.hostKind,
+        host: "hosted",
+        turn: "running",
+        activeTurnId: "turn-after-restart",
+        provenance: "structured",
+        artifactPath,
+        capabilities: { steer: true, structuredAttention: true },
+      },
+    });
+    const client = runtimeJournalClient(journal);
+
+    await drainHeldDeliveries(conversation.id, {
+      async deliver({ delivery, path: deliveryPath, clientMessageId }) {
+        return await deliverHeldStructuredMessage({
+          conversationId: conversation.id,
+          path: deliveryPath,
+          deliveryId: delivery.id,
+          clientMessageId,
+          text: delivery.text,
+          command: delivery.command,
+        }, {
+          enabled: () => true,
+          client: () => client,
+          kick: () => {},
+        }) ?? "delivery-uncertain";
+      },
+    }, reopened);
+
+    expect(journal.operationResult(request.operationId)?.receipt).toMatchObject({
+      kind: request.kind,
+      status: "rejected",
+      reason: "stale-turn",
+      turnId: request.turnId,
+    });
+    expect(journal.effectBatch()).toEqual([]);
+    expect(reopened.snapshot().heldDeliveries[held.id]).toMatchObject({
+      state: "failed",
+      command: held.command,
+      requestDigest: held.requestDigest,
+    });
+    journal.close();
+  }
 });
 
 test("a migration-held delivery switches from the source host to the published Codex successor", async () => {
@@ -1078,7 +1223,18 @@ test("a migration-held delivery switches from the source host to the published C
     requestId: "publish-successor-before-drain",
     expectedRevision: registry.engineRouting("codex").revision,
   });
-  const held = registry.holdDelivery(conversation.id, "continue on the successor", "migration-successor-message");
+  const held = registry.holdDelivery(
+    conversation.id,
+    "continue on the successor",
+    "migration-successor-message",
+    "text",
+    {
+      operationId: "operation-migration-successor-message",
+      kind: "send",
+      policy: "queue",
+      turnId: null,
+    },
+  );
   expect(held.state).toBe("held");
 
   const order: string[] = [];
@@ -1140,6 +1296,7 @@ test("a migration-held delivery switches from the source host to the published C
         deliveryId: delivery.id,
         clientMessageId,
         text: delivery.text,
+        command: delivery.command,
       }, {
         enabled: () => true,
         client: () => client,
@@ -1151,12 +1308,12 @@ test("a migration-held delivery switches from the source host to the published C
   expect(order.slice(0, 3)).toEqual(["verify", "publish", "commit"]);
   expect(sourceLedger.writes).toEqual([]);
   expect(successorLedger.writes).toEqual([{
-    id: held.id,
+    id: held.command.operationId,
     text: "continue on the successor",
     expectedTurnId: null,
   }]);
   expect(registry.pendingDeliveries(conversation.id)).toEqual([]);
-  expect(journal.operationResult(held.id)?.receipt.status).toBe("delivered");
+  expect(journal.operationResult(held.command.operationId)?.receipt.status).toBe("delivered");
 
   await bindStructuredDeliveryQueue([], { registry, client: null });
   journal.close();
@@ -1261,7 +1418,18 @@ test("a migration-held delivery switches from the source host to the published C
     phase: "verifying",
     providerReceipt: receipt,
   });
-  const held = registry.holdDelivery(conversation.id, "continue on the Claude successor", "claude-migration-message");
+  const held = registry.holdDelivery(
+    conversation.id,
+    "continue on the Claude successor",
+    "claude-migration-message",
+    "text",
+    {
+      operationId: "operation-claude-migration-message",
+      kind: "send",
+      policy: "queue",
+      turnId: null,
+    },
+  );
   expect(held.state).toBe("held");
 
   const sourceAccount = {
@@ -1333,6 +1501,7 @@ test("a migration-held delivery switches from the source host to the published C
         deliveryId: delivery.id,
         clientMessageId,
         text: delivery.text,
+        command: delivery.command,
       }, {
         enabled: () => true,
         client: () => client,
@@ -1344,12 +1513,12 @@ test("a migration-held delivery switches from the source host to the published C
   expect(publications).toBe(1);
   expect(sourceLedger.writes).toEqual([]);
   expect(successorLedger.writes).toEqual([{
-    id: held.id,
+    id: held.command.operationId,
     text: "continue on the Claude successor",
     expectedTurnId: null,
   }]);
   expect(registry.pendingDeliveries(conversation.id)).toEqual([]);
-  expect(journal.operationResult(held.id)?.receipt.status).toBe("delivered");
+  expect(journal.operationResult(held.command.operationId)?.receipt.status).toBe("delivered");
 
   await bindStructuredDeliveryQueue([], { registry, client: null });
   journal.close();

--- a/src/lib/runtime/structuredDelivery.integration.test.ts
+++ b/src/lib/runtime/structuredDelivery.integration.test.ts
@@ -1200,6 +1200,177 @@ test("terminal operation replay survives registry and runtime journal compaction
   }
 });
 
+test("provisional adoption preserves runtime idempotency across Codex and Claude", async () => {
+  const scenarios = [
+    {
+      engine: "codex" as const,
+      hostKind: "codex-app-server" as const,
+      sessionId: "eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee",
+    },
+    {
+      engine: "claude" as const,
+      hostKind: "claude-broker" as const,
+      sessionId: "ffffffff-ffff-4fff-8fff-ffffffffffff",
+    },
+  ];
+
+  for (const scenario of scenarios) {
+    const directory = path.join(sandbox, `provisional-operation-owner-${scenario.engine}`);
+    fs.mkdirSync(directory, { recursive: true });
+    const sourcePath = path.join(directory, `source-${scenario.engine}.jsonl`);
+    const targetPath = path.join(directory, `${scenario.sessionId}.jsonl`);
+    const registry = new AgentRegistry(path.join(directory, "agent-registry.json"));
+    const profile = emptyLaunchProfile({ cwd: directory });
+    const canonical = registry.ensureConversation(scenario.engine, sourcePath, "source");
+    registry.reconcileConversations([{
+      engine: scenario.engine,
+      path: targetPath,
+      accountId: "target",
+      launchProfile: profile,
+      turn: { state: "idle", source: "empty", terminalAt: null },
+      observedAt: "2026-07-17T01:00:00.000Z",
+    }]);
+    const provisional = registry.conversationForPath(targetPath)!;
+    const structuredHost = {
+      kind: scenario.hostKind,
+      endpoint: `fake:provisional-${scenario.engine}`,
+      process: null,
+      eventCursor: 0,
+      protocolVersion: "v2",
+      writerClaimEpoch: 5,
+      activeTurnRef: null,
+      pendingAttention: [],
+      activeFlags: [],
+    };
+    registry.upsert({
+      key: { engine: scenario.engine, sessionId: scenario.sessionId },
+      artifactPath: targetPath,
+      cwd: directory,
+      accountId: "target",
+      launchProfile: profile,
+      status: "idle",
+      host: null,
+      structuredHost,
+      claimEpoch: 5,
+      claimOwner: null,
+      pendingAction: null,
+    });
+    const journal = new RuntimeJournal(path.join(directory, "runtime.sqlite"), { structuredHosts: true });
+    journal.append({
+      scope: { type: "session", id: provisional.id },
+      kind: "session-status",
+      payload: {
+        conversationId: provisional.id,
+        sessionKey: { engine: scenario.engine, sessionId: scenario.sessionId },
+        hostKind: scenario.hostKind,
+        host: "hosted",
+        turn: "idle",
+        provenance: "structured",
+        artifactPath: targetPath,
+        capabilities: { steer: scenario.engine === "codex", structuredAttention: true },
+      },
+    });
+    const client = runtimeJournalClient(journal);
+    const ledger = createFakeDeliveryLedger();
+    await bindStructuredDeliveryQueue([{
+      key: { engine: scenario.engine, sessionId: scenario.sessionId },
+      host: observableFakeHost(new FakeEngineHost(ledger)),
+    }], { registry, client });
+    const request = {
+      path: targetPath,
+      conversationId: provisional.id,
+      clientMessageId: `provisional-client-${scenario.engine}`,
+      operationId: `provisional-operation-${scenario.engine}`,
+      kind: "send" as const,
+      policy: "queue" as const,
+      turnId: null,
+      text: `deliver once through ${scenario.engine} adoption`,
+      hasImages: false,
+    };
+
+    try {
+      expect(await enqueueStructuredMessage(request, {
+        enabled: () => true,
+        client: () => client,
+        registry: () => registry,
+        kick: () => {},
+      })).toMatchObject({ ok: true, structured: true, outcome: "queued" });
+      expect(journal.effectBatch()).toHaveLength(1);
+
+      const migration = registry.beginSpawnRequest({
+        engine: scenario.engine,
+        cwd: directory,
+        accountId: "target",
+        conversationId: canonical.id,
+        purpose: "launch",
+        expectedArtifactPath: targetPath,
+      });
+      if (migration.kind !== "created") throw new Error("expected migration successor receipt");
+      expect(registry.settleSpawn(migration.receipt.launchId, {
+        key: { engine: scenario.engine, sessionId: scenario.sessionId },
+        artifactPath: targetPath,
+        cwd: directory,
+        accountId: "target",
+        launchProfile: profile,
+        status: "idle",
+        host: null,
+        structuredHost,
+        claimEpoch: 5,
+        claimOwner: null,
+        pendingAction: null,
+      })).toMatchObject({ kind: "settled", conversation: { id: canonical.id } });
+      expect(registry.canonicalConversationId(provisional.id)).toBe(canonical.id);
+
+      const unrelated = registry.ensureConversation(
+        scenario.engine,
+        path.join(directory, `unrelated-${scenario.engine}.jsonl`),
+        "target",
+      );
+      expect(() => registry.holdDelivery(
+        unrelated.id,
+        request.text,
+        request.clientMessageId,
+        "text",
+        {
+          operationId: request.operationId,
+          kind: request.kind,
+          policy: request.policy,
+          turnId: request.turnId,
+        },
+      )).toThrow("operation id is already reserved for another client message");
+
+      expect(await enqueueStructuredMessage(request, {
+        enabled: () => true,
+        client: () => client,
+        registry: () => registry,
+        kick: () => {},
+      })).toMatchObject({
+        ok: true,
+        structured: true,
+        outcome: "queued",
+        operationId: request.operationId,
+      });
+      expect(await enqueueStructuredMessage({ ...request, text: `${request.text} changed` }, {
+        enabled: () => true,
+        client: () => client,
+        registry: () => registry,
+        kick: () => {},
+      })).toMatchObject({ ok: false, structured: true, outcome: "failed", status: 409 });
+
+      await kickStructuredDeliveryQueue();
+      expect(ledger.writes).toEqual([{
+        id: request.operationId,
+        text: request.text,
+        expectedTurnId: request.turnId,
+      }]);
+      expect(journal.effectBatch()).toEqual([]);
+    } finally {
+      await bindStructuredDeliveryQueue([], { registry, client: null });
+      journal.close();
+    }
+  }
+});
+
 test("a stale synchronization-held steer fails safely across Codex and Claude recovery", async () => {
   const cases = [
     {

--- a/src/lib/runtime/structuredMessageDelivery.test.ts
+++ b/src/lib/runtime/structuredMessageDelivery.test.ts
@@ -32,6 +32,59 @@ function registryWithConversation(accountId = "default") {
   return { registry, conversation };
 }
 
+function recordStructuredOwner(registry: AgentRegistry, conversation: ReturnType<typeof registryWithConversation>["conversation"]): void {
+  const generation = conversation.generations.at(-1)!;
+  registry.upsert({
+    key: { engine: conversation.engine, sessionId: generation.id },
+    artifactPath: generation.path,
+    cwd: generation.launchProfile.cwd,
+    accountId: generation.accountId,
+    launchProfile: generation.launchProfile,
+    status: "idle",
+    host: null,
+    structuredHost: {
+      kind: "codex-app-server",
+      endpoint: "stdio:deployment-window",
+      process: { pid: 101, startIdentity: "runtime-before-restart" },
+      eventCursor: 17,
+      protocolVersion: "v2",
+      writerClaimEpoch: 4,
+      activeTurnRef: null,
+      pendingAttention: [],
+      activeFlags: [],
+    },
+    claimEpoch: 4,
+    claimOwner: "structured-host:runtime-before-restart",
+    pendingAction: null,
+  });
+}
+
+function recordLegacyOwner(registry: AgentRegistry, conversation: ReturnType<typeof registryWithConversation>["conversation"]): void {
+  const generation = conversation.generations.at(-1)!;
+  registry.upsert({
+    key: { engine: conversation.engine, sessionId: generation.id },
+    artifactPath: generation.path,
+    cwd: generation.launchProfile.cwd,
+    accountId: generation.accountId,
+    launchProfile: generation.launchProfile,
+    status: "idle",
+    host: {
+      kind: "tmux",
+      endpoint: "/run/user/1000/tmux/default",
+      server: { pid: 201, startIdentity: "tmux-server" },
+      paneId: "%21",
+      panePid: { pid: 202, startIdentity: "tmux-pane" },
+      windowName: "legacy-root",
+      agent: { pid: 203, startIdentity: "legacy-agent" },
+      argv: ["codex", "resume", generation.id],
+    },
+    structuredHost: null,
+    claimEpoch: 2,
+    claimOwner: null,
+    pendingAction: null,
+  });
+}
+
 function snapshot(ownedConversationId = conversationId): RuntimeSnapshot {
   return {
     schemaVersion: 1,
@@ -86,13 +139,14 @@ test("structured message routing is inert while its gate is disabled", async () 
   expect(called).toBe(false);
 });
 
-test("structured message routing falls through after startup adoption leaves no runtime client", async () => {
+test("structured message routing fences failed startup when no persisted owner exists", async () => {
+  const registry = new AgentRegistry(path.join(sandbox, `registry-${registryNumber += 1}.json`));
   const result = await enqueueStructuredMessage(
     { path: artifactPath, text: "hello", hasImages: false },
-    { enabled: () => true, client: () => null, startupFailed: () => true },
+    { enabled: () => true, client: () => null, registry: () => registry, startupFailed: () => true },
   );
 
-  expect(result).toBeNull();
+  expect(result).toMatchObject({ ok: false, structured: true, outcome: "failed", status: 503 });
 });
 
 test("structured message routing fences a missing runtime client without startup failure evidence", async () => {
@@ -104,30 +158,177 @@ test("structured message routing fences a missing runtime client without startup
   expect(result).toMatchObject({ ok: false, structured: true, outcome: "failed", status: 503 });
 });
 
-test("structured message routing falls through when the snapshot has no owner for the session", async () => {
+test("a persisted structured current generation holds the exact send while the runtime client is absent", async () => {
+  const { registry, conversation } = registryWithConversation();
+  recordStructuredOwner(registry, conversation);
+  let migrationTicks = 0;
+
+  const result = await enqueueStructuredMessage({
+    path: artifactPath,
+    conversationId: conversation.id,
+    clientMessageId: "deployment-window-message",
+    text: "continue through runtime synchronization",
+    hasImages: false,
+  }, {
+    enabled: () => true,
+    client: () => null,
+    registry: () => registry,
+    requestMigrationTick: () => { migrationTicks += 1; },
+    startupFailed: () => false,
+  });
+
+  expect(result).toMatchObject({
+    ok: true,
+    structured: true,
+    target: conversation.id,
+    outcome: "held",
+  });
+  expect(migrationTicks).toBe(1);
+  expect(registry.pendingDeliveries(conversation.id)).toMatchObject([{
+    clientMessageId: "deployment-window-message",
+    text: "continue through runtime synchronization",
+    state: "assigned",
+    generationId: conversation.generations.at(-1)!.id,
+  }]);
+});
+
+test("a persisted tmux current generation falls through during runtime client absence", async () => {
+  const { registry, conversation } = registryWithConversation();
+  recordLegacyOwner(registry, conversation);
+  let migrationTicks = 0;
+
+  const result = await enqueueStructuredMessage({
+    path: artifactPath,
+    conversationId: conversation.id,
+    clientMessageId: "legacy-deployment-window-message",
+    text: "continue through the legacy pane",
+    hasImages: false,
+  }, {
+    enabled: () => true,
+    client: () => null,
+    registry: () => registry,
+    requestMigrationTick: () => { migrationTicks += 1; },
+    startupFailed: () => false,
+  });
+
+  expect(result).toBeNull();
+  expect(migrationTicks).toBe(0);
+  expect(registry.pendingDeliveries(conversation.id)).toEqual([]);
+});
+
+test("conflicting persisted ownership stays fenced during runtime client absence", async () => {
+  const { registry, conversation } = registryWithConversation();
+  recordLegacyOwner(registry, conversation);
+  const generation = conversation.generations.at(-1)!;
+  registry.setStructuredHost({ engine: conversation.engine, sessionId: generation.id }, {
+    kind: "codex-app-server",
+    endpoint: "stdio:conflicting-owner",
+    process: null,
+    eventCursor: 9,
+    protocolVersion: "v2",
+    writerClaimEpoch: 2,
+    activeTurnRef: null,
+    pendingAttention: [],
+    activeFlags: [],
+  });
+
+  const result = await enqueueStructuredMessage({
+    path: artifactPath,
+    conversationId: conversation.id,
+    clientMessageId: "ambiguous-deployment-window-message",
+    text: "keep conflicting ownership fenced",
+    hasImages: false,
+  }, {
+    enabled: () => true,
+    client: () => null,
+    registry: () => registry,
+  });
+
+  expect(result).toMatchObject({ ok: false, structured: true, outcome: "failed", status: 503 });
+  expect(registry.pendingDeliveries(conversation.id)).toEqual([]);
+});
+
+test("structured runtime synchronization keeps images and oversized text request-local", async () => {
+  const { registry, conversation } = registryWithConversation();
+  recordStructuredOwner(registry, conversation);
+  const dependencies = {
+    enabled: () => true,
+    client: () => null,
+    registry: () => registry,
+  };
+
+  const image = await enqueueStructuredMessage({
+    path: artifactPath,
+    conversationId: conversation.id,
+    clientMessageId: "runtime-window-image",
+    text: "image caption",
+    hasImages: true,
+  }, dependencies);
+  const oversized = await enqueueStructuredMessage({
+    path: artifactPath,
+    conversationId: conversation.id,
+    clientMessageId: "runtime-window-oversized",
+    text: "x".repeat(32_001),
+    hasImages: false,
+  }, dependencies);
+
+  expect(image).toMatchObject({ ok: false, structured: true, outcome: "failed", status: 409 });
+  expect(oversized).toMatchObject({ ok: false, structured: true, outcome: "failed", status: 503 });
+  expect(registry.pendingDeliveries(conversation.id)).toEqual([]);
+});
+
+test("legacy runtime synchronization leaves request-local payloads for the legacy ladder", async () => {
+  const { registry, conversation } = registryWithConversation();
+  recordLegacyOwner(registry, conversation);
+  const dependencies = {
+    enabled: () => true,
+    client: () => null,
+    registry: () => registry,
+  };
+
+  expect(await enqueueStructuredMessage({
+    path: artifactPath,
+    conversationId: conversation.id,
+    clientMessageId: "legacy-runtime-window-image",
+    text: "image caption",
+    hasImages: true,
+  }, dependencies)).toBeNull();
+  expect(await enqueueStructuredMessage({
+    path: artifactPath,
+    conversationId: conversation.id,
+    clientMessageId: "legacy-runtime-window-oversized",
+    text: "x".repeat(32_001),
+    hasImages: false,
+  }, dependencies)).toBeNull();
+  expect(registry.pendingDeliveries(conversation.id)).toEqual([]);
+});
+
+test("structured message routing fences when the snapshot and registry have no current owner", async () => {
+  const registry = new AgentRegistry(path.join(sandbox, `registry-${registryNumber += 1}.json`));
   const client = {
     snapshot: async () => ({ ...snapshot(), sessions: [] }),
   } as unknown as RuntimeHostClient;
 
   const result = await enqueueStructuredMessage(
     { path: artifactPath, text: "hello", hasImages: false },
-    { enabled: () => true, client: () => client },
+    { enabled: () => true, client: () => client, registry: () => registry },
   );
 
-  expect(result).toBeNull();
+  expect(result).toMatchObject({ ok: false, structured: true, outcome: "failed", status: 503 });
 });
 
-test("structured message routing falls through when failed startup adoption leaves the snapshot unavailable", async () => {
+test("structured message routing fences a failed startup snapshot without persisted ownership", async () => {
+  const registry = new AgentRegistry(path.join(sandbox, `registry-${registryNumber += 1}.json`));
   const client = {
     snapshot: async () => { throw new Error("startup adoption failed"); },
   } as unknown as RuntimeHostClient;
 
   const result = await enqueueStructuredMessage(
     { path: artifactPath, text: "hello", hasImages: false },
-    { enabled: () => true, client: () => client, startupFailed: () => true },
+    { enabled: () => true, client: () => client, registry: () => registry, startupFailed: () => true },
   );
 
-  expect(result).toBeNull();
+  expect(result).toMatchObject({ ok: false, structured: true, outcome: "failed", status: 503 });
 });
 
 test("structured message routing fences a transient snapshot failure", async () => {
@@ -146,6 +347,61 @@ test("structured message routing fences a transient snapshot failure", async () 
     outcome: "failed",
     status: 503,
   });
+});
+
+test("a persisted structured current generation holds the send after a runtime snapshot failure", async () => {
+  const { registry, conversation } = registryWithConversation();
+  recordStructuredOwner(registry, conversation);
+  let migrationTicks = 0;
+  const client = {
+    snapshot: async () => { throw new Error("runtime host is unavailable"); },
+  } as unknown as RuntimeHostClient;
+
+  const result = await enqueueStructuredMessage({
+    path: artifactPath,
+    conversationId: conversation.id,
+    clientMessageId: "snapshot-window-message",
+    text: "retain this snapshot-window send",
+    hasImages: false,
+  }, {
+    enabled: () => true,
+    client: () => client,
+    registry: () => registry,
+    requestMigrationTick: () => { migrationTicks += 1; },
+    startupFailed: () => false,
+  });
+
+  expect(result).toMatchObject({ ok: true, structured: true, target: conversation.id, outcome: "held" });
+  expect(migrationTicks).toBe(1);
+  expect(registry.pendingDeliveries(conversation.id)).toMatchObject([{
+    clientMessageId: "snapshot-window-message",
+    text: "retain this snapshot-window send",
+    state: "assigned",
+  }]);
+});
+
+test("a persisted tmux current generation falls through after a runtime snapshot failure", async () => {
+  const { registry, conversation } = registryWithConversation();
+  recordLegacyOwner(registry, conversation);
+  const client = {
+    snapshot: async () => { throw new Error("runtime host is unavailable"); },
+  } as unknown as RuntimeHostClient;
+
+  const result = await enqueueStructuredMessage({
+    path: artifactPath,
+    conversationId: conversation.id,
+    clientMessageId: "legacy-snapshot-window-message",
+    text: "deliver through the legacy pane",
+    hasImages: false,
+  }, {
+    enabled: () => true,
+    client: () => client,
+    registry: () => registry,
+    startupFailed: () => false,
+  });
+
+  expect(result).toBeNull();
+  expect(registry.pendingDeliveries(conversation.id)).toEqual([]);
 });
 
 test("structured ownership recovery revokes startup-failure fallback authorization", async () => {
@@ -339,7 +595,7 @@ test("structured ownership stays fenced while its registry projection is missing
   expect(result).toMatchObject({ ok: false, structured: true, outcome: "failed", status: 503 });
 });
 
-test("structured message routing falls through for an unhosted owner", async () => {
+test("structured message routing fences an unhosted runtime projection", async () => {
   const unhostedSnapshot = snapshot();
   unhostedSnapshot.sessions[0] = { ...unhostedSnapshot.sessions[0]!, hostKind: "unhosted" };
   const client = { snapshot: async () => unhostedSnapshot } as unknown as RuntimeHostClient;
@@ -349,7 +605,7 @@ test("structured message routing falls through for an unhosted owner", async () 
     { enabled: () => true, client: () => client },
   );
 
-  expect(result).toBeNull();
+  expect(result).toMatchObject({ ok: false, structured: true, outcome: "failed", status: 503 });
 });
 
 test("structured message routing returns the durable queued receipt immediately", async () => {
@@ -445,7 +701,8 @@ test("migration-held delivery settles through the runtime journal after EngineHo
   expect(outcome).toBe("delivered");
 });
 
-test("held delivery falls through when structured ownership is unavailable", async () => {
+test("held delivery stays fenced when persisted ownership is unavailable", async () => {
+  const registry = new AgentRegistry(path.join(sandbox, `registry-${registryNumber += 1}.json`));
   const request = {
     conversationId: "conversation_missing",
     path: artifactPath,
@@ -460,12 +717,14 @@ test("held delivery falls through when structured ownership is unavailable", asy
   expect(await deliverHeldStructuredMessage(request, {
     enabled: () => true,
     client: () => null,
+    registry: () => registry,
     startupFailed: () => true,
-  })).toBeNull();
+  })).toBe("delivery-uncertain");
   expect(await deliverHeldStructuredMessage(request, {
     enabled: () => true,
     client: () => missingSessionClient,
-  })).toBeNull();
+    registry: () => registry,
+  })).toBe("delivery-uncertain");
 });
 
 test("held delivery fences a missing runtime client without startup failure evidence", async () => {
@@ -480,6 +739,42 @@ test("held delivery fences a missing runtime client without startup failure evid
     client: () => null,
     startupFailed: () => false,
   })).toBe("delivery-uncertain");
+});
+
+test("held delivery keeps a persisted structured owner fenced when startup failed", async () => {
+  const { registry, conversation } = registryWithConversation();
+  recordStructuredOwner(registry, conversation);
+
+  expect(await deliverHeldStructuredMessage({
+    conversationId: conversation.id,
+    path: artifactPath,
+    deliveryId: "held-structured-startup-failure",
+    clientMessageId: "held-structured-startup-failure-message",
+    text: "remain structured through startup recovery",
+  }, {
+    enabled: () => true,
+    client: () => null,
+    registry: () => registry,
+    startupFailed: () => true,
+  })).toBe("delivery-uncertain");
+});
+
+test("held delivery authorizes legacy fallback from persisted tmux ownership", async () => {
+  const { registry, conversation } = registryWithConversation();
+  recordLegacyOwner(registry, conversation);
+
+  expect(await deliverHeldStructuredMessage({
+    conversationId: conversation.id,
+    path: artifactPath,
+    deliveryId: "held-legacy-startup-failure",
+    clientMessageId: "held-legacy-startup-failure-message",
+    text: "continue through the legacy ladder",
+  }, {
+    enabled: () => true,
+    client: () => null,
+    registry: () => registry,
+    startupFailed: () => true,
+  })).toBeNull();
 });
 
 test("held delivery stays uncertain during a transient structured snapshot failure", async () => {

--- a/src/lib/runtime/structuredMessageDelivery.test.ts
+++ b/src/lib/runtime/structuredMessageDelivery.test.ts
@@ -192,6 +192,225 @@ test("a persisted structured current generation holds the exact send while the r
   }]);
 });
 
+test("a reopened synchronization hold replays the exact steer command", async () => {
+  const { registry, conversation } = registryWithConversation();
+  recordStructuredOwner(registry, conversation);
+  const request = {
+    path: artifactPath,
+    conversationId: conversation.id,
+    clientMessageId: "deployment-window-steer",
+    operationId: "operation-deployment-window-steer",
+    kind: "steer" as const,
+    policy: "steer-if-active" as const,
+    turnId: "turn-before-runtime-restart",
+    text: "amend the active turn after runtime recovery",
+    hasImages: false,
+  };
+
+  expect(await enqueueStructuredMessage(request, {
+    enabled: () => true,
+    client: () => null,
+    registry: () => registry,
+    requestMigrationTick: () => {},
+  })).toMatchObject({ ok: true, structured: true, outcome: "held" });
+
+  const reopened = new AgentRegistry(registry.filename);
+  const persisted = reopened.pendingDeliveries(conversation.id)[0]!;
+  expect(persisted).toMatchObject({
+    command: {
+      operationId: request.operationId,
+      kind: request.kind,
+      policy: request.policy,
+      turnId: request.turnId,
+    },
+    requestDigest: expect.any(String),
+  });
+
+  let acceptedCommand: unknown;
+  const receipt = {
+    operationId: request.operationId,
+    idempotencyKey: request.clientMessageId,
+    conversationId: conversation.id,
+    kind: request.kind,
+    status: "delivered" as const,
+    turnId: request.turnId,
+    at: "2026-07-13T00:00:00.000Z",
+    revision: 2,
+  };
+  const client = {
+    snapshot: async () => snapshot(conversation.id),
+    command: async (command: unknown) => {
+      acceptedCommand = command;
+      return { operationId: request.operationId, replayed: false, receipt };
+    },
+    operationStatus: async () => ({ operationId: request.operationId, replayed: true, receipt }),
+  } as unknown as RuntimeHostClient;
+  const heldRequest = {
+    conversationId: conversation.id,
+    path: artifactPath,
+    deliveryId: persisted.id,
+    clientMessageId: request.clientMessageId,
+    text: persisted.text,
+    command: persisted.command,
+  };
+
+  expect(await deliverHeldStructuredMessage(heldRequest, {
+    enabled: () => true,
+    client: () => client,
+    kick: () => {},
+  })).toBe("delivered");
+  expect(acceptedCommand).toEqual({
+    operationId: request.operationId,
+    conversationId: conversation.id,
+    idempotencyKey: request.clientMessageId,
+    kind: request.kind,
+    policy: request.policy,
+    turnId: request.turnId,
+    text: request.text,
+  });
+});
+
+test("a reopened synchronization hold rejects changed payload and command reuse", async () => {
+  const { registry, conversation } = registryWithConversation();
+  recordStructuredOwner(registry, conversation);
+  const dependencies = {
+    enabled: () => true,
+    client: () => null,
+    registry: () => registry,
+    requestMigrationTick: () => {},
+  };
+  const original = {
+    path: artifactPath,
+    conversationId: conversation.id,
+    clientMessageId: "deployment-window-conflict",
+    operationId: "operation-deployment-window-conflict",
+    kind: "steer" as const,
+    policy: "steer-if-active" as const,
+    turnId: "turn-before-conflict",
+    text: "retain the original draft",
+    hasImages: false,
+  };
+
+  expect(await enqueueStructuredMessage(original, dependencies)).toMatchObject({
+    ok: true,
+    structured: true,
+    outcome: "held",
+  });
+  const firstReservation = registry.pendingDeliveries(conversation.id)[0]!;
+  const reopened = new AgentRegistry(registry.filename);
+  const reopenedDependencies = { ...dependencies, registry: () => reopened };
+
+  expect(await enqueueStructuredMessage({
+    ...original,
+    text: "changed caller draft",
+  }, reopenedDependencies)).toMatchObject({
+    ok: false,
+    structured: true,
+    outcome: "failed",
+    status: 409,
+  });
+  expect(await enqueueStructuredMessage({
+    ...original,
+    kind: "send",
+  }, reopenedDependencies)).toMatchObject({
+    ok: false,
+    structured: true,
+    outcome: "failed",
+    status: 409,
+  });
+  expect(await enqueueStructuredMessage({
+    ...original,
+    policy: "queue",
+  }, reopenedDependencies)).toMatchObject({
+    ok: false,
+    structured: true,
+    outcome: "failed",
+    status: 409,
+  });
+  expect(await enqueueStructuredMessage({
+    ...original,
+    turnId: null,
+  }, reopenedDependencies)).toMatchObject({
+    ok: false,
+    structured: true,
+    outcome: "failed",
+    status: 409,
+  });
+  expect(reopened.pendingDeliveries(conversation.id)).toEqual([firstReservation]);
+
+  expect(await enqueueStructuredMessage({
+    ...original,
+    operationId: "operation-from-refreshed-caller",
+  }, reopenedDependencies)).toMatchObject({
+    ok: true,
+    structured: true,
+    outcome: "held",
+  });
+  expect(reopened.pendingDeliveries(conversation.id)[0]).toMatchObject({
+    id: firstReservation.id,
+    text: firstReservation.text,
+    command: firstReservation.command,
+    requestDigest: firstReservation.requestDigest,
+  });
+});
+
+test("a delivered tombstone rejects changed client-id reuse and preserves the caller draft", async () => {
+  const { registry, conversation } = registryWithConversation();
+  recordStructuredOwner(registry, conversation);
+  const original = {
+    path: artifactPath,
+    conversationId: conversation.id,
+    clientMessageId: "delivered-client-id-conflict",
+    operationId: "operation-delivered-client-id-conflict",
+    kind: "send" as const,
+    policy: "queue" as const,
+    turnId: null,
+    text: "the delivered draft",
+    hasImages: false,
+  };
+  const receipt = {
+    operationId: original.operationId,
+    idempotencyKey: original.clientMessageId,
+    conversationId: conversation.id,
+    kind: original.kind,
+    status: "delivered" as const,
+    turnId: "turn-delivered",
+    at: "2026-07-13T00:00:00.000Z",
+    revision: 2,
+  };
+  const client = {
+    snapshot: async () => snapshot(conversation.id),
+    command: async () => ({ operationId: original.operationId, replayed: false, receipt }),
+  } as unknown as RuntimeHostClient;
+
+  expect(await enqueueStructuredMessage(original, {
+    enabled: () => true,
+    client: () => client,
+    registry: () => registry,
+    kick: () => {},
+  })).toMatchObject({ ok: true, structured: true, outcome: "delivered" });
+  const tombstone = Object.values(registry.snapshot().heldDeliveries)[0]!;
+  expect(tombstone).toMatchObject({ state: "delivered", text: "", requestDigest: expect.any(String) });
+
+  const callerDraft = "the caller's changed draft";
+  const conflict = await enqueueStructuredMessage({
+    ...original,
+    kind: "steer" as const,
+    policy: "steer-if-active" as const,
+    turnId: "turn-new",
+    text: callerDraft,
+  }, {
+    enabled: () => true,
+    client: () => null,
+    registry: () => registry,
+    requestMigrationTick: () => {},
+  });
+
+  expect(conflict).toMatchObject({ ok: false, structured: true, outcome: "failed", status: 409 });
+  expect(callerDraft).toBe("the caller's changed draft");
+  expect(registry.snapshot().heldDeliveries[tombstone.id]).toEqual(tombstone);
+});
+
 test("a persisted tmux current generation falls through during runtime client absence", async () => {
   const { registry, conversation } = registryWithConversation();
   recordLegacyOwner(registry, conversation);
@@ -213,6 +432,38 @@ test("a persisted tmux current generation falls through during runtime client ab
 
   expect(result).toBeNull();
   expect(migrationTicks).toBe(0);
+  expect(registry.pendingDeliveries(conversation.id)).toEqual([]);
+});
+
+test("legacy synchronization rejects structured command semantics before fallback", async () => {
+  const { registry, conversation } = registryWithConversation();
+  recordLegacyOwner(registry, conversation);
+  const request = {
+    path: artifactPath,
+    conversationId: conversation.id,
+    clientMessageId: "legacy-structured-command",
+    operationId: "operation-legacy-structured-command",
+    kind: "steer" as const,
+    policy: "steer-if-active" as const,
+    turnId: "stale-legacy-turn",
+    text: "preserve structured command semantics",
+    hasImages: false,
+  };
+  const result = await enqueueStructuredMessage(request, {
+    enabled: () => true,
+    client: () => null,
+    registry: () => registry,
+  });
+  const legacySnapshot = snapshot(conversation.id);
+  legacySnapshot.sessions[0] = { ...legacySnapshot.sessions[0]!, hostKind: "tmux-legacy" };
+  const snapshotResult = await enqueueStructuredMessage(request, {
+    enabled: () => true,
+    client: () => ({ snapshot: async () => legacySnapshot }) as unknown as RuntimeHostClient,
+    registry: () => registry,
+  });
+
+  expect(result).toMatchObject({ ok: false, structured: true, outcome: "failed", status: 409 });
+  expect(snapshotResult).toMatchObject({ ok: false, structured: true, outcome: "failed", status: 409 });
   expect(registry.pendingDeliveries(conversation.id)).toEqual([]);
 });
 
@@ -775,6 +1026,36 @@ test("held delivery authorizes legacy fallback from persisted tmux ownership", a
     registry: () => registry,
     startupFailed: () => true,
   })).toBeNull();
+});
+
+test("held delivery rejects structured command semantics before legacy fallback", async () => {
+  const { registry, conversation } = registryWithConversation();
+  recordLegacyOwner(registry, conversation);
+  const request = {
+    conversationId: conversation.id,
+    path: artifactPath,
+    deliveryId: "held-legacy-structured-command",
+    clientMessageId: "held-legacy-structured-command-message",
+    text: "retain the stale turn fence",
+    command: {
+      operationId: "operation-held-legacy-structured-command",
+      kind: "steer" as const,
+      policy: "steer-if-active" as const,
+      turnId: "stale-legacy-turn",
+    },
+  };
+  expect(await deliverHeldStructuredMessage(request, {
+    enabled: () => true,
+    client: () => null,
+    registry: () => registry,
+  })).toBe("failed");
+  const legacySnapshot = snapshot(conversation.id);
+  legacySnapshot.sessions[0] = { ...legacySnapshot.sessions[0]!, hostKind: "tmux-legacy" };
+  expect(await deliverHeldStructuredMessage(request, {
+    enabled: () => true,
+    client: () => ({ snapshot: async () => legacySnapshot }) as unknown as RuntimeHostClient,
+    registry: () => registry,
+  })).toBe("failed");
 });
 
 test("held delivery stays uncertain during a transient structured snapshot failure", async () => {

--- a/src/lib/runtime/structuredMessageDelivery.ts
+++ b/src/lib/runtime/structuredMessageDelivery.ts
@@ -1,6 +1,6 @@
 import crypto from "node:crypto";
 
-import { agentRegistry, type AgentRegistry } from "@/lib/agent/registry";
+import { agentRegistry, type AgentRegistry, type RegistryConversation } from "@/lib/agent/registry";
 import { requestAccountMigrationTick } from "@/lib/accounts/migration/controllerSignal";
 import type { ViewerConversationId } from "@/lib/accounts/migration/contracts";
 
@@ -8,7 +8,7 @@ import { runtimeHostClient, type RuntimeHostClient } from "./client";
 import type { RuntimeOperationReceipt } from "./contracts";
 import { recoverDeadStructuredConversation } from "./structuredRecovery";
 import { kickStructuredDeliveryQueue } from "./structuredDeliverySignal";
-import { didStructuredHostStartupFail, markStructuredHostStartupReady } from "./startupStatus";
+import { markStructuredHostStartupReady } from "./startupStatus";
 
 export interface StructuredMessageRequest {
   path: string;
@@ -49,6 +49,7 @@ export interface HeldStructuredMessageRequest {
 export interface HeldStructuredMessageDependencies {
   enabled?: () => boolean;
   client?: () => RuntimeHostClient | null;
+  registry?: () => AgentRegistry;
   kick?: () => void | Promise<void>;
   startupFailed?: () => boolean;
   startupRecovered?: () => void;
@@ -68,6 +69,68 @@ function ownershipUnavailable(): StructuredMessageResult {
     error: "structured host ownership is unavailable; retry after runtime synchronization",
     status: 503,
   };
+}
+
+type PersistedMessageOwner = {
+  kind: "structured" | "legacy";
+  conversation: RegistryConversation;
+};
+
+function persistedCurrentOwner(
+  request: Pick<StructuredMessageRequest, "conversationId" | "path">,
+  registry: AgentRegistry,
+): PersistedMessageOwner | null {
+  const conversation = request.conversationId?.startsWith("conversation_")
+    ? registry.conversation(request.conversationId as ViewerConversationId)
+    : registry.conversationForPath(request.path);
+  const generation = conversation?.generations.at(-1);
+  if (!conversation || !generation) return null;
+  const entry = registry.snapshot().entries[`${conversation.engine}:${generation.id}`];
+  if (!entry || entry.artifactPath !== generation.path) return null;
+  const structured = entry.structuredHost !== null && entry.structuredHost !== undefined;
+  const legacy = entry.host !== null;
+  if (structured === legacy) return null;
+  return { kind: structured ? "structured" : "legacy", conversation };
+}
+
+function heldOutcomeDuringRuntimeSynchronization(
+  request: HeldStructuredMessageRequest,
+  registry: AgentRegistry,
+): HeldStructuredMessageOutcome {
+  return persistedCurrentOwner(request, registry)?.kind === "legacy" ? null : "delivery-uncertain";
+}
+
+function holdDuringRuntimeSynchronization(
+  request: StructuredMessageRequest,
+  registry: AgentRegistry,
+  requestTick: () => void,
+): StructuredMessageResult | null {
+  const owner = persistedCurrentOwner(request, registry);
+  if (!owner) return ownershipUnavailable();
+  if (owner.kind === "legacy") return null;
+  const { conversation } = owner;
+  if (request.hasImages) {
+    return { ok: false, structured: true, outcome: "failed", error: "structured host image delivery is unavailable", status: 409 };
+  }
+  try {
+    const idempotencyKey = request.clientMessageId?.trim() || `queue_${crypto.randomUUID()}`;
+    registry.holdDelivery(conversation.id, request.text, idempotencyKey);
+    requestTick();
+    return {
+      ok: true,
+      structured: true,
+      target: conversation.id,
+      outcome: "held",
+    };
+  } catch (error) {
+    return {
+      ok: false,
+      structured: true,
+      outcome: "failed",
+      error: error instanceof Error ? error.message : "structured host delivery failed",
+      status: 503,
+    };
+  }
 }
 
 function recordStructuredRuntimeRecovery(
@@ -94,19 +157,22 @@ export async function deliverHeldStructuredMessage(
 ): Promise<HeldStructuredMessageOutcome> {
   if (!(dependencies.enabled ?? structuredHostsEnabled)()) return null;
   const client = (dependencies.client ?? runtimeHostClient)();
-  if (!client) return (dependencies.startupFailed ?? didStructuredHostStartupFail)() ? null : "delivery-uncertain";
+  if (!client) {
+    return heldOutcomeDuringRuntimeSynchronization(request, (dependencies.registry ?? agentRegistry)());
+  }
   let snapshot: Awaited<ReturnType<RuntimeHostClient["snapshot"]>>;
   try {
     snapshot = await client.snapshot();
   } catch (error) {
     console.error("[structured delivery] runtime snapshot failed", error);
-    return (dependencies.startupFailed ?? didStructuredHostStartupFail)() ? null : "delivery-uncertain";
+    return heldOutcomeDuringRuntimeSynchronization(request, (dependencies.registry ?? agentRegistry)());
   }
   recordStructuredRuntimeRecovery(snapshot, dependencies.startupRecovered ?? markStructuredHostStartupReady);
   const session = snapshot.sessions.find((candidate) => candidate.conversationId === request.conversationId)
     ?? snapshot.sessions.find((candidate) => candidate.artifactPath === request.path);
-  if (!session || session.hostKind === "tmux-legacy") return null;
-  if (session.hostKind !== "codex-app-server" && session.hostKind !== "claude-broker") return null;
+  if (!session) return heldOutcomeDuringRuntimeSynchronization(request, (dependencies.registry ?? agentRegistry)());
+  if (session.hostKind === "tmux-legacy") return null;
+  if (session.hostKind !== "codex-app-server" && session.hostKind !== "claude-broker") return "delivery-uncertain";
   try {
     const result = await client.command({
       kind: "send",
@@ -136,21 +202,38 @@ export async function enqueueStructuredMessage(
 ): Promise<StructuredMessageResult | null> {
   if (!(dependencies.enabled ?? structuredHostsEnabled)()) return null;
   const client = (dependencies.client ?? runtimeHostClient)();
-  if (!client) return (dependencies.startupFailed ?? didStructuredHostStartupFail)() ? null : ownershipUnavailable();
+  if (!client) {
+    return holdDuringRuntimeSynchronization(
+      request,
+      (dependencies.registry ?? agentRegistry)(),
+      dependencies.requestMigrationTick ?? requestAccountMigrationTick,
+    );
+  }
   let snapshot: Awaited<ReturnType<RuntimeHostClient["snapshot"]>>;
   try {
     snapshot = await client.snapshot();
   } catch (error) {
     console.error("[structured delivery] runtime snapshot failed", error);
-    return (dependencies.startupFailed ?? didStructuredHostStartupFail)() ? null : ownershipUnavailable();
+    return holdDuringRuntimeSynchronization(
+      request,
+      (dependencies.registry ?? agentRegistry)(),
+      dependencies.requestMigrationTick ?? requestAccountMigrationTick,
+    );
   }
   recordStructuredRuntimeRecovery(snapshot, dependencies.startupRecovered ?? markStructuredHostStartupReady);
   const session = (request.conversationId
     ? snapshot.sessions.find((candidate) => candidate.conversationId === request.conversationId)
     : undefined)
     ?? snapshot.sessions.find((candidate) => candidate.artifactPath === request.path);
-  if (!session || session.hostKind === "tmux-legacy") return null;
-  if (session.hostKind !== "codex-app-server" && session.hostKind !== "claude-broker") return null;
+  if (!session) {
+    return holdDuringRuntimeSynchronization(
+      request,
+      (dependencies.registry ?? agentRegistry)(),
+      dependencies.requestMigrationTick ?? requestAccountMigrationTick,
+    );
+  }
+  if (session.hostKind === "tmux-legacy") return null;
+  if (session.hostKind !== "codex-app-server" && session.hostKind !== "claude-broker") return ownershipUnavailable();
   if (request.hasImages) {
     return { ok: false, structured: true, outcome: "failed", error: "structured host image delivery is unavailable", status: 409 };
   }

--- a/src/lib/runtime/structuredMessageDelivery.ts
+++ b/src/lib/runtime/structuredMessageDelivery.ts
@@ -45,6 +45,7 @@ export interface StructuredMessageDependencies {
 
 export interface HeldStructuredMessageRequest {
   conversationId: string;
+  runtimeConversationId?: string;
   path: string;
   deliveryId: string;
   clientMessageId: string;
@@ -206,7 +207,7 @@ function deliveredReservationReplay(
   const receipt: RuntimeOperationReceipt = {
     operationId: reservation.command.operationId,
     idempotencyKey,
-    conversationId: reservation.conversationId,
+    conversationId: reservation.runtimeConversationId,
     kind: reservation.command.kind,
     status: "delivered",
     ...(reservation.command.turnId !== undefined ? { turnId: reservation.command.turnId } : {}),
@@ -256,7 +257,7 @@ export async function deliverHeldStructuredMessage(
     const result = await client.command({
       kind: command.kind,
       operationId: command.operationId,
-      conversationId: request.conversationId,
+      conversationId: request.runtimeConversationId ?? request.conversationId,
       idempotencyKey: request.clientMessageId,
       text: request.text,
       policy: command.policy,
@@ -392,7 +393,7 @@ export async function enqueueStructuredMessage(
     const result = await client.command({
       kind: reservation.command.kind,
       operationId: reservation.command.operationId,
-      conversationId: conversation.id,
+      conversationId: reservation.runtimeConversationId,
       idempotencyKey,
       text: request.text,
       policy: reservation.command.policy,

--- a/src/lib/runtime/structuredMessageDelivery.ts
+++ b/src/lib/runtime/structuredMessageDelivery.ts
@@ -7,7 +7,7 @@ import {
   type RegistryConversation,
 } from "@/lib/agent/registry";
 import { requestAccountMigrationTick } from "@/lib/accounts/migration/controllerSignal";
-import type { HeldDeliveryCommand, ViewerConversationId } from "@/lib/accounts/migration/contracts";
+import type { HeldDelivery, HeldDeliveryCommand, ViewerConversationId } from "@/lib/accounts/migration/contracts";
 
 import { runtimeHostClient, type RuntimeHostClient } from "./client";
 import type { RuntimeOperationReceipt } from "./contracts";
@@ -197,6 +197,34 @@ function requestMigrationProgress(
   if (phase && !["committed", "rolled-back"].includes(phase)) requestTick();
 }
 
+function deliveredReservationReplay(
+  reservation: HeldDelivery,
+  idempotencyKey: string,
+  target: ViewerConversationId | null,
+  spawned: boolean,
+): StructuredMessageResult {
+  const receipt: RuntimeOperationReceipt = {
+    operationId: reservation.command.operationId,
+    idempotencyKey,
+    conversationId: reservation.conversationId,
+    kind: reservation.command.kind,
+    status: "delivered",
+    ...(reservation.command.turnId !== undefined ? { turnId: reservation.command.turnId } : {}),
+    reason: null,
+    at: reservation.deliveredAt ?? reservation.createdAt,
+    revision: 1,
+  };
+  return {
+    ok: true,
+    structured: true,
+    target,
+    outcome: "delivered",
+    operationId: reservation.command.operationId,
+    receipt,
+    ...(spawned ? { spawned: true } : {}),
+  };
+}
+
 export async function deliverHeldStructuredMessage(
   request: HeldStructuredMessageRequest,
   dependencies: HeldStructuredMessageDependencies = {},
@@ -330,6 +358,14 @@ export async function enqueueStructuredMessage(
         ...(recoveredHost ? { spawned: true } : {}),
       };
     }
+    if (reservation.state === "delivered") {
+      return deliveredReservationReplay(
+        reservation,
+        idempotencyKey,
+        recoveredHost ? null : conversation.id,
+        recoveredHost,
+      );
+    }
     if (reservation.state === "assigned" && reservation.generationId) {
       const claimed = registry.beginDeliveryAttempt(reservation.id, reservation.generationId);
       if (!claimed) {
@@ -344,7 +380,7 @@ export async function enqueueStructuredMessage(
         };
       }
       claimedReservationId = claimed.id;
-    } else if (reservation.state !== "delivered") {
+    } else {
       return {
         ok: false,
         structured: true,

--- a/src/lib/runtime/structuredMessageDelivery.ts
+++ b/src/lib/runtime/structuredMessageDelivery.ts
@@ -1,8 +1,13 @@
 import crypto from "node:crypto";
 
-import { agentRegistry, type AgentRegistry, type RegistryConversation } from "@/lib/agent/registry";
+import {
+  agentRegistry,
+  DeliveryReservationConflictError,
+  type AgentRegistry,
+  type RegistryConversation,
+} from "@/lib/agent/registry";
 import { requestAccountMigrationTick } from "@/lib/accounts/migration/controllerSignal";
-import type { ViewerConversationId } from "@/lib/accounts/migration/contracts";
+import type { HeldDeliveryCommand, ViewerConversationId } from "@/lib/accounts/migration/contracts";
 
 import { runtimeHostClient, type RuntimeHostClient } from "./client";
 import type { RuntimeOperationReceipt } from "./contracts";
@@ -44,6 +49,7 @@ export interface HeldStructuredMessageRequest {
   deliveryId: string;
   clientMessageId: string;
   text: string;
+  command?: HeldDeliveryCommand;
 }
 
 export interface HeldStructuredMessageDependencies {
@@ -68,6 +74,51 @@ function ownershipUnavailable(): StructuredMessageResult {
     outcome: "failed",
     error: "structured host ownership is unavailable; retry after runtime synchronization",
     status: 503,
+  };
+}
+
+function legacyCommandUnavailable(): StructuredMessageResult {
+  return {
+    ok: false,
+    structured: true,
+    outcome: "failed",
+    error: "legacy delivery cannot preserve structured command semantics",
+    status: 409,
+  };
+}
+
+function requiresStructuredCommand(request: StructuredMessageRequest): boolean {
+  return request.operationId !== undefined
+    || (request.kind ?? "send") !== "send"
+    || (request.policy ?? "interrupt-active") !== "interrupt-active"
+    || request.turnId !== undefined;
+}
+
+function requiresStructuredHeldCommand(request: HeldStructuredMessageRequest): boolean {
+  const command = request.command;
+  return command !== undefined
+    && (command.operationId !== request.deliveryId
+      || command.kind !== "send"
+      || command.policy !== "interrupt-active"
+      || command.turnId !== undefined);
+}
+
+function deliveryFailure(error: unknown): StructuredMessageResult {
+  return {
+    ok: false,
+    structured: true,
+    outcome: "failed",
+    error: error instanceof Error ? error.message : "structured host delivery failed",
+    status: error instanceof DeliveryReservationConflictError ? 409 : 503,
+  };
+}
+
+function commandInput(request: StructuredMessageRequest) {
+  return {
+    ...(request.operationId ? { operationId: request.operationId } : {}),
+    ...(request.kind ? { kind: request.kind } : {}),
+    ...(request.policy ? { policy: request.policy } : {}),
+    ...(request.turnId !== undefined ? { turnId: request.turnId } : {}),
   };
 }
 
@@ -97,7 +148,8 @@ function heldOutcomeDuringRuntimeSynchronization(
   request: HeldStructuredMessageRequest,
   registry: AgentRegistry,
 ): HeldStructuredMessageOutcome {
-  return persistedCurrentOwner(request, registry)?.kind === "legacy" ? null : "delivery-uncertain";
+  if (persistedCurrentOwner(request, registry)?.kind !== "legacy") return "delivery-uncertain";
+  return requiresStructuredHeldCommand(request) ? "failed" : null;
 }
 
 function holdDuringRuntimeSynchronization(
@@ -107,14 +159,14 @@ function holdDuringRuntimeSynchronization(
 ): StructuredMessageResult | null {
   const owner = persistedCurrentOwner(request, registry);
   if (!owner) return ownershipUnavailable();
-  if (owner.kind === "legacy") return null;
+  if (owner.kind === "legacy") return requiresStructuredCommand(request) ? legacyCommandUnavailable() : null;
   const { conversation } = owner;
   if (request.hasImages) {
     return { ok: false, structured: true, outcome: "failed", error: "structured host image delivery is unavailable", status: 409 };
   }
   try {
     const idempotencyKey = request.clientMessageId?.trim() || `queue_${crypto.randomUUID()}`;
-    registry.holdDelivery(conversation.id, request.text, idempotencyKey);
+    registry.holdDelivery(conversation.id, request.text, idempotencyKey, "text", commandInput(request));
     requestTick();
     return {
       ok: true,
@@ -123,13 +175,7 @@ function holdDuringRuntimeSynchronization(
       outcome: "held",
     };
   } catch (error) {
-    return {
-      ok: false,
-      structured: true,
-      outcome: "failed",
-      error: error instanceof Error ? error.message : "structured host delivery failed",
-      status: 503,
-    };
+    return deliveryFailure(error);
   }
 }
 
@@ -171,16 +217,22 @@ export async function deliverHeldStructuredMessage(
   const session = snapshot.sessions.find((candidate) => candidate.conversationId === request.conversationId)
     ?? snapshot.sessions.find((candidate) => candidate.artifactPath === request.path);
   if (!session) return heldOutcomeDuringRuntimeSynchronization(request, (dependencies.registry ?? agentRegistry)());
-  if (session.hostKind === "tmux-legacy") return null;
+  if (session.hostKind === "tmux-legacy") return requiresStructuredHeldCommand(request) ? "failed" : null;
   if (session.hostKind !== "codex-app-server" && session.hostKind !== "claude-broker") return "delivery-uncertain";
   try {
-    const result = await client.command({
-      kind: "send",
+    const command = request.command ?? {
       operationId: request.deliveryId,
+      kind: "send" as const,
+      policy: "interrupt-active" as const,
+    };
+    const result = await client.command({
+      kind: command.kind,
+      operationId: command.operationId,
       conversationId: request.conversationId,
       idempotencyKey: request.clientMessageId,
       text: request.text,
-      policy: "interrupt-active",
+      policy: command.policy,
+      ...(command.turnId !== undefined ? { turnId: command.turnId } : {}),
     });
     try {
       await (dependencies.kick ?? kickStructuredDeliveryQueue)();
@@ -232,7 +284,7 @@ export async function enqueueStructuredMessage(
       dependencies.requestMigrationTick ?? requestAccountMigrationTick,
     );
   }
-  if (session.hostKind === "tmux-legacy") return null;
+  if (session.hostKind === "tmux-legacy") return requiresStructuredCommand(request) ? legacyCommandUnavailable() : null;
   if (session.hostKind !== "codex-app-server" && session.hostKind !== "claude-broker") return ownershipUnavailable();
   if (request.hasImages) {
     return { ok: false, structured: true, outcome: "failed", error: "structured host image delivery is unavailable", status: 409 };
@@ -263,7 +315,7 @@ export async function enqueueStructuredMessage(
   if (!conversation) return ownershipUnavailable();
   try {
     const idempotencyKey = request.clientMessageId?.trim() || `queue_${crypto.randomUUID()}`;
-    let reservation = registry.holdDelivery(conversation.id, request.text, idempotencyKey);
+    let reservation = registry.holdDelivery(conversation.id, request.text, idempotencyKey, "text", commandInput(request));
     let claimedReservationId: string | null = null;
     if (reservation.state === "delivery-uncertain") {
       reservation = registry.retryUncertainDelivery(reservation.id);
@@ -302,13 +354,13 @@ export async function enqueueStructuredMessage(
       };
     }
     const result = await client.command({
-      kind: request.kind ?? "send",
-      ...(request.operationId ? { operationId: request.operationId } : {}),
+      kind: reservation.command.kind,
+      operationId: reservation.command.operationId,
       conversationId: conversation.id,
       idempotencyKey,
       text: request.text,
-      policy: request.policy ?? "interrupt-active",
-      ...(request.turnId !== undefined ? { turnId: request.turnId } : {}),
+      policy: reservation.command.policy,
+      ...(reservation.command.turnId !== undefined ? { turnId: reservation.command.turnId } : {}),
     });
     const receipt = result.receipt;
     if (receipt.status === "rejected" || receipt.status === "failed" || receipt.status === "uncertain") {
@@ -342,12 +394,6 @@ export async function enqueueStructuredMessage(
       ...(recoveredHost ? { spawned: true } : {}),
     };
   } catch (error) {
-    return {
-      ok: false,
-      structured: true,
-      outcome: "failed",
-      error: error instanceof Error ? error.message : "structured host delivery failed",
-      status: 503,
-    };
+    return deliveryFailure(error);
   }
 }

--- a/src/runtime-host/journal.test.ts
+++ b/src/runtime-host/journal.test.ts
@@ -303,6 +303,90 @@ test("runtime restart upgrades global operation idempotency without losing recei
   restarted.close();
 });
 
+test("runtime restart migrates a legacy operation with no conversation identity", () => {
+  const dir = sandbox("operation-idempotency-missing-conversation");
+  const filename = path.join(dir, "events.sqlite");
+  const initial = new RuntimeJournal(filename, { maxEvents: 100, now: () => 100 });
+  const original = initial.executeOperation({
+    kind: "send",
+    operationId: "op-missing-conversation",
+    idempotencyKey: "composer-message-without-conversation",
+    conversationId: "conversation-removed-from-legacy-json",
+    text: "survive the legacy migration",
+    policy: "queue",
+  });
+  initial.close();
+
+  const legacy = new Database(filename);
+  legacy.exec(`
+    BEGIN IMMEDIATE;
+    ALTER TABLE operations RENAME TO operations_scoped_idempotency;
+    CREATE TABLE operations (
+      operation_id TEXT PRIMARY KEY, idempotency_key TEXT NOT NULL UNIQUE,
+      request_hash TEXT NOT NULL, request_json TEXT NOT NULL,
+      receipt_json TEXT NOT NULL, event_seq INTEGER NOT NULL
+    );
+    INSERT INTO operations(operation_id, idempotency_key, request_hash, request_json, receipt_json, event_seq)
+    SELECT operation_id, idempotency_key, request_hash,
+      json_remove(request_json, '$.conversationId'),
+      json_remove(receipt_json, '$.conversationId'),
+      event_seq
+    FROM operations_scoped_idempotency;
+    DROP TABLE operations_scoped_idempotency;
+    COMMIT;
+  `);
+  legacy.close();
+
+  const migrated = new RuntimeJournal(filename, { maxEvents: 100, now: () => 101 });
+  expect(migrated.operationResult(original.operationId)?.receipt.operationId).toBe(original.operationId);
+  migrated.close();
+  const migratedDb = new Database(filename, { readonly: true });
+  expect(migratedDb.query<{ conversation_id: string }, []>(
+    "SELECT conversation_id FROM operations WHERE operation_id = 'op-missing-conversation'",
+  ).get()?.conversation_id).toBe("");
+  migratedDb.close();
+
+  const reopened = new RuntimeJournal(filename, { maxEvents: 100, now: () => 102 });
+  expect(reopened.operationResult(original.operationId)?.receipt.operationId).toBe(original.operationId);
+  reopened.close();
+});
+
+test("runtime restart completes an interrupted operation table rename idempotently", () => {
+  const dir = sandbox("operation-idempotency-interrupted-rename");
+  const filename = path.join(dir, "events.sqlite");
+  const command = {
+    kind: "send" as const,
+    operationId: "op-before-interrupted-rename",
+    idempotencyKey: "composer-message-before-interrupted-rename",
+    conversationId: "conversation-before-interrupted-rename",
+    text: "survive the interrupted table rename",
+    policy: "queue" as const,
+  };
+  const initial = new RuntimeJournal(filename, { maxEvents: 100, now: () => 100 });
+  const original = initial.executeOperation(command);
+  initial.close();
+
+  const interrupted = new Database(filename);
+  interrupted.exec("ALTER TABLE operations RENAME TO operations_global_idempotency");
+  interrupted.close();
+
+  const recovered = new RuntimeJournal(filename, { maxEvents: 100, now: () => 101 });
+  expect(recovered.executeOperation(command)).toEqual({ ...original, replayed: true });
+  recovered.close();
+  const recoveredDb = new Database(filename, { readonly: true });
+  expect(recoveredDb.query<{ count: number }, []>(
+    "SELECT COUNT(*) AS count FROM operations WHERE operation_id = 'op-before-interrupted-rename'",
+  ).get()?.count).toBe(1);
+  expect(recoveredDb.query<{ count: number }, []>(
+    "SELECT COUNT(*) AS count FROM sqlite_master WHERE type = 'table' AND name = 'operations_global_idempotency'",
+  ).get()?.count).toBe(0);
+  recoveredDb.close();
+
+  const reopened = new RuntimeJournal(filename, { maxEvents: 100, now: () => 102 });
+  expect(reopened.executeOperation(command)).toEqual({ ...original, replayed: true });
+  reopened.close();
+});
+
 test("structured send receipts advance through the durable delivery lifecycle", () => {
   const dir = sandbox("structured-delivery-lifecycle");
   const journal = new RuntimeJournal(path.join(dir, "events.sqlite"), {

--- a/src/runtime-host/journal.test.ts
+++ b/src/runtime-host/journal.test.ts
@@ -233,6 +233,76 @@ test("send operations converge by idempotency key and persist one receipt and ef
   journal.close();
 });
 
+test("operation idempotency keys are scoped to their conversation", () => {
+  const dir = sandbox("operation-conversation-dedupe");
+  const journal = new RuntimeJournal(path.join(dir, "events.sqlite"), { maxEvents: 100, now: () => 100 });
+  const first = journal.executeOperation({
+    kind: "send",
+    operationId: "op-conversation-one",
+    idempotencyKey: "composer-message-one",
+    conversationId: "conversation-one",
+    text: "first conversation",
+    policy: "queue",
+  });
+  const second = journal.executeOperation({
+    kind: "send",
+    operationId: "op-conversation-two",
+    idempotencyKey: "composer-message-one",
+    conversationId: "conversation-two",
+    text: "second conversation",
+    policy: "queue",
+  });
+
+  expect(first.replayed).toBe(false);
+  expect(second.replayed).toBe(false);
+  expect(first.receipt.idempotencyKey).toBe(second.receipt.idempotencyKey);
+  expect(journal.snapshot().recentOperations).toHaveLength(2);
+  journal.close();
+});
+
+test("runtime restart upgrades global operation idempotency without losing receipts", () => {
+  const dir = sandbox("operation-idempotency-upgrade");
+  const filename = path.join(dir, "events.sqlite");
+  const originalCommand = {
+    kind: "send" as const,
+    operationId: "op-before-idempotency-upgrade",
+    idempotencyKey: "composer-message-one",
+    conversationId: "conversation-before-upgrade",
+    text: "persist through upgrade",
+    policy: "queue" as const,
+  };
+  const initial = new RuntimeJournal(filename, { maxEvents: 100, now: () => 100 });
+  const original = initial.executeOperation(originalCommand);
+  initial.close();
+
+  const db = new Database(filename);
+  db.exec(`
+    BEGIN IMMEDIATE;
+    ALTER TABLE operations RENAME TO operations_scoped_idempotency;
+    CREATE TABLE operations (
+      operation_id TEXT PRIMARY KEY, idempotency_key TEXT NOT NULL UNIQUE,
+      request_hash TEXT NOT NULL, request_json TEXT NOT NULL,
+      receipt_json TEXT NOT NULL, event_seq INTEGER NOT NULL
+    );
+    INSERT INTO operations(operation_id, idempotency_key, request_hash, request_json, receipt_json, event_seq)
+    SELECT operation_id, idempotency_key, request_hash, request_json, receipt_json, event_seq
+    FROM operations_scoped_idempotency;
+    DROP TABLE operations_scoped_idempotency;
+    COMMIT;
+  `);
+  db.close();
+
+  const restarted = new RuntimeJournal(filename, { maxEvents: 100, now: () => 101 });
+  expect(restarted.executeOperation(originalCommand)).toEqual({ ...original, replayed: true });
+  expect(restarted.executeOperation({
+    ...originalCommand,
+    operationId: "op-after-idempotency-upgrade",
+    conversationId: "conversation-after-upgrade",
+    text: "reuse the composer id in another conversation",
+  }).replayed).toBe(false);
+  restarted.close();
+});
+
 test("structured send receipts advance through the durable delivery lifecycle", () => {
   const dir = sandbox("structured-delivery-lifecycle");
   const journal = new RuntimeJournal(path.join(dir, "events.sqlite"), {

--- a/src/runtime-host/journal.ts
+++ b/src/runtime-host/journal.ts
@@ -1419,24 +1419,57 @@ export class RuntimeJournal {
 
   private migrateOperationIdempotencyScope(): void {
     const columns = new Set(this.db.query<{ name: string }, []>("PRAGMA table_info(operations)").all().map((row) => row.name));
-    if (columns.has("conversation_id")) return;
-    this.db.exec(`
-      BEGIN IMMEDIATE;
-      ALTER TABLE operations RENAME TO operations_global_idempotency;
-      CREATE TABLE operations (
-        operation_id TEXT PRIMARY KEY, conversation_id TEXT NOT NULL, idempotency_key TEXT NOT NULL,
-        request_hash TEXT NOT NULL, request_json TEXT NOT NULL,
-        receipt_json TEXT NOT NULL, event_seq INTEGER NOT NULL,
-        UNIQUE(conversation_id, idempotency_key)
-      );
-      INSERT INTO operations(operation_id, conversation_id, idempotency_key, request_hash, request_json, receipt_json, event_seq)
-      SELECT operation_id,
-        COALESCE(json_extract(request_json, '$.conversationId'), json_extract(receipt_json, '$.conversationId')),
-        idempotency_key, request_hash, request_json, receipt_json, event_seq
-      FROM operations_global_idempotency;
-      DROP TABLE operations_global_idempotency;
-      COMMIT;
-    `);
+    const legacyTableExists = () => Boolean(this.db.query<{ name: string }, []>(
+      "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'operations_global_idempotency'",
+    ).get());
+    if (columns.has("conversation_id") && !legacyTableExists()) return;
+    this.db.exec("BEGIN IMMEDIATE");
+    try {
+      if (!columns.has("conversation_id")) {
+        this.db.exec("ALTER TABLE operations RENAME TO operations_global_idempotency");
+      }
+      this.db.exec(`
+        CREATE TABLE IF NOT EXISTS operations (
+          operation_id TEXT PRIMARY KEY, conversation_id TEXT NOT NULL, idempotency_key TEXT NOT NULL,
+          request_hash TEXT NOT NULL, request_json TEXT NOT NULL,
+          receipt_json TEXT NOT NULL, event_seq INTEGER NOT NULL,
+          UNIQUE(conversation_id, idempotency_key)
+        );
+      `);
+      if (legacyTableExists()) {
+        this.db.exec(`
+          INSERT OR IGNORE INTO operations(operation_id, conversation_id, idempotency_key, request_hash, request_json, receipt_json, event_seq)
+          SELECT operation_id,
+            COALESCE(json_extract(request_json, '$.conversationId'), json_extract(receipt_json, '$.conversationId'), ''),
+            idempotency_key, request_hash, request_json, receipt_json, event_seq
+          FROM operations_global_idempotency;
+        `);
+        const conflict = this.db.query<{ operation_id: string }, []>(`
+          SELECT legacy.operation_id
+          FROM operations_global_idempotency AS legacy
+          LEFT JOIN operations AS scoped
+            ON scoped.operation_id = legacy.operation_id
+            AND scoped.conversation_id = COALESCE(
+              json_extract(legacy.request_json, '$.conversationId'),
+              json_extract(legacy.receipt_json, '$.conversationId'),
+              ''
+            )
+            AND scoped.idempotency_key = legacy.idempotency_key
+            AND scoped.request_hash = legacy.request_hash
+            AND scoped.request_json = legacy.request_json
+            AND scoped.receipt_json = legacy.receipt_json
+            AND scoped.event_seq = legacy.event_seq
+          WHERE scoped.operation_id IS NULL
+          LIMIT 1
+        `).get();
+        if (conflict) throw new Error(`legacy runtime operation conflicts with scoped migration: ${conflict.operation_id}`);
+        this.db.exec("DROP TABLE operations_global_idempotency");
+      }
+      this.db.exec("COMMIT");
+    } catch (error) {
+      try { this.db.exec("ROLLBACK"); } catch { /* transaction already closed */ }
+      throw error;
+    }
   }
 
   private migrateLegacyEvents(): void {

--- a/src/runtime-host/journal.ts
+++ b/src/runtime-host/journal.ts
@@ -254,9 +254,10 @@ export class RuntimeJournal {
       CREATE TABLE IF NOT EXISTS outbox (id TEXT PRIMARY KEY, kind TEXT NOT NULL, payload_json TEXT NOT NULL, event_seq INTEGER NOT NULL, state TEXT NOT NULL);
       CREATE TABLE IF NOT EXISTS producer_receipts (producer_kind TEXT NOT NULL, producer_key TEXT NOT NULL, event_json TEXT NOT NULL, PRIMARY KEY(producer_kind, producer_key));
       CREATE TABLE IF NOT EXISTS operations (
-        operation_id TEXT PRIMARY KEY, idempotency_key TEXT NOT NULL UNIQUE,
+        operation_id TEXT PRIMARY KEY, conversation_id TEXT NOT NULL, idempotency_key TEXT NOT NULL,
         request_hash TEXT NOT NULL, request_json TEXT NOT NULL,
-        receipt_json TEXT NOT NULL, event_seq INTEGER NOT NULL
+        receipt_json TEXT NOT NULL, event_seq INTEGER NOT NULL,
+        UNIQUE(conversation_id, idempotency_key)
       );
       CREATE TABLE IF NOT EXISTS consumer_checkpoints (
         event_id TEXT NOT NULL, consumer TEXT NOT NULL, completed_at INTEGER NOT NULL,
@@ -270,6 +271,7 @@ export class RuntimeJournal {
       CREATE UNIQUE INDEX IF NOT EXISTS viewer_deployments_one_active
         ON viewer_deployments(active) WHERE active = 1;
     `);
+    this.migrateOperationIdempotencyScope();
     this.migrateLegacyEvents();
     for (const row of this.db.query<EventRow, []>("SELECT * FROM events WHERE producer_key IS NOT NULL").all()) {
       this.db.query("INSERT INTO producer_receipts(producer_kind, producer_key, event_json) VALUES (?, ?, ?) ON CONFLICT(producer_kind, producer_key) DO NOTHING")
@@ -325,7 +327,7 @@ export class RuntimeJournal {
     const requestHash = createHash("sha256").update(requestJson).digest("hex");
     this.db.exec("BEGIN IMMEDIATE");
     try {
-      const existing = this.db.query<{ operation_id: string; request_hash: string; receipt_json: string }, [string]>("SELECT operation_id, request_hash, receipt_json FROM operations WHERE idempotency_key = ?").get(command.idempotencyKey);
+      const existing = this.db.query<{ operation_id: string; request_hash: string; receipt_json: string }, [string, string]>("SELECT operation_id, request_hash, receipt_json FROM operations WHERE conversation_id = ? AND idempotency_key = ?").get(command.conversationId, command.idempotencyKey);
       if (existing) {
         if (existing.request_hash !== requestHash) throw new RuntimeIdempotencyConflictError("idempotency key already belongs to another request");
         const result = { operationId: existing.operation_id, receipt: JSON.parse(existing.receipt_json) as RuntimeOperationReceipt, replayed: true };
@@ -362,15 +364,15 @@ export class RuntimeJournal {
         scope: { type: "operation", id: operationId },
         kind: "receipt",
         operationId,
-        producer: { kind: "viewer-command", eventKey: `operation:${command.idempotencyKey}`, hostEpoch: Number(this.meta("host_epoch")) },
+        producer: { kind: "viewer-command", eventKey: `operation:${command.conversationId}:${command.idempotencyKey}`, hostEpoch: Number(this.meta("host_epoch")) },
         payload: receipt as unknown as Record<string, unknown>,
         ...(effect ? { effect } : {}),
       }));
       const committedReceipt: RuntimeOperationReceipt = { ...receipt, revision: event.revision };
       this.upsertEntity("operation", operationId, event.revision, committedReceipt, event.seq);
       this.appendOperationConsequences(command, committedReceipt, operationId);
-      this.db.query("INSERT INTO operations(operation_id, idempotency_key, request_hash, request_json, receipt_json, event_seq) VALUES (?, ?, ?, ?, ?, ?)")
-        .run(operationId, command.idempotencyKey, requestHash, requestJson, stableJson(committedReceipt), event.seq);
+      this.db.query("INSERT INTO operations(operation_id, conversation_id, idempotency_key, request_hash, request_json, receipt_json, event_seq) VALUES (?, ?, ?, ?, ?, ?, ?)")
+        .run(operationId, command.conversationId, command.idempotencyKey, requestHash, requestJson, stableJson(committedReceipt), event.seq);
       this.db.exec("COMMIT");
       this.compactIfNeeded();
       this.notifyWaiters();
@@ -1413,6 +1415,28 @@ export class RuntimeJournal {
 
   private assertHealthy(): void {
     if (this.fault) throw new RuntimeJournalFault(`runtime journal is read-only: ${this.fault}`);
+  }
+
+  private migrateOperationIdempotencyScope(): void {
+    const columns = new Set(this.db.query<{ name: string }, []>("PRAGMA table_info(operations)").all().map((row) => row.name));
+    if (columns.has("conversation_id")) return;
+    this.db.exec(`
+      BEGIN IMMEDIATE;
+      ALTER TABLE operations RENAME TO operations_global_idempotency;
+      CREATE TABLE operations (
+        operation_id TEXT PRIMARY KEY, conversation_id TEXT NOT NULL, idempotency_key TEXT NOT NULL,
+        request_hash TEXT NOT NULL, request_json TEXT NOT NULL,
+        receipt_json TEXT NOT NULL, event_seq INTEGER NOT NULL,
+        UNIQUE(conversation_id, idempotency_key)
+      );
+      INSERT INTO operations(operation_id, conversation_id, idempotency_key, request_hash, request_json, receipt_json, event_seq)
+      SELECT operation_id,
+        COALESCE(json_extract(request_json, '$.conversationId'), json_extract(receipt_json, '$.conversationId')),
+        idempotency_key, request_hash, request_json, receipt_json, event_seq
+      FROM operations_global_idempotency;
+      DROP TABLE operations_global_idempotency;
+      COMMIT;
+    `);
   }
 
   private migrateLegacyEvents(): void {


### PR DESCRIPTION
## Summary

- classify deployment-window ownership from the persisted current AgentRegistry generation when the runtime client or snapshot is unavailable
- reserve structured composer text with the exact client ID and request the existing controller drain
- persist canonical command kind, policy, operation identity, and turn fence across registry reopen and runtime recovery
- retain a versioned request digest over conversation, text, kind, policy, and the absent/null/value turn fence
- return 409 for changed payload or command reuse while preserving the original reservation and delivered tombstone
- apply safe send/interrupt defaults to old text-only reservations
- authorize legacy fallthrough for compatible sends and fence structured-only semantics before legacy actuation
- preserve image and oversized-text request-local behavior
- reconcile identical retries through refresh, outage drain, runtime recovery, and delivered settlement with one engine write

## Root cause

Synchronization holds persisted text and the client ID while recovery rebuilt every command as a new interrupting send. Reusing a client ID returned the existing reservation without proving that the caller supplied the same request. Delivered tombstones had already cleared their text, so changed drafts could receive a false held acknowledgement.

## TDD regressions

- outage and registry-reopen recovery preserve explicit steer fields and the original operation identity
- stale turn fences fail before an engine effect across Codex and Claude
- Codex and Claude migration successor drains preserve the durable command
- legacy outage and snapshot routes reject unsupported structured semantics
- identical retries across reopen, recovery, delivery, and tombstone replay create one reservation and one engine write
- changed text, kind, policy, or turn fence returns 409 and leaves the original reservation unchanged
- delivered-tombstone conflicts preserve the caller draft
- provisional-to-canonical conversation adoption keeps identical retries idempotent
- old text-only reservations reopen with safe schema defaults

## Verification

- `bun test src/lib/runtime/structuredMessageDelivery.test.ts src/lib/runtime/structuredDelivery.integration.test.ts src/lib/accounts/migration/controller.test.ts src/lib/accounts/migration/controllerSignal.test.ts src/lib/accounts/migration/coordinator.test.ts src/lib/agent/registry.test.ts src/lib/delivery.test.ts src/lib/runtime/http.test.ts src/lib/runtime/startup.test.ts src/app/api/tmux/route.test.ts src/app/api/spawn/route.test.ts` — 282 passed
- `bun test src/lib/agent/registry.sqlite.test.ts` — 19 passed
- `bun test src/lib/runtime/structuredSpawn.integration.test.ts src/lib/runtime/codexAppServerHost.integration.test.ts src/lib/runtime/claudeStreamBrokerHost.integration.test.ts` — green, including real Codex and Claude restart/resume integrations
- `bunx tsc --noEmit` — green
- scoped ESLint over all 10 changed files — 0 errors; one inherited warning outside the diff
- `git diff --check` and base diff-check — green
- debug/residue scan — clean
- full-diff self-review across correctness, tests, comments, error handling, types, and simplification — clean

Base: `710c4590b677fe5852ed33e9ab1b78d3eb449fec`

Refs #308
