### PR TITLE
fix(scanner): process-wide scan coordination, split caches, bounded resumable readers (#287)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ versions follow [SemVer](https://semver.org/) (0.x — the API may still move).
 ## [Unreleased]
 
 ### Fixed
+- Multi-gigabyte active transcripts no longer starve the Viewer (#287). One
+  process-wide scan coordinator now owns every catalog generation: the HTTP
+  files cache, the pipeline watchdog, and the account controller join or queue
+  behind a single scan instead of multiplying corpus reads, with pinned
+  refreshes holding an exclusive lease so their pin overlay never leaks into
+  the shared catalog. The remaining open-ended readers honor hard byte
+  budgets — authorship proofs resume from persisted checkpoints at 4 MiB per
+  path inside a 32 MiB cycle budget, and lineage needle scans cap one
+  candidate at 1 MiB inside a 256 KiB generation budget — proven against
+  logical 3 GiB transcripts. Transcript-derived metadata now caches by file
+  identity alone, so project-state reconciliation recomputes only the
+  project/worktree overlay instead of evicting the corpus-wide cache. Runtime
+  host responses settle exactly once and every read-only host request carries
+  the caller's abort signal, ending the late `socket.end` writes
+  (`ERR_STREAM_ALREADY_FINISHED`) after client timeouts.
 - Two #507 final-review repairs. (1) An aged-idle passed stage on a
   cursor-bearing active pipeline stays the ONE real stage conversation card. The
   board ran two independent derivations over the same scan — the idle-worker

--- a/src/app/api/files/route.test.ts
+++ b/src/app/api/files/route.test.ts
@@ -416,6 +416,9 @@ test("concurrent fresh callers share one pending generation through failure and 
     return scan;
   });
 
+  // The scan coordinator starts the merged generation one microtask after the
+  // callers enqueue (#287); both retries still share exactly one scan.
+  await Promise.resolve();
   expect(scans).toBe(scansAfterFailure + 1);
   expect(firstRetrySettled).toBeFalse();
   expect(secondRetrySettled).toBeFalse();
@@ -498,6 +501,9 @@ test("a fresh resource snapshot fences a pre-kill refresh before host election",
   });
 
   expect(filesFresh).toBeTrue();
+  // The scan coordinator starts the fresh generation one microtask after the
+  // resource reader enqueues it (#287).
+  await Promise.resolve();
   expect(scans).toBe(2);
   const payload = await payloadPromise;
   expect(resourceSettled).toBeTrue();

--- a/src/app/api/files/scanCache.real.test.ts
+++ b/src/app/api/files/scanCache.real.test.ts
@@ -14,6 +14,12 @@ process.env.LLV_STATE_DIR = path.join(sandbox, "state");
 process.env.LLV_CODEX_HOME = path.join(sandbox, "codex");
 process.env.LLV_CLAUDE_HOME = path.join(sandbox, "claude");
 process.env.TMPDIR = path.join(sandbox, "tmp");
+/* The claude-tasks root falls back to the legacy /tmp/claude-<uid> directory
+   whenever the $TMPDIR candidate does not exist. On a workstation running live
+   Claude agents that fallback leaks real task outputs into this sandbox and
+   their recent projects evict the deliberately old fixtures from the scheme
+   window. Creating the sandbox candidate keeps the scan hermetic. */
+fs.mkdirSync(path.join(sandbox, "tmp", `claude-${process.getuid?.() ?? 1000}`), { recursive: true });
 
 const sessions = path.join(process.env.LLV_CODEX_HOME, "sessions");
 fs.mkdirSync(sessions, { recursive: true });

--- a/src/app/api/runtime/snapshot/route.ts
+++ b/src/app/api/runtime/snapshot/route.ts
@@ -7,13 +7,15 @@ import { structuredStartupAxis } from "@/lib/runtime/startupStatus";
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
-export async function GET(): Promise<NextResponse> {
+export async function GET(request: Request): Promise<NextResponse> {
   if (!runtimeEventsEnabled()) return NextResponse.json({ error: "runtime events are disabled" }, { status: 503 });
   const client = runtimeHostClient();
   if (!client) return NextResponse.json({ error: "runtime host socket is unavailable" }, { status: 503 });
   try {
     return NextResponse.json({
-      ...await client.snapshot(),
+      // The request signal reaches the runtime host, so a disconnected caller
+      // cancels its socket wait instead of leaving late host work behind.
+      ...await client.snapshot(request.signal),
       structuredHostsEnabled: process.env.LLV_STRUCTURED_HOSTS === "1",
       structuredStartup: structuredStartupAxis(),
     }, { headers: { "cache-control": "no-store" } });

--- a/src/lib/accounts/migration/controller.ts
+++ b/src/lib/accounts/migration/controller.ts
@@ -8,6 +8,7 @@ import { forEachCooperatively, yieldToRuntime } from "@/lib/cooperative";
 import { loadFlows, reconcileFlowConversationOwnershipCooperatively } from "@/lib/flows/store";
 import { reconcileHandoffConversationOwnershipCooperatively } from "@/lib/handoffLineage";
 import { listFilesWithProjectCatalog, reconcileFileControllers } from "@/lib/scanner";
+import { coordinatedControllerScan } from "@/lib/scanner/scanCoordinator";
 import { pidAlive, readPpid } from "@/lib/scanner/process";
 import { runReaperCycle } from "@/lib/reaperRuntime";
 import { runHeadlessProcessReaper } from "@/lib/headlessProcessReaper";
@@ -133,7 +134,9 @@ function reconcileControllerTasks(registry: AgentRegistry, files: ControllerScan
 }
 
 const DEFAULT_CONTROLLER_CYCLE_PORTS: AccountMigrationControllerCyclePorts = {
-  scan: () => listFilesWithProjectCatalog(undefined, { persist: true }),
+  // Reconciliation consumes the process-wide scan generation; it never fans
+  // out an extra scanner run alongside the HTTP cache or the pipeline watchdog.
+  scan: () => coordinatedControllerScan(),
   reconcileInventory: reconcileMigrationInventory,
   reconcileFlowOwnership: reconcileFlowConversationOwnershipCooperatively,
   reconcileWorkflowOwnership: reconcileWorkflowConversationOwnershipCooperatively,

--- a/src/lib/pipelines/controller.ts
+++ b/src/lib/pipelines/controller.ts
@@ -4,7 +4,7 @@ import path from "node:path";
 
 import { statePath } from "@/lib/configDir";
 import { tickFlows } from "@/lib/flows/engine";
-import { listFilesWithProjectCatalog } from "@/lib/scanner";
+import { coordinatedControllerScan } from "@/lib/scanner/scanCoordinator";
 import type { FileEntry } from "@/lib/types";
 
 import { registerPipelineTick } from "./controllerSignal";
@@ -82,7 +82,9 @@ export function writeFlowPipelineControllerHeartbeat(
 
 function productionPorts(): FlowPipelineControllerPorts {
   return {
-    scan: async () => listFilesWithProjectCatalog(undefined, { persist: true }),
+    // The watchdog joins the process-wide scan generation instead of racing
+    // the HTTP cache and the account controller with its own scanner run.
+    scan: async () => coordinatedControllerScan(),
     tickPipelines,
     tickFlows,
     publishHeartbeat: writeFlowPipelineControllerHeartbeat,

--- a/src/lib/reaperRuntime.ts
+++ b/src/lib/reaperRuntime.ts
@@ -32,6 +32,10 @@ import {
   type ReaperReport,
 } from "./reaper";
 
+/* Authorship proof budgets for one controller cycle (#287). */
+const AUTHORSHIP_PATH_PASS_BYTES = 4 * 1024 * 1024;
+const AUTHORSHIP_CYCLE_BUDGET_BYTES = 32 * 1024 * 1024;
+
 const REPORT_FILE = () => statePath("reaper-report.json");
 const STATE_FILE = () => statePath("reaper-state.json");
 const JOURNAL_FILE = () => statePath("reaper-journal.ndjson");
@@ -452,6 +456,12 @@ async function authorshipEvidence(
     if (stamp !== undefined && stamp >= file.mtime) return;
     targets.set(file.path, file.engine);
   });
+  /* Hard byte budgets (#287): one multi-gigabyte ownerless transcript may
+     consume at most AUTHORSHIP_PATH_PASS_BYTES per controller cycle, and all
+     authorship proofs together at most AUTHORSHIP_CYCLE_BUDGET_BYTES. An
+     exhausted pass returns incomplete, the path stays protected as
+     unverified, and the resumable checkpoint continues in the next cycle. */
+  const authorshipReadBudget = { remaining: AUTHORSHIP_CYCLE_BUDGET_BYTES };
   await forEachCooperatively([...targets], async ([pathname, engine]) => {
     if (userAuthoredPaths.has(pathname) || unverifiedPaths.has(pathname)) return;
     if (missingTranscriptPaths.has(pathname)) return;
@@ -470,7 +480,11 @@ async function authorshipEvidence(
       unverifiedPaths.add(pathname);
       return;
     }
-    const scan = await scanUserAuthoredMessagesCooperatively(pathname, engine, viewerMessageAllowance + 1);
+    const scan = await scanUserAuthoredMessagesCooperatively(pathname, engine, viewerMessageAllowance + 1, {
+      resume: true,
+      maxBytes: AUTHORSHIP_PATH_PASS_BYTES,
+      budget: authorshipReadBudget,
+    });
     if (scan.count > viewerMessageAllowance) userAuthoredPaths.add(pathname);
     else if (!scan.complete) unverifiedPaths.add(pathname);
     else verifiedCleanAt.set(pathname, observedMtime);

--- a/src/lib/runtime/client.test.ts
+++ b/src/lib/runtime/client.test.ts
@@ -92,5 +92,5 @@ test("a healthy response resolves once and ignores the pending timeout", async (
     socket.end(JSON.stringify({ id: request.id, ok: true, result: { revision: 7 } }) + "\n");
   });
   const client = new UnixRuntimeHostClient(socketPath, 5_000, 5_000, 5_000);
-  expect(await client.snapshot()).toEqual({ revision: 7 });
+  expect(await client.snapshot() as unknown).toEqual({ revision: 7 });
 });

--- a/src/lib/runtime/client.test.ts
+++ b/src/lib/runtime/client.test.ts
@@ -1,0 +1,96 @@
+import { afterAll, expect, test } from "bun:test";
+import fs from "node:fs";
+import net from "node:net";
+import os from "node:os";
+import path from "node:path";
+
+import { RuntimeHostUnavailableError, UnixRuntimeHostClient } from "./client";
+
+const SANDBOX = fs.mkdtempSync(path.join(os.tmpdir(), "llv-runtime-client-"));
+const servers: net.Server[] = [];
+const connections: net.Socket[] = [];
+
+afterAll(async () => {
+  for (const socket of connections) socket.destroy();
+  await Promise.all(servers.map((server) => new Promise((resolve) => server.close(resolve))));
+  fs.rmSync(SANDBOX, { recursive: true, force: true });
+});
+
+function serve(onRequest: (frame: string, socket: net.Socket) => void): string {
+  const socketPath = path.join(SANDBOX, `${crypto.randomUUID().slice(0, 8)}.sock`);
+  const server = net.createServer((socket) => {
+    connections.push(socket);
+    socket.on("error", () => undefined);
+    let buffer = "";
+    socket.on("data", (chunk) => {
+      buffer += String(chunk);
+      const newline = buffer.indexOf("\n");
+      if (newline < 0) return;
+      onRequest(buffer.slice(0, newline), socket);
+    });
+  });
+  server.listen(socketPath);
+  servers.push(server);
+  return socketPath;
+}
+
+test("snapshot forwards its abort signal and settles exactly once on external abort", async () => {
+  const socketPath = serve(() => {
+    /* never respond — the abort must settle the request */
+  });
+  const client = new UnixRuntimeHostClient(socketPath, 60_000, 60_000, 60_000);
+  const abort = new AbortController();
+  const request = client.snapshot(abort.signal);
+  const outcome = request.then(() => "resolved", (error) => error);
+  abort.abort();
+  const settled = await outcome;
+  expect(settled).toBeInstanceOf(RuntimeHostUnavailableError);
+  expect((settled as Error).message).toBe("runtime host request cancelled");
+});
+
+test("a timeout, a late response, and a socket teardown settle the call exactly once", async () => {
+  let respond: ((frame: string, socket: net.Socket) => void) | null = null;
+  const socketPath = serve((frame, socket) => { respond?.(frame, socket); });
+  const client = new UnixRuntimeHostClient(socketPath, 40, 40, 40);
+  let requestSocket: net.Socket | null = null;
+  let requestFrame = "";
+  respond = (frame, socket) => {
+    requestFrame = frame;
+    requestSocket = socket;
+  };
+  const settlements: unknown[] = [];
+  await client.snapshot().then(
+    (value) => settlements.push({ value }),
+    (error) => settlements.push({ error }),
+  );
+  expect(settlements).toHaveLength(1);
+  expect((settlements[0] as { error: Error }).error.message).toBe("runtime host request timed out");
+
+  // A response arriving after the timeout destroyed the client socket must not
+  // produce a second settlement or an unhandled error.
+  const request = JSON.parse(requestFrame) as { id: string };
+  requestSocket!.write(JSON.stringify({ id: request.id, ok: true, result: {} }) + "\n");
+  await new Promise((resolve) => setTimeout(resolve, 25));
+  expect(settlements).toHaveLength(1);
+});
+
+test("a socket error settles the call exactly once with a transport failure", async () => {
+  const client = new UnixRuntimeHostClient(path.join(SANDBOX, "absent.sock"), 200, 200, 200);
+  const settlements: unknown[] = [];
+  await client.events(0).then(
+    (value) => settlements.push({ value }),
+    (error) => settlements.push({ error }),
+  );
+  await new Promise((resolve) => setTimeout(resolve, 25));
+  expect(settlements).toHaveLength(1);
+  expect((settlements[0] as { error: Error }).error.message).toBe("runtime host is unavailable");
+});
+
+test("a healthy response resolves once and ignores the pending timeout", async () => {
+  const socketPath = serve((frame, socket) => {
+    const request = JSON.parse(frame) as { id: string };
+    socket.end(JSON.stringify({ id: request.id, ok: true, result: { revision: 7 } }) + "\n");
+  });
+  const client = new UnixRuntimeHostClient(socketPath, 5_000, 5_000, 5_000);
+  expect(await client.snapshot()).toEqual({ revision: 7 });
+});

--- a/src/lib/runtime/client.ts
+++ b/src/lib/runtime/client.ts
@@ -31,8 +31,8 @@ export function isRuntimeHostTransportFailure(error: unknown): boolean {
 }
 
 export interface RuntimeHostClient {
-  snapshot(): Promise<RuntimeSnapshot>;
-  events(after: number): Promise<RuntimeReplay>;
+  snapshot(signal?: AbortSignal): Promise<RuntimeSnapshot>;
+  events(after: number, signal?: AbortSignal): Promise<RuntimeReplay>;
   waitEvents(after: number, timeoutMs?: number, signal?: AbortSignal): Promise<RuntimeReplay>;
   append(event: RuntimeEventInput): Promise<unknown>;
   operation(event: RuntimeEventInput): Promise<unknown>;
@@ -58,8 +58,8 @@ export class UnixRuntimeHostClient implements RuntimeHostClient {
     private readonly snapshotTimeoutMs = RUNTIME_SNAPSHOT_REQUEST_TIMEOUT_MS,
   ) {}
 
-  snapshot(): Promise<RuntimeSnapshot> { return this.call("snapshot", undefined, this.snapshotTimeoutMs) as Promise<RuntimeSnapshot>; }
-  events(after: number): Promise<RuntimeReplay> { return this.call("events", { after }) as Promise<RuntimeReplay>; }
+  snapshot(signal?: AbortSignal): Promise<RuntimeSnapshot> { return this.call("snapshot", undefined, this.snapshotTimeoutMs, signal) as Promise<RuntimeSnapshot>; }
+  events(after: number, signal?: AbortSignal): Promise<RuntimeReplay> { return this.call("events", { after }, this.timeoutMs, signal) as Promise<RuntimeReplay>; }
   waitEvents(after: number, timeoutMs = 15_000, signal?: AbortSignal): Promise<RuntimeReplay> { return this.call("wait", { after, timeoutMs }, timeoutMs + 1_000, signal) as Promise<RuntimeReplay>; }
   append(event: RuntimeEventInput): Promise<unknown> { return this.call("append", { event }); }
   operation(event: RuntimeEventInput): Promise<unknown> { return this.call("operation", { event }); }

--- a/src/lib/scanner/describe.test.ts
+++ b/src/lib/scanner/describe.test.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 
 import { afterAll, expect, test } from "bun:test";
 
+import { globalCache } from "./caches";
 import {
   describe,
   parseWorktreeGitdir,
@@ -222,6 +223,70 @@ test("growing Codex transcripts retain cwd metadata after the project cache warm
   expect(describe("codex-sessions", root, transcript, fs.statSync(transcript))).toMatchObject({ cwd, projectRoot: repo });
   fs.appendFileSync(transcript, JSON.stringify({ type: "event_msg", payload: { type: "user_message", message: "continue" } }) + "\n");
   expect(describe("codex-sessions", root, transcript, fs.statSync(transcript))).toMatchObject({ cwd, projectRoot: repo });
+});
+
+test("a project-state change recomputes only the overlay, never transcript metadata (#287)", () => {
+  const base = path.join(SANDBOX, "identity-split");
+  const state = path.join(base, "state");
+  fs.mkdirSync(state, { recursive: true });
+  process.env.LLV_STATE_DIR = state;
+  const repo = path.join(base, "live-log-viewer-next");
+  const worktree = path.join(base, "live-log-viewer-split-branch");
+  const root = path.join(base, "codex-root");
+  const transcript = path.join(root, "2026", "07", "rollout-split.jsonl");
+  fs.mkdirSync(path.dirname(transcript), { recursive: true });
+  fs.writeFileSync(transcript, JSON.stringify({ type: "session_meta", payload: { cwd: worktree } }) + "\n");
+  const st = fs.statSync(transcript);
+
+  /* The checkout does not exist yet: without its .git pointer the cwd cannot
+     regroup under the parent repo and gets a standalone path-derived name. */
+  const before = describe("codex-sessions", root, transcript, st, "state-a");
+  expect(before.cwd).toBe(worktree);
+  expect(before.worktree).toBeUndefined();
+
+  // The checkout appears (reconciliation would rewrite the project state and
+  // change the resolution state key with it).
+  fs.mkdirSync(path.join(repo, ".git", "worktrees", "live-log-viewer-split-branch"), { recursive: true });
+  fs.mkdirSync(worktree, { recursive: true });
+  fs.writeFileSync(
+    path.join(worktree, ".git"),
+    `gitdir: ${path.join(repo, ".git", "worktrees", "live-log-viewer-split-branch")}\n`,
+  );
+
+  /* The cwd-resolution and .git-pointer memos hold the unresolved lookup for
+     10–60 s in production; expire them so the overlay recompute sees the live
+     checkout the way a later scan generation would. */
+  globalCache("project-info-cwd-v1").clear();
+  globalCache("worktree-git").clear();
+
+  /* The overlay recomputes under the new state key without touching the
+     transcript bytes: metadata is keyed by file identity alone. */
+  const realOpenSync = fs.openSync;
+  const realReadFileSync = fs.readFileSync;
+  let transcriptReads = 0;
+  const countTranscript = (target: fs.PathOrFileDescriptor | fs.PathLike) => {
+    if (String(target) === transcript) transcriptReads += 1;
+  };
+  fs.openSync = ((target: fs.PathLike, ...rest: [number | string, (fs.Mode | null)?]) => {
+    countTranscript(target);
+    return realOpenSync(target, ...rest);
+  }) as typeof fs.openSync;
+  fs.readFileSync = ((target: fs.PathOrFileDescriptor, ...rest: unknown[]) => {
+    countTranscript(target);
+    return (realReadFileSync as (...args: unknown[]) => ReturnType<typeof fs.readFileSync>)(target, ...rest);
+  }) as typeof fs.readFileSync;
+  let after;
+  try {
+    after = describe("codex-sessions", root, transcript, st, "state-b");
+  } finally {
+    fs.openSync = realOpenSync;
+    fs.readFileSync = realReadFileSync;
+  }
+  expect(transcriptReads).toBe(0);
+  expect(after.cwd).toBe(worktree);
+  expect(after.title).toBe(before.title);
+  expect(projectForCwd(repo)).toBe(after.project);
+  expect(after.worktree).toBe("live-log-viewer-split-branch");
 });
 
 test("a nested `worktrees` segment under .claude/.codex is left to its own recognizer", () => {

--- a/src/lib/scanner/describe.test.ts
+++ b/src/lib/scanner/describe.test.ts
@@ -26,25 +26,25 @@ afterAll(() => {
 
 test("parseWorktreeGitdir resolves an absolute gitdir into repo + worktree name", () => {
   const info = parseWorktreeGitdir(
-    "/home/u/.agents/tools/live-log-viewer-attention-queue",
-    "gitdir: /home/u/.agents/tools/live-log-viewer-next/.git/worktrees/live-log-viewer-attention-queue\n",
+    "/home/user/.agents/tools/live-log-viewer-attention-queue",
+    "gitdir: /home/user/.agents/tools/live-log-viewer-next/.git/worktrees/live-log-viewer-attention-queue\n",
   );
   expect(info).toEqual({
-    repo: "/home/u/.agents/tools/live-log-viewer-next",
+    repo: "/home/user/.agents/tools/live-log-viewer-next",
     worktree: "live-log-viewer-attention-queue",
   });
 });
 
 test("parseWorktreeGitdir resolves a relative gitdir against the checkout cwd", () => {
-  const info = parseWorktreeGitdir("/home/u/wt", "gitdir: ../main/.git/worktrees/wt");
-  expect(info).toEqual({ repo: "/home/u/main", worktree: "wt" });
+  const info = parseWorktreeGitdir("/home/user/wt", "gitdir: ../main/.git/worktrees/wt");
+  expect(info).toEqual({ repo: "/home/user/main", worktree: "wt" });
 });
 
 test("parseWorktreeGitdir rejects gitdirs that are not linked worktrees", () => {
-  expect(parseWorktreeGitdir("/home/u/sub", "gitdir: /home/u/main/.git")).toBeNull();
-  expect(parseWorktreeGitdir("/home/u/sub", "not a git file")).toBeNull();
+  expect(parseWorktreeGitdir("/home/user/sub", "gitdir: /home/user/main/.git")).toBeNull();
+  expect(parseWorktreeGitdir("/home/user/sub", "not a git file")).toBeNull();
   /* "worktrees" segment without a .git parent is another repo layout, not a linked checkout */
-  expect(parseWorktreeGitdir("/home/u/sub", "gitdir: /home/u/worktrees/x")).toBeNull();
+  expect(parseWorktreeGitdir("/home/user/sub", "gitdir: /home/user/worktrees/x")).toBeNull();
 });
 
 test("an absent cwd cannot inherit the Viewer process project", () => {

--- a/src/lib/scanner/describe.ts
+++ b/src/lib/scanner/describe.ts
@@ -38,10 +38,37 @@ export interface FileDescriptionResult {
   complete: boolean;
 }
 
-type CachedFileDescription = {
+/** Everything derived from the transcript (and sidecar) bytes themselves.
+    Keyed by file identity alone: reconciliation rewriting flows.json or the
+    worktree map must never evict transcript-derived evidence (#287). */
+type TranscriptMetadata = {
+  cwd?: string;
+  sessionStartedAt: string | null;
+  nativeParentThreadId: string | null;
+  title: string;
+  engine: Engine;
+  kind: string;
+  fmt: Fmt;
+};
+
+type CachedTranscriptMetadata = {
   identity: FileDescriptionIdentity;
+  metadata: TranscriptMetadata;
+};
+
+/** Project/worktree resolution overlays the transcript metadata. It depends on
+    the project-state files (flows, workflows, worktree map), so its cache keys
+    on the state revision and the resolved cwd — a flow change recomputes only
+    this overlay while transcript metadata stays untouched (#287). */
+type ProjectOverlay = {
+  project: string;
+  worktree?: string;
+  projectRoot?: string | null;
+};
+
+type CachedProjectOverlay = ProjectOverlay & {
   stateKey: string;
-  description: FileDescription;
+  cwd?: string;
 };
 
 /* Earlier issue-171 builds retained full prompts in these global maps. Clear
@@ -49,7 +76,11 @@ type CachedFileDescription = {
    without waiting for a process restart. */
 globalCache<unknown>("meta-v4").clear();
 globalCache<unknown>("title-v2").clear();
-const metaCache = globalCache<CachedFileDescription>("meta-v6");
+/* The pre-#287 composite description cache keyed transcript metadata on the
+   project-state hash, so reconciliation invalidated it corpus-wide. */
+globalCache<unknown>("meta-v6").clear();
+const transcriptMetaCache = globalCache<CachedTranscriptMetadata>("meta-transcript-v7");
+const projectOverlayCache = globalCache<CachedProjectOverlay>("project-overlay-v1");
 // Title and codex project live in the immutable head of a growing transcript.
 // Resolved head values survive append-only growth, while the complete file
 // identity invalidates same-size rewrites and truncations. A head that has not
@@ -66,13 +97,8 @@ const titleCache = globalCache<HeadMetadataCache<string | null>>("title-v5");
 /* Search text can be large and belongs to the list/search path. Its bounded
    cache lives with the search index; page hydration reads only its visible rows. */
 globalCache<unknown>("conversation-search-v1").clear();
-const codexProjectCache = globalCache<{
-  size: number;
-  mtimeMs: number;
-  stateKey: string;
-  project: string;
-  worktree?: string;
-}>("codex-project-v5");
+/* Subsumed by the split project-overlay cache above (#287). */
+globalCache<unknown>("codex-project-v5").clear();
 const repoSlugCache = globalCache<[number, string | null]>("repo-path-from-slug-v1");
 /* The cwd follows the same append-only head reuse and rewrite invalidation. */
 const cwdCache = globalCache<HeadMetadataCache<string | null>>("claude-cwd-v3");
@@ -808,23 +834,15 @@ export function searchTextForTranscript(pathname: string, size: number, engine: 
   return conversationTextFromLines(head.text.split("\n").slice(0, 151), engine === "codex");
 }
 
-export function describeFile(
+function deriveTranscriptMetadata(
   rootName: RootKey,
-  root: string,
   pathname: string,
   st: fs.Stats,
-  stateKey = projectResolutionStateKey(),
-  identity = fileDescriptionIdentity(rootName, pathname, st),
-): FileDescriptionResult {
-  const cached = metaCache.get(pathname);
-  if (identity.complete && cached?.stateKey === stateKey && sameFileDescriptionIdentity(cached.identity, identity)) {
-    return { description: cached.description, complete: true };
-  }
-  const rel = path.relative(root, pathname);
+  identity: FileDescriptionIdentity,
+): { metadata: TranscriptMetadata; complete: boolean; cwdComplete: boolean } {
   const fn = path.basename(pathname);
-  let project = "other";
-  let worktree: string | undefined;
   let cwd: string | undefined;
+  let cwdComplete = identity.complete;
   let sessionStartedAt: string | null = null;
   let nativeParentThreadId: string | null = null;
   let title: string | null = null;
@@ -837,6 +855,7 @@ export function describeFile(
       ? transcriptCwd(pathname, st)
       : { value: null, complete: false, headPreserved: false };
     complete &&= cwdRead.complete;
+    cwdComplete = cwdRead.complete;
     cwd = cwdRead.value ?? undefined;
     if (complete) {
       const startedAtRead = transcriptStartedAt(pathname, st);
@@ -848,34 +867,6 @@ export function describeFile(
       complete &&= nativeParent.complete;
       nativeParentThreadId = nativeParent.value;
     }
-    const cachedProject = codexProjectCache.get(pathname);
-    const cachedProjectMatches = cwdRead.complete && cachedProject?.stateKey === stateKey
-      && (
-        (cachedProject.size === st.size && cachedProject.mtimeMs === st.mtimeMs)
-        || (st.size > cachedProject.size && cwdRead.headPreserved)
-      );
-    if (cachedProjectMatches) {
-      project = cachedProject.project;
-      worktree = cachedProject.worktree;
-    } else {
-      project = "";
-      const info = cwd ? projectInfoFromCwd(cwd) : null;
-      project = info?.project ?? "";
-      worktree = info?.worktree;
-      if (!project) {
-        const info = projectInfoFromTranscript(pathname);
-        project = info?.project ?? "";
-        worktree = info?.worktree;
-      }
-      if (project && cwdRead.complete) codexProjectCache.set(pathname, {
-        size: st.size,
-        mtimeMs: st.mtimeMs,
-        stateKey,
-        project,
-        worktree,
-      });
-    }
-    if (!project) project = "codex";
     engine = "codex";
     kind = "session";
     fmt = "codex";
@@ -886,28 +877,16 @@ export function describeFile(
     }
     title ??= "Codex session";
   } else if (rootName === "claude-projects") {
-    const slug = rel.split(path.sep)[0] ?? "";
-    const worktreeInfo = worktreeFromSlug(slug);
-    project = worktreeInfo?.project ?? projectFromSlug(slug);
-    worktree = worktreeInfo?.worktree;
-    /* The slug alone cannot tell a sibling worktree checkout from a real
-       standalone project — only the cwd's git metadata can. When it proves a
-       worktree, the session regroups under its main repo's project name. */
     const cwdRead = complete
       ? transcriptCwd(pathname, st)
       : { value: null, complete: false, headPreserved: false };
     complete &&= cwdRead.complete;
+    cwdComplete = cwdRead.complete;
     cwd = cwdRead.value ?? undefined;
     if (complete) {
       const startedAtRead = transcriptStartedAt(pathname, st);
       complete &&= startedAtRead.complete;
       sessionStartedAt = startedAtRead.value;
-    }
-    const info = cwd ? projectInfoFromCwd(cwd) : projectInfoFromTranscript(pathname);
-    const persistedInfo = projectInfoFromTranscript(pathname);
-    if (info && (worktreeInfo || info.worktree || persistedInfo)) {
-      project = info.project;
-      worktree = info.worktree ?? worktree;
     }
     fmt = "claude";
     if (fn.startsWith("agent-")) {
@@ -939,28 +918,124 @@ export function describeFile(
       title ??= "Claude session";
     }
   } else if (rootName === "claude-tasks") {
-    const slug = rel.split(path.sep)[0] ?? "";
-    const info = projectInfoFromSlug(slug);
-    project = info?.project ?? projectFromSlug(slug);
-    worktree = info?.worktree;
     engine = "shell";
     kind = "background";
     title = "Background task " + fn.split(".")[0];
   }
-  const meta = {
+  return {
+    metadata: {
+      cwd,
+      sessionStartedAt,
+      nativeParentThreadId,
+      title: cleanTitle(title ?? fn, 120),
+      engine,
+      kind,
+      fmt,
+    },
+    complete,
+    cwdComplete,
+  };
+}
+
+function resolveProjectOverlay(
+  rootName: RootKey,
+  root: string,
+  pathname: string,
+  cwd: string | undefined,
+  cwdAuthoritative: boolean,
+  stateKey: string,
+): ProjectOverlay {
+  const cached = projectOverlayCache.get(pathname);
+  if (cwdAuthoritative && cached && cached.stateKey === stateKey && cached.cwd === cwd) {
+    return { project: cached.project, worktree: cached.worktree, projectRoot: cached.projectRoot };
+  }
+  let project = "other";
+  let worktree: string | undefined;
+  /* An unresolved codex project falls back to the generic "codex" bucket.
+     That terminal fallback stays uncached so a later scan can re-attempt the
+     disk-dependent resolvers once the checkout or persisted map appears. */
+  let cacheable = cwdAuthoritative;
+  if (rootName === "codex-sessions") {
+    const info = cwd ? projectInfoFromCwd(cwd) : null;
+    project = info?.project ?? "";
+    worktree = info?.worktree;
+    if (!project) {
+      const persisted = projectInfoFromTranscript(pathname);
+      project = persisted?.project ?? "";
+      worktree = persisted?.worktree;
+    }
+    if (!project) {
+      project = "codex";
+      cacheable = false;
+    }
+  } else if (rootName === "claude-projects") {
+    const rel = path.relative(root, pathname);
+    const slug = rel.split(path.sep)[0] ?? "";
+    const worktreeInfo = worktreeFromSlug(slug);
+    project = worktreeInfo?.project ?? projectFromSlug(slug);
+    worktree = worktreeInfo?.worktree;
+    /* The slug alone cannot tell a sibling worktree checkout from a real
+       standalone project — only the cwd's git metadata can. When it proves a
+       worktree, the session regroups under its main repo's project name. */
+    const info = cwd ? projectInfoFromCwd(cwd) : projectInfoFromTranscript(pathname);
+    const persistedInfo = projectInfoFromTranscript(pathname);
+    if (info && (worktreeInfo || info.worktree || persistedInfo)) {
+      project = info.project;
+      worktree = info.worktree ?? worktree;
+    }
+  } else if (rootName === "claude-tasks") {
+    const rel = path.relative(root, pathname);
+    const slug = rel.split(path.sep)[0] ?? "";
+    const info = projectInfoFromSlug(slug);
+    project = info?.project ?? projectFromSlug(slug);
+    worktree = info?.worktree;
+  }
+  const overlay: ProjectOverlay = {
     project,
     worktree,
-    cwd,
-    sessionStartedAt,
-    nativeParentThreadId,
     projectRoot: cwd ? projectRootForCwd(cwd) ?? null : undefined,
-    title: cleanTitle(title ?? fn, 120),
-    engine,
-    kind,
-    fmt,
   };
-  if (complete) metaCache.set(pathname, { identity, stateKey, description: meta });
-  return { description: meta, complete };
+  if (cacheable) projectOverlayCache.set(pathname, { ...overlay, stateKey, cwd });
+  return overlay;
+}
+
+export function describeFile(
+  rootName: RootKey,
+  root: string,
+  pathname: string,
+  st: fs.Stats,
+  stateKey = projectResolutionStateKey(),
+  identity = fileDescriptionIdentity(rootName, pathname, st),
+): FileDescriptionResult {
+  const cachedMeta = transcriptMetaCache.get(pathname);
+  let metadata: TranscriptMetadata;
+  let complete: boolean;
+  let cwdAuthoritative: boolean;
+  if (identity.complete && cachedMeta && sameFileDescriptionIdentity(cachedMeta.identity, identity)) {
+    metadata = cachedMeta.metadata;
+    complete = true;
+    cwdAuthoritative = true;
+  } else {
+    const derived = deriveTranscriptMetadata(rootName, pathname, st, identity);
+    metadata = derived.metadata;
+    complete = derived.complete;
+    cwdAuthoritative = derived.cwdComplete;
+    if (complete) transcriptMetaCache.set(pathname, { identity, metadata });
+  }
+  const overlay = resolveProjectOverlay(rootName, root, pathname, metadata.cwd, cwdAuthoritative, stateKey);
+  const description: FileDescription = {
+    project: overlay.project,
+    worktree: overlay.worktree,
+    cwd: metadata.cwd,
+    sessionStartedAt: metadata.sessionStartedAt,
+    nativeParentThreadId: metadata.nativeParentThreadId,
+    projectRoot: overlay.projectRoot,
+    title: metadata.title,
+    engine: metadata.engine,
+    kind: metadata.kind,
+    fmt: metadata.fmt,
+  };
+  return { description, complete };
 }
 
 export function describe(

--- a/src/lib/scanner/links.performance.test.ts
+++ b/src/lib/scanner/links.performance.test.ts
@@ -247,6 +247,76 @@ test("background command recovery advances within one bounded read budget", asyn
   }
 });
 
+test("background command recovery rescans replacement head after shrink above its offset", async () => {
+  const projectRoot = path.join(SANDBOX, "shrunken-background-projects");
+  const taskRoot = path.join(SANDBOX, "shrunken-background-tasks");
+  const previousProjectRoot = ROOTS["claude-projects"];
+  const previousTaskRoot = ROOTS["claude-tasks"];
+  ROOTS["claude-projects"] = projectRoot;
+  ROOTS["claude-tasks"] = taskRoot;
+  const slug = "-repo-shrunken-background";
+  const sid = "session-shrunken-background";
+  const tid = "task-shrunken-background";
+  const toolUseId = "toolu_shrunken_background";
+  const mainPath = path.join(projectRoot, slug, `${sid}.jsonl`);
+  const taskPath = path.join(taskRoot, slug, sid, "tasks", `${tid}.output`);
+  fs.mkdirSync(path.dirname(mainPath), { recursive: true });
+  fs.mkdirSync(path.dirname(taskPath), { recursive: true });
+  fs.writeFileSync(mainPath, Buffer.alloc(512 * 1024, 0x78));
+  fs.writeFileSync(taskPath, "complete\n");
+  const main = entry(mainPath, `fixture/${slug}/${sid}.jsonl`, 1);
+  const task: FileEntry = {
+    ...entry(taskPath, `${slug}/${sid}/tasks/${tid}.output`, 2),
+    root: "claude-tasks",
+    engine: "shell",
+    fmt: "plain",
+    kind: "task",
+  };
+
+  try {
+    await linkEntries([main, task], { persist: false });
+    expect(task.cmd).toBe("");
+
+    const proof = [
+      JSON.stringify({
+        type: "assistant",
+        message: { content: [{
+          type: "tool_use",
+          id: toolUseId,
+          name: "Bash",
+          input: { command: "bun run replacement-worker", description: "Run replacement worker" },
+        }] },
+      }),
+      JSON.stringify({
+        type: "user",
+        tool_use_id: toolUseId,
+        message: { content: [{
+          type: "tool_result",
+          tool_use_id: toolUseId,
+          content: `background with ID: ${tid}`,
+        }] },
+      }),
+      "",
+    ].join("\n");
+    const replacement = Buffer.alloc(384 * 1024, 0x20);
+    replacement.write(proof, 0, "utf8");
+    fs.writeFileSync(mainPath, replacement);
+    main.size = replacement.length;
+    main.mtime = fs.statSync(mainPath).mtimeMs / 1000;
+
+    await linkEntries([main, task], { persist: false });
+    expect(task).toMatchObject({
+      parent: mainPath,
+      cmd: "bun run replacement-worker",
+      cmdDesc: "Run replacement worker",
+      title: "Run replacement worker",
+    });
+  } finally {
+    ROOTS["claude-projects"] = previousProjectRoot;
+    ROOTS["claude-tasks"] = previousTaskRoot;
+  }
+});
+
 test("background command recovery reserves a bounded fair share for later candidates", async () => {
   const projectRoot = path.join(SANDBOX, "fair-background-projects");
   const taskRoot = path.join(SANDBOX, "fair-background-tasks");

--- a/src/lib/scanner/links.performance.test.ts
+++ b/src/lib/scanner/links.performance.test.ts
@@ -247,6 +247,119 @@ test("background command recovery advances within one bounded read budget", asyn
   }
 });
 
+test("background command recovery reserves a bounded fair share for later candidates", async () => {
+  const projectRoot = path.join(SANDBOX, "fair-background-projects");
+  const taskRoot = path.join(SANDBOX, "fair-background-tasks");
+  const previousProjectRoot = ROOTS["claude-projects"];
+  const previousTaskRoot = ROOTS["claude-tasks"];
+  ROOTS["claude-projects"] = projectRoot;
+  ROOTS["claude-tasks"] = taskRoot;
+  const slug = "-repo-fair-background";
+  const blockedSid = "session-blocked-background";
+  const resolvedSid = "session-resolved-background";
+  const blockedTid = "task-blocked-background";
+  const resolvedTid = "task-resolved-background";
+  const toolUseId = "toolu_resolved_background";
+  const blockedMainPath = path.join(projectRoot, slug, `${blockedSid}.jsonl`);
+  const resolvedMainPath = path.join(projectRoot, slug, `${resolvedSid}.jsonl`);
+  const blockedTaskPath = path.join(taskRoot, slug, blockedSid, "tasks", `${blockedTid}.output`);
+  const resolvedTaskPath = path.join(taskRoot, slug, resolvedSid, "tasks", `${resolvedTid}.output`);
+  fs.mkdirSync(path.dirname(blockedMainPath), { recursive: true });
+  fs.mkdirSync(path.dirname(resolvedMainPath), { recursive: true });
+  fs.mkdirSync(path.dirname(blockedTaskPath), { recursive: true });
+  fs.mkdirSync(path.dirname(resolvedTaskPath), { recursive: true });
+  fs.writeFileSync(blockedMainPath, Buffer.alloc(512 * 1024, 0x78));
+  fs.writeFileSync(resolvedMainPath, [
+    JSON.stringify({
+      type: "assistant",
+      message: {
+        content: [{
+          type: "tool_use",
+          id: toolUseId,
+          name: "Bash",
+          input: { command: "bun run fair-worker", description: "Run fair worker" },
+        }],
+      },
+    }),
+    JSON.stringify({
+      type: "user",
+      tool_use_id: toolUseId,
+      message: {
+        content: [{
+          type: "tool_result",
+          tool_use_id: toolUseId,
+          content: `background with ID: ${resolvedTid}`,
+        }],
+      },
+    }),
+    "",
+  ].join("\n"));
+  fs.writeFileSync(blockedTaskPath, "complete\n");
+  fs.writeFileSync(resolvedTaskPath, "complete\n");
+  /* Fixture names avoid compact-chain probes; this
+     regression measures only the background-command generation allowance. */
+  const blockedMain = entry(blockedMainPath, `fixture/${slug}/${blockedSid}.jsonl`, 1);
+  const resolvedMain = entry(resolvedMainPath, `fixture/${slug}/${resolvedSid}.jsonl`, 2);
+  const blockedTask: FileEntry = {
+    ...entry(blockedTaskPath, `${slug}/${blockedSid}/tasks/${blockedTid}.output`, 3),
+    root: "claude-tasks",
+    engine: "shell",
+    fmt: "plain",
+    kind: "task",
+  };
+  const resolvedTask: FileEntry = {
+    ...entry(resolvedTaskPath, `${slug}/${resolvedSid}/tasks/${resolvedTid}.output`, 4),
+    root: "claude-tasks",
+    engine: "shell",
+    fmt: "plain",
+    kind: "task",
+  };
+  const originalOpen = fs.openSync;
+  const originalRead = fs.readSync;
+  const originalClose = fs.closeSync;
+  const tracked = new Map<number, string>();
+  let blockedBytesRead = 0;
+  let totalBytesRead = 0;
+
+  try {
+    fs.openSync = ((filename: fs.PathLike, flags: fs.OpenMode, mode?: fs.Mode) => {
+      const fd = originalOpen(filename, flags, mode);
+      const resolved = path.resolve(String(filename));
+      if (resolved === blockedMainPath || resolved === resolvedMainPath) tracked.set(fd, resolved);
+      return fd;
+    }) as typeof fs.openSync;
+    fs.readSync = ((fd: number, buffer: NodeJS.ArrayBufferView, offset: number, length: number, position: fs.ReadPosition) => {
+      const read = originalRead(fd, buffer, offset, length, position);
+      const source = tracked.get(fd);
+      if (source) {
+        totalBytesRead += read;
+        if (source === blockedMainPath) blockedBytesRead += read;
+      }
+      return read;
+    }) as typeof fs.readSync;
+    fs.closeSync = ((fd: number) => {
+      tracked.delete(fd);
+      return originalClose(fd);
+    }) as typeof fs.closeSync;
+    await linkEntries([blockedMain, blockedTask, resolvedMain, resolvedTask], { persist: false });
+
+    expect(blockedBytesRead).toBeLessThanOrEqual(128 * 1024);
+    expect(totalBytesRead).toBeLessThanOrEqual(256 * 1024);
+    expect(resolvedTask).toMatchObject({
+      parent: resolvedMainPath,
+      cmd: "bun run fair-worker",
+      cmdDesc: "Run fair worker",
+      title: "Run fair worker",
+    });
+  } finally {
+    fs.openSync = originalOpen;
+    fs.readSync = originalRead;
+    fs.closeSync = originalClose;
+    ROOTS["claude-projects"] = previousProjectRoot;
+    ROOTS["claude-tasks"] = previousTaskRoot;
+  }
+});
+
 test("proven background commands survive restart without source transcript reads", async () => {
   const projectRoot = path.join(SANDBOX, "restart-projects");
   const taskRoot = path.join(SANDBOX, "restart-tasks");

--- a/src/lib/scanner/links.ts
+++ b/src/lib/scanner/links.ts
@@ -442,7 +442,7 @@ function indexedBackgroundCommand(tid: string, source: string, budget: ReadBudge
     return null;
   }
   let index = backgroundIndexCache.get(source);
-  if (!index || stat.size < index.offset || (stat.size === index.size && stat.mtimeMs !== index.mtimeMs)) {
+  if (!index || stat.size < index.size || (stat.size === index.size && stat.mtimeMs !== index.mtimeMs)) {
     index = freshBackgroundIndex(stat.size, stat.mtimeMs);
     backgroundIndexCache.set(source, index);
   } else {

--- a/src/lib/scanner/links.ts
+++ b/src/lib/scanner/links.ts
@@ -660,6 +660,13 @@ export async function linkEntries(entries: FileEntry[], options: { persist?: boo
   const backgroundReadBudget = { remaining: BACKGROUND_SCAN_BUDGET_BYTES };
   const nestedNeedleBudget = { remaining: NESTED_SUBAGENT_NEEDLE_BUDGET_BYTES };
   const byPath = new Map(entries.map((entry) => [entry.path, entry]));
+  const backgroundTasks = new Map<FileEntry, [string, string, string]>();
+  for (const entry of entries) {
+    if (entry.root !== "claude-tasks") continue;
+    const parts = taskParts(ROOTS["claude-tasks"], entry.path);
+    if (parts) backgroundTasks.set(entry, parts);
+  }
+  let remainingBackgroundTasks = backgroundTasks.size;
   for (const entry of entries) {
     if (entry.root === "claude-projects") {
       // Both the direct `subagents/agent-*.jsonl` layout and the nested Workflow
@@ -683,16 +690,24 @@ export async function linkEntries(entries: FileEntry[], options: { persist?: boo
         }
       }
     } else if (entry.root === "claude-tasks") {
-      const parts = taskParts(ROOTS["claude-tasks"], entry.path);
+      const parts = backgroundTasks.get(entry);
       if (!parts) continue;
       const [slug, sid, tid] = parts;
       const [main, subs] = await sessionTranscripts(sid, limit, slug);
+      /* Reserve each pending task a share of this generation's remaining
+         allowance. An unresolved transcript advances only to its share, so
+         later candidates retain bytes for their first proof attempt. Cached
+         hits consume no share and leave those bytes for unresolved tasks. */
+      const allowance = Math.ceil(backgroundReadBudget.remaining / remainingBackgroundTasks);
+      const taskBudget = { remaining: allowance };
       const info = bgCommand(
         tid,
         (main ? [main] : []).concat(subs),
         slugMainTranscripts(slug, sid),
-        backgroundReadBudget,
+        taskBudget,
       );
+      backgroundReadBudget.remaining -= allowance - taskBudget.remaining;
+      remainingBackgroundTasks -= 1;
       if (info) {
         entry.parent = info.source;
         entry.cmd = info.command;

--- a/src/lib/scanner/links.ts
+++ b/src/lib/scanner/links.ts
@@ -48,6 +48,11 @@ const lineageStoreState = globalCache<{
 
 const CHAIN_HEAD_BYTES = 512 * 1024;
 const BACKGROUND_SCAN_BUDGET_BYTES = 256 * 1024;
+/* Nested Claude subagent ownership proofs scan sibling transcripts for a
+   tool-use needle. One generation may spend at most this many fresh bytes on
+   those forward scans; unresolved lineage keeps its path-derived parent and
+   the recorded offsets resume in a later generation (#287). */
+const NESTED_SUBAGENT_NEEDLE_BUDGET_BYTES = 256 * 1024;
 const BACKGROUND_SCAN_CHUNK_BYTES = 64 * 1024;
 const BACKGROUND_INDEX_ENTRY_CAP = 20_000;
 const BACKGROUND_COMMANDS_FILE = "bg-commands.json";
@@ -653,6 +658,7 @@ export async function linkEntries(entries: FileEntry[], options: { persist?: boo
   loadCompactChains();
   const limit = createLimiter(48);
   const backgroundReadBudget = { remaining: BACKGROUND_SCAN_BUDGET_BYTES };
+  const nestedNeedleBudget = { remaining: NESTED_SUBAGENT_NEEDLE_BUDGET_BYTES };
   const byPath = new Map(entries.map((entry) => [entry.path, entry]));
   for (const entry of entries) {
     if (entry.root === "claude-projects") {
@@ -671,6 +677,7 @@ export async function linkEntries(entries: FileEntry[], options: { persist?: boo
           const found = findNeedle(
             toolUse,
             subs.filter((item) => item !== entry.path).concat(main ? [main] : []),
+            nestedNeedleBudget,
           );
           if (found) entry.parent = found;
         }

--- a/src/lib/scanner/needle.performance.test.ts
+++ b/src/lib/scanner/needle.performance.test.ts
@@ -122,5 +122,6 @@ test("a candidate that shrinks above its saved offset rescans replacement head c
   fs.writeFileSync(pathname, replacement);
   expect(fs.statSync(pathname).size).toBeGreaterThan(MIB);
 
+  expect(fileHasNeedle(needle, pathname, { remaining: 0 })).toBe(false);
   expect(fileHasNeedle(needle, pathname, { remaining: MIB })).toBe(true);
 });

--- a/src/lib/scanner/needle.performance.test.ts
+++ b/src/lib/scanner/needle.performance.test.ts
@@ -96,9 +96,41 @@ test("findNeedle shares one generation budget across candidate files", () => {
 
   expect(findNeedle("toolu_shared_budget", [first, second], budget)).toBe(null);
 
-  // First candidate consumed its 1 MiB pass cap, the second the remainder.
+  // Both candidates consume an equal share of the generation allowance.
   expect(observedBytes).toBe(1.5 * MIB);
   expect(budget.remaining).toBe(0);
+});
+
+test("findNeedle reserves production-budget bytes for a later sibling proof", () => {
+  const first = virtualTranscript("fair-production-a.jsonl", MIB);
+  const second = path.join(SANDBOX, "fair-production-b.jsonl");
+  const needle = "toolu_fair_proof";
+  fs.writeFileSync(second, `${needle}\n`);
+  const budget: NeedleScanBudget = { remaining: 256 * 1024 };
+  instrumentReads();
+
+  expect(findNeedle(needle, [first, second], budget)).toBe(second);
+  expect(observedBytes).toBeLessThanOrEqual(256 * 1024);
+  expect(budget.remaining).toBeGreaterThanOrEqual(0);
+});
+
+test("a legacy needle cache entry cannot preserve a stale replacement offset", () => {
+  const pathname = path.join(SANDBOX, "legacy-cache-replacement.jsonl");
+  const needle = "toolu_legacy_replacement";
+  const replacement = Buffer.alloc(2 * MIB, 0x79);
+  replacement.write(needle, 32, "utf8");
+  fs.writeFileSync(pathname, replacement);
+  const cacheStore = globalThis as typeof globalThis & {
+    __llvCaches?: Record<string, Map<string, unknown>>;
+  };
+  cacheStore.__llvCaches ??= {};
+  cacheStore.__llvCaches.needle ??= new Map();
+  cacheStore.__llvCaches.needle.set(needle, {
+    hits: {},
+    scanned: { [pathname]: MIB },
+  });
+
+  expect(fileHasNeedle(needle, pathname, { remaining: MIB })).toBe(true);
 });
 
 test("a truncated candidate restarts its observation instead of skipping content", () => {

--- a/src/lib/scanner/needle.performance.test.ts
+++ b/src/lib/scanner/needle.performance.test.ts
@@ -109,3 +109,18 @@ test("a truncated candidate restarts its observation instead of skipping content
   fs.writeFileSync(pathname, `prefix toolu_truncated suffix\n`);
   expect(fileHasNeedle("toolu_truncated", pathname)).toBe(true);
 });
+
+test("a candidate that shrinks above its saved offset rescans replacement head content", () => {
+  const pathname = path.join(SANDBOX, "shrunken-above-offset.jsonl");
+  const needle = "toolu_replacement_head";
+  fs.writeFileSync(pathname, Buffer.alloc(3 * MIB, 0x78));
+
+  expect(fileHasNeedle(needle, pathname, { remaining: MIB })).toBe(false);
+
+  const replacement = Buffer.alloc(2 * MIB, 0x79);
+  replacement.write(needle, 32, "utf8");
+  fs.writeFileSync(pathname, replacement);
+  expect(fs.statSync(pathname).size).toBeGreaterThan(MIB);
+
+  expect(fileHasNeedle(needle, pathname, { remaining: MIB })).toBe(true);
+});

--- a/src/lib/scanner/needle.performance.test.ts
+++ b/src/lib/scanner/needle.performance.test.ts
@@ -1,0 +1,111 @@
+import { afterAll, afterEach, expect, test } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { fileHasNeedle, findNeedle, type NeedleScanBudget } from "./needle";
+
+const SANDBOX = fs.mkdtempSync(path.join(os.tmpdir(), "llv-needle-performance-"));
+const GIB = 1024 * 1024 * 1024;
+const MIB = 1024 * 1024;
+
+const realReadSync = fs.readSync;
+let observedBytes = 0;
+
+function instrumentReads(): void {
+  observedBytes = 0;
+  (fs as { readSync: typeof fs.readSync }).readSync = ((...args: Parameters<typeof fs.readSync>) => {
+    const read = (realReadSync as (...inner: Parameters<typeof fs.readSync>) => number)(...args);
+    observedBytes += read;
+    return read;
+  }) as typeof fs.readSync;
+}
+
+afterEach(() => {
+  (fs as { readSync: typeof fs.readSync }).readSync = realReadSync;
+});
+
+afterAll(() => {
+  fs.rmSync(SANDBOX, { recursive: true, force: true });
+});
+
+/** A logical 3 GiB append-only transcript: real JSONL rows at the head, a
+    sparse hole for the bulk. Reads stay cheap while sizes match production. */
+function virtualTranscript(name: string, logicalBytes = 3 * GIB): string {
+  const pathname = path.join(SANDBOX, name);
+  const fd = fs.openSync(pathname, "w");
+  try {
+    fs.writeSync(fd, `${JSON.stringify({ type: "assistant", message: { content: [{ type: "text", text: "working" }] } })}\n`);
+    fs.ftruncateSync(fd, logicalBytes);
+  } finally {
+    fs.closeSync(fd);
+  }
+  return pathname;
+}
+
+test("an absent needle in a 3 GiB candidate consumes exactly the generation budget", () => {
+  const pathname = virtualTranscript("absent-needle.jsonl");
+  const budget: NeedleScanBudget = { remaining: 256 * 1024 };
+  instrumentReads();
+
+  expect(fileHasNeedle("toolu_deadbeef", pathname, budget)).toBe(false);
+
+  expect(observedBytes).toBe(256 * 1024);
+  expect(budget.remaining).toBe(0);
+  // An exhausted budget refuses further reads outright.
+  expect(fileHasNeedle("toolu_deadbeef", pathname, budget)).toBe(false);
+  expect(observedBytes).toBe(256 * 1024);
+});
+
+test("a candidate pass is capped at 1 MiB even under a larger generation budget", () => {
+  const pathname = virtualTranscript("pass-capped.jsonl");
+  const budget: NeedleScanBudget = { remaining: 8 * MIB };
+  instrumentReads();
+
+  expect(fileHasNeedle("toolu_pass_cap", pathname, budget)).toBe(false);
+
+  expect(observedBytes).toBe(MIB);
+  expect(budget.remaining).toBe(7 * MIB);
+});
+
+test("budgeted scanning resumes deterministically and proves lineage once reached", () => {
+  const pathname = virtualTranscript("resumable.jsonl", 4 * MIB);
+  const needle = "toolu_resume_proof";
+  const fd = fs.openSync(pathname, "r+");
+  try {
+    const proof = Buffer.from(`{"toolUseId":"${needle}"}\n`);
+    fs.writeSync(fd, proof, 0, proof.length, Math.floor(2.5 * MIB));
+  } finally {
+    fs.closeSync(fd);
+  }
+
+  // Generation 1 and 2 exhaust their 1 MiB budgets before the proof offset.
+  expect(fileHasNeedle(needle, pathname, { remaining: MIB })).toBe(false);
+  expect(fileHasNeedle(needle, pathname, { remaining: MIB })).toBe(false);
+  // Generation 3 reaches 2.5 MiB and proves the lineage.
+  expect(fileHasNeedle(needle, pathname, { remaining: MIB })).toBe(true);
+  // The proven hit is cached: an exhausted budget still answers true.
+  expect(fileHasNeedle(needle, pathname, { remaining: 0 })).toBe(true);
+});
+
+test("findNeedle shares one generation budget across candidate files", () => {
+  const first = virtualTranscript("shared-a.jsonl", 4 * MIB);
+  const second = virtualTranscript("shared-b.jsonl", 4 * MIB);
+  const budget: NeedleScanBudget = { remaining: 1.5 * MIB };
+  instrumentReads();
+
+  expect(findNeedle("toolu_shared_budget", [first, second], budget)).toBe(null);
+
+  // First candidate consumed its 1 MiB pass cap, the second the remainder.
+  expect(observedBytes).toBe(1.5 * MIB);
+  expect(budget.remaining).toBe(0);
+});
+
+test("a truncated candidate restarts its observation instead of skipping content", () => {
+  const pathname = path.join(SANDBOX, "truncated.jsonl");
+  fs.writeFileSync(pathname, "x".repeat(2 * MIB));
+  expect(fileHasNeedle("toolu_truncated", pathname)).toBe(false);
+
+  fs.writeFileSync(pathname, `prefix toolu_truncated suffix\n`);
+  expect(fileHasNeedle("toolu_truncated", pathname)).toBe(true);
+});

--- a/src/lib/scanner/needle.ts
+++ b/src/lib/scanner/needle.ts
@@ -5,6 +5,7 @@ import { globalCache } from "./caches";
 interface NeedleEntry {
   hits: Record<string, boolean>;
   scanned: Record<string, number>;
+  sizes: Record<string, number>;
 }
 
 const needleCache = globalCache<NeedleEntry>("needle");
@@ -184,11 +185,10 @@ const NEEDLE_CANDIDATE_PASS_BYTES = 1024 * 1024;
  */
 export function fileHasNeedle(needle: string, pathname: string, budget?: NeedleScanBudget): boolean {
   let ent = needleCache.get(needle);
-  if (!ent || !ent.hits) {
-    ent = { hits: {}, scanned: ent?.scanned ?? {} };
+  if (!ent || !ent.hits || !ent.sizes) {
+    ent = { hits: ent?.hits ?? {}, scanned: ent?.scanned ?? {}, sizes: ent?.sizes ?? {} };
     needleCache.set(needle, ent);
   }
-  if (ent.hits[pathname]) return true;
   const nb = Buffer.from(needle);
   const pad = Math.max(0, nb.length - 1);
   let size: number;
@@ -198,9 +198,15 @@ export function fileHasNeedle(needle: string, pathname: string, budget?: NeedleS
     return false;
   }
   let done = ent.scanned[pathname] ?? 0;
-  // A shrunken file was truncated or replaced: the recorded offset no longer
-  // describes this content, so the observation restarts from byte zero.
-  if (size < done) done = 0;
+  const observedSize = ent.sizes[pathname];
+  // Any shrink identifies a replacement generation, including one whose new
+  // end remains above the incremental checkpoint.
+  if (observedSize !== undefined && size < observedSize) {
+    done = 0;
+    delete ent.hits[pathname];
+  }
+  ent.sizes[pathname] = size;
+  if (ent.hits[pathname]) return true;
   if (size <= done) return false;
   const allowance = budget === undefined
     ? Number.POSITIVE_INFINITY

--- a/src/lib/scanner/needle.ts
+++ b/src/lib/scanner/needle.ts
@@ -8,7 +8,7 @@ interface NeedleEntry {
   sizes: Record<string, number>;
 }
 
-const needleCache = globalCache<NeedleEntry>("needle");
+const needleCache = globalCache<NeedleEntry>("needle-v2");
 const tailNeedleCache = globalCache<{ size: number; mtimeMs: number; hit: boolean }>("needle-tail-v1");
 type TailUuidIndex = {
   dev: number;
@@ -248,8 +248,24 @@ export function fileHasNeedle(needle: string, pathname: string, budget?: NeedleS
 }
 
 export function findNeedle(needle: string, paths: (string | null | undefined)[], budget?: NeedleScanBudget): string | null {
+  if (budget === undefined) {
+    for (const pathname of paths) {
+      if (pathname && fileHasNeedle(needle, pathname)) return pathname;
+    }
+    return null;
+  }
+
+  let remainingCandidates = paths.reduce((count, pathname) => count + (pathname ? 1 : 0), 0);
   for (const pathname of paths) {
-    if (pathname && fileHasNeedle(needle, pathname, budget)) return pathname;
+    if (!pathname) continue;
+    const allowance = Math.ceil(Math.max(0, budget.remaining) / remainingCandidates);
+    const candidateBudget = { remaining: allowance };
+    const hit = fileHasNeedle(needle, pathname, candidateBudget);
+    if (Number.isFinite(allowance)) {
+      budget.remaining = Math.max(0, budget.remaining - (allowance - candidateBudget.remaining));
+    }
+    remainingCandidates -= 1;
+    if (hit) return pathname;
   }
   return null;
 }

--- a/src/lib/scanner/needle.ts
+++ b/src/lib/scanner/needle.ts
@@ -163,13 +163,26 @@ export function fileTailHasNeedle(needle: string, pathname: string): boolean {
   }
 }
 
+/** Shared hard byte allowance for one scan generation. Exhaustion leaves the
+    observation unresolved; the per-file scanned offsets resume the search in a
+    later generation instead of restarting it. */
+export interface NeedleScanBudget {
+  remaining: number;
+}
+
+/** A single candidate may consume at most this much of a generation budget in
+    one pass, so one multi-gigabyte transcript cannot starve its siblings. */
+const NEEDLE_CANDIDATE_PASS_BYTES = 1024 * 1024;
+
 /**
  * Incremental per-file needle scan: remembers how many bytes of each file were
  * already searched and only scans the appended suffix on later calls. A hit is
  * cached per (needle, file) pair, so different candidate files of the same
- * needle can be checked independently.
+ * needle can be checked independently. A budget bounds the fresh bytes one
+ * call may read; an exhausted budget returns false ("not proven yet") and the
+ * recorded offset makes the next generation continue where this one stopped.
  */
-export function fileHasNeedle(needle: string, pathname: string): boolean {
+export function fileHasNeedle(needle: string, pathname: string, budget?: NeedleScanBudget): boolean {
   let ent = needleCache.get(needle);
   if (!ent || !ent.hits) {
     ent = { hits: {}, scanned: ent?.scanned ?? {} };
@@ -184,8 +197,15 @@ export function fileHasNeedle(needle: string, pathname: string): boolean {
   } catch {
     return false;
   }
-  const done = ent.scanned[pathname] ?? 0;
+  let done = ent.scanned[pathname] ?? 0;
+  // A shrunken file was truncated or replaced: the recorded offset no longer
+  // describes this content, so the observation restarts from byte zero.
+  if (size < done) done = 0;
   if (size <= done) return false;
+  const allowance = budget === undefined
+    ? Number.POSITIVE_INFINITY
+    : Math.min(Math.max(0, budget.remaining), NEEDLE_CANDIDATE_PASS_BYTES);
+  if (allowance <= 0) return false;
   try {
     const fd = fs.openSync(pathname, "r");
     try {
@@ -193,11 +213,13 @@ export function fileHasNeedle(needle: string, pathname: string): boolean {
       let pos = start;
       let carry = Buffer.alloc(0);
       let hit = false;
-      while (pos < size) {
-        const len = Math.min(1 << 20, size - pos);
+      let consumed = 0;
+      while (pos < size && consumed < allowance) {
+        const len = Math.min(1 << 20, Math.ceil(allowance - consumed), size - pos);
         const chunk = Buffer.alloc(len);
         const read = fs.readSync(fd, chunk, 0, len, pos);
         if (!read) break;
+        consumed += read;
         const hay = Buffer.concat([carry, chunk.subarray(0, read)]);
         if (hay.includes(nb)) {
           hit = true;
@@ -206,7 +228,8 @@ export function fileHasNeedle(needle: string, pathname: string): boolean {
         carry = pad ? chunk.subarray(Math.max(0, read - pad), read) : Buffer.alloc(0);
         pos += read;
       }
-      ent.scanned[pathname] = size;
+      if (budget !== undefined && Number.isFinite(consumed)) budget.remaining -= consumed;
+      ent.scanned[pathname] = hit || pos >= size ? size : pos;
       if (hit) ent.hits[pathname] = true;
       return hit;
     } finally {
@@ -217,9 +240,9 @@ export function fileHasNeedle(needle: string, pathname: string): boolean {
   }
 }
 
-export function findNeedle(needle: string, paths: (string | null | undefined)[]): string | null {
+export function findNeedle(needle: string, paths: (string | null | undefined)[], budget?: NeedleScanBudget): string | null {
   for (const pathname of paths) {
-    if (pathname && fileHasNeedle(needle, pathname)) return pathname;
+    if (pathname && fileHasNeedle(needle, pathname, budget)) return pathname;
   }
   return null;
 }

--- a/src/lib/scanner/needle.ts
+++ b/src/lib/scanner/needle.ts
@@ -203,6 +203,7 @@ export function fileHasNeedle(needle: string, pathname: string, budget?: NeedleS
   // end remains above the incremental checkpoint.
   if (observedSize !== undefined && size < observedSize) {
     done = 0;
+    ent.scanned[pathname] = 0;
     delete ent.hits[pathname];
   }
   ent.sizes[pathname] = size;

--- a/src/lib/scanner/scanCache.ts
+++ b/src/lib/scanner/scanCache.ts
@@ -7,7 +7,7 @@ import { listFilesWithProjectCatalog } from "@/lib/scanner";
 import { primeTranscriptTurnEvidence } from "@/lib/scanner/activity";
 import { globalCache } from "@/lib/scanner/caches";
 import { primePersistedLineageFacts } from "@/lib/scanner/links";
-import { coordinatedFileScan } from "@/lib/scanner/scanCoordinator";
+import { coordinatedFileScan, resetFileScanCoordinatorForTests } from "@/lib/scanner/scanCoordinator";
 import type { FileEntry, PendingQuestion } from "@/lib/types";
 import type { TurnState } from "@/lib/accounts/migration/contracts";
 
@@ -463,9 +463,10 @@ function beginPinnedFileScanRefresh(
     && generation >= slot.freshObservationGeneration;
   return installStagedFileScanRefresh(slot, generation, (publish) => instrumentFileScan(slot, generation, reason, async () => {
     /* A pin changes the scan scope, so this generation never serves joiners'
-       fences and never adopts a running scan; it still holds the process-wide
-       single-generation lease through the coordinator (#287). */
-    const pinnedSnapshot = await coordinatedFileScan({ fresh, join: false }, (intent) => listFilesWithProjectCatalog(undefined, {
+       fences, never adopts a running scan, and never merges with other pending
+       callers (their runners cannot reproduce the pin overlay); it still holds
+       the process-wide single-generation lease through the coordinator (#287). */
+    const pinnedSnapshot = await coordinatedFileScan({ fresh, join: false, exclusive: true }, (intent) => listFilesWithProjectCatalog(undefined, {
       persist: intent.persist,
       persistIndex: process.env.LLV_RESOURCE_OBSERVATION_WORKER !== "1",
       pin: pinnedPath,
@@ -813,4 +814,8 @@ export async function currentResourceFileScan(): Promise<CachedFileScan> {
 
 export function resetFilesRouteCacheForTests(): void {
   fileScanCache().clear();
+  /* The coordinator's single-generation lease lives on globalThis alongside
+     this cache. A test that leaves a gated scan unfinished would otherwise
+     wedge every later test's generations behind it. */
+  resetFileScanCoordinatorForTests();
 }

--- a/src/lib/scanner/scanCache.ts
+++ b/src/lib/scanner/scanCache.ts
@@ -7,6 +7,7 @@ import { listFilesWithProjectCatalog } from "@/lib/scanner";
 import { primeTranscriptTurnEvidence } from "@/lib/scanner/activity";
 import { globalCache } from "@/lib/scanner/caches";
 import { primePersistedLineageFacts } from "@/lib/scanner/links";
+import { coordinatedFileScan } from "@/lib/scanner/scanCoordinator";
 import type { FileEntry, PendingQuestion } from "@/lib/types";
 import type { TurnState } from "@/lib/accounts/migration/contracts";
 
@@ -379,13 +380,18 @@ function fileScanRefreshPromise(
 ): Promise<FileScanSnapshot> {
   const fresh = slot.freshObservationGeneration !== undefined
     && generation >= slot.freshObservationGeneration;
+  /* Ordinary and cold refreshes may adopt the process-wide in-flight scan
+     generation (a controller usually started it); revision-, generation- and
+     freshness-fenced refreshes require a scan started after their request and
+     merge into the single trailing generation instead (#287). */
+  const join = reason === "ordinary" || reason === "cold";
   return instrumentFileScan(slot, generation, reason, async () => {
-    const snapshot = await listFilesWithProjectCatalog(undefined, {
-      persist: false,
+    const snapshot = await coordinatedFileScan({ fresh, join }, (intent) => listFilesWithProjectCatalog(undefined, {
+      persist: intent.persist,
       persistIndex: process.env.LLV_RESOURCE_OBSERVATION_WORKER !== "1",
-      ...(fresh ? { fresh: true } : {}),
+      ...(intent.fresh ? { fresh: true } : {}),
       ...(onResourceSnapshot ? { onResourceSnapshot, resourceBaseline: slot.snapshot } : {}),
-    });
+    }));
     if (!snapshot.complete) throw new Error("filesystem scan incomplete");
     if (process.env.LLV_RESOURCE_OBSERVATION_WORKER !== "1") writePersistedFileScanSnapshot(snapshot);
     slot.snapshot = snapshot;
@@ -456,14 +462,17 @@ function beginPinnedFileScanRefresh(
   const fresh = slot.freshObservationGeneration !== undefined
     && generation >= slot.freshObservationGeneration;
   return installStagedFileScanRefresh(slot, generation, (publish) => instrumentFileScan(slot, generation, reason, async () => {
-    const pinnedSnapshot = await listFilesWithProjectCatalog(undefined, {
-      persist: false,
+    /* A pin changes the scan scope, so this generation never serves joiners'
+       fences and never adopts a running scan; it still holds the process-wide
+       single-generation lease through the coordinator (#287). */
+    const pinnedSnapshot = await coordinatedFileScan({ fresh, join: false }, (intent) => listFilesWithProjectCatalog(undefined, {
+      persist: intent.persist,
       persistIndex: process.env.LLV_RESOURCE_OBSERVATION_WORKER !== "1",
       pin: pinnedPath,
-      ...(fresh ? { fresh: true } : {}),
+      ...(intent.fresh ? { fresh: true } : {}),
       onResourceSnapshot: publish,
       resourceBaseline: slot.snapshot,
-    });
+    }));
     if (!pinnedSnapshot.complete) throw new Error("filesystem scan incomplete");
     const pinOverlayPaths = pinnedSnapshot.pinOverlayPaths ?? [];
     const overlayPathSet = new Set(pinOverlayPaths);

--- a/src/lib/scanner/scanCoordinator.test.ts
+++ b/src/lib/scanner/scanCoordinator.test.ts
@@ -135,6 +135,60 @@ test("a fenced caller never adopts a running generation and waits for a trailing
   expect((await fenced).complete).toBe(true);
 });
 
+test("an exclusive caller keeps its own runner and never adopts a covering scan", async () => {
+  const scans: RecordedScan[] = [];
+  const shared = recordingRunner(scans, "shared");
+
+  const leader = coordinatedFileScan({ persist: true, fresh: true }, shared);
+  await Promise.resolve();
+  expect(scans).toHaveLength(1);
+
+  // The running generation covers the intent, but the exclusive runner owns a
+  // private scope (a pinned path) only it can produce.
+  const pinnedScans: RecordedScan[] = [];
+  const pinned = coordinatedFileScan({ exclusive: true, join: false }, recordingRunner(pinnedScans, "pinned"));
+  await Promise.resolve();
+  expect(pinnedScans).toHaveLength(0);
+
+  scans[0]!.release();
+  await leader;
+  await Promise.resolve();
+  await Promise.resolve();
+  expect(pinnedScans).toHaveLength(1);
+  pinnedScans[0]!.release();
+  expect((await pinned).files.map((file) => file.path)).toEqual(["/sessions/pinned.jsonl"]);
+});
+
+test("later callers never merge into a queued exclusive generation", async () => {
+  const scans: RecordedScan[] = [];
+  const shared = recordingRunner(scans, "shared");
+
+  const leader = coordinatedFileScan({}, shared);
+  await Promise.resolve();
+  expect(scans).toHaveLength(1);
+
+  const pinnedScans: RecordedScan[] = [];
+  const pinned = coordinatedFileScan({ exclusive: true, join: false }, recordingRunner(pinnedScans, "pinned"));
+  // The fenced catalog caller queues its own shared generation behind the
+  // exclusive one instead of receiving the pinned runner's snapshot.
+  const fenced = coordinatedFileScan({ join: false }, shared);
+
+  scans[0]!.release();
+  await leader;
+  await Promise.resolve();
+  await Promise.resolve();
+  expect(pinnedScans).toHaveLength(1);
+  expect(scans).toHaveLength(1);
+
+  pinnedScans[0]!.release();
+  expect((await pinned).files.map((file) => file.path)).toEqual(["/sessions/pinned.jsonl"]);
+  await Promise.resolve();
+  await Promise.resolve();
+  expect(scans).toHaveLength(2);
+  scans[1]!.release();
+  expect((await fenced).files.map((file) => file.path)).toEqual(["/sessions/shared.jsonl"]);
+});
+
 test("a failed generation rejects its joiners and the next request scans again", async () => {
   resetFileScanCoordinatorForTests();
   let failures = 0;

--- a/src/lib/scanner/scanCoordinator.test.ts
+++ b/src/lib/scanner/scanCoordinator.test.ts
@@ -1,0 +1,153 @@
+import { beforeEach, expect, test } from "bun:test";
+
+import type { FileEntry } from "@/lib/types";
+
+import type { FileCatalogScan } from "./index";
+import { coordinatedFileScan, resetFileScanCoordinatorForTests, type CoordinatedScanRunner } from "./scanCoordinator";
+
+beforeEach(() => {
+  resetFileScanCoordinatorForTests();
+});
+
+function snapshotFor(marker: string): FileCatalogScan {
+  return {
+    files: [{ path: `/sessions/${marker}.jsonl`, root: "codex-sessions" } as unknown as FileEntry],
+    projectCatalog: [{ project: marker, smt: 1, conversations: 1 }],
+    complete: true,
+  };
+}
+
+interface RecordedScan {
+  intent: { persist: boolean; fresh: boolean };
+  release: () => void;
+}
+
+function recordingRunner(scans: RecordedScan[], marker = "corpus"): CoordinatedScanRunner {
+  return (intent) => new Promise((resolve) => {
+    scans.push({ intent, release: () => resolve(snapshotFor(marker)) });
+  });
+}
+
+test("simultaneous HTTP, pipeline, and account requests produce one scanner invocation", async () => {
+  const scans: RecordedScan[] = [];
+  const runner = recordingRunner(scans);
+
+  const http = coordinatedFileScan({}, runner);
+  const pipeline = coordinatedFileScan({ persist: true }, runner);
+  const account = coordinatedFileScan({ persist: true }, runner);
+  await Promise.resolve();
+  expect(scans).toHaveLength(1);
+  // The single generation carries the union of the callers' intents.
+  expect(scans[0]!.intent).toEqual({ persist: true, fresh: false });
+
+  scans[0]!.release();
+  const [httpScan, pipelineScan, accountScan] = await Promise.all([http, pipeline, account]);
+  for (const scan of [httpScan, pipelineScan, accountScan]) {
+    expect(scan.complete).toBe(true);
+    expect(scan.files.map((file) => file.path)).toEqual(["/sessions/corpus.jsonl"]);
+  }
+  expect(scans).toHaveLength(1);
+});
+
+test("each consumer owns a private snapshot clone", async () => {
+  const scans: RecordedScan[] = [];
+  const runner = recordingRunner(scans);
+
+  const first = coordinatedFileScan({ persist: true }, runner);
+  const second = coordinatedFileScan({}, runner);
+  await Promise.resolve();
+  scans[0]!.release();
+  const [firstScan, secondScan] = await Promise.all([first, second]);
+
+  // A controller mutating its reconciliation copy cannot corrupt another
+  // consumer's snapshot.
+  firstScan.files[0]!.path = "/sessions/mutated.jsonl";
+  expect(secondScan.files[0]!.path).toBe("/sessions/corpus.jsonl");
+});
+
+test("a caller joins a covering in-flight generation instead of scanning again", async () => {
+  const scans: RecordedScan[] = [];
+  const runner = recordingRunner(scans);
+
+  const leader = coordinatedFileScan({ persist: true }, runner);
+  await Promise.resolve();
+  expect(scans).toHaveLength(1);
+
+  const joiner = coordinatedFileScan({}, runner);
+  await Promise.resolve();
+  expect(scans).toHaveLength(1);
+
+  scans[0]!.release();
+  await Promise.all([leader, joiner]);
+  expect(scans).toHaveLength(1);
+});
+
+test("an uncovered intent merges into exactly one trailing generation", async () => {
+  const scans: RecordedScan[] = [];
+  const runner = recordingRunner(scans);
+
+  const plain = coordinatedFileScan({}, runner);
+  await Promise.resolve();
+  expect(scans).toHaveLength(1);
+  expect(scans[0]!.intent).toEqual({ persist: false, fresh: false });
+
+  // Both controllers need persistence the running scan cannot provide; they
+  // coalesce into one trailing generation instead of two.
+  const pipeline = coordinatedFileScan({ persist: true }, runner);
+  const account = coordinatedFileScan({ persist: true, fresh: true }, runner);
+  await Promise.resolve();
+  expect(scans).toHaveLength(1);
+
+  scans[0]!.release();
+  await plain;
+  await Promise.resolve();
+  await Promise.resolve();
+  expect(scans).toHaveLength(2);
+  expect(scans[1]!.intent).toEqual({ persist: true, fresh: true });
+
+  scans[1]!.release();
+  const [pipelineScan, accountScan] = await Promise.all([pipeline, account]);
+  expect(pipelineScan.complete).toBe(true);
+  expect(accountScan.complete).toBe(true);
+  expect(scans).toHaveLength(2);
+});
+
+test("a fenced caller never adopts a running generation and waits for a trailing scan", async () => {
+  const scans: RecordedScan[] = [];
+  const runner = recordingRunner(scans);
+
+  const leader = coordinatedFileScan({ persist: true, fresh: true }, runner);
+  await Promise.resolve();
+  expect(scans).toHaveLength(1);
+
+  // The running generation covers the intent, but the fence requires a scan
+  // that starts after this request.
+  const fenced = coordinatedFileScan({ fresh: true, join: false }, runner);
+  await Promise.resolve();
+  expect(scans).toHaveLength(1);
+
+  scans[0]!.release();
+  await leader;
+  await Promise.resolve();
+  await Promise.resolve();
+  expect(scans).toHaveLength(2);
+  scans[1]!.release();
+  expect((await fenced).complete).toBe(true);
+});
+
+test("a failed generation rejects its joiners and the next request scans again", async () => {
+  resetFileScanCoordinatorForTests();
+  let failures = 0;
+  const failing: CoordinatedScanRunner = async () => {
+    failures += 1;
+    throw new Error("scanner exploded");
+  };
+  await expect(coordinatedFileScan({}, failing)).rejects.toThrow("scanner exploded");
+  expect(failures).toBe(1);
+
+  const scans: RecordedScan[] = [];
+  const recovery = coordinatedFileScan({}, recordingRunner(scans));
+  await Promise.resolve();
+  scans[0]!.release();
+  expect((await recovery).complete).toBe(true);
+});

--- a/src/lib/scanner/scanCoordinator.test.ts
+++ b/src/lib/scanner/scanCoordinator.test.ts
@@ -159,6 +159,25 @@ test("an exclusive caller keeps its own runner and never adopts a covering scan"
   expect((await pinned).files.map((file) => file.path)).toEqual(["/sessions/pinned.jsonl"]);
 });
 
+test("a catalog joiner never adopts a running exclusive generation", async () => {
+  const pinnedScans: RecordedScan[] = [];
+  const pinned = coordinatedFileScan({ exclusive: true, join: false }, recordingRunner(pinnedScans, "pinned"));
+  await Promise.resolve();
+  expect(pinnedScans).toHaveLength(1);
+
+  // The pinned scan's snapshot carries its private overlay; an ordinary
+  // catalog caller must wait for a shared generation instead of adopting it.
+  const scans: RecordedScan[] = [];
+  const joiner = coordinatedFileScan({}, recordingRunner(scans, "shared"));
+  pinnedScans[0]!.release();
+  await pinned;
+  await Promise.resolve();
+  await Promise.resolve();
+  expect(scans).toHaveLength(1);
+  scans[0]!.release();
+  expect((await joiner).files.map((file) => file.path)).toEqual(["/sessions/shared.jsonl"]);
+});
+
 test("later callers never merge into a queued exclusive generation", async () => {
   const scans: RecordedScan[] = [];
   const shared = recordingRunner(scans, "shared");

--- a/src/lib/scanner/scanCoordinator.ts
+++ b/src/lib/scanner/scanCoordinator.ts
@@ -45,6 +45,9 @@ export type CoordinatedScanRunner = (intent: ResolvedScanIntent) => Promise<File
 interface InflightGeneration {
   generation: number;
   intent: ResolvedScanIntent;
+  /** An exclusive generation's snapshot carries private scope (a pin overlay);
+      joiners must never adopt it as the shared catalog. */
+  exclusive: boolean;
   promise: Promise<FileCatalogScan>;
 }
 
@@ -86,7 +89,12 @@ const defaultRunner: CoordinatedScanRunner = (intent) => listFilesWithProjectCat
   ...(intent.fresh ? { fresh: true } : {}),
 });
 
-function startGeneration(state: CoordinatorState, intent: ResolvedScanIntent, runner: CoordinatedScanRunner): InflightGeneration {
+function startGeneration(
+  state: CoordinatorState,
+  intent: ResolvedScanIntent,
+  runner: CoordinatedScanRunner,
+  exclusive: boolean,
+): InflightGeneration {
   state.generation += 1;
   let scan: Promise<FileCatalogScan>;
   try {
@@ -97,6 +105,7 @@ function startGeneration(state: CoordinatorState, intent: ResolvedScanIntent, ru
   const inflight: InflightGeneration = {
     generation: state.generation,
     intent,
+    exclusive,
     promise: scan.finally(() => {
       if (state.inflight === inflight) state.inflight = undefined;
       scheduleStart(state);
@@ -117,7 +126,7 @@ function scheduleStart(state: CoordinatorState): void {
     if (state.inflight) return;
     const pending = state.queue.shift();
     if (!pending) return;
-    startGeneration(state, pending.intent, pending.runner).promise.then(pending.resolve, pending.reject);
+    startGeneration(state, pending.intent, pending.runner, pending.exclusive).promise.then(pending.resolve, pending.reject);
   });
 }
 
@@ -164,7 +173,7 @@ export async function coordinatedFileScan(
   const wanted: ResolvedScanIntent = { persist: intent.persist === true, fresh: intent.fresh === true };
   const exclusive = intent.exclusive === true;
   const inflight = state.inflight;
-  const snapshot = !exclusive && inflight && intent.join !== false && covers(inflight.intent, wanted)
+  const snapshot = !exclusive && inflight && !inflight.exclusive && intent.join !== false && covers(inflight.intent, wanted)
     ? await inflight.promise
     : await enqueue(state, wanted, runner, exclusive);
   return structuredClone(snapshot);

--- a/src/lib/scanner/scanCoordinator.ts
+++ b/src/lib/scanner/scanCoordinator.ts
@@ -27,6 +27,12 @@ export interface FileScanIntent {
       contract requires a scan that STARTED after the request, so they merge
       into the single trailing generation instead. */
   join?: boolean;
+  /** The caller's runner carries private scan scope (a pinned path, a staged
+      resource publisher) that other callers' runners cannot reproduce. An
+      exclusive generation never merges with other pending callers and other
+      callers never merge into it — it still holds the process-wide
+      single-generation lease and queues behind the running scan. */
+  exclusive?: boolean;
 }
 
 interface ResolvedScanIntent {
@@ -45,6 +51,7 @@ interface InflightGeneration {
 interface PendingGeneration {
   intent: ResolvedScanIntent;
   runner: CoordinatedScanRunner;
+  exclusive: boolean;
   promise: Promise<FileCatalogScan>;
   resolve: (snapshot: FileCatalogScan) => void;
   reject: (error: unknown) => void;
@@ -53,7 +60,9 @@ interface PendingGeneration {
 interface CoordinatorState {
   generation: number;
   inflight?: InflightGeneration;
-  pending?: PendingGeneration;
+  /** FIFO of generations waiting for the single-generation lease. At most one
+      entry is shared (non-exclusive); every other entry owns a private scope. */
+  queue: PendingGeneration[];
   startScheduled: boolean;
 }
 
@@ -65,7 +74,7 @@ const coordinatorHost = globalThis as typeof globalThis & {
 };
 
 function coordinatorState(): CoordinatorState {
-  return coordinatorHost.__llvFileScanCoordinator ??= { generation: 0, startScheduled: false };
+  return coordinatorHost.__llvFileScanCoordinator ??= { generation: 0, queue: [], startScheduled: false };
 }
 
 function covers(running: ResolvedScanIntent, wanted: ResolvedScanIntent): boolean {
@@ -105,21 +114,32 @@ function scheduleStart(state: CoordinatorState): void {
   state.startScheduled = true;
   queueMicrotask(() => {
     state.startScheduled = false;
-    if (state.inflight || !state.pending) return;
-    const pending = state.pending;
-    state.pending = undefined;
+    if (state.inflight) return;
+    const pending = state.queue.shift();
+    if (!pending) return;
     startGeneration(state, pending.intent, pending.runner).promise.then(pending.resolve, pending.reject);
   });
 }
 
-function enqueue(state: CoordinatorState, intent: ResolvedScanIntent, runner: CoordinatedScanRunner): Promise<FileCatalogScan> {
-  const pending = state.pending;
-  if (pending) {
-    pending.intent = {
-      persist: pending.intent.persist || intent.persist,
-      fresh: pending.intent.fresh || intent.fresh,
-    };
-    return pending.promise;
+function enqueue(
+  state: CoordinatorState,
+  intent: ResolvedScanIntent,
+  runner: CoordinatedScanRunner,
+  exclusive: boolean,
+): Promise<FileCatalogScan> {
+  if (!exclusive) {
+    /* Only the shared pending generation accepts extra callers: an exclusive
+       pending runs a runner whose scope (pin, staged publisher) would not
+       satisfy them, and merging INTO an exclusive one would widen its scan
+       past what its owner requested. */
+    const shared = state.queue.find((pending) => !pending.exclusive);
+    if (shared) {
+      shared.intent = {
+        persist: shared.intent.persist || intent.persist,
+        fresh: shared.intent.fresh || intent.fresh,
+      };
+      return shared.promise;
+    }
   }
   let resolve!: (snapshot: FileCatalogScan) => void;
   let reject!: (error: unknown) => void;
@@ -127,7 +147,7 @@ function enqueue(state: CoordinatorState, intent: ResolvedScanIntent, runner: Co
     resolve = res;
     reject = rej;
   });
-  state.pending = { intent, runner, promise, resolve, reject };
+  state.queue.push({ intent, runner, exclusive, promise, resolve, reject });
   scheduleStart(state);
   return promise;
 }
@@ -142,10 +162,11 @@ export async function coordinatedFileScan(
 ): Promise<FileCatalogScan> {
   const state = coordinatorState();
   const wanted: ResolvedScanIntent = { persist: intent.persist === true, fresh: intent.fresh === true };
+  const exclusive = intent.exclusive === true;
   const inflight = state.inflight;
-  const snapshot = inflight && intent.join !== false && covers(inflight.intent, wanted)
+  const snapshot = !exclusive && inflight && intent.join !== false && covers(inflight.intent, wanted)
     ? await inflight.promise
-    : await enqueue(state, wanted, runner);
+    : await enqueue(state, wanted, runner, exclusive);
   return structuredClone(snapshot);
 }
 

--- a/src/lib/scanner/scanCoordinator.ts
+++ b/src/lib/scanner/scanCoordinator.ts
@@ -1,0 +1,161 @@
+import { listFilesWithProjectCatalog, type FileCatalogScan } from "@/lib/scanner";
+
+/**
+ * Process-wide filesystem scan coordination (#287).
+ *
+ * Three independent producers used to own scan generations: the HTTP files
+ * cache (10 s cadence), the flow/pipeline watchdog (30 s), and the account
+ * controller (60 s). Each ran the raw scanner directly, so cold or invalidated
+ * generations overlapped and multiplied corpus reads. This coordinator makes
+ * one scan generation active per process: concurrent callers whose intents are
+ * covered join the in-flight generation, and callers needing more (durable
+ * persistence, fresh process observation) merge into exactly one trailing
+ * generation that starts after the current one settles.
+ *
+ * Every caller receives its own deep clone of the completed snapshot, so a
+ * controller mutating its reconciliation copy can never corrupt the snapshot
+ * another consumer published or cached.
+ */
+
+export interface FileScanIntent {
+  /** Durable lineage/state persistence must run inside the scan. */
+  persist?: boolean;
+  /** Process and pane observations must refresh before hydration. */
+  fresh?: boolean;
+  /** Whether an already-running covering generation may serve this caller
+      (default true). Revision- and freshness-fenced callers pass false: their
+      contract requires a scan that STARTED after the request, so they merge
+      into the single trailing generation instead. */
+  join?: boolean;
+}
+
+interface ResolvedScanIntent {
+  persist: boolean;
+  fresh: boolean;
+}
+
+export type CoordinatedScanRunner = (intent: ResolvedScanIntent) => Promise<FileCatalogScan>;
+
+interface InflightGeneration {
+  generation: number;
+  intent: ResolvedScanIntent;
+  promise: Promise<FileCatalogScan>;
+}
+
+interface PendingGeneration {
+  intent: ResolvedScanIntent;
+  runner: CoordinatedScanRunner;
+  promise: Promise<FileCatalogScan>;
+  resolve: (snapshot: FileCatalogScan) => void;
+  reject: (error: unknown) => void;
+}
+
+interface CoordinatorState {
+  generation: number;
+  inflight?: InflightGeneration;
+  pending?: PendingGeneration;
+  startScheduled: boolean;
+}
+
+/* Next.js can instantiate this module more than once per process (dev hot
+   reload, duplicate bundles); the state hangs off globalThis so every copy
+   shares the same single-flight authority. */
+const coordinatorHost = globalThis as typeof globalThis & {
+  __llvFileScanCoordinator?: CoordinatorState;
+};
+
+function coordinatorState(): CoordinatorState {
+  return coordinatorHost.__llvFileScanCoordinator ??= { generation: 0, startScheduled: false };
+}
+
+function covers(running: ResolvedScanIntent, wanted: ResolvedScanIntent): boolean {
+  return (running.persist || !wanted.persist) && (running.fresh || !wanted.fresh);
+}
+
+const defaultRunner: CoordinatedScanRunner = (intent) => listFilesWithProjectCatalog(undefined, {
+  persist: intent.persist,
+  ...(intent.fresh ? { fresh: true } : {}),
+});
+
+function startGeneration(state: CoordinatorState, intent: ResolvedScanIntent, runner: CoordinatedScanRunner): InflightGeneration {
+  state.generation += 1;
+  let scan: Promise<FileCatalogScan>;
+  try {
+    scan = Promise.resolve(runner(intent));
+  } catch (error) {
+    scan = Promise.reject(error);
+  }
+  const inflight: InflightGeneration = {
+    generation: state.generation,
+    intent,
+    promise: scan.finally(() => {
+      if (state.inflight === inflight) state.inflight = undefined;
+      scheduleStart(state);
+    }),
+  };
+  state.inflight = inflight;
+  return inflight;
+}
+
+/* Truly simultaneous requests merge inside one microtask turn, so a burst of
+   HTTP, pipeline, and account callers produces one scanner invocation with the
+   union of their intents rather than a leader scan plus a trailing one. */
+function scheduleStart(state: CoordinatorState): void {
+  if (state.startScheduled) return;
+  state.startScheduled = true;
+  queueMicrotask(() => {
+    state.startScheduled = false;
+    if (state.inflight || !state.pending) return;
+    const pending = state.pending;
+    state.pending = undefined;
+    startGeneration(state, pending.intent, pending.runner).promise.then(pending.resolve, pending.reject);
+  });
+}
+
+function enqueue(state: CoordinatorState, intent: ResolvedScanIntent, runner: CoordinatedScanRunner): Promise<FileCatalogScan> {
+  const pending = state.pending;
+  if (pending) {
+    pending.intent = {
+      persist: pending.intent.persist || intent.persist,
+      fresh: pending.intent.fresh || intent.fresh,
+    };
+    return pending.promise;
+  }
+  let resolve!: (snapshot: FileCatalogScan) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<FileCatalogScan>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  state.pending = { intent, runner, promise, resolve, reject };
+  scheduleStart(state);
+  return promise;
+}
+
+/**
+ * Join or start the process-wide scan generation satisfying `intent`. The
+ * resolved snapshot is a private deep clone owned by the caller.
+ */
+export async function coordinatedFileScan(
+  intent: FileScanIntent = {},
+  runner: CoordinatedScanRunner = defaultRunner,
+): Promise<FileCatalogScan> {
+  const state = coordinatorState();
+  const wanted: ResolvedScanIntent = { persist: intent.persist === true, fresh: intent.fresh === true };
+  const inflight = state.inflight;
+  const snapshot = inflight && intent.join !== false && covers(inflight.intent, wanted)
+    ? await inflight.promise
+    : await enqueue(state, wanted, runner);
+  return structuredClone(snapshot);
+}
+
+/** Controller-facing seam: pipeline and account reconciliation consume the
+    shared generation with durable persistence and keep ownership of their
+    mutation phases; they never fan out extra scanner invocations. */
+export function coordinatedControllerScan(): Promise<FileCatalogScan> {
+  return coordinatedFileScan({ persist: true });
+}
+
+export function resetFileScanCoordinatorForTests(): void {
+  coordinatorHost.__llvFileScanCoordinator = undefined;
+}

--- a/src/lib/session/reader.performance.test.ts
+++ b/src/lib/session/reader.performance.test.ts
@@ -108,6 +108,29 @@ test("an exhausted shared budget preserves a resumable checkpoint without valida
   expect(checkpointFor(pathname)).toEqual(checkpoint);
 });
 
+test("a pre-aborted resumed scan preserves its checkpoint without validating its head", async () => {
+  const pathname = virtualTranscript("resumed-pre-aborted.jsonl", 16 * MIB);
+  await scanUserAuthoredMessagesCooperatively(pathname, "codex", 1, {
+    resume: true,
+    maxBytes: 4 * MIB,
+  });
+  const checkpoint = checkpointFor(pathname)!;
+  const budget: AuthorshipScanBudget = { remaining: 128 * 1024 };
+  const abort = new AbortController();
+  abort.abort();
+
+  const resumed = await scanUserAuthoredMessagesCooperatively(pathname, "codex", 1, {
+    resume: true,
+    maxBytes: 4 * MIB,
+    budget,
+    signal: abort.signal,
+  });
+
+  expect(resumed).toEqual({ count: checkpoint.count, complete: false });
+  expect(budget.remaining).toBe(128 * 1024);
+  expect(checkpointFor(pathname)).toEqual(checkpoint);
+});
+
 test("cancellation lands on a 64 KiB chunk boundary and keeps the checkpoint resumable", async () => {
   const pathname = virtualTranscript("aborted.jsonl");
   const abort = new AbortController();

--- a/src/lib/session/reader.performance.test.ts
+++ b/src/lib/session/reader.performance.test.ts
@@ -85,6 +85,29 @@ test("an exhausted shared budget refuses the pass without touching the transcrip
   expect(budget.remaining).toBe(0);
 });
 
+test("an exhausted shared budget preserves a resumable checkpoint without validating its head", async () => {
+  const pathname = virtualTranscript("resumed-budget-exhausted.jsonl", 16 * MIB);
+
+  const first = await scanUserAuthoredMessagesCooperatively(pathname, "codex", 1, {
+    resume: true,
+    maxBytes: 4 * MIB,
+  });
+  expect(first).toEqual({ count: 0, complete: false });
+  const checkpoint = checkpointFor(pathname)!;
+  expect(checkpoint.offset).toBe(4 * MIB);
+
+  const budget: AuthorshipScanBudget = { remaining: 0 };
+  const resumed = await scanUserAuthoredMessagesCooperatively(pathname, "codex", 1, {
+    resume: true,
+    maxBytes: 4 * MIB,
+    budget,
+  });
+
+  expect(resumed).toEqual({ count: 0, complete: false });
+  expect(budget.remaining).toBe(0);
+  expect(checkpointFor(pathname)).toEqual(checkpoint);
+});
+
 test("cancellation lands on a 64 KiB chunk boundary and keeps the checkpoint resumable", async () => {
   const pathname = virtualTranscript("aborted.jsonl");
   const abort = new AbortController();

--- a/src/lib/session/reader.performance.test.ts
+++ b/src/lib/session/reader.performance.test.ts
@@ -1,0 +1,134 @@
+import { afterAll, expect, test } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { globalCache } from "@/lib/scanner/caches";
+
+import {
+  scanUserAuthoredMessagesCooperatively,
+  type AuthorshipScanBudget,
+} from "./reader";
+
+const SANDBOX = fs.mkdtempSync(path.join(os.tmpdir(), "llv-reader-performance-"));
+const GIB = 1024 * 1024 * 1024;
+const MIB = 1024 * 1024;
+
+afterAll(() => {
+  fs.rmSync(SANDBOX, { recursive: true, force: true });
+});
+
+interface Checkpoint {
+  offset: number;
+  count: number;
+  done: boolean;
+}
+
+function checkpointFor(pathname: string): Checkpoint | undefined {
+  return globalCache<Checkpoint>("authorship-scan-checkpoint-v1").get(pathname);
+}
+
+/** A logical 3 GiB transcript without an owner message: agent rows at the
+    head, a sparse hole for the bulk. */
+function virtualTranscript(name: string, logicalBytes = 3 * GIB): string {
+  const pathname = path.join(SANDBOX, name);
+  const fd = fs.openSync(pathname, "w");
+  try {
+    for (let row = 0; row < 16; row += 1) {
+      fs.writeSync(fd, `${JSON.stringify({ type: "event_msg", payload: { type: "agent_message", message: `progress ${row}` } })}\n`);
+    }
+    fs.ftruncateSync(fd, logicalBytes);
+  } finally {
+    fs.closeSync(fd);
+  }
+  return pathname;
+}
+
+test("a 3 GiB ownerless transcript stops at the exact per-pass byte ceiling and resumes", async () => {
+  const pathname = virtualTranscript("owner-absent.jsonl");
+  const budget: AuthorshipScanBudget = { remaining: 32 * MIB };
+
+  const first = await scanUserAuthoredMessagesCooperatively(pathname, "codex", 1, {
+    resume: true,
+    maxBytes: 4 * MIB,
+    budget,
+  });
+
+  expect(first).toEqual({ count: 0, complete: false });
+  expect(checkpointFor(pathname)!.offset).toBe(4 * MIB);
+  expect(budget.remaining).toBe(28 * MIB);
+
+  // A later cycle resumes from the recorded offset instead of restarting.
+  const second = await scanUserAuthoredMessagesCooperatively(pathname, "codex", 1, {
+    resume: true,
+    maxBytes: 4 * MIB,
+    budget,
+  });
+
+  expect(second).toEqual({ count: 0, complete: false });
+  // The resumed pass pays its 64 KiB head-fingerprint validation and then
+  // continues forward; the first 4 MiB are never re-scanned.
+  expect(checkpointFor(pathname)!.offset).toBe(8 * MIB - 64 * 1024);
+  expect(budget.remaining).toBe(24 * MIB);
+});
+
+test("an exhausted shared budget refuses the pass without touching the transcript", async () => {
+  const pathname = virtualTranscript("budget-exhausted.jsonl", 16 * MIB);
+  const budget: AuthorshipScanBudget = { remaining: 0 };
+
+  const scan = await scanUserAuthoredMessagesCooperatively(pathname, "codex", 1, {
+    maxBytes: 4 * MIB,
+    budget,
+  });
+
+  expect(scan).toEqual({ count: 0, complete: false });
+  expect(budget.remaining).toBe(0);
+});
+
+test("cancellation lands on a 64 KiB chunk boundary and keeps the checkpoint resumable", async () => {
+  const pathname = virtualTranscript("aborted.jsonl");
+  const abort = new AbortController();
+  setTimeout(() => abort.abort(), 0);
+
+  const scan = await scanUserAuthoredMessagesCooperatively(pathname, "codex", 1, {
+    resume: true,
+    signal: abort.signal,
+  });
+
+  expect(scan.complete).toBe(false);
+  const checkpoint = checkpointFor(pathname)!;
+  expect(checkpoint.done).toBe(false);
+  expect(checkpoint.offset).toBeLessThan(3 * GIB);
+  expect(checkpoint.offset % (64 * 1024)).toBe(0);
+});
+
+test("a truncated transcript resets its checkpoint instead of replaying stale evidence", async () => {
+  const pathname = virtualTranscript("truncated.jsonl", 8 * MIB);
+  const first = await scanUserAuthoredMessagesCooperatively(pathname, "codex", 1, {
+    resume: true,
+    maxBytes: 4 * MIB,
+  });
+  expect(first).toEqual({ count: 0, complete: false });
+  expect(checkpointFor(pathname)!.offset).toBe(4 * MIB);
+
+  // Replace the file with a short transcript that contains a human message.
+  fs.writeFileSync(pathname, `${JSON.stringify({ type: "event_msg", payload: { type: "user_message", message: "hello" } })}\n`);
+
+  const second = await scanUserAuthoredMessagesCooperatively(pathname, "codex", 1, { resume: true });
+  expect(second.count).toBe(1);
+});
+
+test("a finished scan replays its verdict from the checkpoint without re-reading", async () => {
+  const pathname = path.join(SANDBOX, "finished.jsonl");
+  fs.writeFileSync(pathname, `${JSON.stringify({ type: "event_msg", payload: { type: "agent_message", message: "done" } })}\n`);
+
+  const first = await scanUserAuthoredMessagesCooperatively(pathname, "codex", 1, { resume: true });
+  expect(first).toEqual({ count: 0, complete: true });
+  expect(checkpointFor(pathname)!.done).toBe(true);
+
+  const budget: AuthorshipScanBudget = { remaining: 128 };
+  const second = await scanUserAuthoredMessagesCooperatively(pathname, "codex", 1, { resume: true, budget });
+  expect(second).toEqual({ count: 0, complete: true });
+  // Only the head-fingerprint validation window was read.
+  expect(budget.remaining).toBe(128 - fs.statSync(pathname).size);
+});

--- a/src/lib/session/reader.ts
+++ b/src/lib/session/reader.ts
@@ -425,6 +425,9 @@ export async function scanUserAuthoredMessagesCooperatively(
       // the recorded offset no longer describes this file's content.
       let valid = checkpoint.dev === stat.dev && checkpoint.ino === stat.ino && stat.size >= checkpoint.offset;
       if (valid && checkpoint.headBytes > 0) {
+        if (options.signal?.aborted) {
+          return { count: checkpoint.count, complete: false };
+        }
         if (authorshipAllowance(options, charged) < checkpoint.headBytes) {
           return { count: checkpoint.count, complete: false };
         }

--- a/src/lib/session/reader.ts
+++ b/src/lib/session/reader.ts
@@ -1,7 +1,8 @@
+import { createHash } from "node:crypto";
 import fs from "node:fs";
-import { StringDecoder } from "node:string_decoder";
 
 import { yieldToRuntime } from "@/lib/cooperative";
+import { globalCache } from "@/lib/scanner/caches";
 import type { Engine } from "@/lib/types";
 
 export type SessionRecordKind = "message" | "reasoning" | "tool_call" | "tool_result" | "trace";
@@ -214,7 +215,8 @@ export function readSession(pathname: string, engine: Extract<Engine, "claude" |
 }
 
 const AUTHORSHIP_SCAN_CHUNK_BYTES = 64 * 1024;
-const AUTHORSHIP_SCAN_MAX_RECORD_CHARS = 8 * 1024 * 1024;
+const AUTHORSHIP_SCAN_MAX_RECORD_BYTES = 8 * 1024 * 1024;
+const AUTHORSHIP_CHECKPOINT_HEAD_BYTES = 64 * 1024;
 
 function recordHasUserMessage(record: Record<string, unknown>, engine: Extract<Engine, "claude" | "codex">): boolean {
   if (engine === "claude") {
@@ -234,14 +236,67 @@ export interface AuthorshipScanResult {
   complete: boolean;
 }
 
-function createAuthorshipScanner(engine: Extract<Engine, "claude" | "codex">, limit: number) {
-  let count = 0;
-  let complete = true;
-  let pending = "";
-  let skippingRecord = false;
-  const decoder = new StringDecoder("utf8");
-  const consume = (line: string): boolean => {
-    const text = line.trim();
+/** Shared hard byte allowance across one controller generation. Exhaustion
+    returns `complete: false`; the persisted per-path checkpoint resumes the
+    scan in a later cycle instead of restarting a multi-gigabyte pass. */
+export interface AuthorshipScanBudget {
+  remaining: number;
+}
+
+export interface AuthorshipScanOptions {
+  /** Cooperative cancellation observed between 64 KiB chunks. */
+  signal?: AbortSignal;
+  /** Hard ceiling of bytes this call may read from the transcript. */
+  maxBytes?: number;
+  /** Shared cross-file allowance charged with every byte actually read. */
+  budget?: AuthorshipScanBudget;
+  /** Reuse and update the process-wide resumable checkpoint for this path. */
+  resume?: boolean;
+}
+
+interface AuthorshipScanCheckpoint {
+  dev: number;
+  ino: number;
+  size: number;
+  mtimeMs: number;
+  /** Absolute offset of the next unread byte. */
+  offset: number;
+  /** Raw bytes of the unterminated line preceding `offset`. */
+  carry: Buffer;
+  skippingRecord: boolean;
+  count: number;
+  parseComplete: boolean;
+  headBytes: number;
+  headFingerprint: string;
+  /** The scan reached EOF at `size`; only appended bytes remain unread. */
+  done: boolean;
+}
+
+const authorshipCheckpoints = globalCache<AuthorshipScanCheckpoint>("authorship-scan-checkpoint-v1");
+
+interface AuthorshipScannerState {
+  count: number;
+  carry: Buffer;
+  skippingRecord: boolean;
+  parseComplete: boolean;
+}
+
+/* Lines assemble at the byte level so a checkpoint can persist the exact
+   scanner state (offset + unterminated-line bytes) without decoder state.
+   Every complete line decodes independently — JSONL records never contain
+   raw newlines, so per-line UTF-8 decoding matches streaming decoding. */
+function createAuthorshipScanner(
+  engine: Extract<Engine, "claude" | "codex">,
+  limit: number,
+  initial?: AuthorshipScannerState,
+) {
+  let count = initial?.count ?? 0;
+  let complete = initial?.parseComplete ?? true;
+  let skippingRecord = initial?.skippingRecord ?? false;
+  let pending: Buffer[] = initial?.carry.length ? [Buffer.from(initial.carry)] : [];
+  let pendingBytes = initial?.carry.length ?? 0;
+  const consume = (line: Buffer): boolean => {
+    const text = line.toString("utf8").trim();
     if (!text) return false;
     try {
       const parsed = JSON.parse(text) as unknown;
@@ -252,38 +307,50 @@ function createAuthorshipScanner(engine: Extract<Engine, "claude" | "codex">, li
       return false;
     }
   };
-  const consumeDecoded = (decoded: string): boolean => {
-    let cursor = 0;
-    while (cursor < decoded.length) {
-      const newline = decoded.indexOf("\n", cursor);
-      const end = newline === -1 ? decoded.length : newline;
-      if (!skippingRecord) {
-        pending += decoded.slice(cursor, end);
-        if (pending.length > AUTHORSHIP_SCAN_MAX_RECORD_CHARS) {
-          pending = "";
-          skippingRecord = true;
-          complete = false;
-        }
-      }
-      if (newline === -1) return false;
-      if (!skippingRecord && consume(pending)) {
-        count += 1;
-        if (count >= limit) return true;
-      }
-      pending = "";
-      skippingRecord = false;
-      cursor = newline + 1;
-    }
-    return false;
+  const resetLine = () => {
+    pending = [];
+    pendingBytes = 0;
+    skippingRecord = false;
   };
   return {
-    consume(chunk: Uint8Array): boolean {
-      return consumeDecoded(decoder.write(chunk));
+    consume(chunk: Buffer): boolean {
+      let cursor = 0;
+      while (cursor <= chunk.length) {
+        const newline = chunk.indexOf(0x0a, cursor);
+        if (newline === -1) {
+          const rest = chunk.length - cursor;
+          if (!skippingRecord && rest > 0) {
+            if (pendingBytes + rest > AUTHORSHIP_SCAN_MAX_RECORD_BYTES) {
+              pending = [];
+              pendingBytes = 0;
+              skippingRecord = true;
+              complete = false;
+            } else {
+              pending.push(Buffer.from(chunk.subarray(cursor)));
+              pendingBytes += rest;
+            }
+          }
+          return false;
+        }
+        if (!skippingRecord) {
+          const segment = chunk.subarray(cursor, newline);
+          if (pendingBytes + segment.length > AUTHORSHIP_SCAN_MAX_RECORD_BYTES) {
+            complete = false;
+          } else if (consume(pendingBytes ? Buffer.concat([...pending, segment]) : segment)) {
+            count += 1;
+            if (count >= limit) {
+              resetLine();
+              return true;
+            }
+          }
+        }
+        resetLine();
+        cursor = newline + 1;
+      }
+      return false;
     },
     finish(): AuthorshipScanResult {
-      const tail = decoder.end();
-      if (tail && consumeDecoded(tail)) return { count, complete };
-      if (!skippingRecord && Boolean(pending) && consume(pending)) count += 1;
+      if (!skippingRecord && pendingBytes > 0 && consume(Buffer.concat(pending))) count += 1;
       return { count, complete };
     },
     result(): AuthorshipScanResult {
@@ -291,6 +358,14 @@ function createAuthorshipScanner(engine: Extract<Engine, "claude" | "codex">, li
     },
     failed(): AuthorshipScanResult {
       return { count, complete: false };
+    },
+    state(): AuthorshipScannerState {
+      return {
+        count,
+        carry: pendingBytes ? Buffer.concat(pending) : Buffer.alloc(0),
+        skippingRecord,
+        parseComplete: complete,
+      };
     },
   };
 }
@@ -318,30 +393,115 @@ export function scanUserAuthoredMessages(
   }
 }
 
+function authorshipHeadFingerprint(bytes: Uint8Array): string {
+  return createHash("sha256").update(bytes).digest("base64url");
+}
+
+/** Bytes this pass may still read under the caller's combined ceilings. */
+function authorshipAllowance(options: AuthorshipScanOptions, charged: number): number {
+  const perCall = (options.maxBytes ?? Number.POSITIVE_INFINITY) - charged;
+  const shared = options.budget === undefined ? Number.POSITIVE_INFINITY : options.budget.remaining;
+  return Math.min(perCall, shared);
+}
+
 export async function scanUserAuthoredMessagesCooperatively(
   pathname: string,
   engine: Extract<Engine, "claude" | "codex">,
   limit = Number.MAX_SAFE_INTEGER,
+  options: AuthorshipScanOptions = {},
 ): Promise<AuthorshipScanResult> {
-  const scanner = createAuthorshipScanner(engine, limit);
   let file: Awaited<ReturnType<typeof fs.promises.open>> | null = null;
+  let charged = 0;
+  const charge = (bytes: number) => {
+    charged += bytes;
+    if (options.budget) options.budget.remaining -= bytes;
+  };
   try {
     file = await fs.promises.open(pathname, "r");
+    const stat = await file.stat();
+    let checkpoint = options.resume ? authorshipCheckpoints.get(pathname) : undefined;
+    if (checkpoint) {
+      // Truncation, replacement, or a rewritten head resets the checkpoint:
+      // the recorded offset no longer describes this file's content.
+      let valid = checkpoint.dev === stat.dev && checkpoint.ino === stat.ino && stat.size >= checkpoint.offset;
+      if (valid && checkpoint.headBytes > 0) {
+        const head = Buffer.allocUnsafe(checkpoint.headBytes);
+        let filled = 0;
+        while (filled < head.length) {
+          const { bytesRead } = await file.read(head, filled, head.length - filled, filled);
+          if (bytesRead === 0) break;
+          filled += bytesRead;
+        }
+        charge(filled);
+        valid = filled === head.length && authorshipHeadFingerprint(head) === checkpoint.headFingerprint;
+      }
+      if (!valid) {
+        authorshipCheckpoints.delete(pathname);
+        checkpoint = undefined;
+      }
+    }
+    if (checkpoint && checkpoint.count >= limit) return { count: checkpoint.count, complete: checkpoint.parseComplete };
+    if (checkpoint?.done && checkpoint.size === stat.size && checkpoint.mtimeMs === stat.mtimeMs) {
+      return { count: checkpoint.count, complete: checkpoint.parseComplete };
+    }
+
+    const scanner = createAuthorshipScanner(engine, limit, checkpoint ?? undefined);
+    let offset = checkpoint?.offset ?? 0;
+    let headBytes = checkpoint?.headBytes ?? 0;
+    let headFingerprint = checkpoint?.headFingerprint ?? "";
+    const save = (done: boolean) => {
+      if (!options.resume) return;
+      const state = scanner.state();
+      authorshipCheckpoints.set(pathname, {
+        dev: stat.dev,
+        ino: stat.ino,
+        size: stat.size,
+        mtimeMs: stat.mtimeMs,
+        offset,
+        carry: state.carry,
+        skippingRecord: state.skippingRecord,
+        count: state.count,
+        parseComplete: state.parseComplete,
+        headBytes,
+        headFingerprint,
+        done,
+      });
+    };
     const chunk = Buffer.allocUnsafe(AUTHORSHIP_SCAN_CHUNK_BYTES);
     let chunksSinceYield = 0;
     for (;;) {
-      const { bytesRead } = await file.read(chunk, 0, chunk.length, null);
+      if (options.signal?.aborted) {
+        save(false);
+        return scanner.failed();
+      }
+      const allowance = authorshipAllowance(options, charged);
+      if (allowance <= 0) {
+        save(false);
+        return scanner.failed();
+      }
+      const { bytesRead } = await file.read(chunk, 0, Math.min(chunk.length, allowance), offset);
       if (bytesRead === 0) break;
-      if (scanner.consume(chunk.subarray(0, bytesRead))) return scanner.result();
+      charge(bytesRead);
+      if (offset === 0 && headBytes === 0) {
+        headBytes = Math.min(bytesRead, AUTHORSHIP_CHECKPOINT_HEAD_BYTES);
+        headFingerprint = authorshipHeadFingerprint(chunk.subarray(0, headBytes));
+      }
+      offset += bytesRead;
+      if (scanner.consume(chunk.subarray(0, bytesRead))) {
+        save(false);
+        return scanner.result();
+      }
       chunksSinceYield += 1;
       if (chunksSinceYield >= 8) {
         chunksSinceYield = 0;
         await yieldToRuntime();
       }
     }
-    return scanner.finish();
+    const finished = scanner.finish();
+    save(true);
+    return finished;
   } catch {
-    return scanner.failed();
+    return { count: 0, complete: false };
   } finally {
     await file?.close().catch(() => undefined);
   }

--- a/src/lib/session/reader.ts
+++ b/src/lib/session/reader.ts
@@ -425,6 +425,9 @@ export async function scanUserAuthoredMessagesCooperatively(
       // the recorded offset no longer describes this file's content.
       let valid = checkpoint.dev === stat.dev && checkpoint.ino === stat.ino && stat.size >= checkpoint.offset;
       if (valid && checkpoint.headBytes > 0) {
+        if (authorshipAllowance(options, charged) < checkpoint.headBytes) {
+          return { count: checkpoint.count, complete: false };
+        }
         const head = Buffer.allocUnsafe(checkpoint.headBytes);
         let filled = 0;
         while (filled < head.length) {

--- a/src/runtime-host/socket.test.ts
+++ b/src/runtime-host/socket.test.ts
@@ -1,0 +1,133 @@
+import { afterAll, expect, test } from "bun:test";
+import fs from "node:fs";
+import net from "node:net";
+import os from "node:os";
+import path from "node:path";
+
+import type { RuntimeSocketRequest, RuntimeSocketResponse } from "@/lib/runtime/contracts";
+
+import type { RuntimeHost } from "./host";
+import { serveRuntimeHost } from "./socket";
+
+const SANDBOX = fs.mkdtempSync(path.join(os.tmpdir(), "llv-runtime-socket-"));
+const servers: net.Server[] = [];
+
+afterAll(async () => {
+  await Promise.all(servers.map((server) => new Promise((resolve) => server.close(resolve))));
+  fs.rmSync(SANDBOX, { recursive: true, force: true });
+});
+
+interface HandledRequest {
+  request: RuntimeSocketRequest;
+  signal: AbortSignal | undefined;
+}
+
+function stubHost(
+  respond: (request: RuntimeSocketRequest, options: { signal?: AbortSignal }) => Promise<RuntimeSocketResponse>,
+  handled: HandledRequest[] = [],
+): RuntimeHost {
+  return {
+    handle: async (request: RuntimeSocketRequest, options: { signal?: AbortSignal } = {}) => {
+      handled.push({ request, signal: options.signal });
+      return respond(request, options);
+    },
+  } as unknown as RuntimeHost;
+}
+
+function serve(host: RuntimeHost, socketErrors: Error[]): string {
+  const socketPath = path.join(SANDBOX, `${crypto.randomUUID().slice(0, 8)}.sock`);
+  const server = serveRuntimeHost(socketPath, host);
+  server.on("connection", (socket) => socket.on("error", (error) => socketErrors.push(error)));
+  servers.push(server);
+  return socketPath;
+}
+
+function once(server: string, frame: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const socket = net.createConnection(server);
+    let buffer = "";
+    socket.on("data", (chunk) => {
+      buffer += String(chunk);
+      if (buffer.includes("\n")) {
+        socket.destroy();
+        resolve(buffer);
+      }
+    });
+    socket.once("error", reject);
+    socket.once("connect", () => socket.write(frame));
+  });
+}
+
+test("a caller disconnect before completion aborts the request and discards the late write", async () => {
+  let releaseResponse = () => {};
+  const gate = new Promise<void>((resolve) => { releaseResponse = () => resolve(); });
+  const handled: HandledRequest[] = [];
+  const socketErrors: Error[] = [];
+  const socketPath = serve(stubHost(async (request) => {
+    await gate;
+    return { id: request.id, ok: true, result: { late: true } };
+  }, handled), socketErrors);
+
+  const client = net.createConnection(socketPath);
+  await new Promise<void>((resolve) => client.once("connect", () => resolve()));
+  client.write(JSON.stringify({ id: "req-1", method: "snapshot" }) + "\n");
+  while (handled.length === 0) await new Promise((resolve) => setTimeout(resolve, 5));
+
+  // The ordinary snapshot request must carry the connection's abort signal.
+  expect(handled[0]!.signal).toBeDefined();
+  expect(handled[0]!.signal!.aborted).toBe(false);
+
+  client.destroy();
+  await new Promise((resolve) => setTimeout(resolve, 25));
+  expect(handled[0]!.signal!.aborted).toBe(true);
+
+  // The host completes after the caller is gone: the settlement must be
+  // discarded silently instead of writing to the finished stream.
+  releaseResponse();
+  await new Promise((resolve) => setTimeout(resolve, 25));
+  expect(socketErrors).toEqual([]);
+});
+
+test("a healthy request settles exactly once with its response frame", async () => {
+  const socketErrors: Error[] = [];
+  const socketPath = serve(stubHost(async (request) => ({ id: request.id, ok: true, result: { fine: true } })), socketErrors);
+
+  const raw = await once(socketPath, JSON.stringify({ id: "req-2", method: "snapshot" }) + "\n");
+  expect(JSON.parse(raw.slice(0, raw.indexOf("\n")))).toEqual({ id: "req-2", ok: true, result: { fine: true } });
+  expect(socketErrors).toEqual([]);
+});
+
+test("a rejected host promise settles the socket with an error frame instead of leaking", async () => {
+  const socketErrors: Error[] = [];
+  const socketPath = serve(stubHost(async () => {
+    throw new Error("host exploded");
+  }), socketErrors);
+
+  const raw = await once(socketPath, JSON.stringify({ id: "req-3", method: "snapshot" }) + "\n");
+  expect(JSON.parse(raw.slice(0, raw.indexOf("\n")))).toMatchObject({ id: "req-3", ok: false });
+  expect(socketErrors).toEqual([]);
+});
+
+test("a timed-out socket destroyed by the server produces zero late writes", async () => {
+  let releaseResponse = () => {};
+  const gate = new Promise<void>((resolve) => { releaseResponse = () => resolve(); });
+  const socketErrors: Error[] = [];
+  const socketPath = path.join(SANDBOX, `${crypto.randomUUID().slice(0, 8)}.sock`);
+  const server = serveRuntimeHost(socketPath, stubHost(async (request) => {
+    await gate;
+    return { id: request.id, ok: true, result: {} };
+  }), { defaultTimeoutMs: 30 });
+  server.on("connection", (socket) => socket.on("error", (error) => socketErrors.push(error)));
+  servers.push(server);
+
+  const client = net.createConnection(socketPath);
+  client.on("error", () => undefined);
+  await new Promise<void>((resolve) => client.once("connect", () => resolve()));
+  client.write(JSON.stringify({ id: "req-4", method: "snapshot" }) + "\n");
+  await new Promise((resolve) => setTimeout(resolve, 80));
+
+  releaseResponse();
+  await new Promise((resolve) => setTimeout(resolve, 25));
+  expect(socketErrors).toEqual([]);
+  client.destroy();
+});

--- a/src/runtime-host/socket.ts
+++ b/src/runtime-host/socket.ts
@@ -2,7 +2,7 @@ import fs from "node:fs";
 import net from "node:net";
 import path from "node:path";
 
-import type { RuntimeSocketRequest } from "@/lib/runtime/contracts";
+import type { RuntimeSocketRequest, RuntimeSocketResponse } from "@/lib/runtime/contracts";
 
 import { RuntimeHost } from "./host";
 
@@ -40,6 +40,18 @@ export function serveRuntimeHost(socketPath: string, host: RuntimeHost, options:
     socket.setTimeout(defaultTimeoutMs, () => socket.destroy());
     let buffer = "";
     let handled = false;
+    let settled = false;
+    /* One-shot terminal settlement: the connection owns exactly one response
+       frame, and a host completing after the caller disconnected (client
+       timeout destroyed its socket, or the server idle timeout fired) must be
+       discarded silently instead of writing to the finished stream — the
+       production ERR_STREAM_ALREADY_FINISHED path. */
+    const settle = (response: RuntimeSocketResponse) => {
+      if (settled) return;
+      settled = true;
+      if (socket.destroyed || socket.writableEnded || !socket.writable) return;
+      socket.end(JSON.stringify(response) + "\n");
+    };
     socket.on("data", (chunk) => {
       if (handled) return;
       buffer += String(chunk);
@@ -54,20 +66,24 @@ export function serveRuntimeHost(socketPath: string, host: RuntimeHost, options:
         const request = JSON.parse(frame) as RuntimeSocketRequest;
         if (!request.id || !request.method) throw new Error("runtime request is malformed");
         if (request.method === "viewer-deployment-request") socket.setTimeout(deploymentTimeoutMs);
+        const failure = (): RuntimeSocketResponse => ({ id: request.id, ok: false, error: "runtime request failed" });
         if (request.method === "wait") {
           if (activeWaitConnections >= maxWaitConnections) {
-            socket.end(JSON.stringify({ id: request.id, ok: false, error: "runtime wait capacity exceeded" }) + "\n");
+            settle({ id: request.id, ok: false, error: "runtime wait capacity exceeded" });
             return;
           }
           activeWaitConnections += 1;
           void host.handle(request, { signal: abort.signal })
-            .then((response) => socket.end(JSON.stringify(response) + "\n"))
+            .then(settle, () => settle(failure()))
             .finally(() => { activeWaitConnections -= 1; });
           return;
         }
-        void host.handle(request).then((response) => socket.end(JSON.stringify(response) + "\n"));
+        /* Every request carries the connection signal, so a disconnected
+           caller stops read-only work early; mutating journal operations
+           ignore the signal and still complete idempotently. */
+        void host.handle(request, { signal: abort.signal }).then(settle, () => settle(failure()));
       } catch {
-        socket.end(JSON.stringify({ id: "unknown", ok: false, error: "runtime request is malformed" }) + "\n");
+        settle({ id: "unknown", ok: false, error: "runtime request is malformed" });
       }
     });
   });


### PR DESCRIPTION
Continues the rescued #287 scanner hardening from additive rescue commit 22ad0018, preserving the full rescue chain (bb825800, 67de83ca, 1023edbb, 22ad0018) without any history rewriting.

## What this delivers

**Process-wide scan coordinator** (`src/lib/scanner/scanCoordinator.ts`). One catalog scan generation is active per process. The HTTP files cache, the flow/pipeline watchdog, and the account controller join a covering in-flight generation or merge into one shared trailing generation carrying the union of their intents. The pending set is a FIFO queue: pinned refreshes mark themselves **exclusive** because their runner carries a private pin scope — they never merge with other callers in either direction, joiners never adopt a running exclusive generation's snapshot, and every consumer receives a private deep clone. `resetFilesRouteCacheForTests` also resets the coordinator, since its single-generation lease lives on `globalThis` beside the route cache.

**Cache identity split** (`src/lib/scanner/describe.ts`). The composite description cache keyed transcript-derived metadata on the project-state hash, so every flows/worktree-map rewrite evicted it corpus-wide. Transcript metadata (cwd, title, engine, timestamps) now caches by file identity alone; project/worktree resolution is a separate overlay cached by state revision + resolved cwd. A new regression proves a state-key change regroups the project without one byte of transcript re-reading.

**Bounded, resumable readers.** Authorship proofs persist per-path checkpoints (device, inode, offset, carry, head fingerprint) and resume at 4 MiB per path inside a 32 MiB controller-cycle budget; truncation or a rewritten head resets the checkpoint. Lineage needle scans cap one candidate at 1 MiB per pass inside a 256 KiB generation budget and restart after truncation. Exhaustion stays fail-closed: unverified authorship and unresolved lineage keep their protected fallbacks.

**Cooperative cancellation.** Authorship scans observe an `AbortSignal` on 64 KiB chunk boundaries and yield to the runtime every 512 KiB; read-only runtime-host client methods accept signals and the snapshot route forwards its request signal.

**One-shot response settlement** (`src/runtime-host/socket.ts`). Each connection owns exactly one response frame; a host completing after the caller disconnected discards the write instead of hitting the finished stream — the production `ERR_STREAM_ALREADY_FINISHED` path. Every request carries the connection abort signal; the host consumes it only for read-only waits, so journal mutations still complete idempotently.

## Logical 3 GiB pressure evidence

Deterministic RED→GREEN regressions run against logical 3 GiB sparse transcripts:

- `src/lib/session/reader.performance.test.ts` — a 3 GiB ownerless transcript stops at the exact per-pass ceiling and resumes from its checkpoint; an exhausted shared budget refuses the pass without touching the file; cancellation lands on a 64 KiB boundary with a resumable checkpoint; truncation resets stale evidence; a finished scan replays its verdict.
- `src/lib/scanner/needle.performance.test.ts` — an absent needle in a 3 GiB candidate consumes exactly the generation budget; per-candidate passes cap at 1 MiB; budgeted scans resume deterministically and prove lineage once reached; truncated candidates restart.

All 10 pass in ~100 ms.

## Verification

- Focused: scanner + session + files route + runtime client + host socket: **369 pass / 0 fail** (41 files); real-corpus scan cache: **16 pass / 0 fail**; route suite restored to the baseline **65/65**.
- `bunx tsc --noEmit` clean; changed-file ESLint clean (one inherited warning in `reaperRuntime.ts`, present on the baseline); `next build` + MCP build pass; `git diff --check` clean; privacy publication gate **PASS**.
- Baseline classification (disposable checkout at merge base 421451ae): the whole-repo single-process run fails there too (**70 fail + 9 errors** vs **24 fail** on this branch) from known cross-file `mock.module` interference; every failure unique to this branch's run passes in isolation, and the 3 combined-run failures in `src/app/api/files` reproduce byte-identically at the baseline.

## Out of scope

Production exact-SHA deployment and live pressure acceptance require the Deployer role and explicit operator approval.

Closes nothing on its own; tracks #287.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
