### PR TITLE
fix: present readable project and role titles (#345)

### DIFF
--- a/src/app/api/files/response.ts
+++ b/src/app/api/files/response.ts
@@ -11,6 +11,7 @@ import { conversationCatalogSnapshot } from "@/lib/scanner/conversationCatalog";
 import { pidAlive, readPpid } from "@/lib/scanner/process";
 import { loadFlows } from "@/lib/flows/store";
 import { reviewOutcomeFor } from "@/lib/flows/reviewOutcome";
+import { overlayPromptDisplayTitles } from "@/lib/displayNames";
 import { projectRestoredFlows } from "@/lib/flows/visibility";
 import { loadPipelines } from "@/lib/pipelines/store";
 import type { Pipeline } from "@/lib/pipelines/types";
@@ -304,6 +305,12 @@ export async function buildFilesResponse(request: Request, dependencies: FilesRo
      explicit user rename keeps final precedence (the role title becomes its
      Reset base), and never rewrites native transcripts. */
   overlayRoleSessionTitles({ files, flows, tasks: storedTasks, conversationAliases: registrySnapshot.conversationAliases });
+  /* Prompt-title fallback (issue #345): sessions the role overlay could not
+     claim — legacy spawns without durable lineage, fresh role spawns with no
+     owning task yet — still show the raw «You are the Orchestrator…» scaffold
+     as their title. Compact those to the role word; user renames keep final
+     precedence exactly as above. */
+  overlayPromptDisplayTitles(files);
   markTiming("files-role-titles");
   timings.push(`files-flows;dur=${(performance.now() - flowsStartedAt).toFixed(1)}`);
   /* Human-authorship pin for the board's worker-class auto-collapse (issue

--- a/src/components/OverviewBoard.render.test.tsx
+++ b/src/components/OverviewBoard.render.test.tsx
@@ -1,0 +1,60 @@
+import { expect, test } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import type { FileEntry } from "@/lib/types";
+
+import { OverviewBoard } from "./OverviewBoard";
+
+/* Overview cards (issue #345): the project heading presents the display name
+   while the card's click handler keeps the canonical key. Server render
+   assumes the desktop grid; the mobile drawer variant of the same names is
+   covered by ProjectRail.dom.test.tsx. */
+
+function fileEntry(overrides: Partial<FileEntry>): FileEntry {
+  return {
+    path: "/sessions/a.jsonl",
+    root: "claude-projects",
+    name: "a.jsonl",
+    project: "-agents-tools-live-log-viewer-next",
+    title: "Session",
+    engine: "claude",
+    kind: "session",
+    fmt: "claude",
+    parent: null,
+    mtime: 1_000,
+    size: 1,
+    activity: "idle",
+    proc: null,
+    pid: null,
+    model: null,
+    pendingQuestion: null,
+    waitingInput: null,
+    ...overrides,
+  } as FileEntry;
+}
+
+test("overview cards show display names, canonical keys never render as text", () => {
+  const files = [
+    fileEntry({ path: "/sessions/viewer.jsonl" }),
+    /* A live branch whose title the server overlay already compacted from the
+       raw spawn prompt: the card renders the compact role title. */
+    fileEntry({ path: "/sessions/orch.jsonl", title: "Orchestrator", activity: "live" }),
+    fileEntry({ path: "/sessions/plain.jsonl", project: "CelestiaCompose" }),
+  ];
+  const html = renderToStaticMarkup(
+    <OverviewBoard
+      files={files}
+      projectCatalog={[]}
+      pipelines={[]}
+      workflows={[]}
+      archivedProjects={new Set()}
+      now={2_000}
+      onSelectProject={() => {}}
+      onSelectFile={() => {}}
+    />,
+  );
+  expect(html).toContain(">live-log-viewer-next<");
+  expect(html).not.toContain("-agents-tools-live-log-viewer-next");
+  expect(html).toContain("CelestiaCompose");
+  expect(html).toContain("Orchestrator");
+});

--- a/src/components/OverviewBoard.tsx
+++ b/src/components/OverviewBoard.tsx
@@ -4,6 +4,7 @@ import { Menu } from "lucide-react";
 import { useMemo } from "react";
 
 import { useColumns } from "@/hooks/useColumns";
+import { projectDisplayName } from "@/lib/displayNames";
 import { useLocale } from "@/lib/i18n";
 import type { FileEntry, ProjectCatalogEntry } from "@/lib/types";
 import type { Pipeline } from "@/lib/pipelines/types";
@@ -99,7 +100,7 @@ export function OverviewBoard({ files, projectCatalog, pipelines, workflows, arc
             >
               <span className="flex items-center gap-2">
                 <span className={`h-2 w-2 shrink-0 rounded-full ${summary.liveCount ? "animate-pulse bg-success" : "bg-strong"}`} />
-                <span className="min-w-0 flex-1 truncate text-[13px] font-bold">{summary.project}</span>
+                <span className="min-w-0 flex-1 truncate text-[13px] font-bold">{projectDisplayName(summary.project)}</span>
                 {summary.liveCount ? (
                   <span className="shrink-0 text-caption font-semibold tabular-nums text-muted">{summary.liveCount}</span>
                 ) : null}

--- a/src/components/ProjectDashboard.tsx
+++ b/src/components/ProjectDashboard.tsx
@@ -9,6 +9,7 @@ import { FavoritesProvider, type FavoritesApi } from "./favorites/FavoritesConte
 import { resolveFavoriteRows } from "./favorites/favoriteRows";
 import { useIsMobile } from "@/hooks/useIsMobile";
 import { viewBus } from "@/hooks/viewPresenceBus";
+import { projectDisplayName } from "@/lib/displayNames";
 import type { Flow } from "@/lib/flows/types";
 import { useLocale } from "@/lib/i18n";
 import type { Pipeline } from "@/lib/pipelines/types";
@@ -1219,7 +1220,7 @@ export function ProjectDashboard({
             <Menu className={isMobile ? "h-5 w-5" : "h-4 w-4"} aria-hidden />
           </button>
         ) : null}
-        <h1 className={`truncate text-[13.5px] font-bold ${isMobile ? "min-w-0 flex-1" : ""}`}>{project}</h1>
+        <h1 className={`truncate text-[13.5px] font-bold ${isMobile ? "min-w-0 flex-1" : ""}`} title={project}>{projectDisplayName(project)}</h1>
         <BoardHistoryControls
           canUndo={history.canUndo}
           canRedo={history.canRedo}

--- a/src/components/ProjectRail.dom.test.tsx
+++ b/src/components/ProjectRail.dom.test.tsx
@@ -1,0 +1,170 @@
+import { afterAll, afterEach, expect, test } from "bun:test";
+import { Window } from "happy-dom";
+import { flushSync } from "react-dom";
+import { createRoot, type Root } from "react-dom/client";
+
+import { setLocale } from "@/lib/i18n";
+import type { FileEntry } from "@/lib/types";
+
+import { ProjectRail } from "./ProjectRail";
+
+/* Presentation names on the rail (issue #345): the leading-dash canonical key
+   `-agents-tools-live-log-viewer-next` must render as `live-log-viewer-next`
+   while selection and filtering keep operating on the canonical key. Covered
+   on the desktop rail and the 390px drawer, in English and Ukrainian. */
+
+const dom = new Window({ url: "http://localhost/" });
+
+/* The rail's breakpoint is `(max-width: 767px)` through useIsMobile; useFlip
+   reads the bare `matchMedia` global for reduced-motion. One switchable stub
+   serves both. */
+let viewportWidth = 1280;
+const matchMediaStub = (query: string) => ({
+  matches: query.includes("max-width") && viewportWidth <= 767,
+  media: String(query),
+  onchange: null,
+  addEventListener() {},
+  removeEventListener() {},
+  addListener() {},
+  removeListener() {},
+  dispatchEvent() {
+    return false;
+  },
+});
+(dom as unknown as { matchMedia: typeof matchMediaStub }).matchMedia = matchMediaStub;
+
+Object.assign(globalThis, {
+  window: dom,
+  document: dom.document,
+  navigator: dom.navigator,
+  Node: dom.Node,
+  HTMLElement: dom.HTMLElement,
+  HTMLInputElement: dom.HTMLInputElement,
+  Event: dom.Event,
+  MouseEvent: dom.MouseEvent,
+  sessionStorage: dom.sessionStorage,
+  localStorage: dom.localStorage,
+  matchMedia: matchMediaStub,
+});
+
+/* The rail's footers (resources, limits) and header controls poll APIs on
+   mount; both tolerate a failed response and stay in their empty states. */
+const realFetch = globalThis.fetch;
+globalThis.fetch = (async () => ({ ok: false, status: 503, json: async () => ({}) })) as unknown as typeof fetch;
+
+function fileEntry(overrides: Partial<FileEntry>): FileEntry {
+  return {
+    path: "/sessions/a.jsonl",
+    root: "claude-projects",
+    name: "a.jsonl",
+    project: "-agents-tools-live-log-viewer-next",
+    title: "Session",
+    engine: "claude",
+    kind: "session",
+    fmt: "claude",
+    parent: null,
+    mtime: 1_000,
+    size: 1,
+    activity: "idle",
+    proc: null,
+    pid: null,
+    model: null,
+    pendingQuestion: null,
+    waitingInput: null,
+    ...overrides,
+  } as FileEntry;
+}
+
+/* One project key reached from a live worktree checkout and from a deleted
+   one: the scanner resolves both cwds to the parent repo, so the rail sees a
+   single canonical key. A second, plain-named project rides along. */
+const files: FileEntry[] = [
+  fileEntry({ path: "/sessions/live-worktree.jsonl", cwd: "/home/u/.agents/tools/live-log-viewer-next/.worktrees/wt-a" }),
+  fileEntry({ path: "/sessions/deleted-worktree.jsonl", cwd: "/home/u/.agents/tools/live-log-viewer-next/.worktrees/wt-gone" }),
+  fileEntry({ path: "/sessions/plain.jsonl", project: "CelestiaCompose" }),
+];
+
+let root: Root | null = null;
+afterEach(() => {
+  if (root) flushSync(() => root?.unmount());
+  root = null;
+  dom.document.body.replaceChildren();
+  setLocale("en");
+  viewportWidth = 1280;
+});
+
+function renderRail(onSelect: (project: string) => void = () => {}): HTMLElement {
+  const container = dom.document.createElement("div");
+  dom.document.body.appendChild(container);
+  root = createRoot(container as unknown as Element);
+  flushSync(() =>
+    root!.render(
+      <ProjectRail
+        files={files}
+        projectCatalog={[]}
+        pipelines={[]}
+        workflows={[]}
+        archivedProjects={new Set()}
+        selected="-agents-tools-live-log-viewer-next"
+        loaded
+        now={2_000}
+        onSelect={onSelect}
+      />,
+    ),
+  );
+  return container as unknown as HTMLElement;
+}
+
+function railRows(container: HTMLElement): HTMLElement[] {
+  return [...container.querySelectorAll("nav button")] as HTMLElement[];
+}
+
+test("desktop rail shows the display name, never the leading-dash key, and selects by canonical key", () => {
+  const selections: string[] = [];
+  const container = renderRail((project) => selections.push(project));
+  const rows = railRows(container);
+  const viewerRow = rows.find((row) => row.textContent?.includes("live-log-viewer-next"));
+  expect(viewerRow).toBeDefined();
+  expect(viewerRow!.textContent).not.toContain("-agents-tools-live-log-viewer-next");
+  /* The two worktree-derived sessions (one live, one deleted checkout) group
+     into this single row — no lookalike neighbor exists. */
+  expect(rows.filter((row) => row.textContent?.includes("live-log-viewer-next"))).toHaveLength(1);
+  expect(rows.find((row) => row.textContent?.includes("CelestiaCompose"))).toBeDefined();
+
+  viewerRow!.dispatchEvent(new dom.MouseEvent("click", { bubbles: true }) as unknown as Event);
+  expect(selections).toEqual(["-agents-tools-live-log-viewer-next"]);
+});
+
+test("the filter input is present; its matching predicate is covered in displayNames.test.ts", () => {
+  const container = renderRail();
+  expect(container.querySelector("input")?.getAttribute("placeholder")).toBe("Filter projects…");
+});
+
+test("390px drawer in Ukrainian keeps the display name and the localized landmarks", () => {
+  viewportWidth = 390;
+  setLocale("uk");
+  const container = renderRail();
+  const nav = container.querySelector("nav");
+  expect(nav?.getAttribute("aria-label")).toBe("Проєкти");
+  expect(container.textContent).toContain("Логи агентів");
+  const rows = railRows(container);
+  const viewerRow = rows.find((row) => row.textContent?.includes("live-log-viewer-next"));
+  expect(viewerRow).toBeDefined();
+  expect(viewerRow!.textContent).not.toContain("-agents-tools-live-log-viewer-next");
+  /* Touch target: mobile rows carry the 44px min-height class. */
+  expect(viewerRow!.className).toContain("min-h-11");
+});
+
+test("390px drawer in English mirrors the Ukrainian structure", () => {
+  viewportWidth = 390;
+  const container = renderRail();
+  expect(container.querySelector("nav")?.getAttribute("aria-label")).toBe("Projects");
+  const viewerRow = railRows(container).find((row) => row.textContent?.includes("live-log-viewer-next"));
+  expect(viewerRow).toBeDefined();
+  expect(viewerRow!.className).toContain("min-h-11");
+});
+
+/* Restore the real fetch for any later test file sharing this process. */
+afterAll(() => {
+  globalThis.fetch = realFetch;
+});

--- a/src/components/ProjectRail.tsx
+++ b/src/components/ProjectRail.tsx
@@ -4,6 +4,7 @@ import { useMemo, useState } from "react";
 
 import { Badge } from "@/components/ui/Badge";
 import { useIsMobile } from "@/hooks/useIsMobile";
+import { projectDisplayName, projectMatchesQuery } from "@/lib/displayNames";
 import { useLocale } from "@/lib/i18n";
 import type { FileEntry, ProjectCatalogEntry } from "@/lib/types";
 import type { Pipeline } from "@/lib/pipelines/types";
@@ -43,8 +44,7 @@ export function ProjectRail({ files, projectCatalog, pipelines, workflows, archi
   const [archiveOpen, setArchiveOpen] = useState(false);
   const summaries = useMemo(() => buildProjectSummaries(files, now, workflows, projectCatalog, pipelines), [files, now, workflows, projectCatalog, pipelines]);
   const visible = useMemo(() => {
-    const q = query.trim().toLowerCase();
-    return q ? summaries.filter((summary) => summary.project.toLowerCase().includes(q)) : summaries;
+    return summaries.filter((summary) => projectMatchesQuery(summary.project, query));
   }, [summaries, query]);
   const activeRows = useMemo(() => visible.filter((summary) => !archivedProjects.has(summary.project)), [visible, archivedProjects]);
   const archivedRows = useMemo(() => visible.filter((summary) => archivedProjects.has(summary.project)), [visible, archivedProjects]);
@@ -124,7 +124,7 @@ export function ProjectRail({ files, projectCatalog, pipelines, workflows, archi
           {activeRows.map((summary) => (
             <div key={summary.project} data-flip-key={summary.project}>
               <RailRow
-                label={summary.project}
+                label={projectDisplayName(summary.project)}
                 live={summary.liveCount}
                 attention={summary.attentionCount}
                 total={summary.conversations}
@@ -157,7 +157,7 @@ export function ProjectRail({ files, projectCatalog, pipelines, workflows, archi
               ? archivedRows.map((summary) => (
                   <RailRow
                     key={summary.project}
-                    label={summary.project}
+                    label={projectDisplayName(summary.project)}
                     live={summary.liveCount}
                     attention={summary.attentionCount}
                     total={summary.conversations}

--- a/src/components/SwitchCard.tsx
+++ b/src/components/SwitchCard.tsx
@@ -3,6 +3,7 @@
 import { CornerDownRight } from "lucide-react";
 
 import { X } from "@/components/icons";
+import { projectDisplayName } from "@/lib/displayNames";
 import { useLocale } from "@/lib/i18n";
 import type { FileEntry } from "@/lib/types";
 
@@ -89,7 +90,7 @@ export function SwitchCard({ file, title, project, currentProject, descendants, 
           }`}
           title={project}
         >
-          {project}
+          {projectDisplayName(project)}
         </span>
       </div>
       <div className={`relative mt-2 min-w-0 ${large ? "text-[14px]" : "text-[12.5px]"} font-bold leading-snug`} title={title}>

--- a/src/components/Switchboard.tsx
+++ b/src/components/Switchboard.tsx
@@ -7,6 +7,7 @@ import { useArchivedPaths } from "@/hooks/useArchivedPaths";
 import { useConversationCatalog } from "@/hooks/useConversationCatalog";
 import { useTimeline } from "@/hooks/useTimeline";
 import { useSwitchboardData, type SwitchboardItem } from "@/hooks/useSwitchboardData";
+import { projectDisplayName } from "@/lib/displayNames";
 import type { Flow } from "@/lib/flows/types";
 import { useLocale } from "@/lib/i18n";
 import { cleanTitle } from "@/lib/title";
@@ -181,7 +182,7 @@ export function Switchboard({ files, flows, project, loaded, onOpenFile, onOpenC
                         }}
                       >
                         <span className="min-w-0 flex-1 truncate text-[12.5px] font-semibold text-primary">{cleanTitle(file.title, 100)}</span>
-                        <span className="max-w-[240px] shrink-0 truncate rounded-full border border-border bg-canvas px-2 py-0.5 text-[10.5px] font-semibold text-muted">{file.project}</span>
+                        <span className="max-w-[240px] shrink-0 truncate rounded-full border border-border bg-canvas px-2 py-0.5 text-[10.5px] font-semibold text-muted" title={file.project}>{projectDisplayName(file.project)}</span>
                       </button>
                     ))}
                   </div>
@@ -264,7 +265,7 @@ export function Switchboard({ files, flows, project, loaded, onOpenFile, onOpenC
                           className="flex min-w-0 items-center gap-2 rounded-[8px] border border-border bg-card/60 px-3 py-1.5 text-[11.5px] text-muted"
                         >
                           <span className="min-w-0 flex-1 truncate">{item.title}</span>
-                          <span className="shrink-0 truncate text-[10.5px]">{item.project}</span>
+                          <span className="shrink-0 truncate text-[10.5px]" title={item.project}>{projectDisplayName(item.project)}</span>
                           <button
                             className="shrink-0 rounded-full border border-border bg-canvas px-2 py-0.5 text-[10.5px] font-semibold text-primary hover:border-accent/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40"
                             onClick={() => unarchive(item.file.path)}

--- a/src/components/Viewer.tsx
+++ b/src/components/Viewer.tsx
@@ -13,6 +13,7 @@ import { useBoardState } from "@/hooks/useBoardState";
 import { useIsMobile } from "@/hooks/useIsMobile";
 import { useViewPresence } from "@/hooks/useViewPresence";
 import { OVERVIEW_CONTEXT, OVERVIEW_SLICE, viewBus } from "@/hooks/viewPresenceBus";
+import { projectDisplayName } from "@/lib/displayNames";
 import { type TFunction, useLocale } from "@/lib/i18n";
 import type { FileEntry } from "@/lib/types";
 
@@ -539,8 +540,8 @@ export function Viewer() {
                 <span className="min-w-0 flex-1 truncate text-[12px] font-semibold text-primary">
                   {cleanTitle(item.file.title, 90)}
                 </span>
-                <span className="shrink-0 rounded-full border border-border bg-canvas px-1.5 text-[10px] font-semibold text-muted">
-                  {item.project}
+                <span className="shrink-0 rounded-full border border-border bg-canvas px-1.5 text-[10px] font-semibold text-muted" title={item.project}>
+                  {projectDisplayName(item.project)}
                 </span>
                 <span className="shrink-0 text-[10.5px] text-muted">{fmtAge(item.since)}</span>
               </span>

--- a/src/components/mobile/MobileFocusView.tsx
+++ b/src/components/mobile/MobileFocusView.tsx
@@ -7,6 +7,7 @@ import { Loader2, X } from "@/components/icons";
 import { TaskSheet, type TaskSheetView } from "@/components/tasks/TaskSheet";
 import { taskRelationsByPath } from "@/components/tasks/taskRelations";
 import { viewBus } from "@/hooks/viewPresenceBus";
+import { projectDisplayName } from "@/lib/displayNames";
 import type { Flow } from "@/lib/flows/types";
 import type { Pipeline } from "@/lib/pipelines/types";
 import { useLocale } from "@/lib/i18n";
@@ -481,7 +482,7 @@ export function MobileFocusView({ project, groups, manual, files, flows, reviewG
         <div className="fixed inset-0 z-50 flex flex-col bg-canvas pb-[env(safe-area-inset-bottom)]">
           <div className="flex min-h-[52px] shrink-0 items-center gap-2 border-b border-border bg-card px-2 py-1.5">
             <span className="shrink-0 pl-1 text-[13px] font-bold">{t("mobile.map")}</span>
-            <span className="min-w-0 flex-1 truncate text-[11.5px] text-muted">{project}</span>
+            <span className="min-w-0 flex-1 truncate text-[11.5px] text-muted">{projectDisplayName(project)}</span>
             {/* role="group" — aria-label on a role-less div is ignored by
                 accessibility APIs, so AT would hear two bare toggle buttons
                 with no "Map framing" context (round-1 review). */}

--- a/src/components/tasks/TaskPanel.tsx
+++ b/src/components/tasks/TaskPanel.tsx
@@ -6,6 +6,7 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { Link2, X } from "@/components/icons";
 import { activityDot, cleanTitle, fmtAge } from "@/components/utils";
 import { useTaskDraft } from "@/hooks/useTaskDraft";
+import { projectDisplayName } from "@/lib/displayNames";
 import { getLocale, useLocale } from "@/lib/i18n";
 import { formatDue, isOverdue } from "@/lib/tasks/helpers";
 import type { BoardTask } from "@/lib/tasks/types";
@@ -62,7 +63,7 @@ function FavoritesSection({
               <span className="min-w-0 flex-1 truncate text-ui font-semibold">
                 {cleanTitle(file.title, 90) || t("tasks.untitled")}
               </span>
-              {scopeAll ? <span className="max-w-[90px] shrink-0 truncate text-caption text-muted">{project}</span> : null}
+              {scopeAll ? <span className="max-w-[90px] shrink-0 truncate text-caption text-muted">{projectDisplayName(project)}</span> : null}
             </button>
             <button
               type="button"

--- a/src/components/tasks/TaskSheet.tsx
+++ b/src/components/tasks/TaskSheet.tsx
@@ -9,6 +9,7 @@ import { activityDot, cleanTitle, engineBadge, fmtAge } from "@/components/utils
 import { useAutosizePinned } from "@/hooks/useAutosizePinned";
 import { useDictation } from "@/hooks/useDictation";
 import { useTaskDraft } from "@/hooks/useTaskDraft";
+import { projectDisplayName } from "@/lib/displayNames";
 import { useLocale } from "@/lib/i18n";
 import type { BoardTask, TaskStatus } from "@/lib/tasks/types";
 import type { FileEntry } from "@/lib/types";
@@ -385,7 +386,7 @@ export function TaskSheet({
         <span className="shrink-0 pl-1 text-[13px] font-bold">
           {view === "new" ? t("tasks.sheetNew") : openTask ? taskTitle(openTask.text) || t("tasks.untitled") : t("tasks.panelTitle")}
         </span>
-        <span className="min-w-0 flex-1 truncate text-[11.5px] text-muted">{project}</span>
+        <span className="min-w-0 flex-1 truncate text-[11.5px] text-muted" title={project}>{projectDisplayName(project)}</span>
         <button
           type="button"
           className="flex h-11 w-11 shrink-0 items-center justify-center rounded-[8px] border border-border bg-canvas text-muted hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40"

--- a/src/lib/displayNames.test.ts
+++ b/src/lib/displayNames.test.ts
@@ -1,0 +1,177 @@
+import { describe, expect, test } from "bun:test";
+
+import { overlayPromptDisplayTitles, projectDisplayName, projectMatchesQuery, rolePromptDisplayTitle } from "./displayNames";
+import type { FileEntry } from "./types";
+
+/* Presentation names (issue #345): every case here mirrors an identity the
+   scanner actually produces. The canonical key is never changed — only the
+   text a person reads. */
+
+describe("projectDisplayName", () => {
+  test("the leading-dash viewer slug drops its container prefix", () => {
+    expect(projectDisplayName("-agents-tools-live-log-viewer-next")).toBe("live-log-viewer-next");
+  });
+
+  test("worktree-derived and deleted-worktree sessions share the parent repo key, so they share one display name", () => {
+    /* `projectInfoFromCwd` resolves a live checkout at
+       `<repo>/.worktrees/<name>` and a deleted one replayed from the worktree
+       map to the SAME canonical key. The presentation layer is a pure function
+       of that key, so equal keys can never present as different projects. */
+    const liveWorktreeProject = "-agents-tools-live-log-viewer-next";
+    const deletedWorktreeProject = "-agents-tools-live-log-viewer-next";
+    expect(projectDisplayName(liveWorktreeProject)).toBe(projectDisplayName(deletedWorktreeProject));
+    expect(projectDisplayName(liveWorktreeProject)).toBe("live-log-viewer-next");
+  });
+
+  test("readable keys pass through untouched", () => {
+    expect(projectDisplayName("live-log-viewer-next")).toBe("live-log-viewer-next");
+    expect(projectDisplayName("latand")).toBe("latand");
+    expect(projectDisplayName("other")).toBe("other");
+    expect(projectDisplayName("CelestiaCompose")).toBe("CelestiaCompose");
+  });
+
+  test("an unrecognized dashed slug at least loses its leading dashes", () => {
+    expect(projectDisplayName("-srv-apps-foo")).toBe("srv-apps-foo");
+  });
+
+  test("never returns an empty string", () => {
+    expect(projectDisplayName("-")).toBe("-");
+    expect(projectDisplayName("---")).toBe("---");
+    /* A bare container prefix has no repo remainder to show. */
+    expect(projectDisplayName("-agents-tools-")).toBe("agents-tools-");
+  });
+});
+
+describe("projectMatchesQuery", () => {
+  test("matches by canonical key and by display name, case-insensitively", () => {
+    const project = "-agents-tools-live-log-viewer-next";
+    expect(projectMatchesQuery(project, "-agents-tools")).toBe(true);
+    expect(projectMatchesQuery(project, "Viewer")).toBe(true);
+    expect(projectMatchesQuery(project, "live-log-viewer-next")).toBe(true);
+    expect(projectMatchesQuery(project, "celestia")).toBe(false);
+    expect(projectMatchesQuery("CelestiaCompose", "celestia")).toBe(true);
+  });
+
+  test("an empty or whitespace query matches everything", () => {
+    expect(projectMatchesQuery("anything", "")).toBe(true);
+    expect(projectMatchesQuery("anything", "   ")).toBe(true);
+  });
+});
+
+describe("rolePromptDisplayTitle", () => {
+  test("the orchestrator scaffold compacts to the role word", () => {
+    expect(
+      rolePromptDisplayTitle(
+        "You are the Orchestrator. Drive work through the production Viewer API at http://127.0.0.1:8898. Use fresh empty sessions…",
+      ),
+    ).toBe("Orchestrator");
+  });
+
+  test("a mode-carrying scaffold keeps the mode", () => {
+    expect(rolePromptDisplayTitle("You are a Builder in tdd mode. Implement the scoped product directive with focused checks.")).toBe(
+      "Builder — tdd",
+    );
+    expect(rolePromptDisplayTitle("You are an Architect in design mode. Ground the design in current code.")).toBe(
+      "Architect — design",
+    );
+  });
+
+  test("a qualified role keeps only the role word", () => {
+    expect(rolePromptDisplayTitle("You are a fresh-context Reviewer. Inspect the diff with lens correctness.")).toBe("Reviewer");
+  });
+
+  test("dashed and plain roles without modes compact to the bare role", () => {
+    expect(rolePromptDisplayTitle("You are a Prod-auditor. Investigate the questions through the read wrapper only.")).toBe(
+      "Prod-auditor",
+    );
+    expect(rolePromptDisplayTitle("You are a Cleaner. Classify the dirty checkout and preserve evidence.")).toBe("Cleaner");
+    expect(rolePromptDisplayTitle("You are a Deployer. Plan the blue/green deployment for merged SHA abc.")).toBe("Deployer");
+  });
+
+  test("a legacy lowercase scaffold still resolves a known role", () => {
+    expect(rolePromptDisplayTitle("You are the reviewer in an implement-review loop. Working directory: /x")).toBe("Reviewer");
+  });
+
+  test("an unresolved template placeholder is not a mode", () => {
+    expect(rolePromptDisplayTitle("You are a Builder in {{mode}} mode. Implement the scoped product directive.")).toBe("Builder");
+  });
+
+  test("a truncated scan title (cleanTitle ellipsis) still compacts", () => {
+    expect(rolePromptDisplayTitle("You are the Orchestrator. Drive work through the production Viewer API at http://127.0.0.1:8…")).toBe(
+      "Orchestrator",
+    );
+  });
+
+  test("human titles and conversational openers pass through as null", () => {
+    expect(rolePromptDisplayTitle("Fix login redirect")).toBeNull();
+    expect(rolePromptDisplayTitle("308 · LLV rescue · Orchestrator")).toBeNull();
+    expect(rolePromptDisplayTitle("You are right, the bug is in proxy.ts")).toBeNull();
+    expect(rolePromptDisplayTitle("You are the best. Thanks for the help")).toBeNull();
+    expect(rolePromptDisplayTitle("You are Claude Code running in a sandbox. Do the thing")).toBeNull();
+    /* A bare role intro with no directive after it is not a scaffold. */
+    expect(rolePromptDisplayTitle("You are a Builder in tdd mode.")).toBeNull();
+    /* Ukrainian titles are untouched. */
+    expect(rolePromptDisplayTitle("Виправити редірект логіну")).toBeNull();
+  });
+});
+
+function entry(overrides: Partial<FileEntry>): FileEntry {
+  return {
+    path: "/tmp/x.jsonl",
+    root: "claude-projects",
+    name: "x.jsonl",
+    project: "-agents-tools-live-log-viewer-next",
+    title: "Claude session",
+    engine: "claude",
+    kind: "session",
+    fmt: "claude",
+    parent: null,
+    mtime: 0,
+    size: 0,
+    activity: "idle",
+    proc: null,
+    pid: null,
+    pendingQuestion: null,
+    waitingInput: null,
+    ...overrides,
+  } as FileEntry;
+}
+
+describe("overlayPromptDisplayTitles", () => {
+  test("compacts a prompt-only legacy session title in place", () => {
+    const files = [
+      entry({ path: "/a", title: "You are the Orchestrator. Drive work through the production Viewer API at http://127.0.0.1:8898." }),
+      entry({ path: "/b", title: "Fix login redirect" }),
+    ];
+    overlayPromptDisplayTitles(files);
+    expect(files[0]!.title).toBe("Orchestrator");
+    expect(files[1]!.title).toBe("Fix login redirect");
+  });
+
+  test("a user rename keeps precedence; the compact form replaces only its Reset base", () => {
+    const files = [
+      entry({
+        path: "/a",
+        title: "My renamed worker",
+        autoTitle: "You are a Builder in tdd mode. Implement the scoped product directive.",
+      }),
+    ];
+    overlayPromptDisplayTitles(files);
+    expect(files[0]!.title).toBe("My renamed worker");
+    expect(files[0]!.autoTitle).toBe("Builder — tdd");
+  });
+
+  test("only agent engines are considered", () => {
+    const files = [
+      entry({ path: "/a", engine: "shell", kind: "background", title: "You are a Cleaner. Classify the dirty checkout now." }),
+    ];
+    overlayPromptDisplayTitles(files);
+    expect(files[0]!.title).toBe("You are a Cleaner. Classify the dirty checkout now.");
+  });
+
+  test("a role-titled worker from the durable overlay no longer matches and stays", () => {
+    const files = [entry({ path: "/a", title: "#345 mobile naming — builder" })];
+    overlayPromptDisplayTitles(files);
+    expect(files[0]!.title).toBe("#345 mobile naming — builder");
+  });
+});

--- a/src/lib/displayNames.ts
+++ b/src/lib/displayNames.ts
@@ -1,0 +1,124 @@
+import type { FileEntry } from "@/lib/types";
+
+/*
+ * Presentation names (issue #345, mobile audit finding 3).
+ *
+ * The canonical project key is a dashed cwd slug (`projectFromSlug`), and a
+ * Viewer-spawned session's fallback title is the head of its machine-authored
+ * spawn prompt. Both are load-bearing identity — grouping, routing, ownership,
+ * lineage and search all key on them — but neither is a name a person should
+ * read: `-agents-tools-live-log-viewer-next` starts with a dash, «You are the
+ * Orchestrator. Drive work…» is a prompt, not a title.
+ *
+ * This module is the single presentation layer over those identifiers. Every
+ * function is pure and display-only: callers keep the canonical value for
+ * keys, handlers, comparisons and search, and pass only the RENDERED text
+ * through here. Nothing on disk or in the read model's identity fields ever
+ * changes, so live and deleted worktrees of the same repo (which resolve to
+ * the same canonical key) always present the same name.
+ */
+
+/** Dashed slug prefixes of known repo containers whose remainder is the repo
+    name itself. `~/.agents/tools/<repo>` encodes (after the home prefix is
+    stripped) as `-agents-tools-<repo>` — the leading-dash project of the
+    audit. Mirrors the repo roots `scanner/describe.ts` recognizes. */
+const CONTAINER_SLUG_PREFIXES = ["-agents-tools-"];
+
+/**
+ * Human name of a canonical project key. A known container prefix is dropped
+ * to leave the repo name; any other leading-dash slug at least loses the
+ * dashes. Everything already readable (plain repo names, the home project,
+ * "other") passes through untouched. Never returns an empty string.
+ */
+export function projectDisplayName(project: string): string {
+  for (const prefix of CONTAINER_SLUG_PREFIXES) {
+    if (project.startsWith(prefix) && project.length > prefix.length) {
+      return project.slice(prefix.length);
+    }
+  }
+  const undashed = project.replace(/^-+/, "");
+  return undashed || project;
+}
+
+/**
+ * Rail-filter predicate: a query matches a project when it matches the
+ * canonical key OR the presented name, so typing what the row shows works
+ * while key-based muscle memory keeps working. An empty query matches all.
+ */
+export function projectMatchesQuery(project: string, query: string): boolean {
+  const q = query.trim().toLowerCase();
+  if (!q) return true;
+  return project.toLowerCase().includes(q) || projectDisplayName(project).toLowerCase().includes(q);
+}
+
+/** Built-in role names (lib/roles/defaults) accepted even when a legacy
+    scaffold spells them lowercase («You are the reviewer in an
+    implement-review loop…»). */
+const KNOWN_ROLE_WORDS = new Set([
+  "orchestrator",
+  "reviewer",
+  "builder",
+  "architect",
+  "cleaner",
+  "prod-auditor",
+  "deployer",
+  "verifier",
+]);
+
+/** A role word is a single capitalized token («Orchestrator», «Prod-auditor»)
+    or a known built-in role name in any case. */
+function roleWordOf(descriptor: string): string | null {
+  const word = descriptor.split(" ").filter(Boolean).at(-1) ?? "";
+  if (/^[A-Z][A-Za-z-]{1,24}$/.test(word)) return word;
+  if (KNOWN_ROLE_WORDS.has(word.toLowerCase())) return word[0]!.toUpperCase() + word.slice(1);
+  return null;
+}
+
+/**
+ * Compact display title for a session whose title is a raw spawn-prompt
+ * scaffold: «You are a Builder in tdd mode. Implement…» → «Builder — tdd»,
+ * «You are the Orchestrator. Drive work…» → «Orchestrator». Returns null for
+ * anything that does not look like a role scaffold — a human-authored title,
+ * a conversational «You are right, …» with no role word, or a bare «You are
+ * the X» with no directive after it — so callers fall back to the raw title.
+ */
+export function rolePromptDisplayTitle(title: string): string | null {
+  const head = /^You are (?:the |an? )?([^.,:]{1,60}?)[.,:]/.exec(title);
+  if (!head || !title.slice(head[0].length).trim()) return null;
+  let descriptor = head[1]!.trim();
+  let mode: string | null = null;
+  const inClause = descriptor.indexOf(" in ");
+  if (inClause > 0) {
+    const context = descriptor.slice(inClause + " in ".length).trim();
+    descriptor = descriptor.slice(0, inClause).trim();
+    const modeMatch = /^(\S+) mode$/.exec(context);
+    /* An unresolved template placeholder ({{mode}}) is not a mode. */
+    if (modeMatch && !modeMatch[1]!.includes("{")) mode = modeMatch[1]!;
+  }
+  const role = roleWordOf(descriptor);
+  if (!role) return null;
+  return mode ? `${role} — ${mode}` : role;
+}
+
+/**
+ * Read-model overlay: replaces spawn-scaffold titles with their compact role
+ * form. Runs AFTER the durable role-title overlay (issue #325) — a worker
+ * with a durable role and an owning task already carries «subject — role» and
+ * no longer matches the scaffold shape — so this is the fallback for
+ * prompt-only sessions: legacy spawns without durable lineage and fresh role
+ * spawns not yet claimed by a task. A user rename (signalled by a preserved
+ * `autoTitle`) keeps final precedence; the compact form then only replaces
+ * its Reset base. Native transcripts are never rewritten.
+ */
+export function overlayPromptDisplayTitles(files: FileEntry[]): void {
+  for (const file of files) {
+    if (file.engine !== "claude" && file.engine !== "codex") continue;
+    if (file.autoTitle !== undefined) {
+      const compact = rolePromptDisplayTitle(file.autoTitle);
+      if (compact) file.autoTitle = compact;
+      continue;
+    }
+    const compact = rolePromptDisplayTitle(file.title);
+    if (compact) file.title = compact;
+  }
+}


### PR DESCRIPTION
Closes #345

## Summary
- adds one presentation-name layer for project keys and role scaffold titles
- keeps routing, lineage, ownership, worktree grouping, and canonical keys stable
- covers desktop rail, Overview, scheme cards, task surfaces, and 390px mobile views

## Verification
- fresh review PASS with no findings
- 24 focused tests plus TypeScript and changed-file ESLint
- production build succeeds
- worktree grouping after deletion remains covered