### PR TITLE
fix(privacy): trust escaped reference label parsing

### DIFF
--- a/scripts/privacy-github-audit.ts
+++ b/scripts/privacy-github-audit.ts
@@ -166,11 +166,31 @@ async function fetchPages(
 
 function markdownImageDestinations(text: string): string[] {
   const destinations: string[] = [];
-  const normalizeLabel = (label: string): string => label.trim().replaceAll(/\s+/g, " ").toLocaleLowerCase("en-US");
+  const normalizeLabel = (label: string): string => label
+    .replaceAll(/\\([!"#$%&'()*+,\-./:;<=>?@[\\\]^_`{|}~])/g, "$1")
+    .trim()
+    .replaceAll(/\s+/g, " ")
+    .toLocaleLowerCase("en-US");
+  const labelEndFrom = (start: number): number => {
+    for (let cursor = start; cursor < text.length; cursor += 1) {
+      if (text[cursor] === "\\" && cursor + 1 < text.length) {
+        cursor += 1;
+        continue;
+      }
+      if (text[cursor] === "\r" || text[cursor] === "\n") return -1;
+      if (text[cursor] === "]") return cursor;
+    }
+    return -1;
+  };
   const definitions = new Map<string, string>();
-  const definitionPattern = /^[ \t]{0,3}\[([^\]\r\n]+)\]:[ \t]*(?:<([^>\r\n]+)>|([^\s\r\n]+))/gm;
-  for (const definition of text.matchAll(definitionPattern)) {
-    definitions.set(normalizeLabel(definition[1]), definition[2] ?? definition[3]);
+  const definitionStartPattern = /^[ \t]{0,3}\[/gm;
+  for (const definitionStart of text.matchAll(definitionStartPattern)) {
+    const labelStart = (definitionStart.index ?? 0) + definitionStart[0].length;
+    const labelEnd = labelEndFrom(labelStart);
+    if (labelEnd === -1 || labelEnd === labelStart || text[labelEnd + 1] !== ":") continue;
+    const destination = text.slice(labelEnd + 2).match(/^[ \t]*(?:<([^>\r\n]+)>|([^\s\r\n]+))/);
+    if (!destination) continue;
+    definitions.set(normalizeLabel(text.slice(labelStart, labelEnd)), destination[1] ?? destination[2]);
   }
   let searchFrom = 0;
   while (searchFrom < text.length) {
@@ -194,7 +214,7 @@ function markdownImageDestinations(text: string): string[] {
       let referenceLabel = label;
       let nextSearchFrom = labelEnd + 1;
       if (text[labelEnd + 1] === "[") {
-        const referenceEnd = text.indexOf("]", labelEnd + 2);
+        const referenceEnd = labelEndFrom(labelEnd + 2);
         if (referenceEnd !== -1) {
           referenceLabel = text.slice(labelEnd + 2, referenceEnd) || label;
           nextSearchFrom = referenceEnd + 1;

--- a/scripts/privacy-publication-gate.test.ts
+++ b/scripts/privacy-publication-gate.test.ts
@@ -2203,6 +2203,53 @@ describe("privacy publication gate", () => {
     }
   });
 
+  test("audits escaped reference labels in Markdown images", async () => {
+    const originalOcrLanguages = process.env.LLV_PRIVACY_OCR_LANGUAGES;
+    const syntheticHome = ["", "home", "fixture-person", "escaped-reference-media"].join("/");
+    const media = pngWithCustomMetadata("eXIf", syntheticHome);
+    const mediaPath = "/user-attachments/assets/escaped-reference-capture";
+    const resolvedMedia = `https://github.com${mediaPath}`;
+    const requests: string[] = [];
+    const languageResult = Bun.spawnSync({ cmd: ["tesseract", "--list-langs"], stderr: "pipe", stdout: "pipe" });
+    const ocrLanguage = languageResult.stdout.toString().split(/\r?\n/).find((language) => /^[a-z0-9_]+$/i.test(language) && language !== "osd");
+    process.env.LLV_PRIVACY_OCR_LANGUAGES = ocrLanguage ?? "missing-test-language";
+    const fetcher = async (input: string | URL): Promise<Response> => {
+      const url = new URL(input);
+      requests.push(url.href);
+      if (url.href === resolvedMedia) {
+        return new Response(Uint8Array.from(media), { headers: { "content-type": "image/png" } });
+      }
+      if (url.pathname.endsWith("/issues/448")) {
+        return Response.json({
+          body: `![alt][a\\]b]\n\n[a\\]b]: ${mediaPath}`,
+          title: "Synthetic issue",
+        });
+      }
+      if (url.pathname.endsWith("/issues/448/comments")) return Response.json([]);
+      return new Response(null, { status: 404 });
+    };
+
+    try {
+      const findings = await auditGithubPublication({
+        apiUrl: "https://api.github.test/",
+        fetcher,
+        number: 448,
+        repo: "example/repository",
+        requireKnownValues: false,
+        token: "synthetic-github-audit-token",
+      });
+      const output = formatPrivacyReport(findings);
+
+      expect(output).toBe("PRIVACY GATE: FAIL\nhome_path: 1\nprovenance_missing: 1\n");
+      expect(requests).toHaveLength(3);
+      expect(requests.at(-1)).toBe(resolvedMedia);
+      expect(output).not.toContain(syntheticHome);
+    } finally {
+      if (originalOcrLanguages === undefined) delete process.env.LLV_PRIVACY_OCR_LANGUAGES;
+      else process.env.LLV_PRIVACY_OCR_LANGUAGES = originalOcrLanguages;
+    }
+  });
+
   test("fetches entity-encoded GitHub media references for inspection", async () => {
     const originalOcrLanguages = process.env.LLV_PRIVACY_OCR_LANGUAGES;
     const syntheticHome = ["", "home", "fixture-person", "encoded-media"].join("/");


### PR DESCRIPTION
Prerequisite trusted-parser repair for #456.

Parses GFM reference definition and explicit image labels with escape-aware bracket scanning, normalizes Markdown punctuation escapes, and adds an end-to-end relative extensionless media regression.

Verification: focused RED/GREEN reproduction, 86-test full privacy suite on the matching PR repair, TypeScript, scoped ESLint, production build, repository gate, and authenticated tracker audit.