### PR TITLE
fix(accounts): restore in-place Claude login recovery (#470)

### DIFF
--- a/src/app/api/accounts/claude/route.test.ts
+++ b/src/app/api/accounts/claude/route.test.ts
@@ -98,6 +98,72 @@ test("one login is admitted at a time, then cancel and retry create a fresh oper
   expect(retryBody.login.operationId).not.toBe(firstBody.login.operationId);
 });
 
+test("retry reauthenticates legacy Main in place through the supervised flow (issue #470)", async () => {
+  const retry = await POST(new NextRequest("http://127.0.0.1/api/accounts/claude", {
+    method: "POST",
+    headers: { host: "127.0.0.1", "content-type": "application/json" },
+    body: JSON.stringify({ action: "retry", id: "default" }),
+  }));
+
+  expect(retry.status).toBe(202);
+  const body = await retry.json() as { account: { id: string; kind: string }; login: { phase: string }; target: string };
+  expect(body.account).toEqual(expect.objectContaining({ id: "default", kind: "legacy" }));
+  expect(body.login.phase).toBe("awaiting_browser");
+  expect(body.target).toBe("claude-auth-login");
+});
+
+test("a managed account erroring with credentials present retries in place, keeping its identity (issue #470)", async () => {
+  const created = await POST(new NextRequest("http://127.0.0.1/api/accounts/claude", {
+    method: "POST",
+    headers: { host: "127.0.0.1", "content-type": "application/json" },
+    body: JSON.stringify({ label: "Erroring managed" }),
+  }));
+  const createdBody = await created.json() as { account: { id: string }; login: { operationId: string } };
+  // Cancel the create's live op, then write a safe credential file — the account
+  // now looks like production's error case: credentials present but reauth needed.
+  await DELETE(new NextRequest(`http://127.0.0.1/api/accounts/claude/login/${createdBody.login.operationId}`, {
+    method: "DELETE", headers: { host: "127.0.0.1" },
+  }), { params: Promise.resolve({ operationId: createdBody.login.operationId }) });
+  fs.writeFileSync(path.join(sandbox, "accounts", "claude", createdBody.account.id, ".credentials.json"), "{}", { mode: 0o600 });
+
+  const retry = await POST(new NextRequest("http://127.0.0.1/api/accounts/claude", {
+    method: "POST",
+    headers: { host: "127.0.0.1", "content-type": "application/json" },
+    body: JSON.stringify({ action: "retry", id: createdBody.account.id }),
+  }));
+
+  expect(retry.status).toBe(202);
+  const retryBody = await retry.json() as { account: { id: string; kind: string }; login: { phase: string; operationId: string } };
+  expect(retryBody.account).toEqual(expect.objectContaining({ id: createdBody.account.id, kind: "managed" }));
+  expect(retryBody.login.phase).toBe("awaiting_browser");
+  expect(retryBody.login.operationId).not.toBe(createdBody.login.operationId);
+});
+
+test("a failed legacy retry returns a sanitized, retryable error and never leaks detail (issue #470)", async () => {
+  setClaudeLoginSupervisorForTests(new ClaudeLoginSupervisor({
+    spawn: () => child as never,
+    kill: () => undefined,
+    pidStartToken: () => null, // fails the launch fence
+    isExpectedClaude: () => true,
+    waitForExit: async () => undefined,
+    status: async () => ({ loggedIn: false, method: null, email: null, plan: null }),
+    now: () => 1_000,
+    setTimeout: (callback, ms) => { if (ms <= 2_000) callback(); return {} as NodeJS.Timeout; },
+    clearTimeout: () => undefined,
+  }));
+
+  const retry = await POST(new NextRequest("http://127.0.0.1/api/accounts/claude", {
+    method: "POST",
+    headers: { host: "127.0.0.1", "content-type": "application/json" },
+    body: JSON.stringify({ action: "retry", id: "default" }),
+  }));
+
+  expect(retry.status).toBe(503);
+  const body = await retry.json() as { error: string; code: string };
+  expect(body.code).toBe("launch_unfenced");
+  expect(JSON.stringify(body)).not.toContain("/proc/");
+});
+
 test("the authorization code is accepted through stdin and never appears in the response", async () => {
   const created = await POST(new NextRequest("http://127.0.0.1/api/accounts/claude", {
     method: "POST",

--- a/src/app/api/accounts/claude/route.ts
+++ b/src/app/api/accounts/claude/route.ts
@@ -33,8 +33,10 @@ export async function POST(req: NextRequest) {
       if (body.action === "retry") {
         if (typeof body.id !== "string") return failure(400, "invalid_account", "Account id must be a string");
         try {
+          // Legacy Main and managed accounts alike can reauthenticate in place;
+          // the supervisor fences the login to that account's safe home.
           const account = listClaudeAccounts().find((candidate) => candidate.id === body.id);
-          if (!account || account.kind !== "managed") throw new UnknownClaudeAccountError(body.id);
+          if (!account) throw new UnknownClaudeAccountError(body.id);
           const login = claudeLoginSupervisor.start(account.id);
           if (login.phase === "failed") return failure(503, login.result?.code ?? "start_failed", login.result?.message ?? "Claude login could not start");
           return accountResponse(account, login);

--- a/src/app/api/accounts/route.test.ts
+++ b/src/app/api/accounts/route.test.ts
@@ -262,6 +262,38 @@ test("Claude provider reauthentication projects stored credentials as signed out
   }));
 });
 
+test("legacy Main projects a fresh failed auth check as an error while keeping its credentials (issue #470)", async () => {
+  fs.mkdirSync(process.env.LLV_CLAUDE_HOME!, { recursive: true, mode: 0o700 });
+  fs.writeFileSync(path.join(process.env.LLV_CLAUDE_HOME!, ".credentials.json"), "{}", { mode: 0o600 });
+  const observedAt = new Date().toISOString();
+  agentRegistry().recordQuotaEvaluation({
+    engine: "claude",
+    observations: [{
+      engine: "claude",
+      accountId: "default",
+      authenticated: false,
+      authCheckedAt: observedAt,
+      limits: null,
+      provenance: { source: "unavailable", reason: "quota-probe-failed", staleSince: null },
+      observedAt,
+      bootId: "legacy-main-error-route-test",
+    }],
+    signature: null,
+    bootId: "legacy-main-error-route-test",
+    now: observedAt,
+    minimumGapMs: 60_000,
+  });
+
+  const body = await (await GET()).json() as {
+    claude: { accounts: Array<{ id: string; kind: string; authPresent: boolean; auth: { state: string } }> };
+  };
+  expect(body.claude.accounts.find((item) => item.id === "default")).toEqual(expect.objectContaining({
+    kind: "legacy",
+    authPresent: true,
+    auth: expect.objectContaining({ state: "error" }),
+  }));
+});
+
 test("future quota and auth observations remain ineligible", async () => {
   const account = createManagedCodexAccount("Future");
   setCodexAccountLoginPane(account.id, { paneId: "%future", windowName: "codex-login", startedAt: 0 });

--- a/src/components/AccountsPanel.dom.test.tsx
+++ b/src/components/AccountsPanel.dom.test.tsx
@@ -145,6 +145,38 @@ test("canceling an armed removal backs out without removing the account", async 
   expect([...view.host.querySelectorAll("button")].some((button) => button.textContent === "Remove")).toBe(true);
 });
 
+test("clicking Retry on an erroring legacy Main starts an in-place login recovery (issue #470)", async () => {
+  let retried: string | null = null;
+  const initial = state(login(), {
+    accounts: [{ id: "default", label: "Main", kind: "legacy", authPresent: true, authHealth: "error", loginPending: false, loginState: "authenticated", deviceAuth: null, login: null }],
+    active: "default",
+    retryLogin: async (id) => { retried = id; return true; },
+  });
+  const view = await mount(initial);
+  mounted.push(view);
+  const retry = [...view.host.querySelectorAll("button")].find((button) => button.textContent === "Retry")!;
+
+  flushSync(() => { retry.click(); });
+  await Promise.resolve();
+  expect(retried as unknown as string).toBe("default");
+});
+
+test("clicking Sign in on a signed-out legacy Main starts an in-place login recovery (issue #470)", async () => {
+  let retried: string | null = null;
+  const initial = state(login(), {
+    accounts: [{ id: "default", label: "Main", kind: "legacy", authPresent: false, authHealth: "signed_out", loginPending: false, loginState: "idle", deviceAuth: null, login: null }],
+    active: "",
+    retryLogin: async (id) => { retried = id; return true; },
+  });
+  const view = await mount(initial);
+  mounted.push(view);
+  const signIn = [...view.host.querySelectorAll("button")].find((button) => button.textContent === "Sign in")!;
+
+  flushSync(() => { signIn.click(); });
+  await Promise.resolve();
+  expect(retried as unknown as string).toBe("default");
+});
+
 test("signed-out and pending account rows cannot be selected", async () => {
   const initial = state(login(), {
     accounts: [

--- a/src/components/AccountsPanel.render.test.tsx
+++ b/src/components/AccountsPanel.render.test.tsx
@@ -74,14 +74,14 @@ test("shows account ids and auth health when labels collide", () => {
   const html = render(base({
     engine: "claude",
     accounts: [
-      { id: "botfatherdev-2", label: "botfatherdev", kind: "managed", authPresent: true, authHealth: "signed_out", loginPending: false, loginState: "idle", deviceAuth: null },
-      { id: "botfatherdev-3", label: "botfatherdev", kind: "managed", authPresent: true, authHealth: "authenticated", loginPending: false, loginState: "authenticated", deviceAuth: null },
+      { id: "managed-two", label: "Managed two", kind: "managed", authPresent: true, authHealth: "signed_out", loginPending: false, loginState: "idle", deviceAuth: null },
+      { id: "managed-three", label: "Managed three", kind: "managed", authPresent: true, authHealth: "authenticated", loginPending: false, loginState: "authenticated", deviceAuth: null },
     ],
-    active: "botfatherdev-3",
+    active: "managed-three",
   }));
 
-  expect(html).toContain("botfatherdev-2");
-  expect(html).toContain("botfatherdev-3");
+  expect(html).toContain("managed-two");
+  expect(html).toContain("managed-three");
   expect(html).toContain("Signed out");
   expect(html).toContain("Authenticated");
   expect(html).toContain("bg-danger-soft text-danger");

--- a/src/components/AccountsPanel.render.test.tsx
+++ b/src/components/AccountsPanel.render.test.tsx
@@ -229,9 +229,24 @@ test("an unknown failure code falls back to the generic sanitized line", () => {
 test("a managed unauthenticated account with no live login offers Sign in", () => {
   const html = render(claudeState(null));
   expect(html).toContain("Sign in");
-  // A legacy account never gets the managed sign-in affordance.
-  const legacy = render(claudeState(null, { accounts: [{ id: "acc", label: "Acc", kind: "legacy", authPresent: false, loginPending: false, loginState: "idle", deviceAuth: null, login: null }] }));
-  expect(legacy).not.toContain(">Sign in<");
+});
+
+test("legacy Main stranded in signed_out or error gets an in-place recovery affordance (issue #470)", () => {
+  // A signed-out legacy account offers Sign in — legacy is no longer excluded.
+  const signedOut = render(claudeState(null, { accounts: [{ id: "default", label: "Main", kind: "legacy", authPresent: false, authHealth: "signed_out", loginPending: false, loginState: "idle", deviceAuth: null, login: null }] }));
+  expect(signedOut).toContain(">Sign in<");
+  // A credentialed legacy account whose live auth is erroring offers Retry.
+  const errored = render(claudeState(null, { accounts: [{ id: "default", label: "Main", kind: "legacy", authPresent: true, authHealth: "error", loginPending: false, loginState: "authenticated", deviceAuth: null, login: null }] }));
+  expect(errored).toContain(">Retry<");
+  // A healthy legacy account shows no recovery affordance.
+  const healthy = render(claudeState(null, { accounts: [{ id: "default", label: "Main", kind: "legacy", authPresent: true, authHealth: "authenticated", loginPending: false, loginState: "authenticated", deviceAuth: null, login: null }] }));
+  expect(healthy).not.toContain(">Sign in<");
+  expect(healthy).not.toContain(">Retry<");
+});
+
+test("a managed account erroring with credentials present offers Retry in place (issue #470)", () => {
+  const html = render(claudeState(null, { accounts: [{ id: "acc", label: "Acc", kind: "managed", authPresent: true, authHealth: "error", loginPending: false, loginState: "authenticated", deviceAuth: null, login: null }] }));
+  expect(html).toContain(">Retry<");
 });
 
 test("a live claude login disables the Add-account submit (no second sign-in races)", () => {

--- a/src/components/AccountsPanel.tsx
+++ b/src/components/AccountsPanel.tsx
@@ -232,9 +232,10 @@ function AccountRow({ account, engine, activeId, onSelect, onRemove, disabled, f
 
 /** The Claude sign-in slice for one account row (issue #61). Renders the live
     login phase (browser link + bounded code entry, Cancel), a sanitized failure
-    with Retry, or a Sign in affordance for a managed unauthenticated account —
-    and never removes the account. Codex rows never mount this (device login owns
-    its own inline affordance in AccountRow). */
+    with Retry, or a Sign in / Retry affordance for any account stranded in
+    signed_out or error — legacy Main included (issue #470) — and never removes
+    the account. Codex rows never mount this (device login owns its own inline
+    affordance in AccountRow). */
 function ClaudeLoginRow({ account, state, loginBusy }: { account: AccountOption; state: EngineAccountsState; loginBusy: boolean }) {
   const { t } = useLocale();
   const login = account.login ?? null;
@@ -373,9 +374,13 @@ function ClaudeLoginRow({ account, state, loginBusy }: { account: AccountOption;
     );
   }
 
-  // Managed account with no auth and no live op (covers canceled and the broken
-  // production account): a Sign in affordance that restarts login in place.
-  if (account.kind === "managed" && (!account.authPresent || authHealth(account) === "signed_out")) {
+  // Any Claude account stranded in signed_out or error with no live op — legacy
+  // Main included (issue #470) — gets an in-place recovery affordance that never
+  // removes the account: Sign in when signed out, Retry when a credentialed
+  // account is erroring. This also covers a canceled managed sign-in.
+  const health = authHealth(account);
+  if (health === "signed_out" || health === "error" || !account.authPresent) {
+    const label = health === "error" ? t("accounts.retry") : t("accounts.claudeLogin.signIn");
     return (
       <div ref={rowRef} tabIndex={-1} className="flex items-center gap-2 px-3 pb-2 pl-[26px] focus-visible:outline-none">
         <button
@@ -384,7 +389,7 @@ function ClaudeLoginRow({ account, state, loginBusy }: { account: AccountOption;
           disabled={busy || loginBusy}
           className="inline-flex min-h-[44px] shrink-0 items-center rounded-[7px] border border-border bg-canvas px-2.5 py-0.5 text-[11px] font-semibold hover:bg-sunken disabled:opacity-45 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 sm:min-h-0"
         >
-          {t("accounts.claudeLogin.signIn")}
+          {label}
         </button>
       </div>
     );

--- a/src/lib/accounts/claudeLogin.test.ts
+++ b/src/lib/accounts/claudeLogin.test.ts
@@ -52,6 +52,42 @@ test("a clean environment starts the Claude CLI login protocol without activatio
   expect(calls).toEqual([{ command: expect.any(String), args: ["auth", "login", "--claudeai"] }]);
 });
 
+test("legacy Main reauthenticates in place at its exact home with provider auth cleared (issue #470)", () => {
+  process.env.ANTHROPIC_API_KEY = "present";
+  const calls: Array<{ env: NodeJS.ProcessEnv | undefined }> = [];
+  const supervisor = new ClaudeLoginSupervisor({
+    ...ports(),
+    spawn: (_command, _args, options) => {
+      calls.push({ env: options?.env as NodeJS.ProcessEnv | undefined });
+      return child as never;
+    },
+  });
+
+  // The legacy Main account id is "default"; no managed home is created for it.
+  const operation = supervisor.start("default");
+
+  expect(operation).toEqual(expect.objectContaining({ phase: "awaiting_browser" }));
+  expect(calls[0].env?.CLAUDE_CONFIG_DIR).toBe(process.env.LLV_CLAUDE_HOME!);
+  expect(calls[0].env?.ANTHROPIC_API_KEY).toBeUndefined();
+  expect(calls[0].env?.UMASK).toBe("077");
+  delete process.env.ANTHROPIC_API_KEY;
+});
+
+test("a managed account still erroring with a safe credential file can retry in place (issue #470)", () => {
+  const account = createManagedClaudeAccount("Erroring");
+  fs.writeFileSync(path.join(account.home, ".credentials.json"), "{}", { mode: 0o600 });
+  const calls: Array<{ env: NodeJS.ProcessEnv | undefined }> = [];
+  const supervisor = new ClaudeLoginSupervisor({
+    ...ports(),
+    spawn: (_command, _args, options) => { calls.push({ env: options?.env as NodeJS.ProcessEnv | undefined }); return child as never; },
+  });
+
+  const operation = supervisor.start(account.id);
+
+  expect(operation).toEqual(expect.objectContaining({ phase: "awaiting_browser" }));
+  expect(calls[0].env?.CLAUDE_CONFIG_DIR).toBe(account.home);
+});
+
 test("an unfenced child is rejected before it can accept a login code", () => {
   const account = createManagedClaudeAccount("Unfenced");
   const supervisor = new ClaudeLoginSupervisor({ ...ports(), pidStartToken: () => null });
@@ -442,8 +478,16 @@ test("timeout records its terminal outcome after killing a TERM-resistant child"
   expect(supervisor.get(operation.operationId)).toEqual(expect.objectContaining({ phase: "timed_out" }));
 });
 
-test("legacy Main status keeps the normal process environment", () => {
-  expect(claudeStatusEnvironment(process.env.LLV_CLAUDE_HOME!)).toBe(process.env);
+test("legacy Main status targets its exact home with inherited provider auth cleared", () => {
+  const env = claudeStatusEnvironment(process.env.LLV_CLAUDE_HOME!);
+  expect(env).not.toBe(process.env);
+  expect(env.CLAUDE_CONFIG_DIR).toBe(process.env.LLV_CLAUDE_HOME!);
+  expect(env.ANTHROPIC_API_KEY).toBeUndefined();
+  expect(env.CLAUDE_CODE_OAUTH_TOKEN).toBeUndefined();
+});
+
+test("an unrecognized home keeps the plain process environment for status", () => {
+  expect(claudeStatusEnvironment("/tmp/not-a-claude-home")).toBe(process.env);
 });
 
 test("a reservation blocks a second account creation before filesystem mutation", () => {

--- a/src/lib/accounts/claudeLogin.test.ts
+++ b/src/lib/accounts/claudeLogin.test.ts
@@ -14,7 +14,7 @@ type ClaudeLoginPorts = import("./claudeLogin").ClaudeLoginPorts;
 
 class FakeChild extends EventEmitter { pid = 4242; stdout = new EventEmitter(); stderr = new EventEmitter(); writes: string[] = []; stdin = { write: (text: string) => { this.writes.push(text); return true; }, end: () => undefined }; }
 let child: FakeChild; let signals: string[]; let inheritedChildAlive: boolean;
-function ports(): ClaudeLoginPorts { return { spawn: () => child as never, kill: (_pid, signal) => { signals.push(signal); if (signal === "SIGKILL") inheritedChildAlive = false; }, pidStartToken: () => inheritedChildAlive ? "start-1" : null, isExpectedClaude: () => true, waitForExit: async () => undefined, status: async () => ({ loggedIn: true, method: "oauth", email: "a@example.test", plan: "max" }), now: () => 1_000, setTimeout: (fn, ms) => { if (ms <= 2_000) fn(); return {} as NodeJS.Timeout; }, clearTimeout: () => undefined }; }
+function ports(): ClaudeLoginPorts { return { spawn: () => child as never, kill: (_pid, signal) => { signals.push(signal); if (signal === "SIGKILL") inheritedChildAlive = false; }, pidStartToken: () => inheritedChildAlive ? "start-1" : null, isExpectedClaude: () => true, waitForExit: async () => undefined, status: async () => ({ loggedIn: true, method: "oauth", email: "a@example.com", plan: "max" }), now: () => 1_000, setTimeout: (fn, ms) => { if (ms <= 2_000) fn(); return {} as NodeJS.Timeout; }, clearTimeout: () => undefined }; }
 beforeEach(() => { fs.rmSync(process.env.LLV_STATE_DIR!, { recursive: true, force: true }); child = new FakeChild(); signals = []; inheritedChildAlive = true; });
 afterAll(() => { if (OLD_STATE === undefined) delete process.env.LLV_STATE_DIR; else process.env.LLV_STATE_DIR = OLD_STATE; if (OLD_HOME === undefined) delete process.env.LLV_CLAUDE_HOME; else process.env.LLV_CLAUDE_HOME = OLD_HOME; fs.rmSync(SANDBOX, { recursive: true, force: true }); });
 
@@ -191,11 +191,11 @@ test("input is admitted only after the browser prompt and persists verification 
 test("restart reconciliation rejects PID reuse and preserves only an interrupted safe DTO", async () => {
   const file = path.join(process.env.LLV_STATE_DIR!, "claude-auth-operations.json");
   fs.mkdirSync(path.dirname(file), { recursive: true });
-  fs.writeFileSync(file, JSON.stringify([{ operationId: "00000000-0000-4000-8000-000000000001", accountId: "work", phase: "awaiting_browser", pid: 4242, startToken: "old-start", generation: 3, startedAt: new Date(0).toISOString(), deadlineAt: new Date(1).toISOString() }]));
+  fs.writeFileSync(file, JSON.stringify([{ operationId: "operation-restart-one", accountId: "work", phase: "awaiting_browser", pid: 4242, startToken: "old-start", generation: 3, startedAt: new Date(0).toISOString(), deadlineAt: new Date(1).toISOString() }]));
   const supervisor = new ClaudeLoginSupervisor({ ...ports(), pidStartToken: () => "new-process" });
   await supervisor.whenRecovered();
   expect(signals).toEqual([]);
-  expect(supervisor.get("00000000-0000-4000-8000-000000000001")).toEqual(expect.objectContaining({ phase: "interrupted", loginUrl: null, acceptsCode: false }));
+  expect(supervisor.get("operation-restart-one")).toEqual(expect.objectContaining({ phase: "interrupted", loginUrl: null, acceptsCode: false }));
 });
 
 test("malformed persisted operations are discarded so recovery cannot block a fresh login", () => {
@@ -343,7 +343,7 @@ test("a delayed auth status cannot overwrite a completed cancellation", async ()
   await Promise.resolve();
 
   const canceled = await supervisor.cancel(operation.operationId);
-  resolveStatus({ loggedIn: true, method: "oauth", email: "a@example.test", plan: "max" });
+  resolveStatus({ loggedIn: true, method: "oauth", email: "a@example.com", plan: "max" });
   await Promise.resolve();
 
   expect(canceled.phase).toBe("canceled");
@@ -396,7 +396,7 @@ test("restart sends TERM and KILL, awaits the resistant child exit, then verifie
   fs.writeFileSync(path.join(account.home, ".credentials.json"), "{}", { mode: 0o600 });
   const file = path.join(process.env.LLV_STATE_DIR!, "claude-auth-operations.json");
   fs.mkdirSync(path.dirname(file), { recursive: true });
-  fs.writeFileSync(file, JSON.stringify([{ operationId: "00000000-0000-4000-8000-000000000002", accountId: account.id, phase: "awaiting_browser", pid: 4242, startToken: "start-1", generation: 3, startedAt: new Date(0).toISOString(), deadlineAt: new Date(1).toISOString() }]));
+  fs.writeFileSync(file, JSON.stringify([{ operationId: "operation-restart-two", accountId: account.id, phase: "awaiting_browser", pid: 4242, startToken: "start-1", generation: 3, startedAt: new Date(0).toISOString(), deadlineAt: new Date(1).toISOString() }]));
   const calls: string[] = [];
   const supervisor = new ClaudeLoginSupervisor({
     ...ports(),
@@ -408,13 +408,13 @@ test("restart sends TERM and KILL, awaits the resistant child exit, then verifie
     waitForExit: async () => { calls.push("wait"); },
     status: async () => {
       calls.push("status");
-      return { loggedIn: true, method: "oauth", email: "a@example.test", plan: "max" };
+      return { loggedIn: true, method: "oauth", email: "a@example.com", plan: "max" };
     },
   });
   await supervisor.whenRecovered();
   expect(signals).toEqual(["SIGTERM", "SIGKILL"]);
   expect(calls).toEqual(["kill:SIGTERM", "wait", "kill:SIGKILL", "wait", "status"]);
-  expect(supervisor.get("00000000-0000-4000-8000-000000000002")).toEqual(expect.objectContaining({ phase: "authenticated" }));
+  expect(supervisor.get("operation-restart-two")).toEqual(expect.objectContaining({ phase: "authenticated" }));
 });
 
 test("a restart with a safe credential file remains interrupted when Claude status is logged out", async () => {
@@ -422,7 +422,7 @@ test("a restart with a safe credential file remains interrupted when Claude stat
   fs.writeFileSync(path.join(account.home, ".credentials.json"), "{}", { mode: 0o600 });
   const file = path.join(process.env.LLV_STATE_DIR!, "claude-auth-operations.json");
   fs.mkdirSync(path.dirname(file), { recursive: true });
-  fs.writeFileSync(file, JSON.stringify([{ operationId: "00000000-0000-4000-8000-000000000012", accountId: account.id, phase: "verifying", pid: 4242, startToken: "start-1", generation: 12, startedAt: new Date(0).toISOString(), deadlineAt: new Date(1).toISOString() }]));
+  fs.writeFileSync(file, JSON.stringify([{ operationId: "operation-restart-twelve", accountId: account.id, phase: "verifying", pid: 4242, startToken: "start-1", generation: 12, startedAt: new Date(0).toISOString(), deadlineAt: new Date(1).toISOString() }]));
   const statusHomes: string[] = [];
   const restarted = new ClaudeLoginSupervisor({
     ...ports(),
@@ -435,14 +435,14 @@ test("a restart with a safe credential file remains interrupted when Claude stat
   await restarted.whenRecovered();
 
   expect(statusHomes).toEqual([account.home]);
-  expect(restarted.get("00000000-0000-4000-8000-000000000012")).toEqual(expect.objectContaining({ phase: "interrupted", result: expect.objectContaining({ code: "interrupted" }) }));
+  expect(restarted.get("operation-restart-twelve")).toEqual(expect.objectContaining({ phase: "interrupted", result: expect.objectContaining({ code: "interrupted" }) }));
 });
 
 test("a retry after recovery supersedes the recovered operation", async () => {
   const account = createManagedClaudeAccount("Recovered retry");
   const file = path.join(process.env.LLV_STATE_DIR!, "claude-auth-operations.json");
   fs.mkdirSync(path.dirname(file), { recursive: true });
-  fs.writeFileSync(file, JSON.stringify([{ operationId: "00000000-0000-4000-8000-000000000009", accountId: account.id, phase: "awaiting_browser", pid: 4242, startToken: "old-start", generation: 9, startedAt: new Date(0).toISOString(), deadlineAt: new Date(1).toISOString() }]));
+  fs.writeFileSync(file, JSON.stringify([{ operationId: "operation-restart-nine", accountId: account.id, phase: "awaiting_browser", pid: 4242, startToken: "old-start", generation: 9, startedAt: new Date(0).toISOString(), deadlineAt: new Date(1).toISOString() }]));
   const restarted = new ClaudeLoginSupervisor(ports());
   await restarted.whenRecovered();
 
@@ -463,10 +463,10 @@ test("a successful login requires a safe credential file and survives restart as
   const credentials = path.join(account.home, ".credentials.json");
   fs.writeFileSync(credentials, "{}", { mode: 0o600 });
   const file = path.join(process.env.LLV_STATE_DIR!, "claude-auth-operations.json");
-  fs.writeFileSync(file, JSON.stringify([{ operationId: "00000000-0000-4000-8000-000000000003", accountId: account.id, phase: "verifying", pid: 4242, startToken: "start-1", generation: 9, startedAt: new Date(0).toISOString(), deadlineAt: new Date(1).toISOString() }]));
+  fs.writeFileSync(file, JSON.stringify([{ operationId: "operation-restart-three", accountId: account.id, phase: "verifying", pid: 4242, startToken: "start-1", generation: 9, startedAt: new Date(0).toISOString(), deadlineAt: new Date(1).toISOString() }]));
   const restarted = new ClaudeLoginSupervisor(ports());
   await restarted.whenRecovered();
-  expect(restarted.get("00000000-0000-4000-8000-000000000003")).toEqual(expect.objectContaining({ phase: "authenticated" }));
+  expect(restarted.get("operation-restart-three")).toEqual(expect.objectContaining({ phase: "authenticated" }));
 });
 
 test("timeout records its terminal outcome after killing a TERM-resistant child", async () => {

--- a/src/lib/accounts/claudeLogin.ts
+++ b/src/lib/accounts/claudeLogin.ts
@@ -8,7 +8,7 @@ import { statePath } from "@/lib/configDir";
 import { AccountMutationBusyError, withAccountMutationLock, withAccountMutationLockAsync } from "./accountMutation";
 
 import type { LoginOperationSummary, LoginPhase, LoginResult } from "./contracts";
-import { claudeAccountForSpawn, claudeManagedEnvironment, isManagedClaudeHome, managedClaudeCredentialIsSafe } from "./claude";
+import { claudeAccountForSpawn, claudeManagedEnvironment, isManagedClaudeHome, legacyClaudeHome, managedClaudeCredentialIsSafe } from "./claude";
 
 const OUTPUT_LIMIT = 64 * 1024;
 const CODE_LIMIT = 8 * 1024;
@@ -89,8 +89,18 @@ function expectedClaude(pid: number): boolean {
   try { return isExpectedClaudeLoginCommand(fs.readFileSync(`/proc/${pid}/cmdline`, "utf8")); } catch { return false; }
 }
 
+/** A recognized Claude home is either a safe managed home or the exact legacy
+    Main home. Both reauthenticate in place; nothing else may direct the login. */
+export function isSupervisedClaudeHome(home: string): boolean {
+  return isManagedClaudeHome(home) || home === legacyClaudeHome();
+}
+
+/** Status reads target the exact account home with inherited provider auth
+    variables cleared, so a legacy or managed check reflects the OAuth
+    credentials at that home rather than an ambient API key. An unrecognized
+    home keeps the plain process environment. */
 export function claudeStatusEnvironment(home: string): NodeJS.ProcessEnv {
-  return isManagedClaudeHome(home) ? claudeManagedEnvironment(home) : process.env;
+  return isSupervisedClaudeHome(home) ? claudeManagedEnvironment(home) : process.env;
 }
 
 async function structuredStatus(home: string): Promise<{ loggedIn: boolean; method: string | null; email: string | null; plan: string | null }> {
@@ -304,7 +314,10 @@ export class ClaudeLoginSupervisor {
       const id = operationId;
       if (!id) throw new Error("Claude login operation is unavailable");
       const account = claudeAccountForSpawn(accountId);
-      if (account.kind !== "managed" || !isManagedClaudeHome(account.home)) throw new Error("unsafe Claude account");
+      // Legacy Main reauthenticates at its exact legacy home; managed accounts at
+      // their safe managed home. claudeManagedEnvironment pins CLAUDE_CONFIG_DIR to
+      // that home and strips inherited provider auth variables for either kind.
+      if (!isSupervisedClaudeHome(account.home)) throw new Error("unsafe Claude account");
       const child = this.ports.spawn(resolveBinary("claude"), ["auth", "login", "--claudeai"], {
         cwd: osHome(), env: { ...claudeManagedEnvironment(account.home), UMASK: "077" }, detached: true, stdio: ["pipe", "pipe", "pipe"],
       });
@@ -554,7 +567,9 @@ export class ClaudeLoginSupervisor {
         if (terminated && typeof inherited.accountId === "string") {
           try {
             const account = claudeAccountForSpawn(inherited.accountId);
-            if (account.kind === "managed" && managedClaudeCredentialIsSafe(account.home, true)) {
+            // Verify recovery for either a safe managed home or the exact legacy
+            // Main home, and only when its credential file passes the safety check.
+            if (isSupervisedClaudeHome(account.home) && managedClaudeCredentialIsSafe(account.home, true)) {
               const status = await this.ports.status(account.home);
               authenticated = status.loggedIn;
             }


### PR DESCRIPTION
## Summary

- show an in-place Sign in or Retry action for Claude accounts in `signed_out` or `error`, including legacy Main
- supervise legacy Main login at its exact configured home with provider-auth environment variables cleared
- keep the existing process identity fence, one-operation lock, credential-file safety checks, sanitized failure responses, and account identity
- cover supervisor, route, projection, render, and DOM behavior

## Verification

- 93 focused tests passed
- full-suite delta matches the pre-change baseline; zero new failures
- `bunx tsc --noEmit`
- changed-file ESLint
- production build
- privacy delta: zero new findings

The source diff was independently inspected for home ownership, process fencing, environment sanitization, and credential preservation.

Closes #470.