### PR TITLE
fix(pipelines): settle stalled structured stages from durable evidence (#337)

### DIFF
--- a/src/lib/pipelines/durableEvidence.test.ts
+++ b/src/lib/pipelines/durableEvidence.test.ts
@@ -66,6 +66,73 @@ test("a Codex turn with an open tool call is busy", async () => {
   expect(await durableStageTurnEvidence("codex", file)).toMatchObject({ turn: "busy" });
 });
 
+test("a Codex terminal verdict with trailing bookkeeping records stays terminal (#337 production shape)", async () => {
+  /* The exact production tail: fenced verdict, task_complete, then bookkeeping
+     records append after the turn ends — the scan holds jsonl_turn_stalled at
+     this final size while the turn is durably terminal. */
+  const file = writeTranscript("codex-terminal-bookkeeping.jsonl", [
+    { timestamp: "2026-07-18T12:00:00.000Z", payload: { type: "task_started" } },
+    { timestamp: "2026-07-18T12:04:00.000Z", payload: { type: "agent_message", message: PASS_TEXT } },
+    { timestamp: "2026-07-18T12:05:00.000Z", payload: { type: "task_complete", last_agent_message: PASS_TEXT } },
+    { timestamp: "2026-07-18T12:05:01.000Z", payload: { type: "token_count", info: { total_token_usage: { input_tokens: 52_144, output_tokens: 3_902 } } } },
+  ]);
+
+  const evidence = await durableStageTurnEvidence("codex", file);
+  expect(evidence).toMatchObject({ turn: "terminal", message: { text: PASS_TEXT } });
+  expect(evidence!.message!.ts).toBe(Date.parse("2026-07-18T12:05:00.000Z"));
+});
+
+test("a Claude end-turn verdict with a trailing bookkeeping record stays terminal (#337 production shape)", async () => {
+  const file = writeTranscript("claude-terminal-bookkeeping.jsonl", [
+    { type: "user", timestamp: "2026-07-18T12:00:00.000Z", message: { role: "user", content: "prompt" } },
+    {
+      type: "assistant",
+      timestamp: "2026-07-18T12:05:00.000Z",
+      message: { role: "assistant", stop_reason: "end_turn", content: [{ type: "text", text: PASS_TEXT }] },
+    },
+    { type: "file-history-snapshot", timestamp: "2026-07-18T12:05:01.000Z", snapshot: { trackedFileBackups: {} } },
+  ]);
+
+  const evidence = await durableStageTurnEvidence("claude", file);
+  expect(evidence).toMatchObject({ turn: "terminal", message: { text: PASS_TEXT } });
+});
+
+test("a Codex verdict whose turn still holds an open tool call is busy, never terminal", async () => {
+  const file = writeTranscript("codex-open-tool-verdict.jsonl", [
+    { timestamp: "2026-07-18T13:00:00.000Z", payload: { type: "task_started" } },
+    { timestamp: "2026-07-18T13:01:00.000Z", payload: { type: "function_call", call_id: "call-9" } },
+    { timestamp: "2026-07-18T13:04:00.000Z", payload: { type: "agent_message", message: PASS_TEXT } },
+    { timestamp: "2026-07-18T13:05:00.000Z", payload: { type: "task_complete", last_agent_message: PASS_TEXT } },
+  ]);
+
+  expect(await durableStageTurnEvidence("codex", file)).toMatchObject({ turn: "busy" });
+});
+
+test("a user record after a terminal Codex verdict reopens the turn as busy", async () => {
+  const file = writeTranscript("codex-user-followup.jsonl", [
+    { timestamp: "2026-07-18T14:00:00.000Z", payload: { type: "task_started" } },
+    { timestamp: "2026-07-18T14:04:00.000Z", payload: { type: "agent_message", message: PASS_TEXT } },
+    { timestamp: "2026-07-18T14:05:00.000Z", payload: { type: "task_complete", last_agent_message: PASS_TEXT } },
+    { timestamp: "2026-07-18T14:06:00.000Z", payload: { type: "user_message", message: "one more request before you stop" } },
+  ]);
+
+  expect(await durableStageTurnEvidence("codex", file)).toMatchObject({ turn: "busy" });
+});
+
+test("a user record after a terminal Claude verdict reopens the turn as busy", async () => {
+  const file = writeTranscript("claude-user-followup.jsonl", [
+    { type: "user", timestamp: "2026-07-18T14:00:00.000Z", message: { role: "user", content: "prompt" } },
+    {
+      type: "assistant",
+      timestamp: "2026-07-18T14:05:00.000Z",
+      message: { role: "assistant", stop_reason: "end_turn", content: [{ type: "text", text: PASS_TEXT }] },
+    },
+    { type: "user", timestamp: "2026-07-18T14:06:00.000Z", message: { role: "user", content: "one more request" } },
+  ]);
+
+  expect(await durableStageTurnEvidence("claude", file)).toMatchObject({ turn: "busy" });
+});
+
 test("a missing or torn artifact yields no durable evidence", async () => {
   expect(await durableStageTurnEvidence("claude", path.join(dir, "absent.jsonl"))).toBeNull();
 

--- a/src/lib/pipelines/engine.test.ts
+++ b/src/lib/pipelines/engine.test.ts
@@ -608,6 +608,22 @@ function makeStructuredAttempt() {
   savePipelines([pipeline]);
 }
 
+/** The production projection shape (#337): scanner resource-scope inheritance
+    keeps the transcript `jsonl_turn_stalled` at its final byte size forever. */
+function stalledEntry(pathname: string): FileEntry {
+  return { ...entry(pathname), activity: "stalled", activityReason: "jsonl_turn_stalled" };
+}
+
+function countDurableReads(h: ReturnType<typeof harness>): () => number {
+  let reads = 0;
+  const base = h.ports.durableTurnEvidence;
+  h.ports.durableTurnEvidence = async (engine, transcriptPath) => {
+    reads += 1;
+    return base(engine, transcriptPath);
+  };
+  return () => reads;
+}
+
 function pinStageHead(h: ReturnType<typeof harness>) {
   const baseExec = h.ports.exec;
   h.ports.exec = (command, args, cwd) => args[0] === "rev-parse" && args[1] === "HEAD"
@@ -725,6 +741,117 @@ test("a durable busy turn blocks scanner-message settlement even for a parseable
     expect(current.runs[0]!.attempts[0]!.state).toBe("running");
     expect(current.runs[0]!.attempts[0]!.verdict).toBeNull();
   }
+});
+
+test("a pane-less stalled projection with a stuck running runtime ledger settles from durable terminal evidence (#337 production shape)", async () => {
+  const h = harness();
+  await runningStructuredStage(h);
+  /* Production shape: the transcript ended in a fenced verdict plus trailing
+     bookkeeping records, the scan projects jsonl_turn_stalled at the final
+     size, and the runtime session ledger stays stuck `running` forever. */
+  h.setConversationActive(true);
+  h.durableTurns.set("/codex/stage-1.jsonl", {
+    turn: "terminal",
+    message: { text: PASS_TEXT, ts: 5_000_000 },
+  });
+
+  await tickPipelines([stalledEntry("/codex/stage-1.jsonl")], h.ports);
+
+  const current = loadPipelines()[0]!;
+  expect(current.state).toBe("running");
+  expect(current.cursor).toEqual({ stageId: "build", state: "pending" });
+  expect(current.lastPassedCommit).toBe(STAGE_HEAD);
+  expect(current.runs[0]!.attempts[0]).toMatchObject({
+    state: "passed",
+    output: "integration complete",
+    verdict: { status: "pass", confidence: 0.9 },
+  });
+
+  /* Settles exactly once: the frozen stalled projection on later wake-ups
+     neither re-settles nor appends attempts — history stays append-only. */
+  await tickPipelines([stalledEntry("/codex/stage-1.jsonl")], h.ports);
+  await tickPipelines([stalledEntry("/codex/stage-1.jsonl")], h.ports);
+  expect(loadPipelines()[0]!.runs[0]!.attempts).toHaveLength(1);
+  expect(h.calls.filter((call) => call.startsWith("spawn:")).length).toBe(2);
+});
+
+test("a restart-primed stalled cache at final size settles without a runtime session (#337)", async () => {
+  const h = harness();
+  await runningStructuredStage(h);
+  /* Restart: the scan cache re-primes busy at the final size and the fresh
+     runtime host has no session for the conversation (ledger answers null). */
+  h.setConversationActive(null);
+  h.durableTurns.set("/codex/stage-1.jsonl", {
+    turn: "terminal",
+    message: { text: PASS_TEXT, ts: 5_000_000 },
+  });
+
+  await tickPipelines([stalledEntry("/codex/stage-1.jsonl")], h.ports);
+
+  const current = loadPipelines()[0]!;
+  expect(current.state).toBe("running");
+  expect(current.cursor).toEqual({ stageId: "build", state: "pending" });
+  expect(current.lastPassedCommit).toBe(STAGE_HEAD);
+  expect(current.runs[0]!.attempts[0]!.state).toBe("passed");
+});
+
+test("a genuinely busy durable turn keeps a stalled pane-less attempt running (#337)", async () => {
+  for (const active of [true, null] as const) {
+    const h = harness();
+    await runningStructuredStage(h);
+    h.setConversationActive(active);
+    /* The trailing scanner message even parses as a verdict; the durable open
+       turn (open tool call or a later user follow-up) still blocks settlement. */
+    h.finish("/codex/stage-1.jsonl", "pass");
+    h.durableTurns.set("/codex/stage-1.jsonl", {
+      turn: "busy",
+      message: h.messages.get("/codex/stage-1.jsonl")!,
+    });
+
+    await tickPipelines([stalledEntry("/codex/stage-1.jsonl")], h.ports);
+
+    const current = loadPipelines()[0]!;
+    expect(current.state).toBe("running");
+    expect(current.runs[0]!.attempts[0]!.state).toBe("running");
+    expect(current.runs[0]!.attempts[0]!.verdict).toBeNull();
+  }
+});
+
+test("live and open-turn projections never consult the durable read (#337 cheap path)", async () => {
+  const h = harness();
+  await runningStructuredStage(h);
+  h.setConversationActive(null);
+  const reads = countDurableReads(h);
+  h.durableTurns.set("/codex/stage-1.jsonl", {
+    turn: "terminal",
+    message: { text: PASS_TEXT, ts: 5_000_000 },
+  });
+
+  await tickPipelines([{ ...entry("/codex/stage-1.jsonl"), activity: "live", activityReason: "jsonl_turn_open" }], h.ports);
+  await tickPipelines([{ ...entry("/codex/stage-1.jsonl"), activity: "live", activityReason: "mtime_fresh" }], h.ports);
+
+  expect(reads()).toBe(0);
+  expect(loadPipelines()[0]!.runs[0]!.attempts[0]!.state).toBe("running");
+});
+
+test("a pane-hosted stalled attempt keeps the cheap return without a durable read", async () => {
+  const h = harness();
+  await create(h.ports);
+  await tickPipelines([], h.ports);
+  await tickPipelines([], h.ports);
+  const reads = countDurableReads(h);
+  h.durableTurns.set("/codex/stage-1.jsonl", {
+    turn: "terminal",
+    message: { text: PASS_TEXT, ts: 5_000_000 },
+  });
+
+  await tickPipelines([stalledEntry("/codex/stage-1.jsonl")], h.ports);
+
+  expect(reads()).toBe(0);
+  const current = loadPipelines()[0]!;
+  expect(current.state).toBe("running");
+  expect(current.runs[0]!.attempts[0]!.state).toBe("running");
+  expect(current.runs[0]!.attempts[0]!.verdict).toBeNull();
 });
 
 test("a genuinely terminal turn without a valid verdict stays parked and retry preserves the attempt receipt", async () => {

--- a/src/lib/pipelines/engine.ts
+++ b/src/lib/pipelines/engine.ts
@@ -544,8 +544,16 @@ async function tickRunStage(
   }
   const entry = entries.find((candidate) => candidate.path === attempt!.agentPath);
   /* Cheap live path: the scan projects an open turn and the runtime ledger does
-     not contradict it — no durable read needed while the agent works. */
-  if (entry && structuredActive !== false && (entry.activity === "live" || entry.activityReason === "jsonl_turn_open" || entry.activityReason === "jsonl_turn_stalled")) return;
+     not contradict it — no durable read needed while the agent works. A stalled
+     projection is only cheap evidence for pane-hosted attempts (their liveness
+     probe guards settlement): scanner resource-scope inheritance keeps
+     `jsonl_turn_stalled` frozen at the final byte size, and a stale `running`
+     runtime ledger cannot contradict it, so a pane-less structured attempt must
+     fall through to the durable transcript read instead (#337). */
+  const scanProjectsOpenTurn = entry?.activity === "live"
+    || entry?.activityReason === "jsonl_turn_open"
+    || (entry?.activityReason === "jsonl_turn_stalled" && attempt.paneId !== null);
+  if (entry && structuredActive !== false && scanProjectsOpenTurn) return;
 
   /* The transcript artifact is the completion authority (#337). A terminal turn
      whose completion evidence belongs to this attempt and ends in a valid fenced


### PR DESCRIPTION
Refs #337.

## Root cause

Pane-less structured attempts projected as `jsonl_turn_stalled` returned from the cheap live gate before durable transcript evidence was consulted. A stale runtime turn ledger and scanner cache could therefore keep a completed fenced verdict running indefinitely.

## Repair

- routes stalled pane-less structured attempts through durable turn evidence
- preserves live and `jsonl_turn_open` protection
- preserves pane-hosted stalled behavior
- preserves genuinely busy turns, mid-turn follow-ups, aliases, append-only history, and #383 supersedence
- adds production-shaped restart and trailing-bookkeeping regressions

## Verification

- 114 focused pipeline tests
- TypeScript
- changed-file ESLint
- production build
- `git diff --check`

Fresh independent Fable review is running before merge.
