### PR TITLE
feat(feed): collapse interactive stdin polling into a compact readable row (#497)

### DIFF
--- a/scripts/readable-tool-shots.tsx
+++ b/scripts/readable-tool-shots.tsx
@@ -46,11 +46,11 @@ const gitStatus = toolEvent({ ...execSuccess, ts, id: "g1", cwd: "/workspace/app
 const npmDev = toolEvent({ id: "e2", tool: "exec_command", ts, summary: "npm run dev", command: "npm run dev", cwd: "/workspace/app", outputPreview: "starting dev server on :3000" });
 const wait = toolEvent({ id: "w2", tool: "wait", ts, summary: "wait · 8479", statusLabel: "waiting 10s", session: "8479", poll: true, durationMs: 10_000, outputPreview: "compiled successfully" });
 // A run of empty polls (issue #497): each is a bare poll with no output; the
-// group must coalesce them into one compact counted row, not five dead cards.
+// group must coalesce them into one compact counted row.
 const polls = Array.from({ length: 5 }, (_, i) =>
   toolEvent({ id: `s${i}`, tool: "write_stdin", ts, summary: "stdin → 8479 · poll", statusLabel: "waiting 5s", session: "8479", poll: true, durationMs: 5_000, outputPreview: "" }),
 );
-// A keystroke write_stdin is never collapsed — it keeps its readable row.
+// A keystroke write_stdin keeps its readable row.
 const keystroke = toolEvent({ id: "k2", tool: "write_stdin", ts, summary: "stdin → 8479 · y⏎", session: "8479", outputPreview: "accepted" });
 const bunTest = toolEvent({
   id: "e3", tool: "exec_command", ts, summary: "bun test", command: "bun test ./src/components/feed", cwd: "/workspace/app",

--- a/scripts/readable-tool-shots.tsx
+++ b/scripts/readable-tool-shots.tsx
@@ -44,8 +44,14 @@ function group(calls: ToolEvent[], hasErr: boolean, active = false): CmdGroupIte
 const ts = "2100-01-02T12:00:00Z";
 const gitStatus = toolEvent({ ...execSuccess, ts, id: "g1", cwd: "/workspace/app", endTs: "2100-01-02T12:00:00.240Z" });
 const npmDev = toolEvent({ id: "e2", tool: "exec_command", ts, summary: "npm run dev", command: "npm run dev", cwd: "/workspace/app", outputPreview: "starting dev server on :3000" });
-const wait = toolEvent({ id: "w2", tool: "wait", ts, summary: "wait · 8479", statusLabel: "waiting 10s", durationMs: 10_000, outputPreview: "compiled successfully" });
-const poll = toolEvent({ id: "s2", tool: "write_stdin", ts, summary: "stdin → 8479 · poll", statusLabel: "waiting 5s", durationMs: 5_000, outputPreview: "" });
+const wait = toolEvent({ id: "w2", tool: "wait", ts, summary: "wait · 8479", statusLabel: "waiting 10s", session: "8479", poll: true, durationMs: 10_000, outputPreview: "compiled successfully" });
+// A run of empty polls (issue #497): each is a bare poll with no output; the
+// group must coalesce them into one compact counted row, not five dead cards.
+const polls = Array.from({ length: 5 }, (_, i) =>
+  toolEvent({ id: `s${i}`, tool: "write_stdin", ts, summary: "stdin → 8479 · poll", statusLabel: "waiting 5s", session: "8479", poll: true, durationMs: 5_000, outputPreview: "" }),
+);
+// A keystroke write_stdin is never collapsed — it keeps its readable row.
+const keystroke = toolEvent({ id: "k2", tool: "write_stdin", ts, summary: "stdin → 8479 · y⏎", session: "8479", outputPreview: "accepted" });
 const bunTest = toolEvent({
   id: "e3", tool: "exec_command", ts, summary: "bun test", command: "bun test ./src/components/feed", cwd: "/workspace/app",
   status: "err", statusLabel: "exit 1", exitCode: 1, durationMs: 1830, endTs: "2100-01-02T12:00:01.830Z", open: true,
@@ -53,8 +59,8 @@ const bunTest = toolEvent({
   stderr: "error: expected true to be false\n  at feed.test.ts:88", stderrTruncated: false,
 });
 
-const okCalls = [gitStatus, npmDev, wait, poll, toolEvent({ id: "r1", tool: "Read", family: "read", icon: "file", ts, summary: "Read config.ts" })];
-const errCalls = [gitStatus, npmDev, wait, poll, bunTest];
+const okCalls = [gitStatus, npmDev, wait, ...polls, keystroke, toolEvent({ id: "r1", tool: "Read", family: "read", icon: "file", ts, summary: "Read config.ts" })];
+const errCalls = [gitStatus, npmDev, wait, ...polls, keystroke, bunTest];
 
 function page(): string {
   const collapsed = renderToStaticMarkup(<CmdGroupCard item={group(okCalls, false)} />);

--- a/src/components/feed/__fixtures__/readableTools.ts
+++ b/src/components/feed/__fixtures__/readableTools.ts
@@ -118,22 +118,45 @@ export const nestedParent = toolEvent({
   summary: "npm run dev",
   command: "npm run dev",
   cwd: "/workspace/app",
+  session: "8479",
   outputPreview: "starting dev server",
 });
+/** A wait that surfaced real output: a poll, but never collapsed — its captured
+    line stays readable in its own follow-up row (issue #497). */
 export const nestedWait = toolEvent({
   id: "wait-1",
   tool: "wait",
   summary: "wait · 8479",
   statusLabel: "waiting 10s",
+  session: "8479",
+  poll: true,
   outputPreview: "compiled successfully",
 });
+/** A bare empty poll: no keystrokes, no output — the row that collapses. */
 export const nestedPoll = toolEvent({
   id: "poll-1",
   tool: "write_stdin",
   summary: "stdin → 8479 · poll",
   statusLabel: "waiting 5s",
+  session: "8479",
+  poll: true,
+  durationMs: 5000,
   outputPreview: "",
 });
+/** A write_stdin carrying real keystrokes: never a poll, keeps its session. */
+export const nestedKeystroke = toolEvent({
+  id: "keys-1",
+  tool: "write_stdin",
+  summary: "stdin → 8479 · y⏎",
+  session: "8479",
+  outputPreview: "",
+});
+
+/** An empty poll builder for a collapsing run: each carries the shared session
+    and a wall-time, but no output — the row the group must coalesce (#497). */
+export function emptyPoll(id: string, over: Partial<ToolEvent> = {}): ToolEvent {
+  return toolEvent({ id, tool: "wait", summary: "wait · 8479", session: "8479", poll: true, durationMs: 5000, outputPreview: "", statusLabel: "waiting 5s", ...over });
+}
 
 /** A cmd-group carrying the nested exec/wait/poll run plus a standalone read. */
 export function nestedGroup(over: Partial<CmdGroupItem> = {}): CmdGroupItem {
@@ -146,6 +169,35 @@ export function nestedGroup(over: Partial<CmdGroupItem> = {}): CmdGroupItem {
     t1: "2026-07-10T10:00:20Z",
     byTool: { exec_command: 1, wait: 1, write_stdin: 1, Read: 1 },
     okCount: 4,
+    errCount: 0,
+    hasErr: false,
+    active: false,
+    ...over,
+  };
+}
+
+/** A poll-dominated interactive run (issue #497 production evidence): one exec
+    parent trailed by six empty polls that must coalesce into one compact counted
+    row, with a keystroke write_stdin still readable at the tail. */
+export function pollHeavyGroup(over: Partial<CmdGroupItem> = {}): CmdGroupItem {
+  const calls = [
+    nestedParent,
+    emptyPoll("p1"),
+    emptyPoll("p2"),
+    emptyPoll("p3"),
+    emptyPoll("p4"),
+    emptyPoll("p5"),
+    emptyPoll("p6"),
+    nestedKeystroke,
+  ];
+  return {
+    kind: "cmd-group",
+    ids: calls.map((c) => c.id),
+    calls,
+    t0: calls[0].ts,
+    t1: "2026-07-10T10:00:40Z",
+    byTool: { exec_command: 1, wait: 6, write_stdin: 1 },
+    okCount: 8,
     errCount: 0,
     hasErr: false,
     active: false,

--- a/src/components/feed/__fixtures__/readableTools.ts
+++ b/src/components/feed/__fixtures__/readableTools.ts
@@ -121,8 +121,8 @@ export const nestedParent = toolEvent({
   session: "8479",
   outputPreview: "starting dev server",
 });
-/** A wait that surfaced real output: a poll, but never collapsed — its captured
-    line stays readable in its own follow-up row (issue #497). */
+/** A wait that surfaced real output keeps its captured line readable in a
+    dedicated follow-up row (issue #497). */
 export const nestedWait = toolEvent({
   id: "wait-1",
   tool: "wait",
@@ -143,7 +143,7 @@ export const nestedPoll = toolEvent({
   durationMs: 5000,
   outputPreview: "",
 });
-/** A write_stdin carrying real keystrokes: never a poll, keeps its session. */
+/** A write_stdin carrying real keystrokes keeps its session and readable row. */
 export const nestedKeystroke = toolEvent({
   id: "keys-1",
   tool: "write_stdin",
@@ -152,8 +152,8 @@ export const nestedKeystroke = toolEvent({
   outputPreview: "",
 });
 
-/** An empty poll builder for a collapsing run: each carries the shared session
-    and a wall-time, but no output — the row the group must coalesce (#497). */
+/** An empty poll builder for a collapsing run: each carries the shared session,
+    a wall-time, and an empty output captured by the coalesced row (#497). */
 export function emptyPoll(id: string, over: Partial<ToolEvent> = {}): ToolEvent {
   return toolEvent({ id, tool: "wait", summary: "wait · 8479", session: "8479", poll: true, durationMs: 5000, outputPreview: "", statusLabel: "waiting 5s", ...over });
 }

--- a/src/components/feed/cards/CmdGroupCard.tsx
+++ b/src/components/feed/cards/CmdGroupCard.tsx
@@ -5,9 +5,9 @@ import { useState } from "react";
 import { ChevronRight } from "../../icons";
 import { hhmm } from "../../utils";
 import { tr, type CmdGroupItem } from "../parse";
-import { groupNestedCalls } from "../toolBlocks";
+import { coalesceFollowUps, groupNestedCalls } from "../toolBlocks";
 import { StatusIcon } from "./shared";
-import { ToolBlockRow } from "./ToolCard";
+import { PollRow, ToolBlockRow } from "./ToolCard";
 
 /* A run of ≥2 consecutive tool events folded into one quiet ToolLine header
    (design doc §3.4): `▸ N дій · Tool ×a · Tool ×b · t0–t1`.
@@ -98,18 +98,28 @@ export function CmdGroupCard({ item }: { item: CmdGroupItem }) {
           tool_use), so the id alone is not a unique key. */}
       {open ? (
         <ol className="mb-1 mt-1 space-y-0.5">
-          {blocks.map((block, bi) => (
-            <li key={`${block.parent.id}:${bi}`} className="min-w-0">
-              <ToolBlockRow event={block.parent} index={bi + 1} />
-              {block.children.length ? (
-                <div className="ml-4 border-l border-border pl-2">
-                  {block.children.map((child, ci) => (
-                    <ToolBlockRow key={`${child.id}:${ci}`} event={child} nested />
-                  ))}
-                </div>
-              ) : null}
-            </li>
-          ))}
+          {blocks.map((block, bi) => {
+            /* Consecutive empty polls coalesce into one compact counted row; a
+               keystroke write_stdin or an output-bearing wait stays a full
+               readable follow-up (issue #497). */
+            const children = coalesceFollowUps(block.children);
+            return (
+              <li key={`${block.parent.id}:${bi}`} className="min-w-0">
+                <ToolBlockRow event={block.parent} index={bi + 1} />
+                {children.length ? (
+                  <div className="ml-4 border-l border-border pl-2">
+                    {children.map((child, ci) =>
+                      child.kind === "polls" ? (
+                        <PollRow key={`poll:${ci}`} events={child.events} session={child.session} elapsedMs={child.elapsedMs} />
+                      ) : (
+                        <ToolBlockRow key={`${child.event.id}:${ci}`} event={child.event} nested />
+                      ),
+                    )}
+                  </div>
+                ) : null}
+              </li>
+            );
+          })}
         </ol>
       ) : null}
     </details>

--- a/src/components/feed/cards/ToolCard.tsx
+++ b/src/components/feed/cards/ToolCard.tsx
@@ -9,7 +9,7 @@ import { hhmm } from "../../utils";
 import { CopyButton } from "../CopyButton";
 import { tr, type ToolEvent } from "../parse";
 import type { ArgChip } from "../tools";
-import { formatDuration } from "../toolBlocks";
+import { formatDuration, isFollowUpCall } from "../toolBlocks";
 import { useRawLine } from "../rawLine";
 import { DiffCard } from "./DiffCard";
 import { OrchestrationCard } from "./OrchestrationCard";
@@ -142,7 +142,12 @@ function RawRecord({ event }: { event: ToolEvent }) {
    collapsed transcript keeps its DOM small (issue #9 §7/§8). */
 export function ToolBody({ event }: { event: ToolEvent }) {
   const hasDiff = event.body?.type === "diff";
-  const showOutput = !hasDiff || Boolean(event.outputPreview.trim());
+  /* An interactive follow-up (wait/write_stdin) that captured nothing carries no
+     output, source, or raw record worth a card: hide those empty fields so it
+     never shows an apology chip or a dead raw-record toggle (issue #497). A
+     follow-up that surfaced output, or failed, keeps its full readable body. */
+  const emptyFollowUp = isFollowUpCall(event) && !event.outputPreview.trim() && event.stderr === undefined && event.status !== "err";
+  const showOutput = !emptyFollowUp && (!hasDiff || Boolean(event.outputPreview.trim()));
   return (
     <div className="mb-1 mt-1 rounded-surface bg-sunken px-3 py-2.5">
       <ToolChips chips={event.chips} />
@@ -169,7 +174,24 @@ export function ToolBody({ event }: { event: ToolEvent }) {
           emptyLabel={tr("tools.noStderr")}
         />
       ) : null}
-      <RawRecord event={event} />
+      {emptyFollowUp ? null : <RawRecord event={event} />}
+    </div>
+  );
+}
+
+/** A coalesced run of consecutive empty interactive polls, rendered as one quiet
+    counted row instead of N signal-free cards (issue #497). It keeps the shared
+    session identity and the summed elapsed wall-time, so an operator still reads
+    "how long the command was polled" without scrolling past every tick. */
+export function PollRow({ events, session, elapsedMs }: { events: ToolEvent[]; session?: string; elapsedMs?: number }) {
+  const count = events.length;
+  const elapsed = typeof elapsedMs === "number" && elapsedMs > 0 ? formatDuration(elapsedMs) : "";
+  const detail = [tr("tools.pollRun", { count }), session ? `→ ${session}` : "", elapsed].filter(Boolean).join(" · ");
+  return (
+    <div className="flex items-center gap-2 rounded-control py-0.5 text-ui text-muted/80">
+      <span className="shrink-0 select-none text-muted" aria-hidden>↳</span>
+      <GlyphIcon name="clock" className="h-3.5 w-3.5 shrink-0" />
+      <span className="min-w-0 flex-1 truncate tabular-nums text-caption">{detail}</span>
     </div>
   );
 }

--- a/src/components/feed/cards/ToolCard.tsx
+++ b/src/components/feed/cards/ToolCard.tsx
@@ -142,10 +142,10 @@ function RawRecord({ event }: { event: ToolEvent }) {
    collapsed transcript keeps its DOM small (issue #9 §7/§8). */
 export function ToolBody({ event }: { event: ToolEvent }) {
   const hasDiff = event.body?.type === "diff";
-  /* An interactive follow-up (wait/write_stdin) that captured nothing carries no
-     output, source, or raw record worth a card: hide those empty fields so it
-     never shows an apology chip or a dead raw-record toggle (issue #497). A
-     follow-up that surfaced output, or failed, keeps its full readable body. */
+  /* An interactive follow-up (wait/write_stdin) with an empty result carries no
+     useful output, source, or raw record. Hiding those fields removes the
+     apology chip and dead raw-record toggle (issue #497). Output and failures
+     keep their full readable body. */
   const emptyFollowUp = isFollowUpCall(event) && !event.outputPreview.trim() && event.stderr === undefined && event.status !== "err";
   const showOutput = !emptyFollowUp && (!hasDiff || Boolean(event.outputPreview.trim()));
   return (
@@ -179,8 +179,8 @@ export function ToolBody({ event }: { event: ToolEvent }) {
   );
 }
 
-/** A coalesced run of consecutive empty interactive polls, rendered as one quiet
-    counted row instead of N signal-free cards (issue #497). It keeps the shared
+/** A coalesced run of consecutive empty interactive polls rendered as one quiet
+    counted row (issue #497). It keeps the shared
     session identity and the summed elapsed wall-time, so an operator still reads
     "how long the command was polled" without scrolling past every tick. */
 export function PollRow({ events, session, elapsedMs }: { events: ToolEvent[]; session?: string; elapsedMs?: number }) {

--- a/src/components/feed/cards/readableTool.dom.test.tsx
+++ b/src/components/feed/cards/readableTool.dom.test.tsx
@@ -134,7 +134,7 @@ test("a cmd-group nests wait/stdin follow-ups under an ordered exec block", () =
   // The output-bearing wait keeps its own readable follow-up row.
   const firstBlock = list!.querySelector("li")!;
   expect(firstBlock.textContent).toContain("wait");
-  // The empty poll collapses to the compact counted row, not a full stdin card.
+  // The empty poll collapses to the compact counted row.
   expect(firstBlock.textContent).toContain(en("tools.pollRun", { count: 1 }));
 });
 
@@ -146,7 +146,7 @@ test("a poll-dominated run collapses its empty polls into one counted row", () =
   expect(firstBlock.textContent).toContain(en("tools.pollRun", { count: 6 }));
   // ...carries the shared session identity...
   expect(firstBlock.textContent).toContain("8479");
-  // ...and the summed elapsed wall-time (6 × 5s = 30s), not 6 separate cards.
+  // The row shows the summed elapsed wall-time (6 × 5s = 30s).
   expect(firstBlock.textContent).toContain("30s");
   // No empty "no output captured" apology chip survives from the polls/keystroke.
   expect(host.textContent).not.toContain(en("tools.noOutput"));
@@ -154,7 +154,7 @@ test("a poll-dominated run collapses its empty polls into one counted row", () =
   // keystroke contribute none (pre-#497 they each mounted their own).
   const rawToggles = [...host.querySelectorAll("button")].filter((b) => (b.textContent ?? "") === en("tools.rawRecord"));
   expect(rawToggles).toHaveLength(1);
-  // The trailing keystroke write_stdin is never collapsed — it stays readable.
+  // The trailing keystroke write_stdin stays readable.
   expect(host.textContent).toContain("y⏎");
 });
 

--- a/src/components/feed/cards/readableTool.dom.test.tsx
+++ b/src/components/feed/cards/readableTool.dom.test.tsx
@@ -11,13 +11,17 @@ import {
   largeStdout,
   longCommand,
   nestedGroup,
+  pollHeavyGroup,
   toolEvent,
   truncatedOutput,
   unknownFallback,
   withStderr,
 } from "../__fixtures__/readableTools";
+import { translate } from "@/lib/i18n";
 import { CmdGroupCard } from "./CmdGroupCard";
 import { ToolCard } from "./ToolCard";
+
+const en = (key: Parameters<typeof translate>[1], params?: Parameters<typeof translate>[2]) => translate("en", key, params);
 
 const dom = new Window();
 Object.assign(globalThis, {
@@ -127,10 +131,31 @@ test("a cmd-group nests wait/stdin follow-ups under an ordered exec block", () =
   expect(list!.querySelectorAll(":scope > li").length).toBe(2);
   // The ordinal marker renders for the first block.
   expect(host.textContent).toContain("1.");
-  // The nested follow-ups sit inside the first block, not as their own rows.
+  // The output-bearing wait keeps its own readable follow-up row.
   const firstBlock = list!.querySelector("li")!;
   expect(firstBlock.textContent).toContain("wait");
-  expect(firstBlock.textContent).toContain("stdin");
+  // The empty poll collapses to the compact counted row, not a full stdin card.
+  expect(firstBlock.textContent).toContain(en("tools.pollRun", { count: 1 }));
+});
+
+test("a poll-dominated run collapses its empty polls into one counted row", () => {
+  const host = mount(<CmdGroupCard item={pollHeavyGroup()} />);
+  open(host.querySelector("details")!);
+  const firstBlock = host.querySelector("ol > li")!;
+  // Six empty polls fold into a single compact row that states the count...
+  expect(firstBlock.textContent).toContain(en("tools.pollRun", { count: 6 }));
+  // ...carries the shared session identity...
+  expect(firstBlock.textContent).toContain("8479");
+  // ...and the summed elapsed wall-time (6 × 5s = 30s), not 6 separate cards.
+  expect(firstBlock.textContent).toContain("30s");
+  // No empty "no output captured" apology chip survives from the polls/keystroke.
+  expect(host.textContent).not.toContain(en("tools.noOutput"));
+  // Only the parent exec keeps a raw-record toggle; the 6 polls and the empty
+  // keystroke contribute none (pre-#497 they each mounted their own).
+  const rawToggles = [...host.querySelectorAll("button")].filter((b) => (b.textContent ?? "") === en("tools.rawRecord"));
+  expect(rawToggles).toHaveLength(1);
+  // The trailing keystroke write_stdin is never collapsed — it stays readable.
+  expect(host.textContent).toContain("y⏎");
 });
 
 test("reduced motion: animated chrome opts out under prefers-reduced-motion", () => {

--- a/src/components/feed/cards/toolLifecycle.dom.test.tsx
+++ b/src/components/feed/cards/toolLifecycle.dom.test.tsx
@@ -5,8 +5,12 @@ import { renderToStaticMarkup } from "react-dom/server";
 import { flushSync } from "react-dom";
 import { createRoot, type Root } from "react-dom/client";
 
+import { translate } from "@/lib/i18n";
+
 import { activeGroup, activeFailureGroup, settledGroup, nestedGroup } from "../__fixtures__/readableTools";
 import { CmdGroupCard } from "./CmdGroupCard";
+
+const en = (key: Parameters<typeof translate>[1], params?: Parameters<typeof translate>[2]) => translate("en", key, params);
 
 const dom = new Window();
 Object.assign(globalThis, {
@@ -150,8 +154,10 @@ test("nested wait/stdin follow-ups stay owned by their exec inside the live aggr
   // Two top-level blocks; the follow-ups render inside the first, inline.
   expect(list.querySelectorAll(":scope > li").length).toBe(2);
   const firstBlock = list.querySelector("li")!;
+  // The output-bearing wait keeps its readable row; the empty poll collapses to
+  // the compact counted row rather than a full stdin card (issue #497).
   expect(firstBlock.textContent).toContain("wait");
-  expect(firstBlock.textContent).toContain("stdin");
+  expect(firstBlock.textContent).toContain(en("tools.pollRun", { count: 1 }));
   // Still no nested disclosure: the aggregate details is the only one.
   expect(h.querySelectorAll("details").length).toBe(1);
 });

--- a/src/components/feed/parse.test.ts
+++ b/src/components/feed/parse.test.ts
@@ -948,7 +948,7 @@ describe("Codex functions.exec orchestration", () => {
     expect(JSON.stringify(event)).not.toContain("SECRETLEAK99");
   });
 
-  test("unwraps metadata-passthrough exec calls and preserves nested stdin poll details", () => {
+  test("normalizes a concrete metadata-wrapped stdin poll into its interactive event", () => {
     const lines = [
       JSON.stringify({
         type: "response_item",
@@ -977,12 +977,32 @@ describe("Codex functions.exec orchestration", () => {
 
     const event = buildFeed(codexFile, lines, false, "").items.find((item) => item.kind === "tool");
     if (event?.kind !== "tool") throw new Error("expected metadata-wrapped exec tool");
-    expect(event.orchestration?.calls).toHaveLength(2);
-    expect(event.orchestration?.calls[0]?.tool).toBe("write_stdin");
-    expect(event.orchestration?.calls[0]?.summary).toContain("73");
-    expect(event.orchestration?.calls[0]?.summary.toLowerCase()).toContain("poll");
+    expect(event.tool).toBe("write_stdin");
+    expect(event.session).toBe("73");
+    expect(event.poll).toBe(true);
+    expect(event.orchestration).toBeUndefined();
+    expect(event.summary).toContain("73");
+    expect(event.summary.toLowerCase()).toContain("poll");
     expect(event.outputPreview).toContain("process is still running");
     expect(event.outputPreview).not.toContain("Script completed");
+  });
+
+  test("metadata-wrapped empty polls group under the exec session that owns them", () => {
+    const lines = [
+      orch('const r = await tools.exec_command({cmd:"docker ps"}); text(r.output);', "exec", "t1"),
+      orchOutput("exec", "Script running with session ID 27292\nWall time 1.0 seconds\nOutput:\nfaststream_app"),
+      orch('const r = await tools.write_stdin({session_id:27292, chars:""}); text(r.output);', "poll-1", "t2"),
+      orchOutput("poll-1", "Script running with cell ID 27292\nWall time 5.0 seconds\nOutput:\n"),
+      orch('const r = await tools.write_stdin({session_id:27292, chars:""}); text(r.output);', "poll-2", "t3"),
+      orchOutput("poll-2", "Script running with cell ID 27292\nWall time 5.0 seconds\nOutput:\n"),
+    ];
+    const item = buildFeed(codexFile, lines, false, "").items[0];
+    if (item?.kind !== "cmd-group") throw new Error("expected grouped interactive run");
+    const blocks = groupNestedCalls(item.calls);
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0].parent.session).toBe("27292");
+    expect(blocks[0].children.map((event) => event.tool)).toEqual(["write_stdin", "write_stdin"]);
+    expect(blocks[0].children.every((event) => event.poll === true && event.orchestration === undefined)).toBe(true);
   });
 
   test("keeps runtime stdin argument expressions visible in nested summaries", () => {

--- a/src/components/feed/parse.ts
+++ b/src/components/feed/parse.ts
@@ -104,6 +104,11 @@ export type ToolEvent = {
       its args. Lets the readable group fold each follow-up under the exec that
       actually owns its session, even when several sessions interleave (#475). */
   session?: string;
+  /** A bare interactive poll: a `wait`, or a `write_stdin` that sent no
+      keystrokes. Empty consecutive polls collapse into one compact counted row
+      so a long-running command's tail does not dominate the feed (#497). A
+      `write_stdin` carrying real characters is a keystroke, never a poll. */
+  poll?: boolean;
   open: boolean;
   orchestration?: Orchestration;
   /** Present on a `ScheduleWakeup` call: drives the dedicated wakeup card. */
@@ -1200,6 +1205,9 @@ export function createFeedSession(cfg: FeedSessionConfig): FeedSession {
     const body: ToolBody | undefined = diff && diff.files.length ? { type: "diff", files: diff.files, filesTruncated: diff.filesTruncated } : undefined;
     const command = opts.command !== undefined ? redactSecrets(opts.command).slice(0, COMMAND_MAX) : undefined;
     const summary = opts.summary !== undefined ? redactSecrets(opts.summary).replace(/\s+/g, " ").trim().slice(0, 160) : s.summary;
+    /* A bare poll carries no keystrokes: every `wait`, and a `write_stdin` whose
+       `chars` payload is the deliberately empty string (issue #497 / #141). */
+    const poll = opts.tool === "wait" || (opts.tool === "write_stdin" && !(typeof args.chars === "string" && args.chars.length > 0));
     return {
       kind: "tool",
       id: opts.id,
@@ -1222,6 +1230,7 @@ export function createFeedSession(cfg: FeedSessionConfig): FeedSession {
         const session = sessionFromArgs(args);
         return { ...(cwd ? { cwd } : {}), ...(session !== undefined ? { session } : {}) };
       })() : {}),
+      ...(poll ? { poll: true } : {}),
       /* An edit/write card opens its structured diff inline by default — a
          compact preview of the first lines, with a toggle for the rest — so the
          change is visible without a click (issue #90). */

--- a/src/components/feed/parse.ts
+++ b/src/components/feed/parse.ts
@@ -106,8 +106,8 @@ export type ToolEvent = {
   session?: string;
   /** A bare interactive poll: a `wait`, or a `write_stdin` that sent no
       keystrokes. Empty consecutive polls collapse into one compact counted row
-      so a long-running command's tail does not dominate the feed (#497). A
-      `write_stdin` carrying real characters is a keystroke, never a poll. */
+      and keep a long-running command's tail concise (#497). A `write_stdin`
+      carrying real characters remains a readable keystroke. */
   poll?: boolean;
   open: boolean;
   orchestration?: Orchestration;
@@ -705,6 +705,22 @@ function objFieldScalar(argsSrc: string, keys: readonly string[]): string | numb
   return undefined;
 }
 
+/* Whether an object field is encoded as a concrete literal in generated tool
+   source. Interactive wrappers need this distinction because identifier values
+   such as `chars` can only be interpreted by the runtime. */
+function objFieldIsConcreteScalar(argsSrc: string, keys: readonly string[]): boolean {
+  for (const key of keys) {
+    const re = new RegExp(`(?:^|[{,([\\s])${key}\\s*:\\s*`);
+    const match = re.exec(argsSrc);
+    if (!match) continue;
+    const start = (match.index ?? 0) + match[0].length;
+    const ch = argsSrc[start];
+    if (ch === '"' || ch === "'" || ch === "`") return true;
+    return /^(?:-?\d+(?:\.\d+)?|true\b|false\b)/.test(argsSrc.slice(start));
+  }
+  return false;
+}
+
 /* The first string/template literal in an argument source. */
 function firstLiteral(argsSrc: string): string {
   for (let i = 0; i < argsSrc.length; i += 1) {
@@ -866,9 +882,15 @@ function batchCommands(fullInput: string): string[] {
  * the full source and raw record expose the ground truth at level 2. Returns
  * null for a plain custom tool, which keeps rendering as one generic row.
  */
-function parseOrchestration(input: string): { overlay: Partial<ToolEvent>; body?: Orchestration; diff?: DiffModel } | null {
+function parseOrchestration(input: string): {
+  overlay: Partial<ToolEvent>;
+  body?: Orchestration;
+  diff?: DiffModel;
+  directInteractive?: { tool: "wait" | "write_stdin"; args: Record<string, unknown> };
+} | null {
   if (!input || !/\btools\.[A-Za-z_]\w*\s*\(/.test(input)) return null;
   const calls: NestedCall[] = [];
+  let concreteInteractive: { tool: "wait" | "write_stdin"; args: Record<string, unknown> } | undefined;
   ORCH_CALL_RE.lastIndex = 0;
   let match: RegExpExecArray | null;
   while ((match = ORCH_CALL_RE.exec(input)) && calls.length < ORCH_MAX_CALLS) {
@@ -876,8 +898,14 @@ function parseOrchestration(input: string): { overlay: Partial<ToolEvent>; body?
     const open = match.index + match[0].length - 1; // the '(' at the end of the match
     const argsSrc = sliceCallArgs(input, open);
     const tool = ORCH_METHOD_TOOL[method] ?? method;
-    const s = summarizeTool(tool, orchCallArgs(tool, argsSrc, input), "codex");
+    const args = orchCallArgs(tool, argsSrc, input);
+    const s = summarizeTool(tool, args, "codex");
     calls.push({ id: `${method}#${calls.length}`, tool: method, family: s.family, icon: s.icon, summary: s.summary });
+    if (tool === "wait" || tool === "write_stdin") {
+      const concreteSession = objFieldIsConcreteScalar(argsSrc, ["session_id", "cell_id"]);
+      const concreteInput = tool === "wait" || objFieldIsConcreteScalar(argsSrc, ["chars"]);
+      if (concreteSession && concreteInput) concreteInteractive = { tool, args };
+    }
   }
   ORCH_HELPER_RE.lastIndex = 0;
   while ((match = ORCH_HELPER_RE.exec(input)) && calls.length < ORCH_MAX_CALLS) {
@@ -889,6 +917,13 @@ function parseOrchestration(input: string): { overlay: Partial<ToolEvent>; body?
   if (!toolCalls.length) return null;
   const source = redactSecrets(input).slice(0, COMMAND_MAX);
   const sourceTruncated = input.length > COMMAND_MAX;
+
+  /* A one-operation generated wrapper represents the concrete wait/stdin call
+     directly. The normalized event inherits session ownership, polling intent,
+     result output, and compact follow-up grouping. */
+  if (toolCalls.length === 1 && concreteInteractive) {
+    return { overlay: {}, directInteractive: concreteInteractive };
+  }
 
   /* An apply_patch payload embedded in the JS source parses into the same diff
      model a first-class apply_patch gets, so the card renders the structured
@@ -1225,7 +1260,7 @@ export function createFeedSession(cfg: FeedSessionConfig): FeedSession {
       statusLabel: tr("render.executing"),
       outputPreview: "",
       outputTruncated: false,
-      ...(family === "shell" ? (() => {
+      ...(s.family === "shell" ? (() => {
         const cwd = cwdOf(args, command);
         const session = sessionFromArgs(args);
         return { ...(cwd ? { cwd } : {}), ...(session !== undefined ? { session } : {}) };
@@ -1321,7 +1356,8 @@ export function createFeedSession(cfg: FeedSessionConfig): FeedSession {
   const emitCustomTool = (ts: unknown, name: string, input: string, callId?: string): ToolEvent => {
     const id = callId || "plain-" + pushSeq + "-" + String(ts ?? "");
     const orch = parseOrchestration(input);
-    const base = newToolEvent({ ts, id, tool: name, args: { input }, engine: "codex", diff: orch?.diff });
+    const direct = orch?.directInteractive;
+    const base = newToolEvent({ ts, id, tool: direct?.tool ?? name, args: direct?.args ?? { input }, engine: "codex", diff: orch?.diff });
     const event = orch ? { ...base, ...orch.overlay, ...(orch.body ? { orchestration: orch.body } : {}) } : base;
     registerCall(event);
     return event;

--- a/src/components/feed/readableTool.parse.test.ts
+++ b/src/components/feed/readableTool.parse.test.ts
@@ -91,3 +91,28 @@ test("a wait/write_stdin run nests as follow-ups of the exec that owns them", ()
   // Each nested call preserves its own individual state.
   expect(blocks[0].children.every((c) => c.status === "ok")).toBe(true);
 });
+
+test("the parser marks bare polls but not keystroke write_stdin", () => {
+  const line = (payload: Record<string, unknown>, ts: string) => JSON.stringify({ type: "response_item", timestamp: ts, payload });
+  const lines = [
+    line({ type: "function_call", call_id: "e1", name: "exec_command", arguments: JSON.stringify({ cmd: "npm run dev", workdir: "/w" }) }, "2026-07-10T10:00:00Z"),
+    line({ type: "function_call_output", call_id: "e1", output: "Script running with session ID 8479\nWall time 1.0 seconds\nOutput:\nbooting" }, "2026-07-10T10:00:01Z"),
+    // A wait is always a bare poll.
+    line({ type: "function_call", call_id: "w1", name: "wait", arguments: JSON.stringify({ cell_id: "8479", yield_time_ms: 10000 }) }, "2026-07-10T10:00:02Z"),
+    line({ type: "function_call_output", call_id: "w1", output: "Script running with cell ID 8479\nWall time 10.0 seconds\nOutput:\n" }, "2026-07-10T10:00:12Z"),
+    // An empty write_stdin is a poll; a keystroke write_stdin is not.
+    line({ type: "function_call", call_id: "s1", name: "write_stdin", arguments: JSON.stringify({ session_id: 8479, chars: "" }) }, "2026-07-10T10:00:13Z"),
+    line({ type: "function_call_output", call_id: "s1", output: "Script running with cell ID 8479\nWall time 5.0 seconds\nOutput:\n" }, "2026-07-10T10:00:18Z"),
+    line({ type: "function_call", call_id: "k1", name: "write_stdin", arguments: JSON.stringify({ session_id: 8479, chars: "y\n" }) }, "2026-07-10T10:00:19Z"),
+    line({ type: "function_call_output", call_id: "k1", output: "Script running with cell ID 8479\nWall time 0.2 seconds\nOutput:\naccepted" }, "2026-07-10T10:00:20Z"),
+  ];
+  const group = buildFeed(codexFile, lines, false, "").items.find((item): item is CmdGroupItem => item.kind === "cmd-group");
+  if (!group) throw new Error("expected a cmd-group");
+  const byId = new Map(group.calls.map((c) => [c.id, c]));
+  expect(byId.get("e1")?.poll).toBeUndefined(); // the exec parent is not a poll
+  expect(byId.get("w1")?.poll).toBe(true);
+  expect(byId.get("s1")?.poll).toBe(true);
+  // Keystrokes are retained as a readable, non-poll write; the session survives.
+  expect(byId.get("k1")?.poll).not.toBe(true);
+  expect(byId.get("k1")?.session).toBe("8479");
+});

--- a/src/components/feed/readableTool.parse.test.ts
+++ b/src/components/feed/readableTool.parse.test.ts
@@ -92,7 +92,7 @@ test("a wait/write_stdin run nests as follow-ups of the exec that owns them", ()
   expect(blocks[0].children.every((c) => c.status === "ok")).toBe(true);
 });
 
-test("the parser marks bare polls but not keystroke write_stdin", () => {
+test("the parser distinguishes bare polls from keystroke write_stdin", () => {
   const line = (payload: Record<string, unknown>, ts: string) => JSON.stringify({ type: "response_item", timestamp: ts, payload });
   const lines = [
     line({ type: "function_call", call_id: "e1", name: "exec_command", arguments: JSON.stringify({ cmd: "npm run dev", workdir: "/w" }) }, "2026-07-10T10:00:00Z"),
@@ -100,7 +100,7 @@ test("the parser marks bare polls but not keystroke write_stdin", () => {
     // A wait is always a bare poll.
     line({ type: "function_call", call_id: "w1", name: "wait", arguments: JSON.stringify({ cell_id: "8479", yield_time_ms: 10000 }) }, "2026-07-10T10:00:02Z"),
     line({ type: "function_call_output", call_id: "w1", output: "Script running with cell ID 8479\nWall time 10.0 seconds\nOutput:\n" }, "2026-07-10T10:00:12Z"),
-    // An empty write_stdin is a poll; a keystroke write_stdin is not.
+    // An empty write_stdin is a poll; a keystroke keeps its input semantics.
     line({ type: "function_call", call_id: "s1", name: "write_stdin", arguments: JSON.stringify({ session_id: 8479, chars: "" }) }, "2026-07-10T10:00:13Z"),
     line({ type: "function_call_output", call_id: "s1", output: "Script running with cell ID 8479\nWall time 5.0 seconds\nOutput:\n" }, "2026-07-10T10:00:18Z"),
     line({ type: "function_call", call_id: "k1", name: "write_stdin", arguments: JSON.stringify({ session_id: 8479, chars: "y\n" }) }, "2026-07-10T10:00:19Z"),
@@ -109,7 +109,7 @@ test("the parser marks bare polls but not keystroke write_stdin", () => {
   const group = buildFeed(codexFile, lines, false, "").items.find((item): item is CmdGroupItem => item.kind === "cmd-group");
   if (!group) throw new Error("expected a cmd-group");
   const byId = new Map(group.calls.map((c) => [c.id, c]));
-  expect(byId.get("e1")?.poll).toBeUndefined(); // the exec parent is not a poll
+  expect(byId.get("e1")?.poll).toBeUndefined(); // the exec parent owns the session
   expect(byId.get("w1")?.poll).toBe(true);
   expect(byId.get("s1")?.poll).toBe(true);
   // Keystrokes are retained as a readable, non-poll write; the session survives.

--- a/src/components/feed/toolBlocks.test.ts
+++ b/src/components/feed/toolBlocks.test.ts
@@ -1,7 +1,7 @@
 import { expect, test } from "bun:test";
 
-import { toolEvent } from "./__fixtures__/readableTools";
-import { formatDuration, groupNestedCalls, isFollowUpCall } from "./toolBlocks";
+import { emptyPoll, toolEvent } from "./__fixtures__/readableTools";
+import { coalesceFollowUps, formatDuration, groupNestedCalls, isCollapsiblePoll, isFollowUpCall } from "./toolBlocks";
 
 test("wait and write_stdin are follow-ups; a plain exec is not", () => {
   expect(isFollowUpCall(toolEvent({ tool: "wait" }))).toBe(true);
@@ -59,6 +59,56 @@ test("a follow-up whose session matches no exec stays standalone", () => {
   expect(blocks.map((b) => b.parent.id)).toEqual(["eA", "wOrphan"]);
   expect(blocks[0].children.map((c) => c.id)).toEqual(["wA"]);
   expect(blocks[1].children).toHaveLength(0);
+});
+
+test("only a bare empty poll is collapsible — keystrokes, output, and errors are not", () => {
+  // A wait/empty write_stdin with no captured output collapses.
+  expect(isCollapsiblePoll(emptyPoll("p1"))).toBe(true);
+  expect(isCollapsiblePoll(toolEvent({ tool: "write_stdin", poll: true, outputPreview: "" }))).toBe(true);
+  // A poll that surfaced output stays a full readable row.
+  expect(isCollapsiblePoll(emptyPoll("p2", { outputPreview: "ready" }))).toBe(false);
+  // A keystroke write_stdin is never a poll.
+  expect(isCollapsiblePoll(toolEvent({ tool: "write_stdin", poll: false, outputPreview: "" }))).toBe(false);
+  // A failed poll keeps its own row so the failure is never hidden.
+  expect(isCollapsiblePoll(emptyPoll("p3", { status: "err", statusLabel: "exit 1" }))).toBe(false);
+  // A poll that carries a stderr stream is not collapsed.
+  expect(isCollapsiblePoll(emptyPoll("p4", { stderr: "boom" }))).toBe(false);
+  // A plain exec is never a poll.
+  expect(isCollapsiblePoll(toolEvent({ tool: "Bash" }))).toBe(false);
+});
+
+test("consecutive empty polls coalesce into one counted run with summed elapsed", () => {
+  const children = [emptyPoll("p1"), emptyPoll("p2"), emptyPoll("p3")];
+  const out = coalesceFollowUps(children);
+  expect(out).toHaveLength(1);
+  expect(out[0].kind).toBe("polls");
+  if (out[0].kind !== "polls") throw new Error("expected a polls run");
+  expect(out[0].events).toHaveLength(3);
+  expect(out[0].session).toBe("8479");
+  // Each fixture poll carries a 5s wall-time; the run sums them.
+  expect(out[0].elapsedMs).toBe(15000);
+});
+
+test("keystrokes and output-bearing waits break the poll run and stay their own rows", () => {
+  const children = [
+    emptyPoll("p1"),
+    emptyPoll("p2"),
+    toolEvent({ id: "k1", tool: "write_stdin", poll: false, summary: "stdin → 8479 · y⏎" }),
+    emptyPoll("p3"),
+    emptyPoll("p4", { outputPreview: "ready" }),
+    emptyPoll("p5"),
+  ];
+  const out = coalesceFollowUps(children);
+  // run(p1,p2) · call(k1) · run(p3) · call(p4 with output) · run(p5)
+  expect(out.map((c) => c.kind)).toEqual(["polls", "call", "polls", "call", "polls"]);
+  if (out[0].kind !== "polls") throw new Error("expected a polls run");
+  expect(out[0].events.map((e) => e.id)).toEqual(["p1", "p2"]);
+});
+
+test("a single empty poll still collapses — a run of one, so its empty body never renders", () => {
+  const out = coalesceFollowUps([emptyPoll("solo")]);
+  expect(out).toHaveLength(1);
+  expect(out[0].kind).toBe("polls");
 });
 
 test("formatDuration scales from ms to seconds to minutes", () => {

--- a/src/components/feed/toolBlocks.test.ts
+++ b/src/components/feed/toolBlocks.test.ts
@@ -61,19 +61,19 @@ test("a follow-up whose session matches no exec stays standalone", () => {
   expect(blocks[1].children).toHaveLength(0);
 });
 
-test("only a bare empty poll is collapsible — keystrokes, output, and errors are not", () => {
+test("bare empty polls collapse while keystrokes, output, and errors keep rows", () => {
   // A wait/empty write_stdin with no captured output collapses.
   expect(isCollapsiblePoll(emptyPoll("p1"))).toBe(true);
   expect(isCollapsiblePoll(toolEvent({ tool: "write_stdin", poll: true, outputPreview: "" }))).toBe(true);
   // A poll that surfaced output stays a full readable row.
   expect(isCollapsiblePoll(emptyPoll("p2", { outputPreview: "ready" }))).toBe(false);
-  // A keystroke write_stdin is never a poll.
+  // A keystroke write_stdin keeps its readable input row.
   expect(isCollapsiblePoll(toolEvent({ tool: "write_stdin", poll: false, outputPreview: "" }))).toBe(false);
-  // A failed poll keeps its own row so the failure is never hidden.
+  // A failed poll keeps its own visible row.
   expect(isCollapsiblePoll(emptyPoll("p3", { status: "err", statusLabel: "exit 1" }))).toBe(false);
-  // A poll that carries a stderr stream is not collapsed.
+  // A poll carrying stderr keeps its readable row.
   expect(isCollapsiblePoll(emptyPoll("p4", { stderr: "boom" }))).toBe(false);
-  // A plain exec is never a poll.
+  // A plain exec owns its regular command row.
   expect(isCollapsiblePoll(toolEvent({ tool: "Bash" }))).toBe(false);
 });
 
@@ -105,7 +105,7 @@ test("keystrokes and output-bearing waits break the poll run and stay their own 
   expect(out[0].events.map((e) => e.id)).toEqual(["p1", "p2"]);
 });
 
-test("a single empty poll still collapses — a run of one, so its empty body never renders", () => {
+test("a single empty poll collapses and omits its empty body", () => {
   const out = coalesceFollowUps([emptyPoll("solo")]);
   expect(out).toHaveLength(1);
   expect(out[0].kind).toBe("polls");

--- a/src/components/feed/toolBlocks.ts
+++ b/src/components/feed/toolBlocks.ts
@@ -57,10 +57,9 @@ export function groupNestedCalls(calls: readonly ToolEvent[]): ToolBlock[] {
   return blocks;
 }
 
-/* A poll worth collapsing (issue #497): a bare `wait`/empty `write_stdin` that
-   captured nothing worth a full card — no output, no stderr, and not an error.
-   A poll that surfaced output (e.g. a `wait` that returned "ready") or failed
-   keeps its own readable row so nothing meaningful is ever hidden. */
+/* A poll worth collapsing (issue #497): a bare `wait`/empty `write_stdin` with
+   empty output, empty stderr, and a successful status. Output and failures keep
+   their own readable rows. */
 export function isCollapsiblePoll(event: ToolEvent): boolean {
   return event.poll === true && event.status !== "err" && !event.outputPreview.trim() && event.stderr === undefined;
 }
@@ -77,8 +76,7 @@ export type ToolChild =
  * collapsible polls coalesce into one `polls` run that carries the shared
  * session and the summed elapsed wall-time, while a keystroke `write_stdin` or a
  * poll that captured output stays its own readable `call` (issue #497). A single
- * empty poll still collapses — a run of one — so its empty output/raw-record
- * fields never render.
+ * empty poll also forms a run of one and omits empty output/raw-record fields.
  */
 export function coalesceFollowUps(children: readonly ToolEvent[]): ToolChild[] {
   const out: ToolChild[] = [];

--- a/src/components/feed/toolBlocks.ts
+++ b/src/components/feed/toolBlocks.ts
@@ -57,6 +57,49 @@ export function groupNestedCalls(calls: readonly ToolEvent[]): ToolBlock[] {
   return blocks;
 }
 
+/* A poll worth collapsing (issue #497): a bare `wait`/empty `write_stdin` that
+   captured nothing worth a full card — no output, no stderr, and not an error.
+   A poll that surfaced output (e.g. a `wait` that returned "ready") or failed
+   keeps its own readable row so nothing meaningful is ever hidden. */
+export function isCollapsiblePoll(event: ToolEvent): boolean {
+  return event.poll === true && event.status !== "err" && !event.outputPreview.trim() && event.stderr === undefined;
+}
+
+/** One rendered child under an exec block: either a full follow-up call row, or
+    a coalesced run of consecutive empty polls shown as one compact counted row
+    (issue #497). */
+export type ToolChild =
+  | { kind: "call"; event: ToolEvent }
+  | { kind: "polls"; events: ToolEvent[]; session?: string; elapsedMs?: number };
+
+/**
+ * Folds a block's flat follow-up children into render children: consecutive
+ * collapsible polls coalesce into one `polls` run that carries the shared
+ * session and the summed elapsed wall-time, while a keystroke `write_stdin` or a
+ * poll that captured output stays its own readable `call` (issue #497). A single
+ * empty poll still collapses — a run of one — so its empty output/raw-record
+ * fields never render.
+ */
+export function coalesceFollowUps(children: readonly ToolEvent[]): ToolChild[] {
+  const out: ToolChild[] = [];
+  for (const event of children) {
+    if (isCollapsiblePoll(event)) {
+      const last = out[out.length - 1];
+      const ms = typeof event.durationMs === "number" && Number.isFinite(event.durationMs) ? event.durationMs : 0;
+      if (last && last.kind === "polls") {
+        last.events.push(event);
+        if (last.session === undefined && event.session !== undefined) last.session = event.session;
+        last.elapsedMs = (last.elapsedMs ?? 0) + ms;
+        continue;
+      }
+      out.push({ kind: "polls", events: [event], session: event.session, elapsedMs: ms });
+      continue;
+    }
+    out.push({ kind: "call", event });
+  }
+  return out;
+}
+
 /** Human wall-clock duration: sub-second in ms, then `N.Ns`, then `Mm Ss`. */
 export function formatDuration(ms: number): string {
   const locale = getLocale();

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -811,6 +811,7 @@ export const en = {
   "tools.noOutputTip": "the full output lives in the rollout session",
   "tools.stdin": "stdin",
   "tools.stdinPoll": "poll",
+  "tools.pollRun": { one: "{count} poll", other: "{count} polls" },
   "tools.wait": "wait",
   "tools.session": "session",
   "tools.waitingSeconds": "waiting {n}s",

--- a/src/lib/i18n/uk.ts
+++ b/src/lib/i18n/uk.ts
@@ -785,6 +785,7 @@ export const uk: Record<keyof typeof en, Message> = {
   "tools.noOutputTip": "повний вивід зберігається в сесії rollout",
   "tools.stdin": "stdin",
   "tools.stdinPoll": "опитування",
+  "tools.pollRun": { one: "{count} опитування", few: "{count} опитування", many: "{count} опитувань", other: "{count} опитувань" },
   "tools.wait": "очікування",
   "tools.session": "сесія",
   "tools.waitingSeconds": "очікування {n} с",


### PR DESCRIPTION
## Problem

Interactive `wait` and empty `write_stdin` polls expanded into repeated full cards. Generated `functions.exec` wrappers also produced nested source and raw-record sections for each poll. Long-running commands buried the formatted command and saved output under dozens of signal-free rows.

## Change

- Normalize concrete one-operation `functions.exec` wrappers around `wait` or `write_stdin` into first-class interactive events with session ownership.
- Mark signal-free polls and coalesce consecutive runs into one compact row with count, session, and summed wall time.
- Preserve keystrokes, failures, captured output, parent commands, and completed-group summaries.
- Omit empty output, source, and raw-record controls from interactive follow-ups.
- Add English and Ukrainian compact labels.

## Acceptance

- [x] Consecutive empty polls render as one compact row.
- [x] Generated wrapper polls attach to their owning exec session.
- [x] Keystrokes and captured output retain readable rows.
- [x] Empty provenance controls disappear.
- [x] Desktop and 390px layouts remain within the viewport.
- [x] Focused parser, helper, DOM, and render coverage passes.

## Verification

- 132 focused tests passed.
- TypeScript passed.
- ESLint passed for changed source and tests.
- Production build passed.
- Synthetic desktop and 390px screenshots confirmed compact polling, readable keystrokes, and stable horizontal geometry.
