### PR TITLE
Block Claude Workflow and hidden multi-agent tools in structured spawns (#381)

### DIFF
--- a/.claude/skills/live-log-viewer-orchestration/SKILL.md
+++ b/.claude/skills/live-log-viewer-orchestration/SKILL.md
@@ -23,13 +23,13 @@ Templates map 1:1 to `agent:*` labels on GitHub issues (`Latand/live-log-viewer-
 
 | Template (engine) | Use for | Avoid |
 |---|---|---|
-| **GPT-5.6-Sol** (Codex) | Architecture, planning, bug diagnosis, adversarial review — default owner of issues | LLV UX/UI implementation |
+| **GPT-5.6-Sol** (Codex) | Visible review swarms of five or more reviewers (Viewer pipeline stages) and tasks the operator explicitly assigns to it | Default ownership of LLV UX/UI or Viewer bug work — that is Fable's |
 | **GPT-5.6-Terra** (Codex) | Well-scoped implementation when the operator explicitly assigns it; parked otherwise | Unassigned pickup, open-ended design |
 | **Opus 4.8** (Claude) | Frontend styling, icons, visual polish outside LLV | Bug-finding, deep logic |
-| **Fable 5** (Claude) | LLV UX/UI design, implementation, and debugging; planning/architecture; reviewing results; orchestrator/advisor | — |
+| **Fable 5** (Claude) | All LLV UX/UI and Viewer bug investigation, implementation, and review; planning/architecture; orchestrator/advisor | — |
 | **Sonnet 5** (Claude) | Web/docs research, lightweight tasks (Haiku 4.5 for cheap throughput) | Deep design/review |
 
-Assignment defaults: issues → Sol; LLV UX/UI design, implementation, and debugging → Fable; diagnosis → Sol xhigh; research → Sonnet; Terra stays parked until the operator explicitly assigns a task to it. Reviews go to Fable 5 (at most one or two independent passes) or Sol xhigh; Codex work and adversarial reviews stay with those two.
+Assignment defaults: all LLV UX/UI and Viewer bug investigation, implementation, and review go to Fable by default. Sol is reserved for visible review swarms of five or more reviewers and for explicit operator exceptions. Research goes to Sonnet, and Terra stays parked until the operator explicitly assigns a task to it. Fable runs at most one or two independent review passes on any change.
 
 **Review-pass policy (#381).** Fable performs at most **one or two independent review passes** on any change. A review swarm of **five or more reviewers is Sol-only** and runs as visible Viewer pipeline stages (explicit `/api/spawn` workers or flows the operator sees on the board). Structured Fable hosts deny the native Claude multi-agent tools (`Task`, `Agent`, `Workflow`, `TeamCreate`, `TeamDelete`, `SendMessage`); spawn every helper through the Viewer API so it appears on the board with correct lineage.
 

--- a/.claude/skills/live-log-viewer-orchestration/SKILL.md
+++ b/.claude/skills/live-log-viewer-orchestration/SKILL.md
@@ -23,13 +23,15 @@ Templates map 1:1 to `agent:*` labels on GitHub issues (`Latand/live-log-viewer-
 
 | Template (engine) | Use for | Avoid |
 |---|---|---|
-| **GPT-5.6-Sol** (Codex) | Architecture, planning, bug diagnosis, adversarial review — default owner of issues | Mechanical implementation |
-| **GPT-5.6-Terra** (Codex) | Implementation and review-fixing of well-scoped tasks | Open-ended design |
-| **Opus 4.8** (Claude) | Frontend: styling, UI, icons, visual polish | Bug-finding, deep logic |
-| **Fable 5** (Claude) | Planning/architecture, UX/UI design, reviewing results; orchestrator/advisor | — |
+| **GPT-5.6-Sol** (Codex) | Architecture, planning, bug diagnosis, adversarial review — default owner of issues | LLV UX/UI implementation |
+| **GPT-5.6-Terra** (Codex) | Well-scoped implementation when the operator explicitly assigns it; parked otherwise | Unassigned pickup, open-ended design |
+| **Opus 4.8** (Claude) | Frontend styling, icons, visual polish outside LLV | Bug-finding, deep logic |
+| **Fable 5** (Claude) | LLV UX/UI design, implementation, and debugging; planning/architecture; reviewing results; orchestrator/advisor | — |
 | **Sonnet 5** (Claude) | Web/docs research, lightweight tasks (Haiku 4.5 for cheap throughput) | Deep design/review |
 
-Assignment defaults: issues → Sol; UX/UI design → Fable; frontend implementation → Opus; mechanical implementation → Terra; diagnosis → Sol xhigh; research → Sonnet. A visual/layout bug is frontend work (Opus). Reviews go to Fable 5 or Sol xhigh — Opus and Sonnet review neither Codex work nor anything adversarial.
+Assignment defaults: issues → Sol; LLV UX/UI design, implementation, and debugging → Fable; diagnosis → Sol xhigh; research → Sonnet; Terra stays parked until the operator explicitly assigns a task to it. Reviews go to Fable 5 (at most one or two independent passes) or Sol xhigh; Codex work and adversarial reviews stay with those two.
+
+**Review-pass policy (#381).** Fable performs at most **one or two independent review passes** on any change. A review swarm of **five or more reviewers is Sol-only** and runs as visible Viewer pipeline stages (explicit `/api/spawn` workers or flows the operator sees on the board). Structured Fable hosts deny the native Claude multi-agent tools (`Task`, `Agent`, `Workflow`, `TeamCreate`, `TeamDelete`, `SendMessage`); spawn every helper through the Viewer API so it appears on the board with correct lineage.
 
 ## Spawning
 

--- a/src/lib/agent/cli.test.ts
+++ b/src/lib/agent/cli.test.ts
@@ -161,7 +161,7 @@ test("managed Claude fresh and resume commands pin the transcript owner and scru
   const settings = JSON.parse(fs.readFileSync(settingsPath, "utf8")) as {
     hooks: { PreToolUse: Array<{ matcher: string }> };
   };
-  expect(settings.hooks.PreToolUse.some((group) => group.matcher === "Task|Agent")).toBe(true);
+  expect(settings.hooks.PreToolUse.some((group) => group.matcher === "Task|Agent|Workflow|TeamCreate|TeamDelete|SendMessage")).toBe(true);
   const resumed = resumeSpecFor("claude-projects", transcript)?.command ?? "";
   expect(resumed).toContain(`CLAUDE_CONFIG_DIR='${account.home}'`);
   expect(resumed).toContain("--resume");

--- a/src/lib/agent/spawnPolicy.test.ts
+++ b/src/lib/agent/spawnPolicy.test.ts
@@ -3,7 +3,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
-import { applyClaudeSpawnPolicy, fenceViewerSpawnPrompt, NATIVE_SUBAGENT_DENY_MESSAGE, prepareManagedClaudeSpawnHome, VIEWER_SPAWN_PROMPT_FENCE } from "./spawnPolicy";
+import { applyClaudeSpawnPolicy, fenceViewerSpawnPrompt, NATIVE_MULTI_AGENT_HOOK_MATCHER, NATIVE_MULTI_AGENT_TOOLS, NATIVE_SUBAGENT_DENY_MESSAGE, prepareManagedClaudeSpawnHome, VIEWER_SPAWN_PROMPT_FENCE } from "./spawnPolicy";
 
 const homes: string[] = [];
 
@@ -17,7 +17,7 @@ function home(): string {
   return directory;
 }
 
-test("Claude spawn policy installs a Task/Agent hook that denies with Viewer lineage guidance", async () => {
+test("Claude spawn policy installs a multi-agent deny hook with Viewer lineage guidance", async () => {
   const accountHome = home();
 
   const installed = applyClaudeSpawnPolicy(accountHome, { profileId: "denied" });
@@ -26,7 +26,7 @@ test("Claude spawn policy installs a Task/Agent hook that denies with Viewer lin
   };
 
   expect(settings.hooks.PreToolUse).toContainEqual({
-    matcher: "Task|Agent",
+    matcher: "Task|Agent|Workflow|TeamCreate|TeamDelete|SendMessage",
     hooks: [{ type: "command", command: installed.command }],
   });
   expect((settings as unknown as { disableAllHooks: boolean }).disableAllHooks).toBe(false);
@@ -38,6 +38,27 @@ test("Claude spawn policy installs a Task/Agent hook that denies with Viewer lin
 
   expect(await denied.exited).toBe(2);
   expect(await new Response(denied.stderr).text()).toBe(`${NATIVE_SUBAGENT_DENY_MESSAGE}\n`);
+});
+
+test("Claude spawn policy pins the audited multi-agent set and denies Workflow and team tools (#381)", async () => {
+  expect([...NATIVE_MULTI_AGENT_TOOLS]).toEqual(["Task", "Agent", "Workflow", "TeamCreate", "TeamDelete", "SendMessage"]);
+  expect(NATIVE_MULTI_AGENT_HOOK_MATCHER).toBe("Task|Agent|Workflow|TeamCreate|TeamDelete|SendMessage");
+  /* The hook matcher is a regex over tool names: every audited entry point must
+     match, while shell/filesystem and background-shell tools must stay free. */
+  const matcher = new RegExp(NATIVE_MULTI_AGENT_HOOK_MATCHER);
+  for (const tool of NATIVE_MULTI_AGENT_TOOLS) expect(matcher.test(tool)).toBe(true);
+  for (const tool of ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "WebFetch", "NotebookEdit"]) {
+    expect(matcher.test(tool)).toBe(false);
+  }
+
+  const installed = applyClaudeSpawnPolicy(home(), { profileId: "audited" });
+  for (const tool of ["Workflow", "TeamCreate", "SendMessage"]) {
+    const denied = Bun.spawn(["sh", "-c", installed.command], { stdin: "pipe", stdout: "pipe", stderr: "pipe" });
+    denied.stdin.write(JSON.stringify({ hook_event_name: "PreToolUse", tool_name: tool, tool_input: {} }));
+    denied.stdin.end();
+    expect(await denied.exited).toBe(2);
+    expect(await new Response(denied.stderr).text()).toBe(`${NATIVE_SUBAGENT_DENY_MESSAGE}\n`);
+  }
 });
 
 test("Claude spawn policy rejects an account restriction that suppresses flag-provided hooks", () => {
@@ -68,7 +89,7 @@ test("Claude spawn policy preserves user settings and re-injects one managed hoo
   };
 
   expect(fs.readFileSync(settingsPath, "utf8")).toBe(userSettings);
-  expect(profile.hooks.PreToolUse.filter((group) => group.matcher === "Task|Agent")).toHaveLength(1);
+  expect(profile.hooks.PreToolUse.filter((group) => group.matcher === "Task|Agent|Workflow|TeamCreate|TeamDelete|SendMessage")).toHaveLength(1);
 });
 
 test("Claude spawn policy seeds a fresh account from the shared user settings snapshot", () => {
@@ -104,7 +125,7 @@ test("allowSubagents uses an isolated profile while the denied profile stays enf
     hooks: { PreToolUse: Array<{ matcher: string; hooks: Array<{ type: string; command: string }> }> };
   };
 
-  expect(denied.hooks.PreToolUse.some((group) => group.matcher === "Task|Agent")).toBe(true);
+  expect(denied.hooks.PreToolUse.some((group) => group.matcher === "Task|Agent|Workflow|TeamCreate|TeamDelete|SendMessage")).toBe(true);
   expect(allowed.hooks.PreToolUse).toEqual([{ matcher: "Read", hooks: [{ type: "command", command: "user-read-hook" }] }]);
 });
 

--- a/src/lib/agent/spawnPolicy.test.ts
+++ b/src/lib/agent/spawnPolicy.test.ts
@@ -43,12 +43,23 @@ test("Claude spawn policy installs a multi-agent deny hook with Viewer lineage g
 test("Claude spawn policy pins the audited multi-agent set and denies Workflow and team tools (#381)", async () => {
   expect([...NATIVE_MULTI_AGENT_TOOLS]).toEqual(["Task", "Agent", "Workflow", "TeamCreate", "TeamDelete", "SendMessage"]);
   expect(NATIVE_MULTI_AGENT_HOOK_MATCHER).toBe("Task|Agent|Workflow|TeamCreate|TeamDelete|SendMessage");
-  /* The hook matcher is a regex over tool names: every audited entry point must
-     match, while shell/filesystem and background-shell tools must stay free. */
-  const matcher = new RegExp(NATIVE_MULTI_AGENT_HOOK_MATCHER);
-  for (const tool of NATIVE_MULTI_AGENT_TOOLS) expect(matcher.test(tool)).toBe(true);
-  for (const tool of ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "WebFetch", "NotebookEdit"]) {
-    expect(matcher.test(tool)).toBe(false);
+  /* The installed Claude CLI (2.1.214) applies a PreToolUse matcher by splitting
+     it on "|" and testing exact membership of the tool name, so "Task" denies
+     only Task and never TaskOutput. A substring or unanchored-regex model would
+     wrongly swallow the task-list tools, so the assertions below model the exact
+     split-membership semantics. */
+  const deniedByMatcher = (tool: string): boolean => NATIVE_MULTI_AGENT_HOOK_MATCHER.split("|").includes(tool);
+  for (const tool of NATIVE_MULTI_AGENT_TOOLS) expect(deniedByMatcher(tool)).toBe(true);
+  /* Task-list tools, background-shell tools, and full Bash/filesystem access
+     must remain allowed on denied structured hosts. */
+  const allowedTools = [
+    "TaskOutput", "TaskStop", "TaskCreate",
+    "BashOutput", "KillShell",
+    "Bash", "Read", "Write", "Edit", "Glob", "Grep", "WebFetch", "NotebookEdit",
+  ];
+  for (const tool of allowedTools) {
+    expect(deniedByMatcher(tool)).toBe(false);
+    expect(NATIVE_MULTI_AGENT_TOOLS).not.toContain(tool);
   }
 
   const installed = applyClaudeSpawnPolicy(home(), { profileId: "audited" });

--- a/src/lib/agent/spawnPolicy.ts
+++ b/src/lib/agent/spawnPolicy.ts
@@ -10,6 +10,17 @@ const MANAGED_HOOK_PREFIX = "LLV_MANAGED_NATIVE_SUBAGENT_DENY=1 ";
 const MANAGED_DIR = ".llv";
 const MANAGED_HOOK = "deny-native-subagents.sh";
 
+/** Every native multi-agent entry point in the installed Claude CLI (#381 audit,
+    CLI 2.1.214): subagent spawns (Task, Agent), Workflow orchestration scripts,
+    and the agent-team surface (TeamCreate, TeamDelete, SendMessage). Swarm
+    views are UI wrappers that launch through these same tools. Background
+    shells and task-list tools (TaskOutput, TaskStop, TaskCreate…) never create
+    child agents and stay allowed alongside full Bash/filesystem access. */
+export const NATIVE_MULTI_AGENT_TOOLS: readonly string[] = Object.freeze([
+  "Task", "Agent", "Workflow", "TeamCreate", "TeamDelete", "SendMessage",
+]);
+export const NATIVE_MULTI_AGENT_HOOK_MATCHER = NATIVE_MULTI_AGENT_TOOLS.join("|");
+
 export const VIEWER_SPAWN_ENDPOINT = "http://127.0.0.1:8898/api/spawn";
 export const VIEWER_SPAWN_CAPABILITY_ENV = "LLV_SPAWN_CAPABILITY";
 export const VIEWER_SPAWN_CAPABILITY_HEADER = "x-llv-spawn-capability";
@@ -154,7 +165,7 @@ export function applyClaudeSpawnPolicy(
     const script = `#!/bin/sh\nprintf '%s\\n' ${shellQuote(NATIVE_SUBAGENT_DENY_MESSAGE)} >&2\nexit 2\n`;
     atomicWrite(result.hookPath, script, 0o700);
     preToolUse.push({
-      matcher: "Task|Agent",
+      matcher: NATIVE_MULTI_AGENT_HOOK_MATCHER,
       hooks: [{ type: "command", command: result.command }],
     });
   }

--- a/src/lib/flows/exec.test.ts
+++ b/src/lib/flows/exec.test.ts
@@ -285,7 +285,7 @@ test("headless managed Claude reviewer installs the native sub-agent deny profil
   };
 
   expect(settingsIndex).toBeGreaterThanOrEqual(0);
-  expect(settings.hooks.PreToolUse.some((group) => group.matcher === "Task|Agent")).toBe(true);
+  expect(settings.hooks.PreToolUse.some((group) => group.matcher === "Task|Agent|Workflow|TeamCreate|TeamDelete|SendMessage")).toBe(true);
   expect(built.env.LLV_TOKEN).toBeUndefined();
   delete process.env.LLV_TOKEN;
 });

--- a/src/lib/runtime/claudeStreamBrokerHost.test.ts
+++ b/src/lib/runtime/claudeStreamBrokerHost.test.ts
@@ -15,6 +15,7 @@ import {
   claudeCliAuthStatus,
   ClaudeStreamBrokerHost,
   FileClaudeDeliveryLedger,
+  NATIVE_MULTI_AGENT_DENY_FLAG,
   type ClaudeDeliveryLedger,
   type ClaudeDeliveryState,
 } from "./claudeStreamBrokerHost";
@@ -280,7 +281,7 @@ describe("ClaudeStreamBrokerHost", () => {
     expect(captured.args).toContain("--output-format");
     expect(captured.args).toContain("--safe-mode");
     expect(captured.args).toContain("--disallowedTools");
-    expect(captured.args).toContain("Task,Agent");
+    expect(captured.args).toContain("Task,Agent,Workflow,TeamCreate,TeamDelete,SendMessage");
     expect(captured.args).toContain("--replay-user-messages");
     expect(captured.args).toContain("--permission-prompt-tool");
     expect(captured.args?.at(captured.args.indexOf("--permission-prompt-tool") + 1)).toBe("stdio");
@@ -333,7 +334,7 @@ describe("ClaudeStreamBrokerHost", () => {
 
     const index = captured.args!.indexOf("--disallowedTools");
     expect(index).toBeGreaterThanOrEqual(0);
-    expect(captured.args![index + 1]).toBe("Task,Agent,Edit,Write,NotebookEdit");
+    expect(captured.args![index + 1]).toBe("Task,Agent,Workflow,TeamCreate,TeamDelete,SendMessage,Edit,Write,NotebookEdit");
     await host.release();
   });
 
@@ -558,8 +559,9 @@ describe("ClaudeStreamBrokerHost", () => {
       hooks: { PreToolUse: Array<{ matcher: string }> };
     };
     expect(deniedSettingsIndex).toBeGreaterThanOrEqual(0);
-    expect(deniedCapture.args).toContain("Task,Agent");
-    expect(deniedSettings.hooks.PreToolUse.some((group) => group.matcher === "Task|Agent")).toBe(true);
+    expect(deniedCapture.args).toContain("Task,Agent,Workflow,TeamCreate,TeamDelete,SendMessage");
+    expect(deniedSettings.hooks.PreToolUse.some((group) => group.matcher === "Task|Agent|Workflow|TeamCreate|TeamDelete|SendMessage")).toBe(true);
+    expect((await denied.health()).activeFlags).toContain(NATIVE_MULTI_AGENT_DENY_FLAG);
     await denied.release();
 
     const allowedLedger = new RecordingDeliveryLedger();
@@ -580,8 +582,9 @@ describe("ClaudeStreamBrokerHost", () => {
       hooks: { PreToolUse: Array<{ matcher: string }> };
     };
     expect(allowedSettingsIndex).toBeGreaterThanOrEqual(0);
-    expect(allowedCapture.args).not.toContain("Task,Agent");
-    expect(allowedSettings.hooks.PreToolUse.some((group) => group.matcher === "Task|Agent")).toBe(false);
+    expect(allowedCapture.args).not.toContain("--disallowedTools");
+    expect(allowedSettings.hooks.PreToolUse.some((group) => group.matcher === "Task|Agent|Workflow|TeamCreate|TeamDelete|SendMessage")).toBe(false);
+    expect((await allowed.health()).activeFlags).not.toContain(NATIVE_MULTI_AGENT_DENY_FLAG);
     await allowed.release();
   });
 
@@ -628,7 +631,7 @@ describe("ClaudeStreamBrokerHost", () => {
     const adoptedSettings = JSON.parse(fs.readFileSync(adoptedSettingsPath, "utf8"));
     expect(freshSettings.theme).toBe("shared-dark");
     expect(freshSettings.env).toEqual({ SHARED_SETTING: "kept" });
-    expect(freshSettings.hooks.PreToolUse.map((group) => group.matcher)).toEqual(["Read", "Task|Agent"]);
+    expect(freshSettings.hooks.PreToolUse.map((group) => group.matcher)).toEqual(["Read", "Task|Agent|Workflow|TeamCreate|TeamDelete|SendMessage"]);
     expect(adoptedSettings).toEqual(freshSettings);
     await adopted.release();
 
@@ -651,7 +654,7 @@ describe("ClaudeStreamBrokerHost", () => {
     const legacyProfile = JSON.parse(fs.readFileSync(legacyProfilePath, "utf8")) as {
       hooks: { PreToolUse: Array<{ matcher: string }> };
     };
-    expect(legacyProfile.hooks.PreToolUse.some((group) => group.matcher === "Task|Agent")).toBe(true);
+    expect(legacyProfile.hooks.PreToolUse.some((group) => group.matcher === "Task|Agent|Workflow|TeamCreate|TeamDelete|SendMessage")).toBe(true);
     expect(fs.readFileSync(legacySettingsPath, "utf8")).toBe(legacySettings);
     await legacy.release();
   });

--- a/src/lib/runtime/claudeStreamBrokerHost.ts
+++ b/src/lib/runtime/claudeStreamBrokerHost.ts
@@ -6,7 +6,7 @@ import path from "node:path";
 import { StringDecoder } from "node:string_decoder";
 
 import { statePath } from "@/lib/configDir";
-import { applyClaudeSpawnPolicy } from "@/lib/agent/spawnPolicy";
+import { applyClaudeSpawnPolicy, NATIVE_MULTI_AGENT_TOOLS } from "@/lib/agent/spawnPolicy";
 import { claudeTranscriptPath } from "@/lib/agent/transcript";
 import { procBackend } from "@/lib/proc";
 import { signalDetachedProcessGroup, type ProcessSignal } from "@/lib/processGroup";
@@ -216,6 +216,11 @@ const CHILD_ENV_ALLOWLIST = [
 ] as const;
 const DEFAULT_TIMEOUT_MS = 30_000;
 const DEFAULT_SHUTDOWN_GRACE_MS = 1_000;
+
+/** Durable launch evidence: hosts that launched with the native multi-agent
+    denial advertise the effective denied-tool set so registry snapshots and
+    incident review (#381) can verify the restriction without the argv. */
+export const NATIVE_MULTI_AGENT_DENY_FLAG = `native-multi-agent-deny:${NATIVE_MULTI_AGENT_TOOLS.join(",")}`;
 const MAX_REPLAY_ENVELOPE_BYTES = 256 * 1024;
 const MAX_LINE_BYTES = MAX_STRUCTURED_IMAGE_ENCODED_BYTES + MAX_REPLAY_ENVELOPE_BYTES;
 
@@ -475,6 +480,7 @@ export class ClaudeStreamBrokerHost implements EngineHost {
   private terminationStarted = false;
   private readonly reapedPromise: Promise<void>;
   private resolveReaped!: () => void;
+  private readonly launchFlags: readonly string[];
 
   private constructor(
     child: ChildProcessWithoutNullStreams,
@@ -494,6 +500,9 @@ export class ClaudeStreamBrokerHost implements EngineHost {
     this.cursor = options.initialEventCursor ?? 0;
     this.protocolVersion = auth.version ?? null;
     this.account = { type: auth.authMethod, planType: auth.subscriptionType };
+    this.launchFlags = options.allowSubagents
+      ? [STRUCTURED_IMAGE_CAPABILITY]
+      : [STRUCTURED_IMAGE_CAPABILITY, NATIVE_MULTI_AGENT_DENY_FLAG];
     this.reapedPromise = new Promise((resolve) => { this.resolveReaped = resolve; });
     child.stdout.on("data", (chunk: Buffer | string) => {
       this.acceptStdout(typeof chunk === "string" ? chunk : this.stdoutDecoder.write(chunk));
@@ -547,7 +556,7 @@ export class ClaudeStreamBrokerHost implements EngineHost {
       "--permission-mode", options.permissionMode ?? "default",
     ];
     const disallowedTools = [
-      ...(!options.allowSubagents ? ["Task", "Agent"] : []),
+      ...(!options.allowSubagents ? NATIVE_MULTI_AGENT_TOOLS : []),
       ...(options.readOnly ? ["Edit", "Write", "NotebookEdit"] : []),
     ];
     if (disallowedTools.length > 0) args.push("--disallowedTools", disallowedTools.join(","));
@@ -772,7 +781,7 @@ export class ClaudeStreamBrokerHost implements EngineHost {
       protocolVersion: this.protocolVersion,
       activeTurnRef: this.activeTurnId,
       pendingAttention: [...this.attentions.keys()],
-      activeFlags: [STRUCTURED_IMAGE_CAPABILITY],
+      activeFlags: [...this.launchFlags],
       account: this.account,
     };
   }


### PR DESCRIPTION
## Summary

- deny six native Claude multi-agent entry points from CLI 2.1.214: `Task`, `Agent`, `Workflow`, `TeamCreate`, `TeamDelete`, `SendMessage`
- enforce the same set through structured-host `--disallowedTools` and the Viewer-managed `PreToolUse` hook
- preserve shell, filesystem, background-shell, and task-list capabilities
- publish the effective denial set in structured host `activeFlags`
- route LLV UX/UI and Viewer bug investigation, implementation, and review to Fable by default
- reserve Sol for visible review swarms of five or more and explicit operator exceptions

## Verification

- exact head: `1b94fd591b8fc6e987ffd1e7adbaa400e15692a4`
- original implementation: 226 focused and adjacent tests passed
- final follow-up: 51 spawn-policy and broker-host tests passed
- exact split-membership coverage protects `TaskOutput`, `TaskStop`, `TaskCreate`, background shell, Bash, and filesystem tools
- TypeScript clean
- changed-file ESLint clean
- production build succeeded
- `git diff --check` clean
- working tree clean and branch pushed
- fresh Fable review: `NO FINDINGS`

## Review policy

Fable performed one independent review pass per revision. Native Claude multi-agent entry points remain blocked for structured hosts.

Closes #381
