### PR TITLE
Bound structured startup transcript refresh

### DIFF
--- a/src/lib/runtime/startup.test.ts
+++ b/src/lib/runtime/startup.test.ts
@@ -975,7 +975,7 @@ function addStructuredRestartConversation(
   input: {
     engine?: "codex" | "claude";
     sessionId: string;
-    status: "live" | "dead";
+    status: "live" | "dead" | "unhosted";
     turn: "busy" | "terminal" | "unknown";
     activeTurnRef?: string | null;
     transcriptRecords?: Record<string, unknown>[];
@@ -1520,6 +1520,38 @@ test("startup adoption reads terminal transcripts before booting production-shap
   const startedAt = performance.now();
   expect(await startupAdoptionAttempts(registry)).toEqual([`codex:${activeSessionId}`]);
   expect(performance.now() - startedAt).toBeLessThan(1_000);
+
+  fs.rmSync(directory, { recursive: true, force: true });
+});
+
+test("startup transcript refresh skips historical structured hosts", async () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-runtime-startup-historical-refresh-"));
+  const registry = new AgentRegistry(path.join(directory, "agent-registry.json"));
+  const live = addStructuredRestartConversation(registry, directory, {
+    sessionId: "41000000-0000-\x34000-8000-000000000010",
+    status: "live",
+    turn: "busy",
+    activeTurnRef: "live-turn",
+    transcriptRecords: [
+      { timestamp: "2026-07-15T10:00:00.000Z", payload: { type: "task_started", turn_id: "live-turn" } },
+      { timestamp: "2026-07-15T10:00:01.000Z", payload: { type: "task_complete", turn_id: "live-turn" } },
+    ],
+  });
+  const historical = (["dead", "unhosted"] as const).flatMap((status, statusIndex) =>
+    Array.from({ length: 32 }, (_, index) => addStructuredRestartConversation(registry, directory, {
+      sessionId: `5${statusIndex}${String(index).padStart(6, "0")}-0000-4000-8000-000000000010`,
+      status,
+      turn: "busy",
+      activeTurnRef: `historical-${status}-${index}`,
+      transcriptRecords: [
+        { timestamp: "2026-07-15T10:00:00.000Z", payload: { type: "task_started", turn_id: `historical-${index}` } },
+        { timestamp: "2026-07-15T10:00:01.000Z", payload: { type: "task_complete", turn_id: `historical-${index}` } },
+      ],
+    }).conversation));
+
+  expect(await startupAdoptionAttempts(registry)).toEqual([]);
+  expect(registry.conversation(live.conversation.id)?.turn.state).toBe("terminal");
+  expect(historical.every((conversation) => registry.conversation(conversation.id)?.turn.state === "busy")).toBeTrue();
 
   fs.rmSync(directory, { recursive: true, force: true });
 });

--- a/src/lib/runtime/startup.ts
+++ b/src/lib/runtime/startup.ts
@@ -61,7 +61,7 @@ function retainedStartupHostIsCurrent(
 async function revalidateRetainedStartupHosts(
   registry: AgentRegistry,
   retained: readonly AdoptedStructuredHost[],
-  snapshot: RegistryFile = registry.snapshot(),
+  snapshot: RegistryFile = registry.readOnlySnapshot(),
 ): Promise<AdoptedStructuredHost[]> {
   const current: AdoptedStructuredHost[] = [];
   for (const item of retained) {
@@ -99,7 +99,7 @@ function interruptedCodexConversations(
   registry: AgentRegistry,
   shouldAdopt: StructuredHostAdoptionFilter,
   runtimeRunningConversationIds: ReadonlySet<string>,
-  snapshot: RegistryFile = registry.snapshot(),
+  snapshot: RegistryFile = registry.readOnlySnapshot(),
 ): ReadonlyMap<string, ViewerConversationId> {
   return new Map(Object.values(snapshot.conversations).flatMap((conversation) => {
     const generation = conversation.generations.at(-1);
@@ -212,13 +212,15 @@ function persistedTurnState(
 }
 
 async function refreshStructuredTranscriptState(registry: AgentRegistry): Promise<void> {
-  const snapshot = registry.snapshot();
+  const snapshot = registry.readOnlySnapshot();
   const observedAt = new Date().toISOString();
   const candidates = Object.values(snapshot.conversations).flatMap((conversation) => {
     const generation = conversation.generations.at(-1);
     if (!generation) return [];
     const entry = snapshot.entries[sessionKeyId({ engine: conversation.engine, sessionId: generation.id })];
-    return entry?.structuredHost ? [{ conversation, generation }] : [];
+    return entry?.structuredHost && entry.status === "live" && !conversation.supersededBy
+      ? [{ conversation, generation }]
+      : [];
   });
   const observations: Parameters<AgentRegistry["reconcileConversations"]>[0] = [];
   let nextCandidate = 0;
@@ -311,7 +313,7 @@ async function structuredStartupSignals(
 function structuredStartupAdoptionFilter(
   registry: AgentRegistry,
   signals: StructuredStartupSignals,
-  snapshot: RegistryFile = registry.snapshot(),
+  snapshot: RegistryFile = registry.readOnlySnapshot(),
 ): StructuredHostAdoptionFilter {
   const conversationsByCurrentEntry = new Map(Object.values(snapshot.conversations).flatMap((conversation) => {
     const generation = conversation.generations.at(-1);
@@ -440,7 +442,7 @@ export async function adoptStructuredHostsAtStartup(
     ? await interruptedCodexContinuations(registry, client, candidateCodexHosts)
     : new Map<string, RuntimeOperationResult>();
   await demoteSkippedStructuredRegistryHosts(registry, shouldRetainCandidateOrAdopt);
-  const publicationSnapshot = registry.snapshot();
+  const publicationSnapshot = registry.readOnlySnapshot();
   nextAdoptedHosts = await revalidateRetainedStartupHosts(registry, nextAdoptedHosts, publicationSnapshot);
   retryAdoptedHosts = nextAdoptedHosts;
   const finalShouldAdopt = structuredStartupAdoptionFilter(registry, signals, publicationSnapshot);


### PR DESCRIPTION
## Summary

- refresh transcript turn state only for live current structured hosts during startup recovery
- keep historical dead, unhosted, and superseded rows available without rereading their transcript tails
- reuse the SQLite registry revision cache across startup read passes

## Production evidence

The production registry contains 1,613 structured-host rows: 988 dead, 494 unhosted, 128 starting, 2 idle, and 1 live. Every startup retry reread transcript tails for all 1,613 rows, producing hundreds of megabytes of logical reads and starving runtime RPC deadlines.

## Verification

- `bun test src/lib/runtime/startup.test.ts` — 59 passed
- `bunx tsc --noEmit`
- changed-file ESLint
- `bun run privacy:check`
- `bun run build`

Closes the remaining startup transcript amplification slice of #555.