### PR TITLE
Fix bounded mobile map framing and attachment test stability

### DIFF
--- a/src/components/imageAttachments.progressive.dom.test.tsx
+++ b/src/components/imageAttachments.progressive.dom.test.tsx
@@ -1,5 +1,6 @@
 import { afterAll, afterEach, beforeAll, beforeEach, expect, test } from "bun:test";
 import { Window } from "happy-dom";
+import { act } from "react";
 import { flushSync } from "react-dom";
 import { createRoot, type Root } from "react-dom/client";
 
@@ -58,6 +59,20 @@ const SAVED: Record<string, unknown> = {};
 
 /* Reads resolve on a microtask, so let the promise `.then` and React's flush run. */
 const tick = async () => { await Promise.resolve(); await new Promise((resolve) => setTimeout(resolve, 0)); };
+const waitFor = async (condition: () => boolean, timeoutMs = 1000): Promise<void> => {
+  const previousActEnvironment = G.IS_REACT_ACT_ENVIRONMENT;
+  G.IS_REACT_ACT_ENVIRONMENT = true;
+  const deadline = Date.now() + timeoutMs;
+  try {
+    while (!condition()) {
+      if (Date.now() >= deadline) throw new Error("timed out waiting for React state to settle");
+      await act(tick);
+    }
+  } finally {
+    if (previousActEnvironment === undefined) delete G.IS_REACT_ACT_ENVIRONMENT;
+    else G.IS_REACT_ACT_ENVIRONMENT = previousActEnvironment;
+  }
+};
 
 const captured: { api: UseImageAttachmentsReturn | null; errors: string[] } = { api: null, errors: [] };
 const api = () => captured.api!;
@@ -114,7 +129,7 @@ test("each read settles independently — a slow file never blocks its siblings"
   expect(statusesOf()).toEqual(["reading", "ready"]);
   expect(api().images.map((image) => image.base64)).toEqual(["ZmFzdA=="]);
   DeferredReader.take("slow.png").resolve("data:image/png;base64,c2xvdw==");
-  await tick();
+  await waitFor(() => statusesOf().join() === "ready,ready");
   expect(statusesOf()).toEqual(["ready", "ready"]);
   /* Ready projection preserves selection order regardless of settle order. */
   expect(api().images.map((image) => image.base64)).toEqual(["c2xvdw==", "ZmFzdA=="]);

--- a/src/components/mobile/MobileMapLite.dom.test.tsx
+++ b/src/components/mobile/MobileMapLite.dom.test.tsx
@@ -18,6 +18,7 @@ const OVERRIDES: Record<string, unknown> = {
   HTMLElement: dom.HTMLElement,
   Event: dom.Event,
   MouseEvent: dom.MouseEvent,
+  WheelEvent: dom.WheelEvent,
   sessionStorage: dom.sessionStorage,
   localStorage: dom.localStorage,
   matchMedia: (q: string) => ({ matches: /max-width/.test(String(q)), media: String(q), onchange: null, addEventListener() {}, removeEventListener() {}, addListener() {}, removeListener() {}, dispatchEvent() { return false; } }),
@@ -111,4 +112,106 @@ test("all framing consumes the negative world origin", async () => {
 
   const marker = dom.document.querySelector(`[data-map-key="${node.file.path}"]`) as unknown as HTMLElement;
   expect(Number.parseFloat(marker.style.left)).toBeCloseTo(28, 5);
+});
+
+test("all framing fits negative, distant, and clustered bounds while wheel zoom stays continuous", async () => {
+  const source = buildMobileMapFixture(500);
+  source.layout.nodes[0]!.x = -1_200;
+  source.layout.nodes[0]!.y = -800;
+  source.layout.nodes[399]!.x = source.layout.width + 20_000;
+  source.layout.nodes[400]!.x = source.layout.width + 60_000;
+  source.layout.nodes[400]!.y = source.layout.height + 30_000;
+
+  mount(<MobileMapLite layout={source.layout} tasks={source.tasks} workerStacks={source.workerStacks} frame="all" ringKey={null} onPick={() => {}} />);
+  await settle();
+
+  const map = dom.document.querySelector('[data-testid="mobile-map"]') as unknown as HTMLElement;
+  const markers = [...dom.document.querySelectorAll('[data-testid="mobile-map-marker"]')] as unknown as HTMLElement[];
+  const clusters = [...dom.document.querySelectorAll('[data-testid="mobile-map-cluster"]')] as unknown as HTMLElement[];
+  expect(markers).toHaveLength(400);
+  expect(clusters.length).toBeGreaterThan(0);
+
+  for (const element of [...markers, ...clusters]) {
+    const left = Number.parseFloat(element.style.left);
+    const top = Number.parseFloat(element.style.top);
+    const width = element.dataset.testid === "mobile-map-marker" ? Number.parseFloat(element.style.width) : 40;
+    const height = element.dataset.testid === "mobile-map-marker" ? Number.parseFloat(element.style.height) : 40;
+    expect(left).toBeGreaterThanOrEqual(0);
+    expect(top).toBeGreaterThanOrEqual(0);
+    expect(left + width).toBeLessThanOrEqual(390);
+    expect(top + height).toBeLessThanOrEqual(620);
+  }
+  expect(markers.every((marker) => Number.parseFloat(marker.style.width) >= 40 && Number.parseFloat(marker.style.height) >= 40)).toBe(true);
+
+  const negativeMarker = dom.document.querySelector(`[data-map-key="${source.layout.nodes[0]!.file.path}"]`) as unknown as HTMLElement;
+  const leftBeforeZoom = Number.parseFloat(negativeMarker.style.left);
+  const zoomIn = new dom.WheelEvent("wheel", { bubbles: true, deltaY: -100 });
+  Object.defineProperties(zoomIn, { clientX: { value: 195 }, clientY: { value: 310 } });
+  flushSync(() => map.dispatchEvent(zoomIn as unknown as Event));
+  await settle();
+  const leftAfterZoomIn = Number.parseFloat(negativeMarker.style.left);
+  expect(leftAfterZoomIn).toBeLessThan(leftBeforeZoom);
+  expect(Math.abs(leftAfterZoomIn - leftBeforeZoom)).toBeLessThan(100);
+
+  const zoomOut = new dom.WheelEvent("wheel", { bubbles: true, deltaY: 100 });
+  Object.defineProperties(zoomOut, { clientX: { value: 195 }, clientY: { value: 310 } });
+  flushSync(() => map.dispatchEvent(zoomOut as unknown as Event));
+  await settle();
+  expect(Number.parseFloat(negativeMarker.style.left)).toBeCloseTo(leftBeforeZoom, 5);
+});
+
+test("current framing centers the retained focus marker at interactive scale", async () => {
+  const source = buildMobileMapFixture(500);
+  const focused = source.layout.nodes[450]!;
+  mount(
+    <MobileMapLite
+      layout={source.layout}
+      tasks={source.tasks}
+      workerStacks={source.workerStacks}
+      frame="current"
+      ringKey={focused.file.path}
+      onPick={() => {}}
+    />,
+  );
+  await settle();
+
+  const marker = dom.document.querySelector(`[data-map-key="${focused.file.path}"]`) as unknown as HTMLElement;
+  const left = Number.parseFloat(marker.style.left);
+  const top = Number.parseFloat(marker.style.top);
+  const width = Number.parseFloat(marker.style.width);
+  const height = Number.parseFloat(marker.style.height);
+  expect(left + width / 2).toBeCloseTo(195, 5);
+  expect(top + height / 2).toBeCloseTo(310, 5);
+  expect({ width, height }).toEqual({ width: focused.w, height: focused.h });
+});
+
+test("current framing without a ring keeps the fitted fallback gesture floor", async () => {
+  const source = buildMobileMapFixture(8);
+  const leftNode = { ...source.layout.nodes[0]!, x: -5_000 };
+  const rightNode = { ...source.layout.nodes[1]!, x: 5_000 };
+  const layout = {
+    ...source.layout,
+    nodes: [leftNode, rightNode],
+    edges: [],
+    stacks: [],
+    decks: [],
+    drafts: [],
+    byPath: new Map([[leftNode.file.path, leftNode], [rightNode.file.path, rightNode]]),
+    width: 1,
+    height: 1,
+  };
+  mount(<MobileMapLite layout={layout} tasks={[]} workerStacks={[]} frame="current" ringKey={null} onPick={() => {}} />);
+  await settle();
+
+  const map = dom.document.querySelector('[data-testid="mobile-map"]') as unknown as HTMLElement;
+  const marker = dom.document.querySelector(`[data-map-key="${leftNode.file.path}"]`) as unknown as HTMLElement;
+  const leftBeforeZoom = Number.parseFloat(marker.style.left);
+  const zoomIn = new dom.WheelEvent("wheel", { bubbles: true, deltaY: -100 });
+  Object.defineProperties(zoomIn, { clientX: { value: 195 }, clientY: { value: 310 } });
+  flushSync(() => map.dispatchEvent(zoomIn as unknown as Event));
+  await settle();
+
+  const leftAfterZoom = Number.parseFloat(marker.style.left);
+  expect(leftAfterZoom).toBeLessThan(leftBeforeZoom);
+  expect(Math.abs(leftAfterZoom - leftBeforeZoom)).toBeLessThan(100);
 });

--- a/src/components/mobile/MobileMapLite.tsx
+++ b/src/components/mobile/MobileMapLite.tsx
@@ -13,6 +13,7 @@ import { buildMobileMapModel, type MapMarker, type MapRect, type MobileMapModel 
 const Z_MIN = 0.15;
 const Z_MAX = 1.6;
 const FIT_PAD = 28;
+const MARKER_MIN_SIZE = 40;
 const DEFAULT_VIEWPORT = { w: 390, h: 620 };
 
 interface Camera {
@@ -33,8 +34,18 @@ function frameRect(rect: { x: number; y: number; w: number; h: number }, viewpor
 }
 
 function fitAll(world: MapRect, viewport: { w: number; h: number }): Camera {
-  const z = clamp(Math.min((viewport.w - FIT_PAD * 2) / world.w, (viewport.h - FIT_PAD * 2) / world.h), Z_MIN, Z_MAX);
-  return frameRect(world, viewport, z);
+  /* Anchored marker buttons retain a 40px footprint at distant zoom levels.
+     Reserve that footprint and allow All below the regular interaction floor. */
+  const availableW = Math.max(viewport.w - FIT_PAD * 2 - MARKER_MIN_SIZE, 1);
+  const availableH = Math.max(viewport.h - FIT_PAD * 2 - MARKER_MIN_SIZE, 1);
+  const z = Math.min(availableW / world.w, availableH / world.h, Z_MAX);
+  const renderedW = world.w * z + MARKER_MIN_SIZE;
+  const renderedH = world.h * z + MARKER_MIN_SIZE;
+  return {
+    z,
+    tx: FIT_PAD + (viewport.w - FIT_PAD * 2 - renderedW) / 2 - world.x * z,
+    ty: FIT_PAD + (viewport.h - FIT_PAD * 2 - renderedH) / 2 - world.y * z,
+  };
 }
 
 /**
@@ -65,6 +76,8 @@ export function MobileMapLite({
   /* The ring key rides into the model so the focused marker is never folded
      into a cluster past the cap (PR #431) — `ringRect` below must resolve. */
   const model = useMemo<MobileMapModel>(() => buildMobileMapModel(layout, tasks, workerStacks, ringKey), [layout, tasks, workerStacks, ringKey]);
+  const ringRect = useMemo(() => model.markers.find((marker) => marker.key === ringKey)?.rect ?? null, [model.markers, ringKey]);
+  const currentRect = frame === "current" ? ringRect : null;
 
   const surfaceRef = useRef<HTMLDivElement>(null);
   const [viewport, setViewport] = useState(DEFAULT_VIEWPORT);
@@ -73,6 +86,8 @@ export function MobileMapLite({
      even on the largest board. */
   const [ready, setReady] = useState(false);
   const [camera, setCamera] = useState<Camera>(() => fitAll(model.world, DEFAULT_VIEWPORT));
+  const allCamera = useMemo(() => fitAll(model.world, viewport), [model.world, viewport]);
+  const gestureMinZoom = currentRect ? Z_MIN : Math.min(Z_MIN, allCamera.z);
 
   /* Measure the surface (default viewport keeps SSR/tests stable) and reframe. */
   useEffect(() => {
@@ -101,17 +116,16 @@ export function MobileMapLite({
 
   /* Reframe when the frame toggle, the ring, or the measured viewport changes —
      never mid-gesture (the deps exclude camera). */
-  const ringRect = useMemo(() => model.markers.find((marker) => marker.key === ringKey)?.rect ?? null, [model.markers, ringKey]);
   /* Reframe the camera when the frame toggle, ring, viewport, or world changes —
      never mid-gesture (the deps exclude camera). */
   /* eslint-disable react-hooks/set-state-in-effect */
   useEffect(() => {
-    if (frame === "current" && ringRect) {
-      setCamera(frameRect(ringRect, viewport, clamp(1, Z_MIN, Z_MAX)));
+    if (currentRect) {
+      setCamera(frameRect(currentRect, viewport, clamp(1, Z_MIN, Z_MAX)));
     } else {
-      setCamera(fitAll(model.world, viewport));
+      setCamera(allCamera);
     }
-  }, [frame, ringRect, viewport, model.world]);
+  }, [currentRect, viewport, allCamera]);
   /* eslint-enable react-hooks/set-state-in-effect */
 
   /* Pointer pan + pinch/wheel zoom, all clamped. Pointer math only — no camera
@@ -133,7 +147,7 @@ export function MobileMapLite({
       const dist = Math.hypot(a!.x - b!.x, a!.y - b!.y);
       if (!pinch.current) pinch.current = { dist, z: camera.z };
       else if (pinch.current.dist > 0) {
-        const z = clamp(pinch.current.z * (dist / pinch.current.dist), Z_MIN, Z_MAX);
+        const z = clamp(pinch.current.z * (dist / pinch.current.dist), gestureMinZoom, Z_MAX);
         setCamera((cam) => ({ ...cam, z }));
       }
       return;
@@ -147,7 +161,7 @@ export function MobileMapLite({
   const onWheel = (event: React.WheelEvent) => {
     const factor = Math.exp(-event.deltaY * 0.0015);
     setCamera((cam) => {
-      const z = clamp(cam.z * factor, Z_MIN, Z_MAX);
+      const z = clamp(cam.z * factor, gestureMinZoom, Z_MAX);
       /* Zoom about the pointer so the point under the cursor stays put. */
       const rect = surfaceRef.current?.getBoundingClientRect();
       const px = rect ? event.clientX - rect.left : viewport.w / 2;
@@ -215,8 +229,8 @@ function Marker({ marker, camera, active, onPick }: { marker: MapMarker; camera:
   const { t } = useLocale();
   const left = marker.rect.x * camera.z + camera.tx;
   const top = marker.rect.y * camera.z + camera.ty;
-  const width = Math.max(marker.rect.w * camera.z, 40);
-  const height = Math.max(marker.rect.h * camera.z, 40);
+  const width = Math.max(marker.rect.w * camera.z, MARKER_MIN_SIZE);
+  const height = Math.max(marker.rect.h * camera.z, MARKER_MIN_SIZE);
   const badge = marker.file ? engineBadge(marker.file) : null;
   const label = marker.title || t(`mobile.marker.${marker.kind}`);
   const disabled = marker.pickKey === null;
@@ -232,7 +246,7 @@ function Marker({ marker, camera, active, onPick }: { marker: MapMarker; camera:
       className={`absolute flex flex-col justify-center gap-0.5 overflow-hidden rounded-[8px] border px-1.5 text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 ${
         active ? "border-accent bg-accent/10" : marker.kind === "draft" ? "border-dashed border-border bg-canvas" : "border-border bg-card"
       } ${disabled ? "opacity-60" : ""}`}
-      style={{ left, top, width, height, minWidth: 40, minHeight: 40 }}
+      style={{ left, top, width, height, minWidth: MARKER_MIN_SIZE, minHeight: MARKER_MIN_SIZE }}
     >
       <span className="flex items-center gap-1">
         {marker.file ? <span className={`h-1.5 w-1.5 shrink-0 rounded-full ${activityDot(marker.file.activity)}`} aria-hidden /> : null}

--- a/src/components/mobile/mobileMapModel.test.ts
+++ b/src/components/mobile/mobileMapModel.test.ts
@@ -90,6 +90,31 @@ test("lineage edges only connect kept markers — no dangling endpoint into a cl
   }
 });
 
+test("focus retention keeps lineage only when both endpoint markers remain visible", () => {
+  const { layout, tasks, workerStacks } = buildMobileMapFixture(500);
+  const visibleSource = layout.nodes[0]!;
+  const clusteredSource = layout.nodes[MAP_MARKER_CAP - 1]!;
+  const focusedDestination = layout.nodes[450]!;
+  const edgeFrom = (source: typeof visibleSource) => ({
+    to: focusedDestination.file.path,
+    x1: source.x + 40,
+    y1: source.y + source.h,
+    x2: focusedDestination.x + focusedDestination.w / 2,
+    y2: focusedDestination.y,
+    color: "#888",
+    live: false,
+  });
+  const visibleEdge = edgeFrom(visibleSource);
+  layout.edges = [edgeFrom(clusteredSource), visibleEdge];
+
+  const model = buildMobileMapModel(layout, tasks, workerStacks, focusedDestination.file.path);
+  const visibleKeys = new Set(model.markers.map((marker) => marker.key));
+  expect(visibleKeys.has(visibleSource.file.path)).toBe(true);
+  expect(visibleKeys.has(clusteredSource.file.path)).toBe(false);
+  expect(visibleKeys.has(focusedDestination.file.path)).toBe(true);
+  expect(model.edges).toEqual([{ x1: visibleEdge.x1, y1: visibleEdge.y1, x2: visibleEdge.x2, y2: visibleEdge.y2 }]);
+});
+
 test("all-frame bounds span negative and distant markers plus overflow clusters", () => {
   const { layout, tasks, workerStacks } = buildMobileMapFixture(500);
   layout.nodes[0]!.x = -1_200;

--- a/src/components/mobile/mobileMapModel.ts
+++ b/src/components/mobile/mobileMapModel.ts
@@ -202,12 +202,14 @@ export function buildMobileMapModel(
   }
   const clusters = clusterOverflow(overflow);
 
-  /* Parent lineage only, one path each — resolved against markers so a dangling
-     endpoint (an edge into a clustered node) is dropped rather than drawn. */
+  /* Parent lineage only, one path each. Clustering either endpoint removes the
+     connector, so every retained edge terminates at two visible markers. */
   const kept = new Set(markers.map((marker) => marker.key));
+  const visibleSources = markers.filter((marker) => marker.kind === "node").map((marker) => marker.rect);
   const edges: MapEdge[] = [];
   for (const edge of layout.edges) {
     if (!kept.has(edge.to)) continue;
+    if (!visibleSources.some((rect) => pointInRect(rect, edge.x1, edge.y1))) continue;
     edges.push({ x1: edge.x1, y1: edge.y1, x2: edge.x2, y2: edge.y2 });
     if (edges.length >= MAP_MARKER_CAP) break;
   }
@@ -229,6 +231,10 @@ export function buildMobileMapModel(
     world: { x: left, y: top, w: Math.max(right - left, 1), h: Math.max(bottom - top, 1) },
     total: candidates.length,
   };
+}
+
+function pointInRect(rect: MapRect, x: number, y: number): boolean {
+  return x >= rect.x && x <= rect.x + rect.w && y >= rect.y && y <= rect.y + rect.h;
 }
 
 function bandRow(count: number, worldW: number): number {


### PR DESCRIPTION
Closes #433.

## Summary

- bound the mobile lite-map camera using retained markers, cluster bounds, and retained lineage endpoints
- preserve focused markers while capping large-board DOM size
- cover negative and distant coordinates across 390px and desktop viewports
- replace the progressive attachment test's fixed scheduler tick with a condition-based React-aware wait

## Verification

- `bun test src/components/imageAttachments.progressive.dom.test.tsx src/components/mobile/MobileMapLite.dom.test.tsx src/components/mobile/mobileMapModel.test.ts` — 22 passed, 2046 assertions
- progressive attachment suite repeated 50 times — 300 passed, 1350 assertions
- `bunx tsc --noEmit`
- changed-file ESLint
- `git diff --check origin/main...HEAD`
- `bun run build`
- independent review: `NO FINDINGS`, confidence 0.94

## Review evidence

The reviewer validated a 1440x900 surface, the committed 390px regression, all 400 retained markers, both overflow clusters, merge safety against current `origin/main`, and exact equivalence of the bounded-map implementation.
