### PR TITLE
Reuse completed scans for PID tmux target probes

### DIFF
--- a/src/app/api/tmux/route.test.ts
+++ b/src/app/api/tmux/route.test.ts
@@ -24,6 +24,7 @@ let transcriptReads = 0;
 let lastTranscriptReadFresh: boolean | undefined;
 let lastTranscriptReadFiles: unknown;
 let completedScanReads = 0;
+let pidResolutionFiles: unknown;
 let pidTargets = new Map<number, string | null>();
 let resourceTarget: Record<string, unknown> | null = null;
 const endpoint = {
@@ -148,7 +149,10 @@ mock.module("@/lib/tmux", () => ({
   killPane: async () => {},
   paneScreen: async () => "",
   panePidOf: async () => null,
-  resolveRequestedTmuxTarget: async (pid: number | null) => (pid === null ? null : pidTargets.get(pid) ?? null),
+  resolveRequestedTmuxTarget: async (pid: number | null, files?: unknown) => {
+    pidResolutionFiles = files;
+    return pid === null ? null : pidTargets.get(pid) ?? null;
+  },
   resolveTarget: async (pid: number) => pidTargets.get(pid) ?? null,
   knownLivePids: async () => new Set<number>(),
   panePidMap: async () => new Map<number, string>(),
@@ -248,12 +252,16 @@ test("/api/tmux attach reports a restarted server and rejects malformed, cross-o
 });
 
 test("/api/tmux GET keeps pid lookup for pid-only compatibility requests", async () => {
+  completedScanReads = 0;
+  pidResolutionFiles = undefined;
   pidTargets = new Map([[77, "agents:9.0"]]);
 
   const response = await GET(get("http://127.0.0.1/api/tmux?pid=77"));
 
   expect(response.status).toBe(200);
   expect(await response.json()).toEqual({ target: "agents:9.0" });
+  expect(completedScanReads).toBe(1);
+  expect(pidResolutionFiles).toBe(completedFiles);
 });
 
 test("/api/tmux POST carries concurrent sends through the delivery seam", async () => {

--- a/src/app/api/tmux/route.ts
+++ b/src/app/api/tmux/route.ts
@@ -28,7 +28,7 @@ import {
   resolveTmuxAttach,
   tmuxEndpointDescriptor,
 } from "@/lib/tmux";
-import type { ApiError } from "@/lib/types";
+import type { ApiError, FileEntry } from "@/lib/types";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -59,9 +59,9 @@ interface SendResponse {
   receipt?: { operationId: string; status: string };
 }
 
-async function currentTranscriptHosts() {
-  const files = (await completedFileScan()).snapshot.files;
-  return readTranscriptHosts(true, files);
+async function currentTranscriptHosts(files?: FileEntry[]) {
+  const entries = files ?? (await completedFileScan()).snapshot.files;
+  return readTranscriptHosts(true, entries);
 }
 
 function respond(outcome: DeliveryOutcome): NextResponse<SendResponse | ApiError | { ok: false; outcome: "failed"; error: string }> {
@@ -73,13 +73,14 @@ function respond(outcome: DeliveryOutcome): NextResponse<SendResponse | ApiError
 }
 
 async function targetForRequest(pid: number | null, filePath: string): Promise<string | null> {
+  const files = (await completedFileScan()).snapshot.files;
   if (filePath && pathAllowed(filePath)) {
     /* A transcript path names the conversation being addressed. Its canonical
        host therefore wins over a client-side pid that may have exited and
        been recycled for another session between scanner polls. */
-    return canonicalTranscriptTarget(await currentTranscriptHosts(), filePath);
+    return canonicalTranscriptTarget(await currentTranscriptHosts(files), filePath);
   }
-  return pid === null ? null : resolveRequestedTmuxTarget(pid);
+  return pid === null ? null : resolveRequestedTmuxTarget(pid, files);
 }
 
 function attachJson(body: AttachResponse | AttachError, status = 200): NextResponse<AttachResponse | AttachError> {

--- a/src/app/api/tmux/targets/route.test.ts
+++ b/src/app/api/tmux/targets/route.test.ts
@@ -7,6 +7,7 @@ const SECOND_PATH = "/allowed/second.jsonl";
 let transcriptReads = 0;
 let completedScanReads = 0;
 let suppliedFiles: unknown;
+let pidResolutionFiles: unknown;
 let pidTargets = new Map<number, string | null>();
 
 const completedFiles = [{ path: FIRST_PATH }, { path: SECOND_PATH }];
@@ -34,7 +35,10 @@ mock.module("@/lib/scanner/scanCache", () => ({
 }));
 mock.module("@/lib/scanner/roots", () => ({ pathAllowed: (pathname: string) => pathname.startsWith("/allowed/") }));
 mock.module("@/lib/tmux", () => ({
-  resolveRequestedTmuxTarget: async (pid: number | null) => (pid === null ? null : pidTargets.get(pid) ?? null),
+  resolveRequestedTmuxTarget: async (pid: number | null, files: unknown) => {
+    pidResolutionFiles = files;
+    return pid === null ? null : pidTargets.get(pid) ?? null;
+  },
 }));
 
 const { POST } = await import("./route");
@@ -51,6 +55,7 @@ test("/api/tmux/targets projects every path from one canonical host snapshot", a
   transcriptReads = 0;
   completedScanReads = 0;
   suppliedFiles = undefined;
+  pidResolutionFiles = undefined;
   pidTargets = new Map([[11, "agents:9.0"]]);
 
   const response = await POST(request({
@@ -68,4 +73,5 @@ test("/api/tmux/targets projects every path from one canonical host snapshot", a
   expect(transcriptReads).toBe(1);
   expect(completedScanReads).toBe(1);
   expect(suppliedFiles).toBe(completedFiles);
+  expect(pidResolutionFiles).toBe(completedFiles);
 });

--- a/src/app/api/tmux/targets/route.ts
+++ b/src/app/api/tmux/targets/route.ts
@@ -4,6 +4,7 @@ import { readTranscriptHosts, type TranscriptHostSnapshot } from "@/lib/agent/tr
 import { completedFileScan } from "@/lib/scanner/scanCache";
 import { pathAllowed } from "@/lib/scanner/roots";
 import { resolveRequestedTmuxTarget } from "@/lib/tmux";
+import type { FileEntry } from "@/lib/types";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -22,6 +23,7 @@ interface TargetBatchResponse {
 
 async function targetForRequest(
   snapshot: TranscriptHostSnapshot,
+  files: readonly FileEntry[],
   pid: number | null,
   pathname: string,
 ): Promise<string | null> {
@@ -30,7 +32,7 @@ async function targetForRequest(
        another process, so it is used only when the request has no path. */
     return snapshot.canonicalFor(pathname)?.display ?? null;
   }
-  return pid === null ? null : resolveRequestedTmuxTarget(pid);
+  return pid === null ? null : resolveRequestedTmuxTarget(pid, files);
 }
 
 function parseReqs(body: unknown): TargetBatchReq[] | null {
@@ -64,6 +66,6 @@ export async function POST(req: NextRequest): Promise<NextResponse<TargetBatchRe
      closed. PID-only compatibility requests retain their own lookup. */
   const files = (await completedFileScan()).snapshot.files;
   const snapshot = await readTranscriptHosts(true, files);
-  const pairs = await Promise.all(reqs.map(async ({ id, pid, path }) => [id, await targetForRequest(snapshot, pid, path)] as const));
+  const pairs = await Promise.all(reqs.map(async ({ id, pid, path }) => [id, await targetForRequest(snapshot, files, pid, path)] as const));
   return NextResponse.json({ targets: Object.fromEntries(pairs) });
 }

--- a/src/lib/tmux.test.ts
+++ b/src/lib/tmux.test.ts
@@ -12,6 +12,7 @@ import {
   createSpawnWindow,
   createTmuxEndpointDescriptor,
   killTmuxHostIfMatches,
+  knownLivePidsFrom,
   legacyClaudeTmuxSpawnRefusal,
   spawnAgentWithPrompt,
   renameTmuxWindowForPid,
@@ -23,6 +24,16 @@ import {
   tmuxEndpoint,
   verifyTmuxSpawnBinding,
 } from "@/lib/tmux";
+
+test("known live pid validation reuses a supplied scanner snapshot", () => {
+  const live = knownLivePidsFrom([
+    { pid: process.pid, proc: "running" },
+    { pid: process.pid, proc: "done" },
+    { pid: null, proc: "running" },
+  ] as never);
+
+  expect([...live]).toEqual([process.pid]);
+});
 
 describe("renameTmuxWindowForPid guards", () => {
   test("a non-positive pid never touches tmux", async () => {

--- a/src/lib/tmux.ts
+++ b/src/lib/tmux.ts
@@ -24,6 +24,7 @@ import type { RuntimeImageUpload } from "@/lib/runtime/runtimeImageStore";
 import { spawnTransport, type SpawnTransport } from "@/lib/runtime/spawnTransport";
 import { listFiles } from "@/lib/scanner";
 import { agentProcesses, isHelperArgv, pidAlive, readArgv, readPpid, type AgentProcess } from "@/lib/scanner/process";
+import type { FileEntry } from "@/lib/types";
 import {
   composerLine,
   detectBlockingGate,
@@ -547,26 +548,36 @@ export async function resolveTarget(pid: number): Promise<TmuxTarget | null> {
  * Scanner-known pids that are currently running. The web caller may only target
  * one of these — an arbitrary pid from the request is never trusted directly.
  */
-export async function knownLivePids(): Promise<Set<number>> {
+export function knownLivePidsFrom(entries: readonly FileEntry[]): Set<number> {
   const pids = new Set<number>();
-  for (const entry of await listFiles()) {
+  for (const entry of entries) {
     if (entry.pid !== null && entry.proc === "running" && pidAlive(entry.pid)) pids.add(entry.pid);
   }
   return pids;
 }
 
+export async function knownLivePids(): Promise<Set<number>> {
+  return knownLivePidsFrom(await listFiles());
+}
+
 /** Resolves and revalidates a request pid against the scanner's live set. */
-export async function targetForKnownPid(pid: number): Promise<TmuxTarget | null | "unknown"> {
-  const live = await knownLivePids();
+export async function targetForKnownPid(
+  pid: number,
+  entries?: readonly FileEntry[],
+): Promise<TmuxTarget | null | "unknown"> {
+  const live = entries ? knownLivePidsFrom(entries) : await knownLivePids();
   if (!live.has(pid)) return "unknown";
   return resolveTarget(pid);
 }
 
 /** Resolves a scanner-approved pid only. Transcript-to-pane policy lives in
     agent/transcriptHost so resource observation and delivery cannot diverge. */
-export async function resolveRequestedTmuxTarget(pid: number | null): Promise<TmuxTarget | null> {
+export async function resolveRequestedTmuxTarget(
+  pid: number | null,
+  entries?: readonly FileEntry[],
+): Promise<TmuxTarget | null> {
   if (pid !== null) {
-    const target = await targetForKnownPid(pid);
+    const target = await targetForKnownPid(pid, entries);
     if (target !== "unknown" && target !== null) return target;
   }
   return null;


### PR DESCRIPTION
## Summary

- reuse the current completed scanner snapshot for PID-only tmux target validation
- preserve the live-PID security gate through `pidAlive`
- prevent every PID-only board entry from starting another full `listFiles()` scan

## Production cause

After #583 removed the path-based host scan fan-out, PID-only entries in `/api/tmux/targets` still called `knownLivePids()` independently. Each call launched a full scanner traversal. With multiple visible conversations and browser tabs, this sustained roughly 100% CPU and 160-186 MB/s reads.

## Verification

- `bun test src/app/api/tmux/targets/route.test.ts`
- `bun test src/app/api/tmux/route.test.ts`
- `bun test src/lib/tmux.test.ts`
- `bunx tsc --noEmit`
- changed-file ESLint
- `bun run privacy:check`
- `bun run build`
- `git diff --check`

Closes the remaining PID-only scan fan-out in #555.