### PR TITLE
Patch SQLite registry snapshots by dirty row

### DIFF
--- a/src/lib/agent/registry.sqlite.test.ts
+++ b/src/lib/agent/registry.sqlite.test.ts
@@ -47,6 +47,57 @@ test("a keyed SQLite mutation reads only the targeted row payload", () => {
   expect(store.snapshot().file.receipts["row-read-1000"]?.error).toBe("updated");
 });
 
+test("a committed SQLite mutation patches the read-only snapshot and parsed-row cache", () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-registry-sqlite-row-cache-"));
+  const filename = path.join(directory, "agent-registry.json");
+  const seed = new AgentRegistry(filename);
+  const template = seed.beginSpawn("codex", "/row-cache-seed");
+  const initial = seed.snapshot();
+  for (let index = 0; index < 2_000; index += 1) {
+    const launchId = `row-cache-${String(index).padStart(4, "0")}`;
+    initial.receipts[launchId] = { ...structuredClone(template), launchId };
+  }
+  const targetLaunchId = "row-cache-1000";
+  let receiptPayloadReads = 0;
+  let receiptPayloadParses = 0;
+  let snapshotLoads = 0;
+  const store = new SqliteAgentRegistryStore(path.join(directory, "agent-registry.sqlite"), {
+    initialSnapshot: initial,
+    normalize: normalizeRegistry,
+    onSnapshotLoad: () => { snapshotLoads += 1; },
+    onRowPayloadRead: (collection, count) => {
+      if (collection === "receipts") receiptPayloadReads += count;
+    },
+    onRowPayloadParse: (collection, count) => {
+      if (collection === "receipts") receiptPayloadParses += count;
+    },
+  });
+  const first = store.readOnlySnapshot();
+  expect(first.file.receipts[targetLaunchId]?.error).toBeNull();
+  expect(receiptPayloadParses).toBe(2_001);
+  receiptPayloadReads = 0;
+  receiptPayloadParses = 0;
+  snapshotLoads = 0;
+
+  store.mutate((file) => {
+    file.receipts[targetLaunchId]!.error = "updated";
+  }, false);
+  const second = store.readOnlySnapshot();
+
+  expect(receiptPayloadReads).toBe(1);
+  expect(receiptPayloadParses).toBe(0);
+  expect(snapshotLoads).toBe(0);
+  expect(second.revision).toBe(first.revision + 1);
+  expect(second.file.receipts[targetLaunchId]?.error).toBe("updated");
+  expect(first.file.receipts[targetLaunchId]?.error).toBeNull();
+
+  expect(() => store.mutate((file) => {
+    file.receipts[targetLaunchId]!.error = "rolled back";
+    throw new Error("rollback");
+  }, false)).toThrow("rollback");
+  expect(store.readOnlySnapshot().file.receipts[targetLaunchId]?.error).toBe("updated");
+});
+
 test("SQLite first boot imports JSON and preserves membership and capability digest paths", () => {
   const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-registry-sqlite-import-"));
   const filename = path.join(directory, "agent-registry.json");

--- a/src/lib/agent/sqliteRegistryStore.ts
+++ b/src/lib/agent/sqliteRegistryStore.ts
@@ -32,6 +32,7 @@ const META_FIELDS = [
 export type RowCollection = (typeof ROW_COLLECTIONS)[number];
 type StoredRow = { collection: string; row_key: string; value_json: string; row_order: number };
 type MetaRow = { key: string; value: string };
+type CachedRow = { valueJson: string; parsed: unknown };
 
 interface RegistryChanges {
   rows: Map<RowCollection, Set<string>>;
@@ -60,6 +61,7 @@ export interface SqliteRegistryStoreOptions {
   onWriterWait?(durationMs: number): void;
   onSnapshotLoad?(): void;
   onRowPayloadRead?(collection: RowCollection, count: number): void;
+  onRowPayloadParse?(collection: RowCollection, count: number): void;
 }
 
 interface LazyRegistrySnapshot extends SqliteRegistrySnapshot {
@@ -100,6 +102,8 @@ export class SqliteAgentRegistryStore {
   private readonly onWriterWait: ((durationMs: number) => void) | undefined;
   private readonly onSnapshotLoad: (() => void) | undefined;
   private readonly onRowPayloadRead: ((collection: RowCollection, count: number) => void) | undefined;
+  private readonly onRowPayloadParse: ((collection: RowCollection, count: number) => void) | undefined;
+  private readonly rowCache = new Map<RowCollection, Map<string, CachedRow>>();
   private readOnlyCache: SqliteRegistrySnapshot | null = null;
 
   constructor(readonly filename: string, options: SqliteRegistryStoreOptions) {
@@ -112,6 +116,7 @@ export class SqliteAgentRegistryStore {
     this.onWriterWait = options.onWriterWait;
     this.onSnapshotLoad = options.onSnapshotLoad;
     this.onRowPayloadRead = options.onRowPayloadRead;
+    this.onRowPayloadParse = options.onRowPayloadParse;
     this.db.exec("PRAGMA busy_timeout = 5000; PRAGMA journal_mode = WAL; PRAGMA synchronous = FULL; PRAGMA foreign_keys = ON; PRAGMA auto_vacuum = INCREMENTAL;");
     this.db.exec(`
       CREATE TABLE IF NOT EXISTS registry_meta (
@@ -151,10 +156,14 @@ export class SqliteAgentRegistryStore {
   }
 
   snapshot(): SqliteRegistrySnapshot {
+    return this.loadSnapshot(false);
+  }
+
+  private loadSnapshot(useRowCache: boolean): SqliteRegistrySnapshot {
     this.onSnapshotLoad?.();
     this.db.exec("BEGIN");
     try {
-      const snapshot = this.loadInTransaction();
+      const snapshot = this.loadInTransaction(useRowCache);
       this.db.exec("COMMIT");
       return snapshot;
     } catch (error) {
@@ -170,7 +179,7 @@ export class SqliteAgentRegistryStore {
   readOnlySnapshot(): SqliteRegistrySnapshot {
     const revision = this.revision();
     if (this.readOnlyCache?.revision === revision) return this.readOnlyCache;
-    this.readOnlyCache = this.snapshot();
+    this.readOnlyCache = this.loadSnapshot(true);
     return this.readOnlyCache;
   }
 
@@ -208,7 +217,7 @@ export class SqliteAgentRegistryStore {
       }
       if (changed) {
         this.secureFiles();
-        this.readOnlyCache = null;
+        this.updateCachesAfterCommit(current.file, changes, revision);
       }
       if (includeSnapshot) {
         const committed = this.snapshot();
@@ -230,6 +239,7 @@ export class SqliteAgentRegistryStore {
       this.persistDiff(current.file, file, revision);
       this.db.exec("COMMIT");
       this.secureFiles();
+      this.rowCache.clear();
       this.readOnlyCache = null;
       return { file, revision, replaced: true };
     } catch (error) {
@@ -255,14 +265,14 @@ export class SqliteAgentRegistryStore {
     }
   }
 
-  private loadInTransaction(): SqliteRegistrySnapshot {
-    const snapshot = this.loadLazyInTransaction(false);
+  private loadInTransaction(useRowCache = false): SqliteRegistrySnapshot {
+    const snapshot = this.loadLazyInTransaction(false, useRowCache);
     for (const collection of ROW_COLLECTIONS) void snapshot.file[collection];
     for (const field of META_FIELDS) void snapshot.file[field];
     return snapshot;
   }
 
-  private loadLazyInTransaction(trackMutations = true): LazyRegistrySnapshot {
+  private loadLazyInTransaction(trackMutations = true, useRowCache = trackMutations): LazyRegistrySnapshot {
     const file = this.normalize({ version: 2, entries: {}, receipts: {} });
     const loadedCollections = new Map<RowCollection, RegistryFile[RowCollection]>();
     const baselineCollections = new Map<RowCollection, Map<string, string | null>>();
@@ -283,7 +293,10 @@ export class SqliteAgentRegistryStore {
           ).all(collection);
           this.onRowPayloadRead?.(collection, storedRows.length);
           for (const row of storedRows) {
-            (storedValue as Record<string, unknown>)[row.row_key] = JSON.parse(row.value_json);
+            const parsed = this.parseRow(collection, row.row_key, row.value_json, useRowCache);
+            (storedValue as Record<string, unknown>)[row.row_key] = trackMutations
+              ? structuredClone(parsed)
+              : parsed;
             baseline.set(row.row_key, row.value_json);
           }
           const input: Record<string, unknown> = { version: 2, entries: {}, receipts: {} };
@@ -357,7 +370,7 @@ export class SqliteAgentRegistryStore {
             const stored = readBaseline(key);
             if (stored === null) return undefined;
             const input: Record<string, unknown> = { version: 2, entries: {}, receipts: {} };
-            input[collection] = { [key]: JSON.parse(stored) };
+            input[collection] = { [key]: structuredClone(this.parseRow(collection, key, stored, useRowCache)) };
             const normalized = this.normalize(input)[collection] as Record<string, unknown>;
             if (!Object.hasOwn(normalized, key)) return undefined;
             rows[key] = normalized[key];
@@ -369,7 +382,12 @@ export class SqliteAgentRegistryStore {
             const unloaded: Record<string, unknown> = {};
             for (const row of stored) {
               if (!Object.hasOwn(rows, row.row_key) && !deleted.has(row.row_key)) {
-                unloaded[row.row_key] = JSON.parse(row.value_json);
+                unloaded[row.row_key] = structuredClone(this.parseRow(
+                  collection,
+                  row.row_key,
+                  row.value_json,
+                  useRowCache,
+                ));
               }
             }
             const input: Record<string, unknown> = { version: 2, entries: {}, receipts: {} };
@@ -512,6 +530,83 @@ export class SqliteAgentRegistryStore {
         return changes;
       },
     };
+  }
+
+  private parseRow(
+    collection: RowCollection,
+    key: string,
+    valueJson: string,
+    useCache: boolean,
+  ): unknown {
+    if (!useCache) {
+      this.onRowPayloadParse?.(collection, 1);
+      return JSON.parse(valueJson);
+    }
+    let collectionCache = this.rowCache.get(collection);
+    if (!collectionCache) {
+      collectionCache = new Map();
+      this.rowCache.set(collection, collectionCache);
+    }
+    const cached = collectionCache.get(key);
+    if (cached?.valueJson === valueJson) return cached.parsed;
+    const parsed = JSON.parse(valueJson);
+    this.onRowPayloadParse?.(collection, 1);
+    collectionCache.set(key, { valueJson, parsed });
+    return parsed;
+  }
+
+  private updateCachesAfterCommit(
+    file: RegistryFile,
+    changes: RegistryChanges,
+    revision: number,
+  ): void {
+    const cachedSnapshot = this.readOnlyCache?.revision === revision - 1
+      ? this.readOnlyCache
+      : null;
+    const nextFile = cachedSnapshot ? { ...cachedSnapshot.file } : null;
+
+    for (const [collection, keys] of changes.rows) {
+      const currentRows = file[collection] as Record<string, unknown>;
+      let collectionCache = this.rowCache.get(collection);
+      if (!collectionCache) {
+        collectionCache = new Map();
+        this.rowCache.set(collection, collectionCache);
+      }
+      const nextRows = nextFile
+        ? { ...(cachedSnapshot!.file[collection] as Record<string, unknown>) }
+        : null;
+      for (const key of keys) {
+        if (!Object.hasOwn(currentRows, key)) {
+          collectionCache.delete(key);
+          if (nextRows) delete nextRows[key];
+          continue;
+        }
+        const valueJson = JSON.stringify(currentRows[key]);
+        const parsed = JSON.parse(valueJson) as unknown;
+        collectionCache.set(key, { valueJson, parsed });
+        if (nextRows) nextRows[key] = parsed;
+      }
+      if (nextFile && nextRows) {
+        if (changes.order.has(collection)) {
+          const ordered: Record<string, unknown> = {};
+          for (const key of Object.keys(currentRows)) {
+            if (Object.hasOwn(nextRows, key)) ordered[key] = nextRows[key];
+          }
+          (nextFile as unknown as Record<string, unknown>)[collection] = ordered;
+        } else {
+          (nextFile as unknown as Record<string, unknown>)[collection] = nextRows;
+        }
+      }
+    }
+
+    if (nextFile) {
+      for (const field of changes.meta) {
+        (nextFile as unknown as Record<string, unknown>)[field] = structuredClone(file[field]);
+      }
+      this.readOnlyCache = { file: nextFile, revision };
+    } else {
+      this.readOnlyCache = null;
+    }
   }
 
   private persistAll(file: RegistryFile, revision: number): void {


### PR DESCRIPTION
## Summary
- retain parsed SQLite registry rows across read-only snapshots
- clone cached rows before mutable transactions to preserve rollback isolation
- patch the immutable read-only snapshot and row cache from dirty keys after each commit
- keep external revision reloads correct by comparing the stored JSON payload before reusing a parsed row

## Hot-path effect
A mutation followed by `readOnlySnapshot()` now reads only the targeted row and performs zero receipt JSON parses in the 2,001-row regression fixture. The read-only snapshot advances to the committed revision without a full snapshot load.

## Verification
- 68 focused SQLite registry, structured recovery, and tmux route tests
- production-sized 10-lane SQLite benchmark: operation p95 14.4ms, writer wait p95 3.3ms, reader p95 0.0ms
- TypeScript
- changed-file ESLint
- diff check
- production build

Related to #555.