### PR TITLE
Cache settled host reconciliation reads

### DIFF
--- a/src/lib/agent/registry.sqlite.test.ts
+++ b/src/lib/agent/registry.sqlite.test.ts
@@ -1040,6 +1040,25 @@ test("SQLite snapshot cache follows external revisions and reports writer metric
   });
 });
 
+test("SQLite ordered collection reads use the collection-order index", () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-registry-order-index-"));
+  const filename = path.join(directory, "agent-registry.json");
+  const registry = new AgentRegistry(filename, undefined, undefined, { sqliteMode: "sqlite" });
+  for (let index = 0; index < 20; index += 1) {
+    registry.ensureConversation("codex", `/sessions/order-index-${index}.jsonl`, "default");
+  }
+
+  const db = new Database(path.join(directory, "agent-registry.sqlite"), { readonly: true });
+  const plan = db.query<{ detail: string }, [string]>(
+    "EXPLAIN QUERY PLAN SELECT collection, row_key, value_json, row_order FROM registry_rows WHERE collection = ? ORDER BY row_order",
+  ).all("conversations");
+  db.close();
+
+  expect(plan.some((row) => row.detail.includes("registry_rows_collection_order"))).toBeTrue();
+  expect(plan.some((row) => row.detail.includes("TEMP B-TREE"))).toBeFalse();
+  fs.rmSync(directory, { recursive: true, force: true });
+});
+
 test.each(["off", "dual-write", "read", "sqlite"] as const)(
   "%s diagnostics keep cumulative counts and a rolling rate beyond the percentile sample cap",
   (sqliteMode) => {

--- a/src/lib/agent/sqliteRegistryStore.ts
+++ b/src/lib/agent/sqliteRegistryStore.ts
@@ -111,6 +111,10 @@ export class SqliteAgentRegistryStore {
         COMMIT;
       `);
     }
+    this.db.exec(`
+      CREATE INDEX IF NOT EXISTS registry_rows_collection_order
+      ON registry_rows(collection, row_order);
+    `);
     this.secureFiles();
     this.importFirstBoot(options.initialSnapshot);
   }

--- a/src/lib/agent/transcriptHost.test.ts
+++ b/src/lib/agent/transcriptHost.test.ts
@@ -196,6 +196,61 @@ test("stable tmux host reconciliation reads one snapshot without registry mutati
   fs.rmSync(directory, { recursive: true, force: true });
 });
 
+test("completed launch host polls reuse the SQLite registry read cache", () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-host-reconcile-launch-cache-"));
+  let snapshotLoads = 0;
+  const registry = new AgentRegistry(path.join(directory, "registry.json"), undefined, undefined, {
+    sqliteMode: "sqlite",
+    onSqliteSnapshotLoad: () => { snapshotLoads += 1; },
+  });
+  const hostEvidence: TmuxHostEvidence = {
+    kind: "tmux",
+    endpoint: "/run/user/1000/agent-log-viewer",
+    server: { pid: 900, startIdentity: "900:one" },
+    paneId: "%1",
+    panePid: { pid: 100, startIdentity: "100:one" },
+    windowName: "codex-resume",
+    agent: { pid: 200, startIdentity: "200:one" },
+    argv: ["codex", "resume", SESSION],
+  };
+  const begun = registry.beginSpawnRequest({ engine: "codex", cwd: "/repo", accountId: "terra" });
+  if (begun.kind !== "created") throw new Error("expected create");
+  registry.completeObservedSpawn(begun.receipt.launchId, {
+    key: { engine: "codex", sessionId: SESSION },
+    artifactPath: PATHNAME,
+    cwd: "/repo",
+    accountId: "terra",
+    status: "live",
+    host: hostEvidence,
+    claimEpoch: 0,
+    claimOwner: null,
+    pendingAction: null,
+  });
+  const host: TranscriptHost = {
+    tmuxServerPid: 900,
+    paneId: "%1",
+    panePid: 100,
+    agentPid: 200,
+    display: "agents:4.0",
+    windowName: "codex-resume",
+    engine: "codex",
+    cwd: "/repo",
+    agentArgv: ["codex", "resume", SESSION],
+    agentIdentity: "200:one",
+    launchId: begun.receipt.launchId,
+    claimedPaths: [PATHNAME],
+    primaryPath: PATHNAME,
+  };
+  registry.readOnlySnapshot();
+  const warmedLoads = snapshotLoads;
+
+  reconcileObservedTranscriptHosts([host], { registry, evidenceForHost: () => hostEvidence });
+  reconcileObservedTranscriptHosts([host], { registry, evidenceForHost: () => hostEvidence });
+
+  expect(snapshotLoads).toBe(warmedLoads);
+  fs.rmSync(directory, { recursive: true, force: true });
+});
+
 test("registry resume receives one conversation-bound capability at central actuation", () => {
   const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-resume-capability-"));
   const registry = new AgentRegistry(path.join(directory, "registry.json"));

--- a/src/lib/agent/transcriptHost.ts
+++ b/src/lib/agent/transcriptHost.ts
@@ -642,7 +642,7 @@ export function reconcileObservedTranscriptHosts(
   const quarantinedPaneIds = new Set<string>();
   for (const host of hosts) {
     const evidence = evidenceForHost(host);
-    if (host.launchId) {
+    if (host.launchId && !host.primaryPath) {
       registry.confirmSpawnPaneAlive(host.launchId, evidence, { engine: host.engine, cwd: host.cwd });
       mutated = true;
     }
@@ -657,9 +657,29 @@ export function reconcileObservedTranscriptHosts(
       const rootPath = launchReceiptRootArtifact(host);
       const rootKey = rootPath ? sessionKeyFromTranscript(host.engine, rootPath) : null;
       if (!rootPath || !rootKey) {
+        registry.confirmSpawnPaneAlive(host.launchId, evidence, { engine: host.engine, cwd: host.cwd });
+        mutated = true;
         quarantinedPaneIds.add(host.paneId);
         continue;
       }
+      const rootId = `${rootKey.engine}:${rootKey.sessionId}`;
+      const receipt = snapshot.receipts[host.launchId];
+      const existing = snapshot.entries[rootId];
+      if (receipt?.state === "completed"
+        && receipt.cwd === host.cwd
+        && receipt.artifactPath === rootPath
+        && receipt.key?.engine === rootKey.engine
+        && receipt.key.sessionId === rootKey.sessionId
+        && isDeepStrictEqual(receipt.verifiedHost, evidence)
+        && existing?.artifactPath === rootPath
+        && existing.cwd === host.cwd
+        && existing.status === "live"
+        && existing.pendingAction === null
+        && isDeepStrictEqual(existing.host, evidence)) {
+        seen.add(rootId);
+        continue;
+      }
+      registry.confirmSpawnPaneAlive(host.launchId, evidence, { engine: host.engine, cwd: host.cwd });
       const settled = registry.completeObservedSpawn(host.launchId, {
         key: rootKey,
         artifactPath: rootPath,
@@ -675,7 +695,7 @@ export function reconcileObservedTranscriptHosts(
       /* A mismatched pane/artifact remains quarantined. It must never fall
          through into the generic upsert and overwrite the real receipt. */
       if (settled.kind === "settled") {
-        seen.add(`${rootKey.engine}:${rootKey.sessionId}`);
+        seen.add(rootId);
         continue;
       }
       quarantinedPaneIds.add(host.paneId);
@@ -702,7 +722,11 @@ export function reconcileObservedTranscriptHosts(
     }
     seen.add(id);
   }
-  if (mutated) snapshot = registry.snapshot();
+  /* Completed launch hosts are observed on every tmux-target poll. Their
+     confirmation is usually a durable no-op. The revision-aware read cache
+     supplies fresh projection state for every browser tab, and a real
+     mutation invalidates that cache synchronously. */
+  if (mutated) snapshot = registry.readOnlySnapshot();
   for (const [id, entry] of Object.entries(snapshot.entries)) {
     if (entry.host?.kind === "tmux" && !seen.has(id)) registry.markUnhosted(entry.key);
   }


### PR DESCRIPTION
## Summary

- fast-path already settled launch hosts during tmux reconciliation
- reuse the revision-aware registry read cache after real host mutations
- add the SQLite `(collection, row_order)` index used by ordered snapshot reads

## Production evidence

After #584 removed PID-only scanner fan-out, the Viewer remained near 100% CPU. `/proc` sampling showed repeated `etilqs_*` SQLite temp files and 30-50 MB/s cancelled writes. The 20 MB registry used a temp B-tree for every ordered collection load. Settled launch hosts also called `confirmSpawnPaneAlive()` plus `completeObservedSpawn()` on every `/api/tmux/targets` poll, invalidating the snapshot cache and reloading the full registry for each browser tab.

The regression proves two repeated settled-host polls cause zero SQLite snapshot loads after warm-up. The query-plan regression requires `registry_rows_collection_order` and rejects a temp B-tree. A production-sized local query benchmark improved 30 ordered collection reads from 781 ms to 247 ms with the index.

## Verification

- 26 transcript-host tests pass
- full `registry.sqlite.test.ts` pass
- TypeScript passes
- changed-file ESLint passes
- privacy gate passes
- production build passes
- diff-check passes

Follow-up for #555.