### PR TITLE
fix(runtime): retain handoff acknowledgements across promotions (#253)

### DIFF
--- a/src/lib/runtime/handoffQueue.test.ts
+++ b/src/lib/runtime/handoffQueue.test.ts
@@ -221,6 +221,50 @@ describe("candidate health failure and rollback (protocol step 6)", () => {
     expect(retry.replay.map((d) => d.deliveryId)).toEqual(["d1"]);
   });
 
+  test("rollback preserves acknowledgements inherited from earlier promotions", () => {
+    const { q } = queue();
+    const delivery = (deliveryId: string, seq: number) => ({
+      deliveryId,
+      clientMessageId: `client-${deliveryId}`,
+      seq,
+    });
+
+    q.enqueue([rowInput({
+      operationId: "handoff_blue",
+      pendingDeliveries: [delivery("d1", 1)],
+    })]);
+    q.beginDrain("gen-blue");
+    q.claim("handoff_blue", { fromGeneration: "gen-blue", toGeneration: "gen-green" });
+    expect(q.acknowledgeReplay("handoff_blue", "gen-green", ["d1"])).toBe(true);
+
+    q.enqueue([rowInput({
+      operationId: "handoff_green",
+      hostGeneration: "gen-green",
+      pendingDeliveries: [delivery("d1", 1), delivery("d2", 2)],
+    })]);
+    q.beginDrain("gen-green");
+    q.claim("handoff_green", { fromGeneration: "gen-green", toGeneration: "gen-teal" });
+    expect(q.acknowledgeReplay("handoff_green", "gen-teal", ["d2"])).toBe(true);
+
+    q.failCandidate("gen-teal");
+    expect(q.claim("handoff_green", {
+      fromGeneration: "gen-green",
+      toGeneration: "gen-teal-retry",
+    }).replay.map(({ deliveryId }) => deliveryId)).toEqual(["d2"]);
+    expect(q.acknowledgeReplay("handoff_green", "gen-teal-retry", ["d2"])).toBe(true);
+
+    q.enqueue([rowInput({
+      operationId: "handoff_teal",
+      hostGeneration: "gen-teal-retry",
+      pendingDeliveries: [delivery("d1", 1), delivery("d2", 2), delivery("d3", 3)],
+    })]);
+    q.beginDrain("gen-teal-retry");
+    expect(q.claim("handoff_teal", {
+      fromGeneration: "gen-teal-retry",
+      toGeneration: "gen-purple",
+    }).replay.map(({ deliveryId }) => deliveryId)).toEqual(["d3"]);
+  });
+
   test("outgoing generation is only retirable once every row is claimed, terminal, or explicitly failed", () => {
     const { q } = queue();
     q.enqueue([

--- a/src/lib/runtime/handoffQueue.ts
+++ b/src/lib/runtime/handoffQueue.ts
@@ -63,7 +63,7 @@ export interface HandoffRow extends HandoffRowInput {
   predecessorGeneration: string | null;
   /** Generation that claimed the row; the terminal predecessor -> successor link. */
   successorGeneration: string | null;
-  /** Delivery ids acknowledged by the successor after idempotent delivery. */
+  /** Delivery ids acknowledged by every successor in the promotion chain. */
   replayedDeliveryIds: string[];
   interruptionOutcome: HandoffInterruptionOutcome | null;
   lastError: string | null;
@@ -163,6 +163,15 @@ function replacementDeliveries(previous: HandoffRow, incoming: readonly HandoffD
     .map((delivery, index) => ({ ...delivery, seq: index + 1 }));
 }
 
+function acknowledgedDeliveryIds(
+  history: readonly HandoffRow[],
+  conversationId: string,
+): string[] {
+  return [...new Set(history
+    .filter((row) => row.conversationId === conversationId)
+    .flatMap((row) => row.replayedDeliveryIds))];
+}
+
 function terminalStatusFor(turnState: HandoffTurnState): HandoffStatus {
   return turnState === "terminal" ? "terminal" : "claimed";
 }
@@ -245,7 +254,7 @@ export class HandoffQueue {
           status: "pending",
           predecessorGeneration: null,
           successorGeneration: null,
-          replayedDeliveryIds: [],
+          replayedDeliveryIds: acknowledgedDeliveryIds(state.history, input.conversationId),
           interruptionOutcome: null,
           lastError: null,
           enqueuedAt: now,
@@ -383,7 +392,7 @@ export class HandoffQueue {
         row.status = predecessor && drainingGenerations.has(predecessor) ? "draining" : "pending";
         row.predecessorGeneration = null;
         row.successorGeneration = null;
-        row.replayedDeliveryIds = [];
+        row.replayedDeliveryIds = acknowledgedDeliveryIds(state.history, row.conversationId);
         row.interruptionOutcome = null;
         row.updatedAt = now;
       }

--- a/src/lib/runtime/handoffQueueStore.test.ts
+++ b/src/lib/runtime/handoffQueueStore.test.ts
@@ -170,6 +170,58 @@ test("SQLite restart keeps one active conversation lease and its completed hando
   }
 });
 
+test("three promotions retain every durable replay acknowledgement across restarts", () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-handoff-queue-three-promotions-"));
+  const filename = path.join(directory, "handoff-queue.sqlite");
+  const delivery = (id: string, seq: number) => ({ deliveryId: id, clientMessageId: `client-${id}`, seq });
+
+  try {
+    const blue = new HandoffQueue(new SqliteHandoffQueueStore(filename));
+    blue.enqueue([rowInput({
+      operationId: "handoff_root_blue",
+      hostGeneration: "gen-blue",
+      pendingDeliveries: [delivery("d1", 1)],
+    })]);
+    blue.beginDrain("gen-blue");
+    expect(blue.claim("handoff_root_blue", {
+      fromGeneration: "gen-blue",
+      toGeneration: "gen-green",
+    }).replay.map(({ deliveryId }) => deliveryId)).toEqual(["d1"]);
+    expect(blue.acknowledgeReplay("handoff_root_blue", "gen-green", ["d1"])).toBe(true);
+
+    const green = new HandoffQueue(new SqliteHandoffQueueStore(filename));
+    green.enqueue([rowInput({
+      operationId: "handoff_root_green",
+      hostGeneration: "gen-green",
+      pendingDeliveries: [delivery("d1", 1), delivery("d2", 2)],
+    })]);
+    green.beginDrain("gen-green");
+    expect(green.claim("handoff_root_green", {
+      fromGeneration: "gen-green",
+      toGeneration: "gen-teal",
+    }).replay.map(({ deliveryId }) => deliveryId)).toEqual(["d2"]);
+    expect(green.acknowledgeReplay("handoff_root_green", "gen-teal", ["d2"])).toBe(true);
+
+    const teal = new HandoffQueue(new SqliteHandoffQueueStore(filename));
+    teal.enqueue([rowInput({
+      operationId: "handoff_root_teal",
+      hostGeneration: "gen-teal",
+      pendingDeliveries: [delivery("d1", 1), delivery("d2", 2), delivery("d3", 3)],
+    })]);
+    teal.beginDrain("gen-teal");
+    expect(teal.claim("handoff_root_teal", {
+      fromGeneration: "gen-teal",
+      toGeneration: "gen-purple",
+    }).replay.map(({ deliveryId }) => deliveryId)).toEqual(["d3"]);
+    expect(teal.history().map((row) => row.operationId)).toEqual([
+      "handoff_root_blue",
+      "handoff_root_green",
+    ]);
+  } finally {
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});
+
 test("SQLite restart preserves a drain-window turn refresh before claim", () => {
   const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-handoff-queue-turn-"));
   const filename = path.join(directory, "handoff-queue.sqlite");


### PR DESCRIPTION
## Summary

- retain cumulative acknowledgement fences from durable completed handoff history
- preserve those fences across candidate replacement and rollback
- recover older persisted chains during their next promotion
- add deterministic three-promotion and SQLite restart regressions

## Production context

PR #476 entered `main` at `7389a145991bb05b7818dee294f8c5c61c96fe3f`. Production remains pinned to `6ae55a113122b6da7a543ed6f4571c875f150c2d` until this repair passes review and release gates.

## Verification

- RED on `7389a145`: third promotion replayed `d1` together with `d3`
- GREEN on `7214119b`: third promotion emits only `d3`
- focused queue/store suites: 32 tests, 127 assertions
- TypeScript: passed
- scoped ESLint: passed
- diff check: passed
- fresh exact-head review: running in pipeline `4f8620c9`

Relates #253.
