### PR TITLE
fix(flows): serialize review relay settlement

### DIFF
--- a/src/lib/flows/engine.test.ts
+++ b/src/lib/flows/engine.test.ts
@@ -10,8 +10,11 @@ import { AgentRegistry, agentRegistry } from "@/lib/agent/registry";
 
 import type { Flow } from "./types";
 
+let relayDeliveries = 0;
+let releaseRelayDeliveries: Array<() => void> = [];
+
 process.env.LLV_STATE_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "llv-flow-engine-test-"));
-const { captureReviewHead, newRound, tickFlows, persistTickFlows, flowTickBase, reviewerLaunchPersisted, abandonLaunch, adoptSyntheticLaunchTakeover, recordHeadlessLaunch, relayFixOrPark, reserveReviewerSpawn } = await import("./engine");
+const { captureReviewHead, newRound, tickFlow, tickFlows, persistTickFlows, flowTickBase, reviewerLaunchPersisted, abandonLaunch, adoptSyntheticLaunchTakeover, recordHeadlessLaunch, relayFixOrPark, reserveReviewerSpawn, setRelayDeliveryForTest } = await import("./engine");
 const { loadFlows, outputPathFor, saveFlows, stderrPathFor, stdoutPathFor } = await import("./store");
 
 afterAll(() => {
@@ -1130,6 +1133,89 @@ function raceFlow(over: Partial<Flow>): Flow {
     ...over,
   } as unknown as Flow;
 }
+
+test("overlapping relay ticks deliver one review and settle the round once (#529)", async () => {
+  relayDeliveries = 0;
+  releaseRelayDeliveries = [];
+  const restoreDelivery = setRelayDeliveryForTest(async (flow) => {
+    relayDeliveries += 1;
+    await new Promise<void>((resolve) => { releaseRelayDeliveries.push(resolve); });
+    return flow.implementerPath;
+  });
+  const implementer = writeCodexEntry("relay-single-flight-implementer.jsonl", {
+    id: ["039f421e", "02e1", "73e0", "9b77", "bebde063f529"].join("-"),
+    cwd: "/repo",
+  }, Date.now() / 1_000);
+  const findingsPath = path.join(process.env.LLV_STATE_DIR!, "relay-findings.md");
+  fs.writeFileSync(findingsPath, "VERDICT: REQUEST_CHANGES\n\nFix the relay race.\n");
+  const round = {
+    ...newRound(raceFlow({ rounds: [] }), "marker", "head ready"),
+    findingsPath,
+    verdict: "REQUEST_CHANGES" as const,
+    findingsCount: 1,
+    reviewedAt: "2026-07-21T16:16:05.000Z",
+    terminalAt: "2026-07-21T16:16:05.000Z",
+  };
+  const original = raceFlow({
+    id: "flow-relay-single-flight",
+    implementerPath: implementer.path,
+    state: "relaying",
+    rounds: [round],
+  });
+  saveFlows([original]);
+  const first = structuredClone(original);
+  const second = structuredClone(original);
+  const firstBase = flowTickBase([first]);
+  const secondBase = flowTickBase([second]);
+  const entriesByPath = new Map([[implementer.path, implementer]]);
+
+  try {
+    const firstTick = tickFlow(first, [implementer], entriesByPath, () => persistTickFlows([first], firstBase));
+    while (relayDeliveries < 1) await new Promise<void>((resolve) => setImmediate(resolve));
+    const secondTick = tickFlow(second, [implementer], entriesByPath, () => persistTickFlows([second], secondBase));
+    await new Promise<void>((resolve) => setImmediate(resolve));
+
+    expect(relayDeliveries).toBe(1);
+    for (const release of releaseRelayDeliveries) release();
+    await Promise.all([firstTick, secondTick]);
+    persistTickFlows([first], firstBase);
+    persistTickFlows([second], secondBase);
+
+    expect(loadFlows()[0]).toMatchObject({
+      state: "fixing",
+      rounds: [{
+        n: 1,
+        relayDelivery: { path: implementer.path, deliveredAt: expect.any(String) },
+        relayedAt: expect.any(String),
+      }],
+    });
+
+    fs.appendFileSync(implementer.path, `${JSON.stringify({
+      timestamp: new Date(Date.now() + 1_000).toISOString(),
+      type: "event_msg",
+      payload: { type: "task_complete", last_agent_message: "REVIEW_READY: repaired head" },
+    })}\n`);
+    const stat = fs.statSync(implementer.path);
+    const repairedEntry = { ...implementer, size: stat.size, mtime: stat.mtimeMs / 1_000 };
+    const recovered = structuredClone(loadFlows()[0]!);
+    const recoveredBase = flowTickBase([recovered]);
+    await tickFlow(recovered, [repairedEntry], new Map([[repairedEntry.path, repairedEntry]]), () => {
+      persistTickFlows([recovered], recoveredBase);
+    });
+    persistTickFlows([recovered], recoveredBase);
+
+    expect(loadFlows()[0]).toMatchObject({
+      state: "spawning",
+      rounds: [
+        { n: 1, reviewerBindingId: round.reviewerBindingId, findingsPath, verdict: "REQUEST_CHANGES" },
+        { n: 2, triggeredBy: "marker", readyNote: "repaired head", reviewHeadSha: null, reviewerBindingId: expect.any(String) },
+      ],
+    });
+  } finally {
+    for (const release of releaseRelayDeliveries) release();
+    restoreDelivery();
+  }
+});
 
 test("persistTickFlows respects a concurrent close instead of reopening the flow (issue #118 review)", () => {
   /* The tick started with the flow reviewing; the operator closed it during the

--- a/src/lib/flows/engine.test.ts
+++ b/src/lib/flows/engine.test.ts
@@ -1176,13 +1176,20 @@ test("overlapping relay ticks deliver one review and settle the round once (#529
     await new Promise<void>((resolve) => setImmediate(resolve));
 
     expect(relayDeliveries).toBe(1);
+    fs.appendFileSync(implementer.path, `${JSON.stringify({
+      timestamp: new Date(Date.now() + 1_000).toISOString(),
+      type: "event_msg",
+      payload: { type: "task_complete", last_agent_message: "REVIEW_READY: repaired head" },
+    })}\n`);
+    saveFlows([{ ...loadFlows()[0]!, state: "paused", pausedState: "relaying" }]);
     for (const release of releaseRelayDeliveries) release();
     await Promise.all([firstTick, secondTick]);
     persistTickFlows([first], firstBase);
     persistTickFlows([second], secondBase);
 
     expect(loadFlows()[0]).toMatchObject({
-      state: "fixing",
+      state: "paused",
+      pausedState: "relaying",
       rounds: [{
         n: 1,
         relayDelivery: { path: implementer.path, deliveredAt: expect.any(String) },
@@ -1190,20 +1197,20 @@ test("overlapping relay ticks deliver one review and settle the round once (#529
       }],
     });
 
-    fs.appendFileSync(implementer.path, `${JSON.stringify({
-      timestamp: new Date(Date.now() + 1_000).toISOString(),
-      type: "event_msg",
-      payload: { type: "task_complete", last_agent_message: "REVIEW_READY: repaired head" },
-    })}\n`);
     const stat = fs.statSync(implementer.path);
     const repairedEntry = { ...implementer, size: stat.size, mtime: stat.mtimeMs / 1_000 };
-    const recovered = structuredClone(loadFlows()[0]!);
-    const recoveredBase = flowTickBase([recovered]);
-    await tickFlow(recovered, [repairedEntry], new Map([[repairedEntry.path, repairedEntry]]), () => {
+    const resumed = { ...loadFlows()[0]!, state: "relaying" as const, pausedState: null };
+    saveFlows([resumed]);
+    for (let pass = 0; pass < 2; pass += 1) {
+      const recovered = structuredClone(loadFlows()[0]!);
+      const recoveredBase = flowTickBase([recovered]);
+      await tickFlow(recovered, [repairedEntry], new Map([[repairedEntry.path, repairedEntry]]), () => {
+        persistTickFlows([recovered], recoveredBase);
+      });
       persistTickFlows([recovered], recoveredBase);
-    });
-    persistTickFlows([recovered], recoveredBase);
+    }
 
+    expect(relayDeliveries).toBe(1);
     expect(loadFlows()[0]).toMatchObject({
       state: "spawning",
       rounds: [
@@ -1233,6 +1240,35 @@ test("persistTickFlows respects a concurrent close instead of reopening the flow
   const after = loadFlows()[0]!;
   expect(after.state).toBe("closed");
   expect(after.closedAt).toBe("2026-05-05T01:00:00Z");
+});
+
+test("relay settlement does not contaminate a concurrently retried round", () => {
+  const round = {
+    ...newRound(raceFlow({ rounds: [] }), "marker", null),
+    verdict: "REQUEST_CHANGES" as const,
+  };
+  const started = raceFlow({ state: "relaying", rounds: [round] });
+  saveFlows([started]);
+  const clone = structuredClone(started);
+  const base = flowTickBase([clone]);
+  const retriedRound = {
+    ...round,
+    reviewerBindingId: crypto.randomUUID(),
+    relayStartedAt: null,
+    relayDelivery: null,
+    relayedAt: null,
+  };
+  saveFlows([raceFlow({ state: "paused", pausedState: "spawning", rounds: [retriedRound] })]);
+  clone.state = "fixing";
+  clone.rounds[0]!.relayDelivery = { path: "/impl", deliveredAt: "2026-07-21T17:00:00.000Z" };
+  clone.rounds[0]!.relayedAt = "2026-07-21T17:00:00.000Z";
+
+  persistTickFlows([clone], base);
+
+  expect(loadFlows()[0]).toMatchObject({
+    state: "paused",
+    rounds: [{ relayDelivery: null, relayedAt: null }],
+  });
 });
 
 test("persistTickFlows preserves a flow created during the tick (issue #118 review)", () => {

--- a/src/lib/flows/engine.ts
+++ b/src/lib/flows/engine.ts
@@ -634,6 +634,10 @@ async function relayFindings(flow: Flow, entriesByPath: Map<string, FileEntry>, 
   const deliveredAt = isoNow();
   round.relayDelivery = { path: deliveryPath, deliveredAt };
   round.relayedAt = deliveredAt;
+  completeRelayTransition(flow, round);
+}
+
+function completeRelayTransition(flow: Flow, round: Round): void {
   if (round.verdict === "APPROVE") {
     flow.state = "approved";
     flow.closedAt = isoNow();
@@ -823,6 +827,10 @@ export async function tickFlow(
 
   if (flow.state === "relaying") {
     const relayKey = roundKey(flow, round);
+    if (round.relayedAt !== null) {
+      completeRelayTransition(flow, round);
+      return JSON.stringify(flow) !== before;
+    }
     const activeRelay = relayLeases.get(relayKey);
     if (activeRelay) {
       await activeRelay;
@@ -886,7 +894,8 @@ export function flowTickBase(flows: Flow[]): Map<string, FlowTickBase> {
  *     operator edit (e.g. set-roles updating a spawn_pending round's frozen
  *     reviewerRole) is never clobbered by the tick's stale clone;
  *   - a flow whose disk state/rounds/closedAt diverged from the tick's base was
- *     taken over by the operator — the operator wins (a close is never reopened);
+ *     taken over by the operator; pause/close retain their lifecycle state while
+ *     accepting exact-round successful relay settlement, and other takeovers win;
  *   - otherwise the tick's result lands, but operator-owned fields are taken from
  *     disk: top-level roles/roundLimit/mode, and each unstarted round's
  *     reviewerRole (the tick never edits an unspawned round's snapshot — only
@@ -906,7 +915,29 @@ export function persistTickFlows(flows: Flow[], base: Map<string, FlowTickBase>)
       diskFlow.state !== start.state ||
       diskFlow.rounds.length !== start.roundsLen ||
       diskFlow.closedAt !== start.closedAt;
-    if (takenOver) return diskFlow;
+    if (takenOver) {
+      if (diskFlow.state !== "paused" && diskFlow.state !== "closed") return diskFlow;
+      const baseFlow = JSON.parse(start.snapshot) as Flow;
+      const settledByRound = new Map(tick.rounds.flatMap((round) => {
+        const baseRound = baseFlow.rounds.find((item) => item.n === round.n);
+        return baseRound?.relayedAt == null && round.relayDelivery && round.relayedAt
+          ? [[round.n, round] as const]
+          : [];
+      }));
+      if (settledByRound.size === 0) return diskFlow;
+      return {
+        ...diskFlow,
+        rounds: diskFlow.rounds.map((diskRound) => {
+          const settled = settledByRound.get(diskRound.n);
+          return settled && settled.reviewerBindingId === diskRound.reviewerBindingId ? {
+            ...diskRound,
+            relayStartedAt: settled.relayStartedAt,
+            relayDelivery: settled.relayDelivery,
+            relayedAt: settled.relayedAt,
+          } : diskRound;
+        }),
+      };
+    }
     /* Fence an unstarted round's reviewer snapshot to the disk value ONLY when the
        tick did not itself change it (comparing to the pre-tick base): then a
        difference on disk is a concurrent set-roles that must survive. When the tick

--- a/src/lib/flows/engine.ts
+++ b/src/lib/flows/engine.ts
@@ -38,8 +38,13 @@ import { chooseHeadlessReviewer, rateLimitStateDetail } from "./reviewerPolicy";
 const TERMINAL_STATES = new Set<FlowState>(["approved", "done_comment", "needs_decision", "closed"]);
 const READY_RE = /^REVIEW_READY:\s*(.*)$/m;
 const UUID_RE = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/i;
-const store = globalThis as unknown as { __llvFlowTick?: boolean };
+const store = globalThis as unknown as {
+  __llvFlowTick?: boolean;
+  __llvFlowRelayLeases?: Map<string, Promise<void>>;
+};
 const relayStartedThisProcess = new Set<string>();
+const relayLeases = store.__llvFlowRelayLeases ??= new Map<string, Promise<void>>();
+let sendRelay: typeof sendToImplementer;
 const MAX_HEADLESS_NO_VERDICT_RETRIES = 1;
 const REVIEWER_LAUNCH_LEASE_MS = 60_000;
 const SYNTHETIC_LAUNCH_LOSS_DETAILS = new Set([
@@ -261,6 +266,13 @@ export async function sendToImplementer(flow: Flow, entriesByPath: Map<string, F
   const outcome = await deliverToTranscriptHost({ entry, spec, payload: text });
   if (!outcome.ok) throw new Error(outcome.error);
   return entry.path;
+}
+
+sendRelay = sendToImplementer;
+
+export function setRelayDeliveryForTest(delivery: typeof sendToImplementer): () => void {
+  sendRelay = delivery;
+  return () => { sendRelay = sendToImplementer; };
 }
 
 function sessionIdFromHeadlessStdout(stdout: string): string | null {
@@ -618,7 +630,7 @@ async function relayFindings(flow: Flow, entriesByPath: Map<string, FileEntry>, 
   if (!round.findingsPath) throw new Error("round has no findings artifact");
   const findings = fs.readFileSync(round.findingsPath, "utf8");
   flow.state = "relaying";
-  const deliveryPath = await sendToImplementer(flow, entriesByPath, relayPrompt(round, findings));
+  const deliveryPath = await sendRelay(flow, entriesByPath, relayPrompt(round, findings));
   const deliveredAt = isoNow();
   round.relayDelivery = { path: deliveryPath, deliveredAt };
   round.relayedAt = deliveredAt;
@@ -651,7 +663,7 @@ export function relayFixOrPark(flow: Flow): void {
   }
 }
 
-async function tickFlow(
+export async function tickFlow(
   flow: Flow,
   entries: FileEntry[],
   entriesByPath: Map<string, FileEntry>,
@@ -811,20 +823,35 @@ async function tickFlow(
 
   if (flow.state === "relaying") {
     const relayKey = roundKey(flow, round);
+    const activeRelay = relayLeases.get(relayKey);
+    if (activeRelay) {
+      await activeRelay;
+      return JSON.stringify(flow) !== before;
+    }
     if (round.relayStartedAt && round.relayedAt === null && !relayStartedThisProcess.has(relayKey)) {
       markNeedsDecision(flow, "relay was interrupted; it may have been delivered twice");
       return JSON.stringify(flow) !== before;
     }
+    const lease = (async () => {
+      try {
+        round.relayStartedAt = isoNow();
+        relayStartedThisProcess.add(relayKey);
+        persistCheckpoint();
+        await relayFindings(flow, entriesByPath, round);
+        persistCheckpoint();
+      } catch (error) {
+        markRoundError(round, error instanceof Error ? error.message : String(error));
+        flow.state = "paused";
+        flow.pausedState = "relaying";
+        flow.stateDetail = round.error;
+        persistCheckpoint();
+      }
+    })();
+    relayLeases.set(relayKey, lease);
     try {
-      round.relayStartedAt = isoNow();
-      relayStartedThisProcess.add(relayKey);
-      persistCheckpoint();
-      await relayFindings(flow, entriesByPath, round);
-    } catch (error) {
-      markRoundError(round, error instanceof Error ? error.message : String(error));
-      flow.state = "paused";
-      flow.pausedState = "relaying";
-      flow.stateDetail = round.error;
+      await lease;
+    } finally {
+      if (relayLeases.get(relayKey) === lease) relayLeases.delete(relayKey);
     }
     return JSON.stringify(flow) !== before;
   }

--- a/src/lib/pipelines/controller.test.ts
+++ b/src/lib/pipelines/controller.test.ts
@@ -131,7 +131,7 @@ test("a phase deadline releases the controller and later watchdog ticks keep pip
   await first;
 
   expect(flowCalls).toBe(1);
-  expect(pipelineCalls).toBe(1);
+  expect(pipelineCalls).toBe(2);
   expect(heartbeats).toContainEqual(expect.objectContaining({
     phase: "flows",
     state: "timed-out",
@@ -147,12 +147,51 @@ test("a phase deadline releases the controller and later watchdog ticks keep pip
 
   await controller.poll();
   expect(flowCalls).toBe(1);
-  expect(pipelineCalls).toBe(2);
+  expect(pipelineCalls).toBe(4);
   expect(heartbeats).toContainEqual(expect.objectContaining({
     phase: "flows",
     state: "blocked",
     ageMs: 500,
   }));
+});
+
+test("a blocked flow phase still lets the completed scan feed pipeline settlement (#529)", async () => {
+  type ManualTimer = { active: boolean; callback: () => void };
+  const timers: ManualTimer[] = [];
+  const entry = { path: "/sessions/completed-builder.jsonl" } as never;
+  const pipelineEntries: unknown[][] = [];
+  let scans = 0;
+  let markFlowStarted = () => {};
+  const flowStarted = new Promise<void>((resolve) => { markFlowStarted = resolve; });
+  const wedged = new Promise<never>(() => {});
+  const controller = new FlowPipelineController({
+    scan: async () => {
+      scans += 1;
+      return { files: [entry], complete: true };
+    },
+    tickPipelines: async (entries) => {
+      pipelineEntries.push(entries);
+      return { changed: false };
+    },
+    tickFlows: async () => {
+      markFlowStarted();
+      return wedged;
+    },
+    scheduleTimeout: (callback) => {
+      const timer = { active: true, callback };
+      timers.push(timer);
+      return timer;
+    },
+    clearTimeout: (timer) => { (timer as ManualTimer).active = false; },
+  }, { phaseDeadlineMs: 500 });
+
+  const tick = controller.tick("durable-pass-verdict");
+  await flowStarted;
+  timers.find((timer) => timer.active)!.callback();
+  await tick;
+
+  expect(scans).toBe(1);
+  expect(pipelineEntries).toEqual([[], [entry]]);
 });
 
 test("startup recovery and the watchdog converge a pending transition without duplicate effects", async () => {

--- a/src/lib/pipelines/controller.ts
+++ b/src/lib/pipelines/controller.ts
@@ -178,7 +178,8 @@ export class FlowPipelineController {
         : flowOutcome?.state === "failed" ? flowOutcome.error : null;
       if (failure !== null) throw failure;
       const changed = (pipelineOutcome.state === "completed" && pipelineOutcome.value.changed)
-        || (flowOutcome?.state === "completed" && flowOutcome.value.changed);
+        || (flowOutcome?.state === "completed" && flowOutcome.value.changed)
+        || (scanOutcome?.state === "completed" && scanOutcome.value.complete);
       if (!changed) break;
     }
     const blocked = [...this.activePhases.entries()]


### PR DESCRIPTION
Closes #529

## Summary
- share a per-flow/round relay lease across Viewer module instances
- checkpoint successful or failed relay settlement before releasing the lease
- cover overlapping delivery, durable fixing transition, and automatic repaired-head round creation

## Verification
- `bun test src/lib/flows/engine.test.ts src/lib/pipelines/controller.test.ts src/lib/pipelines/controllerSignal.test.ts`
- `bunx tsc --noEmit`
- `bun run lint -- src/lib/flows/engine.ts src/lib/flows/engine.test.ts src/lib/pipelines/controller.ts src/lib/pipelines/controller.test.ts`
- `bun run privacy:check`
- `git diff --check`