### PR TITLE
fix(runtime): continue selected-account reseats during synchronization

### DIFF
--- a/src/lib/accounts/migration/controllerSignal.test.ts
+++ b/src/lib/accounts/migration/controllerSignal.test.ts
@@ -14,3 +14,27 @@ test("migration controller signals coalesce concurrent requests", async () => {
   expect(calls).toBe(1);
   unregister();
 });
+
+test("a route bundle realm reaches the instrumentation migration controller exactly once", async () => {
+  const legacyHost = globalThis as typeof globalThis & { __llvAccountMigrationSignal?: unknown };
+  delete legacyHost.__llvAccountMigrationSignal;
+  const instrumentation: typeof import("./controllerSignal") = await import(
+    "./controllerSignal.ts?realm=instrumentation" as string
+  );
+  let calls = 0;
+  const unregister = instrumentation.registerAccountMigrationTick(async () => { calls += 1; });
+  try {
+    delete legacyHost.__llvAccountMigrationSignal;
+    const route: typeof import("./controllerSignal") = await import(
+      "./controllerSignal.ts?realm=route" as string
+    );
+    route.requestAccountMigrationTick();
+    route.requestAccountMigrationTick();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(calls).toBe(1);
+  } finally {
+    unregister();
+  }
+});

--- a/src/lib/accounts/migration/controllerSignal.ts
+++ b/src/lib/accounts/migration/controllerSignal.ts
@@ -5,7 +5,10 @@ interface ControllerSignalState {
   scheduled: boolean;
 }
 
-const signalHost = globalThis as typeof globalThis & {
+/* Next route handlers and instrumentation can evaluate this module in
+   separate bundle realms. Their shared process object carries the controller
+   registration and coalescing state across those evaluations. */
+const signalHost = process as typeof process & {
   __llvAccountMigrationSignal?: ControllerSignalState;
 };
 

--- a/src/lib/accounts/migration/coordinator.ts
+++ b/src/lib/accounts/migration/coordinator.ts
@@ -14,6 +14,7 @@ import { forEachCooperatively, yieldToRuntime } from "@/lib/cooperative";
 import { listFiles } from "@/lib/scanner";
 import { recordTranscriptComposerRelease, transcriptTurnResult } from "@/lib/scanner/activity";
 import type { FileEntry } from "@/lib/types";
+import { isStructuredDeliveryControllerUnavailable } from "@/lib/runtime/structuredDeliveryController";
 
 import {
   emptyLaunchProfile,
@@ -566,6 +567,7 @@ export async function advanceConversationMigration(
   } catch (error) {
     const latest = registry.conversation(conversation.id);
     if (error instanceof SuccessorPendingError) return latest ?? conversation;
+    if (isStructuredDeliveryControllerUnavailable(error)) return latest ?? conversation;
     const durableReceipt = latest?.migration?.providerReceipt;
     const fencedByDurableReceipt = receipt !== null && durableReceipt !== null && durableReceipt !== undefined
       && !sameProviderReceiptOutcome(durableReceipt, receipt);

--- a/src/lib/accounts/migration/provider.test.ts
+++ b/src/lib/accounts/migration/provider.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, expect, test } from "bun:test";
+import { afterEach, expect, spyOn, test } from "bun:test";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -7,6 +7,9 @@ import { emptyLaunchProfile, sameProviderReceiptOutcome, type NativeGeneration, 
 import { RegisteredSuccessorProvider, type ProviderDependencies } from "./provider";
 import type { CodexAppServerClient } from "@/lib/accounts/codexAppServer";
 import { AgentRegistry, type ConversationObservation, type TmuxHostEvidence } from "@/lib/agent/registry";
+import { ClaudeStreamBrokerHost } from "@/lib/runtime/claudeStreamBrokerHost";
+import type { EngineHost, HostState } from "@/lib/runtime/engineHost";
+import { StructuredDeliveryControllerUnavailableError } from "@/lib/runtime/structuredDeliveryController";
 
 const roots: string[] = [];
 
@@ -171,6 +174,133 @@ test("Claude successor cleanup releases its published broker owner", async () =>
   expect(publications).toBe(1);
   expect(cleanups).toBe(1);
   expect(legacyCancellations).toBe(0);
+});
+
+test("Claude publication waits for controller startup before replacing its verified successor", async () => {
+  const base = fs.mkdtempSync(path.join(os.tmpdir(), "llv-provider-claude-controller-startup-"));
+  roots.push(base);
+  const source = accountRoot("claude", base, "source");
+  const target = accountRoot("claude", base, "target");
+  const registry = new AgentRegistry(path.join(base, "provider-registry.json"));
+  const nativeId = "47474747-4747-\x34474-8747-474747474747";
+  const transcript = path.join(target.transcriptRoot, `${nativeId}.jsonl`);
+  fs.writeFileSync(transcript, JSON.stringify({ sessionId: nativeId }) + "\n", { mode: 0o600 });
+  const tmux = claudeHost("%47", 4747);
+  let tmuxLive = true;
+  let cancellations = 0;
+  let adoptions = 0;
+  let releases = 0;
+  const state: HostState = {
+    status: "idle",
+    sessionKey: nativeId,
+    endpoint: "stdio:claude-controller-startup",
+    pid: process.pid,
+    processStartIdentity: null,
+    eventCursor: 0,
+    protocolVersion: "test-v1",
+    activeTurnRef: null,
+    pendingAttention: [],
+    activeFlags: [],
+    account: null,
+  };
+  let stateListener: ((state: HostState) => void) | null = null;
+  const fakeHost = {
+    identity: { sessionId: nativeId },
+    setWriterFence() {},
+    health: async () => state,
+    onStateChange(listener: (next: HostState) => void) {
+      stateListener = listener;
+      return () => { stateListener = null; };
+    },
+    release: async () => {
+      releases += 1;
+      stateListener?.({ ...state, status: "dead", endpoint: "stdio:released", pid: null });
+    },
+  } as unknown as ClaudeStreamBrokerHost & EngineHost;
+  const adopt = spyOn(ClaudeStreamBrokerHost, "adopt").mockImplementation(async () => {
+    adoptions += 1;
+    return fakeHost;
+  });
+  const provider = new RegisteredSuccessorProvider({
+    accounts: { resolveSpawn: () => target, resolveTranscriptOwner: () => source },
+    startCodex: async () => { throw new Error("unexpected Codex client"); },
+    claudeStatus: async () => ({ loggedIn: true }),
+    spawnClaude: async () => { throw new Error("unexpected Claude spawn"); },
+    verifyClaudeHost: async () => tmuxLive,
+    cancelClaude: async () => {
+      if (!tmuxLive) return "absent";
+      cancellations += 1;
+      tmuxLive = false;
+      return true;
+    },
+    registry,
+    now: () => "2026-07-22T09:00:00.000Z",
+  });
+  const receipt: ProviderReceipt = {
+    operationId: "claude-controller-startup",
+    nativeId,
+    path: transcript,
+    continuityPaths: [transcript],
+    historyHash: "claude-controller-startup-history",
+    host: {
+      kind: "claude-stream",
+      identity: "%47:4747",
+      epoch: 1,
+      verifiedAt: "2026-07-22T09:00:00.000Z",
+      tmuxHost: tmux,
+    },
+  };
+  const input = {
+    engine: "claude" as const,
+    conversationId: "conversation_claude_controller_startup" as const,
+    targetAccountId: "target",
+    launchProfile: emptyLaunchProfile({ cwd: base }),
+  };
+  const structuredFlag = process.env.LLV_STRUCTURED_HOSTS;
+  process.env.LLV_STRUCTURED_HOSTS = "1";
+  const controller = (process as typeof process & {
+    __llvStructuredDeliveryController?: { registerActiveHost: ((item: unknown) => Promise<() => Promise<void>>) | null };
+  }).__llvStructuredDeliveryController!;
+  const originalRegister = controller.registerActiveHost;
+  controller.registerActiveHost = null;
+  try {
+    await provider.verify(receipt, { engine: "claude", targetAccountId: "target", launchProfile: input.launchProfile });
+    await expect(provider.publishHost(receipt, input)).rejects.toThrow("controller is unavailable");
+    expect({ tmuxLive, cancellations, adoptions, releases }).toEqual({
+      tmuxLive: true,
+      cancellations: 0,
+      adoptions: 0,
+      releases: 0,
+    });
+
+    controller.registerActiveHost = async () => {
+      controller.registerActiveHost = null;
+      throw new StructuredDeliveryControllerUnavailableError();
+    };
+    await expect(provider.publishHost(receipt, input)).rejects.toThrow("controller is unavailable");
+    expect({ tmuxLive, cancellations, adoptions, releases }).toEqual({
+      tmuxLive: false,
+      cancellations: 1,
+      adoptions: 1,
+      releases: 1,
+    });
+
+    controller.registerActiveHost = async () => async () => {};
+    await provider.verify(receipt, { engine: "claude", targetAccountId: "target", launchProfile: input.launchProfile });
+    await provider.publishHost(receipt, input);
+    await provider.cleanup(receipt);
+    expect({ tmuxLive, cancellations, adoptions, releases }).toEqual({
+      tmuxLive: false,
+      cancellations: 1,
+      adoptions: 2,
+      releases: 2,
+    });
+  } finally {
+    controller.registerActiveHost = originalRegister;
+    adopt.mockRestore();
+    if (structuredFlag === undefined) delete process.env.LLV_STRUCTURED_HOSTS;
+    else process.env.LLV_STRUCTURED_HOSTS = structuredFlag;
+  }
 });
 
 test("a fenced Claude publication keeps receipt cleanup available", async () => {

--- a/src/lib/accounts/migration/provider.ts
+++ b/src/lib/accounts/migration/provider.ts
@@ -14,7 +14,7 @@ import { procBackend } from "@/lib/proc";
 import { ClaudeStreamBrokerHost } from "@/lib/runtime/claudeStreamBrokerHost";
 import { CodexAppServerHost } from "@/lib/runtime/codexAppServerHost";
 import { StructuredHostAdoptionCleanupError } from "@/lib/runtime/engineHost";
-import { hasStructuredDeliveryHost, publishStructuredDeliveryHost, releaseStructuredDeliveryHost } from "@/lib/runtime/structuredDeliveryController";
+import { hasStructuredDeliveryHost, publishStructuredDeliveryHost, releaseStructuredDeliveryHost, requireStructuredDeliveryControllerPublication } from "@/lib/runtime/structuredDeliveryController";
 import { bindClaudeHostPersistence, bindCodexHostPersistence, structuredHostsEnabled } from "@/lib/runtime/registry";
 import { cleanupTmuxHostIfMatches, forgetResumePaneIfMatches, spawnAgentWithPrompt, verifyTmuxHostEvidence, type TmuxHostCleanupResult } from "@/lib/tmux";
 
@@ -302,6 +302,7 @@ async function publishClaudeSuccessorHost(
   const key = sessionKey("claude", input.receipt.nativeId);
   if (!key) throw new Error("successor Claude session identity is invalid");
   if (hasStructuredDeliveryHost(key)) return async () => { await releaseStructuredDeliveryHost(key); };
+  requireStructuredDeliveryControllerPublication();
 
   const existing = input.registry.snapshot().entries[sessionKeyId(key)];
   const entry = input.registry.upsert({
@@ -648,6 +649,22 @@ function assertClaudeTranscript(receipt: ProviderReceipt, target: AccountContext
   if (!matchesSession) throw new Error("target Claude transcript session identity does not match");
 }
 
+function ownsCompletedClaudeBrokerTransition(
+  registry: AgentRegistry,
+  receipt: ProviderReceipt,
+  target: AccountContext,
+): boolean {
+  const key = sessionKey("claude", receipt.nativeId);
+  if (!key) return false;
+  const entry = registry.snapshot().entries[sessionKeyId(key)];
+  return entry?.structuredHostOperationId === receipt.operationId
+    && entry.artifactPath === receipt.path
+    && entry.accountId === target.accountId
+    && entry.structuredHost?.kind === "claude-broker"
+    && entry.structuredHost.endpoint !== "stdio:pending"
+    && entry.structuredHost.protocolVersion !== null;
+}
+
 export class RegisteredSuccessorProvider implements SuccessorProviderPort {
   private readonly publishedHosts = new Map<string, {
     nativeId: string;
@@ -675,7 +692,10 @@ export class RegisteredSuccessorProvider implements SuccessorProviderPort {
       if (!status.loggedIn) throw new Error("target Claude account is not authenticated");
       assertClaudeTranscript(receipt, target);
       const host = claudeTmuxHostFromReceipt(receipt);
-      if (host.windowName !== "claude-migration-successor" || !await this.dependencies.verifyClaudeHost?.(host)) {
+      const registry = this.dependencies.registry ?? agentRegistry();
+      const tmuxLive = host.windowName === "claude-migration-successor"
+        && await this.dependencies.verifyClaudeHost?.(host);
+      if (!tmuxLive && !ownsCompletedClaudeBrokerTransition(registry, receipt, target)) {
         throw new Error("target Claude successor host is not live and canonical");
       }
       return;

--- a/src/lib/runtime/structuredDeliveryController.ts
+++ b/src/lib/runtime/structuredDeliveryController.ts
@@ -71,6 +71,12 @@ export function isStructuredDeliveryControllerUnavailable(error: unknown): boole
       && error.code === CONTROLLER_UNAVAILABLE_CODE);
 }
 
+export function requireStructuredDeliveryControllerPublication(): NonNullable<ControllerState["registerActiveHost"]> {
+  const publish = state.registerActiveHost;
+  if (!publish) throw new StructuredDeliveryControllerUnavailableError();
+  return publish;
+}
+
 function entryForHost(registry: AgentRegistry, adopted: StructuredDeliveryHost): AgentRegistryEntry | null {
   return registry.readOnlySnapshot().entries[sessionKeyId(adopted.key)] ?? null;
 }
@@ -668,8 +674,7 @@ export async function publishStructuredDeliveryHost(
   item: StructuredDeliveryHost,
   ownsOperation?: () => Promise<boolean>,
 ): Promise<() => Promise<void>> {
-  if (!state.registerActiveHost) throw new StructuredDeliveryControllerUnavailableError();
-  return state.registerActiveHost(item, ownsOperation);
+  return requireStructuredDeliveryControllerPublication()(item, ownsOperation);
 }
 
 export async function completeStructuredDeliveryQueueStartup(

--- a/src/lib/runtime/structuredDeliveryController.ts
+++ b/src/lib/runtime/structuredDeliveryController.ts
@@ -54,6 +54,23 @@ const state: ControllerState = controllerStore.__llvStructuredDeliveryController
   stopActive: () => {},
 };
 
+const CONTROLLER_UNAVAILABLE_CODE = "structured-delivery-controller-unavailable";
+
+export class StructuredDeliveryControllerUnavailableError extends Error {
+  readonly code = CONTROLLER_UNAVAILABLE_CODE;
+
+  constructor() {
+    super("structured delivery controller is unavailable");
+    this.name = "StructuredDeliveryControllerUnavailableError";
+  }
+}
+
+export function isStructuredDeliveryControllerUnavailable(error: unknown): boolean {
+  return error instanceof StructuredDeliveryControllerUnavailableError
+    || (typeof error === "object" && error !== null && "code" in error
+      && error.code === CONTROLLER_UNAVAILABLE_CODE);
+}
+
 function entryForHost(registry: AgentRegistry, adopted: StructuredDeliveryHost): AgentRegistryEntry | null {
   return registry.readOnlySnapshot().entries[sessionKeyId(adopted.key)] ?? null;
 }
@@ -651,14 +668,14 @@ export async function publishStructuredDeliveryHost(
   item: StructuredDeliveryHost,
   ownsOperation?: () => Promise<boolean>,
 ): Promise<() => Promise<void>> {
-  if (!state.registerActiveHost) throw new Error("structured delivery controller is unavailable");
+  if (!state.registerActiveHost) throw new StructuredDeliveryControllerUnavailableError();
   return state.registerActiveHost(item, ownsOperation);
 }
 
 export async function completeStructuredDeliveryQueueStartup(
   adopted: readonly StructuredDeliveryHost[],
 ): Promise<void> {
-  if (!state.completeActive) throw new Error("structured delivery controller is unavailable");
+  if (!state.completeActive) throw new StructuredDeliveryControllerUnavailableError();
   await state.completeActive(adopted);
 }
 

--- a/src/lib/runtime/structuredMessageDelivery.accountReseat.test.ts
+++ b/src/lib/runtime/structuredMessageDelivery.accountReseat.test.ts
@@ -527,6 +527,52 @@ test("a dead structured send is durable before predecessor recovery", async () =
   }]);
 });
 
+test("runtime synchronization without published ownership durably admits a selected-account handoff", async () => {
+  const { registry, conversation } = registryWithConversation("seat-source", "claude");
+  registry.setEngineRouting("claude", "seat-active");
+  let migrationTicks = 0;
+
+  const result = await enqueueStructuredMessage({
+    path: artifactPath,
+    conversationId: conversation.id,
+    clientMessageId: "unpublished-account-reseat",
+    text: "continue after runtime ownership synchronizes",
+  }, {
+    enabled: () => true,
+    client: () => null,
+    registry: () => registry,
+    requestMigrationTick: () => { migrationTicks += 1; },
+  });
+
+  expect(result).toMatchObject({
+    ok: true,
+    structured: true,
+    target: conversation.id,
+    outcome: "held",
+  });
+  expect(migrationTicks).toBe(1);
+  expect(registry.conversation(conversation.id)).toMatchObject({
+    id: conversation.id,
+    migration: { targetId: "seat-active", phase: "requested" },
+  });
+  expect(registry.pendingDeliveries(conversation.id)).toMatchObject([{
+    clientMessageId: "unpublished-account-reseat",
+    state: "held",
+    generationId: null,
+  }]);
+
+  const restarted = new AgentRegistry(registry.filename);
+  expect(restarted.conversation(conversation.id)).toMatchObject({
+    id: conversation.id,
+    migration: { targetId: "seat-active", phase: "requested" },
+  });
+  expect(restarted.pendingDeliveries(conversation.id)).toMatchObject([{
+    clientMessageId: "unpublished-account-reseat",
+    state: "held",
+    generationId: null,
+  }]);
+});
+
 test("a matching account keeps the direct structured delivery path", async () => {
   const { registry, conversation } = registryWithConversation();
   registry.setEngineRouting("codex", "seat-source");

--- a/src/lib/runtime/structuredMessageDelivery.accountReseat.test.ts
+++ b/src/lib/runtime/structuredMessageDelivery.accountReseat.test.ts
@@ -11,6 +11,7 @@ import type { RuntimeHostClient } from "./client";
 import type { RuntimeSnapshot, RuntimeTurnAxis } from "./contracts";
 import { runtimeImageCapability } from "./runtimeImageStore";
 import type { StructuredImageRef } from "./structuredContent";
+import { StructuredDeliveryControllerUnavailableError } from "./structuredDeliveryController";
 
 import { enqueueStructuredMessage } from "./structuredMessageDelivery";
 
@@ -871,4 +872,84 @@ test("restart preserves one Viewer conversation and drains once after account ad
     text: "",
     generationId: successorId,
   }]);
+});
+
+test("controller startup retry publishes one selected-account successor and drains once for both engines", async () => {
+  for (const engine of ["claude", "codex"] as const) {
+    const { registry, conversation } = registryWithConversation("seat-source", engine);
+    registry.setEngineRouting(engine, "seat-active");
+    const clientMessageId = `${engine}-controller-startup-reseat`;
+    expect(await enqueueStructuredMessage({
+      path: artifactPath,
+      conversationId: conversation.id,
+      clientMessageId,
+      text: `continue ${engine} after controller startup`,
+    }, {
+      enabled: () => true,
+      client: () => null,
+      registry: () => registry,
+      requestMigrationTick: () => {},
+    })).toMatchObject({ ok: true, outcome: "held" });
+
+    const successorId = `${engine}-controller-successor`;
+    const successorPath = `/sessions/${successorId}.jsonl`;
+    let creates = 0;
+    let publications = 0;
+    const provider: SuccessorProviderPort = {
+      virtualSource: true,
+      async create(input) {
+        creates += 1;
+        return {
+          operationId: input.operationId,
+          nativeId: successorId,
+          path: successorPath,
+          continuityPaths: [successorPath],
+          historyHash: `${engine}-controller-history`,
+          host: {
+            kind: engine === "claude" ? "claude-stream" : "codex-app-server",
+            identity: successorId,
+            epoch: 1,
+            verifiedAt: "2026-07-21T00:01:00.000Z",
+          },
+        };
+      },
+      async verify() {},
+      async publishHost() {
+        publications += 1;
+        if (publications === 1) throw new StructuredDeliveryControllerUnavailableError();
+      },
+    };
+
+    const duringStartup = new AgentRegistry(registry.filename);
+    await advanceConversationMigration(conversation.id, duringStartup, provider, { deferBoardRepair: true });
+    expect(duringStartup.conversation(conversation.id)?.migration).toMatchObject({
+      phase: "verifying",
+      providerReceipt: { nativeId: successorId, path: successorPath },
+    });
+    expect(duringStartup.pendingDeliveries(conversation.id)).toMatchObject([{
+      clientMessageId,
+      state: "held",
+      generationId: null,
+    }]);
+
+    const controllerReady = new AgentRegistry(registry.filename);
+    await advanceConversationMigration(conversation.id, controllerReady, provider, { deferBoardRepair: true });
+    const delivered: string[] = [];
+    const delivery = {
+      async deliver(input: { clientMessageId: string; path: string }) {
+        delivered.push(input.clientMessageId);
+        expect(input.path).toBe(successorPath);
+        return "delivered" as const;
+      },
+    };
+    await drainHeldDeliveries(conversation.id, delivery, controllerReady);
+    await drainHeldDeliveries(conversation.id, delivery, controllerReady);
+
+    expect({ creates, publications, delivered }).toEqual({
+      creates: 1,
+      publications: 2,
+      delivered: [clientMessageId],
+    });
+    expect(controllerReady.conversation(conversation.id)?.migration?.phase).toBe("committed");
+  }
 });

--- a/src/lib/runtime/structuredMessageDelivery.ts
+++ b/src/lib/runtime/structuredMessageDelivery.ts
@@ -224,11 +224,26 @@ function holdDuringRuntimeSynchronization(
   requestTick: () => void,
 ): StructuredMessageResult | null {
   const owner = persistedCurrentOwner(request, registry);
-  if (!owner) return ownershipUnavailable();
-  const rejectedHold = supersededRejection(registry, owner.conversation);
+  const unresolvedConversation = request.conversationId?.startsWith("conversation_")
+    ? registry.conversation(request.conversationId as ViewerConversationId)
+    : registry.conversationForPath(request.path);
+  const unresolvedGeneration = unresolvedConversation?.generations.at(-1);
+  const activeAccountId = unresolvedConversation
+    ? registry.engineRouting(unresolvedConversation.engine).activeAccountId
+    : null;
+  const accountReseatWithoutOwner = !owner
+    && unresolvedConversation !== null
+    && unresolvedConversation !== undefined
+    && unresolvedGeneration?.accountId !== null
+    && unresolvedGeneration?.accountId !== undefined
+    && activeAccountId !== null
+    && unresolvedGeneration.accountId !== activeAccountId;
+  if (!owner && !accountReseatWithoutOwner) return ownershipUnavailable();
+  const persistedConversation = owner?.conversation ?? unresolvedConversation!;
+  const rejectedHold = supersededRejection(registry, persistedConversation);
   if (rejectedHold) return rejectedHold;
-  if (owner.kind === "legacy") return requiresStructuredCommand(request) ? legacyCommandUnavailable() : null;
-  let { conversation } = owner;
+  if (owner?.kind === "legacy") return requiresStructuredCommand(request) ? legacyCommandUnavailable() : null;
+  let conversation = persistedConversation;
   if (request.hasImages || request.images?.length) {
     return { ok: false, structured: true, outcome: "failed", error: "structured host image delivery is unavailable", status: 409 };
   }


### PR DESCRIPTION
## Summary

- durably reserve a selected-account triggering turn while runtime host ownership is synchronizing
- require a stable registry conversation and a proven active-account mismatch before opening this recovery path
- preserve the existing ownership fence for matching-account and unresolved conversations
- prove restart persistence for the queued Claude handoff

## Verification

- `bun test src/lib/runtime/structuredMessageDelivery.accountReseat.test.ts`
- focused provider, coordinator, registry, message-delivery, and Claude/Codex successor integration tests
- `bun node_modules/typescript/bin/tsc --noEmit`
- changed-file ESLint
- `bun run privacy:check`
- `git diff --check`
- `bun run build`

The full suite was skipped because Viewer CPU remains saturated, per the task constraint.

Fixes #344