### PR TITLE
perf(scanner): keep controller scans incremental under pipeline churn

### DIFF
--- a/src/lib/scanner/describe.ts
+++ b/src/lib/scanner/describe.ts
@@ -999,6 +999,25 @@ function resolveProjectOverlay(
   return overlay;
 }
 
+/** Refresh state-backed project attribution from a durable complete summary.
+    A resolver-version migration can reuse transcript metadata while deriving
+    the current project, worktree, and canonical root. */
+export function reprojectFileDescription(
+  rootName: RootKey,
+  root: string,
+  pathname: string,
+  description: FileDescription,
+  stateKey = projectResolutionStateKey(),
+): FileDescription {
+  const overlay = resolveProjectOverlay(rootName, root, pathname, description.cwd, true, stateKey);
+  return {
+    ...description,
+    project: overlay.project,
+    worktree: overlay.worktree,
+    projectRoot: overlay.projectRoot,
+  };
+}
+
 export function describeFile(
   rootName: RootKey,
   root: string,

--- a/src/lib/scanner/discover.performance.test.ts
+++ b/src/lib/scanner/discover.performance.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from "bun:test";
+import fs from "node:fs";
 import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -61,6 +62,119 @@ test("large-catalog reconciliation keeps event-loop lag below the controller bud
     expect(percentile(lags, 0.95)).toBeLessThan(EVENT_LOOP_BUDGET_MS);
     expect(Math.max(...lags)).toBeLessThan(EVENT_LOOP_BUDGET_MS);
   } finally {
+    if (previousStateDir === undefined) delete process.env.LLV_STATE_DIR;
+    else process.env.LLV_STATE_DIR = previousStateDir;
+    await rm(base, { recursive: true, force: true });
+  }
+}, 30_000);
+
+test("pipeline status churn keeps a 100 MB growing transcript scan incremental and responsive", async () => {
+  const base = await mkdtemp(path.join(os.tmpdir(), "llv-growing-controller-scan-"));
+  const previousStateDir = process.env.LLV_STATE_DIR;
+  const stateDir = path.join(base, "state");
+  process.env.LLV_STATE_DIR = stateDir;
+  const originalOpen = fs.openSync;
+  const originalRead = fs.readSync;
+  const originalReadFile = fs.readFileSync;
+  const originalClose = fs.closeSync;
+  const tracked = new Set<number>();
+  let bytesRead = 0;
+  try {
+    const roots: Record<RootKey, string> = {
+      "codex-sessions": path.join(base, "codex-sessions"),
+      "claude-projects": path.join(base, "claude-projects"),
+      "claude-tasks": path.join(base, "claude-tasks"),
+    };
+    await Promise.all([...Object.values(roots), stateDir].map((root) => mkdir(root, { recursive: true })));
+    const flowPath = path.join(stateDir, "flows.json");
+    const workflowPath = path.join(stateDir, "workflows.json");
+    const writeControllerState = (state: string, heartbeatAt: number) => {
+      fs.writeFileSync(flowPath, JSON.stringify({
+        schemaVersion: 3,
+        flows: [{
+          id: "flow-growing",
+          project: "large-catalog",
+          cwd: "/repo/large-catalog",
+          implementerPath: "/sessions/implementer.jsonl",
+          state,
+          stateDetail: `heartbeat-${heartbeatAt}`,
+          rounds: [{ reviewerPath: "/sessions/reviewer.jsonl", state, heartbeatAt }],
+        }],
+      }) + "\n");
+      fs.writeFileSync(workflowPath, JSON.stringify({
+        workflows: [{
+          id: "workflow-growing",
+          project: "large-catalog",
+          repoDir: "/repo/large-catalog",
+          worktreeDir: "/repo/large-catalog-worktree",
+          state,
+          stageRuns: [{ agentPath: "/sessions/stage.jsonl", state, heartbeatAt }],
+        }],
+      }) + "\n");
+    };
+    writeControllerState("running", 100);
+    fs.writeFileSync(path.join(stateDir, "worktree-map.json"), "{}\n");
+
+    const active = path.join(roots["codex-sessions"], "rollout-active.jsonl");
+    const activeFd = fs.openSync(active, "w");
+    const sessionMeta = `${JSON.stringify({ type: "session_meta", payload: { cwd: "/repo/large-catalog" } })}\n`;
+    fs.writeSync(activeFd, sessionMeta, 0, "utf8");
+    fs.ftruncateSync(activeFd, 100 * 1024 * 1024);
+    fs.writeSync(activeFd, "\n", 100 * 1024 * 1024 - 1, "utf8");
+    fs.closeSync(activeFd);
+    const stableTranscript = `${sessionMeta}${JSON.stringify({ type: "event_msg", payload: { type: "task_complete" } })}\n`;
+    await Promise.all(Array.from({ length: LARGE_CATALOG_SIZE - 1 }, (_, index) => writeFile(
+      path.join(roots["codex-sessions"], `rollout-stable-${String(index).padStart(4, "0")}.jsonl`),
+      stableTranscript,
+    )));
+
+    const initial = await discoverFilesWithProjectCatalog(roots, undefined, { persist: true });
+    expect(initial.projectCatalog.reduce((total, project) => total + project.conversations, 0)).toBe(LARGE_CATALOG_SIZE);
+    writeControllerState("needs_decision", 200);
+    fs.appendFileSync(active, `${JSON.stringify({ type: "event_msg", payload: { type: "agent_message", message: "continued" } })}\n`);
+    const scannerCaches = (globalThis as typeof globalThis & { __llvCaches?: Record<string, Map<string, unknown>> }).__llvCaches;
+    for (const cache of Object.values(scannerCaches ?? {})) cache.clear();
+
+    const transcriptPaths = new Set([active, ...Array.from({ length: LARGE_CATALOG_SIZE - 1 }, (_, index) =>
+      path.join(roots["codex-sessions"], `rollout-stable-${String(index).padStart(4, "0")}.jsonl`))]);
+    fs.openSync = ((filename: fs.PathLike, flags: fs.OpenMode, mode?: fs.Mode) => {
+      const fd = originalOpen(filename, flags, mode);
+      if (transcriptPaths.has(path.resolve(String(filename)))) tracked.add(fd);
+      return fd;
+    }) as typeof fs.openSync;
+    fs.readSync = ((fd: number, buffer: NodeJS.ArrayBufferView, offset: number, length: number, position: fs.ReadPosition) => {
+      const read = originalRead(fd, buffer, offset, length, position);
+      if (tracked.has(fd)) bytesRead += read;
+      return read;
+    }) as typeof fs.readSync;
+    fs.readFileSync = ((filename: fs.PathOrFileDescriptor, ...args: unknown[]) => {
+      const value = Reflect.apply(originalReadFile, fs, [filename, ...args]) as Buffer | string;
+      if (typeof filename !== "number" && transcriptPaths.has(path.resolve(String(filename)))) {
+        bytesRead += typeof value === "string" ? Buffer.byteLength(value) : value.byteLength;
+      }
+      return value;
+    }) as typeof fs.readFileSync;
+    fs.closeSync = ((fd: number) => {
+      tracked.delete(fd);
+      return originalClose(fd);
+    }) as typeof fs.closeSync;
+
+    const startedAt = performance.now();
+    const lags = await eventLoopLagsWhile(async () => {
+      const scan = await discoverFilesWithProjectCatalog(roots, undefined, { persist: false });
+      expect(scan.projectCatalog.reduce((total, project) => total + project.conversations, 0)).toBe(LARGE_CATALOG_SIZE);
+    });
+    const durationMs = performance.now() - startedAt;
+
+    expect(bytesRead).toBeLessThanOrEqual(2 * 1024 * 1024);
+    expect(durationMs).toBeLessThan(15_000);
+    expect(percentile(lags, 0.95)).toBeLessThan(EVENT_LOOP_BUDGET_MS);
+    expect(Math.max(...lags)).toBeLessThan(EVENT_LOOP_BUDGET_MS);
+  } finally {
+    fs.openSync = originalOpen;
+    fs.readSync = originalRead;
+    fs.readFileSync = originalReadFile;
+    fs.closeSync = originalClose;
     if (previousStateDir === undefined) delete process.env.LLV_STATE_DIR;
     else process.env.LLV_STATE_DIR = previousStateDir;
     await rm(base, { recursive: true, force: true });

--- a/src/lib/scanner/discover.performance.test.ts
+++ b/src/lib/scanner/discover.performance.test.ts
@@ -7,6 +7,7 @@ import { performance } from "node:perf_hooks";
 
 import type { RootKey } from "../types";
 import { discoverFilesWithProjectCatalog } from "./discover";
+import { PROJECT_RESOLUTION_VERSION } from "./projectState";
 
 const LARGE_CATALOG_SIZE = 800;
 const EVENT_LOOP_BUDGET_MS = 100;
@@ -122,7 +123,10 @@ test("pipeline status churn keeps a 100 MB growing transcript scan incremental a
     fs.ftruncateSync(activeFd, 100 * 1024 * 1024);
     fs.writeSync(activeFd, "\n", 100 * 1024 * 1024 - 1, "utf8");
     fs.closeSync(activeFd);
-    const stableTranscript = `${sessionMeta}${JSON.stringify({ type: "event_msg", payload: { type: "task_complete" } })}\n`;
+    const stableTranscript = `${sessionMeta}${JSON.stringify({
+      type: "event_msg",
+      payload: { type: "agent_message", message: "x".repeat(8 * 1024) },
+    })}\n${JSON.stringify({ type: "event_msg", payload: { type: "task_complete" } })}\n`;
     await Promise.all(Array.from({ length: LARGE_CATALOG_SIZE - 1 }, (_, index) => writeFile(
       path.join(roots["codex-sessions"], `rollout-stable-${String(index).padStart(4, "0")}.jsonl`),
       stableTranscript,
@@ -130,6 +134,14 @@ test("pipeline status churn keeps a 100 MB growing transcript scan incremental a
 
     const initial = await discoverFilesWithProjectCatalog(roots, undefined, { persist: true });
     expect(initial.projectCatalog.reduce((total, project) => total + project.conversations, 0)).toBe(LARGE_CATALOG_SIZE);
+    const catalogPath = path.join(stateDir, "project-catalog.json");
+    const legacyCatalog = JSON.parse(fs.readFileSync(catalogPath, "utf8")) as {
+      resolutionVersion: number;
+      files: Record<string, { stateKey: string }>;
+    };
+    legacyCatalog.resolutionVersion = 2;
+    for (const file of Object.values(legacyCatalog.files)) file.stateKey = "legacy-raw-controller-key";
+    fs.writeFileSync(catalogPath, JSON.stringify(legacyCatalog) + "\n");
     writeControllerState("needs_decision", 200);
     fs.appendFileSync(active, `${JSON.stringify({ type: "event_msg", payload: { type: "agent_message", message: "continued" } })}\n`);
     const scannerCaches = (globalThis as typeof globalThis & { __llvCaches?: Record<string, Map<string, unknown>> }).__llvCaches;
@@ -161,13 +173,16 @@ test("pipeline status churn keeps a 100 MB growing transcript scan incremental a
 
     const startedAt = performance.now();
     const lags = await eventLoopLagsWhile(async () => {
-      const scan = await discoverFilesWithProjectCatalog(roots, undefined, { persist: false });
+      const scan = await discoverFilesWithProjectCatalog(roots, undefined, { persist: true });
       expect(scan.projectCatalog.reduce((total, project) => total + project.conversations, 0)).toBe(LARGE_CATALOG_SIZE);
+      expect(scan.files.every((entry) => entry.project === "large-catalog")).toBe(true);
     });
     const durationMs = performance.now() - startedAt;
+    const migratedCatalog = JSON.parse(fs.readFileSync(catalogPath, "utf8")) as { resolutionVersion: number };
 
     expect(bytesRead).toBeLessThanOrEqual(2 * 1024 * 1024);
     expect(durationMs).toBeLessThan(15_000);
+    expect(migratedCatalog.resolutionVersion).toBe(PROJECT_RESOLUTION_VERSION);
     expect(percentile(lags, 0.95)).toBeLessThan(EVENT_LOOP_BUDGET_MS);
     expect(Math.max(...lags)).toBeLessThan(EVENT_LOOP_BUDGET_MS);
   } finally {

--- a/src/lib/scanner/projectCatalog.ts
+++ b/src/lib/scanner/projectCatalog.ts
@@ -11,6 +11,7 @@ import { replaceConversationCatalog, type ConversationCatalogEntry } from "./con
 import {
   describeFile,
   fileDescriptionIdentity,
+  reprojectFileDescription,
   type FileDescription,
 } from "./describe";
 import type { RawEntry } from "./discover";
@@ -217,9 +218,74 @@ function fallbackTitle(raw: RawEntry, kind: string): string {
   return "Background task " + filename.split(".")[0];
 }
 
+function storeCachedFile(state: ProjectCatalogState, file: ProjectCatalogFile): void {
+  state.files[file.path] = {
+    summaryVersion: file.summaryVersion,
+    summaryIncomplete: file.summaryIncomplete,
+    rootName: file.rootName,
+    size: file.size,
+    mtimeMs: file.mtimeMs,
+    sidecarSize: file.sidecarSize,
+    sidecarMtimeMs: file.sidecarMtimeMs,
+    stateKey: file.stateKey,
+    project: file.project,
+    projectRoot: file.projectRoot,
+    kind: file.kind,
+    session: file.session,
+    worktree: file.worktree,
+    cwd: file.cwd ?? null,
+    sessionStartedAt: file.sessionStartedAt ?? null,
+    nativeParentThreadId: file.nativeParentThreadId ?? null,
+    title: file.titleCached ? file.title : undefined,
+    engine: file.engine,
+    fmt: file.fmt,
+  };
+}
+
 function cachedFile(raw: RawEntry, state: ProjectCatalogState, stateKey: string): ProjectCatalogFile {
   const cached = state.files[raw.path];
   const identity = fileDescriptionIdentity(raw.rootName, raw.path, raw.st);
+  const durableSummaryMatches = identity.complete
+    && cached?.summaryVersion === PROJECT_SUMMARY_VERSION
+    && cached.size === raw.st.size
+    && cached.mtimeMs === raw.st.mtimeMs
+    && cached.sidecarSize === identity.sidecarSize
+    && cached.sidecarMtimeMs === identity.sidecarMtimeMs
+    && cached.projectRoot !== undefined;
+  if (durableSummaryMatches && (
+    state.resolutionVersion !== PROJECT_RESOLUTION_VERSION
+    || cached.stateKey !== stateKey
+  )) {
+    const description = reprojectFileDescription(raw.rootName, raw.root, raw.path, {
+      project: cached.project,
+      worktree: cached.worktree,
+      cwd: cached.cwd ?? undefined,
+      sessionStartedAt: cached.sessionStartedAt,
+      nativeParentThreadId: cached.nativeParentThreadId,
+      projectRoot: cached.projectRoot,
+      title: cached.title ?? fallbackTitle(raw, cached.kind),
+      engine: cached.engine ?? engineForRoot(raw.rootName),
+      kind: cached.kind,
+      fmt: cached.fmt ?? fmtForRoot(raw.rootName),
+    }, stateKey);
+    const file: ProjectCatalogFile = {
+      ...cached,
+      path: raw.path,
+      stateKey,
+      project: description.project,
+      projectRoot: description.projectRoot ?? null,
+      worktree: description.worktree,
+      cwd: description.cwd,
+      session: isConversation(raw.rootName, description.kind),
+      title: description.title,
+      titleCached: true,
+      engine: description.engine,
+      kind: description.kind,
+      fmt: description.fmt,
+    };
+    storeCachedFile(state, file);
+    return file;
+  }
   if (
     state.resolutionVersion === PROJECT_RESOLUTION_VERSION &&
     identity.complete &&
@@ -297,27 +363,7 @@ function cachedFile(raw: RawEntry, state: ProjectCatalogState, stateKey: string)
     engine: meta.engine,
     fmt: meta.fmt,
   };
-  state.files[raw.path] = {
-    summaryVersion: file.summaryVersion,
-    summaryIncomplete: file.summaryIncomplete,
-    rootName: file.rootName,
-    size: file.size,
-    mtimeMs: file.mtimeMs,
-    sidecarSize: file.sidecarSize,
-    sidecarMtimeMs: file.sidecarMtimeMs,
-    stateKey: file.stateKey,
-    project: file.project,
-    projectRoot: file.projectRoot,
-    kind: file.kind,
-    session: file.session,
-    worktree: file.worktree,
-    cwd: file.cwd ?? null,
-    sessionStartedAt: file.sessionStartedAt ?? null,
-    nativeParentThreadId: file.nativeParentThreadId ?? null,
-    title: file.titleCached ? file.title : undefined,
-    engine: file.engine,
-    fmt: file.fmt,
-  };
+  storeCachedFile(state, file);
   return file;
 }
 

--- a/src/lib/scanner/projectState.test.ts
+++ b/src/lib/scanner/projectState.test.ts
@@ -1,0 +1,93 @@
+import { afterEach, beforeEach, expect, test } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { projectResolutionStateKey } from "./projectState";
+
+let sandbox = "";
+let previousStateDir: string | undefined;
+
+beforeEach(() => {
+  previousStateDir = process.env.LLV_STATE_DIR;
+  sandbox = fs.mkdtempSync(path.join(os.tmpdir(), "llv-project-state-"));
+  process.env.LLV_STATE_DIR = sandbox;
+  fs.writeFileSync(path.join(sandbox, "worktree-map.json"), "{}\n");
+});
+
+afterEach(() => {
+  if (previousStateDir === undefined) delete process.env.LLV_STATE_DIR;
+  else process.env.LLV_STATE_DIR = previousStateDir;
+  fs.rmSync(sandbox, { recursive: true, force: true });
+});
+
+function writeState(name: "flows.json" | "workflows.json", value: unknown): void {
+  fs.writeFileSync(path.join(sandbox, name), JSON.stringify(value) + "\n");
+}
+
+test("status-only controller rewrites preserve the project resolution state key", () => {
+  writeState("flows.json", {
+    schemaVersion: 3,
+    flows: [{
+      id: "flow-1",
+      project: "viewer",
+      cwd: "/repo/viewer-worktree",
+      implementerPath: "/sessions/implementer.jsonl",
+      state: "running",
+      stateDetail: "scanning",
+      rounds: [{ reviewerPath: "/sessions/reviewer.jsonl", state: "running", updatedAt: 100 }],
+    }],
+  });
+  writeState("workflows.json", {
+    workflows: [{
+      id: "workflow-1",
+      project: "viewer",
+      repoDir: "/repo/viewer",
+      worktreeDir: "/repo/viewer-worktree",
+      fixerPath: "/sessions/fixer.jsonl",
+      state: "running",
+      stageRuns: [{ agentPath: "/sessions/stage.jsonl", state: "running", heartbeatAt: 100 }],
+    }],
+  });
+  const before = projectResolutionStateKey();
+
+  writeState("flows.json", {
+    schemaVersion: 3,
+    flows: [{
+      id: "flow-1",
+      project: "viewer",
+      cwd: "/repo/viewer-worktree",
+      implementerPath: "/sessions/implementer.jsonl",
+      state: "needs_decision",
+      stateDetail: "controller deadline",
+      rounds: [{ reviewerPath: "/sessions/reviewer.jsonl", state: "completed", updatedAt: 200 }],
+    }],
+  });
+  writeState("workflows.json", {
+    workflows: [{
+      id: "workflow-1",
+      project: "viewer",
+      repoDir: "/repo/viewer",
+      worktreeDir: "/repo/viewer-worktree",
+      fixerPath: "/sessions/fixer.jsonl",
+      state: "completed",
+      stageRuns: [{ agentPath: "/sessions/stage.jsonl", state: "completed", heartbeatAt: 200 }],
+    }],
+  });
+
+  expect(projectResolutionStateKey()).toBe(before);
+});
+
+test("project attribution path changes advance the project resolution state key", () => {
+  writeState("flows.json", {
+    flows: [{ project: "viewer", cwd: "/repo/first", implementerPath: "/sessions/first.jsonl", rounds: [] }],
+  });
+  writeState("workflows.json", { workflows: [] });
+  const before = projectResolutionStateKey();
+
+  writeState("flows.json", {
+    flows: [{ project: "viewer", cwd: "/repo/second", implementerPath: "/sessions/second.jsonl", rounds: [] }],
+  });
+
+  expect(projectResolutionStateKey()).not.toBe(before);
+});

--- a/src/lib/scanner/projectState.ts
+++ b/src/lib/scanner/projectState.ts
@@ -4,23 +4,88 @@ import path from "node:path";
 
 import { stateDir } from "@/lib/configDir";
 
-const PROJECT_STATE_FILES = ["flows.json", "workflows.json", "worktree-map.json"] as const;
-export const PROJECT_RESOLUTION_VERSION = 2;
+export const PROJECT_RESOLUTION_VERSION = 3;
+
+/* Project summaries depend on the attribution facts consumed by
+   persistedProjects(). Hashing these stable projections keeps controller
+   heartbeats and stage status updates from invalidating the whole catalog. */
+
+function record(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : null;
+}
+
+function populatedString(value: unknown): string | null {
+  return typeof value === "string" && value.trim() ? value : null;
+}
+
+function pathList(value: unknown, key: string): string[] {
+  if (!Array.isArray(value)) return [];
+  return [...new Set(value.flatMap((candidate) => {
+    const pathname = populatedString(record(candidate)?.[key]);
+    return pathname ? [pathname] : [];
+  }))].sort();
+}
+
+function flowProjectFacts(value: unknown): unknown[] {
+  const source = record(value);
+  if (!source || !Array.isArray(source.flows)) return [];
+  return source.flows.flatMap((candidate) => {
+    const flow = record(candidate);
+    const project = populatedString(flow?.project);
+    const cwd = populatedString(flow?.cwd);
+    if (!flow || !project || !cwd) return [];
+    return [[
+      project,
+      cwd,
+      populatedString(flow.implementerPath),
+      pathList(flow.rounds, "reviewerPath"),
+    ]];
+  });
+}
+
+function workflowProjectFacts(value: unknown): unknown[] {
+  const source = record(value);
+  if (!source || !Array.isArray(source.workflows)) return [];
+  return source.workflows.flatMap((candidate) => {
+    const workflow = record(candidate);
+    const project = populatedString(workflow?.project);
+    const repoDir = populatedString(workflow?.repoDir);
+    const worktreeDir = populatedString(workflow?.worktreeDir);
+    if (!workflow || !project || (!repoDir && !worktreeDir)) return [];
+    return [[
+      project,
+      repoDir,
+      worktreeDir,
+      pathList(workflow.stageRuns, "agentPath"),
+      populatedString(workflow.fixerPath),
+    ]];
+  });
+}
+
+function stateJson(name: string): unknown {
+  try {
+    return JSON.parse(fs.readFileSync(path.join(stateDir(), name), "utf8")) as unknown;
+  } catch {
+    return null;
+  }
+}
 
 export function projectResolutionStateKey(): string {
   const dir = stateDir();
   const hash = crypto.createHash("sha1");
   hash.update(dir);
   hash.update(`\0resolver-version\0${PROJECT_RESOLUTION_VERSION}`);
-  for (const name of PROJECT_STATE_FILES) {
-    hash.update("\0");
-    hash.update(name);
-    hash.update("\0");
-    try {
-      hash.update(fs.readFileSync(path.join(dir, name)));
-    } catch {
-      hash.update("<missing>");
-    }
+  hash.update("\0flows.json\0");
+  hash.update(JSON.stringify(flowProjectFacts(stateJson("flows.json"))));
+  hash.update("\0workflows.json\0");
+  hash.update(JSON.stringify(workflowProjectFacts(stateJson("workflows.json"))));
+  hash.update("\0worktree-map.json\0");
+  try {
+    hash.update(fs.readFileSync(path.join(dir, "worktree-map.json")));
+  } catch {
+    hash.update("<missing>");
   }
   return hash.digest("hex");
 }


### PR DESCRIPTION
Closes #537

## Summary
- derive the project-resolution cache key from stable attribution facts used by flow/workflow mapping
- migrate durable v2 catalog summaries through project-only reprojection with zero historical transcript-body rereads
- cover 800 conversations, a growing sparse 100 MB Codex transcript, pipeline status churn, legacy catalog migration, event-loop lag, persistence, and a 15-second controller budget

## Review round
- exact-base root review found a cold v2-to-v3 migration risk
- the repair preserves durable transcript metadata and persists resolver v3 during the first controller scan
- cumulative exact-head review completed with no remaining findings

## Verification
- `bun test src/lib/scanner` — 226 pass
- `bun test src/app/api/files/scanCache.real.test.ts` — 16 pass
- `bun x tsc --noEmit`
- scoped ESLint
- `bun run build`
- `bun run privacy:check`
