### PR TITLE
fix(migration): project terminal OAuth and rate-limit turn state (#516)

### DIFF
--- a/src/lib/accounts/migration/coordinator.test.ts
+++ b/src/lib/accounts/migration/coordinator.test.ts
@@ -3224,6 +3224,84 @@ describe("durable account migration coordinator", () => {
     expect(advanced.migration?.phase).toBe("committed");
   });
 
+  test("a dead null-host Claude OAuth failure releases the waiting-turn reseat exactly once", async () => {
+    /* Issue #516: the Claude CLI died on an OAuth failure — the transcript
+       ends in a structured `authentication_failed` API-error record and no
+       host remains to append a `result` record. The reseat must read that
+       record as the terminal turn, create exactly one successor, and send the
+       held stable clientMessageId to the successor once — across registry
+       restarts and repeated ticks, never to the predecessor. */
+    const store = registry();
+    const pathname = path.join(path.dirname(store.filename), "oauth-dead-source.jsonl");
+    const successorPath = "/oauth-successor.jsonl";
+    fs.writeFileSync(pathname, JSON.stringify({
+      type: "user",
+      timestamp: "2026-07-17T15:00:00.000Z",
+      message: { role: "user", content: [{ type: "text", text: "continue" }] },
+    }) + "\n");
+    store.reconcileConversations([{
+      ...observation(pathname, "expired", "busy"),
+      engine: "claude",
+    }]);
+    const conversation = store.conversationForPath(pathname)!;
+    expect(conversation.generations.at(-1)?.host ?? null).toBeNull();
+    expect(store.requestConversationReseat(conversation.id, "healthy").migration?.phase).toBe("waiting-turn");
+    const held = store.holdDelivery(conversation.id, "continue after reseat", "oauth-held-client");
+    expect(held).toMatchObject({ state: "held", generationId: null, clientMessageId: "oauth-held-client" });
+
+    fs.appendFileSync(pathname, JSON.stringify({
+      type: "assistant",
+      timestamp: "2026-07-17T15:00:01.000Z",
+      isApiErrorMessage: true,
+      error: "authentication_failed",
+      message: {
+        role: "assistant",
+        model: "<synthetic>",
+        stop_reason: "stop_sequence",
+        stop_sequence: "",
+        content: [{ type: "text", text: "OAuth authentication failed · run /login" }],
+      },
+    }) + "\n");
+    const entry = inventoryEntry(pathname, {
+      root: "claude-projects",
+      engine: "claude",
+      fmt: "claude",
+      model: "claude-fable-5",
+      activity: "stalled",
+      activityReason: undefined,
+    });
+    const counts = { create: 0, verify: 0 };
+    const migrationProvider = provider([successorPath], counts);
+    const sends: { path: string; clientMessageId: string }[] = [];
+    const deliveryPort = {
+      async deliver(input: { path: string; clientMessageId: string }) {
+        sends.push({ path: input.path, clientMessageId: input.clientMessageId });
+        return "delivered" as const;
+      },
+    };
+
+    await reconcileMigrationInventory(store, [entry]);
+    expect(store.conversation(conversation.id)?.turn.state).toBe("terminal");
+    await reconcileMigrations(migrationProvider, deliveryPort, store);
+    const committed = store.conversation(conversation.id)!;
+    expect(committed.migration?.phase).toBe("committed");
+    expect(counts.create).toBe(1);
+    expect(committed.generations).toHaveLength(2);
+    expect(committed.generations.at(-1)?.path).toBe(successorPath);
+    expect(sends).toEqual([{ path: successorPath, clientMessageId: "oauth-held-client" }]);
+    expect(store.pendingDeliveries(conversation.id)).toEqual([]);
+
+    const restarted = new AgentRegistry(store.filename);
+    await reconcileMigrations(migrationProvider, deliveryPort, restarted);
+    await reconcileMigrations(migrationProvider, deliveryPort, restarted);
+    await advanceConversationMigration(conversation.id, restarted, migrationProvider);
+    expect(counts.create).toBe(1);
+    expect(sends).toEqual([{ path: successorPath, clientMessageId: "oauth-held-client" }]);
+    expect(restarted.conversation(conversation.id)?.migration?.phase).toBe("committed");
+    expect(restarted.conversation(conversation.id)?.generations).toHaveLength(2);
+    expect(restarted.pendingDeliveries(conversation.id)).toEqual([]);
+  });
+
   test("a conversation reseat completes without booking the engine auto-balance outcome or cooldown", async () => {
     const store = registry();
     store.reconcileConversations([

--- a/src/lib/accounts/migration/coordinator.test.ts
+++ b/src/lib/accounts/migration/coordinator.test.ts
@@ -3229,8 +3229,10 @@ describe("durable account migration coordinator", () => {
        ends in a structured `authentication_failed` API-error record and no
        host remains to append a `result` record. The reseat must read that
        record as the terminal turn, create exactly one successor, and send the
-       held stable clientMessageId to the successor once — across registry
-       restarts and repeated ticks, never to the predecessor. */
+       held stable clientMessageId to the successor once — even when the
+       process crashes right after the terminal inventory is persisted, so the
+       whole release runs through a reopened registry — and repeated ticks
+       stay stable, never sending to the predecessor. */
     const store = registry();
     const pathname = path.join(path.dirname(store.filename), "oauth-dead-source.jsonl");
     const successorPath = "/oauth-successor.jsonl";
@@ -3271,7 +3273,15 @@ describe("durable account migration coordinator", () => {
       activityReason: undefined,
     });
     const counts = { create: 0, verify: 0 };
-    const migrationProvider = provider([successorPath], counts);
+    const baseProvider = provider([successorPath], counts);
+    const createdOperations: string[] = [];
+    const migrationProvider: SuccessorProviderPort = {
+      ...baseProvider,
+      async create(input) {
+        createdOperations.push(input.operationId);
+        return baseProvider.create(input);
+      },
+    };
     const sends: { path: string; clientMessageId: string }[] = [];
     const deliveryPort = {
       async deliver(input: { path: string; clientMessageId: string }) {
@@ -3282,22 +3292,35 @@ describe("durable account migration coordinator", () => {
 
     await reconcileMigrationInventory(store, [entry]);
     expect(store.conversation(conversation.id)?.turn.state).toBe("terminal");
-    await reconcileMigrations(migrationProvider, deliveryPort, store);
-    const committed = store.conversation(conversation.id)!;
+    const operationId = store.conversation(conversation.id)!.migration!.operationId;
+
+    /* Crash boundary: the process dies right after the terminal inventory is
+       persisted — before migration reconciliation, successor commit, or
+       delivery. Every recovery pass runs through the reopened registry. */
+    const restarted = new AgentRegistry(store.filename);
+    expect(restarted.conversation(conversation.id)?.turn.state).toBe("terminal");
+    await reconcileMigrations(migrationProvider, deliveryPort, restarted);
+    const committed = restarted.conversation(conversation.id)!;
     expect(committed.migration?.phase).toBe("committed");
+    expect(committed.migration?.operationId).toBe(operationId);
+    expect(createdOperations).toEqual([operationId]);
     expect(counts.create).toBe(1);
     expect(committed.generations).toHaveLength(2);
     expect(committed.generations.at(-1)?.path).toBe(successorPath);
     expect(sends).toEqual([{ path: successorPath, clientMessageId: "oauth-held-client" }]);
-    expect(store.pendingDeliveries(conversation.id)).toEqual([]);
+    expect(sends.filter((send) => send.path === pathname)).toHaveLength(0);
+    expect(restarted.snapshot().migrationIntents[committed.migration!.intentId]).toMatchObject({ scope: "conversation", state: "complete" });
+    expect(restarted.pendingDeliveries(conversation.id)).toEqual([]);
 
-    const restarted = new AgentRegistry(store.filename);
     await reconcileMigrations(migrationProvider, deliveryPort, restarted);
+    await drainHeldDeliveries(conversation.id, deliveryPort, restarted);
     await reconcileMigrations(migrationProvider, deliveryPort, restarted);
     await advanceConversationMigration(conversation.id, restarted, migrationProvider);
     expect(counts.create).toBe(1);
+    expect(createdOperations).toEqual([operationId]);
     expect(sends).toEqual([{ path: successorPath, clientMessageId: "oauth-held-client" }]);
     expect(restarted.conversation(conversation.id)?.migration?.phase).toBe("committed");
+    expect(restarted.conversation(conversation.id)?.migration?.operationId).toBe(operationId);
     expect(restarted.conversation(conversation.id)?.generations).toHaveLength(2);
     expect(restarted.pendingDeliveries(conversation.id)).toEqual([]);
   });

--- a/src/lib/accounts/migration/turnState.test.ts
+++ b/src/lib/accounts/migration/turnState.test.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
 
 import { turnStateFromRecords } from "./turnState";
 
@@ -78,5 +78,114 @@ test("Claude migration waits for a top-level result event", () => {
     state: "terminal",
     source: "lifecycle",
     terminalAt: "2026-07-10T00:00:02Z",
+  });
+});
+
+describe("issue 516 — structured Claude API-error records project the terminal turn", () => {
+  const user = (timestamp: string) => ({
+    type: "user",
+    timestamp,
+    message: { role: "user", content: [{ type: "text", text: "continue" }] },
+  });
+  const workingAssistant = (timestamp: string) => ({
+    type: "assistant",
+    timestamp,
+    message: { role: "assistant", stop_reason: null, content: [{ type: "text", text: "working" }] },
+  });
+  const apiError = (timestamp: string, error: string | null, flagged = true, stop: string | null = "stop_sequence") => ({
+    type: "assistant",
+    timestamp,
+    isApiErrorMessage: flagged,
+    ...(error === null ? {} : { error }),
+    message: { role: "assistant", model: "<synthetic>", stop_reason: stop, content: [{ type: "text", text: "API Error" }] },
+  });
+  const result = (timestamp: string) => ({ type: "result", timestamp, subtype: "success" });
+
+  const authoritativeCases: {
+    name: string;
+    records: Record<string, unknown>[];
+    expected: { state: string; source: string; terminalAt: string | null };
+  }[] = [
+    {
+      name: "an authentication_failed API error closes the turn as lifecycle-terminal",
+      records: [user("2026-07-17T15:00:00Z"), apiError("2026-07-17T15:00:01Z", "authentication_failed")],
+      expected: { state: "terminal", source: "lifecycle", terminalAt: "2026-07-17T15:00:01Z" },
+    },
+    {
+      name: "a rate_limit API error closes the turn as lifecycle-terminal",
+      records: [user("2026-07-17T15:00:00Z"), apiError("2026-07-17T15:00:01Z", "rate_limit")],
+      expected: { state: "terminal", source: "lifecycle", terminalAt: "2026-07-17T15:00:01Z" },
+    },
+    {
+      name: "an unknown API error code keeps the busy-assistant projection",
+      records: [user("2026-07-17T15:00:00Z"), apiError("2026-07-17T15:00:01Z", "model_not_found")],
+      expected: { state: "busy", source: "assistant", terminalAt: null },
+    },
+    {
+      name: "a flagged API error without a structured code keeps the busy-assistant projection",
+      records: [user("2026-07-17T15:00:00Z"), apiError("2026-07-17T15:00:01Z", null)],
+      expected: { state: "busy", source: "assistant", terminalAt: null },
+    },
+    {
+      name: "a terminal error code on an unflagged assistant record keeps the busy-assistant projection",
+      records: [user("2026-07-17T15:00:00Z"), apiError("2026-07-17T15:00:01Z", "authentication_failed", false)],
+      expected: { state: "busy", source: "assistant", terminalAt: null },
+    },
+    {
+      name: "a newer user record reopens the turn after a terminal API error",
+      records: [
+        user("2026-07-17T15:00:00Z"),
+        apiError("2026-07-17T15:00:01Z", "authentication_failed"),
+        user("2026-07-17T15:00:02Z"),
+      ],
+      expected: { state: "busy", source: "lifecycle", terminalAt: null },
+    },
+    {
+      name: "a newer ordinary assistant record reopens the turn after a terminal API error",
+      records: [
+        user("2026-07-17T15:00:00Z"),
+        apiError("2026-07-17T15:00:01Z", "rate_limit"),
+        workingAssistant("2026-07-17T15:00:02Z"),
+      ],
+      expected: { state: "busy", source: "assistant", terminalAt: null },
+    },
+    {
+      name: "a later result record stays terminal at its own timestamp",
+      records: [
+        user("2026-07-17T15:00:00Z"),
+        apiError("2026-07-17T15:00:01Z", "authentication_failed"),
+        result("2026-07-17T15:00:02Z"),
+      ],
+      expected: { state: "terminal", source: "lifecycle", terminalAt: "2026-07-17T15:00:02Z" },
+    },
+  ];
+
+  for (const { name, records, expected } of authoritativeCases) {
+    test(`authoritative: ${name}`, () => {
+      expect(turnStateFromRecords(records, false, true)).toEqual(expected as ReturnType<typeof turnStateFromRecords>);
+    });
+  }
+
+  test("activity: a terminal API error without a stop reason closes the turn", () => {
+    const records = [user("2026-07-17T15:00:00Z"), apiError("2026-07-17T15:00:01Z", "authentication_failed", true, null)];
+    expect(turnStateFromRecords(records, false)).toEqual({
+      state: "terminal",
+      source: "lifecycle",
+      terminalAt: "2026-07-17T15:00:01Z",
+    });
+  });
+
+  test("activity: an unknown API error without a stop reason keeps the busy-assistant projection", () => {
+    const records = [user("2026-07-17T15:00:00Z"), apiError("2026-07-17T15:00:01Z", "model_not_found", true, null)];
+    expect(turnStateFromRecords(records, false)).toEqual({ state: "busy", source: "assistant", terminalAt: null });
+  });
+
+  test("activity: an ordinary stop_sequence assistant record keeps its terminal projection", () => {
+    const records = [user("2026-07-17T15:00:00Z"), apiError("2026-07-17T15:00:01Z", null, false)];
+    expect(turnStateFromRecords(records, false)).toEqual({
+      state: "terminal",
+      source: "lifecycle",
+      terminalAt: "2026-07-17T15:00:01Z",
+    });
   });
 });

--- a/src/lib/accounts/migration/turnState.ts
+++ b/src/lib/accounts/migration/turnState.ts
@@ -9,6 +9,18 @@ function timestamp(record: RecordLike): string | null {
   return typeof value === "string" ? value : null;
 }
 
+/** Structured API-error verdicts after which the Claude CLI surrenders the
+    turn for good: no `result` record will ever follow, so the flagged record
+    itself is the terminal lifecycle evidence (issue #516). Other error codes
+    keep the busy projection because the CLI may retry within the same turn. */
+const TERMINAL_API_ERRORS = new Set(["authentication_failed", "rate_limit"]);
+
+function terminalApiError(record: RecordLike): boolean {
+  return record.isApiErrorMessage === true
+    && typeof record.error === "string"
+    && TERMINAL_API_ERRORS.has(record.error);
+}
+
 /** The newest authoritative lifecycle or tool event wins. Assistant prose
     cannot close an active turn because it commonly precedes tool work. */
 export function turnStateFromRecords(records: RecordLike[], codex: boolean, authoritative = false): TurnState {
@@ -77,7 +89,9 @@ export function turnStateFromRecords(records: RecordLike[], codex: boolean, auth
       } else if (record.type === "user") {
         state = { state: "busy", source: "lifecycle", terminalAt: null };
       } else if (record.type === "assistant") {
-        state = { state: "busy", source: "assistant", terminalAt: null };
+        state = terminalApiError(record)
+          ? { state: "terminal", source: "lifecycle", terminalAt: timestamp(record) }
+          : { state: "busy", source: "assistant", terminalAt: null };
       }
     }
     return state;
@@ -85,6 +99,7 @@ export function turnStateFromRecords(records: RecordLike[], codex: boolean, auth
 
   for (const record of [...records].reverse()) {
     if (record.type === "assistant") {
+      if (terminalApiError(record)) return { state: "terminal", source: "lifecycle", terminalAt: timestamp(record) };
       const stop = stringValue((recordValue(record.message) ?? {}).stop_reason);
       if (stop === "end_turn" || stop === "stop_sequence") return { state: "terminal", source: "lifecycle", terminalAt: timestamp(record) };
       return { state: "busy", source: "assistant", terminalAt: null };


### PR DESCRIPTION
## Summary

Implements the passed diagnosis from pipeline c7e214a7 for issue #516.

A Claude session that dies on an OAuth or rate-limit failure ends its transcript with a structured assistant API-error record (`isApiErrorMessage: true` plus a top-level `error` code) and no live host remains to append a `result` record. The authoritative turn projection in `turnStateFromRecords` classified every assistant record as busy, so the conversation never read terminal, `successorCreationReady` never released, and the reseat parked in `waiting-turn` forever with its held send fenced.

## Change

`src/lib/accounts/migration/turnState.ts` now classifies a flagged assistant API-error record as lifecycle-terminal **only** when `isApiErrorMessage === true` and the structured `error` code is `authentication_failed` or `rate_limit` (record shape verified against real Claude CLI transcripts). Applied in both the authoritative and the activity projections. Record ordering is preserved:

- a newer user or ordinary assistant record reopens the busy turn,
- a later `result` record stays terminal at its own timestamp,
- ordinary `stop_sequence` records and unknown API error codes (`model_not_found`, unflagged records, missing codes) keep their current behavior.

Codex projection is untouched.

## Tests (RED-first)

- `turnState.test.ts`: table-driven coverage over both projections — the two terminal codes, unknown/unflagged/missing codes, reopen-by-user, reopen-by-assistant, later-result precedence, and the no-stop-reason activity case. The three defect-shaped cases failed before the fix and pass after; every preserved-behavior case passed both before and after.
- `coordinator.test.ts`: one integration regression proving a dead null-host OAuth failure leaves `waiting-turn`, creates exactly one successor, sends the held stable `clientMessageId` once to the successor path, survives a registry restart plus repeated reconcile/advance ticks with no duplicate creation or send, and never delivers to the predecessor.

## Verification

- `bun test src/lib/accounts/migration/turnState.test.ts` — 15 pass.
- `bun test src/lib/accounts/migration/coordinator.test.ts` — 85 pass.
- Broad gate `bun test src/lib/accounts src/lib/scanner src/lib/runtime src/lib/pipelines` — 1281 pass, 0 fail.
- Full `bun test` — 4928 pass / 24 fail; the same 24 tests fail identically on the base commit (pre-existing environment/UI failures, verified via stash run), none touch this change.
- `bunx tsc --noEmit` — clean. `bun run lint` — only pre-existing findings in `scripts/*.cjs` and `reaperRuntime.ts`; changed files are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)