### PR TITLE
test(deploy): cover exact revision validation boundaries (#454)

### DIFF
--- a/scripts/rebuild.test.ts
+++ b/scripts/rebuild.test.ts
@@ -74,6 +74,25 @@ test("rebuild accepts an exact revision as its positional argument", () => {
   });
 });
 
+for (const [name, revision] of [
+  ["39 lowercase hex characters", "a".repeat(39)],
+  ["41 lowercase hex characters", "a".repeat(41)],
+  ["uppercase hex", "A".repeat(40)],
+  ["embedded whitespace", `${"a".repeat(20)} ${"b".repeat(19)}`],
+  ["a ref-like value", "refs/heads/main"],
+  ["an embedded newline", `${"a".repeat(20)}\n${"b".repeat(20)}`],
+  ["an embedded carriage return", `${"a".repeat(20)}\r${"b".repeat(20)}`],
+] as const) {
+  test(`rebuild rejects ${name} before deployment admission`, () => {
+    const setup = fixture();
+    const result = runRebuild("invalid-revision", setup, revision);
+
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr.toString()).toContain("invalid revision");
+    expect(fs.existsSync(setup.capture)).toBe(false);
+  });
+}
+
 test("rebuild serializes a quoted 200-character idempotency key as JSON", () => {
   const setup = fixture();
   const prefix = 'release"1\\';


### PR DESCRIPTION
## Summary

Current main already contains the exact-40-character revision validator from PR #354. This adds the missing shell-level boundary matrix for 39 and 41 characters, uppercase hex, whitespace, ref-like input, newline, and carriage return. Every rejected value is proven to stop before deployment admission.

## Verification

- scripts/rebuild.test.ts: 11 passed
- diff check: passed

Closes #454
Closes #427
Closes #276