### PR TITLE
Runtime: share structured controller across Next bundle realms

### DIFF
--- a/src/lib/runtime/startupStatus.test.ts
+++ b/src/lib/runtime/startupStatus.test.ts
@@ -16,7 +16,7 @@ test("separate bundle module instances share structured startup status", async (
 
 test("issue 367: the structured startup axis never reports ready before adoption succeeds", async () => {
   const { markStructuredHostStartupFailed, markStructuredHostStartupReady, structuredStartupAxis } = await import(`./startupStatus?${"axis-copy"}`);
-  const store = globalThis as typeof globalThis & { __llvStructuredHostStartupFailed?: boolean };
+  const store = process as typeof process & { __llvStructuredHostStartupFailed?: boolean };
   const previous = store.__llvStructuredHostStartupFailed;
   try {
     delete store.__llvStructuredHostStartupFailed;

--- a/src/lib/runtime/startupStatus.ts
+++ b/src/lib/runtime/startupStatus.ts
@@ -1,4 +1,4 @@
-const startupStore = globalThis as typeof globalThis & {
+const startupStore = process as typeof process & {
   __llvStructuredHostStartupFailed?: boolean;
 };
 

--- a/src/lib/runtime/structuredDelivery.integration.test.ts
+++ b/src/lib/runtime/structuredDelivery.integration.test.ts
@@ -296,6 +296,13 @@ test("the controller republishes a live host into a restarted runtime journal", 
     await bindStructuredDeliveryQueue([{ key, host }], { registry, client });
     expect(journal.snapshot().sessions.find((session) => session.conversationId === conversation.id)?.host).toBe("hosted");
 
+    /* A route bundle can have a different realm global from instrumentation.
+       Removing the realm-local legacy slot must leave the process controller
+       available to the route-side publication API. */
+    delete (globalThis as typeof globalThis & { __llvStructuredDeliveryController?: unknown })
+      .__llvStructuredDeliveryController;
+    expect(await republishStructuredDeliveryHost(key)).toBeTrue();
+
     journal.close();
     journal = new RuntimeJournal(path.join(directory, "runtime-after.sqlite"), { structuredHosts: true });
     expect(journal.snapshot().sessions.find((session) => session.conversationId === conversation.id)).toBeUndefined();

--- a/src/lib/runtime/structuredDeliveryController.ts
+++ b/src/lib/runtime/structuredDeliveryController.ts
@@ -24,10 +24,10 @@ export interface StructuredDeliveryHost {
 const DELIVERY_DRAIN_COALESCE_MS = 25;
 const DELIVERY_DRAIN_MAX_BACKOFF_MS = 1_000;
 
-/* Next standalone bundles instrumentation and route handlers separately, so a
-   module-level `let` written by startup adoption is invisible to routes. The
-   controller registration must live on `globalThis`, like every other
-   cross-bundle singleton in this codebase (see scanner/caches.ts). */
+/* Next standalone can evaluate instrumentation and route handlers in separate
+   bundle realms inside one Node process. Realm-local globals cannot carry the
+   controller registration between those bundles. The injected `process`
+   object is shared by the realms, so it owns the process-scoped controller. */
 interface ControllerState {
   activeQueue: StructuredDeliveryQueue | null;
   activeHosts: Map<string, EngineHost> | null;
@@ -37,7 +37,7 @@ interface ControllerState {
   terminateActiveHost: ((key: SessionKey) => Promise<boolean>) | null;
   stopActive: () => void;
 }
-const controllerStore = globalThis as typeof globalThis & { __llvStructuredDeliveryController?: ControllerState };
+const controllerStore = process as typeof process & { __llvStructuredDeliveryController?: ControllerState };
 const state: ControllerState = controllerStore.__llvStructuredDeliveryController ??= {
   activeQueue: null,
   activeHosts: null,

--- a/src/lib/runtime/structuredDeliverySignal.test.ts
+++ b/src/lib/runtime/structuredDeliverySignal.test.ts
@@ -1,0 +1,16 @@
+import { expect, test } from "bun:test";
+
+import { kickStructuredDeliveryQueue, setStructuredDeliveryKick } from "./structuredDeliverySignal";
+
+test("route bundle realms observe the process-owned delivery kick", async () => {
+  let calls = 0;
+  setStructuredDeliveryKick(() => { calls += 1; });
+  try {
+    delete (globalThis as typeof globalThis & { __llvStructuredDeliveryKick?: unknown })
+      .__llvStructuredDeliveryKick;
+    await kickStructuredDeliveryQueue();
+    expect(calls).toBe(1);
+  } finally {
+    setStructuredDeliveryKick(null);
+  }
+});

--- a/src/lib/runtime/structuredDeliverySignal.ts
+++ b/src/lib/runtime/structuredDeliverySignal.ts
@@ -1,7 +1,6 @@
-/* The kick is registered by startup adoption (instrumentation bundle) and
-   fired from route handlers (their own bundle), so it must live on
-   `globalThis` — module-level state does not cross Next standalone bundles. */
-const signalStore = globalThis as typeof globalThis & {
+/* Startup adoption and route handlers can run in separate Next bundle realms.
+   The Node process object carries the kick across those realm boundaries. */
+const signalStore = process as typeof process & {
   __llvStructuredDeliveryKick?: (() => void | Promise<void>) | null;
 };
 


### PR DESCRIPTION
## Problem

Production reported `structuredStartup: ready` while pipeline and UI spawns failed with `structured delivery controller is unavailable`. Next standalone evaluates instrumentation and route handlers in separate bundle realms. Realm-local globals held separate controller registrations inside one Node process.

Closes #488.

## Changes

- store the structured delivery controller on the process-shared Node object
- move the delivery kick and startup readiness axis to the same process-shared boundary
- add regressions that remove legacy realm-local slots while controller publication and route-side kicks remain available

## Verification

- 33 runtime tests passed
- TypeScript passed
- changed-file ESLint passed
- privacy publication gate passed
- `git diff --check` passed
- production Next.js and MCP bundle build passed