### PR TITLE
Runtime: reconcile abandoned MCP-owned spawns

### DIFF
--- a/src/lib/reaperRuntime.ts
+++ b/src/lib/reaperRuntime.ts
@@ -14,7 +14,7 @@ import type { Flow, FlowMergeEvidence } from "@/lib/flows/types";
 import { reconcileMigrationInventory } from "@/lib/accounts/migration/coordinator";
 import { procBackend } from "@/lib/proc";
 import { runtimeHostClient } from "@/lib/runtime/client";
-import { reconcileTerminalSpawnsHeldByLiveOwners } from "@/lib/runtime/staleSpawnOwner";
+import { reconcileStaleSpawnsHeldByLiveOwners } from "@/lib/runtime/staleSpawnOwner";
 import { terminalizeStaleStructuredSpawns } from "@/lib/runtime/structuredSpawn";
 import { listFiles } from "@/lib/scanner";
 import { isNativeCodexSubagentTranscript } from "@/lib/scanner/codexNative";
@@ -767,7 +767,7 @@ export interface ReaperActuationOverrides {
   saveFlows?: typeof saveFlows;
   now?: () => number;
   runtimeClient?: typeof runtimeHostClient;
-  reconcileTerminalOwnerSpawns?: typeof reconcileTerminalSpawnsHeldByLiveOwners;
+  reconcileLiveOwnerSpawns?: typeof reconcileStaleSpawnsHeldByLiveOwners;
   terminalizeStaleSpawns?: typeof terminalizeStaleStructuredSpawns;
 }
 
@@ -787,8 +787,8 @@ export async function runReaperCycle(options: {
   const runtimeClientForSpawns = (options.actuation?.runtimeClient ?? runtimeHostClient)();
   if (runtimeClientForSpawns) {
     try {
-      await (options.actuation?.reconcileTerminalOwnerSpawns
-        ?? reconcileTerminalSpawnsHeldByLiveOwners)(registry, runtimeClientForSpawns);
+      await (options.actuation?.reconcileLiveOwnerSpawns
+        ?? reconcileStaleSpawnsHeldByLiveOwners)(registry, runtimeClientForSpawns);
     } catch (error) {
       console.error("[reaper] terminal structured spawn owner convergence failed", error);
     }

--- a/src/lib/runtime/staleSpawnOwner.test.ts
+++ b/src/lib/runtime/staleSpawnOwner.test.ts
@@ -7,7 +7,7 @@ import { emptyLaunchProfile } from "@/lib/accounts/migration/contracts";
 import { AgentRegistry } from "@/lib/agent/registry";
 
 import type { RuntimeHostClient } from "./client";
-import { reconcileTerminalSpawnsHeldByLiveOwners } from "./staleSpawnOwner";
+import { reconcileStaleSpawnsHeldByLiveOwners } from "./staleSpawnOwner";
 import { STALE_STRUCTURED_SPAWN_TIMEOUT_MS } from "./structuredSpawn";
 
 test("a terminal operation releases a stale launch from a long-lived admission owner", async () => {
@@ -42,7 +42,7 @@ test("a terminal operation releases a stale launch from a long-lived admission o
   } as unknown as RuntimeHostClient;
 
   try {
-    const result = await reconcileTerminalSpawnsHeldByLiveOwners(store, client, {
+    const result = await reconcileStaleSpawnsHeldByLiveOwners(store, client, {
       now: () => Date.now() + STALE_STRUCTURED_SPAWN_TIMEOUT_MS + 60_000,
       ownerAlive: () => true,
     });
@@ -88,13 +88,48 @@ test("an open operation remains owned by its healthy admission process", async (
   } as unknown as RuntimeHostClient;
 
   try {
-    const result = await reconcileTerminalSpawnsHeldByLiveOwners(store, client, {
+    const result = await reconcileStaleSpawnsHeldByLiveOwners(store, client, {
       now: () => Date.now() + STALE_STRUCTURED_SPAWN_TIMEOUT_MS + 60_000,
       ownerAlive: () => true,
     });
 
     expect(result).toEqual({ examined: 0, terminalized: [], recovered: [] });
     expect(store.snapshot().receipts[receipt.launchId]?.state).toBe("starting");
+  } finally {
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+test("a stale launch with no runtime operation leaves its long-lived admission owner", async () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-missing-operation-owner-"));
+  const store = new AgentRegistry(path.join(directory, "registry.json"), undefined, undefined, { sqliteMode: "off" });
+  const begun = store.beginSpawnRequest({
+    engine: "codex",
+    cwd: "/repo",
+    transport: "structured",
+    accountId: "work",
+    clientAttemptId: "missing_operation_owner_attempt_a1",
+    requestDigest: "f".repeat(64),
+    launchProfile: emptyLaunchProfile({ cwd: "/repo" }),
+  });
+  if (begun.kind !== "created") throw new Error("expected structured launch creation");
+  const receipt = begun.receipt;
+  const client = {
+    operationStatus: async () => null,
+    snapshot: async () => ({ revision: 0, sessions: [] }),
+  } as unknown as RuntimeHostClient;
+
+  try {
+    const result = await reconcileStaleSpawnsHeldByLiveOwners(store, client, {
+      now: () => Date.now() + STALE_STRUCTURED_SPAWN_TIMEOUT_MS + 60_000,
+      ownerAlive: () => true,
+    });
+
+    expect(result).toEqual({ examined: 1, terminalized: [receipt.launchId], recovered: [] });
+    expect(store.snapshot().receipts[receipt.launchId]).toMatchObject({
+      state: "failed",
+      error: `structured spawn runtime snapshot has no session after ${STALE_STRUCTURED_SPAWN_TIMEOUT_MS}ms`,
+    });
   } finally {
     fs.rmSync(directory, { recursive: true, force: true });
   }

--- a/src/lib/runtime/staleSpawnOwner.ts
+++ b/src/lib/runtime/staleSpawnOwner.ts
@@ -25,12 +25,12 @@ function admissionOwnerAlive(owner: AdmissionOwner): boolean {
 }
 
 /**
- * Releases stale structured launches whose runtime operation already reached a
- * terminal state while their long-lived admission process remained healthy.
- * The regular stale-launch pass deliberately protects live owners, so this
- * narrow pre-pass supplies the missing per-operation evidence.
+ * Reconciles stale structured launches held by a healthy long-lived admission
+ * process when the exact runtime operation is terminal or absent. The regular
+ * stale-launch pass protects live owners, so this narrow pre-pass supplies the
+ * missing per-operation evidence and retains every open operation.
  */
-export async function reconcileTerminalSpawnsHeldByLiveOwners(
+export async function reconcileStaleSpawnsHeldByLiveOwners(
   registry: AgentRegistry,
   client: RuntimeHostClient,
   options: {
@@ -60,7 +60,7 @@ export async function reconcileTerminalSpawnsHeldByLiveOwners(
     if (!Number.isFinite(createdMs) || now() - createdMs < timeoutMs) continue;
 
     const operation = await client.operationStatus(receipt.launchId).catch(() => null);
-    if (!operation || !TERMINAL_OPERATION_STATUSES.has(operation.receipt.status)) continue;
+    if (operation && !TERMINAL_OPERATION_STATUSES.has(operation.receipt.status)) continue;
     examined += 1;
 
     try {


### PR DESCRIPTION
## Summary

- reconcile stale live-owner launch receipts when the exact runtime operation is absent
- retain owner protection for open runtime operations
- reuse full replay reconciliation so late session, transcript, host, or delivery evidence can recover the launch

## Production evidence

Three pipeline launches remained in `starting` for nearly an hour. Their admission owner was the healthy long-lived Viewer MCP process. The pipeline spawn calls had already returned `pipeline structured runtime host is unavailable`, and the runtime contained no matching operation or session.

## Verification

- 47 focused tests passed
- TypeScript passed
- changed-file ESLint passed with one pre-existing warning
- privacy publication gate passed
- `git diff --check` passed

Closes #334.