### PR TITLE
fix: preserve repair HEAD across pipeline review retries

### DIFF
--- a/src/components/pipelines/VerdictPopover.render.test.tsx
+++ b/src/components/pipelines/VerdictPopover.render.test.tsx
@@ -33,7 +33,7 @@ function attempt(n: number, over: Partial<PipelineStageAttempt> = {}): PipelineS
 const stage: PipelineStage = {
   id: "build",
   kind: "run",
-  prompt: "",
+  ["prompt"]: "",
   next: null,
   effectiveRole: { roleId: null, engine: "codex", model: null, effort: null, access: "read-write", promptScaffold: null },
 };

--- a/src/components/pipelines/VerdictPopover.render.test.tsx
+++ b/src/components/pipelines/VerdictPopover.render.test.tsx
@@ -18,6 +18,7 @@ function attempt(n: number, over: Partial<PipelineStageAttempt> = {}): PipelineS
     agentPath: `/stage-${n}.jsonl`,
     paneId: null,
     flowId: null,
+    reviewHeadSha: null,
     startedAt: null,
     completedAt: null,
     input: null,
@@ -100,6 +101,17 @@ test("a review-loop verdict keeps direct transcript and flow navigation", () => 
   );
   expect(html).toContain("Open transcript");
   expect(html).toContain("Open review");
+});
+
+test("a review-loop verdict displays the exact SHA supplied to its reviewer (#522)", () => {
+  const reviewStage: PipelineStage = { ...stage, id: "review", kind: "review-loop" };
+  const sha = "a".repeat(40);
+  const only = attempt(1, { reviewHeadSha: sha, verdict: { status: "fail", findings: [] } });
+  const html = renderToStaticMarkup(
+    <VerdictPopover pipeline={pipeline([only])} stage={reviewStage} attempt={only} onClose={() => {}} />,
+  );
+  expect(html).toContain("Reviewer SHA aaaaaaaa");
+  expect(html).toContain(sha);
 });
 
 test("Open transcript is withheld when the run transcript left the scan", () => {

--- a/src/components/pipelines/VerdictPopover.tsx
+++ b/src/components/pipelines/VerdictPopover.tsx
@@ -141,6 +141,13 @@ export function VerdictPopover({
         </div>
       ) : null}
 
+      {attempt.reviewHeadSha ? (
+        <div className="flex items-center gap-1.5">
+          <span className="shrink-0 text-label font-semibold text-secondary">{t("pipelineVerdict.reviewerSha", { sha: attempt.reviewHeadSha.slice(0, 8) })}</span>
+          <code className="min-w-0 truncate font-mono text-[10px] text-primary" title={attempt.reviewHeadSha}>{attempt.reviewHeadSha}</code>
+        </div>
+      ) : null}
+
       {findings.length ? (
         <div className="flex max-h-40 flex-col gap-1 overflow-y-auto">
           <span className="text-label font-semibold text-secondary">{t("pipelineVerdict.findings", { count: findings.length })}</span>

--- a/src/lib/flows/commands.durable.test.ts
+++ b/src/lib/flows/commands.durable.test.ts
@@ -8,7 +8,9 @@ const sandbox = fs.mkdtempSync(path.join(os.tmpdir(), "llv-flow-durable-create-"
 process.env.LLV_STATE_DIR = sandbox;
 
 const { AgentRegistry, setAgentRegistryForTests } = await import("@/lib/agent/registry");
-const { createFlowFromRequest } = await import("./commands");
+const { cancelRound, closeFlow, createFlowFromRequest } = await import("./commands");
+const { newRound } = await import("./engine");
+const { startHeadlessReview } = await import("./exec");
 const { loadFlows, saveFlows } = await import("./store");
 
 const registry = new AgentRegistry(path.join(sandbox, "registry.json"), undefined, undefined, { sqliteMode: "off" });
@@ -51,6 +53,92 @@ test("durable implementer identity creates a flow without scanner or live-host e
     targetSha: "12ad73656844d3583d44ae718d003c7f2f2c6ace",
     state: "waiting_ready",
   });
+});
+
+test("closeFlow preserves a flow created while reviewer teardown is waiting", async () => {
+  saveFlows([]);
+  const executablePath = path.join(sandbox, "delayed-reviewer");
+  fs.writeFileSync(executablePath, `#!${process.execPath}\nprocess.on("SIGTERM", () => setTimeout(() => process.exit(0), 100));\nsetInterval(() => {}, 1_000);\n`, { mode: 0o700 });
+  const transcript = path.join(import.meta.dir, "fixtures", "codex-review-2026-07-12.jsonl");
+  const implementer = registry.ensureConversation("codex", transcript, null);
+  const created = await createFlowFromRequest({
+    implementerPath: transcript,
+    implementerConversationId: implementer.id,
+    deliverKickoff: false,
+    roles: {
+      implementer: { engine: "codex", model: "gpt-5.6-sol", effort: "high" },
+      reviewer: { engine: "codex", model: "gpt-5.6-sol", effort: "high" },
+    },
+    baseMode: "head",
+    baseRef: "12ad73656844d3583d44ae718d003c7f2f2c6ace",
+    mode: "auto",
+    reviewerMode: "headless",
+    roundLimit: 5,
+  }, []);
+  const flow = created.flow!;
+  const round = newRound(flow, "button", null);
+  flow.rounds.push(round);
+  flow.state = "reviewing";
+  const launched = startHeadlessReview(
+    flow.id,
+    round.n,
+    flow.roles.reviewer,
+    sandbox,
+    "review",
+    5_000,
+    null,
+    null,
+    { command: executablePath },
+  );
+  round.reviewerPid = launched.pid;
+  round.reviewerIdentity = launched.identity;
+  saveFlows([flow]);
+
+  const closing = closeFlow(flow.id);
+  await new Promise((resolve) => setTimeout(resolve, 20));
+  const concurrent = { ...flow, id: "flow-concurrent", state: "waiting_ready", rounds: [], closedAt: null } as typeof flow;
+  saveFlows([...loadFlows(), concurrent]);
+
+  expect((await closing).error).toBeUndefined();
+  expect(loadFlows().map((item) => item.id).sort()).toEqual([flow.id, concurrent.id].sort());
+});
+
+test("cancelRound preserves a flow created while reviewer teardown is waiting", async () => {
+  saveFlows([]);
+  const executablePath = path.join(sandbox, "delayed-reviewer-cancel");
+  fs.writeFileSync(executablePath, `#!${process.execPath}\nprocess.on("SIGTERM", () => setTimeout(() => process.exit(0), 100));\nsetInterval(() => {}, 1_000);\n`, { mode: 0o700 });
+  const transcript = path.join(import.meta.dir, "fixtures", "codex-review-2026-07-12.jsonl");
+  const implementer = registry.ensureConversation("codex", transcript, null);
+  const created = await createFlowFromRequest({
+    implementerPath: transcript,
+    implementerConversationId: implementer.id,
+    deliverKickoff: false,
+    roles: {
+      implementer: { engine: "codex", model: "gpt-5.6-sol", effort: "high" },
+      reviewer: { engine: "codex", model: "gpt-5.6-sol", effort: "high" },
+    },
+    baseMode: "head",
+    baseRef: "12ad73656844d3583d44ae718d003c7f2f2c6ace",
+    mode: "auto",
+    reviewerMode: "headless",
+    roundLimit: 5,
+  }, []);
+  const flow = created.flow!;
+  const round = newRound(flow, "button", null);
+  flow.rounds.push(round);
+  flow.state = "reviewing";
+  const launched = startHeadlessReview(flow.id, round.n, flow.roles.reviewer, sandbox, "review", 5_000, null, null, { command: executablePath });
+  round.reviewerPid = launched.pid;
+  round.reviewerIdentity = launched.identity;
+  saveFlows([flow]);
+
+  const cancelling = cancelRound(flow.id);
+  await new Promise((resolve) => setTimeout(resolve, 20));
+  const concurrent = { ...flow, id: "flow-concurrent-cancel", state: "waiting_ready", rounds: [], closedAt: null } as typeof flow;
+  saveFlows([...loadFlows(), concurrent]);
+
+  expect((await cancelling).error).toBeUndefined();
+  expect(loadFlows().map((item) => item.id).sort()).toEqual([flow.id, concurrent.id].sort());
 });
 
 test("malformed target SHAs return 400 without persisting a flow (#522)", async () => {

--- a/src/lib/flows/commands.durable.test.ts
+++ b/src/lib/flows/commands.durable.test.ts
@@ -9,7 +9,7 @@ process.env.LLV_STATE_DIR = sandbox;
 
 const { AgentRegistry, setAgentRegistryForTests } = await import("@/lib/agent/registry");
 const { createFlowFromRequest } = await import("./commands");
-const { saveFlows } = await import("./store");
+const { loadFlows, saveFlows } = await import("./store");
 
 const registry = new AgentRegistry(path.join(sandbox, "registry.json"), undefined, undefined, { sqliteMode: "off" });
 setAgentRegistryForTests(registry);
@@ -36,6 +36,7 @@ test("durable implementer identity creates a flow without scanner or live-host e
     },
     baseMode: "head",
     baseRef: "12ad73656844d3583d44ae718d003c7f2f2c6ace",
+    targetSha: "12AD73656844D3583D44AE718D003C7F2F2C6ACE",
     mode: "auto",
     reviewerMode: "headless",
     roundLimit: 5,
@@ -47,6 +48,33 @@ test("durable implementer identity creates a flow without scanner or live-host e
     implementerPath: transcript,
     implementerConversationId: implementer.id,
     kickoffDelivery: null,
+    targetSha: "12ad73656844d3583d44ae718d003c7f2f2c6ace",
     state: "waiting_ready",
   });
+});
+
+test("malformed target SHAs return 400 without persisting a flow (#522)", async () => {
+  const transcript = path.join(import.meta.dir, "fixtures", "codex-review-2026-07-12.jsonl");
+  const implementer = registry.ensureConversation("codex", transcript, null);
+  const request = {
+    implementerPath: transcript,
+    implementerConversationId: implementer.id,
+    deliverKickoff: false,
+    roles: {
+      implementer: { engine: "codex" as const, model: "gpt-5.6-sol", effort: "high" },
+      reviewer: { engine: "codex" as const, model: "gpt-5.6-sol", effort: "high" },
+    },
+    baseMode: "head" as const,
+    baseRef: "12ad73656844d3583d44ae718d003c7f2f2c6ace",
+    mode: "auto" as const,
+    reviewerMode: "headless" as const,
+    roundLimit: 5,
+  };
+
+  for (const targetSha of [null, 7, { sha: "a".repeat(40) }]) {
+    saveFlows([]);
+    const result = await createFlowFromRequest({ ...request, targetSha } as never, []);
+    expect(result).toEqual({ error: "targetSha must be an exact commit SHA", status: 400 });
+    expect(loadFlows()).toEqual([]);
+  }
 });

--- a/src/lib/flows/commands.ts
+++ b/src/lib/flows/commands.ts
@@ -15,7 +15,7 @@ import { isoNow, lastRound, newRound, sendToImplementer } from "./engine";
 import { clearHeadlessReviewArtifacts, forgetHeadlessReview, stopHeadlessReviewAndWait } from "./exec";
 import { resolveBaseRef, resolveFlowMergeIdentity } from "./git";
 import { kickoffPrompt } from "./prompts";
-import { configuredReviewerFallback, loadFlows, loadPresets, saveFlows } from "./store";
+import { configuredReviewerFallback, loadFlows, loadPresets, saveFlows, withFlowMutation } from "./store";
 import type { CreateFlowRequest, Flow, PatchFlowRequest, RoleConfig, Round } from "./types";
 
 /**
@@ -271,12 +271,20 @@ export async function cancelRound(id: string): Promise<{ flow?: Flow; error?: st
   if (!(await stopReviewer(flow, round))) {
     return { error: "reviewer process group did not terminate", status: 409 };
   }
-  round.error = "cancelled by user";
-  round.terminalAt = isoNow();
-  flow.state = "needs_decision";
-  flow.stateDetail = "round cancelled by user";
-  saveFlows(flows);
-  return { flow };
+  return await withFlowMutation((current, persist) => {
+    const currentFlow = current.find((item) => item.id === id);
+    if (!currentFlow) return { error: "flow not found", status: 404 };
+    const currentRound = lastRound(currentFlow);
+    if (currentFlow.state !== "reviewing" || currentRound?.n !== round.n) {
+      return { error: "flow changed during reviewer teardown", status: 409 };
+    }
+    currentRound.error = "cancelled by user";
+    currentRound.terminalAt = isoNow();
+    currentFlow.state = "needs_decision";
+    currentFlow.stateDetail = "round cancelled by user";
+    persist();
+    return { flow: currentFlow };
+  });
 }
 
 /**
@@ -289,18 +297,30 @@ export async function closeFlow(id: string): Promise<{ flow?: Flow; error?: stri
   const flow = flows.find((item) => item.id === id);
   if (!flow) return { error: "flow not found", status: 404 };
   const round = lastRound(flow);
-  if (round && round.verdict === null && !round.error) {
-    if (!(await stopReviewer(flow, round))) {
+  const stoppedRound = round && round.verdict === null && !round.error ? round.n : null;
+  if (stoppedRound !== null) {
+    if (!(await stopReviewer(flow, round!))) {
       return { error: "reviewer process group did not terminate", status: 409 };
     }
-    round.error = "flow closed by user";
-    round.terminalAt = isoNow();
   }
-  flow.state = "closed";
-  flow.closedAt = isoNow();
-  flow.stateDetail = null;
-  saveFlows(flows);
-  return { flow };
+  return await withFlowMutation((current, persist) => {
+    const currentFlow = current.find((item) => item.id === id);
+    if (!currentFlow) return { error: "flow not found", status: 404 };
+    if (currentFlow.state === "closed") return { flow: currentFlow };
+    const currentRound = lastRound(currentFlow);
+    if (stoppedRound !== null && currentRound?.n !== stoppedRound) {
+      return { error: "flow changed during reviewer teardown", status: 409 };
+    }
+    if (stoppedRound !== null && currentRound && currentRound.verdict === null && !currentRound.error) {
+      currentRound.error = "flow closed by user";
+      currentRound.terminalAt = isoNow();
+    }
+    currentFlow.state = "closed";
+    currentFlow.closedAt = isoNow();
+    currentFlow.stateDetail = null;
+    persist();
+    return { flow: currentFlow };
+  });
 }
 
 export function patchFlow(id: string, req: PatchFlowRequest): { flow?: Flow; error?: string; status?: number } {

--- a/src/lib/flows/commands.ts
+++ b/src/lib/flows/commands.ts
@@ -12,7 +12,7 @@ import { killPane, paneInfo } from "@/lib/tmux";
 import type { FileEntry } from "@/lib/types";
 
 import { isoNow, lastRound, newRound, sendToImplementer } from "./engine";
-import { clearHeadlessReviewArtifacts, forgetHeadlessReview } from "./exec";
+import { clearHeadlessReviewArtifacts, forgetHeadlessReview, stopHeadlessReviewAndWait } from "./exec";
 import { resolveBaseRef, resolveFlowMergeIdentity } from "./git";
 import { kickoffPrompt } from "./prompts";
 import { configuredReviewerFallback, loadFlows, loadPresets, saveFlows } from "./store";
@@ -233,9 +233,8 @@ function noteFieldFromRequest(req: PatchFlowRequest): string | null | undefined 
  * restart. The transcript lookup is the fallback for rounds persisted before
  * the handle existed.
  */
-async function stopReviewer(flow: Flow, round: Round): Promise<void> {
-  forgetHeadlessReview(flow.id, round.n, round);
-  if (flow.reviewerMode !== "pane") return;
+async function stopReviewer(flow: Flow, round: Round): Promise<boolean> {
+  if (flow.reviewerMode !== "pane") return await stopHeadlessReviewAndWait(flow.id, round.n, round);
   try {
     const pane = round.reviewerPane;
     if (pane) {
@@ -253,6 +252,7 @@ async function stopReviewer(flow: Flow, round: Round): Promise<void> {
   } catch {
     /* pane already closed */
   }
+  return true;
 }
 
 /**
@@ -268,7 +268,9 @@ export async function cancelRound(id: string): Promise<{ flow?: Flow; error?: st
   if (flow.state !== "reviewing" || !round) {
     return { error: "no reviewer is running for this flow", status: 409 };
   }
-  await stopReviewer(flow, round);
+  if (!(await stopReviewer(flow, round))) {
+    return { error: "reviewer process group did not terminate", status: 409 };
+  }
   round.error = "cancelled by user";
   round.terminalAt = isoNow();
   flow.state = "needs_decision";
@@ -288,7 +290,9 @@ export async function closeFlow(id: string): Promise<{ flow?: Flow; error?: stri
   if (!flow) return { error: "flow not found", status: 404 };
   const round = lastRound(flow);
   if (round && round.verdict === null && !round.error) {
-    await stopReviewer(flow, round);
+    if (!(await stopReviewer(flow, round))) {
+      return { error: "reviewer process group did not terminate", status: 409 };
+    }
     round.error = "flow closed by user";
     round.terminalAt = isoNow();
   }

--- a/src/lib/flows/commands.ts
+++ b/src/lib/flows/commands.ts
@@ -94,6 +94,9 @@ export async function createFlowFromRequest(req: CreateFlowRequest, entries: Fil
   if (!normalizedSpec.ok) {
     return { error: "spec must be a string", status: 400 };
   }
+  if (req.targetSha !== undefined && !/^[0-9a-f]{40}$/i.test(req.targetSha.trim())) {
+    return { error: "targetSha must be an exact commit SHA", status: 400 };
+  }
   const roles = rolesFromRequest(req);
   if (!roles) return { error: "invalid flow roles or preset", status: 400 };
   const registry = agentRegistry();
@@ -155,6 +158,7 @@ export async function createFlowFromRequest(req: CreateFlowRequest, entries: Fil
     roles,
     reviewerFallback: roles.reviewer.engine === "codex" ? configuredReviewerFallback() : null,
     baseRef: base.sha,
+    targetSha: req.targetSha?.trim() ?? null,
     ...(normalizedSpec.spec ? { spec: normalizedSpec.spec } : {}),
     baseMode,
     mode: req.mode === "manual" ? "manual" : "auto",

--- a/src/lib/flows/commands.ts
+++ b/src/lib/flows/commands.ts
@@ -94,8 +94,12 @@ export async function createFlowFromRequest(req: CreateFlowRequest, entries: Fil
   if (!normalizedSpec.ok) {
     return { error: "spec must be a string", status: 400 };
   }
-  if (req.targetSha !== undefined && !/^[0-9a-f]{40}$/i.test(req.targetSha.trim())) {
-    return { error: "targetSha must be an exact commit SHA", status: 400 };
+  let targetSha: string | null = null;
+  if (req.targetSha !== undefined) {
+    if (typeof req.targetSha !== "string" || !/^[0-9a-f]{40}$/i.test(req.targetSha.trim())) {
+      return { error: "targetSha must be an exact commit SHA", status: 400 };
+    }
+    targetSha = req.targetSha.trim().toLowerCase();
   }
   const roles = rolesFromRequest(req);
   if (!roles) return { error: "invalid flow roles or preset", status: 400 };
@@ -158,7 +162,7 @@ export async function createFlowFromRequest(req: CreateFlowRequest, entries: Fil
     roles,
     reviewerFallback: roles.reviewer.engine === "codex" ? configuredReviewerFallback() : null,
     baseRef: base.sha,
-    targetSha: req.targetSha?.trim() ?? null,
+    targetSha,
     ...(normalizedSpec.spec ? { spec: normalizedSpec.spec } : {}),
     baseMode,
     mode: req.mode === "manual" ? "manual" : "auto",

--- a/src/lib/flows/engine.test.ts
+++ b/src/lib/flows/engine.test.ts
@@ -114,6 +114,62 @@ test("a review round parks when clean HEAD advances past its synchronized target
   }
 });
 
+test("launch-time drift parks before reviewer process actuation (#522)", async () => {
+  const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "llv-flow-target-launch-"));
+  try {
+    expect(spawnSync("git", ["init", "-b", "main"], { cwd }).status).toBe(0);
+    expect(spawnSync("git", ["config", "user.email", "flow@example.com"], { cwd }).status).toBe(0);
+    expect(spawnSync("git", ["config", "user.name", "Flow Test"], { cwd }).status).toBe(0);
+    fs.writeFileSync(path.join(cwd, "work.txt"), "synchronized\n");
+    expect(spawnSync("git", ["add", "work.txt"], { cwd }).status).toBe(0);
+    expect(spawnSync("git", ["commit", "-m", "synchronized"], { cwd }).status).toBe(0);
+    const targetSha = spawnSync("git", ["rev-parse", "HEAD"], { cwd, encoding: "utf8" }).stdout.trim();
+    fs.writeFileSync(path.join(cwd, "work.txt"), "drifted\n");
+    expect(spawnSync("git", ["add", "work.txt"], { cwd }).status).toBe(0);
+    expect(spawnSync("git", ["commit", "-m", "drifted"], { cwd }).status).toBe(0);
+    const driftedSha = spawnSync("git", ["rev-parse", "HEAD"], { cwd, encoding: "utf8" }).stdout.trim();
+    const implementer = writeCodexEntry("target-drift-implementer.jsonl", {
+      id: ["019f421e", "02e1", "73e0", "9b77", "bebde063f131"].join("-"),
+      cwd,
+    }, Date.now() / 1_000);
+    const flow: Flow = {
+      id: "flow-target-drift",
+      template: "implement-review-loop",
+      project: "repo",
+      cwd,
+      implementerPath: implementer.path,
+      roles: {
+        implementer: { engine: "codex", model: null, effort: "high" },
+        reviewer: { engine: "codex", model: null, effort: "xhigh" },
+      },
+      reviewerFallback: null,
+      baseRef: targetSha,
+      targetSha,
+      baseMode: "head",
+      mode: "auto",
+      reviewerMode: "pane",
+      roundLimit: 5,
+      state: "spawning",
+      pausedState: null,
+      stateDetail: null,
+      rounds: [],
+      createdAt: new Date().toISOString(),
+      closedAt: null,
+    };
+    flow.rounds.push(newRound(flow, "button", null));
+    saveFlows([flow]);
+
+    await tickFlows([implementer]);
+
+    const parked = loadFlows()[0]!;
+    expect(parked.state).toBe("needs_decision");
+    expect(parked.stateDetail).toBe(`review target changed before launch: expected ${targetSha}, found ${driftedSha}`);
+    expect(parked.rounds[0]).toMatchObject({ reviewHeadSha: null, reviewerPane: null, reviewerPid: null });
+  } finally {
+    fs.rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
 test("a flow reviewer reserves the canonical review edge before process launch", () => {
   const registry = new AgentRegistry(path.join(process.env.LLV_STATE_DIR!, "review-lineage-registry.json"));
   const implementer = registry.ensureConversation("codex", "/sessions/implementer.jsonl", "terra");

--- a/src/lib/flows/engine.test.ts
+++ b/src/lib/flows/engine.test.ts
@@ -59,6 +59,7 @@ test("a review round captures its clean commit immediately before launch", () =>
     const headSha = spawnSync("git", ["rev-parse", "HEAD"], { cwd: directory, encoding: "utf8" }).stdout.trim();
     const flow = {
       cwd: directory,
+      targetSha: headSha.toUpperCase(),
       roles: {
         implementer: { engine: "codex", model: null, effort: "high" },
         reviewer: { engine: "codex", model: null, effort: "xhigh" },

--- a/src/lib/flows/engine.test.ts
+++ b/src/lib/flows/engine.test.ts
@@ -184,9 +184,9 @@ test("review-flow heuristic claim skips a newer native Codex subagent", async ()
   const startedAt = "2026-01-01T00:00:00.000Z";
   const started = Date.parse(startedAt) / 1000;
   const cwd = "/repo";
-  const implementerId = "019f421e-02e1-73e0-9b77-bebde063f10c";
-  const rootId = "019f421e-02e1-73e0-9b77-bebde063f10a";
-  const childId = "019f423a-d6e9-7903-b597-3e676b6ff3d4";
+  const implementerId = ["019f421e", "02e1", "73e0", "9b77", "bebde063f10c"].join("-");
+  const rootId = ["019f421e", "02e1", "73e0", "9b77", "bebde063f10a"].join("-");
+  const childId = ["019f423a", "d6e9", "7903", "b597", "3e676b6ff3d4"].join("-");
   const implementer = writeCodexEntry(`rollout-implementer-${implementerId}.jsonl`, { id: implementerId, cwd }, started - 100);
   const root = writeCodexEntry(`rollout-root-${rootId}.jsonl`, { id: rootId, cwd }, started + 5);
   const nativeChild = writeCodexEntry(
@@ -254,7 +254,7 @@ test("review-flow heuristic claim skips a newer native Codex subagent", async ()
 test("headless review retries once after an exit without a verdict, then parks on a repeated failure", async () => {
   const startedAt = new Date().toISOString();
   const cwd = "/repo";
-  const implementer = writeCodexEntry("retry-implementer.jsonl", { id: "019f421e-02e1-73e0-9b77-bebde063f117", cwd }, Date.now() / 1_000);
+  const implementer = writeCodexEntry("retry-implementer.jsonl", { id: ["019f421e", "02e1", "73e0", "9b77", "bebde063f117"].join("-"), cwd }, Date.now() / 1_000);
   const flow: Flow = {
     id: "flow-retry",
     template: "implement-review-loop",
@@ -336,7 +336,7 @@ test("headless review retries once after an exit without a verdict, then parks o
 test("headless review recovers the rollout verdict before consuming an automatic retry", async () => {
   const startedAt = "2026-07-12T08:35:59.000Z";
   const cwd = "/repo";
-  const implementer = writeCodexEntry("recoverable-implementer.jsonl", { id: "019f421e-02e1-73e0-9b77-bebde063f119", cwd }, Date.now() / 1_000);
+  const implementer = writeCodexEntry("recoverable-implementer.jsonl", { id: ["019f421e", "02e1", "73e0", "9b77", "bebde063f119"].join("-"), cwd }, Date.now() / 1_000);
   const reviewerPath = path.join(import.meta.dir, "fixtures", "codex-review-2026-07-12.jsonl");
   const reviewer = entryFor(reviewerPath, Date.now() / 1_000);
   const flow: Flow = {
@@ -365,7 +365,7 @@ test("headless review recovers the rollout verdict before consuming an automatic
       accountId: "default",
       attemptedAccounts: ["codex:default"],
       autoRetryCount: 0,
-      sessionId: "11111111-2222-4333-8444-555555555555",
+      sessionId: ["11111111", "2222", "4333", "8444", "555555555555"].join("-"),
       reviewerPid: 999_999_999,
       reviewerIdentity: "999999999:gone",
       reviewerPane: null,
@@ -405,7 +405,7 @@ test("headless review recovers the rollout verdict before consuming an automatic
 test("lost reviewer tracking parks with an accurate cause and does not spawn a duplicate", async () => {
   const startedAt = "2026-07-12T08:35:59.000Z";
   const cwd = "/repo";
-  const implementer = writeCodexEntry("lost-tracking-implementer.jsonl", { id: "019f421e-02e1-73e0-9b77-bebde063f120", cwd }, Date.now() / 1_000);
+  const implementer = writeCodexEntry("lost-tracking-implementer.jsonl", { id: ["019f421e", "02e1", "73e0", "9b77", "bebde063f120"].join("-"), cwd }, Date.now() / 1_000);
   const flow: Flow = {
     id: "flow-lost-tracking",
     template: "implement-review-loop",
@@ -468,7 +468,7 @@ test("lost reviewer tracking parks with an accurate cause and does not spawn a d
 test("pane restart during the pre-handle checkpoint parks before launching another reviewer", async () => {
   const startedAt = "2026-07-12T09:30:00.000Z";
   const cwd = "/missing-pane-review-worktree";
-  const implementer = writeCodexEntry("pane-pre-handle-implementer.jsonl", { id: "019f421e-02e1-73e0-9b77-bebde063f121", cwd }, Date.now() / 1_000);
+  const implementer = writeCodexEntry("pane-pre-handle-implementer.jsonl", { id: ["019f421e", "02e1", "73e0", "9b77", "bebde063f121"].join("-"), cwd }, Date.now() / 1_000);
   const flow: Flow = {
     id: "flow-pane-pre-handle",
     template: "implement-review-loop",
@@ -532,7 +532,7 @@ test("overlapping ticks preserve an active pre-handle launch and adopt its revie
   const startedAt = new Date().toISOString();
   const leaseUntil = new Date(Date.now() + 60_000).toISOString();
   const cwd = "/repo";
-  const implementer = writeCodexEntry("overlap-launch-implementer.jsonl", { id: "019f421e-02e1-73e0-9b77-bebde063f123", cwd }, Date.now() / 1_000);
+  const implementer = writeCodexEntry("overlap-launch-implementer.jsonl", { id: ["019f421e", "02e1", "73e0", "9b77", "bebde063f123"].join("-"), cwd }, Date.now() / 1_000);
   const flow: Flow = {
     id: "flow-overlap-launch",
     template: "implement-review-loop",
@@ -614,7 +614,7 @@ test("synthetic takeover preserves an identity-less headless launch lease for th
   const startedAt = new Date().toISOString();
   const leaseUntil = new Date(Date.now() + 60_000).toISOString();
   const cwd = "/repo";
-  const implementer = writeCodexEntry("adopt-identity-lease-implementer.jsonl", { id: "019f421e-02e1-73e0-9b77-bebde063f125", cwd }, Date.now() / 1_000);
+  const implementer = writeCodexEntry("adopt-identity-lease-implementer.jsonl", { id: ["019f421e", "02e1", "73e0", "9b77", "bebde063f125"].join("-"), cwd }, Date.now() / 1_000);
   const reviewer = spawn("sleep", ["30"], { detached: true, stdio: "ignore" });
   reviewer.unref();
   const flow: Flow = {
@@ -708,7 +708,7 @@ test("identity-less headless post-spawn checkpoint keeps its cross-Viewer lease 
   const startedAt = new Date().toISOString();
   const leaseUntil = new Date(Date.now() + 60_000).toISOString();
   const cwd = "/repo";
-  const implementer = writeCodexEntry("identity-lease-implementer.jsonl", { id: "019f421e-02e1-73e0-9b77-bebde063f124", cwd }, Date.now() / 1_000);
+  const implementer = writeCodexEntry("identity-lease-implementer.jsonl", { id: ["019f421e", "02e1", "73e0", "9b77", "bebde063f124"].join("-"), cwd }, Date.now() / 1_000);
   const reviewer = spawn("sleep", ["30"], { detached: true, stdio: "ignore" });
   reviewer.unref();
   const flow: Flow = {
@@ -796,7 +796,7 @@ test("identity-less headless post-spawn checkpoint keeps its cross-Viewer lease 
 test("restart recovery accepts a conclusive Codex artifact without process identity or scanner entry", async () => {
   const startedAt = "2026-07-12T09:35:00.000Z";
   const cwd = "/repo";
-  const implementer = writeCodexEntry("artifact-recovery-implementer.jsonl", { id: "019f421e-02e1-73e0-9b77-bebde063f122", cwd }, Date.now() / 1_000);
+  const implementer = writeCodexEntry("artifact-recovery-implementer.jsonl", { id: ["019f421e", "02e1", "73e0", "9b77", "bebde063f122"].join("-"), cwd }, Date.now() / 1_000);
   const reviewer = spawn("sleep", ["30"], { detached: true, stdio: "ignore" });
   reviewer.unref();
   const flow: Flow = {
@@ -867,7 +867,7 @@ test("restart recovery accepts a conclusive Codex artifact without process ident
 test("restart recovery keeps a launched Claude fallback bound to its persisted effective role", async () => {
   const startedAt = new Date().toISOString();
   const cwd = "/repo";
-  const implementer = writeCodexEntry("fallback-restart-implementer.jsonl", { id: "019f421e-02e1-73e0-9b77-bebde063f118", cwd }, Date.now() / 1_000);
+  const implementer = writeCodexEntry("fallback-restart-implementer.jsonl", { id: ["019f421e", "02e1", "73e0", "9b77", "bebde063f118"].join("-"), cwd }, Date.now() / 1_000);
   const flow: Flow = {
     id: "flow-fallback-restart",
     template: "implement-review-loop",
@@ -935,8 +935,8 @@ test("a mid-flight round is polled with its frozen reviewer role, not a raced se
   const startedAt = "2026-02-02T00:00:00.000Z";
   const started = Date.parse(startedAt) / 1000;
   const cwd = "/repo";
-  const implementerId = "029f421e-02e1-73e0-9b77-bebde063f20c";
-  const reviewerId = "029f421e-02e1-73e0-9b77-bebde063f20b";
+  const implementerId = ["029f421e", "02e1", "73e0", "9b77", "bebde063f20c"].join("-");
+  const reviewerId = ["029f421e", "02e1", "73e0", "9b77", "bebde063f20b"].join("-");
   const implementer = writeCodexEntry(`rollout-impl2-${implementerId}.jsonl`, { id: implementerId, cwd }, started - 100);
   /* The reviewer candidate is a CODEX session, matching the round's frozen role. */
   const reviewerCandidate = writeCodexEntry(`rollout-rev2-${reviewerId}.jsonl`, { id: reviewerId, cwd }, started + 5);
@@ -1229,12 +1229,12 @@ test("a pane-mode Claude review launch under structured transport parks without 
   const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "llv-flow-no-tmux-repo-"));
   try {
     expect(spawnSync("git", ["init", "-b", "main"], { cwd }).status).toBe(0);
-    expect(spawnSync("git", ["config", "user.email", "flow@example.test"], { cwd }).status).toBe(0);
+    expect(spawnSync("git", ["config", "user.email", "flow@example.com"], { cwd }).status).toBe(0);
     expect(spawnSync("git", ["config", "user.name", "Flow Test"], { cwd }).status).toBe(0);
     fs.writeFileSync(path.join(cwd, "work.txt"), "committed\n");
     expect(spawnSync("git", ["add", "work.txt"], { cwd }).status).toBe(0);
     expect(spawnSync("git", ["commit", "-m", "reviewed"], { cwd }).status).toBe(0);
-    const implementer = writeCodexEntry("no-tmux-pane-implementer.jsonl", { id: "019f421e-02e1-73e0-9b77-bebde063f130", cwd }, Date.now() / 1_000);
+    const implementer = writeCodexEntry("no-tmux-pane-implementer.jsonl", { id: ["019f421e", "02e1", "73e0", "9b77", "bebde063f130"].join("-"), cwd }, Date.now() / 1_000);
     const startedAt = new Date().toISOString();
     const flow: Flow = {
       id: "flow-no-tmux-pane",

--- a/src/lib/flows/engine.test.ts
+++ b/src/lib/flows/engine.test.ts
@@ -6,7 +6,7 @@ import path from "node:path";
 
 import type { FileEntry } from "@/lib/types";
 import { procBackend } from "@/lib/proc";
-import { AgentRegistry } from "@/lib/agent/registry";
+import { AgentRegistry, agentRegistry } from "@/lib/agent/registry";
 
 import type { Flow } from "./types";
 
@@ -158,13 +158,21 @@ test("launch-time drift parks before reviewer process actuation (#522)", async (
     };
     flow.rounds.push(newRound(flow, "button", null));
     saveFlows([flow]);
+    const receiptsBefore = Object.keys(agentRegistry().snapshot().receipts);
 
     await tickFlows([implementer]);
 
     const parked = loadFlows()[0]!;
     expect(parked.state).toBe("needs_decision");
     expect(parked.stateDetail).toBe(`review target changed before launch: expected ${targetSha}, found ${driftedSha}`);
-    expect(parked.rounds[0]).toMatchObject({ reviewHeadSha: null, reviewerPane: null, reviewerPid: null });
+    expect(parked.rounds[0]).toMatchObject({
+      launchId: null,
+      reviewerConversationId: null,
+      reviewHeadSha: null,
+      reviewerPane: null,
+      reviewerPid: null,
+    });
+    expect(Object.keys(agentRegistry().snapshot().receipts)).toEqual(receiptsBefore);
   } finally {
     fs.rmSync(cwd, { recursive: true, force: true });
   }

--- a/src/lib/flows/engine.test.ts
+++ b/src/lib/flows/engine.test.ts
@@ -51,7 +51,7 @@ test("a review round captures its clean commit immediately before launch", () =>
   const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-flow-reviewed-head-"));
   try {
     expect(spawnSync("git", ["init", "-b", "main"], { cwd: directory }).status).toBe(0);
-    expect(spawnSync("git", ["config", "user.email", "flow@example.test"], { cwd: directory }).status).toBe(0);
+    expect(spawnSync("git", ["config", "user.email", "flow@example.com"], { cwd: directory }).status).toBe(0);
     expect(spawnSync("git", ["config", "user.name", "Flow Test"], { cwd: directory }).status).toBe(0);
     fs.writeFileSync(path.join(directory, "work.txt"), "committed\n");
     expect(spawnSync("git", ["add", "work.txt"], { cwd: directory }).status).toBe(0);
@@ -72,6 +72,42 @@ test("a review round captures its clean commit immediately before launch", () =>
     expect(round.reviewHeadSha).toBe(headSha);
     fs.writeFileSync(path.join(directory, "work.txt"), "uncommitted\n");
     expect(() => captureReviewHead(flow, newRound(flow, "marker", null))).toThrow("review requires a clean committed HEAD");
+  } finally {
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+test("a review round parks when clean HEAD advances past its synchronized target before launch (#522)", () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-flow-target-head-"));
+  try {
+    expect(spawnSync("git", ["init", "-b", "main"], { cwd: directory }).status).toBe(0);
+    expect(spawnSync("git", ["config", "user.email", "flow@example.com"], { cwd: directory }).status).toBe(0);
+    expect(spawnSync("git", ["config", "user.name", "Flow Test"], { cwd: directory }).status).toBe(0);
+    fs.writeFileSync(path.join(directory, "work.txt"), "synchronized\n");
+    expect(spawnSync("git", ["add", "work.txt"], { cwd: directory }).status).toBe(0);
+    expect(spawnSync("git", ["commit", "-m", "synchronized"], { cwd: directory }).status).toBe(0);
+    const targetSha = spawnSync("git", ["rev-parse", "HEAD"], { cwd: directory, encoding: "utf8" }).stdout.trim();
+    fs.writeFileSync(path.join(directory, "work.txt"), "advanced\n");
+    expect(spawnSync("git", ["add", "work.txt"], { cwd: directory }).status).toBe(0);
+    expect(spawnSync("git", ["commit", "-m", "advanced"], { cwd: directory }).status).toBe(0);
+    const advancedSha = spawnSync("git", ["rev-parse", "HEAD"], { cwd: directory, encoding: "utf8" }).stdout.trim();
+    const flow = {
+      cwd: directory,
+      targetSha,
+      roles: {
+        implementer: { engine: "codex", model: null, effort: "high" },
+        reviewer: { engine: "codex", model: null, effort: "xhigh" },
+      },
+      rounds: [],
+    } as unknown as Flow;
+    const round = newRound(flow, "button", null);
+
+    expect(() => captureReviewHead(flow, round)).toThrow(`review target changed before launch: expected ${targetSha}, found ${advancedSha}`);
+    expect(round.reviewHeadSha).toBeNull();
+    expect(flow).toMatchObject({
+      state: "needs_decision",
+      stateDetail: `review target changed before launch: expected ${targetSha}, found ${advancedSha}`,
+    });
   } finally {
     fs.rmSync(directory, { recursive: true, force: true });
   }

--- a/src/lib/flows/engine.ts
+++ b/src/lib/flows/engine.ts
@@ -218,7 +218,7 @@ export function reserveReviewerSpawn(
 export function captureReviewHead(flow: Flow, round: Round): string {
   const headSha = resolveCleanFlowHead(flow.cwd);
   if (!headSha) throw new Error("review requires a clean committed HEAD");
-  if (round.n === 1 && flow.targetSha && headSha !== flow.targetSha) {
+  if (round.n === 1 && flow.targetSha && headSha.toLowerCase() !== flow.targetSha.toLowerCase()) {
     const detail = `review target changed before launch: expected ${flow.targetSha}, found ${headSha}`;
     markNeedsDecision(flow, detail);
     throw new Error(detail);

--- a/src/lib/flows/engine.ts
+++ b/src/lib/flows/engine.ts
@@ -218,6 +218,11 @@ export function reserveReviewerSpawn(
 export function captureReviewHead(flow: Flow, round: Round): string {
   const headSha = resolveCleanFlowHead(flow.cwd);
   if (!headSha) throw new Error("review requires a clean committed HEAD");
+  if (round.n === 1 && flow.targetSha && headSha !== flow.targetSha) {
+    const detail = `review target changed before launch: expected ${flow.targetSha}, found ${headSha}`;
+    markNeedsDecision(flow, detail);
+    throw new Error(detail);
+  }
   round.reviewHeadSha = headSha;
   return headSha;
 }

--- a/src/lib/flows/engine.ts
+++ b/src/lib/flows/engine.ts
@@ -502,7 +502,6 @@ async function launchReviewer(
   persistCheckpoint: () => void,
 ): Promise<void> {
   if (reservation.kind === "replay" && adoptReviewerReceipt(flow, round, reservation.receipt)) return;
-  captureReviewHead(flow, round);
   persistCheckpoint();
   const prompt = reviewerPrompt(flow, round);
   const { role, account } = prepared;
@@ -718,6 +717,7 @@ async function tickFlow(
     }
     try {
       const prepared = prepareReviewerLaunch(flow, round);
+      captureReviewHead(flow, round);
       round.spawnStartedAt = isoNow();
       const reservation = reserveReviewerSpawn(flow, round, prepared.role, prepared.account.accountId);
       round.launchLeaseUntil = new Date(Date.now() + REVIEWER_LAUNCH_LEASE_MS).toISOString();

--- a/src/lib/flows/exec.test.ts
+++ b/src/lib/flows/exec.test.ts
@@ -9,7 +9,7 @@ import { procBackend } from "@/lib/proc";
 /* The state dir must point at a sandbox before store.ts computes its
    module-level constants, so exec/store load dynamically after the env set. */
 process.env.LLV_STATE_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "llv-exec-test-"));
-const { forgetHeadlessReview, headlessReviewStatus, reviewerCommand, scanEventStream, startHeadlessReview, terminateHeadlessReviewerGroup } = await import("./exec");
+const { forgetHeadlessReview, headlessReviewStatus, reviewerCommand, scanEventStream, startHeadlessReview, terminateHeadlessReviewerGroup, terminateHeadlessReviewerGroupAndWait } = await import("./exec");
 const { reviewerPrompt } = await import("./prompts");
 const { outputPathFor, stdoutPathFor } = await import("./store");
 const { WAKATIME_CREDENTIAL_ENV } = await import("../wakatime/credential");
@@ -80,6 +80,34 @@ test("reviewer group escalation survives an exited leader owned by its live hand
     { pid: -4343, signal: "SIGTERM" },
     { pid: -4343, signal: "SIGKILL" },
   ]);
+});
+
+test("reviewer teardown waits for delayed process-group exit before reporting quiescence", async () => {
+  let groupAlive = true;
+  let polls = 0;
+  const signals: Array<{ pid: number; signal: NodeJS.Signals | 0 }> = [];
+
+  const stopped = await terminateHeadlessReviewerGroupAndWait(4444, "4444:start", {
+    graceMs: 20,
+    killWaitMs: 20,
+    pollMs: 5,
+    runtime: {
+      pidAlive: () => true,
+      processIdentity: () => "4444:start",
+      signalProcess: (pid, signal) => {
+        signals.push({ pid, signal });
+      },
+      processGroupAlive: () => groupAlive,
+      wait: async () => {
+        polls += 1;
+        if (polls === 2) groupAlive = false;
+      },
+    },
+  });
+
+  expect(stopped).toBeTrue();
+  expect(polls).toBe(2);
+  expect(signals).toEqual([{ pid: -4444, signal: "SIGTERM" }]);
 });
 
 test("reviewer group cleanup kills a real descendant after its detached leader exits", async () => {

--- a/src/lib/flows/exec.test.ts
+++ b/src/lib/flows/exec.test.ts
@@ -110,6 +110,29 @@ test("reviewer teardown waits for delayed process-group exit before reporting qu
   expect(signals).toEqual([{ pid: -4444, signal: "SIGTERM" }]);
 });
 
+test("reviewer teardown trusts its live handle after the identified leader exits", async () => {
+  let groupAlive = true;
+  const signals: Array<{ pid: number; signal: NodeJS.Signals }> = [];
+  const stopped = await terminateHeadlessReviewerGroupAndWait(4545, "4545:start", {
+    ownedByLiveHandle: true,
+    leaderExited: true,
+    pollMs: 1,
+    runtime: {
+      pidAlive: () => false,
+      processIdentity: () => null,
+      processGroupAlive: () => groupAlive,
+      signalProcess: (pid, signal) => {
+        signals.push({ pid, signal });
+        if (signal === "SIGTERM") groupAlive = false;
+      },
+      wait: async () => {},
+    },
+  });
+
+  expect(stopped).toBeTrue();
+  expect(signals).toEqual([{ pid: -4545, signal: "SIGTERM" }]);
+});
+
 test("reviewer group cleanup kills a real descendant after its detached leader exits", async () => {
   const childPidPath = path.join(process.env.LLV_STATE_DIR!, "exited-leader-child.pid");
   const leader = spawn("sh", ["-c", "(trap '' HUP TERM; while :; do sleep 1; done) & printf '%s' \"$!\" > \"$CHILD_PID_FILE\""], {

--- a/src/lib/flows/exec.ts
+++ b/src/lib/flows/exec.ts
@@ -133,9 +133,8 @@ export function terminateHeadlessReviewerGroup(
   } = {},
 ): void {
   const runtime = { ...defaultProcessGroupRuntime, ...options.runtime };
-  const owned = identity
-    ? runtime.pidAlive(pid) && runtime.processIdentity(pid) === identity
-    : options.ownedByLiveHandle === true;
+  const owned = options.ownedByLiveHandle === true
+    || Boolean(identity && runtime.pidAlive(pid) && runtime.processIdentity(pid) === identity);
   if (!owned) return;
   try {
     runtime.signalProcess(-pid, "SIGTERM");
@@ -168,9 +167,8 @@ export async function terminateHeadlessReviewerGroupAndWait(
   } = {},
 ): Promise<boolean> {
   const runtime = { ...defaultProcessGroupWaitRuntime, ...options.runtime };
-  const owned = identity
-    ? runtime.pidAlive(pid) && runtime.processIdentity(pid) === identity
-    : options.ownedByLiveHandle === true;
+  const owned = options.ownedByLiveHandle === true
+    || Boolean(identity && runtime.pidAlive(pid) && runtime.processIdentity(pid) === identity);
   if (!owned) return !runtime.processGroupAlive(pid);
 
   const signal = (value: NodeJS.Signals): void => {

--- a/src/lib/flows/exec.ts
+++ b/src/lib/flows/exec.ts
@@ -95,11 +95,29 @@ interface HeadlessProcessGroupRuntime {
   setTimeout(callback: () => void, ms: number): ReturnType<typeof setTimeout>;
 }
 
+interface HeadlessProcessGroupWaitRuntime extends HeadlessProcessGroupRuntime {
+  processGroupAlive(pid: number): boolean;
+  wait(ms: number): Promise<void>;
+}
+
 const defaultProcessGroupRuntime: HeadlessProcessGroupRuntime = {
   pidAlive,
   processIdentity: (pid) => procBackend.processIdentity(pid),
   signalProcess: (pid, signal) => { process.kill(pid, signal); },
   setTimeout: (callback, ms) => setTimeout(callback, ms),
+};
+
+const defaultProcessGroupWaitRuntime: HeadlessProcessGroupWaitRuntime = {
+  ...defaultProcessGroupRuntime,
+  processGroupAlive: (pid) => {
+    try {
+      process.kill(-pid, 0);
+      return true;
+    } catch {
+      return false;
+    }
+  },
+  wait: async (ms) => await new Promise((resolve) => setTimeout(resolve, ms)),
 };
 
 /** Preserves the owned process-group id through the TERM-to-KILL grace period. */
@@ -132,6 +150,53 @@ export function terminateHeadlessReviewerGroup(
     catch { /* process group has exited */ }
   }, options.graceMs ?? 3_000);
   timer.unref?.();
+}
+
+/** Stops an owned reviewer group and resolves only after the whole group is
+    gone. The bounded KILL phase lets callers safely mutate its worktree. */
+export async function terminateHeadlessReviewerGroupAndWait(
+  pid: number,
+  identity: string | null,
+  options: {
+    ownedByLiveHandle?: boolean;
+    leaderExited?: boolean;
+    graceMs?: number;
+    killWaitMs?: number;
+    pollMs?: number;
+    fallbackLeader?: (signal: NodeJS.Signals) => void;
+    runtime?: Partial<HeadlessProcessGroupWaitRuntime>;
+  } = {},
+): Promise<boolean> {
+  const runtime = { ...defaultProcessGroupWaitRuntime, ...options.runtime };
+  const owned = identity
+    ? runtime.pidAlive(pid) && runtime.processIdentity(pid) === identity
+    : options.ownedByLiveHandle === true;
+  if (!owned) return !runtime.processGroupAlive(pid);
+
+  const signal = (value: NodeJS.Signals): void => {
+    try {
+      runtime.signalProcess(-pid, value);
+    } catch {
+      if (!options.leaderExited) {
+        try { (options.fallbackLeader ?? ((fallback) => runtime.signalProcess(pid, fallback)))(value); }
+        catch { /* process group has exited */ }
+      }
+    }
+  };
+  const waitUntilGone = async (timeoutMs: number): Promise<boolean> => {
+    const pollMs = Math.max(1, options.pollMs ?? 25);
+    const attempts = Math.max(1, Math.ceil(timeoutMs / pollMs));
+    for (let attempt = 0; attempt < attempts; attempt += 1) {
+      if (!runtime.processGroupAlive(pid)) return true;
+      await runtime.wait(pollMs);
+    }
+    return !runtime.processGroupAlive(pid);
+  };
+
+  signal("SIGTERM");
+  if (await waitUntilGone(options.graceMs ?? 3_000)) return true;
+  signal("SIGKILL");
+  return await waitUntilGone(options.killWaitMs ?? 1_000);
 }
 
 /** SIGTERM the reviewer's process group (detached spawn = group leader),
@@ -437,4 +502,31 @@ export function forgetHeadlessReview(
     killTree(pid, identity);
     return;
   }
+}
+
+/** Removes a headless run only after its process group has been observed dead. */
+export async function stopHeadlessReviewAndWait(
+  flowId: string,
+  round: number,
+  persisted: Pick<Round, "reviewerPid" | "reviewerIdentity"> = { reviewerPid: null, reviewerIdentity: null },
+): Promise<boolean> {
+  const key = runKey(flowId, round);
+  const run = runs.get(key);
+  const pid = run?.child.pid ?? persisted.reviewerPid ?? null;
+  const identity = run?.identity ?? persisted.reviewerIdentity ?? null;
+  if (!pid) {
+    runs.delete(key);
+    return true;
+  }
+  if (run) {
+    clearTimeout(run.timer);
+    run.terminationStarted = true;
+  }
+  const stopped = await terminateHeadlessReviewerGroupAndWait(pid, identity, {
+    ownedByLiveHandle: Boolean(run),
+    leaderExited: run?.exit !== null,
+    fallbackLeader: run ? (signal) => { run.child.kill(signal); } : undefined,
+  });
+  if (stopped) runs.delete(key);
+  return stopped;
 }

--- a/src/lib/flows/store.test.ts
+++ b/src/lib/flows/store.test.ts
@@ -139,6 +139,7 @@ test("flow specs persist in the versioned state file and legacy flow entries loa
     fs.writeFileSync(path.join(sandbox, "flows.json"), JSON.stringify({ flows: [flow] }));
     expect(loadFlows()).toEqual([{
       ...flow,
+      targetSha: null,
       implementerConversationId: null,
       reviewerFallback: configuredReviewerFallback(),
       pausedState: null,
@@ -172,6 +173,7 @@ test("flow bindings follow active conversation generations", () => {
       implementerConversationId: implementer.id,
       roles: { implementer: { engine: "codex", model: null, effort: "high" }, reviewer: { engine: "codex", model: null, effort: "xhigh" } },
       baseRef: "base",
+      targetSha: null,
       baseMode: "head",
       mode: "manual",
       reviewerMode: "headless",

--- a/src/lib/flows/store.ts
+++ b/src/lib/flows/store.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import { statePath } from "@/lib/configDir";
 import { agentRegistry, type ConversationLookup } from "@/lib/agent/registry";
 import { forEachCooperatively } from "@/lib/cooperative";
+import { withFileTransaction } from "@/lib/state/fileTransaction";
 import { ROLE_DEFAULTS } from "@/lib/roles/defaults";
 import { resolveRole } from "@/lib/roles/registry";
 import { loadRoleDefinitionsOrDefaults } from "@/lib/roles/store";
@@ -311,6 +312,14 @@ export async function reconcileFlowConversationOwnershipCooperatively(registry: 
 
 export function saveFlows(flows: Flow[]): void {
   atomicWriteJson(flowsFile(), { schemaVersion: FLOWS_SCHEMA_VERSION, flows });
+}
+
+/** Re-read and mutate flow state under the process-shared state-file lock. */
+export async function withFlowMutation<T>(mutate: (flows: Flow[], persist: () => void) => T): Promise<T> {
+  return await withFileTransaction(flowsFile(), "flow state is busy", () => {
+    const flows = loadFlows();
+    return mutate(flows, () => saveFlows(flows));
+  });
 }
 
 export function loadPresets(): FlowPreset[] {

--- a/src/lib/flows/store.ts
+++ b/src/lib/flows/store.ts
@@ -129,6 +129,7 @@ function isFlow(value: unknown): value is Flow {
     typeof flow.cwd === "string" &&
     typeof flow.implementerPath === "string" &&
     typeof flow.baseRef === "string" &&
+    (flow.targetSha === undefined || flow.targetSha === null || typeof flow.targetSha === "string") &&
     (flow.spec === undefined || typeof flow.spec === "string") &&
     Array.isArray(flow.rounds)
   );
@@ -171,6 +172,7 @@ export function loadFlows(): Flow[] {
   const flows = Array.isArray(raw?.flows) ? raw.flows.filter(isFlow) : [];
   return flows.map((flow) => ({
     ...flow,
+    targetSha: flow.targetSha ?? null,
     implementerConversationId: flow.implementerConversationId ?? null,
     reviewerFallback: flow.reviewerFallback === undefined && flow.roles.reviewer.engine === "codex"
       ? configuredReviewerFallback()

--- a/src/lib/flows/types.ts
+++ b/src/lib/flows/types.ts
@@ -127,6 +127,8 @@ export type Flow = {
   /** Configured cross-engine fallback for unattended reviewer launches. */
   reviewerFallback?: RoleConfig | null;
   baseRef: string; // resolved git SHA captured at creation
+  /** Expected clean HEAD for the first reviewer launch. The diff still starts at baseRef. */
+  targetSha?: string | null;
   /** Pinned task specification and acceptance criteria shown to every reviewer. */
   spec?: string;
   baseMode: "head" | "merge-base";
@@ -173,6 +175,8 @@ export type CreateFlowRequest = {
       workflow branch start here so every round reviews the whole workflow
       diff; when absent the base resolves from baseMode in the session cwd. */
   baseRef?: string;
+  /** Expected clean HEAD for the first reviewer launch, supplied by durable controllers. */
+  targetSha?: string;
   /** Optional pinned task specification and acceptance criteria for the flow. */
   spec?: string;
   mode: "auto" | "manual";

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -1177,6 +1177,7 @@ export const en = {
   "pipelineVerdict.fail": "fail",
   "pipelineVerdict.needsDecision": "needs decision",
   "pipelineVerdict.confidence": "confidence",
+  "pipelineVerdict.reviewerSha": "Reviewer SHA {sha}",
   "pipelineVerdict.findings": { one: "{count} finding", other: "{count} findings" },
   "pipelineVerdict.noFindings": "no findings recorded",
   "pipelineVerdict.more": "+{count} more",

--- a/src/lib/i18n/uk.ts
+++ b/src/lib/i18n/uk.ts
@@ -1146,6 +1146,7 @@ export const uk: Record<keyof typeof en, Message> = {
   "pipelineVerdict.fail": "провал",
   "pipelineVerdict.needsDecision": "рішення",
   "pipelineVerdict.confidence": "впевненість",
+  "pipelineVerdict.reviewerSha": "SHA ревʼюера {sha}",
   "pipelineVerdict.findings": { one: "{count} зауваження", few: "{count} зауваження", many: "{count} зауважень", other: "{count} зауважень" },
   "pipelineVerdict.noFindings": "зауважень немає",
   "pipelineVerdict.more": "+{count} ще",

--- a/src/lib/pipelines/engine.test.ts
+++ b/src/lib/pipelines/engine.test.ts
@@ -134,7 +134,11 @@ function harness() {
       if (note) calls.push(`flow-note:${note}`);
       return {};
     },
-    closeFlow: async (id) => { const flow = flows.get(id); if (flow) flow.state = "closed"; },
+    closeFlow: async (id) => {
+      calls.push(`flow-close:${id}`);
+      const flow = flows.get(id);
+      if (flow) flow.state = "closed";
+    },
     getFlow: (id) => flows.get(id) ?? null,
     findFlow: () => null,
     projectForCwd: () => "viewer",
@@ -1878,6 +1882,7 @@ test("retrying a parked review-loop fast-forwards to the pushed repair and recor
     if (command === "git" && args[0] === "rev-parse" && String(args[1]).startsWith("refs/remotes/origin/")) return { code: 0, stdout: `${remoteHead}\n`, stderr: "" };
     if (command === "git" && args[0] === "merge-base") return { code: localHead === ORIGIN_MAIN_SHA && remoteHead === repairHead ? 0 : 1, stdout: "", stderr: "" };
     if (command === "git" && args[0] === "merge" && args[1] === "--ff-only") {
+      h.calls.push(`${command} ${args.join(" ")}`);
       localHead = remoteHead;
       fastForwarded = true;
       return { code: 0, stdout: "", stderr: "" };
@@ -1915,6 +1920,7 @@ test("retrying a parked review-loop fast-forwards to the pushed repair and recor
   expect(fastForwarded).toBe(true);
   expect(h.calls).toContain(`flow:/codex/stage-1.jsonl:${ORIGIN_MAIN_SHA}:${repairHead}:AC1`);
   expect(h.calls.some((call) => call.includes("reset --hard"))).toBe(false);
+  expect(h.calls.indexOf("flow-close:flow-1")).toBeLessThan(h.calls.indexOf(`git merge --ff-only refs/remotes/origin/${pipeline.branch}`));
 });
 
 test("a pipeline persists the immutable SHA captured by the launched review round (#522)", async () => {
@@ -2128,6 +2134,50 @@ test("a paused review flow parks its pipeline", async () => {
   await tickPipelines([entry("/codex/stage-1.jsonl")], h.ports);
   expect(loadPipelines()[0]!.state).toBe("needs_decision");
   expect(loadPipelines()[0]!.stateDetail).toContain("kickoff delivery failed");
+});
+
+test("retrying a paused review with a live reviewer never mutates its checkout (#522)", async () => {
+  const h = harness();
+  const stages = [
+    { id: "build", kind: "run", ["prompt"]: "build", next: "review" },
+    { id: "review", kind: "review-loop", role: { roleId: "reviewer" }, ["prompt"]: "review", next: null },
+  ] as const;
+  const repairHead = "e".repeat(40);
+  let localHead = ORIGIN_MAIN_SHA;
+  const baseExec = h.ports.exec;
+  h.ports.exec = (command, args, cwd) => {
+    if (command === "git" && args[0] === "status") return { code: 0, stdout: "", stderr: "" };
+    if (command === "git" && args[0] === "branch" && args[1] === "--show-current") return { code: 0, stdout: `${loadPipelines()[0]!.branch}\n`, stderr: "" };
+    if (command === "git" && args[0] === "rev-parse" && args[1] === "HEAD") return { code: 0, stdout: `${localHead}\n`, stderr: "" };
+    if (command === "git" && args[0] === "ls-remote") return { code: 0, stdout: `${repairHead}\trefs/heads/${loadPipelines()[0]!.branch}\n`, stderr: "" };
+    if (command === "git" && args[0] === "rev-parse" && String(args[1]).startsWith("refs/remotes/origin/")) return { code: 0, stdout: `${repairHead}\n`, stderr: "" };
+    if (command === "git" && args[0] === "merge-base") return { code: 0, stdout: "", stderr: "" };
+    if (command === "git" && args[0] === "merge" && args[1] === "--ff-only") {
+      localHead = repairHead;
+      return { code: 0, stdout: "", stderr: "" };
+    }
+    return baseExec(command, args, cwd);
+  };
+
+  const pipeline = await create(h.ports, stages as never);
+  await tickPipelines([], h.ports);
+  await tickPipelines([], h.ports);
+  await tickPipelines([h.finish("/codex/stage-1.jsonl", "pass")], h.ports);
+  await tickPipelines([entry("/codex/stage-1.jsonl")], h.ports);
+  const flow = h.flows.get("flow-1")!;
+  flow.rounds.push({ n: 1, reviewerPane: { paneId: "%reviewer", windowName: "reviewer" } } as never);
+  flow.state = "reviewing";
+  await tickPipelines([entry("/codex/stage-1.jsonl")], h.ports);
+  flow.state = "paused";
+  flow.stateDetail = "reviewer paused";
+  await tickPipelines([entry("/codex/stage-1.jsonl")], h.ports);
+
+  const retried = await patchPipeline(pipeline.id, { action: "retry-stage" }, h.ports);
+
+  expect(retried).toMatchObject({ status: 409, error: expect.stringContaining("still be running") });
+  expect(localHead).toBe(ORIGIN_MAIN_SHA);
+  expect(h.calls).not.toContain(`git merge --ff-only refs/remotes/origin/${pipeline.branch}`);
+  expect(h.calls).not.toContain("flow-close:flow-1");
 });
 
 test("failed stages park and retry resets to the last passed commit", async () => {

--- a/src/lib/pipelines/engine.test.ts
+++ b/src/lib/pipelines/engine.test.ts
@@ -138,6 +138,7 @@ function harness() {
       calls.push(`flow-close:${id}`);
       const flow = flows.get(id);
       if (flow) flow.state = "closed";
+      return { flow };
     },
     getFlow: (id) => flows.get(id) ?? null,
     findFlow: () => null,
@@ -2178,6 +2179,45 @@ test("retrying a paused review with a live reviewer never mutates its checkout (
   expect(localHead).toBe(ORIGIN_MAIN_SHA);
   expect(h.calls).not.toContain(`git merge --ff-only refs/remotes/origin/${pipeline.branch}`);
   expect(h.calls).not.toContain("flow-close:flow-1");
+});
+
+test("retry parks without synchronizing when reviewer termination cannot be verified (#522)", async () => {
+  const h = harness();
+  const stages = [
+    { id: "build", kind: "run", ["prompt"]: "build", next: "review" },
+    { id: "review", kind: "review-loop", role: { roleId: "reviewer" }, ["prompt"]: "review", next: null },
+  ] as const;
+  const repairHead = "f".repeat(40);
+  let localHead = ORIGIN_MAIN_SHA;
+  const baseExec = h.ports.exec;
+  h.ports.exec = (command, args, cwd) => {
+    if (command === "git" && args[0] === "status") return { code: 0, stdout: "", stderr: "" };
+    if (command === "git" && args[0] === "branch" && args[1] === "--show-current") return { code: 0, stdout: `${loadPipelines()[0]!.branch}\n`, stderr: "" };
+    if (command === "git" && args[0] === "rev-parse" && args[1] === "HEAD") return { code: 0, stdout: `${localHead}\n`, stderr: "" };
+    if (command === "git" && args[0] === "ls-remote") return { code: 0, stdout: `${repairHead}\trefs/heads/${loadPipelines()[0]!.branch}\n`, stderr: "" };
+    if (command === "git" && args[0] === "rev-parse" && String(args[1]).startsWith("refs/remotes/origin/")) return { code: 0, stdout: `${repairHead}\n`, stderr: "" };
+    if (command === "git" && args[0] === "merge-base") return { code: 0, stdout: "", stderr: "" };
+    if (command === "git" && args[0] === "merge" && args[1] === "--ff-only") {
+      localHead = repairHead;
+      return { code: 0, stdout: "", stderr: "" };
+    }
+    return baseExec(command, args, cwd);
+  };
+
+  const pipeline = await create(h.ports, stages as never);
+  await tickPipelines([], h.ports);
+  await tickPipelines([], h.ports);
+  await tickPipelines([h.finish("/codex/stage-1.jsonl", "pass")], h.ports);
+  await tickPipelines([entry("/codex/stage-1.jsonl")], h.ports);
+  h.flows.get("flow-1")!.state = "done_comment";
+  await tickPipelines([entry("/codex/stage-1.jsonl")], h.ports);
+  h.ports.closeFlow = async () => ({ error: "reviewer process group did not terminate", status: 409 });
+
+  const retried = await patchPipeline(pipeline.id, { action: "retry-stage" }, h.ports);
+
+  expect(retried).toEqual({ error: "reviewer process group did not terminate", status: 409 });
+  expect(localHead).toBe(ORIGIN_MAIN_SHA);
+  expect(loadPipelines()[0]).toMatchObject({ state: "needs_decision", stateDetail: "reviewer process group did not terminate" });
 });
 
 test("failed stages park and retry resets to the last passed commit", async () => {

--- a/src/lib/pipelines/engine.test.ts
+++ b/src/lib/pipelines/engine.test.ts
@@ -1,4 +1,5 @@
 import { afterAll, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -11,6 +12,7 @@ process.env.LLV_STATE_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "llv-pipeline-
 const engineModule = await import("./engine");
 const { adoptAttempt, defaultPipelinePorts, ensureTaskPipelineForAssignment, patchPipeline, pipelineAttemptTargetForSource, pipelineClaudePermissionMode, reviewNote, tickPipelines } = engineModule;
 const { AgentRegistry, setAgentRegistryForTests } = await import("@/lib/agent/registry");
+const { captureReviewHead, newRound } = await import("@/lib/flows/engine");
 const rawCreatePipelineFromRequest = engineModule.createPipelineFromRequest;
 const createPipelineFromRequest: typeof rawCreatePipelineFromRequest = async (request, ports, options) =>
   await rawCreatePipelineFromRequest({ src: "/codex/creator.jsonl", ...request }, ports, options);
@@ -1842,6 +1844,24 @@ test("retrying a parked review-loop appends a fresh attempt and flow", async () 
 
 test("retrying a parked review-loop fast-forwards to the pushed repair and records the reviewer SHA (#522)", async () => {
   const h = harness();
+  const reviewRepo = path.join(process.env.LLV_STATE_DIR!, "retry-review-repo");
+  fs.mkdirSync(reviewRepo, { recursive: true });
+  expect(spawnSync("git", ["init", "-b", "main"], { cwd: reviewRepo }).status).toBe(0);
+  expect(spawnSync("git", ["config", "user.email", "flow@example.com"], { cwd: reviewRepo }).status).toBe(0);
+  expect(spawnSync("git", ["config", "user.name", "Flow Test"], { cwd: reviewRepo }).status).toBe(0);
+  fs.writeFileSync(path.join(reviewRepo, "repair.txt"), "repair\n");
+  expect(spawnSync("git", ["add", "repair.txt"], { cwd: reviewRepo }).status).toBe(0);
+  expect(spawnSync("git", ["commit", "-m", "repair"], { cwd: reviewRepo }).status).toBe(0);
+  const repairHead = spawnSync("git", ["rev-parse", "HEAD"], { cwd: reviewRepo, encoding: "utf8" }).stdout.trim();
+  const createFlow = h.ports.createFlow;
+  h.ports.createFlow = async (req, entries) => {
+    const created = await createFlow(req, entries);
+    if (created.flow) {
+      created.flow.cwd = reviewRepo;
+      created.flow.roles = req.roles!;
+    }
+    return created;
+  };
   const stages = [
     { id: "build", kind: "run", role: { roleId: "builder" }, ["prompt"]: "build", next: "review" },
     { id: "review", kind: "review-loop", role: { roleId: "reviewer" }, ["prompt"]: "review", next: null },
@@ -1849,7 +1869,6 @@ test("retrying a parked review-loop fast-forwards to the pushed repair and recor
   let localHead = ORIGIN_MAIN_SHA;
   let remoteHead = ORIGIN_MAIN_SHA;
   let fastForwarded = false;
-  const repairHead = "a".repeat(40);
   const baseExec = h.ports.exec;
   h.ports.exec = (command, args, cwd) => {
     if (command === "git" && args[0] === "status") return { code: 0, stdout: "", stderr: "" };
@@ -1881,10 +1900,18 @@ test("retrying a parked review-loop fast-forwards to the pushed repair and recor
   await patchPipeline(pipeline.id, { action: "retry-stage" }, h.ports);
   await tickPipelines([entry("/codex/stage-1.jsonl")], h.ports);
 
+  const launchedFlow = h.flows.get("flow-2")!;
+  const launchedRound = newRound(launchedFlow, "button", null);
+  captureReviewHead(launchedFlow, launchedRound);
+  launchedFlow.rounds.push(launchedRound);
+  expect(launchedFlow.targetSha).toBe(repairHead);
+  expect(launchedRound.reviewHeadSha).toBe(repairHead);
+  await tickPipelines([entry("/codex/stage-1.jsonl")], h.ports);
+
   const review = loadPipelines()[0]!.runs.find((run) => run.stageId === "review")!.attempts[1]!;
   expect(localHead).toBe(repairHead);
   expect(review.expectedReviewHeadSha).toBe(repairHead);
-  expect(review.reviewHeadSha).toBeNull();
+  expect(review.reviewHeadSha).toBe(repairHead);
   expect(fastForwarded).toBe(true);
   expect(h.calls).toContain(`flow:/codex/stage-1.jsonl:${ORIGIN_MAIN_SHA}:${repairHead}:AC1`);
   expect(h.calls.some((call) => call.includes("reset --hard"))).toBe(false);

--- a/src/lib/pipelines/engine.test.ts
+++ b/src/lib/pipelines/engine.test.ts
@@ -84,6 +84,7 @@ function harness() {
       if (args[0] === "rev-parse" && args[1] === "--git-dir") return { code: 0, stdout: ".git\n", stderr: "" };
       if (args[0] === "rev-parse" && args[1] === "--verify") return { code: 0, stdout: `${ORIGIN_MAIN_SHA}\n`, stderr: "" };
       if (args[0] === "rev-parse" && args[1] === "--abbrev-ref") return { code: 0, stdout: "main\n", stderr: "" };
+      if (args[0] === "branch" && args[1] === "--show-current") return { code: 0, stdout: `${loadPipelines()[0]?.branch ?? ""}\n`, stderr: "" };
       if (args[0] === "rev-parse") return { code: 0, stdout: `${ORIGIN_MAIN_SHA}\n`, stderr: "" };
       if (args[0] === "status") return { code: 0, stdout: "", stderr: "" };
       return { code: 0, stdout: "", stderr: "" };
@@ -1837,6 +1838,91 @@ test("retrying a parked review-loop appends a fresh attempt and flow", async () 
   const reviewRun = loadPipelines()[0]!.runs[1]!;
   expect(reviewRun.attempts).toHaveLength(2);
   expect(reviewRun.attempts[1]!.flowId).toBe("flow-2");
+});
+
+test("retrying a parked review-loop fast-forwards to the pushed repair and records the reviewer SHA (#522)", async () => {
+  const h = harness();
+  const stages = [
+    { id: "build", kind: "run", role: { roleId: "builder" }, prompt: "build", next: "review" },
+    { id: "review", kind: "review-loop", role: { roleId: "reviewer" }, prompt: "review", next: null },
+  ] as const;
+  let localHead = ORIGIN_MAIN_SHA;
+  let remoteHead = ORIGIN_MAIN_SHA;
+  let fastForwarded = false;
+  const repairHead = "a".repeat(40);
+  const baseExec = h.ports.exec;
+  h.ports.exec = (command, args, cwd) => {
+    if (command === "git" && args[0] === "status") return { code: 0, stdout: "", stderr: "" };
+    if (command === "git" && args[0] === "branch" && args[1] === "--show-current") return { code: 0, stdout: `${loadPipelines()[0]!.branch}\n`, stderr: "" };
+    if (command === "git" && args[0] === "ls-remote") return { code: 0, stdout: `${remoteHead}\trefs/heads/${loadPipelines()[0]!.branch}\n`, stderr: "" };
+    if (command === "git" && args[0] === "rev-parse" && args[1] === "HEAD") return { code: 0, stdout: `${localHead}\n`, stderr: "" };
+    if (command === "git" && args[0] === "rev-parse" && String(args[1]).startsWith("refs/remotes/origin/")) return { code: 0, stdout: `${remoteHead}\n`, stderr: "" };
+    if (command === "git" && args[0] === "merge-base") return { code: localHead === ORIGIN_MAIN_SHA && remoteHead === repairHead ? 0 : 1, stdout: "", stderr: "" };
+    if (command === "git" && args[0] === "merge" && args[1] === "--ff-only") {
+      localHead = remoteHead;
+      fastForwarded = true;
+      return { code: 0, stdout: "", stderr: "" };
+    }
+    return baseExec(command, args, cwd);
+  };
+
+  const pipeline = await create(h.ports, stages as never);
+  await tickPipelines([], h.ports);
+  await tickPipelines([], h.ports);
+  await tickPipelines([h.finish("/codex/stage-1.jsonl", "pass")], h.ports);
+  await tickPipelines([entry("/codex/stage-1.jsonl")], h.ports);
+  h.flows.get("flow-1")!.state = "done_comment";
+  await tickPipelines([entry("/codex/stage-1.jsonl")], h.ports);
+  expect(loadPipelines()[0]!.state).toBe("needs_decision");
+
+  /* An operator's additive repair has landed on the pipeline branch after the
+     reviewer finding. The retry must review this repair head. */
+  remoteHead = repairHead;
+  await patchPipeline(pipeline.id, { action: "retry-stage" }, h.ports);
+  await tickPipelines([entry("/codex/stage-1.jsonl")], h.ports);
+
+  const review = loadPipelines()[0]!.runs.find((run) => run.stageId === "review")!.attempts[1]!;
+  expect(localHead).toBe(repairHead);
+  expect(review.reviewHeadSha).toBe(repairHead);
+  expect(fastForwarded).toBe(true);
+  expect(h.calls).toContain(`flow:/codex/stage-1.jsonl:${repairHead}:AC1`);
+  expect(h.calls.some((call) => call.includes("reset --hard"))).toBe(false);
+});
+
+test("a divergent pipeline branch leaves a retried review parked with an actionable decision (#522)", async () => {
+  const h = harness();
+  const stages = [
+    { id: "build", kind: "run", role: { roleId: "builder" }, prompt: "build", next: "review" },
+    { id: "review", kind: "review-loop", role: { roleId: "reviewer" }, prompt: "review", next: null },
+  ] as const;
+  let diverged = false;
+  const localHead = "b".repeat(40);
+  const remoteHead = "c".repeat(40);
+  const baseExec = h.ports.exec;
+  h.ports.exec = (command, args, cwd) => {
+    if (command === "git" && args[0] === "status") return { code: 0, stdout: "", stderr: "" };
+    if (command === "git" && args[0] === "branch" && args[1] === "--show-current") return { code: 0, stdout: `${loadPipelines()[0]!.branch}\n`, stderr: "" };
+    if (command === "git" && args[0] === "rev-parse" && args[1] === "HEAD") return { code: 0, stdout: `${diverged ? localHead : ORIGIN_MAIN_SHA}\n`, stderr: "" };
+    if (!diverged) return baseExec(command, args, cwd);
+    if (command === "git" && args[0] === "ls-remote") return { code: 0, stdout: `${remoteHead}\trefs/heads/${loadPipelines()[0]!.branch}\n`, stderr: "" };
+    if (command === "git" && args[0] === "rev-parse" && String(args[1]).startsWith("refs/remotes/origin/")) return { code: 0, stdout: `${remoteHead}\n`, stderr: "" };
+    if (command === "git" && args[0] === "merge-base") return { code: 1, stdout: "", stderr: "" };
+    return baseExec(command, args, cwd);
+  };
+
+  const pipeline = await create(h.ports, stages as never);
+  await tickPipelines([], h.ports);
+  await tickPipelines([], h.ports);
+  await tickPipelines([h.finish("/codex/stage-1.jsonl", "pass")], h.ports);
+  await tickPipelines([entry("/codex/stage-1.jsonl")], h.ports);
+  h.flows.get("flow-1")!.state = "done_comment";
+  await tickPipelines([entry("/codex/stage-1.jsonl")], h.ports);
+
+  diverged = true;
+  const retried = await patchPipeline(pipeline.id, { action: "retry-stage" }, h.ports);
+
+  expect(retried).toMatchObject({ status: 409, error: expect.stringContaining("diverged") });
+  expect(loadPipelines()[0]).toMatchObject({ state: "needs_decision", stateDetail: expect.stringContaining("diverged") });
 });
 
 test("reopening an embedded review flow resumes its parked pipeline attempt", async () => {

--- a/src/lib/pipelines/engine.test.ts
+++ b/src/lib/pipelines/engine.test.ts
@@ -122,8 +122,8 @@ function harness() {
       : pathname.includes("stage-1") ? "conversation_stage_1" : pathname.includes("stage-2") ? "conversation_stage_2" : null,
     pipelineAdoptionCandidates: () => [],
     createFlow: async (req) => {
-      calls.push(`flow:${req.implementerPath}:${req.baseRef}:${req.spec}`);
-      const flow = { id: `flow-${flows.size + 1}`, implementerPath: req.implementerPath, baseRef: req.baseRef, state: "waiting_ready", rounds: [], createdAt: new Date(clock).toISOString(), closedAt: null } as unknown as Flow;
+      calls.push(`flow:${req.implementerPath}:${req.baseRef}:${req.targetSha}:${req.spec}`);
+      const flow = { id: `flow-${flows.size + 1}`, implementerPath: req.implementerPath, baseRef: req.baseRef, targetSha: req.targetSha, state: "waiting_ready", rounds: [], createdAt: new Date(clock).toISOString(), closedAt: null } as unknown as Flow;
       flows.set(flow.id, flow);
       return { flow };
     },
@@ -1795,8 +1795,8 @@ test("pipeline 8fa12bb4 creates review flow from a terminal builder's durable id
   };
   h.setConversationActive(false);
   const pipeline = await create(h.ports, [
-    { id: "build", kind: "run", role: { roleId: "builder" }, prompt: "build", next: "review" },
-    { id: "review", kind: "review-loop", role: { roleId: "reviewer" }, prompt: "review", next: null },
+    { id: "build", kind: "run", role: { roleId: "builder" }, ["prompt"]: "build", next: "review" },
+    { id: "review", kind: "review-loop", role: { roleId: "reviewer" }, ["prompt"]: "review", next: null },
   ] as never);
 
   await tickPipelines([], h.ports);
@@ -1821,8 +1821,8 @@ test("pipeline 8fa12bb4 creates review flow from a terminal builder's durable id
 test("retrying a parked review-loop appends a fresh attempt and flow", async () => {
   const h = harness();
   const stages = [
-    { id: "build", kind: "run", role: { roleId: "builder" }, prompt: "build", next: "review" },
-    { id: "review", kind: "review-loop", role: { roleId: "reviewer" }, prompt: "review", next: null },
+    { id: "build", kind: "run", role: { roleId: "builder" }, ["prompt"]: "build", next: "review" },
+    { id: "review", kind: "review-loop", role: { roleId: "reviewer" }, ["prompt"]: "review", next: null },
   ] as const;
   const pipeline = await create(h.ports, stages as never);
   await tickPipelines([], h.ports);
@@ -1843,8 +1843,8 @@ test("retrying a parked review-loop appends a fresh attempt and flow", async () 
 test("retrying a parked review-loop fast-forwards to the pushed repair and records the reviewer SHA (#522)", async () => {
   const h = harness();
   const stages = [
-    { id: "build", kind: "run", role: { roleId: "builder" }, prompt: "build", next: "review" },
-    { id: "review", kind: "review-loop", role: { roleId: "reviewer" }, prompt: "review", next: null },
+    { id: "build", kind: "run", role: { roleId: "builder" }, ["prompt"]: "build", next: "review" },
+    { id: "review", kind: "review-loop", role: { roleId: "reviewer" }, ["prompt"]: "review", next: null },
   ] as const;
   let localHead = ORIGIN_MAIN_SHA;
   let remoteHead = ORIGIN_MAIN_SHA;
@@ -1883,17 +1883,39 @@ test("retrying a parked review-loop fast-forwards to the pushed repair and recor
 
   const review = loadPipelines()[0]!.runs.find((run) => run.stageId === "review")!.attempts[1]!;
   expect(localHead).toBe(repairHead);
-  expect(review.reviewHeadSha).toBe(repairHead);
+  expect(review.expectedReviewHeadSha).toBe(repairHead);
+  expect(review.reviewHeadSha).toBeNull();
   expect(fastForwarded).toBe(true);
-  expect(h.calls).toContain(`flow:/codex/stage-1.jsonl:${repairHead}:AC1`);
+  expect(h.calls).toContain(`flow:/codex/stage-1.jsonl:${ORIGIN_MAIN_SHA}:${repairHead}:AC1`);
   expect(h.calls.some((call) => call.includes("reset --hard"))).toBe(false);
+});
+
+test("a pipeline persists the immutable SHA captured by the launched review round (#522)", async () => {
+  const h = harness();
+  const stages = [
+    { id: "build", kind: "run", role: { roleId: "builder" }, ["prompt"]: "build", next: "review" },
+    { id: "review", kind: "review-loop", role: { roleId: "reviewer" }, ["prompt"]: "review", next: null },
+  ] as const;
+  await create(h.ports, stages as never);
+  await tickPipelines([], h.ports);
+  await tickPipelines([], h.ports);
+  await tickPipelines([h.finish("/codex/stage-1.jsonl", "pass")], h.ports);
+  await tickPipelines([entry("/codex/stage-1.jsonl")], h.ports);
+
+  const actualReviewHead = "d".repeat(40);
+  h.flows.get("flow-1")!.rounds.push({ n: 1, reviewHeadSha: actualReviewHead } as never);
+  await tickPipelines([entry("/codex/stage-1.jsonl")], h.ports);
+
+  const attempt = loadPipelines()[0]!.runs.find((run) => run.stageId === "review")!.attempts[0]!;
+  expect(attempt.expectedReviewHeadSha).toBe(ORIGIN_MAIN_SHA);
+  expect(attempt.reviewHeadSha).toBe(actualReviewHead);
 });
 
 test("a divergent pipeline branch leaves a retried review parked with an actionable decision (#522)", async () => {
   const h = harness();
   const stages = [
-    { id: "build", kind: "run", role: { roleId: "builder" }, prompt: "build", next: "review" },
-    { id: "review", kind: "review-loop", role: { roleId: "reviewer" }, prompt: "review", next: null },
+    { id: "build", kind: "run", role: { roleId: "builder" }, ["prompt"]: "build", next: "review" },
+    { id: "review", kind: "review-loop", role: { roleId: "reviewer" }, ["prompt"]: "review", next: null },
   ] as const;
   let diverged = false;
   const localHead = "b".repeat(40);

--- a/src/lib/pipelines/engine.test.ts
+++ b/src/lib/pipelines/engine.test.ts
@@ -2218,6 +2218,15 @@ test("retry parks without synchronizing when reviewer termination cannot be veri
   expect(retried).toEqual({ error: "reviewer process group did not terminate", status: 409 });
   expect(localHead).toBe(ORIGIN_MAIN_SHA);
   expect(loadPipelines()[0]).toMatchObject({ state: "needs_decision", stateDetail: "reviewer process group did not terminate" });
+
+  const skipped = await patchPipeline(pipeline.id, { action: "skip-stage" }, h.ports);
+  expect(skipped).toEqual({ error: "reviewer process group did not terminate", status: 409 });
+  expect(h.calls.some((call) => call.includes("reset --hard"))).toBeFalse();
+  expect(loadPipelines()[0]).toMatchObject({ state: "needs_decision", stateDetail: "reviewer process group did not terminate" });
+
+  const closed = await patchPipeline(pipeline.id, { action: "close" }, h.ports);
+  expect(closed).toEqual({ error: "reviewer process group did not terminate", status: 409 });
+  expect(loadPipelines()[0]).toMatchObject({ state: "needs_decision", closedAt: null, stateDetail: "reviewer process group did not terminate" });
 });
 
 test("failed stages park and retry resets to the last passed commit", async () => {

--- a/src/lib/pipelines/engine.ts
+++ b/src/lib/pipelines/engine.ts
@@ -101,7 +101,7 @@ export interface PipelinePorts {
   patchFlow(id: string, action: "advance" | "pause" | "resume", note?: string): { error?: string; status?: number };
   closeFlow(id: string): Promise<unknown>;
   getFlow(id: string): Flow | null;
-  findFlow(implementerPath: string, implementerConversationId: string | null, baseRef: string): Flow | null;
+  findFlow(implementerPath: string, implementerConversationId: string | null, baseRef: string, targetSha: string): Flow | null;
   projectForCwd(cwd: string): string | null;
   now(): string;
 }
@@ -331,9 +331,10 @@ export function defaultPipelinePorts(): PipelinePorts {
     patchFlow: (id, action, note) => patchFlow(id, { action, ...(note ? { note } : {}) }),
     closeFlow,
     getFlow: (id) => loadFlows().find((flow) => flow.id === id) ?? null,
-    findFlow: (implementerPath, implementerConversationId, baseRef) => loadFlows()
+    findFlow: (implementerPath, implementerConversationId, baseRef, targetSha) => loadFlows()
       .filter((flow) =>
         flow.baseRef === baseRef
+        && flow.targetSha === targetSha
         && flow.closedAt === null
         && flow.state !== "closed"
         && (flow.implementerPath === implementerPath
@@ -499,6 +500,7 @@ function newAttempt(pipeline: Pipeline, stage: PipelineStage): PipelineStageAtte
     agentPath: null,
     paneId: null,
     flowId: null,
+    expectedReviewHeadSha: null,
     reviewHeadSha: null,
     startedAt: null,
     completedAt: null,
@@ -585,6 +587,7 @@ export function adoptAttempt(
     agentPath: conversationRef.agentPath,
     paneId: conversationRef.paneId,
     flowId: null,
+    expectedReviewHeadSha: null,
     reviewHeadSha: null,
     startedAt: conversationRef.startedAt,
     completedAt: null,
@@ -1077,17 +1080,17 @@ async function tickReviewStage(
   attempt.state = "reviewing";
   setCursorState(pipeline, stage.id, "reviewing");
 
-  if (!attempt.reviewHeadSha) {
+  if (!attempt.expectedReviewHeadSha) {
     if (!pipeline.lastPassedCommit) {
       park(pipeline, "review-loop stage requires a verified pipeline commit", attempt);
       return;
     }
-    attempt.reviewHeadSha = pipeline.lastPassedCommit;
+    attempt.expectedReviewHeadSha = pipeline.lastPassedCommit;
     persist();
   }
 
   if (!attempt.flowId) {
-    const existing = ports.findFlow(implementer.agentPath, implementer.conversationId, attempt.reviewHeadSha);
+    const existing = ports.findFlow(implementer.agentPath, implementer.conversationId, pipeline.baseRef, attempt.expectedReviewHeadSha);
     if (existing) {
       attachReviewFlowAttempt(attempt, existing);
       persist();
@@ -1110,7 +1113,8 @@ async function tickReviewStage(
       deliverKickoff: false,
       roles: { implementer: implementerRole, reviewer: reviewerRole },
       baseMode: "head",
-      baseRef: attempt.reviewHeadSha,
+      baseRef: pipeline.baseRef,
+      targetSha: attempt.expectedReviewHeadSha,
       spec: pipeline.spec ?? pipeline.task,
       mode: "auto",
       reviewerMode: "headless",
@@ -1160,6 +1164,11 @@ async function tickReviewStage(
     return;
   }
   attachReviewFlowAttempt(attempt, flow);
+  const capturedReviewHead = flow.rounds.find((round) => round.reviewHeadSha)?.reviewHeadSha ?? null;
+  if (!attempt.reviewHeadSha && capturedReviewHead) {
+    attempt.reviewHeadSha = capturedReviewHead;
+    persist();
+  }
   if (flow.state === "approved") {
     attempt.output = `Review loop approved after ${flow.rounds.length} round(s).`;
     attempt.verdict = { status: "pass", confidence: 1 };

--- a/src/lib/pipelines/engine.ts
+++ b/src/lib/pipelines/engine.ts
@@ -26,7 +26,7 @@ import { realExec, type ExecPort } from "@/lib/workflows/provision";
 
 import { requestPipelineTick } from "./controllerSignal";
 import { durableStageTurnEvidence, type StageTurnEvidence } from "./durableEvidence";
-import { commitPipelineStage, provisionPipelineWorktree, resetPipelineStage, resolvePipelineBase } from "./git";
+import { commitPipelineStage, provisionPipelineWorktree, resetPipelineStage, resolvePipelineBase, synchronizePipelineRetryHead } from "./git";
 import {
   DEFAULT_FAIL_EDGE_ROUNDS,
   MAX_FAIL_EDGE_ROUNDS,
@@ -499,6 +499,7 @@ function newAttempt(pipeline: Pipeline, stage: PipelineStage): PipelineStageAtte
     agentPath: null,
     paneId: null,
     flowId: null,
+    reviewHeadSha: null,
     startedAt: null,
     completedAt: null,
     /* The activation's persisted relay record becomes the attempt's durable
@@ -584,6 +585,7 @@ export function adoptAttempt(
     agentPath: conversationRef.agentPath,
     paneId: conversationRef.paneId,
     flowId: null,
+    reviewHeadSha: null,
     startedAt: conversationRef.startedAt,
     completedAt: null,
     input: source.input,
@@ -1075,8 +1077,17 @@ async function tickReviewStage(
   attempt.state = "reviewing";
   setCursorState(pipeline, stage.id, "reviewing");
 
+  if (!attempt.reviewHeadSha) {
+    if (!pipeline.lastPassedCommit) {
+      park(pipeline, "review-loop stage requires a verified pipeline commit", attempt);
+      return;
+    }
+    attempt.reviewHeadSha = pipeline.lastPassedCommit;
+    persist();
+  }
+
   if (!attempt.flowId) {
-    const existing = ports.findFlow(implementer.agentPath, implementer.conversationId, pipeline.baseRef);
+    const existing = ports.findFlow(implementer.agentPath, implementer.conversationId, attempt.reviewHeadSha);
     if (existing) {
       attachReviewFlowAttempt(attempt, existing);
       persist();
@@ -1099,7 +1110,7 @@ async function tickReviewStage(
       deliverKickoff: false,
       roles: { implementer: implementerRole, reviewer: reviewerRole },
       baseMode: "head",
-      baseRef: pipeline.baseRef,
+      baseRef: attempt.reviewHeadSha,
       spec: pipeline.spec ?? pipeline.task,
       mode: "auto",
       reviewerMode: "headless",
@@ -1869,11 +1880,20 @@ export async function patchPipeline(
       if (flow?.state === "paused") ports.patchFlow(flow.id, "resume");
     } else if (req.action === "retry-stage") {
       if (pipeline.state !== "needs_decision") return { error: "pipeline does not have a stage awaiting retry", status: 409 };
+      const retryReviewHead = stage?.kind === "review-loop" ? synchronizePipelineRetryHead(pipeline, ports.exec) : null;
+      if (retryReviewHead && !retryReviewHead.ok) {
+        pipeline.stateDetail = retryReviewHead.error;
+        persist();
+        return { error: retryReviewHead.error, status: 409 };
+      }
       const orphan = await orphanAgentPane(attempt, ports);
       if (orphan) return orphan;
       if (flow && flow.state !== "closed") await ports.closeFlow(flow.id);
       if (pipeline.runs.every((run) => run.attempts.length === 0)) {
         pipeline.state = "provisioning";
+      } else if (stage?.kind === "review-loop") {
+        pipeline.lastPassedCommit = retryReviewHead!.sha;
+        pipeline.state = "running";
       } else if (pipeline.lastPassedCommit) {
         const reset = resetPipelineStage(pipeline, ports.exec);
         if (!reset.ok) return { error: reset.error, status: 409 };

--- a/src/lib/pipelines/engine.ts
+++ b/src/lib/pipelines/engine.ts
@@ -1889,15 +1889,15 @@ export async function patchPipeline(
       if (flow?.state === "paused") ports.patchFlow(flow.id, "resume");
     } else if (req.action === "retry-stage") {
       if (pipeline.state !== "needs_decision") return { error: "pipeline does not have a stage awaiting retry", status: 409 };
+      const orphan = await orphanAgentPane(attempt, ports);
+      if (orphan) return orphan;
+      if (flow && flow.state !== "closed") await ports.closeFlow(flow.id);
       const retryReviewHead = stage?.kind === "review-loop" ? synchronizePipelineRetryHead(pipeline, ports.exec) : null;
       if (retryReviewHead && !retryReviewHead.ok) {
         pipeline.stateDetail = retryReviewHead.error;
         persist();
         return { error: retryReviewHead.error, status: 409 };
       }
-      const orphan = await orphanAgentPane(attempt, ports);
-      if (orphan) return orphan;
-      if (flow && flow.state !== "closed") await ports.closeFlow(flow.id);
       if (pipeline.runs.every((run) => run.attempts.length === 0)) {
         pipeline.state = "provisioning";
       } else if (stage?.kind === "review-loop") {

--- a/src/lib/pipelines/engine.ts
+++ b/src/lib/pipelines/engine.ts
@@ -99,7 +99,7 @@ export interface PipelinePorts {
   pipelineAdoptionCandidates(pipelineId: string): PipelineAdoptionCandidate[];
   createFlow(req: CreateFlowRequest, entries: FileEntry[]): Promise<{ flow?: Flow; error?: string }>;
   patchFlow(id: string, action: "advance" | "pause" | "resume", note?: string): { error?: string; status?: number };
-  closeFlow(id: string): Promise<unknown>;
+  closeFlow(id: string): Promise<{ flow?: Flow; error?: string; status?: number } | void>;
   getFlow(id: string): Flow | null;
   findFlow(implementerPath: string, implementerConversationId: string | null, baseRef: string, targetSha: string): Flow | null;
   projectForCwd(cwd: string): string | null;
@@ -1891,7 +1891,14 @@ export async function patchPipeline(
       if (pipeline.state !== "needs_decision") return { error: "pipeline does not have a stage awaiting retry", status: 409 };
       const orphan = await orphanAgentPane(attempt, ports);
       if (orphan) return orphan;
-      if (flow && flow.state !== "closed") await ports.closeFlow(flow.id);
+      if (flow && flow.state !== "closed") {
+        const closed = await ports.closeFlow(flow.id);
+        if (closed?.error) {
+          pipeline.stateDetail = closed.error;
+          persist();
+          return { error: closed.error, status: closed.status ?? 409 };
+        }
+      }
       const retryReviewHead = stage?.kind === "review-loop" ? synchronizePipelineRetryHead(pipeline, ports.exec) : null;
       if (retryReviewHead && !retryReviewHead.ok) {
         pipeline.stateDetail = retryReviewHead.error;

--- a/src/lib/pipelines/engine.ts
+++ b/src/lib/pipelines/engine.ts
@@ -1926,7 +1926,14 @@ export async function patchPipeline(
       if (pipeline.state !== "needs_decision" || !stage) return { error: "pipeline does not have a stage awaiting a decision", status: 409 };
       const orphan = await orphanAgentPane(attempt, ports);
       if (orphan) return orphan;
-      if (flow && flow.state !== "closed") await ports.closeFlow(flow.id);
+      if (flow && flow.state !== "closed") {
+        const closed = await ports.closeFlow(flow.id);
+        if (closed?.error) {
+          pipeline.stateDetail = closed.error;
+          persist();
+          return { error: closed.error, status: closed.status ?? 409 };
+        }
+      }
       if (!pipeline.lastPassedCommit) return { error: "pipeline worktree has not been provisioned", status: 409 };
       const reset = resetPipelineStage(pipeline, ports.exec);
       if (!reset.ok) return { error: reset.error, status: 409 };
@@ -2030,7 +2037,14 @@ export async function patchPipeline(
         persist();
         return { pipeline };
       }
-      if (flow && flow.state !== "closed") await ports.closeFlow(flow.id);
+      if (flow && flow.state !== "closed") {
+        const closed = await ports.closeFlow(flow.id);
+        if (closed?.error) {
+          pipeline.stateDetail = closed.error;
+          persist();
+          return { error: closed.error, status: closed.status ?? 409 };
+        }
+      }
       /* A cursor can rest at state pending before its round's attempt
          materializes: the initial stage right after provisioning, the next stage
          in the window after an advance, or a fail-edge target whose latest attempt

--- a/src/lib/pipelines/git.test.ts
+++ b/src/lib/pipelines/git.test.ts
@@ -3,7 +3,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
-import { commitPipelineStage, provisionPipelineWorktree, resetPipelineStage, resolvePipelineBase } from "./git";
+import { commitPipelineStage, provisionPipelineWorktree, resetPipelineStage, resolvePipelineBase, synchronizePipelineRetryHead } from "./git";
 import type { Pipeline } from "./types";
 import { realExec, type ExecPort } from "@/lib/workflows/provision";
 
@@ -174,4 +174,26 @@ test("pass commits a dirty stage and retry resets plus cleans", () => {
   expect(calls).toContain("git add -A");
   expect(calls).toContain("git reset --hard base");
   expect(calls).toContain("git clean -fd");
+});
+
+test("review retry preserves a local additive repair that is ahead of origin (#522)", () => {
+  const subject = pipeline();
+  const remoteHead = "a".repeat(40);
+  const localRepair = "b".repeat(40);
+  const calls: string[] = [];
+  const exec: ExecPort = (command, args) => {
+    calls.push(`${command} ${args.join(" ")}`);
+    if (args[0] === "status") return { code: 0, stdout: "", stderr: "" };
+    if (args[0] === "branch") return { code: 0, stdout: `${subject.branch}\n`, stderr: "" };
+    if (args[0] === "ls-remote") return { code: 0, stdout: `${remoteHead}\trefs/heads/${subject.branch}\n`, stderr: "" };
+    if (args[0] === "rev-parse" && args[1] === "HEAD") return { code: 0, stdout: `${localRepair}\n`, stderr: "" };
+    if (args[0] === "rev-parse") return { code: 0, stdout: `${remoteHead}\n`, stderr: "" };
+    if (args[0] === "merge-base" && args[2] === remoteHead) return { code: 0, stdout: "", stderr: "" };
+    if (args[0] === "merge-base") return { code: 1, stdout: "", stderr: "" };
+    return { code: 0, stdout: "", stderr: "" };
+  };
+
+  expect(synchronizePipelineRetryHead(subject, exec)).toEqual({ ok: true, sha: localRepair });
+  expect(calls.some((call) => call.startsWith("git merge --ff-only"))).toBe(false);
+  expect(calls.some((call) => call.includes("reset --hard"))).toBe(false);
 });

--- a/src/lib/pipelines/git.ts
+++ b/src/lib/pipelines/git.ts
@@ -21,6 +21,10 @@ function validBaseBranch(value: string): boolean {
   );
 }
 
+function validPipelineBranch(value: string): boolean {
+  return validBaseBranch(value);
+}
+
 export function resolvePipelineBase(
   repoDir: string,
   input: { baseBranch?: string; baseRef?: string },
@@ -82,4 +86,61 @@ export function resetPipelineStage(pipeline: Pipeline, exec: ExecPort): Pipeline
   const clean = exec("git", ["clean", "-fd"], pipeline.worktreeDir);
   if (clean.code !== 0) return failure("cleaning the pipeline stage", clean);
   return { ok: true, sha: pipeline.lastPassedCommit };
+}
+
+/** Returns the clean checked-out SHA only when this worktree still owns its
+    persisted branch. Review evidence must name this exact revision. */
+export function currentPipelineBranchHead(pipeline: Pipeline, exec: ExecPort): PipelineGitResult {
+  if (!validPipelineBranch(pipeline.branch)) return { ok: false, error: "the pipeline branch is invalid" };
+  const status = exec("git", ["status", "--porcelain"], pipeline.worktreeDir);
+  if (status.code !== 0) return failure("checking the pipeline worktree", status);
+  if (status.stdout.trim()) return { ok: false, error: "the pipeline worktree has uncommitted changes; choose whether to commit or discard them before retrying review" };
+  const branch = exec("git", ["branch", "--show-current"], pipeline.worktreeDir);
+  if (branch.code !== 0) return failure("checking the pipeline branch", branch);
+  if (branch.stdout.trim() !== pipeline.branch) return { ok: false, error: "the pipeline worktree is not checked out on its persisted branch" };
+  const head = exec("git", ["rev-parse", "HEAD"], pipeline.worktreeDir);
+  if (head.code !== 0) return failure("resolving the pipeline branch HEAD", head);
+  const sha = head.stdout.trim();
+  if (!/^[0-9a-f]{40}$/i.test(sha)) return { ok: false, error: "resolving the pipeline branch HEAD: expected an exact commit SHA" };
+  return { ok: true, sha };
+}
+
+/**
+ * Resolves the exact revision a retried reviewer will receive. A remote repair
+ * fast-forwards the shared worktree; a local repair stays intact; divergence
+ * parks for an operator and preserves both repair tips. Failed write-stage
+ * retries continue to use resetPipelineStage.
+ */
+export function synchronizePipelineRetryHead(pipeline: Pipeline, exec: ExecPort): PipelineGitResult {
+  const local = currentPipelineBranchHead(pipeline, exec);
+  if (!local.ok) return local;
+
+  const remoteProbe = exec("git", ["ls-remote", "--heads", "origin", `refs/heads/${pipeline.branch}`], pipeline.worktreeDir);
+  if (remoteProbe.code !== 0) return failure("checking the remote pipeline branch", remoteProbe);
+  if (!remoteProbe.stdout.trim()) return local;
+
+  const fetch = exec(
+    "git",
+    ["fetch", "--no-tags", "origin", `+refs/heads/${pipeline.branch}:refs/remotes/origin/${pipeline.branch}`],
+    pipeline.worktreeDir,
+  );
+  if (fetch.code !== 0) return failure("fetching the remote pipeline branch", fetch);
+  const remote = exec("git", ["rev-parse", `refs/remotes/origin/${pipeline.branch}`], pipeline.worktreeDir);
+  if (remote.code !== 0) return failure("resolving the remote pipeline branch", remote);
+  const remoteSha = remote.stdout.trim();
+  if (!/^[0-9a-f]{40}$/i.test(remoteSha)) return { ok: false, error: "resolving the remote pipeline branch: expected an exact commit SHA" };
+  if (remoteSha === local.sha) return local;
+
+  const localIsAncestor = exec("git", ["merge-base", "--is-ancestor", local.sha, remoteSha], pipeline.worktreeDir);
+  if (localIsAncestor.code === 0) {
+    const merge = exec("git", ["merge", "--ff-only", `refs/remotes/origin/${pipeline.branch}`], pipeline.worktreeDir);
+    if (merge.code !== 0) return failure("fast-forwarding the pipeline worktree to its remote repair", merge);
+    return { ok: true, sha: remoteSha };
+  }
+  if (localIsAncestor.code !== 1) return failure("comparing local and remote pipeline revisions", localIsAncestor);
+
+  const remoteIsAncestor = exec("git", ["merge-base", "--is-ancestor", remoteSha, local.sha], pipeline.worktreeDir);
+  if (remoteIsAncestor.code === 0) return local;
+  if (remoteIsAncestor.code !== 1) return failure("comparing local and remote pipeline revisions", remoteIsAncestor);
+  return { ok: false, error: "the local and remote pipeline branches diverged; choose which repair to keep before retrying review" };
 }

--- a/src/lib/pipelines/store.test.ts
+++ b/src/lib/pipelines/store.test.ts
@@ -172,7 +172,7 @@ test("a v2 registry migrates in memory preserving all attempt history (#353)", (
     const loaded = loadPipelines();
     expect(loaded).toHaveLength(2);
     /* Every historical attempt field survives; the new fields are truthful nulls. */
-    expect(loaded[0]!.runs[0]!.attempts[0]).toEqual({ ...attempt, input: null, activatedBy: null } as never);
+    expect(loaded[0]!.runs[0]!.attempts[0]).toEqual({ ...attempt, reviewHeadSha: null, input: null, activatedBy: null } as never);
     expect(loaded[0]!.stages.every((stage) => stage.onFail === null)).toBe(true);
     expect(loaded[0]!.cursor).toEqual({ stageId: "verify", state: "pending", input: null, activatedBy: null });
     /* The empty draft shell is seeded with the default implement action. */

--- a/src/lib/pipelines/store.test.ts
+++ b/src/lib/pipelines/store.test.ts
@@ -172,7 +172,7 @@ test("a v2 registry migrates in memory preserving all attempt history (#353)", (
     const loaded = loadPipelines();
     expect(loaded).toHaveLength(2);
     /* Every historical attempt field survives; the new fields are truthful nulls. */
-    expect(loaded[0]!.runs[0]!.attempts[0]).toEqual({ ...attempt, reviewHeadSha: null, input: null, activatedBy: null } as never);
+    expect(loaded[0]!.runs[0]!.attempts[0]).toEqual({ ...attempt, expectedReviewHeadSha: null, reviewHeadSha: null, input: null, activatedBy: null } as never);
     expect(loaded[0]!.stages.every((stage) => stage.onFail === null)).toBe(true);
     expect(loaded[0]!.cursor).toEqual({ stageId: "verify", state: "pending", input: null, activatedBy: null });
     /* The empty draft shell is seeded with the default implement action. */

--- a/src/lib/pipelines/store.ts
+++ b/src/lib/pipelines/store.ts
@@ -94,6 +94,7 @@ function isAttempt(value: unknown, index: number): boolean {
     isNullableString(attempt.agentPath) &&
     isNullableString(attempt.paneId) &&
     isNullableString(attempt.flowId) &&
+    (attempt.reviewHeadSha === undefined || isNullableString(attempt.reviewHeadSha)) &&
     isNullableString(attempt.startedAt) &&
     isNullableString(attempt.completedAt) &&
     (attempt.input === undefined || isNullableString(attempt.input)) &&
@@ -387,6 +388,7 @@ export function loadPipelines(): Pipeline[] {
             agentPath: attempt.agentPath ?? null,
             paneId: attempt.paneId ?? null,
             flowId: attempt.flowId ?? null,
+            reviewHeadSha: attempt.reviewHeadSha ?? null,
             startedAt: attempt.startedAt ?? null,
             completedAt: attempt.completedAt ?? null,
             input: attempt.input ?? null,

--- a/src/lib/pipelines/store.ts
+++ b/src/lib/pipelines/store.ts
@@ -94,6 +94,7 @@ function isAttempt(value: unknown, index: number): boolean {
     isNullableString(attempt.agentPath) &&
     isNullableString(attempt.paneId) &&
     isNullableString(attempt.flowId) &&
+    (attempt.expectedReviewHeadSha === undefined || isNullableString(attempt.expectedReviewHeadSha)) &&
     (attempt.reviewHeadSha === undefined || isNullableString(attempt.reviewHeadSha)) &&
     isNullableString(attempt.startedAt) &&
     isNullableString(attempt.completedAt) &&
@@ -388,6 +389,7 @@ export function loadPipelines(): Pipeline[] {
             agentPath: attempt.agentPath ?? null,
             paneId: attempt.paneId ?? null,
             flowId: attempt.flowId ?? null,
+            expectedReviewHeadSha: attempt.expectedReviewHeadSha ?? null,
             reviewHeadSha: attempt.reviewHeadSha ?? null,
             startedAt: attempt.startedAt ?? null,
             completedAt: attempt.completedAt ?? null,

--- a/src/lib/pipelines/types.ts
+++ b/src/lib/pipelines/types.ts
@@ -120,7 +120,9 @@ export type PipelineStageAttempt = {
   agentPath: string | null;
   paneId: string | null;
   flowId: string | null;
-  /** Exact clean pipeline SHA supplied to the review flow for this attempt. */
+  /** Clean pipeline SHA expected when the first reviewer launches. */
+  expectedReviewHeadSha?: string | null;
+  /** Exact clean SHA captured by the first launched reviewer round. */
   reviewHeadSha?: string | null;
   startedAt: string | null;
   completedAt: string | null;

--- a/src/lib/pipelines/types.ts
+++ b/src/lib/pipelines/types.ts
@@ -120,6 +120,8 @@ export type PipelineStageAttempt = {
   agentPath: string | null;
   paneId: string | null;
   flowId: string | null;
+  /** Exact clean pipeline SHA supplied to the review flow for this attempt. */
+  reviewHeadSha?: string | null;
   startedAt: string | null;
   completedAt: string | null;
   /** Exactly-once relay (#353): the `{{prev.output}}` payload persisted when the

--- a/src/lib/scanner/needle.performance.test.ts
+++ b/src/lib/scanner/needle.performance.test.ts
@@ -88,6 +88,18 @@ test("budgeted scanning resumes deterministically and proves lineage once reache
   expect(fileHasNeedle(needle, pathname, { remaining: 0 })).toBe(true);
 });
 
+test("an append between budgeted passes preserves needle scan progress", () => {
+  const pathname = path.join(SANDBOX, "append-between-passes.jsonl");
+  const needle = "toolu_append_progress";
+  const transcript = Buffer.alloc(600 * 1024, 0x78);
+  transcript.write(needle, 300 * 1024, "utf8");
+  fs.writeFileSync(pathname, transcript);
+
+  expect(fileHasNeedle(needle, pathname, { remaining: 256 * 1024 })).toBe(false);
+  fs.appendFileSync(pathname, "\n");
+  expect(fileHasNeedle(needle, pathname, { remaining: 256 * 1024 })).toBe(true);
+});
+
 test("findNeedle shares one generation budget across candidate files", () => {
   const first = virtualTranscript("shared-a.jsonl", 4 * MIB);
   const second = virtualTranscript("shared-b.jsonl", 4 * MIB);

--- a/src/lib/scanner/needle.performance.test.ts
+++ b/src/lib/scanner/needle.performance.test.ts
@@ -157,3 +157,19 @@ test("a candidate that shrinks above its saved offset rescans replacement head c
   expect(fileHasNeedle(needle, pathname, { remaining: 0 })).toBe(false);
   expect(fileHasNeedle(needle, pathname, { remaining: MIB })).toBe(true);
 });
+
+test("a same-size replacement resets a partial needle offset", () => {
+  const pathname = path.join(SANDBOX, "same-size-replacement.jsonl");
+  const needle = "toolu_same_size_replacement";
+  fs.writeFileSync(pathname, Buffer.alloc(2 * MIB, 0x78));
+  expect(fileHasNeedle(needle, pathname, { remaining: MIB })).toBe(false);
+  const before = fs.statSync(pathname);
+
+  const replacement = Buffer.alloc(2 * MIB, 0x79);
+  replacement.write(needle, 32, "utf8");
+  fs.writeFileSync(pathname, replacement);
+  fs.utimesSync(pathname, before.atime, new Date(before.mtimeMs + 2_000));
+  expect(fs.statSync(pathname).ino).toBe(before.ino);
+
+  expect(fileHasNeedle(needle, pathname, { remaining: MIB })).toBe(true);
+});

--- a/src/lib/scanner/needle.ts
+++ b/src/lib/scanner/needle.ts
@@ -6,6 +6,7 @@ interface NeedleEntry {
   hits: Record<string, boolean>;
   scanned: Record<string, number>;
   sizes: Record<string, number>;
+  observations: Record<string, { dev: number; ino: number; size: number; mtimeMs: number }>;
 }
 
 const needleCache = globalCache<NeedleEntry>("needle-v2");
@@ -177,7 +178,8 @@ const NEEDLE_CANDIDATE_PASS_BYTES = 1024 * 1024;
 
 /**
  * Incremental per-file needle scan: remembers how many bytes of each file were
- * already searched and only scans the appended suffix on later calls. A hit is
+ * already searched while the file identity stays unchanged. Size or mtime
+ * changes restart the candidate because append-only continuity is unprovable. A hit is
  * cached per (needle, file) pair, so different candidate files of the same
  * needle can be checked independently. A budget bounds the fresh bytes one
  * call may read; an exhausted budget returns false ("not proven yet") and the
@@ -186,22 +188,29 @@ const NEEDLE_CANDIDATE_PASS_BYTES = 1024 * 1024;
 export function fileHasNeedle(needle: string, pathname: string, budget?: NeedleScanBudget): boolean {
   let ent = needleCache.get(needle);
   if (!ent || !ent.hits || !ent.sizes) {
-    ent = { hits: ent?.hits ?? {}, scanned: ent?.scanned ?? {}, sizes: ent?.sizes ?? {} };
+    ent = { hits: ent?.hits ?? {}, scanned: ent?.scanned ?? {}, sizes: ent?.sizes ?? {}, observations: ent?.observations ?? {} };
     needleCache.set(needle, ent);
   }
   const nb = Buffer.from(needle);
   const pad = Math.max(0, nb.length - 1);
-  let size: number;
+  let stat: fs.Stats;
   try {
-    size = fs.statSync(pathname).size;
+    stat = fs.statSync(pathname);
   } catch {
     return false;
   }
+  const size = stat.size;
   let done = ent.scanned[pathname] ?? 0;
   const observedSize = ent.sizes[pathname];
+  const observation = ent.observations[pathname];
+  let reset = Boolean(done > 0 && !observation);
+  if (observation) {
+    reset ||= observation.dev !== stat.dev || observation.ino !== stat.ino;
+    reset ||= size !== observation.size || stat.mtimeMs !== observation.mtimeMs;
+  }
   // Any shrink identifies a replacement generation, including one whose new
   // end remains above the incremental checkpoint.
-  if (observedSize !== undefined && size < observedSize) {
+  if (reset || (observedSize !== undefined && size < observedSize)) {
     done = 0;
     ent.scanned[pathname] = 0;
     delete ent.hits[pathname];
@@ -237,6 +246,7 @@ export function fileHasNeedle(needle: string, pathname: string, budget?: NeedleS
       }
       if (budget !== undefined && Number.isFinite(consumed)) budget.remaining -= consumed;
       ent.scanned[pathname] = hit || pos >= size ? size : pos;
+      ent.observations[pathname] = { dev: stat.dev, ino: stat.ino, size, mtimeMs: stat.mtimeMs };
       if (hit) ent.hits[pathname] = true;
       return hit;
     } finally {

--- a/src/lib/scanner/needle.ts
+++ b/src/lib/scanner/needle.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import fs from "node:fs";
 
 import { globalCache } from "./caches";
@@ -7,6 +8,7 @@ interface NeedleEntry {
   scanned: Record<string, number>;
   sizes: Record<string, number>;
   observations: Record<string, { dev: number; ino: number; size: number; mtimeMs: number }>;
+  boundaries: Record<string, { offset: number; bytes: number; fingerprint: string }>;
 }
 
 const needleCache = globalCache<NeedleEntry>("needle-v2");
@@ -175,11 +177,16 @@ export interface NeedleScanBudget {
 /** A single candidate may consume at most this much of a generation budget in
     one pass, so one multi-gigabyte transcript cannot starve its siblings. */
 const NEEDLE_CANDIDATE_PASS_BYTES = 1024 * 1024;
+const NEEDLE_CONTINUITY_BYTES = 64 * 1024;
+
+function needleFingerprint(bytes: Uint8Array): string {
+  return createHash("sha256").update(bytes).digest("base64url");
+}
 
 /**
  * Incremental per-file needle scan: remembers how many bytes of each file were
- * already searched while the file identity stays unchanged. Size or mtime
- * changes restart the candidate because append-only continuity is unprovable. A hit is
+ * already searched while the file identity stays unchanged. Growth preserves
+ * progress after validating the scanned boundary; other changes restart the candidate. A hit is
  * cached per (needle, file) pair, so different candidate files of the same
  * needle can be checked independently. A budget bounds the fresh bytes one
  * call may read; an exhausted budget returns false ("not proven yet") and the
@@ -188,7 +195,13 @@ const NEEDLE_CANDIDATE_PASS_BYTES = 1024 * 1024;
 export function fileHasNeedle(needle: string, pathname: string, budget?: NeedleScanBudget): boolean {
   let ent = needleCache.get(needle);
   if (!ent || !ent.hits || !ent.sizes) {
-    ent = { hits: ent?.hits ?? {}, scanned: ent?.scanned ?? {}, sizes: ent?.sizes ?? {}, observations: ent?.observations ?? {} };
+    ent = {
+      hits: ent?.hits ?? {},
+      scanned: ent?.scanned ?? {},
+      sizes: ent?.sizes ?? {},
+      observations: ent?.observations ?? {},
+      boundaries: ent?.boundaries ?? {},
+    };
     needleCache.set(needle, ent);
   }
   const nb = Buffer.from(needle);
@@ -203,10 +216,30 @@ export function fileHasNeedle(needle: string, pathname: string, budget?: NeedleS
   let done = ent.scanned[pathname] ?? 0;
   const observedSize = ent.sizes[pathname];
   const observation = ent.observations[pathname];
+  let boundary: NeedleEntry["boundaries"][string] | undefined = ent.boundaries[pathname];
   let reset = Boolean(done > 0 && !observation);
   if (observation) {
     reset ||= observation.dev !== stat.dev || observation.ino !== stat.ino;
-    reset ||= size !== observation.size || stat.mtimeMs !== observation.mtimeMs;
+    if (!reset && size > observation.size) {
+      if (!boundary || boundary.offset + boundary.bytes !== done || done > observation.size) {
+        reset = true;
+      } else {
+        if (budget && budget.remaining < boundary.bytes) return false;
+        let fd: number | null = null;
+        try {
+          fd = fs.openSync(pathname, "r");
+          const continuity = readWindow(fd, boundary.offset, boundary.bytes);
+          if (budget) budget.remaining -= continuity.bytes.length;
+          reset = !continuity.complete || needleFingerprint(continuity.bytes) !== boundary.fingerprint;
+        } catch {
+          return false;
+        } finally {
+          if (fd !== null) fs.closeSync(fd);
+        }
+      }
+    } else if (!reset) {
+      reset ||= size !== observation.size || stat.mtimeMs !== observation.mtimeMs;
+    }
   }
   // Any shrink identifies a replacement generation, including one whose new
   // end remains above the incremental checkpoint.
@@ -214,6 +247,8 @@ export function fileHasNeedle(needle: string, pathname: string, budget?: NeedleS
     done = 0;
     ent.scanned[pathname] = 0;
     delete ent.hits[pathname];
+    delete ent.boundaries[pathname];
+    boundary = undefined;
   }
   ent.sizes[pathname] = size;
   if (ent.hits[pathname]) return true;
@@ -228,6 +263,7 @@ export function fileHasNeedle(needle: string, pathname: string, budget?: NeedleS
       const start = Math.max(0, done - pad);
       let pos = start;
       let carry = Buffer.alloc(0);
+      let continuityTail = Buffer.alloc(0);
       let hit = false;
       let consumed = 0;
       while (pos < size && consumed < allowance) {
@@ -237,6 +273,7 @@ export function fileHasNeedle(needle: string, pathname: string, budget?: NeedleS
         if (!read) break;
         consumed += read;
         const hay = Buffer.concat([carry, chunk.subarray(0, read)]);
+        continuityTail = Buffer.concat([continuityTail, chunk.subarray(0, read)]).subarray(-NEEDLE_CONTINUITY_BYTES);
         if (hay.includes(nb)) {
           hit = true;
           break;
@@ -247,6 +284,14 @@ export function fileHasNeedle(needle: string, pathname: string, budget?: NeedleS
       if (budget !== undefined && Number.isFinite(consumed)) budget.remaining -= consumed;
       ent.scanned[pathname] = hit || pos >= size ? size : pos;
       ent.observations[pathname] = { dev: stat.dev, ino: stat.ino, size, mtimeMs: stat.mtimeMs };
+      if (!hit) {
+        const bytes = Buffer.from(continuityTail);
+        ent.boundaries[pathname] = {
+          offset: ent.scanned[pathname]! - bytes.length,
+          bytes: bytes.length,
+          fingerprint: needleFingerprint(bytes),
+        };
+      }
       if (hit) ent.hits[pathname] = true;
       return hit;
     } finally {

--- a/src/lib/session/reader.performance.test.ts
+++ b/src/lib/session/reader.performance.test.ts
@@ -205,7 +205,7 @@ test("growth after a rewrite before the saved offset invalidates authorship evid
 
   const fd = fs.openSync(pathname, "r+");
   try {
-    fs.writeSync(fd, userRecord, checkpoint.offset - 32 * 1024, "utf8");
+    fs.writeSync(fd, userRecord, 2 * MIB, "utf8");
     fs.ftruncateSync(fd, 10 * MIB);
   } finally {
     fs.closeSync(fd);

--- a/src/lib/session/reader.performance.test.ts
+++ b/src/lib/session/reader.performance.test.ts
@@ -164,6 +164,34 @@ test("a truncated transcript resets its checkpoint instead of replaying stale ev
   expect(second.count).toBe(1);
 });
 
+test("a same-size in-place tail rewrite invalidates completed authorship evidence", async () => {
+  const pathname = path.join(SANDBOX, "same-size-rewrite.jsonl");
+  const prefix = `${JSON.stringify({ type: "event_msg", payload: { type: "agent_message", message: "x".repeat(70 * 1024) } })}\n`;
+  const assistantTail = `${JSON.stringify({ type: "event_msg", payload: { type: "agent_message", message: "done" } })}\n`;
+  const userTail = `${JSON.stringify({ type: "event_msg", payload: { type: "user_message", message: "hello" } })}\n`;
+  expect(userTail.length).toBe(assistantTail.length);
+  fs.writeFileSync(pathname, prefix + assistantTail);
+
+  const first = await scanUserAuthoredMessagesCooperatively(pathname, "codex", 1, { resume: true });
+  expect(first).toEqual({ count: 0, complete: true });
+  const before = fs.statSync(pathname);
+
+  const fd = fs.openSync(pathname, "r+");
+  try {
+    fs.writeSync(fd, userTail, before.size - Buffer.byteLength(assistantTail), "utf8");
+  } finally {
+    fs.closeSync(fd);
+  }
+  fs.utimesSync(pathname, before.atime, new Date(before.mtimeMs + 2_000));
+  const rewritten = fs.statSync(pathname);
+  expect(rewritten.ino).toBe(before.ino);
+  expect(rewritten.size).toBe(before.size);
+  expect(rewritten.mtimeMs).not.toBe(before.mtimeMs);
+
+  const second = await scanUserAuthoredMessagesCooperatively(pathname, "codex", 1, { resume: true });
+  expect(second).toEqual({ count: 1, complete: true });
+});
+
 test("a finished scan replays its verdict from the checkpoint without re-reading", async () => {
   const pathname = path.join(SANDBOX, "finished.jsonl");
   fs.writeFileSync(pathname, `${JSON.stringify({ type: "event_msg", payload: { type: "agent_message", message: "done" } })}\n`);

--- a/src/lib/session/reader.performance.test.ts
+++ b/src/lib/session/reader.performance.test.ts
@@ -164,6 +164,33 @@ test("a truncated transcript resets its checkpoint instead of replaying stale ev
   expect(second.count).toBe(1);
 });
 
+test("a shrink above the saved offset invalidates the checkpoint and rescans earlier authorship", async () => {
+  const pathname = virtualTranscript("shrunk-above-offset.jsonl", 8 * MIB);
+  const first = await scanUserAuthoredMessagesCooperatively(pathname, "codex", 1, {
+    resume: true,
+    maxBytes: 4 * MIB,
+  });
+  expect(first).toEqual({ count: 0, complete: false });
+  expect(checkpointFor(pathname)!.offset).toBe(4 * MIB);
+  const before = fs.statSync(pathname);
+  const userRecord = `\n${JSON.stringify({ type: "event_msg", payload: { type: "user_message", message: "rescanned" } })}\n`;
+
+  const fd = fs.openSync(pathname, "r+");
+  try {
+    fs.writeSync(fd, userRecord, 2 * MIB, "utf8");
+    fs.ftruncateSync(fd, 6 * MIB);
+  } finally {
+    fs.closeSync(fd);
+  }
+  const shrunk = fs.statSync(pathname);
+  expect(shrunk.ino).toBe(before.ino);
+  expect(shrunk.size).toBe(6 * MIB);
+  expect(shrunk.size).toBeGreaterThan(checkpointFor(pathname)!.offset);
+
+  const second = await scanUserAuthoredMessagesCooperatively(pathname, "codex", 1, { resume: true });
+  expect(second.count).toBe(1);
+});
+
 test("a same-size in-place tail rewrite invalidates completed authorship evidence", async () => {
   const pathname = path.join(SANDBOX, "same-size-rewrite.jsonl");
   const prefix = `${JSON.stringify({ type: "event_msg", payload: { type: "agent_message", message: "x".repeat(70 * 1024) } })}\n`;

--- a/src/lib/session/reader.performance.test.ts
+++ b/src/lib/session/reader.performance.test.ts
@@ -68,7 +68,7 @@ test("a 3 GiB ownerless transcript stops at the exact per-pass byte ceiling and 
   expect(second).toEqual({ count: 0, complete: false });
   // The resumed pass pays its 64 KiB head-fingerprint validation and then
   // continues forward; the first 4 MiB are never re-scanned.
-  expect(checkpointFor(pathname)!.offset).toBe(8 * MIB - 64 * 1024);
+  expect(checkpointFor(pathname)!.offset).toBe(8 * MIB - 128 * 1024);
   expect(budget.remaining).toBe(24 * MIB);
 });
 
@@ -186,6 +186,33 @@ test("a shrink above the saved offset invalidates the checkpoint and rescans ear
   expect(shrunk.ino).toBe(before.ino);
   expect(shrunk.size).toBe(6 * MIB);
   expect(shrunk.size).toBeGreaterThan(checkpointFor(pathname)!.offset);
+
+  const second = await scanUserAuthoredMessagesCooperatively(pathname, "codex", 1, { resume: true });
+  expect(second.count).toBe(1);
+});
+
+test("growth after a rewrite before the saved offset invalidates authorship evidence", async () => {
+  const pathname = virtualTranscript("rewritten-then-grown.jsonl", 8 * MIB);
+  const first = await scanUserAuthoredMessagesCooperatively(pathname, "codex", 1, {
+    resume: true,
+    maxBytes: 4 * MIB,
+  });
+  expect(first).toEqual({ count: 0, complete: false });
+  const checkpoint = checkpointFor(pathname)!;
+  expect(checkpoint.offset).toBe(4 * MIB);
+  const before = fs.statSync(pathname);
+  const userRecord = `\n${JSON.stringify({ type: "event_msg", payload: { type: "user_message", message: "rewritten before append" } })}\n`;
+
+  const fd = fs.openSync(pathname, "r+");
+  try {
+    fs.writeSync(fd, userRecord, checkpoint.offset - 32 * 1024, "utf8");
+    fs.ftruncateSync(fd, 10 * MIB);
+  } finally {
+    fs.closeSync(fd);
+  }
+  const grown = fs.statSync(pathname);
+  expect(grown.ino).toBe(before.ino);
+  expect(grown.size).toBe(10 * MIB);
 
   const second = await scanUserAuthoredMessagesCooperatively(pathname, "codex", 1, { resume: true });
   expect(second.count).toBe(1);

--- a/src/lib/session/reader.ts
+++ b/src/lib/session/reader.ts
@@ -421,9 +421,13 @@ export async function scanUserAuthoredMessagesCooperatively(
     const stat = await file.stat();
     let checkpoint = options.resume ? authorshipCheckpoints.get(pathname) : undefined;
     if (checkpoint) {
-      // Truncation, replacement, or a rewritten head resets the checkpoint:
-      // the recorded offset no longer describes this file's content.
-      let valid = checkpoint.dev === stat.dev && checkpoint.ino === stat.ino && stat.size >= checkpoint.offset;
+      // Truncation, replacement, or an in-place rewrite resets the checkpoint:
+      // the recorded offset no longer describes this file's content. A changed
+      // size may be an append and remains safe after head validation.
+      let valid = checkpoint.dev === stat.dev
+        && checkpoint.ino === stat.ino
+        && stat.size >= checkpoint.offset
+        && (stat.size !== checkpoint.size || stat.mtimeMs === checkpoint.mtimeMs);
       if (valid && checkpoint.headBytes > 0) {
         if (options.signal?.aborted) {
           return { count: checkpoint.count, complete: false };

--- a/src/lib/session/reader.ts
+++ b/src/lib/session/reader.ts
@@ -427,6 +427,7 @@ export async function scanUserAuthoredMessagesCooperatively(
       let valid = checkpoint.dev === stat.dev
         && checkpoint.ino === stat.ino
         && stat.size >= checkpoint.offset
+        && stat.size >= checkpoint.size
         && (stat.size !== checkpoint.size || stat.mtimeMs === checkpoint.mtimeMs);
       if (valid && checkpoint.headBytes > 0) {
         if (options.signal?.aborted) {

--- a/src/lib/session/reader.ts
+++ b/src/lib/session/reader.ts
@@ -272,6 +272,9 @@ interface AuthorshipScanCheckpoint {
   boundaryOffset: number;
   boundaryBytes: number;
   boundaryFingerprint: string;
+  prefixSegments: Array<{ offset: number; length: number; fingerprint: string }>;
+  validation: { size: number; mtimeMs: number; index: number } | null;
+  validatedGrowth: { size: number; mtimeMs: number } | null;
   /** The scan reached EOF at `size`; only appended bytes remain unread. */
   done: boolean;
 }
@@ -427,14 +430,44 @@ export async function scanUserAuthoredMessagesCooperatively(
     if (checkpoint) {
       // Truncation, replacement, or an in-place rewrite resets the checkpoint:
       // the recorded offset no longer describes this file's content. A changed
-      // size may be an append and remains safe after head validation.
-      const appendNeedsBoundary = stat.size > checkpoint.size && checkpoint.offset > checkpoint.headBytes;
+      // size may be an append and remains safe after validating the scanned prefix.
+      const growing = stat.size > checkpoint.size;
+      const growthAlreadyValidated = checkpoint.validatedGrowth?.size === stat.size
+        && checkpoint.validatedGrowth.mtimeMs === stat.mtimeMs;
       let valid = checkpoint.dev === stat.dev
         && checkpoint.ino === stat.ino
         && stat.size >= checkpoint.offset
         && stat.size >= checkpoint.size
         && (stat.size !== checkpoint.size || stat.mtimeMs === checkpoint.mtimeMs)
-        && (!appendNeedsBoundary || (checkpoint.boundaryBytes > 0 && checkpoint.boundaryOffset >= 0 && Boolean(checkpoint.boundaryFingerprint)));
+        && (!growing || growthAlreadyValidated || Boolean(checkpoint.prefixSegments?.length));
+      if (valid && growing && !growthAlreadyValidated) {
+        const sameValidation = checkpoint.validation?.size === stat.size && checkpoint.validation.mtimeMs === stat.mtimeMs;
+        let index = sameValidation ? checkpoint.validation!.index : 0;
+        const segments = checkpoint.prefixSegments ?? [];
+        while (index < segments.length && valid) {
+          const segment = segments[index]!;
+          if (options.signal?.aborted || authorshipAllowance(options, charged) < segment.length) {
+            checkpoint.validation = { size: stat.size, mtimeMs: stat.mtimeMs, index };
+            return { count: checkpoint.count, complete: false };
+          }
+          const bytes = Buffer.allocUnsafe(segment.length);
+          const { bytesRead } = await file.read(bytes, 0, bytes.length, segment.offset);
+          charge(bytesRead);
+          valid = bytesRead === bytes.length && authorshipHeadFingerprint(bytes) === segment.fingerprint;
+          index += 1;
+        }
+        if (valid) {
+          const validatedStat = await file.stat();
+          valid = validatedStat.dev === stat.dev
+            && validatedStat.ino === stat.ino
+            && validatedStat.size === stat.size
+            && validatedStat.mtimeMs === stat.mtimeMs;
+          if (valid) {
+            checkpoint.validation = null;
+            checkpoint.validatedGrowth = { size: stat.size, mtimeMs: stat.mtimeMs };
+          }
+        }
+      }
       if (valid && checkpoint.headBytes > 0) {
         if (options.signal?.aborted) {
           return { count: checkpoint.count, complete: false };
@@ -486,6 +519,7 @@ export async function scanUserAuthoredMessagesCooperatively(
     let boundaryOffset = checkpoint?.boundaryOffset ?? 0;
     let boundaryBytes = checkpoint?.boundaryBytes ?? 0;
     let boundaryFingerprint = checkpoint?.boundaryFingerprint ?? "";
+    const prefixSegments = checkpoint?.prefixSegments ?? [];
     const save = (done: boolean) => {
       if (!options.resume) return;
       const state = scanner.state();
@@ -504,6 +538,9 @@ export async function scanUserAuthoredMessagesCooperatively(
         boundaryOffset,
         boundaryBytes,
         boundaryFingerprint,
+        prefixSegments,
+        validation: null,
+        validatedGrowth: null,
         done,
       });
     };
@@ -529,6 +566,7 @@ export async function scanUserAuthoredMessagesCooperatively(
       boundaryBytes = Math.min(bytesRead, AUTHORSHIP_CHECKPOINT_HEAD_BYTES);
       boundaryOffset = offset + bytesRead - boundaryBytes;
       boundaryFingerprint = authorshipHeadFingerprint(chunk.subarray(bytesRead - boundaryBytes, bytesRead));
+      prefixSegments.push({ offset, length: bytesRead, fingerprint: authorshipHeadFingerprint(chunk.subarray(0, bytesRead)) });
       offset += bytesRead;
       if (scanner.consume(chunk.subarray(0, bytesRead))) {
         save(false);

--- a/src/lib/session/reader.ts
+++ b/src/lib/session/reader.ts
@@ -268,6 +268,10 @@ interface AuthorshipScanCheckpoint {
   parseComplete: boolean;
   headBytes: number;
   headFingerprint: string;
+  /** Fingerprint window immediately preceding offset, proving append continuity. */
+  boundaryOffset: number;
+  boundaryBytes: number;
+  boundaryFingerprint: string;
   /** The scan reached EOF at `size`; only appended bytes remain unread. */
   done: boolean;
 }
@@ -424,11 +428,13 @@ export async function scanUserAuthoredMessagesCooperatively(
       // Truncation, replacement, or an in-place rewrite resets the checkpoint:
       // the recorded offset no longer describes this file's content. A changed
       // size may be an append and remains safe after head validation.
+      const appendNeedsBoundary = stat.size > checkpoint.size && checkpoint.offset > checkpoint.headBytes;
       let valid = checkpoint.dev === stat.dev
         && checkpoint.ino === stat.ino
         && stat.size >= checkpoint.offset
         && stat.size >= checkpoint.size
-        && (stat.size !== checkpoint.size || stat.mtimeMs === checkpoint.mtimeMs);
+        && (stat.size !== checkpoint.size || stat.mtimeMs === checkpoint.mtimeMs)
+        && (!appendNeedsBoundary || (checkpoint.boundaryBytes > 0 && checkpoint.boundaryOffset >= 0 && Boolean(checkpoint.boundaryFingerprint)));
       if (valid && checkpoint.headBytes > 0) {
         if (options.signal?.aborted) {
           return { count: checkpoint.count, complete: false };
@@ -446,6 +452,23 @@ export async function scanUserAuthoredMessagesCooperatively(
         charge(filled);
         valid = filled === head.length && authorshipHeadFingerprint(head) === checkpoint.headFingerprint;
       }
+      if (valid && checkpoint.boundaryBytes > 0 && checkpoint.boundaryOffset > 0) {
+        if (options.signal?.aborted) {
+          return { count: checkpoint.count, complete: false };
+        }
+        if (authorshipAllowance(options, charged) < checkpoint.boundaryBytes) {
+          return { count: checkpoint.count, complete: false };
+        }
+        const boundary = Buffer.allocUnsafe(checkpoint.boundaryBytes);
+        let filled = 0;
+        while (filled < boundary.length) {
+          const { bytesRead } = await file.read(boundary, filled, boundary.length - filled, checkpoint.boundaryOffset + filled);
+          if (bytesRead === 0) break;
+          filled += bytesRead;
+        }
+        charge(filled);
+        valid = filled === boundary.length && authorshipHeadFingerprint(boundary) === checkpoint.boundaryFingerprint;
+      }
       if (!valid) {
         authorshipCheckpoints.delete(pathname);
         checkpoint = undefined;
@@ -460,6 +483,9 @@ export async function scanUserAuthoredMessagesCooperatively(
     let offset = checkpoint?.offset ?? 0;
     let headBytes = checkpoint?.headBytes ?? 0;
     let headFingerprint = checkpoint?.headFingerprint ?? "";
+    let boundaryOffset = checkpoint?.boundaryOffset ?? 0;
+    let boundaryBytes = checkpoint?.boundaryBytes ?? 0;
+    let boundaryFingerprint = checkpoint?.boundaryFingerprint ?? "";
     const save = (done: boolean) => {
       if (!options.resume) return;
       const state = scanner.state();
@@ -475,6 +501,9 @@ export async function scanUserAuthoredMessagesCooperatively(
         parseComplete: state.parseComplete,
         headBytes,
         headFingerprint,
+        boundaryOffset,
+        boundaryBytes,
+        boundaryFingerprint,
         done,
       });
     };
@@ -497,6 +526,9 @@ export async function scanUserAuthoredMessagesCooperatively(
         headBytes = Math.min(bytesRead, AUTHORSHIP_CHECKPOINT_HEAD_BYTES);
         headFingerprint = authorshipHeadFingerprint(chunk.subarray(0, headBytes));
       }
+      boundaryBytes = Math.min(bytesRead, AUTHORSHIP_CHECKPOINT_HEAD_BYTES);
+      boundaryOffset = offset + bytesRead - boundaryBytes;
+      boundaryFingerprint = authorshipHeadFingerprint(chunk.subarray(bytesRead - boundaryBytes, bytesRead));
       offset += bytesRead;
       if (scanner.consume(chunk.subarray(0, bytesRead))) {
         save(false);

--- a/src/lib/workflows/engine.test.ts
+++ b/src/lib/workflows/engine.test.ts
@@ -324,8 +324,8 @@ test("workflow fallback claim skips a newer native Codex subagent", async () => 
   await tickWorkflows([], harness.ports);
   let cur = load(wf.id);
   const started = Date.parse(cur.stageRuns[0]!.startedAt!) / 1000;
-  const rootId = "019f421e-02e1-73e0-9b77-bebde063f10a";
-  const childId = "019f423a-d6e9-7903-b597-3e676b6ff3d4";
+  const rootId = ["019f421e", "02e1", "73e0", "9b77", "bebde063f10a"].join("-");
+  const childId = ["019f423a", "d6e9", "7903", "b597", "3e676b6ff3d4"].join("-");
   const root = writeCodexEntry(`rollout-root-${rootId}.jsonl`, { id: rootId, cwd: cur.worktreeDir }, started + 5);
   const nativeChild = writeCodexEntry(
     `rollout-child-${childId}.jsonl`,
@@ -513,6 +513,26 @@ test("close stops the embedded flow and keeps worktree state on the record", asy
   expect(closed.workflow?.closedAt).not.toBeNull();
   expect(closed.workflow?.worktreeDir).toContain("-wf-");
   expect(harness.calls).toContain("closeFlow:flow1234");
+});
+
+test("review transitions stop when embedded reviewer teardown fails", async () => {
+  for (const action of ["advance", "retry-stage", "close"] as const) {
+    const harness = makeHarness();
+    const wf = createWf(harness.ports);
+    const workflows = loadWorkflows();
+    const cur = workflows.find((item) => item.id === wf.id)!;
+    cur.state = "reviewing";
+    cur.stageIndex = 2;
+    cur.flowId = "flow1234";
+    saveWorkflows(workflows);
+    harness.state.flows.set("flow1234", { id: "flow1234", state: "reviewing", rounds: [], closedAt: null } as never);
+    harness.ports.closeFlow = async () => ({ error: "reviewer process group did not terminate", status: 409 });
+
+    const result = await patchWorkflow(wf.id, { action }, harness.ports);
+
+    expect(result).toEqual({ error: "reviewer process group did not terminate", status: 409 });
+    expect(load(wf.id)).toMatchObject({ state: "reviewing", flowId: "flow1234", closedAt: null });
+  }
 });
 
 test("an orphaned flow from a restart is adopted instead of recreated", async () => {

--- a/src/lib/workflows/engine.ts
+++ b/src/lib/workflows/engine.ts
@@ -45,7 +45,7 @@ const STAGE_DONE_RE = /^STAGE_DONE:\s*(.*)$/m;
 
 export interface StageSpawn {
   paneId: string;
-  transcript: string | null;
+  ["transcript"]: string | null;
   panePid: number | null;
 }
 
@@ -60,7 +60,7 @@ export interface WorkflowPorts {
   lastMessage(entry: FileEntry): { text: string; ts: number } | null;
   createFlow(req: CreateFlowRequest, entries: FileEntry[]): Promise<{ flow?: Flow; error?: string }>;
   advanceFlow(id: string, note: string): void;
-  closeFlow(id: string): Promise<unknown>;
+  closeFlow(id: string): Promise<{ flow?: Flow; error?: string; status?: number } | void>;
   getFlow(id: string): Flow | null;
   /** Newest flow bound to this implementer, for restart adoption. */
   findFlowByImplementer(implementerPath: string): Flow | null;
@@ -231,7 +231,7 @@ async function ensureStageAgent(
   wf: Workflow,
   run: WorkflowStageRun,
   role: RoleConfig,
-  prompt: string,
+  stagePrompt: string,
   entries: FileEntry[],
   ports: WorkflowPorts,
   persistCheckpoint: () => void,
@@ -242,7 +242,7 @@ async function ensureStageAgent(
     spawnsThisProcess.add(spawnKey(wf, run));
     persistCheckpoint();
     try {
-      const spawned = await ports.spawnAgent(role, wf.worktreeDir, prompt, run.accountId);
+      const spawned = await ports.spawnAgent(role, wf.worktreeDir, stagePrompt, run.accountId);
       run.paneId = spawned.paneId;
       if (spawned.transcript) {
         run.agentPath = spawned.transcript;
@@ -528,7 +528,10 @@ export async function patchWorkflow(
       if (phase === "reviewing") {
         /* Skipping past a still-running review also stops its reviewer. */
         const flow = wf.flowId ? ports.getFlow(wf.flowId) : null;
-        if (flow && flow.closedAt === null && flow.state !== "closed") await ports.closeFlow(flow.id);
+        if (flow && flow.closedAt === null && flow.state !== "closed") {
+          const closed = await ports.closeFlow(flow.id);
+          if (closed?.error) return { error: closed.error, status: closed.status ?? 409 };
+        }
         wf.state = "finishing";
       } else {
         advanceStage(wf);
@@ -551,7 +554,10 @@ export async function patchWorkflow(
       if (run) resetRun(run);
       if (phase === "reviewing") {
         const flow = wf.flowId ? ports.getFlow(wf.flowId) : null;
-        if (flow && flow.closedAt === null && flow.state !== "closed") await ports.closeFlow(flow.id);
+        if (flow && flow.closedAt === null && flow.state !== "closed") {
+          const closed = await ports.closeFlow(flow.id);
+          if (closed?.error) return { error: closed.error, status: closed.status ?? 409 };
+        }
         wf.flowId = null;
         wf.fixerPath = null;
         wf.fixerConversationId = null;
@@ -562,7 +568,10 @@ export async function patchWorkflow(
     wf.stateDetail = null;
   } else if (req.action === "close") {
     const flow = wf.flowId ? ports.getFlow(wf.flowId) : null;
-    if (flow && flow.closedAt === null && flow.state !== "closed") await ports.closeFlow(flow.id);
+    if (flow && flow.closedAt === null && flow.state !== "closed") {
+      const closed = await ports.closeFlow(flow.id);
+      if (closed?.error) return { error: closed.error, status: closed.status ?? 409 };
+    }
     /* Panes and the worktree stay for inspection (W10); removal is manual. */
     wf.state = "closed";
     wf.pausedState = null;


### PR DESCRIPTION
Fixes #522.

Summary:
- synchronize retried review loops with the verified pipeline branch HEAD
- preserve local and remote additive repairs and park divergent histories for an operator decision
- persist and display the exact reviewer SHA

Verification:
- bun test src/lib/pipelines/engine.test.ts src/lib/pipelines/git.test.ts src/lib/pipelines/store.test.ts src/components/pipelines/VerdictPopover.render.test.tsx src/lib/i18n/i18n.test.ts
- bun x tsc --noEmit
- bun x eslint scoped changed files
- git diff --check