### PR TITLE
Reuse cached registry snapshots across read paths

### DIFF
--- a/src/app/api/account-migrations/[intentId]/action.ts
+++ b/src/app/api/account-migrations/[intentId]/action.ts
@@ -22,14 +22,14 @@ export async function updateMigrationAction(
   try {
     if (body.action === "stop") {
       const stopped = registry.setMigrationIntentState(intentId, "stopped", body.expectedRevision as number | undefined);
-      for (const conversation of Object.values(registry.snapshot().conversations)) {
+      for (const conversation of Object.values(registry.readOnlySnapshot().conversations)) {
         if (conversation.migration?.intentId === intentId && conversation.migration.phase === "rolled-back") {
           await drainHeldDeliveries(conversation.id, deliveryPort, registry);
         }
       }
       return NextResponse.json(stopped);
     }
-    const snapshot = registry.snapshot();
+    const snapshot = registry.readOnlySnapshot();
     const intent = snapshot.migrationIntents[intentId];
     if (!intent) return NextResponse.json({ error: "migration intent is unknown" }, { status: 404 });
     if (body.expectedRevision !== undefined && intent.revision !== body.expectedRevision) return NextResponse.json({ error: "migration intent revision is stale" }, { status: 409 });

--- a/src/app/api/accounts/claude/route.ts
+++ b/src/app/api/accounts/claude/route.ts
@@ -100,11 +100,11 @@ export async function DELETE(req: NextRequest) {
         return NextResponse.json({ error: "Claude account has active sessions, conversations, or sign-in", code: "account_removal_blocked", blockers }, { status: 409 });
       }
       const registry = agentRegistry();
-      const beforeRetirement = registry.snapshot();
+      const beforeRetirement = registry.readOnlySnapshot();
       try {
         if (login && LIVE_CLAUDE_LOGIN_PHASES.has(login.phase)) await claudeLoginSupervisor.cancel(login.operationId);
         registry.retireAccount("claude", account.id, "default");
-        const retired = registry.snapshot();
+        const retired = registry.readOnlySnapshot();
         try {
           const removal = removeManagedClaudeAccount(account.id);
           requestAccountMigrationTick();

--- a/src/app/api/accounts/codex/route.ts
+++ b/src/app/api/accounts/codex/route.ts
@@ -79,12 +79,12 @@ export async function DELETE(req: NextRequest) {
         return NextResponse.json({ error: "Codex account has active sessions, conversations, or sign-in", code: "account_removal_blocked", blockers }, { status: 409 });
       }
       const registry = agentRegistry();
-      const beforeRetirement = registry.snapshot();
+      const beforeRetirement = registry.readOnlySnapshot();
       try {
         if (login.attemptState === "pending") await managedCodexRuntime().cancelLogin(account.id);
         if (account.loginPane !== null) setCodexAccountLoginPane(account.id, null);
         registry.retireAccount("codex", account.id, "default");
-        const retired = registry.snapshot();
+        const retired = registry.readOnlySnapshot();
         try {
           const removal = removeManagedCodexAccount(account.id);
           requestAccountMigrationTick();

--- a/src/app/api/board/route.ts
+++ b/src/app/api/board/route.ts
@@ -29,7 +29,7 @@ function mutationsWithConversationAliases(mutations: readonly BoardMutationV1[])
 
   let snapshot: ReturnType<ReturnType<typeof agentRegistry>["snapshot"]>;
   try {
-    snapshot = agentRegistry().snapshot();
+    snapshot = agentRegistry().readOnlySnapshot();
   } catch (error) {
     if (error instanceof RegistryReadError) return [...mutations];
     throw error;

--- a/src/app/api/pipelines/route.ts
+++ b/src/app/api/pipelines/route.ts
@@ -41,7 +41,7 @@ function pipelineOriginRejection(req: NextRequest, body: CreatePipelineRequest):
     const caller = authenticatedAgentSpawnCaller(req, body.src, registry);
     if ("error" in caller) return NextResponse.json({ error: caller.error }, { status: caller.status ?? 403 });
     if (caller.kind === "agent") {
-      const role = conversationAgentRole(registry.snapshot(), caller.conversationId);
+      const role = conversationAgentRole(registry.readOnlySnapshot(), caller.conversationId);
       if (isSpawnDeniedRole(role)) {
         return NextResponse.json({ error: reviewerOriginSpawnGuidance(role), code: "reviewer_origin_spawn" }, { status: 403 });
       }
@@ -58,7 +58,7 @@ function pipelineOriginRejection(req: NextRequest, body: CreatePipelineRequest):
   const srcPath = typeof body.src === "string" && body.src.trim() ? body.src.trim() : null;
   const srcConversation = srcPath ? registry.conversationForPath(srcPath) : null;
   if (srcConversation) {
-    const role = conversationAgentRole(registry.snapshot(), srcConversation.id);
+    const role = conversationAgentRole(registry.readOnlySnapshot(), srcConversation.id);
     if (isSpawnDeniedRole(role)) {
       return NextResponse.json({ error: reviewerOriginSpawnGuidance(role), code: "reviewer_origin_spawn" }, { status: 403 });
     }

--- a/src/app/api/tasks/[id]/spawn/route.ts
+++ b/src/app/api/tasks/[id]/spawn/route.ts
@@ -200,7 +200,7 @@ async function postTaskSpawn(
   let retryOf: SpawnReceipt | null = null;
   if (typeof body.retryOfLaunchId === "string") {
     const launchId = body.retryOfLaunchId.trim();
-    const receipt = registry.snapshot().receipts[launchId] ?? null;
+    const receipt = registry.readOnlySnapshot().receipts[launchId] ?? null;
     const assignment = task.assignments.find((item) => item.launchId === launchId) ?? null;
     if (!receipt || !assignment) {
       return NextResponse.json({ error: "retryOfLaunchId does not name an assignment of this task" }, { status: 404 });
@@ -340,7 +340,7 @@ async function postTaskSpawn(
       admittedTask = admitted.task;
     } catch (error) {
       registry.failSpawn(launchReceipt.launchId, "task admission could not be persisted");
-      const failed = registry.snapshot().receipts[launchReceipt.launchId] ?? launchReceipt;
+      const failed = registry.readOnlySnapshot().receipts[launchReceipt.launchId] ?? launchReceipt;
       return NextResponse.json(taskSpawnResponse(failed, task, { ...admittedPatch, state: "failed" }, {
         error: error instanceof Error ? error.message : "task admission could not be persisted",
       }), { status: 500 });
@@ -350,7 +350,7 @@ async function postTaskSpawn(
       const binding = await dependencies.ensureTaskPipelineForAssignment(admittedTask, pipelineSpawnParams(null));
       if (!binding.pipeline) {
         registry.failSpawn(launchReceipt.launchId, binding.error ?? "could not reserve task pipeline");
-        const failed = registry.snapshot().receipts[launchReceipt.launchId] ?? launchReceipt;
+        const failed = registry.readOnlySnapshot().receipts[launchReceipt.launchId] ?? launchReceipt;
         const failedAt = isoNow();
         const failedPatch = assignmentPatch(failed, failedAt, account.accountId, engine);
         const persisted = persistAssignment(dependencies, id, failedPatch, failedAt);
@@ -393,12 +393,12 @@ async function postTaskSpawn(
       registry.markSpawnPathPending(launchReceipt.launchId);
     }
   } catch (error) {
-    const observed = registry.snapshot().receipts[launchReceipt.launchId] ?? launchReceipt;
+    const observed = registry.readOnlySnapshot().receipts[launchReceipt.launchId] ?? launchReceipt;
     if (observed.pane) {
       if (observed.state === "prompt-delivered" || observed.state === "host-verified") {
         registry.markSpawnPathPending(observed.launchId);
       }
-      const pending = registry.snapshot().receipts[observed.launchId] ?? observed;
+      const pending = registry.readOnlySnapshot().receipts[observed.launchId] ?? observed;
       const at = isoNow();
       const patch = assignmentPatch(pending, at, account.accountId, engine);
       let taskAfterRecovery = admittedTask;
@@ -413,7 +413,7 @@ async function postTaskSpawn(
       }), { status: 202 });
     }
     registry.failSpawn(launchReceipt.launchId, error instanceof Error ? error.message : "task spawn failed");
-    const failed = registry.snapshot().receipts[launchReceipt.launchId] ?? observed;
+    const failed = registry.readOnlySnapshot().receipts[launchReceipt.launchId] ?? observed;
     const at = isoNow();
     const patch = assignmentPatch(failed, at, account.accountId, engine);
     try {
@@ -427,7 +427,7 @@ async function postTaskSpawn(
     }), { status: 500 });
   }
 
-  const completed = registry.snapshot().receipts[launchReceipt.launchId] ?? launchReceipt;
+  const completed = registry.readOnlySnapshot().receipts[launchReceipt.launchId] ?? launchReceipt;
   const completedAt = isoNow();
   const completedPatch = assignmentPatch(completed, completedAt, account.accountId, engine);
   if (dependencies.ensureTaskPipelineForAssignment && completed.artifactPath) {

--- a/src/lib/accounts/migration/controller.ts
+++ b/src/lib/accounts/migration/controller.ts
@@ -40,7 +40,7 @@ export async function reconcileAccountMigrationCycle(
   await yieldToRuntime();
   await reconcileMigrations(provider, delivery, registry);
   await yieldToRuntime();
-  await forEachCooperatively(Object.values(registry.snapshot().conversations), async (conversation) => {
+  await forEachCooperatively(Object.values(registry.readOnlySnapshot().conversations), async (conversation) => {
     if (conversation.migration?.phase === "rolled-back") await drainHeldDeliveries(conversation.id, delivery, registry);
   });
   await yieldToRuntime();
@@ -48,7 +48,7 @@ export async function reconcileAccountMigrationCycle(
 }
 
 export function syncCompatibilityRouting(registry: AgentRegistry): void {
-  const current = registry.snapshot().engineRouting;
+  const current = registry.readOnlySnapshot().engineRouting;
   const claudeNeedsSync = (() => {
     try { return Boolean(current.claude.activeAccountId && current.claude.activeAccountId !== activeClaudeAccountId()); }
     catch { return true; }
@@ -59,7 +59,7 @@ export function syncCompatibilityRouting(registry: AgentRegistry): void {
   })();
   if (!claudeNeedsSync && !codexNeedsSync) return;
   withAccountMutationLock(() => {
-    const snapshot = registry.snapshot();
+    const snapshot = registry.readOnlySnapshot();
     const claude = snapshot.engineRouting.claude.activeAccountId;
     const codex = snapshot.engineRouting.codex.activeAccountId;
     try { if (claude && claude !== activeClaudeAccountId()) setActiveClaudeAccount(claude); } catch { /* registry routing stays authoritative */ }
@@ -116,7 +116,7 @@ async function reconcileControllerRuntime(registry: AgentRegistry, files: Contro
 }
 
 function reconcileControllerTasks(registry: AgentRegistry, files: ControllerScan["files"]): void {
-  const currentLookup = conversationLookupFromSnapshot(registry.snapshot());
+  const currentLookup = conversationLookupFromSnapshot(registry.readOnlySnapshot());
   mutateTasks((current) => {
     const reconciled = reconcileTasks(files, current, {
       pathForPanePid: (panePid, entries) => pathForPanePid(entries, panePid, readPpid),

--- a/src/lib/accounts/migration/coordinator.test.ts
+++ b/src/lib/accounts/migration/coordinator.test.ts
@@ -203,8 +203,8 @@ describe("durable account migration coordinator", () => {
     fs.writeFileSync(secondPath, JSON.stringify({ type: "event_msg", timestamp: "2026-07-11T00:00:00.000Z", payload: { type: "task_complete" } }) + "\n");
     store.reconcileConversations([observation(firstPath, "default", "idle")]);
     let snapshotCalls = 0;
-    const originalSnapshot = store.snapshot.bind(store);
-    store.snapshot = (() => { snapshotCalls += 1; return originalSnapshot(); }) as typeof store.snapshot;
+    const originalSnapshot = store.readOnlySnapshot.bind(store);
+    store.readOnlySnapshot = (() => { snapshotCalls += 1; return originalSnapshot(); }) as typeof store.readOnlySnapshot;
     store.conversationForPath = (() => { throw new Error("inventory must use its snapshot index"); }) as typeof store.conversationForPath;
     store.launchProfileForPath = (() => { throw new Error("inventory must use its snapshot index"); }) as typeof store.launchProfileForPath;
     const files = [firstPath, secondPath].map((pathname): FileEntry => ({

--- a/src/lib/accounts/migration/coordinator.ts
+++ b/src/lib/accounts/migration/coordinator.ts
@@ -81,7 +81,7 @@ function projectedInventoryTurn(
 
 async function inventory(files: FileEntry[], registry: AgentRegistry): Promise<ConversationObservation[]> {
   const inventoryStartedAt = Date.now();
-  const snapshot = registry.snapshot();
+  const snapshot = registry.readOnlySnapshot();
   const conversationByPath = new Map<string, RegistryConversation>();
   const launchProfileByPath = new Map<string, RegistryConversation["generations"][number]["launchProfile"]>();
   await forEachCooperatively(Object.values(snapshot.conversations), (conversation) => {
@@ -159,7 +159,7 @@ export async function reconcileMigrationInventory(registry: AgentRegistry = agen
 }
 
 function previewFromSnapshot(engine: MigrationEngine, targetId: string, registry: AgentRegistry): MigrationPreview {
-  const snapshot = registry.snapshot();
+  const snapshot = registry.readOnlySnapshot();
   const target = (engine === "claude" ? accountManager.resolveSpawn("claude", targetId) : accountManager.resolveSpawn("codex", targetId));
   const targetLabel = (engine === "claude" ? listClaudeAccounts() : listCodexAccounts()).find((account) => account.id === target.accountId)?.label ?? target.accountId;
   return {
@@ -652,7 +652,7 @@ export async function reconcileMigrations(
   registry: AgentRegistry = agentRegistry(),
   options: MigrationCoordinatorOptions = {},
 ): Promise<void> {
-  const before = registry.snapshot();
+  const before = registry.readOnlySnapshot();
   await forEachCooperatively(Object.values(before.pendingSuccessorCleanups), async (pending) => {
     const owner = registry.conversation(pending.conversationId);
     if (owner) await cleanupDiscardedSuccessor(provider, pending.receipt, owner, registry);
@@ -693,7 +693,7 @@ export async function reconcileMigrations(
     if (advanced.migration?.phase === "committed" && pendingDeliveries.has(advanced.id)) await drainHeldDeliveries(advanced.id, delivery, registry);
   });
   await yieldToRuntime();
-  const after = registry.snapshot();
+  const after = registry.readOnlySnapshot();
   await repairCommittedBoardSuccessions(
     Object.values(after.conversations),
     registry,

--- a/src/lib/accounts/migration/provider.ts
+++ b/src/lib/accounts/migration/provider.ts
@@ -201,7 +201,7 @@ async function publishCodexSuccessorHost(input: StructuredHostPublicationInput):
   if (!key) throw new Error("successor Codex thread identity is invalid");
   if (hasStructuredDeliveryHost(key)) return async () => { await releaseStructuredDeliveryHost(key); };
 
-  const existing = input.registry.snapshot().entries[sessionKeyId(key)];
+  const existing = input.registry.readOnlySnapshot().entries[sessionKeyId(key)];
   const entry = input.registry.upsert({
     ...(existing ?? {
       key,
@@ -304,7 +304,7 @@ async function publishClaudeSuccessorHost(
   if (hasStructuredDeliveryHost(key)) return async () => { await releaseStructuredDeliveryHost(key); };
   requireStructuredDeliveryControllerPublication();
 
-  const existing = input.registry.snapshot().entries[sessionKeyId(key)];
+  const existing = input.registry.readOnlySnapshot().entries[sessionKeyId(key)];
   const entry = input.registry.upsert({
     ...(existing ?? {
       key,
@@ -656,7 +656,7 @@ function ownsCompletedClaudeBrokerTransition(
 ): boolean {
   const key = sessionKey("claude", receipt.nativeId);
   if (!key) return false;
-  const entry = registry.snapshot().entries[sessionKeyId(key)];
+  const entry = registry.readOnlySnapshot().entries[sessionKeyId(key)];
   return entry?.structuredHostOperationId === receipt.operationId
     && entry.artifactPath === receipt.path
     && entry.accountId === target.accountId

--- a/src/lib/accounts/removal.ts
+++ b/src/lib/accounts/removal.ts
@@ -13,7 +13,7 @@ const LIVE_RECEIPT_STATES = new Set(["starting", "pane-bound", "host-verified", 
  *  already opts into, and the window is milliseconds. Closing it fully would
  *  need cross-store atomicity between the agent and accounts registries. */
 export function accountRemovalBlockers(engine: ManagedAccountEngine, accountId: string): AccountRemovalBlocker[] {
-  const snapshot = agentRegistry().snapshot();
+  const snapshot = agentRegistry().readOnlySnapshot();
   const liveEntry = Object.values(snapshot.entries).some((entry) =>
     entry.key.engine === engine && (entry.accountId === accountId || entry.accountId === null) && LIVE_ENTRY_STATUSES.has(entry.status));
   const liveReceipt = Object.values(snapshot.receipts).some((receipt) =>

--- a/src/lib/agent/registry.ts
+++ b/src/lib/agent/registry.ts
@@ -3409,7 +3409,7 @@ export class AgentRegistry {
     host: TmuxHostEvidence,
     observed: { engine: Extract<AgentEngine, "claude" | "codex">; cwd: string },
   ): SpawnReceipt | null {
-    const current = this.snapshot().receipts[launchId];
+    const current = this.readOnlySnapshot().receipts[launchId];
     if (!current || current.state !== "conflicted") return current ? clone(current) : null;
     return this.mutate((file) => {
       const receipt = this.confirmSpawnPaneAliveInFile(file, launchId, host, observed);
@@ -4001,7 +4001,7 @@ export class AgentRegistry {
   }
 
   ownsStructuredHostClaim(key: SessionKey, claimOwner: string, claimEpoch: number): boolean {
-    const entry = this.snapshot().entries[sessionKeyId(key)];
+    const entry = this.readOnlySnapshot().entries[sessionKeyId(key)];
     return entry?.claimOwner === claimOwner
       && entry.claimEpoch === claimEpoch
       && entry.structuredHost?.writerClaimEpoch === claimEpoch;

--- a/src/lib/agent/spawnCommand.ts
+++ b/src/lib/agent/spawnCommand.ts
@@ -412,7 +412,7 @@ export async function executeSpawnRequest(
     if (begun.kind === "conflict") return NextResponse.json({ error: "spawn attempt conflicts with its original request" }, { status: 409 });
     const adoptMaterializedAttempt = async (receipt: typeof begun.receipt, agentPath: string): Promise<void> => {
       if (!pipelineSourceConversationId || !dependencies.adoptPipelineAttemptFromSource) return;
-      const materialized = registry.snapshot().receipts[receipt.launchId] ?? receipt;
+      const materialized = registry.readOnlySnapshot().receipts[receipt.launchId] ?? receipt;
       try {
         await dependencies.adoptPipelineAttemptFromSource(pipelineSourceConversationId, {
           launchId: materialized.launchId,
@@ -494,7 +494,7 @@ export async function executeSpawnRequest(
     if (begun.kind === "replay") {
       const structured = begun.receipt.transport === "structured"
         || (begun.receipt.transport === null
-          && Boolean(begun.receipt.key && registry.snapshot().entries[sessionKeyId(begun.receipt.key)]?.structuredHost));
+          && Boolean(begun.receipt.key && registry.readOnlySnapshot().entries[sessionKeyId(begun.receipt.key)]?.structuredHost));
       let receipt = begun.receipt;
       let initialMessage: SpawnResponse["initialMessage"] | undefined;
       const runtimeClient = structured ? dependencies.runtimeHostClient() : null;
@@ -583,7 +583,7 @@ export async function executeSpawnRequest(
     const key = childPath ? sessionKeyFromTranscript(engine, childPath) : null;
     if (!pane.host || !await verifyTmuxHostEvidence(pane.host)) {
       agentRegistry().invalidateSpawnHost(begun.receipt.launchId, "spawn host disappeared before API confirmation");
-      const lost = agentRegistry().snapshot().receipts[begun.receipt.launchId]!;
+      const lost = agentRegistry().readOnlySnapshot().receipts[begun.receipt.launchId]!;
       return NextResponse.json(spawnResponseForReceipt(lost, childPath));
     }
     if (!childPath || !key || !pane.receipt) {
@@ -626,12 +626,12 @@ export async function executeSpawnRequest(
     }
     if (!await verifyTmuxHostEvidence(pane.host)) {
       agentRegistry().invalidateSpawnHost(begun.receipt.launchId, "spawn host disappeared before API response");
-      const lost = agentRegistry().snapshot().receipts[begun.receipt.launchId]!;
+      const lost = agentRegistry().readOnlySnapshot().receipts[begun.receipt.launchId]!;
       return NextResponse.json(spawnResponseForReceipt(lost, childPath));
     }
     return NextResponse.json(spawnResponseForReceipt(settled.receipt, childPath));
   } catch (error) {
-    const receipt = launchId ? agentRegistry().snapshot().receipts[launchId] : null;
+    const receipt = launchId ? agentRegistry().readOnlySnapshot().receipts[launchId] : null;
     if (!receipt || receipt.pane === null) {
       if (receipt) agentRegistry().failSpawn(receipt.launchId, "spawn failed before pane binding");
       deleteInboxImages(imagePaths);
@@ -647,7 +647,7 @@ export async function executeSpawnRequest(
     if (accountError) return accountError;
     if (receipt?.pane) {
       if (receipt.state === "prompt-delivered" || receipt.state === "host-verified") agentRegistry().markSpawnPathPending(receipt.launchId);
-      const recovered = agentRegistry().snapshot().receipts[receipt.launchId];
+      const recovered = agentRegistry().readOnlySnapshot().receipts[receipt.launchId];
       if (recovered) return NextResponse.json(spawnResponseForReceipt(recovered, recovered.artifactPath));
     }
     return NextResponse.json({ error: error instanceof Error ? error.message : String(error) }, { status: 500 });

--- a/src/lib/delivery.test.ts
+++ b/src/lib/delivery.test.ts
@@ -667,7 +667,7 @@ test("conversation kill refreshes the registry host inside the session lock", as
   const killed: string[] = [];
   const unhosted: string[] = [];
   const registry = {
-    snapshot: () => snapshots++ === 0 ? oldSnapshot : freshSnapshot,
+    readOnlySnapshot: () => snapshots++ === 0 ? oldSnapshot : freshSnapshot,
     withOperationLock: async (_key: unknown, _owner: unknown, task: () => Promise<unknown>) => task(),
     markUnhosted: (key: { sessionId: string }) => { unhosted.push(key.sessionId); },
   };

--- a/src/lib/delivery.ts
+++ b/src/lib/delivery.ts
@@ -103,7 +103,7 @@ export async function reconfigureConversation(
   const entry = (await (overrides.listFiles ?? listFiles)()).find((item) => item.path === filePath);
   if (!entry || (entry.engine !== "claude" && entry.engine !== "codex")) return failure("conversation is unavailable", 403);
   const registry = overrides.registry ?? agentRegistry();
-  const registered = registeredHostForPath(registry.snapshot(), filePath);
+  const registered = registeredHostForPath(registry.readOnlySnapshot(), filePath);
   if (!registered?.host) return failure("no registered agent pane for this conversation", 404);
   const conversation = registry.conversationForPath(filePath);
   const generation = conversation?.generations.at(-1);
@@ -142,7 +142,7 @@ export async function reconfigureConversation(
   const owner = { pid: process.pid, startIdentity: procBackend.processIdentity(process.pid) };
   try {
     const prepared = await registry.withOperationLock(registered.key, owner, async () => {
-      const refreshed = registeredHostForPath(registry.snapshot(), filePath);
+      const refreshed = registeredHostForPath(registry.readOnlySnapshot(), filePath);
       if (!refreshed?.host || refreshed.host.paneId !== paneId) {
         return failure("the registered pane changed", 409);
       }
@@ -375,7 +375,7 @@ interface KillConversationOverrides {
   pathAllowed?: typeof pathAllowed;
   listFiles?: typeof listFiles;
   registrySnapshot?: () => ReturnType<ReturnType<typeof agentRegistry>["snapshot"]>;
-  registry?: Pick<AgentRegistry, "snapshot" | "withOperationLock" | "markUnhosted">;
+  registry?: Pick<AgentRegistry, "readOnlySnapshot" | "withOperationLock" | "markUnhosted">;
   killHost?: typeof killTmuxHostIfMatches;
 }
 
@@ -419,8 +419,8 @@ export async function killConversation(filePath: string, overrides: KillConversa
   }
   const registry = overrides.registry ?? agentRegistry();
   const readSnapshot = overrides.registry
-    ? () => registry.snapshot()
-    : overrides.registrySnapshot ?? (() => registry.snapshot());
+    ? () => registry.readOnlySnapshot()
+    : overrides.registrySnapshot ?? (() => registry.readOnlySnapshot());
   const registered = registeredHostForPath(readSnapshot(), filePath);
   if (!registered?.host) return failure("no registered agent pane for this conversation", 404);
   const owner = { pid: process.pid, startIdentity: procBackend.processIdentity(process.pid) };
@@ -434,7 +434,7 @@ export async function killConversation(filePath: string, overrides: KillConversa
       const killed = await (overrides.killHost ?? killTmuxHostIfMatches)(refreshed.host);
       if (!killed) return failure("the registered pane changed or its process did not exit", 409);
       if (overrides.registry || !overrides.registrySnapshot) {
-        const current = registry.snapshot().entries[`${refreshed.key.engine}:${refreshed.key.sessionId}`];
+        const current = registry.readOnlySnapshot().entries[`${refreshed.key.engine}:${refreshed.key.sessionId}`];
         if (current?.artifactPath === filePath && sameRegisteredHost(current.host, refreshed.host)) registry.markUnhosted(refreshed.key);
       }
       forgetResumePane(filePath);

--- a/src/lib/flows/engine.ts
+++ b/src/lib/flows/engine.ts
@@ -464,7 +464,7 @@ function adoptReviewerReceipt(flow: Flow, round: Round, receipt: SpawnReceipt): 
 function settleReviewerSpawn(flow: Flow, round: Round, role: RoleConfig, accountId: string | null, host: TmuxHostEvidence | null = null): void {
   if (!round.launchId || !round.reviewerPath) return;
   const registry = agentRegistry();
-  const receipt = registry.snapshot().receipts[round.launchId];
+  const receipt = registry.readOnlySnapshot().receipts[round.launchId];
   if (!receipt) return;
   if (receipt?.state === "completed") {
     round.reviewerConversationId = receipt.conversationId;
@@ -832,7 +832,7 @@ export async function tickFlow(
     }
     maybeClaimReviewerPathByHeuristic(flow, entries, round);
     settleReviewerSpawn(flow, round, reviewerRoleFor(flow, round), round.accountId ?? null, round.reviewerPane
-      ? agentRegistry().snapshot().receipts[round.launchId ?? ""]?.verifiedHost ?? null
+      ? agentRegistry().readOnlySnapshot().receipts[round.launchId ?? ""]?.verifiedHost ?? null
       : null);
     if (round.reviewerPath) {
       const reviewer = entriesByPath.get(round.reviewerPath);

--- a/src/lib/reaperRuntime.ts
+++ b/src/lib/reaperRuntime.ts
@@ -749,7 +749,7 @@ async function actuateCandidate(
   const processIdentity = overrides.processIdentity ?? ((pid: number) => procBackend.processIdentity(pid));
   const initialHost = (await observeHosts(true)).hosts.find((host) => hostMatchesCandidate(host, agent, processIdentity));
   if (!initialHost?.primaryPath) return false;
-  const entry = Object.values(registry.snapshot().entries).find((candidate) => candidate.artifactPath === agent.path);
+  const entry = Object.values(registry.readOnlySnapshot().entries).find((candidate) => candidate.artifactPath === agent.path);
   if (!entry) return false;
   const owner = { pid: process.pid, startIdentity: procBackend.processIdentity(process.pid) };
   return registry.withOperationLock(entry.key, owner, async () => {
@@ -764,10 +764,10 @@ async function actuateCandidate(
       const current = evaluateReaper(currentInput);
       const candidate = current.agents.find((item) => reportMatchesCandidate(item, agent));
       if (!candidate?.eligible) return false;
-      if (deliveryRevision(registry.snapshot(), candidate.conversationId)
+      if (deliveryRevision(registry.readOnlySnapshot(), candidate.conversationId)
         !== deliveryRevision(currentInput.registry, candidate.conversationId)) return false;
       const killed = await killHost(expectedEvidence);
-      const registeredHost = registry.snapshot().entries[`${entry.key.engine}:${entry.key.sessionId}`]?.host;
+      const registeredHost = registry.readOnlySnapshot().entries[`${entry.key.engine}:${entry.key.sessionId}`]?.host;
       if (killed && registeredHost && sameTmuxEvidence(registeredHost, expectedEvidence)) {
         registry.markUnhosted(entry.key);
       }

--- a/src/lib/runtime/structuredControls.ts
+++ b/src/lib/runtime/structuredControls.ts
@@ -47,7 +47,7 @@ export async function dispatchStructuredControl(
       : null;
   const generation = conversation?.generations.at(-1);
   if (!conversation || !generation) return null;
-  const snapshot = registry.snapshot();
+  const snapshot = registry.readOnlySnapshot();
   const entry = snapshot.entries[sessionKeyId({ engine: conversation.engine, sessionId: generation.id })];
   if (!entry) return null;
   /* Host teardown clears the structuredHost column before terminal kill

--- a/src/lib/runtime/structuredRecovery.ts
+++ b/src/lib/runtime/structuredRecovery.ts
@@ -79,7 +79,7 @@ function candidateFor(
   const generation = conversation?.generations.at(-1);
   if (!conversation || !generation) return null;
   const key = { engine: conversation.engine, sessionId: generation.id } as const;
-  const snapshot = registry.snapshot();
+  const snapshot = registry.readOnlySnapshot();
   const entry = snapshot.entries[sessionKeyId(key)];
   if (!entry || entry.host) return null;
   const structuredReceipt = Object.values(snapshot.receipts).some((receipt) =>

--- a/src/lib/runtime/structuredSpawn.ts
+++ b/src/lib/runtime/structuredSpawn.ts
@@ -96,7 +96,7 @@ function reconciledInitialMessage(
 
 function settleInitialMessageReservation(registry: AgentRegistry, launchId: string): void {
   const clientMessageId = `spawn_${launchId}`;
-  const reservation = Object.values(registry.snapshot().heldDeliveries)
+  const reservation = Object.values(registry.readOnlySnapshot().heldDeliveries)
     .find((delivery) => delivery.clientMessageId === clientMessageId);
   if (reservation && reservation.state !== "delivered") {
     registry.recordDeliveryOutcome(reservation.id, "delivered");
@@ -104,7 +104,7 @@ function settleInitialMessageReservation(registry: AgentRegistry, launchId: stri
 }
 
 function markInitialMessageTimeout(registry: AgentRegistry, launchId: string, error: StructuredInitialMessageTimeoutError): void {
-  const reservation = Object.values(registry.snapshot().heldDeliveries)
+  const reservation = Object.values(registry.readOnlySnapshot().heldDeliveries)
     .find((delivery) => delivery.clientMessageId === `spawn_${launchId}`);
   if (reservation && reservation.state !== "delivered") {
     registry.recordDeliveryOutcome(reservation.id, "delivery-uncertain", error.message);
@@ -181,7 +181,7 @@ export async function reconcileStructuredSpawnReplay(
     releaseHost?: (key: SessionKey) => Promise<boolean>;
   } = {},
 ): Promise<SpawnReceipt & { initialMessage: "pending" | "queued" | "delivered" | "failed" }> {
-  const current = registry.snapshot().receipts[launchId];
+  const current = registry.readOnlySnapshot().receipts[launchId];
   if (!current) throw new Error("unknown spawn receipt");
   if (current.state === "completed") {
     return { ...current, initialMessage: "delivered" };
@@ -265,7 +265,7 @@ export async function reconcileStructuredSpawnReplay(
   }
   const messageStatus = operation?.receipt.status;
   const runtimeSession = runtime?.sessions.find((candidate) => candidate.conversationId === current.conversationId) ?? null;
-  const entry = current.key ? registry.snapshot().entries[sessionKeyId(current.key)] : null;
+  const entry = current.key ? registry.readOnlySnapshot().entries[sessionKeyId(current.key)] : null;
   const matchingRuntimeSession = Boolean(runtimeSession
     && current.key
     && sessionKeyId(runtimeSession.sessionKey) === sessionKeyId(current.key)
@@ -309,10 +309,10 @@ export async function reconcileStructuredSpawnReplay(
     if (current.key) {
       await (options.releaseHost ?? releaseStructuredDeliveryHost)(current.key).catch(() => false);
     }
-    const failed = registry.snapshot().receipts[launchId] ?? current;
+    const failed = registry.readOnlySnapshot().receipts[launchId] ?? current;
     return { ...failed, initialMessage: "failed" };
   }
-  const receipt = registry.snapshot().receipts[launchId] ?? current;
+  const receipt = registry.readOnlySnapshot().receipts[launchId] ?? current;
   return {
     ...receipt,
     initialMessage: reconciledInitialMessage(receipt, messageStatus, runtimeDelivered),
@@ -528,7 +528,7 @@ export async function recoverPendingStructuredSpawns(
     return registeringConversationIds;
   };
 
-  const snapshot = registry.snapshot();
+  const snapshot = registry.readOnlySnapshot();
   for (const receipt of Object.values(snapshot.receipts)) {
     const effect = spawnEffects.get(receipt.launchId);
     if (receipt.state === "failed" && receipt.transport !== "tmux") {
@@ -566,7 +566,7 @@ export async function recoverPendingStructuredSpawns(
       const identity = resumeIdentityForReceipt(registry, receipt);
       let claimed: AgentRegistryEntry | null = null;
       if (identity) {
-        const entry = registry.snapshot().entries[sessionKeyId(identity.key)];
+        const entry = registry.readOnlySnapshot().entries[sessionKeyId(identity.key)];
         if (entry?.structuredHost) {
           claimed = registry.claimStructuredHost(identity.key, {
             pid: process.pid,
@@ -773,7 +773,7 @@ async function defaultStartHost(input: StructuredSpawnInput, capability: string)
   const env = { ...input.account.env, LLV_SPAWN_CAPABILITY: capability };
   const resumeSessionId = structuredResumeSessionId(input);
   const initialEventCursor = resumeSessionId
-    ? input.registry.snapshot().entries[sessionKeyId({ engine: input.engine, sessionId: resumeSessionId })]?.structuredHost?.eventCursor
+    ? input.registry.readOnlySnapshot().entries[sessionKeyId({ engine: input.engine, sessionId: resumeSessionId })]?.structuredHost?.eventCursor
     : undefined;
   if (initialEventCursor !== undefined
     && (!Number.isSafeInteger(initialEventCursor) || initialEventCursor < 0)) {
@@ -917,7 +917,7 @@ export async function spawnStructuredConversation(
       ...(input.receipt.purpose === "resume-successor" ? { sessionId: structuredResumeSessionId(input) } : {}),
     }));
     const capability = input.registry.rotateSpawnCapabilityForReceipt(input.receipt.launchId);
-    const resumeEntry = resumeKey ? input.registry.snapshot().entries[sessionKeyId(resumeKey)] : null;
+    const resumeEntry = resumeKey ? input.registry.readOnlySnapshot().entries[sessionKeyId(resumeKey)] : null;
     if (resumeEntry?.structuredHost) {
       adoptionClaim = input.registry.claimStructuredHost(resumeKey!, processIdentity(), { allowUnhosted: true });
       if (!adoptionClaim?.claimOwner) {
@@ -1032,14 +1032,14 @@ export async function spawnStructuredConversation(
     let failedEntry: AgentRegistryEntry | null = null;
     let failedIdentity = resumeIdentity;
     if (key) {
-      const entry = input.registry.snapshot().entries[sessionKeyId(key)];
+      const entry = input.registry.readOnlySnapshot().entries[sessionKeyId(key)];
       if (entry) {
         failedEntry = entry;
         failedIdentity = { key, artifactPath: entry.artifactPath };
       }
     } else {
       if (resumeIdentity) {
-        failedEntry = input.registry.snapshot().entries[sessionKeyId(resumeIdentity.key)] ?? null;
+        failedEntry = input.registry.readOnlySnapshot().entries[sessionKeyId(resumeIdentity.key)] ?? null;
       }
     }
     if (typeof failedEntry?.structuredHostOperationId === "string"

--- a/src/lib/runtime/structuredTerminal.ts
+++ b/src/lib/runtime/structuredTerminal.ts
@@ -21,7 +21,7 @@ export async function materializeStructuredTerminal(
   const conversation = registry.conversationForPath(artifactPath);
   const generation = conversation?.generations.at(-1);
   if (!conversation || !generation) throw new Error("structured conversation is unavailable");
-  const entry = registry.snapshot().entries[sessionKeyId({ engine: conversation.engine, sessionId: generation.id })];
+  const entry = registry.readOnlySnapshot().entries[sessionKeyId({ engine: conversation.engine, sessionId: generation.id })];
   if (!entry?.structuredHost || entry.status === "dead" || entry.status === "unhosted") {
     throw new Error("structured conversation has no live host to attach");
   }

--- a/src/lib/scanner/index.ts
+++ b/src/lib/scanner/index.ts
@@ -110,7 +110,7 @@ export function pinnedPathsFor(value: string | readonly string[] | undefined): R
   if (!values.length) return new Set();
   try {
     const registry = agentRegistry();
-    const snapshot = registry.snapshot();
+    const snapshot = registry.readOnlySnapshot();
     const paths = new Set<string>();
     const latestByKnownPath = new Map<string, string>();
     const conversationIdByKnownPath = new Map<string, `conversation_${string}`>();

--- a/src/lib/session/titleTarget.ts
+++ b/src/lib/session/titleTarget.ts
@@ -44,7 +44,7 @@ function ownedPaths(conversation: { generations: readonly { path: string }[]; co
     still found after coalescing. */
 function aliasConversationIds(canonicalId: string): string[] {
   const registry = agentRegistry();
-  const aliases = registry.snapshot().conversationAliases;
+  const aliases = registry.readOnlySnapshot().conversationAliases;
   const result: string[] = [];
   for (const alias of Object.keys(aliases)) {
     if (alias !== canonicalId && registry.canonicalConversationId(alias as ViewerConversationId) === canonicalId) result.push(alias);


### PR DESCRIPTION
Closes #555.

## Summary
- route every production AgentRegistry read path through the revision-fenced `readOnlySnapshot()` cache
- preserve isolated mutable snapshots for callers that explicitly request `snapshot()`
- update delivery and migration test seams to exercise the cached reader

## Production evidence
After #589 established one process-wide registry instance, the Viewer still read roughly 117 MB/s and saturated a CPU core. The remaining production call sites invoked `snapshot()` repeatedly, forcing full SQLite registry materialization for 1,600+ rows and starving runtime-client deadlines used by message delivery.

## Verification
- 558 targeted tests passed across registry, delivery, structured spawn/recovery, migration, reaper, scanner, board, task spawn, and pipelines
- `bunx tsc --noEmit`
- changed-file ESLint: 0 errors
- `bun run privacy:check`
- `bun run build`