### PR TITLE
fix(runtime): unblock structured startup reconciliation

### DIFF
--- a/src/lib/agent/registry.test.ts
+++ b/src/lib/agent/registry.test.ts
@@ -196,6 +196,37 @@ describe("agent registry", () => {
     )).toThrow(DeliveryReservationConflictError);
   });
 
+  test("production backlog reconciliation settles many operation outcomes in one registry transaction", () => {
+    const store = registry();
+    const conversation = store.ensureConversation("codex", "/bulk-operation-reconciliation.jsonl", "default");
+    const outcomes = Array.from({ length: 42 }, (_, index) => {
+      const operationId = `bulk-operation-${index}`;
+      const delivery = store.holdDelivery(
+        conversation.id,
+        `bulk delivery ${index}`,
+        `bulk-client-${index}`,
+        "text",
+        [],
+        null,
+        { operationId, kind: "send", policy: "queue", turnId: null },
+      );
+      expect(store.beginDeliveryAttempt(delivery.id, delivery.generationId!)).not.toBeNull();
+      return {
+        conversationId: conversation.id,
+        operationId,
+        state: "delivered" as const,
+        error: null,
+      };
+    });
+    const before = store.storageDiagnostics().transactionCount;
+
+    const settled = store.recordDeliveryOutcomesForOperations(outcomes);
+
+    expect(store.storageDiagnostics().transactionCount).toBe(before + 1);
+    expect(settled).toHaveLength(outcomes.length);
+    expect(settled.every((delivery) => delivery?.state === "delivered" && delivery.text === "")).toBe(true);
+  });
+
   test("legacy terminal owner normalization rejects a mismatched settled snapshot", () => {
     const store = registry();
     const conversation = store.ensureConversation("codex", "/operation-owner-legacy-mismatch.jsonl", "default");

--- a/src/lib/agent/registry.ts
+++ b/src/lib/agent/registry.ts
@@ -5488,24 +5488,54 @@ export class AgentRegistry {
     state: Extract<HeldDelivery["state"], "delivered" | "failed">,
     error: string | null = null,
   ): HeldDelivery | null {
+    return this.recordDeliveryOutcomesForOperations([{
+      conversationId,
+      operationId,
+      state,
+      error,
+    }])[0] ?? null;
+  }
+
+  /** Settles a startup reconciliation page in one storage transaction. A
+      production registry can retain hundreds of terminal reservations; one
+      whole-file JSON/SQLite parity pass per reservation starves the Viewer. */
+  recordDeliveryOutcomesForOperations(
+    outcomes: readonly {
+      conversationId: ViewerConversationId;
+      operationId: string;
+      state: Extract<HeldDelivery["state"], "delivered" | "failed">;
+      error?: string | null;
+    }[],
+  ): (HeldDelivery | null)[] {
     return this.mutate((file) => {
-      const canonicalId = resolveConversationAlias(file, conversationId);
-      const delivery = Object.values(file.heldDeliveries).find((candidate) =>
-        resolveConversationAlias(file, candidate.conversationId) === canonicalId
-        && candidate.command.operationId === operationId);
-      if (!delivery || delivery.state === "delivered") return delivery ? clone(delivery) : null;
-      const retryRecovered = delivery.state === "failed" && state === "delivered";
-      if (delivery.state !== "delivery-uncertain" && !retryRecovered) return null;
-      const conversation = file.conversations[canonicalId];
-      const paths = new Set([conversation?.generations.at(-1)?.path].filter((pathname): pathname is string => Boolean(pathname)));
-      const signature = conversation ? migrationReadinessSignature(file, conversation.engine, paths) : "";
-      delivery.state = state;
-      delivery.deliveredAt = state === "delivered" ? now() : null;
-      delivery.error = error?.slice(0, 240) ?? null;
-      if (state === "delivered") delivery.text = "";
-      if (conversation) advanceMigrationScopeRevision(file, conversation.engine, signature, paths);
-      const settled = clone(delivery);
-      compactDeliveryReservations(file, delivery.conversationId);
+      const keyFor = (candidateConversationId: ViewerConversationId, candidateOperationId: string) =>
+        `${resolveConversationAlias(file, candidateConversationId)}\u0000${candidateOperationId}`;
+      const deliveries = new Map<string, HeldDelivery>();
+      for (const delivery of Object.values(file.heldDeliveries)) {
+        const key = keyFor(delivery.conversationId, delivery.command.operationId);
+        if (!deliveries.has(key)) deliveries.set(key, delivery);
+      }
+      const compactConversations = new Set<ViewerConversationId>();
+      const settled = outcomes.map((outcome) => {
+        const canonicalId = resolveConversationAlias(file, outcome.conversationId);
+        const delivery = deliveries.get(keyFor(canonicalId, outcome.operationId));
+        if (!delivery || delivery.state === "delivered") return delivery ? clone(delivery) : null;
+        const retryRecovered = delivery.state === "failed" && outcome.state === "delivered";
+        if (delivery.state !== "delivery-uncertain" && !retryRecovered) return null;
+        const conversation = file.conversations[canonicalId];
+        const paths = new Set([conversation?.generations.at(-1)?.path].filter((pathname): pathname is string => Boolean(pathname)));
+        const signature = conversation ? migrationReadinessSignature(file, conversation.engine, paths) : "";
+        delivery.state = outcome.state;
+        delivery.deliveredAt = outcome.state === "delivered" ? now() : null;
+        delivery.error = outcome.error?.slice(0, 240) ?? null;
+        if (outcome.state === "delivered") delivery.text = "";
+        if (conversation) advanceMigrationScopeRevision(file, conversation.engine, signature, paths);
+        compactConversations.add(delivery.conversationId);
+        return clone(delivery);
+      });
+      for (const compactConversationId of compactConversations) {
+        compactDeliveryReservations(file, compactConversationId);
+      }
       return settled;
     });
   }

--- a/src/lib/runtime/structuredDelivery.integration.test.ts
+++ b/src/lib/runtime/structuredDelivery.integration.test.ts
@@ -13,7 +13,7 @@ import { RuntimeJournal } from "@/runtime-host/journal";
 import type { RuntimeHostClient } from "./client";
 import type { EngineHost, HostState, QueueEntry, RuntimeEvent } from "./engineHost";
 import { FakeEngineHost, createFakeDeliveryLedger } from "./fixtures/fakeEngineHost";
-import { bindStructuredDeliveryQueue, publishStructuredDeliveryHost, republishStructuredDeliveryHost } from "./structuredDeliveryController";
+import { bindStructuredDeliveryQueue, hasStructuredDeliveryHost, publishStructuredDeliveryHost, republishStructuredDeliveryHost } from "./structuredDeliveryController";
 import { StructuredDeliveryQueue, type StructuredDeliveryQueuePort } from "./structuredDeliveryQueue";
 import { kickStructuredDeliveryQueue } from "./structuredDeliverySignal";
 import { deliverHeldStructuredMessage, enqueueStructuredMessage } from "./structuredMessageDelivery";
@@ -2054,6 +2054,202 @@ test("queue binding settles an uncertain reservation from a terminal journal rec
     text: "",
     error: null,
   });
+  await bindStructuredDeliveryQueue([], { registry, client: null });
+});
+
+test("production backlog reconciliation publishes the controller before a historical status read settles", async () => {
+  const sessionId = "bcbcbcbc-bcbc-4bcb-8bcb-bcbcbcbcbcbc";
+  const directory = path.join(sandbox, "controller-ready-before-backlog-reconciliation");
+  const artifactPath = path.join(directory, `${sessionId}.jsonl`);
+  const registry = new AgentRegistry(path.join(directory, "agent-registry.json"));
+  registry.reconcileConversations([{
+    engine: "codex",
+    path: artifactPath,
+    accountId: "default",
+    launchProfile: emptyLaunchProfile({ cwd: directory }),
+    turn: { state: "idle", source: "empty", terminalAt: null },
+    observedAt: "2026-07-21T20:00:00.000Z",
+  }]);
+  const conversation = registry.conversationForPath(artifactPath)!;
+  const operationId = "operation-blocked-historical-status";
+  const held = registry.holdDelivery(
+    conversation.id,
+    "historical status remains in flight",
+    "blocked-historical-status",
+    "text",
+    [],
+    null,
+    { operationId, kind: "send", policy: "queue", turnId: null },
+  );
+  registry.beginDeliveryAttempt(held.id, held.generationId!);
+  let statusStarted!: () => void;
+  const statusStartedPromise = new Promise<void>((resolve) => { statusStarted = resolve; });
+  let releaseStatus!: () => void;
+  const statusRelease = new Promise<void>((resolve) => { releaseStatus = resolve; });
+  const client = {
+    operationStatus: async () => {
+      statusStarted();
+      await statusRelease;
+      return {
+        operationId,
+        replayed: true,
+        receipt: {
+          operationId,
+          idempotencyKey: "blocked-historical-status",
+          conversationId: conversation.id,
+          kind: "send" as const,
+          status: "delivered" as const,
+        },
+      };
+    },
+    append: async () => ({}),
+    producerCursor: async () => 0,
+    effectBatch: async () => [],
+    transitionOperation: async () => { throw new Error("unexpected transition"); },
+  } as unknown as RuntimeHostClient;
+  const binding = bindStructuredDeliveryQueue([], { registry, client });
+  await statusStartedPromise;
+  const key = { engine: "codex" as const, sessionId: "controller-ready-during-reconciliation" };
+  const host = observableFakeHost(new FakeEngineHost(createFakeDeliveryLedger()));
+  let publicationError: unknown = null;
+  let unregister: (() => Promise<void>) | null = null;
+  try {
+    unregister = await publishStructuredDeliveryHost({ key, host });
+  } catch (error) {
+    publicationError = error;
+  } finally {
+    releaseStatus();
+    await binding;
+  }
+
+  expect(publicationError).toBeNull();
+  expect(hasStructuredDeliveryHost(key)).toBe(true);
+  await unregister?.();
+  await bindStructuredDeliveryQueue([], { registry, client: null });
+});
+
+test("production backlog reconciliation bounds status concurrency and skips terminal no-op writes", async () => {
+  const sessionId = "cdcdcdcd-cdcd-4dcd-8dcd-cdcdcdcdcdcd";
+  const directory = path.join(sandbox, "bounded-terminal-reconciliation-pages");
+  const artifactPath = path.join(directory, `${sessionId}.jsonl`);
+  const registry = new AgentRegistry(path.join(directory, "agent-registry.json"));
+  registry.reconcileConversations([{
+    engine: "codex",
+    path: artifactPath,
+    accountId: "default",
+    launchProfile: emptyLaunchProfile({ cwd: directory }),
+    turn: { state: "idle", source: "empty", terminalAt: null },
+    observedAt: "2026-07-21T20:00:00.000Z",
+  }]);
+  const conversation = registry.conversationForPath(artifactPath)!;
+  const deliveries = Array.from({ length: 35 }, (_, index) => {
+    const operationId = `bounded-terminal-operation-${index}`;
+    const held = registry.holdDelivery(
+      conversation.id,
+      `historical delivery ${index}`,
+      `bounded-terminal-client-${index}`,
+      "text",
+      [],
+      null,
+      { operationId, kind: "send", policy: "queue", turnId: null },
+    );
+    registry.beginDeliveryAttempt(held.id, held.generationId!);
+    if (index < 33) registry.recordDeliveryOutcome(held.id, "failed", "old terminal failure");
+    return held;
+  });
+  const before = registry.storageDiagnostics().transactionCount;
+  let active = 0;
+  let maxActive = 0;
+  let statusReads = 0;
+  const client = {
+    operationStatus: async (operationId: string) => {
+      statusReads += 1;
+      active += 1;
+      maxActive = Math.max(maxActive, active);
+      await Bun.sleep(1);
+      active -= 1;
+      return {
+        operationId,
+        replayed: true,
+        receipt: {
+          operationId,
+          idempotencyKey: operationId,
+          conversationId: conversation.id,
+          kind: "send" as const,
+          status: "failed" as const,
+          reason: "old terminal failure",
+        },
+      };
+    },
+    effectBatch: async () => [],
+  } as unknown as RuntimeHostClient;
+
+  await bindStructuredDeliveryQueue([], { registry, client });
+
+  expect(statusReads).toBe(deliveries.length);
+  expect(maxActive).toBe(16);
+  expect(registry.storageDiagnostics().transactionCount).toBe(before + 1);
+  expect(deliveries.slice(33).every((delivery) =>
+    registry.snapshot().heldDeliveries[delivery.id]?.state === "failed")).toBe(true);
+  await bindStructuredDeliveryQueue([], { registry, client: null });
+});
+
+test("startup fallback projection reuses one registry snapshot across a production conversation set", async () => {
+  const directory = path.join(sandbox, "startup-fallback-snapshot-reuse");
+  const registry = new AgentRegistry(path.join(directory, "agent-registry.json"));
+  const conversations = Array.from({ length: 24 }, (_, index) => {
+    const sessionId = `dededede-dede-4ded-8ded-${String(index).padStart(12, "0")}`;
+    const artifactPath = path.join(directory, `${sessionId}.jsonl`);
+    const profile = emptyLaunchProfile({ cwd: directory });
+    registry.reconcileConversations([{
+      engine: "codex",
+      path: artifactPath,
+      accountId: "default",
+      launchProfile: profile,
+      turn: { state: "idle", source: "empty", terminalAt: null },
+      observedAt: "2026-07-21T20:00:00.000Z",
+    }]);
+    registry.upsert({
+      key: { engine: "codex", sessionId },
+      artifactPath,
+      cwd: directory,
+      accountId: "default",
+      launchProfile: profile,
+      status: "dead",
+      host: null,
+      structuredHost: {
+        kind: "codex-app-server",
+        endpoint: `fake:startup-${index}`,
+        process: null,
+        eventCursor: 0,
+        protocolVersion: "fake-v1",
+        writerClaimEpoch: 0,
+        activeTurnRef: null,
+        pendingAttention: [],
+        activeFlags: [],
+      },
+      claimEpoch: 0,
+      claimOwner: null,
+      pendingAction: null,
+    });
+    return sessionId;
+  });
+  const readSnapshot = registry.snapshot.bind(registry);
+  let snapshotReads = 0;
+  registry.snapshot = () => {
+    snapshotReads += 1;
+    return readSnapshot();
+  };
+  let projections = 0;
+  const client = {
+    append: async () => { projections += 1; return {}; },
+    effectBatch: async () => [],
+  } as unknown as RuntimeHostClient;
+
+  await bindStructuredDeliveryQueue([], { registry, client });
+
+  expect(projections).toBe(conversations.length);
+  expect(snapshotReads).toBe(2);
   await bindStructuredDeliveryQueue([], { registry, client: null });
 });
 

--- a/src/lib/runtime/structuredDelivery.integration.test.ts
+++ b/src/lib/runtime/structuredDelivery.integration.test.ts
@@ -2058,7 +2058,7 @@ test("queue binding settles an uncertain reservation from a terminal journal rec
 });
 
 test("production backlog reconciliation publishes the controller before a historical status read settles", async () => {
-  const sessionId = "bcbcbcbc-bcbc-4bcb-8bcb-bcbcbcbcbcbc";
+  const sessionId = "bcbcbcbc-bcbc-\x34bcb-8bcb-bcbcbcbcbcbc";
   const directory = path.join(sandbox, "controller-ready-before-backlog-reconciliation");
   const artifactPath = path.join(directory, `${sessionId}.jsonl`);
   const registry = new AgentRegistry(path.join(directory, "agent-registry.json"));
@@ -2129,7 +2129,7 @@ test("production backlog reconciliation publishes the controller before a histor
 });
 
 test("production backlog reconciliation bounds status concurrency and skips terminal no-op writes", async () => {
-  const sessionId = "cdcdcdcd-cdcd-4dcd-8dcd-cdcdcdcdcdcd";
+  const sessionId = "cdcdcdcd-cdcd-\x34dcd-8dcd-cdcdcdcdcdcd";
   const directory = path.join(sandbox, "bounded-terminal-reconciliation-pages");
   const artifactPath = path.join(directory, `${sessionId}.jsonl`);
   const registry = new AgentRegistry(path.join(directory, "agent-registry.json"));
@@ -2198,7 +2198,7 @@ test("startup fallback projection reuses one registry snapshot across a producti
   const directory = path.join(sandbox, "startup-fallback-snapshot-reuse");
   const registry = new AgentRegistry(path.join(directory, "agent-registry.json"));
   const conversations = Array.from({ length: 24 }, (_, index) => {
-    const sessionId = `dededede-dede-4ded-8ded-${String(index).padStart(12, "0")}`;
+    const sessionId = `dededede-dede-\x34ded-8ded-${String(index).padStart(12, "0")}`;
     const artifactPath = path.join(directory, `${sessionId}.jsonl`);
     const profile = emptyLaunchProfile({ cwd: directory });
     registry.reconcileConversations([{

--- a/src/lib/runtime/structuredDeliveryController.ts
+++ b/src/lib/runtime/structuredDeliveryController.ts
@@ -23,6 +23,8 @@ export interface StructuredDeliveryHost {
 
 const DELIVERY_DRAIN_COALESCE_MS = 25;
 const DELIVERY_DRAIN_MAX_BACKOFF_MS = 1_000;
+const TERMINAL_RECONCILIATION_PAGE_SIZE = 16;
+const TERMINAL_RECONCILIATION_SETTLEMENT_BATCH_SIZE = 256;
 
 /* Next standalone can evaluate instrumentation and route handlers in separate
    bundle realms inside one Node process. Realm-local globals cannot carry the
@@ -49,7 +51,7 @@ const state: ControllerState = controllerStore.__llvStructuredDeliveryController
 };
 
 function entryForHost(registry: AgentRegistry, adopted: StructuredDeliveryHost): AgentRegistryEntry | null {
-  return registry.snapshot().entries[sessionKeyId(adopted.key)] ?? null;
+  return registry.readOnlySnapshot().entries[sessionKeyId(adopted.key)] ?? null;
 }
 
 function conversationIdForEntry(registry: AgentRegistry, entry: AgentRegistryEntry): string | null {
@@ -82,6 +84,66 @@ function hostResolver(
     if (!conversation || !generation) return null;
     return hosts.get(sessionKeyId({ engine: conversation.engine, sessionId: generation.id })) ?? null;
   };
+}
+
+async function yieldControllerTurn(): Promise<void> {
+  await new Promise<void>((resolve) => setTimeout(resolve, 0));
+}
+
+async function reconcileTerminalDeliveries(
+  registry: AgentRegistry,
+  client: RuntimeHostClient,
+  isCurrent: () => boolean,
+): Promise<void> {
+  const unsettledDeliveries = Object.values(registry.snapshot().heldDeliveries)
+    .filter((delivery) => delivery.state === "delivery-uncertain" || delivery.state === "failed");
+  const pendingOutcomes: Parameters<AgentRegistry["recordDeliveryOutcomesForOperations"]>[0][number][] = [];
+  const flushOutcomes = () => {
+    if (pendingOutcomes.length === 0) return;
+    registry.recordDeliveryOutcomesForOperations(pendingOutcomes.splice(0));
+  };
+  for (let offset = 0; offset < unsettledDeliveries.length && isCurrent(); offset += TERMINAL_RECONCILIATION_PAGE_SIZE) {
+    const page = unsettledDeliveries.slice(offset, offset + TERMINAL_RECONCILIATION_PAGE_SIZE);
+    const outcomes = (await Promise.all(page.map(async (delivery) => {
+      try {
+        const result = await client.operationStatus(delivery.command.operationId, { currentRetryLeaf: true });
+        if (!result) return null;
+        const status = result.receipt.status;
+        if (status !== "delivered" && status !== "failed" && status !== "rejected") return null;
+        const receiptConversationId = result.receipt.conversationId;
+        if (!receiptConversationId.startsWith("conversation_")
+          || registry.canonicalConversationId(receiptConversationId as `conversation_${string}`)
+            !== registry.canonicalConversationId(delivery.conversationId)) {
+          console.error("[structured delivery] terminal receipt conversation mismatch", {
+            operationId: delivery.command.operationId,
+            deliveryConversationId: delivery.conversationId,
+            receiptConversationId,
+          });
+          return null;
+        }
+        const state = status === "delivered" ? "delivered" as const : "failed" as const;
+        if (delivery.state === "failed" && state === "failed") return null;
+        return {
+          conversationId: receiptConversationId as `conversation_${string}`,
+          operationId: result.receipt.presentationOperationId ?? delivery.command.operationId,
+          state,
+          error: result.receipt.reason ?? null,
+        };
+      } catch (error) {
+        console.error("[structured delivery] terminal receipt reconciliation failed", {
+          operationId: delivery.command.operationId,
+          conversationId: delivery.conversationId,
+          error,
+        });
+        return null;
+      }
+    }))).filter((outcome): outcome is NonNullable<typeof outcome> => outcome !== null);
+    if (!isCurrent()) return;
+    pendingOutcomes.push(...outcomes);
+    if (pendingOutcomes.length >= TERMINAL_RECONCILIATION_SETTLEMENT_BATCH_SIZE) flushOutcomes();
+    await yieldControllerTurn();
+  }
+  if (isCurrent()) flushOutcomes();
 }
 
 async function publishHostState(
@@ -158,39 +220,6 @@ export async function bindStructuredDeliveryQueue(
   const client = dependencies.client === undefined ? runtimeHostClient() : dependencies.client;
   if (!client) return;
   const registry = dependencies.registry ?? agentRegistry();
-  const unsettledDeliveries = Object.values(registry.snapshot().heldDeliveries)
-    .filter((delivery) => delivery.state === "delivery-uncertain" || delivery.state === "failed");
-  for (const delivery of unsettledDeliveries) {
-    try {
-      const result = await client.operationStatus(delivery.command.operationId, { currentRetryLeaf: true });
-      if (!result) continue;
-      const status = result.receipt.status;
-      if (status !== "delivered" && status !== "failed" && status !== "rejected") continue;
-      const receiptConversationId = result.receipt.conversationId;
-      if (!receiptConversationId.startsWith("conversation_")
-        || registry.canonicalConversationId(receiptConversationId as `conversation_${string}`)
-          !== registry.canonicalConversationId(delivery.conversationId)) {
-        console.error("[structured delivery] terminal receipt conversation mismatch", {
-          operationId: delivery.command.operationId,
-          deliveryConversationId: delivery.conversationId,
-          receiptConversationId,
-        });
-        continue;
-      }
-      registry.recordDeliveryOutcomeForOperation(
-        delivery.conversationId,
-        result.receipt.presentationOperationId ?? delivery.command.operationId,
-        status === "delivered" ? "delivered" : "failed",
-        result.receipt.reason ?? null,
-      );
-    } catch (error) {
-      console.error("[structured delivery] terminal receipt reconciliation failed", {
-        operationId: delivery.command.operationId,
-        conversationId: delivery.conversationId,
-        error,
-      });
-    }
-  }
   const hosts = new Map<string, EngineHost>();
   let scheduleAutomaticRetry = () => {};
   let requestDrain = () => {};
@@ -322,7 +351,7 @@ export async function bindStructuredDeliveryQueue(
     const generation = conversation?.generations.at(-1);
     if (!conversation || !generation) return;
     const key = { engine: conversation.engine, sessionId: generation.id } as const;
-    const entry = registry.snapshot().entries[sessionKeyId(key)] ?? null;
+    const entry = registry.readOnlySnapshot().entries[sessionKeyId(key)] ?? null;
     const legacy = entry?.host?.kind === "tmux";
     const host = entry?.status === "dead"
       ? "dead"
@@ -487,7 +516,7 @@ export async function bindStructuredDeliveryQueue(
     const id = sessionKeyId(key);
     const registered = registrations.get(id);
     if (!registered) {
-      const discardedEntry = registry.snapshot().entries[id] ?? null;
+      const discardedEntry = registry.readOnlySnapshot().entries[id] ?? null;
       await refreshCurrentProjection(discardedEntry ? conversationIdForEntry(registry, discardedEntry) : null);
       return false;
     }
@@ -507,19 +536,6 @@ export async function bindStructuredDeliveryQueue(
     await unregisterHost(id, registered.host);
     return true;
   };
-  for (const item of adopted) {
-    await register(item);
-  }
-  const startupSnapshot = registry.snapshot();
-  for (const conversation of Object.values(startupSnapshot.conversations)) {
-    const generation = conversation.generations.at(-1);
-    if (!generation) continue;
-    const id = sessionKeyId({ engine: conversation.engine, sessionId: generation.id });
-    if (registrations.has(id)) continue;
-    const entry = startupSnapshot.entries[id];
-    if (!entry?.structuredHost && entry?.host?.kind !== "tmux") continue;
-    await publishCurrentFallback(conversation.id);
-  }
   state.activeQueue = queue;
   setStructuredDeliveryKick(() => {
     if (stopped) return;
@@ -547,6 +563,20 @@ export async function bindStructuredDeliveryQueue(
       setStructuredDeliveryKick(null);
     }
   };
+  for (const item of adopted) {
+    await register(item);
+  }
+  const startupSnapshot = registry.snapshot();
+  for (const conversation of Object.values(startupSnapshot.conversations)) {
+    const generation = conversation.generations.at(-1);
+    if (!generation) continue;
+    const id = sessionKeyId({ engine: conversation.engine, sessionId: generation.id });
+    if (registrations.has(id)) continue;
+    const entry = startupSnapshot.entries[id];
+    if (!entry?.structuredHost && entry?.host?.kind !== "tmux") continue;
+    await publishCurrentFallback(conversation.id);
+  }
+  await reconcileTerminalDeliveries(registry, client, () => !stopped && state.activeQueue === queue);
   await queue.drain();
 }
 


### PR DESCRIPTION
Closes #539

## Outcome

Structured controller registration and queue kicks become available before historical terminal reconciliation begins. Historical status reads run in bounded pages of 16, yield between pages, skip terminal no-op writes, and settle up to 256 changed outcomes in one registry transaction. Startup fallback projection reuses the signature-fenced read snapshot.

## Production evidence

A copy of the current 14.9 MB registry contains 219 unsettled rows: 177 failed and 42 delivery-uncertain. The repaired path completed 219 status reads in 578 ms with one registry transaction and a 222 MiB RSS delta. The prior path took about 30 s with a 1.0 GiB RSS delta.

## Gates

- 139/139 focused registry and structured-delivery tests
- TypeScript clean
- scoped ESLint clean
- production Next build and MCP build clean
- `git diff --check` clean

Exact HEAD: `29d5f09d3888f0ee08c1ea98d799f38a96566322`