### PR TITLE
Throttle files revision scan bursts

### DIFF
--- a/src/app/api/files/route.test.ts
+++ b/src/app/api/files/route.test.ts
@@ -1461,48 +1461,51 @@ test("a warm global-only incomplete response retains an out-of-cap pin until its
 });
 
 test("concurrent requests for one files revision share one forced scan", async () => {
-  await GET(new Request("http://127.0.0.1/api/files"));
+  await cachedFileScan();
   let release!: () => void;
   scanGates.push(new Promise<void>((resolve) => { release = resolve; }));
-  const request = () => GET(new Request("http://127.0.0.1/api/files", {
-    headers: { "x-llv-files-revision": "41" },
-  }));
+  const request = () => cachedFileScan(undefined, undefined, Number.MAX_SAFE_INTEGER, 41);
 
   const first = request();
   await Promise.resolve();
   const second = request();
   release();
   await Promise.all([first, second]);
+  await currentFileScan();
 
   expect(scans).toBe(2);
 });
 
-test("a completed client revision cannot suppress a later refresh with the same value", async () => {
-  const request = () => GET(new Request("http://127.0.0.1/api/files", {
-    headers: { "x-llv-files-revision": "41" },
-  }));
+test("a completed revision generation absorbs newer revision noise inside the scan cooldown", async () => {
+  await cachedFileScan();
+  const started = await cachedFileScan(undefined, undefined, Number.MAX_SAFE_INTEGER, 41);
+  const completed = await currentFileScan();
+  const repeated = await cachedFileScan(undefined, undefined, Date.now(), 42);
 
-  await request();
-  await request();
-
+  expect(started.targetGeneration).toBeGreaterThan(started.generation);
+  expect(repeated.generation).toBe(completed.generation);
+  expect(repeated.targetGeneration).toBe(completed.generation);
   expect(scans).toBe(2);
 });
 
-test("a newer revision waits for a follow-up scan when an older scan is in flight", async () => {
+test("a newer revision during an active scan does not reserve a trailing full-corpus scan", async () => {
+  scannedFiles = [file("/sessions/warm.jsonl")];
+  await cachedFileScan();
   let releaseOlder!: () => void;
   scanGates.push(new Promise<void>((resolve) => { releaseOlder = resolve; }));
   scannedFiles = [file("/sessions/revision-1.jsonl")];
-  const older = cachedFileScan(undefined, undefined, Date.now(), 1);
+  const older = await cachedFileScan(undefined, undefined, Number.MAX_SAFE_INTEGER, 1);
   await Promise.resolve();
-  expect(scans).toBe(1);
+  expect(scans).toBe(2);
 
   scannedFiles = [file("/sessions/revision-2.jsonl")];
-  const newer = cachedFileScan(undefined, undefined, Date.now(), 2);
+  const newer = await cachedFileScan(undefined, undefined, Number.MAX_SAFE_INTEGER, 2);
   releaseOlder();
-  await older;
-  const result = await newer;
+  const completed = await currentFileScan();
 
-  expect(result.snapshot.files.map((entry) => entry.path)).toEqual(["/sessions/revision-2.jsonl"]);
+  expect(older.targetGeneration).toBeGreaterThan(older.generation);
+  expect(newer.targetGeneration).toBe(newer.generation);
+  expect(completed.snapshot.files.map((entry) => entry.path)).toEqual(["/sessions/revision-1.jsonl"]);
   expect(scans).toBe(2);
 });
 
@@ -1532,24 +1535,20 @@ test("a persisted legacy cache slot serves stale data during fresh hydration", a
   expect(next.snapshot.files.map((entry) => entry.path)).toEqual(["/sessions/upgraded-fresh.jsonl"]);
 });
 
-test("an arbitrary client revision cannot suppress a later background refresh", async () => {
+test("an arbitrary client revision cannot suppress a later refresh beyond the cooldown", async () => {
   scannedFiles = [file("/sessions/untrusted-watermark.jsonl")];
   await GET(new Request("http://127.0.0.1/api/files", {
     headers: { "x-llv-files-revision": String(Number.MAX_SAFE_INTEGER) },
   }));
 
   scannedFiles = [file("/sessions/genuine-revision.jsonl")];
-  const response = await GET(new Request("http://127.0.0.1/api/files", {
-    headers: { "x-llv-files-revision": "7" },
-  }));
-  const body = await response.json() as { files: FileEntry[] };
+  const stale = await cachedFileScan(undefined, undefined, Number.MAX_SAFE_INTEGER, 7);
 
-  expect(body.files.map((entry) => entry.path)).toEqual(["/sessions/untrusted-watermark.jsonl"]);
+  expect(stale.snapshot.files.map((entry) => entry.path)).toEqual(["/sessions/untrusted-watermark.jsonl"]);
   expect(scans).toBe(2);
 
-  await new Promise<void>((resolve) => setImmediate(resolve));
-  const next = await GET(new Request("http://127.0.0.1/api/files"));
-  expect((await next.json()).files.map((entry: FileEntry) => entry.path)).toEqual(["/sessions/genuine-revision.jsonl"]);
+  const completed = await currentFileScan();
+  expect(completed.snapshot.files.map((entry) => entry.path)).toEqual(["/sessions/genuine-revision.jsonl"]);
 });
 
 test("a client generation above the issued watermark cannot advance the server counter", async () => {

--- a/src/lib/scanner/scanCache.ts
+++ b/src/lib/scanner/scanCache.ts
@@ -660,6 +660,32 @@ export async function cachedFileScan(
   const scanPinnedPath = pinnedPath && !slot.snapshot?.files.some((file) => file.path === pinnedPath)
     ? pinnedPath
     : undefined;
+  const completedPinned = scanPinnedPath ? slot.pinnedSnapshots?.get(scanPinnedPath) : undefined;
+  const hasCompletedScope = scanPinnedPath === undefined || completedPinned !== undefined;
+  const scopeRefreshedAt = completedPinned?.refreshedAt ?? slot.refreshedAt;
+
+  /* Transcript appends can publish many runtime revisions during one full
+     inventory scan. A completed scope remains authoritative for the existing
+     fallback cadence, and an active scan absorbs newer revision noise. The log
+     stream carries message bytes immediately; the next bounded inventory pass
+     reconciles metadata without reserving an endless chain of full scans. */
+  if (
+    requiredRevision !== undefined
+    && slot.snapshot
+    && hasCompletedScope
+    && (
+      (slot.refresh !== undefined && slot.refresh.generation > (completedPinned?.generation ?? slot.snapshotGeneration))
+      || (slot.lastScan?.reason === "revision" && now - scopeRefreshedAt < FILE_SCAN_ORDINARY_REFRESH_MS)
+    )
+  ) {
+    const completedGeneration = completedPinned?.generation ?? slot.snapshotGeneration;
+    return completedScan(
+      slot,
+      scanPinnedPath,
+      completedGeneration,
+      slot.refresh ? "stale" : "hit",
+    );
+  }
 
   let targetGeneration = requiredGeneration !== undefined && requiredGeneration <= slot.requestedGeneration
     ? requiredGeneration


### PR DESCRIPTION
## Summary
- coalesce transcript-driven file revision noise while a full inventory scan is active
- keep completed revision scopes authoritative for the existing 10-second fallback cadence
- preserve immediate message bytes through the live log stream while bounding metadata reconciliation

## Production cause
Each active transcript append published a new files revision. Distinct revisions reserved another full-corpus scan, so a busy conversation kept the scan queue permanently non-empty, consumed roughly one CPU core, and starved runtime-client deadlines.

## Verification
- `bun test src/app/api/files/route.test.ts --timeout 30000` — 72 pass
- `bun test src/app/api/files/scanCache.real.test.ts --timeout 30000` — 16 pass
- `bun test src/hooks/useFiles.test.ts --timeout 30000` — 23 pass
- `bunx tsc --noEmit`
- changed-file ESLint
- `bun run build`
- `bun run privacy:check`
- `git diff --check`

Closes the revision-storm portion of #555.