### PR TITLE
Fix blue-green external tmux supervisor mount

### DIFF
--- a/src/runtime-host/candidateContainer.test.ts
+++ b/src/runtime-host/candidateContainer.test.ts
@@ -120,6 +120,7 @@ test("promoted candidate derives its runtime contract from Compose", () => {
   expect(valuesAfter(args, "--mount")).toEqual([
     "type=bind,source=/home/user,target=/home/user",
     "type=bind,source=/tmp/tmux-1000,target=/tmp/tmux-1000",
+    "type=bind,source=/run/user/1000/agent-log-viewer,target=/run/user/1000/agent-log-viewer",
   ]);
   expect(args[args.indexOf("--restart") + 1]).toBe("unless-stopped");
   expect(args[args.indexOf("--network") + 1]).toBe("host");
@@ -183,7 +184,11 @@ test("actual Viewer Compose keys remain covered by the candidate generator", () 
   expect(Object.keys(environment).sort()).toEqual([
     ...new Set([...Object.keys(service.environment), "LLV_RUNTIME_EVENTS", "LLV_RUNTIME_HOST_SOCKET"]),
   ].sort());
-  expect(valuesAfter(args, "--mount")).toHaveLength(service.volumes.length);
+  const mounts = valuesAfter(args, "--mount");
+  const externalTmpdir = "/run/user/1000/agent-log-viewer";
+  const composeAlreadyMountsSupervisor = service.volumes.some((volume) => volume.target === externalTmpdir);
+  expect(mounts).toHaveLength(service.volumes.length + (composeAlreadyMountsSupervisor ? 0 : 1));
+  expect(mounts).toContain(`type=bind,source=${externalTmpdir},target=${externalTmpdir}`);
   expect(args[args.indexOf("--restart") + 1]).toBe(service.restart);
   expect(environment.LLV_ALLOW_LEGACY_VIEWER).toBe("1");
   expect(args.slice(args.indexOf(candidate.image) + 1)).toEqual(
@@ -257,6 +262,26 @@ test("candidate tmux environment follows the durable migration marker", () => {
   expect(checked).toEqual(["/state/legacy-tmux-migration-complete"]);
 
   expect(viewerCandidateTmuxEnvironment("/state", "1000", configured, () => false)).toEqual(configured);
+});
+
+test("candidate reuses an existing external tmux supervisor mount", () => {
+  const externalTmpdir = "/run/user/1000/agent-log-viewer";
+  const service = {
+    ...composeService,
+    volumes: [
+      ...composeService.volumes,
+      { type: "bind", source: externalTmpdir, target: externalTmpdir, bind: {} },
+    ],
+  } satisfies ViewerComposeService;
+  const args = viewerCandidateDockerArgs(candidate, service, {
+    runtimeSocket: "/state/runtime-host.sock",
+    legacyTmuxExternal: "1",
+    tmuxTmpdir: externalTmpdir,
+  });
+
+  expect(valuesAfter(args, "--mount").filter((mount) => mount.includes(externalTmpdir))).toEqual([
+    `type=bind,source=${externalTmpdir},target=${externalTmpdir}`,
+  ]);
 });
 
 test("container retention keeps the serving and immediate rollback releases", () => {

--- a/src/runtime-host/candidateContainer.ts
+++ b/src/runtime-host/candidateContainer.ts
@@ -146,6 +146,32 @@ export function viewerCandidateTmuxEnvironment(
     : configured;
 }
 
+function viewerCandidateVolumes(
+  service: ViewerComposeService,
+  overrides: Pick<ViewerCandidateContainerOverrides, "legacyTmuxExternal" | "tmuxTmpdir">,
+): ViewerComposeVolume[] {
+  if (overrides.legacyTmuxExternal !== "1") return service.volumes;
+  if (!path.isAbsolute(overrides.tmuxTmpdir)) throw new Error("External tmux directory must be absolute");
+
+  const existing = service.volumes.find((volume) => volume.target === overrides.tmuxTmpdir);
+  if (existing) {
+    if (existing.source !== overrides.tmuxTmpdir || existing.read_only) {
+      throw new Error("External tmux directory mount does not expose the host supervisor path");
+    }
+    return service.volumes;
+  }
+
+  return [
+    ...service.volumes,
+    {
+      type: "bind",
+      source: overrides.tmuxTmpdir,
+      target: overrides.tmuxTmpdir,
+      bind: {},
+    },
+  ];
+}
+
 export function viewerCandidateDockerArgs(
   candidate: ViewerReleaseIdentity,
   service: ViewerComposeService,
@@ -166,6 +192,7 @@ export function viewerCandidateDockerArgs(
     "dev.live-log-viewer.managed": "1",
     "dev.live-log-viewer.revision": candidate.revision,
   };
+  const volumes = viewerCandidateVolumes(service, overrides);
   const command = service.command?.map((argument) => argument.replaceAll("$$", () => "$")) ?? [];
   const args = [
     "docker", "run", "-d",
@@ -178,7 +205,7 @@ export function viewerCandidateDockerArgs(
     "--user", service.user,
     "--workdir", service.working_dir,
     ...Object.entries(environment).sort(([left], [right]) => left.localeCompare(right)).flatMap(([key, value]) => ["-e", `${key}=${value}`]),
-    ...service.volumes.flatMap((volume) => [
+    ...volumes.flatMap((volume) => [
       "--mount",
       `type=bind,source=${volume.source},target=${volume.target}${volume.read_only ? ",readonly" : ""}`,
     ]),


### PR DESCRIPTION
Closes #495.

## Summary

- bind the configured external `TMUX_TMPDIR` into promoted candidates
- preserve existing Compose mounts and reuse an existing matching supervisor mount
- reject relative, read-only, and remapped supervisor mounts
- cover promotion and duplicate-mount behavior with regression tests

## Verification

- `bun test src/runtime-host/candidateContainer.test.ts src/runtime-host/deployment.test.ts scripts/runtime-host-viewer-adapter.test.ts` — 27 passed
- `bun x tsc --noEmit`
- changed-file ESLint
- `git diff --check`
- `bun run build`
