### PR TITLE
Recover SQLite mirror and delivery-controller startup

### DIFF
--- a/docs/agent-registry-sqlite.md
+++ b/docs/agent-registry-sqlite.md
@@ -5,7 +5,7 @@ The registry supports four values for `LLV_AGENT_REGISTRY_SQLITE`:
 - `off` keeps `agent-registry.json` authoritative. This is the default.
 - `dual-write` reads JSON, writes JSON and SQLite under the existing JSON writer lock, and verifies parity after every mutation.
 - `read` reads and transacts through `agent-registry.sqlite` in WAL mode, then refreshes `agent-registry.json` on a bounded five-second checkpoint cadence. Startup and release demotion write a revision-stamped checkpoint.
-- `sqlite` uses SQLite for reads and writes after the parity burn-in. It refreshes the JSON mirror at process start and removes JSON serialization from registry operations.
+- `sqlite` uses SQLite for reads and writes after the parity burn-in. It refreshes the JSON mirror at process start, repairs missing, malformed, stale, or torn mirror state from authoritative SQLite, and removes JSON serialization from registry operations. A mirror revision ahead of SQLite remains fenced because it can indicate durable-state rollback.
 
 The first process that opens any gated SQLite mode creates `agent-registry.sqlite` and imports the normalized contents of `agent-registry.json` in one transaction. An interrupted import has no migration marker, so the next boot retries the complete import. Durable memberships, spawn receipts, capability digests, lineage, conversation generations, migration state, delivery receipts, and routing policy all migrate through the same snapshot.
 

--- a/src/instrumentation.test.ts
+++ b/src/instrumentation.test.ts
@@ -279,21 +279,42 @@ test("server startup mints the operator capability and rotates it on request", a
   }
 });
 
-test("structured-host startup logs the thrown adoption error object", async () => {
+test("structured-host startup retries an arbitrary recoverable adoption error", async () => {
   const failure = new Error("container adoption failed");
   const logged: unknown[][] = [];
+  const scheduled: Array<() => void> = [];
+  let attempts = 0;
 
   try {
     await runStructuredHostStartup(
-      async () => { throw failure; },
+      async () => {
+        attempts += 1;
+        if (attempts === 1) throw failure;
+      },
       (...args) => { logged.push(args); },
+      {
+        random: () => 0.5,
+        schedule: (callback) => {
+          scheduled.push(callback);
+          return { unref() {} };
+        },
+      },
     );
 
-    expect(logged).toEqual([["[structured hosts] startup adoption failed", failure]]);
+    expect(logged).toEqual([["[structured hosts] startup adoption failed; retry scheduled", failure]]);
     expect(didStructuredHostStartupFail()).toBe(true);
-    await runStructuredHostStartup(async () => undefined, (...args) => { logged.push(args); });
+    expect(scheduled).toHaveLength(1);
+
+    scheduled.shift()!();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(attempts).toBe(2);
     expect(didStructuredHostStartupFail()).toBe(false);
-    expect(logged).toHaveLength(1);
+    expect(logged).toEqual([
+      ["[structured hosts] startup adoption failed; retry scheduled", failure],
+      ["[structured hosts] startup adoption recovered", { attempts: 2 }],
+    ]);
   } finally {
     markStructuredHostStartupReady();
   }
@@ -312,6 +333,7 @@ test("structured-host startup self-heals after the runtime socket becomes ready"
       },
       (...args) => { logged.push(args); },
       {
+        random: () => 0.5,
         schedule: (callback, delayMs) => {
           scheduled.push({ callback, delayMs });
           return { unref() {} };
@@ -358,6 +380,7 @@ test("structured-host startup uses bounded backoff with one pending retry", asyn
       {
         initialRetryMs: 25,
         maxRetryMs: 50,
+        random: () => 0.5,
         schedule: (callback, delayMs) => {
           scheduled.push({ callback, delayMs });
           return { unref() {} };
@@ -388,6 +411,32 @@ test("structured-host startup uses bounded backoff with one pending retry", asyn
       ],
       ["[structured hosts] startup adoption recovered", { attempts: 5 }],
     ]);
+  } finally {
+    markStructuredHostStartupReady();
+  }
+});
+
+test("structured-host startup applies bounded jitter to recoverable retries", async () => {
+  const delays: number[] = [];
+
+  try {
+    await runStructuredHostStartup(
+      async () => { throw new Error("transient registry contention"); },
+      () => {},
+      {
+        initialRetryMs: 100,
+        maxRetryMs: 1_000,
+        jitterRatio: 0.2,
+        random: () => 1,
+        schedule: (_callback, delayMs) => {
+          delays.push(delayMs);
+          return { unref() {} };
+        },
+      },
+    );
+
+    expect(delays).toEqual([120]);
+    expect(didStructuredHostStartupFail()).toBe(true);
   } finally {
     markStructuredHostStartupReady();
   }

--- a/src/lib/agent/registry.sqlite.test.ts
+++ b/src/lib/agent/registry.sqlite.test.ts
@@ -297,6 +297,80 @@ test("dual-write keeps JSON authoritative and SQLite reads require parity", () =
   expect(() => new AgentRegistry(filename, undefined, undefined, { sqliteMode: "read" })).toThrow(RegistryParityError);
 });
 
+test("authoritative SQLite startup repairs a same-revision mirror mismatch", () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-registry-sqlite-repair-equal-"));
+  const filename = path.join(directory, "agent-registry.json");
+  const registry = new AgentRegistry(filename, undefined, undefined, { sqliteMode: "sqlite" });
+  const receipt = registry.beginSpawn("codex", "/sqlite-authoritative");
+  registry.checkpointRollbackMirror();
+
+  const mirror = JSON.parse(fs.readFileSync(filename, "utf8")) as ReturnType<AgentRegistry["snapshot"]> & { _sqliteRevision: number };
+  mirror.receipts[receipt.launchId]!.cwd = "/torn-mirror";
+  fs.writeFileSync(filename, JSON.stringify(mirror));
+
+  const recovered = new AgentRegistry(filename, undefined, undefined, { sqliteMode: "sqlite" });
+  expect(recovered.snapshot().receipts[receipt.launchId]!.cwd).toBe("/sqlite-authoritative");
+  expect(new AgentRegistry(filename).snapshot()).toEqual(recovered.snapshot());
+});
+
+test("authoritative SQLite startup stamps and repairs a legacy mirror", () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-registry-sqlite-repair-legacy-"));
+  const filename = path.join(directory, "agent-registry.json");
+  const registry = new AgentRegistry(filename, undefined, undefined, { sqliteMode: "sqlite" });
+  const receipt = registry.beginSpawn("codex", "/sqlite-legacy-mirror");
+  registry.checkpointRollbackMirror();
+
+  const mirror = JSON.parse(fs.readFileSync(filename, "utf8")) as ReturnType<AgentRegistry["snapshot"]> & { _sqliteRevision?: number };
+  delete mirror._sqliteRevision;
+  delete mirror.receipts[receipt.launchId];
+  fs.writeFileSync(filename, JSON.stringify(mirror));
+
+  const recovered = new AgentRegistry(filename, undefined, undefined, { sqliteMode: "sqlite" });
+  const repaired = JSON.parse(fs.readFileSync(filename, "utf8")) as { _sqliteRevision?: number };
+  const revision = recovered.storageDiagnostics().revision;
+  if (revision === null) throw new Error("expected an authoritative SQLite revision");
+  expect(recovered.snapshot().receipts[receipt.launchId]).toBeDefined();
+  expect(repaired._sqliteRevision).toBe(revision);
+});
+
+test.each(["malformed", "lower"] as const)(
+  "authoritative SQLite startup repairs a %s mirror revision",
+  (scenario) => {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), `llv-registry-sqlite-repair-${scenario}-`));
+    const filename = path.join(directory, "agent-registry.json");
+    const registry = new AgentRegistry(filename, undefined, undefined, { sqliteMode: "sqlite" });
+    const receipt = registry.beginSpawn("codex", `/sqlite-${scenario}-mirror`);
+    registry.checkpointRollbackMirror();
+
+    const mirror = JSON.parse(fs.readFileSync(filename, "utf8")) as ReturnType<AgentRegistry["snapshot"]> & { _sqliteRevision: unknown };
+    mirror._sqliteRevision = scenario === "malformed"
+      ? "broken"
+      : Number(registry.storageDiagnostics().revision) - 1;
+    delete mirror.receipts[receipt.launchId];
+    fs.writeFileSync(filename, JSON.stringify(mirror));
+
+    const recovered = new AgentRegistry(filename, undefined, undefined, { sqliteMode: "sqlite" });
+    const revision = recovered.storageDiagnostics().revision;
+    if (revision === null) throw new Error("expected an authoritative SQLite revision");
+    expect(recovered.snapshot().receipts[receipt.launchId]).toBeDefined();
+    expect((JSON.parse(fs.readFileSync(filename, "utf8")) as { _sqliteRevision: number })._sqliteRevision)
+      .toBe(revision);
+  },
+);
+
+test("authoritative SQLite startup fences a mirror revision ahead of durable state", () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-registry-sqlite-ahead-"));
+  const filename = path.join(directory, "agent-registry.json");
+  const registry = new AgentRegistry(filename, undefined, undefined, { sqliteMode: "sqlite" });
+  registry.checkpointRollbackMirror();
+  const mirror = JSON.parse(fs.readFileSync(filename, "utf8")) as { _sqliteRevision: number };
+  mirror._sqliteRevision += 1;
+  fs.writeFileSync(filename, JSON.stringify(mirror));
+
+  expect(() => new AgentRegistry(filename, undefined, undefined, { sqliteMode: "sqlite" }))
+    .toThrow("agent registry JSON mirror revision is ahead of SQLite");
+});
+
 test("SQLite restart normalizes legacy held-delivery rows before parity", () => {
   const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-registry-sqlite-held-upgrade-"));
   const filename = path.join(directory, "agent-registry.json");

--- a/src/lib/agent/registry.ts
+++ b/src/lib/agent/registry.ts
@@ -2350,7 +2350,13 @@ export class AgentRegistry {
     if (this.sqliteMode === "read" || this.sqliteMode === "sqlite") {
       const sqlite = this.sqliteStore!.snapshot();
       const mirrorRevision = sqliteMirrorRevision(this.filename);
-      if (mirrorRevision === null || mirrorRevision === sqlite.revision) this.assertSqliteParity(sqlite);
+      /* `read` is the parity burn-in, so a same-revision mismatch must stop
+         rollout. In authoritative `sqlite` mode the JSON file is a rollback
+         mirror: missing stamps and torn/stale same-revision contents are
+         repaired from the durable SQLite snapshot during every startup. */
+      if (this.sqliteMode === "read" && (mirrorRevision === null || mirrorRevision === sqlite.revision)) {
+        this.assertSqliteParity(sqlite);
+      }
       if (mirrorRevision !== null && mirrorRevision > sqlite.revision) {
         throw new RegistryParityError("agent registry JSON mirror revision is ahead of SQLite");
       }

--- a/src/lib/viewerInstrumentation.ts
+++ b/src/lib/viewerInstrumentation.ts
@@ -1,7 +1,6 @@
 import fs from "node:fs";
 
 import { statePath } from "@/lib/configDir";
-import { RuntimeHostUnavailableError } from "@/lib/runtime/client";
 import { markStructuredHostStartupFailed, markStructuredHostStartupReady } from "@/lib/runtime/startupStatus";
 import { StructuredRuntimeRequirementError } from "@/lib/proc/darwinIdentity";
 import { discardWakatimeEnvironmentCredential } from "@/lib/wakatime/credential";
@@ -26,6 +25,8 @@ interface StructuredHostStartupOptions {
   schedule?: (callback: () => void, delayMs: number) => ActivationTimer;
   initialRetryMs?: number;
   maxRetryMs?: number;
+  jitterRatio?: number;
+  random?: () => number;
 }
 
 interface ViewerReleaseActivationOptions {
@@ -184,6 +185,8 @@ export async function runStructuredHostStartup(
 ): Promise<void> {
   const schedule = options.schedule ?? ((callback, delayMs) => setTimeout(callback, delayMs));
   const maxRetryMs = options.maxRetryMs ?? 1_000;
+  const jitterRatio = Math.min(Math.max(options.jitterRatio ?? 0.2, 0), 1);
+  const random = options.random ?? Math.random;
   let retryMs = options.initialRetryMs ?? 100;
   let retryPending = false;
   let attempts = 0;
@@ -200,12 +203,9 @@ export async function runStructuredHostStartup(
         log("[structured hosts] startup adoption failed", error);
         throw error;
       }
-      if (!(error instanceof RuntimeHostUnavailableError)) {
-        log("[structured hosts] startup adoption failed", error);
-        return;
-      }
       if (retryPending) return;
-      const delayMs = retryMs;
+      const jitter = 1 + ((Math.min(Math.max(random(), 0), 1) * 2) - 1) * jitterRatio;
+      const delayMs = Math.min(maxRetryMs, Math.max(0, Math.round(retryMs * jitter)));
       retryMs = Math.min(retryMs * 2, maxRetryMs);
       retryPending = true;
       if (attempts === 1) log("[structured hosts] startup adoption failed; retry scheduled", error);


### PR DESCRIPTION
## Summary

- repair missing, malformed, stale, and torn JSON mirrors from authoritative SQLite during `sqlite`-mode startup
- retain the ahead-of-SQLite revision fence for rollback diagnostics
- retry all recoverable structured-host startup failures with bounded exponential backoff and jitter
- keep structured startup health failed until adoption succeeds

## Live incident covered

Production reproduced both paths during the `b8019916` rollout: `/api/files` returned 500 after a same-revision receipts mismatch, and the delivery controller stayed unavailable after the failed adoption attempt. Manual mirror re-materialization plus a clean restart restored service. This change makes both recoveries automatic.

## Verification

- 72 focused registry/instrumentation tests
- TypeScript
- changed-file ESLint
- diff check
- privacy publication gate
- production build

Refs [#571](https://github.com/Latand/live-log-viewer-next/issues/571)
Refs [#572](https://github.com/Latand/live-log-viewer-next/issues/572)
