### PR TITLE
Fix Claude refresh-lock replacement ownership

### DIFF
--- a/src/lib/accounts/claudeOauth.test.ts
+++ b/src/lib/accounts/claudeOauth.test.ts
@@ -92,6 +92,7 @@ test("only positive invalid_grant evidence is fenced while other failures remain
   const unclassified401 = account("unclassified-401");
   const invalidGrant = account("invalid-grant");
   const invalidGrant401 = account("invalid-grant-401");
+  const unauthorizedClient = account("unauthorized-client");
   const invalidScope = account("invalid-scope");
   const transient = account("transient");
 
@@ -111,6 +112,10 @@ test("only positive invalid_grant evidence is fenced while other failures remain
     now: () => NOW,
     fetch: async () => Response.json({ error: "invalid_grant" }, { status: 401 }),
   })).resolves.toBe("invalid");
+  await expect(refreshClaudeOauth(unauthorizedClient, {
+    now: () => NOW,
+    fetch: async () => Response.json({ error: "unauthorized_client" }, { status: 401 }),
+  })).resolves.toBe("unknown");
   await expect(refreshClaudeOauth(invalidScope, {
     now: () => NOW,
     fetch: async () => Response.json({ error: "invalid_scope" }, { status: 400 }),
@@ -193,11 +198,13 @@ test("a native refresh lock bounds Viewer admission without starting duplicate r
 
   expect(result).toBe("unknown");
   expect(fetchCalls).toBe(0);
+  expect(fs.existsSync(path.join(candidate.home, ".oauth_refresh.lock"))).toBeTrue();
 });
 
 test("a legacy native refresh lock bounds Viewer admission without starting duplicate refresh work", async () => {
   const candidate = account("legacy-native-lock");
-  fs.mkdirSync(`${fs.realpathSync(candidate.home)}.lock`, { mode: 0o700 });
+  const legacyLock = `${fs.realpathSync(candidate.home)}.lock`;
+  fs.mkdirSync(legacyLock, { mode: 0o700 });
   let fetchCalls = 0;
 
   const result = await refreshClaudeOauth(candidate, {
@@ -211,7 +218,29 @@ test("a legacy native refresh lock bounds Viewer admission without starting dupl
 
   expect(result).toBe("unknown");
   expect(fetchCalls).toBe(0);
+  expect(fs.existsSync(legacyLock)).toBeTrue();
   expect(fs.existsSync(path.join(candidate.home, ".oauth_refresh.lock"))).toBeFalse();
+});
+
+test("Viewer release preserves native lock directories replaced by another owner", async () => {
+  const candidate = account("replaced-native-locks");
+  const currentLock = path.join(candidate.home, ".oauth_refresh.lock");
+  const legacyLock = `${fs.realpathSync(candidate.home)}.lock`;
+
+  const result = await refreshClaudeOauth(candidate, {
+    now: () => NOW,
+    fetch: async () => {
+      fs.rmdirSync(legacyLock);
+      fs.rmdirSync(currentLock);
+      fs.mkdirSync(currentLock, { mode: 0o700 });
+      fs.mkdirSync(legacyLock, { mode: 0o700 });
+      return new Response(null, { status: 503 });
+    },
+  });
+
+  expect(result).toBe("unknown");
+  expect(fs.existsSync(currentLock)).toBeTrue();
+  expect(fs.existsSync(legacyLock)).toBeTrue();
 });
 
 test("Viewer reuses a native rotation completed while waiting for the refresh lock", async () => {

--- a/src/lib/accounts/claudeOauth.ts
+++ b/src/lib/accounts/claudeOauth.ts
@@ -100,8 +100,14 @@ async function acquireDirectoryLock(lock: string, startedAt: number, waitMs: num
   for (;;) {
     try {
       fs.mkdirSync(lock, { mode: 0o700 });
+      const descriptor = fs.openSync(lock, "r");
+      const owned = fs.fstatSync(descriptor);
       return () => {
-        try { fs.rmdirSync(lock); } catch { /* Claude may have cleared a stale lock after the bounded refresh window. */ }
+        try {
+          const current = fs.statSync(lock);
+          if (current.dev === owned.dev && current.ino === owned.ino) fs.rmdirSync(lock);
+        } catch { /* Claude may have cleared or replaced the lock after the bounded refresh window. */ }
+        finally { fs.closeSync(descriptor); }
       };
     } catch (error) {
       if ((error as NodeJS.ErrnoException).code !== "EEXIST") return null;


### PR DESCRIPTION
## Summary

- preserves native Claude refresh-lock directories when another owner replaces the lock during Viewer cleanup
- carries the required unique commit from PR #333 onto current main after the production-train merge
- keeps the older PR branch and history available

## Verification

- `bun test src/lib/accounts/claudeOauth.test.ts src/lib/accounts/spawnHealth.test.ts src/app/api/spawn/route.test.ts`: 55 passed, 0 failed
- `bun x tsc --noEmit`
- focused ESLint
- `git diff --check origin/main...HEAD`

Closes #331 after production verification.