### PR TITLE
Bridge legacy Claude resumes to the structured broker

### DIFF
--- a/src/lib/runtime/structuredRecovery.test.ts
+++ b/src/lib/runtime/structuredRecovery.test.ts
@@ -978,7 +978,73 @@ test.each(["codex", "claude"] as const)("duplicate %s recovery clicks reuse one 
   expect(terminalRejections).toBe(0);
 });
 
-test("legacy tmux history remains on the legacy resume path after cutover", async () => {
+test("a registered legacy Claude transcript bridges into the structured broker", async () => {
+  const sessionId = crypto.randomUUID();
+  const cwd = path.join(sandbox, `legacy-claude-bridge-${sessionId}`);
+  const artifactPath = path.join(cwd, `${sessionId}.jsonl`);
+  fs.mkdirSync(cwd, { recursive: true });
+  fs.writeFileSync(artifactPath, "");
+  const registry = new AgentRegistry(path.join(cwd, "registry.json"), undefined, undefined, { sqliteMode: "off" });
+  const conversation = registry.ensureConversation("claude", artifactPath, "default");
+  expect(registry.snapshot().entries[`claude:${sessionId}`]).toBeUndefined();
+  let spawnCalls = 0;
+  let drainRequests = 0;
+
+  const result = await recoverDeadStructuredConversation({
+    path: artifactPath,
+    conversationId: conversation.id,
+  }, {
+    registry,
+    client: {} as RuntimeHostClient,
+    transport: () => "structured",
+    resolveAccount: (engine, accountId) => {
+      expect({ engine, accountId }).toEqual({ engine: "claude", accountId: "default" });
+      return {
+        engine: "claude",
+        accountId: "default",
+        kind: "managed",
+        home: path.join(cwd, "account"),
+        transcriptRoot: cwd,
+        env: { NODE_ENV: "test" },
+      };
+    },
+    spawn: async (input) => {
+      spawnCalls += 1;
+      expect(input.receipt).toMatchObject({
+        conversationId: conversation.id,
+        purpose: "resume-successor",
+        transport: "structured",
+        accountId: "default",
+      });
+      expect(input.spec).toMatchObject({
+        engine: "claude",
+        ["transcript"]: artifactPath,
+      });
+      return {
+        ok: true,
+        target: null,
+        path: artifactPath,
+        launchId: input.receipt.launchId,
+        conversationId: conversation.id,
+        launched: true,
+        retrySafe: false,
+        initialMessage: "delivered" as const,
+        state: "settled",
+      };
+    },
+    requestDeliveryDrain: () => { drainRequests += 1; },
+  });
+
+  expect(result).toMatchObject({
+    conversationId: conversation.id,
+    path: artifactPath,
+    spawned: true,
+  });
+  expect(spawnCalls).toBe(1);
+  expect(drainRequests).toBe(1);
+});
+
+test("legacy Codex tmux history remains on the legacy resume path after cutover", async () => {
   const sessionId = crypto.randomUUID();
   const cwd = path.join(sandbox, `legacy-${sessionId}`);
   const artifactPath = path.join(cwd, `${sessionId}.jsonl`);

--- a/src/lib/runtime/structuredRecovery.ts
+++ b/src/lib/runtime/structuredRecovery.ts
@@ -81,25 +81,30 @@ function candidateFor(
   const key = { engine: conversation.engine, sessionId: generation.id } as const;
   const snapshot = registry.readOnlySnapshot();
   const entry = snapshot.entries[sessionKeyId(key)];
-  if (!entry || entry.host) return null;
+  if (entry?.host) return null;
   const structuredReceipt = Object.values(snapshot.receipts).some((receipt) =>
     receipt.transport === "structured"
       && receipt.state === "completed"
       && registry.canonicalConversationId(receipt.conversationId) === conversation.id);
-  if (!entry.structuredHost && !structuredReceipt) return null;
-  const terminal = entry.status === "dead" || entry.status === "unhosted";
-  const publishReady = Boolean(structuredHostProcessAlive(entry.structuredHost?.process ?? null)
-    && entry.claimOwner
+  /* Interactive Claude tmux resumes are prohibited after structured cutover.
+     Registered legacy transcripts reach the pane-less broker through this
+     recovery path, including conversations that predate registry entries. */
+  const legacyClaudeBridge = conversation.engine === "claude";
+  if (!entry && !legacyClaudeBridge) return null;
+  if (entry && !entry.structuredHost && !structuredReceipt && !legacyClaudeBridge) return null;
+  const terminal = entry?.status === "dead" || entry?.status === "unhosted";
+  const publishReady = Boolean(structuredHostProcessAlive(entry?.structuredHost?.process ?? null)
+    && entry?.claimOwner
     && entry.pendingAction === null
     && !terminal);
   const profile = emptyLaunchProfile(durableProfileWins ? {
-    ...(entry.launchProfile ?? {}),
+    ...(entry?.launchProfile ?? {}),
     ...generation.launchProfile,
-    cwd: generation.launchProfile.cwd || entry.launchProfile?.cwd || entry.cwd,
+    cwd: generation.launchProfile.cwd || entry?.launchProfile?.cwd || entry?.cwd,
   } : {
     ...generation.launchProfile,
-    ...(entry.launchProfile ?? {}),
-    cwd: entry.launchProfile?.cwd || generation.launchProfile.cwd || entry.cwd,
+    ...(entry?.launchProfile ?? {}),
+    cwd: entry?.launchProfile?.cwd || generation.launchProfile.cwd || entry?.cwd,
   });
   const recordedParent = snapshot.lineageEdges[conversation.id]?.parentConversationId
     ?? profile.parentConversationId;
@@ -111,7 +116,7 @@ function candidateFor(
     engine: conversation.engine,
     key,
     path: generation.path,
-    accountId: generation.accountId ?? entry.accountId,
+    accountId: generation.accountId ?? entry?.accountId ?? null,
     parentConversationId: parentConversationId === conversation.id ? null : parentConversationId,
     spec: {
       command: "",


### PR DESCRIPTION
## Summary
- route registered legacy Claude transcripts through structured recovery even when they predate registry entries
- preserve the legacy Codex resume path
- request a delivery drain after the structured Claude successor starts

## Verification
- 25 structured recovery and tmux route tests
- 164 focused delivery and recovery tests
- TypeScript
- changed-file ESLint
- privacy checks
- production build