### PR TITLE
fix(runtime): recover stale hosts with lossless image drafts

### DIFF
--- a/src/components/TmuxComposer.runtimeSnapshot.dom.test.tsx
+++ b/src/components/TmuxComposer.runtimeSnapshot.dom.test.tsx
@@ -17,7 +17,7 @@ import { createRoot, type Root } from "react-dom/client";
 
 import type { RuntimeSessionView } from "@/hooks/useRuntime";
 import type { FileEntry } from "@/lib/types";
-import { setLocale } from "@/lib/i18n";
+import { setLocale, translate } from "@/lib/i18n";
 
 const dom = new Window();
 installActEnv();
@@ -96,6 +96,7 @@ const realFetch = globalThis.fetch;
 
 afterEach(() => {
   setLocale("en");
+  structuredView.session.host = "hosted";
   globalThis.fetch = realFetch;
   document.body.replaceChildren();
   localStorage.clear();
@@ -177,6 +178,55 @@ const delivered = (body: SendBody) => ({
       revision: 1,
     },
   },
+});
+
+test("unhosted structured composer sends through durable recovery admission", async () => {
+  structuredView.session.host = "unhosted";
+  const sends: SendBody[] = [];
+  mockWire(sends, [delivered]);
+
+  const { host, root } = await renderInto(<TmuxComposer file={file} deadHost />);
+  const { type, submit } = composerControls(host);
+  await settle(() => type("continue while the host recovers"));
+  await settle(() => submit());
+
+  expect(sends).toHaveLength(1);
+  expect(sends[0]).toMatchObject({
+    text: "continue while the host recovers",
+    idempotencyKey: expect.any(String),
+  });
+  await act(async () => root.unmount());
+});
+
+test("structured recovery state is bounded and exposes retry details", async () => {
+  structuredView.session.host = "unhosted";
+  let finishRecovery!: (response: Response) => void;
+  globalThis.fetch = (async (input: string | URL | Request) => {
+    const url = String(input);
+    if (url === "/api/tmux/targets") {
+      return { ok: true, status: 200, json: async () => ({ targets: {} }) } as Response;
+    }
+    if (url !== "/api/runtime/send") throw new Error(`unexpected request: ${url}`);
+    return new Promise<Response>((resolve) => { finishRecovery = resolve; });
+  }) as typeof fetch;
+
+  const { host, root } = await renderInto(<TmuxComposer file={file} deadHost />);
+  const { type, submit } = composerControls(host);
+  await settle(() => type("preserve this recovery draft"));
+  await settle(() => submit());
+  expect(host.textContent).toContain(translate("en", "composer.receiptRecovering"));
+
+  await act(async () => {
+    finishRecovery({
+      ok: false,
+      status: 503,
+      json: async () => ({ error: "recovery attempt failed; retry is available" }),
+    } as Response);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+  expect(host.textContent).toContain("recovery attempt failed; retry is available");
+  expect((host.querySelector("textarea") as HTMLTextAreaElement).value).toBe("preserve this recovery draft");
+  await act(async () => root.unmount());
 });
 
 test("a same-key retry re-sends the ORIGINAL runtime snapshot even after the selection changed", async () => {

--- a/src/components/TmuxComposer.runtimeSnapshot.dom.test.tsx
+++ b/src/components/TmuxComposer.runtimeSnapshot.dom.test.tsx
@@ -21,6 +21,19 @@ import { setLocale, translate } from "@/lib/i18n";
 
 const dom = new Window();
 installActEnv();
+class ImmediateFileReader {
+  result: string | null = null;
+  error: null = null;
+  onload: (() => void) | null = null;
+  onerror: (() => void) | null = null;
+  onabort: (() => void) | null = null;
+
+  readAsDataURL(file: File): void {
+    const mime = file.type || "image/png";
+    this.result = `data:${mime};base64,${Buffer.from(file.name).toString("base64")}`;
+    queueMicrotask(() => this.onload?.());
+  }
+}
 Object.assign(globalThis, {
   window: dom,
   document: dom.document,
@@ -32,7 +45,7 @@ Object.assign(globalThis, {
   CustomEvent: dom.CustomEvent,
   MouseEvent: dom.MouseEvent,
   File: dom.File,
-  FileReader: dom.FileReader,
+  FileReader: ImmediateFileReader,
   requestAnimationFrame: dom.requestAnimationFrame.bind(dom),
   cancelAnimationFrame: dom.cancelAnimationFrame.bind(dom),
   localStorage: dom.localStorage,
@@ -113,6 +126,7 @@ const file: FileEntry = {
 interface SendBody {
   idempotencyKey: string;
   text: string;
+  images?: Array<{ base64: string; mime: string }>;
   runtime?: { model?: string; effort?: string; fast?: boolean };
 }
 
@@ -124,7 +138,7 @@ function mockWire(sends: SendBody[], respond: Array<(body: SendBody) => { status
   globalThis.fetch = (async (input: string | URL | Request, init?: { body?: string }) => {
     const url = String(input);
     if (url === "/api/tmux/targets") return { ok: true, status: 200, json: async () => ({ targets: {} }) } as Response;
-    if (url !== "/api/runtime/send") return { ok: true, status: 200, json: async () => ({ ok: true }) } as Response;
+    if (url !== "/api/runtime/send") throw new Error(`unexpected request: ${url}`);
     const body = JSON.parse(init?.body ?? "{}") as SendBody;
     sends.push(body);
     const script = respond[Math.min(call++, respond.length - 1)]!(body);
@@ -163,6 +177,31 @@ function composerControls(host: HTMLElement) {
   return { type, submit };
 }
 
+async function pasteImages(host: HTMLElement, names: string[]): Promise<void> {
+  const textarea = host.querySelector("textarea") as HTMLTextAreaElement;
+  const propsKey = Object.keys(textarea).find((key) => key.startsWith("__reactProps$"))!;
+  const props = (textarea as unknown as Record<string, {
+    onPaste(event: unknown): void;
+  }>)[propsKey]!;
+  const files = names.map((name) => new dom.File([name], name, { type: "image/png" }) as unknown as File);
+  await act(async () => {
+    props.onPaste({
+      clipboardData: {
+        items: files.map((image) => ({ type: image.type, getAsFile: () => image })),
+      },
+      preventDefault() {},
+    });
+    await Promise.resolve();
+  });
+  for (let attempt = 0; attempt < 20; attempt += 1) {
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+    if (host.querySelectorAll('[data-testid="attachment-tile"][data-status="ready"]').length === names.length) return;
+  }
+  throw new Error("image attachments did not finish reading");
+}
+
 const delivered = (body: SendBody) => ({
   status: 200,
   json: {
@@ -195,6 +234,55 @@ test("unhosted structured composer sends through durable recovery admission", as
     text: "continue while the host recovers",
     idempotencyKey: expect.any(String),
   });
+  await act(async () => root.unmount());
+});
+
+test("dead structured image-only submission keeps every selected image off the unsafe recovery path", async () => {
+  const sends: SendBody[] = [];
+  mockWire(sends, [() => ({ status: 503, json: { error: "recovery failed before image admission" } })]);
+
+  const { host, root } = await renderInto(<TmuxComposer file={file} />);
+  await pasteImages(host, ["first.png", "second.png"]);
+  expect(host.querySelectorAll('[data-testid="attachment-tile"][data-status="ready"]')).toHaveLength(2);
+
+  structuredView.session.host = "unhosted";
+  await act(async () => {
+    root.render(<TmuxComposer file={file} deadHost />);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+
+  const imagePicker = host.querySelector(`button[aria-label="${translate("en", "composer.addImages")}"]`) as HTMLButtonElement;
+  const send = host.querySelector('button[type="submit"]') as HTMLButtonElement;
+  expect(imagePicker.disabled).toBe(true);
+  expect(send.disabled).toBe(true);
+
+  await settle(() => composerControls(host).submit());
+  expect(sends).toHaveLength(0);
+  expect(host.querySelectorAll('[data-testid="attachment-tile"][data-status="ready"]')).toHaveLength(2);
+  await act(async () => root.unmount());
+});
+
+test("dead structured text-plus-image submission preserves the complete draft with image-specific recovery guidance", async () => {
+  const sends: SendBody[] = [];
+  mockWire(sends, [() => ({ status: 503, json: { error: "recovery failed before image admission" } })]);
+
+  const { host, root } = await renderInto(<TmuxComposer file={file} />);
+  const { type } = composerControls(host);
+  await settle(() => type("keep this text with both screenshots"));
+  await pasteImages(host, ["context.png", "result.png"]);
+
+  structuredView.session.host = "unhosted";
+  await act(async () => {
+    root.render(<TmuxComposer file={file} deadHost />);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+  await settle(() => composerControls(host).submit());
+
+  expect(sends).toHaveLength(0);
+  expect((host.querySelector("textarea") as HTMLTextAreaElement).value)
+    .toBe("keep this text with both screenshots");
+  expect(host.querySelectorAll('[data-testid="attachment-tile"][data-status="ready"]')).toHaveLength(2);
+  expect(host.textContent).toContain(translate("en", "composer.imagesBlockedDuringRecovery"));
   await act(async () => root.unmount());
 });
 

--- a/src/components/TmuxComposer.tsx
+++ b/src/components/TmuxComposer.tsx
@@ -760,9 +760,12 @@ export function TmuxComposer({
   // path at all, so the whole composer stands down below (finding 2).
   const { caps, structuredSession } = useAgentCapabilities(file);
   const structuredImageCapability = structuredSession?.session.capabilities?.imageInput;
-  const structuredImagesDisabled = Boolean(structuredSession && !structuredImageCapability?.supported);
+  const structuredImageControl = caps.controls.images;
+  const structuredImagesDisabled = Boolean(structuredSession && structuredImageControl.state !== "enabled");
   const structuredImagesReason = structuredImagesDisabled
-    ? t("composer.structuredImagesProtocol")
+    ? t(structuredImageControl.state === "disabled"
+      ? structuredImageControl.reason
+      : "composer.structuredImagesProtocol")
     : undefined;
   /* While a card is switching accounts its next send is held for the successor
      (Sol delivery fence): the composer shows the held affordance instead of
@@ -969,6 +972,10 @@ export function TmuxComposer({
        message durably and uses the same request to recover its engine host. */
     if (deadHost && !structuredSession) {
       setStatus({ kind: "err", text: t("deadHost.sendBlocked") });
+      return;
+    }
+    if (structuredSession && structuredImagesDisabled && sentImages.length) {
+      setStatus({ kind: "err", text: structuredImagesReason! });
       return;
     }
     /* Host not yet resolved under the runtime plane: block the POST so a

--- a/src/components/TmuxComposer.tsx
+++ b/src/components/TmuxComposer.tsx
@@ -944,9 +944,9 @@ export function TmuxComposer({
   // A surface whose Send capability is hidden exposes NO message surface — no
   // Send, quick-ack, mic, or image path, and fires zero requests. This gates the
   // gated scanner-shaped subagent (inert row) that `canMessageWithoutPane` would
-  // otherwise treat as resumable and let POST /api/tmux (finding 2). Dead and
-  // unresolved hosts keep a *disabled* Send (not hidden), so their composer stays
-  // visible-but-blocked via `deadHost`/`sendBlockedReason`.
+  // otherwise treat as resumable and let POST /api/tmux (finding 2). Unresolved
+  // hosts keep a disabled Send. Durable structured ownership can
+  // keep a dead-host composer usable through recovery admission.
   if (caps.controls.send.state === "hidden") return null;
   const resumable = canMessageWithoutPane(file);
   if (target === null && !resumable) return null;
@@ -965,10 +965,9 @@ export function TmuxComposer({
        still sends and later clears the same set. */
     const sentImages: PendingImage[] = attachments.imagesRef.current.map((image) => ({ ...image }));
     if (busy || voiceSending || (!payloadText.trim() && !sentImages.length)) return;
-    /* Dead host (§5): the draft survives but no POST is attempted, so no new
-       `rejected: dead-host` receipts can stack. The banner is the single source
-       of the bad news; the composer only says why Send is inert. */
-    if (deadHost) {
+    /* A legacy dead host keeps its draft local. Structured ownership admits the
+       message durably and uses the same request to recover its engine host. */
+    if (deadHost && !structuredSession) {
       setStatus({ kind: "err", text: t("deadHost.sendBlocked") });
       return;
     }
@@ -981,7 +980,9 @@ export function TmuxComposer({
     }
     if (structuredSession && sentImages.length && !attachments.validate()) return;
     setBusy(true);
-    setStatus(null);
+    setStatus(deadHost
+      ? { kind: "info", text: t("composer.receiptRecovering") }
+      : null);
     /* Idempotency key: the backend can dedupe a retried held/failed delivery
        against this id so the successor never receives the same prompt twice. */
     const clientMessageId = deliveryAttemptKey(idempotencyKey.current, retry?.clientMessageId);
@@ -1237,12 +1238,12 @@ export function TmuxComposer({
   /* Mode chip, interrupt, compact, and attach-terminal now live in the unified
      control strip (issue #241); the composer no longer renders them. */
 
-  /* The main send surface is inert on a dead host (§5) or an unresolved host
-     (finding 1); quick-ack calls the same `send()`, so it must obey the same
-     block — otherwise the menu offers a control whose POST the inner guard
-     silently swallows (round-3 finding). Blocked ⇒ the action leaves the menu
-     entirely, so neither pointer nor keyboard can reach an enabled quick-ack. */
-  const sendBlocked = deadHost || Boolean(sendBlockedReason);
+  /* The main send surface stays inert for legacy dead hosts and unresolved
+     ownership. Structured dead hosts use durable recovery admission. Quick-ack
+     calls the same `send()`, so it obeys the same block and leaves the menu when
+     blocked (round-3 finding). */
+  const deadHostBlocksSend = deadHost && !structuredSession;
+  const sendBlocked = deadHostBlocksSend || Boolean(sendBlockedReason);
   const canQuickAck = (!spawnMode || relayMode) && !sendBlocked;
   const quickAckDisabled = busy || voiceSending || attachments.images.length > 0;
 
@@ -1366,15 +1367,15 @@ export function TmuxComposer({
               ]
             : []
         }
-        showImage={!deadHost}
+        showImage={!deadHostBlocksSend}
         imageDisabled={structuredImagesDisabled}
         imageDisabledReason={structuredImagesReason}
-        sendDisabledReason={deadHost ? t("deadHost.sendBlocked") : sendBlockedReason ?? undefined}
+        sendDisabledReason={deadHostBlocksSend ? t("deadHost.sendBlocked") : sendBlockedReason ?? undefined}
         receipts={
           displayedRuntimeReceipts.length
             ? <RuntimeComposerReceipts
                 receipts={displayedRuntimeReceipts}
-                actionsDisabled={busy || voiceSending || deadHost}
+                actionsDisabled={busy || voiceSending || deadHostBlocksSend}
                 dismissed={dismissedReceipts}
                 onRetry={(receipt) => void retryRuntimeReceipt(receipt)}
                 onEdit={editRuntimeReceipt}

--- a/src/components/agentCapabilities.test.ts
+++ b/src/components/agentCapabilities.test.ts
@@ -270,12 +270,13 @@ test("resume: runtime picks the on-resume profile, stop/compact/kill hidden", ()
   expect(state("send", f, null)).toBe("enabled");
 });
 
-test("dead: only terminal (the escape hatch) survives; send is disabled, not attempted", () => {
+test("dead structured host keeps durable text send available and disables images until recovery", () => {
   const f = file({ proc: "running" });
   const view = rv("claude-broker", "dead");
   expect(state("terminal", f, view)).toBe("enabled");
-  expect(reason("send", f, view)).toBe("deadHost.sendBlocked");
-  for (const c of ["stop", "compact", "runtime", "kill", "images"] as ControlName[]) {
+  expect(state("send", f, view)).toBe("enabled");
+  expect(reason("images", f, view)).toBe("composer.imagesBlockedDuringRecovery");
+  for (const c of ["stop", "compact", "runtime", "kill"] as ControlName[]) {
     expect(state(c, f, view)).toBe("hidden");
   }
 });

--- a/src/components/agentCapabilities.ts
+++ b/src/components/agentCapabilities.ts
@@ -322,8 +322,10 @@ export function capabilitiesFor(file: FileEntry, rv: RuntimeSessionView | null, 
           runtime: HIDDEN,
           kill: HIDDEN,
           terminal: ENABLED, // the dead-host escape hatch (§5/§6)
-          images: HIDDEN,
-          send: disabled("deadHost.sendBlocked"),
+          // Text has a durable pre-recovery hold. Images remain in the local
+          // draft until a live host can reserve their runtime-store bytes.
+          images: disabled("composer.imagesBlockedDuringRecovery"),
+          send: ENABLED,
         },
       };
     case "superseded":

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -274,6 +274,7 @@ export const en = {
   "composer.structuredImagesUnavailable": "Image delivery is unavailable for structured conversations",
   "composer.codexImagesTextOnly": "The selected Codex model accepts text input only.",
   "composer.structuredImagesProtocol": "This structured host has no negotiated image capability.",
+  "composer.imagesBlockedDuringRecovery": "Images stay selected until the structured host is recovered.",
   "composer.imageCapabilityLoading": "Image capability is loading.",
   "composer.imageCapabilityError": "Image capability could not be loaded.",
   "composer.imageCapabilityRetry": "Retry image check",

--- a/src/lib/i18n/uk.ts
+++ b/src/lib/i18n/uk.ts
@@ -265,6 +265,7 @@ export const uk: Record<keyof typeof en, Message> = {
   "composer.structuredImagesUnavailable": "Структуровані розмови поки не підтримують картинки",
   "composer.codexImagesTextOnly": "Обрана модель Codex приймає лише текст.",
   "composer.structuredImagesProtocol": "Цей структурований хост не узгодив підтримку зображень.",
+  "composer.imagesBlockedDuringRecovery": "Зображення залишаться вибраними до відновлення структурованого хоста.",
   "composer.imageCapabilityLoading": "Завантажуємо дані про підтримку зображень.",
   "composer.imageCapabilityError": "Не вдалося завантажити дані про підтримку зображень.",
   "composer.imageCapabilityRetry": "Повторити перевірку зображень",

--- a/src/lib/runtime/structuredControls.test.ts
+++ b/src/lib/runtime/structuredControls.test.ts
@@ -6,6 +6,7 @@ import crypto from "node:crypto";
 import { afterAll, expect, test } from "bun:test";
 
 import { AgentRegistry } from "@/lib/agent/registry";
+import { procBackend } from "@/lib/proc";
 
 import { RuntimeHostUnavailableError, type RuntimeHostClient } from "./client";
 import { dispatchStructuredControl } from "./structuredControls";
@@ -14,30 +15,35 @@ const sandbox = fs.mkdtempSync(path.join(os.tmpdir(), "llv-structured-controls-"
 afterAll(() => fs.rmSync(sandbox, { recursive: true, force: true }));
 
 function structuredConversation(
-  options: { parentConversationId?: `conversation_${string}`; registry?: AgentRegistry } = {},
+  options: {
+    engine?: "claude" | "codex";
+    parentConversationId?: `conversation_${string}`;
+    registry?: AgentRegistry;
+  } = {},
 ): { registry: AgentRegistry; path: string; conversationId: string } {
+  const engine = options.engine ?? "codex";
   const id = crypto.randomUUID();
   const pathname = path.join(sandbox, `${id}.jsonl`);
   const registry = options.registry
     ?? new AgentRegistry(path.join(sandbox, `${id}.registry.json`), undefined, undefined, { sqliteMode: "off" });
   const begun = registry.beginSpawnRequest({
-    engine: "codex",
+    engine,
     cwd: sandbox,
-    accountId: "codex-subscription",
+    accountId: `${engine}-subscription`,
     ...(options.parentConversationId ? { parentConversationId: options.parentConversationId } : {}),
   });
   if (begun.kind !== "created") throw new Error("spawn receipt was unavailable");
   const settled = registry.settleSpawn(begun.receipt.launchId, {
-    key: { engine: "codex", sessionId: id },
+    key: { engine, sessionId: id },
     artifactPath: pathname,
     cwd: sandbox,
-    accountId: "codex-subscription",
+    accountId: `${engine}-subscription`,
     status: "live",
     host: null,
     structuredHost: {
-      kind: "codex-app-server",
+      kind: engine === "codex" ? "codex-app-server" : "claude-broker",
       endpoint: "fake:stdio",
-      process: { pid: process.pid, startIdentity: "test-process" },
+      process: { pid: process.pid, startIdentity: procBackend.processIdentity(process.pid) },
       eventCursor: 1,
       protocolVersion: "fake-v1",
       writerClaimEpoch: 1,
@@ -76,6 +82,104 @@ test("structured ownership resolves from conversation identity", async () => {
   });
 
   expect(result).toEqual({ status: 409, body: { error: "structured host does not support the resume control" } });
+});
+
+test("stale-live Codex resume recovers the production conversation identity", async () => {
+  const fixture = structuredConversation();
+  const conversation = fixture.registry.conversation(fixture.conversationId as `conversation_${string}`)!;
+  const generation = conversation.generations.at(-1)!;
+  const key = { engine: conversation.engine, sessionId: generation.id } as const;
+  const entry = fixture.registry.snapshot().entries[`${key.engine}:${key.sessionId}`]!;
+  const staleProcess = { pid: 1_275_500, startIdentity: "production-start-identity" };
+  fixture.registry.setStructuredHostClaimed(key, {
+    ...entry.structuredHost!,
+    process: staleProcess,
+    activeTurnRef: "019f7ac9-2509-7f53-a3af-e9400967a43f",
+  }, "live", entry.claimOwner!, entry.claimEpoch, true);
+  const recoveries: unknown[] = [];
+
+  const result = await dispatchStructuredControl({
+    path: fixture.path,
+    conversationId: fixture.conversationId,
+    action: "resume",
+  }, {
+    registry: fixture.registry,
+    enabled: () => true,
+    hostProcessAlive: (identity) => {
+      expect(identity).toEqual(staleProcess);
+      return false;
+    },
+    recover: async (request) => {
+      recoveries.push(request);
+      return {
+        target: null,
+        path: fixture.path,
+        conversationId: fixture.conversationId as `conversation_${string}`,
+        spawned: true,
+      };
+    },
+  });
+
+  expect(recoveries).toEqual([{
+    path: fixture.path,
+    conversationId: fixture.conversationId,
+  }]);
+  expect(result).toEqual({
+    status: 200,
+    body: {
+      ok: true,
+      structured: true,
+      target: fixture.conversationId,
+      outcome: "resumed",
+      spawned: true,
+    },
+  });
+});
+
+test("stale-live Claude resume recovers after a PID start-identity mismatch", async () => {
+  const fixture = structuredConversation({ engine: "claude" });
+  const conversation = fixture.registry.conversation(fixture.conversationId as `conversation_${string}`)!;
+  const generation = conversation.generations.at(-1)!;
+  const key = { engine: conversation.engine, sessionId: generation.id } as const;
+  const entry = fixture.registry.snapshot().entries[`${key.engine}:${key.sessionId}`]!;
+  fixture.registry.setStructuredHostClaimed(key, {
+    ...entry.structuredHost!,
+    process: { pid: process.pid, startIdentity: "reused-pid-start-identity" },
+    activeTurnRef: "stale-claude-turn",
+  }, "live", entry.claimOwner!, entry.claimEpoch, true);
+  const recoveries: unknown[] = [];
+
+  const result = await dispatchStructuredControl({
+    path: fixture.path,
+    conversationId: fixture.conversationId,
+    action: "resume",
+  }, {
+    registry: fixture.registry,
+    enabled: () => true,
+    recover: async (request) => {
+      recoveries.push(request);
+      return {
+        target: null,
+        path: fixture.path,
+        conversationId: fixture.conversationId as `conversation_${string}`,
+        spawned: true,
+      };
+    },
+  });
+
+  expect(recoveries).toEqual([{
+    path: fixture.path,
+    conversationId: fixture.conversationId,
+  }]);
+  expect(result).toMatchObject({
+    status: 200,
+    body: {
+      ok: true,
+      target: fixture.conversationId,
+      outcome: "resumed",
+      spawned: true,
+    },
+  });
 });
 
 test("dead structured resume falls through to canonical recovery", async () => {

--- a/src/lib/runtime/structuredControls.ts
+++ b/src/lib/runtime/structuredControls.ts
@@ -1,12 +1,14 @@
-import { agentRegistry, type AgentRegistry } from "@/lib/agent/registry";
+import { agentRegistry, type AgentRegistry, type ProcessIdentity } from "@/lib/agent/registry";
 import { sessionKeyId } from "@/lib/agent/sessionKey";
 
 import { isRuntimeHostTransportFailure, runtimeHostClient, type RuntimeHostClient } from "./client";
 import { newOperationId } from "./contracts";
 import { kickStructuredDeliveryQueue } from "./structuredDeliverySignal";
+import { recoverDeadStructuredConversation, structuredHostProcessAlive } from "./structuredRecovery";
 
 export type StructuredControlResult =
   | { status: 200; body: { ok: true; structured: true; target: string; outcome: "delivered" } }
+  | { status: 200; body: { ok: true; structured: true; target: string; outcome: "resumed"; spawned: boolean } }
   | { status: 200 | 202; body: { ok: true; structured: true; target: string; operationId: string; receipt: { operationId: string; status: string } } }
   | { status: 409 | 503; body: { error: string } };
 
@@ -24,6 +26,8 @@ export async function dispatchStructuredControl(
     operationId?: () => string;
     kick?: () => void;
     enabled?: () => boolean;
+    recover?: typeof recoverDeadStructuredConversation;
+    hostProcessAlive?: (identity: ProcessIdentity | null) => boolean;
   } = {},
 ): Promise<StructuredControlResult | null> {
   if (!request.action) return null;
@@ -49,6 +53,30 @@ export async function dispatchStructuredControl(
   if (request.action !== "interrupt" && request.action !== "kill") {
     if (request.action === "resume" && (entry.status === "dead" || entry.status === "unhosted")) {
       return null;
+    }
+    if (request.action === "resume"
+      && !(dependencies.hostProcessAlive ?? structuredHostProcessAlive)(entry.structuredHost?.process ?? null)) {
+      try {
+        const recovered = await (dependencies.recover ?? recoverDeadStructuredConversation)({
+          path: request.path || generation.path,
+          conversationId: conversation.id,
+        }, { registry });
+        if (!recovered) {
+          return { status: 503, body: { error: "structured recovery ownership is unavailable" } };
+        }
+        return {
+          status: 200,
+          body: {
+            ok: true,
+            structured: true,
+            target: conversation.id,
+            outcome: "resumed",
+            spawned: recovered.spawned,
+          },
+        };
+      } catch (error) {
+        return { status: 503, body: { error: error instanceof Error ? error.message : String(error) } };
+      }
     }
     const label = ["compact", "dialog-key", "kill", "reconfigure", "resume"].includes(request.action)
       ? request.action

--- a/src/lib/runtime/structuredMessageDelivery.test.ts
+++ b/src/lib/runtime/structuredMessageDelivery.test.ts
@@ -1360,11 +1360,12 @@ test("structured message routing only falls through for an explicit legacy owner
   expect(result).toBeNull();
 });
 
-test("dead structured message routing recovers the host before admitting the send", async () => {
+test("dead structured composer send is durable before recovery and delivers after claim", async () => {
   const { registry, conversation } = registryWithConversation();
   const deadSnapshot = snapshot(conversation.id);
   deadSnapshot.sessions[0] = { ...deadSnapshot.sessions[0]!, host: "dead" };
   let recovered = false;
+  let durableBeforeRecovery = false;
   const commands: unknown[] = [];
   const client = {
     snapshot: async () => deadSnapshot,
@@ -1407,6 +1408,9 @@ test("dead structured message routing recovers the host before admitting the sen
       client: () => client,
       registry: () => registry,
       recover: async () => {
+        durableBeforeRecovery = registry.pendingDeliveries(conversation.id).some((delivery) =>
+          delivery.clientMessageId === "recovered-message-one"
+            && delivery.text === "continue after host loss");
         recovered = true;
         return { target: null, path: artifactPath, conversationId: conversation.id, spawned: true };
       },
@@ -1414,6 +1418,7 @@ test("dead structured message routing recovers the host before admitting the sen
     } as never,
   );
 
+  expect(durableBeforeRecovery).toBe(true);
   expect(recovered).toBe(true);
   expect(commands).toHaveLength(1);
   expect(result).toMatchObject({
@@ -1478,7 +1483,12 @@ test("structured recovery failures remain admitted, avoid delivery, and allow a 
     status: 503,
   });
   expect(commands).toEqual([]);
-  expect(registry.pendingDeliveries(conversation.id)).toEqual([]);
+  expect(registry.pendingDeliveries(conversation.id)).toHaveLength(1);
+  expect(registry.pendingDeliveries(conversation.id)[0]).toMatchObject({
+    clientMessageId: "recovery-retry-message",
+    state: "assigned",
+    text: "retain this draft through recovery failure",
+  });
 
   await expect(enqueueStructuredMessage(request, dependencies)).resolves.toMatchObject({
     ok: true,
@@ -1487,6 +1497,7 @@ test("structured recovery failures remain admitted, avoid delivery, and allow a 
     outcome: "queued",
   });
   expect(commands).toHaveLength(1);
+  expect(Object.values(registry.snapshot().heldDeliveries)).toHaveLength(1);
 });
 
 test("structured message republishes an in-process host after runtime restart before recovery", async () => {

--- a/src/lib/runtime/structuredMessageDelivery.ts
+++ b/src/lib/runtime/structuredMessageDelivery.ts
@@ -453,6 +453,25 @@ export async function enqueueStructuredMessage(
      recovery of a retired round would silently fork it (issue #383). */
   const rejected = supersededRejection(registry, registry.conversation(session.conversationId as ViewerConversationId));
   if (rejected) return rejected;
+  const conversation = registry.conversation(session.conversationId as ViewerConversationId);
+  if (!conversation) return ownershipUnavailable();
+  const idempotencyKey = request.clientMessageId?.trim() || `queue_${crypto.randomUUID()}`;
+  if ((session.host === "dead" || session.host === "unhosted") && !wantsImages) {
+    try {
+      const content = structuredContent(request.text, []);
+      registry.holdDelivery(
+        conversation.id,
+        content.content.text,
+        idempotencyKey,
+        "text",
+        [],
+        content.contentDigest,
+        commandInput(request),
+      );
+    } catch (error) {
+      return deliveryFailure(error);
+    }
+  }
   let recoveredHost = false;
   /* Ownership recovery comes BEFORE capability evaluation: a dead projection
      carries no image capability, and judging the payload against it would 409
@@ -494,8 +513,6 @@ export async function enqueueStructuredMessage(
   if (encodedImageBytes > imageCapability.maxEncodedBytesPerRequest) {
     return { ok: false, structured: true, outcome: "failed", error: "runtime image request encoding is too large", status: 413 };
   }
-  const conversation = registry.conversation(session.conversationId as ViewerConversationId);
-  if (!conversation) return ownershipUnavailable();
   try {
     if (rawImages.length > 0 && suppliedRefs.length > 0) throw new Error("structured image payload is ambiguous");
     /* Conflict preflight computes candidate refs and digest before writing.
@@ -506,7 +523,6 @@ export async function enqueueStructuredMessage(
       ? suppliedRefs
       : (dependencies.previewImageRefs ?? runtimeImageRefsForUploads)(rawImages);
     const content = structuredContent(request.text, refs);
-    const idempotencyKey = request.clientMessageId?.trim() || `queue_${crypto.randomUUID()}`;
     const admissionKey = request.clientMessageId?.trim()
       ? `${conversation.id} ${request.clientMessageId.trim()}`
       : null;

--- a/src/lib/runtime/structuredRecovery.test.ts
+++ b/src/lib/runtime/structuredRecovery.test.ts
@@ -583,7 +583,7 @@ test.each(["codex", "claude"] as const)("current verified %s tmux ownership outr
   expect(state.registry.snapshot().entries[`${engine}:${state.key.sessionId}`]?.host).toEqual(state.tmuxHost);
 });
 
-test.each(["codex", "claude"] as const)("concurrent %s sends wait for recovery publication before either admission", async (engine) => {
+test.each(["codex", "claude"] as const)("duplicate %s recovery clicks reuse one stale-live recovery until host publication", async (engine) => {
   const sessionId = crypto.randomUUID();
   const cwd = path.join(sandbox, `${engine}-publication-barrier-${sessionId}`);
   const artifactPath = path.join(cwd, `${sessionId}.jsonl`);
@@ -599,16 +599,16 @@ test.each(["codex", "claude"] as const)("concurrent %s sends wait for recovery p
     cwd,
     accountId: `${engine}-account`,
     launchProfile: profile,
-    status: "dead",
+    status: "live",
     host: null,
     structuredHost: {
       kind: engine === "codex" ? "codex-app-server" : "claude-broker",
-      endpoint: "stdio:released",
-      process: null,
+      endpoint: "stdio:stale",
+      process: { pid: 2_000_000_000, startIdentity: `${engine}-stale-process` },
       eventCursor: 0,
       protocolVersion: "v2",
       writerClaimEpoch: 1,
-      activeTurnRef: null,
+      activeTurnRef: `${engine}-stale-turn`,
       pendingAttention: [],
       activeFlags: [],
     },
@@ -629,9 +629,10 @@ test.each(["codex", "claude"] as const)("concurrent %s sends wait for recovery p
   let claimed!: () => void;
   const claimObserved = new Promise<void>((resolve) => { claimed = resolve; });
   let spawnCalls = 0;
+  let deliveryDrainRequests = 0;
   let admissions = 0;
   let terminalRejections = 0;
-  const recoverAndAdmit = async () => {
+  const recoverFromClick = async () => {
     const recovered = await recoverDeadStructuredConversation({ path: artifactPath, conversationId: conversation.id }, {
       registry,
       client: {} as RuntimeHostClient,
@@ -699,15 +700,21 @@ test.each(["codex", "claude"] as const)("concurrent %s sends wait for recovery p
           state: "settled",
         };
       },
+      requestDeliveryDrain: () => {
+        const published = registry.snapshot().entries[`${engine}:${sessionId}`];
+        expect(published).toMatchObject({ status: "idle", pendingAction: null });
+        expect(published?.structuredHost?.process).not.toBeNull();
+        deliveryDrainRequests += 1;
+      },
     });
     const entry = registry.snapshot().entries[`${engine}:${sessionId}`];
     if (!recovered || !entry?.structuredHost?.process || !entry.claimOwner) terminalRejections += 1;
     else admissions += 1;
   };
 
-  const first = recoverAndAdmit();
+  const first = recoverFromClick();
   await claimObserved;
-  const second = recoverAndAdmit();
+  const second = recoverFromClick();
   await Promise.resolve();
   expect(admissions).toBe(0);
   expect(terminalRejections).toBe(0);
@@ -715,6 +722,7 @@ test.each(["codex", "claude"] as const)("concurrent %s sends wait for recovery p
   await Promise.all([first, second]);
 
   expect(spawnCalls).toBe(1);
+  expect(deliveryDrainRequests).toBe(1);
   expect(admissions).toBe(2);
   expect(terminalRejections).toBe(0);
 });

--- a/src/lib/runtime/structuredRecovery.ts
+++ b/src/lib/runtime/structuredRecovery.ts
@@ -1,8 +1,9 @@
 import type { AccountContext } from "@/lib/accounts/contracts";
 import { accountManager } from "@/lib/accounts/manager";
 import { emptyLaunchProfile, type ViewerConversationId } from "@/lib/accounts/migration/contracts";
+import { requestAccountMigrationTick } from "@/lib/accounts/migration/controllerSignal";
 import type { ResumeSpec } from "@/lib/agent/cli";
-import { agentRegistry, type AgentRegistry } from "@/lib/agent/registry";
+import { agentRegistry, type AgentRegistry, type ProcessIdentity } from "@/lib/agent/registry";
 import { sessionKeyId, type SessionKey } from "@/lib/agent/sessionKey";
 import { procBackend } from "@/lib/proc";
 
@@ -29,6 +30,7 @@ export interface StructuredRecoveryDependencies {
   resolveAccount?: (engine: "claude" | "codex", accountId: string | null) => AccountContext;
   spawn?: typeof spawnStructuredConversation;
   processIdentity?: () => { pid: number; startIdentity: string | null };
+  requestDeliveryDrain?: () => void;
 }
 
 interface RecoveryCandidate {
@@ -42,7 +44,7 @@ interface RecoveryCandidate {
   publishReady: boolean;
 }
 
-function processIdentityAlive(identity: { pid: number; startIdentity: string | null } | null): boolean {
+export function structuredHostProcessAlive(identity: ProcessIdentity | null): boolean {
   if (!identity || !Number.isInteger(identity.pid) || identity.pid <= 0) return false;
   if (!procBackend.pidAlive(identity.pid)) return false;
   return identity.startIdentity === null || procBackend.processIdentity(identity.pid) === identity.startIdentity;
@@ -72,7 +74,7 @@ function candidateFor(
       && registry.canonicalConversationId(receipt.conversationId) === conversation.id);
   if (!entry.structuredHost && !structuredReceipt) return null;
   const terminal = entry.status === "dead" || entry.status === "unhosted";
-  const publishReady = Boolean(processIdentityAlive(entry.structuredHost?.process ?? null)
+  const publishReady = Boolean(structuredHostProcessAlive(entry.structuredHost?.process ?? null)
     && entry.claimOwner
     && entry.pendingAction === null
     && !terminal);
@@ -152,6 +154,7 @@ async function recoverCandidate(
       client,
     });
     if (!response.ok || !response.path) throw new Error("structured recovery host did not publish its transcript");
+    (dependencies.requestDeliveryDrain ?? requestAccountMigrationTick)();
     return {
       target: null,
       path: response.path,

--- a/src/lib/runtime/structuredSpawn.integration.test.ts
+++ b/src/lib/runtime/structuredSpawn.integration.test.ts
@@ -10,6 +10,7 @@ import type { AccountContext } from "@/lib/accounts/contracts";
 import type { ResumeSpec } from "@/lib/agent/cli";
 import { AgentRegistry } from "@/lib/agent/registry";
 import { spawnResponseForReceipt } from "@/lib/agent/spawnResponse";
+import { procBackend } from "@/lib/proc";
 import { RuntimeJournal } from "@/runtime-host/journal";
 
 import { RuntimeHostUnavailableError, type RuntimeHostClient } from "./client";
@@ -19,6 +20,7 @@ import { bindStructuredDeliveryQueue, hasStructuredDeliveryHost } from "./struct
 import { dispatchStructuredControl } from "./structuredControls";
 import { kickStructuredDeliveryQueue } from "./structuredDeliverySignal";
 import { enqueueStructuredMessage } from "./structuredMessageDelivery";
+import { recoverDeadStructuredConversation } from "./structuredRecovery";
 import { INITIAL_MESSAGE_TIMEOUT_MS, reconcileStructuredSpawnReplay, recoverPendingStructuredSpawns, spawnStructuredConversation, structuredClaudePermissionMode, structuredClaudeSpawnPolicyBaseSettingsPath, waitForStructuredInitialMessage, withRuntimeAdmissionRetry, type SpawnedStructuredHost } from "./structuredSpawn";
 import { materializeStructuredTerminal } from "./structuredTerminal";
 
@@ -777,6 +779,138 @@ class RoundTripHost implements SpawnedStructuredHost {
     });
   }
 }
+
+test.each(["codex", "claude"] as const)("%s stale-live recovery converges registry and runtime on one durable conversation", async (engine) => {
+  const sessionId = crypto.randomUUID();
+  const cwd = path.join(sandbox, `stale-live-recovery-${engine}-${sessionId}`);
+  const artifactPath = path.join(cwd, `${sessionId}.jsonl`);
+  fs.mkdirSync(cwd, { recursive: true });
+  fs.writeFileSync(artifactPath, "");
+  const registry = new AgentRegistry(path.join(cwd, "registry.json"), undefined, undefined, { sqliteMode: "off" });
+  const journal = new RuntimeJournal(path.join(cwd, "runtime.sqlite"), { structuredHosts: true });
+  const client = runtimeClient(journal);
+  const accountId = `${engine}-subscription`;
+  const conversation = registry.ensureConversation(engine, artifactPath, accountId);
+  const key = { engine, sessionId } as const;
+  const staleProcess = { pid: 2_000_000_000, startIdentity: `${engine}-stale-start` };
+  const launchProfile = emptyLaunchProfile({ cwd });
+  registry.upsert({
+    key,
+    artifactPath,
+    cwd,
+    accountId,
+    launchProfile,
+    status: "live",
+    host: null,
+    structuredHost: {
+      kind: engine === "codex" ? "codex-app-server" : "claude-broker",
+      endpoint: "stdio:stale",
+      process: staleProcess,
+      eventCursor: 7,
+      protocolVersion: "v2",
+      writerClaimEpoch: 4,
+      activeTurnRef: `${engine}-stale-turn`,
+      pendingAttention: [],
+      activeFlags: [],
+    },
+    claimEpoch: 4,
+    claimOwner: `structured-host:${JSON.stringify(staleProcess)}`,
+    pendingAction: null,
+  });
+  await client.append({
+    scope: { type: "session", id: conversation.id },
+    kind: "session-status",
+    producer: {
+      kind: engine === "codex" ? "codex-app-server" : "claude-broker",
+      eventKey: `${engine}-stale-unhosted`,
+    },
+    payload: {
+      conversationId: conversation.id,
+      sessionKey: key,
+      hostKind: engine === "codex" ? "codex-app-server" : "claude-broker",
+      host: "unhosted",
+      turn: "idle",
+      provenance: "derived",
+      accountId,
+      cwd,
+      artifactPath,
+      capabilities: { steer: engine === "codex", structuredAttention: true },
+      activeTurnId: null,
+    },
+  });
+  const host = new RoundTripHost(engine, artifactPath, sessionId);
+  const owner = { pid: process.pid, startIdentity: procBackend.processIdentity(process.pid) };
+  let drainRequests = 0;
+
+  const recovered = await recoverDeadStructuredConversation({
+    path: artifactPath,
+    conversationId: conversation.id,
+  }, {
+    registry,
+    client,
+    transport: () => "structured",
+    resolveAccount: () => ({
+      engine,
+      accountId,
+      kind: "managed",
+      home: cwd,
+      transcriptRoot: cwd,
+      env: { NODE_ENV: "test" },
+    }),
+    spawn: (input) => spawnStructuredConversation(input, {
+      startHost: async () => host,
+      bindHost: async (targetRegistry, targetKey, runningHost, claimOwner, claimEpoch) => {
+        const state = await runningHost.health();
+        targetRegistry.setStructuredHostClaimed(targetKey, {
+          kind: engine === "codex" ? "codex-app-server" : "claude-broker",
+          endpoint: state.endpoint,
+          process: owner,
+          eventCursor: state.eventCursor,
+          protocolVersion: state.protocolVersion,
+          writerClaimEpoch: claimEpoch,
+          activeTurnRef: state.activeTurnRef,
+          pendingAttention: state.pendingAttention,
+          activeFlags: state.activeFlags,
+        }, "idle", claimOwner, claimEpoch);
+        return () => {};
+      },
+      publishHost: async (targetKey, runningHost) => {
+        await bindStructuredDeliveryQueue([{ key: targetKey, host: runningHost }], { registry, client });
+        return async () => {};
+      },
+      processIdentity: () => owner,
+    }),
+    processIdentity: () => owner,
+    requestDeliveryDrain: () => { drainRequests += 1; },
+  });
+
+  expect(recovered).toMatchObject({
+    conversationId: conversation.id,
+    path: artifactPath,
+    spawned: true,
+  });
+  expect(registry.conversation(conversation.id)).toMatchObject({
+    id: conversation.id,
+    generations: [expect.objectContaining({ id: sessionId, path: artifactPath })],
+  });
+  expect(registry.snapshot().entries[`${engine}:${sessionId}`]).toMatchObject({
+    status: "idle",
+    pendingAction: null,
+    structuredHost: {
+      process: owner,
+      activeTurnRef: null,
+      writerClaimEpoch: 5,
+    },
+  });
+  expect(journal.snapshot().sessions.find((session) => session.conversationId === conversation.id)).toMatchObject({
+    conversationId: conversation.id,
+    sessionKey: key,
+    host: "hosted",
+    turn: "idle",
+  });
+  expect(drainRequests).toBe(1);
+  expect(host.sent).toEqual([]);
+});
 
 class UnreapableRoundTripHost extends RoundTripHost {
   override async release(): Promise<void> {


### PR DESCRIPTION
## Summary

- integrate the exact `d649d633` stale-host recovery change onto current `origin/main`
- preserve durable text admission before structured host recovery
- disable image intake and image-bearing submission while the dead host lacks durable image reservation
- retain the complete text draft and every staged image through recovery failure
- expose image-specific recovery guidance in English and Ukrainian

Supersedes #449 with the additive dead-host image recovery repair.

Closes #446

## Verification

- 223 focused composer, capability, locale, runtime, delivery, recovery, spawn, and route tests passed
- TypeScript passed with `bunx tsc --noEmit`
- ESLint passed for all 13 changed TypeScript files
- production build passed with `bun run build`
- `git diff --check origin/main` passed
- full diff self-review passed with no findings