### PR TITLE
ci(privacy): install trusted workflow dependencies

### DIFF
--- a/.github/workflows/privacy-publication.yml
+++ b/.github/workflows/privacy-publication.yml
@@ -32,6 +32,10 @@ jobs:
         with:
           bun-version: 1.3.3
 
+      - name: Install trusted dependencies
+        working-directory: trusted
+        run: bun install --frozen-lockfile
+
       - name: Install media inspection tools
         run: |
           sudo apt-get update

--- a/.github/workflows/privacy-tracker-audit.yml
+++ b/.github/workflows/privacy-tracker-audit.yml
@@ -38,6 +38,9 @@ jobs:
         with:
           bun-version: 1.3.3
 
+      - name: Install trusted dependencies
+        run: bun install --frozen-lockfile
+
       - name: Install media inspection tools
         run: |
           sudo apt-get update


### PR DESCRIPTION
Follow-up prerequisite for #456.

Adds frozen dependency installation to both default-branch-owned privacy workflows. This closes the first live publication-job failure where the trusted test process could not resolve the committed parser dependency.

Verification: frozen install, 85 privacy tests, and diff validation.