### PR TITLE
fix: stop repeated privacy failures on clean issue comments

### DIFF
--- a/.github/workflows/privacy-tracker-audit.yml
+++ b/.github/workflows/privacy-tracker-audit.yml
@@ -51,6 +51,12 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
           LLV_PRIVACY_KNOWN_VALUE_FINGERPRINTS_FILE: scripts/privacy-known-value-fingerprints.json
           LLV_PRIVACY_OCR_LANGUAGES: eng+ukr
+          PUBLICATION_ISSUE_COMMENT_ID: ${{ github.event_name == 'issue_comment' && github.event.comment.id || '' }}
           PUBLICATION_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number || inputs.publication_number }}
           PUBLICATION_REPO: ${{ github.repository }}
-        run: bun scripts/privacy-github-audit.ts --repo "$PUBLICATION_REPO" --number "$PUBLICATION_NUMBER"
+        run: |
+          arguments=(--repo "$PUBLICATION_REPO" --number "$PUBLICATION_NUMBER")
+          if [[ -n "$PUBLICATION_ISSUE_COMMENT_ID" ]]; then
+            arguments+=(--issue-comment "$PUBLICATION_ISSUE_COMMENT_ID")
+          fi
+          bun scripts/privacy-github-audit.ts "${arguments[@]}"

--- a/scripts/privacy-github-audit.ts
+++ b/scripts/privacy-github-audit.ts
@@ -18,6 +18,7 @@ export type GithubAuditOptions = {
   number: number;
   repo: string;
   requireKnownValues?: boolean;
+  surface?: { id: number; kind: "issue_comment" };
   token: string;
 };
 
@@ -426,34 +427,53 @@ export async function auditGithubPublication(options: GithubAuditOptions): Promi
   const fetcher = options.fetcher ?? fetch;
   const githubBase = new URL(`https://github.com/${options.repo}/`);
   const root = `repos/${options.repo}`;
-  const issueResult = await fetchJson(
-    new URL(`${root}/issues/${options.number}`, apiBase),
-    options.token,
-    apiBase.origin,
-    fetcher,
-  );
-  if (typeof issueResult !== "object" || issueResult === null || Array.isArray(issueResult)) {
-    addFinding(findings, "inspection_error");
-    return findings;
-  }
-  const issue = issueResult as GithubIssue;
-  const comments = await fetchPages(apiBase, `${root}/issues/${options.number}/comments`, options.token, fetcher);
-  if (!comments) {
-    addFinding(findings, "inspection_error");
-    return findings;
-  }
-  const texts = new Set(surfaceTexts([issue, ...comments]));
-  if (issue.pull_request) {
-    const [pullResult, reviewComments, reviews] = await Promise.all([
-      fetchJson(new URL(`${root}/pulls/${options.number}`, apiBase), options.token, apiBase.origin, fetcher),
-      fetchPages(apiBase, `${root}/pulls/${options.number}/comments`, options.token, fetcher),
-      fetchPages(apiBase, `${root}/pulls/${options.number}/reviews`, options.token, fetcher),
-    ]);
-    if (typeof pullResult !== "object" || pullResult === null || Array.isArray(pullResult) || !reviewComments || !reviews) {
+  const texts = new Set<string>();
+  if (options.surface) {
+    if (!Number.isSafeInteger(options.surface.id) || options.surface.id < 1) {
+      addFinding(findings, "configuration_error");
+      return findings;
+    }
+    const commentResult = await fetchJson(
+      new URL(`${root}/issues/comments/${options.surface.id}`, apiBase),
+      options.token,
+      apiBase.origin,
+      fetcher,
+    );
+    if (typeof commentResult !== "object" || commentResult === null || Array.isArray(commentResult)) {
       addFinding(findings, "inspection_error");
       return findings;
     }
-    for (const text of surfaceTexts([pullResult as GithubSurface, ...reviewComments, ...reviews])) texts.add(text);
+    for (const text of surfaceTexts([commentResult as GithubSurface])) texts.add(text);
+  } else {
+    const issueResult = await fetchJson(
+      new URL(`${root}/issues/${options.number}`, apiBase),
+      options.token,
+      apiBase.origin,
+      fetcher,
+    );
+    if (typeof issueResult !== "object" || issueResult === null || Array.isArray(issueResult)) {
+      addFinding(findings, "inspection_error");
+      return findings;
+    }
+    const issue = issueResult as GithubIssue;
+    const comments = await fetchPages(apiBase, `${root}/issues/${options.number}/comments`, options.token, fetcher);
+    if (!comments) {
+      addFinding(findings, "inspection_error");
+      return findings;
+    }
+    for (const text of surfaceTexts([issue, ...comments])) texts.add(text);
+    if (issue.pull_request) {
+      const [pullResult, reviewComments, reviews] = await Promise.all([
+        fetchJson(new URL(`${root}/pulls/${options.number}`, apiBase), options.token, apiBase.origin, fetcher),
+        fetchPages(apiBase, `${root}/pulls/${options.number}/comments`, options.token, fetcher),
+        fetchPages(apiBase, `${root}/pulls/${options.number}/reviews`, options.token, fetcher),
+      ]);
+      if (typeof pullResult !== "object" || pullResult === null || Array.isArray(pullResult) || !reviewComments || !reviews) {
+        addFinding(findings, "inspection_error");
+        return findings;
+      }
+      for (const text of surfaceTexts([pullResult as GithubSurface, ...reviewComments, ...reviews])) texts.add(text);
+    }
   }
 
   for (const text of texts) mergeFindings(findings, sensitiveClasses(text));
@@ -518,11 +538,15 @@ function argumentValue(arguments_: string[], flag: string): string | undefined {
 if (import.meta.main) {
   const arguments_ = process.argv.slice(2);
   const number = Number(argumentValue(arguments_, "--number"));
+  const issueCommentId = argumentValue(arguments_, "--issue-comment");
   const findings = await auditGithubPublication({
     apiUrl: argumentValue(arguments_, "--api-url"),
     number,
     repo: argumentValue(arguments_, "--repo") ?? "",
     requireKnownValues: true,
+    surface: issueCommentId === undefined
+      ? undefined
+      : { id: Number(issueCommentId), kind: "issue_comment" },
     token: process.env.GITHUB_TOKEN ?? process.env.GH_TOKEN ?? "",
   });
   reportPrivacyFindings(findings);

--- a/scripts/privacy-publication-gate.test.ts
+++ b/scripts/privacy-publication-gate.test.ts
@@ -1303,6 +1303,15 @@ describe("privacy publication gate", () => {
     expect(workflow).toContain('--base "$PRIVACY_BASE_SHA"');
   });
 
+  test("scopes issue-comment audits to the triggering comment", () => {
+    const workflow = readFileSync(join(import.meta.dir, "..", ".github", "workflows", "privacy-tracker-audit.yml"), "utf8");
+
+    expect(workflow).toContain(
+      "PUBLICATION_ISSUE_COMMENT_ID: ${{ github.event_name == 'issue_comment' && github.event.comment.id || '' }}",
+    );
+    expect(workflow).toContain('--issue-comment "$PUBLICATION_ISSUE_COMMENT_ID"');
+  });
+
   test("uses trusted scanner and fingerprints when every candidate gate surface is tampered", () => {
     const root = mkdtempSync(join(tmpdir(), "llv-privacy-gate-"));
     temporaryDirectories.push(root);
@@ -1929,6 +1938,57 @@ describe("privacy publication gate", () => {
       if (originalOcrLanguages === undefined) delete process.env.LLV_PRIVACY_OCR_LANGUAGES;
       else process.env.LLV_PRIVACY_OCR_LANGUAGES = originalOcrLanguages;
     }
+  });
+
+  test("audits only the triggering issue comment when a surface is selected", async () => {
+    const syntheticHome = ["", "home", "fixture-person", "historical-issue"].join("/");
+    const requests: string[] = [];
+    const fetcher = async (input: string | URL): Promise<Response> => {
+      const url = new URL(input);
+      requests.push(url.pathname);
+      if (url.pathname.endsWith("/issues/421")) return Response.json({ body: syntheticHome, title: "Historical issue" });
+      if (url.pathname.endsWith("/issues/421/comments")) return Response.json([{ body: "Clean historical comment" }]);
+      if (url.pathname.endsWith("/issues/comments/999")) return Response.json({ body: "Clean current status" });
+      return new Response(null, { status: 404 });
+    };
+
+    const findings = await auditGithubPublication({
+      apiUrl: "https://api.github.test/",
+      fetcher,
+      number: 421,
+      repo: "example/repository",
+      requireKnownValues: false,
+      surface: { id: 999, kind: "issue_comment" },
+      token: "synthetic-github-audit-token",
+    });
+
+    expect(formatPrivacyReport(findings)).toBe("PRIVACY GATE: PASS\n");
+    expect(requests).toEqual(["/repos/example/repository/issues/comments/999"]);
+  });
+
+  test("keeps triggering issue-comment audits fail closed with class-only diagnostics", async () => {
+    const syntheticIdentifier = ["12345678", "1234", "4abc", "8def", "123456789abc"].join("-");
+    const fetcher = async (input: string | URL): Promise<Response> => {
+      const url = new URL(input);
+      if (url.pathname.endsWith("/issues/comments/999")) {
+        return Response.json({ body: `Sensitive resource ${syntheticIdentifier}` });
+      }
+      return new Response(null, { status: 404 });
+    };
+
+    const findings = await auditGithubPublication({
+      apiUrl: "https://api.github.test/",
+      fetcher,
+      number: 421,
+      repo: "example/repository",
+      requireKnownValues: false,
+      surface: { id: 999, kind: "issue_comment" },
+      token: "synthetic-github-audit-token",
+    });
+    const output = formatPrivacyReport(findings);
+
+    expect(output).toBe("PRIVACY GATE: FAIL\nresource_identifier: 1\n");
+    expect(output).not.toContain(syntheticIdentifier);
   });
 
   test("audits issue titles with class-only diagnostics", async () => {


### PR DESCRIPTION
## Summary
- audit the triggering issue comment for `issue_comment` events
- preserve the full publication scan for other triggers and manual dispatch
- cover clean current comments over contaminated history and fail-closed sensitive comments

## Cause
Every `issue_comment` event rescanned the entire issue history. Historical findings in #420 and #421 made each clean status update fail again and send another notification.

## Verification
- `bun test scripts/privacy-publication-gate.test.ts` — 98 pass
- `bunx tsc --noEmit`
- scoped ESLint
- `bun run privacy:check`
- production-shaped current-comment harnesses for #420 and #421 — PASS
- independent full-diff review — NO FINDINGS

## Test note
The full repository suite exposed an existing order-sensitive `EngineAccountSwitch` shared-store failure. Its isolated test file passes 3/3.