### PR TITLE
ux(runtime): compact dead-host banner, draftable images while host is down

### DIFF
--- a/src/components/TmuxComposer.deadRecovery.dom.test.tsx
+++ b/src/components/TmuxComposer.deadRecovery.dom.test.tsx
@@ -4,8 +4,8 @@
  *
  *   - Send stays enabled: text is admitted durably and delivered after the
  *     host recovers (the capability matrix's `dead` row keeps send ENABLED);
- *   - the image restriction is explained inline (the matrix disables images
- *     with `composer.imagesBlockedDuringRecovery` while the host is down);
+ *   - the image picker stays usable: images queue in the local draft and the
+ *     old inline restriction line is gone (compact-feed pass);
  *   - the model/reasoning pill is NOT offered (the matrix hides `runtime` on
  *     the dead surface), so no committed evidence may depict one.
  *
@@ -193,9 +193,9 @@ test.each(["en", "uk"] as const)(
     expect(send.getAttribute("aria-disabled")).toBe("false");
     expect(send.disabled).toBe(false);
 
-    /* The image restriction is explained inline in the current locale — a
-       phone has no tooltip, so the disabled picker alone would be mute. */
-    expect(host.textContent).toContain(translate(locale, "composer.imagesBlockedDuringRecovery"));
+    /* Images stay draftable while the host is down (compact-feed pass): no
+       blocking explainer renders and the picker is not disabled. */
+    expect(host.textContent).not.toContain(translate(locale, "composer.imagesBlockedDuringRecovery"));
 
     /* Production capability visibility: the matrix hides the runtime control
        on the dead surface, so no model/reasoning pill may render. */

--- a/src/components/TmuxComposer.tsx
+++ b/src/components/TmuxComposer.tsx
@@ -1794,8 +1794,8 @@ export function TmuxComposer({
             : []
         }
         showImage={!deadHostBlocksSend}
-        imageDisabled={structuredImagesDisabled}
-        imageDisabledReason={structuredImagesReason}
+        imageDisabled={structuredImagesDisabled && caps.surface !== "dead"}
+        imageDisabledReason={caps.surface === "dead" ? undefined : structuredImagesReason}
         sendPayloadAvailable={replayGenerationAvailable}
         sendDisabledReason={deadHostBlocksSend
           ? t("deadHost.sendBlocked")

--- a/src/components/runtime/DeadHostBanner.action.test.tsx
+++ b/src/components/runtime/DeadHostBanner.action.test.tsx
@@ -50,7 +50,9 @@ async function mount(): Promise<{ host: HTMLElement; root: Root }> {
 }
 
 const byLabel = (host: HTMLElement, key: Parameters<typeof translate>[1]) =>
-  [...host.querySelectorAll("button")].find((b) => (b.textContent ?? "").includes(translate("en", key)))!;
+  [...host.querySelectorAll("button")].find((b) =>
+    (b.textContent ?? "").includes(translate("en", key))
+    || (b.getAttribute("aria-label") ?? "").includes(translate("en", key)))!;
 
 const click = async (button: HTMLButtonElement) => {
   await act(async () => {

--- a/src/components/runtime/DeadHostBanner.copy.dom.test.tsx
+++ b/src/components/runtime/DeadHostBanner.copy.dom.test.tsx
@@ -56,22 +56,21 @@ for (const locale of LOCALES) {
     const facts = FACTS[locale];
     // The line must state the restriction as a restriction (not merely that a
     // selection persists) and tie its release to recovery.
-    expect(line).toMatch(locale === "en" ? /can[’']t be attached|cannot be attached/i : /не можна додат/i);
+    // Drafting stays allowed while the host is down; the line only ties image
+    // delivery to recovery (compact-feed pass).
     expect(line).toMatch(facts.recovery);
   });
 
-  test(`the ${locale} banner renders the truthful body with all three recovery controls`, () => {
+  test(`the ${locale} banner stays one compact row with all three recovery controls`, () => {
     const t: Parameters<typeof DeadHostBannerView>[0]["t"] = (key, params) => translate(locale, key, params);
     const html = renderToStaticMarkup(
       <DeadHostBannerView t={t} sinceLabel="5m" onRespawn={() => {}} onAttach={() => {}} onRecheck={() => {}} />,
     );
-    // The body reaches the DOM (apostrophes are HTML-escaped in static markup,
-    // so assert an escape-free distinctive fragment of each fact).
+    // The explainer body is gone (compact-feed pass): the title states the
+    // queueing contract and every control stays reachable.
     const body = translate(locale, "deadHost.body");
     const escapeFree = (value: string) => value.split(/[&<>'’]/)[0]!.trim();
-    const fragment = escapeFree(body);
-    expect(fragment.length).toBeGreaterThan(10);
-    expect(html).toContain(fragment);
+    expect(html).not.toContain(escapeFree(body));
     for (const control of ["deadHost.respawn", "deadHost.attach", "deadHost.recheck"] as const) {
       expect(html).toContain(translate(locale, control));
     }

--- a/src/components/runtime/DeadHostBanner.dom.test.tsx
+++ b/src/components/runtime/DeadHostBanner.dom.test.tsx
@@ -35,10 +35,8 @@ test("the banner states what died and when, as a polite status, with the danger 
   expect(html).toContain("data-dead-host-banner");
   expect(html).toContain("border-danger/45");
   expect(html).toContain(translate("en", "deadHost.title", { since: "12 min" }));
-  // (the apostrophe in "can't" is HTML-escaped in static markup, so assert an
-  // escape-free fragment of the truthful body)
-  expect(html).toContain("Pending approvals expired");
-  expect(html).toContain("delivered after the host recovers");
+  // The compact banner carries no explainer body — state lives in the title.
+  expect(html).not.toContain("Pending approvals expired");
   expect(html).toContain(translate("en", "deadHost.respawn"));
   expect(html).toContain(translate("en", "deadHost.attach"));
   expect(html).toContain(translate("en", "deadHost.recheck"));

--- a/src/components/runtime/DeadHostBanner.tsx
+++ b/src/components/runtime/DeadHostBanner.tsx
@@ -51,24 +51,27 @@ export function DeadHostBannerView({
   respawnError = null,
   recheckError = null,
 }: DeadHostBannerViewProps) {
+  /* Compact contract: the dead host is one quiet row, not a screen-eating
+     explainer. A sent message queues durably and auto-delivers on recovery, so
+     the row only names the state and offers Respawn plus a terminal escape
+     hatch; the re-check affordance folds into the small refresh icon. */
   return (
     <div
       role="status"
       aria-live="polite"
       data-dead-host-banner
-      className="flex shrink-0 flex-col gap-1.5 border-b border-danger/45 bg-danger-soft px-2.5 py-2"
+      className="shrink-0 border-b border-danger/45 bg-danger-soft px-2.5 py-1"
     >
-      <div className="flex items-center gap-1.5 text-label font-bold text-danger">
-        <AlertTriangle className="h-3.5 w-3.5 shrink-0" aria-hidden />
-        <span className="min-w-0 truncate">{t("deadHost.title", { since: sinceLabel })}</span>
-      </div>
-      <p className="text-caption font-semibold text-secondary">{t("deadHost.body")}</p>
-      <div className="flex flex-wrap items-center gap-1.5">
+      <div className="flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1">
+        <AlertTriangle className="h-3.5 w-3.5 shrink-0 text-danger" aria-hidden />
+        <span className="min-w-0 flex-1 truncate text-label font-bold text-danger">
+          {t("deadHost.title", { since: sinceLabel })}
+        </span>
         <button
           type="button"
           onClick={onRespawn}
           disabled={respawnBusy}
-          className="inline-flex min-h-11 items-center gap-1 rounded-control border border-accent bg-accent px-2.5 text-label font-bold text-white hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/50 disabled:opacity-60 sm:min-h-8"
+          className="inline-flex min-h-7 items-center gap-1 rounded-control border border-accent bg-accent px-2 text-label font-bold text-white hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/50 disabled:opacity-60 [@media(pointer:coarse)]:min-h-11"
         >
           {respawnBusy ? <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden /> : <Play className="h-3.5 w-3.5" aria-hidden />}
           {t("deadHost.respawn")}
@@ -76,25 +79,28 @@ export function DeadHostBannerView({
         <button
           type="button"
           onClick={onAttach}
-          className="inline-flex min-h-11 items-center gap-1 rounded-control border border-border bg-canvas px-2.5 text-label font-semibold text-secondary hover:border-accent/45 hover:text-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 sm:min-h-8"
+          title={t("deadHost.attach")}
+          aria-label={t("deadHost.attach")}
+          className="inline-flex min-h-7 items-center gap-1 rounded-control border border-border bg-canvas px-2 text-label font-semibold text-secondary hover:border-accent/45 hover:text-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 [@media(pointer:coarse)]:min-h-11"
         >
-          <SquareTerminal className="h-3.5 w-3.5" aria-hidden /> {t("deadHost.attach")}
+          <SquareTerminal className="h-3.5 w-3.5" aria-hidden />
         </button>
         <button
           type="button"
           onClick={onRecheck}
           disabled={recheckBusy}
-          className="inline-flex min-h-11 items-center gap-1 rounded-control border border-border bg-canvas px-2.5 text-label font-semibold text-muted hover:border-accent/45 hover:text-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 disabled:opacity-60 sm:min-h-8"
+          title={t("deadHost.recheck")}
+          aria-label={t("deadHost.recheck")}
+          className="inline-flex min-h-7 items-center rounded-control border border-border bg-canvas px-1.5 text-muted hover:border-accent/45 hover:text-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 disabled:opacity-60 [@media(pointer:coarse)]:min-h-11"
         >
           {recheckBusy ? <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden /> : <RotateCcw className="h-3.5 w-3.5" aria-hidden />}
-          {t("deadHost.recheck")}
         </button>
       </div>
       {respawnError ? (
-        <p role="alert" className="text-caption font-semibold text-danger">{respawnError}</p>
+        <p role="alert" className="mt-1 text-caption font-semibold text-danger">{respawnError}</p>
       ) : null}
       {recheckError ? (
-        <p role="alert" className="text-caption font-semibold text-danger">{recheckError}</p>
+        <p role="alert" className="mt-1 text-caption font-semibold text-danger">{recheckError}</p>
       ) : null}
     </div>
   );

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -282,7 +282,7 @@ export const en = {
   "composer.structuredImagesUnavailable": "Image delivery is unavailable for structured conversations",
   "composer.codexImagesTextOnly": "The selected Codex model accepts text input only.",
   "composer.structuredImagesProtocol": "This structured host has no negotiated image capability.",
-  "composer.imagesBlockedDuringRecovery": "Images can't be attached while the host is down — staged ones stay selected and are delivered after recovery.",
+  "composer.imagesBlockedDuringRecovery": "Drafted images will be sent after the host recovers; text can be sent right away.",
   "composer.imageCapabilityLoading": "Image capability is loading.",
   "composer.imageCapabilityError": "Image capability could not be loaded.",
   "composer.imageCapabilityRetry": "Retry image check",
@@ -339,7 +339,7 @@ export const en = {
   "strip.resolving": "resolving the agent host…",
 
   // Dead-host banner (issue #247)
-  "deadHost.title": "Agent host died · {since}",
+  "deadHost.title": "Agent inactive · {since} — messages will queue",
   "deadHost.body": "Text you send now is saved durably and delivered after the host recovers. Images can't be attached until then. Pending approvals expired — recover with the controls below.",
   "deadHost.respawn": "Respawn conversation",
   "deadHost.attach": "Open in terminal",

--- a/src/lib/i18n/uk.ts
+++ b/src/lib/i18n/uk.ts
@@ -273,7 +273,7 @@ export const uk: Record<keyof typeof en, Message> = {
   "composer.structuredImagesUnavailable": "Структуровані розмови поки не підтримують картинки",
   "composer.codexImagesTextOnly": "Обрана модель Codex приймає лише текст.",
   "composer.structuredImagesProtocol": "Цей структурований хост не узгодив підтримку зображень.",
-  "composer.imagesBlockedDuringRecovery": "Зображення не можна додати, доки хост не працює — вже додані залишаться вибраними й будуть доставлені після відновлення.",
+  "composer.imagesBlockedDuringRecovery": "Зображення з чернетки буде надіслано після відновлення хоста; текст можна надіслати вже зараз.",
   "composer.imageCapabilityLoading": "Завантажуємо дані про підтримку зображень.",
   "composer.imageCapabilityError": "Не вдалося завантажити дані про підтримку зображень.",
   "composer.imageCapabilityRetry": "Повторити перевірку зображень",
@@ -342,7 +342,7 @@ export const uk: Record<keyof typeof en, Message> = {
   "strip.resolving": "визначаємо середовище агента…",
 
   // Dead-host banner (issue #247)
-  "deadHost.title": "Хост агента помер · {since}",
+  "deadHost.title": "Агент неактивний · {since} — повідомлення підуть у чергу",
   "deadHost.body": "Текст, надісланий зараз, надійно зберігається і буде доставлений після відновлення хоста. Зображення не можна додати, доки хост не повернеться. Очікувані підтвердження застаріли — відновіть роботу елементами керування нижче.",
   "deadHost.respawn": "Відновити розмову",
   "deadHost.attach": "Відкрити в терміналі",


### PR DESCRIPTION
## Summary
Continuation of the operator's compact-feed pass (#558).

- **Dead-host banner → one row.** Title now states the queueing contract ("Агент неактивний · N — повідомлення підуть у чергу"); the three-line explainer body is gone; terminal + re-check become icon buttons. Errors keep visible alert lines.
- **Images stay draftable while the host is down.** The picker is no longer disabled on the dead surface — images queue in the local draft; only delivery waits for host recovery. Blocking inline explainer removed; copy shortened (EN/UK).

## Testing
- tsc clean; eslint clean on changed files
- DeadHostBanner suites 19/19, McpCallCard + feed cards + composer dead-recovery/pendingImages suites green (tests asserting the removed explainer updated to the new contract)
- Broader parallel-run failures were verified as pre-existing flake (same suites pass in isolation on clean main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)