### PR TITLE
feat(feed): readable tool blocks with lifecycle parity (#475)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,8 @@ prod.log
 !/.claude/skills/
 /.tmux-multi-agent/
 /fixtures/demo-home/.capture/
+
+# ad-hoc readable-tool review stills (issue #475): regenerate with
+# `bun scripts/readable-tool-shots.tsx`. Committed screenshots must instead go
+# through the provenance-signed demo-capture pipeline, so keep these local.
+/docs/media/readable-tools/

--- a/scripts/readable-tool-shots.tsx
+++ b/scripts/readable-tool-shots.tsx
@@ -1,0 +1,95 @@
+/**
+ * Privacy-safe screenshots for the readable tool block (issue #475).
+ *
+ *   bun scripts/readable-tool-shots.tsx
+ *
+ * Server-renders the real feed cards (collapsed aggregate + expanded readable
+ * blocks) against the production Tailwind stylesheet emitted by `bun run build`,
+ * then captures desktop and 390px stills with local headless Chrome. Every
+ * value is synthetic — no real path, secret, or host is rendered.
+ */
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { CmdGroupCard } from "@/components/feed/cards/CmdGroupCard";
+import { ToolCard } from "@/components/feed/cards/ToolCard";
+import { execSuccess, toolEvent } from "@/components/feed/__fixtures__/readableTools";
+import type { CmdGroupItem, ToolEvent } from "@/components/feed/parse";
+
+const OUT_DIR = path.join(import.meta.dir, "..", "docs", "media", "readable-tools");
+const CHROME = process.env.CHROME_BIN || "google-chrome-stable";
+
+function group(calls: ToolEvent[], hasErr: boolean): CmdGroupItem {
+  const byTool: Record<string, number> = {};
+  for (const c of calls) byTool[c.tool] = (byTool[c.tool] ?? 0) + 1;
+  return {
+    kind: "cmd-group",
+    ids: calls.map((c) => c.id),
+    calls,
+    t0: calls[0].ts,
+    t1: "2100-01-02T12:00:20Z",
+    byTool,
+    okCount: calls.filter((c) => c.status === "ok").length,
+    errCount: calls.filter((c) => c.status === "err").length,
+    hasErr,
+  };
+}
+
+// The exec run the group folds: a clean status, an interactive dev-server with a
+// wait tail and stdin poll, and a failing test with split stdout/stderr.
+const ts = "2100-01-02T12:00:00Z";
+const gitStatus = toolEvent({ ...execSuccess, ts, id: "g1", cwd: "/workspace/app", endTs: "2100-01-02T12:00:00.240Z" });
+const npmDev = toolEvent({ id: "e2", tool: "exec_command", ts, summary: "npm run dev", command: "npm run dev", cwd: "/workspace/app", outputPreview: "starting dev server on :3000" });
+const wait = toolEvent({ id: "w2", tool: "wait", ts, summary: "wait · 8479", statusLabel: "waiting 10s", durationMs: 10_000, outputPreview: "compiled successfully" });
+const poll = toolEvent({ id: "s2", tool: "write_stdin", ts, summary: "stdin → 8479 · poll", statusLabel: "waiting 5s", durationMs: 5_000, outputPreview: "" });
+const bunTest = toolEvent({
+  id: "e3", tool: "exec_command", ts, summary: "bun test", command: "bun test ./src/components/feed", cwd: "/workspace/app",
+  status: "err", statusLabel: "exit 1", exitCode: 1, durationMs: 1830, endTs: "2100-01-02T12:00:01.830Z", open: true,
+  outputPreview: "src/feed.test.ts:\n 41 pass\n 1 fail",
+  stderr: "error: expected true to be false\n  at feed.test.ts:88", stderrTruncated: false,
+});
+
+const okCalls = [gitStatus, npmDev, wait, poll, toolEvent({ id: "r1", tool: "Read", family: "read", icon: "file", ts, summary: "Read config.ts" })];
+const errCalls = [gitStatus, npmDev, wait, poll, bunTest];
+
+function page(): string {
+  const collapsed = renderToStaticMarkup(<CmdGroupCard item={group(okCalls, false)} />);
+  const expanded = renderToStaticMarkup(<CmdGroupCard item={group(errCalls, true)} />);
+  const single = renderToStaticMarkup(<ToolCard event={{ ...execSuccess, ts, endTs: "2100-01-02T12:00:00.240Z", open: true }} />);
+  const css = fs.readdirSync(path.join(import.meta.dir, "..", ".next", "static", "css"))
+    .filter((f) => f.endsWith(".css"))
+    .map((f) => fs.readFileSync(path.join(import.meta.dir, "..", ".next", "static", "css", f), "utf8"))
+    .join("\n");
+  const section = (title: string, body: string) =>
+    `<div class="mb-4"><div class="mb-1 text-caption font-semibold uppercase tracking-wide text-muted">${title}</div><div class="text-secondary">${body}</div></div>`;
+  return `<!doctype html><html lang="en" data-theme="light"><head><meta charset="utf-8"><style>${css}
+    html,body{margin:0;background:var(--color-canvas)}
+    #shot{padding:20px}
+  </style></head><body><div id="shot">
+    ${section("Compact aggregate (collapsed)", collapsed)}
+    ${section("Readable blocks (expanded)", expanded)}
+    ${section("Standalone tool block", single)}
+  </div></body></html>`;
+}
+
+function capture(html: string, width: number, name: string): void {
+  const htmlPath = path.join(OUT_DIR, `${name}.html`);
+  fs.writeFileSync(htmlPath, html);
+  const out = path.join(OUT_DIR, `${name}.png`);
+  const res = spawnSync(CHROME, [
+    "--headless=new", "--disable-gpu", "--no-sandbox", "--hide-scrollbars", "--force-device-scale-factor=1",
+    `--window-size=${width},1400`, `--screenshot=${out}`, `file://${htmlPath}`,
+  ], { encoding: "utf8" });
+  if (res.status !== 0) throw new Error(`chrome failed for ${name}: ${res.stderr}`);
+  fs.rmSync(htmlPath);
+  const bytes = fs.statSync(out).size;
+  process.stdout.write(`${name}.png ${bytes} bytes @ ${width}px\n`);
+}
+
+fs.mkdirSync(OUT_DIR, { recursive: true });
+const html = page();
+capture(html, 1280, "readable-tools-desktop");
+capture(html, 390, "readable-tools-390");

--- a/scripts/readable-tool-shots.tsx
+++ b/scripts/readable-tool-shots.tsx
@@ -22,7 +22,7 @@ import type { CmdGroupItem, ToolEvent } from "@/components/feed/parse";
 const OUT_DIR = path.join(import.meta.dir, "..", "docs", "media", "readable-tools");
 const CHROME = process.env.CHROME_BIN || "google-chrome-stable";
 
-function group(calls: ToolEvent[], hasErr: boolean): CmdGroupItem {
+function group(calls: ToolEvent[], hasErr: boolean, active = false): CmdGroupItem {
   const byTool: Record<string, number> = {};
   for (const c of calls) byTool[c.tool] = (byTool[c.tool] ?? 0) + 1;
   return {
@@ -35,6 +35,7 @@ function group(calls: ToolEvent[], hasErr: boolean): CmdGroupItem {
     okCount: calls.filter((c) => c.status === "ok").length,
     errCount: calls.filter((c) => c.status === "err").length,
     hasErr,
+    active,
   };
 }
 
@@ -57,7 +58,9 @@ const errCalls = [gitStatus, npmDev, wait, poll, bunTest];
 
 function page(): string {
   const collapsed = renderToStaticMarkup(<CmdGroupCard item={group(okCalls, false)} />);
-  const expanded = renderToStaticMarkup(<CmdGroupCard item={group(errCalls, true)} />);
+  // The live trailing aggregate renders expanded with every command and output
+  // shown inline — no per-call disclosure (issue #475).
+  const expanded = renderToStaticMarkup(<CmdGroupCard item={group(errCalls, true, true)} />);
   const single = renderToStaticMarkup(<ToolCard event={{ ...execSuccess, ts, endTs: "2100-01-02T12:00:00.240Z", open: true }} />);
   const css = fs.readdirSync(path.join(import.meta.dir, "..", ".next", "static", "css"))
     .filter((f) => f.endsWith(".css"))

--- a/src/components/feed/__fixtures__/readableTools.ts
+++ b/src/components/feed/__fixtures__/readableTools.ts
@@ -119,6 +119,7 @@ export const nestedParent = toolEvent({
   command: "npm run dev",
   cwd: "/workspace/app",
   outputPreview: "starting dev server",
+  runtimeSessionId: "8479",
 });
 export const nestedWait = toolEvent({
   id: "wait-1",
@@ -126,6 +127,7 @@ export const nestedWait = toolEvent({
   summary: "wait · 8479",
   statusLabel: "waiting 10s",
   outputPreview: "compiled successfully",
+  runtimeSessionId: "8479",
 });
 export const nestedPoll = toolEvent({
   id: "poll-1",
@@ -133,6 +135,7 @@ export const nestedPoll = toolEvent({
   summary: "stdin → 8479 · poll",
   statusLabel: "waiting 5s",
   outputPreview: "",
+  runtimeSessionId: "8479",
 });
 
 /** A cmd-group carrying the nested exec/wait/poll run plus a standalone read. */

--- a/src/components/feed/__fixtures__/readableTools.ts
+++ b/src/components/feed/__fixtures__/readableTools.ts
@@ -1,0 +1,187 @@
+import type { CmdGroupItem, ToolEvent } from "../parse";
+
+/* Synthetic fixtures behind the readable tool block (issue #475). Two flavours:
+   - ToolEvent objects for DOM tests that render the cards directly.
+   - Raw JSONL line builders for parser tests that feed buildFeed and assert the
+     structured fields (cwd, exitCode, durationMs, endTs, split stderr).
+   No fixture carries a real path, secret, or host value. */
+
+export function toolEvent(over: Partial<ToolEvent> = {}): ToolEvent {
+  return {
+    kind: "tool",
+    id: "call-1",
+    ts: "2026-07-10T10:00:00Z",
+    srcCall: 0,
+    family: "shell",
+    tool: "Bash",
+    icon: "shell",
+    summary: "ls -la",
+    chips: [],
+    status: "ok",
+    statusLabel: "ok",
+    outputPreview: "",
+    outputTruncated: false,
+    open: false,
+    ...over,
+  };
+}
+
+/** exec success: cwd, duration, exit 0, and a small stdout body. */
+export const execSuccess = toolEvent({
+  id: "exec-ok",
+  summary: "git status",
+  command: "git status --short",
+  cwd: "/workspace/app",
+  durationMs: 240,
+  endTs: "2026-07-10T10:00:00.240Z",
+  exitCode: 0,
+  outputPreview: " M src/index.ts\n M README.md",
+});
+
+/** exec failure: non-zero exit, danger tone, error text on the output stream. */
+export const execFailure = toolEvent({
+  id: "exec-err",
+  summary: "bun test",
+  command: "bun test",
+  cwd: "/workspace/app",
+  durationMs: 1830,
+  endTs: "2026-07-10T10:00:01.830Z",
+  status: "err",
+  statusLabel: "exit 3",
+  exitCode: 3,
+  outputPreview: "1 fail\nexpected true to be false",
+  open: true,
+});
+
+/** A long multiline command that must wrap instead of scrolling the document. */
+export const longCommand = toolEvent({
+  id: "exec-long",
+  summary: "for f in *.ts; do …",
+  command:
+    "for f in $(git ls-files '*.ts'); do echo \"formatting ${f} with a rather long pipeline of tools\"; prettier --write \"$f\" && eslint --fix \"$f\"; done && echo done",
+  cwd: "/workspace/a/very/deeply/nested/project/that/keeps/going/and/going/src",
+  durationMs: 62_000,
+  endTs: "2026-07-10T10:01:02Z",
+  exitCode: 0,
+  outputPreview: "formatting one.ts\nformatting two.ts\ndone",
+});
+
+/** Large stdout that overflows the preview budget and offers "show all". */
+export const largeStdout = toolEvent({
+  id: "exec-big",
+  summary: "cat build.log",
+  command: "cat build.log",
+  outputPreview: Array.from({ length: 80 }, (_, i) => `line ${i + 1} of build output`).join("\n"),
+  outputTruncated: false,
+});
+
+/** Split stdout + stderr streams into their own disclosures. */
+export const withStderr = toolEvent({
+  id: "exec-stderr",
+  summary: "cargo build",
+  command: "cargo build --release",
+  cwd: "/workspace/rust",
+  durationMs: 4200,
+  endTs: "2026-07-10T10:00:04.200Z",
+  exitCode: 0,
+  outputPreview: "Compiling app v0.1.0\nFinished release target",
+  stderr: "warning: unused variable `x`\nwarning: 1 warning emitted",
+  stderrTruncated: false,
+});
+
+/** Explicitly truncated stdout: the block must say so and gate "show all". */
+export const truncatedOutput = toolEvent({
+  id: "exec-trunc",
+  summary: "grep -r pattern",
+  command: "grep -rn pattern .",
+  outputPreview: Array.from({ length: 60 }, (_, i) => `match ${i + 1}`).join("\n"),
+  outputTruncated: true,
+});
+
+/** Unknown typed payload: a tool the taxonomy does not recognize keeps the
+    generic fallback summary and renders without a command block or a crash. */
+export const unknownFallback = toolEvent({
+  id: "unknown-1",
+  family: "other",
+  tool: "SomeFutureTool",
+  icon: "tool",
+  summary: "SomeFutureTool: opaque payload",
+  command: undefined,
+  outputPreview: "{\"result\":\"opaque\"}",
+});
+
+/** A Codex interactive-shell run: an exec parent followed by a wait tail and an
+    empty stdin poll — the three the group must nest as one ordered block. */
+export const nestedParent = toolEvent({
+  id: "exec-session",
+  tool: "exec_command",
+  summary: "npm run dev",
+  command: "npm run dev",
+  cwd: "/workspace/app",
+  outputPreview: "starting dev server",
+});
+export const nestedWait = toolEvent({
+  id: "wait-1",
+  tool: "wait",
+  summary: "wait · 8479",
+  statusLabel: "waiting 10s",
+  outputPreview: "compiled successfully",
+});
+export const nestedPoll = toolEvent({
+  id: "poll-1",
+  tool: "write_stdin",
+  summary: "stdin → 8479 · poll",
+  statusLabel: "waiting 5s",
+  outputPreview: "",
+});
+
+/** A cmd-group carrying the nested exec/wait/poll run plus a standalone read. */
+export function nestedGroup(): CmdGroupItem {
+  const calls = [nestedParent, nestedWait, nestedPoll, toolEvent({ id: "read-1", family: "read", tool: "Read", icon: "file", summary: "Read config.ts" })];
+  return {
+    kind: "cmd-group",
+    ids: calls.map((c) => c.id),
+    calls,
+    t0: calls[0].ts,
+    t1: "2026-07-10T10:00:20Z",
+    byTool: { exec_command: 1, wait: 1, write_stdin: 1, Read: 1 },
+    okCount: 4,
+    errCount: 0,
+    hasErr: false,
+  };
+}
+
+/* --- Raw JSONL line builders for the parser fixtures --------------------- */
+
+const codexLine = (payload: Record<string, unknown>, timestamp = "2026-07-10T10:00:00Z") =>
+  JSON.stringify({ type: "response_item", timestamp, payload });
+
+/** Codex exec_command (cwd via the `workdir` arg) → result with a Wall time
+    preamble, an exit code, and an explicitly delimited stderr tail. */
+export function codexExecStderrLines(): string[] {
+  return [
+    codexLine({
+      type: "function_call",
+      call_id: "call-x",
+      name: "exec_command",
+      arguments: JSON.stringify({ cmd: "make", workdir: "/workspace/build" }),
+    }),
+    codexLine(
+      {
+        type: "function_call_output",
+        call_id: "call-x",
+        output: "Script completed\nWall time 2.5 seconds\nProcess exited with code 0\nOutput:\nbuilt target app\n[stderr]\nwarning: deprecated flag",
+      },
+      "2026-07-10T10:00:03Z",
+    ),
+  ];
+}
+
+/** A plain Claude Bash call whose command carries a `cd … &&` cwd prefix and a
+    non-zero exit result. */
+export function claudeExecFailLines(): string[] {
+  return [
+    JSON.stringify({ type: "assistant", timestamp: "2026-07-10T10:00:00Z", message: { content: [{ type: "tool_use", id: "b1", name: "Bash", input: { command: "cd /workspace/app && bun test" } }] } }),
+    JSON.stringify({ type: "user", timestamp: "2026-07-10T10:00:02Z", message: { content: [{ type: "tool_result", tool_use_id: "b1", content: [{ type: "text", text: "1 fail\nexited with code 2" }], is_error: true }] } }),
+  ];
+}

--- a/src/components/feed/__fixtures__/readableTools.ts
+++ b/src/components/feed/__fixtures__/readableTools.ts
@@ -136,7 +136,7 @@ export const nestedPoll = toolEvent({
 });
 
 /** A cmd-group carrying the nested exec/wait/poll run plus a standalone read. */
-export function nestedGroup(): CmdGroupItem {
+export function nestedGroup(over: Partial<CmdGroupItem> = {}): CmdGroupItem {
   const calls = [nestedParent, nestedWait, nestedPoll, toolEvent({ id: "read-1", family: "read", tool: "Read", icon: "file", summary: "Read config.ts" })];
   return {
     kind: "cmd-group",
@@ -148,10 +148,80 @@ export function nestedGroup(): CmdGroupItem {
     okCount: 4,
     errCount: 0,
     hasErr: false,
+    active: false,
+    ...over,
+  };
+}
+
+/** A settled aggregate group: two completed exec calls with commands + output,
+    no active flag — a historical run rendered from a static transcript. */
+export function settledGroup(over: Partial<CmdGroupItem> = {}): CmdGroupItem {
+  const calls = [
+    { ...execSuccess, id: "g-1" },
+    { ...withStderr, id: "g-2" },
+  ];
+  return {
+    kind: "cmd-group",
+    ids: calls.map((c) => c.id),
+    calls,
+    t0: calls[0].ts,
+    t1: "2026-07-10T10:00:04Z",
+    byTool: { Bash: 2 },
+    okCount: 2,
+    errCount: 0,
+    hasErr: false,
+    active: false,
+    ...over,
+  };
+}
+
+/** The trailing live aggregate: the same run marked `active` — one expanded
+    group whose commands and outputs must all show immediately (issue #475). */
+export function activeGroup(over: Partial<CmdGroupItem> = {}): CmdGroupItem {
+  return settledGroup({ active: true, ...over });
+}
+
+/** A trailing live aggregate that carries a failure: the compact summary must
+    keep the failure status and count visible even after it auto-collapses. */
+export function activeFailureGroup(over: Partial<CmdGroupItem> = {}): CmdGroupItem {
+  const calls = [
+    { ...execSuccess, id: "gf-1" },
+    { ...execFailure, id: "gf-2" },
+  ];
+  return {
+    kind: "cmd-group",
+    ids: calls.map((c) => c.id),
+    calls,
+    t0: calls[0].ts,
+    t1: "2026-07-10T10:00:01Z",
+    byTool: { Bash: 2 },
+    okCount: 1,
+    errCount: 1,
+    hasErr: true,
+    active: true,
+    ...over,
   };
 }
 
 /* --- Raw JSONL line builders for the parser fixtures --------------------- */
+
+/** A live Claude turn whose trailing tool run is still in flight: two completed
+    Bash calls followed by a third that has no result yet (status "run"). The
+    whole run must fold into one active aggregate — the in-flight call included —
+    not a settled group plus a loose running row (issue #475). */
+export function liveTrailingRunLines(): string[] {
+  const toolUse = (id: string, command: string, ts: string) =>
+    JSON.stringify({ type: "assistant", timestamp: ts, message: { content: [{ type: "tool_use", id, name: "Bash", input: { command } }] } });
+  const toolResult = (id: string, text: string, ts: string) =>
+    JSON.stringify({ type: "user", timestamp: ts, message: { content: [{ type: "tool_result", tool_use_id: id, content: [{ type: "text", text }] }] } });
+  return [
+    toolUse("b1", "git status --short", "2026-07-10T10:00:00Z"),
+    toolResult("b1", " M src/index.ts", "2026-07-10T10:00:00Z"),
+    toolUse("b2", "bun test", "2026-07-10T10:00:01Z"),
+    toolResult("b2", "5 pass", "2026-07-10T10:00:01Z"),
+    toolUse("b3", "bun run build", "2026-07-10T10:00:02Z"),
+  ];
+}
 
 const codexLine = (payload: Record<string, unknown>, timestamp = "2026-07-10T10:00:00Z") =>
   JSON.stringify({ type: "response_item", timestamp, payload });

--- a/src/components/feed/cards/CmdGroupCard.tsx
+++ b/src/components/feed/cards/CmdGroupCard.tsx
@@ -5,6 +5,7 @@ import { useState } from "react";
 import { ChevronRight } from "../../icons";
 import { hhmm } from "../../utils";
 import { tr, type CmdGroupItem } from "../parse";
+import { groupNestedCalls } from "../toolBlocks";
 import { StatusIcon } from "./shared";
 import { ToolLine } from "./ToolCard";
 
@@ -25,6 +26,9 @@ export function CmdGroupCard({ item }: { item: CmdGroupItem }) {
   const t0 = hhmm(item.t0);
   const t1 = hhmm(item.t1);
   const range = t0 && t1 && t0 !== t1 ? `${t0}–${t1}` : t0 || t1;
+  /* One ordered block per top-level call, with any trailing wait/stdin polls
+     nested under the exec that owns them (issue #475). */
+  const blocks = groupNestedCalls(item.calls);
   return (
     <details
       className="group/grp ml-9"
@@ -38,7 +42,7 @@ export function CmdGroupCard({ item }: { item: CmdGroupItem }) {
           item.hasErr ? "text-danger" : "text-muted"
         }`}
       >
-        <ChevronRight className="h-3.5 w-3.5 shrink-0 transition-transform group-open/grp:rotate-90" aria-hidden />
+        <ChevronRight className="h-3.5 w-3.5 shrink-0 transition-transform motion-reduce:transition-none group-open/grp:rotate-90" aria-hidden />
         <span className="flex min-w-0 flex-1 items-center gap-1 truncate text-secondary">
           {tr("render.actions", { count: item.calls.length })}
           {tools ? " · " + tools : ""}
@@ -52,16 +56,26 @@ export function CmdGroupCard({ item }: { item: CmdGroupItem }) {
         {range ? <span className="ml-auto shrink-0 text-caption tabular-nums text-muted">{range}</span> : null}
       </summary>
       {/* Each grouped call reuses the shared ToolLine, so an expanded call shows
-          the same chips + raw record a standalone line does. The time is dropped
-          here — the range lives in the group header above. */}
+          the same readable block a standalone line does. Blocks are an ordered
+          list; a wait/stdin follow-up renders nested under its parent exec while
+          keeping its own state. The time is dropped — the range lives in the
+          header above. A transcript can carry the same tool id twice (a resume
+          re-emits the tool_use), so the id alone is not a unique key. */}
       {mounted ? (
-        <div className="mb-1 mt-1 space-y-0.5">
-          {item.calls.map((event, idx) => (
-            /* A transcript can carry the same tool id twice (a resume re-emits the
-               tool_use), so the id alone is not a unique key. */
-            <ToolLine key={`${item.ids[idx]}:${idx}`} event={event} showTime={false} />
+        <ol className="mb-1 mt-1 space-y-0.5">
+          {blocks.map((block, bi) => (
+            <li key={`${block.parent.id}:${bi}`} className="min-w-0">
+              <ToolLine event={block.parent} showTime={false} index={bi + 1} />
+              {block.children.length ? (
+                <div className="ml-4 border-l border-border pl-2">
+                  {block.children.map((child, ci) => (
+                    <ToolLine key={`${child.id}:${ci}`} event={child} showTime={false} nested />
+                  ))}
+                </div>
+              ) : null}
+            </li>
           ))}
-        </div>
+        </ol>
       ) : null}
     </details>
   );

--- a/src/components/feed/cards/CmdGroupCard.tsx
+++ b/src/components/feed/cards/CmdGroupCard.tsx
@@ -25,6 +25,7 @@ export function CmdGroupCard({ item }: { item: CmdGroupItem }) {
   /* The operator's manual choice once the group has settled. `null` means "no
      manual choice yet", so the default (error → open, else collapsed) applies. */
   const [manualOpen, setManualOpen] = useState<boolean | null>(null);
+  const [autoCollapseApplied, setAutoCollapseApplied] = useState(false);
   /* The single auto-collapse: detect the first live→settled transition during
      render (the React-blessed "adjust state on prop change" pattern) so the
      collapse is applied before the DOM ever shows the settled group open. A
@@ -34,7 +35,10 @@ export function CmdGroupCard({ item }: { item: CmdGroupItem }) {
   const [wasActive, setWasActive] = useState(active);
   if (wasActive !== active) {
     setWasActive(active);
-    if (wasActive && !active) setManualOpen(false);
+    if (wasActive && !active && !autoCollapseApplied) {
+      setAutoCollapseApplied(true);
+      setManualOpen(false);
+    }
   }
 
   /* Active → always open; settled → the operator's choice, else the error

--- a/src/components/feed/cards/CmdGroupCard.tsx
+++ b/src/components/feed/cards/CmdGroupCard.tsx
@@ -7,19 +7,40 @@ import { hhmm } from "../../utils";
 import { tr, type CmdGroupItem } from "../parse";
 import { groupNestedCalls } from "../toolBlocks";
 import { StatusIcon } from "./shared";
-import { ToolLine } from "./ToolCard";
+import { ToolBlockRow } from "./ToolCard";
 
 /* A run of ≥2 consecutive tool events folded into one quiet ToolLine header
-   (design doc §3.4): `▸ N дій · Tool ×a · Tool ×b · t0–t1`. Expanded, it lists
-   the individual calls as quiet ToolLines. A group carrying an error opens by
-   default and shows the failing line in danger — an error is never hidden. */
+   (design doc §3.4): `▸ N дій · Tool ×a · Tool ×b · t0–t1`.
+
+   Lifecycle parity with Claude's UPDATE cards (issue #475): while the run is the
+   live trailing aggregate (`item.active`) the group is forced open and its body
+   shows every command and its owned output at once — no nested disclosure. When
+   the run settles (`active` flips to false) the group auto-collapses exactly once
+   to the compact summary; after that the operator's manual open/close wins and
+   persists across live ticks. A settled group that carries an error opens by
+   default so a failure is never hidden, and its count stays on the compact
+   summary line even when collapsed. */
 export function CmdGroupCard({ item }: { item: CmdGroupItem }) {
-  /* Children (and their diff / output / raw-record bodies) mount only after the
-     group is first expanded. A diff-backed child sets open:true, so rendering it
-     inside a still-collapsed group would eagerly build the hidden body and break
-     the §3.4 lazy contract for long edit runs (issue #9 §7/§8). An error group
-     opens by default, so it mounts immediately. */
-  const [mounted, setMounted] = useState(item.hasErr);
+  const active = item.active;
+  /* The operator's manual choice once the group has settled. `null` means "no
+     manual choice yet", so the default (error → open, else collapsed) applies. */
+  const [manualOpen, setManualOpen] = useState<boolean | null>(null);
+  /* The single auto-collapse: detect the first live→settled transition during
+     render (the React-blessed "adjust state on prop change" pattern) so the
+     collapse is applied before the DOM ever shows the settled group open. A
+     never-active (historical) group never triggers it, so it keeps its error-open
+     default; and it fires once, so a later re-feed can't reclose a group the
+     operator has reopened. */
+  const [wasActive, setWasActive] = useState(active);
+  if (wasActive !== active) {
+    setWasActive(active);
+    if (wasActive && !active) setManualOpen(false);
+  }
+
+  /* Active → always open; settled → the operator's choice, else the error
+     default. */
+  const open = active ? true : (manualOpen ?? item.hasErr);
+
   const tools = Object.entries(item.byTool)
     .map(([tool, count]) => `${tool} ×${count}`)
     .join(" · ");
@@ -32,9 +53,17 @@ export function CmdGroupCard({ item }: { item: CmdGroupItem }) {
   return (
     <details
       className="group/grp ml-9"
-      open={item.hasErr}
+      open={open}
       onToggle={(e) => {
-        if (e.currentTarget.open) setMounted(true);
+        const next = e.currentTarget.open;
+        /* While live the aggregate stays open: undo an operator's collapse
+           attempt (React won't re-assert an unchanged `open` prop, so reset the
+           DOM node directly) instead of recording it. */
+        if (active) {
+          if (!next) e.currentTarget.open = true;
+          return;
+        }
+        if (next !== open) setManualOpen(next);
       }}
     >
       <summary
@@ -55,21 +84,22 @@ export function CmdGroupCard({ item }: { item: CmdGroupItem }) {
         </span>
         {range ? <span className="ml-auto shrink-0 text-caption tabular-nums text-muted">{range}</span> : null}
       </summary>
-      {/* Each grouped call reuses the shared ToolLine, so an expanded call shows
-          the same readable block a standalone line does. Blocks are an ordered
-          list; a wait/stdin follow-up renders nested under its parent exec while
-          keeping its own state. The time is dropped — the range lives in the
-          header above. A transcript can carry the same tool id twice (a resume
-          re-emits the tool_use), so the id alone is not a unique key. */}
-      {mounted ? (
+      {/* An ordered list of readable blocks. Each call renders inline via
+          {@link ToolBlockRow} — its command and output are shown at once, with no
+          per-call disclosure to click — and a wait/stdin follow-up renders nested
+          under its parent exec while keeping its own state. Mounted only while
+          open, so a collapsed transcript keeps its DOM small (issue #9 §7/§8). A
+          transcript can carry the same tool id twice (a resume re-emits the
+          tool_use), so the id alone is not a unique key. */}
+      {open ? (
         <ol className="mb-1 mt-1 space-y-0.5">
           {blocks.map((block, bi) => (
             <li key={`${block.parent.id}:${bi}`} className="min-w-0">
-              <ToolLine event={block.parent} showTime={false} index={bi + 1} />
+              <ToolBlockRow event={block.parent} index={bi + 1} />
               {block.children.length ? (
                 <div className="ml-4 border-l border-border pl-2">
                   {block.children.map((child, ci) => (
-                    <ToolLine key={`${child.id}:${ci}`} event={child} showTime={false} nested />
+                    <ToolBlockRow key={`${child.id}:${ci}`} event={child} nested />
                   ))}
                 </div>
               ) : null}

--- a/src/components/feed/cards/OutputPreview.tsx
+++ b/src/components/feed/cards/OutputPreview.tsx
@@ -21,18 +21,34 @@ export function OutputPreview({
   truncated,
   lang,
   copyLabel,
+  heading,
+  tone = "out",
+  emptyLabel,
+  emptyTip,
+  showAllLabel,
 }: {
   output: string;
   truncated: boolean;
   lang?: string | null;
   copyLabel?: string;
+  /** Small stream label above the block (e.g. "stdout"/"stderr", issue #475). */
+  heading?: string;
+  /** `err` tints the block and heading for the stderr stream. */
+  tone?: "out" | "err";
+  emptyLabel?: string;
+  emptyTip?: string;
+  showAllLabel?: string;
 }) {
   const [all, setAll] = useState(false);
+  const label = heading ? (
+    <div className={`mb-1 text-[10.5px] font-semibold uppercase tracking-wide ${tone === "err" ? "text-danger" : "text-muted"}`}>{heading}</div>
+  ) : null;
   if (!output.trim()) {
     return (
       <div className="mt-1.5">
-        <span className="inline-flex items-center rounded-md bg-sunken px-2 py-0.5 text-[11px] text-muted" title={tr("tools.noOutputTip")}>
-          {tr("tools.noOutput")}
+        {label}
+        <span className="inline-flex items-center rounded-md bg-sunken px-2 py-0.5 text-[11px] text-muted" title={emptyTip ?? tr("tools.noOutputTip")}>
+          {emptyLabel ?? tr("tools.noOutput")}
         </span>
       </div>
     );
@@ -40,19 +56,21 @@ export function OutputPreview({
   const lines = output.split("\n");
   const overflow = lines.length > PREVIEW_LINES || output.length > PREVIEW_CHARS;
   const shown = all ? output : lines.slice(0, PREVIEW_LINES).join("\n").slice(0, PREVIEW_CHARS);
+  const border = tone === "err" ? "border-danger/40" : "border-border";
   return (
     <div className="group/out relative mt-1.5">
+      {label}
       {all && lang ? (
         <CodeBlock code={shown} lang={lang} />
       ) : (
-        <pre className="max-h-[420px] max-w-full overflow-auto whitespace-pre rounded-[10px] border border-border bg-sunken px-3 py-2 font-mono text-[12px]">
+        <pre className={`max-h-[420px] max-w-full overflow-auto whitespace-pre-wrap [overflow-wrap:anywhere] rounded-[10px] border ${border} bg-sunken px-3 py-2 font-mono text-[12px]`}>
           {shown}
         </pre>
       )}
       <CopyButton
         text={output}
         label={copyLabel ?? tr("tools.copyOutput")}
-        className="absolute right-1.5 top-1.5 opacity-0 transition-opacity focus-visible:opacity-100 group-hover/out:opacity-100 [@media(hover:none)]:opacity-60"
+        className={`absolute right-1.5 opacity-0 transition-opacity motion-reduce:transition-none focus-visible:opacity-100 group-hover/out:opacity-100 [@media(hover:none)]:opacity-60 ${heading ? "top-6" : "top-1.5"}`}
       />
       {overflow ? (
         <button
@@ -65,7 +83,7 @@ export function OutputPreview({
               {tr("common.collapse")} <ChevronUp className="h-3 w-3" aria-hidden />
             </>
           ) : (
-            tr("tools.showOutput") + (truncated ? " · " + tr("render.truncated") : "")
+            (showAllLabel ?? tr("tools.showOutput")) + (truncated ? " · " + tr("render.truncated") : "")
           )}
         </button>
       ) : truncated ? (

--- a/src/components/feed/cards/ToolCard.tsx
+++ b/src/components/feed/cards/ToolCard.tsx
@@ -4,11 +4,12 @@ import { useState } from "react";
 
 import { debugRaw } from "@/lib/review";
 
-import { GlyphIcon } from "../../icons";
+import { AlarmClock, GlyphIcon } from "../../icons";
 import { hhmm } from "../../utils";
 import { CopyButton } from "../CopyButton";
 import { tr, type ToolEvent } from "../parse";
 import type { ArgChip } from "../tools";
+import { formatDuration } from "../toolBlocks";
 import { useRawLine } from "../rawLine";
 import { DiffCard } from "./DiffCard";
 import { OrchestrationCard } from "./OrchestrationCard";
@@ -29,6 +30,73 @@ export function ToolChips({ chips }: { chips: ArgChip[] }) {
           {chip.value}
         </span>
       ))}
+    </div>
+  );
+}
+
+/* The exit status shown in the readable block (issue #475): a real numeric code
+   when the result reported one, else a plain ok/error verdict. Meaningless for a
+   non-shell tool that carries no code, so those render no exit chip. */
+function exitLabel(event: ToolEvent): string | null {
+  if (event.exitCode !== undefined) return tr("tools.exitCode", { code: event.exitCode });
+  if (event.status === "err") return event.statusLabel || tr("render.error");
+  if (event.status === "ok" && event.family === "shell") return tr("tools.exitOk");
+  return null;
+}
+
+/* One quiet metadata row over the command: cwd, wall-clock span, duration, and
+   exit status — the auditable header a terminal client shows. Renders nothing
+   when a call carries none of them (a plain non-shell tool). */
+function ToolMeta({ event }: { event: ToolEvent }) {
+  const start = hhmm(event.ts);
+  const end = event.endTs !== undefined ? hhmm(event.endTs) : "";
+  const span = end && start ? tr("tools.ranAt", { start, end }) : "";
+  const duration = event.durationMs !== undefined ? formatDuration(event.durationMs) : "";
+  const exit = exitLabel(event);
+  if (!event.cwd && !span && !duration && !exit) return null;
+  return (
+    <div className="mb-1.5 flex flex-col gap-1 text-[11px] text-muted">
+      <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
+        {exit ? (
+          <span className={`inline-flex items-center gap-1 font-semibold ${statusClass(event.status)}`}>
+            <StatusIcon status={event.status} className="h-3 w-3" />
+            {exit}
+          </span>
+        ) : null}
+        {duration ? (
+          <span className="inline-flex items-center gap-1 tabular-nums">
+            <AlarmClock className="h-3 w-3" aria-hidden />
+            {duration}
+          </span>
+        ) : null}
+        {span ? <span className="tabular-nums">{span}</span> : null}
+      </div>
+      {event.cwd ? (
+        <div className="flex min-w-0 items-center gap-1">
+          <span className="shrink-0 uppercase tracking-wide text-[10px]">{tr("tools.cwd")}</span>
+          <code className="min-w-0 flex-1 truncate font-mono text-[11px] text-secondary" title={event.cwd}>
+            {event.cwd}
+          </code>
+          <CopyButton text={event.cwd} label={tr("tools.copyCwd")} className="shrink-0 p-0.5" />
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+/* The full redacted command with a copy control, wrapped instead of scrolled so
+   a long line never forces document-level horizontal overflow on 390px. */
+function CommandBlock({ command }: { command: string }) {
+  return (
+    <div className="group/cmd relative">
+      <pre className="max-w-full whitespace-pre-wrap [overflow-wrap:anywhere] rounded-control border border-border bg-card py-1.5 pl-3 pr-10 font-mono text-ui">
+        {"$ " + command}
+      </pre>
+      <CopyButton
+        text={command}
+        label={tr("tools.copyCommand")}
+        className="absolute right-1.5 top-1.5 opacity-0 transition-opacity motion-reduce:transition-none focus-visible:opacity-100 group-hover/cmd:opacity-100 [@media(hover:none)]:opacity-60"
+      />
     </div>
   );
 }
@@ -60,7 +128,7 @@ function RawRecord({ event }: { event: ToolEvent }) {
         <CopyButton text={event.id} label={tr("tools.copyId")} className="p-0.5" />
       </div>
       {record ? (
-        <pre className="max-h-[300px] max-w-full overflow-auto whitespace-pre rounded-[10px] border border-border bg-sunken px-3 py-2 font-mono text-[11px]">{record}</pre>
+        <pre className="max-h-[300px] max-w-full overflow-auto whitespace-pre-wrap [overflow-wrap:anywhere] rounded-[10px] border border-border bg-sunken px-3 py-2 font-mono text-[11px]">{record}</pre>
       ) : (
         <span className="inline-flex items-center rounded-md bg-sunken px-2 py-0.5 text-[11px] text-muted">{tr("tools.noRawRecord")}</span>
       )}
@@ -68,22 +136,72 @@ function RawRecord({ event }: { event: ToolEvent }) {
   );
 }
 
+/* The expanded readable body of a tool call (issue #475): chips, the auditable
+   command header, structured diff/orchestration, and separate stdout/stderr
+   disclosures. Mounted lazily by {@link ToolLine} on first expand, so a long
+   collapsed transcript keeps its DOM small (issue #9 §7/§8). */
+export function ToolBody({ event }: { event: ToolEvent }) {
+  const hasDiff = event.body?.type === "diff";
+  const showOutput = !hasDiff || Boolean(event.outputPreview.trim());
+  return (
+    <div className="mb-1 mt-1 rounded-surface bg-sunken px-3 py-2.5">
+      <ToolChips chips={event.chips} />
+      <ToolMeta event={event} />
+      {event.command ? <CommandBlock command={event.command} /> : null}
+      {event.orchestration ? <OrchestrationCard orchestration={event.orchestration} source={event.command} /> : null}
+      {hasDiff && event.body?.type === "diff" ? <DiffCard body={event.body} /> : null}
+      {showOutput ? (
+        <OutputPreview
+          output={event.outputPreview}
+          truncated={event.outputTruncated}
+          lang={event.lang}
+          heading={event.stderr !== undefined ? tr("tools.stdout") : undefined}
+        />
+      ) : null}
+      {event.stderr !== undefined ? (
+        <OutputPreview
+          output={event.stderr}
+          truncated={Boolean(event.stderrTruncated)}
+          heading={tr("tools.stderr")}
+          tone="err"
+          copyLabel={tr("tools.copyStderr")}
+          showAllLabel={tr("tools.showStderr")}
+          emptyLabel={tr("tools.noStderr")}
+        />
+      ) : null}
+      <RawRecord event={event} />
+    </div>
+  );
+}
+
 /** One normalized tool event rendered as a quiet ToolLine (design doc §3.4):
     a borderless, tile-less single row — glyph + summary + (non-ok status) +
-    time — that reads as chrome between messages. The body (chips, diff/output,
-    raw record) mounts only after the first expand into a sunken block, keeping
-    a long transcript's collapsed DOM small (issue #9 §7/§8) — the same lazy
-    contract holds when the line renders inside a cmd-group. An error is never
-    quiet: it carries a danger left edge and danger text, always visible.
+    time — that reads as chrome between messages. The body mounts only after the
+    first expand into a sunken readable block (issue #475), keeping a long
+    transcript's collapsed DOM small (issue #9 §7/§8) — the same lazy contract
+    holds when the line renders inside a cmd-group. An error is never quiet: it
+    carries a danger left edge and danger text, always visible.
 
     On a coarse pointer the summary inflates to a 44px tap target (rule 8 /
     #145–#146) while the visual line stays dense on desktop; `showTime` is off
-    for a grouped child, whose time range already lives in the group header. */
-export function ToolLine({ event, showTime = true, className = "" }: { event: ToolEvent; showTime?: boolean; className?: string }) {
+    for a grouped child, whose time range already lives in the group header.
+    `index` prefixes an ordinal in a numbered group block; `nested` marks a
+    wait/stdin follow-up rendered under its parent exec. */
+export function ToolLine({
+  event,
+  showTime = true,
+  className = "",
+  index,
+  nested = false,
+}: {
+  event: ToolEvent;
+  showTime?: boolean;
+  className?: string;
+  index?: number;
+  nested?: boolean;
+}) {
   const [mounted, setMounted] = useState(event.open);
   const time = hhmm(event.ts);
-  const hasDiff = event.body?.type === "diff";
-  const showOutput = !hasDiff || Boolean(event.outputPreview.trim());
   const isErr = event.status === "err";
   return (
     <details
@@ -95,9 +213,13 @@ export function ToolLine({ event, showTime = true, className = "" }: { event: To
     >
       <summary
         className={`flex cursor-pointer list-none items-center gap-2 rounded-control py-0.5 text-ui hover:bg-sunken [@media(pointer:coarse)]:min-h-11 [&::-webkit-details-marker]:hidden ${
-          isErr ? "border-l-2 border-danger bg-danger-soft pl-2 pr-1 text-danger" : "text-muted"
+          isErr ? "border-l-2 border-danger bg-danger-soft pl-2 pr-1 text-danger" : nested ? "text-muted/90" : "text-muted"
         }`}
       >
+        {index !== undefined ? (
+          <span className="shrink-0 tabular-nums text-caption font-semibold text-muted">{index}.</span>
+        ) : null}
+        {nested ? <span className="shrink-0 select-none text-muted" aria-hidden>↳</span> : null}
         <GlyphIcon name={event.icon} className="h-3.5 w-3.5 shrink-0" />
         <span className={`min-w-0 flex-1 truncate ${isErr ? "font-semibold" : "text-secondary"}`} title={event.summary}>
           {event.summary}
@@ -110,20 +232,7 @@ export function ToolLine({ event, showTime = true, className = "" }: { event: To
         ) : null}
         {showTime && time ? <span className="shrink-0 text-caption tabular-nums text-muted">{time}</span> : null}
       </summary>
-      {mounted ? (
-        <div className="mb-1 mt-1 rounded-surface bg-sunken px-3 py-2.5">
-          <ToolChips chips={event.chips} />
-          {event.command ? (
-            <pre className="max-w-full overflow-x-auto whitespace-pre rounded-control border border-border bg-card px-3 py-1.5 font-mono text-ui">
-              {"$ " + event.command}
-            </pre>
-          ) : null}
-          {event.orchestration ? <OrchestrationCard orchestration={event.orchestration} source={event.command} /> : null}
-          {hasDiff && event.body?.type === "diff" ? <DiffCard body={event.body} /> : null}
-          {showOutput ? <OutputPreview output={event.outputPreview} truncated={event.outputTruncated} lang={event.lang} /> : null}
-          <RawRecord event={event} />
-        </div>
-      ) : null}
+      {mounted ? <ToolBody event={event} /> : null}
     </details>
   );
 }

--- a/src/components/feed/cards/ToolCard.tsx
+++ b/src/components/feed/cards/ToolCard.tsx
@@ -174,6 +174,43 @@ export function ToolBody({ event }: { event: ToolEvent }) {
   );
 }
 
+/** One tool call rendered as an always-open readable block inside an expanded
+    aggregate group (issue #475). Unlike {@link ToolLine} it is not a `<details>`:
+    the quiet header (ordinal, glyph, summary, non-ok status) and the full
+    command/output body are both shown at once, so an operator sees every command
+    and its owned output the moment the aggregate opens — no nested disclosure to
+    click, matching Claude's live UPDATE cards. An error keeps its danger edge.
+    `index` prefixes the ordinal; `nested` marks a wait/stdin follow-up rendered
+    under its parent exec while keeping its own state. */
+export function ToolBlockRow({ event, index, nested = false }: { event: ToolEvent; index?: number; nested?: boolean }) {
+  const isErr = event.status === "err";
+  return (
+    <div className="min-w-0">
+      <div
+        className={`flex items-center gap-2 rounded-control py-0.5 text-ui ${
+          isErr ? "border-l-2 border-danger bg-danger-soft pl-2 pr-1 text-danger" : nested ? "text-muted/90" : "text-muted"
+        }`}
+      >
+        {index !== undefined ? (
+          <span className="shrink-0 tabular-nums text-caption font-semibold text-muted">{index}.</span>
+        ) : null}
+        {nested ? <span className="shrink-0 select-none text-muted" aria-hidden>↳</span> : null}
+        <GlyphIcon name={event.icon} className="h-3.5 w-3.5 shrink-0" />
+        <span className={`min-w-0 flex-1 truncate ${isErr ? "font-semibold" : "text-secondary"}`} title={event.summary}>
+          {event.summary}
+        </span>
+        {event.status !== "ok" ? (
+          <span className={`inline-flex shrink-0 items-center gap-1 text-caption font-semibold ${statusClass(event.status)}`}>
+            <StatusIcon status={event.status} className="h-3 w-3" />
+            {event.statusLabel}
+          </span>
+        ) : null}
+      </div>
+      <ToolBody event={event} />
+    </div>
+  );
+}
+
 /** One normalized tool event rendered as a quiet ToolLine (design doc §3.4):
     a borderless, tile-less single row — glyph + summary + (non-ok status) +
     time — that reads as chrome between messages. The body mounts only after the

--- a/src/components/feed/cards/readableTool.dom.test.tsx
+++ b/src/components/feed/cards/readableTool.dom.test.tsx
@@ -1,0 +1,156 @@
+import { afterEach, beforeEach, expect, mock, test } from "bun:test";
+import { Window } from "happy-dom";
+import type { ReactElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { flushSync } from "react-dom";
+import { createRoot, type Root } from "react-dom/client";
+
+import {
+  execFailure,
+  execSuccess,
+  largeStdout,
+  longCommand,
+  nestedGroup,
+  toolEvent,
+  truncatedOutput,
+  unknownFallback,
+  withStderr,
+} from "../__fixtures__/readableTools";
+import { CmdGroupCard } from "./CmdGroupCard";
+import { ToolCard } from "./ToolCard";
+
+const dom = new Window();
+Object.assign(globalThis, {
+  window: dom,
+  document: dom.document,
+  navigator: dom.navigator,
+  Node: dom.Node,
+  HTMLElement: dom.HTMLElement,
+  HTMLButtonElement: dom.HTMLButtonElement,
+  HTMLDetailsElement: dom.HTMLDetailsElement,
+  Event: dom.Event,
+  KeyboardEvent: dom.KeyboardEvent,
+  MouseEvent: dom.MouseEvent,
+});
+
+let clipboardText = "";
+beforeEach(() => {
+  clipboardText = "";
+  Object.defineProperty(dom.navigator, "clipboard", {
+    configurable: true,
+    value: { writeText: mock(async (text: string) => { clipboardText = text; }) },
+  });
+});
+
+let root: Root | null = null;
+afterEach(() => {
+  if (root) flushSync(() => root!.unmount());
+  root = null;
+  document.body.replaceChildren();
+});
+
+function mount(node: ReactElement): HTMLDivElement {
+  const host = document.createElement("div");
+  document.body.append(host);
+  root = createRoot(host);
+  flushSync(() => root!.render(node));
+  return host as unknown as HTMLDivElement;
+}
+
+// Open the closest details ancestor lazily, the way a click/Enter on its summary
+// would, then let React mount the body.
+function open(details: Element): void {
+  (details as unknown as { open: boolean }).open = true;
+  flushSync(() => details.dispatchEvent(new dom.Event("toggle") as unknown as Event));
+}
+
+test("disclosure mounts the readable body only after the row is expanded", () => {
+  const host = mount(<ToolCard event={toolEvent({ ...execSuccess, open: false })} />);
+  // Collapsed: no command block yet (lazy DOM contract).
+  expect(host.querySelector("pre")).toBeNull();
+  open(host.querySelector("details")!);
+  const pre = host.querySelector("pre");
+  expect(pre?.textContent).toContain("git status --short");
+  // cwd, duration, and exit status all surface in the expanded block.
+  expect(host.textContent).toContain("/workspace/app");
+  expect(host.textContent).toContain("240ms");
+  expect(host.textContent).toContain("exit 0");
+});
+
+test("the copy control writes the full command to the clipboard", async () => {
+  const host = mount(<ToolCard event={{ ...execSuccess, open: true }} />);
+  const copy = [...host.querySelectorAll("button")].find((b) => (b.getAttribute("aria-label") ?? "").toLowerCase().includes("command"));
+  expect(copy).toBeTruthy();
+  copy!.click();
+  await Promise.resolve();
+  expect(clipboardText).toBe("git status --short");
+});
+
+test("stdout and stderr render as separate labelled disclosures", () => {
+  const host = mount(<ToolCard event={{ ...withStderr, open: true }} />);
+  const text = host.textContent ?? "";
+  expect(text).toContain("stdout");
+  expect(text).toContain("stderr");
+  expect(text).toContain("Finished release target");
+  expect(text).toContain("unused variable");
+  // The stderr block owns its own copy control.
+  const labels = [...host.querySelectorAll("button")].map((b) => (b.getAttribute("aria-label") ?? "").toLowerCase());
+  expect(labels.some((l) => l.includes("stderr"))).toBe(true);
+});
+
+test("explicit truncation is stated and gates a show-all reveal", () => {
+  const host = mount(<ToolCard event={{ ...truncatedOutput, open: true }} />);
+  const showAll = [...host.querySelectorAll("button")].find((b) => (b.textContent ?? "").includes("truncated"));
+  expect(showAll).toBeTruthy();
+  // A large but un-truncated output still offers show-all without the truncated tag.
+  const host2 = mount(<ToolCard event={{ ...largeStdout, open: true }} />);
+  const btns = [...host2.querySelectorAll("button")].map((b) => b.textContent ?? "");
+  expect(btns.some((t) => t.includes("show all"))).toBe(true);
+});
+
+test("keyboard operation: every affordance is a native focusable control", () => {
+  const host = mount(<ToolCard event={execFailure} />);
+  // The disclosure is a <summary> (Enter/Space toggles it natively).
+  const summary = host.querySelector("summary");
+  expect(summary?.tagName).toBe("SUMMARY");
+  // Copy is a real <button>; activating it via the keyboard path (click) copies.
+  const copy = [...host.querySelectorAll("button")].find((b) => (b.getAttribute("aria-label") ?? "").toLowerCase().includes("command"));
+  expect(copy?.tagName).toBe("BUTTON");
+});
+
+test("a cmd-group nests wait/stdin follow-ups under an ordered exec block", () => {
+  const host = mount(<CmdGroupCard item={nestedGroup()} />);
+  open(host.querySelector("details")!);
+  const list = host.querySelector("ol");
+  expect(list).toBeTruthy();
+  // Two top-level blocks: the exec (owning wait+poll) and the standalone Read.
+  expect(list!.querySelectorAll(":scope > li").length).toBe(2);
+  // The ordinal marker renders for the first block.
+  expect(host.textContent).toContain("1.");
+  // The nested follow-ups sit inside the first block, not as their own rows.
+  const firstBlock = list!.querySelector("li")!;
+  expect(firstBlock.textContent).toContain("wait");
+  expect(firstBlock.textContent).toContain("stdin");
+});
+
+test("reduced motion: animated chrome opts out under prefers-reduced-motion", () => {
+  const group = renderToStaticMarkup(<CmdGroupCard item={nestedGroup()} />);
+  expect(group).toContain("motion-reduce:transition-none");
+  const running = renderToStaticMarkup(<ToolCard event={toolEvent({ status: "run", statusLabel: "executing…" })} />);
+  expect(running).toContain("motion-reduce:animate-none");
+});
+
+test("responsive wrapping: the command wraps instead of scrolling the document", () => {
+  const markup = renderToStaticMarkup(<ToolCard event={{ ...longCommand, open: true }} />);
+  expect(markup).toContain("whitespace-pre-wrap");
+  expect(markup).toContain("[overflow-wrap:anywhere]");
+  // No forced horizontal scroll region that could push past a 390px viewport.
+  expect(markup).not.toContain("overflow-x-auto");
+});
+
+test("an unknown typed payload keeps its fallback body without a command block", () => {
+  const host = mount(<ToolCard event={{ ...unknownFallback, open: true }} />);
+  expect(host.textContent).toContain("SomeFutureTool");
+  // No `$ ` command line for a payload the taxonomy does not model.
+  expect([...host.querySelectorAll("pre")].some((p) => (p.textContent ?? "").startsWith("$ "))).toBe(false);
+});

--- a/src/components/feed/cards/shared.tsx
+++ b/src/components/feed/cards/shared.tsx
@@ -10,7 +10,7 @@ export function StatusIcon({ status, className }: { status: ToolStatus; classNam
   const cls = className ?? "h-3.5 w-3.5";
   if (status === "ok") return <Check className={cls} aria-hidden />;
   if (status === "err") return <X className={cls} aria-hidden />;
-  return <Loader2 className={`${cls} animate-spin`} aria-hidden />;
+  return <Loader2 className={`${cls} animate-spin motion-reduce:animate-none`} aria-hidden />;
 }
 
 export function FileRef({ file, line }: { file: string; line?: number }) {

--- a/src/components/feed/cards/toolCards.render.test.tsx
+++ b/src/components/feed/cards/toolCards.render.test.tsx
@@ -144,6 +144,7 @@ function cmdGroup(calls: ToolEvent[]): CmdGroupItem {
     okCount,
     errCount,
     hasErr: errCount > 0,
+    active: false,
   };
 }
 

--- a/src/components/feed/cards/toolLifecycle.dom.test.tsx
+++ b/src/components/feed/cards/toolLifecycle.dom.test.tsx
@@ -1,0 +1,147 @@
+import { afterEach, beforeEach, expect, mock, test } from "bun:test";
+import { Window } from "happy-dom";
+import type { ReactElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { flushSync } from "react-dom";
+import { createRoot, type Root } from "react-dom/client";
+
+import { activeGroup, activeFailureGroup, settledGroup, nestedGroup } from "../__fixtures__/readableTools";
+import { CmdGroupCard } from "./CmdGroupCard";
+
+const dom = new Window();
+Object.assign(globalThis, {
+  window: dom,
+  document: dom.document,
+  navigator: dom.navigator,
+  Node: dom.Node,
+  HTMLElement: dom.HTMLElement,
+  HTMLButtonElement: dom.HTMLButtonElement,
+  HTMLDetailsElement: dom.HTMLDetailsElement,
+  Event: dom.Event,
+  KeyboardEvent: dom.KeyboardEvent,
+  MouseEvent: dom.MouseEvent,
+});
+
+beforeEach(() => {
+  Object.defineProperty(dom.navigator, "clipboard", {
+    configurable: true,
+    value: { writeText: mock(async () => {}) },
+  });
+});
+
+let root: Root | null = null;
+let host: HTMLDivElement | null = null;
+afterEach(() => {
+  if (root) flushSync(() => root!.unmount());
+  root = null;
+  host = null;
+  document.body.replaceChildren();
+});
+
+function mount(node: ReactElement): HTMLDivElement {
+  const el = document.createElement("div");
+  document.body.append(el);
+  root = createRoot(el);
+  flushSync(() => root!.render(node));
+  host = el as unknown as HTMLDivElement;
+  return host;
+}
+
+// Re-render into the *same* root, so the component instance (and its lifecycle
+// state) persists across the tick — the way an incremental re-feed updates it.
+function rerender(node: ReactElement): HTMLDivElement {
+  flushSync(() => root!.render(node));
+  return host!;
+}
+
+function toggle(details: Element, open: boolean): void {
+  (details as unknown as { open: boolean }).open = open;
+  flushSync(() => details.dispatchEvent(new dom.Event("toggle") as unknown as Event));
+}
+
+test("a live aggregate renders open with every command and output shown immediately", () => {
+  const h = mount(<CmdGroupCard item={activeGroup()} />);
+  const details = h.querySelector("details")!;
+  // The aggregate is open without any interaction.
+  expect((details as unknown as { open: boolean }).open).toBe(true);
+  // Both commands and both outputs are visible right away.
+  expect(h.textContent).toContain("git status --short");
+  expect(h.textContent).toContain("cargo build --release");
+  expect(h.textContent).toContain(" M src/index.ts");
+  expect(h.textContent).toContain("Finished release target");
+});
+
+test("no nested second disclosure: the only <details> is the aggregate itself", () => {
+  const h = mount(<CmdGroupCard item={activeGroup()} />);
+  // The per-call rows are inline blocks, not their own collapsible <details>.
+  expect(h.querySelectorAll("details").length).toBe(1);
+});
+
+test("live → settled auto-collapses the aggregate exactly once", () => {
+  const h = mount(<CmdGroupCard item={activeGroup()} />);
+  expect((h.querySelector("details") as unknown as { open: boolean }).open).toBe(true);
+  // The run settles: the same group re-fed with active:false.
+  rerender(<CmdGroupCard item={settledGroup()} />);
+  const details = h.querySelector("details")!;
+  expect((details as unknown as { open: boolean }).open).toBe(false);
+  // Collapsed to the compact summary — the bodies are gone.
+  expect(h.textContent).not.toContain("git status --short");
+  // A further settled tick does not fight the collapse (stays closed).
+  rerender(<CmdGroupCard item={settledGroup()} />);
+  expect((h.querySelector("details") as unknown as { open: boolean }).open).toBe(false);
+});
+
+test("a manual reopen after settle persists across ticks until the operator closes it", () => {
+  const h = mount(<CmdGroupCard item={activeGroup()} />);
+  rerender(<CmdGroupCard item={settledGroup()} />); // settle + auto-collapse
+  const details = h.querySelector("details")!;
+  expect((details as unknown as { open: boolean }).open).toBe(false);
+  // Operator reopens it.
+  toggle(details, true);
+  expect((h.querySelector("details") as unknown as { open: boolean }).open).toBe(true);
+  expect(h.textContent).toContain("git status --short");
+  // A later settled re-feed keeps it open — the auto-collapse fires only once.
+  rerender(<CmdGroupCard item={settledGroup()} />);
+  expect((h.querySelector("details") as unknown as { open: boolean }).open).toBe(true);
+  // Operator closes it; the choice sticks across the next tick.
+  toggle(h.querySelector("details")!, false);
+  rerender(<CmdGroupCard item={settledGroup()} />);
+  expect((h.querySelector("details") as unknown as { open: boolean }).open).toBe(false);
+});
+
+test("the compact summary keeps the failure status and count after collapse", () => {
+  const h = mount(<CmdGroupCard item={activeFailureGroup()} />);
+  rerender(<CmdGroupCard item={activeFailureGroup({ active: false })} />);
+  const summary = h.querySelector("summary")!;
+  // Collapsed, but the failure count is still on the compact summary line.
+  expect((h.querySelector("details") as unknown as { open: boolean }).open).toBe(false);
+  expect(summary.textContent).toContain("1");
+  expect(summary.querySelector(".text-danger")).toBeTruthy();
+});
+
+test("nested wait/stdin follow-ups stay owned by their exec inside the live aggregate", () => {
+  const h = mount(<CmdGroupCard item={nestedGroup({ active: true })} />);
+  const list = h.querySelector("ol")!;
+  // Two top-level blocks; the follow-ups render inside the first, inline.
+  expect(list.querySelectorAll(":scope > li").length).toBe(2);
+  const firstBlock = list.querySelector("li")!;
+  expect(firstBlock.textContent).toContain("wait");
+  expect(firstBlock.textContent).toContain("stdin");
+  // Still no nested disclosure: the aggregate details is the only one.
+  expect(h.querySelectorAll("details").length).toBe(1);
+});
+
+test("keyboard: the aggregate toggle is a native <summary>", () => {
+  const h = mount(<CmdGroupCard item={settledGroup()} />);
+  expect(h.querySelector("summary")?.tagName).toBe("SUMMARY");
+});
+
+test("reduced motion and responsive wrapping hold for the live aggregate", () => {
+  const markup = renderToStaticMarkup(<CmdGroupCard item={activeGroup()} />);
+  // Animated chrome opts out under prefers-reduced-motion.
+  expect(markup).toContain("motion-reduce:transition-none");
+  // The command wraps at 390px instead of forcing a horizontal scroll region.
+  expect(markup).toContain("whitespace-pre-wrap");
+  expect(markup).toContain("[overflow-wrap:anywhere]");
+  expect(markup).not.toContain("overflow-x-auto");
+});

--- a/src/components/feed/cards/toolLifecycle.dom.test.tsx
+++ b/src/components/feed/cards/toolLifecycle.dom.test.tsx
@@ -109,6 +109,16 @@ test("a manual reopen after settle persists across ticks until the operator clos
   expect((h.querySelector("details") as unknown as { open: boolean }).open).toBe(false);
 });
 
+test("a later live tick does not arm a second auto-collapse over the operator choice", () => {
+  const h = mount(<CmdGroupCard item={activeGroup()} />);
+  rerender(<CmdGroupCard item={settledGroup()} />);
+  const details = h.querySelector("details")!;
+  toggle(details, true);
+  rerender(<CmdGroupCard item={activeGroup()} />);
+  rerender(<CmdGroupCard item={settledGroup()} />);
+  expect((h.querySelector("details") as unknown as { open: boolean }).open).toBe(true);
+});
+
 test("the compact summary keeps the failure status and count after collapse", () => {
   const h = mount(<CmdGroupCard item={activeFailureGroup()} />);
   rerender(<CmdGroupCard item={activeFailureGroup({ active: false })} />);

--- a/src/components/feed/parse.test.ts
+++ b/src/components/feed/parse.test.ts
@@ -399,20 +399,23 @@ describe("feed session identity stability", () => {
     }
   });
 
-  test("a tool_result changes only its own cmd item", () => {
+  test("a tool_result inside a live aggregate rebuilds the group but keeps the user bubble and key", () => {
     const session = createFeedSession({ engine: "claude", fmt: "claude", showSvc: false, lineFilter: "" });
     const lines = [claudeUser("go"), claudeTool("c1", "Bash", "ls"), claudeTool("c2", "Bash", "pwd")];
     const before = session.feed(lines, 0, true);
+    // The trailing live run of two calls is one active aggregate (issue #475).
+    expect(before.items).toHaveLength(2);
+    expect(before.items[1].item.kind).toBe("cmd-group");
     const after = session.feed([...lines, claudeResult("c1", "ok done")], 0, true);
-    // user bubble and the untouched second call keep their identity
+    // The user bubble is untouched, and the aggregate keeps its stable key.
     expect(after.items[0].item).toBe(before.items[0].item);
-    expect(after.items[2].item).toBe(before.items[2].item);
-    // the resolved call is a fresh object with the result attached
-    expect(after.items[1].item).not.toBe(before.items[1].item);
-    const resolved = after.items[1].item;
-    if (resolved.kind !== "tool") throw new Error("expected tool item");
-    expect(resolved.status).toBe("ok");
     expect(after.items[1].key).toBe(before.items[1].key);
+    // The group is a fresh object with c1 resolved and c2 still in flight.
+    expect(after.items[1].item).not.toBe(before.items[1].item);
+    const group = after.items[1].item;
+    if (group.kind !== "cmd-group") throw new Error("expected a cmd-group");
+    expect(group.calls.map((call) => call.status)).toEqual(["ok", "run"]);
+    expect(group.active).toBe(true);
   });
 
   test("idempotent re-feed of an unchanged window returns the cached snapshot", () => {
@@ -437,7 +440,7 @@ describe("feed session identity stability", () => {
     expect(after.items[0].item).toBe(group);
   });
 
-  test("a live trailing tool run folds its completed prefix but keeps the current call visible (§3.4)", () => {
+  test("a live trailing tool run folds the whole active run — the in-flight call included — into one aggregate (issue #475)", () => {
     const lines = [
       claudeTool("a1", "Bash", "echo 1"),
       claudeResult("a1", "1"),
@@ -445,23 +448,22 @@ describe("feed session identity stability", () => {
       claudeResult("a2", "2"),
       claudeTool("a3", "Read", "cat x.txt"), // in-flight: no result yet
     ];
-    // Live: the completed a1/a2 fold; the current a3 stays its own visible line —
-    // a live 40-call run must not read as 40 individual ToolLines.
+    // Live: the whole trailing run is one active aggregate — no loose running row.
     const live = buildFeed({ ...claudeFile, activity: "live" } as FileEntry, lines, false, "");
-    expect(live.items).toHaveLength(2);
+    expect(live.items).toHaveLength(1);
     const group = live.items[0];
     if (group.kind !== "cmd-group") throw new Error("expected a cmd-group");
-    expect(group.calls.map((call) => call.id)).toEqual(["a1", "a2"]);
-    const current = live.items[1];
-    if (current.kind !== "tool") throw new Error("expected the current call as a visible tool line");
-    expect(current.id).toBe("a3");
-    // Settled (not live): the whole run folds into one group.
+    expect(group.calls.map((call) => call.id)).toEqual(["a1", "a2", "a3"]);
+    expect(group.calls[2].status).toBe("run");
+    expect(group.active).toBe(true);
+    // Settled (not live): the same run folds into one inactive group.
     const settled = buildFeed(claudeFile, lines, false, "");
     expect(settled.items).toHaveLength(1);
     expect(settled.items[0].kind).toBe("cmd-group");
+    if (settled.items[0].kind === "cmd-group") expect(settled.items[0].active).toBe(false);
   });
 
-  test("a live tail keeps every concurrent in-flight call visible, folding only the completed prefix (§3.4)", () => {
+  test("a live tail folds every concurrent in-flight call into the active aggregate (issue #475)", () => {
     const lines = [
       claudeTool("c1", "Bash", "echo 1"),
       claudeResult("c1", "1"),
@@ -473,20 +475,24 @@ describe("feed session identity stability", () => {
       claudeTool("r2", "Bash", "sleep 2"), // in-flight, concurrent
     ];
     const live = buildFeed({ ...claudeFile, activity: "live" } as FileEntry, lines, false, "");
-    // The completed c1/c2/c3 fold; both running calls stay their own visible lines.
-    expect(live.items).toHaveLength(3);
+    // One active aggregate holds the completed prefix and both running calls.
+    expect(live.items).toHaveLength(1);
     const group = live.items[0];
-    if (group.kind !== "cmd-group") throw new Error("expected the completed prefix folded");
-    expect(group.calls.map((call) => call.id)).toEqual(["c1", "c2", "c3"]);
-    const running = live.items.slice(1);
-    expect(running.map((item) => (item.kind === "tool" ? item.id : item.kind))).toEqual(["r1", "r2"]);
-    expect(running.every((item) => item.kind === "tool" && item.status === "run")).toBe(true);
+    if (group.kind !== "cmd-group") throw new Error("expected one active aggregate");
+    expect(group.calls.map((call) => call.id)).toEqual(["c1", "c2", "c3", "r1", "r2"]);
+    expect(group.calls.slice(-2).every((call) => call.status === "run")).toBe(true);
+    expect(group.active).toBe(true);
   });
 
-  test("a live tail of only concurrent run calls stays fully visible with no group", () => {
+  test("a live tail of only concurrent run calls is one active aggregate (issue #475)", () => {
     const lines = [claudeTool("r1", "Bash", "a"), claudeTool("r2", "Bash", "b"), claudeTool("r3", "Bash", "c")];
     const live = buildFeed({ ...claudeFile, activity: "live" } as FileEntry, lines, false, "");
-    expect(live.items.map((item) => (item.kind === "tool" ? item.id : item.kind))).toEqual(["r1", "r2", "r3"]);
+    expect(live.items).toHaveLength(1);
+    const group = live.items[0];
+    if (group.kind !== "cmd-group") throw new Error("expected one active aggregate");
+    expect(group.calls.map((call) => call.id)).toEqual(["r1", "r2", "r3"]);
+    expect(group.calls.every((call) => call.status === "run")).toBe(true);
+    expect(group.active).toBe(true);
   });
 
   test("prepended history resets the session and reparses the wider window", () => {

--- a/src/components/feed/parse.ts
+++ b/src/components/feed/parse.ts
@@ -147,6 +147,11 @@ export type CmdGroupItem = {
   okCount: number;
   errCount: number;
   hasErr: boolean;
+  /** True while this is the live trailing run: one expanded aggregate that
+      shows every command and its output immediately. Flips to false when the
+      run settles (a new turn appends after it, or the session stops being
+      live), which the card reads to auto-collapse exactly once (issue #475). */
+  active: boolean;
 };
 export type Item =
   | { kind: "prose"; ts: unknown; text: string; engine: "codex" | "claude" }
@@ -1927,12 +1932,12 @@ export function createFeedSession(cfg: FeedSessionConfig): FeedSession {
      tool event folds (Read/Bash/Edit/diff-bodied/orchestration alike); a "think"
      item inside a run is absorbed without breaking it (it carries no signal once
      the run it annotates is folded), while prose/user/tmsg/review/image break it.
-     In a live trailing run only the leading completed prefix folds; every
-     in-flight (`run`) call stays a visible line (and if none is running, the
-     most-recent call is held out), so a live 40-call run reads as one quiet
-     group plus its running call(s), never 40 rows (§3.4). A group whose members'
-     events are all identity-equal to the previous snapshot's is reused as-is,
-     keeping its card memoized. */
+     The live trailing run folds whole — the in-flight (`run`) calls included —
+     into one aggregate marked `active`, which the card renders expanded so every
+     command and output shows immediately (issue #475). An interior or settled
+     run folds the same way but with `active: false`. A group whose members'
+     events are all identity-equal to the previous snapshot's — and whose active
+     lifecycle matches — is reused as-is, keeping its card memoized. */
   const buildSnapshot = (isLive: boolean): FeedSnapshot => {
     const out: FeedEntry[] = [];
     const nextGroups = new Map<number, CmdGroupItem>();
@@ -1959,24 +1964,20 @@ export function createFeedSession(cfg: FeedSessionConfig): FeedSession {
         else if (cur.item.kind !== "think") break;
         j += 1;
       }
-      /* A live trailing run folds only its leading completed prefix: every
-         in-flight (`run`) call stays a visible line so concurrent running calls
-         are never buried in a quiet closed group, and if none is running the
-         most-recent call is still held out. A completed or interior run folds in
-         full. */
+      /* The whole run folds into one aggregate. When it is the live trailing
+         run it is marked active — the card renders it expanded with every
+         command and output shown at once (issue #475); an interior or settled
+         run folds the same way but inactive, so the card auto-collapses it to
+         the compact summary. */
       const isLiveTail = isLive && j === entries.length;
-      let foldCount = toolEntries.length;
-      if (isLiveTail) {
-        const firstRun = toolEntries.findIndex((entry) => entry.item.status === "run");
-        foldCount = firstRun >= 0 ? firstRun : toolEntries.length - 1;
-      }
+      const foldCount = toolEntries.length;
       if (foldCount >= CMD_GROUP_MIN) {
         const grouped = toolEntries.slice(0, foldCount);
         const groupEnd = grouped[grouped.length - 1].idx + 1;
         const gkey = grouped[0].seq;
         const prev = prevGroups.get(gkey);
         let group: CmdGroupItem;
-        if (prev && prev.calls.length === grouped.length && grouped.every((entry, k) => prev.calls[k] === entry.item)) {
+        if (prev && prev.active === isLiveTail && prev.calls.length === grouped.length && grouped.every((entry, k) => prev.calls[k] === entry.item)) {
           group = prev;
         } else {
           const byTool: Record<string, number> = {};
@@ -1998,6 +1999,7 @@ export function createFeedSession(cfg: FeedSessionConfig): FeedSession {
             okCount,
             errCount,
             hasErr: errCount > 0,
+            active: isLiveTail,
           };
         }
         nextGroups.set(gkey, group);

--- a/src/components/feed/parse.ts
+++ b/src/components/feed/parse.ts
@@ -88,6 +88,17 @@ export type ToolEvent = {
   statusLabel: string;
   outputPreview: string;
   outputTruncated: boolean;
+  /** Working directory recovered from the call args or a `cd … &&` prefix. */
+  cwd?: string;
+  /** Numeric exit code recovered from a `exited with code N` result line. */
+  exitCode?: number;
+  /** Wall-clock duration in ms, from a Codex `Wall time` preamble. */
+  durationMs?: number;
+  /** Result timestamp, once the tool result attaches (end of the run). */
+  endTs?: unknown;
+  /** stderr split from the combined result, rendered in its own disclosure. */
+  stderr?: string;
+  stderrTruncated?: boolean;
   open: boolean;
   orchestration?: Orchestration;
   /** Present on a `ScheduleWakeup` call: drives the dedicated wakeup card. */
@@ -502,6 +513,11 @@ const CMD_GROUP_MIN = 2;
 const OUTPUT_OK_MAX = 12_000;
 const OUTPUT_ERR_MAX = 60_000;
 const COMMAND_MAX = 8_000;
+/* An explicit stderr delimiter a payload may carry so the readable block can
+   split the two streams into their own bounded disclosures (issue #475). Only an
+   explicit marker splits — an undelimited body stays entirely stdout, so the
+   parser never guesses which lines were errors. */
+const STDERR_MARKER = /^[ \t]*(?:\[stderr\]|-{2,}\s*stderr\s*-{2,}|stderr:)[ \t]*$/im;
 /* Wakeup reason/prompt are redacted and bounded before they reach the card, the
    same safety funnel every other tool field passes through (issue #161 review).
    The reason is a one-line summary; the prompt is the longer wake plan. */
@@ -511,9 +527,22 @@ const WAKEUP_PROMPT_MAX = 4_000;
    known variants). Used to strip the contiguous leading metadata block. */
 const PREAMBLE_LINE = /^(?:Chunk ID:|Wall time\b|Original token count:|Output:[ \t]*$|Script completed\b|Script running with (?:cell|session) ID\b|Process running with (?:cell|session) ID\b|Process exited with code\b)/;
 const CODE_EXT_RE = /\.([A-Za-z0-9]{1,10})$/;
+const CWD_MAX = 400;
 
 function extLang(path: string): string | null {
   return path.match(CODE_EXT_RE)?.[1]?.toLowerCase() ?? null;
+}
+
+/* The working directory a shell call ran in: an explicit `cwd`/`workdir` arg
+   (Codex `exec_command`, orchestrated `tools.exec_command`) wins; otherwise the
+   leading `cd <path> &&` of the command reveals it. Redacted and bounded here so
+   the readable block (issue #475) never surfaces a raw or unbounded path. */
+function cwdOf(args: Record<string, unknown>, command?: string): string | undefined {
+  const explicit = args.cwd ?? args.workdir ?? args.working_directory ?? args.cd;
+  const raw = typeof explicit === "string" && explicit.trim() ? explicit.trim() : command?.match(/^\s*cd\s+('([^']+)'|"([^"]+)"|(\S+))\s*&&/)?.slice(2).find(Boolean);
+  if (!raw) return undefined;
+  const safe = redactSecrets(raw).trim().slice(0, CWD_MAX);
+  return safe || undefined;
 }
 
 /* Grouping bucket key: the verbatim tool name, falling back to the family for
@@ -1157,6 +1186,10 @@ export function createFeedSession(cfg: FeedSessionConfig): FeedSession {
       statusLabel: tr("render.executing"),
       outputPreview: "",
       outputTruncated: false,
+      ...(family === "shell" ? (() => {
+        const cwd = cwdOf(args, command);
+        return cwd ? { cwd } : {};
+      })() : {}),
       /* An edit/write card opens its structured diff inline by default — a
          compact preview of the first lines, with a toggle for the rest — so the
          change is visible without a click (issue #90). */
@@ -1225,10 +1258,10 @@ export function createFeedSession(cfg: FeedSessionConfig): FeedSession {
   };
   /* A shell command from any engine. `callId` is absent for plain job logs, so
      a synthetic id keeps the row addressable (and the last one attachable). */
-  const addShell = (ts: unknown, command: string, callId?: string, tool = "Bash"): ToolEvent => {
+  const addShell = (ts: unknown, command: string, callId?: string, tool = "Bash", extraArgs?: Record<string, unknown>): ToolEvent => {
     const id = callId || "plain-" + pushSeq + "-" + String(ts ?? "");
     const engine = cfg.engine === "codex" ? "codex" : "claude";
-    const event = newToolEvent({ ts, id, tool, args: { command }, engine, command });
+    const event = newToolEvent({ ts, id, tool, args: { ...extraArgs, command }, engine, command });
     const rec = registerCall(event);
     if (!callId) lastPlainCall = rec;
     return event;
@@ -1280,14 +1313,36 @@ export function createFeedSession(cfg: FeedSessionConfig): FeedSession {
     /* An empty codex wait/stdin chunk collapses to "waiting Ns" rather than an
        "ok" with a signal-free block (issue #141 §4). */
     const idleWait = !body && (prev.tool === "wait" || prev.tool === "write_stdin") && wallSeconds !== undefined;
+    /* Split an explicitly delimited stderr tail off the stdout head so the two
+       streams get their own disclosures (issue #475). No marker → all stdout. */
+    let stdoutBody = body;
+    let stderrBody = "";
+    /* Only a shell exec has a stderr stream; a Read/Edit result is file text, so
+       a `stderr:` line inside it must never be mistaken for a delimiter. */
+    const mark = prev.family === "shell" ? body.match(STDERR_MARKER) : null;
+    if (mark && mark.index !== undefined) {
+      stdoutBody = body.slice(0, mark.index).replace(/\n+$/, "");
+      stderrBody = body.slice(mark.index + mark[0].length).replace(/^\n+/, "");
+    }
     let outputPreview = prev.outputPreview;
     let outputTruncated = prev.outputTruncated;
-    if (body) {
+    if (stdoutBody) {
       const limit = isErr ? OUTPUT_ERR_MAX : OUTPUT_OK_MAX;
-      const combined = (prev.outputPreview + "\n" + redactSecrets(body)).trim();
+      const combined = (prev.outputPreview + "\n" + redactSecrets(stdoutBody)).trim();
       outputTruncated = prev.outputTruncated || combined.length > limit;
       outputPreview = combined.slice(-limit);
     }
+    let stderr = prev.stderr;
+    let stderrTruncated = prev.stderrTruncated;
+    if (stderrBody) {
+      const combined = ((prev.stderr ?? "") + "\n" + redactSecrets(stderrBody)).trim();
+      stderrTruncated = (prev.stderrTruncated ?? false) || combined.length > OUTPUT_ERR_MAX;
+      stderr = combined.slice(-OUTPUT_ERR_MAX);
+    }
+    const exitCode = code !== undefined ? Number(code) : prev.exitCode;
+    const durationMs = wallSeconds !== undefined ? Math.round(Number(wallSeconds) * 1000) : prev.durationMs;
+    const startMs = typeof prev.ts === "string" || typeof prev.ts === "number" ? Date.parse(String(prev.ts)) : NaN;
+    const endTs = durationMs !== undefined && Number.isFinite(startMs) ? new Date(startMs + durationMs).toISOString() : prev.endTs;
     /* A wakeup's result carries the RESOLVED schedule (issue #161): on success
        refine the fire time from it (it overrides the requested delay); on error
        the call is rejected — mark it failed so it never counts down and never
@@ -1318,6 +1373,11 @@ export function createFeedSession(cfg: FeedSessionConfig): FeedSession {
       srcResult: curSrc,
       outputPreview,
       outputTruncated,
+      ...(exitCode !== undefined ? { exitCode } : {}),
+      ...(durationMs !== undefined ? { durationMs } : {}),
+      ...(endTs !== undefined ? { endTs } : {}),
+      ...(stderr !== undefined ? { stderr } : {}),
+      ...(stderrTruncated !== undefined ? { stderrTruncated } : {}),
       ...(wakeup ? { wakeup } : {}),
       ...(mcp ? { mcp } : {}),
     };
@@ -1573,7 +1633,7 @@ export function createFeedSession(cfg: FeedSessionConfig): FeedSession {
         const name = textPart(p.name);
         if (name === "exec_command" || name === "shell") {
           const cmd = String(args.cmd ?? args.command ?? "").replace(/^\/usr\/bin\/zsh -lc /, "");
-          return void addShell(ts, cmd, textPart(p.call_id), name);
+          return void addShell(ts, cmd, textPart(p.call_id), name, args);
         }
         if (name === "apply_patch") {
           return void addPatch(ts, String(args.input ?? ""), textPart(p.call_id));

--- a/src/components/feed/parse.ts
+++ b/src/components/feed/parse.ts
@@ -94,6 +94,8 @@ export type ToolEvent = {
   exitCode?: number;
   /** Wall-clock duration in ms, from a Codex `Wall time` preamble. */
   durationMs?: number;
+  /** Interactive shell cell/session that owns this call and its follow-ups. */
+  runtimeSessionId?: string;
   /** Result timestamp, once the tool result attaches (end of the run). */
   endTs?: unknown;
   /** stderr split from the combined result, rendered in its own disclosure. */
@@ -1174,6 +1176,7 @@ export function createFeedSession(cfg: FeedSessionConfig): FeedSession {
     const body: ToolBody | undefined = diff && diff.files.length ? { type: "diff", files: diff.files, filesTruncated: diff.filesTruncated } : undefined;
     const command = opts.command !== undefined ? redactSecrets(opts.command).slice(0, COMMAND_MAX) : undefined;
     const summary = opts.summary !== undefined ? redactSecrets(opts.summary).replace(/\s+/g, " ").trim().slice(0, 160) : s.summary;
+    const runtimeSessionId = String(args.session_id ?? args.cell_id ?? "").trim() || undefined;
     return {
       kind: "tool",
       id: opts.id,
@@ -1191,6 +1194,7 @@ export function createFeedSession(cfg: FeedSessionConfig): FeedSession {
       statusLabel: tr("render.executing"),
       outputPreview: "",
       outputTruncated: false,
+      ...(runtimeSessionId ? { runtimeSessionId } : {}),
       ...(family === "shell" ? (() => {
         const cwd = cwdOf(args, command);
         return cwd ? { cwd } : {};
@@ -1299,6 +1303,8 @@ export function createFeedSession(cfg: FeedSessionConfig): FeedSession {
        an empty `wait` can render a compact "waiting Ns" line (issue #141). Matches
        both `Wall time: 30 seconds` and the bare `Wall time 10.0 seconds` wrapper. */
     const wallSeconds = output.match(/Wall time:?\s*([\d.]+)\s*seconds?/i)?.[1];
+    const runtimeSessionId = output.match(/(?:Script|Process) running with (?:cell|session) ID\s+([^\s]+)/i)?.[1]
+      ?? callRec.event.runtimeSessionId;
     /* Codex wraps custom-tool AND interactive-shell (wait / write_stdin) results
        in a metadata preamble whose lines vary by tool and version:
          Chunk ID: …             Script completed
@@ -1380,6 +1386,7 @@ export function createFeedSession(cfg: FeedSessionConfig): FeedSession {
       outputTruncated,
       ...(exitCode !== undefined ? { exitCode } : {}),
       ...(durationMs !== undefined ? { durationMs } : {}),
+      ...(runtimeSessionId ? { runtimeSessionId } : {}),
       ...(endTs !== undefined ? { endTs } : {}),
       ...(stderr !== undefined ? { stderr } : {}),
       ...(stderrTruncated !== undefined ? { stderrTruncated } : {}),

--- a/src/components/feed/readableTool.parse.test.ts
+++ b/src/components/feed/readableTool.parse.test.ts
@@ -1,0 +1,93 @@
+import { expect, test } from "bun:test";
+
+import type { FileEntry } from "@/lib/types";
+
+import { codexExecStderrLines, claudeExecFailLines } from "./__fixtures__/readableTools";
+import { buildFeed, type CmdGroupItem, type ToolEvent } from "./parse";
+import { groupNestedCalls } from "./toolBlocks";
+
+const codexFile = { path: "/tmp/x.jsonl", engine: "codex", fmt: "codex", activity: "recent" } as FileEntry;
+const claudeFile = { path: "/tmp/x.jsonl", engine: "claude", fmt: "claude", activity: "recent" } as FileEntry;
+
+function onlyTool(file: FileEntry, lines: string[]): ToolEvent {
+  const tool = buildFeed(file, lines, false, "").items.find((item) => item.kind === "tool");
+  if (!tool || tool.kind !== "tool") throw new Error("expected a tool event");
+  return tool;
+}
+
+test("codex exec_command captures cwd, exit code, duration, and end time", () => {
+  const event = onlyTool(codexFile, codexExecStderrLines());
+  expect(event.command).toBe("make");
+  expect(event.cwd).toBe("/workspace/build");
+  expect(event.exitCode).toBe(0);
+  expect(event.durationMs).toBe(2500);
+  // endTs is the call start + duration, so it renders a real wall-clock span.
+  expect(event.endTs).toBe(new Date(Date.parse("2026-07-10T10:00:00Z") + 2500).toISOString());
+});
+
+test("an explicit stderr delimiter splits the stream out of stdout", () => {
+  const event = onlyTool(codexFile, codexExecStderrLines());
+  expect(event.outputPreview).toContain("built target app");
+  expect(event.outputPreview).not.toContain("warning: deprecated flag");
+  expect(event.stderr).toBe("warning: deprecated flag");
+  expect(event.stderrTruncated).toBe(false);
+});
+
+test("a Claude cd-prefixed Bash failure recovers cwd and a non-zero exit", () => {
+  const event = onlyTool(claudeFile, claudeExecFailLines());
+  expect(event.cwd).toBe("/workspace/app");
+  expect(event.status).toBe("err");
+  expect(event.exitCode).toBe(2);
+  expect(event.stderr).toBeUndefined();
+});
+
+test("an undelimited body stays entirely on stdout — the parser never guesses stderr", () => {
+  const lines = [
+    JSON.stringify({ type: "assistant", timestamp: "2026-07-10T10:00:00Z", message: { content: [{ type: "tool_use", id: "b1", name: "Bash", input: { command: "echo hi" } }] } }),
+    JSON.stringify({ type: "user", timestamp: "2026-07-10T10:00:01Z", message: { content: [{ type: "tool_result", tool_use_id: "b1", content: [{ type: "text", text: "hi\nerror: not a real stderr section" }] }] } }),
+  ];
+  const event = onlyTool(claudeFile, lines);
+  expect(event.stderr).toBeUndefined();
+  expect(event.outputPreview).toContain("error: not a real stderr section");
+});
+
+test("a large stdout result marks itself truncated past the cap", () => {
+  const big = Array.from({ length: 20_000 }, (_, i) => `row ${i}`).join("\n");
+  const lines = [
+    JSON.stringify({ type: "assistant", timestamp: "2026-07-10T10:00:00Z", message: { content: [{ type: "tool_use", id: "b1", name: "Bash", input: { command: "cat big.log" } }] } }),
+    JSON.stringify({ type: "user", timestamp: "2026-07-10T10:00:01Z", message: { content: [{ type: "tool_result", tool_use_id: "b1", content: [{ type: "text", text: big }] }] } }),
+  ];
+  const event = onlyTool(claudeFile, lines);
+  expect(event.outputTruncated).toBe(true);
+});
+
+test("an unknown tool keeps its generic typed fallback and never a command block", () => {
+  const lines = [
+    JSON.stringify({ type: "assistant", timestamp: "2026-07-10T10:00:00Z", message: { content: [{ type: "tool_use", id: "u1", name: "SomeFutureTool", input: { payload: "opaque" } }] } }),
+    JSON.stringify({ type: "user", timestamp: "2026-07-10T10:00:01Z", message: { content: [{ type: "tool_result", tool_use_id: "u1", content: [{ type: "text", text: "ok" }] }] } }),
+  ];
+  const event = onlyTool(claudeFile, lines);
+  expect(event.family).toBe("other");
+  expect(event.command).toBeUndefined();
+  expect(event.summary).toContain("SomeFutureTool");
+});
+
+test("a wait/write_stdin run nests as follow-ups of the exec that owns them", () => {
+  const line = (payload: Record<string, unknown>, ts: string) => JSON.stringify({ type: "response_item", timestamp: ts, payload });
+  const lines = [
+    line({ type: "function_call", call_id: "e1", name: "exec_command", arguments: JSON.stringify({ cmd: "npm run dev", workdir: "/w" }) }, "2026-07-10T10:00:00Z"),
+    line({ type: "function_call_output", call_id: "e1", output: "Script running with session ID 8479\nWall time 1.0 seconds\nOutput:\nbooting" }, "2026-07-10T10:00:01Z"),
+    line({ type: "function_call", call_id: "w1", name: "wait", arguments: JSON.stringify({ cell_id: "8479", yield_time_ms: 10000 }) }, "2026-07-10T10:00:02Z"),
+    line({ type: "function_call_output", call_id: "w1", output: "Script running with cell ID 8479\nWall time 10.0 seconds\nOutput:\nready" }, "2026-07-10T10:00:12Z"),
+    line({ type: "function_call", call_id: "s1", name: "write_stdin", arguments: JSON.stringify({ session_id: 8479, chars: "" }) }, "2026-07-10T10:00:13Z"),
+    line({ type: "function_call_output", call_id: "s1", output: "Script running with cell ID 8479\nWall time 5.0 seconds\nOutput:\n" }, "2026-07-10T10:00:18Z"),
+  ];
+  const group = buildFeed(codexFile, lines, false, "").items.find((item): item is CmdGroupItem => item.kind === "cmd-group");
+  if (!group) throw new Error("expected a cmd-group");
+  const blocks = groupNestedCalls(group.calls);
+  expect(blocks).toHaveLength(1);
+  expect(blocks[0].parent.tool).toBe("exec_command");
+  expect(blocks[0].children.map((c) => c.tool)).toEqual(["wait", "write_stdin"]);
+  // Each nested call preserves its own individual state.
+  expect(blocks[0].children.every((c) => c.status === "ok")).toBe(true);
+});

--- a/src/components/feed/toolBlocks.test.ts
+++ b/src/components/feed/toolBlocks.test.ts
@@ -12,9 +12,9 @@ test("wait and write_stdin are follow-ups; a plain exec is not", () => {
 
 test("follow-ups nest under the preceding exec while peers stay separate blocks", () => {
   const calls = [
-    toolEvent({ id: "e1", tool: "exec_command" }),
-    toolEvent({ id: "w1", tool: "wait" }),
-    toolEvent({ id: "s1", tool: "write_stdin" }),
+    toolEvent({ id: "e1", tool: "exec_command", runtimeSessionId: "8479" }),
+    toolEvent({ id: "w1", tool: "wait", runtimeSessionId: "8479" }),
+    toolEvent({ id: "s1", tool: "write_stdin", runtimeSessionId: "8479" }),
     toolEvent({ id: "e2", tool: "Bash" }),
     toolEvent({ id: "r1", tool: "Read", family: "read" }),
   ];
@@ -25,10 +25,24 @@ test("follow-ups nest under the preceding exec while peers stay separate blocks"
 });
 
 test("a leading follow-up with no parent stands as its own block", () => {
-  const blocks = groupNestedCalls([toolEvent({ id: "w1", tool: "wait" }), toolEvent({ id: "w2", tool: "wait" })]);
+  const blocks = groupNestedCalls([
+    toolEvent({ id: "w1", tool: "wait", runtimeSessionId: "8479" }),
+    toolEvent({ id: "w2", tool: "wait", runtimeSessionId: "8479" }),
+  ]);
   expect(blocks).toHaveLength(1);
   expect(blocks[0].parent.id).toBe("w1");
   expect(blocks[0].children.map((c) => c.id)).toEqual(["w2"]);
+});
+
+test("a follow-up never attaches to a neighboring command from another session", () => {
+  const blocks = groupNestedCalls([
+    toolEvent({ id: "e1", tool: "exec_command", runtimeSessionId: "111" }),
+    toolEvent({ id: "e2", tool: "exec_command", runtimeSessionId: "222" }),
+    toolEvent({ id: "w1", tool: "wait", runtimeSessionId: "111" }),
+  ]);
+  expect(blocks.map((block) => block.parent.id)).toEqual(["e1", "e2"]);
+  expect(blocks[0].children.map((child) => child.id)).toEqual(["w1"]);
+  expect(blocks[1].children).toHaveLength(0);
 });
 
 test("formatDuration scales from ms to seconds to minutes", () => {

--- a/src/components/feed/toolBlocks.test.ts
+++ b/src/components/feed/toolBlocks.test.ts
@@ -1,0 +1,40 @@
+import { expect, test } from "bun:test";
+
+import { toolEvent } from "./__fixtures__/readableTools";
+import { formatDuration, groupNestedCalls, isFollowUpCall } from "./toolBlocks";
+
+test("wait and write_stdin are follow-ups; a plain exec is not", () => {
+  expect(isFollowUpCall(toolEvent({ tool: "wait" }))).toBe(true);
+  expect(isFollowUpCall(toolEvent({ tool: "write_stdin" }))).toBe(true);
+  expect(isFollowUpCall(toolEvent({ tool: "Bash" }))).toBe(false);
+  expect(isFollowUpCall(toolEvent({ tool: "exec_command" }))).toBe(false);
+});
+
+test("follow-ups nest under the preceding exec while peers stay separate blocks", () => {
+  const calls = [
+    toolEvent({ id: "e1", tool: "exec_command" }),
+    toolEvent({ id: "w1", tool: "wait" }),
+    toolEvent({ id: "s1", tool: "write_stdin" }),
+    toolEvent({ id: "e2", tool: "Bash" }),
+    toolEvent({ id: "r1", tool: "Read", family: "read" }),
+  ];
+  const blocks = groupNestedCalls(calls);
+  expect(blocks.map((b) => b.parent.id)).toEqual(["e1", "e2", "r1"]);
+  expect(blocks[0].children.map((c) => c.id)).toEqual(["w1", "s1"]);
+  expect(blocks[1].children).toHaveLength(0);
+});
+
+test("a leading follow-up with no parent stands as its own block", () => {
+  const blocks = groupNestedCalls([toolEvent({ id: "w1", tool: "wait" }), toolEvent({ id: "w2", tool: "wait" })]);
+  expect(blocks).toHaveLength(1);
+  expect(blocks[0].parent.id).toBe("w1");
+  expect(blocks[0].children.map((c) => c.id)).toEqual(["w2"]);
+});
+
+test("formatDuration scales from ms to seconds to minutes", () => {
+  expect(formatDuration(240)).toBe("240ms");
+  expect(formatDuration(2500)).toBe("2.5s");
+  expect(formatDuration(45_000)).toBe("45s");
+  expect(formatDuration(62_000)).toBe("1m 2s");
+  expect(formatDuration(-5)).toBe("");
+});

--- a/src/components/feed/toolBlocks.ts
+++ b/src/components/feed/toolBlocks.ts
@@ -1,0 +1,51 @@
+import { getLocale, translate } from "@/lib/i18n";
+
+import type { ToolEvent } from "./parse";
+
+/* Pure helpers behind the readable expanded tool block (issue #475): the
+   parent/child nesting of Codex interactive-shell follow-ups, and the duration
+   formatter. Kept apart from the React card so both can be unit-tested against
+   synthetic ToolEvent fixtures without a DOM. */
+
+export type ToolBlock = { parent: ToolEvent; children: ToolEvent[] };
+
+/* Codex interactive-shell control calls that trail a parent exec: a `wait`
+   tails the running cell and a `write_stdin` (including an empty poll) feeds it.
+   They read as follow-ups of the exec that opened the session, never as peers. */
+const FOLLOW_UP_TOOLS = new Set(["wait", "write_stdin"]);
+
+export function isFollowUpCall(event: ToolEvent): boolean {
+  return FOLLOW_UP_TOOLS.has(event.tool);
+}
+
+/**
+ * Folds a group's flat call list into ordered blocks: each non-follow-up call
+ * owns the wait/write_stdin polls that immediately trail it, so nested waits
+ * render under their parent exec while keeping their own individual state. A
+ * leading follow-up with no parent yet stands as its own block.
+ */
+export function groupNestedCalls(calls: readonly ToolEvent[]): ToolBlock[] {
+  const blocks: ToolBlock[] = [];
+  for (const call of calls) {
+    const last = blocks[blocks.length - 1];
+    if (last && isFollowUpCall(call)) last.children.push(call);
+    else blocks.push({ parent: call, children: [] });
+  }
+  return blocks;
+}
+
+/** Human wall-clock duration: sub-second in ms, then `N.Ns`, then `Mm Ss`. */
+export function formatDuration(ms: number): string {
+  const locale = getLocale();
+  const t = (key: Parameters<typeof translate>[1], params?: Parameters<typeof translate>[2]) => translate(locale, key, params);
+  if (!Number.isFinite(ms) || ms < 0) return "";
+  if (ms < 1000) return t("tools.durationMs", { n: Math.round(ms) });
+  const totalSec = ms / 1000;
+  if (totalSec < 60) {
+    const n = totalSec < 10 ? Math.round(totalSec * 10) / 10 : Math.round(totalSec);
+    return t("tools.durationSec", { n });
+  }
+  const m = Math.floor(totalSec / 60);
+  const s = Math.round(totalSec % 60);
+  return t("tools.durationMin", { m, s: s === 60 ? 0 : s });
+}

--- a/src/components/feed/toolBlocks.ts
+++ b/src/components/feed/toolBlocks.ts
@@ -19,17 +19,21 @@ export function isFollowUpCall(event: ToolEvent): boolean {
 }
 
 /**
- * Folds a group's flat call list into ordered blocks: each non-follow-up call
- * owns the wait/write_stdin polls that immediately trail it, so nested waits
- * render under their parent exec while keeping their own individual state. A
- * leading follow-up with no parent yet stands as its own block.
+ * Folds a group's flat call list into ordered blocks. Interactive follow-ups
+ * attach only to a call carrying the same runtime cell/session id. A follow-up
+ * without a matching owner stays visible as its own block.
  */
 export function groupNestedCalls(calls: readonly ToolEvent[]): ToolBlock[] {
   const blocks: ToolBlock[] = [];
   for (const call of calls) {
-    const last = blocks[blocks.length - 1];
-    if (last && isFollowUpCall(call)) last.children.push(call);
-    else blocks.push({ parent: call, children: [] });
+    if (isFollowUpCall(call) && call.runtimeSessionId) {
+      const owner = blocks.findLast((block) => block.parent.runtimeSessionId === call.runtimeSessionId);
+      if (owner) {
+        owner.children.push(call);
+        continue;
+      }
+    }
+    blocks.push({ parent: call, children: [] });
   }
   return blocks;
 }

--- a/src/components/feed/toolLifecycle.parse.test.ts
+++ b/src/components/feed/toolLifecycle.parse.test.ts
@@ -1,0 +1,50 @@
+import { expect, test } from "bun:test";
+
+import type { FileEntry } from "@/lib/types";
+
+import { liveTrailingRunLines } from "./__fixtures__/readableTools";
+import { buildFeed, createFeedSession, type CmdGroupItem, type FeedEntry, type Item } from "./parse";
+
+const liveClaude = { path: "/tmp/x.jsonl", engine: "claude", fmt: "claude", activity: "live" } as FileEntry;
+
+function onlyGroup(items: (Item | FeedEntry)[]): CmdGroupItem {
+  const unwrapped = items.map((entry) => ("item" in entry ? entry.item : entry));
+  const group = unwrapped.find((item): item is CmdGroupItem => item.kind === "cmd-group");
+  if (!group) throw new Error("expected a cmd-group");
+  return group;
+}
+
+test("a live trailing run folds the whole active run — the in-flight call included — into one aggregate", () => {
+  const items = buildFeed(liveClaude, liveTrailingRunLines(), false, "").items;
+  // Exactly one aggregate, no loose running row trailing it.
+  expect(items.filter((item) => item.kind === "cmd-group")).toHaveLength(1);
+  expect(items.filter((item) => item.kind === "tool")).toHaveLength(0);
+  const group = onlyGroup(items);
+  // All three calls (two done + one running) belong to the aggregate.
+  expect(group.calls).toHaveLength(3);
+  expect(group.calls.map((c) => c.status)).toEqual(["ok", "ok", "run"]);
+  // The trailing live aggregate is marked active.
+  expect(group.active).toBe(true);
+});
+
+test("the aggregate settles (active → false) once it is no longer the live trailing run", () => {
+  const session = createFeedSession({ engine: "claude", fmt: "claude", showSvc: false, lineFilter: "" });
+  const lines = liveTrailingRunLines();
+  const live = onlyGroup(session.feed(lines, 0, true).items);
+  expect(live.active).toBe(true);
+  // The same window, re-fed as a settled (non-live) session: the group settles.
+  const settled = onlyGroup(session.feed(lines, 0, false).items);
+  expect(settled.active).toBe(false);
+  // The calls are unchanged — only the lifecycle flag flips.
+  expect(settled.calls).toHaveLength(3);
+});
+
+test("a settled group re-fed while still live keeps its identity and active flag stable", () => {
+  const session = createFeedSession({ engine: "claude", fmt: "claude", showSvc: false, lineFilter: "" });
+  const lines = liveTrailingRunLines();
+  const first = onlyGroup(session.feed(lines, 0, true).items);
+  const second = onlyGroup(session.feed(lines, 0, true).items);
+  // No new events arrived, so the memoized group is reused as-is.
+  expect(second).toBe(first);
+  expect(second.active).toBe(true);
+});

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -826,6 +826,23 @@ export const en = {
   "tools.copyDiff": "Copy diff",
   "tools.copyOutput": "Copy output",
   "tools.source": "source",
+  // Readable expanded tool block (issue #475)
+  "tools.action": "action {index}",
+  "tools.cwd": "cwd",
+  "tools.copyCwd": "copy cwd",
+  "tools.copyCommand": "Copy command",
+  "tools.stdout": "stdout",
+  "tools.stderr": "stderr",
+  "tools.copyStderr": "Copy stderr",
+  "tools.showStderr": "show all stderr",
+  "tools.noStderr": "no stderr captured",
+  "tools.exitOk": "exit 0",
+  "tools.exitCode": "exit {code}",
+  "tools.durationSec": "{n}s",
+  "tools.durationMin": "{m}m {s}s",
+  "tools.durationMs": "{n}ms",
+  "tools.ranAt": "{start}–{end}",
+  "tools.nestedWaits": { one: "{count} follow-up", other: "{count} follow-ups" },
 
   // ScheduleWakeup card + board timer chip (issue #161)
   "wakeup.card": "scheduled wakeup",

--- a/src/lib/i18n/uk.ts
+++ b/src/lib/i18n/uk.ts
@@ -800,6 +800,23 @@ export const uk: Record<keyof typeof en, Message> = {
   "tools.copyDiff": "Копіювати diff",
   "tools.copyOutput": "Копіювати вивід",
   "tools.source": "джерело",
+  // Readable expanded tool block (issue #475)
+  "tools.action": "дія {index}",
+  "tools.cwd": "cwd",
+  "tools.copyCwd": "копіювати cwd",
+  "tools.copyCommand": "Копіювати команду",
+  "tools.stdout": "stdout",
+  "tools.stderr": "stderr",
+  "tools.copyStderr": "Копіювати stderr",
+  "tools.showStderr": "показати весь stderr",
+  "tools.noStderr": "stderr не збережено",
+  "tools.exitOk": "код виходу 0",
+  "tools.exitCode": "код виходу {code}",
+  "tools.durationSec": "{n} с",
+  "tools.durationMin": "{m} хв {s} с",
+  "tools.durationMs": "{n} мс",
+  "tools.ranAt": "{start}–{end}",
+  "tools.nestedWaits": { one: "{count} додатковий", few: "{count} додаткові", many: "{count} додаткових", other: "{count} додаткових" },
 
   // ScheduleWakeup card + board timer chip (issue #161)
   "wakeup.card": "заплановане пробудження",


### PR DESCRIPTION
## Summary

- render readable command and owned output bodies for expanded tool activity
- aggregate the trailing live tool run and collapse it once after settlement
- preserve operator-controlled reopening, failure summaries, and nested wait/stdin ownership
- add desktop and 390px fixture coverage plus parser and DOM regression tests

## Verification

- 189 focused feed tests passed
- TypeScript passed
- exact-head independent review is running in pipeline 907676bf

Closes #475.