### PR TITLE
fix(pipelines): synchronize embedded review-flow generations

### DIFF
--- a/src/app/api/files/response.ts
+++ b/src/app/api/files/response.ts
@@ -508,7 +508,11 @@ export async function buildFilesResponse(request: Request, dependencies: FilesRo
   let pipelinesError: string | undefined;
   try {
     const reconciled = await withPipelineMutation((current, persist) => {
-      if (reconcileEmbeddedReviewFlows(current, storedFlows)) persist();
+      /* Re-read after acquiring the pipeline transaction: the controller can
+         advance flows between the scan's earlier projection read and this
+         persistence window. The synchronization seam also fences older round
+         counts/timestamps, so a delayed response cannot rewind its parent. */
+      if (reconcileEmbeddedReviewFlows(current, loadFlows())) persist();
       return current;
     });
     pipelines = filterPipelinesForFileScan(reconciled, files, {

--- a/src/app/api/files/response.ts
+++ b/src/app/api/files/response.ts
@@ -14,7 +14,8 @@ import { loadFlows } from "@/lib/flows/store";
 import { reviewOutcomeFor } from "@/lib/flows/reviewOutcome";
 import { overlayPromptDisplayTitles } from "@/lib/displayNames";
 import { projectRestoredFlows } from "@/lib/flows/visibility";
-import { loadPipelines } from "@/lib/pipelines/store";
+import { reconcileEmbeddedReviewFlows } from "@/lib/pipelines/engine";
+import { withPipelineMutation } from "@/lib/pipelines/store";
 import type { Pipeline } from "@/lib/pipelines/types";
 import { filterPipelinesForFileScan } from "@/lib/pipelines/visibility";
 import { pathForPanePid, reconcileTasks } from "@/lib/tasks/reconcile";
@@ -506,7 +507,11 @@ export async function buildFilesResponse(request: Request, dependencies: FilesRo
   let pipelines: Pipeline[] = [];
   let pipelinesError: string | undefined;
   try {
-    pipelines = filterPipelinesForFileScan(loadPipelines(), files, {
+    const reconciled = await withPipelineMutation((current, persist) => {
+      if (reconcileEmbeddedReviewFlows(current, storedFlows)) persist();
+      return current;
+    });
+    pipelines = filterPipelinesForFileScan(reconciled, files, {
       pinnedPaths: visibilityPinnedPaths,
       memberships: registrySnapshot.memberships,
     });

--- a/src/app/api/files/response.ts
+++ b/src/app/api/files/response.ts
@@ -10,7 +10,7 @@ import { preallocatedStructuredSpawnCards } from "@/lib/agent/spawnProjection";
 import { conversationCatalogSnapshot } from "@/lib/scanner/conversationCatalog";
 import { pidAlive, readPpid } from "@/lib/scanner/process";
 import { repositoryForProjectRoot } from "@/lib/flows/git";
-import { loadFlows } from "@/lib/flows/store";
+import { loadFlows, withFlowSnapshot } from "@/lib/flows/store";
 import { reviewOutcomeFor } from "@/lib/flows/reviewOutcome";
 import { overlayPromptDisplayTitles } from "@/lib/displayNames";
 import { projectRestoredFlows } from "@/lib/flows/visibility";
@@ -380,30 +380,15 @@ export async function buildFilesResponse(request: Request, dependencies: FilesRo
      with no such lineage are untouched. */
   overlayLineageProjectAffinity(files);
   markTiming("files-project-affinity");
-  const storedFlows = loadFlows();
+  let storedFlows = loadFlows();
   markTiming("files-flow-store");
-  const flows = projectRestoredFlows(storedFlows, files, {
+  let flows = projectRestoredFlows(storedFlows, files, {
     pinnedPaths: visibilityPinnedPaths,
     memberships: registrySnapshot.memberships,
   });
   markTiming("files-flow-restore");
   const storedTasks = loadTasks();
   markTiming("files-task-store");
-  /* Role titles (issue #325): a Viewer-spawned worker whose scan/launch title
-     is machine boilerplate («Codex session», the spawn prompt head) presents
-     its durable identity instead — task subject + role for builders, reviewed
-     subject + round for reviewers. Runs after overlaySessionTitles so an
-     explicit user rename keeps final precedence (the role title becomes its
-     Reset base), and never rewrites native transcripts. */
-  overlayRoleSessionTitles({ files, flows, tasks: storedTasks, conversationAliases: registrySnapshot.conversationAliases });
-  /* Prompt-title fallback (issue #345): sessions the role overlay could not
-     claim — legacy spawns without durable lineage, fresh role spawns with no
-     owning task yet — still show the raw «You are the Orchestrator…» scaffold
-     as their title. Compact those to the role word; user renames keep final
-     precedence exactly as above. */
-  overlayPromptDisplayTitles(files);
-  markTiming("files-role-titles");
-  timings.push(`files-flows;dur=${(performance.now() - flowsStartedAt).toFixed(1)}`);
   /* Human-authorship pin for the board's worker-class auto-collapse (issue
      #112): the reaper's sticky evidence (PR #125) marks any transcript that
      carries a real user message. Both authorship and fail-closed freshness span
@@ -507,15 +492,20 @@ export async function buildFilesResponse(request: Request, dependencies: FilesRo
   let pipelines: Pipeline[] = [];
   let pipelinesError: string | undefined;
   try {
-    const reconciled = await withPipelineMutation((current, persist) => {
-      /* Re-read after acquiring the pipeline transaction: the controller can
-         advance flows between the scan's earlier projection read and this
-         persistence window. The synchronization seam also fences older round
-         counts/timestamps, so a delayed response cannot rewind its parent. */
-      if (reconcileEmbeddedReviewFlows(current, loadFlows())) persist();
-      return current;
+    const reconciled = await withFlowSnapshot(async (projectionFlows) =>
+      await withPipelineMutation((current, persist) => {
+        /* The flow lock spans parent persistence and captures the exact array
+           returned below. Controller transitions cannot split the deck/flow
+           generation from its synchronized parent projection. */
+        if (reconcileEmbeddedReviewFlows(current, projectionFlows)) persist();
+        return { pipelines: current, flows: [...projectionFlows] };
+      }));
+    storedFlows = reconciled.flows;
+    flows = projectRestoredFlows(storedFlows, files, {
+      pinnedPaths: visibilityPinnedPaths,
+      memberships: registrySnapshot.memberships,
     });
-    pipelines = filterPipelinesForFileScan(reconciled, files, {
+    pipelines = filterPipelinesForFileScan(reconciled.pipelines, files, {
       pinnedPaths: visibilityPinnedPaths,
       memberships: registrySnapshot.memberships,
     });
@@ -523,6 +513,14 @@ export async function buildFilesResponse(request: Request, dependencies: FilesRo
     pipelinesError = error instanceof Error ? error.message : "pipeline registry unreadable";
     console.error("[files] pipelines store unreadable; serving without pipelines", error);
   }
+  /* Role titles (issue #325) and the returned flow read model consume the same
+     transaction-captured flow generation as pipelines. A controller advance
+     during the earlier scan can therefore never mix deck/annotation generation
+     N with parent generation N+1. Explicit user titles keep final precedence. */
+  overlayRoleSessionTitles({ files, flows, tasks: storedTasks, conversationAliases: registrySnapshot.conversationAliases });
+  overlayPromptDisplayTitles(files);
+  markTiming("files-role-titles");
+  timings.push(`files-flows;dur=${(performance.now() - flowsStartedAt).toFixed(1)}`);
   markTiming("files-stores");
   const projectsStartedAt = performance.now();
   const projected = projectRateLimitReadModel(files, flows, registrySnapshot);

--- a/src/app/api/files/response.ts
+++ b/src/app/api/files/response.ts
@@ -492,11 +492,11 @@ export async function buildFilesResponse(request: Request, dependencies: FilesRo
   let pipelines: Pipeline[] = [];
   let pipelinesError: string | undefined;
   try {
-    const reconciled = await withFlowSnapshot(async (projectionFlows) =>
-      await withPipelineMutation((current, persist) => {
-        /* The flow lock spans parent persistence and captures the exact array
-           returned below. Controller transitions cannot split the deck/flow
-           generation from its synchronized parent projection. */
+    const reconciled = await withPipelineMutation((current, persist) =>
+      withFlowSnapshot((projectionFlows) => {
+        /* Every cross-store lifecycle path acquires pipeline before flow. The
+           flow lock spans parent persistence and captures the exact array
+           returned below, so the returned deck and parent share a generation. */
         if (reconcileEmbeddedReviewFlows(current, projectionFlows)) persist();
         return { pipelines: current, flows: [...projectionFlows] };
       }));

--- a/src/app/api/files/route.test.ts
+++ b/src/app/api/files/route.test.ts
@@ -43,6 +43,7 @@ beforeEach(() => {
   scanGates = [];
   hydrateScannedFiles = (files) => files;
   tmuxHealth = { status: "healthy" };
+  flowsStore = () => [];
   replaceConversationCatalog([]);
 });
 
@@ -88,7 +89,8 @@ mock.module("@/lib/scanner", () => ({
   },
 }));
 let pipelinesStore: () => unknown[] = () => [];
-mock.module("@/lib/flows/store", () => ({ loadFlows: () => [] }));
+let flowsStore: () => unknown[] = () => [];
+mock.module("@/lib/flows/store", () => ({ loadFlows: () => flowsStore() }));
 mock.module("@/lib/pipelines/store", () => ({ loadPipelines: () => pipelinesStore() }));
 mock.module("@/lib/pipelines/visibility", () => ({ filterPipelinesForFileScan: () => [] }));
 let boardTasksStore: () => unknown[] = () => [];
@@ -146,6 +148,37 @@ test("repeated files reads reuse the pure read snapshot and retain ETag behavior
   expect(first.headers.get("server-timing")).toMatch(/files-flow-restore;dur=\d+(?:\.\d+)?/);
   expect(first.headers.get("server-timing")).toMatch(/files-task-store;dur=\d+(?:\.\d+)?/);
   expect(first.headers.get("server-timing")).toMatch(/files-role-titles;dur=\d+(?:\.\d+)?/);
+});
+
+test("issue 532: files response returns the transaction-captured flow generation", async () => {
+  const oldFlow = {
+    id: "flow-atomic-projection", template: "implement-review-loop", project: "demo", cwd: "/repo",
+    implementerPath: "/missing/implementer.jsonl", roles: {
+      implementer: { engine: "codex", model: null, effort: "low" },
+      reviewer: { engine: "codex", model: null, effort: "high" },
+    }, baseRef: "a".repeat(40), baseMode: "head", mode: "auto", reviewerMode: "headless",
+    roundLimit: 5, state: "reviewing", stateDetail: null,
+    rounds: [{ n: 1, reviewerPath: "/reviewer-1.jsonl", reviewHeadSha: "1".repeat(40) }],
+    createdAt: "2026-07-22T00:00:00Z", closedAt: null,
+  };
+  const currentFlow = {
+    ...structuredClone(oldFlow),
+    rounds: [
+      ...oldFlow.rounds,
+      { n: 2, reviewerPath: "/reviewer-2.jsonl", reviewHeadSha: "2".repeat(40) },
+    ],
+  };
+  let reads = 0;
+  flowsStore = () => structuredClone(reads++ === 0 ? [oldFlow] : [currentFlow]);
+  scannedFiles = [];
+
+  const response = await GET(new Request("http://127.0.0.1/api/files"));
+  const body = await response.json() as { flows: Array<{ id: string; rounds: Array<{ n: number }> }> };
+  expect(reads).toBeGreaterThanOrEqual(2);
+  expect(body.flows).toEqual([expect.objectContaining({
+    id: currentFlow.id,
+    rounds: [expect.objectContaining({ n: 1 }), expect.objectContaining({ n: 2 })],
+  })]);
 });
 
 test("volatile registry diagnostics do not invalidate an otherwise stable files ETag", async () => {

--- a/src/components/scheme/pipelineRegionGeometry.test.ts
+++ b/src/components/scheme/pipelineRegionGeometry.test.ts
@@ -208,6 +208,55 @@ describe("neighboring pipeline regions never intersect (#531)", () => {
     expectMembersContained(layout, "pb");
   });
 
+  test("issue 532 atomic projection keeps a delayed multi-round task pipeline beside a host-loss neighbor", () => {
+    const origin = entry({ path: "/origin", activity: "live" });
+    const builder = entry({ path: "/origin/a", parent: origin.path, kind: "subagent", activity: "live" });
+    const files = [origin, builder];
+    const reviewFlow = flow({
+      id: "flow-a",
+      implementerPath: builder.path,
+      rounds: Array.from({ length: 5 }, (_, index) => round(index + 1, null)),
+    });
+    const pipelineA = pipe({
+      id: "pa",
+      taskIds: ["task-a"],
+      stages: [
+        { id: "build", kind: "run", prompt: "", next: "review" },
+        { id: "review", kind: "review-loop", prompt: "", next: null },
+      ],
+      cursor: { stageId: "review", state: "reviewing", input: null, activatedBy: null },
+      runs: [
+        { stageId: "build", attempts: [{ n: 1, state: "passed", agentPath: builder.path, flowId: null }] },
+        { stageId: "review", attempts: [{ n: 1, state: "reviewing", agentPath: null, flowId: reviewFlow.id }] },
+      ],
+    });
+    const pipelineB = pipe({
+      id: "pb",
+      stages: [
+        { id: "build", kind: "run", prompt: "", next: "review" },
+        { id: "review", kind: "review-loop", prompt: "", next: null },
+      ],
+      cursor: { stageId: "build", state: "running", input: null, activatedBy: null },
+      runs: [{ stageId: "build", attempts: [{ n: 1, state: "running", agentPath: "/lost/b", flowId: null }] }],
+    });
+    const task = {
+      id: "task-a", project: "demo", status: "assigned", text: "Synchronize flow generation",
+      placement: "pinned", pos: { x: 9000, y: 9000 }, assignments: [],
+      createdAt: "2026-07-22T00:00:00Z", updatedAt: "2026-07-22T00:00:00Z",
+    } as unknown as BoardTask;
+    const layout = buildSchemeLayout(
+      buildBranchGroups(files, "demo"), [], files, [reviewFlow], [],
+      [pipelineA, pipelineB], [pipelineA, pipelineB], new Set(), new Set(), [task],
+    );
+
+    expect(layout.decks.find((candidate) => candidate.key === deckKey(reviewFlow.id))).toBeTruthy();
+    expect(layout.regionTasks.find((candidate) => candidate.taskId === task.id)?.pipelineId).toBe("pa");
+    expect(layout.slots.some((candidate) => candidate.pipeline.id === "pb")).toBe(true);
+    expectMembersContained(layout, "pa");
+    expectMembersContained(layout, "pb");
+    expectRegionsSeparated(layout);
+  });
+
   test("completed stages standing in as full cards keep neighboring regions disjoint", () => {
     /* Both pipelines finished build + review; the idle transcripts are not live
        nodes, so both stages stand in as completed cards — a two-card row under

--- a/src/lib/flows/engine.test.ts
+++ b/src/lib/flows/engine.test.ts
@@ -161,6 +161,48 @@ test("issue 532: a marker-created pipeline round captures its published repair h
   }
 });
 
+test("issue 532: a dirty marker-time checkout parks with an actionable decision", async () => {
+  const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "llv-flow-marker-dirty-"));
+  try {
+    expect(spawnSync("git", ["init", "-b", "main"], { cwd }).status).toBe(0);
+    expect(spawnSync("git", ["config", "user.email", "flow@example.com"], { cwd }).status).toBe(0);
+    expect(spawnSync("git", ["config", "user.name", "Flow Test"], { cwd }).status).toBe(0);
+    fs.writeFileSync(path.join(cwd, "work.txt"), "committed\n");
+    expect(spawnSync("git", ["add", "work.txt"], { cwd }).status).toBe(0);
+    expect(spawnSync("git", ["commit", "-m", "base"], { cwd }).status).toBe(0);
+    fs.writeFileSync(path.join(cwd, "work.txt"), "dirty\n");
+    const implementer = writeCodexEntry("marker-dirty-implementer.jsonl", {
+      id: ["069f421e", "02e1", "73e0", "9b77", "bebde063f529"].join("-"),
+      cwd,
+    }, Date.now() / 1_000);
+    fs.appendFileSync(implementer.path, `${JSON.stringify({
+      timestamp: new Date(Date.now() + 1_000).toISOString(),
+      type: "event_msg",
+      payload: { type: "task_complete", last_agent_message: "REVIEW_READY: dirty repair" },
+    })}\n`);
+    const stat = fs.statSync(implementer.path);
+    const current = { ...implementer, size: stat.size, mtime: stat.mtimeMs / 1_000 };
+    const flow = raceFlow({
+      id: "flow-marker-dirty",
+      cwd,
+      headRef: "main",
+      implementerPath: current.path,
+      state: "fixing",
+      rounds: [],
+      createdAt: "2026-07-21T00:00:00Z",
+    });
+
+    expect(await tickFlow(flow, [current], new Map([[current.path, current]]), () => {})).toBe(true);
+    expect(flow).toMatchObject({
+      state: "needs_decision",
+      stateDetail: "review requires a clean committed HEAD",
+      rounds: [{ n: 1, error: "review requires a clean committed HEAD" }],
+    });
+  } finally {
+    fs.rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
 test("a review round parks when clean HEAD advances past its synchronized target before launch (#522)", () => {
   const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-flow-target-head-"));
   try {

--- a/src/lib/flows/engine.test.ts
+++ b/src/lib/flows/engine.test.ts
@@ -114,6 +114,53 @@ test("issue 533: a repair review parks when its remote branch is behind the capt
   }
 });
 
+test("issue 532: a marker-created pipeline round captures its published repair head before spawning", async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "llv-flow-marker-head-"));
+  const cwd = path.join(root, "worktree");
+  const remote = path.join(root, "origin.git");
+  fs.mkdirSync(cwd);
+  try {
+    expect(spawnSync("git", ["init", "--bare", remote]).status).toBe(0);
+    expect(spawnSync("git", ["init", "-b", "main"], { cwd }).status).toBe(0);
+    expect(spawnSync("git", ["config", "user.email", "flow@example.com"], { cwd }).status).toBe(0);
+    expect(spawnSync("git", ["config", "user.name", "Flow Test"], { cwd }).status).toBe(0);
+    expect(spawnSync("git", ["remote", "add", "origin", remote], { cwd }).status).toBe(0);
+    fs.writeFileSync(path.join(cwd, "work.txt"), "repair\n");
+    expect(spawnSync("git", ["add", "work.txt"], { cwd }).status).toBe(0);
+    expect(spawnSync("git", ["commit", "-m", "repair"], { cwd }).status).toBe(0);
+    expect(spawnSync("git", ["push", "-u", "origin", "main"], { cwd }).status).toBe(0);
+    const repairHead = spawnSync("git", ["rev-parse", "HEAD"], { cwd, encoding: "utf8" }).stdout.trim();
+    const implementer = writeCodexEntry("marker-head-implementer.jsonl", {
+      id: ["059f421e", "02e1", "73e0", "9b77", "bebde063f529"].join("-"),
+      cwd,
+    }, Date.now() / 1_000);
+    fs.appendFileSync(implementer.path, `${JSON.stringify({
+      timestamp: new Date(Date.now() + 1_000).toISOString(),
+      type: "event_msg",
+      payload: { type: "task_complete", last_agent_message: "REVIEW_READY: published repair" },
+    })}\n`);
+    const stat = fs.statSync(implementer.path);
+    const current = { ...implementer, size: stat.size, mtime: stat.mtimeMs / 1_000 };
+    const flow = raceFlow({
+      id: "flow-marker-head",
+      cwd,
+      headRef: "main",
+      implementerPath: current.path,
+      state: "fixing",
+      rounds: [{ ...newRound(raceFlow({ rounds: [] }), "marker", null), n: 1, reviewedAt: "2026-07-22T00:00:00Z", relayedAt: "2026-07-22T00:01:00Z" }],
+      createdAt: "2026-07-21T00:00:00Z",
+    });
+
+    expect(await tickFlow(flow, [current], new Map([[current.path, current]]), () => {})).toBe(true);
+    expect(flow).toMatchObject({
+      state: "spawning",
+      rounds: [expect.anything(), { n: 2, triggeredBy: "marker", readyNote: "published repair", reviewHeadSha: repairHead }],
+    });
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
 test("a review round parks when clean HEAD advances past its synchronized target before launch (#522)", () => {
   const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-flow-target-head-"));
   try {

--- a/src/lib/flows/engine.ts
+++ b/src/lib/flows/engine.ts
@@ -711,7 +711,9 @@ export async function tickFlow(
         flow.state = flow.mode === "manual" ? "spawn_pending" : "spawning";
         flow.stateDetail = null;
       } catch (error) {
-        markerRound.error = error instanceof Error ? error.message : "review head capture failed";
+        const detail = error instanceof Error ? error.message : "review head capture failed";
+        markerRound.error = detail;
+        markNeedsDecision(flow, detail);
       }
     }
     return JSON.stringify(flow) !== before;

--- a/src/lib/flows/engine.ts
+++ b/src/lib/flows/engine.ts
@@ -973,7 +973,14 @@ export function persistTickFlows(flows: Flow[], base: Map<string, FlowTickBase>)
         ? { ...round, reviewerRole: diskRound.reviewerRole }
         : round;
     });
-    return { ...tick, rounds, roles: diskFlow.roles, roundLimit: diskFlow.roundLimit, mode: diskFlow.mode };
+    return {
+      ...tick,
+      revision: diskFlow.revision,
+      rounds,
+      roles: diskFlow.roles,
+      roundLimit: diskFlow.roundLimit,
+      mode: diskFlow.mode,
+    };
   });
   saveFlows(merged);
 }

--- a/src/lib/flows/engine.ts
+++ b/src/lib/flows/engine.ts
@@ -701,9 +701,18 @@ export async function tickFlow(
   if (flow.state === "waiting_ready" || flow.state === "fixing") {
     const note = detectReadyMarker(flow, implementer);
     if (note !== null) {
-      flow.rounds.push(newRound(flow, "marker", note));
-      flow.state = flow.mode === "manual" ? "spawn_pending" : "spawning";
-      flow.stateDetail = null;
+      const markerRound = newRound(flow, "marker", note);
+      flow.rounds.push(markerRound);
+      try {
+        /* Pipeline-owned flows carry headRef. Capture their clean published
+           repair fence in the same durable marker transition, before a delayed
+           reviewer launch or parent reconciliation can expose the prior HEAD. */
+        if (flow.headRef) captureReviewHead(flow, markerRound);
+        flow.state = flow.mode === "manual" ? "spawn_pending" : "spawning";
+        flow.stateDetail = null;
+      } catch (error) {
+        markerRound.error = error instanceof Error ? error.message : "review head capture failed";
+      }
     }
     return JSON.stringify(flow) !== before;
   }

--- a/src/lib/flows/store.test.ts
+++ b/src/lib/flows/store.test.ts
@@ -139,12 +139,65 @@ test("flow specs persist in the versioned state file and legacy flow entries loa
     fs.writeFileSync(path.join(sandbox, "flows.json"), JSON.stringify({ flows: [flow] }));
     expect(loadFlows()).toEqual([{
       ...flow,
+      revision: 0,
       targetSha: null,
       implementerConversationId: null,
       reviewerFallback: configuredReviewerFallback(),
       pausedState: null,
       kickoffDelivery: null,
     }]);
+  } finally {
+    if (previousState === undefined) delete process.env.LLV_STATE_DIR;
+    else process.env.LLV_STATE_DIR = previousState;
+    fs.rmSync(sandbox, { recursive: true, force: true });
+  }
+});
+
+test("flow persistence assigns a monotonic revision to binding-only generations", () => {
+  const previousState = process.env.LLV_STATE_DIR;
+  const sandbox = fs.mkdtempSync(path.join(os.tmpdir(), "llv-flow-revision-"));
+  process.env.LLV_STATE_DIR = sandbox;
+  const flow = {
+    id: "revision-flow",
+    template: "implement-review-loop",
+    project: "repo",
+    cwd: "/repo",
+    implementerPath: "/implementer.jsonl",
+    roles: { implementer: { engine: "codex" as const, model: null, effort: "high" }, reviewer: { engine: "codex" as const, model: null, effort: "xhigh" } },
+    baseRef: "base",
+    baseMode: "head" as const,
+    mode: "auto" as const,
+    reviewerMode: "headless" as const,
+    roundLimit: 5,
+    state: "reviewing" as const,
+    stateDetail: null,
+    rounds: [{
+      n: 1,
+      reviewerPath: "/reviewer-new.jsonl",
+      findingsPath: null,
+      triggeredBy: "marker" as const,
+      readyNote: null,
+      verdict: null,
+      findingsCount: null,
+      startedAt: "2026-07-22T10:00:00.000Z",
+      reviewedAt: null,
+      relayedAt: null,
+      error: null,
+    }],
+    createdAt: "2026-07-22T10:00:00.000Z",
+    closedAt: null,
+  } satisfies Flow;
+  try {
+    saveFlows([flow]);
+    const first = loadFlows()[0]!;
+    expect(first.revision).toBe(1);
+
+    first.rounds[0]!.reviewerPath = "/reviewer-next.jsonl";
+    saveFlows([first]);
+    expect(loadFlows()[0]).toMatchObject({
+      revision: 2,
+      rounds: [{ reviewerPath: "/reviewer-next.jsonl" }],
+    });
   } finally {
     if (previousState === undefined) delete process.env.LLV_STATE_DIR;
     else process.env.LLV_STATE_DIR = previousState;

--- a/src/lib/flows/store.test.ts
+++ b/src/lib/flows/store.test.ts
@@ -205,6 +205,58 @@ test("flow persistence assigns a monotonic revision to binding-only generations"
   }
 });
 
+test("a delayed stale flow writer cannot replace a newer lifecycle generation", () => {
+  const previousState = process.env.LLV_STATE_DIR;
+  const sandbox = fs.mkdtempSync(path.join(os.tmpdir(), "llv-flow-stale-writer-"));
+  process.env.LLV_STATE_DIR = sandbox;
+  try {
+    const flow = {
+      id: "stale-writer-flow",
+      template: "implement-review-loop",
+      project: "repo",
+      cwd: "/repo",
+      implementerPath: "/implementer.jsonl",
+      roles: { implementer: { engine: "codex" as const, model: null, effort: "high" }, reviewer: { engine: "codex" as const, model: null, effort: "xhigh" } },
+      baseRef: "base",
+      baseMode: "head" as const,
+      mode: "auto" as const,
+      reviewerMode: "headless" as const,
+      roundLimit: 5,
+      state: "reviewing" as const,
+      stateDetail: null,
+      rounds: [],
+      createdAt: "2026-07-22T10:00:00.000Z",
+      closedAt: null,
+    } satisfies Flow;
+    saveFlows([flow]);
+    const stale = structuredClone(loadFlows()[0]!);
+    const current = loadFlows()[0]!;
+    current.state = "needs_decision";
+    current.stateDetail = "review host was lost";
+    saveFlows([current]);
+    expect(loadFlows()[0]!.revision).toBe(2);
+
+    stale.state = "reviewing";
+    stale.stateDetail = null;
+    saveFlows([stale]);
+
+    expect(loadFlows()[0]).toMatchObject({
+      revision: 2,
+      state: "needs_decision",
+      stateDetail: "review host was lost",
+    });
+    expect(stale).toMatchObject({
+      revision: 2,
+      state: "needs_decision",
+      stateDetail: "review host was lost",
+    });
+  } finally {
+    if (previousState === undefined) delete process.env.LLV_STATE_DIR;
+    else process.env.LLV_STATE_DIR = previousState;
+    fs.rmSync(sandbox, { recursive: true, force: true });
+  }
+});
+
 test("flow bindings follow active conversation generations", () => {
   const previousState = process.env.LLV_STATE_DIR;
   const sandbox = fs.mkdtempSync(path.join(os.tmpdir(), "llv-flow-owner-"));

--- a/src/lib/flows/store.ts
+++ b/src/lib/flows/store.ts
@@ -318,10 +318,19 @@ function comparableFlow(flow: Flow): string {
   return JSON.stringify(content);
 }
 
+function replaceFlow(target: Flow, source: Flow): void {
+  for (const key of Object.keys(target)) delete (target as unknown as Record<string, unknown>)[key];
+  Object.assign(target, structuredClone(source));
+}
+
 function saveFlowsUnlocked(flows: Flow[]): void {
   const storedById = new Map(loadFlows().map((flow) => [flow.id, flow] as const));
   for (const flow of flows) {
     const stored = storedById.get(flow.id);
+    if (stored && flow.revision !== undefined && flow.revision < (stored.revision ?? 0)) {
+      replaceFlow(flow, stored);
+      continue;
+    }
     flow.revision = stored && comparableFlow(stored) === comparableFlow(flow)
       ? stored.revision ?? 0
       : (stored?.revision ?? 0) + 1;

--- a/src/lib/flows/store.ts
+++ b/src/lib/flows/store.ts
@@ -5,7 +5,7 @@ import path from "node:path";
 import { statePath } from "@/lib/configDir";
 import { agentRegistry, type ConversationLookup } from "@/lib/agent/registry";
 import { forEachCooperatively } from "@/lib/cooperative";
-import { withFileTransaction } from "@/lib/state/fileTransaction";
+import { withFileTransaction, withFileTransactionSync } from "@/lib/state/fileTransaction";
 import { ROLE_DEFAULTS } from "@/lib/roles/defaults";
 import { resolveRole } from "@/lib/roles/registry";
 import { loadRoleDefinitionsOrDefaults } from "@/lib/roles/store";
@@ -174,6 +174,7 @@ export function loadFlows(): Flow[] {
   const flows = Array.isArray(raw?.flows) ? raw.flows.filter(isFlow) : [];
   return flows.map((flow) => ({
     ...flow,
+    revision: flow.revision ?? 0,
     targetSha: flow.targetSha ?? null,
     implementerConversationId: flow.implementerConversationId ?? null,
     reviewerFallback: flow.reviewerFallback === undefined && flow.roles.reviewer.engine === "codex"
@@ -311,22 +312,39 @@ export async function reconcileFlowConversationOwnershipCooperatively(registry: 
   mergeFlowOwnershipPatches(patches);
 }
 
-export function saveFlows(flows: Flow[]): void {
+function comparableFlow(flow: Flow): string {
+  const content: Flow = { ...flow };
+  delete content.revision;
+  return JSON.stringify(content);
+}
+
+function saveFlowsUnlocked(flows: Flow[]): void {
+  const storedById = new Map(loadFlows().map((flow) => [flow.id, flow] as const));
+  for (const flow of flows) {
+    const stored = storedById.get(flow.id);
+    flow.revision = stored && comparableFlow(stored) === comparableFlow(flow)
+      ? stored.revision ?? 0
+      : (stored?.revision ?? 0) + 1;
+  }
   atomicWriteJson(flowsFile(), { schemaVersion: FLOWS_SCHEMA_VERSION, flows });
+}
+
+export function saveFlows(flows: Flow[]): void {
+  withFileTransactionSync(flowsFile(), "flow state is busy", () => saveFlowsUnlocked(flows));
 }
 
 /** Re-read and mutate flow state under the process-shared state-file lock. */
 export async function withFlowMutation<T>(mutate: (flows: Flow[], persist: () => void) => T): Promise<T> {
   return await withFileTransaction(flowsFile(), "flow state is busy", () => {
     const flows = loadFlows();
-    return mutate(flows, () => saveFlows(flows));
+    return mutate(flows, () => saveFlowsUnlocked(flows));
   });
 }
 
 /** Hold the flow registry lock while a cross-store consumer projects one exact
     durable generation. The callback cannot mutate flows through this interface. */
-export async function withFlowSnapshot<T>(read: (flows: readonly Flow[]) => Promise<T> | T): Promise<T> {
-  return await withFileTransaction(flowsFile(), "flow state is busy", () => read(loadFlows()));
+export function withFlowSnapshot<T>(read: (flows: readonly Flow[]) => T): T {
+  return withFileTransactionSync(flowsFile(), "flow state is busy", () => read(loadFlows()));
 }
 
 export function loadPresets(): FlowPreset[] {

--- a/src/lib/flows/store.ts
+++ b/src/lib/flows/store.ts
@@ -323,6 +323,12 @@ export async function withFlowMutation<T>(mutate: (flows: Flow[], persist: () =>
   });
 }
 
+/** Hold the flow registry lock while a cross-store consumer projects one exact
+    durable generation. The callback cannot mutate flows through this interface. */
+export async function withFlowSnapshot<T>(read: (flows: readonly Flow[]) => Promise<T> | T): Promise<T> {
+  return await withFileTransaction(flowsFile(), "flow state is busy", () => read(loadFlows()));
+}
+
 export function loadPresets(): FlowPreset[] {
   const raw = readJson(presetsFile()) as PresetFile | null;
   const presets = Array.isArray(raw?.presets) ? raw.presets.filter(isPreset) : [];

--- a/src/lib/flows/types.ts
+++ b/src/lib/flows/types.ts
@@ -118,6 +118,8 @@ export type Round = {
 
 export type Flow = {
   id: string;
+  /** Durable store generation used to fence stale cross-store projections. */
+  revision?: number;
   template: FlowTemplateId;
   project: string; // FileEntry.project of the implementer
   cwd: string; // implementer's working directory

--- a/src/lib/pipelines/engine.test.ts
+++ b/src/lib/pipelines/engine.test.ts
@@ -2454,6 +2454,16 @@ test("issue 532: a four-round embedded flow authoritatively repairs its stale pa
     reviewFlowSync: { roundCount: 5, relayState: "reviewing" },
   });
   expect((await tickPipelines([], h.ports)).changed).toBe(false);
+
+  const staleFlow = structuredClone(flow);
+  staleFlow.rounds = staleFlow.rounds.slice(0, 4);
+  expect(reconcileEmbeddedReviewFlows([loadPipelines()[0]!], [staleFlow], "2026-07-22T00:07:00.000Z")).toBe(false);
+  expect(loadPipelines()[0]!.runs[1]!.attempts[0]).toMatchObject({
+    agentPath: "/codex/reviewer-5.jsonl",
+    expectedReviewHeadSha: finalHead,
+    reviewHeadSha: finalHead,
+    reviewFlowSync: { roundCount: 5 },
+  });
 });
 
 test("issue 532: projection rebinds one flow-first partial write and refuses ambiguous candidates", async () => {

--- a/src/lib/pipelines/engine.test.ts
+++ b/src/lib/pipelines/engine.test.ts
@@ -2456,6 +2456,36 @@ test("issue 532: a four-round embedded flow authoritatively repairs its stale pa
   expect((await tickPipelines([], h.ports)).changed).toBe(false);
 });
 
+test("issue 532: projection rebinds one flow-first partial write and refuses ambiguous candidates", async () => {
+  const h = harness();
+  await create(h.ports, [
+    { id: "build", kind: "run", prompt: "build", next: "review" },
+    { id: "review", kind: "review-loop", role: { roleId: "reviewer" }, prompt: "review", next: null },
+  ] as never);
+  await tickPipelines([], h.ports);
+  await tickPipelines([], h.ports);
+  await tickPipelines([h.finish("/codex/stage-1.jsonl", "pass")], h.ports);
+  await tickPipelines([], h.ports);
+
+  const parent = loadPipelines()[0]!;
+  const attempt = parent.runs[1]!.attempts[0]!;
+  const flow = h.flows.get("flow-1")!;
+  attempt.flowId = null;
+  attempt.agentPath = null;
+  attempt.conversationId = null;
+
+  /* No scan entries and no runtime host: the files read owns recovery. */
+  expect(reconcileEmbeddedReviewFlows([parent], [flow], "2026-07-22T01:00:00.000Z")).toBe(true);
+  expect(attempt).toMatchObject({ flowId: flow.id, reviewFlowSync: { roundCount: 0 } });
+  expect(reconcileEmbeddedReviewFlows([parent], [flow], "2026-07-22T01:01:00.000Z")).toBe(false);
+
+  attempt.flowId = null;
+  attempt.reviewFlowSync = undefined;
+  const duplicate = { ...structuredClone(flow), id: "flow-duplicate" };
+  expect(reconcileEmbeddedReviewFlows([parent], [flow, duplicate], "2026-07-22T01:02:00.000Z")).toBe(false);
+  expect(attempt.flowId).toBeNull();
+});
+
 for (const terminalState of ["done_comment", "needs_decision"] as const) {
   test(`a later ${terminalState} outcome replaces stale startup evidence once across restart ticks (#526)`, async () => {
     const h = harness();

--- a/src/lib/pipelines/engine.test.ts
+++ b/src/lib/pipelines/engine.test.ts
@@ -2432,6 +2432,15 @@ test("issue 532: a four-round embedded flow authoritatively repairs its stale pa
   });
   expect(reconcileEmbeddedReviewFlows([parent], [flow], "2026-07-22T00:05:00.000Z")).toBe(false);
 
+  flow.revision = 2;
+  flow.rounds[3]!.reviewerPath = "/codex/reviewer-new.jsonl";
+  expect(reconcileEmbeddedReviewFlows([parent], [flow], "2026-07-22T00:05:30.000Z")).toBe(true);
+  const equalTimestampStaleFlow = structuredClone(flow);
+  equalTimestampStaleFlow.revision = 1;
+  equalTimestampStaleFlow.rounds[3]!.reviewerPath = "/codex/reviewer-old.jsonl";
+  expect(reconcileEmbeddedReviewFlows([parent], [equalTimestampStaleFlow], "2026-07-22T00:05:31.000Z")).toBe(false);
+  expect(reviewAttempt.agentPath).toBe("/codex/reviewer-new.jsonl");
+
   /* Model the partial-write crash: flows.json advances with a delayed final
      marker while pipelines.json still contains generation four. A fresh
      controller has no scan entries or runtime host and must converge once. */
@@ -2445,6 +2454,7 @@ test("issue 532: a four-round embedded flow authoritatively repairs its stale pa
     verdict: null,
     startedAt: "2026-07-22T00:06:00.000Z",
   } as never);
+  flow.revision = 3;
   expect((await tickPipelines([], h.ports)).changed).toBe(true);
   const recovered = loadPipelines()[0]!.runs[1]!.attempts[0]!;
   expect(recovered).toMatchObject({

--- a/src/lib/pipelines/engine.test.ts
+++ b/src/lib/pipelines/engine.test.ts
@@ -11,7 +11,7 @@ import type { AgentRegistry as AgentRegistryType } from "@/lib/agent/registry";
 
 process.env.LLV_STATE_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "llv-pipeline-engine-"));
 const engineModule = await import("./engine");
-const { adoptAttempt, defaultPipelinePorts, ensureTaskPipelineForAssignment, patchPipeline, pipelineAttemptTargetForSource, pipelineClaudePermissionMode, reviewNote, tickPipelines } = engineModule;
+const { adoptAttempt, defaultPipelinePorts, ensureTaskPipelineForAssignment, patchPipeline, pipelineAttemptTargetForSource, pipelineClaudePermissionMode, reconcileEmbeddedReviewFlows, reviewNote, tickPipelines } = engineModule;
 const { AgentRegistry, setAgentRegistryForTests } = await import("@/lib/agent/registry");
 const { newRound } = await import("@/lib/flows/engine");
 const rawCreatePipelineFromRequest = engineModule.createPipelineFromRequest;
@@ -2381,6 +2381,79 @@ test("REQUEST_CHANGES recovery keeps the bound reviewer in the review slot and l
     agentPath: "/codex/reviewer.jsonl",
     conversationId: "conversation_reviewer",
   });
+});
+
+test("issue 532: a four-round embedded flow authoritatively repairs its stale parent once", async () => {
+  const h = harness();
+  await create(h.ports, [
+    { id: "build", kind: "run", prompt: "build", next: "review" },
+    { id: "review", kind: "review-loop", role: { roleId: "reviewer" }, prompt: "review", next: null },
+  ] as never);
+  await tickPipelines([], h.ports);
+  await tickPipelines([], h.ports);
+  await tickPipelines([h.finish("/codex/stage-1.jsonl", "pass")], h.ports);
+  await tickPipelines([entry("/codex/stage-1.jsonl")], h.ports);
+
+  const flow = h.flows.get("flow-1")!;
+  const heads = ["1", "2", "3", "4"].map((digit) => digit.repeat(40));
+  flow.rounds = heads.map((reviewHeadSha, index) => ({
+    n: index + 1,
+    reviewerPath: `/codex/reviewer-${index + 1}.jsonl`,
+    reviewerConversationId: `conversation_reviewer_${index + 1}`,
+    reviewHeadSha,
+    verdict: index < 3 ? "REQUEST_CHANGES" : null,
+    reviewedAt: index < 3 ? `2026-07-22T00:0${index}:00.000Z` : null,
+    relayedAt: index < 3 ? `2026-07-22T00:0${index}:30.000Z` : null,
+  } as never));
+  flow.state = "reviewing";
+
+  const parent = loadPipelines()[0]!;
+  const reviewAttempt = parent.runs[1]!.attempts[0]!;
+  reviewAttempt.agentPath = "/codex/reviewer-2.jsonl";
+  reviewAttempt.conversationId = "conversation_reviewer_2";
+  reviewAttempt.expectedReviewHeadSha = heads[1]!;
+  reviewAttempt.reviewHeadSha = heads[1]!;
+
+  expect(reconcileEmbeddedReviewFlows([parent], [flow], "2026-07-22T00:04:00.000Z")).toBe(true);
+  expect(reviewAttempt).toMatchObject({
+    agentPath: "/codex/reviewer-4.jsonl",
+    conversationId: "conversation_reviewer_4",
+    expectedReviewHeadSha: heads[3],
+    reviewHeadSha: heads[3],
+    reviewFlowSync: {
+      roundCount: 4,
+      implementerHeadSha: heads[3],
+      reviewerHeadSha: heads[3],
+      verdict: null,
+      relayState: "reviewing",
+      terminalState: null,
+      synchronizedAt: "2026-07-22T00:04:00.000Z",
+    },
+  });
+  expect(reconcileEmbeddedReviewFlows([parent], [flow], "2026-07-22T00:05:00.000Z")).toBe(false);
+
+  /* Model the partial-write crash: flows.json advances with a delayed final
+     marker while pipelines.json still contains generation four. A fresh
+     controller has no scan entries or runtime host and must converge once. */
+  savePipelines([parent]);
+  const finalHead = "5".repeat(40);
+  flow.rounds.push({
+    n: 5,
+    reviewerPath: "/codex/reviewer-5.jsonl",
+    reviewerConversationId: "conversation_reviewer_5",
+    reviewHeadSha: finalHead,
+    verdict: null,
+    startedAt: "2026-07-22T00:06:00.000Z",
+  } as never);
+  expect((await tickPipelines([], h.ports)).changed).toBe(true);
+  const recovered = loadPipelines()[0]!.runs[1]!.attempts[0]!;
+  expect(recovered).toMatchObject({
+    agentPath: "/codex/reviewer-5.jsonl",
+    expectedReviewHeadSha: finalHead,
+    reviewHeadSha: finalHead,
+    reviewFlowSync: { roundCount: 5, relayState: "reviewing" },
+  });
+  expect((await tickPipelines([], h.ports)).changed).toBe(false);
 });
 
 for (const terminalState of ["done_comment", "needs_decision"] as const) {

--- a/src/lib/pipelines/engine.ts
+++ b/src/lib/pipelines/engine.ts
@@ -745,6 +745,15 @@ function synchronizeReviewFlowAttempt(attempt: PipelineStageAttempt, flow: Flow,
     })),
   })).digest("hex").slice(0, 16);
   if (attempt.reviewFlowSync?.generation === generation) return false;
+  const synchronized = attempt.reviewFlowSync;
+  if (synchronized) {
+    if (snapshot.roundCount < synchronized.roundCount) return false;
+    const synchronizedSourceMs = synchronized.sourceUpdatedAt ? Date.parse(synchronized.sourceUpdatedAt) : Number.NaN;
+    if (snapshot.roundCount === synchronized.roundCount
+      && Number.isFinite(sourceMs)
+      && Number.isFinite(synchronizedSourceMs)
+      && sourceMs < synchronizedSourceMs) return false;
+  }
   attachReviewFlowAttempt(attempt, flow);
   if (reviewerHeadSha) {
     attempt.expectedReviewHeadSha = reviewerHeadSha;

--- a/src/lib/pipelines/engine.ts
+++ b/src/lib/pipelines/engine.ts
@@ -718,6 +718,7 @@ function synchronizeReviewFlowAttempt(attempt: PipelineStageAttempt, flow: Flow,
   const sourceMs = sourceUpdatedAt ? Date.parse(sourceUpdatedAt) : Number.NaN;
   const syncMs = Date.parse(synchronizedAt);
   const snapshot = {
+    sourceRevision: flow.revision ?? 0,
     roundCount: flow.rounds.length,
     implementerHeadSha,
     reviewerHeadSha,
@@ -747,6 +748,8 @@ function synchronizeReviewFlowAttempt(attempt: PipelineStageAttempt, flow: Flow,
   if (attempt.reviewFlowSync?.generation === generation) return false;
   const synchronized = attempt.reviewFlowSync;
   if (synchronized) {
+    const synchronizedRevision = synchronized.sourceRevision ?? 0;
+    if (synchronizedRevision > 0 && snapshot.sourceRevision <= synchronizedRevision) return false;
     if (snapshot.roundCount < synchronized.roundCount) return false;
     const synchronizedSourceMs = synchronized.sourceUpdatedAt ? Date.parse(synchronized.sourceUpdatedAt) : Number.NaN;
     if (snapshot.roundCount === synchronized.roundCount

--- a/src/lib/pipelines/engine.ts
+++ b/src/lib/pipelines/engine.ts
@@ -767,8 +767,33 @@ export function reconcileEmbeddedReviewFlows(
   synchronizedAt = new Date().toISOString(),
 ): boolean {
   const byId = new Map(flows.map((flow) => [flow.id, flow] as const));
+  const claimedFlowIds = new Set(pipelines.flatMap((pipeline) =>
+    pipeline.runs.flatMap((run) => run.attempts.flatMap((attempt) => attempt.flowId ? [attempt.flowId] : []))));
   let changed = false;
   for (const pipeline of pipelines) {
+    /* Flow creation commits before the parent can persist flowId. Recover that
+       flow-first crash only from the same unique identity used at creation;
+       ambiguity fails closed so projection cannot claim a foreign flow. */
+    for (const stage of pipeline.stages) {
+      if (stage.kind !== "review-loop") continue;
+      const attempt = currentAttempt(pipeline, stage.id);
+      if (!attempt || attempt.flowId || !attempt.expectedReviewHeadSha) continue;
+      const implementer = latestPassedRun(pipeline, stage.id);
+      if (!implementer?.agentPath) continue;
+      const candidates = flows.filter((flow) =>
+        !claimedFlowIds.has(flow.id)
+        && flow.baseRef === pipeline.baseRef
+        && flow.targetSha === attempt.expectedReviewHeadSha
+        && flow.closedAt === null
+        && flow.state !== "closed"
+        && (flow.implementerPath === implementer.agentPath
+          || Boolean(implementer.conversationId && flow.implementerConversationId === implementer.conversationId)));
+      if (candidates.length === 1) {
+        attempt.flowId = candidates[0]!.id;
+        claimedFlowIds.add(candidates[0]!.id);
+        changed = true;
+      }
+    }
     for (const run of pipeline.runs) {
       for (const attempt of run.attempts) {
         const flow = attempt.flowId ? byId.get(attempt.flowId) : null;

--- a/src/lib/pipelines/engine.ts
+++ b/src/lib/pipelines/engine.ts
@@ -696,6 +696,89 @@ function attachReviewFlowAttempt(attempt: PipelineStageAttempt, flow: Flow): voi
   attempt.paneId = round?.reviewerPane?.paneId ?? attempt.paneId;
 }
 
+const TERMINAL_REVIEW_FLOW_STATES: ReadonlySet<Flow["state"]> = new Set([
+  "approved", "done_comment", "needs_decision", "closed",
+]);
+
+function flowSourceUpdatedAt(flow: Flow): string | null {
+  const values = [flow.createdAt, flow.closedAt];
+  for (const round of flow.rounds) {
+    values.push(round.startedAt, round.spawnStartedAt ?? null, round.reviewedAt, round.relayStartedAt ?? null,
+      round.relayedAt, round.terminalAt ?? null);
+  }
+  return values.filter((value): value is string => Boolean(value))
+    .sort((left, right) => right.localeCompare(left))[0] ?? null;
+}
+
+function synchronizeReviewFlowAttempt(attempt: PipelineStageAttempt, flow: Flow, synchronizedAt: string): boolean {
+  const round = flow.rounds.at(-1) ?? null;
+  const implementerHeadSha = flow.rounds.findLast((candidate) => candidate.reviewHeadSha)?.reviewHeadSha ?? flow.targetSha ?? null;
+  const reviewerHeadSha = round?.reviewHeadSha ?? null;
+  const sourceUpdatedAt = flowSourceUpdatedAt(flow);
+  const sourceMs = sourceUpdatedAt ? Date.parse(sourceUpdatedAt) : Number.NaN;
+  const syncMs = Date.parse(synchronizedAt);
+  const snapshot = {
+    roundCount: flow.rounds.length,
+    implementerHeadSha,
+    reviewerHeadSha,
+    verdict: round?.verdict ?? null,
+    relayState: flow.state,
+    terminalState: TERMINAL_REVIEW_FLOW_STATES.has(flow.state) ? flow.state : null,
+    sourceUpdatedAt,
+  };
+  const generation = crypto.createHash("sha256").update(JSON.stringify({
+    ...snapshot,
+    stateDetail: flow.stateDetail,
+    implementerPath: flow.implementerPath,
+    implementerConversationId: flow.implementerConversationId ?? null,
+    rounds: flow.rounds.map((candidate) => ({
+      n: candidate.n,
+      reviewerPath: candidate.reviewerPath,
+      reviewerConversationId: candidate.reviewerConversationId ?? null,
+      reviewHeadSha: candidate.reviewHeadSha ?? null,
+      verdict: candidate.verdict,
+      reviewedAt: candidate.reviewedAt,
+      relayStartedAt: candidate.relayStartedAt ?? null,
+      relayedAt: candidate.relayedAt,
+      terminalAt: candidate.terminalAt ?? null,
+      error: candidate.error,
+    })),
+  })).digest("hex").slice(0, 16);
+  if (attempt.reviewFlowSync?.generation === generation) return false;
+  attachReviewFlowAttempt(attempt, flow);
+  if (reviewerHeadSha) {
+    attempt.expectedReviewHeadSha = reviewerHeadSha;
+    attempt.reviewHeadSha = reviewerHeadSha;
+  }
+  attempt.reviewFlowSync = {
+    generation,
+    ...snapshot,
+    synchronizedAt,
+    lagMs: Number.isFinite(sourceMs) && Number.isFinite(syncMs) ? Math.max(0, syncMs - sourceMs) : null,
+  };
+  return true;
+}
+
+/** Apply the embedded flow's current durable generation to every bound parent.
+    Shared by controller recovery and the board read path. */
+export function reconcileEmbeddedReviewFlows(
+  pipelines: Pipeline[],
+  flows: readonly Flow[],
+  synchronizedAt = new Date().toISOString(),
+): boolean {
+  const byId = new Map(flows.map((flow) => [flow.id, flow] as const));
+  let changed = false;
+  for (const pipeline of pipelines) {
+    for (const run of pipeline.runs) {
+      for (const attempt of run.attempts) {
+        const flow = attempt.flowId ? byId.get(attempt.flowId) : null;
+        if (flow) changed = synchronizeReviewFlowAttempt(attempt, flow, synchronizedAt) || changed;
+      }
+    }
+  }
+  return changed;
+}
+
 /** Advance along the pass edge, persisting the relay record: the completed
     attempt's output is the next activation's `{{prev.output}}`, written in the
     same mutation as the verdict/commit that produced it (exactly-once, #353). */
@@ -1302,9 +1385,20 @@ function reconcileBoundReviewFlow(pipeline: Pipeline, ports: PipelinePorts): boo
   pipeline.stateDetail = null;
   attempt.state = "reviewing";
   attempt.error = null;
-  attachReviewFlowAttempt(attempt, flow);
+  synchronizeReviewFlowAttempt(attempt, flow, ports.now());
   setCursorState(pipeline, stage.id, "reviewing");
   return true;
+}
+
+function reconcilePipelineEmbeddedFlows(pipeline: Pipeline, ports: PipelinePorts): boolean {
+  let changed = false;
+  for (const run of pipeline.runs) {
+    for (const attempt of run.attempts) {
+      const flow = attempt.flowId ? ports.getFlow(attempt.flowId) : null;
+      if (flow) changed = synchronizeReviewFlowAttempt(attempt, flow, ports.now()) || changed;
+    }
+  }
+  return changed;
 }
 
 function reconcileParkedStructuredSpawn(pipeline: Pipeline, ports: PipelinePorts): boolean {
@@ -1346,7 +1440,8 @@ export async function tickPipelines(entries: FileEntry[], ports: PipelinePorts =
     const result = await withPipelineMutation(async (pipelines, persist) => {
       let changed = false;
       for (const pipeline of pipelines) {
-        let pipelineChanged = reconcilePendingPipelineAdoptions(pipeline, ports);
+        let pipelineChanged = reconcilePipelineEmbeddedFlows(pipeline, ports);
+        pipelineChanged = reconcilePendingPipelineAdoptions(pipeline, ports) || pipelineChanged;
         pipelineChanged = await reconcileHistoricalAttempts(pipeline, entries, ports) || pipelineChanged;
         pipelineChanged = rebindPipelineAttemptPaths(pipeline, ports) || pipelineChanged;
         pipelineChanged = reconcileParkedStructuredSpawn(pipeline, ports) || pipelineChanged;

--- a/src/lib/pipelines/store.ts
+++ b/src/lib/pipelines/store.ts
@@ -68,6 +68,23 @@ function isVerdict(value: unknown): boolean {
   return value === null || stageVerdictFrom(value) !== null;
 }
 
+function isReviewFlowSync(value: unknown): boolean {
+  if (value === undefined) return true;
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  const sync = value as Record<string, unknown>;
+  const flowStates = ["waiting_ready", "spawn_pending", "spawning", "reviewing", "relay_pending", "relaying", "fixing", "approved", "done_comment", "needs_decision", "paused", "closed"];
+  return typeof sync.generation === "string"
+    && Number.isInteger(sync.roundCount) && (sync.roundCount as number) >= 0
+    && isNullableString(sync.implementerHeadSha)
+    && isNullableString(sync.reviewerHeadSha)
+    && (sync.verdict === null || ["APPROVE", "REQUEST_CHANGES", "COMMENT"].includes(String(sync.verdict)))
+    && flowStates.includes(String(sync.relayState))
+    && (sync.terminalState === null || flowStates.includes(String(sync.terminalState)))
+    && typeof sync.synchronizedAt === "string"
+    && isNullableString(sync.sourceUpdatedAt)
+    && (sync.lagMs === null || (typeof sync.lagMs === "number" && Number.isFinite(sync.lagMs) && sync.lagMs >= 0));
+}
+
 function isActivation(value: unknown): value is PipelineEdgeActivation | null {
   if (value === null || value === undefined) return true;
   if (!value || typeof value !== "object" || Array.isArray(value)) return false;
@@ -96,6 +113,7 @@ function isAttempt(value: unknown, index: number): boolean {
     isNullableString(attempt.flowId) &&
     (attempt.expectedReviewHeadSha === undefined || isNullableString(attempt.expectedReviewHeadSha)) &&
     (attempt.reviewHeadSha === undefined || isNullableString(attempt.reviewHeadSha)) &&
+    isReviewFlowSync(attempt.reviewFlowSync) &&
     isNullableString(attempt.startedAt) &&
     isNullableString(attempt.completedAt) &&
     (attempt.input === undefined || isNullableString(attempt.input)) &&
@@ -391,6 +409,7 @@ export function loadPipelines(): Pipeline[] {
             flowId: attempt.flowId ?? null,
             expectedReviewHeadSha: attempt.expectedReviewHeadSha ?? null,
             reviewHeadSha: attempt.reviewHeadSha ?? null,
+            reviewFlowSync: attempt.reviewFlowSync ? { ...attempt.reviewFlowSync } : undefined,
             startedAt: attempt.startedAt ?? null,
             completedAt: attempt.completedAt ?? null,
             input: attempt.input ?? null,

--- a/src/lib/pipelines/store.ts
+++ b/src/lib/pipelines/store.ts
@@ -74,6 +74,7 @@ function isReviewFlowSync(value: unknown): boolean {
   const sync = value as Record<string, unknown>;
   const flowStates = ["waiting_ready", "spawn_pending", "spawning", "reviewing", "relay_pending", "relaying", "fixing", "approved", "done_comment", "needs_decision", "paused", "closed"];
   return typeof sync.generation === "string"
+    && (sync.sourceRevision === undefined || (Number.isInteger(sync.sourceRevision) && (sync.sourceRevision as number) >= 0))
     && Number.isInteger(sync.roundCount) && (sync.roundCount as number) >= 0
     && isNullableString(sync.implementerHeadSha)
     && isNullableString(sync.reviewerHeadSha)

--- a/src/lib/pipelines/types.ts
+++ b/src/lib/pipelines/types.ts
@@ -124,6 +124,21 @@ export type PipelineStageAttempt = {
   expectedReviewHeadSha?: string | null;
   /** Exact clean SHA captured by the first launched reviewer round. */
   reviewHeadSha?: string | null;
+  /** Authoritative projection of the embedded flow. The generation is a
+      content digest, so reconciliation remains idempotent across processes and
+      independently committed flow/pipeline writes. */
+  reviewFlowSync?: {
+    generation: string;
+    roundCount: number;
+    implementerHeadSha: string | null;
+    reviewerHeadSha: string | null;
+    verdict: import("@/lib/flows/types").ReviewVerdict | null;
+    relayState: import("@/lib/flows/types").FlowState;
+    terminalState: import("@/lib/flows/types").FlowState | null;
+    synchronizedAt: string;
+    sourceUpdatedAt: string | null;
+    lagMs: number | null;
+  };
   startedAt: string | null;
   completedAt: string | null;
   /** Exactly-once relay (#353): the `{{prev.output}}` payload persisted when the

--- a/src/lib/pipelines/types.ts
+++ b/src/lib/pipelines/types.ts
@@ -129,6 +129,7 @@ export type PipelineStageAttempt = {
       independently committed flow/pipeline writes. */
   reviewFlowSync?: {
     generation: string;
+    sourceRevision?: number;
     roundCount: number;
     implementerHeadSha: string | null;
     reviewerHeadSha: string | null;


### PR DESCRIPTION
## Summary

- derive one authoritative content-addressed synchronization snapshot from each embedded review flow
- persist round count, implementer and reviewer HEAD fences, verdict, relay and terminal state, plus lag diagnostics on the parent review attempt
- reconcile stale parents during controller recovery and before files-response board projection
- cover four repair rounds, a delayed final marker, partial store persistence, controller restart, runtime-host absence, and repeated reconciliation

## Gates

- focused pipeline synchronization and #526/#533 regression tests
- pipeline store tests
- focused files-response recovery tests
- #531 pipeline-region geometry and DOM tests
- TypeScript
- changed-file ESLint
- production build
- privacy publication gate
- git diff --check

Fixes #532
