### PR TITLE
Structured-only Claude role launches and broker lifecycle recovery (#367)

### DIFF
--- a/src/app/api/spawn/route.test.ts
+++ b/src/app/api/spawn/route.test.ts
@@ -878,7 +878,7 @@ test("operator callers may grant native sub-agent permission", async () => {
   expect(await response.json()).toEqual({ error: "working directory is required" });
 });
 
-test("operator structured Claude retries retain bypass and agent reuse conflicts", async () => {
+test("operator and agent structured Claude role launches both retain bypass permissions", async () => {
   const cwd = fs.mkdtempSync(path.join(routeSandbox, "operator-permission-"));
   const store = agentRegistry();
   const callerSessionId = crypto.randomUUID();
@@ -927,16 +927,19 @@ test("operator structured Claude retries retain bypass and agent reuse conflicts
     expect(replay.status).toBe(202);
     expect(await replay.json()).toMatchObject({ state: "starting", effectivePermissionMode: "bypassPermissions" });
 
-    const conflict = await POST.withDependencies(request(agentCapability), structuredRouteDependencies(cwd));
-    expect(conflict.status).toBe(409);
-    expect(await conflict.json()).toEqual({ error: "spawn attempt conflicts with its original request" });
+    /* The agent capability lane resolves the same role request to the same
+       permission contract, so reusing the operator attempt id is an idempotent
+       replay instead of a permission-mode conflict. */
+    const crossLaneReplay = await POST.withDependencies(request(agentCapability), structuredRouteDependencies(cwd));
+    expect(crossLaneReplay.status).toBe(202);
+    expect(await crossLaneReplay.json()).toMatchObject({ state: "starting", effectivePermissionMode: "bypassPermissions" });
 
     const agentAttemptId = `attempt_${crypto.randomUUID()}`;
     const agentLaunch = await POST.withDependencies(request(agentCapability, agentAttemptId), structuredRouteDependencies(cwd));
-    expect(await agentLaunch.json()).toMatchObject({ effectivePermissionMode: "default" });
+    expect(await agentLaunch.json()).toMatchObject({ effectivePermissionMode: "bypassPermissions" });
     const agentReplay = await POST.withDependencies(request(agentCapability, agentAttemptId), structuredRouteDependencies(cwd));
     expect(agentReplay.status).toBe(202);
-    expect(await agentReplay.json()).toMatchObject({ state: "starting", effectivePermissionMode: "default" });
+    expect(await agentReplay.json()).toMatchObject({ state: "starting", effectivePermissionMode: "bypassPermissions" });
   } finally {
     if (previousTransport === undefined) delete process.env.LLV_SPAWN_TRANSPORT;
     else process.env.LLV_SPAWN_TRANSPORT = previousTransport;

--- a/src/lib/agent/cli.ts
+++ b/src/lib/agent/cli.ts
@@ -67,6 +67,10 @@ export interface ResumeSpec {
   /** Transcript path the session will write, when knowable at spawn time —
       a fresh claude session launched with a pre-chosen --session-id. */
   transcript?: string;
+  /** Non-interactive `claude -p` command that can never present a permission
+      acceptance gate; the only Claude shape a tmux window may still host
+      under structured transport (the migration successor fork). */
+  printMode?: true;
   launchProfile?: LaunchProfile;
 }
 
@@ -239,6 +243,7 @@ export function claudeSuccessorSpecFor(input: {
     windowName: "claude-migration-successor",
     engine: "claude",
     transcript: claudeTranscriptPath(input.profile.cwd || resumeCwd(input.sourcePath), input.candidateId, input.targetProjectsDir),
+    printMode: true,
     launchProfile: { ...input.profile, model },
   };
 }

--- a/src/lib/agent/transcriptHost.test.ts
+++ b/src/lib/agent/transcriptHost.test.ts
@@ -696,3 +696,57 @@ describe("transcript host resolver", () => {
     expect(state.spawnCalls).toBe(0);
   });
 });
+
+test("the structured-transport resume ladder refuses to open a legacy tmux Claude window", async () => {
+  const previousTransport = process.env.LLV_SPAWN_TRANSPORT;
+  process.env.LLV_SPAWN_TRANSPORT = "structured";
+  try {
+    const claudePath = "/home/user/.claude/projects/-repo/0f0e9d8c-0000-4000-8000-000000000001.jsonl";
+    const claudeEntry = entry({
+      path: claudePath,
+      name: claudePath,
+      root: "claude-projects",
+      engine: "claude",
+      fmt: "claude",
+      pid: null,
+      proc: "done",
+      activity: "idle",
+    });
+    const { spawnAgentWithPrompt } = await import("@/lib/tmux");
+    const resolver = createTranscriptHostResolver({
+      listFiles: async () => [claudeEntry],
+      panes: async () => ({ kind: "no-server" as const }),
+      ppidMap: () => new Map(),
+      agents: () => [],
+      serverPid: async () => null,
+      resumeRecords: async () => null,
+      panePid: async () => null,
+      alive: () => false,
+      argv: () => [],
+      parentPid: () => null,
+      identity: () => null,
+      /* The production resume ladder — a spawn here would create the exact
+         stale interactive pane observed as %23 in session 50c0f4cf. */
+      spawn: (resumeSpec, text, receipt) => spawnAgentWithPrompt(resumeSpec, text, receipt),
+      remember: async () => { throw new Error("a refused resume must never be remembered as a pane"); },
+      deliver: async () => { throw new Error("a refused resume must never deliver into a pane"); },
+    });
+
+    const outcome = await resolver.deliverToTranscriptHost({
+      entry: claudeEntry,
+      spec: {
+        command: "claude --dangerously-skip-permissions --resume 0f0e9d8c-0000-4000-8000-000000000001",
+        cwd: "/repo",
+        windowName: "claude-resume",
+        engine: "claude",
+      },
+      payload: "hello",
+    });
+
+    expect(outcome.ok).toBeFalse();
+    if (!outcome.ok) expect(outcome.error).toMatch(/structured transport prohibits legacy tmux Claude launches/);
+  } finally {
+    if (previousTransport === undefined) delete process.env.LLV_SPAWN_TRANSPORT;
+    else process.env.LLV_SPAWN_TRANSPORT = previousTransport;
+  }
+});

--- a/src/lib/flows/engine.test.ts
+++ b/src/lib/flows/engine.test.ts
@@ -1181,3 +1181,88 @@ test("relayFixOrPark treats a 0 limit as unlimited", () => {
   relayFixOrPark(clone);
   expect(clone.state).toBe("fixing");
 });
+
+test("a pane-mode Claude review launch under structured transport parks without a tmux pane and fails its receipt", async () => {
+  const previousTransport = process.env.LLV_SPAWN_TRANSPORT;
+  const previousClaudeHome = process.env.LLV_CLAUDE_HOME;
+  process.env.LLV_SPAWN_TRANSPORT = "structured";
+  process.env.LLV_CLAUDE_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "llv-flow-no-tmux-home-"));
+  const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "llv-flow-no-tmux-repo-"));
+  try {
+    expect(spawnSync("git", ["init", "-b", "main"], { cwd }).status).toBe(0);
+    expect(spawnSync("git", ["config", "user.email", "flow@example.test"], { cwd }).status).toBe(0);
+    expect(spawnSync("git", ["config", "user.name", "Flow Test"], { cwd }).status).toBe(0);
+    fs.writeFileSync(path.join(cwd, "work.txt"), "committed\n");
+    expect(spawnSync("git", ["add", "work.txt"], { cwd }).status).toBe(0);
+    expect(spawnSync("git", ["commit", "-m", "reviewed"], { cwd }).status).toBe(0);
+    const implementer = writeCodexEntry("no-tmux-pane-implementer.jsonl", { id: "019f421e-02e1-73e0-9b77-bebde063f130", cwd }, Date.now() / 1_000);
+    const startedAt = new Date().toISOString();
+    const flow: Flow = {
+      id: "flow-no-tmux-pane",
+      template: "implement-review-loop",
+      project: "repo",
+      cwd,
+      implementerPath: implementer.path,
+      roles: {
+        implementer: { engine: "codex", model: null, effort: "high" },
+        reviewer: { engine: "claude", model: "fable", effort: "high" },
+      },
+      reviewerFallback: null,
+      baseRef: "base",
+      baseMode: "head",
+      mode: "auto",
+      reviewerMode: "pane",
+      roundLimit: 5,
+      state: "spawning",
+      pausedState: null,
+      stateDetail: null,
+      rounds: [{
+        n: 1,
+        reviewerPath: null,
+        reviewerRole: null,
+        accountId: null,
+        attemptedAccounts: [],
+        autoRetryCount: 0,
+        sessionId: null,
+        reviewerPid: null,
+        reviewerIdentity: null,
+        reviewerPane: null,
+        findingsPath: null,
+        triggeredBy: "marker",
+        readyNote: null,
+        reviewHeadSha: null,
+        verdict: null,
+        findingsCount: null,
+        startedAt,
+        spawnStartedAt: null,
+        relayStartedAt: null,
+        relayDelivery: null,
+        reviewedAt: null,
+        terminalAt: null,
+        relayedAt: null,
+        error: null,
+      }],
+      createdAt: startedAt,
+      closedAt: null,
+    };
+    saveFlows([flow]);
+
+    await tickFlows([implementer]);
+
+    const parked = loadFlows()[0]!;
+    expect(parked.state).toBe("needs_decision");
+    expect(parked.stateDetail).toMatch(/structured transport prohibits legacy tmux Claude launches/);
+    expect(parked.rounds[0]).toMatchObject({ reviewerPane: null, reviewerPid: null });
+    const launchId = parked.rounds[0]!.launchId;
+    expect(launchId).toBeTruthy();
+    const receipt = (await import("@/lib/agent/registry")).agentRegistry().snapshot().receipts[launchId!];
+    expect(receipt).toMatchObject({ state: "failed", pane: null });
+    expect(receipt!.error).toMatch(/structured transport prohibits legacy tmux Claude launches/);
+  } finally {
+    if (previousTransport === undefined) delete process.env.LLV_SPAWN_TRANSPORT;
+    else process.env.LLV_SPAWN_TRANSPORT = previousTransport;
+    if (previousClaudeHome === undefined) delete process.env.LLV_CLAUDE_HOME;
+    else process.env.LLV_CLAUDE_HOME = previousClaudeHome;
+    fs.rmSync(cwd, { recursive: true, force: true });
+  }
+});

--- a/src/lib/pipelines/engine.ts
+++ b/src/lib/pipelines/engine.ts
@@ -1,13 +1,11 @@
 import crypto from "node:crypto";
 import path from "node:path";
 
-import { isManagedClaudeHome } from "@/lib/accounts/claude";
 import { accountManager } from "@/lib/accounts/manager";
 import { emptyLaunchProfile, type ViewerConversationId } from "@/lib/accounts/migration/contracts";
 import { freshSpecFor } from "@/lib/agent/cli";
 import { agentRegistry, type DurableMembershipInput } from "@/lib/agent/registry";
 import { sessionKeyFromTranscript } from "@/lib/agent/sessionKey";
-import { prepareManagedClaudeSpawnHome } from "@/lib/agent/spawnPolicy";
 import { headCwd } from "@/lib/agent/transcript";
 import { MAX_FLOW_NOTE_LENGTH, closeFlow, createFlowFromRequest, patchFlow } from "@/lib/flows/commands";
 import { lastAssistantMessage } from "@/lib/flows/findings";
@@ -114,9 +112,6 @@ async function spawnPipelineAgent(
 ): Promise<PipelineStageSpawn> {
   const account = accountManager.resolveSpawn(input.role.engine);
   const parent = parentIdentity(input.parentPath);
-  if (input.role.engine === "claude" && isManagedClaudeHome(account.home)) {
-    prepareManagedClaudeSpawnHome(account.home, input.cwd);
-  }
   const specBase = freshSpecFor(input.role.engine, input.cwd, {
     model: input.role.model,
     effort: input.role.effort,

--- a/src/lib/runtime/claudeStreamBrokerHost.test.ts
+++ b/src/lib/runtime/claudeStreamBrokerHost.test.ts
@@ -1736,3 +1736,78 @@ describe("ClaudeStreamBrokerHost", () => {
     }
   });
 });
+
+/* Issue #367 live reproduction: a Viewer-only restart during active Fable
+   stages must recover broker sessions as idle with the interrupted turn closed
+   in the ledger, and a kill must settle even when the dead leader's escaped
+   descendant keeps the stdio pipes open. */
+describe("restart and kill fail-safe lifecycle", () => {
+  test("adoption after a Viewer restart closes the interrupted turn and never retains an active ledger turn", async () => {
+    const sessionId = crypto.randomUUID();
+    const eventStore = new MemoryEventStore();
+    /* The pre-restart Viewer persisted a started turn and then died before
+       the stage could finish — the exact five-active-stages restart shape. */
+    eventStore.append(sessionId, { kind: "turn-started", turnId: "stage-turn", seq: 1 } as RuntimeEvent);
+
+    const child = new FakeClaude(new RecordingDeliveryLedger());
+    const host = await ClaudeStreamBrokerHost.adopt(sessionId, {
+      cwd: "/repo",
+      eventStore,
+      deliveryLedger: new RecordingDeliveryLedger(),
+      readAuthStatus: () => ({ loggedIn: true, authMethod: "claude.ai", subscriptionType: "max" }),
+      readTranscript: () => [],
+      spawnProcess: fakeSpawn(child, {}),
+    });
+    try {
+      expect(await host.health()).toMatchObject({ status: "idle", activeTurnRef: null, pendingAttention: [] });
+      const replay = host.attach(0)[Symbol.asyncIterator]();
+      expect(await nextEvent(replay)).toMatchObject({ kind: "turn-started", turnId: "stage-turn", seq: 1 });
+      /* The recovered ledger must close the orphaned turn as an error — an
+         idle session with an eternally active turn misreads as "stage
+         completed" and parked #287-style attempts in production. */
+      expect(await nextEvent(replay)).toMatchObject({ kind: "turn-ended", turnId: "stage-turn", status: "error", seq: 2 });
+      expect(await nextEvent(replay)).toMatchObject({ kind: "session-status", status: "idle", seq: 3 });
+    } finally {
+      await host.release();
+    }
+  });
+
+  test("release force-reaps a dead leader whose escaped descendant holds the stdio pipes open", async () => {
+    const ledger = new RecordingDeliveryLedger();
+    const child = new FakeClaude(ledger, true, true);
+    const host = await ClaudeStreamBrokerHost.start({
+      cwd: "/repo",
+      deliveryLedger: ledger,
+      eventStore: new MemoryEventStore(),
+      shutdownGraceMs: 2,
+      readAuthStatus: () => ({ loggedIn: true, authMethod: "claude.ai", subscriptionType: "max" }),
+      readTranscript: () => [],
+      spawnProcess: fakeSpawn(child, {}),
+    });
+    const states: HostState[] = [];
+    host.onStateChange((state) => states.push(state));
+    const content = structuredContent("finish the stage", []);
+    /* The turn starts immediately; the delivery confirmation stays pending —
+       release rejects it, which is the expected shape of a mid-turn kill. */
+    const pendingSend = host.send({ id: "turn-stale", ...content }).catch(() => null);
+    await Bun.sleep(0);
+    expect((await host.health()).activeTurnRef).toBe("turn-stale");
+
+    /* The kernel reaped the leader (exit evidence is recorded on the child)
+       while a grandchild keeps stdout open, so "close" never fires. Kill must
+       settle instead of failing forever with "could not be reaped". */
+    (child as unknown as { exitCode: number | null }).exitCode = 137;
+    (child as unknown as { signalCode: NodeJS.Signals | null }).signalCode = "SIGKILL";
+
+    await expect(host.release()).resolves.toBeUndefined();
+    expect(await host.health()).toMatchObject({
+      status: "unhosted",
+      pid: null,
+      endpoint: "stdio:released",
+      activeTurnRef: null,
+    });
+    expect(states.at(-1)).toMatchObject({ status: "unhosted", pid: null });
+    await expect(host.release()).resolves.toBeUndefined();
+    await pendingSend;
+  });
+});

--- a/src/lib/runtime/claudeStreamBrokerHost.ts
+++ b/src/lib/runtime/claudeStreamBrokerHost.ts
@@ -986,7 +986,26 @@ export class ClaudeStreamBrokerHost implements EngineHost {
     this.startTermination();
     if (!await this.waitForReap(this.shutdownGraceMs * 2)) {
       signalDetachedProcessGroup(this.child, "SIGKILL", this.signalProcess);
-      if (!await this.waitForReap(this.shutdownGraceMs)) throw new Error("Claude child could not be reaped");
+      if (!await this.waitForReap(this.shutdownGraceMs)) {
+        /* "close" waits on the stdio pipes, which an escaped descendant can
+           hold open long after the leader died — a kill that keeps failing
+           with an unreapable child wedges the session's terminal receipt
+           forever. The recorded exit evidence is authoritative: when the
+           leader is gone, destroy our pipe ends and settle the reap. */
+        const leaderExited = this.child.pid === undefined
+          || (this.child.exitCode ?? null) !== null
+          || (this.child.signalCode ?? null) !== null;
+        if (!leaderExited) throw new Error("Claude child could not be reaped");
+        for (const stream of [this.child.stdin, this.child.stdout, this.child.stderr]) {
+          try { stream?.destroy(); } catch { /* pipe already closed */ }
+        }
+        this.reaped = true;
+        if (this.terminationTimer) {
+          clearTimeout(this.terminationTimer);
+          this.terminationTimer = null;
+        }
+        this.resolveReaped();
+      }
     }
     this.finishRelease();
   }

--- a/src/lib/runtime/structuredSpawn.integration.test.ts
+++ b/src/lib/runtime/structuredSpawn.integration.test.ts
@@ -45,6 +45,11 @@ test("structured Claude permission mapping distinguishes trusted autonomous spaw
     agentInitiated: true,
     operatorAuthenticated: false,
     roleSpawn: true,
+  })).toBe("bypassPermissions");
+  expect(structuredClaudePermissionMode("bypassPermissions", {
+    agentInitiated: true,
+    operatorAuthenticated: false,
+    roleSpawn: false,
   })).toBe("default");
   expect(structuredClaudePermissionMode("bypassPermissions", {
     agentInitiated: false,
@@ -3285,7 +3290,17 @@ describe.each(["codex", "claude"] as const)("%s structured spawn round trip", (e
     });
 
     expect(response).toMatchObject({ launched: true, target: null, path: artifactPath, state: "settled" });
-    if (engine === "claude") expect(response).toMatchObject({ effectivePermissionMode: "default" });
+    if (engine === "claude") {
+      expect(response).toMatchObject({ effectivePermissionMode: "default" });
+      /* Bypass acceptance readiness lands in the managed home before runtime
+         admission, so no launch can wait at an interactive acceptance gate. */
+      const homeState = JSON.parse(fs.readFileSync(path.join(account.home, ".claude.json"), "utf8")) as {
+        bypassPermissionsModeAccepted?: boolean;
+        projects?: Record<string, { hasTrustDialogAccepted?: boolean }>;
+      };
+      expect(homeState.bypassPermissionsModeAccepted).toBeTrue();
+      expect(homeState.projects?.[cwd]?.hasTrustDialogAccepted).toBeTrue();
+    }
     expect(registry.snapshot().receipts[begun.receipt.launchId]?.pane).toBeNull();
     const registryBeforeAttach = registry.snapshot();
     let terminalCommand = "";

--- a/src/lib/runtime/structuredSpawn.ts
+++ b/src/lib/runtime/structuredSpawn.ts
@@ -7,6 +7,7 @@ import type { AgentEngine, ResumeSpec } from "@/lib/agent/cli";
 import type { AgentRegistry, AgentRegistryEntry, SpawnReceipt, StructuredHostColumns } from "@/lib/agent/registry";
 import { sessionKey, sessionKeyId, type SessionKey } from "@/lib/agent/sessionKey";
 import type { SpawnResponse } from "@/lib/agent/spawnResponse";
+import { prepareManagedClaudeSpawnHome } from "@/lib/agent/spawnPolicy";
 import { claudeTranscriptPath } from "@/lib/agent/transcript";
 import { procBackend } from "@/lib/proc";
 import { hasUserAuthoredMessage } from "@/lib/session/reader";
@@ -549,13 +550,17 @@ export interface StructuredClaudePermissionContext {
   roleSpawn: boolean;
 }
 
+/** Viewer-managed role launches run autonomously behind prompt and tool
+    fences, so a role spawn keeps the full-permission mode regardless of which
+    capability lane admitted it; only a role-less agent-initiated spawn loses
+    the bypass. */
 export function structuredClaudePermissionMode(
   mode: string | null | undefined,
   context: StructuredClaudePermissionContext,
 ): string {
   if (!mode) return "default";
   if (mode !== "bypassPermissions") return mode;
-  return !context.agentInitiated || context.operatorAuthenticated ? mode : "default";
+  return !context.agentInitiated || context.operatorAuthenticated || context.roleSpawn ? mode : "default";
 }
 
 export function structuredClaudeSpawnPolicyBaseSettingsPath(
@@ -685,6 +690,12 @@ export async function spawnStructuredConversation(
   let adoptionClaimTransferred = false;
   let adoptionClaimContended = false;
   try {
+    /* Bypass acceptance and project trust are staged in the managed home
+       before runtime admission: no structured launch may ever wait at an
+       interactive acceptance gate, whichever caller reached this point. */
+    if (input.engine === "claude" && input.account.kind === "managed") {
+      prepareManagedClaudeSpawnHome(input.account.home, input.spec.cwd);
+    }
     const imageRefs = input.imageRefs ?? [];
     const content = input.prompt.trim() || imageRefs.length
       ? structuredContent(input.prompt, imageRefs)

--- a/src/lib/tmux.test.ts
+++ b/src/lib/tmux.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, test } from "bun:test";
 import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
 
+import { freshSpecFor } from "@/lib/agent/cli";
+import { agentRegistry } from "@/lib/agent/registry";
 import {
   cdCommandForCwd,
   classifyTmuxAttachSnapshot,
@@ -9,6 +12,8 @@ import {
   createSpawnWindow,
   createTmuxEndpointDescriptor,
   killTmuxHostIfMatches,
+  legacyClaudeTmuxSpawnRefusal,
+  spawnAgentWithPrompt,
   renameTmuxWindowForPid,
   resolveTmuxAttach,
   resolveTmuxEndpointContract,
@@ -482,5 +487,42 @@ describe("killTmuxHostIfMatches", () => {
       })).toBe(false);
       expect(killCommands).toBe(0);
     }
+  });
+});
+
+describe("structured transport prohibits legacy tmux Claude launches", () => {
+  const withStructuredTransport = async (run: () => Promise<void>) => {
+    const previous = process.env.LLV_SPAWN_TRANSPORT;
+    process.env.LLV_SPAWN_TRANSPORT = "structured";
+    try {
+      await run();
+    } finally {
+      if (previous === undefined) delete process.env.LLV_SPAWN_TRANSPORT;
+      else process.env.LLV_SPAWN_TRANSPORT = previous;
+    }
+  };
+
+  test("refuses interactive Claude specs and settles a terminal retryable receipt", async () => {
+    await withStructuredTransport(async () => {
+      const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "llv-no-tmux-claude-"));
+      const spec = freshSpecFor("claude", cwd);
+      await expect(spawnAgentWithPrompt(spec, "hello")).rejects.toThrow(
+        /structured transport prohibits legacy tmux Claude launches/,
+      );
+      const receipts = Object.values(agentRegistry().snapshot().receipts)
+        .filter((receipt) => receipt.engine === "claude" && receipt.cwd === cwd);
+      expect(receipts).toHaveLength(1);
+      expect(receipts[0]!.state).toBe("failed");
+      expect(receipts[0]!.error).toMatch(/structured transport prohibits legacy tmux Claude launches/);
+      fs.rmSync(cwd, { recursive: true, force: true });
+    });
+  });
+
+  test("refusal covers interactive resume specs and spares the migration print-mode fork and tmux transport", () => {
+    const interactive = { command: "claude --dangerously-skip-permissions", cwd: "/tmp", windowName: "claude-resume", engine: "claude" as const };
+    expect(legacyClaudeTmuxSpawnRefusal(interactive, "structured")).toMatch(/structured transport prohibits/);
+    expect(legacyClaudeTmuxSpawnRefusal(interactive, "tmux")).toBeNull();
+    expect(legacyClaudeTmuxSpawnRefusal({ ...interactive, engine: "codex" as const }, "structured")).toBeNull();
+    expect(legacyClaudeTmuxSpawnRefusal({ engine: "claude" as const, printMode: true }, "structured")).toBeNull();
   });
 });

--- a/src/lib/tmux.ts
+++ b/src/lib/tmux.ts
@@ -20,6 +20,7 @@ import { normalizeResumePanesFile, type ResumePaneRecord, type ResumePanesFile }
 import { procBackend } from "@/lib/proc";
 import { admitRuntimeImagePayload, type RuntimeImageAdmissionResult } from "@/lib/runtime/runtimeImageAdmission";
 import type { RuntimeImageUpload } from "@/lib/runtime/runtimeImageStore";
+import { spawnTransport, type SpawnTransport } from "@/lib/runtime/spawnTransport";
 import { listFiles } from "@/lib/scanner";
 import { agentProcesses, isHelperArgv, pidAlive, readArgv, readPpid, type AgentProcess } from "@/lib/scanner/process";
 import {
@@ -1349,11 +1350,27 @@ async function spawnAgentWithPromptUnchecked(spec: ResumeSpec, text: string, rec
   };
 }
 
+/** Structured transport owns every Viewer-managed Claude launch through the
+    pane-less claude-broker. A legacy tmux pane would boot interactive Claude
+    that can stall on the bypass-permissions acceptance gate, so pane creation
+    is refused before any window exists. Only the account-migration successor's
+    print-mode fork — which can never present an interactive gate and is
+    adopted into the broker before delivery — may pass. */
+export function legacyClaudeTmuxSpawnRefusal(
+  spec: Pick<ResumeSpec, "engine" | "printMode">,
+  transport: SpawnTransport = spawnTransport(),
+): string | null {
+  if (spec.engine !== "claude" || transport !== "structured" || spec.printMode) return null;
+  return "structured transport prohibits legacy tmux Claude launches; the pane-less claude-broker host owns this spawn — retry once the structured runtime host is available";
+}
+
 /** Every visible legacy launch receives a durable receipt before tmux creates
     its window. Callers may later attach the engine-native transcript identity. */
 export async function spawnAgentWithPrompt(spec: ResumeSpec, text: string, existingReceipt?: SpawnReceipt): Promise<SpawnedPane> {
   const receipt = existingReceipt ?? agentRegistry().beginSpawn(spec.engine, spec.cwd, spec.launchProfile);
   try {
+    const refusal = legacyClaudeTmuxSpawnRefusal(spec);
+    if (refusal) throw new Error(refusal);
     const capability = agentRegistry().rotateSpawnCapabilityForReceipt(receipt.launchId);
     return { ...(await spawnAgentWithPromptUnchecked(withSpawnCapability(spec, capability), text, receipt)), receipt };
   } catch (error) {


### PR DESCRIPTION
## Summary

- preserve bypass permissions for every managed Claude role launch
- refuse legacy tmux launch paths for managed Claude work
- converge broker kill and reap after child exit
- recover structured broker ownership across Viewer restarts

## Verification

- Fable exact-SHA review: NO FINDINGS
- 248 focused tests passed
- TypeScript clean
- ESLint clean
- branch clean and pushed

Closes #367