### PR TITLE
perf(pipelines): reuse registry projection cache

### DIFF
--- a/src/lib/pipelines/engine.test.ts
+++ b/src/lib/pipelines/engine.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, expect, test } from "bun:test";
+import { afterAll, expect, spyOn, test } from "bun:test";
 import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
@@ -27,6 +27,24 @@ type StageTurnEvidence = import("./durableEvidence").StageTurnEvidence;
 registerPipelineTick(async () => {});
 
 afterAll(() => fs.rmSync(process.env.LLV_STATE_DIR!, { recursive: true, force: true }));
+
+test("default pipeline projections reuse one registry parse across the historical backlog", () => {
+  const registryPath = path.join(process.env.LLV_STATE_DIR!, "projection-cache-agent-registry.json");
+  const registry = new AgentRegistry(registryPath);
+  setAgentRegistryForTests(registry);
+  const reads = spyOn(fs, "readFileSync");
+  try {
+    const ports = defaultPipelinePorts();
+    for (let index = 0; index < 300; index += 1) {
+      expect(ports.pipelineAdoptionCandidates(`historical-${index}`)).toEqual([]);
+      expect(ports.spawnReceipt(`missing-${index}`)).toBeNull();
+    }
+    expect(reads.mock.calls.filter(([filename]) => filename === registryPath)).toHaveLength(1);
+  } finally {
+    reads.mockRestore();
+    setAgentRegistryForTests(null);
+  }
+});
 
 const RUN_STAGES = [
   { id: "plan", kind: "run", role: { roleId: "architect" }, access: "read-only", prompt: "Plan {{task}}", next: "build" },

--- a/src/lib/pipelines/engine.ts
+++ b/src/lib/pipelines/engine.ts
@@ -250,7 +250,7 @@ export function defaultPipelinePorts(): PipelinePorts {
     roleLookup: pipelineRoleLookup,
     spawnAgent: spawnPipelineAgent,
     spawnReceipt: (launchId) => {
-      const receipt = agentRegistry().snapshot().receipts[launchId];
+      const receipt = agentRegistry().readOnlySnapshot().receipts[launchId];
       if (!receipt) return null;
       return {
         state: receipt.state,
@@ -291,7 +291,7 @@ export function defaultPipelinePorts(): PipelinePorts {
     sourcePathAllowed: transcriptAllowed,
     conversationIdForPath: (pathname) => agentRegistry().conversationForPath(pathname)?.id ?? null,
     pipelineAdoptionCandidates: (pipelineId) => {
-      const snapshot = agentRegistry().snapshot();
+      const snapshot = agentRegistry().readOnlySnapshot();
       const receipts = Object.values(snapshot.receipts);
       const candidates: PipelineAdoptionCandidate[] = [];
       for (const [conversationId, memberships] of Object.entries(snapshot.memberships)) {


### PR DESCRIPTION
Closes #541

## Summary

- route pipeline receipt and adoption projections through the signature-fenced read-only registry cache
- cover a 300-pipeline backlog with a physical-read count regression
- preserve automatic cache invalidation through the existing atomic replacement signature fence

## Verification

- `bun test src/lib/pipelines/engine.test.ts src/lib/agent/registry.test.ts` — 220 pass
- `bunx tsc --noEmit`
- `bunx eslint src/lib/pipelines/engine.ts src/lib/pipelines/engine.test.ts`
- `bun run build`
- production-state copy: 298 pipelines projected in 34.9 ms, 355 MiB RSS