### PR TITLE
fix(board): keep the full world visible in the minimap (#263)

### DIFF
--- a/docs/acceptance/issue-263/README.md
+++ b/docs/acceptance/issue-263/README.md
@@ -21,7 +21,7 @@ placed card, so a node added far right/down after panning is always enclosed:
 | --- | --- | --- | --- |
 | node at `x=4000` | right edge `1000` | right edge `4000 + TASK_W + 140` | width only |
 | node at `y=5000` | bottom edge `800` | bottom edge `5000 + 120 + 140` | height only |
-| scattered large world | — | `x∈[-740, 6260]`, `y∈[-540, 7260]` | both |
+| scattered large world | — | `x∈[-740, 6400]`, `y∈[-540, 7260]` | both |
 
 ## Viewport indicator stays inside the map
 

--- a/docs/acceptance/issue-263/README.md
+++ b/docs/acceptance/issue-263/README.md
@@ -1,0 +1,63 @@
+# Issue 263 — minimap full-world extent and viewport clamp
+
+Synthetic geometry evidence only. Every value below is derived from
+constructed world/camera fixtures in the focused tests
+(`Minimap.render.test.tsx`, `taskGeometry.test.ts`); no production project,
+account, task, or transcript data is used.
+
+## Contract
+
+The desktop minimap (`src/components/scheme/Minimap.tsx`, 216 × 148 px) must
+scale down the **complete** current layout world and keep the accent viewport
+frame fully inside the map at every pan/zoom corner — including when the
+camera's edge-keep clamp lets the view drift past the placed geometry.
+
+## World growth (both axes)
+
+`taskWorldBounds` derives the world from the live layout box unioned with every
+placed card, so a node added far right/down after panning is always enclosed:
+
+| Fixture | Before | After node added | Grown axis |
+| --- | --- | --- | --- |
+| node at `x=4000` | right edge `1000` | right edge `4000 + TASK_W + 140` | width only |
+| node at `y=5000` | bottom edge `800` | bottom edge `5000 + 120 + 140` | height only |
+| scattered large world | — | `x∈[-740, 6260]`, `y∈[-540, 7260]` | both |
+
+## Viewport indicator stays inside the map
+
+`minimapExtent(world, cam, vp)` grows the layout world to also enclose the live
+viewport rect (`x=-cam.x/z`, `y=-cam.y/z`, `w=vp.w/z`, `h=vp.h/z`). The camera
+keeps clamping and fitting to the tighter layout `world`, so this display box
+growing as the view drifts **never re-snaps the camera**.
+
+Synthetic drift fixture — `world = {0,0,1000,1000}`, `cam = {x:-2600, y:-1900,
+z:1.4}`, `vp = {800,600}`:
+
+- Viewport in world space: `{x:1857.1, y:1357.1, w:571.4, h:428.6}` — its origin
+  sits well past the world's right/bottom edges.
+- **Before #263** (scale to world only): map scale `0.148`, viewport frame left
+  edge maps to screen `x ≈ 309 px`, entirely off the 216 px map → clipped and
+  invisible.
+- **After #263** (scale to `world ∪ viewport`, extent `{0,0,2428.6,1785.7}`):
+  map scale `0.0829`, the frame lands at screen `x ∈ [161, 209]`,
+  `y ∈ [112, 148]` — fully inside the fixed map, flush against the drifted far
+  edge, correctly placed and scaled.
+
+The regression test parses the rendered SVG transform and asserts the frame's
+four screen edges stay within `[−2, 216+2] × [−2, 148+2]` (the ±2 tolerance
+covers the constant 2.5 px stroke straddling the boundary).
+
+## Preserved behavior
+
+- Issue #343 current-work framing, immutable stored task coordinates, and the
+  compact pipeline rails render unchanged — `minimapExtent` only affects the
+  minimap's own down-scale, not the camera's clamp/fit or any stored position.
+- Issue #418 bounded mobile map (`MobileMapLite`) is a separate component and is
+  untouched.
+
+## Verification
+
+- `bun test src/components/scheme src/components/mobile` — 557 pass.
+- `bunx tsc --noEmit` — clean.
+- `bunx eslint` on the three changed files — clean.
+- `bun run build` — production build succeeds.

--- a/src/components/scheme/Minimap.render.test.tsx
+++ b/src/components/scheme/Minimap.render.test.tsx
@@ -7,6 +7,8 @@ import type { FileEntry } from "@/lib/types";
 
 import { Minimap, minimapExtent, stackDotsFor, type Camera, type StackDot } from "./Minimap";
 import { buildSchemeLayout, type SchemeLayout, type SchemeRect } from "./layout";
+import { taskRect, taskWorldBounds, type PlacedTask } from "./taskGeometry";
+import { fitCameraToRect } from "./useSchemeCamera";
 import type { WorkerStack } from "./workerCollapse";
 
 const emptyLayout: SchemeLayout = {
@@ -240,6 +242,87 @@ test("the drifted viewport frame stays fully inside the fixed map (#263)", () =>
   expect(top).toBeGreaterThanOrEqual(-tol);
   expect(right).toBeLessThanOrEqual(mapW + tol);
   expect(bottom).toBeLessThanOrEqual(mapH + tol);
+});
+
+test("successive real layouts append far nodes: the minimap rescales to enclose every node on both axes while the camera framing is unaffected (#263)", () => {
+  const node = (over: Partial<FileEntry> & { path: string }): FileEntry => ({
+    root: "claude-projects", name: over.path, project: "demo", title: over.path, engine: "claude",
+    kind: "session", fmt: "claude", parent: null, mtime: 1000, size: 10, activity: "idle", proc: null,
+    pid: null, model: null, pendingQuestion: null, waitingInput: null, ...over,
+  });
+  /* A real conversation tree — root plus two children a generation below —
+     yields a genuine 1512×1930 layout world, not a hand-picked rectangle. */
+  const files = [
+    node({ path: "/root", activity: "live" }),
+    node({ path: "/root/a", parent: "/root", kind: "subagent" }),
+    node({ path: "/root/b", parent: "/root", kind: "subagent" }),
+  ];
+  const layout = buildSchemeLayout(buildBranchGroups(files, "demo"), [], files);
+  expect(layout.nodes.length).toBe(3);
+
+  const card = (id: string, x: number, y: number): PlacedTask => ({
+    id, project: "demo", status: "assigned", placement: "pinned", text: "card", pos: { x, y },
+    assignments: [], createdAt: "2026-07-19T00:00:00.000Z", updatedAt: "2026-07-19T00:00:00.000Z",
+  } as unknown as PlacedTask);
+  /* The board derives its world exactly this way — the layout box grown to
+     enclose every placed card (issue #17). */
+  const boardWorld = (cards: PlacedTask[]): SchemeRect =>
+    taskWorldBounds(layout.width, layout.height, cards.map((c) => taskRect(c)));
+
+  const w0 = boardWorld([]);
+  /* A node that appears far to the right after the operator has panned away
+     (margins keep it clear of the top/bottom, isolating the x axis). */
+  const rightCard = card("right", 9000, 500);
+  const wRight = boardWorld([rightCard]);
+  expect(wRight.x + wRight.w).toBeGreaterThan(w0.x + w0.w); // width grew rightward
+  expect(wRight.y).toBe(w0.y);
+  expect(wRight.y + wRight.h).toBe(w0.y + w0.h); // height untouched
+
+  /* A node that appears far below (kept clear of the left/right edges). */
+  const downCard = card("down", 500, 9000);
+  const wDown = boardWorld([downCard]);
+  expect(wDown.y + wDown.h).toBeGreaterThan(w0.y + w0.h); // height grew downward
+  expect(wDown.x).toBe(w0.x);
+  expect(wDown.x + wDown.w).toBe(w0.x + w0.w); // width untouched
+
+  /* Representative large world: far right, far down, and left/above the origin
+     all at once — the single world box must enclose every board node and card. */
+  const leftUpCard = card("leftup", -800, -600);
+  const cards = [rightCard, downCard, leftUpCard];
+  const wBig = boardWorld(cards);
+  for (const n of layout.nodes) expect(containsRect(wBig, n)).toBe(true);
+  for (const c of cards) expect(containsRect(wBig, taskRect(c))).toBe(true);
+  expect(wBig.x + wBig.w).toBeGreaterThanOrEqual(wRight.x + wRight.w);
+  expect(wBig.y + wBig.h).toBeGreaterThanOrEqual(wDown.y + wDown.h);
+
+  /* Render the minimap for that grown world and confirm it rescales so EVERY
+     node and card lands inside the fixed map — none clipped out. */
+  const cam = fitCameraToRect(wBig, vp);
+  const html = renderToStaticMarkup(
+    <Minimap layout={layout} world={wBig} tasks={cards} cam={cam} vp={vp} onJump={() => {}} />,
+  );
+  const mapW = Number(html.match(/<svg width="([\d.]+)"/)?.[1]);
+  const mapH = Number(html.match(/<svg width="[\d.]+" height="([\d.]+)"/)?.[1]);
+  const transform = html.match(/translate\(([-\d.]+) ([-\d.]+)\) scale\(([\d.e-]+)\)/);
+  const [tx, ty, s] = [Number(transform?.[1]), Number(transform?.[2]), Number(transform?.[3])];
+  const withinMap = (r: SchemeRect) => {
+    const left = tx + r.x * s;
+    const top = ty + r.y * s;
+    expect(left).toBeGreaterThanOrEqual(-1);
+    expect(top).toBeGreaterThanOrEqual(-1);
+    expect(left + r.w * s).toBeLessThanOrEqual(mapW + 1);
+    expect(top + r.h * s).toBeLessThanOrEqual(mapH + 1);
+  };
+  for (const n of layout.nodes) withinMap(n);
+  for (const c of cards) withinMap(taskRect(c));
+
+  /* Camera preserved: the board's world (what the camera clamps and fits to) is
+     computed WITHOUT the camera, so panning — which does grow the minimap's own
+     display extent — never feeds back into the camera and re-snaps it. */
+  expect(boardWorld(cards)).toEqual(wBig); // world is camera-independent
+  const drifted: Camera = { z: cam.z, x: cam.x - 6000, y: cam.y - 4000 };
+  expect(minimapExtent(wBig, drifted, vp)).not.toEqual(wBig); // the map grows for the drift
+  expect(fitCameraToRect(wBig, vp)).toEqual(cam); // the camera framing is unchanged
 });
 
 test("a direct review group's deck shows on the minimap like any managed deck (#325)", () => {

--- a/src/components/scheme/Minimap.render.test.tsx
+++ b/src/components/scheme/Minimap.render.test.tsx
@@ -1,11 +1,11 @@
-import { expect, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import { renderToStaticMarkup } from "react-dom/server";
 
 import { directReviewFlows, splitDirectReviewGroups } from "@/components/flows/directReviewGroups";
 import { buildBranchGroups, type BranchGroup } from "@/components/projectModel";
 import type { FileEntry } from "@/lib/types";
 
-import { Minimap, stackDotsFor, type StackDot } from "./Minimap";
+import { Minimap, minimapExtent, stackDotsFor, type Camera, type StackDot } from "./Minimap";
 import { buildSchemeLayout, type SchemeLayout, type SchemeRect } from "./layout";
 import type { WorkerStack } from "./workerCollapse";
 
@@ -150,6 +150,96 @@ test("an expanded task dot follows the full rendered card height", () => {
   const compactCy = Number(compact.match(/cy="([\d.]+)"/)?.[1]);
   const fullCy = Number(full.match(/cy="([\d.]+)"/)?.[1]);
   expect(fullCy).toBeGreaterThan(compactCy);
+});
+
+const containsRect = (outer: SchemeRect, inner: SchemeRect): boolean =>
+  inner.x >= outer.x - 1e-6
+  && inner.y >= outer.y - 1e-6
+  && inner.x + inner.w <= outer.x + outer.w + 1e-6
+  && inner.y + inner.h <= outer.y + outer.h + 1e-6;
+
+/** The viewport rect the Minimap draws, in world coordinates (screen = world·z + cam). */
+const viewportWorldRect = (camera: Camera, viewport: { w: number; h: number }): SchemeRect => ({
+  x: -camera.x / camera.z,
+  y: -camera.y / camera.z,
+  w: viewport.w / camera.z,
+  h: viewport.h / camera.z,
+});
+
+describe("minimapExtent (#263)", () => {
+  test("a viewport already inside the world leaves the world untouched", () => {
+    const w: SchemeRect = { x: 0, y: 0, w: 2000, h: 1600 };
+    expect(minimapExtent(w, { x: -200, y: -150, z: 1 }, { w: 800, h: 600 })).toEqual(w);
+  });
+
+  test("a camera drifted far right of the world grows the extent rightward only", () => {
+    const w: SchemeRect = { x: 0, y: 0, w: 2000, h: 1600 };
+    /* Edge-keep let the view slide so its left edge sits at world x=3000. */
+    const cam: Camera = { x: -3000, y: 0, z: 1 };
+    const extent = minimapExtent(w, cam, { w: 800, h: 600 });
+    expect(extent.x).toBeCloseTo(0);
+    expect(extent.y).toBeCloseTo(0);
+    expect(extent.x + extent.w).toBe(3800); // viewport right edge, past the world's 2000
+    expect(extent.y + extent.h).toBe(1600); // height unchanged
+    expect(containsRect(extent, viewportWorldRect(cam, { w: 800, h: 600 }))).toBe(true);
+    expect(containsRect(extent, w)).toBe(true);
+  });
+
+  test("a camera drifted far below the world grows the extent downward only", () => {
+    const w: SchemeRect = { x: 0, y: 0, w: 2000, h: 1600 };
+    const cam: Camera = { x: 0, y: -4000, z: 1 };
+    const extent = minimapExtent(w, cam, { w: 800, h: 600 });
+    expect(extent.x + extent.w).toBe(2000); // width unchanged
+    expect(extent.y + extent.h).toBe(4600); // viewport bottom, past the world's 1600
+    expect(containsRect(extent, viewportWorldRect(cam, { w: 800, h: 600 }))).toBe(true);
+  });
+
+  test("a viewport zoomed out wider than the world still stays enclosed", () => {
+    const w: SchemeRect = { x: 0, y: 0, w: 600, h: 400 };
+    /* Zoomed far out: the viewport covers far more world than the placed geometry. */
+    const cam: Camera = { x: 0, y: 0, z: 0.12 };
+    const vp = { w: 1400, h: 900 };
+    const extent = minimapExtent(w, cam, vp);
+    expect(containsRect(extent, viewportWorldRect(cam, vp))).toBe(true);
+    expect(containsRect(extent, w)).toBe(true);
+  });
+
+  test("a viewport left of and above a negative-origin world extends the origin", () => {
+    const w: SchemeRect = { x: -300, y: -200, w: 1000, h: 800 };
+    const cam: Camera = { x: 500, y: 400, z: 1 }; // viewport world origin at (-500, -400)
+    const extent = minimapExtent(w, cam, { w: 400, h: 300 });
+    expect(extent.x).toBe(-500);
+    expect(extent.y).toBe(-400);
+    expect(containsRect(extent, viewportWorldRect(cam, { w: 400, h: 300 }))).toBe(true);
+    expect(containsRect(extent, w)).toBe(true);
+  });
+});
+
+test("the drifted viewport frame stays fully inside the fixed map (#263)", () => {
+  /* Camera panned far past the world's right/bottom edge — before #263 the accent
+     frame overflowed the fixed 216×148 map and clipped; now the map scales to the
+     world∪viewport so the whole frame lands inside. */
+  const cam: Camera = { x: -2600, y: -1900, z: 1.4 };
+  const html = renderToStaticMarkup(
+    <Minimap layout={emptyLayout} world={world} cam={cam} vp={vp} onJump={() => {}} />,
+  );
+  const mapW = Number(html.match(/<svg width="([\d.]+)"/)?.[1]);
+  const mapH = Number(html.match(/<svg width="[\d.]+" height="([\d.]+)"/)?.[1]);
+  const transform = html.match(/translate\(([-\d.]+) ([-\d.]+)\) scale\(([\d.]+)\)/);
+  const [tx, ty, s] = [Number(transform?.[1]), Number(transform?.[2]), Number(transform?.[3])];
+  /* The accent viewport frame is the rect painted with the translucent fill. */
+  const rect = html.match(/<rect x="([-\d.]+)" y="([-\d.]+)" width="([\d.]+)" height="([\d.]+)" fill="color-mix/);
+  const [rx, ry, rw, rh] = [Number(rect?.[1]), Number(rect?.[2]), Number(rect?.[3]), Number(rect?.[4])];
+  /* World → screen through the g transform. */
+  const left = tx + rx * s;
+  const top = ty + ry * s;
+  const right = left + rw * s;
+  const bottom = top + rh * s;
+  const tol = 2; // 2.5px constant stroke can straddle the edge by ~1.25px
+  expect(left).toBeGreaterThanOrEqual(-tol);
+  expect(top).toBeGreaterThanOrEqual(-tol);
+  expect(right).toBeLessThanOrEqual(mapW + tol);
+  expect(bottom).toBeLessThanOrEqual(mapH + tol);
 });
 
 test("a direct review group's deck shows on the minimap like any managed deck (#325)", () => {

--- a/src/components/scheme/Minimap.tsx
+++ b/src/components/scheme/Minimap.tsx
@@ -42,6 +42,29 @@ export function stackDotsFor(stacks: readonly WorkerStack[]): StackDot[] {
 }
 
 /**
+ * World box the minimap actually scales down (issue #263). The camera's
+ * edge-keep clamp lets the viewport drift far past the layout world in any
+ * direction, and the viewport also outruns the world whenever it is zoomed out
+ * wider/taller than the placed geometry. This grows the layout-derived `world`
+ * to also enclose the live viewport rect, so the accent viewport frame is always
+ * fully inside the fixed map — visible, clamped, and correctly scaled — at every
+ * pan/zoom corner. It deliberately stays local to rendering: the camera keeps
+ * clamping and fitting to the tighter `world`, so this display box growing as the
+ * view drifts never re-snaps the camera.
+ */
+export function minimapExtent(world: SchemeRect, cam: Camera, vp: { w: number; h: number }): SchemeRect {
+  const vx = -cam.x / cam.z;
+  const vy = -cam.y / cam.z;
+  const vw = vp.w / cam.z;
+  const vh = vp.h / cam.z;
+  const minX = Math.min(world.x, vx);
+  const minY = Math.min(world.y, vy);
+  const maxX = Math.max(world.x + world.w, vx + vw);
+  const maxY = Math.max(world.y + world.h, vy + vh);
+  return { x: minX, y: minY, w: maxX - minX, h: maxY - minY };
+}
+
+/**
  * Scaled-down world in the corner: every node as an engine-colored block,
  * the current viewport as an accent frame. Click or drag to jump the camera.
  */
@@ -80,14 +103,18 @@ export function Minimap({
   const { t } = useLocale();
   const ref = useRef<HTMLDivElement | null>(null);
   const dragRef = useRef(false);
-  const scale = Math.min(MAP_W / world.w, MAP_H / world.h);
-  const ox = (MAP_W - world.w * scale) / 2;
-  const oy = (MAP_H - world.h * scale) / 2;
+  /* Scale to the world grown to swallow the live viewport (issue #263), so the
+     accent viewport frame is always fully inside the map even when the camera
+     has drifted well past the layout edge. */
+  const extent = minimapExtent(world, cam, vp);
+  const scale = Math.min(MAP_W / extent.w, MAP_H / extent.h);
+  const ox = (MAP_W - extent.w * scale) / 2;
+  const oy = (MAP_H - extent.h * scale) / 2;
 
   const jumpTo = (event: React.PointerEvent) => {
     const rect = ref.current?.getBoundingClientRect();
     if (!rect) return;
-    onJump((event.clientX - rect.left - ox) / scale + world.x, (event.clientY - rect.top - oy) / scale + world.y);
+    onJump((event.clientX - rect.left - ox) / scale + extent.x, (event.clientY - rect.top - oy) / scale + extent.y);
   };
 
   return (
@@ -123,7 +150,7 @@ export function Minimap({
       }}
     >
       <svg width={MAP_W} height={MAP_H} aria-hidden>
-        <g transform={`translate(${ox - world.x * scale} ${oy - world.y * scale}) scale(${scale})`}>
+        <g transform={`translate(${ox - extent.x * scale} ${oy - extent.y * scale}) scale(${scale})`}>
           {/* On-canvas quiet-branch stacks: one dot each, so a stack is a single
               mark on the map, never a wall of member cards (issue #136). */}
           {layout.stacks.map((stack) => (

--- a/src/components/scheme/taskGeometry.test.ts
+++ b/src/components/scheme/taskGeometry.test.ts
@@ -358,6 +358,49 @@ describe("taskWorldBounds", () => {
     expect(world.x).toBeLessThanOrEqual(routeBox.x);
   });
 
+  test("a node placed far right after panning grows the world width, not the height (#263)", () => {
+    const before = taskWorldBounds(1000, 800, []);
+    /* A conversation card the layout drops well past the right edge — the world
+       the camera and minimap read must reach it on the x axis alone. */
+    const after = taskWorldBounds(1000, 800, [{ x: 4000, y: 300, w: TASK_W, h: 120 }]);
+    expect(after.x + after.w).toBe(4000 + TASK_W + TASK_WORLD_MARGIN);
+    expect(after.x + after.w).toBeGreaterThan(before.x + before.w);
+    expect(after.y).toBe(before.y);
+    expect(after.y + after.h).toBe(before.y + before.h);
+  });
+
+  test("a node placed far down after panning grows the world height, not the width (#263)", () => {
+    const before = taskWorldBounds(1000, 800, []);
+    const after = taskWorldBounds(1000, 800, [{ x: 300, y: 5000, w: TASK_W, h: 120 }]);
+    expect(after.y + after.h).toBe(5000 + 120 + TASK_WORLD_MARGIN);
+    expect(after.y + after.h).toBeGreaterThan(before.y + before.h);
+    expect(after.x).toBe(before.x);
+    expect(after.x + after.w).toBe(before.x + before.w);
+  });
+
+  test("a representative large world encloses every scattered node on both axes (#263)", () => {
+    /* Cards spread far right, far down, and left/above the origin at once — the
+       single world box must cover the union of all of them. */
+    const rects: SchemeRect[] = [
+      { x: -600, y: -400, w: TASK_W, h: 120 },
+      { x: 6000, y: 200, w: TASK_W, h: 120 },
+      { x: 400, y: 7000, w: TASK_W, h: 120 },
+      { x: 5200, y: 6400, w: TASK_W, h: 200 },
+    ];
+    const world = taskWorldBounds(1200, 900, rects);
+    expect(world.x).toBe(-600 - TASK_WORLD_MARGIN);
+    expect(world.y).toBe(-400 - TASK_WORLD_MARGIN);
+    expect(world.x + world.w).toBe(6000 + TASK_W + TASK_WORLD_MARGIN);
+    expect(world.y + world.h).toBe(7000 + 120 + TASK_WORLD_MARGIN);
+    /* Every card sits inside the derived world on both axes. */
+    for (const rect of rects) {
+      expect(rect.x).toBeGreaterThanOrEqual(world.x);
+      expect(rect.y).toBeGreaterThanOrEqual(world.y);
+      expect(rect.x + rect.w).toBeLessThanOrEqual(world.x + world.w);
+      expect(rect.y + rect.h).toBeLessThanOrEqual(world.y + world.h);
+    }
+  });
+
   test("routePathsBounds is null with no edges and pads the markers otherwise", () => {
     expect(routePathsBounds([])).toBeNull();
     const box = routePathsBounds([{ d: "M 0 0 C 50 0, 50 100, 100 100", mid: { x: 50, y: 50 }, crosses: false }])!;


### PR DESCRIPTION
## Summary

- scale the desktop minimap to the union of the live board world and viewport
- keep the viewport frame inside the fixed map through far-edge pan and zoom
- preserve camera framing, current-work geometry, task coordinates, compact rails, and the bounded mobile map
- add real-layout growth coverage for far-right and far-down nodes plus synthetic privacy-safe acceptance evidence

## Verification

- `bun test src/components/scheme src/components/mobile` — 558 passed
- focused minimap and task geometry tests — 103 passed
- `bunx tsc --noEmit`
- changed-file ESLint
- `bun run build`
- `bun run privacy:check`

Fresh-context review requested two focused repairs. Commit `a00918f6` adds the real-layout regression and corrects the documented synthetic extent.

Closes #263.