### PR TITLE
fix(ci): make tracker privacy findings advisory

### DIFF
--- a/.github/workflows/privacy-tracker-audit.yml
+++ b/.github/workflows/privacy-tracker-audit.yml
@@ -59,4 +59,4 @@ jobs:
           if [[ -n "$PUBLICATION_ISSUE_COMMENT_ID" ]]; then
             arguments+=(--issue-comment "$PUBLICATION_ISSUE_COMMENT_ID")
           fi
-          bun scripts/privacy-github-audit.ts "${arguments[@]}"
+          bun scripts/privacy-github-audit.ts "${arguments[@]}" --report-only

--- a/scripts/privacy-github-audit.ts
+++ b/scripts/privacy-github-audit.ts
@@ -5,8 +5,8 @@ import { extname, join } from "node:path";
 import {
   canonicalSensitiveText,
   type FindingClass,
+  formatPrivacyReport,
   inspectPaths,
-  reportPrivacyFindings,
   sensitiveClasses,
 } from "./privacy-publication-gate";
 
@@ -32,6 +32,17 @@ type GithubSurface = {
   body?: unknown;
   title?: unknown;
 };
+
+const operationalFailureClasses = new Set<FindingClass>([
+  "configuration_error",
+  "inspection_error",
+  "tool_unavailable",
+]);
+
+export function shouldFailGithubAudit(findings: Map<FindingClass, number>, reportOnly: boolean): boolean {
+  if (!reportOnly) return findings.size > 0;
+  return [...findings.keys()].some((finding) => operationalFailureClasses.has(finding));
+}
 
 const trustedMediaHosts = new Set([
   "github.com",
@@ -549,5 +560,6 @@ if (import.meta.main) {
       : { id: Number(issueCommentId), kind: "issue_comment" },
     token: process.env.GITHUB_TOKEN ?? process.env.GH_TOKEN ?? "",
   });
-  reportPrivacyFindings(findings);
+  process.stdout.write(formatPrivacyReport(findings));
+  if (shouldFailGithubAudit(findings, arguments_.includes("--report-only"))) process.exitCode = 1;
 }

--- a/scripts/privacy-publication-gate.test.ts
+++ b/scripts/privacy-publication-gate.test.ts
@@ -5,7 +5,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { deflateSync } from "node:zlib";
 
-import { auditGithubPublication } from "./privacy-github-audit";
+import { auditGithubPublication, shouldFailGithubAudit } from "./privacy-github-audit";
 import { formatPrivacyReport } from "./privacy-publication-gate";
 
 const gate = join(import.meta.dir, "privacy-publication-gate.ts");
@@ -1346,6 +1346,18 @@ exec "$LLV_TEST_REAL_GIT" "$@"
       "PUBLICATION_ISSUE_COMMENT_ID: ${{ github.event_name == 'issue_comment' && github.event.comment.id || '' }}",
     );
     expect(workflow).toContain('--issue-comment "$PUBLICATION_ISSUE_COMMENT_ID"');
+  });
+
+  test("reports post-publication tracker findings without hiding audit failures", () => {
+    const workflow = readFileSync(join(import.meta.dir, "..", ".github", "workflows", "privacy-tracker-audit.yml"), "utf8");
+
+    expect(workflow).not.toContain("continue-on-error: true");
+    expect(workflow).toContain('bun scripts/privacy-github-audit.ts "${arguments[@]}" --report-only');
+    expect(shouldFailGithubAudit(new Map([["resource_identifier", 1]]), true)).toBe(false);
+    expect(shouldFailGithubAudit(new Map([["home_path", 1]]), true)).toBe(false);
+    expect(shouldFailGithubAudit(new Map([["inspection_error", 1]]), true)).toBe(true);
+    expect(shouldFailGithubAudit(new Map([["configuration_error", 1]]), true)).toBe(true);
+    expect(shouldFailGithubAudit(new Map([["resource_identifier", 1]]), false)).toBe(true);
   });
 
   test("uses trusted scanner and fingerprints when every candidate gate surface is tampered", () => {


### PR DESCRIPTION
## Summary

- add a report-only mode for privacy findings discovered on already-public tracker surfaces
- keep configuration, inspection, and tool failures blocking
- preserve the fail-closed pull-request publication gate
- cover the workflow and exit policy with a regression test

## Verification

- bun test scripts/privacy-publication-gate.test.ts (100 passed)
- bun run lint -- scripts/privacy-github-audit.ts scripts/privacy-publication-gate.test.ts
- actionlint .github/workflows/privacy-tracker-audit.yml
- git diff --check