### PR TITLE
feat(feed): render live assistant deltas ahead of the transcript flush

### DIFF
--- a/src/components/LogFeed.tsx
+++ b/src/components/LogFeed.tsx
@@ -5,6 +5,7 @@ import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 
 import { ArrowDown, ChevronUp, Sparkle } from "@/components/icons";
 import { useLogTail } from "@/hooks/useLogTail";
+import { useRuntimeSessionByArtifact } from "@/hooks/useRuntime";
 import { conversationIdentity } from "@/lib/accounts/identity";
 import { getLocale, translate, useLocale } from "@/lib/i18n";
 import type { FileEntry } from "@/lib/types";
@@ -100,6 +101,9 @@ interface Props {
 export function LogFeed({ file, showSvc, lineFilter, onStatus, paused, follow, setFollow, compact = false }: Props) {
   const { locale, t } = useLocale();
   const memoryKey = file ? conversationIdentity(file) : null;
+  /* Live streaming text: `delta` events from the structured host render the
+     in-flight assistant reply immediately, ahead of the transcript flush. */
+  const liveTurn = useRuntimeSessionByArtifact(file?.path ?? null)?.session.liveTurn ?? null;
   /* The scroll magnet lives per feed instance, so each column remembers its
      own state across polls: glued to the live tail, or released by the user.
      A remount inherits the transcript's remembered state. */
@@ -478,6 +482,12 @@ export function LogFeed({ file, showSvc, lineFilter, onStatus, paused, follow, s
                     </div>
                   );
                 })}
+                {liveTurn?.text ? (
+                  <div data-live-turn className="my-2 ml-9 whitespace-pre-wrap [overflow-wrap:anywhere] text-ui text-primary">
+                    {liveTurn.text}
+                    <span className="ml-0.5 inline-block h-3.5 w-1.5 animate-pulse rounded-[2px] bg-accent align-text-bottom" aria-hidden />
+                  </div>
+                ) : null}
                 <ConversationAttention file={file} />
                 {!file.pendingQuestion && !file.waitingInput && endedQuestion ? (
                   <div className="my-4 rounded-[8px] border border-border bg-sunken px-4 py-3 text-[13px] font-semibold text-muted">{endedQuestion}</div>

--- a/src/components/runtime/runtimeModel.test.ts
+++ b/src/components/runtime/runtimeModel.test.ts
@@ -140,6 +140,32 @@ function receipt(overrides: Partial<RuntimeReceipt> & { operationId: string; con
   };
 }
 
+/* --------------------- live turn streaming --------------------- */
+
+describe("live turn delta buffering", () => {
+  test("delta events accumulate per turn and clear on item completion and turn end", () => {
+    let store = installSnapshot(snapshot());
+    store = apply(store, env("turn-started", { type: "session", id: "conv_a" }, 4, { conversationId: "conv_a", turnId: "t1" }));
+    store = apply(store, env("delta", { type: "session", id: "conv_a" }, 5, { conversationId: "conv_a", turnId: "t1", text: "Hel" }));
+    store = apply(store, env("delta", { type: "session", id: "conv_a" }, 6, { conversationId: "conv_a", turnId: "t1", text: "lo" }));
+    expect(store.sessions["conv_a"]?.liveTurn).toEqual({ turnId: "t1", text: "Hello" });
+    store = apply(store, env("item", { type: "session", id: "conv_a" }, 7, { conversationId: "conv_a", turnId: "t1", phase: "completed", item: {} }));
+    expect(store.sessions["conv_a"]?.liveTurn).toBeNull();
+    store = apply(store, env("delta", { type: "session", id: "conv_a" }, 8, { conversationId: "conv_a", turnId: "t1", text: "more" }));
+    expect(store.sessions["conv_a"]?.liveTurn?.text).toBe("more");
+    store = apply(store, env("turn-ended", { type: "session", id: "conv_a" }, 9, { conversationId: "conv_a", turnId: "t1", outcome: "completed" }));
+    expect(store.sessions["conv_a"]?.liveTurn).toBeNull();
+  });
+
+  test("a started item leaves the live buffer alone", () => {
+    let store = installSnapshot(snapshot());
+    store = apply(store, env("turn-started", { type: "session", id: "conv_a" }, 4, { conversationId: "conv_a", turnId: "t1" }));
+    store = apply(store, env("delta", { type: "session", id: "conv_a" }, 5, { conversationId: "conv_a", turnId: "t1", text: "streaming" }));
+    store = apply(store, env("item", { type: "session", id: "conv_a" }, 6, { conversationId: "conv_a", turnId: "t1", phase: "started", item: {} }));
+    expect(store.sessions["conv_a"]?.liveTurn?.text).toBe("streaming");
+  });
+});
+
 /* --------------------- strict revision guard --------------------- */
 
 describe("applyEvent revision guard", () => {

--- a/src/components/runtime/runtimeModel.ts
+++ b/src/components/runtime/runtimeModel.ts
@@ -25,6 +25,9 @@ import type { Workflow } from "@/lib/workflows/types";
 import type { RuntimePendingReconfigure, RuntimeSettingsCapability, ViewerDeploymentStatus } from "@/lib/runtime/contracts";
 import type { RuntimeImageCapability } from "@/lib/runtime/structuredContent";
 
+/** Cap on buffered live-turn text: enough for any readable reply, never a leak. */
+const LIVE_TURN_TEXT_LIMIT = 64 * 1024;
+
 /* ------------------------------------------------------------------ *
  * Vocabulary (frozen)                                                 *
  * ------------------------------------------------------------------ */
@@ -246,6 +249,9 @@ export interface RuntimeSession {
   pendingReconfigure?: RuntimePendingReconfigure | null;
   /** Unresolved drift notice, if any. */
   drift?: RuntimeDrift | null;
+  /** In-flight assistant text accumulated from live `delta` events, rendered
+      as a streaming bubble until the transcript materializes the item. */
+  liveTurn?: { turnId: string; text: string } | null;
 }
 
 /**
@@ -471,7 +477,34 @@ function reduceKnown(store: RuntimeStore, env: RuntimeEnvelope, revision: number
         ...s,
         turn: "running",
         activeTurnId: p.turnId ?? s.activeTurnId,
+        liveTurn: null,
       }));
+      break;
+    }
+    case "delta": {
+      /* Live assistant text: append the streamed fragment so the feed can
+         render the reply the moment tokens arrive, without waiting for the
+         transcript flush + tail poll. Bounded so a runaway turn cannot grow
+         the store without limit. */
+      const p = env.payload as { conversationId?: string; turnId?: string; text?: string };
+      const fragment = typeof p.text === "string" ? p.text : "";
+      if (!fragment) break;
+      updateSession(store, p.conversationId ?? env.scope.id, revision, (s) => {
+        const turnId = p.turnId ?? s.activeTurnId ?? "unknown";
+        const prev = s.liveTurn && s.liveTurn.turnId === turnId ? s.liveTurn.text : "";
+        return { ...s, liveTurn: { turnId, text: (prev + fragment).slice(-LIVE_TURN_TEXT_LIMIT) } };
+      });
+      break;
+    }
+    case "item": {
+      /* A completed item means the engine has materialized the streamed text —
+         the transcript tail will carry it momentarily, so the live buffer
+         retires instead of double-rendering. */
+      const p = env.payload as { conversationId?: string; phase?: string };
+      if (p.phase !== "completed") break;
+      updateSession(store, p.conversationId ?? env.scope.id, revision, (s) =>
+        s.liveTurn ? { ...s, liveTurn: null } : s,
+      );
       break;
     }
     case "turn-ended": {
@@ -480,6 +513,7 @@ function reduceKnown(store: RuntimeStore, env: RuntimeEnvelope, revision: number
         ...s,
         turn: "idle",
         activeTurnId: null,
+        liveTurn: null,
       }));
       break;
     }

--- a/src/lib/runtime/contracts.ts
+++ b/src/lib/runtime/contracts.ts
@@ -350,6 +350,9 @@ export interface RuntimeSession {
   activeTurnId: string | null;
   pendingReconfigure?: RuntimePendingReconfigure | null;
   drift?: RuntimeDrift | null;
+  /** In-flight assistant text accumulated from live `delta` events, rendered
+      as a streaming bubble until the transcript materializes the item. */
+  liveTurn?: { turnId: string; text: string } | null;
 }
 
 export interface ScopedEntity<T> {


### PR DESCRIPTION
## Summary
Operator priority: sending a message to any chat must render the reply as fast as a native JSON-RPC client.

Root cause of the perceived lag: `item/agentMessage/delta` events already flow codex app-server → runtime-host → `/api/runtime/stream` SSE, but the client reducer ignored them — the feed only updates from the transcript tail, which codex writes item-by-item (plus a 1.2s fallback poll). So the first tokens of a reply were invisible until the whole item flushed.

- `RuntimeSession.liveTurn` — bounded (64KB) per-session streaming buffer; reducer appends `delta` fragments, resets on `turn-started`, clears on completed `item` (transcript catches up) and `turn-ended`.
- `LogFeed` renders the buffer as a live streaming bubble with a pulse caret; existing ResizeObserver re-glue keeps follow-mode pinned to the bottom as it grows.

## Testing
- New reducer tests: accumulate → clear-on-item-completed → re-accumulate → clear-on-turn-end; started items leave the buffer alone.
- `bun test src/components/runtime src/hooks` — 242 pass / 0 fail; tsc, eslint, production build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)