### PR TITLE
fix(spawn): recover orphaned admission and replay ownership

### DIFF
--- a/src/app/api/spawn/route.test.ts
+++ b/src/app/api/spawn/route.test.ts
@@ -46,6 +46,14 @@ function structuredRouteDependencies(cwd: string): SpawnRouteTestDependencies {
       transcriptRoot: path.join(cwd, "projects"),
       env: { NODE_ENV: "test" },
     }),
+    resolveSpawnAccount: (_engine, accountId) => ({
+      engine: "claude",
+      accountId: accountId ?? "claude-test",
+      kind: "managed",
+      home: path.join(cwd, "account"),
+      transcriptRoot: path.join(cwd, "projects"),
+      env: { NODE_ENV: "test" },
+    }),
     runtimeHostClient: () => ({} as RuntimeHostClient),
     defer: (work) => { void work(); },
     spawnStructuredConversation: async (input) => ({
@@ -231,6 +239,14 @@ test("fresh processes rescue one orphaned immediate structured admission exactly
       registry: agentRegistry,
       assertStructuredRuntime: () => {},
       resolveHealthySpawnAccount: async () => ({
+        engine: "claude",
+        accountId: "claude-test",
+        kind: "managed",
+        home: path.join(${JSON.stringify(sandbox)}, "account"),
+        transcriptRoot: path.join(${JSON.stringify(sandbox)}, "projects"),
+        env: { NODE_ENV: "test" },
+      }),
+      resolveSpawnAccount: () => ({
         engine: "claude",
         accountId: "claude-test",
         kind: "managed",
@@ -698,6 +714,153 @@ test("operator structured Claude retries retain bypass and agent reuse conflicts
     const agentReplay = await POST.withDependencies(request(agentCapability, agentAttemptId), structuredRouteDependencies(cwd));
     expect(agentReplay.status).toBe(202);
     expect(await agentReplay.json()).toMatchObject({ state: "starting", effectivePermissionMode: "default" });
+  } finally {
+    if (previousTransport === undefined) delete process.env.LLV_SPAWN_TRANSPORT;
+    else process.env.LLV_SPAWN_TRANSPORT = previousTransport;
+    if (previousHosts === undefined) delete process.env.LLV_STRUCTURED_HOSTS;
+    else process.env.LLV_STRUCTURED_HOSTS = previousHosts;
+    if (previousEvents === undefined) delete process.env.LLV_RUNTIME_EVENTS;
+    else process.env.LLV_RUNTIME_EVENTS = previousEvents;
+    if (previousSocket === undefined) delete process.env.LLV_RUNTIME_HOST_SOCKET;
+    else process.env.LLV_RUNTIME_HOST_SOCKET = previousSocket;
+    if (previousUi === undefined) delete process.env.NEXT_PUBLIC_RUNTIME_UI;
+    else process.env.NEXT_PUBLIC_RUNTIME_UI = previousUi;
+  }
+});
+
+test("structured replay keeps its admitted account after routing changes", async () => {
+  const cwd = fs.mkdtempSync(path.join(routeSandbox, "account-rotation-replay-"));
+  const store = registry();
+  const deferred: Array<() => Promise<void>> = [];
+  const effects: string[] = [];
+  const accountResolutions: string[] = [];
+  let routedAccountId = "account-a";
+  const account = (accountId: string) => ({
+    engine: "claude" as const,
+    accountId,
+    kind: "managed" as const,
+    home: path.join(cwd, accountId),
+    transcriptRoot: path.join(cwd, accountId, "projects"),
+    env: { NODE_ENV: "test" },
+  });
+  const runtimeClient = {
+    operationStatus: async () => null,
+    snapshot: async () => ({ sessions: [] }),
+  } as unknown as RuntimeHostClient;
+  const dependencies = {
+    ...structuredRouteDependencies(cwd),
+    registry: () => store,
+    resolveHealthySpawnAccount: async () => {
+      accountResolutions.push(`healthy:${routedAccountId}`);
+      return account(routedAccountId);
+    },
+    resolveSpawnAccount: (_engine: "claude" | "codex", accountId: string | null) => {
+      accountResolutions.push(`exact:${accountId ?? "null"}`);
+      return account(accountId ?? routedAccountId);
+    },
+    runtimeHostClient: () => runtimeClient,
+    defer: (work: () => Promise<void>) => { deferred.push(work); },
+    spawnStructuredConversation: async (input: Parameters<SpawnRouteTestDependencies["spawnStructuredConversation"]>[0]) => {
+      effects.push(`worker:${input.account.accountId}`);
+      const sessionId = crypto.randomUUID();
+      const artifactPath = path.join(cwd, `${sessionId}.jsonl`);
+      fs.writeFileSync(artifactPath, JSON.stringify({ type: "user", message: input.prompt }) + "\n");
+      effects.push(`first-prompt:${input.prompt}`);
+      const settled = input.registry.settleSpawn(input.receipt.launchId, {
+        key: { engine: input.engine, sessionId },
+        artifactPath,
+        cwd: input.spec.cwd,
+        accountId: input.account.accountId,
+        launchProfile: input.spec.launchProfile,
+        status: "starting",
+        host: null,
+        claimEpoch: 0,
+        claimOwner: null,
+        pendingAction: null,
+      });
+      if (settled.kind !== "settled") throw new Error("account replay settlement conflicted");
+      return {
+        ok: true as const,
+        target: null,
+        path: artifactPath,
+        launchId: input.receipt.launchId,
+        conversationId: input.receipt.conversationId,
+        launched: true,
+        retrySafe: false,
+        initialMessage: "delivered" as const,
+        state: "settled" as const,
+      };
+    },
+  } as SpawnRouteTestDependencies;
+  const previousTransport = process.env.LLV_SPAWN_TRANSPORT;
+  const previousHosts = process.env.LLV_STRUCTURED_HOSTS;
+  const previousEvents = process.env.LLV_RUNTIME_EVENTS;
+  const previousSocket = process.env.LLV_RUNTIME_HOST_SOCKET;
+  const previousUi = process.env.NEXT_PUBLIC_RUNTIME_UI;
+  process.env.LLV_SPAWN_TRANSPORT = "structured";
+  process.env.LLV_STRUCTURED_HOSTS = "1";
+  process.env.LLV_RUNTIME_EVENTS = "1";
+  process.env.LLV_RUNTIME_HOST_SOCKET = path.join(cwd, "runtime.sock");
+  process.env.NEXT_PUBLIC_RUNTIME_UI = "1";
+  const alternateCwd = fs.mkdtempSync(path.join(routeSandbox, "account-rotation-conflict-"));
+  const alternateParent = store.ensureConversation("claude", path.join(cwd, "alternate-parent.jsonl"), "account-a");
+  const request = (overrides: Record<string, unknown> = {}) => new NextRequest("http://127.0.0.1:8898/api/spawn", {
+    method: "POST",
+    headers: {
+      host: "127.0.0.1:8898",
+      origin: "http://127.0.0.1:8898",
+      "sec-fetch-site": "same-origin",
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({
+      engine: "claude",
+      cwd,
+      prompt: "repair release",
+      clientAttemptId: "account_rotation_replay_20260717_a1",
+      ...overrides,
+    }),
+  });
+  try {
+    const admitted = await POST.withDependencies(request(), dependencies);
+    const admittedBody = await admitted.json();
+    expect(admitted.status).toBe(202);
+    expect(store.spawnReceiptForClientAttempt("account_rotation_replay_20260717_a1")).toMatchObject({
+      launchId: admittedBody.launchId,
+      accountId: "account-a",
+    });
+    routedAccountId = "account-b";
+
+    const replay = await POST.withDependencies(request(), dependencies);
+    expect(accountResolutions).toEqual(["healthy:account-a", "exact:account-a"]);
+    expect(replay.status).toBe(202);
+    expect(await replay.json()).toMatchObject({
+      launchId: admittedBody.launchId,
+      conversationId: admittedBody.conversationId,
+      state: "starting",
+    });
+
+    const changedRequests = [
+      request({ prompt: "changed release scope" }),
+      request({ model: "opus" }),
+      request({ effort: "high" }),
+      request({ cwd: alternateCwd }),
+      request({ engine: "codex" }),
+      request({ parentConversationId: alternateParent.id }),
+      request({ accountId: "account-b" }),
+      request({ images: [{ mime: "image/png", base64: "eA==" }] }),
+    ];
+    for (const changedRequest of changedRequests) {
+      const conflict = await POST.withDependencies(changedRequest, dependencies);
+      expect(conflict.status).toBe(409);
+    }
+
+    expect(deferred).toHaveLength(1);
+    await Promise.all(deferred.map((work) => work()));
+    expect(effects).toEqual(["worker:account-a", "first-prompt:repair release"]);
+    expect(store.snapshot().receipts[admittedBody.launchId]).toMatchObject({
+      accountId: "account-a",
+      state: "completed",
+    });
   } finally {
     if (previousTransport === undefined) delete process.env.LLV_SPAWN_TRANSPORT;
     else process.env.LLV_SPAWN_TRANSPORT = previousTransport;

--- a/src/app/api/spawn/route.test.ts
+++ b/src/app/api/spawn/route.test.ts
@@ -205,6 +205,152 @@ test("a fresh process resolves and refreshes a persisted Claude account before o
   });
 }, 20_000);
 
+test("fresh processes rescue one orphaned immediate structured admission exactly once", async () => {
+  const sandbox = fs.mkdtempSync(path.join(routeSandbox, "orphaned-structured-admission-"));
+  const stateDir = path.join(sandbox, "state");
+  const cwd = path.join(sandbox, "workspace");
+  const effectsPath = path.join(sandbox, "effects.jsonl");
+  fs.mkdirSync(stateDir, { recursive: true });
+  fs.mkdirSync(cwd);
+
+  const routePath = path.join(import.meta.dir, "route.ts");
+  const source = `
+    const fs = await import("node:fs");
+    const path = await import("node:path");
+    const crypto = await import("node:crypto");
+    const { NextRequest } = await import("next/server");
+    const { agentRegistry } = await import("@/lib/agent/registry");
+    const { POST } = await import(${JSON.stringify(routePath)});
+    const phase = process.env.LLV_TEST_PHASE;
+    const deferred = [];
+    const client = {
+      operationStatus: async () => null,
+      snapshot: async () => ({ sessions: [] }),
+    };
+    const dependencies = {
+      registry: agentRegistry,
+      assertStructuredRuntime: () => {},
+      resolveHealthySpawnAccount: async () => ({
+        engine: "claude",
+        accountId: "claude-test",
+        kind: "managed",
+        home: path.join(${JSON.stringify(sandbox)}, "account"),
+        transcriptRoot: path.join(${JSON.stringify(sandbox)}, "projects"),
+        env: { NODE_ENV: "test" },
+      }),
+      runtimeHostClient: () => client,
+      defer: (work) => { deferred.push(work); },
+      spawnStructuredConversation: async (input) => {
+        fs.appendFileSync(${JSON.stringify(effectsPath)}, JSON.stringify({ effect: "worker", pid: process.pid }) + "\\n");
+        const sessionId = crypto.randomUUID();
+        const artifactPath = path.join(${JSON.stringify(sandbox)}, sessionId + ".jsonl");
+        fs.writeFileSync(artifactPath, JSON.stringify({ type: "user", message: input.prompt }) + "\\n");
+        fs.appendFileSync(${JSON.stringify(effectsPath)}, JSON.stringify({ effect: "first-prompt", pid: process.pid }) + "\\n");
+        const settled = input.registry.settleSpawn(input.receipt.launchId, {
+          key: { engine: input.engine, sessionId },
+          artifactPath,
+          cwd: input.spec.cwd,
+          accountId: input.account.accountId,
+          launchProfile: input.spec.launchProfile,
+          status: "starting",
+          host: null,
+          claimEpoch: 0,
+          claimOwner: null,
+          pendingAction: null,
+        });
+        if (settled.kind !== "settled") throw new Error("structured rescue settlement conflicted");
+        return {
+          ok: true,
+          target: null,
+          path: artifactPath,
+          launchId: input.receipt.launchId,
+          conversationId: input.receipt.conversationId,
+          launched: true,
+          retrySafe: false,
+          initialMessage: "delivered",
+          state: "settled",
+        };
+      },
+    };
+    const response = await POST.withDependencies(new NextRequest("http://127.0.0.1:8898/api/spawn", {
+      method: "POST",
+      headers: {
+        host: "127.0.0.1:8898",
+        origin: "http://127.0.0.1:8898",
+        "sec-fetch-site": "same-origin",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        engine: "claude",
+        cwd: ${JSON.stringify(cwd)},
+        prompt: "repair the assigned task",
+        clientAttemptId: "orphaned_admission_20260717_a1",
+      }),
+    }), dependencies);
+    const body = await response.json();
+    if (phase === "recover") await Promise.all(deferred.map((work) => work()));
+    const receipt = agentRegistry().snapshot().receipts[body.launchId];
+    process.stdout.write(JSON.stringify({
+      status: response.status,
+      body,
+      deferred: deferred.length,
+      receiptState: receipt?.state ?? null,
+    }));
+  `;
+  const run = async (phase: "admit" | "recover") => {
+    const child = Bun.spawn({
+      cmd: [process.execPath, "-e", source],
+      cwd: process.cwd(),
+      env: {
+        ...process.env,
+        LLV_TEST_PHASE: phase,
+        LLV_STATE_DIR: stateDir,
+        LLV_AGENT_REGISTRY_SQLITE: "off",
+        LLV_SPAWN_TRANSPORT: "structured",
+        LLV_STRUCTURED_HOSTS: "1",
+        LLV_RUNTIME_EVENTS: "1",
+        LLV_RUNTIME_HOST_SOCKET: path.join(sandbox, "runtime.sock"),
+        NEXT_PUBLIC_RUNTIME_UI: "1",
+      },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [exit, stdout, stderr] = await Promise.all([
+      child.exited,
+      new Response(child.stdout).text(),
+      new Response(child.stderr).text(),
+    ]);
+    expect({ exit, stderr }).toEqual({ exit: 0, stderr: "" });
+    return JSON.parse(stdout) as {
+      status: number;
+      body: { launchId: string; conversationId: string; state: string };
+      deferred: number;
+      receiptState: string | null;
+    };
+  };
+
+  const admitted = await run("admit");
+  expect(admitted).toMatchObject({ status: 202, deferred: 1, receiptState: "starting" });
+
+  const recovered = await Promise.all([run("recover"), run("recover")]);
+  const effects = fs.existsSync(effectsPath)
+    ? fs.readFileSync(effectsPath, "utf8").trim().split("\n").map((line) => JSON.parse(line) as { effect: string })
+    : [];
+  const finalReceipt = new AgentRegistry(path.join(stateDir, "agent-registry.json"), undefined, undefined, { sqliteMode: "off" })
+    .snapshot().receipts[admitted.body.launchId];
+
+  expect(new Set(recovered.map((result) => result.body.launchId))).toEqual(new Set([admitted.body.launchId]));
+  expect(new Set(recovered.map((result) => result.body.conversationId))).toEqual(new Set([admitted.body.conversationId]));
+  expect(recovered.filter((result) => result.deferred === 1)).toHaveLength(1);
+  expect(effects.map((effect) => effect.effect)).toEqual(["worker", "first-prompt"]);
+  expect(finalReceipt).toMatchObject({
+    launchId: admitted.body.launchId,
+    conversationId: admitted.body.conversationId,
+    state: "completed",
+    completionMode: "route-completed",
+  });
+}, 20_000);
+
 test("structured spawn runtime fence preserves durable state", async () => {
   const cwd = fs.mkdtempSync(path.join(routeSandbox, "structured-runtime-fence-"));
   const registryPath = path.join(cwd, "cold-agent-registry.json");

--- a/src/app/api/spawn/route.ts
+++ b/src/app/api/spawn/route.ts
@@ -6,7 +6,7 @@ import { after, NextRequest, NextResponse } from "next/server";
 
 import { UnknownAccountError } from "@/lib/accounts/codex";
 import { claudeSettingsPath, isManagedClaudeHome, UnknownClaudeAccountError } from "@/lib/accounts/claude";
-import { resolveHealthySpawnAccount } from "@/lib/accounts/manager";
+import { accountManager, resolveHealthySpawnAccount } from "@/lib/accounts/manager";
 import { emptyLaunchProfile } from "@/lib/accounts/migration/contracts";
 import { freshSpecFor, type AgentEngine } from "@/lib/agent/cli";
 import { agentRegistry, SpawnChildLimitError } from "@/lib/agent/registry";
@@ -47,6 +47,7 @@ const SUGGEST_MAX = 10;
 interface SpawnRouteDependencies {
   registry: typeof agentRegistry;
   resolveHealthySpawnAccount: typeof resolveHealthySpawnAccount;
+  resolveSpawnAccount: typeof accountManager.resolveSpawn;
   runtimeHostClient: typeof runtimeHostClient;
   spawnStructuredConversation: typeof spawnStructuredConversation;
   assertStructuredRuntime: typeof assertDarwinStructuredRuntime;
@@ -56,6 +57,7 @@ interface SpawnRouteDependencies {
 const productionSpawnRouteDependencies: SpawnRouteDependencies = {
   registry: agentRegistry,
   resolveHealthySpawnAccount,
+  resolveSpawnAccount: (engine, accountId) => accountManager.resolveSpawn(engine, accountId),
   runtimeHostClient,
   spawnStructuredConversation,
   assertStructuredRuntime: assertDarwinStructuredRuntime,
@@ -197,7 +199,11 @@ async function postSpawn(
   let imagePaths: string[] = [];
   let launchId: string | null = null;
   try {
-    const account = await dependencies.resolveHealthySpawnAccount(engine, body.accountId);
+    const clientAttemptId = typeof body.clientAttemptId === "string" ? body.clientAttemptId : null;
+    const existingAttempt = clientAttemptId ? registry.spawnReceiptForClientAttempt(clientAttemptId) : null;
+    const account = existingAttempt && body.accountId === undefined && existingAttempt.accountId !== null
+      ? dependencies.resolveSpawnAccount(existingAttempt.engine, existingAttempt.accountId)
+      : await dependencies.resolveHealthySpawnAccount(engine, body.accountId);
     const lineage = resolveSpawnLineage(spawnLineageSelectorForCaller(authenticatedCaller, {
       ...body,
       role: role.value?.role,
@@ -261,7 +267,7 @@ async function postSpawn(
       reviewsConversationId: reviewedConversationId,
       liveChildrenCap: authenticatedCaller?.liveChildrenCap,
       launchProfile: spec.launchProfile,
-      clientAttemptId: body.clientAttemptId ?? null,
+      clientAttemptId,
       requestDigest: digest,
     });
     if (begun.kind === "conflict") return NextResponse.json({ error: "spawn attempt conflicts with its original request" }, { status: 409 });

--- a/src/app/api/spawn/route.ts
+++ b/src/app/api/spawn/route.ts
@@ -265,6 +265,46 @@ async function postSpawn(
       requestDigest: digest,
     });
     if (begun.kind === "conflict") return NextResponse.json({ error: "spawn attempt conflicts with its original request" }, { status: 409 });
+    const deferStructuredSpawn = (
+      receipt: typeof begun.receipt,
+      runtimeClient: NonNullable<ReturnType<typeof dependencies.runtimeHostClient>>,
+    ): void => {
+      dependencies.defer(async () => {
+        let response: SpawnResponse;
+        try {
+          response = await dependencies.spawnStructuredConversation({
+            engine,
+            receipt,
+            spec,
+            account,
+            prompt,
+            registry,
+            client: runtimeClient,
+          });
+        } catch (error) {
+          console.error("[spawn] structured launch failed", {
+            launchId: receipt.launchId,
+            conversationId: receipt.conversationId,
+            error,
+          });
+          return;
+        }
+        if (parentArtifactPath && response.path) {
+          try {
+            rememberHandoffChild(response.path, parentArtifactPath);
+            persistHandoffLineage();
+          } catch (error) {
+            console.error("[spawn] handoff lineage persistence failed", {
+              launchId: receipt.launchId,
+              conversationId: receipt.conversationId,
+              childArtifactPath: response.path,
+              parentArtifactPath,
+              error,
+            });
+          }
+        }
+      });
+    };
     if (begun.kind === "replay") {
       const structured = begun.receipt.transport === "structured"
         || (begun.receipt.transport === null
@@ -280,6 +320,9 @@ async function postSpawn(
         } catch {
           /* The durable registry receipt remains available during runtime resynchronization. */
         }
+        const admission = registry.claimStartingStructuredSpawn(receipt.launchId);
+        receipt = admission.receipt;
+        if (admission.claimed) deferStructuredSpawn(receipt, runtimeClient);
       }
       const response = spawnResponseForReceipt(receipt, receipt.artifactPath, { structured, initialMessage });
       return NextResponse.json(response, { status: spawnReplayStatus(response, structured) });
@@ -297,41 +340,7 @@ async function postSpawn(
     if (transport === "structured") {
       const runtimeClient = dependencies.runtimeHostClient();
       if (!runtimeClient) throw new Error("structured spawn runtime host is unavailable");
-      dependencies.defer(async () => {
-        let response: SpawnResponse;
-        try {
-          response = await dependencies.spawnStructuredConversation({
-            engine,
-            receipt: begun.receipt,
-            spec,
-            account,
-            prompt,
-            registry,
-            client: runtimeClient,
-          });
-        } catch (error) {
-          console.error("[spawn] structured launch failed", {
-            launchId: begun.receipt.launchId,
-            conversationId: begun.receipt.conversationId,
-            error,
-          });
-          return;
-        }
-        if (parentArtifactPath && response.path) {
-          try {
-            rememberHandoffChild(response.path, parentArtifactPath);
-            persistHandoffLineage();
-          } catch (error) {
-            console.error("[spawn] handoff lineage persistence failed", {
-              launchId: begun.receipt.launchId,
-              conversationId: begun.receipt.conversationId,
-              childArtifactPath: response.path,
-              parentArtifactPath,
-              error,
-            });
-          }
-        }
-      });
+      deferStructuredSpawn(begun.receipt, runtimeClient);
       return NextResponse.json(
         spawnResponseForReceipt(begun.receipt, begun.receipt.artifactPath, { structured: true }),
         { status: 202 },

--- a/src/app/api/tasks/[id]/spawn/route.test.ts
+++ b/src/app/api/tasks/[id]/spawn/route.test.ts
@@ -195,3 +195,155 @@ test("pre-pane spawn failure returns an ownerless task to inbox", async () => {
     error: "process exited before pane creation",
   });
 });
+
+test("a deliberate retry after pre-pane failure creates one fresh launch", async () => {
+  const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "llv-task-deliberate-retry-"));
+  const registry = new AgentRegistry(path.join(cwd, "registry.json"), undefined, undefined, { sqliteMode: "off" });
+  let tasks: BoardTask[] = [{
+    id: "4f337f38-48dd-44af-bf15-5b544ce3ea14",
+    project: "live-log-viewer-next",
+    status: "inbox",
+    text: "Retry release ownership",
+    placement: "pinned",
+    pos: { x: 0, y: 0 },
+    assignments: [],
+    createdAt: "2026-07-17T10:00:00.000Z",
+    updatedAt: "2026-07-17T10:00:00.000Z",
+  }];
+  let spawnCalls = 0;
+  const dependencies = {
+    registry: () => registry,
+    loadTasks: () => tasks,
+    mutateTasks: (mutator: (current: BoardTask[]) => { tasks?: BoardTask[]; result: unknown }) => {
+      const mutation = mutator(tasks);
+      if (mutation.tasks) tasks = mutation.tasks;
+      return mutation.result;
+    },
+    resolveSpawnAccount: () => ({
+      engine: "claude" as const,
+      accountId: "claude-work",
+      kind: "managed" as const,
+      home: cwd,
+      transcriptRoot: cwd,
+      env: { NODE_ENV: "test" },
+    }),
+    resolveSpawnedTranscriptPath: async () => {
+      throw new Error("transcript lookup must stay unreachable");
+    },
+    spawnAgentWithPrompt: async () => {
+      spawnCalls += 1;
+      throw new Error("process exited before pane creation");
+    },
+  } as Parameters<typeof POST.withDependencies>[2];
+  const request = () => new NextRequest(
+    "http://127.0.0.1/api/tasks/4f337f38-48dd-44af-bf15-5b544ce3ea14/spawn",
+    {
+      method: "POST",
+      headers: { origin: "http://127.0.0.1", host: "127.0.0.1", "content-type": "application/json" },
+      body: JSON.stringify({ engine: "claude", cwd }),
+    },
+  );
+  const context = { params: Promise.resolve({ id: tasks[0]!.id }) };
+
+  const first = await POST.withDependencies(request(), context, dependencies);
+  const firstBody = await first.json();
+  const retry = await POST.withDependencies(request(), context, dependencies);
+  const retryBody = await retry.json();
+
+  expect([first.status, retry.status]).toEqual([500, 500]);
+  expect(retryBody.launchId).not.toBe(firstBody.launchId);
+  expect(spawnCalls).toBe(2);
+  expect(tasks[0]).toMatchObject({ status: "inbox" });
+  expect(tasks[0]?.assignments).toEqual([
+    expect.objectContaining({ launchId: firstBody.launchId, state: "failed" }),
+    expect.objectContaining({ launchId: retryBody.launchId, state: "failed" }),
+  ]);
+});
+
+test("concurrent and lost-response replays actuate each deliberate gesture once", async () => {
+  const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "llv-task-gesture-replay-"));
+  const registry = new AgentRegistry(path.join(cwd, "registry.json"), undefined, undefined, { sqliteMode: "off" });
+  let tasks: BoardTask[] = [{
+    id: "4f337f38-48dd-44af-bf15-5b544ce3ea15",
+    project: "live-log-viewer-next",
+    status: "inbox",
+    text: "Replay one launch gesture",
+    placement: "pinned",
+    pos: { x: 0, y: 0 },
+    assignments: [],
+    createdAt: "2026-07-17T10:00:00.000Z",
+    updatedAt: "2026-07-17T10:00:00.000Z",
+  }];
+  let spawnCalls = 0;
+  let signalStarted: (() => void) | null = null;
+  let releaseSpawn: (() => void) | null = null;
+  const dependencies = {
+    registry: () => registry,
+    loadTasks: () => tasks,
+    mutateTasks: (mutator: (current: BoardTask[]) => { tasks?: BoardTask[]; result: unknown }) => {
+      const mutation = mutator(tasks);
+      if (mutation.tasks) tasks = mutation.tasks;
+      return mutation.result;
+    },
+    resolveSpawnAccount: () => ({
+      engine: "claude" as const,
+      accountId: "claude-work",
+      kind: "managed" as const,
+      home: cwd,
+      transcriptRoot: cwd,
+      env: { NODE_ENV: "test" },
+    }),
+    resolveSpawnedTranscriptPath: async () => {
+      throw new Error("transcript lookup must stay unreachable");
+    },
+    spawnAgentWithPrompt: async () => {
+      spawnCalls += 1;
+      signalStarted?.();
+      await new Promise<void>((resolve) => { releaseSpawn = resolve; });
+      throw new Error("process exited before pane creation");
+    },
+  } as Parameters<typeof POST.withDependencies>[2];
+  const context = { params: Promise.resolve({ id: tasks[0]!.id }) };
+  const request = (clientAttemptId: string) => new NextRequest(
+    "http://127.0.0.1/api/tasks/4f337f38-48dd-44af-bf15-5b544ce3ea15/spawn",
+    {
+      method: "POST",
+      headers: { origin: "http://127.0.0.1", host: "127.0.0.1", "content-type": "application/json" },
+      body: JSON.stringify({ engine: "claude", cwd, clientAttemptId }),
+    },
+  );
+  const runGesture = async (clientAttemptId: string) => {
+    const started = new Promise<void>((resolve) => { signalStarted = resolve; });
+    const firstPromise = POST.withDependencies(request(clientAttemptId), context, dependencies);
+    await started;
+    const concurrent = await POST.withDependencies(request(clientAttemptId), context, dependencies);
+    releaseSpawn?.();
+    const first = await firstPromise;
+    const lostResponseReplay = await POST.withDependencies(request(clientAttemptId), context, dependencies);
+    signalStarted = null;
+    releaseSpawn = null;
+    return {
+      first,
+      firstBody: await first.json(),
+      concurrent,
+      concurrentBody: await concurrent.json(),
+      replay: lostResponseReplay,
+      replayBody: await lostResponseReplay.json(),
+    };
+  };
+
+  const firstGesture = await runGesture("task_gesture_20260717_a1");
+  const secondGesture = await runGesture("task_gesture_20260717_a2");
+
+  for (const gesture of [firstGesture, secondGesture]) {
+    expect([gesture.first.status, gesture.concurrent.status, gesture.replay.status]).toEqual([500, 202, 200]);
+    expect(gesture.concurrentBody.launchId).toBe(gesture.firstBody.launchId);
+    expect(gesture.replayBody.launchId).toBe(gesture.firstBody.launchId);
+  }
+  expect(secondGesture.firstBody.launchId).not.toBe(firstGesture.firstBody.launchId);
+  expect(spawnCalls).toBe(2);
+  expect(tasks[0]?.assignments).toEqual([
+    expect.objectContaining({ launchId: firstGesture.firstBody.launchId, state: "failed" }),
+    expect.objectContaining({ launchId: secondGesture.firstBody.launchId, state: "failed" }),
+  ]);
+});

--- a/src/app/api/tasks/[id]/spawn/route.test.ts
+++ b/src/app/api/tasks/[id]/spawn/route.test.ts
@@ -117,3 +117,81 @@ test("task attribution failure replays one launched pane into one durable assign
     state: "delivered",
   })]);
 });
+
+test("pre-pane spawn failure returns an ownerless task to inbox", async () => {
+  const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "llv-task-ownerless-failure-"));
+  const registry = new AgentRegistry(path.join(cwd, "registry.json"), undefined, undefined, { sqliteMode: "off" });
+  let tasks: BoardTask[] = [{
+    id: "4f337f38-48dd-44af-bf15-5b544ce3ea13",
+    project: "live-log-viewer-next",
+    status: "inbox",
+    text: "Repair release ownership",
+    placement: "pinned",
+    pos: { x: 0, y: 0 },
+    assignments: [],
+    createdAt: "2026-07-17T10:00:00.000Z",
+    updatedAt: "2026-07-17T10:00:00.000Z",
+  }];
+  const dependencies = {
+    registry: () => registry,
+    loadTasks: () => tasks,
+    mutateTasks: (mutator: (current: BoardTask[]) => { tasks?: BoardTask[]; result: unknown }) => {
+      const mutation = mutator(tasks);
+      if (mutation.tasks) tasks = mutation.tasks;
+      return mutation.result;
+    },
+    resolveSpawnAccount: () => ({
+      engine: "claude" as const,
+      accountId: "claude-work",
+      kind: "managed" as const,
+      home: cwd,
+      transcriptRoot: cwd,
+      env: { NODE_ENV: "test" },
+    }),
+    resolveSpawnedTranscriptPath: async () => {
+      throw new Error("transcript lookup must stay unreachable");
+    },
+    spawnAgentWithPrompt: async () => {
+      throw new Error("process exited before pane creation");
+    },
+  } as Parameters<typeof POST.withDependencies>[2];
+  const response = await POST.withDependencies(new NextRequest(
+    "http://127.0.0.1/api/tasks/4f337f38-48dd-44af-bf15-5b544ce3ea13/spawn",
+    {
+      method: "POST",
+      headers: { origin: "http://127.0.0.1", host: "127.0.0.1", "content-type": "application/json" },
+      body: JSON.stringify({
+        engine: "claude",
+        cwd,
+        clientAttemptId: "task_ownerless_failure_20260717_a1",
+      }),
+    },
+  ), { params: Promise.resolve({ id: tasks[0]!.id }) }, dependencies);
+  const body = await response.json();
+  const launchId = body.launchId;
+
+  expect(response.status).toBe(500);
+  expect(body).toMatchObject({
+    launchId: expect.any(String),
+    assignment: "failed",
+    state: "failed",
+    retrySafe: true,
+    task: { status: "inbox" },
+  });
+  expect(tasks[0]).toMatchObject({
+    status: "inbox",
+    assignments: [{
+      launchId,
+      path: null,
+      panePid: null,
+      state: "failed",
+      error: "process exited before pane creation",
+    }],
+  });
+  const receiptSnapshot = registry.snapshot().receipts;
+  expect(Object.keys(receiptSnapshot)).toContain(launchId);
+  expect(receiptSnapshot[launchId]).toMatchObject({
+    state: "failed",
+    error: "process exited before pane creation",
+  });
+});

--- a/src/app/api/tasks/[id]/spawn/route.ts
+++ b/src/app/api/tasks/[id]/spawn/route.ts
@@ -84,6 +84,15 @@ function stableTaskAttemptId(task: BoardTask, shape: Record<string, unknown>): s
   return `task_${digest.slice(0, 48)}`;
 }
 
+function nextTaskAttemptId(registry: AgentRegistry, task: BoardTask, shape: Record<string, unknown>): string {
+  const base = stableTaskAttemptId(task, shape);
+  for (let generation = 1; ; generation += 1) {
+    const candidate = generation === 1 ? base : `${base}_${generation}`;
+    const receipt = registry.spawnReceiptForClientAttempt(candidate);
+    if (!receipt || receipt.state !== "failed") return candidate;
+  }
+}
+
 function taskRequestDigest(task: BoardTask, shape: Record<string, unknown>): string {
   return crypto.createHash("sha256").update(JSON.stringify({ taskId: task.id, text: task.text, shape })).digest("hex");
 }
@@ -185,6 +194,7 @@ async function postTaskSpawn(
   const task = dependencies.loadTasks().find((item) => item.id === id);
   if (!task) return NextResponse.json({ error: "task not found" }, { status: 404 });
 
+  const registry = dependencies.registry();
   const previous = pinnedAccountId(task.assignments, engine);
   let account: AccountContext;
   try {
@@ -202,7 +212,7 @@ async function postTaskSpawn(
   };
   const clientAttemptId = typeof body.clientAttemptId === "string"
     ? body.clientAttemptId
-    : stableTaskAttemptId(task, shape);
+    : nextTaskAttemptId(registry, task, shape);
   const specBase = freshSpecFor(engine, cwdResult.cwd, {
     model: selectedModel.model,
     effort: reasoning.effort,
@@ -221,7 +231,6 @@ async function postTaskSpawn(
       title: task.text.split("\n")[0]?.trim() || null,
     }),
   };
-  const registry = dependencies.registry();
   const begun = registry.beginSpawnRequest({
     engine,
     cwd: cwdResult.cwd,

--- a/src/components/tasks/taskApi.test.ts
+++ b/src/components/tasks/taskApi.test.ts
@@ -1,0 +1,29 @@
+import { afterEach, expect, test } from "bun:test";
+
+import { createTaskSpawnGesture, spawnTaskAgent } from "./taskApi";
+
+const realFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = realFetch;
+});
+
+test("task spawn gestures own distinct replay-stable attempt identities", async () => {
+  const first = createTaskSpawnGesture({ engine: "claude", cwd: "/repo", model: "opus" });
+  const second = createTaskSpawnGesture({ engine: "claude", cwd: "/repo", model: "opus" });
+  const bodies: unknown[] = [];
+  globalThis.fetch = (async (_url: string | URL | Request, init?: RequestInit) => {
+    bodies.push(JSON.parse(String(init?.body)));
+    return new Response(JSON.stringify({ error: "lost response" }), {
+      status: 500,
+      headers: { "content-type": "application/json" },
+    });
+  }) as typeof fetch;
+
+  await spawnTaskAgent("task-1", first);
+  await spawnTaskAgent("task-1", first);
+  await spawnTaskAgent("task-1", second);
+
+  expect(first.clientAttemptId).not.toBe(second.clientAttemptId);
+  expect(bodies).toEqual([first, first, second]);
+});

--- a/src/components/tasks/taskApi.ts
+++ b/src/components/tasks/taskApi.ts
@@ -215,7 +215,13 @@ export interface SpawnAgentInput {
   cwd: string;
   effort?: string;
   fast?: boolean;
-  clientAttemptId?: string;
+  clientAttemptId: string;
+}
+
+/** Creates one launch identity for a user gesture. Keep the returned value
+    through retries whose response may have been lost. */
+export function createTaskSpawnGesture(input: Omit<SpawnAgentInput, "clientAttemptId">): SpawnAgentInput {
+  return { ...input, clientAttemptId: newClientRequestId() };
 }
 
 /** Spawns an agent with the task text as the brief; same stale-text guard

--- a/src/lib/agent/registry.test.ts
+++ b/src/lib/agent/registry.test.ts
@@ -2643,7 +2643,7 @@ describe("agent registry", () => {
     }));
     const restarted = new AgentRegistry(store.filename).snapshot();
     expect(restarted.version).toBe(2);
-    expect(restarted.receipts.legacy).toMatchObject({ clientAttemptId: null, pane: null, key: null, state: "starting" });
+    expect(restarted.receipts.legacy).toMatchObject({ clientAttemptId: null, pane: null, key: null, state: "starting", artifactLifecycle: "pending" });
     expect(restarted.receipts.legacy?.conversationId.startsWith("conversation_")).toBe(true);
   });
 

--- a/src/lib/agent/registry.test.ts
+++ b/src/lib/agent/registry.test.ts
@@ -1155,6 +1155,42 @@ describe("agent registry", () => {
     expect(store.beginSpawnRequest({ ...request, transport: "tmux" }).kind).toBe("conflict");
   });
 
+  test("structured admission recovery fences a live owner and adopts a recycled pid", () => {
+    const store = registry((owner) =>
+      owner.pid === process.pid || (owner.pid === 987_654 && owner.startIdentity === "987654:new"));
+    const begun = store.beginSpawnRequest({
+      engine: "claude",
+      cwd: "/repo",
+      accountId: "work",
+      clientAttemptId: "attempt_admission_owner",
+      requestDigest: "digest",
+      transport: "structured",
+    });
+    if (begun.kind !== "created") throw new Error("expected create");
+    const snapshot = store.snapshot();
+    snapshot.receipts[begun.receipt.launchId]!.admissionOwner = {
+      pid: 987_654,
+      startIdentity: "987654:new",
+    };
+    fs.writeFileSync(store.filename, JSON.stringify(snapshot));
+
+    expect(store.claimStartingStructuredSpawn(begun.receipt.launchId)).toMatchObject({
+      claimed: false,
+      receipt: { admissionOwner: { pid: 987_654, startIdentity: "987654:new" } },
+    });
+
+    snapshot.receipts[begun.receipt.launchId]!.admissionOwner = {
+      pid: 987_654,
+      startIdentity: "987654:old",
+    };
+    fs.writeFileSync(store.filename, JSON.stringify(snapshot));
+
+    expect(store.claimStartingStructuredSpawn(begun.receipt.launchId)).toMatchObject({
+      claimed: true,
+      receipt: { admissionOwner: { pid: process.pid } },
+    });
+  });
+
   test("spawn capability digest durably resolves its reserved conversation", () => {
     const store = registry();
     const digest = "a".repeat(64);

--- a/src/lib/agent/registry.ts
+++ b/src/lib/agent/registry.ts
@@ -137,6 +137,8 @@ export interface SpawnReceipt {
   createdAt: string;
   state: "starting" | "pane-bound" | "host-verified" | "prompt-delivered" | "path-pending" | "completed" | "failed" | "conflicted";
   artifactPath: string | null;
+  /** Tracks whether inventory has ever materialized the reserved artifact. */
+  artifactLifecycle: "pending" | "materialized";
   key: SessionKey | null;
   pane: TmuxSpawnBinding | null;
   verifiedHost: TmuxHostEvidence | null;
@@ -1263,6 +1265,7 @@ function normalizeReceipt(value: SpawnReceipt): SpawnReceipt {
       ? value.parentConversationId as ViewerConversationId
       : null,
     state,
+    artifactLifecycle: value.artifactLifecycle === "materialized" ? "materialized" : "pending",
     key: value.key && typeof value.key === "object" && (value.key.engine === "claude" || value.key.engine === "codex") && typeof value.key.sessionId === "string" ? value.key : null,
     pane,
     verifiedHost: value.verifiedHost && typeof value.verifiedHost === "object" && value.verifiedHost.kind === "tmux" ? value.verifiedHost : null,
@@ -2125,6 +2128,7 @@ export class AgentRegistry {
         createdAt,
         state: "starting",
         artifactPath: input.expectedArtifactPath ?? null,
+        artifactLifecycle: "pending",
         key: null,
         pane: null,
         verifiedHost: null,
@@ -3068,7 +3072,18 @@ export class AgentRegistry {
           migrationReceiptByPath.set(receiptPath, receipt);
         }
       }
+      const pendingStructuredReceiptsByPath = new Map<string, SpawnReceipt[]>();
+      for (const receipt of Object.values(file.receipts)) {
+        if (receipt.transport !== "structured" || receipt.artifactLifecycle !== "pending" || !receipt.artifactPath) continue;
+        const pathKey = `${receipt.engine}:${receipt.artifactPath}`;
+        const receipts = pendingStructuredReceiptsByPath.get(pathKey) ?? [];
+        receipts.push(receipt);
+        pendingStructuredReceiptsByPath.set(pathKey, receipts);
+      }
       for (const observation of observations) {
+        for (const receipt of pendingStructuredReceiptsByPath.get(`${observation.engine}:${observation.path}`) ?? []) {
+          receipt.artifactLifecycle = "materialized";
+        }
         const nativeId = sessionKeyFromTranscript(observation.engine, observation.path)?.sessionId ?? null;
         const pathPendingLaunchId = pathPendingLaunches.get(observation.path);
         if (nativeId && pathPendingLaunchId) {

--- a/src/lib/agent/registry.ts
+++ b/src/lib/agent/registry.ts
@@ -2005,6 +2005,12 @@ export class AgentRegistry {
     return readFile(this.filename);
   }
 
+  spawnReceiptForClientAttempt(clientAttemptId: string): SpawnReceipt | null {
+    const receipt = Object.values(this.readOnlySnapshot().receipts)
+      .find((candidate) => candidate.clientAttemptId === clientAttemptId);
+    return receipt ? clone(receipt) : null;
+  }
+
   conversationIdForSpawnCapabilityDigest(digest: string): ViewerConversationId | null {
     if (!/^[0-9a-f]{64}$/.test(digest)) return null;
     const file = this.readOnlySnapshot();

--- a/src/lib/agent/registry.ts
+++ b/src/lib/agent/registry.ts
@@ -116,6 +116,9 @@ export interface SpawnReceipt {
   requestDigest: string | null;
   /** Launch transport fixed when the idempotent reservation is created. */
   transport: "tmux" | "structured" | null;
+  /** Process that owns pre-host structured admission. A replacement may take
+      this fence only after the recorded process identity is no longer live. */
+  admissionOwner: ProcessIdentity | null;
   /** One-way binding for the caller credential injected into this worker. */
   spawnCapabilityDigest: string | null;
   /** Reserved at receipt birth so path discovery cannot choose the identity. */
@@ -1234,6 +1237,14 @@ function normalizeReceipt(value: SpawnReceipt): SpawnReceipt {
     clientAttemptId: typeof value.clientAttemptId === "string" ? value.clientAttemptId : null,
     requestDigest: typeof value.requestDigest === "string" ? value.requestDigest : null,
     transport: value.transport === "tmux" || value.transport === "structured" ? value.transport : null,
+    admissionOwner: value.admissionOwner
+      && Number.isInteger(value.admissionOwner.pid)
+      && value.admissionOwner.pid > 0
+      ? {
+          pid: value.admissionOwner.pid,
+          startIdentity: typeof value.admissionOwner.startIdentity === "string" ? value.admissionOwner.startIdentity : null,
+        }
+      : null,
     spawnCapabilityDigest: typeof value.spawnCapabilityDigest === "string" && /^[0-9a-f]{64}$/.test(value.spawnCapabilityDigest)
       ? value.spawnCapabilityDigest
       : null,
@@ -2089,6 +2100,9 @@ export class AgentRegistry {
         clientAttemptId: input.clientAttemptId ?? null,
         requestDigest: input.requestDigest ?? null,
         transport: input.transport ?? null,
+        admissionOwner: input.transport === "structured"
+          ? { pid: process.pid, startIdentity: procBackend.processIdentity(process.pid) }
+          : null,
         spawnCapabilityDigest: typeof input.spawnCapabilityDigest === "string" && /^[0-9a-f]{64}$/.test(input.spawnCapabilityDigest)
           ? input.spawnCapabilityDigest
           : null,
@@ -2154,6 +2168,26 @@ export class AgentRegistry {
         recordMembership(file, receipt.conversationId, membership, receipt.createdAt);
       }
       return { kind: "created", receipt: clone(receipt) };
+    });
+  }
+
+  /** Atomically adopts a structured receipt whose pre-host owner exited.
+      A live owner keeps responsibility for its process-local deferred work. */
+  claimStartingStructuredSpawn(launchId: string): { claimed: boolean; receipt: SpawnReceipt } {
+    return this.mutate((file) => {
+      const receipt = file.receipts[launchId];
+      if (!receipt) throw new Error("unknown spawn receipt");
+      if (receipt.transport !== "structured" || receipt.state !== "starting" || receipt.key || receipt.pane) {
+        return { claimed: false, receipt: clone(receipt) };
+      }
+      if (receipt.admissionOwner && this.ownerAlive(receipt.admissionOwner)) {
+        return { claimed: false, receipt: clone(receipt) };
+      }
+      receipt.admissionOwner = {
+        pid: process.pid,
+        startIdentity: procBackend.processIdentity(process.pid),
+      };
+      return { claimed: true, receipt: clone(receipt) };
     });
   }
 

--- a/src/lib/agent/registry.ts
+++ b/src/lib/agent/registry.ts
@@ -1275,6 +1275,31 @@ function normalizeReceipt(value: SpawnReceipt): SpawnReceipt {
   };
 }
 
+function backfillMaterializedSpawnArtifacts(file: RegistryFile): RegistryFile {
+  for (const receipt of Object.values(file.receipts)) {
+    if (receipt.transport !== "structured"
+      || receipt.state !== "completed"
+      || receipt.artifactLifecycle !== "pending"
+      || !receipt.artifactPath) continue;
+    const conversation = file.conversations[resolveConversationAlias(file, receipt.conversationId)];
+    const generation = conversation?.generations.find((candidate) => candidate.path === receipt.artifactPath);
+    const observedCompletion = receipt.completionMode === "observed-completed" || receipt.completionMode === "route-recovered";
+    const singleGenerationLaunchObservedAfterSettlement = receipt.purpose === "launch"
+      && conversation?.generations.length === 1
+      && conversation.continuityPaths.length === 0
+      && conversation.migration === null
+      && conversation.turn.observedAt !== null
+      && generation !== undefined
+      && observationIsCurrent(generation.createdAt, conversation.turn.observedAt);
+    if (conversation?.engine === receipt.engine
+      && generation
+      && (observedCompletion || singleGenerationLaunchObservedAfterSettlement)) {
+      receipt.artifactLifecycle = "materialized";
+    }
+  }
+  return file;
+}
+
 function upgradeV1(parsed: Omit<Partial<RegistryFile>, "version">): RegistryFile {
   const legacy = parsed.legacyResumePanes;
   return {
@@ -1302,7 +1327,7 @@ export function normalizeRegistry(value: unknown): RegistryFile {
     throw new RegistryReadError("agent registry schema is unsupported");
   }
   const legacy = parsed.legacyResumePanes;
-  return {
+  return backfillMaterializedSpawnArtifacts({
       version: 2,
       entries: Object.fromEntries(Object.entries(parsed.entries).map(([id, entry]) => [id, normalizeEntry(entry)])),
       receipts: Object.fromEntries(Object.entries(parsed.receipts).map(([id, receipt]) => [id, normalizeReceipt(receipt)])),
@@ -1340,7 +1365,7 @@ export function normalizeRegistry(value: unknown): RegistryFile {
       pendingSuccessorCleanups: parsed.pendingSuccessorCleanups && typeof parsed.pendingSuccessorCleanups === "object"
         ? parsed.pendingSuccessorCleanups
         : {},
-  };
+  });
 }
 
 function readFileWithPayload(filename: string): { file: RegistryFile; payload: string | null } {

--- a/src/lib/agent/spawnProjection.test.ts
+++ b/src/lib/agent/spawnProjection.test.ts
@@ -1,0 +1,252 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { expect, test } from "bun:test";
+
+import { emptyLaunchProfile } from "@/lib/accounts/migration/contracts";
+import type { FileEntry } from "@/lib/types";
+
+import { AgentRegistry } from "./registry";
+import { preallocatedStructuredSpawnCards } from "./spawnProjection";
+
+function scannedFile(pathname: string): FileEntry {
+  return {
+    path: pathname,
+    root: "codex-sessions",
+    name: path.basename(pathname),
+    project: "repo",
+    title: "Settled spawn",
+    engine: "codex",
+    kind: "session",
+    fmt: "codex",
+    parent: null,
+    mtime: 1,
+    size: 1,
+    activity: "idle",
+    proc: null,
+    pid: null,
+    model: null,
+    pendingQuestion: null,
+    waitingInput: null,
+  };
+}
+
+function observeArtifact(registry: AgentRegistry, artifactPath: string, cwd: string): void {
+  registry.reconcileConversations([{
+    engine: "codex",
+    path: artifactPath,
+    accountId: "work",
+    launchProfile: emptyLaunchProfile({ cwd }),
+    turn: { state: "idle", source: "empty", terminalAt: null },
+    observedAt: "2026-07-17T10:00:00.000Z",
+  }]);
+}
+
+test("a settled artifact stays projected across restart until inventory observes it", () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-spawn-projection-scan-lag-"));
+  const filename = path.join(directory, "agent-registry.json");
+  const artifactPath = path.join(directory, "019f7b8a-9f75-7dc0-b231-17f7eadd7fe0.jsonl");
+  try {
+    fs.writeFileSync(artifactPath, `${JSON.stringify({ type: "user", message: "scan lag" })}\n`);
+    const registry = new AgentRegistry(filename, undefined, undefined, { sqliteMode: "off" });
+    const begun = registry.beginSpawnRequest({
+      engine: "codex",
+      cwd: directory,
+      transport: "structured",
+      accountId: "work",
+      clientAttemptId: "scan_lag_20260717_a1",
+      requestDigest: "c".repeat(64),
+      launchProfile: emptyLaunchProfile({ cwd: directory }),
+    });
+    if (begun.kind !== "created") throw new Error("expected structured launch creation");
+    registry.settleSpawn(begun.receipt.launchId, {
+      key: { engine: "codex", sessionId: "019f7b8a-9f75-7dc0-b231-17f7eadd7fe0" },
+      artifactPath,
+      cwd: directory,
+      accountId: "work",
+      launchProfile: emptyLaunchProfile({ cwd: directory }),
+      status: "unhosted",
+      host: null,
+      claimEpoch: 0,
+      claimOwner: null,
+      pendingAction: null,
+    });
+
+    const restarted = new AgentRegistry(filename, undefined, undefined, { sqliteMode: "off" });
+    expect(preallocatedStructuredSpawnCards([], restarted.snapshot())).toHaveLength(1);
+  } finally {
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+test("a deleted settled structured transcript stays absent after JSON restart", () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-spawn-projection-delete-"));
+  const filename = path.join(directory, "agent-registry.json");
+  const artifactPath = path.join(directory, "019f7b8a-9f75-7dc0-b231-17f7eadd7fe1.jsonl");
+  try {
+    fs.writeFileSync(artifactPath, `${JSON.stringify({ type: "user", message: "settled" })}\n`);
+    const registry = new AgentRegistry(filename, undefined, undefined, { sqliteMode: "off" });
+    const begun = registry.beginSpawnRequest({
+      engine: "codex",
+      cwd: directory,
+      transport: "structured",
+      accountId: "work",
+      clientAttemptId: "settled_delete_20260717_a1",
+      requestDigest: "d".repeat(64),
+      launchProfile: emptyLaunchProfile({ cwd: directory }),
+    });
+    if (begun.kind !== "created") throw new Error("expected structured launch creation");
+    const settled = registry.settleSpawn(begun.receipt.launchId, {
+      key: { engine: "codex", sessionId: "019f7b8a-9f75-7dc0-b231-17f7eadd7fe1" },
+      artifactPath,
+      cwd: directory,
+      accountId: "work",
+      launchProfile: emptyLaunchProfile({ cwd: directory }),
+      status: "unhosted",
+      host: null,
+      claimEpoch: 0,
+      claimOwner: null,
+      pendingAction: null,
+    });
+    expect(settled.kind).toBe("settled");
+    expect(preallocatedStructuredSpawnCards([scannedFile(artifactPath)], registry.snapshot())).toEqual([]);
+    observeArtifact(registry, artifactPath, directory);
+
+    fs.unlinkSync(artifactPath);
+    const restarted = new AgentRegistry(filename, undefined, undefined, { sqliteMode: "off" });
+
+    expect(preallocatedStructuredSpawnCards([], restarted.snapshot())).toEqual([]);
+  } finally {
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+test("a pending launch remains visible until inventory materializes its transcript", () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-spawn-projection-pending-"));
+  const filename = path.join(directory, "agent-registry.json");
+  const artifactPath = path.join(directory, "019f7b8a-9f75-7dc0-b231-17f7eadd7fe2.jsonl");
+  try {
+    const registry = new AgentRegistry(filename, undefined, undefined, { sqliteMode: "off" });
+    const begun = registry.beginSpawnRequest({
+      engine: "codex",
+      cwd: directory,
+      transport: "structured",
+      accountId: "work",
+      clientAttemptId: "pending_materialize_20260717_a1",
+      requestDigest: "e".repeat(64),
+      launchProfile: emptyLaunchProfile({ cwd: directory }),
+    });
+    if (begun.kind !== "created") throw new Error("expected structured launch creation");
+    registry.settleSpawn(begun.receipt.launchId, {
+      key: { engine: "codex", sessionId: "019f7b8a-9f75-7dc0-b231-17f7eadd7fe2" },
+      artifactPath,
+      cwd: directory,
+      accountId: "work",
+      launchProfile: emptyLaunchProfile({ cwd: directory }),
+      status: "unhosted",
+      host: null,
+      claimEpoch: 0,
+      claimOwner: null,
+      pendingAction: null,
+    });
+
+    expect(preallocatedStructuredSpawnCards([], registry.snapshot())).toHaveLength(1);
+
+    fs.writeFileSync(artifactPath, `${JSON.stringify({ type: "user", message: "materialized" })}\n`);
+    observeArtifact(registry, artifactPath, directory);
+    fs.unlinkSync(artifactPath);
+
+    const restarted = new AgentRegistry(filename, undefined, undefined, { sqliteMode: "off" });
+    expect(preallocatedStructuredSpawnCards([], restarted.snapshot())).toEqual([]);
+  } finally {
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+test("SQLite restart preserves materialized transcript deletion and pending launch visibility", () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-spawn-projection-sqlite-"));
+  const filename = path.join(directory, "agent-registry.json");
+  const artifactPath = path.join(directory, "019f7b8a-9f75-7dc0-b231-17f7eadd7fe3.jsonl");
+  try {
+    fs.writeFileSync(artifactPath, `${JSON.stringify({ type: "user", message: "sqlite" })}\n`);
+    const registry = new AgentRegistry(filename, undefined, undefined, { sqliteMode: "sqlite" });
+    const settled = registry.beginSpawnRequest({
+      engine: "codex",
+      cwd: directory,
+      transport: "structured",
+      accountId: "work",
+      clientAttemptId: "sqlite_delete_20260717_a1",
+      requestDigest: "f".repeat(64),
+      launchProfile: emptyLaunchProfile({ cwd: directory }),
+    });
+    const pending = registry.beginSpawnRequest({
+      engine: "claude",
+      cwd: directory,
+      transport: "structured",
+      accountId: "work",
+      clientAttemptId: "sqlite_pending_20260717_a1",
+      requestDigest: "a".repeat(64),
+      launchProfile: emptyLaunchProfile({ cwd: directory }),
+    });
+    if (settled.kind !== "created" || pending.kind !== "created") throw new Error("expected structured launch creation");
+    registry.settleSpawn(settled.receipt.launchId, {
+      key: { engine: "codex", sessionId: "019f7b8a-9f75-7dc0-b231-17f7eadd7fe3" },
+      artifactPath,
+      cwd: directory,
+      accountId: "work",
+      launchProfile: emptyLaunchProfile({ cwd: directory }),
+      status: "unhosted",
+      host: null,
+      claimEpoch: 0,
+      claimOwner: null,
+      pendingAction: null,
+    });
+    observeArtifact(registry, artifactPath, directory);
+    fs.unlinkSync(artifactPath);
+
+    const restarted = new AgentRegistry(filename, undefined, undefined, { sqliteMode: "sqlite" });
+    const cards = preallocatedStructuredSpawnCards([], restarted.snapshot());
+
+    expect(cards).toHaveLength(1);
+    expect(cards[0]).toMatchObject({
+      path: `spawn:${pending.receipt.launchId}`,
+      spawn: { state: "starting", initialMessage: "pending" },
+    });
+  } finally {
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+test("inventory materialization stays scoped to the observed engine", () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-spawn-projection-engine-scope-"));
+  const artifactPath = path.join(directory, "shared.jsonl");
+  try {
+    const registry = new AgentRegistry(path.join(directory, "registry.json"), undefined, undefined, { sqliteMode: "off" });
+    const codex = registry.beginSpawnRequest({
+      engine: "codex",
+      cwd: directory,
+      transport: "structured",
+      expectedArtifactPath: artifactPath,
+      clientAttemptId: "engine_scope_codex_20260717_a1",
+      requestDigest: "1".repeat(64),
+    });
+    const claude = registry.beginSpawnRequest({
+      engine: "claude",
+      cwd: directory,
+      transport: "structured",
+      expectedArtifactPath: artifactPath,
+      clientAttemptId: "engine_scope_claude_20260717_a1",
+      requestDigest: "2".repeat(64),
+    });
+    if (codex.kind !== "created" || claude.kind !== "created") throw new Error("expected structured launch creation");
+
+    observeArtifact(registry, artifactPath, directory);
+    const snapshot = registry.snapshot();
+
+    expect(snapshot.receipts[codex.receipt.launchId]?.artifactLifecycle).toBe("materialized");
+    expect(snapshot.receipts[claude.receipt.launchId]?.artifactLifecycle).toBe("pending");
+  } finally {
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});

--- a/src/lib/agent/spawnProjection.test.ts
+++ b/src/lib/agent/spawnProjection.test.ts
@@ -80,6 +80,153 @@ test("a settled artifact stays projected across restart until inventory observes
   }
 });
 
+test("a legacy completed receipt with a recorded transcript stays materialized after restart", () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-spawn-projection-legacy-materialized-"));
+  const filename = path.join(directory, "agent-registry.json");
+  const artifactPath = path.join(directory, "019f678d-951e-77f1-bc6a-c3175a6a7bd4.jsonl");
+  try {
+    fs.writeFileSync(artifactPath, `${JSON.stringify({ type: "user", message: "legacy completed transcript" })}\n`);
+    const registry = new AgentRegistry(filename, undefined, undefined, { sqliteMode: "off" });
+    const begun = registry.beginSpawnRequest({
+      engine: "codex",
+      cwd: directory,
+      transport: "structured",
+      accountId: "work",
+      clientAttemptId: "legacy_materialized_20260717_a1",
+      requestDigest: "b".repeat(64),
+      launchProfile: emptyLaunchProfile({ cwd: directory }),
+    });
+    if (begun.kind !== "created") throw new Error("expected structured launch creation");
+    registry.settleSpawn(begun.receipt.launchId, {
+      key: { engine: "codex", sessionId: "019f678d-951e-77f1-bc6a-c3175a6a7bd4" },
+      artifactPath,
+      cwd: directory,
+      accountId: "work",
+      launchProfile: emptyLaunchProfile({ cwd: directory }),
+      status: "unhosted",
+      host: null,
+      claimEpoch: 0,
+      claimOwner: null,
+      pendingAction: null,
+    });
+    observeArtifact(registry, artifactPath, directory);
+
+    const legacy = JSON.parse(fs.readFileSync(filename, "utf8")) as {
+      receipts: Record<string, { artifactLifecycle?: string; createdAt: string }>;
+    };
+    delete legacy.receipts[begun.receipt.launchId]?.artifactLifecycle;
+    legacy.receipts[begun.receipt.launchId]!.createdAt = "2026-07-15T20:00:00.000Z";
+    fs.writeFileSync(filename, JSON.stringify(legacy));
+
+    const restarted = new AgentRegistry(filename, undefined, undefined, { sqliteMode: "off" });
+    expect(restarted.snapshot().receipts[begun.receipt.launchId]?.artifactLifecycle).toBe("materialized");
+    expect(preallocatedStructuredSpawnCards([], restarted.snapshot())).toEqual([]);
+  } finally {
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+test("SQLite import backfills a rollout-era pending lifecycle from durable inventory evidence", () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-spawn-projection-legacy-sqlite-"));
+  const filename = path.join(directory, "agent-registry.json");
+  const artifactPath = path.join(directory, "019f678d-951e-77f1-bc6a-c3175a6a7bd5.jsonl");
+  try {
+    fs.writeFileSync(artifactPath, `${JSON.stringify({ type: "user", message: "legacy sqlite transcript" })}\n`);
+    const jsonRegistry = new AgentRegistry(filename, undefined, undefined, { sqliteMode: "off" });
+    const begun = jsonRegistry.beginSpawnRequest({
+      engine: "codex",
+      cwd: directory,
+      transport: "structured",
+      accountId: "work",
+      clientAttemptId: "legacy_sqlite_materialized_20260717_a1",
+      requestDigest: "7".repeat(64),
+      launchProfile: emptyLaunchProfile({ cwd: directory }),
+    });
+    if (begun.kind !== "created") throw new Error("expected structured launch creation");
+    jsonRegistry.settleSpawn(begun.receipt.launchId, {
+      key: { engine: "codex", sessionId: "019f678d-951e-77f1-bc6a-c3175a6a7bd5" },
+      artifactPath,
+      cwd: directory,
+      accountId: "work",
+      launchProfile: emptyLaunchProfile({ cwd: directory }),
+      status: "unhosted",
+      host: null,
+      claimEpoch: 0,
+      claimOwner: null,
+      pendingAction: null,
+    });
+    observeArtifact(jsonRegistry, artifactPath, directory);
+
+    const rolloutEra = JSON.parse(fs.readFileSync(filename, "utf8")) as {
+      receipts: Record<string, { artifactLifecycle: string; createdAt: string }>;
+    };
+    rolloutEra.receipts[begun.receipt.launchId]!.artifactLifecycle = "pending";
+    rolloutEra.receipts[begun.receipt.launchId]!.createdAt = "2026-07-15T20:00:00.000Z";
+    fs.writeFileSync(filename, JSON.stringify(rolloutEra));
+
+    const imported = new AgentRegistry(filename, undefined, undefined, { sqliteMode: "sqlite" });
+    expect(imported.snapshot().receipts[begun.receipt.launchId]?.artifactLifecycle).toBe("materialized");
+    const restarted = new AgentRegistry(filename, undefined, undefined, { sqliteMode: "sqlite" });
+    expect(preallocatedStructuredSpawnCards([], restarted.snapshot())).toEqual([]);
+  } finally {
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+test("another generation's newer observation cannot materialize a pending launch", () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-spawn-projection-existing-scan-lag-"));
+  const filename = path.join(directory, "agent-registry.json");
+  const firstPath = path.join(directory, "019f678d-951e-77f1-bc6a-c3175a6a7bd6.jsonl");
+  const successorPath = path.join(directory, "019f678d-951e-77f1-bc6a-c3175a6a7bd7.jsonl");
+  try {
+    const registry = new AgentRegistry(filename, undefined, undefined, { sqliteMode: "off" });
+    const conversation = registry.ensureConversation("codex", firstPath, "work");
+    observeArtifact(registry, firstPath, directory);
+    const begun = registry.beginSpawnRequest({
+      engine: "codex",
+      cwd: directory,
+      transport: "structured",
+      accountId: "work",
+      conversationId: conversation.id,
+      clientAttemptId: "successor_scan_lag_20260717_a1",
+      requestDigest: "8".repeat(64),
+      launchProfile: emptyLaunchProfile({ cwd: directory }),
+    });
+    if (begun.kind !== "created") throw new Error("expected structured launch creation");
+    registry.settleSpawn(begun.receipt.launchId, {
+      key: { engine: "codex", sessionId: "019f678d-951e-77f1-bc6a-c3175a6a7bd7" },
+      artifactPath: successorPath,
+      cwd: directory,
+      accountId: "work",
+      launchProfile: emptyLaunchProfile({ cwd: directory }),
+      status: "unhosted",
+      host: null,
+      claimEpoch: 0,
+      claimOwner: null,
+      pendingAction: null,
+    });
+
+    const persisted = JSON.parse(fs.readFileSync(filename, "utf8")) as {
+      receipts: Record<string, { createdAt: string }>;
+      conversations: Record<string, {
+        generations: Array<{ path: string; createdAt: string }>;
+        turn: { observedAt: string | null };
+      }>;
+    };
+    persisted.receipts[begun.receipt.launchId]!.createdAt = "2026-07-17T08:00:00.000Z";
+    persisted.conversations[conversation.id]!.turn.observedAt = "2026-07-17T11:00:00.000Z";
+    persisted.conversations[conversation.id]!.generations
+      .find((generation) => generation.path === successorPath)!.createdAt = "2026-07-17T10:00:00.000Z";
+    fs.writeFileSync(filename, JSON.stringify(persisted));
+
+    const restarted = new AgentRegistry(filename, undefined, undefined, { sqliteMode: "off" });
+    expect(restarted.snapshot().receipts[begun.receipt.launchId]?.artifactLifecycle).toBe("pending");
+    expect(preallocatedStructuredSpawnCards([], restarted.snapshot())).toHaveLength(1);
+  } finally {
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});
+
 test("a deleted settled structured transcript stays absent after JSON restart", () => {
   const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-spawn-projection-delete-"));
   const filename = path.join(directory, "agent-registry.json");

--- a/src/lib/agent/spawnProjection.ts
+++ b/src/lib/agent/spawnProjection.ts
@@ -50,6 +50,7 @@ function newestUnscannedReceipts(files: readonly FileEntry[], snapshot: Registry
   const byConversation = new Map<string, SpawnReceipt>();
   for (const receipt of Object.values(snapshot.receipts)) {
     if (receipt.transport !== "structured" || receipt.purpose !== "launch") continue;
+    if (receipt.artifactLifecycle !== "pending") continue;
     if (scannedConversations.has(receipt.conversationId)) continue;
     if (receipt.artifactPath && scannedPaths.has(receipt.artifactPath)) continue;
     const current = byConversation.get(receipt.conversationId);

--- a/src/lib/runtime/client.ts
+++ b/src/lib/runtime/client.ts
@@ -4,6 +4,7 @@ import type { RuntimeEventInput, RuntimeOperationCommand, RuntimeOperationResult
 import { runtimeHostSocket } from "./flags";
 
 const MAX_RESPONSE_FRAME_BYTES = 8 * 1024 * 1024;
+export const RUNTIME_SNAPSHOT_REQUEST_TIMEOUT_MS = 10_000;
 export const VIEWER_DEPLOYMENT_REQUEST_TIMEOUT_MS = 120_000;
 
 export class RuntimeHostUnavailableError extends Error {
@@ -37,9 +38,10 @@ export class UnixRuntimeHostClient implements RuntimeHostClient {
     private readonly socketPath: string,
     private readonly timeoutMs = 3_000,
     private readonly deploymentTimeoutMs = VIEWER_DEPLOYMENT_REQUEST_TIMEOUT_MS,
+    private readonly snapshotTimeoutMs = RUNTIME_SNAPSHOT_REQUEST_TIMEOUT_MS,
   ) {}
 
-  snapshot(): Promise<RuntimeSnapshot> { return this.call("snapshot") as Promise<RuntimeSnapshot>; }
+  snapshot(): Promise<RuntimeSnapshot> { return this.call("snapshot", undefined, this.snapshotTimeoutMs) as Promise<RuntimeSnapshot>; }
   events(after: number): Promise<RuntimeReplay> { return this.call("events", { after }) as Promise<RuntimeReplay>; }
   waitEvents(after: number, timeoutMs = 15_000, signal?: AbortSignal): Promise<RuntimeReplay> { return this.call("wait", { after, timeoutMs }, timeoutMs + 1_000, signal) as Promise<RuntimeReplay>; }
   append(event: RuntimeEventInput): Promise<unknown> { return this.call("append", { event }); }

--- a/src/lib/tasks/commands.ts
+++ b/src/lib/tasks/commands.ts
@@ -328,7 +328,7 @@ export function mergeAssignments(assignments: TaskAssignment[], patches: Assignm
   let next = assignments.slice();
   for (const patch of patches) {
     const index = next.findIndex((assignment) => {
-      if (patch.launchId && assignment.launchId === patch.launchId) return true;
+      if (patch.launchId && assignment.launchId) return assignment.launchId === patch.launchId;
       if (patch.path !== null && assignment.path === patch.path) return true;
       return patch.path === null && patch.panePid !== null && assignment.path === null && assignment.panePid === patch.panePid;
       });

--- a/src/lib/tasks/commands.ts
+++ b/src/lib/tasks/commands.ts
@@ -366,15 +366,18 @@ export function applyAssignmentPatches(
   const index = existing.findIndex((task) => task.id === id);
   if (index < 0) return { ok: false, error: "task not found", status: 404 };
   const task = existing[index]!;
-  /* A handoff routes the task into an agent's composer without delivering, but
-     it still moves the card off «inbox» — the task now belongs to that agent. */
-  const hasSuccess = patches.some(
-    (patch) => patch.state === "delivered" || patch.state === "spawning" || patch.state === "handoff",
+  const assignments = mergeAssignments(task.assignments, patches);
+  const hasOwner = assignments.some(
+    (assignment) => assignment.state === "delivered" || assignment.state === "spawning" || assignment.state === "handoff",
   );
+  let status = task.status;
+  if (status === "inbox" || status === "assigned") {
+    status = hasOwner ? "assigned" : "inbox";
+  }
   const updated: BoardTask = {
     ...task,
-    status: task.status === "inbox" && hasSuccess ? "assigned" : task.status,
-    assignments: mergeAssignments(task.assignments, patches),
+    status,
+    assignments,
     updatedAt: now,
   };
   const tasks = existing.slice();

--- a/src/lib/tasks/tasks.test.ts
+++ b/src/lib/tasks/tasks.test.ts
@@ -320,6 +320,28 @@ describe("task delivery assembly", () => {
     expect(result.task.assignments).toEqual([{ path: "/one", panePid: null, state: "delivered", error: null, at: "new" }]);
   });
 
+  test("launch identity upgrades a legacy path assignment without duplicating it", () => {
+    const assignments = mergeAssignments([
+      { path: "/legacy", panePid: null, state: "spawning", error: null, at: "old" },
+    ], [{
+      launchId: "launch-attributed",
+      path: "/legacy",
+      panePid: 42,
+      state: "delivered",
+      error: null,
+      at: "new",
+    }]);
+
+    expect(assignments).toEqual([{
+      launchId: "launch-attributed",
+      path: "/legacy",
+      panePid: 42,
+      state: "delivered",
+      error: null,
+      at: "new",
+    }]);
+  });
+
   test("failed launch preserves ownership held by another active assignment", () => {
     for (const state of ["spawning", "delivered", "handoff"] as const) {
       const existing = task({

--- a/src/lib/tasks/tasks.test.ts
+++ b/src/lib/tasks/tasks.test.ts
@@ -320,6 +320,35 @@ describe("task delivery assembly", () => {
     expect(result.task.assignments).toEqual([{ path: "/one", panePid: null, state: "delivered", error: null, at: "new" }]);
   });
 
+  test("failed launch preserves ownership held by another active assignment", () => {
+    for (const state of ["spawning", "delivered", "handoff"] as const) {
+      const existing = task({
+        status: "assigned",
+        assignments: [
+          { launchId: `owner-${state}`, path: `/${state}`, panePid: null, state, error: null, at: "old" },
+          { launchId: "failed-launch", path: null, panePid: null, state: "spawning", error: null, at: "admitted" },
+        ],
+      });
+      const result = applyAssignmentPatches([existing], existing.id, [{
+        launchId: "failed-launch",
+        path: null,
+        panePid: null,
+        state: "failed",
+        error: "process exited before pane creation",
+        at: "failed",
+      }], "failed");
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) throw new Error(result.error);
+      expect(result.task.status).toBe("assigned");
+      expect(result.task.assignments).toContainEqual(expect.objectContaining({
+        launchId: "failed-launch",
+        state: "failed",
+        error: "process exited before pane creation",
+      }));
+    }
+  });
+
   test("task launch replay updates one assignment by durable launch identity", () => {
     const launchId = "9173e9a2-2f14-4a70-818a-bd4052a1ad4a";
     const conversationId = "conversation_ac6029b9";

--- a/src/runtime-host/journal.test.ts
+++ b/src/runtime-host/journal.test.ts
@@ -1564,6 +1564,38 @@ test("concurrent socket replays keep maximum-size command output byte-bounded an
   journal.close();
 });
 
+test("a production-sized snapshot has a bounded read budget independent from controls", async () => {
+  const dir = sandbox("socket-large-snapshot-budget");
+  const socketPath = path.join(dir, "runtime.sock");
+  const server = net.createServer((socket) => {
+    let frame = "";
+    socket.on("data", (chunk) => {
+      frame += String(chunk);
+      const newline = frame.indexOf("\n");
+      if (newline < 0) return;
+      const request = JSON.parse(frame.slice(0, newline)) as { id: string; method: string };
+      setTimeout(() => {
+        const result = request.method === "snapshot"
+          ? { snapshotSeq: 1, transportPadding: "x".repeat(950 * 1024) }
+          : { reset: false, floorSeq: 0, events: [] };
+        socket.end(`${JSON.stringify({ id: request.id, ok: true, result })}\n`);
+      }, 60);
+    });
+  });
+  server.listen(socketPath);
+  await new Promise<void>((resolve) => server.once("listening", resolve));
+  const client = new UnixRuntimeHostClient(socketPath, 20, 100, 250);
+
+  try {
+    const snapshot = await client.snapshot() as unknown as { transportPadding: string };
+    expect(Buffer.byteLength(snapshot.transportPadding)).toBe(950 * 1024);
+    await expect(client.events(0)).rejects.toThrow("runtime host request timed out");
+  } finally {
+    await new Promise<void>((resolve, reject) => server.close((error) => error ? reject(error) : resolve()));
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 test("structured queue controls cross the local runtime socket", async () => {
   const dir = sandbox("structured-socket");
   const socketPath = path.join(dir, "runtime.sock");


### PR DESCRIPTION
# Summary

- recover orphaned immediate structured admissions through a durable PID and process-start identity fence
- make concurrent replacement processes converge on one worker and one first prompt
- preserve idempotent spawn replay across automatic account-health rotation
- recompute task ownership after terminal pre-pane failures while retaining failed audit assignments
- persist structured artifact materialization so deleted settled transcripts stay absent across polls and restarts
- keep scan-lag and genuinely pending structured launches visible through immediate-202 and restart recovery
- allocate one client attempt identity per task launch gesture and rotate legacy fallback identities after retry-safe terminal failure
- preserve exactly-once actuation for concurrent and lost-response replays within each gesture

# Release context

This PR targets `release/spawn-rescue-20260717` and contains the repair delta found by independent exact-SHA reviews of the cumulative PR #332 and PR #333 production candidate.

The transcript lifecycle is durable in JSON and SQLite modes. Inventory observations are keyed by engine and artifact path. Task gesture IDs remain stable for ambiguous-response replay, while deliberate retries after pre-pane terminal failure receive fresh launch identities.

# TDD evidence

- settled transcript deletion probe reproduced a permanent `spawn:<launchId>` recovered card before the lifecycle repair
- scan-lag restart probe reproduced a visibility gap before inventory became the sole materialization authority
- cross-engine probe reproduced an incorrect shared-path materialization before engine-scoped indexing
- deliberate task retry probe reproduced HTTP 500 then HTTP 200 with one launch before fallback rotation
- legacy path-assignment probe reproduced duplicate audit rows before launch-aware compatibility matching
- concurrent and post-terminal replay probes preserve one actuation per explicit gesture

# Verification

- 418 cumulative changed-surface tests passed, covering the reviewer’s prior 399-test surface
- 180 repeated critical executions passed across nine race and lifecycle cases
- JSON restart deletion and pending visibility passed
- SQLite restart compatibility passed
- cross-process orphan rescue passed
- account A to B replay passed
- ownerless inbox recovery and mixed-owner preservation passed
- TypeScript passed
- changed-file ESLint passed
- production build passed
- `git diff --check` passed
- clean full-diff self-review passed
- local and remote head: `a54466387bdafc8f92b5fdb740ce6b60b656fe54`

# Tracking

- primary incident: #282
- pathless failure presentation and retry controls: #334
