### PR TITLE
docs: MCP quick install + all-accounts installer script

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,35 @@ For a local clone, point the client at the launcher:
 }
 ```
 
+Quick install from the CLI:
+
+```bash
+# Claude Code (user scope)
+claude mcp add viewer -s user -- bun /absolute/path/to/live-log-viewer-next/bin/mcp-server.mjs
+
+# Codex — append to ~/.codex/config.toml
+[mcp_servers.viewer]
+command = "bun"
+args = ["/absolute/path/to/live-log-viewer-next/bin/mcp-server.mjs"]
+```
+
+To register the server everywhere at once — the operator's Claude Code and
+Codex configs plus every Viewer-managed account under
+`~/.config/agent-log-viewer/accounts` (their spawned agents each run with
+their own `CLAUDE_CONFIG_DIR`/`CODEX_HOME`, so each account needs its own
+registration) — run the idempotent installer and re-run it after adding
+accounts:
+
+```bash
+scripts/install-mcp.sh                     # registers the repo's bin/mcp-server.mjs
+LLV_MCP_BIN=/path/to/mcp-server.mjs \
+  scripts/install-mcp.sh                   # point at a stable runtime copy instead
+```
+
+The server name must stay `viewer` (or another `isViewerMcpServer()` match:
+`viewer-*`, `agent-log-viewer*`) — transcript calls attributed to other names
+do not render as Viewer cards.
+
 The v1 tools are `spawn_agent`, `send_message`, `create_task`, `update_task`,
 `create_pipeline`, `pipeline_action`, `link_task_to_pipeline`,
 `list_conversations`, `get_conversation`, `deploy_exact_sha`, and

--- a/scripts/install-mcp.sh
+++ b/scripts/install-mcp.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Register the Viewer MCP server ("viewer") everywhere agents run on this
+# machine: the operator's Claude Code user config, the operator's Codex
+# config, and every Viewer-managed account (CLAUDE_CONFIG_DIR /
+# CODEX_HOME under ~/.config/agent-log-viewer/accounts). Idempotent —
+# safe to re-run after adding accounts.
+#
+# The server name must stay "viewer" (or an isViewerMcpServer() match in
+# src/lib/mcp/presentation.ts) so transcript calls render as Viewer cards.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+MCP_BIN="${LLV_MCP_BIN:-$REPO_ROOT/bin/mcp-server.mjs}"
+ACCOUNTS_ROOT="${LLV_CONFIG_ROOT:-$HOME/.config/agent-log-viewer}/accounts"
+
+if [ ! -f "$MCP_BIN" ]; then
+  echo "error: MCP launcher not found at $MCP_BIN (set LLV_MCP_BIN to override)" >&2
+  exit 1
+fi
+
+add_claude() { # $1 = label, $2 = CLAUDE_CONFIG_DIR or "" for the user default
+  local label="$1" dir="$2"
+  if [ -n "$dir" ]; then
+    if CLAUDE_CONFIG_DIR="$dir" claude mcp get viewer >/dev/null 2>&1; then
+      echo "claude[$label]: viewer already registered"
+    else
+      CLAUDE_CONFIG_DIR="$dir" claude mcp add viewer -s user -- bun "$MCP_BIN" >/dev/null
+      echo "claude[$label]: viewer added"
+    fi
+  else
+    if claude mcp get viewer >/dev/null 2>&1; then
+      echo "claude[$label]: viewer already registered"
+    else
+      claude mcp add viewer -s user -- bun "$MCP_BIN" >/dev/null
+      echo "claude[$label]: viewer added"
+    fi
+  fi
+}
+
+add_codex_toml() { # $1 = label, $2 = config.toml path
+  local label="$1" toml="$2"
+  if [ ! -f "$toml" ]; then
+    echo "codex[$label]: no config.toml, skipped"
+    return
+  fi
+  if grep -q '^\[mcp_servers\.viewer\]' "$toml"; then
+    echo "codex[$label]: viewer already registered"
+    return
+  fi
+  printf '\n[mcp_servers.viewer]\ncommand = "bun"\nargs = ["%s"]\n' "$MCP_BIN" >> "$toml"
+  echo "codex[$label]: viewer added"
+}
+
+command -v claude >/dev/null 2>&1 && add_claude user "" || echo "claude: CLI not found, skipped user config"
+add_codex_toml user "$HOME/.codex/config.toml"
+
+for dir in "$ACCOUNTS_ROOT"/claude/*/; do
+  [ -d "$dir" ] || continue
+  case "$dir" in *.lock/) continue ;; esac
+  add_claude "$(basename "$dir")" "$dir"
+done
+
+for dir in "$ACCOUNTS_ROOT"/codex/*/; do
+  [ -d "$dir" ] || continue
+  case "$dir" in *.lock/) continue ;; esac
+  add_codex_toml "$(basename "$dir")" "${dir}config.toml"
+done
+
+echo "done. New agent sessions pick the server up at startup; running sessions need a restart."


### PR DESCRIPTION
Adds `scripts/install-mcp.sh` — idempotent registration of the `viewer` MCP server across the operator's Claude Code/Codex configs and every Viewer-managed account (each spawned agent runs with its own `CLAUDE_CONFIG_DIR`/`CODEX_HOME`, so each account needs its own entry). Extends the README MCP section with CLI one-liners, the installer, and the server-naming constraint (`isViewerMcpServer`): only `viewer`/`viewer-*`/`agent-log-viewer*` render as Viewer cards in transcripts.

Verified live: stdio handshake, all 11 tools listed, `list_conversations` returns data, `clientRequestId` replay and idempotency-conflict behavior confirmed; installer ran idempotently across 6 managed Claude accounts + 1 Codex account.

🤖 Generated with [Claude Code](https://claude.com/claude-code)