### PR TITLE
Share the agent registry across Next bundle realms

### DIFF
--- a/src/lib/agent/registry.ts
+++ b/src/lib/agent/registry.ts
@@ -5718,7 +5718,10 @@ export class AgentRegistry {
   }
 }
 
-const registryProcessState = globalThis as typeof globalThis & {
+/* Next standalone evaluates instrumentation and route handlers in separate
+   bundle realms. The injected process object is shared by those realms and
+   carries one SQLite connection, snapshot cache, and revision cache. */
+const registryProcessState = process as typeof process & {
   __llvAgentRegistry?: AgentRegistry | null;
 };
 


### PR DESCRIPTION
## Summary
- store the AgentRegistry singleton on the process object shared by Next standalone bundle realms
- give instrumentation and route handlers one SQLite connection, row cache, snapshot cache, and revision cache

## Live diagnosis
After #595, registry SQL access dropped, yet the live Viewer still performed about five full registry materializations in six seconds. The process had one SQLite PID owner, and the remaining invalidations aligned with Next bundle-realm boundaries. The structured delivery controller already uses the process object for this exact standalone-runtime constraint; the registry now follows the same process-scoped ownership model.

## Verification
- 150 registry/SQLite tests passed before the tmpfs quota was reached by accumulated historical test fixtures
- the quota-only failed production benchmark passed after removing inactive `llv-registry-*` test directories: operation p95 16.4ms, writer wait p95 3.2ms, reader p95 0.1ms
- TypeScript
- changed-file ESLint
- diff check
- production build

Related to #555.