### PR TITLE
Share registry snapshot cache across startup recovery

### DIFF
--- a/scripts/privacy-publication-gate.test.ts
+++ b/scripts/privacy-publication-gate.test.ts
@@ -497,6 +497,20 @@ exec "$LLV_TEST_REAL_GIT" "$@"
     expect(result.stderr.toString()).toBe("");
   });
 
+  test("scans several text files after one large source file", () => {
+    const directory = mkdtempSync(join(tmpdir(), "llv-privacy-gate-multi-text-"));
+    temporaryDirectories.push(directory);
+    const paths = ["large.ts", "second.ts", "third.ts", "fourth.ts"].map((name) => join(directory, name));
+    writeFileSync(paths[0]!, "export const fixture = true;\n".repeat(12_000));
+    for (const path of paths.slice(1)) writeFileSync(path, "export const fixture = true;\n");
+
+    const result = runGate(paths);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout.toString()).toBe("PRIVACY GATE: PASS\n");
+    expect(result.stderr.toString()).toBe("");
+  });
+
   test("detects quoted credential assignments containing punctuation", () => {
     const directory = mkdtempSync(join(tmpdir(), "llv-privacy-gate-"));
     temporaryDirectories.push(directory);

--- a/scripts/privacy-publication-gate.ts
+++ b/scripts/privacy-publication-gate.ts
@@ -546,19 +546,19 @@ export function sensitiveClasses(text: string): Set<FindingClass> {
     findings.add("known_value");
   }
   const unixHomePattern = /(?:^|[\s"'(=:/])\/(?:home|Users)\/([A-Za-z0-9._-]+)(?:\/|$)/gm;
-  for (const match of searchableText.matchAll(unixHomePattern)) {
+  for (let match = unixHomePattern.exec(searchableText); match; match = unixHomePattern.exec(searchableText)) {
     if (match[1].toLowerCase() === "user") continue;
     findings.add("home_path");
     break;
   }
   const windowsHomePattern = /(?:^|[\s"'(])[A-Za-z]:\\Users\\([A-Za-z0-9._-]+)(?:\\|$)/gim;
-  for (const match of searchableText.matchAll(windowsHomePattern)) {
+  for (let match = windowsHomePattern.exec(searchableText); match; match = windowsHomePattern.exec(searchableText)) {
     if (match[1].toLowerCase() === "user") continue;
     findings.add("home_path");
     break;
   }
   const emailPattern = /\b[A-Z0-9.!#$%&'*+/=?^_`{|}~-]+@([A-Z0-9.-]+\.[A-Z]{2,})\b/gi;
-  for (const match of searchableText.matchAll(emailPattern)) {
+  for (let match = emailPattern.exec(searchableText); match; match = emailPattern.exec(searchableText)) {
     const domain = match[1].toLowerCase();
     if (domain === "example.com" || domain === "example.net" || domain === "example.org" || domain.endsWith(".invalid")) continue;
     findings.add("email_address");
@@ -579,7 +579,8 @@ export function sensitiveClasses(text: string): Set<FindingClass> {
     `s${separator}k`,
   ].join("|") + String.raw`[^a-z0-9\r\n]{0,8}?[_-][^a-z0-9\r\n]*`, "gi");
   for (const line of searchableText.split(/\r?\n/)) {
-    for (const match of line.matchAll(splitTokenPrefix)) {
+    splitTokenPrefix.lastIndex = 0;
+    for (let match = splitTokenPrefix.exec(line); match; match = splitTokenPrefix.exec(line)) {
       const compactTail = compactSensitiveText(line.slice(match.index));
       if (/^(?:githubpat|gh[pousr]|xox[baprs]|sk)[a-z0-9]{12,}/i.test(compactTail)) {
         findings.add("credential");

--- a/src/lib/agent/registry.ts
+++ b/src/lib/agent/registry.ts
@@ -5718,12 +5718,15 @@ export class AgentRegistry {
   }
 }
 
-let registry: AgentRegistry | null = null;
+const registryProcessState = globalThis as typeof globalThis & {
+  __llvAgentRegistry?: AgentRegistry | null;
+};
+
 export function agentRegistry(): AgentRegistry {
-  registry ??= new AgentRegistry();
-  return registry;
+  registryProcessState.__llvAgentRegistry ??= new AgentRegistry();
+  return registryProcessState.__llvAgentRegistry;
 }
 
 export function setAgentRegistryForTests(value: AgentRegistry | null): void {
-  registry = value;
+  registryProcessState.__llvAgentRegistry = value;
 }

--- a/src/lib/runtime/registry.ts
+++ b/src/lib/runtime/registry.ts
@@ -334,7 +334,7 @@ export async function demoteSkippedStructuredRegistryHosts(
   registry: AgentRegistry,
   shouldAdopt: StructuredHostAdoptionFilter,
 ): Promise<void> {
-  const rows = Object.values(registry.snapshot().entries).filter((entry) =>
+  const rows = Object.values(registry.readOnlySnapshot().entries).filter((entry) =>
     entry.structuredHost && !shouldAdopt(entry));
   for (const entry of rows) {
     const host = entry.structuredHost!;
@@ -349,7 +349,7 @@ export async function demoteSkippedStructuredRegistryHosts(
     const owner = { pid: process.pid, startIdentity: procBackend.processIdentity(process.pid) };
     try {
       await registry.withOperationLock(entry.key, owner, async () => {
-        const current = registry.snapshot().entries[sessionKeyId(entry.key)];
+        const current = registry.readOnlySnapshot().entries[sessionKeyId(entry.key)];
         if (!current?.structuredHost || shouldAdopt(current)) return;
         /* A PID-only claim cannot prove ownership across reboot. Runtime and
            transcript signals already excluded this row from adoption, so the
@@ -360,7 +360,7 @@ export async function demoteSkippedStructuredRegistryHosts(
           reclaimUnverifiedOwner: true,
         });
         if (!claimed) {
-          const current = registry.snapshot().entries[sessionKeyId(entry.key)];
+          const current = registry.readOnlySnapshot().entries[sessionKeyId(entry.key)];
           const orphan = current?.structuredHost?.kind === "claude-broker"
             ? current.structuredHost.process
             : null;
@@ -396,7 +396,7 @@ export async function adoptCodexRegistryHosts(
   shouldAdopt: StructuredHostAdoptionFilter = () => true,
 ): Promise<AdoptedCodexHost[]> {
   if (!structuredHostsEnabled(env)) return [];
-  const rows = Object.values(registry.snapshot().entries).filter((entry) =>
+  const rows = Object.values(registry.readOnlySnapshot().entries).filter((entry) =>
     entry.key.engine === "codex"
     && entry.structuredHost?.kind === "codex-app-server"
     && shouldAdopt(entry));
@@ -456,7 +456,7 @@ export async function adoptClaudeRegistryHosts(
   shouldAdopt: StructuredHostAdoptionFilter = () => true,
 ): Promise<AdoptedClaudeHost[]> {
   if (!structuredHostsEnabled(env)) return [];
-  const rows = Object.values(registry.snapshot().entries).filter((entry) =>
+  const rows = Object.values(registry.readOnlySnapshot().entries).filter((entry) =>
     entry.key.engine === "claude"
     && entry.structuredHost?.kind === "claude-broker"
     && shouldAdopt(entry));
@@ -467,7 +467,7 @@ export async function adoptClaudeRegistryHosts(
       await registry.withOperationLock(entry.key, owner, async () => {
         let claimed = registry.claimStructuredHost(entry.key, owner, { allowUnhosted: true });
         if (!claimed) {
-          const current = registry.snapshot().entries[`claude:${entry.key.sessionId}`];
+          const current = registry.readOnlySnapshot().entries[`claude:${entry.key.sessionId}`];
           const orphan = current?.structuredHost?.kind === "claude-broker"
             ? current.structuredHost.process
             : null;

--- a/src/lib/runtime/startup.ts
+++ b/src/lib/runtime/startup.ts
@@ -129,7 +129,7 @@ async function enqueueInterruptedCodexContinuations(
     const conversationId = interrupted.get(key);
     if (!conversationId) continue;
     if (pendingContinuationConversationIds.has(conversationId)) continue;
-    const entry = registry.snapshot().entries[key];
+    const entry = registry.readOnlySnapshot().entries[key];
     if (!entry) throw new Error(`adopted Codex registry row disappeared: ${key}`);
     const operationId = interruptedCodexContinuationOperationId(item.key.sessionId, entry.claimEpoch);
     const existing = existingByKey.get(key);
@@ -168,7 +168,7 @@ async function interruptedCodexContinuations(
   const existingByKey = new Map<string, RuntimeOperationResult>();
   for (const item of adopted) {
     const key = sessionKeyId(item.key);
-    const entry = registry.snapshot().entries[key];
+    const entry = registry.readOnlySnapshot().entries[key];
     if (!entry) continue;
     const current = await client.operationStatus(
       interruptedCodexContinuationOperationId(item.key.sessionId, entry.claimEpoch),

--- a/src/lib/runtime/structuredDeliveryController.ts
+++ b/src/lib/runtime/structuredDeliveryController.ts
@@ -122,7 +122,7 @@ async function reconcileTerminalDeliveries(
   client: RuntimeHostClient,
   isCurrent: () => boolean,
 ): Promise<void> {
-  const unsettledDeliveries = Object.values(registry.snapshot().heldDeliveries)
+  const unsettledDeliveries = Object.values(registry.readOnlySnapshot().heldDeliveries)
     .filter((delivery) => delivery.state === "delivery-uncertain" || delivery.state === "failed");
   const pendingOutcomes: Parameters<AgentRegistry["recordDeliveryOutcomesForOperations"]>[0][number][] = [];
   const flushOutcomes = () => {
@@ -270,7 +270,7 @@ export async function bindStructuredDeliveryQueue(
         );
         if (status === "delivered" && operationId.startsWith("spawn_message_")) {
           const launchId = operationId.slice("spawn_message_".length);
-          const receipt = registry.snapshot().receipts[launchId];
+          const receipt = registry.readOnlySnapshot().receipts[launchId];
           if (receipt?.conversationId === conversationId && receipt.state !== "completed") {
             const { reconcileStructuredSpawnReplay } = await import("./structuredSpawn");
             await reconcileStructuredSpawnReplay(launchId, registry, client);
@@ -636,7 +636,7 @@ export async function bindStructuredDeliveryQueue(
     completion = completion.catch(() => {}).then(async () => {
       if (stopped || state.activeQueue !== queue) return;
       for (const item of items) await register(item);
-      const startupSnapshot = registry.snapshot();
+      const startupSnapshot = registry.readOnlySnapshot();
       const runtimeSnapshot = typeof client.snapshot === "function"
         ? await client.snapshot().catch(() => null)
         : null;


### PR DESCRIPTION
## Summary

- route startup adoption and delivery-controller reads through the revision-aware SQLite snapshot cache
- share the AgentRegistry singleton across Next instrumentation and route bundles through process-global state
- stabilize repeated multi-file privacy inspection under Bun 1.3.3 by using explicit RegExp cursors

## Production evidence

After #588 removed historical transcript-tail fanout, the Viewer still consumed about 102% CPU and 111 MB/s of logical reads. Startup recovery retries were performing five to six uncached full registry snapshots each second. The process also held two independent SQLite/WAL descriptor pairs, showing duplicate registry instances across bundles.

## Verification

- runtime/registry/startup/SQLite suites: 112 passed
- privacy publication gate suite: 101 passed
- TypeScript
- changed-file ESLint
- privacy publication gate
- production build

Continues #555.