### PR TITLE
perf(scanner): bound restart lineage reads and preserve proven chains

### DIFF
--- a/src/app/api/files/scanCache.real.test.ts
+++ b/src/app/api/files/scanCache.real.test.ts
@@ -265,11 +265,12 @@ test("a persisted completed generation primes permanent lineage facts", async ()
       description: "Run durable worker",
       source,
     });
-    expect(cacheStore.__llvCaches?.["compact-links-v1"]?.get(successor)).toBe(predecessor);
+    /* A snapshot parent between two mains may be the unproven nearest-older
+       fallback, so it must not prime the proven compact-chain store. */
+    expect(cacheStore.__llvCaches?.["compact-links-v1"]?.get(successor)).toBeUndefined();
     taskEntry.parent = null;
     taskEntry.cmd = "";
     taskEntry.cmdDesc = "";
-    predecessorEntry.parent = null;
     await linkEntries([sourceEntry, taskEntry, predecessorEntry, successorEntry], { persist: false });
     expect(taskEntry).toMatchObject({
       parent: source,
@@ -277,7 +278,6 @@ test("a persisted completed generation primes permanent lineage facts", async ()
       cmdDesc: "Run durable worker",
       title: "Run durable worker",
     });
-    expect(predecessorEntry.parent).toBe(successor);
   } finally {
     for (const pathname of [source, task, predecessor, successor]) fs.rmSync(pathname, { force: true });
     process.env.LLV_STATE_DIR = previousTestStateDir;

--- a/src/app/api/files/scanCache.real.test.ts
+++ b/src/app/api/files/scanCache.real.test.ts
@@ -3,6 +3,8 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
+import type { FileEntry } from "@/lib/types";
+
 const sandbox = fs.mkdtempSync(path.join(os.tmpdir(), "llv-files-real-scan-"));
 const previousStateDir = process.env.LLV_STATE_DIR;
 const previousCodexHome = process.env.LLV_CODEX_HOME;
@@ -19,6 +21,7 @@ fs.mkdirSync(sessions, { recursive: true });
 const { listFilesWithProjectCatalog } = await import("@/lib/scanner");
 const { ROOTS } = await import("@/lib/scanner/roots");
 const { cachedFileScan, currentFileScan, resetFilesRouteCacheForTests } = await import("@/lib/scanner/scanCache");
+const { linkEntries } = await import("@/lib/scanner/links");
 const { activityVerdict, transcriptTurnResult } = await import("@/lib/scanner/activity");
 const { entryEffort } = await import("@/lib/scanner/effort");
 const { entryModels } = await import("@/lib/scanner/model");
@@ -183,6 +186,106 @@ test("a persisted completed generation avoids cold tail rereads for unchanged tr
     fs.rmSync(testStateDir, { recursive: true, force: true });
   }
 }, 20_000);
+
+test("a persisted completed generation primes permanent lineage facts", async () => {
+  const previousTestStateDir = process.env.LLV_STATE_DIR;
+  const testStateDir = path.join(sandbox, "durable-lineage-reuse-state");
+  const slug = "-repo-durable-lineage";
+  const sid = "session-durable-lineage";
+  const tid = "task-durable-lineage";
+  const source = path.join(sandbox, "durable-lineage-source.jsonl");
+  const task = path.join(ROOTS["claude-tasks"], slug, sid, "tasks", `${tid}.output`);
+  const predecessor = path.join(sandbox, "durable-lineage-predecessor.jsonl");
+  const successor = path.join(sandbox, "durable-lineage-successor.jsonl");
+  const cacheStore = globalThis as typeof globalThis & { __llvCaches?: Record<string, Map<string, unknown>> };
+  const makeEntry = (
+    pathname: string,
+    root: FileEntry["root"],
+    name: string,
+    overrides: Partial<FileEntry> = {},
+  ): FileEntry => {
+    const stat = fs.statSync(pathname);
+    return {
+      path: pathname,
+      root,
+      name,
+      project: "repo",
+      title: "Durable lineage",
+      engine: root === "claude-tasks" ? "shell" : "claude",
+      kind: root === "claude-tasks" ? "task" : "session",
+      fmt: root === "claude-tasks" ? "plain" : "claude",
+      parent: null,
+      mtime: stat.mtimeMs / 1000,
+      size: stat.size,
+      activity: "idle",
+      activityReason: "mtime_old",
+      derivationComplete: true,
+      proc: null,
+      pid: null,
+      model: root === "claude-tasks" ? null : "sonnet-4",
+      pendingQuestion: null,
+      waitingInput: null,
+      ...overrides,
+    };
+  };
+  try {
+    process.env.LLV_STATE_DIR = testStateDir;
+    fs.mkdirSync(path.dirname(task), { recursive: true });
+    fs.writeFileSync(source, "source\n");
+    fs.writeFileSync(task, "complete\n");
+    fs.writeFileSync(predecessor, "predecessor\n");
+    fs.writeFileSync(successor, "successor\n");
+    const sourceEntry = makeEntry(source, "claude-projects", `${slug}/${sid}.jsonl`);
+    const taskEntry = makeEntry(task, "claude-tasks", `${slug}/${sid}/tasks/${tid}.output`, {
+      parent: source,
+      cmd: "bun run durable-worker",
+      cmdDesc: "Run durable worker",
+      title: "Run durable worker",
+    });
+    const predecessorEntry = makeEntry(predecessor, "claude-projects", `${slug}/predecessor.jsonl`, {
+      parent: successor,
+    });
+    const successorEntry = makeEntry(successor, "claude-projects", `${slug}/successor.jsonl`);
+    fs.mkdirSync(testStateDir, { recursive: true });
+    fs.writeFileSync(path.join(testStateDir, "files-scan-snapshot.json"), JSON.stringify({
+      version: 1,
+      snapshot: {
+        complete: true,
+        files: [sourceEntry, taskEntry, predecessorEntry, successorEntry],
+        projectCatalog: [],
+      },
+    }));
+    for (const cache of Object.values(cacheStore.__llvCaches ?? {})) cache.clear();
+    resetFilesRouteCacheForTests();
+
+    await cachedFileScan(undefined, undefined, 0);
+
+    expect(cacheStore.__llvCaches?.bgcmd?.get(tid)).toEqual({
+      command: "bun run durable-worker",
+      description: "Run durable worker",
+      source,
+    });
+    expect(cacheStore.__llvCaches?.["compact-links-v1"]?.get(successor)).toBe(predecessor);
+    taskEntry.parent = null;
+    taskEntry.cmd = "";
+    taskEntry.cmdDesc = "";
+    predecessorEntry.parent = null;
+    await linkEntries([sourceEntry, taskEntry, predecessorEntry, successorEntry], { persist: false });
+    expect(taskEntry).toMatchObject({
+      parent: source,
+      cmd: "bun run durable-worker",
+      cmdDesc: "Run durable worker",
+      title: "Run durable worker",
+    });
+    expect(predecessorEntry.parent).toBe(successor);
+  } finally {
+    for (const pathname of [source, task, predecessor, successor]) fs.rmSync(pathname, { force: true });
+    process.env.LLV_STATE_DIR = previousTestStateDir;
+    resetFilesRouteCacheForTests();
+    fs.rmSync(testStateDir, { recursive: true, force: true });
+    for (const cache of Object.values(cacheStore.__llvCaches ?? {})) cache.clear();
+  }
+});
 
 test("persisted Claude question state hydrates without transcript reads and stays retryable", async () => {
   const previousTestStateDir = process.env.LLV_STATE_DIR;

--- a/src/lib/scanner/links.performance.test.ts
+++ b/src/lib/scanner/links.performance.test.ts
@@ -9,7 +9,7 @@ const SANDBOX = fs.mkdtempSync(path.join(os.tmpdir(), "llv-links-performance-tes
 const REAL_STATE = process.env.LLV_STATE_DIR;
 process.env.LLV_STATE_DIR = path.join(SANDBOX, "state");
 
-const { linkEntries } = await import("./links");
+const { linkEntries, primePersistedLineageFacts } = await import("./links");
 const { ROOTS } = await import("./roots");
 
 afterAll(() => {
@@ -309,6 +309,38 @@ test("proven background commands survive restart without source transcript reads
   }
 });
 
+test("a snapshot heuristic edge cannot outrank a provable compaction predecessor", async () => {
+  const slug = "-repo-heuristic-compaction";
+  const successorPath = path.join(SANDBOX, "heuristic-successor.jsonl");
+  const provenPath = path.join(SANDBOX, "heuristic-proven.jsonl");
+  const strayPath = path.join(SANDBOX, "heuristic-stray.jsonl");
+  const logicalParentUuid = "bbbbbbbb-cccc-4ddd-8eee-ffffffffffff";
+  fs.writeFileSync(successorPath, `${JSON.stringify({
+    type: "system",
+    subtype: "compact_boundary",
+    logicalParentUuid,
+  })}\n`);
+  fs.writeFileSync(provenPath, `${JSON.stringify({ type: "assistant", uuid: logicalParentUuid })}\n`);
+  fs.writeFileSync(strayPath, `${JSON.stringify({ type: "user", uuid: "unrelated" })}\n`);
+  const successor = entry(successorPath, `${slug}/heuristic-successor.jsonl`, 3);
+  successor.activity = "live";
+  const proven = entry(provenPath, `${slug}/heuristic-proven.jsonl`, 2);
+  const stray = entry(strayPath, `${slug}/heuristic-stray.jsonl`, 1);
+
+  /* The persisted snapshot carried the nearest-older fallback taken while the
+     live successor had no provable predecessor on disk. That edge is a guess,
+     not an immutable fact, so a later generation with the true predecessor
+     visible must re-prove instead of trusting the primed guess. */
+  const snapshotSuccessor = { ...successor };
+  const snapshotStray = { ...stray, parent: successor.path };
+  primePersistedLineageFacts([snapshotSuccessor, snapshotStray]);
+
+  await linkEntries([successor, proven, stray], { persist: false });
+
+  expect(proven.parent).toBe(successor.path);
+  expect(stray.parent).toBeNull();
+});
+
 test("proven compaction chains survive restart after predecessor growth", async () => {
   const slug = "-repo-restart-compaction";
   const predecessorPath = path.join(SANDBOX, "restart-predecessor.jsonl");
@@ -364,6 +396,6 @@ test("proven compaction chains survive restart after predecessor growth", async 
     fs.closeSync = originalClose;
   }
 
-  expect(predecessor.parent).toBe(successor.path);
+  expect(predecessor.parent as string | null).toBe(successor.path);
   expect(bytesRead).toBeLessThanOrEqual(512 * 1024);
 });

--- a/src/lib/scanner/links.performance.test.ts
+++ b/src/lib/scanner/links.performance.test.ts
@@ -1,0 +1,369 @@
+import { afterAll, expect, test } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import type { FileEntry } from "../types";
+
+const SANDBOX = fs.mkdtempSync(path.join(os.tmpdir(), "llv-links-performance-test-"));
+const REAL_STATE = process.env.LLV_STATE_DIR;
+process.env.LLV_STATE_DIR = path.join(SANDBOX, "state");
+
+const { linkEntries } = await import("./links");
+const { ROOTS } = await import("./roots");
+
+afterAll(() => {
+  if (REAL_STATE !== undefined) process.env.LLV_STATE_DIR = REAL_STATE;
+  else delete process.env.LLV_STATE_DIR;
+  fs.rmSync(SANDBOX, { recursive: true, force: true });
+});
+
+function entry(pathname: string, name: string, mtime: number): FileEntry {
+  const stat = fs.statSync(pathname);
+  return {
+    path: pathname,
+    root: "claude-projects",
+    name,
+    project: "repo",
+    title: "session",
+    engine: "claude",
+    kind: "session",
+    fmt: "claude",
+    parent: null,
+    mtime,
+    size: stat.size,
+    activity: "idle",
+    derivationComplete: true,
+    proc: null,
+    pid: null,
+    model: "sonnet-4",
+    pendingQuestion: null,
+    waitingInput: null,
+  };
+}
+
+test("compaction lineage proof reads a bounded predecessor tail", async () => {
+  const slug = "-repo-bounded-compaction";
+  const predecessorPath = path.join(SANDBOX, "predecessor.jsonl");
+  const successorPath = path.join(SANDBOX, "successor.jsonl");
+  const logicalParentUuid = "11111111-2222-4333-8444-555555555555";
+  fs.writeFileSync(predecessorPath, Buffer.concat([
+    Buffer.from(`${JSON.stringify({ type: "user", uuid: "head" })}\n`),
+    Buffer.alloc(8 * 1024 * 1024, 0x20),
+    Buffer.from(`\n${JSON.stringify({ type: "assistant", uuid: logicalParentUuid })}\n`),
+  ]));
+  fs.writeFileSync(successorPath, `${JSON.stringify({
+    type: "system",
+    subtype: "compact_boundary",
+    logicalParentUuid,
+  })}\n`);
+  const predecessor = entry(predecessorPath, `${slug}/predecessor.jsonl`, 1);
+  const successor = entry(successorPath, `${slug}/successor.jsonl`, 2);
+  const originalOpen = fs.openSync;
+  const originalRead = fs.readSync;
+  const originalClose = fs.closeSync;
+  const tracked = new Set<number>();
+  let bytesRead = 0;
+  fs.openSync = ((filename: fs.PathLike, flags: fs.OpenMode, mode?: fs.Mode) => {
+    const fd = originalOpen(filename, flags, mode);
+    if (path.resolve(String(filename)) === predecessorPath) tracked.add(fd);
+    return fd;
+  }) as typeof fs.openSync;
+  fs.readSync = ((fd: number, buffer: NodeJS.ArrayBufferView, offset: number, length: number, position: fs.ReadPosition) => {
+    const read = originalRead(fd, buffer, offset, length, position);
+    if (tracked.has(fd)) bytesRead += read;
+    return read;
+  }) as typeof fs.readSync;
+  fs.closeSync = ((fd: number) => {
+    tracked.delete(fd);
+    return originalClose(fd);
+  }) as typeof fs.closeSync;
+
+  try {
+    await linkEntries([predecessor, successor], { persist: false });
+  } finally {
+    fs.openSync = originalOpen;
+    fs.readSync = originalRead;
+    fs.closeSync = originalClose;
+  }
+
+  expect(predecessor.parent).toBe(successor.path);
+  expect(bytesRead).toBeLessThanOrEqual(1024 * 1024);
+});
+
+test("background command recovery advances within one bounded read budget", async () => {
+  const projectRoot = path.join(SANDBOX, "background-projects");
+  const taskRoot = path.join(SANDBOX, "background-tasks");
+  const previousProjectRoot = ROOTS["claude-projects"];
+  const previousTaskRoot = ROOTS["claude-tasks"];
+  ROOTS["claude-projects"] = projectRoot;
+  ROOTS["claude-tasks"] = taskRoot;
+  const slug = "-repo-bounded-background";
+  const sid = "session-bounded-background";
+  const tid = "task-bounded-background";
+  const toolUseId = "toolu_bounded_background";
+  const mainPath = path.join(projectRoot, slug, `${sid}.jsonl`);
+  const taskPath = path.join(taskRoot, slug, sid, "tasks", `${tid}.output`);
+  fs.mkdirSync(path.dirname(mainPath), { recursive: true });
+  fs.mkdirSync(path.dirname(taskPath), { recursive: true });
+  const toolUse = JSON.stringify({
+    type: "assistant",
+    message: {
+      content: [{
+        type: "tool_use",
+        id: toolUseId,
+        name: "Bash",
+        input: { command: "bun run bounded-worker", description: "Run bounded worker" },
+      }],
+    },
+  });
+  const filler = `${JSON.stringify({ type: "progress", payload: "x".repeat(64 * 1024) })}\n`.repeat(128);
+  const banner = JSON.stringify({
+    type: "user",
+    tool_use_id: toolUseId,
+    message: {
+      content: [{
+        type: "tool_result",
+        tool_use_id: toolUseId,
+        content: `background with ID: ${tid}`,
+      }],
+    },
+  });
+  fs.writeFileSync(mainPath, `${toolUse}\n${filler}${banner}\n`);
+  fs.writeFileSync(taskPath, "complete\n");
+  const main = entry(mainPath, `${slug}/${sid}.jsonl`, 1);
+  const task: FileEntry = {
+    ...entry(taskPath, `${slug}/${sid}/tasks/${tid}.output`, 2),
+    root: "claude-tasks",
+    engine: "shell",
+    fmt: "plain",
+    kind: "task",
+  };
+
+  const originalOpen = fs.openSync;
+  const originalRead = fs.readSync;
+  const originalReadFile = fs.readFileSync;
+  const originalClose = fs.closeSync;
+  const tracked = new Set<number>();
+  let bytesRead = 0;
+  try {
+    await linkEntries([main], { persist: false });
+    fs.openSync = ((filename: fs.PathLike, flags: fs.OpenMode, mode?: fs.Mode) => {
+      const fd = originalOpen(filename, flags, mode);
+      if (path.resolve(String(filename)) === mainPath) tracked.add(fd);
+      return fd;
+    }) as typeof fs.openSync;
+    fs.readSync = ((fd: number, buffer: NodeJS.ArrayBufferView, offset: number, length: number, position: fs.ReadPosition) => {
+      const read = originalRead(fd, buffer, offset, length, position);
+      if (tracked.has(fd)) bytesRead += read;
+      return read;
+    }) as typeof fs.readSync;
+    fs.readFileSync = ((filename: fs.PathOrFileDescriptor, ...args: unknown[]) => {
+      const value = Reflect.apply(originalReadFile, fs, [filename, ...args]) as Buffer | string;
+      if (typeof filename !== "number" && path.resolve(String(filename)) === mainPath) {
+        bytesRead += typeof value === "string" ? Buffer.byteLength(value) : value.byteLength;
+      }
+      return value;
+    }) as typeof fs.readFileSync;
+    fs.closeSync = ((fd: number) => {
+      tracked.delete(fd);
+      return originalClose(fd);
+    }) as typeof fs.closeSync;
+
+    const readsByPass: number[] = [];
+    for (let attempt = 0; attempt < 40 && task.cmd !== "bun run bounded-worker"; attempt += 1) {
+      const before = bytesRead;
+      await linkEntries([main, task], { persist: false });
+      readsByPass.push(bytesRead - before);
+    }
+
+    expect(task).toMatchObject({
+      parent: mainPath,
+      cmd: "bun run bounded-worker",
+      cmdDesc: "Run bounded worker",
+      title: "Run bounded worker",
+    });
+    expect(Math.max(...readsByPass)).toBeLessThanOrEqual(256 * 1024);
+  } finally {
+    fs.openSync = originalOpen;
+    fs.readSync = originalRead;
+    fs.readFileSync = originalReadFile;
+    fs.closeSync = originalClose;
+    ROOTS["claude-projects"] = previousProjectRoot;
+    ROOTS["claude-tasks"] = previousTaskRoot;
+  }
+});
+
+test("proven background commands survive restart without source transcript reads", async () => {
+  const projectRoot = path.join(SANDBOX, "restart-projects");
+  const taskRoot = path.join(SANDBOX, "restart-tasks");
+  const previousProjectRoot = ROOTS["claude-projects"];
+  const previousTaskRoot = ROOTS["claude-tasks"];
+  ROOTS["claude-projects"] = projectRoot;
+  ROOTS["claude-tasks"] = taskRoot;
+  const slug = "-repo-restart-background";
+  const sid = "session-restart-background";
+  const tid = "task-restart-background";
+  const toolUseId = "toolu_restart_background";
+  const mainPath = path.join(projectRoot, slug, `${sid}.jsonl`);
+  const taskPath = path.join(taskRoot, slug, sid, "tasks", `${tid}.output`);
+  fs.mkdirSync(path.dirname(mainPath), { recursive: true });
+  fs.mkdirSync(path.dirname(taskPath), { recursive: true });
+  fs.writeFileSync(mainPath, [
+    JSON.stringify({
+      type: "assistant",
+      message: {
+        content: [{
+          type: "tool_use",
+          id: toolUseId,
+          name: "Bash",
+          input: { command: "bun run restart-worker", description: "Run restart worker" },
+        }],
+      },
+    }),
+    `${JSON.stringify({ type: "progress", payload: "y".repeat(64 * 1024) })}\n`.repeat(32).trimEnd(),
+    JSON.stringify({
+      type: "user",
+      tool_use_id: toolUseId,
+      message: {
+        content: [{
+          type: "tool_result",
+          tool_use_id: toolUseId,
+          content: `background with ID: ${tid}`,
+        }],
+      },
+    }),
+    "",
+  ].join("\n"));
+  fs.writeFileSync(taskPath, "complete\n");
+  const main = entry(mainPath, `${slug}/${sid}.jsonl`, 1);
+  const task: FileEntry = {
+    ...entry(taskPath, `${slug}/${sid}/tasks/${tid}.output`, 2),
+    root: "claude-tasks",
+    engine: "shell",
+    fmt: "plain",
+    kind: "task",
+  };
+  const cacheStore = globalThis as typeof globalThis & { __llvCaches?: Record<string, Map<string, unknown>> };
+  for (const cache of Object.values(cacheStore.__llvCaches ?? {})) cache.clear();
+
+  const originalOpen = fs.openSync;
+  const originalRead = fs.readSync;
+  const originalReadFile = fs.readFileSync;
+  const originalClose = fs.closeSync;
+  const tracked = new Set<number>();
+  let bytesRead = 0;
+  try {
+    for (let attempt = 0; attempt < 12 && task.cmd !== "bun run restart-worker"; attempt += 1) {
+      await linkEntries([main, task], { persist: true });
+    }
+    expect(task.cmd).toBe("bun run restart-worker");
+    expect(fs.existsSync(path.join(process.env.LLV_STATE_DIR!, "bg-commands.json"))).toBe(true);
+
+    for (const cache of Object.values(cacheStore.__llvCaches ?? {})) cache.clear();
+    task.parent = null;
+    task.cmd = "";
+    task.cmdDesc = "";
+    task.title = "Background task after restart";
+    await linkEntries([main], { persist: false });
+
+    fs.appendFileSync(mainPath, `${JSON.stringify({ type: "progress", payload: "late growth" })}\n`);
+    fs.openSync = ((filename: fs.PathLike, flags: fs.OpenMode, mode?: fs.Mode) => {
+      const fd = originalOpen(filename, flags, mode);
+      if (path.resolve(String(filename)) === mainPath) tracked.add(fd);
+      return fd;
+    }) as typeof fs.openSync;
+    fs.readSync = ((fd: number, buffer: NodeJS.ArrayBufferView, offset: number, length: number, position: fs.ReadPosition) => {
+      const read = originalRead(fd, buffer, offset, length, position);
+      if (tracked.has(fd)) bytesRead += read;
+      return read;
+    }) as typeof fs.readSync;
+    fs.readFileSync = ((filename: fs.PathOrFileDescriptor, ...args: unknown[]) => {
+      const value = Reflect.apply(originalReadFile, fs, [filename, ...args]) as Buffer | string;
+      if (typeof filename !== "number" && path.resolve(String(filename)) === mainPath) {
+        bytesRead += typeof value === "string" ? Buffer.byteLength(value) : value.byteLength;
+      }
+      return value;
+    }) as typeof fs.readFileSync;
+    fs.closeSync = ((fd: number) => {
+      tracked.delete(fd);
+      return originalClose(fd);
+    }) as typeof fs.closeSync;
+
+    await linkEntries([main, task], { persist: false });
+
+    expect(task).toMatchObject({
+      parent: mainPath,
+      cmd: "bun run restart-worker",
+      cmdDesc: "Run restart worker",
+      title: "Run restart worker",
+    });
+    expect(bytesRead).toBe(0);
+  } finally {
+    fs.openSync = originalOpen;
+    fs.readSync = originalRead;
+    fs.readFileSync = originalReadFile;
+    fs.closeSync = originalClose;
+    ROOTS["claude-projects"] = previousProjectRoot;
+    ROOTS["claude-tasks"] = previousTaskRoot;
+  }
+});
+
+test("proven compaction chains survive restart after predecessor growth", async () => {
+  const slug = "-repo-restart-compaction";
+  const predecessorPath = path.join(SANDBOX, "restart-predecessor.jsonl");
+  const successorPath = path.join(SANDBOX, "restart-successor.jsonl");
+  const logicalParentUuid = "66666666-7777-4888-8999-aaaaaaaaaaaa";
+  fs.writeFileSync(predecessorPath, Buffer.concat([
+    Buffer.alloc(2 * 1024 * 1024, 0x20),
+    Buffer.from(`\n${JSON.stringify({ type: "assistant", uuid: logicalParentUuid })}\n`),
+  ]));
+  fs.writeFileSync(successorPath, `${JSON.stringify({
+    type: "system",
+    subtype: "compact_boundary",
+    logicalParentUuid,
+  })}\n`);
+  const predecessor = entry(predecessorPath, `${slug}/restart-predecessor.jsonl`, 1);
+  const successor = entry(successorPath, `${slug}/restart-successor.jsonl`, 2);
+  const cacheStore = globalThis as typeof globalThis & { __llvCaches?: Record<string, Map<string, unknown>> };
+  for (const cache of Object.values(cacheStore.__llvCaches ?? {})) cache.clear();
+
+  await linkEntries([predecessor, successor], { persist: true });
+  expect(predecessor.parent).toBe(successor.path);
+  expect(fs.existsSync(path.join(process.env.LLV_STATE_DIR!, "compact-chains.json"))).toBe(true);
+
+  for (const cache of Object.values(cacheStore.__llvCaches ?? {})) cache.clear();
+  predecessor.parent = null;
+  fs.appendFileSync(predecessorPath, Buffer.alloc(2 * 1024 * 1024, 0x20));
+  predecessor.size = fs.statSync(predecessorPath).size;
+  const originalOpen = fs.openSync;
+  const originalRead = fs.readSync;
+  const originalClose = fs.closeSync;
+  const tracked = new Set<number>();
+  let bytesRead = 0;
+  fs.openSync = ((filename: fs.PathLike, flags: fs.OpenMode, mode?: fs.Mode) => {
+    const fd = originalOpen(filename, flags, mode);
+    if (path.resolve(String(filename)) === predecessorPath) tracked.add(fd);
+    return fd;
+  }) as typeof fs.openSync;
+  fs.readSync = ((fd: number, buffer: NodeJS.ArrayBufferView, offset: number, length: number, position: fs.ReadPosition) => {
+    const read = originalRead(fd, buffer, offset, length, position);
+    if (tracked.has(fd)) bytesRead += read;
+    return read;
+  }) as typeof fs.readSync;
+  fs.closeSync = ((fd: number) => {
+    tracked.delete(fd);
+    return originalClose(fd);
+  }) as typeof fs.closeSync;
+
+  try {
+    await linkEntries([predecessor, successor], { persist: false });
+  } finally {
+    fs.openSync = originalOpen;
+    fs.readSync = originalRead;
+    fs.closeSync = originalClose;
+  }
+
+  expect(predecessor.parent).toBe(successor.path);
+  expect(bytesRead).toBeLessThanOrEqual(512 * 1024);
+});

--- a/src/lib/scanner/links.ts
+++ b/src/lib/scanner/links.ts
@@ -17,7 +17,7 @@ import { codexThreadIdFromPath, nativeCodexParentThreadId } from "./codexNative"
 import { persistWorktreeMap } from "./describe";
 import { taskParts } from "./discover";
 import { readJson, recordValue, recordsValue, stringValue } from "./json";
-import { fileHasNeedle, fileTailHasNeedle, findNeedle } from "./needle";
+import { fileTailHasNeedle, findNeedle } from "./needle";
 import { readPpid } from "./process";
 import { ROOTS } from "./roots";
 
@@ -165,40 +165,26 @@ function rememberCompactChain(successor: string, predecessor: string): void {
 }
 
 /**
- * Prime permanent lineage facts carried by a completed route snapshot. These
- * proofs survive later source growth because Claude transcripts are append-only
- * and both the spawning tool result and compaction edge are immutable history.
+ * Prime permanent lineage facts carried by a completed route snapshot. A
+ * background command survives later source growth because the spawning tool
+ * result is immutable append-only history, and it is only present in the
+ * snapshot after an authoritative same-file extraction. Compaction edges are
+ * deliberately not primed: a snapshot parent can also carry the nearest-older
+ * fallback taken while the successor was live, and only needle-proven edges
+ * (kept in the compact-chains sidecar) may bypass re-proof.
  */
 export function primePersistedLineageFacts(entries: readonly FileEntry[]): void {
-  const completeMains = new Map(
-    entries
-      .filter((entry) => entry.derivationComplete === true
-        && entry.root === "claude-projects"
-        && entry.name.split(path.sep).length === 2)
-      .map((entry) => [entry.path, entry]),
-  );
   for (const entry of entries) {
     if (entry.derivationComplete !== true) continue;
-    if (entry.root === "claude-tasks" && entry.parent && (entry.cmd || entry.cmdDesc)) {
-      const parts = taskParts(ROOTS["claude-tasks"], entry.path);
-      const tid = parts?.[2];
-      if (tid) {
-        cappedSet(bgcmdCache, tid, {
-          command: entry.cmd ?? "",
-          description: entry.cmdDesc ?? "",
-          source: entry.parent,
-        });
-      }
-      continue;
-    }
-    if (entry.root !== "claude-projects" || entry.handoff || !entry.parent) continue;
-    const predecessor = completeMains.get(entry.path);
-    const successor = completeMains.get(entry.parent);
-    if (!predecessor || !successor) continue;
-    const predecessorSlug = predecessor.name.split(path.sep)[0];
-    const successorSlug = successor.name.split(path.sep)[0];
-    if (predecessorSlug && predecessorSlug === successorSlug) {
-      cappedSet(compactLinkCache, successor.path, predecessor.path);
+    if (entry.root !== "claude-tasks" || !entry.parent || (!entry.cmd && !entry.cmdDesc)) continue;
+    const parts = taskParts(ROOTS["claude-tasks"], entry.path);
+    const tid = parts?.[2];
+    if (tid) {
+      cappedSet(bgcmdCache, tid, {
+        command: entry.cmd ?? "",
+        description: entry.cmdDesc ?? "",
+        source: entry.parent,
+      });
     }
   }
 }
@@ -283,7 +269,7 @@ function chainCompactedSessions(entries: FileEntry[]): void {
     for (const successor of ordered) {
       const rememberedPath = compactLinkCache.get(successor.path);
       const remembered = rememberedPath
-        ? ordered.find((candidate) => candidate.path === rememberedPath && candidate !== successor)
+        ? ordered.find((candidate) => candidate.path === rememberedPath && candidate !== successor && !candidate.parent)
         : undefined;
       if (remembered && !chainsBack(successor, remembered, mains)) {
         remembered.parent = successor.path;

--- a/src/lib/scanner/links.ts
+++ b/src/lib/scanner/links.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import { readdir } from "node:fs/promises";
 import path from "node:path";
+import crypto from "node:crypto";
 
 import { statePath } from "@/lib/configDir";
 
@@ -16,16 +17,191 @@ import { codexThreadIdFromPath, nativeCodexParentThreadId } from "./codexNative"
 import { persistWorktreeMap } from "./describe";
 import { taskParts } from "./discover";
 import { readJson, recordValue, recordsValue, stringValue } from "./json";
-import { fileHasNeedle, findNeedle } from "./needle";
+import { fileHasNeedle, fileTailHasNeedle, findNeedle } from "./needle";
 import { readPpid } from "./process";
 import { ROOTS } from "./roots";
 
 const sidSlugCache = globalCache<string>("sid-slug");
-const bgcmdCache = globalCache<{ command: string; description: string; source: string } | null>("bgcmd");
+type BackgroundCommand = { command: string; description: string; source: string };
+type BackgroundTranscriptIndex = {
+  size: number;
+  mtimeMs: number;
+  offset: number;
+  carry: Buffer;
+  toolUses: Map<string, Omit<BackgroundCommand, "source">>;
+  taskToolUses: Map<string, string>;
+  commands: Map<string, Omit<BackgroundCommand, "source">>;
+  complete: boolean;
+};
+
+const bgcmdCache = globalCache<BackgroundCommand>("bgcmd");
+const backgroundIndexCache = globalCache<BackgroundTranscriptIndex>("background-index-v1");
 const chainCache = globalCache<[number, string | null]>("chain-uuid");
+const compactLinkCache = globalCache<string>("compact-links-v1");
+const lineageStoreState = globalCache<{
+  backgroundLoaded: boolean;
+  backgroundDirty: boolean;
+  compactLoaded: boolean;
+  compactDirty: boolean;
+}>("lineage-store-state-v1");
 
 const CHAIN_HEAD_BYTES = 512 * 1024;
+const BACKGROUND_SCAN_BUDGET_BYTES = 256 * 1024;
+const BACKGROUND_SCAN_CHUNK_BYTES = 64 * 1024;
+const BACKGROUND_INDEX_ENTRY_CAP = 20_000;
+const BACKGROUND_COMMANDS_FILE = "bg-commands.json";
+const BACKGROUND_COMMANDS_VERSION = 1;
+const COMPACT_CHAINS_FILE = "compact-chains.json";
+const COMPACT_CHAINS_VERSION = 1;
 type Limit = <T>(work: () => Promise<T>) => Promise<T>;
+type ReadBudget = { remaining: number };
+
+function currentLineageStoreState() {
+  const filename = statePath(BACKGROUND_COMMANDS_FILE);
+  let state = lineageStoreState.get(filename);
+  if (!state) {
+    state = {
+      backgroundLoaded: false,
+      backgroundDirty: false,
+      compactLoaded: false,
+      compactDirty: false,
+    };
+    lineageStoreState.set(filename, state);
+  }
+  return state;
+}
+
+function loadBackgroundCommands(): void {
+  const state = currentLineageStoreState();
+  if (state.backgroundLoaded) return;
+  state.backgroundLoaded = true;
+  const stored = readJson(statePath(BACKGROUND_COMMANDS_FILE));
+  if (stored?.version !== BACKGROUND_COMMANDS_VERSION) return;
+  const commands = recordValue(stored.commands);
+  if (!commands) return;
+  for (const [tid, value] of Object.entries(commands)) {
+    const command = recordValue(value);
+    if (!command || typeof command.command !== "string" || typeof command.description !== "string"
+      || typeof command.source !== "string" || (!command.command && !command.description)) continue;
+    if (!bgcmdCache.has(tid)) {
+      cappedSet(bgcmdCache, tid, {
+        command: command.command,
+        description: command.description,
+        source: command.source,
+      });
+    }
+  }
+}
+
+function loadCompactChains(): void {
+  const state = currentLineageStoreState();
+  if (state.compactLoaded) return;
+  state.compactLoaded = true;
+  const stored = readJson(statePath(COMPACT_CHAINS_FILE));
+  if (stored?.version !== COMPACT_CHAINS_VERSION) return;
+  const links = recordValue(stored.links);
+  if (!links) return;
+  for (const [successor, predecessor] of Object.entries(links)) {
+    if (typeof predecessor === "string" && predecessor !== successor && !compactLinkCache.has(successor)) {
+      cappedSet(compactLinkCache, successor, predecessor);
+    }
+  }
+}
+
+function writeStateFile(filename: string, value: unknown): boolean {
+  let temporary: string | null = null;
+  try {
+    fs.mkdirSync(path.dirname(filename), { recursive: true, mode: 0o700 });
+    fs.chmodSync(path.dirname(filename), 0o700);
+    temporary = path.join(path.dirname(filename), `.${path.basename(filename)}.${process.pid}.${crypto.randomUUID()}.tmp`);
+    fs.writeFileSync(temporary, JSON.stringify(value) + "\n", { encoding: "utf8", mode: 0o600 });
+    fs.renameSync(temporary, filename);
+    return true;
+  } catch {
+    if (temporary) {
+      try {
+        fs.unlinkSync(temporary);
+      } catch {
+        // The temporary file may be absent when directory creation failed.
+      }
+    }
+    return false;
+  }
+}
+
+function persistBackgroundCommands(): void {
+  const state = currentLineageStoreState();
+  if (!state.backgroundDirty) return;
+  const commands = Object.fromEntries(
+    [...bgcmdCache].filter(([, info]) => info.command || info.description),
+  );
+  if (writeStateFile(statePath(BACKGROUND_COMMANDS_FILE), {
+    version: BACKGROUND_COMMANDS_VERSION,
+    commands,
+  })) state.backgroundDirty = false;
+}
+
+function persistCompactChains(): void {
+  const state = currentLineageStoreState();
+  if (!state.compactDirty) return;
+  if (writeStateFile(statePath(COMPACT_CHAINS_FILE), {
+    version: COMPACT_CHAINS_VERSION,
+    links: Object.fromEntries(compactLinkCache),
+  })) state.compactDirty = false;
+}
+
+function rememberBackgroundCommand(tid: string, info: BackgroundCommand): void {
+  if (bgcmdCache.get(tid)?.command === info.command
+    && bgcmdCache.get(tid)?.description === info.description
+    && bgcmdCache.get(tid)?.source === info.source) return;
+  cappedSet(bgcmdCache, tid, info);
+  currentLineageStoreState().backgroundDirty = true;
+}
+
+function rememberCompactChain(successor: string, predecessor: string): void {
+  if (successor === predecessor || compactLinkCache.get(successor) === predecessor) return;
+  cappedSet(compactLinkCache, successor, predecessor);
+  currentLineageStoreState().compactDirty = true;
+}
+
+/**
+ * Prime permanent lineage facts carried by a completed route snapshot. These
+ * proofs survive later source growth because Claude transcripts are append-only
+ * and both the spawning tool result and compaction edge are immutable history.
+ */
+export function primePersistedLineageFacts(entries: readonly FileEntry[]): void {
+  const completeMains = new Map(
+    entries
+      .filter((entry) => entry.derivationComplete === true
+        && entry.root === "claude-projects"
+        && entry.name.split(path.sep).length === 2)
+      .map((entry) => [entry.path, entry]),
+  );
+  for (const entry of entries) {
+    if (entry.derivationComplete !== true) continue;
+    if (entry.root === "claude-tasks" && entry.parent && (entry.cmd || entry.cmdDesc)) {
+      const parts = taskParts(ROOTS["claude-tasks"], entry.path);
+      const tid = parts?.[2];
+      if (tid) {
+        cappedSet(bgcmdCache, tid, {
+          command: entry.cmd ?? "",
+          description: entry.cmdDesc ?? "",
+          source: entry.parent,
+        });
+      }
+      continue;
+    }
+    if (entry.root !== "claude-projects" || entry.handoff || !entry.parent) continue;
+    const predecessor = completeMains.get(entry.path);
+    const successor = completeMains.get(entry.parent);
+    if (!predecessor || !successor) continue;
+    const predecessorSlug = predecessor.name.split(path.sep)[0];
+    const successorSlug = successor.name.split(path.sep)[0];
+    if (predecessorSlug && predecessorSlug === successorSlug) {
+      cappedSet(compactLinkCache, successor.path, predecessor.path);
+    }
+  }
+}
 
 function createLimiter(max: number): Limit {
   let active = 0;
@@ -105,6 +281,14 @@ function chainCompactedSessions(entries: FileEntry[]): void {
   for (const mains of mainsBySlug.values()) {
     const ordered = [...mains].sort((a, b) => a.mtime - b.mtime);
     for (const successor of ordered) {
+      const rememberedPath = compactLinkCache.get(successor.path);
+      const remembered = rememberedPath
+        ? ordered.find((candidate) => candidate.path === rememberedPath && candidate !== successor)
+        : undefined;
+      if (remembered && !chainsBack(successor, remembered, mains)) {
+        remembered.parent = successor.path;
+        continue;
+      }
       const uuid = compactParentUuid(successor.path, successor.size);
       if (!uuid) continue;
       // Late system records (away_summary…) can bump the predecessor's mtime
@@ -115,9 +299,9 @@ function chainCompactedSessions(entries: FileEntry[]): void {
         .filter((candidate) => candidate !== successor && !candidate.parent)
         .sort((a, b) => b.mtime - a.mtime);
       const alive = successor.activity === "live" || successor.activity === "recent";
-      const predecessor =
-        candidates.find((candidate) => fileHasNeedle(uuid, candidate.path)) ??
-        (alive ? candidates.find((candidate) => candidate.activity !== "live") : undefined);
+      const proven = candidates.find((candidate) => fileTailHasNeedle(uuid, candidate.path));
+      if (proven) rememberCompactChain(successor.path, proven.path);
+      const predecessor = proven ?? (alive ? candidates.find((candidate) => candidate.activity !== "live") : undefined);
       if (predecessor && !chainsBack(successor, predecessor, mains)) predecessor.parent = successor.path;
     }
   }
@@ -189,57 +373,144 @@ function slugMainTranscripts(slug: string, excludeSid: string): string[] {
     .map((candidate) => candidate.pathname);
 }
 
-function extractBgInfo(needle: string, src: string): { command: string; description: string } | null {
-  let toolId: string | null = null;
-  try {
-    for (const line of fs.readFileSync(src, "utf8").split("\n")) {
-      if (!line.includes(needle)) continue;
-      toolId = line.match(/"tool_use_id"\s*:\s*"([^"]+)"/)?.[1] ?? null;
-      break;
-    }
-    if (!toolId) return null;
-    for (const line of fs.readFileSync(src, "utf8").split("\n")) {
-      if (!line.includes(toolId) || !line.includes('"tool_use"')) continue;
-      try {
-        const obj = JSON.parse(line);
-        const content = recordsValue(recordValue(obj.message)?.content);
-        for (const part of content) {
-          if (part.type === "tool_use" && part.id === toolId) {
-            const input = recordValue(part.input) ?? {};
-            return {
-              command: String(input.command ?? ""),
-              description: String(input.description ?? ""),
-            };
-          }
-        }
-      } catch {
-        /* skip */
-      }
-    }
-  } catch {
-    /* skip */
+function cappedSet<K, V>(map: Map<K, V>, key: K, value: V): void {
+  map.delete(key);
+  map.set(key, value);
+  while (map.size > BACKGROUND_INDEX_ENTRY_CAP) {
+    const oldest = map.keys().next().value;
+    if (oldest === undefined) break;
+    map.delete(oldest);
   }
-  return null;
 }
 
-function bgCommand(tid: string, transcripts: (string | null)[], fallbackTranscripts: string[]) {
-  if (bgcmdCache.has(tid)) return bgcmdCache.get(tid) ?? null;
-  const needle = "background with ID: " + tid;
-  // A transcript may quote the needle without owning the task (a grep over
-  // logs, a pasted excerpt), so a hit only counts as authoritative when the
-  // spawning tool_use with its command is recovered from the same file.
-  let weak: { command: string; description: string; source: string } | null = null;
-  for (const src of [...transcripts, ...fallbackTranscripts]) {
-    if (!src || !fileHasNeedle(needle, src)) continue;
-    const info = extractBgInfo(needle, src);
-    if (info && (info.command || info.description)) {
-      const full = { ...info, source: src };
-      bgcmdCache.set(tid, full);
-      return full;
-    }
-    weak ??= { command: "", description: "", source: src };
+function resolveIndexedBackgroundCommands(index: BackgroundTranscriptIndex): void {
+  for (const [tid, toolUseId] of index.taskToolUses) {
+    const toolUse = index.toolUses.get(toolUseId);
+    if (toolUse && (toolUse.command || toolUse.description)) cappedSet(index.commands, tid, toolUse);
   }
-  if (weak) bgcmdCache.set(tid, weak);
+}
+
+function indexBackgroundLine(index: BackgroundTranscriptIndex, line: string): void {
+  if (line.includes('"tool_use"')) {
+    try {
+      const obj = JSON.parse(line);
+      const content = recordsValue(recordValue(obj.message)?.content);
+      for (const part of content) {
+        if (part.type !== "tool_use" || typeof part.id !== "string") continue;
+        const input = recordValue(part.input) ?? {};
+        const command = typeof input.command === "string" ? input.command : "";
+        const description = typeof input.description === "string" ? input.description : "";
+        if (command || description) cappedSet(index.toolUses, part.id, { command, description });
+      }
+    } catch {
+      // A malformed or incomplete record remains eligible after the file grows.
+    }
+  }
+
+  if (line.includes("background with ID: ")) {
+    const toolUseId = line.match(/"tool_use_id"\s*:\s*"([^"]+)"/)?.[1];
+    if (toolUseId) {
+      for (const match of line.matchAll(/background with ID: ([A-Za-z0-9_-]+)/g)) {
+        const tid = match[1];
+        if (tid) cappedSet(index.taskToolUses, tid, toolUseId);
+      }
+    }
+  }
+  resolveIndexedBackgroundCommands(index);
+}
+
+function consumeBackgroundChunk(index: BackgroundTranscriptIndex, chunk: Buffer): void {
+  const bytes = index.carry.length ? Buffer.concat([index.carry, chunk]) : chunk;
+  let lineStart = 0;
+  for (let newline = bytes.indexOf(0x0a, lineStart); newline >= 0; newline = bytes.indexOf(0x0a, lineStart)) {
+    indexBackgroundLine(index, bytes.toString("utf8", lineStart, newline));
+    lineStart = newline + 1;
+  }
+  index.carry = lineStart < bytes.length ? Buffer.from(bytes.subarray(lineStart)) : Buffer.alloc(0);
+}
+
+function freshBackgroundIndex(size: number, mtimeMs: number): BackgroundTranscriptIndex {
+  return {
+    size,
+    mtimeMs,
+    offset: 0,
+    carry: Buffer.alloc(0),
+    toolUses: new Map(),
+    taskToolUses: new Map(),
+    commands: new Map(),
+    complete: size === 0,
+  };
+}
+
+function indexedBackgroundCommand(tid: string, source: string, budget: ReadBudget): BackgroundCommand | null {
+  let stat: fs.Stats;
+  try {
+    stat = fs.statSync(source);
+  } catch {
+    return null;
+  }
+  let index = backgroundIndexCache.get(source);
+  if (!index || stat.size < index.offset || (stat.size === index.size && stat.mtimeMs !== index.mtimeMs)) {
+    index = freshBackgroundIndex(stat.size, stat.mtimeMs);
+    backgroundIndexCache.set(source, index);
+  } else {
+    index.size = stat.size;
+    index.mtimeMs = stat.mtimeMs;
+    index.complete = index.offset >= stat.size;
+  }
+
+  const cached = index.commands.get(tid);
+  if (cached) return { ...cached, source };
+  if (!index.complete && budget.remaining > 0) {
+    let fd: number | null = null;
+    try {
+      fd = fs.openSync(source, "r");
+      while (index.offset < stat.size && budget.remaining > 0 && !index.commands.has(tid)) {
+        const requested = Math.min(
+          BACKGROUND_SCAN_CHUNK_BYTES,
+          budget.remaining,
+          stat.size - index.offset,
+        );
+        const chunk = Buffer.allocUnsafe(requested);
+        const read = fs.readSync(fd, chunk, 0, requested, index.offset);
+        if (read === 0) break;
+        index.offset += read;
+        budget.remaining -= read;
+        consumeBackgroundChunk(index, read === chunk.length ? chunk : Buffer.from(chunk.subarray(0, read)));
+      }
+      index.complete = index.offset >= stat.size;
+      if (index.complete && index.carry.length > 0) indexBackgroundLine(index, index.carry.toString("utf8"));
+    } catch {
+      // The next refresh resumes from the last completely consumed byte.
+    } finally {
+      if (fd !== null) fs.closeSync(fd);
+    }
+  }
+
+  const resolved = index.commands.get(tid);
+  if (resolved) return { ...resolved, source };
+  return index.taskToolUses.has(tid) ? { command: "", description: "", source } : null;
+}
+
+function bgCommand(
+  tid: string,
+  transcripts: (string | null)[],
+  fallbackTranscripts: string[],
+  budget: ReadBudget,
+): BackgroundCommand | null {
+  const cached = bgcmdCache.get(tid);
+  if (cached) return cached;
+  let weak: BackgroundCommand | null = null;
+  for (const source of new Set([...transcripts, ...fallbackTranscripts])) {
+    if (!source) continue;
+    const info = indexedBackgroundCommand(tid, source, budget);
+    if (!info) continue;
+    if (info.command || info.description) {
+      rememberBackgroundCommand(tid, info);
+      return info;
+    }
+    weak ??= info;
+  }
   return weak;
 }
 
@@ -391,7 +662,10 @@ function attachHandoffParents(entries: FileEntry[], persist: boolean): void {
 
 export async function linkEntries(entries: FileEntry[], options: { persist?: boolean } = {}): Promise<void> {
   const persist = options.persist !== false;
+  loadBackgroundCommands();
+  loadCompactChains();
   const limit = createLimiter(48);
+  const backgroundReadBudget = { remaining: BACKGROUND_SCAN_BUDGET_BYTES };
   const byPath = new Map(entries.map((entry) => [entry.path, entry]));
   for (const entry of entries) {
     if (entry.root === "claude-projects") {
@@ -417,7 +691,12 @@ export async function linkEntries(entries: FileEntry[], options: { persist?: boo
       if (!parts) continue;
       const [slug, sid, tid] = parts;
       const [main, subs] = await sessionTranscripts(sid, limit, slug);
-      const info = bgCommand(tid, (main ? [main] : []).concat(subs), slugMainTranscripts(slug, sid));
+      const info = bgCommand(
+        tid,
+        (main ? [main] : []).concat(subs),
+        slugMainTranscripts(slug, sid),
+        backgroundReadBudget,
+      );
       if (info) {
         entry.parent = info.source;
         entry.cmd = info.command;
@@ -457,5 +736,9 @@ export async function linkEntries(entries: FileEntry[], options: { persist?: boo
     if (!entry.parent || !byPath.has(entry.parent)) entry.parent = null;
     else entry.project = rootProject(entry);
   }
-  if (persist) persistWorktreeMap();
+  if (persist) {
+    persistBackgroundCommands();
+    persistCompactChains();
+    persistWorktreeMap();
+  }
 }

--- a/src/lib/scanner/needle.ts
+++ b/src/lib/scanner/needle.ts
@@ -8,6 +8,73 @@ interface NeedleEntry {
 }
 
 const needleCache = globalCache<NeedleEntry>("needle");
+const tailNeedleCache = globalCache<{ size: number; mtimeMs: number; hit: boolean }>("needle-tail-v1");
+
+const INITIAL_TAIL_BYTES = 128 * 1024;
+const MAX_TAIL_BYTES = 1024 * 1024;
+
+function readWindow(fd: number, start: number, length: number): { bytes: Buffer; complete: boolean } {
+  const bytes = Buffer.allocUnsafe(length);
+  let filled = 0;
+  while (filled < length) {
+    const read = fs.readSync(fd, bytes, filled, length - filled, start + filled);
+    if (read === 0) break;
+    filled += read;
+  }
+  return {
+    bytes: filled === bytes.length ? bytes : Buffer.from(bytes.subarray(0, filled)),
+    complete: filled === length,
+  };
+}
+
+/**
+ * Search the immutable end of an append-only transcript through two bounded
+ * windows. Compaction markers reference the predecessor's tail UUID, so the
+ * first 128 KiB tail covers the common case and the preceding bytes extend
+ * the same observation to a 1 MiB ceiling.
+ */
+export function fileTailHasNeedle(needle: string, pathname: string): boolean {
+  const cacheKey = `${needle}\u0000${pathname}`;
+  let stat: fs.Stats;
+  try {
+    stat = fs.statSync(pathname);
+  } catch {
+    return false;
+  }
+  const cached = tailNeedleCache.get(cacheKey);
+  if (cached?.hit) return true;
+  if (cached?.size === stat.size && cached.mtimeMs === stat.mtimeMs) return false;
+
+  const bytes = Buffer.from(needle);
+  const initialLength = Math.min(stat.size, INITIAL_TAIL_BYTES);
+  let fd: number | null = null;
+  try {
+    fd = fs.openSync(pathname, "r");
+    const initial = readWindow(fd, stat.size - initialLength, initialLength);
+    if (initial.bytes.includes(bytes)) {
+      tailNeedleCache.set(cacheKey, { size: stat.size, mtimeMs: stat.mtimeMs, hit: true });
+      return true;
+    }
+
+    let complete = initial.complete;
+    let hit = false;
+    const totalLength = Math.min(stat.size, MAX_TAIL_BYTES);
+    const prefixLength = totalLength - initialLength;
+    if (prefixLength > 0) {
+      const prefix = readWindow(fd, stat.size - totalLength, prefixLength);
+      complete &&= prefix.complete;
+      hit = Buffer.concat([prefix.bytes, initial.bytes]).includes(bytes);
+    }
+    if (hit || complete) {
+      tailNeedleCache.set(cacheKey, { size: stat.size, mtimeMs: stat.mtimeMs, hit });
+    }
+    return hit;
+  } catch {
+    return false;
+  } finally {
+    if (fd !== null) fs.closeSync(fd);
+  }
+}
 
 /**
  * Incremental per-file needle scan: remembers how many bytes of each file were

--- a/src/lib/scanner/scanCache.ts
+++ b/src/lib/scanner/scanCache.ts
@@ -6,6 +6,7 @@ import { statePath } from "@/lib/configDir";
 import { listFilesWithProjectCatalog } from "@/lib/scanner";
 import { primeTranscriptTurnEvidence } from "@/lib/scanner/activity";
 import { globalCache } from "@/lib/scanner/caches";
+import { primePersistedLineageFacts } from "@/lib/scanner/links";
 import type { FileEntry, PendingQuestion } from "@/lib/types";
 import type { TurnState } from "@/lib/accounts/migration/contracts";
 
@@ -144,6 +145,7 @@ function persistedQuestionDraft(entry: FileEntry): Omit<PendingQuestion, "pid" |
 }
 
 function primePersistedFileDerivations(snapshot: FileScanSnapshot): void {
+  primePersistedLineageFacts(snapshot.files);
   for (const entry of snapshot.files) {
     if (entry.derivationComplete !== true) continue;
     let current: fs.Stats;


### PR DESCRIPTION
## Summary

- preserve the rescued bounded scanner-index work from `19ce975e`
- keep compact-chain durability authoritative through needle-proven `compact-chains.json`
- stop snapshot-carried heuristic parent edges from contaminating the proven chain store
- preserve durable background-command priming across restarts
- add bounded performance and restart correctness coverage

## Production evidence

- restart-with-snapshot reads: 56.9 MiB → 13.2 MiB
- warm generation: about 5 MiB / 250 ms
- 400 bounded lineage passes: 7.1 MiB total with byte-identical recovered background commands
- first fresh-install generation still pays the bounded model/effort head fallback; this remains a follow-up slice in #287

## Verification

- 26/26 focused scanner and files API tests
- TypeScript clean
- changed-file ESLint clean
- production build green
- `git diff --check` clean
- fresh Fable correctness/performance review: APPROVE

The full-suite environment failures reproduced on the base commit and remain outside this five-file diff.

Advances #287.