### PR TITLE
Reject contradictory pipeline review verdicts

### DIFF
--- a/src/lib/pipelines/engine.test.ts
+++ b/src/lib/pipelines/engine.test.ts
@@ -950,6 +950,42 @@ test("a durable fail verdict parks with the verdict receipt preserved", async ()
   });
 });
 
+test("a contradictory durable pass verdict parks with the parser failure reason", async () => {
+  const h = harness();
+  await runningStructuredStage(h);
+  h.setConversationActive(true);
+  h.durableTurns.set("/codex/stage-1.jsonl", {
+    turn: "terminal",
+    message: {
+      text: [
+        "VERDICT: REQUEST_CHANGES",
+        "",
+        "- [P1] Preserve the failed review",
+        "",
+        "```json",
+        '{"status":"pass","findings":["Preserve the failed review"]}',
+        "```",
+      ].join("\n"),
+      ts: 5_000_000,
+    },
+  });
+
+  await tickPipelines([], h.ports);
+
+  const reason = 'contradictory stage verdict: status "pass" cannot include findings';
+  const current = loadPipelines()[0]!;
+  expect(current.state).toBe("needs_decision");
+  expect(current.stateDetail).toBe(reason);
+  expect(current.cursor).toEqual({ stageId: "plan", state: "running" });
+  expect(current.lastPassedCommit).toBe(ORIGIN_MAIN_SHA);
+  expect(current.runs[0]!.attempts[0]).toMatchObject({
+    state: "needs_decision",
+    output: "VERDICT: REQUEST_CHANGES\n\n- [P1] Preserve the failed review",
+    verdict: null,
+    error: reason,
+  });
+});
+
 test("durable settlement is idempotent across repeated wake-up ticks", async () => {
   const h = harness();
   await runningStructuredStage(h);

--- a/src/lib/pipelines/engine.test.ts
+++ b/src/lib/pipelines/engine.test.ts
@@ -1225,6 +1225,43 @@ test("retry and skip refuse while a verdict-less parked stage still hosts a live
   expect(retried.pipeline?.state).toBe("running");
 });
 
+test("retry and skip recover a completed pane-hosted semantic contradiction", async () => {
+  for (const action of ["retry-stage", "skip-stage"] as const) {
+    const h = harness();
+    const pipeline = await create(h.ports);
+    await tickPipelines([], h.ports);
+    await tickPipelines([], h.ports);
+    h.messages.set("/codex/stage-1.jsonl", {
+      text: [
+        "VERDICT: REQUEST_CHANGES",
+        "",
+        "```json",
+        '{"status":"pass"}',
+        "```",
+      ].join("\n"),
+      ts: 5_000_000,
+    });
+    await tickPipelines([entry("/codex/stage-1.jsonl")], h.ports);
+
+    const parkedAttempt = loadPipelines()[0]!.runs[0]!.attempts[0]!;
+    expect(parkedAttempt).toMatchObject({
+      state: "needs_decision",
+      paneId: "%1",
+      verdict: null,
+      error: 'contradictory stage verdict: prose marker "REQUEST_CHANGES" disagrees with JSON status "pass"',
+    });
+    expect(parkedAttempt.completedAt).toBeTruthy();
+
+    const recovered = await patchPipeline(pipeline.id, { action }, h.ports);
+    expect(recovered.error).toBeUndefined();
+    expect(recovered.pipeline?.state).toBe("running");
+    expect(recovered.pipeline?.cursor).toEqual({
+      stageId: action === "retry-stage" ? "plan" : "build",
+      state: "pending",
+    });
+  }
+});
+
 test("closing a mid-run or parked pipeline persists a record that loads back", async () => {
   const h = harness();
   const running = await create(h.ports);

--- a/src/lib/pipelines/engine.ts
+++ b/src/lib/pipelines/engine.ts
@@ -413,9 +413,8 @@ function commitPassedStage(
   advancePipeline(pipeline, stage, ports);
 }
 
-/** One-shot settlement of a completed stage turn. Records the verdict on the
-    attempt, then either commits + advances (pass) or parks with the verdict
-    preserved (fail / needs_decision). */
+/** One-shot settlement of a completed stage turn. Semantic contradictions park
+    with their parser reason. Valid verdicts are recorded before settlement. */
 function settleStageVerdict(
   pipeline: Pipeline,
   stage: PipelineStage,
@@ -425,6 +424,11 @@ function settleStageVerdict(
   persist: () => void,
 ): void {
   attempt.output = parsed.output;
+  if ("failureReason" in parsed) {
+    attempt.completedAt = ports.now();
+    park(pipeline, parsed.failureReason, attempt);
+    return;
+  }
   attempt.verdict = parsed.verdict;
   if (parsed.verdict.status !== "pass") {
     attempt.state = parsed.verdict.status === "fail" ? "failed" : "needs_decision";

--- a/src/lib/pipelines/engine.ts
+++ b/src/lib/pipelines/engine.ts
@@ -1037,13 +1037,13 @@ export async function createPipelineFromRequest(
 /** A park without a verdict (interrupted spawn, vanished transcript) can
     leave the stage agent mid-turn in its pane; retry/skip would reset the
     worktree under it and the next passed stage would commit its strays. An
-    attempt that produced a verdict finished its turn — an idle interactive
-    CLI in the pane is safe to leave behind. */
+    attempt with a verdict or terminal completion timestamp finished its turn;
+    an idle interactive CLI in the pane is safe to leave behind. */
 async function orphanAgentPane(
   attempt: PipelineStageAttempt | null,
   ports: PipelinePorts,
 ): Promise<{ error: string; status: number } | null> {
-  if (!attempt || attempt.verdict || !attempt.paneId) return null;
+  if (!attempt || attempt.verdict || attempt.completedAt || !attempt.paneId) return null;
   if (!(await ports.paneAgentAlive(attempt.paneId))) return null;
   return { error: `stage agent may still be running in pane ${attempt.paneId}; wait for it to exit or kill the pane first`, status: 409 };
 }

--- a/src/lib/pipelines/prompts.test.ts
+++ b/src/lib/pipelines/prompts.test.ts
@@ -37,6 +37,9 @@ test("run prompt renders task, previous output, spec, access, verdict, and nesti
   expect(prompt).toContain("AC1: structured verdict");
   expect(prompt).toContain("Access: read-write");
   expect(prompt).toContain('"status":"pass"');
+  expect(prompt).toContain('"findings":[]');
+  expect(prompt).toContain("Pass requires findings to be empty or omitted.");
+  expect(prompt).toContain("REQUEST_CHANGES=fail");
   expect(prompt).toContain("Pipeline nesting is forbidden");
   expect(prompt).toContain("Role preset: builder");
   expect(prompt).toContain("Keep the implementation focused on pipeline support.");

--- a/src/lib/pipelines/prompts.ts
+++ b/src/lib/pipelines/prompts.ts
@@ -38,9 +38,11 @@ export function renderStagePrompt(
     "",
     "Finish the completed turn with one fenced JSON object as the final block. This block is the only completion authority:",
     "```json",
-    '{"status":"pass","findings":["optional bounded finding"],"confidence":0.9}',
+    '{"status":"pass","findings":[],"confidence":0.9}',
     "```",
     "Use pass when the stage contract is complete, fail for a retryable stage failure, and needs_decision when operator judgment is required.",
+    "Pass requires findings to be empty or omitted. Use fail or needs_decision when findings describe unresolved work.",
+    "Every prose terminal marker must agree with the JSON status: APPROVE=pass, REQUEST_CHANGES=fail, COMMENT=needs_decision. NO FINDINGS agrees with pass.",
     "Human-readable output may appear before the JSON block. Never place text after the block.",
   ].join("\n");
 }

--- a/src/lib/pipelines/verdict.test.ts
+++ b/src/lib/pipelines/verdict.test.ts
@@ -25,3 +25,100 @@ test("the final fenced JSON block is completion authority and preserves prose ou
   expect(parseStageVerdict("```json\n{\"status\":\"pass\"}\n```\ntrailing prose")).toBeNull();
   expect(parseStageVerdict("VERDICT: pass")).toBeNull();
 });
+
+test("a pass verdict with findings returns an explicit contradiction", () => {
+  expect(parseStageVerdict([
+    "VERDICT: REQUEST_CHANGES",
+    "",
+    "- [P1] Preserve the failed review",
+    "",
+    "```json",
+    '{"status":"pass","findings":["Preserve the failed review"]}',
+    "```",
+  ].join("\n"))).toEqual({
+    failureReason: 'contradictory stage verdict: status "pass" cannot include findings',
+    output: "VERDICT: REQUEST_CHANGES\n\n- [P1] Preserve the failed review",
+  });
+});
+
+test("a prose request-changes marker cannot disagree with the JSON verdict", () => {
+  expect(parseStageVerdict([
+    "VERDICT: REQUEST_CHANGES",
+    "",
+    "Review found a blocking regression.",
+    "",
+    "```json",
+    '{"status":"pass","confidence":0.9}',
+    "```",
+  ].join("\n"))).toEqual({
+    failureReason: 'contradictory stage verdict: prose marker "REQUEST_CHANGES" disagrees with JSON status "pass"',
+    output: "VERDICT: REQUEST_CHANGES\n\nReview found a blocking regression.",
+  });
+});
+
+test("a prose approve marker cannot disagree with the JSON verdict", () => {
+  expect(parseStageVerdict([
+    "VERDICT: APPROVE",
+    "",
+    "```json",
+    '{"status":"fail","findings":["verification failed"]}',
+    "```",
+  ].join("\n"))).toEqual({
+    failureReason: 'contradictory stage verdict: prose marker "APPROVE" disagrees with JSON status "fail"',
+    output: "VERDICT: APPROVE",
+  });
+});
+
+test("a no-findings marker cannot disagree with the JSON verdict", () => {
+  expect(parseStageVerdict([
+    "NO FINDINGS",
+    "",
+    "```json",
+    '{"status":"fail","findings":["verification failed"]}',
+    "```",
+  ].join("\n"))).toEqual({
+    failureReason: 'contradictory stage verdict: prose marker "NO FINDINGS" disagrees with JSON status "fail"',
+    output: "NO FINDINGS",
+  });
+});
+
+test("a clean no-findings pass remains valid", () => {
+  expect(parseStageVerdict([
+    "NO FINDINGS",
+    "",
+    "```json",
+    '{"status":"pass","findings":[],"confidence":1}',
+    "```",
+  ].join("\n"))).toEqual({
+    verdict: { status: "pass", findings: [], confidence: 1 },
+    output: "NO FINDINGS",
+  });
+});
+
+test("a matching fail verdict preserves every finding", () => {
+  expect(parseStageVerdict([
+    "VERDICT: REQUEST_CHANGES",
+    "",
+    "```json",
+    '{"status":"fail","findings":["first regression","second regression"]}',
+    "```",
+  ].join("\n"))).toEqual({
+    verdict: { status: "fail", findings: ["first regression", "second regression"] },
+    output: "VERDICT: REQUEST_CHANGES",
+  });
+});
+
+test("prose marker validation covers content beyond the stored output cap", () => {
+  const boundedOutput = "x".repeat(32_000);
+  expect(parseStageVerdict([
+    boundedOutput,
+    "VERDICT: REQUEST_CHANGES",
+    "",
+    "```json",
+    '{"status":"pass"}',
+    "```",
+  ].join("\n"))).toEqual({
+    failureReason: 'contradictory stage verdict: prose marker "REQUEST_CHANGES" disagrees with JSON status "pass"',
+    output: boundedOutput,
+  });
+});

--- a/src/lib/pipelines/verdict.test.ts
+++ b/src/lib/pipelines/verdict.test.ts
@@ -95,6 +95,35 @@ test("a clean no-findings pass remains valid", () => {
   });
 });
 
+test("fenced and quoted marker examples do not contradict a clean pass", () => {
+  const prose = [
+    "The reviewed prompt includes this failure example:",
+    "",
+    "```text",
+    "VERDICT: REQUEST_CHANGES",
+    "```",
+    "",
+    "~~~text",
+    "~~~json",
+    "VERDICT: REQUEST_CHANGES",
+    "~~~",
+    "",
+    "> VERDICT: REQUEST_CHANGES",
+    "",
+    "NO FINDINGS",
+  ].join("\n");
+  expect(parseStageVerdict([
+    prose,
+    "",
+    "```json",
+    '{"status":"pass","findings":[],"confidence":1}',
+    "```",
+  ].join("\n"))).toEqual({
+    verdict: { status: "pass", findings: [], confidence: 1 },
+    output: prose,
+  });
+});
+
 test("a matching fail verdict preserves every finding", () => {
   expect(parseStageVerdict([
     "VERDICT: REQUEST_CHANGES",

--- a/src/lib/pipelines/verdict.ts
+++ b/src/lib/pipelines/verdict.ts
@@ -4,8 +4,16 @@ const MAX_FINDINGS = 50;
 const MAX_FINDING_CHARS = 2_000;
 const MAX_OUTPUT_CHARS = 32_000;
 const ALLOWED_KEYS = new Set(["status", "findings", "confidence"]);
+const PROSE_VERDICT_STATUSES = {
+  APPROVE: "pass",
+  REQUEST_CHANGES: "fail",
+  COMMENT: "needs_decision",
+  "NO FINDINGS": "pass",
+} as const satisfies Record<string, StageVerdict["status"]>;
+const PROSE_VERDICT_RE = /^\s*(?:VERDICT:\s*(APPROVE|REQUEST_CHANGES|COMMENT)|(NO FINDINGS))\s*$/gim;
 
 export type ParsedStageVerdict = { verdict: StageVerdict; output: string };
+export type RejectedStageVerdict = { failureReason: string; output: string };
 
 export function stageVerdictFrom(value: unknown): StageVerdict | null {
   if (!value || typeof value !== "object" || Array.isArray(value)) return null;
@@ -33,7 +41,7 @@ export function stageVerdictFrom(value: unknown): StageVerdict | null {
   return verdict;
 }
 /** Completion authority is the final fenced JSON block in a completed turn. */
-export function parseStageVerdict(text: string): ParsedStageVerdict | null {
+export function parseStageVerdict(text: string): ParsedStageVerdict | RejectedStageVerdict | null {
   const matches = [...text.matchAll(/```(?:json)?\s*([\s\S]*?)```/gi)];
   const last = matches.at(-1);
   if (!last || last.index === undefined) return null;
@@ -47,5 +55,22 @@ export function parseStageVerdict(text: string): ParsedStageVerdict | null {
   }
   const verdict = stageVerdictFrom(raw);
   if (!verdict) return null;
-  return { verdict, output: text.slice(0, last.index).trim().slice(0, MAX_OUTPUT_CHARS) };
+  const prose = text.slice(0, last.index).trim();
+  const output = prose.slice(0, MAX_OUTPUT_CHARS);
+  if (verdict.status === "pass" && verdict.findings?.length) {
+    return {
+      failureReason: 'contradictory stage verdict: status "pass" cannot include findings',
+      output,
+    };
+  }
+  for (const match of prose.matchAll(PROSE_VERDICT_RE)) {
+    const marker = (match[1] ?? match[2])!.toUpperCase() as keyof typeof PROSE_VERDICT_STATUSES;
+    if (PROSE_VERDICT_STATUSES[marker] !== verdict.status) {
+      return {
+        failureReason: `contradictory stage verdict: prose marker "${marker}" disagrees with JSON status "${verdict.status}"`,
+        output,
+      };
+    }
+  }
+  return { verdict, output };
 }

--- a/src/lib/pipelines/verdict.ts
+++ b/src/lib/pipelines/verdict.ts
@@ -10,7 +10,28 @@ const PROSE_VERDICT_STATUSES = {
   COMMENT: "needs_decision",
   "NO FINDINGS": "pass",
 } as const satisfies Record<string, StageVerdict["status"]>;
-const PROSE_VERDICT_RE = /^\s*(?:VERDICT:\s*(APPROVE|REQUEST_CHANGES|COMMENT)|(NO FINDINGS))\s*$/gim;
+const PROSE_VERDICT_LINE_RE = /^\s*(?:VERDICT:\s*(APPROVE|REQUEST_CHANGES|COMMENT)|(NO FINDINGS))\s*$/i;
+
+type ProseVerdictMarker = keyof typeof PROSE_VERDICT_STATUSES;
+
+function proseVerdictMarkers(prose: string): ProseVerdictMarker[] {
+  const markers: ProseVerdictMarker[] = [];
+  let fence: { marker: "`" | "~"; length: number } | null = null;
+  for (const line of prose.split(/\r?\n/)) {
+    const fenceMatch = /^\s*(`{3,}|~{3,})(.*)$/.exec(line);
+    if (fenceMatch) {
+      const token = fenceMatch[1]!;
+      const marker = token[0] as "`" | "~";
+      if (!fence) fence = { marker, length: token.length };
+      else if (fence.marker === marker && token.length >= fence.length && !fenceMatch[2]!.trim()) fence = null;
+      continue;
+    }
+    if (fence || /^\s*>/.test(line)) continue;
+    const match = PROSE_VERDICT_LINE_RE.exec(line);
+    if (match) markers.push((match[1] ?? match[2])!.toUpperCase() as ProseVerdictMarker);
+  }
+  return markers;
+}
 
 export type ParsedStageVerdict = { verdict: StageVerdict; output: string };
 export type RejectedStageVerdict = { failureReason: string; output: string };
@@ -63,8 +84,7 @@ export function parseStageVerdict(text: string): ParsedStageVerdict | RejectedSt
       output,
     };
   }
-  for (const match of prose.matchAll(PROSE_VERDICT_RE)) {
-    const marker = (match[1] ?? match[2])!.toUpperCase() as keyof typeof PROSE_VERDICT_STATUSES;
+  for (const marker of proseVerdictMarkers(prose)) {
     if (PROSE_VERDICT_STATUSES[marker] !== verdict.status) {
       return {
         failureReason: `contradictory stage verdict: prose marker "${marker}" disagrees with JSON status "${verdict.status}"`,


### PR DESCRIPTION
## Summary

- reject structured review results that combine a passing status with findings
- detect disagreement between prose verdict markers and fenced JSON
- preserve actionable findings across retry and recovery paths
- strengthen parser, engine, restart, and projection regression coverage

## Verification

- 128 pipeline-focused tests pass
- TypeScript check passes
- scoped lint passes
- two independent exact-SHA review stages approved `a47d4b353c4a6ed41aaca4743f7e36e2c82de912`

Closes #425
