### PR TITLE
Keep Codex delivery alive through context compaction

### DIFF
--- a/src/lib/runtime/codexAppServerHost.test.ts
+++ b/src/lib/runtime/codexAppServerHost.test.ts
@@ -1791,6 +1791,44 @@ describe("CodexAppServerHost", () => {
     await host.release();
   });
 
+  test("context compaction can outlive the RPC deadline without killing delivery ownership", async () => {
+    const server = new FakeAppServer("compaction-delivery-thread");
+    server.autoCompleteUserMessage = false;
+    const host = await CodexAppServerHost.start({
+      cwd: "/repo",
+      requestTimeoutMs: 5,
+      eventStore: new MemoryEventStore(),
+      spawnProcess: fakeSpawn(server),
+      ...ownedFakeProcess,
+    });
+
+    const delivery = host.send({ id: "compaction-delivery", text: "continue after compaction" });
+    await Bun.sleep(10);
+    server.notify("item/started", {
+      threadId: "compaction-delivery-thread",
+      turnId: "turn-1",
+      item: { id: "compaction-one", type: "contextCompaction" },
+    });
+    expect(await host.health()).toMatchObject({ status: "active", activeTurnRef: "turn-1" });
+    expect(server.signals).toEqual([]);
+
+    const request = server.requests.find((candidate) => candidate.method === "turn/start")!;
+    const params = request.params as { input: unknown };
+    server.notify("item/completed", {
+      threadId: "compaction-delivery-thread",
+      turnId: "turn-1",
+      item: {
+        type: "userMessage",
+        clientId: "compaction-delivery",
+        content: params.input,
+      },
+    });
+
+    expect(await delivery).toEqual({ outcome: "turn-started", turnId: "turn-1" });
+    expect(server.signals).toEqual([]);
+    await host.release();
+  });
+
   test("an active turn gives thread/read enough time to answer", async () => {
     const ignoredMethods: string[] = [];
     const server = new FakeAppServer("slow-read-thread", "slow-read-thread", false, [], undefined, null, ignoredMethods);

--- a/src/lib/runtime/codexAppServerHost.ts
+++ b/src/lib/runtime/codexAppServerHost.ts
@@ -78,6 +78,7 @@ export interface CodexAppServerHostOptions {
   approvalPolicy?: string;
   env?: NodeJS.ProcessEnv;
   requestTimeoutMs?: number;
+  deliveryConfirmationTimeoutMs?: number;
   shutdownGraceMs?: number;
   initialEventCursor?: number;
   onEventCursorRecovery?: RuntimeEventCursorRecoveryReporter;
@@ -123,6 +124,7 @@ const CHILD_ENV_ALLOWLIST = [
   "LLV_SPAWN_CAPABILITY",
 ] as const;
 const DEFAULT_TIMEOUT_MS = 30_000;
+const DEFAULT_DELIVERY_CONFIRMATION_TIMEOUT_MS = 5 * 60_000;
 const ACTIVE_THREAD_READ_TIMEOUT_MULTIPLIER = 3;
 const LATE_THREAD_READ_RESPONSE_TTL_MULTIPLIER = 3;
 const MIN_LATE_THREAD_READ_RESPONSE_TTL_MS = 1_000;
@@ -280,6 +282,7 @@ export class CodexAppServerHost implements EngineHost {
 
   private readonly child: ChildProcessWithoutNullStreams;
   private readonly requestTimeoutMs: number;
+  private readonly deliveryConfirmationTimeoutMs: number;
   private readonly shutdownGraceMs: number;
   private readonly eventStore: RuntimeEventStore;
   private readonly effort: string | undefined;
@@ -341,6 +344,8 @@ export class CodexAppServerHost implements EngineHost {
     this.child = child;
     this.identity = identity;
     this.requestTimeoutMs = options.requestTimeoutMs ?? DEFAULT_TIMEOUT_MS;
+    this.deliveryConfirmationTimeoutMs = options.deliveryConfirmationTimeoutMs
+      ?? DEFAULT_DELIVERY_CONFIRMATION_TIMEOUT_MS;
     this.shutdownGraceMs = options.shutdownGraceMs ?? DEFAULT_SHUTDOWN_GRACE_MS;
     this.eventStore = options.eventStore ?? new FileRuntimeEventStore();
     this.effort = options.effort;
@@ -1006,7 +1011,7 @@ export class CodexAppServerHost implements EngineHost {
     const timer = setTimeout(() => {
       if (this.pendingDeliveries.get(entry.id)?.promise !== promise) return;
       this.fail(new Error("Codex delivery confirmation timed out; outcome is uncertain"));
-    }, this.requestTimeoutMs);
+    }, this.deliveryConfirmationTimeoutMs);
     const pending = {
       text: entry.text ?? "",
       contentDigest: entry.contentDigest!,


### PR DESCRIPTION
## Summary

- decouple Codex delivery confirmation from the short JSON-RPC deadline
- keep the structured host and writer claim alive while context compaction delays the user-message item
- retain a bounded five-minute confirmation window and exact client-message idempotency

## Verification

- RED reproduced the host death during context compaction
- 124 focused runtime tests passed
- TypeScript passed
- ESLint passed
- production build passed
- diff check passed

Refs #337