### PR TITLE
Enforce reviewer isolation and bounded, tracked agent nesting (#393)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ versions follow [SemVer](https://semver.org/) (0.x — the API may still move).
 ## [Unreleased]
 
 ### Added
+- Reviewer isolation and bounded, tracked agent nesting (#393). Reviewer and
+  verifier sessions keep full filesystem, shell, GitHub, and browser access but
+  have zero child-spawn capability: every launch they originate — direct
+  `/api/spawn`, pipeline creation, or any future MCP surface routed through the
+  registry — is terminally rejected before a child transcript or process
+  exists, with a durable typed rejection receipt (`reviewer_origin_spawn` /
+  `nesting_depth_exceeded`) and actionable guidance. Every delegated launch
+  durably records its role and delegation depth (plus parent, membership,
+  account, and engine) before execution, and a new operator-only
+  `maxAgentNestingDepth` setting (`GET`/`PATCH /api/spawn/policy`,
+  conservative default 2) bounds delegation chains. Resume, restart adoption,
+  account switch, and stage retries conserve the recorded identity; reviewer
+  resume profiles always deny native multi-agent tools.
 - Demo motion pipeline (`bun run demo:motion`, stage B of the demo media
   effort): storyboard-as-data recordings of the four key flows rendered as
   loopable GIFs plus a stitched `docs/media/demo.mp4`, reusing the stage A

--- a/src/app/api/files/response.ts
+++ b/src/app/api/files/response.ts
@@ -285,7 +285,8 @@ export async function buildFilesResponse(request: Request, dependencies: FilesRo
       if (durableEdge || memberships.length) {
         file.durableLineage = {
           kind: durableEdge?.kind ?? "spawn",
-          role: durableEdge?.role ?? null,
+          role: conversation.agentRole ?? durableEdge?.role ?? null,
+          depth: conversation.delegationDepth,
           parentConversationId: durableEdge?.parentConversationId ?? profile.parentConversationId,
           /* Alias-canonical review subject (issue #325): an edge recorded
              against a provisional id must still resolve to the reviewed

--- a/src/app/api/pipelines/route.admission.test.ts
+++ b/src/app/api/pipelines/route.admission.test.ts
@@ -1,0 +1,108 @@
+import crypto from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, expect, test } from "bun:test";
+import { NextRequest } from "next/server";
+
+import type { ViewerConversationId } from "@/lib/accounts/migration/contracts";
+
+const previousStateDir = process.env.LLV_STATE_DIR;
+const sandbox = fs.mkdtempSync(path.join(os.tmpdir(), "llv-pipeline-admission-"));
+process.env.LLV_STATE_DIR = path.join(sandbox, "state");
+
+const { agentRegistry } = await import("@/lib/agent/registry");
+const { POST } = await import("./route");
+
+afterAll(() => {
+  if (previousStateDir === undefined) delete process.env.LLV_STATE_DIR;
+  else process.env.LLV_STATE_DIR = previousStateDir;
+  fs.rmSync(sandbox, { recursive: true, force: true });
+});
+
+function seedCaller(role: string): { capability: string; conversationId: ViewerConversationId; path: string } {
+  const store = agentRegistry();
+  const capability = crypto.randomBytes(32).toString("base64url");
+  const reviews = role === "reviewer"
+    ? store.ensureConversation("codex", `/sessions/reviewed-${crypto.randomUUID()}.jsonl`, "terra").id
+    : null;
+  const begun = store.beginSpawnRequest({
+    engine: "codex",
+    cwd: "/repo",
+    role,
+    reviewsConversationId: reviews,
+    parentConversationId: reviews,
+    origin: { kind: "operator" },
+    spawnCapabilityDigest: crypto.createHash("sha256").update(capability).digest("hex"),
+  });
+  if (begun.kind !== "created") throw new Error("expected create");
+  const sessionId = crypto.randomUUID();
+  const artifactPath = `/sessions/caller-${sessionId}.jsonl`;
+  const settled = store.settleSpawn(begun.receipt.launchId, {
+    key: { engine: "codex", sessionId },
+    artifactPath,
+    cwd: "/repo",
+    accountId: "terra",
+    status: "live",
+    host: null,
+    claimEpoch: 0,
+    claimOwner: null,
+    pendingAction: null,
+  });
+  if (settled.kind !== "settled") throw new Error(`settlement conflict: ${settled.code}`);
+  return { capability, conversationId: settled.conversation.id, path: artifactPath };
+}
+
+function pipelineRequest(body: Record<string, unknown>, headers: Record<string, string> = {}): NextRequest {
+  return new NextRequest("http://127.0.0.1:8898/api/pipelines", {
+    method: "POST",
+    headers: { host: "127.0.0.1:8898", "content-type": "application/json", ...headers },
+    body: JSON.stringify(body),
+  });
+}
+
+test("an authenticated reviewer caller cannot create a pipeline", async () => {
+  const caller = seedCaller("reviewer");
+  const response = await POST(pipelineRequest(
+    { task: "escape", repoDir: process.cwd(), src: caller.path },
+    { "x-llv-spawn-capability": caller.capability },
+  ));
+
+  expect(response.status).toBe(403);
+  expect(await response.json()).toMatchObject({
+    code: "reviewer_origin_spawn",
+    error: expect.stringContaining("in-session"),
+  });
+});
+
+test("a declared reviewer src is rejected even without a capability header", async () => {
+  const caller = seedCaller("verifier");
+  const response = await POST(pipelineRequest({ task: "escape", repoDir: process.cwd(), src: caller.path }));
+
+  expect(response.status).toBe(403);
+  expect(await response.json()).toMatchObject({ code: "reviewer_origin_spawn" });
+});
+
+test("an authenticated builder caller and an unattributed external caller keep today's behavior", async () => {
+  const caller = seedCaller("builder");
+  const authenticated = await POST(pipelineRequest(
+    { task: "", repoDir: process.cwd(), src: caller.path },
+    { "x-llv-spawn-capability": caller.capability },
+  ));
+  expect(authenticated.status).toBe(400);
+  expect(await authenticated.json()).toEqual({ error: "task is required" });
+
+  const external = await POST(pipelineRequest({ task: "" }));
+  expect(external.status).toBe(400);
+  expect(await external.json()).toEqual({ error: "task is required" });
+});
+
+test("a capability header that does not authenticate is rejected before pipeline creation", async () => {
+  const response = await POST(pipelineRequest(
+    { task: "escape", repoDir: process.cwd() },
+    { "x-llv-spawn-capability": "B".repeat(43) },
+  ));
+
+  expect(response.status).toBe(403);
+  expect(await response.json()).toEqual({ error: expect.stringContaining("x-llv-spawn-capability") });
+});

--- a/src/app/api/pipelines/route.ts
+++ b/src/app/api/pipelines/route.ts
@@ -1,5 +1,9 @@
 import { NextRequest, NextResponse } from "next/server";
 
+import { authenticatedAgentSpawnCaller, isAgentInitiatedSpawn } from "@/app/api/spawn/admission";
+import { agentRegistry } from "@/lib/agent/registry";
+import { conversationAgentRole, isSpawnDeniedRole, reviewerOriginSpawnGuidance, type SpawnRejectionCode } from "@/lib/agent/spawnAdmission";
+import { VIEWER_SPAWN_CAPABILITY_HEADER } from "@/lib/agent/spawnPolicy";
 import { createPipelineFromRequest, getPipelines } from "@/lib/pipelines/engine";
 import type { CreatePipelineRequest, Pipeline, PipelineRepoPreflightErrorCode, PipelinesResponse } from "@/lib/pipelines/types";
 import { requestPipelineTick } from "@/lib/pipelines/controllerSignal";
@@ -10,7 +14,7 @@ export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
 type PipelineApiError = ApiError & {
-  code?: PipelineRepoPreflightErrorCode;
+  code?: PipelineRepoPreflightErrorCode | SpawnRejectionCode;
   field?: "repoDir";
   path?: string;
 };
@@ -22,6 +26,39 @@ export async function GET(): Promise<NextResponse<PipelinesResponse | ApiError>>
     return NextResponse.json({ error: error instanceof Error ? error.message : "pipeline registry unreadable" }, { status: 500 });
   }
 }
+
+/** Reviewer isolation for pipeline creation (#393): a pipeline is a spawn
+    container, so a reviewer/verifier caller may not create one. The
+    authenticated capability lane and a declared reviewer `src` are both
+    rejected; external callers without a capability keep the #341 contract.
+    Registry admission independently rejects every stage launch of any
+    reviewer-created container, so this route check is defense in depth. */
+function pipelineOriginRejection(req: NextRequest, body: CreatePipelineRequest): NextResponse<PipelineApiError> | null {
+  if (!isAgentInitiatedSpawn(req)) return null;
+  const registry = agentRegistry();
+  const capability = req.headers.get(VIEWER_SPAWN_CAPABILITY_HEADER)?.trim();
+  if (capability) {
+    const caller = authenticatedAgentSpawnCaller(req, body.src, registry);
+    if ("error" in caller) return NextResponse.json({ error: caller.error }, { status: caller.status ?? 403 });
+    if (caller.kind === "agent") {
+      const role = conversationAgentRole(registry.snapshot(), caller.conversationId);
+      if (isSpawnDeniedRole(role)) {
+        return NextResponse.json({ error: reviewerOriginSpawnGuidance(role), code: "reviewer_origin_spawn" }, { status: 403 });
+      }
+    }
+    return null;
+  }
+  const srcPath = typeof body.src === "string" && body.src.trim() ? body.src.trim() : null;
+  const srcConversation = srcPath ? registry.conversationForPath(srcPath) : null;
+  if (srcConversation) {
+    const role = conversationAgentRole(registry.snapshot(), srcConversation.id);
+    if (isSpawnDeniedRole(role)) {
+      return NextResponse.json({ error: reviewerOriginSpawnGuidance(role), code: "reviewer_origin_spawn" }, { status: 403 });
+    }
+  }
+  return null;
+}
+
 export async function POST(req: NextRequest): Promise<NextResponse<{ ok: true; pipeline: Pipeline } | PipelineApiError>> {
   const rejection = rejectCrossOrigin(req);
   if (rejection) return rejection;
@@ -34,6 +71,8 @@ export async function POST(req: NextRequest): Promise<NextResponse<{ ok: true; p
     return NextResponse.json({ error: "invalid JSON" }, { status: 400 });
   }
   try {
+    const originRejection = pipelineOriginRejection(req, body);
+    if (originRejection) return originRejection;
     const result = await createPipelineFromRequest(body);
     if (!result.pipeline) return NextResponse.json({
       error: result.error ?? "could not create pipeline",

--- a/src/app/api/spawn/policy/route.test.ts
+++ b/src/app/api/spawn/policy/route.test.ts
@@ -1,0 +1,58 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, expect, test } from "bun:test";
+import { NextRequest } from "next/server";
+
+const previousStateDir = process.env.LLV_STATE_DIR;
+const sandbox = fs.mkdtempSync(path.join(os.tmpdir(), "llv-spawn-policy-route-"));
+process.env.LLV_STATE_DIR = sandbox;
+
+const { GET, PATCH } = await import("./route");
+
+afterAll(() => {
+  if (previousStateDir === undefined) delete process.env.LLV_STATE_DIR;
+  else process.env.LLV_STATE_DIR = previousStateDir;
+  fs.rmSync(sandbox, { recursive: true, force: true });
+});
+
+const OPERATOR_HEADERS = {
+  host: "127.0.0.1:8898",
+  origin: "http://127.0.0.1:8898",
+  "sec-fetch-site": "same-origin",
+  "content-type": "application/json",
+};
+
+function patchRequest(body: unknown, headers: Record<string, string> = OPERATOR_HEADERS): NextRequest {
+  return new NextRequest("http://127.0.0.1:8898/api/spawn/policy", {
+    method: "PATCH",
+    headers,
+    body: JSON.stringify(body),
+  });
+}
+
+test("the effective policy defaults to depth 2 and an operator can change it within bounds", async () => {
+  expect(await (await GET()).json()).toEqual({ maxAgentNestingDepth: 2 });
+
+  const updated = await PATCH(patchRequest({ maxAgentNestingDepth: 3 }));
+  expect(updated.status).toBe(200);
+  expect(await updated.json()).toEqual({ maxAgentNestingDepth: 3 });
+  expect(await (await GET()).json()).toEqual({ maxAgentNestingDepth: 3 });
+
+  const outOfBounds = await PATCH(patchRequest({ maxAgentNestingDepth: 5 }));
+  expect(outOfBounds.status).toBe(400);
+  expect(await outOfBounds.json()).toEqual({ error: expect.stringContaining("between 1 and 4") });
+  expect(await (await GET()).json()).toEqual({ maxAgentNestingDepth: 3 });
+  fs.rmSync(path.join(sandbox, "spawn-nesting.json"), { force: true });
+});
+
+test("agent-initiated callers can never raise their own ceiling", async () => {
+  const response = await PATCH(patchRequest(
+    { maxAgentNestingDepth: 4 },
+    { host: "127.0.0.1:8898", "content-type": "application/json" },
+  ));
+
+  expect(response.status).toBe(403);
+  expect(await response.json()).toEqual({ error: expect.stringContaining("operator") });
+  expect(await (await GET()).json()).toEqual({ maxAgentNestingDepth: 2 });
+});

--- a/src/app/api/spawn/policy/route.ts
+++ b/src/app/api/spawn/policy/route.ts
@@ -1,0 +1,44 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import {
+  MAX_AGENT_NESTING_DEPTH,
+  MIN_AGENT_NESTING_DEPTH,
+  loadSpawnNestingPolicy,
+  saveSpawnNestingPolicy,
+  validMaxAgentNestingDepth,
+  type SpawnNestingPolicy,
+} from "@/lib/agent/nestingPolicy";
+import { rejectCrossOrigin } from "@/lib/sameOrigin";
+import type { ApiError } from "@/lib/types";
+
+import { isAgentInitiatedSpawn } from "../admission";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function GET(): Promise<NextResponse<SpawnNestingPolicy>> {
+  return NextResponse.json(loadSpawnNestingPolicy());
+}
+
+/** Operator-only ceiling change (#393): the agent lane can never raise its
+    own nesting ceiling, so any non-same-origin caller is rejected outright. */
+export async function PATCH(req: NextRequest): Promise<NextResponse<SpawnNestingPolicy | ApiError>> {
+  const rejection = rejectCrossOrigin(req);
+  if (rejection) return rejection;
+  if (isAgentInitiatedSpawn(req)) {
+    return NextResponse.json({ error: "spawn nesting policy changes require an operator session" }, { status: 403 });
+  }
+  let body: { maxAgentNestingDepth?: unknown };
+  try {
+    body = (await req.json()) as typeof body;
+  } catch {
+    return NextResponse.json({ error: "invalid JSON" }, { status: 400 });
+  }
+  if (!validMaxAgentNestingDepth(body.maxAgentNestingDepth)) {
+    return NextResponse.json({
+      error: `maxAgentNestingDepth must be an integer between ${MIN_AGENT_NESTING_DEPTH} and ${MAX_AGENT_NESTING_DEPTH}`,
+    }, { status: 400 });
+  }
+  saveSpawnNestingPolicy({ maxAgentNestingDepth: body.maxAgentNestingDepth });
+  return NextResponse.json(loadSpawnNestingPolicy());
+}

--- a/src/app/api/spawn/route.admission.test.ts
+++ b/src/app/api/spawn/route.admission.test.ts
@@ -1,0 +1,233 @@
+import crypto from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, expect, test } from "bun:test";
+import { NextRequest } from "next/server";
+
+import type { RuntimeHostClient } from "@/lib/runtime/client";
+import type { ViewerConversationId } from "@/lib/accounts/migration/contracts";
+
+const sandbox = fs.mkdtempSync(path.join(os.tmpdir(), "llv-spawn-admission-route-"));
+const STRUCTURED_ENV = {
+  LLV_STATE_DIR: path.join(sandbox, "state"),
+  LLV_SPAWN_TRANSPORT: "structured",
+  LLV_STRUCTURED_HOSTS: "1",
+  LLV_RUNTIME_EVENTS: "1",
+  LLV_RUNTIME_HOST_SOCKET: path.join(sandbox, "runtime.sock"),
+  NEXT_PUBLIC_RUNTIME_UI: "1",
+} as const;
+const previousEnv = Object.fromEntries(Object.keys(STRUCTURED_ENV).map((key) => [key, process.env[key]]));
+Object.assign(process.env, STRUCTURED_ENV);
+
+const { agentRegistry } = await import("@/lib/agent/registry");
+const { rotateOperatorSpawnCapability } = await import("@/lib/agent/operatorCapability");
+const { POST } = await import("./route");
+
+afterAll(() => {
+  for (const [key, value] of Object.entries(previousEnv)) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+  fs.rmSync(sandbox, { recursive: true, force: true });
+});
+
+type SpawnRouteTestDependencies = NonNullable<Parameters<typeof POST.withDependencies>[1]>;
+
+function dependencies(cwd: string): SpawnRouteTestDependencies {
+  return {
+    registry: agentRegistry,
+    assertStructuredRuntime: () => {},
+    resolveHealthySpawnAccount: async () => ({
+      engine: "claude",
+      accountId: "claude-test",
+      kind: "managed",
+      home: path.join(cwd, "account"),
+      transcriptRoot: path.join(cwd, "projects"),
+      env: { NODE_ENV: "test" },
+    }),
+    resolveSpawnAccount: (_engine, accountId) => ({
+      engine: "claude",
+      accountId: accountId ?? "claude-test",
+      kind: "managed",
+      home: path.join(cwd, "account"),
+      transcriptRoot: path.join(cwd, "projects"),
+      env: { NODE_ENV: "test" },
+    }),
+    runtimeHostClient: () => ({} as RuntimeHostClient),
+    defer: (work) => { void work(); },
+    storeImages: () => [],
+    spawnStructuredConversation: async (input) => ({
+      ok: true,
+      target: null,
+      path: null,
+      launchId: input.receipt.launchId,
+      conversationId: input.receipt.conversationId,
+      launched: true,
+      retrySafe: false,
+      initialMessage: "delivered",
+      state: "settled",
+    }),
+  };
+}
+
+function settleCaller(store: ReturnType<typeof agentRegistry>, launchId: string): { conversationId: ViewerConversationId; path: string } {
+  const sessionId = crypto.randomUUID();
+  const artifactPath = `/sessions/caller-${sessionId}.jsonl`;
+  const settled = store.settleSpawn(launchId, {
+    key: { engine: "codex", sessionId },
+    artifactPath,
+    cwd: "/repo",
+    accountId: "terra",
+    status: "live",
+    host: null,
+    claimEpoch: 0,
+    claimOwner: null,
+    pendingAction: null,
+  });
+  if (settled.kind !== "settled") throw new Error(`settlement conflict: ${settled.code}`);
+  return { conversationId: settled.conversation.id, path: artifactPath };
+}
+
+function seedCaller(role: string | null, origin?: { kind: "agent"; conversationId: ViewerConversationId }): { capability: string; conversationId: ViewerConversationId; path: string } {
+  const store = agentRegistry();
+  const capability = crypto.randomBytes(32).toString("base64url");
+  const reviews = role === "reviewer"
+    ? store.ensureConversation("codex", `/sessions/reviewed-${crypto.randomUUID()}.jsonl`, "terra").id
+    : null;
+  const begun = store.beginSpawnRequest({
+    engine: "codex",
+    cwd: "/repo",
+    role,
+    reviewsConversationId: reviews,
+    parentConversationId: reviews,
+    origin: origin ?? { kind: "operator" },
+    spawnCapabilityDigest: crypto.createHash("sha256").update(capability).digest("hex"),
+  });
+  if (begun.kind !== "created") throw new Error("expected create");
+  const settled = settleCaller(store, begun.receipt.launchId);
+  return { capability, ...settled };
+}
+
+function agentRequest(capability: string, body: Record<string, unknown>): NextRequest {
+  return new NextRequest("http://127.0.0.1:8898/api/spawn", {
+    method: "POST",
+    headers: {
+      host: "127.0.0.1:8898",
+      "content-type": "application/json",
+      "x-llv-spawn-capability": capability,
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+test("an authenticated reviewer caller receives a typed 403 with a durable terminal receipt and zero child artifacts", async () => {
+  const cwd = fs.mkdtempSync(path.join(sandbox, "reviewer-caller-"));
+  const caller = seedCaller("reviewer");
+  const response = await POST.withDependencies(agentRequest(caller.capability, {
+    cwd,
+    prompt: "spawn a helper",
+    src: caller.path,
+    role: "builder",
+  }), dependencies(cwd));
+
+  expect(response.status).toBe(403);
+  const body = await response.json() as { error: string; code: string; launchId: string; conversationId: string; rejection: { code: string; origin: { role: string } } };
+  expect(body.code).toBe("reviewer_origin_spawn");
+  expect(body.error).toContain("in-session");
+  expect(body.rejection.origin).toMatchObject({ role: "reviewer", conversationId: caller.conversationId });
+
+  const snapshot = agentRegistry().snapshot();
+  expect(snapshot.receipts[body.launchId]).toMatchObject({ state: "failed", rejection: { code: "reviewer_origin_spawn" } });
+  expect(snapshot.conversations[body.conversationId]).toBeUndefined();
+  expect(snapshot.lineageEdges[body.conversationId]).toBeUndefined();
+  expect(snapshot.memberships[body.conversationId]).toBeUndefined();
+});
+
+test("a verifier caller is rejected identically", async () => {
+  const cwd = fs.mkdtempSync(path.join(sandbox, "verifier-caller-"));
+  const caller = seedCaller("verifier");
+  const response = await POST.withDependencies(agentRequest(caller.capability, {
+    cwd,
+    prompt: "spawn a helper",
+    src: caller.path,
+    role: "builder",
+  }), dependencies(cwd));
+
+  expect(response.status).toBe(403);
+  expect(await response.json()).toMatchObject({ code: "reviewer_origin_spawn" });
+});
+
+test("a caller at the depth ceiling receives a typed nesting 403 before any child transcript", async () => {
+  const cwd = fs.mkdtempSync(path.join(sandbox, "depth-caller-"));
+  const rootCaller = seedCaller("orchestrator");
+  const depth1 = seedCaller("builder", { kind: "agent", conversationId: rootCaller.conversationId });
+  const depth2 = seedCaller("builder", { kind: "agent", conversationId: depth1.conversationId });
+
+  const allowedResponse = await POST.withDependencies(agentRequest(depth1.capability, {
+    cwd,
+    prompt: "one more helper",
+    src: depth1.path,
+    role: "builder",
+  }), dependencies(cwd));
+  expect(allowedResponse.status).toBe(202);
+
+  const response = await POST.withDependencies(agentRequest(depth2.capability, {
+    cwd,
+    prompt: "too deep",
+    src: depth2.path,
+    role: "builder",
+  }), dependencies(cwd));
+
+  expect(response.status).toBe(403);
+  const body = await response.json() as { code: string; rejection: { childDepth: number; maxDepth: number } };
+  expect(body.code).toBe("nesting_depth_exceeded");
+  expect(body.rejection).toMatchObject({ childDepth: 3, maxDepth: 2 });
+});
+
+test("reviewer and verifier launches cannot enable subagents on any lane", async () => {
+  const operator = rotateOperatorSpawnCapability();
+  const operatorResponse = await POST(agentRequest(operator, {
+    cwd: "/repo",
+    prompt: "review",
+    src: "/caller.jsonl",
+    role: "reviewer",
+    roleParams: { diffSource: "PR #1" },
+    reviews: "/implementer.jsonl",
+    allowSubagents: true,
+  }));
+  expect(operatorResponse.status).toBe(400);
+  expect(await operatorResponse.json()).toEqual({ error: expect.stringContaining("cannot enable subagents") });
+
+  const browserResponse = await POST(new NextRequest("http://127.0.0.1:8898/api/spawn", {
+    method: "POST",
+    headers: {
+      host: "127.0.0.1:8898",
+      origin: "http://127.0.0.1:8898",
+      "sec-fetch-site": "same-origin",
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({ cwd: "/repo", prompt: "verify", role: "verifier", roleParams: { claims: "the fix holds" }, allowSubagents: true }),
+  }));
+  expect(browserResponse.status).toBe(400);
+  expect(await browserResponse.json()).toEqual({ error: expect.stringContaining("cannot enable subagents") });
+});
+
+test("a non-reviewer agent caller keeps spawning normally", async () => {
+  const cwd = fs.mkdtempSync(path.join(sandbox, "builder-caller-"));
+  const caller = seedCaller("builder");
+  const response = await POST.withDependencies(agentRequest(caller.capability, {
+    cwd,
+    prompt: "delegate",
+    src: caller.path,
+    role: "builder",
+  }), dependencies(cwd));
+
+  expect(response.status).toBe(202);
+  const body = await response.json() as { launchId: string };
+  expect(agentRegistry().snapshot().receipts[body.launchId]).toMatchObject({
+    agentRole: "builder",
+    delegationDepth: 1,
+    rejection: null,
+  });
+});

--- a/src/app/api/spawn/route.ts
+++ b/src/app/api/spawn/route.ts
@@ -17,7 +17,8 @@ import { assertDarwinStructuredRuntime } from "@/lib/proc/darwinIdentity";
 import { spawnContentDigest, spawnParentSelector, spawnRequestDigest } from "@/lib/agent/spawnIdentity";
 import { sessionKeyFromTranscript, sessionKeyId } from "@/lib/agent/sessionKey";
 import { resolveSpawnLineage, SpawnParentError } from "@/lib/agent/spawnParent";
-import { spawnReplayStatus, spawnResponseForReceipt, type SpawnResponse } from "@/lib/agent/spawnResponse";
+import { SpawnAdmissionError, isSpawnDeniedRole } from "@/lib/agent/spawnAdmission";
+import { spawnRejectionResponse, spawnReplayStatus, spawnResponseForReceipt, type SpawnResponse } from "@/lib/agent/spawnResponse";
 import { applyClaudeSpawnPolicy, prepareManagedClaudeSpawnHome } from "@/lib/agent/spawnPolicy";
 import { resolveSpawnedTranscriptPath } from "@/lib/agent/spawnedTranscript";
 import { headCwd } from "@/lib/agent/transcript";
@@ -156,6 +157,13 @@ async function postSpawn(
   }
   if (role.value?.role !== "reviewer" && body.reviews !== undefined) {
     return NextResponse.json({ error: "reviews requires role: reviewer" }, { status: 400 });
+  }
+  /* Reviewer isolation (#393): reviewer/verifier launch profiles always carry
+     allowSubagents:false, so every engine denies native multi-agent tools on
+     fresh launch, resume, and restart adoption. Even the operator lane cannot
+     combine a denied role with subagent access. */
+  if (role.value && isSpawnDeniedRole(role.value.role) && body.allowSubagents === true) {
+    return NextResponse.json({ error: `${role.value.role} launches cannot enable subagents: reviewer and verifier sessions run every check in-session` }, { status: 400 });
   }
   const engine = body.engine === "claude" || body.engine === "codex"
     ? (body.engine as AgentEngine)
@@ -347,6 +355,12 @@ async function postSpawn(
       supersedes: supersedesConversationId,
       supersedesReason: "recovery-spawn",
       liveChildrenCap: authenticatedCaller?.liveChildrenCap,
+      /* Initiating origin (#393): the authenticated capability caller is the
+         origin of agent-lane launches; same-origin UI and operator-capability
+         launches are depth-0 roots. Lineage parents stay projection metadata. */
+      origin: authenticatedCaller?.kind === "agent"
+        ? { kind: "agent", conversationId: authenticatedCaller.conversationId }
+        : { kind: "operator" },
       launchProfile: spec.launchProfile,
       clientAttemptId,
       requestDigest: digest,
@@ -550,6 +564,9 @@ async function postSpawn(
       deleteInboxImages(imagePaths);
     }
     if (error instanceof SpawnParentError) return NextResponse.json({ error: error.message }, { status: error.status });
+    /* Typed terminal admission rejection (#393): the durable receipt already
+       exists and no transcript or process was created. */
+    if (error instanceof SpawnAdmissionError) return NextResponse.json(spawnRejectionResponse(error), { status: 403 });
     if (error instanceof SpawnChildLimitError) return NextResponse.json({ error: error.message }, { status: 429 });
     if (error instanceof RuntimeImageStorageError) return NextResponse.json({ error: error.message }, { status: 503 });
     if (error instanceof UnknownAccountError || error instanceof UnknownClaudeAccountError) return NextResponse.json({ error: error.message }, { status: 400 });

--- a/src/app/api/tasks/[id]/spawn/route.ts
+++ b/src/app/api/tasks/[id]/spawn/route.ts
@@ -236,6 +236,7 @@ async function postTaskSpawn(
     cwd: cwdResult.cwd,
     transport: "tmux",
     accountId: account.accountId,
+    origin: { kind: "operator" },
     launchProfile: spec.launchProfile,
     clientAttemptId,
     requestDigest: taskRequestDigest(task, shape),

--- a/src/lib/accounts/migration/provider.ts
+++ b/src/lib/accounts/migration/provider.ts
@@ -834,6 +834,7 @@ export class RegisteredSuccessorProvider implements SuccessorProviderPort {
       accountId: target.accountId,
       conversationId,
       purpose: "migration-successor",
+      origin: { kind: "successor" },
       expectedArtifactPath: successorPath,
     });
     if (begun.kind === "conflict") throw new Error("successor Claude operation receipt conflicts");

--- a/src/lib/agent/nestingPolicy.test.ts
+++ b/src/lib/agent/nestingPolicy.test.ts
@@ -1,0 +1,50 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, expect, test } from "bun:test";
+
+const previousStateDir = process.env.LLV_STATE_DIR;
+const sandbox = fs.mkdtempSync(path.join(os.tmpdir(), "llv-nesting-policy-"));
+process.env.LLV_STATE_DIR = sandbox;
+
+const {
+  DEFAULT_MAX_AGENT_NESTING_DEPTH,
+  loadSpawnNestingPolicy,
+  saveSpawnNestingPolicy,
+  validMaxAgentNestingDepth,
+} = await import("./nestingPolicy");
+
+afterAll(() => {
+  if (previousStateDir === undefined) delete process.env.LLV_STATE_DIR;
+  else process.env.LLV_STATE_DIR = previousStateDir;
+  fs.rmSync(sandbox, { recursive: true, force: true });
+});
+
+test("an absent policy file yields the conservative default of 2", () => {
+  expect(DEFAULT_MAX_AGENT_NESTING_DEPTH).toBe(2);
+  expect(loadSpawnNestingPolicy()).toEqual({ maxAgentNestingDepth: 2 });
+});
+
+test("a corrupt or out-of-bounds policy file degrades to the default", () => {
+  const file = path.join(sandbox, "spawn-nesting.json");
+  fs.writeFileSync(file, "not json");
+  expect(loadSpawnNestingPolicy()).toEqual({ maxAgentNestingDepth: 2 });
+  fs.writeFileSync(file, JSON.stringify({ schemaVersion: 1, maxAgentNestingDepth: 99 }));
+  expect(loadSpawnNestingPolicy()).toEqual({ maxAgentNestingDepth: 2 });
+  fs.writeFileSync(file, JSON.stringify({ schemaVersion: 7, maxAgentNestingDepth: 3 }));
+  expect(loadSpawnNestingPolicy()).toEqual({ maxAgentNestingDepth: 2 });
+  fs.rmSync(file);
+});
+
+test("saved policy round-trips and bounds are validated", () => {
+  saveSpawnNestingPolicy({ maxAgentNestingDepth: 3 });
+  expect(loadSpawnNestingPolicy()).toEqual({ maxAgentNestingDepth: 3 });
+  saveSpawnNestingPolicy({ maxAgentNestingDepth: 1 });
+  expect(loadSpawnNestingPolicy()).toEqual({ maxAgentNestingDepth: 1 });
+  expect(() => saveSpawnNestingPolicy({ maxAgentNestingDepth: 0 })).toThrow("between 1 and 4");
+  expect(() => saveSpawnNestingPolicy({ maxAgentNestingDepth: 5 })).toThrow("between 1 and 4");
+  expect(() => saveSpawnNestingPolicy({ maxAgentNestingDepth: 2.5 })).toThrow("between 1 and 4");
+  expect(validMaxAgentNestingDepth(4)).toBe(true);
+  expect(validMaxAgentNestingDepth("2")).toBe(false);
+  fs.rmSync(path.join(sandbox, "spawn-nesting.json"));
+});

--- a/src/lib/agent/nestingPolicy.ts
+++ b/src/lib/agent/nestingPolicy.ts
@@ -1,0 +1,61 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import { statePath } from "@/lib/configDir";
+
+export const SPAWN_NESTING_SCHEMA_VERSION = 1;
+
+/** Conservative default (#393): operator roots at depth 0, their delegates at
+    depth 1, and one more helper generation at depth 2. */
+export const DEFAULT_MAX_AGENT_NESTING_DEPTH = 2;
+export const MIN_AGENT_NESTING_DEPTH = 1;
+export const MAX_AGENT_NESTING_DEPTH = 4;
+
+export interface SpawnNestingPolicy {
+  maxAgentNestingDepth: number;
+}
+
+interface SpawnNestingPolicyFile extends SpawnNestingPolicy {
+  schemaVersion: typeof SPAWN_NESTING_SCHEMA_VERSION;
+}
+
+const policyFile = () => statePath("spawn-nesting.json");
+
+export function validMaxAgentNestingDepth(value: unknown): value is number {
+  return Number.isInteger(value)
+    && (value as number) >= MIN_AGENT_NESTING_DEPTH
+    && (value as number) <= MAX_AGENT_NESTING_DEPTH;
+}
+
+/** Durable nesting ceiling. An absent or corrupt file degrades to the
+    default so admission never fails open on depth or blocks on policy IO. */
+export function loadSpawnNestingPolicy(): SpawnNestingPolicy {
+  let text: string;
+  try {
+    text = fs.readFileSync(policyFile(), "utf8");
+  } catch {
+    return { maxAgentNestingDepth: DEFAULT_MAX_AGENT_NESTING_DEPTH };
+  }
+  try {
+    const raw = JSON.parse(text) as Partial<SpawnNestingPolicyFile>;
+    if (raw.schemaVersion === SPAWN_NESTING_SCHEMA_VERSION && validMaxAgentNestingDepth(raw.maxAgentNestingDepth)) {
+      return { maxAgentNestingDepth: raw.maxAgentNestingDepth };
+    }
+  } catch { /* corrupt policy degrades to the default below */ }
+  return { maxAgentNestingDepth: DEFAULT_MAX_AGENT_NESTING_DEPTH };
+}
+
+export function saveSpawnNestingPolicy(policy: SpawnNestingPolicy): void {
+  if (!validMaxAgentNestingDepth(policy.maxAgentNestingDepth)) {
+    throw new Error(`maxAgentNestingDepth must be an integer between ${MIN_AGENT_NESTING_DEPTH} and ${MAX_AGENT_NESTING_DEPTH}`);
+  }
+  const target = policyFile();
+  fs.mkdirSync(path.dirname(target), { recursive: true });
+  const temp = path.join(path.dirname(target), `.${path.basename(target)}.${process.pid}.tmp`);
+  const file: SpawnNestingPolicyFile = {
+    schemaVersion: SPAWN_NESTING_SCHEMA_VERSION,
+    maxAgentNestingDepth: policy.maxAgentNestingDepth,
+  };
+  fs.writeFileSync(temp, JSON.stringify(file, null, 2) + "\n", "utf8");
+  fs.renameSync(temp, target);
+}

--- a/src/lib/agent/registry.admission.test.ts
+++ b/src/lib/agent/registry.admission.test.ts
@@ -1,0 +1,295 @@
+import crypto from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, expect, test } from "bun:test";
+
+import type { ViewerConversationId } from "@/lib/accounts/migration/contracts";
+
+const previousStateDir = process.env.LLV_STATE_DIR;
+const sandbox = fs.mkdtempSync(path.join(os.tmpdir(), "llv-registry-admission-"));
+process.env.LLV_STATE_DIR = path.join(sandbox, "state");
+
+const { AgentRegistry } = await import("./registry");
+const { SpawnAdmissionError } = await import("./spawnAdmission");
+const { saveSpawnNestingPolicy } = await import("./nestingPolicy");
+
+afterAll(() => {
+  if (previousStateDir === undefined) delete process.env.LLV_STATE_DIR;
+  else process.env.LLV_STATE_DIR = previousStateDir;
+  fs.rmSync(sandbox, { recursive: true, force: true });
+});
+
+function registryAt(name: string): { store: InstanceType<typeof AgentRegistry>; filename: string } {
+  const filename = path.join(sandbox, `${name}.json`);
+  return { store: new AgentRegistry(filename, undefined, undefined, { sqliteMode: "off" }), filename };
+}
+
+function settleLaunch(
+  store: InstanceType<typeof AgentRegistry>,
+  launchId: string,
+  sessionId = crypto.randomUUID(),
+): ViewerConversationId {
+  const settled = store.settleSpawn(launchId, {
+    key: { engine: "codex", sessionId },
+    artifactPath: `/sessions/${sessionId}.jsonl`,
+    cwd: "/repo",
+    accountId: "terra",
+    status: "live",
+    host: null,
+    claimEpoch: 0,
+    claimOwner: null,
+    pendingAction: null,
+  });
+  if (settled.kind !== "settled") throw new Error(`settlement conflict: ${settled.code}`);
+  return settled.conversation.id;
+}
+
+function spawnAtDepth(
+  store: InstanceType<typeof AgentRegistry>,
+  origin: Parameters<InstanceType<typeof AgentRegistry>["beginSpawnRequest"]>[0]["origin"],
+  role: string | null = null,
+): { launchId: string; conversationId: ViewerConversationId } {
+  const begun = store.beginSpawnRequest({ engine: "codex", cwd: "/repo", origin, role });
+  if (begun.kind !== "created") throw new Error("expected create");
+  return { launchId: begun.receipt.launchId, conversationId: settleLaunch(store, begun.receipt.launchId) };
+}
+
+test("a reviewer-origin launch is terminally rejected with a durable typed receipt and zero child artifacts", () => {
+  const { store } = registryAt("reviewer-origin");
+  const implementer = store.ensureConversation("codex", "/sessions/reviewed-implementer.jsonl", "terra");
+  const reviewerBegun = store.beginSpawnRequest({
+    engine: "codex",
+    cwd: "/repo",
+    role: "reviewer",
+    reviewsConversationId: implementer.id,
+    parentConversationId: implementer.id,
+    origin: { kind: "operator" },
+  });
+  if (reviewerBegun.kind !== "created") throw new Error("expected create");
+  expect(reviewerBegun.receipt.agentRole).toBe("reviewer");
+  expect(reviewerBegun.receipt.delegationDepth).toBe(0);
+  const reviewerId = settleLaunch(store, reviewerBegun.receipt.launchId);
+  expect(store.conversation(reviewerId)).toMatchObject({ agentRole: "reviewer", delegationDepth: 0 });
+
+  const attempt = () => store.beginSpawnRequest({
+    engine: "codex",
+    cwd: "/repo",
+    parentConversationId: reviewerId,
+    role: "builder",
+    origin: { kind: "agent", conversationId: reviewerId },
+    clientAttemptId: "reviewer-child-attempt-1",
+    requestDigest: "digest-1",
+    memberships: [],
+  });
+  expect(attempt).toThrow(SpawnAdmissionError);
+
+  let rejectionError: InstanceType<typeof SpawnAdmissionError> | null = null;
+  try {
+    attempt();
+  } catch (error) {
+    rejectionError = error as InstanceType<typeof SpawnAdmissionError>;
+  }
+  const receipt = rejectionError!.receipt;
+  expect(receipt.state).toBe("failed");
+  expect(receipt.completionMode).toBeNull();
+  expect(receipt.rejection).toMatchObject({
+    code: "reviewer_origin_spawn",
+    origin: { kind: "agent", conversationId: reviewerId, role: "reviewer", depth: 0 },
+    requestedRole: "builder",
+    childDepth: 1,
+    maxDepth: 2,
+  });
+  expect(receipt.error).toBe(receipt.rejection!.guidance);
+
+  const snapshot = store.snapshot();
+  const durable = snapshot.receipts[receipt.launchId]!;
+  expect(durable.state).toBe("failed");
+  expect(durable.rejection?.code).toBe("reviewer_origin_spawn");
+  expect(snapshot.conversations[receipt.conversationId]).toBeUndefined();
+  expect(snapshot.lineageEdges[receipt.conversationId]).toBeUndefined();
+  expect(snapshot.memberships[receipt.conversationId]).toBeUndefined();
+
+  /* Replay of the same clientAttemptId is idempotent: the identical rejected
+     receipt comes back, no second receipt appears. */
+  const receiptsBefore = Object.keys(snapshot.receipts).length;
+  let replayed: InstanceType<typeof SpawnAdmissionError> | null = null;
+  try {
+    attempt();
+  } catch (error) {
+    replayed = error as InstanceType<typeof SpawnAdmissionError>;
+  }
+  expect(replayed!.receipt.launchId).toBe(receipt.launchId);
+  expect(Object.keys(store.snapshot().receipts).length).toBe(receiptsBefore);
+});
+
+test("delegation depth records at birth and the ceiling rejects the child that would exceed it", () => {
+  const { store } = registryAt("depth-chain");
+  const root = spawnAtDepth(store, { kind: "operator" });
+  expect(store.conversation(root.conversationId)).toMatchObject({ delegationDepth: 0 });
+
+  const first = spawnAtDepth(store, { kind: "agent", conversationId: root.conversationId });
+  expect(store.conversation(first.conversationId)).toMatchObject({ delegationDepth: 1 });
+
+  const second = spawnAtDepth(store, { kind: "agent", conversationId: first.conversationId });
+  expect(store.conversation(second.conversationId)).toMatchObject({ delegationDepth: 2 });
+
+  let rejection: InstanceType<typeof SpawnAdmissionError> | null = null;
+  try {
+    store.beginSpawnRequest({
+      engine: "codex",
+      cwd: "/repo",
+      origin: { kind: "agent", conversationId: second.conversationId },
+    });
+  } catch (error) {
+    rejection = error as InstanceType<typeof SpawnAdmissionError>;
+  }
+  expect(rejection!.rejection).toMatchObject({
+    code: "nesting_depth_exceeded",
+    childDepth: 3,
+    maxDepth: 2,
+    origin: { kind: "agent", conversationId: second.conversationId, depth: 2 },
+  });
+  expect(store.snapshot().conversations[rejection!.receipt.conversationId]).toBeUndefined();
+});
+
+test("the durable nesting policy governs the ceiling", () => {
+  const { store } = registryAt("policy-ceiling");
+  saveSpawnNestingPolicy({ maxAgentNestingDepth: 1 });
+  try {
+    const root = spawnAtDepth(store, { kind: "operator" });
+    const first = spawnAtDepth(store, { kind: "agent", conversationId: root.conversationId });
+    expect(() => store.beginSpawnRequest({
+      engine: "codex",
+      cwd: "/repo",
+      origin: { kind: "agent", conversationId: first.conversationId },
+    })).toThrow("capped at depth 1");
+  } finally {
+    fs.rmSync(path.join(process.env.LLV_STATE_DIR!, "spawn-nesting.json"), { force: true });
+  }
+});
+
+test("container origin keys on the creator, not the lineage parent, and records membership before launch", () => {
+  const { store } = registryAt("container-origin");
+  const implementer = store.ensureConversation("codex", "/sessions/pipeline-implementer.jsonl", "terra");
+  const reviewerBegun = store.beginSpawnRequest({
+    engine: "codex",
+    cwd: "/repo",
+    role: "reviewer",
+    reviewsConversationId: implementer.id,
+    parentConversationId: implementer.id,
+    origin: { kind: "operator" },
+  });
+  if (reviewerBegun.kind !== "created") throw new Error("expected create");
+  const reviewerId = settleLaunch(store, reviewerBegun.receipt.launchId);
+
+  /* A stage whose lineage parent is the passed review stage stays admissible
+     (I7): the initiating origin is the pipeline creator. */
+  const stage = store.beginSpawnRequest({
+    engine: "codex",
+    cwd: "/repo",
+    parentConversationId: reviewerId,
+    role: "builder",
+    origin: { kind: "container", container: "pipeline", containerId: "pipe1234", creatorConversationId: null },
+    memberships: [{
+      kind: "pipeline",
+      containerId: "pipe1234",
+      role: "builder",
+      slot: "build:1",
+      stageId: "build",
+      stageOrder: 0,
+      round: 1,
+      parentConversationId: reviewerId,
+    }],
+  });
+  if (stage.kind !== "created") throw new Error("expected create");
+  expect(stage.receipt.delegationDepth).toBe(1);
+  expect(stage.receipt.agentRole).toBe("builder");
+  const snapshot = store.snapshot();
+  expect(snapshot.memberships[stage.receipt.conversationId]).toMatchObject([{ containerId: "pipe1234", role: "builder" }]);
+  expect(snapshot.lineageEdges[stage.receipt.conversationId]).toMatchObject({ parentConversationId: reviewerId, role: "builder" });
+
+  /* A container reviewer stage records its role without a reviews target. */
+  const reviewStage = store.beginSpawnRequest({
+    engine: "codex",
+    cwd: "/repo",
+    parentConversationId: stage.receipt.conversationId,
+    role: "reviewer",
+    origin: { kind: "container", container: "pipeline", containerId: "pipe1234", creatorConversationId: null },
+  });
+  if (reviewStage.kind !== "created") throw new Error("expected create");
+  expect(reviewStage.receipt.agentRole).toBe("reviewer");
+  expect(store.snapshot().lineageEdges[reviewStage.receipt.conversationId]).toMatchObject({ kind: "review", role: "reviewer" });
+
+  /* A reviewer-created container is a reviewer-origin launch. */
+  expect(() => store.beginSpawnRequest({
+    engine: "codex",
+    cwd: "/repo",
+    origin: { kind: "container", container: "pipeline", containerId: "pipe9999", creatorConversationId: reviewerId },
+  })).toThrow(SpawnAdmissionError);
+});
+
+test("successor purposes are exempt, carry recorded identity, and force reviewer profiles to deny subagents", () => {
+  const { store } = registryAt("successor-carry");
+  const implementer = store.ensureConversation("codex", "/sessions/successor-implementer.jsonl", "terra");
+  const reviewerBegun = store.beginSpawnRequest({
+    engine: "codex",
+    cwd: "/repo",
+    role: "reviewer",
+    reviewsConversationId: implementer.id,
+    parentConversationId: implementer.id,
+    origin: { kind: "operator" },
+  });
+  if (reviewerBegun.kind !== "created") throw new Error("expected create");
+  const reviewerId = settleLaunch(store, reviewerBegun.receipt.launchId);
+
+  const resume = store.beginSpawnRequest({
+    engine: "codex",
+    cwd: "/repo",
+    conversationId: reviewerId,
+    purpose: "resume-successor",
+    origin: { kind: "successor" },
+    launchProfile: { allowSubagents: true },
+  });
+  if (resume.kind !== "created") throw new Error("expected create");
+  expect(resume.receipt.agentRole).toBe("reviewer");
+  expect(resume.receipt.delegationDepth).toBe(0);
+  expect(resume.receipt.rejection).toBeNull();
+  expect(resume.receipt.launchProfile.allowSubagents).toBe(false);
+  expect(store.conversation(reviewerId)).toMatchObject({ agentRole: "reviewer", delegationDepth: 0 });
+
+  /* Account-switch successors conserve the same identity without admission. */
+  const migration = store.beginSpawnRequest({
+    engine: "codex",
+    cwd: "/repo",
+    conversationId: reviewerId,
+    purpose: "migration-successor",
+    origin: { kind: "successor" },
+  });
+  if (migration.kind !== "created") throw new Error("expected create");
+  expect(migration.receipt).toMatchObject({ agentRole: "reviewer", delegationDepth: 0, rejection: null });
+});
+
+test("legacy registry files load with null role and depth and legacy receipts stay unrejected", () => {
+  const { store, filename } = registryAt("legacy-normalize");
+  const { conversationId } = spawnAtDepth(store, { kind: "operator" }, "builder");
+  const raw = JSON.parse(fs.readFileSync(filename, "utf8")) as Record<string, unknown>;
+  for (const receipt of Object.values(raw.receipts as Record<string, Record<string, unknown>>)) {
+    delete receipt.agentRole;
+    delete receipt.delegationDepth;
+    delete receipt.rejection;
+  }
+  for (const conversation of Object.values(raw.conversations as Record<string, Record<string, unknown>>)) {
+    delete conversation.agentRole;
+    delete conversation.delegationDepth;
+  }
+  fs.writeFileSync(filename, JSON.stringify(raw));
+  const reloaded = new AgentRegistry(filename, undefined, undefined, { sqliteMode: "off" });
+  const conversation = reloaded.conversation(conversationId);
+  expect(conversation).toMatchObject({ agentRole: null, delegationDepth: null });
+  for (const receipt of Object.values(reloaded.snapshot().receipts)) {
+    expect(receipt.agentRole).toBeNull();
+    expect(receipt.delegationDepth).toBeNull();
+    expect(receipt.rejection).toBeNull();
+  }
+});

--- a/src/lib/agent/registry.ts
+++ b/src/lib/agent/registry.ts
@@ -28,6 +28,16 @@ import {
 } from "@/lib/accounts/migration/contracts";
 
 import type { AgentEngine } from "./cli";
+import { loadSpawnNestingPolicy } from "./nestingPolicy";
+import {
+  SpawnAdmissionError,
+  isSpawnDeniedRole,
+  nestingDepthGuidance,
+  resolveSpawnOrigin,
+  reviewerOriginSpawnGuidance,
+  type SpawnOrigin,
+  type SpawnRejection,
+} from "./spawnAdmission";
 import { sessionKeyFromTranscript, sessionKeyId, type SessionKey } from "./sessionKey";
 import { SqliteAgentRegistryStore, type SqliteRegistrySnapshot } from "./sqliteRegistryStore";
 import type { ResumePaneRecord } from "@/lib/resumePanesFile";
@@ -153,6 +163,16 @@ export interface SpawnReceipt {
   target: string | null;
   completionMode: "route-completed" | "observed-completed" | "route-recovered" | null;
   error: string | null;
+  /** Role preset id of the launched agent (#393). Null for legacy and
+      role-less launches; successor receipts carry the conversation's value. */
+  agentRole: string | null;
+  /** Delegation depth computed at admission (#393): 0 for operator/external
+      roots, depth(origin)+1 for agent- and container-origin launches. */
+  delegationDepth: number | null;
+  /** Typed terminal admission rejection (#393). Non-null means this receipt
+      never launched: no conversation, lineage edge, membership, transcript,
+      or process exists for it. */
+  rejection: SpawnRejection | null;
   launchProfile: LaunchProfile;
   /** Validated explicit operator project. Becomes durable conversation
       ownership at admission; `launchProfile.project` stays a hint. */
@@ -219,6 +239,11 @@ export interface SpawnRequest {
   expectedArtifactPath?: string | null;
   /** Atomic direct-child admission guard for agent-initiated Viewer spawns. */
   liveChildrenCap?: number;
+  /** Initiating origin (#393). Agent- and container-origin launches pass
+      reviewer-isolation and nesting-depth admission inside the same mutation
+      that writes the receipt; operator/external origins are depth-0 roots and
+      successor origins are exempt identity-preserving relaunches. */
+  origin?: SpawnOrigin;
 }
 
 export class SpawnChildLimitError extends Error {
@@ -290,6 +315,12 @@ export interface RegistryConversation {
       #383). Null for every non-superseded conversation, including all legacy
       records. Cleared only by an explicit operator "resume here" fork. */
   supersededBy: ConversationSupersedence | null;
+  /** Durable role identity copied from the launch receipt at admission
+      (#393). Never re-derived by resume, migration, or restart adoption. */
+  agentRole: string | null;
+  /** Durable delegation depth recorded at birth (#393). Null for legacy
+      conversations; admission then falls back to membership/lineage evidence. */
+  delegationDepth: number | null;
   turn: TurnState & { observedAt: string | null };
   createdAt: string;
   updatedAt: string;
@@ -959,6 +990,8 @@ function normalizeConversation(value: RegistryConversation): RegistryConversatio
     migration,
     migrationOptOut,
     supersededBy,
+    agentRole: normalizeAgentRole((value as Partial<RegistryConversation>).agentRole),
+    delegationDepth: normalizeDelegationDepth((value as Partial<RegistryConversation>).delegationDepth),
     turn: value.turn && typeof value.turn === "object"
       ? { state: value.turn.state, source: value.turn.source, terminalAt: value.turn.terminalAt ?? null, observedAt: value.turn.observedAt ?? null }
       : { state: "unknown", source: "empty", terminalAt: null, observedAt: null },
@@ -1522,6 +1555,8 @@ function adoptProvisionalOwner(
     && (!target.migrationOptOut || owner.migrationOptOut.updatedAt > target.migrationOptOut.updatedAt)) {
     target.migrationOptOut = { ...owner.migrationOptOut };
   }
+  target.agentRole ??= owner.agentRole;
+  target.delegationDepth ??= owner.delegationDepth;
   for (const receipt of Object.values(file.receipts)) {
     if (receipt.conversationId === owner.id) receipt.conversationId = target.id;
     if (receipt.parentConversationId === owner.id) receipt.parentConversationId = target.id;
@@ -1651,8 +1686,42 @@ function normalizeReceipt(value: SpawnReceipt): SpawnReceipt {
     verifiedHost: value.verifiedHost && typeof value.verifiedHost === "object" && value.verifiedHost.kind === "tmux" ? value.verifiedHost : null,
     target: pane?.paneId ?? (typeof value.target === "string" && /^%\d+$/.test(value.target) ? value.target : null),
     completionMode: value.completionMode === "route-completed" || value.completionMode === "observed-completed" || value.completionMode === "route-recovered" ? value.completionMode : null,
+    agentRole: normalizeAgentRole(value.agentRole),
+    delegationDepth: normalizeDelegationDepth(value.delegationDepth),
+    rejection: normalizeSpawnRejection(value.rejection),
     launchProfile: emptyLaunchProfile({ ...(value.launchProfile ?? {}), cwd: value.launchProfile?.cwd ?? value.cwd }),
     explicitProject: validExplicitProject(value.explicitProject),
+  };
+}
+
+function normalizeAgentRole(value: unknown): string | null {
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+function normalizeDelegationDepth(value: unknown): number | null {
+  return Number.isInteger(value) && (value as number) >= 0 ? value as number : null;
+}
+
+function normalizeSpawnRejection(value: SpawnRejection | null | undefined): SpawnRejection | null {
+  if (!value || typeof value !== "object") return null;
+  if (value.code !== "reviewer_origin_spawn" && value.code !== "nesting_depth_exceeded") return null;
+  const origin = value.origin;
+  if (!origin || (origin.kind !== "agent" && origin.kind !== "container")) return null;
+  return {
+    code: value.code,
+    origin: {
+      kind: origin.kind,
+      conversationId: typeof origin.conversationId === "string" && origin.conversationId.startsWith("conversation_")
+        ? origin.conversationId
+        : null,
+      role: normalizeAgentRole(origin.role),
+      depth: Number.isInteger(origin.depth) && origin.depth >= 0 ? origin.depth : 0,
+    },
+    requestedRole: normalizeAgentRole(value.requestedRole),
+    childDepth: Number.isInteger(value.childDepth) && value.childDepth >= 0 ? value.childDepth : 0,
+    maxDepth: Number.isInteger(value.maxDepth) && value.maxDepth >= 1 ? value.maxDepth : 1,
+    guidance: typeof value.guidance === "string" ? value.guidance : "",
+    rejectedAt: typeof value.rejectedAt === "string" ? value.rejectedAt : now(),
   };
 }
 
@@ -2495,14 +2564,33 @@ export class AgentRegistry {
   }
 
   /** Create or replay a client-correlated durable launch receipt. Existing
-      internal callers use beginSpawn() and receive an uncorrelated receipt. */
+      internal callers use beginSpawn() and receive an uncorrelated receipt.
+      Throws SpawnAdmissionError (#393) after durably persisting a typed
+      terminal rejection receipt when the initiating origin is a denied role
+      or the child would exceed the nesting-depth ceiling. */
   beginSpawnRequest(input: SpawnRequest): SpawnBeginResult {
-    return this.mutate((file) => {
+    const result = this.mutate((file) => this.beginSpawnRequestInFile(file, input));
+    if (result.kind === "rejected") throw new SpawnAdmissionError(result.receipt, result.receipt.rejection!);
+    if (result.kind === "replay" && result.receipt.rejection) {
+      throw new SpawnAdmissionError(result.receipt, result.receipt.rejection);
+    }
+    return result;
+  }
+
+  private beginSpawnRequestInFile(
+    file: RegistryFile,
+    input: SpawnRequest,
+  ): SpawnBeginResult | { kind: "rejected"; receipt: SpawnReceipt } {
+    {
       const conversationId = input.conversationId ? resolveConversationAlias(file, input.conversationId) : null;
       const parentConversationId = input.parentConversationId ? resolveConversationAlias(file, input.parentConversationId) : null;
       const reviewsConversationId = input.reviewsConversationId ? resolveConversationAlias(file, input.reviewsConversationId) : null;
       const role = typeof input.role === "string" && input.role.trim() ? input.role.trim() : null;
-      if (role === "reviewer" && !reviewsConversationId) throw new Error("reviewer spawn requires reviewsConversationId");
+      /* Container-origin reviewer stages review their stage diff; membership
+         rows identify the subject, so the review edge needs no target id. */
+      if (role === "reviewer" && !reviewsConversationId && input.origin?.kind !== "container") {
+        throw new Error("reviewer spawn requires reviewsConversationId");
+      }
       if (reviewsConversationId && role !== "reviewer") throw new Error("reviewsConversationId requires reviewer role");
       const explicitProject = input.explicitProject == null ? null : validExplicitProject(input.explicitProject);
       if (input.explicitProject != null && !explicitProject) throw new Error("explicit project is not a valid project key");
@@ -2522,6 +2610,11 @@ export class AgentRegistry {
       const profile = input.purpose === "resume-successor" && currentProfile
         ? mergeResumeLaunchProfile(currentProfile, requestedProfile)
         : requestedProfile;
+      /* Reviewer/verifier conversations never regain native multi-agent
+         tooling (#393): the sticky-true resume merge and any historically
+         corrupted profile are both overridden here, so restart adoption and
+         resume successors re-derive their launch flags from a denying profile. */
+      if (isSpawnDeniedRole(existingConversation?.agentRole)) profile.allowSubagents = false;
       if (existingConversation && existingConversation.engine !== input.engine) {
         throw new Error("spawn conversation ownership is invalid");
       }
@@ -2541,7 +2634,43 @@ export class AgentRegistry {
           return { kind: compatible ? "replay" : "conflict", receipt: clone(existing) };
         }
       }
-      if (input.liveChildrenCap !== undefined) {
+      /* Origin admission (#393): reviewer isolation and bounded nesting run
+         inside the same mutation that writes the receipt, so no call site —
+         present or future MCP — can race or bypass it. Successor purposes are
+         identity-preserving relaunches, not child launches, and are exempt. */
+      const purpose = input.purpose ?? "launch";
+      const successorIdentity = purpose !== "launch" || input.origin?.kind === "successor";
+      const resolvedOrigin = !successorIdentity && input.origin ? resolveSpawnOrigin(file, input.origin) : null;
+      const childDepth = successorIdentity
+        ? existingConversation?.delegationDepth ?? null
+        : resolvedOrigin ? resolvedOrigin.depth + 1 : 0;
+      const childRole = successorIdentity ? existingConversation?.agentRole ?? null : role;
+      let rejection: SpawnRejection | null = null;
+      if (resolvedOrigin) {
+        const maxDepth = loadSpawnNestingPolicy().maxAgentNestingDepth;
+        if (isSpawnDeniedRole(resolvedOrigin.role)) {
+          rejection = {
+            code: "reviewer_origin_spawn",
+            origin: resolvedOrigin,
+            requestedRole: role,
+            childDepth: childDepth ?? 0,
+            maxDepth,
+            guidance: reviewerOriginSpawnGuidance(resolvedOrigin.role),
+            rejectedAt: now(),
+          };
+        } else if (childDepth !== null && childDepth > maxDepth) {
+          rejection = {
+            code: "nesting_depth_exceeded",
+            origin: resolvedOrigin,
+            requestedRole: role,
+            childDepth,
+            maxDepth,
+            guidance: nestingDepthGuidance(childDepth, maxDepth),
+            rejectedAt: now(),
+          };
+        }
+      }
+      if (!rejection && input.liveChildrenCap !== undefined) {
         if (!Number.isInteger(input.liveChildrenCap) || input.liveChildrenCap < 1) throw new Error("liveChildrenCap must be a positive integer");
         if (!parentConversationId) throw new Error("liveChildrenCap requires parentConversationId");
         if (liveViewerChildCount(file, parentConversationId) >= input.liveChildrenCap) {
@@ -2579,19 +2708,25 @@ export class AgentRegistry {
         accountId: input.accountId ?? null,
         parentConversationId,
         createdAt,
-        state: "starting",
-        artifactPath: input.expectedArtifactPath ?? null,
+        state: rejection ? "failed" : "starting",
+        artifactPath: rejection ? null : input.expectedArtifactPath ?? null,
         artifactLifecycle: "pending",
         key: null,
         pane: null,
         verifiedHost: null,
         target: null,
         completionMode: null,
-        error: null,
+        error: rejection ? rejection.guidance : null,
+        agentRole: childRole,
+        delegationDepth: childDepth,
+        rejection,
         launchProfile: profile,
         explicitProject,
       };
       file.receipts[receipt.launchId] = receipt;
+      /* A rejected launch persists exactly one terminal receipt: no lineage
+         edge, no membership, no conversation record, no process (#393). */
+      if (rejection) return { kind: "rejected", receipt: clone(receipt) };
       if (receipt.parentConversationId && receipt.parentConversationId !== receipt.conversationId) {
         const existingLineage = input.purpose === "resume-successor"
           ? file.lineageEdges[receipt.conversationId]
@@ -2619,7 +2754,7 @@ export class AgentRegistry {
             parentSessionKey: input.parentSessionKey ?? null,
             childArtifactPath: null,
             parentArtifactPath: input.parentArtifactPath ?? null,
-            kind: reviewsConversationId ? "review" : "spawn",
+            kind: reviewsConversationId || role === "reviewer" ? "review" : "spawn",
             role,
             reviewsConversationId,
             source: "viewer-spawn",
@@ -2632,7 +2767,7 @@ export class AgentRegistry {
         recordMembership(file, receipt.conversationId, membership, receipt.createdAt);
       }
       return { kind: "created", receipt: clone(receipt) };
-    });
+    }
   }
 
   /** Atomically adopts a structured receipt whose pre-host owner exited.
@@ -2873,10 +3008,17 @@ export class AgentRegistry {
       migration: null,
       migrationOptOut: null,
       supersededBy: null,
+      agentRole: null,
+      delegationDepth: null,
       turn: { state: "unknown" as const, source: "empty" as const, terminalAt: null, observedAt: null },
       createdAt,
       updatedAt: createdAt,
     };
+    /* Durable role/depth identity (#393): stamped once from the launch
+       receipt and conserved thereafter — successor and resume receipts never
+       re-derive or demote it. */
+    conversation.agentRole ??= receipt.agentRole;
+    conversation.delegationDepth ??= receipt.delegationDepth;
     if (conversation.engine !== receipt.engine) return conflict("spawn_identity_conflict");
     if (receipt.purpose === "resume-successor" && !resumeCanRebaseMigration(conversation.migration)) {
       return conflict("spawn_identity_conflict");
@@ -3519,6 +3661,8 @@ export class AgentRegistry {
         migration: null,
         migrationOptOut: null,
         supersededBy: null,
+        agentRole: null,
+        delegationDepth: null,
         turn: { state: "unknown", source: "empty", terminalAt: null, observedAt: null },
         createdAt,
         updatedAt: createdAt,
@@ -3688,6 +3832,8 @@ export class AgentRegistry {
             migration: null,
             migrationOptOut: null,
             supersededBy: null,
+            agentRole: null,
+            delegationDepth: null,
             turn: { ...observation.turn, observedAt: observation.observedAt },
             createdAt,
             updatedAt: createdAt,

--- a/src/lib/agent/spawnAdmission.test.ts
+++ b/src/lib/agent/spawnAdmission.test.ts
@@ -1,0 +1,216 @@
+import { expect, test } from "bun:test";
+
+import type { ViewerConversationId } from "@/lib/accounts/migration/contracts";
+
+import type { DurableConversationMembership, RegistryConversation, RegistryFile, SpawnLineageEdge } from "./registry";
+import {
+  SPAWN_DENIED_ROLE_IDS,
+  conversationAgentRole,
+  conversationDelegationDepth,
+  isSpawnDeniedRole,
+  nestingDepthGuidance,
+  resolveSpawnOrigin,
+  reviewerOriginSpawnGuidance,
+} from "./spawnAdmission";
+
+type FileView = Pick<RegistryFile, "conversations" | "conversationAliases" | "lineageEdges" | "memberships">;
+
+function conversation(id: string, fields: Partial<RegistryConversation> = {}): RegistryConversation {
+  return {
+    id: id as ViewerConversationId,
+    engine: "codex",
+    generations: [],
+    continuityPaths: [],
+    abandonedContinuityPaths: [],
+    projectOwnership: null,
+    migration: null,
+    migrationOptOut: null,
+    supersededBy: null,
+    agentRole: null,
+    delegationDepth: null,
+    turn: { state: "unknown", source: "empty", terminalAt: null, observedAt: null },
+    createdAt: "2026-07-18T00:00:00.000Z",
+    updatedAt: "2026-07-18T00:00:00.000Z",
+    ...fields,
+  };
+}
+
+function edge(child: string, parent: string, fields: Partial<SpawnLineageEdge> = {}): SpawnLineageEdge {
+  return {
+    childConversationId: child as ViewerConversationId,
+    parentConversationId: parent as ViewerConversationId,
+    childSessionKey: null,
+    parentSessionKey: null,
+    childArtifactPath: null,
+    parentArtifactPath: null,
+    kind: "spawn",
+    role: null,
+    reviewsConversationId: null,
+    source: "viewer-spawn",
+    evidence: { launchId: null, clientAttemptId: null },
+    createdAt: "2026-07-18T00:00:00.000Z",
+    ...fields,
+  };
+}
+
+function membership(conversationId: string, role: string, createdAt: string): DurableConversationMembership {
+  return {
+    conversationId: conversationId as ViewerConversationId,
+    kind: "pipeline",
+    containerId: "pipe1234",
+    role,
+    slot: `${role}:${createdAt}`,
+    stageId: null,
+    stageOrder: null,
+    round: null,
+    parentConversationId: null,
+    createdAt,
+  };
+}
+
+function view(fields: Partial<FileView> = {}): FileView {
+  return { conversations: {}, conversationAliases: {}, lineageEdges: {}, memberships: {}, ...fields };
+}
+
+test("the denied-role contract pins reviewer and verifier and nothing else", () => {
+  expect(SPAWN_DENIED_ROLE_IDS).toEqual(["reviewer", "verifier"]);
+  expect(isSpawnDeniedRole("reviewer")).toBe(true);
+  expect(isSpawnDeniedRole("verifier")).toBe(true);
+  expect(isSpawnDeniedRole("builder")).toBe(false);
+  expect(isSpawnDeniedRole(null)).toBe(false);
+  expect(isSpawnDeniedRole(undefined)).toBe(false);
+});
+
+test("role resolution prefers the recorded conversation role, then lineage edge, then newest membership", () => {
+  const recorded = view({
+    conversations: { conversation_a: conversation("conversation_a", { agentRole: "builder" }) },
+    lineageEdges: { conversation_a: edge("conversation_a", "conversation_p", { role: "reviewer" }) },
+  });
+  expect(conversationAgentRole(recorded, "conversation_a" as ViewerConversationId)).toBe("builder");
+
+  const edged = view({
+    conversations: { conversation_a: conversation("conversation_a") },
+    lineageEdges: { conversation_a: edge("conversation_a", "conversation_p", { role: "reviewer" }) },
+  });
+  expect(conversationAgentRole(edged, "conversation_a" as ViewerConversationId)).toBe("reviewer");
+
+  const membered = view({
+    memberships: {
+      conversation_a: [
+        membership("conversation_a", "builder", "2026-07-01T00:00:00.000Z"),
+        membership("conversation_a", "verifier", "2026-07-02T00:00:00.000Z"),
+      ],
+    },
+  });
+  expect(conversationAgentRole(membered, "conversation_a" as ViewerConversationId)).toBe("verifier");
+
+  expect(conversationAgentRole(view(), "conversation_unknown" as ViewerConversationId)).toBeNull();
+});
+
+test("role resolution follows conversation aliases", () => {
+  const aliased = view({
+    conversationAliases: { conversation_old: "conversation_new" as ViewerConversationId },
+    conversations: { conversation_new: conversation("conversation_new", { agentRole: "reviewer" }) },
+  });
+  expect(conversationAgentRole(aliased, "conversation_old" as ViewerConversationId)).toBe("reviewer");
+});
+
+test("depth resolution prefers the recorded depth and falls back membership-first for legacy records", () => {
+  const recorded = view({
+    conversations: { conversation_a: conversation("conversation_a", { delegationDepth: 2 }) },
+    memberships: { conversation_a: [membership("conversation_a", "builder", "2026-07-01T00:00:00.000Z")] },
+  });
+  expect(conversationDelegationDepth(recorded, "conversation_a" as ViewerConversationId)).toBe(2);
+
+  /* Legacy container children chain lineage stage-to-stage; membership means
+     depth 1, not the lineage-hop count. */
+  const containerLegacy = view({
+    conversations: { conversation_a: conversation("conversation_a") },
+    memberships: { conversation_a: [membership("conversation_a", "builder", "2026-07-01T00:00:00.000Z")] },
+    lineageEdges: {
+      conversation_a: edge("conversation_a", "conversation_b"),
+      conversation_b: edge("conversation_b", "conversation_c"),
+      conversation_c: edge("conversation_c", "conversation_root"),
+    },
+  });
+  expect(conversationDelegationDepth(containerLegacy, "conversation_a" as ViewerConversationId)).toBe(1);
+
+  expect(conversationDelegationDepth(view(), "conversation_root" as ViewerConversationId)).toBe(0);
+});
+
+test("legacy depth walks lineage edges bounded and cycle-guarded", () => {
+  const chained = view({
+    lineageEdges: {
+      conversation_a: edge("conversation_a", "conversation_b"),
+      conversation_b: edge("conversation_b", "conversation_c"),
+    },
+  });
+  expect(conversationDelegationDepth(chained, "conversation_a" as ViewerConversationId)).toBe(2);
+
+  const withRecordedAncestor = view({
+    conversations: { conversation_b: conversation("conversation_b", { delegationDepth: 3 }) },
+    lineageEdges: { conversation_a: edge("conversation_a", "conversation_b") },
+  });
+  expect(conversationDelegationDepth(withRecordedAncestor, "conversation_a" as ViewerConversationId)).toBe(4);
+
+  const cyclic = view({
+    lineageEdges: {
+      conversation_a: edge("conversation_a", "conversation_b"),
+      conversation_b: edge("conversation_b", "conversation_a"),
+    },
+  });
+  expect(conversationDelegationDepth(cyclic, "conversation_a" as ViewerConversationId)).toBe(1);
+
+  const edges: FileView["lineageEdges"] = {};
+  for (let index = 0; index < 20; index += 1) {
+    edges[`conversation_${index}`] = edge(`conversation_${index}`, `conversation_${index + 1}`);
+  }
+  expect(conversationDelegationDepth(view({ lineageEdges: edges }), "conversation_0" as ViewerConversationId)).toBe(8);
+
+  /* Engine-native lineage never contributes delegation depth. */
+  const native = view({
+    lineageEdges: { conversation_a: edge("conversation_a", "conversation_b", { source: "engine-native" }) },
+  });
+  expect(conversationDelegationDepth(native, "conversation_a" as ViewerConversationId)).toBe(0);
+});
+
+test("origin resolution keys on the agent caller or the container creator", () => {
+  const file = view({
+    conversations: {
+      conversation_reviewer: conversation("conversation_reviewer", { agentRole: "reviewer", delegationDepth: 1 }),
+    },
+  });
+  expect(resolveSpawnOrigin(file, { kind: "agent", conversationId: "conversation_reviewer" as ViewerConversationId })).toEqual({
+    kind: "agent",
+    conversationId: "conversation_reviewer" as ViewerConversationId,
+    role: "reviewer",
+    depth: 1,
+  });
+  expect(resolveSpawnOrigin(file, {
+    kind: "container",
+    container: "pipeline",
+    containerId: "pipe1234",
+    creatorConversationId: "conversation_reviewer" as ViewerConversationId,
+  })).toEqual({
+    kind: "container",
+    conversationId: "conversation_reviewer" as ViewerConversationId,
+    role: "reviewer",
+    depth: 1,
+  });
+  expect(resolveSpawnOrigin(file, {
+    kind: "container",
+    container: "flow",
+    containerId: "flow1234",
+    creatorConversationId: null,
+  })).toEqual({ kind: "container", conversationId: null, role: null, depth: 0 });
+  expect(resolveSpawnOrigin(file, { kind: "operator" })).toBeNull();
+  expect(resolveSpawnOrigin(file, { kind: "external" })).toBeNull();
+  expect(resolveSpawnOrigin(file, { kind: "successor" })).toBeNull();
+});
+
+test("rejection guidance is actionable and names the escalation paths", () => {
+  expect(reviewerOriginSpawnGuidance("reviewer")).toContain("in-session");
+  expect(reviewerOriginSpawnGuidance("verifier")).toStartWith("Verifier");
+  expect(nestingDepthGuidance(3, 2)).toContain("depth 2");
+  expect(nestingDepthGuidance(3, 2)).toContain("maxAgentNestingDepth");
+});

--- a/src/lib/agent/spawnAdmission.ts
+++ b/src/lib/agent/spawnAdmission.ts
@@ -1,0 +1,138 @@
+import type { ViewerConversationId } from "@/lib/accounts/migration/contracts";
+
+import type { RegistryFile, SpawnReceipt } from "./registry";
+import { VIEWER_SPAWN_ENDPOINT } from "./spawnPolicy";
+
+/** Roles with zero child-spawn capability (#393). A hardcoded contract
+    constant: role overrides only carry config/promptScaffold, so no
+    persisted preset can widen this set. */
+export const SPAWN_DENIED_ROLE_IDS: readonly string[] = Object.freeze(["reviewer", "verifier"]);
+
+export function isSpawnDeniedRole(role: string | null | undefined): boolean {
+  return typeof role === "string" && SPAWN_DENIED_ROLE_IDS.includes(role);
+}
+
+export type SpawnRejectionCode = "reviewer_origin_spawn" | "nesting_depth_exceeded";
+
+/** Who initiated a launch. Enforcement keys on this declared/authenticated
+    initiator — never on the lineage parent, which may legitimately be a
+    reviewer transcript (pipeline stages chain through the last passed stage). */
+export type SpawnOrigin =
+  | { kind: "operator" }
+  | { kind: "agent"; conversationId: ViewerConversationId }
+  | { kind: "container"; container: "pipeline" | "flow"; containerId: string; creatorConversationId: ViewerConversationId | null }
+  | { kind: "external" }
+  | { kind: "successor" };
+
+export interface SpawnRejection {
+  code: SpawnRejectionCode;
+  origin: {
+    kind: "agent" | "container";
+    conversationId: ViewerConversationId | null;
+    role: string | null;
+    depth: number;
+  };
+  requestedRole: string | null;
+  /** Depth the child would have had. */
+  childDepth: number;
+  /** Policy ceiling at rejection time. */
+  maxDepth: number;
+  guidance: string;
+  rejectedAt: string;
+}
+
+/** Typed terminal admission rejection (#393): the receipt is durable and
+    terminal, and no conversation, lineage edge, membership, transcript, or
+    process exists for it. */
+export class SpawnAdmissionError extends Error {
+  constructor(readonly receipt: SpawnReceipt, readonly rejection: SpawnRejection) {
+    super(rejection.guidance);
+    this.name = "SpawnAdmissionError";
+  }
+}
+
+export function reviewerOriginSpawnGuidance(role: string | null): string {
+  const label = role === "verifier" ? "Verifier" : "Reviewer";
+  return `${label} sessions run every check in-session — filesystem, shell, GitHub, and browser access stay available, but child agents do not. For more perspectives, report the need to your parent so an operator or orchestrator adds a visible reviewer stage (POST /api/pipelines or POST ${VIEWER_SPAWN_ENDPOINT}).`;
+}
+
+export function nestingDepthGuidance(childDepth: number, maxDepth: number): string {
+  return `Agent nesting is capped at depth ${maxDepth} and this launch would create a depth-${childDepth} child. Finish delegated work in-session or report the need to your parent. An operator can raise maxAgentNestingDepth in Viewer spawn settings (PATCH /api/spawn/policy).`;
+}
+
+type AdmissionFileView = Pick<RegistryFile, "conversations" | "conversationAliases" | "lineageEdges" | "memberships">;
+
+function canonicalId(file: AdmissionFileView, id: ViewerConversationId): ViewerConversationId {
+  const seen = new Set<ViewerConversationId>();
+  let current = id;
+  while (!seen.has(current)) {
+    seen.add(current);
+    const next = file.conversationAliases[current];
+    if (!next) return current;
+    current = next;
+  }
+  return current;
+}
+
+/** Durable role of a conversation, resolved fail-open for legacy records:
+    the recorded conversation role, else its lineage-edge role, else its
+    newest membership role, else null (unknown ≠ reviewer). */
+export function conversationAgentRole(file: AdmissionFileView, id: ViewerConversationId): string | null {
+  const canonical = canonicalId(file, id);
+  const recorded = file.conversations[canonical]?.agentRole;
+  if (typeof recorded === "string" && recorded.trim()) return recorded;
+  const edgeRole = file.lineageEdges[canonical]?.role;
+  if (typeof edgeRole === "string" && edgeRole.trim()) return edgeRole;
+  const memberships = file.memberships[canonical] ?? [];
+  const newest = [...memberships].sort((left, right) => right.createdAt.localeCompare(left.createdAt))[0];
+  return newest?.role ?? null;
+}
+
+const LEGACY_DEPTH_WALK_CAP = 8;
+
+/** Delegation depth of a conversation. Recorded-at-birth depth wins; legacy
+    records fall back to container membership (⇒ 1 — pipeline lineage chains
+    stage-to-stage, so an edge walk would overcount container children) and
+    then a bounded, cycle-guarded lineage-edge walk. */
+export function conversationDelegationDepth(file: AdmissionFileView, id: ViewerConversationId): number {
+  const canonical = canonicalId(file, id);
+  const recorded = file.conversations[canonical]?.delegationDepth;
+  if (Number.isInteger(recorded) && recorded! >= 0) return recorded!;
+  if ((file.memberships[canonical] ?? []).length > 0) return 1;
+  let depth = 0;
+  const seen = new Set<ViewerConversationId>([canonical]);
+  let current = canonical;
+  while (depth < LEGACY_DEPTH_WALK_CAP) {
+    const edge = file.lineageEdges[current];
+    if (!edge || edge.source !== "viewer-spawn") break;
+    const parent = canonicalId(file, edge.parentConversationId);
+    if (seen.has(parent)) break;
+    seen.add(parent);
+    depth += 1;
+    const parentRecorded = file.conversations[parent]?.delegationDepth;
+    if (Number.isInteger(parentRecorded) && parentRecorded! >= 0) return parentRecorded! + depth;
+    current = parent;
+  }
+  return depth;
+}
+
+export interface ResolvedSpawnOrigin {
+  kind: "agent" | "container";
+  conversationId: ViewerConversationId | null;
+  role: string | null;
+  depth: number;
+}
+
+/** Role and depth of the initiating origin, for the origin kinds that are
+    subject to admission. Operator/external/successor origins are roots. */
+export function resolveSpawnOrigin(file: AdmissionFileView, origin: SpawnOrigin): ResolvedSpawnOrigin | null {
+  if (origin.kind !== "agent" && origin.kind !== "container") return null;
+  const originConversationId = origin.kind === "agent" ? origin.conversationId : origin.creatorConversationId;
+  const canonical = originConversationId ? canonicalId(file, originConversationId) : null;
+  return {
+    kind: origin.kind,
+    conversationId: canonical,
+    role: canonical ? conversationAgentRole(file, canonical) : null,
+    depth: canonical ? conversationDelegationDepth(file, canonical) : 0,
+  };
+}

--- a/src/lib/agent/spawnProjection.test.ts
+++ b/src/lib/agent/spawnProjection.test.ts
@@ -450,3 +450,81 @@ test("inventory materialization stays scoped to the observed engine", () => {
     fs.rmSync(directory, { recursive: true, force: true });
   }
 });
+
+test("a rejected launch projects a terminal failed card with zero conversation artifacts and lineage depth is exposed", () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-spawn-projection-rejection-"));
+  const filename = path.join(directory, "agent-registry.json");
+  try {
+    const registry = new AgentRegistry(filename, undefined, undefined, { sqliteMode: "off" });
+    const rootBegun = registry.beginSpawnRequest({
+      engine: "codex",
+      cwd: directory,
+      transport: "structured",
+      accountId: "work",
+      role: "reviewer",
+      reviewsConversationId: registry.ensureConversation("codex", path.join(directory, "reviewed.jsonl"), "work").id,
+      origin: { kind: "operator" },
+      launchProfile: emptyLaunchProfile({ cwd: directory }),
+    });
+    if (rootBegun.kind !== "created") throw new Error("expected creation");
+    const settled = registry.settleSpawn(rootBegun.receipt.launchId, {
+      key: { engine: "codex", sessionId: "019f7b8a-9f75-7dc0-b231-17f7eadd7fe1" },
+      artifactPath: path.join(directory, "019f7b8a-9f75-7dc0-b231-17f7eadd7fe1.jsonl"),
+      cwd: directory,
+      accountId: "work",
+      status: "live",
+      host: null,
+      claimEpoch: 0,
+      claimOwner: null,
+      pendingAction: null,
+    });
+    if (settled.kind !== "settled") throw new Error("expected settlement");
+
+    let launchId = "";
+    let conversationId = "";
+    try {
+      registry.beginSpawnRequest({
+        engine: "codex",
+        cwd: directory,
+        transport: "structured",
+        accountId: "work",
+        origin: { kind: "agent", conversationId: settled.conversation.id },
+        launchProfile: emptyLaunchProfile({ cwd: directory }),
+      });
+      throw new Error("expected a spawn admission rejection");
+    } catch (error) {
+      const rejection = error as { receipt?: { launchId: string; conversationId: string } };
+      if (!rejection.receipt) throw error;
+      launchId = rejection.receipt.launchId;
+      conversationId = rejection.receipt.conversationId;
+    }
+
+    const snapshot = registry.snapshot();
+    expect(snapshot.conversations[conversationId]).toBeUndefined();
+    const cards = preallocatedStructuredSpawnCards([], snapshot);
+    const rejectedCard = cards.find((card) => card.path === `spawn:${launchId}`)!;
+    expect(rejectedCard).toMatchObject({
+      activity: "stalled",
+      activityReason: "structured_spawn_failed",
+      spawn: { state: "failed", retrySafe: true },
+    });
+
+    /* Lineage depth rides the projection for admitted launches. */
+    const childBegun = registry.beginSpawnRequest({
+      engine: "codex",
+      cwd: directory,
+      transport: "structured",
+      accountId: "work",
+      parentConversationId: settled.conversation.id,
+      role: "builder",
+      origin: { kind: "operator" },
+      launchProfile: emptyLaunchProfile({ cwd: directory }),
+    });
+    if (childBegun.kind !== "created") throw new Error("expected creation");
+    const childCard = preallocatedStructuredSpawnCards([], registry.snapshot())
+      .find((card) => card.path === `spawn:${childBegun.receipt.launchId}`)!;
+    expect(childCard.durableLineage).toMatchObject({ role: "builder", depth: 0 });
+  } finally {
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});

--- a/src/lib/agent/spawnProjection.ts
+++ b/src/lib/agent/spawnProjection.ts
@@ -130,7 +130,8 @@ export function preallocatedStructuredSpawnCards(
       ...(edge || memberships.length ? {
         durableLineage: {
           kind: edge?.kind ?? "spawn",
-          role: edge?.role ?? null,
+          role: receipt.agentRole ?? edge?.role ?? null,
+          depth: receipt.delegationDepth,
           parentConversationId: edge?.parentConversationId ?? receipt.parentConversationId,
           reviewsConversationId: edge?.reviewsConversationId ?? null,
           memberships: memberships.map((membership) => ({

--- a/src/lib/agent/spawnResponse.ts
+++ b/src/lib/agent/spawnResponse.ts
@@ -1,4 +1,25 @@
 import type { SpawnReceipt } from "@/lib/agent/registry";
+import type { SpawnAdmissionError, SpawnRejection, SpawnRejectionCode } from "@/lib/agent/spawnAdmission";
+
+/** HTTP shape of a typed terminal admission rejection (#393). The receipt is
+    durable; `error` carries the actionable guidance for the caller. */
+export interface SpawnRejectionResponse {
+  error: string;
+  code: SpawnRejectionCode;
+  launchId: string;
+  conversationId: string;
+  rejection: SpawnRejection;
+}
+
+export function spawnRejectionResponse(error: SpawnAdmissionError): SpawnRejectionResponse {
+  return {
+    error: error.rejection.guidance,
+    code: error.rejection.code,
+    launchId: error.receipt.launchId,
+    conversationId: error.receipt.conversationId,
+    rejection: error.rejection,
+  };
+}
 
 export interface SpawnResponse {
   ok: true;

--- a/src/lib/agent/transcriptHost.ts
+++ b/src/lib/agent/transcriptHost.ts
@@ -730,6 +730,7 @@ export function beginRegistryResume(
     accountId: current?.accountId ?? null,
     conversationId: conversation.id,
     purpose: "resume-successor",
+    origin: { kind: "successor" },
     launchProfile: spec.launchProfile ?? current?.launchProfile,
   });
   return { receipt: begun.receipt, spec };

--- a/src/lib/flows/engine.test.ts
+++ b/src/lib/flows/engine.test.ts
@@ -93,6 +93,9 @@ test("a flow reviewer reserves the canonical review edge before process launch",
   const begun = reserveReviewerSpawn(flow, round, flow.roles.reviewer, "terra", registry);
 
   expect(begun.kind).toBe("created");
+  /* Flow reviewer rounds are container-origin launches (#393): the reviewer
+     identity and its delegation depth are durable before any process exists. */
+  expect(begun.receipt).toMatchObject({ agentRole: "reviewer", delegationDepth: 1, rejection: null });
   expect(round).toMatchObject({ launchId: begun.receipt.launchId, reviewerConversationId: begun.receipt.conversationId });
   expect(registry.snapshot()).toMatchObject({
     lineageEdges: {

--- a/src/lib/flows/engine.ts
+++ b/src/lib/flows/engine.ts
@@ -186,6 +186,9 @@ export function reserveReviewerSpawn(
     parentArtifactPath: parentPath,
     role: "reviewer",
     reviewsConversationId: owner.id,
+    /* Container origin (#393): the flow controller initiates reviewer rounds,
+       not the implementer — the implementer is only the lineage parent. */
+    origin: { kind: "container", container: "flow", containerId: flow.id, creatorConversationId: null },
     memberships: [{
       kind: "flow",
       containerId: flow.id,

--- a/src/lib/pipelines/engine.ts
+++ b/src/lib/pipelines/engine.ts
@@ -67,6 +67,10 @@ export interface PipelinePorts {
     parentPath: string | null;
     clientAttemptId: string;
     membership: DurableMembershipInput;
+    /** Pipeline creator (#393): the container acts for the conversation that
+        created it, so reviewer-isolation and depth admission key on this —
+        never on the lineage parent, which may be a passed review stage. */
+    creatorConversationId: string | null;
     /** Prior-attempt conversation this stage retry terminally supersedes
         (issue #383); attempt chains become round chains automatically. */
     supersedes?: string | null;
@@ -154,6 +158,9 @@ async function spawnPipelineAgent(
     ...(supersedes ? { supersedes } : {}),
     prompt: input.prompt,
   })).digest("hex");
+  const creatorConversationId = input.creatorConversationId?.startsWith("conversation_")
+    ? registry.canonicalConversationId(input.creatorConversationId as ViewerConversationId)
+    : null;
   const begun = registry.beginSpawnRequest({
     engine: input.role.engine,
     cwd: input.cwd,
@@ -162,6 +169,17 @@ async function spawnPipelineAgent(
     parentConversationId: parent.conversationId,
     parentSessionKey: parent.sessionKey,
     parentArtifactPath: parent.conversationId ? input.parentPath : null,
+    role: input.role.roleId,
+    /* Container origin (#393): admission keys on the pipeline creator, so a
+       reviewer-lineage-parent stage stays admissible while a reviewer-created
+       pipeline is terminally rejected. Retries reuse the same origin, so
+       delegation depth is stable across rounds. */
+    origin: {
+      kind: "container",
+      container: "pipeline",
+      containerId: input.membership.containerId,
+      creatorConversationId,
+    },
     memberships: [{ ...input.membership, parentConversationId: parent.conversationId }],
     launchProfile,
     clientAttemptId: input.clientAttemptId,
@@ -483,6 +501,7 @@ async function tickRunStage(
         prompt,
         parentPath: latestCompletedAgentPath(pipeline, stage.id),
         clientAttemptId: clientAttemptId(pipeline, stage, attempt),
+        creatorConversationId: pipeline.srcConversationId,
         supersedes: priorAttempt?.conversationId ?? null,
         membership: {
           kind: "pipeline",

--- a/src/lib/runtime/structuredRecovery.ts
+++ b/src/lib/runtime/structuredRecovery.ts
@@ -131,6 +131,7 @@ async function recoverCandidate(
       conversationId: current.conversationId,
       parentConversationId: current.parentConversationId,
       purpose: "resume-successor",
+      origin: { kind: "successor" },
       expectedArtifactPath: current.path,
       launchProfile: current.spec.launchProfile,
     });

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -153,6 +153,9 @@ export interface FileEntry {
   durableLineage?: {
     kind: "spawn" | "review";
     role: string | null;
+    /** Recorded delegation depth (#393): 0 for operator/external roots,
+        depth(origin)+1 for delegated launches; absent/null for legacy records. */
+    depth?: number | null;
     parentConversationId: string | null;
     reviewsConversationId: string | null;
     memberships: Array<{


### PR DESCRIPTION
Implements issue #393 on current origin/main.

## What changed

**Single admission choke point.** `beginSpawnRequest` now takes an initiating `origin` (`operator` / `agent` / `container` / `external` / `successor`) and runs admission inside the same registry mutation that writes the receipt, so no call site — including any future MCP surface routed through the registry — can race or bypass it. Reviewer/verifier-origin launches (`reviewer_origin_spawn`) and over-depth launches (`nesting_depth_exceeded`) are terminally rejected **before any child transcript or process exists**, persisting one durable, typed, terminal rejection receipt with actionable guidance. `clientAttemptId` replay returns the identical rejected receipt. HTTP callers get a typed 403 (`SpawnRejectionResponse`).

**Durable role + depth identity.** Every receipt and conversation records `agentRole` and `delegationDepth` at admission (0 for operator/external roots, `depth(origin)+1` for delegated launches). Resume, restart adoption, account switch, supersedence, and stage retries conserve the recorded values (`successor` origins are exempt identity-preserving relaunches). Legacy records resolve fail-open: recorded field → lineage-edge role → newest membership role; depth via membership (⇒1) or a bounded, cycle-guarded lineage walk. Registry schema stays version 2; all new fields default null and old files load unchanged.

**Reviewer capability floor preserved.** Reviewer/verifier keep full filesystem, shell, GitHub, and browser access. The `/api/spawn` route rejects `role: reviewer|verifier` + `allowSubagents: true` on **every** lane (closing the operator escalation), and the registry forces `allowSubagents:false` on resume-successor merges for denied-role conversations — so the #381 Claude `--disallowedTools`/hook set and Codex `multi_agent:false` config hold across fresh launch, resume, and restart adoption. The `LLV_SPAWN_CAPABILITY` token stays injected: every use is server-side denied with a durable, auditable receipt.

**Durable nesting policy.** New `spawn-nesting.json` store (default **2**, bounds 1–4) plus operator-only `GET`/`PATCH /api/spawn/policy`; agent-initiated PATCH is rejected, so no agent can raise its own ceiling.

**Containers.** Pipeline stage spawns pass a `container` origin keyed on the **pipeline creator** — a reviewer-lineage-parent stage stays admissible (origin ≠ lineage parent) while a reviewer-created pipeline is rejected at both `POST /api/pipelines` (authenticated reviewer caller and declared reviewer `src`) and, defense in depth, at every stage launch. Pipeline stages now record `role` on their lineage edge (reviewer stages included; the reviews-target coupling is relaxed only for container origins). Flow reviewer rounds pass a flow container origin. Stage retries reuse the same origin, so depth is stable across rounds. #341 external-caller inference and #387 same-mutation membership registration are preserved (unattributed external pipeline creation keeps today's behavior).

**Projection.** `durableLineage` gains `depth` (and role now backed by the conversation record) in both the files response and pre-admission spawn cards; rejected receipts project as terminal failed cards with zero conversation artifacts.

## Verification

- `bunx tsc --noEmit` clean; changed-file `eslint` clean; `bun run build` passes.
- 27 new tests across `spawnAdmission`, `nestingPolicy`, `registry.admission`, `spawn/route.admission`, `pipelines/route.admission`, `spawn/policy/route`, `spawnProjection`, and flow reviewer receipt pinning — covering reviewer/verifier deny (agent lane + container creator), depth math and ceiling, policy bounds and operator-only PATCH, successor/migration identity carry, reviewer resume `allowSubagents` hardening, replay idempotency, legacy-file normalization, I7 (reviewer lineage parent admissible), and terminal-card projection.
- Full targeted suites green: `src/lib/agent` (263), `src/app/api/spawn|pipelines|tasks`, `src/lib/pipelines|flows|runtime|accounts` (1018/1019 — the one failure is the pre-existing `codexAppServerHost.integration` test that needs a real Codex binary and fails on baseline too; likewise 3 pre-existing `scanCache.real` EIO-simulation failures).

Residual (stated in the design): native Codex `spawn_agent` honoring `multi_agent:false` remains #284's obligation; this PR pins the launch config, not the native fix. Legacy operator-spawned `src`-less reviewer sessions predating durable role records stay fail-open until their next round.

🤖 Generated with [Claude Code](https://claude.com/claude-code)