### PR TITLE
Flatten remaining feed detail cards

### DIFF
--- a/src/components/feed/cards/BlobCard.tsx
+++ b/src/components/feed/cards/BlobCard.tsx
@@ -13,10 +13,10 @@ export function BlobCard({ bytes, text }: { bytes: number; text: string }) {
       <button
         type="button"
         onClick={() => setOpen(true)}
-        className="my-2 ml-9 flex items-center gap-2 rounded-[14px] border border-border bg-card px-3.5 py-2 text-[13px] shadow-1"
+        className="my-2 ml-9 flex items-center gap-2 rounded-surface border border-border bg-card px-3 py-1.5 text-[13px]"
       >
-        <span className="flex h-6.5 w-6.5 items-center justify-center rounded-lg bg-sunken">
-          <GlyphIcon name="blob" className="h-4 w-4" />
+        <span className="flex h-6 w-6 items-center justify-center rounded-lg bg-sunken">
+          <GlyphIcon name="blob" className="h-3.5 w-3.5" />
         </span>
         <span className="font-semibold">{tr("render.dataKb", { n: kb })}</span>
         <span className="ml-1 text-[12px] font-semibold text-accent">{tr("common.show")}</span>
@@ -24,11 +24,11 @@ export function BlobCard({ bytes, text }: { bytes: number; text: string }) {
     );
   }
   return (
-    <div className="my-2 ml-9 overflow-hidden rounded-[14px] border border-border bg-card shadow-1">
-      <pre className="max-h-[340px] overflow-auto whitespace-pre-wrap break-all bg-sunken px-3.5 py-2.5 font-mono text-[11.5px]">
+    <div className="my-2 ml-9 overflow-hidden rounded-surface border border-border bg-card">
+      <pre className="max-h-[340px] overflow-auto whitespace-pre-wrap break-all bg-sunken px-3 py-2 font-mono text-[11.5px]">
         {text}
       </pre>
-      <button type="button" onClick={() => setOpen(false)} className="block w-full border-t border-border px-3.5 py-1.5 text-[12px] text-muted">
+      <button type="button" onClick={() => setOpen(false)} className="block w-full border-t border-border px-3 py-1.5 text-[12px] text-muted">
         {tr("common.collapse")}
       </button>
     </div>

--- a/src/components/feed/cards/MemCitationCard.tsx
+++ b/src/components/feed/cards/MemCitationCard.tsx
@@ -1,4 +1,4 @@
-import { GlyphIcon } from "../../icons";
+import { ChevronRight, GlyphIcon } from "../../icons";
 import { tr, type MemCitationItem } from "../parse";
 import { FileRef } from "./shared";
 
@@ -6,20 +6,20 @@ export function MemCitationCard({ item }: { item: MemCitationItem }) {
   const visibleEntries = item.entries.slice(0, 8);
   const visibleIds = item.rolloutIds.slice(0, 6);
   return (
-    <details className="group my-2 ml-9 overflow-hidden rounded-[14px] border border-border bg-card text-[12px] shadow-1">
-      <summary className="flex cursor-pointer list-none items-center gap-2 px-3.5 py-2">
-        <span className="flex h-6.5 w-6.5 shrink-0 items-center justify-center rounded-lg bg-sunken">
-          <GlyphIcon name="citation" className="h-4 w-4" />
+    <details className="group my-2 ml-9 overflow-hidden rounded-surface border border-border bg-card text-[12px]">
+      <summary className="flex cursor-pointer list-none items-center gap-2 px-3 py-1.5">
+        <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-lg bg-sunken">
+          <GlyphIcon name="citation" className="h-3.5 w-3.5" />
         </span>
         <span className="text-[13px] font-semibold">{tr("render.memoryCitations", { count: item.entries.length })}</span>
         <span className="ml-auto text-[11px] font-semibold text-accent group-open:hidden">{tr("common.show")}</span>
         <span className="ml-auto hidden text-[11px] font-semibold text-accent group-open:inline">{tr("common.collapse")}</span>
       </summary>
-      <div className="border-t border-border px-3.5 py-2.5">
+      <div className="border-t border-border px-3 py-2">
         {visibleEntries.length ? (
-          <div className="space-y-1.5">
+          <div className="divide-y divide-border">
             {visibleEntries.map((entry, idx) => (
-              <div key={idx} className="min-w-0 rounded-[9px] bg-sunken px-2.5 py-1.5">
+              <div key={idx} className="min-w-0 py-1.5 first:pt-0 last:pb-0">
                 <FileRef file={entry.target} line={entry.line ? Number(entry.line.split("-", 1)[0]) : undefined} />
                 {entry.note ? <div className="mt-1 whitespace-pre-wrap break-words text-[12px] text-secondary">{entry.note}</div> : null}
               </div>
@@ -42,11 +42,12 @@ export function MemCitationCard({ item }: { item: MemCitationItem }) {
             {item.rolloutIds.length > visibleIds.length ? <span className="text-[11px] text-muted">+{item.rolloutIds.length - visibleIds.length}</span> : null}
           </div>
         ) : null}
-        <details className="mt-2 rounded-[10px] border border-border bg-sunken text-[12px]">
-          <summary className="cursor-pointer list-none px-3 py-1.5 font-semibold text-muted">
+        <details className="group/raw mt-2 text-[12px]">
+          <summary className="inline-flex cursor-pointer list-none items-center gap-1 font-semibold text-muted hover:text-accent [&::-webkit-details-marker]:hidden">
+            <ChevronRight className="h-3 w-3 transition-transform group-open/raw:rotate-90" aria-hidden />
             raw citation block{item.truncated ? " · " + tr("render.truncated") : ""}
           </summary>
-          <pre className="max-h-[260px] overflow-auto whitespace-pre-wrap border-t border-border px-3 py-2 font-mono text-[11.5px] text-secondary">
+          <pre className="mt-1 max-h-[260px] overflow-auto whitespace-pre-wrap [overflow-wrap:anywhere] border-t border-border pt-1.5 font-mono text-[11.5px] text-secondary">
             {item.raw}
           </pre>
         </details>

--- a/src/components/feed/cards/RecordCard.tsx
+++ b/src/components/feed/cards/RecordCard.tsx
@@ -13,12 +13,12 @@ export function RecordCard({ item }: { item: TranscriptRecordItem }) {
         <span className="min-w-0 truncate rounded-md bg-sunken px-1.5 py-0.5 font-mono text-caption text-primary">{item.recordType}</span>
         {time ? <span className="ml-auto shrink-0 tabular-nums">{time}</span> : null}
       </summary>
-      <div className="mb-1 mt-1 overflow-hidden rounded-surface border border-border bg-sunken">
-        <div className="flex items-center gap-2 border-b border-border px-3 py-1 text-caption font-semibold text-muted">
+      <div className="mb-1 mt-1">
+        <div className="mb-1 flex items-center gap-2 text-caption font-semibold text-muted">
           <span>{tr("render.recordDetails")}</span>
-          {item.truncated ? <span className="rounded-md bg-card px-1.5 py-0.5">{tr("render.truncated")}</span> : null}
+          {item.truncated ? <span className="rounded-md bg-sunken px-1.5 py-0.5">{tr("render.truncated")}</span> : null}
         </div>
-        <pre className="max-h-[320px] max-w-full overflow-auto whitespace-pre-wrap break-words px-3 py-2 font-mono text-[11px] text-secondary">{item.body}</pre>
+        <pre className="max-h-[320px] max-w-full overflow-auto whitespace-pre-wrap break-words border-t border-border pt-1.5 font-mono text-[11px] text-secondary">{item.body}</pre>
       </div>
     </details>
   );

--- a/src/components/feed/cards/ReviewCard.tsx
+++ b/src/components/feed/cards/ReviewCard.tsx
@@ -1,6 +1,6 @@
 import type { ReviewCardItem, ReviewSeverity } from "@/lib/review";
 
-import { Ban, CircleCheck, Command, MessageCircle } from "../../icons";
+import { Ban, ChevronRight, CircleCheck, Command, MessageCircle } from "../../icons";
 import { hhmm } from "../../utils";
 import { md, mdBlocks } from "../markdown";
 import { tr } from "../parse";
@@ -34,12 +34,12 @@ export function ReviewCard({ item }: { item: ReviewCardItem }) {
   const findingCount = item.findings.length;
   const visibleFindings = item.findings.slice(0, 12);
   return (
-    <div className="my-3.5 ml-9 overflow-hidden rounded-[14px] border border-codex/20 bg-card shadow-1">
-      <div className="flex flex-wrap items-center gap-2 border-b border-border px-3.5 py-2.5">
-        <span className="flex h-6.5 w-6.5 shrink-0 items-center justify-center rounded-lg bg-codex-soft text-codex">
-          <Command className="h-4 w-4" aria-hidden />
+    <div className="my-3 ml-9 overflow-hidden rounded-surface border border-codex/20 bg-card">
+      <div className="flex flex-wrap items-center gap-2 border-b border-border px-3 py-2">
+        <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-lg bg-codex-soft text-codex">
+          <Command className="h-3.5 w-3.5" aria-hidden />
         </span>
-        <span className="text-[13.5px] font-bold">Codex review</span>
+        <span className="text-[13px] font-bold">Codex review</span>
         {item.verdict ? (
           <span className={`rounded-full border px-2.5 py-0.5 text-[11.5px] font-extrabold ${verdictClass(item.verdict)}`}>
             <VerdictLabel verdict={item.verdict} />
@@ -50,14 +50,14 @@ export function ReviewCard({ item }: { item: ReviewCardItem }) {
         </span>
         {hhmm(item.ts) ? <span className="ml-auto text-label tabular-nums text-muted">{hhmm(item.ts)}</span> : null}
       </div>
-      <div className="px-3.5 py-2.5">
+      <div className="px-3 py-2">
         {item.summary.length ? (
           <div className="mb-2 whitespace-pre-wrap break-words text-[13px] text-secondary">{mdBlocks(item.summary.join("\n"))}</div>
         ) : null}
         {visibleFindings.length ? (
-          <div className="space-y-2">
+          <div className="divide-y divide-border">
             {visibleFindings.map((finding, idx) => (
-              <div key={idx} className="rounded-[10px] border border-border bg-sunken px-3 py-2">
+              <div key={idx} className="py-2 first:pt-0 last:pb-0">
                 <div className="flex flex-wrap items-center gap-2">
                   <span className={`rounded-full border px-2 py-0.5 text-[10.5px] font-extrabold ${severityClass(finding.severity)}`}>
                     {finding.severity}
@@ -78,9 +78,12 @@ export function ReviewCard({ item }: { item: ReviewCardItem }) {
         {item.findings.length > visibleFindings.length ? (
           <div className="mt-2 text-[12px] text-muted">{tr("render.moreFindings", { count: item.findings.length - visibleFindings.length })}</div>
         ) : null}
-        <details className="mt-2 rounded-[10px] border border-border bg-sunken text-[12px]">
-          <summary className="cursor-pointer list-none px-3 py-1.5 font-semibold text-muted">raw review text</summary>
-          <pre className="max-h-[320px] overflow-auto whitespace-pre-wrap border-t border-border px-3 py-2 font-mono text-[11.5px] text-secondary">
+        <details className="group/raw mt-2 text-[12px]">
+          <summary className="inline-flex cursor-pointer list-none items-center gap-1 font-semibold text-muted hover:text-accent [&::-webkit-details-marker]:hidden">
+            <ChevronRight className="h-3 w-3 transition-transform group-open/raw:rotate-90" aria-hidden />
+            raw review text
+          </summary>
+          <pre className="mt-1 max-h-[320px] overflow-auto whitespace-pre-wrap [overflow-wrap:anywhere] border-t border-border pt-1.5 font-mono text-[11.5px] text-secondary">
             {item.raw}
           </pre>
         </details>

--- a/src/components/feed/cards/SysMsgCard.tsx
+++ b/src/components/feed/cards/SysMsgCard.tsx
@@ -17,7 +17,7 @@ export function SysMsgCard({ label, text }: { label: string; text: string }) {
       </summary>
       <div className="mb-1 mt-1">
         <span className="mb-1 inline-flex items-center rounded-control bg-sunken px-1.5 py-0.5 font-mono text-caption text-muted">{label}</span>
-        <pre className="max-h-[320px] overflow-auto whitespace-pre-wrap break-words rounded-surface border border-border bg-sunken px-3 py-2 font-mono text-label text-secondary">
+        <pre className="mt-1 max-h-[320px] overflow-auto whitespace-pre-wrap break-words border-t border-border pt-1.5 font-mono text-label text-secondary">
           {text}
         </pre>
       </div>

--- a/src/components/feed/cards/WakeupCard.tsx
+++ b/src/components/feed/cards/WakeupCard.tsx
@@ -5,7 +5,7 @@ import { useEffect, useState } from "react";
 import { useLocale } from "@/lib/i18n";
 import { wakeupPhase } from "@/lib/wakeup";
 
-import { GlyphIcon } from "../../icons";
+import { ChevronRight, GlyphIcon } from "../../icons";
 import { fmtWakeClock, fmtWakeRelative } from "../../wakeupFormat";
 import { mdBlocks } from "../markdown";
 import { type ToolEvent, type WakeupEventInfo } from "../parse";
@@ -68,10 +68,10 @@ export function WakeupCard({ event, wakeup }: { event: ToolEvent; wakeup: Wakeup
   const iconTone = active ? "bg-warning-soft text-warning" : failed ? "bg-danger-soft text-danger" : "bg-sunken text-muted";
 
   return (
-    <details className={`group/wake my-2.5 ml-9 overflow-hidden rounded-[14px] border shadow-1 ${cardTone}`} open={active || failed}>
-      <summary className="flex min-h-[44px] cursor-pointer list-none items-center gap-2.5 px-3.5 py-2">
-        <span className={`flex h-6.5 w-6.5 shrink-0 items-center justify-center rounded-lg ${iconTone}`}>
-          <GlyphIcon name="clock" className="h-4 w-4" />
+    <details className={`group/wake my-2.5 ml-9 overflow-hidden rounded-surface border ${cardTone}`} open={active || failed}>
+      <summary className="flex min-h-[44px] cursor-pointer list-none items-center gap-2.5 px-3 py-2">
+        <span className={`flex h-6 w-6 shrink-0 items-center justify-center rounded-lg ${iconTone}`}>
+          <GlyphIcon name="clock" className="h-3.5 w-3.5" />
         </span>
         <span className="flex min-w-0 flex-1 flex-col">
           <span className="truncate text-[12.5px] font-semibold" title={reason || headline}>
@@ -83,7 +83,7 @@ export function WakeupCard({ event, wakeup }: { event: ToolEvent; wakeup: Wakeup
           <span className={`shrink-0 text-[11px] font-bold tabular-nums ${badge.tone}`}>{badge.text}</span>
         ) : null}
       </summary>
-      <div className="border-t border-border px-3.5 py-2.5">
+      <div className="border-t border-border px-3 py-2">
         <div className="mb-2 flex flex-wrap items-center gap-x-2 gap-y-1 text-[11.5px] text-muted">
           <span className={`font-semibold ${failed ? "text-danger" : "text-primary"}`}>{headline}</span>
           {relative ? <span>· {relative}</span> : null}
@@ -97,11 +97,12 @@ export function WakeupCard({ event, wakeup }: { event: ToolEvent; wakeup: Wakeup
           </div>
         ) : null}
         {prompt ? (
-          <details className="group/plan rounded-[10px] border border-border bg-sunken">
-            <summary className="flex min-h-[44px] cursor-pointer list-none items-center gap-1.5 px-3 py-2 text-[11.5px] font-semibold text-muted">
+          <details className="group/plan">
+            <summary className="inline-flex min-h-[44px] cursor-pointer list-none items-center gap-1.5 text-[11.5px] font-semibold text-muted hover:text-accent [&::-webkit-details-marker]:hidden">
+              <ChevronRight className="h-3 w-3 transition-transform group-open/plan:rotate-90" aria-hidden />
               {t("wakeup.plan")}
             </summary>
-            <div className="border-t border-border px-3 py-2 text-[12.5px] leading-snug">{mdBlocks(prompt)}</div>
+            <div className="border-t border-border pt-2 text-[12.5px] leading-snug">{mdBlocks(prompt)}</div>
           </details>
         ) : (
           <span className="text-[11.5px] text-muted">{t("wakeup.noPlan")}</span>

--- a/src/components/runtime/McpCallCard.tsx
+++ b/src/components/runtime/McpCallCard.tsx
@@ -144,20 +144,20 @@ export function McpCallCard({
     <article
       data-testid="mcp-call-card"
       data-state={state}
-      className={`relative my-3 ml-9 overflow-hidden rounded-[14px] border bg-card shadow-1 ${
+      className={`relative my-2.5 ml-9 overflow-hidden rounded-surface border bg-card ${
         state === "error" ? "border-danger/40" : state === "success" ? "border-success/25" : "border-accent/35"
       }`}
     >
       {state === "pending" ? (
         <div data-testid="mcp-call-progress" className="absolute inset-x-0 top-0 h-0.5 animate-pulse bg-gradient-to-r from-transparent via-accent to-transparent" />
       ) : null}
-      <div className="flex items-start gap-3 px-3.5 py-3">
+      <div className="flex items-start gap-2.5 px-3 py-2.5">
         <span
-          className={`relative mt-0.5 flex h-9 w-9 shrink-0 items-center justify-center rounded-[11px] ${
+          className={`relative mt-0.5 flex h-7 w-7 shrink-0 items-center justify-center rounded-lg ${
             state === "error" ? "bg-danger-soft text-danger" : state === "success" ? "bg-success-soft text-success" : "bg-accent-soft text-accent"
           }`}
         >
-          <Icon className={`h-[18px] w-[18px] ${state === "pending" ? "animate-pulse" : ""}`} aria-hidden />
+          <Icon className={`h-4 w-4 ${state === "pending" ? "animate-pulse" : ""}`} aria-hidden />
           {state === "pending" ? <span className="absolute -bottom-1 -right-1 h-2.5 w-2.5 animate-ping rounded-full bg-accent/70" aria-hidden /> : null}
         </span>
         <div className="min-w-0 flex-1">
@@ -186,7 +186,7 @@ export function McpCallCard({
             <summary className="inline-flex min-h-6 cursor-pointer list-none items-center font-semibold hover:text-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 [&::-webkit-details-marker]:hidden">
               Details
             </summary>
-            <pre className="mt-1 max-h-[320px] max-w-full overflow-auto whitespace-pre rounded-[10px] border border-border bg-sunken px-3 py-2 font-mono text-[10.5px] text-secondary">{payload}</pre>
+            <pre className="mt-1 max-h-[320px] max-w-full overflow-auto whitespace-pre-wrap [overflow-wrap:anywhere] border-t border-border pt-1.5 font-mono text-[10.5px] text-secondary">{payload}</pre>
           </details>
         </div>
       </div>


### PR DESCRIPTION
## Summary

- flatten Review, MCP, memory citation, record, system-message, wakeup, and blob cards
- replace nested sunken shells with hairline dividers and compact disclosures
- preserve structured diff cards and prominent protocol/image content
- keep long JSON, citation, and raw record content wrapping within mobile width

## Verification

- `TMPDIR=/dev/shm bun test src/components/feed src/components/runtime` — 296 passed
- changed-file ESLint — passed
- `git diff --check` — passed
- builder rendered the real components at desktop and 390px mobile widths with no horizontal overflow