### PR TITLE
fix(runtime): integrate structured synchronization ownership

### DIFF
--- a/docs/pr-330-runtime-sync-integration.md
+++ b/docs/pr-330-runtime-sync-integration.md
@@ -1,0 +1,43 @@
+# PR #330 runtime synchronization integration
+
+This integration pins `origin/main` at
+`e575dc06aa77fd6d913b90d98268fc77eb64173a` and PR #330 at
+`ceb495d2d58fe08a703b9e50a9ea2adbaf30dd1c`.
+
+## Range-diff evidence
+
+The audit used:
+
+```sh
+git range-diff --no-dual-color --creation-factor=80 \
+  710c4590b677fe5852ed33e9ab1b78d3eb449fec..ceb495d2d58fe08a703b9e50a9ea2adbaf30dd1c \
+  710c4590b677fe5852ed33e9ab1b78d3eb449fec..e575dc06aa77fd6d913b90d98268fc77eb64173a
+```
+
+The range-diff identified three exact matches already present in the pinned
+main ancestry. They were omitted from new integration work:
+
+- `4469df33d6c9d2e725f76c605d7ce67d8c70d0ef` — structured sends remain held
+  during synchronization.
+- `94386859479b3652880f07fc30c0536c3c3d5b4c` — canonical held commands and
+  request digests remain durable.
+- `de08bd24cddd271d95a088ba5bab23aa36f64754` — startup recovery and controller
+  drain behavior remain present.
+
+The merge base between the pinned main and PR head is the third commit above,
+`de08bd24cddd271d95a088ba5bab23aa36f64754`. The remaining nine PR commits were
+unmatched and retained because they carry live ownership, recovery, compaction,
+and migration semantics.
+
+## Conflict decisions
+
+- Current image content-digest conflict handling and corrupt-image reservation
+  recovery remain active beside explicit operation ownership.
+- Current terminal journal reconciliation fixtures remain alongside durable
+  registry ownership, compacted replay, and provisional-adoption fixtures.
+- Current structured write envelopes remain asserted through partial matches in
+  the older PR fixtures.
+
+The retained range covers partial startup adoption, explicit and durable
+operation ownership, re-entrant journal migration, compacted terminal replay,
+provisional owner adoption, bounded terminal owners, and active owner retention.

--- a/src/lib/accounts/migration/contracts.ts
+++ b/src/lib/accounts/migration/contracts.ts
@@ -214,6 +214,7 @@ export interface HeldDeliveryCommandInput {
 export interface HeldDelivery {
   id: string;
   conversationId: ViewerConversationId;
+  runtimeConversationId: ViewerConversationId;
   text: string;
   createdAt: string;
   clientMessageId: string | null;

--- a/src/lib/accounts/migration/contracts.ts
+++ b/src/lib/accounts/migration/contracts.ts
@@ -213,6 +213,7 @@ export interface HeldDeliveryCommandInput {
 export interface HeldDelivery {
   id: string;
   conversationId: ViewerConversationId;
+  runtimeConversationId: ViewerConversationId;
   text: string;
   createdAt: string;
   clientMessageId: string | null;

--- a/src/lib/accounts/migration/controller.test.ts
+++ b/src/lib/accounts/migration/controller.test.ts
@@ -79,6 +79,7 @@ test("controller preserves durable image refs while draining a migration-held st
   expect(outcome).toBe("delivered");
   expect(structured).toEqual([{
     conversationId: conversation.id,
+    runtimeConversationId: conversation.id,
     path: "/structured-successor.jsonl",
     deliveryId: claimed.id,
     clientMessageId: "migration-message",
@@ -101,6 +102,7 @@ test("controller keeps an uncertain structured claim fenced when ownership canno
   const delivery = {
     id: "held-one",
     conversationId: "conversation_11111111-1111-4111-8111-111111111111" as const,
+    runtimeConversationId: "conversation_11111111-1111-4111-8111-111111111111" as const,
     text: "continue",
     createdAt: "2026-07-13T00:00:00.000Z",
     clientMessageId: "migration-message",

--- a/src/lib/accounts/migration/controller.test.ts
+++ b/src/lib/accounts/migration/controller.test.ts
@@ -75,6 +75,7 @@ test("controller drains a migration-held structured message through the runtime 
   expect(outcome).toBe("delivered");
   expect(structured).toEqual([{
     conversationId: conversation.id,
+    runtimeConversationId: conversation.id,
     path: "/structured-successor.jsonl",
     deliveryId: claimed.id,
     clientMessageId: "migration-message",
@@ -96,6 +97,7 @@ test("controller keeps an uncertain structured claim fenced when ownership canno
   const delivery = {
     id: "held-one",
     conversationId: "conversation_11111111-1111-4111-8111-111111111111" as const,
+    runtimeConversationId: "conversation_11111111-1111-4111-8111-111111111111" as const,
     text: "continue",
     createdAt: "2026-07-13T00:00:00.000Z",
     clientMessageId: "migration-message",

--- a/src/lib/accounts/migration/deliveryPort.ts
+++ b/src/lib/accounts/migration/deliveryPort.ts
@@ -31,6 +31,7 @@ export function createMigrationDeliveryPort(
   });
   const deliverStructured = ({ delivery, path, clientMessageId }: HeldDeliveryInput) => structuredDelivery({
     conversationId: delivery.conversationId,
+    runtimeConversationId: delivery.runtimeConversationId,
     path,
     deliveryId: delivery.id,
     clientMessageId,

--- a/src/lib/accounts/migration/deliveryPort.ts
+++ b/src/lib/accounts/migration/deliveryPort.ts
@@ -30,6 +30,7 @@ export function createMigrationDeliveryPort(
   });
   const deliverStructured = ({ delivery, path, clientMessageId }: HeldDeliveryInput) => structuredDelivery({
     conversationId: delivery.conversationId,
+    runtimeConversationId: delivery.runtimeConversationId,
     path,
     deliveryId: delivery.id,
     clientMessageId,

--- a/src/lib/agent/registry.sqlite.test.ts
+++ b/src/lib/agent/registry.sqlite.test.ts
@@ -148,6 +148,182 @@ test("SQLite restart normalizes legacy held-delivery rows before parity", () => 
   });
 });
 
+test("SQLite restart derives and persists explicit operation ownership before tombstone compaction", () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-registry-sqlite-operation-owner-"));
+  const filename = path.join(directory, "agent-registry.json");
+  const sqliteFilename = path.join(directory, "agent-registry.sqlite");
+  const sqlite = new AgentRegistry(filename, undefined, undefined, { sqliteMode: "sqlite" });
+  const conversation = sqlite.ensureConversation("codex", "/sessions/sqlite-operation-owner.jsonl", "default");
+  const command = { operationId: "sqlite-operation-owner", kind: "send" as const, policy: "queue" as const };
+  const original = sqlite.holdDelivery(
+    conversation.id,
+    "retain SQLite operation ownership",
+    "sqlite-operation-owner-client",
+    "text",
+    [],
+    null,
+    command,
+  );
+  const claimed = sqlite.beginDeliveryAttempt(original.id, original.generationId!);
+  expect(claimed).not.toBeNull();
+  sqlite.recordDeliveryOutcome(original.id, "delivered");
+
+  const legacyDb = new Database(sqliteFilename);
+  legacyDb.query("DELETE FROM registry_rows WHERE collection = ?").run("deliveryOperationOwners");
+  legacyDb.close();
+
+  const restarted = new AgentRegistry(filename, undefined, undefined, { sqliteMode: "sqlite" });
+  expect(restarted.snapshot().deliveryOperationOwners[command.operationId]).toMatchObject({
+    clientMessageId: "sqlite-operation-owner-client",
+    deliveryId: original.id,
+    command,
+  });
+  for (let index = 0; index < 101; index += 1) {
+    const delivery = restarted.holdDelivery(
+      conversation.id,
+      `later SQLite delivery ${index}`,
+      `later-sqlite-delivery-${index}`,
+    );
+    restarted.recordDeliveryOutcome(delivery.id, "delivered");
+  }
+  expect(restarted.snapshot().heldDeliveries[original.id]).toBeUndefined();
+
+  const persistedDb = new Database(sqliteFilename, { readonly: true });
+  expect(persistedDb.query<{ count: number }, [string, string]>(
+    "SELECT COUNT(*) AS count FROM registry_rows WHERE collection = ? AND row_key = ?",
+  ).get("deliveryOperationOwners", command.operationId)?.count).toBe(1);
+  persistedDb.close();
+  const reopened = new AgentRegistry(filename, undefined, undefined, { sqliteMode: "sqlite" });
+  expect(reopened.snapshot().deliveryOperationOwners[command.operationId]).toMatchObject({
+    terminalState: "delivered",
+    requestDigest: original.requestDigest,
+  });
+  expect(reopened.snapshot().deliveryOperationOwners[command.operationId]).not.toHaveProperty("settledDelivery");
+  expect(() => reopened.holdDelivery(
+    conversation.id,
+    "retain SQLite operation ownership",
+    "second-sqlite-operation-owner-client",
+    "text",
+    [],
+    null,
+    command,
+  )).toThrow("operation id is already reserved for another client message");
+  expect(reopened.holdDelivery(
+    conversation.id,
+    "retain SQLite operation ownership",
+    "sqlite-operation-owner-client",
+    "text",
+    [],
+    null,
+    command,
+  )).toMatchObject({ id: original.id, state: "delivered", command });
+});
+
+test("terminal operation ownership stays bounded and payload-free in JSON and SQLite", () => {
+  for (const backend of ["json", "sqlite"] as const) {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), `llv-registry-bounded-owners-${backend}-`));
+    const filename = path.join(directory, "agent-registry.json");
+    const sqliteFilename = path.join(directory, "agent-registry.sqlite");
+    const storage = { sqliteMode: backend === "sqlite" ? "sqlite" as const : "off" as const };
+    let store = new AgentRegistry(filename, undefined, undefined, storage);
+    const conversation = store.ensureConversation("codex", `/sessions/bounded-owners-${backend}.jsonl`, "default");
+    const writeFailures = (start: number, end: number) => {
+      for (let index = start; index < end; index += 1) {
+        const suffix = String(index).padStart(3, "0");
+        const delivery = store.holdDelivery(
+          conversation.id,
+          `sensitive failed payload ${backend} ${suffix}`,
+          `bounded-owner-client-${backend}-${suffix}`,
+          "text",
+          [],
+          null,
+          {
+            operationId: `bounded-owner-operation-${backend}-${suffix}`,
+            kind: "send",
+            policy: "queue",
+          },
+        );
+        if (!store.beginDeliveryAttempt(delivery.id, delivery.generationId!)) {
+          throw new Error("expected explicit operation delivery attempt");
+        }
+        store.recordDeliveryOutcome(delivery.id, "failed", "host unavailable");
+      }
+    };
+    const sqliteOwnerStats = () => {
+      const db = new Database(sqliteFilename, { readonly: true });
+      const stats = db.query<{ count: number; bytes: number }, [string]>(
+        "SELECT COUNT(*) AS count, COALESCE(SUM(LENGTH(value_json)), 0) AS bytes FROM registry_rows WHERE collection = ?",
+      ).get("deliveryOperationOwners")!;
+      const payload = db.query<{ value_json: string }, [string]>(
+        "SELECT value_json FROM registry_rows WHERE collection = ? ORDER BY row_order",
+      ).all("deliveryOperationOwners").map((row) => row.value_json).join("\n");
+      db.close();
+      return { ...stats, payload };
+    };
+
+    writeFailures(0, 220);
+    const firstJsonBytes = fs.statSync(filename).size;
+    const firstSqliteStats = backend === "sqlite" ? sqliteOwnerStats() : null;
+    writeFailures(220, 440);
+    store.compactDeliveryReservations();
+
+    const snapshot = store.snapshot();
+    expect(Object.keys(snapshot.deliveryOperationOwners)).toHaveLength(200);
+    expect(Object.values(snapshot.deliveryOperationOwners).every((owner) =>
+      owner.terminalState === "failed" && !("settledDelivery" in owner))).toBeTrue();
+    const retainedIndex = "250";
+    const retainedOperationId = `bounded-owner-operation-${backend}-${retainedIndex}`;
+    const retainedText = `sensitive failed payload ${backend} ${retainedIndex}`;
+    const retainedClientId = `bounded-owner-client-${backend}-${retainedIndex}`;
+    expect(snapshot.deliveryOperationOwners[retainedOperationId]).toMatchObject({
+      terminalState: "failed",
+      requestDigest: expect.any(String),
+    });
+    expect(Object.values(snapshot.heldDeliveries)
+      .some((delivery) => delivery.command.operationId === retainedOperationId)).toBeFalse();
+    expect(fs.readFileSync(filename, "utf8")).not.toContain(retainedText);
+    expect(fs.statSync(filename).size).toBeLessThanOrEqual(firstJsonBytes + 16_384);
+    if (backend === "sqlite") {
+      const secondSqliteStats = sqliteOwnerStats();
+      expect(secondSqliteStats.count).toBe(200);
+      expect(secondSqliteStats.bytes).toBeLessThanOrEqual(firstSqliteStats!.bytes + 4_096);
+      expect(secondSqliteStats.payload).not.toContain(retainedText);
+    }
+
+    store = new AgentRegistry(filename, undefined, undefined, storage);
+    expect(store.holdDelivery(
+      conversation.id,
+      retainedText,
+      retainedClientId,
+      "text",
+      [],
+      null,
+      { operationId: retainedOperationId, kind: "send", policy: "queue" },
+    )).toMatchObject({ state: "failed", text: retainedText });
+    expect(Object.values(store.snapshot().heldDeliveries)
+      .some((delivery) => delivery.command.operationId === retainedOperationId)).toBeFalse();
+    expect(() => store.holdDelivery(
+      conversation.id,
+      `${retainedText} changed`,
+      retainedClientId,
+      "text",
+      [],
+      null,
+      { operationId: retainedOperationId, kind: "send", policy: "queue" },
+    )).toThrow("operation id is already reserved for another client message");
+    const unrelated = store.ensureConversation("codex", `/sessions/unrelated-${backend}.jsonl`, "default");
+    expect(() => store.holdDelivery(
+      unrelated.id,
+      retainedText,
+      retainedClientId,
+      "text",
+      [],
+      null,
+      { operationId: retainedOperationId, kind: "send", policy: "queue" },
+    )).toThrow("operation id is already reserved for another client message");
+  }
+}, 15_000);
+
 test("dual-write leaves both backends unchanged after a no-op mutation", () => {
   const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-registry-sqlite-noop-"));
   const filename = path.join(directory, "agent-registry.json");

--- a/src/lib/agent/registry.sqlite.test.ts
+++ b/src/lib/agent/registry.sqlite.test.ts
@@ -192,6 +192,11 @@ test("SQLite restart derives and persists explicit operation ownership before to
   ).get("deliveryOperationOwners", command.operationId)?.count).toBe(1);
   persistedDb.close();
   const reopened = new AgentRegistry(filename, undefined, undefined, { sqliteMode: "sqlite" });
+  expect(reopened.snapshot().deliveryOperationOwners[command.operationId]).toMatchObject({
+    terminalState: "delivered",
+    requestDigest: original.requestDigest,
+  });
+  expect(reopened.snapshot().deliveryOperationOwners[command.operationId]).not.toHaveProperty("settledDelivery");
   expect(() => reopened.holdDelivery(
     conversation.id,
     "retain SQLite operation ownership",
@@ -205,7 +210,104 @@ test("SQLite restart derives and persists explicit operation ownership before to
     "sqlite-operation-owner-client",
     "text",
     command,
-  )).toMatchObject({ id: original.id, state: "delivered", attempts: claimed!.attempts, command });
+  )).toMatchObject({ id: original.id, state: "delivered", command });
+});
+
+test("terminal operation ownership stays bounded and payload-free in JSON and SQLite", () => {
+  for (const backend of ["json", "sqlite"] as const) {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), `llv-registry-bounded-owners-${backend}-`));
+    const filename = path.join(directory, "agent-registry.json");
+    const sqliteFilename = path.join(directory, "agent-registry.sqlite");
+    const storage = { sqliteMode: backend === "sqlite" ? "sqlite" as const : "off" as const };
+    let store = new AgentRegistry(filename, undefined, undefined, storage);
+    const conversation = store.ensureConversation("codex", `/sessions/bounded-owners-${backend}.jsonl`, "default");
+    const writeFailures = (start: number, end: number) => {
+      for (let index = start; index < end; index += 1) {
+        const suffix = String(index).padStart(3, "0");
+        const delivery = store.holdDelivery(
+          conversation.id,
+          `sensitive failed payload ${backend} ${suffix}`,
+          `bounded-owner-client-${backend}-${suffix}`,
+          "text",
+          {
+            operationId: `bounded-owner-operation-${backend}-${suffix}`,
+            kind: "send",
+            policy: "queue",
+          },
+        );
+        if (!store.beginDeliveryAttempt(delivery.id, delivery.generationId!)) {
+          throw new Error("expected explicit operation delivery attempt");
+        }
+        store.recordDeliveryOutcome(delivery.id, "failed", "host unavailable");
+      }
+    };
+    const sqliteOwnerStats = () => {
+      const db = new Database(sqliteFilename, { readonly: true });
+      const stats = db.query<{ count: number; bytes: number }, [string]>(
+        "SELECT COUNT(*) AS count, COALESCE(SUM(LENGTH(value_json)), 0) AS bytes FROM registry_rows WHERE collection = ?",
+      ).get("deliveryOperationOwners")!;
+      const payload = db.query<{ value_json: string }, [string]>(
+        "SELECT value_json FROM registry_rows WHERE collection = ? ORDER BY row_order",
+      ).all("deliveryOperationOwners").map((row) => row.value_json).join("\n");
+      db.close();
+      return { ...stats, payload };
+    };
+
+    writeFailures(0, 220);
+    const firstJsonBytes = fs.statSync(filename).size;
+    const firstSqliteStats = backend === "sqlite" ? sqliteOwnerStats() : null;
+    writeFailures(220, 440);
+    store.compactDeliveryReservations();
+
+    const snapshot = store.snapshot();
+    expect(Object.keys(snapshot.deliveryOperationOwners)).toHaveLength(200);
+    expect(Object.values(snapshot.deliveryOperationOwners).every((owner) =>
+      owner.terminalState === "failed" && !("settledDelivery" in owner))).toBeTrue();
+    const retainedIndex = "250";
+    const retainedOperationId = `bounded-owner-operation-${backend}-${retainedIndex}`;
+    const retainedText = `sensitive failed payload ${backend} ${retainedIndex}`;
+    const retainedClientId = `bounded-owner-client-${backend}-${retainedIndex}`;
+    expect(snapshot.deliveryOperationOwners[retainedOperationId]).toMatchObject({
+      terminalState: "failed",
+      requestDigest: expect.any(String),
+    });
+    expect(Object.values(snapshot.heldDeliveries)
+      .some((delivery) => delivery.command.operationId === retainedOperationId)).toBeFalse();
+    expect(fs.readFileSync(filename, "utf8")).not.toContain(retainedText);
+    expect(fs.statSync(filename).size).toBeLessThanOrEqual(firstJsonBytes + 16_384);
+    if (backend === "sqlite") {
+      const secondSqliteStats = sqliteOwnerStats();
+      expect(secondSqliteStats.count).toBe(200);
+      expect(secondSqliteStats.bytes).toBeLessThanOrEqual(firstSqliteStats!.bytes + 4_096);
+      expect(secondSqliteStats.payload).not.toContain(retainedText);
+    }
+
+    store = new AgentRegistry(filename, undefined, undefined, storage);
+    expect(store.holdDelivery(
+      conversation.id,
+      retainedText,
+      retainedClientId,
+      "text",
+      { operationId: retainedOperationId, kind: "send", policy: "queue" },
+    )).toMatchObject({ state: "failed", text: retainedText });
+    expect(Object.values(store.snapshot().heldDeliveries)
+      .some((delivery) => delivery.command.operationId === retainedOperationId)).toBeFalse();
+    expect(() => store.holdDelivery(
+      conversation.id,
+      `${retainedText} changed`,
+      retainedClientId,
+      "text",
+      { operationId: retainedOperationId, kind: "send", policy: "queue" },
+    )).toThrow("operation id is already reserved for another client message");
+    const unrelated = store.ensureConversation("codex", `/sessions/unrelated-${backend}.jsonl`, "default");
+    expect(() => store.holdDelivery(
+      unrelated.id,
+      retainedText,
+      retainedClientId,
+      "text",
+      { operationId: retainedOperationId, kind: "send", policy: "queue" },
+    )).toThrow("operation id is already reserved for another client message");
+  }
 });
 
 test("dual-write leaves both backends unchanged after a no-op mutation", () => {

--- a/src/lib/agent/registry.sqlite.test.ts
+++ b/src/lib/agent/registry.sqlite.test.ts
@@ -148,6 +148,66 @@ test("SQLite restart normalizes legacy held-delivery rows before parity", () => 
   });
 });
 
+test("SQLite restart derives and persists explicit operation ownership before tombstone compaction", () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-registry-sqlite-operation-owner-"));
+  const filename = path.join(directory, "agent-registry.json");
+  const sqliteFilename = path.join(directory, "agent-registry.sqlite");
+  const sqlite = new AgentRegistry(filename, undefined, undefined, { sqliteMode: "sqlite" });
+  const conversation = sqlite.ensureConversation("codex", "/sessions/sqlite-operation-owner.jsonl", "default");
+  const command = { operationId: "sqlite-operation-owner", kind: "send" as const, policy: "queue" as const };
+  const original = sqlite.holdDelivery(
+    conversation.id,
+    "retain SQLite operation ownership",
+    "sqlite-operation-owner-client",
+    "text",
+    command,
+  );
+  const claimed = sqlite.beginDeliveryAttempt(original.id, original.generationId!);
+  expect(claimed).not.toBeNull();
+  sqlite.recordDeliveryOutcome(original.id, "delivered");
+
+  const legacyDb = new Database(sqliteFilename);
+  legacyDb.query("DELETE FROM registry_rows WHERE collection = ?").run("deliveryOperationOwners");
+  legacyDb.close();
+
+  const restarted = new AgentRegistry(filename, undefined, undefined, { sqliteMode: "sqlite" });
+  expect(restarted.snapshot().deliveryOperationOwners[command.operationId]).toMatchObject({
+    clientMessageId: "sqlite-operation-owner-client",
+    deliveryId: original.id,
+    command,
+  });
+  for (let index = 0; index < 101; index += 1) {
+    const delivery = restarted.holdDelivery(
+      conversation.id,
+      `later SQLite delivery ${index}`,
+      `later-sqlite-delivery-${index}`,
+    );
+    restarted.recordDeliveryOutcome(delivery.id, "delivered");
+  }
+  expect(restarted.snapshot().heldDeliveries[original.id]).toBeUndefined();
+
+  const persistedDb = new Database(sqliteFilename, { readonly: true });
+  expect(persistedDb.query<{ count: number }, [string, string]>(
+    "SELECT COUNT(*) AS count FROM registry_rows WHERE collection = ? AND row_key = ?",
+  ).get("deliveryOperationOwners", command.operationId)?.count).toBe(1);
+  persistedDb.close();
+  const reopened = new AgentRegistry(filename, undefined, undefined, { sqliteMode: "sqlite" });
+  expect(() => reopened.holdDelivery(
+    conversation.id,
+    "retain SQLite operation ownership",
+    "second-sqlite-operation-owner-client",
+    "text",
+    command,
+  )).toThrow("operation id is already reserved for another client message");
+  expect(reopened.holdDelivery(
+    conversation.id,
+    "retain SQLite operation ownership",
+    "sqlite-operation-owner-client",
+    "text",
+    command,
+  )).toMatchObject({ id: original.id, state: "delivered", attempts: claimed!.attempts, command });
+});
+
 test("dual-write leaves both backends unchanged after a no-op mutation", () => {
   const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-registry-sqlite-noop-"));
   const filename = path.join(directory, "agent-registry.json");

--- a/src/lib/agent/registry.test.ts
+++ b/src/lib/agent/registry.test.ts
@@ -121,6 +121,196 @@ describe("agent registry", () => {
     expect(retained.map((delivery) => delivery.id)).toContain("legacy-104");
   });
 
+  test("compaction retains explicit operation ownership after its delivery tombstone expires", () => {
+    const store = registry();
+    const conversation = store.ensureConversation("codex", "/operation-owner-compaction.jsonl", "default");
+    const refs = [{ sha256: "a".repeat(64), mime: "image/png" as const, bytes: 67 }];
+    const content = structuredContent("retain operation ownership", refs);
+    const command = {
+      operationId: "operation-owner-before-compaction",
+      kind: "steer" as const,
+      policy: "steer-if-active" as const,
+      turnId: "turn-before-compaction",
+    };
+    const original = store.holdDelivery(
+      conversation.id,
+      content.content.text,
+      "operation-owner-client",
+      "runtime-images",
+      refs,
+      content.contentDigest,
+      command,
+    );
+    const claimed = store.beginDeliveryAttempt(original.id, original.generationId!);
+    expect(claimed).not.toBeNull();
+    store.recordDeliveryOutcome(original.id, "delivered");
+    for (let index = 0; index < 101; index += 1) {
+      const delivery = store.holdDelivery(
+        conversation.id,
+        `later delivery ${index}`,
+        `later-delivery-${index}`,
+      );
+      store.recordDeliveryOutcome(delivery.id, "delivered");
+    }
+    expect(store.snapshot().heldDeliveries[original.id]).toBeUndefined();
+    expect(store.snapshot().deliveryOperationOwners[command.operationId]).toMatchObject({
+      terminalState: "delivered",
+      requestDigest: original.requestDigest,
+      contentDigest: content.contentDigest,
+    });
+    expect(store.snapshot().deliveryOperationOwners[command.operationId]).not.toHaveProperty("settledDelivery");
+
+    const reopened = new AgentRegistry(store.filename);
+    expect(() => reopened.holdDelivery(
+      conversation.id,
+      content.content.text,
+      "second-operation-owner-client",
+      "runtime-images",
+      refs,
+      content.contentDigest,
+      command,
+    )).toThrow("operation id is already reserved for another client message");
+    expect(reopened.holdDelivery(
+      conversation.id,
+      content.content.text,
+      "operation-owner-client",
+      "runtime-images",
+      refs,
+      content.contentDigest,
+      command,
+    )).toMatchObject({
+      id: original.id,
+      command,
+      requestDigest: original.requestDigest,
+      state: "delivered",
+    });
+    const changed = structuredContent(content.content.text, [{ sha256: "b".repeat(64), mime: "image/png" as const, bytes: 91 }]);
+    expect(() => reopened.holdDelivery(
+      conversation.id,
+      changed.content.text,
+      "operation-owner-client",
+      "runtime-images",
+      changed.content.images,
+      changed.contentDigest,
+      command,
+    )).toThrow(DeliveryReservationConflictError);
+  });
+
+  test("legacy terminal owner normalization rejects a mismatched settled snapshot", () => {
+    const store = registry();
+    const conversation = store.ensureConversation("codex", "/operation-owner-legacy-mismatch.jsonl", "default");
+    const command = { operationId: "operation-owner-legacy-mismatch", kind: "send" as const, policy: "queue" as const };
+    const original = store.holdDelivery(
+      conversation.id,
+      "keep this operation active",
+      "operation-owner-legacy-mismatch-client",
+      "text",
+      [],
+      null,
+      command,
+    );
+    const unrelated = store.holdDelivery(conversation.id, "unrelated terminal payload", "unrelated-terminal-client");
+    store.recordDeliveryOutcome(unrelated.id, "delivered");
+    const snapshot = store.snapshot();
+    const legacyOwner = snapshot.deliveryOperationOwners[command.operationId] as unknown as {
+      createdAt?: string;
+      terminalState?: string | null;
+      settledDelivery?: typeof unrelated;
+    };
+    delete legacyOwner.createdAt;
+    delete legacyOwner.terminalState;
+    legacyOwner.settledDelivery = snapshot.heldDeliveries[unrelated.id];
+    fs.writeFileSync(store.filename, JSON.stringify(snapshot));
+
+    const reopened = new AgentRegistry(store.filename);
+
+    expect(reopened.snapshot().deliveryOperationOwners[command.operationId]).toMatchObject({
+      deliveryId: original.id,
+      terminalState: null,
+    });
+    expect(reopened.holdDelivery(
+      conversation.id,
+      "keep this operation active",
+      "operation-owner-legacy-mismatch-client",
+      "text",
+      [],
+      null,
+      command,
+    )).toMatchObject({ id: original.id, state: "assigned" });
+  });
+
+  test("retrying a failed explicit operation restores active ownership across compaction and restart", () => {
+    const store = registry();
+    const conversation = store.ensureConversation("codex", "/operation-owner-failed-retry.jsonl", "default");
+    const command = { operationId: "operation-owner-failed-retry", kind: "send" as const, policy: "queue" as const };
+    const original = store.holdDelivery(
+      conversation.id,
+      "retry this operation",
+      "operation-owner-failed-retry-client",
+      "text",
+      [],
+      null,
+      command,
+    );
+    expect(store.beginDeliveryAttempt(original.id, original.generationId!)).not.toBeNull();
+    store.recordDeliveryOutcome(original.id, "failed", "host unavailable");
+    expect(store.snapshot().deliveryOperationOwners[command.operationId]?.terminalState).toBe("failed");
+
+    expect(store.holdDelivery(
+      conversation.id,
+      "retry this operation",
+      "operation-owner-failed-retry-client",
+      "text",
+      [],
+      null,
+      command,
+    )).toMatchObject({ id: original.id, state: "assigned" });
+    store.compactDeliveryReservations();
+
+    expect(store.snapshot().deliveryOperationOwners[command.operationId]).toMatchObject({
+      deliveryId: original.id,
+      terminalState: null,
+    });
+    const reopened = new AgentRegistry(store.filename);
+    expect(reopened.snapshot().deliveryOperationOwners[command.operationId]).toMatchObject({
+      deliveryId: original.id,
+      terminalState: null,
+    });
+  });
+
+  test("discarding an unactuated explicit reservation releases its operation ownership", () => {
+    const store = registry();
+    const conversation = store.ensureConversation("codex", "/operation-owner-discard.jsonl", "default");
+    const command = { operationId: "operation-owner-before-discard", kind: "send" as const, policy: "queue" as const };
+    const original = store.holdDelivery(
+      conversation.id,
+      "discard before actuation",
+      "operation-owner-before-discard-client",
+      "text",
+      [],
+      null,
+      command,
+    );
+    expect(store.snapshot().deliveryOperationOwners[command.operationId]?.deliveryId).toBe(original.id);
+
+    store.discardDelivery(original.id);
+
+    expect(store.snapshot().deliveryOperationOwners[command.operationId]).toBeUndefined();
+    const replacement = store.holdDelivery(
+      conversation.id,
+      "reuse after discard",
+      "operation-owner-after-discard-client",
+      "text",
+      [],
+      null,
+      command,
+    );
+    expect(replacement).toMatchObject({ clientMessageId: "operation-owner-after-discard-client", command });
+    expect(store.beginDeliveryAttempt(replacement.id, replacement.generationId!)).not.toBeNull();
+    store.discardDelivery(replacement.id);
+    expect(store.snapshot().deliveryOperationOwners[command.operationId]?.deliveryId).toBe(replacement.id);
+  });
+
   test("a restarted legacy delivered tombstone replays while modern digests retain payload conflicts", () => {
     const store = registry();
     const conversation = store.ensureConversation("codex", "/legacy-delivered-retry.jsonl", "default");
@@ -2810,7 +3000,20 @@ describe("agent registry", () => {
       role: "reviewer",
       reviewsConversationId: provisional.id,
     });
-    const held = store.holdDelivery(provisional.id, "deliver after migration", "provisional-migration-message");
+    const held = store.holdDelivery(
+      provisional.id,
+      "deliver after migration",
+      "provisional-migration-message",
+      "text",
+      [],
+      null,
+      {
+        operationId: "operation-provisional-migration-message",
+        kind: "steer",
+        policy: "steer-if-active",
+        turnId: "turn-before-provisional-adoption",
+      },
+    );
     store.reconcileConversations([{
       engine: "claude",
       path: "/child.jsonl",
@@ -2851,13 +3054,45 @@ describe("agent registry", () => {
       parentConversationId: caller.id,
       reviewsConversationId: original.id,
     });
-    expect(snapshot.heldDeliveries[held.id]).toMatchObject({ conversationId: original.id });
-    expect(store.holdDelivery(original.id, "deliver after migration", "provisional-migration-message").id).toBe(held.id);
+    expect(snapshot.heldDeliveries[held.id]).toMatchObject({
+      conversationId: original.id,
+      command: held.command,
+      requestDigest: held.requestDigest,
+    });
+    const matchingRetry = store.holdDelivery(
+      provisional.id,
+      "deliver after migration",
+      "provisional-migration-message",
+      "text",
+      [],
+      null,
+      { ...held.command, operationId: "operation-from-matching-alias-retry" },
+    );
+    expect(matchingRetry).toMatchObject({ id: held.id, command: held.command, requestDigest: held.requestDigest });
+    expect(() => store.holdDelivery(
+      original.id,
+      "deliver after migration",
+      "second-client-provisional-migration-message",
+      "text",
+      [],
+      null,
+      held.command,
+    )).toThrow("operation id is already reserved for another client message");
     expect(store.conversationForPath("/child.jsonl")?.generations[0]?.launchProfile.parentConversationId).toBe(original.id);
     expect(snapshot.conversationAliases[provisional.id]).toBe(original.id);
     expect(store.canonicalConversationId(provisional.id)).toBe(original.id);
     expect(store.conversation(provisional.id)?.id).toBe(original.id);
-    expect(new AgentRegistry(store.filename).conversation(provisional.id)?.id).toBe(original.id);
+    const reopened = new AgentRegistry(store.filename);
+    expect(reopened.conversation(provisional.id)?.id).toBe(original.id);
+    expect(() => reopened.holdDelivery(
+      provisional.id,
+      "deliver after migration",
+      "third-client-provisional-migration-message",
+      "text",
+      [],
+      null,
+      held.command,
+    )).toThrow("operation id is already reserved for another client message");
   });
 
   test("normalizes a legacy receipt after restart without changing its schema version", () => {

--- a/src/lib/agent/registry.test.ts
+++ b/src/lib/agent/registry.test.ts
@@ -213,6 +213,41 @@ describe("agent registry", () => {
     )).toMatchObject({ id: original.id, state: "assigned" });
   });
 
+  test("retrying a failed explicit operation restores active ownership across compaction and restart", () => {
+    const store = registry();
+    const conversation = store.ensureConversation("codex", "/operation-owner-failed-retry.jsonl", "default");
+    const command = { operationId: "operation-owner-failed-retry", kind: "send" as const, policy: "queue" as const };
+    const original = store.holdDelivery(
+      conversation.id,
+      "retry this operation",
+      "operation-owner-failed-retry-client",
+      "text",
+      command,
+    );
+    expect(store.beginDeliveryAttempt(original.id, original.generationId!)).not.toBeNull();
+    store.recordDeliveryOutcome(original.id, "failed", "host unavailable");
+    expect(store.snapshot().deliveryOperationOwners[command.operationId]?.terminalState).toBe("failed");
+
+    expect(store.holdDelivery(
+      conversation.id,
+      "retry this operation",
+      "operation-owner-failed-retry-client",
+      "text",
+      command,
+    )).toMatchObject({ id: original.id, state: "assigned" });
+    store.compactDeliveryReservations();
+
+    expect(store.snapshot().deliveryOperationOwners[command.operationId]).toMatchObject({
+      deliveryId: original.id,
+      terminalState: null,
+    });
+    const reopened = new AgentRegistry(store.filename);
+    expect(reopened.snapshot().deliveryOperationOwners[command.operationId]).toMatchObject({
+      deliveryId: original.id,
+      terminalState: null,
+    });
+  });
+
   test("discarding an unactuated explicit reservation releases its operation ownership", () => {
     const store = registry();
     const conversation = store.ensureConversation("codex", "/operation-owner-discard.jsonl", "default");

--- a/src/lib/agent/registry.test.ts
+++ b/src/lib/agent/registry.test.ts
@@ -146,6 +146,11 @@ describe("agent registry", () => {
       store.recordDeliveryOutcome(delivery.id, "delivered");
     }
     expect(store.snapshot().heldDeliveries[original.id]).toBeUndefined();
+    expect(store.snapshot().deliveryOperationOwners[command.operationId]).toMatchObject({
+      terminalState: "delivered",
+      requestDigest: original.requestDigest,
+    });
+    expect(store.snapshot().deliveryOperationOwners[command.operationId]).not.toHaveProperty("settledDelivery");
 
     const reopened = new AgentRegistry(store.filename);
     expect(() => reopened.holdDelivery(
@@ -166,8 +171,46 @@ describe("agent registry", () => {
       command,
       requestDigest: original.requestDigest,
       state: "delivered",
-      attempts: claimed!.attempts,
     });
+  });
+
+  test("legacy terminal owner normalization rejects a mismatched settled snapshot", () => {
+    const store = registry();
+    const conversation = store.ensureConversation("codex", "/operation-owner-legacy-mismatch.jsonl", "default");
+    const command = { operationId: "operation-owner-legacy-mismatch", kind: "send" as const, policy: "queue" as const };
+    const original = store.holdDelivery(
+      conversation.id,
+      "keep this operation active",
+      "operation-owner-legacy-mismatch-client",
+      "text",
+      command,
+    );
+    const unrelated = store.holdDelivery(conversation.id, "unrelated terminal payload", "unrelated-terminal-client");
+    store.recordDeliveryOutcome(unrelated.id, "delivered");
+    const snapshot = store.snapshot();
+    const legacyOwner = snapshot.deliveryOperationOwners[command.operationId] as unknown as {
+      createdAt?: string;
+      terminalState?: string | null;
+      settledDelivery?: typeof unrelated;
+    };
+    delete legacyOwner.createdAt;
+    delete legacyOwner.terminalState;
+    legacyOwner.settledDelivery = snapshot.heldDeliveries[unrelated.id];
+    fs.writeFileSync(store.filename, JSON.stringify(snapshot));
+
+    const reopened = new AgentRegistry(store.filename);
+
+    expect(reopened.snapshot().deliveryOperationOwners[command.operationId]).toMatchObject({
+      deliveryId: original.id,
+      terminalState: null,
+    });
+    expect(reopened.holdDelivery(
+      conversation.id,
+      "keep this operation active",
+      "operation-owner-legacy-mismatch-client",
+      "text",
+      command,
+    )).toMatchObject({ id: original.id, state: "assigned" });
   });
 
   test("discarding an unactuated explicit reservation releases its operation ownership", () => {

--- a/src/lib/agent/registry.test.ts
+++ b/src/lib/agent/registry.test.ts
@@ -2549,7 +2549,18 @@ describe("agent registry", () => {
       role: "reviewer",
       reviewsConversationId: provisional.id,
     });
-    const held = store.holdDelivery(provisional.id, "deliver after migration", "provisional-migration-message");
+    const held = store.holdDelivery(
+      provisional.id,
+      "deliver after migration",
+      "provisional-migration-message",
+      "text",
+      {
+        operationId: "operation-provisional-migration-message",
+        kind: "steer",
+        policy: "steer-if-active",
+        turnId: "turn-before-provisional-adoption",
+      },
+    );
     store.reconcileConversations([{
       engine: "claude",
       path: "/child.jsonl",
@@ -2590,13 +2601,39 @@ describe("agent registry", () => {
       parentConversationId: caller.id,
       reviewsConversationId: original.id,
     });
-    expect(snapshot.heldDeliveries[held.id]).toMatchObject({ conversationId: original.id });
-    expect(store.holdDelivery(original.id, "deliver after migration", "provisional-migration-message").id).toBe(held.id);
+    expect(snapshot.heldDeliveries[held.id]).toMatchObject({
+      conversationId: original.id,
+      command: held.command,
+      requestDigest: held.requestDigest,
+    });
+    const matchingRetry = store.holdDelivery(
+      provisional.id,
+      "deliver after migration",
+      "provisional-migration-message",
+      "text",
+      { ...held.command, operationId: "operation-from-matching-alias-retry" },
+    );
+    expect(matchingRetry).toMatchObject({ id: held.id, command: held.command, requestDigest: held.requestDigest });
+    expect(() => store.holdDelivery(
+      original.id,
+      "deliver after migration",
+      "second-client-provisional-migration-message",
+      "text",
+      held.command,
+    )).toThrow("operation id is already reserved for another client message");
     expect(store.conversationForPath("/child.jsonl")?.generations[0]?.launchProfile.parentConversationId).toBe(original.id);
     expect(snapshot.conversationAliases[provisional.id]).toBe(original.id);
     expect(store.canonicalConversationId(provisional.id)).toBe(original.id);
     expect(store.conversation(provisional.id)?.id).toBe(original.id);
-    expect(new AgentRegistry(store.filename).conversation(provisional.id)?.id).toBe(original.id);
+    const reopened = new AgentRegistry(store.filename);
+    expect(reopened.conversation(provisional.id)?.id).toBe(original.id);
+    expect(() => reopened.holdDelivery(
+      provisional.id,
+      "deliver after migration",
+      "third-client-provisional-migration-message",
+      "text",
+      held.command,
+    )).toThrow("operation id is already reserved for another client message");
   });
 
   test("normalizes a legacy receipt after restart without changing its schema version", () => {

--- a/src/lib/agent/registry.test.ts
+++ b/src/lib/agent/registry.test.ts
@@ -118,6 +118,87 @@ describe("agent registry", () => {
     expect(retained.map((delivery) => delivery.id)).toContain("legacy-104");
   });
 
+  test("compaction retains explicit operation ownership after its delivery tombstone expires", () => {
+    const store = registry();
+    const conversation = store.ensureConversation("codex", "/operation-owner-compaction.jsonl", "default");
+    const command = {
+      operationId: "operation-owner-before-compaction",
+      kind: "steer" as const,
+      policy: "steer-if-active" as const,
+      turnId: "turn-before-compaction",
+    };
+    const original = store.holdDelivery(
+      conversation.id,
+      "retain operation ownership",
+      "operation-owner-client",
+      "text",
+      command,
+    );
+    const claimed = store.beginDeliveryAttempt(original.id, original.generationId!);
+    expect(claimed).not.toBeNull();
+    store.recordDeliveryOutcome(original.id, "delivered");
+    for (let index = 0; index < 101; index += 1) {
+      const delivery = store.holdDelivery(
+        conversation.id,
+        `later delivery ${index}`,
+        `later-delivery-${index}`,
+      );
+      store.recordDeliveryOutcome(delivery.id, "delivered");
+    }
+    expect(store.snapshot().heldDeliveries[original.id]).toBeUndefined();
+
+    const reopened = new AgentRegistry(store.filename);
+    expect(() => reopened.holdDelivery(
+      conversation.id,
+      "retain operation ownership",
+      "second-operation-owner-client",
+      "text",
+      command,
+    )).toThrow("operation id is already reserved for another client message");
+    expect(reopened.holdDelivery(
+      conversation.id,
+      "retain operation ownership",
+      "operation-owner-client",
+      "text",
+      command,
+    )).toMatchObject({
+      id: original.id,
+      command,
+      requestDigest: original.requestDigest,
+      state: "delivered",
+      attempts: claimed!.attempts,
+    });
+  });
+
+  test("discarding an unactuated explicit reservation releases its operation ownership", () => {
+    const store = registry();
+    const conversation = store.ensureConversation("codex", "/operation-owner-discard.jsonl", "default");
+    const command = { operationId: "operation-owner-before-discard", kind: "send" as const, policy: "queue" as const };
+    const original = store.holdDelivery(
+      conversation.id,
+      "discard before actuation",
+      "operation-owner-before-discard-client",
+      "text",
+      command,
+    );
+    expect(store.snapshot().deliveryOperationOwners[command.operationId]?.deliveryId).toBe(original.id);
+
+    store.discardDelivery(original.id);
+
+    expect(store.snapshot().deliveryOperationOwners[command.operationId]).toBeUndefined();
+    const replacement = store.holdDelivery(
+      conversation.id,
+      "reuse after discard",
+      "operation-owner-after-discard-client",
+      "text",
+      command,
+    );
+    expect(replacement).toMatchObject({ clientMessageId: "operation-owner-after-discard-client", command });
+    expect(store.beginDeliveryAttempt(replacement.id, replacement.generationId!)).not.toBeNull();
+    store.discardDelivery(replacement.id);
+    expect(store.snapshot().deliveryOperationOwners[command.operationId]?.deliveryId).toBe(replacement.id);
+  });
+
   test("reopening an old text-only reservation applies safe command defaults", () => {
     const store = registry();
     const conversation = store.ensureConversation("codex", "/legacy-text-only-delivery.jsonl", "default");

--- a/src/lib/agent/registry.ts
+++ b/src/lib/agent/registry.ts
@@ -237,6 +237,18 @@ export interface RegistryConversation {
   updatedAt: string;
 }
 
+export interface DeliveryOperationOwner {
+  conversationId: ViewerConversationId;
+  runtimeConversationId: ViewerConversationId;
+  clientMessageId: string | null;
+  deliveryId: string;
+  command: HeldDeliveryCommand;
+  requestDigest: string;
+  contentDigest: string | null;
+  createdAt: string;
+  terminalState: Extract<HeldDelivery["state"], "delivered" | "failed"> | null;
+}
+
 export interface RegistryFile {
   version: 2;
   entries: Record<string, AgentRegistryEntry>;
@@ -257,6 +269,7 @@ export interface RegistryFile {
   autoBalance: Record<Extract<AgentEngine, "claude" | "codex">, AutoBalancePolicy>;
   quotaObservations: Record<Extract<AgentEngine, "claude" | "codex">, Record<string, DurableQuotaObservation>>;
   heldDeliveries: Record<string, HeldDelivery>;
+  deliveryOperationOwners: Record<string, DeliveryOperationOwner>;
   pendingSuccessorCleanups: Record<string, { conversationId: ViewerConversationId; receipt: ProviderReceipt; createdAt: string; lastError: string | null }>;
 }
 
@@ -576,8 +589,8 @@ export class MigrationRevisionError extends Error {
 }
 
 export class DeliveryReservationConflictError extends Error {
-  constructor() {
-    super("client message id is already reserved for another request");
+  constructor(message = "client message id is already reserved for another request") {
+    super(message);
     this.name = "DeliveryReservationConflictError";
   }
 }
@@ -614,6 +627,7 @@ const EMPTY: RegistryFile = {
   autoBalance: { claude: emptyPolicy(), codex: emptyPolicy() },
   quotaObservations: { claude: {}, codex: {} },
   heldDeliveries: {},
+  deliveryOperationOwners: {},
   pendingSuccessorCleanups: {},
 };
 
@@ -951,6 +965,9 @@ function normalizeHeldDelivery(value: HeldDelivery): HeldDelivery {
   }
   return {
     ...value,
+    runtimeConversationId: typeof value.runtimeConversationId === "string" && value.runtimeConversationId.startsWith("conversation_")
+      ? value.runtimeConversationId as ViewerConversationId
+      : value.conversationId,
     text: state === "delivered" ? "" : text,
     clientMessageId: value.clientMessageId ?? null,
     payloadKind,
@@ -970,7 +987,122 @@ function normalizeHeldDelivery(value: HeldDelivery): HeldDelivery {
   };
 }
 
+function terminalDeliveryState(
+  delivery: HeldDelivery | null | undefined,
+): Extract<HeldDelivery["state"], "delivered" | "failed"> | null {
+  return delivery?.state === "delivered" || delivery?.state === "failed" ? delivery.state : null;
+}
+
+function syncDeliveryOperationOwnerState(file: RegistryFile, delivery: HeldDelivery): void {
+  const owner = file.deliveryOperationOwners[delivery.command.operationId];
+  if (owner?.deliveryId === delivery.id) owner.terminalState = terminalDeliveryState(delivery);
+}
+
+function normalizeDeliveryOperationOwners(
+  value: unknown,
+  heldDeliveries: RegistryFile["heldDeliveries"],
+): RegistryFile["deliveryOperationOwners"] {
+  const owners: RegistryFile["deliveryOperationOwners"] = {};
+  if (value && typeof value === "object" && !Array.isArray(value)) {
+    for (const [operationId, candidate] of Object.entries(value)) {
+      if (!operationId || !candidate || typeof candidate !== "object" || Array.isArray(candidate)) continue;
+      const owner = candidate as Partial<DeliveryOperationOwner> & { settledDelivery?: HeldDelivery };
+      if (typeof owner.conversationId !== "string" || !owner.conversationId.startsWith("conversation_")
+        || (owner.clientMessageId !== null && typeof owner.clientMessageId !== "string")
+        || typeof owner.deliveryId !== "string" || !owner.deliveryId
+        || typeof owner.requestDigest !== "string" || !owner.requestDigest) continue;
+      const settledCandidate = owner.settledDelivery && typeof owner.settledDelivery === "object"
+        ? normalizeHeldDelivery(owner.settledDelivery)
+        : null;
+      const settledDelivery = settledCandidate?.id === owner.deliveryId
+        && settledCandidate.command.operationId === operationId
+        && settledCandidate.requestDigest === owner.requestDigest
+        && terminalDeliveryState(settledCandidate) !== null
+        ? settledCandidate
+        : null;
+      const referencedCandidate = heldDeliveries[owner.deliveryId];
+      const referencedDelivery = referencedCandidate?.command.operationId === operationId
+        && referencedCandidate.requestDigest === owner.requestDigest
+        ? referencedCandidate
+        : null;
+      const terminalState = referencedDelivery
+        ? terminalDeliveryState(referencedDelivery)
+        : owner.terminalState === "delivered" || owner.terminalState === "failed"
+          ? owner.terminalState
+          : terminalDeliveryState(settledDelivery);
+      owners[operationId] = {
+        conversationId: owner.conversationId as ViewerConversationId,
+        runtimeConversationId: typeof owner.runtimeConversationId === "string" && owner.runtimeConversationId.startsWith("conversation_")
+          ? owner.runtimeConversationId as ViewerConversationId
+          : heldDeliveries[owner.deliveryId]?.runtimeConversationId ?? owner.conversationId as ViewerConversationId,
+        clientMessageId: owner.clientMessageId,
+        deliveryId: owner.deliveryId,
+        command: { ...canonicalHeldDeliveryCommand(owner.command, operationId), operationId },
+        requestDigest: owner.requestDigest,
+        contentDigest: typeof owner.contentDigest === "string"
+          ? owner.contentDigest
+          : referencedDelivery?.contentDigest ?? settledDelivery?.contentDigest ?? null,
+        createdAt: typeof owner.createdAt === "string"
+          ? owner.createdAt
+          : referencedDelivery?.createdAt ?? settledDelivery?.createdAt ?? LEGACY_POLICY_RESTARTED_AT,
+        terminalState,
+      };
+    }
+  }
+  for (const delivery of Object.values(heldDeliveries)) {
+    if (delivery.command.operationId === delivery.id || !delivery.requestDigest) continue;
+    owners[delivery.command.operationId] ??= {
+      conversationId: delivery.conversationId,
+      runtimeConversationId: delivery.runtimeConversationId,
+      clientMessageId: delivery.clientMessageId,
+      deliveryId: delivery.id,
+      command: delivery.command,
+      requestDigest: delivery.requestDigest,
+      contentDigest: delivery.contentDigest,
+      createdAt: delivery.createdAt,
+      terminalState: terminalDeliveryState(delivery),
+    };
+  }
+  return owners;
+}
+
+const DELIVERY_OPERATION_OWNER_TERMINAL_LIMIT = 200;
+
+function compactDeliveryOperationOwners(file: RegistryFile, onlyConversationId?: ViewerConversationId): void {
+  const terminalGroups = new Map<ViewerConversationId, Array<[string, DeliveryOperationOwner]>>();
+  for (const [operationId, owner] of Object.entries(file.deliveryOperationOwners)) {
+    if (owner.terminalState === null) continue;
+    const canonicalId = resolveConversationAlias(file, owner.conversationId);
+    if (onlyConversationId && canonicalId !== resolveConversationAlias(file, onlyConversationId)) continue;
+    const group = terminalGroups.get(canonicalId) ?? [];
+    group.push([operationId, owner]);
+    terminalGroups.set(canonicalId, group);
+  }
+  for (const owners of terminalGroups.values()) {
+    owners.sort(([leftId, left], [rightId, right]) =>
+      right.createdAt.localeCompare(left.createdAt) || rightId.localeCompare(leftId));
+    for (const [operationId] of owners.slice(DELIVERY_OPERATION_OWNER_TERMINAL_LIMIT)) {
+      delete file.deliveryOperationOwners[operationId];
+    }
+  }
+}
+
 function compactDeliveryReservations(file: RegistryFile, onlyConversationId?: ViewerConversationId): number {
+  for (const delivery of Object.values(file.heldDeliveries)) {
+    if (delivery.command.operationId === delivery.id || !delivery.requestDigest) continue;
+    file.deliveryOperationOwners[delivery.command.operationId] ??= {
+      conversationId: delivery.conversationId,
+      runtimeConversationId: delivery.runtimeConversationId,
+      clientMessageId: delivery.clientMessageId,
+      deliveryId: delivery.id,
+      command: delivery.command,
+      requestDigest: delivery.requestDigest,
+      contentDigest: delivery.contentDigest,
+      createdAt: delivery.createdAt,
+      terminalState: null,
+    };
+    syncDeliveryOperationOwnerState(file, delivery);
+  }
   const deliveredGroups = new Map<ViewerConversationId, HeldDelivery[]>();
   const failedGroups = new Map<ViewerConversationId, HeldDelivery[]>();
   for (const delivery of Object.values(file.heldDeliveries)) {
@@ -1006,6 +1138,7 @@ function compactDeliveryReservations(file: RegistryFile, onlyConversationId?: Vi
       removed += 1;
     }
   }
+  compactDeliveryOperationOwners(file, onlyConversationId);
   return removed;
 }
 
@@ -1047,6 +1180,7 @@ function conversationDurabilityScore(file: RegistryFile, conversation: RegistryC
   for (const edge of Object.values(file.lineageEdges)) if (edge.parentConversationId === conversation.id) score += 5;
   if (file.memberships[conversation.id]?.length) score += 10;
   for (const delivery of Object.values(file.heldDeliveries)) if (delivery.conversationId === conversation.id) score += 5;
+  for (const owner of Object.values(file.deliveryOperationOwners)) if (owner.conversationId === conversation.id) score += 5;
   return score;
 }
 
@@ -1218,6 +1352,11 @@ function adoptProvisionalOwner(
   for (const delivery of Object.values(file.heldDeliveries)) {
     if (delivery.conversationId === owner.id) delivery.conversationId = target.id;
   }
+  for (const operationOwner of Object.values(file.deliveryOperationOwners)) {
+    if (operationOwner.conversationId === owner.id) {
+      operationOwner.conversationId = target.id;
+    }
+  }
   for (const entry of Object.values(file.entries)) {
     if (entry.launchProfile?.parentConversationId === owner.id) {
       entry.launchProfile = { ...entry.launchProfile, parentConversationId: target.id };
@@ -1347,6 +1486,9 @@ export function normalizeRegistry(value: unknown): RegistryFile {
     throw new RegistryReadError("agent registry schema is unsupported");
   }
   const legacy = parsed.legacyResumePanes;
+  const heldDeliveries = parsed.heldDeliveries && typeof parsed.heldDeliveries === "object"
+    ? Object.fromEntries(Object.entries(parsed.heldDeliveries).map(([id, delivery]) => [id, normalizeHeldDelivery(delivery)]))
+    : {};
   return backfillMaterializedSpawnArtifacts({
       version: 2,
       entries: Object.fromEntries(Object.entries(parsed.entries).map(([id, entry]) => [id, normalizeEntry(entry)])),
@@ -1379,9 +1521,8 @@ export function normalizeRegistry(value: unknown): RegistryFile {
       quotaObservations: parsed.quotaObservations && typeof parsed.quotaObservations === "object"
         ? { ...EMPTY.quotaObservations, ...parsed.quotaObservations }
         : clone(EMPTY.quotaObservations),
-      heldDeliveries: parsed.heldDeliveries && typeof parsed.heldDeliveries === "object"
-        ? Object.fromEntries(Object.entries(parsed.heldDeliveries).map(([id, delivery]) => [id, normalizeHeldDelivery(delivery)]))
-        : {},
+      heldDeliveries,
+      deliveryOperationOwners: normalizeDeliveryOperationOwners(parsed.deliveryOperationOwners, heldDeliveries),
       pendingSuccessorCleanups: parsed.pendingSuccessorCleanups && typeof parsed.pendingSuccessorCleanups === "object"
         ? parsed.pendingSuccessorCleanups
         : {},
@@ -3390,6 +3531,7 @@ export class AgentRegistry {
             delivery.generationId = source.id;
             delivery.assignedAt = changedAt;
             delivery.error = null;
+            syncDeliveryOperationOwnerState(file, delivery);
           }
         }
         conversation.migration = null;
@@ -3463,6 +3605,7 @@ export class AgentRegistry {
               delivery.generationId = source.id;
               delivery.assignedAt = changedAt;
               delivery.error = null;
+              syncDeliveryOperationOwnerState(file, delivery);
             }
             conversation.migration = null;
             conversation.updatedAt = changedAt;
@@ -3749,6 +3892,7 @@ export class AgentRegistry {
         delivery.generationId = generation.id;
         delivery.assignedAt = committedAt;
         delivery.error = null;
+        syncDeliveryOperationOwnerState(file, delivery);
       }
       file.conversationRevision[conversation.engine] += 1;
       file.engineRouting[conversation.engine].revision += 1;
@@ -3789,6 +3933,7 @@ export class AgentRegistry {
             delivery.generationId = source.id;
             delivery.assignedAt = intent.updatedAt;
             delivery.error = null;
+            syncDeliveryOperationOwnerState(file, delivery);
           }
         }
       }
@@ -3893,11 +4038,40 @@ export class AgentRegistry {
     assertStructuredTextEnvelope(text);
     return this.mutate((file) => {
       const canonicalId = resolveConversationAlias(file, conversationId);
-      const existing = clientMessageId ? Object.values(file.heldDeliveries).find((item) => item.conversationId === canonicalId && item.clientMessageId === clientMessageId) : undefined;
+      const existing = clientMessageId ? Object.values(file.heldDeliveries).find((item) =>
+        resolveConversationAlias(file, item.conversationId) === canonicalId
+        && item.clientMessageId === clientMessageId) : undefined;
       const requestedCommand = canonicalHeldDeliveryCommand(commandInput, existing?.id ?? "pending-delivery");
       const requestDigest = heldDeliveryRequestDigest(canonicalId, text, requestedCommand);
-      if (existing?.requestDigest && !heldDeliveryRequestDigests(file, canonicalId, text, requestedCommand).has(existing.requestDigest)) {
+      const requestedDigests = heldDeliveryRequestDigests(file, canonicalId, text, requestedCommand);
+      let terminalOperationRetry: DeliveryOperationOwner | null = null;
+      if (existing?.requestDigest && !requestedDigests.has(existing.requestDigest)) {
         throw new DeliveryReservationConflictError();
+      }
+      if (!existing && commandInput.operationId) {
+        const ownedDelivery = Object.values(file.heldDeliveries).find((item) =>
+          item.command.operationId === requestedCommand.operationId);
+        const operationOwner = file.deliveryOperationOwners[requestedCommand.operationId]
+          ?? (ownedDelivery?.requestDigest ? {
+            conversationId: ownedDelivery.conversationId,
+            runtimeConversationId: ownedDelivery.runtimeConversationId,
+            clientMessageId: ownedDelivery.clientMessageId,
+            deliveryId: ownedDelivery.id,
+            command: ownedDelivery.command,
+            requestDigest: ownedDelivery.requestDigest,
+            contentDigest: ownedDelivery.contentDigest,
+            createdAt: ownedDelivery.createdAt,
+            terminalState: terminalDeliveryState(ownedDelivery),
+          } : null);
+        const matchingOwner = operationOwner
+          && resolveConversationAlias(file, operationOwner.conversationId) === canonicalId
+          && operationOwner.clientMessageId === clientMessageId
+          && requestedDigests.has(operationOwner.requestDigest)
+          && (!operationOwner.contentDigest || !contentDigest || operationOwner.contentDigest === contentDigest);
+        if (operationOwner && !matchingOwner) {
+          throw new DeliveryReservationConflictError("operation id is already reserved for another client message");
+        }
+        if (matchingOwner && operationOwner.terminalState) terminalOperationRetry = clone(operationOwner);
       }
       const conversation = file.conversations[canonicalId];
       const paths = new Set([conversation?.generations.at(-1)?.path].filter((pathname): pathname is string => Boolean(pathname)));
@@ -3906,7 +4080,10 @@ export class AgentRegistry {
         && ["requested", "preparing", "successor-starting", "verifying"].includes(conversation.migration.phase);
       const current = conversation?.generations.at(-1);
       const place = (delivery: HeldDelivery): HeldDelivery => {
-        if (delivery.state === "delivered" || delivery.state === "delivery-uncertain") return clone(delivery);
+        if (delivery.state === "delivered" || delivery.state === "delivery-uncertain") {
+          syncDeliveryOperationOwnerState(file, delivery);
+          return clone(delivery);
+        }
         delivery.deliveredAt = null;
         delivery.error = null;
         if (migrationBlocksDelivery) {
@@ -3923,6 +4100,7 @@ export class AgentRegistry {
           delivery.assignedAt = null;
           delivery.error = "delivery target is unavailable and remains recoverable";
         }
+        syncDeliveryOperationOwnerState(file, delivery);
         if (conversation) advanceMigrationScopeRevision(file, conversation.engine, signature, paths);
         return clone(delivery);
       };
@@ -3938,10 +4116,35 @@ export class AgentRegistry {
         if (existing.error === CORRUPT_HELD_DELIVERY_IMAGES_ERROR) return clone(existing);
         return place(existing);
       }
+      if (terminalOperationRetry) {
+        const terminalState = terminalOperationRetry.terminalState;
+        if (terminalState === null) throw new Error("terminal operation replay state is missing");
+        return {
+          id: terminalOperationRetry.deliveryId,
+          conversationId: canonicalId,
+          runtimeConversationId: terminalOperationRetry.runtimeConversationId,
+          text,
+          createdAt: terminalOperationRetry.createdAt,
+          clientMessageId,
+          payloadKind,
+          runtimeImages: runtimeImages.map((image) => ({ ...image })),
+          contentDigest,
+          artifactPaths: [],
+          command: terminalOperationRetry.command,
+          requestDigest: terminalOperationRetry.requestDigest,
+          state: terminalState,
+          generationId: null,
+          attempts: 0,
+          assignedAt: null,
+          deliveredAt: terminalState === "delivered" ? terminalOperationRetry.createdAt : null,
+          error: terminalState === "failed" ? "delivery failed" : null,
+        };
+      }
       const deliveryId = crypto.randomUUID();
       const held: HeldDelivery = {
         id: deliveryId,
         conversationId: canonicalId,
+        runtimeConversationId: canonicalId,
         text,
         createdAt: now(),
         clientMessageId,
@@ -3962,6 +4165,19 @@ export class AgentRegistry {
       const count = Object.values(file.heldDeliveries).filter((item) => item.conversationId === canonicalId && item.state !== "delivered").length;
       if (count >= 100) throw new Error("held delivery limit reached for conversation");
       file.heldDeliveries[held.id] = held;
+      if (commandInput.operationId) {
+        file.deliveryOperationOwners[held.command.operationId] ??= {
+          conversationId: canonicalId,
+          runtimeConversationId: held.runtimeConversationId,
+          clientMessageId,
+          deliveryId: held.id,
+          command: held.command,
+          requestDigest: held.requestDigest!,
+          contentDigest: held.contentDigest,
+          createdAt: held.createdAt,
+          terminalState: null,
+        };
+      }
       return place(held);
     });
   }
@@ -4034,6 +4250,7 @@ export class AgentRegistry {
       delivery.state = "delivery-uncertain";
       delivery.attempts += 1;
       delivery.error = "delivery started; recovery requires an explicit outcome";
+      syncDeliveryOperationOwnerState(file, delivery);
       if (conversation) advanceMigrationScopeRevision(file, conversation.engine, signature, paths);
       return clone(delivery);
     });
@@ -4112,6 +4329,12 @@ export class AgentRegistry {
       const conversation = delivery ? file.conversations[resolveConversationAlias(file, delivery.conversationId)] : undefined;
       const paths = new Set([conversation?.generations.at(-1)?.path].filter((pathname): pathname is string => Boolean(pathname)));
       const signature = conversation ? migrationReadinessSignature(file, conversation.engine, paths) : "";
+      if (delivery) {
+        const operationOwner = file.deliveryOperationOwners[delivery.command.operationId];
+        if (delivery.attempts === 0 && operationOwner?.deliveryId === delivery.id) {
+          delete file.deliveryOperationOwners[delivery.command.operationId];
+        }
+      }
       delete file.heldDeliveries[id];
       if (conversation) advanceMigrationScopeRevision(file, conversation.engine, signature, paths);
     });
@@ -4151,6 +4374,7 @@ export class AgentRegistry {
         delivery.assignedAt = null;
         delivery.deliveredAt = null;
         delivery.error = null;
+        syncDeliveryOperationOwnerState(file, delivery);
         if (conversation) advanceMigrationScopeRevision(file, conversation.engine, signature, paths);
         return clone(delivery);
       }
@@ -4159,6 +4383,7 @@ export class AgentRegistry {
         delivery.state = "failed";
         delivery.deliveredAt = null;
         delivery.error = "delivery target is unavailable and remains recoverable";
+        syncDeliveryOperationOwnerState(file, delivery);
         if (conversation) advanceMigrationScopeRevision(file, conversation.engine, signature, paths);
         return clone(delivery);
       }
@@ -4167,6 +4392,7 @@ export class AgentRegistry {
       delivery.assignedAt = now();
       delivery.deliveredAt = null;
       delivery.error = null;
+      syncDeliveryOperationOwnerState(file, delivery);
       if (conversation) advanceMigrationScopeRevision(file, conversation.engine, signature, paths);
       return clone(delivery);
     });
@@ -4198,6 +4424,7 @@ export class AgentRegistry {
         delivery.generationId = source.id;
         delivery.assignedAt = rolledAt;
         delivery.error = null;
+        syncDeliveryOperationOwnerState(file, delivery);
       }
       conversation.migration = { ...conversation.migration, phase: "rolled-back", error: null, errorCode: null, updatedAt: rolledAt };
       conversation.updatedAt = rolledAt;

--- a/src/lib/agent/registry.ts
+++ b/src/lib/agent/registry.ts
@@ -238,7 +238,8 @@ export interface DeliveryOperationOwner {
   deliveryId: string;
   command: HeldDeliveryCommand;
   requestDigest: string;
-  settledDelivery?: HeldDelivery;
+  createdAt: string;
+  terminalState: Extract<HeldDelivery["state"], "delivered" | "failed"> | null;
 }
 
 export interface RegistryFile {
@@ -959,6 +960,12 @@ function normalizeHeldDelivery(value: HeldDelivery): HeldDelivery {
   };
 }
 
+function terminalDeliveryState(
+  delivery: HeldDelivery | null | undefined,
+): Extract<HeldDelivery["state"], "delivered" | "failed"> | null {
+  return delivery?.state === "delivered" || delivery?.state === "failed" ? delivery.state : null;
+}
+
 function normalizeDeliveryOperationOwners(
   value: unknown,
   heldDeliveries: RegistryFile["heldDeliveries"],
@@ -967,11 +974,24 @@ function normalizeDeliveryOperationOwners(
   if (value && typeof value === "object" && !Array.isArray(value)) {
     for (const [operationId, candidate] of Object.entries(value)) {
       if (!operationId || !candidate || typeof candidate !== "object" || Array.isArray(candidate)) continue;
-      const owner = candidate as Partial<DeliveryOperationOwner>;
+      const owner = candidate as Partial<DeliveryOperationOwner> & { settledDelivery?: HeldDelivery };
       if (typeof owner.conversationId !== "string" || !owner.conversationId.startsWith("conversation_")
         || (owner.clientMessageId !== null && typeof owner.clientMessageId !== "string")
         || typeof owner.deliveryId !== "string" || !owner.deliveryId
         || typeof owner.requestDigest !== "string" || !owner.requestDigest) continue;
+      const settledCandidate = owner.settledDelivery && typeof owner.settledDelivery === "object"
+        ? normalizeHeldDelivery(owner.settledDelivery)
+        : null;
+      const settledDelivery = settledCandidate?.id === owner.deliveryId
+        && settledCandidate.command.operationId === operationId
+        && settledCandidate.requestDigest === owner.requestDigest
+        && terminalDeliveryState(settledCandidate) !== null
+        ? settledCandidate
+        : null;
+      const referencedDelivery = heldDeliveries[owner.deliveryId];
+      const terminalState = owner.terminalState === "delivered" || owner.terminalState === "failed"
+        ? owner.terminalState
+        : terminalDeliveryState(settledDelivery) ?? terminalDeliveryState(referencedDelivery);
       owners[operationId] = {
         conversationId: owner.conversationId as ViewerConversationId,
         runtimeConversationId: typeof owner.runtimeConversationId === "string" && owner.runtimeConversationId.startsWith("conversation_")
@@ -981,16 +1001,11 @@ function normalizeDeliveryOperationOwners(
         deliveryId: owner.deliveryId,
         command: { ...canonicalHeldDeliveryCommand(owner.command, operationId), operationId },
         requestDigest: owner.requestDigest,
+        createdAt: typeof owner.createdAt === "string"
+          ? owner.createdAt
+          : referencedDelivery?.createdAt ?? settledDelivery?.createdAt ?? LEGACY_POLICY_RESTARTED_AT,
+        terminalState,
       };
-      if (owner.settledDelivery && typeof owner.settledDelivery === "object") {
-        const settledDelivery = normalizeHeldDelivery(owner.settledDelivery);
-        if (settledDelivery.id === owner.deliveryId
-          && settledDelivery.command.operationId === operationId
-          && settledDelivery.requestDigest === owner.requestDigest
-          && ["delivered", "failed"].includes(settledDelivery.state)) {
-          owners[operationId].settledDelivery = settledDelivery;
-        }
-      }
     }
   }
   for (const delivery of Object.values(heldDeliveries)) {
@@ -1002,22 +1017,50 @@ function normalizeDeliveryOperationOwners(
       deliveryId: delivery.id,
       command: delivery.command,
       requestDigest: delivery.requestDigest,
+      createdAt: delivery.createdAt,
+      terminalState: terminalDeliveryState(delivery),
     };
   }
   return owners;
 }
 
+const DELIVERY_OPERATION_OWNER_TERMINAL_LIMIT = 200;
+
+function compactDeliveryOperationOwners(file: RegistryFile, onlyConversationId?: ViewerConversationId): void {
+  const terminalGroups = new Map<ViewerConversationId, Array<[string, DeliveryOperationOwner]>>();
+  for (const [operationId, owner] of Object.entries(file.deliveryOperationOwners)) {
+    if (owner.terminalState === null) continue;
+    const canonicalId = resolveConversationAlias(file, owner.conversationId);
+    if (onlyConversationId && canonicalId !== resolveConversationAlias(file, onlyConversationId)) continue;
+    const group = terminalGroups.get(canonicalId) ?? [];
+    group.push([operationId, owner]);
+    terminalGroups.set(canonicalId, group);
+  }
+  for (const owners of terminalGroups.values()) {
+    owners.sort(([leftId, left], [rightId, right]) =>
+      right.createdAt.localeCompare(left.createdAt) || rightId.localeCompare(leftId));
+    for (const [operationId] of owners.slice(DELIVERY_OPERATION_OWNER_TERMINAL_LIMIT)) {
+      delete file.deliveryOperationOwners[operationId];
+    }
+  }
+}
+
 function compactDeliveryReservations(file: RegistryFile, onlyConversationId?: ViewerConversationId): number {
   for (const delivery of Object.values(file.heldDeliveries)) {
     if (delivery.command.operationId === delivery.id || !delivery.requestDigest) continue;
-    file.deliveryOperationOwners[delivery.command.operationId] ??= {
+    const owner = file.deliveryOperationOwners[delivery.command.operationId] ??= {
       conversationId: delivery.conversationId,
       runtimeConversationId: delivery.runtimeConversationId,
       clientMessageId: delivery.clientMessageId,
       deliveryId: delivery.id,
       command: delivery.command,
       requestDigest: delivery.requestDigest,
+      createdAt: delivery.createdAt,
+      terminalState: null,
     };
+    if (owner.deliveryId === delivery.id && (delivery.state === "delivered" || delivery.state === "failed")) {
+      owner.terminalState = delivery.state;
+    }
   }
   const deliveredGroups = new Map<ViewerConversationId, HeldDelivery[]>();
   const failedGroups = new Map<ViewerConversationId, HeldDelivery[]>();
@@ -1036,14 +1079,9 @@ function compactDeliveryReservations(file: RegistryFile, onlyConversationId?: Vi
     }
   }
   let removed = 0;
-  const retainSettledOwner = (delivery: HeldDelivery): void => {
-    const owner = file.deliveryOperationOwners[delivery.command.operationId];
-    if (owner?.deliveryId === delivery.id) owner.settledDelivery = clone(delivery);
-  };
   for (const deliveries of deliveredGroups.values()) {
     deliveries.sort((left, right) => (right.deliveredAt ?? right.createdAt).localeCompare(left.deliveredAt ?? left.createdAt) || right.id.localeCompare(left.id));
     for (const expired of deliveries.slice(100)) {
-      retainSettledOwner(expired);
       delete file.heldDeliveries[expired.id];
       removed += 1;
     }
@@ -1055,11 +1093,11 @@ function compactDeliveryReservations(file: RegistryFile, onlyConversationId?: Vi
     const retainedFailed = Math.max(0, Math.min(50, 99 - activeCount));
     deliveries.sort((left, right) => right.createdAt.localeCompare(left.createdAt) || right.id.localeCompare(left.id));
     for (const expired of deliveries.slice(retainedFailed)) {
-      retainSettledOwner(expired);
       delete file.heldDeliveries[expired.id];
       removed += 1;
     }
   }
+  compactDeliveryOperationOwners(file, onlyConversationId);
   return removed;
 }
 
@@ -1273,7 +1311,6 @@ function adoptProvisionalOwner(
   for (const operationOwner of Object.values(file.deliveryOperationOwners)) {
     if (operationOwner.conversationId === owner.id) {
       operationOwner.conversationId = target.id;
-      if (operationOwner.settledDelivery) operationOwner.settledDelivery.conversationId = target.id;
     }
   }
   for (const entry of Object.values(file.entries)) {
@@ -3825,7 +3862,7 @@ export class AgentRegistry {
       const requestedCommand = canonicalHeldDeliveryCommand(commandInput, existing?.id ?? "pending-delivery");
       const requestDigest = heldDeliveryRequestDigest(canonicalId, text, requestedCommand);
       const requestedDigests = heldDeliveryRequestDigests(file, canonicalId, text, requestedCommand);
-      let settledOperationRetry: HeldDelivery | null = null;
+      let terminalOperationRetry: DeliveryOperationOwner | null = null;
       if (existing && !requestedDigests.has(existing.requestDigest ?? "")) {
         throw new DeliveryReservationConflictError();
       }
@@ -3840,6 +3877,8 @@ export class AgentRegistry {
             deliveryId: ownedDelivery.id,
             command: ownedDelivery.command,
             requestDigest: ownedDelivery.requestDigest,
+            createdAt: ownedDelivery.createdAt,
+            terminalState: terminalDeliveryState(ownedDelivery),
           } : null);
         const matchingOwner = operationOwner
           && resolveConversationAlias(file, operationOwner.conversationId) === canonicalId
@@ -3848,9 +3887,7 @@ export class AgentRegistry {
         if (operationOwner && !matchingOwner) {
           throw new DeliveryReservationConflictError("operation id is already reserved for another client message");
         }
-        if (matchingOwner && operationOwner.settledDelivery) {
-          settledOperationRetry = clone(operationOwner.settledDelivery);
-        }
+        if (matchingOwner && operationOwner.terminalState) terminalOperationRetry = clone(operationOwner);
       }
       const conversation = file.conversations[canonicalId];
       const paths = new Set([conversation?.generations.at(-1)?.path].filter((pathname): pathname is string => Boolean(pathname)));
@@ -3880,9 +3917,27 @@ export class AgentRegistry {
         return clone(delivery);
       };
       if (existing) return place(existing);
-      if (settledOperationRetry) {
-        file.heldDeliveries[settledOperationRetry.id] = settledOperationRetry;
-        return place(settledOperationRetry);
+      if (terminalOperationRetry) {
+        const terminalState = terminalOperationRetry.terminalState;
+        if (terminalState === null) throw new Error("terminal operation replay state is missing");
+        return {
+          id: terminalOperationRetry.deliveryId,
+          conversationId: canonicalId,
+          runtimeConversationId: terminalOperationRetry.runtimeConversationId,
+          text,
+          createdAt: terminalOperationRetry.createdAt,
+          clientMessageId,
+          payloadKind,
+          artifactPaths: [],
+          command: terminalOperationRetry.command,
+          requestDigest: terminalOperationRetry.requestDigest,
+          state: terminalState,
+          generationId: null,
+          attempts: 0,
+          assignedAt: null,
+          deliveredAt: terminalState === "delivered" ? terminalOperationRetry.createdAt : null,
+          error: terminalState === "failed" ? "delivery failed" : null,
+        };
       }
       const deliveryId = crypto.randomUUID();
       const held: HeldDelivery = {
@@ -3915,6 +3970,8 @@ export class AgentRegistry {
           deliveryId: held.id,
           command: held.command,
           requestDigest: held.requestDigest!,
+          createdAt: held.createdAt,
+          terminalState: null,
         };
       }
       return place(held);

--- a/src/lib/agent/registry.ts
+++ b/src/lib/agent/registry.ts
@@ -233,6 +233,7 @@ export interface RegistryConversation {
 
 export interface DeliveryOperationOwner {
   conversationId: ViewerConversationId;
+  runtimeConversationId: ViewerConversationId;
   clientMessageId: string | null;
   deliveryId: string;
   command: HeldDeliveryCommand;
@@ -938,6 +939,9 @@ function normalizeHeldDelivery(value: HeldDelivery): HeldDelivery {
     : null;
   return {
     ...value,
+    runtimeConversationId: typeof value.runtimeConversationId === "string" && value.runtimeConversationId.startsWith("conversation_")
+      ? value.runtimeConversationId as ViewerConversationId
+      : value.conversationId,
     text: state === "delivered" ? "" : text,
     clientMessageId: value.clientMessageId ?? null,
     payloadKind: value.payloadKind ?? "text",
@@ -970,6 +974,9 @@ function normalizeDeliveryOperationOwners(
         || typeof owner.requestDigest !== "string" || !owner.requestDigest) continue;
       owners[operationId] = {
         conversationId: owner.conversationId as ViewerConversationId,
+        runtimeConversationId: typeof owner.runtimeConversationId === "string" && owner.runtimeConversationId.startsWith("conversation_")
+          ? owner.runtimeConversationId as ViewerConversationId
+          : heldDeliveries[owner.deliveryId]?.runtimeConversationId ?? owner.conversationId as ViewerConversationId,
         clientMessageId: owner.clientMessageId,
         deliveryId: owner.deliveryId,
         command: { ...canonicalHeldDeliveryCommand(owner.command, operationId), operationId },
@@ -990,6 +997,7 @@ function normalizeDeliveryOperationOwners(
     if (delivery.command.operationId === delivery.id || !delivery.requestDigest) continue;
     owners[delivery.command.operationId] ??= {
       conversationId: delivery.conversationId,
+      runtimeConversationId: delivery.runtimeConversationId,
       clientMessageId: delivery.clientMessageId,
       deliveryId: delivery.id,
       command: delivery.command,
@@ -1004,6 +1012,7 @@ function compactDeliveryReservations(file: RegistryFile, onlyConversationId?: Vi
     if (delivery.command.operationId === delivery.id || !delivery.requestDigest) continue;
     file.deliveryOperationOwners[delivery.command.operationId] ??= {
       conversationId: delivery.conversationId,
+      runtimeConversationId: delivery.runtimeConversationId,
       clientMessageId: delivery.clientMessageId,
       deliveryId: delivery.id,
       command: delivery.command,
@@ -3826,6 +3835,7 @@ export class AgentRegistry {
         const operationOwner = file.deliveryOperationOwners[requestedCommand.operationId]
           ?? (ownedDelivery?.requestDigest ? {
             conversationId: ownedDelivery.conversationId,
+            runtimeConversationId: ownedDelivery.runtimeConversationId,
             clientMessageId: ownedDelivery.clientMessageId,
             deliveryId: ownedDelivery.id,
             command: ownedDelivery.command,
@@ -3878,6 +3888,7 @@ export class AgentRegistry {
       const held: HeldDelivery = {
         id: deliveryId,
         conversationId: canonicalId,
+        runtimeConversationId: canonicalId,
         text,
         createdAt: now(),
         clientMessageId,
@@ -3899,6 +3910,7 @@ export class AgentRegistry {
       if (commandInput.operationId) {
         file.deliveryOperationOwners[held.command.operationId] ??= {
           conversationId: canonicalId,
+          runtimeConversationId: held.runtimeConversationId,
           clientMessageId,
           deliveryId: held.id,
           command: held.command,

--- a/src/lib/agent/registry.ts
+++ b/src/lib/agent/registry.ts
@@ -570,8 +570,8 @@ export class MigrationRevisionError extends Error {
 }
 
 export class DeliveryReservationConflictError extends Error {
-  constructor() {
-    super("client message id is already reserved for another request");
+  constructor(message = "client message id is already reserved for another request") {
+    super(message);
     this.name = "DeliveryReservationConflictError";
   }
 }
@@ -3730,11 +3730,20 @@ export class AgentRegistry {
     if (payloadKind === "text" && (!text || text.length > 32_000)) throw new Error("held delivery must contain at most 32000 characters");
     return this.mutate((file) => {
       const canonicalId = resolveConversationAlias(file, conversationId);
-      const existing = clientMessageId ? Object.values(file.heldDeliveries).find((item) => item.conversationId === canonicalId && item.clientMessageId === clientMessageId) : undefined;
+      const existing = clientMessageId ? Object.values(file.heldDeliveries).find((item) =>
+        resolveConversationAlias(file, item.conversationId) === canonicalId
+        && item.clientMessageId === clientMessageId) : undefined;
       const requestedCommand = canonicalHeldDeliveryCommand(commandInput, existing?.id ?? "pending-delivery");
       const requestDigest = heldDeliveryRequestDigest(canonicalId, text, requestedCommand);
       if (existing && !heldDeliveryRequestDigests(file, canonicalId, text, requestedCommand).has(existing.requestDigest ?? "")) {
         throw new DeliveryReservationConflictError();
+      }
+      if (!existing && commandInput.operationId) {
+        const operationOwner = Object.values(file.heldDeliveries).find((item) =>
+          item.command.operationId === requestedCommand.operationId);
+        if (operationOwner) {
+          throw new DeliveryReservationConflictError("operation id is already reserved for another client message");
+        }
       }
       const conversation = file.conversations[canonicalId];
       const paths = new Set([conversation?.generations.at(-1)?.path].filter((pathname): pathname is string => Boolean(pathname)));

--- a/src/lib/agent/registry.ts
+++ b/src/lib/agent/registry.ts
@@ -966,6 +966,11 @@ function terminalDeliveryState(
   return delivery?.state === "delivered" || delivery?.state === "failed" ? delivery.state : null;
 }
 
+function syncDeliveryOperationOwnerState(file: RegistryFile, delivery: HeldDelivery): void {
+  const owner = file.deliveryOperationOwners[delivery.command.operationId];
+  if (owner?.deliveryId === delivery.id) owner.terminalState = terminalDeliveryState(delivery);
+}
+
 function normalizeDeliveryOperationOwners(
   value: unknown,
   heldDeliveries: RegistryFile["heldDeliveries"],
@@ -988,10 +993,16 @@ function normalizeDeliveryOperationOwners(
         && terminalDeliveryState(settledCandidate) !== null
         ? settledCandidate
         : null;
-      const referencedDelivery = heldDeliveries[owner.deliveryId];
-      const terminalState = owner.terminalState === "delivered" || owner.terminalState === "failed"
-        ? owner.terminalState
-        : terminalDeliveryState(settledDelivery) ?? terminalDeliveryState(referencedDelivery);
+      const referencedCandidate = heldDeliveries[owner.deliveryId];
+      const referencedDelivery = referencedCandidate?.command.operationId === operationId
+        && referencedCandidate.requestDigest === owner.requestDigest
+        ? referencedCandidate
+        : null;
+      const terminalState = referencedDelivery
+        ? terminalDeliveryState(referencedDelivery)
+        : owner.terminalState === "delivered" || owner.terminalState === "failed"
+          ? owner.terminalState
+          : terminalDeliveryState(settledDelivery);
       owners[operationId] = {
         conversationId: owner.conversationId as ViewerConversationId,
         runtimeConversationId: typeof owner.runtimeConversationId === "string" && owner.runtimeConversationId.startsWith("conversation_")
@@ -1048,7 +1059,7 @@ function compactDeliveryOperationOwners(file: RegistryFile, onlyConversationId?:
 function compactDeliveryReservations(file: RegistryFile, onlyConversationId?: ViewerConversationId): number {
   for (const delivery of Object.values(file.heldDeliveries)) {
     if (delivery.command.operationId === delivery.id || !delivery.requestDigest) continue;
-    const owner = file.deliveryOperationOwners[delivery.command.operationId] ??= {
+    file.deliveryOperationOwners[delivery.command.operationId] ??= {
       conversationId: delivery.conversationId,
       runtimeConversationId: delivery.runtimeConversationId,
       clientMessageId: delivery.clientMessageId,
@@ -1058,9 +1069,7 @@ function compactDeliveryReservations(file: RegistryFile, onlyConversationId?: Vi
       createdAt: delivery.createdAt,
       terminalState: null,
     };
-    if (owner.deliveryId === delivery.id && (delivery.state === "delivered" || delivery.state === "failed")) {
-      owner.terminalState = delivery.state;
-    }
+    syncDeliveryOperationOwnerState(file, delivery);
   }
   const deliveredGroups = new Map<ViewerConversationId, HeldDelivery[]>();
   const failedGroups = new Map<ViewerConversationId, HeldDelivery[]>();
@@ -3360,6 +3369,7 @@ export class AgentRegistry {
             delivery.generationId = source.id;
             delivery.assignedAt = changedAt;
             delivery.error = null;
+            syncDeliveryOperationOwnerState(file, delivery);
           }
         }
         conversation.migration = null;
@@ -3433,6 +3443,7 @@ export class AgentRegistry {
               delivery.generationId = source.id;
               delivery.assignedAt = changedAt;
               delivery.error = null;
+              syncDeliveryOperationOwnerState(file, delivery);
             }
             conversation.migration = null;
             conversation.updatedAt = changedAt;
@@ -3719,6 +3730,7 @@ export class AgentRegistry {
         delivery.generationId = generation.id;
         delivery.assignedAt = committedAt;
         delivery.error = null;
+        syncDeliveryOperationOwnerState(file, delivery);
       }
       file.conversationRevision[conversation.engine] += 1;
       file.engineRouting[conversation.engine].revision += 1;
@@ -3759,6 +3771,7 @@ export class AgentRegistry {
             delivery.generationId = source.id;
             delivery.assignedAt = intent.updatedAt;
             delivery.error = null;
+            syncDeliveryOperationOwnerState(file, delivery);
           }
         }
       }
@@ -3896,7 +3909,10 @@ export class AgentRegistry {
         && ["requested", "preparing", "successor-starting", "verifying"].includes(conversation.migration.phase);
       const current = conversation?.generations.at(-1);
       const place = (delivery: HeldDelivery): HeldDelivery => {
-        if (delivery.state === "delivered" || delivery.state === "delivery-uncertain") return clone(delivery);
+        if (delivery.state === "delivered" || delivery.state === "delivery-uncertain") {
+          syncDeliveryOperationOwnerState(file, delivery);
+          return clone(delivery);
+        }
         delivery.deliveredAt = null;
         delivery.error = null;
         if (migrationBlocksDelivery) {
@@ -3913,6 +3929,7 @@ export class AgentRegistry {
           delivery.assignedAt = null;
           delivery.error = "delivery target is unavailable and remains recoverable";
         }
+        syncDeliveryOperationOwnerState(file, delivery);
         if (conversation) advanceMigrationScopeRevision(file, conversation.engine, signature, paths);
         return clone(delivery);
       };
@@ -4023,6 +4040,7 @@ export class AgentRegistry {
       delivery.state = "delivery-uncertain";
       delivery.attempts += 1;
       delivery.error = "delivery started; recovery requires an explicit outcome";
+      syncDeliveryOperationOwnerState(file, delivery);
       if (conversation) advanceMigrationScopeRevision(file, conversation.engine, signature, paths);
       return clone(delivery);
     });
@@ -4118,6 +4136,7 @@ export class AgentRegistry {
         delivery.assignedAt = null;
         delivery.deliveredAt = null;
         delivery.error = null;
+        syncDeliveryOperationOwnerState(file, delivery);
         if (conversation) advanceMigrationScopeRevision(file, conversation.engine, signature, paths);
         return clone(delivery);
       }
@@ -4126,6 +4145,7 @@ export class AgentRegistry {
         delivery.state = "failed";
         delivery.deliveredAt = null;
         delivery.error = "delivery target is unavailable and remains recoverable";
+        syncDeliveryOperationOwnerState(file, delivery);
         if (conversation) advanceMigrationScopeRevision(file, conversation.engine, signature, paths);
         return clone(delivery);
       }
@@ -4134,6 +4154,7 @@ export class AgentRegistry {
       delivery.assignedAt = now();
       delivery.deliveredAt = null;
       delivery.error = null;
+      syncDeliveryOperationOwnerState(file, delivery);
       if (conversation) advanceMigrationScopeRevision(file, conversation.engine, signature, paths);
       return clone(delivery);
     });
@@ -4165,6 +4186,7 @@ export class AgentRegistry {
         delivery.generationId = source.id;
         delivery.assignedAt = rolledAt;
         delivery.error = null;
+        syncDeliveryOperationOwnerState(file, delivery);
       }
       conversation.migration = { ...conversation.migration, phase: "rolled-back", error: null, errorCode: null, updatedAt: rolledAt };
       conversation.updatedAt = rolledAt;

--- a/src/lib/agent/registry.ts
+++ b/src/lib/agent/registry.ts
@@ -231,6 +231,15 @@ export interface RegistryConversation {
   updatedAt: string;
 }
 
+export interface DeliveryOperationOwner {
+  conversationId: ViewerConversationId;
+  clientMessageId: string | null;
+  deliveryId: string;
+  command: HeldDeliveryCommand;
+  requestDigest: string;
+  settledDelivery?: HeldDelivery;
+}
+
 export interface RegistryFile {
   version: 2;
   entries: Record<string, AgentRegistryEntry>;
@@ -251,6 +260,7 @@ export interface RegistryFile {
   autoBalance: Record<Extract<AgentEngine, "claude" | "codex">, AutoBalancePolicy>;
   quotaObservations: Record<Extract<AgentEngine, "claude" | "codex">, Record<string, DurableQuotaObservation>>;
   heldDeliveries: Record<string, HeldDelivery>;
+  deliveryOperationOwners: Record<string, DeliveryOperationOwner>;
   pendingSuccessorCleanups: Record<string, { conversationId: ViewerConversationId; receipt: ProviderReceipt; createdAt: string; lastError: string | null }>;
 }
 
@@ -608,6 +618,7 @@ const EMPTY: RegistryFile = {
   autoBalance: { claude: emptyPolicy(), codex: emptyPolicy() },
   quotaObservations: { claude: {}, codex: {} },
   heldDeliveries: {},
+  deliveryOperationOwners: {},
   pendingSuccessorCleanups: {},
 };
 
@@ -944,7 +955,61 @@ function normalizeHeldDelivery(value: HeldDelivery): HeldDelivery {
   };
 }
 
+function normalizeDeliveryOperationOwners(
+  value: unknown,
+  heldDeliveries: RegistryFile["heldDeliveries"],
+): RegistryFile["deliveryOperationOwners"] {
+  const owners: RegistryFile["deliveryOperationOwners"] = {};
+  if (value && typeof value === "object" && !Array.isArray(value)) {
+    for (const [operationId, candidate] of Object.entries(value)) {
+      if (!operationId || !candidate || typeof candidate !== "object" || Array.isArray(candidate)) continue;
+      const owner = candidate as Partial<DeliveryOperationOwner>;
+      if (typeof owner.conversationId !== "string" || !owner.conversationId.startsWith("conversation_")
+        || (owner.clientMessageId !== null && typeof owner.clientMessageId !== "string")
+        || typeof owner.deliveryId !== "string" || !owner.deliveryId
+        || typeof owner.requestDigest !== "string" || !owner.requestDigest) continue;
+      owners[operationId] = {
+        conversationId: owner.conversationId as ViewerConversationId,
+        clientMessageId: owner.clientMessageId,
+        deliveryId: owner.deliveryId,
+        command: { ...canonicalHeldDeliveryCommand(owner.command, operationId), operationId },
+        requestDigest: owner.requestDigest,
+      };
+      if (owner.settledDelivery && typeof owner.settledDelivery === "object") {
+        const settledDelivery = normalizeHeldDelivery(owner.settledDelivery);
+        if (settledDelivery.id === owner.deliveryId
+          && settledDelivery.command.operationId === operationId
+          && settledDelivery.requestDigest === owner.requestDigest
+          && ["delivered", "failed"].includes(settledDelivery.state)) {
+          owners[operationId].settledDelivery = settledDelivery;
+        }
+      }
+    }
+  }
+  for (const delivery of Object.values(heldDeliveries)) {
+    if (delivery.command.operationId === delivery.id || !delivery.requestDigest) continue;
+    owners[delivery.command.operationId] ??= {
+      conversationId: delivery.conversationId,
+      clientMessageId: delivery.clientMessageId,
+      deliveryId: delivery.id,
+      command: delivery.command,
+      requestDigest: delivery.requestDigest,
+    };
+  }
+  return owners;
+}
+
 function compactDeliveryReservations(file: RegistryFile, onlyConversationId?: ViewerConversationId): number {
+  for (const delivery of Object.values(file.heldDeliveries)) {
+    if (delivery.command.operationId === delivery.id || !delivery.requestDigest) continue;
+    file.deliveryOperationOwners[delivery.command.operationId] ??= {
+      conversationId: delivery.conversationId,
+      clientMessageId: delivery.clientMessageId,
+      deliveryId: delivery.id,
+      command: delivery.command,
+      requestDigest: delivery.requestDigest,
+    };
+  }
   const deliveredGroups = new Map<ViewerConversationId, HeldDelivery[]>();
   const failedGroups = new Map<ViewerConversationId, HeldDelivery[]>();
   for (const delivery of Object.values(file.heldDeliveries)) {
@@ -962,9 +1027,14 @@ function compactDeliveryReservations(file: RegistryFile, onlyConversationId?: Vi
     }
   }
   let removed = 0;
+  const retainSettledOwner = (delivery: HeldDelivery): void => {
+    const owner = file.deliveryOperationOwners[delivery.command.operationId];
+    if (owner?.deliveryId === delivery.id) owner.settledDelivery = clone(delivery);
+  };
   for (const deliveries of deliveredGroups.values()) {
     deliveries.sort((left, right) => (right.deliveredAt ?? right.createdAt).localeCompare(left.deliveredAt ?? left.createdAt) || right.id.localeCompare(left.id));
     for (const expired of deliveries.slice(100)) {
+      retainSettledOwner(expired);
       delete file.heldDeliveries[expired.id];
       removed += 1;
     }
@@ -976,6 +1046,7 @@ function compactDeliveryReservations(file: RegistryFile, onlyConversationId?: Vi
     const retainedFailed = Math.max(0, Math.min(50, 99 - activeCount));
     deliveries.sort((left, right) => right.createdAt.localeCompare(left.createdAt) || right.id.localeCompare(left.id));
     for (const expired of deliveries.slice(retainedFailed)) {
+      retainSettledOwner(expired);
       delete file.heldDeliveries[expired.id];
       removed += 1;
     }
@@ -1021,6 +1092,7 @@ function conversationDurabilityScore(file: RegistryFile, conversation: RegistryC
   for (const edge of Object.values(file.lineageEdges)) if (edge.parentConversationId === conversation.id) score += 5;
   if (file.memberships[conversation.id]?.length) score += 10;
   for (const delivery of Object.values(file.heldDeliveries)) if (delivery.conversationId === conversation.id) score += 5;
+  for (const owner of Object.values(file.deliveryOperationOwners)) if (owner.conversationId === conversation.id) score += 5;
   return score;
 }
 
@@ -1189,6 +1261,12 @@ function adoptProvisionalOwner(
   for (const delivery of Object.values(file.heldDeliveries)) {
     if (delivery.conversationId === owner.id) delivery.conversationId = target.id;
   }
+  for (const operationOwner of Object.values(file.deliveryOperationOwners)) {
+    if (operationOwner.conversationId === owner.id) {
+      operationOwner.conversationId = target.id;
+      if (operationOwner.settledDelivery) operationOwner.settledDelivery.conversationId = target.id;
+    }
+  }
   for (const entry of Object.values(file.entries)) {
     if (entry.launchProfile?.parentConversationId === owner.id) {
       entry.launchProfile = { ...entry.launchProfile, parentConversationId: target.id };
@@ -1285,6 +1363,9 @@ export function normalizeRegistry(value: unknown): RegistryFile {
     throw new RegistryReadError("agent registry schema is unsupported");
   }
   const legacy = parsed.legacyResumePanes;
+  const heldDeliveries = parsed.heldDeliveries && typeof parsed.heldDeliveries === "object"
+    ? Object.fromEntries(Object.entries(parsed.heldDeliveries).map(([id, delivery]) => [id, normalizeHeldDelivery(delivery)]))
+    : {};
   return {
       version: 2,
       entries: Object.fromEntries(Object.entries(parsed.entries).map(([id, entry]) => [id, normalizeEntry(entry)])),
@@ -1317,9 +1398,8 @@ export function normalizeRegistry(value: unknown): RegistryFile {
       quotaObservations: parsed.quotaObservations && typeof parsed.quotaObservations === "object"
         ? { ...EMPTY.quotaObservations, ...parsed.quotaObservations }
         : clone(EMPTY.quotaObservations),
-      heldDeliveries: parsed.heldDeliveries && typeof parsed.heldDeliveries === "object"
-        ? Object.fromEntries(Object.entries(parsed.heldDeliveries).map(([id, delivery]) => [id, normalizeHeldDelivery(delivery)]))
-        : {},
+      heldDeliveries,
+      deliveryOperationOwners: normalizeDeliveryOperationOwners(parsed.deliveryOperationOwners, heldDeliveries),
       pendingSuccessorCleanups: parsed.pendingSuccessorCleanups && typeof parsed.pendingSuccessorCleanups === "object"
         ? parsed.pendingSuccessorCleanups
         : {},
@@ -3735,14 +3815,31 @@ export class AgentRegistry {
         && item.clientMessageId === clientMessageId) : undefined;
       const requestedCommand = canonicalHeldDeliveryCommand(commandInput, existing?.id ?? "pending-delivery");
       const requestDigest = heldDeliveryRequestDigest(canonicalId, text, requestedCommand);
-      if (existing && !heldDeliveryRequestDigests(file, canonicalId, text, requestedCommand).has(existing.requestDigest ?? "")) {
+      const requestedDigests = heldDeliveryRequestDigests(file, canonicalId, text, requestedCommand);
+      let settledOperationRetry: HeldDelivery | null = null;
+      if (existing && !requestedDigests.has(existing.requestDigest ?? "")) {
         throw new DeliveryReservationConflictError();
       }
       if (!existing && commandInput.operationId) {
-        const operationOwner = Object.values(file.heldDeliveries).find((item) =>
+        const ownedDelivery = Object.values(file.heldDeliveries).find((item) =>
           item.command.operationId === requestedCommand.operationId);
-        if (operationOwner) {
+        const operationOwner = file.deliveryOperationOwners[requestedCommand.operationId]
+          ?? (ownedDelivery?.requestDigest ? {
+            conversationId: ownedDelivery.conversationId,
+            clientMessageId: ownedDelivery.clientMessageId,
+            deliveryId: ownedDelivery.id,
+            command: ownedDelivery.command,
+            requestDigest: ownedDelivery.requestDigest,
+          } : null);
+        const matchingOwner = operationOwner
+          && resolveConversationAlias(file, operationOwner.conversationId) === canonicalId
+          && operationOwner.clientMessageId === clientMessageId
+          && requestedDigests.has(operationOwner.requestDigest);
+        if (operationOwner && !matchingOwner) {
           throw new DeliveryReservationConflictError("operation id is already reserved for another client message");
+        }
+        if (matchingOwner && operationOwner.settledDelivery) {
+          settledOperationRetry = clone(operationOwner.settledDelivery);
         }
       }
       const conversation = file.conversations[canonicalId];
@@ -3773,6 +3870,10 @@ export class AgentRegistry {
         return clone(delivery);
       };
       if (existing) return place(existing);
+      if (settledOperationRetry) {
+        file.heldDeliveries[settledOperationRetry.id] = settledOperationRetry;
+        return place(settledOperationRetry);
+      }
       const deliveryId = crypto.randomUUID();
       const held: HeldDelivery = {
         id: deliveryId,
@@ -3795,6 +3896,15 @@ export class AgentRegistry {
       const count = Object.values(file.heldDeliveries).filter((item) => item.conversationId === canonicalId && item.state !== "delivered").length;
       if (count >= 100) throw new Error("held delivery limit reached for conversation");
       file.heldDeliveries[held.id] = held;
+      if (commandInput.operationId) {
+        file.deliveryOperationOwners[held.command.operationId] ??= {
+          conversationId: canonicalId,
+          clientMessageId,
+          deliveryId: held.id,
+          command: held.command,
+          requestDigest: held.requestDigest!,
+        };
+      }
       return place(held);
     });
   }
@@ -3894,6 +4004,12 @@ export class AgentRegistry {
       const conversation = delivery ? file.conversations[resolveConversationAlias(file, delivery.conversationId)] : undefined;
       const paths = new Set([conversation?.generations.at(-1)?.path].filter((pathname): pathname is string => Boolean(pathname)));
       const signature = conversation ? migrationReadinessSignature(file, conversation.engine, paths) : "";
+      if (delivery) {
+        const operationOwner = file.deliveryOperationOwners[delivery.command.operationId];
+        if (delivery.attempts === 0 && operationOwner?.deliveryId === delivery.id) {
+          delete file.deliveryOperationOwners[delivery.command.operationId];
+        }
+      }
       delete file.heldDeliveries[id];
       if (conversation) advanceMigrationScopeRevision(file, conversation.engine, signature, paths);
     });

--- a/src/lib/agent/sqliteRegistryStore.ts
+++ b/src/lib/agent/sqliteRegistryStore.ts
@@ -15,6 +15,7 @@ const ROW_COLLECTIONS = [
   "conversationAliases",
   "migrationIntents",
   "heldDeliveries",
+  "deliveryOperationOwners",
   "pendingSuccessorCleanups",
 ] as const satisfies ReadonlyArray<keyof RegistryFile>;
 
@@ -222,10 +223,13 @@ export class SqliteAgentRegistryStore {
         }
         const input: Record<string, unknown> = { version: 2, entries: {}, receipts: {} };
         input[collection] = storedValue;
+        if (collection === "deliveryOperationOwners") input.heldDeliveries = file.heldDeliveries;
         value = this.normalize(input)[collection] as typeof value;
         loaded = true;
         loadedCollections.set(collection, value);
-        baselineCollections.set(collection, structuredClone(value));
+        baselineCollections.set(collection, structuredClone(
+          collection === "deliveryOperationOwners" ? storedValue : value,
+        ) as typeof value);
       };
       Object.defineProperty(file, collection, {
         configurable: true,

--- a/src/lib/runtime/startup.test.ts
+++ b/src/lib/runtime/startup.test.ts
@@ -4,15 +4,18 @@ import path from "node:path";
 import { expect, test } from "bun:test";
 
 import { emptyLaunchProfile } from "@/lib/accounts/migration/contracts";
+import { drainHeldDeliveries } from "@/lib/accounts/migration/coordinator";
 import { AgentRegistry } from "@/lib/agent/registry";
 import { RuntimeJournal } from "@/runtime-host/journal";
+import { runStructuredHostStartup } from "@/instrumentation";
 
-import type { RuntimeHostClient } from "./client";
-import { bindStructuredDeliveryQueue } from "./structuredDeliveryController";
+import { RuntimeHostUnavailableError, type RuntimeHostClient } from "./client";
+import { bindStructuredDeliveryQueue, hasStructuredDeliveryHost } from "./structuredDeliveryController";
 import { createFakeDeliveryLedger, FakeEngineHost } from "./fixtures/fakeEngineHost";
 import type { StructuredHostAdoptionFilter } from "./registry";
-import { enqueueStructuredMessage } from "./structuredMessageDelivery";
-import { adoptStructuredHostsAtStartup, type StructuredStartupDependencies } from "./startup";
+import { deliverHeldStructuredMessage, enqueueStructuredMessage } from "./structuredMessageDelivery";
+import { didStructuredHostStartupFail } from "./startupStatus";
+import { adoptStructuredHostsAtStartup, structuredStartupHosts, type StructuredStartupDependencies } from "./startup";
 
 function runtimeClient(journal: RuntimeJournal): RuntimeHostClient {
   return {
@@ -357,6 +360,127 @@ test.each(["codex", "claude"] as const)("successful %s restart adoption publishe
   await bindStructuredDeliveryQueue([], { registry, client: null });
   journal.close();
   fs.rmSync(directory, { recursive: true, force: true });
+});
+
+test("startup socket recovery retains a partially adopted host and drains its held send once", async () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-runtime-startup-partial-adoption-"));
+  const { conversation, registry, sessionId } = structuredRestartFixture(directory, "codex", "unhosted");
+  const journal = new RuntimeJournal(path.join(directory, "runtime.sqlite"), { structuredHosts: true });
+  const client = runtimeJournalClient(journal);
+  const key = { engine: "codex" as const, sessionId };
+  const operationId = "operation-partial-adoption-held-send";
+  const held = registry.holdDelivery(
+    conversation.id,
+    "deliver after partial startup adoption",
+    "partial-adoption-held-send",
+    "text",
+    [],
+    null,
+    { operationId, kind: "send", policy: "queue", turnId: null },
+  );
+  const ledger = createFakeDeliveryLedger();
+  const listeners = new Set<() => void>();
+  const host = Object.assign(new FakeEngineHost(ledger), {
+    onStateChange: () => {
+      const listener = () => {};
+      listeners.add(listener);
+      return () => { listeners.delete(listener); };
+    },
+  });
+  const scheduled: Array<() => void> = [];
+  let adoptedProcesses = 0;
+  let effectCalls = 0;
+  const startupClient = {
+    ...client,
+    producerCursor: async (producerKind: string, eventKeyPrefix: string) =>
+      journal.producerCursor(producerKind, eventKeyPrefix),
+    effectBatch: async (kinds?: readonly string[], afterEventSeq?: number) => {
+      effectCalls += 1;
+      if (effectCalls === 2) {
+        throw new RuntimeHostUnavailableError("runtime socket failed after host adoption");
+      }
+      return journal.effectBatch(100, kinds, afterEventSeq);
+    },
+  } as RuntimeHostClient;
+  const dependencies: StructuredStartupDependencies = {
+    registry,
+    client: startupClient,
+    adopt: async (received, _optionsFor, _env, shouldAdopt = () => true) => {
+      const entry = received.snapshot().entries[`codex:${sessionId}`];
+      if (!entry || !shouldAdopt(entry) || adoptedProcesses > 0) return [];
+      const processIdentity = { pid: process.pid, startIdentity: "partial-adoption-process" };
+      const claimed = received.claimStructuredHost(key, processIdentity, { allowUnhosted: true });
+      if (!claimed?.structuredHost || !claimed.claimOwner) throw new Error("partial adoption claim was unavailable");
+      const persisted = received.setStructuredHostClaimed(key, {
+        ...claimed.structuredHost,
+        endpoint: "fake:partial-adoption",
+        process: processIdentity,
+      }, "idle", claimed.claimOwner, claimed.claimEpoch);
+      if (!persisted) throw new Error("partial adoption writer claim was lost");
+      adoptedProcesses += 1;
+      return [{ key, host: host as never }];
+    },
+    adoptClaude: async () => [],
+  };
+
+  try {
+    await runStructuredHostStartup(
+      () => adoptStructuredHostsAtStartup(dependencies),
+      () => {},
+      {
+        schedule: (callback) => {
+          scheduled.push(callback);
+          return { unref() {} };
+        },
+      },
+    );
+
+    expect(adoptedProcesses).toBe(1);
+    expect(scheduled).toHaveLength(1);
+    scheduled.shift()!();
+    await waitFor(() => !didStructuredHostStartupFail());
+    expect(hasStructuredDeliveryHost(key)).toBe(true);
+
+    await drainHeldDeliveries(conversation.id, {
+      deliver: async ({ delivery, path: deliveryPath, clientMessageId }) =>
+        await deliverHeldStructuredMessage({
+          conversationId: conversation.id,
+          path: deliveryPath,
+          deliveryId: delivery.id,
+          clientMessageId,
+          text: delivery.text,
+          command: delivery.command,
+        }, {
+          enabled: () => true,
+          client: () => startupClient,
+          registry: () => registry,
+        }) ?? "delivery-uncertain",
+    }, registry);
+    await drainHeldDeliveries(conversation.id, {
+      deliver: async () => { throw new Error("delivered hold must not drain twice"); },
+    }, registry);
+
+    expect(structuredStartupHosts()).toMatchObject([{ key, host }]);
+    expect(ledger.writes).toEqual([expect.objectContaining({
+      id: operationId,
+      text: "deliver after partial startup adoption",
+      expectedTurnId: null,
+    })]);
+    expect(registry.snapshot().heldDeliveries[held.id]).toMatchObject({ state: "delivered", text: "" });
+    expect(listeners.size).toBe(1);
+    expect(adoptedProcesses).toBe(1);
+    expect(registry.snapshot().entries[`codex:${sessionId}`]).toMatchObject({
+      claimOwner: expect.any(String),
+      structuredHost: {
+        process: { pid: process.pid, startIdentity: "partial-adoption-process" },
+        writerClaimEpoch: expect.any(Number),
+      },
+    });
+  } finally {
+    await bindStructuredDeliveryQueue([], { registry, client: null });
+    journal.close();
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
 });
 
 test("terminal structured row with a cleared ownership marker stays outside startup adoption", async () => {

--- a/src/lib/runtime/startup.test.ts
+++ b/src/lib/runtime/startup.test.ts
@@ -4,15 +4,18 @@ import path from "node:path";
 import { expect, test } from "bun:test";
 
 import { emptyLaunchProfile } from "@/lib/accounts/migration/contracts";
+import { drainHeldDeliveries } from "@/lib/accounts/migration/coordinator";
 import { AgentRegistry } from "@/lib/agent/registry";
 import { RuntimeJournal } from "@/runtime-host/journal";
+import { runStructuredHostStartup } from "@/instrumentation";
 
-import type { RuntimeHostClient } from "./client";
-import { bindStructuredDeliveryQueue } from "./structuredDeliveryController";
+import { RuntimeHostUnavailableError, type RuntimeHostClient } from "./client";
+import { bindStructuredDeliveryQueue, hasStructuredDeliveryHost } from "./structuredDeliveryController";
 import { createFakeDeliveryLedger, FakeEngineHost } from "./fixtures/fakeEngineHost";
 import type { StructuredHostAdoptionFilter } from "./registry";
-import { enqueueStructuredMessage } from "./structuredMessageDelivery";
-import { adoptStructuredHostsAtStartup, type StructuredStartupDependencies } from "./startup";
+import { deliverHeldStructuredMessage, enqueueStructuredMessage } from "./structuredMessageDelivery";
+import { didStructuredHostStartupFail } from "./startupStatus";
+import { adoptStructuredHostsAtStartup, structuredStartupHosts, type StructuredStartupDependencies } from "./startup";
 
 function runtimeClient(journal: RuntimeJournal): RuntimeHostClient {
   return {
@@ -357,6 +360,125 @@ test.each(["codex", "claude"] as const)("successful %s restart adoption publishe
   await bindStructuredDeliveryQueue([], { registry, client: null });
   journal.close();
   fs.rmSync(directory, { recursive: true, force: true });
+});
+
+test("startup socket recovery retains a partially adopted host and drains its held send once", async () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-runtime-startup-partial-adoption-"));
+  const { artifactPath, conversation, registry, sessionId } = structuredRestartFixture(directory, "codex", "unhosted");
+  const journal = new RuntimeJournal(path.join(directory, "runtime.sqlite"), { structuredHosts: true });
+  const client = runtimeJournalClient(journal);
+  const key = { engine: "codex" as const, sessionId };
+  const operationId = "operation-partial-adoption-held-send";
+  const held = registry.holdDelivery(
+    conversation.id,
+    "deliver after partial startup adoption",
+    "partial-adoption-held-send",
+    "text",
+    { operationId, kind: "send", policy: "queue", turnId: null },
+  );
+  const ledger = createFakeDeliveryLedger();
+  const listeners = new Set<() => void>();
+  const host = Object.assign(new FakeEngineHost(ledger), {
+    onStateChange: () => {
+      const listener = () => {};
+      listeners.add(listener);
+      return () => { listeners.delete(listener); };
+    },
+  });
+  const scheduled: Array<() => void> = [];
+  let adoptedProcesses = 0;
+  let effectCalls = 0;
+  const startupClient = {
+    ...client,
+    producerCursor: async (producerKind: string, eventKeyPrefix: string) =>
+      journal.producerCursor(producerKind, eventKeyPrefix),
+    effectBatch: async (kinds?: readonly string[], afterEventSeq?: number) => {
+      effectCalls += 1;
+      if (effectCalls === 2) {
+        throw new RuntimeHostUnavailableError("runtime socket failed after host adoption");
+      }
+      return journal.effectBatch(100, kinds, afterEventSeq);
+    },
+  } as RuntimeHostClient;
+  const dependencies: StructuredStartupDependencies = {
+    registry,
+    client: startupClient,
+    adopt: async (received, _optionsFor, _env, shouldAdopt = () => true) => {
+      const entry = received.snapshot().entries[`codex:${sessionId}`];
+      if (!entry || !shouldAdopt(entry) || adoptedProcesses > 0) return [];
+      const processIdentity = { pid: process.pid, startIdentity: "partial-adoption-process" };
+      const claimed = received.claimStructuredHost(key, processIdentity, { allowUnhosted: true });
+      if (!claimed?.structuredHost || !claimed.claimOwner) throw new Error("partial adoption claim was unavailable");
+      const persisted = received.setStructuredHostClaimed(key, {
+        ...claimed.structuredHost,
+        endpoint: "fake:partial-adoption",
+        process: processIdentity,
+      }, "idle", claimed.claimOwner, claimed.claimEpoch);
+      if (!persisted) throw new Error("partial adoption writer claim was lost");
+      adoptedProcesses += 1;
+      return [{ key, host: host as never }];
+    },
+    adoptClaude: async () => [],
+  };
+
+  try {
+    await runStructuredHostStartup(
+      () => adoptStructuredHostsAtStartup(dependencies),
+      () => {},
+      {
+        schedule: (callback) => {
+          scheduled.push(callback);
+          return { unref() {} };
+        },
+      },
+    );
+
+    expect(adoptedProcesses).toBe(1);
+    expect(scheduled).toHaveLength(1);
+    scheduled.shift()!();
+    await waitFor(() => !didStructuredHostStartupFail());
+    expect(hasStructuredDeliveryHost(key)).toBe(true);
+
+    await drainHeldDeliveries(conversation.id, {
+      deliver: async ({ delivery, path: deliveryPath, clientMessageId }) =>
+        await deliverHeldStructuredMessage({
+          conversationId: conversation.id,
+          path: deliveryPath,
+          deliveryId: delivery.id,
+          clientMessageId,
+          text: delivery.text,
+          command: delivery.command,
+        }, {
+          enabled: () => true,
+          client: () => startupClient,
+          registry: () => registry,
+        }) ?? "delivery-uncertain",
+    }, registry);
+    await drainHeldDeliveries(conversation.id, {
+      deliver: async () => { throw new Error("delivered hold must not drain twice"); },
+    }, registry);
+
+    expect(structuredStartupHosts()).toMatchObject([{ key, host }]);
+    expect(ledger.writes).toEqual([{
+      id: operationId,
+      text: "deliver after partial startup adoption",
+      expectedTurnId: null,
+    }]);
+    expect(registry.snapshot().heldDeliveries[held.id]).toMatchObject({ state: "delivered", text: "" });
+    expect(listeners.size).toBe(1);
+    expect(adoptedProcesses).toBe(1);
+    expect(registry.snapshot().entries[`codex:${sessionId}`]).toMatchObject({
+      claimOwner: expect.any(String),
+      structuredHost: {
+        process: { pid: process.pid, startIdentity: "partial-adoption-process" },
+        writerClaimEpoch: expect.any(Number),
+      },
+    });
+  } finally {
+    await bindStructuredDeliveryQueue([], { registry, client: null });
+    journal.close();
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
 });
 
 test("terminal structured row with a cleared ownership marker stays outside startup adoption", async () => {

--- a/src/lib/runtime/startup.test.ts
+++ b/src/lib/runtime/startup.test.ts
@@ -364,7 +364,7 @@ test.each(["codex", "claude"] as const)("successful %s restart adoption publishe
 
 test("startup socket recovery retains a partially adopted host and drains its held send once", async () => {
   const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-runtime-startup-partial-adoption-"));
-  const { artifactPath, conversation, registry, sessionId } = structuredRestartFixture(directory, "codex", "unhosted");
+  const { conversation, registry, sessionId } = structuredRestartFixture(directory, "codex", "unhosted");
   const journal = new RuntimeJournal(path.join(directory, "runtime.sqlite"), { structuredHosts: true });
   const client = runtimeJournalClient(journal);
   const key = { engine: "codex" as const, sessionId };

--- a/src/lib/runtime/startup.ts
+++ b/src/lib/runtime/startup.ts
@@ -20,6 +20,19 @@ import { recoverPendingStructuredSpawns } from "./structuredSpawn";
 
 type AdoptedStructuredHost = AdoptedCodexHost | AdoptedClaudeHost;
 let adoptedHosts: AdoptedStructuredHost[] = [];
+let retryAdoptedHosts: AdoptedStructuredHost[] = [];
+
+function retainAdoptedHosts(
+  retained: readonly AdoptedStructuredHost[],
+  adopted: readonly AdoptedStructuredHost[],
+): AdoptedStructuredHost[] {
+  const hosts = new Map(retained.map((item) => [sessionKeyId(item.key), item]));
+  for (const item of adopted) {
+    const key = sessionKeyId(item.key);
+    if (!hosts.has(key)) hosts.set(key, item);
+  }
+  return [...hosts.values()];
+}
 
 const RUNTIME_EFFECT_PAGE_SIZE = 100;
 const STRUCTURED_HOST_OPERATION_EFFECT_KINDS = [
@@ -133,6 +146,7 @@ export async function adoptStructuredHostsAtStartup(
   dependencies: StructuredStartupDependencies = {},
 ): Promise<AdoptedStructuredHost[]> {
   assertDarwinStructuredRuntime();
+  let nextAdoptedHosts = retryAdoptedHosts;
   const registry = dependencies.registry ?? agentRegistry();
   const client = dependencies.client === undefined ? runtimeHostClient() : dependencies.client;
   const signals = await structuredStartupSignals(registry, client);
@@ -158,6 +172,8 @@ export async function adoptStructuredHostsAtStartup(
     process.env,
     shouldAdopt,
   );
+  nextAdoptedHosts = retainAdoptedHosts(nextAdoptedHosts, codex);
+  retryAdoptedHosts = nextAdoptedHosts;
   const claude = await (dependencies.adoptClaude ?? adoptClaudeRegistryHosts)(
     registry,
     (entry) => {
@@ -181,10 +197,13 @@ export async function adoptStructuredHostsAtStartup(
     process.env,
     shouldAdopt,
   );
-  adoptedHosts = [...codex, ...claude];
+  nextAdoptedHosts = retainAdoptedHosts(nextAdoptedHosts, claude);
+  retryAdoptedHosts = nextAdoptedHosts;
   await demoteSkippedStructuredRegistryHosts(registry, shouldAdopt);
-  await bindStructuredDeliveryQueue(adoptedHosts, { registry: dependencies.registry, client });
+  await bindStructuredDeliveryQueue(nextAdoptedHosts, { registry: dependencies.registry, client });
   if (client) await recoverPendingStructuredSpawns(registry, client);
+  adoptedHosts = nextAdoptedHosts;
+  retryAdoptedHosts = [];
   return adoptedHosts;
 }
 

--- a/src/lib/runtime/structuredDelivery.integration.test.ts
+++ b/src/lib/runtime/structuredDelivery.integration.test.ts
@@ -1277,6 +1277,335 @@ test("queue binding settles a rejected journal receipt as a recoverable failure"
   await bindStructuredDeliveryQueue([], { registry, client: null });
 });
 
+test("terminal operation replay survives registry and runtime journal compaction", async () => {
+  const sessionId = "dddddddd-dddd-4ddd-8ddd-dddddddddddd";
+  const directory = path.join(sandbox, "durable-operation-ownership");
+  const artifactPath = path.join(directory, `${sessionId}.jsonl`);
+  const registry = new AgentRegistry(path.join(directory, "agent-registry.json"));
+  const profile = emptyLaunchProfile({ cwd: directory });
+  registry.reconcileConversations([{
+    engine: "codex",
+    path: artifactPath,
+    accountId: "default",
+    launchProfile: profile,
+    turn: { state: "idle", source: "empty", terminalAt: null },
+    observedAt: "2026-07-17T00:00:00.000Z",
+  }]);
+  const conversation = registry.conversationForPath(artifactPath)!;
+  registry.upsert({
+    key: { engine: "codex", sessionId },
+    artifactPath,
+    cwd: directory,
+    accountId: "default",
+    launchProfile: profile,
+    status: "idle",
+    host: null,
+    structuredHost: {
+      kind: "codex-app-server",
+      endpoint: "fake:operation-owner",
+      process: null,
+      eventCursor: 0,
+      protocolVersion: "v2",
+      writerClaimEpoch: 4,
+      activeTurnRef: null,
+      pendingAttention: [],
+      activeFlags: [],
+    },
+    claimEpoch: 4,
+    claimOwner: null,
+    pendingAction: null,
+  });
+  const runtimeFilename = path.join(directory, "runtime.sqlite");
+  let journal = new RuntimeJournal(runtimeFilename, { structuredHosts: true });
+  journal.append({
+    scope: { type: "session", id: conversation.id },
+    kind: "session-status",
+    payload: {
+      conversationId: conversation.id,
+      sessionKey: { engine: "codex", sessionId },
+      hostKind: "codex-app-server",
+      host: "hosted",
+      turn: "idle",
+      provenance: "structured",
+      artifactPath,
+      capabilities: { steer: true, structuredAttention: true },
+    },
+  });
+  const client = runtimeJournalClient(journal);
+  const ledger = createFakeDeliveryLedger();
+  await bindStructuredDeliveryQueue([{
+    key: { engine: "codex", sessionId },
+    host: observableFakeHost(new FakeEngineHost(ledger)),
+  }], { registry, client });
+  const original = {
+    path: artifactPath,
+    conversationId: conversation.id,
+    clientMessageId: "operation-owner-client-one",
+    operationId: "operation-owned-by-client-one",
+    kind: "send" as const,
+    policy: "queue" as const,
+    turnId: null,
+    text: "actuate this command once",
+    hasImages: false,
+  };
+
+  try {
+    expect(await enqueueStructuredMessage(original, {
+      enabled: () => true,
+      client: () => client,
+      registry: () => registry,
+      kick: () => {},
+    })).toMatchObject({ ok: true, structured: true, outcome: "queued" });
+    await kickStructuredDeliveryQueue();
+    expect(ledger.writes).toEqual([expect.objectContaining({
+      id: original.operationId,
+      text: original.text,
+      expectedTurnId: original.turnId,
+    })]);
+
+    expect(await enqueueStructuredMessage({
+      ...original,
+      clientMessageId: "operation-owner-client-two",
+    }, {
+      enabled: () => true,
+      client: () => client,
+      registry: () => registry,
+      kick: () => {},
+    })).toMatchObject({
+      ok: false,
+      structured: true,
+      outcome: "failed",
+      status: 409,
+    });
+
+    expect(await enqueueStructuredMessage(original, {
+      enabled: () => true,
+      client: () => client,
+      registry: () => registry,
+      kick: () => {},
+    })).toMatchObject({ ok: true, structured: true, outcome: "delivered" });
+    expect(ledger.writes).toHaveLength(1);
+
+    for (let index = 0; index < 101; index += 1) {
+      const later = registry.holdDelivery(
+        conversation.id,
+        `later terminal delivery ${index}`,
+        `later-terminal-delivery-${index}`,
+      );
+      registry.recordDeliveryOutcome(later.id, "delivered");
+    }
+    expect(Object.values(registry.snapshot().heldDeliveries)
+      .some((delivery) => delivery.command.operationId === original.operationId)).toBeFalse();
+    journal.append({ scope: { type: "system", id: "runtime" }, kind: "files.revision", payload: { filesRevision: 1 } });
+    journal.append({ scope: { type: "system", id: "runtime" }, kind: "files.revision", payload: { filesRevision: 2 } });
+    journal.compact(1);
+    expect(journal.operationResult(original.operationId)).toBeNull();
+    expect(journal.effectBatch()).toEqual([]);
+    journal.close();
+
+    const reopened = new AgentRegistry(registry.filename);
+    journal = new RuntimeJournal(runtimeFilename, { structuredHosts: true });
+    const restartedClient = runtimeJournalClient(journal);
+    expect(await enqueueStructuredMessage(original, {
+      enabled: () => true,
+      client: () => restartedClient,
+      registry: () => reopened,
+      kick: () => {},
+    })).toMatchObject({
+      ok: true,
+      structured: true,
+      outcome: "delivered",
+      operationId: original.operationId,
+      receipt: { status: "delivered" },
+    });
+    expect(await enqueueStructuredMessage({ ...original, text: "changed after compaction" }, {
+      enabled: () => true,
+      client: () => restartedClient,
+      registry: () => reopened,
+      kick: () => {},
+    })).toMatchObject({ ok: false, structured: true, outcome: "failed", status: 409 });
+    expect(reopened.pendingDeliveries(conversation.id)).toEqual([]);
+    expect(journal.effectBatch()).toEqual([]);
+    expect(ledger.writes).toHaveLength(1);
+  } finally {
+    await bindStructuredDeliveryQueue([], { registry, client: null });
+    journal.close();
+  }
+});
+
+test("provisional adoption preserves runtime idempotency across Codex and Claude", async () => {
+  const scenarios = [
+    {
+      engine: "codex" as const,
+      hostKind: "codex-app-server" as const,
+      sessionId: "eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee",
+    },
+    {
+      engine: "claude" as const,
+      hostKind: "claude-broker" as const,
+      sessionId: "ffffffff-ffff-4fff-8fff-ffffffffffff",
+    },
+  ];
+
+  for (const scenario of scenarios) {
+    const directory = path.join(sandbox, `provisional-operation-owner-${scenario.engine}`);
+    fs.mkdirSync(directory, { recursive: true });
+    const sourcePath = path.join(directory, `source-${scenario.engine}.jsonl`);
+    const targetPath = path.join(directory, `${scenario.sessionId}.jsonl`);
+    const registry = new AgentRegistry(path.join(directory, "agent-registry.json"));
+    const profile = emptyLaunchProfile({ cwd: directory });
+    const canonical = registry.ensureConversation(scenario.engine, sourcePath, "source");
+    registry.reconcileConversations([{
+      engine: scenario.engine,
+      path: targetPath,
+      accountId: "target",
+      launchProfile: profile,
+      turn: { state: "idle", source: "empty", terminalAt: null },
+      observedAt: "2026-07-17T01:00:00.000Z",
+    }]);
+    const provisional = registry.conversationForPath(targetPath)!;
+    const structuredHost = {
+      kind: scenario.hostKind,
+      endpoint: `fake:provisional-${scenario.engine}`,
+      process: null,
+      eventCursor: 0,
+      protocolVersion: "v2",
+      writerClaimEpoch: 5,
+      activeTurnRef: null,
+      pendingAttention: [],
+      activeFlags: [],
+    };
+    registry.upsert({
+      key: { engine: scenario.engine, sessionId: scenario.sessionId },
+      artifactPath: targetPath,
+      cwd: directory,
+      accountId: "target",
+      launchProfile: profile,
+      status: "idle",
+      host: null,
+      structuredHost,
+      claimEpoch: 5,
+      claimOwner: null,
+      pendingAction: null,
+    });
+    const journal = new RuntimeJournal(path.join(directory, "runtime.sqlite"), { structuredHosts: true });
+    journal.append({
+      scope: { type: "session", id: provisional.id },
+      kind: "session-status",
+      payload: {
+        conversationId: provisional.id,
+        sessionKey: { engine: scenario.engine, sessionId: scenario.sessionId },
+        hostKind: scenario.hostKind,
+        host: "hosted",
+        turn: "idle",
+        provenance: "structured",
+        artifactPath: targetPath,
+        capabilities: { steer: scenario.engine === "codex", structuredAttention: true },
+      },
+    });
+    const client = runtimeJournalClient(journal);
+    const ledger = createFakeDeliveryLedger();
+    await bindStructuredDeliveryQueue([{
+      key: { engine: scenario.engine, sessionId: scenario.sessionId },
+      host: observableFakeHost(new FakeEngineHost(ledger)),
+    }], { registry, client });
+    const request = {
+      path: targetPath,
+      conversationId: provisional.id,
+      clientMessageId: `provisional-client-${scenario.engine}`,
+      operationId: `provisional-operation-${scenario.engine}`,
+      kind: "send" as const,
+      policy: "queue" as const,
+      turnId: null,
+      text: `deliver once through ${scenario.engine} adoption`,
+      hasImages: false,
+    };
+
+    try {
+      expect(await enqueueStructuredMessage(request, {
+        enabled: () => true,
+        client: () => client,
+        registry: () => registry,
+        kick: () => {},
+      })).toMatchObject({ ok: true, structured: true, outcome: "queued" });
+      expect(journal.effectBatch()).toHaveLength(1);
+
+      const migration = registry.beginSpawnRequest({
+        engine: scenario.engine,
+        cwd: directory,
+        accountId: "target",
+        conversationId: canonical.id,
+        purpose: "launch",
+        expectedArtifactPath: targetPath,
+      });
+      if (migration.kind !== "created") throw new Error("expected migration successor receipt");
+      expect(registry.settleSpawn(migration.receipt.launchId, {
+        key: { engine: scenario.engine, sessionId: scenario.sessionId },
+        artifactPath: targetPath,
+        cwd: directory,
+        accountId: "target",
+        launchProfile: profile,
+        status: "idle",
+        host: null,
+        structuredHost,
+        claimEpoch: 5,
+        claimOwner: null,
+        pendingAction: null,
+      })).toMatchObject({ kind: "settled", conversation: { id: canonical.id } });
+      expect(registry.canonicalConversationId(provisional.id)).toBe(canonical.id);
+
+      const unrelated = registry.ensureConversation(
+        scenario.engine,
+        path.join(directory, `unrelated-${scenario.engine}.jsonl`),
+        "target",
+      );
+      expect(() => registry.holdDelivery(
+        unrelated.id,
+        request.text,
+        request.clientMessageId,
+        "text",
+        [],
+        null,
+        {
+          operationId: request.operationId,
+          kind: request.kind,
+          policy: request.policy,
+          turnId: request.turnId,
+        },
+      )).toThrow("operation id is already reserved for another client message");
+
+      expect(await enqueueStructuredMessage(request, {
+        enabled: () => true,
+        client: () => client,
+        registry: () => registry,
+        kick: () => {},
+      })).toMatchObject({
+        ok: true,
+        structured: true,
+        outcome: "queued",
+        operationId: request.operationId,
+      });
+      expect(await enqueueStructuredMessage({ ...request, text: `${request.text} changed` }, {
+        enabled: () => true,
+        client: () => client,
+        registry: () => registry,
+        kick: () => {},
+      })).toMatchObject({ ok: false, structured: true, outcome: "failed", status: 409 });
+
+      await kickStructuredDeliveryQueue();
+      expect(ledger.writes).toEqual([expect.objectContaining({
+        id: request.operationId,
+        text: request.text,
+        expectedTurnId: request.turnId,
+      })]);
+      expect(journal.effectBatch()).toEqual([]);
+    } finally {
+      await bindStructuredDeliveryQueue([], { registry, client: null });
+      journal.close();
+    }
+  }
+});
+
 test("a stale synchronization-held steer fails safely across Codex and Claude recovery", async () => {
   const cases = [
     {

--- a/src/lib/runtime/structuredDelivery.integration.test.ts
+++ b/src/lib/runtime/structuredDelivery.integration.test.ts
@@ -1044,7 +1044,7 @@ test("runtime recovery drains one durable synchronization hold into one engine c
   journal.close();
 });
 
-test("explicit operation ownership rejects a second client and recovers without an uncertain tombstone", async () => {
+test("terminal operation replay survives registry and runtime journal compaction", async () => {
   const sessionId = "dddddddd-dddd-4ddd-8ddd-dddddddddddd";
   const directory = path.join(sandbox, "durable-operation-ownership");
   const artifactPath = path.join(directory, `${sessionId}.jsonl`);
@@ -1082,7 +1082,8 @@ test("explicit operation ownership rejects a second client and recovers without 
     claimOwner: null,
     pendingAction: null,
   });
-  const journal = new RuntimeJournal(path.join(directory, "runtime.sqlite"), { structuredHosts: true });
+  const runtimeFilename = path.join(directory, "runtime.sqlite");
+  let journal = new RuntimeJournal(runtimeFilename, { structuredHosts: true });
   journal.append({
     scope: { type: "session", id: conversation.id },
     kind: "session-status",
@@ -1152,20 +1153,47 @@ test("explicit operation ownership rejects a second client and recovers without 
     })).toMatchObject({ ok: true, structured: true, outcome: "delivered" });
     expect(ledger.writes).toHaveLength(1);
 
-    const reopened = new AgentRegistry(registry.filename);
-    expect(reopened.pendingDeliveries(conversation.id)).toEqual([]);
-    expect(Object.values(reopened.snapshot().heldDeliveries)).toMatchObject([{
-      clientMessageId: original.clientMessageId,
-      command: {
-        operationId: original.operationId,
-        kind: original.kind,
-        policy: original.policy,
-        turnId: original.turnId,
-      },
-      state: "delivered",
-      text: "",
-    }]);
+    for (let index = 0; index < 101; index += 1) {
+      const later = registry.holdDelivery(
+        conversation.id,
+        `later terminal delivery ${index}`,
+        `later-terminal-delivery-${index}`,
+      );
+      registry.recordDeliveryOutcome(later.id, "delivered");
+    }
+    expect(Object.values(registry.snapshot().heldDeliveries)
+      .some((delivery) => delivery.command.operationId === original.operationId)).toBeFalse();
+    journal.append({ scope: { type: "system", id: "runtime" }, kind: "files.revision", payload: { filesRevision: 1 } });
+    journal.append({ scope: { type: "system", id: "runtime" }, kind: "files.revision", payload: { filesRevision: 2 } });
+    journal.compact(1);
+    expect(journal.operationResult(original.operationId)).toBeNull();
     expect(journal.effectBatch()).toEqual([]);
+    journal.close();
+
+    const reopened = new AgentRegistry(registry.filename);
+    journal = new RuntimeJournal(runtimeFilename, { structuredHosts: true });
+    const restartedClient = runtimeJournalClient(journal);
+    expect(await enqueueStructuredMessage(original, {
+      enabled: () => true,
+      client: () => restartedClient,
+      registry: () => reopened,
+      kick: () => {},
+    })).toMatchObject({
+      ok: true,
+      structured: true,
+      outcome: "delivered",
+      operationId: original.operationId,
+      receipt: { status: "delivered" },
+    });
+    expect(await enqueueStructuredMessage({ ...original, text: "changed after compaction" }, {
+      enabled: () => true,
+      client: () => restartedClient,
+      registry: () => reopened,
+      kick: () => {},
+    })).toMatchObject({ ok: false, structured: true, outcome: "failed", status: 409 });
+    expect(reopened.pendingDeliveries(conversation.id)).toEqual([]);
+    expect(journal.effectBatch()).toEqual([]);
+    expect(ledger.writes).toHaveLength(1);
   } finally {
     await bindStructuredDeliveryQueue([], { registry, client: null });
     journal.close();

--- a/src/lib/runtime/structuredDelivery.integration.test.ts
+++ b/src/lib/runtime/structuredDelivery.integration.test.ts
@@ -1044,6 +1044,134 @@ test("runtime recovery drains one durable synchronization hold into one engine c
   journal.close();
 });
 
+test("explicit operation ownership rejects a second client and recovers without an uncertain tombstone", async () => {
+  const sessionId = "dddddddd-dddd-4ddd-8ddd-dddddddddddd";
+  const directory = path.join(sandbox, "durable-operation-ownership");
+  const artifactPath = path.join(directory, `${sessionId}.jsonl`);
+  const registry = new AgentRegistry(path.join(directory, "agent-registry.json"));
+  const profile = emptyLaunchProfile({ cwd: directory });
+  registry.reconcileConversations([{
+    engine: "codex",
+    path: artifactPath,
+    accountId: "default",
+    launchProfile: profile,
+    turn: { state: "idle", source: "empty", terminalAt: null },
+    observedAt: "2026-07-17T00:00:00.000Z",
+  }]);
+  const conversation = registry.conversationForPath(artifactPath)!;
+  registry.upsert({
+    key: { engine: "codex", sessionId },
+    artifactPath,
+    cwd: directory,
+    accountId: "default",
+    launchProfile: profile,
+    status: "idle",
+    host: null,
+    structuredHost: {
+      kind: "codex-app-server",
+      endpoint: "fake:operation-owner",
+      process: null,
+      eventCursor: 0,
+      protocolVersion: "v2",
+      writerClaimEpoch: 4,
+      activeTurnRef: null,
+      pendingAttention: [],
+      activeFlags: [],
+    },
+    claimEpoch: 4,
+    claimOwner: null,
+    pendingAction: null,
+  });
+  const journal = new RuntimeJournal(path.join(directory, "runtime.sqlite"), { structuredHosts: true });
+  journal.append({
+    scope: { type: "session", id: conversation.id },
+    kind: "session-status",
+    payload: {
+      conversationId: conversation.id,
+      sessionKey: { engine: "codex", sessionId },
+      hostKind: "codex-app-server",
+      host: "hosted",
+      turn: "idle",
+      provenance: "structured",
+      artifactPath,
+      capabilities: { steer: true, structuredAttention: true },
+    },
+  });
+  const client = runtimeJournalClient(journal);
+  const ledger = createFakeDeliveryLedger();
+  await bindStructuredDeliveryQueue([{
+    key: { engine: "codex", sessionId },
+    host: observableFakeHost(new FakeEngineHost(ledger)),
+  }], { registry, client });
+  const original = {
+    path: artifactPath,
+    conversationId: conversation.id,
+    clientMessageId: "operation-owner-client-one",
+    operationId: "operation-owned-by-client-one",
+    kind: "send" as const,
+    policy: "queue" as const,
+    turnId: null,
+    text: "actuate this command once",
+    hasImages: false,
+  };
+
+  try {
+    expect(await enqueueStructuredMessage(original, {
+      enabled: () => true,
+      client: () => client,
+      registry: () => registry,
+      kick: () => {},
+    })).toMatchObject({ ok: true, structured: true, outcome: "queued" });
+    await kickStructuredDeliveryQueue();
+    expect(ledger.writes).toEqual([{
+      id: original.operationId,
+      text: original.text,
+      expectedTurnId: original.turnId,
+    }]);
+
+    expect(await enqueueStructuredMessage({
+      ...original,
+      clientMessageId: "operation-owner-client-two",
+    }, {
+      enabled: () => true,
+      client: () => client,
+      registry: () => registry,
+      kick: () => {},
+    })).toMatchObject({
+      ok: false,
+      structured: true,
+      outcome: "failed",
+      status: 409,
+    });
+
+    expect(await enqueueStructuredMessage(original, {
+      enabled: () => true,
+      client: () => client,
+      registry: () => registry,
+      kick: () => {},
+    })).toMatchObject({ ok: true, structured: true, outcome: "delivered" });
+    expect(ledger.writes).toHaveLength(1);
+
+    const reopened = new AgentRegistry(registry.filename);
+    expect(reopened.pendingDeliveries(conversation.id)).toEqual([]);
+    expect(Object.values(reopened.snapshot().heldDeliveries)).toMatchObject([{
+      clientMessageId: original.clientMessageId,
+      command: {
+        operationId: original.operationId,
+        kind: original.kind,
+        policy: original.policy,
+        turnId: original.turnId,
+      },
+      state: "delivered",
+      text: "",
+    }]);
+    expect(journal.effectBatch()).toEqual([]);
+  } finally {
+    await bindStructuredDeliveryQueue([], { registry, client: null });
+    journal.close();
+  }
+});
+
 test("a stale synchronization-held steer fails safely across Codex and Claude recovery", async () => {
   const cases = [
     {

--- a/src/lib/runtime/structuredDelivery.integration.test.ts
+++ b/src/lib/runtime/structuredDelivery.integration.test.ts
@@ -1200,6 +1200,177 @@ test("terminal operation replay survives registry and runtime journal compaction
   }
 });
 
+test("provisional adoption preserves runtime idempotency across Codex and Claude", async () => {
+  const scenarios = [
+    {
+      engine: "codex" as const,
+      hostKind: "codex-app-server" as const,
+      sessionId: "eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee",
+    },
+    {
+      engine: "claude" as const,
+      hostKind: "claude-broker" as const,
+      sessionId: "ffffffff-ffff-4fff-8fff-ffffffffffff",
+    },
+  ];
+
+  for (const scenario of scenarios) {
+    const directory = path.join(sandbox, `provisional-operation-owner-${scenario.engine}`);
+    fs.mkdirSync(directory, { recursive: true });
+    const sourcePath = path.join(directory, `source-${scenario.engine}.jsonl`);
+    const targetPath = path.join(directory, `${scenario.sessionId}.jsonl`);
+    const registry = new AgentRegistry(path.join(directory, "agent-registry.json"));
+    const profile = emptyLaunchProfile({ cwd: directory });
+    const canonical = registry.ensureConversation(scenario.engine, sourcePath, "source");
+    registry.reconcileConversations([{
+      engine: scenario.engine,
+      path: targetPath,
+      accountId: "target",
+      launchProfile: profile,
+      turn: { state: "idle", source: "empty", terminalAt: null },
+      observedAt: "2026-07-17T01:00:00.000Z",
+    }]);
+    const provisional = registry.conversationForPath(targetPath)!;
+    const structuredHost = {
+      kind: scenario.hostKind,
+      endpoint: `fake:provisional-${scenario.engine}`,
+      process: null,
+      eventCursor: 0,
+      protocolVersion: "v2",
+      writerClaimEpoch: 5,
+      activeTurnRef: null,
+      pendingAttention: [],
+      activeFlags: [],
+    };
+    registry.upsert({
+      key: { engine: scenario.engine, sessionId: scenario.sessionId },
+      artifactPath: targetPath,
+      cwd: directory,
+      accountId: "target",
+      launchProfile: profile,
+      status: "idle",
+      host: null,
+      structuredHost,
+      claimEpoch: 5,
+      claimOwner: null,
+      pendingAction: null,
+    });
+    const journal = new RuntimeJournal(path.join(directory, "runtime.sqlite"), { structuredHosts: true });
+    journal.append({
+      scope: { type: "session", id: provisional.id },
+      kind: "session-status",
+      payload: {
+        conversationId: provisional.id,
+        sessionKey: { engine: scenario.engine, sessionId: scenario.sessionId },
+        hostKind: scenario.hostKind,
+        host: "hosted",
+        turn: "idle",
+        provenance: "structured",
+        artifactPath: targetPath,
+        capabilities: { steer: scenario.engine === "codex", structuredAttention: true },
+      },
+    });
+    const client = runtimeJournalClient(journal);
+    const ledger = createFakeDeliveryLedger();
+    await bindStructuredDeliveryQueue([{
+      key: { engine: scenario.engine, sessionId: scenario.sessionId },
+      host: observableFakeHost(new FakeEngineHost(ledger)),
+    }], { registry, client });
+    const request = {
+      path: targetPath,
+      conversationId: provisional.id,
+      clientMessageId: `provisional-client-${scenario.engine}`,
+      operationId: `provisional-operation-${scenario.engine}`,
+      kind: "send" as const,
+      policy: "queue" as const,
+      turnId: null,
+      text: `deliver once through ${scenario.engine} adoption`,
+      hasImages: false,
+    };
+
+    try {
+      expect(await enqueueStructuredMessage(request, {
+        enabled: () => true,
+        client: () => client,
+        registry: () => registry,
+        kick: () => {},
+      })).toMatchObject({ ok: true, structured: true, outcome: "queued" });
+      expect(journal.effectBatch()).toHaveLength(1);
+
+      const migration = registry.beginSpawnRequest({
+        engine: scenario.engine,
+        cwd: directory,
+        accountId: "target",
+        conversationId: canonical.id,
+        purpose: "launch",
+        expectedArtifactPath: targetPath,
+      });
+      if (migration.kind !== "created") throw new Error("expected migration successor receipt");
+      expect(registry.settleSpawn(migration.receipt.launchId, {
+        key: { engine: scenario.engine, sessionId: scenario.sessionId },
+        artifactPath: targetPath,
+        cwd: directory,
+        accountId: "target",
+        launchProfile: profile,
+        status: "idle",
+        host: null,
+        structuredHost,
+        claimEpoch: 5,
+        claimOwner: null,
+        pendingAction: null,
+      })).toMatchObject({ kind: "settled", conversation: { id: canonical.id } });
+      expect(registry.canonicalConversationId(provisional.id)).toBe(canonical.id);
+
+      const unrelated = registry.ensureConversation(
+        scenario.engine,
+        path.join(directory, `unrelated-${scenario.engine}.jsonl`),
+        "target",
+      );
+      expect(() => registry.holdDelivery(
+        unrelated.id,
+        request.text,
+        request.clientMessageId,
+        "text",
+        {
+          operationId: request.operationId,
+          kind: request.kind,
+          policy: request.policy,
+          turnId: request.turnId,
+        },
+      )).toThrow("operation id is already reserved for another client message");
+
+      expect(await enqueueStructuredMessage(request, {
+        enabled: () => true,
+        client: () => client,
+        registry: () => registry,
+        kick: () => {},
+      })).toMatchObject({
+        ok: true,
+        structured: true,
+        outcome: "queued",
+        operationId: request.operationId,
+      });
+      expect(await enqueueStructuredMessage({ ...request, text: `${request.text} changed` }, {
+        enabled: () => true,
+        client: () => client,
+        registry: () => registry,
+        kick: () => {},
+      })).toMatchObject({ ok: false, structured: true, outcome: "failed", status: 409 });
+
+      await kickStructuredDeliveryQueue();
+      expect(ledger.writes).toEqual([{
+        id: request.operationId,
+        text: request.text,
+        expectedTurnId: request.turnId,
+      }]);
+      expect(journal.effectBatch()).toEqual([]);
+    } finally {
+      await bindStructuredDeliveryQueue([], { registry, client: null });
+      journal.close();
+    }
+  }
+});
+
 test("a stale synchronization-held steer fails safely across Codex and Claude recovery", async () => {
   const cases = [
     {

--- a/src/lib/runtime/structuredMessageDelivery.ts
+++ b/src/lib/runtime/structuredMessageDelivery.ts
@@ -8,7 +8,7 @@ import {
 } from "@/lib/agent/registry";
 import { withAccountMutationLockAsync } from "@/lib/accounts/accountMutation";
 import { requestAccountMigrationTick } from "@/lib/accounts/migration/controllerSignal";
-import type { HeldDeliveryCommand, ViewerConversationId } from "@/lib/accounts/migration/contracts";
+import type { HeldDelivery, HeldDeliveryCommand, ViewerConversationId } from "@/lib/accounts/migration/contracts";
 
 import { runtimeHostClient, type RuntimeHostClient } from "./client";
 import type { RuntimeOperationReceipt, RuntimeSession } from "./contracts";
@@ -80,6 +80,7 @@ async function withAdmissionSection<T>(key: string | null, run: () => T | Promis
 
 export interface HeldStructuredMessageRequest {
   conversationId: string;
+  runtimeConversationId?: string;
   path: string;
   deliveryId: string;
   clientMessageId: string;
@@ -261,6 +262,34 @@ function requestMigrationProgress(
   if (phase && !["committed", "rolled-back"].includes(phase)) requestTick();
 }
 
+function deliveredReservationReplay(
+  reservation: HeldDelivery,
+  idempotencyKey: string,
+  target: ViewerConversationId | null,
+  spawned: boolean,
+): StructuredMessageResult {
+  const receipt: RuntimeOperationReceipt = {
+    operationId: reservation.command.operationId,
+    idempotencyKey,
+    conversationId: reservation.runtimeConversationId,
+    kind: reservation.command.kind,
+    status: "delivered",
+    ...(reservation.command.turnId !== undefined ? { turnId: reservation.command.turnId } : {}),
+    reason: null,
+    at: reservation.deliveredAt ?? reservation.createdAt,
+    revision: 1,
+  };
+  return {
+    ok: true,
+    structured: true,
+    target,
+    outcome: "delivered",
+    operationId: reservation.command.operationId,
+    receipt,
+    ...(spawned ? { spawned: true } : {}),
+  };
+}
+
 export async function deliverHeldStructuredMessage(
   request: HeldStructuredMessageRequest,
   dependencies: HeldStructuredMessageDependencies = {},
@@ -308,7 +337,7 @@ export async function deliverHeldStructuredMessage(
     const result = await client.command({
       kind: command.kind,
       operationId: command.operationId,
-      conversationId: request.conversationId,
+      conversationId: request.runtimeConversationId ?? request.conversationId,
       idempotencyKey: request.clientMessageId,
       text: content.content.text,
       ...(refs.length ? { images: refs } : {}),
@@ -494,6 +523,14 @@ export async function enqueueStructuredMessage(
         ...(recoveredHost ? { spawned: true } : {}),
       };
     }
+    if (reservation.state === "delivered") {
+      return deliveredReservationReplay(
+        reservation,
+        idempotencyKey,
+        recoveredHost ? null : conversation.id,
+        recoveredHost,
+      );
+    }
     if (reservation.state === "assigned" && reservation.generationId) {
       const claimed = registry.beginDeliveryAttempt(reservation.id, reservation.generationId);
       if (!claimed) {
@@ -508,7 +545,7 @@ export async function enqueueStructuredMessage(
         };
       }
       claimedReservationId = claimed.id;
-    } else if (reservation.state !== "delivered") {
+    } else {
       return {
         ok: false,
         structured: true,
@@ -520,7 +557,7 @@ export async function enqueueStructuredMessage(
     const result = await client.command({
       kind: reservation.command.kind,
       operationId: reservation.command.operationId,
-      conversationId: conversation.id,
+      conversationId: reservation.runtimeConversationId,
       idempotencyKey,
       text: content.content.text,
       ...(refs.length ? { images: refs } : {}),

--- a/src/lib/runtime/structuredMessageDelivery.ts
+++ b/src/lib/runtime/structuredMessageDelivery.ts
@@ -45,6 +45,7 @@ export interface StructuredMessageDependencies {
 
 export interface HeldStructuredMessageRequest {
   conversationId: string;
+  runtimeConversationId?: string;
   path: string;
   deliveryId: string;
   clientMessageId: string;
@@ -206,7 +207,7 @@ function deliveredReservationReplay(
   const receipt: RuntimeOperationReceipt = {
     operationId: reservation.command.operationId,
     idempotencyKey,
-    conversationId: reservation.conversationId,
+    conversationId: reservation.runtimeConversationId,
     kind: reservation.command.kind,
     status: "delivered",
     ...(reservation.command.turnId !== undefined ? { turnId: reservation.command.turnId } : {}),
@@ -256,7 +257,7 @@ export async function deliverHeldStructuredMessage(
     const result = await client.command({
       kind: command.kind,
       operationId: command.operationId,
-      conversationId: request.conversationId,
+      conversationId: request.runtimeConversationId ?? request.conversationId,
       idempotencyKey: request.clientMessageId,
       text: request.text,
       policy: command.policy,
@@ -392,7 +393,7 @@ export async function enqueueStructuredMessage(
     const result = await client.command({
       kind: reservation.command.kind,
       operationId: reservation.command.operationId,
-      conversationId: conversation.id,
+      conversationId: reservation.runtimeConversationId,
       idempotencyKey,
       text: request.text,
       policy: reservation.command.policy,

--- a/src/lib/runtime/structuredMessageDelivery.ts
+++ b/src/lib/runtime/structuredMessageDelivery.ts
@@ -7,7 +7,7 @@ import {
   type RegistryConversation,
 } from "@/lib/agent/registry";
 import { requestAccountMigrationTick } from "@/lib/accounts/migration/controllerSignal";
-import type { HeldDeliveryCommand, ViewerConversationId } from "@/lib/accounts/migration/contracts";
+import type { HeldDelivery, HeldDeliveryCommand, ViewerConversationId } from "@/lib/accounts/migration/contracts";
 
 import { runtimeHostClient, type RuntimeHostClient } from "./client";
 import type { RuntimeOperationReceipt } from "./contracts";
@@ -197,6 +197,34 @@ function requestMigrationProgress(
   if (phase && !["committed", "rolled-back"].includes(phase)) requestTick();
 }
 
+function deliveredReservationReplay(
+  reservation: HeldDelivery,
+  idempotencyKey: string,
+  target: ViewerConversationId | null,
+  spawned: boolean,
+): StructuredMessageResult {
+  const receipt: RuntimeOperationReceipt = {
+    operationId: reservation.command.operationId,
+    idempotencyKey,
+    conversationId: reservation.conversationId,
+    kind: reservation.command.kind,
+    status: "delivered",
+    ...(reservation.command.turnId !== undefined ? { turnId: reservation.command.turnId } : {}),
+    reason: null,
+    at: reservation.deliveredAt ?? reservation.createdAt,
+    revision: 1,
+  };
+  return {
+    ok: true,
+    structured: true,
+    target,
+    outcome: "delivered",
+    operationId: reservation.command.operationId,
+    receipt,
+    ...(spawned ? { spawned: true } : {}),
+  };
+}
+
 export async function deliverHeldStructuredMessage(
   request: HeldStructuredMessageRequest,
   dependencies: HeldStructuredMessageDependencies = {},
@@ -330,6 +358,14 @@ export async function enqueueStructuredMessage(
         ...(recoveredHost ? { spawned: true } : {}),
       };
     }
+    if (reservation.state === "delivered") {
+      return deliveredReservationReplay(
+        reservation,
+        idempotencyKey,
+        recoveredHost ? null : conversation.id,
+        recoveredHost,
+      );
+    }
     if (reservation.state === "assigned" && reservation.generationId) {
       const claimed = registry.beginDeliveryAttempt(reservation.id, reservation.generationId);
       if (!claimed) {
@@ -344,7 +380,7 @@ export async function enqueueStructuredMessage(
         };
       }
       claimedReservationId = claimed.id;
-    } else if (reservation.state !== "delivered") {
+    } else {
       return {
         ok: false,
         structured: true,

--- a/src/runtime-host/journal.test.ts
+++ b/src/runtime-host/journal.test.ts
@@ -292,6 +292,90 @@ test("image refs remain ordered and participate in journal idempotency", () => {
   journal.close();
 });
 
+test("runtime restart migrates a legacy operation with no conversation identity", () => {
+  const dir = sandbox("operation-idempotency-missing-conversation");
+  const filename = path.join(dir, "events.sqlite");
+  const initial = new RuntimeJournal(filename, { maxEvents: 100, now: () => 100 });
+  const original = initial.executeOperation({
+    kind: "send",
+    operationId: "op-missing-conversation",
+    idempotencyKey: "composer-message-without-conversation",
+    conversationId: "conversation-removed-from-legacy-json",
+    text: "survive the legacy migration",
+    policy: "queue",
+  });
+  initial.close();
+
+  const legacy = new Database(filename);
+  legacy.exec(`
+    BEGIN IMMEDIATE;
+    ALTER TABLE operations RENAME TO operations_scoped_idempotency;
+    CREATE TABLE operations (
+      operation_id TEXT PRIMARY KEY, idempotency_key TEXT NOT NULL UNIQUE,
+      request_hash TEXT NOT NULL, request_json TEXT NOT NULL,
+      receipt_json TEXT NOT NULL, event_seq INTEGER NOT NULL
+    );
+    INSERT INTO operations(operation_id, idempotency_key, request_hash, request_json, receipt_json, event_seq)
+    SELECT operation_id, idempotency_key, request_hash,
+      json_remove(request_json, '$.conversationId'),
+      json_remove(receipt_json, '$.conversationId'),
+      event_seq
+    FROM operations_scoped_idempotency;
+    DROP TABLE operations_scoped_idempotency;
+    COMMIT;
+  `);
+  legacy.close();
+
+  const migrated = new RuntimeJournal(filename, { maxEvents: 100, now: () => 101 });
+  expect(migrated.operationResult(original.operationId)?.receipt.operationId).toBe(original.operationId);
+  migrated.close();
+  const migratedDb = new Database(filename, { readonly: true });
+  expect(migratedDb.query<{ conversation_id: string }, []>(
+    "SELECT conversation_id FROM operations WHERE operation_id = 'op-missing-conversation'",
+  ).get()?.conversation_id).toBe("");
+  migratedDb.close();
+
+  const reopened = new RuntimeJournal(filename, { maxEvents: 100, now: () => 102 });
+  expect(reopened.operationResult(original.operationId)?.receipt.operationId).toBe(original.operationId);
+  reopened.close();
+});
+
+test("runtime restart completes an interrupted operation table rename idempotently", () => {
+  const dir = sandbox("operation-idempotency-interrupted-rename");
+  const filename = path.join(dir, "events.sqlite");
+  const command = {
+    kind: "send" as const,
+    operationId: "op-before-interrupted-rename",
+    idempotencyKey: "composer-message-before-interrupted-rename",
+    conversationId: "conversation-before-interrupted-rename",
+    text: "survive the interrupted table rename",
+    policy: "queue" as const,
+  };
+  const initial = new RuntimeJournal(filename, { maxEvents: 100, now: () => 100 });
+  const original = initial.executeOperation(command);
+  initial.close();
+
+  const interrupted = new Database(filename);
+  interrupted.exec("ALTER TABLE operations RENAME TO operations_global_idempotency");
+  interrupted.close();
+
+  const recovered = new RuntimeJournal(filename, { maxEvents: 100, now: () => 101 });
+  expect(recovered.executeOperation(command)).toEqual({ ...original, replayed: true });
+  recovered.close();
+  const recoveredDb = new Database(filename, { readonly: true });
+  expect(recoveredDb.query<{ count: number }, []>(
+    "SELECT COUNT(*) AS count FROM operations WHERE operation_id = 'op-before-interrupted-rename'",
+  ).get()?.count).toBe(1);
+  expect(recoveredDb.query<{ count: number }, []>(
+    "SELECT COUNT(*) AS count FROM sqlite_master WHERE type = 'table' AND name = 'operations_global_idempotency'",
+  ).get()?.count).toBe(0);
+  recoveredDb.close();
+
+  const reopened = new RuntimeJournal(filename, { maxEvents: 100, now: () => 102 });
+  expect(reopened.executeOperation(command)).toEqual({ ...original, replayed: true });
+  reopened.close();
+});
+
 test("structured send receipts advance through the durable delivery lifecycle", () => {
   const dir = sandbox("structured-delivery-lifecycle");
   const journal = new RuntimeJournal(path.join(dir, "events.sqlite"), {

--- a/src/runtime-host/journal.test.ts
+++ b/src/runtime-host/journal.test.ts
@@ -303,6 +303,90 @@ test("runtime restart upgrades global operation idempotency without losing recei
   restarted.close();
 });
 
+test("runtime restart migrates a legacy operation with no conversation identity", () => {
+  const dir = sandbox("operation-idempotency-missing-conversation");
+  const filename = path.join(dir, "events.sqlite");
+  const initial = new RuntimeJournal(filename, { maxEvents: 100, now: () => 100 });
+  const original = initial.executeOperation({
+    kind: "send",
+    operationId: "op-missing-conversation",
+    idempotencyKey: "composer-message-without-conversation",
+    conversationId: "conversation-removed-from-legacy-json",
+    text: "survive the legacy migration",
+    policy: "queue",
+  });
+  initial.close();
+
+  const legacy = new Database(filename);
+  legacy.exec(`
+    BEGIN IMMEDIATE;
+    ALTER TABLE operations RENAME TO operations_scoped_idempotency;
+    CREATE TABLE operations (
+      operation_id TEXT PRIMARY KEY, idempotency_key TEXT NOT NULL UNIQUE,
+      request_hash TEXT NOT NULL, request_json TEXT NOT NULL,
+      receipt_json TEXT NOT NULL, event_seq INTEGER NOT NULL
+    );
+    INSERT INTO operations(operation_id, idempotency_key, request_hash, request_json, receipt_json, event_seq)
+    SELECT operation_id, idempotency_key, request_hash,
+      json_remove(request_json, '$.conversationId'),
+      json_remove(receipt_json, '$.conversationId'),
+      event_seq
+    FROM operations_scoped_idempotency;
+    DROP TABLE operations_scoped_idempotency;
+    COMMIT;
+  `);
+  legacy.close();
+
+  const migrated = new RuntimeJournal(filename, { maxEvents: 100, now: () => 101 });
+  expect(migrated.operationResult(original.operationId)?.receipt.operationId).toBe(original.operationId);
+  migrated.close();
+  const migratedDb = new Database(filename, { readonly: true });
+  expect(migratedDb.query<{ conversation_id: string }, []>(
+    "SELECT conversation_id FROM operations WHERE operation_id = 'op-missing-conversation'",
+  ).get()?.conversation_id).toBe("");
+  migratedDb.close();
+
+  const reopened = new RuntimeJournal(filename, { maxEvents: 100, now: () => 102 });
+  expect(reopened.operationResult(original.operationId)?.receipt.operationId).toBe(original.operationId);
+  reopened.close();
+});
+
+test("runtime restart completes an interrupted operation table rename idempotently", () => {
+  const dir = sandbox("operation-idempotency-interrupted-rename");
+  const filename = path.join(dir, "events.sqlite");
+  const command = {
+    kind: "send" as const,
+    operationId: "op-before-interrupted-rename",
+    idempotencyKey: "composer-message-before-interrupted-rename",
+    conversationId: "conversation-before-interrupted-rename",
+    text: "survive the interrupted table rename",
+    policy: "queue" as const,
+  };
+  const initial = new RuntimeJournal(filename, { maxEvents: 100, now: () => 100 });
+  const original = initial.executeOperation(command);
+  initial.close();
+
+  const interrupted = new Database(filename);
+  interrupted.exec("ALTER TABLE operations RENAME TO operations_global_idempotency");
+  interrupted.close();
+
+  const recovered = new RuntimeJournal(filename, { maxEvents: 100, now: () => 101 });
+  expect(recovered.executeOperation(command)).toEqual({ ...original, replayed: true });
+  recovered.close();
+  const recoveredDb = new Database(filename, { readonly: true });
+  expect(recoveredDb.query<{ count: number }, []>(
+    "SELECT COUNT(*) AS count FROM operations WHERE operation_id = 'op-before-interrupted-rename'",
+  ).get()?.count).toBe(1);
+  expect(recoveredDb.query<{ count: number }, []>(
+    "SELECT COUNT(*) AS count FROM sqlite_master WHERE type = 'table' AND name = 'operations_global_idempotency'",
+  ).get()?.count).toBe(0);
+  recoveredDb.close();
+
+  const reopened = new RuntimeJournal(filename, { maxEvents: 100, now: () => 102 });
+  expect(reopened.executeOperation(command)).toEqual({ ...original, replayed: true });
+  reopened.close();
+});
+
 test("structured send receipts advance through the durable delivery lifecycle", () => {
   const dir = sandbox("structured-delivery-lifecycle");
   const journal = new RuntimeJournal(path.join(dir, "events.sqlite"), {

--- a/src/runtime-host/journal.ts
+++ b/src/runtime-host/journal.ts
@@ -1471,24 +1471,57 @@ export class RuntimeJournal {
 
   private migrateOperationIdempotencyScope(): void {
     const columns = new Set(this.db.query<{ name: string }, []>("PRAGMA table_info(operations)").all().map((row) => row.name));
-    if (columns.has("conversation_id")) return;
-    this.db.exec(`
-      BEGIN IMMEDIATE;
-      ALTER TABLE operations RENAME TO operations_global_idempotency;
-      CREATE TABLE operations (
-        operation_id TEXT PRIMARY KEY, conversation_id TEXT NOT NULL, idempotency_key TEXT NOT NULL,
-        request_hash TEXT NOT NULL, request_json TEXT NOT NULL,
-        receipt_json TEXT NOT NULL, event_seq INTEGER NOT NULL,
-        UNIQUE(conversation_id, idempotency_key)
-      );
-      INSERT INTO operations(operation_id, conversation_id, idempotency_key, request_hash, request_json, receipt_json, event_seq)
-      SELECT operation_id,
-        COALESCE(json_extract(request_json, '$.conversationId'), json_extract(receipt_json, '$.conversationId')),
-        idempotency_key, request_hash, request_json, receipt_json, event_seq
-      FROM operations_global_idempotency;
-      DROP TABLE operations_global_idempotency;
-      COMMIT;
-    `);
+    const legacyTableExists = () => Boolean(this.db.query<{ name: string }, []>(
+      "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'operations_global_idempotency'",
+    ).get());
+    if (columns.has("conversation_id") && !legacyTableExists()) return;
+    this.db.exec("BEGIN IMMEDIATE");
+    try {
+      if (!columns.has("conversation_id")) {
+        this.db.exec("ALTER TABLE operations RENAME TO operations_global_idempotency");
+      }
+      this.db.exec(`
+        CREATE TABLE IF NOT EXISTS operations (
+          operation_id TEXT PRIMARY KEY, conversation_id TEXT NOT NULL, idempotency_key TEXT NOT NULL,
+          request_hash TEXT NOT NULL, request_json TEXT NOT NULL,
+          receipt_json TEXT NOT NULL, event_seq INTEGER NOT NULL,
+          UNIQUE(conversation_id, idempotency_key)
+        );
+      `);
+      if (legacyTableExists()) {
+        this.db.exec(`
+          INSERT OR IGNORE INTO operations(operation_id, conversation_id, idempotency_key, request_hash, request_json, receipt_json, event_seq)
+          SELECT operation_id,
+            COALESCE(json_extract(request_json, '$.conversationId'), json_extract(receipt_json, '$.conversationId'), ''),
+            idempotency_key, request_hash, request_json, receipt_json, event_seq
+          FROM operations_global_idempotency;
+        `);
+        const conflict = this.db.query<{ operation_id: string }, []>(`
+          SELECT legacy.operation_id
+          FROM operations_global_idempotency AS legacy
+          LEFT JOIN operations AS scoped
+            ON scoped.operation_id = legacy.operation_id
+            AND scoped.conversation_id = COALESCE(
+              json_extract(legacy.request_json, '$.conversationId'),
+              json_extract(legacy.receipt_json, '$.conversationId'),
+              ''
+            )
+            AND scoped.idempotency_key = legacy.idempotency_key
+            AND scoped.request_hash = legacy.request_hash
+            AND scoped.request_json = legacy.request_json
+            AND scoped.receipt_json = legacy.receipt_json
+            AND scoped.event_seq = legacy.event_seq
+          WHERE scoped.operation_id IS NULL
+          LIMIT 1
+        `).get();
+        if (conflict) throw new Error(`legacy runtime operation conflicts with scoped migration: ${conflict.operation_id}`);
+        this.db.exec("DROP TABLE operations_global_idempotency");
+      }
+      this.db.exec("COMMIT");
+    } catch (error) {
+      try { this.db.exec("ROLLBACK"); } catch { /* transaction already closed */ }
+      throw error;
+    }
   }
 
   private migrateLegacyEvents(): void {

--- a/src/runtime-host/journal.ts
+++ b/src/runtime-host/journal.ts
@@ -1419,24 +1419,57 @@ export class RuntimeJournal {
 
   private migrateOperationIdempotencyScope(): void {
     const columns = new Set(this.db.query<{ name: string }, []>("PRAGMA table_info(operations)").all().map((row) => row.name));
-    if (columns.has("conversation_id")) return;
-    this.db.exec(`
-      BEGIN IMMEDIATE;
-      ALTER TABLE operations RENAME TO operations_global_idempotency;
-      CREATE TABLE operations (
-        operation_id TEXT PRIMARY KEY, conversation_id TEXT NOT NULL, idempotency_key TEXT NOT NULL,
-        request_hash TEXT NOT NULL, request_json TEXT NOT NULL,
-        receipt_json TEXT NOT NULL, event_seq INTEGER NOT NULL,
-        UNIQUE(conversation_id, idempotency_key)
-      );
-      INSERT INTO operations(operation_id, conversation_id, idempotency_key, request_hash, request_json, receipt_json, event_seq)
-      SELECT operation_id,
-        COALESCE(json_extract(request_json, '$.conversationId'), json_extract(receipt_json, '$.conversationId')),
-        idempotency_key, request_hash, request_json, receipt_json, event_seq
-      FROM operations_global_idempotency;
-      DROP TABLE operations_global_idempotency;
-      COMMIT;
-    `);
+    const legacyTableExists = () => Boolean(this.db.query<{ name: string }, []>(
+      "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'operations_global_idempotency'",
+    ).get());
+    if (columns.has("conversation_id") && !legacyTableExists()) return;
+    this.db.exec("BEGIN IMMEDIATE");
+    try {
+      if (!columns.has("conversation_id")) {
+        this.db.exec("ALTER TABLE operations RENAME TO operations_global_idempotency");
+      }
+      this.db.exec(`
+        CREATE TABLE IF NOT EXISTS operations (
+          operation_id TEXT PRIMARY KEY, conversation_id TEXT NOT NULL, idempotency_key TEXT NOT NULL,
+          request_hash TEXT NOT NULL, request_json TEXT NOT NULL,
+          receipt_json TEXT NOT NULL, event_seq INTEGER NOT NULL,
+          UNIQUE(conversation_id, idempotency_key)
+        );
+      `);
+      if (legacyTableExists()) {
+        this.db.exec(`
+          INSERT OR IGNORE INTO operations(operation_id, conversation_id, idempotency_key, request_hash, request_json, receipt_json, event_seq)
+          SELECT operation_id,
+            COALESCE(json_extract(request_json, '$.conversationId'), json_extract(receipt_json, '$.conversationId'), ''),
+            idempotency_key, request_hash, request_json, receipt_json, event_seq
+          FROM operations_global_idempotency;
+        `);
+        const conflict = this.db.query<{ operation_id: string }, []>(`
+          SELECT legacy.operation_id
+          FROM operations_global_idempotency AS legacy
+          LEFT JOIN operations AS scoped
+            ON scoped.operation_id = legacy.operation_id
+            AND scoped.conversation_id = COALESCE(
+              json_extract(legacy.request_json, '$.conversationId'),
+              json_extract(legacy.receipt_json, '$.conversationId'),
+              ''
+            )
+            AND scoped.idempotency_key = legacy.idempotency_key
+            AND scoped.request_hash = legacy.request_hash
+            AND scoped.request_json = legacy.request_json
+            AND scoped.receipt_json = legacy.receipt_json
+            AND scoped.event_seq = legacy.event_seq
+          WHERE scoped.operation_id IS NULL
+          LIMIT 1
+        `).get();
+        if (conflict) throw new Error(`legacy runtime operation conflicts with scoped migration: ${conflict.operation_id}`);
+        this.db.exec("DROP TABLE operations_global_idempotency");
+      }
+      this.db.exec("COMMIT");
+    } catch (error) {
+      try { this.db.exec("ROLLBACK"); } catch { /* transaction already closed */ }
+      throw error;
+    }
   }
 
   private migrateLegacyEvents(): void {


### PR DESCRIPTION
## Summary

- preserve explicit runtime operation ownership across synchronization, adoption, and replay
- retain terminal delivery evidence through compaction and make journal migration re-entrant
- reconcile held structured sends against the runtime conversation identity
- preserve current structured-image digest safeguards while integrating the live PR #330 commits

## Integration evidence

- exact base: `e575dc06aa77fd6d913b90d98268fc77eb64173a`
- reviewed head: `338bdd2ec1b6616b8cae9f6ef2ae4a12cc32662c`
- additive merge commit retains the nine unique commits from PR #330
- detailed range-diff audit: `docs/pr-330-runtime-sync-integration.md`

## Verification

- focused runtime suite: 317/319 in the combined environment
- isolated journal suite with the ambient structured-host flag unset: 45/45
- TypeScript
- changed-file ESLint
- production build
- startup recovery, compacted replay, SQLite and JSON ownership, controller drain, broker late-reap, and no-claim coverage
- independent fresh review: `VERDICT: APPROVE`, `NO FINDINGS`

Closes #308

Supersedes #330 after preserving its unique history.
