### PR TITLE
fix(pipelines): bind review flows to durable attempts

### DIFF
--- a/src/lib/flows/commands.durable.test.ts
+++ b/src/lib/flows/commands.durable.test.ts
@@ -1,0 +1,52 @@
+import { afterAll, expect, test } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const previousStateDir = process.env.LLV_STATE_DIR;
+const sandbox = fs.mkdtempSync(path.join(os.tmpdir(), "llv-flow-durable-create-"));
+process.env.LLV_STATE_DIR = sandbox;
+
+const { AgentRegistry, setAgentRegistryForTests } = await import("@/lib/agent/registry");
+const { createFlowFromRequest } = await import("./commands");
+const { saveFlows } = await import("./store");
+
+const registry = new AgentRegistry(path.join(sandbox, "registry.json"), undefined, undefined, { sqliteMode: "off" });
+setAgentRegistryForTests(registry);
+
+afterAll(() => {
+  setAgentRegistryForTests(null);
+  if (previousStateDir === undefined) delete process.env.LLV_STATE_DIR;
+  else process.env.LLV_STATE_DIR = previousStateDir;
+  fs.rmSync(sandbox, { recursive: true, force: true });
+});
+
+test("durable implementer identity creates a flow without scanner or live-host evidence", async () => {
+  saveFlows([]);
+  const transcript = path.join(import.meta.dir, "fixtures", "codex-review-2026-07-12.jsonl");
+  const implementer = registry.ensureConversation("codex", transcript, null);
+
+  const result = await createFlowFromRequest({
+    implementerPath: transcript,
+    implementerConversationId: implementer.id,
+    deliverKickoff: false,
+    roles: {
+      implementer: { engine: "codex", model: "gpt-5.6-sol", effort: "high" },
+      reviewer: { engine: "codex", model: "gpt-5.6-sol", effort: "high" },
+    },
+    baseMode: "head",
+    baseRef: "12ad73656844d3583d44ae718d003c7f2f2c6ace",
+    mode: "auto",
+    reviewerMode: "headless",
+    roundLimit: 5,
+  }, []);
+
+  expect(result.error).toBeUndefined();
+  expect(result.flow).toMatchObject({
+    cwd: "/repo",
+    implementerPath: transcript,
+    implementerConversationId: implementer.id,
+    kickoffDelivery: null,
+    state: "waiting_ready",
+  });
+});

--- a/src/lib/flows/commands.ts
+++ b/src/lib/flows/commands.ts
@@ -1,10 +1,12 @@
 import crypto from "node:crypto";
+import path from "node:path";
 
 import { isEngineEffort } from "@/lib/agent/efforts";
 import { isCodexLaunchModel, normalizeClaudeLaunchModel } from "@/lib/agent/models";
 import { agentRegistry } from "@/lib/agent/registry";
 import { headCwd } from "@/lib/agent/transcript";
 import { livePaneTarget } from "@/lib/delivery";
+import { projectForCwd } from "@/lib/scanner/describe";
 import { isShellCommand } from "@/lib/status";
 import { killPane, paneInfo } from "@/lib/tmux";
 import type { FileEntry } from "@/lib/types";
@@ -88,42 +90,67 @@ export function normalizeFlowSpec(value: unknown): { ok: true; spec?: string } |
 }
 
 export async function createFlowFromRequest(req: CreateFlowRequest, entries: FileEntry[]): Promise<{ flow?: Flow; error?: string; status?: number }> {
-  const entry = entries.find((item) => item.path === req.implementerPath);
-  if (!entry) return { error: "implementer transcript is unknown", status: 404 };
-  if (entry.root !== "claude-projects" && entry.root !== "codex-sessions") {
-    return { error: "implementer must be a Claude or Codex session", status: 400 };
-  }
-  if (entry.engine !== "claude" && entry.engine !== "codex") {
-    return { error: "implementer must use the Claude or Codex engine", status: 400 };
-  }
   const normalizedSpec = normalizeFlowSpec(req.spec);
   if (!normalizedSpec.ok) {
     return { error: "spec must be a string", status: 400 };
   }
   const roles = rolesFromRequest(req);
   if (!roles) return { error: "invalid flow roles or preset", status: 400 };
-  const baseMode = req.baseMode === "merge-base" ? "merge-base" : "head";
-  const cwd = headCwd(entry.path);
+  const registry = agentRegistry();
+  const requestedConversationId = req.implementerConversationId?.startsWith("conversation_")
+    ? req.implementerConversationId as `conversation_${string}`
+    : null;
+  if (req.implementerConversationId && !requestedConversationId) {
+    return { error: "implementer conversation identity is invalid", status: 400 };
+  }
+  const durableConversation = requestedConversationId ? registry.conversation(requestedConversationId) : null;
+  const scannedByPath = entries.find((item) => item.path === req.implementerPath);
+  const scannedByConversation = requestedConversationId
+    ? entries.find((item) => item.conversationId === requestedConversationId)
+    : undefined;
+  const durablePaths = requestedConversationId
+    ? [req.implementerPath, durableConversation?.generations.at(-1)?.path, scannedByConversation?.path]
+    : [];
+  const durablePath = [...new Set(durablePaths.filter((candidate): candidate is string => Boolean(candidate)))]
+    .find((candidate) => headCwd(candidate) !== null);
+  const resolvedPath = durablePath ?? scannedByPath?.path ?? null;
+  const scanned = resolvedPath
+    ? entries.find((item) => item.path === resolvedPath) ?? scannedByConversation
+    : undefined;
+  if (!resolvedPath) return { error: "implementer transcript is unknown", status: 404 };
+  const owner = durableConversation
+    ?? registry.conversationForPath(resolvedPath)
+    ?? registry.ensureConversation(roles.implementer.engine, resolvedPath, null);
+  if (owner.engine !== roles.implementer.engine) {
+    return { error: "implementer engine does not match its durable conversation", status: 400 };
+  }
+  if (scanned && scanned.root !== "claude-projects" && scanned.root !== "codex-sessions") {
+    return { error: "implementer must be a Claude or Codex session", status: 400 };
+  }
+  if (scanned && scanned.engine !== "claude" && scanned.engine !== "codex") {
+    return { error: "implementer must use the Claude or Codex engine", status: 400 };
+  }
+  const cwd = headCwd(resolvedPath);
   if (!cwd) return { error: "could not determine the session working directory", status: 409 };
+  const project = scanned?.project ?? projectForCwd(cwd) ?? path.basename(cwd);
+  const baseMode = req.baseMode === "merge-base" ? "merge-base" : "head";
   const base =
     typeof req.baseRef === "string" && req.baseRef.trim()
       ? { ok: true as const, sha: req.baseRef.trim() }
       : resolveBaseRef(cwd, baseMode);
   if (!base.ok) return { error: base.error, status: 409 };
   const flows = loadFlows();
-  const existing = flows.find((flow) => flow.implementerPath === entry.path && flow.closedAt === null && flow.state !== "closed");
+  const existing = flows.find((flow) =>
+    (flow.implementerConversationId === owner.id || flow.implementerPath === resolvedPath)
+    && flow.closedAt === null
+    && flow.state !== "closed");
   if (existing) return { error: "implementer already has an active flow", status: 409 };
-  const registry = agentRegistry();
-  const implementerConversation = entry.conversationId?.startsWith("conversation_")
-    ? registry.conversation(entry.conversationId as `conversation_${string}`)
-    : null;
-  const owner = implementerConversation ?? registry.ensureConversation(entry.engine, entry.path, null);
   const flow: Flow = {
     id: crypto.randomUUID().slice(0, 8),
     template: "implement-review-loop",
-    project: entry.project,
+    project,
     cwd,
-    implementerPath: entry.path,
+    implementerPath: resolvedPath,
     implementerConversationId: owner.id,
     roles,
     reviewerFallback: roles.reviewer.engine === "codex" ? configuredReviewerFallback() : null,
@@ -157,15 +184,17 @@ export async function createFlowFromRequest(req: CreateFlowRequest, entries: Fil
   });
   flows.push(flow);
   saveFlows(flows);
-  try {
-    const deliveryPath = await sendToImplementer(flow, new Map(entries.map((item) => [item.path, item])), kickoffPrompt(flow.spec));
-    flow.kickoffDelivery = { path: deliveryPath, deliveredAt: isoNow() };
-    saveFlows(flows);
-  } catch (error) {
-    flow.state = "paused";
-    flow.pausedState = "waiting_ready";
-    flow.stateDetail = error instanceof Error ? error.message : String(error);
-    saveFlows(flows);
+  if (req.deliverKickoff !== false) {
+    try {
+      const deliveryPath = await sendToImplementer(flow, new Map(entries.map((item) => [item.path, item])), kickoffPrompt(flow.spec));
+      flow.kickoffDelivery = { path: deliveryPath, deliveredAt: isoNow() };
+      saveFlows(flows);
+    } catch (error) {
+      flow.state = "paused";
+      flow.pausedState = "waiting_ready";
+      flow.stateDetail = error instanceof Error ? error.message : String(error);
+      saveFlows(flows);
+    }
   }
   return { flow };
 }

--- a/src/lib/flows/types.ts
+++ b/src/lib/flows/types.ts
@@ -160,6 +160,12 @@ export type FlowPreset = {
 
 export type CreateFlowRequest = {
   implementerPath: string;
+  /** Stable Viewer identity supplied by durable controllers when the current
+      scanner slice does not contain the implementer transcript. */
+  implementerConversationId?: string;
+  /** Live implement-review flows deliver their kickoff to the implementer.
+      Terminal pipeline stages start review directly through advance. */
+  deliverKickoff?: boolean;
   preset?: string; // preset name; mutually exclusive with roles
   roles?: Record<FlowRoleKey, RoleConfig>;
   baseMode: "head" | "merge-base";

--- a/src/lib/pipelines/engine.test.ts
+++ b/src/lib/pipelines/engine.test.ts
@@ -1081,6 +1081,52 @@ test("review-loop stage delegates to one regular flow and maps approval", async 
   expect(loadPipelines()[0]!.runs[1]!.attempts[0]!.verdict).toEqual({ status: "pass", confidence: 1 });
 });
 
+test("pipeline 8fa12bb4 creates review flow from a terminal builder's durable identity with an empty scanner slice", async () => {
+  const h = harness();
+  h.ports.spawnAgent = async (_input, onReserved) => {
+    onReserved({ launchId: "launch-1", conversationId: "conversation_stage_1" });
+    return {
+      launchId: "launch-1",
+      conversationId: "conversation_stage_1",
+      sessionId: "session-1",
+      transcript: "/codex/stage-1.jsonl",
+      paneId: null,
+    };
+  };
+  const createFlow = h.ports.createFlow;
+  h.ports.createFlow = async (req, entries) => {
+    const durableConversationId = (req as typeof req & { implementerConversationId?: string }).implementerConversationId;
+    if (!entries.some((candidate) => candidate.path === req.implementerPath) && !durableConversationId) {
+      return { error: "implementer transcript is unknown" };
+    }
+    h.calls.push(`flow-implementer:${durableConversationId ?? "scanner"}`);
+    return createFlow(req, entries);
+  };
+  h.setConversationActive(false);
+  const pipeline = await create(h.ports, [
+    { id: "build", kind: "run", role: { roleId: "builder" }, prompt: "build", next: "review" },
+    { id: "review", kind: "review-loop", role: { roleId: "reviewer" }, prompt: "review", next: null },
+  ] as never);
+
+  await tickPipelines([], h.ports);
+  await tickPipelines([], h.ports);
+  await tickPipelines([h.finish("/codex/stage-1.jsonl", "pass")], h.ports);
+  await tickPipelines([], h.ports);
+
+  const current = loadPipelines().find((candidate) => candidate.id === pipeline.id)!;
+  const build = current.runs.find((run) => run.stageId === "build")!.attempts[0]!;
+  const review = current.runs.find((run) => run.stageId === "review")!.attempts[0]!;
+  expect(build).toMatchObject({
+    state: "passed",
+    conversationId: "conversation_stage_1",
+    agentPath: "/codex/stage-1.jsonl",
+    paneId: null,
+  });
+  expect(current.stateDetail ?? "").not.toContain("implementer transcript is unknown");
+  expect(review.flowId).toBe("flow-1");
+  expect(h.calls).toContain("flow-implementer:conversation_stage_1");
+});
+
 test("retrying a parked review-loop appends a fresh attempt and flow", async () => {
   const h = harness();
   const stages = [
@@ -1101,6 +1147,102 @@ test("retrying a parked review-loop appends a fresh attempt and flow", async () 
   const reviewRun = loadPipelines()[0]!.runs[1]!;
   expect(reviewRun.attempts).toHaveLength(2);
   expect(reviewRun.attempts[1]!.flowId).toBe("flow-2");
+});
+
+test("retry-stage adopts a partially created flow and records its reviewer on the pipeline attempt", async () => {
+  const h = harness();
+  const stages = [
+    { id: "build", kind: "run", role: { roleId: "builder" }, prompt: "build", next: "review" },
+    { id: "review", kind: "review-loop", role: { roleId: "reviewer" }, prompt: "review", next: null },
+  ] as const;
+  const pipeline = await create(h.ports, stages as never);
+  const partial = {
+    id: "flow-partial",
+    implementerPath: "/codex/stage-1.jsonl",
+    implementerConversationId: "conversation_stage_1",
+    baseRef: ORIGIN_MAIN_SHA,
+    state: "reviewing",
+    rounds: [{
+      n: 1,
+      sessionId: "reviewer-session",
+      reviewerPath: "/codex/reviewer.jsonl",
+      reviewerConversationId: "conversation_reviewer",
+    }],
+    createdAt: new Date(1_005_000).toISOString(),
+    closedAt: null,
+  } as unknown as Flow;
+  let createCalls = 0;
+  h.ports.createFlow = async () => {
+    createCalls += 1;
+    if (createCalls === 1) {
+      h.flows.set(partial.id, partial);
+      return { error: "flow persistence completed before response transport failed" };
+    }
+    return { error: "implementer already has an active flow" };
+  };
+  h.ports.findFlow = (_implementerPath, stableIdentity) =>
+    h.flows.has(partial.id) && stableIdentity === "conversation_stage_1" ? partial : null;
+
+  await tickPipelines([], h.ports);
+  await tickPipelines([], h.ports);
+  await tickPipelines([h.finish("/codex/stage-1.jsonl", "pass")], h.ports);
+  await tickPipelines([], h.ports);
+  expect(loadPipelines()[0]!.stateDetail).toContain("response transport failed");
+
+  await patchPipeline(pipeline.id, { action: "retry-stage" }, h.ports);
+  await tickPipelines([], h.ports);
+
+  const reviewRun = loadPipelines()[0]!.runs.find((run) => run.stageId === "review")!;
+  expect(reviewRun.attempts).toHaveLength(2);
+  expect(reviewRun.attempts[1]).toMatchObject({
+    flowId: "flow-partial",
+    sessionId: "reviewer-session",
+    agentPath: "/codex/reviewer.jsonl",
+    conversationId: "conversation_reviewer",
+  });
+  expect(createCalls).toBe(1);
+});
+
+test("retry-stage recovers after the three identical pipeline 8fa12bb4 review creation failures", async () => {
+  const h = harness();
+  const stages = [
+    { id: "build", kind: "run", role: { roleId: "builder" }, prompt: "build", next: "review" },
+    { id: "review", kind: "review-loop", role: { roleId: "reviewer" }, prompt: "review", next: null },
+  ] as const;
+  const pipeline = await create(h.ports, stages as never);
+  const createFlow = h.ports.createFlow;
+  let causePresent = true;
+  h.ports.createFlow = async (req, entries) => {
+    if (causePresent || !req.implementerConversationId) {
+      return { error: "implementer transcript is unknown" };
+    }
+    return createFlow(req, entries);
+  };
+
+  await tickPipelines([], h.ports);
+  await tickPipelines([], h.ports);
+  await tickPipelines([h.finish("/codex/stage-1.jsonl", "pass")], h.ports);
+  await tickPipelines([], h.ports);
+  for (let retry = 0; retry < 2; retry += 1) {
+    await patchPipeline(pipeline.id, { action: "retry-stage" }, h.ports);
+    await tickPipelines([], h.ports);
+  }
+
+  const failed = loadPipelines()[0]!.runs.find((run) => run.stageId === "review")!.attempts;
+  expect(failed).toHaveLength(3);
+  expect(failed.map((attempt) => attempt.error)).toEqual([
+    "creating the review flow failed: implementer transcript is unknown",
+    "creating the review flow failed: implementer transcript is unknown",
+    "creating the review flow failed: implementer transcript is unknown",
+  ]);
+
+  causePresent = false;
+  await patchPipeline(pipeline.id, { action: "retry-stage" }, h.ports);
+  await tickPipelines([], h.ports);
+
+  const recovered = loadPipelines()[0]!.runs.find((run) => run.stageId === "review")!.attempts;
+  expect(recovered).toHaveLength(4);
+  expect(recovered[3]).toMatchObject({ state: "reviewing", flowId: "flow-1", error: null });
 });
 
 test("review-loop startup parks when advance fails", async () => {

--- a/src/lib/pipelines/engine.ts
+++ b/src/lib/pipelines/engine.ts
@@ -95,7 +95,7 @@ export interface PipelinePorts {
   patchFlow(id: string, action: "advance" | "pause" | "resume", note?: string): { error?: string; status?: number };
   closeFlow(id: string): Promise<unknown>;
   getFlow(id: string): Flow | null;
-  findFlow(implementerPath: string, baseRef: string, createdAfter: string): Flow | null;
+  findFlow(implementerPath: string, implementerConversationId: string | null, baseRef: string): Flow | null;
   projectForCwd(cwd: string): string | null;
   now(): string;
 }
@@ -287,8 +287,13 @@ export function defaultPipelinePorts(): PipelinePorts {
     patchFlow: (id, action, note) => patchFlow(id, { action, ...(note ? { note } : {}) }),
     closeFlow,
     getFlow: (id) => loadFlows().find((flow) => flow.id === id) ?? null,
-    findFlow: (implementerPath, baseRef, createdAfter) => loadFlows()
-      .filter((flow) => flow.implementerPath === implementerPath && flow.baseRef === baseRef && flow.createdAt >= createdAfter)
+    findFlow: (implementerPath, implementerConversationId, baseRef) => loadFlows()
+      .filter((flow) =>
+        flow.baseRef === baseRef
+        && flow.closedAt === null
+        && flow.state !== "closed"
+        && (flow.implementerPath === implementerPath
+          || Boolean(implementerConversationId && flow.implementerConversationId === implementerConversationId)))
       .sort((left, right) => right.createdAt.localeCompare(left.createdAt))[0] ?? null,
     projectForCwd,
     now: () => new Date().toISOString(),
@@ -463,6 +468,16 @@ function newAttempt(pipeline: Pipeline, stage: PipelineStage): PipelineStageAtte
   };
   run.attempts.push(attempt);
   return attempt;
+}
+
+function attachReviewFlowAttempt(attempt: PipelineStageAttempt, flow: Flow): void {
+  attempt.flowId = flow.id;
+  const round = flow.rounds.at(-1);
+  attempt.launchId = round?.launchId ?? attempt.launchId;
+  attempt.sessionId = round?.sessionId ?? attempt.sessionId;
+  attempt.agentPath = round?.reviewerPath ?? attempt.agentPath;
+  attempt.conversationId = round?.reviewerConversationId ?? attempt.conversationId;
+  attempt.paneId = round?.reviewerPane?.paneId ?? attempt.paneId;
 }
 
 /** Advance along the pass edge, persisting the relay record: the completed
@@ -845,9 +860,10 @@ async function tickReviewStage(
   setCursorState(pipeline, stage.id, "reviewing");
 
   if (!attempt.flowId) {
-    const existing = ports.findFlow(implementer.agentPath, pipeline.baseRef, attempt.startedAt);
+    const existing = ports.findFlow(implementer.agentPath, implementer.conversationId, pipeline.baseRef);
     if (existing) {
-      attempt.flowId = existing.id;
+      attachReviewFlowAttempt(attempt, existing);
+      persist();
       return;
     }
     persist();
@@ -863,6 +879,8 @@ async function tickReviewStage(
     };
     const created = await ports.createFlow({
       implementerPath: implementer.agentPath,
+      ...(implementer.conversationId ? { implementerConversationId: implementer.conversationId } : {}),
+      deliverKickoff: false,
       roles: { implementer: implementerRole, reviewer: reviewerRole },
       baseMode: "head",
       baseRef: pipeline.baseRef,
@@ -875,7 +893,7 @@ async function tickReviewStage(
       park(pipeline, `creating the review flow failed: ${created.error ?? "unknown error"}`, attempt);
       return;
     }
-    attempt.flowId = created.flow.id;
+    attachReviewFlowAttempt(attempt, created.flow);
     persist();
     if (created.flow.state === "paused") {
       park(pipeline, `review flow startup paused: ${created.flow.stateDetail ?? "kickoff delivery failed"}`, attempt);
@@ -914,10 +932,7 @@ async function tickReviewStage(
     if (advanced.error) park(pipeline, `advancing the review flow failed: ${advanced.error}`, attempt);
     return;
   }
-  const round = flow.rounds.at(-1);
-  attempt.sessionId = round?.sessionId ?? attempt.sessionId;
-  attempt.agentPath = round?.reviewerPath ?? attempt.agentPath;
-  attempt.conversationId = round?.reviewerConversationId ?? attempt.conversationId;
+  attachReviewFlowAttempt(attempt, flow);
   if (flow.state === "approved") {
     attempt.output = `Review loop approved after ${flow.rounds.length} round(s).`;
     attempt.verdict = { status: "pass", confidence: 1 };


### PR DESCRIPTION
## Summary

- Resolve embedded review-flow implementers from the pipeline attempt durable `agentPath` and `conversationId`, with scanner and registry evidence available as fallbacks.
- Start terminal builder review flows directly and skip kickoff delivery that requires a live implementer host.
- Adopt active partially-created flows by stable implementer identity plus base ref, then persist reviewer launch/session/path/conversation fields on the review-stage attempt.
- Preserve clean `retry-stage` recovery after repeated review creation failures.

## Production reproduction

Pipeline `8fa12bb4` reached a passed build at commit `c0072eae` with durable transcript path and conversation identity. The build→review transition parked with `creating the review flow failed: implementer transcript is unknown`. Two subsequent `retry-stage` attempts returned the same error, including a retry after the transcript appeared in `/api/files`. A direct `/api/spawn` review resolved the same transcript successfully.

The RED coverage reproduces the terminal builder, dead host, empty scanner slice, three identical failures, partial flow persistence, and detached reviewer ownership shape.

## Verification

- Focused pipeline/flows/board ownership tests: 175 passed, 596 assertions
- TypeScript: passed
- Scoped ESLint: passed
- Production build: passed
- Self-review: no high-confidence findings

Board task: `ac3340f2-6375-4c31-b967-b95babd972ba`

Closes #420