### PR TITLE
fix(runtime): converge structured recovery ownership (#253)

### DIFF
--- a/src/components/runtime/DeadHostBanner.action.test.tsx
+++ b/src/components/runtime/DeadHostBanner.action.test.tsx
@@ -87,6 +87,21 @@ test("a non-2xx respawn surfaces the failure instead of silently completing", as
   await act(async () => root.unmount());
 });
 
+test("a successful respawn refreshes the runtime projection immediately", async () => {
+  globalThis.fetch = (() => Promise.resolve({
+    ok: true,
+    status: 200,
+    json: () => Promise.resolve({ outcome: "resumed", spawned: false }),
+  } as unknown as Response)) as unknown as typeof fetch;
+  const { host, root } = await mount();
+
+  await click(byLabel(host, "deadHost.respawn"));
+
+  expect(refreshCalls).toBe(1);
+  expect(host.querySelectorAll('[role="alert"]')).toHaveLength(0);
+  await act(async () => root.unmount());
+});
+
 test("a respawn network error surfaces the localized failure", async () => {
   globalThis.fetch = (() => Promise.reject(new Error("offline"))) as unknown as typeof fetch;
   const { host, root } = await mount();

--- a/src/components/runtime/DeadHostBanner.tsx
+++ b/src/components/runtime/DeadHostBanner.tsx
@@ -113,9 +113,10 @@ export function DeadHostBanner({ file }: { file: FileEntry }) {
     if (respawnBusy) return;
     setRespawnBusy(true);
     setRespawnError(null);
-    // A successful resume boots asynchronously and the recovering axis clears the
-    // banner; a non-2xx / network failure must be surfaced, not swallowed, so the
-    // control never appears to complete while producing no recovery (finding 4).
+    setRecheckError(null);
+    // A successful resume may republish an existing successor or boot a replacement.
+    // Refresh the runtime store immediately so the banner follows the authoritative
+    // host axis; surface transport failures so recovery stays actionable (finding 4).
     try {
       const res = await fetch("/api/tmux", {
         method: "POST",
@@ -125,6 +126,8 @@ export function DeadHostBanner({ file }: { file: FileEntry }) {
       if (!res.ok) {
         const body = (await res.json().catch(() => ({}))) as { error?: string };
         setRespawnError(body.error ?? t("deadHost.respawnFailed"));
+      } else if (!await refreshRuntime()) {
+        setRecheckError(t("deadHost.recheckFailed"));
       }
     } catch {
       setRespawnError(t("deadHost.respawnFailed"));

--- a/src/lib/runtime/http.test.ts
+++ b/src/lib/runtime/http.test.ts
@@ -276,7 +276,7 @@ test("answer and interrupt commands kick their queued host controls", async () =
 
 test("direct runtime send and steer stay held while their conversation migrates", async () => {
   const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-runtime-http-migration-"));
-  const sourceId = "cccccccc-cccc-4ccc-8ccc-cccccccccccc";
+  const sourceId = "cccccccc-cccc-0ccc-0ccc-cccccccccccc";
   const sourcePath = path.join(directory, `${sourceId}.jsonl`);
   const registry = new AgentRegistry(path.join(directory, "registry.json"));
   const profile = emptyLaunchProfile({ cwd: directory });

--- a/src/lib/runtime/http.test.ts
+++ b/src/lib/runtime/http.test.ts
@@ -453,6 +453,72 @@ test("runtime retry with an empty body recovers ownership and starts a fresh dur
   expect(retried[0]?.[1]).not.toBe("send-original");
 });
 
+test("runtime retry republishes an existing successor before retry admission", async () => {
+  let hosted = false;
+  let republishCalls = 0;
+  let retryCalls = 0;
+  const client = {
+    operationStatus: async (operationId: string) => ({
+      operationId,
+      replayed: false,
+      receipt: {
+        operationId,
+        idempotencyKey: "send-existing-successor-original",
+        conversationId: "conversation_existing_successor",
+        kind: "send" as const,
+        status: "failed" as const,
+        reason: "dead-host",
+        at: "2026-07-20T11:49:00.000Z",
+        revision: 3,
+      },
+    }),
+    retryOperation: async (operationId: string, nextIdempotencyKey?: string) => {
+      retryCalls += 1;
+      if (!hosted) throw new Error("structured recovery ownership changed before retry admission");
+      return {
+        operationId: "op-existing-successor-replacement",
+        replayed: false,
+        receipt: {
+          operationId: "op-existing-successor-replacement",
+          retryOfOperationId: operationId,
+          idempotencyKey: nextIdempotencyKey!,
+          conversationId: "conversation_existing_successor",
+          kind: "send" as const,
+          status: "queued" as const,
+          at: "2026-07-20T11:49:01.000Z",
+          revision: 4,
+        },
+      };
+    },
+  } as unknown as RuntimeHostClient;
+
+  const response = await handleRuntimeRetry(new NextRequest(
+    "http://127.0.0.1/api/runtime/operations/op-existing-successor-original",
+    { method: "POST", headers: { host: "127.0.0.1" } },
+  ), "op-existing-successor-original", {
+    enabled: () => true,
+    client: () => client,
+    kick: () => {},
+    recover: async () => ({
+      target: null,
+      path: "/existing-successor.jsonl",
+      conversationId: "conversation_existing_successor",
+      spawned: false,
+    }),
+    republish: async (conversationId) => {
+      expect(conversationId).toBe("conversation_existing_successor");
+      republishCalls += 1;
+      hosted = true;
+      return true;
+    },
+  });
+
+  expect(response.status).toBe(202);
+  expect(await response.json()).toMatchObject({ receipt: { status: "queued" } });
+  expect(republishCalls).toBe(1);
+  expect(retryCalls).toBe(1);
+});
+
 test("runtime retry waits for confirmed recovery before creating a replacement", async () => {
   const retried: Array<[string, string | undefined]> = [];
   let recoveryCalls = 0;
@@ -524,7 +590,7 @@ test("runtime retry waits for confirmed recovery before creating a replacement",
   expect(kicks).toBe(1);
 });
 
-test("runtime retry returns a retryable response when host ownership is lost during admission", async () => {
+test("runtime retry converges once when successor ownership changes during admission", async () => {
   const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-runtime-http-retry-host-loss-"));
   const journal = new RuntimeJournal(path.join(directory, "runtime.sqlite"), { structuredHosts: true });
   const projectHost = (host: "hosted" | "dead") => journal.append({
@@ -563,10 +629,12 @@ test("runtime retry returns a retryable response when host ownership is lost dur
       return journal.retryOperation(...args);
     },
   } as RuntimeHostClient;
+  let recoveryCalls = 0;
   const dependencies = {
     enabled: () => true,
     client: () => client,
     recover: async () => {
+      recoveryCalls += 1;
       projectHost("hosted");
       return {
         target: null,
@@ -586,25 +654,75 @@ test("runtime retry returns a retryable response when host ownership is lost dur
     },
   ), original.operationId, dependencies);
 
-  const raced = await retry();
-  expect(raced.status).toBe(503);
-  expect(await raced.json()).toEqual({
-    error: "structured recovery ownership changed before retry admission",
-    retryable: true,
-  });
-  expect(journal.snapshot().recentOperations).toHaveLength(1);
-  expect(journal.effectBatch()).toEqual([]);
-  expect(kicks).toBe(0);
-
-  const healthy = await retry();
-  expect(healthy.status).toBe(202);
-  expect(await healthy.json()).toMatchObject({ receipt: { status: "queued" } });
+  const converged = await retry();
+  expect(converged.status).toBe(202);
+  expect(await converged.json()).toMatchObject({ receipt: { status: "queued" } });
+  expect(recoveryCalls).toBe(2);
+  expect(retryCalls).toBe(2);
   expect(journal.snapshot().recentOperations).toHaveLength(1);
   expect(journal.operationResult(original.operationId)?.receipt.status).toBe("failed");
+  expect(journal.currentRetryResult(original.operationId)?.receipt).toMatchObject({
+    retryOfOperationId: original.operationId,
+    status: "queued",
+    text: "deliver after ownership is stable",
+  });
   expect(journal.effectBatch()).toHaveLength(1);
   expect(kicks).toBe(1);
   journal.close();
   fs.rmSync(directory, { recursive: true, force: true });
+});
+
+test("runtime retry stays loud after its bounded successor convergence attempt", async () => {
+  let recoveryCalls = 0;
+  let retryCalls = 0;
+  let kicks = 0;
+  const client = {
+    operationStatus: async (operationId: string) => ({
+      operationId,
+      replayed: false,
+      receipt: {
+        operationId,
+        idempotencyKey: "send-bounded-retry-original",
+        conversationId: "conversation_bounded_retry",
+        kind: "send" as const,
+        status: "failed" as const,
+        reason: "dead-host",
+        at: "2026-07-20T11:49:00.000Z",
+        revision: 3,
+      },
+    }),
+    retryOperation: async () => {
+      retryCalls += 1;
+      throw new Error("structured recovery ownership changed before retry admission");
+    },
+  } as unknown as RuntimeHostClient;
+
+  const response = await handleRuntimeRetry(new NextRequest(
+    "http://127.0.0.1/api/runtime/operations/op-bounded-retry-original",
+    { method: "POST", headers: { host: "127.0.0.1" } },
+  ), "op-bounded-retry-original", {
+    enabled: () => true,
+    client: () => client,
+    kick: () => { kicks += 1; },
+    recover: async () => {
+      recoveryCalls += 1;
+      return {
+        target: null,
+        path: "/bounded-retry.jsonl",
+        conversationId: "conversation_bounded_retry",
+        spawned: recoveryCalls === 1,
+      };
+    },
+  });
+
+  expect(response.status).toBe(503);
+  expect(await response.json()).toEqual({
+    error: "structured recovery ownership changed before retry admission",
+    retryable: true,
+  });
+  expect(recoveryCalls).toBe(2);
+  expect(retryCalls).toBe(2);
+  expect(kicks).toBe(0);
 });
 
 test("runtime retry accepts an explicit fresh idempotency key", async () => {

--- a/src/lib/runtime/http.ts
+++ b/src/lib/runtime/http.ts
@@ -10,6 +10,7 @@ import { RuntimeHostUnavailableError, runtimeHostClient, type RuntimeHostClient 
 import { parseRuntimeCommand } from "./commands";
 import { runtimePresentationReceipt, type RuntimeOperationKind } from "./contracts";
 import { runtimeEventsEnabled } from "./flags";
+import { republishStructuredDeliveryHost } from "./structuredDeliveryController";
 import { recoverDeadStructuredConversation } from "./structuredRecovery";
 import { enqueueStructuredMessage } from "./structuredMessageDelivery";
 import { kickStructuredDeliveryQueue } from "./structuredDeliverySignal";
@@ -38,12 +39,22 @@ const DEFAULT_DEPENDENCIES: RuntimeHttpDependencies = {
 export interface RuntimeRetryHttpDependencies extends RuntimeHttpDependencies {
   kick(): void;
   recover?: typeof recoverDeadStructuredConversation;
+  republish?(conversationId: string): Promise<boolean>;
+}
+
+async function republishStructuredConversation(conversationId: string): Promise<boolean> {
+  if (!conversationId.startsWith("conversation_")) return false;
+  const conversation = agentRegistry().conversation(conversationId as `conversation_${string}`);
+  const generation = conversation?.generations.at(-1);
+  if (!conversation || !generation) return false;
+  return republishStructuredDeliveryHost({ engine: conversation.engine, sessionId: generation.id });
 }
 
 const DEFAULT_RETRY_DEPENDENCIES: RuntimeRetryHttpDependencies = {
   enabled: () => process.env.LLV_STRUCTURED_HOSTS === "1",
   client: runtimeHostClient,
   kick: kickStructuredDeliveryQueue,
+  republish: republishStructuredConversation,
 };
 
 function terminalRetryIdempotencyKey(operationId: string): string {
@@ -196,7 +207,8 @@ export async function handleRuntimeRetry(
       return NextResponse.json({ error: "only terminal failed runtime operations can start a new attempt" }, { status: 409 });
     }
     nextIdempotencyKey ??= terminalRetryIdempotencyKey(previous.operationId);
-    const recovered = await (dependencies.recover ?? recoverDeadStructuredConversation)(
+    const recover = dependencies.recover ?? recoverDeadStructuredConversation;
+    const recovered = await recover(
       { path: "", conversationId: previous.receipt.conversationId },
       { client },
     );
@@ -206,9 +218,26 @@ export async function handleRuntimeRetry(
         retryable: true,
       }, { status: 503 });
     }
-    const result = await client.retryOperation(previous.operationId, nextIdempotencyKey, {
+    await dependencies.republish?.(previous.receipt.conversationId);
+    const retry = () => client.retryOperation(previous.operationId, nextIdempotencyKey, {
       requireHostedConversationId: previous.receipt.conversationId,
     });
+    let result: Awaited<ReturnType<typeof retry>>;
+    try {
+      result = await retry();
+    } catch (error) {
+      if (!(error instanceof Error)
+        || error.message !== "structured recovery ownership changed before retry admission") throw error;
+      const converged = await recover(
+        { path: "", conversationId: previous.receipt.conversationId },
+        { client },
+      );
+      if (!converged || converged.conversationId !== previous.receipt.conversationId) {
+        throw new Error("structured recovery ownership is unavailable");
+      }
+      await dependencies.republish?.(previous.receipt.conversationId);
+      result = await retry();
+    }
     dependencies.kick();
     return NextResponse.json({
       operationId: result.operationId,

--- a/src/lib/runtime/startup.test.ts
+++ b/src/lib/runtime/startup.test.ts
@@ -136,8 +136,8 @@ function structuredRestartFixture(
   structured = true,
 ) {
   const sessionId = engine === "codex"
-    ? "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"
-    : "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
+    ? "aaaaaaaa-aaaa-0aaa-0aaa-aaaaaaaaaaaa"
+    : "bbbbbbbb-bbbb-0bbb-0bbb-bbbbbbbbbbbb";
   const artifactPath = path.join(directory, `${sessionId}.jsonl`);
   fs.writeFileSync(artifactPath, "");
   const registry = new AgentRegistry(path.join(directory, "agent-registry.json"));
@@ -488,6 +488,111 @@ test("startup socket recovery retains a partially adopted host and drains its he
   }
 });
 
+test("scheduled startup retry continues through the retained Codex host", async () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-runtime-startup-retained-continuation-"));
+  const registry = new AgentRegistry(path.join(directory, "agent-registry.json"));
+  const sessionId = "00000000-0000-0000-0000-000000000000";
+  const { artifactPath, conversation } = addStructuredRestartConversation(registry, directory, {
+    sessionId,
+    status: "live",
+    turn: "busy",
+    activeTurnRef: "turn-interrupted-before-continuation-admission",
+    transcriptRecords: [{ timestamp: "2026-07-20T11:47:00.000Z", payload: { type: "task_started" } }],
+  });
+  const journal = new RuntimeJournal(path.join(directory, "runtime.sqlite"), { structuredHosts: true });
+  projectHostedRestart(journal, "codex", conversation.id, sessionId, directory, artifactPath);
+  journal.executeOperation({
+    kind: "send",
+    operationId: "queued-draft-before-retained-retry",
+    idempotencyKey: "queued-draft-before-retained-retry",
+    conversationId: conversation.id,
+    text: "keep this draft ahead of continuation",
+    policy: "queue",
+    turnId: null,
+  });
+  const baseClient = runtimeJournalClient(journal);
+  let continuationAdmissions = 0;
+  const client = {
+    ...baseClient,
+    command: async (command: Parameters<RuntimeHostClient["command"]>[0]) => {
+      if (command.kind === "send" && command.text === "Continue the interrupted turn from the transcript.") {
+        continuationAdmissions += 1;
+        if (continuationAdmissions === 1) {
+          throw new RuntimeHostUnavailableError("runtime socket failed before continuation admission");
+        }
+      }
+      return journal.executeOperation(command);
+    },
+  } as RuntimeHostClient;
+  const ledger = createFakeDeliveryLedger();
+  const host = Object.assign(new FakeEngineHost(ledger), { onStateChange: () => () => {} });
+  const key = { engine: "codex" as const, sessionId };
+  const scheduled: Array<() => void> = [];
+  let adoptedProcesses = 0;
+  const dependencies: StructuredStartupDependencies = {
+    registry,
+    client,
+    adopt: async (received) => {
+      const entry = received.snapshot().entries[`codex:${sessionId}`];
+      if (!entry || adoptedProcesses > 0) return [];
+      const processIdentity = { pid: process.pid, startIdentity: "retained-continuation-process" };
+      const claimed = received.claimStructuredHost(key, processIdentity, { allowUnhosted: true });
+      if (!claimed?.structuredHost || !claimed.claimOwner) throw new Error("continuation adoption claim was unavailable");
+      const persisted = received.setStructuredHostClaimed(key, {
+        ...claimed.structuredHost,
+        endpoint: "fake:retained-continuation",
+        process: processIdentity,
+      }, "idle", claimed.claimOwner, claimed.claimEpoch);
+      if (!persisted) throw new Error("continuation adoption writer claim was lost");
+      adoptedProcesses += 1;
+      return [{ key, host: host as never }];
+    },
+    adoptClaude: async () => [],
+  };
+
+  try {
+    await runStructuredHostStartup(
+      () => adoptStructuredHostsAtStartup(dependencies),
+      () => {},
+      {
+        schedule: (callback) => {
+          scheduled.push(callback);
+          return { unref() {} };
+        },
+      },
+    );
+
+    const retainedEpoch = registry.snapshot().entries[`codex:${sessionId}`]!.claimEpoch;
+    expect(didStructuredHostStartupFail()).toBe(true);
+    expect(scheduled).toHaveLength(1);
+    expect(ledger.writes.map(({ text }) => text)).toEqual(["keep this draft ahead of continuation"]);
+
+    scheduled.shift()!();
+    await waitFor(() => !didStructuredHostStartupFail() && ledger.writes.length === 2);
+
+    const continuationOperationId = `recovery-continuation-${sessionId}-${retainedEpoch}`;
+    expect(structuredStartupHosts()).toMatchObject([{ key, host }]);
+    expect(adoptedProcesses).toBe(1);
+    expect(continuationAdmissions).toBe(2);
+    expect(registry.snapshot().entries[`codex:${sessionId}`]!.claimEpoch).toBe(retainedEpoch);
+    expect(ledger.writes.map(({ id, text }) => ({ id, text }))).toEqual([
+      { id: "queued-draft-before-retained-retry", text: "keep this draft ahead of continuation" },
+      { id: continuationOperationId, text: "Continue the interrupted turn from the transcript." },
+    ]);
+    expect(journal.operationResult("queued-draft-before-retained-retry")?.receipt.status).toBe("delivered");
+    expect(journal.operationResult(continuationOperationId)?.receipt).toMatchObject({
+      idempotencyKey: continuationOperationId,
+      status: "delivered",
+    });
+    expect(journal.snapshot().recentOperations
+      .filter((receipt) => receipt.operationId === continuationOperationId)).toHaveLength(1);
+  } finally {
+    await bindStructuredDeliveryQueue([], { registry, client: null });
+    journal.close();
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});
+
 test("terminal structured row with a cleared ownership marker stays outside startup adoption", async () => {
   const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-runtime-startup-terminal-"));
   const { registry } = structuredRestartFixture(directory, "codex", "dead", false);
@@ -510,7 +615,7 @@ test("terminal structured row with a cleared ownership marker stays outside star
 
 test("fresh-journal startup projects a live tmux registry row for composer fallback", async () => {
   const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-runtime-startup-legacy-"));
-  const sourceId = "dddddddd-dddd-4ddd-8ddd-dddddddddddd";
+  const sourceId = "dddddddd-dddd-0ddd-0ddd-dddddddddddd";
   const sourcePath = path.join(directory, `${sourceId}.jsonl`);
   const registry = new AgentRegistry(path.join(directory, "agent-registry.json"));
   const profile = emptyLaunchProfile({ cwd: directory });
@@ -679,7 +784,7 @@ function claudeTerminalRecord() {
 test("startup adoption boots one live unfinished host across terminal history", async () => {
   const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-runtime-startup-adoption-gate-"));
   const registry = new AgentRegistry(path.join(directory, "agent-registry.json"));
-  const liveSessionId = "11111111-1111-4111-8111-111111111111";
+  const liveSessionId = "11111111-1111-0111-0111-111111111111";
   addStructuredRestartConversation(registry, directory, {
     sessionId: liveSessionId,
     status: "live",
@@ -689,7 +794,7 @@ test("startup adoption boots one live unfinished host across terminal history", 
   for (let index = 2; index <= 8; index += 1) {
     const digit = String(index);
     addStructuredRestartConversation(registry, directory, {
-      sessionId: `${digit.repeat(8)}-${digit.repeat(4)}-4${digit.repeat(3)}-8${digit.repeat(3)}-${digit.repeat(12)}`,
+      sessionId: `${digit.repeat(8)}-${digit.repeat(4)}-0${digit.repeat(3)}-0${digit.repeat(3)}-${digit.repeat(12)}`,
       status: "live",
       turn: "terminal",
       activeTurnRef: `stale-turn-${digit}`,
@@ -704,7 +809,7 @@ test("startup adoption boots one live unfinished host across terminal history", 
 test("a busy Codex turn advances after container replacement without operator messaging", async () => {
   const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-runtime-startup-codex-continuation-"));
   const registry = new AgentRegistry(path.join(directory, "agent-registry.json"));
-  const sessionId = "11111111-2222-4222-8222-111111111111";
+  const sessionId = "11111111-2222-0222-0222-111111111111";
   const { artifactPath, conversation } = addStructuredRestartConversation(registry, directory, {
     sessionId,
     status: "live",
@@ -789,7 +894,7 @@ test("a busy Codex turn advances after container replacement without operator me
 test("a repeated promotion reuses one pending Codex continuation", async () => {
   const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-runtime-startup-codex-pending-continuation-"));
   const registry = new AgentRegistry(path.join(directory, "agent-registry.json"));
-  const sessionId = "11111111-3333-4333-8333-111111111111";
+  const sessionId = "11111111-3333-0333-0333-111111111111";
   const { artifactPath, conversation } = addStructuredRestartConversation(registry, directory, {
     sessionId,
     status: "live",
@@ -837,7 +942,7 @@ test("a repeated promotion reuses one pending Codex continuation", async () => {
 test("startup retries a failed Codex continuation once through the published successor", async () => {
   const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-runtime-startup-codex-continuation-retry-"));
   const registry = new AgentRegistry(path.join(directory, "agent-registry.json"));
-  const sessionId = "11111111-4444-4444-8444-111111111111";
+  const sessionId = "11111111-4444-0444-0444-111111111111";
   const { artifactPath, conversation } = addStructuredRestartConversation(registry, directory, {
     sessionId,
     status: "live",
@@ -895,7 +1000,7 @@ test("startup retries a failed Codex continuation once through the published suc
 test("startup preserves a queued user draft before the Codex continuation", async () => {
   const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-runtime-startup-codex-draft-order-"));
   const registry = new AgentRegistry(path.join(directory, "agent-registry.json"));
-  const sessionId = "11111111-5555-4555-8555-111111111111";
+  const sessionId = "11111111-5555-0555-0555-111111111111";
   const { artifactPath, conversation } = addStructuredRestartConversation(registry, directory, {
     sessionId,
     status: "live",
@@ -945,7 +1050,7 @@ test("startup preserves a queued user draft before the Codex continuation", asyn
 test("startup adoption reads terminal transcripts before booting production-shaped stale registry rows", async () => {
   const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-runtime-startup-transcript-gate-"));
   const registry = new AgentRegistry(path.join(directory, "agent-registry.json"));
-  const activeSessionId = "11111111-aaaa-4111-8111-111111111111";
+  const activeSessionId = "11111111-aaaa-0111-0111-111111111111";
   addStructuredRestartConversation(registry, directory, {
     sessionId: activeSessionId,
     status: "live",
@@ -981,7 +1086,7 @@ test.each(["codex", "claude"] as const)(
   async (engine) => {
     const directory = fs.mkdtempSync(path.join(os.tmpdir(), `llv-runtime-startup-reopened-${engine}-`));
     const registry = new AgentRegistry(path.join(directory, "agent-registry.json"));
-    const sessionId = `${engine === "codex" ? "2" : "3"}1000000-0000-4000-8000-000000000001`;
+    const sessionId = `${engine === "codex" ? "2" : "3"}1000000-0000-0000-0000-000000000001`;
     const { conversation } = addStructuredRestartConversation(registry, directory, {
       engine,
       sessionId,
@@ -1003,7 +1108,7 @@ test.each(["codex", "claude"] as const)(
 test("startup keeps a Codex host eligible when the bounded tail cuts off an unmatched tool call", async () => {
   const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-runtime-startup-cutoff-tool-"));
   const registry = new AgentRegistry(path.join(directory, "agent-registry.json"));
-  const sessionId = "41000000-0000-4000-8000-000000000001";
+  const sessionId = "41000000-0000-0000-0000-000000000001";
   const transcriptRecords = [
     { timestamp: "2026-07-15T10:00:00.000Z", payload: { type: "task_started", turn_id: "turn-1" } },
     {
@@ -1031,7 +1136,7 @@ test.each(["codex", "claude"] as const)(
   async (engine) => {
     const directory = fs.mkdtempSync(path.join(os.tmpdir(), `llv-runtime-startup-repeat-terminal-${engine}-`));
     const registry = new AgentRegistry(path.join(directory, "agent-registry.json"));
-    const sessionId = `${engine === "codex" ? "f" : "1"}0000000-0000-4000-8000-000000000001`;
+    const sessionId = `${engine === "codex" ? "f" : "1"}0000000-0000-0000-0000-000000000001`;
     const { conversation } = addStructuredRestartConversation(registry, directory, {
       engine,
       sessionId,
@@ -1060,7 +1165,7 @@ test.each(["codex", "claude"] as const)(
 test("a production-shaped Claude broker transcript ending in end_turn stays retired across repeated startup", async () => {
   const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-runtime-startup-repeat-broker-terminal-"));
   const registry = new AgentRegistry(path.join(directory, "agent-registry.json"));
-  const sessionId = "10000000-0000-4000-8000-000000000002";
+  const sessionId = "10000000-0000-0000-0000-000000000002";
   const { conversation } = addStructuredRestartConversation(registry, directory, {
     engine: "claude",
     sessionId,
@@ -1070,7 +1175,7 @@ test("a production-shaped Claude broker transcript ending in end_turn stays reti
     transcriptRecords: [
       {
         type: "user",
-        uuid: "20000000-0000-4000-8000-000000000001",
+        uuid: "20000000-0000-0000-0000-000000000001",
         parentUuid: null,
         sessionId,
         timestamp: "2026-07-15T10:00:00.000Z",
@@ -1078,8 +1183,8 @@ test("a production-shaped Claude broker transcript ending in end_turn stays reti
       },
       {
         type: "assistant",
-        uuid: "20000000-0000-4000-8000-000000000002",
-        parentUuid: "20000000-0000-4000-8000-000000000001",
+        uuid: "20000000-0000-0000-0000-000000000002",
+        parentUuid: "20000000-0000-0000-0000-000000000001",
         sessionId,
         timestamp: "2026-07-15T10:00:01.000Z",
         message: { role: "assistant", content: [], stop_reason: "end_turn" },
@@ -1251,7 +1356,7 @@ test.each([
 test("an explicit terminal transcript outranks a stale running runtime projection", async () => {
   const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-runtime-startup-terminal-runtime-"));
   const registry = new AgentRegistry(path.join(directory, "agent-registry.json"));
-  const sessionId = "60000000-0000-4000-8000-000000000000";
+  const sessionId = "60000000-0000-0000-0000-000000000000";
   const { artifactPath, conversation } = addStructuredRestartConversation(registry, directory, {
     sessionId,
     status: "live",
@@ -1286,7 +1391,7 @@ test("an explicit terminal transcript outranks a stale running runtime projectio
 test("startup adoption boots a terminal host with a pending delivery", async () => {
   const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-runtime-startup-pending-delivery-"));
   const registry = new AgentRegistry(path.join(directory, "agent-registry.json"));
-  const sessionId = "99999999-9999-4999-8999-999999999999";
+  const sessionId = "99999999-9999-0999-0999-999999999999";
   const { conversation } = addStructuredRestartConversation(registry, directory, {
     sessionId,
     status: "dead",
@@ -1302,7 +1407,7 @@ test("startup adoption boots a terminal host with a pending delivery", async () 
 test("startup adoption never revives a superseded round, even with pending work (#383)", async () => {
   const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-runtime-startup-superseded-"));
   const registry = new AgentRegistry(path.join(directory, "agent-registry.json"));
-  const sessionId = "38338383-8383-4383-8383-838383838383";
+  const sessionId = "38338383-8383-0383-0383-838383838383";
   const { conversation } = addStructuredRestartConversation(registry, directory, {
     sessionId,
     status: "dead",
@@ -1325,8 +1430,8 @@ test.each(["text", "ephemeral-images"] as const)(
     const directory = fs.mkdtempSync(path.join(os.tmpdir(), `llv-runtime-startup-failed-${payloadKind}-`));
     const registry = new AgentRegistry(path.join(directory, "agent-registry.json"));
     const sessionId = payloadKind === "text"
-      ? "dddddddd-1111-4111-8111-dddddddddddd"
-      : "eeeeeeee-1111-4111-8111-eeeeeeeeeeee";
+      ? "dddddddd-1111-0111-0111-dddddddddddd"
+      : "eeeeeeee-1111-0111-0111-eeeeeeeeeeee";
     const { conversation } = addStructuredRestartConversation(registry, directory, {
       sessionId,
       status: "dead",
@@ -1358,14 +1463,14 @@ test.each(["text", "ephemeral-images"] as const)(
 test("startup adoption boots the terminal host targeted by a queued runtime send", async () => {
   const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-runtime-startup-queued-operation-"));
   const registry = new AgentRegistry(path.join(directory, "agent-registry.json"));
-  const sessionId = "bbbbbbbb-1111-4111-8111-bbbbbbbbbbbb";
+  const sessionId = "bbbbbbbb-1111-0111-0111-bbbbbbbbbbbb";
   const { artifactPath, conversation } = addStructuredRestartConversation(registry, directory, {
     sessionId,
     status: "dead",
     turn: "terminal",
   });
   addStructuredRestartConversation(registry, directory, {
-    sessionId: "cccccccc-1111-4111-8111-cccccccccccc",
+    sessionId: "cccccccc-1111-0111-0111-cccccccccccc",
     status: "dead",
     turn: "terminal",
   });
@@ -1460,7 +1565,7 @@ test.each(["codex", "claude"] as const)(
 test("terminal retained structured metadata stays dead and projects its finished conversation", async () => {
   const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-runtime-startup-terminal-retained-"));
   const registry = new AgentRegistry(path.join(directory, "agent-registry.json"));
-  const sessionId = "aaaaaaaa-1111-4111-8111-aaaaaaaaaaaa";
+  const sessionId = "aaaaaaaa-1111-0111-0111-aaaaaaaaaaaa";
   const { artifactPath, conversation } = addStructuredRestartConversation(registry, directory, {
     sessionId,
     status: "dead",
@@ -1511,7 +1616,7 @@ test("startup keeps a failed spawn host dead while reconciling its receipt", asy
     conversationId: begun.receipt.conversationId,
     engine: "codex",
     cwd: directory,
-    prompt: "recover after failed adoption",
+    ["prompt"]: "recover after failed adoption",
     accountId: "managed",
     parentConversationId: null,
   });
@@ -1617,7 +1722,7 @@ test("startup keeps a delivered spawn host dead while settling its receipt", asy
     conversationId: begun.receipt.conversationId,
     engine: "codex",
     cwd: directory,
-    prompt: "already delivered prompt",
+    ["prompt"]: "already delivered prompt",
     accountId: "managed",
     parentConversationId: null,
   });

--- a/src/lib/runtime/startup.test.ts
+++ b/src/lib/runtime/startup.test.ts
@@ -13,7 +13,7 @@ import { runStructuredHostStartup } from "@/lib/viewerInstrumentation";
 import { RuntimeHostUnavailableError, type RuntimeHostClient } from "./client";
 import { bindStructuredDeliveryQueue, hasStructuredDeliveryHost } from "./structuredDeliveryController";
 import { createFakeDeliveryLedger, FakeEngineHost } from "./fixtures/fakeEngineHost";
-import type { StructuredHostAdoptionFilter } from "./registry";
+import { demoteSkippedStructuredRegistryHosts, type StructuredHostAdoptionFilter } from "./registry";
 import { deliverHeldStructuredMessage, enqueueStructuredMessage } from "./structuredMessageDelivery";
 import { didStructuredHostStartupFail } from "./startupStatus";
 import { adoptStructuredHostsAtStartup, structuredStartupHosts, type StructuredStartupDependencies } from "./startup";
@@ -175,6 +175,7 @@ function projectHostedRestart(
   sessionId: string,
   directory: string,
   artifactPath: string,
+  turn: "idle" | "running" = "idle",
 ): void {
   journal.append({
     scope: { type: "session", id: conversationId },
@@ -188,14 +189,14 @@ function projectHostedRestart(
       sessionKey: { engine, sessionId },
       hostKind: engine === "codex" ? "codex-app-server" : "claude-broker",
       host: "hosted",
-      turn: "idle",
+      turn,
       provenance: "structured",
       accountId: null,
       parentConversationId: null,
       cwd: directory,
       artifactPath,
       capabilities: { steer: engine === "codex", structuredAttention: true },
-      activeTurnId: null,
+      activeTurnId: turn === "running" ? "runtime-running-turn" : null,
     },
   });
 }
@@ -593,6 +594,156 @@ test("scheduled startup retry continues through the retained Codex host", async 
   }
 });
 
+test.each(["terminal", "demoted-superseded", "new-generation"] as const)(
+  "scheduled startup retry releases a %s retained host",
+  async (condition) => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-runtime-startup-discarded-retained-host-"));
+  const registry = new AgentRegistry(path.join(directory, "agent-registry.json"));
+  const sessionId = "00000000-0000-0000-0000-000000000000";
+  const { artifactPath, conversation } = addStructuredRestartConversation(registry, directory, {
+    sessionId,
+    status: "live",
+    turn: "busy",
+    activeTurnRef: "turn-interrupted-before-supersedence",
+    transcriptRecords: [{ timestamp: "2026-07-20T11:47:00.000Z", payload: { type: "task_started" } }],
+  });
+  const journal = new RuntimeJournal(path.join(directory, "runtime.sqlite"), { structuredHosts: true });
+  const baseClient = runtimeJournalClient(journal);
+  let continuationAdmissions = 0;
+  let failStartupSignalsAfterDiscard = false;
+  const client = {
+    ...baseClient,
+    snapshot: async () => {
+      if (failStartupSignalsAfterDiscard) {
+        failStartupSignalsAfterDiscard = false;
+        throw new RuntimeHostUnavailableError("runtime socket failed after retained host discard");
+      }
+      return baseClient.snapshot();
+    },
+    command: async (command: Parameters<RuntimeHostClient["command"]>[0]) => {
+      if (command.kind === "send" && command.text === "Continue the interrupted turn from the transcript.") {
+        continuationAdmissions += 1;
+        if (continuationAdmissions === 1) {
+          throw new RuntimeHostUnavailableError("runtime socket failed after retained host publication");
+        }
+      }
+      return journal.executeOperation(command);
+    },
+  } as RuntimeHostClient;
+  const ledger = createFakeDeliveryLedger();
+  let releaseCalls = 0;
+  const host = Object.assign(new FakeEngineHost(ledger), {
+    onStateChange: () => () => {},
+    release: async () => { releaseCalls += 1; },
+  });
+  const key = { engine: "codex" as const, sessionId };
+  const scheduled: Array<() => void> = [];
+  let adoptedProcesses = 0;
+  const dependencies: StructuredStartupDependencies = {
+    registry,
+    client,
+    adopt: async (received) => {
+      const entry = received.snapshot().entries[`codex:${sessionId}`];
+      if (!entry || adoptedProcesses > 0) return [];
+      const processIdentity = { pid: process.pid, startIdentity: "discarded-retained-process" };
+      const claimed = received.claimStructuredHost(key, processIdentity, { allowUnhosted: true });
+      if (!claimed?.structuredHost || !claimed.claimOwner) throw new Error("discarded host claim was unavailable");
+      const persisted = received.setStructuredHostClaimed(key, {
+        ...claimed.structuredHost,
+        endpoint: "fake:discarded-retained",
+        process: processIdentity,
+      }, "idle", claimed.claimOwner, claimed.claimEpoch);
+      if (!persisted) throw new Error("discarded host writer claim was lost");
+      adoptedProcesses += 1;
+      return [{ key, host: host as never }];
+    },
+    adoptClaude: async () => [],
+  };
+
+  try {
+    await runStructuredHostStartup(
+      () => adoptStructuredHostsAtStartup(dependencies),
+      () => {},
+      {
+        schedule: (callback) => {
+          scheduled.push(callback);
+          return { unref() {} };
+        },
+      },
+    );
+
+    expect(didStructuredHostStartupFail()).toBe(true);
+    expect(scheduled).toHaveLength(1);
+    expect(ledger.writes).toEqual([]);
+
+    if (condition === "terminal") {
+      fs.appendFileSync(artifactPath, `${JSON.stringify({
+        timestamp: "2026-07-20T11:48:00.000Z",
+        payload: { type: "task_complete", turn_id: "turn-interrupted-before-supersedence" },
+      })}\n`);
+    } else if (condition === "demoted-superseded") {
+      await demoteSkippedStructuredRegistryHosts(registry, () => false);
+      const successor = registry.ensureConversation("codex", path.join(directory, "successor.jsonl"), null);
+      registry.recordSupersedence(conversation.id, successor.id, "recovery-spawn");
+      failStartupSignalsAfterDiscard = true;
+    } else {
+      const successorId = "synthetic-current-generation";
+      const successorPath = path.join(directory, "current-generation.jsonl");
+      fs.writeFileSync(successorPath, "");
+      const operationId = "advance-current-generation";
+      const receipt = {
+        operationId,
+        nativeId: successorId,
+        path: successorPath,
+        continuityPaths: [successorPath],
+        historyHash: "synthetic-current-generation-history",
+        host: {
+          kind: "codex-app-server" as const,
+          identity: successorId,
+          epoch: 1,
+          verifiedAt: "2026-07-20T11:48:00.000Z",
+        },
+      };
+      registry.setConversationMigration(conversation.id, {
+        intentId: "advance-current-generation-intent",
+        phase: "verifying",
+        targetId: "successor-account",
+        revision: 1,
+        operationId,
+        providerReceipt: receipt,
+        error: null,
+        updatedAt: "2026-07-20T11:48:00.000Z",
+      });
+      registry.commitSuccessor(conversation.id, {
+        id: successorId,
+        path: successorPath,
+        accountId: "successor-account",
+      }, 1, operationId, receipt);
+    }
+
+    scheduled.shift()!();
+    if (condition === "demoted-superseded") {
+      await waitFor(() => didStructuredHostStartupFail() && scheduled.length === 1);
+      expect(releaseCalls).toBe(1);
+      scheduled.shift()!();
+    }
+    await waitFor(() => !didStructuredHostStartupFail());
+
+    expect(structuredStartupHosts()).toEqual([]);
+    expect(adoptedProcesses).toBe(1);
+    expect(continuationAdmissions).toBe(1);
+    expect(ledger.writes).toEqual([]);
+    expect(releaseCalls).toBe(1);
+    expect(journal.snapshot().recentOperations.filter((receipt) =>
+      receipt.operationId.startsWith(`recovery-continuation-${sessionId}-`))).toEqual([]);
+  } finally {
+    await bindStructuredDeliveryQueue([], { registry, client: null });
+    journal.close();
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+  },
+);
+
 test("terminal structured row with a cleared ownership marker stays outside startup adoption", async () => {
   const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-runtime-startup-terminal-"));
   const { registry } = structuredRestartFixture(directory, "codex", "dead", false);
@@ -691,7 +842,7 @@ function addStructuredRestartConversation(
     engine?: "codex" | "claude";
     sessionId: string;
     status: "live" | "dead";
-    turn: "busy" | "terminal";
+    turn: "busy" | "terminal" | "unknown";
     activeTurnRef?: string | null;
     transcriptRecords?: Record<string, unknown>[];
     transcriptSuffix?: string;
@@ -805,6 +956,109 @@ test("startup adoption boots one live unfinished host across terminal history", 
 
   fs.rmSync(directory, { recursive: true, force: true });
 });
+
+test("unknown Codex durable state continues when the structured host retains an active turn", async () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-runtime-startup-codex-unknown-active-turn-"));
+  const registry = new AgentRegistry(path.join(directory, "agent-registry.json"));
+  const sessionId = "00000000-0000-0000-0000-000000000000";
+  const { conversation } = addStructuredRestartConversation(registry, directory, {
+    sessionId,
+    status: "live",
+    turn: "unknown",
+    activeTurnRef: "turn-retained-through-unknown-state",
+  });
+  const journal = new RuntimeJournal(path.join(directory, "runtime.sqlite"), { structuredHosts: true });
+  const client = runtimeJournalClient(journal);
+  const ledger = createFakeDeliveryLedger();
+  const host = Object.assign(new FakeEngineHost(ledger), { onStateChange: () => () => {} });
+
+  await adoptStructuredHostsAtStartup({
+    registry,
+    client,
+    adopt: async () => [{ key: { engine: "codex", sessionId }, host: host as never }],
+    adoptClaude: async () => [],
+  });
+
+  expect(registry.conversation(conversation.id)?.turn.state).toBe("unknown");
+  expect(ledger.writes).toEqual([expect.objectContaining({
+    id: `recovery-continuation-${sessionId}-3`,
+    text: "Continue the interrupted turn from the transcript.",
+  })]);
+
+  await bindStructuredDeliveryQueue([], { registry, client: null });
+  journal.close();
+  fs.rmSync(directory, { recursive: true, force: true });
+});
+
+test("unknown Codex durable state continues from runtime-running evidence", async () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-runtime-startup-codex-unknown-running-"));
+  const registry = new AgentRegistry(path.join(directory, "agent-registry.json"));
+  const sessionId = "00000000-0000-0000-0000-000000000000";
+  const { artifactPath, conversation } = addStructuredRestartConversation(registry, directory, {
+    sessionId,
+    status: "live",
+    turn: "unknown",
+    activeTurnRef: null,
+  });
+  const journal = new RuntimeJournal(path.join(directory, "runtime.sqlite"), { structuredHosts: true });
+  projectHostedRestart(journal, "codex", conversation.id, sessionId, directory, artifactPath, "running");
+  const client = runtimeJournalClient(journal);
+  const ledger = createFakeDeliveryLedger();
+  const host = Object.assign(new FakeEngineHost(ledger), { onStateChange: () => () => {} });
+
+  await adoptStructuredHostsAtStartup({
+    registry,
+    client,
+    adopt: async () => [{ key: { engine: "codex", sessionId }, host: host as never }],
+    adoptClaude: async () => [],
+  });
+
+  expect(ledger.writes).toEqual([expect.objectContaining({
+    id: `recovery-continuation-${sessionId}-3`,
+  })]);
+
+  await bindStructuredDeliveryQueue([], { registry, client: null });
+  journal.close();
+  fs.rmSync(directory, { recursive: true, force: true });
+});
+
+test.each(["terminal", "superseded"] as const)(
+  "%s Codex conversation stays outside startup continuation",
+  async (condition) => {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), `llv-runtime-startup-codex-${condition}-continuation-`));
+    const registry = new AgentRegistry(path.join(directory, "agent-registry.json"));
+    const sessionId = "00000000-0000-0000-0000-000000000000";
+    const { conversation } = addStructuredRestartConversation(registry, directory, {
+      sessionId,
+      status: condition === "superseded" ? "dead" : "live",
+      turn: condition === "terminal" ? "terminal" : "unknown",
+      activeTurnRef: "stale-predecessor-turn",
+    });
+    if (condition === "superseded") {
+      const successor = registry.ensureConversation("codex", path.join(directory, "successor.jsonl"), null);
+      registry.recordSupersedence(conversation.id, successor.id, "recovery-spawn");
+      const entry = registry.snapshot().entries[`codex:${sessionId}`]!;
+      registry.upsert({ ...entry, status: "live" });
+    }
+    const journal = new RuntimeJournal(path.join(directory, "runtime.sqlite"), { structuredHosts: true });
+    const client = runtimeJournalClient(journal);
+    const ledger = createFakeDeliveryLedger();
+    const host = Object.assign(new FakeEngineHost(ledger), { onStateChange: () => () => {} });
+
+    await adoptStructuredHostsAtStartup({
+      registry,
+      client,
+      adopt: async () => [{ key: { engine: "codex", sessionId }, host: host as never }],
+      adoptClaude: async () => [],
+    });
+
+    expect(ledger.writes).toEqual([]);
+
+    await bindStructuredDeliveryQueue([], { registry, client: null });
+    journal.close();
+    fs.rmSync(directory, { recursive: true, force: true });
+  },
+);
 
 test("a busy Codex turn advances after container replacement without operator messaging", async () => {
   const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-runtime-startup-codex-continuation-"));
@@ -991,6 +1245,61 @@ test("startup retries a failed Codex continuation once through the published suc
 
   await startup();
   expect(ledger.writes).toHaveLength(1);
+
+  await bindStructuredDeliveryQueue([], { registry, client: null });
+  journal.close();
+  fs.rmSync(directory, { recursive: true, force: true });
+});
+
+test("startup retries one failed same-epoch Codex continuation after a lost admission response", async () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-runtime-startup-codex-same-epoch-retry-"));
+  const registry = new AgentRegistry(path.join(directory, "agent-registry.json"));
+  const sessionId = "00000000-0000-0000-0000-000000000000";
+  const { artifactPath, conversation } = addStructuredRestartConversation(registry, directory, {
+    sessionId,
+    status: "live",
+    turn: "busy",
+    activeTurnRef: "turn-interrupted-after-admission",
+    transcriptRecords: [{ timestamp: "2026-07-20T11:47:00.000Z", payload: { type: "task_started" } }],
+  });
+  const journal = new RuntimeJournal(path.join(directory, "runtime.sqlite"), { structuredHosts: true });
+  const client = runtimeJournalClient(journal);
+  projectHostedRestart(journal, "codex", conversation.id, sessionId, directory, artifactPath);
+  const failedOperationId = `recovery-continuation-${sessionId}-3`;
+  journal.executeOperation({
+    kind: "send",
+    operationId: failedOperationId,
+    idempotencyKey: failedOperationId,
+    conversationId: conversation.id,
+    text: "Continue the interrupted turn from the transcript.",
+    policy: "queue",
+    turnId: null,
+  });
+  journal.transitionOperation(failedOperationId, "delivering");
+  journal.transitionOperation(failedOperationId, "failed", { reason: "response lost after durable admission" });
+  const ledger = createFakeDeliveryLedger();
+  const host = Object.assign(new FakeEngineHost(ledger), { onStateChange: () => () => {} });
+  const startup = () => adoptStructuredHostsAtStartup({
+    registry,
+    client,
+    adopt: async () => [{ key: { engine: "codex", sessionId }, host: host as never }],
+    adoptClaude: async () => [],
+  });
+
+  await startup();
+
+  expect(journal.currentRetryResult(failedOperationId)?.receipt).toMatchObject({
+    retryOfOperationId: failedOperationId,
+    idempotencyKey: `${failedOperationId}-retry-1`,
+    status: "delivered",
+  });
+  expect(ledger.writes).toHaveLength(1);
+  expect(registry.snapshot().entries[`codex:${sessionId}`]!.claimEpoch).toBe(3);
+
+  await startup();
+  expect(ledger.writes).toHaveLength(1);
+  expect(journal.snapshot().recentOperations.filter((receipt) =>
+    receipt.retryOfOperationId === failedOperationId)).toHaveLength(1);
 
   await bindStructuredDeliveryQueue([], { registry, client: null });
   journal.close();

--- a/src/lib/runtime/startup.test.ts
+++ b/src/lib/runtime/startup.test.ts
@@ -331,12 +331,24 @@ test.each(["codex", "claude"] as const)("successful %s restart adoption publishe
   const ledger = createFakeDeliveryLedger();
   const host = Object.assign(new FakeEngineHost(ledger), { onStateChange: () => () => {} });
   const key = { engine, sessionId } as const;
+  const adoptHost = (received: AgentRegistry) => {
+    const processIdentity = { pid: process.pid, startIdentity: `hosted-${engine}-process` };
+    const claimed = received.claimStructuredHost(key, processIdentity, { allowUnhosted: true });
+    if (!claimed?.structuredHost || !claimed.claimOwner) throw new Error("hosted restart claim was unavailable");
+    const persisted = received.setStructuredHostClaimed(key, {
+      ...claimed.structuredHost,
+      endpoint: `fake:hosted-${engine}`,
+      process: processIdentity,
+    }, "live", claimed.claimOwner, claimed.claimEpoch);
+    if (!persisted) throw new Error("hosted restart claim was lost");
+    return [{ key, host: host as never }];
+  };
 
   await adoptStructuredHostsAtStartup({
     registry,
     client,
-    adopt: async () => engine === "codex" ? [{ key, host: host as never }] : [],
-    adoptClaude: async () => engine === "claude" ? [{ key, host: host as never }] : [],
+    adopt: async (received) => engine === "codex" ? adoptHost(received) as never : [],
+    adoptClaude: async (received) => engine === "claude" ? adoptHost(received) as never : [],
   });
 
   expect(journal.snapshot().sessions).toMatchObject([{
@@ -594,7 +606,7 @@ test("scheduled startup retry continues through the retained Codex host", async 
   }
 });
 
-test.each(["terminal", "demoted-superseded", "new-generation"] as const)(
+test.each(["terminal", "demoted-superseded", "new-generation", "superseded-during-signals"] as const)(
   "scheduled startup retry releases a %s retained host",
   async (condition) => {
   const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-runtime-startup-discarded-retained-host-"));
@@ -605,12 +617,17 @@ test.each(["terminal", "demoted-superseded", "new-generation"] as const)(
     status: "live",
     turn: "busy",
     activeTurnRef: "turn-interrupted-before-supersedence",
-    transcriptRecords: [{ timestamp: "2026-07-20T11:47:00.000Z", payload: { type: "task_started" } }],
+    transcriptRecords: [{
+      timestamp: "2026-07-20T11:47:00.000Z",
+      payload: { type: "task_started", turn_id: "turn-interrupted-before-supersedence" },
+    }],
   });
   const journal = new RuntimeJournal(path.join(directory, "runtime.sqlite"), { structuredHosts: true });
   const baseClient = runtimeJournalClient(journal);
   let continuationAdmissions = 0;
   let failStartupSignalsAfterDiscard = false;
+  let supersedeDuringEffectBatch = false;
+  let supersedenceDuringSignals = 0;
   const client = {
     ...baseClient,
     snapshot: async () => {
@@ -619,6 +636,19 @@ test.each(["terminal", "demoted-superseded", "new-generation"] as const)(
         throw new RuntimeHostUnavailableError("runtime socket failed after retained host discard");
       }
       return baseClient.snapshot();
+    },
+    effectBatch: async (...args: Parameters<RuntimeHostClient["effectBatch"]>) => {
+      const batch = await baseClient.effectBatch(...args);
+      if (supersedeDuringEffectBatch) {
+        supersedeDuringEffectBatch = false;
+        supersedenceDuringSignals += 1;
+        const staleEntry = registry.snapshot().entries[`codex:${sessionId}`]!;
+        await demoteSkippedStructuredRegistryHosts(registry, () => false);
+        const successor = registry.ensureConversation("codex", path.join(directory, "signal-successor.jsonl"), null);
+        registry.recordSupersedence(conversation.id, successor.id, "recovery-spawn");
+        registry.upsert({ ...staleEntry, status: "live" });
+      }
+      return batch;
     },
     command: async (command: Parameters<RuntimeHostClient["command"]>[0]) => {
       if (command.kind === "send" && command.text === "Continue the interrupted turn from the transcript.") {
@@ -652,7 +682,7 @@ test.each(["terminal", "demoted-superseded", "new-generation"] as const)(
         ...claimed.structuredHost,
         endpoint: "fake:discarded-retained",
         process: processIdentity,
-      }, "idle", claimed.claimOwner, claimed.claimEpoch);
+      }, "live", claimed.claimOwner, claimed.claimEpoch);
       if (!persisted) throw new Error("discarded host writer claim was lost");
       adoptedProcesses += 1;
       return [{ key, host: host as never }];
@@ -677,7 +707,7 @@ test.each(["terminal", "demoted-superseded", "new-generation"] as const)(
     expect(ledger.writes).toEqual([]);
 
     if (condition === "terminal") {
-      fs.appendFileSync(artifactPath, `${JSON.stringify({
+      fs.appendFileSync(artifactPath, `\n${JSON.stringify({
         timestamp: "2026-07-20T11:48:00.000Z",
         payload: { type: "task_complete", turn_id: "turn-interrupted-before-supersedence" },
       })}\n`);
@@ -686,7 +716,7 @@ test.each(["terminal", "demoted-superseded", "new-generation"] as const)(
       const successor = registry.ensureConversation("codex", path.join(directory, "successor.jsonl"), null);
       registry.recordSupersedence(conversation.id, successor.id, "recovery-spawn");
       failStartupSignalsAfterDiscard = true;
-    } else {
+    } else if (condition === "new-generation") {
       const successorId = "synthetic-current-generation";
       const successorPath = path.join(directory, "current-generation.jsonl");
       fs.writeFileSync(successorPath, "");
@@ -719,6 +749,8 @@ test.each(["terminal", "demoted-superseded", "new-generation"] as const)(
         path: successorPath,
         accountId: "successor-account",
       }, 1, operationId, receipt);
+    } else {
+      supersedeDuringEffectBatch = true;
     }
 
     scheduled.shift()!();
@@ -736,6 +768,16 @@ test.each(["terminal", "demoted-superseded", "new-generation"] as const)(
     expect(releaseCalls).toBe(1);
     expect(journal.snapshot().recentOperations.filter((receipt) =>
       receipt.operationId.startsWith(`recovery-continuation-${sessionId}-`))).toEqual([]);
+
+    if (condition === "superseded-during-signals") {
+      expect(supersedenceDuringSignals).toBe(1);
+      await adoptStructuredHostsAtStartup(dependencies);
+      expect(structuredStartupHosts()).toEqual([]);
+      expect(ledger.writes).toEqual([]);
+      expect(releaseCalls).toBe(1);
+      expect(journal.snapshot().recentOperations.filter((receipt) =>
+        receipt.operationId.startsWith(`recovery-continuation-${sessionId}-`))).toEqual([]);
+    }
   } finally {
     await bindStructuredDeliveryQueue([], { registry, client: null });
     journal.close();

--- a/src/lib/runtime/startup.test.ts
+++ b/src/lib/runtime/startup.test.ts
@@ -119,7 +119,11 @@ function runtimeJournalClient(journal: RuntimeJournal): RuntimeHostClient {
     snapshot: async () => journal.snapshot(),
     append: async (event) => journal.append(event),
     command: async (command) => journal.executeOperation(command),
-    operationStatus: async (operationId) => journal.operationResult(operationId),
+    operationStatus: async (operationId, options) => options?.currentRetryLeaf
+      ? journal.currentRetryResult(operationId)
+      : journal.operationResult(operationId),
+    retryOperation: async (operationId, nextIdempotencyKey, options) =>
+      journal.retryOperation(operationId, nextIdempotencyKey, options),
     effectBatch: async (kinds, afterEventSeq) => journal.effectBatch(100, kinds, afterEventSeq),
     transitionOperation: async (operationId, status, details) => journal.transitionOperation(operationId, status, details),
   } as RuntimeHostClient;
@@ -694,6 +698,247 @@ test("startup adoption boots one live unfinished host across terminal history", 
 
   expect(await startupAdoptionAttempts(registry)).toEqual([`codex:${liveSessionId}`]);
 
+  fs.rmSync(directory, { recursive: true, force: true });
+});
+
+test("a busy Codex turn advances after container replacement without operator messaging", async () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-runtime-startup-codex-continuation-"));
+  const registry = new AgentRegistry(path.join(directory, "agent-registry.json"));
+  const sessionId = "11111111-2222-4222-8222-111111111111";
+  const { artifactPath, conversation } = addStructuredRestartConversation(registry, directory, {
+    sessionId,
+    status: "live",
+    turn: "busy",
+    activeTurnRef: "turn-interrupted-by-promotion",
+    transcriptRecords: [{ timestamp: "2026-07-20T11:47:00.000Z", payload: { type: "task_started" } }],
+  });
+  const journal = new RuntimeJournal(path.join(directory, "runtime.sqlite"), { structuredHosts: true });
+  const client = runtimeJournalClient(journal);
+  const ledger = createFakeDeliveryLedger();
+  const baseHost = new FakeEngineHost(ledger);
+  let host = Object.assign(baseHost, {
+    onStateChange: () => () => {},
+    send: async (entry: Parameters<FakeEngineHost["send"]>[0]) => {
+      const receipt = await FakeEngineHost.prototype.send.call(baseHost, entry);
+      fs.appendFileSync(artifactPath, `${JSON.stringify({
+        timestamp: "2026-07-20T11:50:00.000Z",
+        payload: { type: "user_message", text: entry.text },
+      })}\n`);
+      return receipt;
+    },
+  });
+  const before = fs.statSync(artifactPath).size;
+
+  const startup = () => adoptStructuredHostsAtStartup({
+    registry,
+    client,
+    adopt: async (received, _optionsFor, _env, shouldAdopt = () => true) => {
+      const entry = received.snapshot().entries[`codex:${sessionId}`];
+      return entry?.structuredHost && shouldAdopt(entry)
+        ? [{ key: { engine: "codex", sessionId }, host: host as never }]
+        : [];
+    },
+    adoptClaude: async () => [],
+  });
+  await startup();
+
+  await waitFor(() => ledger.writes.length === 1);
+  expect(ledger.writes).toEqual([expect.objectContaining({
+    text: "Continue the interrupted turn from the transcript.",
+  })]);
+  expect(fs.statSync(artifactPath).size).toBeGreaterThan(before);
+  expect(registry.conversation(conversation.id)?.id).toBe(conversation.id);
+  const advanced = fs.statSync(artifactPath).size;
+
+  await startup();
+  expect(ledger.writes).toHaveLength(1);
+  expect(fs.statSync(artifactPath).size).toBe(advanced);
+
+  const nextLedger = createFakeDeliveryLedger();
+  const nextBaseHost = new FakeEngineHost(nextLedger);
+  host = Object.assign(nextBaseHost, {
+    onStateChange: () => () => {},
+    send: async (entry: Parameters<FakeEngineHost["send"]>[0]) => {
+      const receipt = await FakeEngineHost.prototype.send.call(nextBaseHost, entry);
+      fs.appendFileSync(artifactPath, `${JSON.stringify({
+        timestamp: "2026-07-20T11:55:00.000Z",
+        payload: { type: "user_message", text: entry.text },
+      })}\n`);
+      return receipt;
+    },
+  });
+  const entry = registry.snapshot().entries[`codex:${sessionId}`]!;
+  registry.upsert({
+    ...entry,
+    claimEpoch: 4,
+    structuredHost: { ...entry.structuredHost!, writerClaimEpoch: 4 },
+  });
+
+  await startup();
+  await waitFor(() => nextLedger.writes.length === 1);
+  expect(nextLedger.writes).toEqual([expect.objectContaining({
+    id: `recovery-continuation-${sessionId}-4`,
+  })]);
+  expect(fs.statSync(artifactPath).size).toBeGreaterThan(advanced);
+
+  await bindStructuredDeliveryQueue([], { registry, client: null });
+  journal.close();
+  fs.rmSync(directory, { recursive: true, force: true });
+});
+
+test("a repeated promotion reuses one pending Codex continuation", async () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-runtime-startup-codex-pending-continuation-"));
+  const registry = new AgentRegistry(path.join(directory, "agent-registry.json"));
+  const sessionId = "11111111-3333-4333-8333-111111111111";
+  const { artifactPath, conversation } = addStructuredRestartConversation(registry, directory, {
+    sessionId,
+    status: "live",
+    turn: "busy",
+    activeTurnRef: "turn-interrupted-before-retry",
+    transcriptRecords: [{ timestamp: "2026-07-20T11:47:00.000Z", payload: { type: "task_started" } }],
+  });
+  const journal = new RuntimeJournal(path.join(directory, "runtime.sqlite"), { structuredHosts: true });
+  const client = runtimeJournalClient(journal);
+  projectHostedRestart(journal, "codex", conversation.id, sessionId, directory, artifactPath);
+  const pendingOperationId = `recovery-continuation-${sessionId}-3`;
+  journal.executeOperation({
+    kind: "send",
+    operationId: pendingOperationId,
+    idempotencyKey: pendingOperationId,
+    conversationId: conversation.id,
+    text: "Continue the interrupted turn from the transcript.",
+    policy: "queue",
+    turnId: null,
+  });
+  const entry = registry.snapshot().entries[`codex:${sessionId}`]!;
+  registry.upsert({
+    ...entry,
+    claimEpoch: 5,
+    structuredHost: { ...entry.structuredHost!, writerClaimEpoch: 5 },
+  });
+  const ledger = createFakeDeliveryLedger();
+  const host = Object.assign(new FakeEngineHost(ledger), { onStateChange: () => () => {} });
+
+  await adoptStructuredHostsAtStartup({
+    registry,
+    client,
+    adopt: async () => [{ key: { engine: "codex", sessionId }, host: host as never }],
+    adoptClaude: async () => [],
+  });
+
+  expect(ledger.writes).toEqual([expect.objectContaining({ id: pendingOperationId })]);
+  expect(journal.operationResult(`recovery-continuation-${sessionId}-5`)).toBeNull();
+
+  await bindStructuredDeliveryQueue([], { registry, client: null });
+  journal.close();
+  fs.rmSync(directory, { recursive: true, force: true });
+});
+
+test("startup retries a failed Codex continuation once through the published successor", async () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-runtime-startup-codex-continuation-retry-"));
+  const registry = new AgentRegistry(path.join(directory, "agent-registry.json"));
+  const sessionId = "11111111-4444-4444-8444-111111111111";
+  const { artifactPath, conversation } = addStructuredRestartConversation(registry, directory, {
+    sessionId,
+    status: "live",
+    turn: "busy",
+    activeTurnRef: "turn-interrupted-before-failed-continuation",
+    transcriptRecords: [{ timestamp: "2026-07-20T11:47:00.000Z", payload: { type: "task_started" } }],
+  });
+  const journal = new RuntimeJournal(path.join(directory, "runtime.sqlite"), { structuredHosts: true });
+  const client = runtimeJournalClient(journal);
+  projectHostedRestart(journal, "codex", conversation.id, sessionId, directory, artifactPath);
+  const failedOperationId = `recovery-continuation-${sessionId}-3`;
+  journal.executeOperation({
+    kind: "send",
+    operationId: failedOperationId,
+    idempotencyKey: failedOperationId,
+    conversationId: conversation.id,
+    text: "Continue the interrupted turn from the transcript.",
+    policy: "queue",
+    turnId: null,
+  });
+  journal.transitionOperation(failedOperationId, "delivering");
+  journal.transitionOperation(failedOperationId, "failed", { reason: "successor socket closed" });
+  const entry = registry.snapshot().entries[`codex:${sessionId}`]!;
+  registry.upsert({
+    ...entry,
+    claimEpoch: 4,
+    structuredHost: { ...entry.structuredHost!, writerClaimEpoch: 4 },
+  });
+  const ledger = createFakeDeliveryLedger();
+  const host = Object.assign(new FakeEngineHost(ledger), { onStateChange: () => () => {} });
+  const startup = () => adoptStructuredHostsAtStartup({
+    registry,
+    client,
+    adopt: async () => [{ key: { engine: "codex", sessionId }, host: host as never }],
+    adoptClaude: async () => [],
+  });
+
+  await startup();
+
+  expect(journal.currentRetryResult(failedOperationId)?.receipt).toMatchObject({
+    retryOfOperationId: failedOperationId,
+    status: "delivered",
+  });
+  expect(journal.operationResult(`recovery-continuation-${sessionId}-4`)).toBeNull();
+  expect(ledger.writes).toHaveLength(1);
+
+  await startup();
+  expect(ledger.writes).toHaveLength(1);
+
+  await bindStructuredDeliveryQueue([], { registry, client: null });
+  journal.close();
+  fs.rmSync(directory, { recursive: true, force: true });
+});
+
+test("startup preserves a queued user draft before the Codex continuation", async () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-runtime-startup-codex-draft-order-"));
+  const registry = new AgentRegistry(path.join(directory, "agent-registry.json"));
+  const sessionId = "11111111-5555-4555-8555-111111111111";
+  const { artifactPath, conversation } = addStructuredRestartConversation(registry, directory, {
+    sessionId,
+    status: "live",
+    turn: "busy",
+    activeTurnRef: "turn-interrupted-with-queued-draft",
+    transcriptRecords: [{ timestamp: "2026-07-20T11:47:00.000Z", payload: { type: "task_started" } }],
+  });
+  const journal = new RuntimeJournal(path.join(directory, "runtime.sqlite"), { structuredHosts: true });
+  const client = runtimeJournalClient(journal);
+  projectHostedRestart(journal, "codex", conversation.id, sessionId, directory, artifactPath);
+  journal.executeOperation({
+    kind: "send",
+    operationId: "queued-user-draft-before-promotion",
+    idempotencyKey: "queued-user-draft-before-promotion",
+    conversationId: conversation.id,
+    text: "keep this queued draft lossless",
+    policy: "queue",
+    turnId: null,
+  });
+  const ledger = createFakeDeliveryLedger();
+  const host = Object.assign(new FakeEngineHost(ledger), { onStateChange: () => () => {} });
+
+  await adoptStructuredHostsAtStartup({
+    registry,
+    client,
+    adopt: async () => [{ key: { engine: "codex", sessionId }, host: host as never }],
+    adoptClaude: async () => [],
+  });
+
+  expect(ledger.writes.map(({ id, text }) => ({ id, text }))).toEqual([
+    { id: "queued-user-draft-before-promotion", text: "keep this queued draft lossless" },
+    {
+      id: `recovery-continuation-${sessionId}-3`,
+      text: "Continue the interrupted turn from the transcript.",
+    },
+  ]);
+  expect(journal.operationResult("queued-user-draft-before-promotion")?.receipt).toMatchObject({
+    status: "delivered",
+    text: "keep this queued draft lossless",
+  });
+
+  await bindStructuredDeliveryQueue([], { registry, client: null });
+  journal.close();
   fs.rmSync(directory, { recursive: true, force: true });
 });
 

--- a/src/lib/runtime/startup.ts
+++ b/src/lib/runtime/startup.ts
@@ -322,7 +322,10 @@ export async function adoptStructuredHostsAtStartup(
   const client = dependencies.client === undefined ? runtimeHostClient() : dependencies.client;
   const signals = await structuredStartupSignals(registry, client);
   const shouldAdopt = structuredStartupAdoptionFilter(registry, signals);
-  const interruptedCodex = interruptedCodexConversations(registry, shouldAdopt);
+  const retainedHostKeys = new Set(nextAdoptedHosts.map((item) => sessionKeyId(item.key)));
+  const shouldRetainOrAdopt: StructuredHostAdoptionFilter = (entry) =>
+    retainedHostKeys.has(sessionKeyId(entry.key)) || shouldAdopt(entry);
+  const interruptedCodex = interruptedCodexConversations(registry, shouldRetainOrAdopt);
   const resolveCodexOwner = dependencies.resolveCodexOwner ?? ((entry: AgentRegistryEntry) =>
     accountManager.resolveTranscriptOwner("codex", entry.artifactPath));
   const resolveClaudeOwner = dependencies.resolveClaudeOwner ?? ((entry: AgentRegistryEntry) =>
@@ -371,16 +374,19 @@ export async function adoptStructuredHostsAtStartup(
   );
   nextAdoptedHosts = retainAdoptedHosts(nextAdoptedHosts, claude);
   retryAdoptedHosts = nextAdoptedHosts;
+  const availableCodexHosts = nextAdoptedHosts.filter(
+    (item): item is AdoptedCodexHost => item.key.engine === "codex",
+  );
   const previousCodexContinuations = client
-    ? await previousInterruptedCodexContinuations(registry, client, codex, interruptedCodex)
+    ? await previousInterruptedCodexContinuations(registry, client, availableCodexHosts, interruptedCodex)
     : new Map<string, RuntimeOperationResult>();
-  await demoteSkippedStructuredRegistryHosts(registry, shouldAdopt);
+  await demoteSkippedStructuredRegistryHosts(registry, shouldRetainOrAdopt);
   await bindStructuredDeliveryQueue(nextAdoptedHosts, { registry: dependencies.registry, client });
   if (client) {
     await enqueueInterruptedCodexContinuations(
       registry,
       client,
-      codex,
+      availableCodexHosts,
       interruptedCodex,
       previousCodexContinuations,
       signals.pendingCodexContinuationConversationIds,

--- a/src/lib/runtime/startup.ts
+++ b/src/lib/runtime/startup.ts
@@ -38,6 +38,34 @@ function retainAdoptedHosts(
   return [...hosts.values()];
 }
 
+function retainedStartupHostIsCurrent(
+  registry: AgentRegistry,
+  item: AdoptedStructuredHost,
+): boolean {
+  const snapshot = registry.snapshot();
+  const key = sessionKeyId(item.key);
+  const entry = snapshot.entries[key];
+  if (!entry?.structuredHost || entry.status === "dead" || entry.status === "unhosted") return false;
+  const conversation = Object.values(snapshot.conversations).find((candidate) =>
+    candidate.engine === item.key.engine
+      && candidate.generations.at(-1)?.id === item.key.sessionId);
+  return Boolean(conversation
+    && conversation.turn.state !== "terminal"
+    && !conversation.supersededBy);
+}
+
+async function revalidateRetainedStartupHosts(
+  registry: AgentRegistry,
+  retained: readonly AdoptedStructuredHost[],
+): Promise<AdoptedStructuredHost[]> {
+  const current: AdoptedStructuredHost[] = [];
+  for (const item of retained) {
+    if (retainedStartupHostIsCurrent(registry, item)) current.push(item);
+    else await item.host.release();
+  }
+  return current;
+}
+
 const RUNTIME_EFFECT_PAGE_SIZE = 100;
 const STRUCTURED_HOST_OPERATION_EFFECT_KINDS = [
   "runtime.send",
@@ -65,14 +93,19 @@ function interruptedCodexContinuationOperationId(sessionId: string, claimEpoch: 
 function interruptedCodexConversations(
   registry: AgentRegistry,
   shouldAdopt: StructuredHostAdoptionFilter,
+  runtimeRunningConversationIds: ReadonlySet<string>,
 ): ReadonlyMap<string, ViewerConversationId> {
   const snapshot = registry.snapshot();
   return new Map(Object.values(snapshot.conversations).flatMap((conversation) => {
     const generation = conversation.generations.at(-1);
-    if (conversation.engine !== "codex" || conversation.turn.state !== "busy" || !generation) return [];
+    if (conversation.engine !== "codex" || !generation) return [];
     const key = { engine: "codex" as const, sessionId: generation.id };
     const entry = snapshot.entries[sessionKeyId(key)];
-    return entry?.structuredHost && shouldAdopt(entry)
+    const interrupted = conversation.turn.state === "busy"
+      || (conversation.turn.state === "unknown"
+        && (Boolean(entry?.structuredHost?.activeTurnRef)
+          || runtimeRunningConversationIds.has(registry.canonicalConversationId(conversation.id))));
+    return interrupted && entry?.structuredHost && shouldAdopt(entry)
       ? [[sessionKeyId(key), conversation.id] as const]
       : [];
   }));
@@ -83,7 +116,7 @@ async function enqueueInterruptedCodexContinuations(
   client: RuntimeHostClient,
   adopted: readonly AdoptedCodexHost[],
   interrupted: ReadonlyMap<string, ViewerConversationId>,
-  previousByKey: ReadonlyMap<string, RuntimeOperationResult>,
+  existingByKey: ReadonlyMap<string, RuntimeOperationResult>,
   pendingContinuationConversationIds: ReadonlySet<string>,
 ): Promise<void> {
   for (const item of adopted) {
@@ -91,23 +124,25 @@ async function enqueueInterruptedCodexContinuations(
     const conversationId = interrupted.get(key);
     if (!conversationId) continue;
     if (pendingContinuationConversationIds.has(conversationId)) continue;
-    const previous = previousByKey.get(key);
-    if (previous) {
-      if (previous.receipt.status === "failed" || previous.receipt.status === "rejected") {
-        if (!previous.receipt.retryOfOperationId) {
+    const entry = registry.snapshot().entries[key];
+    if (!entry) throw new Error(`adopted Codex registry row disappeared: ${key}`);
+    const operationId = interruptedCodexContinuationOperationId(item.key.sessionId, entry.claimEpoch);
+    const existing = existingByKey.get(key);
+    if (existing) {
+      if (existing.receipt.status === "failed" || existing.receipt.status === "rejected") {
+        if (!existing.receipt.retryOfOperationId) {
           await client.retryOperation(
-            previous.operationId,
-            `${previous.receipt.idempotencyKey}-retry-1`,
+            existing.operationId,
+            `${existing.receipt.idempotencyKey}-retry-1`,
             { requireHostedConversationId: conversationId },
           );
         }
         continue;
       }
-      if (previous.receipt.status !== "delivered" || previous.receipt.retryOfOperationId) continue;
+      if (existing.operationId === operationId
+        || existing.receipt.status !== "delivered"
+        || existing.receipt.retryOfOperationId) continue;
     }
-    const entry = registry.snapshot().entries[key];
-    if (!entry) throw new Error(`adopted Codex registry row disappeared: ${key}`);
-    const operationId = interruptedCodexContinuationOperationId(item.key.sessionId, entry.claimEpoch);
     await client.command({
       kind: "send",
       operationId,
@@ -120,25 +155,34 @@ async function enqueueInterruptedCodexContinuations(
   }
 }
 
-async function previousInterruptedCodexContinuations(
+async function interruptedCodexContinuations(
   registry: AgentRegistry,
   client: RuntimeHostClient,
   adopted: readonly AdoptedCodexHost[],
   interrupted: ReadonlyMap<string, ViewerConversationId>,
 ): Promise<ReadonlyMap<string, RuntimeOperationResult>> {
-  const previousByKey = new Map<string, RuntimeOperationResult>();
+  const existingByKey = new Map<string, RuntimeOperationResult>();
   for (const item of adopted) {
     const key = sessionKeyId(item.key);
     if (!interrupted.has(key)) continue;
     const entry = registry.snapshot().entries[key];
-    if (!entry || entry.claimEpoch <= 0) continue;
+    if (!entry) continue;
+    const current = await client.operationStatus(
+      interruptedCodexContinuationOperationId(item.key.sessionId, entry.claimEpoch),
+      { currentRetryLeaf: true },
+    );
+    if (current) {
+      existingByKey.set(key, current);
+      continue;
+    }
+    if (entry.claimEpoch <= 0) continue;
     const previous = await client.operationStatus(
       interruptedCodexContinuationOperationId(item.key.sessionId, entry.claimEpoch - 1),
       { currentRetryLeaf: true },
     );
-    if (previous) previousByKey.set(key, previous);
+    if (previous) existingByKey.set(key, previous);
   }
-  return previousByKey;
+  return existingByKey;
 }
 
 function persistedTurnState(
@@ -316,16 +360,21 @@ export async function adoptStructuredHostsAtStartup(
   dependencies: StructuredStartupDependencies = {},
 ): Promise<AdoptedStructuredHost[]> {
   assertDarwinStructuredRuntime();
-  let nextAdoptedHosts = retryAdoptedHosts;
   const registry = dependencies.registry ?? agentRegistry();
   await refreshStructuredTranscriptState(registry);
+  let nextAdoptedHosts = await revalidateRetainedStartupHosts(registry, retryAdoptedHosts);
+  retryAdoptedHosts = nextAdoptedHosts;
   const client = dependencies.client === undefined ? runtimeHostClient() : dependencies.client;
   const signals = await structuredStartupSignals(registry, client);
   const shouldAdopt = structuredStartupAdoptionFilter(registry, signals);
   const retainedHostKeys = new Set(nextAdoptedHosts.map((item) => sessionKeyId(item.key)));
   const shouldRetainOrAdopt: StructuredHostAdoptionFilter = (entry) =>
     retainedHostKeys.has(sessionKeyId(entry.key)) || shouldAdopt(entry);
-  const interruptedCodex = interruptedCodexConversations(registry, shouldRetainOrAdopt);
+  const interruptedCodex = interruptedCodexConversations(
+    registry,
+    shouldRetainOrAdopt,
+    signals.hostedRunningConversationIds,
+  );
   const resolveCodexOwner = dependencies.resolveCodexOwner ?? ((entry: AgentRegistryEntry) =>
     accountManager.resolveTranscriptOwner("codex", entry.artifactPath));
   const resolveClaudeOwner = dependencies.resolveClaudeOwner ?? ((entry: AgentRegistryEntry) =>
@@ -377,8 +426,8 @@ export async function adoptStructuredHostsAtStartup(
   const availableCodexHosts = nextAdoptedHosts.filter(
     (item): item is AdoptedCodexHost => item.key.engine === "codex",
   );
-  const previousCodexContinuations = client
-    ? await previousInterruptedCodexContinuations(registry, client, availableCodexHosts, interruptedCodex)
+  const existingCodexContinuations = client
+    ? await interruptedCodexContinuations(registry, client, availableCodexHosts, interruptedCodex)
     : new Map<string, RuntimeOperationResult>();
   await demoteSkippedStructuredRegistryHosts(registry, shouldRetainOrAdopt);
   await bindStructuredDeliveryQueue(nextAdoptedHosts, { registry: dependencies.registry, client });
@@ -388,7 +437,7 @@ export async function adoptStructuredHostsAtStartup(
       client,
       availableCodexHosts,
       interruptedCodex,
-      previousCodexContinuations,
+      existingCodexContinuations,
       signals.pendingCodexContinuationConversationIds,
     );
     await kickStructuredDeliveryQueue();

--- a/src/lib/runtime/startup.ts
+++ b/src/lib/runtime/startup.ts
@@ -2,7 +2,7 @@ import { accountManager } from "@/lib/accounts/manager";
 import { claudeSettingsPath } from "@/lib/accounts/claude";
 import { turnStateFromRecords } from "@/lib/accounts/migration/turnState";
 import type { ViewerConversationId } from "@/lib/accounts/migration/contracts";
-import { agentRegistry, type AgentRegistry, type AgentRegistryEntry } from "@/lib/agent/registry";
+import { agentRegistry, type AgentRegistry, type AgentRegistryEntry, type RegistryFile } from "@/lib/agent/registry";
 import { sessionKeyId } from "@/lib/agent/sessionKey";
 import { VIEWER_SPAWN_CAPABILITY_ENV } from "@/lib/agent/spawnPolicy";
 import { assertDarwinStructuredRuntime } from "@/lib/proc/darwinIdentity";
@@ -39,10 +39,9 @@ function retainAdoptedHosts(
 }
 
 function retainedStartupHostIsCurrent(
-  registry: AgentRegistry,
+  snapshot: RegistryFile,
   item: AdoptedStructuredHost,
 ): boolean {
-  const snapshot = registry.snapshot();
   const key = sessionKeyId(item.key);
   const entry = snapshot.entries[key];
   if (!entry?.structuredHost || entry.status === "dead" || entry.status === "unhosted") return false;
@@ -57,10 +56,11 @@ function retainedStartupHostIsCurrent(
 async function revalidateRetainedStartupHosts(
   registry: AgentRegistry,
   retained: readonly AdoptedStructuredHost[],
+  snapshot: RegistryFile = registry.snapshot(),
 ): Promise<AdoptedStructuredHost[]> {
   const current: AdoptedStructuredHost[] = [];
   for (const item of retained) {
-    if (retainedStartupHostIsCurrent(registry, item)) current.push(item);
+    if (retainedStartupHostIsCurrent(snapshot, item)) current.push(item);
     else await item.host.release();
   }
   return current;
@@ -94,8 +94,8 @@ function interruptedCodexConversations(
   registry: AgentRegistry,
   shouldAdopt: StructuredHostAdoptionFilter,
   runtimeRunningConversationIds: ReadonlySet<string>,
+  snapshot: RegistryFile = registry.snapshot(),
 ): ReadonlyMap<string, ViewerConversationId> {
-  const snapshot = registry.snapshot();
   return new Map(Object.values(snapshot.conversations).flatMap((conversation) => {
     const generation = conversation.generations.at(-1);
     if (conversation.engine !== "codex" || !generation) return [];
@@ -159,12 +159,10 @@ async function interruptedCodexContinuations(
   registry: AgentRegistry,
   client: RuntimeHostClient,
   adopted: readonly AdoptedCodexHost[],
-  interrupted: ReadonlyMap<string, ViewerConversationId>,
 ): Promise<ReadonlyMap<string, RuntimeOperationResult>> {
   const existingByKey = new Map<string, RuntimeOperationResult>();
   for (const item of adopted) {
     const key = sessionKeyId(item.key);
-    if (!interrupted.has(key)) continue;
     const entry = registry.snapshot().entries[key];
     if (!entry) continue;
     const current = await client.operationStatus(
@@ -308,8 +306,8 @@ async function structuredStartupSignals(
 function structuredStartupAdoptionFilter(
   registry: AgentRegistry,
   signals: StructuredStartupSignals,
+  snapshot: RegistryFile = registry.snapshot(),
 ): StructuredHostAdoptionFilter {
-  const snapshot = registry.snapshot();
   const conversationsByCurrentEntry = new Map(Object.values(snapshot.conversations).flatMap((conversation) => {
     const generation = conversation.generations.at(-1);
     return generation
@@ -367,14 +365,6 @@ export async function adoptStructuredHostsAtStartup(
   const client = dependencies.client === undefined ? runtimeHostClient() : dependencies.client;
   const signals = await structuredStartupSignals(registry, client);
   const shouldAdopt = structuredStartupAdoptionFilter(registry, signals);
-  const retainedHostKeys = new Set(nextAdoptedHosts.map((item) => sessionKeyId(item.key)));
-  const shouldRetainOrAdopt: StructuredHostAdoptionFilter = (entry) =>
-    retainedHostKeys.has(sessionKeyId(entry.key)) || shouldAdopt(entry);
-  const interruptedCodex = interruptedCodexConversations(
-    registry,
-    shouldRetainOrAdopt,
-    signals.hostedRunningConversationIds,
-  );
   const resolveCodexOwner = dependencies.resolveCodexOwner ?? ((entry: AgentRegistryEntry) =>
     accountManager.resolveTranscriptOwner("codex", entry.artifactPath));
   const resolveClaudeOwner = dependencies.resolveClaudeOwner ?? ((entry: AgentRegistryEntry) =>
@@ -423,19 +413,38 @@ export async function adoptStructuredHostsAtStartup(
   );
   nextAdoptedHosts = retainAdoptedHosts(nextAdoptedHosts, claude);
   retryAdoptedHosts = nextAdoptedHosts;
-  const availableCodexHosts = nextAdoptedHosts.filter(
+  const candidateHostKeys = new Set(nextAdoptedHosts.map((item) => sessionKeyId(item.key)));
+  const shouldRetainCandidateOrAdopt: StructuredHostAdoptionFilter = (entry) =>
+    candidateHostKeys.has(sessionKeyId(entry.key)) || shouldAdopt(entry);
+  const candidateCodexHosts = nextAdoptedHosts.filter(
     (item): item is AdoptedCodexHost => item.key.engine === "codex",
   );
   const existingCodexContinuations = client
-    ? await interruptedCodexContinuations(registry, client, availableCodexHosts, interruptedCodex)
+    ? await interruptedCodexContinuations(registry, client, candidateCodexHosts)
     : new Map<string, RuntimeOperationResult>();
-  await demoteSkippedStructuredRegistryHosts(registry, shouldRetainOrAdopt);
+  await demoteSkippedStructuredRegistryHosts(registry, shouldRetainCandidateOrAdopt);
+  const publicationSnapshot = registry.snapshot();
+  nextAdoptedHosts = await revalidateRetainedStartupHosts(registry, nextAdoptedHosts, publicationSnapshot);
+  retryAdoptedHosts = nextAdoptedHosts;
+  const finalShouldAdopt = structuredStartupAdoptionFilter(registry, signals, publicationSnapshot);
+  const finalHostKeys = new Set(nextAdoptedHosts.map((item) => sessionKeyId(item.key)));
+  const shouldPublish: StructuredHostAdoptionFilter = (entry) =>
+    finalHostKeys.has(sessionKeyId(entry.key)) || finalShouldAdopt(entry);
+  const interruptedCodex = interruptedCodexConversations(
+    registry,
+    shouldPublish,
+    signals.hostedRunningConversationIds,
+    publicationSnapshot,
+  );
+  const finalCodexHosts = nextAdoptedHosts.filter(
+    (item): item is AdoptedCodexHost => item.key.engine === "codex",
+  );
   await bindStructuredDeliveryQueue(nextAdoptedHosts, { registry: dependencies.registry, client });
   if (client) {
     await enqueueInterruptedCodexContinuations(
       registry,
       client,
-      availableCodexHosts,
+      finalCodexHosts,
       interruptedCodex,
       existingCodexContinuations,
       signals.pendingCodexContinuationConversationIds,

--- a/src/lib/runtime/startup.ts
+++ b/src/lib/runtime/startup.ts
@@ -17,7 +17,9 @@ import {
   type StructuredHostAdoptionFilter,
 } from "./registry";
 import { runtimeHostClient, type RuntimeHostClient } from "./client";
+import type { RuntimeOperationResult } from "./contracts";
 import { bindStructuredDeliveryQueue } from "./structuredDeliveryController";
+import { kickStructuredDeliveryQueue } from "./structuredDeliverySignal";
 import { recoverPendingStructuredSpawns } from "./structuredSpawn";
 
 type AdoptedStructuredHost = AdoptedCodexHost | AdoptedClaudeHost;
@@ -49,9 +51,95 @@ const STRUCTURED_HOST_OPERATION_EFFECT_KINDS = [
 interface StructuredStartupSignals {
   hostedRunningConversationIds: ReadonlySet<string>;
   pendingOperationConversationIds: ReadonlySet<string>;
+  pendingCodexContinuationConversationIds: ReadonlySet<string>;
 }
 
 const TRANSCRIPT_REFRESH_CONCURRENCY = 16;
+const INTERRUPTED_CODEX_CONTINUATION_OPERATION_PREFIX = "recovery-continuation";
+const INTERRUPTED_CODEX_CONTINUATION_TEXT = "Continue the interrupted turn from the transcript.";
+
+function interruptedCodexContinuationOperationId(sessionId: string, claimEpoch: number): string {
+  return `${INTERRUPTED_CODEX_CONTINUATION_OPERATION_PREFIX}-${sessionId}-${claimEpoch}`;
+}
+
+function interruptedCodexConversations(
+  registry: AgentRegistry,
+  shouldAdopt: StructuredHostAdoptionFilter,
+): ReadonlyMap<string, ViewerConversationId> {
+  const snapshot = registry.snapshot();
+  return new Map(Object.values(snapshot.conversations).flatMap((conversation) => {
+    const generation = conversation.generations.at(-1);
+    if (conversation.engine !== "codex" || conversation.turn.state !== "busy" || !generation) return [];
+    const key = { engine: "codex" as const, sessionId: generation.id };
+    const entry = snapshot.entries[sessionKeyId(key)];
+    return entry?.structuredHost && shouldAdopt(entry)
+      ? [[sessionKeyId(key), conversation.id] as const]
+      : [];
+  }));
+}
+
+async function enqueueInterruptedCodexContinuations(
+  registry: AgentRegistry,
+  client: RuntimeHostClient,
+  adopted: readonly AdoptedCodexHost[],
+  interrupted: ReadonlyMap<string, ViewerConversationId>,
+  previousByKey: ReadonlyMap<string, RuntimeOperationResult>,
+  pendingContinuationConversationIds: ReadonlySet<string>,
+): Promise<void> {
+  for (const item of adopted) {
+    const key = sessionKeyId(item.key);
+    const conversationId = interrupted.get(key);
+    if (!conversationId) continue;
+    if (pendingContinuationConversationIds.has(conversationId)) continue;
+    const previous = previousByKey.get(key);
+    if (previous) {
+      if (previous.receipt.status === "failed" || previous.receipt.status === "rejected") {
+        if (!previous.receipt.retryOfOperationId) {
+          await client.retryOperation(
+            previous.operationId,
+            `${previous.receipt.idempotencyKey}-retry-1`,
+            { requireHostedConversationId: conversationId },
+          );
+        }
+        continue;
+      }
+      if (previous.receipt.status !== "delivered" || previous.receipt.retryOfOperationId) continue;
+    }
+    const entry = registry.snapshot().entries[key];
+    if (!entry) throw new Error(`adopted Codex registry row disappeared: ${key}`);
+    const operationId = interruptedCodexContinuationOperationId(item.key.sessionId, entry.claimEpoch);
+    await client.command({
+      kind: "send",
+      operationId,
+      idempotencyKey: operationId,
+      conversationId,
+      text: INTERRUPTED_CODEX_CONTINUATION_TEXT,
+      policy: "queue",
+      turnId: null,
+    });
+  }
+}
+
+async function previousInterruptedCodexContinuations(
+  registry: AgentRegistry,
+  client: RuntimeHostClient,
+  adopted: readonly AdoptedCodexHost[],
+  interrupted: ReadonlyMap<string, ViewerConversationId>,
+): Promise<ReadonlyMap<string, RuntimeOperationResult>> {
+  const previousByKey = new Map<string, RuntimeOperationResult>();
+  for (const item of adopted) {
+    const key = sessionKeyId(item.key);
+    if (!interrupted.has(key)) continue;
+    const entry = registry.snapshot().entries[key];
+    if (!entry || entry.claimEpoch <= 0) continue;
+    const previous = await client.operationStatus(
+      interruptedCodexContinuationOperationId(item.key.sessionId, entry.claimEpoch - 1),
+      { currentRetryLeaf: true },
+    );
+    if (previous) previousByKey.set(key, previous);
+  }
+  return previousByKey;
+}
 
 function persistedTurnState(
   records: Record<string, unknown>[],
@@ -128,6 +216,7 @@ async function structuredStartupSignals(
     return {
       hostedRunningConversationIds: new Set(),
       pendingOperationConversationIds: new Set(),
+      pendingCodexContinuationConversationIds: new Set(),
     };
   }
   const runtime = await client.snapshot();
@@ -142,13 +231,20 @@ async function structuredStartupSignals(
       || receipt.status === "applying")
     .filter((receipt) => receipt.kind !== "kill")
     .map((receipt) => canonicalConversationId(registry, receipt.conversationId)));
+  const pendingCodexContinuationConversationIds = new Set<string>();
   let afterEventSeq = 0;
   while (true) {
     const batch = await client.effectBatch(STRUCTURED_HOST_OPERATION_EFFECT_KINDS, afterEventSeq);
     for (const effect of batch) {
       const conversationId = effect.payload.conversationId;
       if (typeof conversationId === "string") {
-        pendingOperationConversationIds.add(canonicalConversationId(registry, conversationId));
+        const canonicalId = canonicalConversationId(registry, conversationId);
+        pendingOperationConversationIds.add(canonicalId);
+        if (effect.kind === "runtime.send"
+          && typeof effect.payload.operationId === "string"
+          && effect.payload.operationId.startsWith(`${INTERRUPTED_CODEX_CONTINUATION_OPERATION_PREFIX}-`)) {
+          pendingCodexContinuationConversationIds.add(canonicalId);
+        }
       }
     }
     if (batch.length < RUNTIME_EFFECT_PAGE_SIZE) break;
@@ -158,7 +254,11 @@ async function structuredStartupSignals(
     }
     afterEventSeq = next;
   }
-  return { hostedRunningConversationIds, pendingOperationConversationIds };
+  return {
+    hostedRunningConversationIds,
+    pendingOperationConversationIds,
+    pendingCodexContinuationConversationIds,
+  };
 }
 
 function structuredStartupAdoptionFilter(
@@ -222,6 +322,7 @@ export async function adoptStructuredHostsAtStartup(
   const client = dependencies.client === undefined ? runtimeHostClient() : dependencies.client;
   const signals = await structuredStartupSignals(registry, client);
   const shouldAdopt = structuredStartupAdoptionFilter(registry, signals);
+  const interruptedCodex = interruptedCodexConversations(registry, shouldAdopt);
   const resolveCodexOwner = dependencies.resolveCodexOwner ?? ((entry: AgentRegistryEntry) =>
     accountManager.resolveTranscriptOwner("codex", entry.artifactPath));
   const resolveClaudeOwner = dependencies.resolveClaudeOwner ?? ((entry: AgentRegistryEntry) =>
@@ -270,8 +371,22 @@ export async function adoptStructuredHostsAtStartup(
   );
   nextAdoptedHosts = retainAdoptedHosts(nextAdoptedHosts, claude);
   retryAdoptedHosts = nextAdoptedHosts;
+  const previousCodexContinuations = client
+    ? await previousInterruptedCodexContinuations(registry, client, codex, interruptedCodex)
+    : new Map<string, RuntimeOperationResult>();
   await demoteSkippedStructuredRegistryHosts(registry, shouldAdopt);
   await bindStructuredDeliveryQueue(nextAdoptedHosts, { registry: dependencies.registry, client });
+  if (client) {
+    await enqueueInterruptedCodexContinuations(
+      registry,
+      client,
+      codex,
+      interruptedCodex,
+      previousCodexContinuations,
+      signals.pendingCodexContinuationConversationIds,
+    );
+    await kickStructuredDeliveryQueue();
+  }
   if (client) await recoverPendingStructuredSpawns(registry, client);
   adoptedHosts = nextAdoptedHosts;
   retryAdoptedHosts = [];

--- a/src/lib/runtime/structuredControls.test.ts
+++ b/src/lib/runtime/structuredControls.test.ts
@@ -60,7 +60,7 @@ function structuredConversation(
   return { registry, path: pathname, conversationId: begun.receipt.conversationId };
 }
 
-test.each(["compact", "dialog-key", "resume"])(
+test.each(["compact", "dialog-key"])(
   "structured ownership fences the %s control before legacy routing",
   async (action) => {
     const fixture = structuredConversation();
@@ -207,15 +207,30 @@ test("a failed structured restart keeps reconfigure routing during host recovery
   expect(commands).toHaveLength(1);
 });
 
-test("structured ownership resolves from conversation identity", async () => {
+test("resume converges on and republishes an already live structured successor", async () => {
   const fixture = structuredConversation();
+  const republished: unknown[] = [];
   const result = await dispatchStructuredControl({ path: "", conversationId: fixture.conversationId, action: "resume" }, {
     registry: fixture.registry,
     client: null,
     enabled: () => true,
+    republish: async (key) => {
+      republished.push(key);
+      return true;
+    },
   });
 
-  expect(result).toEqual({ status: 409, body: { error: "structured host does not support the resume control" } });
+  expect(republished).toEqual([{ engine: "codex", sessionId: expect.any(String) }]);
+  expect(result).toEqual({
+    status: 200,
+    body: {
+      ok: true,
+      structured: true,
+      target: fixture.conversationId,
+      outcome: "resumed",
+      spawned: false,
+    },
+  });
 });
 
 test("stale-live Codex resume recovers the production conversation identity", async () => {

--- a/src/lib/runtime/structuredControls.ts
+++ b/src/lib/runtime/structuredControls.ts
@@ -6,6 +6,7 @@ import { sessionKeyId } from "@/lib/agent/sessionKey";
 
 import { isRuntimeHostTransportFailure, runtimeHostClient, type RuntimeHostClient } from "./client";
 import { newOperationId } from "./contracts";
+import { republishStructuredDeliveryHost } from "./structuredDeliveryController";
 import { kickStructuredDeliveryQueue } from "./structuredDeliverySignal";
 import { recoverDeadStructuredConversation, structuredHostProcessAlive } from "./structuredRecovery";
 
@@ -32,6 +33,7 @@ export async function dispatchStructuredControl(
     enabled?: () => boolean;
     accountExists?: (engine: "claude" | "codex", accountId: string) => boolean;
     recover?: typeof recoverDeadStructuredConversation;
+    republish?: typeof republishStructuredDeliveryHost;
     hostProcessAlive?: (identity: ProcessIdentity | null) => boolean;
   } = {},
 ): Promise<StructuredControlResult | null> {
@@ -64,12 +66,28 @@ export async function dispatchStructuredControl(
   if (!entry.structuredHost && !structuredKill && !structuredReconfigureRestart) return null;
 
   if (request.action !== "interrupt" && request.action !== "kill" && request.action !== "reconfigure") {
-    if (request.action === "resume" && (entry.status === "dead" || entry.status === "unhosted")) {
-      return null;
-    }
-    if (request.action === "resume"
-      && !(dependencies.hostProcessAlive ?? structuredHostProcessAlive)(entry.structuredHost?.process ?? null)) {
+    if (request.action === "resume") {
+      if (entry.status === "dead" || entry.status === "unhosted") return null;
       try {
+        if ((dependencies.hostProcessAlive ?? structuredHostProcessAlive)(entry.structuredHost?.process ?? null)) {
+          const republished = await (dependencies.republish ?? republishStructuredDeliveryHost)({
+            engine: conversation.engine,
+            sessionId: generation.id,
+          });
+          if (!republished) {
+            return { status: 503, body: { error: "structured recovery ownership is unavailable" } };
+          }
+          return {
+            status: 200,
+            body: {
+              ok: true,
+              structured: true,
+              target: conversation.id,
+              outcome: "resumed",
+              spawned: false,
+            },
+          };
+        }
         const recovered = await (dependencies.recover ?? recoverDeadStructuredConversation)({
           path: request.path || generation.path,
           conversationId: conversation.id,
@@ -91,7 +109,7 @@ export async function dispatchStructuredControl(
         return { status: 503, body: { error: error instanceof Error ? error.message : String(error) } };
       }
     }
-    const label = ["compact", "dialog-key", "kill", "reconfigure", "resume"].includes(request.action)
+    const label = ["compact", "dialog-key", "kill", "reconfigure"].includes(request.action)
       ? request.action
       : "requested";
     return { status: 409, body: { error: `structured host does not support the ${label} control` } };


### PR DESCRIPTION
## Summary

- persist and drain post-promotion continuation through the ordered runtime queue
- republish live structured successors during Resume and terminal Retry
- converge one ownership-change race while preserving idempotency and draft order
- keep terminal recovery failures visible and retryable

## Verification

- focused runtime and UI suite: 119 passing
- TypeScript passed
- scoped ESLint passed
- production build passed
- exact CelestiaCompose production failure shape covered

Closes #253