### PR TITLE
chore(spawn): raise live-child cap per caller from 3 to 20

### DIFF
--- a/src/app/api/spawn/admission.ts
+++ b/src/app/api/spawn/admission.ts
@@ -6,7 +6,7 @@ import type { AgentRegistry } from "@/lib/agent/registry";
 import { matchesOperatorSpawnCapability, OperatorSpawnCapabilityError } from "@/lib/agent/operatorCapability";
 import { VIEWER_SPAWN_CAPABILITY_HEADER, VIEWER_SPAWN_ENDPOINT } from "@/lib/agent/spawnPolicy";
 
-export const AGENT_SPAWN_LIVE_CHILD_CAP = 3;
+export const AGENT_SPAWN_LIVE_CHILD_CAP = 20;
 export const AGENT_SPAWN_LINEAGE_ERROR = `Agent-initiated spawns require role; reviewer spawns also require reviews (the implementer conversation or transcript). The parent is inferred from the authenticated caller conversation; src stays optional verification. POST ${VIEWER_SPAWN_ENDPOINT} with {engine, model, cwd, prompt, role, src?, reviews?}.`;
 
 export type AuthenticatedSpawnCaller =

--- a/src/app/api/spawn/route.test.ts
+++ b/src/app/api/spawn/route.test.ts
@@ -737,7 +737,7 @@ test("agent capability binds src to the caller conversation", () => {
   expect(authenticatedAgentSpawnCaller(request, callerPath, store)).toEqual({
     kind: "agent",
     conversationId: begun.receipt.conversationId,
-    liveChildrenCap: 3,
+    liveChildrenCap: 20,
   });
 
   const other = store.ensureConversation("codex", "/sessions/other.jsonl", "terra");
@@ -800,7 +800,7 @@ test("operator capability file failures preserve agent admission and reject unkn
     expect(authenticatedAgentSpawnCaller(request(capability), callerPath, store)).toEqual({
       kind: "agent",
       conversationId: begun.receipt.conversationId,
-      liveChildrenCap: 3,
+      liveChildrenCap: 20,
     });
     expect(authenticatedAgentSpawnCaller(request("C".repeat(43)), "/caller.jsonl", store)).toEqual({
       error: expect.stringContaining("capability read failed"),


### PR DESCRIPTION
One-line policy bump: `AGENT_SPAWN_LIVE_CHILD_CAP` 3 → 20 (+ test literals).

Rationale: an orchestrating conversation fanning out parallel builders/reviewers hits the cap of 3 immediately — today six pipelines forced external reviewer spawns to queue for slots. 20 keeps a sane runaway guard while allowing real parallelism.

Gates: spawn route tests 34/34, TypeScript clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)