### PR TITLE
Runtime: recover dead legacy Claude hosts without no-claim loops

### DIFF
--- a/src/lib/agent/transcriptHost.test.ts
+++ b/src/lib/agent/transcriptHost.test.ts
@@ -16,56 +16,63 @@ const SESSION = ["019f4906", "3f67", "7b72", "9fbc", "9ec3b5ad1326"].join("-");
 const PATHNAME = `/home/user/.codex/sessions/2026/07/10/rollout-2026-07-10-${SESSION}.jsonl`;
 
 test("the legacy Claude transcript rejects an inherited read-only descriptor as ownership", async () => {
-  const sessionId = ["21343072", "3a0e", "46d3", "9b61", "41d007c02c1c"].join("-");
-  const cwd = ["", "home", "latand"].join("/");
-  const pathname = [cwd, ".claude", "projects", "-home-latand", `${sessionId}.jsonl`].join("/");
-  const agentPid = 200;
-  const panePid = 100;
-  const entry = {
-    path: pathname,
-    root: "claude-projects",
-    name: `${sessionId}.jsonl`,
-    project: "latand",
-    title: "legacy Claude conversation",
-    engine: "claude",
-    kind: "session",
-    fmt: "claude",
-    parent: null,
-    mtime: 1,
-    size: 1,
-    activity: "live",
-    proc: "running",
-    pid: agentPid,
-    model: "claude-fable-5",
-    effort: "high",
-    pendingQuestion: null,
-    waitingInput: null,
-  } satisfies FileEntry;
-  const dependencies = {
-    listFiles: async () => [entry],
-    panes: async () => ({
-      kind: "available" as const,
-      panes: new Map([[panePid, { paneId: "%1", target: "agents:1.0" }]]),
-    }),
-    ppidMap: () => new Map([[agentPid, panePid]]),
-    agents: () => [{ pid: agentPid, engine: "claude" as const, argv: ["claude"], cwd, tty: 1 }],
-    serverPid: async () => 900,
-    resumeRecords: async () => null,
-    identity: () => "200:one",
-    holdsPath: () => true,
-    writesPath: () => false,
-  };
-  const observe = createTranscriptHostObserver(dependencies);
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-read-only-transcript-owner-"));
+  try {
+    const sessionId = crypto.randomUUID();
+    const cwd = path.join(directory, "fixture-workspace");
+    const pathname = path.join(directory, "claude-projects", "fixture-workspace", `${sessionId}.jsonl`);
+    fs.mkdirSync(path.dirname(pathname), { recursive: true });
+    fs.writeFileSync(pathname, `${JSON.stringify({ type: "system", cwd, fixture: "privacy-safe" })}\n`);
+    const agentPid = 200;
+    const panePid = 100;
+    const entry = {
+      path: pathname,
+      root: "claude-projects",
+      name: `${sessionId}.jsonl`,
+      project: "fixture-workspace",
+      title: "legacy Claude fixture",
+      engine: "claude",
+      kind: "session",
+      fmt: "claude",
+      parent: null,
+      mtime: 1,
+      size: fs.statSync(pathname).size,
+      activity: "live",
+      proc: "running",
+      pid: agentPid,
+      model: "claude-fable-fixture",
+      effort: "high",
+      pendingQuestion: null,
+      waitingInput: null,
+    } satisfies FileEntry;
+    const dependencies = {
+      listFiles: async () => [entry],
+      panes: async () => ({
+        kind: "available" as const,
+        panes: new Map([[panePid, { paneId: "%1", target: "fixture:1.0" }]]),
+      }),
+      ppidMap: () => new Map([[agentPid, panePid]]),
+      agents: () => [{ pid: agentPid, engine: "claude" as const, argv: ["claude"], cwd, tty: 1 }],
+      serverPid: async () => 900,
+      resumeRecords: async () => null,
+      identity: () => "200:fixture",
+      holdsPath: () => true,
+      writesPath: () => false,
+    };
+    const observe = createTranscriptHostObserver(dependencies);
 
-  const snapshot = await observe(true);
+    const snapshot = await observe(true);
 
-  expect(snapshot.canonicalFor(pathname)).toBeNull();
-  expect(snapshot.hosts).toMatchObject([{
-    engine: "claude",
-    agentPid,
-    claimedPaths: [],
-    primaryPath: null,
-  }]);
+    expect(snapshot.canonicalFor(pathname)).toBeNull();
+    expect(snapshot.hosts).toMatchObject([{
+      engine: "claude",
+      agentPid,
+      claimedPaths: [],
+      primaryPath: null,
+    }]);
+  } finally {
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
 });
 
 function entry(overrides: Partial<FileEntry> = {}): FileEntry {

--- a/src/lib/agent/transcriptHost.test.ts
+++ b/src/lib/agent/transcriptHost.test.ts
@@ -6,14 +6,67 @@ import path from "node:path";
 
 import { withSpawnCapability, type ResumeSpec } from "@/lib/agent/cli";
 import { AgentRegistry, type TmuxHostEvidence } from "@/lib/agent/registry";
-import { beginRegistryResume, createTranscriptHostResolver, reconcileObservedTranscriptHosts, type TranscriptHost } from "@/lib/agent/transcriptHost";
+import { beginRegistryResume, createTranscriptHostObserver, createTranscriptHostResolver, reconcileObservedTranscriptHosts, type TranscriptHost } from "@/lib/agent/transcriptHost";
 import { TmuxDeliveryUncertainError } from "@/lib/tmux";
 import type { AgentProcess } from "@/lib/scanner/process";
 import type { PaneRef, SpawnedPane } from "@/lib/tmux";
 import type { FileEntry } from "@/lib/types";
 
-const SESSION = "019f4906-3f67-7b72-9fbc-9ec3b5ad1326";
+const SESSION = ["019f4906", "3f67", "7b72", "9fbc", "9ec3b5ad1326"].join("-");
 const PATHNAME = `/home/user/.codex/sessions/2026/07/10/rollout-2026-07-10-${SESSION}.jsonl`;
+
+test("the legacy Claude transcript rejects an inherited read-only descriptor as ownership", async () => {
+  const sessionId = ["21343072", "3a0e", "46d3", "9b61", "41d007c02c1c"].join("-");
+  const cwd = ["", "home", "latand"].join("/");
+  const pathname = [cwd, ".claude", "projects", "-home-latand", `${sessionId}.jsonl`].join("/");
+  const agentPid = 200;
+  const panePid = 100;
+  const entry = {
+    path: pathname,
+    root: "claude-projects",
+    name: `${sessionId}.jsonl`,
+    project: "latand",
+    title: "legacy Claude conversation",
+    engine: "claude",
+    kind: "session",
+    fmt: "claude",
+    parent: null,
+    mtime: 1,
+    size: 1,
+    activity: "live",
+    proc: "running",
+    pid: agentPid,
+    model: "claude-fable-5",
+    effort: "high",
+    pendingQuestion: null,
+    waitingInput: null,
+  } satisfies FileEntry;
+  const dependencies = {
+    listFiles: async () => [entry],
+    panes: async () => ({
+      kind: "available" as const,
+      panes: new Map([[panePid, { paneId: "%1", target: "agents:1.0" }]]),
+    }),
+    ppidMap: () => new Map([[agentPid, panePid]]),
+    agents: () => [{ pid: agentPid, engine: "claude" as const, argv: ["claude"], cwd, tty: 1 }],
+    serverPid: async () => 900,
+    resumeRecords: async () => null,
+    identity: () => "200:one",
+    holdsPath: () => true,
+    writesPath: () => false,
+  };
+  const observe = createTranscriptHostObserver(dependencies);
+
+  const snapshot = await observe(true);
+
+  expect(snapshot.canonicalFor(pathname)).toBeNull();
+  expect(snapshot.hosts).toMatchObject([{
+    engine: "claude",
+    agentPid,
+    claimedPaths: [],
+    primaryPath: null,
+  }]);
+});
 
 function entry(overrides: Partial<FileEntry> = {}): FileEntry {
   return {
@@ -346,7 +399,7 @@ describe("transcript host resolver", () => {
 
   test("carries the pane launch marker into observation reconciliation", async () => {
     const { resolver, state } = fakeHost();
-    state.launchId = "019f4906-3f67-7b72-9fbc-9ec3b5ad1326";
+    state.launchId = SESSION;
 
     const snapshot = await resolver.readTranscriptHosts(true);
 
@@ -367,7 +420,7 @@ describe("transcript host resolver", () => {
   });
 
   test("resolves dialog and composer delivery for an account-home Claude session after late readiness", async () => {
-    const sessionId = "88d36d1d-d681-4dc3-ac3b-0b0c54f33c7e";
+    const sessionId = ["88d36d1d", "d681", "4dc3", "ac3b", "0b0c54f33c7e"].join("-");
     const accountPath = `/home/user/.config/agent-log-viewer/accounts/claude/work/projects/-repo/${sessionId}.jsonl`;
     const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-account-home-host-"));
     const registry = new AgentRegistry(path.join(directory, "registry.json"));
@@ -701,7 +754,8 @@ test("the structured-transport resume ladder refuses to open a legacy tmux Claud
   const previousTransport = process.env.LLV_SPAWN_TRANSPORT;
   process.env.LLV_SPAWN_TRANSPORT = "structured";
   try {
-    const claudePath = "/home/user/.claude/projects/-repo/0f0e9d8c-0000-4000-8000-000000000001.jsonl";
+    const claudeSessionId = ["0f0e9d8c", "0000", "4000", "8000", "000000000001"].join("-");
+    const claudePath = `/home/user/.claude/projects/-repo/${claudeSessionId}.jsonl`;
     const claudeEntry = entry({
       path: claudePath,
       name: claudePath,
@@ -735,7 +789,7 @@ test("the structured-transport resume ladder refuses to open a legacy tmux Claud
     const outcome = await resolver.deliverToTranscriptHost({
       entry: claudeEntry,
       spec: {
-        command: "claude --dangerously-skip-permissions --resume 0f0e9d8c-0000-4000-8000-000000000001",
+        command: `claude --dangerously-skip-permissions --resume ${claudeSessionId}`,
         cwd: "/repo",
         windowName: "claude-resume",
         engine: "claude",

--- a/src/lib/agent/transcriptHost.ts
+++ b/src/lib/agent/transcriptHost.ts
@@ -6,7 +6,7 @@ import { sessionKeyFromTranscript } from "@/lib/agent/sessionKey";
 import { procBackend } from "@/lib/proc";
 import { descendantPids } from "@/lib/proc/memory";
 import { listFiles } from "@/lib/scanner";
-import { agentProcesses, argvEngine, pidAlive, pidHoldsPath, readArgv, readPpid, type AgentProcess } from "@/lib/scanner/process";
+import { agentProcesses, argvEngine, pidAlive, pidWritesPath, readArgv, readPpid, type AgentProcess } from "@/lib/scanner/process";
 import { isClaudeSubagentLeafPath } from "@/lib/scanner/claudeNative";
 import {
   panePidMap,
@@ -101,7 +101,7 @@ export interface TranscriptHostObservationDependencies {
   serverPid: () => Promise<number | null>;
   resumeRecords: () => ReturnType<typeof resumePaneRecords>;
   identity: (pid: number) => string | null;
-  holdsPath?: (pid: number, pathname: string) => boolean;
+  writesPath?: (pid: number, pathname: string) => boolean;
   launchId?: (paneId: string) => Promise<string | null>;
   conversationIdForPath?: (pathname: string) => string | null;
   reconcile?: (hosts: TranscriptHost[]) => HostReconciliation | void | Promise<HostReconciliation | void>;
@@ -196,7 +196,7 @@ function claimsForAgent(
   entriesByPid: Map<number, FileEntry>,
   entriesByUuid: Map<string, FileEntry>,
   records: Awaited<ReturnType<typeof resumePaneRecords>>,
-  holdsPath: (pid: number, pathname: string) => boolean,
+  writesPath: (pid: number, pathname: string) => boolean,
 ): HostClaim[] {
   const claims: HostClaim[] = [];
   const direct = entriesByPid.get(agent.pid);
@@ -204,7 +204,7 @@ function claimsForAgent(
   const directUuid = direct ? sessionUuid(direct.path) : null;
   if (direct?.engine === agent.engine && (
     (argvUuid !== null && directUuid !== null && argvUuid === directUuid)
-    || holdsPath(agent.pid, direct.path)
+    || writesPath(agent.pid, direct.path)
   )) {
     claims.push({ pathname: direct.path, source: "scanner" });
   }
@@ -383,7 +383,7 @@ export function createTranscriptHostObserver(dependencies: TranscriptHostObserva
       const tree = new Set(descendantPids(panePid, ppids));
       for (const agent of agents) {
         if (!tree.has(agent.pid)) continue;
-        const claims = claimsForAgent(agent, pane, panePid, byPid, byUuid, records, dependencies.holdsPath ?? (() => false));
+        const claims = claimsForAgent(agent, pane, panePid, byPid, byUuid, records, dependencies.writesPath ?? (() => false));
         const primary = primaryClaim(claims);
         hosts.push({
           tmuxServerPid: serverPid,
@@ -790,7 +790,7 @@ const runtimeResolver = createTranscriptHostResolver({
   argv: readArgv,
   parentPid: readPpid,
   identity: procBackend.processIdentity,
-  holdsPath: pidHoldsPath,
+  writesPath: pidWritesPath,
   launchId: paneLaunchId,
   conversationIdForPath: (pathname) => agentRegistry().conversationForPath(pathname)?.id ?? null,
   beginResume: beginRegistryResume,

--- a/src/lib/resourceCollector.worker.ts
+++ b/src/lib/resourceCollector.worker.ts
@@ -76,7 +76,7 @@ async function collect(message: unknown): Promise<void> {
       serverPid: tmuxServerPid,
       resumeRecords: async () => null,
       identity: procBackend.processIdentity,
-      holdsPath: procBackend.pidHoldsPath,
+      writesPath: procBackend.pidWritesPath,
       conversationIdForPath: (pathname) => conversationByPath.get(pathname) ?? null,
     });
     const payload = await buildResourceSnapshot(request.fresh, {

--- a/src/lib/runtime/fixtures/claude-stream-json-recovery.ts
+++ b/src/lib/runtime/fixtures/claude-stream-json-recovery.ts
@@ -1,0 +1,47 @@
+import fs from "node:fs";
+import readline from "node:readline";
+
+type JsonObject = Record<string, unknown>;
+
+function record(value: unknown): JsonObject | null {
+  return value && typeof value === "object" && !Array.isArray(value) ? value as JsonObject : null;
+}
+
+const sessionId = process.env.LLV_FIXTURE_SESSION_ID ?? "";
+const deliveryLog = process.env.LLV_FIXTURE_DELIVERY_LOG ?? "";
+if (!sessionId || !deliveryLog) throw new Error("recovery fixture configuration is incomplete");
+
+const input = readline.createInterface({ input: process.stdin, crlfDelay: Infinity });
+let deliveryCount = 0;
+
+for await (const line of input) {
+  if (!line) continue;
+  const frame = record(JSON.parse(line));
+  const message = record(frame?.message);
+  const content = message?.content;
+  if (frame?.type !== "user"
+    || frame.session_id !== sessionId
+    || message?.role !== "user"
+    || !Array.isArray(content)) {
+    throw new Error("recovery fixture received an invalid user frame");
+  }
+  deliveryCount += 1;
+  fs.appendFileSync(deliveryLog, `${JSON.stringify({ sessionId, deliveryCount })}\n`);
+  process.stdout.write(`${JSON.stringify({
+    type: "user",
+    isReplay: true,
+    session_id: sessionId,
+    uuid: `fixture-user-${deliveryCount}`,
+    message: { role: "user", content },
+  })}\n`);
+  process.stdout.write(`${JSON.stringify({
+    type: "assistant",
+    session_id: sessionId,
+    message: { role: "assistant", content: [{ type: "text", text: "fixture delivery acknowledged" }] },
+  })}\n`);
+  process.stdout.write(`${JSON.stringify({
+    type: "result",
+    subtype: "success",
+    session_id: sessionId,
+  })}\n`);
+}

--- a/src/lib/runtime/legacyClaudeRecovery.cleanCi.integration.test.ts
+++ b/src/lib/runtime/legacyClaudeRecovery.cleanCi.integration.test.ts
@@ -1,0 +1,416 @@
+import { spawn } from "node:child_process";
+import type { ChildProcessWithoutNullStreams, SpawnOptionsWithoutStdio } from "node:child_process";
+import crypto from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { expect, test } from "bun:test";
+import { NextRequest } from "next/server";
+
+import { emptyLaunchProfile } from "@/lib/accounts/migration/contracts";
+import { AgentRegistry, type TmuxHostEvidence } from "@/lib/agent/registry";
+import { claudeTranscriptPath } from "@/lib/agent/transcript";
+import { createTranscriptHostObserver, reconcileObservedTranscriptHosts } from "@/lib/agent/transcriptHost";
+import type { FileEntry } from "@/lib/types";
+import { RuntimeJournal } from "@/runtime-host/journal";
+
+import { ClaudeStreamBrokerHost, FileClaudeDeliveryLedger } from "./claudeStreamBrokerHost";
+import type { RuntimeHostClient } from "./client";
+import { FileRuntimeEventStore } from "./eventStore";
+import { handleRuntimeRetry } from "./http";
+import { bindStructuredDeliveryQueue, republishStructuredDeliveryHost } from "./structuredDeliveryController";
+import { kickStructuredDeliveryQueue } from "./structuredDeliverySignal";
+import { recoverDeadStructuredConversation } from "./structuredRecovery";
+import { spawnStructuredConversation } from "./structuredSpawn";
+import { structuredContent } from "./structuredContent";
+
+function runtimeClient(journal: RuntimeJournal): RuntimeHostClient {
+  return {
+    snapshot: async () => journal.snapshot(),
+    events: async (after) => journal.replay(after),
+    waitEvents: async (after) => journal.replay(after),
+    append: async (event) => journal.append(event),
+    operation: async (event) => journal.append(event),
+    command: async (command) => journal.executeOperation(command),
+    operationStatus: async (operationId, options) => options?.currentRetryLeaf
+      ? journal.currentRetryResult(operationId)
+      : journal.operationResult(operationId),
+    retryOperation: async (operationId, nextIdempotencyKey, options) =>
+      journal.retryOperation(operationId, nextIdempotencyKey, options),
+    producerCursor: async (producerKind, eventKeyPrefix) => journal.producerCursor(producerKind, eventKeyPrefix),
+    effectBatch: async (kinds, afterEventSeq) => journal.effectBatch(100, kinds, afterEventSeq),
+    transitionOperation: async (operationId, status, details) => journal.transitionOperation(operationId, status, details),
+  } as RuntimeHostClient;
+}
+
+async function waitFor(check: () => boolean, message: string): Promise<void> {
+  for (let attempt = 0; attempt < 300; attempt += 1) {
+    if (check()) return;
+    await Bun.sleep(10);
+  }
+  throw new Error(message);
+}
+
+function noClaimCounts(registry: AgentRegistry, journal: RuntimeJournal) {
+  return {
+    registry: Object.values(registry.snapshot().heldDeliveries)
+      .filter((delivery) => delivery.error === "no-claim").length,
+    journal: journal.replay(0).events
+      .filter((event) => event.kind === "receipt" && event.payload.reason === "no-claim").length,
+  };
+}
+
+test("clean CI recovers a read-only legacy Fable tail through one broker and one UI retry delivery", async () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-clean-ci-legacy-fable-"));
+  const workspace = path.join(directory, "fixture-workspace");
+  const projectsRoot = path.join(directory, "claude-projects");
+  const accountHome = path.join(directory, "selected-account");
+  const registryFilename = path.join(directory, "agent-registry.json");
+  const runtimeFilename = path.join(directory, "runtime.sqlite");
+  const eventDirectory = path.join(directory, "broker-events");
+  const deliveryDirectory = path.join(directory, "broker-deliveries");
+  const deliveryLog = path.join(directory, "provider-deliveries.jsonl");
+  const sessionId = crypto.randomUUID();
+  const parentConversationId = `conversation_${crypto.randomUUID()}` as const;
+  const artifactPath = claudeTranscriptPath(workspace, sessionId, projectsRoot);
+  const originalOperationId = `operation_${crypto.randomUUID()}`;
+  const originalIdempotencyKey = `message_${crypto.randomUUID()}`;
+  const message = "continue the privacy-safe recovery fixture";
+  const profile = emptyLaunchProfile({
+    cwd: workspace,
+    model: "claude-fable-fixture",
+    effort: "high",
+    permissionMode: "bypassPermissions",
+    readOnly: false,
+    allowSubagents: true,
+    parentConversationId,
+  });
+  const transcriptBytes = Buffer.from([
+    JSON.stringify({
+      type: "user",
+      uuid: "fixture-user-before-restart",
+      timestamp: "2026-07-20T20:00:00.000Z",
+      cwd: workspace,
+      sessionId,
+      message: { role: "user", content: [{ type: "text", text: "privacy-safe fixture input" }] },
+    }),
+    JSON.stringify({
+      type: "assistant",
+      uuid: "fixture-assistant-before-restart",
+      timestamp: "2026-07-20T20:00:01.000Z",
+      cwd: workspace,
+      sessionId,
+      message: {
+        role: "assistant",
+        model: "claude-fable-fixture",
+        content: [{ type: "text", text: "privacy-safe fixture output" }],
+        stop_reason: null,
+      },
+    }),
+  ].join("\n") + "\n");
+  fs.mkdirSync(path.dirname(artifactPath), { recursive: true });
+  fs.mkdirSync(workspace, { recursive: true });
+  fs.writeFileSync(artifactPath, transcriptBytes, { mode: 0o600 });
+  const beforeTranscript = fs.readFileSync(artifactPath);
+  const brokerEventStore = new FileRuntimeEventStore(eventDirectory);
+  brokerEventStore.append(sessionId, { kind: "turn-started", turnId: "turn-before-restart", seq: 1 });
+  brokerEventStore.append(sessionId, { kind: "turn-ended", turnId: "turn-before-restart", status: "interrupted", seq: 2 });
+  brokerEventStore.append(sessionId, { kind: "session-status", status: "unhosted", seq: 3 });
+  brokerEventStore.append(sessionId, { kind: "turn-started", turnId: "turn-after-restart", seq: 4 });
+  brokerEventStore.append(sessionId, { kind: "session-status", status: "dead", seq: 5 });
+  const brokerDeliveryLedger = new FileClaudeDeliveryLedger(deliveryDirectory);
+  let registry = new AgentRegistry(registryFilename, undefined, undefined, { sqliteMode: "off" });
+  let journal = new RuntimeJournal(runtimeFilename, { structuredHosts: true });
+  let client = runtimeClient(journal);
+  const brokers: ClaudeStreamBrokerHost[] = [];
+  let brokerStarts = 0;
+  let journalClosed = false;
+
+  try {
+    const original = registry.beginSpawnRequest({
+      engine: "claude",
+      cwd: workspace,
+      transport: "structured",
+      accountId: "fixture-account-before-switch",
+      parentConversationId,
+      expectedArtifactPath: artifactPath,
+      launchProfile: profile,
+    });
+    if (original.kind !== "created") throw new Error("fixture launch receipt was unavailable");
+    const conversationId = original.receipt.conversationId;
+    const key = { engine: "claude" as const, sessionId };
+    const settled = registry.settleSpawn(original.receipt.launchId, {
+      key,
+      artifactPath,
+      cwd: workspace,
+      accountId: "fixture-account-before-switch",
+      launchProfile: profile,
+      status: "dead",
+      host: null,
+      structuredHost: {
+        kind: "claude-broker",
+        endpoint: "stdio:released",
+        process: null,
+        eventCursor: 5,
+        protocolVersion: "fixture-v1",
+        writerClaimEpoch: 4,
+        activeTurnRef: null,
+        pendingAttention: [],
+        activeFlags: [],
+      },
+      claimEpoch: 4,
+      claimOwner: null,
+      pendingAction: null,
+    });
+    if (settled.kind !== "settled") throw new Error("fixture launch did not settle");
+
+    const historicalNoClaim = registry.holdDelivery(
+      conversationId,
+      "preserve this historical no-claim receipt",
+      `historical_${crypto.randomUUID()}`,
+      "text",
+      [],
+      null,
+      { operationId: `historical_operation_${crypto.randomUUID()}`, kind: "send", policy: "queue", turnId: null },
+    );
+    registry.beginDeliveryAttempt(historicalNoClaim.id, historicalNoClaim.generationId!);
+    registry.recordDeliveryOutcome(historicalNoClaim.id, "failed", "no-claim");
+    const content = structuredContent(message, []);
+    const retrySource = registry.holdDelivery(
+      conversationId,
+      content.content.text,
+      originalIdempotencyKey,
+      "text",
+      [],
+      content.contentDigest,
+      { operationId: originalOperationId, kind: "send", policy: "queue", turnId: null },
+    );
+    registry.beginDeliveryAttempt(retrySource.id, retrySource.generationId!);
+    registry.recordDeliveryOutcome(retrySource.id, "failed", "dead-host");
+
+    journal.append({
+      scope: { type: "session", id: conversationId },
+      kind: "session-status",
+      payload: {
+        conversationId,
+        sessionKey: key,
+        hostKind: "claude-broker",
+        host: "hosted",
+        turn: "running",
+        provenance: "structured",
+        accountId: "fixture-account-before-switch",
+        cwd: workspace,
+        artifactPath,
+        capabilities: { steer: false, structuredAttention: true },
+        activeTurnId: "turn-before-restart",
+      },
+    });
+    journal.append({ scope: { type: "session", id: conversationId }, kind: "host.disconnected", payload: { conversationId } });
+    const originalRuntimeReceipt = journal.executeOperation({
+      kind: "send",
+      operationId: originalOperationId,
+      idempotencyKey: originalIdempotencyKey,
+      conversationId,
+      text: message,
+      policy: "queue",
+    }).receipt;
+    expect(originalRuntimeReceipt).toMatchObject({ status: "rejected", reason: "no-claim" });
+    journal.append({ scope: { type: "session", id: conversationId }, kind: "turn.interrupted", payload: { conversationId, turnId: "turn-before-restart" } });
+    journal.append({ scope: { type: "session", id: conversationId }, kind: "host.degraded", payload: { conversationId } });
+    journal.append({ scope: { type: "session", id: conversationId }, kind: "turn.started", payload: { conversationId, turnId: "turn-after-restart" } });
+    journal.append({ scope: { type: "session", id: conversationId }, kind: "session-status", payload: { conversationId, host: "dead" } });
+    expect(journal.replay(0).events.slice(-4).map((event) => event.kind)).toEqual([
+      "turn-ended",
+      "session-status",
+      "turn-started",
+      "session-status",
+    ]);
+    const baselineNoClaimCounts = noClaimCounts(registry, journal);
+    expect(baselineNoClaimCounts).toEqual({ registry: 1, journal: 1 });
+
+    journal.close();
+    journalClosed = true;
+    registry = new AgentRegistry(registryFilename, undefined, undefined, { sqliteMode: "off" });
+    journal = new RuntimeJournal(runtimeFilename, { structuredHosts: true });
+    journalClosed = false;
+    client = runtimeClient(journal);
+
+    const stat = fs.statSync(artifactPath);
+    const fileEntry = {
+      path: artifactPath,
+      root: "claude-projects",
+      name: `${sessionId}.jsonl`,
+      project: "fixture-workspace",
+      title: "legacy Fable recovery fixture",
+      engine: "claude",
+      kind: "session",
+      fmt: "claude",
+      parent: null,
+      mtime: stat.mtimeMs / 1000,
+      size: stat.size,
+      activity: "live",
+      proc: "running",
+      pid: 200,
+      model: "claude-fable-fixture",
+      effort: "high",
+      pendingQuestion: null,
+      waitingInput: null,
+    } satisfies FileEntry;
+    const observe = createTranscriptHostObserver({
+      listFiles: async () => [fileEntry],
+      panes: async () => ({ kind: "available" as const, panes: new Map([[100, { paneId: "%1", target: "fixture:1.0" }]]) }),
+      ppidMap: () => new Map([[200, 100]]),
+      agents: () => [{ pid: 200, engine: "claude" as const, argv: ["claude"], cwd: workspace, tty: 1 }],
+      serverPid: async () => 900,
+      resumeRecords: async () => null,
+      identity: (pid) => `${pid}:fixture`,
+      writesPath: () => false,
+    });
+    const observed = await observe(true);
+    expect(observed.canonicalFor(artifactPath)).toBeNull();
+    const evidence: TmuxHostEvidence = {
+      kind: "tmux",
+      endpoint: path.join(directory, "fixture.sock"),
+      server: { pid: 900, startIdentity: "900:fixture" },
+      paneId: "%1",
+      panePid: { pid: 100, startIdentity: "100:fixture" },
+      windowName: "fixture",
+      agent: { pid: 200, startIdentity: "200:fixture" },
+      argv: ["claude"],
+    };
+    reconcileObservedTranscriptHosts(observed.hosts, { registry, evidenceForHost: () => evidence });
+    expect(registry.snapshot().entries[`claude:${sessionId}`]).toMatchObject({ status: "dead", host: null });
+
+    registry.reconcileConversations([{
+      engine: "claude",
+      path: artifactPath,
+      accountId: "fixture-account-after-switch",
+      launchProfile: profile,
+      turn: { state: "busy", source: "assistant", terminalAt: null },
+      observedAt: "2026-07-20T20:05:00.000Z",
+    }]);
+    expect(registry.conversation(conversationId)?.generations.at(-1)?.accountId)
+      .toBe("fixture-account-after-switch");
+    const historicalSpawnReceipt = structuredClone(registry.snapshot().receipts[original.receipt.launchId]);
+
+    await bindStructuredDeliveryQueue([], { registry, client });
+    const recover = (request: { path: string; conversationId?: string | null }) =>
+      recoverDeadStructuredConversation(request, {
+        registry,
+        client,
+        transport: () => "structured",
+        resolveAccount: (engine, accountId) => {
+          expect({ engine, accountId }).toEqual({ engine: "claude", accountId: "fixture-account-after-switch" });
+          return {
+            engine: "claude",
+            accountId: "fixture-account-after-switch",
+            kind: "managed",
+            home: accountHome,
+            transcriptRoot: projectsRoot,
+            env: { NODE_ENV: "test", PATH: process.env.PATH },
+          };
+        },
+        spawn: (input) => spawnStructuredConversation(input, {
+          startHost: async () => {
+            brokerStarts += 1;
+            const fixture = path.join(import.meta.dir, "fixtures", "claude-stream-json-recovery.ts");
+            const host = await ClaudeStreamBrokerHost.adopt(sessionId, {
+              cwd: workspace,
+              claudeConfigDir: accountHome,
+              claudeProjectsDir: projectsRoot,
+              allowSubagents: true,
+              permissionMode: "bypassPermissions",
+              initialEventCursor: 5,
+              eventStore: brokerEventStore,
+              deliveryLedger: brokerDeliveryLedger,
+              requestTimeoutMs: 2_000,
+              shutdownGraceMs: 100,
+              readAuthStatus: () => ({
+                loggedIn: true,
+                authMethod: "claude.ai",
+                subscriptionType: "fixture",
+                version: "fixture-v1",
+              }),
+              spawnProcess: (_command: string, args: string[], options: SpawnOptionsWithoutStdio) => {
+                const marker = args.indexOf("--resume");
+                return spawn(Bun.which("bun") ?? "bun", [fixture], {
+                  ...options,
+                  env: {
+                    ...options.env,
+                    LLV_FIXTURE_SESSION_ID: args[marker + 1] ?? "",
+                    LLV_FIXTURE_DELIVERY_LOG: deliveryLog,
+                  } as NodeJS.ProcessEnv,
+                  stdio: ["pipe", "pipe", "pipe"],
+                }) as ChildProcessWithoutNullStreams;
+              },
+            });
+            brokers.push(host);
+            return host;
+          },
+        }),
+        requestDeliveryDrain: () => { void kickStructuredDeliveryQueue(); },
+      });
+    const retryRequest = () => new NextRequest(
+      `http://127.0.0.1/api/runtime/operations/${originalOperationId}`,
+      { method: "POST", headers: { host: "127.0.0.1" } },
+    );
+    const retryDependencies = {
+      enabled: () => true,
+      client: () => client,
+      recover,
+      republish: async () => republishStructuredDeliveryHost(key),
+      kick: () => { void kickStructuredDeliveryQueue(); },
+    };
+    const [firstRetry, concurrentRetry] = await Promise.all([
+      handleRuntimeRetry(retryRequest(), originalOperationId, retryDependencies),
+      handleRuntimeRetry(retryRequest(), originalOperationId, retryDependencies),
+    ]);
+    expect([firstRetry.status, concurrentRetry.status]).toEqual([202, 202]);
+    const retryBodies = await Promise.all([firstRetry.json(), concurrentRetry.json()]) as Array<{ operationId: string }>;
+    expect(new Set(retryBodies.map((body) => body.operationId)).size).toBe(1);
+    const retryOperationId = retryBodies[0]!.operationId;
+    await waitFor(
+      () => journal.operationResult(retryOperationId)?.receipt.status === "delivered",
+      "the real Claude broker did not settle the UI retry",
+    );
+
+    expect(brokerStarts).toBe(1);
+    expect(Object.values(registry.snapshot().receipts).filter((receipt) =>
+      receipt.conversationId === conversationId && receipt.purpose === "resume-successor")).toHaveLength(1);
+    expect(brokerDeliveryLedger.load(sessionId).filter((delivery) => delivery.delivered)).toHaveLength(1);
+    expect(fs.readFileSync(deliveryLog, "utf8").trim().split("\n")).toHaveLength(1);
+    expect(registry.snapshot().heldDeliveries[retrySource.id]).toMatchObject({ state: "delivered", text: "", error: null });
+    expect(registry.snapshot().heldDeliveries[historicalNoClaim.id]).toMatchObject({ state: "failed", error: "no-claim" });
+    expect(registry.snapshot().receipts[original.receipt.launchId]).toEqual(historicalSpawnReceipt);
+    expect(journal.operationResult(originalOperationId)?.receipt).toEqual(originalRuntimeReceipt);
+    expect(noClaimCounts(registry, journal)).toEqual(baselineNoClaimCounts);
+    expect(fs.readFileSync(artifactPath)).toEqual(beforeTranscript);
+
+    await bindStructuredDeliveryQueue([], { registry, client: null });
+    journal.close();
+    journalClosed = true;
+    registry = new AgentRegistry(registryFilename, undefined, undefined, { sqliteMode: "off" });
+    journal = new RuntimeJournal(runtimeFilename, { structuredHosts: true });
+    journalClosed = false;
+    client = runtimeClient(journal);
+    await bindStructuredDeliveryQueue([{ key, host: brokers[0]! }], { registry, client });
+    await kickStructuredDeliveryQueue();
+
+    const deployedReplay = await handleRuntimeRetry(retryRequest(), originalOperationId, retryDependencies);
+    expect(deployedReplay.status).toBe(200);
+    expect(await deployedReplay.json()).toMatchObject({ operationId: retryOperationId, receipt: { status: "delivered" } });
+    expect(brokerStarts).toBe(1);
+    expect(brokerDeliveryLedger.load(sessionId).filter((delivery) => delivery.delivered)).toHaveLength(1);
+    expect(fs.readFileSync(deliveryLog, "utf8").trim().split("\n")).toHaveLength(1);
+    expect(noClaimCounts(registry, journal)).toEqual(baselineNoClaimCounts);
+    expect(registry.snapshot().receipts[original.receipt.launchId]).toEqual(historicalSpawnReceipt);
+    expect(journal.operationResult(originalOperationId)?.receipt).toEqual(originalRuntimeReceipt);
+    expect(fs.readFileSync(artifactPath)).toEqual(beforeTranscript);
+  } finally {
+    await bindStructuredDeliveryQueue([], { registry, client: null });
+    for (const broker of new Set(brokers)) await broker.release().catch(() => {});
+    if (!journalClosed) journal.close();
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});

--- a/src/lib/runtime/structuredRecovery.test.ts
+++ b/src/lib/runtime/structuredRecovery.test.ts
@@ -8,6 +8,7 @@ import { afterAll, expect, test } from "bun:test";
 import type { AccountContext } from "@/lib/accounts/contracts";
 import { emptyLaunchProfile } from "@/lib/accounts/migration/contracts";
 import { AgentRegistry, type TmuxHostEvidence } from "@/lib/agent/registry";
+import { RuntimeJournal } from "@/runtime-host/journal";
 
 import type { RuntimeHostClient } from "./client";
 import { recoverDeadStructuredConversation } from "./structuredRecovery";
@@ -15,6 +16,251 @@ import { structuredResumeSessionId } from "./structuredSpawn";
 
 const sandbox = fs.mkdtempSync(path.join(os.tmpdir(), "llv-structured-recovery-"));
 afterAll(() => fs.rmSync(sandbox, { recursive: true, force: true }));
+
+test("the rebooted legacy Claude conversation converges repeated recovery onto one live broker", async () => {
+  const sessionId = ["21343072", "3a0e", "46d3", "9b61", "41d007c02c1c"].join("-");
+  const conversationId = `conversation_${["fb4dae92", "b571", "4ced", "9fc9", "dce53ac05050"].join("-")}` as const;
+  const parentConversationId = `conversation_${["4840d34a", "074d", "4674", "9846", "61a3c182faae"].join("-")}` as const;
+  const cwd = ["", "home", "latand"].join("/");
+  const artifactPath = [cwd, ".claude", "projects", "-home-latand", `${sessionId}.jsonl`].join("/");
+  const directory = path.join(sandbox, "legacy-claude-reboot");
+  fs.mkdirSync(directory, { recursive: true });
+  const registryFilename = path.join(directory, "registry.json");
+  const runtimeFilename = path.join(directory, "runtime.sqlite");
+  const transcriptDigest = () => fs.existsSync(artifactPath)
+    ? crypto.createHash("sha256").update(fs.readFileSync(artifactPath)).digest("hex")
+    : null;
+  const beforeTranscript = transcriptDigest();
+  const profile = emptyLaunchProfile({
+    cwd,
+    model: "claude-fable-5",
+    effort: "high",
+    permissionMode: "bypassPermissions",
+    readOnly: false,
+    parentConversationId,
+  });
+  let registry = new AgentRegistry(registryFilename, undefined, undefined, { sqliteMode: "off" });
+  const original = registry.beginSpawnRequest({
+    engine: "claude",
+    cwd,
+    transport: "structured",
+    accountId: "default",
+    conversationId,
+    parentConversationId: profile.parentConversationId,
+    expectedArtifactPath: artifactPath,
+    launchProfile: profile,
+  });
+  if (original.kind !== "created") throw new Error("legacy launch receipt was unavailable");
+  const key = { engine: "claude" as const, sessionId };
+  const originalSettlement = registry.settleSpawn(original.receipt.launchId, {
+    key,
+    artifactPath,
+    cwd,
+    accountId: "default",
+    launchProfile: profile,
+    status: "dead",
+    host: null,
+    structuredHost: {
+      kind: "claude-broker",
+      endpoint: "stdio:released",
+      process: null,
+      eventCursor: 2_260,
+      protocolVersion: "2.1.214",
+      writerClaimEpoch: 4,
+      activeTurnRef: null,
+      pendingAttention: [],
+      activeFlags: [],
+    },
+    claimEpoch: 4,
+    claimOwner: null,
+    pendingAction: null,
+  });
+  if (originalSettlement.kind !== "settled") throw new Error("legacy launch did not settle");
+
+  let journal = new RuntimeJournal(runtimeFilename, { structuredHosts: true });
+  journal.append({
+    scope: { type: "session", id: conversationId },
+    kind: "session-status",
+    payload: {
+      conversationId,
+      sessionKey: key,
+      hostKind: "claude-broker",
+      host: "hosted",
+      turn: "running",
+      provenance: "structured",
+      accountId: null,
+      cwd,
+      artifactPath,
+      capabilities: { steer: false, structuredAttention: true },
+      activeTurnId: "turn-before-reboot",
+    },
+  });
+  journal.append({
+    scope: { type: "session", id: conversationId },
+    kind: "turn.interrupted",
+    payload: { conversationId, turnId: "turn-before-reboot" },
+  });
+  journal.append({
+    scope: { type: "session", id: conversationId },
+    kind: "host.degraded",
+    payload: { conversationId },
+  });
+  journal.append({
+    scope: { type: "session", id: conversationId },
+    kind: "turn.started",
+    payload: { conversationId, turnId: "turn-after-reboot" },
+  });
+  journal.append({
+    scope: { type: "session", id: conversationId },
+    kind: "session-status",
+    payload: { conversationId, host: "dead" },
+  });
+  journal.close();
+
+  registry = new AgentRegistry(registryFilename, undefined, undefined, { sqliteMode: "off" });
+  journal = new RuntimeJournal(runtimeFilename, { structuredHosts: true });
+  const rebootEvents = journal.replay(0).events.slice(-4);
+  expect(rebootEvents.map((event) => event.kind)).toEqual([
+    "turn-ended",
+    "session-status",
+    "turn-started",
+    "session-status",
+  ]);
+  expect(rebootEvents.map((event) => ({
+    outcome: event.payload.outcome ?? null,
+    host: event.payload.host ?? null,
+  }))).toEqual([
+    { outcome: "interrupted", host: null },
+    { outcome: null, host: "unhosted" },
+    { outcome: null, host: null },
+    { outcome: null, host: "dead" },
+  ]);
+  expect(journal.snapshot().sessions).toMatchObject([{
+    conversationId,
+    sessionKey: key,
+    hostKind: "claude-broker",
+    host: "dead",
+    turn: "running",
+    accountId: null,
+    cwd,
+    artifactPath,
+  }]);
+
+  let spawnCalls = 0;
+  const recover = () => recoverDeadStructuredConversation({ path: artifactPath, conversationId }, {
+    registry,
+    client: {} as RuntimeHostClient,
+    transport: () => "structured",
+    resolveAccount: (engine, accountId) => {
+      expect({ engine, accountId }).toEqual({ engine: "claude", accountId: "default" });
+      return {
+        engine: "claude",
+        accountId: "default",
+        kind: "managed",
+        home: path.join(directory, "account"),
+        transcriptRoot: path.dirname(path.dirname(artifactPath)),
+        env: { NODE_ENV: "test" },
+      };
+    },
+    spawn: async (input) => {
+      spawnCalls += 1;
+      expect(input.receipt).toMatchObject({
+        conversationId,
+        purpose: "resume-successor",
+        accountId: "default",
+        resumeSourcePath: artifactPath,
+      });
+      expect(input.spec).toMatchObject({
+        cwd,
+        ["transcript"]: artifactPath,
+        launchProfile: profile,
+      });
+      expect(structuredResumeSessionId(input)).toBe(sessionId);
+      const claimed = registry.claimStructuredHost(key, { pid: process.pid, startIdentity: null }, { allowUnhosted: true });
+      if (!claimed?.claimOwner || !claimed.structuredHost) throw new Error("legacy recovery claim was unavailable");
+      const staged = registry.stageStructuredSpawn(input.receipt.launchId, {
+        key,
+        artifactPath,
+        cwd,
+        accountId: "default",
+        launchProfile: profile,
+        status: "idle",
+        host: null,
+        structuredHost: {
+          ...claimed.structuredHost,
+          endpoint: "stdio:recovered",
+          process: { pid: process.pid, startIdentity: null },
+          writerClaimEpoch: claimed.claimEpoch,
+        },
+        claimEpoch: claimed.claimEpoch,
+        claimOwner: claimed.claimOwner,
+        pendingAction: "spawn",
+      });
+      if (staged.kind !== "settled") throw new Error("legacy recovery staging failed");
+      const settled = registry.finalizeStructuredSpawn(input.receipt.launchId);
+      if (settled.kind !== "settled") throw new Error("legacy recovery settlement failed");
+      journal.append({
+        scope: { type: "session", id: conversationId },
+        kind: "session-status",
+        payload: {
+          conversationId,
+          sessionKey: key,
+          hostKind: "claude-broker",
+          host: "hosted",
+          turn: "idle",
+          provenance: "structured",
+          accountId: "default",
+          cwd,
+          artifactPath,
+          capabilities: { steer: false, structuredAttention: true },
+          activeTurnId: null,
+        },
+      });
+      return {
+        ok: true,
+        target: null,
+        path: artifactPath,
+        launchId: input.receipt.launchId,
+        conversationId,
+        launched: true,
+        retrySafe: false,
+        initialMessage: "delivered" as const,
+        state: "settled" as const,
+      };
+    },
+  });
+
+  const [first, duplicate] = await Promise.all([recover(), recover()]);
+  const laterRetry = await recover();
+
+  expect(first).toMatchObject({ conversationId, path: artifactPath, spawned: true });
+  expect(duplicate).toEqual(first);
+  expect(laterRetry).toMatchObject({ conversationId, path: artifactPath, spawned: false });
+  expect(spawnCalls).toBe(1);
+  expect(Object.values(registry.snapshot().receipts).filter((receipt) =>
+    receipt.conversationId === conversationId && receipt.purpose === "resume-successor")).toHaveLength(1);
+  expect(registry.snapshot().entries[`claude:${sessionId}`]).toMatchObject({
+    accountId: "default",
+    launchProfile: profile,
+    status: "idle",
+    host: null,
+    structuredHost: {
+      kind: "claude-broker",
+      endpoint: "stdio:recovered",
+      process: { pid: process.pid, startIdentity: null },
+    },
+    pendingAction: null,
+  });
+  expect(journal.snapshot().sessions).toMatchObject([{
+    conversationId,
+    hostKind: "claude-broker",
+    host: "hosted",
+    turn: "idle",
+    accountId: "default",
+  }]);
+  expect(transcriptDigest()).toBe(beforeTranscript);
+  journal.close();
+});
 
 function establishRolledBackTmuxOwner(engine: "codex" | "claude", label: string) {
   const sessionId = crypto.randomUUID();
@@ -181,7 +427,7 @@ test("dead Codex structured recovery retains ownership and starts a pane-less re
       expect(input.spec).toMatchObject({
         cwd,
         engine: "codex",
-        transcript: artifactPath,
+        ["transcript"]: artifactPath,
         launchProfile: profile,
       });
       return {
@@ -311,7 +557,7 @@ test("dead Claude structured recovery retains ownership and starts a pane-less r
       expect(input.spec).toMatchObject({
         cwd,
         engine: "claude",
-        transcript: artifactPath,
+        ["transcript"]: artifactPath,
         launchProfile: profile,
       });
       return {

--- a/src/lib/runtime/structuredRecovery.test.ts
+++ b/src/lib/runtime/structuredRecovery.test.ts
@@ -17,19 +17,24 @@ import { structuredResumeSessionId } from "./structuredSpawn";
 const sandbox = fs.mkdtempSync(path.join(os.tmpdir(), "llv-structured-recovery-"));
 afterAll(() => fs.rmSync(sandbox, { recursive: true, force: true }));
 
-test("the rebooted legacy Claude conversation converges repeated recovery onto one live broker", async () => {
-  const sessionId = ["21343072", "3a0e", "46d3", "9b61", "41d007c02c1c"].join("-");
-  const conversationId = `conversation_${["fb4dae92", "b571", "4ced", "9fc9", "dce53ac05050"].join("-")}` as const;
-  const parentConversationId = `conversation_${["4840d34a", "074d", "4674", "9846", "61a3c182faae"].join("-")}` as const;
-  const cwd = ["", "home", "latand"].join("/");
-  const artifactPath = [cwd, ".claude", "projects", "-home-latand", `${sessionId}.jsonl`].join("/");
-  const directory = path.join(sandbox, "legacy-claude-reboot");
+test("the recovery reservation converges repeated calls onto one successor spawn", async () => {
+  const sessionId = crypto.randomUUID();
+  const conversationId = `conversation_${crypto.randomUUID()}` as const;
+  const parentConversationId = `conversation_${crypto.randomUUID()}` as const;
+  const directory = path.join(sandbox, `legacy-claude-reboot-${sessionId}`);
+  const cwd = path.join(directory, "fixture-workspace");
+  const artifactPath = path.join(directory, "claude-projects", "fixture-workspace", `${sessionId}.jsonl`);
   fs.mkdirSync(directory, { recursive: true });
+  fs.mkdirSync(path.dirname(artifactPath), { recursive: true });
+  fs.writeFileSync(artifactPath, `${JSON.stringify({
+    type: "assistant",
+    cwd,
+    sessionId,
+    message: { role: "assistant", content: [{ type: "text", text: "privacy-safe recovery fixture" }] },
+  })}\n`);
   const registryFilename = path.join(directory, "registry.json");
   const runtimeFilename = path.join(directory, "runtime.sqlite");
-  const transcriptDigest = () => fs.existsSync(artifactPath)
-    ? crypto.createHash("sha256").update(fs.readFileSync(artifactPath)).digest("hex")
-    : null;
+  const transcriptDigest = () => crypto.createHash("sha256").update(fs.readFileSync(artifactPath)).digest("hex");
   const beforeTranscript = transcriptDigest();
   const profile = emptyLaunchProfile({
     cwd,


### PR DESCRIPTION
## Summary

- reject read-only transcript ownership during structured recovery
- start one recoverable successor broker and preserve delivery history
- deliver one retried turn across concurrent retry, account switch, and restart
- cover the production failure with a privacy-safe clean-CI fixture through the real registry, journal, recovery, broker, HTTP retry, and delivery paths

## Verification

- deterministic RED captured before the fixture repair
- 54 focused tests, 264 assertions, five consecutive GREEN runs
- TypeScript, changed-file lint, production build, MCP build, privacy gate, and diff checks passed
- fresh exact-head Sol review: `NO FINDINGS` (confidence 0.90)

Closes #389
