### PR TITLE
Repair structured runtime convergence under concurrent launches (#367)

### DIFF
--- a/src/app/api/runtime/snapshot/route.ts
+++ b/src/app/api/runtime/snapshot/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 
 import { runtimeHostClient } from "@/lib/runtime/client";
 import { runtimeEventsEnabled } from "@/lib/runtime/flags";
+import { structuredStartupAxis } from "@/lib/runtime/startupStatus";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -14,6 +15,7 @@ export async function GET(): Promise<NextResponse> {
     return NextResponse.json({
       ...await client.snapshot(),
       structuredHostsEnabled: process.env.LLV_STRUCTURED_HOSTS === "1",
+      structuredStartup: structuredStartupAxis(),
     }, { headers: { "cache-control": "no-store" } });
   } catch (error) {
     return NextResponse.json({ error: error instanceof Error ? error.message : "runtime host is unavailable" }, { status: 503 });

--- a/src/lib/runtime/claudeStreamBrokerHost.test.ts
+++ b/src/lib/runtime/claudeStreamBrokerHost.test.ts
@@ -12,6 +12,7 @@ import { AgentRegistry } from "@/lib/agent/registry";
 import { procBackend } from "@/lib/proc";
 
 import {
+  claudeCliAuthStatus,
   ClaudeStreamBrokerHost,
   FileClaudeDeliveryLedger,
   type ClaudeDeliveryLedger,
@@ -1809,5 +1810,57 @@ describe("restart and kill fail-safe lifecycle", () => {
     expect(states.at(-1)).toMatchObject({ status: "unhosted", pid: null });
     await expect(host.release()).resolves.toBeUndefined();
     await pendingSend;
+  });
+});
+
+describe("issue 367 concurrent launch admission", () => {
+  test("the default auth probe keeps the event loop free for simultaneous structured launches", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "llv-claude-auth-probe-"));
+    const binary = path.join(dir, "claude");
+    fs.writeFileSync(binary, [
+      "#!/bin/sh",
+      'if [ "$1" = "auth" ]; then',
+      "  sleep 0.25",
+      '  printf \'{"loggedIn":true,"authMethod":"claude.ai","subscriptionType":"pro"}\\n\'',
+      'elif [ "$1" = "--version" ]; then',
+      "  printf '2.1.17 (Claude Code)\\n'",
+      "fi",
+    ].join("\n"), { mode: 0o755 });
+    try {
+      /* Production #367: four simultaneous Fable launches starved each other's
+         3s runtime-host socket calls into "runtime host request timed out"
+         behind synchronous CLI probes. The probe must leave the loop running:
+         a spawnSync probe would freeze this interval for the whole batch. */
+      let ticks = 0;
+      const timer = setInterval(() => { ticks += 1; }, 10);
+      const statuses = await Promise.all(Array.from({ length: 4 }, () =>
+        claudeCliAuthStatus(binary, { NODE_ENV: "test", PATH: process.env.PATH }, dir)));
+      clearInterval(timer);
+      for (const status of statuses) {
+        expect(status).toEqual({
+          loggedIn: true,
+          authMethod: "claude.ai",
+          subscriptionType: "pro",
+          version: "2.1.17",
+        });
+      }
+      expect(ticks).toBeGreaterThanOrEqual(8);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("a failing auth probe binary rejects without leaking provider diagnostics", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "llv-claude-auth-fail-"));
+    const binary = path.join(dir, "claude");
+    fs.writeFileSync(binary, "#!/bin/sh\nexit 1\n", { mode: 0o755 });
+    try {
+      await expect(claudeCliAuthStatus(binary, { NODE_ENV: "test", PATH: process.env.PATH }, dir))
+        .rejects.toThrow("Claude subscription authentication check failed");
+      await expect(claudeCliAuthStatus(path.join(dir, "missing"), { NODE_ENV: "test", PATH: process.env.PATH }, dir))
+        .rejects.toThrow("Claude subscription authentication probe failed");
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
   });
 });

--- a/src/lib/runtime/claudeStreamBrokerHost.ts
+++ b/src/lib/runtime/claudeStreamBrokerHost.ts
@@ -1,4 +1,4 @@
-import { spawn, spawnSync } from "node:child_process";
+import { spawn } from "node:child_process";
 import type { ChildProcessWithoutNullStreams, SpawnOptionsWithoutStdio } from "node:child_process";
 import crypto from "node:crypto";
 import fs from "node:fs";
@@ -295,13 +295,39 @@ function subscriptionEnv(source: NodeJS.ProcessEnv, claudeConfigDir?: string): N
   return env;
 }
 
-function defaultAuthStatus(binary: string, env: NodeJS.ProcessEnv, cwd: string): ClaudeAuthStatus {
-  const result = spawnSync(binary, ["auth", "status"], { cwd, env, encoding: "utf8" });
+const MAX_AUTH_PROBE_STDOUT_BYTES = 1024 * 1024;
+
+/* The auth probe runs on the Viewer request loop while other structured
+   launches, runtime-socket calls, and broker stdout pumps share it. It must
+   never block the event loop: production #367 saw four simultaneous Claude
+   launches starve each other's 3s runtime-host calls into "runtime host
+   request timed out" behind synchronous CLI probes. */
+function claudeCliProbe(
+  binary: string,
+  args: string[],
+  cwd: string,
+  env: NodeJS.ProcessEnv,
+): Promise<{ status: number | null; stdout: string }> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(binary, args, { cwd, env, stdio: ["ignore", "pipe", "pipe"] });
+    let stdout = "";
+    child.stdout.setEncoding("utf8");
+    child.stdout.on("data", (chunk: string) => {
+      if (stdout.length < MAX_AUTH_PROBE_STDOUT_BYTES) stdout += chunk;
+    });
+    child.stderr.on("data", () => { /* Provider diagnostics may contain credentials. */ });
+    child.on("error", (error) => reject(new Error(`Claude subscription authentication probe failed: ${safeError(error)}`)));
+    child.on("close", (code) => resolve({ status: code, stdout }));
+  });
+}
+
+export async function claudeCliAuthStatus(binary: string, env: NodeJS.ProcessEnv, cwd: string): Promise<ClaudeAuthStatus> {
+  const result = await claudeCliProbe(binary, ["auth", "status"], cwd, env);
   if (result.status !== 0) throw new Error("Claude subscription authentication check failed");
   let value: JsonObject | null = null;
   try { value = record(JSON.parse(result.stdout)); } catch { /* handled below */ }
   if (!value) throw new Error("Claude subscription authentication status was invalid");
-  const versionResult = spawnSync(binary, ["--version"], { cwd, env, encoding: "utf8" });
+  const versionResult = await claudeCliProbe(binary, ["--version"], cwd, env);
   const version = versionResult.status === 0 ? versionResult.stdout.match(/\b\d+\.\d+\.\d+\b/)?.[0] ?? null : null;
   return {
     loggedIn: value.loggedIn === true,
@@ -510,7 +536,7 @@ export class ClaudeStreamBrokerHost implements EngineHost {
   ): Promise<ClaudeStreamBrokerHost> {
     const binary = options.binary ?? process.env.LLV_CLAUDE_BINARY ?? "claude";
     const env = subscriptionEnv(options.env ?? process.env, options.claudeConfigDir);
-    const auth = await (options.readAuthStatus?.() ?? defaultAuthStatus(binary, env, options.cwd));
+    const auth = await (options.readAuthStatus?.() ?? claudeCliAuthStatus(binary, env, options.cwd));
     if (!auth.loggedIn || auth.authMethod !== "claude.ai" || !auth.subscriptionType) {
       throw new Error("Claude stream hosting requires a claude.ai subscription login");
     }

--- a/src/lib/runtime/client.ts
+++ b/src/lib/runtime/client.ts
@@ -13,6 +13,23 @@ export class RuntimeHostUnavailableError extends Error {
   }
 }
 
+const TRANSPORT_FAILURE_MESSAGES = new Set([
+  "runtime host request timed out",
+  "runtime host is unavailable",
+  "runtime host response exceeds limit",
+  "runtime host returned invalid JSON",
+  "runtime host response id mismatch",
+]);
+
+/** True only for socket-level failures the client itself produced, where the
+    request may or may not have reached the journal. Idempotent commands are
+    safe to replay against these; deterministic server rejections are not. */
+export function isRuntimeHostTransportFailure(error: unknown): boolean {
+  return error instanceof RuntimeHostUnavailableError
+    && error.code === undefined
+    && TRANSPORT_FAILURE_MESSAGES.has(error.message);
+}
+
 export interface RuntimeHostClient {
   snapshot(): Promise<RuntimeSnapshot>;
   events(after: number): Promise<RuntimeReplay>;

--- a/src/lib/runtime/startupStatus.test.ts
+++ b/src/lib/runtime/startupStatus.test.ts
@@ -13,3 +13,21 @@ test("separate bundle module instances share structured startup status", async (
     instrumentationCopy.markStructuredHostStartupReady();
   }
 });
+
+test("issue 367: the structured startup axis never reports ready before adoption succeeds", async () => {
+  const { markStructuredHostStartupFailed, markStructuredHostStartupReady, structuredStartupAxis } = await import(`./startupStatus?${"axis-copy"}`);
+  const store = globalThis as typeof globalThis & { __llvStructuredHostStartupFailed?: boolean };
+  const previous = store.__llvStructuredHostStartupFailed;
+  try {
+    delete store.__llvStructuredHostStartupFailed;
+    expect(structuredStartupAxis({ LLV_STRUCTURED_HOSTS: "1" })).toBe("pending");
+    markStructuredHostStartupFailed();
+    expect(structuredStartupAxis({ LLV_STRUCTURED_HOSTS: "1" })).toBe("failed");
+    markStructuredHostStartupReady();
+    expect(structuredStartupAxis({ LLV_STRUCTURED_HOSTS: "1" })).toBe("ready");
+    expect(structuredStartupAxis({})).toBeNull();
+  } finally {
+    if (previous === undefined) delete store.__llvStructuredHostStartupFailed;
+    else store.__llvStructuredHostStartupFailed = previous;
+  }
+});

--- a/src/lib/runtime/startupStatus.ts
+++ b/src/lib/runtime/startupStatus.ts
@@ -13,3 +13,16 @@ export function markStructuredHostStartupReady(): void {
 export function didStructuredHostStartupFail(): boolean {
   return startupStore.__llvStructuredHostStartupFailed === true;
 }
+
+/** Truthful readiness axis for operator surfaces: "ready" only after startup
+    adoption succeeded, "failed" after it failed, "pending" before either, and
+    null when structured hosting is disabled. Production #367 reported ready
+    health while structured spawn admission was failing end to end. */
+export function structuredStartupAxis(
+  env: Readonly<Record<string, string | undefined>> = process.env,
+): "ready" | "failed" | "pending" | null {
+  if (env.LLV_STRUCTURED_HOSTS !== "1") return null;
+  const failed = startupStore.__llvStructuredHostStartupFailed;
+  if (failed === undefined) return "pending";
+  return failed ? "failed" : "ready";
+}

--- a/src/lib/runtime/structuredSpawn.integration.test.ts
+++ b/src/lib/runtime/structuredSpawn.integration.test.ts
@@ -12,14 +12,14 @@ import { AgentRegistry } from "@/lib/agent/registry";
 import { spawnResponseForReceipt } from "@/lib/agent/spawnResponse";
 import { RuntimeJournal } from "@/runtime-host/journal";
 
-import type { RuntimeHostClient } from "./client";
+import { RuntimeHostUnavailableError, type RuntimeHostClient } from "./client";
 import { CodexAppServerHost, type CodexAppServerHostOptions } from "./codexAppServerHost";
 import { StructuredHostAdoptionCleanupError, type DeliveryReceipt, type HostState, type QueueEntry, type RuntimeEvent } from "./engineHost";
 import { bindStructuredDeliveryQueue, hasStructuredDeliveryHost } from "./structuredDeliveryController";
 import { dispatchStructuredControl } from "./structuredControls";
 import { kickStructuredDeliveryQueue } from "./structuredDeliverySignal";
 import { enqueueStructuredMessage } from "./structuredMessageDelivery";
-import { INITIAL_MESSAGE_TIMEOUT_MS, reconcileStructuredSpawnReplay, recoverPendingStructuredSpawns, spawnStructuredConversation, structuredClaudePermissionMode, structuredClaudeSpawnPolicyBaseSettingsPath, waitForStructuredInitialMessage, type SpawnedStructuredHost } from "./structuredSpawn";
+import { INITIAL_MESSAGE_TIMEOUT_MS, reconcileStructuredSpawnReplay, recoverPendingStructuredSpawns, spawnStructuredConversation, structuredClaudePermissionMode, structuredClaudeSpawnPolicyBaseSettingsPath, waitForStructuredInitialMessage, withRuntimeAdmissionRetry, type SpawnedStructuredHost } from "./structuredSpawn";
 import { materializeStructuredTerminal } from "./structuredTerminal";
 
 type UnsequencedEvent = RuntimeEvent extends infer Event
@@ -3039,9 +3039,11 @@ test("a delivering kill terminalizes a stale structured wrapper owned by the liv
     claimOwner: null,
     pendingAction: null,
   });
+  /* The delivered kill receipt now converges the projection in the journal
+     transaction itself (#367): a dead host reads idle, never unknown. */
   expect(journal.snapshot().sessions.find((session) => session.conversationId === conversation.id)).toMatchObject({
     host: "dead",
-    turn: "unknown",
+    turn: "idle",
     activeTurnId: null,
   });
   expect(await client.effectBatch(["runtime.kill"], 0)).toEqual([]);
@@ -3468,4 +3470,264 @@ test("structured spawn fails loudly when Codex omits the transcript-path capabil
 
   expect(registry.snapshot().receipts[begun.receipt.launchId]?.state).toBe("failed");
   expect(journal.operationResult(begun.receipt.launchId)?.receipt).toMatchObject({ status: "failed", reason: expect.stringContaining("transcript path") });
+});
+
+test("issue 367: four simultaneous structured Claude launches admit past transient runtime socket timeouts", async () => {
+  const id = crypto.randomUUID();
+  const cwd = path.join(sandbox, `concurrent-admission-${id}`);
+  fs.mkdirSync(cwd, { recursive: true });
+  const registry = new AgentRegistry(path.join(cwd, "registry.json"), undefined, undefined, { sqliteMode: "off" });
+  const journal = new RuntimeJournal(path.join(cwd, "runtime.sqlite"), { structuredHosts: true });
+  const client = runtimeClient(journal);
+  /* Production: launches 6799487f/90d9d097/feee9a74/875ef8e1 all became
+     terminal retry-safe failures on their first "runtime host request timed
+     out". The admission command is idempotent by launch id, so a transport
+     timeout must be retried instead of minting a failed receipt. */
+  const timedOutOnce = new Set<string>();
+  const flakyClient = {
+    ...client,
+    command: async (command: Parameters<RuntimeHostClient["command"]>[0]) => {
+      if (command.kind === "spawn" && command.operationId && !timedOutOnce.has(command.operationId)) {
+        timedOutOnce.add(command.operationId);
+        throw new RuntimeHostUnavailableError("runtime host request timed out");
+      }
+      return client.command(command);
+    },
+  } as RuntimeHostClient;
+
+  const launchProfile = emptyLaunchProfile({ cwd, permissionMode: "bypassPermissions" });
+  const launches = Array.from({ length: 4 }, (_, index) => {
+    const begun = registry.beginSpawnRequest({
+      engine: "claude",
+      cwd,
+      transport: "structured",
+      accountId: `claude-account-${index}`,
+      launchProfile,
+    });
+    if (begun.kind !== "created") throw new Error("spawn receipt was unavailable");
+    const sessionId = crypto.randomUUID();
+    const artifactPath = path.join(cwd, `${sessionId}.jsonl`);
+    return { receipt: begun.receipt, host: new RoundTripHost("claude", artifactPath, sessionId), artifactPath };
+  });
+
+  const responses = await Promise.all(launches.map(({ receipt, host, artifactPath }) =>
+    spawnStructuredConversation({
+      engine: "claude",
+      receipt,
+      spec: { command: "claude", cwd, windowName: "fable", engine: "claude", transcript: artifactPath, launchProfile },
+      account: { engine: "claude", accountId: receipt.accountId ?? "default", kind: "legacy", home: cwd, transcriptRoot: cwd, env: { NODE_ENV: "test" } },
+      prompt: "",
+      registry,
+      client: flakyClient,
+    }, {
+      startHost: async () => host,
+      bindHost: async (targetRegistry, key, runningHost, claimOwner, claimEpoch) => {
+        const state = await runningHost.health();
+        targetRegistry.setStructuredHostClaimed(key, {
+          kind: "claude-broker",
+          endpoint: state.endpoint,
+          process: { pid: process.pid, startIdentity: "test-process" },
+          eventCursor: state.eventCursor,
+          protocolVersion: state.protocolVersion,
+          writerClaimEpoch: claimEpoch,
+          activeTurnRef: state.activeTurnRef,
+          pendingAttention: state.pendingAttention,
+          activeFlags: state.activeFlags,
+        }, "idle", claimOwner, claimEpoch);
+        return () => {};
+      },
+      publishHost: async () => async () => {},
+      processIdentity: () => ({ pid: process.pid, startIdentity: "test-process" }),
+    })));
+
+  expect(timedOutOnce.size).toBe(4);
+  for (const [index, response] of responses.entries()) {
+    expect(response).toMatchObject({ launched: true, state: "settled", initialMessage: "delivered" });
+    const receipt = registry.snapshot().receipts[launches[index]!.receipt.launchId];
+    expect(receipt?.state).toBe("completed");
+    const operation = journal.operationResult(launches[index]!.receipt.launchId);
+    expect(operation?.receipt.status).toBe("delivered");
+  }
+  journal.close();
+});
+
+test("issue 367: admission retry replays only transport failures", async () => {
+  const attempts: number[] = [];
+  let calls = 0;
+  await expect(withRuntimeAdmissionRetry(async () => {
+    calls += 1;
+    if (calls < 3) throw new RuntimeHostUnavailableError("runtime host request timed out");
+    return "admitted";
+  }, { sleep: async (ms) => { attempts.push(ms); } })).resolves.toBe("admitted");
+  expect(calls).toBe(3);
+  expect(attempts).toEqual([250, 500]);
+
+  await expect(withRuntimeAdmissionRetry(async () => {
+    throw new RuntimeHostUnavailableError("runtime host request timed out");
+  }, { sleep: async () => {} })).rejects.toThrow("runtime host request timed out");
+
+  let deterministicCalls = 0;
+  await expect(withRuntimeAdmissionRetry(async () => {
+    deterministicCalls += 1;
+    throw new RuntimeHostUnavailableError("idempotency key already belongs to another request", "conflict");
+  }, { sleep: async () => {} })).rejects.toThrow("idempotency key already belongs to another request");
+  expect(deterministicCalls).toBe(1);
+});
+
+test("issue 367: a launch failing before identity staging retires its registering placeholder", async () => {
+  const id = crypto.randomUUID();
+  const cwd = path.join(sandbox, `placeholder-retire-${id}`);
+  fs.mkdirSync(cwd, { recursive: true });
+  const registry = new AgentRegistry(path.join(cwd, "registry.json"), undefined, undefined, { sqliteMode: "off" });
+  const journal = new RuntimeJournal(path.join(cwd, "runtime.sqlite"), { structuredHosts: true });
+  const client = runtimeClient(journal);
+  const launchProfile = emptyLaunchProfile({ cwd });
+  const begun = registry.beginSpawnRequest({ engine: "claude", cwd, transport: "structured", launchProfile });
+  if (begun.kind !== "created") throw new Error("spawn receipt was unavailable");
+
+  await expect(spawnStructuredConversation({
+    engine: "claude",
+    receipt: begun.receipt,
+    spec: { command: "claude", cwd, windowName: "fable", engine: "claude", launchProfile },
+    account: { engine: "claude", accountId: "default", kind: "legacy", home: cwd, transcriptRoot: cwd, env: { NODE_ENV: "test" } },
+    prompt: "Implement",
+    registry,
+    client,
+  }, {
+    startHost: async () => { throw new Error("Claude stream hosting requires a claude.ai subscription login"); },
+    processIdentity: () => ({ pid: process.pid, startIdentity: "test-process" }),
+  })).rejects.toThrow("Claude stream hosting requires a claude.ai subscription login");
+
+  const session = journal.snapshot().sessions.find((candidate) => candidate.conversationId === begun.receipt.conversationId);
+  expect(session).toMatchObject({ host: "dead", turn: "idle", activeTurnId: null });
+  expect(journal.operationResult(begun.receipt.launchId)?.receipt.status).toBe("failed");
+  expect(registry.snapshot().receipts[begun.receipt.launchId]?.state).toBe("failed");
+  journal.close();
+});
+
+test("issue 367: startup recovery closes a queued runtime spawn whose durable receipt already failed", async () => {
+  const id = crypto.randomUUID();
+  const cwd = path.join(sandbox, `startup-registering-${id}`);
+  fs.mkdirSync(cwd, { recursive: true });
+  const registry = new AgentRegistry(path.join(cwd, "registry.json"), undefined, undefined, { sqliteMode: "off" });
+  const journal = new RuntimeJournal(path.join(cwd, "runtime.sqlite"), { structuredHosts: true });
+  const client = runtimeClient(journal);
+  const launchProfile = emptyLaunchProfile({ cwd });
+  const begun = registry.beginSpawnRequest({ engine: "claude", cwd, transport: "structured", launchProfile });
+  if (begun.kind !== "created") throw new Error("spawn receipt was unavailable");
+
+  /* Production shape: the admission command landed in the journal, the Viewer
+     then failed the durable receipt, and its terminal transition to the
+     runtime host timed out. The row sat registering/unknown through the
+     hostEpoch 43 restart. */
+  await client.command({
+    kind: "spawn",
+    operationId: begun.receipt.launchId,
+    idempotencyKey: begun.receipt.launchId,
+    conversationId: begun.receipt.conversationId,
+    engine: "claude",
+    cwd,
+    prompt: "Implement",
+  });
+  registry.failSpawn(begun.receipt.launchId, "runtime host request timed out");
+  expect(journal.snapshot().sessions[0]).toMatchObject({ host: "registering", turn: "unknown" });
+
+  await recoverPendingStructuredSpawns(registry, client);
+
+  expect(journal.operationResult(begun.receipt.launchId)?.receipt.status).toBe("failed");
+  expect(journal.snapshot().sessions[0]).toMatchObject({ host: "dead", turn: "idle", activeTurnId: null });
+
+  /* The pass is idempotent across repeated startups. */
+  await recoverPendingStructuredSpawns(registry, client);
+  expect(journal.snapshot().sessions[0]).toMatchObject({ host: "dead", turn: "idle" });
+  journal.close();
+});
+
+test("issue 367: a post-kill relaunch that exhausts admission never leaves a live queued placeholder", async () => {
+  const killedId = crypto.randomUUID();
+  const cwd = path.join(sandbox, `post-kill-relaunch-${killedId}`);
+  fs.mkdirSync(cwd, { recursive: true });
+  const killedPath = path.join(cwd, `${killedId}.jsonl`);
+  const registry = new AgentRegistry(path.join(cwd, "registry.json"), undefined, undefined, { sqliteMode: "off" });
+  const journal = new RuntimeJournal(path.join(cwd, "runtime.sqlite"), { structuredHosts: true });
+  const client = runtimeClient(journal);
+
+  /* Production 2026-07-18: completed structured Fable #156 was killed through
+     /api/tmux and its OS PID exited; the delivered kill must leave a dead/idle
+     projection behind. */
+  const killedConversation = registry.ensureConversation("claude", killedPath, "default");
+  await client.append({
+    scope: { type: "session", id: killedConversation.id },
+    kind: "session-status",
+    payload: {
+      conversationId: killedConversation.id,
+      sessionKey: { engine: "claude", sessionId: killedId },
+      hostKind: "claude-broker",
+      host: "hosted",
+      turn: "running",
+      activeTurnId: "turn-156",
+      provenance: "structured",
+      artifactPath: killedPath,
+      capabilities: { steer: false, structuredAttention: true },
+    },
+  });
+  await client.command({
+    kind: "kill",
+    operationId: `kill_${killedId}`,
+    idempotencyKey: `kill_${killedId}`,
+    conversationId: killedConversation.id,
+    sessionKey: { engine: "claude", sessionId: killedId },
+  });
+  await client.transitionOperation(`kill_${killedId}`, "delivering");
+  await client.transitionOperation(`kill_${killedId}`, "delivered");
+  expect(journal.snapshot().sessions.find((session) => session.conversationId === killedConversation.id))
+    .toMatchObject({ host: "dead", turn: "idle", activeTurnId: null });
+
+  /* The next pipeline launch (78a584be shape) hit "runtime host request timed
+     out" on every admission attempt. The durable receipt must converge to a
+     terminal retry-safe failure — /api/files kept reporting it as live
+     structured_spawn_queued with no PID, no session, and no transcript. */
+  const launchProfile = emptyLaunchProfile({ cwd, permissionMode: "bypassPermissions" });
+  const begun = registry.beginSpawnRequest({ engine: "claude", cwd, transport: "structured", launchProfile });
+  if (begun.kind !== "created") throw new Error("spawn receipt was unavailable");
+  let admissionAttempts = 0;
+  const deadClient = {
+    ...client,
+    command: async (command: Parameters<RuntimeHostClient["command"]>[0]) => {
+      if (command.kind === "kill") return client.command(command);
+      admissionAttempts += 1;
+      throw new RuntimeHostUnavailableError("runtime host request timed out");
+    },
+    transitionOperation: async (...args: Parameters<RuntimeHostClient["transitionOperation"]>) => {
+      if (args[1] === "failed") throw new RuntimeHostUnavailableError("runtime host request timed out");
+      return client.transitionOperation(...args);
+    },
+  } as RuntimeHostClient;
+
+  await expect(spawnStructuredConversation({
+    engine: "claude",
+    receipt: begun.receipt,
+    spec: { command: "claude", cwd, windowName: "fable", engine: "claude", launchProfile },
+    account: { engine: "claude", accountId: "default", kind: "legacy", home: cwd, transcriptRoot: cwd, env: { NODE_ENV: "test" } },
+    prompt: "Implement the stage",
+    registry,
+    client: deadClient,
+  }, {
+    startHost: async () => { throw new Error("admission never reached host start"); },
+    processIdentity: () => ({ pid: process.pid, startIdentity: "test-process" }),
+  })).rejects.toThrow("runtime host request timed out");
+
+  expect(admissionAttempts).toBe(3);
+  const failed = registry.snapshot().receipts[begun.receipt.launchId];
+  expect(failed).toMatchObject({ state: "failed", key: null, artifactPath: null });
+  expect(failed?.error).toContain("runtime host request timed out");
+  /* No placeholder session may survive for the failed launch: the admission
+     command never landed, so the runtime snapshot must not show the
+     conversation at all — and the replay reconciler reports the failure. */
+  expect(journal.snapshot().sessions.find((session) => session.conversationId === begun.receipt.conversationId))
+    .toBeUndefined();
+  const reconciled = await reconcileStructuredSpawnReplay(begun.receipt.launchId, registry, client);
+  expect(reconciled.initialMessage).toBe("failed");
+  expect(reconciled.state).toBe("failed");
+  journal.close();
 });

--- a/src/lib/runtime/structuredSpawn.ts
+++ b/src/lib/runtime/structuredSpawn.ts
@@ -15,7 +15,7 @@ import { hardenedRedact } from "@/lib/view/compactText";
 
 import { ClaudeStreamBrokerHost } from "./claudeStreamBrokerHost";
 import { CodexAppServerHost } from "./codexAppServerHost";
-import type { RuntimeHostClient } from "./client";
+import { isRuntimeHostTransportFailure, type RuntimeHostClient } from "./client";
 import { StructuredHostAdoptionCleanupError, type EngineHost, type HostState } from "./engineHost";
 import type { RuntimeOperationResult, RuntimeSession } from "./contracts";
 import { bindClaudeHostPersistence, bindCodexHostPersistence } from "./registry";
@@ -31,6 +31,31 @@ export type SpawnedStructuredHost = EngineHost & {
 
 export const INITIAL_MESSAGE_TIMEOUT_MS = 30_000;
 const INITIAL_MESSAGE_POLL_MS = 250;
+export const ADMISSION_RETRY_ATTEMPTS = 3;
+const ADMISSION_RETRY_BACKOFF_MS = 250;
+
+/** Runtime admission calls carry the durable launch id as their idempotency
+    key, so a replay lands on the original receipt. Production #367 saw
+    simultaneous launches turn transient socket timeouts into terminal failed
+    receipts; transport-level failures are retried before giving up. */
+export async function withRuntimeAdmissionRetry<T>(
+  request: () => Promise<T>,
+  options: { attempts?: number; sleep?: (ms: number) => Promise<void> } = {},
+): Promise<T> {
+  const attempts = options.attempts ?? ADMISSION_RETRY_ATTEMPTS;
+  const sleep = options.sleep ?? ((ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms)));
+  let lastError: unknown;
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    try {
+      return await request();
+    } catch (error) {
+      if (!isRuntimeHostTransportFailure(error)) throw error;
+      lastError = error;
+      if (attempt < attempts) await sleep(ADMISSION_RETRY_BACKOFF_MS * attempt);
+    }
+  }
+  throw lastError;
+}
 const INITIAL_MESSAGE_DELIVERED = new Set(["delivered", "turn-started", "steered"]);
 const INITIAL_MESSAGE_FAILED = new Set(["failed", "rejected", "uncertain", "interrupted"]);
 
@@ -349,9 +374,37 @@ export async function recoverPendingStructuredSpawns(
     afterEventSeq = next;
   }
 
+  let registeringConversationIds: Set<string> | null = null;
+  const registeringSessions = async (): Promise<Set<string>> => {
+    if (!registeringConversationIds) {
+      const runtime = await client.snapshot().catch(() => null);
+      registeringConversationIds = new Set((runtime?.sessions ?? [])
+        .filter((session) => session.host === "registering")
+        .map((session) => session.conversationId));
+    }
+    return registeringConversationIds;
+  };
+
   const snapshot = registry.snapshot();
   for (const receipt of Object.values(snapshot.receipts)) {
     const effect = spawnEffects.get(receipt.launchId);
+    if (receipt.state === "failed" && receipt.transport !== "tmux") {
+      /* The durable launch receipt failed, but its runtime spawn operation can
+         survive as queued when the terminal transition itself timed out. The
+         placeholder session then sits registering/unknown until someone closes
+         the operation; the journal retires the placeholder on that transition. */
+      if (!(await registeringSessions()).has(receipt.conversationId)) continue;
+      const operation = await client.operationStatus(receipt.launchId);
+      const status = operation?.receipt.status;
+      if (operation
+        && operation.receipt.conversationId === receipt.conversationId
+        && (status === "pending" || status === "queued" || status === "delivering")) {
+        await client.transitionOperation(receipt.launchId, "failed", {
+          reason: (receipt.error ?? "structured spawn failed before runtime acknowledgement").slice(0, 240),
+        });
+      }
+      continue;
+    }
     if (receipt.state === "starting" && !receipt.key && receipt.transport !== "tmux") {
       const operation = await client.operationStatus(receipt.launchId);
       if (receipt.transport !== "structured" && !effect && !operation) continue;
@@ -700,7 +753,7 @@ export async function spawnStructuredConversation(
     const content = input.prompt.trim() || imageRefs.length
       ? structuredContent(input.prompt, imageRefs)
       : null;
-    await input.client.command({
+    await withRuntimeAdmissionRetry(() => input.client.command({
       kind: "spawn",
       operationId,
       idempotencyKey: operationId,
@@ -713,7 +766,7 @@ export async function spawnStructuredConversation(
       accountId: input.account.accountId,
       parentConversationId: input.receipt.parentConversationId,
       ...(input.receipt.purpose === "resume-successor" ? { sessionId: structuredResumeSessionId(input) } : {}),
-    });
+    }));
     const capability = input.registry.rotateSpawnCapabilityForReceipt(input.receipt.launchId);
     const resumeEntry = resumeKey ? input.registry.snapshot().entries[sessionKeyId(resumeKey)] : null;
     if (resumeEntry?.structuredHost) {
@@ -773,7 +826,7 @@ export async function spawnStructuredConversation(
         state: "path-pending",
       };
     }
-    await input.client.transitionOperation(operationId, "delivered");
+    await withRuntimeAdmissionRetry(() => input.client.transitionOperation(operationId, "delivered"));
     const settled = input.registry.finalizeStructuredSpawn(input.receipt.launchId);
     if (settled.kind === "conflict") throw new Error(`structured spawn registry conflict: ${settled.code}`);
     return {

--- a/src/runtime-host/journal.test.ts
+++ b/src/runtime-host/journal.test.ts
@@ -1828,3 +1828,189 @@ test("runtime host fencing reclaims a stale process identity", () => {
   fence.release();
   expect(fs.existsSync(filename)).toBe(false);
 });
+
+test("issue 367: a failed structured spawn retires its registering placeholder with the terminal receipt", () => {
+  const dir = sandbox("spawn-failed-placeholder");
+  const journal = new RuntimeJournal(path.join(dir, "events.sqlite"), { maxEvents: 100, now: () => 100, structuredHosts: true });
+  journal.executeOperation({
+    kind: "spawn",
+    conversationId: "conversation_fable_one",
+    operationId: "launch-6799487f",
+    idempotencyKey: "launch-6799487f",
+    engine: "claude",
+    cwd: "/repo",
+    prompt: "Implement the follow-up",
+    accountId: "botfatherdev-2",
+  });
+  expect(journal.snapshot().sessions[0]).toMatchObject({
+    conversationId: "conversation_fable_one",
+    hostKind: "claude-broker",
+    host: "registering",
+    turn: "unknown",
+  });
+
+  const failed = journal.transitionOperation("launch-6799487f", "failed", { reason: "runtime host request timed out" });
+  expect(failed.receipt.status).toBe("failed");
+  const snapshot = journal.snapshot();
+  expect(snapshot.sessions).toHaveLength(1);
+  expect(snapshot.sessions[0]).toMatchObject({
+    conversationId: "conversation_fable_one",
+    host: "dead",
+    turn: "idle",
+    activeTurnId: null,
+    attentionIds: [],
+  });
+  expect(snapshot.runtime.health).toBe("ready");
+
+  const replayed = journal.transitionOperation("launch-6799487f", "failed", { reason: "runtime host request timed out" });
+  expect(replayed.replayed).toBe(true);
+  journal.close();
+});
+
+test("issue 367: a delivered spawn keeps its placeholder for the launcher's hosted projection", () => {
+  const dir = sandbox("spawn-delivered-placeholder");
+  const journal = new RuntimeJournal(path.join(dir, "events.sqlite"), { maxEvents: 100, now: () => 100, structuredHosts: true });
+  journal.executeOperation({
+    kind: "spawn",
+    conversationId: "conversation_fable_live",
+    operationId: "launch-live",
+    idempotencyKey: "launch-live",
+    engine: "claude",
+    cwd: "/repo",
+    prompt: "Implement",
+  });
+  journal.transitionOperation("launch-live", "delivered");
+  expect(journal.snapshot().sessions[0]).toMatchObject({
+    conversationId: "conversation_fable_live",
+    host: "registering",
+  });
+  journal.close();
+});
+
+test("issue 367: a new host epoch retires registering placeholders abandoned by prior-epoch launches", () => {
+  const dir = sandbox("epoch-registering-sweep");
+  const filename = path.join(dir, "events.sqlite");
+  const journal = new RuntimeJournal(filename, { maxEvents: 100, now: () => 100, structuredHosts: true });
+  for (const conversation of ["conversation_stale_a", "conversation_stale_b"]) {
+    journal.executeOperation({
+      kind: "spawn",
+      conversationId: conversation,
+      operationId: `launch-${conversation}`,
+      idempotencyKey: `launch-${conversation}`,
+      engine: "claude",
+      cwd: "/repo",
+      prompt: "Implement",
+    });
+  }
+  journal.append({
+    scope: runtimeScope("session", "conversation_hosted"),
+    kind: "session-status",
+    payload: {
+      conversationId: "conversation_hosted",
+      sessionKey: { engine: "claude", sessionId: "session-hosted" },
+      hostKind: "claude-broker",
+      host: "hosted",
+      turn: "running",
+      activeTurnId: "turn-live",
+      provenance: "structured",
+      capabilities: { steer: false, structuredAttention: true },
+    },
+  });
+  journal.close();
+
+  const restarted = new RuntimeJournal(filename, { maxEvents: 100, now: () => 200, structuredHosts: true });
+  const epoch = restarted.claimHostEpoch();
+  expect(epoch).toBe(2);
+  const sessions = new Map(restarted.snapshot().sessions.map((session) => [session.conversationId, session]));
+  expect(sessions.get("conversation_stale_a")).toMatchObject({ host: "dead", turn: "idle", activeTurnId: null });
+  expect(sessions.get("conversation_stale_b")).toMatchObject({ host: "dead", turn: "idle", activeTurnId: null });
+  expect(sessions.get("conversation_hosted")).toMatchObject({ host: "hosted", turn: "running", activeTurnId: "turn-live" });
+
+  const again = restarted.claimHostEpoch();
+  expect(again).toBe(3);
+  expect(restarted.snapshot().sessions.filter((session) => session.host === "registering")).toEqual([]);
+  restarted.close();
+});
+
+test("issue 367: a delivered structured kill converges host and turn projection with its receipt", () => {
+  const dir = sandbox("kill-terminal-projection");
+  const journal = new RuntimeJournal(path.join(dir, "events.sqlite"), { maxEvents: 100, now: () => 100, structuredHosts: true });
+  journal.append({
+    scope: runtimeScope("session", "conversation_limit"),
+    kind: "session-status",
+    payload: {
+      conversationId: "conversation_limit",
+      sessionKey: { engine: "claude", sessionId: "session-limit" },
+      hostKind: "claude-broker",
+      host: "hosted",
+      turn: "running",
+      activeTurnId: "turn-spend-limit",
+      attentionIds: ["attention-open"],
+      provenance: "structured",
+      artifactPath: "/sessions/limit.jsonl",
+      capabilities: { steer: false, structuredAttention: true },
+    },
+  });
+
+  const queued = journal.executeOperation({
+    kind: "kill",
+    conversationId: "conversation_limit",
+    operationId: "op-kill-limit",
+    idempotencyKey: "op-kill-limit",
+    sessionKey: { engine: "claude", sessionId: "session-limit" },
+  });
+  expect(queued.receipt.status).toBe("queued");
+  expect(journal.snapshot().sessions[0]).toMatchObject({ host: "hosted", turn: "running" });
+
+  journal.transitionOperation("op-kill-limit", "delivering");
+  expect(journal.snapshot().sessions[0]).toMatchObject({ host: "hosted", turn: "running" });
+
+  const delivered = journal.transitionOperation("op-kill-limit", "delivered");
+  expect(delivered.receipt.status).toBe("delivered");
+  const session = journal.snapshot().sessions[0];
+  expect(session).toMatchObject({
+    conversationId: "conversation_limit",
+    host: "dead",
+    turn: "idle",
+    activeTurnId: null,
+    attentionIds: [],
+  });
+
+  const replayed = journal.transitionOperation("op-kill-limit", "delivered");
+  expect(replayed.replayed).toBe(true);
+  expect(journal.snapshot().sessions[0]).toMatchObject({ host: "dead", turn: "idle" });
+  journal.close();
+});
+
+test("issue 367: a failed structured kill leaves the live projection untouched", () => {
+  const dir = sandbox("kill-failed-projection");
+  const journal = new RuntimeJournal(path.join(dir, "events.sqlite"), { maxEvents: 100, now: () => 100, structuredHosts: true });
+  journal.append({
+    scope: runtimeScope("session", "conversation_alive"),
+    kind: "session-status",
+    payload: {
+      conversationId: "conversation_alive",
+      sessionKey: { engine: "claude", sessionId: "session-alive" },
+      hostKind: "claude-broker",
+      host: "hosted",
+      turn: "running",
+      activeTurnId: "turn-live",
+      provenance: "structured",
+      capabilities: { steer: false, structuredAttention: true },
+    },
+  });
+  journal.executeOperation({
+    kind: "kill",
+    conversationId: "conversation_alive",
+    operationId: "op-kill-alive",
+    idempotencyKey: "op-kill-alive",
+    sessionKey: { engine: "claude", sessionId: "session-alive" },
+  });
+  journal.transitionOperation("op-kill-alive", "failed", { reason: "structured host termination is unavailable" });
+  expect(journal.snapshot().sessions[0]).toMatchObject({
+    host: "hosted",
+    turn: "running",
+    activeTurnId: "turn-live",
+  });
+  journal.close();
+});

--- a/src/runtime-host/journal.ts
+++ b/src/runtime-host/journal.ts
@@ -843,7 +843,35 @@ export class RuntimeJournal {
       const epoch = Number(this.meta("host_epoch")) + 1;
       this.metaSet("host_epoch", String(epoch));
       this.metaSet("health", "ready");
+      /* A fresh spawn placeholder (identity still the conversation id, no
+         transcript ever published) cannot outlive the host epoch that admitted
+         it: materialization always re-projects hosted state from the launcher.
+         Rows still registering at a new epoch are orphans of interrupted or
+         failed launches — production #367 kept them registering/unknown across
+         restarts while health claimed ready. Resume admissions keep their
+         prior identity and settle through Viewer startup recovery. */
+      for (const session of this.entityValues<RuntimeSession>("session")) {
+        if (session.host !== "registering") continue;
+        if (session.artifactPath !== null || session.sessionKey.sessionId !== session.conversationId) continue;
+        this.appendInTransaction(normalizeRuntimeEventInput({
+          scope: { type: "session", id: session.conversationId },
+          kind: "session-status",
+          producer: {
+            kind: "runtime-host",
+            hostEpoch: epoch,
+            eventKey: `host-epoch:${epoch}:registering-reconciled:${session.conversationId}`,
+          },
+          payload: {
+            conversationId: session.conversationId,
+            host: "dead",
+            turn: "idle",
+            activeTurnId: null,
+            attentionIds: [],
+          },
+        }));
+      }
       this.db.exec("COMMIT");
+      this.notifyWaiters();
       return epoch;
     } catch (error) {
       try { this.db.exec("ROLLBACK"); } catch { /* transaction already closed */ }
@@ -1257,6 +1285,63 @@ export class RuntimeJournal {
 
   private appendCompletionConsequences(command: RuntimeOperationCommand, receipt: RuntimeOperationReceipt, operationId: string): void {
     const producer = { kind: "runtime-effect", hostEpoch: Number(this.meta("host_epoch")) };
+    if (command.kind === "spawn"
+      && !command.sessionId
+      && (receipt.status === "failed" || receipt.status === "rejected" || receipt.status === "uncertain")) {
+      /* A fresh spawn placeholder session only ever leaves "registering"
+         through the launcher's own hosted projection. When the launch fails
+         first, the terminal receipt is the durable truth and must retire the
+         placeholder in the same transaction — production #367 left failed
+         launches parked as registering/unknown across runtime-host restarts.
+         Resume admissions (sessionId present) keep their prior writer's
+         projection and settle through the Viewer recovery ladder instead. */
+      const session = this.entity<RuntimeSession>("session", command.conversationId);
+      if (session && session.host === "registering") {
+        this.appendInTransaction(normalizeRuntimeEventInput({
+          scope: { type: "session", id: command.conversationId },
+          kind: "session-status",
+          operationId,
+          producer: { ...producer, eventKey: `operation:${operationId}:spawn-${receipt.status}-session-dead` },
+          payload: {
+            conversationId: command.conversationId,
+            host: "dead",
+            turn: "idle",
+            activeTurnId: null,
+            attentionIds: [],
+          },
+        }));
+      }
+      return;
+    }
+    if (command.kind === "kill" && receipt.status === "delivered") {
+      /* The delivered kill receipt asserts the OS processes are gone. Viewer
+         projections ride best-effort publish chains, so the journal converges
+         host/turn itself — production #367 kept killed conversations at
+         hosted/running after their child PIDs disappeared. A kill aimed at a
+         predecessor generation must not touch a live successor's projection,
+         so the session must still belong to the killed generation. */
+      const session = this.entity<RuntimeSession>("session", command.conversationId);
+      const killedGeneration = session
+        && session.sessionKey.engine === command.sessionKey.engine
+        && session.sessionKey.sessionId === command.sessionKey.sessionId;
+      if (session && killedGeneration
+        && (session.host !== "dead" || session.turn !== "idle" || session.activeTurnId !== null)) {
+        this.appendInTransaction(normalizeRuntimeEventInput({
+          scope: { type: "session", id: command.conversationId },
+          kind: "session-status",
+          operationId,
+          producer: { ...producer, eventKey: `operation:${operationId}:kill-delivered-session-dead` },
+          payload: {
+            conversationId: command.conversationId,
+            host: "dead",
+            turn: "idle",
+            activeTurnId: null,
+            attentionIds: [],
+          },
+        }));
+      }
+      return;
+    }
     if (command.kind === "answer" && receipt.status === "answered") {
       this.appendInTransaction(normalizeRuntimeEventInput({
         scope: { type: "session", id: command.conversationId },


### PR DESCRIPTION
## Summary

- Makes Claude CLI auth and version probes asynchronous so concurrent structured launches keep the Viewer event loop responsive.
- Retries transport-level runtime admission failures with a stable launch id and journal replay safety.
- Retires failed fresh placeholders transactionally and reconciles orphaned placeholders on runtime-host restart.
- Exposes truthful structured startup readiness.
- Converges successful structured kills to durable dead/idle session state with successor-generation protection.

## Verification

- Exact reviewed HEAD: `3c62ad39789a74bc3f446094027094be1e94b3a7`
- Fresh Fable verdict: `APPROVE`, no findings
- 320 focused and neighboring runtime tests: pass
- `tsc --noEmit`: pass
- ESLint on all changed source files: pass
- Reviewer worktree remained byte-identical

## Production evidence

The current production build reproduced path-pending and delivery-uncertain launch placeholders under concurrent structured work. This change covers that failure shape directly and preserves the structured-only architecture.

Closes #367