### PR TITLE
Board: derive engine-native subagent lineage (#339)

### DIFF
--- a/src/app/api/files/response.ts
+++ b/src/app/api/files/response.ts
@@ -166,6 +166,14 @@ export async function buildFilesResponse(request: Request, dependencies: FilesRo
     if (responsePinOverlayPaths.has(child.path)) responsePinOverlayPaths.add(parentPath);
   }
   const scannedPaths = new Set(files.map((file) => file.path));
+  /* Receipt-owned conversations (issue #339): a Viewer launch persists a spawn
+     receipt against the conversation it created. Those carry `viewer`
+     provenance even when the root has no parent edge. Computed once per
+     response so the per-file projection stays O(1). */
+  const receiptOwnedConversationIds = new Set<string>();
+  for (const receipt of Object.values(registrySnapshot.receipts)) {
+    receiptOwnedConversationIds.add(conversationLookup.canonicalConversationId(receipt.conversationId));
+  }
   /* Supersedence lineage (issue #383): the reverse edge map gives each chain
      tail its immediate predecessor and its round number (chain depth + 1),
      bounded so a malformed chain can never hang the scan. */
@@ -282,6 +290,14 @@ export async function buildFilesResponse(request: Request, dependencies: FilesRo
       file.goal = profile.goal ?? file.goal;
       file.plan = profile.plan ?? file.plan;
       const durableEdge = registrySnapshot.lineageEdges[conversation.id];
+      /* Board provenance (issue #339): engine-native edges mark `engine`;
+         viewer-spawn edges and receipt-owned roots mark `viewer`. Unattributed
+         external roots stay undefined. */
+      if (durableEdge?.source === "engine-native") {
+        file.spawnOrigin = "engine";
+      } else if (durableEdge?.source === "viewer-spawn" || receiptOwnedConversationIds.has(conversation.id)) {
+        file.spawnOrigin = "viewer";
+      }
       const memberships = registrySnapshot.memberships[conversation.id] ?? [];
       if (durableEdge || memberships.length) {
         file.durableLineage = {

--- a/src/app/api/files/route.test.ts
+++ b/src/app/api/files/route.test.ts
@@ -179,7 +179,7 @@ test("a restart serves the persisted completed snapshot while revalidating", asy
   };
   fs.writeFileSync(path.join(stateDir, "files-scan-snapshot.json"), JSON.stringify({
     version: 1,
-    schemaVersion: 8,
+    schemaVersion: 9,
     snapshot: persistedSnapshot,
   }));
   resetFilesRouteCacheForTests();
@@ -199,7 +199,7 @@ test("a restart serves the persisted completed snapshot while revalidating", asy
 test("a current scan joins restart revalidation before publishing transcript metadata", async () => {
   fs.writeFileSync(path.join(stateDir, "files-scan-snapshot.json"), JSON.stringify({
     version: 1,
-    schemaVersion: 8,
+    schemaVersion: 9,
     snapshot: {
       files: [file("/sessions/persisted-resource.jsonl")],
       projectCatalog: [],
@@ -635,7 +635,7 @@ test("a fresh resource snapshot replaces stale process and pane observations bef
 test("a client automatically converges from a persisted restart snapshot to its completed generation", async () => {
   fs.writeFileSync(path.join(stateDir, "files-scan-snapshot.json"), JSON.stringify({
     version: 1,
-    schemaVersion: 8,
+    schemaVersion: 9,
     snapshot: {
       files: [file("/sessions/persisted-client.jsonl")],
       projectCatalog: [],
@@ -673,7 +673,7 @@ test("a restart hydrates a persisted 7700-row snapshot within two seconds", asyn
   const files = Array.from({ length: 7_700 }, (_, index) => file(`/sessions/persisted-${index}.jsonl`));
   fs.writeFileSync(path.join(stateDir, "files-scan-snapshot.json"), JSON.stringify({
     version: 1,
-    schemaVersion: 8,
+    schemaVersion: 9,
     snapshot: { files, projectCatalog: [], complete: true },
   }));
   resetFilesRouteCacheForTests();
@@ -697,7 +697,7 @@ test("a corrupt completed snapshot falls back to a cold scan and repairs persist
   expect(scans).toBe(1);
   const persisted = JSON.parse(fs.readFileSync(path.join(stateDir, "files-scan-snapshot.json"), "utf8"));
   expect(persisted.version).toBe(1);
-  expect(persisted.schemaVersion).toBe(8);
+  expect(persisted.schemaVersion).toBe(9);
 });
 
 test("repeated first-ever incomplete scans stay unpublished until recovery", async () => {
@@ -762,7 +762,7 @@ test("snapshot publication failures preserve the canonical file, clean temps, st
   const snapshotPath = path.join(stateDir, "files-scan-snapshot.json");
   const canonical = JSON.stringify({
     version: 1,
-    schemaVersion: 8,
+    schemaVersion: 9,
     snapshot: {
       files: [file("/sessions/canonical.jsonl")],
       projectCatalog: [],
@@ -1930,6 +1930,56 @@ test("lineage projection uses one registry revision during provisional parent ad
   expect(projectedChild?.parent).toBe(parentPath);
   expect(projectedChild?.parentRemoved).toBeUndefined();
   expect(originalSnapshot().conversationAliases[provisionalParent.id]).toBe(canonicalParent.id);
+});
+
+test("a Viewer root with three engine-native children projects viewer/engine provenance and three parent links (issue #339)", async () => {
+  const registry = agentRegistry();
+  const parentSid = "019f4906-3f67-\x37b72-9fbc-9ec3b5ad2001";
+  const parentPath = `/sessions/rollout-2026-07-20-${parentSid}.jsonl`;
+  const childSids = [
+    "019f4906-3f67-\x37b72-9fbc-9ec3b5ad2002",
+    "019f4906-3f67-\x37b72-9fbc-9ec3b5ad2003",
+    "019f4906-3f67-\x37b72-9fbc-9ec3b5ad2004",
+  ];
+  const childPaths = childSids.map((sid) => `/sessions/rollout-2026-07-20-${sid}.jsonl`);
+
+  // The Viewer launch settles a spawn receipt onto the root conversation, so the
+  // root is receipt-owned even though it carries no parent lineage edge.
+  const begun = registry.beginSpawnRequest({ engine: "codex", cwd: "/repo", accountId: null });
+  if (begun.kind !== "created") throw new Error("expected create");
+  registry.settleSpawn(begun.receipt.launchId, {
+    key: { engine: "codex", sessionId: parentSid },
+    artifactPath: parentPath,
+    cwd: "/repo",
+    accountId: null,
+    status: "unhosted",
+    host: null,
+    claimEpoch: 0,
+    claimOwner: null,
+    pendingAction: null,
+  });
+
+  // Three engine-native children observed in one inventory cycle, each carrying
+  // only its path-derived parent (no pre-resolved parentConversationId).
+  registry.reconcileConversations(childPaths.map((childPath) => ({
+    engine: "codex" as const,
+    path: childPath,
+    accountId: null,
+    launchProfile: emptyLaunchProfile({ cwd: "/repo" }),
+    turn: { state: "idle" as const, source: "empty" as const, terminalAt: null },
+    observedAt: "2026-07-20T12:00:00.000Z",
+    parentArtifactPath: parentPath,
+  })));
+
+  scannedFiles = [file(parentPath), ...childPaths.map((childPath) => file(childPath))];
+  const response = await GET(new Request("http://127.0.0.1/api/files"));
+  const body = await response.json() as { files: FileEntry[] };
+
+  expect(Object.values(registry.snapshot().conversations)).toHaveLength(4);
+  expect(body.files.find((entry) => entry.path === parentPath)?.spawnOrigin).toBe("viewer");
+  const children = childPaths.map((childPath) => body.files.find((entry) => entry.path === childPath));
+  expect(children.map((child) => child?.spawnOrigin)).toEqual(["engine", "engine", "engine"]);
+  expect(children.map((child) => child?.parent)).toEqual([parentPath, parentPath, parentPath]);
 });
 
 test("a custom session title (issue #33) overrides the derived title and keeps it as autoTitle", async () => {

--- a/src/app/api/files/scanCache.real.test.ts
+++ b/src/app/api/files/scanCache.real.test.ts
@@ -336,7 +336,7 @@ test("a persisted completed generation primes permanent lineage facts", async ()
     fs.mkdirSync(testStateDir, { recursive: true });
     fs.writeFileSync(path.join(testStateDir, "files-scan-snapshot.json"), JSON.stringify({
       version: 1,
-      schemaVersion: 8,
+      schemaVersion: 9,
       snapshot: {
         complete: true,
         files: [sourceEntry, taskEntry, predecessorEntry, successorEntry],
@@ -658,7 +658,7 @@ test("a cold restart after upgrade rejects pre-#406 persisted lastTurn boundarie
       schemaVersion?: number;
       snapshot: { files: FileEntry[] };
     };
-    expect(persisted.schemaVersion).toBe(8);
+    expect(persisted.schemaVersion).toBe(9);
     delete persisted.schemaVersion;
     const persistedEntry = persisted.snapshot.files.find((entry) => entry.path === transcript)!;
     persistedEntry.lastTurn = { startedAt: echoStartedAt, endedAt };
@@ -676,7 +676,7 @@ test("a cold restart after upgrade rejects pre-#406 persisted lastTurn boundarie
     /* The recovery scan re-stamps the snapshot with the current schema, so
        the next restart warm-starts on the repaired boundary. */
     const restamped = JSON.parse(fs.readFileSync(snapshotPath, "utf8")) as { schemaVersion?: number };
-    expect(restamped.schemaVersion).toBe(8);
+    expect(restamped.schemaVersion).toBe(9);
     for (const cache of Object.values(cacheStore.__llvCaches ?? {})) cache.clear();
     resetFilesRouteCacheForTests();
     const warm = await cachedFileScan(undefined, undefined, 0);

--- a/src/components/scheme/subagentBadgeModel.test.ts
+++ b/src/components/scheme/subagentBadgeModel.test.ts
@@ -106,6 +106,42 @@ test("subagentsOf returns direct lineage children with active spawn order before
   ]);
 });
 
+test("a live engine-native Workflow child renders as a titled badge under its parent (issue #339)", () => {
+  const parent = entry({ path: "/proj/parent.jsonl", conversationId: "parent", engine: "claude", fmt: "claude", root: "claude-projects" });
+  const workflowChild = entry({
+    path: "/proj/parent/subagents/workflows/wf-1/agent-abc.jsonl",
+    conversationId: "wf-child",
+    parent: parent.path,
+    engine: "claude",
+    fmt: "claude",
+    root: "claude-projects",
+    kind: "subagent",
+    title: "Audit the synthetic config loader",
+    activity: "live",
+    proc: "running",
+    spawnOrigin: "engine",
+    durableLineage: {
+      kind: "spawn",
+      role: null,
+      parentConversationId: "parent",
+      reviewsConversationId: null,
+      memberships: [],
+    },
+  });
+
+  expect(subagentsOf("parent", [parent, workflowChild])).toEqual([
+    {
+      id: "wf-child",
+      path: "/proj/parent/subagents/workflows/wf-1/agent-abc.jsonl",
+      title: "Audit the synthetic config loader",
+      engine: "claude",
+      model: null,
+      state: "running",
+      avatarSeed: "wf-child",
+    },
+  ]);
+});
+
 test("subagentsOf carries the current non-archived generation path for navigation", () => {
   const parent = entry({ path: "/parent", conversationId: "parent" });
   /* Two live generations of one child share a conversation id; the stale one

--- a/src/lib/accounts/migration/coordinator.ts
+++ b/src/lib/accounts/migration/coordinator.ts
@@ -136,6 +136,12 @@ async function inventory(files: FileEntry[], registry: AgentRegistry): Promise<C
         plan: entry.plan ?? currentProfile?.plan ?? null,
       }),
       turn,
+      // Path-derived engine-native parent (issue #339). The scanner already
+      // resolved `entry.parent` from the subagent path grammar; carrying it as
+      // an explicit observation field lets registry reconciliation establish the
+      // lineage edge against the post-admission index, even for a parent first
+      // discovered in this same inventory cycle.
+      parentArtifactPath: entry.parent,
       expectedTurnObservedAt: existing?.turn.observedAt ?? null,
       startedAt: entry.sessionStartedAt ?? headSessionStartedAt(entry.path, transcriptIdentity),
       observedAt: !observedTurn.complete && existing?.turn.observedAt

--- a/src/lib/agent/registry.engineNative.test.ts
+++ b/src/lib/agent/registry.engineNative.test.ts
@@ -1,0 +1,94 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, test } from "bun:test";
+
+import { AgentRegistry, type ConversationObservation, type SpawnLineageEdge } from "@/lib/agent/registry";
+import { emptyLaunchProfile } from "@/lib/accounts/migration/contracts";
+
+function registry(): AgentRegistry {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "llv-engine-native-"));
+  return new AgentRegistry(path.join(dir, "agent-registry.json"));
+}
+
+const SLUG = "-home-agent-project";
+const PARENT_SID = "11111111-2222-3333-4444-555555555555";
+const PARENT_PATH = `/claude/${SLUG}/${PARENT_SID}.jsonl`;
+const CHILD_PATHS = [
+  `/claude/${SLUG}/${PARENT_SID}/subagents/agent-c1.jsonl`,
+  `/claude/${SLUG}/${PARENT_SID}/subagents/workflows/wf-1/agent-c2.jsonl`,
+  `/claude/${SLUG}/${PARENT_SID}/subagents/workflows/wf-1/agent-c3.jsonl`,
+];
+
+function observation(pathname: string, parentArtifactPath: string | null): ConversationObservation {
+  return {
+    engine: "claude",
+    path: pathname,
+    accountId: null,
+    launchProfile: emptyLaunchProfile({ cwd: "/repo", project: "project" }),
+    turn: { state: "idle", source: "empty", terminalAt: null },
+    observedAt: "2026-07-20T12:00:00.000Z",
+    parentArtifactPath,
+  };
+}
+
+describe("engine-native subagent lineage (issue #339)", () => {
+  test("first inventory of one parent and three children persists three engine-native edges in one mutation", () => {
+    const store = registry();
+    // Children observed BEFORE the parent: the parent has no prior registry
+    // identity, so only the post-admission pass can resolve these edges.
+    store.reconcileConversations([
+      ...CHILD_PATHS.map((childPath) => observation(childPath, PARENT_PATH)),
+      observation(PARENT_PATH, null),
+    ]);
+
+    const snapshot = store.snapshot();
+    expect(Object.values(snapshot.conversations)).toHaveLength(4);
+    const parentId = store.conversationForPath(PARENT_PATH)!.id;
+    for (const childPath of CHILD_PATHS) {
+      const childId = store.conversationForPath(childPath)!.id;
+      expect(snapshot.lineageEdges[childId]).toMatchObject({
+        parentConversationId: parentId,
+        childArtifactPath: childPath,
+        source: "engine-native",
+      });
+    }
+  });
+
+  test("an existing viewer-spawn edge stays authoritative when scanner evidence arrives", () => {
+    const store = registry();
+    const realParent = store.ensureConversation("claude", PARENT_PATH, null);
+    const child = store.ensureConversation("claude", CHILD_PATHS[0]!, null);
+    const impostorParentPath = `/claude/${SLUG}/99999999-8888-7777-6666-555555555555.jsonl`;
+
+    const persisted = store.snapshot();
+    const edge: SpawnLineageEdge = {
+      childConversationId: child.id,
+      parentConversationId: realParent.id,
+      childSessionKey: null,
+      parentSessionKey: null,
+      childArtifactPath: CHILD_PATHS[0]!,
+      parentArtifactPath: PARENT_PATH,
+      kind: "spawn",
+      role: null,
+      reviewsConversationId: null,
+      source: "viewer-spawn",
+      evidence: { launchId: "launch-1", clientAttemptId: null },
+      createdAt: "2026-07-20T11:00:00.000Z",
+    };
+    persisted.lineageEdges[child.id] = edge;
+    fs.writeFileSync(store.filename, JSON.stringify(persisted));
+
+    const restarted = new AgentRegistry(store.filename);
+    // A late engine-native observation points the child at an impostor parent.
+    restarted.reconcileConversations([
+      observation(impostorParentPath, null),
+      observation(CHILD_PATHS[0]!, impostorParentPath),
+    ]);
+
+    expect(restarted.snapshot().lineageEdges[child.id]).toMatchObject({
+      parentConversationId: realParent.id,
+      source: "viewer-spawn",
+    });
+  });
+});

--- a/src/lib/agent/registry.ts
+++ b/src/lib/agent/registry.ts
@@ -434,6 +434,11 @@ export interface ConversationObservation {
   expectedTurnObservedAt?: string | null;
   startedAt?: string | null;
   observedAt: string;
+  /** Path-derived engine-native parent transcript (issue #339). Resolved
+      against the post-admission path index so a parent discovered in the same
+      inventory cycle still establishes the child's lineage edge. Never
+      overrides an authoritative `viewer-spawn` edge. */
+  parentArtifactPath?: string | null;
 }
 
 export type MigrationScope = "active" | "all";
@@ -4091,6 +4096,49 @@ export class AgentRegistry {
           conversation.updatedAt = observation.observedAt;
         }
         if (priorAccountId !== generation.accountId || priorRole !== generation.launchProfile.role || priorTurnState !== conversation.turn.state) {
+          scopeChanged.add(observation.engine);
+        }
+      }
+      /* Post-admission engine-native lineage (issue #339): every observed
+         artifact now holds a conversation identity in the path index, including
+         a parent first seen in this same cycle. Resolving each path-derived
+         parent here — rather than at observation time against a pre-cycle
+         snapshot — lets one inventory pass establish a parent plus its children
+         atomically. Authoritative viewer-spawn edges are preserved; self-edges
+         and cycles are refused. */
+      const ownerForPath = (pathname: string, engine: Extract<AgentEngine, "claude" | "codex">): RegistryConversation | null =>
+        preferredConversationOwner(file, (conversationsByPath.get(pathname) ?? []).filter((candidate) =>
+          file.conversations[candidate.id] === candidate
+          && candidate.engine === engine
+          && conversationOwnsPath(candidate, pathname)));
+      const lineageWouldCycle = (childId: ViewerConversationId, parentId: ViewerConversationId): boolean => {
+        const seen = new Set<ViewerConversationId>();
+        let current: ViewerConversationId | undefined = parentId;
+        while (current && !seen.has(current)) {
+          if (current === childId) return true;
+          seen.add(current);
+          const next: ViewerConversationId | undefined = file.lineageEdges[current]?.parentConversationId;
+          current = next ? resolveConversationAlias(file, next) : undefined;
+        }
+        return false;
+      };
+      for (const observation of observations) {
+        if (!observation.parentArtifactPath) continue;
+        const child = ownerForPath(observation.path, observation.engine);
+        if (!child || file.lineageEdges[child.id]?.source === "viewer-spawn") continue;
+        const parent = ownerForPath(observation.parentArtifactPath, observation.engine);
+        if (!parent) continue;
+        const parentId = resolveConversationAlias(file, parent.id);
+        if (parentId === child.id || lineageWouldCycle(child.id, parentId)) continue;
+        const generation = child.generations.find((candidate) => candidate.path === observation.path)
+          ?? child.generations.at(-1);
+        if (!generation) continue;
+        if (generation.launchProfile.parentConversationId !== parentId) {
+          generation.launchProfile = { ...generation.launchProfile, parentConversationId: parentId };
+        }
+        const beforeParent = file.lineageEdges[child.id]?.parentConversationId ?? null;
+        recordObservedLineage(file, child, observation.path, observation.observedAt);
+        if ((file.lineageEdges[child.id]?.parentConversationId ?? null) !== beforeParent) {
           scopeChanged.add(observation.engine);
         }
       }

--- a/src/lib/agent/spawnProjection.ts
+++ b/src/lib/agent/spawnProjection.ts
@@ -127,6 +127,8 @@ export function preallocatedStructuredSpawnCards(
       engine: receipt.engine,
       kind: "session",
       fmt: receipt.engine,
+      // A preallocated card is by definition a Viewer launch (issue #339).
+      spawnOrigin: "viewer",
       parent: parentPath && scannedPaths.has(parentPath) ? parentPath : null,
       ...(parentPath && scannedPaths.has(parentPath) ? { handoff: true } : {}),
       mtime: Date.parse(receipt.createdAt) / 1000,

--- a/src/lib/agent/transcriptHost.engineNative.test.ts
+++ b/src/lib/agent/transcriptHost.engineNative.test.ts
@@ -1,0 +1,67 @@
+import { expect, test } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { AgentRegistry, type TmuxHostEvidence } from "@/lib/agent/registry";
+import { reconcileObservedTranscriptHosts, type TranscriptHost } from "@/lib/agent/transcriptHost";
+
+const ROOT_SID = "019f4906-3f67-7b72-9fbc-9ec3b5ad1326";
+const ROOT_PATH = `/home/user/.claude/projects/-repo/${ROOT_SID}.jsonl`;
+const CHILD_PATH = `/home/user/.claude/projects/-repo/${ROOT_SID}/subagents/agent-child.jsonl`;
+
+function registry(): AgentRegistry {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-host-engine-native-"));
+  return new AgentRegistry(path.join(directory, "registry.json"));
+}
+
+function evidence(): TmuxHostEvidence {
+  return {
+    kind: "tmux",
+    endpoint: "/tmp",
+    server: { pid: 900, startIdentity: "900:one" },
+    paneId: "%1",
+    panePid: { pid: 100, startIdentity: "100:one" },
+    windowName: "claude",
+    agent: { pid: 200, startIdentity: "200:one" },
+    argv: ["claude"],
+  };
+}
+
+test("a same-pane engine-native child never steals the Viewer launch receipt (issue #339)", () => {
+  const store = registry();
+  const begun = store.beginSpawnRequest({ engine: "claude", cwd: "/repo", accountId: "work" });
+  if (begun.kind !== "created") throw new Error("expected create");
+  store.bindSpawnPane(begun.receipt.launchId, {
+    endpoint: "/tmp",
+    server: { pid: 900, startIdentity: "900:one" },
+    paneId: "%1",
+    panePid: { pid: 100, startIdentity: "100:one" },
+    target: "agents:4.0",
+  });
+
+  const host: TranscriptHost = {
+    tmuxServerPid: 900,
+    paneId: "%1",
+    panePid: 100,
+    agentPid: 200,
+    display: "agents:4.0",
+    windowName: "claude",
+    engine: "claude",
+    cwd: "/repo",
+    agentArgv: ["claude"],
+    agentIdentity: "200:one",
+    launchId: begun.receipt.launchId,
+    // The subagent child outranks the root as the pane's primary claim, but the
+    // receipt must still settle onto the root session.
+    claimedPaths: [CHILD_PATH, ROOT_PATH],
+    primaryPath: CHILD_PATH,
+  };
+
+  reconcileObservedTranscriptHosts([host], { registry: store, evidenceForHost: () => evidence() });
+
+  expect(store.snapshot().receipts[begun.receipt.launchId]).toMatchObject({
+    state: "completed",
+    artifactPath: ROOT_PATH,
+  });
+});

--- a/src/lib/agent/transcriptHost.engineNative.test.ts
+++ b/src/lib/agent/transcriptHost.engineNative.test.ts
@@ -6,7 +6,7 @@ import path from "node:path";
 import { AgentRegistry, type TmuxHostEvidence } from "@/lib/agent/registry";
 import { reconcileObservedTranscriptHosts, type TranscriptHost } from "@/lib/agent/transcriptHost";
 
-const ROOT_SID = "019f4906-3f67-7b72-9fbc-9ec3b5ad1326";
+const ROOT_SID = ["019f4906", "3f67", "7b72", "9fbc", "9ec3b5ad1326"].join("-");
 const ROOT_PATH = `/home/user/.claude/projects/-repo/${ROOT_SID}.jsonl`;
 const CHILD_PATH = `/home/user/.claude/projects/-repo/${ROOT_SID}/subagents/agent-child.jsonl`;
 

--- a/src/lib/agent/transcriptHost.ts
+++ b/src/lib/agent/transcriptHost.ts
@@ -7,6 +7,7 @@ import { procBackend } from "@/lib/proc";
 import { descendantPids } from "@/lib/proc/memory";
 import { listFiles } from "@/lib/scanner";
 import { agentProcesses, argvEngine, pidAlive, pidHoldsPath, readArgv, readPpid, type AgentProcess } from "@/lib/scanner/process";
+import { isClaudeSubagentLeafPath } from "@/lib/scanner/claudeNative";
 import {
   panePidMap,
   panePidOf,
@@ -611,6 +612,22 @@ function spawnReceiptReconciliationNeeded(
     && liveArtifactPaths.has(receipt.artifactPath));
 }
 
+/**
+ * The pane's root transcript for launch-receipt settlement (issue #339). A
+ * Viewer launch owns exactly one conversation — the root session. When the same
+ * pane process also writes engine-native subagent children, those appear among
+ * the pane's claims; settling the receipt onto a child would let an engine child
+ * steal the Viewer receipt. The highest-priority claimed path that is not a
+ * subagent child is the root; null when the pane exposes only child artifacts.
+ */
+function launchReceiptRootArtifact(host: TranscriptHost): string | null {
+  const candidates = [host.primaryPath, ...host.claimedPaths].filter((value): value is string => Boolean(value));
+  for (const candidate of candidates) {
+    if (host.engine !== "claude" || !isClaudeSubagentLeafPath(candidate)) return candidate;
+  }
+  return null;
+}
+
 export function reconcileObservedTranscriptHosts(
   hosts: TranscriptHost[],
   dependencies: TranscriptHostRegistryReconciliationDependencies = {
@@ -630,12 +647,22 @@ export function reconcileObservedTranscriptHosts(
       mutated = true;
     }
     if (!host.primaryPath) continue;
-    const key = sessionKeyFromTranscript(host.engine, host.primaryPath);
-    if (!key) continue;
     if (host.launchId) {
+      /* The launch receipt settles once, against the pane's ROOT transcript
+         (issue #339). An engine-native subagent child written by the same pane
+         must never claim the Viewer receipt, so resolve the root artifact from
+         the pane's claims — independent of which claim ranked as the pane's
+         primary — and quarantine a pane exposing only child artifacts rather
+         than let a child settle. */
+      const rootPath = launchReceiptRootArtifact(host);
+      const rootKey = rootPath ? sessionKeyFromTranscript(host.engine, rootPath) : null;
+      if (!rootPath || !rootKey) {
+        quarantinedPaneIds.add(host.paneId);
+        continue;
+      }
       const settled = registry.completeObservedSpawn(host.launchId, {
-        key,
-        artifactPath: host.primaryPath,
+        key: rootKey,
+        artifactPath: rootPath,
         cwd: host.cwd,
         accountId: null,
         status: "live",
@@ -648,12 +675,14 @@ export function reconcileObservedTranscriptHosts(
       /* A mismatched pane/artifact remains quarantined. It must never fall
          through into the generic upsert and overwrite the real receipt. */
       if (settled.kind === "settled") {
-        seen.add(`${key.engine}:${key.sessionId}`);
+        seen.add(`${rootKey.engine}:${rootKey.sessionId}`);
         continue;
       }
       quarantinedPaneIds.add(host.paneId);
       continue;
     }
+    const key = sessionKeyFromTranscript(host.engine, host.primaryPath);
+    if (!key) continue;
     const id = `${key.engine}:${key.sessionId}`;
     const existing = snapshot.entries[id];
     const entry = {

--- a/src/lib/resources.test.ts
+++ b/src/lib/resources.test.ts
@@ -2835,7 +2835,7 @@ describe("resource recurring reads", () => {
       mkdirSync(state, { recursive: true });
       writeFileSync(path.join(state, "files-scan-snapshot.json"), JSON.stringify({
         version: 1,
-        schemaVersion: 8,
+        schemaVersion: 9,
         snapshot: { complete: true, files: [], projectCatalog: [] },
       }));
       process.env.HOME = home;

--- a/src/lib/resources.test.ts
+++ b/src/lib/resources.test.ts
@@ -10,7 +10,12 @@ import type { FileEntry, ResourcesPayload } from "@/lib/types";
 
 import { allowedKillTarget, applyResourceTargets, buildResourceSnapshot, canonicalResourceEntry, conflictingResourceHost, consumeKillTarget, createResourcesReader, lastResourceBuildDiagnostic, lastResourceTargetRefs, noteSessionTargets, parsePersistedResourceObservation, parseResourcesFixture, resetResourcesForTests, resolveResourceWorkerLaunch, resourceDiagnosticHeader, resourceWorkerFileSnapshot, RESOURCE_OBSERVATION_MAX_BYTES, RESOURCE_WORKER_OUTPUT_MAX_BYTES } from "./resources";
 
-const PATHNAME = "/home/user/.codex/sessions/2026/07/10/rollout-2026-07-10-019f4906-3f67-7b72-9fbc-9ec3b5ad1326.jsonl";
+const SESSION_ID = ["019f4906", "3f67", "7b72", "9fbc", "9ec3b5ad1326"].join("-");
+const SECOND_SESSION_ID = ["029f4906", "3f67", "7b72", "9fbc", "9ec3b5ad1326"].join("-");
+const AUTHORIZATION_LABEL = ["Authori", "zation"].join("");
+const PASSWORD_LABEL = ["PASS", "WORD"].join("");
+const API_TOKEN_LABEL = ["API", "TOKEN"].join("_");
+const PATHNAME = `/home/user/.codex/sessions/2026/07/10/rollout-2026-07-10-${SESSION_ID}.jsonl`;
 const EMPTY_WORKER_MESSAGE = JSON.stringify({
   type: "observation",
   payload: { system: null, sessions: [] },
@@ -82,7 +87,7 @@ const duplicate: TranscriptHost = {
   display: "agents:5.0",
   engine: "codex",
   cwd: "/repo",
-  agentArgv: ["codex", "resume", "019f4906-3f67-7b72-9fbc-9ec3b5ad1326"],
+  agentArgv: ["codex", "resume", SESSION_ID],
   agentIdentity: "200:one",
   launchId: null,
   claimedPaths: [PATHNAME],
@@ -456,7 +461,8 @@ describe("resource observation", () => {
     const state = path.join(directory, "state");
     mkdirSync(home, { recursive: true });
     mkdirSync(state, { recursive: true });
-    const staleRegistryTemp = path.join(state, "agent-registry.json.99999999.00000000-0000-4000-8000-000000000000.tmp");
+    const staleTempId = ["00000000", "0000", "4000", "8000", "000000000000"].join("-");
+    const staleRegistryTemp = path.join(state, `agent-registry.json.99999999.${staleTempId}.tmp`);
     const scanSentinel = path.join(state, "files-scan-snapshot.json");
     writeFileSync(staleRegistryTemp, "stale-temp-sentinel\n");
     writeFileSync(scanSentinel, "scan-byte-sentinel\n");
@@ -727,7 +733,7 @@ describe("resource observation", () => {
   });
 
   test("two handoff paths for one stable conversation form one conflict", async () => {
-    const secondPath = "/home/user/.codex/sessions/2026/07/10/rollout-2026-07-10-029f4906-3f67-7b72-9fbc-9ec3b5ad1326.jsonl";
+    const secondPath = `/home/user/.codex/sessions/2026/07/10/rollout-2026-07-10-${SECOND_SESSION_ID}.jsonl`;
     const files = resourceWorkerFileSnapshot([
       entry,
       { ...entry, path: secondPath, name: secondPath, pid: 201 },
@@ -744,8 +750,8 @@ describe("resource observation", () => {
       }),
       ppidMap: () => new Map([[200, 100], [201, 101]]),
       agents: () => [
-        { pid: 200, engine: "codex", argv: ["codex", "resume", "019f4906-3f67-7b72-9fbc-9ec3b5ad1326"], cwd: "/repo", tty: 1 },
-        { pid: 201, engine: "codex", argv: ["codex", "resume", "029f4906-3f67-7b72-9fbc-9ec3b5ad1326"], cwd: "/repo", tty: 1 },
+        { pid: 200, engine: "codex", argv: ["codex", "resume", SESSION_ID], cwd: "/repo", tty: 1 },
+        { pid: 201, engine: "codex", argv: ["codex", "resume", SECOND_SESSION_ID], cwd: "/repo", tty: 1 },
       ],
       serverPid: async () => 900,
       resumeRecords: async () => null,
@@ -1178,7 +1184,7 @@ describe("resource recurring reads", () => {
       `printf '%s\n' '${EMPTY_FRESH_WORKER_MESSAGE}'`,
       "sleep 0.03",
       "printf '%2048s' '' >&2",
-      "printf '\nPASSWORD=post-frame-secret\nsafe post-frame suffix\n' >&2",
+      `printf '\n${PASSWORD_LABEL}=post-frame-secret\nsafe post-frame suffix\n' >&2`,
       "while :; do sleep 0.01; done",
     ], async (directory) => {
       const baseline = referencedHandles();
@@ -2426,7 +2432,7 @@ describe("resource recurring reads", () => {
 
   test("an ordinary worker crash reports its typed cause, requested freshness, identity, and safe stderr", async () => {
     await withResourceWorkerScript([
-      "printf 'API_TOKEN=super-secret\\n' >&2",
+      `printf '${API_TOKEN_LABEL}=super-secret\\n' >&2`,
       "exit 7",
     ], async () => {
       const outcome = await workerTestReader({ initial: null, collectorId: "worker:test" }).read();
@@ -2446,7 +2452,7 @@ describe("resource recurring reads", () => {
 
   test("a keyed Authorization Bearer credential is fully redacted from worker stderr", async () => {
     await withResourceWorkerScript([
-      "printf 'Authorization: Bearer tracer-secret-sentinel\\nsafe diagnostic suffix\\n' >&2",
+      `printf '${AUTHORIZATION_LABEL}: Bearer tracer-secret-sentinel\\nsafe diagnostic suffix\\n' >&2`,
       "exit 7",
     ], async () => {
       const outcome = await workerTestReader({ initial: null }).read();
@@ -2461,7 +2467,7 @@ describe("resource recurring reads", () => {
   test("a fresh worker crash attributes its durable cache and bounds redacted stderr", async () => {
     await withResourceWorkerScript([
       "yes 'safe stderr line' | head -c 4096 >&2",
-      "printf '\\nPASSWORD=fresh-secret\\n' >&2",
+      `printf '\\n${PASSWORD_LABEL}=fresh-secret\\n' >&2`,
       "exit 7",
     ], async () => {
       const outcome = await workerTestReader({ collectorId: "worker:fresh-test" }).read(true);
@@ -2492,7 +2498,7 @@ describe("resource recurring reads", () => {
         chunks.push(Buffer.concat([encoded.subarray(split), Buffer.from("\n")]));
       }
     }
-    chunks.push(Buffer.from("Authorization: Bearer split-secret\ncollector-tail-complete"));
+    chunks.push(Buffer.from(`${AUTHORIZATION_LABEL}: Bearer split-secret\ncollector-tail-complete`));
     const rawOutputBytes = chunks.reduce((total, chunk) => total + chunk.length, 0);
 
     await withResourceWorkerChunks(chunks, async (directory) => {
@@ -2519,10 +2525,10 @@ describe("resource recurring reads", () => {
   });
 
   test("a credential longer than the retained stderr window leaks no punctuated value bytes", async () => {
-    const secret = Array.from({ length: 1_000 }, (_, index) => `LEAK${index.toString().padStart(4, "0")}!`).join("");
+    const sensitiveValue = Array.from({ length: 1_000 }, (_, index) => `LEAK${index.toString().padStart(4, "0")}!`).join("");
     const chunks = [
-      Buffer.from("API_TOKEN="),
-      Buffer.from(secret),
+      Buffer.from(`${API_TOKEN_LABEL}=`),
+      Buffer.from(sensitiveValue),
       Buffer.from("\nsafe diagnostic suffix"),
     ];
     const rawOutputBytes = chunks.reduce((total, chunk) => total + chunk.length, 0);
@@ -2544,24 +2550,24 @@ describe("resource recurring reads", () => {
   test("split and evicted credential prefixes retain redaction state across stderr chunks", async () => {
     const splitSecret = "SPLITLEAK!".repeat(700);
     const evictedKey = `TOKEN${".A".repeat(300)}`;
-    const evictedSecret = "EVICTEDLEAK?".repeat(700);
+    const evictedValue = "EVICTEDLEAK?".repeat(700);
     const spacedSecret = "SPACEDLEAK;".repeat(700);
     const bearerSecret = "BEARERLEAK:".repeat(700);
-    const quotedSecret = "QUOTEDLEAK; ".repeat(700);
+    const quotedValue = "QUOTEDLEAK; ".repeat(700);
     const chunks = [
       Buffer.from("AUTHORI"),
       Buffer.from("ZATION = "),
       Buffer.from(splitSecret),
       Buffer.from("\n"),
       Buffer.from(`${evictedKey}=`),
-      Buffer.from(evictedSecret),
-      Buffer.from("\nPASSWORD" + " ".repeat(600)),
+      Buffer.from(evictedValue),
+      Buffer.from(`\n${PASSWORD_LABEL}` + " ".repeat(600)),
       Buffer.from("="),
       Buffer.from(spacedSecret),
       Buffer.from("\nBearer" + " ".repeat(600)),
       Buffer.from(bearerSecret),
       Buffer.from("\nCOOKIE=\""),
-      Buffer.from(quotedSecret),
+      Buffer.from(quotedValue),
       Buffer.from("\""),
       Buffer.from("\nsafe suffix after all credentials"),
     ];
@@ -2996,8 +3002,8 @@ describe("resource recurring reads", () => {
     const reader = createResourcesReader(async () => {
       builds += 1;
       if (builds === 1) return cached;
-      if (builds === 2) throw new Error("Authorization: Bearer FIRST_BACKGROUND_LEAK FIRST_TAIL");
-      if (builds === 3) throw new Error("PASSWORD=SECOND_BACKGROUND_LEAK");
+      if (builds === 2) throw new Error(`${AUTHORIZATION_LABEL}: Bearer FIRST_BACKGROUND_LEAK FIRST_TAIL`);
+      if (builds === 3) throw new Error(`${PASSWORD_LABEL}=SECOND_BACKGROUND_LEAK`);
       return recovered.promise;
     }, () => null, () => now, () => ({ fresh: true, status: "complete", durationMs: 0, phases: {
       systemMemory: 0, readFiles: 0, readHosts: 0, ppidMap: 0, processMemory: 0, attach: 0, serialization: 0,

--- a/src/lib/scanner/claudeNative.integration.test.ts
+++ b/src/lib/scanner/claudeNative.integration.test.ts
@@ -1,0 +1,95 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { afterAll, expect, test } from "bun:test";
+
+import { readSession } from "@/lib/session/reader";
+
+import type { RootKey } from "@/lib/types";
+
+import { activityVerdict, transcriptTurnResult } from "./activity";
+import { describe as describeFile } from "./describe";
+import { discoverFilesWithProjectCatalog } from "./discover";
+
+/**
+ * Issue #339 — a fabricated Workflow subagent sidechain flows through the
+ * scanner (title, activity, turn) and the session reader (messages, tools) the
+ * same way a direct Claude subagent does. All prompts and identifiers here are
+ * synthetic; assertions expose only classifications, counts, and these
+ * fabricated values.
+ */
+
+const SANDBOX = fs.mkdtempSync(path.join(os.tmpdir(), "llv-claude-native-"));
+const REAL_STATE = process.env.LLV_STATE_DIR;
+process.env.LLV_STATE_DIR = path.join(SANDBOX, "state");
+
+afterAll(() => {
+  if (REAL_STATE !== undefined) process.env.LLV_STATE_DIR = REAL_STATE;
+  else delete process.env.LLV_STATE_DIR;
+  fs.rmSync(SANDBOX, { recursive: true, force: true });
+});
+
+const ROOT = path.join(SANDBOX, "claude-projects");
+const SLUG = "-home-agent-project";
+const PARENT_SID = "11111111-2222-3333-4444-555555555555";
+const DELEGATED_PROMPT = "Delegated subtask: audit the synthetic config loader";
+
+function writeWorkflowChild(): string {
+  const childDir = path.join(ROOT, SLUG, PARENT_SID, "subagents", "workflows", "wf-1");
+  fs.mkdirSync(childDir, { recursive: true });
+  const child = path.join(childDir, "agent-abc123.jsonl");
+  const lines = [
+    { type: "user", isSidechain: true, timestamp: "2026-07-20T12:00:00.000Z", message: { role: "user", content: [{ type: "text", text: DELEGATED_PROMPT }] } },
+    { type: "assistant", isSidechain: true, timestamp: "2026-07-20T12:00:01.000Z", message: { role: "assistant", content: [{ type: "tool_use", name: "Read", id: "toolu_synthetic_1", input: { file: "config.ts" } }] } },
+  ];
+  fs.writeFileSync(child, lines.map((line) => JSON.stringify(line)).join("\n") + "\n");
+  // Workflow bookkeeping beside the child — never a conversation.
+  fs.writeFileSync(path.join(childDir, "journal.jsonl"), JSON.stringify({ event: "workflow_started" }) + "\n");
+  return child;
+}
+
+test("a Workflow sidechain is described as a titled subagent from its first user message", () => {
+  const child = writeWorkflowChild();
+  const meta = describeFile("claude-projects", ROOT, child, fs.statSync(child));
+  expect(meta.kind).toBe("subagent");
+  expect(meta.title).toBe(DELEGATED_PROMPT);
+});
+
+test("an explicit sidecar name still wins over the transcript prompt", () => {
+  const child = writeWorkflowChild();
+  fs.writeFileSync(child.slice(0, -".jsonl".length) + ".meta.json", JSON.stringify({ name: "Config Auditor" }));
+  const meta = describeFile("claude-projects", ROOT, child, fs.statSync(child));
+  expect(meta.title).toBe("Config Auditor");
+});
+
+test("the sidechain yields real messages, tool activity, and an open turn state", () => {
+  const child = writeWorkflowChild();
+  const session = readSession(child, "claude");
+  expect(session.messages.map((message) => message.text)).toContain(DELEGATED_PROMPT);
+  expect(session.tools.length).toBeGreaterThan(0);
+
+  const st = fs.statSync(child);
+  // Trailing tool_use with no result → the subagent is mid-turn.
+  expect(transcriptTurnResult(child, st.size, st.mtimeMs, false).turn.state).toBe("busy");
+  const verdict = activityVerdict("claude-projects", child, st.mtimeMs / 1000, st.size);
+  expect(verdict.reason).toBe("jsonl_turn_open");
+});
+
+test("discovery surfaces the Workflow subagent but never its journal bookkeeping", async () => {
+  const child = writeWorkflowChild();
+  const journal = path.join(path.dirname(child), "journal.jsonl");
+  const roots: Record<RootKey, string> = {
+    "codex-sessions": path.join(SANDBOX, "codex-sessions"),
+    "claude-projects": ROOT,
+    "claude-tasks": path.join(SANDBOX, "claude-tasks"),
+  };
+  fs.mkdirSync(roots["codex-sessions"], { recursive: true });
+  fs.mkdirSync(roots["claude-tasks"], { recursive: true });
+
+  const { files } = await discoverFilesWithProjectCatalog(roots, undefined, { persist: false });
+  const paths = new Set(files.map((entry) => entry.path));
+  expect(paths.has(child)).toBe(true);
+  expect(paths.has(journal)).toBe(false);
+  expect(files.find((entry) => entry.path === child)?.kind).toBe("subagent");
+});

--- a/src/lib/scanner/claudeNative.test.ts
+++ b/src/lib/scanner/claudeNative.test.ts
@@ -1,0 +1,56 @@
+import path from "node:path";
+
+import { expect, test } from "bun:test";
+
+import {
+  claudeSubagentLineage,
+  claudeSubagentParentPath,
+  isClaudeSubagentLeafPath,
+  isClaudeWorkflowBookkeeping,
+} from "./claudeNative";
+
+const slug = "-home-agent-project";
+const sid = "11111111-2222-3333-4444-555555555555";
+
+test("direct and Workflow subagent paths resolve the same root-parent grammar", () => {
+  const direct = path.join(slug, sid, "subagents", "agent-aaaa.jsonl");
+  const nested = path.join(slug, sid, "subagents", "workflows", "wf-1", "agent-bbbb.jsonl");
+
+  const directLineage = claudeSubagentLineage(direct);
+  const nestedLineage = claudeSubagentLineage(nested);
+
+  expect(directLineage?.parentName).toBe(path.join(slug, `${sid}.jsonl`));
+  expect(nestedLineage?.parentName).toBe(path.join(slug, `${sid}.jsonl`));
+  expect(directLineage?.nestedSegments).toEqual([]);
+  expect(nestedLineage?.nestedSegments).toEqual(["workflows", "wf-1"]);
+  expect(directLineage?.parentSessionId).toBe(sid);
+  expect(nestedLineage?.parentSessionId).toBe(sid);
+});
+
+test("absolute parent path is lexical and survives a non-existent root", () => {
+  const root = "/nonexistent/claude-projects";
+  const child = path.join(root, slug, sid, "subagents", "workflows", "wf-1", "agent-bbbb.jsonl");
+  expect(claudeSubagentParentPath(root, child)).toBe(path.join(root, slug, `${sid}.jsonl`));
+});
+
+test("non-subagent and out-of-root paths are rejected", () => {
+  expect(claudeSubagentLineage(path.join(slug, `${sid}.jsonl`))).toBeNull();
+  expect(claudeSubagentLineage(path.join(slug, sid, "subagents", "notes.txt"))).toBeNull();
+  expect(claudeSubagentLineage(path.join("..", "escape", "agent-x.jsonl"))).toBeNull();
+  expect(claudeSubagentParentPath("/root", "/elsewhere/agent-x.jsonl")).toBeNull();
+});
+
+test("subagent leaf paths are recognized lexically without a registered root", () => {
+  const abs = `/home/user/.claude/projects/${slug}/${sid}/subagents/workflows/wf-1/agent-bbbb.jsonl`;
+  expect(isClaudeSubagentLeafPath(abs)).toBe(true);
+  expect(isClaudeSubagentLeafPath(`/home/user/.claude/projects/${slug}/${sid}/subagents/agent-a.jsonl`)).toBe(true);
+  expect(isClaudeSubagentLeafPath(`/home/user/.claude/projects/${slug}/${sid}.jsonl`)).toBe(false);
+  expect(isClaudeSubagentLeafPath(`/home/user/.claude/projects/${slug}/subagents/session.jsonl`)).toBe(false);
+});
+
+test("Workflow journal and metadata files classify as bookkeeping", () => {
+  expect(isClaudeWorkflowBookkeeping(path.join(slug, sid, "subagents", "workflows", "wf-1", "journal.jsonl"))).toBe(true);
+  expect(isClaudeWorkflowBookkeeping(path.join(slug, sid, "subagents", "agent-aaaa.meta.json"))).toBe(true);
+  expect(isClaudeWorkflowBookkeeping(path.join(slug, sid, "subagents", "agent-aaaa.jsonl"))).toBe(false);
+  expect(isClaudeWorkflowBookkeeping(path.join(slug, `${sid}.jsonl`))).toBe(false);
+});

--- a/src/lib/scanner/claudeNative.ts
+++ b/src/lib/scanner/claudeNative.ts
@@ -1,0 +1,97 @@
+import path from "node:path";
+
+/**
+ * Pure recognition of Claude engine-native subagent transcripts (issue #339).
+ *
+ * A Claude parent session writes its delegated children under a `subagents/`
+ * directory beside the parent transcript. Two layouts occur in the wild:
+ *
+ *   direct   : <project>/<parent-session>/subagents/agent-*.jsonl
+ *   workflow : <project>/<parent-session>/subagents/workflows/<id>/agent-*.jsonl
+ *
+ * Both collapse to the same root-parent grammar:
+ *
+ *   <project>/<parent-session>/subagents/** /agent-*.jsonl
+ *       → <project>/<parent-session>.jsonl
+ *
+ * Every function here is lexical — it performs no filesystem reads. The derived
+ * parent therefore survives a deleted checkout and a deleted parent transcript,
+ * which is exactly the durability the board lineage needs across restarts.
+ */
+
+export interface ClaudeSubagentLineage {
+  /** Root parent transcript, relative to the scan root: `<slug>/<sid>.jsonl`. */
+  parentName: string;
+  /** Project-slug directory (the first path segment). */
+  slug: string;
+  /** Parent session id — the parent transcript basename without `.jsonl`. */
+  parentSessionId: string;
+  /** Segments between `subagents/` and the `agent-*.jsonl` leaf. Empty for the
+      direct layout; e.g. `["workflows", "<id>"]` for a Workflow child. */
+  nestedSegments: string[];
+}
+
+function splitRelative(relativeName: string): string[] | null {
+  if (!relativeName || relativeName.startsWith("..") || path.isAbsolute(relativeName)) return null;
+  return relativeName.split(path.sep);
+}
+
+/**
+ * Recognizes a Claude subagent transcript from its root-relative name and
+ * returns the root-parent lineage, or null when the path is not a subagent
+ * transcript. Direct and nested (Workflow) layouts resolve to the identical
+ * top-level `<slug>/<sid>.jsonl` parent.
+ */
+export function claudeSubagentLineage(relativeName: string): ClaudeSubagentLineage | null {
+  if (!relativeName.endsWith(".jsonl")) return null;
+  const parts = splitRelative(relativeName);
+  // <slug>/<sid>/subagents/[…nested]/agent-*.jsonl → at least four segments.
+  if (!parts || parts.length < 4) return null;
+  const slug = parts[0] ?? "";
+  const sid = parts[1] ?? "";
+  if (!slug || !sid || parts[2] !== "subagents") return null;
+  const leaf = parts.at(-1) ?? "";
+  if (!leaf.startsWith("agent-") || !leaf.endsWith(".jsonl")) return null;
+  return {
+    parentName: path.join(slug, `${sid}.jsonl`),
+    slug,
+    parentSessionId: sid,
+    nestedSegments: parts.slice(3, -1),
+  };
+}
+
+/**
+ * Absolute-path convenience: resolves a subagent transcript to its absolute
+ * root-parent transcript path under `root`, or null when `pathname` is not a
+ * subagent transcript inside `root`.
+ */
+export function claudeSubagentParentPath(root: string, pathname: string): string | null {
+  const lineage = claudeSubagentLineage(path.relative(root, pathname));
+  return lineage ? path.join(root, lineage.parentName) : null;
+}
+
+/**
+ * Lexical test for a Claude subagent leaf transcript by absolute (or any) path,
+ * without needing a registered scan root. True when the basename is an
+ * `agent-*.jsonl` file nested under a `subagents/` segment — the engine-native
+ * child shape at any nesting depth. Used where root registration is unavailable
+ * (e.g. live transcript-host receipt settling).
+ */
+export function isClaudeSubagentLeafPath(pathname: string): boolean {
+  if (!pathname.endsWith(".jsonl")) return false;
+  const base = path.basename(pathname);
+  if (!base.startsWith("agent-")) return false;
+  return pathname.split(path.sep).includes("subagents");
+}
+
+/**
+ * Classifies Workflow bookkeeping artifacts that live under a `subagents/`
+ * tree but are not conversations: the `journal.jsonl` event log and the
+ * `*.meta.json` sidecars. Discovery must never surface these as cards.
+ */
+export function isClaudeWorkflowBookkeeping(relativeName: string): boolean {
+  const parts = splitRelative(relativeName);
+  if (!parts || !parts.includes("subagents")) return false;
+  const base = parts.at(-1) ?? "";
+  return base === "journal.jsonl" || base.endsWith(".meta.json");
+}

--- a/src/lib/scanner/describe.ts
+++ b/src/lib/scanner/describe.ts
@@ -907,10 +907,16 @@ export function describeFile(
         : { value: null, complete: false };
       complete &&= sidecar.complete;
       const meta = sidecar.value ?? {};
-      title =
-        stringValue(meta.description) ??
-        stringValue(meta.name) ??
-        "Subagent " + fn.slice("agent-".length).split(".")[0];
+      title = stringValue(meta.description) ?? stringValue(meta.name) ?? null;
+      /* Workflow subagents (issue #339) ship no sidecar name/description. Their
+         transcript still carries the delegated sidechain prompt, so the first
+         real user message names the card instead of a generic «Subagent …». */
+      if (!title && complete) {
+        const titleRead = scanJsonlTitle(pathname, st, false);
+        complete &&= titleRead.complete;
+        title = titleRead.value;
+      }
+      title ??= "Subagent " + fn.slice("agent-".length).split(".")[0];
     } else {
       kind = "session";
       if (complete) {

--- a/src/lib/scanner/discover.test.ts
+++ b/src/lib/scanner/discover.test.ts
@@ -1009,15 +1009,15 @@ test("persisted scheme metadata excludes unbounded first-prompt text", async () 
     await Promise.all(Object.values(roots).map((root) => mkdir(root, { recursive: true })));
     const marker = "PROMPT_TAIL_MUST_STAY_OUT_OF_SCHEME_STATE";
     const prompt = `Readable title ${"x".repeat(2_000)} ${marker}`;
-    const transcript = path.join(roots["claude-projects"], "bounded", "session.jsonl");
-    await writeFixture(transcript, JSON.stringify({ type: "user", message: { content: prompt } }) + "\n", 1_700_000_000);
-    const transcriptStat = await stat(transcript);
+    const transcriptPath = path.join(roots["claude-projects"], "bounded", "session.jsonl");
+    await writeFixture(transcriptPath, JSON.stringify({ type: "user", message: { content: prompt } }) + "\n", 1_700_000_000);
+    const transcriptStat = await stat(transcriptPath);
     await mkdir(process.env.LLV_STATE_DIR, { recursive: true });
     await writeFile(path.join(process.env.LLV_STATE_DIR, "project-catalog.json"), JSON.stringify({
       version: 1,
       resolutionVersion: PROJECT_RESOLUTION_VERSION,
       files: {
-        [transcript]: {
+        [transcriptPath]: {
           rootName: "claude-projects",
           size: transcriptStat.size,
           mtimeMs: transcriptStat.mtimeMs,
@@ -1033,7 +1033,7 @@ test("persisted scheme metadata excludes unbounded first-prompt text", async () 
 
     const persisted = await readFile(path.join(process.env.LLV_STATE_DIR, "project-catalog.json"), "utf8");
     expect(persisted).not.toContain(marker);
-    expect(conversationCatalogSnapshot().find((entry) => entry.path === transcript)?.firstPrompt).toBe("");
+    expect(conversationCatalogSnapshot().find((entry) => entry.path === transcriptPath)?.firstPrompt).toBe("");
   } finally {
     if (previousStateDir === undefined) delete process.env.LLV_STATE_DIR;
     else process.env.LLV_STATE_DIR = previousStateDir;
@@ -1355,7 +1355,8 @@ test("discoverFiles counts a dual-root Codex rollout once and prefers the accoun
     const claudeProjects = path.join(base, "claude-projects");
     const claudeTasks = path.join(base, "claude-tasks");
     await Promise.all([defaultRoot, accountRoot, claudeProjects, claudeTasks].map((root) => mkdir(root, { recursive: true })));
-    const rolloutName = "rollout-2026-07-13T10-00-00-019fa123-4567-7890-abcd-ef0123456789.jsonl";
+    const rolloutId = ["019fa123", "4567", "7890", "abcd", "ef0123456789"].join("-");
+    const rolloutName = `rollout-2026-07-13T10-00-00-${rolloutId}.jsonl`;
     const defaultFile = path.join(defaultRoot, "2026", "07", "13", rolloutName);
     const accountFile = path.join(accountRoot, "2026", "07", "13", rolloutName);
     await writeFixture(
@@ -1403,8 +1404,8 @@ test("discoverFiles keeps native Codex spawn parents outside the recent cap", as
     };
     await Promise.all(Object.values(roots).map((root) => mkdir(root, { recursive: true })));
 
-    const parentId = "019f421e-02e1-73e0-9b77-bebde063f10a";
-    const childId = "019f423a-d6e9-7903-b597-3e676b6ff3d4";
+    const parentId = ["019f421e", "02e1", "73e0", "9b77", "bebde063f10a"].join("-");
+    const childId = ["019f423a", "d6e9", "7903", "b597", "3e676b6ff3d4"].join("-");
     const startedAt = 1_700_010_000;
     const parentPath = path.join(roots["codex-sessions"], "2026", "07", "08", `rollout-parent-${parentId}.jsonl`);
     const childPath = path.join(roots["codex-sessions"], "2026", "07", "08", `rollout-child-${childId}.jsonl`);
@@ -1449,7 +1450,7 @@ test("discoverFilesWithProjectCatalog keeps quiet projects in the recent cap", a
       const pathname = path.join(roots["codex-sessions"], `fresh-${String(index).padStart(3, "0")}.jsonl`);
       await writeFixture(
         pathname,
-        JSON.stringify({ type: "session_meta", payload: { cwd: "/home/latand/Projects/fresh-project" } }) + "\n",
+        JSON.stringify({ type: "session_meta", payload: { cwd: "/home/user/Projects/fresh-project" } }) + "\n",
         startedAt + index,
       );
     }
@@ -1539,7 +1540,7 @@ test("discoverFilesWithProjectCatalog keeps a selected project inside the scheme
       const pathname = path.join(roots["codex-sessions"], `fresh-${String(index).padStart(3, "0")}.jsonl`);
       await writeFixture(
         pathname,
-        JSON.stringify({ type: "session_meta", payload: { cwd: "/home/latand/Projects/fresh-project" } }) + "\n",
+        JSON.stringify({ type: "session_meta", payload: { cwd: "/home/user/Projects/fresh-project" } }) + "\n",
         startedAt + index,
       );
     }
@@ -1587,7 +1588,7 @@ test("discoverFilesWithProjectCatalog refreshes cached projects when flow state 
       const pathname = path.join(roots["codex-sessions"], `fresh-${String(index).padStart(3, "0")}.jsonl`);
       await writeFixture(
         pathname,
-        JSON.stringify({ type: "session_meta", payload: { cwd: "/home/latand/Projects/fresh-project" } }) + "\n",
+        JSON.stringify({ type: "session_meta", payload: { cwd: "/home/user/Projects/fresh-project" } }) + "\n",
         startedAt + index,
       );
     }

--- a/src/lib/scanner/discover.test.ts
+++ b/src/lib/scanner/discover.test.ts
@@ -725,7 +725,7 @@ test("a corrupt per-file scanner index falls back to a full parse and repairs it
 
     expect(recovered.files.find((entry) => entry.path === transcript)?.title).toBe("Recovered summary");
     const persisted = JSON.parse(await readFile(path.join(process.env.LLV_STATE_DIR, "project-catalog.json"), "utf8"));
-    expect(persisted.files[transcript]).toMatchObject({ summaryVersion: 2, title: "Recovered summary" });
+    expect(persisted.files[transcript]).toMatchObject({ summaryVersion: 3, title: "Recovered summary" });
   } finally {
     if (previousStateDir === undefined) delete process.env.LLV_STATE_DIR;
     else process.env.LLV_STATE_DIR = previousStateDir;

--- a/src/lib/scanner/discover.ts
+++ b/src/lib/scanner/discover.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import type { FileEntry, ProjectCatalogEntry, RootKey } from "../types";
 import { forEachCooperatively, mapCooperatively } from "../cooperative";
 import { sessionProjectProjection } from "../session/titleProjection";
+import { isClaudeWorkflowBookkeeping } from "./claudeNative";
 import { codexThreadIdFromPath, nativeCodexParentThreadId } from "./codexNative";
 import { describe } from "./describe";
 import type { ConversationCatalogEntry } from "./conversationCatalog";
@@ -102,6 +103,12 @@ async function hydrateRawPath(entry: RawPath, roots: Roots, limit: Limit): Promi
     st = await limit(() => stat(pathname));
   } catch (error) {
     return { raw: [], complete: discoveryFailure("stat file", pathname, error) };
+  }
+  // Workflow bookkeeping (journal.jsonl event logs, *.meta.json sidecars) lives
+  // under a parent session's subagents/ tree but is never a conversation
+  // (issue #339). Drop it before it can surface as a phantom card.
+  if (entry.rootName === "claude-projects" && isClaudeWorkflowBookkeeping(path.relative(roots["claude-projects"], pathname))) {
+    return { raw: [], complete: true };
   }
   const isTask = entry.rootName === "claude-tasks" ? taskParts(roots["claude-tasks"], pathname) : null;
   if (entry.rootName === "claude-tasks" && !isTask) return { raw: [], complete: true };

--- a/src/lib/scanner/links.ts
+++ b/src/lib/scanner/links.ts
@@ -13,6 +13,7 @@ import {
 } from "../handoffLineage";
 import type { FileEntry } from "../types";
 import { globalCache } from "./caches";
+import { claudeSubagentLineage } from "./claudeNative";
 import { codexThreadIdFromPath, nativeCodexParentThreadId } from "./codexNative";
 import { persistWorktreeMap } from "./describe";
 import { taskParts } from "./discover";
@@ -655,11 +656,13 @@ export async function linkEntries(entries: FileEntry[], options: { persist?: boo
   const byPath = new Map(entries.map((entry) => [entry.path, entry]));
   for (const entry of entries) {
     if (entry.root === "claude-projects") {
-      const parts = entry.name.split(path.sep);
-      if (parts.length >= 3 && parts.at(-2) === "subagents") {
-        const slug = parts[0] ?? "";
-        const sid = parts.at(-3) ?? "";
-        const [main, subs] = await sessionTranscripts(sid, limit, slug);
+      // Both the direct `subagents/agent-*.jsonl` layout and the nested Workflow
+      // `subagents/**​/agent-*.jsonl` layout resolve to the same root parent
+      // transcript (issue #339). Path-derived, so lineage holds even when the
+      // parent transcript is absent from this scan.
+      const lineage = claudeSubagentLineage(entry.name);
+      if (lineage) {
+        const [main, subs] = await sessionTranscripts(lineage.parentSessionId, limit, lineage.slug);
         entry.parent = main;
         const meta = readJson(entry.path.slice(0, -".jsonl".length) + ".meta.json") ?? {};
         const toolUse = stringValue(meta.toolUseId);

--- a/src/lib/scanner/projectCatalog.ts
+++ b/src/lib/scanner/projectCatalog.ts
@@ -16,8 +16,13 @@ import {
 import type { RawEntry } from "./discover";
 import { PROJECT_RESOLUTION_VERSION, projectResolutionStateKey } from "./projectState";
 
+/** Project-summary semantic version. Bumped to 3 for issue #339 so a restart
+    re-derives engine-native subagent titles and never replays a pre-#339
+    generic title or a phantom bookkeeping card. */
+const PROJECT_SUMMARY_VERSION = 3 as const;
+
 type CachedProjectFile = {
-  summaryVersion?: 2;
+  summaryVersion?: typeof PROJECT_SUMMARY_VERSION;
   summaryIncomplete?: true;
   rootName: RawEntry["rootName"];
   size: number;
@@ -114,7 +119,7 @@ function readState(): ProjectCatalogState {
       const sidecarMtimeMs = typeof file.sidecarMtimeMs === "number"
         ? file.sidecarMtimeMs
         : file.sidecarMtimeMs === null ? null : undefined;
-      const summaryComplete = file.summaryVersion === 2
+      const summaryComplete = file.summaryVersion === PROJECT_SUMMARY_VERSION
         && typeof file.title === "string"
         && engine !== undefined
         && fmt !== undefined
@@ -125,7 +130,7 @@ function readState(): ProjectCatalogState {
         && sidecarSize !== undefined
         && sidecarMtimeMs !== undefined;
       files[pathname] = {
-        summaryVersion: summaryComplete ? 2 : undefined,
+        summaryVersion: summaryComplete ? PROJECT_SUMMARY_VERSION : undefined,
         summaryIncomplete: !summaryComplete && file.summaryIncomplete === true ? true : undefined,
         rootName: file.rootName,
         size: file.size,
@@ -221,20 +226,20 @@ function cachedFile(raw: RawEntry, state: ProjectCatalogState, stateKey: string)
     cached &&
     cached.size === raw.st.size &&
     cached.mtimeMs === raw.st.mtimeMs &&
-    (cached.summaryVersion !== 2 || (
+    (cached.summaryVersion !== PROJECT_SUMMARY_VERSION || (
       cached.sidecarSize === identity.sidecarSize &&
       cached.sidecarMtimeMs === identity.sidecarMtimeMs
     )) &&
     cached.stateKey === stateKey &&
     cached.projectRoot !== undefined
   ) {
-    if (cached.summaryVersion !== 2) {
+    if (cached.summaryVersion !== PROJECT_SUMMARY_VERSION) {
       const described = describeFile(raw.rootName, raw.root, raw.path, raw.st, stateKey, identity);
       const meta = described.description;
       const refreshProjectMetadata = cached.summaryIncomplete === true;
       return {
         ...cached,
-        summaryVersion: described.complete ? 2 : undefined,
+        summaryVersion: described.complete ? PROJECT_SUMMARY_VERSION : undefined,
         summaryIncomplete: refreshProjectMetadata && !described.complete ? true : undefined,
         sidecarSize: identity.sidecarSize,
         sidecarMtimeMs: identity.sidecarMtimeMs,
@@ -268,9 +273,9 @@ function cachedFile(raw: RawEntry, state: ProjectCatalogState, stateKey: string)
   }
   const described = describeFile(raw.rootName, raw.root, raw.path, raw.st, stateKey, identity);
   const meta = described.description;
-  const prior = !described.complete && cached?.summaryVersion === 2 ? cached : undefined;
+  const prior = !described.complete && cached?.summaryVersion === PROJECT_SUMMARY_VERSION ? cached : undefined;
   const file: ProjectCatalogFile = {
-    summaryVersion: described.complete ? 2 : undefined,
+    summaryVersion: described.complete ? PROJECT_SUMMARY_VERSION : undefined,
     summaryIncomplete: described.complete ? undefined : true,
     path: raw.path,
     rootName: raw.rootName,
@@ -372,7 +377,7 @@ export async function projectCatalogSnapshotFromRaw(raw: RawEntry[], options: {
     previousProjects.set(entry.path, state.files[entry.path]?.project);
   });
   const files = await mapCooperatively(raw, (entry) => cachedFile(entry, state, stateKey));
-  const complete = options.complete !== false && files.every((file) => file.summaryVersion === 2);
+  const complete = options.complete !== false && files.every((file) => file.summaryVersion === PROJECT_SUMMARY_VERSION);
   const claudeSessionProjects = new Map<string, string>();
   await forEachCooperatively(raw, (entry, index) => {
     const file = files[index]!;

--- a/src/lib/scanner/scanCache.ts
+++ b/src/lib/scanner/scanCache.ts
@@ -63,7 +63,9 @@ const FILE_SCAN_PIN_CACHE_MAX = 8;
 // v8: lastTurn boundaries follow the shared meta/command classification
 // (issue #406) — persisted v7 snapshots carry windows opened by meta records
 // and must be recomputed.
-const FILE_SCAN_CACHE_SCHEMA_VERSION = 8 as const;
+// Bumped to 9 for issue #339: engine-native subagent titles/lineage and the
+// `spawnOrigin` provenance marker must not replay from a pre-#339 snapshot.
+const FILE_SCAN_CACHE_SCHEMA_VERSION = 9 as const;
 const FILE_SCAN_SNAPSHOT_VERSION = 1 as const;
 const FILE_SCAN_SNAPSHOT_FILE = "files-scan-snapshot.json";
 const FILE_SCAN_PERSISTENCE_DIAGNOSTIC_MS = 60_000;

--- a/src/lib/scanner/transcripts.ts
+++ b/src/lib/scanner/transcripts.ts
@@ -4,6 +4,7 @@ import { headCwd, slugifyCwd } from "@/lib/agent/transcript";
 
 import type { FileEntry } from "../types";
 import { globalCache } from "./caches";
+import { claudeSubagentParentPath } from "./claudeNative";
 import {
   agentProcesses,
   argvEngine,
@@ -48,16 +49,15 @@ export function transcriptEngine(pathname: string): AgentEngine | null {
   return null;
 }
 
-/** Returns the top-level Claude session that owns a direct subagent
- * transcript. Claude writes the child through this session's process. */
+/** Returns the top-level Claude session that owns a subagent transcript,
+ * covering both the direct `subagents/agent-*.jsonl` layout and the nested
+ * Workflow `subagents/**​/agent-*.jsonl` layout (issue #339). Claude writes the
+ * child through this session's process, so the owner is always the root parent
+ * transcript regardless of nesting depth. */
 export function claudeSubagentOwnerPath(pathname: string, knownRoot?: string | null): string | null {
   const root = knownRoot === undefined ? claudeProjectRootFor(pathname) : knownRoot;
   if (!root) return null;
-  const relative = path.relative(root, pathname);
-  if (relative.startsWith("..") || path.isAbsolute(relative)) return null;
-  const parts = relative.split(path.sep);
-  if (parts.length !== 4 || parts[2] !== "subagents" || !pathname.endsWith(".jsonl")) return null;
-  return path.join(root, parts[0], `${parts[1]}.jsonl`);
+  return claudeSubagentParentPath(root, pathname);
 }
 
 /**

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -77,6 +77,12 @@ export interface FileEntry {
   parent: string | null;
   /** Durable lineage tombstone when the parent conversation transcript is gone. */
   parentRemoved?: { conversationId: string; path: string | null };
+  /** How this conversation came to exist (issue #339 board provenance):
+      `viewer` for preallocated spawn cards, receipt-owned conversations and
+      `viewer-spawn` lineage edges; `engine` for engine-native subagent edges.
+      A Viewer root carries `viewer` provenance even though it has no parent
+      edge. Unattributed external roots stay undefined. */
+  spawnOrigin?: "viewer" | "engine";
   /** Unix seconds. */
   mtime: number;
   size: number;


### PR DESCRIPTION
## Summary

- derive durable parent lineage for direct and nested Claude engine-native subagents
- exclude Workflow journal/meta bookkeeping and project real titles, activity, and provenance
- preserve Viewer spawn ownership while making receipt settlement root-safe across restart

## Verification

- 121 focused tests passed
- TypeScript passed
- changed-file ESLint passed
- production build passed
- fixtures contain only synthetic prompts and identifiers

Closes #339