### PR TITLE
P0: preserve delivery controller across startup retries

### DIFF
--- a/src/lib/runtime/startup.test.ts
+++ b/src/lib/runtime/startup.test.ts
@@ -92,6 +92,39 @@ test("startup publishes the structured controller before transcript refresh sett
   journal.close();
 });
 
+test("startup retry preserves a host registered after the first attempt fails", async () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-runtime-startup-controller-retry-"));
+  const registry = new AgentRegistry(path.join(directory, "agent-registry.json"));
+  const journal = new RuntimeJournal(path.join(directory, "runtime.sqlite"), { structuredHosts: true });
+  const client = runtimeClient(journal);
+  let refreshAttempts = 0;
+  const dependencies = {
+    registry,
+    client,
+    refreshTranscriptState: async () => {
+      refreshAttempts += 1;
+      if (refreshAttempts === 1) throw new RuntimeHostUnavailableError("runtime host is unavailable");
+    },
+    adopt: async () => [],
+    adoptClaude: async () => [],
+  } satisfies StructuredStartupDependencies;
+
+  await expect(adoptStructuredHostsAtStartup(dependencies)).rejects.toThrow("runtime host is unavailable");
+
+  const key = { engine: "claude" as const, sessionId: "hosted-between-startup-attempts" };
+  const host = Object.assign(new FakeEngineHost(createFakeDeliveryLedger()), { onStateChange: () => () => {} });
+  const unregister = await publishStructuredDeliveryHost({ key, host });
+  expect(hasStructuredDeliveryHost(key)).toBe(true);
+
+  await adoptStructuredHostsAtStartup(dependencies);
+  expect(hasStructuredDeliveryHost(key)).toBe(true);
+
+  await unregister();
+  await bindStructuredDeliveryQueue([], { registry, client: null });
+  journal.close();
+  fs.rmSync(directory, { recursive: true, force: true });
+});
+
 test("server startup delegates managed rows with file credentials and their launch profile", async () => {
   const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-runtime-startup-"));
   const registry = new AgentRegistry(path.join(directory, "agent-registry.json"));

--- a/src/lib/runtime/startup.ts
+++ b/src/lib/runtime/startup.ts
@@ -19,7 +19,11 @@ import {
 } from "./registry";
 import { runtimeHostClient, type RuntimeHostClient } from "./client";
 import type { RuntimeOperationResult } from "./contracts";
-import { bindStructuredDeliveryQueue, completeStructuredDeliveryQueueStartup } from "./structuredDeliveryController";
+import {
+  bindStructuredDeliveryQueue,
+  completeStructuredDeliveryQueueStartup,
+  hasStructuredDeliveryController,
+} from "./structuredDeliveryController";
 import { kickStructuredDeliveryQueue } from "./structuredDeliverySignal";
 import { recoverPendingStructuredSpawns } from "./structuredSpawn";
 
@@ -363,9 +367,9 @@ export async function adoptStructuredHostsAtStartup(
   const registry = dependencies.registry ?? agentRegistry();
   const client = dependencies.client === undefined ? runtimeHostClient() : dependencies.client;
   const controllerBoundEarly = client !== null;
-  if (client) {
+  if (client && !hasStructuredDeliveryController(registry)) {
     await bindStructuredDeliveryQueue([], {
-      registry: dependencies.registry,
+      registry,
       client,
       deferStartupWork: true,
     });
@@ -455,7 +459,7 @@ export async function adoptStructuredHostsAtStartup(
   if (controllerBoundEarly) {
     await completeStructuredDeliveryQueueStartup(nextAdoptedHosts);
   } else {
-    await bindStructuredDeliveryQueue(nextAdoptedHosts, { registry: dependencies.registry, client });
+    await bindStructuredDeliveryQueue(nextAdoptedHosts, { registry, client });
   }
   if (client) {
     await enqueueInterruptedCodexContinuations(

--- a/src/lib/runtime/structuredDeliveryController.ts
+++ b/src/lib/runtime/structuredDeliveryController.ts
@@ -32,6 +32,7 @@ const TERMINAL_RECONCILIATION_SETTLEMENT_BATCH_SIZE = 256;
    object is shared by the realms, so it owns the process-scoped controller. */
 interface ControllerState {
   activeQueue: StructuredDeliveryQueue | null;
+  activeRegistry: AgentRegistry | null;
   activeHosts: Map<string, EngineHost> | null;
   registerActiveHost: ((item: StructuredDeliveryHost, ownsOperation?: () => Promise<boolean>) => Promise<() => Promise<void>>) | null;
   republishActiveHost: ((key: SessionKey) => Promise<boolean>) | null;
@@ -43,6 +44,7 @@ interface ControllerState {
 const controllerStore = process as typeof process & { __llvStructuredDeliveryController?: ControllerState };
 const state: ControllerState = controllerStore.__llvStructuredDeliveryController ??= {
   activeQueue: null,
+  activeRegistry: null,
   activeHosts: null,
   registerActiveHost: null,
   republishActiveHost: null,
@@ -214,6 +216,7 @@ export async function bindStructuredDeliveryQueue(
   state.stopActive();
   state.stopActive = () => {};
   state.activeQueue = null;
+  state.activeRegistry = null;
   state.activeHosts = null;
   state.registerActiveHost = null;
   state.republishActiveHost = null;
@@ -561,6 +564,7 @@ export async function bindStructuredDeliveryQueue(
     return true;
   };
   state.activeQueue = queue;
+  state.activeRegistry = registry;
   setStructuredDeliveryKick(() => {
     if (stopped) return;
     if (drainTimer) clearTimeout(drainTimer);
@@ -579,6 +583,7 @@ export async function bindStructuredDeliveryQueue(
     hosts.clear();
     if (state.activeQueue === queue) {
       state.activeQueue = null;
+      state.activeRegistry = null;
       state.activeHosts = null;
       state.registerActiveHost = null;
       state.republishActiveHost = null;
@@ -590,7 +595,7 @@ export async function bindStructuredDeliveryQueue(
   };
   let completion = Promise.resolve();
   const complete = (items: readonly StructuredDeliveryHost[]) => {
-    completion = completion.then(async () => {
+    completion = completion.catch(() => {}).then(async () => {
       if (stopped || state.activeQueue !== queue) return;
       for (const item of items) await register(item);
       const startupSnapshot = registry.snapshot();
@@ -616,6 +621,13 @@ export async function bindStructuredDeliveryQueue(
   };
   state.completeActive = complete;
   if (!dependencies.deferStartupWork) await complete(adopted);
+}
+
+export function hasStructuredDeliveryController(registry: AgentRegistry): boolean {
+  return state.activeQueue !== null
+    && state.activeRegistry === registry
+    && state.registerActiveHost !== null
+    && state.completeActive !== null;
 }
 
 export function hasStructuredDeliveryHost(key: SessionKey): boolean {


### PR DESCRIPTION
Closes #547

Reuses the process-scoped structured delivery controller when startup retries against the same registry. Hosts that register between attempts remain attached, and a prior failed completion can advance on the next attempt.

Evidence:
- RED: a host registered after the first startup failure disappeared on retry
- GREEN: host survives retry and the partial-adoption socket recovery drains exactly once
- 146 runtime tests pass
- TypeScript, scoped ESLint, and privacy gate clean
- production and MCP builds clean