### PR TITLE
ux(feed): compact MCP receipt card and drop noise labels

### DIFF
--- a/src/components/feed/cards/OrchestrationCard.tsx
+++ b/src/components/feed/cards/OrchestrationCard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { ChevronRight, GlyphIcon } from "../../icons";
+import { GlyphIcon } from "../../icons";
 import { tr, type NestedCall, type Orchestration } from "../parse";
 
 /* One inner operation of a functions.exec record: its icon and target/command
@@ -18,32 +18,19 @@ function NestedRow({ call }: { call: NestedCall }) {
 }
 
 /** The structured detail of a `functions.exec` orchestration record: the nested
-    calls (level 1) and the full JavaScript source (level 2). Both live flat on
-    the parent's sunken well — a small stream label plus a hairline separator
-    stand in for the old nested borders. */
-export function OrchestrationCard({ orchestration, source }: { orchestration: Orchestration; source?: string }) {
+    calls, flat on the parent's sunken well. The raw JavaScript source disclosure
+    was dropped in the compact-feed pass — the parsed rows already carry the
+    meaning, and the "source" toggle was noise the operator never opens. */
+export function OrchestrationCard({ orchestration }: { orchestration: Orchestration; source?: string }) {
+  if (!orchestration.calls.length) return null;
   return (
     <div className="mt-1.5 space-y-1.5">
-      {orchestration.calls.length ? (
-        <div>
-          <div className="mb-0.5 text-[10.5px] font-semibold uppercase tracking-wide text-muted">{tr("tools.nestedCalls")}</div>
-          {orchestration.calls.map((call, i) => (
-            <NestedRow key={`${call.id}:${i}`} call={call} />
-          ))}
-        </div>
-      ) : null}
-      {orchestration.source.trim() || source?.trim() ? (
-        <details className="group/src">
-          <summary className="inline-flex cursor-pointer list-none items-center gap-1 text-[11px] font-semibold text-muted hover:text-accent [&::-webkit-details-marker]:hidden">
-            <ChevronRight className="h-3 w-3 transition-transform group-open/src:rotate-90" aria-hidden />
-            {tr("tools.source")}
-          </summary>
-          <pre className="mt-1 max-h-[300px] max-w-full overflow-auto whitespace-pre-wrap [overflow-wrap:anywhere] border-t border-border pt-1.5 font-mono text-[11px]">
-            {orchestration.source || source}
-            {orchestration.sourceTruncated ? "\n…" : ""}
-          </pre>
-        </details>
-      ) : null}
+      <div>
+        <div className="mb-0.5 text-[10.5px] font-semibold uppercase tracking-wide text-muted">{tr("tools.nestedCalls")}</div>
+        {orchestration.calls.map((call, i) => (
+          <NestedRow key={`${call.id}:${i}`} call={call} />
+        ))}
+      </div>
     </div>
   );
 }

--- a/src/components/feed/cards/OutputPreview.tsx
+++ b/src/components/feed/cards/OutputPreview.tsx
@@ -23,8 +23,6 @@ export function OutputPreview({
   copyLabel,
   heading,
   tone = "out",
-  emptyLabel,
-  emptyTip,
   showAllLabel,
 }: {
   output: string;
@@ -35,24 +33,15 @@ export function OutputPreview({
   heading?: string;
   /** `err` tints the block and heading for the stderr stream. */
   tone?: "out" | "err";
-  emptyLabel?: string;
-  emptyTip?: string;
   showAllLabel?: string;
 }) {
   const [all, setAll] = useState(false);
   const label = heading ? (
     <div className={`mb-0.5 text-[10.5px] font-semibold uppercase tracking-wide ${tone === "err" ? "text-danger" : "text-muted"}`}>{heading}</div>
   ) : null;
-  if (!output.trim()) {
-    return (
-      <div className="mt-1.5">
-        {label}
-        <span className="text-[11px] text-muted" title={emptyTip ?? tr("tools.noOutputTip")}>
-          {emptyLabel ?? tr("tools.noOutput")}
-        </span>
-      </div>
-    );
-  }
+  /* Absent output renders nothing at all: an "no output captured" apology row
+     is pure noise the operator scrolls past (compact-feed pass). */
+  if (!output.trim()) return null;
   const lines = output.split("\n");
   const overflow = lines.length > PREVIEW_LINES || output.length > PREVIEW_CHARS;
   const shown = all ? output : lines.slice(0, PREVIEW_LINES).join("\n").slice(0, PREVIEW_CHARS);

--- a/src/components/feed/cards/ToolCard.tsx
+++ b/src/components/feed/cards/ToolCard.tsx
@@ -2,15 +2,12 @@
 
 import { useState } from "react";
 
-import { debugRaw } from "@/lib/review";
-
 import { AlarmClock, GlyphIcon } from "../../icons";
 import { hhmm } from "../../utils";
 import { CopyButton } from "../CopyButton";
 import { tr, type ToolEvent } from "../parse";
 import type { ArgChip } from "../tools";
-import { formatDuration, isCollapsiblePoll, isFollowUpCall } from "../toolBlocks";
-import { useRawLine } from "../rawLine";
+import { formatDuration, isFollowUpCall } from "../toolBlocks";
 import { DiffCard } from "./DiffCard";
 import { OrchestrationCard } from "./OrchestrationCard";
 import { OutputPreview } from "./OutputPreview";
@@ -102,41 +99,6 @@ function CommandBlock({ command }: { command: string }) {
   );
 }
 
-/* Level-2 provenance: the redacted raw source line(s) resolved lazily and
-   client-side from the retained window. Slid out of the window → a quiet chip.
-   The call id is exposed for diagnosis and copy. */
-function RawRecord({ event }: { event: ToolEvent }) {
-  const getRaw = useRawLine();
-  const [open, setOpen] = useState(false);
-  if (!open) {
-    return (
-      <button
-        type="button"
-        onClick={() => setOpen(true)}
-        className="mt-1.5 text-[11px] font-semibold text-muted hover:text-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40"
-      >
-        {tr("tools.rawRecord")}
-      </button>
-    );
-  }
-  const indices = [event.srcCall, event.srcResult].filter((n): n is number => typeof n === "number");
-  const raw = indices.map((n) => getRaw(n)).filter((line): line is string => line !== null);
-  const record = raw.length ? debugRaw(raw.join("\n")).raw : "";
-  return (
-    <div className="mt-1.5">
-      <div className="mb-1 flex items-center gap-2 text-[10.5px] text-muted">
-        <span className="font-mono">{tr("tools.callId", { id: event.id })}</span>
-        <CopyButton text={event.id} label={tr("tools.copyId")} className="p-0.5" />
-      </div>
-      {record ? (
-        <pre className="max-h-[300px] max-w-full overflow-auto whitespace-pre-wrap [overflow-wrap:anywhere] border-t border-border pt-1.5 font-mono text-[11px]">{record}</pre>
-      ) : (
-        <span className="text-[11px] text-muted">{tr("tools.noRawRecord")}</span>
-      )}
-    </div>
-  );
-}
-
 /* The expanded readable body of a tool call (issue #475): chips, the auditable
    command header, structured diff/orchestration, and separate stdout/stderr
    disclosures. Mounted lazily by {@link ToolLine} on first expand, so a long
@@ -148,7 +110,6 @@ export function ToolBody({ event }: { event: ToolEvent }) {
      source disclosure. Meaningful stdin keeps that bounded redacted provenance
      even when the result body is empty (issue #502). */
   const emptyFollowUp = isFollowUpCall(event) && !event.outputPreview.trim() && event.stderr === undefined && event.status !== "err";
-  const emptyPoll = isCollapsiblePoll(event);
   const showOutput = !emptyFollowUp && (!hasDiff || Boolean(event.outputPreview.trim()));
   return (
     <div className="mb-1 mt-1 rounded-surface bg-sunken px-2.5 py-2">
@@ -173,10 +134,8 @@ export function ToolBody({ event }: { event: ToolEvent }) {
           tone="err"
           copyLabel={tr("tools.copyStderr")}
           showAllLabel={tr("tools.showStderr")}
-          emptyLabel={tr("tools.noStderr")}
         />
       ) : null}
-      {emptyPoll ? null : <RawRecord event={event} />}
     </div>
   );
 }

--- a/src/components/feed/cards/readableTool.dom.test.tsx
+++ b/src/components/feed/cards/readableTool.dom.test.tsx
@@ -153,15 +153,14 @@ test("a poll-dominated run collapses its empty polls into one counted row", () =
   expect(firstBlock.textContent).toContain("30s");
   // No empty "no output captured" apology chip survives from the polls/keystroke.
   expect(host.textContent).not.toContain(en("tools.noOutput"));
-  // The parent and meaningful keystroke retain provenance; the 6 empty polls
-  // contribute no raw-record toggles.
+  // The raw-record noise toggle is gone from every call (compact-feed pass).
   const rawToggles = [...host.querySelectorAll("button")].filter((b) => (b.textContent ?? "") === en("tools.rawRecord"));
-  expect(rawToggles).toHaveLength(2);
+  expect(rawToggles).toHaveLength(0);
   // The trailing keystroke write_stdin stays readable.
   expect(host.textContent).toContain("y⏎");
 });
 
-test("meaningful empty-output stdin retains complete redacted raw provenance", () => {
+test("meaningful empty-output stdin renders without a raw-record toggle", () => {
   const tail = "final-provenance-suffix";
   const sensitiveKey = String.fromCharCode(112, 97, 115, 115, 119, 111, 114, 100);
   const privateMarker = "REDACTION_VALUE_MARKER";
@@ -188,11 +187,10 @@ test("meaningful empty-output stdin retains complete redacted raw provenance", (
     </RawLineProvider>,
   );
   expect(event.summary).not.toContain(tail);
+  // The raw-record disclosure is gone (compact-feed pass); no secret material
+  // reaches the DOM through the removed provenance path.
   const provenance = [...host.querySelectorAll("button")].find((button) => button.textContent === en("tools.rawRecord"));
-  expect(provenance).toBeTruthy();
-  flushSync(() => provenance!.click());
-  expect(host.textContent).toContain(tail);
-  expect(host.textContent).toContain(`${sensitiveKey}=[redacted]`);
+  expect(provenance).toBeUndefined();
   expect(host.textContent).not.toContain(privateMarker);
 });
 

--- a/src/components/feed/cards/toolCards.render.test.tsx
+++ b/src/components/feed/cards/toolCards.render.test.tsx
@@ -50,13 +50,12 @@ test("a non-ok tool row surfaces its status label even when collapsed", () => {
   expect(html).toContain("text-danger");
 });
 
-test("an auto-opened error row mounts its body and shows the compact no-output chip", () => {
+test("an auto-opened error row mounts its body without empty-output noise", () => {
   const html = renderToStaticMarkup(<ToolCard event={toolEvent({ status: "err", statusLabel: "exit 1", open: true, outputPreview: "" })} />);
-  expect(html).toContain(en("tools.noOutput"));
-  expect(html).toContain(en("tools.noOutputTip"));
-  // No leftover apology prose.
+  // Absent output renders nothing: no apology chip, no raw-record toggle (compact-feed pass).
+  expect(html).not.toContain(en("tools.noOutput"));
   expect(html).not.toContain("rollout session in the left list");
-  expect(html).toContain(en("tools.rawRecord"));
+  expect(html).not.toContain(en("tools.rawRecord"));
 });
 
 test("the summary row is a native <summary> and every icon is aria-hidden", () => {
@@ -197,10 +196,10 @@ test("a cmd-group carrying an error opens and mounts the failing child's full bo
   // The failing line is danger and never silenced.
   expect(html).toContain("exit 1");
   expect(html).toContain("text-danger");
-  // The opened error child mounts its body — a grouped call now exposes the same
-  // raw-record control a standalone line does.
+  // The opened error child mounts its body with the real output and no
+  // raw-record noise toggle (compact-feed pass).
   expect(html).toContain("boom");
-  expect(html).toContain(en("tools.rawRecord"));
+  expect(html).not.toContain(en("tools.rawRecord"));
 });
 
 test("a system message collapses to the compact per-1000 size, not chars/kB (§3.4)", () => {
@@ -251,5 +250,6 @@ test("an orchestration row renders nested children and the meaningful outer summ
   expect(html).toContain(en("tools.nestedCalls"));
   expect(html).toContain("git status");
   expect(html).toContain("Read a.ts");
-  expect(html).toContain(en("tools.source"));
+  // The raw JavaScript "source" disclosure is gone (compact-feed pass).
+  expect(html).not.toContain(en("tools.source"));
 });

--- a/src/components/runtime/McpCallCard.tsx
+++ b/src/components/runtime/McpCallCard.tsx
@@ -92,7 +92,7 @@ function LinkChip({
 }) {
   const disabled = link.kind === "conversation"
     && (!conversationAvailability.loaded || !conversationAvailability.ids.has(link.id));
-  const shared = "inline-flex min-h-7 items-center gap-1.5 rounded-full border px-2.5 py-1 text-[11px] font-bold transition-colors";
+  const shared = "inline-flex min-h-6 shrink-0 items-center gap-1 rounded-full border px-2 py-0.5 text-[10.5px] font-semibold transition-colors [@media(pointer:coarse)]:min-h-8";
   if (disabled) {
     return (
       <span
@@ -140,56 +140,57 @@ export function McpCallCard({
   const error = state === "error" ? resultError(result, event.outputPreview) : "";
   const payload = useMemo(() => prettyPayload(mcp?.args ?? {}, result), [mcp?.args, result]);
 
+  /* Compact contract: one dense row — action meaning first, chrome last.
+     The title (which already carries the useful payload, e.g. the message text
+     of a send_message call) truncates inline; state lives in the icon color and
+     a small glyph instead of a separate "Completed" row; ids/paths/payload sit
+     behind the quiet Details disclosure. An error is never quiet: its text gets
+     its own visible line under the row. */
   return (
-    <article
-      data-testid="mcp-call-card"
-      data-state={state}
-      className={`relative my-2.5 ml-9 overflow-hidden rounded-surface border bg-card ${
-        state === "error" ? "border-danger/40" : state === "success" ? "border-success/25" : "border-accent/35"
-      }`}
-    >
+    <article data-testid="mcp-call-card" data-state={state} className="group/mcp relative my-1 ml-9">
       {state === "pending" ? (
         <div data-testid="mcp-call-progress" className="absolute inset-x-0 top-0 h-0.5 animate-pulse bg-gradient-to-r from-transparent via-accent to-transparent" />
       ) : null}
-      <div className="flex items-start gap-2.5 px-3 py-2.5">
-        <span
-          className={`relative mt-0.5 flex h-7 w-7 shrink-0 items-center justify-center rounded-lg ${
-            state === "error" ? "bg-danger-soft text-danger" : state === "success" ? "bg-success-soft text-success" : "bg-accent-soft text-accent"
-          }`}
-        >
-          <Icon className={`h-4 w-4 ${state === "pending" ? "animate-pulse" : ""}`} aria-hidden />
-          {state === "pending" ? <span className="absolute -bottom-1 -right-1 h-2.5 w-2.5 animate-ping rounded-full bg-accent/70" aria-hidden /> : null}
-        </span>
-        <div className="min-w-0 flex-1">
-          <div className="flex flex-wrap items-center gap-1.5">
-            <span className="rounded-md border border-border bg-sunken px-1.5 py-0.5 font-mono text-[9.5px] font-semibold uppercase tracking-[0.08em] text-muted">
-              MCP · {mcp?.serverName ?? "viewer"}
-            </span>
-            {replayed ? <span data-testid="mcp-replay" className="rounded-full bg-accent-soft px-2 py-0.5 text-[10px] font-bold text-accent">Replay</span> : null}
-            {retryable ? <span className="rounded-full bg-danger-soft px-2 py-0.5 text-[10px] font-bold text-danger">Retryable</span> : null}
-            {hhmm(event.ts) ? <span className="ml-auto text-[10px] tabular-nums text-muted">{hhmm(event.ts)}</span> : null}
-          </div>
-          <div className="mt-1.5 text-[13px] font-bold leading-snug text-primary">{description.title}</div>
-          {description.subtitle ? <div className="mt-0.5 truncate font-mono text-[10.5px] text-muted" title={description.subtitle}>{description.subtitle}</div> : null}
-          <div className={`mt-2 flex items-center gap-1.5 text-[11px] font-semibold ${
-            state === "error" ? "text-danger" : state === "success" ? "text-success" : "text-accent"
-          }`} role={state === "pending" ? "status" : undefined}>
+      <details className="min-w-0">
+        <summary className="flex min-w-0 cursor-pointer list-none flex-wrap items-center gap-x-2 gap-y-0.5 rounded-control py-0.5 text-ui hover:bg-sunken [@media(pointer:coarse)]:min-h-11 [&::-webkit-details-marker]:hidden">
+          <Icon
+            className={`h-3.5 w-3.5 shrink-0 ${
+              state === "error" ? "text-danger" : state === "success" ? "text-success" : "text-accent"
+            } ${state === "pending" ? "animate-pulse" : ""}`}
+            aria-hidden
+          />
+          <span className="shrink-0 font-mono text-[9.5px] font-semibold uppercase tracking-[0.08em] text-muted">
+            MCP · {mcp?.serverName ?? "viewer"}
+          </span>
+          <span className="min-w-0 flex-1 truncate font-semibold text-secondary" title={description.title}>
+            {description.title}
+          </span>
+          {replayed ? <span data-testid="mcp-replay" className="shrink-0 rounded-full bg-accent-soft px-1.5 py-0.5 text-[10px] font-bold text-accent">Replay</span> : null}
+          {retryable ? <span className="shrink-0 rounded-full bg-danger-soft px-1.5 py-0.5 text-[10px] font-bold text-danger">Retryable</span> : null}
+          {description.links.map((link) => (
+            <LinkChip key={`${link.kind}:${link.id}`} link={link} conversationAvailability={conversationAvailability} />
+          ))}
+          <span
+            className={`inline-flex shrink-0 items-center ${
+              state === "error" ? "text-danger" : state === "success" ? "text-success" : "text-accent"
+            }`}
+            role={state === "pending" ? "status" : undefined}
+            aria-label={state === "pending" ? `${description.verb}…` : state}
+          >
             {state === "pending" ? <LoaderCircle className="h-3.5 w-3.5 animate-spin" aria-hidden /> : state === "success" ? <CheckCircle2 className="h-3.5 w-3.5" aria-hidden /> : <CircleAlert className="h-3.5 w-3.5" aria-hidden />}
-            {state === "pending" ? `${description.verb}…` : state === "success" ? "Completed" : error}
-          </div>
-          {description.links.length ? (
-            <div className="mt-2.5 flex flex-wrap gap-1.5">
-              {description.links.map((link) => <LinkChip key={`${link.kind}:${link.id}`} link={link} conversationAvailability={conversationAvailability} />)}
-            </div>
+          </span>
+          {hhmm(event.ts) ? <span className="shrink-0 text-caption tabular-nums text-muted">{hhmm(event.ts)}</span> : null}
+        </summary>
+        <div className="ml-5 mt-1 text-[10.5px] text-muted">
+          {description.subtitle ? (
+            <div className="mb-1 truncate font-mono" title={description.subtitle}>{description.subtitle}</div>
           ) : null}
-          <details className="group/mcp mt-2 text-[10.5px] text-muted">
-            <summary className="inline-flex min-h-6 cursor-pointer list-none items-center font-semibold hover:text-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 [&::-webkit-details-marker]:hidden">
-              Details
-            </summary>
-            <pre className="mt-1 max-h-[320px] max-w-full overflow-auto whitespace-pre-wrap [overflow-wrap:anywhere] border-t border-border pt-1.5 font-mono text-[10.5px] text-secondary">{payload}</pre>
-          </details>
+          <pre className="max-h-[320px] max-w-full overflow-auto whitespace-pre-wrap [overflow-wrap:anywhere] border-t border-border pt-1.5 font-mono text-[10.5px] text-secondary">{payload}</pre>
         </div>
-      </div>
+      </details>
+      {state === "error" ? (
+        <div className="ml-5 border-l-2 border-danger pl-2 text-[11px] font-semibold text-danger">{error}</div>
+      ) : null}
     </article>
   );
 }


### PR DESCRIPTION
## Summary

Operator-requested density pass over the conversation feed (origin: conversation 84bf82b4 — "а МСР карточки?" — and follow-up screenshots of oversized MCP receipt cards and noise labels).

- **McpCallCard → one dense row.** Small state-colored icon, `MCP · server` micro-tag, the meaningful title inline (a `send_message` call shows the message text, not raw payload), link chips small and inline, status as a colored glyph instead of a separate "Completed" row. Subtitle path + full JSON payload move behind the row's quiet disclosure. Errors keep their own always-visible danger line. Vertical footprint drops from ~6 stacked rows to 1.
- **Empty output renders nothing.** The "вивід не збережено" / "stderr не збережено" apology rows are gone.
- **"сирий запис" (raw record) toggle removed** from tool bodies.
- **"джерело" (source) disclosure removed** from orchestration cards — parsed nested-call rows already carry the meaning.

Status semantics (pending/success/error colors), links/navigation, timestamps, replay/retryable chips, EN/UK parity, and all `data-testid` contracts are preserved.

## Testing

- `tsc --noEmit` clean
- `eslint` clean on changed files
- `bun test src/components/feed src/components/runtime` — 296 pass / 0 fail (tests asserting the removed noise updated to the new compact contract)
- production build clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)