### PR TITLE
fix(feed): preserve compact stdin identity and provenance (#502)

### DIFF
--- a/src/components/feed/cards/ToolCard.tsx
+++ b/src/components/feed/cards/ToolCard.tsx
@@ -9,7 +9,7 @@ import { hhmm } from "../../utils";
 import { CopyButton } from "../CopyButton";
 import { tr, type ToolEvent } from "../parse";
 import type { ArgChip } from "../tools";
-import { formatDuration, isFollowUpCall } from "../toolBlocks";
+import { formatDuration, isCollapsiblePoll, isFollowUpCall } from "../toolBlocks";
 import { useRawLine } from "../rawLine";
 import { DiffCard } from "./DiffCard";
 import { OrchestrationCard } from "./OrchestrationCard";
@@ -142,11 +142,12 @@ function RawRecord({ event }: { event: ToolEvent }) {
    collapsed transcript keeps its DOM small (issue #9 §7/§8). */
 export function ToolBody({ event }: { event: ToolEvent }) {
   const hasDiff = event.body?.type === "diff";
-  /* An interactive follow-up (wait/write_stdin) with an empty result carries no
-     useful output, source, or raw record. Hiding those fields removes the
-     apology chip and dead raw-record toggle (issue #497). Output and failures
-     keep their full readable body. */
+  /* An interactive follow-up with an empty result carries no useful output, so
+     its apology chip stays suppressed. A collapsible empty poll also omits its
+     source disclosure. Meaningful stdin keeps that bounded redacted provenance
+     even when the result body is empty (issue #502). */
   const emptyFollowUp = isFollowUpCall(event) && !event.outputPreview.trim() && event.stderr === undefined && event.status !== "err";
+  const emptyPoll = isCollapsiblePoll(event);
   const showOutput = !emptyFollowUp && (!hasDiff || Boolean(event.outputPreview.trim()));
   return (
     <div className="mb-1 mt-1 rounded-surface bg-sunken px-3 py-2.5">
@@ -174,7 +175,7 @@ export function ToolBody({ event }: { event: ToolEvent }) {
           emptyLabel={tr("tools.noStderr")}
         />
       ) : null}
-      {emptyFollowUp ? null : <RawRecord event={event} />}
+      {emptyPoll ? null : <RawRecord event={event} />}
     </div>
   );
 }

--- a/src/components/feed/cards/readableTool.dom.test.tsx
+++ b/src/components/feed/cards/readableTool.dom.test.tsx
@@ -17,9 +17,12 @@ import {
   unknownFallback,
   withStderr,
 } from "../__fixtures__/readableTools";
+import type { FileEntry } from "@/lib/types";
 import { translate } from "@/lib/i18n";
 import { CmdGroupCard } from "./CmdGroupCard";
 import { ToolCard } from "./ToolCard";
+import { buildFeed } from "../parse";
+import { RawLineProvider } from "../rawLine";
 
 const en = (key: Parameters<typeof translate>[1], params?: Parameters<typeof translate>[2]) => translate("en", key, params);
 
@@ -150,12 +153,47 @@ test("a poll-dominated run collapses its empty polls into one counted row", () =
   expect(firstBlock.textContent).toContain("30s");
   // No empty "no output captured" apology chip survives from the polls/keystroke.
   expect(host.textContent).not.toContain(en("tools.noOutput"));
-  // Only the parent exec keeps a raw-record toggle; the 6 polls and the empty
-  // keystroke contribute none (pre-#497 they each mounted their own).
+  // The parent and meaningful keystroke retain provenance; the 6 empty polls
+  // contribute no raw-record toggles.
   const rawToggles = [...host.querySelectorAll("button")].filter((b) => (b.textContent ?? "") === en("tools.rawRecord"));
-  expect(rawToggles).toHaveLength(1);
+  expect(rawToggles).toHaveLength(2);
   // The trailing keystroke write_stdin stays readable.
   expect(host.textContent).toContain("y⏎");
+});
+
+test("meaningful empty-output stdin retains complete redacted raw provenance", () => {
+  const tail = "final-provenance-suffix";
+  const sensitiveKey = String.fromCharCode(112, 97, 115, 115, 119, 111, 114, 100);
+  const privateMarker = "REDACTION_VALUE_MARKER";
+  const chars = `${"x".repeat(340)}${tail} ${sensitiveKey}=${privateMarker}`;
+  const lines = [
+    JSON.stringify({
+      type: "response_item",
+      timestamp: "2026-07-10T10:00:00Z",
+      payload: { type: "function_call", call_id: "stdin-long", name: "write_stdin", arguments: JSON.stringify({ session_id: 8479, chars }) },
+    }),
+    JSON.stringify({
+      type: "response_item",
+      timestamp: "2026-07-10T10:00:01Z",
+      payload: { type: "function_call_output", call_id: "stdin-long", output: "Script running with cell ID 8479\nWall time 0.1 seconds\nOutput:\n" },
+    }),
+  ];
+  const file = { path: "/workspace/session.jsonl", engine: "codex", fmt: "codex", activity: "recent" } as FileEntry;
+  const event = buildFeed(file, lines, false, "").items.find((item) => item.kind === "tool");
+  if (event?.kind !== "tool") throw new Error("expected a tool event");
+
+  const host = mount(
+    <RawLineProvider value={(src) => lines[src] ?? null}>
+      <ToolCard event={{ ...event, open: true }} />
+    </RawLineProvider>,
+  );
+  expect(event.summary).not.toContain(tail);
+  const provenance = [...host.querySelectorAll("button")].find((button) => button.textContent === en("tools.rawRecord"));
+  expect(provenance).toBeTruthy();
+  flushSync(() => provenance!.click());
+  expect(host.textContent).toContain(tail);
+  expect(host.textContent).toContain(`${sensitiveKey}=[redacted]`);
+  expect(host.textContent).not.toContain(privateMarker);
 });
 
 test("reduced motion: animated chrome opts out under prefers-reduced-motion", () => {

--- a/src/components/feed/parse.ts
+++ b/src/components/feed/parse.ts
@@ -99,10 +99,10 @@ export type ToolEvent = {
   /** stderr split from the combined result, rendered in its own disclosure. */
   stderr?: string;
   stderrTruncated?: boolean;
-  /** Redacted, bounded interactive-shell session/cell this call owns: an exec
-      reports it in its result preamble, a wait/write_stdin follow-up names it in
-      its args. Lets the readable group fold each follow-up under the exec that
-      actually owns its session, even when several sessions interleave (#475). */
+  /** Redacted, bounded interactive-shell session/cell display label. An exec
+      reports it in its result preamble, and a wait/write_stdin follow-up names
+      it in its args. Grouping uses a separate parser-private ownership token so
+      display redaction or truncation cannot cross-attach sessions (#502). */
   session?: string;
   /** A bare interactive poll: a `wait`, or a `write_stdin` that sent no
       keystrokes. Empty consecutive polls collapse into one compact counted row
@@ -116,6 +116,30 @@ export type ToolEvent = {
   /** Structured Viewer MCP attribution recovered from engine-owned metadata. */
   mcp?: ViewerMcpCall;
 };
+
+/* Session ownership stays outside the serializable ToolEvent surface. The
+   parser assigns an opaque per-feed token while the UI receives only the
+   redacted display label carried by `event.session`. */
+type SessionOwner = object;
+const sessionOwnership = new WeakMap<ToolEvent, SessionOwner>();
+
+/** Compare the private ownership tokens produced by the parser. Synthetic and
+    legacy events without tokens retain display-label matching for fixtures and
+    older callers. A token on either side requires an exact private match. */
+export function hasSameSessionOwner(left: ToolEvent, right: ToolEvent): boolean {
+  const leftOwner = sessionOwnership.get(left);
+  const rightOwner = sessionOwnership.get(right);
+  if (leftOwner !== undefined || rightOwner !== undefined) {
+    return leftOwner !== undefined && leftOwner === rightOwner;
+  }
+  return left.session !== undefined && left.session === right.session;
+}
+
+function retainSessionOwner(event: ToolEvent, owner: SessionOwner | undefined): ToolEvent {
+  if (owner !== undefined) sessionOwnership.set(event, owner);
+  return event;
+}
+
 export type CitationEntry = {
   target: string;
   line?: string;
@@ -433,6 +457,28 @@ function toolOutputText(value: unknown): string {
   return value === undefined || value === null ? "" : redactTranscriptText(JSON.stringify(value));
 }
 
+/* Read the interactive session identifier from the original output envelope
+   before toolOutputText redacts its display copy. The value feeds only the
+   parser-private ownership map. */
+function toolOutputSession(value: unknown): string | undefined {
+  const matchText = (text: string) => text.match(SESSION_RESULT_RE)?.[1];
+  if (typeof value === "string") return matchText(value);
+  if (!Array.isArray(value)) return undefined;
+  for (const part of value) {
+    if (typeof part === "string") {
+      const session = matchText(part);
+      if (session !== undefined) return session;
+      continue;
+    }
+    if (!part || typeof part !== "object" || Array.isArray(part)) continue;
+    const block = rec(part);
+    const text = textPart(block.text) || textPart(block.input_text) || textPart(block.output_text);
+    const session = matchText(text);
+    if (session !== undefined) return session;
+  }
+  return undefined;
+}
+
 function toolOutputFailed(text: string): boolean {
   return /^Script failed\b/im.test(text) || /\b(?:exit|exited with) code [1-9]\d*\b/i.test(text);
 }
@@ -566,19 +612,18 @@ const SESSION_ID_MAX = 120;
    (both engines/wrappers, issue #141). */
 const SESSION_RESULT_RE = /\brunning with (?:cell|session) ID\s+(\S+)/i;
 
-/* The redacted, bounded session/cell key a shell call owns. A follow-up names it
-   in its args (numeric in write_stdin, string in wait — see objFieldScalar); an
-   exec reports it in its result preamble. Passed through the shared redaction/cap
-   funnel so the readable block never surfaces a raw or unbounded value (#475). */
-function sessionKey(value: unknown): string | undefined {
+/* Normalize the private session/cell identifier before assigning an opaque
+   ownership token. Numeric and string forms of the same identifier converge. */
+function rawSessionId(value: unknown): string | undefined {
   const raw = typeof value === "string" ? value : typeof value === "number" && Number.isFinite(value) ? String(value) : "";
-  if (!raw.trim()) return undefined;
-  const safe = redactSecrets(raw).trim().slice(0, SESSION_ID_MAX);
-  return safe || undefined;
+  return raw.trim() || undefined;
 }
 
-function sessionFromArgs(args: Record<string, unknown>): string | undefined {
-  return sessionKey(args.session_id ?? args.cell_id);
+/* The bounded label is the only session identity available to serialization
+   and renderers. Private matching uses the token retained in sessionOwnership. */
+function sessionLabel(raw: string): string | undefined {
+  const safe = redactSecrets(raw).trim().slice(0, SESSION_ID_MAX);
+  return safe || undefined;
 }
 
 /* Grouping bucket key: the verbatim tool name, falling back to the family for
@@ -1056,6 +1101,18 @@ export function createFeedSession(cfg: FeedSessionConfig): FeedSession {
 
   const entries: StoredEntry[] = [];
   const calls = new Map<string, CallRec>();
+  const sessionOwners = new Map<string, SessionOwner>();
+  const sessionIdentity = (value: unknown): { label?: string; owner: SessionOwner } | undefined => {
+    const raw = rawSessionId(value);
+    if (raw === undefined) return undefined;
+    let owner = sessionOwners.get(raw);
+    if (owner === undefined) {
+      owner = {};
+      sessionOwners.set(raw, owner);
+    }
+    return { label: sessionLabel(raw), owner };
+  };
+  const sessionFromArgs = (args: Record<string, unknown>) => sessionIdentity(args.session_id ?? args.cell_id);
   /* Outgoing teammate messages awaiting their delivery echo, by tool_use id;
      the reverse map exists only so window-slide eviction can prune. */
   const tmsgSeqs = new Map<string, number>();
@@ -1243,7 +1300,8 @@ export function createFeedSession(cfg: FeedSessionConfig): FeedSession {
     /* A bare poll carries no keystrokes: every `wait`, and a `write_stdin` whose
        `chars` payload is the deliberately empty string (issue #497 / #141). */
     const poll = opts.tool === "wait" || (opts.tool === "write_stdin" && !(typeof args.chars === "string" && args.chars.length > 0));
-    return {
+    const session = s.family === "shell" ? sessionFromArgs(args) : undefined;
+    const event: ToolEvent = {
       kind: "tool",
       id: opts.id,
       ts: opts.ts,
@@ -1262,8 +1320,7 @@ export function createFeedSession(cfg: FeedSessionConfig): FeedSession {
       outputTruncated: false,
       ...(s.family === "shell" ? (() => {
         const cwd = cwdOf(args, command);
-        const session = sessionFromArgs(args);
-        return { ...(cwd ? { cwd } : {}), ...(session !== undefined ? { session } : {}) };
+        return { ...(cwd ? { cwd } : {}), ...(session?.label !== undefined ? { session: session.label } : {}) };
       })() : {}),
       ...(poll ? { poll: true } : {}),
       /* An edit/write card opens its structured diff inline by default — a
@@ -1277,6 +1334,7 @@ export function createFeedSession(cfg: FeedSessionConfig): FeedSession {
         result: opts.mcp.result ? boundedMcpRecord(opts.mcp.result) : null,
       } } : {}),
     };
+    return retainSessionOwner(event, session?.owner);
   };
   const registerCall = (event: ToolEvent): CallRec => {
     const seq = push(event);
@@ -1358,13 +1416,15 @@ export function createFeedSession(cfg: FeedSessionConfig): FeedSession {
     const orch = parseOrchestration(input);
     const direct = orch?.directInteractive;
     const base = newToolEvent({ ts, id, tool: direct?.tool ?? name, args: direct?.args ?? { input }, engine: "codex", diff: orch?.diff });
-    const event = orch ? { ...base, ...orch.overlay, ...(orch.body ? { orchestration: orch.body } : {}) } : base;
+    const event = orch
+      ? retainSessionOwner({ ...base, ...orch.overlay, ...(orch.body ? { orchestration: orch.body } : {}) }, sessionOwnership.get(base))
+      : base;
     registerCall(event);
     return event;
   };
   /* Attaches a result copy-on-write: the record gets a fresh ToolEvent and the
      owning entry a fresh item, so exactly one row changes identity. */
-  const attach = (callRec: CallRec | undefined, output: string, errFlag?: boolean) => {
+  const attach = (callRec: CallRec | undefined, output: string, errFlag?: boolean, rawSession?: string) => {
     if (!callRec) return null;
     const code = output.match(/exited with code (\d+)/)?.[1];
     /* Codex interactive-shell wall time, read before the preamble is stripped, so
@@ -1420,7 +1480,9 @@ export function createFeedSession(cfg: FeedSessionConfig): FeedSession {
     const durationMs = wallSeconds !== undefined ? Math.round(Number(wallSeconds) * 1000) : prev.durationMs;
     /* The exec that opened the session reports it in its result preamble; a
        follow-up already carries its session from its args, so keep that. */
-    const session = prev.session ?? (prev.family === "shell" ? sessionKey(output.match(SESSION_RESULT_RE)?.[1]) : undefined);
+    const detectedSession = prev.family === "shell" ? sessionIdentity(rawSession ?? output.match(SESSION_RESULT_RE)?.[1]) : undefined;
+    const session = prev.session ?? detectedSession?.label;
+    const sessionOwner = sessionOwnership.get(prev) ?? detectedSession?.owner;
     const startMs = typeof prev.ts === "string" || typeof prev.ts === "number" ? Date.parse(String(prev.ts)) : NaN;
     const endTs = durationMs !== undefined && Number.isFinite(startMs) ? new Date(startMs + durationMs).toISOString() : prev.endTs;
     /* A wakeup's result carries the RESOLVED schedule (issue #161): on success
@@ -1441,7 +1503,7 @@ export function createFeedSession(cfg: FeedSessionConfig): FeedSession {
         wakeup = { ...refined, superseded: wakeup.superseded, failed: false };
       }
     }
-    const event: ToolEvent = {
+    const event = retainSessionOwner({
       ...prev,
       status: isErr ? "err" : "ok",
       statusLabel: isErr
@@ -1461,7 +1523,7 @@ export function createFeedSession(cfg: FeedSessionConfig): FeedSession {
       ...(session !== undefined ? { session } : {}),
       ...(wakeup ? { wakeup } : {}),
       ...(mcp ? { mcp } : {}),
-    };
+    }, sessionOwner);
     callRec.event = event;
     const idx = entryIndex(callRec.seq);
     if (idx >= 0 && idx < entries.length) {
@@ -1476,7 +1538,7 @@ export function createFeedSession(cfg: FeedSessionConfig): FeedSession {
     if (wakeup && wakeup.failed) recomputeWakeupStates();
     return event;
   };
-  const addOutput = (callId: string | undefined, output: string, err?: boolean) => {
+  const addOutput = (callId: string | undefined, output: string, err?: boolean, rawSession?: string) => {
     if (!callId) return;
     const tseq = tmsgSeqs.get(callId);
     if (tseq !== undefined) {
@@ -1493,7 +1555,7 @@ export function createFeedSession(cfg: FeedSessionConfig): FeedSession {
       }
       return;
     }
-    const event = attach(calls.get(callId), output, err);
+    const event = attach(calls.get(callId), output, err, rawSession);
     if (!event && output && showSvc) push({ kind: "svc", text: "output: " + redactSecrets(output).slice(0, 200) });
   };
   const addSvc = (text: string) => {
@@ -1727,8 +1789,9 @@ export function createFeedSession(cfg: FeedSessionConfig): FeedSession {
         return void registerCall(newToolEvent({ ts, id: textPart(p.call_id) || "plain-" + pushSeq + "-" + String(ts ?? ""), tool: name, args, engine: "codex" }));
       }
       if (p.type === "function_call_output") {
+        const rawSession = toolOutputSession(p.output);
         const output = toolOutputText(p.output);
-        return addOutput(textPart(p.call_id), output, toolOutputFailed(output));
+        return addOutput(textPart(p.call_id), output, toolOutputFailed(output), rawSession);
       }
       /* Fresh rollouts wrap apply_patch as a "custom_tool_call": `input` is the
          raw patch text directly (unlike function_call, whose `arguments` is a
@@ -1743,8 +1806,9 @@ export function createFeedSession(cfg: FeedSessionConfig): FeedSession {
         return void emitCustomTool(ts, name, input, id);
       }
       if (p.type === "custom_tool_call_output") {
+        const rawSession = toolOutputSession(p.output);
         const output = toolOutputText(p.output);
-        return addOutput(textPart(p.call_id), output, toolOutputFailed(output));
+        return addOutput(textPart(p.call_id), output, toolOutputFailed(output), rawSession);
       }
       if (p.type === "reasoning" || p.type === "agent_message") return addSvc(textPart(p.type));
       return addRecord(ts, textPart(p.type) || "item", p);
@@ -1947,6 +2011,7 @@ export function createFeedSession(cfg: FeedSessionConfig): FeedSession {
   const reset = () => {
     entries.length = 0;
     calls.clear();
+    sessionOwners.clear();
     tmsgSeqs.clear();
     tmsgKeyBySeq.clear();
     hiddenSvcBySrc.clear();

--- a/src/components/feed/readableTool.parse.test.ts
+++ b/src/components/feed/readableTool.parse.test.ts
@@ -4,7 +4,7 @@ import type { FileEntry } from "@/lib/types";
 
 import { codexExecStderrLines, claudeExecFailLines } from "./__fixtures__/readableTools";
 import { buildFeed, type CmdGroupItem, type ToolEvent } from "./parse";
-import { groupNestedCalls } from "./toolBlocks";
+import { coalesceFollowUps, groupNestedCalls } from "./toolBlocks";
 
 const codexFile = { path: "/tmp/x.jsonl", engine: "codex", fmt: "codex", activity: "recent" } as FileEntry;
 const claudeFile = { path: "/tmp/x.jsonl", engine: "claude", fmt: "claude", activity: "recent" } as FileEntry;
@@ -90,6 +90,69 @@ test("a wait/write_stdin run nests as follow-ups of the exec that owns them", ()
   expect(blocks[0].children.map((c) => c.tool)).toEqual(["wait", "write_stdin"]);
   // Each nested call preserves its own individual state.
   expect(blocks[0].children.every((c) => c.status === "ok")).toBe(true);
+});
+
+test("redacted session-label collisions retain separate ownership and poll runs", () => {
+  const line = (payload: Record<string, unknown>, ts: string) => JSON.stringify({ type: "response_item", timestamp: ts, payload });
+  const sensitiveKey = String.fromCharCode(116, 111, 107, 101, 110);
+  const firstSession = `${sensitiveKey}=opaque-first-session`;
+  const secondSession = `${sensitiveKey}=opaque-second-session`;
+  const lines = [
+    line({ type: "function_call", call_id: "eA", name: "exec_command", arguments: JSON.stringify({ cmd: "serve A" }) }, "2026-07-10T10:00:00Z"),
+    line({ type: "function_call_output", call_id: "eA", output: `Script running with session ID ${firstSession}\nWall time 1.0 seconds\nOutput:\nA` }, "2026-07-10T10:00:01Z"),
+    line({ type: "function_call", call_id: "eB", name: "exec_command", arguments: JSON.stringify({ cmd: "serve B" }) }, "2026-07-10T10:00:02Z"),
+    line({ type: "function_call_output", call_id: "eB", output: `Script running with session ID ${secondSession}\nWall time 1.0 seconds\nOutput:\nB` }, "2026-07-10T10:00:03Z"),
+    line({ type: "function_call", call_id: "pA1", name: "write_stdin", arguments: JSON.stringify({ session_id: firstSession, chars: "" }) }, "2026-07-10T10:00:04Z"),
+    line({ type: "function_call_output", call_id: "pA1", output: `Script running with cell ID ${firstSession}\nWall time 5.0 seconds\nOutput:\n` }, "2026-07-10T10:00:09Z"),
+    line({ type: "function_call", call_id: "pA2", name: "write_stdin", arguments: JSON.stringify({ session_id: firstSession, chars: "" }) }, "2026-07-10T10:00:10Z"),
+    line({ type: "function_call_output", call_id: "pA2", output: `Script running with cell ID ${firstSession}\nWall time 5.0 seconds\nOutput:\n` }, "2026-07-10T10:00:15Z"),
+    line({ type: "function_call", call_id: "pB1", name: "write_stdin", arguments: JSON.stringify({ session_id: secondSession, chars: "" }) }, "2026-07-10T10:00:16Z"),
+    line({ type: "function_call_output", call_id: "pB1", output: `Script running with cell ID ${secondSession}\nWall time 5.0 seconds\nOutput:\n` }, "2026-07-10T10:00:21Z"),
+    line({ type: "function_call", call_id: "pB2", name: "write_stdin", arguments: JSON.stringify({ session_id: secondSession, chars: "" }) }, "2026-07-10T10:00:22Z"),
+    line({ type: "function_call_output", call_id: "pB2", output: `Script running with cell ID ${secondSession}\nWall time 5.0 seconds\nOutput:\n` }, "2026-07-10T10:00:27Z"),
+  ];
+  const group = buildFeed(codexFile, lines, false, "").items.find((item): item is CmdGroupItem => item.kind === "cmd-group");
+  if (!group) throw new Error("expected a cmd-group");
+
+  const blocks = groupNestedCalls(group.calls);
+  expect(blocks.map((block) => block.parent.id)).toEqual(["eA", "eB"]);
+  expect(blocks[0].children.map((child) => child.id)).toEqual(["pA1", "pA2"]);
+  expect(blocks[1].children.map((child) => child.id)).toEqual(["pB1", "pB2"]);
+  expect(coalesceFollowUps(blocks[0].children)).toHaveLength(1);
+  expect(coalesceFollowUps(blocks[1].children)).toHaveLength(1);
+
+  const serialized = JSON.stringify(group);
+  expect(serialized).not.toContain(firstSession);
+  expect(serialized).not.toContain(secondSession);
+  expect(group.calls.every((call) => call.session === `${sensitiveKey}=[redacted]`)).toBe(true);
+});
+
+test("metadata-wrapped in-flight stdin retains private session ownership", () => {
+  const line = (payload: Record<string, unknown>, ts: string) => JSON.stringify({ type: "response_item", timestamp: ts, payload });
+  const sensitiveKey = String.fromCharCode(116, 111, 107, 101, 110);
+  const firstSession = `${sensitiveKey}=metadata-first-session`;
+  const secondSession = `${sensitiveKey}=metadata-second-session`;
+  const exec = (id: string, ts: string) => line({ type: "function_call", call_id: id, name: "exec_command", arguments: JSON.stringify({ cmd: `serve ${id}` }) }, ts);
+  const output = (id: string, session: string, ts: string) => line({ type: "function_call_output", call_id: id, output: `Script running with session ID ${session}\nOutput:\nready` }, ts);
+  const stdin = (id: string, session: string, ts: string) =>
+    line({ type: "custom_tool_call", call_id: id, name: "exec", input: `await tools.write_stdin({ session_id: "${session}", chars: "" });` }, ts);
+  const lines = [
+    exec("eA", "2026-07-10T10:00:00Z"),
+    output("eA", firstSession, "2026-07-10T10:00:01Z"),
+    exec("eB", "2026-07-10T10:00:02Z"),
+    output("eB", secondSession, "2026-07-10T10:00:03Z"),
+    stdin("pA", firstSession, "2026-07-10T10:00:04Z"),
+    stdin("pB", secondSession, "2026-07-10T10:00:05Z"),
+  ];
+  const group = buildFeed(codexFile, lines, false, "").items.find((item): item is CmdGroupItem => item.kind === "cmd-group");
+  if (!group) throw new Error("expected a cmd-group");
+
+  const blocks = groupNestedCalls(group.calls);
+  expect(blocks.map((block) => block.parent.id)).toEqual(["eA", "eB"]);
+  expect(blocks[0].children.map((child) => child.id)).toEqual(["pA"]);
+  expect(blocks[1].children.map((child) => child.id)).toEqual(["pB"]);
+  expect(JSON.stringify(group)).not.toContain(firstSession);
+  expect(JSON.stringify(group)).not.toContain(secondSession);
 });
 
 test("the parser distinguishes bare polls from keystroke write_stdin", () => {

--- a/src/components/feed/toolBlocks.test.ts
+++ b/src/components/feed/toolBlocks.test.ts
@@ -118,3 +118,13 @@ test("formatDuration scales from ms to seconds to minutes", () => {
   expect(formatDuration(62_000)).toBe("1m 2s");
   expect(formatDuration(-5)).toBe("");
 });
+
+test("formatDuration rounds total seconds before minute rollover", () => {
+  const coalesced = coalesceFollowUps([
+    emptyPoll("p1", { durationMs: 59_750 }),
+    emptyPoll("p2", { durationMs: 59_750 }),
+  ]);
+  if (coalesced[0]?.kind !== "polls") throw new Error("expected a polls run");
+  expect(formatDuration(coalesced[0].elapsedMs ?? 0)).toBe("2m 0s");
+  expect(formatDuration(179_500)).toBe("3m 0s");
+});

--- a/src/components/feed/toolBlocks.ts
+++ b/src/components/feed/toolBlocks.ts
@@ -1,6 +1,6 @@
 import { getLocale, translate } from "@/lib/i18n";
 
-import type { ToolEvent } from "./parse";
+import { hasSameSessionOwner, type ToolEvent } from "./parse";
 
 /* Pure helpers behind the readable expanded tool block (issue #475): the
    parent/child nesting of Codex interactive-shell follow-ups, and the duration
@@ -27,7 +27,7 @@ export function isFollowUpCall(event: ToolEvent): boolean {
 function ownerBlock(blocks: readonly ToolBlock[], followUp: ToolEvent): ToolBlock | undefined {
   if (followUp.session !== undefined) {
     for (let i = blocks.length - 1; i >= 0; i -= 1) {
-      if (blocks[i].parent.session === followUp.session) return blocks[i];
+      if (hasSameSessionOwner(blocks[i].parent, followUp)) return blocks[i];
     }
     return undefined;
   }
@@ -109,7 +109,8 @@ export function formatDuration(ms: number): string {
     const n = totalSec < 10 ? Math.round(totalSec * 10) / 10 : Math.round(totalSec);
     return t("tools.durationSec", { n });
   }
-  const m = Math.floor(totalSec / 60);
-  const s = Math.round(totalSec % 60);
-  return t("tools.durationMin", { m, s: s === 60 ? 0 : s });
+  const roundedSec = Math.round(totalSec);
+  const m = Math.floor(roundedSec / 60);
+  const s = roundedSec % 60;
+  return t("tools.durationMin", { m, s });
 }


### PR DESCRIPTION
Closes #502.

## Summary

- keep a private opaque ownership token separate from the redacted display label
- retain bounded redacted stdin provenance for meaningful empty-output writes
- round total seconds before splitting minutes and seconds
- preserve compact poll folding, session isolation, translations, and 390px containment

## Verification

- 206 focused feed tests / 1,370 assertions
- 99 privacy tests and publication gate
- TypeScript and changed-file ESLint
- production build including MCP bundle
- desktop and 390px rendering checks

Exact implementation commit: `f3d5ae012b8988a29235d40174c178dca2cb7fa4`.
