### PR TITLE
fix(pipelines): reconcile terminal review flows

### DIFF
--- a/src/lib/pipelines/engine.test.ts
+++ b/src/lib/pipelines/engine.test.ts
@@ -2225,6 +2225,46 @@ test("a later approval stays parked when its reviewed head differs from the curr
   expect(loadPipelines()[0]!.stateDetail).toBe(parked.stateDetail);
 });
 
+test("an approval parks when the clean head advances during final settlement (#526)", async () => {
+  const h = harness();
+  await create(h.ports, [
+    { id: "build", kind: "run", prompt: "build", next: "review" },
+    { id: "review", kind: "review-loop", role: { roleId: "reviewer" }, prompt: "review", next: null },
+  ] as never);
+  await tickPipelines([], h.ports);
+  await tickPipelines([], h.ports);
+  await tickPipelines([h.finish("/codex/stage-1.jsonl", "pass")], h.ports);
+  await tickPipelines([entry("/codex/stage-1.jsonl")], h.ports);
+
+  const flow = h.flows.get("flow-1")!;
+  flow.rounds.push({ n: 1, reviewHeadSha: ORIGIN_MAIN_SHA } as never);
+  flow.state = "approved";
+  const newerHead = "e".repeat(40);
+  let headReads = 0;
+  const baseExec = h.ports.exec;
+  h.ports.exec = (command, args, cwd) => {
+    if (command === "git" && args[0] === "rev-parse" && args[1] === "HEAD") {
+      headReads += 1;
+      return { code: 0, stdout: `${headReads === 1 ? ORIGIN_MAIN_SHA : newerHead}\n`, stderr: "" };
+    }
+    return baseExec(command, args, cwd);
+  };
+
+  await tickPipelines([], h.ports);
+  const parked = loadPipelines()[0]!;
+  expect(headReads).toBe(2);
+  expect(parked).toMatchObject({
+    state: "needs_decision",
+    stateDetail: expect.stringContaining(`settled ${newerHead}`),
+    lastPassedCommit: ORIGIN_MAIN_SHA,
+  });
+  expect(parked.cursor?.stageId).toBe("review");
+  expect(parked.runs[1]!.attempts[0]).toMatchObject({
+    state: "needs_decision",
+    reviewHeadSha: ORIGIN_MAIN_SHA,
+  });
+});
+
 test("REQUEST_CHANGES recovery keeps the bound reviewer in the review slot and lets the flow relay continue (#526)", async () => {
   const h = harness();
   await create(h.ports, [
@@ -2369,6 +2409,34 @@ test("a restarted committing review parks when the branch head drifted after app
   });
   expect(parked.runs[1]!.attempts[0]).toMatchObject({ state: "needs_decision", reviewHeadSha: ORIGIN_MAIN_SHA });
   expect(h.calls.some((call) => call.startsWith("git commit"))).toBe(false);
+});
+
+test("a restarted committing review parks when the clean head advances during final settlement (#526)", async () => {
+  const h = await persistedCommittingReview();
+  const newerHead = "c".repeat(40);
+  let headReads = 0;
+  const baseExec = h.ports.exec;
+  h.ports.exec = (command, args, cwd) => {
+    if (command === "git" && args[0] === "rev-parse" && args[1] === "HEAD") {
+      headReads += 1;
+      return { code: 0, stdout: `${headReads === 1 ? ORIGIN_MAIN_SHA : newerHead}\n`, stderr: "" };
+    }
+    return baseExec(command, args, cwd);
+  };
+
+  await tickPipelines([], h.ports);
+  const parked = loadPipelines()[0]!;
+  expect(headReads).toBe(2);
+  expect(parked).toMatchObject({
+    state: "needs_decision",
+    stateDetail: expect.stringContaining(`settled ${newerHead}`),
+    lastPassedCommit: ORIGIN_MAIN_SHA,
+  });
+  expect(parked.cursor?.stageId).toBe("review");
+  expect(parked.runs[1]!.attempts[0]).toMatchObject({
+    state: "needs_decision",
+    reviewHeadSha: ORIGIN_MAIN_SHA,
+  });
 });
 
 test("a restarted committing review parks without committing post-review changes (#526)", async () => {

--- a/src/lib/pipelines/engine.test.ts
+++ b/src/lib/pipelines/engine.test.ts
@@ -1773,6 +1773,7 @@ test("review-loop stage delegates to one regular flow and maps approval", async 
   expect(h.calls.filter((call) => call.startsWith("flow:")).length).toBe(1);
   expect(h.calls).toContain("flow-patch:flow-1:advance");
   expect(h.calls.some((call) => call.includes("Reviewer guidance"))).toBe(true);
+  h.flows.get("flow-1")!.rounds.push({ n: 1, reviewHeadSha: ORIGIN_MAIN_SHA } as never);
   h.flows.get("flow-1")!.state = "approved";
   await tickPipelines([entry("/codex/stage-1.jsonl")], h.ports);
   expect(loadPipelines()[0]!.state).toBe("completed");
@@ -2135,6 +2136,134 @@ test("a paused review flow parks its pipeline", async () => {
   await tickPipelines([entry("/codex/stage-1.jsonl")], h.ports);
   expect(loadPipelines()[0]!.state).toBe("needs_decision");
   expect(loadPipelines()[0]!.stateDetail).toContain("kickoff delivery failed");
+});
+
+test("a later exact-head approval replaces a stale startup pause and completes after controller restart (#526)", async () => {
+  const h = harness();
+  const stages = [
+    { id: "build", kind: "run", prompt: "build", next: "review" },
+    { id: "review", kind: "review-loop", role: { roleId: "reviewer" }, prompt: "review", next: null },
+  ] as const;
+  await create(h.ports, stages as never);
+  await tickPipelines([], h.ports);
+  await tickPipelines([], h.ports);
+  await tickPipelines([h.finish("/codex/stage-1.jsonl", "pass")], h.ports);
+  await tickPipelines([entry("/codex/stage-1.jsonl")], h.ports);
+
+  const flow = h.flows.get("flow-1")!;
+  flow.state = "paused";
+  flow.stateDetail = "paused by user";
+  await tickPipelines([entry("/codex/stage-1.jsonl")], h.ports);
+  const parked = loadPipelines()[0]!;
+  expect(parked.state).toBe("needs_decision");
+  expect(parked.runs[1]!.attempts[0]).toMatchObject({
+    flowId: "flow-1",
+    state: "needs_decision",
+    error: "review flow paused during startup: paused by user",
+  });
+
+  flow.rounds.push({
+    n: 1,
+    reviewHeadSha: ORIGIN_MAIN_SHA,
+    launchId: "review-launch",
+    sessionId: "review-session",
+    reviewerPath: "/codex/reviewer.jsonl",
+    reviewerConversationId: "conversation_reviewer",
+  } as never);
+  flow.state = "approved";
+  flow.stateDetail = null;
+
+  /* A fresh controller process sees only durable pipeline + flow state. */
+  await tickPipelines([entry("/codex/reviewer.jsonl")], h.ports);
+  const completed = loadPipelines()[0]!;
+  expect(completed.state).toBe("completed");
+  expect(completed.stateDetail).toBeNull();
+  expect(completed.runs[1]!.attempts).toHaveLength(1);
+  expect(completed.runs[1]!.attempts[0]).toMatchObject({
+    flowId: "flow-1",
+    state: "passed",
+    error: null,
+    reviewHeadSha: ORIGIN_MAIN_SHA,
+    agentPath: "/codex/reviewer.jsonl",
+    conversationId: "conversation_reviewer",
+  });
+
+  const afterCompletion = JSON.stringify(completed);
+  await tickPipelines([entry("/codex/reviewer.jsonl")], h.ports);
+  expect(JSON.stringify(loadPipelines()[0])).toBe(afterCompletion);
+});
+
+test("a later approval stays parked when its reviewed head differs from the current pipeline head (#526)", async () => {
+  const h = harness();
+  await create(h.ports, [
+    { id: "build", kind: "run", prompt: "build", next: "review" },
+    { id: "review", kind: "review-loop", role: { roleId: "reviewer" }, prompt: "review", next: null },
+  ] as never);
+  await tickPipelines([], h.ports);
+  await tickPipelines([], h.ports);
+  await tickPipelines([h.finish("/codex/stage-1.jsonl", "pass")], h.ports);
+  await tickPipelines([entry("/codex/stage-1.jsonl")], h.ports);
+
+  const flow = h.flows.get("flow-1")!;
+  flow.state = "paused";
+  flow.stateDetail = "transient controller restart";
+  await tickPipelines([], h.ports);
+  flow.rounds.push({ n: 1, reviewHeadSha: "f".repeat(40) } as never);
+  flow.state = "approved";
+  flow.stateDetail = null;
+
+  await tickPipelines([], h.ports);
+  const parked = loadPipelines()[0]!;
+  expect(parked.state).toBe("needs_decision");
+  expect(parked.stateDetail).toContain("approved review flow head mismatch");
+  expect(parked.runs[1]!.attempts[0]).toMatchObject({
+    state: "needs_decision",
+    reviewHeadSha: "f".repeat(40),
+    error: expect.stringContaining(`current pipeline head is ${ORIGIN_MAIN_SHA}`),
+  });
+  expect((await tickPipelines([], h.ports)).changed).toBe(false);
+  expect(loadPipelines()[0]!.stateDetail).toBe(parked.stateDetail);
+});
+
+test("REQUEST_CHANGES recovery keeps the bound reviewer in the review slot and lets the flow relay continue (#526)", async () => {
+  const h = harness();
+  await create(h.ports, [
+    { id: "build", kind: "run", prompt: "build", next: "review" },
+    { id: "review", kind: "review-loop", role: { roleId: "reviewer" }, prompt: "review", next: null },
+  ] as never);
+  await tickPipelines([], h.ports);
+  await tickPipelines([], h.ports);
+  await tickPipelines([h.finish("/codex/stage-1.jsonl", "pass")], h.ports);
+  await tickPipelines([entry("/codex/stage-1.jsonl")], h.ports);
+
+  const flow = h.flows.get("flow-1")!;
+  flow.state = "paused";
+  flow.stateDetail = "relay controller unavailable";
+  await tickPipelines([], h.ports);
+  flow.rounds.push({
+    n: 1,
+    verdict: "REQUEST_CHANGES",
+    reviewHeadSha: ORIGIN_MAIN_SHA,
+    launchId: "review-launch",
+    sessionId: "review-session",
+    reviewerPath: "/codex/reviewer.jsonl",
+    reviewerConversationId: "conversation_reviewer",
+  } as never);
+  flow.state = "relay_pending";
+  flow.stateDetail = null;
+
+  await tickPipelines([entry("/codex/reviewer.jsonl")], h.ports);
+  const relaying = loadPipelines()[0]!;
+  expect(relaying.state).toBe("running");
+  expect(relaying.stateDetail).toBeNull();
+  expect(relaying.runs[1]!.attempts).toHaveLength(1);
+  expect(relaying.runs[1]!.attempts[0]).toMatchObject({
+    flowId: "flow-1",
+    state: "reviewing",
+    error: null,
+    agentPath: "/codex/reviewer.jsonl",
+    conversationId: "conversation_reviewer",
+  });
 });
 
 test("retrying a paused review with a live reviewer never mutates its checkout (#522)", async () => {
@@ -3120,6 +3249,7 @@ test("consecutive reviews cross a migration boundary and resume positional imple
   await tickPipelines([], ports); // spawn build
   await tickPipelines([h.finish("/codex/stage-1.jsonl", "pass", "built")], ports); // build → review1
   await tickPipelines([entry("/codex/stage-1.jsonl")], ports); // review1 opens flow-1
+  h.flows.get("flow-1")!.rounds.push({ n: 1, reviewHeadSha: ORIGIN_MAIN_SHA } as never);
   h.flows.get("flow-1")!.state = "approved";
   await tickPipelines([entry("/codex/stage-1.jsonl")], ports); // review1 approves → review2
 

--- a/src/lib/pipelines/engine.test.ts
+++ b/src/lib/pipelines/engine.test.ts
@@ -2266,6 +2266,55 @@ test("REQUEST_CHANGES recovery keeps the bound reviewer in the review slot and l
   });
 });
 
+for (const terminalState of ["done_comment", "needs_decision"] as const) {
+  test(`a later ${terminalState} outcome replaces stale startup evidence once across restart ticks (#526)`, async () => {
+    const h = harness();
+    await create(h.ports, [
+      { id: "build", kind: "run", prompt: "build", next: "review" },
+      { id: "review", kind: "review-loop", role: { roleId: "reviewer" }, prompt: "review", next: null },
+    ] as never);
+    await tickPipelines([], h.ports);
+    await tickPipelines([], h.ports);
+    await tickPipelines([h.finish("/codex/stage-1.jsonl", "pass")], h.ports);
+    await tickPipelines([entry("/codex/stage-1.jsonl")], h.ports);
+
+    const flow = h.flows.get("flow-1")!;
+    flow.state = "paused";
+    flow.stateDetail = "startup transport unavailable";
+    await tickPipelines([], h.ports);
+    expect(loadPipelines()[0]!.runs[1]!.attempts[0]!.error)
+      .toBe("review flow paused during startup: startup transport unavailable");
+
+    flow.rounds.push({
+      n: 1,
+      verdict: terminalState === "done_comment" ? "COMMENT" : null,
+      reviewHeadSha: ORIGIN_MAIN_SHA,
+      reviewerPath: "/codex/reviewer.jsonl",
+      reviewerConversationId: "conversation_reviewer",
+    } as never);
+    flow.state = terminalState;
+    flow.stateDetail = terminalState === "done_comment" ? "reviewer left a comment" : "reviewer relay failed";
+
+    await tickPipelines([entry("/codex/reviewer.jsonl")], h.ports);
+    const reconciled = loadPipelines()[0]!;
+    const expectedError = `review loop ended in ${terminalState}: ${flow.stateDetail}`;
+    expect(reconciled).toMatchObject({ state: "needs_decision", stateDetail: expectedError });
+    expect(reconciled.runs[1]!.attempts).toHaveLength(1);
+    expect(reconciled.runs[1]!.attempts[0]).toMatchObject({
+      flowId: "flow-1",
+      state: "needs_decision",
+      error: expectedError,
+      reviewHeadSha: ORIGIN_MAIN_SHA,
+      agentPath: "/codex/reviewer.jsonl",
+      conversationId: "conversation_reviewer",
+    });
+
+    expect((await tickPipelines([entry("/codex/reviewer.jsonl")], h.ports)).changed).toBe(false);
+    expect(loadPipelines()[0]!.runs[1]!.attempts).toHaveLength(1);
+    expect(loadPipelines()[0]!.stateDetail).toBe(expectedError);
+  });
+}
+
 test("retrying a paused review with a live reviewer never mutates its checkout (#522)", async () => {
   const h = harness();
   const stages = [

--- a/src/lib/pipelines/engine.test.ts
+++ b/src/lib/pipelines/engine.test.ts
@@ -2315,6 +2315,82 @@ for (const terminalState of ["done_comment", "needs_decision"] as const) {
   });
 }
 
+async function persistedCommittingReview() {
+  const h = harness();
+  await create(h.ports, [
+    { id: "build", kind: "run", prompt: "build", next: "review" },
+    { id: "review", kind: "review-loop", role: { roleId: "reviewer" }, prompt: "review", next: null },
+  ] as never);
+  await tickPipelines([], h.ports);
+  await tickPipelines([], h.ports);
+  await tickPipelines([h.finish("/codex/stage-1.jsonl", "pass")], h.ports);
+  await tickPipelines([entry("/codex/stage-1.jsonl")], h.ports);
+
+  const pipeline = loadPipelines()[0]!;
+  const attempt = pipeline.runs[1]!.attempts[0]!;
+  attempt.state = "committing";
+  attempt.reviewHeadSha = ORIGIN_MAIN_SHA;
+  attempt.output = "Review loop approved after 1 round(s).";
+  attempt.verdict = { status: "pass", confidence: 1 };
+  pipeline.cursor = { ...pipeline.cursor!, state: "committing" };
+  savePipelines([pipeline]);
+  return h;
+}
+
+test("a restarted committing review completes once when its clean head still matches (#526)", async () => {
+  const h = await persistedCommittingReview();
+
+  await tickPipelines([], h.ports);
+  const completed = loadPipelines()[0]!;
+  expect(completed.state).toBe("completed");
+  expect(completed.runs[1]!.attempts[0]).toMatchObject({ state: "passed", reviewHeadSha: ORIGIN_MAIN_SHA });
+
+  const afterCompletion = JSON.stringify(completed);
+  expect((await tickPipelines([], h.ports)).changed).toBe(false);
+  expect(JSON.stringify(loadPipelines()[0])).toBe(afterCompletion);
+});
+
+test("a restarted committing review parks when the branch head drifted after approval (#526)", async () => {
+  const h = await persistedCommittingReview();
+  const driftedHead = "d".repeat(40);
+  const baseExec = h.ports.exec;
+  h.ports.exec = (command, args, cwd) => {
+    if (command === "git" && args[0] === "rev-parse" && args[1] === "HEAD") {
+      return { code: 0, stdout: `${driftedHead}\n`, stderr: "" };
+    }
+    return baseExec(command, args, cwd);
+  };
+
+  await tickPipelines([], h.ports);
+  const parked = loadPipelines()[0]!;
+  expect(parked).toMatchObject({
+    state: "needs_decision",
+    stateDetail: expect.stringContaining(`current pipeline head is ${driftedHead}`),
+  });
+  expect(parked.runs[1]!.attempts[0]).toMatchObject({ state: "needs_decision", reviewHeadSha: ORIGIN_MAIN_SHA });
+  expect(h.calls.some((call) => call.startsWith("git commit"))).toBe(false);
+});
+
+test("a restarted committing review parks without committing post-review changes (#526)", async () => {
+  const h = await persistedCommittingReview();
+  const baseExec = h.ports.exec;
+  h.ports.exec = (command, args, cwd) => {
+    if (command === "git" && args[0] === "status") {
+      return { code: 0, stdout: " M post-review.txt\n", stderr: "" };
+    }
+    return baseExec(command, args, cwd);
+  };
+
+  await tickPipelines([], h.ports);
+  const parked = loadPipelines()[0]!;
+  expect(parked).toMatchObject({
+    state: "needs_decision",
+    stateDetail: expect.stringContaining("uncommitted changes"),
+  });
+  expect(parked.runs[1]!.attempts[0]).toMatchObject({ state: "needs_decision", reviewHeadSha: ORIGIN_MAIN_SHA });
+  expect(h.calls.some((call) => call.startsWith("git add") || call.startsWith("git commit"))).toBe(false);
+});
+
 test("retrying a paused review with a live reviewer never mutates its checkout (#522)", async () => {
   const h = harness();
   const stages = [

--- a/src/lib/pipelines/engine.ts
+++ b/src/lib/pipelines/engine.ts
@@ -750,6 +750,14 @@ function commitPassedStage(
     park(pipeline, result.error, attempt);
     return;
   }
+  if (stage.kind === "review-loop" && result.sha !== attempt.reviewHeadSha) {
+    park(
+      pipeline,
+      `approved review flow head mismatch during settlement: reviewed ${attempt.reviewHeadSha ?? "no exact head"}, settled ${result.sha}`,
+      attempt,
+    );
+    return;
+  }
   pipeline.lastPassedCommit = result.sha;
   attempt.state = "passed";
   attempt.completedAt = ports.now();

--- a/src/lib/pipelines/engine.ts
+++ b/src/lib/pipelines/engine.ts
@@ -26,7 +26,7 @@ import { realExec, type ExecPort } from "@/lib/workflows/provision";
 
 import { requestPipelineTick } from "./controllerSignal";
 import { durableStageTurnEvidence, type StageTurnEvidence } from "./durableEvidence";
-import { commitPipelineStage, provisionPipelineWorktree, resetPipelineStage, resolvePipelineBase, synchronizePipelineRetryHead } from "./git";
+import { commitPipelineStage, currentPipelineBranchHead, provisionPipelineWorktree, resetPipelineStage, resolvePipelineBase, synchronizePipelineRetryHead } from "./git";
 import {
   DEFAULT_FAIL_EDGE_ROUNDS,
   MAX_FAIL_EDGE_ROUNDS,
@@ -1164,12 +1164,25 @@ async function tickReviewStage(
     return;
   }
   attachReviewFlowAttempt(attempt, flow);
-  const capturedReviewHead = flow.rounds.find((round) => round.reviewHeadSha)?.reviewHeadSha ?? null;
-  if (!attempt.reviewHeadSha && capturedReviewHead) {
+  const capturedReviewHead = flow.rounds.findLast((round) => round.reviewHeadSha)?.reviewHeadSha ?? null;
+  if (capturedReviewHead && attempt.reviewHeadSha !== capturedReviewHead) {
     attempt.reviewHeadSha = capturedReviewHead;
     persist();
   }
   if (flow.state === "approved") {
+    const currentHead = currentPipelineBranchHead(pipeline, ports.exec);
+    if (!currentHead.ok) {
+      park(pipeline, `approved review flow could not verify the current pipeline head: ${currentHead.error}`, attempt);
+      return;
+    }
+    if (!capturedReviewHead || capturedReviewHead !== currentHead.sha) {
+      park(
+        pipeline,
+        `approved review flow head mismatch: reviewed ${capturedReviewHead ?? "no exact head"}, current pipeline head is ${currentHead.sha}`,
+        attempt,
+      );
+      return;
+    }
     attempt.output = `Review loop approved after ${flow.rounds.length} round(s).`;
     attempt.verdict = { status: "pass", confidence: 1 };
     attempt.state = "committing";
@@ -1224,18 +1237,32 @@ const REOPENED_REVIEW_FLOW_STATES: ReadonlySet<Flow["state"]> = new Set([
   "fixing",
   "approved",
 ]);
+const RECONCILABLE_BOUND_FLOW_ERRORS = [
+  "review flow startup paused:",
+  "review flow paused during startup:",
+  "advancing the review flow failed:",
+  "review loop ended in ",
+  "embedded review flow record disappeared",
+] as const;
 
-function resumeReopenedReviewFlow(pipeline: Pipeline, ports: PipelinePorts): boolean {
+function reconcileBoundReviewFlow(pipeline: Pipeline, ports: PipelinePorts): boolean {
   if (pipeline.state !== "needs_decision") return false;
   const stage = currentStage(pipeline);
   if (stage?.kind !== "review-loop") return false;
   const attempt = currentAttempt(pipeline, stage.id);
+  const attemptError = attempt?.error;
   const flow = attempt?.flowId ? ports.getFlow(attempt.flowId) : null;
-  if (!attempt?.error?.startsWith("review loop ended in ") || !flow || !REOPENED_REVIEW_FLOW_STATES.has(flow.state)) return false;
+  if (
+    !attemptError
+    || !RECONCILABLE_BOUND_FLOW_ERRORS.some((prefix) => attemptError.startsWith(prefix))
+    || !flow
+    || !REOPENED_REVIEW_FLOW_STATES.has(flow.state)
+  ) return false;
   pipeline.state = "running";
   pipeline.stateDetail = null;
   attempt.state = "reviewing";
   attempt.error = null;
+  attachReviewFlowAttempt(attempt, flow);
   setCursorState(pipeline, stage.id, "reviewing");
   return true;
 }
@@ -1251,7 +1278,7 @@ export async function tickPipelines(entries: FileEntry[], ports: PipelinePorts =
         let pipelineChanged = reconcilePendingPipelineAdoptions(pipeline, ports);
         pipelineChanged = await reconcileHistoricalAttempts(pipeline, entries, ports) || pipelineChanged;
         pipelineChanged = rebindPipelineAttemptPaths(pipeline, ports) || pipelineChanged;
-        pipelineChanged = resumeReopenedReviewFlow(pipeline, ports) || pipelineChanged;
+        pipelineChanged = reconcileBoundReviewFlow(pipeline, ports) || pipelineChanged;
         if (!TERMINAL_STATES.has(pipeline.state) && pipeline.state !== "paused" && pipeline.state !== "needs_decision") {
           pipelineChanged = await tickPipeline(pipeline, entries, ports, persist) || pipelineChanged;
         }

--- a/src/lib/pipelines/engine.ts
+++ b/src/lib/pipelines/engine.ts
@@ -1189,8 +1189,9 @@ async function tickReviewStage(
     setCursorState(pipeline, stage.id, "committing");
     persist();
     commitPassedStage(pipeline, stage, attempt, ports);
-  } else if (flow.state === "needs_decision" || flow.state === "done_comment" || flow.state === "closed") {
-    park(pipeline, `review loop ended in ${flow.state}: ${flow.stateDetail ?? "operator decision required"}`, attempt);
+  } else {
+    const terminalError = terminalReviewFlowError(flow);
+    if (terminalError) park(pipeline, terminalError, attempt);
   }
 }
 
@@ -1227,7 +1228,7 @@ async function tickPipeline(pipeline: Pipeline, entries: FileEntry[], ports: Pip
 }
 
 const tickStore = globalThis as unknown as { __llvPipelineTick?: boolean };
-const REOPENED_REVIEW_FLOW_STATES: ReadonlySet<Flow["state"]> = new Set([
+const RECONCILABLE_REVIEW_FLOW_STATES: ReadonlySet<Flow["state"]> = new Set([
   "waiting_ready",
   "spawn_pending",
   "spawning",
@@ -1236,6 +1237,9 @@ const REOPENED_REVIEW_FLOW_STATES: ReadonlySet<Flow["state"]> = new Set([
   "relaying",
   "fixing",
   "approved",
+  "needs_decision",
+  "done_comment",
+  "closed",
 ]);
 const RECONCILABLE_BOUND_FLOW_ERRORS = [
   "review flow startup paused:",
@@ -1244,6 +1248,11 @@ const RECONCILABLE_BOUND_FLOW_ERRORS = [
   "review loop ended in ",
   "embedded review flow record disappeared",
 ] as const;
+
+function terminalReviewFlowError(flow: Flow): string | null {
+  if (flow.state !== "needs_decision" && flow.state !== "done_comment" && flow.state !== "closed") return null;
+  return `review loop ended in ${flow.state}: ${flow.stateDetail ?? "operator decision required"}`;
+}
 
 function reconcileBoundReviewFlow(pipeline: Pipeline, ports: PipelinePorts): boolean {
   if (pipeline.state !== "needs_decision") return false;
@@ -1256,8 +1265,9 @@ function reconcileBoundReviewFlow(pipeline: Pipeline, ports: PipelinePorts): boo
     !attemptError
     || !RECONCILABLE_BOUND_FLOW_ERRORS.some((prefix) => attemptError.startsWith(prefix))
     || !flow
-    || !REOPENED_REVIEW_FLOW_STATES.has(flow.state)
+    || !RECONCILABLE_REVIEW_FLOW_STATES.has(flow.state)
   ) return false;
+  if (attemptError === terminalReviewFlowError(flow)) return false;
   pipeline.state = "running";
   pipeline.stateDetail = null;
   attempt.state = "reviewing";

--- a/src/lib/pipelines/engine.ts
+++ b/src/lib/pipelines/engine.ts
@@ -744,7 +744,8 @@ function commitPassedStage(
   attempt: PipelineStageAttempt,
   ports: PipelinePorts,
 ): void {
-  const result = commitPipelineStage(pipeline, stage.id, stage.kind === "review-loop" || attempt.effectiveRole.access === "read-write", ports.exec);
+  const allowCommit = stage.kind === "run" && attempt.effectiveRole.access === "read-write";
+  const result = commitPipelineStage(pipeline, stage.id, allowCommit, ports.exec);
   if (!result.ok) {
     park(pipeline, result.error, attempt);
     return;
@@ -1068,6 +1069,11 @@ async function tickReviewStage(
     : prior ?? newAttempt(pipeline, stage);
   if (!attempt || pipeline.state === "needs_decision") return;
   if (attempt.state === "committing") {
+    const fenceError = reviewHeadFenceError(pipeline, attempt, ports);
+    if (fenceError) {
+      park(pipeline, fenceError, attempt);
+      return;
+    }
     commitPassedStage(pipeline, stage, attempt, ports);
     return;
   }
@@ -1170,17 +1176,9 @@ async function tickReviewStage(
     persist();
   }
   if (flow.state === "approved") {
-    const currentHead = currentPipelineBranchHead(pipeline, ports.exec);
-    if (!currentHead.ok) {
-      park(pipeline, `approved review flow could not verify the current pipeline head: ${currentHead.error}`, attempt);
-      return;
-    }
-    if (!capturedReviewHead || capturedReviewHead !== currentHead.sha) {
-      park(
-        pipeline,
-        `approved review flow head mismatch: reviewed ${capturedReviewHead ?? "no exact head"}, current pipeline head is ${currentHead.sha}`,
-        attempt,
-      );
+    const fenceError = reviewHeadFenceError(pipeline, attempt, ports);
+    if (fenceError) {
+      park(pipeline, fenceError, attempt);
       return;
     }
     attempt.output = `Review loop approved after ${flow.rounds.length} round(s).`;
@@ -1248,6 +1246,13 @@ const RECONCILABLE_BOUND_FLOW_ERRORS = [
   "review loop ended in ",
   "embedded review flow record disappeared",
 ] as const;
+
+function reviewHeadFenceError(pipeline: Pipeline, attempt: PipelineStageAttempt, ports: PipelinePorts): string | null {
+  const currentHead = currentPipelineBranchHead(pipeline, ports.exec);
+  if (!currentHead.ok) return `approved review flow could not verify the current pipeline head: ${currentHead.error}`;
+  if (attempt.reviewHeadSha === currentHead.sha) return null;
+  return `approved review flow head mismatch: reviewed ${attempt.reviewHeadSha ?? "no exact head"}, current pipeline head is ${currentHead.sha}`;
+}
 
 function terminalReviewFlowError(flow: Flow): string | null {
   if (flow.state !== "needs_decision" && flow.state !== "done_comment" && flow.state !== "closed") return null;


### PR DESCRIPTION
Closes #526

## Summary
- reconcile parked review attempts when their bound flow progresses after startup or controller errors
- require the approving reviewer SHA to match the clean current pipeline branch HEAD
- retain the existing attempt and refresh its reviewer-slot identity during recovery
- keep REQUEST_CHANGES relay and restart ticks idempotent

## Verification
- `bun test src/lib/pipelines/engine.test.ts src/lib/pipelines/controller.test.ts src/lib/pipelines/store.test.ts src/lib/flows/engine.test.ts src/lib/flows/store.test.ts` (164 pass)
- `bunx tsc --noEmit`
- `bun run lint -- src/lib/pipelines/engine.ts src/lib/pipelines/engine.test.ts`
- `bun run privacy:check`
- `git diff --check`