### PR TITLE
P0: publish structured controller before startup adoption

### DIFF
--- a/src/lib/runtime/startup.test.ts
+++ b/src/lib/runtime/startup.test.ts
@@ -54,7 +54,7 @@ test("startup publishes the structured controller before transcript refresh sett
   });
   await refreshStartedPromise;
 
-  const sessionId = "abababab-abab-4aba-8aba-abababababab";
+  const sessionId = "early-controller-session";
   const artifactPath = path.join(directory, `${sessionId}.jsonl`);
   fs.writeFileSync(artifactPath, "");
   registry.upsert({

--- a/src/lib/runtime/startup.test.ts
+++ b/src/lib/runtime/startup.test.ts
@@ -11,7 +11,7 @@ import { RuntimeJournal } from "@/runtime-host/journal";
 import { runStructuredHostStartup } from "@/lib/viewerInstrumentation";
 
 import { RuntimeHostUnavailableError, type RuntimeHostClient } from "./client";
-import { bindStructuredDeliveryQueue, hasStructuredDeliveryHost } from "./structuredDeliveryController";
+import { bindStructuredDeliveryQueue, hasStructuredDeliveryHost, publishStructuredDeliveryHost } from "./structuredDeliveryController";
 import { createFakeDeliveryLedger, FakeEngineHost } from "./fixtures/fakeEngineHost";
 import { demoteSkippedStructuredRegistryHosts, type StructuredHostAdoptionFilter } from "./registry";
 import { deliverHeldStructuredMessage, enqueueStructuredMessage } from "./structuredMessageDelivery";
@@ -32,6 +32,65 @@ function runtimeClient(journal: RuntimeJournal): RuntimeHostClient {
     transitionOperation: async (operationId, status, details) => journal.transitionOperation(operationId, status, details),
   } as RuntimeHostClient;
 }
+
+test("startup publishes the structured controller before transcript refresh settles", async () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-runtime-startup-early-controller-"));
+  const registry = new AgentRegistry(path.join(directory, "agent-registry.json"));
+  const journal = new RuntimeJournal(path.join(directory, "runtime.sqlite"), { structuredHosts: true });
+  const client = runtimeClient(journal);
+  let refreshStarted!: () => void;
+  const refreshStartedPromise = new Promise<void>((resolve) => { refreshStarted = resolve; });
+  let releaseRefresh!: () => void;
+  const refreshRelease = new Promise<void>((resolve) => { releaseRefresh = resolve; });
+  const startup = adoptStructuredHostsAtStartup({
+    registry,
+    client,
+    refreshTranscriptState: async () => {
+      refreshStarted();
+      await refreshRelease;
+    },
+    adopt: async () => [],
+    adoptClaude: async () => [],
+  });
+  await refreshStartedPromise;
+
+  const sessionId = "abababab-abab-4aba-8aba-abababababab";
+  const artifactPath = path.join(directory, `${sessionId}.jsonl`);
+  fs.writeFileSync(artifactPath, "");
+  registry.upsert({
+    key: { engine: "codex", sessionId },
+    artifactPath,
+    cwd: directory,
+    accountId: null,
+    launchProfile: emptyLaunchProfile({ cwd: directory }),
+    status: "idle",
+    host: null,
+    structuredHost: {
+      kind: "codex-app-server",
+      endpoint: "fake:early-controller",
+      process: null,
+      eventCursor: 0,
+      protocolVersion: "test",
+      writerClaimEpoch: 0,
+      activeTurnRef: null,
+      pendingAttention: [],
+      activeFlags: [],
+    },
+    claimEpoch: 0,
+    claimOwner: null,
+    pendingAction: "spawn",
+  });
+  const key = { engine: "codex" as const, sessionId };
+  const host = Object.assign(new FakeEngineHost(createFakeDeliveryLedger()), { onStateChange: () => () => {} });
+  const unregister = await publishStructuredDeliveryHost({ key, host });
+  expect(hasStructuredDeliveryHost(key)).toBe(true);
+
+  await unregister();
+  releaseRefresh();
+  await startup;
+  await bindStructuredDeliveryQueue([], { registry, client: null });
+  journal.close();
+});
 
 test("server startup delegates managed rows with file credentials and their launch profile", async () => {
   const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-runtime-startup-"));

--- a/src/lib/runtime/startup.ts
+++ b/src/lib/runtime/startup.ts
@@ -19,7 +19,7 @@ import {
 } from "./registry";
 import { runtimeHostClient, type RuntimeHostClient } from "./client";
 import type { RuntimeOperationResult } from "./contracts";
-import { bindStructuredDeliveryQueue } from "./structuredDeliveryController";
+import { bindStructuredDeliveryQueue, completeStructuredDeliveryQueueStartup } from "./structuredDeliveryController";
 import { kickStructuredDeliveryQueue } from "./structuredDeliverySignal";
 import { recoverPendingStructuredSpawns } from "./structuredSpawn";
 
@@ -343,6 +343,7 @@ function structuredStartupAdoptionFilter(
 export interface StructuredStartupDependencies {
   registry?: AgentRegistry;
   client?: RuntimeHostClient | null;
+  refreshTranscriptState?: (registry: AgentRegistry) => Promise<void>;
   adopt?: typeof adoptCodexRegistryHosts;
   adoptClaude?: typeof adoptClaudeRegistryHosts;
   resolveCodexOwner?: (entry: AgentRegistryEntry) => { home: string; kind: "legacy" | "managed" } | null;
@@ -360,10 +361,18 @@ export async function adoptStructuredHostsAtStartup(
 ): Promise<AdoptedStructuredHost[]> {
   assertDarwinStructuredRuntime();
   const registry = dependencies.registry ?? agentRegistry();
-  await refreshStructuredTranscriptState(registry);
+  const client = dependencies.client === undefined ? runtimeHostClient() : dependencies.client;
+  const controllerBoundEarly = client !== null;
+  if (client) {
+    await bindStructuredDeliveryQueue([], {
+      registry: dependencies.registry,
+      client,
+      deferStartupWork: true,
+    });
+  }
+  await (dependencies.refreshTranscriptState ?? refreshStructuredTranscriptState)(registry);
   let nextAdoptedHosts = await revalidateRetainedStartupHosts(registry, retryAdoptedHosts);
   retryAdoptedHosts = nextAdoptedHosts;
-  const client = dependencies.client === undefined ? runtimeHostClient() : dependencies.client;
   const signals = await structuredStartupSignals(registry, client);
   const shouldAdopt = structuredStartupAdoptionFilter(registry, signals);
   const resolveCodexOwner = dependencies.resolveCodexOwner ?? ((entry: AgentRegistryEntry) =>
@@ -443,7 +452,11 @@ export async function adoptStructuredHostsAtStartup(
   const finalCodexHosts = nextAdoptedHosts.filter(
     (item): item is AdoptedCodexHost => item.key.engine === "codex",
   );
-  await bindStructuredDeliveryQueue(nextAdoptedHosts, { registry: dependencies.registry, client });
+  if (controllerBoundEarly) {
+    await completeStructuredDeliveryQueueStartup(nextAdoptedHosts);
+  } else {
+    await bindStructuredDeliveryQueue(nextAdoptedHosts, { registry: dependencies.registry, client });
+  }
   if (client) {
     await enqueueInterruptedCodexContinuations(
       registry,

--- a/src/lib/runtime/structuredDeliveryController.ts
+++ b/src/lib/runtime/structuredDeliveryController.ts
@@ -37,6 +37,7 @@ interface ControllerState {
   republishActiveHost: ((key: SessionKey) => Promise<boolean>) | null;
   releaseActiveHost: ((key: SessionKey) => Promise<boolean>) | null;
   terminateActiveHost: ((key: SessionKey) => Promise<boolean>) | null;
+  completeActive: ((adopted: readonly StructuredDeliveryHost[]) => Promise<void>) | null;
   stopActive: () => void;
 }
 const controllerStore = process as typeof process & { __llvStructuredDeliveryController?: ControllerState };
@@ -47,6 +48,7 @@ const state: ControllerState = controllerStore.__llvStructuredDeliveryController
   republishActiveHost: null,
   releaseActiveHost: null,
   terminateActiveHost: null,
+  completeActive: null,
   stopActive: () => {},
 };
 
@@ -206,6 +208,7 @@ export async function bindStructuredDeliveryQueue(
     registry?: AgentRegistry;
     client?: RuntimeHostClient | null;
     recover?: StructuredConversationRecovery;
+    deferStartupWork?: boolean;
   } = {},
 ): Promise<void> {
   state.stopActive();
@@ -216,6 +219,7 @@ export async function bindStructuredDeliveryQueue(
   state.republishActiveHost = null;
   state.releaseActiveHost = null;
   state.terminateActiveHost = null;
+  state.completeActive = null;
   setStructuredDeliveryKick(null);
   const client = dependencies.client === undefined ? runtimeHostClient() : dependencies.client;
   if (!client) return;
@@ -560,24 +564,32 @@ export async function bindStructuredDeliveryQueue(
       state.republishActiveHost = null;
       state.releaseActiveHost = null;
       state.terminateActiveHost = null;
+      state.completeActive = null;
       setStructuredDeliveryKick(null);
     }
   };
-  for (const item of adopted) {
-    await register(item);
-  }
-  const startupSnapshot = registry.snapshot();
-  for (const conversation of Object.values(startupSnapshot.conversations)) {
-    const generation = conversation.generations.at(-1);
-    if (!generation) continue;
-    const id = sessionKeyId({ engine: conversation.engine, sessionId: generation.id });
-    if (registrations.has(id)) continue;
-    const entry = startupSnapshot.entries[id];
-    if (!entry?.structuredHost && entry?.host?.kind !== "tmux") continue;
-    await publishCurrentFallback(conversation.id);
-  }
-  await reconcileTerminalDeliveries(registry, client, () => !stopped && state.activeQueue === queue);
-  await queue.drain();
+  let completion = Promise.resolve();
+  const complete = (items: readonly StructuredDeliveryHost[]) => {
+    completion = completion.then(async () => {
+      if (stopped || state.activeQueue !== queue) return;
+      for (const item of items) await register(item);
+      const startupSnapshot = registry.snapshot();
+      for (const conversation of Object.values(startupSnapshot.conversations)) {
+        const generation = conversation.generations.at(-1);
+        if (!generation) continue;
+        const id = sessionKeyId({ engine: conversation.engine, sessionId: generation.id });
+        if (registrations.has(id)) continue;
+        const entry = startupSnapshot.entries[id];
+        if (!entry?.structuredHost && entry?.host?.kind !== "tmux") continue;
+        await publishCurrentFallback(conversation.id);
+      }
+      await reconcileTerminalDeliveries(registry, client, () => !stopped && state.activeQueue === queue);
+      await queue.drain();
+    });
+    return completion;
+  };
+  state.completeActive = complete;
+  if (!dependencies.deferStartupWork) await complete(adopted);
 }
 
 export function hasStructuredDeliveryHost(key: SessionKey): boolean {
@@ -590,6 +602,13 @@ export async function publishStructuredDeliveryHost(
 ): Promise<() => Promise<void>> {
   if (!state.registerActiveHost) throw new Error("structured delivery controller is unavailable");
   return state.registerActiveHost(item, ownsOperation);
+}
+
+export async function completeStructuredDeliveryQueueStartup(
+  adopted: readonly StructuredDeliveryHost[],
+): Promise<void> {
+  if (!state.completeActive) throw new Error("structured delivery controller is unavailable");
+  await state.completeActive(adopted);
 }
 
 export async function republishStructuredDeliveryHost(key: SessionKey): Promise<boolean> {


### PR DESCRIPTION
Closes #543

Publishes the process-wide structured delivery controller as soon as the runtime-host client is available. Startup transcript refresh and host adoption continue while newly registered hosts can already attach to the controller. Historical fallback reconciliation and queue drain remain deferred until adopted hosts are known.

Evidence:
- RED: early-controller regression timed out at 5 seconds before the fix
- GREEN: startup suite 57 pass
- delivery/spawn integration suites 88 pass
- TypeScript clean
- scoped ESLint clean
- production and MCP builds clean