### PR TITLE
Stop abandoned log SSE streams at backpressure

### DIFF
--- a/src/lib/logTailStream.test.ts
+++ b/src/lib/logTailStream.test.ts
@@ -6,7 +6,7 @@ import { readTailChunk } from "@/lib/logRead";
 import { MAX_CHUNK, ROOTS } from "@/lib/scanner/roots";
 import type { LogChunk } from "@/lib/types";
 
-import { LogTailStreamSession, type LogTailStreamEvent } from "./logTailStream";
+import { createLogTailEventStream, LogTailStreamSession, type LogTailStreamEvent } from "./logTailStream";
 
 fs.mkdirSync(ROOTS["codex-sessions"], { recursive: true });
 const SANDBOX = fs.mkdtempSync(path.join(ROOTS["codex-sessions"], "llv-log-tail-stream-test-"));
@@ -86,15 +86,21 @@ describe("LogTailStreamSession", () => {
   test("file growth pushes the appended bytes", async () => {
     const file = writeLog("growth.log", "one\n");
     const events: LogTailStreamEvent[] = [];
+    let notifyGrowth: () => void = () => undefined;
     const session = new LogTailStreamSession([{ id: "log", path: file, offset: 4 }], {
       restatMs: 60_000,
       heartbeatMs: 60_000,
+      watchFile: (_pathname, onChange) => {
+        notifyGrowth = onChange;
+        return { close: () => undefined };
+      },
       onEvent: (event) => events.push(event),
     });
     try {
       session.start();
       await waitFor(() => events.length >= 1);
       fs.appendFileSync(file, "two\n");
+      notifyGrowth();
       await waitFor(() => events.some((event) => event.id === "log" && !("error" in event.chunk) && event.chunk.data === "two\n"));
     } finally {
       session.close();
@@ -180,5 +186,23 @@ describe("LogTailStreamSession", () => {
     await Bun.sleep(80);
     expect(closeCount).toBe(1);
     expect(comments).toBe(commentsAtClose);
+  });
+
+  test("an unread event stream closes when a second chunk meets backpressure", async () => {
+    const first = writeLog("backpressure-a.log", "first\n");
+    const second = writeLog("backpressure-b.log", "second\n");
+    const reader = createLogTailEventStream([
+      { id: "a", path: first, offset: 0 },
+      { id: "b", path: second, offset: 0 },
+    ]).getReader();
+
+    await Bun.sleep(20);
+    const initial = await reader.read();
+    const terminal = await reader.read();
+    await reader.cancel();
+
+    expect(initial.done).toBe(false);
+    expect(new TextDecoder().decode(initial.value)).toContain('"id":"a"');
+    expect(terminal.done).toBe(true);
   });
 });

--- a/src/lib/logTailStream.ts
+++ b/src/lib/logTailStream.ts
@@ -252,16 +252,37 @@ function encodeComment(comment: string): Uint8Array {
 
 export function createLogTailEventStream(subs: LogStreamSub[], signal?: AbortSignal): ReadableStream<Uint8Array> {
   let session: LogTailStreamSession | null = null;
+  let stopped = false;
   return new ReadableStream<Uint8Array>({
     start(controller) {
+      const enqueue = (payload: Uint8Array) => {
+        if (stopped) return;
+        /* A stale SSE response can outlive its browser connection under the
+           production Next/Bun adapter. Stop at the first queued chunk: the
+           EventSource reconnect resumes from the browser's durable offset,
+           while an abandoned response cannot buffer transcript data forever. */
+        if ((controller.desiredSize ?? 1) <= 0) {
+          stopped = true;
+          session?.close();
+          try { controller.close(); } catch { /* response already closed */ }
+          return;
+        }
+        try {
+          controller.enqueue(payload);
+        } catch {
+          stopped = true;
+          session?.close();
+        }
+      };
       session = new LogTailStreamSession(subs, {
         signal,
-        onEvent: (event) => controller.enqueue(encodeChunk(event)),
-        onComment: (comment) => controller.enqueue(encodeComment(comment)),
+        onEvent: (event) => enqueue(encodeChunk(event)),
+        onComment: (comment) => enqueue(encodeComment(comment)),
       });
       session.start();
     },
     cancel() {
+      stopped = true;
       session?.close();
       session = null;
     },


### PR DESCRIPTION
Follow-up for #555 after live validation of #578.

## Summary

- observe `ReadableStreamDefaultController.desiredSize` before each SSE chunk
- close the log-tail session and response when a disconnected or stalled consumer leaves a chunk queued
- let EventSource reconnect from the browser-owned offset
- make the native watcher regression deterministic with an injected watcher callback

## Production evidence

After #578 reduced each stale replay from a 190 MB backlog to 768 KiB, the new Viewer still sustained about 110% CPU. In five seconds it read another 815 MB and serialized 229 MB. `/proc/<pid>/fd` showed 3-5 simultaneous handles per transcript, including static transcripts, which identifies abandoned SSE responses continuing to buffer after reconnects.

## Verification

- RED: an unread stream accepted a second subscriber chunk and stayed open
- GREEN: the second chunk meets backpressure, closes the session, and the reader reaches EOF
- 12 focused tests pass
- `bunx tsc --noEmit`
- changed-file ESLint
- `bun run build`
