### PR TITLE
fix(deploy): answer the capability gate from configuration, not registry load

### DIFF
--- a/src/app/api/runtime/deployments/capabilities/v1/route.ts
+++ b/src/app/api/runtime/deployments/capabilities/v1/route.ts
@@ -1,12 +1,15 @@
-import { agentRegistry } from "@/lib/agent/registry";
+import { sqliteModeFromEnvironment } from "@/lib/agent/registry";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
+/* The deployment readiness gate probes this route with a 5s budget. It must
+   answer from configuration alone: instantiating the agent registry here made
+   the first probe pay a multi-MB JSON parse and time out, failing every
+   deploy with "capability gate failed" while the candidate was healthy. */
 export function GET(): Response {
-  const registryBackendMode = agentRegistry().storageDiagnostics().backendMode;
   return Response.json(
-    { capability: "viewer-deployments", version: 1, registryBackendMode },
+    { capability: "viewer-deployments", version: 1, registryBackendMode: sqliteModeFromEnvironment() },
     { headers: { "cache-control": "no-store" } },
   );
 }

--- a/src/lib/agent/registry.ts
+++ b/src/lib/agent/registry.ts
@@ -2250,7 +2250,9 @@ export class RegistryParityError extends Error {
   override name = "RegistryParityError";
 }
 
-function sqliteModeFromEnvironment(): AgentRegistrySqliteMode {
+/** Pure env read: lets health/capability probes answer without paying the
+    full registry load (a multi-MB JSON parse) on first touch. */
+export function sqliteModeFromEnvironment(): AgentRegistrySqliteMode {
   const configured = process.env.LLV_AGENT_REGISTRY_SQLITE ?? "off";
   if (configured === "off" || configured === "dual-write" || configured === "read" || configured === "sqlite") return configured;
   throw new Error("LLV_AGENT_REGISTRY_SQLITE must be off, dual-write, read, or sqlite");


### PR DESCRIPTION
## Summary
Root cause of "нічого не доїжджає в прод": every blue-green deploy failed at `candidate-health` with **"Viewer deployment capability gate failed"** even though the candidate was healthy (recorded evidence: root 200, authenticated 200, unauthorized 403, every asset 200).

The gate probes `/api/runtime/deployments/capabilities/v1` with a 5s fetch budget. The route called `agentRegistry().storageDiagnostics()`, and the registry's first touch parses the ~15MB `agent-registry.json` — the probe timed out on every retry for the entire readiness window, so deploys `deploy_7ef1871e` (62d957e2) and `deploy_cc79eb55` (5b3f7ffd) both failed and prod stayed on the morning build.

`registryBackendMode` derives purely from `LLV_AGENT_REGISTRY_SQLITE`, so the route now answers from the environment without loading the registry. Verified live against a leftover candidate container: with warm state the endpoint returns 200 both plain and with the remote+Bearer probe headers.

## Testing
- tsc, eslint clean; production build clean
- 281 tests across the touched surfaces pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)