### PR TITLE
Flatten expanded tool details

### DIFF
--- a/src/components/feed/cards/OrchestrationCard.tsx
+++ b/src/components/feed/cards/OrchestrationCard.tsx
@@ -1,42 +1,44 @@
 "use client";
 
-import { GlyphIcon } from "../../icons";
+import { ChevronRight, GlyphIcon } from "../../icons";
 import { tr, type NestedCall, type Orchestration } from "../parse";
 
 /* One inner operation of a functions.exec record: its icon and target/command
-   summary. Four concurrent tools read as four distinct structured children.
-   The transcript stores the combined result on the outer event and omits
-   per-call status/output, so each child shows parsed data only. */
+   summary, rendered as a bare quiet line on the shared well. Four concurrent
+   tools read as four distinct rows. The summary wraps so a long command stays
+   fully visible. The transcript stores the combined result on the outer event
+   and omits per-call status/output, so each child shows parsed data only. */
 function NestedRow({ call }: { call: NestedCall }) {
   return (
-    <div className="flex items-center gap-2 rounded-[10px] border border-border bg-card px-2.5 py-1 text-[11.5px]">
-      <span className="flex h-4.5 w-4.5 shrink-0 items-center justify-center rounded-md bg-sunken">
-        <GlyphIcon name={call.icon} className="h-3 w-3" />
-      </span>
-      <span className="min-w-0 flex-1 truncate" title={call.summary}>
-        {call.summary}
-      </span>
+    <div className="flex items-start gap-2 py-0.5 font-mono text-[11.5px] text-secondary">
+      <GlyphIcon name={call.icon} className="mt-0.5 h-3.5 w-3.5 shrink-0 text-muted" />
+      <span className="min-w-0 flex-1 [overflow-wrap:anywhere]">{call.summary}</span>
     </div>
   );
 }
 
 /** The structured detail of a `functions.exec` orchestration record: the nested
-    calls (level 1) and the full JavaScript source (level 2). */
+    calls (level 1) and the full JavaScript source (level 2). Both live flat on
+    the parent's sunken well — a small stream label plus a hairline separator
+    stand in for the old nested borders. */
 export function OrchestrationCard({ orchestration, source }: { orchestration: Orchestration; source?: string }) {
   return (
     <div className="mt-1.5 space-y-1.5">
       {orchestration.calls.length ? (
-        <div className="space-y-1">
-          <div className="text-[10.5px] font-semibold text-secondary">{tr("tools.nestedCalls")}</div>
+        <div>
+          <div className="mb-0.5 text-[10.5px] font-semibold uppercase tracking-wide text-muted">{tr("tools.nestedCalls")}</div>
           {orchestration.calls.map((call, i) => (
             <NestedRow key={`${call.id}:${i}`} call={call} />
           ))}
         </div>
       ) : null}
       {orchestration.source.trim() || source?.trim() ? (
-        <details className="overflow-hidden rounded-[10px] border border-border bg-sunken">
-          <summary className="cursor-pointer list-none px-2.5 py-1 text-[11px] font-semibold text-muted">{tr("tools.source")}</summary>
-          <pre className="max-h-[300px] max-w-full overflow-auto whitespace-pre border-t border-border px-3 py-2 font-mono text-[11px]">
+        <details className="group/src">
+          <summary className="inline-flex cursor-pointer list-none items-center gap-1 text-[11px] font-semibold text-muted hover:text-accent [&::-webkit-details-marker]:hidden">
+            <ChevronRight className="h-3 w-3 transition-transform group-open/src:rotate-90" aria-hidden />
+            {tr("tools.source")}
+          </summary>
+          <pre className="mt-1 max-h-[300px] max-w-full overflow-auto whitespace-pre-wrap [overflow-wrap:anywhere] border-t border-border pt-1.5 font-mono text-[11px]">
             {orchestration.source || source}
             {orchestration.sourceTruncated ? "\n…" : ""}
           </pre>

--- a/src/components/feed/cards/OutputPreview.tsx
+++ b/src/components/feed/cards/OutputPreview.tsx
@@ -41,13 +41,13 @@ export function OutputPreview({
 }) {
   const [all, setAll] = useState(false);
   const label = heading ? (
-    <div className={`mb-1 text-[10.5px] font-semibold uppercase tracking-wide ${tone === "err" ? "text-danger" : "text-muted"}`}>{heading}</div>
+    <div className={`mb-0.5 text-[10.5px] font-semibold uppercase tracking-wide ${tone === "err" ? "text-danger" : "text-muted"}`}>{heading}</div>
   ) : null;
   if (!output.trim()) {
     return (
       <div className="mt-1.5">
         {label}
-        <span className="inline-flex items-center rounded-md bg-sunken px-2 py-0.5 text-[11px] text-muted" title={emptyTip ?? tr("tools.noOutputTip")}>
+        <span className="text-[11px] text-muted" title={emptyTip ?? tr("tools.noOutputTip")}>
           {emptyLabel ?? tr("tools.noOutput")}
         </span>
       </div>
@@ -56,21 +56,23 @@ export function OutputPreview({
   const lines = output.split("\n");
   const overflow = lines.length > PREVIEW_LINES || output.length > PREVIEW_CHARS;
   const shown = all ? output : lines.slice(0, PREVIEW_LINES).join("\n").slice(0, PREVIEW_CHARS);
-  const border = tone === "err" ? "border-danger/40" : "border-border";
+  /* stderr keeps a thin danger left-edge so the failing stream stays scannable
+     without wrapping the whole block in its own bordered card. */
+  const edge = tone === "err" ? "border-l-2 border-danger/50 pl-2" : "";
   return (
     <div className="group/out relative mt-1.5">
       {label}
       {all && lang ? (
         <CodeBlock code={shown} lang={lang} />
       ) : (
-        <pre className={`max-h-[420px] max-w-full overflow-auto whitespace-pre-wrap [overflow-wrap:anywhere] rounded-[10px] border ${border} bg-sunken px-3 py-2 font-mono text-[12px]`}>
+        <pre className={`max-h-[420px] max-w-full overflow-auto whitespace-pre-wrap [overflow-wrap:anywhere] pr-8 font-mono text-[12px] text-secondary ${edge}`}>
           {shown}
         </pre>
       )}
       <CopyButton
         text={output}
         label={copyLabel ?? tr("tools.copyOutput")}
-        className={`absolute right-1.5 opacity-0 transition-opacity motion-reduce:transition-none focus-visible:opacity-100 group-hover/out:opacity-100 [@media(hover:none)]:opacity-60 ${heading ? "top-6" : "top-1.5"}`}
+        className={`absolute right-0 opacity-0 transition-opacity motion-reduce:transition-none focus-visible:opacity-100 group-hover/out:opacity-100 [@media(hover:none)]:opacity-60 ${heading ? "top-5" : "top-0"}`}
       />
       {overflow ? (
         <button

--- a/src/components/feed/cards/ToolCard.tsx
+++ b/src/components/feed/cards/ToolCard.tsx
@@ -44,9 +44,10 @@ function exitLabel(event: ToolEvent): string | null {
   return null;
 }
 
-/* One quiet metadata row over the command: cwd, wall-clock span, duration, and
-   exit status — the auditable header a terminal client shows. Renders nothing
-   when a call carries none of them (a plain non-shell tool). */
+/* One quiet metadata row over the command: exit status, duration, wall-clock
+   span, and cwd — the auditable header a terminal client shows, folded into a
+   single wrapping line so it never stacks into its own multi-row card. Renders
+   nothing when a call carries none of them (a plain non-shell tool). */
 function ToolMeta({ event }: { event: ToolEvent }) {
   const start = hhmm(event.ts);
   const end = event.endTs !== undefined ? hhmm(event.endTs) : "";
@@ -55,47 +56,47 @@ function ToolMeta({ event }: { event: ToolEvent }) {
   const exit = exitLabel(event);
   if (!event.cwd && !span && !duration && !exit) return null;
   return (
-    <div className="mb-1.5 flex flex-col gap-1 text-[11px] text-muted">
-      <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
-        {exit ? (
-          <span className={`inline-flex items-center gap-1 font-semibold ${statusClass(event.status)}`}>
-            <StatusIcon status={event.status} className="h-3 w-3" />
-            {exit}
-          </span>
-        ) : null}
-        {duration ? (
-          <span className="inline-flex items-center gap-1 tabular-nums">
-            <AlarmClock className="h-3 w-3" aria-hidden />
-            {duration}
-          </span>
-        ) : null}
-        {span ? <span className="tabular-nums">{span}</span> : null}
-      </div>
+    <div className="mb-1 flex min-w-0 flex-wrap items-center gap-x-3 gap-y-0.5 text-[11px] text-muted">
+      {exit ? (
+        <span className={`inline-flex items-center gap-1 font-semibold ${statusClass(event.status)}`}>
+          <StatusIcon status={event.status} className="h-3 w-3" />
+          {exit}
+        </span>
+      ) : null}
+      {duration ? (
+        <span className="inline-flex items-center gap-1 tabular-nums">
+          <AlarmClock className="h-3 w-3" aria-hidden />
+          {duration}
+        </span>
+      ) : null}
+      {span ? <span className="tabular-nums">{span}</span> : null}
       {event.cwd ? (
-        <div className="flex min-w-0 items-center gap-1">
-          <span className="shrink-0 uppercase tracking-wide text-[10px]">{tr("tools.cwd")}</span>
-          <code className="min-w-0 flex-1 truncate font-mono text-[11px] text-secondary" title={event.cwd}>
+        <span className="inline-flex min-w-0 max-w-full items-center gap-1">
+          <code className="min-w-0 truncate font-mono text-[11px] text-secondary" title={event.cwd}>
             {event.cwd}
           </code>
           <CopyButton text={event.cwd} label={tr("tools.copyCwd")} className="shrink-0 p-0.5" />
-        </div>
+        </span>
       ) : null}
     </div>
   );
 }
 
-/* The full redacted command with a copy control, wrapped instead of scrolled so
-   a long line never forces document-level horizontal overflow on 390px. */
+/* The full redacted command, the hero of the block: bare monospace on the
+   shared sunken well (no nested card/border — those only stacked chrome the
+   user did not open), wrapped instead of scrolled so a long line stays fully
+   visible and never forces document-level horizontal overflow on 390px. */
 function CommandBlock({ command }: { command: string }) {
   return (
     <div className="group/cmd relative">
-      <pre className="max-w-full whitespace-pre-wrap [overflow-wrap:anywhere] rounded-control border border-border bg-card py-1.5 pl-3 pr-10 font-mono text-ui">
-        {"$ " + command}
+      <pre className="max-w-full whitespace-pre-wrap [overflow-wrap:anywhere] py-0.5 pr-10 font-mono text-ui text-primary">
+        <span className="select-none text-muted">$ </span>
+        {command}
       </pre>
       <CopyButton
         text={command}
         label={tr("tools.copyCommand")}
-        className="absolute right-1.5 top-1.5 opacity-0 transition-opacity motion-reduce:transition-none focus-visible:opacity-100 group-hover/cmd:opacity-100 [@media(hover:none)]:opacity-60"
+        className="absolute right-0 top-0 opacity-0 transition-opacity motion-reduce:transition-none focus-visible:opacity-100 group-hover/cmd:opacity-100 [@media(hover:none)]:opacity-60"
       />
     </div>
   );
@@ -128,9 +129,9 @@ function RawRecord({ event }: { event: ToolEvent }) {
         <CopyButton text={event.id} label={tr("tools.copyId")} className="p-0.5" />
       </div>
       {record ? (
-        <pre className="max-h-[300px] max-w-full overflow-auto whitespace-pre-wrap [overflow-wrap:anywhere] rounded-[10px] border border-border bg-sunken px-3 py-2 font-mono text-[11px]">{record}</pre>
+        <pre className="max-h-[300px] max-w-full overflow-auto whitespace-pre-wrap [overflow-wrap:anywhere] border-t border-border pt-1.5 font-mono text-[11px]">{record}</pre>
       ) : (
-        <span className="inline-flex items-center rounded-md bg-sunken px-2 py-0.5 text-[11px] text-muted">{tr("tools.noRawRecord")}</span>
+        <span className="text-[11px] text-muted">{tr("tools.noRawRecord")}</span>
       )}
     </div>
   );
@@ -150,7 +151,7 @@ export function ToolBody({ event }: { event: ToolEvent }) {
   const emptyPoll = isCollapsiblePoll(event);
   const showOutput = !emptyFollowUp && (!hasDiff || Boolean(event.outputPreview.trim()));
   return (
-    <div className="mb-1 mt-1 rounded-surface bg-sunken px-3 py-2.5">
+    <div className="mb-1 mt-1 rounded-surface bg-sunken px-2.5 py-2">
       <ToolChips chips={event.chips} />
       <ToolMeta event={event} />
       {event.command ? <CommandBlock command={event.command} /> : null}


### PR DESCRIPTION
## Summary

- flatten command, output, nested-call, source, and raw-record details into one readable well
- preserve full wrapped commands and compact metadata on desktop and mobile
- retain stderr emphasis, copy controls, provenance disclosure, and raw-record access

## Verification

- `bun test src/components/feed` — 206 passed
- `git diff --check`
- synthetic visual acceptance at desktop width and 390 px mobile width
- zero TypeScript errors under `src/`
