### PR TITLE
Composer: recover after receipt reconciliation expiry

### DIFF
--- a/src/components/ComposerBar.tsx
+++ b/src/components/ComposerBar.tsx
@@ -55,6 +55,9 @@ export interface ComposerBarProps {
   /** When set, Send is disabled with this tooltip and no submit is attempted
       (issue #247 §5: a dead host blocks sends so no rejected receipts stack). */
   sendDisabledReason?: string;
+  /** A caller-owned immutable generation can supply the payload while the
+      editable textarea and image tray are empty. */
+  sendPayloadAvailable?: boolean;
   /** Durable runtime receipt chips for the last sends on this target (issue
       #25). Rendered under the status line; absent while the runtime bus is off,
       so the composer is unchanged on the landing-disabled path. */
@@ -139,6 +142,7 @@ export function ComposerBar({
   imageDisabled = false,
   imageDisabledReason,
   sendDisabledReason,
+  sendPayloadAvailable = false,
   receipts,
 }: ComposerBarProps) {
   const {
@@ -156,6 +160,8 @@ export function ComposerBar({
     dictationRecording,
     busy,
     status,
+    dictationBusy,
+    attachmentsBlocked,
   } = composer;
   const { t } = useLocale();
   const isMobile = useIsMobile();
@@ -180,7 +186,8 @@ export function ComposerBar({
       ? t("img.blockedFailed")
       : undefined;
   const sendBlocked = Boolean(sendDisabledReason);
-  const sendDisabled = sendBlocked || (!canSend && !hasSendMenu) || imageSendBlocked;
+  const effectiveCanSend = canSend || (sendPayloadAvailable && !fieldsDisabled && !dictationBusy && !attachmentsBlocked);
+  const sendDisabled = sendBlocked || (!effectiveCanSend && !hasSendMenu) || imageSendBlocked;
   /* Composer action buttons (send, image) are a 32px visual control with a 44px
      touch hit area via a pseudo-element (design doc §3.5, matching the anchored
      mic), so the accent send never renders as a full 44×44 block on a phone;
@@ -235,14 +242,14 @@ export function ComposerBar({
               dictationRecording && !sendBlocked
                 ? () => void stopAndSend()
                 : (event) => {
-                    if (sendBlocked || !canSend) {
+                    if (sendBlocked || !effectiveCanSend) {
                       event.preventDefault();
                       event.stopPropagation();
                     }
                   }
             }
             disabled={sendDisabled}
-            aria-disabled={sendBlocked || !canSend || imageSendBlocked}
+            aria-disabled={sendBlocked || !effectiveCanSend || imageSendBlocked}
             aria-label={sendBlocked ? sendDisabledReason! : dictationRecording ? sendLabelRecording : sendLabelIdle}
             style={dictationRecording ? undefined : sendIdleStyle}
             className={`inline-flex shrink-0 items-center justify-center rounded-control border text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/50 disabled:opacity-40 aria-disabled:opacity-40 ${iconBtn} ${
@@ -336,7 +343,7 @@ export function ComposerBar({
                off just the typed prefix and leave the recording running. */
             if (event.key === "Enter" && !event.shiftKey && !event.nativeEvent.isComposing) {
               event.preventDefault();
-              if (sendBlocked || !canSend || imageSendBlocked) return;
+              if (sendBlocked || !effectiveCanSend || imageSendBlocked) return;
               if (dictation.phase === "rec") void stopAndSend();
               else void submit();
             }

--- a/src/components/TmuxComposer.deliveryState.dom.test.tsx
+++ b/src/components/TmuxComposer.deliveryState.dom.test.tsx
@@ -199,6 +199,30 @@ test("a failure renders once with retry, edit, and dismiss, and dismissal report
   flushSync(() => root.unmount());
 });
 
+test("retry appears once only after an authoritative retryable terminal failure", async () => {
+  setLocale("en");
+  const retryLabel = translate("en", "runtime.receipt.retry");
+  const view = (status: RuntimeReceipt["status"]) => (
+    <RuntimeComposerReceipts
+      receipts={[receipt({ operationId: `op-${status}`, status, text: "preserved generation" })]}
+      onRetry={() => {}}
+      onEdit={() => {}}
+      onDismiss={() => {}}
+    />
+  );
+  const { host, root } = await renderInto(view("uncertain"));
+  const retries = () => [...host.querySelectorAll("button")]
+    .filter((button) => button.textContent === retryLabel);
+
+  expect(retries()).toHaveLength(0);
+  await settle(() => root.render(view("rejected")));
+  expect(retries()).toHaveLength(0);
+  await settle(() => root.render(view("failed")));
+  expect(retries()).toHaveLength(1);
+
+  await act(async () => root.unmount());
+});
+
 test("a dismissed failure stays dismissed across a composer remount", async () => {
   mockTargets();
   publishReceipts([receipt({ operationId: "op-persist", status: "failed", reason: "dead-host", text: "retry або ні" })]);

--- a/src/components/TmuxComposer.reconciliation.dom.test.tsx
+++ b/src/components/TmuxComposer.reconciliation.dom.test.tsx
@@ -8,6 +8,8 @@ import type { RuntimeReceipt } from "@/components/runtime/runtimeModel";
 import { setLocale, translate } from "@/lib/i18n";
 import type { FileEntry } from "@/lib/types";
 
+import { ComposerAdmissionTimeoutError } from "./composerAdmissionDeadline";
+
 const dom = new Window();
 Object.assign(globalThis, {
   window: dom,
@@ -26,8 +28,9 @@ Object.assign(globalThis, {
   localStorage: dom.localStorage,
   sessionStorage: dom.sessionStorage,
 });
+let mobileViewport = false;
 (dom as unknown as { matchMedia: (query: string) => unknown }).matchMedia = (query: string) => ({
-  matches: false,
+  matches: mobileViewport && query.includes("max-width"),
   media: query,
   addEventListener() {},
   removeEventListener() {},
@@ -41,6 +44,7 @@ Object.assign(globalThis, {
 const actualRuntimeHooks = await import("@/hooks/useRuntime");
 const receiptListeners = new Set<() => void>();
 let busReceipts: RuntimeReceipt[] = [];
+let refreshRuntimeImpl: () => Promise<boolean> = async () => false;
 function publishReceipts(next: RuntimeReceipt[]): void {
   busReceipts = next;
   for (const listener of receiptListeners) listener();
@@ -48,6 +52,7 @@ function publishReceipts(next: RuntimeReceipt[]): void {
 mock.module("@/hooks/useRuntime", () => ({
   ...actualRuntimeHooks,
   useRuntimeSession: () => null,
+  refreshRuntime: () => refreshRuntimeImpl(),
   useRuntimeReceiptsForArtifact: () => useSyncExternalStore(
     (listener) => {
       receiptListeners.add(listener);
@@ -149,7 +154,7 @@ test("a mid-flight queued admission settles the generation and the stale timeout
     expect(previews()).toHaveLength(count);
   };
   const admission = (status: RuntimeReceipt["status"], revision: number): RuntimeReceipt => ({
-    operationId: "ac0223c0-2bef-46dd-a26e-143b758f66dc",
+    operationId: "op-remount-admitted",
     idempotencyKey: sentKeys[0]!,
     conversationId: "conversation_bus-session",
     kind: "send",
@@ -257,7 +262,7 @@ test("a queued admission after remount still clears the persisted generation exa
     flushSync(() => appendComposerDraft(conversationId, "after refresh typing"));
     /* The refresh snapshot already carries the durable queued admission. */
     publishReceipts([{
-      operationId: "ac0223c0-2bef-46dd-a26e-143b758f66dc",
+      operationId: "op-remount-admitted",
       idempotencyKey: sentKeys[0]!,
       conversationId: "conversation_bus-session",
       kind: "send",
@@ -282,6 +287,279 @@ test("a queued admission after remount still clears the persisted generation exa
   } finally {
     flushSync(() => root.unmount());
     publishReceipts([]);
+    sessionStorage.clear();
+    host.remove();
+  }
+});
+
+test("a refresh resumes a timed-out generation without another send", async () => {
+  setLocale("en");
+  mobileViewport = false;
+  const conversationId = "conv-timeout-refresh";
+  const prompt = "preserve this generation across refresh";
+  const sentKeys: string[] = [];
+  let refreshCalls = 0;
+  globalThis.fetch = (async (input, init) => {
+    if (String(input) === "/api/tmux/targets") {
+      return { ok: true, json: async () => ({ targets: { "0": null } }) } as Response;
+    }
+    if (String(input) !== "/api/tmux") throw new Error(`unexpected request: ${String(input)}`);
+    const body = JSON.parse(String(init?.body)) as { clientMessageId: string };
+    sentKeys.push(body.clientMessageId);
+    throw new ComposerAdmissionTimeoutError();
+  }) as typeof fetch;
+  refreshRuntimeImpl = () => {
+    refreshCalls += 1;
+    return new Promise<boolean>(() => {});
+  };
+
+  sessionStorage.setItem(`llvDraft:${conversationId}`, prompt);
+  const host = document.createElement("div");
+  document.body.append(host);
+  let root = createRoot(host);
+  flushSync(() => root.render(<TmuxComposer file={fileFor(conversationId)} />));
+  let textarea = host.querySelector("textarea") as HTMLTextAreaElement;
+
+  try {
+    flushSync(() => textarea.closest("form")!.dispatchEvent(new dom.Event("submit", { bubbles: true, cancelable: true }) as unknown as Event));
+    for (let attempt = 0; attempt < 50 && refreshCalls === 0; attempt += 1) {
+      await new Promise((resolve) => setTimeout(resolve, 2));
+    }
+    expect(sentKeys).toHaveLength(1);
+    expect(sessionStorage.getItem(`llvPendingSend:${conversationId}`)).toContain('"reconciling":true');
+
+    flushSync(() => root.unmount());
+    let releaseRefresh: (() => void) | null = null;
+    refreshRuntimeImpl = () => new Promise<boolean>((resolve) => {
+      refreshCalls += 1;
+      releaseRefresh = () => {
+        publishReceipts([{
+          operationId: "op-timeout-refresh",
+          idempotencyKey: sentKeys[0]!,
+          conversationId,
+          kind: "send",
+          status: "queued",
+          text: prompt,
+          at: "2026-07-20T08:01:00.000Z",
+          revision: 1,
+        }]);
+        resolve(true);
+      };
+    });
+    root = createRoot(host);
+    flushSync(() => root.render(<TmuxComposer file={fileFor(conversationId)} />));
+    for (let attempt = 0; attempt < 50 && releaseRefresh === null; attempt += 1) {
+      await new Promise((resolve) => setTimeout(resolve, 2));
+    }
+    expect(releaseRefresh).not.toBeNull();
+    expect(sentKeys).toHaveLength(1);
+
+    textarea = host.querySelector("textarea") as HTMLTextAreaElement;
+    const propsKey = Object.keys(textarea).find((key) => key.startsWith("__reactProps$"))!;
+    const textareaProps = (textarea as unknown as Record<string, { onChange(event: unknown): void }>)[propsKey]!;
+    flushSync(() => textareaProps.onChange({ target: { value: `${prompt}\nafter refresh typing` } }));
+    flushSync(() => releaseRefresh!());
+    for (let attempt = 0; attempt < 50 && textarea.value !== "after refresh typing"; attempt += 1) {
+      await new Promise((resolve) => setTimeout(resolve, 2));
+    }
+
+    expect(textarea.value).toBe("after refresh typing");
+    expect(sessionStorage.getItem(`llvPendingSend:${conversationId}`)).toBeNull();
+    expect(host.querySelectorAll('[data-receipt-status="queued"]')).toHaveLength(1);
+  } finally {
+    flushSync(() => root.unmount());
+    publishReceipts([]);
+    refreshRuntimeImpl = async () => false;
+    sessionStorage.clear();
+    host.remove();
+  }
+});
+
+test("a delayed receipt reconciles one text-plus-images generation on desktop and 390px", async () => {
+  setLocale("en");
+  for (const [width, mobile] of [[1440, false], [390, true]] as const) {
+    mobileViewport = mobile;
+    Object.defineProperty(dom, "innerWidth", { configurable: true, value: width });
+    const conversationId = `conv-delayed-${width}`;
+    const prompt = `inspect both screenshots at ${width}`;
+    const nextDraft = `continue typing at ${width}`;
+    const sentKeys: string[] = [];
+    let releaseRefresh: (() => void) | null = null;
+    globalThis.fetch = (async (input, init) => {
+      if (String(input) === "/api/tmux/targets") {
+        return { ok: true, json: async () => ({ targets: { "0": null } }) } as Response;
+      }
+      if (String(input) !== "/api/tmux") throw new Error(`unexpected request: ${String(input)}`);
+      const body = JSON.parse(String(init?.body)) as { clientMessageId: string };
+      sentKeys.push(body.clientMessageId);
+      throw new ComposerAdmissionTimeoutError();
+    }) as typeof fetch;
+    refreshRuntimeImpl = () => new Promise<boolean>((resolve) => {
+      releaseRefresh = () => {
+        publishReceipts([{
+          operationId: `op-delayed-${width}`,
+          idempotencyKey: sentKeys[0]!,
+          conversationId,
+          kind: "send",
+          status: "queued",
+          text: prompt,
+          at: "2026-07-20T08:00:00.000Z",
+          revision: 1,
+        }]);
+        resolve(true);
+      };
+    });
+
+    sessionStorage.setItem(`llvDraft:${conversationId}`, prompt);
+    const host = document.createElement("div");
+    document.body.append(host);
+    const root = createRoot(host);
+    flushSync(() => root.render(<TmuxComposer file={fileFor(conversationId)} />));
+    const textarea = host.querySelector("textarea") as HTMLTextAreaElement;
+    const form = textarea.closest("form")!;
+    const propsKey = Object.keys(textarea).find((key) => key.startsWith("__reactProps$"))!;
+    const textareaProps = (textarea as unknown as Record<string, {
+      onChange(event: unknown): void;
+      onPaste(event: unknown): void;
+    }>)[propsKey]!;
+    const previews = () => [...host.querySelectorAll("img")].map((image) => image.getAttribute("src"));
+    const pasteImage = (tag: string) => {
+      const bytes = new TextEncoder().encode(`png-${tag}`);
+      textareaProps.onPaste({
+        clipboardData: { items: [{ type: "image/png", getAsFile: () => new dom.File([bytes], `${tag}.png`, { type: "image/png" }) }] },
+        preventDefault() {},
+      });
+    };
+    const untilPreviews = async (count: number) => {
+      for (let attempt = 0; attempt < 50 && previews().length !== count; attempt += 1) {
+        await new Promise((resolve) => setTimeout(resolve, 2));
+      }
+      expect(previews()).toHaveLength(count);
+    };
+
+    try {
+      pasteImage(`first-${width}`);
+      pasteImage(`second-${width}`);
+      await untilPreviews(2);
+      flushSync(() => form.dispatchEvent(new dom.Event("submit", { bubbles: true, cancelable: true }) as unknown as Event));
+      for (let attempt = 0; attempt < 50 && releaseRefresh === null; attempt += 1) {
+        await new Promise((resolve) => setTimeout(resolve, 2));
+      }
+      expect(releaseRefresh).not.toBeNull();
+      expect(sentKeys).toHaveLength(1);
+
+      flushSync(() => textareaProps.onChange({ target: { value: `${prompt}\n${nextDraft}` } }));
+      pasteImage(`third-${width}`);
+      await untilPreviews(3);
+      const nextPreview = previews()[2];
+      flushSync(() => form.dispatchEvent(new dom.Event("submit", { bubbles: true, cancelable: true }) as unknown as Event));
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(sentKeys).toHaveLength(1);
+
+      flushSync(() => releaseRefresh!());
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(textarea.value).toBe(nextDraft);
+      expect(previews()).toEqual([nextPreview]);
+      expect(new Set(sentKeys)).toEqual(new Set([sentKeys[0]!]));
+      expect(host.querySelectorAll('[data-receipt-status="queued"]')).toHaveLength(1);
+      expect(host.querySelector(`[aria-label="${translate("en", "runtime.receipt.retry")}"]`)).toBeNull();
+      if (mobile) {
+        expect(form.getAttribute("data-testid")).toBe("bounded-mobile-composer");
+      } else {
+        expect(form.getAttribute("data-testid")).toBeNull();
+      }
+    } finally {
+      flushSync(() => root.unmount());
+      publishReceipts([]);
+      refreshRuntimeImpl = async () => false;
+      sessionStorage.clear();
+      host.remove();
+    }
+  }
+  mobileViewport = false;
+});
+
+test("only a confirmed retryable failure exposes Retry after a timeout", async () => {
+  setLocale("en");
+  mobileViewport = false;
+  const conversationId = "conv-timeout-terminal";
+  const prompt = "keep this failed generation exact";
+  const sentKeys: string[] = [];
+  globalThis.fetch = (async (input, init) => {
+    if (String(input) === "/api/tmux/targets") {
+      return { ok: true, json: async () => ({ targets: { "0": null } }) } as Response;
+    }
+    if (String(input) !== "/api/tmux") throw new Error(`unexpected request: ${String(input)}`);
+    const body = JSON.parse(String(init?.body)) as { clientMessageId: string };
+    sentKeys.push(body.clientMessageId);
+    throw new ComposerAdmissionTimeoutError();
+  }) as typeof fetch;
+  refreshRuntimeImpl = () => new Promise<boolean>(() => {});
+  sessionStorage.setItem(`llvDraft:${conversationId}`, prompt);
+
+  const host = document.createElement("div");
+  document.body.append(host);
+  const root = createRoot(host);
+  flushSync(() => root.render(<TmuxComposer file={fileFor(conversationId)} />));
+  const textarea = host.querySelector("textarea") as HTMLTextAreaElement;
+  const form = textarea.closest("form")!;
+  const propsKey = Object.keys(textarea).find((key) => key.startsWith("__reactProps$"))!;
+  const textareaProps = (textarea as unknown as Record<string, { onPaste(event: unknown): void }>)[propsKey]!;
+  const pasteImage = (tag: string) => textareaProps.onPaste({
+    clipboardData: {
+      items: [{
+        type: "image/png",
+        getAsFile: () => new dom.File([new TextEncoder().encode(tag)], `${tag}.png`, { type: "image/png" }),
+      }],
+    },
+    preventDefault() {},
+  });
+  const untilImages = async (count: number) => {
+    for (let attempt = 0; attempt < 50 && host.querySelectorAll("img").length !== count; attempt += 1) {
+      await new Promise((resolve) => setTimeout(resolve, 2));
+    }
+    expect(host.querySelectorAll("img")).toHaveLength(count);
+  };
+  const terminalReceipt = (status: RuntimeReceipt["status"], revision: number): RuntimeReceipt => ({
+    operationId: "op-timeout-terminal",
+    idempotencyKey: sentKeys[0]!,
+    conversationId,
+    kind: "send",
+    status,
+    text: prompt,
+    reason: "dead-host",
+    at: "2026-07-20T08:02:00.000Z",
+    revision,
+  });
+  const retries = () => [...host.querySelectorAll("button")]
+    .filter((button) => button.textContent === translate("en", "runtime.receipt.retry"));
+
+  try {
+    pasteImage("failure-first");
+    pasteImage("failure-second");
+    await untilImages(2);
+    flushSync(() => form.dispatchEvent(new dom.Event("submit", { bubbles: true, cancelable: true }) as unknown as Event));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(sentKeys).toHaveLength(1);
+
+    flushSync(() => publishReceipts([terminalReceipt("uncertain", 1)]));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect((host.querySelector('button[type="submit"]') as HTMLButtonElement).disabled).toBe(true);
+    expect(retries()).toHaveLength(0);
+    expect(textarea.value).toBe(prompt);
+    expect(host.querySelectorAll("img")).toHaveLength(2);
+
+    flushSync(() => publishReceipts([terminalReceipt("failed", 2)]));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect((host.querySelector('button[type="submit"]') as HTMLButtonElement).disabled).toBe(false);
+    expect(retries()).toHaveLength(1);
+    expect(host.querySelectorAll("[data-receipt-message]")).toHaveLength(1);
+    expect(textarea.value).toBe(prompt);
+    expect(host.querySelectorAll("img")).toHaveLength(2);
+  } finally {
+    flushSync(() => root.unmount());
+    publishReceipts([]);
+    refreshRuntimeImpl = async () => false;
     sessionStorage.clear();
     host.remove();
   }

--- a/src/components/TmuxComposer.reconciliationExpiry.dom.test.tsx
+++ b/src/components/TmuxComposer.reconciliationExpiry.dom.test.tsx
@@ -1,0 +1,514 @@
+import { afterAll, expect, mock, test } from "bun:test";
+import { Window } from "happy-dom";
+import { useSyncExternalStore } from "react";
+import { flushSync } from "react-dom";
+import { createRoot } from "react-dom/client";
+
+import type { RuntimeReceipt } from "@/components/runtime/runtimeModel";
+import { setLocale, translate } from "@/lib/i18n";
+import type { FileEntry } from "@/lib/types";
+
+const dom = new Window();
+Object.assign(globalThis, {
+  window: dom,
+  document: dom.document,
+  navigator: dom.navigator,
+  Node: dom.Node,
+  HTMLElement: dom.HTMLElement,
+  HTMLButtonElement: dom.HTMLButtonElement,
+  Event: dom.Event,
+  CustomEvent: dom.CustomEvent,
+  MouseEvent: dom.MouseEvent,
+  File: dom.File,
+  FileReader: dom.FileReader,
+  requestAnimationFrame: dom.requestAnimationFrame.bind(dom),
+  cancelAnimationFrame: dom.cancelAnimationFrame.bind(dom),
+  localStorage: dom.localStorage,
+  sessionStorage: dom.sessionStorage,
+});
+let mobileViewport = false;
+(dom as unknown as { matchMedia: (query: string) => unknown }).matchMedia = (query: string) => ({
+  matches: mobileViewport && query.includes("max-width"),
+  media: query,
+  addEventListener() {},
+  removeEventListener() {},
+});
+
+/* The local reconciliation window is a product-real 30s. These tests exercise
+   its EXPIRY, so the module is mocked to a few tens of milliseconds while every
+   reconciliation primitive stays the real implementation — the component reads
+   the window/poll constants and threads them through, so shrinking them here
+   drives the production code path. bun runs each test file in its own module
+   graph, so this override stays isolated from the 30s tests next door. */
+const actualDeadline = await import("./composerAdmissionDeadline");
+mock.module("./composerAdmissionDeadline", () => ({
+  ...actualDeadline,
+  COMPOSER_RECEIPT_RECONCILIATION_MS: 40,
+  COMPOSER_RECEIPT_POLL_INTERVAL_MS: 5,
+}));
+const { ComposerAdmissionTimeoutError } = actualDeadline;
+
+/* A controllable durable-receipt stream stands in for the runtime bus (see the
+   sibling reconciliation test for the rationale). */
+const actualRuntimeHooks = await import("@/hooks/useRuntime");
+const receiptListeners = new Set<() => void>();
+let busReceipts: RuntimeReceipt[] = [];
+let refreshRuntimeImpl: () => Promise<boolean> = async () => false;
+function publishReceipts(next: RuntimeReceipt[]): void {
+  busReceipts = next;
+  for (const listener of receiptListeners) listener();
+}
+mock.module("@/hooks/useRuntime", () => ({
+  ...actualRuntimeHooks,
+  useRuntimeSession: () => null,
+  refreshRuntime: () => refreshRuntimeImpl(),
+  useRuntimeReceiptsForArtifact: () => useSyncExternalStore(
+    (listener) => {
+      receiptListeners.add(listener);
+      return () => receiptListeners.delete(listener);
+    },
+    () => busReceipts,
+    () => busReceipts,
+  ),
+}));
+afterAll(() => {
+  mock.module("@/hooks/useRuntime", () => actualRuntimeHooks);
+  mock.module("./composerAdmissionDeadline", () => actualDeadline);
+});
+
+const { TmuxComposer } = await import("./TmuxComposer");
+
+function fileFor(conversationId: string): FileEntry {
+  return {
+    path: `/${conversationId}.jsonl`,
+    root: "codex-sessions",
+    name: `${conversationId}.jsonl`,
+    project: "viewer",
+    title: conversationId,
+    engine: "codex",
+    kind: "session",
+    fmt: "codex",
+    parent: null,
+    mtime: 1,
+    size: 1,
+    activity: "idle",
+    proc: "running",
+    pid: null,
+    conversationId,
+    pendingQuestion: null,
+    waitingInput: null,
+  } as FileEntry;
+}
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+const submitButton = (host: HTMLElement) => host.querySelector('button[type="submit"]') as HTMLButtonElement;
+async function untilSendEnabled(host: HTMLElement): Promise<void> {
+  for (let attempt = 0; attempt < 100 && submitButton(host).disabled; attempt += 1) await sleep(3);
+  expect(submitButton(host).disabled).toBe(false);
+}
+
+test("no receipt within the local window recovers the composer for an exactly-once same-key retry", async () => {
+  setLocale("en");
+  mobileViewport = false;
+  const conversationId = "conv-expiry-recover";
+  const prompt = "confirm the deploy went out";
+  const sentKeys: string[] = [];
+  globalThis.fetch = (async (input, init) => {
+    if (String(input) === "/api/tmux/targets") {
+      return { ok: true, json: async () => ({ targets: { "0": null } }) } as Response;
+    }
+    if (String(input) !== "/api/tmux") throw new Error(`unexpected request: ${String(input)}`);
+    const body = JSON.parse(String(init?.body)) as { clientMessageId: string };
+    sentKeys.push(body.clientMessageId);
+    if (sentKeys.length === 1) throw new ComposerAdmissionTimeoutError();
+    /* The explicit retry replays the SAME key and this time is admitted. */
+    return {
+      ok: true,
+      status: 200,
+      json: async () => ({
+        ok: true,
+        structured: true,
+        receipt: {
+          operationId: "op-expiry-retry",
+          idempotencyKey: body.clientMessageId,
+          conversationId,
+          kind: "send",
+          status: "queued",
+          text: prompt,
+          at: "2026-07-20T09:00:00.000Z",
+          revision: 1,
+        },
+      }),
+    } as Response;
+  }) as typeof fetch;
+  refreshRuntimeImpl = async () => false;
+
+  sessionStorage.setItem(`llvDraft:${conversationId}`, prompt);
+  const host = document.createElement("div");
+  document.body.append(host);
+  const root = createRoot(host);
+  flushSync(() => root.render(<TmuxComposer file={fileFor(conversationId)} />));
+  const textarea = host.querySelector("textarea") as HTMLTextAreaElement;
+  const form = textarea.closest("form")!;
+
+  try {
+    flushSync(() => form.dispatchEvent(new dom.Event("submit", { bubbles: true, cancelable: true }) as unknown as Event));
+    /* The window expires with no receipt; the composer must NOT stay disabled. */
+    await untilSendEnabled(host);
+    expect(sentKeys).toHaveLength(1);
+    expect(textarea.value).toBe(prompt);
+    /* Accurate, recoverable wording for the expired-window state. */
+    expect(host.textContent).toContain(translate("en", "composer.deliveryUnconfirmed"));
+    /* One durable, honest receipt row for the preserved generation. */
+    expect(host.querySelectorAll('[data-receipt-status="uncertain"]')).toHaveLength(1);
+    expect(host.querySelector("[data-receipt-preview]")?.textContent).toBe(prompt);
+    /* The reconciliation loop never actuates a second send on its own. */
+    await sleep(60);
+    expect(sentKeys).toHaveLength(1);
+    expect(sessionStorage.getItem(`llvPendingSend:${conversationId}`)).toContain(sentKeys[0]!);
+
+    /* The operator explicitly retries: the ORIGINAL key replays idempotently. */
+    flushSync(() => form.dispatchEvent(new dom.Event("submit", { bubbles: true, cancelable: true }) as unknown as Event));
+    await sleep(0);
+    expect(sentKeys).toHaveLength(2);
+    expect(sentKeys[1]).toBe(sentKeys[0]);
+    expect(textarea.value).toBe("");
+    expect(host.querySelectorAll('[data-receipt-status="queued"]')).toHaveLength(1);
+  } finally {
+    flushSync(() => root.unmount());
+    publishReceipts([]);
+    refreshRuntimeImpl = async () => false;
+    sessionStorage.clear();
+    host.remove();
+  }
+});
+
+test("a late receipt after the window still settles the preserved generation with no resend", async () => {
+  setLocale("en");
+  mobileViewport = false;
+  const conversationId = "conv-expiry-late";
+  const prompt = "did the migration finish";
+  const sentKeys: string[] = [];
+  globalThis.fetch = (async (input, init) => {
+    if (String(input) === "/api/tmux/targets") {
+      return { ok: true, json: async () => ({ targets: { "0": null } }) } as Response;
+    }
+    if (String(input) !== "/api/tmux") throw new Error(`unexpected request: ${String(input)}`);
+    const body = JSON.parse(String(init?.body)) as { clientMessageId: string };
+    sentKeys.push(body.clientMessageId);
+    throw new ComposerAdmissionTimeoutError();
+  }) as typeof fetch;
+  refreshRuntimeImpl = async () => false;
+
+  sessionStorage.setItem(`llvDraft:${conversationId}`, prompt);
+  const host = document.createElement("div");
+  document.body.append(host);
+  const root = createRoot(host);
+  flushSync(() => root.render(<TmuxComposer file={fileFor(conversationId)} />));
+  const textarea = host.querySelector("textarea") as HTMLTextAreaElement;
+  const form = textarea.closest("form")!;
+
+  try {
+    flushSync(() => form.dispatchEvent(new dom.Event("submit", { bubbles: true, cancelable: true }) as unknown as Event));
+    await untilSendEnabled(host);
+    expect(host.querySelectorAll('[data-receipt-status="uncertain"]')).toHaveLength(1);
+
+    /* The durable admission finally lands, well after the local window closed. */
+    flushSync(() => publishReceipts([{
+      operationId: "op-expiry-late",
+      idempotencyKey: sentKeys[0]!,
+      conversationId,
+      kind: "send",
+      status: "queued",
+      text: prompt,
+      at: "2026-07-20T09:01:00.000Z",
+      revision: 1,
+    }]));
+    await sleep(0);
+
+    expect(textarea.value).toBe("");
+    expect(sentKeys).toHaveLength(1);
+    /* The uncertain row is superseded — exactly one durable receipt remains. */
+    expect(host.querySelectorAll('[data-receipt-status="uncertain"]')).toHaveLength(0);
+    expect(host.querySelectorAll('[data-receipt-status="queued"]')).toHaveLength(1);
+    expect(sessionStorage.getItem(`llvPendingSend:${conversationId}`)).toBe(null);
+  } finally {
+    flushSync(() => root.unmount());
+    publishReceipts([]);
+    refreshRuntimeImpl = async () => false;
+    sessionStorage.clear();
+    host.remove();
+  }
+});
+
+test("the recovered generation survives a remount and keeps its original key", async () => {
+  setLocale("en");
+  mobileViewport = false;
+  const conversationId = "conv-expiry-remount";
+  const prompt = "still preserved across a refresh";
+  const sentKeys: string[] = [];
+  globalThis.fetch = (async (input, init) => {
+    if (String(input) === "/api/tmux/targets") {
+      return { ok: true, json: async () => ({ targets: { "0": null } }) } as Response;
+    }
+    if (String(input) !== "/api/tmux") throw new Error(`unexpected request: ${String(input)}`);
+    const body = JSON.parse(String(init?.body)) as { clientMessageId: string };
+    sentKeys.push(body.clientMessageId);
+    throw new ComposerAdmissionTimeoutError();
+  }) as typeof fetch;
+  refreshRuntimeImpl = async () => false;
+
+  sessionStorage.setItem(`llvDraft:${conversationId}`, prompt);
+  const host = document.createElement("div");
+  document.body.append(host);
+  let root = createRoot(host);
+  flushSync(() => root.render(<TmuxComposer file={fileFor(conversationId)} />));
+
+  try {
+    flushSync(() => (host.querySelector("textarea") as HTMLTextAreaElement)
+      .closest("form")!.dispatchEvent(new dom.Event("submit", { bubbles: true, cancelable: true }) as unknown as Event));
+    await untilSendEnabled(host);
+    expect(sentKeys).toHaveLength(1);
+    /* The released marker must not re-arm the disabled window on remount. */
+    expect(sessionStorage.getItem(`llvPendingSend:${conversationId}`)).not.toContain('"reconciling":true');
+
+    flushSync(() => root.unmount());
+    root = createRoot(host);
+    flushSync(() => root.render(<TmuxComposer file={fileFor(conversationId)} />));
+    await sleep(10);
+
+    const textarea = host.querySelector("textarea") as HTMLTextAreaElement;
+    const form = textarea.closest("form")!;
+    /* The composer accepts input again after the refresh. */
+    expect(submitButton(host).disabled).toBe(false);
+    expect(textarea.value).toBe(prompt);
+
+    /* The explicit retry replays the ORIGINAL key across the remount. */
+    flushSync(() => form.dispatchEvent(new dom.Event("submit", { bubbles: true, cancelable: true }) as unknown as Event));
+    await sleep(0);
+    expect(sentKeys).toHaveLength(2);
+    expect(sentKeys[1]).toBe(sentKeys[0]);
+  } finally {
+    flushSync(() => root.unmount());
+    publishReceipts([]);
+    refreshRuntimeImpl = async () => false;
+    sessionStorage.clear();
+    host.remove();
+  }
+});
+
+test("typing after the window survives; a late admission clears only the sent prefix", async () => {
+  setLocale("en");
+  mobileViewport = false;
+  const conversationId = "conv-expiry-typing";
+  const prompt = "check the logs";
+  const sentKeys: string[] = [];
+  globalThis.fetch = (async (input, init) => {
+    if (String(input) === "/api/tmux/targets") {
+      return { ok: true, json: async () => ({ targets: { "0": null } }) } as Response;
+    }
+    if (String(input) !== "/api/tmux") throw new Error(`unexpected request: ${String(input)}`);
+    const body = JSON.parse(String(init?.body)) as { clientMessageId: string };
+    sentKeys.push(body.clientMessageId);
+    throw new ComposerAdmissionTimeoutError();
+  }) as typeof fetch;
+  refreshRuntimeImpl = async () => false;
+
+  sessionStorage.setItem(`llvDraft:${conversationId}`, prompt);
+  const host = document.createElement("div");
+  document.body.append(host);
+  const root = createRoot(host);
+  flushSync(() => root.render(<TmuxComposer file={fileFor(conversationId)} />));
+  const textarea = host.querySelector("textarea") as HTMLTextAreaElement;
+  const form = textarea.closest("form")!;
+  const propsKey = Object.keys(textarea).find((key) => key.startsWith("__reactProps$"))!;
+  const textareaProps = (textarea as unknown as Record<string, { onChange(event: unknown): void }>)[propsKey]!;
+
+  try {
+    flushSync(() => form.dispatchEvent(new dom.Event("submit", { bubbles: true, cancelable: true }) as unknown as Event));
+    await untilSendEnabled(host);
+
+    flushSync(() => textareaProps.onChange({ target: { value: `${prompt}\nand the metrics` } }));
+    expect(textarea.value).toBe(`${prompt}\nand the metrics`);
+
+    flushSync(() => publishReceipts([{
+      operationId: "op-expiry-typing",
+      idempotencyKey: sentKeys[0]!,
+      conversationId,
+      kind: "send",
+      status: "queued",
+      text: prompt,
+      at: "2026-07-20T09:02:00.000Z",
+      revision: 1,
+    }]));
+    await sleep(0);
+    /* The admitted prefix leaves; the typing added after the window survives. */
+    expect(textarea.value).toBe("and the metrics");
+    expect(sentKeys).toHaveLength(1);
+  } finally {
+    flushSync(() => root.unmount());
+    publishReceipts([]);
+    refreshRuntimeImpl = async () => false;
+    sessionStorage.clear();
+    host.remove();
+  }
+});
+
+test("a terminal failure after the window exposes Retry and re-enables the composer", async () => {
+  setLocale("en");
+  mobileViewport = false;
+  const conversationId = "conv-expiry-terminal";
+  const prompt = "keep this exact after it fails";
+  const sentKeys: string[] = [];
+  globalThis.fetch = (async (input, init) => {
+    if (String(input) === "/api/tmux/targets") {
+      return { ok: true, json: async () => ({ targets: { "0": null } }) } as Response;
+    }
+    if (String(input) !== "/api/tmux") throw new Error(`unexpected request: ${String(input)}`);
+    const body = JSON.parse(String(init?.body)) as { clientMessageId: string };
+    sentKeys.push(body.clientMessageId);
+    throw new ComposerAdmissionTimeoutError();
+  }) as typeof fetch;
+  refreshRuntimeImpl = async () => false;
+
+  sessionStorage.setItem(`llvDraft:${conversationId}`, prompt);
+  const host = document.createElement("div");
+  document.body.append(host);
+  const root = createRoot(host);
+  flushSync(() => root.render(<TmuxComposer file={fileFor(conversationId)} />));
+  const textarea = host.querySelector("textarea") as HTMLTextAreaElement;
+  const form = textarea.closest("form")!;
+  const retries = () => [...host.querySelectorAll("button")]
+    .filter((button) => button.textContent === translate("en", "runtime.receipt.retry"));
+
+  try {
+    flushSync(() => form.dispatchEvent(new dom.Event("submit", { bubbles: true, cancelable: true }) as unknown as Event));
+    await untilSendEnabled(host);
+    expect(host.querySelectorAll('[data-receipt-status="uncertain"]')).toHaveLength(1);
+    expect(retries()).toHaveLength(0);
+
+    flushSync(() => publishReceipts([{
+      operationId: "op-expiry-terminal",
+      idempotencyKey: sentKeys[0]!,
+      conversationId,
+      kind: "send",
+      status: "failed",
+      reason: "dead-host",
+      text: prompt,
+      at: "2026-07-20T09:03:00.000Z",
+      revision: 1,
+    }]));
+    await sleep(0);
+
+    /* The failure supersedes the uncertain row and offers Retry; the composer
+       stays usable and the payload stays exact. */
+    expect(submitButton(host).disabled).toBe(false);
+    expect(host.querySelectorAll('[data-receipt-status="uncertain"]')).toHaveLength(0);
+    expect(retries()).toHaveLength(1);
+    expect(textarea.value).toBe(prompt);
+    expect(sentKeys).toHaveLength(1);
+  } finally {
+    flushSync(() => root.unmount());
+    publishReceipts([]);
+    refreshRuntimeImpl = async () => false;
+    sessionStorage.clear();
+    host.remove();
+  }
+});
+
+test("multiple images survive the window and ride the same-key retry on desktop and 390px", async () => {
+  setLocale("en");
+  for (const [width, mobile] of [[1440, false], [390, true]] as const) {
+    mobileViewport = mobile;
+    Object.defineProperty(dom, "innerWidth", { configurable: true, value: width });
+    const conversationId = `conv-expiry-images-${width}`;
+    const prompt = `compare both shots at ${width}`;
+    const sentKeys: string[] = [];
+    const sentImageCounts: number[] = [];
+    globalThis.fetch = (async (input, init) => {
+      if (String(input) === "/api/tmux/targets") {
+        return { ok: true, json: async () => ({ targets: { "0": null } }) } as Response;
+      }
+      if (String(input) !== "/api/tmux") throw new Error(`unexpected request: ${String(input)}`);
+      const body = JSON.parse(String(init?.body)) as { clientMessageId: string; images?: unknown[] };
+      sentKeys.push(body.clientMessageId);
+      sentImageCounts.push(body.images?.length ?? 0);
+      if (sentKeys.length === 1) throw new ComposerAdmissionTimeoutError();
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({
+          ok: true,
+          structured: true,
+          receipt: {
+            operationId: `op-expiry-images-${width}`,
+            idempotencyKey: body.clientMessageId,
+            conversationId,
+            kind: "send",
+            status: "queued",
+            text: prompt,
+            at: "2026-07-20T09:04:00.000Z",
+            revision: 1,
+          },
+        }),
+      } as Response;
+    }) as typeof fetch;
+    refreshRuntimeImpl = async () => false;
+
+    sessionStorage.setItem(`llvDraft:${conversationId}`, prompt);
+    const host = document.createElement("div");
+    document.body.append(host);
+    const root = createRoot(host);
+    flushSync(() => root.render(<TmuxComposer file={fileFor(conversationId)} />));
+    const textarea = host.querySelector("textarea") as HTMLTextAreaElement;
+    const form = textarea.closest("form")!;
+    const propsKey = Object.keys(textarea).find((key) => key.startsWith("__reactProps$"))!;
+    const textareaProps = (textarea as unknown as Record<string, { onPaste(event: unknown): void }>)[propsKey]!;
+    const previews = () => [...host.querySelectorAll("img")].map((image) => image.getAttribute("src"));
+    const pasteImage = (tag: string) => {
+      const bytes = new TextEncoder().encode(`png-${tag}`);
+      textareaProps.onPaste({
+        clipboardData: { items: [{ type: "image/png", getAsFile: () => new dom.File([bytes], `${tag}.png`, { type: "image/png" }) }] },
+        preventDefault() {},
+      });
+    };
+    const untilPreviews = async (count: number) => {
+      for (let attempt = 0; attempt < 50 && previews().length !== count; attempt += 1) await sleep(2);
+      expect(previews()).toHaveLength(count);
+    };
+
+    try {
+      pasteImage(`first-${width}`);
+      pasteImage(`second-${width}`);
+      await untilPreviews(2);
+      const attached = previews();
+      flushSync(() => form.dispatchEvent(new dom.Event("submit", { bubbles: true, cancelable: true }) as unknown as Event));
+      await untilSendEnabled(host);
+      expect(sentImageCounts).toEqual([2]);
+      /* Both attachments stay through the window — nothing was admitted. */
+      expect(previews()).toEqual(attached);
+      expect(host.querySelectorAll('[data-receipt-status="uncertain"]')).toHaveLength(1);
+
+      /* The explicit retry replays the same key with the exact same images. */
+      flushSync(() => form.dispatchEvent(new dom.Event("submit", { bubbles: true, cancelable: true }) as unknown as Event));
+      await sleep(0);
+      expect(sentKeys).toHaveLength(2);
+      expect(sentKeys[1]).toBe(sentKeys[0]);
+      expect(sentImageCounts).toEqual([2, 2]);
+      expect(previews()).toEqual([]);
+      expect(host.querySelectorAll('[data-receipt-status="queued"]')).toHaveLength(1);
+      if (mobile) {
+        expect(form.getAttribute("data-testid")).toBe("bounded-mobile-composer");
+      } else {
+        expect(form.getAttribute("data-testid")).toBeNull();
+      }
+    } finally {
+      flushSync(() => root.unmount());
+      publishReceipts([]);
+      refreshRuntimeImpl = async () => false;
+      sessionStorage.clear();
+      host.remove();
+    }
+  }
+  mobileViewport = false;
+});

--- a/src/components/TmuxComposer.reconciliationExpiry.dom.test.tsx
+++ b/src/components/TmuxComposer.reconciliationExpiry.dom.test.tsx
@@ -126,7 +126,7 @@ test("late receipt-free legacy success settles live-pane and resume generations 
       if (String(input) !== "/api/tmux") throw new Error(`unexpected request: ${String(input)}`);
       const body = JSON.parse(String(init?.body)) as { clientMessageId: string; text: string };
       attempts.push({ key: body.clientMessageId, text: body.text });
-      await sleep(18);
+      await sleep(75);
       return {
         ok: true,
         status: 200,
@@ -153,7 +153,14 @@ test("late receipt-free legacy success settles live-pane and resume generations 
       flushSync(() => form.dispatchEvent(new dom.Event("submit", { bubbles: true, cancelable: true }) as unknown as Event));
       await sleep(10);
       flushSync(() => textareaProps.onChange({ target: { value: later } }));
-      await sleep(20);
+      await sleep(50);
+      expect(host.querySelectorAll('[data-receipt-status="uncertain"]')).toHaveLength(1);
+      for (let attempt = 0; attempt < 50 && sessionStorage.getItem(`llvPendingSend:${conversationId}`); attempt += 1) {
+        await sleep(3);
+      }
+      for (let attempt = 0; attempt < 50 && host.querySelectorAll('[data-receipt-status="uncertain"]').length; attempt += 1) {
+        await sleep(3);
+      }
 
       expect(attempts).toEqual([{ key: attempts[0]!.key, text: original }]);
       expect(textarea.value).toBe(later);

--- a/src/components/TmuxComposer.reconciliationExpiry.dom.test.tsx
+++ b/src/components/TmuxComposer.reconciliationExpiry.dom.test.tsx
@@ -183,6 +183,72 @@ test("no receipt within the local window recovers the composer for an exactly-on
   }
 });
 
+test("editing after expiry retries the immutable generation and preserves the later draft", async () => {
+  setLocale("en");
+  mobileViewport = false;
+  const conversationId = "conv-expiry-edited-draft";
+  const original = "confirm the original deployment";
+  const laterDraft = "inspect the follow-up metrics";
+  const attempts: { key: string; text: string }[] = [];
+  globalThis.fetch = (async (input, init) => {
+    if (String(input) === "/api/tmux/targets") {
+      return { ok: true, json: async () => ({ targets: { "0": null } }) } as Response;
+    }
+    if (String(input) !== "/api/tmux") throw new Error(`unexpected request: ${String(input)}`);
+    const body = JSON.parse(String(init?.body)) as { clientMessageId: string; text: string };
+    attempts.push({ key: body.clientMessageId, text: body.text });
+    if (attempts.length === 1) throw new ComposerAdmissionTimeoutError();
+    return {
+      ok: true,
+      status: 200,
+      json: async () => ({
+        ok: true,
+        structured: true,
+        receipt: {
+          operationId: "op-expiry-edited-draft",
+          idempotencyKey: body.clientMessageId,
+          conversationId,
+          kind: "send",
+          status: "queued",
+          text: original,
+          at: "2026-07-20T09:00:30.000Z",
+          revision: 1,
+        },
+      }),
+    } as Response;
+  }) as typeof fetch;
+  refreshRuntimeImpl = async () => false;
+
+  sessionStorage.setItem(`llvDraft:${conversationId}`, original);
+  const host = document.createElement("div");
+  document.body.append(host);
+  const root = createRoot(host);
+  flushSync(() => root.render(<TmuxComposer file={fileFor(conversationId)} />));
+  const textarea = host.querySelector("textarea") as HTMLTextAreaElement;
+  const form = textarea.closest("form")!;
+  const propsKey = Object.keys(textarea).find((key) => key.startsWith("__reactProps$"))!;
+  const textareaProps = (textarea as unknown as Record<string, { onChange(event: unknown): void }>)[propsKey]!;
+
+  try {
+    flushSync(() => form.dispatchEvent(new dom.Event("submit", { bubbles: true, cancelable: true }) as unknown as Event));
+    await untilSendEnabled(host);
+    flushSync(() => textareaProps.onChange({ target: { value: laterDraft } }));
+
+    flushSync(() => form.dispatchEvent(new dom.Event("submit", { bubbles: true, cancelable: true }) as unknown as Event));
+    await sleep(0);
+
+    expect(attempts).toHaveLength(2);
+    expect(attempts[1]).toEqual({ key: attempts[0]!.key, text: original });
+    expect(textarea.value).toBe(laterDraft);
+  } finally {
+    flushSync(() => root.unmount());
+    publishReceipts([]);
+    refreshRuntimeImpl = async () => false;
+    sessionStorage.clear();
+    host.remove();
+  }
+});
+
 test("a late receipt after the window still settles the preserved generation with no resend", async () => {
   setLocale("en");
   mobileViewport = false;
@@ -295,6 +361,96 @@ test("the recovered generation survives a remount and keeps its original key", a
     sessionStorage.clear();
     host.remove();
   }
+});
+
+test("an image-bearing generation restores exact bytes across a remount on desktop and 390px", async () => {
+  setLocale("en");
+  for (const [width, mobile] of [[1440, false], [390, true]] as const) {
+    mobileViewport = mobile;
+    Object.defineProperty(dom, "innerWidth", { configurable: true, value: width });
+    const conversationId = `conv-expiry-image-remount-${width}`;
+    const prompt = `restore the screenshot at ${width}`;
+    const attempts: { key: string; images: string[] }[] = [];
+    globalThis.fetch = (async (input, init) => {
+      if (String(input) === "/api/tmux/targets") {
+        return { ok: true, json: async () => ({ targets: { "0": null } }) } as Response;
+      }
+      if (String(input) !== "/api/tmux") throw new Error(`unexpected request: ${String(input)}`);
+      const body = JSON.parse(String(init?.body)) as { clientMessageId: string; images?: { base64: string }[] };
+      attempts.push({ key: body.clientMessageId, images: body.images?.map((image) => image.base64) ?? [] });
+      if (attempts.length === 1) throw new ComposerAdmissionTimeoutError();
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({
+          ok: true,
+          structured: true,
+          receipt: {
+            operationId: `op-expiry-image-remount-${width}`,
+            idempotencyKey: body.clientMessageId,
+            conversationId,
+            kind: "send",
+            status: "queued",
+            text: prompt,
+            at: "2026-07-20T09:01:30.000Z",
+            revision: 1,
+          },
+        }),
+      } as Response;
+    }) as typeof fetch;
+    refreshRuntimeImpl = async () => false;
+
+    sessionStorage.setItem(`llvDraft:${conversationId}`, prompt);
+    const host = document.createElement("div");
+    document.body.append(host);
+    let root = createRoot(host);
+    flushSync(() => root.render(<TmuxComposer file={fileFor(conversationId)} />));
+    let textarea = host.querySelector("textarea") as HTMLTextAreaElement;
+    let form = textarea.closest("form")!;
+    const propsKey = Object.keys(textarea).find((key) => key.startsWith("__reactProps$"))!;
+    const textareaProps = (textarea as unknown as Record<string, { onPaste(event: unknown): void }>)[propsKey]!;
+    const image = new TextEncoder().encode(`remount-image-${width}`);
+
+    try {
+      textareaProps.onPaste({
+        clipboardData: { items: [{ type: "image/png", getAsFile: () => new dom.File([image], `remount-${width}.png`, { type: "image/png" }) }] },
+        preventDefault() {},
+      });
+      for (let attempt = 0; attempt < 50 && host.querySelectorAll('[data-testid="attachment-tile"][data-status="ready"]').length !== 1; attempt += 1) {
+        await sleep(2);
+      }
+      expect(host.querySelectorAll('[data-testid="attachment-tile"][data-status="ready"]')).toHaveLength(1);
+
+      flushSync(() => form.dispatchEvent(new dom.Event("submit", { bubbles: true, cancelable: true }) as unknown as Event));
+      await untilSendEnabled(host);
+      expect(attempts[0]?.images).toHaveLength(1);
+
+      flushSync(() => root.unmount());
+      root = createRoot(host);
+      flushSync(() => root.render(<TmuxComposer file={fileFor(conversationId)} />));
+      for (let attempt = 0; attempt < 50 && host.querySelectorAll('[data-testid="attachment-tile"][data-status="ready"]').length !== 1; attempt += 1) {
+        await sleep(2);
+      }
+      expect(host.querySelectorAll('[data-testid="attachment-tile"][data-status="ready"]')).toHaveLength(1);
+
+      textarea = host.querySelector("textarea") as HTMLTextAreaElement;
+      form = textarea.closest("form")!;
+      flushSync(() => form.dispatchEvent(new dom.Event("submit", { bubbles: true, cancelable: true }) as unknown as Event));
+      await sleep(0);
+
+      expect(attempts).toHaveLength(2);
+      expect(attempts[1]).toEqual(attempts[0]);
+      expect(host.querySelectorAll('[data-testid="attachment-tile"]')).toHaveLength(0);
+      if (mobile) expect(form.getAttribute("data-testid")).toBe("bounded-mobile-composer");
+    } finally {
+      flushSync(() => root.unmount());
+      publishReceipts([]);
+      refreshRuntimeImpl = async () => false;
+      sessionStorage.clear();
+      host.remove();
+    }
+  }
+  mobileViewport = false;
 });
 
 test("typing after the window survives; a late admission clears only the sent prefix", async () => {
@@ -416,7 +572,7 @@ test("a terminal failure after the window exposes Retry and re-enables the compo
   }
 });
 
-test("multiple images survive the window and ride the same-key retry on desktop and 390px", async () => {
+test("an edited image tray retries the immutable images and preserves later attachments on desktop and 390px", async () => {
   setLocale("en");
   for (const [width, mobile] of [[1440, false], [390, true]] as const) {
     mobileViewport = mobile;
@@ -424,15 +580,15 @@ test("multiple images survive the window and ride the same-key retry on desktop 
     const conversationId = `conv-expiry-images-${width}`;
     const prompt = `compare both shots at ${width}`;
     const sentKeys: string[] = [];
-    const sentImageCounts: number[] = [];
+    const sentImages: string[][] = [];
     globalThis.fetch = (async (input, init) => {
       if (String(input) === "/api/tmux/targets") {
         return { ok: true, json: async () => ({ targets: { "0": null } }) } as Response;
       }
       if (String(input) !== "/api/tmux") throw new Error(`unexpected request: ${String(input)}`);
-      const body = JSON.parse(String(init?.body)) as { clientMessageId: string; images?: unknown[] };
+      const body = JSON.parse(String(init?.body)) as { clientMessageId: string; images?: { base64: string }[] };
       sentKeys.push(body.clientMessageId);
-      sentImageCounts.push(body.images?.length ?? 0);
+      sentImages.push(body.images?.map((image) => image.base64) ?? []);
       if (sentKeys.length === 1) throw new ComposerAdmissionTimeoutError();
       return {
         ok: true,
@@ -484,18 +640,29 @@ test("multiple images survive the window and ride the same-key retry on desktop 
       const attached = previews();
       flushSync(() => form.dispatchEvent(new dom.Event("submit", { bubbles: true, cancelable: true }) as unknown as Event));
       await untilSendEnabled(host);
-      expect(sentImageCounts).toEqual([2]);
+      expect(sentImages[0]).toHaveLength(2);
       /* Both attachments stay through the window — nothing was admitted. */
       expect(previews()).toEqual(attached);
       expect(host.querySelectorAll('[data-receipt-status="uncertain"]')).toHaveLength(1);
 
-      /* The explicit retry replays the same key with the exact same images. */
+      /* The operator edits the tray before retrying. The removed original and
+         newly-added image belong to UI state around the pending generation. */
+      const firstTile = host.querySelector('[data-testid="attachment-tile"]') as HTMLElement;
+      flushSync(() => (firstTile.querySelector("button") as HTMLButtonElement).click());
+      pasteImage(`later-${width}`);
+      await untilPreviews(2);
+      const editedTray = previews();
+      expect(editedTray).not.toEqual(attached);
+
+      /* The retry replays the same key with the original image bytes. */
       flushSync(() => form.dispatchEvent(new dom.Event("submit", { bubbles: true, cancelable: true }) as unknown as Event));
       await sleep(0);
       expect(sentKeys).toHaveLength(2);
       expect(sentKeys[1]).toBe(sentKeys[0]);
-      expect(sentImageCounts).toEqual([2, 2]);
-      expect(previews()).toEqual([]);
+      expect(sentImages[1]).toEqual(sentImages[0]);
+      /* Settlement removes the surviving original image by intake id. The
+         attachment added after expiry remains for the following generation. */
+      expect(previews()).toEqual([editedTray[1]]);
       expect(host.querySelectorAll('[data-receipt-status="queued"]')).toHaveLength(1);
       if (mobile) {
         expect(form.getAttribute("data-testid")).toBe("bounded-mobile-composer");

--- a/src/components/TmuxComposer.reconciliationExpiry.dom.test.tsx
+++ b/src/components/TmuxComposer.reconciliationExpiry.dom.test.tsx
@@ -43,6 +43,7 @@ let mobileViewport = false;
 const actualDeadline = await import("./composerAdmissionDeadline");
 mock.module("./composerAdmissionDeadline", () => ({
   ...actualDeadline,
+  COMPOSER_ADMISSION_DEADLINE_MS: 8,
   COMPOSER_RECEIPT_RECONCILIATION_MS: 40,
   COMPOSER_RECEIPT_POLL_INTERVAL_MS: 5,
 }));
@@ -106,6 +107,68 @@ async function untilSendEnabled(host: HTMLElement): Promise<void> {
   for (let attempt = 0; attempt < 100 && submitButton(host).disabled; attempt += 1) await sleep(3);
   expect(submitButton(host).disabled).toBe(false);
 }
+
+test("late receipt-free legacy success settles live-pane and resume generations once", async () => {
+  setLocale("en");
+  mobileViewport = false;
+  for (const scenario of [
+    { name: "pane", target: "agents:1.0", outcome: "delivered-to-live" },
+    { name: "resume", target: null, outcome: "resumed" },
+  ] as const) {
+    const conversationId = `conv-expiry-legacy-${scenario.name}`;
+    const original = `send through delayed ${scenario.name}`;
+    const later = `keep this ${scenario.name} draft`;
+    const attempts: { key: string; text: string }[] = [];
+    globalThis.fetch = (async (input, init) => {
+      if (String(input) === "/api/tmux/targets") {
+        return { ok: true, json: async () => ({ targets: { "0": scenario.target } }) } as Response;
+      }
+      if (String(input) !== "/api/tmux") throw new Error(`unexpected request: ${String(input)}`);
+      const body = JSON.parse(String(init?.body)) as { clientMessageId: string; text: string };
+      attempts.push({ key: body.clientMessageId, text: body.text });
+      await sleep(18);
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({
+          ok: true,
+          outcome: scenario.outcome,
+          ...(scenario.name === "resume" ? { spawned: true, target: "agents:2.0" } : {}),
+        }),
+      } as Response;
+    }) as typeof fetch;
+    refreshRuntimeImpl = async () => false;
+    sessionStorage.setItem(`llvDraft:${conversationId}`, original);
+
+    const host = document.createElement("div");
+    document.body.append(host);
+    const root = createRoot(host);
+    flushSync(() => root.render(<TmuxComposer file={fileFor(conversationId)} />));
+    const textarea = host.querySelector("textarea") as HTMLTextAreaElement;
+    const form = textarea.closest("form")!;
+    const propsKey = Object.keys(textarea).find((key) => key.startsWith("__reactProps$"))!;
+    const textareaProps = (textarea as unknown as Record<string, { onChange(event: unknown): void }>)[propsKey]!;
+    try {
+      await sleep(5);
+      flushSync(() => form.dispatchEvent(new dom.Event("submit", { bubbles: true, cancelable: true }) as unknown as Event));
+      await sleep(10);
+      flushSync(() => textareaProps.onChange({ target: { value: later } }));
+      await sleep(20);
+
+      expect(attempts).toEqual([{ key: attempts[0]!.key, text: original }]);
+      expect(textarea.value).toBe(later);
+      expect(sessionStorage.getItem(`llvPendingSend:${conversationId}`)).toBeNull();
+      expect(host.querySelectorAll('[data-receipt-status="uncertain"]')).toHaveLength(0);
+      expect(submitButton(host).disabled).toBe(false);
+    } finally {
+      flushSync(() => root.unmount());
+      publishReceipts([]);
+      refreshRuntimeImpl = async () => false;
+      sessionStorage.clear();
+      host.remove();
+    }
+  }
+});
 
 test("no receipt within the local window recovers the composer for an exactly-once same-key retry", async () => {
   setLocale("en");

--- a/src/components/TmuxComposer.reconciliationExpiry.dom.test.tsx
+++ b/src/components/TmuxComposer.reconciliationExpiry.dom.test.tsx
@@ -113,13 +113,15 @@ test("no receipt within the local window recovers the composer for an exactly-on
   const conversationId = "conv-expiry-recover";
   const prompt = "confirm the deploy went out";
   const sentKeys: string[] = [];
+  const sentRuntimes: { model?: string; effort?: string; fast?: boolean }[] = [];
   globalThis.fetch = (async (input, init) => {
     if (String(input) === "/api/tmux/targets") {
       return { ok: true, json: async () => ({ targets: { "0": null } }) } as Response;
     }
     if (String(input) !== "/api/tmux") throw new Error(`unexpected request: ${String(input)}`);
-    const body = JSON.parse(String(init?.body)) as { clientMessageId: string };
+    const body = JSON.parse(String(init?.body)) as { clientMessageId: string; model?: string; effort?: string; fast?: boolean };
     sentKeys.push(body.clientMessageId);
+    sentRuntimes.push({ model: body.model, effort: body.effort, fast: body.fast });
     if (sentKeys.length === 1) throw new ComposerAdmissionTimeoutError();
     /* The explicit retry replays the SAME key and this time is admitted. */
     return {
@@ -144,13 +146,17 @@ test("no receipt within the local window recovers the composer for an exactly-on
   refreshRuntimeImpl = async () => false;
 
   sessionStorage.setItem(`llvDraft:${conversationId}`, prompt);
+  localStorage.setItem(`llvAgentRuntime:${conversationId}:resume`, JSON.stringify({
+    model: "gpt-5.6-sol",
+    effort: "high",
+    fast: false,
+  }));
   const host = document.createElement("div");
   document.body.append(host);
-  const root = createRoot(host);
+  let root = createRoot(host);
   flushSync(() => root.render(<TmuxComposer file={fileFor(conversationId)} />));
-  const textarea = host.querySelector("textarea") as HTMLTextAreaElement;
-  const form = textarea.closest("form")!;
-
+  let textarea = host.querySelector("textarea") as HTMLTextAreaElement;
+  let form = textarea.closest("form")!;
   try {
     flushSync(() => form.dispatchEvent(new dom.Event("submit", { bubbles: true, cancelable: true }) as unknown as Event));
     /* The window expires with no receipt; the composer must NOT stay disabled. */
@@ -168,10 +174,27 @@ test("no receipt within the local window recovers the composer for an exactly-on
     expect(sessionStorage.getItem(`llvPendingSend:${conversationId}`)).toContain(sentKeys[0]!);
 
     /* The operator explicitly retries: the ORIGINAL key replays idempotently. */
+    flushSync(() => {
+      const propsKey = Object.keys(textarea).find((key) => key.startsWith("__reactProps$"))!;
+      const props = (textarea as unknown as Record<string, { onChange(event: unknown): void }>)[propsKey]!;
+      props.onChange({ target: { value: "" } });
+    });
+    flushSync(() => root.unmount());
+    root = createRoot(host);
+    flushSync(() => root.render(<TmuxComposer file={fileFor(conversationId)} />));
+    await untilSendEnabled(host);
+    textarea = host.querySelector("textarea") as HTMLTextAreaElement;
+    localStorage.setItem(`llvAgentRuntime:${conversationId}:resume`, JSON.stringify({
+      model: "gpt-5.6-sol",
+      effort: "low",
+      fast: true,
+    }));
+    form = textarea.closest("form")!;
     flushSync(() => form.dispatchEvent(new dom.Event("submit", { bubbles: true, cancelable: true }) as unknown as Event));
     await sleep(0);
     expect(sentKeys).toHaveLength(2);
     expect(sentKeys[1]).toBe(sentKeys[0]);
+    expect(sentRuntimes[1]).toEqual(sentRuntimes[0]);
     expect(textarea.value).toBe("");
     expect(host.querySelectorAll('[data-receipt-status="queued"]')).toHaveLength(1);
   } finally {
@@ -179,6 +202,7 @@ test("no receipt within the local window recovers the composer for an exactly-on
     publishReceipts([]);
     refreshRuntimeImpl = async () => false;
     sessionStorage.clear();
+    localStorage.clear();
     host.remove();
   }
 });
@@ -408,7 +432,10 @@ test("an image-bearing generation restores exact bytes across a remount on deskt
     let textarea = host.querySelector("textarea") as HTMLTextAreaElement;
     let form = textarea.closest("form")!;
     const propsKey = Object.keys(textarea).find((key) => key.startsWith("__reactProps$"))!;
-    const textareaProps = (textarea as unknown as Record<string, { onPaste(event: unknown): void }>)[propsKey]!;
+    const textareaProps = (textarea as unknown as Record<string, {
+      onPaste(event: unknown): void;
+      onChange(event: unknown): void;
+    }>)[propsKey]!;
     const image = new TextEncoder().encode(`remount-image-${width}`);
 
     try {
@@ -425,6 +452,18 @@ test("an image-bearing generation restores exact bytes across a remount on deskt
       await untilSendEnabled(host);
       expect(attempts[0]?.images).toHaveLength(1);
 
+      flushSync(() => textareaProps.onChange({ target: { value: `later draft ${width}` } }));
+      flushSync(() => (host.querySelector('[data-testid="attachment-tile"] button') as HTMLButtonElement).click());
+      textareaProps.onPaste({
+        clipboardData: { items: [{ type: "image/png", getAsFile: () => new dom.File([`later-${width}`], `later-${width}.png`, { type: "image/png" }) }] },
+        preventDefault() {},
+      });
+      for (let attempt = 0; attempt < 50 && host.querySelectorAll('[data-testid="attachment-tile"][data-status="ready"]').length !== 1; attempt += 1) {
+        await sleep(2);
+      }
+      const laterPreview = (host.querySelector('[data-testid="attachment-tile"] img') as HTMLImageElement).src;
+      await sleep(0);
+
       flushSync(() => root.unmount());
       root = createRoot(host);
       flushSync(() => root.render(<TmuxComposer file={fileFor(conversationId)} />));
@@ -440,7 +479,9 @@ test("an image-bearing generation restores exact bytes across a remount on deskt
 
       expect(attempts).toHaveLength(2);
       expect(attempts[1]).toEqual(attempts[0]);
-      expect(host.querySelectorAll('[data-testid="attachment-tile"]')).toHaveLength(0);
+      expect((host.querySelector("textarea") as HTMLTextAreaElement).value).toBe(`later draft ${width}`);
+      expect(host.querySelectorAll('[data-testid="attachment-tile"]')).toHaveLength(1);
+      expect((host.querySelector('[data-testid="attachment-tile"] img') as HTMLImageElement).src).toBe(laterPreview);
       if (mobile) expect(form.getAttribute("data-testid")).toBe("bounded-mobile-composer");
     } finally {
       flushSync(() => root.unmount());
@@ -520,6 +561,25 @@ test("a terminal failure after the window exposes Retry and re-enables the compo
     if (String(input) === "/api/tmux/targets") {
       return { ok: true, json: async () => ({ targets: { "0": null } }) } as Response;
     }
+    if (String(input) === "/api/runtime/operations/op-expiry-terminal") {
+      return {
+        ok: true,
+        status: 202,
+        json: async () => ({
+          receipt: {
+            operationId: "op-expiry-terminal-retry",
+            idempotencyKey: "key-expiry-terminal-retry",
+            retryOfOperationId: "op-expiry-terminal",
+            conversationId,
+            kind: "send",
+            status: "queued",
+            text: prompt,
+            at: "2026-07-20T09:03:30.000Z",
+            revision: 1,
+          },
+        }),
+      } as Response;
+    }
     if (String(input) !== "/api/tmux") throw new Error(`unexpected request: ${String(input)}`);
     const body = JSON.parse(String(init?.body)) as { clientMessageId: string };
     sentKeys.push(body.clientMessageId);
@@ -530,10 +590,12 @@ test("a terminal failure after the window exposes Retry and re-enables the compo
   sessionStorage.setItem(`llvDraft:${conversationId}`, prompt);
   const host = document.createElement("div");
   document.body.append(host);
-  const root = createRoot(host);
+  let root = createRoot(host);
   flushSync(() => root.render(<TmuxComposer file={fileFor(conversationId)} />));
   const textarea = host.querySelector("textarea") as HTMLTextAreaElement;
   const form = textarea.closest("form")!;
+  const terminalPropsKey = Object.keys(textarea).find((key) => key.startsWith("__reactProps$"))!;
+  const terminalTextareaProps = (textarea as unknown as Record<string, { onChange(event: unknown): void }>)[terminalPropsKey]!;
   const retries = () => [...host.querySelectorAll("button")]
     .filter((button) => button.textContent === translate("en", "runtime.receipt.retry"));
 
@@ -563,6 +625,18 @@ test("a terminal failure after the window exposes Retry and re-enables the compo
     expect(retries()).toHaveLength(1);
     expect(textarea.value).toBe(prompt);
     expect(sentKeys).toHaveLength(1);
+
+    flushSync(() => terminalTextareaProps.onChange({ target: { value: `${prompt}\nlater turn` } }));
+    flushSync(() => (retries()[0] as HTMLButtonElement).click());
+    for (let attempt = 0; attempt < 50 && textarea.value !== "later turn"; attempt += 1) await sleep(2);
+    expect(textarea.value).toBe("later turn");
+    expect(sessionStorage.getItem(`llvPendingSend:${conversationId}`)).toBeNull();
+
+    flushSync(() => root.unmount());
+    root = createRoot(host);
+    flushSync(() => root.render(<TmuxComposer file={fileFor(conversationId)} />));
+    expect((host.querySelector("textarea") as HTMLTextAreaElement).value).toBe("later turn");
+    expect(sessionStorage.getItem(`llvPendingSend:${conversationId}`)).toBeNull();
   } finally {
     flushSync(() => root.unmount());
     publishReceipts([]);
@@ -570,6 +644,75 @@ test("a terminal failure after the window exposes Retry and re-enables the compo
     sessionStorage.clear();
     host.remove();
   }
+});
+
+test("an incomplete quota snapshot stays fenced through remount until authoritative settlement", async () => {
+  setLocale("en");
+  for (const [width, mobile] of [[1440, false], [390, true]] as const) {
+    mobileViewport = mobile;
+    Object.defineProperty(dom, "innerWidth", { configurable: true, value: width });
+    const conversationId = `conv-expiry-quota-${width}`;
+    const original = `original quota payload ${width}`;
+    const later = `later safe payload ${width}`;
+    const sent: { key: string; text: string }[] = [];
+    globalThis.fetch = (async (input, init) => {
+      if (String(input) === "/api/tmux/targets") {
+        return { ok: true, json: async () => ({ targets: { "0": null } }) } as Response;
+      }
+      if (String(input) !== "/api/tmux") throw new Error(`unexpected request: ${String(input)}`);
+      const body = JSON.parse(String(init?.body)) as { clientMessageId: string; text: string };
+      sent.push({ key: body.clientMessageId, text: body.text });
+      return { ok: true, status: 200, json: async () => ({ ok: true, outcome: "delivered-to-live" }) } as Response;
+    }) as typeof fetch;
+    refreshRuntimeImpl = async () => false;
+    sessionStorage.setItem(`llvDraft:${conversationId}`, later);
+    sessionStorage.setItem(`llvPendingSend:${conversationId}`, JSON.stringify([{
+      key: `key-quota-${width}`,
+      text: original,
+      images: [],
+      payloadComplete: false,
+      reconciling: true,
+    }]));
+
+    const host = document.createElement("div");
+    document.body.append(host);
+    const root = createRoot(host);
+    flushSync(() => root.render(<TmuxComposer file={fileFor(conversationId)} />));
+    const textarea = host.querySelector("textarea") as HTMLTextAreaElement;
+    const form = textarea.closest("form")!;
+    try {
+      await sleep(70);
+      expect(submitButton(host).disabled).toBe(true);
+      expect(sent).toEqual([]);
+
+      flushSync(() => publishReceipts([{
+        operationId: `op-quota-${width}`,
+        idempotencyKey: `key-quota-${width}`,
+        conversationId,
+        kind: "send",
+        status: "queued",
+        text: original,
+        at: "2026-07-20T09:04:00.000Z",
+        revision: 1,
+      }]));
+      await untilSendEnabled(host);
+      expect(textarea.value).toBe(later);
+      expect(sessionStorage.getItem(`llvPendingSend:${conversationId}`)).toBeNull();
+
+      flushSync(() => form.dispatchEvent(new dom.Event("submit", { bubbles: true, cancelable: true }) as unknown as Event));
+      await sleep(0);
+      expect(sent).toHaveLength(1);
+      expect(sent[0]?.text).toBe(later);
+      expect(sent[0]?.key).not.toBe(`key-quota-${width}`);
+    } finally {
+      flushSync(() => root.unmount());
+      publishReceipts([]);
+      refreshRuntimeImpl = async () => false;
+      sessionStorage.clear();
+      host.remove();
+    }
+  }
+  mobileViewport = false;
 });
 
 test("an edited image tray retries the immutable images and preserves later attachments on desktop and 390px", async () => {

--- a/src/components/TmuxComposer.reconciliationExpiry.dom.test.tsx
+++ b/src/components/TmuxComposer.reconciliationExpiry.dom.test.tsx
@@ -1,6 +1,6 @@
 import { afterAll, expect, mock, test } from "bun:test";
 import { Window } from "happy-dom";
-import { useSyncExternalStore } from "react";
+import { useLayoutEffect, useSyncExternalStore } from "react";
 import { flushSync } from "react-dom";
 import { createRoot } from "react-dom/client";
 
@@ -78,6 +78,24 @@ afterAll(() => {
 });
 
 const { TmuxComposer } = await import("./TmuxComposer");
+
+function IdentityCommitHarness({ file, onCommit }: { file: FileEntry; onCommit?: () => void }) {
+  useLayoutEffect(() => {
+    onCommit?.();
+  }, [file.conversationId, onCommit]);
+  return <TmuxComposer file={file} />;
+}
+
+function PresenceCommitHarness({ file, visible, onHiddenCommit }: {
+  file: FileEntry;
+  visible: boolean;
+  onHiddenCommit?: () => void;
+}) {
+  useLayoutEffect(() => {
+    if (!visible) onHiddenCommit?.();
+  }, [onHiddenCommit, visible]);
+  return visible ? <TmuxComposer file={file} /> : null;
+}
 
 function fileFor(conversationId: string): FileEntry {
   return {
@@ -174,6 +192,122 @@ test("late receipt-free legacy success settles live-pane and resume generations 
       sessionStorage.clear();
       host.remove();
     }
+  }
+});
+
+test("identity commit invalidates a delayed legacy success before passive cleanup", async () => {
+  setLocale("en");
+  mobileViewport = false;
+  const originalId = "conv-expiry-identity-original";
+  const successorId = "conv-expiry-identity-successor";
+  const original = "original identity payload";
+  let resolveResponse!: (response: Response) => void;
+  globalThis.fetch = (async (input) => {
+    if (String(input) === "/api/tmux/targets") {
+      return { ok: true, json: async () => ({ targets: { "0": "agents:1.0" } }) } as Response;
+    }
+    if (String(input) !== "/api/tmux") throw new Error(`unexpected request: ${String(input)}`);
+    return new Promise<Response>((resolve) => {
+      resolveResponse = resolve;
+    });
+  }) as typeof fetch;
+  refreshRuntimeImpl = async () => false;
+  sessionStorage.setItem(`llvDraft:${originalId}`, original);
+
+  const host = document.createElement("div");
+  document.body.append(host);
+  const root = createRoot(host);
+  flushSync(() => root.render(<IdentityCommitHarness file={fileFor(originalId)} />));
+  try {
+    await sleep(5);
+    const form = (host.querySelector("textarea") as HTMLTextAreaElement).closest("form")!;
+    flushSync(() => form.dispatchEvent(new dom.Event("submit", { bubbles: true, cancelable: true }) as unknown as Event));
+    for (let attempt = 0; attempt < 50 && !host.querySelector('[data-receipt-status="uncertain"]'); attempt += 1) {
+      await sleep(3);
+    }
+    const pendingBefore = sessionStorage.getItem(`llvPendingSend:${originalId}`);
+    expect(pendingBefore).not.toBeNull();
+
+    const enrichedFile = { ...fileFor(successorId), path: fileFor(originalId).path };
+    flushSync(() => root.render(
+      <IdentityCommitHarness
+        file={enrichedFile}
+        onCommit={() => resolveResponse({
+          ok: true,
+          status: 200,
+          json: async () => ({ ok: true, outcome: "delivered-to-live" }),
+        } as Response)}
+      />,
+    ));
+    await sleep(30);
+
+    expect((host.querySelector("textarea") as HTMLTextAreaElement).value).toBe(original);
+    expect(sessionStorage.getItem(`llvDraft:${successorId}`)).toBe(original);
+    expect(sessionStorage.getItem(`llvPendingSend:${successorId}`)).not.toBeNull();
+  } finally {
+    flushSync(() => root.unmount());
+    publishReceipts([]);
+    refreshRuntimeImpl = async () => false;
+    sessionStorage.clear();
+    host.remove();
+  }
+});
+
+test("unmount commit invalidates a delayed legacy success before passive cleanup", async () => {
+  setLocale("en");
+  mobileViewport = false;
+  const conversationId = "conv-expiry-unmount";
+  const prompt = "keep the unmounted generation";
+  let resolveResponse!: (response: Response) => void;
+  globalThis.fetch = (async (input) => {
+    if (String(input) === "/api/tmux/targets") {
+      return { ok: true, json: async () => ({ targets: { "0": "agents:1.0" } }) } as Response;
+    }
+    if (String(input) !== "/api/tmux") throw new Error(`unexpected request: ${String(input)}`);
+    return new Promise<Response>((resolve) => {
+      resolveResponse = resolve;
+    });
+  }) as typeof fetch;
+  refreshRuntimeImpl = async () => false;
+  sessionStorage.setItem(`llvDraft:${conversationId}`, prompt);
+
+  const host = document.createElement("div");
+  document.body.append(host);
+  const root = createRoot(host);
+  flushSync(() => root.render(<PresenceCommitHarness file={fileFor(conversationId)} visible />));
+  try {
+    await sleep(5);
+    const form = (host.querySelector("textarea") as HTMLTextAreaElement).closest("form")!;
+    flushSync(() => form.dispatchEvent(new dom.Event("submit", { bubbles: true, cancelable: true }) as unknown as Event));
+    for (let attempt = 0; attempt < 50 && !host.querySelector('[data-receipt-status="uncertain"]'); attempt += 1) {
+      await sleep(3);
+    }
+    const pendingBefore = sessionStorage.getItem(`llvPendingSend:${conversationId}`);
+    expect(pendingBefore).not.toBeNull();
+
+    flushSync(() => root.render(
+      <PresenceCommitHarness
+        file={fileFor(conversationId)}
+        visible={false}
+        onHiddenCommit={() => resolveResponse({
+          ok: true,
+          status: 200,
+          json: async () => ({ ok: true, outcome: "delivered-to-live" }),
+        } as Response)}
+      />,
+    ));
+    await sleep(10);
+
+    const pendingAfter = JSON.parse(sessionStorage.getItem(`llvPendingSend:${conversationId}`) ?? "[]") as Array<{ key: string; text: string }>;
+    expect(pendingAfter).toHaveLength(1);
+    expect(pendingAfter[0]).toMatchObject({ text: prompt });
+    expect(sessionStorage.getItem(`llvDraft:${conversationId}`)).toBe(prompt);
+  } finally {
+    flushSync(() => root.unmount());
+    publishReceipts([]);
+    refreshRuntimeImpl = async () => false;
+    sessionStorage.clear();
+    host.remove();
   }
 });
 

--- a/src/components/TmuxComposer.runtimeSnapshot.dom.test.tsx
+++ b/src/components/TmuxComposer.runtimeSnapshot.dom.test.tsx
@@ -382,6 +382,38 @@ test("a same-key retry re-sends the ORIGINAL runtime snapshot even after the sel
   await act(async () => root.unmount());
 });
 
+test("a remounted same-key retry restores the original runtime snapshot", async () => {
+  localStorage.setItem("llvAgentRuntime:conv-snapshot:profile", JSON.stringify({ effort: "ultra" }));
+  const sends: SendBody[] = [];
+  mockWire(sends, [
+    () => ({ status: 502, json: { error: "wire down" } }),
+    delivered,
+  ]);
+
+  const rendered = await renderInto(<TmuxComposer file={file} />);
+  const host = rendered.host;
+  let root = rendered.root;
+  await settle(() => composerControls(host).type("persist this runtime generation"));
+  await settle(() => composerControls(host).submit());
+  expect(sends[0]!.runtime).toEqual({ effort: "ultra" });
+
+  await act(async () => root.unmount());
+  writeProfile(file, { effort: "low" });
+  root = createRoot(host);
+  await act(async () => {
+    root.render(<TmuxComposer file={file} />);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+  await settle(() => composerControls(host).submit());
+
+  expect(sends).toHaveLength(2);
+  expect(sends[1]!.idempotencyKey).toBe(sends[0]!.idempotencyKey);
+  expect(sends[1]!.text).toBe(sends[0]!.text);
+  expect(sends[1]!.runtime).toEqual({ effort: "ultra" });
+
+  await act(async () => root.unmount());
+});
+
 test("the delegating mock leaks nothing: another conversation resolves the REAL session and takes the legacy send path", async () => {
   /* Regression for the bun mock.module leak: an unconditional structured stub
      here flipped every later-loaded pane test (e.g. BranchPane.render) to the
@@ -414,14 +446,22 @@ test("a send with no explicit selection rides no runtime override, on first atte
     delivered,
   ]);
 
-  const { host, root } = await renderInto(<TmuxComposer file={file} />);
+  const rendered = await renderInto(<TmuxComposer file={file} />);
+  const host = rendered.host;
+  let root = rendered.root;
   const { type, submit } = composerControls(host);
 
   await settle(() => type("no override"));
   await settle(() => submit());
-  // A selection made after admission must not leak into the key's retry.
+  await act(async () => root.unmount());
+  // A selection made after admission must not leak into the key's retry after remount.
   writeProfile(file, { effort: "medium" });
-  await settle(() => submit());
+  root = createRoot(host);
+  await act(async () => {
+    root.render(<TmuxComposer file={file} />);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+  await settle(() => composerControls(host).submit());
 
   expect(sends).toHaveLength(2);
   expect(sends[0]!.runtime).toBeUndefined();

--- a/src/components/TmuxComposer.test.ts
+++ b/src/components/TmuxComposer.test.ts
@@ -478,9 +478,9 @@ test("settlePendingDeliveries is idempotent across repeated admission receipts",
   expect(second.remaining).toEqual([]);
 });
 
-test("pending generations persist text-only per conversation and reload bounded", () => {
-  /* A remount or refresh must not orphan an accepted message in the composer:
-     the unsettled generation reloads (attachment snapshots are memory-only). */
+test("pending generations persist immutable image snapshots per conversation and reload bounded", () => {
+  /* A remount or refresh must retain the exact generation bytes needed for an
+     idempotent retry. Preview URLs are rebuilt from the persisted image body. */
   const backing = new Map<string, string>();
   const globalStore = globalThis as { sessionStorage?: unknown };
   const previous = globalStore.sessionStorage;
@@ -494,15 +494,66 @@ test("pending generations persist text-only per conversation and reload bounded"
       key: `key-${index}`,
       text: `ask ${index}`,
       images: index === 0 ? [pendingImage("a")] : [],
+      ...(index === 0 ? {
+        runtime: { model: "gpt-5.6-sol", effort: "high", fast: true },
+        runtimeCaptured: true as const,
+      } : {}),
     }));
     writePendingDeliveries("conv-persist", entries);
     const reloaded = readPendingDeliveries("conv-persist");
     expect(reloaded).toHaveLength(8);
-    expect(reloaded[0]).toEqual({ key: "key-0", text: "ask 0", images: [] });
+    expect(reloaded[0]).toEqual({
+      key: "key-0",
+      text: "ask 0",
+      images: [{
+        base64: Buffer.from("a").toString("base64"),
+        mime: "image/png",
+        preview: `data:image/png;base64,${Buffer.from("a").toString("base64")}`,
+      }],
+      runtime: { model: "gpt-5.6-sol", effort: "high", fast: true },
+      runtimeCaptured: true,
+    });
     writePendingDeliveries("conv-persist", []);
     expect(readPendingDeliveries("conv-persist")).toEqual([]);
     backing.set("llvPendingSend:conv-corrupt", "{not json");
     expect(readPendingDeliveries("conv-corrupt")).toEqual([]);
+  } finally {
+    if (previous === undefined) delete globalStore.sessionStorage;
+    else globalStore.sessionStorage = previous;
+  }
+});
+
+test("quota fallback preserves settlement metadata and marks the replay payload incomplete", () => {
+  const backing = new Map<string, string>();
+  const globalStore = globalThis as { sessionStorage?: unknown };
+  const previous = globalStore.sessionStorage;
+  globalStore.sessionStorage = {
+    getItem: (key: string) => backing.get(key) ?? null,
+    setItem: (key: string, value: string) => {
+      const serialized = String(value);
+      if (serialized.length > 500) throw new Error("quota");
+      backing.set(key, serialized);
+    },
+    removeItem: (key: string) => void backing.delete(key),
+  };
+  try {
+    writePendingDeliveries("conv-quota", [{
+      key: "key-image",
+      text: "preserve the receipt owner",
+      images: [{ base64: "A".repeat(2_000), mime: "image/png", preview: "blob:preview" }],
+      runtime: { model: "gpt-5.6-sol", effort: "xhigh" },
+      runtimeCaptured: true,
+      reconciling: true,
+    }]);
+    expect(readPendingDeliveries("conv-quota")).toEqual([{
+      key: "key-image",
+      text: "preserve the receipt owner",
+      images: [],
+      runtime: { model: "gpt-5.6-sol", effort: "xhigh" },
+      runtimeCaptured: true,
+      reconciling: true,
+      payloadComplete: false,
+    }]);
   } finally {
     if (previous === undefined) delete globalStore.sessionStorage;
     else globalStore.sessionStorage = previous;

--- a/src/components/TmuxComposer.test.ts
+++ b/src/components/TmuxComposer.test.ts
@@ -327,7 +327,7 @@ test("a bounded receipt summary keeps retry while withholding lossy edit", () =>
 /* ── Exact draft clearing on accepted delivery ──────────────────────────── */
 
 import type { PendingImage } from "./imageAttachments";
-import { adoptComposerState, attachmentsAfterDelivery, draftAfterDelivery, readPendingDeliveries, settlePendingDeliveries, writePendingDeliveries, type PendingDelivery } from "./TmuxComposer";
+import { adoptComposerState, attachmentsAfterDelivery, draftAfterDelivery, readPendingDeliveries, rebindPendingOperations, settlePendingDeliveries, writePendingDeliveries, type PendingDelivery } from "./TmuxComposer";
 
 function deliveredReceipt(key: string, status: RuntimeReceipt["status"] = "delivered", text?: string): RuntimeReceipt {
   return {
@@ -478,6 +478,27 @@ test("settlePendingDeliveries is idempotent across repeated admission receipts",
   expect(second.remaining).toEqual([]);
 });
 
+test("a retry leaf takes ownership and settles the original generation once", () => {
+  const pending: PendingDelivery[] = [{
+    key: "key-original",
+    operationId: "op-original",
+    text: "original ask",
+    images: [pendingImage("original")],
+  }];
+  const retryLeaf = {
+    ...deliveredReceipt("key-retry", "queued"),
+    operationId: "op-retry",
+    retryOfOperationId: "op-original",
+  };
+  const rebound = rebindPendingOperations(pending, [retryLeaf]);
+  expect(rebound[0]?.operationId).toBe("op-retry");
+  const first = settlePendingDeliveries(rebound, [retryLeaf]);
+  const second = settlePendingDeliveries(first.remaining, [retryLeaf]);
+  expect(first.settled).toEqual([{ entry: rebound[0]!, text: "original ask" }]);
+  expect(first.remaining).toEqual([]);
+  expect(second.settled).toEqual([]);
+});
+
 test("pending generations persist immutable image snapshots per conversation and reload bounded", () => {
   /* A remount or refresh must retain the exact generation bytes needed for an
      idempotent retry. Preview URLs are rebuilt from the persisted image body. */
@@ -497,6 +518,7 @@ test("pending generations persist immutable image snapshots per conversation and
       ...(index === 0 ? {
         runtime: { model: "gpt-5.6-sol", effort: "high", fast: true },
         runtimeCaptured: true as const,
+        operationId: "op-key-0",
       } : {}),
     }));
     writePendingDeliveries("conv-persist", entries);
@@ -512,6 +534,7 @@ test("pending generations persist immutable image snapshots per conversation and
       }],
       runtime: { model: "gpt-5.6-sol", effort: "high", fast: true },
       runtimeCaptured: true,
+      operationId: "op-key-0",
     });
     writePendingDeliveries("conv-persist", []);
     expect(readPendingDeliveries("conv-persist")).toEqual([]);
@@ -543,6 +566,7 @@ test("quota fallback preserves settlement metadata and marks the replay payload 
       images: [{ base64: "A".repeat(2_000), mime: "image/png", preview: "blob:preview" }],
       runtime: { model: "gpt-5.6-sol", effort: "xhigh" },
       runtimeCaptured: true,
+      operationId: "op-image",
       reconciling: true,
     }]);
     expect(readPendingDeliveries("conv-quota")).toEqual([{
@@ -551,6 +575,7 @@ test("quota fallback preserves settlement metadata and marks the replay payload 
       images: [],
       runtime: { model: "gpt-5.6-sol", effort: "xhigh" },
       runtimeCaptured: true,
+      operationId: "op-image",
       reconciling: true,
       payloadComplete: false,
     }]);

--- a/src/components/TmuxComposer.tsx
+++ b/src/components/TmuxComposer.tsx
@@ -1027,6 +1027,14 @@ export function TmuxComposer({
     displayedRuntimeReceiptsRef.current = displayedRuntimeReceipts;
   }, [displayedRuntimeReceipts]);
   const receiptReconciliations = useRef<Map<string, AbortController>>(new Map());
+  const legacyResponseEpoch = useRef<{ cardId: string; active: boolean }>({ cardId, active: true });
+  useEffect(() => {
+    const epoch = { cardId, active: true };
+    legacyResponseEpoch.current = epoch;
+    return () => {
+      epoch.active = false;
+    };
+  }, [cardId]);
   const dismissedReceipts = new Set(dismissedReceiptIds);
   const dismissReceipts = (operationIds: string[]) => {
     if (!operationIds.length) return;
@@ -1412,6 +1420,9 @@ export function TmuxComposer({
       persistSent([...prior, entry].slice(-SENT_LIMIT));
       const attempt = pendingDeliveries.current.find((candidate) => candidate.key === clientMessageId);
       persistPendingDeliveries(pendingDeliveries.current.filter((candidate) => candidate.key !== clientMessageId));
+      setImmediateRuntimeReceipts((current) => current.filter((candidate) =>
+        candidate.idempotencyKey !== clientMessageId
+        && candidate.operationId !== unconfirmedReceiptOperationId(clientMessageId)));
       if (idempotencyKey.current === clientMessageId) idempotencyKey.current = mintIdempotencyKey();
       settleGeneration(payloadText, attempt?.images ?? sentImages);
       setStatus({
@@ -1426,6 +1437,7 @@ export function TmuxComposer({
       });
       inputRef.current?.focus();
     };
+    const responseEpoch = legacyResponseEpoch.current;
     let admissionRequest: Promise<ComposerSendResult> | null = null;
     try {
       admissionRequest = Promise.resolve(structuredSession
@@ -1565,10 +1577,10 @@ export function TmuxComposer({
                 : receipt;
             }
             if (!result.ok || result.structured) return null;
+            if (!responseEpoch.active || legacyResponseEpoch.current !== responseEpoch) return null;
             const controller = receiptReconciliations.current.get(clientMessageId);
-            if (!controller || controller.signal.aborted) return null;
             settleLegacySuccess(result);
-            controller.abort();
+            controller?.abort();
             receiptReconciliations.current.delete(clientMessageId);
             setReconcilingSend(receiptReconciliations.current.size > 0);
             return null;

--- a/src/components/TmuxComposer.tsx
+++ b/src/components/TmuxComposer.tsx
@@ -20,6 +20,7 @@ import type { RuntimeReceipt } from "@/components/runtime/runtimeModel";
 
 import { ComposerBar } from "./ComposerBar";
 import {
+  COMPOSER_ADMISSION_DEADLINE_MS,
   COMPOSER_RECEIPT_POLL_INTERVAL_MS,
   COMPOSER_RECEIPT_RECONCILIATION_MS,
   ComposerAdmissionTimeoutError,
@@ -1394,6 +1395,37 @@ export function TmuxComposer({
       setText(draftAfterDelivery(textRef.current, clearedText));
       attachments.settleDelivered(snapshot);
     };
+    const settleLegacySuccess = (result: ComposerSendResult) => {
+      if (settledSendKeys.current.has(clientMessageId)) return;
+      const imgCount = sentImages.length;
+      const held = result.outcome === "held" || result.outcome === "queued" || result.outcome === "recovering";
+      const at = nowMs();
+      const entry: SentEntry = {
+        id: at,
+        text: payloadText.trim() || (imgCount ? t("composer.imagesCount", { count: imgCount }) : ""),
+        at,
+        via: result.outcome === "resumed" || result.spawned ? "spawn" : "pane",
+        state: held ? (result.outcome as DeliveryReceiptState) : "sent",
+        clientMessageId,
+      };
+      const prior = retry ? sent.filter((item) => item.id !== retry.receiptId) : sent;
+      persistSent([...prior, entry].slice(-SENT_LIMIT));
+      const attempt = pendingDeliveries.current.find((candidate) => candidate.key === clientMessageId);
+      persistPendingDeliveries(pendingDeliveries.current.filter((candidate) => candidate.key !== clientMessageId));
+      if (idempotencyKey.current === clientMessageId) idempotencyKey.current = mintIdempotencyKey();
+      settleGeneration(payloadText, attempt?.images ?? sentImages);
+      setStatus({
+        kind: held ? "info" : "ok",
+        text: held
+          ? t("composer.deliveryHeld", { label: file.migration?.targetLabel ?? file.migration?.targetAccountId ?? "" })
+          : result.outcome === "resumed" || result.spawned
+            ? t("composer.spawned", { target: result.target ?? "" })
+            : result.imagePaths?.length
+              ? t("composer.sentPaths", { count: result.imagePaths.length })
+              : t("common.sent"),
+      });
+      inputRef.current?.focus();
+    };
     let admissionRequest: Promise<ComposerSendResult> | null = null;
     try {
       admissionRequest = Promise.resolve(structuredSession
@@ -1435,7 +1467,7 @@ export function TmuxComposer({
             const body = await response.json() as ComposerSendResult;
             return { ...body, status: response.status, ok: response.ok && body.ok === true };
           }));
-      const json = await withComposerAdmissionDeadline(admissionRequest);
+      const json = await withComposerAdmissionDeadline(admissionRequest, COMPOSER_ADMISSION_DEADLINE_MS);
       if (!json.ok) {
         if (json.structured && json.receipt) {
           /* Keep the payload readable in the compact receipt for retry and
@@ -1507,38 +1539,7 @@ export function TmuxComposer({
         inputRef.current?.focus();
         return;
       }
-      const imgCount = sentImages.length;
-      // The migration delivery fence returns `held`/`queued`/`recovering` when
-      // the text was accepted for the successor rather than delivered live. Those
-      // are durable acknowledgements (the backend persisted the message), so the
-      // draft clears but the receipt tracks the pending state until it resolves.
-      const held = json.outcome === "held" || json.outcome === "queued" || json.outcome === "recovering";
-      const at = nowMs();
-      const entry: SentEntry = {
-        id: at,
-        text: payloadText.trim() || (imgCount ? t("composer.imagesCount", { count: imgCount }) : ""),
-        at,
-        via: json.outcome === "resumed" || json.spawned ? "spawn" : "pane",
-        state: held ? (json.outcome as DeliveryReceiptState) : "sent",
-        clientMessageId,
-      };
-      const prior = retry ? sent.filter((item) => item.id !== retry.receiptId) : sent;
-      persistSent([...prior, entry].slice(-SENT_LIMIT));
-      const attempt = pendingDeliveries.current.find((candidate) => candidate.key === clientMessageId);
-      persistPendingDeliveries(pendingDeliveries.current.filter((candidate) => candidate.key !== clientMessageId));
-      if (idempotencyKey.current === clientMessageId) idempotencyKey.current = mintIdempotencyKey(); // next draft is a new message
-      settleGeneration(payloadText, attempt?.images ?? sentImages);
-      setStatus({
-        kind: held ? "info" : "ok",
-        text: held
-          ? t("composer.deliveryHeld", { label: file.migration?.targetLabel ?? file.migration?.targetAccountId ?? "" })
-          : json.outcome === "resumed" || json.spawned
-            ? t("composer.spawned", { target: json.target ?? "" })
-            : json.imagePaths?.length
-              ? t("composer.sentPaths", { count: json.imagePaths.length })
-              : t("common.sent"),
-      });
-      inputRef.current?.focus();
+      settleLegacySuccess(json);
     } catch (error) {
       /* The request died on the wire AFTER the server may have accepted it.
          The pre-flight record (text AND attachment snapshot) stays armed so a
@@ -1557,11 +1558,20 @@ export function TmuxComposer({
             entry.key === clientMessageId ? { ...entry, reconciling: true } : entry));
           const lateReceipt = admissionRequest?.then((result) => {
             const receipt = result.receipt;
-            if (!receipt || (!receiptIsAdmitted(receipt.status) && !receiptIsTerminal(receipt.status))) return null;
-            return (receipt.kind === "send" || receipt.kind === "steer")
-              && !receipt.text && payloadText.trim()
-              ? { ...receipt, text: payloadText.trim() }
-              : receipt;
+            if (receipt && (receiptIsAdmitted(receipt.status) || receiptIsTerminal(receipt.status))) {
+              return (receipt.kind === "send" || receipt.kind === "steer")
+                && !receipt.text && payloadText.trim()
+                ? { ...receipt, text: payloadText.trim() }
+                : receipt;
+            }
+            if (!result.ok || result.structured) return null;
+            const controller = receiptReconciliations.current.get(clientMessageId);
+            if (!controller || controller.signal.aborted) return null;
+            settleLegacySuccess(result);
+            controller.abort();
+            receiptReconciliations.current.delete(clientMessageId);
+            setReconcilingSend(receiptReconciliations.current.size > 0);
+            return null;
           });
           startReceiptReconciliation(clientMessageId, lateReceipt);
         }

--- a/src/components/TmuxComposer.tsx
+++ b/src/components/TmuxComposer.tsx
@@ -104,13 +104,14 @@ export function deliveryAttemptKey(current: string, stored?: string): string {
   return stored || current;
 }
 
+type RetryAwareReceipt = RuntimeReceipt & { retryOfOperationId?: string | null };
+const retryParentOperationId = (receipt: RuntimeReceipt): string | null =>
+  (receipt as RetryAwareReceipt).retryOfOperationId ?? null;
+
 export function mergeRuntimeReceipts(
   runtimeReceipts: RuntimeReceipt[],
   immediateReceipts: RuntimeReceipt[],
 ): RuntimeReceipt[] {
-  type RetryAwareReceipt = RuntimeReceipt & { retryOfOperationId?: string | null };
-  const retryParent = (receipt: RuntimeReceipt): string | null =>
-    (receipt as RetryAwareReceipt).retryOfOperationId ?? null;
   const allReceipts = [...runtimeReceipts, ...immediateReceipts];
   const keysByOperationId = new Map<string, Set<string>>();
   const operationsByIdempotencyKey = new Map<string, Set<string>>();
@@ -161,7 +162,7 @@ export function mergeRuntimeReceipts(
   for (const receipt of attempts) {
     const lineage = new Set<string>([receipt.operationId]);
     const ancestors: string[] = [];
-    let ancestor = retryParent(receipt);
+    let ancestor = retryParentOperationId(receipt);
     let cyclic = false;
     while (ancestor) {
       if (lineage.has(ancestor)) {
@@ -172,7 +173,7 @@ export function mergeRuntimeReceipts(
       const parent = byOperationId.get(ancestor);
       if (!parent) break;
       ancestors.push(ancestor);
-      ancestor = retryParent(parent);
+      ancestor = retryParentOperationId(parent);
     }
     if (!cyclic) {
       for (const operationId of ancestors) superseded.add(operationId);
@@ -482,6 +483,9 @@ export interface PendingDelivery {
       replay. Such a record remains observable for late receipt settlement and
       never lends its key to a new payload after remount. */
   payloadComplete?: false;
+  /** Current runtime operation that owns this logical generation. A manual
+      retry rotates the operation while preserving the generation. */
+  operationId?: string;
   /** The immediate request crossed its deadline and snapshot reconciliation
       still owns this generation. Persisted so a refresh resumes observation. */
   reconciling?: true;
@@ -494,6 +498,7 @@ const SETTLED_SEND_KEY_LIMIT = 32;
     survives a composer remount or a full page refresh (the attachment snapshot
     is memory-only — previews don't survive a refresh either). */
 const pendingSendKey = (id: string) => "llvPendingSend:" + id;
+const draftImagesKey = (id: string) => "llvDraftImages:" + id;
 
 interface PersistedPendingDelivery {
   key?: unknown;
@@ -503,6 +508,7 @@ interface PersistedPendingDelivery {
   runtimeCaptured?: unknown;
   reconciling?: unknown;
   payloadComplete?: unknown;
+  operationId?: unknown;
 }
 
 function persistedRuntime(value: unknown): RuntimeProfile | undefined {
@@ -532,6 +538,29 @@ function persistedImages(value: unknown): PendingImage[] | null {
   return images;
 }
 
+function readDraftImages(id: string): PendingImage[] | null {
+  try {
+    const raw = sessionStorage.getItem(draftImagesKey(id));
+    return raw === null ? null : persistedImages(JSON.parse(raw));
+  } catch {
+    return null;
+  }
+}
+
+function writeDraftImages(id: string, images: readonly PendingImage[], preserveEmpty: boolean): void {
+  try {
+    if (!images.length && !preserveEmpty) {
+      sessionStorage.removeItem(draftImagesKey(id));
+      return;
+    }
+    sessionStorage.setItem(draftImagesKey(id), JSON.stringify(images.map(({ id: imageId, base64, mime }) => ({
+      ...(imageId ? { id: imageId } : {}),
+      base64,
+      mime,
+    }))));
+  } catch { /* The visible in-memory tray remains authoritative. */ }
+}
+
 export function readPendingDeliveries(id: string): PendingDelivery[] {
   try {
     const raw = JSON.parse(sessionStorage.getItem(pendingSendKey(id)) ?? "[]") as PersistedPendingDelivery[];
@@ -551,6 +580,7 @@ export function readPendingDeliveries(id: string): PendingDelivery[] {
           ...(runtime ? { runtime } : {}),
           ...(entry.runtimeCaptured === true ? { runtimeCaptured: true as const } : {}),
           ...(payloadComplete ? {} : { payloadComplete: false as const }),
+          ...(typeof entry.operationId === "string" ? { operationId: entry.operationId } : {}),
           ...(entry.reconciling === true ? { reconciling: true as const } : {}),
         };
       });
@@ -562,7 +592,7 @@ export function readPendingDeliveries(id: string): PendingDelivery[] {
 export function writePendingDeliveries(id: string, pending: readonly PendingDelivery[]): void {
   try {
     if (pending.length) {
-      sessionStorage.setItem(pendingSendKey(id), JSON.stringify(pending.map(({ key, text, images, runtime, runtimeCaptured, reconciling, payloadComplete }) => ({
+      sessionStorage.setItem(pendingSendKey(id), JSON.stringify(pending.map(({ key, text, images, runtime, runtimeCaptured, reconciling, payloadComplete, operationId }) => ({
         key,
         text,
         images: images.map(({ id: imageId, base64, mime }) => ({
@@ -574,6 +604,7 @@ export function writePendingDeliveries(id: string, pending: readonly PendingDeli
         ...(runtimeCaptured ? { runtimeCaptured: true } : {}),
         ...(reconciling ? { reconciling: true } : {}),
         ...(payloadComplete === false ? { payloadComplete: false } : {}),
+        ...(operationId ? { operationId } : {}),
       }))));
     } else {
       sessionStorage.removeItem(pendingSendKey(id));
@@ -583,12 +614,13 @@ export function writePendingDeliveries(id: string, pending: readonly PendingDeli
        settlement metadata and explicitly fence the key from payload replay;
        the in-memory owner still holds all bytes until this mount ends. */
     try {
-      sessionStorage.setItem(pendingSendKey(id), JSON.stringify(pending.map(({ key, text, runtime, runtimeCaptured, reconciling }) => ({
+      sessionStorage.setItem(pendingSendKey(id), JSON.stringify(pending.map(({ key, text, runtime, runtimeCaptured, reconciling, operationId }) => ({
         key,
         text,
         ...(runtime ? { runtime } : {}),
         ...(runtimeCaptured ? { runtimeCaptured: true } : {}),
         ...(reconciling ? { reconciling: true } : {}),
+        ...(operationId ? { operationId } : {}),
         payloadComplete: false,
       }))));
     } catch { /* opaque origin: in-memory settlement remains authoritative */ }
@@ -599,6 +631,21 @@ function releasePendingReconciliation(entry: PendingDelivery): PendingDelivery {
   const released = { ...entry };
   delete released.reconciling;
   return released;
+}
+
+export function rebindPendingOperations(
+  pending: readonly PendingDelivery[],
+  receipts: readonly RuntimeReceipt[],
+): PendingDelivery[] {
+  return pending.map((entry) => {
+    const owner = receipts.find((receipt) =>
+      Boolean(entry.operationId) && retryParentOperationId(receipt) === entry.operationId)
+      ?? receipts.find((receipt) => receipt.operationId === entry.operationId)
+      ?? receipts.find((receipt) => receipt.idempotencyKey === entry.key);
+    return owner && owner.operationId !== entry.operationId
+      ? { ...entry, operationId: owner.operationId }
+      : entry;
+  });
 }
 
 /**
@@ -617,8 +664,13 @@ export function settlePendingDeliveries(
   receipts: readonly RuntimeReceipt[],
 ): { settled: { entry: PendingDelivery; text: string }[]; remaining: PendingDelivery[] } {
   const admittedByKey = new Map<string, RuntimeReceipt>();
+  const admittedByOperation = new Map<string, RuntimeReceipt>();
   for (const receipt of receipts) {
     if (!receiptIsAdmitted(receipt.status)) continue;
+    const currentOperation = admittedByOperation.get(receipt.operationId);
+    if (!currentOperation || (receipt.status === "delivered" && currentOperation.status !== "delivered")) {
+      admittedByOperation.set(receipt.operationId, receipt);
+    }
     const current = admittedByKey.get(receipt.idempotencyKey);
     if (!current || (receipt.status === "delivered" && current.status !== "delivered")) {
       admittedByKey.set(receipt.idempotencyKey, receipt);
@@ -627,7 +679,8 @@ export function settlePendingDeliveries(
   const settled: { entry: PendingDelivery; text: string }[] = [];
   const remaining: PendingDelivery[] = [];
   for (const entry of pending) {
-    const receipt = admittedByKey.get(entry.key);
+    const receipt = admittedByKey.get(entry.key)
+      ?? (entry.operationId ? admittedByOperation.get(entry.operationId) : undefined);
     if (!receipt) {
       remaining.push(entry);
       continue;
@@ -727,7 +780,7 @@ export function adoptComposerState(path: string, cardId: string): void {
     const previousOwner = sessionStorage.getItem(composerOwnerKey(path));
     for (const from of [previousOwner, path]) {
       if (!from || from === cardId) continue;
-      for (const keyOf of [draftKey, pendingSendKey, sentKey, dismissedReceiptsKey]) {
+      for (const keyOf of [draftKey, draftImagesKey, pendingSendKey, sentKey, dismissedReceiptsKey]) {
         const legacy = sessionStorage.getItem(keyOf(from));
         if (legacy === null) continue;
         if (sessionStorage.getItem(keyOf(cardId)) === null) sessionStorage.setItem(keyOf(cardId), legacy);
@@ -927,6 +980,7 @@ export function TmuxComposer({
     imageCapability: structuredSession ? structuredImageCapability ?? null : null,
   });
   const { text, textRef, setText, setTextState, inputRef, setStatus, busy, setBusy, voiceSending, attachments } = composer;
+  const attachmentDraftHydrated = useRef(false);
   const isMobile = useIsMobile();
   /* Interrupt / compact / attach-terminal / mode chip moved into the unified
      control strip (issue #241) — the composer keeps only the message surface
@@ -935,6 +989,8 @@ export function TmuxComposer({
   const [immediateRuntimeReceipts, setImmediateRuntimeReceipts] = useState<RuntimeReceipt[]>([]);
   const [reconcilingSend, setReconcilingSend] = useState(() =>
     typeof window !== "undefined" && readPendingDeliveries(cardId).some((entry) => entry.reconciling));
+  const [replayGenerationAvailable, setReplayGenerationAvailable] = useState(() =>
+    typeof window !== "undefined" && readPendingDeliveries(cardId).some((entry) => entry.payloadComplete !== false));
   /* Operation ids whose settled problem rows the user dismissed (issue #264
      rule 3). Persisted per conversation identity and adopted across id
      rotations alongside the draft. */
@@ -985,6 +1041,7 @@ export function TmuxComposer({
 
   const persistPendingDeliveries = (next: PendingDelivery[]) => {
     pendingDeliveries.current = next;
+    setReplayGenerationAvailable(next.some((entry) => entry.payloadComplete !== false));
     writePendingDeliveries(cardId, next);
   };
 
@@ -1023,7 +1080,6 @@ export function TmuxComposer({
      Retry. This path performs no automatic actuation. */
   const releaseReconciliationToRetry = (clientMessageId: string) => {
     receiptReconciliations.current.delete(clientMessageId);
-    setReconcilingSend(receiptReconciliations.current.size > 0);
     /* Drop the reconciling marker so a remount exposes a recoverable retry.
        Keep the generation so a late receipt can settle it and the key remains
        replayable. */
@@ -1033,6 +1089,9 @@ export function TmuxComposer({
         : entry));
     const entry = pendingDeliveries.current.find((candidate) => candidate.key === clientMessageId);
     if (!entry) return;
+    /* A quota-limited remount lacks bytes for a safe replay. Keep the composer
+       fenced while the durable receipt stream determines the original fate. */
+    setReconcilingSend(receiptReconciliations.current.size > 0 || entry.payloadComplete === false);
     setStatus({ kind: "err", text: t("composer.deliveryUnconfirmed") });
     setImmediateRuntimeReceipts((current) => [
       unconfirmedReceipt(clientMessageId, cardId, entry.text),
@@ -1093,20 +1152,26 @@ export function TmuxComposer({
     receiptReconciliations.current.clear();
     const restoredPending = readPendingDeliveries(cardId);
     pendingDeliveries.current = restoredPending;
+    setReplayGenerationAvailable(restoredPending.some((entry) => entry.payloadComplete !== false));
     runtimeSendSnapshots.current = new Map();
-    /* An unsettled generation whose exact draft survived the remount keeps its
-       original idempotency key. An explicit retry then replays idempotently and
-       cannot mint a second actuation. */
+    /* Replay ownership survives independently from the editable draft. The
+       next submit resolves the oldest unresolved generation first while text
+       and attachments prepared for a later turn remain in the composer. */
     const draftNow = typeof window !== "undefined" ? sessionStorage.getItem(draftKey(cardId)) ?? "" : "";
-    const resumable = restoredPending.find((entry) => entry.payloadComplete !== false && entry.text === draftNow);
-    const restoredImages = resumable ? attachments.replace(resumable.images.map((image) => ({ ...image }))) : false;
+    const resumable = restoredPending.find((entry) => entry.payloadComplete !== false);
+    const draftImages = readDraftImages(cardId);
+    attachmentDraftHydrated.current = false;
+    const trayImages = draftImages ?? (resumable?.text === draftNow ? resumable.images : []);
+    const restoredImages = attachments.replace(trayImages.map((image) => ({ ...image })));
+    queueMicrotask(() => { attachmentDraftHydrated.current = true; });
     if (resumable && restoredImages) {
       idempotencyKey.current = resumable.key;
       if (resumable.runtimeCaptured) runtimeSendSnapshots.current.set(resumable.key, resumable.runtime);
     }
     const reconcilingKeys = restoredPending.filter((entry) => entry.reconciling).map((entry) => entry.key);
-    setReconcilingSend(reconcilingKeys.length > 0);
-    if (reconcilingKeys.length) setStatus({ kind: "err", text: t("composer.admissionTimedOut") });
+    const hasIncompletePayload = restoredPending.some((entry) => entry.payloadComplete === false);
+    setReconcilingSend(reconcilingKeys.length > 0 || hasIncompletePayload);
+    if (reconcilingKeys.length || hasIncompletePayload) setStatus({ kind: "err", text: t("composer.admissionTimedOut") });
     for (const key of reconcilingKeys) startReceiptReconciliation(key);
     settledSendKeys.current = new Set();
     /* Keyed by identity alone: a path migration under a stable id must not
@@ -1115,6 +1180,11 @@ export function TmuxComposer({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [cardId]);
   /* eslint-enable react-hooks/set-state-in-effect */
+
+  useEffect(() => {
+    if (!attachmentDraftHydrated.current) return;
+    writeDraftImages(cardId, attachments.images, pendingDeliveries.current.length > 0);
+  }, [attachments.images, cardId]);
 
   /* Settle submitted generations against the receipt stream: a durably
      admitted receipt (queued or beyond) for a remembered key means the server
@@ -1141,7 +1211,20 @@ export function TmuxComposer({
       if (failure) idempotencyKey.current = mintIdempotencyKey();
     }
     if (!pendingDeliveries.current.length) return;
+    /* A retry leaf receives a fresh idempotency key and points at its parent
+       operation. Move logical-generation ownership to that leaf before
+       settlement so queued/delivered retry receipts consume the original once. */
+    const rebound = rebindPendingOperations(pendingDeliveries.current, displayedRuntimeReceipts);
+    const operationChanged = rebound.some((entry, index) => entry !== pendingDeliveries.current[index]);
+    if (operationChanged) persistPendingDeliveries(rebound);
     const { settled, remaining } = settlePendingDeliveries(pendingDeliveries.current, displayedRuntimeReceipts);
+    const incompleteStillUncertain = remaining.some((entry) => {
+      if (entry.payloadComplete !== false) return false;
+      return !displayedRuntimeReceipts.some((receipt) =>
+        (receipt.idempotencyKey === entry.key || receipt.operationId === entry.operationId)
+        && receiptIsTerminal(receipt.status));
+    });
+    setReconcilingSend(receiptReconciliations.current.size > 0 || incompleteStillUncertain);
     if (!settled.length) return;
     persistPendingDeliveries(remaining);
     for (const settlement of settled) {
@@ -1259,11 +1342,17 @@ export function TmuxComposer({
       ? { kind: "info", text: t("composer.receiptRecovering") }
       : null);
     /* The runtime settings this key rides with, frozen at its first attempt so
-       a replay stays byte-identical (issue #390 §10). */
-    if (structuredSession && !runtimeSendSnapshots.current.has(clientMessageId)) {
+       structured sends and legacy resume spawns replay byte-identically. */
+    const legacyResumeRuntime = spawnMode && !relayMode;
+    const capturesRuntime = Boolean(structuredSession) || legacyResumeRuntime;
+    if (capturesRuntime && !runtimeSendSnapshots.current.has(clientMessageId)) {
       runtimeSendSnapshots.current.set(
         clientMessageId,
-        replayGeneration?.runtimeCaptured ? replayGeneration.runtime : sendRuntimeFrom(file),
+        replayGeneration?.runtimeCaptured
+          ? replayGeneration.runtime
+          : structuredSession
+            ? sendRuntimeFrom(file)
+            : resumeProfileBody(file),
       );
       while (runtimeSendSnapshots.current.size > SETTLED_SEND_KEY_LIMIT) {
         const oldest = runtimeSendSnapshots.current.keys().next().value;
@@ -1290,7 +1379,7 @@ export function TmuxComposer({
           text: payloadText,
           images: sentImages,
           ...(runtimeOverride ? { runtime: runtimeOverride } : {}),
-          ...(structuredSession ? { runtimeCaptured: true as const } : {}),
+          ...(capturesRuntime ? { runtimeCaptured: true as const } : {}),
         },
         ...pendingDeliveries.current,
       ].slice(0, PENDING_DELIVERY_LIMIT));
@@ -1340,7 +1429,7 @@ export function TmuxComposer({
               /* The "on resume" profile (issue #241 §4): when this send reopens a
                  finished root conversation, boot it with the model/effort the
                  strip's picker saved. Ignored for a live pane or a subagent relay. */
-              ...(spawnMode && !relayMode ? resumeProfileBody(file) : {}),
+              ...(legacyResumeRuntime ? runtimeOverride ?? {} : {}),
             }),
           }).then(async (response) => {
             const body = await response.json() as ComposerSendResult;
@@ -1664,6 +1753,7 @@ export function TmuxComposer({
         showImage={!deadHostBlocksSend}
         imageDisabled={structuredImagesDisabled}
         imageDisabledReason={structuredImagesReason}
+        sendPayloadAvailable={replayGenerationAvailable}
         sendDisabledReason={deadHostBlocksSend
           ? t("deadHost.sendBlocked")
           : reconcilingSend

--- a/src/components/TmuxComposer.tsx
+++ b/src/components/TmuxComposer.tsx
@@ -20,6 +20,8 @@ import type { RuntimeReceipt } from "@/components/runtime/runtimeModel";
 
 import { ComposerBar } from "./ComposerBar";
 import {
+  COMPOSER_RECEIPT_POLL_INTERVAL_MS,
+  COMPOSER_RECEIPT_RECONCILIATION_MS,
   ComposerAdmissionTimeoutError,
   reconcileComposerReceipt,
   withComposerAdmissionDeadline,
@@ -557,6 +559,29 @@ export function settlePendingDeliveries(
   return { settled, remaining };
 }
 
+/** A synthetic, local-only receipt row for a generation whose reconciliation
+    window closed without a durable admission or terminal receipt. It carries
+    the original idempotency key. A later durable receipt for the same key
+    supersedes it through mergeRuntimeReceipts tier two, keeping one visible row
+    per message. The row records an unconfirmed state and leaves draft settlement
+    to an authoritative receipt. */
+const UNCONFIRMED_RECEIPT_PREFIX = "composer-unconfirmed:";
+function unconfirmedReceiptOperationId(clientMessageId: string): string {
+  return UNCONFIRMED_RECEIPT_PREFIX + clientMessageId;
+}
+function unconfirmedReceipt(clientMessageId: string, conversationId: string, text: string): RuntimeReceipt {
+  return {
+    operationId: unconfirmedReceiptOperationId(clientMessageId),
+    idempotencyKey: clientMessageId,
+    conversationId,
+    kind: "send",
+    status: "uncertain",
+    text,
+    at: new Date().toISOString(),
+    revision: 0,
+  };
+}
+
 /** Removes one attachment per delivered snapshot entry, so attachments added
     while the send was in flight survive. An id-bearing snapshot matches ONLY
     its intake id — if that slot is already gone, a late replayed receipt must
@@ -909,6 +934,33 @@ export function TmuxComposer({
     setReconcilingSend(receiptReconciliations.current.size > 0);
   };
 
+  /* The local reconciliation window closed without a durable admission or
+     terminal receipt. Release the composer for an explicit same-key retry.
+     Preserve the generation, its idempotency key, and its attachments. The
+     durable receipt stream continues observing: a late admission clears the
+     draft through settlePendingDeliveries, and a terminal failure surfaces
+     Retry. This path performs no automatic actuation. */
+  const releaseReconciliationToRetry = (clientMessageId: string) => {
+    receiptReconciliations.current.delete(clientMessageId);
+    setReconcilingSend(receiptReconciliations.current.size > 0);
+    /* Drop the reconciling marker so a remount exposes a recoverable retry.
+       Keep the generation so a late receipt can settle it and the key remains
+       replayable. */
+    persistPendingDeliveries(pendingDeliveries.current.map((entry) =>
+      entry.key === clientMessageId
+        ? { key: entry.key, text: entry.text, images: entry.images }
+        : entry));
+    const entry = pendingDeliveries.current.find((candidate) => candidate.key === clientMessageId);
+    if (!entry) return;
+    setStatus({ kind: "err", text: t("composer.deliveryUnconfirmed") });
+    setImmediateRuntimeReceipts((current) => [
+      unconfirmedReceipt(clientMessageId, cardId, entry.text),
+      ...current.filter((candidate) =>
+        candidate.idempotencyKey !== clientMessageId
+        && candidate.operationId !== unconfirmedReceiptOperationId(clientMessageId)),
+    ].slice(0, 8));
+  };
+
   const startReceiptReconciliation = (
     clientMessageId: string,
     lateReceipt?: Promise<RuntimeReceipt | null>,
@@ -923,9 +975,18 @@ export function TmuxComposer({
         && (receiptIsAdmitted(receipt.status) || receiptIsTerminal(receipt.status))) ?? null,
       refresh: refreshRuntime,
       late: lateReceipt,
+      timeoutMs: COMPOSER_RECEIPT_RECONCILIATION_MS,
+      pollIntervalMs: COMPOSER_RECEIPT_POLL_INTERVAL_MS,
       signal: controller.signal,
     }).then((receipt) => {
-      if (controller.signal.aborted || receipt === null) return;
+      /* An admitted or terminal receipt aborts through
+         finishReceiptReconciliation. A remount also aborts this owner. Both
+         paths already own settlement, so this resolution stays silent. */
+      if (controller.signal.aborted) return;
+      if (receipt === null) {
+        releaseReconciliationToRetry(clientMessageId);
+        return;
+      }
       setImmediateRuntimeReceipts((current) => [
         receipt,
         ...current.filter((candidate) => candidate.operationId !== receipt.operationId),
@@ -951,6 +1012,12 @@ export function TmuxComposer({
     receiptReconciliations.current.clear();
     const restoredPending = readPendingDeliveries(cardId);
     pendingDeliveries.current = restoredPending;
+    /* An unsettled generation whose exact draft survived the remount keeps its
+       original idempotency key. An explicit retry then replays idempotently and
+       cannot mint a second actuation. */
+    const draftNow = typeof window !== "undefined" ? sessionStorage.getItem(draftKey(cardId)) ?? "" : "";
+    const resumableKey = restoredPending.find((entry) => entry.text === draftNow)?.key;
+    if (resumableKey) idempotencyKey.current = resumableKey;
     const reconcilingKeys = restoredPending.filter((entry) => entry.reconciling).map((entry) => entry.key);
     setReconcilingSend(reconcilingKeys.length > 0);
     if (reconcilingKeys.length) setStatus({ kind: "err", text: t("composer.admissionTimedOut") });
@@ -975,6 +1042,18 @@ export function TmuxComposer({
         candidate.idempotencyKey === key
         && (receiptIsAdmitted(candidate.status) || receiptIsTerminal(candidate.status)));
       if (receipt) finishReceiptReconciliation(key, receipt);
+    }
+    /* A terminal non-admitted receipt (failed/rejected) for a preserved
+       generation the local window already released: mint a fresh key so the
+       next message is never replay-deduped into silence. The failure itself
+       surfaces Retry through the durable receipt stack. */
+    for (const entry of pendingDeliveries.current) {
+      if (receiptReconciliations.current.has(entry.key)) continue;
+      if (idempotencyKey.current !== entry.key) continue;
+      const failure = displayedRuntimeReceipts.find((candidate) =>
+        candidate.idempotencyKey === entry.key
+        && receiptIsTerminal(candidate.status) && !receiptIsAdmitted(candidate.status));
+      if (failure) idempotencyKey.current = mintIdempotencyKey();
     }
     if (!pendingDeliveries.current.length) return;
     const { settled, remaining } = settlePendingDeliveries(pendingDeliveries.current, displayedRuntimeReceipts);

--- a/src/components/TmuxComposer.tsx
+++ b/src/components/TmuxComposer.tsx
@@ -10,7 +10,7 @@ import type { TFunction } from "@/lib/i18n";
 import { Badge, type BadgeTone } from "@/components/ui/Badge";
 import { useComposer } from "@/hooks/useComposer";
 import { useIsMobile } from "@/hooks/useIsMobile";
-import { sendRuntimeMessage, useRuntimeReceiptsForArtifact, type RuntimeSessionView } from "@/hooks/useRuntime";
+import { refreshRuntime, sendRuntimeMessage, useRuntimeReceiptsForArtifact, type RuntimeSessionView } from "@/hooks/useRuntime";
 import { useTmuxTarget } from "@/hooks/useTmuxTarget";
 import { conversationIdentity } from "@/lib/accounts/identity";
 import { cardMigrationState, migrationHoldsSends } from "@/lib/accounts/migration";
@@ -19,7 +19,11 @@ import type { FileEntry } from "@/lib/types";
 import type { RuntimeReceipt } from "@/components/runtime/runtimeModel";
 
 import { ComposerBar } from "./ComposerBar";
-import { ComposerAdmissionTimeoutError, withComposerAdmissionDeadline } from "./composerAdmissionDeadline";
+import {
+  ComposerAdmissionTimeoutError,
+  reconcileComposerReceipt,
+  withComposerAdmissionDeadline,
+} from "./composerAdmissionDeadline";
 import { RuntimePill } from "./RuntimePill";
 import { savedResumeProfile, sendRuntimeFrom, type RuntimeProfile } from "./runtimeProfile";
 import { type PendingImage } from "./imageAttachments";
@@ -73,6 +77,19 @@ interface SentEntry {
   state?: DeliveryReceiptState;
   /** Idempotency key echoed to the backend so a retry can't double-deliver. */
   clientMessageId?: string;
+}
+
+interface ComposerSendResult {
+  ok?: boolean;
+  structured?: boolean;
+  error?: string;
+  /** HTTP status of the response, absent when the response was lost. */
+  status?: number;
+  imagePaths?: string[];
+  target?: string;
+  spawned?: boolean;
+  outcome?: "delivered-to-live" | "resumed" | "held" | "queued" | "delivering" | "delivered" | "recovering" | "failed";
+  receipt?: RuntimeReceipt;
 }
 
 const SENT_LIMIT = 8;
@@ -455,6 +472,9 @@ export interface PendingDelivery {
       admission removes exactly these from the composer, so images attached
       after the send stay put. */
   images: readonly PendingImage[];
+  /** The immediate request crossed its deadline and snapshot reconciliation
+      still owns this generation. Persisted so a refresh resumes observation. */
+  reconciling?: true;
 }
 
 const PENDING_DELIVERY_LIMIT = 8;
@@ -467,13 +487,18 @@ const pendingSendKey = (id: string) => "llvPendingSend:" + id;
 
 export function readPendingDeliveries(id: string): PendingDelivery[] {
   try {
-    const raw = JSON.parse(sessionStorage.getItem(pendingSendKey(id)) ?? "[]") as { key?: unknown; text?: unknown }[];
+    const raw = JSON.parse(sessionStorage.getItem(pendingSendKey(id)) ?? "[]") as { key?: unknown; text?: unknown; reconciling?: unknown }[];
     if (!Array.isArray(raw)) return [];
     return raw
-      .filter((entry): entry is { key: string; text: string } =>
+      .filter((entry): entry is { key: string; text: string; reconciling?: unknown } =>
         Boolean(entry) && typeof entry.key === "string" && typeof entry.text === "string")
       .slice(0, PENDING_DELIVERY_LIMIT)
-      .map((entry) => ({ key: entry.key, text: entry.text, images: [] }));
+      .map((entry) => ({
+        key: entry.key,
+        text: entry.text,
+        images: [],
+        ...(entry.reconciling === true ? { reconciling: true as const } : {}),
+      }));
   } catch {
     return [];
   }
@@ -482,7 +507,11 @@ export function readPendingDeliveries(id: string): PendingDelivery[] {
 export function writePendingDeliveries(id: string, pending: readonly PendingDelivery[]): void {
   try {
     if (pending.length) {
-      sessionStorage.setItem(pendingSendKey(id), JSON.stringify(pending.map(({ key, text }) => ({ key, text }))));
+      sessionStorage.setItem(pendingSendKey(id), JSON.stringify(pending.map(({ key, text, reconciling }) => ({
+        key,
+        text,
+        ...(reconciling ? { reconciling: true } : {}),
+      }))));
     } else {
       sessionStorage.removeItem(pendingSendKey(id));
     }
@@ -798,6 +827,8 @@ export function TmuxComposer({
      (text, images, mic, send) and its delivery receipts. */
   const [sent, setSent] = useState<SentEntry[]>([]);
   const [immediateRuntimeReceipts, setImmediateRuntimeReceipts] = useState<RuntimeReceipt[]>([]);
+  const [reconcilingSend, setReconcilingSend] = useState(() =>
+    typeof window !== "undefined" && readPendingDeliveries(cardId).some((entry) => entry.reconciling));
   /* Operation ids whose settled problem rows the user dismissed (issue #264
      rule 3). Persisted per conversation identity and adopted across id
      rotations alongside the draft. */
@@ -828,6 +859,11 @@ export function TmuxComposer({
      is disabled or the session is legacy/unhosted). */
   const runtimeReceipts = useRuntimeReceiptsForArtifact(file.path, cardId);
   const displayedRuntimeReceipts = mergeRuntimeReceipts(runtimeReceipts, immediateRuntimeReceipts);
+  const displayedRuntimeReceiptsRef = useRef(displayedRuntimeReceipts);
+  useLayoutEffect(() => {
+    displayedRuntimeReceiptsRef.current = displayedRuntimeReceipts;
+  }, [displayedRuntimeReceipts]);
+  const receiptReconciliations = useRef<Map<string, AbortController>>(new Map());
   const dismissedReceipts = new Set(dismissedReceiptIds);
   const dismissReceipts = (operationIds: string[]) => {
     if (!operationIds.length) return;
@@ -857,6 +893,51 @@ export function TmuxComposer({
     }
   };
 
+  const finishReceiptReconciliation = (clientMessageId: string, receipt: RuntimeReceipt) => {
+    const controller = receiptReconciliations.current.get(clientMessageId);
+    if (!controller) return;
+    controller.abort();
+    receiptReconciliations.current.delete(clientMessageId);
+    setStatus(null);
+    if (receiptIsTerminal(receipt.status) && !receiptIsAdmitted(receipt.status)) {
+      persistPendingDeliveries(pendingDeliveries.current.map((entry) =>
+        entry.key === clientMessageId
+          ? { key: entry.key, text: entry.text, images: entry.images }
+          : entry));
+      if (idempotencyKey.current === clientMessageId) idempotencyKey.current = mintIdempotencyKey();
+    }
+    setReconcilingSend(receiptReconciliations.current.size > 0);
+  };
+
+  const startReceiptReconciliation = (
+    clientMessageId: string,
+    lateReceipt?: Promise<RuntimeReceipt | null>,
+  ) => {
+    if (receiptReconciliations.current.has(clientMessageId)) return;
+    const controller = new AbortController();
+    receiptReconciliations.current.set(clientMessageId, controller);
+    setReconcilingSend(true);
+    void reconcileComposerReceipt({
+      read: () => displayedRuntimeReceiptsRef.current.find((receipt) =>
+        receipt.idempotencyKey === clientMessageId
+        && (receiptIsAdmitted(receipt.status) || receiptIsTerminal(receipt.status))) ?? null,
+      refresh: refreshRuntime,
+      late: lateReceipt,
+      signal: controller.signal,
+    }).then((receipt) => {
+      if (controller.signal.aborted || receipt === null) return;
+      setImmediateRuntimeReceipts((current) => [
+        receipt,
+        ...current.filter((candidate) => candidate.operationId !== receipt.operationId),
+      ].slice(0, 8));
+    });
+  };
+
+  useEffect(() => () => {
+    for (const controller of receiptReconciliations.current.values()) controller.abort();
+    receiptReconciliations.current.clear();
+  }, []);
+
   /* eslint-disable react-hooks/set-state-in-effect */
   useEffect(() => {
     /* Identity enrichment without a remount (a poll fills in the conversation
@@ -866,7 +947,14 @@ export function TmuxComposer({
     setSent(readSent(cardId));
     setImmediateRuntimeReceipts([]);
     setDismissedReceiptIds(readDismissedReceipts(cardId));
-    pendingDeliveries.current = readPendingDeliveries(cardId);
+    for (const controller of receiptReconciliations.current.values()) controller.abort();
+    receiptReconciliations.current.clear();
+    const restoredPending = readPendingDeliveries(cardId);
+    pendingDeliveries.current = restoredPending;
+    const reconcilingKeys = restoredPending.filter((entry) => entry.reconciling).map((entry) => entry.key);
+    setReconcilingSend(reconcilingKeys.length > 0);
+    if (reconcilingKeys.length) setStatus({ kind: "err", text: t("composer.admissionTimedOut") });
+    for (const key of reconcilingKeys) startReceiptReconciliation(key);
     settledSendKeys.current = new Set();
     runtimeSendSnapshots.current = new Map();
     /* Keyed by identity alone: a path migration under a stable id must not
@@ -882,6 +970,12 @@ export function TmuxComposer({
      survives; a rewritten draft for the next turn stays untouched). Runs on
      mount too, so a refresh snapshot reconciles a persisted generation. */
   useEffect(() => {
+    for (const [key] of receiptReconciliations.current) {
+      const receipt = displayedRuntimeReceipts.find((candidate) =>
+        candidate.idempotencyKey === key
+        && (receiptIsAdmitted(candidate.status) || receiptIsTerminal(candidate.status)));
+      if (receipt) finishReceiptReconciliation(key, receipt);
+    }
     if (!pendingDeliveries.current.length) return;
     const { settled, remaining } = settlePendingDeliveries(pendingDeliveries.current, displayedRuntimeReceipts);
     if (!settled.length) return;
@@ -967,7 +1061,7 @@ export function TmuxComposer({
        carries onto the wire. Read through the ref so a submit racing a paste
        still sends and later clears the same set. */
     const sentImages: PendingImage[] = attachments.imagesRef.current.map((image) => ({ ...image }));
-    if (busy || voiceSending || (!payloadText.trim() && !sentImages.length)) return;
+    if (busy || voiceSending || reconcilingSend || (!payloadText.trim() && !sentImages.length)) return;
     /* A legacy dead host keeps its draft local. Structured ownership admits a
        text-only message durably and uses that request to recover its engine host. */
     if (deadHost && !structuredSession) {
@@ -1031,19 +1125,9 @@ export function TmuxComposer({
       setText(draftAfterDelivery(textRef.current, clearedText));
       attachments.settleDelivered(snapshot);
     };
+    let admissionRequest: Promise<ComposerSendResult> | null = null;
     try {
-      const json: {
-        ok?: boolean;
-        structured?: boolean;
-        error?: string;
-        /** HTTP status of the response, absent when the response was lost. */
-        status?: number;
-        imagePaths?: string[];
-        target?: string;
-        spawned?: boolean;
-        outcome?: "delivered-to-live" | "resumed" | "held" | "queued" | "delivering" | "delivered" | "recovering" | "failed";
-        receipt?: RuntimeReceipt;
-      } = await withComposerAdmissionDeadline(Promise.resolve(structuredSession
+      admissionRequest = Promise.resolve(structuredSession
         ? !reachesWire
           ? { ok: false, structured: true, error: structuredImagesReason }
           : sendRuntimeMessage({
@@ -1079,9 +1163,10 @@ export function TmuxComposer({
               ...(spawnMode && !relayMode ? resumeProfileBody(file) : {}),
             }),
           }).then(async (response) => {
-            const body = await response.json() as typeof json;
+            const body = await response.json() as ComposerSendResult;
             return { ...body, status: response.status, ok: response.ok && body.ok === true };
-          })));
+          }));
+      const json = await withComposerAdmissionDeadline(admissionRequest);
       if (!json.ok) {
         if (json.structured && json.receipt) {
           /* Keep the payload readable in the compact receipt for retry and
@@ -1198,6 +1283,19 @@ export function TmuxComposer({
             ? t("composer.admissionTimedOut")
             : t("common.serverUnavailable"),
         });
+        if (error instanceof ComposerAdmissionTimeoutError) {
+          persistPendingDeliveries(pendingDeliveries.current.map((entry) =>
+            entry.key === clientMessageId ? { ...entry, reconciling: true } : entry));
+          const lateReceipt = admissionRequest?.then((result) => {
+            const receipt = result.receipt;
+            if (!receipt || (!receiptIsAdmitted(receipt.status) && !receiptIsTerminal(receipt.status))) return null;
+            return (receipt.kind === "send" || receipt.kind === "steer")
+              && !receipt.text && payloadText.trim()
+              ? { ...receipt, text: payloadText.trim() }
+              : receipt;
+          });
+          startReceiptReconciliation(clientMessageId, lateReceipt);
+        }
       }
     } finally {
       setBusy(false);
@@ -1250,7 +1348,7 @@ export function TmuxComposer({
      Quick-ack calls the same `send()`, so it obeys the same block and leaves the
      menu when blocked (round-3 finding). */
   const deadHostBlocksSend = deadHost && !structuredSession;
-  const sendBlocked = deadHostBlocksSend || Boolean(sendBlockedReason);
+  const sendBlocked = deadHostBlocksSend || reconcilingSend || Boolean(sendBlockedReason);
   const canQuickAck = (!spawnMode || relayMode) && !sendBlocked;
   const quickAckDisabled = busy || voiceSending || attachments.images.length > 0;
 
@@ -1386,7 +1484,11 @@ export function TmuxComposer({
         showImage={!deadHostBlocksSend}
         imageDisabled={structuredImagesDisabled}
         imageDisabledReason={structuredImagesReason}
-        sendDisabledReason={deadHostBlocksSend ? t("deadHost.sendBlocked") : sendBlockedReason ?? undefined}
+        sendDisabledReason={deadHostBlocksSend
+          ? t("deadHost.sendBlocked")
+          : reconcilingSend
+            ? t("composer.admissionTimedOut")
+            : sendBlockedReason ?? undefined}
         receipts={
           displayedRuntimeReceipts.length
             ? <RuntimeComposerReceipts

--- a/src/components/TmuxComposer.tsx
+++ b/src/components/TmuxComposer.tsx
@@ -474,6 +474,14 @@ export interface PendingDelivery {
       admission removes exactly these from the composer, so images attached
       after the send stay put. */
   images: readonly PendingImage[];
+  /** Runtime selection frozen with the first request under this key. */
+  runtime?: RuntimeProfile;
+  /** Records that runtime absence was captured deliberately. */
+  runtimeCaptured?: true;
+  /** False when a legacy/quota-limited record lacks bytes needed for an exact
+      replay. Such a record remains observable for late receipt settlement and
+      never lends its key to a new payload after remount. */
+  payloadComplete?: false;
   /** The immediate request crossed its deadline and snapshot reconciliation
       still owns this generation. Persisted so a refresh resumes observation. */
   reconciling?: true;
@@ -487,20 +495,65 @@ const SETTLED_SEND_KEY_LIMIT = 32;
     is memory-only — previews don't survive a refresh either). */
 const pendingSendKey = (id: string) => "llvPendingSend:" + id;
 
+interface PersistedPendingDelivery {
+  key?: unknown;
+  text?: unknown;
+  images?: unknown;
+  runtime?: unknown;
+  runtimeCaptured?: unknown;
+  reconciling?: unknown;
+  payloadComplete?: unknown;
+}
+
+function persistedRuntime(value: unknown): RuntimeProfile | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
+  const raw = value as Record<string, unknown>;
+  const runtime: RuntimeProfile = {};
+  if (typeof raw.model === "string") runtime.model = raw.model;
+  if (typeof raw.effort === "string") runtime.effort = raw.effort;
+  if (typeof raw.fast === "boolean") runtime.fast = raw.fast;
+  return Object.keys(runtime).length ? runtime : undefined;
+}
+
+function persistedImages(value: unknown): PendingImage[] | null {
+  if (!Array.isArray(value)) return null;
+  const images: PendingImage[] = [];
+  for (const candidate of value) {
+    if (!candidate || typeof candidate !== "object" || Array.isArray(candidate)) return null;
+    const raw = candidate as Record<string, unknown>;
+    if (typeof raw.base64 !== "string" || typeof raw.mime !== "string") return null;
+    images.push({
+      ...(typeof raw.id === "string" ? { id: raw.id } : {}),
+      base64: raw.base64,
+      mime: raw.mime,
+      preview: `data:${raw.mime};base64,${raw.base64}`,
+    });
+  }
+  return images;
+}
+
 export function readPendingDeliveries(id: string): PendingDelivery[] {
   try {
-    const raw = JSON.parse(sessionStorage.getItem(pendingSendKey(id)) ?? "[]") as { key?: unknown; text?: unknown; reconciling?: unknown }[];
+    const raw = JSON.parse(sessionStorage.getItem(pendingSendKey(id)) ?? "[]") as PersistedPendingDelivery[];
     if (!Array.isArray(raw)) return [];
     return raw
-      .filter((entry): entry is { key: string; text: string; reconciling?: unknown } =>
+      .filter((entry): entry is PersistedPendingDelivery & { key: string; text: string } =>
         Boolean(entry) && typeof entry.key === "string" && typeof entry.text === "string")
       .slice(0, PENDING_DELIVERY_LIMIT)
-      .map((entry) => ({
-        key: entry.key,
-        text: entry.text,
-        images: [],
-        ...(entry.reconciling === true ? { reconciling: true as const } : {}),
-      }));
+      .map((entry) => {
+        const images = persistedImages(entry.images);
+        const payloadComplete = images !== null && entry.payloadComplete !== false;
+        const runtime = persistedRuntime(entry.runtime);
+        return {
+          key: entry.key,
+          text: entry.text,
+          images: images ?? [],
+          ...(runtime ? { runtime } : {}),
+          ...(entry.runtimeCaptured === true ? { runtimeCaptured: true as const } : {}),
+          ...(payloadComplete ? {} : { payloadComplete: false as const }),
+          ...(entry.reconciling === true ? { reconciling: true as const } : {}),
+        };
+      });
   } catch {
     return [];
   }
@@ -509,15 +562,43 @@ export function readPendingDeliveries(id: string): PendingDelivery[] {
 export function writePendingDeliveries(id: string, pending: readonly PendingDelivery[]): void {
   try {
     if (pending.length) {
-      sessionStorage.setItem(pendingSendKey(id), JSON.stringify(pending.map(({ key, text, reconciling }) => ({
+      sessionStorage.setItem(pendingSendKey(id), JSON.stringify(pending.map(({ key, text, images, runtime, runtimeCaptured, reconciling, payloadComplete }) => ({
         key,
         text,
+        images: images.map(({ id: imageId, base64, mime }) => ({
+          ...(imageId ? { id: imageId } : {}),
+          base64,
+          mime,
+        })),
+        ...(runtime ? { runtime } : {}),
+        ...(runtimeCaptured ? { runtimeCaptured: true } : {}),
         ...(reconciling ? { reconciling: true } : {}),
+        ...(payloadComplete === false ? { payloadComplete: false } : {}),
       }))));
     } else {
       sessionStorage.removeItem(pendingSendKey(id));
     }
-  } catch { /* quota/opaque-origin: the in-memory generation still settles */ }
+  } catch {
+    /* Large image generations may exceed synchronous browser storage. Retain
+       settlement metadata and explicitly fence the key from payload replay;
+       the in-memory owner still holds all bytes until this mount ends. */
+    try {
+      sessionStorage.setItem(pendingSendKey(id), JSON.stringify(pending.map(({ key, text, runtime, runtimeCaptured, reconciling }) => ({
+        key,
+        text,
+        ...(runtime ? { runtime } : {}),
+        ...(runtimeCaptured ? { runtimeCaptured: true } : {}),
+        ...(reconciling ? { reconciling: true } : {}),
+        payloadComplete: false,
+      }))));
+    } catch { /* opaque origin: in-memory settlement remains authoritative */ }
+  }
+}
+
+function releasePendingReconciliation(entry: PendingDelivery): PendingDelivery {
+  const released = { ...entry };
+  delete released.reconciling;
+  return released;
 }
 
 /**
@@ -927,7 +1008,7 @@ export function TmuxComposer({
     if (receiptIsTerminal(receipt.status) && !receiptIsAdmitted(receipt.status)) {
       persistPendingDeliveries(pendingDeliveries.current.map((entry) =>
         entry.key === clientMessageId
-          ? { key: entry.key, text: entry.text, images: entry.images }
+          ? releasePendingReconciliation(entry)
           : entry));
       if (idempotencyKey.current === clientMessageId) idempotencyKey.current = mintIdempotencyKey();
     }
@@ -948,7 +1029,7 @@ export function TmuxComposer({
        replayable. */
     persistPendingDeliveries(pendingDeliveries.current.map((entry) =>
       entry.key === clientMessageId
-        ? { key: entry.key, text: entry.text, images: entry.images }
+        ? releasePendingReconciliation(entry)
         : entry));
     const entry = pendingDeliveries.current.find((candidate) => candidate.key === clientMessageId);
     if (!entry) return;
@@ -1012,18 +1093,22 @@ export function TmuxComposer({
     receiptReconciliations.current.clear();
     const restoredPending = readPendingDeliveries(cardId);
     pendingDeliveries.current = restoredPending;
+    runtimeSendSnapshots.current = new Map();
     /* An unsettled generation whose exact draft survived the remount keeps its
        original idempotency key. An explicit retry then replays idempotently and
        cannot mint a second actuation. */
     const draftNow = typeof window !== "undefined" ? sessionStorage.getItem(draftKey(cardId)) ?? "" : "";
-    const resumableKey = restoredPending.find((entry) => entry.text === draftNow)?.key;
-    if (resumableKey) idempotencyKey.current = resumableKey;
+    const resumable = restoredPending.find((entry) => entry.payloadComplete !== false && entry.text === draftNow);
+    const restoredImages = resumable ? attachments.replace(resumable.images.map((image) => ({ ...image }))) : false;
+    if (resumable && restoredImages) {
+      idempotencyKey.current = resumable.key;
+      if (resumable.runtimeCaptured) runtimeSendSnapshots.current.set(resumable.key, resumable.runtime);
+    }
     const reconcilingKeys = restoredPending.filter((entry) => entry.reconciling).map((entry) => entry.key);
     setReconcilingSend(reconcilingKeys.length > 0);
     if (reconcilingKeys.length) setStatus({ kind: "err", text: t("composer.admissionTimedOut") });
     for (const key of reconcilingKeys) startReceiptReconciliation(key);
     settledSendKeys.current = new Set();
-    runtimeSendSnapshots.current = new Map();
     /* Keyed by identity alone: a path migration under a stable id must not
        wipe the immediate receipts or the settled-key memory (`file.path` is
        only read to adopt records the old identity left behind). */
@@ -1135,11 +1220,21 @@ export function TmuxComposer({
   };
 
   const send = async (overrideText?: string, retry?: { receiptId: number; clientMessageId?: string }) => {
-    const payloadText = overrideText ?? text;
+    const requestedText = overrideText ?? text;
     /* The generation snapshot: exactly the text and attachments this attempt
        carries onto the wire. Read through the ref so a submit racing a paste
        still sends and later clears the same set. */
-    const sentImages: PendingImage[] = attachments.imagesRef.current.map((image) => ({ ...image }));
+    const requestedImages: PendingImage[] = attachments.imagesRef.current.map((image) => ({ ...image }));
+    /* Resolve the key before selecting the payload. A generation retained after
+       uncertain admission owns an immutable text/image snapshot; later edits
+       stay in the composer for the following generation while an explicit
+       submit replays the original bytes under the original key. */
+    const clientMessageId = deliveryAttemptKey(idempotencyKey.current, retry?.clientMessageId);
+    const replayGeneration = pendingDeliveries.current.find((entry) => entry.key === clientMessageId);
+    const payloadText = replayGeneration?.text ?? requestedText;
+    const sentImages: PendingImage[] = replayGeneration
+      ? replayGeneration.images.map((image) => ({ ...image }))
+      : requestedImages;
     if (busy || voiceSending || reconcilingSend || (!payloadText.trim() && !sentImages.length)) return;
     /* A legacy dead host keeps its draft local. Structured ownership admits a
        text-only message durably and uses that request to recover its engine host. */
@@ -1163,13 +1258,13 @@ export function TmuxComposer({
     setStatus(deadHost
       ? { kind: "info", text: t("composer.receiptRecovering") }
       : null);
-    /* Idempotency key: the backend can dedupe a retried held/failed delivery
-       against this id so the successor never receives the same prompt twice. */
-    const clientMessageId = deliveryAttemptKey(idempotencyKey.current, retry?.clientMessageId);
     /* The runtime settings this key rides with, frozen at its first attempt so
        a replay stays byte-identical (issue #390 §10). */
     if (structuredSession && !runtimeSendSnapshots.current.has(clientMessageId)) {
-      runtimeSendSnapshots.current.set(clientMessageId, sendRuntimeFrom(file));
+      runtimeSendSnapshots.current.set(
+        clientMessageId,
+        replayGeneration?.runtimeCaptured ? replayGeneration.runtime : sendRuntimeFrom(file),
+      );
       while (runtimeSendSnapshots.current.size > SETTLED_SEND_KEY_LIMIT) {
         const oldest = runtimeSendSnapshots.current.keys().next().value;
         if (oldest === undefined) break;
@@ -1190,7 +1285,13 @@ export function TmuxComposer({
       && !pendingDeliveries.current.some((entry) => entry.key === clientMessageId);
     if (recordedThisAttempt) {
       persistPendingDeliveries([
-        { key: clientMessageId, text: payloadText, images: sentImages },
+        {
+          key: clientMessageId,
+          text: payloadText,
+          images: sentImages,
+          ...(runtimeOverride ? { runtime: runtimeOverride } : {}),
+          ...(structuredSession ? { runtimeCaptured: true as const } : {}),
+        },
         ...pendingDeliveries.current,
       ].slice(0, PENDING_DELIVERY_LIMIT));
     }

--- a/src/components/TmuxComposer.tsx
+++ b/src/components/TmuxComposer.tsx
@@ -1028,7 +1028,7 @@ export function TmuxComposer({
   }, [displayedRuntimeReceipts]);
   const receiptReconciliations = useRef<Map<string, AbortController>>(new Map());
   const legacyResponseEpoch = useRef<{ cardId: string; active: boolean }>({ cardId, active: true });
-  useEffect(() => {
+  useLayoutEffect(() => {
     const epoch = { cardId, active: true };
     legacyResponseEpoch.current = epoch;
     return () => {

--- a/src/components/composerAdmissionDeadline.test.ts
+++ b/src/components/composerAdmissionDeadline.test.ts
@@ -1,6 +1,9 @@
 import { expect, test } from "bun:test";
 
-import { ComposerAdmissionTimeoutError, withComposerAdmissionDeadline } from "./composerAdmissionDeadline";
+import {
+  ComposerAdmissionTimeoutError,
+  withComposerAdmissionDeadline,
+} from "./composerAdmissionDeadline";
 
 test("a request without an admission response releases the composer deadline", async () => {
   const neverSettles = new Promise<Response>(() => {});

--- a/src/components/composerAdmissionDeadline.ts
+++ b/src/components/composerAdmissionDeadline.ts
@@ -1,4 +1,6 @@
 export const COMPOSER_ADMISSION_DEADLINE_MS = 15_000;
+export const COMPOSER_RECEIPT_RECONCILIATION_MS = 30_000;
+export const COMPOSER_RECEIPT_POLL_INTERVAL_MS = 1_000;
 
 export class ComposerAdmissionTimeoutError extends Error {
   constructor() {
@@ -12,8 +14,7 @@ export class ComposerAdmissionTimeoutError extends Error {
  *
  * The request continues in the background because the server may have already
  * accepted it. Durable receipt reconciliation owns the eventual settlement;
- * the deadline only releases the input so the operator can retry with the same
- * idempotency key.
+ * the deadline releases the busy state while the original key remains fenced.
  */
 export function withComposerAdmissionDeadline<T>(request: Promise<T>, timeoutMs = COMPOSER_ADMISSION_DEADLINE_MS): Promise<T> {
   let timer: ReturnType<typeof setTimeout> | undefined;
@@ -23,4 +24,79 @@ export function withComposerAdmissionDeadline<T>(request: Promise<T>, timeoutMs 
   return Promise.race([request, deadline]).finally(() => {
     if (timer !== undefined) clearTimeout(timer);
   });
+}
+
+interface ComposerReceiptReconciliation<T> {
+  read: () => T | null;
+  refresh: () => Promise<boolean>;
+  late?: Promise<T | null>;
+  timeoutMs?: number;
+  pollIntervalMs?: number;
+  signal?: AbortSignal;
+}
+
+function waitFor(ms: number, signal?: AbortSignal): Promise<void> {
+  if (signal?.aborted || ms <= 0) return Promise.resolve();
+  return new Promise((resolve) => {
+    const timer = setTimeout(finish, ms);
+    function finish() {
+      clearTimeout(timer);
+      signal?.removeEventListener("abort", finish);
+      resolve();
+    }
+    signal?.addEventListener("abort", finish, { once: true });
+  });
+}
+
+function refreshBeforeDeadline(
+  refresh: () => Promise<boolean>,
+  timeoutMs: number,
+  signal?: AbortSignal,
+): Promise<void> {
+  if (signal?.aborted || timeoutMs <= 0) return Promise.resolve();
+  return new Promise((resolve) => {
+    const timer = setTimeout(finish, timeoutMs);
+    function finish() {
+      clearTimeout(timer);
+      signal?.removeEventListener("abort", finish);
+      resolve();
+    }
+    signal?.addEventListener("abort", finish, { once: true });
+    void refresh().then(finish, finish);
+  });
+}
+
+/** Polls the authoritative runtime snapshot for a receipt after the immediate
+ * admission response misses its deadline. The original send remains owned by
+ * its caller, so this loop never issues another actuation. */
+export async function reconcileComposerReceipt<T>({
+  read,
+  refresh,
+  late,
+  timeoutMs = COMPOSER_RECEIPT_RECONCILIATION_MS,
+  pollIntervalMs = COMPOSER_RECEIPT_POLL_INTERVAL_MS,
+  signal,
+}: ComposerReceiptReconciliation<T>): Promise<T | null> {
+  const deadline = Date.now() + timeoutMs;
+  const pendingForever = new Promise<never>(() => {});
+  const lateReceipt: Promise<T> = late
+    ? late.then((value) => value ?? pendingForever, () => pendingForever)
+    : pendingForever;
+  while (!signal?.aborted) {
+    const current = read();
+    if (current !== null) return current;
+    const remaining = deadline - Date.now();
+    if (remaining <= 0) return null;
+    const refreshed = await Promise.race([
+      refreshBeforeDeadline(refresh, remaining, signal).then(read),
+      lateReceipt,
+    ]);
+    if (refreshed !== null) return refreshed;
+    const afterWait = await Promise.race([
+      waitFor(Math.min(pollIntervalMs, Math.max(0, deadline - Date.now())), signal).then(read),
+      lateReceipt,
+    ]);
+    if (afterWait !== null) return afterWait;
+  }
+  return null;
 }

--- a/src/components/composerDeliveryReconciliation.integration.test.ts
+++ b/src/components/composerDeliveryReconciliation.integration.test.ts
@@ -1,0 +1,32 @@
+import { expect, test } from "bun:test";
+
+import {
+  ComposerAdmissionTimeoutError,
+  reconcileComposerReceipt,
+  withComposerAdmissionDeadline,
+} from "./composerAdmissionDeadline";
+
+test("a timed-out admission keeps one actuation while its late response yields the receipt", async () => {
+  const clientMessageId = "composer-delayed-receipt";
+  let actuations = 0;
+  const durableDelivery = new Promise<{ idempotencyKey: string }>((resolve) => {
+    actuations += 1;
+    setTimeout(() => {
+      resolve({ idempotencyKey: clientMessageId });
+    }, 15);
+  });
+
+  await expect(withComposerAdmissionDeadline(durableDelivery, 2))
+    .rejects.toBeInstanceOf(ComposerAdmissionTimeoutError);
+
+  const reconciled = await reconcileComposerReceipt({
+    read: () => null,
+    refresh: async () => false,
+    late: durableDelivery,
+    timeoutMs: 100,
+    pollIntervalMs: 1,
+  });
+
+  expect(reconciled).toEqual({ idempotencyKey: clientMessageId });
+  expect(actuations).toBe(1);
+});

--- a/src/components/composerDeliveryReconciliation.integration.test.ts
+++ b/src/components/composerDeliveryReconciliation.integration.test.ts
@@ -30,3 +30,43 @@ test("a timed-out admission keeps one actuation while its late response yields t
   expect(reconciled).toEqual({ idempotencyKey: clientMessageId });
   expect(actuations).toBe(1);
 });
+
+test("an expired window with no receipt resolves to null so the caller can recover", async () => {
+  const actuations = 0;
+  let refreshes = 0;
+
+  const reconciled = await reconcileComposerReceipt<{ idempotencyKey: string }>({
+    read: () => {
+      /* Reading the authoritative snapshot never issues a send. */
+      return null;
+    },
+    refresh: async () => {
+      refreshes += 1;
+      return false;
+    },
+    timeoutMs: 30,
+    pollIntervalMs: 4,
+  });
+
+  /* A null resolution is the recoverable signal: the window closed without a
+     receipt, and reconciliation issued zero sends. */
+  expect(reconciled).toBeNull();
+  expect(actuations).toBe(0);
+  expect(refreshes).toBeGreaterThan(0);
+});
+
+test("an aborted window resolves to null without waiting out the deadline", async () => {
+  const controller = new AbortController();
+  const started = Date.now();
+  const pending = reconcileComposerReceipt({
+    read: () => null,
+    refresh: () => new Promise<boolean>(() => {}),
+    timeoutMs: 10_000,
+    pollIntervalMs: 1_000,
+    signal: controller.signal,
+  });
+  controller.abort();
+
+  expect(await pending).toBeNull();
+  expect(Date.now() - started).toBeLessThan(1_000);
+});

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -267,6 +267,7 @@ export const en = {
   "composer.removeFromQueue": "Remove from queue",
   "composer.deliveryHeld": "Held for «{label}» — delivers after the account switch",
   "composer.admissionTimedOut": "Delivery confirmation timed out. Checking the durable receipt; your message remains preserved.",
+  "composer.deliveryUnconfirmed": "Delivery couldn't be confirmed. Your message is preserved — send again to retry safely; the same message key is reused.",
   "composer.runtimePill": "Model and reasoning — applies to your next message",
   "composer.reasoningGroup": "Reasoning",
   "composer.modelGroup": "Model",

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -266,7 +266,7 @@ export const en = {
   "composer.queueAria": "Queue of sent messages",
   "composer.removeFromQueue": "Remove from queue",
   "composer.deliveryHeld": "Held for «{label}» — delivers after the account switch",
-  "composer.admissionTimedOut": "Delivery confirmation timed out. Retry safely; the same message key will be reused.",
+  "composer.admissionTimedOut": "Delivery confirmation timed out. Checking the durable receipt; your message remains preserved.",
   "composer.runtimePill": "Model and reasoning — applies to your next message",
   "composer.reasoningGroup": "Reasoning",
   "composer.modelGroup": "Model",

--- a/src/lib/i18n/uk.ts
+++ b/src/lib/i18n/uk.ts
@@ -259,6 +259,7 @@ export const uk: Record<keyof typeof en, Message> = {
   "composer.removeFromQueue": "Прибрати з черги",
   "composer.deliveryHeld": "Притримано для «{label}» — доставиться після зміни акаунта",
   "composer.admissionTimedOut": "Час очікування підтвердження вичерпано. Перевіряємо надійну квитанцію; повідомлення збережено.",
+  "composer.deliveryUnconfirmed": "Не вдалося підтвердити доставку. Повідомлення збережено — надішліть ще раз, щоб безпечно повторити; той самий ключ повідомлення буде використано.",
   "composer.runtimePill": "Модель і міркування — застосується до наступного повідомлення",
   "composer.reasoningGroup": "Міркування",
   "composer.modelGroup": "Модель",

--- a/src/lib/i18n/uk.ts
+++ b/src/lib/i18n/uk.ts
@@ -258,7 +258,7 @@ export const uk: Record<keyof typeof en, Message> = {
   "composer.queueAria": "Черга надісланих повідомлень",
   "composer.removeFromQueue": "Прибрати з черги",
   "composer.deliveryHeld": "Притримано для «{label}» — доставиться після зміни акаунта",
-  "composer.admissionTimedOut": "Час очікування підтвердження вичерпано. Повторіть безпечно — ключ повідомлення збережено.",
+  "composer.admissionTimedOut": "Час очікування підтвердження вичерпано. Перевіряємо надійну квитанцію; повідомлення збережено.",
   "composer.runtimePill": "Модель і міркування — застосується до наступного повідомлення",
   "composer.reasoningGroup": "Міркування",
   "composer.modelGroup": "Модель",


### PR DESCRIPTION
## Summary

- release the composer after the local durable-receipt reconciliation window expires
- preserve the original message key, draft text, and attachment generation for an explicit idempotent retry
- keep late admission and terminal failure settlement active after the composer becomes usable
- restore the retry key across a composer remount

## Verification

- 63 focused composer and reconciliation tests passed
- TypeScript passed
- changed-file ESLint passed
- production build passed
- privacy publication gate passed

## Acceptance coverage

- missing receipt after the local window
- late admission
- composer remount
- typing after timeout
- terminal failure
- multiple images on desktop and 390px

Closes #421
