### PR TITLE
fix(pipelines): warm-start controller scans

### DIFF
--- a/src/app/api/files/route.test.ts
+++ b/src/app/api/files/route.test.ts
@@ -108,6 +108,7 @@ afterAll(() => {
 });
 
 const { cachedFileScan, currentFileScan, resetFilesRouteCacheForTests } = await import("@/lib/scanner/scanCache");
+const { controllerFileScan } = await import("@/lib/pipelines/controller");
 const { allowedKillTarget, buildResourceSnapshot, lastResourceTargetRefs, noteSessionTargets, readResourceFileSnapshot } = await import("@/lib/resources");
 const { GET } = await import("./route");
 
@@ -274,6 +275,33 @@ test("a restart serves the persisted completed snapshot while revalidating", asy
   expect(scans).toBe(1);
   const next = await cachedFileScan();
   expect(next.snapshot.files.map((entry) => entry.path)).toEqual(["/sessions/refreshed.jsonl"]);
+});
+
+test("the pipeline controller warm-starts from the persisted completed snapshot while revalidating", async () => {
+  fs.writeFileSync(path.join(stateDir, "files-scan-snapshot.json"), JSON.stringify({
+    version: 1,
+    schemaVersion: 9,
+    snapshot: {
+      files: [file("/sessions/persisted-controller.jsonl")],
+      projectCatalog: [],
+      complete: true,
+    },
+  }));
+  resetFilesRouteCacheForTests();
+  let release!: () => void;
+  scanGates.push(new Promise<void>((resolve) => { release = resolve; }));
+  scannedFiles = [file("/sessions/refreshed-controller.jsonl")];
+
+  const started = performance.now();
+  const snapshot = await controllerFileScan();
+
+  expect(performance.now() - started).toBeLessThan(300);
+  expect(snapshot.files.map((entry) => entry.path)).toEqual(["/sessions/persisted-controller.jsonl"]);
+  expect(scans).toBe(0);
+
+  await new Promise<void>((resolve) => setImmediate(resolve));
+  expect(scans).toBe(1);
+  release();
 });
 
 test("a current scan joins restart revalidation before publishing transcript metadata", async () => {

--- a/src/lib/pipelines/controller.ts
+++ b/src/lib/pipelines/controller.ts
@@ -4,7 +4,7 @@ import path from "node:path";
 
 import { statePath } from "@/lib/configDir";
 import { tickFlows } from "@/lib/flows/engine";
-import { coordinatedControllerScan } from "@/lib/scanner/scanCoordinator";
+import { completedFileScan } from "@/lib/scanner/scanCache";
 import type { FileEntry } from "@/lib/types";
 
 import { registerPipelineTick } from "./controllerSignal";
@@ -80,11 +80,19 @@ export function writeFlowPipelineControllerHeartbeat(
   fs.renameSync(temporary, filename);
 }
 
+export async function controllerFileScan(): Promise<{ files: FileEntry[]; complete: boolean }> {
+  const completed = await completedFileScan();
+  return {
+    files: completed.snapshot.files,
+    complete: completed.snapshot.complete,
+  };
+}
+
 function productionPorts(): FlowPipelineControllerPorts {
   return {
-    // The watchdog joins the process-wide scan generation instead of racing
-    // the HTTP cache and the account controller with its own scanner run.
-    scan: async () => coordinatedControllerScan(),
+    // Consume the latest completed generation immediately. The shared scan
+    // cache starts stale revalidation in the background for the next pass.
+    scan: controllerFileScan,
     tickPipelines,
     tickFlows,
     publishHeartbeat: writeFlowPipelineControllerHeartbeat,


### PR DESCRIPTION
Closes #549\n\n- serve the pipeline controller from the latest completed persisted file snapshot\n- start shared stale revalidation in the background\n- cover restart latency and refresh behavior with a focused regression\n\nGates: focused controller/files tests, isolated real scan-cache tests, TypeScript, scoped ESLint, privacy gate, production and MCP build.