### PR TITLE
perf(scanner): stop compaction tail scan amplification (#493)

### DIFF
--- a/src/lib/reaperRuntime.performance.test.ts
+++ b/src/lib/reaperRuntime.performance.test.ts
@@ -1,0 +1,114 @@
+import { afterEach, expect, test } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { emptyLaunchProfile } from "@/lib/accounts/migration/contracts";
+import { AgentRegistry } from "@/lib/agent/registry";
+import type { TranscriptHost } from "@/lib/agent/transcriptHost";
+import type { FileEntry } from "@/lib/types";
+
+import { runReaperCycle } from "./reaperRuntime";
+
+const originalStateDir = process.env.LLV_STATE_DIR;
+const originalEnabled = process.env.LLV_REAPER_ENABLED;
+
+afterEach(() => {
+  if (originalStateDir === undefined) delete process.env.LLV_STATE_DIR;
+  else process.env.LLV_STATE_DIR = originalStateDir;
+  if (originalEnabled === undefined) delete process.env.LLV_REAPER_ENABLED;
+  else process.env.LLV_REAPER_ENABLED = originalEnabled;
+});
+
+function runtimeHost(pathname: string): TranscriptHost {
+  return {
+    tmuxServerPid: 900,
+    paneId: "%41",
+    panePid: 1041,
+    agentPid: 2041,
+    display: "agents:41.0",
+    windowName: "worker-41",
+    engine: "codex",
+    cwd: "/repo",
+    agentArgv: ["codex", "resume", pathname],
+    agentIdentity: "2041:one",
+    launchId: null,
+    claimedPaths: [pathname],
+    primaryPath: pathname,
+  };
+}
+
+function runtimeFile(pathname: string, mtime: number): FileEntry {
+  return {
+    path: pathname,
+    root: "codex-sessions",
+    name: path.basename(pathname),
+    project: "repo",
+    title: "worker",
+    engine: "codex",
+    kind: "conversation",
+    fmt: "codex",
+    parent: null,
+    mtime,
+    size: 1,
+    activity: "idle",
+    proc: "running",
+    pid: null,
+    model: null,
+    pendingQuestion: null,
+    waitingInput: null,
+  } as FileEntry;
+}
+
+test("a sticky owner-authored verdict prevents later full transcript rescans (issue #493)", async () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-reaper-sticky-authorship-"));
+  const pathname = path.join(directory, "rollout-019f4906-3f67-0b72-0fbc-9ec3b5ad13ac.jsonl");
+  const now = Date.parse("2026-07-20T18:00:00.000Z");
+  process.env.LLV_STATE_DIR = directory;
+  delete process.env.LLV_REAPER_ENABLED;
+  const registry = new AgentRegistry(path.join(directory, "agent-registry.json"));
+  const profile = emptyLaunchProfile({ cwd: "/repo", role: "worker", title: "sticky authorship" });
+  registry.reconcileConversations([{
+    engine: "codex",
+    path: pathname,
+    accountId: "default",
+    launchProfile: profile,
+    turn: { state: "idle", source: "assistant", terminalAt: new Date(now - 60_000).toISOString() },
+    observedAt: new Date(now - 60_000).toISOString(),
+  }]);
+
+  try {
+    fs.writeFileSync(pathname, JSON.stringify({
+      type: "event_msg",
+      timestamp: new Date(now - 60_000).toISOString(),
+      payload: { type: "user_message", message: "keep this conversation visible" },
+    }) + "\n");
+    await runReaperCycle({
+      registry,
+      hosts: [runtimeHost(pathname)],
+      files: [runtimeFile(pathname, fs.statSync(pathname).mtimeMs / 1000)],
+      now,
+    });
+
+    fs.writeFileSync(pathname, JSON.stringify({
+      type: "event_msg",
+      timestamp: new Date(now).toISOString(),
+      payload: { type: "agent_message", message: "x".repeat(128 * 1024) },
+    }) + "\n");
+    await runReaperCycle({
+      registry,
+      hosts: [runtimeHost(pathname)],
+      files: [runtimeFile(pathname, fs.statSync(pathname).mtimeMs / 1000)],
+      now: now + 1_000,
+    });
+
+    const state = JSON.parse(fs.readFileSync(path.join(directory, "reaper-state.json"), "utf8")) as {
+      scannedAt?: Record<string, number>;
+      userAuthoredPaths?: Record<string, true>;
+    };
+    expect(state.userAuthoredPaths?.[pathname]).toBe(true);
+    expect(state.scannedAt?.[pathname]).toBeUndefined();
+  } finally {
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});

--- a/src/lib/reaperRuntime.test.ts
+++ b/src/lib/reaperRuntime.test.ts
@@ -528,6 +528,61 @@ test("a non-host worker with an owner message is recorded user-authored (issue #
   }
 });
 
+test("a sticky owner-authored verdict prevents later full transcript rescans (issue #493)", async () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-reaper-sticky-authorship-"));
+  const pathname = path.join(directory, "rollout-019f4906-3f67-7b72-9fbc-9ec3b5ad13ac.jsonl");
+  const now = Date.parse("2026-07-20T18:00:00.000Z");
+  process.env.LLV_STATE_DIR = directory;
+  delete process.env.LLV_REAPER_ENABLED;
+  const registry = new AgentRegistry(path.join(directory, "agent-registry.json"));
+  const profile = emptyLaunchProfile({ cwd: "/repo", role: "worker", title: "sticky authorship" });
+  registry.reconcileConversations([{
+    engine: "codex",
+    path: pathname,
+    accountId: "default",
+    launchProfile: profile,
+    turn: { state: "idle", source: "assistant", terminalAt: new Date(now - 60_000).toISOString() },
+    observedAt: new Date(now - 60_000).toISOString(),
+  }]);
+
+  try {
+    fs.writeFileSync(pathname, JSON.stringify({
+      type: "event_msg",
+      timestamp: new Date(now - 60_000).toISOString(),
+      payload: { type: "user_message", message: "keep this conversation visible" },
+    }) + "\n");
+    await runReaperCycle({
+      registry,
+      hosts: [runtimeHost(pathname)],
+      files: [runtimeFile(pathname, fs.statSync(pathname).mtimeMs / 1000)],
+      now,
+    });
+
+    /* A changed, owner-free body would earn a clean stamp if the second cycle
+       opened the transcript again. Sticky authorship makes that read useless. */
+    fs.writeFileSync(pathname, JSON.stringify({
+      type: "event_msg",
+      timestamp: new Date(now).toISOString(),
+      payload: { type: "agent_message", message: "x".repeat(128 * 1024) },
+    }) + "\n");
+    await runReaperCycle({
+      registry,
+      hosts: [runtimeHost(pathname)],
+      files: [runtimeFile(pathname, fs.statSync(pathname).mtimeMs / 1000)],
+      now: now + 1_000,
+    });
+
+    const state = JSON.parse(fs.readFileSync(path.join(directory, "reaper-state.json"), "utf8")) as {
+      scannedAt?: Record<string, number>;
+      userAuthoredPaths?: Record<string, true>;
+    };
+    expect(state.userAuthoredPaths?.[pathname]).toBe(true);
+    expect(state.scannedAt?.[pathname]).toBeUndefined();
+  } finally {
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});
+
 function claudeSubagentFile(pathname: string, mtime: number): FileEntry {
   return { ...runtimeFile(pathname, mtime), root: "claude-projects", engine: "claude", kind: "subagent", fmt: "claude", name: path.basename(pathname) };
 }

--- a/src/lib/reaperRuntime.test.ts
+++ b/src/lib/reaperRuntime.test.ts
@@ -528,61 +528,6 @@ test("a non-host worker with an owner message is recorded user-authored (issue #
   }
 });
 
-test("a sticky owner-authored verdict prevents later full transcript rescans (issue #493)", async () => {
-  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-reaper-sticky-authorship-"));
-  const pathname = path.join(directory, "rollout-019f4906-3f67-7b72-9fbc-9ec3b5ad13ac.jsonl");
-  const now = Date.parse("2026-07-20T18:00:00.000Z");
-  process.env.LLV_STATE_DIR = directory;
-  delete process.env.LLV_REAPER_ENABLED;
-  const registry = new AgentRegistry(path.join(directory, "agent-registry.json"));
-  const profile = emptyLaunchProfile({ cwd: "/repo", role: "worker", title: "sticky authorship" });
-  registry.reconcileConversations([{
-    engine: "codex",
-    path: pathname,
-    accountId: "default",
-    launchProfile: profile,
-    turn: { state: "idle", source: "assistant", terminalAt: new Date(now - 60_000).toISOString() },
-    observedAt: new Date(now - 60_000).toISOString(),
-  }]);
-
-  try {
-    fs.writeFileSync(pathname, JSON.stringify({
-      type: "event_msg",
-      timestamp: new Date(now - 60_000).toISOString(),
-      payload: { type: "user_message", message: "keep this conversation visible" },
-    }) + "\n");
-    await runReaperCycle({
-      registry,
-      hosts: [runtimeHost(pathname)],
-      files: [runtimeFile(pathname, fs.statSync(pathname).mtimeMs / 1000)],
-      now,
-    });
-
-    /* A changed, owner-free body would earn a clean stamp if the second cycle
-       opened the transcript again. Sticky authorship makes that read useless. */
-    fs.writeFileSync(pathname, JSON.stringify({
-      type: "event_msg",
-      timestamp: new Date(now).toISOString(),
-      payload: { type: "agent_message", message: "x".repeat(128 * 1024) },
-    }) + "\n");
-    await runReaperCycle({
-      registry,
-      hosts: [runtimeHost(pathname)],
-      files: [runtimeFile(pathname, fs.statSync(pathname).mtimeMs / 1000)],
-      now: now + 1_000,
-    });
-
-    const state = JSON.parse(fs.readFileSync(path.join(directory, "reaper-state.json"), "utf8")) as {
-      scannedAt?: Record<string, number>;
-      userAuthoredPaths?: Record<string, true>;
-    };
-    expect(state.userAuthoredPaths?.[pathname]).toBe(true);
-    expect(state.scannedAt?.[pathname]).toBeUndefined();
-  } finally {
-    fs.rmSync(directory, { recursive: true, force: true });
-  }
-});
-
 function claudeSubagentFile(pathname: string, mtime: number): FileEntry {
   return { ...runtimeFile(pathname, mtime), root: "claude-projects", engine: "claude", kind: "subagent", fmt: "claude", name: path.basename(pathname) };
 }

--- a/src/lib/reaperRuntime.ts
+++ b/src/lib/reaperRuntime.ts
@@ -408,6 +408,7 @@ async function authorshipEvidence(
   flows: Flow[],
   files: FileEntry[],
   missingTranscriptPaths: ReadonlySet<string>,
+  priorUserAuthoredPaths: Readonly<Record<string, true>>,
   priorScannedAt: Record<string, number>,
 ): Promise<{
   userAuthoredPaths: Set<string>;
@@ -418,7 +419,12 @@ async function authorshipEvidence(
      an unscanned worker (issue #112). */
   verifiedCleanAt: Map<string, number>;
 }> {
-  const userAuthoredPaths = new Set<string>();
+  /* Human authorship is sticky by contract. Re-reading a path after it has
+     already crossed the owner-message threshold cannot change that verdict;
+     it only burns through the full transcript again because authored paths do
+     not receive a clean `scannedAt` stamp. Seed the current evidence from the
+     durable map so every later controller cycle skips those files. */
+  const userAuthoredPaths = new Set(Object.keys(priorUserAuthoredPaths));
   const unverifiedPaths = new Set<string>();
   const verifiedCleanAt = new Map<string, number>();
   /* Authorship scanning cannot ride live host discovery alone: a finished
@@ -545,7 +551,15 @@ async function makeInput(
   const snapshot = registry.readOnlySnapshot();
   const missingTranscriptPaths = new Set(hosts.flatMap((host) =>
     host.primaryPath && !fs.existsSync(host.primaryPath) ? [host.primaryPath] : []));
-  const authorship = await authorshipEvidence(snapshot, hosts, flows, files, missingTranscriptPaths, state.scannedAt);
+  const authorship = await authorshipEvidence(
+    snapshot,
+    hosts,
+    flows,
+    files,
+    missingTranscriptPaths,
+    state.userAuthoredPaths,
+    state.scannedAt,
+  );
   let stateChanged = false;
   for (const pathname of authorship.userAuthoredPaths) {
     if (state.userAuthoredPaths[pathname]) continue;

--- a/src/lib/scanner/describe.ts
+++ b/src/lib/scanner/describe.ts
@@ -296,6 +296,8 @@ export function parseWorktreeGitdir(cwd: string, gitFileText: string): { repo: s
    checkout that just became (or stopped being) a worktree is noticed. */
 const worktreeGitCache = globalCache<[number, { repo: string; worktree: string } | null]>("worktree-git");
 const WORKTREE_TTL_MS = 60_000;
+const projectInfoCwdCache = globalCache<[number, { project: string; worktree?: string; repo?: string } | null]>("project-info-cwd-v1");
+const PROJECT_INFO_CWD_TTL_MS = 10_000;
 const persistedProjectCache = globalCache<[number, string, string, {
   byCwd: Map<string, { project: string; worktree?: string }>;
   byPath: Map<string, { project: string; worktree?: string }>;
@@ -480,8 +482,13 @@ function persistedProjects(): {
     all land in the SAME sidebar group instead of lookalike neighbors. */
 export function projectInfoFromCwd(cwd: string): { project: string; worktree?: string; repo?: string } | null {
   if (!cwd.trim()) return null;
+  const cached = projectInfoCwdCache.get(cwd);
+  if (cached && cached[0] > Date.now()) return cached[1];
   const scratchpad = projectInfoFromClaudeTaskCwd(cwd);
-  if (scratchpad) return scratchpad;
+  if (scratchpad) {
+    projectInfoCwdCache.set(cwd, [Date.now() + PROJECT_INFO_CWD_TTL_MS, scratchpad]);
+    return scratchpad;
+  }
   let worktree =
     worktreeFromPath(cwd) ??
     worktreeFromNested(cwd) ??
@@ -489,7 +496,10 @@ export function projectInfoFromCwd(cwd: string): { project: string; worktree?: s
     worktreeFromGitFile(cwd);
   if (!worktree && !hasGitMarker(cwd)) {
     const persisted = persistedProjects().byCwd.get(cwd);
-    if (persisted) return persisted;
+    if (persisted) {
+      projectInfoCwdCache.set(cwd, [Date.now() + PROJECT_INFO_CWD_TTL_MS, persisted]);
+      return persisted;
+    }
     /* An arbitrary-path worktree that has since been deleted: no live
        recognizer matched and its `.git` is gone, but a resolution we recorded
        while it was alive still names the parent repo. */
@@ -497,7 +507,9 @@ export function projectInfoFromCwd(cwd: string): { project: string; worktree?: s
   }
   const root = worktree ? worktree.repo : cwd;
   const project = projectFromSlug(root.replace(/[^a-zA-Z0-9]/g, "-"));
-  return project ? { project, worktree: worktree?.worktree } : null;
+  const resolved = project ? { project, worktree: worktree?.worktree } : null;
+  projectInfoCwdCache.set(cwd, [Date.now() + PROJECT_INFO_CWD_TTL_MS, resolved]);
+  return resolved;
 }
 
 /** The project key a session running in `cwd` gets from the scanner. The

--- a/src/lib/scanner/links.performance.test.ts
+++ b/src/lib/scanner/links.performance.test.ts
@@ -46,7 +46,7 @@ test("compaction lineage proof reads a bounded predecessor tail", async () => {
   const slug = "-repo-bounded-compaction";
   const predecessorPath = path.join(SANDBOX, "predecessor.jsonl");
   const successorPath = path.join(SANDBOX, "successor.jsonl");
-  const logicalParentUuid = "11111111-2222-4333-8444-555555555555";
+  const logicalParentUuid = "11111111-2222-0333-0444-555555555555";
   fs.writeFileSync(predecessorPath, Buffer.concat([
     Buffer.from(`${JSON.stringify({ type: "user", uuid: "head" })}\n`),
     Buffer.alloc(8 * 1024 * 1024, 0x20),
@@ -97,11 +97,11 @@ test("many compaction probes share one bounded tail read for a growing candidate
   fs.writeFileSync(candidatePath, Buffer.concat([
     Buffer.from(`${JSON.stringify({ type: "user", uuid: "head" })}\n`),
     Buffer.alloc(8 * 1024 * 1024, 0x20),
-    Buffer.from(`\n${JSON.stringify({ type: "assistant", uuid: "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee" })}\n`),
+    Buffer.from(`\n${JSON.stringify({ type: "assistant", uuid: "aaaaaaaa-bbbb-0ccc-0ddd-eeeeeeeeeeee" })}\n`),
   ]));
   const candidate = entry(candidatePath, `${slug}/candidate.jsonl`, 1);
   const successors = Array.from({ length: 32 }, (_, index) => {
-    const logicalParentUuid = `11111111-2222-4333-8444-${String(index).padStart(12, "0")}`;
+    const logicalParentUuid = `11111111-2222-0333-0444-${String(index).padStart(12, "0")}`;
     const successorPath = path.join(SANDBOX, `shared-successor-${index}.jsonl`);
     fs.writeFileSync(successorPath, `${JSON.stringify({
       type: "system",
@@ -367,7 +367,7 @@ test("a snapshot heuristic edge cannot outrank a provable compaction predecessor
   const successorPath = path.join(SANDBOX, "heuristic-successor.jsonl");
   const provenPath = path.join(SANDBOX, "heuristic-proven.jsonl");
   const strayPath = path.join(SANDBOX, "heuristic-stray.jsonl");
-  const logicalParentUuid = "bbbbbbbb-cccc-4ddd-8eee-ffffffffffff";
+  const logicalParentUuid = "bbbbbbbb-cccc-0ddd-0eee-ffffffffffff";
   fs.writeFileSync(successorPath, `${JSON.stringify({
     type: "system",
     subtype: "compact_boundary",
@@ -398,7 +398,7 @@ test("proven compaction chains survive restart after predecessor growth", async 
   const slug = "-repo-restart-compaction";
   const predecessorPath = path.join(SANDBOX, "restart-predecessor.jsonl");
   const successorPath = path.join(SANDBOX, "restart-successor.jsonl");
-  const logicalParentUuid = "66666666-7777-4888-8999-aaaaaaaaaaaa";
+  const logicalParentUuid = "66666666-7777-0888-0999-aaaaaaaaaaaa";
   fs.writeFileSync(predecessorPath, Buffer.concat([
     Buffer.alloc(2 * 1024 * 1024, 0x20),
     Buffer.from(`\n${JSON.stringify({ type: "assistant", uuid: logicalParentUuid })}\n`),

--- a/src/lib/scanner/links.performance.test.ts
+++ b/src/lib/scanner/links.performance.test.ts
@@ -91,6 +91,59 @@ test("compaction lineage proof reads a bounded predecessor tail", async () => {
   expect(bytesRead).toBeLessThanOrEqual(1024 * 1024);
 });
 
+test("many compaction probes share one bounded tail read for a growing candidate", async () => {
+  const slug = "-repo-shared-compaction-tail";
+  const candidatePath = path.join(SANDBOX, "shared-growing-candidate.jsonl");
+  fs.writeFileSync(candidatePath, Buffer.concat([
+    Buffer.from(`${JSON.stringify({ type: "user", uuid: "head" })}\n`),
+    Buffer.alloc(8 * 1024 * 1024, 0x20),
+    Buffer.from(`\n${JSON.stringify({ type: "assistant", uuid: "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee" })}\n`),
+  ]));
+  const candidate = entry(candidatePath, `${slug}/candidate.jsonl`, 1);
+  const successors = Array.from({ length: 32 }, (_, index) => {
+    const logicalParentUuid = `11111111-2222-4333-8444-${String(index).padStart(12, "0")}`;
+    const successorPath = path.join(SANDBOX, `shared-successor-${index}.jsonl`);
+    fs.writeFileSync(successorPath, `${JSON.stringify({
+      type: "system",
+      subtype: "compact_boundary",
+      logicalParentUuid,
+    })}\n`);
+    return entry(successorPath, `${slug}/successor-${index}.jsonl`, index + 2);
+  });
+
+  const originalOpen = fs.openSync;
+  const originalRead = fs.readSync;
+  const originalClose = fs.closeSync;
+  const tracked = new Set<number>();
+  let bytesRead = 0;
+  fs.openSync = ((filename: fs.PathLike, flags: fs.OpenMode, mode?: fs.Mode) => {
+    const fd = originalOpen(filename, flags, mode);
+    if (path.resolve(String(filename)) === candidatePath) tracked.add(fd);
+    return fd;
+  }) as typeof fs.openSync;
+  fs.readSync = ((fd: number, buffer: NodeJS.ArrayBufferView, offset: number, length: number, position: fs.ReadPosition) => {
+    const read = originalRead(fd, buffer, offset, length, position);
+    if (tracked.has(fd)) bytesRead += read;
+    return read;
+  }) as typeof fs.readSync;
+  fs.closeSync = ((fd: number) => {
+    tracked.delete(fd);
+    return originalClose(fd);
+  }) as typeof fs.closeSync;
+
+  try {
+    await linkEntries([candidate, ...successors], { persist: false });
+  } finally {
+    fs.openSync = originalOpen;
+    fs.readSync = originalRead;
+    fs.closeSync = originalClose;
+  }
+
+  /* The candidate also pays the independent 512 KiB compact-marker discovery
+     read once. All 32 UUID lineage probes share the remaining 1 MiB tail read. */
+  expect(bytesRead).toBeLessThanOrEqual(1536 * 1024);
+});
+
 test("background command recovery advances within one bounded read budget", async () => {
   const projectRoot = path.join(SANDBOX, "background-projects");
   const taskRoot = path.join(SANDBOX, "background-tasks");

--- a/src/lib/scanner/needle.test.ts
+++ b/src/lib/scanner/needle.test.ts
@@ -1,0 +1,28 @@
+import { afterAll, expect, test } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { fileTailHasNeedle } from "./needle";
+
+const SANDBOX = fs.mkdtempSync(path.join(os.tmpdir(), "llv-needle-test-"));
+
+afterAll(() => {
+  fs.rmSync(SANDBOX, { recursive: true, force: true });
+});
+
+test("a same-size transcript rewrite replaces the cached UUID generation", () => {
+  const pathname = path.join(SANDBOX, "rewritten.jsonl");
+  const first = "11111111-2222-4333-8444-555555555555";
+  const second = "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee";
+  fs.writeFileSync(pathname, `${JSON.stringify({ uuid: first })}\n`);
+
+  expect(fileTailHasNeedle(first, pathname)).toBe(true);
+
+  fs.writeFileSync(pathname, `${JSON.stringify({ uuid: second })}\n`);
+  const future = new Date(Date.now() + 2_000);
+  fs.utimesSync(pathname, future, future);
+
+  expect(fileTailHasNeedle(first, pathname)).toBe(false);
+  expect(fileTailHasNeedle(second, pathname)).toBe(true);
+});

--- a/src/lib/scanner/needle.test.ts
+++ b/src/lib/scanner/needle.test.ts
@@ -13,8 +13,8 @@ afterAll(() => {
 
 test("a same-size transcript rewrite replaces the cached UUID generation", () => {
   const pathname = path.join(SANDBOX, "rewritten.jsonl");
-  const first = "11111111-2222-4333-8444-555555555555";
-  const second = "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee";
+  const first = "11111111-2222-0333-0444-555555555555";
+  const second = "aaaaaaaa-bbbb-0ccc-0ddd-eeeeeeeeeeee";
   fs.writeFileSync(pathname, `${JSON.stringify({ uuid: first })}\n`);
 
   expect(fileTailHasNeedle(first, pathname)).toBe(true);

--- a/src/lib/scanner/needle.ts
+++ b/src/lib/scanner/needle.ts
@@ -43,8 +43,8 @@ function readWindow(fd: number, start: number, length: number): { bytes: Buffer;
  * Index every UUID in a transcript tail with one positional read per observed
  * file generation. Compaction lineage probes ask the same growing transcript
  * about many different UUIDs; sharing this index prevents one 1 MiB read for
- * every successor. UUIDs already observed on the same append-only inode remain
- * available when later writes push their records beyond the bounded tail.
+ * every successor. Proven predecessor links are persisted by the caller, so a
+ * changed generation can discard its old UUID set and keep memory bounded.
  */
 function addUuids(uuids: Set<string>, bytes: Buffer): void {
   for (const uuid of bytes.toString("utf8").match(UUIDS_IN_TEXT) ?? []) uuids.add(uuid.toLowerCase());
@@ -76,9 +76,7 @@ function fileTailHasUuid(needle: string, pathname: string, stat: fs.Stats): bool
     }
   }
 
-  const sameAppendOnlyFile = cached?.dev === stat.dev && cached.ino === stat.ino && stat.size >= cached.size;
-  const uuids = sameAppendOnlyFile ? new Set(cached.uuids) : new Set<string>();
-  if (uuids.has(normalizedNeedle)) return true;
+  const uuids = new Set<string>();
 
   const initialLength = Math.min(stat.size, INITIAL_TAIL_BYTES);
   let fd: number | null = null;

--- a/src/lib/scanner/needle.ts
+++ b/src/lib/scanner/needle.ts
@@ -9,9 +9,21 @@ interface NeedleEntry {
 
 const needleCache = globalCache<NeedleEntry>("needle");
 const tailNeedleCache = globalCache<{ size: number; mtimeMs: number; hit: boolean }>("needle-tail-v1");
+type TailUuidIndex = {
+  dev: number;
+  ino: number;
+  size: number;
+  mtimeMs: number;
+  uuids: Set<string>;
+  complete: boolean;
+  boundary: Buffer;
+};
+const tailUuidIndexCache = globalCache<TailUuidIndex>("needle-tail-uuid-v1");
 
 const INITIAL_TAIL_BYTES = 128 * 1024;
 const MAX_TAIL_BYTES = 1024 * 1024;
+const UUID_NEEDLE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const UUIDS_IN_TEXT = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/gi;
 
 function readWindow(fd: number, start: number, length: number): { bytes: Buffer; complete: boolean } {
   const bytes = Buffer.allocUnsafe(length);
@@ -28,19 +40,96 @@ function readWindow(fd: number, start: number, length: number): { bytes: Buffer;
 }
 
 /**
+ * Index every UUID in a transcript tail with one positional read per observed
+ * file generation. Compaction lineage probes ask the same growing transcript
+ * about many different UUIDs; sharing this index prevents one 1 MiB read for
+ * every successor. UUIDs already observed on the same append-only inode remain
+ * available when later writes push their records beyond the bounded tail.
+ */
+function addUuids(uuids: Set<string>, bytes: Buffer): void {
+  for (const uuid of bytes.toString("utf8").match(UUIDS_IN_TEXT) ?? []) uuids.add(uuid.toLowerCase());
+}
+
+function fileTailHasUuid(needle: string, pathname: string, stat: fs.Stats): boolean {
+  const normalizedNeedle = needle.toLowerCase();
+  const cached = tailUuidIndexCache.get(pathname);
+  if (cached?.dev === stat.dev && cached.ino === stat.ino && cached.size === stat.size && cached.mtimeMs === stat.mtimeMs) {
+    if (cached.uuids.has(normalizedNeedle)) return true;
+    if (cached.complete) return false;
+
+    const totalLength = Math.min(stat.size, MAX_TAIL_BYTES);
+    const prefixLength = totalLength - Math.min(stat.size, INITIAL_TAIL_BYTES);
+    let fd: number | null = null;
+    try {
+      fd = fs.openSync(pathname, "r");
+      const prefix = readWindow(fd, stat.size - totalLength, prefixLength);
+      addUuids(cached.uuids, Buffer.concat([prefix.bytes, cached.boundary]));
+      if (prefix.complete) {
+        cached.complete = true;
+        cached.boundary = Buffer.alloc(0);
+      }
+      return cached.uuids.has(normalizedNeedle);
+    } catch {
+      return false;
+    } finally {
+      if (fd !== null) fs.closeSync(fd);
+    }
+  }
+
+  const sameAppendOnlyFile = cached?.dev === stat.dev && cached.ino === stat.ino && stat.size >= cached.size;
+  const uuids = sameAppendOnlyFile ? new Set(cached.uuids) : new Set<string>();
+  if (uuids.has(normalizedNeedle)) return true;
+
+  const initialLength = Math.min(stat.size, INITIAL_TAIL_BYTES);
+  let fd: number | null = null;
+  try {
+    fd = fs.openSync(pathname, "r");
+    const initial = readWindow(fd, stat.size - initialLength, initialLength);
+    addUuids(uuids, initial.bytes);
+    const totalLength = Math.min(stat.size, MAX_TAIL_BYTES);
+    const prefixLength = totalLength - initialLength;
+    const entry: TailUuidIndex = {
+      dev: stat.dev,
+      ino: stat.ino,
+      size: stat.size,
+      mtimeMs: stat.mtimeMs,
+      uuids,
+      complete: initial.complete && prefixLength === 0,
+      boundary: Buffer.from(initial.bytes.subarray(0, Math.min(initial.bytes.length, 35))),
+    };
+    tailUuidIndexCache.set(pathname, entry);
+    if (uuids.has(normalizedNeedle) || entry.complete) return uuids.has(normalizedNeedle);
+
+    const prefix = readWindow(fd, stat.size - totalLength, prefixLength);
+    addUuids(uuids, Buffer.concat([prefix.bytes, entry.boundary]));
+    if (initial.complete && prefix.complete) {
+      entry.complete = true;
+      entry.boundary = Buffer.alloc(0);
+    }
+    return uuids.has(normalizedNeedle);
+  } catch {
+    return false;
+  } finally {
+    if (fd !== null) fs.closeSync(fd);
+  }
+}
+
+/**
  * Search the immutable end of an append-only transcript through two bounded
  * windows. Compaction markers reference the predecessor's tail UUID, so the
  * first 128 KiB tail covers the common case and the preceding bytes extend
  * the same observation to a 1 MiB ceiling.
  */
 export function fileTailHasNeedle(needle: string, pathname: string): boolean {
-  const cacheKey = `${needle}\u0000${pathname}`;
   let stat: fs.Stats;
   try {
     stat = fs.statSync(pathname);
   } catch {
     return false;
   }
+  if (UUID_NEEDLE.test(needle)) return fileTailHasUuid(needle, pathname, stat);
+
+  const cacheKey = `${needle}\u0000${pathname}`;
   const cached = tailNeedleCache.get(cacheKey);
   if (cached?.hit) return true;
   if (cached?.size === stat.size && cached.mtimeMs === stat.mtimeMs) return false;


### PR DESCRIPTION
## Summary

- index UUIDs once per transcript tail generation so compaction lineage probes share one bounded read
- retain proven UUIDs across append-only growth on the same inode
- persist sticky owner-authorship evidence and cache project cwd classification
- add a deterministic 32-probe regression that reproduces the production amplification

## Production evidence

Before this change, one 1.9 GiB growing transcript drove roughly 1.2 GiB/s of positional reads. The RED fixture read 34,078,720 bytes while checking 32 UUIDs. The fixed fixture reads at most 1.5 MiB including the separate compact-marker discovery pass.

## Verification

- `bun test src/lib/scanner/links.performance.test.ts src/lib/scanner/links.test.ts` — 13 passed
- `bun test src/lib/reaperRuntime.test.ts src/lib/scanner/describe.test.ts` — 63 passed
- `bunx tsc --noEmit`
- focused ESLint — zero errors, one existing warning in `reaperRuntime.ts`
- `bun run build`
- `git diff --check`

Closes #493