### PR TITLE
fix(ui): make elapsed work duration truthful across interruptions (#268)

### DIFF
--- a/src/app/api/files/scanCache.real.test.ts
+++ b/src/app/api/files/scanCache.real.test.ts
@@ -165,7 +165,7 @@ test("a persisted completed generation avoids cold tail rereads for unchanged tr
     if (Object.hasOwn(persisted!, "goal")) expect(caches["goal-v2"]?.get(transcript)).toEqual([persisted!.size, mtimeMs, persisted!.goal]);
     if (Object.hasOwn(persisted!, "ctx")) expect(caches["ctx-v2"]?.get(transcript)).toEqual([persisted!.size, mtimeMs, persisted!.ctx]);
     if (Object.hasOwn(persisted!, "lastTurn")) {
-      expect(caches["last-turn-v3"]?.get(transcript)).toEqual([persisted!.size, mtimeMs, persisted!.lastTurn]);
+      expect(caches["last-turn-v4"]?.get(transcript)).toEqual([persisted!.size, mtimeMs, persisted!.lastTurn]);
     }
 
     activityVerdict(persisted!.root, transcript, persisted!.mtime, persisted!.size);

--- a/src/app/api/files/scanCache.real.test.ts
+++ b/src/app/api/files/scanCache.real.test.ts
@@ -165,7 +165,7 @@ test("a persisted completed generation avoids cold tail rereads for unchanged tr
     if (Object.hasOwn(persisted!, "goal")) expect(caches["goal-v2"]?.get(transcript)).toEqual([persisted!.size, mtimeMs, persisted!.goal]);
     if (Object.hasOwn(persisted!, "ctx")) expect(caches["ctx-v2"]?.get(transcript)).toEqual([persisted!.size, mtimeMs, persisted!.ctx]);
     if (Object.hasOwn(persisted!, "lastTurn")) {
-      expect(caches["last-turn-v2"]?.get(transcript)).toEqual([persisted!.size, mtimeMs, persisted!.lastTurn]);
+      expect(caches["last-turn-v3"]?.get(transcript)).toEqual([persisted!.size, mtimeMs, persisted!.lastTurn]);
     }
 
     activityVerdict(persisted!.root, transcript, persisted!.mtime, persisted!.size);

--- a/src/components/LogFeed.tsx
+++ b/src/components/LogFeed.tsx
@@ -19,7 +19,7 @@ import { ConversationAttention } from "./runtime/ConversationAttention";
 import { speakableAnswer } from "./feed/speakableAnswer";
 import { isSubagent } from "./projectModel";
 import { TaskHeader } from "./TaskHeader";
-import { workedCaption } from "./turnDuration";
+import { TurnStatusBar } from "./TurnStatusBar";
 
 /** Items rendered initially and added per «show earlier» step. */
 const RENDER_STEP = 1500;
@@ -84,36 +84,6 @@ function viewportAnchor(scroller: HTMLElement, path: string): ViewportAnchor | n
 
 function rowForAnchor(scroller: HTMLElement, key: string): HTMLElement | null {
   return feedRows(scroller).find((row) => row.dataset.feedKey === key) ?? null;
-}
-
-/** Animated presence row: the agent of a live transcript is mid-turn right now. */
-function WorkingRow({ icon: Icon, label }: { icon: LucideIcon; label: string }) {
-  return (
-    <div className="mt-2 flex items-center gap-2 text-[12px] font-semibold text-success">
-      <span className="flex items-center gap-0.5" aria-hidden>
-        <span className="h-1.5 w-1.5 animate-bounce rounded-full bg-success" />
-        <span className="h-1.5 w-1.5 animate-bounce rounded-full bg-success [animation-delay:150ms]" />
-        <span className="h-1.5 w-1.5 animate-bounce rounded-full bg-success [animation-delay:300ms]" />
-      </span>
-      <Icon className="h-3.5 w-3.5" aria-hidden />
-      {label}
-    </div>
-  );
-}
-
-/** Muted caption after the final message once the turn is complete, mirroring
-    the codex TUI's "Worked for …" line (issue #231). Renders nothing while the
-    turn is still running — `workedCaption` returns null until `endedAt` is set. */
-function WorkedSeparator({ file }: { file: FileEntry }) {
-  const caption = workedCaption(file);
-  if (!caption) return null;
-  return (
-    <div className="mt-3 flex items-center gap-2 text-[11px] font-semibold text-muted" role="note">
-      <span className="h-px flex-1 bg-border" aria-hidden />
-      <span className="tabular-nums">{caption}</span>
-      <span className="h-px flex-1 bg-border" aria-hidden />
-    </div>
-  );
 }
 
 interface Props {
@@ -391,17 +361,24 @@ export function LogFeed({ file, showSvc, lineFilter, onStatus, paused, follow, s
     setMagnet(true, true);
   };
 
-  /* Compact panes center the floating pill: on the phone a right-anchored
-     pill would sit over the tool rows' status column. */
-  const pillPos = compact ? "left-1/2 -translate-x-1/2" : "right-3";
+  /* The floating pill is centered on every surface — the same axis as the
+     pinned TurnStatusBar below, per the issue #268 operator note: the two
+     bottom elements share one axis and separate slots, so they can never
+     collide at any pane width. (A right-anchored pill also sat over the tool
+     rows' status column on the phone.) */
+  const pillPos = "left-1/2 -translate-x-1/2";
 
   return (
     <RawLineProvider value={getRawLine}>
+    <div className="flex min-h-0 flex-1 flex-col">
+    {/* The pill anchors to the scroller wrapper — NOT the pane column — so the
+        pinned status bar below is structurally outside its overlay area. */}
     <div className="relative flex min-h-0 flex-1 flex-col">
       {file && feed.items.length ? (
         magnet ? (
           file.activity === "live" ? (
             <div
+              data-live-tail-pill
               className={`pointer-events-none absolute bottom-2 ${pillPos} z-10 inline-flex items-center gap-1 rounded-full bg-success px-2 py-0.5 text-[10px] font-bold text-white shadow-1 transition-transform duration-200 ${
                 pulse ? "scale-125" : "scale-100"
               }`}
@@ -501,7 +478,6 @@ export function LogFeed({ file, showSvc, lineFilter, onStatus, paused, follow, s
                 {!file.pendingQuestion && !file.waitingInput && endedQuestion ? (
                   <div className="my-4 rounded-[8px] border border-border bg-sunken px-4 py-3 text-[13px] font-semibold text-muted">{endedQuestion}</div>
                 ) : null}
-                {file.activity === "live" ? <WorkingRow icon={working.icon} label={working.label} /> : null}
                 {file.activity === "recent" && isAwaitingUser(file) ? (
                   <div className="mt-2 flex items-center gap-1.5 text-[11.5px] font-semibold text-warning">
                     <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-warning" aria-hidden /> {t("feed.finishedTurn")}
@@ -511,7 +487,6 @@ export function LogFeed({ file, showSvc, lineFilter, onStatus, paused, follow, s
                     <CornerDownRight className="h-3.5 w-3.5" aria-hidden /> {t("feed.returnedResult")}
                   </div>
                 ) : null}
-                <WorkedSeparator file={file} />
               </>
             ) : (
               <div className="mt-[14vh] text-center text-muted">
@@ -539,6 +514,13 @@ export function LogFeed({ file, showSvc, lineFilter, onStatus, paused, follow, s
         )}
         </div>
       </div>
+    </div>
+    {/* Bottom working-status slot (issue #268): live «працює · 4:32» ticking
+        from the initiating prompt, or the frozen «Працював N» total after the
+        turn ends. Pinned below the scroller in every pane variant. */}
+    {file ? (
+      <TurnStatusBar file={file} workingLabel={working.label} workingIcon={working.icon} compact={compact} />
+    ) : null}
     </div>
     </RawLineProvider>
   );

--- a/src/components/TurnStatusBar.dom.test.tsx
+++ b/src/components/TurnStatusBar.dom.test.tsx
@@ -112,6 +112,19 @@ test("a new prompt after a finished turn resets the timer to the new receipt", (
   }
 });
 
+test("finished caption's accessible output is the localized visible duration text", () => {
+  const t0 = Date.parse("2026-07-18T10:00:00.000Z");
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  render(file({ startedAt: t0, endedAt: t0 + (12 * 60 + 30) * 1000 }, "idle"), container);
+  const caption = container.querySelector('[data-turn-status="finished"] .tabular-nums');
+  expect(caption?.textContent).toBe("Worked for 12m 30s");
+  // The caption span is role-less: an aria-label there would override the
+  // visible localized caption for assistive tech, so it must carry none and
+  // expose the caption itself as its accessible output (issue #268 review).
+  expect(caption?.hasAttribute("aria-label")).toBe(false);
+});
+
 test("live agent with no known boundary keeps the working label without a timer", () => {
   const container = document.createElement("div");
   document.body.appendChild(container);

--- a/src/components/TurnStatusBar.dom.test.tsx
+++ b/src/components/TurnStatusBar.dom.test.tsx
@@ -1,0 +1,128 @@
+import { afterEach, expect, setSystemTime, test } from "bun:test";
+import { Window } from "happy-dom";
+import { Sparkle } from "@/components/icons";
+import { flushSync } from "react-dom";
+import { createRoot, type Root } from "react-dom/client";
+
+import type { FileEntry } from "@/lib/types";
+
+import { TurnStatusBar } from "./TurnStatusBar";
+
+const dom = new Window();
+Object.assign(globalThis, {
+  window: dom,
+  document: dom.document,
+  navigator: dom.navigator,
+  Node: dom.Node,
+  HTMLElement: dom.HTMLElement,
+  HTMLButtonElement: dom.HTMLButtonElement,
+  Event: dom.Event,
+  MouseEvent: dom.MouseEvent,
+});
+
+let root: Root | null = null;
+afterEach(() => {
+  if (root) flushSync(() => root!.unmount());
+  root = null;
+  setSystemTime();
+});
+
+const file = (lastTurn: FileEntry["lastTurn"], activity: FileEntry["activity"]) =>
+  ({ lastTurn, activity }) as Pick<FileEntry, "lastTurn" | "activity">;
+
+const render = (entry: Pick<FileEntry, "lastTurn" | "activity">, container: HTMLElement) => {
+  root ??= createRoot(container);
+  flushSync(() => root!.render(<TurnStatusBar file={entry} workingLabel="working…" workingIcon={Sparkle} />));
+};
+
+test("live open turn ticks the elapsed timer every second and freezes at terminal", () => {
+  const realSet = globalThis.setInterval;
+  const realClear = globalThis.clearInterval;
+  let tick: (() => void) | null = null;
+  let started = 0;
+  const cleared: number[] = [];
+  // @ts-expect-error test double
+  globalThis.setInterval = (fn: () => void) => {
+    tick = fn;
+    started += 1;
+    return started;
+  };
+  // @ts-expect-error test double
+  globalThis.clearInterval = (id: number) => cleared.push(id);
+  try {
+    const t0 = Date.parse("2026-07-18T10:00:00.000Z");
+    setSystemTime(new Date(t0));
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+
+    // Prompt accepted at t0, agent working: the bottom slot carries the label
+    // and a named timer element seeded at 0:00.
+    render(file({ startedAt: t0, endedAt: null }, "live"), container);
+    const timer = () => container.querySelector('[role="timer"]');
+    expect(container.querySelector('[data-turn-status="running"]')).not.toBeNull();
+    expect(timer()?.getAttribute("aria-label")).toBe("elapsed work time");
+    expect(timer()?.textContent).toBe("0:00");
+    expect(started).toBe(1);
+
+    // 4 minutes 32 seconds into the turn (a long tool call in between — the
+    // timer tracks the wall clock, not transcript writes).
+    setSystemTime(new Date(t0 + (4 * 60 + 32) * 1000));
+    flushSync(() => tick!());
+    expect(timer()?.textContent).toBe("4:32");
+
+    // The turn ends: the timer unmounts (its interval cleared) and the frozen
+    // total spans initiating prompt → last activity, not the last action.
+    render(file({ startedAt: t0, endedAt: t0 + 5 * 60 * 1000 }, "recent"), container);
+    expect(timer()).toBeNull();
+    expect(cleared).toContain(1);
+    const finished = container.querySelector('[data-turn-status="finished"]');
+    expect(finished?.textContent).toContain("Worked for 5m");
+    expect(container.querySelector('[data-turn-status="running"]')).toBeNull();
+  } finally {
+    globalThis.setInterval = realSet;
+    globalThis.clearInterval = realClear;
+  }
+});
+
+test("a new prompt after a finished turn resets the timer to the new receipt", () => {
+  const realSet = globalThis.setInterval;
+  let tick: (() => void) | null = null;
+  // @ts-expect-error test double
+  globalThis.setInterval = (fn: () => void) => {
+    tick = fn;
+    return 1;
+  };
+  try {
+    const t0 = Date.parse("2026-07-18T10:00:00.000Z");
+    setSystemTime(new Date(t0));
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    render(file({ startedAt: t0 - 60 * 60 * 1000, endedAt: t0 - 30 * 60 * 1000 }, "idle"), container);
+    expect(container.querySelector('[data-turn-status="finished"]')).not.toBeNull();
+
+    // Second prompt lands at t0+10s and the scanner reopens the boundary: the
+    // timer restarts from the NEW receipt, not the previous turn's start.
+    const t1 = t0 + 10_000;
+    render(file({ startedAt: t1, endedAt: null }, "live"), container);
+    setSystemTime(new Date(t1 + 3000));
+    flushSync(() => tick!());
+    expect(container.querySelector('[role="timer"]')?.textContent).toBe("0:03");
+  } finally {
+    globalThis.setInterval = realSet;
+  }
+});
+
+test("live agent with no known boundary keeps the working label without a timer", () => {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  render(file(null, "live"), container);
+  expect(container.querySelector('[data-turn-status="running"]')?.textContent).toContain("working…");
+  expect(container.querySelector('[role="timer"]')).toBeNull();
+});
+
+test("idle pane with no completed turn renders nothing", () => {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  render(file(null, "idle"), container);
+  expect(container.querySelector("[data-turn-status]")).toBeNull();
+});

--- a/src/components/TurnStatusBar.tsx
+++ b/src/components/TurnStatusBar.tsx
@@ -87,7 +87,10 @@ export function TurnStatusBar({ file, workingLabel, workingIcon: Icon, compact =
       className={`flex shrink-0 items-center gap-2 border-t border-border ${pad} text-[11px] font-semibold text-muted`}
     >
       <span className="h-px flex-1 bg-border" aria-hidden />
-      <span className="tabular-nums" aria-label={t("turn.timer")}>{caption}</span>
+      {/* No aria-label here: this role-less span's accessible output must be
+          the caption itself — the localized visible duration text — not a
+          generic timer name that would override it (issue #268 review). */}
+      <span className="tabular-nums">{caption}</span>
       <span className="h-px flex-1 bg-border" aria-hidden />
     </div>
   );

--- a/src/components/TurnStatusBar.tsx
+++ b/src/components/TurnStatusBar.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+import type { LucideIcon } from "lucide-react";
+import { useEffect, useState } from "react";
+
+import { useLocale } from "@/lib/i18n";
+import type { FileEntry } from "@/lib/types";
+
+import { clockDuration, workedCaption } from "./turnDuration";
+
+/** Live elapsed readout for the current turn, ticking once a second. The value
+    derives from `startedAt` against the wall clock on every tick, so a new
+    turn's changed `startedAt` resets the display without a remount, and a
+    stalled poll cannot freeze it mid-run. */
+function ElapsedTimer({ startedAt, label }: { startedAt: number; label: string }) {
+  const [now, setNow] = useState(() => Date.now());
+  useEffect(() => {
+    const id = setInterval(() => setNow(Date.now()), 1000);
+    return () => clearInterval(id);
+  }, []);
+  return (
+    <span role="timer" aria-label={label} className="tabular-nums">
+      {clockDuration((now - startedAt) / 1000)}
+    </span>
+  );
+}
+
+interface Props {
+  file: Pick<FileEntry, "lastTurn" | "activity">;
+  workingLabel: string;
+  workingIcon: LucideIcon;
+  compact?: boolean;
+}
+
+/**
+ * Pinned bottom working-status slot of a conversation pane (issue #268). One
+ * of two mutually exclusive states, both centered on the pane's vertical axis:
+ *
+ *  - running («працює · 4:32»): the agent is live and the turn is open — the
+ *    working label plus a 1 Hz timer from the initiating prompt to now. The
+ *    timer keeps counting across long tool calls because it tracks the wall
+ *    clock, not transcript writes.
+ *  - finished («Працював 12 хв 30 с»): the frozen total from the initiating
+ *    prompt to the agent's last activity, never a single action's own span.
+ *
+ * The bar lives OUTSIDE the transcript scroller, so the floating live-tail
+ * pill (anchored inside the scroller) can never collide with it at any width.
+ * Renders nothing when no turn boundary is known and the agent is idle.
+ */
+export function TurnStatusBar({ file, workingLabel, workingIcon: Icon, compact = false }: Props) {
+  const { t } = useLocale();
+  const turn = file.lastTurn ?? null;
+  const running = file.activity === "live" && (!turn || turn.endedAt === null);
+  const pad = compact ? "px-3 py-1" : "px-6 py-1.5";
+
+  if (running) {
+    return (
+      <div
+        /* Deliberately NOT role="status": a live region would announce every
+           1 Hz tick. The timer's own role="timer" keeps it silent but named. */
+        data-turn-status="running"
+        className={`flex shrink-0 items-center justify-center gap-2 border-t border-border ${pad} text-[12px] font-semibold text-success`}
+      >
+        <span className="flex items-center gap-0.5" aria-hidden>
+          <span className="h-1.5 w-1.5 animate-bounce rounded-full bg-success" />
+          <span className="h-1.5 w-1.5 animate-bounce rounded-full bg-success [animation-delay:150ms]" />
+          <span className="h-1.5 w-1.5 animate-bounce rounded-full bg-success [animation-delay:300ms]" />
+        </span>
+        <Icon className="h-3.5 w-3.5 shrink-0" aria-hidden />
+        <span className="min-w-0 truncate">{workingLabel}</span>
+        {turn ? (
+          <>
+            <span aria-hidden>·</span>
+            <ElapsedTimer startedAt={turn.startedAt} label={t("turn.timer")} />
+          </>
+        ) : null}
+      </div>
+    );
+  }
+
+  const caption = workedCaption(file);
+  if (!caption) return null;
+  return (
+    <div
+      role="note"
+      data-turn-status="finished"
+      className={`flex shrink-0 items-center gap-2 border-t border-border ${pad} text-[11px] font-semibold text-muted`}
+    >
+      <span className="h-px flex-1 bg-border" aria-hidden />
+      <span className="tabular-nums" aria-label={t("turn.timer")}>{caption}</span>
+      <span className="h-px flex-1 bg-border" aria-hidden />
+    </div>
+  );
+}

--- a/src/components/turnDuration.test.ts
+++ b/src/components/turnDuration.test.ts
@@ -1,7 +1,23 @@
 import { describe, expect, test } from "bun:test";
 
 import type { FileEntry } from "@/lib/types";
-import { humanizeDuration, recencyTurnInfo, turnDurationSeconds, workedCaption } from "./turnDuration";
+import { clockDuration, humanizeDuration, recencyTurnInfo, turnDurationSeconds, workedCaption } from "./turnDuration";
+
+describe("clockDuration", () => {
+  test("minutes and padded seconds", () => {
+    expect(clockDuration(0)).toBe("0:00");
+    expect(clockDuration(7)).toBe("0:07");
+    expect(clockDuration(4 * 60 + 32)).toBe("4:32");
+  });
+  test("hours pad both lower fields", () => {
+    expect(clockDuration(3600 + 4 * 60 + 9)).toBe("1:04:09");
+    expect(clockDuration(2 * 3600)).toBe("2:00:00");
+  });
+  test("clamps negatives and fractions", () => {
+    expect(clockDuration(-5)).toBe("0:00");
+    expect(clockDuration(59.9)).toBe("0:59");
+  });
+});
 
 describe("humanizeDuration", () => {
   test("seconds only", () => {

--- a/src/components/turnDuration.ts
+++ b/src/components/turnDuration.ts
@@ -25,6 +25,18 @@ export function humanizeDuration(seconds: number, locale: Locale = getLocale()):
   return seg.join(units.sep);
 }
 
+/** Ticking-clock rendering for the live bottom timer: «4:32», «1:04:09».
+    Locale-neutral digits, so the same string serves en and uk next to their
+    own «працює…»/"working…" labels. Negative inputs clamp to «0:00». */
+export function clockDuration(seconds: number): string {
+  const total = Math.max(0, Math.floor(seconds));
+  const h = Math.floor(total / 3600);
+  const m = Math.floor((total % 3600) / 60);
+  const s = total % 60;
+  const pad = (value: number) => String(value).padStart(2, "0");
+  return h > 0 ? `${h}:${pad(m)}:${pad(s)}` : `${m}:${pad(s)}`;
+}
+
 /** Seconds spanned by a completed turn, or null when it is still running or the
     boundary is unavailable. */
 export function turnDurationSeconds(file: Pick<FileEntry, "lastTurn">): number | null {

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -51,6 +51,7 @@ export const en = {
   "turn.worked": "Worked for {d}",
   "turn.running": "working {d}",
   "turn.lastRun": "last run: {d}",
+  "turn.timer": "elapsed work time",
 
   // Conversation kind labels (display of file.kind discriminant)
   "kind.session": "session",

--- a/src/lib/i18n/uk.ts
+++ b/src/lib/i18n/uk.ts
@@ -48,6 +48,7 @@ export const uk: Record<keyof typeof en, Message> = {
   "turn.worked": "Працював {d}",
   "turn.running": "працює {d}",
   "turn.lastRun": "останній прогін: {d}",
+  "turn.timer": "час роботи",
 
   "kind.session": "сесія",
   "kind.subagent": "субагент",

--- a/src/lib/scanner/scanCache.ts
+++ b/src/lib/scanner/scanCache.ts
@@ -60,7 +60,9 @@ const FILE_SCAN_FRESH_MS = 1_000;
 /** Poll-driven attempts share the client's fallback cadence, including failures. */
 const FILE_SCAN_ORDINARY_REFRESH_MS = 10_000;
 const FILE_SCAN_PIN_CACHE_MAX = 8;
-const FILE_SCAN_CACHE_SCHEMA_VERSION = 5 as const;
+// v6: lastTurn boundaries switched to initiating-prompt semantics (issue #268)
+// — persisted v5 snapshots carry last-prompt starts and must be recomputed.
+const FILE_SCAN_CACHE_SCHEMA_VERSION = 6 as const;
 const FILE_SCAN_SNAPSHOT_VERSION = 1 as const;
 const FILE_SCAN_SNAPSHOT_FILE = "files-scan-snapshot.json";
 const FILE_SCAN_PERSISTENCE_DIAGNOSTIC_MS = 60_000;
@@ -200,7 +202,7 @@ function primePersistedFileDerivations(snapshot: FileScanSnapshot): void {
     if (Object.hasOwn(entry, "goal")) globalCache<[number, number, FileEntry["goal"]]>("goal-v2").set(entry.path, [entry.size, mtimeMs, entry.goal]);
     if (Object.hasOwn(entry, "ctx")) globalCache<[number, number, FileEntry["ctx"]]>("ctx-v2").set(entry.path, [entry.size, mtimeMs, entry.ctx]);
     if (Object.hasOwn(entry, "lastTurn")) {
-      globalCache<[number, number, FileEntry["lastTurn"]]>("last-turn-v2").set(entry.path, [entry.size, mtimeMs, entry.lastTurn]);
+      globalCache<[number, number, FileEntry["lastTurn"]]>("last-turn-v3").set(entry.path, [entry.size, mtimeMs, entry.lastTurn]);
     }
     if (Object.hasOwn(entry, "pendingWakeup")) {
       globalCache<[number, number, FileEntry["pendingWakeup"]]>("wakeup-v2").set(entry.path, [entry.size, mtimeMs, entry.pendingWakeup]);

--- a/src/lib/scanner/scanCache.ts
+++ b/src/lib/scanner/scanCache.ts
@@ -60,9 +60,10 @@ const FILE_SCAN_FRESH_MS = 1_000;
 /** Poll-driven attempts share the client's fallback cadence, including failures. */
 const FILE_SCAN_ORDINARY_REFRESH_MS = 10_000;
 const FILE_SCAN_PIN_CACHE_MAX = 8;
-// v6: lastTurn boundaries switched to initiating-prompt semantics (issue #268)
-// — persisted v5 snapshots carry last-prompt starts and must be recomputed.
-const FILE_SCAN_CACHE_SCHEMA_VERSION = 6 as const;
+// v7: lastTurn boundaries now close on interrupt/crash failure evidence
+// (issue #268 review) — persisted v6 snapshots carry windows that never end
+// without a terminal record and must be recomputed.
+const FILE_SCAN_CACHE_SCHEMA_VERSION = 7 as const;
 const FILE_SCAN_SNAPSHOT_VERSION = 1 as const;
 const FILE_SCAN_SNAPSHOT_FILE = "files-scan-snapshot.json";
 const FILE_SCAN_PERSISTENCE_DIAGNOSTIC_MS = 60_000;
@@ -202,7 +203,7 @@ function primePersistedFileDerivations(snapshot: FileScanSnapshot): void {
     if (Object.hasOwn(entry, "goal")) globalCache<[number, number, FileEntry["goal"]]>("goal-v2").set(entry.path, [entry.size, mtimeMs, entry.goal]);
     if (Object.hasOwn(entry, "ctx")) globalCache<[number, number, FileEntry["ctx"]]>("ctx-v2").set(entry.path, [entry.size, mtimeMs, entry.ctx]);
     if (Object.hasOwn(entry, "lastTurn")) {
-      globalCache<[number, number, FileEntry["lastTurn"]]>("last-turn-v3").set(entry.path, [entry.size, mtimeMs, entry.lastTurn]);
+      globalCache<[number, number, FileEntry["lastTurn"]]>("last-turn-v4").set(entry.path, [entry.size, mtimeMs, entry.lastTurn]);
     }
     if (Object.hasOwn(entry, "pendingWakeup")) {
       globalCache<[number, number, FileEntry["pendingWakeup"]]>("wakeup-v2").set(entry.path, [entry.size, mtimeMs, entry.pendingWakeup]);

--- a/src/lib/scanner/turnDuration.test.ts
+++ b/src/lib/scanner/turnDuration.test.ts
@@ -111,6 +111,37 @@ describe("lastTurnFromRecords — Claude", () => {
   test("no prompt in the window → null", () => {
     expect(lastTurnFromRecords([claudeAssistantEnd("2026-07-14T10:00:40.000Z")], false)).toBeNull();
   });
+
+  test("steering prompt mid-run keeps the initiating prompt as the start", () => {
+    // Operator (or a relaying agent) drops a follow-up while the agent is
+    // still working: the total must span initiating prompt → last activity,
+    // never just the last message's own slice (issue #268 operator comment).
+    const boundary = lastTurnFromRecords(
+      [
+        claudeUser("2026-07-14T10:00:00.000Z", "start the work"),
+        claudeAssistantOpen("2026-07-14T10:00:05.000Z"),
+        claudeUser("2026-07-14T10:29:41.000Z", "also check the tests"),
+        claudeAssistantEnd("2026-07-14T10:30:00.000Z"),
+      ],
+      false,
+    );
+    expect(boundary).toEqual({
+      startedAt: ms("2026-07-14T10:00:00.000Z"),
+      endedAt: ms("2026-07-14T10:30:00.000Z"),
+    });
+  });
+
+  test("steering prompt on a still-running turn keeps the start and stays open", () => {
+    const boundary = lastTurnFromRecords(
+      [
+        claudeUser("2026-07-14T10:00:00.000Z", "start"),
+        claudeAssistantOpen("2026-07-14T10:00:05.000Z"),
+        claudeUser("2026-07-14T10:20:00.000Z", "steer"),
+      ],
+      false,
+    );
+    expect(boundary).toEqual({ startedAt: ms("2026-07-14T10:00:00.000Z"), endedAt: null });
+  });
 });
 
 describe("lastTurnFromRecords — Codex", () => {
@@ -162,5 +193,23 @@ describe("lastTurnFromRecords — Codex", () => {
 
   test("no user message in the window → null", () => {
     expect(lastTurnFromRecords([codexTaskComplete("2026-07-14T10:00:00.000Z")], true)).toBeNull();
+  });
+
+  test("relayed user_message mid-run keeps the initiating prompt as the start", () => {
+    const boundary = lastTurnFromRecords(
+      [
+        codexUser("2026-07-14T10:00:00.000Z", "start the work"),
+        codexTaskStarted("2026-07-14T10:00:01.000Z"),
+        codexToolCall("2026-07-14T10:00:05.000Z", "c1"),
+        codexUser("2026-07-14T10:44:00.000Z", "relayed follow-up"),
+        codexToolOutput("2026-07-14T10:44:30.000Z", "c1"),
+        codexTaskComplete("2026-07-14T10:45:00.000Z"),
+      ],
+      true,
+    );
+    expect(boundary).toEqual({
+      startedAt: ms("2026-07-14T10:00:00.000Z"),
+      endedAt: ms("2026-07-14T10:45:00.000Z"),
+    });
   });
 });

--- a/src/lib/scanner/turnDuration.test.ts
+++ b/src/lib/scanner/turnDuration.test.ts
@@ -25,6 +25,18 @@ const claudeAssistantEnd = (timestamp: string) => ({
   timestamp,
   message: { role: "assistant", stop_reason: "end_turn", content: [{ type: "text", text: "done" }] },
 });
+const claudeInterrupt = (timestamp: string, extra: Record<string, unknown> = { interruptedMessageId: "msg-1" }) => ({
+  type: "user",
+  timestamp,
+  ...extra,
+  message: { role: "user", content: [{ type: "text", text: "[Request interrupted by user]" }] },
+});
+const claudeApiError = (timestamp: string) => ({
+  type: "assistant",
+  timestamp,
+  isApiErrorMessage: true,
+  message: { role: "assistant", stop_reason: null, content: [{ type: "text", text: "API Error: 500" }] },
+});
 
 // ── Codex rollout record builders ───────────────────────────────────────────
 const codexUser = (timestamp: string, message: string) => ({
@@ -137,6 +149,81 @@ describe("lastTurnFromRecords — Claude", () => {
         claudeUser("2026-07-14T10:00:00.000Z", "start"),
         claudeAssistantOpen("2026-07-14T10:00:05.000Z"),
         claudeUser("2026-07-14T10:20:00.000Z", "steer"),
+      ],
+      false,
+    );
+    expect(boundary).toEqual({ startedAt: ms("2026-07-14T10:00:00.000Z"), endedAt: null });
+  });
+
+  test("interrupt sentinel closes the window without a terminal record", () => {
+    // Ctrl-C leaves no `result` / `end_turn` record — only the protocol user
+    // record. The window must still end there instead of ticking forever
+    // (issue #268 review finding).
+    const boundary = lastTurnFromRecords(
+      [
+        claudeUser("2026-07-14T10:00:00.000Z", "start"),
+        claudeAssistantOpen("2026-07-14T10:00:05.000Z"),
+        claudeInterrupt("2026-07-14T10:04:00.000Z"),
+      ],
+      false,
+    );
+    expect(boundary).toEqual({
+      startedAt: ms("2026-07-14T10:00:00.000Z"),
+      endedAt: ms("2026-07-14T10:04:00.000Z"),
+    });
+  });
+
+  test("bare interrupt sentinel text (no id field) also closes the window", () => {
+    const boundary = lastTurnFromRecords(
+      [
+        claudeUser("2026-07-14T10:00:00.000Z", "start"),
+        claudeInterrupt("2026-07-14T10:01:30.000Z", {}),
+      ],
+      false,
+    );
+    expect(boundary).toEqual({
+      startedAt: ms("2026-07-14T10:00:00.000Z"),
+      endedAt: ms("2026-07-14T10:01:30.000Z"),
+    });
+  });
+
+  test("the prompt after an interrupt initiates a new window", () => {
+    const boundary = lastTurnFromRecords(
+      [
+        claudeUser("2026-07-14T10:00:00.000Z", "start"),
+        claudeAssistantOpen("2026-07-14T10:00:05.000Z"),
+        claudeInterrupt("2026-07-14T10:04:00.000Z"),
+        claudeUser("2026-07-14T10:05:00.000Z", "try a different approach"),
+      ],
+      false,
+    );
+    expect(boundary).toEqual({ startedAt: ms("2026-07-14T10:05:00.000Z"), endedAt: null });
+  });
+
+  test("API-error crash closes the window at the error record", () => {
+    const boundary = lastTurnFromRecords(
+      [
+        claudeUser("2026-07-14T10:00:00.000Z", "start"),
+        claudeAssistantOpen("2026-07-14T10:00:05.000Z"),
+        claudeApiError("2026-07-14T10:02:00.000Z"),
+      ],
+      false,
+    );
+    expect(boundary).toEqual({
+      startedAt: ms("2026-07-14T10:00:00.000Z"),
+      endedAt: ms("2026-07-14T10:02:00.000Z"),
+    });
+  });
+
+  test("a survived API error keeps the run open and steering continuous", () => {
+    // The error was transient: the model kept working after it, so a later
+    // prompt steers the same window instead of resetting the start.
+    const boundary = lastTurnFromRecords(
+      [
+        claudeUser("2026-07-14T10:00:00.000Z", "start"),
+        claudeApiError("2026-07-14T10:00:30.000Z"),
+        claudeAssistantOpen("2026-07-14T10:00:40.000Z"),
+        claudeUser("2026-07-14T10:10:00.000Z", "steer"),
       ],
       false,
     );

--- a/src/lib/scanner/turnDuration.ts
+++ b/src/lib/scanner/turnDuration.ts
@@ -6,7 +6,7 @@ import { recordValue, recordsValue, stringValue } from "./json";
 
 type RecordLike = Record<string, unknown>;
 
-const turnBoundaryCache = globalCache<[number, number, TurnBoundary | null]>("last-turn-v3");
+const turnBoundaryCache = globalCache<[number, number, TurnBoundary | null]>("last-turn-v4");
 
 function parseMillis(value: unknown): number | null {
   if (typeof value !== "string") return null;
@@ -56,39 +56,92 @@ function isTurnClose(record: RecordLike, codex: boolean): boolean {
   return stop === "end_turn" || stop === "stop_sequence";
 }
 
+/** Authoritative failure evidence that ends the run WITHOUT a terminal record:
+    the operator interrupted the turn (Claude appends a protocol user record —
+    `interruptedMessageId` plus the bracket sentinel) or the run crashed on an
+    API error surfaced as a flagged assistant message. The window must close on
+    it so the next prompt INITIATES a new turn instead of steering a run that
+    no longer exists (issue #268 review). Codex interruptions emit a real
+    `turn_aborted` lifecycle record, so only the Claude shape needs this. */
+function isTurnFailure(record: RecordLike, codex: boolean): boolean {
+  if (codex) return false;
+  if (record.type === "assistant") return record.isApiErrorMessage === true;
+  if (record.type !== "user") return false;
+  if ("interruptedMessageId" in record) return true;
+  const content = recordValue(record.message)?.content;
+  const text = typeof content === "string"
+    ? content
+    : recordsValue(content).map((part) => stringValue(part.text) ?? "").join("\n");
+  return /^\s*\[Request interrupted by user(?: for tool use)?\]\s*$/.test(text);
+}
+
 /** Turn boundaries for the most-recent turn from a chronological record slice.
     The turn opens at the prompt that INITIATED the work — the first prompt
     after the previous turn closed, whoever sent it (operator or a relaying
     agent). Prompts landing while the run is still open (steering, relayed
     follow-ups) must NOT reset the boundary: the reported span is «initiating
     prompt → last activity», never a single action's own duration (issue #268).
-    The turn closes at the terminal assistant/tool output — but only once the
-    turn is complete. While the agent is still working `endedAt` stays null so
-    the UI can tick live elapsed. Returns null when no opening prompt survives
-    in the tail window. Pure for testability. */
+    The turn closes at the terminal assistant/tool output — or, when the run
+    was interrupted or crashed and no terminal record exists, at the
+    authoritative failure evidence. While the agent is still working `endedAt`
+    stays null so the UI can tick live elapsed. Returns null when no opening
+    prompt survives in the tail window. Pure for testability. */
 export function lastTurnFromRecords(records: RecordLike[], codex: boolean): TurnBoundary | null {
   let startedAt: number | null = null;
   let open = false;
+  let failed = false;
+  let failedAt: number | null = null;
   for (const record of records) {
+    // Failure evidence outranks the prompt shape: the interrupt sentinel is a
+    // user record with real text and would otherwise register as a prompt.
+    if (isTurnFailure(record, codex)) {
+      if (open) {
+        failed = true;
+        failedAt = parseMillis(record.timestamp) ?? failedAt;
+      }
+      open = false;
+      continue;
+    }
     if (isTurnStart(record, codex)) {
       // A later steering prompt only fills in for an initiating prompt whose
       // own timestamp failed to parse — it never moves a valid boundary.
-      if (!open || startedAt === null) startedAt = parseMillis(record.timestamp);
+      if (!open || startedAt === null) {
+        startedAt = parseMillis(record.timestamp);
+        failed = false;
+        failedAt = null;
+      }
       open = true;
       continue;
     }
-    if (isTurnClose(record, codex)) open = false;
+    if (isTurnClose(record, codex)) {
+      open = false;
+      failed = false;
+      failedAt = null;
+      continue;
+    }
+    // Assistant output after failure evidence proves the run survived it (a
+    // retried API error): reopen so later prompts keep steering, not resetting.
+    if (failed && record.type === "assistant") {
+      failed = false;
+      failedAt = null;
+      open = true;
+    }
   }
   if (startedAt === null) return null;
 
   const state = structuredTurnStateFromRecords(records, codex);
-  if (state.state !== "terminal") return { startedAt, endedAt: null };
+  // The turn is complete on a terminal lifecycle record, or — when none was
+  // ever written — on authoritative failure evidence (interrupt sentinel,
+  // API-error crash): the window closes there so the elapsed timer cannot run
+  // forever on a dead turn (issue #268 review).
+  const terminal = state.state === "terminal";
+  if (!terminal && !failed) return { startedAt, endedAt: null };
 
   // A completed turn ends at the terminal lifecycle record's timestamp (the
-  // last assistant/tool output). Fall back to the newest parseable timestamp in
-  // the slice if the terminal record carried none, and never let a clock skew
-  // push the end before the start.
-  let endedAt = parseMillis(state.terminalAt);
+  // last assistant/tool output) or, failure-closed, at the failure record's.
+  // Fall back to the newest parseable timestamp in the slice if that record
+  // carried none, and never let a clock skew push the end before the start.
+  let endedAt = terminal ? parseMillis(state.terminalAt) : failedAt;
   if (endedAt === null) {
     for (let index = records.length - 1; index >= 0; index -= 1) {
       const millis = parseMillis(records[index]!.timestamp);

--- a/src/lib/scanner/turnDuration.ts
+++ b/src/lib/scanner/turnDuration.ts
@@ -6,7 +6,7 @@ import { recordValue, recordsValue, stringValue } from "./json";
 
 type RecordLike = Record<string, unknown>;
 
-const turnBoundaryCache = globalCache<[number, number, TurnBoundary | null]>("last-turn-v2");
+const turnBoundaryCache = globalCache<[number, number, TurnBoundary | null]>("last-turn-v3");
 
 function parseMillis(value: unknown): number | null {
   if (typeof value !== "string") return null;
@@ -41,18 +41,43 @@ function isTurnStart(record: RecordLike, codex: boolean): boolean {
   );
 }
 
+/** True when a record closes the active run for start-detection purposes: the
+    next prompt after it INITIATES a new turn instead of steering the current
+    one. Claude: the turn's final assistant message (`end_turn`/`stop_sequence`)
+    or a headless `result` record. Codex: task/turn lifecycle completion. */
+function isTurnClose(record: RecordLike, codex: boolean): boolean {
+  if (codex) {
+    const type = stringValue((recordValue(record.payload) ?? {}).type);
+    return type === "task_complete" || type === "turn_complete" || type === "turn_completed" || type === "turn_aborted";
+  }
+  if (record.type === "result") return true;
+  if (record.type !== "assistant") return false;
+  const stop = stringValue((recordValue(record.message) ?? {}).stop_reason);
+  return stop === "end_turn" || stop === "stop_sequence";
+}
+
 /** Turn boundaries for the most-recent turn from a chronological record slice.
-    The turn opens at the LAST prompt in the slice (multi-turn transcripts show
-    only the current turn) and closes at the terminal assistant/tool output —
-    but only once the turn is complete. While the agent is still working
-    `endedAt` stays null so the UI can tick live elapsed. Returns null when no
-    opening prompt survives in the tail window. Pure for testability. */
+    The turn opens at the prompt that INITIATED the work — the first prompt
+    after the previous turn closed, whoever sent it (operator or a relaying
+    agent). Prompts landing while the run is still open (steering, relayed
+    follow-ups) must NOT reset the boundary: the reported span is «initiating
+    prompt → last activity», never a single action's own duration (issue #268).
+    The turn closes at the terminal assistant/tool output — but only once the
+    turn is complete. While the agent is still working `endedAt` stays null so
+    the UI can tick live elapsed. Returns null when no opening prompt survives
+    in the tail window. Pure for testability. */
 export function lastTurnFromRecords(records: RecordLike[], codex: boolean): TurnBoundary | null {
   let startedAt: number | null = null;
-  for (let index = records.length - 1; index >= 0; index -= 1) {
-    if (!isTurnStart(records[index]!, codex)) continue;
-    startedAt = parseMillis(records[index]!.timestamp);
-    break;
+  let open = false;
+  for (const record of records) {
+    if (isTurnStart(record, codex)) {
+      // A later steering prompt only fills in for an initiating prompt whose
+      // own timestamp failed to parse — it never moves a valid boundary.
+      if (!open || startedAt === null) startedAt = parseMillis(record.timestamp);
+      open = true;
+      continue;
+    }
+    if (isTurnClose(record, codex)) open = false;
   }
   if (startedAt === null) return null;
 


### PR DESCRIPTION
Refs #268.

## Scope

- integrates the complete elapsed-work implementation from exact commit `7adfa791`
- keeps the completed visible duration as the accessible output
- closes interrupted and crashed Claude work windows from authoritative failure evidence
- starts a fresh duration window on the next prompt
- preserves steering continuity after survived transient errors
- bumps persisted timer snapshots and boundary cache versions

## Verification

- 40 focused turn-duration, status-bar, and turn-state tests
- TypeScript
- changed-file ESLint
- production build
- `git diff --check`

Fresh independent Fable review is running before merge.
