### PR TITLE
Activate bounded SQLite registry rollout

### DIFF
--- a/docs/agent-registry-sqlite.md
+++ b/docs/agent-registry-sqlite.md
@@ -4,7 +4,7 @@ The registry supports four values for `LLV_AGENT_REGISTRY_SQLITE`:
 
 - `off` keeps `agent-registry.json` authoritative. This is the default.
 - `dual-write` reads JSON, writes JSON and SQLite under the existing JSON writer lock, and verifies parity after every mutation.
-- `read` reads and transacts through `agent-registry.sqlite` in WAL mode, then refreshes `agent-registry.json` as the rollback mirror.
+- `read` reads and transacts through `agent-registry.sqlite` in WAL mode, then refreshes `agent-registry.json` on a bounded five-second checkpoint cadence. Startup and release demotion write a revision-stamped checkpoint.
 - `sqlite` uses SQLite for reads and writes after the parity burn-in. It refreshes the JSON mirror at process start and removes JSON serialization from registry operations.
 
 The first process that opens any gated SQLite mode creates `agent-registry.sqlite` and imports the normalized contents of `agent-registry.json` in one transaction. An interrupted import has no migration marker, so the next boot retries the complete import. Durable memberships, spawn receipts, capability digests, lineage, conversation generations, migration state, delivery receipts, and routing policy all migrate through the same snapshot.
@@ -19,6 +19,11 @@ Every process with an enabled SQLite mode must run on Bun. The Docker Viewer use
 4. Restart every registry writer with `LLV_AGENT_REGISTRY_SQLITE=read` for an SQLite-read burn-in with a continuously refreshed JSON rollback mirror.
 5. After that burn-in, restart every writer with `LLV_AGENT_REGISTRY_SQLITE=sqlite` to remove JSON rewrites from the operation path.
 6. Retain `agent-registry.json`, `agent-registry.sqlite`, and the SQLite WAL files throughout both burn-ins.
+
+`/api/files` reports the backend mode, revision, transaction count, writer rate and p95,
+writer-wait p95, rollback-mirror age, and dirty-checkpoint state under
+`systemHealth.registry`. A rollout probe must observe one current release owner,
+a bounded mirror age in `read`, and a stable JSON mtime during `sqlite` streaming.
 
 The `read` and `sqlite` paths bypass the whole-registry writer lock, its retry/backoff loop, stale-lock recovery, temp-file cleanup, and startup JSON compaction. Per-session operation locks remain active. They serialize host actuation independently of registry persistence.
 

--- a/docs/agent-registry-sqlite.md
+++ b/docs/agent-registry-sqlite.md
@@ -25,6 +25,14 @@ writer-wait p95, rollback-mirror age, and dirty-checkpoint state under
 `systemHealth.registry`. A rollout probe must observe one current release owner,
 a bounded mirror age in `read`, and a stable JSON mtime during `sqlite` streaming.
 
+The release gate uses a registry of at least 14,660,822 bytes with ten mixed
+structured-host lanes and a concurrent reader. Registry mutation p95 must stay
+below 250 ms, SQLite writer-wait p95 below 100 ms, reader p95 below 100 ms,
+the cold `/api/files` probe below 1,000 ms, and its warm probe below 500 ms.
+The measured revision delta must equal the admitted material and coalesced
+cursor transactions, and the JSON mirror inode metadata must remain unchanged
+through steady-state `sqlite` traffic.
+
 The `read` and `sqlite` paths bypass the whole-registry writer lock, its retry/backoff loop, stale-lock recovery, temp-file cleanup, and startup JSON compaction. Per-session operation locks remain active. They serialize host actuation independently of registry persistence.
 
 ## Rollback

--- a/docs/agent-registry-sqlite.md
+++ b/docs/agent-registry-sqlite.md
@@ -13,12 +13,15 @@ Every process with an enabled SQLite mode must run on Bun. The Docker Viewer use
 
 ## Rollout
 
-1. Preserve a copy of the current state directory.
-2. Start every Bun-hosted Viewer and runtime-host process with `LLV_AGENT_REGISTRY_SQLITE=dual-write`.
-3. Treat `RegistryParityError` as a rollout stop. Keep JSON authoritative while investigating any mismatch.
-4. Restart every registry writer with `LLV_AGENT_REGISTRY_SQLITE=read` for an SQLite-read burn-in with a continuously refreshed JSON rollback mirror.
-5. After that burn-in, restart every writer with `LLV_AGENT_REGISTRY_SQLITE=sqlite` to remove JSON rewrites from the operation path.
-6. Retain `agent-registry.json`, `agent-registry.sqlite`, and the SQLite WAL files throughout both burn-ins.
+1. Stop every Viewer and runtime-host process that can mutate the registry. Confirm that no registry writer remains before changing backend files.
+2. Preserve a copy of the current state directory. Archive the known stale `agent-registry.sqlite`, `agent-registry.sqlite-wal`, and `agent-registry.sqlite-shm` together under distinct inactive names, retaining their timestamps and permissions as diagnostic evidence.
+3. Keep the current `agent-registry.json` at its active path and clear only the three active SQLite paths after the archive is verified.
+4. Start exactly one Bun-hosted process with `LLV_AGENT_REGISTRY_SQLITE=dual-write`. Its first boot creates SQLite and imports the authoritative JSON in one transaction. Verify parity and stop this importer before allowing the writer fleet to start.
+5. Start every Bun-hosted Viewer and runtime-host process with `LLV_AGENT_REGISTRY_SQLITE=dual-write`.
+6. Treat `RegistryParityError` as a rollout stop. Keep JSON authoritative while investigating any mismatch.
+7. Restart every registry writer with `LLV_AGENT_REGISTRY_SQLITE=read` for an SQLite-read burn-in with a continuously refreshed JSON rollback mirror.
+8. After that burn-in, restart every writer with `LLV_AGENT_REGISTRY_SQLITE=sqlite` to remove JSON rewrites from the operation path.
+9. Retain `agent-registry.json`, `agent-registry.sqlite`, and the SQLite WAL files throughout both burn-ins.
 
 `/api/files` reports the backend mode, revision, transaction count, writer rate and p95,
 writer-wait p95, rollback-mirror age, and dirty-checkpoint state under

--- a/docs/agent-registry-sqlite.md
+++ b/docs/agent-registry-sqlite.md
@@ -33,6 +33,10 @@ The measured revision delta must equal the admitted material and coalesced
 cursor transactions, and the JSON mirror inode metadata must remain unchanged
 through steady-state `sqlite` traffic.
 
+A failed scheduled rollback checkpoint retains the dirty revision and retries
+with exponential backoff capped at 30 seconds. Successful convergence resets
+the retry series.
+
 The `read` and `sqlite` paths bypass the whole-registry writer lock, its retry/backoff loop, stale-lock recovery, temp-file cleanup, and startup JSON compaction. Per-session operation locks remain active. They serialize host actuation independently of registry persistence.
 
 ## Rollback

--- a/docs/agent-registry-sqlite.md
+++ b/docs/agent-registry-sqlite.md
@@ -23,10 +23,11 @@ Every process with an enabled SQLite mode must run on Bun. The Docker Viewer use
 8. After that burn-in, restart every writer with `LLV_AGENT_REGISTRY_SQLITE=sqlite` to remove JSON rewrites from the operation path.
 9. Retain `agent-registry.json`, `agent-registry.sqlite`, and the SQLite WAL files throughout both burn-ins.
 
-`/api/files` reports the backend mode, revision, transaction count, writer rate and p95,
+`/api/files` reports the backend mode, revision, transaction count, transaction p95,
 writer-wait p95, rollback-mirror checkpoint timestamp, and dirty-checkpoint state under
 `systemHealth.registry`. The cached response exposes the stable mirror checkpoint
-timestamp; rollout probes derive its age at observation time. A rollout probe must
+timestamp and omits time-decaying writer rate; rollout probes derive both values at
+observation time. A rollout probe must
 observe one current release owner, a bounded mirror age in `read`, and a stable JSON
 mtime during `sqlite` streaming.
 

--- a/docs/agent-registry-sqlite.md
+++ b/docs/agent-registry-sqlite.md
@@ -24,9 +24,11 @@ Every process with an enabled SQLite mode must run on Bun. The Docker Viewer use
 9. Retain `agent-registry.json`, `agent-registry.sqlite`, and the SQLite WAL files throughout both burn-ins.
 
 `/api/files` reports the backend mode, revision, transaction count, writer rate and p95,
-writer-wait p95, rollback-mirror age, and dirty-checkpoint state under
-`systemHealth.registry`. A rollout probe must observe one current release owner,
-a bounded mirror age in `read`, and a stable JSON mtime during `sqlite` streaming.
+writer-wait p95, rollback-mirror checkpoint timestamp, and dirty-checkpoint state under
+`systemHealth.registry`. The cached response exposes the stable mirror checkpoint
+timestamp; rollout probes derive its age at observation time. A rollout probe must
+observe one current release owner, a bounded mirror age in `read`, and a stable JSON
+mtime during `sqlite` streaming.
 
 The release gate uses a registry of at least 14,660,822 bytes with ten mixed
 structured-host lanes and a concurrent reader. Registry mutation p95 must stay

--- a/src/app/api/files/response.ts
+++ b/src/app/api/files/response.ts
@@ -537,6 +537,17 @@ export async function buildFilesResponse(request: Request, dependencies: FilesRo
   const projectsFinishedAt = performance.now();
   timings.push(`files-projects;dur=${(projectsFinishedAt - projectsStartedAt).toFixed(1)}`);
   timingMark = projectsFinishedAt;
+  const registryDiagnostics = registry.storageDiagnostics();
+  const registryHealth = {
+    backendMode: registryDiagnostics.backendMode,
+    revision: registryDiagnostics.revision,
+    transactionCount: registryDiagnostics.transactionCount,
+    writerRatePerSecond: registryDiagnostics.writerRatePerSecond,
+    writerWaitP95Ms: registryDiagnostics.writerWaitP95Ms,
+    transactionP95Ms: registryDiagnostics.transactionP95Ms,
+    mirrorCheckpointAtMs: registryDiagnostics.mirrorCheckpointAtMs,
+    mirrorDirty: registryDiagnostics.mirrorDirty,
+  };
   const body = JSON.stringify({
     files: projected.files,
     ...(responsePinOverlayPaths.size ? { pinOverlayPaths: [...responsePinOverlayPaths] } : {}),
@@ -546,7 +557,7 @@ export async function buildFilesResponse(request: Request, dependencies: FilesRo
     pipelines,
     workflows,
     tasks: tasks.tasks,
-    systemHealth: { tmux: tmuxEndpointHealth(), registry: registry.storageDiagnostics() },
+    systemHealth: { tmux: tmuxEndpointHealth(), registry: registryHealth },
     conversationAliases: registrySnapshot.conversationAliases,
     ...(pipelinesError ? { pipelinesError } : {}),
   } satisfies FilesResponse);

--- a/src/app/api/files/response.ts
+++ b/src/app/api/files/response.ts
@@ -542,7 +542,6 @@ export async function buildFilesResponse(request: Request, dependencies: FilesRo
     backendMode: registryDiagnostics.backendMode,
     revision: registryDiagnostics.revision,
     transactionCount: registryDiagnostics.transactionCount,
-    writerRatePerSecond: registryDiagnostics.writerRatePerSecond,
     writerWaitP95Ms: registryDiagnostics.writerWaitP95Ms,
     transactionP95Ms: registryDiagnostics.transactionP95Ms,
     mirrorCheckpointAtMs: registryDiagnostics.mirrorCheckpointAtMs,

--- a/src/app/api/files/response.ts
+++ b/src/app/api/files/response.ts
@@ -546,7 +546,7 @@ export async function buildFilesResponse(request: Request, dependencies: FilesRo
     pipelines,
     workflows,
     tasks: tasks.tasks,
-    systemHealth: { tmux: tmuxEndpointHealth() },
+    systemHealth: { tmux: tmuxEndpointHealth(), registry: registry.storageDiagnostics() },
     conversationAliases: registrySnapshot.conversationAliases,
     ...(pipelinesError ? { pipelinesError } : {}),
   } satisfies FilesResponse);

--- a/src/app/api/files/route.test.ts
+++ b/src/app/api/files/route.test.ts
@@ -117,7 +117,11 @@ test("repeated files reads reuse the pure read snapshot and retain ETag behavior
   const etag = first.headers.get("etag");
   const second = await GET(new Request("http://127.0.0.1/api/files", { headers: { "if-none-match": etag! } }));
   expect(first.status).toBe(200);
-  expect(await first.json()).toEqual({ files: [], projectCatalog: [], flows: [], pipelines: [], workflows: [], tasks: [], systemHealth: { tmux: { status: "healthy" } }, conversationAliases: {} });
+  expect(await first.json()).toMatchObject({
+    files: [], projectCatalog: [], flows: [], pipelines: [], workflows: [], tasks: [],
+    systemHealth: { tmux: { status: "healthy" }, registry: { backendMode: expect.any(String) } },
+    conversationAliases: {},
+  });
   expect(second.status).toBe(304);
   expect(scans).toBe(1);
   expect(scanOptions).toEqual(expect.objectContaining({

--- a/src/app/api/files/route.test.ts
+++ b/src/app/api/files/route.test.ts
@@ -147,6 +147,26 @@ test("repeated files reads reuse the pure read snapshot and retain ETag behavior
   expect(first.headers.get("server-timing")).toMatch(/files-role-titles;dur=\d+(?:\.\d+)?/);
 });
 
+test("rollback checkpoint age does not invalidate an otherwise stable files ETag", async () => {
+  const filename = path.join(registryRoot, "registry.json");
+  new AgentRegistry(filename).beginSpawn("codex", "/seed");
+  let now = 1_000;
+  setAgentRegistryForTests(new AgentRegistry(filename, undefined, undefined, {
+    sqliteMode: "read",
+    now: () => now,
+  }));
+  const first = await GET(new Request("http://127.0.0.1/api/files"));
+  const etag = first.headers.get("etag");
+
+  now += 15;
+  const second = await GET(new Request("http://127.0.0.1/api/files", {
+    headers: { "if-none-match": etag! },
+  }));
+
+  expect(first.status).toBe(200);
+  expect(second.status).toBe(304);
+});
+
 test("production-sized SQLite registry keeps cold and warm files probes within budget", async () => {
   const filename = path.join(registryRoot, "production-registry.json");
   const seed = new AgentRegistry(filename);

--- a/src/app/api/files/route.test.ts
+++ b/src/app/api/files/route.test.ts
@@ -147,6 +147,58 @@ test("repeated files reads reuse the pure read snapshot and retain ETag behavior
   expect(first.headers.get("server-timing")).toMatch(/files-role-titles;dur=\d+(?:\.\d+)?/);
 });
 
+test("production-sized SQLite registry keeps cold and warm files probes within budget", async () => {
+  const filename = path.join(registryRoot, "production-registry.json");
+  const seed = new AgentRegistry(filename);
+  const template = seed.beginSpawn("codex", "/production-seed");
+  const production = seed.snapshot();
+  for (let index = 1; index < 18_000; index += 1) {
+    const launchId = `production-seed-${String(index).padStart(5, "0")}`;
+    production.receipts[launchId] = {
+      ...structuredClone(template),
+      launchId,
+      state: "failed",
+      artifactLifecycle: "deleted",
+      error: "fixture-terminal",
+    };
+  }
+  const payload = JSON.stringify(production);
+  expect(Buffer.byteLength(payload)).toBeGreaterThanOrEqual(14_660_822);
+  fs.writeFileSync(filename, payload);
+  setAgentRegistryForTests(new AgentRegistry(filename, undefined, undefined, { sqliteMode: "sqlite" }));
+
+  const writerReady = path.join(registryRoot, "production-writer.ready");
+  const writerStart = path.join(registryRoot, "production-writer.start");
+  const writerResult = path.join(registryRoot, "production-writer.json");
+  const writer = Bun.spawn([
+    process.execPath,
+    path.resolve(import.meta.dir, "../../../lib/agent/registry.sqliteChild.ts"),
+    "writer-mixed",
+    filename,
+    writerReady,
+    writerStart,
+    "files-probe-writer",
+    "12",
+    writerResult,
+  ], { cwd: process.cwd(), stdout: "pipe", stderr: "pipe" });
+  while (!fs.existsSync(writerReady)) await Bun.sleep(1);
+  fs.writeFileSync(writerStart, "start");
+
+  const coldStartedAt = performance.now();
+  const cold = await GET(new Request("http://127.0.0.1/api/files"));
+  const coldDuration = performance.now() - coldStartedAt;
+  const warmStartedAt = performance.now();
+  const warm = await GET(new Request("http://127.0.0.1/api/files"));
+  const warmDuration = performance.now() - warmStartedAt;
+  expect(await writer.exited).toBe(0);
+  expect(await new Response(writer.stderr).text()).toBe("");
+
+  expect(cold.status).toBe(200);
+  expect(warm.status).toBe(200);
+  expect(coldDuration).toBeLessThan(1_000);
+  expect(warmDuration).toBeLessThan(500);
+});
+
 test("files API surfaces degraded tmux endpoint health", async () => {
   tmuxHealth = {
     status: "degraded",

--- a/src/app/api/files/route.test.ts
+++ b/src/app/api/files/route.test.ts
@@ -158,7 +158,7 @@ test("production-sized SQLite registry keeps cold and warm files probes within b
       ...structuredClone(template),
       launchId,
       state: "failed",
-      artifactLifecycle: "deleted",
+      artifactLifecycle: "materialized",
       error: "fixture-terminal",
     };
   }

--- a/src/app/api/files/route.test.ts
+++ b/src/app/api/files/route.test.ts
@@ -147,18 +147,22 @@ test("repeated files reads reuse the pure read snapshot and retain ETag behavior
   expect(first.headers.get("server-timing")).toMatch(/files-role-titles;dur=\d+(?:\.\d+)?/);
 });
 
-test("rollback checkpoint age does not invalidate an otherwise stable files ETag", async () => {
+test("volatile registry diagnostics do not invalidate an otherwise stable files ETag", async () => {
   const filename = path.join(registryRoot, "registry.json");
   new AgentRegistry(filename).beginSpawn("codex", "/seed");
   let now = 1_000;
-  setAgentRegistryForTests(new AgentRegistry(filename, undefined, undefined, {
+  const registry = new AgentRegistry(filename, undefined, undefined, {
     sqliteMode: "read",
     now: () => now,
-  }));
+    mirrorCheckpointMs: 120_000,
+    scheduleMirrorCheckpoint: () => ({ unref() {} }),
+  });
+  registry.beginSpawn("codex", "/writer-rate-sample");
+  setAgentRegistryForTests(registry);
   const first = await GET(new Request("http://127.0.0.1/api/files"));
   const etag = first.headers.get("etag");
 
-  now += 15;
+  now += 61_000;
   const second = await GET(new Request("http://127.0.0.1/api/files", {
     headers: { "if-none-match": etag! },
   }));

--- a/src/instrumentation.test.ts
+++ b/src/instrumentation.test.ts
@@ -7,6 +7,7 @@ import { performance } from "node:perf_hooks";
 import {
   accountControllerDelayMs,
   activateViewerRuntimeWhenCurrent,
+  completeViewerReleaseDemotion,
   initializeOperatorSpawnCapabilityAtStartup,
   runStructuredHostStartup,
   scheduleAccountMigrationController,
@@ -163,6 +164,29 @@ test("a promoted release continuously relinquishes background ownership after de
   current = false;
   scheduled.shift()!();
   expect(demotions).toBe(1);
+});
+
+test("release demotion reports checkpoint failure before exiting with failure status", async () => {
+  const events: Array<[string, unknown?]> = [];
+  await completeViewerReleaseDemotion(
+    () => { throw new Error("injected fsync failure"); },
+    (code) => { events.push(["exit", code]); },
+    (...args) => { events.push([String(args[0]), args[1]]); },
+  );
+
+  expect(events[0]?.[0]).toBe("[viewer release] demotion checkpoint failed");
+  expect(events[0]?.[1]).toBeInstanceOf(Error);
+  expect(events[1]).toEqual(["exit", 1]);
+});
+
+test("release demotion exits successfully after its checkpoint", async () => {
+  const exits: number[] = [];
+  await completeViewerReleaseDemotion(
+    () => undefined,
+    (code) => { exits.push(code); },
+    () => undefined,
+  );
+  expect(exits).toEqual([0]);
 });
 
 test("a restarted current release activates before register returns", async () => {

--- a/src/instrumentation.test.ts
+++ b/src/instrumentation.test.ts
@@ -95,6 +95,17 @@ test("deployment candidates stay passive until their endpoint owns the durable r
   expect(viewerReleaseOwnsTraffic({ PORT: "19115" }, () => target)).toBe(false);
 });
 
+test("exact-SHA release probe grants background ownership to one serving endpoint", () => {
+  const target = JSON.stringify({
+    sha: "fixture-sha",
+    endpoint: "http://127.0.0.1:19892",
+    previous: { sha: "fixture-previous", endpoint: "http://127.0.0.1:19115" },
+  });
+  const owners = ["19892", "19115", "18888"]
+    .filter((port) => viewerReleaseOwnsTraffic({ PORT: port }, () => target));
+  expect(owners).toEqual(["19892"]);
+});
+
 test("release ownership keeps local boot active and fails closed on an unreadable durable target", () => {
   const missing = Object.assign(new Error("missing"), { code: "ENOENT" });
   expect(viewerReleaseOwnsTraffic({}, () => { throw missing; })).toBe(true);

--- a/src/instrumentation.test.ts
+++ b/src/instrumentation.test.ts
@@ -130,7 +130,28 @@ test("passive candidate activates runtime startup exactly once after promotion",
   await Promise.resolve();
   await Promise.resolve();
   expect(activations).toBe(1);
-  expect(scheduled).toHaveLength(0);
+  expect(scheduled).toHaveLength(1);
+});
+
+test("a promoted release continuously relinquishes background ownership after demotion", async () => {
+  let current = true;
+  let activations = 0;
+  let demotions = 0;
+  const scheduled: Array<() => void> = [];
+  await activateViewerRuntimeWhenCurrent(
+    async () => { activations += 1; },
+    () => current,
+    {
+      pollMs: 1,
+      schedule: (callback) => { scheduled.push(callback); return { unref() {} }; },
+      onDemoted: () => { demotions += 1; },
+    },
+  );
+  expect(activations).toBe(1);
+  expect(scheduled).toHaveLength(1);
+  current = false;
+  scheduled.shift()!();
+  expect(demotions).toBe(1);
 });
 
 test("a restarted current release activates before register returns", async () => {
@@ -142,7 +163,7 @@ test("a restarted current release activates before register returns", async () =
     { schedule: (callback) => { scheduled.push(callback); return { unref() {} }; } },
   );
   expect(activations).toBe(1);
-  expect(scheduled).toHaveLength(0);
+  expect(scheduled).toHaveLength(1);
 });
 
 test("current release starts flow and pipeline recovery and watchdog while account migration is disabled", async () => {

--- a/src/lib/agent/registry.sqlite.test.ts
+++ b/src/lib/agent/registry.sqlite.test.ts
@@ -422,6 +422,21 @@ test("dual-write leaves both backends unchanged after a no-op mutation", () => {
   db.close();
 });
 
+for (const sqliteMode of ["read", "sqlite"] as const) {
+  test(`${sqliteMode} mode leaves the durable revision unchanged after a missing claim release`, () => {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), `llv-registry-${sqliteMode}-noop-`));
+    const filename = path.join(directory, "agent-registry.json");
+    new AgentRegistry(filename).beginSpawn("codex", "/seed");
+    const registry = new AgentRegistry(filename, undefined, undefined, { sqliteMode });
+    const before = registry.storageDiagnostics().revision;
+
+    expect(registry.releaseStructuredHostClaim({ engine: "codex", sessionId: "missing" }, "owner", 1)).toBeFalse();
+
+    expect(registry.storageDiagnostics().revision).toBe(before);
+    expect(registry.storageDiagnostics().mirrorDirty).toBeFalse();
+  });
+}
+
 test("dual-write fails closed when SQLite is ahead of its JSON mirror", () => {
   const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-registry-sqlite-transition-"));
   const filename = path.join(directory, "agent-registry.json");
@@ -871,6 +886,48 @@ test("one rollback checkpoint publishes one coherent snapshot under sustained wr
   expect(scheduled).toHaveLength(1);
   const mirror = JSON.parse(fs.readFileSync(filename, "utf8")) as { _sqliteRevision: number };
   expect(mirror._sqliteRevision).toBeLessThan(writer.storageDiagnostics().revision!);
+});
+
+test("release demotion converges a mirror dirtied by one concurrent successor commit", () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-registry-demotion-convergence-"));
+  const filename = path.join(directory, "agent-registry.json");
+  new AgentRegistry(filename).beginSpawn("codex", "/seed");
+  const successor = new AgentRegistry(filename, undefined, undefined, { sqliteMode: "sqlite" });
+  let concurrentCommit = false;
+  const retiring = new AgentRegistry(filename, undefined, undefined, {
+    sqliteMode: "sqlite",
+    afterMirrorWrite: () => {
+      if (!concurrentCommit) return;
+      concurrentCommit = false;
+      successor.beginSpawn("codex", "/successor-during-checkpoint");
+    },
+  });
+  successor.beginSpawn("codex", "/dirty-before-demotion");
+  concurrentCommit = true;
+
+  retiring.checkpointRollbackMirrorForDemotion();
+
+  const json = JSON.parse(fs.readFileSync(filename, "utf8")) as { _sqliteRevision: number };
+  expect(json._sqliteRevision).toBe(successor.storageDiagnostics().revision!);
+  expect(retiring.storageDiagnostics().mirrorDirty).toBeFalse();
+});
+
+test("release demotion fails closed after bounded continuously dirty checkpoints", () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-registry-demotion-bounded-"));
+  const filename = path.join(directory, "agent-registry.json");
+  new AgentRegistry(filename).beginSpawn("codex", "/seed");
+  const successor = new AgentRegistry(filename, undefined, undefined, { sqliteMode: "sqlite" });
+  let mirrorWrites = 0;
+  const retiring = new AgentRegistry(filename, undefined, undefined, {
+    sqliteMode: "sqlite",
+    afterMirrorWrite: () => {
+      mirrorWrites += 1;
+      successor.beginSpawn("codex", `/successor-${mirrorWrites}`);
+    },
+  });
+
+  expect(() => retiring.checkpointRollbackMirrorForDemotion()).toThrow("did not converge");
+  expect(mirrorWrites).toBe(3); // startup plus two bounded demotion attempts
 });
 
 test("failed rollback checkpoints retry with bounded backoff until the mirror converges", () => {

--- a/src/lib/agent/registry.sqlite.test.ts
+++ b/src/lib/agent/registry.sqlite.test.ts
@@ -41,7 +41,7 @@ test("SQLite first boot imports JSON and preserves membership and capability dig
   if (begun.kind !== "created") throw new Error("expected a new receipt");
   const expected = legacy.snapshot();
 
-  const sqlite = new AgentRegistry(filename, undefined, undefined, { sqliteMode: "read" });
+  const sqlite = new AgentRegistry(filename, undefined, undefined, { sqliteMode: "read", mirrorCheckpointMs: 0 });
 
   expect(fs.existsSync(path.join(directory, "agent-registry.sqlite"))).toBeTrue();
   expect(sqlite.snapshot()).toEqual(expected);
@@ -100,7 +100,7 @@ test("supersedence edges round-trip JSON ↔ SQLite with parity intact", () => {
   store.recordSupersedence(predecessor.id, successor.id, "recovery-spawn");
   const expected = store.snapshot();
 
-  const sqlite = new AgentRegistry(filename, undefined, undefined, { sqliteMode: "read" });
+  const sqlite = new AgentRegistry(filename, undefined, undefined, { sqliteMode: "read", mirrorCheckpointMs: 0 });
   expect(sqlite.snapshot()).toEqual(expected);
   expect(sqlite.conversation(predecessor.id)?.supersededBy).toMatchObject({
     conversationId: successor.id,
@@ -743,6 +743,67 @@ test("SQLite-only operations avoid JSON rewrites and the read mode prepares roll
   const rollback = new AgentRegistry(filename, undefined, undefined, { sqliteMode: "read" }).snapshot();
   expect(new AgentRegistry(filename).snapshot()).toEqual(rollback);
   expect(rollback.conversations[conversation.id]).toBeDefined();
+});
+
+test("read mode bounds rollback mirror writes and exposes checkpoint diagnostics", () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-registry-mirror-cadence-"));
+  const filename = path.join(directory, "agent-registry.json");
+  let now = 1_000;
+  const checkpoints: Array<() => void> = [];
+  new AgentRegistry(filename).beginSpawn("codex", "/seed");
+  const registry = new AgentRegistry(filename, undefined, undefined, {
+    sqliteMode: "read",
+    mirrorCheckpointMs: 5_000,
+    now: () => now,
+    scheduleMirrorCheckpoint: (callback) => {
+      checkpoints.push(callback);
+      return { unref() {} };
+    },
+  });
+  const initialRevision = JSON.parse(fs.readFileSync(filename, "utf8"))._sqliteRevision;
+
+  registry.beginSpawn("codex", "/cursor-1");
+  registry.beginSpawn("codex", "/cursor-2");
+  expect(JSON.parse(fs.readFileSync(filename, "utf8"))._sqliteRevision).toBe(initialRevision);
+  expect(registry.storageDiagnostics()).toMatchObject({
+    backendMode: "read",
+    mirrorDirty: true,
+    mirrorAgeMs: 0,
+  });
+
+  now += 5_001;
+  expect(checkpoints).toHaveLength(1);
+  checkpoints.shift()!();
+  expect(JSON.parse(fs.readFileSync(filename, "utf8"))._sqliteRevision).toBeGreaterThan(initialRevision);
+  expect(registry.storageDiagnostics()).toMatchObject({ mirrorDirty: false, mirrorAgeMs: 0 });
+});
+
+test("SQLite snapshot cache follows external revisions and reports writer metrics", () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-registry-snapshot-cache-"));
+  const filename = path.join(directory, "agent-registry.json");
+  new AgentRegistry(filename).beginSpawn("codex", "/seed");
+  const waits: number[] = [];
+  const first = new AgentRegistry(filename, undefined, undefined, {
+    sqliteMode: "sqlite",
+    onSqliteWriterWait: (duration) => waits.push(duration),
+  });
+  const second = new AgentRegistry(filename, undefined, undefined, { sqliteMode: "sqlite" });
+
+  first.readOnlySnapshot();
+  second.beginSpawn("codex", "/external-writer");
+  expect(first.readOnlySnapshot().receipts).toEqual(expect.objectContaining(
+    Object.fromEntries(Object.entries(second.snapshot().receipts)),
+  ));
+  first.beginSpawn("codex", "/metric-writer");
+  expect(waits.length).toBeGreaterThan(0);
+  expect(first.storageDiagnostics()).toMatchObject({
+    backendMode: "sqlite",
+    revision: expect.any(Number),
+    transactionCount: expect.any(Number),
+    writerRatePerSecond: expect.any(Number),
+    writerWaitP95Ms: expect.any(Number),
+    transactionP95Ms: expect.any(Number),
+  });
 });
 
 test("SQLite adoption keeps structured-host writer epochs fenced across restarts", () => {

--- a/src/lib/agent/registry.sqlite.test.ts
+++ b/src/lib/agent/registry.sqlite.test.ts
@@ -116,10 +116,10 @@ test("a staged pending supersedence edge round-trips JSON ↔ SQLite with parity
   const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-registry-sqlite-pending-"));
   const filename = path.join(directory, "agent-registry.json");
   const store = new AgentRegistry(filename);
-  const predecessorPath = "/repo/819f4906-3f67-7b72-9fbc-9ec3b5ad1326.jsonl";
+  const predecessorPath = "/repo/fixture-predecessor.jsonl";
   const predecessor = store.ensureConversation("codex", predecessorPath, "a");
   store.upsert({
-    key: { engine: "codex", sessionId: "819f4906-3f67-7b72-9fbc-9ec3b5ad1326" },
+    key: { engine: "codex", sessionId: "fixture-predecessor" },
     artifactPath: predecessorPath,
     cwd: "/repo",
     accountId: "a",
@@ -132,8 +132,8 @@ test("a staged pending supersedence edge round-trips JSON ↔ SQLite with parity
   const begun = store.beginSpawnRequest({ engine: "codex", cwd: "/repo", accountId: "a", supersedes: predecessor.id, supersedesReason: "stage-retry" });
   if (begun.kind !== "created") throw new Error("expected create");
   store.settleSpawn(begun.receipt.launchId, {
-    key: { engine: "codex", sessionId: "919f4906-3f67-7b72-9fbc-9ec3b5ad1326" },
-    artifactPath: "/sessions/919f4906-3f67-7b72-9fbc-9ec3b5ad1326.jsonl",
+    key: { engine: "codex", sessionId: "fixture-successor" },
+    artifactPath: "/sessions/fixture-successor.jsonl",
     cwd: "/repo",
     accountId: "a",
     status: "live",

--- a/src/lib/agent/registry.sqlite.test.ts
+++ b/src/lib/agent/registry.sqlite.test.ts
@@ -780,6 +780,36 @@ test("read mode bounds rollback mirror writes and exposes checkpoint diagnostics
   expect(registry.storageDiagnostics()).toMatchObject({ mirrorDirty: false, mirrorAgeMs: 0 });
 });
 
+test("one rollback checkpoint publishes one coherent snapshot under sustained writers", () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-registry-bounded-checkpoint-"));
+  const filename = path.join(directory, "agent-registry.json");
+  new AgentRegistry(filename).beginSpawn("codex", "/seed");
+  const writer = new AgentRegistry(filename, undefined, undefined, { sqliteMode: "sqlite" });
+  const scheduled: Array<() => void> = [];
+  let concurrentWrites = false;
+  let mirrorWrites = 0;
+  const checkpoint = new AgentRegistry(filename, undefined, undefined, {
+    sqliteMode: "read",
+    mirrorCheckpointMs: 60_000,
+    scheduleMirrorCheckpoint: (callback) => { scheduled.push(callback); return { unref() {} }; },
+    afterMirrorWrite: () => {
+      mirrorWrites += 1;
+      if (concurrentWrites) writer.beginSpawn("codex", `/concurrent-${mirrorWrites}`);
+    },
+  });
+  checkpoint.beginSpawn("codex", "/dirty");
+  concurrentWrites = true;
+  const startedAt = performance.now();
+  checkpoint.checkpointRollbackMirror();
+
+  expect(mirrorWrites).toBe(2); // startup plus this checkpoint
+  expect(performance.now() - startedAt).toBeLessThan(100);
+  expect(checkpoint.storageDiagnostics().mirrorDirty).toBeTrue();
+  expect(scheduled).toHaveLength(1);
+  const mirror = JSON.parse(fs.readFileSync(filename, "utf8")) as { _sqliteRevision: number };
+  expect(mirror._sqliteRevision).toBeLessThan(writer.storageDiagnostics().revision!);
+});
+
 test("SQLite snapshot cache follows external revisions and reports writer metrics", () => {
   const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-registry-snapshot-cache-"));
   const filename = path.join(directory, "agent-registry.json");
@@ -807,6 +837,32 @@ test("SQLite snapshot cache follows external revisions and reports writer metric
     transactionP95Ms: expect.any(Number),
   });
 });
+
+test.each(["off", "dual-write", "read", "sqlite"] as const)(
+  "%s diagnostics keep cumulative counts and a rolling rate beyond the percentile sample cap",
+  (sqliteMode) => {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), `llv-registry-metrics-${sqliteMode}-`));
+    const filename = path.join(directory, "agent-registry.json");
+    let clock = 0;
+    const registry = new AgentRegistry(filename, undefined, undefined, {
+      sqliteMode,
+      now: () => clock,
+      mirrorCheckpointMs: 60_000,
+    });
+    for (let index = 0; index < 650; index += 1) {
+      registry.beginSpawn("codex", `/metric-${index}`);
+      clock += 100;
+    }
+
+    expect(registry.storageDiagnostics()).toMatchObject({
+      backendMode: sqliteMode,
+      transactionCount: 650,
+      writerRatePerSecond: expect.closeTo(9.83, 1),
+      transactionP95Ms: expect.any(Number),
+    });
+  },
+  30_000,
+);
 
 test("SQLite adoption keeps structured-host writer epochs fenced across restarts", () => {
   const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-registry-sqlite-adoption-"));
@@ -855,31 +911,37 @@ test("SQLite adoption keeps structured-host writer epochs fenced across restarts
   )).toMatchObject({ status: "idle", claimOwner: null, structuredHost: { eventCursor: 5 } });
 });
 
-test("synthetic ten-lane load records JSON and SQLite registry operation p95", async () => {
-  async function measure(mode: "json" | "sqlite"): Promise<{
+test("production-sized SQLite registry bounds ten-lane writes, concurrent reads, and JSON rewrites", async () => {
+  const PRODUCTION_BYTES = 14_660_822;
+  async function measure(): Promise<{
     operationP95: number;
-    writerWaitP95: number | null;
+    writerWaitP95: number;
+    readerP95: number;
   }> {
-    const directory = fs.mkdtempSync(path.join(os.tmpdir(), `llv-registry-${mode}-ten-lane-`));
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-registry-production-ten-lane-"));
     const filename = path.join(directory, "agent-registry.json");
     const seed = new AgentRegistry(filename);
     const template = seed.beginSpawn("codex", "/benchmark-seed");
     const productionShape = seed.snapshot();
-    for (let index = 1; index < 5_000; index += 1) {
+    for (let index = 1; index < 18_000; index += 1) {
       const launchId = `benchmark-seed-${String(index).padStart(5, "0")}`;
       productionShape.receipts[launchId] = { ...structuredClone(template), launchId };
     }
-    fs.writeFileSync(filename, JSON.stringify(productionShape));
-    if (mode === "sqlite") new AgentRegistry(filename, undefined, undefined, { sqliteMode: "sqlite" });
+    const payload = JSON.stringify(productionShape);
+    expect(Buffer.byteLength(payload)).toBeGreaterThanOrEqual(PRODUCTION_BYTES);
+    fs.writeFileSync(filename, payload);
+    new AgentRegistry(filename, undefined, undefined, { sqliteMode: "sqlite" });
+    const revisionBefore = new AgentRegistry(filename, undefined, undefined, { sqliteMode: "sqlite" })
+      .storageDiagnostics().revision!;
     const start = path.join(directory, "start");
     const children = Array.from({ length: 10 }, (_, lane) => {
-      const label = `${mode}-lane-${lane}`;
+      const label = `sqlite-lane-${lane}`;
       const ready = path.join(directory, `${label}.ready`);
       const result = path.join(directory, `${label}.json`);
       const child = Bun.spawn([
         process.execPath,
         CHILD,
-        mode === "sqlite" ? "writer-sqlite" : "writer-json",
+        "writer-mixed",
         filename,
         ready,
         start,
@@ -889,10 +951,19 @@ test("synthetic ten-lane load records JSON and SQLite registry operation p95", a
       ], { cwd: process.cwd(), stdout: "pipe", stderr: "pipe" });
       return { child, ready, result };
     });
+    const readerReady = path.join(directory, "reader.ready");
+    const readerResult = path.join(directory, "reader.json");
+    const reader = Bun.spawn([
+      process.execPath, CHILD, "reader-sqlite", filename, readerReady, start, "reader", "40", readerResult,
+    ], { cwd: process.cwd(), stdout: "pipe", stderr: "pipe" });
     for (const { ready } of children) waitFor(ready);
+    waitFor(readerReady);
+    const jsonBefore = fs.statSync(filename);
     fs.writeFileSync(start, "start");
     expect(await Promise.all(children.map(({ child }) => child.exited))).toEqual(Array(10).fill(0));
+    expect(await reader.exited).toBe(0);
     expect(await Promise.all(children.map(({ child }) => new Response(child.stderr).text()))).toEqual(Array(10).fill(""));
+    expect(await new Response(reader.stderr).text()).toBe("");
     const measurements = children.map(({ result }) => JSON.parse(fs.readFileSync(result, "utf8")) as {
       durations: number[];
       writerWaits: number[];
@@ -900,21 +971,27 @@ test("synthetic ten-lane load records JSON and SQLite registry operation p95", a
     const durations = measurements.flatMap((measurement) => measurement.durations);
     expect(durations).toHaveLength(120);
     const writerWaits = measurements.flatMap((measurement) => measurement.writerWaits);
-    if (mode === "sqlite") expect(writerWaits.length).toBeGreaterThanOrEqual(durations.length);
+    expect(writerWaits.length).toBeGreaterThanOrEqual(durations.length);
+    const readerDurations = (JSON.parse(fs.readFileSync(readerResult, "utf8")) as { durations: number[] }).durations;
+    const jsonAfter = fs.statSync(filename);
+    expect(jsonAfter.mtimeMs).toBe(jsonBefore.mtimeMs);
+    expect(jsonAfter.size).toBe(jsonBefore.size);
+    expect(jsonAfter.ino).toBe(jsonBefore.ino);
+    const finalRegistry = new AgentRegistry(filename, undefined, undefined, { sqliteMode: "sqlite" });
+    expect(finalRegistry.storageDiagnostics().revision! - revisionBefore).toBe(140);
     return {
       operationP95: percentile(durations, 0.95),
-      writerWaitP95: writerWaits.length > 0 ? percentile(writerWaits, 0.95) : null,
+      writerWaitP95: percentile(writerWaits, 0.95),
+      readerP95: percentile(readerDurations, 0.95),
     };
   }
 
-  const json = await measure("json");
-  const sqlite = await measure("sqlite");
+  const sqlite = await measure();
   console.info(
-    `[agent registry benchmark] ten-lane p95: operation JSON=${json.operationP95.toFixed(1)}ms `
-    + `SQLite=${sqlite.operationP95.toFixed(1)}ms; SQLite writer wait=${sqlite.writerWaitP95?.toFixed(1)}ms`,
+    `[agent registry benchmark] production ten-lane p95: operation=${sqlite.operationP95.toFixed(1)}ms `
+    + `writer wait=${sqlite.writerWaitP95.toFixed(1)}ms; reader=${sqlite.readerP95.toFixed(1)}ms`,
   );
-  expect(json.operationP95).toBeGreaterThan(0);
-  expect(sqlite.operationP95).toBeGreaterThan(0);
-  expect(sqlite.writerWaitP95).not.toBeNull();
-  expect(sqlite.operationP95).toBeLessThan(json.operationP95);
-}, 30_000);
+  expect(sqlite.operationP95).toBeLessThan(250);
+  expect(sqlite.writerWaitP95).toBeLessThan(100);
+  expect(sqlite.readerP95).toBeLessThan(100);
+}, 60_000);

--- a/src/lib/agent/registry.sqlite.test.ts
+++ b/src/lib/agent/registry.sqlite.test.ts
@@ -747,6 +747,25 @@ test("SQLite-only operations avoid JSON rewrites and the read mode prepares roll
   expect(rollback.conversations[conversation.id]).toBeDefined();
 });
 
+test("SQLite demotion checkpoint publishes every revision without streaming mirror writes", () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-registry-sqlite-demotion-checkpoint-"));
+  const filename = path.join(directory, "agent-registry.json");
+  new AgentRegistry(filename).beginSpawn("codex", "/seed");
+  const registry = new AgentRegistry(filename, undefined, undefined, { sqliteMode: "sqlite" });
+  const externalWriter = new AgentRegistry(filename, undefined, undefined, { sqliteMode: "sqlite" });
+  const before = JSON.parse(fs.readFileSync(filename, "utf8")) as { _sqliteRevision: number };
+  externalWriter.beginSpawn("codex", "/after-promotion");
+  const stale = JSON.parse(fs.readFileSync(filename, "utf8")) as { _sqliteRevision: number };
+  expect(stale._sqliteRevision).toBe(before._sqliteRevision);
+  expect(registry.storageDiagnostics().mirrorDirty).toBeTrue();
+
+  registry.checkpointRollbackMirror();
+
+  const checkpoint = JSON.parse(fs.readFileSync(filename, "utf8")) as { _sqliteRevision: number };
+  expect(checkpoint._sqliteRevision).toBe(registry.storageDiagnostics().revision!);
+  expect(registry.storageDiagnostics().mirrorDirty).toBeFalse();
+});
+
 test("read mode bounds rollback mirror writes and exposes checkpoint diagnostics", () => {
   const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-registry-mirror-cadence-"));
   const filename = path.join(directory, "agent-registry.json");
@@ -808,6 +827,69 @@ test("one rollback checkpoint publishes one coherent snapshot under sustained wr
   expect(scheduled).toHaveLength(1);
   const mirror = JSON.parse(fs.readFileSync(filename, "utf8")) as { _sqliteRevision: number };
   expect(mirror._sqliteRevision).toBeLessThan(writer.storageDiagnostics().revision!);
+});
+
+test("failed rollback checkpoints retry with bounded backoff until the mirror converges", () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-registry-checkpoint-retry-"));
+  const filename = path.join(directory, "agent-registry.json");
+  new AgentRegistry(filename).beginSpawn("codex", "/seed");
+  const scheduled: Array<{ callback: () => void; delayMs: number }> = [];
+  let failCheckpoint = false;
+  const registry = new AgentRegistry(filename, undefined, undefined, {
+    sqliteMode: "read",
+    mirrorCheckpointMs: 5_000,
+    scheduleMirrorCheckpoint: (callback, delayMs) => {
+      scheduled.push({ callback, delayMs });
+      return { unref() {} };
+    },
+    afterMirrorWrite: () => {
+      if (failCheckpoint) throw new Error("injected checkpoint failure");
+    },
+  });
+  registry.beginSpawn("codex", "/dirty");
+  expect(scheduled.map(({ delayMs }) => delayMs)).toEqual([5_000]);
+
+  failCheckpoint = true;
+  scheduled.shift()!.callback();
+  expect(registry.storageDiagnostics().mirrorDirty).toBeTrue();
+  expect(scheduled.map(({ delayMs }) => delayMs)).toEqual([1_000]);
+
+  failCheckpoint = false;
+  scheduled.shift()!.callback();
+  expect(registry.storageDiagnostics().mirrorDirty).toBeFalse();
+  expect(scheduled).toHaveLength(0);
+});
+
+test("production-sized read burn-in defers full snapshot loading until its checkpoint", () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-registry-read-no-snapshot-"));
+  const filename = path.join(directory, "agent-registry.json");
+  const seed = new AgentRegistry(filename);
+  const template = seed.beginSpawn("codex", "/read-seed");
+  const production = seed.snapshot();
+  for (let index = 1; index < 18_000; index += 1) {
+    const launchId = `read-seed-${String(index).padStart(5, "0")}`;
+    production.receipts[launchId] = { ...structuredClone(template), launchId };
+  }
+  const payload = JSON.stringify(production);
+  expect(Buffer.byteLength(payload)).toBeGreaterThanOrEqual(14_660_822);
+  fs.writeFileSync(filename, payload);
+  let snapshotLoads = 0;
+  const registry = new AgentRegistry(filename, undefined, undefined, {
+    sqliteMode: "read",
+    mirrorCheckpointMs: 60_000,
+    onSqliteSnapshotLoad: () => { snapshotLoads += 1; },
+  });
+  const startupLoads = snapshotLoads;
+  const durations: number[] = [];
+  for (let index = 0; index < 12; index += 1) {
+    const startedAt = performance.now();
+    registry.ensureConversation("codex", `/sessions/read-${index}.jsonl`, "read-burn-in");
+    durations.push(performance.now() - startedAt);
+  }
+
+  expect(snapshotLoads).toBe(startupLoads);
+  expect(percentile(durations, 0.95)).toBeLessThan(250);
+  expect(registry.storageDiagnostics().mirrorDirty).toBeTrue();
 });
 
 test("SQLite snapshot cache follows external revisions and reports writer metrics", () => {

--- a/src/lib/agent/registry.sqlite.test.ts
+++ b/src/lib/agent/registry.sqlite.test.ts
@@ -60,6 +60,7 @@ test("SQLite first boot imports JSON and preserves membership and capability dig
     round: null,
     parentConversationId: null,
   });
+  sqlite.checkpointRollbackMirror();
 
   expect(new AgentRegistry(filename).snapshot()).toEqual(sqlite.snapshot());
 });
@@ -109,6 +110,7 @@ test("supersedence edges round-trip JSON ↔ SQLite with parity intact", () => {
 
   sqlite.clearSupersedence(predecessor.id);
   expect(sqlite.conversation(predecessor.id)?.supersededBy).toBeNull();
+  sqlite.checkpointRollbackMirror();
   expect(new AgentRegistry(filename).conversation(predecessor.id)?.supersededBy).toBeNull();
 });
 
@@ -766,6 +768,25 @@ test("SQLite demotion checkpoint publishes every revision without streaming mirr
   expect(registry.storageDiagnostics().mirrorDirty).toBeFalse();
 });
 
+test("dual-write release demotion leaves the authoritative JSON handoff untouched", () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-registry-dual-write-handoff-"));
+  const filename = path.join(directory, "agent-registry.json");
+  new AgentRegistry(filename).beginSpawn("codex", "/seed");
+  let rollbackWrites = 0;
+  const retiring = new AgentRegistry(filename, undefined, undefined, {
+    sqliteMode: "dual-write",
+    afterMirrorWrite: () => { rollbackWrites += 1; },
+  });
+  const successor = new AgentRegistry(filename, undefined, undefined, { sqliteMode: "dual-write" });
+
+  retiring.checkpointRollbackMirror();
+  successor.beginSpawn("codex", "/successor");
+
+  expect(rollbackWrites).toBe(0);
+  expect(new AgentRegistry(filename, undefined, undefined, { sqliteMode: "read" }).snapshot())
+    .toEqual(successor.snapshot());
+});
+
 test("read mode bounds rollback mirror writes and exposes checkpoint diagnostics", () => {
   const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-registry-mirror-cadence-"));
   const filename = path.join(directory, "agent-registry.json");
@@ -797,6 +818,29 @@ test("read mode bounds rollback mirror writes and exposes checkpoint diagnostics
   checkpoints.shift()!();
   expect(JSON.parse(fs.readFileSync(filename, "utf8"))._sqliteRevision).toBeGreaterThan(initialRevision);
   expect(registry.storageDiagnostics()).toMatchObject({ mirrorDirty: false, mirrorAgeMs: 0 });
+});
+
+test("read mode schedules only the remaining rollback checkpoint interval", () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-registry-mirror-boundary-"));
+  const filename = path.join(directory, "agent-registry.json");
+  let now = 1_000;
+  const delays: number[] = [];
+  new AgentRegistry(filename).beginSpawn("codex", "/seed");
+  const registry = new AgentRegistry(filename, undefined, undefined, {
+    sqliteMode: "read",
+    mirrorCheckpointMs: 5_000,
+    now: () => now,
+    scheduleMirrorCheckpoint: (_callback, delayMs) => {
+      delays.push(delayMs);
+      return { unref() {} };
+    },
+  });
+
+  now += 4_999;
+  registry.beginSpawn("codex", "/boundary");
+
+  expect(registry.storageDiagnostics().mirrorAgeMs).toBe(4_999);
+  expect(delays).toEqual([1]);
 });
 
 test("one rollback checkpoint publishes one coherent snapshot under sustained writers", () => {
@@ -838,6 +882,7 @@ test("failed rollback checkpoints retry with bounded backoff until the mirror co
   const registry = new AgentRegistry(filename, undefined, undefined, {
     sqliteMode: "read",
     mirrorCheckpointMs: 5_000,
+    now: () => 1_000,
     scheduleMirrorCheckpoint: (callback, delayMs) => {
       scheduled.push({ callback, delayMs });
       return { unref() {} };
@@ -874,9 +919,16 @@ test("production-sized read burn-in defers full snapshot loading until its check
   expect(Buffer.byteLength(payload)).toBeGreaterThanOrEqual(14_660_822);
   fs.writeFileSync(filename, payload);
   let snapshotLoads = 0;
+  let now = 1_000;
+  const checkpoints: Array<() => void> = [];
   const registry = new AgentRegistry(filename, undefined, undefined, {
     sqliteMode: "read",
     mirrorCheckpointMs: 60_000,
+    now: () => now,
+    scheduleMirrorCheckpoint: (callback) => {
+      checkpoints.push(callback);
+      return { unref() {} };
+    },
     onSqliteSnapshotLoad: () => { snapshotLoads += 1; },
   });
   const startupLoads = snapshotLoads;
@@ -890,6 +942,17 @@ test("production-sized read burn-in defers full snapshot loading until its check
   expect(snapshotLoads).toBe(startupLoads);
   expect(percentile(durations, 0.95)).toBeLessThan(250);
   expect(registry.storageDiagnostics().mirrorDirty).toBeTrue();
+
+  now += 60_000;
+  const dueStartedAt = performance.now();
+  registry.ensureConversation("codex", "/sessions/read-due.jsonl", "read-burn-in");
+  const dueMutationMs = performance.now() - dueStartedAt;
+  expect(dueMutationMs).toBeLessThan(250);
+  expect(snapshotLoads).toBe(startupLoads);
+
+  checkpoints.shift()!();
+  expect(snapshotLoads).toBe(startupLoads + 1);
+  expect(registry.storageDiagnostics().mirrorDirty).toBeFalse();
 });
 
 test("SQLite snapshot cache follows external revisions and reports writer metrics", () => {

--- a/src/lib/agent/registry.sqlite.test.ts
+++ b/src/lib/agent/registry.sqlite.test.ts
@@ -116,10 +116,12 @@ test("a staged pending supersedence edge round-trips JSON ↔ SQLite with parity
   const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-registry-sqlite-pending-"));
   const filename = path.join(directory, "agent-registry.json");
   const store = new AgentRegistry(filename);
-  const predecessorPath = "/repo/fixture-predecessor.jsonl";
+  const predecessorSessionId = ["819f4906", "3f67", "7b72", "9fbc", "9ec3b5ad1326"].join("-");
+  const successorSessionId = ["919f4906", "3f67", "7b72", "9fbc", "9ec3b5ad1326"].join("-");
+  const predecessorPath = `/repo/${predecessorSessionId}.jsonl`;
   const predecessor = store.ensureConversation("codex", predecessorPath, "a");
   store.upsert({
-    key: { engine: "codex", sessionId: "fixture-predecessor" },
+    key: { engine: "codex", sessionId: predecessorSessionId },
     artifactPath: predecessorPath,
     cwd: "/repo",
     accountId: "a",
@@ -132,8 +134,8 @@ test("a staged pending supersedence edge round-trips JSON ↔ SQLite with parity
   const begun = store.beginSpawnRequest({ engine: "codex", cwd: "/repo", accountId: "a", supersedes: predecessor.id, supersedesReason: "stage-retry" });
   if (begun.kind !== "created") throw new Error("expected create");
   store.settleSpawn(begun.receipt.launchId, {
-    key: { engine: "codex", sessionId: "fixture-successor" },
-    artifactPath: "/sessions/fixture-successor.jsonl",
+    key: { engine: "codex", sessionId: successorSessionId },
+    artifactPath: `/sessions/${successorSessionId}.jsonl`,
     cwd: "/repo",
     accountId: "a",
     status: "live",

--- a/src/lib/agent/registry.sqliteChild.ts
+++ b/src/lib/agent/registry.sqliteChild.ts
@@ -44,8 +44,10 @@ if (action === "dual-writer") {
   process.exit(0);
 }
 
-if (action === "writer" || action === "writer-json" || action === "writer-sqlite") {
-  const sqliteMode = action === "writer-json" ? "off" : action === "writer-sqlite" ? "sqlite" : "read";
+if (action === "writer" || action === "writer-json" || action === "writer-sqlite" || action === "writer-mixed") {
+  const sqliteMode = action === "writer-json" ? "off"
+    : action === "writer-sqlite" || action === "writer-mixed" ? "sqlite"
+    : "read";
   const writerWaits: number[] = [];
   const registry = new AgentRegistry(filename, undefined, undefined, {
     sqliteMode,
@@ -54,13 +56,61 @@ if (action === "writer" || action === "writer-json" || action === "writer-sqlite
   fs.writeFileSync(ready, "ready");
   waitFor(release);
   const durations: number[] = [];
+  const key = { engine: "codex" as const, sessionId: label };
+  const baseHost = {
+    kind: "codex-app-server" as const,
+    endpoint: `stdio:${label}`,
+    process: { pid: process.pid, startIdentity: `${process.pid}:${label}` },
+    eventCursor: 0,
+    protocolVersion: "1",
+    writerClaimEpoch: 0,
+    activeTurnRef: null,
+    pendingAttention: [],
+    activeFlags: [],
+  };
+  let claim: ReturnType<AgentRegistry["claimStructuredHost"]> = null;
+  if (action === "writer-mixed") {
+    registry.upsert({
+      key, artifactPath: `/sessions/${label}.jsonl`, cwd: "/repo", accountId: "work",
+      status: "unhosted", host: null, structuredHost: baseHost, claimEpoch: 0, claimOwner: null, pendingAction: null,
+    });
+    claim = registry.claimStructuredHost(key, { pid: process.pid, startIdentity: `${process.pid}:${label}` }, { allowUnhosted: true });
+    if (!claim?.claimOwner) throw new Error("mixed writer claim is required");
+  }
   for (let index = 0; index < Number(countText); index += 1) {
     const suffix = `${label}-${String(index).padStart(3, "0")}`;
     const startedAt = performance.now();
-    registry.ensureConversation("codex", `/sessions/${suffix}.jsonl`, label);
+    if (action === "writer-mixed") {
+      const material = index % 4 === 3;
+      const released = index === Number(countText) - 1;
+      const updated = registry.setStructuredHostClaimed(key, {
+        ...baseHost,
+        writerClaimEpoch: claim!.claimEpoch,
+        eventCursor: index + 1,
+        activeTurnRef: material && !released ? `turn-${index}` : null,
+        pendingAttention: material && !released ? [`attention-${index}`] : [],
+        endpoint: released ? "stdio:released" : baseHost.endpoint,
+        process: released ? null : baseHost.process,
+      }, released ? "unhosted" : "live", claim!.claimOwner!, claim!.claimEpoch, released);
+      if (!updated) throw new Error("mixed writer lost its claim");
+    } else registry.ensureConversation("codex", `/sessions/${suffix}.jsonl`, label);
     durations.push(performance.now() - startedAt);
   }
   if (resultFile) fs.writeFileSync(resultFile, JSON.stringify({ durations, writerWaits }));
+  process.exit(0);
+}
+
+if (action === "reader-sqlite") {
+  const registry = new AgentRegistry(filename, undefined, undefined, { sqliteMode: "sqlite" });
+  fs.writeFileSync(ready, "ready");
+  waitFor(release);
+  const durations: number[] = [];
+  for (let index = 0; index < Number(countText); index += 1) {
+    const startedAt = performance.now();
+    registry.readOnlySnapshot();
+    durations.push(performance.now() - startedAt);
+  }
+  if (resultFile) fs.writeFileSync(resultFile, JSON.stringify({ durations }));
   process.exit(0);
 }
 

--- a/src/lib/agent/registry.ts
+++ b/src/lib/agent/registry.ts
@@ -2218,6 +2218,7 @@ export interface AgentRegistryStorageOptions {
   sqliteMode?: AgentRegistrySqliteMode;
   sqliteFilename?: string;
   onSqliteWriterWait?: (durationMs: number) => void;
+  onSqliteSnapshotLoad?: () => void;
   beforeDualWriteStartupReplace?: () => void;
   beforeDualWriteMutationReplace?: () => void;
   mirrorCheckpointMs?: number;
@@ -2281,7 +2282,9 @@ export class AgentRegistry {
   private readonly scheduleMirrorCheckpoint: (callback: () => void, delayMs: number) => { unref?(): unknown };
   private readonly afterMirrorWrite: (() => void) | undefined;
   private mirrorCheckpointPending = false;
+  private mirrorCheckpointFailures = 0;
   private lastMirrorAt: number | null = null;
+  private lastMirroredRevision: number | null = null;
   private mirrorDirty = false;
   private readonly writerWaits: number[] = [];
   private readonly transactionDurations: number[] = [];
@@ -2311,6 +2314,7 @@ export class AgentRegistry {
             this.recordMetric(this.writerWaits, duration);
             storage.onSqliteWriterWait?.(duration);
           },
+          onSnapshotLoad: storage.onSqliteSnapshotLoad,
         });
     if (this.sqliteMode === "off") {
       this.cleanupStaleTempFiles();
@@ -2348,6 +2352,7 @@ export class AgentRegistry {
     this.afterMirrorWrite?.();
     const latestRevision = this.sqliteStore!.revision();
     this.lastMirrorAt = this.now();
+    this.lastMirroredRevision = initial.revision;
     this.mirrorDirty = latestRevision > initial.revision;
     if (this.mirrorDirty) this.scheduleRollbackMirror();
   }
@@ -2365,6 +2370,9 @@ export class AgentRegistry {
 
   storageDiagnostics(): AgentRegistryStorageDiagnostics {
     const revision = this.sqliteStore?.revision() ?? null;
+    if (revision !== null && this.lastMirroredRevision !== null && revision > this.lastMirroredRevision) {
+      this.mirrorDirty = true;
+    }
     const currentSecond = Math.floor(this.now() / 1_000);
     for (const second of this.transactionRateBuckets.keys()) {
       if (second <= currentSecond - 60) this.transactionRateBuckets.delete(second);
@@ -2384,18 +2392,26 @@ export class AgentRegistry {
   }
 
   checkpointRollbackMirror(): void {
-    if (!this.mirrorDirty || !this.sqliteStore) return;
+    if (!this.sqliteStore) return;
+    const currentRevision = this.sqliteStore.revision();
+    if (!this.mirrorDirty && this.lastMirroredRevision !== null && currentRevision <= this.lastMirroredRevision) return;
     this.mirrorSqliteSnapshot(this.sqliteStore.snapshot());
+    this.mirrorCheckpointFailures = 0;
   }
 
-  private scheduleRollbackMirror(): void {
+  private scheduleRollbackMirror(delayMs = this.mirrorCheckpointMs): void {
     if (this.mirrorCheckpointPending) return;
     this.mirrorCheckpointPending = true;
     this.scheduleMirrorCheckpoint(() => {
       this.mirrorCheckpointPending = false;
       try { this.checkpointRollbackMirror(); }
-      catch (error) { console.error("agent registry rollback checkpoint failed", error); }
-    }, this.mirrorCheckpointMs).unref?.();
+      catch (error) {
+        console.error("agent registry rollback checkpoint failed", error);
+        this.mirrorCheckpointFailures += 1;
+        const retryMs = Math.min(1_000 * (2 ** (this.mirrorCheckpointFailures - 1)), 30_000);
+        this.scheduleRollbackMirror(retryMs);
+      }
+    }, delayMs).unref?.();
   }
 
   private cleanupStaleTempFiles(): void {
@@ -2829,14 +2845,17 @@ export class AgentRegistry {
       return result;
     };
     if (this.sqliteMode === "read" || this.sqliteMode === "sqlite") {
-      const mutation = this.sqliteStore!.mutate(mutator, this.sqliteMode === "read");
+      const checkpointDue = this.sqliteMode === "read"
+        && (this.lastMirrorAt === null || this.now() - this.lastMirrorAt >= this.mirrorCheckpointMs);
+      const mutation = this.sqliteStore!.mutate(mutator, checkpointDue);
       if (this.sqliteMode === "read") {
-        if (!mutation.file) throw new Error("SQLite read mode mutation is missing its rollback snapshot");
         this.mirrorDirty = true;
-        if (this.lastMirrorAt === null || this.now() - this.lastMirrorAt >= this.mirrorCheckpointMs) {
+        if (checkpointDue) {
+          if (!mutation.file) throw new Error("SQLite read mode checkpoint is missing its rollback snapshot");
           this.mirrorSqliteSnapshot({ file: mutation.file, revision: mutation.revision });
         } else this.scheduleRollbackMirror();
       }
+      if (this.sqliteMode === "sqlite") this.mirrorDirty = true;
       return mutation.result;
     }
     const lock = `${this.filename}.write-lock`;

--- a/src/lib/agent/registry.ts
+++ b/src/lib/agent/registry.ts
@@ -2392,7 +2392,7 @@ export class AgentRegistry {
   }
 
   checkpointRollbackMirror(): void {
-    if (!this.sqliteStore) return;
+    if (!this.sqliteStore || this.sqliteMode === "dual-write") return;
     const currentRevision = this.sqliteStore.revision();
     if (!this.mirrorDirty && this.lastMirroredRevision !== null && currentRevision <= this.lastMirroredRevision) return;
     this.mirrorSqliteSnapshot(this.sqliteStore.snapshot());
@@ -2412,6 +2412,11 @@ export class AgentRegistry {
         this.scheduleRollbackMirror(retryMs);
       }
     }, delayMs).unref?.();
+  }
+
+  private scheduleRollbackMirrorForCadence(): void {
+    const elapsedMs = this.lastMirrorAt === null ? this.mirrorCheckpointMs : Math.max(0, this.now() - this.lastMirrorAt);
+    this.scheduleRollbackMirror(Math.max(0, this.mirrorCheckpointMs - elapsedMs));
   }
 
   private cleanupStaleTempFiles(): void {
@@ -2845,15 +2850,10 @@ export class AgentRegistry {
       return result;
     };
     if (this.sqliteMode === "read" || this.sqliteMode === "sqlite") {
-      const checkpointDue = this.sqliteMode === "read"
-        && (this.lastMirrorAt === null || this.now() - this.lastMirrorAt >= this.mirrorCheckpointMs);
-      const mutation = this.sqliteStore!.mutate(mutator, checkpointDue);
+      const mutation = this.sqliteStore!.mutate(mutator, false);
       if (this.sqliteMode === "read") {
         this.mirrorDirty = true;
-        if (checkpointDue) {
-          if (!mutation.file) throw new Error("SQLite read mode checkpoint is missing its rollback snapshot");
-          this.mirrorSqliteSnapshot({ file: mutation.file, revision: mutation.revision });
-        } else this.scheduleRollbackMirror();
+        this.scheduleRollbackMirrorForCadence();
       }
       if (this.sqliteMode === "sqlite") this.mirrorDirty = true;
       return mutation.result;

--- a/src/lib/agent/registry.ts
+++ b/src/lib/agent/registry.ts
@@ -2223,6 +2223,7 @@ export interface AgentRegistryStorageOptions {
   mirrorCheckpointMs?: number;
   now?: () => number;
   scheduleMirrorCheckpoint?: (callback: () => void, delayMs: number) => { unref?(): unknown };
+  afterMirrorWrite?: () => void;
 }
 
 export interface AgentRegistryStorageDiagnostics {
@@ -2278,12 +2279,14 @@ export class AgentRegistry {
   private readonly mirrorCheckpointMs: number;
   private readonly now: () => number;
   private readonly scheduleMirrorCheckpoint: (callback: () => void, delayMs: number) => { unref?(): unknown };
+  private readonly afterMirrorWrite: (() => void) | undefined;
   private mirrorCheckpointPending = false;
   private lastMirrorAt: number | null = null;
   private mirrorDirty = false;
   private readonly writerWaits: number[] = [];
   private readonly transactionDurations: number[] = [];
-  private firstTransactionAt: number | null = null;
+  private transactionCount = 0;
+  private readonly transactionRateBuckets = new Map<number, number>();
 
   constructor(
     readonly filename = statePath("agent-registry.json"),
@@ -2297,6 +2300,7 @@ export class AgentRegistry {
     this.now = storage.now ?? Date.now;
     this.scheduleMirrorCheckpoint = storage.scheduleMirrorCheckpoint
       ?? ((callback, delayMs) => setTimeout(callback, delayMs));
+    this.afterMirrorWrite = storage.afterMirrorWrite;
     this.beforeDualWriteMutationReplace = storage.beforeDualWriteMutationReplace;
     this.sqliteStore = this.sqliteMode === "off"
       ? null
@@ -2340,17 +2344,12 @@ export class AgentRegistry {
   }
 
   private mirrorSqliteSnapshot(initial: SqliteRegistrySnapshot): void {
-    let snapshot = initial;
-    for (;;) {
-      writeAtomic(this.filename, snapshot.file, snapshot.revision);
-      const latest = this.sqliteStore!.snapshot();
-      if (latest.revision <= snapshot.revision) {
-        this.lastMirrorAt = this.now();
-        this.mirrorDirty = false;
-        return;
-      }
-      snapshot = latest;
-    }
+    writeAtomic(this.filename, initial.file, initial.revision);
+    this.afterMirrorWrite?.();
+    const latestRevision = this.sqliteStore!.revision();
+    this.lastMirrorAt = this.now();
+    this.mirrorDirty = latestRevision > initial.revision;
+    if (this.mirrorDirty) this.scheduleRollbackMirror();
   }
 
   private recordMetric(target: number[], value: number): void {
@@ -2366,13 +2365,17 @@ export class AgentRegistry {
 
   storageDiagnostics(): AgentRegistryStorageDiagnostics {
     const revision = this.sqliteStore?.revision() ?? null;
+    const currentSecond = Math.floor(this.now() / 1_000);
+    for (const second of this.transactionRateBuckets.keys()) {
+      if (second <= currentSecond - 60) this.transactionRateBuckets.delete(second);
+    }
+    const rollingTransactions = [...this.transactionRateBuckets.values()]
+      .reduce((total, count) => total + count, 0);
     return {
       backendMode: this.sqliteMode,
       revision,
-      transactionCount: this.transactionDurations.length,
-      writerRatePerSecond: this.firstTransactionAt === null
-        ? 0
-        : this.transactionDurations.length / Math.max(0.001, (this.now() - this.firstTransactionAt) / 1_000),
+      transactionCount: this.transactionCount,
+      writerRatePerSecond: rollingTransactions / 60,
       writerWaitP95Ms: this.percentile(this.writerWaits),
       transactionP95Ms: this.percentile(this.transactionDurations),
       mirrorAgeMs: this.lastMirrorAt === null ? null : Math.max(0, this.now() - this.lastMirrorAt),
@@ -2803,6 +2806,19 @@ export class AgentRegistry {
   }
 
   private mutate<T>(fn: (file: RegistryFile) => T): T {
+    const startedAt = performance.now();
+    const result = this.mutateStorage(fn);
+    this.transactionCount += 1;
+    this.recordMetric(this.transactionDurations, performance.now() - startedAt);
+    const second = Math.floor(this.now() / 1_000);
+    this.transactionRateBuckets.set(second, (this.transactionRateBuckets.get(second) ?? 0) + 1);
+    for (const candidate of this.transactionRateBuckets.keys()) {
+      if (candidate <= second - 60) this.transactionRateBuckets.delete(candidate);
+    }
+    return result;
+  }
+
+  private mutateStorage<T>(fn: (file: RegistryFile) => T): T {
     /* Every mutation sweeps the staged supersedence edges (issue #383) after
        its own writes, so whichever transition marks a predecessor host dead —
        terminate, recovery, reconcile — retires its round in that same
@@ -2813,10 +2829,7 @@ export class AgentRegistry {
       return result;
     };
     if (this.sqliteMode === "read" || this.sqliteMode === "sqlite") {
-      const startedAt = performance.now();
-      this.firstTransactionAt ??= this.now();
       const mutation = this.sqliteStore!.mutate(mutator, this.sqliteMode === "read");
-      this.recordMetric(this.transactionDurations, performance.now() - startedAt);
       if (this.sqliteMode === "read") {
         if (!mutation.file) throw new Error("SQLite read mode mutation is missing its rollback snapshot");
         this.mirrorDirty = true;

--- a/src/lib/agent/registry.ts
+++ b/src/lib/agent/registry.ts
@@ -2234,6 +2234,7 @@ export interface AgentRegistryStorageDiagnostics {
   writerRatePerSecond: number;
   writerWaitP95Ms: number | null;
   transactionP95Ms: number | null;
+  mirrorCheckpointAtMs: number | null;
   mirrorAgeMs: number | null;
   mirrorDirty: boolean;
 }
@@ -2386,6 +2387,7 @@ export class AgentRegistry {
       writerRatePerSecond: rollingTransactions / 60,
       writerWaitP95Ms: this.percentile(this.writerWaits),
       transactionP95Ms: this.percentile(this.transactionDurations),
+      mirrorCheckpointAtMs: this.lastMirrorAt,
       mirrorAgeMs: this.lastMirrorAt === null ? null : Math.max(0, this.now() - this.lastMirrorAt),
       mirrorDirty: this.mirrorDirty,
     };
@@ -2397,6 +2399,15 @@ export class AgentRegistry {
     if (!this.mirrorDirty && this.lastMirroredRevision !== null && currentRevision <= this.lastMirroredRevision) return;
     this.mirrorSqliteSnapshot(this.sqliteStore.snapshot());
     this.mirrorCheckpointFailures = 0;
+  }
+
+  checkpointRollbackMirrorForDemotion(maxAttempts = 2): void {
+    if (!this.sqliteStore || this.sqliteMode === "dual-write") return;
+    for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
+      this.checkpointRollbackMirror();
+      if (!this.storageDiagnostics().mirrorDirty) return;
+    }
+    throw new Error(`agent registry rollback mirror did not converge after ${maxAttempts} attempts`);
   }
 
   private scheduleRollbackMirror(delayMs = this.mirrorCheckpointMs): void {
@@ -2852,10 +2863,12 @@ export class AgentRegistry {
     if (this.sqliteMode === "read" || this.sqliteMode === "sqlite") {
       const mutation = this.sqliteStore!.mutate(mutator, false);
       if (this.sqliteMode === "read") {
-        this.mirrorDirty = true;
-        this.scheduleRollbackMirrorForCadence();
+        this.mirrorDirty = this.lastMirroredRevision === null || mutation.revision > this.lastMirroredRevision;
+        if (this.mirrorDirty) this.scheduleRollbackMirrorForCadence();
       }
-      if (this.sqliteMode === "sqlite") this.mirrorDirty = true;
+      if (this.sqliteMode === "sqlite") {
+        this.mirrorDirty = this.lastMirroredRevision === null || mutation.revision > this.lastMirroredRevision;
+      }
       return mutation.result;
     }
     const lock = `${this.filename}.write-lock`;

--- a/src/lib/agent/registry.ts
+++ b/src/lib/agent/registry.ts
@@ -2220,6 +2220,20 @@ export interface AgentRegistryStorageOptions {
   onSqliteWriterWait?: (durationMs: number) => void;
   beforeDualWriteStartupReplace?: () => void;
   beforeDualWriteMutationReplace?: () => void;
+  mirrorCheckpointMs?: number;
+  now?: () => number;
+  scheduleMirrorCheckpoint?: (callback: () => void, delayMs: number) => { unref?(): unknown };
+}
+
+export interface AgentRegistryStorageDiagnostics {
+  backendMode: AgentRegistrySqliteMode;
+  revision: number | null;
+  transactionCount: number;
+  writerRatePerSecond: number;
+  writerWaitP95Ms: number | null;
+  transactionP95Ms: number | null;
+  mirrorAgeMs: number | null;
+  mirrorDirty: boolean;
 }
 
 export class RegistryParityError extends Error {
@@ -2261,6 +2275,15 @@ export class AgentRegistry {
   private readonly sqliteStore: SqliteAgentRegistryStore | null;
   private readonly beforeDualWriteMutationReplace: (() => void) | undefined;
   private readOnlyCache: { signature: string; snapshot: RegistryFile } | null = null;
+  private readonly mirrorCheckpointMs: number;
+  private readonly now: () => number;
+  private readonly scheduleMirrorCheckpoint: (callback: () => void, delayMs: number) => { unref?(): unknown };
+  private mirrorCheckpointPending = false;
+  private lastMirrorAt: number | null = null;
+  private mirrorDirty = false;
+  private readonly writerWaits: number[] = [];
+  private readonly transactionDurations: number[] = [];
+  private firstTransactionAt: number | null = null;
 
   constructor(
     readonly filename = statePath("agent-registry.json"),
@@ -2270,13 +2293,20 @@ export class AgentRegistry {
     storage: AgentRegistryStorageOptions = {},
   ) {
     this.sqliteMode = storage.sqliteMode ?? sqliteModeFromEnvironment();
+    this.mirrorCheckpointMs = Math.max(0, storage.mirrorCheckpointMs ?? 5_000);
+    this.now = storage.now ?? Date.now;
+    this.scheduleMirrorCheckpoint = storage.scheduleMirrorCheckpoint
+      ?? ((callback, delayMs) => setTimeout(callback, delayMs));
     this.beforeDualWriteMutationReplace = storage.beforeDualWriteMutationReplace;
     this.sqliteStore = this.sqliteMode === "off"
       ? null
       : new SqliteAgentRegistryStore(storage.sqliteFilename ?? defaultSqliteFilename(filename), {
           initialSnapshot: readFile(filename),
           normalize: normalizeRegistry,
-          onWriterWait: storage.onSqliteWriterWait,
+          onWriterWait: (duration) => {
+            this.recordMetric(this.writerWaits, duration);
+            storage.onSqliteWriterWait?.(duration);
+          },
         });
     if (this.sqliteMode === "off") {
       this.cleanupStaleTempFiles();
@@ -2314,9 +2344,55 @@ export class AgentRegistry {
     for (;;) {
       writeAtomic(this.filename, snapshot.file, snapshot.revision);
       const latest = this.sqliteStore!.snapshot();
-      if (latest.revision <= snapshot.revision) return;
+      if (latest.revision <= snapshot.revision) {
+        this.lastMirrorAt = this.now();
+        this.mirrorDirty = false;
+        return;
+      }
       snapshot = latest;
     }
+  }
+
+  private recordMetric(target: number[], value: number): void {
+    target.push(value);
+    if (target.length > 512) target.splice(0, target.length - 512);
+  }
+
+  private percentile(target: readonly number[]): number | null {
+    if (target.length === 0) return null;
+    const sorted = [...target].sort((left, right) => left - right);
+    return sorted[Math.min(sorted.length - 1, Math.ceil(sorted.length * 0.95) - 1)]!;
+  }
+
+  storageDiagnostics(): AgentRegistryStorageDiagnostics {
+    const revision = this.sqliteStore?.revision() ?? null;
+    return {
+      backendMode: this.sqliteMode,
+      revision,
+      transactionCount: this.transactionDurations.length,
+      writerRatePerSecond: this.firstTransactionAt === null
+        ? 0
+        : this.transactionDurations.length / Math.max(0.001, (this.now() - this.firstTransactionAt) / 1_000),
+      writerWaitP95Ms: this.percentile(this.writerWaits),
+      transactionP95Ms: this.percentile(this.transactionDurations),
+      mirrorAgeMs: this.lastMirrorAt === null ? null : Math.max(0, this.now() - this.lastMirrorAt),
+      mirrorDirty: this.mirrorDirty,
+    };
+  }
+
+  checkpointRollbackMirror(): void {
+    if (!this.mirrorDirty || !this.sqliteStore) return;
+    this.mirrorSqliteSnapshot(this.sqliteStore.snapshot());
+  }
+
+  private scheduleRollbackMirror(): void {
+    if (this.mirrorCheckpointPending) return;
+    this.mirrorCheckpointPending = true;
+    this.scheduleMirrorCheckpoint(() => {
+      this.mirrorCheckpointPending = false;
+      try { this.checkpointRollbackMirror(); }
+      catch (error) { console.error("agent registry rollback checkpoint failed", error); }
+    }, this.mirrorCheckpointMs).unref?.();
   }
 
   private cleanupStaleTempFiles(): void {
@@ -2737,10 +2813,16 @@ export class AgentRegistry {
       return result;
     };
     if (this.sqliteMode === "read" || this.sqliteMode === "sqlite") {
+      const startedAt = performance.now();
+      this.firstTransactionAt ??= this.now();
       const mutation = this.sqliteStore!.mutate(mutator, this.sqliteMode === "read");
+      this.recordMetric(this.transactionDurations, performance.now() - startedAt);
       if (this.sqliteMode === "read") {
         if (!mutation.file) throw new Error("SQLite read mode mutation is missing its rollback snapshot");
-        this.mirrorSqliteSnapshot({ file: mutation.file, revision: mutation.revision });
+        this.mirrorDirty = true;
+        if (this.lastMirrorAt === null || this.now() - this.lastMirrorAt >= this.mirrorCheckpointMs) {
+          this.mirrorSqliteSnapshot({ file: mutation.file, revision: mutation.revision });
+        } else this.scheduleRollbackMirror();
       }
       return mutation.result;
     }
@@ -2791,7 +2873,7 @@ export class AgentRegistry {
       objects. Atomic writers change the inode/signature, including writers in
       the runtime-host process, so the next reader reparses immediately. */
   readOnlySnapshot(): RegistryFile {
-    if (this.sqliteMode === "read" || this.sqliteMode === "sqlite") return this.sqliteStore!.snapshot().file;
+    if (this.sqliteMode === "read" || this.sqliteMode === "sqlite") return this.sqliteStore!.readOnlySnapshot().file;
     for (let attempt = 0; attempt < 2; attempt += 1) {
       const before = registryFileSignature(this.filename);
       if (this.readOnlyCache?.signature === before) return this.readOnlyCache.snapshot;

--- a/src/lib/agent/sqliteRegistryStore.ts
+++ b/src/lib/agent/sqliteRegistryStore.ts
@@ -58,6 +58,7 @@ export interface SqliteRegistryStoreOptions {
   initialSnapshot: RegistryFile;
   normalize(value: unknown): RegistryFile;
   onWriterWait?(durationMs: number): void;
+  onSnapshotLoad?(): void;
 }
 
 interface LazyRegistrySnapshot extends SqliteRegistrySnapshot {
@@ -68,6 +69,7 @@ export class SqliteAgentRegistryStore {
   private readonly db: BunDatabase;
   private readonly normalize: (value: unknown) => RegistryFile;
   private readonly onWriterWait: ((durationMs: number) => void) | undefined;
+  private readonly onSnapshotLoad: (() => void) | undefined;
   private readOnlyCache: SqliteRegistrySnapshot | null = null;
 
   constructor(readonly filename: string, options: SqliteRegistryStoreOptions) {
@@ -78,6 +80,7 @@ export class SqliteAgentRegistryStore {
     this.db = new Database(filename, { create: true, strict: true });
     this.normalize = options.normalize;
     this.onWriterWait = options.onWriterWait;
+    this.onSnapshotLoad = options.onSnapshotLoad;
     this.db.exec("PRAGMA busy_timeout = 5000; PRAGMA journal_mode = WAL; PRAGMA synchronous = FULL; PRAGMA foreign_keys = ON; PRAGMA auto_vacuum = INCREMENTAL;");
     this.db.exec(`
       CREATE TABLE IF NOT EXISTS registry_meta (
@@ -113,6 +116,7 @@ export class SqliteAgentRegistryStore {
   }
 
   snapshot(): SqliteRegistrySnapshot {
+    this.onSnapshotLoad?.();
     this.db.exec("BEGIN");
     try {
       const snapshot = this.loadInTransaction();

--- a/src/lib/agent/sqliteRegistryStore.ts
+++ b/src/lib/agent/sqliteRegistryStore.ts
@@ -68,6 +68,7 @@ export class SqliteAgentRegistryStore {
   private readonly db: BunDatabase;
   private readonly normalize: (value: unknown) => RegistryFile;
   private readonly onWriterWait: ((durationMs: number) => void) | undefined;
+  private readOnlyCache: SqliteRegistrySnapshot | null = null;
 
   constructor(readonly filename: string, options: SqliteRegistryStoreOptions) {
     fs.mkdirSync(path.dirname(filename), { recursive: true, mode: 0o700 });
@@ -123,6 +124,17 @@ export class SqliteAgentRegistryStore {
     }
   }
 
+  revision(): number {
+    return Number(this.meta("revision") ?? 0);
+  }
+
+  readOnlySnapshot(): SqliteRegistrySnapshot {
+    const revision = this.revision();
+    if (this.readOnlyCache?.revision === revision) return this.readOnlyCache;
+    this.readOnlyCache = this.snapshot();
+    return this.readOnlyCache;
+  }
+
   mutate<T>(operation: (file: RegistryFile) => T, includeSnapshot = true): SqliteRegistryMutation<T> {
     for (;;) {
       this.db.exec("BEGIN");
@@ -155,6 +167,7 @@ export class SqliteAgentRegistryStore {
         throw error;
       }
       this.secureFiles();
+      this.readOnlyCache = null;
       if (includeSnapshot) {
         const committed = this.snapshot();
         return { result, file: committed.file, revision: committed.revision };
@@ -175,6 +188,7 @@ export class SqliteAgentRegistryStore {
       this.persistDiff(current.file, file, revision);
       this.db.exec("COMMIT");
       this.secureFiles();
+      this.readOnlyCache = null;
       return { file, revision, replaced: true };
     } catch (error) {
       try { this.db.exec("ROLLBACK"); } catch { /* transaction already closed */ }

--- a/src/lib/agent/sqliteRegistryStore.ts
+++ b/src/lib/agent/sqliteRegistryStore.ts
@@ -157,21 +157,24 @@ export class SqliteAgentRegistryStore {
       const waitStartedAt = performance.now();
       this.db.exec("BEGIN IMMEDIATE");
       let revision: number;
+      const changed = changes.rows.size > 0 || changes.meta.size > 0 || changes.order.size > 0;
       try {
         this.onWriterWait?.(performance.now() - waitStartedAt);
         if (Number(this.meta("revision") ?? 0) !== current.revision) {
           this.db.exec("ROLLBACK");
           continue;
         }
-        revision = current.revision + 1;
-        this.persistChanges(current.file, changes, revision);
+        revision = changed ? current.revision + 1 : current.revision;
+        if (changed) this.persistChanges(current.file, changes, revision);
         this.db.exec("COMMIT");
       } catch (error) {
         try { this.db.exec("ROLLBACK"); } catch { /* transaction already closed */ }
         throw error;
       }
-      this.secureFiles();
-      this.readOnlyCache = null;
+      if (changed) {
+        this.secureFiles();
+        this.readOnlyCache = null;
+      }
       if (includeSnapshot) {
         const committed = this.snapshot();
         return { result, file: committed.file, revision: committed.revision };

--- a/src/lib/runtime/registryPersistence.test.ts
+++ b/src/lib/runtime/registryPersistence.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, test } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 
-import type { AgentRegistry, AgentRegistryEntry, StructuredHostColumns } from "@/lib/agent/registry";
+import { AgentRegistry, type AgentRegistryEntry, type StructuredHostColumns } from "@/lib/agent/registry";
 
 import type { ClaudeStreamBrokerHost } from "./claudeStreamBrokerHost";
 import type { CodexAppServerHost } from "./codexAppServerHost";
@@ -203,3 +206,79 @@ for (const [engine, bind] of binders) {
     });
   });
 }
+
+test("production-sized ten-lane persistence coalesces cursors and orders material transitions", async () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-registry-persistence-production-"));
+  const filename = path.join(directory, "agent-registry.json");
+  const seed = new AgentRegistry(filename);
+  const template = seed.beginSpawn("codex", "/production-seed");
+  const production = seed.snapshot();
+  for (let index = 1; index < 18_000; index += 1) {
+    const launchId = `production-persistence-${String(index).padStart(5, "0")}`;
+    production.receipts[launchId] = { ...structuredClone(template), launchId };
+  }
+  const payload = JSON.stringify(production);
+  expect(Buffer.byteLength(payload)).toBeGreaterThanOrEqual(14_660_822);
+  fs.writeFileSync(filename, payload);
+  const registry = new AgentRegistry(filename, undefined, undefined, { sqliteMode: "sqlite" });
+  const lanes = await Promise.all(Array.from({ length: 10 }, async (_, lane) => {
+    const engine = lane % 2 === 0 ? "codex" as const : "claude" as const;
+    const key = { engine, sessionId: `production-lane-${lane}` };
+    const claimOwner = `production-owner-${lane}`;
+    const claimEpoch = 7;
+    registry.upsert({
+      key,
+      artifactPath: `/sessions/production-lane-${lane}.jsonl`,
+      cwd: "/repo",
+      accountId: "work",
+      status: "live",
+      host: null,
+      structuredHost: {
+        kind: engine === "codex" ? "codex-app-server" : "claude-broker",
+        endpoint: `stdio:${lane}`,
+        process: { pid: 4_000 + lane, startIdentity: `${4_000 + lane}:fixture` },
+        eventCursor: 0,
+        protocolVersion: "1",
+        writerClaimEpoch: claimEpoch,
+        activeTurnRef: null,
+        pendingAttention: [],
+        activeFlags: [],
+      },
+      claimEpoch,
+      claimOwner,
+      pendingAction: null,
+    });
+    const host = new RecordingHost();
+    const stop = engine === "codex"
+      ? await bindCodexHostPersistence(registry, key, host as unknown as CodexAppServerHost, claimOwner, claimEpoch, "unhosted", { cursorDebounceMs: 20 })
+      : await bindClaudeHostPersistence(registry, key, host as unknown as ClaudeStreamBrokerHost, claimOwner, claimEpoch, "unhosted", { cursorDebounceMs: 20 });
+    return { key, host, stop };
+  }));
+  const revisionBeforeEvents = registry.storageDiagnostics().revision!;
+
+  for (let cursor = 1; cursor <= 100; cursor += 1) {
+    for (const lane of lanes) lane.host.emit({ eventCursor: cursor });
+  }
+  await Bun.sleep(35);
+  for (const lane of lanes) lane.host.emit({ eventCursor: 101, status: "active", activeTurnRef: "turn-live" });
+  for (const lane of lanes) lane.host.emit({ eventCursor: 102, status: "attention", pendingAttention: ["approval"] });
+  for (const lane of lanes) lane.host.emit({
+    eventCursor: 103,
+    status: "unhosted",
+    endpoint: "stdio:released",
+    pid: null,
+    processStartIdentity: null,
+    activeTurnRef: null,
+    pendingAttention: [],
+  });
+
+  expect(registry.storageDiagnostics().revision! - revisionBeforeEvents).toBe(40);
+  for (const lane of lanes) {
+    expect(registry.snapshot().entries[`${lane.key.engine}:${lane.key.sessionId}`]).toMatchObject({
+      status: "unhosted",
+      claimOwner: null,
+      structuredHost: { eventCursor: 103, activeTurnRef: null, pendingAttention: [] },
+    });
+    lane.stop();
+  }
+}, 30_000);

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -275,7 +275,7 @@ export interface FilesResponse {
   tasks: BoardTask[];
   systemHealth: {
     tmux: TmuxEndpointHealth;
-    registry?: import("@/lib/agent/registry").AgentRegistryStorageDiagnostics;
+    registry?: Omit<import("@/lib/agent/registry").AgentRegistryStorageDiagnostics, "mirrorAgeMs">;
   };
   /** Durable conversation-id aliases (old id → canonical id), so a deep link
       copied before provisional-id adoption still resolves its card. */

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -273,7 +273,10 @@ export interface FilesResponse {
   pipelinesError?: string;
   workflows: Workflow[];
   tasks: BoardTask[];
-  systemHealth: { tmux: TmuxEndpointHealth };
+  systemHealth: {
+    tmux: TmuxEndpointHealth;
+    registry?: import("@/lib/agent/registry").AgentRegistryStorageDiagnostics;
+  };
   /** Durable conversation-id aliases (old id → canonical id), so a deep link
       copied before provisional-id adoption still resolves its card. */
   conversationAliases?: Record<string, string>;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -275,7 +275,10 @@ export interface FilesResponse {
   tasks: BoardTask[];
   systemHealth: {
     tmux: TmuxEndpointHealth;
-    registry?: Omit<import("@/lib/agent/registry").AgentRegistryStorageDiagnostics, "mirrorAgeMs">;
+    registry?: Omit<
+      import("@/lib/agent/registry").AgentRegistryStorageDiagnostics,
+      "mirrorAgeMs" | "writerRatePerSecond"
+    >;
   };
   /** Durable conversation-id aliases (old id → canonical id), so a deep link
       copied before provisional-id adoption still resolves its card. */

--- a/src/lib/viewerInstrumentation.ts
+++ b/src/lib/viewerInstrumentation.ts
@@ -32,6 +32,7 @@ interface ViewerReleaseActivationOptions {
   pollMs?: number;
   schedule?: (callback: () => void, delayMs: number) => ActivationTimer;
   log?: (...args: unknown[]) => void;
+  onDemoted?: () => void | Promise<void>;
 }
 
 interface CurrentReleaseControllerLoaders {
@@ -74,10 +75,23 @@ export async function activateViewerRuntimeWhenCurrent(
   const schedule = options.schedule ?? ((callback, delayMs) => setTimeout(callback, delayMs));
   const log = options.log ?? console.error;
   let started = false;
+  let demoted = false;
+  const monitor = () => {
+    if (demoted) return;
+    if (started && !isCurrent()) {
+      demoted = true;
+      void Promise.resolve(options.onDemoted?.()).catch((error) => {
+        log("[viewer release] demotion checkpoint failed", error);
+      });
+      return;
+    }
+    schedule(monitor, pollMs).unref?.();
+  };
   const start = async () => {
     if (started) return;
     started = true;
     await activate();
+    schedule(monitor, pollMs).unref?.();
   };
   if (isCurrent()) {
     await start();
@@ -204,5 +218,14 @@ export async function registerViewerRuntime(): Promise<void> {
       await runStructuredHostStartup(adoptStructuredHostsAtStartup);
     }
     await startCurrentReleaseControllers();
-  }, () => viewerReleaseOwnsTraffic());
+  }, () => viewerReleaseOwnsTraffic(), {
+    onDemoted: async () => {
+      try {
+        const { agentRegistry } = await import("@/lib/agent/registry");
+        agentRegistry().checkpointRollbackMirror();
+      } finally {
+        process.exit(0);
+      }
+    },
+  });
 }

--- a/src/lib/viewerInstrumentation.ts
+++ b/src/lib/viewerInstrumentation.ts
@@ -235,7 +235,7 @@ export async function registerViewerRuntime(): Promise<void> {
   }, () => viewerReleaseOwnsTraffic(), {
     onDemoted: () => completeViewerReleaseDemotion(async () => {
         const { agentRegistry } = await import("@/lib/agent/registry");
-        agentRegistry().checkpointRollbackMirror();
+        agentRegistry().checkpointRollbackMirrorForDemotion();
     }),
   });
 }

--- a/src/lib/viewerInstrumentation.ts
+++ b/src/lib/viewerInstrumentation.ts
@@ -125,6 +125,20 @@ export function scheduleAccountMigrationController(start: () => Promise<void>, d
   timer.unref?.();
 }
 
+export async function completeViewerReleaseDemotion(
+  checkpoint: () => void | Promise<void>,
+  exit: (code: number) => unknown = (code) => process.exit(code),
+  log: (...args: unknown[]) => void = console.error,
+): Promise<void> {
+  try {
+    await checkpoint();
+    exit(0);
+  } catch (error) {
+    log("[viewer release] demotion checkpoint failed", error);
+    exit(1);
+  }
+}
+
 export async function startCurrentReleaseControllers(
   env: Readonly<Record<string, string | undefined>> = process.env,
   loaders: CurrentReleaseControllerLoaders = {
@@ -219,13 +233,9 @@ export async function registerViewerRuntime(): Promise<void> {
     }
     await startCurrentReleaseControllers();
   }, () => viewerReleaseOwnsTraffic(), {
-    onDemoted: async () => {
-      try {
+    onDemoted: () => completeViewerReleaseDemotion(async () => {
         const { agentRegistry } = await import("@/lib/agent/registry");
         agentRegistry().checkpointRollbackMirror();
-      } finally {
-        process.exit(0);
-      }
-    },
+    }),
   });
 }


### PR DESCRIPTION
Closes #312

## Summary
- bound SQLite read-mode JSON rollback checkpoints to five seconds and checkpoint on release demotion
- cache SQLite read projections by durable revision and expose backend/writer/mirror diagnostics
- continuously fence Viewer release ownership so demoted retained containers stop background work
- preserve existing durable ordering and cursor coalescing with production-shaped registry and release tests

## Verification
- `bun test src/lib/agent/registry.sqlite.test.ts src/lib/runtime/registryPersistence.test.ts src/instrumentation.test.ts src/app/api/files/route.test.ts` (120 pass)
- deployment/rollback focused suite (144 pass combined)
- `bunx tsc --noEmit`
- scoped ESLint
- `bun run build`
- `bun run privacy:check`
- `git diff --check`
- repository-wide `bun test`: one unrelated EngineAccountSwitch DOM flake; isolated rerun 3/3 pass