### PR TITLE
Restore structured delivery under scanner pressure and orphaned turns

### DIFF
--- a/src/lib/accounts/migration/coordinator.ts
+++ b/src/lib/accounts/migration/coordinator.ts
@@ -241,7 +241,12 @@ function terminalMigrationPhase(phase: string): boolean {
 }
 
 function successorCreationReady(conversation: RegistryConversation, registry: AgentRegistry): boolean {
-  if (conversation.turn.state !== "terminal" && conversation.turn.state !== "idle") return false;
+  const sourcePath = conversation.generations.at(-1)?.path;
+  const unmaterializedEmptyTurn = conversation.turn.state === "unknown"
+    && conversation.turn.source === "empty"
+    && Boolean(sourcePath)
+    && !fs.existsSync(sourcePath!);
+  if (conversation.turn.state !== "terminal" && conversation.turn.state !== "idle" && !unmaterializedEmptyTurn) return false;
   return !registry.pendingDeliveries(conversation.id).some((delivery) => delivery.state === "delivery-uncertain");
 }
 

--- a/src/lib/agent/registry.ts
+++ b/src/lib/agent/registry.ts
@@ -464,7 +464,7 @@ function migrationReadiness(
   file: RegistryFile,
   conversation: RegistryConversation,
 ): "idle" | "busy" | "deferred" {
-  if (conversation.turn.state === "busy" || conversation.turn.state === "unknown") return "busy";
+  if (migrationTurnIsBusy(file, conversation)) return "busy";
   const deliveryInFlight = Object.values(file.heldDeliveries).some((delivery) =>
     delivery.conversationId === conversation.id && delivery.state === "delivery-uncertain");
   if (deliveryInFlight) return "busy";
@@ -476,6 +476,19 @@ function migrationReadiness(
   const hasPendingDelivery = Object.values(file.heldDeliveries).some((delivery) =>
     delivery.conversationId === conversation.id && delivery.state !== "delivered");
   return hasPendingDelivery ? "idle" : "deferred";
+}
+
+function migrationTurnIsBusy(file: RegistryFile, conversation: RegistryConversation): boolean {
+  const currentPath = conversation.generations.at(-1)?.path;
+  const hasPendingDelivery = Object.values(file.heldDeliveries).some((delivery) =>
+    delivery.conversationId === conversation.id && delivery.state !== "delivered");
+  const unmaterializedEmptyTurn = conversation.turn.state === "unknown"
+    && conversation.turn.source === "empty"
+    && Boolean(currentPath)
+    && !fs.existsSync(currentPath!)
+    && !hasPendingDelivery;
+  return conversation.turn.state === "busy"
+    || (conversation.turn.state === "unknown" && !unmaterializedEmptyTurn);
 }
 
 function resumeCanRebaseMigration(migration: ConversationMigration | null): boolean {
@@ -3592,7 +3605,7 @@ export class AgentRegistry {
     if (activeIntent && source && source.accountId !== activeIntent.targetId && !conversation.migration) {
       conversation.migration = {
         intentId: activeIntent.id,
-        phase: conversation.turn.state === "busy" || conversation.turn.state === "unknown" ? "waiting-turn" : "requested",
+        phase: migrationTurnIsBusy(file, conversation) ? "waiting-turn" : "requested",
         targetId: activeIntent.targetId,
         revision: activeIntent.revision,
         error: null,
@@ -5103,7 +5116,7 @@ export class AgentRegistry {
       if (!source) throw new Error("conversation has no source generation");
       conversation.migration = {
         ...current,
-        phase: conversation.turn.state === "busy" || conversation.turn.state === "unknown" ? "waiting-turn" : "requested",
+        phase: migrationTurnIsBusy(file, conversation) ? "waiting-turn" : "requested",
         targetId: intent.targetId,
         revision: intent.revision,
         operationId: current.errorCode === "codex-fork-outcome-unknown" ? current.operationId : crypto.randomUUID(),

--- a/src/lib/runtime/structuredMessageDelivery.accountReseat.test.ts
+++ b/src/lib/runtime/structuredMessageDelivery.accountReseat.test.ts
@@ -6,14 +6,14 @@ import { afterAll, expect, test } from "bun:test";
 
 import { AgentRegistry } from "@/lib/agent/registry";
 import { advanceConversationMigration, drainHeldDeliveries } from "@/lib/accounts/migration/coordinator";
-import { emptyLaunchProfile, type SuccessorProviderPort, type TurnState } from "@/lib/accounts/migration/contracts";
+import { emptyLaunchProfile, type HeldDelivery, type SuccessorProviderPort, type TurnState } from "@/lib/accounts/migration/contracts";
 import type { RuntimeHostClient } from "./client";
 import type { RuntimeSnapshot, RuntimeTurnAxis } from "./contracts";
 import { runtimeImageCapability } from "./runtimeImageStore";
 import type { StructuredImageRef } from "./structuredContent";
 import { StructuredDeliveryControllerUnavailableError } from "./structuredDeliveryController";
 
-import { enqueueStructuredMessage } from "./structuredMessageDelivery";
+import { deliverHeldStructuredMessage, enqueueStructuredMessage } from "./structuredMessageDelivery";
 
 const artifactPath = "/sessions/native-source.jsonl";
 const sandbox = fs.mkdtempSync(path.join(os.tmpdir(), "llv-account-reseat-"));
@@ -26,6 +26,7 @@ function registryWithConversation(
   accountId = "seat-source",
   engine: "codex" | "claude" = "codex",
   turnState: Exclude<TurnState["state"], "terminal"> = "idle",
+  turnSource: TurnState["source"] = turnState === "idle" ? "empty" : "assistant",
 ) {
   const registry = new AgentRegistry(path.join(sandbox, `registry-${registryNumber += 1}.json`));
   registry.reconcileConversations([{
@@ -33,7 +34,7 @@ function registryWithConversation(
     path: artifactPath,
     accountId,
     launchProfile: emptyLaunchProfile({ cwd: "/repo", project: "project" }),
-    turn: { state: turnState, source: turnState === "idle" ? "empty" : "assistant", terminalAt: null },
+    turn: { state: turnState, source: turnSource, terminalAt: null },
     observedAt: "2026-07-21T00:00:00.000Z",
   }]);
   return { registry, conversation: registry.conversationForPath(artifactPath)! };
@@ -694,6 +695,139 @@ test("an explicit migration opt-out keeps a synchronization hold assigned to the
   await drainHeldDeliveries(conversation.id, delivery, restarted);
   await drainHeldDeliveries(conversation.id, delivery, restarted);
   expect(sourceDeliveries).toEqual(["synchronization-opted-out-send"]);
+});
+
+test("a fresh empty-turn spawn on a draining source account reaches one successor", async () => {
+  const { registry, conversation } = registryWithConversation("seat-source", "codex", "unknown", "empty");
+  registry.setEngineRouting("codex", "seat-active");
+  let predecessorCommands = 0;
+  const result = await enqueueStructuredMessage({
+    path: artifactPath,
+    conversationId: conversation.id,
+    clientMessageId: "fresh-empty-turn-send",
+    text: "start on the selected account",
+  }, {
+    enabled: () => true,
+    client: () => deliveredClient(conversation.id, () => { predecessorCommands += 1; }, "unknown"),
+    registry: () => registry,
+    requestMigrationTick: () => {},
+  });
+
+  expect(result).toMatchObject({ ok: true, outcome: "held" });
+  expect(predecessorCommands).toBe(0);
+  expect(registry.conversation(conversation.id)?.migration?.phase).toBe("requested");
+
+  let successorCreates = 0;
+  const successorPath = "/sessions/fresh-empty-successor.jsonl";
+  await advanceConversationMigration(conversation.id, registry, {
+    virtualSource: true,
+    async create(input) {
+      successorCreates += 1;
+      return {
+        operationId: input.operationId,
+        nativeId: "fresh-empty-successor",
+        path: successorPath,
+        continuityPaths: [successorPath],
+        historyHash: "fresh-empty-history",
+        host: { kind: "codex-app-server", identity: "fresh-empty-successor", epoch: 1, verifiedAt: new Date().toISOString() },
+      };
+    },
+    async verify() {},
+  }, { deferBoardRepair: true });
+  const delivered: string[] = [];
+  const port = {
+    async deliver(input: { path: string; clientMessageId: string }) {
+      expect(input.path).toBe(successorPath);
+      delivered.push(input.clientMessageId);
+      return "delivered" as const;
+    },
+  };
+  await drainHeldDeliveries(conversation.id, port, registry);
+  await drainHeldDeliveries(conversation.id, port, registry);
+
+  expect({ successorCreates, delivered }).toEqual({
+    successorCreates: 1,
+    delivered: ["fresh-empty-turn-send"],
+  });
+  expect(registry.conversation(conversation.id)?.migration?.phase).toBe("committed");
+});
+
+test("a post-rollback stale busy owner recovers its missing host and drains once", async () => {
+  const { registry, conversation } = registryWithConversation("seat-source", "codex", "busy");
+  recordStructuredOwner(registry, conversation);
+  registry.setEngineRouting("codex", "seat-active");
+  const admitted = await enqueueStructuredMessage({
+    path: artifactPath,
+    conversationId: conversation.id,
+    clientMessageId: "stale-busy-post-rollback",
+    text: "continue after the orphaned turn",
+  }, {
+    enabled: () => true,
+    client: () => null,
+    registry: () => registry,
+    requestMigrationTick: () => {},
+  });
+  expect(admitted).toMatchObject({ ok: true, outcome: "held" });
+  registry.rollbackConversationMigration(conversation.id, registry.conversation(conversation.id)!.migration!.revision);
+
+  let hostAvailable = false;
+  let recoveries = 0;
+  let commands = 0;
+  const client = {
+    snapshot: async () => hostAvailable ? snapshot(conversation.id, "codex", "hosted", "idle") : {
+      ...snapshot(conversation.id, "codex", "dead", "unknown"),
+      sessions: [],
+    },
+    command: async (command: { operationId: string; idempotencyKey: string; conversationId: string }) => {
+      commands += 1;
+      return {
+        operationId: command.operationId,
+        replayed: false,
+        receipt: {
+          operationId: command.operationId,
+          idempotencyKey: command.idempotencyKey,
+          conversationId: command.conversationId,
+          kind: "send" as const,
+          status: "delivered" as const,
+          at: "2026-07-22T00:00:00.000Z",
+          revision: 1,
+        },
+      };
+    },
+    operationStatus: async () => null,
+  } as unknown as RuntimeHostClient;
+  const port = {
+    async deliver(input: { delivery: { id: string; conversationId: string; text: string; command: HeldDelivery["command"] }; path: string; clientMessageId: string }) {
+      return await deliverHeldStructuredMessage({
+        conversationId: input.delivery.conversationId,
+        path: input.path,
+        deliveryId: input.delivery.id,
+        clientMessageId: input.clientMessageId,
+        text: input.delivery.text,
+        command: input.delivery.command,
+      }, {
+        enabled: () => true,
+        client: () => client,
+        registry: () => registry,
+        kick: () => {},
+        recover: async () => {
+          recoveries += 1;
+          hostAvailable = true;
+          return { target: null, path: artifactPath, conversationId: conversation.id, spawned: true };
+        },
+      }) ?? "delivery-uncertain";
+    },
+  };
+  await drainHeldDeliveries(conversation.id, port, registry);
+  await drainHeldDeliveries(conversation.id, port, registry);
+  await drainHeldDeliveries(conversation.id, port, registry);
+
+  expect({ recoveries, commands }).toEqual({ recoveries: 1, commands: 1 });
+  expect(Object.values(registry.snapshot().heldDeliveries)).toMatchObject([{
+    clientMessageId: "stale-busy-post-rollback",
+    state: "delivered",
+    attempts: 2,
+  }]);
 });
 
 test("runtime synchronization preserves an already-claimed source delivery during reseat", async () => {

--- a/src/lib/runtime/structuredMessageDelivery.ts
+++ b/src/lib/runtime/structuredMessageDelivery.ts
@@ -103,9 +103,10 @@ export interface HeldStructuredMessageDependencies {
   startupFailed?: () => boolean;
   startupRecovered?: () => void;
   republish?: (key: RuntimeSession["sessionKey"]) => Promise<boolean>;
+  recover?: typeof recoverDeadStructuredConversation;
 }
 
-export type HeldStructuredMessageOutcome = "delivered" | "failed" | "delivery-uncertain" | null;
+export type HeldStructuredMessageOutcome = "delivered" | "failed" | "delivery-uncertain" | "held" | null;
 
 function structuredHostsEnabled(): boolean {
   return process.env.LLV_STRUCTURED_HOSTS === "1";
@@ -402,21 +403,41 @@ export async function deliverHeldStructuredMessage(
   dependencies: HeldStructuredMessageDependencies = {},
 ): Promise<HeldStructuredMessageOutcome> {
   if (!(dependencies.enabled ?? structuredHostsEnabled)()) return null;
+  const registry = (dependencies.registry ?? agentRegistry)();
   const client = (dependencies.client ?? runtimeHostClient)();
   if (!client) {
-    return heldOutcomeDuringRuntimeSynchronization(request, (dependencies.registry ?? agentRegistry)());
+    return heldOutcomeDuringRuntimeSynchronization(request, registry);
   }
   let snapshot: Awaited<ReturnType<RuntimeHostClient["snapshot"]>>;
   try {
     snapshot = await client.snapshot();
   } catch (error) {
     console.error("[structured delivery] runtime snapshot failed", error);
-    return heldOutcomeDuringRuntimeSynchronization(request, (dependencies.registry ?? agentRegistry)());
+    return heldOutcomeDuringRuntimeSynchronization(request, registry);
   }
   recordStructuredRuntimeRecovery(snapshot, dependencies.startupRecovered ?? markStructuredHostStartupReady);
   let session = snapshot.sessions.find((candidate) => candidate.conversationId === request.conversationId)
     ?? snapshot.sessions.find((candidate) => candidate.artifactPath === request.path);
-  if (!session) return heldOutcomeDuringRuntimeSynchronization(request, (dependencies.registry ?? agentRegistry)());
+  if (!session) {
+    if (persistedCurrentOwner(request, registry)?.kind !== "structured") {
+      return heldOutcomeDuringRuntimeSynchronization(request, registry);
+    }
+    try {
+      const recovered = await (dependencies.recover ?? recoverDeadStructuredConversation)({
+        path: request.path,
+        conversationId: request.conversationId,
+      }, {
+        registry,
+        client,
+        requestDeliveryDrain: () => {
+          void (dependencies.kick ?? kickStructuredDeliveryQueue)();
+        },
+      });
+      return recovered ? "held" : "delivery-uncertain";
+    } catch {
+      return "delivery-uncertain";
+    }
+  }
   try {
     const refreshed = await refreshRepublishedSession(
       session,

--- a/src/lib/scanner/links.performance.test.ts
+++ b/src/lib/scanner/links.performance.test.ts
@@ -635,3 +635,35 @@ test("proven compaction chains survive restart after predecessor growth", async 
   expect(predecessor.parent as string | null).toBe(successor.path);
   expect(bytesRead).toBeLessThanOrEqual(512 * 1024);
 });
+
+test("runtime callbacks advance while a large lineage projection is linking", async () => {
+  const pathname = path.join(SANDBOX, "cooperative-linking.jsonl");
+  fs.writeFileSync(pathname, "{}\n");
+  let runtimeCallbackAdvanced = false;
+  const callback = new Promise<void>((resolve) => {
+    setImmediate(() => {
+      runtimeCallbackAdvanced = true;
+      resolve();
+    });
+  });
+  const entries = Array.from({ length: 96 }, (_, index) => {
+    const projected = entry(pathname, `cooperative-${index}`, index);
+    Object.defineProperty(projected, "root", {
+      configurable: true,
+      get() {
+        const deadline = performance.now() + 2;
+        while (performance.now() < deadline) {
+          // Reproduce CPU-heavy synchronous projection work in production scans.
+        }
+        return "system";
+      },
+    });
+    projected.path = `${pathname}-${index}`;
+    return projected;
+  });
+
+  await linkEntries(entries, { persist: false });
+
+  expect(runtimeCallbackAdvanced).toBe(true);
+  await callback;
+});

--- a/src/lib/scanner/links.ts
+++ b/src/lib/scanner/links.ts
@@ -11,6 +11,7 @@ import {
   persistHandoffLineage,
   rememberHandoffChild,
 } from "../handoffLineage";
+import { forEachCooperatively } from "../cooperative";
 import type { FileEntry } from "../types";
 import { globalCache } from "./caches";
 import { claudeSubagentLineage } from "./claudeNative";
@@ -252,15 +253,15 @@ function compactParentUuid(pathname: string, size: number): string | null {
  * already gone (middle hop of a longer chain), the nearest older non-live
  * session of the same slug stands in.
  */
-function chainCompactedSessions(entries: FileEntry[]): void {
+async function chainCompactedSessions(entries: FileEntry[]): Promise<void> {
   const mainsBySlug = new Map<string, FileEntry[]>();
-  for (const entry of entries) {
-    if (entry.root !== "claude-projects") continue;
+  await forEachCooperatively(entries, (entry) => {
+    if (entry.root !== "claude-projects") return;
     const parts = entry.name.split(path.sep);
-    if (parts.length !== 2) continue;
+    if (parts.length !== 2) return;
     const slug = parts[0] ?? "";
     mainsBySlug.set(slug, (mainsBySlug.get(slug) ?? []).concat(entry));
-  }
+  });
   const chainsBack = (from: FileEntry, target: FileEntry, mains: FileEntry[]): boolean => {
     const byPath = new Map(mains.map((main) => [main.path, main]));
     const seen = new Set<string>();
@@ -270,19 +271,19 @@ function chainCompactedSessions(entries: FileEntry[]): void {
     }
     return false;
   };
-  for (const mains of mainsBySlug.values()) {
+  await forEachCooperatively([...mainsBySlug.values()], async (mains) => {
     const ordered = [...mains].sort((a, b) => a.mtime - b.mtime);
-    for (const successor of ordered) {
+    await forEachCooperatively(ordered, (successor) => {
       const rememberedPath = compactLinkCache.get(successor.path);
       const remembered = rememberedPath
         ? ordered.find((candidate) => candidate.path === rememberedPath && candidate !== successor && !candidate.parent)
         : undefined;
       if (remembered && !chainsBack(successor, remembered, mains)) {
         remembered.parent = successor.path;
-        continue;
+        return;
       }
       const uuid = compactParentUuid(successor.path, successor.size);
-      if (!uuid) continue;
+      if (!uuid) return;
       // Late system records (away_summary…) can bump the predecessor's mtime
       // above the successor's, so candidates are not mtime-gated: the marker
       // uuid proves direction and chainsBack blocks accidental cycles. The
@@ -295,8 +296,8 @@ function chainCompactedSessions(entries: FileEntry[]): void {
       if (proven) rememberCompactChain(successor.path, proven.path);
       const predecessor = proven ?? (alive ? candidates.find((candidate) => candidate.activity !== "live") : undefined);
       if (predecessor && !chainsBack(successor, predecessor, mains)) predecessor.parent = successor.path;
-    }
-  }
+    });
+  });
 }
 
 async function globWalk(dir: string, pred: (pathname: string) => boolean, limit: Limit): Promise<string[]> {
@@ -557,16 +558,16 @@ function persistLineage(): void {
   }
 }
 
-function attachNativeCodexSubagentParents(entries: FileEntry[], persist: boolean): void {
+async function attachNativeCodexSubagentParents(entries: FileEntry[], persist: boolean): Promise<void> {
   loadLineage();
   const pathByThreadId = new Map<string, string>();
-  for (const entry of entries) {
-    if (entry.root !== "codex-sessions" || !entry.path.endsWith(".jsonl")) continue;
+  await forEachCooperatively(entries, (entry) => {
+    if (entry.root !== "codex-sessions" || !entry.path.endsWith(".jsonl")) return;
     const id = codexThreadIdFromPath(entry.path);
     if (id) pathByThreadId.set(id, entry.path);
-  }
-  for (const entry of entries) {
-    if (entry.root !== "codex-sessions" || entry.parent) continue;
+  });
+  await forEachCooperatively(entries, (entry) => {
+    if (entry.root !== "codex-sessions" || entry.parent) return;
     const parentThreadId = entry.nativeParentThreadId === undefined
       ? nativeCodexParentThreadId(entry.path, entry.size, entry.mtime * 1000)
       : entry.nativeParentThreadId;
@@ -575,7 +576,7 @@ function attachNativeCodexSubagentParents(entries: FileEntry[], persist: boolean
       entry.parent = parent;
       if (persist) rememberLineage(entry.path, parent);
     }
-  }
+  });
   if (persist) persistLineage();
 }
 
@@ -585,17 +586,17 @@ function attachNativeCodexSubagentParents(entries: FileEntry[], persist: boolean
  * is the spawner: the nearest Claude or Codex ancestor owns the child rollout.
  * This is a spawn-lineage fact; no mtime or project heuristics participate.
  */
-function attachLiveCodexParents(entries: FileEntry[], persist: boolean): void {
+async function attachLiveCodexParents(entries: FileEntry[], persist: boolean): Promise<void> {
   loadLineage();
   const orphans = entries.filter((entry) => entry.root === "codex-sessions" && !entry.parent);
   if (orphans.length === 0) return;
   const ownerByPid = new Map<number, string>();
-  for (const entry of entries) {
+  await forEachCooperatively(entries, (entry) => {
     if ((entry.root === "claude-projects" || entry.root === "codex-sessions") && entry.pid !== null) {
       ownerByPid.set(entry.pid, entry.path);
     }
-  }
-  for (const rollout of orphans) {
+  });
+  await forEachCooperatively(orphans, (rollout) => {
     let resolved: string | null = null;
     const seen = new Set<number>();
     for (let pid: number | null = rollout.pid; pid !== null && !seen.has(pid); pid = readPpid(pid)) {
@@ -615,7 +616,7 @@ function attachLiveCodexParents(entries: FileEntry[], persist: boolean): void {
       const remembered = lineageCache.get(rollout.path);
       if (remembered) rollout.parent = remembered;
     }
-  }
+  });
   if (persist) persistLineage();
 }
 
@@ -627,12 +628,12 @@ function attachLiveCodexParents(entries: FileEntry[], persist: boolean): void {
  * The `handoff` flag makes the UI treat the child as a branch of its source
  * rather than a compaction predecessor.
  */
-function attachHandoffParents(entries: FileEntry[], persist: boolean): void {
+async function attachHandoffParents(entries: FileEntry[], persist: boolean): Promise<void> {
   const byPath = new Map(entries.map((entry) => [entry.path, entry]));
-  for (const entry of entries) {
-    if (entry.parent) continue;
-    if (entry.root !== "claude-projects" && entry.root !== "codex-sessions") continue;
-    if (!entry.path.endsWith(".jsonl") || entry.path.includes(path.sep + "subagents" + path.sep)) continue;
+  await forEachCooperatively(entries, (entry) => {
+    if (entry.parent) return;
+    if (entry.root !== "claude-projects" && entry.root !== "codex-sessions") return;
+    if (!entry.path.endsWith(".jsonl") || entry.path.includes(path.sep + "subagents" + path.sep)) return;
     let parent = handoffParentForChild(entry.path);
     if (!parent && entry.pid !== null) {
       const seen = new Set<number>();
@@ -648,7 +649,7 @@ function attachHandoffParents(entries: FileEntry[], persist: boolean): void {
       entry.parent = parent;
       entry.handoff = true;
     }
-  }
+  });
   if (persist) persistHandoffLineage();
 }
 
@@ -661,13 +662,13 @@ export async function linkEntries(entries: FileEntry[], options: { persist?: boo
   const nestedNeedleBudget = { remaining: NESTED_SUBAGENT_NEEDLE_BUDGET_BYTES };
   const byPath = new Map(entries.map((entry) => [entry.path, entry]));
   const backgroundTasks = new Map<FileEntry, [string, string, string]>();
-  for (const entry of entries) {
-    if (entry.root !== "claude-tasks") continue;
+  await forEachCooperatively(entries, (entry) => {
+    if (entry.root !== "claude-tasks") return;
     const parts = taskParts(ROOTS["claude-tasks"], entry.path);
     if (parts) backgroundTasks.set(entry, parts);
-  }
+  });
   let remainingBackgroundTasks = backgroundTasks.size;
-  for (const entry of entries) {
+  await forEachCooperatively(entries, async (entry) => {
     if (entry.root === "claude-projects") {
       // Both the direct `subagents/agent-*.jsonl` layout and the nested Workflow
       // `subagents/**​/agent-*.jsonl` layout resolve to the same root parent
@@ -691,7 +692,7 @@ export async function linkEntries(entries: FileEntry[], options: { persist?: boo
       }
     } else if (entry.root === "claude-tasks") {
       const parts = backgroundTasks.get(entry);
-      if (!parts) continue;
+      if (!parts) return;
       const [slug, sid, tid] = parts;
       const [main, subs] = await sessionTranscripts(sid, limit, slug);
       /* Reserve each pending task a share of this generation's remaining
@@ -727,11 +728,11 @@ export async function linkEntries(entries: FileEntry[], options: { persist?: boo
         entry.cmdDesc = "";
       }
     }
-  }
-  attachNativeCodexSubagentParents(entries, persist);
-  attachLiveCodexParents(entries, persist);
-  attachHandoffParents(entries, persist);
-  chainCompactedSessions(entries);
+  });
+  await attachNativeCodexSubagentParents(entries, persist);
+  await attachLiveCodexParents(entries, persist);
+  await attachHandoffParents(entries, persist);
+  await chainCompactedSessions(entries);
   const rootProject = (entry: FileEntry): string => {
     const seen = new Set<string>();
     let cur: FileEntry = entry;
@@ -743,10 +744,10 @@ export async function linkEntries(entries: FileEntry[], options: { persist?: boo
     }
     return entry.project;
   };
-  for (const entry of entries) {
+  await forEachCooperatively(entries, (entry) => {
     if (!entry.parent || !byPath.has(entry.parent)) entry.parent = null;
     else entry.project = rootProject(entry);
-  }
+  });
   if (persist) {
     persistBackgroundCommands();
     persistCompactChains();


### PR DESCRIPTION
## Summary

- yield cooperatively across lineage-linking passes so runtime socket responses and delivery callbacks advance during large scans
- let fresh unmaterialized empty-turn launches progress through account adoption while preserving incomplete transcript and delivery-race fences
- recover a persisted structured owner when a held delivery finds its runtime session missing, then requeue and drain exactly once

Closes #565
Relates to #555

## Verification

- RED regression proved a runtime callback stayed blocked for the full 1.73s lineage projection before the fix
- 315 focused scanner, registry, migration, and structured-delivery tests pass
- TypeScript passes
- changed-file ESLint passes
- production build passes