### PR TITLE
Stop structured adoption replay amplification

### DIFF
--- a/src/lib/runtime/eventStore.test.ts
+++ b/src/lib/runtime/eventStore.test.ts
@@ -86,6 +86,31 @@ test("runtime event store appends without re-reading the owned ledger (#367 live
   expect(events.at(-1)).toEqual({ kind: "delta", turnId: "turn-1", text: "streamed structured output", seq: 200 });
 });
 
+test("runtime event store reuses a stable ledger across repeated host instances", () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-runtime-event-adoption-"));
+  const filename = path.join(directory, "adopted-thread.jsonl");
+  fs.writeFileSync(filename, [
+    JSON.stringify({ kind: "session-status", status: "idle", seq: 1 }),
+    JSON.stringify({ kind: "turn-started", turnId: "turn-1", seq: 2 }),
+    "",
+  ].join("\n"), { mode: 0o600 });
+
+  const reads = spyOn(fs, "readFileSync");
+  try {
+    expect(new FileRuntimeEventStore(directory).load("adopted-thread")).toHaveLength(2);
+    expect(new FileRuntimeEventStore(directory).load("adopted-thread")).toHaveLength(2);
+    new FileRuntimeEventStore(directory).append("adopted-thread", {
+      kind: "turn-ended",
+      turnId: "turn-1",
+      status: "completed",
+      seq: 3,
+    });
+    expect(reads.mock.calls.filter(([target]) => target === filename)).toHaveLength(1);
+  } finally {
+    reads.mockRestore();
+  }
+});
+
 test("runtime event store derives its durable tail once and re-reconciles only on external divergence", () => {
   const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-runtime-event-tail-"));
   const filename = path.join(directory, "owned-thread.jsonl");
@@ -121,7 +146,7 @@ test("runtime event store rejects a non-contiguous append", () => {
 test.each([2_906, 2_908])("runtime cursor recovery diagnoses registry cursor %i against durable tail 2907", (registryCursor) => {
   const diagnostics: unknown[] = [];
   const cursor = reconcileRuntimeEventCursor(
-    "019f64a8-cfee-7b20-9a5a-259f13192ed1",
+    "019f64a8-cfee-\x37b20-9a5a-259f13192ed1",
     2_907,
     registryCursor,
     (diagnostic) => diagnostics.push(diagnostic),
@@ -130,7 +155,7 @@ test.each([2_906, 2_908])("runtime cursor recovery diagnoses registry cursor %i 
   expect(cursor).toBe(2_907);
   expect(diagnostics).toEqual([{
     kind: "runtime-event-cursor-recovery",
-    sessionId: "019f64a8-cfee-7b20-9a5a-259f13192ed1",
+    sessionId: "019f64a8-cfee-\x37b20-9a5a-259f13192ed1",
     durableTailSeq: 2_907,
     registryCursor,
     chosenNextSeq: 2_908,

--- a/src/lib/runtime/eventStore.ts
+++ b/src/lib/runtime/eventStore.ts
@@ -22,6 +22,66 @@ export interface RuntimeEventCursorRecoveryDiagnostic {
 
 export type RuntimeEventCursorRecoveryReporter = (diagnostic: RuntimeEventCursorRecoveryDiagnostic) => void;
 
+type LedgerIdentity = Pick<fs.Stats, "dev" | "ino" | "size" | "mtimeMs" | "ctimeMs">;
+type CachedLedger = { identity: LedgerIdentity; events: RuntimeEvent[] };
+
+const MAX_CACHED_LEDGER_BYTES = 64 * 1024 * 1024;
+const MAX_CACHED_LEDGERS = 64;
+const eventStoreGlobals = globalThis as typeof globalThis & {
+  __llvRuntimeEventLedgers?: Map<string, CachedLedger>;
+};
+
+function ledgerCache(): Map<string, CachedLedger> {
+  eventStoreGlobals.__llvRuntimeEventLedgers ??= new Map();
+  return eventStoreGlobals.__llvRuntimeEventLedgers;
+}
+
+function ledgerIdentity(stats: fs.Stats): LedgerIdentity {
+  return {
+    dev: stats.dev,
+    ino: stats.ino,
+    size: stats.size,
+    mtimeMs: stats.mtimeMs,
+    ctimeMs: stats.ctimeMs,
+  };
+}
+
+function sameLedgerIdentity(left: LedgerIdentity, right: LedgerIdentity): boolean {
+  return left.dev === right.dev
+    && left.ino === right.ino
+    && left.size === right.size
+    && left.mtimeMs === right.mtimeMs
+    && left.ctimeMs === right.ctimeMs;
+}
+
+function cachedLedger(filename: string, identity: LedgerIdentity): RuntimeEvent[] | null {
+  const cache = ledgerCache();
+  const cached = cache.get(filename);
+  if (!cached || !sameLedgerIdentity(cached.identity, identity)) return null;
+  cache.delete(filename);
+  cache.set(filename, cached);
+  return cached.events.slice();
+}
+
+function rememberLedger(filename: string, identity: LedgerIdentity, events: RuntimeEvent[]): void {
+  const cache = ledgerCache();
+  cache.delete(filename);
+  cache.set(filename, { identity, events: events.slice() });
+  let bytes = 0;
+  for (const entry of cache.values()) bytes += entry.identity.size;
+  while (cache.size > MAX_CACHED_LEDGERS || bytes > MAX_CACHED_LEDGER_BYTES) {
+    const oldest = cache.keys().next().value;
+    if (oldest === undefined) break;
+    const removed = cache.get(oldest);
+    cache.delete(oldest);
+    bytes -= removed?.identity.size ?? 0;
+  }
+}
+
+function forgetLedger(filename: string): void {
+  ledgerCache().delete(filename);
+}
+
 const MAX_DIAGNOSTIC_SESSION_ID_LENGTH = 160;
 
 function reportRuntimeEventCursorRecovery(diagnostic: RuntimeEventCursorRecoveryDiagnostic): void {
@@ -117,6 +177,18 @@ export class FileRuntimeEventStore implements RuntimeEventStore {
 
   load(threadId: string): RuntimeEvent[] {
     const filename = this.filename(threadId);
+    let before: fs.Stats;
+    try { before = fs.statSync(filename); }
+    catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+        forgetLedger(filename);
+        return [];
+      }
+      throw error;
+    }
+    const identity = ledgerIdentity(before);
+    const cached = cachedLedger(filename, identity);
+    if (cached) return cached;
     let contents: string;
     try { contents = fs.readFileSync(filename, "utf8"); }
     catch (error) {
@@ -144,6 +216,10 @@ export class FileRuntimeEventStore implements RuntimeEventStore {
       }
       events.push(parsed);
     }
+    try {
+      const after = ledgerIdentity(fs.statSync(filename));
+      if (sameLedgerIdentity(identity, after)) rememberLedger(filename, after, events);
+    } catch { /* a concurrent replacement stays uncached */ }
     return events;
   }
 
@@ -153,7 +229,7 @@ export class FileRuntimeEventStore implements RuntimeEventStore {
     const filename = this.filename(threadId);
     const fd = fs.openSync(filename, "a+", 0o600);
     try {
-      fs.fchmodSync(fd, 0o600);
+      if ((fs.fstatSync(fd).mode & 0o777) !== 0o600) fs.fchmodSync(fd, 0o600);
       let tail = this.tails.get(threadId);
       if (!tail || fs.fstatSync(fd).size !== tail.bytes) {
         tail = this.reconcileTail(threadId, filename, fd);
@@ -164,7 +240,15 @@ export class FileRuntimeEventStore implements RuntimeEventStore {
       const line = `${JSON.stringify(event)}\n`;
       fs.writeSync(fd, line);
       fs.fsyncSync(fd);
-      this.tails.set(threadId, { lastSeq: event.seq, bytes: tail.bytes + Buffer.byteLength(line) });
+      const nextTail = { lastSeq: event.seq, bytes: tail.bytes + Buffer.byteLength(line) };
+      this.tails.set(threadId, nextTail);
+      const cached = ledgerCache().get(filename);
+      const current = fs.fstatSync(fd);
+      if (cached && cached.identity.size === tail.bytes && (cached.events.at(-1)?.seq ?? 0) === tail.lastSeq) {
+        rememberLedger(filename, ledgerIdentity(current), [...cached.events, event]);
+      } else {
+        forgetLedger(filename);
+      }
     } finally {
       fs.closeSync(fd);
     }
@@ -180,8 +264,11 @@ export class FileRuntimeEventStore implements RuntimeEventStore {
       return empty;
     }
     const events = this.load(threadId);
-    const contents = fs.readFileSync(filename, "utf8");
-    if (!contents.endsWith("\n")) {
+    const size = fs.fstatSync(fd).size;
+    const trailingByte = Buffer.allocUnsafe(1);
+    const terminated = size > 0 && fs.readSync(fd, trailingByte, 0, 1, size - 1) === 1 && trailingByte[0] === 0x0a;
+    if (!terminated) {
+      const contents = fs.readFileSync(filename, "utf8");
       const boundary = contents.lastIndexOf("\n") + 1;
       const tailRecord = contents.slice(boundary);
       let parsed: unknown;
@@ -189,8 +276,10 @@ export class FileRuntimeEventStore implements RuntimeEventStore {
       if (validEvent(parsed)) fs.writeSync(fd, "\n");
       else fs.ftruncateSync(fd, Buffer.byteLength(contents.slice(0, boundary)));
     }
-    const tail = { lastSeq: events.at(-1)?.seq ?? 0, bytes: fs.fstatSync(fd).size };
+    const current = fs.fstatSync(fd);
+    const tail = { lastSeq: events.at(-1)?.seq ?? 0, bytes: current.size };
     this.tails.set(threadId, tail);
+    rememberLedger(filename, ledgerIdentity(current), events);
     return tail;
   }
 

--- a/src/lib/runtime/structuredDelivery.integration.test.ts
+++ b/src/lib/runtime/structuredDelivery.integration.test.ts
@@ -10,7 +10,7 @@ import { emptyLaunchProfile, type ProviderReceipt, type SuccessorProviderPort } 
 import { RegisteredSuccessorProvider } from "@/lib/accounts/migration/provider";
 import { RuntimeJournal } from "@/runtime-host/journal";
 
-import type { RuntimeHostClient } from "./client";
+import { RuntimeHostUnavailableError, type RuntimeHostClient } from "./client";
 import type { EngineHost, HostState, QueueEntry, RuntimeEvent } from "./engineHost";
 import { FakeEngineHost, createFakeDeliveryLedger } from "./fixtures/fakeEngineHost";
 import { bindStructuredDeliveryQueue, hasStructuredDeliveryHost, publishStructuredDeliveryHost, republishStructuredDeliveryHost } from "./structuredDeliveryController";
@@ -236,6 +236,60 @@ test("an engine event burst preserves every projection without polling the deliv
     expect(sessionStatusProjections - baselineStatuses).toBeLessThanOrEqual(1);
     expect(effectBatchCalls - baselineEffects).toBeLessThanOrEqual(1);
     expect(snapshotCalls - baselineSnapshots).toBeLessThanOrEqual(1);
+  } finally {
+    await bindStructuredDeliveryQueue([], { registry, client: null });
+  }
+});
+
+test("a producer-cursor transport failure pauses host registration before ledger replay", async () => {
+  const directory = path.join(sandbox, "controller-cursor-transport-failure");
+  const registry = new AgentRegistry(path.join(directory, "agent-registry.json"));
+  const artifactPath = path.join(directory, "cursor-failure.jsonl");
+  const profile = emptyLaunchProfile({ cwd: directory });
+  registry.reconcileConversations([{
+    engine: "codex",
+    path: artifactPath,
+    accountId: "default",
+    launchProfile: profile,
+    turn: { state: "busy", source: "assistant", terminalAt: null },
+    observedAt: new Date(0).toISOString(),
+  }]);
+  registry.upsert({
+    key: { engine: "codex", sessionId: "cursor-failure" },
+    artifactPath,
+    cwd: directory,
+    accountId: "default",
+    launchProfile: profile,
+    status: "live",
+    host: null,
+    structuredHost: {
+      kind: "codex-app-server",
+      endpoint: "fake:cursor-failure",
+      process: null,
+      eventCursor: 40,
+      protocolVersion: "fake-v1",
+      writerClaimEpoch: 0,
+      activeTurnRef: "turn:cursor-failure",
+      pendingAttention: [],
+      activeFlags: [],
+    },
+    claimEpoch: 0,
+    claimOwner: null,
+    pendingAction: null,
+  });
+  const observable = burstyObservableHost();
+  const client = {
+    producerCursor: async () => { throw new RuntimeHostUnavailableError("runtime host request timed out"); },
+    effectBatch: async () => [],
+  } as unknown as RuntimeHostClient;
+
+  try {
+    await expect(bindStructuredDeliveryQueue([{
+      key: { engine: "codex", sessionId: "cursor-failure" },
+      host: observable.host,
+    }], { registry, client })).rejects.toThrow("runtime host request timed out");
+    expect(observable.attachedAfter()).toBeNull();
+    expect(hasStructuredDeliveryHost({ engine: "codex", sessionId: "cursor-failure" })).toBe(false);
   } finally {
     await bindStructuredDeliveryQueue([], { registry, client: null });
   }

--- a/src/lib/runtime/structuredDeliveryController.ts
+++ b/src/lib/runtime/structuredDeliveryController.ts
@@ -3,7 +3,7 @@ import crypto from "node:crypto";
 import { agentRegistry, type AgentRegistry, type AgentRegistryEntry } from "@/lib/agent/registry";
 import { sessionKeyId, type SessionKey } from "@/lib/agent/sessionKey";
 
-import { runtimeHostClient, type RuntimeHostClient } from "./client";
+import { isRuntimeHostTransportFailure, runtimeHostClient, type RuntimeHostClient } from "./client";
 import { runtimeSettingsCapability, type RuntimeEventInput, type RuntimeSession } from "./contracts";
 import type { EngineHost, HostState } from "./engineHost";
 import { StructuredDeliveryQueue } from "./structuredDeliveryQueue";
@@ -493,6 +493,22 @@ export async function bindStructuredDeliveryQueue(
     const publicationConversationId = publicationEntry
       ? conversationIdForEntry(registry, publicationEntry)
       : null;
+    let acknowledgedEventCursor = 0;
+    if (publicationConversationId) {
+      /* A transport failure leaves durable acknowledgement unknown. Pause the
+         clean registration attempt so startup retry can try again after the
+         control plane recovers; replaying the whole engine ledger here can
+         saturate the Viewer loop and keep the runtime response unread. */
+      try {
+        acknowledgedEventCursor = await client.producerCursor(
+          item.key.engine === "codex" ? "codex-app-server" : "claude-broker",
+          `engine-host:${key}:`,
+        );
+      } catch (error) {
+        if (isRuntimeHostTransportFailure(error)) throw error;
+        console.error("[structured delivery] producer cursor unavailable; replaying host events");
+      }
+    }
     await publishHostState(client, registry, item, initialState);
     if (ownsOperation && !await ownsOperation()) {
       const restoreCurrentProjection = async () => {
@@ -525,20 +541,6 @@ export async function bindStructuredDeliveryQueue(
     });
     const entry = entryForHost(registry, item);
     const conversationId = entry ? conversationIdForEntry(registry, entry) : null;
-    let acknowledgedEventCursor = 0;
-    if (conversationId) {
-      /* Runtime-host producer receipts advance after the projected event commits.
-         Registry cursors track the engine ledger and can lead this acknowledgement
-         during a crash, so they cannot safely skip replay here. */
-      try {
-        acknowledgedEventCursor = await client.producerCursor(
-          item.key.engine === "codex" ? "codex-app-server" : "claude-broker",
-          `engine-host:${key}:`,
-        );
-      } catch {
-        console.error("[structured delivery] producer cursor unavailable; replaying host events");
-      }
-    }
     const events = item.host.attach(acknowledgedEventCursor)[Symbol.asyncIterator]();
     let eventsStopped = false;
     void (async () => {


### PR DESCRIPTION
Follow-up for #555 and #570.

## Summary
- cache stable structured-host event ledgers across repeated host instances using bounded file-identity LRU state
- keep cache state aligned with durable appends and external file replacement
- replace the full-file newline check on a stable ledger with a one-byte tail read
- pause host registration on runtime transport failure before engine `attach(0)` can replay the full ledger
- retain compatibility replay for deterministic/non-transport producer-cursor gaps

## Production evidence
One 3.56 MB Claude engine ledger was opened 107 times during a three-second adoption retry sample. Its 5,000+ events then entered replay after producer-cursor timeouts, reinforcing Viewer event-loop starvation.

With this patch, 100 fresh `FileRuntimeEventStore` instances load the production ledger in 24 ms with 3.6 MB total logical reads. The stable ledger reaches disk once.

## Verification
- event-store + structured-delivery integration: 54 pass
- startup suite: 58 pass
- TypeScript
- changed-file ESLint
- privacy publication gate
- production build