### PR TITLE
Stop files generation retries from starving scans

### DIFF
--- a/src/app/api/files/route.test.ts
+++ b/src/app/api/files/route.test.ts
@@ -150,6 +150,46 @@ test("repeated files reads reuse the pure read snapshot and retain ETag behavior
   expect(first.headers.get("server-timing")).toMatch(/files-role-titles;dur=\d+(?:\.\d+)?/);
 });
 
+test("generation completion retries skip the stale projection while its refresh is running", async () => {
+  scannedFiles = [file("/sessions/generation-1.jsonl")];
+  const initial = await GET(new Request("http://127.0.0.1/api/files"));
+  const etag = initial.headers.get("etag");
+  expect(initial.headers.get("x-llv-files-generation")).toBe("1");
+
+  let releaseRefresh!: () => void;
+  scanGates.push(new Promise<void>((resolve) => { releaseRefresh = resolve; }));
+  scannedFiles = [file("/sessions/generation-2.jsonl")];
+  try {
+    const revision = await GET(new Request("http://127.0.0.1/api/files", {
+      headers: {
+        "if-none-match": etag!,
+        "x-llv-files-revision": "41",
+      },
+    }));
+    expect(revision.headers.get("x-llv-files-generation")).toBe("1");
+    expect(revision.headers.get("x-llv-files-target-generation")).toBe("2");
+
+    const retry = await GET(new Request("http://127.0.0.1/api/files", {
+      headers: {
+        "if-none-match": etag!,
+        "x-llv-files-generation": "2",
+      },
+    }));
+
+    expect(retry.status).toBe(304);
+    expect(await retry.text()).toBe("");
+    expect(retry.headers.get("etag")).toBe(etag);
+    expect(retry.headers.get("x-llv-files-generation")).toBe("1");
+    expect(retry.headers.get("x-llv-files-target-generation")).toBe("2");
+    expect(retry.headers.get("x-llv-files-cache")).toBe("stale");
+    expect(retry.headers.get("server-timing")).toContain("files-generation-wait");
+    expect(retry.headers.get("server-timing")).not.toContain("files-registry");
+    expect(scans).toBe(2);
+  } finally {
+    releaseRefresh();
+  }
+});
+
 test("issue 532: files response returns the transaction-captured flow generation", async () => {
   const oldFlow = {
     id: "flow-atomic-projection", template: "implement-review-loop", project: "demo", cwd: "/repo",

--- a/src/app/api/files/route.ts
+++ b/src/app/api/files/route.ts
@@ -11,44 +11,58 @@ function generationHeader(request: Request, name: string): number | undefined {
   return Number.isSafeInteger(generation) ? generation : undefined;
 }
 
+type CachedScan = Awaited<ReturnType<typeof cachedFileScan>>;
+
+function applyScanHeaders(response: Response, scan: CachedScan, projectionTiming?: string | null): void {
+  response.headers.set("x-llv-files-generation", String(scan.generation));
+  response.headers.set("x-llv-files-target-generation", String(scan.targetGeneration));
+  response.headers.set("x-llv-files-cache", scan.cacheStatus);
+  response.headers.set("x-llv-files-cache-requests", String(scan.requestCount));
+  const serverTiming = [`files-clone;dur=${scan.cloneDurationMs.toFixed(1)}`];
+  if (scan.lastScan) {
+    const failure = scan.lastScan.status === "failed" ? " failed" : "";
+    serverTiming.push(`files-scan;dur=${scan.lastScan.durationMs.toFixed(1)};desc="${scan.lastScan.reason} generation ${scan.lastScan.generation}${failure}"`);
+  }
+  if (projectionTiming) serverTiming.push(projectionTiming);
+  response.headers.set("server-timing", serverTiming.join(", "));
+}
+
 export async function GET(request: Request): Promise<Response> {
   const requiredRevision = generationHeader(request, "x-llv-files-revision");
   const requiredGeneration = generationHeader(request, "x-llv-files-generation");
-  let responseGeneration = 0;
-  let targetGeneration = 0;
-  let cacheStatus: "hit" | "stale" | "miss" = "miss";
-  let requestCount = 0;
-  let cloneDurationMs = 0;
-  let lastScan: Awaited<ReturnType<typeof cachedFileScan>>["lastScan"];
+  const url = new URL(request.url);
+  const selectedProject = url.searchParams.get("project")?.trim() || undefined;
+  const pinnedPath = url.searchParams.get("path")?.trim() || undefined;
+  const scan = await cachedFileScan(
+    selectedProject,
+    pinnedPath,
+    Date.now(),
+    requiredRevision,
+    requiredGeneration,
+  );
+
+  /* Completion retries already hold the last successful representation. While
+     its requested scan is still running, rebuilding the multi-store projection
+     only delays that scan and can form a self-sustaining retry storm. */
+  const previousEtag = request.headers.get("if-none-match");
+  if (requiredGeneration !== undefined && scan.generation < scan.targetGeneration && previousEtag) {
+    const response = new Response(null, {
+      status: 304,
+      headers: {
+        ETag: previousEtag,
+        "server-timing": `files-generation-wait;dur=0.0;desc="generation ${scan.generation} of ${scan.targetGeneration}"`,
+      },
+    });
+    applyScanHeaders(response, scan, response.headers.get("server-timing"));
+    return response;
+  }
+
   const response = await buildFilesResponse(request, {
-    listFilesWithProjectCatalog: async (selectedProject, pinnedPath) => {
-      const scan = await cachedFileScan(
-        selectedProject,
-        pinnedPath,
-        Date.now(),
-        requiredRevision,
-        requiredGeneration,
-      );
-      responseGeneration = scan.generation;
-      targetGeneration = scan.targetGeneration;
-      cacheStatus = scan.cacheStatus;
-      requestCount = scan.requestCount;
-      cloneDurationMs = scan.cloneDurationMs;
-      lastScan = scan.lastScan;
+    listFilesWithProjectCatalog: async () => {
       return { ...scan.snapshot, pinOverlayPaths: scan.pinOverlayPaths };
     },
   });
-  response.headers.set("x-llv-files-generation", String(responseGeneration));
-  response.headers.set("x-llv-files-target-generation", String(targetGeneration));
-  response.headers.set("x-llv-files-cache", cacheStatus);
-  response.headers.set("x-llv-files-cache-requests", String(requestCount));
-  const serverTiming = [`files-clone;dur=${cloneDurationMs.toFixed(1)}`];
-  if (lastScan) {
-    const failure = lastScan.status === "failed" ? " failed" : "";
-    serverTiming.push(`files-scan;dur=${lastScan.durationMs.toFixed(1)};desc="${lastScan.reason} generation ${lastScan.generation}${failure}"`);
-  }
   const projectionTiming = response.headers.get("server-timing");
-  if (projectionTiming) serverTiming.push(projectionTiming);
-  response.headers.set("server-timing", serverTiming.join(", "));
+  applyScanHeaders(response, scan, projectionTiming);
   return response;
 }


### PR DESCRIPTION
Fixes the production feedback loop behind #555 and blocked structured delivery.

A completion retry that already holds an ETag now returns a bodyless 304 while its requested scan generation is still running. This skips registry/flow/task projection and the ~1.9 MB JSON response until the scan catches up, allowing the event loop to finish the generation and service runtime-host deadlines.

Production evidence before the fix:
- standalone scan: about 1.5 seconds
- production scan under retry load: 80.7 seconds
- `/api/files` response body: about 1.9 MB
- Viewer I/O under load: about 9.3 GB read in 10 seconds

Validation:
- RED-first generation retry regression
- 93 focused route/client tests pass
- TypeScript passes
- changed-file ESLint passes
- production build passes
- privacy publication gate passes

Head: `562efa15d5da95546858d3351f10fda8251cd3dd`