### PR TITLE
#156: contain mobile pipelines and compact task cards

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "darwin"
   ],
   "scripts": {
-    "dev": "next dev --webpack --hostname 127.0.0.1",
+    "dev": "NODE_ENV=development next dev --webpack --hostname 127.0.0.1",
     "build": "next build --webpack",
     "demo:capture": "bun scripts/demo-capture.ts",
     "demo:motion": "bun scripts/demo-motion.ts",

--- a/src/components/ProjectDashboard.tsx
+++ b/src/components/ProjectDashboard.tsx
@@ -23,8 +23,8 @@ import { ConversationList } from "./ConversationList";
 import { clearDraftStorage, draftCwd, draftParentConversationId, draftSrc, replaceUnverifiedDraftCwd, requireDraftCwdConfirmation, seedDraftCwd, setDraftCwd, setDraftSrc, setDraftText } from "./DraftAgentPane";
 import { planBoardConvergence, planClose } from "./projectBoardMutations";
 import { directReviewFlows, isDirectReviewFlow, splitDirectReviewGroups } from "./flows/directReviewGroups";
-import { claimedReviewerDescendantPaths, foldClaimedReviewers, isActiveFlow } from "./flows/flowModel";
-import { compactPipelineArtifactPaths, compactPipelineLayoutFlows, createDraftPipeline, excludeCompactPipelineArtifacts, pipelinesForProject, replaceCompactPipelineEphemeral, type PipelineTemplate } from "./pipelines/pipelineModel";
+import { claimedReviewerDescendantPaths, foldClaimedReviewers, isActiveFlow, resolveFlowMemberPaths } from "./flows/flowModel";
+import { compactPipelineArtifactPaths, compactPipelineLayoutFlows, createDraftPipeline, excludeCompactPipelineArtifacts, pipelinesForProject, replaceCompactPipelineEphemeral, resolvePipelineMemberPaths, type PipelineTemplate } from "./pipelines/pipelineModel";
 import { PipelineTemplatePicker } from "./pipelines/PipelineTemplatePicker";
 import { buildSchemeLayout } from "./scheme/layout";
 import { collapsibleWorkerFiles, groupWorkerStacks, pipelineOriginOf, pipelineStagePipelineIds, protectedReviewerNodes } from "./scheme/workerCollapse";
@@ -286,8 +286,8 @@ function HeaderMenuItem({ icon, label, onSelect, disabled = false }: { icon: Rea
 
 export function ProjectDashboard({
   files,
-  flows,
-  pipelines,
+  flows: rawFlows,
+  pipelines: rawPipelines,
   pipelinesError,
   workflows,
   tasks,
@@ -312,6 +312,15 @@ export function ProjectDashboard({
 }: Props) {
   const { t } = useLocale();
   const isMobile = useIsMobile();
+  /* Durable flow/pipeline records freeze member transcript paths at launch; an
+     account migration rotates a conversation onto a new path and every
+     projection that string-matches the frozen one (halos, decks, claiming,
+     stacks, strips, counts) drops the live generation — it resurfaces as a
+     detached standalone card (#325/#353). Canonicalize member paths to current
+     generations ONCE at this data boundary so every consumer below agrees.
+     PATCH-backed actions key on flow/pipeline ids and are unaffected. */
+  const flows = useMemo(() => resolveFlowMemberPaths(rawFlows, files), [rawFlows, files]);
+  const pipelines = useMemo(() => resolvePipelineMemberPaths(rawPipelines, files), [rawPipelines, files]);
   const highlightTimer = useRef<number | null>(null);
   const pendingFocusRef = useRef<string | null>(null);
   /* The board arrangement (which windows, hidden/expanded, view mode, task

--- a/src/components/flows/flowModel.test.ts
+++ b/src/components/flows/flowModel.test.ts
@@ -7,9 +7,11 @@ import { protectedReviewerNodes } from "@/components/scheme/workerCollapse";
 
 import {
   claimedReviewerDescendantPaths,
+  flowByImplementer,
   flowPresentation,
   foldClaimedReviewers,
   isActiveFlow,
+  resolveFlowMemberPaths,
   reviewerBindingTargetsForRound,
   reviewerFileForRound,
   reviewerFilesForRound,
@@ -73,6 +75,39 @@ function flow(overrides: Partial<Flow> & { implementerPath: string; reviewerPath
     ...overrides,
   };
 }
+
+describe("resolveFlowMemberPaths (durable members follow path rotation — #325/#353)", () => {
+  test("an implementer whose conversation migrated anchors its flow on the current generation", () => {
+    const files = [
+      entry({ path: "/impl-old", conversationId: "conversation-impl", migratedTo: "/impl-new" }),
+      entry({ path: "/impl-new", conversationId: "conversation-impl", predecessorPath: "/impl-old" }),
+    ];
+    const stale = flow({ implementerPath: "/impl-old", reviewerPath: "/reviewer", implementerConversationId: "conversation-impl" });
+    const resolved = resolveFlowMemberPaths([stale], files);
+    expect(resolved[0]!.implementerPath).toBe("/impl-new");
+    /* The deck keys off the implementer path — the successor node hosts it. */
+    expect(flowByImplementer(resolved).has("/impl-new")).toBe(true);
+  });
+
+  test("a rotated reviewer round points its raw path at the current generation", () => {
+    const files = [
+      entry({ path: "/rev-old", conversationId: "conversation-rev", migratedTo: "/rev-new" }),
+      entry({ path: "/rev-new", conversationId: "conversation-rev", predecessorPath: "/rev-old" }),
+    ];
+    const stale = flow({ implementerPath: "/impl", reviewerPath: "/rev-old" });
+    stale.rounds[0]!.reviewerConversationId = "conversation-rev";
+    const resolved = resolveFlowMemberPaths([stale], files);
+    expect(resolved[0]!.rounds[0]!.reviewerPath).toBe("/rev-new");
+  });
+
+  test("stable flows keep their identity", () => {
+    const stable = flow({ implementerPath: "/impl", reviewerPath: "/rev" });
+    const input = [stable];
+    const resolved = resolveFlowMemberPaths(input, [entry({ path: "/impl" }), entry({ path: "/rev" })]);
+    expect(resolved).toBe(input);
+    expect(resolved[0]).toBe(stable);
+  });
+});
 
 describe("reviewer folding", () => {
   test("resolves a resumed reviewer through its stable durable edge", () => {

--- a/src/components/flows/flowModel.ts
+++ b/src/components/flows/flowModel.ts
@@ -3,7 +3,7 @@ import { useMemo, useSyncExternalStore } from "react";
 import { getLocale, type Locale, type MessageKey, type TFunction, translate } from "@/lib/i18n";
 import type { Flow, FlowAction, FlowRoleKey, FlowState, ReviewVerdict, RoleConfig, Round } from "@/lib/flows/types";
 import type { FileEntry } from "@/lib/types";
-import { currentConversationFile, withoutArchivedPredecessors } from "@/lib/accounts/identity";
+import { currentConversationFile, currentMemberPath, withoutArchivedPredecessors } from "@/lib/accounts/identity";
 
 import { isConversation } from "@/components/projectModel";
 import { formatRateLimitTime } from "@/components/rateLimit";
@@ -57,6 +57,35 @@ export function useEffectiveFlows(flows: Flow[]): Flow[] {
         : flow,
     );
   }, [flows, closed]);
+}
+
+/**
+ * Canonicalizes a flow's member paths — the implementer anchor and each round's
+ * raw reviewer path — to the transcripts currently hosting those conversations
+ * (issues #325/#353). The deck, halo, folding, links and worker-stack grammars
+ * all key off these raw paths; after an account migration rotates a member onto
+ * a new transcript they stop matching, the deck never places, and reviewers
+ * resurface as detached standalone cards. Identity-stable: untouched flows (the
+ * common case) return the same references.
+ */
+export function resolveFlowMemberPaths(flows: Flow[], files: readonly FileEntry[]): Flow[] {
+  let changedAny = false;
+  const out = flows.map((flow) => {
+    const implementerPath = currentMemberPath(flow.implementerPath, flow.implementerConversationId, files) ?? flow.implementerPath;
+    let roundsChanged = false;
+    const rounds = flow.rounds.map((round) => {
+      /* Only rewrite a recorded path — a round whose reviewer hasn't attached
+         yet keeps its null (the "once known" contract). */
+      const reviewerPath = round.reviewerPath ? currentMemberPath(round.reviewerPath, round.reviewerConversationId, files) : round.reviewerPath;
+      if (reviewerPath === round.reviewerPath) return round;
+      roundsChanged = true;
+      return { ...round, reviewerPath };
+    });
+    if (implementerPath === flow.implementerPath && !roundsChanged) return flow;
+    changedAny = true;
+    return { ...flow, implementerPath, ...(roundsChanged ? { rounds } : {}) };
+  });
+  return changedAny ? out : flows;
 }
 
 /** Flows that still occupy their implementer's node on the scheme. */

--- a/src/components/mobile/MobileFocusView.tsx
+++ b/src/components/mobile/MobileFocusView.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { ListTodo, Map as MapIcon } from "lucide-react";
+import { ChevronDown, ChevronUp, ListTodo, Map as MapIcon } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { Loader2, X } from "@/components/icons";
@@ -24,7 +24,7 @@ import { paneState, type PaneState } from "@/components/paneState";
 import type { BranchGroup } from "@/components/projectModel";
 import { activityDot, cleanTitle, engineBadge } from "@/components/utils";
 
-import { STAGE_GLYPH, STAGE_TONES, compactPipelineLayoutFlows, compactStageOpenTarget, latestAttempt, pipelineLinkedTasks, renderableFlowIds, stageChipLabel, stageChipState, stageHasEvidence, stageHasNavigableHistory } from "@/components/pipelines/pipelineModel";
+import { PIPELINE_ATTENTION_STATES, PIPELINE_BUSY_STATES, STAGE_GLYPH, STAGE_TONES, compactPipelineLayoutFlows, compactStageOpenTarget, latestAttempt, pipelineLinkedTasks, pipelineStateLabel, renderableFlowIds, stageChipLabel, stageChipState, stageHasEvidence, stageHasNavigableHistory } from "@/components/pipelines/pipelineModel";
 import { PipelineStrip } from "@/components/pipelines/PipelineStrip";
 import { VerdictPopover } from "@/components/pipelines/VerdictPopover";
 import { deckKey } from "@/components/scheme/agentLinks";
@@ -464,9 +464,9 @@ export function MobileFocusView({ project, groups, manual, files, flows, reviewG
       {/* When a conversation IS focused, docked pipelines keep a compact
           plan/control bar below the pane so their surface never disappears. */}
       {(activeNode || activeDeck || activeDraft) && dockedPipelines.length ? (
-        <div className="max-h-[42vh] shrink-0 divide-y divide-border overflow-y-auto border-t border-border bg-card">
+        <div className="max-h-[34vh] shrink-0 divide-y divide-border overflow-y-auto border-t border-border bg-card">
           {dockedPipelines.map((pipeline) => (
-            <MobilePipelineDock key={pipeline.id} pipeline={pipeline} flows={flows} files={files} renderablePaths={renderablePaths} renderableFlows={renderableFlows} linkedTasks={linkedTasksByPipeline.get(pipeline.id) ?? []} onOpenPath={openStagePath} onOpenFlow={openPipelineFlow} onOpenTask={openPipelineTask} />
+            <MobilePipelineDock key={pipeline.id} pipeline={pipeline} flows={flows} files={files} renderablePaths={renderablePaths} renderableFlows={renderableFlows} linkedTasks={linkedTasksByPipeline.get(pipeline.id) ?? []} defaultExpanded={false} onOpenPath={openStagePath} onOpenFlow={openPipelineFlow} onOpenTask={openPipelineTask} />
           ))}
         </div>
       ) : null}
@@ -531,9 +531,9 @@ export function MobileFocusView({ project, groups, manual, files, flows, reviewG
               only full-plan surface for every active pipeline, memberful ones
               included (issue #156). */}
           {dockedPipelines.length ? (
-            <div className="max-h-[38vh] shrink-0 divide-y divide-border overflow-y-auto border-t border-border bg-card">
+            <div className="max-h-[30vh] shrink-0 divide-y divide-border overflow-y-auto border-t border-border bg-card">
               {dockedPipelines.map((pipeline) => (
-                <MobilePipelineDock key={pipeline.id} pipeline={pipeline} flows={flows} files={files} renderablePaths={renderablePaths} renderableFlows={renderableFlows} linkedTasks={linkedTasksByPipeline.get(pipeline.id) ?? []} onOpenPath={openStagePath} onOpenFlow={openPipelineFlow} onOpenTask={openPipelineTask} />
+                <MobilePipelineDock key={pipeline.id} pipeline={pipeline} flows={flows} files={files} renderablePaths={renderablePaths} renderableFlows={renderableFlows} linkedTasks={linkedTasksByPipeline.get(pipeline.id) ?? []} defaultExpanded={false} onOpenPath={openStagePath} onOpenFlow={openPipelineFlow} onOpenTask={openPipelineTask} />
               ))}
             </div>
           ) : null}
@@ -682,6 +682,10 @@ export function MobilePipelineDock({
   renderablePaths,
   renderableFlows,
   linkedTasks = [],
+  /** With a conversation focused, docks mount collapsed to one 44px disclosure
+      row so the transcript stays the dominant surface (issue #156). The
+      empty-state branch — where the dock IS the surface — mounts expanded. */
+  defaultExpanded = true,
   onOpenPath,
   onOpenFlow,
   onOpenTask,
@@ -692,25 +696,69 @@ export function MobilePipelineDock({
   renderablePaths?: ReadonlySet<string>;
   renderableFlows?: ReadonlySet<string>;
   linkedTasks?: BoardTask[];
+  defaultExpanded?: boolean;
   onOpenPath?: (path: string) => void;
   onOpenFlow?: (flowId: string) => void;
   onOpenTask?: (task: BoardTask) => void;
 }) {
+  const { t } = useLocale();
+  const [expanded, setExpanded] = useState(defaultExpanded);
   const draft = pipeline.state === "draft";
+  const attention = PIPELINE_ATTENTION_STATES.has(pipeline.state);
+  const busyState = PIPELINE_BUSY_STATES.has(pipeline.state);
+  /* Same 1-based "stage k/n" read as the strip header, so the collapsed row and
+     the expanded rail can never disagree about position. */
+  const total = pipeline.stages.length;
+  const cursorIndex = pipeline.cursor ? pipeline.stages.findIndex((stage) => stage.id === pipeline.cursor!.stageId) : -1;
+  const position = cursorIndex >= 0 ? cursorIndex + 1 : total;
+  const statusBadge = busyState
+    ? "bg-accent-soft text-accent"
+    : attention || draft
+      ? "bg-warning-soft text-warning"
+      : pipeline.state === "completed"
+        ? "bg-success-soft text-success"
+        : "bg-sunken text-muted";
   return (
     <div className="px-2 py-1.5 [&_button]:!h-11 [&_button]:!min-h-11" data-testid="mobile-pipeline-dock" data-pipeline-draft={draft || undefined}>
-      <PipelineStrip
-        pipeline={pipeline}
-        flows={flows}
-        files={files}
-        renderablePaths={renderablePaths}
-        renderableFlows={renderableFlows}
-        mobile
-        linkedTasks={linkedTasks}
-        onOpenPath={onOpenPath}
-        onOpenFlow={onOpenFlow}
-        onOpenTask={onOpenTask}
-      />
+      <button
+        type="button"
+        data-testid="mobile-pipeline-dock-summary"
+        aria-expanded={expanded}
+        aria-label={t(expanded ? "pipelineMobile.collapseDock" : "pipelineMobile.expandDock", { task: pipeline.task })}
+        onClick={() => setExpanded((prev) => !prev)}
+        className="flex min-h-11 w-full items-center gap-2 rounded-control px-1 text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40"
+      >
+        <span
+          className={`h-2.5 w-2.5 shrink-0 rounded-full ${
+            busyState ? "animate-pulse bg-accent" : attention || draft ? "bg-warning" : pipeline.state === "completed" ? "bg-success" : "bg-strong"
+          }`}
+          aria-hidden
+        />
+        <span className="min-w-0 flex-1 truncate text-ui font-semibold text-primary">{pipeline.task}</span>
+        <span className={`shrink-0 rounded-full px-1.5 py-0.5 text-caption font-semibold ${statusBadge}`}>
+          {pipelineStateLabel(t, pipeline.state)}
+        </span>
+        {!draft && total ? (
+          <span className="shrink-0 text-label font-semibold tabular-nums text-muted">
+            {t("pipelineStrip.stageOf", { k: position, n: total })}
+          </span>
+        ) : null}
+        {expanded ? <ChevronUp className="h-4 w-4 shrink-0 text-muted" aria-hidden /> : <ChevronDown className="h-4 w-4 shrink-0 text-muted" aria-hidden />}
+      </button>
+      {expanded ? (
+        <PipelineStrip
+          pipeline={pipeline}
+          flows={flows}
+          files={files}
+          renderablePaths={renderablePaths}
+          renderableFlows={renderableFlows}
+          mobile
+          linkedTasks={linkedTasks}
+          onOpenPath={onOpenPath}
+          onOpenFlow={onOpenFlow}
+          onOpenTask={onOpenTask}
+        />
+      ) : null}
     </div>
   );
 }

--- a/src/components/mobile/MobilePipelineDock.render.test.tsx
+++ b/src/components/mobile/MobilePipelineDock.render.test.tsx
@@ -33,7 +33,10 @@ test("mobile dock surfaces the full plan + 44px controls for a memberless pipeli
   expect(html).toContain("aria-label=\"Close pipeline\"");
   const controlRows = html.match(/h-11/g) ?? [];
   expect(controlRows.length).toBeGreaterThanOrEqual(2);
-  expect(html).toContain("Configure stage plan, state pending");
+  /* Evidence-less stages compact to glyph chips on mobile (#156) but a
+     configurable stage keeps its tap → configuration disclosure. */
+  expect(html).toContain('data-stage-compact="true"');
+  expect(html).toContain('aria-label="plan, pending"');
   expect(html).toContain('data-pipeline-stage="plan"');
 });
 
@@ -51,6 +54,34 @@ test("pipelinesToDock docks every active pipeline group — memberful ones too (
 
   /* Both pipelines dock, in group order; the flow group contributes nothing. */
   expect(docked.map((p) => p.id)).toEqual(["p1", "p2"]);
+});
+
+test("a collapsed dock is one warning-aware summary row; expanded reveals the full rail (#156)", () => {
+  const collapsed = renderToStaticMarkup(<MobilePipelineDock pipeline={provisioning} defaultExpanded={false} />);
+  /* Only the 44px disclosure row: title, status badge, stage counter, chevron. */
+  expect(collapsed).toContain('data-testid="mobile-pipeline-dock-summary"');
+  expect(collapsed).toContain('aria-label="Expand pipeline Refactor the board"');
+  expect(collapsed).toContain('aria-expanded="false"');
+  expect(collapsed).toContain("Refactor the board");
+  expect(collapsed).toContain("stage 3/3");
+  expect(collapsed).not.toContain('aria-label="Pipeline stages"');
+  expect(collapsed).not.toContain("Pause pipeline");
+
+  /* Expanded keeps the disclosure row and mounts the full mobile rail below. */
+  const expanded = renderToStaticMarkup(<MobilePipelineDock pipeline={provisioning} defaultExpanded />);
+  expect(expanded).toContain('aria-label="Collapse pipeline Refactor the board"');
+  expect(expanded).toContain('aria-label="Pipeline stages"');
+
+  /* A parked or draft pipeline stays visible without expanding: the collapsed
+     summary row carries the warning-toned state badge. */
+  const parked = renderToStaticMarkup(
+    <MobilePipelineDock pipeline={{ ...provisioning, state: "needs_decision" } as Pipeline} defaultExpanded={false} />,
+  );
+  expect(parked).toContain("bg-warning-soft");
+  const draft = renderToStaticMarkup(
+    <MobilePipelineDock pipeline={{ ...provisioning, state: "draft" } as Pipeline} defaultExpanded={false} />,
+  );
+  expect(draft).toContain("bg-warning-soft");
 });
 
 test("a paused pipeline shows Resume; a completed one keeps Close but drops pause/resume", () => {

--- a/src/components/mobile/directReviewDeck.dom.test.tsx
+++ b/src/components/mobile/directReviewDeck.dom.test.tsx
@@ -242,6 +242,11 @@ test("an active pipeline-owned review keeps prior same-round bindings in the com
   expect(deckChip).toBeUndefined();
 
   const dock = dom.document.querySelector('[data-testid="mobile-pipeline-dock"]');
+  /* With a conversation focused the dock mounts collapsed (#156); the full rail
+     — and its verdict/round history — stays reachable behind the disclosure. */
+  const summary = dock!.querySelector('[data-testid="mobile-pipeline-dock-summary"]') as unknown as HTMLButtonElement;
+  flushSync(() => summary.click());
+  await settle();
   const history = ([...dock!.querySelectorAll("button")] as unknown as HTMLButtonElement[])
     .filter((button) => button.getAttribute("aria-label")?.startsWith("Open verdict for stage"))
     .at(-1);

--- a/src/components/mobile/dockDisclosure.dom.test.tsx
+++ b/src/components/mobile/dockDisclosure.dom.test.tsx
@@ -1,0 +1,201 @@
+import { afterAll, afterEach, beforeAll, beforeEach, expect, mock, test } from "bun:test";
+import { Window } from "happy-dom";
+import { createRoot, type Root } from "react-dom/client";
+import { flushSync } from "react-dom";
+
+import { emptyStore } from "@/components/runtime/runtimeModel";
+import type { BranchGroup } from "@/components/projectModel";
+import type { FileEntry } from "@/lib/types";
+import type { Pipeline } from "@/lib/pipelines/types";
+import type { WorkerStack } from "@/components/scheme/workerCollapse";
+
+/*
+ * Issue #156 — the focused conversation must stay the dominant mobile surface.
+ * With a pane focused, every docked pipeline mounts COLLAPSED to one 44px
+ * disclosure row inside a bounded (≤34vh) dock bar; expanding one reveals the
+ * full rail. The empty-state branch (no conversation — the dock IS the surface)
+ * keeps its docks expanded.
+ */
+
+const actualRuntimeHooks = await import("@/hooks/useRuntime");
+const inertRuntime = { enabled: false, connection: "offline" as const, resyncedAt: null, store: emptyStore() };
+mock.module("@/hooks/useRuntime", () => ({
+  ...actualRuntimeHooks,
+  useRuntimeBusState: () => ({ ...inertRuntime, lastEventAt: null }),
+  useRuntime: () => inertRuntime,
+  useRuntimeSession: () => null,
+  useRuntimeReceiptsForArtifact: () => [],
+  useRuntimeFlow: () => null,
+}));
+
+const { MobileFocusView } = await import("@/components/mobile/MobileFocusView");
+
+const dom = new Window({ url: "http://localhost/" });
+const G = globalThis as Record<string, unknown>;
+const OVERRIDES: Record<string, unknown> = {
+  window: dom,
+  document: dom.document,
+  navigator: dom.navigator,
+  Node: dom.Node,
+  HTMLElement: dom.HTMLElement,
+  Event: dom.Event,
+  MouseEvent: dom.MouseEvent,
+  sessionStorage: dom.sessionStorage,
+  localStorage: dom.localStorage,
+  matchMedia: (q: string) => ({ matches: /max-width/.test(String(q)), media: String(q), onchange: null, addEventListener() {}, removeEventListener() {}, addListener() {}, removeListener() {}, dispatchEvent() { return false; } }),
+  requestAnimationFrame: (cb: (t: number) => void) => setTimeout(() => cb(0), 0) as unknown as number,
+  cancelAnimationFrame: (id: number) => clearTimeout(id),
+  ResizeObserver: class { observe() {} unobserve() {} disconnect() {} },
+  IntersectionObserver: class { observe() {} unobserve() {} disconnect() {} takeRecords() { return []; } },
+  fetch: (async () => ({ ok: true, status: 200, json: async () => ({}), text: async () => "" })) as unknown as typeof fetch,
+};
+const HAS: Record<string, boolean> = {};
+const SAVED: Record<string, unknown> = {};
+const settle = async () => { await new Promise((r) => setTimeout(r, 0)); await new Promise((r) => setTimeout(r, 0)); };
+
+beforeAll(() => {
+  for (const key of Object.keys(OVERRIDES)) { HAS[key] = key in G; SAVED[key] = G[key]; G[key] = OVERRIDES[key]; }
+  (dom.HTMLElement.prototype as unknown as { scrollIntoView: () => void }).scrollIntoView = () => {};
+});
+afterAll(async () => {
+  await settle();
+  for (const key of Object.keys(OVERRIDES)) { if (HAS[key]) G[key] = SAVED[key]; else delete G[key]; }
+  mock.module("@/hooks/useRuntime", () => actualRuntimeHooks);
+});
+
+let roots: Root[] = [];
+beforeEach(() => { dom.document.body.replaceChildren(); roots = []; });
+afterEach(async () => { for (const r of roots) flushSync(() => r.unmount()); roots = []; await settle(); dom.sessionStorage.clear(); });
+
+function mount(node: React.ReactElement): Root {
+  const host = dom.document.createElement("div");
+  dom.document.body.appendChild(host);
+  const root = createRoot(host as unknown as Element);
+  flushSync(() => root.render(node));
+  return root;
+}
+
+const pipeline = {
+  id: "p1", task: "Ship the mobile dock", project: "demo", repoDir: "/r", worktreeDir: "/w",
+  branch: "b", baseBranch: "main", baseRef: "a", lastPassedCommit: "a",
+  stages: [
+    { id: "plan", kind: "run", prompt: "", next: "build", effectiveRole: { roleId: null, engine: "codex", model: null, effort: null, access: "read-only", promptScaffold: null } },
+    { id: "build", kind: "run", prompt: "", next: null, effectiveRole: { roleId: null, engine: "codex", model: null, effort: null, access: "read-write", promptScaffold: null } },
+  ],
+  runs: [], cursor: null, state: "provisioning", pausedState: null, stateDetail: null,
+  srcPath: null, srcConversationId: null, createdAt: new Date(0).toISOString(), closedAt: null,
+} as unknown as Pipeline;
+
+function entry(overrides: Partial<FileEntry> & { path: string }): FileEntry {
+  return {
+    root: "claude-projects",
+    name: overrides.path,
+    project: "demo",
+    title: overrides.path,
+    engine: "claude",
+    kind: "session",
+    fmt: "claude",
+    parent: null,
+    mtime: 1_000,
+    size: 10,
+    activity: "idle",
+    proc: null,
+    pid: null,
+    model: null,
+    pendingQuestion: null,
+    waitingInput: null,
+    ...overrides,
+  };
+}
+
+function view(groups: BranchGroup[], files: FileEntry[], stacks: WorkerStack[] = []) {
+  return (
+    <MobileFocusView
+      project="demo"
+      groups={groups}
+      manual={[]}
+      files={files}
+      flows={[]}
+      pipelines={[pipeline]}
+      surfacePipelines={[pipeline]}
+      workerStacks={stacks}
+      tasks={[]}
+      drafts={[]}
+      loaded
+      focus={null}
+      onSelect={() => {}}
+      onClose={() => {}}
+      onDraftClose={() => {}}
+      onDraftSpawned={() => {}}
+    />
+  );
+}
+
+test("a focused conversation keeps docked pipelines collapsed inside a ≤34vh bar; expanding reveals the rail (#156)", async () => {
+  const conversation = entry({ path: "/session", title: "Main session", activity: "live", mtime: 9_000 });
+  const group: BranchGroup = {
+    key: conversation.path,
+    columns: [{ file: conversation, tasks: [] }],
+    returnable: [],
+    finished: [],
+    smt: conversation.mtime,
+    orphanTask: false,
+  };
+  roots.push(mount(view([group], [conversation])));
+  await settle();
+
+  /* The dock bar below the focused pane is height-bounded tighter than before. */
+  const dock = dom.document.querySelector('[data-testid="mobile-pipeline-dock"]');
+  expect(dock).not.toBeNull();
+  const bar = dock!.closest("div.shrink-0");
+  expect(bar).not.toBeNull();
+  expect(bar!.className).toContain("max-h-[34vh]");
+
+  /* Collapsed by default: only the summary row, no stage rail, so the
+     conversation stays dominant. */
+  expect(dock!.querySelector('[data-testid="mobile-pipeline-dock-summary"]')).not.toBeNull();
+  expect(dock!.querySelector('[aria-label="Pipeline stages"]')).toBeNull();
+
+  /* The disclosure expands to the full rail on demand. */
+  const toggle = dock!.querySelector('[data-testid="mobile-pipeline-dock-summary"]') as unknown as HTMLButtonElement;
+  flushSync(() => toggle.click());
+  await settle();
+  expect(dom.document.querySelector('[data-testid="mobile-pipeline-dock"] [aria-label="Pipeline stages"]')).not.toBeNull();
+});
+
+test("the empty-state branch (no conversation) mounts its docks expanded — the dock IS the surface", async () => {
+  roots.push(mount(view([], [])));
+  await settle();
+
+  const dock = dom.document.querySelector('[data-testid="mobile-pipeline-dock"]');
+  expect(dock).not.toBeNull();
+  expect(dock!.querySelector('[aria-label="Pipeline stages"]')).not.toBeNull();
+});
+
+test("the map overlay dock bar is bounded to 30vh with collapsed docks (#156)", async () => {
+  const conversation = entry({ path: "/session", title: "Main session", activity: "live", mtime: 9_000 });
+  const group: BranchGroup = {
+    key: conversation.path,
+    columns: [{ file: conversation, tasks: [] }],
+    returnable: [],
+    finished: [],
+    smt: conversation.mtime,
+    orphanTask: false,
+  };
+  const stack: WorkerStack = { key: "stack::pipe:p1", kind: "pipeline", id: "p1", items: [] };
+  roots.push(mount(view([group], [conversation], [stack])));
+  await settle();
+
+  const openBtn = dom.document.querySelector('button[aria-label="Open the project map"]') as HTMLButtonElement | null;
+  expect(openBtn).not.toBeNull();
+  flushSync(() => openBtn!.click());
+  await settle();
+
+  const overlay = dom.document.querySelector('[aria-label="Close the map"]')!.closest("div.fixed")!;
+  const dock = overlay.querySelector('[data-testid="mobile-pipeline-dock"]');
+  expect(dock).not.toBeNull();
+  const bar = dock!.closest("div.shrink-0");
+  expect(bar!.className).toContain("max-h-[30vh]");
+  expect(dock!.querySelector('[data-testid="mobile-pipeline-dock-summary"]')).not.toBeNull();
+  expect(dock!.querySelector('[aria-label="Pipeline stages"]')).toBeNull();
+});

--- a/src/components/mobile/mapDock.dom.test.tsx
+++ b/src/components/mobile/mapDock.dom.test.tsx
@@ -141,9 +141,18 @@ test("opening the mobile map keeps every active pipeline's full plan on a dock i
   expect(found).toBe(true);
 
   const overlay = dom.document.querySelector('[aria-label="Close the map"]')!.closest("div.fixed");
-  // The whole planned stage graph rides on that dock card.
-  expect(overlay!.textContent).toContain("plan");
-  expect(overlay!.textContent).toContain("build");
+  /* Docks mount collapsed inside the overlay (#156); the whole planned stage
+     graph stays one disclosure tap away. */
+  const summary = overlay!.querySelector('[data-testid="mobile-pipeline-dock-summary"]') as HTMLButtonElement | null;
+  expect(summary).not.toBeNull();
+  flushSync(() => summary!.click());
+  await settle();
+  /* Evidence-less stages render as glyph chips (#156): the full stage graph is
+     present with each stage named to assistive tech. */
+  expect(overlay!.querySelector('[data-pipeline-stage="plan"]')).not.toBeNull();
+  expect(overlay!.querySelector('[data-pipeline-stage="build"]')).not.toBeNull();
+  expect(overlay!.querySelector('[aria-label="plan, pending"]')).not.toBeNull();
+  expect(overlay!.querySelector('[aria-label="build, pending"]')).not.toBeNull();
 
   const framing = overlay!.querySelector('[aria-label="Map framing"]')!;
   const all = Array.from(framing.querySelectorAll("button")).find((button) => button.textContent === "All");

--- a/src/components/pipelines/PipelineStrip.render.test.tsx
+++ b/src/components/pipelines/PipelineStrip.render.test.tsx
@@ -123,6 +123,73 @@ test("the compact pipeline surface exposes the full pinned base SHA", () => {
   expect(html).toContain(`Base ${baseRef}`);
 });
 
+test("mobile contains the rail and defers diagnostics while desktop markup stays complete", () => {
+  const baseRef = "48c739bbcc87b3244aee7fb0e2d1b3f8e312548f";
+  const stages = [stage("plan"), stage("build")];
+  const passed = attempt({
+    state: "passed",
+    agentPath: "/build.jsonl",
+    startedAt: "2026-07-18T10:00:00.000Z",
+    completedAt: "2026-07-18T10:01:30.000Z",
+    verdict: { status: "pass", findings: [], confidence: 0.95 },
+  });
+  const p = pipeline({
+    baseRef,
+    lastPassedCommit: baseRef,
+    stages,
+    runs: [{ stageId: "build", attempts: [passed] }],
+  });
+  const mobile = renderToStaticMarkup(
+    <PipelineStrip mobile pipeline={p} renderablePaths={new Set(["/build.jsonl"])} onOpenPath={() => undefined} />,
+  );
+  const desktop = renderToStaticMarkup(
+    <PipelineStrip pipeline={p} renderablePaths={new Set(["/build.jsonl"])} onOpenPath={() => undefined} />,
+  );
+
+  expect(mobile).toContain("max-w-full");
+  expect(mobile).toContain("overflow-hidden");
+  expect(mobile).toContain("justify-start");
+  expect(mobile).not.toContain(`Base ${baseRef}`);
+  expect(mobile).not.toContain("data-stage-evidence");
+  expect(mobile).not.toContain("Open previous stage plan");
+
+  expect(desktop).toContain("justify-center");
+  expect(desktop).toContain(`Base ${baseRef}`);
+  expect(desktop).toContain('data-stage-evidence="passed"');
+  expect(desktop).toContain("Open previous stage plan");
+});
+
+test("mobile compacts empty stages while a parked decision keeps its full controls", () => {
+  const build = stage("build");
+  const pending = renderToStaticMarkup(
+    <PipelineStrip
+      mobile
+      pipeline={pipeline({ state: "draft", stages: [build], cursor: { stageId: build.id, state: "pending" } })}
+    />,
+  );
+  const parked = renderToStaticMarkup(
+    <PipelineStrip
+      mobile
+      pipeline={pipeline({
+        state: "needs_decision",
+        stages: [build],
+        cursor: { stageId: build.id, state: "running" },
+        runs: [{ stageId: build.id, attempts: [attempt({ state: "needs_decision", agentPath: null })] }],
+      })}
+    />,
+  );
+
+  expect(pending).toContain('data-stage-compact="true"');
+  expect(pending).toContain('aria-label="build, pending"');
+  expect(pending).toContain("h-11 w-11");
+  expect(pending).not.toContain(">build</span>");
+
+  expect(parked).not.toContain("data-stage-compact");
+  expect(parked).toContain("max-w-[180px]");
+  expect(parked).toContain('aria-label="Retry stage"');
+  expect(parked).toContain('aria-label="Skip"');
+});
+
 test("compact history exposes evidence, configuration, and ordered lineage controls (#353)", () => {
   const stages = [stage("plan"), stage("build"), stage("verify")];
   const passed = attempt({

--- a/src/components/pipelines/PipelineStrip.render.test.tsx
+++ b/src/components/pipelines/PipelineStrip.render.test.tsx
@@ -247,3 +247,35 @@ test("every linked task keeps a direct control inside the bounded rail (#353)", 
   expect(html).toContain("overflow-x-auto");
   expect(html).not.toContain("+2");
 });
+
+test("the compact board strip is one bounded scrolling row — it can never wrap over the pane below (#353)", () => {
+  const linkedTasks = Array.from({ length: 4 }, (_, index) => ({
+    id: `task-${index + 1}`, project: "proj", status: "assigned" as const, text: `Linked ${index + 1}`,
+    placement: "unplaced" as const, assignments: [], createdAt: "2026-07-18T00:00:00Z", updatedAt: "2026-07-18T00:00:00Z",
+  }));
+  const parked = pipeline({ state: "needs_decision", cursor: { stageId: "build", state: "running" } });
+  const compact = renderToStaticMarkup(<PipelineStrip pipeline={parked} linkedTasks={linkedTasks} compact onOpenTask={() => undefined} />);
+  /* The board mounts anchor the strip's TOP inside the group's 44px headroom /
+     above a node's pane; a wrapped second row paints over the chat. The compact
+     root therefore never wraps — it scrolls internally instead. */
+  const root = compact.slice(compact.indexOf("Pipeline "), compact.indexOf("<span"));
+  expect(root).toContain("flex-nowrap");
+  expect(root).toContain("overflow-x-auto");
+  expect(root).not.toContain("flex-wrap");
+  /* Everything stays reachable inside the scroller: tasks + full controls. */
+  for (let index = 1; index <= 4; index += 1) expect(compact).toContain(`Open linked task Linked ${index}`);
+  expect(compact).toContain("Retry stage");
+  /* The standalone (builder-panel) strip keeps its wrapping layout. */
+  const standalone = renderToStaticMarkup(<PipelineStrip pipeline={parked} linkedTasks={linkedTasks} onOpenTask={() => undefined} />);
+  expect(standalone.slice(standalone.indexOf("Pipeline "), standalone.indexOf("<span"))).toContain("flex-wrap");
+});
+
+test("the mobile action row shrinks and wraps inside the rail — no button is clipped off-screen (#156 AC6)", () => {
+  const parked = pipeline({ state: "needs_decision", cursor: { stageId: "build", state: "running" } });
+  const mobile = renderToStaticMarkup(<PipelineStrip mobile pipeline={parked} />);
+  /* `shrink-0` keeps the row max-content wide and the rail's overflow clip cuts
+     the trailing buttons (Close pipeline) off-screen at 390px. */
+  expect(mobile).toContain('class="flex flex-wrap items-center gap-1.5 min-w-0 shrink"');
+  const desktop = renderToStaticMarkup(<PipelineStrip pipeline={parked} />);
+  expect(desktop).toContain('class="flex flex-wrap items-center gap-1.5 shrink-0"');
+});

--- a/src/components/pipelines/PipelineStrip.tsx
+++ b/src/components/pipelines/PipelineStrip.tsx
@@ -256,7 +256,7 @@ function StageChip({
 
   return (
     <li ref={chipRef} className="relative flex shrink-0 items-center gap-1.5" data-pipeline-stage={stage.id} data-stage-state={state}>
-      {previousStage ? (
+      {previousStage && !mobile ? (
         <span
           role="group"
           aria-label={t("pipelineStrip.lineageAria", { from: previousLabel, to: label })}
@@ -321,7 +321,7 @@ function StageChip({
             <span aria-hidden>{attempt!.verdict ? (attempt!.verdict.status === "pass" ? "✓" : attempt!.verdict.status === "fail" ? "✕" : "●") : "!"}</span>
           </button>
         ) : null}
-        {terminalEvidence && attempt ? (
+        {!mobile && terminalEvidence && attempt ? (
           <span
             data-stage-evidence={attempt.state}
             aria-label={t("pipelineStrip.evidenceAria", {
@@ -458,7 +458,7 @@ export function PipelineStrip({
       data-scheme-ui
       role="group"
       aria-label={t("pipelineStrip.groupAria", { task: pipeline.task })}
-      className={`pointer-events-auto flex min-h-9 w-full flex-wrap items-center gap-x-2.5 gap-y-1 rounded-surface border bg-card/95 py-1 shadow-1 ${compact ? "px-2.5" : "px-3"} ${mobile ? "[&_button]:min-h-11 [&_button]:min-w-11" : ""} ${draft ? "border-2 border-dashed border-warning" : attention ? "border-warning/70" : "border-border"}`}
+      className={`pointer-events-auto flex min-h-9 w-full flex-wrap items-center gap-x-2.5 gap-y-1 rounded-surface border bg-card/95 py-1 shadow-1 ${compact ? "px-2.5" : "px-3"} ${mobile ? "max-w-full overflow-hidden [&_button]:min-h-11 [&_button]:min-w-11" : ""} ${draft ? "border-2 border-dashed border-warning" : attention ? "border-warning/70" : "border-border"}`}
     >
       <span className="flex min-w-0 max-w-full shrink-0 items-center gap-2 sm:max-w-[46%]">
         <span
@@ -485,12 +485,12 @@ export function PipelineStrip({
         ) : null}
         {detail ? <span className={`min-w-0 truncate text-ui font-semibold ${attention ? "text-warning" : "text-danger"}`} title={detail}>{detail}</span> : null}
       </span>
-      {pipeline.baseRef ? (
+      {!mobile && pipeline.baseRef ? (
         <span className="shrink-0 rounded-control border border-border bg-sunken px-1.5 py-0.5 font-mono text-caption text-muted" title={t("pipelineStrip.baseSha", { sha: pipeline.baseRef })}>
           {t("pipelineStrip.baseSha", { sha: pipeline.baseRef })}
         </span>
       ) : null}
-      <ol className="no-scrollbar flex min-w-0 flex-1 items-center justify-center gap-1.5 overflow-x-auto" aria-label={t("pipelineStrip.stagesAria")}>
+      <ol className={`no-scrollbar flex min-w-0 flex-1 items-center gap-1.5 overflow-x-auto ${mobile ? "justify-start" : "justify-center"}`} aria-label={t("pipelineStrip.stagesAria")}>
         {pipeline.stages.map((stage, index) => (
           <StageChip
             key={stage.id}

--- a/src/components/pipelines/PipelineStrip.tsx
+++ b/src/components/pipelines/PipelineStrip.tsx
@@ -24,6 +24,7 @@ import {
   stageAttempts,
   stageChipLabel,
   stageChipState,
+  stageDockCompact,
   stageHasEvidence,
   stageHasNavigableHistory,
   compactStageOpenTarget,
@@ -238,6 +239,12 @@ function StageChip({
   const canOpenFlow = Boolean(attempt?.flowId && renderableFlows.has(attempt.flowId));
   const canOpenPath = Boolean(attempt?.agentPath && (!renderablePaths || renderablePaths.has(attempt.agentPath)));
 
+  /* Mobile dock (#156): a stage with NO transcript evidence — nothing the
+     verdict sheet, history, or open-transcript could reveal — renders as a
+     glyph-only round chip so an empty/draft/terminal plan stays compact. A
+     configurable draft stage compacts too but keeps its tap → configuration. */
+  const dockCompact = mobile && stageDockCompact(pipeline, stage, attempt, flows, renderableFlows, renderablePaths, files);
+
   const previousTarget = previousStage ? targetFor(previousStage) : null;
   const previousConfigurable = previousStage ? stageConfigurable(previousStage) : false;
   const previousLabel = previousStage ? stageChipLabel(t, previousStage) : "";
@@ -286,6 +293,22 @@ function StageChip({
           </button>
         </span>
       ) : null}
+      {dockCompact ? (
+        <button
+          ref={stageButtonRef}
+          type="button"
+          data-stage-compact="true"
+          disabled={!canOpen}
+          onClick={openStage}
+          aria-expanded={configurable ? configurationOpen : undefined}
+          aria-label={t("pipelineStrip.compactChipAria", { label, state: chipState })}
+          className={`inline-flex h-11 w-11 items-center justify-center rounded-full text-label font-bold focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 disabled:cursor-default ${pulse ? "animate-pulse" : ""}`}
+          style={{ backgroundColor: tone.soft, color: tone.color }}
+          title={title}
+        >
+          <span aria-hidden>{configurable ? <Settings2 className="h-3.5 w-3.5" /> : glyph || (stage.kind === "review-loop" ? "⟳" : "▸")}</span>
+        </button>
+      ) : (
       <span className={`inline-flex items-stretch rounded-control border ${terminalEvidence ? "border-border bg-sunken" : "border-transparent"}`}>
         <button
           ref={stageButtonRef}
@@ -340,6 +363,7 @@ function StageChip({
           </span>
         ) : null}
       </span>
+      )}
       {open && attempt ? (
         <AnchoredVerdict anchorRef={chipRef}>
           <VerdictPopover pipeline={pipeline} stage={stage} attempt={attempt} flows={flows} files={files} availablePaths={renderablePaths} mobile={mobile} canOpenFlow={canOpenFlow} canOpenPath={canOpenPath} onClose={onCloseVerdict} onOpenPath={onOpenPath} onOpenFlow={onOpenFlow} />
@@ -458,7 +482,14 @@ export function PipelineStrip({
       data-scheme-ui
       role="group"
       aria-label={t("pipelineStrip.groupAria", { task: pipeline.task })}
-      className={`pointer-events-auto flex min-h-9 w-full flex-wrap items-center gap-x-2.5 gap-y-1 rounded-surface border bg-card/95 py-1 shadow-1 ${compact ? "px-2.5" : "px-3"} ${mobile ? "max-w-full overflow-hidden [&_button]:min-h-11 [&_button]:min-w-11" : ""} ${draft ? "border-2 border-dashed border-warning" : attention ? "border-warning/70" : "border-border"}`}
+      className={`pointer-events-auto flex min-h-9 w-full items-center gap-x-2.5 gap-y-1 rounded-surface border bg-card/95 py-1 shadow-1 ${
+        /* Board mounts (#353/#156 "task links covering chats"): the compact
+           strip hovers inside the group's 44px headroom band / above a node's
+           pane, anchored by its top — any wrapped second row paints OVER the
+           chat below it. Single row + internal horizontal scroll keeps the
+           height bounded; every popover already escapes through a body portal. */
+        compact ? "no-scrollbar flex-nowrap overflow-x-auto px-2.5" : "flex-wrap px-3"
+      } ${mobile ? "max-w-full overflow-hidden [&_button]:min-h-11 [&_button]:min-w-11" : ""} ${draft ? "border-2 border-dashed border-warning" : attention ? "border-warning/70" : "border-border"}`}
     >
       <span className="flex min-w-0 max-w-full shrink-0 items-center gap-2 sm:max-w-[46%]">
         <span
@@ -540,7 +571,12 @@ export function PipelineStrip({
           })}
         </span>
       ) : null}
-      <span className="flex shrink-0 flex-wrap items-center gap-1.5">
+      {/* Mobile (#156 AC6): the action row must SHRINK to the rail width so its
+          own flex-wrap engages — `shrink-0` keeps it max-content wide and the
+          rail's overflow clip cuts the trailing buttons off-screen. Desktop
+          keeps shrink-0: full-size buttons stay reachable by the compact
+          scroller instead of shrinking. */}
+      <span className={`flex flex-wrap items-center gap-1.5 ${mobile ? "min-w-0 shrink" : "shrink-0"}`}>
         {error ? <span className="max-w-[220px] truncate text-caption font-semibold text-danger" title={error}>{error}</span> : null}
         {busy ? <RefreshCw className="h-3.5 w-3.5 animate-spin text-muted" aria-hidden /> : null}
         {draft ? (

--- a/src/components/pipelines/pipelineModel.test.ts
+++ b/src/components/pipelines/pipelineModel.test.ts
@@ -16,6 +16,7 @@ import {
   draftStagesToInput,
   normalizeStageOrder,
   compactPipelineArtifactPaths,
+  stageDockCompact,
   compactStageOpenTarget,
   excludeCompactPipelineArtifacts,
   pipelineAnnouncement,
@@ -581,6 +582,37 @@ describe("stageHasEvidence (running attempts have no verdict sheet)", () => {
   test("no attempt is no evidence", () => {
     expect(stageHasEvidence(p({}), runStage, null)).toBe(false);
   });
+});
+
+test("stageDockCompact keeps every stage with transcript evidence fully disclosed", () => {
+  const build = stage("build");
+  const skipped = { n: 1, state: "skipped", agentPath: null, verdict: null, error: null } as never;
+  const parked = { n: 1, state: "needs_decision", agentPath: null, verdict: null, error: null } as never;
+  const passedWithVerdict = { n: 1, state: "passed", agentPath: null, verdict: { status: "pass" }, error: null } as never;
+  const passedWithPath = { n: 1, state: "passed", agentPath: "/build.jsonl", verdict: null, error: null } as never;
+  const pendingPipeline = pipeline({ stages: [build], state: "draft", cursor: { stageId: build.id, state: "pending" } });
+
+  expect(stageDockCompact(pendingPipeline, build, null, [], new Set(), new Set(), [])).toBe(true);
+  expect(stageDockCompact(pipeline({ stages: [build] }), build, skipped, [], new Set(), new Set(), [])).toBe(true);
+  expect(stageDockCompact(
+    pipeline({ stages: [build], state: "needs_decision", cursor: { stageId: build.id, state: "running" } }),
+    build,
+    parked,
+    [],
+    new Set(),
+    new Set(),
+    [],
+  )).toBe(false);
+  expect(stageDockCompact(pipeline({ stages: [build] }), build, passedWithVerdict, [], new Set(), new Set(), [])).toBe(false);
+  expect(stageDockCompact(
+    pipeline({ stages: [build] }),
+    build,
+    passedWithPath,
+    [],
+    new Set(),
+    new Set(["/build.jsonl"]),
+    [],
+  )).toBe(false);
 });
 
 describe("stageHasNavigableHistory", () => {

--- a/src/components/pipelines/pipelineModel.test.ts
+++ b/src/components/pipelines/pipelineModel.test.ts
@@ -16,6 +16,8 @@ import {
   draftStagesToInput,
   normalizeStageOrder,
   compactPipelineArtifactPaths,
+  latestAttempt,
+  resolvePipelineMemberPaths,
   stageDockCompact,
   compactStageOpenTarget,
   excludeCompactPipelineArtifacts,
@@ -581,6 +583,53 @@ describe("stageHasEvidence (running attempts have no verdict sheet)", () => {
   });
   test("no attempt is no evidence", () => {
     expect(stageHasEvidence(p({}), runStage, null)).toBe(false);
+  });
+});
+
+describe("resolvePipelineMemberPaths (durable members follow path rotation — #325/#353)", () => {
+  const build = stage("build");
+  const fileAt = (path: string, over: Partial<FileEntry> = {}): FileEntry => ({ path, ...over }) as FileEntry;
+  const rotated = [
+    fileAt("/old.jsonl", { conversationId: "c1", migratedTo: "/new.jsonl" }),
+    fileAt("/new.jsonl", { conversationId: "c1", predecessorPath: "/old.jsonl" }),
+  ];
+  const staleAttempt = { n: 1, state: "passed", conversationId: "c1", agentPath: "/old.jsonl", flowId: null, verdict: null, error: null } as never;
+
+  test("an attempt whose conversation migrated resolves to the current generation path", () => {
+    const stale = pipeline({ stages: [build], runs: [{ stageId: build.id, attempts: [staleAttempt] }] });
+    const [resolved] = resolvePipelineMemberPaths([stale], rotated);
+    expect(latestAttempt(resolved!, build.id)?.agentPath).toBe("/new.jsonl");
+  });
+
+  test("a recorded path that became an archived predecessor redirects without a stored conversation id", () => {
+    const idless = { n: 1, state: "passed", conversationId: null, agentPath: "/old.jsonl", flowId: null, verdict: null, error: null } as never;
+    const stale = pipeline({ stages: [build], runs: [{ stageId: build.id, attempts: [idless] }] });
+    const [resolved] = resolvePipelineMemberPaths([stale], rotated);
+    expect(latestAttempt(resolved!, build.id)?.agentPath).toBe("/new.jsonl");
+  });
+
+  test("a conversation whose current generation left the scan keeps the recorded path", () => {
+    const stale = pipeline({ stages: [build], runs: [{ stageId: build.id, attempts: [staleAttempt] }] });
+    const [resolved] = resolvePipelineMemberPaths([stale], []);
+    expect(latestAttempt(resolved!, build.id)?.agentPath).toBe("/old.jsonl");
+  });
+
+  test("records that need no rewrite keep their identity", () => {
+    const current = { n: 1, state: "passed", conversationId: "c1", agentPath: "/same.jsonl", flowId: null, verdict: null, error: null } as never;
+    const stable = pipeline({ stages: [build], runs: [{ stageId: build.id, attempts: [current] }] });
+    const out = resolvePipelineMemberPaths([stable], [fileAt("/same.jsonl", { conversationId: "c1" })]);
+    expect(out[0]).toBe(stable);
+  });
+
+  test("claiming follows the rotation: the successor transcript is compact evidence, never a standalone card (#353)", () => {
+    const stale = pipeline({
+      stages: [build],
+      state: "completed",
+      runs: [{ stageId: build.id, attempts: [staleAttempt] }],
+    });
+    const resolved = resolvePipelineMemberPaths([stale], rotated);
+    const compact = compactPipelineArtifactPaths(resolved, [], rotated);
+    expect(compact.has("/new.jsonl")).toBe(true);
   });
 });
 

--- a/src/components/pipelines/pipelineModel.ts
+++ b/src/components/pipelines/pipelineModel.ts
@@ -471,6 +471,21 @@ export function stageHasNavigableHistory(
   ));
 }
 
+/** Mobile dock stages stay small only when every history entry point is empty. */
+export function stageDockCompact(
+  pipeline: Pipeline,
+  stage: PipelineStage,
+  attempt: PipelineStageAttempt | null,
+  flows: readonly Flow[] = [],
+  renderableFlows?: ReadonlySet<string>,
+  renderablePaths?: ReadonlySet<string>,
+  files: readonly FileEntry[] = [],
+): boolean {
+  return !stageHasEvidence(pipeline, stage, attempt)
+    && !stageHasNavigableHistory(pipeline, stage, attempt, flows, renderablePaths, files)
+    && compactStageOpenTarget(stage, attempt, flows, renderableFlows, renderablePaths, files) === null;
+}
+
 /** Localized label for a raw attempt state (the prior-attempt audit), so a
     verdict-less attempt never shows an English identifier in the uk UI. */
 export function attemptStateLabel(t: TFunction, state: PipelineAttemptState): string {

--- a/src/components/pipelines/pipelineModel.ts
+++ b/src/components/pipelines/pipelineModel.ts
@@ -1,5 +1,6 @@
 import { roleNameById } from "@/components/builderCopy";
 import { reviewerBindingTargetsForRound } from "@/components/flows/flowModel";
+import { currentMemberPath } from "@/lib/accounts/identity";
 import { applyPipelineSnapshot, revertPipelineSnapshot } from "@/hooks/useFiles";
 import { getLocale, translate, type MessageKey, type TFunction } from "@/lib/i18n";
 import type { FileEntry } from "@/lib/types";
@@ -76,6 +77,41 @@ export function canSourcePipeline(file: FileEntry): boolean {
     reveal the always-available detailed surface (#93 §2.2). */
 export function pipelineStripDomId(pipelineId: string): string {
   return `pipeline-strip-${pipelineId}`;
+}
+
+/**
+ * Canonicalizes every stage attempt's `agentPath` to the transcript that
+ * currently hosts its conversation (issues #325/#353). Durable pipeline records
+ * freeze the launch-time path; an account migration rotates the member onto a
+ * new transcript, and every projection that string-matches the frozen path —
+ * group halos, rails, compact claiming, worker stacks, strip mounting, open
+ * actions — silently drops the live generation, which then renders as a
+ * detached standalone card while the pipeline group under-counts its members.
+ * Applying this at the dashboard's data boundary repairs all of them at once.
+ * Identity-stable: untouched records (the common case) return the same
+ * references, so memoized consumers don't churn.
+ */
+export function resolvePipelineMemberPaths(pipelines: Pipeline[], files: readonly FileEntry[]): Pipeline[] {
+  let changedAny = false;
+  const out = pipelines.map((pipeline) => {
+    let changed = false;
+    const runs = pipeline.runs.map((run) => {
+      let runChanged = false;
+      const attempts = run.attempts.map((attempt) => {
+        const path = currentMemberPath(attempt.agentPath, attempt.conversationId, files);
+        if (path === attempt.agentPath) return attempt;
+        runChanged = true;
+        return { ...attempt, agentPath: path };
+      });
+      if (!runChanged) return run;
+      changed = true;
+      return { ...run, attempts };
+    });
+    if (!changed) return pipeline;
+    changedAny = true;
+    return { ...pipeline, runs };
+  });
+  return changedAny ? out : pipelines;
 }
 
 export function pipelinesForProject(pipelines: Pipeline[], project: string, files: FileEntry[]): Pipeline[] {

--- a/src/components/scheme/EdgeChips.tsx
+++ b/src/components/scheme/EdgeChips.tsx
@@ -110,15 +110,18 @@ function OverflowDisclosure({ edge, rows, open, onToggle, onClose, onFit, vp }: 
   );
 }
 
-export function EdgeChips({ clusters, cam, vp, hidden, onFit }: {
+export function EdgeChips({ clusters, cam, vp, hidden, obstacles = [], onFit }: {
   clusters: readonly BoardCluster[];
   cam: Camera;
   vp: { w: number; h: number };
   hidden: boolean;
+  /** Screen-space boxes of rendered conversation surfaces: a chip that would
+      paint over one folds into the edge's «+N» disclosure (issue #292). */
+  obstacles?: readonly SchemeRect[];
   onFit: (rect: SchemeRect) => void;
 }) {
   const { t } = useLocale();
-  const partition = useMemo(() => offscreenClusterChips(clusters, cam, vp), [clusters, cam, vp]);
+  const partition = useMemo(() => offscreenClusterChips(clusters, cam, vp, 4, obstacles), [clusters, cam, vp, obstacles]);
   const [openEdge, setOpenEdge] = useState<ChipEdge | null>(null);
   if (hidden || (!partition.visible.length && !partition.overflow.length)) return null;
 

--- a/src/components/scheme/SchemeBoard.tsx
+++ b/src/components/scheme/SchemeBoard.tsx
@@ -675,6 +675,20 @@ export function SchemeBoard({
     onFit: announceFit,
   });
 
+  /* Screen-space boxes of every rendered conversation surface (panes + review
+     decks): an edge-navigation chip that would paint over one folds into the
+     «+N» disclosure instead of covering chat content (issue #292 rejection). */
+  const chipObstacles = useMemo(
+    () =>
+      [...layout.nodes, ...layout.decks].map((surface) => ({
+        x: surface.x * cam.z + cam.x,
+        y: surface.y * cam.z + cam.y,
+        w: surface.w * cam.z,
+        h: surface.h * cam.z,
+      })),
+    [layout, cam],
+  );
+
   /* The fit functions change identity on every poll-driven relayout (useFiles
      hands a fresh `files` array ~10s, re-memoizing the layout), so the framing
      effect reads them through a ref and re-applies only on a real mapFrame
@@ -1093,6 +1107,7 @@ export function SchemeBoard({
         cam={cam}
         vp={vp}
         hidden={mapMode || Boolean(marquee) || panning}
+        obstacles={chipObstacles}
         onFit={fitRect}
       />
 

--- a/src/components/scheme/TaskCard.dom.test.tsx
+++ b/src/components/scheme/TaskCard.dom.test.tsx
@@ -103,6 +103,33 @@ test("a compact overflowing card clamps with a fade and Expand — no internal s
   expect(dom.document.querySelector('[data-scheme-task="t1"]')!.className).not.toContain("z-30");
 });
 
+test("exactly 20 hard lines expose Expand; 19 keep the plain body (padding boundary, Finding)", async () => {
+  /* The compact clamp is a border-box max-height: the body's 16px vertical
+     padding (py-2) is spent inside TASK_BODY_MAX, so the plain preview holds
+     only 19 full 17px lines (339px padded). A 20th hard line (356px padded)
+     crosses the clamp and must render the fade + Expand disclosure — never a
+     silently clipped last line (issue #292 contract). */
+  const nineteen = Array.from({ length: 19 }, (_, i) => `l${i}`).join("\n");
+  const twenty = `${nineteen}\nl19`;
+
+  roots.push(mount(<TaskCard task={task(twenty)} files={[]} camRef={camRef} handlers={handlers} />));
+  await settle();
+  const body = dom.document.querySelector("[data-task-body]")!;
+  expect((body as unknown as HTMLElement).style.maxHeight).toBe(`${TASK_BODY_MAX - TASK_DISCLOSURE_H}px`);
+  expect(dom.document.querySelector("[data-task-fade]")).not.toBeNull();
+  expect(dom.document.querySelector("[data-task-disclosure]")).not.toBeNull();
+  expect(body.className).toContain("overflow-hidden");
+  expect(body.className).not.toContain("overflow-y-auto");
+  dom.document.body.replaceChildren();
+
+  roots.push(mount(<TaskCard task={task(nineteen)} files={[]} camRef={camRef} handlers={handlers} />));
+  await settle();
+  const plain = dom.document.querySelector("[data-task-body]")!;
+  expect((plain as unknown as HTMLElement).style.maxHeight).toBe(`${TASK_BODY_MAX}px`);
+  expect(dom.document.querySelector("[data-task-fade]")).toBeNull();
+  expect(dom.document.querySelector("[data-task-disclosure]")).toBeNull();
+});
+
 test("a short card keeps the plain body: no disclosure, no fade, full cap", async () => {
   expect(taskCardExpandable({ text: "short task" })).toBe(false);
   roots.push(mount(<TaskCard task={task("short task")} files={[]} camRef={camRef} handlers={handlers} />));

--- a/src/components/scheme/TaskCard.dom.test.tsx
+++ b/src/components/scheme/TaskCard.dom.test.tsx
@@ -1,0 +1,115 @@
+import { afterAll, afterEach, beforeAll, beforeEach, expect, test } from "bun:test";
+import { Window } from "happy-dom";
+import { createRoot, type Root } from "react-dom/client";
+import { flushSync } from "react-dom";
+
+import { TaskCard, type TaskCardHandlers } from "./TaskCard";
+import { TASK_BODY_MAX, TASK_DISCLOSURE_H, taskCardExpandable, type PlacedTask } from "./taskGeometry";
+
+/*
+ * Issue #292 production rejection: a compact task card must never scroll its
+ * body internally — it clamps to a fixed preview with a fade and an in-card
+ * Expand control; the expanded card shows the full body with no nested scroll,
+ * lifted into the elevated overlay band the editing state already uses.
+ */
+
+const dom = new Window({ url: "http://localhost/" });
+const G = globalThis as Record<string, unknown>;
+const OVERRIDES: Record<string, unknown> = {
+  window: dom,
+  document: dom.document,
+  navigator: dom.navigator,
+  Node: dom.Node,
+  HTMLElement: dom.HTMLElement,
+  Event: dom.Event,
+  MouseEvent: dom.MouseEvent,
+  requestAnimationFrame: (cb: (t: number) => void) => setTimeout(() => cb(0), 0) as unknown as number,
+  cancelAnimationFrame: (id: number) => clearTimeout(id),
+};
+const HAS: Record<string, boolean> = {};
+const SAVED: Record<string, unknown> = {};
+const settle = async () => { await new Promise((r) => setTimeout(r, 0)); };
+
+beforeAll(() => {
+  for (const key of Object.keys(OVERRIDES)) { HAS[key] = key in G; SAVED[key] = G[key]; G[key] = OVERRIDES[key]; }
+});
+afterAll(async () => {
+  await settle();
+  for (const key of Object.keys(OVERRIDES)) { if (HAS[key]) G[key] = SAVED[key]; else delete G[key]; }
+});
+
+let roots: Root[] = [];
+beforeEach(() => { dom.document.body.replaceChildren(); roots = []; });
+afterEach(async () => { for (const r of roots) flushSync(() => r.unmount()); roots = []; await settle(); });
+
+const handlers: TaskCardHandlers = {
+  patch: async () => null,
+  remove: () => {},
+  handoff: async () => {},
+  draft: () => {},
+  unassign: () => {},
+  center: () => {},
+} as unknown as TaskCardHandlers;
+
+const longText = "Long task\n" + Array.from({ length: 40 }, (_, i) => `line ${i + 1} of the overflowing body`).join("\n");
+
+function task(text: string): PlacedTask {
+  return {
+    id: "t1", project: "demo", status: "assigned", text, placement: "board",
+    pos: { x: 10, y: 10 }, assignments: [], createdAt: "2026-07-18T00:00:00Z", updatedAt: "2026-07-18T00:00:00Z",
+  } as unknown as PlacedTask;
+}
+
+function mount(node: React.ReactElement): Root {
+  const host = dom.document.createElement("div");
+  dom.document.body.appendChild(host);
+  const root = createRoot(host as unknown as Element);
+  flushSync(() => root.render(node));
+  return root;
+}
+
+const camRef = { current: { x: 0, y: 0, z: 1 } };
+
+test("a compact overflowing card clamps with a fade and Expand — no internal scrollbar (#292)", async () => {
+  expect(taskCardExpandable({ text: longText })).toBe(true);
+  roots.push(mount(<TaskCard task={task(longText)} files={[]} camRef={camRef} handlers={handlers} />));
+  await settle();
+
+  const body = dom.document.querySelector("[data-task-body]")!;
+  expect(body.className).not.toContain("overflow-y-auto");
+  expect(body.className).toContain("overflow-hidden");
+  /* Preview cap reserves the disclosure row inside the geometry estimate. */
+  expect((body as unknown as HTMLElement).style.maxHeight).toBe(`${TASK_BODY_MAX - TASK_DISCLOSURE_H}px`);
+  expect(dom.document.querySelector("[data-task-fade]")).not.toBeNull();
+
+  const disclosure = dom.document.querySelector("[data-task-disclosure]") as unknown as HTMLButtonElement;
+  expect(disclosure).not.toBeNull();
+  expect(disclosure.getAttribute("aria-expanded")).toBe("false");
+
+  /* Expand: full body (no cap, no fade), still no internal scroll, and the card
+     lifts into the elevated overlay band (z-30, like editing). */
+  flushSync(() => disclosure.click());
+  await settle();
+  expect(disclosure.getAttribute("aria-expanded")).toBe("true");
+  expect((body as unknown as HTMLElement).style.maxHeight).toBe("");
+  expect(dom.document.querySelector("[data-task-fade]")).toBeNull();
+  expect(dom.document.querySelector('[data-scheme-task="t1"]')!.className).toContain("z-30");
+
+  /* Collapse restores the exact compact presentation. */
+  flushSync(() => disclosure.click());
+  await settle();
+  expect(disclosure.getAttribute("aria-expanded")).toBe("false");
+  expect((body as unknown as HTMLElement).style.maxHeight).toBe(`${TASK_BODY_MAX - TASK_DISCLOSURE_H}px`);
+  expect(dom.document.querySelector('[data-scheme-task="t1"]')!.className).not.toContain("z-30");
+});
+
+test("a short card keeps the plain body: no disclosure, no fade, full cap", async () => {
+  expect(taskCardExpandable({ text: "short task" })).toBe(false);
+  roots.push(mount(<TaskCard task={task("short task")} files={[]} camRef={camRef} handlers={handlers} />));
+  await settle();
+
+  expect(dom.document.querySelector("[data-task-disclosure]")).toBeNull();
+  expect(dom.document.querySelector("[data-task-fade]")).toBeNull();
+  const body = dom.document.querySelector("[data-task-body]")!;
+  expect((body as unknown as HTMLElement).style.maxHeight).toBe(`${TASK_BODY_MAX}px`);
+});

--- a/src/components/scheme/TaskCard.tsx
+++ b/src/components/scheme/TaskCard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { FoldVertical, Link2, Loader2, Send, Trash2, X } from "lucide-react";
+import { ChevronDown, ChevronUp, FoldVertical, Link2, Loader2, Send, Trash2, X } from "lucide-react";
 import { memo, useEffect, useRef, useState } from "react";
 
 import { useLocale } from "@/lib/i18n";
@@ -14,7 +14,7 @@ import { activityDot, cleanTitle, engineBadge, engineBadgeFor } from "@/componen
 
 import type { Camera } from "./Minimap";
 import { MOVE_EASE, MOVE_MS } from "./nodes";
-import { TASK_BODY_MAX, TASK_W, taskRect, type PlacedTask, type SchemeRect } from "./taskGeometry";
+import { TASK_BODY_MAX, TASK_DISCLOSURE_H, TASK_W, taskCardExpandable, taskRect, type PlacedTask, type SchemeRect } from "./taskGeometry";
 
 /* Below this zoom the card text is unreadable: an edit click glides first. */
 const EDIT_MIN_Z = 0.55;
@@ -163,6 +163,12 @@ export const TaskCard = memo(function TaskCard({
      bumps on the PATCH), so the card never snaps back mid-poll. */
   const [localPos, setLocalPos] = useState<{ x: number; y: number; seen: string } | null>(null);
   const [editing, setEditing] = useState(false);
+  /* Session-only full-text disclosure (issue #292): compact cards clamp with a
+     fade — never an internal scrollbar — and Expand lifts the card into the
+     same elevated overlay band editing uses, so the full body reads above the
+     board while stored geometry (placement, minimap, edges) keeps the compact
+     box. The durable stack fold (`handlers.collapse`) is a different verb. */
+  const [textExpanded, setTextExpanded] = useState(false);
   const [draft, setDraft] = useState("");
   /* The last edit ended blank: nothing was saved (the server rejects empty
      text), so handoffs/drafts are blocked until the user restores the text. */
@@ -278,7 +284,9 @@ export const TaskCard = memo(function TaskCard({
   const title = taskTitle(task.text) || t("tasks.untitled");
   const rest = task.text.includes("\n") ? task.text.slice(task.text.indexOf("\n") + 1) : "";
   const byPath = new Map(files.map((file) => [file.path, file]));
-  const lifted = editing || drag !== null;
+  const expandable = taskCardExpandable(task);
+  const showFullText = expandable && textExpanded;
+  const lifted = editing || drag !== null || showFullText;
 
   /* The handoff gesture, task-flavored: pull the arrow off the «send» pill
      onto a pane to route the task into that agent's composer (nothing is
@@ -334,12 +342,42 @@ export const TaskCard = memo(function TaskCard({
             maxLength={6000}
           />
         ) : (
-          <div data-task-body className="cursor-text overflow-y-auto px-3 py-2" style={{ maxHeight: TASK_BODY_MAX }}>
-            <div className="whitespace-pre-wrap break-words text-[12.5px] font-bold leading-[17px] text-primary">{title}</div>
-            {rest.trim() ? (
-              <div className="whitespace-pre-wrap break-words text-[12.5px] leading-[17px] text-secondary">{rest}</div>
+          <>
+            {/* Compact: fixed preview, clipped with a fade — zero internal
+                scrollbar (issue #292). The expandable card reserves the
+                disclosure row INSIDE the body cap so its rendered height stays
+                within the pure geometry estimate. */}
+            <div
+              data-task-body
+              className="relative cursor-text overflow-hidden px-3 py-2"
+              style={showFullText ? undefined : { maxHeight: expandable ? TASK_BODY_MAX - TASK_DISCLOSURE_H : TASK_BODY_MAX }}
+            >
+              <div className="whitespace-pre-wrap break-words text-[12.5px] font-bold leading-[17px] text-primary">{title}</div>
+              {rest.trim() ? (
+                <div className="whitespace-pre-wrap break-words text-[12.5px] leading-[17px] text-secondary">{rest}</div>
+              ) : null}
+              {expandable && !showFullText ? (
+                <div
+                  aria-hidden
+                  data-task-fade
+                  className="pointer-events-none absolute inset-x-0 bottom-0 h-8"
+                  style={{ background: `linear-gradient(to bottom, transparent, ${tone.soft})` }}
+                />
+              ) : null}
+            </div>
+            {expandable ? (
+              <button
+                type="button"
+                data-task-disclosure
+                aria-expanded={showFullText}
+                className="flex h-6 w-full shrink-0 items-center justify-center gap-1 text-[10.5px] font-semibold text-muted hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40"
+                onClick={() => setTextExpanded((value) => !value)}
+              >
+                {showFullText ? <ChevronUp className="h-3 w-3" aria-hidden /> : <ChevronDown className="h-3 w-3" aria-hidden />}
+                {t(showFullText ? "tasks.collapseText" : "tasks.expandText")}
+              </button>
             ) : null}
-          </div>
+          </>
         )}
         {task.source || task.assignments.length ? (
           <div className="flex flex-col gap-1 px-2 pb-2">

--- a/src/components/scheme/agentLinks.test.ts
+++ b/src/components/scheme/agentLinks.test.ts
@@ -2,6 +2,9 @@ import { describe, expect, test } from "bun:test";
 
 import type { Flow, FlowState, Round } from "@/lib/flows/types";
 import type { Pipeline } from "@/lib/pipelines/types";
+import type { FileEntry } from "@/lib/types";
+
+import { resolvePipelineMemberPaths } from "@/components/pipelines/pipelineModel";
 
 import { buildAnchorIndex, currentRound, deckKey, deriveFlowLinks, deriveGroups, derivePipelineLinks, flowLinkKey, flowLinkPhase, groupRect, hueFromId, pipelineRailSegment } from "./agentLinks";
 import type { SchemeRect } from "./layout";
@@ -446,6 +449,37 @@ describe("group overlay derivation (issue #118)", () => {
     } as unknown as Pipeline;
     const specs = deriveGroups([], [pipeline], (key) => (["/build-1", "/build-2"].includes(key) ? key : null));
     expect([...specs[0]!.members].sort()).toEqual(["/build-1", "/build-2"]);
+  });
+
+  test("a stage transcript rotated by an account migration stays inside its pipeline halo (#353)", () => {
+    /* Production shape: the build attempt froze /old at launch; the conversation
+       migrated onto /new ("Continued from «default»"), which is the only node the
+       board draws. Without member-path resolution the halo loses the live
+       generation and it renders as a detached standalone card. */
+    const stale = {
+      id: "p1",
+      state: "running",
+      stages: [
+        { id: "plan", kind: "run", next: "build" },
+        { id: "build", kind: "run", next: null },
+      ],
+      runs: [
+        { stageId: "plan", attempts: [{ agentPath: "/plan", conversationId: null }] },
+        { stageId: "build", attempts: [{ agentPath: "/old", conversationId: "c-build" }] },
+      ],
+    } as unknown as Pipeline;
+    const files = [
+      { path: "/old", conversationId: "c-build", migratedTo: "/new" },
+      { path: "/new", conversationId: "c-build", predecessorPath: "/old" },
+    ] as unknown as FileEntry[];
+    const resolved = resolvePipelineMemberPaths([stale], files);
+    const anchorOf = (key: string) => (["/plan", "/new"].includes(key) ? key : null);
+    expect([...deriveGroups([], resolved, anchorOf)[0]!.members].sort()).toEqual(["/new", "/plan"]);
+    /* The handoff rail reaches the successor node too — the "stage 2/3 shows one
+       conversation" symptom came from this same frozen-path seam. */
+    const links = derivePipelineLinks(resolved, anchorOf);
+    expect(links).toHaveLength(1);
+    expect(links[0]).toMatchObject({ from: "/plan", to: "/new" });
   });
 
   test("closed flows and pipelines produce no group (dissolves on close)", () => {

--- a/src/components/scheme/offscreenClusters.test.ts
+++ b/src/components/scheme/offscreenClusters.test.ts
@@ -46,3 +46,37 @@ describe("offscreen cluster chips", () => {
     expect(reverse).toEqual(forward);
   });
 });
+
+describe("pane-overlap folding (issue #292: navigation chips never cover chat content)", () => {
+  test("a chip whose pill would paint over a conversation pane folds into the edge overflow", () => {
+    /* A focused pane fills the whole viewport — production shape from the
+       rejection screenshot: left-edge task chips floated over the transcript. */
+    const fullPane = { x: 0, y: 0, w: 1_000, h: 700 };
+    const chips = offscreenClusterChips([cluster("left-task", -700, 300)], cam, vp, 4, [fullPane]);
+    expect(chips.visible).toHaveLength(0);
+    expect(chips.overflow.map((chip) => chip.cluster.key)).toEqual(["left-task"]);
+  });
+
+  test("a pane elsewhere on screen leaves a non-overlapping chip visible", () => {
+    /* Pane in the right half; the left-edge chip band stays free. */
+    const rightPane = { x: 500, y: 0, w: 500, h: 700 };
+    const chips = offscreenClusterChips([cluster("left-task", -700, 300)], cam, vp, 4, [rightPane]);
+    expect(chips.visible.map((chip) => chip.cluster.key)).toEqual(["left-task"]);
+    expect(chips.overflow).toHaveLength(0);
+  });
+
+  test("folding respects the camera projection of the obstacle", () => {
+    /* World-space pane at the viewport's left edge only after the camera pans. */
+    const pane = { x: 2_000, y: 0, w: 500, h: 700 };
+    const panned = { x: -2_000, y: 0, z: 1 };
+    const chips = offscreenClusterChips(
+      [cluster("left-task", 1_000, 300)],
+      panned,
+      vp,
+      4,
+      [{ x: pane.x * panned.z + panned.x, y: pane.y, w: pane.w, h: pane.h }],
+    );
+    expect(chips.visible).toHaveLength(0);
+    expect(chips.overflow).toHaveLength(1);
+  });
+});

--- a/src/components/scheme/offscreenClusters.ts
+++ b/src/components/scheme/offscreenClusters.ts
@@ -35,6 +35,18 @@ export interface ClusterChipPartition {
 const intersects = (a: SchemeRect, b: SchemeRect): boolean =>
   a.x < b.x + b.w && a.x + a.w > b.x && a.y < b.y + b.h && a.y + a.h > b.y;
 
+/* The rendered pill's outer bounds (max-w-[240px], min-h-11) resolved from the
+   per-edge CSS transform in EdgeChips, in screen space. Conservative: a shorter
+   label yields a narrower pill inside this box. */
+const CHIP_W = 240;
+const CHIP_H = 44;
+function chipBox(chip: Omit<ClusterChip, "cluster">): SchemeRect {
+  if (chip.edge === "left") return { x: chip.x, y: chip.y - CHIP_H / 2, w: CHIP_W, h: CHIP_H };
+  if (chip.edge === "right") return { x: chip.x - CHIP_W, y: chip.y - CHIP_H / 2, w: CHIP_W, h: CHIP_H };
+  if (chip.edge === "top") return { x: chip.x - CHIP_W / 2, y: chip.y, w: CHIP_W, h: CHIP_H };
+  return { x: chip.x - CHIP_W / 2, y: chip.y - CHIP_H, w: CHIP_W, h: CHIP_H };
+}
+
 function chipAnchor(rect: SchemeRect, cam: Camera, vp: { w: number; h: number }): Omit<ClusterChip, "cluster"> {
   const cx = (rect.x + rect.w / 2) * cam.z + cam.x;
   const cy = (rect.y + rect.h / 2) * cam.z + cam.y;
@@ -53,12 +65,17 @@ function chipAnchor(rect: SchemeRect, cam: Camera, vp: { w: number; h: number })
   return { edge, x: Math.max(pad, Math.min(vp.w - pad, vx + dx * ty)), y: edge === "bottom" ? vp.h - pad : pad };
 }
 
-/** Pure off-screen filtering, ray/edge placement, priority, and per-edge cap. */
+/** Pure off-screen filtering, ray/edge placement, priority, and per-edge cap.
+ * `obstacles` are screen-space boxes of rendered conversation surfaces (panes,
+ * decks): a chip whose pill would paint over one folds into that edge's compact
+ * «+N» disclosure instead — relation/navigation chips must never overlay chat
+ * content (issue #292 production rejection). */
 export function offscreenClusterChips(
   clusters: readonly BoardCluster[],
   cam: Camera,
   vp: { w: number; h: number },
   perEdgeCap = 4,
+  obstacles: readonly SchemeRect[] = [],
 ): ClusterChipPartition {
   const viewport: SchemeRect = { x: -cam.x / cam.z, y: -cam.y / cam.z, w: vp.w / cam.z, h: vp.h / cam.z };
   const sorted = clusters
@@ -70,7 +87,8 @@ export function offscreenClusterChips(
   for (const cluster of sorted) {
     const chip = { cluster, ...chipAnchor(cluster.rect, cam, vp) };
     const count = counts.get(chip.edge) ?? 0;
-    if (count < perEdgeCap) {
+    const box = chipBox(chip);
+    if (count < perEdgeCap && !obstacles.some((obstacle) => intersects(box, obstacle))) {
       visible.push(chip);
       counts.set(chip.edge, count + 1);
     } else {

--- a/src/components/scheme/taskGeometry.test.ts
+++ b/src/components/scheme/taskGeometry.test.ts
@@ -1100,13 +1100,17 @@ describe("taskCardExpandable (issue #292: compact preview + Expand, no internal 
     expect(taskCardExpandable({ text: long })).toBe(true);
   });
 
-  test("the boundary tracks the same wrap simulation as the height estimate", () => {
-    /* 20 hard lines × 17px = 340 — exactly at the cap: not expandable; one more
-       line crosses it. */
-    const atCap = Array.from({ length: 20 }, (_, i) => `l${i}`).join("\n");
-    const pastCap = `${atCap}\nl20`;
-    expect(taskCardExpandable({ text: atCap })).toBe(false);
-    expect(taskCardExpandable({ text: pastCap })).toBe(true);
+  test("the boundary accounts for the body's 16px vertical padding (Finding)", () => {
+    /* The compact clamp is a border-box max-height: the body's py-2 padding
+       (16px) is spent inside TASK_BODY_MAX, so the plain preview holds only
+       19 full hard lines (19 × 17 + 16 = 339 ≤ 340). Exactly 20 hard lines
+       (20 × 17 + 16 = 356 > 340) would clip their last line — they must
+       expose Expand. The pre-fix gate compared bare text height (20 × 17 =
+       340 ≯ 340) and silently clipped line 20 with no fade and no control. */
+    const nineteen = Array.from({ length: 19 }, (_, i) => `l${i}`).join("\n");
+    const twenty = `${nineteen}\nl19`;
+    expect(taskCardExpandable({ text: nineteen })).toBe(false);
+    expect(taskCardExpandable({ text: twenty })).toBe(true);
   });
 
   test("an expandable card's compact height estimate stays capped — the disclosure fits inside it", () => {

--- a/src/components/scheme/taskGeometry.test.ts
+++ b/src/components/scheme/taskGeometry.test.ts
@@ -14,8 +14,10 @@ import {
   routeTaskEdge,
   routeTaskEdges,
   TASK_BODY_MAX,
+  TASK_DISCLOSURE_H,
   TASK_W,
   TASK_WORLD_MARGIN,
+  taskCardExpandable,
   taskCardHeight,
   taskEdgesSignature,
   taskRect,
@@ -1088,5 +1090,31 @@ describe("taskEdgesSignature — poll-stable route cache key (Finding 2)", () =>
     expect(taskEdgesSignature([geom("a", 0, 40, 300, 300)], cards, [])).not.toBe(base);
     expect(taskEdgesSignature(edges, [{ id: "a", x: 80, y: 10, w: 260, h: 100 }], [])).not.toBe(base);
     expect(taskEdgesSignature(edges, cards, [{ x: 0, y: 0, w: 10, h: 10 }])).not.toBe(base);
+  });
+});
+
+describe("taskCardExpandable (issue #292: compact preview + Expand, no internal scroll)", () => {
+  test("short text is not expandable; text past the compact cap is", () => {
+    expect(taskCardExpandable({ text: "one line" })).toBe(false);
+    const long = Array.from({ length: 40 }, (_, i) => `line ${i}`).join("\n");
+    expect(taskCardExpandable({ text: long })).toBe(true);
+  });
+
+  test("the boundary tracks the same wrap simulation as the height estimate", () => {
+    /* 20 hard lines × 17px = 340 — exactly at the cap: not expandable; one more
+       line crosses it. */
+    const atCap = Array.from({ length: 20 }, (_, i) => `l${i}`).join("\n");
+    const pastCap = `${atCap}\nl20`;
+    expect(taskCardExpandable({ text: atCap })).toBe(false);
+    expect(taskCardExpandable({ text: pastCap })).toBe(true);
+  });
+
+  test("an expandable card's compact height estimate stays capped — the disclosure fits inside it", () => {
+    const long = Array.from({ length: 60 }, (_, i) => `line ${i}`).join("\n");
+    const height = taskCardHeight({ text: long, assignments: [], source: undefined });
+    /* strip 6 + capped body 340 + pad 20: the rendered preview (340−24) plus the
+       24px disclosure row exactly fills the same box. */
+    expect(height).toBe(6 + TASK_BODY_MAX + 20);
+    expect(TASK_DISCLOSURE_H).toBe(24);
   });
 });

--- a/src/components/scheme/taskGeometry.ts
+++ b/src/components/scheme/taskGeometry.ts
@@ -56,6 +56,12 @@ const CHARS_PER_LINE = Math.max(1, Math.floor(BODY_CONTENT_W / MAX_GLYPH_W));
    bound for any row count. */
 const CHIP_ROW_H = 28;
 const CHIP_PAD = 8;
+/* The compact body's own vertical padding (py-2 → 8px top + 8px bottom). The
+   preview clamp is a border-box max-height, so this padding lives INSIDE
+   TASK_BODY_MAX and the text itself gets only TASK_BODY_MAX − 16px: exactly 19
+   hard lines (19 × 17 + 16 = 339) fit the plain clamp, while a 20th line
+   crosses it and must expose the disclosure. */
+const BODY_PAD_Y = 16;
 
 /**
  * Worst-case rendered row count for one hard line under `whitespace-pre-wrap` +
@@ -119,13 +125,17 @@ export const TASK_DISCLOSURE_H = 24;
 /**
  * Whether the card's body text can outgrow the compact preview cap — the
  * disclosure gate (issue #292: compact cards clamp with a fade + Expand
- * control; they never scroll internally). Uses the same upper-bound wrap
- * simulation as the height estimate, so a genuinely overflowing card is always
+ * control; they never scroll internally). The clamp is a border-box
+ * max-height, so the body's 16px vertical padding is spent inside it and the
+ * gate compares padded content height — text alone against TASK_BODY_MAX let
+ * an exactly-20-hard-line card (340px of text + 16px padding) clip its last
+ * line with no fade and no Expand. Uses the same upper-bound wrap simulation
+ * as the height estimate, so a genuinely overflowing card is always
  * expandable; a borderline card may offer Expand for text that already fits,
  * which is harmless.
  */
 export function taskCardExpandable(task: Pick<BoardTask, "text">): boolean {
-  return taskTextRows(task.text) * LINE_H > TASK_BODY_MAX;
+  return taskTextRows(task.text) * LINE_H + BODY_PAD_Y > TASK_BODY_MAX;
 }
 
 /**

--- a/src/components/scheme/taskGeometry.ts
+++ b/src/components/scheme/taskGeometry.ts
@@ -18,7 +18,8 @@ export function isPlacedTask(task: BoardTask): task is PlacedTask {
 
 /* Task card geometry in world pixels (docs/design/sticky-notes.md). */
 export const TASK_W = 260;
-/** Body height cap; past it the card body scrolls internally. */
+/** Compact body height cap; past it the preview clamps with a fade and an
+    in-card Expand control (issue #292 — never an internal scrollbar). */
 export const TASK_BODY_MAX = 340;
 const TASK_MIN_H = 64;
 /* Card body geometry: 12.5px text on 17px lines inside 12px (px-3) horizontal
@@ -98,23 +99,45 @@ function hardLineRows(line: string): number {
   return rows;
 }
 
+/* Worst-case rendered row count for the whole body text. Split on every hard
+   break `whitespace-pre-wrap` renders — CRLF, a lone CR, or a lone LF — so a
+   string of standalone `\r`s can't hide extra rendered rows inside one counted
+   line and undercount the height. */
+function taskTextRows(text: string): number {
+  let lines = 0;
+  for (const raw of text.split(/\r\n?|\n/)) {
+    lines += hardLineRows(raw);
+  }
+  return lines;
+}
+
+/** Height of the in-card Expand/Collapse disclosure row (h-6). A compact
+    expandable card reserves this INSIDE the body cap, so its rendered height
+    never exceeds the {@link taskCardHeight} estimate. */
+export const TASK_DISCLOSURE_H = 24;
+
+/**
+ * Whether the card's body text can outgrow the compact preview cap — the
+ * disclosure gate (issue #292: compact cards clamp with a fade + Expand
+ * control; they never scroll internally). Uses the same upper-bound wrap
+ * simulation as the height estimate, so a genuinely overflowing card is always
+ * expandable; a borderline card may offer Expand for text that already fits,
+ * which is harmless.
+ */
+export function taskCardExpandable(task: Pick<BoardTask, "text">): boolean {
+  return taskTextRows(task.text) * LINE_H > TASK_BODY_MAX;
+}
+
 /**
  * Estimated on-board height of a task card: status strip + wrapped text
- * (capped at the internal-scroll threshold) + one chip row per assignment.
+ * (capped at the compact preview threshold) + one chip row per assignment.
  * A conservative upper bound of the rendered card — the wrap simulation counts
  * rows against upper-bound glyph widths and every hard break — so the returned
  * box always contains the rendered card and the collision pass never lets two
  * cards overlap on screen.
  */
 export function taskCardHeight(task: Pick<BoardTask, "text" | "assignments" | "source">): number {
-  let lines = 0;
-  /* Split on every hard break `whitespace-pre-wrap` renders — CRLF, a lone CR,
-     or a lone LF — so a string of standalone `\r`s can't hide extra rendered
-     rows inside one counted line and undercount the height. */
-  for (const raw of task.text.split(/\r\n?|\n/)) {
-    lines += hardLineRows(raw);
-  }
-  const bodyH = Math.min(lines * LINE_H, TASK_BODY_MAX) + PAD_Y;
+  const bodyH = Math.min(taskTextRows(task.text) * LINE_H, TASK_BODY_MAX) + PAD_Y;
   const chipRows = task.assignments.length + (task.source ? 1 : 0);
   const chipsH = chipRows ? chipRows * CHIP_ROW_H + CHIP_PAD : 0;
   return Math.max(TASK_MIN_H, STRIP_H + bodyH + chipsH);

--- a/src/instrumentation.test.ts
+++ b/src/instrumentation.test.ts
@@ -11,7 +11,7 @@ import {
   runStructuredHostStartup,
   scheduleAccountMigrationController,
   viewerReleaseOwnsTraffic,
-} from "./instrumentation";
+} from "@/lib/viewerInstrumentation";
 import { operatorSpawnCapabilityPath } from "@/lib/agent/operatorCapability";
 import { StructuredRuntimeRequirementError } from "@/lib/proc/darwinIdentity";
 import { RuntimeHostUnavailableError } from "@/lib/runtime/client";
@@ -245,4 +245,18 @@ test("unsupported structured runtime aborts server startup", async () => {
   } finally {
     markStructuredHostStartupReady();
   }
+});
+
+test("the instrumentation shim keeps node: imports out of its static graph (dev /api/files 500 regression)", () => {
+  /* Next's dev fallback compiler builds src/instrumentation.ts without
+     node:-scheme support: ANY node: builtin reachable from the entry — a
+     top-level import, a re-export, or a dynamic import outside the statically
+     pruned NEXT_RUNTIME === "nodejs" branch — fails the compile and 500s every
+     request. The node-side runtime lives in @/lib/viewerInstrumentation and may
+     only be reached through the guarded dynamic import. */
+  const source = fs.readFileSync(new URL("./instrumentation.ts", import.meta.url), "utf8");
+  expect(source).not.toMatch(/from\s+["']node:/);
+  expect(source).not.toMatch(/^\s*import\s[^(]*viewerInstrumentation/m);
+  expect(source).not.toMatch(/^\s*export\s.*\sfrom\s/m);
+  expect(source).toMatch(/NEXT_RUNTIME === "nodejs"/);
 });

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -1,163 +1,17 @@
-import fs from "node:fs";
-
-import { statePath } from "@/lib/configDir";
-import { RuntimeHostUnavailableError } from "@/lib/runtime/client";
-import { markStructuredHostStartupFailed, markStructuredHostStartupReady } from "@/lib/runtime/startupStatus";
-import { StructuredRuntimeRequirementError } from "@/lib/proc/darwinIdentity";
-
-const RELEASE_ACTIVATION_POLL_MS = 250;
-
-interface ActivationTimer {
-  unref?(): unknown;
-}
-
-interface StructuredHostStartupOptions {
-  schedule?: (callback: () => void, delayMs: number) => ActivationTimer;
-  initialRetryMs?: number;
-  maxRetryMs?: number;
-}
-
-interface ViewerReleaseActivationOptions {
-  pollMs?: number;
-  schedule?: (callback: () => void, delayMs: number) => ActivationTimer;
-  log?: (...args: unknown[]) => void;
-}
-
-/** Candidate containers share production state while their health gate runs.
- * The durable proxy target grants authority to the endpoint currently serving
- * traffic. A missing target keeps local development and first boot active. */
-export function viewerReleaseOwnsTraffic(
-  env: Readonly<Record<string, string | undefined>> = process.env,
-  readTarget: () => string = () => fs.readFileSync(statePath("viewer-release.json"), "utf8"),
-): boolean {
-  const port = env.PORT?.trim();
-  if (!port) return true;
-  let raw: string;
-  try {
-    raw = readTarget();
-  } catch (error) {
-    return (error as NodeJS.ErrnoException).code === "ENOENT";
-  }
-  try {
-    const target = JSON.parse(raw) as { endpoint?: unknown };
-    if (typeof target.endpoint !== "string") return false;
-    return new URL(target.endpoint).port === port;
-  } catch {
-    return false;
-  }
-}
-
-/** Run stateful startup immediately for the current release. A deployment
- * candidate polls the durable target and activates once promotion appoints it. */
-export async function activateViewerRuntimeWhenCurrent(
-  activate: () => Promise<void>,
-  isCurrent: () => boolean,
-  options: ViewerReleaseActivationOptions = {},
-): Promise<void> {
-  const pollMs = options.pollMs ?? RELEASE_ACTIVATION_POLL_MS;
-  const schedule = options.schedule ?? ((callback, delayMs) => setTimeout(callback, delayMs));
-  const log = options.log ?? console.error;
-  let started = false;
-  const start = async () => {
-    if (started) return;
-    started = true;
-    await activate();
-  };
-  if (isCurrent()) {
-    await start();
-    return;
-  }
-  const poll = () => {
-    if (started) return;
-    if (!isCurrent()) {
-      schedule(poll, pollMs).unref?.();
-      return;
-    }
-    void start().catch((error) => log("[viewer release] deferred runtime activation failed", error));
-  };
-  schedule(poll, pollMs).unref?.();
-}
-
-export function accountControllerDelayMs(env: Readonly<Record<string, string | undefined>> = process.env): number {
-  const configured = Number(env.LLV_ACCOUNT_CONTROLLER_DELAY_MS ?? 0);
-  return Number.isFinite(configured) ? Math.max(0, configured) : 0;
-}
-
-export function scheduleAccountMigrationController(start: () => Promise<void>, delayMs: number): void {
-  const run = () => {
-    start().catch((error) => { console.error("[account migration controller] initial durable reconciliation failed", error); });
-  };
-  const timer = setTimeout(() => {
-    if (delayMs > 0) run();
-    // A second zero-delay timer gives already queued readiness probes a turn.
-    else setTimeout(run, 0).unref?.();
-  }, delayMs);
-  timer.unref?.();
-}
-
-export async function initializeOperatorSpawnCapabilityAtStartup(
-  env: Readonly<Record<string, string | undefined>> = process.env,
-): Promise<void> {
-  const { ensureOperatorSpawnCapability, rotateOperatorSpawnCapability } = await import("@/lib/agent/operatorCapability");
-  if (env.LLV_ROTATE_OPERATOR_SPAWN_CAPABILITY === "1") rotateOperatorSpawnCapability();
-  else ensureOperatorSpawnCapability();
-}
-
-export async function runStructuredHostStartup(
-  adopt: () => Promise<unknown>,
-  log: (...args: unknown[]) => void = console.error,
-  options: StructuredHostStartupOptions = {},
-): Promise<void> {
-  const schedule = options.schedule ?? ((callback, delayMs) => setTimeout(callback, delayMs));
-  const maxRetryMs = options.maxRetryMs ?? 1_000;
-  let retryMs = options.initialRetryMs ?? 100;
-  let retryPending = false;
-  let attempts = 0;
-
-  const attempt = async (): Promise<void> => {
-    attempts += 1;
-    try {
-      await adopt();
-      markStructuredHostStartupReady();
-      if (attempts > 1) log("[structured hosts] startup adoption recovered", { attempts });
-    } catch (error) {
-      markStructuredHostStartupFailed();
-      if (error instanceof StructuredRuntimeRequirementError) {
-        log("[structured hosts] startup adoption failed", error);
-        throw error;
-      }
-      if (!(error instanceof RuntimeHostUnavailableError)) {
-        log("[structured hosts] startup adoption failed", error);
-        return;
-      }
-      if (retryPending) return;
-      const delayMs = retryMs;
-      retryMs = Math.min(retryMs * 2, maxRetryMs);
-      retryPending = true;
-      if (attempts === 1) log("[structured hosts] startup adoption failed; retry scheduled", error);
-      schedule(() => {
-        retryPending = false;
-        void attempt().catch((retryError) => {
-          log("[structured hosts] startup adoption retry aborted", retryError);
-        });
-      }, delayMs).unref?.();
-    }
-  };
-
-  await attempt();
-}
-
+/*
+ * Thin Next.js instrumentation shim. This entry is compiled by EVERY dev
+ * compiler — including the pages fallback compiler, which has no node:-scheme
+ * support — so it must not reach any node: builtin, statically or dynamically,
+ * outside the branch below. Webpack substitutes `process.env.NEXT_RUNTIME` per
+ * compiler and prunes the statically-false branch at parse time (an early
+ * `return` does NOT prune — dev builds run no minifier DCE), which is what
+ * keeps `@/lib/viewerInstrumentation`'s node imports out of the fallback
+ * compile. Regression symptom when broken: `UnhandledSchemeError: Reading from
+ * "node:fs" …` at dev boot and a 500 on every request (local QA /api/files).
+ */
 export async function register(): Promise<void> {
-  if (process.env.NEXT_RUNTIME === "edge" || process.env.NEXT_PHASE?.includes("build")) return;
-  await activateViewerRuntimeWhenCurrent(async () => {
-    await initializeOperatorSpawnCapabilityAtStartup();
-    if (process.env.LLV_STRUCTURED_HOSTS === "1") {
-      const { adoptStructuredHostsAtStartup } = await import("@/lib/runtime/startup");
-      await runStructuredHostStartup(adoptStructuredHostsAtStartup);
-    }
-    if (process.env.LLV_ACCOUNT_CONTROLLER_DISABLED !== "1") {
-      const { startAccountMigrationController } = await import("@/lib/accounts/migration/controller");
-      scheduleAccountMigrationController(startAccountMigrationController, accountControllerDelayMs());
-    }
-  }, () => viewerReleaseOwnsTraffic());
+  if (process.env.NEXT_RUNTIME === "nodejs" && !process.env.NEXT_PHASE?.includes("build")) {
+    const { registerViewerRuntime } = await import("@/lib/viewerInstrumentation");
+    await registerViewerRuntime();
+  }
 }

--- a/src/lib/accounts/identity.ts
+++ b/src/lib/accounts/identity.ts
@@ -123,6 +123,35 @@ export function resolveConversationTarget(files: FileEntry[], hash: Conversation
 }
 
 /**
+ * The transcript path that CURRENTLY hosts a durable member record (a pipeline
+ * stage attempt, a flow implementer, a review round). Durable records freeze the
+ * path known at launch; an account migration rotates the conversation onto a new
+ * transcript, and every board adapter that keeps matching the frozen path stops
+ * claiming the live generation — it resurfaces as a detached standalone card
+ * (issues #325/#353). Resolution: the stored conversation id's current
+ * generation wins; a recorded path that became an archived predecessor redirects
+ * through its own conversation id; otherwise the recorded path stands (also when
+ * the current generation has left the scan — the caller's renderable gates
+ * handle absence).
+ */
+export function currentMemberPath(
+  path: string | null,
+  conversationId: string | null | undefined,
+  files: readonly FileEntry[],
+): string | null {
+  if (conversationId) {
+    const current = currentConversationFile(files, conversationId);
+    if (current) return current.path;
+  }
+  if (!path) return path;
+  const recorded = files.find((file) => file.path === path);
+  if (recorded && isArchivedPredecessor(recorded) && recorded.conversationId) {
+    return currentConversationFile(files, recorded.conversationId)?.path ?? path;
+  }
+  return path;
+}
+
+/**
  * Filters archived predecessors out of a board/switchboard/attention list so a
  * migrated conversation shows as exactly one card (its current generation).
  * A no-op on pre-migration payloads.

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -954,6 +954,7 @@ export const en = {
   "pipelineStrip.roundShort": "R{n}",
   "pipelineStrip.attemptSuffix": "×{n}",
   "pipelineStrip.chipAria": "Stage {label}: {state}",
+  "pipelineStrip.compactChipAria": "{label}, {state}",
   "pipelineStrip.stageOf": "stage {k}/{n}",
 
   // pipeline stage placeholders + template picker (#196)
@@ -1041,6 +1042,8 @@ export const en = {
   "pipelineMobile.prevStage": "Previous stage {label}, state {state}",
   "pipelineMobile.nextStage": "Next stage {label}, state {state}",
   "pipelineMobile.openVerdict": "Open verdict for {label}, state {state}",
+  "pipelineMobile.expandDock": "Expand pipeline {task}",
+  "pipelineMobile.collapseDock": "Collapse pipeline {task}",
 
   "wfDraft.paneAria": "Draft of a new workflow",
   "wfDraft.notStarted": "the workflow is not launched yet",
@@ -1360,6 +1363,8 @@ export const en = {
   "tasks.attachCount": { one: "{count} image", other: "{count} images" },
   "tasks.draftDiscarded": "draft discarded",
   "tasks.editAria": "Task text",
+  "tasks.expandText": "Expand",
+  "tasks.collapseText": "Collapse",
   "tasks.spawning": "starting…",
   "tasks.deadChip": "the conversation is gone from the list",
   "tasks.source": "source",

--- a/src/lib/i18n/uk.ts
+++ b/src/lib/i18n/uk.ts
@@ -927,6 +927,7 @@ export const uk: Record<keyof typeof en, Message> = {
   "pipelineStrip.roundShort": "Р{n}",
   "pipelineStrip.attemptSuffix": "×{n}",
   "pipelineStrip.chipAria": "Етап {label}: {state}",
+  "pipelineStrip.compactChipAria": "{label}, {state}",
   "pipelineStrip.stageOf": "етап {k}/{n}",
 
   // плейсхолдери етапів пайплайна + вибір шаблону (#196)
@@ -1014,6 +1015,8 @@ export const uk: Record<keyof typeof en, Message> = {
   "pipelineMobile.prevStage": "Попередній етап {label}, стан: {state}",
   "pipelineMobile.nextStage": "Наступний етап {label}, стан: {state}",
   "pipelineMobile.openVerdict": "Відкрити вердикт для {label}, стан: {state}",
+  "pipelineMobile.expandDock": "Розгорнути пайплайн {task}",
+  "pipelineMobile.collapseDock": "Згорнути пайплайн {task}",
 
   "wfDraft.paneAria": "Чернетка нового воркфлоу",
   "wfDraft.notStarted": "воркфлоу ще не запущений",
@@ -1318,6 +1321,8 @@ export const uk: Record<keyof typeof en, Message> = {
   "tasks.attachCount": { one: "{count} зображення", other: "{count} зображень" },
   "tasks.draftDiscarded": "чернетку відкинуто",
   "tasks.editAria": "Текст задачі",
+  "tasks.expandText": "Розгорнути",
+  "tasks.collapseText": "Згорнути",
   "tasks.spawning": "запускається…",
   "tasks.deadChip": "розмови вже немає у списку",
   "tasks.source": "джерело",

--- a/src/lib/runtime/startup.test.ts
+++ b/src/lib/runtime/startup.test.ts
@@ -8,7 +8,7 @@ import { drainHeldDeliveries } from "@/lib/accounts/migration/coordinator";
 import { AgentRegistry } from "@/lib/agent/registry";
 import { turnStateFromRecords } from "@/lib/scanner/activity";
 import { RuntimeJournal } from "@/runtime-host/journal";
-import { runStructuredHostStartup } from "@/instrumentation";
+import { runStructuredHostStartup } from "@/lib/viewerInstrumentation";
 
 import { RuntimeHostUnavailableError, type RuntimeHostClient } from "./client";
 import { bindStructuredDeliveryQueue, hasStructuredDeliveryHost } from "./structuredDeliveryController";

--- a/src/lib/viewerInstrumentation.ts
+++ b/src/lib/viewerInstrumentation.ts
@@ -1,0 +1,173 @@
+import fs from "node:fs";
+
+import { statePath } from "@/lib/configDir";
+import { RuntimeHostUnavailableError } from "@/lib/runtime/client";
+import { markStructuredHostStartupFailed, markStructuredHostStartupReady } from "@/lib/runtime/startupStatus";
+import { StructuredRuntimeRequirementError } from "@/lib/proc/darwinIdentity";
+
+/*
+ * The Viewer's node-side startup runtime. This module (and everything it pulls
+ * in — node: builtins included) must stay OUT of `src/instrumentation.ts`:
+ * Next's dev fallback compiler builds that entry without node:-scheme support,
+ * so any node: import reachable from it fails the compile and 500s every
+ * request (the local QA `/api/files` regression). `register()` reaches this
+ * module only through a dynamic import inside a statically-pruned
+ * `NEXT_RUNTIME === "nodejs"` branch.
+ */
+
+const RELEASE_ACTIVATION_POLL_MS = 250;
+
+interface ActivationTimer {
+  unref?(): unknown;
+}
+
+interface StructuredHostStartupOptions {
+  schedule?: (callback: () => void, delayMs: number) => ActivationTimer;
+  initialRetryMs?: number;
+  maxRetryMs?: number;
+}
+
+interface ViewerReleaseActivationOptions {
+  pollMs?: number;
+  schedule?: (callback: () => void, delayMs: number) => ActivationTimer;
+  log?: (...args: unknown[]) => void;
+}
+
+/** Candidate containers share production state while their health gate runs.
+ * The durable proxy target grants authority to the endpoint currently serving
+ * traffic. A missing target keeps local development and first boot active. */
+export function viewerReleaseOwnsTraffic(
+  env: Readonly<Record<string, string | undefined>> = process.env,
+  readTarget: () => string = () => fs.readFileSync(statePath("viewer-release.json"), "utf8"),
+): boolean {
+  const port = env.PORT?.trim();
+  if (!port) return true;
+  let raw: string;
+  try {
+    raw = readTarget();
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code === "ENOENT";
+  }
+  try {
+    const target = JSON.parse(raw) as { endpoint?: unknown };
+    if (typeof target.endpoint !== "string") return false;
+    return new URL(target.endpoint).port === port;
+  } catch {
+    return false;
+  }
+}
+
+/** Run stateful startup immediately for the current release. A deployment
+ * candidate polls the durable target and activates once promotion appoints it. */
+export async function activateViewerRuntimeWhenCurrent(
+  activate: () => Promise<void>,
+  isCurrent: () => boolean,
+  options: ViewerReleaseActivationOptions = {},
+): Promise<void> {
+  const pollMs = options.pollMs ?? RELEASE_ACTIVATION_POLL_MS;
+  const schedule = options.schedule ?? ((callback, delayMs) => setTimeout(callback, delayMs));
+  const log = options.log ?? console.error;
+  let started = false;
+  const start = async () => {
+    if (started) return;
+    started = true;
+    await activate();
+  };
+  if (isCurrent()) {
+    await start();
+    return;
+  }
+  const poll = () => {
+    if (started) return;
+    if (!isCurrent()) {
+      schedule(poll, pollMs).unref?.();
+      return;
+    }
+    void start().catch((error) => log("[viewer release] deferred runtime activation failed", error));
+  };
+  schedule(poll, pollMs).unref?.();
+}
+
+export function accountControllerDelayMs(env: Readonly<Record<string, string | undefined>> = process.env): number {
+  const configured = Number(env.LLV_ACCOUNT_CONTROLLER_DELAY_MS ?? 0);
+  return Number.isFinite(configured) ? Math.max(0, configured) : 0;
+}
+
+export function scheduleAccountMigrationController(start: () => Promise<void>, delayMs: number): void {
+  const run = () => {
+    start().catch((error) => { console.error("[account migration controller] initial durable reconciliation failed", error); });
+  };
+  const timer = setTimeout(() => {
+    if (delayMs > 0) run();
+    // A second zero-delay timer gives already queued readiness probes a turn.
+    else setTimeout(run, 0).unref?.();
+  }, delayMs);
+  timer.unref?.();
+}
+
+export async function initializeOperatorSpawnCapabilityAtStartup(
+  env: Readonly<Record<string, string | undefined>> = process.env,
+): Promise<void> {
+  const { ensureOperatorSpawnCapability, rotateOperatorSpawnCapability } = await import("@/lib/agent/operatorCapability");
+  if (env.LLV_ROTATE_OPERATOR_SPAWN_CAPABILITY === "1") rotateOperatorSpawnCapability();
+  else ensureOperatorSpawnCapability();
+}
+
+export async function runStructuredHostStartup(
+  adopt: () => Promise<unknown>,
+  log: (...args: unknown[]) => void = console.error,
+  options: StructuredHostStartupOptions = {},
+): Promise<void> {
+  const schedule = options.schedule ?? ((callback, delayMs) => setTimeout(callback, delayMs));
+  const maxRetryMs = options.maxRetryMs ?? 1_000;
+  let retryMs = options.initialRetryMs ?? 100;
+  let retryPending = false;
+  let attempts = 0;
+
+  const attempt = async (): Promise<void> => {
+    attempts += 1;
+    try {
+      await adopt();
+      markStructuredHostStartupReady();
+      if (attempts > 1) log("[structured hosts] startup adoption recovered", { attempts });
+    } catch (error) {
+      markStructuredHostStartupFailed();
+      if (error instanceof StructuredRuntimeRequirementError) {
+        log("[structured hosts] startup adoption failed", error);
+        throw error;
+      }
+      if (!(error instanceof RuntimeHostUnavailableError)) {
+        log("[structured hosts] startup adoption failed", error);
+        return;
+      }
+      if (retryPending) return;
+      const delayMs = retryMs;
+      retryMs = Math.min(retryMs * 2, maxRetryMs);
+      retryPending = true;
+      if (attempts === 1) log("[structured hosts] startup adoption failed; retry scheduled", error);
+      schedule(() => {
+        retryPending = false;
+        void attempt().catch((retryError) => {
+          log("[structured hosts] startup adoption retry aborted", retryError);
+        });
+      }, delayMs).unref?.();
+    }
+  };
+
+  await attempt();
+}
+
+/** The full node-runtime startup sequence `src/instrumentation.ts` defers to. */
+export async function registerViewerRuntime(): Promise<void> {
+  await activateViewerRuntimeWhenCurrent(async () => {
+    await initializeOperatorSpawnCapabilityAtStartup();
+    if (process.env.LLV_STRUCTURED_HOSTS === "1") {
+      const { adoptStructuredHostsAtStartup } = await import("@/lib/runtime/startup");
+      await runStructuredHostStartup(adoptStructuredHostsAtStartup);
+    }
+    if (process.env.LLV_ACCOUNT_CONTROLLER_DISABLED !== "1") {
+      const { startAccountMigrationController } = await import("@/lib/accounts/migration/controller");
+      scheduleAccountMigrationController(startAccountMigrationController, accountControllerDelayMs());
+    }
+  }, () => viewerReleaseOwnsTraffic());
+}


### PR DESCRIPTION
## Summary

- contain pipeline controls and member cards on 390px mobile layouts while preserving chat space
- claim builder and reviewer conversations into their pipeline/review deck after account migration
- add bidirectional task/conversation navigation and compact task disclosure with fade plus Expand
- isolate viewer instrumentation from browser bundles
- repair the exact 19-line compact boundary so every 20-line card exposes disclosure

## Verification

- focused mobile, pipeline, flow, task-card, geometry, offscreen-cluster, and instrumentation suites
- bunx tsc --noEmit
- changed-file ESLint
- production build
- full suite compared against the e2d0abf5 baseline

Fresh Fable review is running on exact head f8aa42dc.

Closes #156