### PR TITLE
MCP: follow the live Viewer control plane across deploys

### DIFF
--- a/src/app/api/pipelines/tick/route.test.ts
+++ b/src/app/api/pipelines/tick/route.test.ts
@@ -1,0 +1,22 @@
+import { expect, test } from "bun:test";
+import { NextRequest } from "next/server";
+
+import { POST } from "./route";
+
+test("pipeline tick runs inside the live Viewer request process", async () => {
+  let calls = 0;
+  const response = await POST.withDependencies(new NextRequest("http://127.0.0.1:8898/api/pipelines/tick", {
+    method: "POST",
+    headers: {
+      host: "127.0.0.1:8898",
+      origin: "http://127.0.0.1:8898",
+      "sec-fetch-site": "same-origin",
+    },
+  }), async () => {
+    calls += 1;
+    return { pipelines: [], changed: false };
+  });
+
+  expect(response.status).toBe(202);
+  expect(calls).toBe(2);
+});

--- a/src/app/api/pipelines/tick/route.ts
+++ b/src/app/api/pipelines/tick/route.ts
@@ -1,0 +1,22 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { tickPipelines } from "@/lib/pipelines/engine";
+import { rejectCrossOrigin } from "@/lib/sameOrigin";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+type PipelineTick = typeof tickPipelines;
+
+async function post(request: NextRequest, tick: PipelineTick): Promise<NextResponse> {
+  const rejection = rejectCrossOrigin(request);
+  if (rejection) return rejection;
+  await tick([]);
+  await tick([]);
+  return NextResponse.json({ ok: true }, { status: 202 });
+}
+
+export const POST = Object.assign(
+  (request: NextRequest) => post(request, tickPipelines),
+  { withDependencies: (request: NextRequest, tick: PipelineTick) => post(request, tick) },
+);

--- a/src/lib/mcp/bindings.test.ts
+++ b/src/lib/mcp/bindings.test.ts
@@ -21,7 +21,13 @@ test("spawn_agent reaches spawn validation through the operator admission lane",
   const sandbox = fs.mkdtempSync(path.join(os.tmpdir(), "llv-mcp-binding-spawn-"));
   sandboxes.push(sandbox);
   process.env.LLV_STATE_DIR = sandbox;
-  const spawnAgent = viewerMcpBindings().spawn_agent;
+  const requests: Array<{ pathname: string; body: Record<string, unknown>; headers?: Record<string, string> }> = [];
+  const spawnAgent = viewerMcpBindings(undefined, {
+    post: async (pathname, body, headers) => {
+      requests.push({ pathname, body, headers });
+      throw new Error(`directory does not exist: ${String(body.cwd)}`);
+    },
+  }).spawn_agent;
   const missingCwd = path.join(sandbox, "missing-cwd");
 
   for (const request of [
@@ -30,7 +36,60 @@ test("spawn_agent reaches spawn validation through the operator admission lane",
   ]) {
     await expect(spawnAgent(request)).rejects.toThrow(`directory does not exist: ${missingCwd}`);
   }
+  expect(requests.map((request) => request.pathname)).toEqual(["/api/spawn", "/api/spawn"]);
+  expect(requests.every((request) => Boolean(request.headers?.["x-llv-spawn-capability"]))).toBe(true);
   expect(fs.readFileSync(path.join(sandbox, "operator-spawn-capability"), "utf8").trim()).toMatch(/^[A-Za-z0-9_-]{43}$/);
+});
+
+test("runtime-bound MCP tools use the live Viewer control surface", async () => {
+  const requests: Array<{ pathname: string; body: Record<string, unknown> }> = [];
+  const bindings = viewerMcpBindings(undefined, {
+    post: async (pathname, body) => {
+      requests.push({ pathname, body });
+      if (pathname === "/api/spawn") return {
+        conversationId: "conversation_http_control",
+        path: "/repo/session.jsonl",
+        launchId: "launch_http_control",
+        state: "path-pending",
+        initialMessage: "queued",
+      };
+      if (pathname === "/api/tmux") return {
+        operationId: "operation_http_control",
+        outcome: "queued",
+      };
+      return {
+        deploymentId: "deployment_http_control",
+        revision: "a".repeat(40),
+        state: "accepted",
+        replayed: false,
+      };
+    },
+  });
+
+  await bindings.spawn_agent({
+    clientRequestId: "spawn-http-control",
+    cwd: "/repo",
+    ["prompt"]: "implement",
+  });
+  await bindings.send_message({
+    clientRequestId: "send-http-control",
+    conversationId: "conversation_http_control",
+    text: "continue",
+  });
+  await bindings.deploy_exact_sha({
+    clientRequestId: "deploy-http-control",
+    confirm: "deploy",
+    revision: "a".repeat(40),
+  });
+
+  expect(requests.map((request) => request.pathname)).toEqual([
+    "/api/spawn",
+    "/api/tmux",
+    "/api/runtime/deployments",
+  ]);
+  expect(requests[0]?.body.clientAttemptId).toBe("spawn-http-control");
+  expect(requests[1]?.body.clientMessageId).toBe("send-http-control");
+  expect(requests[2]?.body.idempotencyKey).toBe("deploy-http-control");
 });
 
 test("link_task_to_pipeline binds the latest operational attempt after historical adoption", async () => {

--- a/src/lib/mcp/bindings.ts
+++ b/src/lib/mcp/bindings.ts
@@ -1,17 +1,12 @@
 import crypto from "node:crypto";
 
-import { NextRequest } from "next/server";
-
 import { agentRegistry } from "@/lib/agent/registry";
 import { ensureOperatorSpawnCapability } from "@/lib/agent/operatorCapability";
-import { executeSpawnRequest, productionSpawnCommandDependencies } from "@/lib/agent/spawnCommand";
 import { VIEWER_SPAWN_CAPABILITY_HEADER } from "@/lib/agent/spawnPolicy";
-import { deliverConversationMessage } from "@/lib/delivery";
 import { createPipelineFromRequest, getPipelines, patchPipeline } from "@/lib/pipelines/engine";
 import { latestOperationalPipelineAttempt } from "@/lib/pipelines/attemptSelection";
 import { requestPipelineTick } from "@/lib/pipelines/controllerSignal";
 import type { CreatePipelineRequest, PatchPipelineRequest, PipelineAction } from "@/lib/pipelines/types";
-import { RuntimeHostUnavailableError, runtimeHostClient } from "@/lib/runtime/client";
 import { listFiles } from "@/lib/scanner";
 import { readSession } from "@/lib/session/reader";
 import { applyAssignmentPatches, createTask, patchTask, type CreateTaskInput, type PatchTaskInput } from "@/lib/tasks/commands";
@@ -34,6 +29,37 @@ const productionLinkTaskDependencies: LinkTaskToPipelineDependencies = {
   mutateTasks,
   isoNow,
 };
+
+export interface ViewerControlDependencies {
+  post(pathname: string, body: Record<string, unknown>, headers?: Record<string, string>): Promise<Record<string, unknown>>;
+}
+
+const VIEWER_CONTROL_URL = "http://127.0.0.1:8898";
+
+async function postViewerControl(
+  pathname: string,
+  body: Record<string, unknown>,
+  headers: Record<string, string> = {},
+): Promise<Record<string, unknown>> {
+  const baseUrl = process.env.LLV_VIEWER_CONTROL_URL?.trim() || VIEWER_CONTROL_URL;
+  const response = await fetch(new URL(pathname, baseUrl), {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      origin: baseUrl,
+      "sec-fetch-site": "same-origin",
+      ...headers,
+    },
+    body: JSON.stringify(body),
+  });
+  const result = await response.json().catch(() => ({})) as Record<string, unknown>;
+  if (result.error || (!response.ok && result.state !== "busy")) {
+    throw new Error(text(result.error) || `Viewer control request failed with status ${response.status}`);
+  }
+  return result;
+}
+
+const productionViewerControlDependencies: ViewerControlDependencies = { post: postViewerControl };
 
 function text(value: unknown): string {
   return typeof value === "string" ? value.trim() : "";
@@ -64,26 +90,12 @@ function spawnAttemptId(value: string): string {
     : `mcp_${crypto.createHash("sha256").update(value).digest("hex").slice(0, 24)}`;
 }
 
-async function spawnAgent(args: McpToolArgs): Promise<McpToolPayload> {
+async function spawnAgent(args: McpToolArgs, control: ViewerControlDependencies): Promise<McpToolPayload> {
   const clientAttemptId = spawnAttemptId(requestId(args));
   const body = withoutKeys(args, ["clientRequestId"]);
-  const request = new NextRequest("http://127.0.0.1/api/spawn", {
-    method: "POST",
-    headers: {
-      host: "127.0.0.1",
-      origin: "http://127.0.0.1",
-      "sec-fetch-site": "same-origin",
-      "content-type": "application/json",
-      [VIEWER_SPAWN_CAPABILITY_HEADER]: ensureOperatorSpawnCapability(),
-    },
-    body: JSON.stringify({ ...body, clientAttemptId }),
+  const result = await control.post("/api/spawn", { ...body, clientAttemptId }, {
+    [VIEWER_SPAWN_CAPABILITY_HEADER]: ensureOperatorSpawnCapability(),
   });
-  const response = await executeSpawnRequest(request, {
-    ...productionSpawnCommandDependencies,
-    defer: (work) => { void work(); },
-  });
-  const result = await response.json() as Record<string, unknown>;
-  if (!response.ok || result.ok === false || result.error) throw new Error(text(result.error) || `spawn failed with status ${response.status}`);
   return {
     conversationId: result.conversationId,
     transcriptPath: result.path,
@@ -94,12 +106,12 @@ async function spawnAgent(args: McpToolArgs): Promise<McpToolPayload> {
   };
 }
 
-async function sendMessage(args: McpToolArgs): Promise<McpToolPayload> {
+async function sendMessage(args: McpToolArgs, control: ViewerControlDependencies): Promise<McpToolPayload> {
   const conversationId = text(args.conversationId);
   const transcriptPath = text(args.transcriptPath) || text(args.path);
   if (!conversationId && !transcriptPath) throw new Error("conversationId or transcriptPath is required");
   const message = required(args, "text");
-  const outcome = await deliverConversationMessage({
+  const outcome = await control.post("/api/tmux", {
     pid: null,
     path: transcriptPath,
     ...(conversationId ? { conversationId } : {}),
@@ -107,14 +119,13 @@ async function sendMessage(args: McpToolArgs): Promise<McpToolPayload> {
     text: message,
     images: [],
   });
-  if (!outcome.ok) throw new Error(outcome.error);
   const conversation = conversationId
     ? agentRegistry().conversation(conversationId as `conversation_${string}`)
     : agentRegistry().conversationForPath(transcriptPath);
   return {
     conversationId: (conversation?.id ?? conversationId) || null,
     transcriptPath: (conversation?.generations.at(-1)?.path ?? transcriptPath) || null,
-    operationId: outcome.operationId ?? outcome.receipt?.operationId ?? null,
+    operationId: outcome.operationId ?? (outcome.receipt as { operationId?: unknown } | undefined)?.operationId ?? null,
     outcome: outcome.outcome ?? "delivered",
   };
 }
@@ -235,19 +246,17 @@ async function getConversation(args: McpToolArgs): Promise<McpToolPayload> {
   };
 }
 
-async function deployExactSha(args: McpToolArgs): Promise<McpToolPayload> {
+async function deployExactSha(args: McpToolArgs, control: ViewerControlDependencies): Promise<McpToolPayload> {
   if (args.confirm !== "deploy") throw new Error('confirm must equal "deploy"');
   const revision = required(args, "revision");
   if (!/^[0-9a-f]{40}$/i.test(revision)) throw new Error("revision must be a full 40-character commit SHA");
-  const client = runtimeHostClient();
-  if (!client) throw new Error("runtime host socket is unavailable");
-  try {
-    const receipt = await client.requestViewerDeployment({ revision, idempotencyKey: requestId(args) });
-    return { deploymentId: receipt.deploymentId, revision: receipt.revision, replayed: receipt.state === "accepted" && receipt.replayed, state: receipt.state };
-  } catch (error) {
-    if (error instanceof RuntimeHostUnavailableError) throw new Error(error.message);
-    throw error;
-  }
+  const receipt = await control.post("/api/runtime/deployments", { revision, idempotencyKey: requestId(args) });
+  return {
+    deploymentId: receipt.deploymentId,
+    revision: receipt.revision,
+    replayed: receipt.state === "accepted" && receipt.replayed === true,
+    state: receipt.state,
+  };
 }
 
 async function getPipeline(args: McpToolArgs): Promise<McpToolPayload> {
@@ -257,10 +266,13 @@ async function getPipeline(args: McpToolArgs): Promise<McpToolPayload> {
   return { pipelineId, pipeline };
 }
 
-export function viewerMcpBindings(linkTaskDependencies: LinkTaskToPipelineDependencies = productionLinkTaskDependencies): McpToolBindings {
+export function viewerMcpBindings(
+  linkTaskDependencies: LinkTaskToPipelineDependencies = productionLinkTaskDependencies,
+  controlDependencies: ViewerControlDependencies = productionViewerControlDependencies,
+): McpToolBindings {
   return {
-    spawn_agent: spawnAgent,
-    send_message: sendMessage,
+    spawn_agent: (args) => spawnAgent(args, controlDependencies),
+    send_message: (args) => sendMessage(args, controlDependencies),
     create_task: createBoardTask,
     update_task: updateBoardTask,
     create_pipeline: createPipeline,
@@ -268,7 +280,7 @@ export function viewerMcpBindings(linkTaskDependencies: LinkTaskToPipelineDepend
     link_task_to_pipeline: (args) => linkTaskToPipeline(args, linkTaskDependencies),
     list_conversations: listConversations,
     get_conversation: getConversation,
-    deploy_exact_sha: deployExactSha,
+    deploy_exact_sha: (args) => deployExactSha(args, controlDependencies),
     get_pipeline: getPipeline,
   };
 }

--- a/src/lib/pipelines/controllerSignal.test.ts
+++ b/src/lib/pipelines/controllerSignal.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "bun:test";
 
-import { registerPipelineTick, requestPipelineTick } from "./controllerSignal";
+import { registerPipelineTick, requestPipelineTick, requestRemotePipelineTick } from "./controllerSignal";
 
 test("pipeline controller signals coalesce concurrent requests", async () => {
   let calls = 0;
@@ -13,4 +13,17 @@ test("pipeline controller signals coalesce concurrent requests", async () => {
 
   expect(calls).toBe(1);
   unregister();
+});
+
+test("the standalone controller signal targets the live Viewer process", async () => {
+  const requests: Array<{ url: string; method: string | undefined }> = [];
+  await requestRemotePipelineTick(async (input, init) => {
+    requests.push({ url: String(input), method: init?.method });
+    return new Response(JSON.stringify({ ok: true }), { status: 202 });
+  }, { LLV_VIEWER_CONTROL_URL: "http://127.0.0.1:19000" });
+
+  expect(requests).toEqual([{
+    url: "http://127.0.0.1:19000/api/pipelines/tick",
+    method: "POST",
+  }]);
 });

--- a/src/lib/pipelines/controllerSignal.ts
+++ b/src/lib/pipelines/controllerSignal.ts
@@ -1,6 +1,5 @@
-import { tickPipelines } from "./engine";
-
 type PipelineTick = () => Promise<void>;
+type Fetcher = (input: string | URL | Request, init?: RequestInit) => Promise<Response>;
 
 interface PipelineSignalState {
   tick: PipelineTick | null;
@@ -11,9 +10,25 @@ const signalHost = globalThis as typeof globalThis & {
   __llvPipelineSignal?: PipelineSignalState;
 };
 
+export async function requestRemotePipelineTick(
+  fetcher: Fetcher = fetch,
+  env: Record<string, string | undefined> = process.env,
+): Promise<void> {
+  const baseUrl = env.LLV_VIEWER_CONTROL_URL?.trim() || "http://127.0.0.1:8898";
+  const response = await fetcher(new URL("/api/pipelines/tick", baseUrl), {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      origin: baseUrl,
+      "sec-fetch-site": "same-origin",
+    },
+    body: "{}",
+  });
+  if (!response.ok) throw new Error(`pipeline controller request failed with status ${response.status}`);
+}
+
 async function defaultPipelineTick(): Promise<void> {
-  await tickPipelines([]);
-  await tickPipelines([]);
+  await requestRemotePipelineTick();
 }
 
 const signal = signalHost.__llvPipelineSignal ??= { tick: defaultPipelineTick, scheduled: false };


### PR DESCRIPTION
## Problem

The standalone MCP process keeps runtime-socket state from the generation where it started. Blue-green Viewer promotion changes the active runtime host, leaving MCP spawn, delivery, deployment, and pipeline advancement bound to stale process-local state. Launch receipts can remain in `starting` until later reconciliation.

Closes #486.

## Changes

- route MCP spawn, message delivery, and exact-SHA deployment through the live Viewer HTTP control surface
- execute pipeline ticks inside the active Viewer process through a same-origin route
- preserve idempotency keys and operator spawn capability headers
- add focused MCP, controller-signal, and route-handler coverage

## Verification

- 18 focused tests passed
- TypeScript passed
- changed-file ESLint passed
- privacy scan passed
- `git diff --check` passed
- production Next.js and MCP bundle build passed