### PR TITLE
Fix expired Claude OAuth spawn admission

### DIFF
--- a/src/app/api/spawn/route.test.ts
+++ b/src/app/api/spawn/route.test.ts
@@ -8,6 +8,9 @@ import { NextRequest } from "next/server";
 import { agentRegistry, AgentRegistry } from "@/lib/agent/registry";
 import { emptyLaunchProfile } from "@/lib/accounts/migration/contracts";
 import { codexSessionRoots, createManagedCodexAccount } from "@/lib/accounts/codex";
+import type { ClaudeAccount } from "@/lib/accounts/claude";
+import { refreshClaudeOauth } from "@/lib/accounts/claudeOauth";
+import { selectHealthyClaudeAccount } from "@/lib/accounts/spawnHealth";
 import { spawnParentSelector, spawnRequestDigest } from "@/lib/agent/spawnIdentity";
 import { rotateOperatorSpawnCapability } from "@/lib/agent/operatorCapability";
 import { spawnReplayStatus, spawnResponseForReceipt } from "@/lib/agent/spawnResponse";
@@ -60,6 +63,105 @@ function structuredRouteDependencies(cwd: string): SpawnRouteTestDependencies {
     }),
   };
 }
+
+test("post-reboot spawn refreshes an expired Claude account before structured launch", async () => {
+  const cwd = fs.mkdtempSync(path.join(routeSandbox, "expired-claude-spawn-"));
+  const home = path.join(cwd, "claude-home");
+  fs.mkdirSync(home, { mode: 0o700 });
+  fs.writeFileSync(path.join(home, ".credentials.json"), JSON.stringify({
+    claudeAiOauth: {
+      accessToken: crypto.randomUUID(),
+      refreshToken: crypto.randomUUID(),
+      expiresAt: 1,
+      scopes: ["user:inference"],
+    },
+  }), { mode: 0o600 });
+  const account: ClaudeAccount = {
+    id: "rebooted",
+    label: "rebooted",
+    kind: "managed",
+    home,
+    projectsDir: path.join(home, "projects"),
+    authPresent: true,
+    createdAt: 0,
+  };
+  const store = new AgentRegistry(path.join(cwd, "registry.json"), undefined, undefined, { sqliteMode: "off" });
+  let structuredSpawns = 0;
+  const base = structuredRouteDependencies(cwd);
+  const dependencies: SpawnRouteTestDependencies = {
+    ...base,
+    registry: () => store,
+    resolveHealthySpawnAccount: async () => {
+      const selected = await selectHealthyClaudeAccount([account], account.id, {
+        now: () => 2,
+        probe: async () => "valid",
+        refresh: async (candidate) => {
+          const refreshed = await refreshClaudeOauth(candidate, {
+            now: () => 2,
+            fetch: async () => Response.json({
+              access_token: crypto.randomUUID(),
+              refresh_token: crypto.randomUUID(),
+              expires_in: 3_600,
+              scope: "user:inference",
+            }),
+          });
+          return refreshed === "refreshed" ? "valid" : refreshed === "invalid" ? "invalid" : "unknown";
+        },
+      });
+      return {
+        engine: "claude",
+        accountId: selected.id,
+        kind: selected.kind,
+        home: selected.home,
+        transcriptRoot: selected.projectsDir,
+        env: { NODE_ENV: "test" },
+      };
+    },
+    spawnStructuredConversation: async (input) => {
+      structuredSpawns += 1;
+      return await base.spawnStructuredConversation(input);
+    },
+  };
+  const previous = {
+    transport: process.env.LLV_SPAWN_TRANSPORT,
+    hosts: process.env.LLV_STRUCTURED_HOSTS,
+    events: process.env.LLV_RUNTIME_EVENTS,
+    socket: process.env.LLV_RUNTIME_HOST_SOCKET,
+    ui: process.env.NEXT_PUBLIC_RUNTIME_UI,
+  };
+  process.env.LLV_SPAWN_TRANSPORT = "structured";
+  process.env.LLV_STRUCTURED_HOSTS = "1";
+  process.env.LLV_RUNTIME_EVENTS = "1";
+  process.env.LLV_RUNTIME_HOST_SOCKET = path.join(cwd, "runtime.sock");
+  process.env.NEXT_PUBLIC_RUNTIME_UI = "1";
+  try {
+    const response = await POST.withDependencies(new NextRequest("http://127.0.0.1:8898/api/spawn", {
+      method: "POST",
+      headers: {
+        host: "127.0.0.1:8898",
+        origin: "http://127.0.0.1:8898",
+        "sec-fetch-site": "same-origin",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({ engine: "claude", cwd, prompt: "resume work", accountId: account.id }),
+    }), dependencies);
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({ launched: true, state: "settled" });
+    expect(structuredSpawns).toBe(1);
+  } finally {
+    if (previous.transport === undefined) delete process.env.LLV_SPAWN_TRANSPORT;
+    else process.env.LLV_SPAWN_TRANSPORT = previous.transport;
+    if (previous.hosts === undefined) delete process.env.LLV_STRUCTURED_HOSTS;
+    else process.env.LLV_STRUCTURED_HOSTS = previous.hosts;
+    if (previous.events === undefined) delete process.env.LLV_RUNTIME_EVENTS;
+    else process.env.LLV_RUNTIME_EVENTS = previous.events;
+    if (previous.socket === undefined) delete process.env.LLV_RUNTIME_HOST_SOCKET;
+    else process.env.LLV_RUNTIME_HOST_SOCKET = previous.socket;
+    if (previous.ui === undefined) delete process.env.NEXT_PUBLIC_RUNTIME_UI;
+    else process.env.NEXT_PUBLIC_RUNTIME_UI = previous.ui;
+  }
+});
 
 test("structured spawn runtime fence preserves durable state", async () => {
   const cwd = fs.mkdtempSync(path.join(routeSandbox, "structured-runtime-fence-"));

--- a/src/app/api/spawn/route.test.ts
+++ b/src/app/api/spawn/route.test.ts
@@ -8,9 +8,6 @@ import { NextRequest } from "next/server";
 import { agentRegistry, AgentRegistry } from "@/lib/agent/registry";
 import { emptyLaunchProfile } from "@/lib/accounts/migration/contracts";
 import { codexSessionRoots, createManagedCodexAccount } from "@/lib/accounts/codex";
-import type { ClaudeAccount } from "@/lib/accounts/claude";
-import { refreshClaudeOauth } from "@/lib/accounts/claudeOauth";
-import { selectHealthyClaudeAccount } from "@/lib/accounts/spawnHealth";
 import { spawnParentSelector, spawnRequestDigest } from "@/lib/agent/spawnIdentity";
 import { rotateOperatorSpawnCapability } from "@/lib/agent/operatorCapability";
 import { spawnReplayStatus, spawnResponseForReceipt } from "@/lib/agent/spawnResponse";
@@ -64,78 +61,82 @@ function structuredRouteDependencies(cwd: string): SpawnRouteTestDependencies {
   };
 }
 
-test("post-reboot spawn refreshes an expired Claude account before structured launch", async () => {
-  const cwd = fs.mkdtempSync(path.join(routeSandbox, "expired-claude-spawn-"));
-  const home = path.join(cwd, "claude-home");
-  fs.mkdirSync(home, { mode: 0o700 });
+test("a fresh process resolves and refreshes a persisted Claude account before one structured launch", async () => {
+  const sandbox = fs.mkdtempSync(path.join(routeSandbox, "production-resolver-reboot-"));
+  const stateDir = path.join(sandbox, "state");
+  const accountsRoot = path.join(sandbox, "accounts", "claude");
+  const home = path.join(accountsRoot, "rebooted");
+  const cwd = path.join(sandbox, "workspace");
+  fs.mkdirSync(stateDir, { recursive: true, mode: 0o700 });
+  fs.mkdirSync(home, { recursive: true, mode: 0o700 });
+  fs.chmodSync(accountsRoot, 0o700);
+  fs.chmodSync(home, 0o700);
+  fs.mkdirSync(path.join(home, "projects"), { mode: 0o700 });
+  fs.mkdirSync(cwd, { mode: 0o700 });
+  fs.writeFileSync(path.join(stateDir, "claude-accounts.json"), JSON.stringify({
+    version: 1,
+    active: "rebooted",
+    accounts: [{ id: "rebooted", label: "Rebooted", kind: "managed", createdAt: 1 }],
+  }), { mode: 0o600 });
   fs.writeFileSync(path.join(home, ".credentials.json"), JSON.stringify({
     claudeAiOauth: {
-      accessToken: crypto.randomUUID(),
-      refreshToken: crypto.randomUUID(),
+      accessToken: "synthetic-expired-access",
+      refreshToken: "synthetic-refresh",
       expiresAt: 1,
       scopes: ["user:inference"],
     },
   }), { mode: 0o600 });
-  const account: ClaudeAccount = {
-    id: "rebooted",
-    label: "rebooted",
-    kind: "managed",
-    home,
-    projectsDir: path.join(home, "projects"),
-    authPresent: true,
-    createdAt: 0,
-  };
-  const store = new AgentRegistry(path.join(cwd, "registry.json"), undefined, undefined, { sqliteMode: "off" });
-  let structuredSpawns = 0;
-  const base = structuredRouteDependencies(cwd);
-  const dependencies: SpawnRouteTestDependencies = {
-    ...base,
-    registry: () => store,
-    resolveHealthySpawnAccount: async () => {
-      const selected = await selectHealthyClaudeAccount([account], account.id, {
-        now: () => 2,
-        probe: async () => "valid",
-        refresh: async (candidate) => {
-          const refreshed = await refreshClaudeOauth(candidate, {
-            now: () => 2,
-            fetch: async () => Response.json({
-              access_token: crypto.randomUUID(),
-              refresh_token: crypto.randomUUID(),
-              expires_in: 3_600,
-              scope: "user:inference",
-            }),
-          });
-          return refreshed === "refreshed" ? "valid" : refreshed === "invalid" ? "invalid" : "unknown";
-        },
-      });
-      return {
-        engine: "claude",
-        accountId: selected.id,
-        kind: selected.kind,
-        home: selected.home,
-        transcriptRoot: selected.projectsDir,
-        env: { NODE_ENV: "test" },
-      };
-    },
-    spawnStructuredConversation: async (input) => {
-      structuredSpawns += 1;
-      return await base.spawnStructuredConversation(input);
-    },
-  };
-  const previous = {
-    transport: process.env.LLV_SPAWN_TRANSPORT,
-    hosts: process.env.LLV_STRUCTURED_HOSTS,
-    events: process.env.LLV_RUNTIME_EVENTS,
-    socket: process.env.LLV_RUNTIME_HOST_SOCKET,
-    ui: process.env.NEXT_PUBLIC_RUNTIME_UI,
-  };
-  process.env.LLV_SPAWN_TRANSPORT = "structured";
-  process.env.LLV_STRUCTURED_HOSTS = "1";
-  process.env.LLV_RUNTIME_EVENTS = "1";
-  process.env.LLV_RUNTIME_HOST_SOCKET = path.join(cwd, "runtime.sock");
-  process.env.NEXT_PUBLIC_RUNTIME_UI = "1";
-  try {
-    const response = await POST.withDependencies(new NextRequest("http://127.0.0.1:8898/api/spawn", {
+
+  const routePath = path.join(import.meta.dir, "route.ts");
+  const structuredSpawnPath = path.join(import.meta.dir, "../../../lib/runtime/structuredSpawn.ts");
+  const runtimeClientPath = path.join(import.meta.dir, "../../../lib/runtime/client.ts");
+  const source = `
+    const { mock } = await import("bun:test");
+    let refreshRequests = 0;
+    let usageRequests = 0;
+    let structuredSpawns = 0;
+    let launchedAccount = null;
+    globalThis.fetch = async (input, init) => {
+      const url = String(input);
+      if (url === "https://platform.claude.com/v1/oauth/token") {
+        refreshRequests += 1;
+        return Response.json({
+          access_token: "synthetic-current-access",
+          refresh_token: "synthetic-rotated-refresh",
+          expires_in: 3600,
+          scope: "user:inference",
+        });
+      }
+      if (url === "https://api.anthropic.com/api/oauth/usage") {
+        usageRequests += 1;
+        return Response.json({ five_hour: { utilization: 12, resets_at: "2026-07-17T12:00:00.000Z" } });
+      }
+      throw new Error("unexpected synthetic upstream request");
+    };
+    const structured = await import(${JSON.stringify(structuredSpawnPath)});
+    mock.module("@/lib/runtime/structuredSpawn", () => ({
+      ...structured,
+      spawnStructuredConversation: async (input) => {
+        structuredSpawns += 1;
+        launchedAccount = input.account.accountId;
+        return {
+          ok: true,
+          target: null,
+          path: null,
+          effectivePermissionMode: input.spec.launchProfile?.permissionMode ?? "default",
+          launchId: input.receipt.launchId,
+          conversationId: input.receipt.conversationId,
+          launched: true,
+          retrySafe: false,
+          state: "settled",
+        };
+      },
+    }));
+    const runtimeClient = await import(${JSON.stringify(runtimeClientPath)});
+    mock.module("@/lib/runtime/client", () => ({ ...runtimeClient, runtimeHostClient: () => ({}) }));
+    const { NextRequest } = await import("next/server");
+    const { POST } = await import(${JSON.stringify(routePath)});
+    const response = await POST(new NextRequest("http://127.0.0.1:8898/api/spawn", {
       method: "POST",
       headers: {
         host: "127.0.0.1:8898",
@@ -143,25 +144,53 @@ test("post-reboot spawn refreshes an expired Claude account before structured la
         "sec-fetch-site": "same-origin",
         "content-type": "application/json",
       },
-      body: JSON.stringify({ engine: "claude", cwd, prompt: "resume work", accountId: account.id }),
-    }), dependencies);
+      body: JSON.stringify({ engine: "claude", cwd: ${JSON.stringify(cwd)}, prompt: "resume work", accountId: "rebooted" }),
+    }));
+    const body = await response.json();
+    const credentials = JSON.parse(await Bun.file(${JSON.stringify(path.join(home, ".credentials.json"))}).text());
+    process.stdout.write(JSON.stringify({
+      status: response.status,
+      body,
+      refreshRequests,
+      usageRequests,
+      structuredSpawns,
+      launchedAccount,
+      accessToken: credentials.claudeAiOauth.accessToken,
+    }));
+  `;
+  const child = Bun.spawn({
+    cmd: [process.execPath, "-e", source],
+    cwd: process.cwd(),
+    env: {
+      ...process.env,
+      LLV_STATE_DIR: stateDir,
+      LLV_CLAUDE_HOME: path.join(sandbox, "legacy-claude"),
+      LLV_SPAWN_TRANSPORT: "structured",
+      LLV_STRUCTURED_HOSTS: "1",
+      LLV_RUNTIME_EVENTS: "1",
+      LLV_RUNTIME_HOST_SOCKET: path.join(sandbox, "runtime.sock"),
+      NEXT_PUBLIC_RUNTIME_UI: "1",
+    },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [exit, stdout, stderr] = await Promise.all([
+    child.exited,
+    new Response(child.stdout).text(),
+    new Response(child.stderr).text(),
+  ]);
 
-    expect(response.status).toBe(200);
-    expect(await response.json()).toMatchObject({ launched: true, state: "settled" });
-    expect(structuredSpawns).toBe(1);
-  } finally {
-    if (previous.transport === undefined) delete process.env.LLV_SPAWN_TRANSPORT;
-    else process.env.LLV_SPAWN_TRANSPORT = previous.transport;
-    if (previous.hosts === undefined) delete process.env.LLV_STRUCTURED_HOSTS;
-    else process.env.LLV_STRUCTURED_HOSTS = previous.hosts;
-    if (previous.events === undefined) delete process.env.LLV_RUNTIME_EVENTS;
-    else process.env.LLV_RUNTIME_EVENTS = previous.events;
-    if (previous.socket === undefined) delete process.env.LLV_RUNTIME_HOST_SOCKET;
-    else process.env.LLV_RUNTIME_HOST_SOCKET = previous.socket;
-    if (previous.ui === undefined) delete process.env.NEXT_PUBLIC_RUNTIME_UI;
-    else process.env.NEXT_PUBLIC_RUNTIME_UI = previous.ui;
-  }
-});
+  expect({ exit, stderr }).toEqual({ exit: 0, stderr: "" });
+  expect(JSON.parse(stdout)).toEqual({
+    status: 200,
+    body: expect.objectContaining({ launched: true, state: "settled" }),
+    refreshRequests: 1,
+    usageRequests: 1,
+    structuredSpawns: 1,
+    launchedAccount: "rebooted",
+    accessToken: "synthetic-current-access",
+  });
+}, 20_000);
 
 test("structured spawn runtime fence preserves durable state", async () => {
   const cwd = fs.mkdtempSync(path.join(routeSandbox, "structured-runtime-fence-"));

--- a/src/lib/accounts/claudeOauth.test.ts
+++ b/src/lib/accounts/claudeOauth.test.ts
@@ -92,6 +92,7 @@ test("only positive invalid_grant evidence is fenced while other failures remain
   const unclassified401 = account("unclassified-401");
   const invalidGrant = account("invalid-grant");
   const invalidGrant401 = account("invalid-grant-401");
+  const unauthorizedClient = account("unauthorized-client");
   const invalidScope = account("invalid-scope");
   const transient = account("transient");
 
@@ -111,6 +112,10 @@ test("only positive invalid_grant evidence is fenced while other failures remain
     now: () => NOW,
     fetch: async () => Response.json({ error: "invalid_grant" }, { status: 401 }),
   })).resolves.toBe("invalid");
+  await expect(refreshClaudeOauth(unauthorizedClient, {
+    now: () => NOW,
+    fetch: async () => Response.json({ error: "unauthorized_client" }, { status: 401 }),
+  })).resolves.toBe("unknown");
   await expect(refreshClaudeOauth(invalidScope, {
     now: () => NOW,
     fetch: async () => Response.json({ error: "invalid_scope" }, { status: 400 }),
@@ -193,11 +198,13 @@ test("a native refresh lock bounds Viewer admission without starting duplicate r
 
   expect(result).toBe("unknown");
   expect(fetchCalls).toBe(0);
+  expect(fs.existsSync(path.join(candidate.home, ".oauth_refresh.lock"))).toBeTrue();
 });
 
 test("a legacy native refresh lock bounds Viewer admission without starting duplicate refresh work", async () => {
   const candidate = account("legacy-native-lock");
-  fs.mkdirSync(`${fs.realpathSync(candidate.home)}.lock`, { mode: 0o700 });
+  const legacyLock = `${fs.realpathSync(candidate.home)}.lock`;
+  fs.mkdirSync(legacyLock, { mode: 0o700 });
   let fetchCalls = 0;
 
   const result = await refreshClaudeOauth(candidate, {
@@ -211,7 +218,29 @@ test("a legacy native refresh lock bounds Viewer admission without starting dupl
 
   expect(result).toBe("unknown");
   expect(fetchCalls).toBe(0);
+  expect(fs.existsSync(legacyLock)).toBeTrue();
   expect(fs.existsSync(path.join(candidate.home, ".oauth_refresh.lock"))).toBeFalse();
+});
+
+test("Viewer release preserves native lock directories replaced by another owner", async () => {
+  const candidate = account("replaced-native-locks");
+  const currentLock = path.join(candidate.home, ".oauth_refresh.lock");
+  const legacyLock = `${fs.realpathSync(candidate.home)}.lock`;
+
+  const result = await refreshClaudeOauth(candidate, {
+    now: () => NOW,
+    fetch: async () => {
+      fs.rmdirSync(legacyLock);
+      fs.rmdirSync(currentLock);
+      fs.mkdirSync(currentLock, { mode: 0o700 });
+      fs.mkdirSync(legacyLock, { mode: 0o700 });
+      return new Response(null, { status: 503 });
+    },
+  });
+
+  expect(result).toBe("unknown");
+  expect(fs.existsSync(currentLock)).toBeTrue();
+  expect(fs.existsSync(legacyLock)).toBeTrue();
 });
 
 test("Viewer reuses a native rotation completed while waiting for the refresh lock", async () => {

--- a/src/lib/accounts/claudeOauth.test.ts
+++ b/src/lib/accounts/claudeOauth.test.ts
@@ -11,7 +11,10 @@ const NOW = Date.parse("2026-07-17T09:00:00.000Z");
 const homes: string[] = [];
 
 afterEach(() => {
-  for (const home of homes.splice(0)) fs.rmSync(home, { recursive: true, force: true });
+  for (const home of homes.splice(0)) {
+    fs.rmSync(home, { recursive: true, force: true });
+    fs.rmSync(`${home}.lock`, { recursive: true, force: true });
+  }
 });
 
 function account(id: string): ClaudeAccount {
@@ -52,16 +55,17 @@ test("a successful bounded OAuth refresh persists current launch metadata", asyn
   expect(fs.statSync(path.join(candidate.home, ".credentials.json")).mode & 0o777).toBe(0o600);
 });
 
-test("a rejected refresh is fenced while server failures remain transient", async () => {
-  const rejected = account("rejected");
+test("only positive invalid_grant evidence is fenced while other failures remain transient", async () => {
+  const unclassified401 = account("unclassified-401");
   const invalidGrant = account("invalid-grant");
+  const invalidGrant401 = account("invalid-grant-401");
   const invalidScope = account("invalid-scope");
   const transient = account("transient");
 
-  await expect(refreshClaudeOauth(rejected, {
+  await expect(refreshClaudeOauth(unclassified401, {
     now: () => NOW,
     fetch: async () => new Response(null, { status: 401 }),
-  })).resolves.toBe("invalid");
+  })).resolves.toBe("unknown");
   await expect(refreshClaudeOauth(transient, {
     now: () => NOW,
     fetch: async () => new Response(null, { status: 503 }),
@@ -70,13 +74,52 @@ test("a rejected refresh is fenced while server failures remain transient", asyn
     now: () => NOW,
     fetch: async () => Response.json({ error: "invalid_grant" }, { status: 400 }),
   })).resolves.toBe("invalid");
+  await expect(refreshClaudeOauth(invalidGrant401, {
+    now: () => NOW,
+    fetch: async () => Response.json({ error: "invalid_grant" }, { status: 401 }),
+  })).resolves.toBe("invalid");
   await expect(refreshClaudeOauth(invalidScope, {
     now: () => NOW,
     fetch: async () => Response.json({ error: "invalid_scope" }, { status: 400 }),
   })).resolves.toBe("unknown");
 
-  expect(claudeOauthMetadata(rejected)?.expiresAt).toBe(NOW - 1);
+  expect(claudeOauthMetadata(unclassified401)?.expiresAt).toBe(NOW - 1);
   expect(claudeOauthMetadata(transient)?.expiresAt).toBe(NOW - 1);
+});
+
+test("HTTP 401 invalid_client remains a transient compatibility failure", async () => {
+  const candidate = account("invalid-client");
+
+  const result = await refreshClaudeOauth(candidate, {
+    now: () => NOW,
+    fetch: async () => Response.json({ error: "invalid_client" }, { status: 401 }),
+  });
+
+  expect(result).toBe("unknown");
+  expect(claudeOauthMetadata(candidate)?.expiresAt).toBe(NOW - 1);
+});
+
+test("a first-party invalid_scope response retries with the stored inference scopes", async () => {
+  const candidate = account("invalid-scope-fallback");
+  const requestedScopes: string[] = [];
+
+  const result = await refreshClaudeOauth(candidate, {
+    now: () => NOW,
+    fetch: async (_input, init) => {
+      const body = JSON.parse(String(init?.body)) as { scope: string };
+      requestedScopes.push(body.scope);
+      if (requestedScopes.length === 1) {
+        return Response.json({ error: "invalid_scope" }, { status: 400 });
+      }
+      return Response.json({ access_token: crypto.randomUUID(), expires_in: 3_600, scope: body.scope });
+    },
+  });
+
+  expect(result).toBe("refreshed");
+  expect(requestedScopes).toEqual([
+    "user:profile user:inference user:sessions:claude_code user:mcp_servers user:file_upload",
+    "user:inference",
+  ]);
 });
 
 test("a late refresh rejection observes a concurrent native credential rotation", async () => {
@@ -117,6 +160,25 @@ test("a native refresh lock bounds Viewer admission without starting duplicate r
 
   expect(result).toBe("unknown");
   expect(fetchCalls).toBe(0);
+});
+
+test("a legacy native refresh lock bounds Viewer admission without starting duplicate refresh work", async () => {
+  const candidate = account("legacy-native-lock");
+  fs.mkdirSync(`${fs.realpathSync(candidate.home)}.lock`, { mode: 0o700 });
+  let fetchCalls = 0;
+
+  const result = await refreshClaudeOauth(candidate, {
+    now: () => NOW,
+    lockWaitMs: 1,
+    fetch: async () => {
+      fetchCalls += 1;
+      return new Response(null, { status: 503 });
+    },
+  });
+
+  expect(result).toBe("unknown");
+  expect(fetchCalls).toBe(0);
+  expect(fs.existsSync(path.join(candidate.home, ".oauth_refresh.lock"))).toBeFalse();
 });
 
 test("Viewer reuses a native rotation completed while waiting for the refresh lock", async () => {

--- a/src/lib/accounts/claudeOauth.test.ts
+++ b/src/lib/accounts/claudeOauth.test.ts
@@ -1,0 +1,194 @@
+import crypto from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, expect, test } from "bun:test";
+
+import type { ClaudeAccount } from "./claude";
+import { claudeOauthMetadata, refreshClaudeOauth } from "./claudeOauth";
+
+const NOW = Date.parse("2026-07-17T09:00:00.000Z");
+const homes: string[] = [];
+
+afterEach(() => {
+  for (const home of homes.splice(0)) fs.rmSync(home, { recursive: true, force: true });
+});
+
+function account(id: string): ClaudeAccount {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), `llv-claude-oauth-${id}-`));
+  homes.push(home);
+  fs.writeFileSync(path.join(home, ".credentials.json"), JSON.stringify({
+    claudeAiOauth: {
+      accessToken: crypto.randomUUID(),
+      refreshToken: crypto.randomUUID(),
+      expiresAt: NOW - 1,
+      scopes: ["user:inference"],
+      subscriptionType: "max",
+    },
+  }), { mode: 0o600 });
+  return { id, label: id, kind: "managed", home, projectsDir: path.join(home, "projects"), authPresent: true, createdAt: 0 };
+}
+
+test("a successful bounded OAuth refresh persists current launch metadata", async () => {
+  const candidate = account("refreshable");
+  let signal: AbortSignal | null = null;
+
+  const result = await refreshClaudeOauth(candidate, {
+    now: () => NOW,
+    fetch: async (_input, init) => {
+      signal = init?.signal ?? null;
+      return Response.json({
+        access_token: crypto.randomUUID(),
+        refresh_token: crypto.randomUUID(),
+        expires_in: 3_600,
+        scope: "user:inference",
+      });
+    },
+  });
+
+  expect(result).toBe("refreshed");
+  expect(signal).toBeInstanceOf(AbortSignal);
+  expect(claudeOauthMetadata(candidate)).toEqual({ expiresAt: NOW + 3_600_000, refreshable: true });
+  expect(fs.statSync(path.join(candidate.home, ".credentials.json")).mode & 0o777).toBe(0o600);
+});
+
+test("a rejected refresh is fenced while server failures remain transient", async () => {
+  const rejected = account("rejected");
+  const invalidGrant = account("invalid-grant");
+  const invalidScope = account("invalid-scope");
+  const transient = account("transient");
+
+  await expect(refreshClaudeOauth(rejected, {
+    now: () => NOW,
+    fetch: async () => new Response(null, { status: 401 }),
+  })).resolves.toBe("invalid");
+  await expect(refreshClaudeOauth(transient, {
+    now: () => NOW,
+    fetch: async () => new Response(null, { status: 503 }),
+  })).resolves.toBe("unknown");
+  await expect(refreshClaudeOauth(invalidGrant, {
+    now: () => NOW,
+    fetch: async () => Response.json({ error: "invalid_grant" }, { status: 400 }),
+  })).resolves.toBe("invalid");
+  await expect(refreshClaudeOauth(invalidScope, {
+    now: () => NOW,
+    fetch: async () => Response.json({ error: "invalid_scope" }, { status: 400 }),
+  })).resolves.toBe("unknown");
+
+  expect(claudeOauthMetadata(rejected)?.expiresAt).toBe(NOW - 1);
+  expect(claudeOauthMetadata(transient)?.expiresAt).toBe(NOW - 1);
+});
+
+test("a late refresh rejection observes a concurrent native credential rotation", async () => {
+  const candidate = account("native-race");
+
+  const result = await refreshClaudeOauth(candidate, {
+    now: () => NOW,
+    fetch: async () => {
+      fs.writeFileSync(path.join(candidate.home, ".credentials.json"), JSON.stringify({
+        claudeAiOauth: {
+          accessToken: crypto.randomUUID(),
+          refreshToken: crypto.randomUUID(),
+          expiresAt: NOW + 60_000,
+          scopes: ["user:inference"],
+        },
+      }), { mode: 0o600 });
+      return new Response(null, { status: 401 });
+    },
+  });
+
+  expect(result).toBe("refreshed");
+  expect(claudeOauthMetadata(candidate)?.expiresAt).toBe(NOW + 60_000);
+});
+
+test("a native refresh lock bounds Viewer admission without starting duplicate refresh work", async () => {
+  const candidate = account("native-lock");
+  fs.mkdirSync(path.join(candidate.home, ".oauth_refresh.lock"), { mode: 0o700 });
+  let fetchCalls = 0;
+
+  const result = await refreshClaudeOauth(candidate, {
+    now: () => NOW,
+    lockWaitMs: 1,
+    fetch: async () => {
+      fetchCalls += 1;
+      return new Response(null, { status: 503 });
+    },
+  });
+
+  expect(result).toBe("unknown");
+  expect(fetchCalls).toBe(0);
+});
+
+test("Viewer reuses a native rotation completed while waiting for the refresh lock", async () => {
+  const candidate = account("native-winner");
+  const lock = path.join(candidate.home, ".oauth_refresh.lock");
+  fs.mkdirSync(lock, { mode: 0o700 });
+  let fetchCalls = 0;
+  setTimeout(() => {
+    fs.writeFileSync(path.join(candidate.home, ".credentials.json"), JSON.stringify({
+      claudeAiOauth: {
+        accessToken: crypto.randomUUID(),
+        refreshToken: crypto.randomUUID(),
+        expiresAt: NOW + 60_000,
+        scopes: ["user:inference"],
+      },
+    }), { mode: 0o600 });
+    fs.rmdirSync(lock);
+  }, 5);
+
+  const result = await refreshClaudeOauth(candidate, {
+    now: () => NOW,
+    lockWaitMs: 100,
+    fetch: async () => {
+      fetchCalls += 1;
+      return new Response(null, { status: 503 });
+    },
+  });
+
+  expect(result).toBe("refreshed");
+  expect(fetchCalls).toBe(0);
+});
+
+test("custom OAuth credentials stay on a CLI-approved issuer", async () => {
+  const candidate = account("custom-origin");
+  const previous = process.env.CLAUDE_CODE_CUSTOM_OAUTH_URL;
+  process.env.CLAUDE_CODE_CUSTOM_OAUTH_URL = "https://claude.fedstart.com";
+  let requestedUrl = "";
+  try {
+    const result = await refreshClaudeOauth(candidate, {
+      now: () => NOW,
+      fetch: async (input) => {
+        requestedUrl = String(input);
+        return Response.json({ access_token: crypto.randomUUID(), expires_in: 3_600 });
+      },
+    });
+
+    expect(result).toBe("refreshed");
+    expect(requestedUrl).toBe("https://claude.fedstart.com/v1/oauth/token");
+  } finally {
+    if (previous === undefined) delete process.env.CLAUDE_CODE_CUSTOM_OAUTH_URL;
+    else process.env.CLAUDE_CODE_CUSTOM_OAUTH_URL = previous;
+  }
+});
+
+test("an unapproved custom OAuth origin never receives credential content", async () => {
+  const candidate = account("unapproved-origin");
+  const previous = process.env.CLAUDE_CODE_CUSTOM_OAUTH_URL;
+  process.env.CLAUDE_CODE_CUSTOM_OAUTH_URL = "https://example.test";
+  let fetchCalls = 0;
+  try {
+    const result = await refreshClaudeOauth(candidate, {
+      now: () => NOW,
+      fetch: async () => {
+        fetchCalls += 1;
+        return new Response(null, { status: 503 });
+      },
+    });
+
+    expect(result).toBe("unknown");
+    expect(fetchCalls).toBe(0);
+  } finally {
+    if (previous === undefined) delete process.env.CLAUDE_CODE_CUSTOM_OAUTH_URL;
+    else process.env.CLAUDE_CODE_CUSTOM_OAUTH_URL = previous;
+  }
+});

--- a/src/lib/accounts/claudeOauth.test.ts
+++ b/src/lib/accounts/claudeOauth.test.ts
@@ -55,6 +55,39 @@ test("a successful bounded OAuth refresh persists current launch metadata", asyn
   expect(fs.statSync(path.join(candidate.home, ".credentials.json")).mode & 0o777).toBe(0o600);
 });
 
+test("an OAuth redirect cannot forward refresh credentials to another origin", async () => {
+  const candidate = account("redirect-exfiltration");
+  let redirectedRequests = 0;
+  const destination = Bun.serve({
+    port: 0,
+    fetch: () => {
+      redirectedRequests += 1;
+      return new Response(null, { status: 204 });
+    },
+  });
+  const upstream = Bun.serve({
+    port: 0,
+    fetch: () => new Response(null, {
+      status: 307,
+      headers: { location: new URL("/collect-sensitive-request", destination.url).href },
+    }),
+  });
+
+  try {
+    const result = await refreshClaudeOauth(candidate, {
+      now: () => NOW,
+      fetch: async (_input, init) => await fetch(upstream.url, init),
+    });
+
+    expect(result).toBe("unknown");
+    expect(redirectedRequests).toBe(0);
+    expect(claudeOauthMetadata(candidate)?.expiresAt).toBe(NOW - 1);
+  } finally {
+    await upstream.stop(true);
+    await destination.stop(true);
+  }
+});
+
 test("only positive invalid_grant evidence is fenced while other failures remain transient", async () => {
   const unclassified401 = account("unclassified-401");
   const invalidGrant = account("invalid-grant");

--- a/src/lib/accounts/claudeOauth.ts
+++ b/src/lib/accounts/claudeOauth.ts
@@ -100,8 +100,14 @@ async function acquireDirectoryLock(lock: string, startedAt: number, waitMs: num
   for (;;) {
     try {
       fs.mkdirSync(lock, { mode: 0o700 });
+      const descriptor = fs.openSync(lock, "r");
+      const owned = fs.fstatSync(descriptor);
       return () => {
-        try { fs.rmdirSync(lock); } catch { /* Claude may have cleared a stale lock after the bounded refresh window. */ }
+        try {
+          const current = fs.statSync(lock);
+          if (current.dev === owned.dev && current.ino === owned.ino) fs.rmdirSync(lock);
+        } catch { /* Claude may have cleared or replaced the lock after the bounded refresh window. */ }
+        finally { fs.closeSync(descriptor); }
       };
     } catch (error) {
       if ((error as NodeJS.ErrnoException).code !== "EEXIST") return null;

--- a/src/lib/accounts/claudeOauth.ts
+++ b/src/lib/accounts/claudeOauth.ts
@@ -15,6 +15,7 @@ const REFRESH_TIMEOUT_MS = 8_000;
 const REFRESH_LOCK_WAIT_MS = 8_000;
 const REFRESH_LOCK_POLL_MS = 25;
 const DEFAULT_SCOPES = ["user:profile", "user:inference", "user:sessions:claude_code", "user:mcp_servers", "user:file_upload"];
+const PRESERVABLE_EXPANSION_SCOPES = new Set(["user:projects:read", "user:projects:write"]);
 
 export type ClaudeOauthRefreshResult = "refreshed" | "invalid" | "unknown";
 type ClaudeOauthFetch = (input: string | URL | Request, init?: RequestInit) => Promise<Response>;
@@ -95,9 +96,7 @@ function concurrentRotationIsCurrent(account: ClaudeAccount, originalAccessToken
   return metadata !== null && metadata.expiresAt > now;
 }
 
-async function acquireRefreshLock(account: ClaudeAccount, waitMs: number): Promise<(() => void) | null> {
-  const lock = path.join(account.home, ".oauth_refresh.lock");
-  const startedAt = Date.now();
+async function acquireDirectoryLock(lock: string, startedAt: number, waitMs: number): Promise<(() => void) | null> {
   for (;;) {
     try {
       fs.mkdirSync(lock, { mode: 0o700 });
@@ -113,8 +112,26 @@ async function acquireRefreshLock(account: ClaudeAccount, waitMs: number): Promi
   }
 }
 
+async function acquireRefreshLocks(account: ClaudeAccount, waitMs: number): Promise<(() => void) | null> {
+  const startedAt = Date.now();
+  const releaseCurrent = await acquireDirectoryLock(path.join(account.home, ".oauth_refresh.lock"), startedAt, waitMs);
+  if (!releaseCurrent) return null;
+
+  let realHome: string;
+  try { realHome = fs.realpathSync(account.home); } catch { realHome = account.home; }
+  const releaseLegacy = await acquireDirectoryLock(`${realHome}.lock`, startedAt, waitMs);
+  if (!releaseLegacy) {
+    releaseCurrent();
+    return null;
+  }
+
+  return () => {
+    releaseLegacy();
+    releaseCurrent();
+  };
+}
+
 async function rejectedRefreshResult(response: Response): Promise<ClaudeOauthRefreshResult> {
-  if (response.status === 401) return "invalid";
   try {
     const payload = await response.json() as { error?: unknown };
     return payload?.error === "invalid_grant" ? "invalid" : "unknown";
@@ -123,12 +140,22 @@ async function rejectedRefreshResult(response: Response): Promise<ClaudeOauthRef
   }
 }
 
+async function isInvalidScopeResponse(response: Response): Promise<boolean> {
+  if (response.status !== 400) return false;
+  try {
+    const payload = await response.clone().json() as { error?: unknown };
+    return payload?.error === "invalid_scope";
+  } catch {
+    return false;
+  }
+}
+
 /** Rotates an expired Claude OAuth credential without surfacing credential content. */
 export async function refreshClaudeOauth(
   account: ClaudeAccount,
   dependencies: ClaudeOauthRefreshDependencies = productionDependencies,
 ): Promise<ClaudeOauthRefreshResult> {
-  const release = await acquireRefreshLock(account, dependencies.lockWaitMs ?? REFRESH_LOCK_WAIT_MS);
+  const release = await acquireRefreshLocks(account, dependencies.lockWaitMs ?? REFRESH_LOCK_WAIT_MS);
   if (!release) return "unknown";
   try {
     return await refreshClaudeOauthLocked(account, dependencies);
@@ -151,28 +178,47 @@ async function refreshClaudeOauthLocked(
   }
 
   const originalAccessToken = oauth.accessToken;
-  const scopes = Array.isArray(oauth.scopes) && oauth.scopes.every((scope) => typeof scope === "string")
+  const storedScopes = Array.isArray(oauth.scopes) && oauth.scopes.every((scope) => typeof scope === "string")
     ? oauth.scopes as string[]
-    : DEFAULT_SCOPES;
-  const clientId = typeof oauth.clientId === "string" && oauth.clientId.length > 0
-    ? oauth.clientId
+    : [];
+  const hasStoredClientId = typeof oauth.clientId === "string" && oauth.clientId.length > 0;
+  const clientId = hasStoredClientId
+    ? oauth.clientId as string
     : process.env.CLAUDE_CODE_OAUTH_CLIENT_ID || CLAUDE_CODE_CLIENT_ID;
+  const isDefaultFirstPartyClient = !hasStoredClientId
+    && (storedScopes.includes("user:inference") || Boolean(oauth.subscriptionType));
+  let initialScopes = storedScopes.length > 0 ? storedScopes : DEFAULT_SCOPES;
+  if (isDefaultFirstPartyClient) {
+    initialScopes = [...new Set([
+      ...DEFAULT_SCOPES,
+      ...storedScopes.filter((scope) => PRESERVABLE_EXPANSION_SCOPES.has(scope)),
+    ])];
+  }
   const tokenUrl = oauthTokenUrl();
   if (!tokenUrl) return "unknown";
 
+  const signal = AbortSignal.timeout(REFRESH_TIMEOUT_MS);
+  const requestRefresh = (requestedScopes: string[]) => dependencies.fetch(tokenUrl, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      grant_type: "refresh_token",
+      refresh_token: oauth.refreshToken,
+      client_id: clientId,
+      scope: requestedScopes.join(" "),
+    }),
+    signal,
+  });
+
   let response: Response;
   try {
-    response = await dependencies.fetch(tokenUrl, {
-      method: "POST",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify({
-        grant_type: "refresh_token",
-        refresh_token: oauth.refreshToken,
-        client_id: clientId,
-        scope: scopes.join(" "),
-      }),
-      signal: AbortSignal.timeout(REFRESH_TIMEOUT_MS),
-    });
+    response = await requestRefresh(initialScopes);
+    if (isDefaultFirstPartyClient
+      && storedScopes.length > 0
+      && storedScopes.includes("user:inference")
+      && await isInvalidScopeResponse(response)) {
+      response = await requestRefresh(storedScopes);
+    }
   } catch {
     return "unknown";
   }

--- a/src/lib/accounts/claudeOauth.ts
+++ b/src/lib/accounts/claudeOauth.ts
@@ -1,0 +1,223 @@
+import crypto from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+
+import type { ClaudeAccount } from "./claude";
+
+const CLAUDE_OAUTH_TOKEN_URL = "https://platform.claude.com/v1/oauth/token";
+const APPROVED_CUSTOM_OAUTH_ORIGINS = new Set([
+  "https://beacon.claude-ai.staging.ant.dev",
+  "https://claude.fedstart.com",
+  "https://claude-staging.fedstart.com",
+]);
+const CLAUDE_CODE_CLIENT_ID = "9d1c250a-e61b-44d9-88ed-5944d1962f5e";
+const REFRESH_TIMEOUT_MS = 8_000;
+const REFRESH_LOCK_WAIT_MS = 8_000;
+const REFRESH_LOCK_POLL_MS = 25;
+const DEFAULT_SCOPES = ["user:profile", "user:inference", "user:sessions:claude_code", "user:mcp_servers", "user:file_upload"];
+
+export type ClaudeOauthRefreshResult = "refreshed" | "invalid" | "unknown";
+type ClaudeOauthFetch = (input: string | URL | Request, init?: RequestInit) => Promise<Response>;
+
+export interface ClaudeOauthRefreshDependencies {
+  now(): number;
+  fetch: ClaudeOauthFetch;
+  lockWaitMs?: number;
+}
+
+type OauthRecord = Record<string, unknown> & {
+  accessToken?: unknown;
+  refreshToken?: unknown;
+  expiresAt?: unknown;
+  scopes?: unknown;
+  clientId?: unknown;
+};
+
+type CredentialDocument = Record<string, unknown> & { claudeAiOauth?: OauthRecord };
+
+function credentialPath(account: ClaudeAccount): string {
+  return path.join(account.home, ".credentials.json");
+}
+
+function readCredentialDocument(account: ClaudeAccount): CredentialDocument | null {
+  if (!account.authPresent) return null;
+  try {
+    const parsed = JSON.parse(fs.readFileSync(credentialPath(account), "utf8")) as unknown;
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed) ? parsed as CredentialDocument : null;
+  } catch {
+    return null;
+  }
+}
+
+export function claudeOauthMetadata(account: ClaudeAccount): { expiresAt: number; refreshable: boolean } | null {
+  const oauth = readCredentialDocument(account)?.claudeAiOauth;
+  return typeof oauth?.accessToken === "string" && oauth.accessToken.length > 0
+    && typeof oauth.expiresAt === "number" && Number.isFinite(oauth.expiresAt)
+    ? { expiresAt: oauth.expiresAt, refreshable: typeof oauth.refreshToken === "string" && oauth.refreshToken.length > 0 }
+    : null;
+}
+
+function writeCredentialDocument(account: ClaudeAccount, document: CredentialDocument): void {
+  const file = credentialPath(account);
+  const temporary = path.join(account.home, `.${path.basename(file)}.${process.pid}.${crypto.randomUUID()}.tmp`);
+  try {
+    const descriptor = fs.openSync(temporary, "wx", 0o600);
+    try {
+      fs.writeFileSync(descriptor, JSON.stringify(document), "utf8");
+      fs.fsyncSync(descriptor);
+    } finally {
+      fs.closeSync(descriptor);
+    }
+    fs.renameSync(temporary, file);
+    const directory = fs.openSync(account.home, "r");
+    try { fs.fsyncSync(directory); } finally { fs.closeSync(directory); }
+  } finally {
+    fs.rmSync(temporary, { force: true });
+  }
+}
+
+const productionDependencies: ClaudeOauthRefreshDependencies = {
+  now: Date.now,
+  fetch: globalThis.fetch,
+};
+
+function oauthTokenUrl(): string | null {
+  const configured = process.env.CLAUDE_CODE_CUSTOM_OAUTH_URL;
+  if (!configured) return CLAUDE_OAUTH_TOKEN_URL;
+  const origin = configured.replace(/\/+$/, "");
+  return APPROVED_CUSTOM_OAUTH_ORIGINS.has(origin) ? `${origin}/v1/oauth/token` : null;
+}
+
+function concurrentRotationIsCurrent(account: ClaudeAccount, originalAccessToken: string, now: number): boolean {
+  const current = readCredentialDocument(account)?.claudeAiOauth;
+  if (!current || current.accessToken === originalAccessToken) return false;
+  const metadata = claudeOauthMetadata(account);
+  return metadata !== null && metadata.expiresAt > now;
+}
+
+async function acquireRefreshLock(account: ClaudeAccount, waitMs: number): Promise<(() => void) | null> {
+  const lock = path.join(account.home, ".oauth_refresh.lock");
+  const startedAt = Date.now();
+  for (;;) {
+    try {
+      fs.mkdirSync(lock, { mode: 0o700 });
+      return () => {
+        try { fs.rmdirSync(lock); } catch { /* Claude may have cleared a stale lock after the bounded refresh window. */ }
+      };
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "EEXIST") return null;
+      const remaining = waitMs - (Date.now() - startedAt);
+      if (remaining <= 0) return null;
+      await new Promise<void>((resolve) => setTimeout(resolve, Math.min(REFRESH_LOCK_POLL_MS, remaining)));
+    }
+  }
+}
+
+async function rejectedRefreshResult(response: Response): Promise<ClaudeOauthRefreshResult> {
+  if (response.status === 401) return "invalid";
+  try {
+    const payload = await response.json() as { error?: unknown };
+    return payload?.error === "invalid_grant" ? "invalid" : "unknown";
+  } catch {
+    return "unknown";
+  }
+}
+
+/** Rotates an expired Claude OAuth credential without surfacing credential content. */
+export async function refreshClaudeOauth(
+  account: ClaudeAccount,
+  dependencies: ClaudeOauthRefreshDependencies = productionDependencies,
+): Promise<ClaudeOauthRefreshResult> {
+  const release = await acquireRefreshLock(account, dependencies.lockWaitMs ?? REFRESH_LOCK_WAIT_MS);
+  if (!release) return "unknown";
+  try {
+    return await refreshClaudeOauthLocked(account, dependencies);
+  } finally {
+    release();
+  }
+}
+
+async function refreshClaudeOauthLocked(
+  account: ClaudeAccount,
+  dependencies: ClaudeOauthRefreshDependencies,
+): Promise<ClaudeOauthRefreshResult> {
+  const original = readCredentialDocument(account);
+  const oauth = original?.claudeAiOauth;
+  if (!original || !oauth
+    || typeof oauth.accessToken !== "string" || oauth.accessToken.length === 0
+    || typeof oauth.refreshToken !== "string" || oauth.refreshToken.length === 0) return "invalid";
+  if (typeof oauth.expiresAt === "number" && Number.isFinite(oauth.expiresAt) && oauth.expiresAt > dependencies.now()) {
+    return "refreshed";
+  }
+
+  const originalAccessToken = oauth.accessToken;
+  const scopes = Array.isArray(oauth.scopes) && oauth.scopes.every((scope) => typeof scope === "string")
+    ? oauth.scopes as string[]
+    : DEFAULT_SCOPES;
+  const clientId = typeof oauth.clientId === "string" && oauth.clientId.length > 0
+    ? oauth.clientId
+    : process.env.CLAUDE_CODE_OAUTH_CLIENT_ID || CLAUDE_CODE_CLIENT_ID;
+  const tokenUrl = oauthTokenUrl();
+  if (!tokenUrl) return "unknown";
+
+  let response: Response;
+  try {
+    response = await dependencies.fetch(tokenUrl, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        grant_type: "refresh_token",
+        refresh_token: oauth.refreshToken,
+        client_id: clientId,
+        scope: scopes.join(" "),
+      }),
+      signal: AbortSignal.timeout(REFRESH_TIMEOUT_MS),
+    });
+  } catch {
+    return "unknown";
+  }
+
+  if (response.status === 400 || response.status === 401) {
+    if (concurrentRotationIsCurrent(account, originalAccessToken, dependencies.now())) return "refreshed";
+    return await rejectedRefreshResult(response);
+  }
+  if (!response.ok) return "unknown";
+
+  let payload: Record<string, unknown>;
+  try {
+    const parsed = await response.json() as unknown;
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return "unknown";
+    payload = parsed as Record<string, unknown>;
+  } catch {
+    return "unknown";
+  }
+  if (typeof payload.access_token !== "string" || payload.access_token.length === 0
+    || typeof payload.expires_in !== "number" || !Number.isFinite(payload.expires_in) || payload.expires_in <= 0) return "unknown";
+
+  const current = readCredentialDocument(account);
+  const currentOauth = current?.claudeAiOauth;
+  if (!current || !currentOauth) return "unknown";
+  if (currentOauth.accessToken !== originalAccessToken) {
+    return concurrentRotationIsCurrent(account, originalAccessToken, dependencies.now()) ? "refreshed" : "unknown";
+  }
+
+  const nextOauth: OauthRecord = {
+    ...currentOauth,
+    accessToken: payload.access_token,
+    refreshToken: typeof payload.refresh_token === "string" && payload.refresh_token.length > 0
+      ? payload.refresh_token
+      : oauth.refreshToken,
+    expiresAt: dependencies.now() + payload.expires_in * 1_000,
+  };
+  if (typeof payload.scope === "string" && payload.scope.trim()) nextOauth.scopes = payload.scope.trim().split(/\s+/);
+  if (typeof payload.refresh_token_expires_in === "number" && Number.isFinite(payload.refresh_token_expires_in)) {
+    nextOauth.refreshTokenExpiresAt = dependencies.now() + payload.refresh_token_expires_in * 1_000;
+  }
+
+  try {
+    writeCredentialDocument(account, { ...current, claudeAiOauth: nextOauth });
+    return "refreshed";
+  } catch {
+    return "unknown";
+  }
+}

--- a/src/lib/accounts/claudeOauth.ts
+++ b/src/lib/accounts/claudeOauth.ts
@@ -200,6 +200,7 @@ async function refreshClaudeOauthLocked(
   const signal = AbortSignal.timeout(REFRESH_TIMEOUT_MS);
   const requestRefresh = (requestedScopes: string[]) => dependencies.fetch(tokenUrl, {
     method: "POST",
+    redirect: "manual",
     headers: { "content-type": "application/json" },
     body: JSON.stringify({
       grant_type: "refresh_token",

--- a/src/lib/accounts/spawnHealth.test.ts
+++ b/src/lib/accounts/spawnHealth.test.ts
@@ -1,10 +1,13 @@
+import crypto from "node:crypto";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, expect, test } from "bun:test";
 
+import { LIMITS_RATE_LIMITED_REASON, LIMITS_REAUTH_REQUIRED_REASON } from "@/lib/types";
+
 import type { ClaudeAccount } from "./claude";
-import { NoHealthyClaudeAccountError, selectHealthyClaudeAccount } from "./spawnHealth";
+import { claudeValidityFromLimitRead, NoHealthyClaudeAccountError, selectHealthyClaudeAccount } from "./spawnHealth";
 
 const NOW = Date.parse("2026-07-14T09:00:00.000Z");
 const homes: string[] = [];
@@ -13,17 +16,21 @@ afterEach(() => {
   for (const home of homes.splice(0)) fs.rmSync(home, { recursive: true, force: true });
 });
 
-function account(id: string, expiresAt: number, authPresent = true): ClaudeAccount {
+function account(id: string, expiresAt: number, authPresent = true, refreshable = true): ClaudeAccount {
   const home = fs.mkdtempSync(path.join(os.tmpdir(), `llv-spawn-health-${id}-`));
   homes.push(home);
   fs.writeFileSync(path.join(home, ".credentials.json"), JSON.stringify({
-    claudeAiOauth: { accessToken: `${id}-token`, refreshToken: `${id}-refresh`, expiresAt },
+    claudeAiOauth: {
+      accessToken: crypto.randomUUID(),
+      ...(refreshable ? { refreshToken: crypto.randomUUID() } : {}),
+      expiresAt,
+    },
   }), { mode: 0o600 });
   return { id, label: id, kind: "managed", home, projectsDir: path.join(home, "projects"), authPresent, createdAt: 0 };
 }
 
-test("spawn selection skips an expired preferred Claude account and probes a healthy fallback", async () => {
-  const expired = account("expired", NOW - 1);
+test("spawn selection skips an unrefreshable expired preferred Claude account and probes a healthy fallback", async () => {
+  const expired = account("expired", NOW - 1, true, false);
   const healthy = account("healthy", NOW + 60_000);
   const probed: string[] = [];
 
@@ -33,10 +40,102 @@ test("spawn selection skips an expired preferred Claude account and probes a hea
       probed.push(candidate.id);
       return "valid";
     },
+    refresh: async () => "invalid",
   });
 
   expect(selected.id).toBe("healthy");
   expect(probed).toEqual(["healthy"]);
+});
+
+test("live usage evidence retains spawn validity classifications", () => {
+  expect(claudeValidityFromLimitRead({ source: "live", reason: null })).toBe("valid");
+  expect(claudeValidityFromLimitRead({ source: "unavailable", reason: LIMITS_RATE_LIMITED_REASON })).toBe("valid");
+  expect(claudeValidityFromLimitRead({ source: "unavailable", reason: LIMITS_REAUTH_REQUIRED_REASON })).toBe("invalid");
+  expect(claudeValidityFromLimitRead({ source: "unavailable", reason: "credentials missing access token" })).toBe("invalid");
+  expect(claudeValidityFromLimitRead({ source: "unavailable", reason: "credentials unreadable: test fixture" })).toBe("invalid");
+  expect(claudeValidityFromLimitRead({ source: "unavailable", reason: "request timed out" })).toBe("unknown");
+});
+
+test("spawn selection refreshes an expired preferred Claude account before admission", async () => {
+  const expired = account("expired", NOW - 1);
+  const refreshed: string[] = [];
+
+  const selected = await selectHealthyClaudeAccount([expired], "expired", {
+    now: () => NOW,
+    probe: async () => {
+      throw new Error("current-access probe should not run");
+    },
+    refresh: async (candidate) => {
+      refreshed.push(candidate.id);
+      return "valid";
+    },
+  });
+
+  expect(selected.id).toBe("expired");
+  expect(refreshed).toEqual(["expired"]);
+});
+
+test("concurrent admissions coalesce refresh validation for one account", async () => {
+  const expired = account("concurrent", NOW - 1);
+  let refreshCalls = 0;
+  let release!: () => void;
+  const held = new Promise<void>((resolve) => { release = resolve; });
+  const dependencies = {
+    now: () => NOW,
+    probe: async () => "invalid" as const,
+    refresh: async () => {
+      refreshCalls += 1;
+      await held;
+      return "valid" as const;
+    },
+  };
+
+  const first = selectHealthyClaudeAccount([expired], expired.id, dependencies);
+  const second = selectHealthyClaudeAccount([expired], expired.id, dependencies);
+  await Promise.resolve();
+
+  expect(refreshCalls).toBe(1);
+  release();
+  expect((await first).id).toBe(expired.id);
+  expect((await second).id).toBe(expired.id);
+});
+
+test("three expired accounts deterministically select the sole refreshable account", async () => {
+  const accounts = [account("charlie", NOW - 1), account("alpha", NOW - 1), account("bravo", NOW - 1)];
+
+  const selected = await selectHealthyClaudeAccount(accounts, "charlie", {
+    now: () => NOW,
+    probe: async () => "invalid",
+    refresh: async (candidate) => candidate.id === "bravo" ? "valid" : "invalid",
+  });
+
+  expect(selected.id).toBe("bravo");
+});
+
+test("requested-account routing breaks ties inside one health tier", async () => {
+  const accounts = [account("charlie", NOW + 60_000), account("alpha", NOW + 60_000), account("bravo", NOW + 60_000)];
+  const dependencies = {
+    now: () => NOW,
+    probe: async () => "valid" as const,
+    refresh: async () => "invalid" as const,
+  };
+
+  expect((await selectHealthyClaudeAccount(accounts, "charlie", dependencies)).id).toBe("charlie");
+  expect((await selectHealthyClaudeAccount(accounts, null, dependencies)).id).toBe("alpha");
+});
+
+test("missing and non-refreshable credentials stay fenced without validation calls", async () => {
+  const missing = account("missing", NOW + 60_000, false);
+  const expired = account("no-refresh", NOW - 1, true, false);
+  let calls = 0;
+
+  await expect(selectHealthyClaudeAccount([missing, expired], null, {
+    now: () => NOW,
+    probe: async () => { calls += 1; return "valid"; },
+    refresh: async () => { calls += 1; return "valid"; },
+  })).rejects.toBeInstanceOf(NoHealthyClaudeAccountError);
+
+  expect(calls).toBe(0);
 });
 
 test("spawn selection ranks a live-valid account above a transiently unverifiable preferred account", async () => {
@@ -46,6 +145,7 @@ test("spawn selection ranks a live-valid account above a transiently unverifiabl
   const selected = await selectHealthyClaudeAccount([preferred, confirmed], "preferred", {
     now: () => NOW,
     probe: async (candidate) => candidate.id === "confirmed" ? "valid" : "unknown",
+    refresh: async () => "invalid",
   });
 
   expect(selected.id).toBe("confirmed");
@@ -59,6 +159,7 @@ test("spawn selection reports every dead account when none can launch", async ()
     await selectHealthyClaudeAccount([expired, rejected], "expired", {
       now: () => NOW,
       probe: async () => "invalid",
+      refresh: async () => "invalid",
     });
     throw new Error("expected selection to fail");
   } catch (error) {

--- a/src/lib/accounts/spawnHealth.ts
+++ b/src/lib/accounts/spawnHealth.ts
@@ -1,16 +1,39 @@
-import fs from "node:fs";
 import path from "node:path";
 
 import { fetchClaudeLimits } from "@/lib/limits";
 import { LIMITS_RATE_LIMITED_REASON, LIMITS_REAUTH_REQUIRED_REASON } from "@/lib/types";
 
 import type { ClaudeAccount } from "./claude";
+import { claudeOauthMetadata, refreshClaudeOauth } from "./claudeOauth";
 
 export type ClaudeValidityProbeResult = "valid" | "invalid" | "unknown";
 
 export interface ClaudeSpawnHealthDependencies {
   now(): number;
   probe(account: ClaudeAccount): Promise<ClaudeValidityProbeResult>;
+  refresh(account: ClaudeAccount): Promise<ClaudeValidityProbeResult>;
+}
+
+const globalStore = globalThis as typeof globalThis & {
+  __llvClaudeRefreshInflight?: Map<string, Promise<ClaudeValidityProbeResult>>;
+};
+
+function refreshSingleFlight(
+  account: ClaudeAccount,
+  refresh: ClaudeSpawnHealthDependencies["refresh"],
+): Promise<ClaudeValidityProbeResult> {
+  const inflight = globalStore.__llvClaudeRefreshInflight ??= new Map();
+  const key = `${account.id}\0${path.resolve(account.home)}`;
+  const existing = inflight.get(key);
+  if (existing) return existing;
+  const pending = Promise.resolve()
+    .then(() => refresh(account))
+    .catch(() => "unknown" as const)
+    .finally(() => {
+      if (inflight.get(key) === pending) inflight.delete(key);
+    });
+  inflight.set(key, pending);
+  return pending;
 }
 
 export class NoHealthyClaudeAccountError extends Error {
@@ -25,24 +48,9 @@ export class NoHealthyClaudeAccountError extends Error {
   }
 }
 
-function oauthExpiresAt(account: ClaudeAccount): number | null {
-  if (!account.authPresent) return null;
-  try {
-    const credentials = JSON.parse(fs.readFileSync(path.join(account.home, ".credentials.json"), "utf8")) as {
-      claudeAiOauth?: { accessToken?: unknown; expiresAt?: unknown };
-    };
-    const oauth = credentials.claudeAiOauth;
-    return typeof oauth?.accessToken === "string" && oauth.accessToken.length > 0
-      && typeof oauth.expiresAt === "number" && Number.isFinite(oauth.expiresAt)
-      ? oauth.expiresAt
-      : null;
-  } catch {
-    return null;
-  }
-}
-
-async function liveValidityProbe(account: ClaudeAccount): Promise<ClaudeValidityProbeResult> {
-  const result = await fetchClaudeLimits(path.join(account.home, ".credentials.json"));
+export function claudeValidityFromLimitRead(
+  result: { source: string; reason: string | null },
+): ClaudeValidityProbeResult {
   if (result.source === "live" || result.reason === LIMITS_RATE_LIMITED_REASON) return "valid";
   if (result.reason === LIMITS_REAUTH_REQUIRED_REASON
     || result.reason === "credentials missing access token"
@@ -50,9 +58,22 @@ async function liveValidityProbe(account: ClaudeAccount): Promise<ClaudeValidity
   return "unknown";
 }
 
+async function liveValidityProbe(account: ClaudeAccount): Promise<ClaudeValidityProbeResult> {
+  const result = await fetchClaudeLimits(path.join(account.home, ".credentials.json"));
+  return claudeValidityFromLimitRead(result);
+}
+
+async function refreshValidityProbe(account: ClaudeAccount): Promise<ClaudeValidityProbeResult> {
+  const refreshed = await refreshClaudeOauth(account);
+  if (refreshed === "invalid") return "invalid";
+  if (refreshed === "unknown") return "unknown";
+  return await liveValidityProbe(account);
+}
+
 const productionDependencies: ClaudeSpawnHealthDependencies = {
   now: Date.now,
   probe: liveValidityProbe,
+  refresh: refreshValidityProbe,
 };
 
 /**
@@ -68,8 +89,11 @@ export async function selectHealthyClaudeAccount(
 ): Promise<ClaudeAccount> {
   const now = dependencies.now();
   const candidates = await Promise.all(accounts.map(async (account) => {
-    const expiresAt = oauthExpiresAt(account);
-    if (expiresAt === null || expiresAt <= now) return { account, health: "invalid" as const };
+    const oauth = claudeOauthMetadata(account);
+    if (oauth === null) return { account, health: "invalid" as const };
+    if (oauth.expiresAt <= now) {
+      return { account, health: oauth.refreshable ? await refreshSingleFlight(account, dependencies.refresh) : "invalid" as const };
+    }
     return { account, health: await dependencies.probe(account) };
   }));
   const rank = (health: ClaudeValidityProbeResult) => health === "valid" ? 2 : health === "unknown" ? 1 : 0;


### PR DESCRIPTION
## Summary

- refresh expired Claude OAuth credentials through a bounded provider exchange before spawn selection
- coordinate Viewer refreshes with Claude's current and legacy native refresh locks plus a process-wide per-account single-flight
- preserve replacement lock directories when another native owner takes over a stale lock path
- retry first-party `invalid_scope` responses with stored inference scopes, matching Claude Code 2.1.209 compatibility behavior
- reserve terminal credential fencing for positive `invalid_grant` evidence while compatibility and transient failures remain eligible for fallback
- reject OAuth redirects before the refresh-token request can be forwarded to another origin
- validate rotated access through the existing bounded live usage probe, preserving rate-limit and transient fallback semantics
- preserve deterministic requested-account routing and exercise the production resolver from isolated persisted state in a fresh process
- restrict custom OAuth refresh traffic to Claude CLI-approved origins and keep credential content out of logs and responses

## Verification

- `bun test src/lib/accounts/spawnHealth.test.ts src/lib/accounts/claudeOauth.test.ts src/app/api/spawn/route.test.ts` — 44 passed, 123 assertions
- production-resolver mutation probe — severed wiring produced zero refreshes, usage probes, and structured launches; restored wiring passed
- `bun x tsc --noEmit`
- `bun x eslint src/lib/accounts/claudeOauth.ts src/lib/accounts/claudeOauth.test.ts src/lib/accounts/spawnHealth.ts src/lib/accounts/spawnHealth.test.ts src/app/api/spawn/route.test.ts`
- `bun run build`
- `git diff --check origin/main`

Closes #331
