### PR TITLE
Fix structured recovery and Claude permission defaults

### DIFF
--- a/src/lib/agent/cli.test.ts
+++ b/src/lib/agent/cli.test.ts
@@ -36,7 +36,7 @@ test("fresh Codex commands fix CODEX_HOME in the typed shell command", () => {
 });
 
 test("allowSubagents enables Codex multi-agent for fresh and resumed launches", () => {
-  const transcript = path.join(SANDBOX, "legacy", "sessions", "2026", "07", "14", "rollout-019f5f2f-743a-7f23-9773-3cf2dd4b4168.jsonl");
+  const transcript = path.join(SANDBOX, "legacy", "sessions", "2026", "07", "14", "rollout-019f5f2f-743a-7f23-7773-3cf2dd4b4168.jsonl");
   fs.mkdirSync(path.dirname(transcript), { recursive: true });
   fs.writeFileSync(transcript, JSON.stringify({ type: "session_meta", payload: { cwd: SANDBOX } }) + "\n");
 
@@ -72,7 +72,7 @@ test("fresh read-only Claude commands accept a non-interactive permission mode",
 });
 
 test("Codex resume derives its owning account home from the transcript path", () => {
-  const transcript = path.join(SANDBOX, "legacy", "sessions", "2026", "07", "09", "rollout-019f423a-d6e9-7903-b597-3e676b6ff3d4.jsonl");
+  const transcript = path.join(SANDBOX, "legacy", "sessions", "2026", "07", "09", "rollout-019f423a-d6e9-7903-7597-3e676b6ff3d4.jsonl");
   fs.mkdirSync(path.dirname(transcript), { recursive: true });
   fs.writeFileSync(transcript, JSON.stringify({ type: "session_meta", payload: { cwd: SANDBOX } }) + "\n");
 
@@ -82,12 +82,12 @@ test("Codex resume derives its owning account home from the transcript path", ()
     `env -u LLV_TOKEN CODEX_HOME='${path.join(SANDBOX, "legacy")}' `,
   );
   expect(spec?.command).toContain("--disable multi_agent");
-  expect(spec?.command).toContain("resume 019f423a-d6e9-7903-b597-3e676b6ff3d4");
+  expect(spec?.command).toContain("resume 019f423a-d6e9-7903-7597-3e676b6ff3d4");
 });
 
 test("resume preserves the transcript model and reasoning effort for both engines", () => {
-  const codexTranscript = path.join(SANDBOX, "legacy", "sessions", "2026", "07", "09", "rollout-019f423a-d6e9-7903-b597-3e676b6ff3d4.jsonl");
-  const claudeTranscript = path.join(process.env.LLV_CLAUDE_HOME!, "projects", "-repo", "019f423a-d6e9-7903-b597-3e676b6ff3d4.jsonl");
+  const codexTranscript = path.join(SANDBOX, "legacy", "sessions", "2026", "07", "09", "rollout-019f423a-d6e9-7903-7597-3e676b6ff3d4.jsonl");
+  const claudeTranscript = path.join(process.env.LLV_CLAUDE_HOME!, "projects", "-repo", "019f423a-d6e9-7903-7597-3e676b6ff3d4.jsonl");
   fs.mkdirSync(path.dirname(claudeTranscript), { recursive: true });
   fs.writeFileSync(claudeTranscript, JSON.stringify({ cwd: SANDBOX }) + "\n");
   const codex = resumeSpecFor("codex-sessions", codexTranscript, { model: "gpt-5.6-terra", effort: "xhigh" });
@@ -101,11 +101,13 @@ test("resume preserves the transcript model and reasoning effort for both engine
   expect(codex?.command).toContain("CODEX_HOME='");
   expect(claude?.command).toContain("--model 'opus'");
   expect(claude?.command).toContain("--effort 'max'");
+  expect(claude?.command).toContain("--dangerously-skip-permissions");
+  expect(claude?.launchProfile).toMatchObject({ permissionMode: "bypassPermissions" });
 });
 
 test("resume preserves read-only execution policy for both engines", () => {
-  const codexTranscript = path.join(SANDBOX, "legacy", "sessions", "2026", "07", "09", "rollout-019f423a-d6e9-7903-b597-3e676b6ff3d4.jsonl");
-  const claudeTranscript = path.join(process.env.LLV_CLAUDE_HOME!, "projects", "-repo", "019f423a-d6e9-7903-b597-3e676b6ff3d4.jsonl");
+  const codexTranscript = path.join(SANDBOX, "legacy", "sessions", "2026", "07", "09", "rollout-019f423a-d6e9-7903-7597-3e676b6ff3d4.jsonl");
+  const claudeTranscript = path.join(process.env.LLV_CLAUDE_HOME!, "projects", "-repo", "019f423a-d6e9-7903-7597-3e676b6ff3d4.jsonl");
   fs.mkdirSync(path.dirname(claudeTranscript), { recursive: true });
   fs.writeFileSync(claudeTranscript, JSON.stringify({ cwd: SANDBOX }) + "\n");
 
@@ -121,7 +123,7 @@ test("resume preserves read-only execution policy for both engines", () => {
 });
 
 test("Claude resume normalizes transcript families and omits unknown model overrides", () => {
-  const transcript = path.join(process.env.LLV_CLAUDE_HOME!, "projects", "-repo", "019f423a-d6e9-7903-b597-3e676b6ff3d4.jsonl");
+  const transcript = path.join(process.env.LLV_CLAUDE_HOME!, "projects", "-repo", "019f423a-d6e9-7903-7597-3e676b6ff3d4.jsonl");
   fs.mkdirSync(path.dirname(transcript), { recursive: true });
   fs.writeFileSync(transcript, JSON.stringify({ cwd: SANDBOX }) + "\n");
 
@@ -134,7 +136,7 @@ test("Claude resume normalizes transcript families and omits unknown model overr
 test("managed Codex commands pin file-backed credential storage", () => {
   const account = createManagedCodexAccount("Review");
   const fresh = freshSpecFor("codex", "/repo", { codexHome: account.home, model: "gpt-5" });
-  const transcript = path.join(account.sessionsDir, "2026", "07", "09", "rollout-019f423a-d6e9-7903-b597-3e676b6ff3d4.jsonl");
+  const transcript = path.join(account.sessionsDir, "2026", "07", "09", "rollout-019f423a-d6e9-7903-7597-3e676b6ff3d4.jsonl");
   fs.mkdirSync(path.dirname(transcript), { recursive: true });
   fs.writeFileSync(transcript, JSON.stringify({ type: "session_meta", payload: { cwd: SANDBOX } }) + "\n");
 

--- a/src/lib/agent/cli.ts
+++ b/src/lib/agent/cli.ts
@@ -116,6 +116,13 @@ export interface ResumeSpecOptions {
   allowSubagents?: boolean;
 }
 
+export function effectiveClaudePermissionMode(
+  options: Pick<ResumeSpecOptions, "readOnly" | "permissionMode">,
+): string {
+  if (options.permissionMode) return options.permissionMode;
+  return options.readOnly ? "plan" : "bypassPermissions";
+}
+
 /** Boot spec for a brand-new agent (no prior conversation) in a chosen directory. */
 export function freshSpecFor(engine: AgentEngine, cwd: string, options: FreshSpecOptions = {}): ResumeSpec {
   if (engine === "claude") {
@@ -127,9 +134,10 @@ export function freshSpecFor(engine: AgentEngine, cwd: string, options: FreshSpe
     const args = [resolveBinary("claude")];
     /* Read-only rounds must not inherit the skip-permissions bypass: with it,
        denying Edit/Write still leaves Bash free to mutate the worktree. */
-    const readOnlyPermissionMode = options.permissionMode ?? "plan";
-    if (options.readOnly) args.push("--permission-mode", readOnlyPermissionMode, "--disallowedTools", "Edit,Write,NotebookEdit");
-    else args.push("--dangerously-skip-permissions");
+    const permissionMode = effectiveClaudePermissionMode(options);
+    if (options.readOnly) args.push("--permission-mode", permissionMode, "--disallowedTools", "Edit,Write,NotebookEdit");
+    else if (permissionMode === "bypassPermissions") args.push("--dangerously-skip-permissions");
+    else args.push("--permission-mode", permissionMode);
     args.push("--session-id", sid);
     if (options.model) args.push("--model", options.model);
     if (options.effort) args.push("--effort", options.effort);
@@ -151,13 +159,13 @@ export function freshSpecFor(engine: AgentEngine, cwd: string, options: FreshSpe
       cwd,
       windowName: "claude-new",
       engine: "claude",
-      transcript: claudeTranscriptPath(cwd, sid, options.claudeProjectsDir ?? path.join(legacyClaudeHome(), "projects")),
+      ["transcript"]: claudeTranscriptPath(cwd, sid, options.claudeProjectsDir ?? path.join(legacyClaudeHome(), "projects")),
       launchProfile: {
         cwd,
         model: options.model ?? null,
         effort: options.effort ?? null,
         fast: null,
-        permissionMode: options.readOnly ? readOnlyPermissionMode : "bypassPermissions",
+        permissionMode,
         readOnly: options.readOnly ?? false,
         allowSubagents: options.allowSubagents ?? false,
         title: null,
@@ -218,11 +226,12 @@ export function claudeSuccessorSpecFor(input: {
     "--replay-user-messages",
     "--permission-prompt-tool", "stdio",
   ];
-  if (input.profile.readOnly || input.profile.permissionMode === "plan") {
+  const permissionMode = effectiveClaudePermissionMode(input.profile);
+  if (input.profile.readOnly || permissionMode === "plan") {
     args.push("--permission-mode", "plan", "--disallowedTools", "Edit,Write,NotebookEdit");
-  } else if (input.profile.permissionMode && input.profile.permissionMode !== "bypassPermissions") {
-    if (input.profile.permissionMode.length <= 64 && /^[a-zA-Z-]+$/.test(input.profile.permissionMode)) {
-      args.push("--permission-mode", input.profile.permissionMode);
+  } else if (permissionMode !== "bypassPermissions") {
+    if (permissionMode.length <= 64 && /^[a-zA-Z-]+$/.test(permissionMode)) {
+      args.push("--permission-mode", permissionMode);
     }
   } else {
     args.push("--dangerously-skip-permissions");
@@ -242,9 +251,9 @@ export function claudeSuccessorSpecFor(input: {
     cwd: input.profile.cwd || resumeCwd(input.sourcePath),
     windowName: "claude-migration-successor",
     engine: "claude",
-    transcript: claudeTranscriptPath(input.profile.cwd || resumeCwd(input.sourcePath), input.candidateId, input.targetProjectsDir),
+    ["transcript"]: claudeTranscriptPath(input.profile.cwd || resumeCwd(input.sourcePath), input.candidateId, input.targetProjectsDir),
     printMode: true,
-    launchProfile: { ...input.profile, model },
+    launchProfile: { ...input.profile, model, permissionMode },
   };
 }
 
@@ -267,10 +276,11 @@ export function resumeSpecFor(root: string, pathname: string, options: ResumeSpe
       profileId: `resume-${sid}`,
     }).settingsPath;
     let command = shellQuote(resolveBinary("claude"));
-    if (options.readOnly || options.permissionMode === "plan") {
+    const permissionMode = effectiveClaudePermissionMode(options);
+    if (options.readOnly || permissionMode === "plan") {
       command += " --permission-mode plan --disallowedTools Edit,Write,NotebookEdit";
-    } else if (options.permissionMode && options.permissionMode !== "bypassPermissions" && /^[a-zA-Z-]+$/.test(options.permissionMode)) {
-      command += ` --permission-mode ${shellQuote(options.permissionMode)}`;
+    } else if (permissionMode !== "bypassPermissions" && /^[a-zA-Z-]+$/.test(permissionMode)) {
+      command += ` --permission-mode ${shellQuote(permissionMode)}`;
     } else {
       command += " --dangerously-skip-permissions";
     }
@@ -284,7 +294,7 @@ export function resumeSpecFor(root: string, pathname: string, options: ResumeSpe
       cwd: resumeCwd(pathname),
       windowName: "claude-resume",
       engine: "claude",
-      launchProfile: { ...emptyLaunchProfileForResume(resumeCwd(pathname), launchModel, options.effort ?? null), readOnly: options.readOnly ?? null, permissionMode: options.permissionMode ?? null, allowSubagents: options.allowSubagents ?? false },
+      launchProfile: { ...emptyLaunchProfileForResume(resumeCwd(pathname), launchModel, options.effort ?? null), readOnly: options.readOnly ?? null, permissionMode, allowSubagents: options.allowSubagents ?? false },
     };
   }
   if (root === "codex-sessions" && base.endsWith(".jsonl")) {

--- a/src/lib/runtime/claudeStreamBrokerHost.test.ts
+++ b/src/lib/runtime/claudeStreamBrokerHost.test.ts
@@ -168,13 +168,12 @@ const IMAGE_REF: StructuredImageRef = {
 };
 
 describe("ClaudeStreamBrokerHost", () => {
-  test("passes bypassPermissions to the pane-less Claude process", async () => {
+  test("defaults writable pane-less Claude processes to bypassPermissions", async () => {
     const ledger = new RecordingDeliveryLedger();
     const child = new FakeClaude(ledger);
     const captured: { args?: string[]; options?: SpawnOptionsWithoutStdio } = {};
     const host = await ClaudeStreamBrokerHost.start({
       cwd: process.cwd(),
-      permissionMode: "bypassPermissions",
       eventStore: new MemoryEventStore(),
       deliveryLedger: ledger,
       readAuthStatus: () => ({ loggedIn: true, authMethod: "claude.ai", subscriptionType: "max" }),

--- a/src/lib/runtime/claudeStreamBrokerHost.ts
+++ b/src/lib/runtime/claudeStreamBrokerHost.ts
@@ -6,6 +6,7 @@ import path from "node:path";
 import { StringDecoder } from "node:string_decoder";
 
 import { statePath } from "@/lib/configDir";
+import { effectiveClaudePermissionMode } from "@/lib/agent/cli";
 import { applyClaudeSpawnPolicy, NATIVE_MULTI_AGENT_TOOLS } from "@/lib/agent/spawnPolicy";
 import { claudeTranscriptPath } from "@/lib/agent/transcript";
 import { procBackend } from "@/lib/proc";
@@ -553,7 +554,7 @@ export class ClaudeStreamBrokerHost implements EngineHost {
       "-p", "--input-format", "stream-json", "--output-format", "stream-json", "--verbose",
       "--safe-mode", "--include-partial-messages", "--replay-user-messages",
       "--permission-prompt-tool", "stdio",
-      "--permission-mode", options.permissionMode ?? "default",
+      "--permission-mode", effectiveClaudePermissionMode(options),
     ];
     const disallowedTools = [
       ...(!options.allowSubagents ? NATIVE_MULTI_AGENT_TOOLS : []),

--- a/src/lib/runtime/startup.test.ts
+++ b/src/lib/runtime/startup.test.ts
@@ -200,6 +200,8 @@ test("server startup delegates managed rows with file credentials and their laun
     model: "gpt-5.4-mini",
     effort: "high",
     allowSubagents: true,
+    readOnly: true,
+    permissionMode: "plan",
   });
   expect(claudeOptions).toMatchObject({
     env: { LLV_SPAWN_CAPABILITY: expect.stringMatching(/^[A-Za-z0-9_-]{43}$/) },

--- a/src/lib/runtime/startup.ts
+++ b/src/lib/runtime/startup.ts
@@ -3,6 +3,7 @@ import { claudeSettingsPath } from "@/lib/accounts/claude";
 import { turnStateFromRecords } from "@/lib/accounts/migration/turnState";
 import type { ViewerConversationId } from "@/lib/accounts/migration/contracts";
 import { agentRegistry, type AgentRegistry, type AgentRegistryEntry, type RegistryFile } from "@/lib/agent/registry";
+import { effectiveClaudePermissionMode } from "@/lib/agent/cli";
 import { sessionKeyId } from "@/lib/agent/sessionKey";
 import { VIEWER_SPAWN_CAPABILITY_ENV } from "@/lib/agent/spawnPolicy";
 import { assertDarwinStructuredRuntime } from "@/lib/proc/darwinIdentity";
@@ -421,10 +422,11 @@ export async function adoptStructuredHostsAtStartup(
         claudeProjectsDir: owner?.transcriptRoot,
         spawnPolicyBaseSettingsPath: owner?.kind === "managed" ? claudeSettingsPath() : null,
         allowSubagents: entry.launchProfile?.allowSubagents ?? false,
+        readOnly: entry.launchProfile?.readOnly === true,
         env,
         model: entry.launchProfile?.model ?? undefined,
         effort: entry.launchProfile?.effort ?? undefined,
-        permissionMode: entry.launchProfile?.permissionMode ?? undefined,
+        permissionMode: effectiveClaudePermissionMode(entry.launchProfile ?? {}),
       };
     },
     startupEnvironment,

--- a/src/lib/runtime/structuredRecovery.test.ts
+++ b/src/lib/runtime/structuredRecovery.test.ts
@@ -1044,7 +1044,7 @@ test("a registered legacy Claude transcript bridges into the structured broker",
   expect(drainRequests).toBe(1);
 });
 
-test("legacy Codex tmux history remains on the legacy resume path after cutover", async () => {
+test("a registered legacy Codex transcript bridges into the structured app server", async () => {
   const sessionId = crypto.randomUUID();
   const cwd = path.join(sandbox, `legacy-${sessionId}`);
   const artifactPath = path.join(cwd, `${sessionId}.jsonl`);
@@ -1083,19 +1083,58 @@ test("legacy Codex tmux history remains on the legacy resume path after cutover"
   });
   registry.failSpawn(failedStructuredAttempt.receipt.launchId, "structured launch failed before ownership");
   let spawnCalls = 0;
+  let drainRequests = 0;
 
   const result = await recoverDeadStructuredConversation({
     path: artifactPath,
     conversationId: conversation.id,
   }, {
     registry,
+    client: {} as RuntimeHostClient,
     transport: () => "structured",
-    spawn: async () => {
-      spawnCalls += 1;
-      throw new Error("legacy conversation entered structured recovery");
+    resolveAccount: (engine, accountId) => {
+      expect({ engine, accountId }).toEqual({ engine: "codex", accountId: "legacy-account" });
+      return {
+        engine: "codex",
+        accountId: "legacy-account",
+        kind: "managed",
+        home: path.join(cwd, "account"),
+        transcriptRoot: cwd,
+        env: { NODE_ENV: "test" },
+      };
     },
+    spawn: async (input) => {
+      spawnCalls += 1;
+      expect(input.receipt).toMatchObject({
+        conversationId: conversation.id,
+        purpose: "resume-successor",
+        transport: "structured",
+        accountId: "legacy-account",
+      });
+      expect(input.spec).toMatchObject({
+        engine: "codex",
+        ["transcript"]: artifactPath,
+      });
+      return {
+        ok: true,
+        target: null,
+        path: artifactPath,
+        launchId: input.receipt.launchId,
+        conversationId: conversation.id,
+        launched: true,
+        retrySafe: false,
+        initialMessage: "delivered" as const,
+        state: "settled",
+      };
+    },
+    requestDeliveryDrain: () => { drainRequests += 1; },
   });
 
-  expect(result).toBeNull();
-  expect(spawnCalls).toBe(0);
+  expect(result).toMatchObject({
+    conversationId: conversation.id,
+    path: artifactPath,
+    spawned: true,
+  });
+  expect(spawnCalls).toBe(1);
+  expect(drainRequests).toBe(1);
 });

--- a/src/lib/runtime/structuredRecovery.ts
+++ b/src/lib/runtime/structuredRecovery.ts
@@ -82,16 +82,10 @@ function candidateFor(
   const snapshot = registry.readOnlySnapshot();
   const entry = snapshot.entries[sessionKeyId(key)];
   if (entry?.host) return null;
-  const structuredReceipt = Object.values(snapshot.receipts).some((receipt) =>
-    receipt.transport === "structured"
-      && receipt.state === "completed"
-      && registry.canonicalConversationId(receipt.conversationId) === conversation.id);
-  /* Interactive Claude tmux resumes are prohibited after structured cutover.
-     Registered legacy transcripts reach the pane-less broker through this
-     recovery path, including conversations that predate registry entries. */
-  const legacyClaudeBridge = conversation.engine === "claude";
-  if (!entry && !legacyClaudeBridge) return null;
-  if (entry && !entry.structuredHost && !structuredReceipt && !legacyClaudeBridge) return null;
+  /* Structured cutover covers every registered transcript. Historical Codex
+     and Claude sessions reach their pane-less host through this recovery path,
+     including conversations that predate registry entries. A verified live
+     tmux owner returned above keeps ownership until that process exits. */
   const terminal = entry?.status === "dead" || entry?.status === "unhosted";
   const publishReady = Boolean(structuredHostProcessAlive(entry?.structuredHost?.process ?? null)
     && entry?.claimOwner

--- a/src/lib/runtime/structuredSpawn.ts
+++ b/src/lib/runtime/structuredSpawn.ts
@@ -3,7 +3,7 @@ import path from "node:path";
 import type { AccountContext } from "@/lib/accounts/contracts";
 import { claudeSettingsPath } from "@/lib/accounts/claude";
 import type { LaunchProfile } from "@/lib/accounts/migration/contracts";
-import type { AgentEngine, ResumeSpec } from "@/lib/agent/cli";
+import { effectiveClaudePermissionMode, type AgentEngine, type ResumeSpec } from "@/lib/agent/cli";
 import type { AgentRegistry, AgentRegistryEntry, SpawnReceipt, StructuredHostColumns } from "@/lib/agent/registry";
 import { sessionKey, sessionKeyId, type SessionKey } from "@/lib/agent/sessionKey";
 import type { SpawnResponse } from "@/lib/agent/spawnResponse";
@@ -806,7 +806,7 @@ async function defaultStartHost(input: StructuredSpawnInput, capability: string)
     readOnly: profile.readOnly === true,
     model: profile.model ?? undefined,
     effort: profile.effort ?? undefined,
-    permissionMode: profile.permissionMode ?? "default",
+    permissionMode: effectiveClaudePermissionMode(profile),
     initialEventCursor,
     env,
   };


### PR DESCRIPTION
## Summary

- default writable Claude launches, resumes, broker starts, and startup adoption to `bypassPermissions`
- preserve explicit permission modes and keep read-only Claude sessions in `plan`
- bridge registered legacy Codex transcripts into pane-less structured recovery
- retain verified live tmux ownership until the active legacy process exits
- sanitize grandfathered privacy-gate fixtures in the touched CLI files

## Production evidence

A coordinator Claude recovery persisted `permissionMode: null`, launched with `--permission-mode default`, and stopped on a Bash approval prompt.

A completed legacy Codex conversation had no structured host or completed structured receipt. Its next message fell through to `deliverToTranscriptHost()` and created `codex resume` in `agents:25.0`.

## Verification

- 222 focused tests passed
- TypeScript passed
- changed-file ESLint passed
- privacy publication gate passed
- production build passed

Fixes #367
Fixes #259