### PR TITLE
feat(rate-limit): reseat one exhausted conversation safely (#97)

### DIFF
--- a/src/app/api/accounts/route.ts
+++ b/src/app/api/accounts/route.ts
@@ -69,6 +69,9 @@ function migrationProjection(engine: MigrationEngine, snapshot: ReturnType<Retur
   const intent = Object.values(snapshot.migrationIntents)
     .filter((candidate) => {
       if (candidate.engine !== engine) return false;
+      /* A conversation-scoped reseat (issue #97) is not an engine migration:
+         its card carries its own annotation, the panel banner stays down. */
+      if (candidate.scope === "conversation") return false;
       if (candidate.state === "draining") return true;
       return candidate.state === "complete" && Object.values(snapshot.conversations)
         .some((conversation) => conversation.migration?.intentId === candidate.id && conversation.migration.phase === "failed-recoverable");
@@ -102,7 +105,7 @@ function migrationProjection(engine: MigrationEngine, snapshot: ReturnType<Retur
 
 function autoBalanceProjection(engine: MigrationEngine, snapshot: ReturnType<ReturnType<typeof agentRegistry>["snapshot"]>, now: number) {
   const policy = snapshot.autoBalance[engine];
-  const draining = Object.values(snapshot.migrationIntents).some((intent) => intent.engine === engine && intent.state === "draining");
+  const draining = Object.values(snapshot.migrationIntents).some((intent) => intent.engine === engine && intent.state === "draining" && intent.scope !== "conversation");
   const fresh = Object.values(snapshot.quotaObservations[engine]).some((observation) =>
     liveFreshObservation(observation, now));
   const cooling = Boolean(policy.cooldownUntil && Date.parse(policy.cooldownUntil) > now);

--- a/src/app/api/conversations/[conversationId]/migration/route.test.ts
+++ b/src/app/api/conversations/[conversationId]/migration/route.test.ts
@@ -16,22 +16,22 @@ afterEach(() => {
   for (const root of roots.splice(0)) fs.rmSync(root, { recursive: true, force: true });
 });
 
-function observation(pathname: string, accountId: string): ConversationObservation {
+function observation(pathname: string, accountId: string, turnState: "idle" | "busy" = "idle"): ConversationObservation {
   return {
     engine: "codex",
     path: pathname,
     accountId,
     launchProfile: emptyLaunchProfile({ cwd: "/repo/checkout", title: "Implementer", project: "repo", role: "worker" }),
-    turn: { state: "idle", source: "empty", terminalAt: null },
+    turn: { state: turnState, source: "empty", terminalAt: null },
     observedAt: new Date().toISOString(),
   };
 }
 
-function seededRegistry(withHealthyQuota: boolean): { registry: AgentRegistry; id: ViewerConversationId } {
+function seededRegistry(withHealthyQuota: boolean, turnState: "idle" | "busy" = "idle"): { registry: AgentRegistry; id: ViewerConversationId } {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "llv-reseat-route-"));
   roots.push(root);
   const registry = new AgentRegistry(path.join(root, "agent-registry.json"), undefined, undefined, { sqliteMode: "off" });
-  registry.reconcileConversations([observation("/sessions/limited.jsonl", "limited")]);
+  registry.reconcileConversations([observation("/sessions/limited.jsonl", "limited", turnState)]);
   if (withHealthyQuota) {
     registry.recordQuotaEvaluation({
       engine: "codex",
@@ -110,6 +110,19 @@ test("reseat requests a lineage-safe migration once and repeats idempotently", a
   expect(repeat.status).toBe(200);
   expect(await repeat.json()).toMatchObject({ reseat: "already-migrating" });
   expect(registry.conversation(id)!.migration!.operationId).toBe(migration.operationId);
+});
+
+test("a reseat behind a still-open turn exposes its exact wait state", async () => {
+  const { registry, id } = seededRegistry(true, "busy");
+  const response = await POST(
+    reseatRequest(id, { action: "reseat", path: "/sessions/limited.jsonl" }),
+    { params: Promise.resolve({ conversationId: id }) },
+  );
+  expect(response.status).toBe(200);
+  /* The card learns exactly what the reseat waits on instead of a generic
+     "requested"; the wall itself frees the turn on the next inventory pass. */
+  expect(await response.json()).toMatchObject({ reseat: "requested", phase: "waiting-turn" });
+  expect(registry.conversation(id)!.migration!.phase).toBe("waiting-turn");
 });
 
 test("retry reaches normal migration handling", async () => {

--- a/src/app/api/conversations/[conversationId]/migration/route.test.ts
+++ b/src/app/api/conversations/[conversationId]/migration/route.test.ts
@@ -1,7 +1,116 @@
-import { expect, test } from "bun:test";
+import { afterEach, expect, test } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { NextRequest } from "next/server";
 
+import { emptyLaunchProfile, type ViewerConversationId } from "@/lib/accounts/migration/contracts";
+import { AgentRegistry, setAgentRegistryForTests, type ConversationObservation } from "@/lib/agent/registry";
+
 const { POST } = await import("./route");
+
+const roots: string[] = [];
+
+afterEach(() => {
+  setAgentRegistryForTests(null);
+  for (const root of roots.splice(0)) fs.rmSync(root, { recursive: true, force: true });
+});
+
+function observation(pathname: string, accountId: string): ConversationObservation {
+  return {
+    engine: "codex",
+    path: pathname,
+    accountId,
+    launchProfile: emptyLaunchProfile({ cwd: "/repo/checkout", title: "Implementer", project: "repo", role: "worker" }),
+    turn: { state: "idle", source: "empty", terminalAt: null },
+    observedAt: new Date().toISOString(),
+  };
+}
+
+function seededRegistry(withHealthyQuota: boolean): { registry: AgentRegistry; id: ViewerConversationId } {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "llv-reseat-route-"));
+  roots.push(root);
+  const registry = new AgentRegistry(path.join(root, "agent-registry.json"), undefined, undefined, { sqliteMode: "off" });
+  registry.reconcileConversations([observation("/sessions/limited.jsonl", "limited")]);
+  if (withHealthyQuota) {
+    registry.recordQuotaEvaluation({
+      engine: "codex",
+      observations: [{
+        engine: "codex",
+        accountId: "default",
+        authenticated: true,
+        authCheckedAt: new Date().toISOString(),
+        limits: { session: { usedPercent: 5, resetsAt: null }, weekly: null, plan: null, capturedAt: null },
+        provenance: { source: "live", reason: null, staleSince: null },
+        observedAt: new Date().toISOString(),
+        bootId: "boot",
+      }],
+      signature: null,
+      bootId: "boot",
+      now: new Date().toISOString(),
+      minimumGapMs: 0,
+    });
+  }
+  setAgentRegistryForTests(registry);
+  return { registry, id: registry.conversationForPath("/sessions/limited.jsonl")!.id };
+}
+
+function reseatRequest(conversationId: string, body: Record<string, unknown>): NextRequest {
+  return new NextRequest(`http://127.0.0.1/api/conversations/${conversationId}/migration`, {
+    method: "POST",
+    headers: { host: "127.0.0.1", "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+test("reseat requires a known conversation", async () => {
+  seededRegistry(true);
+  const response = await POST(
+    reseatRequest("conversation_missing", { action: "reseat" }),
+    { params: Promise.resolve({ conversationId: "conversation_missing" }) },
+  );
+  expect(response.status).toBe(404);
+});
+
+test("reseat refuses a card whose generation a migration already replaced", async () => {
+  const { id } = seededRegistry(true);
+  const response = await POST(
+    reseatRequest(id, { action: "reseat", path: "/sessions/archived-predecessor.jsonl" }),
+    { params: Promise.resolve({ conversationId: id }) },
+  );
+  expect(response.status).toBe(409);
+  expect(await response.json()).toMatchObject({ reseat: "already-reseated" });
+});
+
+test("reseat without a fresh healthy account is refused, never guessed", async () => {
+  const { id } = seededRegistry(false);
+  const response = await POST(
+    reseatRequest(id, { action: "reseat", path: "/sessions/limited.jsonl" }),
+    { params: Promise.resolve({ conversationId: id }) },
+  );
+  expect(response.status).toBe(409);
+  expect((await response.json() as { error: string }).error).toContain("healthy account");
+});
+
+test("reseat requests a lineage-safe migration once and repeats idempotently", async () => {
+  const { registry, id } = seededRegistry(true);
+  const first = await POST(
+    reseatRequest(id, { action: "reseat", path: "/sessions/limited.jsonl" }),
+    { params: Promise.resolve({ conversationId: id }) },
+  );
+  expect(first.status).toBe(200);
+  expect(await first.json()).toMatchObject({ reseat: "requested", targetId: "default", targetLabel: "Main" });
+  const migration = registry.conversation(id)!.migration!;
+  expect(migration).toMatchObject({ targetId: "default" });
+
+  const repeat = await POST(
+    reseatRequest(id, { action: "reseat", path: "/sessions/limited.jsonl" }),
+    { params: Promise.resolve({ conversationId: id }) },
+  );
+  expect(repeat.status).toBe(200);
+  expect(await repeat.json()).toMatchObject({ reseat: "already-migrating" });
+  expect(registry.conversation(id)!.migration!.operationId).toBe(migration.operationId);
+});
 
 test("retry reaches normal migration handling", async () => {
   const request = new NextRequest("http://127.0.0.1/api/conversations/conversation_missing/migration", {

--- a/src/app/api/conversations/[conversationId]/migration/route.ts
+++ b/src/app/api/conversations/[conversationId]/migration/route.ts
@@ -37,7 +37,7 @@ export async function POST(req: NextRequest, { params }: { params: Promise<{ con
       return NextResponse.json({ reseat: "already-reseated", error: "a successor already replaced this conversation" }, { status: 409 });
     }
     if (conversation.migration && IN_FLIGHT_PHASES.has(conversation.migration.phase)) {
-      return NextResponse.json({ reseat: "already-migrating", conversation });
+      return NextResponse.json({ reseat: "already-migrating", phase: conversation.migration.phase, conversation });
     }
     const accounts = conversation.engine === "claude" ? listClaudeAccounts() : listCodexAccounts();
     const target = chooseReseatTarget(source.accountId, registry.quotaObservations(conversation.engine), accounts);
@@ -52,7 +52,10 @@ export async function POST(req: NextRequest, { params }: { params: Promise<{ con
         if (final.migration?.phase === "committed") await drainHeldDeliveries(final.id, deliveryPort, registry);
       } catch { final = registry.conversation(conversationId as ViewerConversationId) ?? requested; }
     }
-    return NextResponse.json({ reseat: "requested", targetId: target.accountId, targetLabel: target.label, conversation: final });
+    /* `phase` exposes the exact wait state: "waiting-turn" means the reseat is
+       parked until the walled turn releases (the wall itself frees it on the
+       next inventory pass), anything else is actively migrating. */
+    return NextResponse.json({ reseat: "requested", phase: final.migration?.phase ?? null, targetId: target.accountId, targetLabel: target.label, conversation: final });
   }
   if (!Number.isInteger(body.expectedRevision) || (body.expectedRevision as number) < 0) return NextResponse.json({ error: "expectedRevision must be a non-negative integer" }, { status: 400 });
   if (body.action === "rollback") {

--- a/src/app/api/conversations/[conversationId]/migration/route.ts
+++ b/src/app/api/conversations/[conversationId]/migration/route.ts
@@ -1,9 +1,12 @@
 import { NextRequest, NextResponse } from "next/server";
 
 import { agentRegistry } from "@/lib/agent/registry";
+import { listClaudeAccounts } from "@/lib/accounts/claude";
+import { listCodexAccounts } from "@/lib/accounts/codex";
 import { advanceConversationMigration, drainHeldDeliveries } from "@/lib/accounts/migration/coordinator";
 import { createMigrationDeliveryPort } from "@/lib/accounts/migration/deliveryPort";
 import { RegisteredSuccessorProvider } from "@/lib/accounts/migration/provider";
+import { chooseReseatTarget } from "@/lib/accounts/reseat";
 import { rejectCrossOrigin } from "@/lib/sameOrigin";
 import type { ViewerConversationId } from "@/lib/accounts/migration/contracts";
 
@@ -12,11 +15,45 @@ export const dynamic = "force-dynamic";
 
 const deliveryPort = createMigrationDeliveryPort();
 
+const IN_FLIGHT_PHASES = new Set(["requested", "waiting-turn", "preparing", "successor-starting", "verifying"]);
+
 export async function POST(req: NextRequest, { params }: { params: Promise<{ conversationId: string }> }) {
   const rejected = rejectCrossOrigin(req); if (rejected) return rejected;
-  let body: { action?: unknown; expectedRevision?: unknown }; try { body = await req.json() as typeof body; } catch { return NextResponse.json({ error: "invalid JSON" }, { status: 400 }); }
+  let body: { action?: unknown; expectedRevision?: unknown; path?: unknown }; try { body = await req.json() as typeof body; } catch { return NextResponse.json({ error: "invalid JSON" }, { status: 400 }); }
   const { conversationId } = await params;
   if (!conversationId.startsWith("conversation_")) return NextResponse.json({ error: "invalid conversation id" }, { status: 400 });
+  if (body.action === "reseat") {
+    /* One-click rate-limit reseat (issue #97). Lineage first: a client acting
+       on an archived generation (a migration already forked the thread) or on
+       a conversation with an in-flight migration must never mint a second
+       successor — those return idempotently instead of re-requesting. */
+    if (body.path !== undefined && typeof body.path !== "string") return NextResponse.json({ error: "path must be a string" }, { status: 400 });
+    const registry = agentRegistry();
+    const conversation = registry.conversation(conversationId as ViewerConversationId);
+    if (!conversation) return NextResponse.json({ error: "viewer conversation is unknown" }, { status: 404 });
+    const source = conversation.generations.at(-1);
+    if (!source?.accountId) return NextResponse.json({ error: "conversation has no managed account to reseat from" }, { status: 409 });
+    if (typeof body.path === "string" && body.path !== source.path) {
+      return NextResponse.json({ reseat: "already-reseated", error: "a successor already replaced this conversation" }, { status: 409 });
+    }
+    if (conversation.migration && IN_FLIGHT_PHASES.has(conversation.migration.phase)) {
+      return NextResponse.json({ reseat: "already-migrating", conversation });
+    }
+    const accounts = conversation.engine === "claude" ? listClaudeAccounts() : listCodexAccounts();
+    const target = chooseReseatTarget(source.accountId, registry.quotaObservations(conversation.engine), accounts);
+    if (!target) return NextResponse.json({ error: "no healthy account with fresh quota headroom is available" }, { status: 409 });
+    const requested = registry.requestConversationReseat(conversationId as ViewerConversationId, target.accountId);
+    let final = requested;
+    if (requested.migration) {
+      /* Best effort: a provider preflight failure stays recoverable and the
+         background controller keeps reconciling the requested migration. */
+      try {
+        final = await advanceConversationMigration(conversationId as ViewerConversationId, registry, new RegisteredSuccessorProvider());
+        if (final.migration?.phase === "committed") await drainHeldDeliveries(final.id, deliveryPort, registry);
+      } catch { final = registry.conversation(conversationId as ViewerConversationId) ?? requested; }
+    }
+    return NextResponse.json({ reseat: "requested", targetId: target.accountId, targetLabel: target.label, conversation: final });
+  }
   if (!Number.isInteger(body.expectedRevision) || (body.expectedRevision as number) < 0) return NextResponse.json({ error: "expectedRevision must be a non-negative integer" }, { status: 400 });
   if (body.action === "rollback") {
     try {

--- a/src/components/BranchPane.tsx
+++ b/src/components/BranchPane.tsx
@@ -349,7 +349,7 @@ export function BranchPane({ file, tasks, isRoot, onClose, dragHandle, noCompose
                   <EffortPills file={file} />
                 </>
               )}
-              <RateLimitBadge rateLimit={file.rateLimit} />
+              <RateLimitBadge file={file} />
               {/* Scheduled-wakeup chip (#165): a pending self-wake shows on every
                   surface, phone included, since it is actionable status. */}
               <WakeupChip key={wakeupChipKey(file.pendingWakeup)} wakeup={file.pendingWakeup} />

--- a/src/components/RateLimitBadge.dom.test.tsx
+++ b/src/components/RateLimitBadge.dom.test.tsx
@@ -120,6 +120,29 @@ test("a card already owned by a migration offers no reseat", () => {
   expect(dom.document.querySelector("[data-rate-limit-reseat]")).toBeNull();
 });
 
+test("a stale card renders already-reseated as terminal truth, never a fresh reseat", async () => {
+  /* The server's path fence says a successor already owns this thread: the
+     card must state that outcome and go inert — not spin "reseating…" as if
+     a new successor were on the way, and not raise an error alert. */
+  fetchResponse = { ok: false, status: 409, payload: { reseat: "already-reseated", error: "a successor already replaced this conversation" } };
+  mount(<RateLimitBadge file={limitedEntry()} />);
+
+  const button = dom.document.querySelector("[data-rate-limit-reseat]") as unknown as HTMLButtonElement;
+  flushSync(() => { button.click(); });
+  await settle();
+
+  expect(button.hasAttribute("data-rate-limit-reseated")).toBeTrue();
+  expect(button.hasAttribute("disabled")).toBeTrue();
+  expect(button.textContent).toContain("already reseated");
+  expect(button.textContent).not.toContain("reseating");
+  expect(dom.document.querySelector("[role=alert]")).toBeNull();
+
+  /* Terminal means terminal: another tap never re-posts. */
+  flushSync(() => { button.click(); });
+  await settle();
+  expect(fetchCalls).toHaveLength(1);
+});
+
 test("a refused reseat announces its public reason instead of failing silently", async () => {
   fetchResponse = { ok: false, status: 409, payload: { error: "no healthy account with fresh quota headroom is available" } };
   mount(<RateLimitBadge file={limitedEntry()} />);

--- a/src/components/RateLimitBadge.dom.test.tsx
+++ b/src/components/RateLimitBadge.dom.test.tsx
@@ -1,0 +1,134 @@
+import { afterAll, afterEach, beforeAll, beforeEach, expect, test } from "bun:test";
+import { Window } from "happy-dom";
+import { createRoot, type Root } from "react-dom/client";
+import { flushSync } from "react-dom";
+
+import type { FileEntry } from "@/lib/types";
+
+/*
+ * Issue #97 — the one-click successor reseat on a rate-limited card, exercised
+ * in a mobile-shaped DOM (narrow viewport, matchMedia max-width matches, touch
+ * taps). The affordance must render beside the badge, post exactly one
+ * lineage-checked reseat per tap, and stand down while a migration annotation
+ * owns the card.
+ */
+
+const { RateLimitBadge } = await import("@/components/RateLimitBadge");
+
+const dom = new Window({ url: "http://localhost/", width: 390, height: 844 });
+const G = globalThis as Record<string, unknown>;
+const fetchCalls: { url: string; body: Record<string, unknown> }[] = [];
+let fetchResponse: { ok: boolean; status: number; payload: Record<string, unknown> } = { ok: true, status: 200, payload: { reseat: "requested" } };
+const OVERRIDES: Record<string, unknown> = {
+  window: dom,
+  document: dom.document,
+  navigator: dom.navigator,
+  Node: dom.Node,
+  HTMLElement: dom.HTMLElement,
+  Event: dom.Event,
+  MouseEvent: dom.MouseEvent,
+  sessionStorage: dom.sessionStorage,
+  localStorage: dom.localStorage,
+  matchMedia: (q: string) => ({ matches: /max-width/.test(String(q)), media: String(q), onchange: null, addEventListener() {}, removeEventListener() {}, addListener() {}, removeListener() {}, dispatchEvent() { return false; } }),
+  requestAnimationFrame: (cb: (t: number) => void) => setTimeout(() => cb(0), 0) as unknown as number,
+  cancelAnimationFrame: (id: number) => clearTimeout(id),
+  fetch: (async (url: string, init?: { body?: string }) => {
+    fetchCalls.push({ url: String(url), body: JSON.parse(init?.body ?? "{}") as Record<string, unknown> });
+    return { ok: fetchResponse.ok, status: fetchResponse.status, json: async () => fetchResponse.payload, text: async () => "" };
+  }) as unknown as typeof fetch,
+};
+const HAS: Record<string, boolean> = {};
+const SAVED: Record<string, unknown> = {};
+const settle = async () => { await new Promise((r) => setTimeout(r, 0)); await new Promise((r) => setTimeout(r, 0)); };
+
+beforeAll(() => {
+  for (const key of Object.keys(OVERRIDES)) { HAS[key] = key in G; SAVED[key] = G[key]; G[key] = OVERRIDES[key]; }
+});
+afterAll(async () => {
+  await settle();
+  for (const key of Object.keys(OVERRIDES)) { if (HAS[key]) G[key] = SAVED[key]; else delete G[key]; }
+});
+
+let roots: Root[] = [];
+beforeEach(() => { dom.document.body.replaceChildren(); roots = []; fetchCalls.length = 0; fetchResponse = { ok: true, status: 200, payload: { reseat: "requested" } }; });
+afterEach(async () => { for (const r of roots) flushSync(() => r.unmount()); roots = []; await settle(); });
+
+function mount(node: React.ReactElement): Root {
+  const host = dom.document.createElement("div");
+  dom.document.body.appendChild(host);
+  const root = createRoot(host as unknown as Element);
+  flushSync(() => root.render(node));
+  roots.push(root);
+  return root;
+}
+
+function limitedEntry(overrides: Partial<FileEntry> = {}): FileEntry {
+  return {
+    path: "/sessions/limited.jsonl",
+    root: "codex-sessions",
+    name: "limited.jsonl",
+    project: "demo",
+    title: "Implementer",
+    engine: "codex",
+    kind: "session",
+    fmt: "codex",
+    parent: null,
+    mtime: 1_000,
+    size: 10,
+    activity: "live",
+    proc: "running",
+    pid: 42,
+    model: null,
+    pendingQuestion: null,
+    waitingInput: null,
+    conversationId: "conversation_limited",
+    rateLimit: { source: "pane", accountId: "limited", window: "session", resetAt: null },
+    ...overrides,
+  };
+}
+
+test("a tap on the mobile card fires exactly one lineage-checked reseat", async () => {
+  mount(<RateLimitBadge file={limitedEntry()} />);
+
+  const badge = dom.document.querySelector("[data-rate-limited]");
+  expect(badge).not.toBeNull();
+  const button = dom.document.querySelector("[data-rate-limit-reseat]") as unknown as HTMLButtonElement;
+  expect(button).not.toBeNull();
+
+  flushSync(() => { button.click(); });
+  await settle();
+  /* Disabled while requested: a second impatient tap must not double-post. */
+  flushSync(() => { button.click(); });
+  await settle();
+
+  expect(fetchCalls).toHaveLength(1);
+  expect(fetchCalls[0]!.url).toBe("/api/conversations/conversation_limited/migration");
+  expect(fetchCalls[0]!.body).toEqual({ action: "reseat", path: "/sessions/limited.jsonl" });
+  expect(button.hasAttribute("disabled")).toBeTrue();
+});
+
+test("a card already owned by a migration offers no reseat", () => {
+  mount(
+    <RateLimitBadge
+      file={limitedEntry({
+        migration: { intentId: "intent", trigger: "manual", phase: "successor-starting", targetAccountId: "healthy", failure: null },
+      })}
+    />,
+  );
+
+  expect(dom.document.querySelector("[data-rate-limited]")).not.toBeNull();
+  expect(dom.document.querySelector("[data-rate-limit-reseat]")).toBeNull();
+});
+
+test("a refused reseat announces its public reason instead of failing silently", async () => {
+  fetchResponse = { ok: false, status: 409, payload: { error: "no healthy account with fresh quota headroom is available" } };
+  mount(<RateLimitBadge file={limitedEntry()} />);
+
+  const button = dom.document.querySelector("[data-rate-limit-reseat]") as unknown as HTMLButtonElement;
+  flushSync(() => { button.click(); });
+  await settle();
+
+  const alert = dom.document.querySelector("[role=alert]");
+  expect(alert?.textContent).toContain("no healthy account");
+  expect(button.hasAttribute("disabled")).toBeFalse();
+});

--- a/src/components/RateLimitBadge.tsx
+++ b/src/components/RateLimitBadge.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { Loader2, RefreshCcw } from "lucide-react";
+import { Check, Loader2, RefreshCcw } from "lucide-react";
 
 import { Badge } from "@/components/ui/Badge";
 import { postConversationReseat } from "@/lib/accounts/migration";
@@ -17,17 +17,23 @@ import { rateLimitText } from "./rateLimit";
  * present — lineage stays owned by the account-migration coordinator (#40),
  * this is just its per-card trigger. The server re-checks lineage and picks
  * the healthiest account itself, so a stale card can never fork a duplicate
- * successor.
+ * successor; when it reports the successor already exists, the card renders
+ * that as the terminal truth instead of pretending a new reseat started.
  */
 export function RateLimitBadge({ rateLimit, file }: { rateLimit?: RateLimitState | null; file?: FileEntry }) {
   const { locale, t } = useLocale();
-  const [reseat, setReseat] = useState<"idle" | "pending" | "requested" | "failed">("idle");
+  const [reseat, setReseat] = useState<"idle" | "pending" | "requested" | "already-reseated" | "failed">("idle");
+  const [reseatPhase, setReseatPhase] = useState<string | null>(null);
   const [reseatError, setReseatError] = useState<string | null>(null);
   const limit = rateLimit ?? file?.rateLimit;
   if (!limit) return null;
   const label = rateLimitText(t, locale, limit);
   const canReseat = Boolean(file?.conversationId && !file.migration);
   const busy = reseat === "pending" || reseat === "requested";
+  const settled = reseat === "already-reseated";
+  const buttonTitle = settled
+    ? t("rateLimit.reseatAlready")
+    : reseatError ?? (reseat === "requested" && reseatPhase === "waiting-turn" ? t("rateLimit.reseatWaitingTurn") : t("rateLimit.reseatTitle"));
   return (
     <>
       <Badge tone="danger" data-rate-limited="" title={label}>
@@ -37,21 +43,25 @@ export function RateLimitBadge({ rateLimit, file }: { rateLimit?: RateLimitState
         <button
           type="button"
           data-rate-limit-reseat=""
-          disabled={busy}
+          {...(settled ? { "data-rate-limit-reseated": "" } : {})}
+          disabled={busy || settled}
           className="inline-flex shrink-0 touch-manipulation items-center gap-1 rounded-full border border-danger/40 bg-canvas px-1.5 py-0.5 text-[9.5px] font-bold text-danger hover:border-accent/45 hover:text-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 disabled:opacity-60"
-          title={reseatError ?? t("rateLimit.reseatTitle")}
+          title={buttonTitle}
           onClick={async (event) => {
             /* The chip lives inside clickable cards — the action must not
                open/focus the column. */
             event.stopPropagation();
-            if (busy) return;
+            if (busy || settled) return;
             setReseat("pending");
             setReseatError(null);
             const result = await postConversationReseat(file!.conversationId!, file!.path);
             if (result.ok) {
-              /* Stay disabled until the next poll swaps in the migration
-                 ribbon; the server is idempotent either way. */
-              setReseat("requested");
+              /* "already-reseated" is terminal: a successor owns this thread,
+                 the stale card must never look like it started a new reseat.
+                 Otherwise stay disabled until the next poll swaps in the
+                 migration ribbon; the server is idempotent either way. */
+              setReseat(result.state === "already-reseated" ? "already-reseated" : "requested");
+              setReseatPhase(result.phase);
             } else {
               setReseat("failed");
               setReseatError(result.error);
@@ -61,10 +71,12 @@ export function RateLimitBadge({ rateLimit, file }: { rateLimit?: RateLimitState
         >
           {busy ? (
             <Loader2 className="h-2.5 w-2.5 animate-spin motion-reduce:animate-none" aria-hidden />
+          ) : settled ? (
+            <Check className="h-2.5 w-2.5" aria-hidden />
           ) : (
             <RefreshCcw className="h-2.5 w-2.5" aria-hidden />
           )}
-          {reseat === "requested" ? t("rateLimit.reseatRequested") : t("rateLimit.reseat")}
+          {settled ? t("rateLimit.reseatAlready") : reseat === "requested" ? t("rateLimit.reseatRequested") : t("rateLimit.reseat")}
         </button>
       ) : null}
       {reseat === "failed" ? (

--- a/src/components/RateLimitBadge.tsx
+++ b/src/components/RateLimitBadge.tsx
@@ -1,18 +1,77 @@
 "use client";
 
+import { useState } from "react";
+import { Loader2, RefreshCcw } from "lucide-react";
+
 import { Badge } from "@/components/ui/Badge";
+import { postConversationReseat } from "@/lib/accounts/migration";
 import { useLocale } from "@/lib/i18n";
-import type { RateLimitState } from "@/lib/types";
+import type { FileEntry, RateLimitState } from "@/lib/types";
 
 import { rateLimitText } from "./rateLimit";
 
-export function RateLimitBadge({ rateLimit }: { rateLimit?: RateLimitState | null }) {
+/**
+ * Rate-limit chip plus the one-click successor reseat (issue #97). The button
+ * shows only for a conversation the registry can move safely: it needs the
+ * stable `conversationId` and stands down while any migration annotation is
+ * present — lineage stays owned by the account-migration coordinator (#40),
+ * this is just its per-card trigger. The server re-checks lineage and picks
+ * the healthiest account itself, so a stale card can never fork a duplicate
+ * successor.
+ */
+export function RateLimitBadge({ rateLimit, file }: { rateLimit?: RateLimitState | null; file?: FileEntry }) {
   const { locale, t } = useLocale();
-  if (!rateLimit) return null;
-  const label = rateLimitText(t, locale, rateLimit);
+  const [reseat, setReseat] = useState<"idle" | "pending" | "requested" | "failed">("idle");
+  const [reseatError, setReseatError] = useState<string | null>(null);
+  const limit = rateLimit ?? file?.rateLimit;
+  if (!limit) return null;
+  const label = rateLimitText(t, locale, limit);
+  const canReseat = Boolean(file?.conversationId && !file.migration);
+  const busy = reseat === "pending" || reseat === "requested";
   return (
-    <Badge tone="danger" data-rate-limited="" title={label}>
-      {label}
-    </Badge>
+    <>
+      <Badge tone="danger" data-rate-limited="" title={label}>
+        {label}
+      </Badge>
+      {canReseat ? (
+        <button
+          type="button"
+          data-rate-limit-reseat=""
+          disabled={busy}
+          className="inline-flex shrink-0 touch-manipulation items-center gap-1 rounded-full border border-danger/40 bg-canvas px-1.5 py-0.5 text-[9.5px] font-bold text-danger hover:border-accent/45 hover:text-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 disabled:opacity-60"
+          title={reseatError ?? t("rateLimit.reseatTitle")}
+          onClick={async (event) => {
+            /* The chip lives inside clickable cards — the action must not
+               open/focus the column. */
+            event.stopPropagation();
+            if (busy) return;
+            setReseat("pending");
+            setReseatError(null);
+            const result = await postConversationReseat(file!.conversationId!, file!.path);
+            if (result.ok) {
+              /* Stay disabled until the next poll swaps in the migration
+                 ribbon; the server is idempotent either way. */
+              setReseat("requested");
+            } else {
+              setReseat("failed");
+              setReseatError(result.error);
+            }
+          }}
+          onKeyDown={(event) => event.stopPropagation()}
+        >
+          {busy ? (
+            <Loader2 className="h-2.5 w-2.5 animate-spin motion-reduce:animate-none" aria-hidden />
+          ) : (
+            <RefreshCcw className="h-2.5 w-2.5" aria-hidden />
+          )}
+          {reseat === "requested" ? t("rateLimit.reseatRequested") : t("rateLimit.reseat")}
+        </button>
+      ) : null}
+      {reseat === "failed" ? (
+        <span role="alert" aria-live="assertive" className="min-w-0 truncate text-[9.5px] font-semibold text-danger" title={reseatError ?? undefined}>
+          {reseatError ?? t("rateLimit.reseatFailed")}
+        </span>
+      ) : null}
+    </>
   );
 }

--- a/src/components/SwitchCard.tsx
+++ b/src/components/SwitchCard.tsx
@@ -81,7 +81,7 @@ export function SwitchCard({ file, title, project, currentProject, descendants, 
           <span className="shrink-0 rounded-full px-1.5 py-0.5 text-[9.5px] font-bold" style={badge.style}>{badge.label}</span>
         )}
         <EffortPills file={file} />
-        <RateLimitBadge rateLimit={file.rateLimit} />
+        <RateLimitBadge file={file} />
         <WakeupChip key={wakeupChipKey(file.pendingWakeup)} wakeup={file.pendingWakeup} />
         <span
           className={`ml-auto min-w-0 truncate rounded-full border border-border bg-canvas px-1.5 py-0.5 text-[9.5px] font-semibold ${

--- a/src/components/scheme/nodes.tsx
+++ b/src/components/scheme/nodes.tsx
@@ -646,7 +646,7 @@ function LiteNodeShell({ node, ringed, dimmed, flow }: { node: SchemeNode; ringe
             {badge.label}
           </span>
           {node.file.model ? <span className="min-w-0 truncate font-mono text-[11px] text-muted">{node.file.model}</span> : null}
-          <RateLimitBadge rateLimit={node.file.rateLimit} />
+          <RateLimitBadge file={node.file} />
           {/* pointer-events-auto re-enables taps for just the chip inside the
               map's pointer-events-none layer, so its reason disclosure works at
               390px; the chip's own guard keeps the tap from opening the pane. */}

--- a/src/lib/accounts/migration.ts
+++ b/src/lib/accounts/migration.ts
@@ -413,6 +413,9 @@ export async function postConversationMigration(
 export interface ConversationReseatResult {
   ok: boolean;
   state: "requested" | "already-migrating" | "already-reseated" | "failed";
+  /** Exact server-side wait state ("waiting-turn" while a walled turn still
+      owns the pane) so the card can say what the reseat is waiting on. */
+  phase: string | null;
   /** Public failure detail from the route, safe to show; null otherwise. */
   error: string | null;
 }
@@ -429,22 +432,23 @@ export async function postConversationReseat(
   conversationId: string,
   path: string,
 ): Promise<ConversationReseatResult> {
-  if (!conversationId.startsWith("conversation_")) return { ok: false, state: "failed", error: null };
+  if (!conversationId.startsWith("conversation_")) return { ok: false, state: "failed", phase: null, error: null };
   try {
     const response = await fetch(`/api/conversations/${encodeURIComponent(conversationId)}/migration`, {
       method: "POST",
       headers: { "content-type": "application/json" },
       body: JSON.stringify({ action: "reseat", path }),
     });
-    const body = (await response.json().catch(() => null)) as { reseat?: unknown; error?: unknown } | null;
+    const body = (await response.json().catch(() => null)) as { reseat?: unknown; phase?: unknown; error?: unknown } | null;
     const reseat = str(body?.reseat);
+    const phase = str(body?.phase);
     if (response.ok) {
-      return { ok: true, state: reseat === "already-migrating" ? "already-migrating" : "requested", error: null };
+      return { ok: true, state: reseat === "already-migrating" ? "already-migrating" : "requested", phase, error: null };
     }
-    if (reseat === "already-reseated") return { ok: true, state: "already-reseated", error: null };
-    return { ok: false, state: "failed", error: str(body?.error) };
+    if (reseat === "already-reseated") return { ok: true, state: "already-reseated", phase: null, error: null };
+    return { ok: false, state: "failed", phase: null, error: str(body?.error) };
   } catch {
-    return { ok: false, state: "failed", error: null };
+    return { ok: false, state: "failed", phase: null, error: null };
   }
 }
 

--- a/src/lib/accounts/migration.ts
+++ b/src/lib/accounts/migration.ts
@@ -407,6 +407,47 @@ export async function postConversationMigration(
   }
 }
 
+/** Result of the one-click rate-limit reseat (issue #97). `state` mirrors the
+    route's idempotent outcomes so the card can tell "requested" from "someone
+    already moved this thread" without a second poll. */
+export interface ConversationReseatResult {
+  ok: boolean;
+  state: "requested" | "already-migrating" | "already-reseated" | "failed";
+  /** Public failure detail from the route, safe to show; null otherwise. */
+  error: string | null;
+}
+
+/**
+ * One-click healthy-account successor reseat against
+ * `POST /api/conversations/{conversationId}/migration` with `action:"reseat"`.
+ * The server checks registry lineage first and never duplicates a successor;
+ * `path` pins the request to the generation the card renders, so acting on a
+ * stale card (a fork already replaced it) resolves as `already-reseated`
+ * instead of forking again.
+ */
+export async function postConversationReseat(
+  conversationId: string,
+  path: string,
+): Promise<ConversationReseatResult> {
+  if (!conversationId.startsWith("conversation_")) return { ok: false, state: "failed", error: null };
+  try {
+    const response = await fetch(`/api/conversations/${encodeURIComponent(conversationId)}/migration`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ action: "reseat", path }),
+    });
+    const body = (await response.json().catch(() => null)) as { reseat?: unknown; error?: unknown } | null;
+    const reseat = str(body?.reseat);
+    if (response.ok) {
+      return { ok: true, state: reseat === "already-migrating" ? "already-migrating" : "requested", error: null };
+    }
+    if (reseat === "already-reseated") return { ok: true, state: "already-reseated", error: null };
+    return { ok: false, state: "failed", error: str(body?.error) };
+  } catch {
+    return { ok: false, state: "failed", error: null };
+  }
+}
+
 /**
  * Parses a preview response from POST …/active `mode:"preview"`.
  *

--- a/src/lib/accounts/migration/contracts.ts
+++ b/src/lib/accounts/migration/contracts.ts
@@ -190,6 +190,11 @@ export interface MigrationIntent {
   engine: MigrationEngine;
   targetId: string;
   origin: MigrationOrigin;
+  /** An engine drain moves every conversation and owns routing, the Accounts
+      panel banner, and the auto-balance outcome/cooldown. A conversation
+      intent (issue #97 reseat) moves exactly one thread and must stay
+      invisible to all engine-wide machinery. Absent on pre-#97 data: engine. */
+  scope?: "engine" | "conversation";
   revision: number;
   state: MigrationIntentState;
   createdAt: string;

--- a/src/lib/accounts/migration/coordinator.test.ts
+++ b/src/lib/accounts/migration/coordinator.test.ts
@@ -2860,4 +2860,64 @@ describe("durable account migration coordinator", () => {
     expect(JSON.stringify(failed.migration)).not.toContain("durability check failed");
     expect(cleaned).toEqual(["failed-successor"]);
   });
+
+  test("a current pane wall releases a mid-turn reseat on the next inventory pass", async () => {
+    /* Issue #97: the engine printed a live usage wall mid-turn — that turn
+       will never complete, so the reseat must not park in waiting-turn until
+       the reset hour. The wall itself is the release evidence. */
+    const store = registry();
+    const pathname = path.join(path.dirname(store.filename), "walled-mid-turn.jsonl");
+    fs.writeFileSync(pathname, JSON.stringify({ type: "event_msg", timestamp: "2026-07-10T18:00:00.000Z", payload: { type: "task_started" } }) + "\n");
+    store.reconcileConversations([observation(pathname, "limited", "busy")]);
+    const conversation = store.conversationForPath(pathname)!;
+    expect(store.requestConversationReseat(conversation.id, "healthy").migration?.phase).toBe("waiting-turn");
+
+    const counts = { create: 0, verify: 0 };
+    await reconcileMigrationInventory(store, [inventoryEntry(pathname, { activity: "stalled", activityReason: undefined })]);
+    await advanceConversationMigration(conversation.id, store, provider(["/walled-successor.jsonl"], counts));
+    expect(counts.create).toBe(0);
+    expect(store.conversation(conversation.id)?.migration?.phase).toBe("waiting-turn");
+
+    await reconcileMigrationInventory(store, [inventoryEntry(pathname, {
+      activity: "stalled",
+      activityReason: undefined,
+      rateLimit: { source: "pane", accountId: "limited", window: "session", resetAt: 1_784_000_000 },
+    })]);
+    expect(store.conversation(conversation.id)?.turn.state).toBe("idle");
+    const advanced = await advanceConversationMigration(conversation.id, store, provider(["/walled-successor.jsonl"], counts));
+    expect(counts.create).toBe(1);
+    expect(advanced.migration?.phase).toBe("committed");
+  });
+
+  test("a conversation reseat completes without booking the engine auto-balance outcome or cooldown", async () => {
+    const store = registry();
+    store.reconcileConversations([
+      observation("/reseat-source.jsonl", "limited", "idle"),
+      observation("/engine-source.jsonl", "limited", "idle"),
+    ]);
+    const reseated = store.conversationForPath("/reseat-source.jsonl")!;
+    store.requestConversationReseat(reseated.id, "healthy");
+    await reconcileMigrations(provider(["/reseat-successor.jsonl"]), { async deliver() { return "delivered"; } }, store);
+
+    const settled = store.conversation(reseated.id)!;
+    expect(settled.migration?.phase).toBe("committed");
+    expect(store.snapshot().migrationIntents[settled.migration!.intentId]).toMatchObject({ scope: "conversation", state: "complete" });
+    /* One thread moved: engine auto-balance stays free to act. */
+    const policy = store.autoBalancePolicy("codex");
+    expect(policy.cooldownUntil).toBeNull();
+    expect(policy.lastOutcome).toBeNull();
+
+    /* The engine-wide drain keeps its outcome/cooldown contract. */
+    store.commitMigrationIntent({
+      engine: "codex",
+      targetId: "b",
+      origin: "manual",
+      requestId: "engine-after-reseat",
+      expectedRevision: store.engineRouting("codex").revision,
+    });
+    await reconcileMigrations(provider(["/engine-successor-1.jsonl", "/engine-successor-2.jsonl"]), { async deliver() { return "delivered"; } }, store);
+    const balanced = store.autoBalancePolicy("codex");
+    expect(balanced.cooldownUntil).not.toBeNull();
+    expect(balanced.lastOutcome?.kind).toBe("switched");
+  });
 });

--- a/src/lib/accounts/migration/coordinator.ts
+++ b/src/lib/accounts/migration/coordinator.ts
@@ -48,6 +48,14 @@ function engineOf(entry: FileEntry): MigrationEngine | null {
   return entry.engine === "claude" || entry.engine === "codex" ? entry.engine : null;
 }
 
+/** A current pane usage wall (issue #97): the scanner only sets `rateLimit`
+    from a live banner (historical prose is filtered per #56), which means the
+    engine has surrendered the turn — the transcript will not advance before
+    the reset, so for migration purposes the composer is effectively free. */
+function currentPaneWall(entry: FileEntry): boolean {
+  return entry.rateLimit != null;
+}
+
 function projectedInventoryTurn(
   entry: FileEntry,
   parsed: ConversationObservation["turn"] | null,
@@ -61,7 +69,7 @@ function projectedInventoryTurn(
   }
 
   const activityComplete = entry.derivationComplete !== false;
-  if (parsed.state === "busy" && activityComplete && entry.activityReason === "pane_at_composer") {
+  if (parsed.state === "busy" && activityComplete && (entry.activityReason === "pane_at_composer" || currentPaneWall(entry))) {
     return { state: "idle", source: "empty", terminalAt: null };
   }
   if (parsed.state === "unknown" && activityComplete && (entry.activity === "idle" || entry.activity === "recent")) {
@@ -101,7 +109,7 @@ async function inventory(files: FileEntry[], registry: AgentRegistry): Promise<C
     const mtimeMs = entry.mtime * 1000;
     const observedTurn = transcriptTurnResult(entry.path, entry.size, mtimeMs, engine === "codex");
     const parsed = observedTurn.complete ? observedTurn.turn : null;
-    if (observedTurn.complete && entry.derivationComplete !== false && entry.activityReason === "pane_at_composer") {
+    if (observedTurn.complete && entry.derivationComplete !== false && (entry.activityReason === "pane_at_composer" || currentPaneWall(entry))) {
       recordTranscriptComposerRelease(entry.path, entry.size, mtimeMs, engine === "codex");
     }
     const turn = projectedInventoryTurn(entry, parsed, existing);
@@ -631,6 +639,10 @@ export async function reconcileMigrations(
     const owned = conversationsByIntent.get(intent.id) ?? [];
     if (!owned.length || owned.every((conversation) => ["committed", "rolled-back", "failed-recoverable"].includes(conversation.migration?.phase ?? ""))) {
       registry.setMigrationIntentState(intent.id, "complete");
+      /* A conversation-scoped reseat (issue #97) settles one thread: it must
+         not book an engine-wide balance outcome nor start the auto-balance
+         cooldown that would suppress a real engine drain. */
+      if (intent.scope === "conversation") return;
       const outcome = owned.some((conversation) => conversation.migration?.phase === "failed-recoverable") ? "failed-partial" : "complete";
       registry.recordAutoBalanceOutcome(intent.engine, outcome, intent.evidence, new Date(Date.now() + AUTO_BALANCE_COOLDOWN_MS).toISOString());
     }

--- a/src/lib/accounts/reseat.test.ts
+++ b/src/lib/accounts/reseat.test.ts
@@ -1,0 +1,52 @@
+import { expect, test } from "bun:test";
+
+import type { DurableQuotaObservation } from "@/lib/accounts/migration/contracts";
+
+import { chooseReseatTarget } from "./reseat";
+
+const NOW = Date.parse("2026-07-10T18:00:00.000Z");
+
+function observation(accountId: string, usedPercent: number, over: Partial<DurableQuotaObservation> = {}): DurableQuotaObservation {
+  return {
+    engine: "codex",
+    accountId,
+    authenticated: true,
+    authCheckedAt: "2026-07-10T17:59:00.000Z",
+    limits: { session: { usedPercent, resetsAt: null }, weekly: null, plan: null, capturedAt: null },
+    provenance: { source: "live", reason: null, staleSince: null },
+    observedAt: "2026-07-10T17:59:00.000Z",
+    bootId: "boot",
+    ...over,
+  };
+}
+
+const ACCOUNTS = [
+  { id: "limited", label: "Main" },
+  { id: "backup", label: "Backup" },
+  { id: "spare", label: "Spare" },
+];
+
+test("the healthiest known account wins and the exhausted source is excluded", () => {
+  const target = chooseReseatTarget("limited", [
+    observation("limited", 100),
+    observation("backup", 40),
+    observation("spare", 10),
+  ], ACCOUNTS, NOW);
+
+  expect(target).toEqual({ accountId: "spare", label: "Spare", remainingPercent: 90, window: "session" });
+});
+
+test("stale, unauthenticated, thresholded, or unknown accounts never qualify", () => {
+  expect(chooseReseatTarget("limited", [
+    observation("backup", 40, { observedAt: "2026-07-10T17:00:00.000Z" }),
+  ], ACCOUNTS, NOW)).toBeNull();
+  expect(chooseReseatTarget("limited", [
+    observation("backup", 40, { authenticated: false }),
+  ], ACCOUNTS, NOW)).toBeNull();
+  expect(chooseReseatTarget("limited", [
+    observation("backup", 80),
+  ], ACCOUNTS, NOW)).toBeNull();
+  expect(chooseReseatTarget("limited", [
+    observation("removed-account", 10),
+  ], ACCOUNTS, NOW)).toBeNull();
+});

--- a/src/lib/accounts/reseat.ts
+++ b/src/lib/accounts/reseat.ts
@@ -1,0 +1,45 @@
+import type { DurableQuotaObservation } from "@/lib/accounts/migration/contracts";
+import { AUTO_BALANCE_THRESHOLD, effectiveRemaining } from "@/lib/accounts/migration/quotaPolicy";
+
+/** A healthy successor account for a one-click reseat (issue #97). */
+export interface ReseatTarget {
+  accountId: string;
+  label: string;
+  remainingPercent: number;
+  window: "session" | "weekly";
+}
+
+/**
+ * Picks the healthiest known account to reseat a rate-limited conversation
+ * onto. Conservative on purpose: only accounts with a fresh, live,
+ * authenticated quota observation and real headroom (above the auto-balance
+ * threshold) qualify — a stale or unknown account is never chosen, the
+ * operator resolves those through the Accounts panel (#40). Returns `null`
+ * when no such account exists.
+ */
+export function chooseReseatTarget(
+  currentAccountId: string,
+  observations: readonly DurableQuotaObservation[],
+  accounts: readonly { id: string; label: string }[],
+  now = Date.now(),
+): ReseatTarget | null {
+  const labels = new Map(accounts.map((account) => [account.id, account.label] as const));
+  const candidates = observations.flatMap((observation) => {
+    if (observation.accountId === currentAccountId) return [];
+    const label = labels.get(observation.accountId);
+    if (label === undefined) return [];
+    const remaining = effectiveRemaining({
+      engine: observation.engine,
+      accountId: observation.accountId,
+      authenticated: observation.authenticated,
+      limits: observation.limits,
+      provenance: observation.provenance,
+      observedAt: Date.parse(observation.observedAt),
+      authCheckedAt: Date.parse(observation.authCheckedAt),
+    }, now);
+    if (!remaining || remaining.percent <= AUTO_BALANCE_THRESHOLD) return [];
+    return [{ accountId: observation.accountId, label, remainingPercent: remaining.percent, window: remaining.window }];
+  });
+  return candidates.sort((left, right) =>
+    right.remainingPercent - left.remainingPercent || left.accountId.localeCompare(right.accountId))[0] ?? null;
+}

--- a/src/lib/agent/registry.reseat.test.ts
+++ b/src/lib/agent/registry.reseat.test.ts
@@ -70,9 +70,68 @@ for (const mode of ["off", "sqlite"] as const) {
     const source = restored.generations.at(-1)!;
     expect(source.launchProfile.cwd).toBe("/repo/checkout");
     expect(source.launchProfile.parentConversationId).toBe("conversation_parent");
-    expect(Object.values(reopened.snapshot().migrationIntents)).toHaveLength(1);
+    const intents = Object.values(reopened.snapshot().migrationIntents);
+    expect(intents).toHaveLength(1);
+    /* The reseat rides a conversation-scoped intent and must still be one
+       after restart — an engine-scoped survivor would drain the whole engine. */
+    expect(intents[0]).toMatchObject({ scope: "conversation", targetId: "healthy", state: "draining" });
   });
 }
+
+test("a conversation reseat never reuses or retargets the single engine drain intent", () => {
+  const { store, id } = seededRegistry("off", registryFile());
+  const reseated = store.requestConversationReseat(id, "healthy");
+  const reseatIntentId = reseated.migration!.intentId;
+  expect(store.snapshot().migrationIntents[reseatIntentId]).toMatchObject({ scope: "conversation", targetId: "healthy", state: "draining" });
+
+  /* An engine-wide drain that starts while the reseat is in flight must mint
+     its own intent instead of adopting and retargeting the reseat's. */
+  const engineIntent = store.upsertMigrationIntent("codex", "engine-target", "manual", "engine-drain-request");
+  expect(engineIntent.id).not.toBe(reseatIntentId);
+  expect(store.snapshot().migrationIntents[reseatIntentId]).toMatchObject({ scope: "conversation", targetId: "healthy", requestIds: [`reseat:${id}:${reseated.migration!.sourceGenerationId}`] });
+
+  /* Single engine-drain invariant: exactly one engine-scoped draining intent,
+     and repeat engine requests keep converging on it. */
+  const engineDrains = Object.values(store.snapshot().migrationIntents)
+    .filter((intent) => intent.state === "draining" && (intent.scope ?? "engine") === "engine");
+  expect(engineDrains).toHaveLength(1);
+  expect(engineDrains[0]!.id).toBe(engineIntent.id);
+  expect(store.upsertMigrationIntent("codex", "engine-target", "manual", "engine-drain-repeat").id).toBe(engineIntent.id);
+});
+
+test("a new spawn during a conversation reseat is never adopted into the drain", () => {
+  const { store, id } = seededRegistry("off", registryFile());
+  store.requestConversationReseat(id, "healthy");
+
+  const spawnEntry = (sessionId: string, artifactPath: string) => ({
+    key: { engine: "codex" as const, sessionId },
+    artifactPath,
+    cwd: "/repo/checkout",
+    accountId: "limited",
+    status: "live" as const,
+    host: null,
+    claimEpoch: 0,
+    claimOwner: null,
+    pendingAction: null,
+  });
+  const spawn = store.beginSpawn("codex", "/repo/checkout");
+  const settled = store.settleSpawn(spawn.launchId, spawnEntry("019f4906-3f67-7b72-9fbc-9ec3b5ad1326", "/sessions/unrelated-spawn.jsonl"));
+  expect(settled.kind).toBe("settled");
+  expect(store.conversationForPath("/sessions/unrelated-spawn.jsonl")!.migration).toBeNull();
+
+  /* The engine-wide contract is untouched: once a real engine drain is
+     active, a spawn born on the departed account is still adopted. */
+  store.commitMigrationIntent({
+    engine: "codex",
+    targetId: "engine-target",
+    origin: "manual",
+    requestId: "engine-wide-after-reseat",
+    expectedRevision: store.engineRouting("codex").revision,
+  });
+  const second = store.beginSpawn("codex", "/repo/checkout");
+  expect(store.settleSpawn(second.launchId, spawnEntry("019f4906-3f67-7b72-9fbc-9ec3b5ad1327", "/sessions/adopted-spawn.jsonl")).kind).toBe("settled");
+  expect(store.conversationForPath("/sessions/adopted-spawn.jsonl")!.migration).toMatchObject({ targetId: "engine-target" });
+});
 
 test("repeat reseat clicks never mint a second successor operation", () => {
   const { store, id } = seededRegistry("off", registryFile());

--- a/src/lib/agent/registry.reseat.test.ts
+++ b/src/lib/agent/registry.reseat.test.ts
@@ -1,0 +1,115 @@
+import { afterEach, expect, test } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { emptyLaunchProfile, type ViewerConversationId } from "@/lib/accounts/migration/contracts";
+
+import { AgentRegistry, type AgentRegistrySqliteMode, type ConversationObservation } from "./registry";
+
+/*
+ * Issue #97 — one-click successor reseat of a rate-limited conversation.
+ * The registry seam must be lineage-safe (no duplicate successor, ever) and
+ * durable across a viewer restart in both persistence modes.
+ */
+
+const roots: string[] = [];
+
+afterEach(() => {
+  for (const root of roots.splice(0)) fs.rmSync(root, { recursive: true, force: true });
+});
+
+function registryFile(): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "llv-registry-reseat-"));
+  roots.push(root);
+  return path.join(root, "agent-registry.json");
+}
+
+function observation(pathname: string, accountId: string): ConversationObservation {
+  return {
+    engine: "codex",
+    path: pathname,
+    accountId,
+    launchProfile: emptyLaunchProfile({
+      cwd: "/repo/checkout",
+      model: "gpt-5.6-terra",
+      title: "Implementer",
+      project: "repo",
+      role: "worker",
+      parentConversationId: "conversation_parent",
+    }),
+    turn: { state: "idle", source: "empty", terminalAt: null },
+    observedAt: "2026-07-10T18:00:00.000Z",
+  };
+}
+
+function seededRegistry(mode: AgentRegistrySqliteMode, filename: string): { store: AgentRegistry; id: ViewerConversationId } {
+  const store = new AgentRegistry(filename, undefined, undefined, { sqliteMode: mode });
+  store.reconcileConversations([observation("/sessions/limited.jsonl", "limited")]);
+  const id = store.conversationForPath("/sessions/limited.jsonl")!.id;
+  return { store, id };
+}
+
+for (const mode of ["off", "sqlite"] as const) {
+  test(`a requested reseat survives a ${mode === "off" ? "JSON" : "SQLite"} registry restart with cwd and parentage intact`, () => {
+    const filename = registryFile();
+    const { store, id } = seededRegistry(mode, filename);
+    const requested = store.requestConversationReseat(id, "healthy");
+    expect(requested.migration).toMatchObject({ targetId: "healthy", phase: "requested" });
+
+    const reopened = new AgentRegistry(filename, undefined, undefined, { sqliteMode: mode });
+    const restored = reopened.conversation(id)!;
+    expect(restored.migration).toMatchObject({
+      targetId: "healthy",
+      phase: "requested",
+      operationId: requested.migration!.operationId,
+      sourceGenerationId: requested.migration!.sourceGenerationId,
+    });
+    /* The successor inherits the source launch profile at commit time — the
+       restart must not lose the cwd/parent lineage the fork will copy. */
+    const source = restored.generations.at(-1)!;
+    expect(source.launchProfile.cwd).toBe("/repo/checkout");
+    expect(source.launchProfile.parentConversationId).toBe("conversation_parent");
+    expect(Object.values(reopened.snapshot().migrationIntents)).toHaveLength(1);
+  });
+}
+
+test("repeat reseat clicks never mint a second successor operation", () => {
+  const { store, id } = seededRegistry("off", registryFile());
+  const first = store.requestConversationReseat(id, "healthy");
+  const second = store.requestConversationReseat(id, "healthy");
+  expect(second.migration!.operationId).toBe(first.migration!.operationId);
+  expect(Object.values(store.snapshot().migrationIntents)).toHaveLength(1);
+
+  /* Even a click that races the coordinator mid-fork (any in-flight phase, any
+     target) must not re-request: the running operation owns the successor. */
+  const inFlight = store.transitionConversationMigration(id, first.migration!.revision, ["requested"], { phase: "successor-starting" });
+  const raced = store.requestConversationReseat(id, "other-healthy");
+  expect(raced.migration).toMatchObject({
+    targetId: "healthy",
+    phase: "successor-starting",
+    operationId: inFlight.migration!.operationId,
+  });
+});
+
+test("a thread a migration already forked is never reseated again", () => {
+  const { store, id } = seededRegistry("off", registryFile());
+  const requested = store.requestConversationReseat(id, "healthy");
+  const revision = requested.migration!.revision;
+  store.transitionConversationMigration(id, revision, ["requested"], { phase: "preparing" });
+  store.transitionConversationMigration(id, revision, ["preparing"], { phase: "successor-starting" });
+  store.transitionConversationMigration(id, revision, ["successor-starting"], { phase: "verifying" });
+  const committed = store.commitSuccessor(id, {
+    id: "successor-native-id",
+    path: "/sessions/successor.jsonl",
+    accountId: "healthy",
+  }, revision);
+  expect(committed.migration!.phase).toBe("committed");
+  expect(committed.generations).toHaveLength(2);
+  expect(committed.generations.at(-1)!.launchProfile.cwd).toBe("/repo/checkout");
+
+  const repeated = store.requestConversationReseat(id, "healthy");
+  expect(repeated.migration!.phase).toBe("committed");
+  expect(repeated.migration!.operationId).toBe(committed.migration!.operationId);
+  expect(repeated.generations).toHaveLength(2);
+});

--- a/src/lib/agent/registry.ts
+++ b/src/lib/agent/registry.ts
@@ -318,6 +318,13 @@ export interface MigrationScopeCounts {
   alreadyTarget: number;
 }
 
+/** Engine-wide drain machinery (routing, spawn adoption, the single-drain
+    invariant, auto-balance) must never observe a conversation-scoped reseat
+    intent (issue #97). Pre-#97 persisted intents carry no scope: engine. */
+function engineScopedIntent(intent: MigrationIntent): boolean {
+  return (intent.scope ?? "engine") === "engine";
+}
+
 function migrationReadiness(
   file: RegistryFile,
   conversation: RegistryConversation,
@@ -2720,9 +2727,10 @@ export class AgentRegistry {
       file.engineRouting[conversation.engine].revision += 1;
     }
     /* A spawn that began before an account switch remains attributable to its
-       birth account. The already-active migration intent still applies to the
-       new conversation through the existing coordinator contract. */
-    const activeIntent = Object.values(file.migrationIntents).find((intent) => intent.engine === conversation.engine && intent.state === "draining");
+       birth account. The already-active engine-wide migration intent still
+       applies to the new conversation through the existing coordinator
+       contract; a conversation-scoped reseat moves only its own thread. */
+    const activeIntent = Object.values(file.migrationIntents).find((intent) => intent.engine === conversation.engine && intent.state === "draining" && engineScopedIntent(intent));
     const source = conversation.generations.at(-1);
     if (activeIntent && source && source.accountId !== activeIntent.targetId && !conversation.migration) {
       conversation.migration = {
@@ -3597,7 +3605,7 @@ export class AgentRegistry {
       if (repeated) return clone(repeated);
       const route = file.engineRouting[input.engine];
       if (route.revision !== input.expectedRevision) throw new MigrationRevisionError(input.expectedRevision, route.revision);
-      let intent = Object.values(file.migrationIntents).find((candidate) => candidate.engine === input.engine && candidate.state === "draining");
+      let intent = Object.values(file.migrationIntents).find((candidate) => candidate.engine === input.engine && candidate.state === "draining" && engineScopedIntent(candidate));
       if (intent?.origin === "manual" && input.origin === "auto") return clone(intent);
       const changedAt = now();
       if (intent) {
@@ -3687,7 +3695,7 @@ export class AgentRegistry {
 
       const changedAt = now();
       let intent = Object.values(file.migrationIntents)
-        .filter((candidate) => candidate.engine === conversation.engine && candidate.targetId === targetId && candidate.state !== "stopped")
+        .filter((candidate) => candidate.engine === conversation.engine && candidate.targetId === targetId && candidate.state !== "stopped" && engineScopedIntent(candidate))
         .sort((left, right) => right.updatedAt.localeCompare(left.updatedAt))[0];
       if (!intent) {
         intent = {
@@ -3726,8 +3734,10 @@ export class AgentRegistry {
       in-flight migration keeps sole ownership of the successor seat — repeat
       requests never mint a second successor. Unlike
       {@link requestConversationMigrationToActiveAccount} the target account is
-      explicit, and engine routing for future spawns is left to the Accounts
-      panel (issue #40): only this conversation moves. */
+      explicit and the intent is conversation-scoped: only this conversation
+      moves, engine routing for future spawns stays with the Accounts panel
+      (issue #40), new spawns are never adopted into the drain, and the single
+      engine-wide drain intent (if any) is neither reused nor retargeted. */
   requestConversationReseat(id: ViewerConversationId, targetId: string): RegistryConversation {
     return this.mutate((file) => {
       const canonicalId = resolveConversationAlias(file, id);
@@ -3742,8 +3752,13 @@ export class AgentRegistry {
 
       const changedAt = now();
       if (conversation.migrationOptOut?.targetId === targetId) conversation.migrationOptOut = null;
+      const requestId = `reseat:${canonicalId}:${source.id}`;
       let intent = Object.values(file.migrationIntents)
-        .filter((candidate) => candidate.engine === conversation.engine && candidate.targetId === targetId && candidate.state !== "stopped")
+        .filter((candidate) => candidate.scope === "conversation"
+          && candidate.engine === conversation.engine
+          && candidate.targetId === targetId
+          && candidate.state !== "stopped"
+          && candidate.requestIds.some((request) => request.startsWith(`reseat:${canonicalId}:`)))
         .sort((left, right) => right.updatedAt.localeCompare(left.updatedAt))[0];
       if (!intent) {
         intent = {
@@ -3751,16 +3766,18 @@ export class AgentRegistry {
           engine: conversation.engine,
           targetId,
           origin: "manual",
+          scope: "conversation",
           revision: 1,
           state: "draining",
           createdAt: changedAt,
           updatedAt: changedAt,
-          requestIds: [`reseat:${canonicalId}:${source.id}`],
+          requestIds: [requestId],
           evidence: null,
           stoppedAt: null,
         };
         file.migrationIntents[intent.id] = intent;
       } else {
+        if (!intent.requestIds.includes(requestId)) intent.requestIds.push(requestId);
         if (intent.state !== "draining") intent.revision += 1;
         intent.state = "draining";
         intent.updatedAt = changedAt;
@@ -3778,7 +3795,7 @@ export class AgentRegistry {
 
   upsertMigrationIntent(engine: Extract<AgentEngine, "claude" | "codex">, targetId: string, origin: MigrationOrigin, requestId: string, evidence: MigrationIntent["evidence"] = null): MigrationIntent {
     return this.mutate((file) => {
-      const active = Object.values(file.migrationIntents).find((intent) => intent.engine === engine && intent.state === "draining");
+      const active = Object.values(file.migrationIntents).find((intent) => intent.engine === engine && intent.state === "draining" && engineScopedIntent(intent));
       if (active) {
         if (active.origin === "manual" && origin === "auto") return clone(active);
         if (!active.requestIds.includes(requestId)) active.requestIds.push(requestId);

--- a/src/lib/agent/registry.ts
+++ b/src/lib/agent/registry.ts
@@ -3720,6 +3720,62 @@ export class AgentRegistry {
     });
   }
 
+  /** One-click successor reseat of a rate-limited conversation (issue #97).
+      Lineage-safe by construction: a thread whose current generation already
+      runs on `targetId` (a committed migration fork) returns unchanged, and an
+      in-flight migration keeps sole ownership of the successor seat — repeat
+      requests never mint a second successor. Unlike
+      {@link requestConversationMigrationToActiveAccount} the target account is
+      explicit, and engine routing for future spawns is left to the Accounts
+      panel (issue #40): only this conversation moves. */
+  requestConversationReseat(id: ViewerConversationId, targetId: string): RegistryConversation {
+    return this.mutate((file) => {
+      const canonicalId = resolveConversationAlias(file, id);
+      const conversation = file.conversations[canonicalId];
+      if (!conversation) throw new Error("viewer conversation is unknown");
+      const source = conversation.generations.at(-1);
+      if (!source || source.accountId === null || source.accountId === targetId) return clone(conversation);
+      if (conversation.migration
+        && !["committed", "rolled-back", "failed-recoverable"].includes(conversation.migration.phase)) {
+        return clone(conversation);
+      }
+
+      const changedAt = now();
+      if (conversation.migrationOptOut?.targetId === targetId) conversation.migrationOptOut = null;
+      let intent = Object.values(file.migrationIntents)
+        .filter((candidate) => candidate.engine === conversation.engine && candidate.targetId === targetId && candidate.state !== "stopped")
+        .sort((left, right) => right.updatedAt.localeCompare(left.updatedAt))[0];
+      if (!intent) {
+        intent = {
+          id: crypto.randomUUID(),
+          engine: conversation.engine,
+          targetId,
+          origin: "manual",
+          revision: 1,
+          state: "draining",
+          createdAt: changedAt,
+          updatedAt: changedAt,
+          requestIds: [`reseat:${canonicalId}:${source.id}`],
+          evidence: null,
+          stoppedAt: null,
+        };
+        file.migrationIntents[intent.id] = intent;
+      } else {
+        if (intent.state !== "draining") intent.revision += 1;
+        intent.state = "draining";
+        intent.updatedAt = changedAt;
+      }
+
+      const phase = migrationReadiness(file, conversation) === "busy" ? "waiting-turn" : "requested";
+      queueAbandonedMigrationCleanup(file, conversation, changedAt);
+      conversation.migration = conversationMigrationForIntent(conversation, source, intent, phase, changedAt);
+      conversation.updatedAt = changedAt;
+      file.conversationRevision[conversation.engine] += 1;
+      file.engineRouting[conversation.engine].revision += 1;
+      return clone(conversation);
+    });
+  }
+
   upsertMigrationIntent(engine: Extract<AgentEngine, "claude" | "codex">, targetId: string, origin: MigrationOrigin, requestId: string, evidence: MigrationIntent["evidence"] = null): MigrationIntent {
     return this.mutate((file) => {
       const active = Object.values(file.migrationIntents).find((intent) => intent.engine === engine && intent.state === "draining");

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -1274,6 +1274,8 @@ export const en = {
   "rateLimit.reseatRequested": "reseating…",
   "rateLimit.reseatTitle": "Spawn a successor of this conversation on the healthiest signed-in account; the rate-limited one is parked, attached flows follow.",
   "rateLimit.reseatFailed": "reseat failed",
+  "rateLimit.reseatAlready": "already reseated",
+  "rateLimit.reseatWaitingTurn": "Reseat queued: waiting for the rate-limited turn to release the pane, then the successor spawns.",
 
   // useDictation errors
   "dictation.capWarn": "less than a minute of recording left",

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -1270,6 +1270,10 @@ export const en = {
   "status.flow": "flow: {label}",
   "rateLimit.badge": "rate-limited",
   "rateLimit.badgeUntil": "rate-limited until {time}",
+  "rateLimit.reseat": "continue on a healthy account",
+  "rateLimit.reseatRequested": "reseating…",
+  "rateLimit.reseatTitle": "Spawn a successor of this conversation on the healthiest signed-in account; the rate-limited one is parked, attached flows follow.",
+  "rateLimit.reseatFailed": "reseat failed",
 
   // useDictation errors
   "dictation.capWarn": "less than a minute of recording left",

--- a/src/lib/i18n/uk.ts
+++ b/src/lib/i18n/uk.ts
@@ -1242,6 +1242,8 @@ export const uk: Record<keyof typeof en, Message> = {
   "rateLimit.reseatRequested": "пересадка…",
   "rateLimit.reseatTitle": "Створити наступника цієї розмови на найздоровішому акаунті; вичерпана розмова паркується, прив'язані флоу переходять слідом.",
   "rateLimit.reseatFailed": "не вдалося пересадити",
+  "rateLimit.reseatAlready": "вже пересаджено",
+  "rateLimit.reseatWaitingTurn": "Пересадку поставлено в чергу: щойно обмежений хід звільнить панель, буде створено наступника.",
 
   "dictation.capWarn": "залишилось менше хвилини запису",
   "dictation.capStopped": "Запис зупинено на 10-хвилинній межі; текст зʼявиться в полі.",

--- a/src/lib/i18n/uk.ts
+++ b/src/lib/i18n/uk.ts
@@ -1238,6 +1238,10 @@ export const uk: Record<keyof typeof en, Message> = {
   "status.flow": "флоу: {label}",
   "rateLimit.badge": "вичерпано ліміт",
   "rateLimit.badgeUntil": "ліміт до {time}",
+  "rateLimit.reseat": "продовжити на здоровому акаунті",
+  "rateLimit.reseatRequested": "пересадка…",
+  "rateLimit.reseatTitle": "Створити наступника цієї розмови на найздоровішому акаунті; вичерпана розмова паркується, прив'язані флоу переходять слідом.",
+  "rateLimit.reseatFailed": "не вдалося пересадити",
 
   "dictation.capWarn": "залишилось менше хвилини запису",
   "dictation.capStopped": "Запис зупинено на 10-хвилинній межі; текст зʼявиться в полі.",

--- a/src/lib/scanner/waitingInput.test.ts
+++ b/src/lib/scanner/waitingInput.test.ts
@@ -28,6 +28,26 @@ function entry(): FileEntry {
   };
 }
 
+test("a stale historical limit banner above a ready composer raises no rate limit", async () => {
+  /* Issue #97 guard against the #56 inverse: transcript prose that merely
+     mentions an old usage limit must never mark the card rate-limited (and so
+     never offer a successor reseat) while the composer is ready. */
+  const screen = [
+    "You've hit your usage limit. Try again at 7:55 PM.",
+    "Later the run resumed and finished the task.",
+    "❯ ",
+    "  ? for shortcuts",
+  ].join("\n");
+  const result = await waitingInputProbe(entry(), {
+    now: () => NOW,
+    resolveTarget: async () => "agents:3.0",
+    paneScreen: async () => screen,
+  });
+
+  expect(result.rateLimit).toBeNull();
+  expect(result.waiting).toBeNull();
+});
+
 test("a live usage wall bypasses the stable-screen delay", async () => {
   const result = await waitingInputProbe(entry(), {
     now: () => NOW,


### PR DESCRIPTION
## Summary

- expose truthful rate-limit state on conversation cards
- add lineage-safe one-click reseat for the affected conversation
- isolate reseat state from engine-wide account drains and cooldowns
- converge duplicate clicks, stale cards, restart persistence, and terminal already-reseated UI

## Verification

- focused accounts, registry, scanner, API, component, and migration suites passed
- TypeScript, changed-file ESLint, and production build passed
- three environmental EIO tests reproduce at the merge base
- fresh Fable review: NO FINDINGS, confidence 0.88

Closes #97