### PR TITLE
fix: persist explicit project ownership across agent lifecycle

### DIFF
--- a/src/app/api/files/response.ts
+++ b/src/app/api/files/response.ts
@@ -22,11 +22,12 @@ import { filterWorkflowsForFileScan } from "@/lib/workflows/visibility";
 import { projectRateLimitReadModel } from "@/lib/rateLimit";
 import { readAuthorshipEvidence } from "@/lib/reaperAuthorship";
 import { overlayLineageProjectAffinity } from "@/lib/session/projectAffinity";
+import { resolveProjectAttribution } from "@/lib/session/projectResolution";
 import { overlayRoleSessionTitles } from "@/lib/session/roleTitles";
 import { overlaySessionTitles } from "@/lib/session/titleProjection";
 import { tmuxEndpointHealth } from "@/lib/tmux";
 import { claudeProjectRootFor, codexSessionRootFor } from "@/lib/scanner/roots";
-import { projectInfoFromCwd, projectRootForCwd } from "@/lib/scanner/describe";
+import { projectRootForCwd } from "@/lib/scanner/describe";
 import { projectDirectoryFallbacks } from "@/lib/scanner/projectDirectories";
 import type { FilesResponse, ProjectCatalogEntry } from "@/lib/types";
 
@@ -48,7 +49,11 @@ function projectedProjectCatalog(
   for (const conversation of Object.values(snapshot.conversations)) {
     const latest = conversation.generations.at(-1);
     if (!latest) continue;
-    const project = projectInfoFromCwd(latest.launchProfile.cwd)?.project ?? latest.launchProfile.project;
+    const { project } = resolveProjectAttribution({
+      projectOwnership: conversation.projectOwnership,
+      cwd: latest.launchProfile.cwd,
+      launchProfileProject: latest.launchProfile.project,
+    });
     if (project) projectByPath.set(latest.path, project);
     for (const generation of conversation.generations) {
       if (generation.path !== latest.path) archivedPaths.add(generation.path);
@@ -122,9 +127,16 @@ export async function buildFilesResponse(request: Request, dependencies: FilesRo
       path: parentPath,
       root: parentConversation.engine === "codex" ? "codex-sessions" as const : "claude-projects" as const,
       name: rootPath ? path.relative(rootPath, parentPath) : path.basename(parentPath),
-      project: projectInfoFromCwd(parentGeneration.launchProfile.cwd)?.project
-        ?? parentGeneration.launchProfile.project
-        ?? child.project,
+      /* Cross-project lineage stub: the foreign parent groups under ITS owning
+         project (ownership → canonical cwd → profile hint), falling back to
+         the child's project only when the parent has no attribution at all. */
+      project: resolveProjectAttribution({
+        projectOwnership: parentConversation.projectOwnership,
+        cwd: parentGeneration.launchProfile.cwd,
+        launchProfileProject: parentGeneration.launchProfile.project,
+        fallbackProject: child.project,
+      }).project ?? child.project,
+      ...(parentConversation.projectOwnership ? { projectOwnership: { ...parentConversation.projectOwnership } } : {}),
       cwd: parentGeneration.launchProfile.cwd,
       projectRoot: parentGeneration.launchProfile.cwd ? projectRootForCwd(parentGeneration.launchProfile.cwd) : null,
       title: parentGeneration.launchProfile.title ?? path.basename(parentPath, path.extname(parentPath)),
@@ -184,7 +196,13 @@ export async function buildFilesResponse(request: Request, dependencies: FilesRo
       }
       const profile = latest.launchProfile;
       file.title = profile.title ?? file.title;
-      file.project = projectInfoFromCwd(profile.cwd)?.project ?? profile.project ?? file.project;
+      file.project = resolveProjectAttribution({
+        projectOwnership: conversation.projectOwnership,
+        cwd: profile.cwd,
+        launchProfileProject: profile.project,
+        fallbackProject: file.project,
+      }).project ?? file.project;
+      if (conversation.projectOwnership) file.projectOwnership = { ...conversation.projectOwnership };
       file.launchModel = profile.model ?? file.launchModel;
       file.effort = profile.effort ?? file.effort;
       file.goal = profile.goal ?? file.goal;

--- a/src/app/api/files/route.test.ts
+++ b/src/app/api/files/route.test.ts
@@ -1359,6 +1359,131 @@ test("a selected sidebar project cannot replace canonical cwd attribution after 
   expect(entry?.project).not.toBe("latand");
 });
 
+/* Production reproduction (issue #315): conversation_4840d34a… ran with
+   cwd=$HOME, projected under the home-root project, while its Viewer-owned
+   family worked in the LLV worktrees. Explicit operator ownership must move
+   the ROOT's attribution everywhere (files, catalog, lineage) without touching
+   its transcript path, identity, or the children's own attribution. */
+test("explicit operator ownership attributes a home-root conversation to its project across files and catalog", async () => {
+  const registry = agentRegistry();
+  const homeRootCwd = fs.mkdtempSync(path.join(stateDir, "home-root-"));
+  const worktreeCwd = path.join(
+    os.homedir(),
+    ".agents", "tools", "live-log-viewer-next", ".claude", "worktrees", "pipeline-315-builder",
+  );
+  const llvProject = "-agents-tools-live-log-viewer-next";
+  const rootPath = path.join(stateDir, "root-019f4906-3f67-7b72-9fbc-9ec3b5ad1401.jsonl");
+  const childPath = path.join(stateDir, "child-019f4906-3f67-7b72-9fbc-9ec3b5ad1402.jsonl");
+  const begun = registry.beginSpawnRequest({
+    engine: "codex",
+    cwd: homeRootCwd,
+    accountId: "terra",
+    explicitProject: llvProject,
+    launchProfile: emptyLaunchProfile({ cwd: homeRootCwd }),
+  });
+  if (begun.kind !== "created") throw new Error("expected an explicit-project reservation");
+  registry.settleSpawn(begun.receipt.launchId, {
+    key: { engine: "codex", sessionId: "019f4906-3f67-7b72-9fbc-9ec3b5ad1401" },
+    artifactPath: rootPath,
+    cwd: homeRootCwd,
+    accountId: "terra",
+    launchProfile: emptyLaunchProfile({ cwd: homeRootCwd }),
+    status: "idle",
+    host: null,
+    claimEpoch: 0,
+    claimOwner: null,
+    pendingAction: null,
+  });
+
+  const rootScan = file(rootPath);
+  rootScan.project = path.basename(homeRootCwd);
+  rootScan.cwd = homeRootCwd;
+  rootScan.projectRoot = homeRootCwd;
+  const childScan = file(childPath);
+  childScan.project = llvProject;
+  childScan.cwd = worktreeCwd;
+  childScan.worktree = "pipeline-315-builder";
+  childScan.parent = rootPath;
+  scannedFiles = [rootScan, childScan];
+  replaceConversationCatalog([
+    { path: rootPath, root: "codex-sessions", name: "root", project: path.basename(homeRootCwd), title: "root", firstPrompt: "", engine: "codex", kind: "session", fmt: "codex", mtime: 2, size: 1 },
+    { path: childPath, root: "codex-sessions", name: "child", project: llvProject, title: "child", firstPrompt: "", engine: "codex", kind: "session", fmt: "codex", mtime: 1, size: 1 },
+  ]);
+
+  const response = await GET(new Request("http://127.0.0.1/api/files"));
+  const body = await response.json() as { files: FileEntry[]; projectCatalog: Array<{ project: string; conversations: number }> };
+  const root = body.files.find((entry) => entry.path === rootPath);
+  const child = body.files.find((entry) => entry.path === childPath);
+
+  expect(root?.project).toBe(llvProject);
+  expect(root?.projectOwnership).toMatchObject({ project: llvProject, source: "operator" });
+  expect(root?.conversationId).toBe(begun.receipt.conversationId);
+  expect(root?.path).toBe(rootPath);
+  expect(child?.project).toBe(llvProject);
+  expect(child?.worktree).toBe("pipeline-315-builder");
+  /* The whole family now lives under exactly one project key. */
+  expect(new Set([root?.project, child?.project]).size).toBe(1);
+  const catalogProjects = Object.fromEntries(body.projectCatalog.map((entry) => [entry.project, entry.conversations]));
+  expect(catalogProjects[llvProject]).toBe(2);
+  expect(catalogProjects[path.basename(homeRootCwd)]).toBeUndefined();
+});
+
+test("a cross-project lineage stub inherits its owner's explicit project", async () => {
+  const registry = agentRegistry();
+  const homeRootCwd = fs.mkdtempSync(path.join(stateDir, "home-root-"));
+  const llvProject = "-agents-tools-live-log-viewer-next";
+  const parentPath = path.join(stateDir, "parent-019f4906-3f67-7b72-9fbc-9ec3b5ad1411.jsonl");
+  const childPath = path.join(stateDir, "child-019f4906-3f67-7b72-9fbc-9ec3b5ad1412.jsonl");
+  fs.writeFileSync(parentPath, "{}\n");
+  const parentSpawn = registry.beginSpawnRequest({
+    engine: "codex",
+    cwd: homeRootCwd,
+    accountId: "terra",
+    explicitProject: llvProject,
+  });
+  if (parentSpawn.kind !== "created") throw new Error("expected parent reservation");
+  registry.settleSpawn(parentSpawn.receipt.launchId, {
+    key: { engine: "codex", sessionId: "019f4906-3f67-7b72-9fbc-9ec3b5ad1411" },
+    artifactPath: parentPath,
+    cwd: homeRootCwd,
+    accountId: "terra",
+    status: "idle",
+    host: null,
+    claimEpoch: 0,
+    claimOwner: null,
+    pendingAction: null,
+  });
+  const childSpawn = registry.beginSpawnRequest({
+    engine: "codex",
+    cwd: homeRootCwd,
+    accountId: "terra",
+    parentConversationId: parentSpawn.receipt.conversationId,
+  });
+  if (childSpawn.kind !== "created") throw new Error("expected child reservation");
+  registry.settleSpawn(childSpawn.receipt.launchId, {
+    key: { engine: "codex", sessionId: "019f4906-3f67-7b72-9fbc-9ec3b5ad1412" },
+    artifactPath: childPath,
+    cwd: homeRootCwd,
+    accountId: "terra",
+    status: "idle",
+    host: null,
+    claimEpoch: 0,
+    claimOwner: null,
+    pendingAction: null,
+  });
+  const childScan = file(childPath);
+  childScan.cwd = homeRootCwd;
+  scannedFiles = [childScan];
+
+  const response = await GET(new Request("http://127.0.0.1/api/files"));
+  const body = await response.json() as { files: FileEntry[] };
+  const stub = body.files.find((entry) => entry.path === parentPath);
+
+  expect(stub?.activityReason).toBe("lineage_placeholder");
+  expect(stub?.project).toBe(llvProject);
+  expect(stub?.projectOwnership).toMatchObject({ project: llvProject, source: "operator" });
+});
+
 test("a staged structured card stays binding until its initial message is admitted", async () => {
   const registry = agentRegistry();
   const cwd = process.cwd();

--- a/src/app/api/spawn/route.ts
+++ b/src/app/api/spawn/route.ts
@@ -7,7 +7,7 @@ import { after, NextRequest, NextResponse } from "next/server";
 import { UnknownAccountError } from "@/lib/accounts/codex";
 import { claudeSettingsPath, isManagedClaudeHome, UnknownClaudeAccountError } from "@/lib/accounts/claude";
 import { accountManager, resolveHealthySpawnAccount } from "@/lib/accounts/manager";
-import { emptyLaunchProfile } from "@/lib/accounts/migration/contracts";
+import { emptyLaunchProfile, validExplicitProject } from "@/lib/accounts/migration/contracts";
 import { freshSpecFor, type AgentEngine } from "@/lib/agent/cli";
 import { agentRegistry, SpawnChildLimitError } from "@/lib/agent/registry";
 import { reasoningFromBody } from "@/lib/agent/efforts";
@@ -136,7 +136,7 @@ async function postSpawn(
   const rejection = rejectCrossOrigin(req);
   if (rejection) return rejection;
 
-  let body: { engine?: unknown; model?: unknown; cwd?: unknown; prompt?: unknown; images?: unknown; src?: unknown; parent?: unknown; parentConversationId?: unknown; effort?: unknown; fast?: unknown; accountId?: unknown; clientAttemptId?: unknown; role?: unknown; roleParams?: unknown; confirm?: unknown; reviews?: unknown; allowSubagents?: unknown };
+  let body: { engine?: unknown; model?: unknown; cwd?: unknown; prompt?: unknown; images?: unknown; src?: unknown; parent?: unknown; parentConversationId?: unknown; effort?: unknown; fast?: unknown; accountId?: unknown; clientAttemptId?: unknown; role?: unknown; roleParams?: unknown; confirm?: unknown; reviews?: unknown; allowSubagents?: unknown; project?: unknown };
   try {
     body = (await req.json()) as typeof body;
   } catch {
@@ -217,6 +217,17 @@ async function postSpawn(
   if (agentInitiated && body.allowSubagents === true && authenticatedCaller?.kind !== "operator") {
     return NextResponse.json({ error: "allowSubagents requires an authenticated Viewer operator spawn" }, { status: 403 });
   }
+  /* Explicit project ownership (issue #315): a deliberate operator decision,
+     validated here and admitted as the conversation's durable projectOwnership.
+     Sidebar selection or worker-initiated spawns never create ownership. */
+  let explicitProject: string | null = null;
+  if (body.project !== undefined && body.project !== null) {
+    explicitProject = typeof body.project === "string" ? validExplicitProject(body.project) : null;
+    if (!explicitProject) return NextResponse.json({ error: "project must be a valid project key" }, { status: 400 });
+    if (agentInitiated && authenticatedCaller?.kind !== "operator") {
+      return NextResponse.json({ error: "explicit project requires an authenticated Viewer operator spawn" }, { status: 403 });
+    }
+  }
 
   const rawCwd = typeof body.cwd === "string" ? body.cwd.trim() : "";
   if (!rawCwd) return NextResponse.json({ error: "working directory is required" }, { status: 400 });
@@ -260,6 +271,7 @@ async function postSpawn(
       accountId: account.accountId,
       role: role.value?.role ?? null,
       ...(body.allowSubagents === true ? { allowSubagents: true } : {}),
+      ...(explicitProject ? { project: explicitProject } : {}),
       parent: spawnParentSelector({ parentConversationId: parentConversationId ?? undefined }),
       ...(reviewedConversationId ? { reviews: spawnParentSelector({ parentConversationId: reviewedConversationId }) } : {}),
       prompt,
@@ -290,6 +302,7 @@ async function postSpawn(
         parentConversationId,
         allowSubagents: body.allowSubagents === true,
         permissionMode,
+        ...(explicitProject ? { project: explicitProject } : {}),
       }),
     };
     const begun = registry.beginSpawnRequest({
@@ -302,6 +315,7 @@ async function postSpawn(
       parentArtifactPath,
       role: role.value?.role ?? null,
       reviewsConversationId: reviewedConversationId,
+      explicitProject,
       liveChildrenCap: authenticatedCaller?.liveChildrenCap,
       launchProfile: spec.launchProfile,
       clientAttemptId,

--- a/src/lib/accounts/migration/contracts.ts
+++ b/src/lib/accounts/migration/contracts.ts
@@ -8,6 +8,46 @@ export type MigrationOrigin = "manual" | "auto";
 export type MigrationPhase = "requested" | "waiting-turn" | "preparing" | "successor-starting" | "verifying" | "committed" | "failed-recoverable" | "rolled-back";
 export type MigrationIntentState = "draining" | "complete" | "stopped";
 
+/**
+ * Durable conversation-level project authority (issue #315). Distinct from
+ * `launchProfile.project`, which stays a workflow/legacy hint: ownership is
+ * written only by an explicit operator spawn or a relocation operation, and
+ * every files/catalog/board projection must rank it above cwd derivation.
+ */
+export interface ConversationProjectOwnership {
+  project: string;
+  source: "operator" | "relocation";
+  setAt: string;
+  operationId: string;
+}
+
+/* Project keys are scanner slugs (`projectFromSlug` output): dash-joined
+   alphanumerics, optionally rooted with a leading dash, plus the dots that a
+   home-directory basename can contribute. Anything outside that shape (path
+   separators, whitespace, empty) is an ambiguous alias and must be rejected
+   before it becomes durable ownership. */
+const PROJECT_KEY_PATTERN = /^-?[A-Za-z0-9][A-Za-z0-9._-]{0,126}$/;
+
+export function validExplicitProject(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const project = value.trim();
+  return PROJECT_KEY_PATTERN.test(project) ? project : null;
+}
+
+export function normalizeProjectOwnership(value: unknown): ConversationProjectOwnership | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  const ownership = value as Record<string, unknown>;
+  const project = validExplicitProject(ownership.project);
+  if (!project) return null;
+  if (ownership.source !== "operator" && ownership.source !== "relocation") return null;
+  return {
+    project,
+    source: ownership.source,
+    setAt: typeof ownership.setAt === "string" ? ownership.setAt : "1970-01-01T00:00:00.000Z",
+    operationId: typeof ownership.operationId === "string" ? ownership.operationId : "",
+  };
+}
+
 export interface LaunchProfile {
   cwd: string;
   model: string | null;

--- a/src/lib/agent/registry.projectOwnership.test.ts
+++ b/src/lib/agent/registry.projectOwnership.test.ts
@@ -1,0 +1,185 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, test } from "bun:test";
+
+import { AgentRegistry, normalizeRegistry } from "@/lib/agent/registry";
+import { emptyLaunchProfile } from "@/lib/accounts/migration/contracts";
+
+const LLV_PROJECT = "-agents-tools-live-log-viewer-next";
+
+function registry() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "llv-registry-ownership-"));
+  return new AgentRegistry(path.join(dir, "agent-registry.json"));
+}
+
+function spawnEntry(pathname: string, sessionId: string, cwd = "/home/latand") {
+  return {
+    key: { engine: "codex" as const, sessionId },
+    artifactPath: pathname,
+    cwd,
+    accountId: "terra",
+    status: "live" as const,
+    host: null,
+    claimEpoch: 0,
+    claimOwner: null,
+    pendingAction: null,
+  };
+}
+
+describe("durable project ownership", () => {
+  test("an explicit operator spawn admits durable conversation ownership", () => {
+    const store = registry();
+    const cwd = "/home/latand";
+    const begun = store.beginSpawnRequest({
+      engine: "codex",
+      cwd,
+      accountId: "terra",
+      explicitProject: LLV_PROJECT,
+      launchProfile: emptyLaunchProfile({ cwd }),
+    });
+    if (begun.kind !== "created") throw new Error("expected a fresh receipt");
+    expect(begun.receipt.explicitProject).toBe(LLV_PROJECT);
+    expect(begun.receipt.launchProfile.project).toBe(LLV_PROJECT);
+
+    const settled = store.settleSpawn(
+      begun.receipt.launchId,
+      spawnEntry("/transcripts/019f4906-3f67-7b72-9fbc-9ec3b5ad1326.jsonl", "019f4906-3f67-7b72-9fbc-9ec3b5ad1326", cwd),
+    );
+    if (settled.kind !== "settled") throw new Error("expected settlement");
+    expect(settled.conversation.projectOwnership).toMatchObject({
+      project: LLV_PROJECT,
+      source: "operator",
+      operationId: begun.receipt.launchId,
+    });
+    /* Conversation identity, generation identity, and the transcript path are
+       exactly what the settlement recorded — ownership is metadata only. */
+    expect(settled.conversation.id).toBe(begun.receipt.conversationId);
+    expect(settled.conversation.generations.at(-1)?.path)
+      .toBe("/transcripts/019f4906-3f67-7b72-9fbc-9ec3b5ad1326.jsonl");
+  });
+
+  test("an ambiguous explicit project is rejected before any receipt exists", () => {
+    const store = registry();
+    expect(() => store.beginSpawnRequest({
+      engine: "codex",
+      cwd: "/home/latand",
+      explicitProject: "not a/project",
+    })).toThrow("explicit project is not a valid project key");
+    expect(Object.keys(store.snapshot().receipts)).toHaveLength(0);
+  });
+
+  test("a replayed attempt must repeat the same explicit project", () => {
+    const store = registry();
+    const cwd = "/home/latand";
+    const first = store.beginSpawnRequest({
+      engine: "codex",
+      cwd,
+      clientAttemptId: "attempt_ownership_replay_01",
+      requestDigest: "a".repeat(64),
+      explicitProject: LLV_PROJECT,
+    });
+    expect(first.kind).toBe("created");
+    const replay = store.beginSpawnRequest({
+      engine: "codex",
+      cwd,
+      clientAttemptId: "attempt_ownership_replay_01",
+      requestDigest: "a".repeat(64),
+      explicitProject: LLV_PROJECT,
+    });
+    expect(replay.kind).toBe("replay");
+    const conflicting = store.beginSpawnRequest({
+      engine: "codex",
+      cwd,
+      clientAttemptId: "attempt_ownership_replay_01",
+      requestDigest: "a".repeat(64),
+      explicitProject: "latand",
+    });
+    expect(conflicting.kind).toBe("conflict");
+  });
+
+  test("ownership survives a resume successor and is never demoted by later receipts", () => {
+    const store = registry();
+    const cwd = "/home/latand";
+    const sourcePath = "/transcripts/019f4906-3f67-7b72-9fbc-9ec3b5ad1326.jsonl";
+    const begun = store.beginSpawnRequest({
+      engine: "codex",
+      cwd,
+      explicitProject: LLV_PROJECT,
+    });
+    if (begun.kind !== "created") throw new Error("expected a fresh receipt");
+    store.settleSpawn(begun.receipt.launchId, spawnEntry(sourcePath, "019f4906-3f67-7b72-9fbc-9ec3b5ad1326", cwd));
+
+    const resume = store.beginSpawnRequest({
+      engine: "codex",
+      cwd,
+      conversationId: begun.receipt.conversationId,
+      purpose: "resume-successor",
+      launchProfile: emptyLaunchProfile({ cwd }),
+    });
+    if (resume.kind !== "created") throw new Error("expected a resume receipt");
+    const successorPath = "/transcripts/019f4906-4f67-7b72-9fbc-9ec3b5ad1327.jsonl";
+    const settled = store.settleSpawn(
+      resume.receipt.launchId,
+      spawnEntry(successorPath, "019f4906-4f67-7b72-9fbc-9ec3b5ad1327", cwd),
+    );
+    if (settled.kind !== "settled") throw new Error("expected resume settlement");
+    expect(settled.conversation.id).toBe(begun.receipt.conversationId);
+    expect(settled.conversation.projectOwnership).toMatchObject({
+      project: LLV_PROJECT,
+      source: "operator",
+      operationId: begun.receipt.launchId,
+    });
+
+    /* A later explicit receipt for the SAME conversation cannot rewrite the
+       durable record — relocation is the only sanctioned mutation path. */
+    const second = store.beginSpawnRequest({
+      engine: "codex",
+      cwd,
+      conversationId: begun.receipt.conversationId,
+      purpose: "resume-successor",
+      explicitProject: "latand",
+    });
+    if (second.kind !== "created") throw new Error("expected a second resume receipt");
+    const resettled = store.settleSpawn(
+      second.receipt.launchId,
+      spawnEntry("/transcripts/019f4906-5f67-7b72-9fbc-9ec3b5ad1328.jsonl", "019f4906-5f67-7b72-9fbc-9ec3b5ad1328", cwd),
+    );
+    if (resettled.kind !== "settled") throw new Error("expected second settlement");
+    expect(resettled.conversation.projectOwnership?.project).toBe(LLV_PROJECT);
+    expect(resettled.conversation.projectOwnership?.operationId).toBe(begun.receipt.launchId);
+  });
+
+  test("legacy sessions without ownership stay cwd-attributed", () => {
+    const store = registry();
+    const conversation = store.ensureConversation("codex", "/transcripts/legacy.jsonl", "terra");
+    expect(conversation.projectOwnership).toBeNull();
+  });
+
+  test("legacy registry files normalize missing and malformed ownership to null", () => {
+    const store = registry();
+    const begun = store.beginSpawnRequest({ engine: "codex", cwd: "/home/latand", explicitProject: LLV_PROJECT });
+    if (begun.kind !== "created") throw new Error("expected a fresh receipt");
+    store.settleSpawn(
+      begun.receipt.launchId,
+      spawnEntry("/transcripts/019f4906-3f67-7b72-9fbc-9ec3b5ad1326.jsonl", "019f4906-3f67-7b72-9fbc-9ec3b5ad1326"),
+    );
+    const persisted = JSON.parse(fs.readFileSync(store.filename, "utf8")) as {
+      conversations: Record<string, Record<string, unknown>>;
+      receipts: Record<string, Record<string, unknown>>;
+    };
+    const conversation = Object.values(persisted.conversations)[0]!;
+    expect(conversation.projectOwnership).toMatchObject({ project: LLV_PROJECT, source: "operator" });
+
+    /* A registry written before #315 has neither field. */
+    delete conversation.projectOwnership;
+    for (const receipt of Object.values(persisted.receipts)) delete receipt.explicitProject;
+    const legacy = normalizeRegistry(persisted);
+    expect(Object.values(legacy.conversations)[0]!.projectOwnership).toBeNull();
+    expect(Object.values(legacy.receipts)[0]!.explicitProject).toBeNull();
+
+    /* Malformed durable rows fail closed instead of poisoning projections. */
+    conversation.projectOwnership = { project: "bad project", source: "operator" };
+    expect(Object.values(normalizeRegistry(persisted).conversations)[0]!.projectOwnership).toBeNull();
+  });
+});

--- a/src/lib/agent/registry.projectOwnership.test.ts
+++ b/src/lib/agent/registry.projectOwnership.test.ts
@@ -150,6 +150,116 @@ describe("durable project ownership", () => {
     expect(resettled.conversation.projectOwnership?.operationId).toBe(begun.receipt.launchId);
   });
 
+  test("a conflicted resume-successor settlement leaves an unowned conversation unowned", () => {
+    const store = registry();
+    const cwd = "/home/latand";
+    /* Conversation A: settled without operator intent — durably unowned. */
+    const begunA = store.beginSpawnRequest({ engine: "codex", cwd });
+    if (begunA.kind !== "created") throw new Error("expected a fresh receipt");
+    store.settleSpawn(
+      begunA.receipt.launchId,
+      spawnEntry("/transcripts/019f4906-6f67-7b72-9fbc-9ec3b5ad1329.jsonl", "019f4906-6f67-7b72-9fbc-9ec3b5ad1329", cwd),
+    );
+
+    /* Conversation B: two generations, so it can never be adopted as a
+       scanner-allocated provisional owner of its successor path. */
+    const begunB = store.beginSpawnRequest({ engine: "codex", cwd });
+    if (begunB.kind !== "created") throw new Error("expected a fresh receipt");
+    store.settleSpawn(
+      begunB.receipt.launchId,
+      spawnEntry("/transcripts/019f4906-7f67-7b72-9fbc-9ec3b5ad1330.jsonl", "019f4906-7f67-7b72-9fbc-9ec3b5ad1330", cwd),
+    );
+    const resumeB = store.beginSpawnRequest({
+      engine: "codex",
+      cwd,
+      conversationId: begunB.receipt.conversationId,
+      purpose: "resume-successor",
+    });
+    if (resumeB.kind !== "created") throw new Error("expected a resume receipt");
+    const contestedPath = "/transcripts/019f4906-8f67-7b72-9fbc-9ec3b5ad1331.jsonl";
+    const settledB = store.settleSpawn(
+      resumeB.receipt.launchId,
+      spawnEntry(contestedPath, "019f4906-8f67-7b72-9fbc-9ec3b5ad1331", cwd),
+    );
+    if (settledB.kind !== "settled") throw new Error("expected B's resume settlement");
+
+    /* A resume-successor for A carrying explicit operator intent collides with
+       B's owned path. The settlement conflicts — and the conflict must not
+       persist ownership onto A. */
+    const resumeA = store.beginSpawnRequest({
+      engine: "codex",
+      cwd,
+      conversationId: begunA.receipt.conversationId,
+      purpose: "resume-successor",
+      explicitProject: LLV_PROJECT,
+    });
+    if (resumeA.kind !== "created") throw new Error("expected a resume receipt");
+    const conflicted = store.settleSpawn(
+      resumeA.receipt.launchId,
+      spawnEntry(contestedPath, "019f4906-9f67-7b72-9fbc-9ec3b5ad1332", cwd),
+    );
+    expect(conflicted.kind).toBe("conflict");
+    if (conflicted.kind !== "conflict") throw new Error("expected a conflicted settlement");
+    expect(conflicted.code).toBe("spawn_artifact_conflict");
+
+    const snapshot = store.snapshot();
+    expect(snapshot.conversations[begunA.receipt.conversationId]?.projectOwnership).toBeNull();
+    expect(snapshot.conversations[begunB.receipt.conversationId]?.projectOwnership).toBeNull();
+  });
+
+  test("a launch settlement that loses a provisional-owner conflict admits no ownership", () => {
+    const store = registry();
+    const cwd = "/home/latand";
+    /* Conversation A exists unowned; conversation B durably owns the contested
+       path across two generations. */
+    const begunA = store.beginSpawnRequest({ engine: "codex", cwd });
+    if (begunA.kind !== "created") throw new Error("expected a fresh receipt");
+    store.settleSpawn(
+      begunA.receipt.launchId,
+      spawnEntry("/transcripts/019f4907-0f67-7b72-9fbc-9ec3b5ad1333.jsonl", "019f4907-0f67-7b72-9fbc-9ec3b5ad1333", cwd),
+    );
+    const begunB = store.beginSpawnRequest({ engine: "codex", cwd });
+    if (begunB.kind !== "created") throw new Error("expected a fresh receipt");
+    store.settleSpawn(
+      begunB.receipt.launchId,
+      spawnEntry("/transcripts/019f4907-1f67-7b72-9fbc-9ec3b5ad1334.jsonl", "019f4907-1f67-7b72-9fbc-9ec3b5ad1334", cwd),
+    );
+    const resumeB = store.beginSpawnRequest({
+      engine: "codex",
+      cwd,
+      conversationId: begunB.receipt.conversationId,
+      purpose: "resume-successor",
+    });
+    if (resumeB.kind !== "created") throw new Error("expected a resume receipt");
+    const contestedPath = "/transcripts/019f4907-2f67-7b72-9fbc-9ec3b5ad1335.jsonl";
+    const settledB = store.settleSpawn(
+      resumeB.receipt.launchId,
+      spawnEntry(contestedPath, "019f4907-2f67-7b72-9fbc-9ec3b5ad1335", cwd),
+    );
+    if (settledB.kind !== "settled") throw new Error("expected B's resume settlement");
+
+    const launchA = store.beginSpawnRequest({
+      engine: "codex",
+      cwd,
+      conversationId: begunA.receipt.conversationId,
+      explicitProject: LLV_PROJECT,
+    });
+    if (launchA.kind !== "created") throw new Error("expected a launch receipt");
+    const conflicted = store.settleSpawn(
+      launchA.receipt.launchId,
+      spawnEntry(contestedPath, "019f4907-3f67-7b72-9fbc-9ec3b5ad1336", cwd),
+    );
+    expect(conflicted.kind).toBe("conflict");
+    if (conflicted.kind !== "conflict") throw new Error("expected a conflicted settlement");
+    expect(conflicted.code).toBe("spawn_artifact_conflict");
+
+    const snapshot = store.snapshot();
+    expect(snapshot.conversations[begunA.receipt.conversationId]?.projectOwnership).toBeNull();
+    for (const conversation of Object.values(snapshot.conversations)) {
+      expect(conversation.projectOwnership).toBeNull();
+    }
+  });
+
   test("legacy sessions without ownership stay cwd-attributed", () => {
     const store = registry();
     const conversation = store.ensureConversation("codex", "/transcripts/legacy.jsonl", "terra");

--- a/src/lib/agent/registry.ts
+++ b/src/lib/agent/registry.ts
@@ -2634,17 +2634,6 @@ export class AgentRegistry {
       updatedAt: createdAt,
     };
     if (conversation.engine !== receipt.engine) return conflict("spawn_identity_conflict");
-    /* Explicit operator project intent becomes durable ownership exactly once,
-       at admission. An already-owned conversation (an earlier operator spawn or
-       a relocation) keeps its record — succession receipts never demote it. */
-    if (receipt.explicitProject && !conversation.projectOwnership) {
-      conversation.projectOwnership = {
-        project: receipt.explicitProject,
-        source: "operator",
-        setAt: createdAt,
-        operationId: receipt.launchId,
-      };
-    }
     if (receipt.purpose === "resume-successor" && !resumeCanRebaseMigration(conversation.migration)) {
       return conflict("spawn_identity_conflict");
     }
@@ -2702,6 +2691,19 @@ export class AgentRegistry {
           };
         }
       }
+    }
+    /* Explicit operator project intent becomes durable ownership exactly once,
+       at admission — and only after every conflict gate above has passed, so a
+       conflicted settlement never persists ownership onto an existing
+       conversation. An already-owned conversation (an earlier operator spawn or
+       a relocation) keeps its record — succession receipts never demote it. */
+    if (receipt.explicitProject && !conversation.projectOwnership) {
+      conversation.projectOwnership = {
+        project: receipt.explicitProject,
+        source: "operator",
+        setAt: createdAt,
+        operationId: receipt.launchId,
+      };
     }
     if (receipt.purpose !== "migration-successor" && !conversation.generations.some((generation) => generation.path === entry.artifactPath)) {
       conversation.generations.push({

--- a/src/lib/agent/registry.ts
+++ b/src/lib/agent/registry.ts
@@ -8,8 +8,11 @@ import { procBackend } from "@/lib/proc";
 import { withAccountMutationLock } from "@/lib/accounts/accountMutation";
 import {
   emptyLaunchProfile,
+  normalizeProjectOwnership,
+  validExplicitProject,
   type AutoBalancePolicy,
   type ConversationMigration,
+  type ConversationProjectOwnership,
   type DurableQuotaObservation,
   type HeldDelivery,
   type HeldDeliveryCommand,
@@ -147,6 +150,9 @@ export interface SpawnReceipt {
   completionMode: "route-completed" | "observed-completed" | "route-recovered" | null;
   error: string | null;
   launchProfile: LaunchProfile;
+  /** Validated explicit operator project. Becomes durable conversation
+      ownership at admission; `launchProfile.project` stays a hint. */
+  explicitProject: string | null;
 }
 
 export interface SpawnLineageEdge {
@@ -196,6 +202,9 @@ export interface SpawnRequest {
   parentArtifactPath?: string | null;
   role?: string | null;
   reviewsConversationId?: ViewerConversationId | null;
+  /** Explicit operator project intent; validated and admitted as durable
+      conversation ownership. Never inferred from sidebar selection. */
+  explicitProject?: string | null;
   memberships?: DurableMembershipInput[];
   conversationId?: ViewerConversationId;
   purpose?: SpawnReceipt["purpose"];
@@ -229,6 +238,10 @@ export interface RegistryConversation {
   continuityPaths: string[];
   /** Continuity artifacts from canceled successions that must stay outside board aliases. */
   abandonedContinuityPaths: string[];
+  /** Durable project authority (issue #315). Null for legacy sessions and
+      cwd-attributed conversations; projections then fall back to canonical
+      cwd, the launch-profile hint, and the scanner slug in that order. */
+  projectOwnership: ConversationProjectOwnership | null;
   migration: ConversationMigration | null;
   /** Explicit Stop/Keep decision for one target at one routing revision. */
   migrationOptOut: { targetId: string; updatedAt: string } | null;
@@ -559,6 +572,7 @@ function conversationMigrationForIntent(
     boardOperationId: conversation.migration?.boardOperationId ?? null,
     boardPlacementProject: conversation.migration?.boardPlacementProject
       ?? boardProject
+      ?? conversation.projectOwnership?.project
       ?? source.launchProfile.project,
     updatedAt: changedAt,
   };
@@ -872,6 +886,7 @@ function normalizeConversation(value: RegistryConversation): RegistryConversatio
     generations,
     continuityPaths,
     abandonedContinuityPaths,
+    projectOwnership: normalizeProjectOwnership((value as Partial<RegistryConversation>).projectOwnership),
     migration,
     migrationOptOut,
     turn: value.turn && typeof value.turn === "object"
@@ -1432,6 +1447,7 @@ function normalizeReceipt(value: SpawnReceipt): SpawnReceipt {
     target: pane?.paneId ?? (typeof value.target === "string" && /^%\d+$/.test(value.target) ? value.target : null),
     completionMode: value.completionMode === "route-completed" || value.completionMode === "observed-completed" || value.completionMode === "route-recovered" ? value.completionMode : null,
     launchProfile: emptyLaunchProfile({ ...(value.launchProfile ?? {}), cwd: value.launchProfile?.cwd ?? value.cwd }),
+    explicitProject: validExplicitProject(value.explicitProject),
   };
 }
 
@@ -2252,8 +2268,15 @@ export class AgentRegistry {
       const role = typeof input.role === "string" && input.role.trim() ? input.role.trim() : null;
       if (role === "reviewer" && !reviewsConversationId) throw new Error("reviewer spawn requires reviewsConversationId");
       if (reviewsConversationId && role !== "reviewer") throw new Error("reviewsConversationId requires reviewer role");
+      const explicitProject = input.explicitProject == null ? null : validExplicitProject(input.explicitProject);
+      if (input.explicitProject != null && !explicitProject) throw new Error("explicit project is not a valid project key");
       const existingConversation = conversationId ? file.conversations[conversationId] : null;
-      const requestedProfile = emptyLaunchProfile({ cwd: input.cwd, ...(input.launchProfile ?? {}), parentConversationId });
+      const requestedProfile = emptyLaunchProfile({
+        cwd: input.cwd,
+        ...(input.launchProfile ?? {}),
+        ...(explicitProject ? { project: explicitProject } : {}),
+        parentConversationId,
+      });
       const currentProfile = existingConversation?.generations.at(-1)?.launchProfile;
       const profile = input.purpose === "resume-successor" && currentProfile
         ? mergeResumeLaunchProfile(currentProfile, requestedProfile)
@@ -2271,6 +2294,7 @@ export class AgentRegistry {
             && existing.engine === input.engine
             && existing.cwd === input.cwd
             && existing.transport === (input.transport ?? null)
+            && existing.explicitProject === explicitProject
             && existing.launchProfile.permissionMode === profile.permissionMode;
           return { kind: compatible ? "replay" : "conflict", receipt: clone(existing) };
         }
@@ -2322,6 +2346,7 @@ export class AgentRegistry {
         completionMode: null,
         error: null,
         launchProfile: profile,
+        explicitProject,
       };
       file.receipts[receipt.launchId] = receipt;
       if (receipt.parentConversationId && receipt.parentConversationId !== receipt.conversationId) {
@@ -2601,6 +2626,7 @@ export class AgentRegistry {
       generations: [],
       continuityPaths: [],
       abandonedContinuityPaths: [],
+      projectOwnership: null,
       migration: null,
       migrationOptOut: null,
       turn: { state: "unknown" as const, source: "empty" as const, terminalAt: null, observedAt: null },
@@ -2608,6 +2634,17 @@ export class AgentRegistry {
       updatedAt: createdAt,
     };
     if (conversation.engine !== receipt.engine) return conflict("spawn_identity_conflict");
+    /* Explicit operator project intent becomes durable ownership exactly once,
+       at admission. An already-owned conversation (an earlier operator spawn or
+       a relocation) keeps its record — succession receipts never demote it. */
+    if (receipt.explicitProject && !conversation.projectOwnership) {
+      conversation.projectOwnership = {
+        project: receipt.explicitProject,
+        source: "operator",
+        setAt: createdAt,
+        operationId: receipt.launchId,
+      };
+    }
     if (receipt.purpose === "resume-successor" && !resumeCanRebaseMigration(conversation.migration)) {
       return conflict("spawn_identity_conflict");
     }
@@ -2699,7 +2736,7 @@ export class AgentRegistry {
         pendingContinuityPaths: [],
         boardProject: null,
         boardOperationId: null,
-        boardPlacementProject: source.launchProfile.project,
+        boardPlacementProject: conversation.projectOwnership?.project ?? source.launchProfile.project,
         updatedAt: createdAt,
       };
     }
@@ -3218,6 +3255,7 @@ export class AgentRegistry {
         }],
         continuityPaths: [],
         abandonedContinuityPaths: [],
+        projectOwnership: null,
         migration: null,
         migrationOptOut: null,
         turn: { state: "unknown", source: "empty", terminalAt: null, observedAt: null },
@@ -3385,6 +3423,7 @@ export class AgentRegistry {
             }],
             continuityPaths: [],
             abandonedContinuityPaths: [],
+            projectOwnership: null,
             migration: null,
             migrationOptOut: null,
             turn: { ...observation.turn, observedAt: observation.observedAt },

--- a/src/lib/agent/spawnIdentity.ts
+++ b/src/lib/agent/spawnIdentity.ts
@@ -11,6 +11,8 @@ export interface SpawnRequestIdentity {
   accountId: string | null;
   role: string | null;
   allowSubagents?: boolean;
+  /** Explicit operator project ownership; absent for cwd-attributed spawns. */
+  project?: string;
   parent: SpawnParentSelector;
   reviews?: SpawnParentSelector;
   prompt: string;

--- a/src/lib/agent/spawnProjection.ts
+++ b/src/lib/agent/spawnProjection.ts
@@ -1,7 +1,8 @@
 import path from "node:path";
 
 import type { RegistryFile, SpawnReceipt } from "./registry";
-import { projectInfoFromCwd, projectRootForCwd } from "@/lib/scanner/describe";
+import { projectRootForCwd } from "@/lib/scanner/describe";
+import { resolveProjectAttribution } from "@/lib/session/projectResolution";
 import type { FileEntry, StructuredSpawnCardState } from "@/lib/types";
 
 const TERMINAL_SPAWN_RECENT_MS = 15 * 60 * 1_000;
@@ -78,7 +79,18 @@ export function preallocatedStructuredSpawnCards(
   const scannedPaths = new Set(files.map((file) => file.path));
   return newestUnscannedReceipts(files, snapshot).map((receipt) => {
     const spawn = cardState(snapshot, receipt);
-    const project = projectInfoFromCwd(receipt.cwd);
+    /* Pre-admission cards honor the explicit operator project the moment the
+       receipt exists; once admitted, the conversation record is authoritative. */
+    const projectOwnership = snapshot.conversations[receipt.conversationId]?.projectOwnership
+      ?? (receipt.explicitProject
+        ? { project: receipt.explicitProject, source: "operator" as const, setAt: receipt.createdAt, operationId: receipt.launchId }
+        : null);
+    const attribution = resolveProjectAttribution({
+      projectOwnership,
+      cwd: receipt.cwd,
+      launchProfileProject: receipt.launchProfile.project,
+      fallbackProject: path.basename(receipt.cwd),
+    });
     const edge = snapshot.lineageEdges[receipt.conversationId];
     const parentConversationId = edge?.parentConversationId ?? receipt.parentConversationId;
     const parentPath = parentConversationId
@@ -89,10 +101,11 @@ export function preallocatedStructuredSpawnCards(
       path: `spawn:${receipt.launchId}`,
       root: receipt.engine === "codex" ? "codex-sessions" : "claude-projects",
       name: `spawn:${receipt.launchId}`,
-      project: project?.project ?? path.basename(receipt.cwd),
+      project: attribution.project ?? path.basename(receipt.cwd),
+      ...(projectOwnership ? { projectOwnership } : {}),
       cwd: receipt.cwd,
       projectRoot: projectRootForCwd(receipt.cwd) ?? null,
-      ...(project?.worktree ? { worktree: project.worktree } : {}),
+      ...(attribution.worktree ? { worktree: attribution.worktree } : {}),
       title: receipt.launchProfile.title ?? (receipt.engine === "codex" ? "Codex" : "Claude"),
       engine: receipt.engine,
       kind: "session",

--- a/src/lib/session/projectAffinity.ts
+++ b/src/lib/session/projectAffinity.ts
@@ -33,9 +33,11 @@ import type { FileEntry } from "@/lib/types";
  */
 
 /** A member whose project came from a bare directory: nothing resolved a
-    worktree/repo mapping for its cwd, so its attribution is just the cwd. */
+    worktree/repo mapping for its cwd, so its attribution is just the cwd.
+    Durable conversation ownership (issue #315) is never weak — an explicit
+    operator or relocation decision must not be regrouped by lineage. */
 function isWeakAttribution(file: FileEntry): boolean {
-  return Boolean(file.cwd) && !file.worktree && file.projectRoot === file.cwd;
+  return Boolean(file.cwd) && !file.worktree && file.projectRoot === file.cwd && !file.projectOwnership;
 }
 
 /** Is `ancestor` a strict path ancestor of `descendant`? */

--- a/src/lib/session/projectResolution.test.ts
+++ b/src/lib/session/projectResolution.test.ts
@@ -1,0 +1,127 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { afterAll, expect, test } from "bun:test";
+
+import { normalizeProjectOwnership, validExplicitProject } from "@/lib/accounts/migration/contracts";
+import { resolveProjectAttribution } from "./projectResolution";
+
+/* Keep persisted-project and worktree-map reads sandboxed away from the
+   developer's real state directory. */
+const SANDBOX = fs.mkdtempSync(path.join(os.tmpdir(), "llv-project-resolution-"));
+const REAL_STATE = process.env.LLV_STATE_DIR;
+process.env.LLV_STATE_DIR = SANDBOX;
+
+afterAll(() => {
+  if (REAL_STATE !== undefined) process.env.LLV_STATE_DIR = REAL_STATE;
+  else delete process.env.LLV_STATE_DIR;
+  fs.rmSync(SANDBOX, { recursive: true, force: true });
+});
+
+const LLV_PROJECT = "-agents-tools-live-log-viewer-next";
+const LLV_WORKTREE_CWD = path.join(
+  os.homedir(),
+  ".agents",
+  "tools",
+  "live-log-viewer-next",
+  ".claude",
+  "worktrees",
+  "pipeline-315-explicit-ownership",
+);
+
+function operatorOwnership(project: string) {
+  return { project, source: "operator" as const, setAt: "2026-07-16T12:00:00.000Z", operationId: "launch-1" };
+}
+
+test("explicit conversation ownership outranks canonical cwd, profile hint, and fallback", () => {
+  const attribution = resolveProjectAttribution({
+    projectOwnership: operatorOwnership(LLV_PROJECT),
+    cwd: os.homedir(),
+    launchProfileProject: "latand",
+    fallbackProject: "other",
+  });
+  expect(attribution).toMatchObject({ project: LLV_PROJECT, source: "ownership" });
+});
+
+test("ownership keeps the worktree evidence its cwd proves", () => {
+  const attribution = resolveProjectAttribution({
+    projectOwnership: operatorOwnership(LLV_PROJECT),
+    cwd: LLV_WORKTREE_CWD,
+  });
+  expect(attribution).toEqual({
+    project: LLV_PROJECT,
+    worktree: "pipeline-315-explicit-ownership",
+    source: "ownership",
+  });
+});
+
+test("canonical worktree cwd identity outranks a selected-project launch hint", () => {
+  const attribution = resolveProjectAttribution({
+    cwd: LLV_WORKTREE_CWD,
+    launchProfileProject: "latand",
+    fallbackProject: "other",
+  });
+  expect(attribution).toEqual({
+    project: LLV_PROJECT,
+    worktree: "pipeline-315-explicit-ownership",
+    source: "cwd",
+  });
+});
+
+test("a launch-profile hint fills in when no cwd evidence exists", () => {
+  const attribution = resolveProjectAttribution({
+    cwd: "",
+    launchProfileProject: "stikon-dispatcher",
+    fallbackProject: "other",
+  });
+  expect(attribution).toEqual({ project: "stikon-dispatcher", source: "launch-profile" });
+});
+
+test("a legacy session with no metadata keeps its scanner fallback", () => {
+  expect(resolveProjectAttribution({ fallbackProject: "codex" }))
+    .toEqual({ project: "codex", source: "fallback" });
+  expect(resolveProjectAttribution({})).toEqual({ project: null, source: null });
+});
+
+test("a source-project fallback names a cross-project lineage stub", () => {
+  const attribution = resolveProjectAttribution({
+    cwd: "",
+    launchProfileProject: null,
+    fallbackProject: LLV_PROJECT,
+  });
+  expect(attribution).toEqual({ project: LLV_PROJECT, source: "fallback" });
+});
+
+test("blank ownership records never blank the attribution", () => {
+  const attribution = resolveProjectAttribution({
+    projectOwnership: { project: "   ", source: "operator", setAt: "2026-07-16T12:00:00.000Z", operationId: "x" },
+    launchProfileProject: "latand",
+  });
+  expect(attribution).toEqual({ project: "latand", source: "launch-profile" });
+});
+
+test("explicit project validation rejects ambiguous aliases", () => {
+  expect(validExplicitProject(LLV_PROJECT)).toBe(LLV_PROJECT);
+  expect(validExplicitProject("latand")).toBe("latand");
+  expect(validExplicitProject("  latand  ")).toBe("latand");
+  expect(validExplicitProject("")).toBeNull();
+  expect(validExplicitProject("   ")).toBeNull();
+  expect(validExplicitProject("has space")).toBeNull();
+  expect(validExplicitProject("path/traversal")).toBeNull();
+  expect(validExplicitProject("..")).toBeNull();
+  expect(validExplicitProject(42)).toBeNull();
+  expect(validExplicitProject("x".repeat(200))).toBeNull();
+});
+
+test("ownership normalization fails closed on malformed durable records", () => {
+  const valid = operatorOwnership(LLV_PROJECT);
+  expect(normalizeProjectOwnership(valid)).toEqual(valid);
+  expect(normalizeProjectOwnership(null)).toBeNull();
+  expect(normalizeProjectOwnership(undefined)).toBeNull();
+  expect(normalizeProjectOwnership("latand")).toBeNull();
+  expect(normalizeProjectOwnership({ ...valid, source: "scanner" })).toBeNull();
+  expect(normalizeProjectOwnership({ ...valid, project: "" })).toBeNull();
+  expect(normalizeProjectOwnership({ project: LLV_PROJECT, source: "relocation" }))
+    .toEqual({ project: LLV_PROJECT, source: "relocation", setAt: "1970-01-01T00:00:00.000Z", operationId: "" });
+});

--- a/src/lib/session/projectResolution.ts
+++ b/src/lib/session/projectResolution.ts
@@ -1,0 +1,51 @@
+import type { ConversationProjectOwnership } from "@/lib/accounts/migration/contracts";
+import { projectInfoFromCwd } from "@/lib/scanner/describe";
+
+/*
+ * The one authoritative project-attribution path for conversation projections
+ * (issue #315). Files, catalog, board, lineage stubs, resume, and structured
+ * launch cards must all rank the same sources the same way:
+ *
+ *  1. durable conversation ownership (`conversation.projectOwnership`) —
+ *     explicit operator spawn intent or a completed relocation;
+ *  2. canonical repository/worktree identity derived from the cwd — including
+ *     remembered worktrees whose checkout has since been deleted;
+ *  3. the launch-profile project — a workflow and legacy hint only;
+ *  4. the caller's fallback — scanner slug, source-conversation project for a
+ *     cross-project lineage stub, or a path basename.
+ *
+ * Worktree grouping stays a cwd fact: an ownership or profile project renames
+ * the group a conversation lands in, but never invents or erases the worktree
+ * evidence that keeps siblings of one checkout together.
+ */
+
+export type ProjectAttributionSource = "ownership" | "cwd" | "launch-profile" | "fallback";
+
+export interface ProjectAttributionInput {
+  projectOwnership?: ConversationProjectOwnership | null;
+  cwd?: string | null;
+  launchProfileProject?: string | null;
+  fallbackProject?: string | null;
+}
+
+export interface ProjectAttribution {
+  project: string | null;
+  worktree?: string;
+  source: ProjectAttributionSource | null;
+}
+
+export function resolveProjectAttribution(input: ProjectAttributionInput): ProjectAttribution {
+  const cwd = input.cwd?.trim();
+  const cwdInfo = cwd ? projectInfoFromCwd(cwd) : null;
+  const ownership = input.projectOwnership?.project.trim();
+  if (ownership) {
+    return { project: ownership, ...(cwdInfo?.worktree ? { worktree: cwdInfo.worktree } : {}), source: "ownership" };
+  }
+  if (cwdInfo?.project) {
+    return { project: cwdInfo.project, ...(cwdInfo.worktree ? { worktree: cwdInfo.worktree } : {}), source: "cwd" };
+  }
+  const profileProject = input.launchProfileProject?.trim();
+  if (profileProject) return { project: profileProject, source: "launch-profile" };
+  const fallback = input.fallbackProject?.trim();
+  return fallback ? { project: fallback, source: "fallback" } : { project: null, source: null };
+}

--- a/src/lib/session/titleProjection.ts
+++ b/src/lib/session/titleProjection.ts
@@ -3,8 +3,9 @@ import fs from "node:fs";
 import { agentRegistry, normalizeRegistry, RegistryReadError } from "@/lib/agent/registry";
 import type { ViewerConversationId } from "@/lib/accounts/migration/contracts";
 import { statePath } from "@/lib/configDir";
-import { projectInfoFromCwd } from "@/lib/scanner/describe";
 import type { FileEntry } from "@/lib/types";
+
+import { resolveProjectAttribution } from "./projectResolution";
 
 import { isRenameableSessionEntry } from "./renameEligibility";
 import { applyTitleOverride, indexSessionTitles, loadSessionTitles } from "./titleStore";
@@ -58,7 +59,11 @@ function projectRegistrySnapshot(snapshot: RegistrySnapshot, signature: string):
     for (const pathname of owned) if (!conversationByPath.has(pathname)) conversationByPath.set(pathname, conversation.id);
     const latest = conversation.generations.at(-1);
     if (!latest) continue;
-    const project = projectInfoFromCwd(latest.launchProfile.cwd)?.project ?? latest.launchProfile.project;
+    const { project } = resolveProjectAttribution({
+      projectOwnership: conversation.projectOwnership,
+      cwd: latest.launchProfile.cwd,
+      launchProfileProject: latest.launchProfile.project,
+    });
     if (project) projectByPath.set(latest.path, project);
     for (const generation of conversation.generations) {
       if (generation.path !== latest.path) archivedPaths.add(generation.path);
@@ -169,9 +174,13 @@ function sessionTitleProjector(
     const latest = conversation?.generations.at(-1);
     if (latest?.path === entry.path) {
       entry.title = latest.launchProfile.title ?? entry.title;
-      entry.project = projectInfoFromCwd(latest.launchProfile.cwd)?.project
-        ?? latest.launchProfile.project
-        ?? entry.project;
+      entry.project = resolveProjectAttribution({
+        projectOwnership: conversation?.projectOwnership,
+        cwd: latest.launchProfile.cwd,
+        launchProfileProject: latest.launchProfile.project,
+        fallbackProject: entry.project,
+      }).project ?? entry.project;
+      if (conversation?.projectOwnership) entry.projectOwnership = { ...conversation.projectOwnership };
     }
     if (includeRenameEligibility) entry.renamable = isRenameableSessionEntry(entry);
     if (index.size > 0) {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -41,6 +41,11 @@ export interface FileEntry {
   /** Path relative to its root. */
   name: string;
   project: string;
+  /** Durable conversation-level project authority (issue #315): explicit
+      operator spawn intent or a completed relocation. When present, `project`
+      was resolved from it and derived-attribution overlays must not regroup
+      the entry. */
+  projectOwnership?: { project: string; source: "operator" | "relocation"; setAt: string; operationId: string };
   /** Working directory recorded by the conversation transcript. */
   cwd?: string | null;
   /** Identity-bound session creation time parsed from the transcript header. */


### PR DESCRIPTION
## Summary

- persist operator-selected project ownership in the agent registry
- keep worktree grouping evidence and explicit project attribution as separate durable facts
- project one conversation family into one canonical project across files, titles, affinity, migration, and spawn placeholders
- normalize legacy JSON and SQLite registry rows safely
- preserve ownership across resume successors and account migration
- prevent conflicted settlements from admitting ownership

## Verification

- 230 focused tests pass across ownership, files, spawn, registry, projection, affinity, and titles
- 201 focused repair-stage tests pass
- TypeScript clean
- changed-file ESLint clean
- two independent Fable reviews: NO FINDINGS, confidence 0.93 each
- review checkouts remained byte-identical

Closes #315