### PR TITLE
Coalesce visible conversation pin scans

### DIFF
--- a/src/app/api/files/route.test.ts
+++ b/src/app/api/files/route.test.ts
@@ -1167,6 +1167,44 @@ test("a pinned refresh serves stale data then advances the shared global slot wi
   expect(scans).toBe(2);
 });
 
+test("a pin already present in the global snapshot does not start an exclusive scan", async () => {
+  const pinnedPath = "/sessions/visible-pin.jsonl";
+  scannedFiles = [file("/sessions/global.jsonl"), file(pinnedPath)];
+  await cachedFileScan();
+
+  const pinned = await cachedFileScan(undefined, pinnedPath, Date.now());
+  await new Promise<void>((resolve) => setImmediate(resolve));
+
+  expect(pinned.snapshot.files.map((entry) => entry.path)).toEqual([
+    "/sessions/global.jsonl",
+    pinnedPath,
+  ]);
+  expect(pinned.pinOverlayPaths).toBeUndefined();
+  expect(scans).toBe(1);
+});
+
+test("visible pins share one revision generation across browser scopes", async () => {
+  const firstPath = "/sessions/visible-a.jsonl";
+  const secondPath = "/sessions/visible-b.jsonl";
+  scannedFiles = [file(firstPath), file(secondPath)];
+  await cachedFileScan();
+
+  let release!: () => void;
+  scanGates.push(new Promise<void>((resolve) => { release = resolve; }));
+  await Promise.all([
+    cachedFileScan(undefined, firstPath, Date.now(), 580),
+    cachedFileScan(undefined, secondPath, Date.now(), 580),
+  ]);
+  await Promise.resolve();
+  expect(scans).toBe(2);
+
+  release();
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    await new Promise<void>((resolve) => setImmediate(resolve));
+  }
+  expect(scans).toBe(2);
+});
+
 test("pinned response projection cannot mutate the shared global scan rows", async () => {
   const sharedPath = "/sessions/shared-registry-row.jsonl";
   const pinnedPath = "/archive/pin-only-row.jsonl";

--- a/src/lib/scanner/scanCache.ts
+++ b/src/lib/scanner/scanCache.ts
@@ -654,13 +654,19 @@ export async function cachedFileScan(
 ): Promise<CachedFileScan> {
   const slot = globalFileScanSlot();
   slot.requestCount = (slot.requestCount ?? 0) + 1;
+  /* A selected conversation that already belongs to the global snapshot needs
+     no private scan scope. Treating every browser hash as exclusive serializes
+     one full-corpus scan per open tab for the same revision. */
+  const scanPinnedPath = pinnedPath && !slot.snapshot?.files.some((file) => file.path === pinnedPath)
+    ? pinnedPath
+    : undefined;
 
   let targetGeneration = requiredGeneration !== undefined && requiredGeneration <= slot.requestedGeneration
     ? requiredGeneration
     : undefined;
   if (targetGeneration !== undefined) {
-    if (pinnedPath) {
-      targetGeneration = rememberPinnedGeneration(slot, pinnedPath, targetGeneration);
+    if (scanPinnedPath) {
+      targetGeneration = rememberPinnedGeneration(slot, scanPinnedPath, targetGeneration);
     }
   } else if (requiredRevision !== undefined) {
     let requestedGeneration: number;
@@ -672,10 +678,10 @@ export async function cachedFileScan(
       slot.forcedGeneration = requestedGeneration;
     }
     targetGeneration = requestedGeneration;
-    if (pinnedPath) {
-      targetGeneration = rememberPinnedGeneration(slot, pinnedPath, requestedGeneration);
+    if (scanPinnedPath) {
+      targetGeneration = rememberPinnedGeneration(slot, scanPinnedPath, requestedGeneration);
     }
-    const refresh = refreshThroughGeneration(slot, targetGeneration, pinnedPath, "revision");
+    const refresh = refreshThroughGeneration(slot, targetGeneration, scanPinnedPath, "revision");
     const clearForcedGeneration = () => {
       if (slot.forcedGeneration === requestedGeneration) {
         slot.forcedRevision = undefined;
@@ -685,7 +691,7 @@ export async function cachedFileScan(
     if (!slot.snapshot) {
       try {
         await refresh;
-        return completedScan(slot, pinnedPath, targetGeneration, "miss");
+        return completedScan(slot, scanPinnedPath, targetGeneration, "miss");
       } finally {
         clearForcedGeneration();
       }
@@ -694,28 +700,28 @@ export async function cachedFileScan(
   }
 
   if (targetGeneration !== undefined) {
-    const refresh = refreshThroughGeneration(slot, targetGeneration, pinnedPath, "generation");
+    const refresh = refreshThroughGeneration(slot, targetGeneration, scanPinnedPath, "generation");
     const missesSnapshot = !slot.snapshot;
     if (missesSnapshot) await refresh;
     else continueRefreshInBackground(refresh);
-    return completedScan(slot, pinnedPath, targetGeneration, missesSnapshot ? "miss" : undefined);
+    return completedScan(slot, scanPinnedPath, targetGeneration, missesSnapshot ? "miss" : undefined);
   }
 
   /* A pin is an overlay on one global snapshot. The scanner marks every row
      outside the global cap, letting one scan publish both views. A completed
      snapshot serves while that shared refresh runs. */
-  if (pinnedPath) {
+  if (scanPinnedPath) {
     slot.pinnedSnapshots ??= new Map();
-    const pinned = cachedPinnedSnapshot(slot, pinnedPath);
+    const pinned = cachedPinnedSnapshot(slot, scanPinnedPath);
     if (pinned && now - pinned.refreshedAt < FILE_SCAN_FRESH_MS) {
-      return completedScan(slot, pinnedPath, pinned.generation);
+      return completedScan(slot, scanPinnedPath, pinned.generation);
     }
-    targetGeneration = pinnedRefreshGeneration(slot, pinnedPath);
-    const refresh = refreshThroughGeneration(slot, targetGeneration, pinnedPath, "pinned");
+    targetGeneration = pinnedRefreshGeneration(slot, scanPinnedPath);
+    const refresh = refreshThroughGeneration(slot, targetGeneration, scanPinnedPath, "pinned");
     const missesSnapshot = !slot.snapshot;
     if (missesSnapshot) await refresh;
     else continueRefreshInBackground(refresh);
-    return completedScan(slot, pinnedPath, targetGeneration, missesSnapshot ? "miss" : undefined);
+    return completedScan(slot, scanPinnedPath, targetGeneration, missesSnapshot ? "miss" : undefined);
   }
 
   if (!slot.snapshot) {


### PR DESCRIPTION
Continues the production CPU and delivery recovery for #555 after #580.

Every browser scope with a selected conversation passed `path=` into the files cache. Even when that path already existed in the global snapshot, revision hydration treated the scope as exclusive and serialized another full-corpus scan. Seven open conversation scopes could therefore keep the single JS event loop continuously scanning.

This change treats a pin already present in the global snapshot as global scan scope. Visible pins now share one forced revision generation across browser tabs. A genuinely out-of-cap pin keeps the existing exclusive overlay path and convergence behavior.

Validation:
- RED: a visible pin started a second scan; now it starts zero additional scans
- RED: two visible scopes produced three total scans for one revision; now they produce two total scans including the warm generation
- 70 route tests pass
- 16 real scanner tests pass in a fresh process
- 23 client cache tests pass
- TypeScript and changed-file ESLint pass
- production build passes
- privacy publication gate passes

Head: `788100a1942e5db4c5f58a6b56e6b620e9b942e3`