### PR TITLE
fix(scheme): keep every pipeline conversation inside stable non-overlapping colored regions (#531)

### DIFF
--- a/src/components/EffortPills.slot.dom.test.tsx
+++ b/src/components/EffortPills.slot.dom.test.tsx
@@ -151,7 +151,7 @@ test("narrow scheme node (360px): the in-node pane keeps the bars in-flow with n
   const entry = fableRoot({ path: "/node.jsonl", name: "node.jsonl" });
   const node: SchemeNode = { file: entry, tasks: [], under: [], isRoot: true, x: 0, y: 0, w: 360, h: 780 };
   const layout: SchemeLayout = {
-    nodes: [node], edges: [], stacks: [], decks: [], loops: [], groups: [], links: [], drafts: [], slots: [],
+    nodes: [node], edges: [], stacks: [], decks: [], loops: [], groups: [], links: [], drafts: [], slots: [], regionTasks: [],
     byPath: new Map([[entry.path, node]]), width: 2000, height: 1000,
   };
   const { host, root } = mount();

--- a/src/components/mobile/mobileMapFixture.ts
+++ b/src/components/mobile/mobileMapFixture.ts
@@ -111,6 +111,7 @@ export function buildMobileMapFixture(nodeCount = 500): MobileMapFixture {
     links: [],
     drafts,
     slots: [],
+    regionTasks: [],
     byPath,
     width: maxX + COL_GAP,
     height: maxY + ROW_GAP,

--- a/src/components/scheme/Minimap.render.test.tsx
+++ b/src/components/scheme/Minimap.render.test.tsx
@@ -12,7 +12,7 @@ import { fitCameraToRect } from "./useSchemeCamera";
 import type { WorkerStack } from "./workerCollapse";
 
 const emptyLayout: SchemeLayout = {
-  nodes: [], edges: [], stacks: [], decks: [], loops: [], groups: [], links: [], drafts: [], slots: [],
+  nodes: [], edges: [], stacks: [], decks: [], loops: [], groups: [], links: [], drafts: [], slots: [], regionTasks: [],
   byPath: new Map(), width: 1000, height: 1000,
 };
 const world: SchemeRect = { x: 0, y: 0, w: 1000, h: 1000 };

--- a/src/components/scheme/SchemeBoard.pipelineRegions.dom.test.tsx
+++ b/src/components/scheme/SchemeBoard.pipelineRegions.dom.test.tsx
@@ -4,11 +4,13 @@ import { createRoot, type Root } from "react-dom/client";
 import { flushSync } from "react-dom";
 
 import type { Pipeline } from "@/lib/pipelines/types";
+import type { BoardTask } from "@/lib/tasks/types";
 import type { FileEntry } from "@/lib/types";
 import { directReviewFlows } from "@/components/flows/directReviewGroups";
 import { buildBranchGroups } from "@/components/projectModel";
 
 import { SchemeBoard } from "./SchemeBoard";
+import { taskBoxHeight } from "./taskGeometry";
 
 /*
  * DOM regressions for issue #531: on the rendered production board every
@@ -71,10 +73,10 @@ const stages = [
   { id: "polish", kind: "run", prompt: "", next: null, effectiveRole: stageRole("read-write") },
 ];
 
-const pipe = (id: string, agentPath: string, attemptState = "running"): Pipeline =>
+const pipe = (id: string, agentPath: string, attemptState = "running", taskIds: string[] = []): Pipeline =>
   ({
     id, task: `Region ${id}`, project: "demo", repoDir: "/r", worktreeDir: "/w", branch: "b",
-    baseBranch: "main", baseRef: "a", lastPassedCommit: "a", stages,
+    baseBranch: "main", baseRef: "a", lastPassedCommit: "a", stages, taskIds,
     runs: [{ stageId: "build", attempts: [{ n: 1, state: attemptState, agentPath, flowId: null }] }],
     cursor: { stageId: "build", state: attemptState, input: null, activatedBy: null },
     state: attemptState === "needs_decision" ? "needs_decision" : "running",
@@ -150,7 +152,7 @@ function expectSceneGeometry(host: HTMLElement, surfacesByPipeline: Map<string, 
   }
 }
 
-function mountScene(files: FileEntry[], pipelines: Pipeline[]): HTMLElement {
+function mountScene(files: FileEntry[], pipelines: Pipeline[], tasks: BoardTask[] = []): HTMLElement {
   const groups = buildBranchGroups(files, "demo");
   const reviewGroups = directReviewFlows({ files, flows: [], tasks: [] });
   const host = document.createElement("div");
@@ -167,7 +169,7 @@ function mountScene(files: FileEntry[], pipelines: Pipeline[]): HTMLElement {
       reviewGroups={reviewGroups}
       pipelines={pipelines}
       surfacePipelines={pipelines}
-      tasks={[]}
+      tasks={tasks}
       drafts={[]}
       focus={null}
       onSelect={() => {}}
@@ -198,13 +200,38 @@ const directReviewer = entry({
   },
 });
 
+/* The pipeline's board task — a pinned sticky note whose lattice position is far
+   outside the region; region ownership must pull the card inside. */
+const linkedTask = (id: string): BoardTask =>
+  ({
+    id,
+    project: "demo",
+    status: "assigned",
+    text: `Deliver ${id}`,
+    placement: "pinned",
+    pos: { x: 4200, y: 4200 },
+    assignments: [],
+    createdAt: "2026-07-05T00:00:00Z",
+    updatedAt: "2026-07-05T00:00:00Z",
+  }) as unknown as BoardTask;
+
+function linkedTaskRect(host: HTMLElement, task: BoardTask): DomRect {
+  const card = host.querySelector(`[data-scheme-task="${task.id}"]`) as HTMLElement | null;
+  expect(card, `task card ${task.id} must render`).toBeTruthy();
+  const rect = rectOf(card!);
+  /* TaskCard's root carries transform + width; the card's world height is the
+     shared geometry estimate every placement consumer uses. */
+  return { ...rect, h: taskBoxHeight(task, false) };
+}
+
 test("at 62% lite zoom every pipeline surface stays inside its region and neighboring regions keep their gap", async () => {
   /* The user parked the desktop camera at 62% — the lite far-zoom band where the
      production overlap was captured. World geometry must be identical to any
      other zoom: regions disjoint, every surface contained. */
   dom.sessionStorage.setItem("llvCam:demo", JSON.stringify({ x: 0, y: 0, z: 0.62 }));
   const files = [origin, builderA, builderB, directReviewer];
-  const host = mountScene(files, [pipe("pa", "/origin/a"), pipe("pb", "/origin/b")]);
+  const taskA = linkedTask("t-a");
+  const host = mountScene(files, [pipe("pa", "/origin/a", "running", ["t-a"]), pipe("pb", "/origin/b")], [taskA]);
   await settle();
 
   const viewport = host.querySelector('[aria-label^="Agent board"]') as HTMLElement;
@@ -218,16 +245,23 @@ test("at 62% lite zoom every pipeline surface stays inside its region and neighb
     ["pb", ["/origin/b", "slot::pb::review", "slot::pb::polish"]],
   ]);
   expectSceneGeometry(host, surfaces);
+  /* The pipeline's linked task card is owned by pa's region — inside pa, clear
+     of pb. */
+  const halos = haloRects(host);
+  const taskCard = linkedTaskRect(host, taskA);
+  expect(contains(halos.get("pa")!, taskCard), "the linked task card escapes its pipeline region").toBe(true);
+  expect(disjointWithGap(halos.get("pb")!, taskCard, 0), "the linked task card leaks into the neighbor region").toBe(true);
 
   /* Fit All reframes the camera only — the world rects must not move. */
-  const before = [...host.querySelectorAll("[data-scheme-node]")].map((card) => (card as HTMLElement).style.transform);
+  const before = [...host.querySelectorAll("[data-scheme-node], [data-scheme-task]")].map((card) => (card as HTMLElement).style.transform);
   const fit = [...host.querySelectorAll("button")].find((button) => button.title.startsWith("Fit all")) as HTMLButtonElement;
   expect(fit).toBeTruthy();
   flushSync(() => fit.click());
   await settle();
-  const after = [...host.querySelectorAll("[data-scheme-node]")].map((card) => (card as HTMLElement).style.transform);
+  const after = [...host.querySelectorAll("[data-scheme-node], [data-scheme-task]")].map((card) => (card as HTMLElement).style.transform);
   expect(after).toEqual(before);
   expectSceneGeometry(host, surfaces);
+  expect(contains(haloRects(host).get("pa")!, linkedTaskRect(host, taskA))).toBe(true);
 });
 
 test("host loss / delayed materialization: unscanned published transcripts keep two separated shell regions", async () => {
@@ -236,7 +270,8 @@ test("host loss / delayed materialization: unscanned published transcripts keep 
      conversation-shaped shell; the two pipelines still own disjoint regions and
      every shell stays inside its own. */
   const files = [origin];
-  const host = mountScene(files, [pipe("pa", "/lost/a"), pipe("pb", "/lost/b")]);
+  const taskA = linkedTask("t-lost");
+  const host = mountScene(files, [pipe("pa", "/lost/a", "running", ["t-lost"]), pipe("pb", "/lost/b")], [taskA]);
   await settle();
 
   expectSceneGeometry(host, new Map([
@@ -248,6 +283,11 @@ test("host loss / delayed materialization: unscanned published transcripts keep 
   for (const halo of haloRects(host).values()) {
     expect(disjointWithGap(halo, originRect, 0), "a pipeline region covers a foreign conversation").toBe(true);
   }
+  /* The linked task rides the shell region through the publish-to-scan gap. */
+  const halos = haloRects(host);
+  const taskCard = linkedTaskRect(host, taskA);
+  expect(contains(halos.get("pa")!, taskCard), "the linked task card escapes its host-lost pipeline region").toBe(true);
+  expect(disjointWithGap(halos.get("pb")!, taskCard, 0)).toBe(true);
 });
 
 test("parked and completed stage cards stay inside their regions beside a live neighbor", async () => {

--- a/src/components/scheme/SchemeBoard.pipelineRegions.dom.test.tsx
+++ b/src/components/scheme/SchemeBoard.pipelineRegions.dom.test.tsx
@@ -160,8 +160,10 @@ function mountScene(
   tasks: BoardTask[] = [],
   flows: Flow[] = [],
   manual: FileEntry[] = [],
+  sceneFiles: FileEntry[] = files,
+  isolatedManualPaths: ReadonlySet<string> = new Set(),
 ): HTMLElement {
-  const groups = buildBranchGroups(files, "demo");
+  const groups = buildBranchGroups(sceneFiles, "demo");
   const reviewGroups = directReviewFlows({ files, flows, tasks: [] });
   const host = document.createElement("div");
   document.body.append(host);
@@ -177,6 +179,7 @@ function mountScene(
       reviewGroups={reviewGroups}
       pipelines={pipelines}
       surfacePipelines={pipelines}
+      isolatedManualPaths={isolatedManualPaths}
       tasks={tasks}
       drafts={[]}
       focus={null}
@@ -391,9 +394,9 @@ test("managed fixing and closed-hidden/restored lifecycle panes stay inside thei
     ],
     runs: [
       { stageId: "build", attempts: [{ n: 1, state: "passed", agentPath: fixingBuilder.path, conversationId: fixingBuilder.conversationId, flowId: null }] },
-      { stageId: "review", attempts: [{ n: 1, state: "passed", agentPath: fixingReviewer.path, conversationId: fixingReviewer.conversationId, flowId: fixingFlow.id }] },
+      { stageId: "review", attempts: [{ n: 1, state: "reviewing", agentPath: fixingReviewer.path, conversationId: fixingReviewer.conversationId, flowId: fixingFlow.id }] },
     ],
-    cursor: { stageId: "build", state: "running", input: null, activatedBy: null },
+    cursor: { stageId: "review", state: "reviewing", input: null, activatedBy: null },
   } as unknown as Pipeline;
 
   dom.sessionStorage.setItem("llvCam:demo", JSON.stringify({ x: 0, y: 0, z: 0.62 }));
@@ -405,7 +408,11 @@ test("managed fixing and closed-hidden/restored lifecycle panes stay inside thei
   expect(activeHost.querySelectorAll("[data-scheme-node]")).toHaveLength(2);
   expect(activeHost.querySelectorAll('[data-scheme-node="/fix/build"]')).toHaveLength(1);
   expect(activeHost.querySelectorAll('[data-scheme-node="/fix/review"]')).toHaveLength(1);
+  const activeViewport = activeHost.querySelector('[aria-label^="Agent board"]') as HTMLElement;
+  const activeWorld = Array.from(activeViewport.children).find((child) => (child as HTMLElement).style.transform.includes("scale(")) as HTMLElement;
+  expect(activeWorld.style.transform).toContain("scale(0.62)");
 
+  const closedFlow = { ...fixingFlow, state: "closed", closedAt: "2026-07-22T00:03:00Z" } as Flow;
   const closed = {
     ...fixingPipeline,
     state: "closed",
@@ -413,19 +420,37 @@ test("managed fixing and closed-hidden/restored lifecycle panes stay inside thei
     hiddenAt: "2026-07-22T00:03:00Z",
     closedAt: "2026-07-22T00:03:00Z",
   } as unknown as Pipeline;
-  const compact = compactPipelineArtifactPaths([closed], [fixingFlow], [fixingBuilder, fixingReviewer]);
-  const hiddenFiles = excludeCompactPipelineArtifacts([fixingBuilder, fixingReviewer], compact);
-  const hiddenHost = mountScene(hiddenFiles, [], [], []);
+  const fullCatalog = [
+    { ...fixingBuilder, activity: "idle" as const },
+    { ...fixingReviewer, activity: "idle" as const },
+  ];
+  const compact = compactPipelineArtifactPaths([closed], [closedFlow], fullCatalog);
+  const hiddenSceneFiles = excludeCompactPipelineArtifacts(fullCatalog, compact);
+  expect(hiddenSceneFiles).toEqual([]);
+  const hiddenHost = mountScene(fullCatalog, [], [], [closedFlow], [], hiddenSceneFiles);
   await settle();
   expect(hiddenHost.querySelectorAll("[data-scheme-node]")).toHaveLength(0);
   expect(hiddenHost.querySelectorAll('[data-scheme-group="pipeline"]')).toHaveLength(0);
 
   const restored = { ...closed, restored: true } as Pipeline;
-  const restoredReviewer = { ...fixingReviewer, activity: "idle" as const };
-  const restoredHost = mountScene([restoredReviewer], [restored], [], [fixingFlow], [restoredReviewer]);
+  const restoredFlow = { ...closedFlow, restored: true } as Flow;
+  const restoredReviewer = fullCatalog[1]!;
+  dom.sessionStorage.setItem("llvCam:demo", JSON.stringify({ x: 0, y: 0, z: 0.62 }));
+  const restoredHost = mountScene(
+    fullCatalog,
+    [restored],
+    [],
+    [restoredFlow],
+    [restoredReviewer],
+    hiddenSceneFiles,
+    new Set([restoredReviewer.path]),
+  );
   await settle();
   expectSceneGeometry(restoredHost, new Map([["fix-pipeline", [fixingReviewer.path]]]));
   expect(restoredHost.querySelectorAll('[data-scheme-node="/fix/review"]')).toHaveLength(1);
+  const restoredViewport = restoredHost.querySelector('[aria-label^="Agent board"]') as HTMLElement;
+  const restoredWorld = Array.from(restoredViewport.children).find((child) => (child as HTMLElement).style.transform.includes("scale(")) as HTMLElement;
+  expect(restoredWorld.style.transform).toContain("scale(0.62)");
 
   const before = cardRect(restoredHost, fixingReviewer.path);
   const fit = [...restoredHost.querySelectorAll("button")].find((button) => button.title.startsWith("Fit all")) as HTMLButtonElement;

--- a/src/components/scheme/SchemeBoard.pipelineRegions.dom.test.tsx
+++ b/src/components/scheme/SchemeBoard.pipelineRegions.dom.test.tsx
@@ -1,0 +1,265 @@
+import { afterEach, expect, test } from "bun:test";
+import { Window } from "happy-dom";
+import { createRoot, type Root } from "react-dom/client";
+import { flushSync } from "react-dom";
+
+import type { Pipeline } from "@/lib/pipelines/types";
+import type { FileEntry } from "@/lib/types";
+import { directReviewFlows } from "@/components/flows/directReviewGroups";
+import { buildBranchGroups } from "@/components/projectModel";
+
+import { SchemeBoard } from "./SchemeBoard";
+
+/*
+ * DOM regressions for issue #531: on the rendered production board every
+ * pipeline's colored region (the dashed halo) contains ALL of its conversation
+ * surfaces — live panes, placeholder/completed stage shells, and attached review
+ * decks — and two regions never intersect. The camera (62% lite zoom, Fit All)
+ * must never perturb that world geometry.
+ */
+
+const dom = new Window();
+class TestResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+(dom as unknown as { matchMedia: (q: string) => unknown }).matchMedia = () => ({
+  matches: false, media: "", addEventListener() {}, removeEventListener() {}, addListener() {}, removeListener() {}, onchange: null, dispatchEvent: () => false,
+});
+Object.assign(globalThis, {
+  window: dom,
+  document: dom.document,
+  navigator: dom.navigator,
+  Node: dom.Node,
+  HTMLElement: dom.HTMLElement,
+  HTMLButtonElement: dom.HTMLButtonElement,
+  HTMLDivElement: dom.HTMLDivElement,
+  Event: dom.Event,
+  CustomEvent: dom.CustomEvent,
+  MouseEvent: dom.MouseEvent,
+  sessionStorage: dom.sessionStorage,
+  localStorage: dom.localStorage,
+  ResizeObserver: TestResizeObserver,
+  IntersectionObserver: undefined,
+});
+
+const roots = new Set<Root>();
+afterEach(() => {
+  for (const root of roots) flushSync(() => root.unmount());
+  roots.clear();
+  document.body.replaceChildren();
+  dom.sessionStorage.clear();
+  dom.localStorage.clear();
+});
+
+function entry(over: Partial<FileEntry> & { path: string }): FileEntry {
+  return {
+    root: "claude-projects", name: over.path, project: "demo", title: over.path,
+    engine: "claude", kind: "session", fmt: "claude", parent: null, mtime: 1000,
+    size: 10, activity: "live", proc: null, pid: null, model: null,
+    pendingQuestion: null, waitingInput: null, ...over,
+  };
+}
+
+const stageRole = (access: "read-write" | "read-only") =>
+  ({ roleId: null, engine: "codex" as const, model: null, effort: null, access, promptScaffold: null });
+
+const stages = [
+  { id: "build", kind: "run", prompt: "", next: "review", effectiveRole: stageRole("read-write") },
+  { id: "review", kind: "review-loop", prompt: "", next: "polish", onFail: { to: "build", maxRounds: 5 }, effectiveRole: stageRole("read-only") },
+  { id: "polish", kind: "run", prompt: "", next: null, effectiveRole: stageRole("read-write") },
+];
+
+const pipe = (id: string, agentPath: string, attemptState = "running"): Pipeline =>
+  ({
+    id, task: `Region ${id}`, project: "demo", repoDir: "/r", worktreeDir: "/w", branch: "b",
+    baseBranch: "main", baseRef: "a", lastPassedCommit: "a", stages,
+    runs: [{ stageId: "build", attempts: [{ n: 1, state: attemptState, agentPath, flowId: null }] }],
+    cursor: { stageId: "build", state: attemptState, input: null, activatedBy: null },
+    state: attemptState === "needs_decision" ? "needs_decision" : "running",
+    pausedState: null, stateDetail: null, srcPath: null, srcConversationId: null,
+    createdAt: new Date(0).toISOString(), closedAt: null,
+  }) as unknown as Pipeline;
+
+const settle = async () => {
+  for (let i = 0; i < 5; i += 1) await new Promise((resolve) => setTimeout(resolve, 0));
+  flushSync(() => undefined);
+};
+
+interface DomRect { x: number; y: number; w: number; h: number }
+
+/* World rect of a halo region (positioned via left/top) or a board card
+   (positioned via translate()). Both are world-space px, zoom-independent. */
+function rectOf(element: HTMLElement): DomRect {
+  const style = element.style;
+  const translated = /translate\((-?[\d.]+)px,\s*(-?[\d.]+)px\)/.exec(style.transform ?? "");
+  const x = translated ? Number.parseFloat(translated[1]!) : Number.parseFloat(style.left || "0");
+  const y = translated ? Number.parseFloat(translated[2]!) : Number.parseFloat(style.top || "0");
+  return { x, y, w: Number.parseFloat(style.width || "0"), h: Number.parseFloat(style.height || "0") };
+}
+
+const disjointWithGap = (a: DomRect, b: DomRect, gap: number): boolean =>
+  a.x + a.w + gap <= b.x || b.x + b.w + gap <= a.x || a.y + a.h + gap <= b.y || b.y + b.h + gap <= a.y;
+
+const contains = (outer: DomRect, inner: DomRect): boolean =>
+  inner.x >= outer.x && inner.y >= outer.y && inner.x + inner.w <= outer.x + outer.w && inner.y + inner.h <= outer.y + outer.h;
+
+function haloRects(host: HTMLElement): Map<string, DomRect> {
+  const rects = new Map<string, DomRect>();
+  for (const header of host.querySelectorAll("[data-pipeline-group-header]")) {
+    const region = (header as HTMLElement).closest('[data-scheme-group="pipeline"]') as HTMLElement | null;
+    expect(region).toBeTruthy();
+    rects.set(header.getAttribute("data-pipeline-group-header")!, rectOf(region!));
+  }
+  return rects;
+}
+
+function cardRect(host: HTMLElement, key: string): DomRect {
+  const card = host.querySelector(`[data-scheme-node="${key}"]`) as HTMLElement | null;
+  expect(card, `board card ${key} must render`).toBeTruthy();
+  return rectOf(card!);
+}
+
+function expectSceneGeometry(host: HTMLElement, surfacesByPipeline: Map<string, string[]>) {
+  const halos = haloRects(host);
+  const ids = [...surfacesByPipeline.keys()];
+  for (const id of ids) expect(halos.has(id), `pipeline ${id} must own a rendered colored region`).toBe(true);
+  /* Region non-intersection: every pair keeps a stable visible corridor. */
+  const entries = [...halos.entries()];
+  for (let i = 0; i < entries.length; i += 1) {
+    for (let j = i + 1; j < entries.length; j += 1) {
+      const [aId, a] = entries[i]!;
+      const [bId, b] = entries[j]!;
+      expect(
+        disjointWithGap(a, b, 24),
+        `regions ${aId} ${JSON.stringify(a)} and ${bId} ${JSON.stringify(b)} intersect`,
+      ).toBe(true);
+    }
+  }
+  /* Complete child-bounds containment inside the owning region. */
+  for (const [id, keys] of surfacesByPipeline) {
+    const halo = halos.get(id)!;
+    for (const key of keys) {
+      const rect = cardRect(host, key);
+      expect(
+        contains(halo, rect),
+        `surface ${key} ${JSON.stringify(rect)} escapes region ${id} ${JSON.stringify(halo)}`,
+      ).toBe(true);
+    }
+  }
+}
+
+function mountScene(files: FileEntry[], pipelines: Pipeline[]): HTMLElement {
+  const groups = buildBranchGroups(files, "demo");
+  const reviewGroups = directReviewFlows({ files, flows: [], tasks: [] });
+  const host = document.createElement("div");
+  document.body.append(host);
+  const root = createRoot(host);
+  roots.add(root);
+  flushSync(() => root.render(
+    <SchemeBoard
+      project="demo"
+      groups={groups}
+      manual={[]}
+      files={files}
+      flows={[]}
+      reviewGroups={reviewGroups}
+      pipelines={pipelines}
+      surfacePipelines={pipelines}
+      tasks={[]}
+      drafts={[]}
+      focus={null}
+      onSelect={() => {}}
+      onClose={() => {}}
+      onDraftClose={() => {}}
+      onDraftSpawned={() => {}}
+    />,
+  ));
+  return host;
+}
+
+/* Production scene: one origin conversation spawned two pipeline builders. Both
+   pipelines still have future stages, so each grows a placeholder row wider than
+   its builder card. Builder A also carries a direct one-shot review deck. */
+const origin = entry({ path: "/origin" });
+const builderA = entry({ path: "/origin/a", parent: "/origin", kind: "subagent", conversationId: "c-a" });
+const builderB = entry({ path: "/origin/b", parent: "/origin", kind: "subagent", conversationId: "c-b" });
+const directReviewer = entry({
+  path: "/origin/a/review-1",
+  parent: "/origin/a",
+  conversationId: "c-r1",
+  durableLineage: {
+    kind: "review",
+    role: "reviewer",
+    parentConversationId: "c-a",
+    reviewsConversationId: "c-a",
+    memberships: [],
+  },
+});
+
+test("at 62% lite zoom every pipeline surface stays inside its region and neighboring regions keep their gap", async () => {
+  /* The user parked the desktop camera at 62% — the lite far-zoom band where the
+     production overlap was captured. World geometry must be identical to any
+     other zoom: regions disjoint, every surface contained. */
+  dom.sessionStorage.setItem("llvCam:demo", JSON.stringify({ x: 0, y: 0, z: 0.62 }));
+  const files = [origin, builderA, builderB, directReviewer];
+  const host = mountScene(files, [pipe("pa", "/origin/a"), pipe("pb", "/origin/b")]);
+  await settle();
+
+  const viewport = host.querySelector('[aria-label^="Agent board"]') as HTMLElement;
+  const world = Array.from(viewport.children).find((child) => (child as HTMLElement).style.transform.includes("scale(")) as HTMLElement;
+  expect(world.style.transform).toContain("scale(0.62)");
+
+  const directDeck = host.querySelector('[data-scheme-node^="deck::"]');
+  expect(directDeck, "the direct one-shot review deck must render on the board").toBeTruthy();
+  const surfaces = new Map<string, string[]>([
+    ["pa", ["/origin/a", "slot::pa::review", "slot::pa::polish", directDeck!.getAttribute("data-scheme-node")!]],
+    ["pb", ["/origin/b", "slot::pb::review", "slot::pb::polish"]],
+  ]);
+  expectSceneGeometry(host, surfaces);
+
+  /* Fit All reframes the camera only — the world rects must not move. */
+  const before = [...host.querySelectorAll("[data-scheme-node]")].map((card) => (card as HTMLElement).style.transform);
+  const fit = [...host.querySelectorAll("button")].find((button) => button.title.startsWith("Fit all")) as HTMLButtonElement;
+  expect(fit).toBeTruthy();
+  flushSync(() => fit.click());
+  await settle();
+  const after = [...host.querySelectorAll("[data-scheme-node]")].map((card) => (card as HTMLElement).style.transform);
+  expect(after).toEqual(before);
+  expectSceneGeometry(host, surfaces);
+});
+
+test("host loss / delayed materialization: unscanned published transcripts keep two separated shell regions", async () => {
+  /* Both builders published transcripts, then the runtime host died before the
+     scanner surfaced them (the publish-to-place gap). Every stage rides a
+     conversation-shaped shell; the two pipelines still own disjoint regions and
+     every shell stays inside its own. */
+  const files = [origin];
+  const host = mountScene(files, [pipe("pa", "/lost/a"), pipe("pb", "/lost/b")]);
+  await settle();
+
+  expectSceneGeometry(host, new Map([
+    ["pa", ["slot::pa::build", "slot::pa::review", "slot::pa::polish"]],
+    ["pb", ["slot::pb::build", "slot::pb::review", "slot::pb::polish"]],
+  ]));
+  /* The origin conversation belongs to no pipeline: neither region may cover it. */
+  const originRect = cardRect(host, "/origin");
+  for (const halo of haloRects(host).values()) {
+    expect(disjointWithGap(halo, originRect, 0), "a pipeline region covers a foreign conversation").toBe(true);
+  }
+});
+
+test("parked and completed stage cards stay inside their regions beside a live neighbor", async () => {
+  /* pa parked in needs_decision on its builder; pb kept running. The parked
+     pipeline's placeholder row and the live neighbor's row keep both regions
+     separated, and each pipeline's surfaces stay contained. */
+  const files = [origin, builderA, builderB];
+  const host = mountScene(files, [pipe("pa", "/origin/a", "needs_decision"), pipe("pb", "/origin/b")]);
+  await settle();
+
+  expectSceneGeometry(host, new Map([
+    ["pa", ["/origin/a", "slot::pa::review", "slot::pa::polish"]],
+    ["pb", ["/origin/b", "slot::pb::review", "slot::pb::polish"]],
+  ]));
+});

--- a/src/components/scheme/SchemeBoard.pipelineRegions.dom.test.tsx
+++ b/src/components/scheme/SchemeBoard.pipelineRegions.dom.test.tsx
@@ -4,9 +4,11 @@ import { createRoot, type Root } from "react-dom/client";
 import { flushSync } from "react-dom";
 
 import type { Pipeline } from "@/lib/pipelines/types";
+import type { Flow } from "@/lib/flows/types";
 import type { BoardTask } from "@/lib/tasks/types";
 import type { FileEntry } from "@/lib/types";
 import { directReviewFlows } from "@/components/flows/directReviewGroups";
+import { compactPipelineArtifactPaths, excludeCompactPipelineArtifacts } from "@/components/pipelines/pipelineModel";
 import { buildBranchGroups } from "@/components/projectModel";
 
 import { SchemeBoard } from "./SchemeBoard";
@@ -152,9 +154,15 @@ function expectSceneGeometry(host: HTMLElement, surfacesByPipeline: Map<string, 
   }
 }
 
-function mountScene(files: FileEntry[], pipelines: Pipeline[], tasks: BoardTask[] = []): HTMLElement {
+function mountScene(
+  files: FileEntry[],
+  pipelines: Pipeline[],
+  tasks: BoardTask[] = [],
+  flows: Flow[] = [],
+  manual: FileEntry[] = [],
+): HTMLElement {
   const groups = buildBranchGroups(files, "demo");
-  const reviewGroups = directReviewFlows({ files, flows: [], tasks: [] });
+  const reviewGroups = directReviewFlows({ files, flows, tasks: [] });
   const host = document.createElement("div");
   document.body.append(host);
   const root = createRoot(host);
@@ -163,9 +171,9 @@ function mountScene(files: FileEntry[], pipelines: Pipeline[], tasks: BoardTask[
     <SchemeBoard
       project="demo"
       groups={groups}
-      manual={[]}
+      manual={manual}
       files={files}
-      flows={[]}
+      flows={flows}
       reviewGroups={reviewGroups}
       pipelines={pipelines}
       surfacePipelines={pipelines}
@@ -290,6 +298,37 @@ test("host loss / delayed materialization: unscanned published transcripts keep 
   expect(disjointWithGap(halos.get("pb")!, taskCard, 0)).toBe(true);
 });
 
+test("a live pipeline beside a delayed-materialization pipeline keeps 24px of visible halo separation", async () => {
+  /* Production transition: pa already materialized under its source conversation
+     while pb has published a stage transcript that the scanner has not surfaced.
+     The memberless row docks below all live content and must leave the same
+     visible corridor as two materialized pipeline regions. */
+  dom.sessionStorage.setItem("llvCam:demo", JSON.stringify({ x: 0, y: 0, z: 0.62 }));
+  const host = mountScene(
+    [origin, builderA],
+    [pipe("pa", "/origin/a"), pipe("pb", "/lost/b")],
+  );
+  await settle();
+
+  const viewport = host.querySelector('[aria-label^="Agent board"]') as HTMLElement;
+  const world = Array.from(viewport.children).find((child) => (child as HTMLElement).style.transform.includes("scale(")) as HTMLElement;
+  expect(world.style.transform).toContain("scale(0.62)");
+
+  const surfaces = new Map<string, string[]>([
+    ["pa", ["/origin/a", "slot::pa::review", "slot::pa::polish"]],
+    ["pb", ["slot::pb::build", "slot::pb::review", "slot::pb::polish"]],
+  ]);
+  expectSceneGeometry(host, surfaces);
+
+  const before = [...host.querySelectorAll("[data-scheme-node]")].map((card) => (card as HTMLElement).style.transform);
+  const fit = [...host.querySelectorAll("button")].find((button) => button.title.startsWith("Fit all")) as HTMLButtonElement;
+  expect(fit).toBeTruthy();
+  flushSync(() => fit.click());
+  await settle();
+  expect([...host.querySelectorAll("[data-scheme-node]")].map((card) => (card as HTMLElement).style.transform)).toEqual(before);
+  expectSceneGeometry(host, surfaces);
+});
+
 test("parked and completed stage cards stay inside their regions beside a live neighbor", async () => {
   /* pa parked in needs_decision on its builder; pb kept running. The parked
      pipeline's placeholder row and the live neighbor's row keep both regions
@@ -302,4 +341,99 @@ test("parked and completed stage cards stay inside their regions beside a live n
     ["pa", ["/origin/a", "slot::pa::review", "slot::pa::polish"]],
     ["pb", ["/origin/b", "slot::pb::review", "slot::pb::polish"]],
   ]));
+});
+
+test("managed fixing and closed-hidden/restored lifecycle panes stay inside their pipeline region", async () => {
+  const fixingBuilder = entry({ path: "/fix/build", conversationId: "fix-build" });
+  const fixingReviewer = entry({
+    path: "/fix/review",
+    parent: "/fix/build",
+    kind: "subagent",
+    conversationId: "fix-review",
+  });
+  const fixingFlow: Flow = {
+    id: "fix-flow",
+    template: "implement-review-loop",
+    project: "demo",
+    cwd: "/r",
+    implementerPath: fixingBuilder.path,
+    implementerConversationId: fixingBuilder.conversationId,
+    roles: { implementer: { engine: "codex", model: null, effort: "low" }, reviewer: { engine: "codex", model: null, effort: "high" } },
+    baseRef: "a",
+    baseMode: "head",
+    mode: "auto",
+    reviewerMode: "headless",
+    roundLimit: 5,
+    state: "fixing",
+    stateDetail: null,
+    rounds: [{
+      n: 1,
+      reviewerPath: fixingReviewer.path,
+      reviewerConversationId: fixingReviewer.conversationId,
+      findingsPath: null,
+      triggeredBy: "marker",
+      readyNote: null,
+      verdict: "REQUEST_CHANGES",
+      findingsCount: 2,
+      startedAt: "2026-07-22T00:00:00Z",
+      reviewedAt: "2026-07-22T00:01:00Z",
+      relayedAt: "2026-07-22T00:02:00Z",
+      error: null,
+    }],
+    createdAt: "2026-07-22T00:00:00Z",
+    closedAt: null,
+  };
+  const fixingPipeline = {
+    ...pipe("fix-pipeline", fixingBuilder.path),
+    stages: [
+      { id: "build", kind: "run", prompt: "", next: "review", effectiveRole: stageRole("read-write") },
+      { id: "review", kind: "review-loop", prompt: "", next: null, onFail: { to: "build", maxRounds: 5 }, effectiveRole: stageRole("read-only") },
+    ],
+    runs: [
+      { stageId: "build", attempts: [{ n: 1, state: "passed", agentPath: fixingBuilder.path, conversationId: fixingBuilder.conversationId, flowId: null }] },
+      { stageId: "review", attempts: [{ n: 1, state: "passed", agentPath: fixingReviewer.path, conversationId: fixingReviewer.conversationId, flowId: fixingFlow.id }] },
+    ],
+    cursor: { stageId: "build", state: "running", input: null, activatedBy: null },
+  } as unknown as Pipeline;
+
+  dom.sessionStorage.setItem("llvCam:demo", JSON.stringify({ x: 0, y: 0, z: 0.62 }));
+  const activeHost = mountScene([fixingBuilder, fixingReviewer], [fixingPipeline], [], [fixingFlow]);
+  await settle();
+  expectSceneGeometry(activeHost, new Map([["fix-pipeline", [fixingBuilder.path, fixingReviewer.path]]]));
+  expect(activeHost.querySelectorAll('[data-scheme-group="pipeline"]')).toHaveLength(1);
+  expect(activeHost.querySelectorAll('[data-scheme-group="flow"]')).toHaveLength(0);
+  expect(activeHost.querySelectorAll("[data-scheme-node]")).toHaveLength(2);
+  expect(activeHost.querySelectorAll('[data-scheme-node="/fix/build"]')).toHaveLength(1);
+  expect(activeHost.querySelectorAll('[data-scheme-node="/fix/review"]')).toHaveLength(1);
+
+  const closed = {
+    ...fixingPipeline,
+    state: "closed",
+    cursor: null,
+    hiddenAt: "2026-07-22T00:03:00Z",
+    closedAt: "2026-07-22T00:03:00Z",
+  } as unknown as Pipeline;
+  const compact = compactPipelineArtifactPaths([closed], [fixingFlow], [fixingBuilder, fixingReviewer]);
+  const hiddenFiles = excludeCompactPipelineArtifacts([fixingBuilder, fixingReviewer], compact);
+  const hiddenHost = mountScene(hiddenFiles, [], [], []);
+  await settle();
+  expect(hiddenHost.querySelectorAll("[data-scheme-node]")).toHaveLength(0);
+  expect(hiddenHost.querySelectorAll('[data-scheme-group="pipeline"]')).toHaveLength(0);
+
+  const restored = { ...closed, restored: true } as Pipeline;
+  const restoredReviewer = { ...fixingReviewer, activity: "idle" as const };
+  const restoredHost = mountScene([restoredReviewer], [restored], [], [fixingFlow], [restoredReviewer]);
+  await settle();
+  expectSceneGeometry(restoredHost, new Map([["fix-pipeline", [fixingReviewer.path]]]));
+  expect(restoredHost.querySelectorAll('[data-scheme-node="/fix/review"]')).toHaveLength(1);
+
+  const before = cardRect(restoredHost, fixingReviewer.path);
+  const fit = [...restoredHost.querySelectorAll("button")].find((button) => button.title.startsWith("Fit all")) as HTMLButtonElement;
+  flushSync(() => fit.click());
+  await settle();
+  expect(cardRect(restoredHost, fixingReviewer.path)).toEqual(before);
+  flushSync(() => window.dispatchEvent(new dom.KeyboardEvent("keydown", { key: "ArrowRight", bubbles: true }) as unknown as Event));
+  await settle();
+  expect(restoredHost.querySelector('[data-scheme-node="/fix/review"] .ring-2')).toBeTruthy();
+  expectSceneGeometry(restoredHost, new Map([["fix-pipeline", [fixingReviewer.path]]]));
 });

--- a/src/components/scheme/SchemeBoard.tsx
+++ b/src/components/scheme/SchemeBoard.tsx
@@ -250,13 +250,49 @@ export function SchemeBoard({
      flowsByImpl and every strip/hub below keep reading the real `flows`. */
   const deckFlows = useMemo(() => (reviewGroups.length ? [...flows, ...reviewGroups] : flows), [flows, reviewGroups]);
   const layoutFlows = useMemo(() => compactPipelineLayoutFlows(pipelines, deckFlows), [pipelines, deckFlows]);
+  /* Tasks created this session but not yet echoed by the poll: overlaid so a
+     fresh card never blinks out between the POST and the refetch. Entries
+     leave the cache the moment the server echoes them (or on local delete),
+     so a later server-side removal can never be shadowed by a stale copy;
+     the project filter keeps a card created here off other projects' boards. */
+  const [localTasks, setLocalTasks] = useState<BoardTask[]>([]);
+  const [pendingTask, setPendingTask] = useState<{ x: number; y: number } | null>(null);
+  useEffect(() => {
+    const have = new Set(tasks.map((task) => task.id));
+    /* eslint-disable-next-line react-hooks/set-state-in-effect -- prune-only:
+       returns the same reference unless an entry was echoed or reprojected */
+    setLocalTasks((prev) => {
+      const next = prev.filter((task) => !have.has(task.id) && task.project === project);
+      return next.length === prev.length ? prev : next;
+    });
+  }, [tasks, project]);
+  const mergedTasks = useMemo(() => {
+    const have = new Set(tasks.map((task) => task.id));
+    const fresh = localTasks.filter((task) => !have.has(task.id) && task.project === project);
+    return fresh.length ? [...tasks, ...fresh] : tasks;
+  }, [tasks, localTasks, project]);
+  /* Session-only full-text state. Every geometry consumer reads this set, while
+     durable task records and pinned positions stay unchanged. */
+  const [textExpandedIds, setTextExpandedIds] = useState<ReadonlySet<string>>(new Set());
+  useEffect(() => {
+    const present = new Set(mergedTasks.map((task) => task.id));
+    /* eslint-disable-next-line react-hooks/set-state-in-effect -- prune-only state synchronization */
+    setTextExpandedIds((previous) => {
+      if (![...previous].some((id) => !present.has(id))) return previous;
+      return new Set([...previous].filter((id) => present.has(id)));
+    });
+  }, [mergedTasks]);
+  /* Only placed tasks have a board position; unplaced ones (panel/mobile creation)
+     live in the list until place-on-map pins them. */
+  const boardTasks = useMemo(() => mergedTasks.filter(isPlacedTask), [mergedTasks]);
   /* Desktop pipeline ownership is the colored SchemeGroup halo (#353): the board
      layout places every materialized stage conversation and derives one halo that
-     encloses them plus the planned-stage placeholders, so the pipeline reads as a
-     single region — never a detached control card with a duplicate stage graph. */
+     encloses them plus the planned-stage placeholders — and the pipeline's linked
+     task cards (#531), so the pipeline reads as a single region — never a
+     detached control card with a duplicate stage graph. */
   const layout = useMemo(
-    () => buildSchemeLayout(groups, manual, files, layoutFlows, drafts, pipelines, surfacePipelines, favorites, isolatedManualPaths),
-    [groups, manual, files, layoutFlows, drafts, pipelines, surfacePipelines, favorites, isolatedManualPaths],
+    () => buildSchemeLayout(groups, manual, files, layoutFlows, drafts, pipelines, surfacePipelines, favorites, isolatedManualPaths, boardTasks, textExpandedIds),
+    [groups, manual, files, layoutFlows, drafts, pipelines, surfacePipelines, favorites, isolatedManualPaths, boardTasks, textExpandedIds],
   );
 
   /* Selection keys are transcript paths, so the 10s poll relayout keeps the
@@ -515,44 +551,12 @@ export function SchemeBoard({
      the camera↔lasso creation cycle (the lasso needs the camera's viewport). */
   const lassoDownRef = useRef<(event: React.PointerEvent<HTMLDivElement>) => boolean>(() => false);
 
-  /* Tasks created this session but not yet echoed by the poll: overlaid so a
-     fresh card never blinks out between the POST and the refetch. Entries
-     leave the cache the moment the server echoes them (or on local delete),
-     so a later server-side removal can never be shadowed by a stale copy;
-     the project filter keeps a card created here off other projects' boards. */
-  const [localTasks, setLocalTasks] = useState<BoardTask[]>([]);
-  const [pendingTask, setPendingTask] = useState<{ x: number; y: number } | null>(null);
-  useEffect(() => {
-    const have = new Set(tasks.map((task) => task.id));
-    /* eslint-disable-next-line react-hooks/set-state-in-effect -- prune-only:
-       returns the same reference unless an entry was echoed or reprojected */
-    setLocalTasks((prev) => {
-      const next = prev.filter((task) => !have.has(task.id) && task.project === project);
-      return next.length === prev.length ? prev : next;
-    });
-  }, [tasks, project]);
-  const mergedTasks = useMemo(() => {
-    const have = new Set(tasks.map((task) => task.id));
-    const fresh = localTasks.filter((task) => !have.has(task.id) && task.project === project);
-    return fresh.length ? [...tasks, ...fresh] : tasks;
-  }, [tasks, localTasks, project]);
-  /* Session-only full-text state. Every geometry consumer reads this set, while
-     durable task records and pinned positions stay unchanged. */
-  const [textExpandedIds, setTextExpandedIds] = useState<ReadonlySet<string>>(new Set());
-  useEffect(() => {
-    const present = new Set(mergedTasks.map((task) => task.id));
-    /* eslint-disable-next-line react-hooks/set-state-in-effect -- prune-only state synchronization */
-    setTextExpandedIds((previous) => {
-      if (![...previous].some((id) => !present.has(id))) return previous;
-      return new Set([...previous].filter((id) => present.has(id)));
-    });
-  }, [mergedTasks]);
-  /* Panes, decks, stacks and drafts the cards must not bury (issue #17): the
-     placement pass spreads any pileup into their gaps. Group halos are derived
-     from these same rects, so nudging cards never disturbs a flow/pipeline
-     overlay. */
+  /* Panes, decks, stacks, drafts and pipeline-owned task cards the free cards
+     must not bury (issue #17): the placement pass spreads any pileup into their
+     gaps. Group halos are derived from these same rects, so nudging cards never
+     disturbs a flow/pipeline overlay. */
   const taskObstacles = useMemo<SchemeRect[]>(
-    () => [...layout.nodes, ...layout.decks, ...layout.stacks, ...layout.drafts, ...layout.slots].map(({ x, y, w, h }) => ({ x, y, w, h })),
+    () => [...layout.nodes, ...layout.decks, ...layout.stacks, ...layout.drafts, ...layout.slots, ...layout.regionTasks].map(({ x, y, w, h }) => ({ x, y, w, h })),
     [layout],
   );
   /* Card rects the pipeline rails route around (issue #136). Unlike taskObstacles
@@ -562,23 +566,27 @@ export function SchemeBoard({
     () => [...layout.nodes, ...layout.decks, ...layout.stacks, ...layout.drafts, ...layout.slots],
     [layout],
   );
-  /* Only placed tasks have a board position; unplaced ones (panel/mobile creation)
-     live in the list until place-on-map pins them. */
-  const boardTasks = useMemo(() => mergedTasks.filter(isPlacedTask), [mergedTasks]);
+  /* Task cards owned by a pipeline region (#531) sit at the layout's coordinates
+     inside the colored halo; only the remaining free cards run through the
+     collision solver below. */
+  const regionTaskPos = useMemo(
+    () => new Map(layout.regionTasks.map((rect) => [rect.taskId, { x: rect.x, y: rect.y }] as const)),
+    [layout],
+  );
   /* Collision-aware display positions: cards keep their stored spot unless they
      overlap another card or pane, so hand-arranged boards pass through untouched
      while the curator/inbox lattice pileup gets spread out and stays readable. */
   const placement = useMemo(
-    () => resolveTaskPlacements(boardTasks, taskObstacles, textExpandedIds),
-    [boardTasks, taskObstacles, textExpandedIds],
+    () => resolveTaskPlacements(boardTasks.filter((task) => !regionTaskPos.has(task.id)), taskObstacles, textExpandedIds),
+    [boardTasks, regionTaskPos, taskObstacles, textExpandedIds],
   );
   const placedTasks = useMemo(
     () =>
       boardTasks.map((task) => {
-        const spot = placement.get(task.id);
+        const spot = regionTaskPos.get(task.id) ?? placement.get(task.id);
         return spot && (spot.x !== task.pos.x || spot.y !== task.pos.y) ? { ...task, pos: spot } : task;
       }),
-    [boardTasks, placement],
+    [boardTasks, regionTaskPos, placement],
   );
   /* Camera-facing rects: focus glides and map taps resolve task keys. */
   const taskRects = useMemo(

--- a/src/components/scheme/currentWork.test.ts
+++ b/src/components/scheme/currentWork.test.ts
@@ -49,6 +49,7 @@ const layout = (over: Partial<SchemeLayout> = {}): SchemeLayout => ({
   links: [],
   drafts: [],
   slots: [],
+  regionTasks: [],
   byPath: new Map(),
   width: 6_000,
   height: 4_000,

--- a/src/components/scheme/layout.ts
+++ b/src/components/scheme/layout.ts
@@ -70,6 +70,9 @@ export const GROUP_SIBLING_GAP = GROUP_PAD * 2 + GAP_X;
    own, so GAP_Y (130) leaves the two dashed regions overlapping. This corridor
    clears both pads plus a GAP_X lane of visible daylight. */
 export const GROUP_CHILD_GAP = GROUP_PAD * 2 + GROUP_STRIP_HEADROOM + GAP_X;
+/* A memberless pipeline docks below existing content. Its top halo edge includes
+   strip headroom, while the region above extends through its bottom padding. */
+const MEMBERLESS_PIPELINE_GAP = GROUP_PAD * 2 + GROUP_STRIP_HEADROOM + 24;
 /* Pipeline stage placeholder windows (issue #196): node-width dashed cards so a
    stage's live chat window later takes the same footprint in place. The gap
    between two slots carries the handoff arrow badge. */
@@ -964,7 +967,7 @@ export function buildSchemeLayout(
       contentBottom = Math.max(contentBottom, rect.y + rect.h);
     }
     let dockX = PAD;
-    const dockY = contentBottom > 0 ? contentBottom + GROUP_GAP : restTop;
+    const dockY = contentBottom > 0 ? contentBottom + MEMBERLESS_PIPELINE_GAP : restTop;
     for (const plan of stageChainPlans) {
       if (plan.placed) continue;
       dockX = emitCompactRow(plan, dockX, dockY) + GROUP_GAP;

--- a/src/components/scheme/layout.ts
+++ b/src/components/scheme/layout.ts
@@ -61,6 +61,12 @@ export const GROUP_STRIP_HEADROOM = 44;
    both facing sides clears, plus a lane of breathing room, so the two dashed
    outlines never overlap. GAP_X alone (48) leaves a 44px overlap. */
 export const GROUP_SIBLING_GAP = GROUP_PAD * 2 + GAP_X;
+/* Vertical corridor between a grouped parent and a child generation that starts
+   a DIFFERENT flow/pipeline region (#531): the parent halo pads GROUP_PAD below
+   its cards and the child halo pads GROUP_PAD + GROUP_STRIP_HEADROOM above its
+   own, so GAP_Y (130) leaves the two dashed regions overlapping. This corridor
+   clears both pads plus a GAP_X lane of visible daylight. */
+export const GROUP_CHILD_GAP = GROUP_PAD * 2 + GROUP_STRIP_HEADROOM + GAP_X;
 /* Pipeline stage placeholder windows (issue #196): node-width dashed cards so a
    stage's live chat window later takes the same footprint in place. The gap
    between two slots carries the handoff arrow badge. */
@@ -330,6 +336,135 @@ export function buildSchemeLayout(
     return false;
   };
 
+  /* ── Pipeline stage rows, classified BEFORE placement (#531) ─────────────────
+     Every declared stage resolves to exactly one surface (#507 F2): a live full
+     pane (its transcript will be a placed node), a completed full card, or a
+     placeholder. What the pass will place is fully knowable up front — nodes are
+     exactly the branch-group columns plus the manual roots, and a deck lays out
+     exactly when its flow's implementer is such a node — so each pipeline's slot
+     row is planned here and RESERVED inside the tree layout as a child block of
+     its tip. Reserving the row's footprint during placement (instead of dropping
+     it onto the finished board and nudging it around collisions) is what keeps
+     two neighboring pipeline regions from ever intersecting: sibling subtree
+     widths include the rows, so the existing group-boundary gaps apply. */
+  const prePlacedNodePaths = new Set<string>([
+    ...groups.flatMap((group) => group.columns.map((column) => column.file.path)),
+    ...manual.map((file) => file.path),
+  ]);
+  const prePlacedDeckFlowIds = new Set<string>();
+  for (const candidate of deckFor.values()) {
+    if (prePlacedNodePaths.has(candidate.implementerPath)) prePlacedDeckFlowIds.add(candidate.id);
+  }
+  type SlotStage = { stage: PipelineStage; index: number; presentation: "placeholder" | "completed"; attempt?: PipelineStageAttempt };
+  interface StageRowPlan {
+    pipeline: Pipeline;
+    slotStages: SlotStage[];
+    rowW: number;
+    placed: boolean;
+  }
+  const rowPlansByTip = new Map<string, StageRowPlan[]>();
+  const stageRowPlans: StageRowPlan[] = [];
+  {
+    /* Only THIS project's pipelines may grow memberless slot rows — the global
+       list serves cross-project stage membership, so without this fence a
+       foreign draft would drop its slots + halo on every project's canvas. A
+       global pipeline still gets slots once it has a placed member here. */
+    const surfaceIds = new Set(surfacePipelines.map((pipeline) => pipeline.id));
+    const seen = new Set<string>();
+    const pool = [...surfacePipelines, ...pipelines].filter((pipeline) => {
+      if (pipeline.state === "closed" || seen.has(pipeline.id)) return false;
+      seen.add(pipeline.id);
+      return true;
+    });
+    for (const pipeline of pool) {
+      const placeholderIds = new Set(pipelinePlaceholderStages(pipeline, prePlacedNodePaths, prePlacedDeckFlowIds).map((stage) => stage.id));
+      /* Completed cards only grow on an active pipeline, and never for the cursor
+         stage itself: a cursor stage whose only transcript is quiet history
+         (folded into an under-deck) has no live pane and shelves (#343), rather
+         than resurfacing as a card. */
+      const growsHistory = PIPELINE_PLACEHOLDER_STATES.has(pipeline.state);
+      const slotStages: SlotStage[] = [];
+      const memberPaths = new Set<string>();
+      /* The chain's tip: the LAST stage (in chain order) whose live pane will be
+         a placed node. The slot row anchors as its first child block. */
+      let tipPath: string | null = null;
+      for (let index = 0; index < pipeline.stages.length; index += 1) {
+        const stage = pipeline.stages[index]!;
+        const attempt = latestAttempt(pipeline, stage.id);
+        /* The stage's own live transcript — a run session or the live reviewer. */
+        const livePath = attempt?.agentPath ?? null;
+        if (livePath && prePlacedNodePaths.has(livePath)) {
+          memberPaths.add(livePath);
+          tipPath = livePath;
+          continue;
+        }
+        /* A folded review-loop resolves to its flow implementer node (deck laid
+           out): still a live pane, not a slot. */
+        const implPath = stage.kind === "review-loop" && attempt?.flowId ? implOfFlow(attempt.flowId) : null;
+        if (implPath && prePlacedNodePaths.has(implPath)) {
+          memberPaths.add(implPath);
+          tipPath = implPath;
+          continue;
+        }
+        if (placeholderIds.has(stage.id)) {
+          slotStages.push({ stage, index, presentation: "placeholder" });
+          continue;
+        }
+        /* Any materialized attempt (the operational latest or a folded historical
+           one) on a NON-cursor stage is a completed stage whose idle transcript is
+           not a live node: it stands in as a full conversation card at its
+           position. */
+        if (!growsHistory || stage.id === pipeline.cursor?.stageId) continue;
+        const materialized = stageAttempts(pipeline, stage.id).findLast((candidate) => candidate.agentPath || candidate.flowId);
+        if (materialized) {
+          slotStages.push({ stage, index, presentation: "completed", attempt: materialized });
+        }
+      }
+      if (!surfaceIds.has(pipeline.id) && !memberPaths.size) continue;
+      if (!slotStages.length) continue;
+      const rowW = slotStages.length * SLOT_W + (slotStages.length - 1) * SLOT_GAP;
+      const plan: StageRowPlan = { pipeline, slotStages, rowW, placed: false };
+      stageRowPlans.push(plan);
+      if (tipPath) {
+        const list = rowPlansByTip.get(tipPath);
+        if (list) list.push(plan);
+        else rowPlansByTip.set(tipPath, [plan]);
+      }
+    }
+  }
+  const slots: StageSlot[] = [];
+  const slotKeysByPipeline = new Map<string, string[]>();
+  const emitStageRow = (plan: StageRowPlan, sx: number, sy: number) => {
+    plan.placed = true;
+    const keys = slotKeysByPipeline.get(plan.pipeline.id) ?? [];
+    plan.slotStages.forEach((entry, i) => {
+      const { stage, index, presentation, attempt } = entry;
+      const previous = i > 0 ? plan.slotStages[i - 1]! : null;
+      /* The handoff badge renders only between chain-adjacent slots — a gap (a
+         live pane between them) breaks the visual chain. */
+      const adjacent = previous !== null && plan.pipeline.stages[index - 1]?.id === previous.stage.id;
+      const slot: StageSlot = {
+        key: stageSlotKey(plan.pipeline.id, stage.id),
+        pipeline: plan.pipeline,
+        stage,
+        index,
+        total: plan.pipeline.stages.length,
+        presentation,
+        ...(attempt ? { attempt } : {}),
+        ...(adjacent ? { incoming: stage.kind } : {}),
+        x: sx + i * (SLOT_W + SLOT_GAP),
+        y: sy,
+        w: SLOT_W,
+        /* Every slot is a full-size card — completed and placeholder alike share
+           the live conversation's footprint (#507 F2). */
+        h: SLOT_H,
+      };
+      slots.push(slot);
+      keys.push(slot.key);
+    });
+    slotKeysByPipeline.set(plan.pipeline.id, keys);
+  };
+
   /* Handoff drafts hang under their source pane like a child; drafts whose
      source is not on the scheme (or plain «+ Agent» ones) trail the row. */
   const drafts: DraftNode[] = [];
@@ -393,9 +528,30 @@ export function buildSchemeLayout(
         loops.push({ key: "loop::" + flow.id, flow, x1: x + NODE_W, x2: deck.x, y });
         rowH = Math.max(rowH, deck.h);
       }
-      const childTop = y + rowH + GAP_Y;
       const children = childrenOf.get(col.file.path) ?? [];
+      /* A child generation that starts a DIFFERENT flow/pipeline region drops
+         through the wider corridor, so the parent's halo pad and the child
+         region's pad + headroom never overlap (#531). Same-region and ungrouped
+         children keep the tight corridor. */
+      const ownGroupKey = groupKeyOfPath.get(col.file.path) ?? null;
+      const boundaryChild =
+        ownGroupKey !== null &&
+        children.some((child) => {
+          for (const key of subtreeGroups(child.file)) if (key !== ownGroupKey) return true;
+          return false;
+        });
+      const childTop = y + rowH + (boundaryChild ? GROUP_CHILD_GAP : GAP_Y);
       let cx = x + INDENT;
+      /* This pane is a pipeline chain's tip: its planned/completed stage row
+         takes the first child block, RESERVING its footprint inside the subtree
+         width. Anchoring at x + INDENT keeps the hand-off positionally exact —
+         the live window the tree later places for the next stage lands on the
+         placeholder's own coordinates (#196) — and the group-sibling gap after
+         the row keeps any foreign child subtree clear of this pipeline's region. */
+      for (const plan of rowPlansByTip.get(col.file.path) ?? []) {
+        emitStageRow(plan, cx, childTop);
+        cx += plan.rowW + GROUP_SIBLING_GAP;
+      }
       for (let i = 0; i < children.length; i += 1) {
         const child = children[i]!;
         edges.push({
@@ -586,10 +742,11 @@ export function buildSchemeLayout(
     for (const deck of decks) bandBottom = Math.max(bandBottom, deck.y + deck.h);
     for (const stack of stacks) bandBottom = Math.max(bandBottom, stack.y + stack.h);
     for (const draft of drafts) bandBottom = Math.max(bandBottom, draft.y + draft.h);
+    for (const slot of slots) bandBottom = Math.max(bandBottom, slot.y + slot.h);
   }
   const restTop = hasFavorites ? bandBottom + FAV_BAND_GAP : PAD;
 
-  type PlacementMark = { nodes: number; edges: number; stacks: number; decks: number; loops: number; drafts: number };
+  type PlacementMark = { nodes: number; edges: number; stacks: number; decks: number; loops: number; drafts: number; slots: number };
   const markPlacement = (): PlacementMark => ({
     nodes: nodes.length,
     edges: edges.length,
@@ -597,6 +754,7 @@ export function buildSchemeLayout(
     decks: decks.length,
     loops: loops.length,
     drafts: drafts.length,
+    slots: slots.length,
   });
   const shiftPlacement = (mark: PlacementMark, dx: number, dy: number) => {
     for (const rect of nodes.slice(mark.nodes)) { rect.x += dx; rect.y += dy; }
@@ -605,6 +763,7 @@ export function buildSchemeLayout(
     for (const rect of decks.slice(mark.decks)) { rect.x += dx; rect.y += dy; }
     for (const loop of loops.slice(mark.loops)) { loop.x1 += dx; loop.x2 += dx; loop.y += dy; }
     for (const rect of drafts.slice(mark.drafts)) { rect.x += dx; rect.y += dy; }
+    for (const rect of slots.slice(mark.slots)) { rect.x += dx; rect.y += dy; }
   };
   const placementBottom = (mark: PlacementMark): number => {
     let value = 0;
@@ -612,6 +771,7 @@ export function buildSchemeLayout(
     for (const rect of stacks.slice(mark.stacks)) value = Math.max(value, rect.y + rect.h);
     for (const rect of decks.slice(mark.decks)) value = Math.max(value, rect.y + rect.h);
     for (const rect of drafts.slice(mark.drafts)) value = Math.max(value, rect.y + rect.h);
+    for (const rect of slots.slice(mark.slots)) value = Math.max(value, rect.y + rect.h);
     return value;
   };
 
@@ -653,138 +813,23 @@ export function buildSchemeLayout(
      ownership): the halo is the sole pipeline region, so every yet-to-launch
      stage sits beside the materialized conversations it hands off to — never a
      detached rail or a duplicate stage graph. A slot dissolves the instant its
-     stage materializes a live window (the solid card takes its position). */
-  const rectsIntersect = (a: SchemeRect, b: SchemeRect) =>
-    a.x < b.x + b.w && a.x + a.w > b.x && a.y < b.y + b.h && a.y + a.h > b.y;
-  const slots: StageSlot[] = [];
-  const slotKeysByPipeline = new Map<string, string[]>();
+     stage materializes a live window (the solid card takes its position).
+     Tip-anchored rows were reserved and emitted during tree placement (#531);
+     what remains here are the rows of pipelines with no placed member yet
+     (drafts, or every stage still unscanned). They dock in their own band BELOW
+     everything placed, one row beside the next, so a memberless region can never
+     sit on top of a laid-out card or another pipeline's region. */
   {
-    const nodeRectByPath = new Map<string, SchemeRect>(nodes.map((node) => [node.file.path, node]));
-    /* What this pass actually placed, so the placeholder predicate keys off real
-       board presence (a placed transcript node / a laid-out review deck) rather
-       than the stored agentPath/flowId. That retains the live stage's placeholder
-       continuously through the publish → scan → place gap and dissolves it exactly
-       when the node/deck lands — no zero-surface hole, no duplicate (#353 R4). */
-    const placedNodePaths = new Set(nodeRectByPath.keys());
-    const placedDeckFlowIds = new Set(decks.map((deck) => deck.flow.id));
-    /* Only THIS project's pipelines may grow memberless slot rows — the global
-       list serves cross-project stage membership, so without this fence a
-       foreign draft would drop its slots + halo on every project's canvas. A
-       global pipeline still gets slots once it has a placed member here. */
-    const surfaceIds = new Set(surfacePipelines.map((pipeline) => pipeline.id));
-    const seen = new Set<string>();
-    const pool = [...surfacePipelines, ...pipelines].filter((pipeline) => {
-      if (pipeline.state === "closed" || seen.has(pipeline.id)) return false;
-      seen.add(pipeline.id);
-      return true;
-    });
-    let slotDockY = restTop;
-    for (const pipeline of pool) {
-      /* Classify every declared stage into exactly one surface (#507 F2): a live
-         full pane (its transcript is a placed node), a completed full card (a
-         terminal stage of an active pipeline whose idle transcript is not a node),
-         or a placeholder (a future or still-forming pending/spawning stage). Every
-         current stage is a full-size card; only superseded retries fold out of the
-         scene via compactPipelineArtifactPaths. */
-      const placeholderIds = new Set(pipelinePlaceholderStages(pipeline, placedNodePaths, placedDeckFlowIds).map((stage) => stage.id));
-      /* Completed cards only grow on an active pipeline, and never for the cursor
-         stage itself: a cursor stage whose only transcript is quiet history
-         (folded into an under-deck) has no live pane and shelves (#343), rather
-         than resurfacing as a card. */
-      const growsHistory = PIPELINE_PLACEHOLDER_STATES.has(pipeline.state);
-      type SlotStage = { stage: PipelineStage; index: number; presentation: "placeholder" | "completed"; attempt?: PipelineStageAttempt };
-      const slotStages: SlotStage[] = [];
-      const memberPaths = new Set<string>();
-      /* The chain's tip: the LAST stage (in chain order) whose live pane is a
-         placed node. The slot row anchors as its child. */
-      let tip: SchemeRect | null = null;
-      for (let index = 0; index < pipeline.stages.length; index += 1) {
-        const stage = pipeline.stages[index]!;
-        const attempt = latestAttempt(pipeline, stage.id);
-        /* The stage's own live transcript — a run session or the live reviewer. */
-        const livePath = attempt?.agentPath ?? null;
-        const liveRect = livePath ? nodeRectByPath.get(livePath) : undefined;
-        if (liveRect && livePath) {
-          memberPaths.add(livePath);
-          tip = liveRect;
-          continue;
-        }
-        /* A folded review-loop resolves to its flow implementer node (deck laid
-           out): still a live pane, not a slot. */
-        const implPath = stage.kind === "review-loop" && attempt?.flowId ? implOfFlow(attempt.flowId) : null;
-        const implRect = implPath ? nodeRectByPath.get(implPath) : undefined;
-        if (implRect && implPath) {
-          memberPaths.add(implPath);
-          tip = implRect;
-          continue;
-        }
-        if (placeholderIds.has(stage.id)) {
-          slotStages.push({ stage, index, presentation: "placeholder" });
-          continue;
-        }
-        /* Any materialized attempt (the operational latest or a folded historical
-           one) on a NON-cursor stage is a completed stage whose idle transcript is
-           not a live node: it stands in as a full conversation card at its
-           position. */
-        if (!growsHistory || stage.id === pipeline.cursor?.stageId) continue;
-        const materialized = stageAttempts(pipeline, stage.id).findLast((candidate) => candidate.agentPath || candidate.flowId);
-        if (materialized) {
-          slotStages.push({ stage, index, presentation: "completed", attempt: materialized });
-        }
-      }
-      if (!surfaceIds.has(pipeline.id) && !memberPaths.size) continue;
-      if (!slotStages.length) continue;
-      const rowW = slotStages.length * SLOT_W + (slotStages.length - 1) * SLOT_GAP;
-      let sx: number;
-      let sy: number;
-      if (tip) {
-        /* The tree indents a child one INDENT right of its parent and one
-           generation (GAP_Y) below — anchoring the first slot exactly there makes
-           the hand-off positionally exact: the live window the tree places for the
-           next stage lands on the placeholder's own coordinates. */
-        sx = tip.x + INDENT;
-        sy = tip.y + tip.h + GAP_Y;
-        /* Step below any unrelated card the row would cover — bounded, so a
-           pathological board can never loop forever. */
-        const row = (): SchemeRect => ({ x: sx, y: sy, w: rowW, h: SLOT_H });
-        const blocked = () =>
-          nodes.some((node) => !memberPaths.has(node.file.path) && rectsIntersect(node, row())) ||
-          stacks.some((stack) => rectsIntersect(stack, row())) ||
-          decks.some((deck) => rectsIntersect(deck, row()));
-        for (let guard = 0; guard < 40 && blocked(); guard += 1) sy += SLOT_H / 2;
-      } else {
-        sx = cursor;
-        sy = slotDockY;
-        slotDockY += SLOT_H + GROUP_GAP;
-        cursor += rowW + GROUP_GAP;
-      }
-      const keys: string[] = [];
-      slotStages.forEach((entry, i) => {
-        const { stage, index, presentation, attempt } = entry;
-        const previous = i > 0 ? slotStages[i - 1]! : null;
-        /* The handoff badge renders only between chain-adjacent slots — a gap (a
-           live pane between them) breaks the visual chain. */
-        const adjacent = previous !== null && pipeline.stages[index - 1]?.id === previous.stage.id;
-        const slot: StageSlot = {
-          key: stageSlotKey(pipeline.id, stage.id),
-          pipeline,
-          stage,
-          index,
-          total: pipeline.stages.length,
-          presentation,
-          ...(attempt ? { attempt } : {}),
-          ...(adjacent ? { incoming: stage.kind } : {}),
-          x: sx + i * (SLOT_W + SLOT_GAP),
-          y: sy,
-          w: SLOT_W,
-          /* Every slot is a full-size card now — completed and placeholder alike
-             share the live conversation's footprint (#507 F2). */
-          h: SLOT_H,
-        };
-        slots.push(slot);
-        keys.push(slot.key);
-      });
-      slotKeysByPipeline.set(pipeline.id, keys);
+    let contentBottom = 0;
+    for (const rect of [...nodes, ...stacks, ...decks, ...drafts, ...slots]) {
+      contentBottom = Math.max(contentBottom, rect.y + rect.h);
+    }
+    let dockX = PAD;
+    const dockY = contentBottom > 0 ? contentBottom + GROUP_GAP : restTop;
+    for (const plan of stageRowPlans) {
+      if (plan.placed) continue;
+      emitStageRow(plan, dockX, dockY);
+      dockX += plan.rowW + GROUP_GAP;
     }
   }
 
@@ -819,16 +864,47 @@ export function buildSchemeLayout(
      spawned stage subtree reads as part of the same region. Expansion is limited
      to pipeline stage roots on purpose: a standalone flow's halo stays the
      implementer + reviewer deck, so an unrelated agent spawned below the
-     implementer never stretches the flow region across the board. */
+     implementer never stretches the flow region across the board.
+     Two #531 containment/separation rules govern the walk:
+     — every surface ATTACHED to a member pane (its review deck — managed or
+       direct one-shot, its quiet-history stack, its handoff drafts) joins the
+       region, so no conversation surface of the pipeline pokes out of the halo;
+     — a descendant OWNED by a different flow/pipeline is never absorbed (nor is
+       its subtree), so one colored region can never swallow another's cards and
+       force the two dashed outlines to intersect. */
   const placedNodePaths = new Set(nodes.map((node) => node.file.path));
-  const expandMembers = (members: string[]): string[] => {
+  const deckKeyByImplementer = new Map(decks.map((deck) => [deck.flow.implementerPath, deck.key] as const));
+  const attachmentKeysOf = (path: string): string[] => {
+    const keys: string[] = [];
+    const deckAt = deckKeyByImplementer.get(path);
+    if (deckAt) keys.push(deckAt);
+    if (byPath.has(path + "::stack")) keys.push(path + "::stack");
+    for (const id of draftsBySrc.get(path) ?? []) {
+      if (byPath.has("draft::" + id)) keys.push("draft::" + id);
+    }
+    return keys;
+  };
+  const expandMembers = (members: string[], ownKey: string): string[] => {
     const out = new Set(members);
+    const visited = new Set<string>();
+    const walk = (path: string) => {
+      if (visited.has(path)) return;
+      visited.add(path);
+      for (const child of kids.get(path) ?? []) {
+        const owner = groupKeyOfPath.get(child.path);
+        if (owner && owner !== ownKey) continue;
+        if (placedNodePaths.has(child.path)) {
+          out.add(child.path);
+          for (const key of attachmentKeysOf(child.path)) out.add(key);
+        }
+        walk(child.path);
+      }
+    };
     for (const key of members) {
       const file = byAll.get(key);
-      if (!file) continue; // deck/stack/draft keys aren't transcript files
-      for (const row of descendantsOf(file, files)) {
-        if (placedNodePaths.has(row.file.path)) out.add(row.file.path);
-      }
+      if (!file) continue; // deck/stack/draft/slot keys aren't transcript files
+      for (const attachment of attachmentKeysOf(key)) out.add(attachment);
+      walk(key);
     }
     return [...out];
   };
@@ -866,7 +942,7 @@ export function buildSchemeLayout(
   }
   const groupHalos: SchemeGroup[] = [];
   for (const spec of specs) {
-    const members = spec.kind === "pipeline" ? expandMembers(spec.members) : spec.members;
+    const members = spec.kind === "pipeline" ? expandMembers(spec.members, "pipe:" + spec.id) : spec.members;
     const rect = groupRect(members, (key) => byPath.get(key) ?? null, GROUP_PAD);
     if (!rect) continue;
     /* Lift the top edge to enclose the hovering compact header; bottom stays put,

--- a/src/components/scheme/layout.ts
+++ b/src/components/scheme/layout.ts
@@ -1,5 +1,6 @@
 import type { Flow } from "@/lib/flows/types";
 import type { Pipeline, PipelineStage, PipelineStageAttempt } from "@/lib/pipelines/types";
+import type { BoardTask } from "@/lib/tasks/types";
 import type { FileEntry } from "@/lib/types";
 
 import type { DeckRound } from "@/components/flows/RoundDeck";
@@ -20,6 +21,8 @@ import {
   type SchemeGroupSpec,
 } from "./agentLinks";
 import { PIPELINE_PLACEHOLDER_STATES, latestAttempt, pipelinePlaceholderStages, stageAttempts } from "@/components/pipelines/pipelineModel";
+import { linkedPipelineTasks } from "./pipelineAnchor";
+import { TASK_W, isPlacedTask, taskBoxHeight } from "./taskGeometry";
 import { type BranchGroup, descendantsOf, isChildConversation, kidsIndex, projectDescendantsOf } from "@/components/projectModel";
 import { cleanTitle, engineColor } from "@/components/utils";
 import { conversationIdentity } from "@/lib/accounts/identity";
@@ -185,6 +188,17 @@ export interface StageSlot extends SchemeRect {
   incoming?: "run" | "review-loop";
 }
 
+/** A board task card owned by a pipeline region (#531): the layout places it
+    inside the pipeline's colored halo (after the stage chain), overriding the
+    sticky note's lattice position so the pipeline's work item can never sit
+    detached from — or inside a neighbor of — the region it belongs to. */
+export interface RegionTask extends SchemeRect {
+  /** Board key, `task::<id>` — the same key the camera/minimap already use. */
+  key: string;
+  taskId: string;
+  pipelineId: string;
+}
+
 /** Implement↔review pair on the scheme: the corridor the cycle arcs live in. */
 export interface FlowLoop {
   key: string;
@@ -212,6 +226,8 @@ export interface SchemeLayout {
   drafts: DraftNode[];
   /** Dashed placeholder windows for planned pipeline stages (issue #196). */
   slots: StageSlot[];
+  /** Task cards placed inside their pipeline regions (#531). */
+  regionTasks: RegionTask[];
   byPath: Map<string, SchemeRect>;
   width: number;
   height: number;
@@ -258,6 +274,12 @@ export function buildSchemeLayout(
   /** Explicit compact-history inspections render as one pane. Their descendant
       chain remains represented by the pipeline evidence rail. */
   isolatedManualPaths: ReadonlySet<string> = new Set(),
+  /** Board task cards; the ones linked to a surfaced pipeline are placed inside
+      that pipeline's region (#531) and returned as `regionTasks`. */
+  tasks: readonly BoardTask[] = [],
+  /** Session-only expanded-text task ids — an expanded card grows taller, and
+      the region reserves that footprint so containment holds live. */
+  taskTextExpanded: ReadonlySet<string> = new Set(),
 ): SchemeLayout {
   const byAll = new Map(files.map((file) => [file.path, file]));
   const kids = kidsIndex(files);
@@ -336,17 +358,34 @@ export function buildSchemeLayout(
     return false;
   };
 
-  /* ── Pipeline stage rows, classified BEFORE placement (#531) ─────────────────
+  /* ── Pipeline stage chains, classified BEFORE placement (#531) ───────────────
      Every declared stage resolves to exactly one surface (#507 F2): a live full
      pane (its transcript will be a placed node), a completed full card, or a
      placeholder. What the pass will place is fully knowable up front — nodes are
      exactly the branch-group columns plus the manual roots, and a deck lays out
-     exactly when its flow's implementer is such a node — so each pipeline's slot
-     row is planned here and RESERVED inside the tree layout as a child block of
-     its tip. Reserving the row's footprint during placement (instead of dropping
-     it onto the finished board and nudging it around collisions) is what keeps
-     two neighboring pipeline regions from ever intersecting: sibling subtree
-     widths include the rows, so the existing group-boundary gaps apply. */
+     exactly when its flow's implementer is such a node — so each pipeline's
+     stage chain is planned here and RESERVED inside the tree layout. Reserving
+     the chain's footprint during placement (instead of dropping it onto the
+     finished board and nudging it around collisions) is what keeps two
+     neighboring pipeline regions from ever intersecting: sibling subtree widths
+     include the chains, so the existing group-boundary gaps apply.
+
+     Anchoring (#531 round 1 — stable per-stage positions from lineage): stage
+     transcripts materialize as children of the pipeline's lineage host — the
+     conversation the pipeline was launched from (srcPath), which is also the
+     tree parent of every already-placed stage. When that host is a placed node,
+     the WHOLE chain lives in the host's child band at stage-indexed pitch
+     (SLOT_W + SLOT_GAP): stage i's surface — placeholder, completed card, or
+     the live pane the tree places for it — owns the anchor
+     `chainStart + i·pitch` from the very first unscanned render, so a
+     materializing stage lands exactly on its placeholder's coordinates and no
+     neighbor stage's surface moves (unscanned → materialized → host-loss keep
+     identical world anchors), and history reads chronologically left→right:
+     completed → live → future. A wide stage subtree (a spawned agent tree or a
+     folded review deck beside the pane) pushes later anchors right rather than
+     ever overlapping. Without a placed host the chain keeps the round-1
+     behavior: a row reserved under the chain's tip, or a docked row below all
+     content when nothing of the pipeline is placed yet. */
   const prePlacedNodePaths = new Set<string>([
     ...groups.flatMap((group) => group.columns.map((column) => column.file.path)),
     ...manual.map((file) => file.path),
@@ -356,14 +395,20 @@ export function buildSchemeLayout(
     if (prePlacedNodePaths.has(candidate.implementerPath)) prePlacedDeckFlowIds.add(candidate.id);
   }
   type SlotStage = { stage: PipelineStage; index: number; presentation: "placeholder" | "completed"; attempt?: PipelineStageAttempt };
-  interface StageRowPlan {
+  type ChainEntry =
+    | { kind: "node"; index: number; path: string }
+    | { kind: "slot"; index: number; slotStage: SlotStage };
+  interface StageChainPlan {
     pipeline: Pipeline;
-    slotStages: SlotStage[];
-    rowW: number;
+    /** Stage surfaces in stage order: placed child nodes of the host + slots. */
+    entries: ChainEntry[];
+    /** Linked board tasks (#531): placed after the chain, inside the region. */
+    tasks: Array<{ task: BoardTask; h: number }>;
     placed: boolean;
   }
-  const rowPlansByTip = new Map<string, StageRowPlan[]>();
-  const stageRowPlans: StageRowPlan[] = [];
+  const chainPlansByHost = new Map<string, StageChainPlan[]>();
+  const rowPlansByTip = new Map<string, StageChainPlan[]>();
+  const stageChainPlans: StageChainPlan[] = [];
   {
     /* Only THIS project's pipelines may grow memberless slot rows — the global
        list serves cross-project stage membership, so without this fence a
@@ -376,6 +421,8 @@ export function buildSchemeLayout(
       seen.add(pipeline.id);
       return true;
     });
+    /* Each placed task card belongs to at most one pipeline region. */
+    const claimedTaskIds = new Set<string>();
     for (const pipeline of pool) {
       const placeholderIds = new Set(pipelinePlaceholderStages(pipeline, prePlacedNodePaths, prePlacedDeckFlowIds).map((stage) => stage.id));
       /* Completed cards only grow on an active pipeline, and never for the cursor
@@ -383,10 +430,10 @@ export function buildSchemeLayout(
          (folded into an under-deck) has no live pane and shelves (#343), rather
          than resurfacing as a card. */
       const growsHistory = PIPELINE_PLACEHOLDER_STATES.has(pipeline.state);
-      const slotStages: SlotStage[] = [];
+      const stageEntries: ChainEntry[] = [];
       const memberPaths = new Set<string>();
       /* The chain's tip: the LAST stage (in chain order) whose live pane will be
-         a placed node. The slot row anchors as its first child block. */
+         a placed node. */
       let tipPath: string | null = null;
       for (let index = 0; index < pipeline.stages.length; index += 1) {
         const stage = pipeline.stages[index]!;
@@ -396,6 +443,7 @@ export function buildSchemeLayout(
         if (livePath && prePlacedNodePaths.has(livePath)) {
           memberPaths.add(livePath);
           tipPath = livePath;
+          stageEntries.push({ kind: "node", index, path: livePath });
           continue;
         }
         /* A folded review-loop resolves to its flow implementer node (deck laid
@@ -404,10 +452,11 @@ export function buildSchemeLayout(
         if (implPath && prePlacedNodePaths.has(implPath)) {
           memberPaths.add(implPath);
           tipPath = implPath;
+          stageEntries.push({ kind: "node", index, path: implPath });
           continue;
         }
         if (placeholderIds.has(stage.id)) {
-          slotStages.push({ stage, index, presentation: "placeholder" });
+          stageEntries.push({ kind: "slot", index, slotStage: { stage, index, presentation: "placeholder" } });
           continue;
         }
         /* Any materialized attempt (the operational latest or a folded historical
@@ -417,15 +466,33 @@ export function buildSchemeLayout(
         if (!growsHistory || stage.id === pipeline.cursor?.stageId) continue;
         const materialized = stageAttempts(pipeline, stage.id).findLast((candidate) => candidate.agentPath || candidate.flowId);
         if (materialized) {
-          slotStages.push({ stage, index, presentation: "completed", attempt: materialized });
+          stageEntries.push({ kind: "slot", index, slotStage: { stage, index, presentation: "completed", attempt: materialized } });
         }
       }
       if (!surfaceIds.has(pipeline.id) && !memberPaths.size) continue;
-      if (!slotStages.length) continue;
-      const rowW = slotStages.length * SLOT_W + (slotStages.length - 1) * SLOT_GAP;
-      const plan: StageRowPlan = { pipeline, slotStages, rowW, placed: false };
-      stageRowPlans.push(plan);
-      if (tipPath) {
+      const slotCount = stageEntries.filter((entry) => entry.kind === "slot").length;
+      const linkedTasks = linkedPipelineTasks(pipeline, tasks)
+        .filter((task) => isPlacedTask(task) && !claimedTaskIds.has(task.id))
+        .map((task) => ({ task, h: taskBoxHeight(task, taskTextExpanded.has(task.id)) }));
+      if (!slotCount && !linkedTasks.length) continue;
+      for (const { task } of linkedTasks) claimedTaskIds.add(task.id);
+      const plan: StageChainPlan = { pipeline, entries: stageEntries, tasks: linkedTasks, placed: false };
+      stageChainPlans.push(plan);
+      /* The lineage host: the placed conversation the stage transcripts hang
+         under — the tip's tree parent once anything is placed, else the src
+         conversation the pipeline was launched from. */
+      const tipParent = tipPath ? byAll.get(tipPath)?.parent ?? null : null;
+      const hostPath =
+        tipPath && tipParent && prePlacedNodePaths.has(tipParent)
+          ? tipParent
+          : !tipPath && pipeline.srcPath && prePlacedNodePaths.has(pipeline.srcPath)
+            ? pipeline.srcPath
+            : null;
+      if (hostPath) {
+        const list = chainPlansByHost.get(hostPath);
+        if (list) list.push(plan);
+        else chainPlansByHost.set(hostPath, [plan]);
+      } else if (tipPath) {
         const list = rowPlansByTip.get(tipPath);
         if (list) list.push(plan);
         else rowPlansByTip.set(tipPath, [plan]);
@@ -433,36 +500,61 @@ export function buildSchemeLayout(
     }
   }
   const slots: StageSlot[] = [];
-  const slotKeysByPipeline = new Map<string, string[]>();
-  const emitStageRow = (plan: StageRowPlan, sx: number, sy: number) => {
+  const regionTasks: RegionTask[] = [];
+  const regionKeysByPipeline = new Map<string, string[]>();
+  const regionKeys = (pipelineId: string): string[] => {
+    const list = regionKeysByPipeline.get(pipelineId);
+    if (list) return list;
+    const fresh: string[] = [];
+    regionKeysByPipeline.set(pipelineId, fresh);
+    return fresh;
+  };
+  const emitSlot = (plan: StageChainPlan, slotStage: SlotStage, x: number, y: number, previous: SlotStage | null) => {
+    const { stage, index, presentation, attempt } = slotStage;
+    /* The handoff badge renders only between chain-adjacent slots — a gap (a
+       live pane between them) breaks the visual chain. */
+    const adjacent = previous !== null && plan.pipeline.stages[index - 1]?.id === previous.stage.id;
+    const slot: StageSlot = {
+      key: stageSlotKey(plan.pipeline.id, stage.id),
+      pipeline: plan.pipeline,
+      stage,
+      index,
+      total: plan.pipeline.stages.length,
+      presentation,
+      ...(attempt ? { attempt } : {}),
+      ...(adjacent ? { incoming: stage.kind } : {}),
+      x,
+      y,
+      w: SLOT_W,
+      /* Every slot is a full-size card — completed and placeholder alike share
+         the live conversation's footprint (#507 F2). */
+      h: SLOT_H,
+    };
+    slots.push(slot);
+    regionKeys(plan.pipeline.id).push(slot.key);
+  };
+  const emitRegionTask = (plan: StageChainPlan, task: BoardTask, h: number, x: number, y: number) => {
+    const rect: RegionTask = { key: "task::" + task.id, taskId: task.id, pipelineId: plan.pipeline.id, x, y, w: TASK_W, h };
+    regionTasks.push(rect);
+    regionKeys(plan.pipeline.id).push(rect.key);
+  };
+  /* A tip-anchored or docked plan: slots in a compact row, tasks trailing. */
+  const emitCompactRow = (plan: StageChainPlan, sx: number, sy: number) => {
     plan.placed = true;
-    const keys = slotKeysByPipeline.get(plan.pipeline.id) ?? [];
-    plan.slotStages.forEach((entry, i) => {
-      const { stage, index, presentation, attempt } = entry;
-      const previous = i > 0 ? plan.slotStages[i - 1]! : null;
-      /* The handoff badge renders only between chain-adjacent slots — a gap (a
-         live pane between them) breaks the visual chain. */
-      const adjacent = previous !== null && plan.pipeline.stages[index - 1]?.id === previous.stage.id;
-      const slot: StageSlot = {
-        key: stageSlotKey(plan.pipeline.id, stage.id),
-        pipeline: plan.pipeline,
-        stage,
-        index,
-        total: plan.pipeline.stages.length,
-        presentation,
-        ...(attempt ? { attempt } : {}),
-        ...(adjacent ? { incoming: stage.kind } : {}),
-        x: sx + i * (SLOT_W + SLOT_GAP),
-        y: sy,
-        w: SLOT_W,
-        /* Every slot is a full-size card — completed and placeholder alike share
-           the live conversation's footprint (#507 F2). */
-        h: SLOT_H,
-      };
-      slots.push(slot);
-      keys.push(slot.key);
-    });
-    slotKeysByPipeline.set(plan.pipeline.id, keys);
+    let x = sx;
+    let previous: SlotStage | null = null;
+    for (const entry of plan.entries) {
+      if (entry.kind !== "slot") continue;
+      emitSlot(plan, entry.slotStage, x, sy, previous);
+      previous = entry.slotStage;
+      x += SLOT_W + SLOT_GAP;
+    }
+    for (const { task, h } of plan.tasks) {
+      emitRegionTask(plan, task, h, x, sy);
+      x += TASK_W + SLOT_GAP;
+    }
+    /* Right edge of the emitted block (the trailing gap excluded). */
+    return x - SLOT_GAP;
   };
 
   /* Handoff drafts hang under their source pane like a child; drafts whose
@@ -542,35 +634,78 @@ export function buildSchemeLayout(
         });
       const childTop = y + rowH + (boundaryChild ? GROUP_CHILD_GAP : GAP_Y);
       let cx = x + INDENT;
-      /* This pane is a pipeline chain's tip: its planned/completed stage row
-         takes the first child block, RESERVING its footprint inside the subtree
-         width. Anchoring at x + INDENT keeps the hand-off positionally exact —
-         the live window the tree later places for the next stage lands on the
-         placeholder's own coordinates (#196) — and the group-sibling gap after
-         the row keeps any foreign child subtree clear of this pipeline's region. */
-      for (const plan of rowPlansByTip.get(col.file.path) ?? []) {
-        emitStageRow(plan, cx, childTop);
-        cx += plan.rowW + GROUP_SIBLING_GAP;
-      }
-      for (let i = 0; i < children.length; i += 1) {
-        const child = children[i]!;
+      const placeChild = (child: { file: FileEntry; tasks: FileEntry[] }, atX: number): number => {
         edges.push({
           to: child.file.path,
           sourceConversationId: conversationIdentity(col.file),
           targetConversationId: conversationIdentity(child.file),
           x1: x + 40,
           y1: y + h,
-          x2: cx + NODE_W / 2,
+          x2: atX + NODE_W / 2,
           y2: childTop,
           color: engineColor(child.file),
           live: child.file.activity === "live",
         });
+        return place(child, atX, childTop, depth + 1);
+      };
+      /* This pane is a pipeline chain's LINEAGE HOST: the whole stage chain —
+         placed stage children, placeholder/completed slots, and the linked task
+         cards — lays out in this child band at stage-indexed pitch, RESERVING
+         its footprint inside the subtree width. Anchoring stage i at
+         `chainStart + i·pitch` keeps every stage's world anchor identical from
+         the first unscanned render through materialization and host loss
+         (#531 round 1), keeps the hand-off positionally exact (#196: the live
+         window the tree places for a stage lands on its placeholder's own
+         coordinates), and reads chronologically completed → live → future. A
+         stage subtree wider than one card (a spawned agent tree, a folded review
+         deck) pushes the later anchors right instead of overlapping. The
+         group-sibling gap after each chain keeps any foreign child subtree —
+         and the next pipeline's chain — clear of this region. */
+      const chainPlans = chainPlansByHost.get(col.file.path) ?? [];
+      const chainChildPaths = new Set<string>();
+      for (const plan of chainPlans) {
+        for (const entry of plan.entries) if (entry.kind === "node") chainChildPaths.add(entry.path);
+      }
+      const childByPath = new Map(children.map((child) => [child.file.path, child] as const));
+      for (const plan of chainPlans) {
+        plan.placed = true;
+        const baseIndex = plan.entries[0]?.index ?? 0;
+        const chainX0 = cx;
+        let localCx = cx;
+        let previous: SlotStage | null = null;
+        for (const entry of plan.entries) {
+          const ex = Math.max(chainX0 + (entry.index - baseIndex) * (SLOT_W + SLOT_GAP), localCx);
+          if (entry.kind === "slot") {
+            emitSlot(plan, entry.slotStage, ex, childTop, previous);
+            previous = entry.slotStage;
+            localCx = ex + SLOT_W + SLOT_GAP;
+          } else {
+            const child = childByPath.get(entry.path);
+            if (!child) continue;
+            const width = placeChild(child, ex);
+            localCx = ex + Math.max(width, SLOT_W) + SLOT_GAP;
+          }
+        }
+        for (const { task, h: taskH } of plan.tasks) {
+          emitRegionTask(plan, task, taskH, localCx, childTop);
+          localCx += TASK_W + SLOT_GAP;
+        }
+        cx = localCx - SLOT_GAP + GROUP_SIBLING_GAP;
+      }
+      /* This pane is a chain's tip WITHOUT a placed lineage host: the remaining
+         stage row reserves the first child block below, exactly like round 1. */
+      for (const plan of rowPlansByTip.get(col.file.path) ?? []) {
+        cx = emitCompactRow(plan, cx, childTop) + GROUP_SIBLING_GAP;
+      }
+      const looseChildren = children.filter((child) => !chainChildPaths.has(child.file.path));
+      for (let i = 0; i < looseChildren.length; i += 1) {
+        const child = looseChildren[i]!;
         /* Widen the gap only at a flow/pipeline group boundary so two sibling
            halos never overlap (issue #136); the last slot keeps GAP_X, which the
            `used` width below subtracts back off. */
-        const nextChild = children[i + 1];
+        const nextChild = looseChildren[i + 1];
         const gap = nextChild && isGroupBoundary(child.file, nextChild.file) ? GROUP_SIBLING_GAP : GAP_X;
-        cx += place(child, cx, childTop, depth + 1) + gap;
+        cx += placeChild(child, cx) + gap;
       }
       const quiet = stackFor.get(col.file.path)?.filter((entry) => !claimed.has(entry.path));
       if (quiet?.length) {
@@ -743,10 +878,11 @@ export function buildSchemeLayout(
     for (const stack of stacks) bandBottom = Math.max(bandBottom, stack.y + stack.h);
     for (const draft of drafts) bandBottom = Math.max(bandBottom, draft.y + draft.h);
     for (const slot of slots) bandBottom = Math.max(bandBottom, slot.y + slot.h);
+    for (const rect of regionTasks) bandBottom = Math.max(bandBottom, rect.y + rect.h);
   }
   const restTop = hasFavorites ? bandBottom + FAV_BAND_GAP : PAD;
 
-  type PlacementMark = { nodes: number; edges: number; stacks: number; decks: number; loops: number; drafts: number; slots: number };
+  type PlacementMark = { nodes: number; edges: number; stacks: number; decks: number; loops: number; drafts: number; slots: number; regionTasks: number };
   const markPlacement = (): PlacementMark => ({
     nodes: nodes.length,
     edges: edges.length,
@@ -755,6 +891,7 @@ export function buildSchemeLayout(
     loops: loops.length,
     drafts: drafts.length,
     slots: slots.length,
+    regionTasks: regionTasks.length,
   });
   const shiftPlacement = (mark: PlacementMark, dx: number, dy: number) => {
     for (const rect of nodes.slice(mark.nodes)) { rect.x += dx; rect.y += dy; }
@@ -764,6 +901,7 @@ export function buildSchemeLayout(
     for (const loop of loops.slice(mark.loops)) { loop.x1 += dx; loop.x2 += dx; loop.y += dy; }
     for (const rect of drafts.slice(mark.drafts)) { rect.x += dx; rect.y += dy; }
     for (const rect of slots.slice(mark.slots)) { rect.x += dx; rect.y += dy; }
+    for (const rect of regionTasks.slice(mark.regionTasks)) { rect.x += dx; rect.y += dy; }
   };
   const placementBottom = (mark: PlacementMark): number => {
     let value = 0;
@@ -772,6 +910,7 @@ export function buildSchemeLayout(
     for (const rect of decks.slice(mark.decks)) value = Math.max(value, rect.y + rect.h);
     for (const rect of drafts.slice(mark.drafts)) value = Math.max(value, rect.y + rect.h);
     for (const rect of slots.slice(mark.slots)) value = Math.max(value, rect.y + rect.h);
+    for (const rect of regionTasks.slice(mark.regionTasks)) value = Math.max(value, rect.y + rect.h);
     return value;
   };
 
@@ -821,15 +960,14 @@ export function buildSchemeLayout(
      sit on top of a laid-out card or another pipeline's region. */
   {
     let contentBottom = 0;
-    for (const rect of [...nodes, ...stacks, ...decks, ...drafts, ...slots]) {
+    for (const rect of [...nodes, ...stacks, ...decks, ...drafts, ...slots, ...regionTasks]) {
       contentBottom = Math.max(contentBottom, rect.y + rect.h);
     }
     let dockX = PAD;
     const dockY = contentBottom > 0 ? contentBottom + GROUP_GAP : restTop;
-    for (const plan of stageRowPlans) {
+    for (const plan of stageChainPlans) {
       if (plan.placed) continue;
-      emitStageRow(plan, dockX, dockY);
-      dockX += plan.rowW + GROUP_GAP;
+      dockX = emitCompactRow(plan, dockX, dockY) + GROUP_GAP;
     }
   }
 
@@ -840,6 +978,7 @@ export function buildSchemeLayout(
   for (const deck of decks) { bottom = Math.max(bottom, deck.y + deck.h); right = Math.max(right, deck.x + deck.w); }
   for (const draft of drafts) { bottom = Math.max(bottom, draft.y + draft.h); right = Math.max(right, draft.x + draft.w); }
   for (const slot of slots) { bottom = Math.max(bottom, slot.y + slot.h); right = Math.max(right, slot.x + slot.w); }
+  for (const rect of regionTasks) { bottom = Math.max(bottom, rect.y + rect.h); right = Math.max(right, rect.x + rect.w); }
   /* Links resolve against what this pass actually placed, so geometry and
      link endpoints can never disagree. */
   const anchors = buildAnchorIndex(
@@ -857,6 +996,7 @@ export function buildSchemeLayout(
     ...stacks.map((stack) => [stack.key, stack] as const),
     ...decks.map((deck) => [deck.key, deck] as const),
     ...slots.map((slot) => [slot.key, slot] as const),
+    ...regionTasks.map((rect) => [rect.key, rect] as const),
   ]);
   const flowImplementerPath = (flowId: string) => flows.find((flow) => flow.id === flowId)?.implementerPath ?? null;
 
@@ -921,7 +1061,7 @@ export function buildSchemeLayout(
   const pipelineSpecById = new Map(specs.filter((spec) => spec.pipeline).map((spec) => [spec.pipeline!.id, spec] as const));
   const pipelineById = new Map<string, Pipeline>();
   for (const pipeline of [...surfacePipelines, ...pipelines]) if (!pipelineById.has(pipeline.id)) pipelineById.set(pipeline.id, pipeline);
-  for (const [pipelineId, keys] of slotKeysByPipeline) {
+  for (const [pipelineId, keys] of regionKeysByPipeline) {
     const existing = pipelineSpecById.get(pipelineId);
     if (existing) {
       existing.members = [...existing.members, ...keys];
@@ -964,6 +1104,7 @@ export function buildSchemeLayout(
     ],
     drafts,
     slots,
+    regionTasks,
     byPath,
     width: Math.max(
       right + PAD,

--- a/src/components/scheme/nodes.dom.test.tsx
+++ b/src/components/scheme/nodes.dom.test.tsx
@@ -176,6 +176,7 @@ function layout(parts: Partial<SchemeLayout> = {}): SchemeLayout {
     links: [],
     drafts: [],
     slots: [],
+    regionTasks: [],
     byPath: new Map(),
     width: 2000,
     height: 1000,

--- a/src/components/scheme/nodes.strip.dom.test.tsx
+++ b/src/components/scheme/nodes.strip.dom.test.tsx
@@ -87,7 +87,7 @@ function node(entry: FileEntry, x: number): SchemeNode {
 
 function layout(nodes: SchemeNode[]): SchemeLayout {
   return {
-    nodes, edges: [], stacks: [], decks: [], loops: [], groups: [], links: [], drafts: [], slots: [],
+    nodes, edges: [], stacks: [], decks: [], loops: [], groups: [], links: [], drafts: [], slots: [], regionTasks: [],
     byPath: new Map(), width: 2000, height: 1000,
   };
 }

--- a/src/components/scheme/pipelineAnchor.ts
+++ b/src/components/scheme/pipelineAnchor.ts
@@ -64,6 +64,30 @@ function pipelineLineage(pipeline: Pipeline): { paths: Set<string>; conversation
   return { paths, conversationIds };
 }
 
+/**
+ * Every board task linked to a pipeline (#531): the explicit `taskIds` links
+ * first, then tasks whose source or assignments point into the pipeline's
+ * lineage (src conversation or any stage attempt). One shared definition, so
+ * the region layout and the legacy anchor heuristic can never disagree about
+ * which sticky notes belong to a pipeline.
+ */
+export function linkedPipelineTasks(pipeline: Pipeline, tasks: readonly BoardTask[]): BoardTask[] {
+  const explicit = new Set((pipeline as PipelineWithTaskIds).taskIds ?? []);
+  const lineage = pipelineLineage(pipeline);
+  return tasks.filter((task) =>
+    explicit.has(task.id) ||
+    Boolean(
+      (task.source && lineage.paths.has(task.source.path)) ||
+      task.assignments.some((assignment) =>
+        Boolean(
+          (assignment.path && lineage.paths.has(assignment.path)) ||
+          (assignment.conversationId && lineage.conversationIds.has(assignment.conversationId)),
+        ),
+      ),
+    ),
+  );
+}
+
 function manuallyLinkedTask(pipeline: Pipeline, tasks: readonly BoardTask[]): BoardTask | null {
   const lineage = pipelineLineage(pipeline);
   return tasks.find((task) =>

--- a/src/components/scheme/pipelineRegionGeometry.test.ts
+++ b/src/components/scheme/pipelineRegionGeometry.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 
 import type { Flow } from "@/lib/flows/types";
 import type { Pipeline } from "@/lib/pipelines/types";
+import type { BoardTask } from "@/lib/tasks/types";
 import type { FileEntry } from "@/lib/types";
 
 import { directReviewFlows } from "@/components/flows/directReviewGroups";
@@ -270,6 +271,141 @@ describe("neighboring pipeline regions never intersect (#531)", () => {
   });
 });
 
+describe("stage surfaces keep stable lineage anchors (#531 round 1)", () => {
+  /* The pipeline was launched from /origin (srcPath lineage). Stage transcripts
+     materialize as children of that conversation, in stage order. The stage
+     chain must therefore anchor at the SAME world coordinates from the very
+     first unscanned render: a stage's placeholder and the live pane that later
+     replaces it share one anchor, and no other stage's surface moves when a
+     neighbor materializes. */
+  const anchorOfSurface = (layout: SchemeLayout, pipelineId: string, stageId: string, nodePath: string): { x: number; y: number } => {
+    const node = layout.nodes.find((candidate) => candidate.file.path === nodePath);
+    if (node) return { x: node.x, y: node.y };
+    const slot = layout.slots.find((candidate) => candidate.pipeline.id === pipelineId && candidate.stage.id === stageId);
+    expect(slot, `stage ${stageId} must own a surface`).toBeTruthy();
+    return { x: slot!.x, y: slot!.y };
+  };
+
+  test("anchors are identical across unscanned → materialized → host-loss", () => {
+    const origin = entry({ path: "/origin", activity: "live" });
+    const buildFile = entry({ path: "/origin/build", parent: "/origin", kind: "subagent", activity: "live" });
+    const stages = [
+      { id: "build", kind: "run", prompt: "", next: "review" },
+      { id: "review", kind: "review-loop", prompt: "", next: null },
+    ];
+    const pipeline = () => pipe({
+      srcPath: "/origin",
+      stages,
+      cursor: { stageId: "build", state: "running", input: null, activatedBy: null },
+      runs: [{ stageId: "build", attempts: [{ n: 1, state: "running", agentPath: "/origin/build", flowId: null }] }],
+    });
+    const layoutOf = (files: FileEntry[]) => {
+      const p = pipeline();
+      return buildSchemeLayout(buildBranchGroups(files, "demo"), [], files, [], [], [p], [p]);
+    };
+
+    /* A: publish-to-scan gap (also the host-loss-before-scan shape): /origin/build
+       is published but not yet a scene file. */
+    const unscanned = layoutOf([origin]);
+    /* B: the build transcript materialized as a child of the src conversation. */
+    const materialized = layoutOf([origin, buildFile]);
+    /* C: host loss after materialization: the transcript file survives idle. */
+    const hostLost = layoutOf([origin, { ...buildFile, activity: "idle" as const }]);
+
+    const buildA = anchorOfSurface(unscanned, "p1", "build", "/origin/build");
+    const buildB = anchorOfSurface(materialized, "p1", "build", "/origin/build");
+    const buildC = anchorOfSurface(hostLost, "p1", "build", "/origin/build");
+    expect(materialized.nodes.map((node) => node.file.path)).toContain("/origin/build");
+    expect(buildB).toEqual(buildA);
+    expect(buildC).toEqual(buildA);
+
+    const reviewA = anchorOfSurface(unscanned, "p1", "review", "/none");
+    const reviewB = anchorOfSurface(materialized, "p1", "review", "/none");
+    const reviewC = anchorOfSurface(hostLost, "p1", "review", "/none");
+    expect(reviewB).toEqual(reviewA);
+    expect(reviewC).toEqual(reviewA);
+    /* The chain reads left→right in stage order on one band. */
+    expect(reviewA.x).toBeGreaterThan(buildA.x);
+    expect(reviewA.y).toBe(buildA.y);
+    expectRegionsSeparated(materialized);
+    expectMembersContained(materialized, "p1");
+  });
+
+  test("sequentially materializing stages land exactly on their reserved anchors", () => {
+    const origin = entry({ path: "/origin", activity: "live" });
+    const s1 = entry({ path: "/origin/s1", parent: "/origin", kind: "subagent", activity: "live" });
+    const s2 = entry({ path: "/origin/s2", parent: "/origin", kind: "subagent", activity: "live" });
+    const stages = [
+      { id: "one", kind: "run", prompt: "", next: "two" },
+      { id: "two", kind: "run", prompt: "", next: "three" },
+      { id: "three", kind: "run", prompt: "", next: null },
+    ];
+    const pipelineAt = (materializedCount: number) => pipe({
+      srcPath: "/origin",
+      stages,
+      cursor: { stageId: stages[materializedCount - 1]!.id, state: "running", input: null, activatedBy: null },
+      runs: [
+        { stageId: "one", attempts: [{ n: 1, state: materializedCount > 1 ? "passed" : "running", agentPath: "/origin/s1", flowId: null }] },
+        ...(materializedCount > 1 ? [{ stageId: "two", attempts: [{ n: 1, state: "running", agentPath: "/origin/s2", flowId: null }] }] : []),
+      ],
+    });
+    const layoutOf = (files: FileEntry[], p: Pipeline) =>
+      buildSchemeLayout(buildBranchGroups(files, "demo"), [], files, [], [], [p], [p]);
+
+    const first = layoutOf([origin, s1], pipelineAt(1));
+    const second = layoutOf([origin, s1, s2], pipelineAt(2));
+
+    const anchor = (layout: SchemeLayout, stageId: string, nodePath: string) => anchorOfSurface(layout, "p1", stageId, nodePath);
+    /* Stage two's live pane lands exactly on its placeholder's coordinates. */
+    expect(anchor(second, "two", "/origin/s2")).toEqual(anchor(first, "two", "/none"));
+    /* Neither the already-live stage one nor the future stage three moves. */
+    expect(anchor(second, "one", "/origin/s1")).toEqual(anchor(first, "one", "/origin/s1"));
+    expect(anchor(second, "three", "/none")).toEqual(anchor(first, "three", "/none"));
+  });
+
+  test("completed stages read chronologically left of the live pane, future stages to its right", () => {
+    /* Stage history must read left→right: completed cards, then the live
+       cursor pane, then the future placeholders — never a completed card
+       dropping BELOW the live conversation. */
+    const origin = entry({ path: "/origin", activity: "live" });
+    const live = entry({ path: "/origin/polish", parent: "/origin", kind: "subagent", activity: "live" });
+    const files = [origin, live];
+    const stages = [
+      { id: "build", kind: "run", prompt: "", next: "verify" },
+      { id: "verify", kind: "run", prompt: "", next: "polish" },
+      { id: "polish", kind: "run", prompt: "", next: "ship" },
+      { id: "ship", kind: "run", prompt: "", next: null },
+    ];
+    const pipeline = pipe({
+      srcPath: "/origin",
+      stages,
+      cursor: { stageId: "polish", state: "running", input: null, activatedBy: null },
+      runs: [
+        { stageId: "build", attempts: [{ n: 1, state: "passed", agentPath: "/hist/build", flowId: null }] },
+        { stageId: "verify", attempts: [{ n: 1, state: "passed", agentPath: "/hist/verify", flowId: null }] },
+        { stageId: "polish", attempts: [{ n: 1, state: "running", agentPath: "/origin/polish", flowId: null }] },
+      ],
+    });
+    const groups = buildBranchGroups(files, "demo");
+    const layout = buildSchemeLayout(groups, [], files, [], [], [pipeline], [pipeline]);
+
+    const slotOf = (stageId: string) => layout.slots.find((candidate) => candidate.stage.id === stageId)!;
+    const liveNode = layout.nodes.find((candidate) => candidate.file.path === "/origin/polish")!;
+    const buildSlot = slotOf("build");
+    const verifySlot = slotOf("verify");
+    const shipSlot = slotOf("ship");
+    expect(buildSlot.presentation).toBe("completed");
+    expect(verifySlot.presentation).toBe("completed");
+    expect(shipSlot.presentation).toBe("placeholder");
+    /* One chain band, chronological order. */
+    for (const rect of [buildSlot, verifySlot, shipSlot]) expect(rect.y).toBe(liveNode.y);
+    expect(buildSlot.x).toBeLessThan(verifySlot.x);
+    expect(verifySlot.x).toBeLessThan(liveNode.x);
+    expect(liveNode.x).toBeLessThan(shipSlot.x);
+    expectMembersContained(layout, "p1");
+  });
+});
+
 describe("every pipeline conversation surface stays inside its colored region (#531)", () => {
   test("quiet history and a direct one-shot review deck stay inside the pipeline region", () => {
     /* Production shape: the builder conversation of a live pipeline carries a
@@ -350,6 +486,46 @@ describe("every pipeline conversation surface stays inside its colored region (#
     expect(deck).toBeTruthy();
     expect(contains(halo, deck!), "the review deck escapes the pipeline region").toBe(true);
     expectMembersContained(layout, "p1");
+    expectRegionsSeparated(layout);
+  });
+
+  test("a task card linked to the pipeline is owned by the pipeline region (#531 round 1)", () => {
+    /* The pipeline's board task (its work item) is a first-class member of the
+       colored region: the layout places it inside the pipeline chain and the
+       halo contains it, instead of leaving the sticky note wherever the lattice
+       dropped it. */
+    const builder = entry({ path: "/builder", activity: "live" });
+    const files = [builder];
+    const pipeline = pipe({
+      taskIds: ["t-1"],
+      stages: [
+        { id: "build", kind: "run", prompt: "", next: "review" },
+        { id: "review", kind: "review-loop", prompt: "", next: null },
+      ],
+      cursor: { stageId: "build", state: "running", input: null, activatedBy: null },
+      runs: [{ stageId: "build", attempts: [{ n: 1, state: "running", agentPath: "/builder", flowId: null }] }],
+    });
+    const task: BoardTask = {
+      id: "t-1",
+      project: "demo",
+      status: "assigned",
+      text: "P0 #531 keep pipeline regions stable",
+      placement: "pinned",
+      pos: { x: 4000, y: 4000 },
+      assignments: [],
+      createdAt: "2026-07-05T00:00:00Z",
+      updatedAt: "2026-07-05T00:00:00Z",
+    } as unknown as BoardTask;
+    const groups = buildBranchGroups(files, "demo");
+    const layout = buildSchemeLayout(groups, [], files, [], [], [pipeline], [pipeline], new Set(), new Set(), [task]);
+
+    const region = layout.regionTasks.find((candidate) => candidate.taskId === "t-1");
+    expect(region, "the linked task must be placed by the pipeline region").toBeTruthy();
+    expect(region!.pipelineId).toBe("p1");
+    const halo = haloOf(layout, "p1");
+    expect(contains(halo, region!), "the linked task card escapes the pipeline region").toBe(true);
+    expect(layout.byPath.get("task::t-1")).toBe(region!);
+    expect(halo.members).toContain("task::t-1");
     expectRegionsSeparated(layout);
   });
 

--- a/src/components/scheme/pipelineRegionGeometry.test.ts
+++ b/src/components/scheme/pipelineRegionGeometry.test.ts
@@ -1,0 +1,364 @@
+import { describe, expect, test } from "bun:test";
+
+import type { Flow } from "@/lib/flows/types";
+import type { Pipeline } from "@/lib/pipelines/types";
+import type { FileEntry } from "@/lib/types";
+
+import { directReviewFlows } from "@/components/flows/directReviewGroups";
+import { type BranchGroup, buildBranchGroups } from "@/components/projectModel";
+
+import { deckKey, groupRect } from "./agentLinks";
+import { buildSchemeLayout, type SchemeLayout, type SchemeRect } from "./layout";
+
+/*
+ * Region geometry regressions for issue #531: every pipeline's colored halo is
+ * the single ownership region of its conversations, and two regions never
+ * intersect. The fixtures below are production-shaped: real branch groups, real
+ * stage attempts, folded/unfolded review decks, quiet history, host-loss and
+ * publish-to-scan (delayed materialization) gaps.
+ */
+
+function entry(overrides: Partial<FileEntry> & { path: string }): FileEntry {
+  return {
+    root: "claude-projects",
+    name: overrides.path,
+    project: "demo",
+    title: overrides.path,
+    engine: "claude",
+    kind: "session",
+    fmt: "claude",
+    parent: null,
+    mtime: 1_000,
+    size: 10,
+    activity: "idle",
+    proc: null,
+    pid: null,
+    model: null,
+    pendingQuestion: null,
+    waitingInput: null,
+    ...overrides,
+  };
+}
+
+const roleConfig = { engine: "claude" as const, model: null, effort: null };
+
+function flow(overrides: Partial<Flow> & { id: string; implementerPath: string }): Flow {
+  return {
+    template: "implement-review-loop",
+    project: "demo",
+    cwd: "/tmp",
+    roles: { implementer: roleConfig, reviewer: roleConfig },
+    baseRef: "abc",
+    baseMode: "head",
+    mode: "auto",
+    reviewerMode: "headless",
+    roundLimit: 5,
+    state: "reviewing",
+    stateDetail: null,
+    rounds: [],
+    createdAt: "2026-07-05T00:00:00Z",
+    closedAt: null,
+    ...overrides,
+  };
+}
+
+const round = (n: number, reviewerPath: string | null): Flow["rounds"][number] => ({
+  n,
+  reviewerPath,
+  findingsPath: null,
+  triggeredBy: "marker",
+  readyNote: null,
+  verdict: null,
+  findingsCount: null,
+  startedAt: "2026-07-05T00:00:00Z",
+  reviewedAt: null,
+  relayedAt: null,
+  error: null,
+});
+
+const pipe = (over: Record<string, unknown>): Pipeline =>
+  ({
+    id: "p1", task: "Keep regions", project: "demo", repoDir: "/r", worktreeDir: "/w", branch: "b",
+    baseBranch: "main", baseRef: "a", lastPassedCommit: "a",
+    stages: [{ id: "build", kind: "run", prompt: "", next: null }],
+    runs: [], cursor: null, state: "running", pausedState: null, stateDetail: null, srcPath: null,
+    srcConversationId: null, createdAt: "1970", closedAt: null, ...over,
+  }) as unknown as Pipeline;
+
+/* Two rects are disjoint with at least `gap` unclaimed pixels between them. */
+const disjointWithGap = (a: SchemeRect, b: SchemeRect, gap: number): boolean =>
+  a.x + a.w + gap <= b.x || b.x + b.w + gap <= a.x || a.y + a.h + gap <= b.y || b.y + b.h + gap <= a.y;
+
+const contains = (outer: SchemeRect, inner: SchemeRect): boolean =>
+  inner.x >= outer.x && inner.y >= outer.y && inner.x + inner.w <= outer.x + outer.w && inner.y + inner.h <= outer.y + outer.h;
+
+/* The stable visible corridor two neighboring regions must keep (world px). At
+   62% lite zoom this still reads as a ~15px on-screen gap. */
+const REGION_GAP = 24;
+
+function expectRegionsSeparated(layout: SchemeLayout) {
+  const regions = layout.groups;
+  for (let i = 0; i < regions.length; i += 1) {
+    for (let j = i + 1; j < regions.length; j += 1) {
+      const a = regions[i]!;
+      const b = regions[j]!;
+      expect(
+        disjointWithGap(a, b, REGION_GAP),
+        `regions ${a.key} ${JSON.stringify({ x: a.x, y: a.y, w: a.w, h: a.h })} and ${b.key} ${JSON.stringify({ x: b.x, y: b.y, w: b.w, h: b.h })} must keep a ${REGION_GAP}px gap`,
+      ).toBe(true);
+    }
+  }
+}
+
+function haloOf(layout: SchemeLayout, pipelineId: string) {
+  const halo = layout.groups.find((group) => group.kind === "pipeline" && group.id === pipelineId);
+  expect(halo, `pipeline ${pipelineId} must own a colored region`).toBeTruthy();
+  return halo!;
+}
+
+/* Every board surface of the pipeline — member cards plus their slots — must sit
+   fully inside the pipeline's own region. */
+function expectMembersContained(layout: SchemeLayout, pipelineId: string) {
+  const halo = haloOf(layout, pipelineId);
+  for (const key of halo.members) {
+    const rect = layout.byPath.get(key);
+    expect(rect, `member ${key} of ${pipelineId} must be a placed rect`).toBeTruthy();
+    expect(
+      contains(halo, rect!),
+      `member ${key} ${JSON.stringify(rect)} escapes region ${JSON.stringify({ x: halo.x, y: halo.y, w: halo.w, h: halo.h })}`,
+    ).toBe(true);
+  }
+  for (const slot of layout.slots.filter((candidate) => candidate.pipeline.id === pipelineId)) {
+    expect(contains(halo, slot), `slot ${slot.key} escapes its pipeline region`).toBe(true);
+  }
+}
+
+describe("neighboring pipeline regions never intersect (#531)", () => {
+  /* Production shape: one origin conversation spawned two pipeline builders.
+     Each pipeline still has future stages, so each grows a slot row under its
+     builder tip. The two rows are wider than the builder cards — without space
+     reservation they collide and the two colored regions overlap. */
+  const twoPipelineScene = (stageState: string, attemptOver: Record<string, unknown> = {}) => {
+    const origin = entry({ path: "/origin", activity: "live" });
+    const builderA = entry({ path: "/origin/a", parent: "/origin", kind: "subagent", activity: "live" });
+    const builderB = entry({ path: "/origin/b", parent: "/origin", kind: "subagent", activity: "live" });
+    const files = [origin, builderA, builderB];
+    const stages = [
+      { id: "build", kind: "run", prompt: "", next: "review" },
+      { id: "review", kind: "review-loop", prompt: "", next: "polish", onFail: { to: "build", maxRounds: 5 } },
+      { id: "polish", kind: "run", prompt: "", next: null },
+    ];
+    const pipelineOf = (id: string, agentPath: string) => pipe({
+      id,
+      stages,
+      cursor: { stageId: "build", state: stageState, input: null, activatedBy: null },
+      runs: [{ stageId: "build", attempts: [{ n: 1, state: stageState, agentPath, flowId: null, ...attemptOver }] }],
+    });
+    const pipelines = [pipelineOf("pa", "/origin/a"), pipelineOf("pb", "/origin/b")];
+    const groups = buildBranchGroups(files, "demo");
+    return buildSchemeLayout(groups, [], files, [], [], pipelines, pipelines);
+  };
+
+  test("two live sibling pipelines with future-stage slot rows keep disjoint regions", () => {
+    const layout = twoPipelineScene("running");
+    expect(layout.slots.filter((slot) => slot.pipeline.id === "pa")).toHaveLength(2);
+    expect(layout.slots.filter((slot) => slot.pipeline.id === "pb")).toHaveLength(2);
+    expectRegionsSeparated(layout);
+    expectMembersContained(layout, "pa");
+    expectMembersContained(layout, "pb");
+    /* The two slot rows themselves never intersect either. */
+    for (const a of layout.slots.filter((slot) => slot.pipeline.id === "pa")) {
+      for (const b of layout.slots.filter((slot) => slot.pipeline.id === "pb")) {
+        expect(disjointWithGap(a, b, 0), `${a.key} intersects ${b.key}`).toBe(true);
+      }
+    }
+  });
+
+  test("parked (needs_decision) neighbors keep disjoint regions", () => {
+    const layout = twoPipelineScene("needs_decision");
+    expectRegionsSeparated(layout);
+    expectMembersContained(layout, "pa");
+    expectMembersContained(layout, "pb");
+  });
+
+  test("host loss / delayed materialization (published transcripts not yet scanned) keeps disjoint regions", () => {
+    /* The builder attempts have published agentPaths, but the runtime host died
+       before the scanner surfaced them: no scene node exists, every stage rides
+       its placeholder. Both pipelines still own separated regions. */
+    const origin = entry({ path: "/origin", activity: "live" });
+    const files = [origin];
+    const stages = [
+      { id: "build", kind: "run", prompt: "", next: "review" },
+      { id: "review", kind: "review-loop", prompt: "", next: null },
+    ];
+    const pipelineOf = (id: string, agentPath: string) => pipe({
+      id,
+      stages,
+      cursor: { stageId: "build", state: "running", input: null, activatedBy: null },
+      runs: [{ stageId: "build", attempts: [{ n: 1, state: "running", agentPath, flowId: null }] }],
+    });
+    const pipelines = [pipelineOf("pa", "/lost/a"), pipelineOf("pb", "/lost/b")];
+    const groups = buildBranchGroups(files, "demo");
+    const layout = buildSchemeLayout(groups, [], files, [], [], pipelines, pipelines);
+    expect(layout.slots.filter((slot) => slot.pipeline.id === "pa")).toHaveLength(2);
+    expect(layout.slots.filter((slot) => slot.pipeline.id === "pb")).toHaveLength(2);
+    expectRegionsSeparated(layout);
+    expectMembersContained(layout, "pa");
+    expectMembersContained(layout, "pb");
+  });
+
+  test("completed stages standing in as full cards keep neighboring regions disjoint", () => {
+    /* Both pipelines finished build + review; the idle transcripts are not live
+       nodes, so both stages stand in as completed cards — a two-card row under
+       no tip for pa/pb still reads as two separated regions. */
+    const origin = entry({ path: "/origin", activity: "live" });
+    const builderA = entry({ path: "/origin/a", parent: "/origin", kind: "subagent", activity: "live" });
+    const builderB = entry({ path: "/origin/b", parent: "/origin", kind: "subagent", activity: "live" });
+    const files = [origin, builderA, builderB];
+    const stages = [
+      { id: "build", kind: "run", prompt: "", next: "verify" },
+      { id: "verify", kind: "run", prompt: "", next: "polish" },
+      { id: "polish", kind: "run", prompt: "", next: null },
+    ];
+    const pipelineOf = (id: string, livePath: string, historicPath: string) => pipe({
+      id,
+      stages,
+      cursor: { stageId: "polish", state: "running", input: null, activatedBy: null },
+      runs: [
+        { stageId: "build", attempts: [{ n: 1, state: "passed", agentPath: historicPath, flowId: null }] },
+        { stageId: "verify", attempts: [{ n: 1, state: "passed", agentPath: `${historicPath}-verify`, flowId: null }] },
+        { stageId: "polish", attempts: [{ n: 1, state: "running", agentPath: livePath, flowId: null }] },
+      ],
+    });
+    const pipelines = [pipelineOf("pa", "/origin/a", "/hist/a"), pipelineOf("pb", "/origin/b", "/hist/b")];
+    const groups = buildBranchGroups(files, "demo");
+    const layout = buildSchemeLayout(groups, [], files, [], [], pipelines, pipelines);
+    const completed = layout.slots.filter((slot) => slot.presentation === "completed");
+    expect(completed.length).toBe(4);
+    expectRegionsSeparated(layout);
+    expectMembersContained(layout, "pa");
+    expectMembersContained(layout, "pb");
+  });
+
+  test("a standalone review flow launched under a pipeline stage keeps its own separated region", () => {
+    /* Screenshot shape (#531 comment): the pipeline halo and a review-flow zone
+       overlap. A managed flow whose implementer hangs under the pipeline's
+       builder must own a region beside/below the pipeline's — never inside it. */
+    const builder = entry({ path: "/builder", activity: "live" });
+    const codex = entry({ path: "/builder/codex", parent: "/builder", kind: "subagent", activity: "live" });
+    const files = [builder, codex];
+    const pipeline = pipe({
+      stages: [
+        { id: "build", kind: "run", prompt: "", next: "review" },
+        { id: "review", kind: "review-loop", prompt: "", next: null },
+      ],
+      cursor: { stageId: "build", state: "running", input: null, activatedBy: null },
+      runs: [{ stageId: "build", attempts: [{ n: 1, state: "running", agentPath: "/builder", flowId: null }] }],
+    });
+    const sideFlow = flow({ id: "f-side", implementerPath: "/builder/codex", rounds: [round(1, null)] });
+    const groups = buildBranchGroups(files, "demo");
+    const layout = buildSchemeLayout(groups, [], files, [sideFlow], [], [pipeline], [pipeline]);
+
+    const pipelineHalo = haloOf(layout, "p1");
+    const flowHalo = layout.groups.find((group) => group.kind === "flow" && group.id === "f-side");
+    expect(flowHalo).toBeTruthy();
+    expect(
+      disjointWithGap(pipelineHalo, flowHalo!, REGION_GAP),
+      `pipeline region ${JSON.stringify({ x: pipelineHalo.x, y: pipelineHalo.y, w: pipelineHalo.w, h: pipelineHalo.h })} overlaps review-flow region ${JSON.stringify({ x: flowHalo!.x, y: flowHalo!.y, w: flowHalo!.w, h: flowHalo!.h })}`,
+    ).toBe(true);
+    expectMembersContained(layout, "p1");
+  });
+});
+
+describe("every pipeline conversation surface stays inside its colored region (#531)", () => {
+  test("quiet history and a direct one-shot review deck stay inside the pipeline region", () => {
+    /* Production shape: the builder conversation of a live pipeline carries a
+       quiet finished child (folded history) and a direct Codex one-shot review
+       deck. Both belong to the pipeline's story and must sit inside its colored
+       region. */
+    const builder = entry({ path: "/builder", conversationId: "c-build", activity: "live" });
+    const quiet = entry({ path: "/builder/quiet", parent: "/builder", kind: "subagent" });
+    const reviewer = entry({
+      path: "/builder/review-1",
+      parent: "/builder",
+      conversationId: "c-r1",
+      activity: "live",
+      durableLineage: {
+        kind: "review",
+        role: "reviewer",
+        parentConversationId: "c-build",
+        reviewsConversationId: "c-build",
+        memberships: [],
+      },
+    });
+    const files = [builder, quiet, reviewer];
+    const projected = directReviewFlows({ files, flows: [], tasks: [] });
+    expect(projected).toHaveLength(1);
+    const group: BranchGroup = {
+      key: builder.path,
+      columns: [{ file: builder, tasks: [] }],
+      returnable: [quiet],
+      finished: [],
+      smt: builder.mtime,
+      orphanTask: false,
+    };
+    const pipeline = pipe({
+      stages: [
+        { id: "build", kind: "run", prompt: "", next: "review" },
+        { id: "review", kind: "review-loop", prompt: "", next: null },
+      ],
+      cursor: { stageId: "build", state: "running", input: null, activatedBy: null },
+      runs: [{ stageId: "build", attempts: [{ n: 1, state: "running", agentPath: "/builder", flowId: null }] }],
+    });
+    const layout = buildSchemeLayout([group], [], files, projected, [], [pipeline], [pipeline]);
+
+    const halo = haloOf(layout, "p1");
+    const stack = layout.stacks.find((candidate) => candidate.parent === "/builder");
+    expect(stack).toBeTruthy();
+    expect(contains(halo, stack!), "the builder's quiet-history stack escapes the pipeline region").toBe(true);
+    const deck = layout.decks.find((candidate) => candidate.key === deckKey(projected[0]!.id));
+    expect(deck).toBeTruthy();
+    expect(contains(halo, deck!), "the direct review deck escapes the pipeline region").toBe(true);
+    expectMembersContained(layout, "p1");
+  });
+
+  test("an expanded review history (many-round deck) stays inside the pipeline region", () => {
+    /* The pipeline's embedded review flow accumulated 7 rounds; its deck grows
+       spines below the front card. The whole deck — collapsed or expanded — must
+       stay a contained surface of the pipeline region. */
+    const builder = entry({ path: "/builder", activity: "live" });
+    const files = [builder];
+    const rounds = Array.from({ length: 7 }, (_, index) => round(index + 1, null));
+    const reviewFlow = flow({ id: "f-loop", implementerPath: "/builder", rounds });
+    const pipeline = pipe({
+      stages: [
+        { id: "build", kind: "run", prompt: "", next: "review" },
+        { id: "review", kind: "review-loop", prompt: "", next: null },
+      ],
+      cursor: { stageId: "review", state: "reviewing", input: null, activatedBy: null },
+      state: "running",
+      runs: [
+        { stageId: "build", attempts: [{ n: 1, state: "passed", agentPath: "/builder", flowId: null }] },
+        { stageId: "review", attempts: [{ n: 1, state: "reviewing", agentPath: null, flowId: "f-loop" }] },
+      ],
+    });
+    const groups = buildBranchGroups(files, "demo");
+    const layout = buildSchemeLayout(groups, [], files, [reviewFlow], [], [pipeline], [pipeline]);
+
+    const halo = haloOf(layout, "p1");
+    const deck = layout.decks.find((candidate) => candidate.key === deckKey("f-loop"));
+    expect(deck).toBeTruthy();
+    expect(contains(halo, deck!), "the review deck escapes the pipeline region").toBe(true);
+    expectMembersContained(layout, "p1");
+    expectRegionsSeparated(layout);
+  });
+
+  test("groupRect stays a padded union of its member rects", () => {
+    const rects = new Map<string, SchemeRect>([
+      ["a", { x: 100, y: 100, w: 50, h: 50 }],
+      ["b", { x: 300, y: 200, w: 40, h: 40 }],
+    ]);
+    const rect = groupRect(["a", "b", "missing"], (key) => rects.get(key) ?? null, 10);
+    expect(rect).toEqual({ x: 90, y: 90, w: 260, h: 160 });
+  });
+});


### PR DESCRIPTION
Closes #531.

## Problem

Production board evidence (2026-07-21, issue #531 comment): the #312 pipeline halo and a materialized review-flow zone overlapped, and cards belonging to a pipeline extended beyond its colored ownership region — a pipeline read as visually disconnected from its own conversations.

Root causes in `buildSchemeLayout`:

1. **No space reservation for stage rows.** Planned-placeholder / completed-stage rows were placed *after* the tree layout under each pipeline's tip, with a collision check that ignored other pipelines' rows entirely — so two neighboring regions could overlap card-on-card, and the bounding-box halos intersected.
2. **Incomplete region membership.** A member pane's attached surfaces — direct one-shot review decks, quiet-history stacks, handoff drafts — were not halo members, so review decks and folded history poked out of the colored region.
3. **Foreign absorption.** Halo expansion swallowed descendants owned by *other* flows/pipelines (e.g. a standalone Codex review flow launched under a builder), guaranteeing two dashed regions covering the same cards.
4. **Vertical pad collision.** `GAP_Y` (130) is narrower than two facing halo pads plus the header headroom (136), so a child region directly under a grouped parent always overlapped it.

## Fix (frontend layout / board projection only)

- Classify every pipeline's stage row **before** tree placement (placed nodes/decks are fully derivable up front) and emit the row as a **reserved first child block of its chain tip** — subtree widths now include the rows, so the existing group-boundary gaps keep neighboring regions separated with a stable visible corridor, at any zoom (world geometry is zoom-independent, verified at the 62% lite camera and across Fit All).
- The `x + INDENT` anchor is preserved, so a materializing stage window still lands exactly on its placeholder's coordinates (stable slots, #196), and `incoming` handoff badges, slot keys, rail anchoring, and stage ordering are unchanged.
- Memberless pipelines dock their shell rows in a band **below** all placed content instead of at the band head.
- New `GROUP_CHILD_GAP` corridor when a child generation starts a different flow/pipeline region.
- Pipeline halo membership now includes every attached surface of a member pane (managed/direct review decks, quiet stacks, drafts) and **prunes descendants owned by another group**, so a region contains all of its conversations and never swallows another region's cards.

## Regressions added

- `pipelineRegionGeometry.test.ts` — production-shaped world-geometry suite: pairwise region non-intersection with a ≥24px world gap plus complete child-bounds containment across live, parked (needs_decision), completed-card, host-loss / delayed-materialization (published-yet-unscanned), nested review-flow, and 7-round expanded review-deck states.
- `SchemeBoard.pipelineRegions.dom.test.tsx` — rendered-board suite: 62% lite-zoom camera, Fit All (camera-only, world rects unmoved), direct review deck containment, shell-row separation under host loss, parked-beside-live pair, and no region covering a foreign conversation.

## Verification

- Base: exact production main `24b38be0fb4ab49c8ffc8128ed59bd5d4e52c0a0`.
- New suites red on base (5 failures reproducing the overlap/escape), green after the fix (8 + 3 pass).
- Focused: `bun test src/components/scheme src/components/pipelines` — 727 pass / 0 fail.
- Full: `bun test` — 5061 pass / 25 fail; the same 25 failures occur on clean pinned main in a full run (isolation-passing, pre-existing cross-test interference), delta is exactly the 11 new passing tests.
- `bunx tsc --noEmit` clean, scoped `eslint` clean, `bun run build` (webpack + MCP bundle) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)