### PR TITLE
Composer continuity across refresh, migration, and adoption (#272)

### DIFF
--- a/src/components/TmuxComposer.dom.test.tsx
+++ b/src/components/TmuxComposer.dom.test.tsx
@@ -387,6 +387,13 @@ test("the 390px receipt row reserves preview space beside localized state counts
     expect(pending.querySelector("[data-receipt-count-value]")?.textContent).toBe("1");
     expect(problems.querySelector("[data-receipt-count-value]")?.textContent).toBe("2");
 
+    /* Expanded rows keep the message readable beside (or above) the action
+       chip: the row wraps and the text reserves width instead of collapsing
+       into a one-character column at 390px. */
+    const message = host.querySelector("[data-runtime-receipt-details] [data-receipt-message]") as HTMLElement;
+    expect(message.className.split(/\s+/)).toContain("min-w-[8rem]");
+    expect(message.parentElement!.className.split(/\s+/)).toContain("flex-wrap");
+
     flushSync(() => root.unmount());
     host.remove();
   }
@@ -1069,4 +1076,158 @@ test("a stale delivered replay never wipes a draft rewritten for the next turn",
   expect(textarea.value).toBe("brand new ask");
   expect(sessionStorage.getItem("llvDraft:conv-stale")).toBe("brand new ask");
   flushSync(() => root.unmount());
+});
+
+/* ── Issue #272: timeout followed by durable queued admission ───────────── */
+
+/** Production shape of operation ac0223c0-2bef-46dd-a26e-143b758f66dc: the
+    first `/api/tmux` send times out with an `uncertain` receipt, the operator
+    types more while the fate is unknown, and the idempotent retry comes back
+    `queued`. Queue admission is durable, so exactly the submitted generation
+    must leave the composer — the later typing survives, the receipt stack
+    carries the payload, and no stale failure lingers. */
+async function runTimeoutThenQueuedAdmission(locale: "en" | "uk", viewportWidth: number) {
+  (dom as unknown as { innerWidth: number }).innerWidth = viewportWidth;
+  setLocale(locale);
+  const conversationId = `conv-timeout-${locale}-${viewportWidth}`;
+  const prompt = "довгий виробничий запит — ship the composer reconciliation contract";
+  const sentKeys: string[] = [];
+  globalThis.fetch = (async (input, init) => {
+    if (String(input) === "/api/tmux/targets") {
+      return { ok: true, json: async () => ({ targets: { "0": null } }) } as Response;
+    }
+    if (String(input) !== "/api/tmux") throw new Error(`unexpected request: ${String(input)}`);
+    const body = JSON.parse(String(init?.body)) as { clientMessageId: string; text: string };
+    sentKeys.push(body.clientMessageId);
+    if (sentKeys.length === 1) {
+      /* The runtime host request timed out; the server can only attest an
+         uncertain receipt — nothing durable yet, the draft must stay. */
+      return {
+        ok: false,
+        status: 503,
+        json: async () => ({
+          ok: false,
+          structured: true,
+          error: "runtime host request timed out",
+          receipt: {
+            operationId: "ac0223c0-2bef-46dd-a26e-143b758f66dc",
+            idempotencyKey: body.clientMessageId,
+            conversationId,
+            kind: "send",
+            status: "uncertain",
+            reason: "runtime host request timed out",
+            text: prompt,
+            at: "2026-07-18T00:00:00.000Z",
+            revision: 1,
+          },
+        }),
+      } as Response;
+    }
+    /* The idempotent retry replays the key: the operation is durably queued. */
+    return {
+      ok: false,
+      status: 409,
+      json: async () => ({
+        ok: false,
+        structured: true,
+        error: "idempotency key already accepted",
+        receipt: {
+          operationId: "ac0223c0-2bef-46dd-a26e-143b758f66dc",
+          idempotencyKey: body.clientMessageId,
+          conversationId,
+          kind: "send",
+          status: "queued",
+          text: prompt,
+          at: "2026-07-18T00:00:02.000Z",
+          revision: 2,
+        },
+      }),
+    } as Response;
+  }) as typeof fetch;
+
+  const file = {
+    path: `/codex-timeout-${locale}-${viewportWidth}.jsonl`,
+    root: "codex-sessions",
+    name: "codex-timeout.jsonl",
+    project: "viewer",
+    title: "Codex timeout",
+    engine: "codex",
+    kind: "session",
+    fmt: "codex",
+    parent: null,
+    mtime: 1,
+    size: 1,
+    activity: "idle",
+    proc: "running",
+    pid: null,
+    conversationId,
+    pendingQuestion: null,
+    waitingInput: null,
+  } as FileEntry;
+  sessionStorage.setItem(`llvDraft:${conversationId}`, prompt);
+  const host = document.createElement("div");
+  if (viewportWidth <= 430) host.style.width = `${viewportWidth}px`;
+  document.body.append(host);
+  const root = createRoot(host);
+  flushSync(() => root.render(<TmuxComposer file={file} />));
+  const textarea = host.querySelector("textarea") as HTMLTextAreaElement;
+  const form = textarea.closest("form")!;
+  const submit = async () => {
+    flushSync(() => form.dispatchEvent(new dom.Event("submit", { bubbles: true, cancelable: true }) as unknown as Event));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  };
+
+  try {
+    await submit();
+    /* The timeout is a truthful failure: the draft stays editable and the
+       error is announced. */
+    expect(textarea.value).toBe(prompt);
+    expect(host.textContent).toContain("runtime host request timed out");
+
+    /* The operator keeps typing while the first attempt's fate is unknown. */
+    flushSync(() => appendComposerDraft(conversationId, "додатково: also add tests"));
+    expect(textarea.value).toBe(`${prompt}\n\nдодатково: also add tests`);
+
+    await submit();
+    /* Same delivery key both times — an uncertain receipt never rotates it,
+       so the retry replays instead of double-sending. */
+    expect(sentKeys).toHaveLength(2);
+    expect(sentKeys[1]).toBe(sentKeys[0]);
+    /* Durable queue admission clears exactly the submitted generation: the
+       typing that followed survives, in the editor and in storage. */
+    expect(textarea.value).toBe("додатково: also add tests");
+    expect(sessionStorage.getItem(`llvDraft:${conversationId}`)).toBe("додатково: also add tests");
+    /* No stale failure lingers after admission. */
+    expect(host.textContent).not.toContain("runtime host request timed out");
+    expect(host.textContent).not.toContain(translate(locale, "common.failedSend"));
+    /* The payload lives on in a compact truthful receipt: queued, pending
+       count of one, preview text — announced through the live status region. */
+    const stack = host.querySelector("details[data-runtime-receipt-stack]") as HTMLDetailsElement;
+    expect(stack).toBeTruthy();
+    const summary = stack.querySelector("summary")!;
+    expect(summary.textContent).toContain(translate(locale, "runtime.receipt.summary", { count: 1 }));
+    expect(summary.querySelector("[data-receipt-preview]")?.textContent).toBe(prompt);
+    expect(summary.querySelector("[data-receipt-pending-count] [data-receipt-count-value]")?.textContent).toBe("1");
+    expect(host.querySelector('[data-receipt-status="queued"]')?.textContent)
+      .toBe(translate(locale, "runtime.receipt.queued"));
+    expect(host.querySelector('[data-optimistic-message="true"]')?.textContent).toContain(prompt);
+    const status = host.querySelector("[data-runtime-receipt-status]")!;
+    expect(status.getAttribute("role")).toBe("status");
+    expect(status.getAttribute("aria-live")).toBe("polite");
+    expect(status.textContent).toContain(translate(locale, "runtime.receipt.statusPending", { count: 1 }));
+    /* Mobile keeps the 44px summary row; desktop keeps the compact stack. */
+    expect(summary.className.split(/\s+/)).toContain("min-h-11");
+  } finally {
+    flushSync(() => root.unmount());
+    host.remove();
+    (dom as unknown as { innerWidth: number }).innerWidth = 1024;
+  }
+}
+
+test("a timed-out send settles on queued admission via idempotent retry (desktop, EN)", async () => {
+  await runTimeoutThenQueuedAdmission("en", 1024);
+});
+
+test("a timed-out send settles on queued admission via idempotent retry (390px, UK)", async () => {
+  await runTimeoutThenQueuedAdmission("uk", 390);
 });

--- a/src/components/TmuxComposer.focus.dom.test.tsx
+++ b/src/components/TmuxComposer.focus.dom.test.tsx
@@ -1,0 +1,252 @@
+import { afterAll, expect, mock, test } from "bun:test";
+import { Window } from "happy-dom";
+import { useSyncExternalStore } from "react";
+import { flushSync } from "react-dom";
+import { createRoot } from "react-dom/client";
+
+import type { RuntimeReceipt } from "@/components/runtime/runtimeModel";
+import { setLocale } from "@/lib/i18n";
+import type { FileEntry } from "@/lib/types";
+
+const dom = new Window();
+Object.assign(globalThis, {
+  window: dom,
+  document: dom.document,
+  navigator: dom.navigator,
+  Node: dom.Node,
+  HTMLElement: dom.HTMLElement,
+  HTMLButtonElement: dom.HTMLButtonElement,
+  Event: dom.Event,
+  CustomEvent: dom.CustomEvent,
+  MouseEvent: dom.MouseEvent,
+  File: dom.File,
+  FileReader: dom.FileReader,
+  requestAnimationFrame: dom.requestAnimationFrame.bind(dom),
+  cancelAnimationFrame: dom.cancelAnimationFrame.bind(dom),
+  localStorage: dom.localStorage,
+  sessionStorage: dom.sessionStorage,
+});
+/* Per-test viewport: the UK mobile scenario flips this to the 390px branch. */
+let mobileViewport = false;
+(dom as unknown as { matchMedia: (query: string) => unknown }).matchMedia = (query: string) => ({
+  matches: mobileViewport && /max-width/.test(String(query)),
+  media: query,
+  addEventListener() {},
+  removeEventListener() {},
+});
+
+/* The durable receipt stream, controllable per test exactly like production
+   pushes bus updates into a typing user's composer. */
+const actualRuntimeHooks = await import("@/hooks/useRuntime");
+const receiptListeners = new Set<() => void>();
+let busReceipts: RuntimeReceipt[] = [];
+function publishReceipts(next: RuntimeReceipt[]): void {
+  busReceipts = next;
+  for (const listener of receiptListeners) listener();
+}
+mock.module("@/hooks/useRuntime", () => ({
+  ...actualRuntimeHooks,
+  useRuntimeSession: () => null,
+  useRuntimeReceiptsForArtifact: () => useSyncExternalStore(
+    (listener) => {
+      receiptListeners.add(listener);
+      return () => receiptListeners.delete(listener);
+    },
+    () => busReceipts,
+    () => busReceipts,
+  ),
+}));
+afterAll(() => {
+  mock.module("@/hooks/useRuntime", () => actualRuntimeHooks);
+});
+
+const { TmuxComposer } = await import("./TmuxComposer");
+
+globalThis.fetch = (async (input) => {
+  if (String(input) === "/api/tmux/targets") {
+    return { ok: true, json: async () => ({ targets: { "0": null } }) } as Response;
+  }
+  throw new Error(`unexpected request: ${String(input)}`);
+}) as typeof fetch;
+
+function fileFor(overrides: Partial<FileEntry> & { path: string }): FileEntry {
+  return {
+    root: "codex-sessions",
+    name: overrides.path.slice(1),
+    project: "viewer",
+    title: overrides.path,
+    engine: "codex",
+    kind: "session",
+    fmt: "codex",
+    parent: null,
+    mtime: 1,
+    size: 1,
+    activity: "idle",
+    proc: "running",
+    pid: null,
+    conversationId: undefined,
+    pendingQuestion: null,
+    waitingInput: null,
+    ...overrides,
+  } as FileEntry;
+}
+
+function pasteImage(textarea: HTMLTextAreaElement, tag: string): void {
+  const propsKey = Object.keys(textarea).find((key) => key.startsWith("__reactProps$"))!;
+  const props = (textarea as unknown as Record<string, { onPaste(event: unknown): void }>)[propsKey]!;
+  const bytes = new TextEncoder().encode(`png-${tag}`);
+  props.onPaste({
+    clipboardData: { items: [{ type: "image/png", getAsFile: () => new dom.File([bytes], `${tag}.png`, { type: "image/png" }) }] },
+    preventDefault() {},
+  });
+}
+
+test("board polls and receipt updates never move focus, caret, draft, or attachments — and mounting never autofocuses", async () => {
+  setLocale("en");
+  mobileViewport = false;
+  const conversationId = "conv-focus-poll";
+  const draft = "keep my caret steady while the board refreshes";
+  sessionStorage.setItem(`llvDraft:${conversationId}`, draft);
+  const host = document.createElement("div");
+  document.body.append(host);
+  const root = createRoot(host);
+  const entry = (mtime: number, activity: FileEntry["activity"]) =>
+    fileFor({ path: "/focus-poll.jsonl", conversationId, mtime, activity });
+
+  try {
+    flushSync(() => root.render(<TmuxComposer file={entry(1, "idle")} />));
+    const textarea = host.querySelector("textarea") as HTMLTextAreaElement;
+    /* A polling path mounted this composer: it must never take focus itself. */
+    expect(document.activeElement).not.toBe(textarea);
+
+    textarea.focus();
+    textarea.setSelectionRange(5, 5);
+    pasteImage(textarea, "poll-stable");
+    for (let attempt = 0; attempt < 50 && host.querySelectorAll("img").length !== 1; attempt += 1) {
+      await new Promise((resolve) => setTimeout(resolve, 2));
+    }
+    expect(host.querySelectorAll("img")).toHaveLength(1);
+
+    /* Poll refresh: a brand-new FileEntry object with moved mtime/activity. */
+    flushSync(() => root.render(<TmuxComposer file={entry(2, "live")} />));
+    expect(document.activeElement).toBe(textarea);
+    expect(textarea.selectionStart).toBe(5);
+    expect(textarea.selectionEnd).toBe(5);
+    expect(textarea.value).toBe(draft);
+    expect(host.querySelectorAll("img")).toHaveLength(1);
+
+    /* A durable receipt for some other operation streams in mid-typing. */
+    flushSync(() => publishReceipts([{
+      operationId: "op-unrelated",
+      idempotencyKey: "key-unrelated",
+      conversationId: "conversation_bus-session",
+      kind: "send",
+      status: "queued",
+      text: "someone else's message",
+      at: "2026-07-18T00:00:01.000Z",
+      revision: 1,
+    }]));
+    expect(document.activeElement).toBe(textarea);
+    expect(textarea.selectionStart).toBe(5);
+    expect(textarea.value).toBe(draft);
+    expect(host.querySelectorAll("img")).toHaveLength(1);
+  } finally {
+    flushSync(() => root.unmount());
+    publishReceipts([]);
+    sessionStorage.clear();
+    host.remove();
+  }
+});
+
+test("a committed path migration remounts the composer under a new key: focus, caret, and draft survive", () => {
+  setLocale("en");
+  mobileViewport = false;
+  const conversationId = "conv-migrate";
+  const draft = "typed against the predecessor pane";
+  sessionStorage.setItem(`llvDraft:${conversationId}`, draft);
+  const host = document.createElement("div");
+  document.body.append(host);
+  const root = createRoot(host);
+  /* Production shape: the scheme node and the mobile focus view both key the
+     hosting subtree by file.path, so a committed migration is a hard remount. */
+  const board = (file: FileEntry) => (
+    <div key={file.path} className="pane">
+      <TmuxComposer file={file} />
+    </div>
+  );
+
+  try {
+    const predecessor = fileFor({ path: "/predecessor.jsonl", conversationId });
+    flushSync(() => root.render(board(predecessor)));
+    const before = host.querySelector("textarea") as HTMLTextAreaElement;
+    before.focus();
+    before.setSelectionRange(6, 13);
+    expect(document.activeElement).toBe(before);
+
+    const successor = fileFor({
+      path: "/successor.jsonl",
+      conversationId,
+      predecessorPath: "/predecessor.jsonl",
+    } as Partial<FileEntry> & { path: string });
+    flushSync(() => root.render(board(successor)));
+
+    const after = host.querySelector("textarea") as HTMLTextAreaElement;
+    expect(after).not.toBe(before);
+    expect(document.activeElement).toBe(after);
+    expect(after.selectionStart).toBe(6);
+    expect(after.selectionEnd).toBe(13);
+    expect(after.value).toBe(draft);
+  } finally {
+    flushSync(() => root.unmount());
+    sessionStorage.clear();
+    host.remove();
+  }
+});
+
+test("адопційний флап (390px): фокус повертається, чернетка переїжджає на канонічний id, а чужий фокус ніколи не крадеться", () => {
+  setLocale("uk");
+  mobileViewport = true;
+  const draft = "чернетка, набрана під тимчасовим id";
+  sessionStorage.setItem("llvDraft:conv-provisional", draft);
+  const host = document.createElement("div");
+  document.body.append(host);
+  const root = createRoot(host);
+
+  try {
+    /* The entry arrives with a provisional conversation id. */
+    const provisional = fileFor({ path: "/adopt.jsonl", conversationId: "conv-provisional" });
+    flushSync(() => root.render(<TmuxComposer file={provisional} />));
+    const before = host.querySelector("textarea") as HTMLTextAreaElement;
+    expect(before.value).toBe(draft);
+    before.focus();
+    before.setSelectionRange(draft.length, draft.length);
+
+    /* Adoption flap: the scanner drops the entry for a poll cycle… */
+    flushSync(() => root.render(<div />));
+    /* …and re-adds it under the canonical id (same transcript path). */
+    const canonical = fileFor({ path: "/adopt.jsonl", conversationId: "conv-canonical" });
+    flushSync(() => root.render(<TmuxComposer file={canonical} />));
+
+    const after = host.querySelector("textarea") as HTMLTextAreaElement;
+    expect(document.activeElement).toBe(after);
+    expect(after.selectionStart).toBe(draft.length);
+    expect(after.value).toBe(draft);
+    /* The persisted records rode the identity change. */
+    expect(sessionStorage.getItem("llvDraft:conv-canonical")).toBe(draft);
+    expect(sessionStorage.getItem("llvDraft:conv-provisional")).toBe(null);
+
+    /* A second flap while the user has moved on: the returning composer must
+       never yank focus away from what they clicked. */
+    const elsewhere = document.createElement("button");
+    document.body.append(elsewhere);
+    flushSync(() => root.render(<div />));
+    elsewhere.focus();
+    flushSync(() => root.render(<TmuxComposer file={canonical} />));
+    expect(document.activeElement).toBe(elsewhere);
+    elsewhere.remove();
+  } finally {
+    flushSync(() => root.unmount());
+    sessionStorage.clear();
+    host.remove();
+  }
+});

--- a/src/components/TmuxComposer.reconciliation.dom.test.tsx
+++ b/src/components/TmuxComposer.reconciliation.dom.test.tsx
@@ -1,0 +1,288 @@
+import { afterAll, expect, mock, test } from "bun:test";
+import { Window } from "happy-dom";
+import { useSyncExternalStore } from "react";
+import { flushSync } from "react-dom";
+import { createRoot } from "react-dom/client";
+
+import type { RuntimeReceipt } from "@/components/runtime/runtimeModel";
+import { setLocale, translate } from "@/lib/i18n";
+import type { FileEntry } from "@/lib/types";
+
+const dom = new Window();
+Object.assign(globalThis, {
+  window: dom,
+  document: dom.document,
+  navigator: dom.navigator,
+  Node: dom.Node,
+  HTMLElement: dom.HTMLElement,
+  HTMLButtonElement: dom.HTMLButtonElement,
+  Event: dom.Event,
+  CustomEvent: dom.CustomEvent,
+  MouseEvent: dom.MouseEvent,
+  File: dom.File,
+  FileReader: dom.FileReader,
+  requestAnimationFrame: dom.requestAnimationFrame.bind(dom),
+  cancelAnimationFrame: dom.cancelAnimationFrame.bind(dom),
+  localStorage: dom.localStorage,
+  sessionStorage: dom.sessionStorage,
+});
+(dom as unknown as { matchMedia: (query: string) => unknown }).matchMedia = (query: string) => ({
+  matches: false,
+  media: query,
+  addEventListener() {},
+  removeEventListener() {},
+});
+
+/* A controllable durable-receipt stream stands in for the runtime bus: the
+   tests push admission receipts the way production does — through the
+   receipts hook — while the send response is still in flight or after a
+   remount. The actual hooks are restored in afterAll (mock.module is
+   process-global). */
+const actualRuntimeHooks = await import("@/hooks/useRuntime");
+const receiptListeners = new Set<() => void>();
+let busReceipts: RuntimeReceipt[] = [];
+function publishReceipts(next: RuntimeReceipt[]): void {
+  busReceipts = next;
+  for (const listener of receiptListeners) listener();
+}
+mock.module("@/hooks/useRuntime", () => ({
+  ...actualRuntimeHooks,
+  useRuntimeSession: () => null,
+  useRuntimeReceiptsForArtifact: () => useSyncExternalStore(
+    (listener) => {
+      receiptListeners.add(listener);
+      return () => receiptListeners.delete(listener);
+    },
+    () => busReceipts,
+    () => busReceipts,
+  ),
+}));
+afterAll(() => {
+  mock.module("@/hooks/useRuntime", () => actualRuntimeHooks);
+});
+
+const { appendComposerDraft, TmuxComposer } = await import("./TmuxComposer");
+
+function fileFor(conversationId: string): FileEntry {
+  return {
+    path: `/${conversationId}.jsonl`,
+    root: "codex-sessions",
+    name: `${conversationId}.jsonl`,
+    project: "viewer",
+    title: conversationId,
+    engine: "codex",
+    kind: "session",
+    fmt: "codex",
+    parent: null,
+    mtime: 1,
+    size: 1,
+    activity: "idle",
+    proc: "running",
+    pid: null,
+    conversationId,
+    pendingQuestion: null,
+    waitingInput: null,
+  } as FileEntry;
+}
+
+test("a mid-flight queued admission settles the generation and the stale timeout cannot resurrect it", async () => {
+  setLocale("en");
+  const conversationId = "conv-hang-admission";
+  const prompt = "annotate the production screenshot";
+  const sentKeys: string[] = [];
+  const sentImageCounts: number[] = [];
+  let resolveHung!: (response: Response) => void;
+  globalThis.fetch = (async (input, init) => {
+    if (String(input) === "/api/tmux/targets") {
+      return { ok: true, json: async () => ({ targets: { "0": null } }) } as Response;
+    }
+    if (String(input) !== "/api/tmux") throw new Error(`unexpected request: ${String(input)}`);
+    const body = JSON.parse(String(init?.body)) as { clientMessageId: string; images?: unknown[] };
+    sentKeys.push(body.clientMessageId);
+    sentImageCounts.push(body.images?.length ?? 0);
+    if (sentKeys.length === 1) {
+      /* The runtime host hangs: the response settles long after the durable
+         admission has already reached the client on the receipt stream. */
+      return new Promise<Response>((resolve) => { resolveHung = resolve; });
+    }
+    return {
+      ok: true,
+      status: 200,
+      json: async () => ({
+        ok: true,
+        structured: true,
+        receipt: {
+          operationId: "op-next-generation",
+          idempotencyKey: body.clientMessageId,
+          conversationId,
+          kind: "send",
+          status: "queued",
+          text: "next ask",
+          at: "2026-07-18T00:01:00.000Z",
+          revision: 1,
+        },
+      }),
+    } as Response;
+  }) as typeof fetch;
+
+  sessionStorage.setItem(`llvDraft:${conversationId}`, prompt);
+  const host = document.createElement("div");
+  document.body.append(host);
+  const root = createRoot(host);
+  flushSync(() => root.render(<TmuxComposer file={fileFor(conversationId)} />));
+  const textarea = host.querySelector("textarea") as HTMLTextAreaElement;
+  const form = textarea.closest("form")!;
+  const propsKey = Object.keys(textarea).find((key) => key.startsWith("__reactProps$"))!;
+  const textareaProps = (textarea as unknown as Record<string, { onPaste(event: unknown): void }>)[propsKey]!;
+  const previews = () => [...host.querySelectorAll("img")].map((image) => image.getAttribute("src"));
+  const pasteImage = (tag: string) => {
+    const bytes = new TextEncoder().encode(`png-${tag}`);
+    textareaProps.onPaste({
+      clipboardData: { items: [{ type: "image/png", getAsFile: () => new dom.File([bytes], `${tag}.png`, { type: "image/png" }) }] },
+      preventDefault() {},
+    });
+  };
+  const untilPreviews = async (count: number) => {
+    for (let attempt = 0; attempt < 50 && previews().length !== count; attempt += 1) {
+      await new Promise((resolve) => setTimeout(resolve, 2));
+    }
+    expect(previews()).toHaveLength(count);
+  };
+  const admission = (status: RuntimeReceipt["status"], revision: number): RuntimeReceipt => ({
+    operationId: "ac0223c0-2bef-46dd-a26e-143b758f66dc",
+    idempotencyKey: sentKeys[0]!,
+    conversationId: "conversation_bus-session",
+    kind: "send",
+    status,
+    text: prompt,
+    at: `2026-07-18T00:00:0${revision}.000Z`,
+    revision,
+  });
+
+  try {
+    pasteImage("sent-with-attempt");
+    await untilPreviews(1);
+    flushSync(() => form.dispatchEvent(new dom.Event("submit", { bubbles: true, cancelable: true }) as unknown as Event));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(sentImageCounts).toEqual([1]);
+    expect(textarea.value).toBe(prompt);
+
+    /* An image attached while the send hangs belongs to the NEXT generation. */
+    pasteImage("attached-mid-flight");
+    await untilPreviews(2);
+    const laterPreview = previews()[1];
+
+    /* The durable queued admission arrives on the receipt stream while the
+       response is still hanging: exactly the submitted generation leaves the
+       composer — its text and its attachment snapshot, nothing newer. */
+    flushSync(() => publishReceipts([admission("queued", 1)]));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(textarea.value).toBe("");
+    expect(previews()).toEqual([laterPreview]);
+    expect(sessionStorage.getItem(`llvDraft:${conversationId}`)).toBe(null);
+    expect(sessionStorage.getItem(`llvPendingSend:${conversationId}`)).toBe(null);
+
+    /* The operator drafts the next ask before the hung response dies. */
+    flushSync(() => appendComposerDraft(conversationId, "next ask"));
+    expect(textarea.value).toBe("next ask");
+
+    /* The stale timeout finally settles: no false failure, no resurrected
+       text, no re-armed pending generation. */
+    resolveHung({
+      ok: false,
+      status: 503,
+      json: async () => ({ ok: false, error: "runtime host request timed out" }),
+    } as Response);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(textarea.value).toBe("next ask");
+    expect(host.textContent).not.toContain("runtime host request timed out");
+    expect(host.textContent).not.toContain(translate("en", "common.failedSend"));
+    expect(host.textContent).not.toContain(translate("en", "common.serverUnavailable"));
+    expect(sessionStorage.getItem(`llvPendingSend:${conversationId}`)).toBe(null);
+
+    /* A later delivered replay of the settled generation is a no-op: accepted
+       text never resurrects and the next draft is never wiped. */
+    flushSync(() => publishReceipts([admission("delivered", 2)]));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(textarea.value).toBe("next ask");
+
+    /* The next generation goes out under a fresh key with only its own image. */
+    flushSync(() => form.dispatchEvent(new dom.Event("submit", { bubbles: true, cancelable: true }) as unknown as Event));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(sentKeys).toHaveLength(2);
+    expect(sentKeys[1]).not.toBe(sentKeys[0]);
+    expect(sentImageCounts[1]).toBe(1);
+    expect(textarea.value).toBe("");
+  } finally {
+    flushSync(() => root.unmount());
+    publishReceipts([]);
+    sessionStorage.clear();
+    host.remove();
+  }
+});
+
+test("a queued admission after remount still clears the persisted generation exactly", async () => {
+  setLocale("en");
+  const conversationId = "conv-remount-admission";
+  const prompt = "довгий запит that survived a refresh";
+  const sentKeys: string[] = [];
+  globalThis.fetch = (async (input, init) => {
+    if (String(input) === "/api/tmux/targets") {
+      return { ok: true, json: async () => ({ targets: { "0": null } }) } as Response;
+    }
+    if (String(input) !== "/api/tmux") throw new Error(`unexpected request: ${String(input)}`);
+    const body = JSON.parse(String(init?.body)) as { clientMessageId: string };
+    sentKeys.push(body.clientMessageId);
+    return { ok: false, status: 503, json: async () => ({ ok: false, error: "runtime host request timed out" }) } as Response;
+  }) as typeof fetch;
+
+  sessionStorage.setItem(`llvDraft:${conversationId}`, prompt);
+  const host = document.createElement("div");
+  document.body.append(host);
+  let root = createRoot(host);
+  flushSync(() => root.render(<TmuxComposer file={fileFor(conversationId)} />));
+  let textarea = host.querySelector("textarea") as HTMLTextAreaElement;
+
+  try {
+    flushSync(() => textarea.closest("form")!.dispatchEvent(new dom.Event("submit", { bubbles: true, cancelable: true }) as unknown as Event));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(sentKeys).toHaveLength(1);
+    expect(textarea.value).toBe(prompt);
+    /* The unsettled generation is durable client state now. */
+    expect(sessionStorage.getItem(`llvPendingSend:${conversationId}`)).toContain(sentKeys[0]!);
+
+    /* The tab refreshes: the composer unmounts and a fresh one mounts over the
+       persisted draft, with more typing added after the reload. */
+    flushSync(() => root.unmount());
+    flushSync(() => appendComposerDraft(conversationId, "after refresh typing"));
+    /* The refresh snapshot already carries the durable queued admission. */
+    publishReceipts([{
+      operationId: "ac0223c0-2bef-46dd-a26e-143b758f66dc",
+      idempotencyKey: sentKeys[0]!,
+      conversationId: "conversation_bus-session",
+      kind: "send",
+      status: "queued",
+      text: prompt,
+      at: "2026-07-18T00:00:05.000Z",
+      revision: 1,
+    }]);
+    root = createRoot(host);
+    flushSync(() => root.render(<TmuxComposer file={fileFor(conversationId)} />));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    textarea = host.querySelector("textarea") as HTMLTextAreaElement;
+    /* The accepted generation is gone; the post-refresh typing survives. */
+    expect(textarea.value).toBe("after refresh typing");
+    expect(sessionStorage.getItem(`llvDraft:${conversationId}`)).toBe("after refresh typing");
+    expect(sessionStorage.getItem(`llvPendingSend:${conversationId}`)).toBe(null);
+    /* The receipt stack keeps the truthful queued record with the payload. */
+    expect(host.querySelector('[data-receipt-status="queued"]')?.textContent)
+      .toBe(translate("en", "runtime.receipt.queued"));
+    expect(host.querySelector("[data-receipt-preview]")?.textContent).toBe(prompt);
+  } finally {
+    flushSync(() => root.unmount());
+    publishReceipts([]);
+    sessionStorage.clear();
+    host.remove();
+  }
+});

--- a/src/components/TmuxComposer.test.ts
+++ b/src/components/TmuxComposer.test.ts
@@ -311,7 +311,7 @@ test("a bounded receipt summary keeps retry while withholding lossy edit", () =>
 /* ── Exact draft clearing on accepted delivery ──────────────────────────── */
 
 import type { PendingImage } from "./imageAttachments";
-import { attachmentsAfterDelivery, draftAfterDelivery, settlePendingDeliveries, type PendingDelivery } from "./TmuxComposer";
+import { attachmentsAfterDelivery, draftAfterDelivery, readPendingDeliveries, settlePendingDeliveries, writePendingDeliveries, type PendingDelivery } from "./TmuxComposer";
 
 function deliveredReceipt(key: string, status: RuntimeReceipt["status"] = "delivered", text?: string): RuntimeReceipt {
   return {
@@ -350,19 +350,34 @@ test("settlePendingDeliveries clears exactly the delivered keys and keeps the re
     { key: "key-a", text: "first ask", images: [pendingImage("a")] },
     { key: "key-b", text: "second ask", images: [] },
   ];
-  const { delivered, remaining } = settlePendingDeliveries(pending, [deliveredReceipt("key-a")]);
-  expect(delivered).toEqual([{ entry: pending[0]!, text: "first ask" }]);
+  const { settled, remaining } = settlePendingDeliveries(pending, [deliveredReceipt("key-a")]);
+  expect(settled).toEqual([{ entry: pending[0]!, text: "first ask" }]);
   expect(remaining).toEqual([{ key: "key-b", text: "second ask", images: [] }]);
 });
 
-test("settlePendingDeliveries ignores non-delivered and unknown receipts", () => {
+test("settlePendingDeliveries treats durable queue admission as acceptance (issue #272)", () => {
+  /* Production shape of operation ac0223c0: the first response timed out, the
+     idempotent retry returned `queued`. Queue admission is durable — the
+     server holds the message — so the generation settles and the draft clears. */
+  for (const status of ["queued", "delivering", "turn-started", "steered", "answered"] as const) {
+    const pending: PendingDelivery[] = [{ key: "key-a", text: "first ask", images: [] }];
+    const { settled, remaining } = settlePendingDeliveries(pending, [deliveredReceipt("key-a", status)]);
+    expect(settled).toEqual([{ entry: pending[0]!, text: "first ask" }]);
+    expect(remaining).toEqual([]);
+  }
+});
+
+test("settlePendingDeliveries ignores unsettled, failed, and unknown receipts", () => {
   const pending: PendingDelivery[] = [{ key: "key-a", text: "first ask", images: [] }];
-  const { delivered, remaining } = settlePendingDeliveries(pending, [
-    deliveredReceipt("key-a", "queued"),
+  const { settled, remaining } = settlePendingDeliveries(pending, [
+    deliveredReceipt("key-a", "pending"),
+    deliveredReceipt("key-a", "uncertain"),
     deliveredReceipt("key-a", "failed"),
+    deliveredReceipt("key-a", "rejected"),
+    deliveredReceipt("key-a", "interrupted"),
     deliveredReceipt("key-unknown"),
   ]);
-  expect(delivered).toEqual([]);
+  expect(settled).toEqual([]);
   expect(remaining).toEqual(pending);
 });
 
@@ -371,8 +386,26 @@ test("settlePendingDeliveries prefers the receipt's own delivered text over the 
      attempt carried a rewritten draft — the server's record is what actually
      reached the agent, so clearing keys off the receipt text. */
   const pending: PendingDelivery[] = [{ key: "key-a", text: "rewritten draft", images: [] }];
-  const { delivered } = settlePendingDeliveries(pending, [deliveredReceipt("key-a", "delivered", "old turn ask")]);
-  expect(delivered.map((settled) => settled.text)).toEqual(["old turn ask"]);
+  const { settled } = settlePendingDeliveries(pending, [deliveredReceipt("key-a", "delivered", "old turn ask")]);
+  expect(settled.map((settlement) => settlement.text)).toEqual(["old turn ask"]);
+});
+
+test("a queued admission clears by the attempt's full text, never a bounded echo", () => {
+  /* Pre-delivery receipts carry a bounded summary of the message; clearing off
+     a truncated echo would strand the tail of the accepted prompt in the
+     composer. The generation's own record is exact. */
+  const pending: PendingDelivery[] = [{ key: "key-a", text: "a long accepted production prompt", images: [] }];
+  const { settled } = settlePendingDeliveries(pending, [deliveredReceipt("key-a", "queued", "a long accepted")]);
+  expect(settled.map((settlement) => settlement.text)).toEqual(["a long accepted production prompt"]);
+});
+
+test("a delivered record outranks a queued echo for the same key in one receipt set", () => {
+  const pending: PendingDelivery[] = [{ key: "key-a", text: "local attempt text", images: [] }];
+  const { settled } = settlePendingDeliveries(pending, [
+    deliveredReceipt("key-a", "queued", "local attempt"),
+    deliveredReceipt("key-a", "delivered", "server record"),
+  ]);
+  expect(settled.map((settlement) => settlement.text)).toEqual(["server record"]);
 });
 
 test("attachmentsAfterDelivery removes exactly the sent snapshot and keeps later attachments", () => {
@@ -386,11 +419,42 @@ test("attachmentsAfterDelivery removes exactly the sent snapshot and keeps later
   expect(attachmentsAfterDelivery([later], sent)).toEqual([later]);
 });
 
-test("settlePendingDeliveries is idempotent across repeated delivered receipts", () => {
+test("settlePendingDeliveries is idempotent across repeated admission receipts", () => {
   const pending: PendingDelivery[] = [{ key: "key-a", text: "first ask", images: [] }];
-  const first = settlePendingDeliveries(pending, [deliveredReceipt("key-a")]);
+  const first = settlePendingDeliveries(pending, [deliveredReceipt("key-a", "queued")]);
   const second = settlePendingDeliveries(first.remaining, [deliveredReceipt("key-a")]);
-  expect(first.delivered.map((settled) => settled.text)).toEqual(["first ask"]);
-  expect(second.delivered).toEqual([]);
+  expect(first.settled.map((settlement) => settlement.text)).toEqual(["first ask"]);
+  expect(second.settled).toEqual([]);
   expect(second.remaining).toEqual([]);
+});
+
+test("pending generations persist text-only per conversation and reload bounded", () => {
+  /* A remount or refresh must not orphan an accepted message in the composer:
+     the unsettled generation reloads (attachment snapshots are memory-only). */
+  const backing = new Map<string, string>();
+  const globalStore = globalThis as { sessionStorage?: unknown };
+  const previous = globalStore.sessionStorage;
+  globalStore.sessionStorage = {
+    getItem: (key: string) => backing.get(key) ?? null,
+    setItem: (key: string, value: string) => void backing.set(key, String(value)),
+    removeItem: (key: string) => void backing.delete(key),
+  };
+  try {
+    const entries: PendingDelivery[] = Array.from({ length: 10 }, (_, index) => ({
+      key: `key-${index}`,
+      text: `ask ${index}`,
+      images: index === 0 ? [pendingImage("a")] : [],
+    }));
+    writePendingDeliveries("conv-persist", entries);
+    const reloaded = readPendingDeliveries("conv-persist");
+    expect(reloaded).toHaveLength(8);
+    expect(reloaded[0]).toEqual({ key: "key-0", text: "ask 0", images: [] });
+    writePendingDeliveries("conv-persist", []);
+    expect(readPendingDeliveries("conv-persist")).toEqual([]);
+    backing.set("llvPendingSend:conv-corrupt", "{not json");
+    expect(readPendingDeliveries("conv-corrupt")).toEqual([]);
+  } finally {
+    if (previous === undefined) delete globalStore.sessionStorage;
+    else globalStore.sessionStorage = previous;
+  }
 });

--- a/src/components/TmuxComposer.test.ts
+++ b/src/components/TmuxComposer.test.ts
@@ -311,7 +311,7 @@ test("a bounded receipt summary keeps retry while withholding lossy edit", () =>
 /* ── Exact draft clearing on accepted delivery ──────────────────────────── */
 
 import type { PendingImage } from "./imageAttachments";
-import { attachmentsAfterDelivery, draftAfterDelivery, readPendingDeliveries, settlePendingDeliveries, writePendingDeliveries, type PendingDelivery } from "./TmuxComposer";
+import { adoptComposerState, attachmentsAfterDelivery, draftAfterDelivery, readPendingDeliveries, settlePendingDeliveries, writePendingDeliveries, type PendingDelivery } from "./TmuxComposer";
 
 function deliveredReceipt(key: string, status: RuntimeReceipt["status"] = "delivered", text?: string): RuntimeReceipt {
   return {
@@ -453,6 +453,44 @@ test("pending generations persist text-only per conversation and reload bounded"
     expect(readPendingDeliveries("conv-persist")).toEqual([]);
     backing.set("llvPendingSend:conv-corrupt", "{not json");
     expect(readPendingDeliveries("conv-corrupt")).toEqual([]);
+  } finally {
+    if (previous === undefined) delete globalStore.sessionStorage;
+    else globalStore.sessionStorage = previous;
+  }
+});
+
+test("identity adoption moves composer records across id rotations in both directions", () => {
+  const backing = new Map<string, string>();
+  const globalStore = globalThis as { sessionStorage?: unknown };
+  const previous = globalStore.sessionStorage;
+  globalStore.sessionStorage = {
+    getItem: (key: string) => backing.get(key) ?? null,
+    setItem: (key: string, value: string) => void backing.set(key, String(value)),
+    removeItem: (key: string) => void backing.delete(key),
+  };
+  try {
+    /* Pre-identity records live under the bare path; the first enrichment
+       moves them onto the provisional id and remembers the owner. */
+    backing.set("llvDraft:/conv.jsonl", "typed before any id");
+    adoptComposerState("/conv.jsonl", "conv-provisional");
+    expect(backing.get("llvDraft:conv-provisional")).toBe("typed before any id");
+    expect(backing.has("llvDraft:/conv.jsonl")).toBe(false);
+
+    /* The canonical id adopts from the recorded owner, not just the path. */
+    adoptComposerState("/conv.jsonl", "conv-canonical");
+    expect(backing.get("llvDraft:conv-canonical")).toBe("typed before any id");
+    expect(backing.has("llvDraft:conv-provisional")).toBe(false);
+
+    /* A flap that drops the id folds the records back onto the path… */
+    adoptComposerState("/conv.jsonl", "/conv.jsonl");
+    expect(backing.get("llvDraft:/conv.jsonl")).toBe("typed before any id");
+    expect(backing.has("llvComposerOwner:/conv.jsonl")).toBe(false);
+
+    /* …and a record already filed under the new identity always wins. */
+    backing.set("llvDraft:conv-final", "newer draft");
+    adoptComposerState("/conv.jsonl", "conv-final");
+    expect(backing.get("llvDraft:conv-final")).toBe("newer draft");
+    expect(backing.has("llvDraft:/conv.jsonl")).toBe(false);
   } finally {
     if (previous === undefined) delete globalStore.sessionStorage;
     else globalStore.sessionStorage = previous;

--- a/src/components/TmuxComposer.tsx
+++ b/src/components/TmuxComposer.tsx
@@ -22,7 +22,7 @@ import type { RuntimeReceipt } from "@/components/runtime/runtimeModel";
 import { ComposerBar } from "./ComposerBar";
 import { ImagePickerButton, type PendingImage } from "./imageAttachments";
 import { ReceiptChip, runtimeReceiptStatusText } from "./runtime/ReceiptChip";
-import { mintIdempotencyKey, receiptIsTerminal } from "./runtime/runtimeModel";
+import { mintIdempotencyKey, receiptIsAdmitted, receiptIsTerminal } from "./runtime/runtimeModel";
 
 /**
  * A delivery receipt shown above the composer. `state` tracks whether the
@@ -284,9 +284,13 @@ export function RuntimeComposerReceipts({
                     className="flex min-w-0 flex-col items-end gap-0.5 rounded-control bg-card/70 px-2 py-1"
                     {...(pending ? { "data-optimistic-message": "true" } : {})}
                   >
-                    <div className="flex w-full min-w-0 items-start justify-end gap-1.5">
+                    {/* The action chip (state badge + Retry/Edit) wraps under
+                        the message on narrow screens instead of squeezing the
+                        text into a sliver — the payload must stay readable at
+                        390px in exactly the failed state that needs it. */}
+                    <div className="flex w-full min-w-0 flex-wrap items-start justify-end gap-1.5">
                       <span
-                        className="min-w-0 flex-1 whitespace-pre-wrap break-words text-right text-secondary"
+                        className="min-w-[8rem] flex-1 whitespace-pre-wrap break-words text-right text-secondary"
                         data-receipt-message
                       >
                         {receipt.text}
@@ -386,45 +390,89 @@ export function draftAfterDelivery(draft: string, delivered: string): string {
   return draft;
 }
 
-/** A send whose immediate response was lost or deferred, remembered so a later
-    delivered receipt for its idempotency key still clears the draft exactly. */
+/** One submitted draft generation whose fate is not yet settled: recorded when
+    the attempt leaves for the wire, so a durable admission receipt for its
+    idempotency key — however late it arrives, and on whichever plane — clears
+    exactly this generation and nothing typed or attached afterwards. */
 export interface PendingDelivery {
   key: string;
-  /** The draft text this attempt carried, the clearing fallback when the
-      delivered receipt omits its own text. */
+  /** The exact draft text this attempt carried — what admission clears. */
   text: string;
   /** Immutable snapshot of the attachments this attempt carried: a late
-      delivered receipt removes exactly these from the composer, so images
-      attached after the send stay put. */
+      admission removes exactly these from the composer, so images attached
+      after the send stay put. */
   images: readonly PendingImage[];
 }
 
 const PENDING_DELIVERY_LIMIT = 8;
+const SETTLED_SEND_KEY_LIMIT = 32;
+
+/** Text-only projection persisted per conversation so an unsettled generation
+    survives a composer remount or a full page refresh (the attachment snapshot
+    is memory-only — previews don't survive a refresh either). */
+const pendingSendKey = (id: string) => "llvPendingSend:" + id;
+
+export function readPendingDeliveries(id: string): PendingDelivery[] {
+  try {
+    const raw = JSON.parse(sessionStorage.getItem(pendingSendKey(id)) ?? "[]") as { key?: unknown; text?: unknown }[];
+    if (!Array.isArray(raw)) return [];
+    return raw
+      .filter((entry): entry is { key: string; text: string } =>
+        Boolean(entry) && typeof entry.key === "string" && typeof entry.text === "string")
+      .slice(0, PENDING_DELIVERY_LIMIT)
+      .map((entry) => ({ key: entry.key, text: entry.text, images: [] }));
+  } catch {
+    return [];
+  }
+}
+
+export function writePendingDeliveries(id: string, pending: readonly PendingDelivery[]): void {
+  try {
+    if (pending.length) {
+      sessionStorage.setItem(pendingSendKey(id), JSON.stringify(pending.map(({ key, text }) => ({ key, text }))));
+    } else {
+      sessionStorage.removeItem(pendingSendKey(id));
+    }
+  } catch { /* quota/opaque-origin: the in-memory generation still settles */ }
+}
 
 /**
- * Settle pending deliveries against the current receipt set: a `delivered`
- * receipt for a pending key yields the attempt with its delivered text (the
- * receipt's own text is the server's record of what actually reached the
- * agent, so it wins over the local attempt's) and drops the entry, so repeated
- * delivered receipts clear at most once. Non-delivered and unknown receipts
- * change nothing.
+ * Settle pending generations against the current receipt set: a durably
+ * admitted receipt (queued or beyond — {@link receiptIsAdmitted}) for a pending
+ * key yields that generation for clearing and drops the entry, so repeated
+ * receipts for one key clear at most once. For a pre-delivery admission the
+ * generation's own text is what leaves the draft (the receipt's echo may be a
+ * bounded summary, and clearing off a truncated echo would strand a tail); a
+ * `delivered` receipt's text wins, since it is the server's record of what
+ * actually reached the agent on a replayed key. Timeout (`uncertain`),
+ * `pending`, failed/rejected, and unknown receipts change nothing.
  */
 export function settlePendingDeliveries(
   pending: readonly PendingDelivery[],
   receipts: readonly RuntimeReceipt[],
-): { delivered: { entry: PendingDelivery; text: string }[]; remaining: PendingDelivery[] } {
-  const deliveredByKey = new Map<string, RuntimeReceipt>();
+): { settled: { entry: PendingDelivery; text: string }[]; remaining: PendingDelivery[] } {
+  const admittedByKey = new Map<string, RuntimeReceipt>();
   for (const receipt of receipts) {
-    if (receipt.status === "delivered") deliveredByKey.set(receipt.idempotencyKey, receipt);
+    if (!receiptIsAdmitted(receipt.status)) continue;
+    const current = admittedByKey.get(receipt.idempotencyKey);
+    if (!current || (receipt.status === "delivered" && current.status !== "delivered")) {
+      admittedByKey.set(receipt.idempotencyKey, receipt);
+    }
   }
-  const delivered: { entry: PendingDelivery; text: string }[] = [];
+  const settled: { entry: PendingDelivery; text: string }[] = [];
   const remaining: PendingDelivery[] = [];
   for (const entry of pending) {
-    const receipt = deliveredByKey.get(entry.key);
-    if (receipt) delivered.push({ entry, text: typeof receipt.text === "string" && receipt.text ? receipt.text : entry.text });
-    else remaining.push(entry);
+    const receipt = admittedByKey.get(entry.key);
+    if (!receipt) {
+      remaining.push(entry);
+      continue;
+    }
+    const deliveredText = receipt.status === "delivered" && typeof receipt.text === "string" && receipt.text
+      ? receipt.text
+      : entry.text;
+    settled.push({ entry, text: deliveredText });
   }
-  return { delivered, remaining };
+  return { settled, remaining };
 }
 
 /** Removes one attachment per delivered snapshot entry (matched by content,
@@ -573,10 +621,17 @@ export function TmuxComposer({ file, pollPaused = false }: { file: FileEntry; po
      so the runtime host can round-trip it once the structured plane is on; the
      legacy /api/tmux route ignores the extra field. */
   const idempotencyKey = useRef<string>(mintIdempotencyKey());
-  /* Sends the server may have accepted although the immediate response was
-     lost or non-ok: a later `delivered` receipt for one of these keys clears
-     the draft exactly, so an acknowledged message never lingers as a draft. */
+  /* Unsettled submitted generations: recorded when an attempt leaves for the
+     wire, settled by the first durable admission receipt for the key on any
+     plane (immediate response, receipt stream, refresh snapshot). Persisted
+     text-only per conversation so a remount or refresh cannot orphan an
+     accepted message inside the composer. */
   const pendingDeliveries = useRef<PendingDelivery[]>([]);
+  /* Generations that already settled (draft cleared exactly once). A stale
+     timeout settling after a faster durable admission, or a replayed receipt
+     for a consumed key, must neither report a false failure, re-arm a pending
+     entry, nor clear text the user typed afterwards. Bounded, newest last. */
+  const settledSendKeys = useRef<Set<string>>(new Set());
   /* Durable receipts for this session from the runtime bus (empty while the bus
      is disabled or the session is legacy/unhosted). */
   const runtimeReceipts = useRuntimeReceiptsForArtifact(file.path, cardId);
@@ -588,33 +643,52 @@ export function TmuxComposer({ file, pollPaused = false }: { file: FileEntry; po
     return () => window.clearTimeout(timer);
   }, [compactArmed]);
 
+  const persistPendingDeliveries = (next: PendingDelivery[]) => {
+    pendingDeliveries.current = next;
+    writePendingDeliveries(cardId, next);
+  };
+
+  const markSettled = (key: string) => {
+    const keys = settledSendKeys.current;
+    keys.delete(key);
+    keys.add(key);
+    while (keys.size > SETTLED_SEND_KEY_LIMIT) {
+      const oldest = keys.values().next().value;
+      if (oldest === undefined) break;
+      keys.delete(oldest);
+    }
+  };
+
   /* eslint-disable react-hooks/set-state-in-effect */
   useEffect(() => {
     setSent(readSent(cardId));
     setImmediateRuntimeReceipts([]);
-    pendingDeliveries.current = [];
+    pendingDeliveries.current = readPendingDeliveries(cardId);
+    settledSendKeys.current = new Set();
   }, [cardId]);
   /* eslint-enable react-hooks/set-state-in-effect */
 
-  /* Settle lost-response sends against the receipt stream: a `delivered`
-     receipt for a remembered key means the server accepted that attempt and
-     the turn ran, so its exact text leaves the draft (later typing survives;
-     a rewritten draft for the next turn stays untouched). */
+  /* Settle submitted generations against the receipt stream: a durably
+     admitted receipt (queued or beyond) for a remembered key means the server
+     holds that attempt, so its exact text leaves the draft (later typing
+     survives; a rewritten draft for the next turn stays untouched). Runs on
+     mount too, so a refresh snapshot reconciles a persisted generation. */
   useEffect(() => {
     if (!pendingDeliveries.current.length) return;
-    const { delivered, remaining } = settlePendingDeliveries(pendingDeliveries.current, displayedRuntimeReceipts);
-    if (!delivered.length) return;
-    pendingDeliveries.current = remaining;
-    let remainingImages: readonly PendingImage[] = attachments.images;
-    for (const settled of delivered) {
-      const next = draftAfterDelivery(textRef.current, settled.text);
+    const { settled, remaining } = settlePendingDeliveries(pendingDeliveries.current, displayedRuntimeReceipts);
+    if (!settled.length) return;
+    persistPendingDeliveries(remaining);
+    let remainingImages: readonly PendingImage[] = attachments.imagesRef.current;
+    for (const settlement of settled) {
+      markSettled(settlement.entry.key);
+      const next = draftAfterDelivery(textRef.current, settlement.text);
       if (next !== textRef.current) setText(next);
-      remainingImages = attachmentsAfterDelivery(remainingImages, settled.entry.images);
-      /* The delivered attempt consumed its key: minting a fresh one keeps the
+      remainingImages = attachmentsAfterDelivery(remainingImages, settlement.entry.images);
+      /* The admitted attempt consumed its key: minting a fresh one keeps the
          next message from being replay-deduped into silence server-side. */
-      if (settled.entry.key === idempotencyKey.current) idempotencyKey.current = mintIdempotencyKey();
+      if (settlement.entry.key === idempotencyKey.current) idempotencyKey.current = mintIdempotencyKey();
     }
-    if (remainingImages.length !== attachments.images.length) attachments.replace([...remainingImages]);
+    if (remainingImages.length !== attachments.imagesRef.current.length) attachments.replace([...remainingImages]);
     // eslint-disable-next-line react-hooks/exhaustive-deps -- setText/textRef/attachments are hook-stable
   }, [displayedRuntimeReceipts]);
 
@@ -676,13 +750,44 @@ export function TmuxComposer({ file, pollPaused = false }: { file: FileEntry; po
 
   const send = async (overrideText?: string, retry?: { receiptId: number; clientMessageId?: string }) => {
     const payloadText = overrideText ?? text;
-    if (busy || voiceSending || (!payloadText.trim() && !attachments.images.length)) return;
-    if (structuredSession && attachments.images.length && !attachments.validate()) return;
+    /* The generation snapshot: exactly the text and attachments this attempt
+       carries onto the wire. Read through the ref so a submit racing a paste
+       still sends and later clears the same set. */
+    const sentImages: PendingImage[] = attachments.imagesRef.current.map((image) => ({ ...image }));
+    if (busy || voiceSending || (!payloadText.trim() && !sentImages.length)) return;
+    if (structuredSession && sentImages.length && !attachments.validate()) return;
     setBusy(true);
     setStatus(null);
     /* Idempotency key: the backend can dedupe a retried held/failed delivery
        against this id so the successor never receives the same prompt twice. */
     const clientMessageId = deliveryAttemptKey(idempotencyKey.current, retry?.clientMessageId);
+    /* A local pre-flight rejection (image protocol gate) never reaches the
+       wire, so it must not arm a pending generation either. */
+    const reachesWire = !(structuredSession && structuredImagesDisabled && sentImages.length > 0);
+    /* Record the generation BEFORE the request: a durable admission receipt can
+       land on the receipt stream while this response is still in flight, and
+       it must find the generation to clear. The earliest attempt per key stays
+       the immutable record — a replay never overwrites it — and a key whose
+       generation already settled is never re-armed. */
+    const recordedThisAttempt = reachesWire
+      && !settledSendKeys.current.has(clientMessageId)
+      && !pendingDeliveries.current.some((entry) => entry.key === clientMessageId);
+    if (recordedThisAttempt) {
+      persistPendingDeliveries([
+        { key: clientMessageId, text: payloadText, images: sentImages },
+        ...pendingDeliveries.current,
+      ].slice(0, PENDING_DELIVERY_LIMIT));
+    }
+    /* Clear exactly this settled generation: its text prefix leaves the draft
+       (later typing survives) and its attachment snapshot leaves the tray
+       (later images survive). At most once per key — a replayed receipt for an
+       already-settled generation must not touch what the user typed since. */
+    const settleGeneration = (clearedText: string, snapshot: readonly PendingImage[]) => {
+      if (settledSendKeys.current.has(clientMessageId)) return;
+      markSettled(clientMessageId);
+      setText(draftAfterDelivery(textRef.current, clearedText));
+      attachments.replace(attachmentsAfterDelivery(attachments.imagesRef.current, snapshot));
+    };
     try {
       const json: {
         ok?: boolean;
@@ -696,12 +801,12 @@ export function TmuxComposer({ file, pollPaused = false }: { file: FileEntry; po
         outcome?: "delivered-to-live" | "resumed" | "held" | "queued" | "delivering" | "delivered" | "recovering" | "failed";
         receipt?: RuntimeReceipt;
       } = structuredSession
-        ? structuredImagesDisabled && attachments.images.length > 0
+        ? !reachesWire
           ? { ok: false, structured: true, error: structuredImagesReason }
           : await sendRuntimeMessage({
               conversationId: structuredSession.session.conversationId,
               text: payloadText.trim(),
-              images: attachments.images.map((image) => ({ base64: image.base64, mime: image.mime })),
+              images: sentImages.map((image) => ({ base64: image.base64, mime: image.mime })),
               idempotencyKey: clientMessageId,
               policy: "interrupt-active",
             }).then((result) => ({
@@ -723,7 +828,7 @@ export function TmuxComposer({ file, pollPaused = false }: { file: FileEntry; po
               text: payloadText,
               idempotencyKey: clientMessageId,
               clientMessageId,
-              images: attachments.images.map((image) => ({ base64: image.base64, mime: image.mime })),
+              images: sentImages.map((image) => ({ base64: image.base64, mime: image.mime })),
             }),
           }).then(async (response) => {
             const body = await response.json() as typeof json;
@@ -731,40 +836,57 @@ export function TmuxComposer({ file, pollPaused = false }: { file: FileEntry; po
           });
       if (!json.ok) {
         if (json.structured && json.receipt) {
+          /* Keep the payload readable in the compact receipt for retry and
+             audit even when the server's echo omits it. */
+          const receipt: RuntimeReceipt = (json.receipt.kind === "send" || json.receipt.kind === "steer")
+            && !json.receipt.text && payloadText.trim()
+            ? { ...json.receipt, text: payloadText.trim() }
+            : json.receipt;
           setImmediateRuntimeReceipts((current) => [
-            json.receipt!,
-            ...current.filter((receipt) => receipt.operationId !== json.receipt!.operationId),
+            receipt,
+            ...current.filter((candidate) => candidate.operationId !== receipt.operationId),
           ].slice(0, 8));
-          idempotencyKey.current = mintIdempotencyKey();
-          if (json.receipt.status === "delivered") {
-            /* An idempotent replay: this key's FIRST attempt already reached
-               the agent and the turn ran. The accepted delivery clears its
-               exact text (the receipt's record wins) and exactly the FIRST
-               attempt's attachment snapshot — images attached after that
-               attempt stay put for the next message. */
-            const delivered = typeof json.receipt.text === "string" && json.receipt.text ? json.receipt.text : payloadText;
-            setText(draftAfterDelivery(textRef.current, delivered));
+          if (receiptIsAdmitted(receipt.status)) {
+            /* An idempotent replay: this key's FIRST attempt was durably
+               admitted (queued or beyond) — the server holds the message.
+               Clear exactly that generation: for a delivered replay the
+               receipt's record of what reached the agent wins; for a queued
+               admission the attempt's own text does (the echo may be a bounded
+               summary). Attachments clear by the FIRST attempt's snapshot —
+               images attached after that attempt stay put. */
             const attempt = pendingDeliveries.current.find((entry) => entry.key === clientMessageId);
-            pendingDeliveries.current = pendingDeliveries.current.filter((entry) => entry.key !== clientMessageId);
-            if (attempt) attachments.replace(attachmentsAfterDelivery(attachments.images, attempt.images));
-            else attachments.clear();
-            setStatus({ kind: "ok", text: t("common.sent") });
+            persistPendingDeliveries(pendingDeliveries.current.filter((entry) => entry.key !== clientMessageId));
+            const admitted = receipt.status === "delivered" && typeof json.receipt.text === "string" && json.receipt.text
+              ? json.receipt.text
+              : attempt?.text ?? payloadText;
+            settleGeneration(admitted, attempt?.images ?? sentImages);
+            if (idempotencyKey.current === clientMessageId) idempotencyKey.current = mintIdempotencyKey();
+            if (receipt.status === "delivered") setStatus({ kind: "ok", text: t("common.sent") });
             inputRef.current?.focus();
             return;
           }
+          /* A definitive rejection consumed the key — the next submit is a new
+             message. An `uncertain`/`pending` receipt keeps the key so the
+             user's retry replays idempotently instead of double-sending. */
+          if (receiptIsTerminal(receipt.status) && idempotencyKey.current === clientMessageId) {
+            idempotencyKey.current = mintIdempotencyKey();
+          }
+        }
+        if (settledSendKeys.current.has(clientMessageId)) {
+          /* A stale settlement: a durable admission already cleared this
+             generation while the response was in flight. The receipt stack
+             tells the truth — no false failure, no re-armed pending entry. */
+          return;
         }
         /* The earliest attempt per key is the immutable record of what the
            server may have accepted: a retry never overwrites it, and a
-           definitive 4xx rejection (e.g. a changed-payload 409) creates no
-           entry at all — only a lost response (network/5xx) or an explicitly
+           definitive 4xx rejection (e.g. a changed-payload 409) keeps no
+           entry — only a lost response (network/5xx) or an explicitly
            still-moving receipt does. */
-        if (!receiptIsTerminal(json.receipt?.status ?? "pending")
-          && !pendingDeliveries.current.some((entry) => entry.key === clientMessageId)
-          && (json.status === undefined || json.status >= 500)) {
-          pendingDeliveries.current = [
-            { key: clientMessageId, text: payloadText, images: attachments.images.map((image) => ({ ...image })) },
-            ...pendingDeliveries.current,
-          ].slice(0, PENDING_DELIVERY_LIMIT);
+        const possiblyAccepted = !receiptIsTerminal(json.receipt?.status ?? "pending")
+          && (json.status === undefined || json.status >= 500);
+        if (!possiblyAccepted && recordedThisAttempt) {
+          persistPendingDeliveries(pendingDeliveries.current.filter((entry) => entry.key !== clientMessageId));
         }
         // A hard failure keeps the draft text (never cleared) so the message is
         // not lost; the error is announced by the composer's live status region.
@@ -776,14 +898,14 @@ export function TmuxComposer({ file, pollPaused = false }: { file: FileEntry; po
           json.receipt!,
           ...current.filter((receipt) => receipt.operationId !== json.receipt!.operationId),
         ].slice(0, 8));
-        idempotencyKey.current = mintIdempotencyKey();
-        setText(draftAfterDelivery(textRef.current, payloadText));
-        pendingDeliveries.current = pendingDeliveries.current.filter((entry) => entry.key !== clientMessageId);
-        attachments.clear();
+        const attempt = pendingDeliveries.current.find((entry) => entry.key === clientMessageId);
+        persistPendingDeliveries(pendingDeliveries.current.filter((entry) => entry.key !== clientMessageId));
+        if (idempotencyKey.current === clientMessageId) idempotencyKey.current = mintIdempotencyKey();
+        settleGeneration(payloadText, attempt?.images ?? sentImages);
         inputRef.current?.focus();
         return;
       }
-      const imgCount = attachments.images.length;
+      const imgCount = sentImages.length;
       // The migration delivery fence returns `held`/`queued`/`recovering` when
       // the text was accepted for the successor rather than delivered live. Those
       // are durable acknowledgements (the backend persisted the message), so the
@@ -800,10 +922,10 @@ export function TmuxComposer({ file, pollPaused = false }: { file: FileEntry; po
       };
       const prior = retry ? sent.filter((item) => item.id !== retry.receiptId) : sent;
       persistSent([...prior, entry].slice(-SENT_LIMIT));
-      idempotencyKey.current = mintIdempotencyKey(); // next draft is a new message
-      setText(draftAfterDelivery(textRef.current, payloadText));
-      pendingDeliveries.current = pendingDeliveries.current.filter((entry) => entry.key !== clientMessageId);
-      attachments.clear();
+      const attempt = pendingDeliveries.current.find((candidate) => candidate.key === clientMessageId);
+      persistPendingDeliveries(pendingDeliveries.current.filter((candidate) => candidate.key !== clientMessageId));
+      if (idempotencyKey.current === clientMessageId) idempotencyKey.current = mintIdempotencyKey(); // next draft is a new message
+      settleGeneration(payloadText, attempt?.images ?? sentImages);
       setStatus({
         kind: held ? "info" : "ok",
         text: held
@@ -816,17 +938,14 @@ export function TmuxComposer({ file, pollPaused = false }: { file: FileEntry; po
       });
       inputRef.current?.focus();
     } catch {
-      /* The request died on the wire AFTER the server may have accepted it:
-         remember the attempt (text AND attachment snapshot) so a delivered
-         receipt still clears exactly what was sent. An earlier attempt under
-         the same key stays the immutable record. */
-      if (!pendingDeliveries.current.some((entry) => entry.key === clientMessageId)) {
-        pendingDeliveries.current = [
-          { key: clientMessageId, text: payloadText, images: attachments.images.map((image) => ({ ...image })) },
-          ...pendingDeliveries.current,
-        ].slice(0, PENDING_DELIVERY_LIMIT);
+      /* The request died on the wire AFTER the server may have accepted it.
+         The pre-flight record (text AND attachment snapshot) stays armed so a
+         late admission receipt still clears exactly what was sent. A stale
+         death racing a faster durable admission reports nothing — the receipt
+         stack already tells the truth. */
+      if (!settledSendKeys.current.has(clientMessageId)) {
+        setStatus({ kind: "err", text: t("common.serverUnavailable") });
       }
-      setStatus({ kind: "err", text: t("common.serverUnavailable") });
     } finally {
       setBusy(false);
     }

--- a/src/components/TmuxComposer.tsx
+++ b/src/components/TmuxComposer.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useId, useRef, useState } from "react";
+import { useEffect, useId, useLayoutEffect, useRef, useState } from "react";
 
 import { ArrowRight, ArrowUpToLine, ChevronRight, FoldVertical, Loader2, Play, Square, SquareTerminal, X } from "@/components/icons";
 import { Check, Plus, RotateCcw } from "lucide-react";
@@ -515,6 +515,107 @@ function canMessageWithoutPane(file: FileEntry): boolean {
 const draftKey = (id: string) => "llvDraft:" + id;
 const COMPOSE_EVENT = "llv-compose-draft";
 
+/** Links a transcript path to the identity whose sessionStorage records hold
+    that conversation's composer state, so an id rotation can find them. */
+const composerOwnerKey = (path: string) => "llvComposerOwner:" + path;
+
+/** Provisional-id adoption (and late identity enrichment) rotates the card's
+    identity while its transcript path stays put: the draft, the unsettled
+    generations, and the delivery receipts persisted under the old identity
+    must ride along, or a poll that fills in the canonical id would silently
+    orphan the text the user is typing. The owner pointer written per path
+    makes the move bidirectional — a flap that drops the id for a poll adopts
+    the records back onto the path, the next enrichment adopts them forward.
+    Moves each record once; a record already filed under the new identity
+    always wins. */
+export function adoptComposerState(path: string, cardId: string): void {
+  try {
+    const previousOwner = sessionStorage.getItem(composerOwnerKey(path));
+    for (const from of [previousOwner, path]) {
+      if (!from || from === cardId) continue;
+      for (const keyOf of [draftKey, pendingSendKey, sentKey]) {
+        const legacy = sessionStorage.getItem(keyOf(from));
+        if (legacy === null) continue;
+        if (sessionStorage.getItem(keyOf(cardId)) === null) sessionStorage.setItem(keyOf(cardId), legacy);
+        sessionStorage.removeItem(keyOf(from));
+      }
+    }
+    if (cardId === path) sessionStorage.removeItem(composerOwnerKey(path));
+    else sessionStorage.setItem(composerOwnerKey(path), cardId);
+  } catch { /* quota/opaque-origin: in-memory state still carries the turn */ }
+}
+
+/** Focus continuity across composer remounts (issue #272). Board polls churn
+    the hosting keys — a committed migration rewrites the transcript path, an
+    adoption flap drops and re-adds the entry — which remounts the composer
+    mid-typing and throws keyboard focus to `body`. The outgoing textarea
+    records that it held focus (with the caret and scroll position); the next
+    composer for the same conversation reclaims it, but only while nothing else
+    took focus in between, so a poll-driven remount restores exactly what it
+    destroyed and a user's click elsewhere is never overridden. Claims expire
+    after {@link FOCUS_CLAIM_TTL_MS} so a card reopened much later — a real
+    user navigation — never has focus grabbed for it. */
+const FOCUS_CLAIM_TTL_MS = 10_000;
+interface ComposerFocusClaim {
+  start: number;
+  end: number;
+  scrollTop: number;
+  at: number;
+}
+const composerFocusClaims = new Map<string, ComposerFocusClaim>();
+
+function ComposerFocusContinuity({ claimKeys }: {
+  /** Both identity axes of one conversation (stable id and transcript path):
+      a migration keeps the id while the path rotates, an adoption keeps the
+      path while the id rotates — either axis must find the claim. */
+  claimKeys: readonly string[];
+}) {
+  /* The textarea is resolved through the DOM from this anchor, not through the
+     composer's ref: React attaches/detaches refs in tree order, so a sibling's
+     ref is not yet attached when this component mounts and already detached
+     when its cleanup runs — but the form subtree is in the document on both
+     sides of a deletion pass. */
+  const anchorRef = useRef<HTMLElement>(null);
+  const keys = [...new Set(claimKeys)];
+  const keysSignature = keys.join(" ");
+  useLayoutEffect(() => {
+    const composerField = () => anchorRef.current?.closest("form")?.querySelector("textarea") ?? null;
+    const el = composerField();
+    const claim = keys.map((key) => composerFocusClaims.get(key)).find(Boolean);
+    if (el && claim) {
+      for (const key of keys) composerFocusClaims.delete(key);
+      const active = document.activeElement;
+      const focusIsOrphaned = !active || active === document.body || !active.isConnected;
+      if (focusIsOrphaned && nowMs() - claim.at < FOCUS_CLAIM_TTL_MS) {
+        el.focus({ preventScroll: true });
+        const end = Math.min(claim.end, el.value.length);
+        el.setSelectionRange(Math.min(claim.start, end), end);
+        el.scrollTop = claim.scrollTop;
+      }
+    }
+    /* The record runs in the deletion pass, while the textarea is still in the
+       document — a plain re-render never reaches it, so polls that only update
+       data cannot trigger any focus side effect. */
+    return () => {
+      const outgoing = composerField();
+      if (!outgoing || document.activeElement !== outgoing) return;
+      const at = nowMs();
+      for (const [key, stale] of composerFocusClaims) {
+        if (at - stale.at >= FOCUS_CLAIM_TTL_MS) composerFocusClaims.delete(key);
+      }
+      const claim: ComposerFocusClaim = {
+        start: outgoing.selectionStart ?? outgoing.value.length,
+        end: outgoing.selectionEnd ?? outgoing.value.length,
+        scrollTop: outgoing.scrollTop,
+        at,
+      };
+      for (const key of keys) composerFocusClaims.set(key, claim);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- keys is re-derived per render; keysSignature is its value identity
+  }, [keysSignature]);
+  return <span ref={anchorRef} hidden aria-hidden />;
+}
+
 /**
  * Drops text into a conversation's composer from outside (the link-arrow
  * gesture): the stored draft grows and any mounted composer for that
@@ -595,7 +696,13 @@ export function TmuxComposer({ file, pollPaused = false }: { file: FileEntry; po
   /* Column reshuffles can remount the composer mid-typing; the draft lives in
      sessionStorage so the text survives the remount. */
   const composer = useComposer({
-    initialText: () => (typeof window === "undefined" ? "" : sessionStorage.getItem(draftKey(cardId)) ?? ""),
+    initialText: () => {
+      if (typeof window === "undefined") return "";
+      /* A remount that crossed an identity adoption (provisional id →
+         canonical id) must find the draft persisted under the old key. */
+      adoptComposerState(file.path, cardId);
+      return sessionStorage.getItem(draftKey(cardId)) ?? "";
+    },
     persistText: (value) => {
       if (value) sessionStorage.setItem(draftKey(cardId), value);
       else sessionStorage.removeItem(draftKey(cardId));
@@ -661,10 +768,18 @@ export function TmuxComposer({ file, pollPaused = false }: { file: FileEntry; po
 
   /* eslint-disable react-hooks/set-state-in-effect */
   useEffect(() => {
+    /* Identity enrichment without a remount (a poll fills in the conversation
+       id while this instance stays mounted): move the persisted records onto
+       the new key before re-reading them. */
+    adoptComposerState(file.path, cardId);
     setSent(readSent(cardId));
     setImmediateRuntimeReceipts([]);
     pendingDeliveries.current = readPendingDeliveries(cardId);
     settledSendKeys.current = new Set();
+    /* Keyed by identity alone: a path migration under a stable id must not
+       wipe the immediate receipts or the settled-key memory (`file.path` is
+       only read to adopt records the old identity left behind). */
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [cardId]);
   /* eslint-enable react-hooks/set-state-in-effect */
 
@@ -1161,6 +1276,10 @@ export function TmuxComposer({ file, pollPaused = false }: { file: FileEntry; po
       className="flex shrink-0 flex-col gap-1.5 border-t border-border bg-card px-2.5 py-2"
       aria-label={structuredSession ? t("composer.sendStructuredAria") : spawnMode ? t("composer.spawnAria") : t("composer.sendAria", { target: target ?? "" })}
     >
+      {/* Unmounts exactly when the textarea does (a key-churn remount, an
+          adoption flap, a pane-target flap hiding the composer), so its
+          deletion pass can still see who held focus. */}
+      <ComposerFocusContinuity claimKeys={[cardId, file.path]} />
       {/* Proactive hold hint: while the card is switching accounts, the next
           send is queued for the successor rather than delivered live. Shown
           identically under the desktop and mobile composers. */}

--- a/src/components/imageAttachments.tsx
+++ b/src/components/imageAttachments.tsx
@@ -152,6 +152,9 @@ export function useImageAttachments(handlers: {
 
   return {
     images,
+    /** Latest committed attachments, for async send closures whose render-scope
+        `images` may be stale by the time a response or receipt settles. */
+    imagesRef,
     addFiles,
     handlePaste,
     removeAt: (idx: number) => commit(imagesRef.current.filter((_, i) => i !== idx)),

--- a/src/components/runtime/AttentionCard.focus.dom.test.tsx
+++ b/src/components/runtime/AttentionCard.focus.dom.test.tsx
@@ -1,0 +1,97 @@
+import { expect, test } from "bun:test";
+import { Window } from "happy-dom";
+import { flushSync } from "react-dom";
+import { createRoot } from "react-dom/client";
+
+import { setLocale } from "@/lib/i18n";
+
+import { AttentionCard } from "./AttentionCard";
+import type { RuntimeAttention } from "./runtimeModel";
+
+const dom = new Window();
+Object.assign(globalThis, {
+  window: dom,
+  document: dom.document,
+  navigator: dom.navigator,
+  Node: dom.Node,
+  HTMLElement: dom.HTMLElement,
+  HTMLButtonElement: dom.HTMLButtonElement,
+  Event: dom.Event,
+  CustomEvent: dom.CustomEvent,
+  KeyboardEvent: dom.KeyboardEvent,
+  requestAnimationFrame: dom.requestAnimationFrame.bind(dom),
+  cancelAnimationFrame: dom.cancelAnimationFrame.bind(dom),
+});
+(dom as unknown as { matchMedia: (query: string) => unknown }).matchMedia = (query: string) => ({
+  matches: false,
+  media: query,
+  addEventListener() {},
+  removeEventListener() {},
+});
+
+function attention(overrides: Partial<RuntimeAttention>): RuntimeAttention {
+  return {
+    id: "att_1",
+    conversationId: "conv_a",
+    kind: "approval",
+    state: "open",
+    unowned: false,
+    createdAt: "2026-07-10T00:00:00.000Z",
+    request: { command: "rm -rf build" },
+    ...overrides,
+  };
+}
+
+test("an attention card arriving from the runtime never steals focus from a composer mid-typing", async () => {
+  setLocale("en");
+  const composerField = document.createElement("textarea");
+  composerField.value = "half-typed prompt";
+  document.body.append(composerField);
+  composerField.focus();
+  composerField.setSelectionRange(4, 4);
+
+  const host = document.createElement("div");
+  document.body.append(host);
+  const root = createRoot(host);
+  try {
+    /* The runtime event lands while the user is typing. */
+    flushSync(() => root.render(
+      <AttentionCard attention={attention({})} onApprove={() => {}} onDeny={() => {}} />,
+    ));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(document.activeElement).toBe(composerField);
+    expect(composerField.selectionStart).toBe(4);
+
+    /* A heuristic flap replacing the attention must not steal focus either. */
+    flushSync(() => root.render(
+      <AttentionCard attention={attention({ id: "att_2", kind: "waiting_heuristic", request: { detail: "still there?" } })} />,
+    ));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(document.activeElement).toBe(composerField);
+  } finally {
+    flushSync(() => root.unmount());
+    host.remove();
+    composerField.remove();
+  }
+});
+
+test("with no editor focused, the attention card still takes initial focus for keyboard operation", async () => {
+  setLocale("en");
+  (document.activeElement as HTMLElement | null)?.blur?.();
+  const host = document.createElement("div");
+  document.body.append(host);
+  const root = createRoot(host);
+  try {
+    flushSync(() => root.render(
+      <AttentionCard attention={attention({})} onApprove={() => {}} onDeny={() => {}} />,
+    ));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    const active = document.activeElement as HTMLElement | null;
+    expect(active).not.toBe(null);
+    expect(active).not.toBe(document.body);
+    expect(host.contains(active)).toBe(true);
+  } finally {
+    flushSync(() => root.unmount());
+    host.remove();
+  }
+});

--- a/src/components/runtime/AttentionCard.tsx
+++ b/src/components/runtime/AttentionCard.tsx
@@ -48,7 +48,14 @@ export function AttentionCard({ attention, onApprove, onDeny, onAnswerQuestion, 
     const node = cardRef.current;
     if (!node) return;
     const focusables = () => Array.from(node.querySelectorAll<HTMLElement>('button,[href],input,select,textarea,[tabindex]:not([tabindex="-1"])')).filter((el) => !el.hasAttribute("disabled"));
-    focusables()[0]?.focus({ preventScroll: true });
+    /* The card arrives on a runtime event, not a user action: it must never
+       yank the caret out of a field mid-typing (issue #272). It takes initial
+       focus only when nothing text-editable holds it; a typing user reaches it
+       with Tab, at which point the trap below behaves as always. */
+    const active = document.activeElement;
+    const editing = active instanceof HTMLElement
+      && (active.tagName === "TEXTAREA" || active.tagName === "INPUT" || active.isContentEditable);
+    if (!editing) focusables()[0]?.focus({ preventScroll: true });
     const onKey = (event: KeyboardEvent) => {
       if (event.key === "Escape" && onDeny) {
         event.preventDefault();

--- a/src/components/runtime/runtimeModel.ts
+++ b/src/components/runtime/runtimeModel.ts
@@ -624,6 +624,23 @@ export function receiptIsTerminal(status: ReceiptStatus): boolean {
 }
 
 /**
+ * A receipt whose status proves the server durably admitted the message into
+ * the structured queue (or further along the delivery lifecycle). Admission is
+ * the contract point where a composer may clear the submitted draft: the
+ * payload is journaled server-side and survives without the client copy.
+ * `pending`/`uncertain` prove nothing (the attempt may still be lost);
+ * `rejected`/`failed`/`interrupted` admit nothing to deliver.
+ */
+export function receiptIsAdmitted(status: ReceiptStatus): boolean {
+  return status === "queued"
+    || status === "delivering"
+    || status === "turn-started"
+    || status === "steered"
+    || status === "delivered"
+    || status === "answered";
+}
+
+/**
  * Mint an idempotency key for a fresh message draft. Same key must be reused on
  * Retry (never re-sends server-side) and replaced on Edit-and-resend.
  */


### PR DESCRIPTION
## Summary

- Integrates the preserved generation-safe composer settlement commit with additive history.
- Preserves focus, caret, drafts, attachments, and delivery identity across polling, path migration, and account adoption.
- Prevents runtime attention cards from stealing focus while the operator is typing.
- Adds responsive receipt wrapping and production-shaped DOM coverage.

## Verification

- Exact HEAD: `0591b7b9372d3ae6a5bcebd4226604d8cfd984ac`
- Fresh Fable review: pass, confidence 0.92
- Focused composer and attention tests: 51/51
- Runtime component tests: 37/37
- Full component suite: 1055/1055
- `tsc --noEmit`: pass
- ESLint on all changed files: pass
- Reviewer worktree remained byte-identical

## Follow-ups

Two bounded low-severity observations remain recorded on issue #272: pruning a terminally rejected retry entry and a narrow cosmetic false-error window during identity adoption. They do not permit draft loss, duplicate delivery, or focus theft.

Closes #272