### PR TITLE
Reuse completed scans for tmux host probes

### DIFF
--- a/src/app/api/tmux/route.test.ts
+++ b/src/app/api/tmux/route.test.ts
@@ -22,6 +22,8 @@ afterAll(() => {
 
 let transcriptReads = 0;
 let lastTranscriptReadFresh: boolean | undefined;
+let lastTranscriptReadFiles: unknown;
+let completedScanReads = 0;
 let pidTargets = new Map<number, string | null>();
 let resourceTarget: Record<string, unknown> | null = null;
 const endpoint = {
@@ -81,13 +83,22 @@ const snapshot = {
   canonicalFor: (pathname: string) => (pathname === PATHNAME ? host : null),
 };
 
+const completedFiles = [{ path: PATHNAME }];
+
 mock.module("@/lib/agent/transcriptHost", () => ({
   canonicalTranscriptTarget: (observed: typeof snapshot, pathname: string) => observed.canonicalFor(pathname)?.display ?? null,
   deliverToTranscriptHost: async () => ({ kind: "unavailable" }),
-  readTranscriptHosts: async (fresh?: boolean) => {
+  readTranscriptHosts: async (fresh?: boolean, files?: unknown) => {
     transcriptReads += 1;
     lastTranscriptReadFresh = fresh;
+    lastTranscriptReadFiles = files;
     return snapshot;
+  },
+}));
+mock.module("@/lib/scanner/scanCache", () => ({
+  completedFileScan: async () => {
+    completedScanReads += 1;
+    return { snapshot: { files: completedFiles } };
   },
 }));
 mock.module("@/lib/runtime/structuredControls", () => ({
@@ -166,6 +177,8 @@ function post(body: unknown): NextRequest {
 
 test("/api/tmux GET uses the transcript host when a recycled pid disagrees", async () => {
   transcriptReads = 0;
+  completedScanReads = 0;
+  lastTranscriptReadFiles = undefined;
   pidTargets = new Map([[77, "agents:9.0"]]);
 
   const response = await GET(get(`http://127.0.0.1/api/tmux?pid=77&path=${encodeURIComponent(PATHNAME)}`));
@@ -173,11 +186,15 @@ test("/api/tmux GET uses the transcript host when a recycled pid disagrees", asy
   expect(response.status).toBe(200);
   expect(await response.json()).toEqual({ target: "agents:4.0" });
   expect(transcriptReads).toBe(1);
+  expect(completedScanReads).toBe(1);
+  expect(lastTranscriptReadFiles).toBe(completedFiles);
 });
 
 test("/api/tmux attach resolves a fresh transcript host and returns an uncached opaque command", async () => {
   transcriptReads = 0;
+  completedScanReads = 0;
   lastTranscriptReadFresh = undefined;
+  lastTranscriptReadFiles = undefined;
   attachResolution = {
     ok: true,
     target: "agents:8.0",
@@ -200,6 +217,8 @@ test("/api/tmux attach resolves a fresh transcript host and returns an uncached 
   });
   expect(transcriptReads).toBe(1);
   expect(lastTranscriptReadFresh === true).toBe(true);
+  expect(completedScanReads).toBe(1);
+  expect(lastTranscriptReadFiles).toBe(completedFiles);
 });
 
 test("/api/tmux attach resolves an allowlisted orphan resource target", async () => {

--- a/src/app/api/tmux/route.ts
+++ b/src/app/api/tmux/route.ts
@@ -13,6 +13,7 @@ import {
 import { canonicalTranscriptTarget, readTranscriptHosts } from "@/lib/agent/transcriptHost";
 import { reconfigurationFromBody } from "@/lib/agent/reconfigure";
 import { listFiles } from "@/lib/scanner";
+import { completedFileScan } from "@/lib/scanner/scanCache";
 import { pathAllowed } from "@/lib/scanner/roots";
 import { allowedKillTarget, consumeKillTarget } from "@/lib/resources";
 import { rejectCrossOrigin } from "@/lib/sameOrigin";
@@ -58,6 +59,11 @@ interface SendResponse {
   receipt?: { operationId: string; status: string };
 }
 
+async function currentTranscriptHosts() {
+  const files = (await completedFileScan()).snapshot.files;
+  return readTranscriptHosts(true, files);
+}
+
 function respond(outcome: DeliveryOutcome): NextResponse<SendResponse | ApiError | { ok: false; outcome: "failed"; error: string }> {
   if (!outcome.ok) {
     const { status, ...body } = outcome;
@@ -71,7 +77,7 @@ async function targetForRequest(pid: number | null, filePath: string): Promise<s
     /* A transcript path names the conversation being addressed. Its canonical
        host therefore wins over a client-side pid that may have exited and
        been recycled for another session between scanner polls. */
-    return canonicalTranscriptTarget(await readTranscriptHosts(true), filePath);
+    return canonicalTranscriptTarget(await currentTranscriptHosts(), filePath);
   }
   return pid === null ? null : resolveRequestedTmuxTarget(pid);
 }
@@ -93,7 +99,7 @@ export async function GET(req: NextRequest): Promise<NextResponse<TargetResponse
     let reference;
     if (filePath) {
       if (!pathAllowed(filePath)) return attachJson({ error: "invalid transcript path", reason: "tmux-unavailable" }, 400);
-      const host = (await readTranscriptHosts(true)).canonicalFor(filePath);
+      const host = (await currentTranscriptHosts()).canonicalFor(filePath);
       if (host === null) return attachJson({ error: "unknown transcript host", reason: "tmux-unavailable" }, 400);
       reference = captureTmuxAttachReference(host);
     } else {

--- a/src/app/api/tmux/targets/route.test.ts
+++ b/src/app/api/tmux/targets/route.test.ts
@@ -5,7 +5,11 @@ import { NextRequest } from "next/server";
 const FIRST_PATH = "/allowed/first.jsonl";
 const SECOND_PATH = "/allowed/second.jsonl";
 let transcriptReads = 0;
+let completedScanReads = 0;
+let suppliedFiles: unknown;
 let pidTargets = new Map<number, string | null>();
+
+const completedFiles = [{ path: FIRST_PATH }, { path: SECOND_PATH }];
 
 const first = { display: "agents:4.0" };
 const second = { display: "agents:5.0" };
@@ -16,9 +20,16 @@ const snapshot = {
 };
 
 mock.module("@/lib/agent/transcriptHost", () => ({
-  readTranscriptHosts: async () => {
+  readTranscriptHosts: async (_fresh: boolean, files: unknown) => {
     transcriptReads += 1;
+    suppliedFiles = files;
     return snapshot;
+  },
+}));
+mock.module("@/lib/scanner/scanCache", () => ({
+  completedFileScan: async () => {
+    completedScanReads += 1;
+    return { snapshot: { files: completedFiles } };
   },
 }));
 mock.module("@/lib/scanner/roots", () => ({ pathAllowed: (pathname: string) => pathname.startsWith("/allowed/") }));
@@ -38,6 +49,8 @@ function request(body: unknown): NextRequest {
 
 test("/api/tmux/targets projects every path from one canonical host snapshot", async () => {
   transcriptReads = 0;
+  completedScanReads = 0;
+  suppliedFiles = undefined;
   pidTargets = new Map([[11, "agents:9.0"]]);
 
   const response = await POST(request({
@@ -53,4 +66,6 @@ test("/api/tmux/targets projects every path from one canonical host snapshot", a
     targets: { first: "agents:4.0", second: "agents:5.0", "pid-only": "agents:9.0" },
   });
   expect(transcriptReads).toBe(1);
+  expect(completedScanReads).toBe(1);
+  expect(suppliedFiles).toBe(completedFiles);
 });

--- a/src/app/api/tmux/targets/route.ts
+++ b/src/app/api/tmux/targets/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 
 import { readTranscriptHosts, type TranscriptHostSnapshot } from "@/lib/agent/transcriptHost";
+import { completedFileScan } from "@/lib/scanner/scanCache";
 import { pathAllowed } from "@/lib/scanner/roots";
 import { resolveRequestedTmuxTarget } from "@/lib/tmux";
 
@@ -61,7 +62,8 @@ export async function POST(req: NextRequest): Promise<NextResponse<TargetBatchRe
   /* Every path in this batch projects one observation. This keeps the feed's
      target badges internally consistent while panes are being created or
      closed. PID-only compatibility requests retain their own lookup. */
-  const snapshot = await readTranscriptHosts(true);
+  const files = (await completedFileScan()).snapshot.files;
+  const snapshot = await readTranscriptHosts(true, files);
   const pairs = await Promise.all(reqs.map(async ({ id, pid, path }) => [id, await targetForRequest(snapshot, pid, path)] as const));
   return NextResponse.json({ targets: Object.fromEntries(pairs) });
 }

--- a/src/lib/accounts/migration/controller.ts
+++ b/src/lib/accounts/migration/controller.ts
@@ -101,7 +101,7 @@ export interface AccountMigrationControllerCyclePorts {
 
 async function reconcileControllerRuntime(registry: AgentRegistry, files: ControllerScan["files"]): Promise<void> {
   await reconcileAccountLogins();
-  const transcriptHosts = await readTranscriptHosts(true);
+  const transcriptHosts = await readTranscriptHosts(true, files);
   try {
     await runReaperCycle({ registry, hosts: transcriptHosts.hosts, files });
   } catch {


### PR DESCRIPTION
## Summary
- feed `/api/tmux/targets` host resolution from the shared completed file snapshot
- reuse the same snapshot for single tmux target and attach requests
- pass the account controller's existing scan into transcript-host reconciliation

## Production cause
Every open board tab polls `/api/tmux/targets` every five seconds. The endpoint called `readTranscriptHosts(true)` without supplied entries, which launched a full uncapped `listFiles()` traversal. Seven tabs produced roughly 1.4 full scans per second, matching the measured 150–293 MB/s logical reads, ~114% CPU, and 105-second event-loop-delayed scan generation.

## Verification
- tmux target route: 1 pass
- tmux route: 13 pass
- transcript host suite: 24 pass
- account controller suite: 8 pass
- files route suite: 72 pass
- TypeScript, changed-file ESLint, privacy gate, diff-check
- production build

Addresses the dominant event-loop starvation path in #555.