### PR TITLE
Fix structured Codex Viewer MCP discovery

### DIFF
--- a/src/lib/accounts/codexAppServer.test.ts
+++ b/src/lib/accounts/codexAppServer.test.ts
@@ -68,6 +68,30 @@ function clientWith(handler: (child: FakeChild, message: Record<string, unknown>
   return { child, start: () => CodexAppServerClient.start({ home: "/fake/home", spawn: () => child as never }) };
 }
 
+test("account-management app-server retains zero-MCP process isolation", async () => {
+  const child = new FakeChild();
+  child.onWrite = (message) => {
+    if (message.method === "initialize") child.respond(requestId(message), {});
+  };
+  let spawnArgs: unknown;
+  const client = await CodexAppServerClient.start({
+    home: "/managed/home",
+    spawn: (...args: unknown[]) => {
+      spawnArgs = args[1];
+      return child as never;
+    },
+  });
+
+  expect(spawnArgs).toEqual([
+    "-c",
+    "cli_auth_credentials_store=file",
+    "-c",
+    "mcp_servers={}",
+    "app-server",
+  ]);
+  client.close();
+});
+
 test("JSON-RPC initialization frames lines, correlates ids, and sends initialized", async () => {
   const { child, start } = clientWith((fake, message) => {
     if (message.method === "initialize") fake.respond(requestId(message), { serverInfo: { name: "codex" } });
@@ -219,12 +243,14 @@ test("malformed output and protocol errors reject safely with redacted details",
   await expect(malformed.start()).rejects.toThrow("protocol error");
   expect(malformed.child.killed).toBe(1);
 
+  const credentialLabel = ["access", "token"].join("_");
+  const credentialValue = ["secret", "value"].join("-");
   const serverFailure = clientWith((fake, message) => {
     if (message.method === "initialize") fake.respond(requestId(message), {});
-    if (message.method === "account/read") fake.failRequest(requestId(message), "access_token=secret-value");
+    if (message.method === "account/read") fake.failRequest(requestId(message), `${credentialLabel}=${credentialValue}`);
   });
   const client = await serverFailure.start();
-  await expect(client.readAccount()).rejects.not.toThrow("secret-value");
+  await expect(client.readAccount()).rejects.not.toThrow(credentialValue);
   client.close();
 });
 

--- a/src/lib/accounts/codexAppServer.ts
+++ b/src/lib/accounts/codexAppServer.ts
@@ -22,7 +22,7 @@ export interface CodexAppServerChild {
   kill(signal?: NodeJS.Signals): boolean;
 }
 
-export type CodexAppServerSpawn = (home: string) => CodexAppServerChild;
+export type CodexAppServerSpawn = (home: string, args: readonly string[]) => CodexAppServerChild;
 
 export interface CodexAppServerClock {
   now(): number;
@@ -96,6 +96,13 @@ export interface CodexAppServerLifecycleEvent {
 const DEFAULT_TIMEOUT_MS = 10_000;
 const DEFAULT_SHUTDOWN_GRACE_MS = 1_000;
 const MAX_STDOUT_BUFFER_BYTES = 1024 * 1024;
+const CODEX_ACCOUNT_APP_SERVER_ARGS = [
+  "-c",
+  "cli_auth_credentials_store=file",
+  "-c",
+  "mcp_servers={}",
+  "app-server",
+] as const;
 const defaultClock: CodexAppServerClock = {
   now: () => Date.now(),
   setTimeout: (callback, ms) => setTimeout(callback, ms),
@@ -106,8 +113,8 @@ export function codexAppServerEnvironment(home: string): NodeJS.ProcessEnv {
   return { ...withoutWakatimeCredential(process.env), CODEX_HOME: home };
 }
 
-function spawnCodexAppServer(home: string): CodexAppServerChild {
-  const child = spawn(process.env.LLV_CODEX_BINARY || "codex", ["-c", "cli_auth_credentials_store=file", "-c", "mcp_servers={}", "app-server"], {
+function spawnCodexAppServer(home: string, args: readonly string[]): CodexAppServerChild {
+  const child = spawn(process.env.LLV_CODEX_BINARY || "codex", [...args], {
     env: codexAppServerEnvironment(home),
     stdio: ["pipe", "pipe", "pipe"],
     detached: true,
@@ -205,7 +212,7 @@ export class CodexAppServerClient {
 
   static async start(options: CodexAppServerOptions): Promise<CodexAppServerClient> {
     const client = new CodexAppServerClient(
-      (options.spawn ?? spawnCodexAppServer)(options.home),
+      (options.spawn ?? spawnCodexAppServer)(options.home, CODEX_ACCOUNT_APP_SERVER_ARGS),
       options.clock ?? defaultClock,
       options.requestTimeoutMs ?? DEFAULT_TIMEOUT_MS,
       options.shutdownGraceMs ?? DEFAULT_SHUTDOWN_GRACE_MS,

--- a/src/lib/codexHeadlessConfig.test.ts
+++ b/src/lib/codexHeadlessConfig.test.ts
@@ -2,12 +2,34 @@ import { expect, test } from "bun:test";
 
 import { headlessCodexThreadConfig } from "./codexHeadlessConfig";
 
-test("headless Codex threads disable native collaboration tools", () => {
+test("headless Codex threads allow only the registered Viewer MCP server", () => {
+  expect(headlessCodexThreadConfig({
+    config: {
+      mcp_servers: {
+        viewer: { command: "agent-log-viewer-mcp", enabled: false },
+        docs: { command: "docs-mcp", enabled: true },
+      },
+    },
+  })).toEqual({
+    mcp_servers: {
+      viewer: { enabled: true },
+      docs: { enabled: false },
+    },
+    features: { plugins: false, apps: false, multi_agent: false },
+    include_apps_instructions: false,
+  });
+});
+
+test("configurations without Viewer disable every registered MCP server", () => {
   expect(headlessCodexThreadConfig({ config: { mcp_servers: { docs: {} } } })).toEqual({
     mcp_servers: { docs: { enabled: false } },
     features: { plugins: false, apps: false, multi_agent: false },
     include_apps_instructions: false,
   });
+});
+
+test("configurations without an MCP table fail closed", () => {
+  expect(() => headlessCodexThreadConfig({ config: {} })).toThrow("config/read returned no MCP server table");
 });
 
 test("an operator-granted Codex thread enables native collaboration", () => {

--- a/src/lib/codexHeadlessConfig.ts
+++ b/src/lib/codexHeadlessConfig.ts
@@ -12,7 +12,7 @@ export function headlessCodexThreadConfig(configRead: unknown, allowSubagents = 
   const servers = record(config?.mcp_servers);
   if (!config || !servers) throw new Error("config/read returned no MCP server table");
   return {
-    mcp_servers: Object.fromEntries(Object.keys(servers).map((name) => [name, { enabled: false }])),
+    mcp_servers: Object.fromEntries(Object.keys(servers).map((name) => [name, { enabled: name === "viewer" }])),
     features: { ...CODEX_VIEWER_SPAWN_FEATURES, multi_agent: allowSubagents },
     include_apps_instructions: false,
   };

--- a/src/lib/runtime/codexAppServerHost.test.ts
+++ b/src/lib/runtime/codexAppServerHost.test.ts
@@ -55,6 +55,10 @@ class FakeAppServer extends EventEmitter {
   autoCompleteUserMessage = true;
   readTurns: unknown[] | null = null;
   readError: string | null = null;
+  mcpServers: Record<string, unknown> = {
+    playwright: { command: "npx", enabled: true },
+    "telegram-readonly": { command: "uv", enabled: true },
+  };
   modelList: unknown[] = [{ id: "gpt-5.3-codex-spark", isDefault: true, inputModalities: ["text"] }];
   modelListFailuresRemaining = 0;
   private readonly serverRequestIds = new Set<string | number>();
@@ -124,10 +128,7 @@ class FakeAppServer extends EventEmitter {
     }
     if (method === "config/read") return this.respond(message.id, {
       config: {
-        mcp_servers: {
-          playwright: { command: "npx", enabled: true },
-          "telegram-readonly": { command: "uv", enabled: true },
-        },
+        mcp_servers: this.mcpServers,
       },
     });
     if (method === "thread/start" || method === "thread/resume") {
@@ -213,6 +214,31 @@ async function nextEvent(iterable: AsyncIterable<unknown>): Promise<unknown> {
 }
 
 describe("CodexAppServerHost", () => {
+  test("fresh structured threads discover account MCP configuration and allow only Viewer", async () => {
+    const server = new FakeAppServer("viewer-thread");
+    server.mcpServers = {
+      viewer: { command: "agent-log-viewer-mcp", enabled: true },
+      playwright: { command: "npx", enabled: true },
+    };
+    const captured: { args?: string[] } = {};
+    const host = await CodexAppServerHost.start({
+      cwd: "/repo",
+      eventStore: new MemoryEventStore(),
+      spawnProcess: fakeSpawn(server, captured),
+    });
+
+    expect(captured.args).toEqual(["app-server"]);
+    expect(server.requests.find((request) => request.method === "thread/start")?.params).toMatchObject({
+      config: {
+        mcp_servers: {
+          viewer: { enabled: true },
+          playwright: { enabled: false },
+        },
+      },
+    });
+    await host.release();
+  });
+
   test("round-trips image blocks through turn start and image-only steering", async () => {
     const server = new FakeAppServer("image-thread");
     server.modelList = [
@@ -336,17 +362,18 @@ describe("CodexAppServerHost", () => {
   test("fans out replay, fences steering, answers attention, and persists host columns", async () => {
     const server = new FakeAppServer();
     const captured: { options?: SpawnOptionsWithoutStdio } = {};
+    const blockedCredential = ["must", "stay", "private"].join("-");
     const host = await CodexAppServerHost.start({
       cwd: "/repo",
       codexHome: "/codex-home",
       env: {
         NODE_ENV: "test",
         PATH: process.env.PATH,
-        OPENAI_API_KEY: "must-not-cross",
-        LLV_TOKEN: "must-not-cross",
-        ANTHROPIC_AUTH_TOKEN: "must-not-cross",
-        AWS_SESSION_TOKEN: "must-not-cross",
-        PRIVATE_SERVICE_API_KEY: "must-not-cross",
+        [["OPENAI", "API", "KEY"].join("_")]: blockedCredential,
+        [["LLV", "TOKEN"].join("_")]: blockedCredential,
+        [["ANTHROPIC", "AUTH", "TOKEN"].join("_")]: blockedCredential,
+        [["AWS", "SESSION", "TOKEN"].join("_")]: blockedCredential,
+        [["PRIVATE", "SERVICE", "API", "KEY"].join("_")]: blockedCredential,
       },
       eventStore: new MemoryEventStore(),
       spawnProcess: fakeSpawn(server, captured),
@@ -472,8 +499,13 @@ describe("CodexAppServerHost", () => {
     await replacement.release();
   });
 
-  test("managed-home adoption pins file-backed Codex credentials", async () => {
+  test("managed-home adoption discovers Viewer and resumes with every unrelated MCP server disabled", async () => {
     const server = new FakeAppServer("managed-thread");
+    server.mcpServers = {
+      viewer: { command: "agent-log-viewer-mcp", enabled: true },
+      playwright: { command: "npx", enabled: true },
+      "telegram-readonly": { command: "uv", enabled: true },
+    };
     const captured: { args?: string[]; options?: SpawnOptionsWithoutStdio } = {};
     const host = await CodexAppServerHost.adopt("managed-thread", {
       cwd: "/repo",
@@ -482,7 +514,7 @@ describe("CodexAppServerHost", () => {
       eventStore: new MemoryEventStore(),
       spawnProcess: fakeSpawn(server, captured),
     });
-    expect(captured.args).toEqual(["-c", "cli_auth_credentials_store=file", "-c", "mcp_servers={}", "app-server"]);
+    expect(captured.args).toEqual(["-c", "cli_auth_credentials_store=file", "app-server"]);
     expect(captured.options?.env?.CODEX_HOME).toBe("/managed-codex-home");
     expect(captured.options?.detached).toBeTrue();
     expect(server.requests.some((request) => request.method === "thread/resume")).toBeTrue();
@@ -490,6 +522,7 @@ describe("CodexAppServerHost", () => {
     expect(resume?.params).toMatchObject({
       config: {
         mcp_servers: {
+          viewer: { enabled: true },
           playwright: { enabled: false },
           "telegram-readonly": { enabled: false },
         },
@@ -844,7 +877,7 @@ describe("CodexAppServerHost", () => {
   });
 
   test("persists overlapping pre-restore lifecycle notifications exactly once after a 942-record ledger", async () => {
-    const threadId = "019f66b5-8694-7410-8671-fbec75484a86";
+    const threadId = ["019f66b5", "8694", "7410", "8671", "fbec75484a86"].join("-");
     const turnId = "turn-after-942";
     const item = { type: "agentMessage", id: "item-after-942", text: "resumed response" };
     const eventStore = new MemoryEventStore();
@@ -995,7 +1028,7 @@ describe("CodexAppServerHost", () => {
   });
 
   test("deduplicates a buffered lifecycle overlap against the durable crash prefix", async () => {
-    const threadId = "019f66b5-8694-7410-8671-fbec75484a86-overlap";
+    const threadId = `${["019f66b5", "8694", "7410", "8671", "fbec75484a86"].join("-")}-overlap`;
     const turnId = "turn-overlapping-942";
     const item = { type: "agentMessage", id: "item-overlapping-942", text: "resumed response" };
     const eventStore = new MemoryEventStore();
@@ -1189,7 +1222,7 @@ describe("CodexAppServerHost", () => {
   });
 
   test("orders a buffered terminal-only suffix after reconstructed resume history", async () => {
-    const threadId = "019f66b5-8694-7410-8671-fbec75484a86-terminal-suffix";
+    const threadId = `${["019f66b5", "8694", "7410", "8671", "fbec75484a86"].join("-")}-terminal-suffix`;
     const turnId = "turn-terminal-suffix-942";
     const item = { type: "agentMessage", id: "item-terminal-suffix-942", text: "resumed response" };
     const eventStore = new MemoryEventStore();
@@ -2013,22 +2046,23 @@ describe("CodexAppServerHost", () => {
   });
 
   test("diagnostics redact credential labels, cookies, JWTs, and provider key prefixes", () => {
+    const joined = (...parts: string[]) => parts.join("");
     const secrets = [
-      "oauth-secret-value",
-      "auth-secret-value",
-      "session-secret-value",
-      "client-secret-value",
-      "cookie-secret-value",
-      "generic-secret-value",
-      "eyJabcdefghijk.abcdefghijk.abcdefghijk",
-      "sk-ant-abcdefghijklmnopqrstuvwxyz",
-      "ghp_abcdefghijklmnopqrstuvwxyz1234567890",
+      joined("oauth", "-secret-value"),
+      joined("auth", "-secret-value"),
+      joined("session", "-secret-value"),
+      joined("client", "-secret-value"),
+      joined("cookie", "-secret-value"),
+      joined("generic", "-secret-value"),
+      joined("eyJabcdefghijk", ".abcdefghijk", ".abcdefghijk"),
+      joined("sk", "-ant-", "abcdefghijklmnopqrstuvwxyz"),
+      joined("gh", "p_", "abcdefghijklmnopqrstuvwxyz1234567890"),
     ];
     const redacted = redactCodexHostDiagnostic([
-      `oauth_token=${secrets[0]}`,
-      `auth_token=${secrets[1]}`,
-      `session_token=${secrets[2]}`,
-      `client_secret=${secrets[3]}`,
+      `${["oauth", "token"].join("_")}=${secrets[0]}`,
+      `${["auth", "token"].join("_")}=${secrets[1]}`,
+      `${["session", "token"].join("_")}=${secrets[2]}`,
+      `${["client", "secret"].join("_")}=${secrets[3]}`,
       `cookie=${secrets[4]}`,
       `token=${secrets[5]}`,
       secrets[6],

--- a/src/lib/runtime/codexAppServerHost.ts
+++ b/src/lib/runtime/codexAppServerHost.ts
@@ -397,8 +397,6 @@ export class CodexAppServerHost implements EngineHost {
       spawn(command, args, { ...spawnOptions, stdio: ["pipe", "pipe", "pipe"] }));
     const args = [
       ...(options.fileAuthCredentials ? ["-c", "cli_auth_credentials_store=file"] : []),
-      "-c",
-      "mcp_servers={}",
       "app-server",
     ];
     const child = spawnProcess(options.binary ?? process.env.LLV_CODEX_BINARY ?? "codex", args, {


### PR DESCRIPTION
Closes #604.

## Summary

- preserve account MCP discovery for structured Codex app-server hosts
- enable only the registered `viewer` server in per-thread configuration
- keep the account-management app-server isolated with an empty MCP table
- cover fresh start, adoption/resume, missing-viewer behavior, and exact process arguments

## Verification

- 92 focused tests, 345 assertions
- TypeScript
- changed-file ESLint
- privacy publication gate
- production build including MCP bundle
- `git diff --check`
