### PR TITLE
Bound stale live-tail catch-up to prevent Viewer starvation

### DIFF
--- a/src/lib/logRead.ts
+++ b/src/lib/logRead.ts
@@ -25,7 +25,11 @@ export async function readTailChunk(pathname: string, offsetInput: number, budge
   let offset = offsetInput;
   if (!Number.isFinite(offset) || offset < 0) offset = 0;
   if (offset > size) offset = 0;
-  if (offset === 0 && size > MAX_CHUNK) offset = size - MAX_CHUNK;
+  /* A disconnected live subscriber can return with a very old offset. Bound
+     every forward catch-up to the live tail window so reconnect churn cannot
+     replay a multi-hundred-megabyte transcript through the Viewer event loop.
+     Older feed pages remain available through the backward history route. */
+  if (size - offset > MAX_CHUNK) offset = size - MAX_CHUNK;
 
   const want = Math.min(MAX_CHUNK, Math.max(0, budget), Math.max(0, size - offset));
   if (want === 0) return { offset, start: offset, size, data: "" };

--- a/src/lib/logTailStream.test.ts
+++ b/src/lib/logTailStream.test.ts
@@ -2,7 +2,8 @@ import { afterAll, describe, expect, test } from "bun:test";
 import fs from "node:fs";
 import path from "node:path";
 
-import { ROOTS } from "@/lib/scanner/roots";
+import { readTailChunk } from "@/lib/logRead";
+import { MAX_CHUNK, ROOTS } from "@/lib/scanner/roots";
 import type { LogChunk } from "@/lib/types";
 
 import { LogTailStreamSession, type LogTailStreamEvent } from "./logTailStream";
@@ -35,6 +36,22 @@ function asChunk(event: LogTailStreamEvent): LogChunk {
 }
 
 describe("LogTailStreamSession", () => {
+  test("a stale live offset skips an oversized backlog and resumes from the bounded tail", async () => {
+    const prefix = "x".repeat(MAX_CHUNK + 128);
+    const tail = "y".repeat(MAX_CHUNK);
+    const file = writeLog("stale-offset.log", prefix + tail);
+
+    const chunk = await readTailChunk(file, 1);
+
+    expect(chunk).not.toBeNull();
+    expect(chunk).toMatchObject({
+      start: prefix.length,
+      offset: prefix.length + tail.length,
+      size: prefix.length + tail.length,
+      data: tail,
+    });
+  });
+
   test("initial catch-up spends one connection byte budget and continues later", async () => {
     const first = writeLog("budget-a.log", "0123456789");
     const second = writeLog("budget-b.log", "abcde");


### PR DESCRIPTION
Fixes #555.

## Summary

- clamp every forward live-tail read to the latest `MAX_CHUNK` window when a subscriber offset has fallen further behind
- prevent SSE reconnect churn from replaying multi-hundred-megabyte transcripts through the Viewer event loop
- keep older feed pages available through the existing backward history route

## Production evidence

The wedged Viewer kept a 190,261,528-byte transcript open and sustained roughly one core. `/proc/<pid>/io` showed repeated tens of megabytes read and several megabytes serialized every 200 ms. With this change, the same production transcript at stale offset `1` reads exactly 786,432 bytes and completes in 7 ms.

## Verification

- RED before the implementation: stale offset `1` started at byte `1`
- GREEN after the implementation: stale offset starts at byte `189,475,096` and reaches EOF in one bounded read
- 11 focused tests pass
- `bunx tsc --noEmit`
- changed-file ESLint
- `bun run build`
