### PR TITLE
Fix composer send admission hangs (#421)

### DIFF
--- a/src/components/TmuxComposer.tsx
+++ b/src/components/TmuxComposer.tsx
@@ -19,6 +19,7 @@ import type { FileEntry } from "@/lib/types";
 import type { RuntimeReceipt } from "@/components/runtime/runtimeModel";
 
 import { ComposerBar } from "./ComposerBar";
+import { ComposerAdmissionTimeoutError, withComposerAdmissionDeadline } from "./composerAdmissionDeadline";
 import { RuntimePill } from "./RuntimePill";
 import { savedResumeProfile, sendRuntimeFrom, type RuntimeProfile } from "./runtimeProfile";
 import { type PendingImage } from "./imageAttachments";
@@ -1030,10 +1031,10 @@ export function TmuxComposer({
         spawned?: boolean;
         outcome?: "delivered-to-live" | "resumed" | "held" | "queued" | "delivering" | "delivered" | "recovering" | "failed";
         receipt?: RuntimeReceipt;
-      } = structuredSession
+      } = await withComposerAdmissionDeadline(Promise.resolve(structuredSession
         ? !reachesWire
           ? { ok: false, structured: true, error: structuredImagesReason }
-          : await sendRuntimeMessage({
+          : sendRuntimeMessage({
               conversationId: structuredSession.session.conversationId,
               text: payloadText.trim(),
               images: sentImages.map((image) => ({ base64: image.base64, mime: image.mime })),
@@ -1046,11 +1047,11 @@ export function TmuxComposer({
               error: result.error,
               status: result.status,
               receipt: result.receipt,
-              outcome: result.receipt?.status === "delivering" || result.receipt?.status === "delivered"
+              outcome: (result.receipt?.status === "delivering" || result.receipt?.status === "delivered"
                 ? result.receipt.status
-                : "queued",
+                : "queued") as "delivering" | "delivered" | "queued",
             }))
-        : await fetch("/api/tmux", {
+        : fetch("/api/tmux", {
             method: "POST",
             headers: { "content-type": "application/json" },
             body: JSON.stringify({
@@ -1068,7 +1069,7 @@ export function TmuxComposer({
           }).then(async (response) => {
             const body = await response.json() as typeof json;
             return { ...body, status: response.status, ok: response.ok && body.ok === true };
-          });
+          })));
       if (!json.ok) {
         if (json.structured && json.receipt) {
           /* Keep the payload readable in the compact receipt for retry and
@@ -1172,14 +1173,19 @@ export function TmuxComposer({
               : t("common.sent"),
       });
       inputRef.current?.focus();
-    } catch {
+    } catch (error) {
       /* The request died on the wire AFTER the server may have accepted it.
          The pre-flight record (text AND attachment snapshot) stays armed so a
          late admission receipt still clears exactly what was sent. A stale
          death racing a faster durable admission reports nothing — the receipt
          stack already tells the truth. */
       if (!settledSendKeys.current.has(clientMessageId)) {
-        setStatus({ kind: "err", text: t("common.serverUnavailable") });
+        setStatus({
+          kind: "err",
+          text: error instanceof ComposerAdmissionTimeoutError
+            ? t("composer.admissionTimedOut")
+            : t("common.serverUnavailable"),
+        });
       }
     } finally {
       setBusy(false);

--- a/src/components/composerAdmissionDeadline.test.ts
+++ b/src/components/composerAdmissionDeadline.test.ts
@@ -1,0 +1,17 @@
+import { expect, test } from "bun:test";
+
+import { ComposerAdmissionTimeoutError, withComposerAdmissionDeadline } from "./composerAdmissionDeadline";
+
+test("a request without an admission response releases the composer deadline", async () => {
+  const neverSettles = new Promise<Response>(() => {});
+
+  await expect(withComposerAdmissionDeadline(neverSettles, 5))
+    .rejects.toBeInstanceOf(ComposerAdmissionTimeoutError);
+});
+
+test("a durable admission response wins before the deadline", async () => {
+  const response = { ok: true, status: 202 } as Response;
+
+  await expect(withComposerAdmissionDeadline(Promise.resolve(response), 50))
+    .resolves.toBe(response);
+});

--- a/src/components/composerAdmissionDeadline.ts
+++ b/src/components/composerAdmissionDeadline.ts
@@ -1,0 +1,26 @@
+export const COMPOSER_ADMISSION_DEADLINE_MS = 15_000;
+
+export class ComposerAdmissionTimeoutError extends Error {
+  constructor() {
+    super("composer admission timed out");
+    this.name = "ComposerAdmissionTimeoutError";
+  }
+}
+
+/**
+ * Bounds how long the composer blocks on the immediate HTTP response.
+ *
+ * The request continues in the background because the server may have already
+ * accepted it. Durable receipt reconciliation owns the eventual settlement;
+ * the deadline only releases the input so the operator can retry with the same
+ * idempotency key.
+ */
+export function withComposerAdmissionDeadline<T>(request: Promise<T>, timeoutMs = COMPOSER_ADMISSION_DEADLINE_MS): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const deadline = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => reject(new ComposerAdmissionTimeoutError()), timeoutMs);
+  });
+  return Promise.race([request, deadline]).finally(() => {
+    if (timer !== undefined) clearTimeout(timer);
+  });
+}

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -260,6 +260,7 @@ export const en = {
   "composer.queueAria": "Queue of sent messages",
   "composer.removeFromQueue": "Remove from queue",
   "composer.deliveryHeld": "Held for «{label}» — delivers after the account switch",
+  "composer.admissionTimedOut": "Delivery confirmation timed out. Retry safely; the same message key will be reused.",
   "composer.runtimePill": "Model and reasoning — applies to your next message",
   "composer.reasoningGroup": "Reasoning",
   "composer.modelGroup": "Model",

--- a/src/lib/i18n/uk.ts
+++ b/src/lib/i18n/uk.ts
@@ -252,6 +252,7 @@ export const uk: Record<keyof typeof en, Message> = {
   "composer.queueAria": "Черга надісланих повідомлень",
   "composer.removeFromQueue": "Прибрати з черги",
   "composer.deliveryHeld": "Притримано для «{label}» — доставиться після зміни акаунта",
+  "composer.admissionTimedOut": "Час очікування підтвердження вичерпано. Повторіть безпечно — ключ повідомлення збережено.",
   "composer.runtimePill": "Модель і міркування — застосується до наступного повідомлення",
   "composer.reasoningGroup": "Міркування",
   "composer.modelGroup": "Модель",


### PR DESCRIPTION
## Summary

- bound the immediate composer admission wait to 15 seconds
- preserve the exact draft, attachment snapshot, and idempotency key after a timeout
- release the busy state so the operator can retry safely
- show a localized actionable timeout message

## Verification

- `bun test src/components/composerAdmissionDeadline.test.ts src/components/TmuxComposer.reconciliation.dom.test.tsx`
- `bunx tsc --noEmit`
- `git diff --check`

Closes #421