### PR TITLE
Propagate registry mode and bound runtime snapshots

### DIFF
--- a/docs/agent-registry-sqlite.md
+++ b/docs/agent-registry-sqlite.md
@@ -11,6 +11,14 @@ The first process that opens any gated SQLite mode creates `agent-registry.sqlit
 
 Every process with an enabled SQLite mode must run on Bun. The Docker Viewer uses `bun-container --bun`, and the published CLI selects Bun automatically when the gate is enabled. For a source checkout, launch Next with `bun --bun node_modules/.bin/next start`.
 
+Managed releases read the mode from the Viewer Compose environment. Set one
+`LLV_AGENT_REGISTRY_SQLITE=<mode>` entry in the service environment before a
+deployment starts. The immutable Viewer candidate receives that validated
+value, its deployment capability response reports the opened registry mode,
+and the runtime-host successor receives the same value after predecessor
+environment deduplication. Candidate health fails when the configured and
+observed modes differ, so promotion cannot publish a split registry fleet.
+
 ## Rollout
 
 1. Stop every Viewer and runtime-host process that can mutate the registry. Confirm that no registry writer remains before changing backend files.
@@ -27,7 +35,9 @@ Every process with an enabled SQLite mode must run on Bun. The Docker Viewer use
 writer-wait p95, rollback-mirror checkpoint timestamp, and dirty-checkpoint state under
 `systemHealth.registry`. The cached response exposes the stable mirror checkpoint
 timestamp and omits time-decaying writer rate; rollout probes derive both values at
-observation time. A rollout probe must
+observation time. `/api/runtime/deployments/capabilities/v1` reports
+`registryBackendMode` from the registry instance opened by that Viewer process.
+A rollout probe must
 observe one current release owner, a bounded mirror age in `read`, and a stable JSON
 mtime during `sqlite` streaming.
 

--- a/scripts/runtime-host-viewer-adapter.ts
+++ b/scripts/runtime-host-viewer-adapter.ts
@@ -13,6 +13,7 @@ import {
   viewerComposeSnapshotWithoutWakatimeCredential,
   viewerComposeServiceFromConfig,
   viewerComposeServiceUid,
+  viewerRegistryBackendMode,
 } from "../src/runtime-host/candidateContainer";
 import { ensureCanonicalMirror } from "../src/runtime-host/canonicalMirror";
 import { allocateBuiltCandidatePort, candidatePortsFromEnvironmentLists, isCandidatePortAvailable } from "../src/runtime-host/candidatePort";
@@ -28,7 +29,13 @@ import {
   writeRuntimeHostRelease,
 } from "../src/runtime-host/hostRelease";
 import { completeRuntimeHostHandoff, stageRuntimeHostSuccessorContainer } from "../src/runtime-host/hostSuccessor";
-import { hasViewerDeploymentCapability, viewerHealthRequestPlan, waitForViewerReadiness, type ViewerCandidateContainerState } from "../src/runtime-host/deploymentHealth";
+import {
+  hasViewerDeploymentCapability,
+  viewerDeploymentRegistryBackendMode,
+  viewerHealthRequestPlan,
+  waitForViewerReadiness,
+  type ViewerCandidateContainerState,
+} from "../src/runtime-host/deploymentHealth";
 import { withoutWakatimeCredential } from "../src/lib/wakatime/credential";
 
 const defaultConfigDir = process.env.XDG_CONFIG_HOME || path.join(process.env.HOME || "/home/user", ".config");
@@ -241,6 +248,11 @@ async function probeRoutes(candidate: ViewerReleaseIdentity, endpoint: string, e
   const unauthorized = requests.unauthorized ? await fetchStatus(requests.unauthorized.url, requests.unauthorized.headers) : null;
   const capability = await fetchStatus(requests.capability.url, requests.capability.headers);
   const deploymentCapable = hasViewerDeploymentCapability(capability.status, capability.text);
+  const expectedRegistryBackendMode = viewerRegistryBackendMode(
+    viewerComposeServiceFromConfig(fs.readFileSync(composeConfigFile(candidate.container), "utf8")),
+  );
+  const observedRegistryBackendMode = viewerDeploymentRegistryBackendMode(capability.status, capability.text);
+  const registryBackendMatches = observedRegistryBackendMode === expectedRegistryBackendMode;
   const html = authenticated?.status === 200 ? authenticated.text : root.text;
   const paths = referencedAssets(html);
   const assets = await Promise.all(paths.map(async (asset) => ({ path: asset, status: (await fetchStatus(`${endpoint}${asset}`)).status })));
@@ -258,6 +270,7 @@ async function probeRoutes(candidate: ViewerReleaseIdentity, endpoint: string, e
     && assets.length > 0
     && assets.every((asset) => asset.status === 200)
     && deploymentCapable
+    && registryBackendMatches
     && expectedAssetsMatch;
   return {
     checkedAt: new Date().toISOString(), endpoint, processReady, rootStatus: root.status,
@@ -265,6 +278,8 @@ async function probeRoutes(candidate: ViewerReleaseIdentity, endpoint: string, e
     ...(ok ? {} : {
       detail: !deploymentCapable
         ? "Viewer deployment capability gate failed"
+        : !registryBackendMatches
+          ? `Viewer registry backend mode mismatch: expected ${expectedRegistryBackendMode}, observed ${observedRegistryBackendMode ?? "unavailable"}`
         : expectedAssetsMatch
           ? "Viewer health or referenced asset gate failed"
           : "stable listener does not serve the candidate asset set",
@@ -328,6 +343,9 @@ function switchTarget(target: ViewerReleaseIdentity): void {
     needs to survive that exit. Only the runtime-host generation changes —
     Viewer containers and the engine processes they own are never signalled. */
 async function stageRuntimeHostSuccessor(candidate: ViewerReleaseIdentity): Promise<void> {
+  const registryBackendMode = viewerRegistryBackendMode(
+    viewerComposeServiceFromConfig(fs.readFileSync(composeConfigFile(candidate.container), "utf8")),
+  );
   await stageRuntimeHostSuccessorContainer(candidate, runtimeHostImageTag, {
     docker: (argv) => command(["docker", ...argv]),
     writeRelease: (record) => writeRuntimeHostRelease(record, runtimeHostReleaseFile()),
@@ -343,7 +361,7 @@ async function stageRuntimeHostSuccessor(candidate: ViewerReleaseIdentity): Prom
         return null;
       }
     },
-  });
+  }, { registryBackendMode });
 }
 
 async function main(): Promise<unknown> {

--- a/src/app/api/runtime/deployments/capabilities/v1/route.ts
+++ b/src/app/api/runtime/deployments/capabilities/v1/route.ts
@@ -1,9 +1,12 @@
+import { agentRegistry } from "@/lib/agent/registry";
+
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
 export function GET(): Response {
+  const registryBackendMode = agentRegistry().storageDiagnostics().backendMode;
   return Response.json(
-    { capability: "viewer-deployments", version: 1 },
+    { capability: "viewer-deployments", version: 1, registryBackendMode },
     { headers: { "cache-control": "no-store" } },
   );
 }

--- a/src/runtime-host/candidateContainer.test.ts
+++ b/src/runtime-host/candidateContainer.test.ts
@@ -7,6 +7,7 @@ import { runtimeEventsEnabled, runtimeHostSocket } from "@/lib/runtime/flags";
 import { WAKATIME_CREDENTIAL_ENV, withoutWakatimeCredential } from "@/lib/wakatime/credential";
 
 import {
+  AGENT_REGISTRY_SQLITE_ENV,
   obsoleteManagedViewerContainers,
   viewerAuthenticationTokenFromConfig,
   viewerCandidateDockerArgs,
@@ -112,6 +113,7 @@ test("promoted candidate derives its runtime contract from Compose", () => {
   expect(environment.LLV_DOCKER_NSENTER_SHIMS).toBe("1");
   expect(environment.GIT_SSH_COMMAND).toBe("ssh compose-config");
   expect(environment.LLV_ALLOW_LEGACY_VIEWER).toBe("1");
+  expect(environment[AGENT_REGISTRY_SQLITE_ENV]).toBe("off");
   expect(valuesAfter(args, "--label")).toEqual([
     "compose.viewer=production",
     "dev.live-log-viewer.managed=1",
@@ -128,6 +130,29 @@ test("promoted candidate derives its runtime contract from Compose", () => {
   expect(args[args.indexOf("--user") + 1]).toBe("1000:1000");
   expect(args[args.indexOf("--workdir") + 1]).toBe("/app");
   expect(args).toContain("--privileged");
+});
+
+test("promoted candidate validates and pins the operator registry backend mode", () => {
+  const configured = {
+    ...composeService,
+    environment: { ...composeService.environment, [AGENT_REGISTRY_SQLITE_ENV]: "dual-write" },
+  } satisfies ViewerComposeService;
+  const args = viewerCandidateDockerArgs(candidate, configured, {
+    runtimeSocket: "/state/runtime-host.sock",
+    legacyTmuxExternal: "1",
+    tmuxTmpdir: "/run/user/1000/agent-log-viewer",
+  });
+
+  expect(valuesAfter(args, "-e").filter((entry) => entry.startsWith(`${AGENT_REGISTRY_SQLITE_ENV}=`)))
+    .toEqual([`${AGENT_REGISTRY_SQLITE_ENV}=dual-write`]);
+  expect(() => viewerCandidateDockerArgs(candidate, {
+    ...configured,
+    environment: { ...configured.environment, [AGENT_REGISTRY_SQLITE_ENV]: "invalid" },
+  }, {
+    runtimeSocket: "/state/runtime-host.sock",
+    legacyTmuxExternal: "1",
+    tmuxTmpdir: "/run/user/1000/agent-log-viewer",
+  })).toThrow("LLV_AGENT_REGISTRY_SQLITE must be off, dual-write, read, or sqlite");
 });
 
 test("candidate artifacts exclude the legacy WakaTime credential", () => {
@@ -182,7 +207,12 @@ test("actual Viewer Compose keys remain covered by the candidate generator", () 
   });
   const environment = environmentFromArgs(args);
   expect(Object.keys(environment).sort()).toEqual([
-    ...new Set([...Object.keys(service.environment), "LLV_RUNTIME_EVENTS", "LLV_RUNTIME_HOST_SOCKET"]),
+    ...new Set([
+      ...Object.keys(service.environment),
+      AGENT_REGISTRY_SQLITE_ENV,
+      "LLV_RUNTIME_EVENTS",
+      "LLV_RUNTIME_HOST_SOCKET",
+    ]),
   ].sort());
   const mounts = valuesAfter(args, "--mount");
   const externalTmpdir = "/run/user/1000/agent-log-viewer";

--- a/src/runtime-host/candidateContainer.ts
+++ b/src/runtime-host/candidateContainer.ts
@@ -35,6 +35,17 @@ export interface ViewerCandidateContainerOverrides {
   tmuxTmpdir: string;
 }
 
+export const AGENT_REGISTRY_SQLITE_ENV = "LLV_AGENT_REGISTRY_SQLITE";
+export type AgentRegistryBackendMode = "off" | "dual-write" | "read" | "sqlite";
+
+export function viewerRegistryBackendMode(service: Pick<ViewerComposeService, "environment">): AgentRegistryBackendMode {
+  const configured = service.environment[AGENT_REGISTRY_SQLITE_ENV] ?? "off";
+  if (configured === "off" || configured === "dual-write" || configured === "read" || configured === "sqlite") {
+    return configured;
+  }
+  throw new Error("LLV_AGENT_REGISTRY_SQLITE must be off, dual-write, read, or sqlite");
+}
+
 const SERVICE_KEYS = new Set([
   "build", "command", "entrypoint", "environment", "image", "labels", "network_mode",
   "pid", "privileged", "profiles", "restart", "user", "volumes", "working_dir",
@@ -178,8 +189,10 @@ export function viewerCandidateDockerArgs(
   overrides: ViewerCandidateContainerOverrides,
 ): string[] {
   const endpoint = new URL(candidate.endpoint);
+  const registryBackendMode = viewerRegistryBackendMode(service);
   const environment = withoutWakatimeCredential({
     ...service.environment,
+    [AGENT_REGISTRY_SQLITE_ENV]: registryBackendMode,
     PORT: endpoint.port,
     LLV_RUNTIME_EVENTS: "1",
     LLV_RUNTIME_HOST_SOCKET: overrides.runtimeSocket,

--- a/src/runtime-host/deploymentHealth.test.ts
+++ b/src/runtime-host/deploymentHealth.test.ts
@@ -5,7 +5,12 @@ import type { ViewerHealthEvidence } from "@/lib/runtime/contracts";
 import { proxy } from "@/proxy";
 import { GET as deploymentCapability } from "@/app/api/runtime/deployments/capabilities/v1/route";
 
-import { hasViewerDeploymentCapability, viewerHealthRequestPlan, waitForViewerReadiness } from "./deploymentHealth";
+import {
+  hasViewerDeploymentCapability,
+  viewerDeploymentRegistryBackendMode,
+  viewerHealthRequestPlan,
+  waitForViewerReadiness,
+} from "./deploymentHealth";
 
 const originalToken = process.env.LLV_TOKEN;
 afterEach(() => {
@@ -77,9 +82,16 @@ test("health request plan exercises remote authorization and rejection", () => {
 
 test("deployment capability requires the candidate-owned versioned endpoint", async () => {
   const response = deploymentCapability();
+  const body = await response.text();
 
   expect(hasViewerDeploymentCapability(404, "")).toBe(false);
   expect(hasViewerDeploymentCapability(200, JSON.stringify({ deployments: [] }))).toBe(false);
   expect(response.status).toBe(200);
-  expect(hasViewerDeploymentCapability(response.status, await response.text())).toBe(true);
+  expect(hasViewerDeploymentCapability(response.status, body)).toBe(true);
+  expect(viewerDeploymentRegistryBackendMode(response.status, body)).toBe("off");
+  expect(viewerDeploymentRegistryBackendMode(200, JSON.stringify({
+    capability: "viewer-deployments",
+    version: 1,
+    registryBackendMode: "invalid",
+  }))).toBeNull();
 });

--- a/src/runtime-host/deploymentHealth.ts
+++ b/src/runtime-host/deploymentHealth.ts
@@ -40,6 +40,19 @@ export function hasViewerDeploymentCapability(status: number, body: string): boo
   }
 }
 
+export function viewerDeploymentRegistryBackendMode(
+  status: number,
+  body: string,
+): "off" | "dual-write" | "read" | "sqlite" | null {
+  if (!hasViewerDeploymentCapability(status, body)) return null;
+  try {
+    const mode = (JSON.parse(body) as { registryBackendMode?: unknown }).registryBackendMode;
+    return mode === "off" || mode === "dual-write" || mode === "read" || mode === "sqlite" ? mode : null;
+  } catch {
+    return null;
+  }
+}
+
 export interface ViewerReadinessProbe {
   endpoint: string;
   inspect(): Promise<ViewerCandidateContainerState>;

--- a/src/runtime-host/hostSuccessor.test.ts
+++ b/src/runtime-host/hostSuccessor.test.ts
@@ -19,6 +19,7 @@ import {
   stageRuntimeHostSuccessorContainer,
   type RuntimeHostSuccessorPorts,
 } from "./hostSuccessor";
+import { AGENT_REGISTRY_SQLITE_ENV } from "./candidateContainer";
 
 const revision = "b".repeat(40);
 const candidate: ViewerReleaseIdentity = {
@@ -107,6 +108,8 @@ const predecessorInspect = JSON.stringify([{
     Env: [
       "LLV_RUNTIME_EVENTS=1",
       "HOME=/home/user",
+      `${AGENT_REGISTRY_SQLITE_ENV}=off`,
+      `${AGENT_REGISTRY_SQLITE_ENV}=off`,
       `${WAKATIME_CREDENTIAL_ENV}=${wakatimePlaceholderValue}`,
     ],
     Cmd: ["bun-container", "run", "src/runtime-host/main.ts"],
@@ -142,6 +145,7 @@ function harness(overrides: {
   stableRestartCount?: number;
   stableStartedAt?: string;
   successorImage?: string;
+  registryBackendMode?: string;
   updateFailure?: Error;
   wait?: (milliseconds: number) => Promise<void>;
 } = {}): Harness {
@@ -175,6 +179,7 @@ function harness(overrides: {
           `${RUNTIME_HOST_IMAGE_ENV}=${candidate.image}`,
           `${RUNTIME_HOST_REVISION_ENV}=${candidate.revision}`,
           `${RUNTIME_HOST_CONTAINER_ENV}=${successorName}`,
+          `${AGENT_REGISTRY_SQLITE_ENV}=${overrides.registryBackendMode ?? "off"}`,
         ],
       },
     }]);
@@ -379,9 +384,11 @@ function crashHarness(world: CrashWorld): { ports: RuntimeHostSuccessorPorts; ca
    handoff: every mutating step is a short-lived CLI call against dockerd, so
    the successor exists daemon-side before the predecessor generation exits. */
 test("issue 518: staging creates a dockerd-owned successor from the candidate image without stopping the predecessor", async () => {
-  const { ports, calls, events, records, storedIntent } = harness();
+  const { ports, calls, events, records, storedIntent } = harness({ registryBackendMode: "dual-write" });
 
-  const staged = await stageRuntimeHostSuccessorContainer(candidate, "agent-log-viewer:node22", ports);
+  const staged = await stageRuntimeHostSuccessorContainer(candidate, "agent-log-viewer:node22", ports, {
+    registryBackendMode: "dual-write",
+  });
 
   expect(staged.successorContainer).toBe(runtimeHostSuccessorName(revision, candidate.image));
   /* The successor container boots exactly the deployed candidate image with
@@ -393,6 +400,8 @@ test("issue 518: staging creates a dockerd-owned successor from the candidate im
   expect(run).toContain(candidate.image);
   expect(run?.join(" ")).toContain("--restart unless-stopped");
   expect(run?.join(" ")).toContain(`-e ${RUNTIME_HOST_FENCE_WAIT_ENV}=`);
+  expect(run?.filter((entry) => entry === `${AGENT_REGISTRY_SQLITE_ENV}=dual-write`)).toHaveLength(1);
+  expect(run?.some((entry) => entry === `${AGENT_REGISTRY_SQLITE_ENV}=off`)).toBe(false);
   expect(run?.join(" ")).toContain("-v /home/user:/home/user");
   expect(run?.slice(-3)).toEqual(["bun-container", "run", "src/runtime-host/main.ts"]);
   /* The durable record binds the successor to the deployed revision only

--- a/src/runtime-host/hostSuccessor.ts
+++ b/src/runtime-host/hostSuccessor.ts
@@ -3,6 +3,8 @@ import { createHash } from "node:crypto";
 import type { ViewerReleaseIdentity } from "@/lib/runtime/contracts";
 import { withoutWakatimeCredentialEntries } from "@/lib/wakatime/credential";
 
+import { AGENT_REGISTRY_SQLITE_ENV, type AgentRegistryBackendMode } from "./candidateContainer";
+
 import {
   RUNTIME_HOST_CONTAINER_ENV,
   RUNTIME_HOST_IMAGE_ENV,
@@ -59,6 +61,10 @@ export interface RuntimeHostGenerationIdentity {
   image: string;
   revision: string;
   container: string;
+}
+
+export interface RuntimeHostSuccessorOptions {
+  registryBackendMode?: AgentRegistryBackendMode;
 }
 
 export function runtimeHostSuccessorName(revision: string, image: string): string {
@@ -156,7 +162,11 @@ function successorRunArgs(
   name: string,
   candidate: ViewerReleaseIdentity,
   predecessor: PredecessorTopology,
+  options: RuntimeHostSuccessorOptions,
 ): string[] {
+  const inheritedEnvironment = options.registryBackendMode === undefined
+    ? predecessor.env
+    : predecessor.env.filter((entry) => !isEnvironmentEntry(entry, AGENT_REGISTRY_SQLITE_ENV));
   return [
     "run", "-d",
     "--name", name,
@@ -173,7 +183,10 @@ function successorRunArgs(
     ...(predecessor.workingDir ? ["--workdir", predecessor.workingDir] : []),
     ...predecessor.groupAdd.flatMap((group) => ["--group-add", group]),
     ...predecessor.binds.flatMap((bind) => ["-v", bind]),
-    ...predecessor.env.flatMap((entry) => ["-e", entry]),
+    ...inheritedEnvironment.flatMap((entry) => ["-e", entry]),
+    ...(options.registryBackendMode === undefined
+      ? []
+      : ["-e", `${AGENT_REGISTRY_SQLITE_ENV}=${options.registryBackendMode}`]),
     "-e", `${RUNTIME_HOST_FENCE_WAIT_ENV}=${SUCCESSOR_FENCE_WAIT_MS}`,
     "-e", `${RUNTIME_HOST_IMAGE_ENV}=${candidate.image}`,
     "-e", `${RUNTIME_HOST_REVISION_ENV}=${candidate.revision}`,
@@ -203,7 +216,12 @@ function successorStartIdentity(raw: string): SuccessorStartIdentity {
   };
 }
 
-function successorMatchesGeneration(raw: string, name: string, candidate: ViewerReleaseIdentity): boolean {
+function successorMatchesGeneration(
+  raw: string,
+  name: string,
+  candidate: ViewerReleaseIdentity,
+  options: RuntimeHostSuccessorOptions,
+): boolean {
   const inspected = JSON.parse(raw) as Array<Record<string, unknown>>;
   const container = inspected[0] ?? {};
   const config = (container.Config ?? {}) as Record<string, unknown>;
@@ -216,7 +234,9 @@ function successorMatchesGeneration(raw: string, name: string, candidate: Viewer
     && labels["dev.live-log-viewer.revision"] === candidate.revision
     && hasSingleEntry(RUNTIME_HOST_IMAGE_ENV, candidate.image)
     && hasSingleEntry(RUNTIME_HOST_REVISION_ENV, candidate.revision)
-    && hasSingleEntry(RUNTIME_HOST_CONTAINER_ENV, name);
+    && hasSingleEntry(RUNTIME_HOST_CONTAINER_ENV, name)
+    && (options.registryBackendMode === undefined
+      || hasSingleEntry(AGENT_REGISTRY_SQLITE_ENV, options.registryBackendMode));
 }
 
 function encodedPredecessorId(raw: string, successorName: string): string | null {
@@ -231,10 +251,15 @@ function encodedPredecessorId(raw: string, successorName: string): string | null
   return predecessorId;
 }
 
-function successorIsReady(raw: string, name: string, candidate: ViewerReleaseIdentity): boolean {
+function successorIsReady(
+  raw: string,
+  name: string,
+  candidate: ViewerReleaseIdentity,
+  options: RuntimeHostSuccessorOptions,
+): boolean {
   const inspected = JSON.parse(raw) as Array<Record<string, unknown>>;
   const state = (inspected[0]?.State ?? {}) as Record<string, unknown>;
-  return successorMatchesGeneration(raw, name, candidate)
+  return successorMatchesGeneration(raw, name, candidate, options)
     && state.Status === "running"
     && state.Running === true
     && state.Restarting !== true;
@@ -249,14 +274,15 @@ async function observeStableSuccessor(
   name: string,
   candidate: ViewerReleaseIdentity,
   ports: RuntimeHostSuccessorPorts,
+  options: RuntimeHostSuccessorOptions,
 ): Promise<void> {
   const firstEvidence = await ports.docker(["container", "inspect", name]);
-  if (!successorIsReady(firstEvidence, name, candidate)) {
+  if (!successorIsReady(firstEvidence, name, candidate, options)) {
     throw new Error("runtime-host successor container failed its identity or running-state gate");
   }
   await (ports.wait ?? ((milliseconds) => new Promise((resolve) => setTimeout(resolve, milliseconds))))(DOCKER_RESTART_POLICY_STABILITY_MS);
   const stableEvidence = await ports.docker(["container", "inspect", name]);
-  if (!successorIsReady(stableEvidence, name, candidate)) {
+  if (!successorIsReady(stableEvidence, name, candidate, options)) {
     throw new Error("runtime-host successor container did not remain stably ready");
   }
   const first = successorStartIdentity(firstEvidence);
@@ -325,6 +351,7 @@ export async function stageRuntimeHostSuccessorContainer(
   candidate: ViewerReleaseIdentity,
   runtimeHostImageTag: string,
   ports: RuntimeHostSuccessorPorts,
+  options: RuntimeHostSuccessorOptions = {},
 ): Promise<{ successorContainer: string }> {
   const name = runtimeHostSuccessorName(candidate.revision, candidate.image);
   const intent = ports.readHandoffIntent();
@@ -344,7 +371,7 @@ export async function stageRuntimeHostSuccessorContainer(
        predecessor discovery is forbidden here — it would select, disable,
        and exit the successor itself. Both identities come from the intent. */
     await ports.docker(["container", "start", name]);
-    await observeStableSuccessor(name, candidate, ports);
+    await observeStableSuccessor(name, candidate, ports, options);
     await disablePredecessorRestart(intent.predecessorId, ports);
     publishReleaseOnce(name, candidate, ports);
     return { successorContainer: name };
@@ -353,7 +380,7 @@ export async function stageRuntimeHostSuccessorContainer(
   if (!predecessor) throw new Error("runtime-host predecessor container is unavailable for successor staging");
   let predecessorId = predecessor.id;
   try {
-    await ports.docker(successorRunArgs(name, candidate, predecessor));
+    await ports.docker(successorRunArgs(name, candidate, predecessor, options));
   } catch (error) {
     const message = error instanceof Error ? error.message : "";
     /* A same-attempt leftover may be reused only after its complete immutable
@@ -361,7 +388,7 @@ export async function stageRuntimeHostSuccessorContainer(
        stopped so it can never acquire the singleton fence. */
     if (!/is already in use|Conflict/.test(message)) throw error;
     const collision = await ports.docker(["container", "inspect", name]);
-    if (!successorMatchesGeneration(collision, name, candidate)) {
+    if (!successorMatchesGeneration(collision, name, candidate, options)) {
       throw new Error("runtime-host successor container failed its identity or running-state gate");
     }
     const encoded = encodedPredecessorId(collision, name);
@@ -369,7 +396,7 @@ export async function stageRuntimeHostSuccessorContainer(
     predecessorId = encoded;
     await ports.docker(["container", "start", name]);
   }
-  await observeStableSuccessor(name, candidate, ports);
+  await observeStableSuccessor(name, candidate, ports, options);
   ports.writeHandoffIntent({
     revision: candidate.revision,
     image: candidate.image,

--- a/src/runtime-host/journal.test.ts
+++ b/src/runtime-host/journal.test.ts
@@ -176,6 +176,38 @@ test("snapshot exposes the canonical projected runtime model", () => {
   journal.close();
 });
 
+test("snapshot bounds inactive session history while retaining every active session", () => {
+  const dir = sandbox("bounded-inactive-snapshot");
+  const journal = new RuntimeJournal(path.join(dir, "events.sqlite"), { maxEvents: 2_000, now: () => 100 });
+  const projectSession = (conversationId: string, host: "hosted" | "dead") => journal.append({
+    scope: runtimeScope("session", conversationId),
+    kind: "session-status",
+    payload: {
+      conversationId,
+      sessionKey: { engine: "claude", sessionId: `session-${conversationId}` },
+      hostKind: "claude-broker",
+      host,
+      turn: "idle",
+      provenance: "structured",
+      capabilities: { steer: false, structuredAttention: true },
+    },
+  });
+
+  projectSession("conversation_active_oldest", "hosted");
+  for (let index = 0; index < 300; index += 1) {
+    projectSession(`conversation_dead_${String(index).padStart(3, "0")}`, "dead");
+  }
+
+  const snapshot = journal.snapshot();
+  const ids = new Set(snapshot.sessions.map((session) => session.conversationId));
+  expect(snapshot.sessions).toHaveLength(129);
+  expect(ids.has("conversation_active_oldest")).toBeTrue();
+  expect(ids.has("conversation_dead_299")).toBeTrue();
+  expect(ids.has("conversation_dead_000")).toBeFalse();
+  expect(journal.sessionState("conversation_dead_000")).toMatchObject({ host: "dead" });
+  journal.close();
+});
+
 test("issue 51 keeps tool work running until authoritative turn completion", () => {
   const dir = sandbox("terminal-axes");
   const journal = new RuntimeJournal(path.join(dir, "events.sqlite"), { maxEvents: 100, now: () => 100 });

--- a/src/runtime-host/journal.ts
+++ b/src/runtime-host/journal.ts
@@ -35,6 +35,8 @@ import { runtimeImageCapability } from "@/lib/runtime/runtimeImageStore";
 
 export class RuntimeJournalFault extends Error {}
 
+export const RUNTIME_SNAPSHOT_INACTIVE_SESSION_LIMIT = 128;
+
 type EventRow = {
   seq: number;
   event_id: string;
@@ -674,7 +676,7 @@ export class RuntimeJournal {
         serverTime: new Date(this.now()).toISOString(),
         runtime: { hostEpoch: Number(this.meta("host_epoch")), health: this.meta("health") },
         filesRevision: Number(this.meta("files_revision")),
-        sessions: this.entityValues<RuntimeSession>("session").map((session) => ({
+        sessions: this.snapshotSessionValues().map((session) => ({
           ...session,
           recentReceipts: visibleReceipts(session.recentReceipts).map(runtimePresentationReceipt),
         })),
@@ -1603,6 +1605,30 @@ export class RuntimeJournal {
 
   private entityValues<T>(kind: string): T[] {
     return this.db.query<{ state_json: string }, [string]>("SELECT state_json FROM entities WHERE kind = ? ORDER BY id").all(kind).map((row) => JSON.parse(row.state_json) as T);
+  }
+
+  private snapshotSessionValues(): RuntimeSession[] {
+    const active = this.db.query<{ state_json: string }, [string, string, string]>(`
+      SELECT state_json
+      FROM entities
+      WHERE kind = ?
+        AND (
+          json_extract(state_json, '$.host') IS NULL
+          OR json_extract(state_json, '$.host') NOT IN (?, ?)
+        )
+      ORDER BY id
+    `).all("session", "dead", "unhosted");
+    const inactive = this.db.query<{ state_json: string }, [string, string, string, number]>(`
+      SELECT state_json
+      FROM entities
+      WHERE kind = ?
+        AND json_extract(state_json, '$.host') IN (?, ?)
+      ORDER BY checkpoint_seq DESC, id DESC
+      LIMIT ?
+    `).all("session", "dead", "unhosted", RUNTIME_SNAPSHOT_INACTIVE_SESSION_LIMIT);
+    return [...active, ...inactive]
+      .map((row) => JSON.parse(row.state_json) as RuntimeSession)
+      .sort((left, right) => left.conversationId.localeCompare(right.conversationId));
   }
 
   private recentEntityValues<T>(kind: string, limit: number): T[] {


### PR DESCRIPTION
Closes #534
Closes #535

## Summary

- propagate the validated registry backend mode into immutable Viewer candidates and runtime-host successors
- publish the opened mode through the deployment capability endpoint and reject candidate promotion on mode drift
- retain every active runtime session plus the 128 most recent inactive sessions in the hot snapshot
- preserve excluded historical sessions in the durable runtime journal
- document the managed rollout contract

## Production evidence

The copied production journal contained 923 sessions and produced a 3,058,740-byte snapshot. The bounded snapshot retained 55 hosted sessions plus 128 recent dead sessions, produced 1,365,771 bytes, and built in 17.63ms.

## Verification

- bun test src/runtime-host/journal.test.ts: 58 pass
- candidate/host-successor/deployment-health focused suite: 38 pass
- bunx tsc --noEmit
- scoped ESLint
- git diff --check

Registry cutover evidence on the active exact-SHA release: backendMode dual-write, revision 14, mirrorDirty false.