### PR TITLE
fix(scanner): stop full rescans of modern Codex transcripts

### DIFF
--- a/src/lib/session/reader.test.ts
+++ b/src/lib/session/reader.test.ts
@@ -65,6 +65,59 @@ describe("readSession", () => {
     expect(result.messages.map((item) => item.text)).toEqual(["Fix the tests", "Fixed."]);
     expect(result.traces[0]?.name).toBe("turn_complete");
   });
+
+  test("reads modern Codex response-item text and stops authorship scanning at the first user record", () => {
+    const pathname = path.join(SANDBOX, "codex-modern-input-text.jsonl");
+    const firstRows = [
+      { type: "session_meta", payload: { id: "session-modern" } },
+      {
+        type: "response_item",
+        timestamp: "t1",
+        payload: {
+          type: "message",
+          role: "user",
+          content: [{ type: "input_text", text: "Fix the production queue" }],
+        },
+      },
+    ];
+    fs.writeFileSync(pathname, firstRows.map((row) => JSON.stringify(row)).join("\n") + "\n");
+    fs.appendFileSync(pathname, JSON.stringify({
+      type: "response_item",
+      timestamp: "t2",
+      payload: {
+        type: "message",
+        role: "assistant",
+        content: [{ type: "output_text", text: "x".repeat(1024 * 1024) }],
+      },
+    }) + "\n");
+
+    const originalOpen = fs.openSync;
+    const originalRead = fs.readSync;
+    let targetFd: number | null = null;
+    let bytesRead = 0;
+    fs.openSync = ((...args: Parameters<typeof fs.openSync>) => {
+      const fd = originalOpen(...args);
+      if (String(args[0]) === pathname) targetFd = fd;
+      return fd;
+    }) as typeof fs.openSync;
+    fs.readSync = ((...args: Parameters<typeof fs.readSync>) => {
+      const read = originalRead(...args);
+      if (args[0] === targetFd) bytesRead += read;
+      return read;
+    }) as typeof fs.readSync;
+    try {
+      expect(scanUserAuthoredMessages(pathname, "codex", 1)).toEqual({ count: 1, complete: true });
+    } finally {
+      fs.openSync = originalOpen;
+      fs.readSync = originalRead;
+    }
+
+    expect(bytesRead).toBeLessThanOrEqual(64 * 1024);
+    expect(readSession(pathname, "codex").messages.map((item) => item.text)).toEqual([
+      "Fix the production queue",
+      "x".repeat(1024 * 1024),
+    ]);
+  });
 });
 
 test("authorship scan reports malformed and oversized records as incomplete", () => {

--- a/src/lib/session/reader.ts
+++ b/src/lib/session/reader.ts
@@ -77,7 +77,9 @@ function textFromContent(content: unknown): string {
   if (typeof content === "string") return content;
   return arr(content)
     .map((part) => {
-      if (part.type === "text") return str(part.text);
+      if (part.type === "text" || part.type === "input_text" || part.type === "output_text") {
+        return str(part.text);
+      }
       if (part.type === "thinking") return str(part.thinking);
       if (part.type === "tool_use") return `${str(part.name)} ${JSON.stringify(rec(part.input))}`.trim();
       if (part.type === "tool_result") {


### PR DESCRIPTION
Closes #490.

## Problem
Modern Codex messages encode content as `input_text` and `output_text`. The session reader ignored those parts, so authorship scans could miss the first user message and repeatedly read a multi-gigabyte transcript. That saturated the Viewer process and delayed structured host materialization.

## Change
- recognize modern Codex input/output text parts
- add a regression proving the authorship scan stops after the first user record within a 64 KiB read budget
- preserve full session rendering for both user and assistant messages

## Verification
- `bun test src/lib/session/reader.test.ts`
- `bun run tsc --noEmit`
- `bunx eslint src/lib/session/reader.ts src/lib/session/reader.test.ts`
- `git diff --check`
