### PR TITLE
Fix stale structured recovery claims

### DIFF
--- a/src/lib/runtime/structuredRecovery.test.ts
+++ b/src/lib/runtime/structuredRecovery.test.ts
@@ -462,7 +462,7 @@ test("live structured ownership prevents a duplicate recovery host", async () =>
     structuredHost: {
       kind: "codex-app-server",
       endpoint: "stdio:live",
-      process: { pid: process.pid, startIdentity: "live-process" },
+      process: { pid: process.pid, startIdentity: null },
       eventCursor: 7,
       protocolVersion: "v2",
       writerClaimEpoch: 4,
@@ -490,6 +490,75 @@ test("live structured ownership prevents a duplicate recovery host", async () =>
 
   expect(result).toMatchObject({ target: null, conversationId: conversation.id, spawned: false });
   expect(spawnCalls).toBe(0);
+});
+
+test("a dead structured process cannot masquerade as publish-ready ownership", async () => {
+  const sessionId = crypto.randomUUID();
+  const cwd = path.join(sandbox, `stale-owner-${sessionId}`);
+  const artifactPath = path.join(cwd, `${sessionId}.jsonl`);
+  const staleProcess = { pid: 2_000_000_000, startIdentity: "stale-wrapper" };
+  fs.mkdirSync(cwd, { recursive: true });
+  fs.writeFileSync(artifactPath, "");
+  const registry = new AgentRegistry(path.join(cwd, "registry.json"), undefined, undefined, { sqliteMode: "off" });
+  const conversation = registry.ensureConversation("codex", artifactPath, "retained-account");
+  registry.upsert({
+    key: { engine: "codex", sessionId },
+    artifactPath,
+    cwd,
+    accountId: "retained-account",
+    launchProfile: emptyLaunchProfile({ cwd }),
+    status: "idle",
+    host: null,
+    structuredHost: {
+      kind: "codex-app-server",
+      endpoint: "stdio:stale",
+      process: staleProcess,
+      eventCursor: 7,
+      protocolVersion: "v2",
+      writerClaimEpoch: 4,
+      activeTurnRef: null,
+      pendingAttention: [],
+      activeFlags: [],
+    },
+    claimEpoch: 4,
+    claimOwner: `structured-host:${JSON.stringify(staleProcess)}`,
+    pendingAction: null,
+  });
+  let spawnCalls = 0;
+
+  const result = await recoverDeadStructuredConversation({
+    path: artifactPath,
+    conversationId: conversation.id,
+  }, {
+    registry,
+    client: {} as RuntimeHostClient,
+    transport: () => "structured",
+    resolveAccount: () => ({
+      engine: "codex",
+      accountId: "retained-account",
+      kind: "managed",
+      home: cwd,
+      transcriptRoot: cwd,
+      env: { NODE_ENV: "test" },
+    }),
+    spawn: async (input) => {
+      spawnCalls += 1;
+      return {
+        ok: true,
+        target: null,
+        path: artifactPath,
+        launchId: input.receipt.launchId,
+        conversationId: conversation.id,
+        launched: true,
+        retrySafe: false,
+        initialMessage: "delivered",
+        state: "settled",
+      };
+    },
+  });
+
+  expect(result).toMatchObject({ target: null, conversationId: conversation.id, spawned: true });
+  expect(spawnCalls).toBe(1);
 });
 
 test.each(["codex", "claude"] as const)("current verified %s tmux ownership outranks completed structured history", async (engine) => {

--- a/src/lib/runtime/structuredRecovery.ts
+++ b/src/lib/runtime/structuredRecovery.ts
@@ -42,6 +42,12 @@ interface RecoveryCandidate {
   publishReady: boolean;
 }
 
+function processIdentityAlive(identity: { pid: number; startIdentity: string | null } | null): boolean {
+  if (!identity || !Number.isInteger(identity.pid) || identity.pid <= 0) return false;
+  if (!procBackend.pidAlive(identity.pid)) return false;
+  return identity.startIdentity === null || procBackend.processIdentity(identity.pid) === identity.startIdentity;
+}
+
 const recoveryStore = globalThis as typeof globalThis & {
   __llvStructuredRecovery?: Map<string, Promise<StructuredRecoveryResult | null>>;
 };
@@ -66,7 +72,7 @@ function candidateFor(
       && registry.canonicalConversationId(receipt.conversationId) === conversation.id);
   if (!entry.structuredHost && !structuredReceipt) return null;
   const terminal = entry.status === "dead" || entry.status === "unhosted";
-  const publishReady = Boolean(entry.structuredHost?.process
+  const publishReady = Boolean(processIdentityAlive(entry.structuredHost?.process ?? null)
     && entry.claimOwner
     && entry.pendingAction === null
     && !terminal);


### PR DESCRIPTION
## Summary

- validate the persisted structured host PID and start identity before treating recovery ownership as publish-ready
- recover stale dead claims so sends can reach a command-ready host
- preserve the live-host duplicate-process fence

## Verification

- 55 focused structured recovery and delivery tests passed
- TypeScript passed
- ESLint passed
- production build passed

Refs #337