### PR TITLE
#372: preserve delivered structured-kill HTTP outcomes

### DIFF
--- a/src/app/api/tmux/route.test.ts
+++ b/src/app/api/tmux/route.test.ts
@@ -43,6 +43,7 @@ let delivery: (message: unknown) => Promise<{ ok: true; outcome: "delivered-to-l
   target: "agents:4.0",
 });
 let killOutcome: { ok: true; target: string } | { ok: false; outcome: "failed"; error: string; status: number } = { ok: true, target: "agents:4.0" };
+let killCalls = 0;
 let structuredControlCalls = 0;
 let interruptCalls = 0;
 let structuredMessageCalls = 0;
@@ -54,6 +55,7 @@ let structuredMessageResult:
   | { ok: true; structured: true; target: string; outcome: "queued"; operationId: string; receipt: { operationId: string; status: "queued" } }
   | null = null;
 let structuredControlResult:
+  | { status: 200; body: { ok: true; structured: true; target: string; outcome: "delivered" } }
   | { status: 202; body: { ok: true; structured: true; target: string; operationId: string; receipt: { operationId: string; status: string } } }
   | { status: 409; body: { error: string } }
   | null = null;
@@ -108,7 +110,10 @@ mock.module("@/lib/delivery", () => ({
     interruptCalls += 1;
     return { ok: true, target: "" };
   },
-  killConversation: async () => killOutcome,
+  killConversation: async () => {
+    killCalls += 1;
+    return killOutcome;
+  },
   livePaneTarget: async () => null,
   reconfigureConversation: async () => ({ ok: true, outcome: "reconfigured", target: "agents:4.0" }),
   resumeConversation: async () => ({ ok: true, target: "" }),
@@ -388,6 +393,38 @@ test("/api/tmux admits pane-less kill through the structured control path", asyn
       receipt: { status: "queued" },
     });
     expect(structuredControlCalls).toBe(1);
+  } finally {
+    structuredControlResult = null;
+    if (previous === undefined) delete process.env.LLV_STRUCTURED_HOSTS;
+    else process.env.LLV_STRUCTURED_HOSTS = previous;
+  }
+});
+
+test("/api/tmux keeps a conversation-id kill on the structured outcome without legacy fallthrough", async () => {
+  const previous = process.env.LLV_STRUCTURED_HOSTS;
+  structuredControlCalls = 0;
+  killCalls = 0;
+  structuredControlResult = {
+    status: 200,
+    body: {
+      ok: true,
+      structured: true,
+      target: "conversation_dead-replay",
+      outcome: "delivered",
+    },
+  };
+  try {
+    process.env.LLV_STRUCTURED_HOSTS = "1";
+    const response = await POST(post({ conversationId: "conversation_dead-replay", action: "kill" }));
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      ok: true,
+      structured: true,
+      target: "conversation_dead-replay",
+      outcome: "delivered",
+    });
+    expect(structuredControlCalls).toBe(1);
+    expect(killCalls).toBe(0);
   } finally {
     structuredControlResult = null;
     if (previous === undefined) delete process.env.LLV_STRUCTURED_HOSTS;

--- a/src/lib/runtime/structuredControls.test.ts
+++ b/src/lib/runtime/structuredControls.test.ts
@@ -7,17 +7,25 @@ import { afterAll, expect, test } from "bun:test";
 
 import { AgentRegistry } from "@/lib/agent/registry";
 
-import type { RuntimeHostClient } from "./client";
+import { RuntimeHostUnavailableError, type RuntimeHostClient } from "./client";
 import { dispatchStructuredControl } from "./structuredControls";
 
 const sandbox = fs.mkdtempSync(path.join(os.tmpdir(), "llv-structured-controls-"));
 afterAll(() => fs.rmSync(sandbox, { recursive: true, force: true }));
 
-function structuredConversation(): { registry: AgentRegistry; path: string; conversationId: string } {
+function structuredConversation(
+  options: { parentConversationId?: `conversation_${string}`; registry?: AgentRegistry } = {},
+): { registry: AgentRegistry; path: string; conversationId: string } {
   const id = crypto.randomUUID();
   const pathname = path.join(sandbox, `${id}.jsonl`);
-  const registry = new AgentRegistry(path.join(sandbox, `${id}.registry.json`), undefined, undefined, { sqliteMode: "off" });
-  const begun = registry.beginSpawnRequest({ engine: "codex", cwd: sandbox, accountId: "codex-subscription" });
+  const registry = options.registry
+    ?? new AgentRegistry(path.join(sandbox, `${id}.registry.json`), undefined, undefined, { sqliteMode: "off" });
+  const begun = registry.beginSpawnRequest({
+    engine: "codex",
+    cwd: sandbox,
+    accountId: "codex-subscription",
+    ...(options.parentConversationId ? { parentConversationId: options.parentConversationId } : {}),
+  });
   if (begun.kind !== "created") throw new Error("spawn receipt was unavailable");
   const settled = registry.settleSpawn(begun.receipt.launchId, {
     key: { engine: "codex", sessionId: id },
@@ -150,6 +158,180 @@ test("structured kill enters the durable runtime command channel", async () => {
     sessionKey: { engine: "codex", sessionId: expect.any(String) },
   }]);
   expect(kicks).toBe(1);
+});
+
+function terminateStructuredFixture(fixture: { registry: AgentRegistry; conversationId: string }): void {
+  const conversation = fixture.registry.conversation(fixture.conversationId as `conversation_${string}`)!;
+  const generation = conversation.generations.at(-1)!;
+  fixture.registry.terminateStructuredHost({ engine: conversation.engine, sessionId: generation.id });
+}
+
+test("structured kill addressed by conversationId enters the durable command channel", async () => {
+  const fixture = structuredConversation();
+  const commands: unknown[] = [];
+  const client = {
+    command: async (command: unknown) => {
+      commands.push(command);
+      return { operationId: "kill-by-id", receipt: { operationId: "kill-by-id", status: "queued" }, replayed: false };
+    },
+  } as unknown as RuntimeHostClient;
+
+  const result = await dispatchStructuredControl({ path: "", conversationId: fixture.conversationId, action: "kill" }, {
+    registry: fixture.registry,
+    client,
+    operationId: () => "kill-by-id",
+    kick: () => {},
+    enabled: () => true,
+  });
+
+  expect(result).toMatchObject({ status: 202, body: { ok: true, structured: true, target: fixture.conversationId } });
+  expect(commands).toEqual([{
+    kind: "kill",
+    operationId: "kill-by-id",
+    idempotencyKey: "kill-by-id",
+    conversationId: fixture.conversationId,
+    sessionKey: { engine: "codex", sessionId: expect.any(String) },
+  }]);
+});
+
+test("a delivered kill receipt resolves as a terminal success, not a failure", async () => {
+  const fixture = structuredConversation();
+  const client = {
+    command: async () => ({
+      operationId: "kill-delivered",
+      receipt: { operationId: "kill-delivered", status: "delivered" },
+      replayed: true,
+    }),
+  } as unknown as RuntimeHostClient;
+
+  const result = await dispatchStructuredControl({ path: fixture.path, conversationId: "", action: "kill" }, {
+    registry: fixture.registry,
+    client,
+    operationId: () => "kill-delivered",
+    kick: () => {},
+    enabled: () => true,
+  });
+
+  expect(result).toMatchObject({
+    status: 200,
+    body: { ok: true, structured: true, target: fixture.conversationId, receipt: { status: "delivered" } },
+  });
+});
+
+test("a kill transport timeout after journal admission reports the durable receipt", async () => {
+  const fixture = structuredConversation();
+  const probes: string[] = [];
+  let kicks = 0;
+  const client = {
+    command: async () => {
+      throw new RuntimeHostUnavailableError("runtime host request timed out");
+    },
+    operationStatus: async (operationId: string) => {
+      probes.push(operationId);
+      return {
+        operationId,
+        receipt: { operationId, status: "delivered", conversationId: fixture.conversationId },
+        replayed: true,
+      };
+    },
+  } as unknown as RuntimeHostClient;
+
+  const result = await dispatchStructuredControl({ path: "", conversationId: fixture.conversationId, action: "kill" }, {
+    registry: fixture.registry,
+    client,
+    operationId: () => "kill-timeout",
+    kick: () => { kicks += 1; },
+    enabled: () => true,
+  });
+
+  expect(probes).toEqual(["kill-timeout"]);
+  expect(kicks).toBe(1);
+  expect(result).toMatchObject({
+    status: 200,
+    body: { ok: true, structured: true, target: fixture.conversationId, operationId: "kill-timeout", receipt: { status: "delivered" } },
+  });
+});
+
+test("a kill transport timeout with no durable record stays a retryable failure", async () => {
+  const fixture = structuredConversation();
+  const client = {
+    command: async () => {
+      throw new RuntimeHostUnavailableError("runtime host request timed out");
+    },
+    operationStatus: async () => null,
+  } as unknown as RuntimeHostClient;
+
+  const result = await dispatchStructuredControl({ path: fixture.path, conversationId: "", action: "kill" }, {
+    registry: fixture.registry,
+    client,
+    operationId: () => "kill-lost",
+    kick: () => {},
+    enabled: () => true,
+  });
+
+  expect(result).toEqual({ status: 503, body: { error: "runtime host request timed out" } });
+});
+
+test("a dead structured session replays its terminal kill outcome for path callers", async () => {
+  const fixture = structuredConversation();
+  terminateStructuredFixture(fixture);
+
+  const result = await dispatchStructuredControl({ path: fixture.path, conversationId: "", action: "kill" }, {
+    registry: fixture.registry,
+    client: null,
+    enabled: () => true,
+  });
+
+  expect(result).toEqual({
+    status: 200,
+    body: { ok: true, structured: true, target: fixture.conversationId, outcome: "delivered" },
+  });
+});
+
+test("a dead structured session replays its terminal kill outcome for conversation-id callers", async () => {
+  const fixture = structuredConversation();
+  terminateStructuredFixture(fixture);
+
+  const result = await dispatchStructuredControl({ path: "", conversationId: fixture.conversationId, action: "kill" }, {
+    registry: fixture.registry,
+    client: null,
+    enabled: () => true,
+  });
+
+  expect(result).toEqual({
+    status: 200,
+    body: { ok: true, structured: true, target: fixture.conversationId, outcome: "delivered" },
+  });
+});
+
+test("a dead structured branch replays terminal kill without branch/root pane failures", async () => {
+  const root = structuredConversation();
+  const branch = structuredConversation({
+    registry: root.registry,
+    parentConversationId: root.conversationId as `conversation_${string}`,
+  });
+  terminateStructuredFixture(branch);
+  terminateStructuredFixture(root);
+
+  const branchResult = await dispatchStructuredControl({ path: branch.path, conversationId: "", action: "kill" }, {
+    registry: root.registry,
+    client: null,
+    enabled: () => true,
+  });
+  const rootResult = await dispatchStructuredControl({ path: "", conversationId: root.conversationId, action: "kill" }, {
+    registry: root.registry,
+    client: null,
+    enabled: () => true,
+  });
+
+  expect(branchResult).toEqual({
+    status: 200,
+    body: { ok: true, structured: true, target: branch.conversationId, outcome: "delivered" },
+  });
+  expect(rootResult).toEqual({
+    status: 200,
+    body: { ok: true, structured: true, target: root.conversationId, outcome: "delivered" },
+  });
 });
 
 test("disabled structured hosting leaves persisted ownership on the legacy control path", async () => {

--- a/src/lib/runtime/structuredControls.ts
+++ b/src/lib/runtime/structuredControls.ts
@@ -1,12 +1,13 @@
 import { agentRegistry, type AgentRegistry } from "@/lib/agent/registry";
 import { sessionKeyId } from "@/lib/agent/sessionKey";
 
-import { runtimeHostClient, type RuntimeHostClient } from "./client";
+import { isRuntimeHostTransportFailure, runtimeHostClient, type RuntimeHostClient } from "./client";
 import { newOperationId } from "./contracts";
 import { kickStructuredDeliveryQueue } from "./structuredDeliverySignal";
 
 export type StructuredControlResult =
-  | { status: 202; body: { ok: true; structured: true; target: string; operationId: string; receipt: { operationId: string; status: string } } }
+  | { status: 200; body: { ok: true; structured: true; target: string; outcome: "delivered" } }
+  | { status: 200 | 202; body: { ok: true; structured: true; target: string; operationId: string; receipt: { operationId: string; status: string } } }
   | { status: 409 | 503; body: { error: string } };
 
 export interface StructuredControlRequest {
@@ -36,7 +37,14 @@ export async function dispatchStructuredControl(
   const generation = conversation?.generations.at(-1);
   if (!conversation || !generation) return null;
   const entry = registry.snapshot().entries[sessionKeyId({ engine: conversation.engine, sessionId: generation.id })];
-  if (!entry?.structuredHost) return null;
+  if (!entry) return null;
+  /* A delivered kill tears the structuredHost column down, so kill ownership
+     must outlive it: once a conversation has no legacy tmux pane, its kill
+     stays on the structured channel. Falling through to the legacy pane-close
+     ladder here is what turned a durably delivered kill into path-required
+     and branch/root failures (#372). */
+  const structuredKill = request.action === "kill" && !entry.host;
+  if (!entry.structuredHost && !structuredKill) return null;
 
   if (request.action !== "interrupt" && request.action !== "kill") {
     if (request.action === "resume" && (entry.status === "dead" || entry.status === "unhosted")) {
@@ -48,10 +56,19 @@ export async function dispatchStructuredControl(
     return { status: 409, body: { error: `structured host does not support the ${label} control` } };
   }
 
+  if (structuredKill
+    && !entry.structuredHost?.process
+    && (entry.status === "dead" || entry.status === "unhosted")) {
+    /* The durable projection already records this session as torn down, so a
+       repeated kill replays the terminal outcome instead of re-entering the
+       command channel or the legacy pane-close ladder. */
+    return { status: 200, body: { ok: true, structured: true, target: conversation.id, outcome: "delivered" } };
+  }
+
   const client = dependencies.client === undefined ? runtimeHostClient() : dependencies.client;
   if (!client) return { status: 503, body: { error: "structured runtime host is unavailable" } };
+  const operationId = (dependencies.operationId ?? newOperationId)();
   try {
-    const operationId = (dependencies.operationId ?? newOperationId)();
     const result = await client.command(request.action === "kill"
       ? {
           kind: "kill",
@@ -65,11 +82,11 @@ export async function dispatchStructuredControl(
           operationId,
           idempotencyKey: operationId,
           conversationId: conversation.id,
-          turnId: entry.structuredHost.activeTurnRef,
+          turnId: entry.structuredHost?.activeTurnRef ?? null,
         });
     (dependencies.kick ?? kickStructuredDeliveryQueue)();
     return {
-      status: 202,
+      status: result.receipt.status === "delivered" ? 200 : 202,
       body: {
         ok: true,
         structured: true,
@@ -79,6 +96,25 @@ export async function dispatchStructuredControl(
       },
     };
   } catch (error) {
+    if (request.action === "kill" && isRuntimeHostTransportFailure(error)) {
+      /* The socket failed after the command may have reached the journal. The
+         durable receipt, not the transport, decides the outcome of a kill:
+         once admitted or delivered, structured control owns the response. */
+      const durable = await client.operationStatus(operationId).catch(() => null);
+      if (durable) {
+        (dependencies.kick ?? kickStructuredDeliveryQueue)();
+        return {
+          status: durable.receipt.status === "delivered" ? 200 : 202,
+          body: {
+            ok: true,
+            structured: true,
+            target: conversation.id,
+            operationId: durable.operationId,
+            receipt: durable.receipt,
+          },
+        };
+      }
+    }
     return { status: 503, body: { error: error instanceof Error ? error.message : String(error) } };
   }
 }


### PR DESCRIPTION
## Summary

- preserve the delivered structured-control outcome after kill clears the registry host field
- keep the HTTP route owned by the durable structured receipt through host teardown
- cover delivered, replayed, missing-host, and legacy-fallback boundaries

## Verification

- focused structuredControls tests
- focused /api/tmux route tests
- TypeScript
- changed-file ESLint

Fresh Fable review is running on exact head b6fb3cf3.

Closes #372