### PR TITLE
fix: release dead Codex turns during account migration

### DIFF
--- a/src/lib/accounts/migration/coordinator.test.ts
+++ b/src/lib/accounts/migration/coordinator.test.ts
@@ -3224,6 +3224,39 @@ describe("durable account migration coordinator", () => {
     expect(advanced.migration?.phase).toBe("committed");
   });
 
+  test("a released dead Codex source can migrate after an unclosed transcript turn", async () => {
+    const store = registry();
+    const pathname = path.join(path.dirname(store.filename), "released-dead-codex.jsonl");
+    fs.writeFileSync(pathname, JSON.stringify({
+      type: "event_msg",
+      timestamp: "2026-07-22T15:00:00.000Z",
+      payload: { type: "task_started" },
+    }) + "\n");
+    const releasedAt = new Date(fs.statSync(pathname).mtimeMs + 1_000).toISOString();
+    store.reconcileConversations([{ ...observation(pathname, "limited", "busy"), observedAt: releasedAt }]);
+    const conversation = store.conversationForPath(pathname)!;
+    expect(store.requestConversationReseat(conversation.id, "healthy").migration?.phase).toBe("waiting-turn");
+    store.reconcileConversations([{
+      ...observation(pathname, "limited", "idle"),
+      expectedTurnObservedAt: store.conversation(conversation.id)?.turn.observedAt,
+      observedAt: releasedAt,
+    }]);
+
+    const counts = { create: 0, verify: 0 };
+    const writable = fs.openSync(pathname, "a");
+    try {
+      await advanceConversationMigration(conversation.id, store, provider(["/released-successor.jsonl"], counts));
+      expect(counts.create).toBe(0);
+      expect(store.conversation(conversation.id)?.migration?.phase).toBe("requested");
+    } finally {
+      fs.closeSync(writable);
+    }
+
+    const advanced = await advanceConversationMigration(conversation.id, store, provider(["/released-successor.jsonl"], counts));
+    expect(counts.create).toBe(1);
+    expect(advanced.migration?.phase).toBe("committed");
+  });
+
   test("a dead null-host Claude OAuth failure releases the waiting-turn reseat exactly once", async () => {
     /* Issue #516: the Claude CLI died on an OAuth failure — the transcript
        ends in a structured `authentication_failed` API-error record and no

--- a/src/lib/accounts/migration/coordinator.ts
+++ b/src/lib/accounts/migration/coordinator.ts
@@ -13,6 +13,7 @@ import {
 import { forEachCooperatively, yieldToRuntime } from "@/lib/cooperative";
 import { listFiles } from "@/lib/scanner";
 import { recordTranscriptComposerRelease, transcriptTurnResult } from "@/lib/scanner/activity";
+import { writingHolders } from "@/lib/scanner/process";
 import type { FileEntry } from "@/lib/types";
 import { isStructuredDeliveryControllerUnavailable } from "@/lib/runtime/structuredDeliveryController";
 
@@ -270,7 +271,19 @@ function completeProviderTurnObservation(
     return false;
   }
   if (after.size !== before.size || after.mtimeMs !== before.mtimeMs) return false;
-  return observed.turn.state === "terminal" || observed.composerReleased;
+  if (observed.turn.state === "terminal" || observed.composerReleased) return true;
+
+  /* A crashed Codex rollout can retain its final task_started record forever.
+     An inventory release plus a stable file with no writable holder proves
+     that this generation has no provider turn left to preserve. */
+  const releasedAt = conversation.turn.observedAt ? Date.parse(conversation.turn.observedAt) : Number.NaN;
+  const deadCodexSourceWasReleased = conversation.engine === "codex"
+    && conversation.turn.state === "idle"
+    && source.host === null
+    && Number.isFinite(releasedAt)
+    && releasedAt >= after.mtimeMs
+    && !writingHolders([source.path], true).has(source.path);
+  return deadCodexSourceWasReleased;
 }
 
 export interface MigrationCoordinatorOptions {


### PR DESCRIPTION
Closes #565.

## Summary

- allow a stable, released Codex transcript to pass the successor-creation fence when its generation host is gone and no process holds the transcript for writing
- retain the provider fence while any writable holder remains
- cover the production stale-busy sequence from `waiting-turn` through successor commit

## Production evidence

A Codex conversation remained in `waiting-turn` with an unclosed `task_started` transcript, no host, no writable process, and seven held deliveries. Recovery created generation 2 on the selected managed account. Every held delivery reached `delivered` once and the successor became live.

## Verification

- `bun test src/lib/accounts/migration/coordinator.test.ts` — 86 pass
- `bunx tsc --noEmit`
- `bunx eslint src/lib/accounts/migration/coordinator.ts src/lib/accounts/migration/coordinator.test.ts`
- `git diff --check`
