### PR TITLE
P0: drive pipeline transitions from durable terminal events

### DIFF
--- a/src/app/api/pipelines/tick/route.test.ts
+++ b/src/app/api/pipelines/tick/route.test.ts
@@ -3,7 +3,7 @@ import { NextRequest } from "next/server";
 
 import { POST } from "./route";
 
-test("pipeline tick runs inside the live Viewer request process", async () => {
+test("pipeline tick joins one coalesced reconciliation inside the live Viewer process", async () => {
   let calls = 0;
   const response = await POST.withDependencies(new NextRequest("http://127.0.0.1:8898/api/pipelines/tick", {
     method: "POST",
@@ -14,9 +14,8 @@ test("pipeline tick runs inside the live Viewer request process", async () => {
     },
   }), async () => {
     calls += 1;
-    return { pipelines: [], changed: false };
   });
 
   expect(response.status).toBe(202);
-  expect(calls).toBe(2);
+  expect(calls).toBe(1);
 });

--- a/src/app/api/pipelines/tick/route.ts
+++ b/src/app/api/pipelines/tick/route.ts
@@ -1,22 +1,21 @@
 import { NextRequest, NextResponse } from "next/server";
 
-import { tickPipelines } from "@/lib/pipelines/engine";
+import { flowPipelineController } from "@/lib/pipelines/controller";
 import { rejectCrossOrigin } from "@/lib/sameOrigin";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
-type PipelineTick = typeof tickPipelines;
+type PipelineTick = () => Promise<void>;
 
 async function post(request: NextRequest, tick: PipelineTick): Promise<NextResponse> {
   const rejection = rejectCrossOrigin(request);
   if (rejection) return rejection;
-  await tick([]);
-  await tick([]);
+  await tick();
   return NextResponse.json({ ok: true }, { status: 202 });
 }
 
 export const POST = Object.assign(
-  (request: NextRequest) => post(request, tickPipelines),
+  (request: NextRequest) => post(request, () => flowPipelineController().tick("remote-signal")),
   { withDependencies: (request: NextRequest, tick: PipelineTick) => post(request, tick) },
 );

--- a/src/instrumentation.test.ts
+++ b/src/instrumentation.test.ts
@@ -10,10 +10,16 @@ import {
   initializeOperatorSpawnCapabilityAtStartup,
   runStructuredHostStartup,
   scheduleAccountMigrationController,
+  startCurrentReleaseControllers,
   startWakatimeIntegrationIfEnabled,
   viewerReleaseOwnsTraffic,
 } from "@/lib/viewerInstrumentation";
 import { operatorSpawnCapabilityPath } from "@/lib/agent/operatorCapability";
+import {
+  FLOW_PIPELINE_WATCHDOG_MS,
+  FlowPipelineController,
+  startFlowPipelineControllerRuntime,
+} from "@/lib/pipelines/controller";
 import { StructuredRuntimeRequirementError } from "@/lib/proc/darwinIdentity";
 import { RuntimeHostUnavailableError } from "@/lib/runtime/client";
 import { didStructuredHostStartupFail, markStructuredHostStartupReady } from "@/lib/runtime/startupStatus";
@@ -137,6 +143,47 @@ test("a restarted current release activates before register returns", async () =
   );
   expect(activations).toBe(1);
   expect(scheduled).toHaveLength(0);
+});
+
+test("current release starts flow and pipeline recovery and watchdog while account migration is disabled", async () => {
+  const starts: string[] = [];
+  const watchdogs: Array<{ callback: () => void; delayMs: number }> = [];
+  const controller = {
+    tick: async () => undefined,
+    recover: async () => { starts.push("startup"); },
+    poll: async () => { starts.push("watchdog"); },
+  } as unknown as FlowPipelineController;
+  const startFlowPipelineController = () => startFlowPipelineControllerRuntime(controller, {}, {
+    registerTick: () => () => undefined,
+    scheduleInterval: (callback, delayMs) => {
+      const watchdog = { callback, delayMs, unref: () => undefined };
+      watchdogs.push(watchdog);
+      return watchdog;
+    },
+    log: () => undefined,
+  });
+
+  await startCurrentReleaseControllers(
+    { LLV_ACCOUNT_CONTROLLER_DISABLED: "1" },
+    {
+      loadFlowPipelineController: async () => ({
+        startFlowPipelineController,
+      }),
+      loadAccountMigrationController: async () => {
+        starts.push("account-loaded");
+        return { startAccountMigrationController: async () => { starts.push("account"); } };
+      },
+    },
+  );
+  await Promise.resolve();
+
+  expect(starts).toEqual(["startup"]);
+  expect(watchdogs).toHaveLength(1);
+  expect(watchdogs[0]!.delayMs).toBe(FLOW_PIPELINE_WATCHDOG_MS);
+
+  watchdogs[0]!.callback();
+  await Promise.resolve();
+  expect(starts).toEqual(["startup", "watchdog"]);
 });
 
 test("cold boot enables the controller while readiness receives the first runtime turn", async () => {

--- a/src/lib/flows/exec.test.ts
+++ b/src/lib/flows/exec.test.ts
@@ -13,6 +13,7 @@ const { forgetHeadlessReview, headlessReviewStatus, reviewerCommand, scanEventSt
 const { reviewerPrompt } = await import("./prompts");
 const { outputPathFor, stdoutPathFor } = await import("./store");
 const { WAKATIME_CREDENTIAL_ENV } = await import("../wakatime/credential");
+const { registerPipelineTick } = await import("../pipelines/controllerSignal");
 
 afterAll(() => {
   fs.rmSync(process.env.LLV_STATE_DIR!, { recursive: true, force: true });
@@ -202,6 +203,42 @@ test("headless Codex launch closes stdin and excludes the WakaTime credential fr
   } finally {
     forgetHeadlessReview("flow-stdin-eof", 1);
     Reflect.deleteProperty(process.env, WAKATIME_CREDENTIAL_ENV);
+  }
+});
+
+test("a headless review exit schedules one flow and pipeline reconciliation", async () => {
+  const executablePath = path.join(process.env.LLV_STATE_DIR!, "fake-completing-codex");
+  fs.writeFileSync(
+    executablePath,
+    `#!${process.execPath}\nawait Bun.stdin.text();\n`,
+    { mode: 0o700 },
+  );
+  let ticks = 0;
+  let markTicked = () => {};
+  const ticked = new Promise<void>((resolve) => { markTicked = resolve; });
+  const unregister = registerPipelineTick(async () => {
+    ticks += 1;
+    markTicked();
+  });
+
+  try {
+    startHeadlessReview(
+      "flow-completion-signal",
+      1,
+      { engine: "codex", model: null, effort: null },
+      process.cwd(),
+      "review prompt",
+      5_000,
+      null,
+      null,
+      { command: executablePath },
+    );
+    await ticked;
+    await Promise.resolve();
+    expect(ticks).toBe(1);
+  } finally {
+    unregister();
+    forgetHeadlessReview("flow-completion-signal", 1);
   }
 });
 

--- a/src/lib/flows/exec.ts
+++ b/src/lib/flows/exec.ts
@@ -7,6 +7,7 @@ import { resolveBinary } from "@/lib/agent/cli";
 import { claudeManagedEnvironment, claudeSettingsPath } from "@/lib/accounts/claude";
 import { claudeTranscriptPath } from "@/lib/agent/transcript";
 import { applyClaudeSpawnPolicy, fenceViewerSpawnPrompt } from "@/lib/agent/spawnPolicy";
+import { requestPipelineTick } from "@/lib/pipelines/controllerSignal";
 import { procBackend } from "@/lib/proc";
 import { withoutWakatimeCredential } from "@/lib/wakatime/credential";
 
@@ -313,15 +314,23 @@ export function startHeadlessReview(
   };
   run.timer.unref();
   runs.set(key, run);
+  let completionSignaled = false;
+  const signalCompletion = () => {
+    if (completionSignaled) return;
+    completionSignaled = true;
+    requestPipelineTick();
+  };
   child.on("error", () => {
     clearTimeout(run.timer);
     run.exit = { code: null, signal: null };
     killOwnedRun(run);
+    signalCompletion();
   });
   child.on("close", (code, signal) => {
     clearTimeout(run.timer);
     run.exit = { code, signal };
     killOwnedRun(run);
+    signalCompletion();
   });
   return { pid: child.pid ?? null, identity, sessionId: built.sessionId, reviewerPath: built.reviewerPath };
 }

--- a/src/lib/pipelines/controller.test.ts
+++ b/src/lib/pipelines/controller.test.ts
@@ -175,6 +175,40 @@ test("startup recovery and the watchdog converge a pending transition without du
   expect(transitions).toBe(1);
 });
 
+test("a wake during controller settlement runs one additional cycle without duplicate transition effects", async () => {
+  const idleCycles: number[] = [];
+  let transitionPending = false;
+  let transitionEffects = 0;
+  let settlementWake: Promise<void> | null = null;
+  const controller = new FlowPipelineController({
+    tickPipelines: async () => {
+      if (!transitionPending) return { changed: false };
+      transitionPending = false;
+      transitionEffects += 1;
+      return { changed: true };
+    },
+    tickFlows: async () => ({ changed: false }),
+    publishHeartbeat: (heartbeat) => {
+      if (heartbeat.phase !== "idle") return;
+      idleCycles.push(heartbeat.cycle);
+      if (heartbeat.cycle !== 1) return;
+      queueMicrotask(() => {
+        queueMicrotask(() => {
+          transitionPending = true;
+          settlementWake = controller.tick("settlement-wake");
+        });
+      });
+    },
+  });
+
+  await controller.tick("initial");
+  if (settlementWake === null) throw new Error("settlement wake was not scheduled");
+  await settlementWake;
+
+  expect(idleCycles).toEqual([1, 2]);
+  expect(transitionEffects).toBe(1);
+});
+
 test("controller runtime registers startup recovery and one deterministic watchdog", async () => {
   const calls: string[] = [];
   const signals: Array<() => Promise<void>> = [];

--- a/src/lib/pipelines/controller.test.ts
+++ b/src/lib/pipelines/controller.test.ts
@@ -7,7 +7,9 @@ import { AgentRegistry } from "@/lib/agent/registry";
 import { AccountMigrationController } from "@/lib/accounts/migration/controller";
 
 import {
+  FLOW_PIPELINE_WATCHDOG_MS,
   FlowPipelineController,
+  startFlowPipelineControllerRuntime,
   type FlowPipelineControllerHeartbeat,
   type FlowPipelineControllerPorts,
   writeFlowPipelineControllerHeartbeat,
@@ -171,6 +173,54 @@ test("startup recovery and the watchdog converge a pending transition without du
   await controller.poll();
 
   expect(transitions).toBe(1);
+});
+
+test("controller runtime registers startup recovery and one deterministic watchdog", async () => {
+  const calls: string[] = [];
+  const signals: Array<() => Promise<void>> = [];
+  const watchdogs: Array<{ callback: () => void; delayMs: number; unrefCalls: number }> = [];
+  let unregisterCalls = 0;
+  const controller = {
+    tick: async (trigger: string) => { calls.push(trigger); },
+    recover: async () => { calls.push("startup"); },
+    poll: async () => { calls.push("watchdog"); },
+  } as unknown as FlowPipelineController;
+  const state = {};
+  const start = () => startFlowPipelineControllerRuntime(controller, state, {
+    registerTick: (tick) => {
+      signals.push(tick);
+      return () => { unregisterCalls += 1; };
+    },
+    scheduleInterval: (callback, delayMs) => {
+      const watchdog = {
+        callback,
+        delayMs,
+        unrefCalls: 0,
+        unref() { this.unrefCalls += 1; },
+      };
+      watchdogs.push(watchdog);
+      return watchdog;
+    },
+    log: () => undefined,
+  });
+
+  start();
+  await Promise.resolve();
+  expect(calls).toEqual(["startup"]);
+  expect(watchdogs).toHaveLength(1);
+  expect(watchdogs[0]).toMatchObject({ delayMs: FLOW_PIPELINE_WATCHDOG_MS, unrefCalls: 1 });
+
+  watchdogs[0]!.callback();
+  await Promise.resolve();
+  await signals[0]!();
+  expect(calls).toEqual(["startup", "watchdog", "signal"]);
+
+  start();
+  await Promise.resolve();
+  expect(unregisterCalls).toBe(1);
+  expect(signals).toHaveLength(2);
+  expect(watchdogs).toHaveLength(1);
+  expect(calls).toEqual(["startup", "watchdog", "signal", "startup"]);
 });
 
 test("pipeline settlement leads the cycle and one scanner snapshot feeds every flow pass", async () => {

--- a/src/lib/pipelines/controller.test.ts
+++ b/src/lib/pipelines/controller.test.ts
@@ -1,0 +1,209 @@
+import { afterAll, expect, test } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { AgentRegistry } from "@/lib/agent/registry";
+import { AccountMigrationController } from "@/lib/accounts/migration/controller";
+
+import {
+  FlowPipelineController,
+  type FlowPipelineControllerHeartbeat,
+  type FlowPipelineControllerPorts,
+  writeFlowPipelineControllerHeartbeat,
+} from "./controller";
+
+const sandbox = fs.mkdtempSync(path.join(os.tmpdir(), "llv-flow-pipeline-controller-"));
+
+afterAll(() => {
+  fs.rmSync(sandbox, { recursive: true, force: true });
+});
+
+function accountControllerWedgedInRuntime(): Promise<void> {
+  const registry = new AgentRegistry(path.join(sandbox, `registry-${crypto.randomUUID()}.json`));
+  let markRuntimeStarted = () => {};
+  const runtimeStarted = new Promise<void>((resolve) => { markRuntimeStarted = resolve; });
+  const wedged = new Promise<void>(() => {});
+  const controller = new AccountMigrationController(
+    registry,
+    { tick: async () => undefined },
+    null,
+    {
+      scan: async () => ({ files: [], projectCatalog: [], complete: true }),
+      reconcileInventory: async () => registry.snapshot(),
+      reconcileFlowOwnership: async () => undefined,
+      reconcileWorkflowOwnership: async () => undefined,
+      reconcileHandoffOwnership: async () => undefined,
+      reconcileFiles: async () => undefined,
+      reconcileRuntime: async () => {
+        markRuntimeStarted();
+        await wedged;
+      },
+      reconcileTaskStore: async () => undefined,
+      syncRouting: async () => undefined,
+      reconcileMigrationCycle: async () => undefined,
+    },
+  );
+  void controller.tick();
+  return runtimeStarted;
+}
+
+test("a terminal event advances once and launches one reviewer while the account runtime phase is wedged", async () => {
+  await accountControllerWedgedInRuntime();
+  let state: "terminal" | "review-pending" | "review-spawning" | "reviewing" = "terminal";
+  let passTransitions = 0;
+  let reviewerLaunches = 0;
+  const controller = new FlowPipelineController({
+    tickPipelines: async () => {
+      if (state === "terminal") {
+        state = "review-pending";
+        passTransitions += 1;
+        return { changed: true };
+      }
+      if (state === "review-pending") {
+        state = "review-spawning";
+        return { changed: true };
+      }
+      return { changed: false };
+    },
+    tickFlows: async () => {
+      if (state === "review-spawning") {
+        state = "reviewing";
+        reviewerLaunches += 1;
+        return { changed: true };
+      }
+      return { changed: false };
+    },
+  });
+
+  await Promise.all([
+    controller.tick("terminal-event"),
+    controller.tick("terminal-event"),
+    controller.tick("terminal-event"),
+  ]);
+
+  expect(state as string).toBe("reviewing");
+  expect(passTransitions).toBe(1);
+  expect(reviewerLaunches).toBe(1);
+});
+
+test("a phase deadline releases the controller and later watchdog ticks keep pipelines moving", async () => {
+  type ManualTimer = { active: boolean; callback: () => void };
+  const timers: ManualTimer[] = [];
+  const heartbeats: FlowPipelineControllerHeartbeat[] = [];
+  const heartbeatFile = path.join(sandbox, "wedged-heartbeat.json");
+  let now = 1_000;
+  let flowCalls = 0;
+  let pipelineCalls = 0;
+  let markFlowStarted = () => {};
+  const flowStarted = new Promise<void>((resolve) => { markFlowStarted = resolve; });
+  const wedged = new Promise<never>(() => {});
+  const ports: FlowPipelineControllerPorts = {
+    tickPipelines: async () => {
+      pipelineCalls += 1;
+      return { changed: false };
+    },
+    tickFlows: async () => {
+      flowCalls += 1;
+      markFlowStarted();
+      return wedged;
+    },
+    now: () => now,
+    scheduleTimeout: (callback) => {
+      const timer = { active: true, callback };
+      timers.push(timer);
+      return timer;
+    },
+    clearTimeout: (timer) => { (timer as ManualTimer).active = false; },
+    publishHeartbeat: (heartbeat) => {
+      heartbeats.push(heartbeat);
+      writeFlowPipelineControllerHeartbeat(heartbeat, heartbeatFile);
+    },
+  };
+  const controller = new FlowPipelineController(ports, { phaseDeadlineMs: 500 });
+
+  const first = controller.tick("terminal-event");
+  await flowStarted;
+  now = 1_500;
+  timers.find((timer) => timer.active)!.callback();
+  await first;
+
+  expect(flowCalls).toBe(1);
+  expect(pipelineCalls).toBe(1);
+  expect(heartbeats).toContainEqual(expect.objectContaining({
+    phase: "flows",
+    state: "timed-out",
+    ageMs: 500,
+    deadlineMs: 500,
+  }));
+  expect(JSON.parse(fs.readFileSync(heartbeatFile, "utf8"))).toMatchObject({
+    phase: "flows",
+    state: "blocked",
+    ageMs: 500,
+    deadlineMs: 500,
+  });
+
+  await controller.poll();
+  expect(flowCalls).toBe(1);
+  expect(pipelineCalls).toBe(2);
+  expect(heartbeats).toContainEqual(expect.objectContaining({
+    phase: "flows",
+    state: "blocked",
+    ageMs: 500,
+  }));
+});
+
+test("startup recovery and the watchdog converge a pending transition without duplicate effects", async () => {
+  let pending = true;
+  let transitions = 0;
+  const controller = new FlowPipelineController({
+    tickPipelines: async () => {
+      if (!pending) return { changed: false };
+      pending = false;
+      transitions += 1;
+      return { changed: true };
+    },
+    tickFlows: async () => ({ changed: false }),
+  });
+
+  await controller.recover();
+  await controller.poll();
+  await controller.poll();
+
+  expect(transitions).toBe(1);
+});
+
+test("pipeline settlement leads the cycle and one scanner snapshot feeds every flow pass", async () => {
+  const entry = { path: "/sessions/reviewer.jsonl" };
+  const calls: string[] = [];
+  let pipelineChanged = true;
+  const ports = {
+    scan: async () => {
+      calls.push("scan");
+      return { files: [entry], complete: true };
+    },
+    tickPipelines: async (...args: unknown[]) => {
+      const files = args[0] as unknown[] | undefined;
+      calls.push(`pipelines:${files?.length ?? 0}`);
+      const changed = pipelineChanged;
+      pipelineChanged = false;
+      return { changed };
+    },
+    tickFlows: async (...args: unknown[]) => {
+      const files = args[0] as unknown[] | undefined;
+      calls.push(`flows:${files?.length ?? 0}`);
+      expect(files).toEqual([entry]);
+      return { changed: false };
+    },
+  } as unknown as FlowPipelineControllerPorts;
+
+  await new FlowPipelineController(ports).tick("terminal-event");
+
+  expect(calls).toEqual([
+    "pipelines:0",
+    "scan",
+    "flows:1",
+    "pipelines:1",
+    "flows:1",
+  ]);
+});

--- a/src/lib/pipelines/controller.ts
+++ b/src/lib/pipelines/controller.ts
@@ -1,0 +1,298 @@
+import crypto from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+
+import { statePath } from "@/lib/configDir";
+import { tickFlows } from "@/lib/flows/engine";
+import { listFilesWithProjectCatalog } from "@/lib/scanner";
+import type { FileEntry } from "@/lib/types";
+
+import { registerPipelineTick } from "./controllerSignal";
+import { tickPipelines } from "./engine";
+
+export type FlowPipelineControllerPhase = "pipelines" | "scan" | "flows" | "idle";
+export type FlowPipelineControllerHeartbeatState =
+  | "running"
+  | "completed"
+  | "timed-out"
+  | "failed"
+  | "blocked"
+  | "idle";
+
+export interface FlowPipelineControllerHeartbeat {
+  schemaVersion: 1;
+  controller: "flow-pipeline";
+  cycle: number;
+  pass: number;
+  trigger: string;
+  phase: FlowPipelineControllerPhase;
+  state: FlowPipelineControllerHeartbeatState;
+  phaseStartedAt: string;
+  updatedAt: string;
+  ageMs: number;
+  deadlineMs: number;
+}
+
+interface TickResult {
+  changed: boolean;
+}
+
+type TimeoutHandle = unknown;
+
+export interface FlowPipelineControllerPorts {
+  scan?: () => Promise<{ files: FileEntry[]; complete: boolean }>;
+  tickPipelines: (entries: FileEntry[]) => Promise<TickResult>;
+  tickFlows: (entries: FileEntry[]) => Promise<TickResult>;
+  now?: () => number;
+  scheduleTimeout?: (callback: () => void, delayMs: number) => TimeoutHandle;
+  clearTimeout?: (timer: TimeoutHandle) => void;
+  publishHeartbeat?: (heartbeat: FlowPipelineControllerHeartbeat) => void;
+  log?: (message: string, error?: unknown) => void;
+}
+
+export interface FlowPipelineControllerOptions {
+  phaseDeadlineMs?: number;
+  maxPasses?: number;
+}
+
+interface ActivePhase<T = unknown> {
+  startedAt: number;
+  promise: Promise<T>;
+}
+
+type PhaseOutcome<T> =
+  | { state: "completed"; value: T }
+  | { state: "timed-out" | "blocked" }
+  | { state: "failed"; error: unknown };
+
+const DEFAULT_PHASE_DEADLINE_MS = 15_000;
+const DEFAULT_MAX_PASSES = 8;
+export const FLOW_PIPELINE_WATCHDOG_MS = 30_000;
+const HEARTBEAT_FILE = "flow-pipeline-controller-heartbeat.json";
+
+export function writeFlowPipelineControllerHeartbeat(
+  heartbeat: FlowPipelineControllerHeartbeat,
+  filename = statePath(HEARTBEAT_FILE),
+): void {
+  fs.mkdirSync(path.dirname(filename), { recursive: true, mode: 0o700 });
+  const temporary = path.join(path.dirname(filename), `.${path.basename(filename)}.${process.pid}.${crypto.randomUUID()}.tmp`);
+  fs.writeFileSync(temporary, `${JSON.stringify(heartbeat, null, 2)}\n`, { encoding: "utf8", mode: 0o600 });
+  fs.renameSync(temporary, filename);
+}
+
+function productionPorts(): FlowPipelineControllerPorts {
+  return {
+    scan: async () => listFilesWithProjectCatalog(undefined, { persist: true }),
+    tickPipelines,
+    tickFlows,
+    publishHeartbeat: writeFlowPipelineControllerHeartbeat,
+  };
+}
+
+export class FlowPipelineController {
+  private running: Promise<void> | null = null;
+  private trailingCycleRequested = false;
+  private trailingTrigger = "signal";
+  private cycle = 0;
+  private readonly activePhases = new Map<Exclude<FlowPipelineControllerPhase, "idle">, ActivePhase>();
+  private readonly ports: Required<FlowPipelineControllerPorts>;
+  private readonly phaseDeadlineMs: number;
+  private readonly maxPasses: number;
+
+  constructor(ports: FlowPipelineControllerPorts, options: FlowPipelineControllerOptions = {}) {
+    this.ports = {
+      ...ports,
+      scan: ports.scan ?? (async () => ({ files: [], complete: true })),
+      now: ports.now ?? Date.now,
+      scheduleTimeout: ports.scheduleTimeout ?? ((callback, delayMs) => setTimeout(callback, delayMs)),
+      clearTimeout: ports.clearTimeout ?? ((timer) => clearTimeout(timer as ReturnType<typeof setTimeout>)),
+      publishHeartbeat: ports.publishHeartbeat ?? (() => undefined),
+      log: ports.log ?? ((message, error) => {
+        if (error === undefined) console.error(message);
+        else console.error(message, error);
+      }),
+    };
+    this.phaseDeadlineMs = options.phaseDeadlineMs ?? DEFAULT_PHASE_DEADLINE_MS;
+    this.maxPasses = options.maxPasses ?? DEFAULT_MAX_PASSES;
+  }
+
+  tick(trigger = "signal"): Promise<void> {
+    if (this.running) {
+      this.trailingCycleRequested = true;
+      this.trailingTrigger = trigger;
+      return this.running;
+    }
+    this.running = this.runRequestedCycles(trigger).finally(() => { this.running = null; });
+    return this.running;
+  }
+
+  poll(): Promise<void> {
+    return this.running ?? this.tick("watchdog");
+  }
+
+  recover(): Promise<void> {
+    return this.tick("startup");
+  }
+
+  private async runRequestedCycles(initialTrigger: string): Promise<void> {
+    let trigger = initialTrigger;
+    do {
+      this.trailingCycleRequested = false;
+      await this.runCycle(trigger);
+      trigger = this.trailingTrigger;
+    } while (this.trailingCycleRequested);
+  }
+
+  private async runCycle(trigger: string): Promise<void> {
+    const cycle = ++this.cycle;
+    let lastPass = 0;
+    let entries: FileEntry[] = [];
+    let scanComplete = false;
+    for (let pass = 1; pass <= this.maxPasses; pass += 1) {
+      lastPass = pass;
+      const pipelineOutcome = await this.runPhase(
+        "pipelines",
+        cycle,
+        pass,
+        trigger,
+        () => this.ports.tickPipelines(entries),
+      );
+      const scanOutcome = pass === 1
+        ? await this.runPhase("scan", cycle, pass, trigger, this.ports.scan)
+        : null;
+      if (scanOutcome?.state === "failed") throw scanOutcome.error;
+      if (scanOutcome?.state === "completed" && scanOutcome.value.complete) {
+        entries = scanOutcome.value.files;
+        scanComplete = true;
+      }
+      const flowOutcome = scanComplete
+        ? await this.runPhase("flows", cycle, pass, trigger, () => this.ports.tickFlows(entries))
+        : null;
+      const failure = pipelineOutcome.state === "failed"
+        ? pipelineOutcome.error
+        : flowOutcome?.state === "failed" ? flowOutcome.error : null;
+      if (failure !== null) throw failure;
+      const changed = (pipelineOutcome.state === "completed" && pipelineOutcome.value.changed)
+        || (flowOutcome?.state === "completed" && flowOutcome.value.changed);
+      if (!changed) break;
+    }
+    const blocked = [...this.activePhases.entries()]
+      .sort((left, right) => left[1].startedAt - right[1].startedAt)[0];
+    if (blocked) {
+      this.publish({
+        cycle,
+        pass: lastPass,
+        trigger,
+        phase: blocked[0],
+        state: "blocked",
+        startedAt: blocked[1].startedAt,
+      });
+    } else {
+      this.publish({
+        cycle,
+        pass: lastPass,
+        trigger,
+        phase: "idle",
+        state: "idle",
+        startedAt: this.ports.now(),
+      });
+    }
+  }
+
+  private async runPhase<T>(
+    phase: Exclude<FlowPipelineControllerPhase, "idle">,
+    cycle: number,
+    pass: number,
+    trigger: string,
+    work: () => Promise<T>,
+  ): Promise<PhaseOutcome<T>> {
+    const active = this.activePhases.get(phase);
+    if (active) {
+      this.publish({ cycle, pass, trigger, phase, state: "blocked", startedAt: active.startedAt });
+      return { state: "blocked" };
+    }
+
+    const startedAt = this.ports.now();
+    this.publish({ cycle, pass, trigger, phase, state: "running", startedAt });
+    const promise = Promise.resolve().then(work);
+    const lease: ActivePhase<T> = { startedAt, promise };
+    this.activePhases.set(phase, lease);
+    void promise.then(
+      () => { if (this.activePhases.get(phase) === lease) this.activePhases.delete(phase); },
+      () => { if (this.activePhases.get(phase) === lease) this.activePhases.delete(phase); },
+    );
+
+    let releaseDeadline = () => {};
+    const deadline = new Promise<{ state: "timed-out" }>((resolve) => { releaseDeadline = () => resolve({ state: "timed-out" }); });
+    const timer = this.ports.scheduleTimeout(releaseDeadline, this.phaseDeadlineMs);
+    const outcome = await Promise.race<PhaseOutcome<T>>([
+      promise.then(
+        (value) => ({ state: "completed", value }),
+        (error) => ({ state: "failed", error }),
+      ),
+      deadline,
+    ]);
+    this.ports.clearTimeout(timer);
+    this.publish({ cycle, pass, trigger, phase, state: outcome.state, startedAt });
+    if (outcome.state === "failed") {
+      this.ports.log(`[flow pipeline controller] ${phase} phase failed`, outcome.error);
+    } else if (outcome.state === "timed-out") {
+      this.ports.log(`[flow pipeline controller] ${phase} phase exceeded its deadline`);
+    }
+    return outcome;
+  }
+
+  private publish(input: {
+    cycle: number;
+    pass: number;
+    trigger: string;
+    phase: FlowPipelineControllerPhase;
+    state: FlowPipelineControllerHeartbeatState;
+    startedAt: number;
+  }): void {
+    const updatedAt = this.ports.now();
+    try {
+      this.ports.publishHeartbeat({
+        schemaVersion: 1,
+        controller: "flow-pipeline",
+        cycle: input.cycle,
+        pass: input.pass,
+        trigger: input.trigger,
+        phase: input.phase,
+        state: input.state,
+        phaseStartedAt: new Date(input.startedAt).toISOString(),
+        updatedAt: new Date(updatedAt).toISOString(),
+        ageMs: Math.max(0, updatedAt - input.startedAt),
+        deadlineMs: this.phaseDeadlineMs,
+      });
+    } catch (error) {
+      this.ports.log("[flow pipeline controller] durable heartbeat publication failed", error);
+    }
+  }
+}
+
+const controllerHost = globalThis as typeof globalThis & {
+  __llvFlowPipelineController?: FlowPipelineController;
+  __llvFlowPipelineWatchdog?: ReturnType<typeof setInterval>;
+  __llvFlowPipelineUnregister?: () => void;
+};
+
+export function flowPipelineController(): FlowPipelineController {
+  return controllerHost.__llvFlowPipelineController ??= new FlowPipelineController(productionPorts());
+}
+
+export function startFlowPipelineController(): void {
+  const controller = flowPipelineController();
+  controllerHost.__llvFlowPipelineUnregister?.();
+  controllerHost.__llvFlowPipelineUnregister = registerPipelineTick(() => controller.tick("signal"));
+  if (!controllerHost.__llvFlowPipelineWatchdog) {
+    const watchdog = setInterval(() => void controller.poll().catch(() => {
+      console.error("[flow pipeline controller] watchdog reconciliation failed");
+    }), FLOW_PIPELINE_WATCHDOG_MS);
+    watchdog.unref?.();
+    controllerHost.__llvFlowPipelineWatchdog = watchdog;
+  }
+  void controller.recover().catch((error) => {
+    console.error("[flow pipeline controller] startup reconciliation failed", error);
+  });
+}

--- a/src/lib/pipelines/controller.ts
+++ b/src/lib/pipelines/controller.ts
@@ -122,7 +122,10 @@ export class FlowPipelineController {
       this.trailingTrigger = trigger;
       return this.running;
     }
-    this.running = this.runRequestedCycles(trigger).finally(() => { this.running = null; });
+    this.running = this.runRequestedCycles(trigger).finally(() => {
+      this.running = null;
+      if (this.trailingCycleRequested) return this.tick(this.trailingTrigger);
+    });
     return this.running;
   }
 

--- a/src/lib/pipelines/controller.ts
+++ b/src/lib/pipelines/controller.ts
@@ -271,6 +271,39 @@ export class FlowPipelineController {
   }
 }
 
+interface FlowPipelineWatchdogHandle {
+  unref?(): unknown;
+}
+
+interface FlowPipelineControllerRuntimePorts {
+  registerTick: (tick: () => Promise<void>) => () => void;
+  scheduleInterval: (callback: () => void, delayMs: number) => FlowPipelineWatchdogHandle;
+  log: (message: string, error: unknown) => void;
+}
+
+interface FlowPipelineControllerRuntimeState {
+  __llvFlowPipelineWatchdog?: FlowPipelineWatchdogHandle;
+  __llvFlowPipelineUnregister?: () => void;
+}
+
+export function startFlowPipelineControllerRuntime(
+  controller: FlowPipelineController,
+  state: FlowPipelineControllerRuntimeState,
+  ports: FlowPipelineControllerRuntimePorts,
+): void {
+  state.__llvFlowPipelineUnregister?.();
+  state.__llvFlowPipelineUnregister = ports.registerTick(() => controller.tick("signal"));
+  if (!state.__llvFlowPipelineWatchdog) {
+    state.__llvFlowPipelineWatchdog = ports.scheduleInterval(() => void controller.poll().catch((error) => {
+      ports.log("[flow pipeline controller] watchdog reconciliation failed", error);
+    }), FLOW_PIPELINE_WATCHDOG_MS);
+    state.__llvFlowPipelineWatchdog.unref?.();
+  }
+  void controller.recover().catch((error) => {
+    ports.log("[flow pipeline controller] startup reconciliation failed", error);
+  });
+}
+
 const controllerHost = globalThis as typeof globalThis & {
   __llvFlowPipelineController?: FlowPipelineController;
   __llvFlowPipelineWatchdog?: ReturnType<typeof setInterval>;
@@ -282,17 +315,13 @@ export function flowPipelineController(): FlowPipelineController {
 }
 
 export function startFlowPipelineController(): void {
-  const controller = flowPipelineController();
-  controllerHost.__llvFlowPipelineUnregister?.();
-  controllerHost.__llvFlowPipelineUnregister = registerPipelineTick(() => controller.tick("signal"));
-  if (!controllerHost.__llvFlowPipelineWatchdog) {
-    const watchdog = setInterval(() => void controller.poll().catch(() => {
-      console.error("[flow pipeline controller] watchdog reconciliation failed");
-    }), FLOW_PIPELINE_WATCHDOG_MS);
-    watchdog.unref?.();
-    controllerHost.__llvFlowPipelineWatchdog = watchdog;
-  }
-  void controller.recover().catch((error) => {
-    console.error("[flow pipeline controller] startup reconciliation failed", error);
-  });
+  startFlowPipelineControllerRuntime(
+    flowPipelineController(),
+    controllerHost,
+    {
+      registerTick: registerPipelineTick,
+      scheduleInterval: (callback, delayMs) => setInterval(callback, delayMs),
+      log: (message, error) => console.error(message, error),
+    },
+  );
 }

--- a/src/lib/viewerInstrumentation.ts
+++ b/src/lib/viewerInstrumentation.ts
@@ -34,6 +34,11 @@ interface ViewerReleaseActivationOptions {
   log?: (...args: unknown[]) => void;
 }
 
+interface CurrentReleaseControllerLoaders {
+  loadFlowPipelineController: () => Promise<{ startFlowPipelineController: () => void }>;
+  loadAccountMigrationController: () => Promise<{ startAccountMigrationController: () => Promise<void> }>;
+}
+
 /** Candidate containers share production state while their health gate runs.
  * The durable proxy target grants authority to the endpoint currently serving
  * traffic. A missing target keeps local development and first boot active. */
@@ -104,6 +109,20 @@ export function scheduleAccountMigrationController(start: () => Promise<void>, d
     else setTimeout(run, 0).unref?.();
   }, delayMs);
   timer.unref?.();
+}
+
+export async function startCurrentReleaseControllers(
+  env: Readonly<Record<string, string | undefined>> = process.env,
+  loaders: CurrentReleaseControllerLoaders = {
+    loadFlowPipelineController: () => import("@/lib/pipelines/controller"),
+    loadAccountMigrationController: () => import("@/lib/accounts/migration/controller"),
+  },
+): Promise<void> {
+  const { startFlowPipelineController } = await loaders.loadFlowPipelineController();
+  startFlowPipelineController();
+  if (env.LLV_ACCOUNT_CONTROLLER_DISABLED === "1") return;
+  const { startAccountMigrationController } = await loaders.loadAccountMigrationController();
+  scheduleAccountMigrationController(startAccountMigrationController, accountControllerDelayMs(env));
 }
 
 export async function initializeOperatorSpawnCapabilityAtStartup(
@@ -184,11 +203,6 @@ export async function registerViewerRuntime(): Promise<void> {
       const { adoptStructuredHostsAtStartup } = await import("@/lib/runtime/startup");
       await runStructuredHostStartup(adoptStructuredHostsAtStartup);
     }
-    if (process.env.LLV_ACCOUNT_CONTROLLER_DISABLED !== "1") {
-      const { startFlowPipelineController } = await import("@/lib/pipelines/controller");
-      startFlowPipelineController();
-      const { startAccountMigrationController } = await import("@/lib/accounts/migration/controller");
-      scheduleAccountMigrationController(startAccountMigrationController, accountControllerDelayMs());
-    }
+    await startCurrentReleaseControllers();
   }, () => viewerReleaseOwnsTraffic());
 }

--- a/src/lib/viewerInstrumentation.ts
+++ b/src/lib/viewerInstrumentation.ts
@@ -185,6 +185,8 @@ export async function registerViewerRuntime(): Promise<void> {
       await runStructuredHostStartup(adoptStructuredHostsAtStartup);
     }
     if (process.env.LLV_ACCOUNT_CONTROLLER_DISABLED !== "1") {
+      const { startFlowPipelineController } = await import("@/lib/pipelines/controller");
+      startFlowPipelineController();
       const { startAccountMigrationController } = await import("@/lib/accounts/migration/controller");
       scheduleAccountMigrationController(startAccountMigrationController, accountControllerDelayMs());
     }

--- a/src/runtime-host/host.ts
+++ b/src/runtime-host/host.ts
@@ -49,6 +49,7 @@ export class RuntimeHost {
     private readonly consumers?: RuntimeConsumerPorts,
     private readonly deployments?: ViewerDeploymentCoordinator,
     private readonly structuredHosts = process.env.LLV_STRUCTURED_HOSTS === "1",
+    private readonly signalFlowPipelineProgress?: () => void,
   ) {}
 
   async recoverConsumers(): Promise<number> {
@@ -118,9 +119,15 @@ export class RuntimeHost {
       );
       else if (request.method === "append" || request.method === "operation") {
         const event = request.params?.event as RuntimeEventInput;
+        const publishedBefore = this.journal.publishedSeq();
         const appended = this.journal.append(event);
+        const newlyPublished = appended.seq > publishedBefore;
         try { await this.consumeExclusive(appended); }
         catch { console.error("[runtime consumer] committed event will retry asynchronously"); }
+        if (newlyPublished && appended.kind === "turn-ended") {
+          try { this.signalFlowPipelineProgress?.(); }
+          catch { console.error("[flow pipeline controller] committed terminal wake failed"); }
+        }
         result = request.method === "operation" && event.operationId
           ? { operationId: event.operationId, state: "accepted", seq: appended.seq, revision: appended.revision }
           : appended;

--- a/src/runtime-host/host.ts
+++ b/src/runtime-host/host.ts
@@ -122,12 +122,12 @@ export class RuntimeHost {
         const publishedBefore = this.journal.publishedSeq();
         const appended = this.journal.append(event);
         const newlyPublished = appended.seq > publishedBefore;
-        try { await this.consumeExclusive(appended); }
-        catch { console.error("[runtime consumer] committed event will retry asynchronously"); }
         if (newlyPublished && appended.kind === "turn-ended") {
           try { this.signalFlowPipelineProgress?.(); }
           catch { console.error("[flow pipeline controller] committed terminal wake failed"); }
         }
+        try { await this.consumeExclusive(appended); }
+        catch { console.error("[runtime consumer] committed event will retry asynchronously"); }
         result = request.method === "operation" && event.operationId
           ? { operationId: event.operationId, state: "accepted", seq: appended.seq, revision: appended.revision }
           : appended;

--- a/src/runtime-host/journal.test.ts
+++ b/src/runtime-host/journal.test.ts
@@ -1290,6 +1290,49 @@ test("runtime host advances and publishes a flow from a terminal event without f
   journal.close();
 });
 
+test("a newly committed terminal event wakes promptly once while flow delivery is pending", async () => {
+  const journal = new RuntimeJournal(path.join(sandbox("terminal-wake-before-consumer"), "events.sqlite"), { maxEvents: 100, now: () => 100 });
+  let releaseFlowReady = () => {};
+  let markFlowReadyStarted = () => {};
+  const flowReadyStarted = new Promise<void>((resolve) => { markFlowReadyStarted = resolve; });
+  const flowReadyGate = new Promise<void>((resolve) => { releaseFlowReady = resolve; });
+  let progressSignals = 0;
+  const host = new RuntimeHost(journal, {
+    flowReady: async (flowId) => {
+      markFlowReadyStarted();
+      await flowReadyGate;
+      return { id: flowId, state: "spawn_pending" } as unknown as Flow;
+    },
+    workflowStageCompleted: () => undefined,
+    taskDeliveryAcknowledged: () => undefined,
+  }, undefined, false, () => { progressSignals += 1; });
+  const request = {
+    method: "append" as const,
+    params: {
+      event: {
+        scope: runtimeScope("session", "implementer"),
+        kind: "turn.completed" as const,
+        producerKey: "terminal-wake-before-consumer",
+        payload: { flowId: "flow-one", readyNote: "REVIEW_READY: finished" },
+      },
+    },
+  };
+
+  const first = host.handle({ id: "request-one", ...request });
+  await flowReadyStarted;
+  const duplicate = host.handle({ id: "request-two", ...request });
+  await Promise.resolve();
+  const signalsWhilePending = progressSignals;
+  releaseFlowReady();
+  const responses = await Promise.all([first, duplicate]);
+
+  expect(responses.every((response) => response.ok)).toBe(true);
+  expect(signalsWhilePending).toBe(1);
+  expect(progressSignals - signalsWhilePending).toBe(0);
+  expect(progressSignals).toBe(1);
+  journal.close();
+});
+
 test("a failed terminal wake keeps the committed runtime acknowledgement successful", async () => {
   const journal = new RuntimeJournal(path.join(sandbox("terminal-wake-failure"), "events.sqlite"), { maxEvents: 100, now: () => 100 });
   const host = new RuntimeHost(journal, undefined, undefined, false, () => {

--- a/src/runtime-host/journal.test.ts
+++ b/src/runtime-host/journal.test.ts
@@ -1233,6 +1233,7 @@ test("runtime host advances and publishes a flow from a terminal event without f
   const dir = sandbox("flow-consumer");
   const journal = new RuntimeJournal(path.join(dir, "events.sqlite"), { maxEvents: 100, now: () => 100 });
   const calls: string[] = [];
+  let progressSignals = 0;
   const host = new RuntimeHost(journal, {
     flowReady: (flowId, note) => {
       calls.push(`${flowId}:${note}`);
@@ -1240,7 +1241,7 @@ test("runtime host advances and publishes a flow from a terminal event without f
     },
     workflowStageCompleted: () => undefined,
     taskDeliveryAcknowledged: () => undefined,
-  });
+  }, undefined, false, () => { progressSignals += 1; });
   await host.handle({
     id: "session-claim",
     method: "append",
@@ -1284,7 +1285,32 @@ test("runtime host advances and publishes a flow from a terminal event without f
   });
   expect(response.ok).toBe(true);
   expect(calls).toEqual(["flow-one:REVIEW_READY: finished"]);
+  expect(progressSignals).toBe(1);
   expect(journal.snapshot().flows[0]).toMatchObject({ revision: 1, value: { id: "flow-one", state: "spawn_pending" } });
+  journal.close();
+});
+
+test("a failed terminal wake keeps the committed runtime acknowledgement successful", async () => {
+  const journal = new RuntimeJournal(path.join(sandbox("terminal-wake-failure"), "events.sqlite"), { maxEvents: 100, now: () => 100 });
+  const host = new RuntimeHost(journal, undefined, undefined, false, () => {
+    throw new Error("wake transport failed");
+  });
+
+  const response = await host.handle({
+    id: "terminal-wake-request",
+    method: "append",
+    params: {
+      event: {
+        scope: runtimeScope("session", "worker"),
+        kind: "turn.completed",
+        producerKey: "terminal-wake-failure",
+        payload: {},
+      },
+    },
+  });
+
+  expect(response.ok).toBe(true);
+  expect(journal.replay(0).events).toHaveLength(1);
   journal.close();
 });
 

--- a/src/runtime-host/main.ts
+++ b/src/runtime-host/main.ts
@@ -5,6 +5,7 @@ discardWakatimeEnvironmentCredential();
 const { statePath } = await import("@/lib/configDir");
 const { procBackend } = await import("@/lib/proc");
 const { createServerRuntimeConsumers } = await import("@/lib/runtime/serverConsumers");
+const { requestPipelineTick } = await import("@/lib/pipelines/controllerSignal");
 const { RuntimeHost, RuntimeHostFence } = await import("./host");
 const { RuntimeJournal } = await import("./journal");
 const { createLegacyRuntimeScheduler } = await import("./legacyScheduler");
@@ -36,7 +37,7 @@ const deployments = deploymentAdapterPath
     { pid: process.pid, startIdentity: procBackend.processIdentity(process.pid) },
   )
   : undefined;
-const host = new RuntimeHost(journal, createServerRuntimeConsumers(), deployments);
+const host = new RuntimeHost(journal, createServerRuntimeConsumers(), deployments, undefined, requestPipelineTick);
 const deploymentProxy = deployments
   ? serveViewerDeploymentProxy(
     process.env.LLV_VIEWER_DEPLOY_TARGET || statePath("viewer-release.json"),


### PR DESCRIPTION
Closes #457

## Summary

- wake pipeline and flow transitions from durable terminal events
- coalesce producer wakes while preserving consumer retry and deduplication
- start current-release recovery and watchdog independently from account migration
- retain a wake across the controller settlement boundary

## Verification

- controller suite: 6/6
- controller and pipeline engine: 113/113
- runtime and release cluster: 82/82
- 19 acceptance-relevant reviewer tests
- TypeScript
- changed-file ESLint
- production build
- standard and pinned-base privacy gates
- fresh exact-head review: NO FINDINGS, confidence 0.98
