### PR TITLE
P0: skip unchanged startup fallback projections

### DIFF
--- a/src/lib/runtime/structuredDelivery.integration.test.ts
+++ b/src/lib/runtime/structuredDelivery.integration.test.ts
@@ -2194,7 +2194,7 @@ test("production backlog reconciliation bounds status concurrency and skips term
   await bindStructuredDeliveryQueue([], { registry, client: null });
 });
 
-test("startup fallback projection reuses one registry snapshot across a production conversation set", async () => {
+test("startup fallback projection reads one runtime snapshot and publishes only drift across a production conversation set", async () => {
   const directory = path.join(sandbox, "startup-fallback-snapshot-reuse");
   const registry = new AgentRegistry(path.join(directory, "agent-registry.json"));
   const conversations = Array.from({ length: 24 }, (_, index) => {
@@ -2209,6 +2209,7 @@ test("startup fallback projection reuses one registry snapshot across a producti
       turn: { state: "idle", source: "empty", terminalAt: null },
       observedAt: "2026-07-21T20:00:00.000Z",
     }]);
+    const conversation = registry.conversationForPath(artifactPath)!;
     registry.upsert({
       key: { engine: "codex", sessionId },
       artifactPath,
@@ -2232,7 +2233,7 @@ test("startup fallback projection reuses one registry snapshot across a producti
       claimOwner: null,
       pendingAction: null,
     });
-    return sessionId;
+    return { sessionId, conversationId: conversation.id, artifactPath };
   });
   const readSnapshot = registry.snapshot.bind(registry);
   let snapshotReads = 0;
@@ -2241,14 +2242,34 @@ test("startup fallback projection reuses one registry snapshot across a producti
     return readSnapshot();
   };
   let projections = 0;
+  let runtimeSnapshots = 0;
   const client = {
     append: async () => { projections += 1; return {}; },
+    snapshot: async () => {
+      runtimeSnapshots += 1;
+      return {
+        sessions: conversations.map((conversation, index) => ({
+          conversationId: conversation.conversationId,
+          sessionKey: { engine: "codex" as const, sessionId: conversation.sessionId },
+          hostKind: "codex-app-server" as const,
+          host: index === 0 ? "hosted" as const : "dead" as const,
+          turn: "unknown" as const,
+          provenance: "structured" as const,
+          accountId: "default",
+          parentConversationId: null,
+          cwd: directory,
+          artifactPath: conversation.artifactPath,
+          activeTurnId: null,
+        })),
+      };
+    },
     effectBatch: async () => [],
   } as unknown as RuntimeHostClient;
 
   await bindStructuredDeliveryQueue([], { registry, client });
 
-  expect(projections).toBe(conversations.length);
+  expect(projections).toBe(1);
+  expect(runtimeSnapshots).toBe(1);
   expect(snapshotReads).toBe(2);
   await bindStructuredDeliveryQueue([], { registry, client: null });
 });

--- a/src/lib/runtime/structuredDeliveryController.ts
+++ b/src/lib/runtime/structuredDeliveryController.ts
@@ -4,7 +4,7 @@ import { agentRegistry, type AgentRegistry, type AgentRegistryEntry } from "@/li
 import { sessionKeyId, type SessionKey } from "@/lib/agent/sessionKey";
 
 import { runtimeHostClient, type RuntimeHostClient } from "./client";
-import { runtimeSettingsCapability, type RuntimeEventInput } from "./contracts";
+import { runtimeSettingsCapability, type RuntimeEventInput, type RuntimeSession } from "./contracts";
 import type { EngineHost, HostState } from "./engineHost";
 import { StructuredDeliveryQueue } from "./structuredDeliveryQueue";
 import { applyStructuredReconfigure } from "./structuredReconfigure";
@@ -350,7 +350,10 @@ export async function bindStructuredDeliveryQueue(
     }
     return republished;
   };
-  const publishCurrentFallback = async (conversationId: string): Promise<void> => {
+  const publishCurrentFallback = async (
+    conversationId: string,
+    current?: RuntimeSession,
+  ): Promise<void> => {
     const conversation = registry.conversation(conversationId as `conversation_${string}`);
     const generation = conversation?.generations.at(-1);
     if (!conversation || !generation) return;
@@ -363,6 +366,23 @@ export async function bindStructuredDeliveryQueue(
         ? "hosted"
         : "unhosted";
     const turn = entry?.status === "live" ? "running" : entry?.status === "idle" ? "idle" : "unknown";
+    const hostKind = entry?.structuredHost?.kind ?? (legacy ? "tmux-legacy" : "unhosted");
+    const provenance = entry?.structuredHost ? "structured" : "derived";
+    const accountId = entry?.accountId ?? generation.accountId;
+    const parentConversationId = generation.launchProfile.parentConversationId ?? null;
+    const cwd = entry?.cwd ?? generation.launchProfile.cwd;
+    if (current
+      && current.sessionKey.engine === key.engine
+      && current.sessionKey.sessionId === key.sessionId
+      && current.hostKind === hostKind
+      && current.host === (entry?.structuredHost && entry.status === "dead" ? "dead" : host)
+      && current.turn === turn
+      && current.provenance === provenance
+      && current.accountId === accountId
+      && current.parentConversationId === parentConversationId
+      && current.cwd === cwd
+      && current.artifactPath === generation.path
+      && current.activeTurnId === null) return;
     projectionRevision += 1;
     await client.append({
       scope: { type: "session", id: conversationId },
@@ -374,13 +394,13 @@ export async function bindStructuredDeliveryQueue(
       payload: {
         conversationId,
         sessionKey: key,
-        hostKind: entry?.structuredHost?.kind ?? (legacy ? "tmux-legacy" : "unhosted"),
+        hostKind,
         host: entry?.structuredHost && entry.status === "dead" ? "dead" : host,
         turn,
-        provenance: entry?.structuredHost ? "structured" : "derived",
-        accountId: entry?.accountId ?? generation.accountId,
-        parentConversationId: generation.launchProfile.parentConversationId,
-        cwd: entry?.cwd ?? generation.launchProfile.cwd,
+        provenance,
+        accountId,
+        parentConversationId,
+        cwd,
         artifactPath: generation.path,
         capabilities: entry?.structuredHost
           ? {
@@ -574,6 +594,12 @@ export async function bindStructuredDeliveryQueue(
       if (stopped || state.activeQueue !== queue) return;
       for (const item of items) await register(item);
       const startupSnapshot = registry.snapshot();
+      const runtimeSnapshot = typeof client.snapshot === "function"
+        ? await client.snapshot().catch(() => null)
+        : null;
+      const runtimeSessions = new Map(
+        (runtimeSnapshot?.sessions ?? []).map((session) => [session.conversationId, session]),
+      );
       for (const conversation of Object.values(startupSnapshot.conversations)) {
         const generation = conversation.generations.at(-1);
         if (!generation) continue;
@@ -581,7 +607,7 @@ export async function bindStructuredDeliveryQueue(
         if (registrations.has(id)) continue;
         const entry = startupSnapshot.entries[id];
         if (!entry?.structuredHost && entry?.host?.kind !== "tmux") continue;
-        await publishCurrentFallback(conversation.id);
+        await publishCurrentFallback(conversation.id, runtimeSessions.get(conversation.id));
       }
       await reconcileTerminalDeliveries(registry, client, () => !stopped && state.activeQueue === queue);
       await queue.drain();


### PR DESCRIPTION
Closes #545

Reads one durable runtime snapshot before startup fallback projection. Registry fallbacks whose session identity, host axes, lineage, cwd, and artifact path already match runtime state are skipped. Missing or drifted fallbacks continue to publish.

Production evidence:
- 291 repeated codex/claude session-status events appeared during the first three minutes after promotion
- a real Fable host reached hosted state, then its initial prompt hit runtime host request timed out during the replay wave

Verification:
- RED: 24 equivalent production-shaped sessions produced 24 fallback writes
- GREEN: one runtime snapshot, 23 equivalent sessions skipped, one drift published
- 145 runtime tests pass
- TypeScript and scoped ESLint clean
- production and MCP builds clean