### PR TITLE
Fix Claude pipeline autonomous permissions

### DIFF
--- a/src/lib/pipelines/engine.test.ts
+++ b/src/lib/pipelines/engine.test.ts
@@ -7,7 +7,7 @@ import type { Flow } from "@/lib/flows/types";
 import type { FileEntry } from "@/lib/types";
 
 process.env.LLV_STATE_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "llv-pipeline-engine-"));
-const { createPipelineFromRequest, patchPipeline, reviewNote, tickPipelines } = await import("./engine");
+const { createPipelineFromRequest, patchPipeline, pipelineClaudePermissionMode, reviewNote, tickPipelines } = await import("./engine");
 const { loadPipelines, savePipelines } = await import("./store");
 type PipelinePorts = import("./engine").PipelinePorts;
 
@@ -18,6 +18,33 @@ const RUN_STAGES = [
   { id: "build", kind: "run", role: { roleId: "builder" }, engine: "codex", access: "read-write", prompt: "Build from {{prev.output}}", next: null },
 ] as const;
 const ORIGIN_MAIN_SHA = "48c739bbcc87b3244aee7fb0e2d1b3f8e312548f";
+
+test("Claude pipeline roles keep autonomous tool access under read-only scope fences", () => {
+  expect(pipelineClaudePermissionMode({
+    roleId: "architect",
+    engine: "claude",
+    model: "fable",
+    effort: "high",
+    access: "read-only",
+    promptScaffold: "Read-only architecture contract",
+  })).toBe("bypassPermissions");
+  expect(pipelineClaudePermissionMode({
+    roleId: "builder",
+    engine: "claude",
+    model: "fable",
+    effort: "high",
+    access: "read-write",
+    promptScaffold: "Builder contract",
+  })).toBe("bypassPermissions");
+  expect(pipelineClaudePermissionMode({
+    roleId: "reviewer",
+    engine: "codex",
+    model: "gpt-5.6-sol",
+    effort: "xhigh",
+    access: "read-only",
+    promptScaffold: "Reviewer contract",
+  })).toBeNull();
+});
 
 function entry(pathname: string): FileEntry {
   return {

--- a/src/lib/pipelines/engine.ts
+++ b/src/lib/pipelines/engine.ts
@@ -86,6 +86,16 @@ function engineForTranscript(transcript: string): "claude" | "codex" | null {
   return null;
 }
 
+/**
+ * Viewer-managed Claude stages run autonomously. Their role access remains a
+ * product-scope contract, while the CLI permission mode must allow ordinary
+ * repository reads, GitHub inspection, screenshots, and verification commands
+ * without an interactive permission wall.
+ */
+export function pipelineClaudePermissionMode(role: EffectivePipelineRole): string | null {
+  return role.engine === "claude" ? "bypassPermissions" : null;
+}
+
 function parentIdentity(parentPath: string | null): {
   conversationId: ViewerConversationId | null;
   sessionKey: ReturnType<typeof sessionKeyFromTranscript>;
@@ -111,7 +121,7 @@ async function spawnPipelineAgent(
     model: input.role.model,
     effort: input.role.effort,
     readOnly: input.role.access === "read-only",
-    permissionMode: input.role.engine === "claude" && input.role.access === "read-only" ? "dontAsk" : null,
+    permissionMode: pipelineClaudePermissionMode(input.role),
     codexHome: input.role.engine === "codex" ? account.home : null,
     claudeConfigDir: input.role.engine === "claude" ? account.home : null,
     claudeProjectsDir: input.role.engine === "claude" ? account.transcriptRoot : null,


### PR DESCRIPTION
## Summary

- launch every Claude pipeline role with `bypassPermissions`
- retain role-level read-only scope and the existing Edit/Write tool fence
- prevent Fable architect and reviewer stages from failing on ordinary Bash, GitHub, screenshot, and verification reads
- add focused regression coverage for Claude and Codex role mapping

## Verification

- `bun test src/lib/pipelines/engine.test.ts` — 51 pass
- `bun test src/lib/runtime/structuredSpawn.integration.test.ts src/lib/runtime/claudeStreamBrokerHost.test.ts` — 88 pass
- `bun run tsc --noEmit`
- changed-file ESLint
- `bun run build`
