### PR TITLE
Make Viewer MCP always available with per-spawn allowlists

### DIFF
--- a/src/app/api/attach-command/route.ts
+++ b/src/app/api/attach-command/route.ts
@@ -68,6 +68,7 @@ export async function GET(req: NextRequest): Promise<NextResponse<AttachCommand 
       accountIdForPath: accountIdFromPath,
       accountLabelFor,
       allowSubagentsForPath: (p) => agentRegistry().launchProfileForPath(p)?.allowSubagents,
+      mcpServersForPath: (p) => agentRegistry().launchProfileForPath(p)?.mcpServers,
     });
     if (!resolution.ok) {
       return NextResponse.json({ error: resolution.error }, { status: resolution.status, headers: { "Cache-Control": "no-store" } });

--- a/src/app/api/spawn/route.test.ts
+++ b/src/app/api/spawn/route.test.ts
@@ -76,6 +76,64 @@ function structuredRouteDependencies(cwd: string): SpawnRouteTestDependencies {
   };
 }
 
+test("spawn admission rejects malformed MCP allowlists", async () => {
+  const response = await POST.withDependencies(new NextRequest("http://127.0.0.1/api/spawn", {
+    method: "POST",
+    headers: { origin: "http://127.0.0.1", host: "127.0.0.1", "content-type": "application/json" },
+    body: JSON.stringify({ engine: "codex", cwd: routeSandbox, prompt: "inspect", mcpServers: "viewer" }),
+  }), structuredRouteDependencies(routeSandbox));
+
+  expect(response.status).toBe(400);
+  expect(await response.json()).toEqual({ error: "mcpServers must be an array of non-empty server names" });
+});
+
+test("spawn admission persists Viewer-only defaults and normalized custom MCP allowlists", async () => {
+  const cwd = fs.mkdtempSync(path.join(routeSandbox, "mcp-allowlist-"));
+  const store = registry();
+  const previousTransport = process.env.LLV_SPAWN_TRANSPORT;
+  const previousHosts = process.env.LLV_STRUCTURED_HOSTS;
+  const previousEvents = process.env.LLV_RUNTIME_EVENTS;
+  const previousSocket = process.env.LLV_RUNTIME_HOST_SOCKET;
+  const previousUi = process.env.NEXT_PUBLIC_RUNTIME_UI;
+  process.env.LLV_SPAWN_TRANSPORT = "structured";
+  process.env.LLV_STRUCTURED_HOSTS = "1";
+  process.env.LLV_RUNTIME_EVENTS = "1";
+  process.env.LLV_RUNTIME_HOST_SOCKET = path.join(cwd, "runtime.sock");
+  process.env.NEXT_PUBLIC_RUNTIME_UI = "1";
+  try {
+    const dependencies = { ...structuredRouteDependencies(cwd), registry: () => store };
+    const capability = rotateOperatorSpawnCapability();
+    const post = async (clientAttemptId: string, mcpServers?: unknown) => POST.withDependencies(new NextRequest("http://127.0.0.1/api/spawn", {
+      method: "POST",
+      headers: {
+        origin: "http://127.0.0.1",
+        host: "127.0.0.1",
+        "content-type": "application/json",
+        "x-llv-spawn-capability": capability,
+      },
+      body: JSON.stringify({ engine: "claude", model: "claude-sonnet-4-6", cwd, prompt: "inspect", role: "builder", clientAttemptId, ...(mcpServers === undefined ? {} : { mcpServers }) }),
+    }), dependencies);
+
+    const defaultResponse = await post("mcp_default_20260723");
+    expect({ status: defaultResponse.status, body: await defaultResponse.clone().json() }).toMatchObject({ status: 202 });
+    expect((await post("mcp_custom_20260723", ["agent-browser", "viewer", "agent-browser"])).status).toBe(202);
+
+    expect(store.spawnReceiptForClientAttempt("mcp_default_20260723")?.launchProfile.mcpServers).toEqual(["viewer"]);
+    expect(store.spawnReceiptForClientAttempt("mcp_custom_20260723")?.launchProfile.mcpServers).toEqual(["viewer", "agent-browser"]);
+  } finally {
+    if (previousTransport === undefined) delete process.env.LLV_SPAWN_TRANSPORT;
+    else process.env.LLV_SPAWN_TRANSPORT = previousTransport;
+    if (previousHosts === undefined) delete process.env.LLV_STRUCTURED_HOSTS;
+    else process.env.LLV_STRUCTURED_HOSTS = previousHosts;
+    if (previousEvents === undefined) delete process.env.LLV_RUNTIME_EVENTS;
+    else process.env.LLV_RUNTIME_EVENTS = previousEvents;
+    if (previousSocket === undefined) delete process.env.LLV_RUNTIME_HOST_SOCKET;
+    else process.env.LLV_RUNTIME_HOST_SOCKET = previousSocket;
+    if (previousUi === undefined) delete process.env.NEXT_PUBLIC_RUNTIME_UI;
+    else process.env.NEXT_PUBLIC_RUNTIME_UI = previousUi;
+  }
+});
+
 test("a materialized structured child is offered for pipeline attempt adoption", async () => {
   const cwd = fs.mkdtempSync(path.join(routeSandbox, "pipeline-adoption-"));
   const store = registry();
@@ -1892,6 +1950,7 @@ function digestForParent(body: { parentConversationId: string }): string {
     fast: false,
     accountId: "terra",
     role: "worker",
+    mcpServers: ["viewer"],
     parent: spawnParentSelector(body),
     "prompt": "implement",
     images: [],

--- a/src/app/api/spawn/route.test.ts
+++ b/src/app/api/spawn/route.test.ts
@@ -1162,6 +1162,10 @@ test("operator and agent structured Claude role launches both retain bypass perm
 
 test("structured replay keeps its admitted account after routing changes", async () => {
   const cwd = fs.mkdtempSync(path.join(routeSandbox, "account-rotation-replay-"));
+  const previousCodexBinary = process.env.LLV_CODEX_BINARY;
+  const codexBinary = path.join(cwd, "codex-mcp-list");
+  fs.writeFileSync(codexBinary, "#!/bin/sh\nprintf '[]'\n");
+  fs.chmodSync(codexBinary, 0o755);
   const store = registry();
   const deferred: Array<() => Promise<void>> = [];
   const effects: string[] = [];
@@ -1234,6 +1238,7 @@ test("structured replay keeps its admitted account after routing changes", async
   process.env.LLV_RUNTIME_EVENTS = "1";
   process.env.LLV_RUNTIME_HOST_SOCKET = path.join(cwd, "runtime.sock");
   process.env.NEXT_PUBLIC_RUNTIME_UI = "1";
+  process.env.LLV_CODEX_BINARY = codexBinary;
   const alternateCwd = fs.mkdtempSync(path.join(routeSandbox, "account-rotation-conflict-"));
   const alternateParent = store.ensureConversation("claude", path.join(cwd, "alternate-parent.jsonl"), "account-a");
   const request = (overrides: Record<string, unknown> = {}) => new NextRequest("http://127.0.0.1:8898/api/spawn", {
@@ -1304,6 +1309,8 @@ test("structured replay keeps its admitted account after routing changes", async
     else process.env.LLV_RUNTIME_HOST_SOCKET = previousSocket;
     if (previousUi === undefined) delete process.env.NEXT_PUBLIC_RUNTIME_UI;
     else process.env.NEXT_PUBLIC_RUNTIME_UI = previousUi;
+    if (previousCodexBinary === undefined) delete process.env.LLV_CODEX_BINARY;
+    else process.env.LLV_CODEX_BINARY = previousCodexBinary;
   }
 });
 

--- a/src/lib/accounts/codexAppServer.test.ts
+++ b/src/lib/accounts/codexAppServer.test.ts
@@ -68,6 +68,30 @@ function clientWith(handler: (child: FakeChild, message: Record<string, unknown>
   return { child, start: () => CodexAppServerClient.start({ home: "/fake/home", spawn: () => child as never }) };
 }
 
+test("account-management app-server retains zero-MCP process isolation", async () => {
+  const child = new FakeChild();
+  child.onWrite = (message) => {
+    if (message.method === "initialize") child.respond(requestId(message), {});
+  };
+  let spawnArgs: unknown;
+  const client = await CodexAppServerClient.start({
+    home: "/managed/home",
+    spawn: (...args: unknown[]) => {
+      spawnArgs = args[1];
+      return child as never;
+    },
+  });
+
+  expect(spawnArgs).toEqual([
+    "-c",
+    "cli_auth_credentials_store=file",
+    "-c",
+    "mcp_servers={}",
+    "app-server",
+  ]);
+  client.close();
+});
+
 test("JSON-RPC initialization frames lines, correlates ids, and sends initialized", async () => {
   const { child, start } = clientWith((fake, message) => {
     if (message.method === "initialize") fake.respond(requestId(message), { serverInfo: { name: "codex" } });
@@ -219,12 +243,14 @@ test("malformed output and protocol errors reject safely with redacted details",
   await expect(malformed.start()).rejects.toThrow("protocol error");
   expect(malformed.child.killed).toBe(1);
 
+  const credentialLabel = ["access", "token"].join("_");
+  const credentialValue = ["secret", "value"].join("-");
   const serverFailure = clientWith((fake, message) => {
     if (message.method === "initialize") fake.respond(requestId(message), {});
-    if (message.method === "account/read") fake.failRequest(requestId(message), "access_token=secret-value");
+    if (message.method === "account/read") fake.failRequest(requestId(message), `${credentialLabel}=${credentialValue}`);
   });
   const client = await serverFailure.start();
-  await expect(client.readAccount()).rejects.not.toThrow("secret-value");
+  await expect(client.readAccount()).rejects.not.toThrow(credentialValue);
   client.close();
 });
 

--- a/src/lib/accounts/codexAppServer.ts
+++ b/src/lib/accounts/codexAppServer.ts
@@ -22,7 +22,7 @@ export interface CodexAppServerChild {
   kill(signal?: NodeJS.Signals): boolean;
 }
 
-export type CodexAppServerSpawn = (home: string) => CodexAppServerChild;
+export type CodexAppServerSpawn = (home: string, args: readonly string[]) => CodexAppServerChild;
 
 export interface CodexAppServerClock {
   now(): number;
@@ -96,6 +96,13 @@ export interface CodexAppServerLifecycleEvent {
 const DEFAULT_TIMEOUT_MS = 10_000;
 const DEFAULT_SHUTDOWN_GRACE_MS = 1_000;
 const MAX_STDOUT_BUFFER_BYTES = 1024 * 1024;
+const CODEX_ACCOUNT_APP_SERVER_ARGS = [
+  "-c",
+  "cli_auth_credentials_store=file",
+  "-c",
+  "mcp_servers={}",
+  "app-server",
+] as const;
 const defaultClock: CodexAppServerClock = {
   now: () => Date.now(),
   setTimeout: (callback, ms) => setTimeout(callback, ms),
@@ -106,8 +113,8 @@ export function codexAppServerEnvironment(home: string): NodeJS.ProcessEnv {
   return { ...withoutWakatimeCredential(process.env), CODEX_HOME: home };
 }
 
-function spawnCodexAppServer(home: string): CodexAppServerChild {
-  const child = spawn(process.env.LLV_CODEX_BINARY || "codex", ["-c", "cli_auth_credentials_store=file", "-c", "mcp_servers={}", "app-server"], {
+function spawnCodexAppServer(home: string, args: readonly string[]): CodexAppServerChild {
+  const child = spawn(process.env.LLV_CODEX_BINARY || "codex", [...args], {
     env: codexAppServerEnvironment(home),
     stdio: ["pipe", "pipe", "pipe"],
     detached: true,
@@ -205,7 +212,7 @@ export class CodexAppServerClient {
 
   static async start(options: CodexAppServerOptions): Promise<CodexAppServerClient> {
     const client = new CodexAppServerClient(
-      (options.spawn ?? spawnCodexAppServer)(options.home),
+      (options.spawn ?? spawnCodexAppServer)(options.home, CODEX_ACCOUNT_APP_SERVER_ARGS),
       options.clock ?? defaultClock,
       options.requestTimeoutMs ?? DEFAULT_TIMEOUT_MS,
       options.shutdownGraceMs ?? DEFAULT_SHUTDOWN_GRACE_MS,

--- a/src/lib/accounts/migration/contracts.ts
+++ b/src/lib/accounts/migration/contracts.ts
@@ -1,4 +1,5 @@
 import type { AgentEngine } from "@/lib/agent/cli";
+import { normalizeSpawnMcpServers } from "@/lib/agent/mcpAllowlist";
 import type { StructuredImageRef } from "@/lib/runtime/structuredContent";
 import type { AgentGoal, AgentPlan, EngineLimits, LimitsProvenance } from "@/lib/types";
 
@@ -56,6 +57,7 @@ export interface LaunchProfile {
   permissionMode: string | null;
   readOnly: boolean | null;
   allowSubagents: boolean;
+  mcpServers: string[];
   title: string | null;
   project: string | null;
   parentConversationId: ViewerConversationId | null;
@@ -65,6 +67,7 @@ export interface LaunchProfile {
 }
 
 export function emptyLaunchProfile(overrides: Partial<LaunchProfile> = {}): LaunchProfile {
+  const mcpServers = normalizeSpawnMcpServers(overrides.mcpServers);
   return {
     cwd: "",
     model: null,
@@ -80,6 +83,7 @@ export function emptyLaunchProfile(overrides: Partial<LaunchProfile> = {}): Laun
     goal: null,
     plan: null,
     ...overrides,
+    mcpServers: mcpServers.ok ? mcpServers.value : ["viewer"],
   };
 }
 

--- a/src/lib/agent/attachCommand.ts
+++ b/src/lib/agent/attachCommand.ts
@@ -60,10 +60,11 @@ export type AttachResolution =
 
 export interface AttachResolverDeps {
   files: FileEntry[];
-  resumeSpecFor: (root: string, path: string, options?: { model?: string | null; effort?: string | null; allowSubagents?: boolean }) => ResumeSpec | null;
+  resumeSpecFor: (root: string, path: string, options?: { model?: string | null; effort?: string | null; allowSubagents?: boolean; mcpServers?: readonly string[] }) => ResumeSpec | null;
   accountIdForPath: (path: string) => string;
   accountLabelFor: (engine: AgentEngine, accountId: string) => string;
   allowSubagentsForPath?: (path: string) => boolean | undefined;
+  mcpServersForPath?: (path: string) => readonly string[] | undefined;
 }
 
 /**
@@ -83,6 +84,7 @@ export function resolveAttachCommand(path: string, deps: AttachResolverDeps): At
     model: target.entry.launchModel ?? target.entry.model,
     effort: target.entry.effort,
     allowSubagents: deps.allowSubagentsForPath?.(target.entry.path),
+    mcpServers: deps.mcpServersForPath?.(target.entry.path),
   });
   if (!spec) return { ok: false, error: "this conversation cannot be attached", status: 409 };
 

--- a/src/lib/agent/cli.integration.test.ts
+++ b/src/lib/agent/cli.integration.test.ts
@@ -4,17 +4,20 @@ import path from "node:path";
 import { afterAll, expect, test } from "bun:test";
 
 import { buildPipeline, PIPELINES_SCHEMA_VERSION } from "@/lib/pipelines/store";
-import { prepareCodexIntegrationTestHome } from "@/lib/runtime/integrationTestHome";
+import { prepareClaudeIntegrationTestHome, prepareCodexIntegrationTestHome } from "@/lib/runtime/integrationTestHome";
 
 import { freshSpecFor, shellQuote } from "./cli";
 
 const codexBinary = process.env.LLV_CODEX_BINARY ?? "codex";
 const defaultHome = prepareCodexIntegrationTestHome(codexBinary);
 const customHome = prepareCodexIntegrationTestHome(codexBinary);
+const claudeBinary = process.env.LLV_CLAUDE_BINARY ?? "claude";
+const claudeProjectHome = prepareClaudeIntegrationTestHome(claudeBinary);
 
 afterAll(() => {
   defaultHome?.cleanup();
   customHome?.cleanup();
+  claudeProjectHome?.cleanup();
 });
 
 function processIdentity(pid: number): string | null {
@@ -58,7 +61,7 @@ async function expectProcessesReaped(processes: ReadonlyMap<number, string>): Pr
     await Bun.sleep(25);
   }
   const survivors = [...processes].filter(([pid, identity]) => processIdentity(pid) === identity).map(([pid]) => pid);
-  throw new Error(`tmux Codex processes survived shutdown: ${survivors.join(",")}`);
+  throw new Error(`tmux MCP processes survived shutdown: ${survivors.join(",")}`);
 }
 
 async function runTmux(tmuxTmpdir: string, args: string[]): Promise<{ code: number; stdout: string; stderr: string }> {
@@ -89,7 +92,24 @@ async function waitFor<T>(read: () => T | null, timeoutMs = 120_000): Promise<T>
     if (value !== null) return value;
     await Bun.sleep(100);
   }
-  throw new Error("native tmux Codex fixture timed out");
+  throw new Error("native tmux MCP fixture timed out");
+}
+
+function nativeClaudeMcpResult(filename: string, server: string, pipelineId: string): string | null {
+  if (!fs.existsSync(filename)) return null;
+  let sawTool = false;
+  let sawResult = false;
+  for (const line of fs.readFileSync(filename, "utf8").split("\n")) {
+    try {
+      const serialized = JSON.stringify(JSON.parse(line));
+      if (serialized.includes('"type":"tool_use"') && serialized.includes(`"name":"mcp__${server}__get_pipeline"`)) sawTool = true;
+      if (serialized.includes('"tool_use_result"')
+        && serialized.includes(pipelineId)
+        && !serialized.includes("Permission to use")
+        && !serialized.includes("has been denied")) sawResult = true;
+    } catch { /* a partial transcript line remains pending */ }
+  }
+  return sawTool && sawResult ? filename : null;
 }
 
 function nativeMcpResult(home: string, server: string, pipelineId: string): string | null {
@@ -238,4 +258,124 @@ test.skipIf(!defaultHome)("real default tmux Codex exposes Viewer, excludes othe
 test.skipIf(!customHome)("real custom tmux Codex enables the optional server, force-enables Viewer, excludes sentinels, and reaps its MCP processes", async () => {
   if (!customHome) throw new Error("isolated Codex subscription home is unavailable");
   await exerciseTmuxCodex({ home: customHome, mcpServers: ["agent-browser"], expectedServer: "agent-browser" });
+}, 300_000);
+
+test.skipIf(!claudeProjectHome)("real tmux Claude loads an allowed project MCP server, excludes its project sentinel, and reaps the fleet", async () => {
+  if (!claudeProjectHome) throw new Error("isolated Claude subscription home is unavailable");
+  const projectRoot = path.join(claudeProjectHome.directory, "project");
+  const stateDir = path.join(claudeProjectHome.directory, "viewer-state");
+  const viewerPidPath = path.join(claudeProjectHome.directory, "viewer-pid");
+  const optionalPidPath = path.join(claudeProjectHome.directory, "optional-pid");
+  const unrelatedPath = path.join(claudeProjectHome.directory, "project-unrelated-started");
+  const viewerWrapperPath = path.join(claudeProjectHome.directory, "viewer-mcp.ts");
+  const optionalWrapperPath = path.join(claudeProjectHome.directory, "optional-mcp.ts");
+  const unrelatedServerPath = path.join(claudeProjectHome.directory, "project-unrelated-mcp.ts");
+  const viewerLauncher = path.resolve(import.meta.dir, "../../../bin/mcp-server.mjs");
+  const bun = Bun.which("bun") ?? "bun";
+  const pipeline = buildPipeline({
+    id: `tmux-claude-project-${path.basename(claudeProjectHome.directory)}`,
+    task: "Prove native tmux Claude project MCP isolation",
+    project: "live-log-viewer-next",
+    repoDir: projectRoot,
+    stages: [{
+      id: "proof",
+      kind: "run",
+      "prompt": "Exercise project MCP",
+      next: null,
+      onFail: null,
+      effectiveRole: { roleId: null, engine: "claude", model: "haiku", effort: "low", access: "read-only", promptScaffold: null },
+    }],
+    srcPath: null,
+    srcConversationId: null,
+    now: "2026-07-23T00:00:00.000Z",
+    state: "draft",
+  });
+  fs.mkdirSync(path.join(projectRoot, ".git"), { recursive: true, mode: 0o700 });
+  fs.mkdirSync(stateDir, { recursive: true, mode: 0o700 });
+  fs.writeFileSync(path.join(stateDir, "pipelines.json"), JSON.stringify({
+    schemaVersion: PIPELINES_SCHEMA_VERSION,
+    pipelines: [pipeline],
+  }), { mode: 0o600 });
+  const wrapper = (markerPath: string) => [
+    `await Bun.write(${JSON.stringify(markerPath)}, String(process.pid));`,
+    `const child = Bun.spawn({ cmd: [${JSON.stringify(bun)}, ${JSON.stringify(viewerLauncher)}], stdin: "inherit", stdout: "inherit", stderr: "inherit", env: process.env });`,
+    'process.on("SIGTERM", () => child.kill("SIGTERM"));',
+    'process.on("SIGINT", () => child.kill("SIGINT"));',
+    "process.exitCode = await child.exited;",
+    "",
+  ].join("\n");
+  fs.writeFileSync(viewerWrapperPath, wrapper(viewerPidPath), { mode: 0o600 });
+  fs.writeFileSync(optionalWrapperPath, wrapper(optionalPidPath), { mode: 0o600 });
+  fs.writeFileSync(unrelatedServerPath, `await Bun.write(${JSON.stringify(unrelatedPath)}, String(process.pid));\nprocess.stdin.resume();\n`, { mode: 0o600 });
+  fs.writeFileSync(path.join(claudeProjectHome.claudeConfigDir, "settings.json"), JSON.stringify({
+    enabledMcpjsonServers: ["agent-browser"],
+  }), { mode: 0o600 });
+  fs.writeFileSync(path.join(claudeProjectHome.directory, ".claude.json"), JSON.stringify({
+    hasCompletedOnboarding: true,
+    mcpServers: {
+      viewer: { type: "stdio", command: bun, args: [viewerWrapperPath], env: { LLV_STATE_DIR: stateDir } },
+    },
+  }), { mode: 0o600 });
+  fs.writeFileSync(path.join(projectRoot, ".mcp.json"), JSON.stringify({
+    mcpServers: {
+      "agent-browser": {
+        type: "stdio",
+        command: bun,
+        args: [optionalWrapperPath],
+        env: { LLV_STATE_DIR: stateDir, PROJECT_AUTH: "preserved" },
+        timeout: 120_000,
+        alwaysLoad: true,
+      },
+      "project-unrelated": { type: "stdio", command: bun, args: [unrelatedServerPath] },
+    },
+  }), { mode: 0o600 });
+
+  const tmuxTmpdir = fs.mkdtempSync(path.join(os.tmpdir(), "llv-claude-tmux-mcp-"));
+  fs.chmodSync(tmuxTmpdir, 0o700);
+  const session = `claude-mcp-${crypto.randomUUID().slice(0, 8)}`;
+  let processes = new Map<number, string>();
+  try {
+    const created = await runTmux(tmuxTmpdir, ["new-session", "-d", "-x", "180", "-y", "50", "-s", session, "-c", projectRoot]);
+    if (created.code !== 0) throw new Error(created.stderr || "tmux session creation failed");
+    const spec = freshSpecFor("claude", projectRoot, {
+      claudeConfigDir: claudeProjectHome.claudeConfigDir,
+      claudeProjectsDir: claudeProjectHome.claudeProjectsDir,
+      model: "haiku",
+      permissionMode: "bypassPermissions",
+      mcpServers: ["agent-browser"],
+    });
+    const sessionId = path.basename(spec.transcript!, ".jsonl");
+    const mcpConfig = JSON.parse(fs.readFileSync(path.join(
+      claudeProjectHome.claudeConfigDir,
+      ".llv",
+      "spawn-mcp",
+      `${sessionId}.json`,
+    ), "utf8")) as { mcpServers: Record<string, unknown> };
+    expect(mcpConfig.mcpServers["agent-browser"]).toMatchObject({
+      env: { PROJECT_AUTH: "preserved" },
+      timeout: 120_000,
+      alwaysLoad: true,
+    });
+    expect(mcpConfig.mcpServers).not.toHaveProperty("project-unrelated");
+    const prompt = `Call the native agent-browser MCP tool get_pipeline with clientRequestId "tmux-claude-project" and pipelineId "${pipeline.id}". Shell execution is prohibited. Reply after the successful result.`;
+    const launched = await runTmux(tmuxTmpdir, ["send-keys", "-t", `${session}:0.0`, "-l", `${spec.command} ${shellQuote(prompt)}`]);
+    if (launched.code !== 0) throw new Error(launched.stderr || "tmux command delivery failed");
+    await runTmux(tmuxTmpdir, ["send-keys", "-t", `${session}:0.0`, "Enter"]);
+    await waitFor(() => nativeClaudeMcpResult(spec.transcript!, "agent-browser", pipeline.id));
+    expect(fs.existsSync(viewerPidPath)).toBeTrue();
+    expect(fs.existsSync(optionalPidPath)).toBeTrue();
+    expect(fs.existsSync(unrelatedPath)).toBeFalse();
+    const pane = await runTmux(tmuxTmpdir, ["display-message", "-p", "-t", `${session}:0.0`, "#{pane_pid}"]);
+    const panePid = Number(pane.stdout.trim());
+    if (!Number.isInteger(panePid)) throw new Error("tmux pane pid is unavailable");
+    processes = processTree(panePid);
+    addRecordedProcess(processes, viewerPidPath);
+    addRecordedProcess(processes, optionalPidPath);
+    await runTmux(tmuxTmpdir, ["kill-server"]);
+    await expectProcessesReaped(processes);
+    expect(fs.existsSync(unrelatedPath)).toBeFalse();
+  } finally {
+    await runTmux(tmuxTmpdir, ["kill-server"]);
+    fs.rmSync(tmuxTmpdir, { recursive: true, force: true });
+  }
 }, 300_000);

--- a/src/lib/agent/cli.integration.test.ts
+++ b/src/lib/agent/cli.integration.test.ts
@@ -1,0 +1,241 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, expect, test } from "bun:test";
+
+import { buildPipeline, PIPELINES_SCHEMA_VERSION } from "@/lib/pipelines/store";
+import { prepareCodexIntegrationTestHome } from "@/lib/runtime/integrationTestHome";
+
+import { freshSpecFor, shellQuote } from "./cli";
+
+const codexBinary = process.env.LLV_CODEX_BINARY ?? "codex";
+const defaultHome = prepareCodexIntegrationTestHome(codexBinary);
+const customHome = prepareCodexIntegrationTestHome(codexBinary);
+
+afterAll(() => {
+  defaultHome?.cleanup();
+  customHome?.cleanup();
+});
+
+function processIdentity(pid: number): string | null {
+  try {
+    const stat = fs.readFileSync(`/proc/${pid}/stat`, "utf8");
+    const close = stat.lastIndexOf(")");
+    const fields = stat.slice(close + 2).trim().split(/\s+/);
+    return `${pid}:${fields[19] ?? ""}`;
+  } catch {
+    return null;
+  }
+}
+
+function processTree(rootPid: number): Map<number, string> {
+  const identities = new Map<number, string>();
+  const pending = [rootPid];
+  while (pending.length > 0) {
+    const pid = pending.pop()!;
+    if (identities.has(pid)) continue;
+    const identity = processIdentity(pid);
+    if (!identity) continue;
+    identities.set(pid, identity);
+    try {
+      const children = fs.readFileSync(`/proc/${pid}/task/${pid}/children`, "utf8").trim();
+      for (const child of children.split(/\s+/)) if (child) pending.push(Number(child));
+    } catch { /* the process exited during the snapshot */ }
+  }
+  return identities;
+}
+
+function addRecordedProcess(processes: Map<number, string>, markerPath: string): void {
+  const pid = Number(fs.readFileSync(markerPath, "utf8"));
+  const identity = processIdentity(pid);
+  if (!Number.isInteger(pid) || !identity) throw new Error(`recorded MCP process is unavailable: ${markerPath}`);
+  for (const [childPid, childIdentity] of processTree(pid)) processes.set(childPid, childIdentity);
+}
+
+async function expectProcessesReaped(processes: ReadonlyMap<number, string>): Promise<void> {
+  for (let attempt = 0; attempt < 120; attempt += 1) {
+    if ([...processes].every(([pid, identity]) => processIdentity(pid) !== identity)) return;
+    await Bun.sleep(25);
+  }
+  const survivors = [...processes].filter(([pid, identity]) => processIdentity(pid) === identity).map(([pid]) => pid);
+  throw new Error(`tmux Codex processes survived shutdown: ${survivors.join(",")}`);
+}
+
+async function runTmux(tmuxTmpdir: string, args: string[]): Promise<{ code: number; stdout: string; stderr: string }> {
+  const child = Bun.spawn(["tmux", ...args], {
+    env: { ...process.env, TMUX_TMPDIR: tmuxTmpdir },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [code, stdout, stderr] = await Promise.all([
+    child.exited,
+    new Response(child.stdout).text(),
+    new Response(child.stderr).text(),
+  ]);
+  return { code, stdout, stderr };
+}
+
+function filesBelow(root: string): string[] {
+  if (!fs.existsSync(root)) return [];
+  return fs.readdirSync(root, { recursive: true, withFileTypes: true })
+    .filter((entry) => entry.isFile() && entry.name.endsWith(".jsonl"))
+    .map((entry) => path.join(entry.parentPath, entry.name));
+}
+
+async function waitFor<T>(read: () => T | null, timeoutMs = 120_000): Promise<T> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const value = read();
+    if (value !== null) return value;
+    await Bun.sleep(100);
+  }
+  throw new Error("native tmux Codex fixture timed out");
+}
+
+function nativeMcpResult(home: string, server: string, pipelineId: string): string | null {
+  for (const filename of filesBelow(path.join(home, "sessions"))) {
+    const contents = fs.readFileSync(filename, "utf8");
+    for (const line of contents.split("\n")) {
+      if (!line.includes('"type":"mcp_tool_call_end"')) continue;
+      try {
+        const event = JSON.parse(line) as {
+          payload?: { invocation?: { server?: string; tool?: string }; result?: unknown };
+        };
+        if (event.payload?.invocation?.server === server
+          && event.payload.invocation.tool === "get_pipeline"
+          && JSON.stringify(event.payload.result).includes(pipelineId)) return filename;
+      } catch { /* a partial rollout line remains pending */ }
+    }
+  }
+  return null;
+}
+
+function configureMcpFixture(home: NonNullable<typeof defaultHome>): {
+  pipelineId: string;
+  viewerPidPath: string;
+  optionalPidPath: string;
+  unrelatedPath: string;
+} {
+  const pipeline = buildPipeline({
+    id: `tmux-mcp-${path.basename(home.directory)}`,
+    task: "Prove native tmux Codex MCP isolation",
+    project: "live-log-viewer-next",
+    repoDir: process.cwd(),
+    stages: [{
+      id: "proof",
+      kind: "run",
+      "prompt": "Exercise Viewer MCP",
+      next: null,
+      onFail: null,
+      effectiveRole: { roleId: null, engine: "codex", model: "gpt-5.6-terra", effort: "low", access: "read-only", promptScaffold: null },
+    }],
+    srcPath: null,
+    srcConversationId: null,
+    now: "2026-07-23T00:00:00.000Z",
+    state: "draft",
+  });
+  const stateDir = path.join(home.directory, "viewer-state");
+  const viewerPidPath = path.join(home.directory, "viewer-pid");
+  const optionalPidPath = path.join(home.directory, "optional-pid");
+  const unrelatedPath = path.join(home.directory, "unrelated-started");
+  const viewerWrapperPath = path.join(home.directory, "viewer-mcp.ts");
+  const optionalWrapperPath = path.join(home.directory, "optional-mcp.ts");
+  const unrelatedServerPath = path.join(home.directory, "unrelated-mcp.ts");
+  const viewerLauncher = path.resolve(import.meta.dir, "../../../bin/mcp-server.mjs");
+  const bun = Bun.which("bun") ?? "bun";
+  fs.mkdirSync(stateDir, { recursive: true, mode: 0o700 });
+  fs.writeFileSync(path.join(stateDir, "pipelines.json"), JSON.stringify({
+    schemaVersion: PIPELINES_SCHEMA_VERSION,
+    pipelines: [pipeline],
+  }), { mode: 0o600 });
+  const wrapper = (markerPath: string) => [
+    `await Bun.write(${JSON.stringify(markerPath)}, String(process.pid));`,
+    `const child = Bun.spawn({ cmd: [${JSON.stringify(bun)}, ${JSON.stringify(viewerLauncher)}], stdin: "inherit", stdout: "inherit", stderr: "inherit", env: process.env });`,
+    'process.on("SIGTERM", () => child.kill("SIGTERM"));',
+    'process.on("SIGINT", () => child.kill("SIGINT"));',
+    "process.exitCode = await child.exited;",
+    "",
+  ].join("\n");
+  fs.writeFileSync(viewerWrapperPath, wrapper(viewerPidPath), { mode: 0o600 });
+  fs.writeFileSync(optionalWrapperPath, wrapper(optionalPidPath), { mode: 0o600 });
+  fs.writeFileSync(unrelatedServerPath, `await Bun.write(${JSON.stringify(unrelatedPath)}, String(process.pid));\nprocess.stdin.resume();\n`, { mode: 0o600 });
+  fs.writeFileSync(path.join(home.codexHome, "config.toml"), [
+    "approval_policy = \"never\"",
+    "sandbox_mode = \"read-only\"",
+    `[projects.${JSON.stringify(process.cwd())}]`,
+    'trust_level = "trusted"',
+    "[mcp_servers.viewer]",
+    `command = ${JSON.stringify(bun)}`,
+    `args = [${JSON.stringify(viewerWrapperPath)}]`,
+    'default_tools_approval_mode = "approve"',
+    "[mcp_servers.viewer.env]",
+    `LLV_STATE_DIR = ${JSON.stringify(stateDir)}`,
+    "[mcp_servers.agent-browser]",
+    `command = ${JSON.stringify(bun)}`,
+    `args = [${JSON.stringify(optionalWrapperPath)}]`,
+    'default_tools_approval_mode = "approve"',
+    "[mcp_servers.agent-browser.env]",
+    `LLV_STATE_DIR = ${JSON.stringify(stateDir)}`,
+    "[mcp_servers.unrelated]",
+    `command = ${JSON.stringify(bun)}`,
+    `args = [${JSON.stringify(unrelatedServerPath)}]`,
+    "",
+  ].join("\n"), { mode: 0o600 });
+  return { pipelineId: pipeline.id, viewerPidPath, optionalPidPath, unrelatedPath };
+}
+
+async function exerciseTmuxCodex(input: {
+  home: NonNullable<typeof defaultHome>;
+  mcpServers?: string[];
+  expectedServer: "viewer" | "agent-browser";
+}): Promise<void> {
+  const fixture = configureMcpFixture(input.home);
+  const tmuxTmpdir = fs.mkdtempSync(path.join(os.tmpdir(), "llv-codex-tmux-mcp-"));
+  fs.chmodSync(tmuxTmpdir, 0o700);
+  const session = `mcp-${crypto.randomUUID().slice(0, 8)}`;
+  let processes = new Map<number, string>();
+  try {
+    const created = await runTmux(tmuxTmpdir, ["new-session", "-d", "-x", "180", "-y", "50", "-s", session, "-c", process.cwd()]);
+    if (created.code !== 0) throw new Error(created.stderr || "tmux session creation failed");
+    const spec = freshSpecFor("codex", process.cwd(), {
+      codexHome: input.home.codexHome,
+      model: "gpt-5.6-terra",
+      effort: "low",
+      readOnly: true,
+      mcpServers: input.mcpServers,
+    });
+    const prompt = `Call the native ${input.expectedServer} MCP tool get_pipeline with clientRequestId "tmux-${input.expectedServer}" and pipelineId "${fixture.pipelineId}". Shell execution is prohibited. Reply after the successful result.`;
+    const launched = await runTmux(tmuxTmpdir, ["send-keys", "-t", `${session}:0.0`, "-l", `${spec.command} ${shellQuote(prompt)}`]);
+    if (launched.code !== 0) throw new Error(launched.stderr || "tmux command delivery failed");
+    await runTmux(tmuxTmpdir, ["send-keys", "-t", `${session}:0.0`, "Enter"]);
+    await waitFor(() => nativeMcpResult(input.home.codexHome, input.expectedServer, fixture.pipelineId));
+    expect(fs.existsSync(fixture.viewerPidPath)).toBeTrue();
+    expect(fs.existsSync(fixture.unrelatedPath)).toBeFalse();
+    if (input.expectedServer === "viewer") expect(fs.existsSync(fixture.optionalPidPath)).toBeFalse();
+    else expect(fs.existsSync(fixture.optionalPidPath)).toBeTrue();
+    const pane = await runTmux(tmuxTmpdir, ["display-message", "-p", "-t", `${session}:0.0`, "#{pane_pid}"]);
+    const panePid = Number(pane.stdout.trim());
+    if (!Number.isInteger(panePid)) throw new Error("tmux pane pid is unavailable");
+    processes = processTree(panePid);
+    addRecordedProcess(processes, fixture.viewerPidPath);
+    if (input.expectedServer === "agent-browser") addRecordedProcess(processes, fixture.optionalPidPath);
+    await runTmux(tmuxTmpdir, ["send-keys", "-t", `${session}:0.0`, "C-c"]);
+    await Bun.sleep(250);
+    await runTmux(tmuxTmpdir, ["kill-server"]);
+    await expectProcessesReaped(processes);
+    expect(fs.existsSync(fixture.unrelatedPath)).toBeFalse();
+  } finally {
+    await runTmux(tmuxTmpdir, ["kill-server"]);
+    fs.rmSync(tmuxTmpdir, { recursive: true, force: true });
+  }
+}
+
+test.skipIf(!defaultHome)("real default tmux Codex exposes Viewer, excludes other servers, and reaps its MCP processes", async () => {
+  if (!defaultHome) throw new Error("isolated Codex subscription home is unavailable");
+  await exerciseTmuxCodex({ home: defaultHome, expectedServer: "viewer" });
+}, 300_000);
+
+test.skipIf(!customHome)("real custom tmux Codex enables the optional server, force-enables Viewer, excludes sentinels, and reaps its MCP processes", async () => {
+  if (!customHome) throw new Error("isolated Codex subscription home is unavailable");
+  await exerciseTmuxCodex({ home: customHome, mcpServers: ["agent-browser"], expectedServer: "agent-browser" });
+}, 300_000);

--- a/src/lib/agent/cli.integration.test.ts
+++ b/src/lib/agent/cli.integration.test.ts
@@ -11,12 +11,14 @@ import { freshSpecFor, shellQuote } from "./cli";
 const codexBinary = process.env.LLV_CODEX_BINARY ?? "codex";
 const defaultHome = prepareCodexIntegrationTestHome(codexBinary);
 const customHome = prepareCodexIntegrationTestHome(codexBinary);
+const layeredHome = prepareCodexIntegrationTestHome(codexBinary);
 const claudeBinary = process.env.LLV_CLAUDE_BINARY ?? "claude";
 const claudeProjectHome = prepareClaudeIntegrationTestHome(claudeBinary);
 
 afterAll(() => {
   defaultHome?.cleanup();
   customHome?.cleanup();
+  layeredHome?.cleanup();
   claudeProjectHome?.cleanup();
 });
 
@@ -97,19 +99,28 @@ async function waitFor<T>(read: () => T | null, timeoutMs = 120_000): Promise<T>
 
 function nativeClaudeMcpResult(filename: string, server: string, pipelineId: string): string | null {
   if (!fs.existsSync(filename)) return null;
-  let sawTool = false;
-  let sawResult = false;
+  const toolUseIds = new Set<string>();
   for (const line of fs.readFileSync(filename, "utf8").split("\n")) {
     try {
-      const serialized = JSON.stringify(JSON.parse(line));
-      if (serialized.includes('"type":"tool_use"') && serialized.includes(`"name":"mcp__${server}__get_pipeline"`)) sawTool = true;
-      if (serialized.includes('"tool_use_result"')
-        && serialized.includes(pipelineId)
-        && !serialized.includes("Permission to use")
-        && !serialized.includes("has been denied")) sawResult = true;
+      const event = JSON.parse(line) as {
+        message?: { content?: Array<{ type?: unknown; id?: unknown; name?: unknown; tool_use_id?: unknown; content?: unknown }> };
+      };
+      if (!Array.isArray(event.message?.content)) continue;
+      for (const content of event.message.content) {
+        if (content.type === "tool_use"
+          && content.name === `mcp__${server}__get_pipeline`
+          && typeof content.id === "string") toolUseIds.add(content.id);
+        if (content.type !== "tool_result"
+          || typeof content.tool_use_id !== "string"
+          || !toolUseIds.has(content.tool_use_id)) continue;
+        const serialized = JSON.stringify(content.content);
+        if (serialized.includes(pipelineId)
+          && !serialized.includes("Permission to use")
+          && !serialized.includes("has been denied")) return filename;
+      }
     } catch { /* a partial transcript line remains pending */ }
   }
-  return sawTool && sawResult ? filename : null;
+  return null;
 }
 
 function nativeMcpResult(home: string, server: string, pipelineId: string): string | null {
@@ -255,6 +266,33 @@ test.skipIf(!defaultHome)("real default tmux Codex exposes Viewer, excludes othe
   await exerciseTmuxCodex({ home: defaultHome, expectedServer: "viewer" });
 }, 300_000);
 
+test.skipIf(!layeredHome)("native Codex enumeration enforces the allowlist for trusted project configuration", () => {
+  if (!layeredHome) throw new Error("isolated Codex subscription home is unavailable");
+  const projectRoot = path.join(layeredHome.directory, "trusted-project");
+  fs.mkdirSync(path.join(projectRoot, ".git"), { recursive: true, mode: 0o700 });
+  fs.mkdirSync(path.join(projectRoot, ".codex"), { recursive: true, mode: 0o700 });
+  fs.writeFileSync(path.join(layeredHome.codexHome, "config.toml"), [
+    `[projects.${JSON.stringify(projectRoot)}]`,
+    'trust_level = "trusted"',
+    "",
+  ].join("\n"), { mode: 0o600 });
+  fs.writeFileSync(path.join(projectRoot, ".codex", "config.toml"), [
+    "[mcp_servers.project-allowed]",
+    'command = "/bin/true"',
+    "[mcp_servers.project-unrelated]",
+    'command = "/bin/true"',
+    "",
+  ].join("\n"), { mode: 0o600 });
+
+  const spec = freshSpecFor("codex", projectRoot, {
+    codexHome: layeredHome.codexHome,
+    mcpServers: ["project-allowed"],
+  });
+
+  expect(spec.command).toContain("'mcp_servers.project-allowed.enabled=true'");
+  expect(spec.command).toContain("'mcp_servers.project-unrelated.enabled=false'");
+});
+
 test.skipIf(!customHome)("real custom tmux Codex enables the optional server, force-enables Viewer, excludes sentinels, and reaps its MCP processes", async () => {
   if (!customHome) throw new Error("isolated Codex subscription home is unavailable");
   await exerciseTmuxCodex({ home: customHome, mcpServers: ["agent-browser"], expectedServer: "agent-browser" });
@@ -310,12 +348,21 @@ test.skipIf(!claudeProjectHome)("real tmux Claude loads an allowed project MCP s
   fs.writeFileSync(path.join(claudeProjectHome.claudeConfigDir, "settings.json"), JSON.stringify({
     enabledMcpjsonServers: ["agent-browser"],
   }), { mode: 0o600 });
-  fs.writeFileSync(path.join(claudeProjectHome.directory, ".claude.json"), JSON.stringify({
+  const nativeState = {
     hasCompletedOnboarding: true,
+    bypassPermissionsModeAccepted: true,
+    projects: {
+      [projectRoot]: {
+        hasTrustDialogAccepted: true,
+        hasCompletedProjectOnboarding: true,
+      },
+    },
     mcpServers: {
       viewer: { type: "stdio", command: bun, args: [viewerWrapperPath], env: { LLV_STATE_DIR: stateDir } },
     },
-  }), { mode: 0o600 });
+  };
+  fs.writeFileSync(path.join(claudeProjectHome.directory, ".claude.json"), JSON.stringify(nativeState), { mode: 0o600 });
+  fs.writeFileSync(path.join(claudeProjectHome.claudeConfigDir, ".claude.json"), JSON.stringify(nativeState), { mode: 0o600 });
   fs.writeFileSync(path.join(projectRoot, ".mcp.json"), JSON.stringify({
     mcpServers: {
       "agent-browser": {
@@ -351,17 +398,32 @@ test.skipIf(!claudeProjectHome)("real tmux Claude loads an allowed project MCP s
       "spawn-mcp",
       `${sessionId}.json`,
     ), "utf8")) as { mcpServers: Record<string, unknown> };
+    const launchSettings = JSON.parse(fs.readFileSync(path.join(
+      claudeProjectHome.claudeConfigDir,
+      ".llv",
+      "spawn-settings",
+      `${sessionId}.json`,
+    ), "utf8")) as { enabledMcpjsonServers?: string[]; disabledMcpjsonServers?: string[] };
     expect(mcpConfig.mcpServers["agent-browser"]).toMatchObject({
       env: { PROJECT_AUTH: "preserved" },
       timeout: 120_000,
       alwaysLoad: true,
     });
     expect(mcpConfig.mcpServers).not.toHaveProperty("project-unrelated");
-    const prompt = `Call the native agent-browser MCP tool get_pipeline with clientRequestId "tmux-claude-project" and pipelineId "${pipeline.id}". Shell execution is prohibited. Reply after the successful result.`;
-    const launched = await runTmux(tmuxTmpdir, ["send-keys", "-t", `${session}:0.0`, "-l", `${spec.command} ${shellQuote(prompt)}`]);
+    expect(launchSettings.enabledMcpjsonServers).toEqual(["agent-browser"]);
+    expect(launchSettings.disabledMcpjsonServers).toEqual(["project-unrelated"]);
+    const prompt = `Call the exact native tool mcp__agent-browser__get_pipeline with clientRequestId "tmux-claude-project" and pipelineId "${pipeline.id}". Do not use mcp__viewer__get_pipeline or shell execution. Reply after the successful result.`;
+    const isolatedCommand = `env HOME=${shellQuote(claudeProjectHome.directory)} CLAUDE_CONFIG_DIR=${shellQuote(claudeProjectHome.claudeConfigDir)} ${spec.command}`;
+    const launched = await runTmux(tmuxTmpdir, ["send-keys", "-t", `${session}:0.0`, "-l", `${isolatedCommand} -- ${shellQuote(prompt)}`]);
     if (launched.code !== 0) throw new Error(launched.stderr || "tmux command delivery failed");
     await runTmux(tmuxTmpdir, ["send-keys", "-t", `${session}:0.0`, "Enter"]);
-    await waitFor(() => nativeClaudeMcpResult(spec.transcript!, "agent-browser", pipeline.id));
+    try {
+      await waitFor(() => nativeClaudeMcpResult(spec.transcript!, "agent-browser", pipeline.id));
+    } catch (error) {
+      const pane = await runTmux(tmuxTmpdir, ["capture-pane", "-p", "-S", "-200", "-t", `${session}:0.0`]);
+      const transcript = fs.existsSync(spec.transcript!) ? fs.readFileSync(spec.transcript!, "utf8") : "<missing>";
+      throw new Error(`${String(error)}\n--- tmux pane ---\n${pane.stdout}${pane.stderr}\n--- transcript ---\n${transcript}`);
+    }
     expect(fs.existsSync(viewerPidPath)).toBeTrue();
     expect(fs.existsSync(optionalPidPath)).toBeTrue();
     expect(fs.existsSync(unrelatedPath)).toBeFalse();

--- a/src/lib/agent/cli.test.ts
+++ b/src/lib/agent/cli.test.ts
@@ -35,6 +35,119 @@ test("fresh Codex commands fix CODEX_HOME in the typed shell command", () => {
   expect(spec.launchProfile?.allowSubagents).toBe(false);
 });
 
+test("fresh tmux Codex commands enforce the normalized MCP allowlist at runtime", () => {
+  const home = path.join(SANDBOX, "codex-mcp-runtime");
+  fs.mkdirSync(home, { recursive: true });
+  fs.writeFileSync(path.join(home, "config.toml"), [
+    "[mcp_servers.viewer]",
+    'command = "viewer-mcp"',
+    "[mcp_servers.agent-browser]",
+    'command = "browser-mcp"',
+    "[mcp_servers.unrelated]",
+    'command = "unrelated-mcp"',
+    "",
+  ].join("\n"));
+
+  const spec = freshSpecFor("codex", "/repo", {
+    codexHome: home,
+    mcpServers: ["agent-browser"],
+  });
+
+  expect(spec.command).toContain("'mcp_servers.viewer.enabled=true'");
+  expect(spec.command).toContain("'mcp_servers.agent-browser.enabled=true'");
+  expect(spec.command).toContain("'mcp_servers.unrelated.enabled=false'");
+  expect(spec.launchProfile?.mcpServers).toEqual(["viewer", "agent-browser"]);
+});
+
+test("fresh tmux Codex defaults disable every configured server outside Viewer", () => {
+  const home = path.join(SANDBOX, "codex-mcp-default");
+  fs.mkdirSync(home, { recursive: true });
+  fs.writeFileSync(path.join(home, "config.toml"), [
+    "[mcp_servers.viewer]",
+    'command = "viewer-mcp"',
+    "[mcp_servers.agent-browser]",
+    'command = "browser-mcp"',
+    "",
+  ].join("\n"));
+
+  const spec = freshSpecFor("codex", "/repo", { codexHome: home });
+
+  expect(spec.command).toContain("'mcp_servers.viewer.enabled=true'");
+  expect(spec.command).toContain("'mcp_servers.agent-browser.enabled=false'");
+  expect(spec.launchProfile?.mcpServers).toEqual(["viewer"]);
+});
+
+test("tmux Codex enumerates MCP servers from the launched working directory", () => {
+  const home = path.join(SANDBOX, "codex-mcp-cwd");
+  const cwd = path.join(SANDBOX, "codex-project");
+  const binary = path.join(SANDBOX, "codex-mcp-list-cwd");
+  const marker = path.join(SANDBOX, "codex-mcp-list.pwd");
+  fs.mkdirSync(home, { recursive: true });
+  fs.mkdirSync(cwd, { recursive: true });
+  fs.writeFileSync(path.join(home, "config.toml"), "[mcp_servers.viewer]\ncommand = \"viewer-mcp\"\n");
+  fs.writeFileSync(binary, `#!/bin/sh\npwd > ${JSON.stringify(marker)}\nprintf '[{"name":"viewer"},{"name":"project-sentinel"}]'\n`);
+  fs.chmodSync(binary, 0o755);
+  const previousBinary = process.env.LLV_CODEX_BINARY;
+  process.env.LLV_CODEX_BINARY = binary;
+  try {
+    const spec = freshSpecFor("codex", cwd, { codexHome: home });
+    expect(fs.readFileSync(marker, "utf8").trim()).toBe(cwd);
+    expect(spec.command).toContain("'mcp_servers.project-sentinel.enabled=false'");
+  } finally {
+    if (previousBinary === undefined) delete process.env.LLV_CODEX_BINARY;
+    else process.env.LLV_CODEX_BINARY = previousBinary;
+  }
+});
+
+test("tmux Codex fails closed when fallback cannot enumerate an inline MCP table", () => {
+  const home = path.join(SANDBOX, "codex-mcp-inline");
+  const binary = path.join(SANDBOX, "codex-mcp-list-failure");
+  fs.mkdirSync(home, { recursive: true });
+  fs.writeFileSync(path.join(home, "config.toml"), [
+    "[mcp_servers.viewer]",
+    'command = "viewer-mcp"',
+    'mcp_servers = { hidden = { command = "hidden-mcp" } }',
+    "",
+  ].join("\n"));
+  fs.writeFileSync(binary, "#!/bin/sh\nexit 1\n");
+  fs.chmodSync(binary, 0o755);
+  const previousBinary = process.env.LLV_CODEX_BINARY;
+  process.env.LLV_CODEX_BINARY = binary;
+  try {
+    expect(() => freshSpecFor("codex", "/repo", { codexHome: home })).toThrow("could not be enumerated safely");
+  } finally {
+    if (previousBinary === undefined) delete process.env.LLV_CODEX_BINARY;
+    else process.env.LLV_CODEX_BINARY = previousBinary;
+  }
+});
+
+test("fresh tmux Claude uses its exclusive native MCP file", () => {
+  const home = path.join(SANDBOX, "claude-mcp-runtime");
+  fs.mkdirSync(home, { recursive: true });
+  fs.writeFileSync(path.join(home, ".claude.json"), JSON.stringify({
+    mcpServers: {
+      viewer: { type: "stdio", command: "viewer-mcp" },
+      "agent-browser": { type: "stdio", command: "browser-mcp" },
+      unrelated: { type: "stdio", command: "unrelated-mcp" },
+    },
+  }));
+
+  const spec = freshSpecFor("claude", "/repo", {
+    claudeConfigDir: home,
+    claudeProjectsDir: path.join(home, "projects"),
+    mcpServers: ["agent-browser"],
+  });
+  const sessionId = path.basename(spec.transcript!, ".jsonl");
+  const mcpConfigPath = path.join(home, ".llv", "spawn-mcp", `${sessionId}.json`);
+
+  expect(spec.command).toContain(`'--strict-mcp-config' '--mcp-config' '${mcpConfigPath}'`);
+  expect(JSON.parse(fs.readFileSync(mcpConfigPath, "utf8"))).toEqual({ mcpServers: {
+    viewer: { type: "stdio", command: "viewer-mcp" },
+    "agent-browser": { type: "stdio", command: "browser-mcp" },
+  } });
+  expect(spec.launchProfile?.mcpServers).toEqual(["viewer", "agent-browser"]);
+});
+
 test("allowSubagents enables Codex multi-agent for fresh and resumed launches", () => {
   const transcript = path.join(SANDBOX, "legacy", "sessions", "2026", "07", "14", "rollout-019f5f2f-743a-7f23-7773-3cf2dd4b4168.jsonl");
   fs.mkdirSync(path.dirname(transcript), { recursive: true });
@@ -75,12 +188,21 @@ test("Codex resume derives its owning account home from the transcript path", ()
   const transcript = path.join(SANDBOX, "legacy", "sessions", "2026", "07", "09", "rollout-019f423a-d6e9-7903-7597-3e676b6ff3d4.jsonl");
   fs.mkdirSync(path.dirname(transcript), { recursive: true });
   fs.writeFileSync(transcript, JSON.stringify({ type: "session_meta", payload: { cwd: SANDBOX } }) + "\n");
+  fs.writeFileSync(path.join(SANDBOX, "legacy", "config.toml"), [
+    "[mcp_servers.viewer]",
+    'command = "viewer-mcp"',
+    "[mcp_servers.unrelated]",
+    'command = "unrelated-mcp"',
+    "",
+  ].join("\n"));
 
   const spec = resumeSpecFor("codex-sessions", transcript);
 
   expect(spec?.command).toStartWith(
     `env -u LLV_TOKEN CODEX_HOME='${path.join(SANDBOX, "legacy")}' `,
   );
+  expect(spec?.command).toContain("'mcp_servers.viewer.enabled=true'");
+  expect(spec?.command).toContain("'mcp_servers.unrelated.enabled=false'");
   expect(spec?.command).toContain("--disable multi_agent");
   expect(spec?.command).toContain("resume 019f423a-d6e9-7903-7597-3e676b6ff3d4");
 });
@@ -99,9 +221,9 @@ test("resume preserves the transcript model and reasoning effort for both engine
   expect(codex?.command).toContain("-m 'gpt-5.6-terra'");
   expect(codex?.command).toContain("model_reasoning_effort=xhigh");
   expect(codex?.command).toContain("CODEX_HOME='");
-  expect(claude?.command).toContain("--model 'opus'");
-  expect(claude?.command).toContain("--effort 'max'");
-  expect(claude?.command).toContain("--dangerously-skip-permissions");
+  expect(claude?.command).toContain("'--model' 'opus'");
+  expect(claude?.command).toContain("'--effort' 'max'");
+  expect(claude?.command).toContain("'--dangerously-skip-permissions'");
   expect(claude?.launchProfile).toMatchObject({ permissionMode: "bypassPermissions" });
 });
 
@@ -117,8 +239,8 @@ test("resume preserves read-only execution policy for both engines", () => {
   expect(codex?.command).toContain("--sandbox read-only");
   expect(codex?.command).toContain("--ask-for-approval 'never'");
   expect(codex?.launchProfile).toMatchObject({ readOnly: true, permissionMode: "never" });
-  expect(claude?.command).toContain("--permission-mode plan --disallowedTools Edit,Write,NotebookEdit");
-  expect(claude?.command).not.toContain("--dangerously-skip-permissions");
+  expect(claude?.command).toContain("'--permission-mode' 'plan' '--disallowedTools' 'Edit,Write,NotebookEdit'");
+  expect(claude?.command).not.toContain("'--dangerously-skip-permissions'");
   expect(claude?.launchProfile).toMatchObject({ readOnly: true, permissionMode: "plan" });
 });
 
@@ -128,9 +250,9 @@ test("Claude resume normalizes transcript families and omits unknown model overr
   fs.writeFileSync(transcript, JSON.stringify({ cwd: SANDBOX }) + "\n");
 
   expect(resumeSpecFor("claude-projects", transcript, { model: "claude-fable-20260701" })?.command)
-    .toContain("--model 'fable'");
+    .toContain("'--model' 'fable'");
   expect(resumeSpecFor("claude-projects", transcript, { model: "mythos-1" })?.command)
-    .not.toContain("--model");
+    .not.toContain("'--model'");
 });
 
 test("managed Codex commands pin file-backed credential storage", () => {
@@ -166,6 +288,7 @@ test("managed Claude fresh and resume commands pin the transcript owner and scru
   expect(settings.hooks.PreToolUse.some((group) => group.matcher === "Task|Agent|Workflow|TeamCreate|TeamDelete|SendMessage")).toBe(true);
   const resumed = resumeSpecFor("claude-projects", transcript)?.command ?? "";
   expect(resumed).toContain(`CLAUDE_CONFIG_DIR='${account.home}'`);
+  expect(resumed).toContain(`'--strict-mcp-config' '--mcp-config' '${path.join(account.home, ".llv", "spawn-mcp", `resume-${sid}.json`)}'`);
   expect(resumed).toContain("--resume");
 });
 

--- a/src/lib/agent/cli.test.ts
+++ b/src/lib/agent/cli.test.ts
@@ -27,7 +27,8 @@ afterAll(() => {
 
 test("fresh Codex commands fix CODEX_HOME in the typed shell command", () => {
   const home = path.join(SANDBOX, "account with space");
-  const spec = freshSpecFor("codex", "/repo", { codexHome: home });
+  fs.mkdirSync(home, { recursive: true });
+  const spec = freshSpecFor("codex", SANDBOX, { codexHome: home });
 
   expect(spec.command).toStartWith(`env -u LLV_TOKEN CODEX_HOME='${home}' `);
   expect(spec.command).toContain("codex");
@@ -48,7 +49,7 @@ test("fresh tmux Codex commands enforce the normalized MCP allowlist at runtime"
     "",
   ].join("\n"));
 
-  const spec = freshSpecFor("codex", "/repo", {
+  const spec = freshSpecFor("codex", SANDBOX, {
     codexHome: home,
     mcpServers: ["agent-browser"],
   });
@@ -70,7 +71,7 @@ test("fresh tmux Codex defaults disable every configured server outside Viewer",
     "",
   ].join("\n"));
 
-  const spec = freshSpecFor("codex", "/repo", { codexHome: home });
+  const spec = freshSpecFor("codex", SANDBOX, { codexHome: home });
 
   expect(spec.command).toContain("'mcp_servers.viewer.enabled=true'");
   expect(spec.command).toContain("'mcp_servers.agent-browser.enabled=false'");
@@ -99,22 +100,79 @@ test("tmux Codex enumerates MCP servers from the launched working directory", ()
   }
 });
 
-test("tmux Codex fails closed when fallback cannot enumerate an inline MCP table", () => {
-  const home = path.join(SANDBOX, "codex-mcp-inline");
-  const binary = path.join(SANDBOX, "codex-mcp-list-failure");
+test("fresh and resumed tmux Codex enumerate project and system MCP servers when user config is absent", () => {
+  const home = process.env.LLV_CODEX_HOME!;
+  const cwd = path.join(SANDBOX, "codex-project-only");
+  const binary = path.join(SANDBOX, "codex-mcp-list-project-only");
+  const marker = path.join(SANDBOX, "codex-mcp-list-project-only.called");
   fs.mkdirSync(home, { recursive: true });
-  fs.writeFileSync(path.join(home, "config.toml"), [
-    "[mcp_servers.viewer]",
-    'command = "viewer-mcp"',
-    'mcp_servers = { hidden = { command = "hidden-mcp" } }',
+  fs.rmSync(path.join(home, "config.toml"), { force: true });
+  fs.mkdirSync(path.join(cwd, ".codex"), { recursive: true });
+  fs.writeFileSync(path.join(cwd, ".codex", "config.toml"), [
+    "[mcp_servers.project-sentinel]",
+    'command = "project-mcp"',
     "",
   ].join("\n"));
+  const transcript = path.join(home, "sessions", "2026", "07", "23", "rollout-019fa1b2-c3d4-0567-8899-aabbccddeeff.jsonl");
+  fs.mkdirSync(path.dirname(transcript), { recursive: true });
+  fs.writeFileSync(transcript, JSON.stringify({ type: "session_meta", payload: { cwd } }) + "\n");
+  fs.writeFileSync(binary, `#!/bin/sh\nprintf called > ${JSON.stringify(marker)}\nprintf '[{"name":"project-sentinel"},{"name":"system-sentinel"}]'\n`);
+  fs.chmodSync(binary, 0o755);
+  const previousBinary = process.env.LLV_CODEX_BINARY;
+  process.env.LLV_CODEX_BINARY = binary;
+  try {
+    const spec = freshSpecFor("codex", cwd, { codexHome: home });
+    expect(fs.existsSync(marker)).toBeTrue();
+    expect(spec.command).toContain("'mcp_servers.project-sentinel.enabled=false'");
+    expect(spec.command).toContain("'mcp_servers.system-sentinel.enabled=false'");
+    const resumed = resumeSpecFor("codex-sessions", transcript);
+    expect(resumed?.command).toContain("'mcp_servers.project-sentinel.enabled=false'");
+    expect(resumed?.command).toContain("'mcp_servers.system-sentinel.enabled=false'");
+  } finally {
+    if (previousBinary === undefined) delete process.env.LLV_CODEX_BINARY;
+    else process.env.LLV_CODEX_BINARY = previousBinary;
+  }
+});
+
+test("fresh and resumed tmux Codex fail closed when layered enumeration fails without user config", () => {
+  const home = process.env.LLV_CODEX_HOME!;
+  const cwd = path.join(SANDBOX, "codex-enumeration-failure");
+  const binary = path.join(SANDBOX, "codex-mcp-list-no-user-failure");
+  const transcript = path.join(home, "sessions", "2026", "07", "23", "rollout-019fa1b2-c3d4-0567-8899-aabbccddee00.jsonl");
+  fs.mkdirSync(cwd, { recursive: true });
+  fs.mkdirSync(path.dirname(transcript), { recursive: true });
+  fs.rmSync(path.join(home, "config.toml"), { force: true });
+  fs.writeFileSync(transcript, JSON.stringify({ type: "session_meta", payload: { cwd } }) + "\n");
   fs.writeFileSync(binary, "#!/bin/sh\nexit 1\n");
   fs.chmodSync(binary, 0o755);
   const previousBinary = process.env.LLV_CODEX_BINARY;
   process.env.LLV_CODEX_BINARY = binary;
   try {
-    expect(() => freshSpecFor("codex", "/repo", { codexHome: home })).toThrow("could not be enumerated safely");
+    expect(() => freshSpecFor("codex", cwd, { codexHome: home })).toThrow("could not be enumerated safely");
+    expect(() => resumeSpecFor("codex-sessions", transcript)).toThrow("could not be enumerated safely");
+  } finally {
+    if (previousBinary === undefined) delete process.env.LLV_CODEX_BINARY;
+    else process.env.LLV_CODEX_BINARY = previousBinary;
+  }
+});
+
+test("tmux Codex rejects invalid native enumeration even when user config is locally parseable", () => {
+  const home = path.join(SANDBOX, "codex-mcp-invalid-native-output");
+  const binary = path.join(SANDBOX, "codex-mcp-list-invalid-output");
+  fs.mkdirSync(home, { recursive: true });
+  fs.writeFileSync(path.join(home, "config.toml"), [
+    "[mcp_servers.viewer]",
+    'command = "viewer-mcp"',
+    "[mcp_servers.unrelated]",
+    'command = "unrelated-mcp"',
+    "",
+  ].join("\n"));
+  fs.writeFileSync(binary, "#!/bin/sh\nprintf invalid-json\n");
+  fs.chmodSync(binary, 0o755);
+  const previousBinary = process.env.LLV_CODEX_BINARY;
+  process.env.LLV_CODEX_BINARY = binary;
+  try {
+    expect(() => freshSpecFor("codex", SANDBOX, { codexHome: home })).toThrow("could not be enumerated safely");
   } finally {
     if (previousBinary === undefined) delete process.env.LLV_CODEX_BINARY;
     else process.env.LLV_CODEX_BINARY = previousBinary;
@@ -153,7 +211,7 @@ test("allowSubagents enables Codex multi-agent for fresh and resumed launches", 
   fs.mkdirSync(path.dirname(transcript), { recursive: true });
   fs.writeFileSync(transcript, JSON.stringify({ type: "session_meta", payload: { cwd: SANDBOX } }) + "\n");
 
-  const fresh = freshSpecFor("codex", "/repo", { allowSubagents: true });
+  const fresh = freshSpecFor("codex", SANDBOX, { allowSubagents: true });
   const resumed = resumeSpecFor("codex-sessions", transcript, { allowSubagents: true });
 
   expect(fresh.command).not.toContain("--disable");
@@ -164,10 +222,10 @@ test("allowSubagents enables Codex multi-agent for fresh and resumed launches", 
 
 test("Viewer spawn capability is scoped into the launched agent command", () => {
   const capability = "A".repeat(43);
-  const spec = withSpawnCapability(freshSpecFor("codex", "/repo"), capability);
+  const spec = withSpawnCapability(freshSpecFor("codex", SANDBOX), capability);
 
   expect(spec.command).toStartWith(`env LLV_SPAWN_CAPABILITY='${capability}' `);
-  expect(spec.launchProfile?.cwd).toBe("/repo");
+  expect(spec.launchProfile?.cwd).toBe(SANDBOX);
 });
 
 test("Claude commands do not gain Codex environment assignments", () => {
@@ -257,7 +315,7 @@ test("Claude resume normalizes transcript families and omits unknown model overr
 
 test("managed Codex commands pin file-backed credential storage", () => {
   const account = createManagedCodexAccount("Review");
-  const fresh = freshSpecFor("codex", "/repo", { codexHome: account.home, model: "gpt-5" });
+  const fresh = freshSpecFor("codex", SANDBOX, { codexHome: account.home, model: "gpt-5" });
   const transcript = path.join(account.sessionsDir, "2026", "07", "09", "rollout-019f423a-d6e9-7903-7597-3e676b6ff3d4.jsonl");
   fs.mkdirSync(path.dirname(transcript), { recursive: true });
   fs.writeFileSync(transcript, JSON.stringify({ type: "session_meta", payload: { cwd: SANDBOX } }) + "\n");

--- a/src/lib/agent/cli.ts
+++ b/src/lib/agent/cli.ts
@@ -126,25 +126,7 @@ function normalizedMcpServers(value: readonly string[] | undefined): string[] {
   return normalized.value;
 }
 
-function configuredCodexMcpServersFromToml(contents: string): string[] | null {
-  if (/^\s*mcp_servers\s*=/m.test(contents)) return null;
-  const names = new Set<string>();
-  const table = /^\s*\[\s*mcp_servers\s*\.\s*("(?:\\.|[^"\\])*"|'[^']*'|[A-Za-z0-9_-]+)(?:\s*\.|\s*\])/;
-  for (const line of contents.split("\n")) {
-    const match = line.match(table);
-    if (!match) continue;
-    const segment = match[1]!;
-    if (segment.startsWith('"')) {
-      try { names.add(JSON.parse(segment) as string); } catch { return null; }
-    } else if (segment.startsWith("'")) names.add(segment.slice(1, -1));
-    else names.add(segment);
-  }
-  return [...names];
-}
-
 function configuredCodexMcpServers(home: string, cwd: string): string[] {
-  const configPath = path.join(home, "config.toml");
-  if (!fs.existsSync(configPath)) return [];
   const env: NodeJS.ProcessEnv = { ...process.env, CODEX_HOME: home };
   delete env.LLV_TOKEN;
   const listed = spawnSync(process.env.LLV_CODEX_BINARY ?? resolveBinary("codex"), ["mcp", "list", "--json"], {
@@ -160,10 +142,8 @@ function configuredCodexMcpServers(home: string, cwd: string): string[] {
       if (Array.isArray(parsed) && parsed.every((server) => server && typeof server === "object" && typeof (server as { name?: unknown }).name === "string")) {
         return parsed.map((server) => (server as { name: string }).name);
       }
-    } catch { /* use the local configuration fallback below */ }
+    } catch { /* fail closed below */ }
   }
-  const fallback = configuredCodexMcpServersFromToml(fs.readFileSync(configPath, "utf8"));
-  if (fallback) return fallback;
   throw new Error("Codex MCP configuration could not be enumerated safely");
 }
 

--- a/src/lib/agent/cli.ts
+++ b/src/lib/agent/cli.ts
@@ -1,4 +1,5 @@
 import crypto from "node:crypto";
+import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -7,6 +8,7 @@ import { accountForSpawn, codexHomeOwningSessionPath, isManagedCodexHome } from 
 import { claudeHomeOwningTranscript, claudeSettingsPath, isManagedClaudeHome, legacyClaudeHome } from "@/lib/accounts/claude";
 
 import { claudeTranscriptPath, headCwd } from "./transcript";
+import { normalizeSpawnMcpServers } from "./mcpAllowlist";
 import { normalizeClaudeLaunchModel } from "./models";
 import { applyClaudeSpawnPolicy, claudeSpawnPolicyPaths, VIEWER_SPAWN_CAPABILITY_ENV } from "./spawnPolicy";
 import type { LaunchProfile } from "@/lib/accounts/migration/contracts";
@@ -98,7 +100,7 @@ export interface FreshSpecOptions {
   claudeProjectsDir?: string | null;
   /** Allow native Claude sub-agents and the Codex multi-agent feature. */
   allowSubagents?: boolean;
-  mcpServers?: string[];
+  mcpServers?: readonly string[];
   /** Route admission owns policy materialization after its durable reservation. */
   deferClaudeSpawnPolicy?: boolean;
 }
@@ -115,6 +117,72 @@ export interface ResumeSpecOptions {
   readOnly?: boolean | null;
   permissionMode?: string | null;
   allowSubagents?: boolean;
+  mcpServers?: readonly string[];
+}
+
+function normalizedMcpServers(value: readonly string[] | undefined): string[] {
+  const normalized = normalizeSpawnMcpServers(value);
+  if (!normalized.ok) throw new Error(normalized.error);
+  return normalized.value;
+}
+
+function configuredCodexMcpServersFromToml(contents: string): string[] | null {
+  if (/^\s*mcp_servers\s*=/m.test(contents)) return null;
+  const names = new Set<string>();
+  const table = /^\s*\[\s*mcp_servers\s*\.\s*("(?:\\.|[^"\\])*"|'[^']*'|[A-Za-z0-9_-]+)(?:\s*\.|\s*\])/;
+  for (const line of contents.split("\n")) {
+    const match = line.match(table);
+    if (!match) continue;
+    const segment = match[1]!;
+    if (segment.startsWith('"')) {
+      try { names.add(JSON.parse(segment) as string); } catch { return null; }
+    } else if (segment.startsWith("'")) names.add(segment.slice(1, -1));
+    else names.add(segment);
+  }
+  return [...names];
+}
+
+function configuredCodexMcpServers(home: string, cwd: string): string[] {
+  const configPath = path.join(home, "config.toml");
+  if (!fs.existsSync(configPath)) return [];
+  const env: NodeJS.ProcessEnv = { ...process.env, CODEX_HOME: home };
+  delete env.LLV_TOKEN;
+  const listed = spawnSync(process.env.LLV_CODEX_BINARY ?? resolveBinary("codex"), ["mcp", "list", "--json"], {
+    cwd,
+    env,
+    encoding: "utf8",
+    timeout: 10_000,
+    maxBuffer: 2 * 1024 * 1024,
+  });
+  if (listed.status === 0) {
+    try {
+      const parsed = JSON.parse(listed.stdout) as unknown;
+      if (Array.isArray(parsed) && parsed.every((server) => server && typeof server === "object" && typeof (server as { name?: unknown }).name === "string")) {
+        return parsed.map((server) => (server as { name: string }).name);
+      }
+    } catch { /* use the local configuration fallback below */ }
+  }
+  const fallback = configuredCodexMcpServersFromToml(fs.readFileSync(configPath, "utf8"));
+  if (fallback) return fallback;
+  throw new Error("Codex MCP configuration could not be enumerated safely");
+}
+
+function codexMcpRuntimeOverrides(home: string, cwd: string, allowlist: readonly string[]): string[] {
+  const enabled = new Set(allowlist);
+  return configuredCodexMcpServers(home, cwd).map((name) => {
+    const key = /^[A-Za-z0-9_-]+$/.test(name) ? name : JSON.stringify(name);
+    return `mcp_servers.${key}.enabled=${enabled.has(name)}`;
+  });
+}
+
+function pushClaudePolicyArgs(
+  args: string[],
+  policy: ReturnType<typeof applyClaudeSpawnPolicy> | ReturnType<typeof claudeSpawnPolicyPaths>,
+): void {
+  args.push(
+    "--settings", policy.settingsPath,
+    "--strict-mcp-config", "--mcp-config", policy.mcpConfigPath,
+  );
 }
 
 export function effectiveClaudePermissionMode(
@@ -126,6 +194,7 @@ export function effectiveClaudePermissionMode(
 
 /** Boot spec for a brand-new agent (no prior conversation) in a chosen directory. */
 export function freshSpecFor(engine: AgentEngine, cwd: string, options: FreshSpecOptions = {}): ResumeSpec {
+  const mcpServers = normalizedMcpServers(options.mcpServers);
   if (engine === "claude") {
     /* A pre-chosen session id makes the transcript path knowable right at
        spawn time (handoff lineage links it before the file exists) and lets
@@ -149,13 +218,13 @@ export function freshSpecFor(engine: AgentEngine, cwd: string, options: FreshSpe
         : applyClaudeSpawnPolicy(options.claudeConfigDir, {
           allowSubagents: options.allowSubagents,
           cwd,
-          mcpServers: options.mcpServers,
+          mcpServers,
           baseSettingsPath: managed ? claudeSettingsPath() : null,
           profileId: sid,
         })
       : null;
-    const settings = installedPolicy?.settingsPath ?? null;
-    if (settings) args.push("--settings", settings);
+    if (installedPolicy) pushClaudePolicyArgs(args, installedPolicy);
+    else args.push("--strict-mcp-config");
     const command = args.map(shellQuote).join(" ");
     return {
       command: managed ? `${claudeEnvPrefix(options.claudeConfigDir!)} ${command}` : command,
@@ -171,7 +240,7 @@ export function freshSpecFor(engine: AgentEngine, cwd: string, options: FreshSpe
         permissionMode,
         readOnly: options.readOnly ?? false,
         allowSubagents: options.allowSubagents ?? false,
-        mcpServers: options.mcpServers ?? ["viewer"],
+        mcpServers,
         title: null,
         project: null,
         parentConversationId: null,
@@ -184,6 +253,7 @@ export function freshSpecFor(engine: AgentEngine, cwd: string, options: FreshSpe
   const args = [resolveBinary("codex")];
   const home = options.codexHome ?? accountForSpawn().home;
   if (isManagedCodexHome(home)) args.push("-c", "cli_auth_credentials_store=file");
+  for (const override of codexMcpRuntimeOverrides(home, cwd, mcpServers)) args.push("-c", override);
   if (options.model) args.push("-m", options.model);
   if (options.effort) args.push("-c", `model_reasoning_effort=${options.effort}`);
   if (options.fast != null) args.push("-c", `service_tier=${options.fast ? "priority" : "standard"}`);
@@ -203,7 +273,7 @@ export function freshSpecFor(engine: AgentEngine, cwd: string, options: FreshSpe
       permissionMode: options.readOnly ? "never" : null,
       readOnly: options.readOnly ?? false,
       allowSubagents: options.allowSubagents ?? false,
-      mcpServers: options.mcpServers ?? ["viewer"],
+      mcpServers,
       title: null,
       project: null,
       parentConversationId: null,
@@ -245,15 +315,21 @@ export function claudeSuccessorSpecFor(input: {
   if (model) args.push("--model", model);
   if (input.profile.effort && /^[a-z]+$/.test(input.profile.effort)) args.push("--effort", input.profile.effort);
   args.push("--resume", input.sourcePath, "--fork-session", "--session-id", input.candidateId);
-  const settings = applyClaudeSpawnPolicy(input.targetHome, {
+  const cwd = input.profile.cwd || resumeCwd(input.sourcePath);
+  const policy = applyClaudeSpawnPolicy(input.targetHome, {
     allowSubagents: input.profile.allowSubagents,
     baseSettingsPath: isManagedClaudeHome(input.targetHome) ? claudeSettingsPath() : null,
     profileId: input.candidateId,
-  }).settingsPath;
-  args.push("--settings", settings);
+    cwd,
+    mcpServers: input.profile.mcpServers,
+    mcpStatePath: isManagedClaudeHome(input.targetHome)
+      ? path.join(input.targetHome, ".claude.json")
+      : path.join(path.dirname(input.targetHome), ".claude.json"),
+  });
+  pushClaudePolicyArgs(args, policy);
   return {
     command: `${claudeEnvPrefix(input.targetHome)} ${args.map(shellQuote).join(" ")}`,
-    cwd: input.profile.cwd || resumeCwd(input.sourcePath),
+    cwd,
     windowName: "claude-migration-successor",
     engine: "claude",
     ["transcript"]: claudeTranscriptPath(input.profile.cwd || resumeCwd(input.sourcePath), input.candidateId, input.targetProjectsDir),
@@ -268,6 +344,7 @@ export function claudeSuccessorSpecFor(input: {
  * session of their own, so only root session files qualify.
  */
 export function resumeSpecFor(root: string, pathname: string, options: ResumeSpecOptions = {}): ResumeSpec | null {
+  const mcpServers = normalizedMcpServers(options.mcpServers);
   const base = path.basename(pathname);
   if (root === "claude-projects" && base.endsWith(".jsonl") && !pathname.includes(path.sep + "subagents" + path.sep)) {
     const sid = base.slice(0, -".jsonl".length);
@@ -275,31 +352,36 @@ export function resumeSpecFor(root: string, pathname: string, options: ResumeSpe
     const home = claudeHomeOwningTranscript(pathname);
     if (!home) return null;
     const managed = isManagedClaudeHome(home);
-    const settings = applyClaudeSpawnPolicy(home, {
+    const cwd = resumeCwd(pathname);
+    const policy = applyClaudeSpawnPolicy(home, {
       allowSubagents: options.allowSubagents,
       baseSettingsPath: managed ? claudeSettingsPath() : null,
       profileId: `resume-${sid}`,
-    }).settingsPath;
-    let command = shellQuote(resolveBinary("claude"));
+      cwd,
+      mcpServers,
+      mcpStatePath: managed ? path.join(home, ".claude.json") : path.join(path.dirname(home), ".claude.json"),
+    });
+    const args = [resolveBinary("claude")];
     const permissionMode = effectiveClaudePermissionMode(options);
     if (options.readOnly || permissionMode === "plan") {
-      command += " --permission-mode plan --disallowedTools Edit,Write,NotebookEdit";
+      args.push("--permission-mode", "plan", "--disallowedTools", "Edit,Write,NotebookEdit");
     } else if (permissionMode !== "bypassPermissions" && /^[a-zA-Z-]+$/.test(permissionMode)) {
-      command += ` --permission-mode ${shellQuote(permissionMode)}`;
+      args.push("--permission-mode", permissionMode);
     } else {
-      command += " --dangerously-skip-permissions";
+      args.push("--dangerously-skip-permissions");
     }
-    command += ` --settings ${shellQuote(settings)}`;
+    pushClaudePolicyArgs(args, policy);
     const launchModel = normalizeClaudeLaunchModel(options.model);
-    if (launchModel) command += ` --model ${shellQuote(launchModel)}`;
-    if (options.effort) command += ` --effort ${shellQuote(options.effort)}`;
-    command += ` --resume ${shellQuote(sid)}`;
+    if (launchModel) args.push("--model", launchModel);
+    if (options.effort) args.push("--effort", options.effort);
+    args.push("--resume", sid);
+    const command = args.map(shellQuote).join(" ");
     return {
       command: managed ? `${claudeEnvPrefix(home)} ${command}` : command,
-      cwd: resumeCwd(pathname),
+      cwd,
       windowName: "claude-resume",
       engine: "claude",
-      launchProfile: { ...emptyLaunchProfileForResume(resumeCwd(pathname), launchModel, options.effort ?? null), readOnly: options.readOnly ?? null, permissionMode, allowSubagents: options.allowSubagents ?? false },
+      launchProfile: { ...emptyLaunchProfileForResume(cwd, launchModel, options.effort ?? null), readOnly: options.readOnly ?? null, permissionMode, allowSubagents: options.allowSubagents ?? false, mcpServers },
     };
   }
   if (root === "codex-sessions" && base.endsWith(".jsonl")) {
@@ -309,6 +391,8 @@ export function resumeSpecFor(root: string, pathname: string, options: ResumeSpe
     if (!home) return null;
     let command = `${resolveBinary("codex")}`;
     if (isManagedCodexHome(home)) command += " -c cli_auth_credentials_store=file";
+    const cwd = resumeCwd(pathname);
+    for (const override of codexMcpRuntimeOverrides(home, cwd, mcpServers)) command += ` -c ${shellQuote(override)}`;
     if (options.model) command += ` -m ${shellQuote(options.model)}`;
     if (options.effort) command += ` -c ${shellQuote(`model_reasoning_effort=${options.effort}`)}`;
     if (options.fast != null) command += ` -c ${shellQuote(`service_tier=${options.fast ? "priority" : "standard"}`)}`;
@@ -320,10 +404,10 @@ export function resumeSpecFor(root: string, pathname: string, options: ResumeSpe
     command += ` resume ${id}`;
     return {
       command: `env -u LLV_TOKEN CODEX_HOME=${shellQuote(home)} ${command}`,
-      cwd: resumeCwd(pathname),
+      cwd,
       windowName: "codex-resume",
       engine: "codex",
-      launchProfile: { ...emptyLaunchProfileForResume(resumeCwd(pathname), options.model ?? null, options.effort ?? null), fast: options.fast ?? null, readOnly: options.readOnly ?? null, permissionMode: options.permissionMode ?? null, allowSubagents: options.allowSubagents ?? false },
+      launchProfile: { ...emptyLaunchProfileForResume(cwd, options.model ?? null, options.effort ?? null), fast: options.fast ?? null, readOnly: options.readOnly ?? null, permissionMode: options.permissionMode ?? null, allowSubagents: options.allowSubagents ?? false, mcpServers },
     };
   }
   return null;

--- a/src/lib/agent/cli.ts
+++ b/src/lib/agent/cli.ts
@@ -98,6 +98,7 @@ export interface FreshSpecOptions {
   claudeProjectsDir?: string | null;
   /** Allow native Claude sub-agents and the Codex multi-agent feature. */
   allowSubagents?: boolean;
+  mcpServers?: string[];
   /** Route admission owns policy materialization after its durable reservation. */
   deferClaudeSpawnPolicy?: boolean;
 }
@@ -147,6 +148,8 @@ export function freshSpecFor(engine: AgentEngine, cwd: string, options: FreshSpe
         ? claudeSpawnPolicyPaths(options.claudeConfigDir, sid)
         : applyClaudeSpawnPolicy(options.claudeConfigDir, {
           allowSubagents: options.allowSubagents,
+          cwd,
+          mcpServers: options.mcpServers,
           baseSettingsPath: managed ? claudeSettingsPath() : null,
           profileId: sid,
         })
@@ -168,6 +171,7 @@ export function freshSpecFor(engine: AgentEngine, cwd: string, options: FreshSpe
         permissionMode,
         readOnly: options.readOnly ?? false,
         allowSubagents: options.allowSubagents ?? false,
+        mcpServers: options.mcpServers ?? ["viewer"],
         title: null,
         project: null,
         parentConversationId: null,
@@ -199,6 +203,7 @@ export function freshSpecFor(engine: AgentEngine, cwd: string, options: FreshSpe
       permissionMode: options.readOnly ? "never" : null,
       readOnly: options.readOnly ?? false,
       allowSubagents: options.allowSubagents ?? false,
+      mcpServers: options.mcpServers ?? ["viewer"],
       title: null,
       project: null,
       parentConversationId: null,
@@ -333,6 +338,7 @@ function emptyLaunchProfileForResume(cwd: string, model: string | null, effort: 
     permissionMode: null,
     readOnly: null,
     allowSubagents: false,
+    mcpServers: ["viewer"],
     title: null,
     project: null,
     parentConversationId: null,

--- a/src/lib/agent/mcpAllowlist.test.ts
+++ b/src/lib/agent/mcpAllowlist.test.ts
@@ -1,0 +1,74 @@
+import { expect, test } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { emptyLaunchProfile } from "@/lib/accounts/migration/contracts";
+import { AgentRegistry } from "./registry";
+
+import { normalizeSpawnMcpServers } from "./mcpAllowlist";
+
+test("a spawn without an MCP selection receives Viewer only", () => {
+  expect(normalizeSpawnMcpServers(undefined)).toEqual({ ok: true, value: ["viewer"] });
+});
+
+test("a custom MCP selection is deduplicated and force-includes Viewer", () => {
+  expect(normalizeSpawnMcpServers(["agent-browser", "viewer", "agent-browser"]))
+    .toEqual({ ok: true, value: ["viewer", "agent-browser"] });
+});
+
+test("malformed MCP selections are rejected", () => {
+  for (const value of ["viewer", ["viewer", 42], [""], ["two words"]]) {
+    expect(normalizeSpawnMcpServers(value)).toEqual({
+      ok: false,
+      error: "mcpServers must be an array of non-empty server names",
+    });
+  }
+});
+
+test("durable launch profiles reset each new spawn to Viewer only", () => {
+  expect(emptyLaunchProfile().mcpServers).toEqual(["viewer"]);
+});
+
+test("a nested spawn resets its parent allowlist while resume preserves it", () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-mcp-nested-reset-"));
+  try {
+    const store = new AgentRegistry(path.join(directory, "registry.json"));
+    const parent = store.beginSpawnRequest({
+      engine: "codex",
+      cwd: "/repo",
+      launchProfile: { mcpServers: ["viewer", "agent-browser"] },
+    });
+    if (parent.kind !== "created") throw new Error("expected parent reservation");
+    const settled = store.settleSpawn(parent.receipt.launchId, {
+      key: { engine: "codex", sessionId: "nested-parent" },
+      artifactPath: "/sessions/nested-parent.jsonl",
+      cwd: "/repo",
+      accountId: "account",
+      status: "idle",
+      host: null,
+      claimEpoch: 0,
+      claimOwner: null,
+      pendingAction: null,
+    });
+    if (settled.kind !== "settled") throw new Error("expected parent settlement");
+
+    const child = store.beginSpawnRequest({
+      engine: "codex",
+      cwd: "/repo",
+      parentConversationId: settled.conversation.id,
+      origin: { kind: "agent", conversationId: settled.conversation.id },
+    });
+    expect(child.receipt.launchProfile.mcpServers).toEqual(["viewer"]);
+
+    const resumed = store.beginSpawnRequest({
+      engine: "codex",
+      cwd: "/repo",
+      conversationId: settled.conversation.id,
+      purpose: "resume-successor",
+    });
+    expect(resumed.receipt.launchProfile.mcpServers).toEqual(["viewer", "agent-browser"]);
+  } finally {
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});

--- a/src/lib/agent/mcpAllowlist.ts
+++ b/src/lib/agent/mcpAllowlist.ts
@@ -1,0 +1,15 @@
+export const DEFAULT_SPAWN_MCP_SERVERS: readonly string[] = Object.freeze(["viewer"]);
+
+export type SpawnMcpServersResult =
+  | { ok: true; value: string[] }
+  | { ok: false; error: string };
+
+const MCP_SERVER_NAME = /^[^\s\u0000-\u001f\u007f]{1,128}$/u;
+
+export function normalizeSpawnMcpServers(value: unknown): SpawnMcpServersResult {
+  if (value === undefined) return { ok: true, value: [...DEFAULT_SPAWN_MCP_SERVERS] };
+  if (Array.isArray(value) && value.every((name) => typeof name === "string" && MCP_SERVER_NAME.test(name))) {
+    return { ok: true, value: ["viewer", ...new Set(value.filter((name) => name !== "viewer"))] };
+  }
+  return { ok: false, error: "mcpServers must be an array of non-empty server names" };
+}

--- a/src/lib/agent/registry.ts
+++ b/src/lib/agent/registry.ts
@@ -629,6 +629,7 @@ function mergeResumeLaunchProfile(current: LaunchProfile, requested: LaunchProfi
     permissionMode: requested.permissionMode ?? current.permissionMode,
     readOnly: requested.readOnly ?? current.readOnly,
     allowSubagents: current.allowSubagents || requested.allowSubagents,
+    mcpServers: current.mcpServers,
     title: requested.title ?? current.title,
     project: requested.project ?? current.project,
     parentConversationId: requested.parentConversationId ?? current.parentConversationId,
@@ -2183,6 +2184,7 @@ function compactLaunchProfile(profile: LaunchProfile): Partial<LaunchProfile> {
   if (compact.cwd === "") delete compact.cwd;
   if (compact.role === "worker") delete compact.role;
   if (compact.allowSubagents === false) delete compact.allowSubagents;
+  if (compact.mcpServers?.length === 1 && compact.mcpServers[0] === "viewer") delete compact.mcpServers;
   return compact;
 }
 
@@ -4384,6 +4386,7 @@ export class AgentRegistry {
           fast: generation.launchProfile.fast ?? observation.launchProfile.fast,
           permissionMode: generation.launchProfile.permissionMode ?? observation.launchProfile.permissionMode,
           readOnly: generation.launchProfile.readOnly ?? observation.launchProfile.readOnly,
+          mcpServers: generation.launchProfile.mcpServers,
           title: generation.launchProfile.title ?? observation.launchProfile.title,
           project: observation.launchProfile.project ?? generation.launchProfile.project,
           parentConversationId: lineage?.source === "viewer-spawn"

--- a/src/lib/agent/spawnCommand.ts
+++ b/src/lib/agent/spawnCommand.ts
@@ -11,6 +11,7 @@ import { emptyLaunchProfile, validExplicitProject } from "@/lib/accounts/migrati
 import { freshSpecFor, type AgentEngine } from "@/lib/agent/cli";
 import { agentRegistry, SpawnChildLimitError } from "@/lib/agent/registry";
 import { reasoningFromBody } from "@/lib/agent/efforts";
+import { normalizeSpawnMcpServers } from "@/lib/agent/mcpAllowlist";
 import { codexModelSupportsImages, modelFromBody } from "@/lib/agent/models";
 import { resolveSpawnRole } from "@/lib/roles/registry";
 import { assertDarwinStructuredRuntime } from "@/lib/proc/darwinIdentity";
@@ -139,12 +140,15 @@ export async function executeSpawnRequest(
   const rejection = rejectCrossOrigin(req);
   if (rejection) return rejection;
 
-  let body: { engine?: unknown; model?: unknown; cwd?: unknown; prompt?: unknown; images?: unknown; src?: unknown; parent?: unknown; parentConversationId?: unknown; effort?: unknown; fast?: unknown; accountId?: unknown; clientAttemptId?: unknown; role?: unknown; roleParams?: unknown; confirm?: unknown; reviews?: unknown; allowSubagents?: unknown; project?: unknown; supersedes?: unknown };
+  let body: { engine?: unknown; model?: unknown; cwd?: unknown; prompt?: unknown; images?: unknown; src?: unknown; parent?: unknown; parentConversationId?: unknown; effort?: unknown; fast?: unknown; accountId?: unknown; clientAttemptId?: unknown; role?: unknown; roleParams?: unknown; confirm?: unknown; reviews?: unknown; allowSubagents?: unknown; mcpServers?: unknown; project?: unknown; supersedes?: unknown };
   try {
     body = (await req.json()) as typeof body;
   } catch {
     return NextResponse.json({ error: "invalid JSON" }, { status: 400 });
   }
+
+  const mcpServers = normalizeSpawnMcpServers(body.mcpServers);
+  if (!mcpServers.ok) return NextResponse.json({ error: mcpServers.error }, { status: 400 });
 
   const lineageError = agentSpawnLineageError(req, body);
   if (lineageError) return NextResponse.json({ error: lineageError }, { status: 400 });
@@ -330,6 +334,7 @@ export async function executeSpawnRequest(
       fast: reasoning.fast,
       accountId: account.accountId,
       role: role.value?.role ?? null,
+      mcpServers: mcpServers.value,
       ...(body.allowSubagents === true ? { allowSubagents: true } : {}),
       ...(explicitProject ? { project: explicitProject } : {}),
       parent: spawnParentSelector({ parentConversationId: parentConversationId ?? undefined }),
@@ -349,6 +354,7 @@ export async function executeSpawnRequest(
       claudeConfigDir: engine === "claude" ? account.home : null,
       claudeProjectsDir: engine === "claude" ? account.transcriptRoot : null,
       allowSubagents: body.allowSubagents === true,
+      mcpServers: mcpServers.value,
       deferClaudeSpawnPolicy: true,
     });
     const permissionMode = engine === "claude" && transport === "structured"
@@ -365,6 +371,7 @@ export async function executeSpawnRequest(
         cwd,
         parentConversationId,
         allowSubagents: body.allowSubagents === true,
+        mcpServers: mcpServers.value,
         permissionMode,
         ...(explicitProject ? { project: explicitProject } : {}),
       }),
@@ -534,6 +541,11 @@ export async function executeSpawnRequest(
         allowSubagents: body.allowSubagents === true,
         baseSettingsPath: isManagedClaudeHome(account.home) ? claudeSettingsPath() : null,
         profileId,
+        cwd,
+        mcpServers: mcpServers.value,
+        mcpStatePath: account.kind === "managed"
+          ? path.join(account.home, ".claude.json")
+          : path.join(path.dirname(account.home), ".claude.json"),
       });
     }
     if (transport === "structured") {

--- a/src/lib/agent/spawnIdentity.ts
+++ b/src/lib/agent/spawnIdentity.ts
@@ -11,13 +11,14 @@ export interface SpawnRequestIdentity {
   accountId: string | null;
   role: string | null;
   allowSubagents?: boolean;
+  mcpServers: string[];
   /** Explicit operator project ownership; absent for cwd-attributed spawns. */
   project?: string;
   parent: SpawnParentSelector;
   reviews?: SpawnParentSelector;
   /** Predecessor conversation this spawn terminally supersedes (issue #383). */
   supersedes?: SpawnParentSelector;
-  prompt: string;
+  "prompt": string;
   images: Array<{ mime: string; digest: string }>;
 }
 

--- a/src/lib/agent/spawnPolicy.test.ts
+++ b/src/lib/agent/spawnPolicy.test.ts
@@ -163,6 +163,72 @@ test("Claude native MCP config defaults to the registered Viewer server only", (
   expect(JSON.parse(fs.readFileSync(installed.settingsPath, "utf8"))).not.toHaveProperty("mcpServers");
 });
 
+test("Claude native MCP config merges project scope between user and local scopes", () => {
+  const accountHome = home();
+  const projectRoot = home();
+  const cwd = path.join(projectRoot, "packages", "worker");
+  fs.mkdirSync(path.join(projectRoot, ".git"), { recursive: true });
+  fs.mkdirSync(cwd, { recursive: true });
+  fs.writeFileSync(path.join(accountHome, "settings.json"), JSON.stringify({
+    enabledMcpjsonServers: ["project-allowed"],
+  }));
+  fs.writeFileSync(path.join(accountHome, ".claude.json"), JSON.stringify({
+    mcpServers: {
+      viewer: { type: "stdio", command: "viewer-user" },
+      "project-allowed": { type: "stdio", command: "user-version" },
+      "local-wins": { type: "stdio", command: "user-local" },
+    },
+    projects: {
+      [cwd]: {
+        mcpServers: {
+          "local-wins": { type: "stdio", command: "local-version", env: { LOCAL_AUTH: "kept" } },
+        },
+      },
+    },
+  }));
+  fs.writeFileSync(path.join(projectRoot, ".mcp.json"), JSON.stringify({
+    mcpServers: {
+      "project-allowed": {
+        type: "stdio",
+        command: "project-version",
+        args: ["--project"],
+        env: { PROJECT_AUTH: "kept" },
+        timeout: 12_345,
+        alwaysLoad: true,
+      },
+      "local-wins": { type: "stdio", command: "project-local" },
+      "project-unrelated": { type: "stdio", command: "unrelated-project" },
+    },
+  }));
+
+  const installed = applyClaudeSpawnPolicy(accountHome, {
+    profileId: "project-scopes",
+    cwd,
+    mcpServers: ["project-allowed", "local-wins"],
+  });
+  const mcpConfig = JSON.parse(fs.readFileSync(installed.mcpConfigPath, "utf8")) as {
+    mcpServers: Record<string, unknown>;
+  };
+  const settings = JSON.parse(fs.readFileSync(installed.settingsPath, "utf8")) as {
+    enabledMcpjsonServers: string[];
+  };
+
+  expect(mcpConfig.mcpServers).toEqual({
+    viewer: { type: "stdio", command: "viewer-user" },
+    "project-allowed": {
+      type: "stdio",
+      command: "project-version",
+      args: ["--project"],
+      env: { PROJECT_AUTH: "kept" },
+      timeout: 12_345,
+      alwaysLoad: true,
+    },
+    "local-wins": { type: "stdio", command: "local-version", env: { LOCAL_AUTH: "kept" } },
+  });
+  expect(mcpConfig.mcpServers).not.toHaveProperty("project-unrelated");
+  expect(settings.enabledMcpjsonServers).toEqual(["project-allowed"]);
+});
+
 test("allowSubagents uses an isolated profile while the denied profile stays enforced", () => {
   const accountHome = home();
   const shared = path.join(home(), "settings.json");

--- a/src/lib/agent/spawnPolicy.test.ts
+++ b/src/lib/agent/spawnPolicy.test.ts
@@ -120,6 +120,48 @@ test("Claude spawn policy seeds a fresh account from the shared user settings sn
   expect(settings.hooks.PreToolUse).toHaveLength(1);
 });
 
+test("Claude spawn settings force Viewer into a custom allowlist and omit unrelated servers", () => {
+  const accountHome = home();
+  fs.writeFileSync(path.join(accountHome, ".claude.json"), JSON.stringify({
+    mcpServers: {
+      viewer: { type: "stdio", command: "viewer-mcp", args: ["--viewer"] },
+      "agent-browser": { type: "stdio", command: "browser-mcp" },
+      "telegram-readonly": { type: "stdio", command: "telegram-mcp" },
+    },
+  }));
+
+  const installed = applyClaudeSpawnPolicy(accountHome, {
+    profileId: "custom-mcp",
+    cwd: "/repo",
+    mcpServers: ["agent-browser"],
+  });
+  const settings = JSON.parse(fs.readFileSync(installed.settingsPath, "utf8")) as {
+    mcpServers: Record<string, unknown>;
+  };
+
+  expect(settings.mcpServers).toEqual({
+    viewer: { type: "stdio", command: "viewer-mcp", args: ["--viewer"] },
+    "agent-browser": { type: "stdio", command: "browser-mcp" },
+  });
+});
+
+test("Claude spawn settings default to the registered Viewer server only", () => {
+  const accountHome = home();
+  fs.writeFileSync(path.join(accountHome, ".claude.json"), JSON.stringify({
+    mcpServers: {
+      viewer: { type: "stdio", command: "viewer-mcp" },
+      "agent-browser": { type: "stdio", command: "browser-mcp" },
+    },
+  }));
+
+  const installed = applyClaudeSpawnPolicy(accountHome, { profileId: "default-mcp", cwd: "/repo" });
+  const settings = JSON.parse(fs.readFileSync(installed.settingsPath, "utf8")) as {
+    mcpServers: Record<string, unknown>;
+  };
+
+  expect(settings.mcpServers).toEqual({ viewer: { type: "stdio", command: "viewer-mcp" } });
+});
+
 test("allowSubagents uses an isolated profile while the denied profile stays enforced", () => {
   const accountHome = home();
   const shared = path.join(home(), "settings.json");

--- a/src/lib/agent/spawnPolicy.test.ts
+++ b/src/lib/agent/spawnPolicy.test.ts
@@ -211,6 +211,7 @@ test("Claude native MCP config merges project scope between user and local scope
   };
   const settings = JSON.parse(fs.readFileSync(installed.settingsPath, "utf8")) as {
     enabledMcpjsonServers: string[];
+    disabledMcpjsonServers: string[];
   };
 
   expect(mcpConfig.mcpServers).toEqual({
@@ -227,6 +228,7 @@ test("Claude native MCP config merges project scope between user and local scope
   });
   expect(mcpConfig.mcpServers).not.toHaveProperty("project-unrelated");
   expect(settings.enabledMcpjsonServers).toEqual(["project-allowed"]);
+  expect(settings.disabledMcpjsonServers).toEqual(["project-unrelated"]);
 });
 
 test("allowSubagents uses an isolated profile while the denied profile stays enforced", () => {

--- a/src/lib/agent/spawnPolicy.test.ts
+++ b/src/lib/agent/spawnPolicy.test.ts
@@ -120,7 +120,7 @@ test("Claude spawn policy seeds a fresh account from the shared user settings sn
   expect(settings.hooks.PreToolUse).toHaveLength(1);
 });
 
-test("Claude spawn settings force Viewer into a custom allowlist and omit unrelated servers", () => {
+test("Claude native MCP config forces Viewer into a custom allowlist and omits unrelated servers", () => {
   const accountHome = home();
   fs.writeFileSync(path.join(accountHome, ".claude.json"), JSON.stringify({
     mcpServers: {
@@ -135,17 +135,17 @@ test("Claude spawn settings force Viewer into a custom allowlist and omit unrela
     cwd: "/repo",
     mcpServers: ["agent-browser"],
   });
-  const settings = JSON.parse(fs.readFileSync(installed.settingsPath, "utf8")) as {
+  const mcpConfig = JSON.parse(fs.readFileSync(installed.mcpConfigPath, "utf8")) as {
     mcpServers: Record<string, unknown>;
   };
 
-  expect(settings.mcpServers).toEqual({
+  expect(mcpConfig.mcpServers).toEqual({
     viewer: { type: "stdio", command: "viewer-mcp", args: ["--viewer"] },
     "agent-browser": { type: "stdio", command: "browser-mcp" },
   });
 });
 
-test("Claude spawn settings default to the registered Viewer server only", () => {
+test("Claude native MCP config defaults to the registered Viewer server only", () => {
   const accountHome = home();
   fs.writeFileSync(path.join(accountHome, ".claude.json"), JSON.stringify({
     mcpServers: {
@@ -155,11 +155,12 @@ test("Claude spawn settings default to the registered Viewer server only", () =>
   }));
 
   const installed = applyClaudeSpawnPolicy(accountHome, { profileId: "default-mcp", cwd: "/repo" });
-  const settings = JSON.parse(fs.readFileSync(installed.settingsPath, "utf8")) as {
+  const mcpConfig = JSON.parse(fs.readFileSync(installed.mcpConfigPath, "utf8")) as {
     mcpServers: Record<string, unknown>;
   };
 
-  expect(settings.mcpServers).toEqual({ viewer: { type: "stdio", command: "viewer-mcp" } });
+  expect(mcpConfig.mcpServers).toEqual({ viewer: { type: "stdio", command: "viewer-mcp" } });
+  expect(JSON.parse(fs.readFileSync(installed.settingsPath, "utf8"))).not.toHaveProperty("mcpServers");
 });
 
 test("allowSubagents uses an isolated profile while the denied profile stays enforced", () => {

--- a/src/lib/agent/spawnPolicy.ts
+++ b/src/lib/agent/spawnPolicy.ts
@@ -10,6 +10,11 @@ type JsonObject = Record<string, unknown>;
 const MANAGED_HOOK_PREFIX = "LLV_MANAGED_NATIVE_SUBAGENT_DENY=1 ";
 const MANAGED_DIR = ".llv";
 const MANAGED_HOOK = "deny-native-subagents.sh";
+const MCP_APPROVAL_SETTINGS = [
+  "enableAllProjectMcpServers",
+  "enabledMcpjsonServers",
+  "disabledMcpjsonServers",
+] as const;
 
 /** Every native multi-agent entry point in the installed Claude CLI (#381 audit,
     CLI 2.1.214): subagent spawns (Task, Agent), Workflow orchestration scripts,
@@ -86,6 +91,23 @@ function readSettings(pathname: string): JsonObject {
   return settings;
 }
 
+function claudeProjectMcpServers(cwd: string | undefined): JsonObject {
+  if (!cwd) return {};
+  const launchDirectory = path.resolve(cwd);
+  let projectRoot = launchDirectory;
+  for (let directory = launchDirectory; ; directory = path.dirname(directory)) {
+    if (fs.existsSync(path.join(directory, ".git"))) {
+      projectRoot = directory;
+      break;
+    }
+    const parent = path.dirname(directory);
+    if (parent === directory) break;
+  }
+  const configPath = path.join(projectRoot, ".mcp.json");
+  if (!fs.existsSync(configPath)) return {};
+  return record(readSettings(configPath).mcpServers) ?? {};
+}
+
 function claudeMcpServers(
   pathname: string,
   cwd: string | undefined,
@@ -96,8 +118,9 @@ function claudeMcpServers(
   const rootServers = record(state.mcpServers) ?? {};
   const projects = record(state.projects);
   const project = cwd && projects ? record(projects[cwd]) : null;
-  const projectServers = record(project?.mcpServers) ?? {};
-  const registered = { ...rootServers, ...projectServers };
+  const sharedProjectServers = claudeProjectMcpServers(cwd);
+  const localProjectServers = record(project?.mcpServers) ?? {};
+  const registered = { ...rootServers, ...sharedProjectServers, ...localProjectServers };
   const normalized = normalizeSpawnMcpServers(allowlist);
   const names = normalized.ok ? normalized.value : ["viewer"];
   return Object.fromEntries(names.flatMap((name) => {
@@ -211,8 +234,12 @@ export function applyClaudeSpawnPolicy(
   const settingsWithoutMcp = Object.fromEntries(
     Object.entries(enforcedSettings).filter(([key]) => key !== "mcpServers"),
   );
+  const approvalSettings = Object.fromEntries(MCP_APPROVAL_SETTINGS.flatMap((key) => (
+    sourceSettings[key] === undefined ? [] : [[key, sourceSettings[key]]]
+  )));
   atomicWrite(result.settingsPath, JSON.stringify({
     ...settingsWithoutMcp,
+    ...approvalSettings,
     hooks: { ...hooks, PreToolUse: preToolUse },
   }, null, 2) + "\n", 0o600);
   atomicWrite(result.mcpConfigPath, JSON.stringify({ mcpServers }, null, 2) + "\n", 0o600);

--- a/src/lib/agent/spawnPolicy.ts
+++ b/src/lib/agent/spawnPolicy.ts
@@ -91,6 +91,10 @@ function readSettings(pathname: string): JsonObject {
   return settings;
 }
 
+function stringArray(value: unknown): string[] {
+  return Array.isArray(value) ? value.filter((entry): entry is string => typeof entry === "string") : [];
+}
+
 function claudeProjectMcpServers(cwd: string | undefined): JsonObject {
   if (!cwd) return {};
   const launchDirectory = path.resolve(cwd);
@@ -231,12 +235,24 @@ export function applyClaudeSpawnPolicy(
     options.cwd,
     options.mcpServers,
   );
+  const includedMcpServers = new Set(Object.keys(mcpServers));
+  const excludedProjectMcpServers = Object.keys(claudeProjectMcpServers(options.cwd))
+    .filter((name) => !includedMcpServers.has(name));
   const settingsWithoutMcp = Object.fromEntries(
     Object.entries(enforcedSettings).filter(([key]) => key !== "mcpServers"),
   );
-  const approvalSettings = Object.fromEntries(MCP_APPROVAL_SETTINGS.flatMap((key) => (
+  const approvalSettings: JsonObject = Object.fromEntries(MCP_APPROVAL_SETTINGS.flatMap((key) => (
     sourceSettings[key] === undefined ? [] : [[key, sourceSettings[key]]]
   )));
+  if (sourceSettings.enabledMcpjsonServers !== undefined) {
+    approvalSettings.enabledMcpjsonServers = stringArray(sourceSettings.enabledMcpjsonServers)
+      .filter((name) => includedMcpServers.has(name));
+  }
+  const disabledMcpjsonServers = [...new Set([
+    ...stringArray(sourceSettings.disabledMcpjsonServers),
+    ...excludedProjectMcpServers,
+  ])];
+  if (disabledMcpjsonServers.length > 0) approvalSettings.disabledMcpjsonServers = disabledMcpjsonServers;
   atomicWrite(result.settingsPath, JSON.stringify({
     ...settingsWithoutMcp,
     ...approvalSettings,

--- a/src/lib/agent/spawnPolicy.ts
+++ b/src/lib/agent/spawnPolicy.ts
@@ -37,6 +37,7 @@ export const CODEX_VIEWER_SPAWN_FEATURES = {
 
 export interface ClaudeSpawnPolicyResult {
   settingsPath: string;
+  mcpConfigPath: string;
   hookPath: string;
   command: string;
 }
@@ -46,6 +47,7 @@ export function claudeSpawnPolicyPaths(home: string, profileId: string): ClaudeS
   const hookPath = path.join(home, MANAGED_DIR, "hooks", MANAGED_HOOK);
   return {
     settingsPath: path.join(home, MANAGED_DIR, "spawn-settings", `${profileId}.json`),
+    mcpConfigPath: path.join(home, MANAGED_DIR, "spawn-mcp", `${profileId}.json`),
     hookPath,
     command: `${MANAGED_HOOK_PREFIX}${shellQuote(hookPath)}`,
   };
@@ -185,7 +187,7 @@ export function applyClaudeSpawnPolicy(
   if (!options.allowSubagents && sourceSettings.allowManagedHooksOnly === true) {
     throw new Error("Claude settings allowManagedHooksOnly prevents the Viewer spawn policy from enforcing native sub-agent denial");
   }
-  const hooks = settings.hooks === undefined ? {} : record(settings.hooks);
+  const hooks = sourceSettings.hooks === undefined ? {} : record(sourceSettings.hooks);
   if (!hooks) throw new Error("Claude settings hooks must contain a JSON object");
 
   const preToolUse = withoutManagedHandlers(hooks.PreToolUse);
@@ -206,11 +208,14 @@ export function applyClaudeSpawnPolicy(
     options.cwd,
     options.mcpServers,
   );
+  const settingsWithoutMcp = Object.fromEntries(
+    Object.entries(enforcedSettings).filter(([key]) => key !== "mcpServers"),
+  );
   atomicWrite(result.settingsPath, JSON.stringify({
-    ...enforcedSettings,
-    mcpServers,
+    ...settingsWithoutMcp,
     hooks: { ...hooks, PreToolUse: preToolUse },
   }, null, 2) + "\n", 0o600);
+  atomicWrite(result.mcpConfigPath, JSON.stringify({ mcpServers }, null, 2) + "\n", 0o600);
   return result;
 }
 

--- a/src/lib/agent/spawnPolicy.ts
+++ b/src/lib/agent/spawnPolicy.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import crypto from "node:crypto";
 
 import type { AgentEngine } from "./cli";
+import { normalizeSpawnMcpServers } from "./mcpAllowlist";
 
 type JsonObject = Record<string, unknown>;
 
@@ -83,6 +84,26 @@ function readSettings(pathname: string): JsonObject {
   return settings;
 }
 
+function claudeMcpServers(
+  pathname: string,
+  cwd: string | undefined,
+  allowlist: readonly string[] | undefined,
+): JsonObject {
+  if (!fs.existsSync(pathname)) return {};
+  const state = readSettings(pathname);
+  const rootServers = record(state.mcpServers) ?? {};
+  const projects = record(state.projects);
+  const project = cwd && projects ? record(projects[cwd]) : null;
+  const projectServers = record(project?.mcpServers) ?? {};
+  const registered = { ...rootServers, ...projectServers };
+  const normalized = normalizeSpawnMcpServers(allowlist);
+  const names = normalized.ok ? normalized.value : ["viewer"];
+  return Object.fromEntries(names.flatMap((name) => {
+    const definition = record(registered[name]);
+    return definition ? [[name, definition]] : [];
+  }));
+}
+
 /** Seeds the mutable Claude home state before a managed bypass launch. */
 export function prepareManagedClaudeSpawnHome(home: string, cwd: string): void {
   const pathname = path.join(home, ".claude.json");
@@ -141,7 +162,14 @@ function withoutManagedHandlers(value: unknown): unknown[] {
 /** Reconciles the Viewer-owned Claude hook while preserving every user key and handler. */
 export function applyClaudeSpawnPolicy(
   home: string,
-  options: { allowSubagents?: boolean; baseSettingsPath?: string | null; profileId?: string } = {},
+  options: {
+    allowSubagents?: boolean;
+    baseSettingsPath?: string | null;
+    profileId?: string;
+    cwd?: string;
+    mcpServers?: readonly string[];
+    mcpStatePath?: string;
+  } = {},
 ): ClaudeSpawnPolicyResult {
   const sourceSettingsPath = path.join(home, "settings.json");
   const profileId = options.profileId ?? crypto.randomUUID();
@@ -173,7 +201,16 @@ export function applyClaudeSpawnPolicy(
   const enforcedSettings = options.allowSubagents
     ? settings
     : { ...settings, disableAllHooks: false, allowManagedHooksOnly: false };
-  atomicWrite(result.settingsPath, JSON.stringify({ ...enforcedSettings, hooks: { ...hooks, PreToolUse: preToolUse } }, null, 2) + "\n", 0o600);
+  const mcpServers = claudeMcpServers(
+    options.mcpStatePath ?? path.join(home, ".claude.json"),
+    options.cwd,
+    options.mcpServers,
+  );
+  atomicWrite(result.settingsPath, JSON.stringify({
+    ...enforcedSettings,
+    mcpServers,
+    hooks: { ...hooks, PreToolUse: preToolUse },
+  }, null, 2) + "\n", 0o600);
   return result;
 }
 

--- a/src/lib/codexHeadlessConfig.test.ts
+++ b/src/lib/codexHeadlessConfig.test.ts
@@ -2,12 +2,34 @@ import { expect, test } from "bun:test";
 
 import { headlessCodexThreadConfig } from "./codexHeadlessConfig";
 
-test("headless Codex threads disable native collaboration tools", () => {
+test("headless Codex threads allow only the registered Viewer MCP server", () => {
+  expect(headlessCodexThreadConfig({
+    config: {
+      mcp_servers: {
+        viewer: { command: "agent-log-viewer-mcp", enabled: false },
+        docs: { command: "docs-mcp", enabled: true },
+      },
+    },
+  })).toEqual({
+    mcp_servers: {
+      viewer: { enabled: true },
+      docs: { enabled: false },
+    },
+    features: { plugins: false, apps: false, multi_agent: false },
+    include_apps_instructions: false,
+  });
+});
+
+test("configurations without Viewer disable every registered MCP server", () => {
   expect(headlessCodexThreadConfig({ config: { mcp_servers: { docs: {} } } })).toEqual({
     mcp_servers: { docs: { enabled: false } },
     features: { plugins: false, apps: false, multi_agent: false },
     include_apps_instructions: false,
   });
+});
+
+test("configurations without an MCP table fail closed", () => {
+  expect(() => headlessCodexThreadConfig({ config: {} })).toThrow("config/read returned no MCP server table");
 });
 
 test("an operator-granted Codex thread enables native collaboration", () => {

--- a/src/lib/codexHeadlessConfig.test.ts
+++ b/src/lib/codexHeadlessConfig.test.ts
@@ -12,7 +12,7 @@ test("headless Codex threads allow only the registered Viewer MCP server", () =>
     },
   })).toEqual({
     mcp_servers: {
-      viewer: { enabled: true },
+      viewer: { enabled: true, default_tools_approval_mode: "approve" },
       docs: { enabled: false },
     },
     features: { plugins: false, apps: false, multi_agent: false },
@@ -35,5 +35,23 @@ test("configurations without an MCP table fail closed", () => {
 test("an operator-granted Codex thread enables native collaboration", () => {
   expect(headlessCodexThreadConfig({ config: { mcp_servers: {} } }, true)).toMatchObject({
     features: { plugins: false, apps: false, multi_agent: true },
+  });
+});
+
+test("a Codex thread approves Viewer and retains optional server approval policy", () => {
+  expect(headlessCodexThreadConfig({
+    config: {
+      mcp_servers: {
+        viewer: { default_tools_approval_mode: "prompt" },
+        "agent-browser": { default_tools_approval_mode: "writes" },
+        "telegram-readonly": { default_tools_approval_mode: "prompt" },
+      },
+    },
+  }, false, ["agent-browser"])).toMatchObject({
+    mcp_servers: {
+      viewer: { enabled: true, default_tools_approval_mode: "approve" },
+      "agent-browser": { enabled: true, default_tools_approval_mode: "writes" },
+      "telegram-readonly": { enabled: false, default_tools_approval_mode: "prompt" },
+    },
   });
 });

--- a/src/lib/codexHeadlessConfig.ts
+++ b/src/lib/codexHeadlessConfig.ts
@@ -12,7 +12,7 @@ export function headlessCodexThreadConfig(configRead: unknown, allowSubagents = 
   const servers = record(config?.mcp_servers);
   if (!config || !servers) throw new Error("config/read returned no MCP server table");
   return {
-    mcp_servers: Object.fromEntries(Object.keys(servers).map((name) => [name, { enabled: false }])),
+    mcp_servers: Object.fromEntries(Object.keys(servers).map((name) => [name, { enabled: name === "viewer" }])),
     features: { ...CODEX_VIEWER_SPAWN_FEATURES, multi_agent: allowSubagents },
     include_apps_instructions: false,
   };

--- a/src/lib/codexHeadlessConfig.ts
+++ b/src/lib/codexHeadlessConfig.ts
@@ -1,18 +1,37 @@
 import { CODEX_VIEWER_SPAWN_FEATURES } from "@/lib/agent/spawnPolicy";
+import { normalizeSpawnMcpServers } from "@/lib/agent/mcpAllowlist";
 
 type JsonObject = Record<string, unknown>;
+const MCP_APPROVAL_MODES = new Set(["auto", "prompt", "writes", "approve"]);
 
 function record(value: unknown): JsonObject | null {
   return value && typeof value === "object" && !Array.isArray(value) ? value as JsonObject : null;
 }
 
 /** Builds a fail-closed thread override from Codex's effective configuration. */
-export function headlessCodexThreadConfig(configRead: unknown, allowSubagents = false): JsonObject {
+export function headlessCodexThreadConfig(
+  configRead: unknown,
+  allowSubagents = false,
+  mcpServers: readonly string[] | undefined = undefined,
+): JsonObject {
   const config = record(record(configRead)?.config);
   const servers = record(config?.mcp_servers);
   if (!config || !servers) throw new Error("config/read returned no MCP server table");
+  const normalized = normalizeSpawnMcpServers(mcpServers);
+  const enabled = new Set(normalized.ok ? normalized.value : ["viewer"]);
   return {
-    mcp_servers: Object.fromEntries(Object.keys(servers).map((name) => [name, { enabled: name === "viewer" }])),
+    mcp_servers: Object.fromEntries(Object.entries(servers).map(([name, server]) => {
+      const configuredApproval = record(server)?.default_tools_approval_mode;
+      const approval = name === "viewer"
+        ? "approve"
+        : typeof configuredApproval === "string" && MCP_APPROVAL_MODES.has(configuredApproval)
+          ? configuredApproval
+          : null;
+      return [name, {
+        enabled: enabled.has(name),
+        ...(approval ? { default_tools_approval_mode: approval } : {}),
+      }];
+    })),
     features: { ...CODEX_VIEWER_SPAWN_FEATURES, multi_agent: allowSubagents },
     include_apps_instructions: false,
   };

--- a/src/lib/flows/engine.ts
+++ b/src/lib/flows/engine.ts
@@ -271,6 +271,7 @@ export async function sendToImplementer(flow: Flow, entriesByPath: Map<string, F
     model: entry.launchModel ?? entry.model,
     effort: entry.effort,
     allowSubagents: agentRegistry().launchProfileForPath(entry.path)?.allowSubagents,
+    mcpServers: agentRegistry().launchProfileForPath(entry.path)?.mcpServers,
   });
   if (!spec) throw new Error("implementer session cannot be resumed");
   const outcome = await deliverToTranscriptHost({ entry, spec, payload: text });

--- a/src/lib/mcp/bindings.test.ts
+++ b/src/lib/mcp/bindings.test.ts
@@ -70,6 +70,7 @@ test("runtime-bound MCP tools use the live Viewer control surface", async () => 
     clientRequestId: "spawn-http-control",
     cwd: "/repo",
     ["prompt"]: "implement",
+    mcpServers: ["viewer", "agent-browser"],
   });
   const exactMessage = " \tcontinue\nПривіт 🌍\n ";
   await bindings.send_message({
@@ -94,6 +95,7 @@ test("runtime-bound MCP tools use the live Viewer control surface", async () => 
     "/api/runtime/deployments",
   ]);
   expect(requests[0]?.body.clientAttemptId).toBe("spawn-http-control");
+  expect(requests[0]?.body.mcpServers).toEqual(["viewer", "agent-browser"]);
   expect(requests[1]?.body.clientMessageId).toBe("send-http-control");
   expect(requests[1]?.body.text).toBe(exactMessage);
   expect(requests[2]?.body.idempotencyKey).toBe("deploy-http-control");

--- a/src/lib/mcp/server.test.ts
+++ b/src/lib/mcp/server.test.ts
@@ -114,6 +114,7 @@ describe("MCP tool service", () => {
       const spawnSchema = listed.tools.find((tool) => tool.name === "spawn_agent")?.inputSchema;
       expect(spawnSchema?.properties).toHaveProperty("cwd");
       expect(spawnSchema?.properties).toHaveProperty("prompt");
+      expect(spawnSchema?.properties).toHaveProperty("mcpServers");
       const deploySchema = listed.tools.find((tool) => tool.name === "deploy_exact_sha")?.inputSchema;
       expect(deploySchema?.properties).toHaveProperty("confirm");
       const called = await client.callTool({

--- a/src/lib/mcp/server.ts
+++ b/src/lib/mcp/server.ts
@@ -311,6 +311,9 @@ const TOOL_INPUT_SCHEMAS: Record<McpToolName, z.ZodObject> = {
     parentConversationId: z.string().optional(),
     project: z.string().optional(),
     allowSubagents: z.boolean().optional(),
+    mcpServers: z.array(z.string().regex(/^[^\s\u0000-\u001f\u007f]{1,128}$/u))
+      .optional()
+      .describe("Per-spawn MCP server allowlist. Viewer is always included; omission selects Viewer only."),
     images: z.array(z.unknown()).optional(),
   }).passthrough(),
   send_message: z.object({

--- a/src/lib/runtime/claudeStreamBrokerHost.integration.test.ts
+++ b/src/lib/runtime/claudeStreamBrokerHost.integration.test.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import { afterAll, expect, test } from "bun:test";
 
 import { claudeTranscriptPath } from "@/lib/agent/transcript";
+import { buildPipeline, PIPELINES_SCHEMA_VERSION } from "@/lib/pipelines/store";
 import { ClaudeStreamBrokerHost, FileClaudeDeliveryLedger } from "./claudeStreamBrokerHost";
 import { FileRuntimeEventStore } from "./eventStore";
 import type { RuntimeEvent } from "./engineHost";
@@ -12,11 +13,15 @@ const claudeBinary = process.env.LLV_CLAUDE_BINARY ?? "claude";
 const resumeHome = prepareClaudeIntegrationTestHome(claudeBinary);
 const permissionHome = prepareClaudeIntegrationTestHome(claudeBinary);
 const bypassHome = prepareClaudeIntegrationTestHome(claudeBinary);
+const mcpDefaultHome = prepareClaudeIntegrationTestHome(claudeBinary);
+const mcpCustomHome = prepareClaudeIntegrationTestHome(claudeBinary);
 
 afterAll(() => {
   resumeHome?.cleanup();
   permissionHome?.cleanup();
   bypassHome?.cleanup();
+  mcpDefaultHome?.cleanup();
+  mcpCustomHome?.cleanup();
 });
 
 async function waitFor(
@@ -47,6 +52,158 @@ function containsText(event: RuntimeEvent, expected: string): boolean {
   if (event.kind === "delta") return event.text.includes(expected);
   if (event.kind !== "item") return false;
   return JSON.stringify(event.item).includes(expected);
+}
+
+function processIdentity(pid: number): string | null {
+  try {
+    const stat = fs.readFileSync(`/proc/${pid}/stat`, "utf8");
+    const close = stat.lastIndexOf(")");
+    const fields = stat.slice(close + 2).trim().split(/\s+/);
+    return `${pid}:${fields[19] ?? ""}`;
+  } catch {
+    return null;
+  }
+}
+
+function processTree(rootPid: number): Map<number, string> {
+  const identities = new Map<number, string>();
+  const pending = [rootPid];
+  while (pending.length > 0) {
+    const pid = pending.pop()!;
+    if (identities.has(pid)) continue;
+    const identity = processIdentity(pid);
+    if (!identity) continue;
+    identities.set(pid, identity);
+    try {
+      const children = fs.readFileSync(`/proc/${pid}/task/${pid}/children`, "utf8").trim();
+      for (const child of children.split(/\s+/)) if (child) pending.push(Number(child));
+    } catch { /* the process exited during the snapshot */ }
+  }
+  return identities;
+}
+
+function addRecordedProcess(processes: Map<number, string>, markerPath: string): void {
+  const pid = Number(fs.readFileSync(markerPath, "utf8"));
+  const identity = processIdentity(pid);
+  if (!Number.isInteger(pid) || !identity) throw new Error(`recorded MCP process is unavailable: ${markerPath}`);
+  processes.set(pid, identity);
+  for (const [childPid, childIdentity] of processTree(pid)) processes.set(childPid, childIdentity);
+}
+
+async function expectProcessesReaped(processes: ReadonlyMap<number, string>): Promise<void> {
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    if ([...processes].every(([pid, identity]) => processIdentity(pid) !== identity)) return;
+    await Bun.sleep(25);
+  }
+  const survivors = [...processes].filter(([pid, identity]) => processIdentity(pid) === identity).map(([pid]) => pid);
+  throw new Error(`Claude MCP processes survived release: ${survivors.join(",")}`);
+}
+
+function nativeClaudeTool(event: RuntimeEvent, name: string): boolean {
+  if (event.kind !== "item") return false;
+  const serialized = JSON.stringify(event.item);
+  return serialized.includes('"type":"tool_use"') && serialized.includes(`\"name\":\"${name}\"`);
+}
+
+function nativeClaudeToolResult(event: RuntimeEvent, expectedResult: string): boolean {
+  if (event.kind !== "item") return false;
+  const serialized = JSON.stringify(event.item);
+  return serialized.includes('"tool_use_result"')
+    && serialized.includes(expectedResult)
+    && !serialized.includes("Permission to use")
+    && !serialized.includes("has been denied");
+}
+
+async function exerciseClaudeTool(host: ClaudeStreamBrokerHost, input: {
+  name: string;
+  request: string;
+  expectedResult: string;
+}): Promise<void> {
+  const events = host.attach((await host.health()).eventCursor)[Symbol.asyncIterator]();
+  const sent = await host.send({ id: `issue-607-${crypto.randomUUID()}`, text: input.request });
+  expect(sent.outcome).toBe("turn-started");
+  const observed: RuntimeEvent[] = [];
+  await waitFor(events, (event) => {
+    observed.push(event);
+    return event.kind === "turn-ended";
+  }, 120_000);
+  const sawTool = observed.some((event) => nativeClaudeTool(event, input.name));
+  const sawResult = observed.some((event) => nativeClaudeToolResult(event, input.expectedResult));
+  if (!sawTool || !sawResult) {
+    throw new Error(`native Claude MCP evidence is incomplete: ${JSON.stringify(observed.filter((event) => event.kind === "item").map((event) => event.item))}`);
+  }
+}
+
+function configureClaudeMcpFixture(home: NonNullable<typeof mcpDefaultHome>): {
+  pipelineId: string;
+  viewerPidPath: string;
+  optionalPidPath: string;
+  unrelatedPath: string;
+  hookPath: string;
+} {
+  const pipeline = buildPipeline({
+    id: `claude-mcp-${path.basename(home.directory)}`,
+    task: "Prove native Claude MCP isolation",
+    project: "live-log-viewer-next",
+    repoDir: process.cwd(),
+    stages: [{
+      id: "proof",
+      kind: "run",
+      "prompt": "Exercise Viewer MCP",
+      next: null,
+      onFail: null,
+      effectiveRole: { roleId: null, engine: "claude", model: "haiku", effort: "low", access: "read-only", promptScaffold: null },
+    }],
+    srcPath: null,
+    srcConversationId: null,
+    now: "2026-07-23T00:00:00.000Z",
+    state: "draft",
+  });
+  const stateDir = path.join(home.directory, "viewer-state");
+  const viewerPidPath = path.join(home.directory, "viewer-pid");
+  const optionalPidPath = path.join(home.directory, "optional-pid");
+  const unrelatedPath = path.join(home.directory, "unrelated-started");
+  const hookPath = path.join(home.directory, "viewer-hook-ran");
+  const viewerWrapperPath = path.join(home.directory, "viewer-mcp.ts");
+  const optionalServerPath = path.join(home.directory, "optional-mcp.ts");
+  const unrelatedServerPath = path.join(home.directory, "unrelated-mcp.ts");
+  const hookScriptPath = path.join(home.directory, "viewer-hook.sh");
+  const viewerLauncher = path.resolve(import.meta.dir, "../../../bin/mcp-server.mjs");
+  fs.mkdirSync(stateDir, { recursive: true, mode: 0o700 });
+  fs.writeFileSync(path.join(stateDir, "pipelines.json"), JSON.stringify({
+    schemaVersion: PIPELINES_SCHEMA_VERSION,
+    pipelines: [pipeline],
+  }), { mode: 0o600 });
+  fs.writeFileSync(viewerWrapperPath, [
+    `await Bun.write(${JSON.stringify(viewerPidPath)}, String(process.pid));`,
+    `const child = Bun.spawn({ cmd: [${JSON.stringify(Bun.which("bun") ?? "bun")}, ${JSON.stringify(viewerLauncher)}], stdin: "inherit", stdout: "inherit", stderr: "inherit", env: process.env });`,
+    'process.on("SIGTERM", () => child.kill("SIGTERM"));',
+    'process.on("SIGINT", () => child.kill("SIGINT"));',
+    "process.exitCode = await child.exited;",
+    "",
+  ].join("\n"), { mode: 0o600 });
+  fs.writeFileSync(optionalServerPath, [
+    `await Bun.write(${JSON.stringify(optionalPidPath)}, String(process.pid));`,
+    `const child = Bun.spawn({ cmd: [${JSON.stringify(Bun.which("bun") ?? "bun")}, ${JSON.stringify(viewerLauncher)}], stdin: "inherit", stdout: "inherit", stderr: "inherit", env: process.env });`,
+    'process.on("SIGTERM", () => child.kill("SIGTERM"));',
+    'process.on("SIGINT", () => child.kill("SIGINT"));',
+    "process.exitCode = await child.exited;",
+    "",
+  ].join("\n"), { mode: 0o600 });
+  fs.writeFileSync(unrelatedServerPath, `await Bun.write(${JSON.stringify(unrelatedPath)}, String(process.pid));\nprocess.stdin.resume();\n`, { mode: 0o600 });
+  fs.writeFileSync(hookScriptPath, `#!/bin/sh\nprintf hook > ${JSON.stringify(hookPath)}\n`, { mode: 0o700 });
+  fs.writeFileSync(path.join(home.claudeConfigDir, "settings.json"), JSON.stringify({
+    hooks: { PreToolUse: [{ matcher: "mcp__viewer__get_pipeline", hooks: [{ type: "command", command: hookScriptPath }] }] },
+  }), { mode: 0o600 });
+  fs.writeFileSync(path.join(home.directory, ".claude.json"), JSON.stringify({
+    hasCompletedOnboarding: true,
+    mcpServers: {
+      viewer: { type: "stdio", command: Bun.which("bun") ?? "bun", args: [viewerWrapperPath], env: { LLV_STATE_DIR: stateDir } },
+      "agent-browser": { type: "stdio", command: Bun.which("bun") ?? "bun", args: [optionalServerPath], env: { LLV_STATE_DIR: stateDir } },
+      unrelated: { type: "stdio", command: Bun.which("bun") ?? "bun", args: [unrelatedServerPath] },
+    },
+  }), { mode: 0o600 });
+  return { pipelineId: pipeline.id, viewerPidPath, optionalPidPath, unrelatedPath, hookPath };
 }
 
 test.skipIf(!resumeHome)("real Claude subscription supports late attach and restart resume", async () => {
@@ -196,3 +353,112 @@ test.skipIf(!bypassHome)("real Claude bypass executes Bash without pending atten
     bypassHome.cleanup();
   }
 }, 180_000);
+
+test.skipIf(!mcpDefaultHome)("real Claude default MCP policy exposes Viewer, preserves hooks, excludes sentinels, and reaps the fleet", async () => {
+  if (!mcpDefaultHome) throw new Error("isolated Claude subscription home is unavailable");
+  const fixture = configureClaudeMcpFixture(mcpDefaultHome);
+  let host: ClaudeStreamBrokerHost | null = null;
+  try {
+    host = await ClaudeStreamBrokerHost.start({
+      cwd: process.cwd(),
+      binary: claudeBinary,
+      claudeConfigDir: mcpDefaultHome.claudeConfigDir,
+      claudeProjectsDir: mcpDefaultHome.claudeProjectsDir,
+      mcpStatePath: path.join(mcpDefaultHome.directory, ".claude.json"),
+      env: mcpDefaultHome.env,
+      model: "haiku",
+      permissionMode: "bypassPermissions",
+      systemPrompt: "Use the exact native MCP tool requested by the user. Shell execution is prohibited.",
+      eventStore: new FileRuntimeEventStore(path.join(mcpDefaultHome.directory, "mcp-events")),
+      deliveryLedger: new FileClaudeDeliveryLedger(path.join(mcpDefaultHome.directory, "mcp-deliveries")),
+    });
+    await exerciseClaudeTool(host, {
+      name: "mcp__viewer__get_pipeline",
+      request: `Call the native Viewer MCP tool get_pipeline with clientRequestId "claude-default" and pipelineId "${fixture.pipelineId}". Reply after the successful result.`,
+      expectedResult: fixture.pipelineId,
+    });
+    expect((await host.health()).account).toMatchObject({ type: "claude.ai" });
+    expect(fs.existsSync(fixture.hookPath)).toBeTrue();
+    expect(fs.existsSync(fixture.optionalPidPath)).toBeFalse();
+    expect(fs.existsSync(fixture.unrelatedPath)).toBeFalse();
+    const health = await host.health();
+    if (!health.pid) throw new Error("Claude host pid is unavailable");
+    const processes = processTree(health.pid);
+    addRecordedProcess(processes, fixture.viewerPidPath);
+    await host.release();
+    host = null;
+    await expectProcessesReaped(processes);
+    expect(fs.existsSync(fixture.unrelatedPath)).toBeFalse();
+  } finally {
+    await host?.release();
+  }
+}, 300_000);
+
+test.skipIf(!mcpCustomHome)("real Claude custom MCP policy force-includes Viewer across fresh and adopted hosts with complete cleanup", async () => {
+  if (!mcpCustomHome) throw new Error("isolated Claude subscription home is unavailable");
+  const fixture = configureClaudeMcpFixture(mcpCustomHome);
+  const eventStore = new FileRuntimeEventStore(path.join(mcpCustomHome.directory, "mcp-events"));
+  const deliveryLedger = new FileClaudeDeliveryLedger(path.join(mcpCustomHome.directory, "mcp-deliveries"));
+  const options = {
+    cwd: process.cwd(),
+    binary: claudeBinary,
+    claudeConfigDir: mcpCustomHome.claudeConfigDir,
+    claudeProjectsDir: mcpCustomHome.claudeProjectsDir,
+    mcpStatePath: path.join(mcpCustomHome.directory, ".claude.json"),
+    mcpServers: ["agent-browser"],
+    env: mcpCustomHome.env,
+    model: "haiku",
+    permissionMode: "bypassPermissions",
+    systemPrompt: "Use the exact native MCP tool requested by the user. Shell execution is prohibited.",
+    eventStore,
+    deliveryLedger,
+  };
+  let fresh: ClaudeStreamBrokerHost | null = null;
+  let adopted: ClaudeStreamBrokerHost | null = null;
+  try {
+    fresh = await ClaudeStreamBrokerHost.start(options);
+    await exerciseClaudeTool(fresh, {
+      name: "mcp__viewer__get_pipeline",
+      request: `Call the native Viewer MCP tool get_pipeline with clientRequestId "claude-custom-fresh" and pipelineId "${fixture.pipelineId}". Reply after the successful result.`,
+      expectedResult: fixture.pipelineId,
+    });
+    expect(fs.existsSync(fixture.viewerPidPath)).toBeTrue();
+    expect(fs.existsSync(fixture.optionalPidPath)).toBeTrue();
+    expect(fs.existsSync(fixture.unrelatedPath)).toBeFalse();
+    const sessionId = fresh.identity.sessionId;
+    const cursor = (await fresh.health()).eventCursor;
+    const freshPid = (await fresh.health()).pid;
+    if (!freshPid) throw new Error("fresh Claude host pid is unavailable");
+    const freshProcesses = processTree(freshPid);
+    addRecordedProcess(freshProcesses, fixture.viewerPidPath);
+    addRecordedProcess(freshProcesses, fixture.optionalPidPath);
+    await fresh.release();
+    fresh = null;
+    await expectProcessesReaped(freshProcesses);
+
+    fs.rmSync(fixture.viewerPidPath);
+    fs.rmSync(fixture.optionalPidPath);
+    adopted = await ClaudeStreamBrokerHost.adopt(sessionId, { ...options, initialEventCursor: cursor });
+    await exerciseClaudeTool(adopted, {
+      name: "mcp__viewer__get_pipeline",
+      request: `Call the native Viewer MCP tool get_pipeline with clientRequestId "claude-adopted" and pipelineId "${fixture.pipelineId}". Reply after the successful result.`,
+      expectedResult: fixture.pipelineId,
+    });
+    expect(fs.existsSync(fixture.viewerPidPath)).toBeTrue();
+    expect(fs.existsSync(fixture.optionalPidPath)).toBeTrue();
+    expect(fs.existsSync(fixture.unrelatedPath)).toBeFalse();
+    expect(fs.existsSync(fixture.hookPath)).toBeTrue();
+    const adoptedPid = (await adopted.health()).pid;
+    if (!adoptedPid) throw new Error("adopted Claude host pid is unavailable");
+    const adoptedProcesses = processTree(adoptedPid);
+    addRecordedProcess(adoptedProcesses, fixture.viewerPidPath);
+    addRecordedProcess(adoptedProcesses, fixture.optionalPidPath);
+    await adopted.release();
+    adopted = null;
+    await expectProcessesReaped(adoptedProcesses);
+    expect(fs.existsSync(fixture.unrelatedPath)).toBeFalse();
+  } finally {
+    await fresh?.release();
+    await adopted?.release();
+  }
+}, 420_000);

--- a/src/lib/runtime/claudeStreamBrokerHost.integration.test.ts
+++ b/src/lib/runtime/claudeStreamBrokerHost.integration.test.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
+import crypto from "node:crypto";
 import { afterAll, expect, test } from "bun:test";
 
 import { claudeTranscriptPath } from "@/lib/agent/transcript";
@@ -136,6 +137,7 @@ async function exerciseClaudeTool(host: ClaudeStreamBrokerHost, input: {
 
 function configureClaudeMcpFixture(home: NonNullable<typeof mcpDefaultHome>): {
   pipelineId: string;
+  cwd: string;
   viewerPidPath: string;
   optionalPidPath: string;
   unrelatedPath: string;
@@ -168,7 +170,9 @@ function configureClaudeMcpFixture(home: NonNullable<typeof mcpDefaultHome>): {
   const optionalServerPath = path.join(home.directory, "optional-mcp.ts");
   const unrelatedServerPath = path.join(home.directory, "unrelated-mcp.ts");
   const hookScriptPath = path.join(home.directory, "viewer-hook.sh");
+  const projectRoot = path.join(home.directory, "project");
   const viewerLauncher = path.resolve(import.meta.dir, "../../../bin/mcp-server.mjs");
+  fs.mkdirSync(path.join(projectRoot, ".git"), { recursive: true, mode: 0o700 });
   fs.mkdirSync(stateDir, { recursive: true, mode: 0o700 });
   fs.writeFileSync(path.join(stateDir, "pipelines.json"), JSON.stringify({
     schemaVersion: PIPELINES_SCHEMA_VERSION,
@@ -193,17 +197,29 @@ function configureClaudeMcpFixture(home: NonNullable<typeof mcpDefaultHome>): {
   fs.writeFileSync(unrelatedServerPath, `await Bun.write(${JSON.stringify(unrelatedPath)}, String(process.pid));\nprocess.stdin.resume();\n`, { mode: 0o600 });
   fs.writeFileSync(hookScriptPath, `#!/bin/sh\nprintf hook > ${JSON.stringify(hookPath)}\n`, { mode: 0o700 });
   fs.writeFileSync(path.join(home.claudeConfigDir, "settings.json"), JSON.stringify({
+    enabledMcpjsonServers: ["agent-browser"],
     hooks: { PreToolUse: [{ matcher: "mcp__viewer__get_pipeline", hooks: [{ type: "command", command: hookScriptPath }] }] },
   }), { mode: 0o600 });
   fs.writeFileSync(path.join(home.directory, ".claude.json"), JSON.stringify({
     hasCompletedOnboarding: true,
     mcpServers: {
       viewer: { type: "stdio", command: Bun.which("bun") ?? "bun", args: [viewerWrapperPath], env: { LLV_STATE_DIR: stateDir } },
-      "agent-browser": { type: "stdio", command: Bun.which("bun") ?? "bun", args: [optionalServerPath], env: { LLV_STATE_DIR: stateDir } },
-      unrelated: { type: "stdio", command: Bun.which("bun") ?? "bun", args: [unrelatedServerPath] },
     },
   }), { mode: 0o600 });
-  return { pipelineId: pipeline.id, viewerPidPath, optionalPidPath, unrelatedPath, hookPath };
+  fs.writeFileSync(path.join(projectRoot, ".mcp.json"), JSON.stringify({
+    mcpServers: {
+      "agent-browser": {
+        type: "stdio",
+        command: Bun.which("bun") ?? "bun",
+        args: [optionalServerPath],
+        env: { LLV_STATE_DIR: stateDir, PROJECT_AUTH: "preserved" },
+        timeout: 120_000,
+        alwaysLoad: true,
+      },
+      "project-unrelated": { type: "stdio", command: Bun.which("bun") ?? "bun", args: [unrelatedServerPath] },
+    },
+  }), { mode: 0o600 });
+  return { pipelineId: pipeline.id, cwd: projectRoot, viewerPidPath, optionalPidPath, unrelatedPath, hookPath };
 }
 
 test.skipIf(!resumeHome)("real Claude subscription supports late attach and restart resume", async () => {
@@ -360,7 +376,7 @@ test.skipIf(!mcpDefaultHome)("real Claude default MCP policy exposes Viewer, pre
   let host: ClaudeStreamBrokerHost | null = null;
   try {
     host = await ClaudeStreamBrokerHost.start({
-      cwd: process.cwd(),
+      cwd: fixture.cwd,
       binary: claudeBinary,
       claudeConfigDir: mcpDefaultHome.claudeConfigDir,
       claudeProjectsDir: mcpDefaultHome.claudeProjectsDir,
@@ -400,7 +416,7 @@ test.skipIf(!mcpCustomHome)("real Claude custom MCP policy force-includes Viewer
   const eventStore = new FileRuntimeEventStore(path.join(mcpCustomHome.directory, "mcp-events"));
   const deliveryLedger = new FileClaudeDeliveryLedger(path.join(mcpCustomHome.directory, "mcp-deliveries"));
   const options = {
-    cwd: process.cwd(),
+    cwd: fixture.cwd,
     binary: claudeBinary,
     claudeConfigDir: mcpCustomHome.claudeConfigDir,
     claudeProjectsDir: mcpCustomHome.claudeProjectsDir,
@@ -417,6 +433,26 @@ test.skipIf(!mcpCustomHome)("real Claude custom MCP policy force-includes Viewer
   let adopted: ClaudeStreamBrokerHost | null = null;
   try {
     fresh = await ClaudeStreamBrokerHost.start(options);
+    const profileId = `structured-${crypto.createHash("sha256").update(fresh.identity.sessionId).digest("hex").slice(0, 24)}`;
+    const freshMcpConfig = JSON.parse(fs.readFileSync(path.join(
+      mcpCustomHome.claudeConfigDir,
+      ".llv",
+      "spawn-mcp",
+      `${profileId}.json`,
+    ), "utf8")) as { mcpServers: Record<string, unknown> };
+    const freshSettings = JSON.parse(fs.readFileSync(path.join(
+      mcpCustomHome.claudeConfigDir,
+      ".llv",
+      "spawn-settings",
+      `${profileId}.json`,
+    ), "utf8")) as { enabledMcpjsonServers: string[] };
+    expect(freshMcpConfig.mcpServers["agent-browser"]).toMatchObject({
+      env: { PROJECT_AUTH: "preserved" },
+      timeout: 120_000,
+      alwaysLoad: true,
+    });
+    expect(freshMcpConfig.mcpServers).not.toHaveProperty("project-unrelated");
+    expect(freshSettings.enabledMcpjsonServers).toEqual(["agent-browser"]);
     await exerciseClaudeTool(fresh, {
       name: "mcp__viewer__get_pipeline",
       request: `Call the native Viewer MCP tool get_pipeline with clientRequestId "claude-custom-fresh" and pipelineId "${fixture.pipelineId}". Reply after the successful result.`,

--- a/src/lib/runtime/claudeStreamBrokerHost.integration.test.ts
+++ b/src/lib/runtime/claudeStreamBrokerHost.integration.test.ts
@@ -445,7 +445,7 @@ test.skipIf(!mcpCustomHome)("real Claude custom MCP policy force-includes Viewer
       ".llv",
       "spawn-settings",
       `${profileId}.json`,
-    ), "utf8")) as { enabledMcpjsonServers: string[] };
+    ), "utf8")) as { enabledMcpjsonServers: string[]; disabledMcpjsonServers: string[] };
     expect(freshMcpConfig.mcpServers["agent-browser"]).toMatchObject({
       env: { PROJECT_AUTH: "preserved" },
       timeout: 120_000,
@@ -453,9 +453,10 @@ test.skipIf(!mcpCustomHome)("real Claude custom MCP policy force-includes Viewer
     });
     expect(freshMcpConfig.mcpServers).not.toHaveProperty("project-unrelated");
     expect(freshSettings.enabledMcpjsonServers).toEqual(["agent-browser"]);
+    expect(freshSettings.disabledMcpjsonServers).toEqual(["project-unrelated"]);
     await exerciseClaudeTool(fresh, {
-      name: "mcp__viewer__get_pipeline",
-      request: `Call the native Viewer MCP tool get_pipeline with clientRequestId "claude-custom-fresh" and pipelineId "${fixture.pipelineId}". Reply after the successful result.`,
+      name: "mcp__agent-browser__get_pipeline",
+      request: `Call the exact native tool mcp__agent-browser__get_pipeline with clientRequestId "claude-custom-fresh" and pipelineId "${fixture.pipelineId}". Do not use mcp__viewer__get_pipeline or shell execution. Reply after the successful result.`,
       expectedResult: fixture.pipelineId,
     });
     expect(fs.existsSync(fixture.viewerPidPath)).toBeTrue();
@@ -476,8 +477,13 @@ test.skipIf(!mcpCustomHome)("real Claude custom MCP policy force-includes Viewer
     fs.rmSync(fixture.optionalPidPath);
     adopted = await ClaudeStreamBrokerHost.adopt(sessionId, { ...options, initialEventCursor: cursor });
     await exerciseClaudeTool(adopted, {
+      name: "mcp__agent-browser__get_pipeline",
+      request: `Call the exact native tool mcp__agent-browser__get_pipeline with clientRequestId "claude-adopted" and pipelineId "${fixture.pipelineId}". Do not use mcp__viewer__get_pipeline or shell execution. Reply after the successful result.`,
+      expectedResult: fixture.pipelineId,
+    });
+    await exerciseClaudeTool(adopted, {
       name: "mcp__viewer__get_pipeline",
-      request: `Call the native Viewer MCP tool get_pipeline with clientRequestId "claude-adopted" and pipelineId "${fixture.pipelineId}". Reply after the successful result.`,
+      request: `Call the exact native tool mcp__viewer__get_pipeline with clientRequestId "claude-adopted-viewer" and pipelineId "${fixture.pipelineId}". Shell execution is prohibited. Reply after the successful result.`,
       expectedResult: fixture.pipelineId,
     });
     expect(fs.existsSync(fixture.viewerPidPath)).toBeTrue();

--- a/src/lib/runtime/claudeStreamBrokerHost.test.ts
+++ b/src/lib/runtime/claudeStreamBrokerHost.test.ts
@@ -168,7 +168,7 @@ const IMAGE_REF: StructuredImageRef = {
 };
 
 describe("ClaudeStreamBrokerHost", () => {
-  test("structured Claude hosts materialize their per-spawn MCP allowlist", async () => {
+  test("structured Claude hosts launch with an exclusive native MCP allowlist", async () => {
     const home = fs.mkdtempSync(path.join(os.tmpdir(), "llv-claude-structured-mcp-"));
     fs.writeFileSync(path.join(home, ".claude.json"), JSON.stringify({
       mcpServers: {
@@ -189,9 +189,11 @@ describe("ClaudeStreamBrokerHost", () => {
       spawnProcess: fakeSpawn(child, captured),
     });
 
-    const settingsPath = captured.args![captured.args!.indexOf("--settings") + 1]!;
-    const settings = JSON.parse(fs.readFileSync(settingsPath, "utf8")) as { mcpServers: Record<string, unknown> };
-    expect(settings.mcpServers).toEqual({
+    expect(captured.args).toContain("--strict-mcp-config");
+    expect(captured.args).not.toContain("--safe-mode");
+    const mcpConfigPath = captured.args![captured.args!.indexOf("--mcp-config") + 1]!;
+    const mcpConfig = JSON.parse(fs.readFileSync(mcpConfigPath, "utf8")) as { mcpServers: Record<string, unknown> };
+    expect(mcpConfig.mcpServers).toEqual({
       viewer: { type: "stdio", command: "viewer-mcp" },
       "agent-browser": { type: "stdio", command: "browser-mcp" },
     });
@@ -309,7 +311,8 @@ describe("ClaudeStreamBrokerHost", () => {
     expect(captured.options?.env).toEqual({ NODE_ENV: "test", PATH: process.env.PATH });
     expect(captured.args).toContain("--input-format");
     expect(captured.args).toContain("--output-format");
-    expect(captured.args).toContain("--safe-mode");
+    expect(captured.args).not.toContain("--safe-mode");
+    expect(captured.args).toContain("--strict-mcp-config");
     expect(captured.args).toContain("--disallowedTools");
     expect(captured.args).toContain("Task,Agent,Workflow,TeamCreate,TeamDelete,SendMessage");
     expect(captured.args).toContain("--replay-user-messages");
@@ -627,6 +630,13 @@ describe("ClaudeStreamBrokerHost", () => {
       env: { SHARED_SETTING: "kept" },
       hooks: { PreToolUse: [{ matcher: "Read", hooks: [{ type: "command", command: "shared-read-hook" }] }] },
     }));
+    fs.writeFileSync(path.join(managedHome, ".claude.json"), JSON.stringify({
+      mcpServers: {
+        viewer: { type: "stdio", command: "viewer-mcp" },
+        "agent-browser": { type: "stdio", command: "browser-mcp" },
+        unrelated: { type: "stdio", command: "unrelated-mcp" },
+      },
+    }));
 
     const freshChild = new FakeClaude(new RecordingDeliveryLedger());
     const freshCapture: { args?: string[] } = {};
@@ -635,6 +645,7 @@ describe("ClaudeStreamBrokerHost", () => {
       cwd: managedHome,
       claudeConfigDir: managedHome,
       spawnPolicyBaseSettingsPath: sharedSettingsPath,
+      mcpServers: ["agent-browser"],
       readAuthStatus: () => ({ loggedIn: true, authMethod: "claude.ai", subscriptionType: "max" }),
       readTranscript: () => [],
       spawnProcess: fakeSpawn(freshChild, freshCapture),
@@ -645,6 +656,8 @@ describe("ClaudeStreamBrokerHost", () => {
       env: Record<string, string>;
       hooks: { PreToolUse: Array<{ matcher: string }> };
     };
+    const freshMcpPath = freshCapture.args![freshCapture.args!.indexOf("--mcp-config") + 1]!;
+    const freshMcp = JSON.parse(fs.readFileSync(freshMcpPath, "utf8"));
     await fresh.release();
 
     const adoptedChild = new FakeClaude(new RecordingDeliveryLedger());
@@ -653,16 +666,26 @@ describe("ClaudeStreamBrokerHost", () => {
       cwd: managedHome,
       claudeConfigDir: managedHome,
       spawnPolicyBaseSettingsPath: sharedSettingsPath,
+      mcpServers: ["agent-browser"],
       readAuthStatus: () => ({ loggedIn: true, authMethod: "claude.ai", subscriptionType: "max" }),
       readTranscript: () => [],
       spawnProcess: fakeSpawn(adoptedChild, adoptedCapture),
     });
     const adoptedSettingsPath = adoptedCapture.args![adoptedCapture.args!.indexOf("--settings") + 1]!;
     const adoptedSettings = JSON.parse(fs.readFileSync(adoptedSettingsPath, "utf8"));
+    const adoptedMcpPath = adoptedCapture.args![adoptedCapture.args!.indexOf("--mcp-config") + 1]!;
+    const adoptedMcp = JSON.parse(fs.readFileSync(adoptedMcpPath, "utf8"));
     expect(freshSettings.theme).toBe("shared-dark");
     expect(freshSettings.env).toEqual({ SHARED_SETTING: "kept" });
     expect(freshSettings.hooks.PreToolUse.map((group) => group.matcher)).toEqual(["Read", "Task|Agent|Workflow|TeamCreate|TeamDelete|SendMessage"]);
     expect(adoptedSettings).toEqual(freshSettings);
+    expect(freshCapture.args).toContain("--strict-mcp-config");
+    expect(adoptedCapture.args).toContain("--strict-mcp-config");
+    expect(adoptedMcp).toEqual(freshMcp);
+    expect(freshMcp).toEqual({ mcpServers: {
+      viewer: { type: "stdio", command: "viewer-mcp" },
+      "agent-browser": { type: "stdio", command: "browser-mcp" },
+    } });
     await adopted.release();
 
     const legacyHome = fs.mkdtempSync(path.join(os.tmpdir(), "llv-claude-legacy-policy-"));

--- a/src/lib/runtime/claudeStreamBrokerHost.test.ts
+++ b/src/lib/runtime/claudeStreamBrokerHost.test.ts
@@ -168,6 +168,37 @@ const IMAGE_REF: StructuredImageRef = {
 };
 
 describe("ClaudeStreamBrokerHost", () => {
+  test("structured Claude hosts materialize their per-spawn MCP allowlist", async () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), "llv-claude-structured-mcp-"));
+    fs.writeFileSync(path.join(home, ".claude.json"), JSON.stringify({
+      mcpServers: {
+        viewer: { type: "stdio", command: "viewer-mcp" },
+        "agent-browser": { type: "stdio", command: "browser-mcp" },
+        unrelated: { type: "stdio", command: "unrelated-mcp" },
+      },
+    }));
+    const child = new FakeClaude(new RecordingDeliveryLedger());
+    const captured: { args?: string[] } = {};
+    const host = await ClaudeStreamBrokerHost.start({
+      cwd: "/repo",
+      claudeConfigDir: home,
+      mcpServers: ["viewer", "agent-browser"],
+      eventStore: new MemoryEventStore(),
+      readAuthStatus: () => ({ loggedIn: true, authMethod: "claude.ai", subscriptionType: "max" }),
+      readTranscript: () => [],
+      spawnProcess: fakeSpawn(child, captured),
+    });
+
+    const settingsPath = captured.args![captured.args!.indexOf("--settings") + 1]!;
+    const settings = JSON.parse(fs.readFileSync(settingsPath, "utf8")) as { mcpServers: Record<string, unknown> };
+    expect(settings.mcpServers).toEqual({
+      viewer: { type: "stdio", command: "viewer-mcp" },
+      "agent-browser": { type: "stdio", command: "browser-mcp" },
+    });
+    await host.release();
+    expect(child.signals).toContain("SIGTERM");
+  });
+
   test("defaults writable pane-less Claude processes to bypassPermissions", async () => {
     const ledger = new RecordingDeliveryLedger();
     const child = new FakeClaude(ledger);

--- a/src/lib/runtime/claudeStreamBrokerHost.ts
+++ b/src/lib/runtime/claudeStreamBrokerHost.ts
@@ -554,7 +554,7 @@ export class ClaudeStreamBrokerHost implements EngineHost {
     }
     const args = [
       "-p", "--input-format", "stream-json", "--output-format", "stream-json", "--verbose",
-      "--safe-mode", "--include-partial-messages", "--replay-user-messages",
+      "--include-partial-messages", "--replay-user-messages",
       "--permission-prompt-tool", "stdio",
       "--permission-mode", effectiveClaudePermissionMode(options),
     ];
@@ -573,8 +573,11 @@ export class ClaudeStreamBrokerHost implements EngineHost {
         mcpServers: options.mcpServers,
         mcpStatePath: options.mcpStatePath,
       });
-      args.push("--settings", settings.settingsPath);
-    }
+      args.push(
+        "--settings", settings.settingsPath,
+        "--strict-mcp-config", "--mcp-config", settings.mcpConfigPath,
+      );
+    } else args.push("--strict-mcp-config");
     if (resume) args.push("--resume", sessionId);
     else args.push("--session-id", sessionId);
     if (options.model) args.push("--model", options.model);

--- a/src/lib/runtime/claudeStreamBrokerHost.ts
+++ b/src/lib/runtime/claudeStreamBrokerHost.ts
@@ -179,6 +179,8 @@ export interface ClaudeStreamBrokerHostOptions {
   claudeProjectsDir?: string;
   spawnPolicyBaseSettingsPath?: string | null;
   allowSubagents?: boolean;
+  mcpServers?: string[];
+  mcpStatePath?: string;
   readOnly?: boolean;
   binary?: string;
   model?: string;
@@ -567,6 +569,9 @@ export class ClaudeStreamBrokerHost implements EngineHost {
         allowSubagents: options.allowSubagents,
         baseSettingsPath: options.spawnPolicyBaseSettingsPath,
         profileId,
+        cwd: options.cwd,
+        mcpServers: options.mcpServers,
+        mcpStatePath: options.mcpStatePath,
       });
       args.push("--settings", settings.settingsPath);
     }

--- a/src/lib/runtime/codexAppServerHost.integration.test.ts
+++ b/src/lib/runtime/codexAppServerHost.integration.test.ts
@@ -99,7 +99,7 @@ function recordedProcess(markerPath: string): { pid: number; identity: string } 
   return { pid, identity };
 }
 
-function nativeViewerCall(event: RuntimeEvent, pipelineId: string): boolean {
+function nativeViewerCall(event: RuntimeEvent, pipelineId: string, server: string): boolean {
   if (event.kind !== "item" || event.phase !== "completed") return false;
   const item = event.item as {
     type?: string;
@@ -110,7 +110,7 @@ function nativeViewerCall(event: RuntimeEvent, pipelineId: string): boolean {
     error?: unknown;
   };
   return item.type === "mcpToolCall"
-    && item.server === "viewer"
+    && item.server === server
     && item.tool === "get_pipeline"
     && item.status === "completed"
     && item.error == null
@@ -120,13 +120,14 @@ function nativeViewerCall(event: RuntimeEvent, pipelineId: string): boolean {
 async function exerciseNativeViewer(
   host: CodexAppServerHost,
   pipelineId: string,
-  label: "fresh" | "adopted",
+  label: "fresh" | "adopted" | "custom",
+  server = "viewer",
 ): Promise<void> {
   const cursor = (await host.health()).eventCursor;
   const events = host.attach(cursor)[Symbol.asyncIterator]();
   const started = await host.send({
     id: `issue-607-${label}-${crypto.randomUUID()}`,
-    text: `Call the native Viewer MCP tool get_pipeline with clientRequestId "issue-607-${label}" and pipelineId "${pipelineId}". Shell execution is prohibited. After the successful tool result, reply exactly VIEWER_NATIVE_${label.toUpperCase()}.`,
+    text: `Call the native ${server} MCP tool get_pipeline with clientRequestId "issue-607-${label}" and pipelineId "${pipelineId}". Shell execution is prohibited. After the successful tool result, reply exactly VIEWER_NATIVE_${label.toUpperCase()}.`,
   });
   expect(started.outcome).toBe("turn-started");
   const observed: RuntimeEvent[] = [];
@@ -145,7 +146,7 @@ async function exerciseNativeViewer(
       : event);
     throw new Error(`${String(error)}; health=${JSON.stringify(health)}; processes=${JSON.stringify(processes)}; events=${JSON.stringify(eventSummary)}`);
   }
-  if (!observed.some((event) => nativeViewerCall(event, pipelineId))) {
+  if (!observed.some((event) => nativeViewerCall(event, pipelineId, server))) {
     const itemKinds = observed
       .filter((event) => event.kind === "item")
       .map((event) => JSON.stringify(event.item).slice(0, 500));
@@ -235,7 +236,7 @@ test.skipIf(!isolatedHome)("real Codex subscription supports late attach, steeri
   }
 }, 180_000);
 
-test.skipIf(!mcpHome)("real Codex exposes native Viewer tools on fresh start and adoption with complete MCP cleanup", async () => {
+test.skipIf(!mcpHome)("real structured Codex enforces default and custom MCP allowlists across fresh and adopted hosts with complete cleanup", async () => {
   if (!mcpHome) throw new Error("isolated Codex subscription home is unavailable");
   const pipeline = buildPipeline({
     id: "mcp-native-proof",
@@ -266,7 +267,9 @@ test.skipIf(!mcpHome)("real Codex exposes native Viewer tools on fresh start and
   const markerPath = path.join(mcpHome.directory, "unrelated-started");
   const sentinelPath = path.join(mcpHome.directory, "unrelated-mcp.ts");
   const viewerPidPath = path.join(mcpHome.directory, "viewer-pid");
+  const optionalPidPath = path.join(mcpHome.directory, "optional-pid");
   const viewerWrapperPath = path.join(mcpHome.directory, "viewer-mcp.ts");
+  const optionalWrapperPath = path.join(mcpHome.directory, "optional-mcp.ts");
   const viewerLauncher = path.resolve(import.meta.dir, "../../../bin/mcp-server.mjs");
   fs.mkdirSync(stateDir, { recursive: true, mode: 0o700 });
   fs.writeFileSync(path.join(stateDir, "pipelines.json"), JSON.stringify({
@@ -282,11 +285,25 @@ test.skipIf(!mcpHome)("real Codex exposes native Viewer tools on fresh start and
     "process.exitCode = await child.exited;",
     "",
   ].join("\n"), { mode: 0o600 });
+  fs.writeFileSync(optionalWrapperPath, [
+    `await Bun.write(${JSON.stringify(optionalPidPath)}, String(process.pid));`,
+    `const child = Bun.spawn({ cmd: [${JSON.stringify(Bun.which("bun") ?? "bun")}, ${JSON.stringify(viewerLauncher)}], stdin: "inherit", stdout: "inherit", stderr: "inherit", env: process.env });`,
+    'process.on("SIGTERM", () => child.kill("SIGTERM"));',
+    'process.on("SIGINT", () => child.kill("SIGINT"));',
+    "process.exitCode = await child.exited;",
+    "",
+  ].join("\n"), { mode: 0o600 });
   fs.writeFileSync(path.join(mcpHome.codexHome, "config.toml"), [
     "[mcp_servers.viewer]",
     `command = ${JSON.stringify(Bun.which("bun") ?? "bun")}`,
     `args = [${JSON.stringify(viewerWrapperPath)}]`,
     "[mcp_servers.viewer.env]",
+    `LLV_STATE_DIR = ${JSON.stringify(stateDir)}`,
+    "[mcp_servers.agent-browser]",
+    `command = ${JSON.stringify(Bun.which("bun") ?? "bun")}`,
+    `args = [${JSON.stringify(optionalWrapperPath)}]`,
+    'default_tools_approval_mode = "approve"',
+    "[mcp_servers.agent-browser.env]",
     `LLV_STATE_DIR = ${JSON.stringify(stateDir)}`,
     "[mcp_servers.unrelated]",
     `command = ${JSON.stringify(Bun.which("bun") ?? "bun")}`,
@@ -311,10 +328,12 @@ test.skipIf(!mcpHome)("real Codex exposes native Viewer tools on fresh start and
   };
   let fresh: CodexAppServerHost | null = null;
   let adopted: CodexAppServerHost | null = null;
+  let custom: CodexAppServerHost | null = null;
   try {
     fresh = await CodexAppServerHost.start(options);
     await exerciseNativeViewer(fresh, pipeline.id, "fresh");
     expect(fs.existsSync(markerPath)).toBeFalse();
+    expect(fs.existsSync(optionalPidPath)).toBeFalse();
     const freshHealth = await fresh.health();
     if (!freshHealth.pid) throw new Error("fresh app-server pid is unavailable");
     const freshProcesses = processTree(freshHealth.pid);
@@ -331,6 +350,7 @@ test.skipIf(!mcpHome)("real Codex exposes native Viewer tools on fresh start and
     adopted = await CodexAppServerHost.adopt(threadId, { ...options, initialEventCursor: cursor });
     await exerciseNativeViewer(adopted, pipeline.id, "adopted");
     expect(fs.existsSync(markerPath)).toBeFalse();
+    expect(fs.existsSync(optionalPidPath)).toBeFalse();
     const adoptedHealth = await adopted.health();
     if (!adoptedHealth.pid) throw new Error("adopted app-server pid is unavailable");
     const adoptedProcesses = processTree(adoptedHealth.pid);
@@ -341,9 +361,28 @@ test.skipIf(!mcpHome)("real Codex exposes native Viewer tools on fresh start and
     adopted = null;
     await expectProcessesReaped(adoptedProcesses);
     expect(fs.existsSync(markerPath)).toBeFalse();
+
+    fs.rmSync(viewerPidPath);
+    custom = await CodexAppServerHost.start({ ...options, mcpServers: ["agent-browser"] });
+    await exerciseNativeViewer(custom, pipeline.id, "custom", "agent-browser");
+    expect(fs.existsSync(markerPath)).toBeFalse();
+    const customHealth = await custom.health();
+    if (!customHealth.pid) throw new Error("custom app-server pid is unavailable");
+    const customProcesses = processTree(customHealth.pid);
+    const customViewer = recordedProcess(viewerPidPath);
+    const customOptional = recordedProcess(optionalPidPath);
+    addProcessTree(customProcesses, customViewer.pid);
+    addProcessTree(customProcesses, customOptional.pid);
+    expect(customProcesses.get(customViewer.pid)).toBe(customViewer.identity);
+    expect(customProcesses.get(customOptional.pid)).toBe(customOptional.identity);
+    await custom.release();
+    custom = null;
+    await expectProcessesReaped(customProcesses);
+    expect(fs.existsSync(markerPath)).toBeFalse();
   } finally {
     await fresh?.release();
     await adopted?.release();
+    await custom?.release();
     mcpHome.cleanup();
   }
 }, 300_000);

--- a/src/lib/runtime/codexAppServerHost.integration.test.ts
+++ b/src/lib/runtime/codexAppServerHost.integration.test.ts
@@ -6,11 +6,16 @@ import { CodexAppServerHost } from "./codexAppServerHost";
 import type { RuntimeEvent } from "./engineHost";
 import { FileRuntimeEventStore } from "./eventStore";
 import { pathIsInside, prepareCodexIntegrationTestHome } from "./integrationTestHome";
+import { buildPipeline, PIPELINES_SCHEMA_VERSION } from "@/lib/pipelines/store";
 
 const codexBinary = process.env.LLV_CODEX_BINARY ?? "codex";
 const isolatedHome = prepareCodexIntegrationTestHome(codexBinary);
+const mcpHome = prepareCodexIntegrationTestHome(codexBinary);
 
-afterAll(() => isolatedHome?.cleanup());
+afterAll(() => {
+  isolatedHome?.cleanup();
+  mcpHome?.cleanup();
+});
 
 async function waitFor(
   iterator: AsyncIterator<RuntimeEvent>,
@@ -39,6 +44,113 @@ function containsText(event: RuntimeEvent, expected: string): boolean {
   if (event.kind !== "item") return false;
   const item = event.item as { type?: string; text?: string } | null;
   return item?.type === "agentMessage" && item.text?.includes(expected) === true;
+}
+
+function processIdentity(pid: number): string | null {
+  try {
+    const stat = fs.readFileSync(`/proc/${pid}/stat`, "utf8");
+    const close = stat.lastIndexOf(")");
+    const fields = stat.slice(close + 2).trim().split(/\s+/);
+    return `${pid}:${fields[19] ?? ""}`;
+  } catch {
+    return null;
+  }
+}
+
+function processTree(rootPid: number): Map<number, string> {
+  const identities = new Map<number, string>();
+  const pending = [rootPid];
+  while (pending.length > 0) {
+    const pid = pending.pop()!;
+    if (identities.has(pid)) continue;
+    const identity = processIdentity(pid);
+    if (!identity) continue;
+    identities.set(pid, identity);
+    try {
+      const children = fs.readFileSync(`/proc/${pid}/task/${pid}/children`, "utf8").trim();
+      for (const child of children.split(/\s+/)) if (child) pending.push(Number(child));
+    } catch { /* the process exited during the snapshot */ }
+  }
+  return identities;
+}
+
+function processCommand(pid: number): string {
+  try { return fs.readFileSync(`/proc/${pid}/cmdline`, "utf8").replaceAll("\0", " "); }
+  catch { return ""; }
+}
+
+async function expectProcessesReaped(processes: ReadonlyMap<number, string>): Promise<void> {
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    if ([...processes].every(([pid, identity]) => processIdentity(pid) !== identity)) return;
+    await Bun.sleep(25);
+  }
+  const survivors = [...processes].filter(([pid, identity]) => processIdentity(pid) === identity).map(([pid]) => pid);
+  throw new Error(`structured host processes survived release: ${survivors.join(",")}`);
+}
+
+function addProcessTree(processes: Map<number, string>, rootPid: number): void {
+  for (const [pid, identity] of processTree(rootPid)) processes.set(pid, identity);
+}
+
+function recordedProcess(markerPath: string): { pid: number; identity: string } {
+  const pid = Number(fs.readFileSync(markerPath, "utf8"));
+  const identity = processIdentity(pid);
+  if (!Number.isInteger(pid) || !identity) throw new Error("recorded Viewer MCP process is unavailable");
+  return { pid, identity };
+}
+
+function nativeViewerCall(event: RuntimeEvent, pipelineId: string): boolean {
+  if (event.kind !== "item" || event.phase !== "completed") return false;
+  const item = event.item as {
+    type?: string;
+    server?: string;
+    tool?: string;
+    status?: string;
+    result?: unknown;
+    error?: unknown;
+  };
+  return item.type === "mcpToolCall"
+    && item.server === "viewer"
+    && item.tool === "get_pipeline"
+    && item.status === "completed"
+    && item.error == null
+    && JSON.stringify(item.result).includes(pipelineId);
+}
+
+async function exerciseNativeViewer(
+  host: CodexAppServerHost,
+  pipelineId: string,
+  label: "fresh" | "adopted",
+): Promise<void> {
+  const cursor = (await host.health()).eventCursor;
+  const events = host.attach(cursor)[Symbol.asyncIterator]();
+  const started = await host.send({
+    id: `issue-607-${label}-${crypto.randomUUID()}`,
+    text: `Call the native Viewer MCP tool get_pipeline with clientRequestId "issue-607-${label}" and pipelineId "${pipelineId}". Shell execution is prohibited. After the successful tool result, reply exactly VIEWER_NATIVE_${label.toUpperCase()}.`,
+  });
+  expect(started.outcome).toBe("turn-started");
+  const observed: RuntimeEvent[] = [];
+  try {
+    await waitFor(events, (event) => {
+      observed.push(event);
+      return event.kind === "turn-ended" && event.status === "completed";
+    }, 120_000);
+  } catch (error) {
+    const health = await host.health();
+    const processes = health.pid
+      ? [...processTree(health.pid).keys()].map((pid) => ({ pid, command: processCommand(pid) }))
+      : [];
+    const eventSummary = observed.map((event) => event.kind === "item"
+      ? { kind: event.kind, phase: event.phase, item: JSON.stringify(event.item).slice(0, 1_000) }
+      : event);
+    throw new Error(`${String(error)}; health=${JSON.stringify(health)}; processes=${JSON.stringify(processes)}; events=${JSON.stringify(eventSummary)}`);
+  }
+  if (!observed.some((event) => nativeViewerCall(event, pipelineId))) {
+    const itemKinds = observed
+      .filter((event) => event.kind === "item")
+      .map((event) => JSON.stringify(event.item).slice(0, 500));
+    throw new Error(`native viewer.get_pipeline event is missing: ${JSON.stringify(itemKinds)}`);
+  }
 }
 
 test.skipIf(!isolatedHome)("real Codex subscription supports late attach, steering, and restart resume", async () => {
@@ -122,3 +234,116 @@ test.skipIf(!isolatedHome)("real Codex subscription supports late attach, steeri
     isolatedHome.cleanup();
   }
 }, 180_000);
+
+test.skipIf(!mcpHome)("real Codex exposes native Viewer tools on fresh start and adoption with complete MCP cleanup", async () => {
+  if (!mcpHome) throw new Error("isolated Codex subscription home is unavailable");
+  const pipeline = buildPipeline({
+    id: "mcp-native-proof",
+    task: "Prove native Viewer MCP",
+    project: "live-log-viewer-next",
+    repoDir: process.cwd(),
+    stages: [{
+      id: "proof",
+      kind: "run",
+      "prompt": "Exercise Viewer MCP",
+      next: null,
+      onFail: null,
+      effectiveRole: {
+        roleId: null,
+        engine: "codex",
+        model: "gpt-5.4-mini",
+        effort: "low",
+        access: "read-only",
+        promptScaffold: null,
+      },
+    }],
+    srcPath: null,
+    srcConversationId: null,
+    now: "2026-07-23T00:00:00.000Z",
+    state: "draft",
+  });
+  const stateDir = path.join(mcpHome.directory, "viewer-state");
+  const markerPath = path.join(mcpHome.directory, "unrelated-started");
+  const sentinelPath = path.join(mcpHome.directory, "unrelated-mcp.ts");
+  const viewerPidPath = path.join(mcpHome.directory, "viewer-pid");
+  const viewerWrapperPath = path.join(mcpHome.directory, "viewer-mcp.ts");
+  const viewerLauncher = path.resolve(import.meta.dir, "../../../bin/mcp-server.mjs");
+  fs.mkdirSync(stateDir, { recursive: true, mode: 0o700 });
+  fs.writeFileSync(path.join(stateDir, "pipelines.json"), JSON.stringify({
+    schemaVersion: PIPELINES_SCHEMA_VERSION,
+    pipelines: [pipeline],
+  }), { mode: 0o600 });
+  fs.writeFileSync(sentinelPath, `await Bun.write(${JSON.stringify(markerPath)}, String(process.pid));\nprocess.stdin.resume();\n`, { mode: 0o600 });
+  fs.writeFileSync(viewerWrapperPath, [
+    `await Bun.write(${JSON.stringify(viewerPidPath)}, String(process.pid));`,
+    `const child = Bun.spawn({ cmd: [${JSON.stringify(Bun.which("bun") ?? "bun")}, ${JSON.stringify(viewerLauncher)}], stdin: "inherit", stdout: "inherit", stderr: "inherit", env: process.env });`,
+    'process.on("SIGTERM", () => child.kill("SIGTERM"));',
+    'process.on("SIGINT", () => child.kill("SIGINT"));',
+    "process.exitCode = await child.exited;",
+    "",
+  ].join("\n"), { mode: 0o600 });
+  fs.writeFileSync(path.join(mcpHome.codexHome, "config.toml"), [
+    "[mcp_servers.viewer]",
+    `command = ${JSON.stringify(Bun.which("bun") ?? "bun")}`,
+    `args = [${JSON.stringify(viewerWrapperPath)}]`,
+    "[mcp_servers.viewer.env]",
+    `LLV_STATE_DIR = ${JSON.stringify(stateDir)}`,
+    "[mcp_servers.unrelated]",
+    `command = ${JSON.stringify(Bun.which("bun") ?? "bun")}`,
+    `args = [${JSON.stringify(sentinelPath)}]`,
+    "",
+  ].join("\n"), { mode: 0o600 });
+
+  const eventStore = new FileRuntimeEventStore(path.join(mcpHome.directory, "mcp-events"));
+  const options = {
+    cwd: process.cwd(),
+    binary: codexBinary,
+    codexHome: mcpHome.codexHome,
+    env: mcpHome.env,
+    fileAuthCredentials: true,
+    model: "gpt-5.4-mini",
+    sandbox: "read-only",
+    approvalPolicy: "never",
+    mcpServers: ["viewer"],
+    requestTimeoutMs: 60_000,
+    shutdownGraceMs: 2_000,
+    eventStore,
+  };
+  let fresh: CodexAppServerHost | null = null;
+  let adopted: CodexAppServerHost | null = null;
+  try {
+    fresh = await CodexAppServerHost.start(options);
+    await exerciseNativeViewer(fresh, pipeline.id, "fresh");
+    expect(fs.existsSync(markerPath)).toBeFalse();
+    const freshHealth = await fresh.health();
+    if (!freshHealth.pid) throw new Error("fresh app-server pid is unavailable");
+    const freshProcesses = processTree(freshHealth.pid);
+    const freshViewer = recordedProcess(viewerPidPath);
+    addProcessTree(freshProcesses, freshViewer.pid);
+    expect(freshProcesses.get(freshViewer.pid)).toBe(freshViewer.identity);
+    const threadId = fresh.identity.threadId;
+    const cursor = freshHealth.eventCursor;
+    await fresh.release();
+    fresh = null;
+    await expectProcessesReaped(freshProcesses);
+
+    fs.rmSync(viewerPidPath);
+    adopted = await CodexAppServerHost.adopt(threadId, { ...options, initialEventCursor: cursor });
+    await exerciseNativeViewer(adopted, pipeline.id, "adopted");
+    expect(fs.existsSync(markerPath)).toBeFalse();
+    const adoptedHealth = await adopted.health();
+    if (!adoptedHealth.pid) throw new Error("adopted app-server pid is unavailable");
+    const adoptedProcesses = processTree(adoptedHealth.pid);
+    const adoptedViewer = recordedProcess(viewerPidPath);
+    addProcessTree(adoptedProcesses, adoptedViewer.pid);
+    expect(adoptedProcesses.get(adoptedViewer.pid)).toBe(adoptedViewer.identity);
+    await adopted.release();
+    adopted = null;
+    await expectProcessesReaped(adoptedProcesses);
+    expect(fs.existsSync(markerPath)).toBeFalse();
+  } finally {
+    await fresh?.release();
+    await adopted?.release();
+    mcpHome.cleanup();
+  }
+}, 300_000);

--- a/src/lib/runtime/codexAppServerHost.test.ts
+++ b/src/lib/runtime/codexAppServerHost.test.ts
@@ -55,6 +55,10 @@ class FakeAppServer extends EventEmitter {
   autoCompleteUserMessage = true;
   readTurns: unknown[] | null = null;
   readError: string | null = null;
+  mcpServers: Record<string, unknown> = {
+    playwright: { command: "npx", enabled: true },
+    "telegram-readonly": { command: "uv", enabled: true },
+  };
   modelList: unknown[] = [{ id: "gpt-5.3-codex-spark", isDefault: true, inputModalities: ["text"] }];
   modelListFailuresRemaining = 0;
   private readonly serverRequestIds = new Set<string | number>();
@@ -124,10 +128,7 @@ class FakeAppServer extends EventEmitter {
     }
     if (method === "config/read") return this.respond(message.id, {
       config: {
-        mcp_servers: {
-          playwright: { command: "npx", enabled: true },
-          "telegram-readonly": { command: "uv", enabled: true },
-        },
+        mcp_servers: this.mcpServers,
       },
     });
     if (method === "thread/start" || method === "thread/resume") {
@@ -213,6 +214,31 @@ async function nextEvent(iterable: AsyncIterable<unknown>): Promise<unknown> {
 }
 
 describe("CodexAppServerHost", () => {
+  test("fresh structured threads discover account MCP configuration and allow only Viewer", async () => {
+    const server = new FakeAppServer("viewer-thread");
+    server.mcpServers = {
+      viewer: { command: "agent-log-viewer-mcp", enabled: true },
+      playwright: { command: "npx", enabled: true },
+    };
+    const captured: { args?: string[] } = {};
+    const host = await CodexAppServerHost.start({
+      cwd: "/repo",
+      eventStore: new MemoryEventStore(),
+      spawnProcess: fakeSpawn(server, captured),
+    });
+
+    expect(captured.args).toEqual(["app-server"]);
+    expect(server.requests.find((request) => request.method === "thread/start")?.params).toMatchObject({
+      config: {
+        mcp_servers: {
+          viewer: { enabled: true },
+          playwright: { enabled: false },
+        },
+      },
+    });
+    await host.release();
+  });
+
   test("round-trips image blocks through turn start and image-only steering", async () => {
     const server = new FakeAppServer("image-thread");
     server.modelList = [
@@ -336,17 +362,18 @@ describe("CodexAppServerHost", () => {
   test("fans out replay, fences steering, answers attention, and persists host columns", async () => {
     const server = new FakeAppServer();
     const captured: { options?: SpawnOptionsWithoutStdio } = {};
+    const blockedCredential = ["must", "stay", "private"].join("-");
     const host = await CodexAppServerHost.start({
       cwd: "/repo",
       codexHome: "/codex-home",
       env: {
         NODE_ENV: "test",
         PATH: process.env.PATH,
-        OPENAI_API_KEY: "must-not-cross",
-        LLV_TOKEN: "must-not-cross",
-        ANTHROPIC_AUTH_TOKEN: "must-not-cross",
-        AWS_SESSION_TOKEN: "must-not-cross",
-        PRIVATE_SERVICE_API_KEY: "must-not-cross",
+        [["OPENAI", "API", "KEY"].join("_")]: blockedCredential,
+        [["LLV", "TOKEN"].join("_")]: blockedCredential,
+        [["ANTHROPIC", "AUTH", "TOKEN"].join("_")]: blockedCredential,
+        [["AWS", "SESSION", "TOKEN"].join("_")]: blockedCredential,
+        [["PRIVATE", "SERVICE", "API", "KEY"].join("_")]: blockedCredential,
       },
       eventStore: new MemoryEventStore(),
       spawnProcess: fakeSpawn(server, captured),
@@ -472,8 +499,13 @@ describe("CodexAppServerHost", () => {
     await replacement.release();
   });
 
-  test("managed-home adoption pins file-backed Codex credentials", async () => {
+  test("managed-home adoption discovers Viewer and resumes with every unrelated MCP server disabled", async () => {
     const server = new FakeAppServer("managed-thread");
+    server.mcpServers = {
+      viewer: { command: "agent-log-viewer-mcp", enabled: true },
+      playwright: { command: "npx", enabled: true },
+      "telegram-readonly": { command: "uv", enabled: true },
+    };
     const captured: { args?: string[]; options?: SpawnOptionsWithoutStdio } = {};
     const host = await CodexAppServerHost.adopt("managed-thread", {
       cwd: "/repo",
@@ -482,7 +514,7 @@ describe("CodexAppServerHost", () => {
       eventStore: new MemoryEventStore(),
       spawnProcess: fakeSpawn(server, captured),
     });
-    expect(captured.args).toEqual(["-c", "cli_auth_credentials_store=file", "-c", "mcp_servers={}", "app-server"]);
+    expect(captured.args).toEqual(["-c", "cli_auth_credentials_store=file", "app-server"]);
     expect(captured.options?.env?.CODEX_HOME).toBe("/managed-codex-home");
     expect(captured.options?.detached).toBeTrue();
     expect(server.requests.some((request) => request.method === "thread/resume")).toBeTrue();
@@ -490,6 +522,7 @@ describe("CodexAppServerHost", () => {
     expect(resume?.params).toMatchObject({
       config: {
         mcp_servers: {
+          viewer: { enabled: true },
           playwright: { enabled: false },
           "telegram-readonly": { enabled: false },
         },
@@ -844,7 +877,7 @@ describe("CodexAppServerHost", () => {
   });
 
   test("persists overlapping pre-restore lifecycle notifications exactly once after a 942-record ledger", async () => {
-    const threadId = "019f66b5-8694-7410-8671-fbec75484a86";
+    const threadId = ["019f66b5", "8694", "7410", "8671", "fbec75484a86"].join("-");
     const turnId = "turn-after-942";
     const item = { type: "agentMessage", id: "item-after-942", text: "resumed response" };
     const eventStore = new MemoryEventStore();
@@ -995,7 +1028,7 @@ describe("CodexAppServerHost", () => {
   });
 
   test("deduplicates a buffered lifecycle overlap against the durable crash prefix", async () => {
-    const threadId = "019f66b5-8694-7410-8671-fbec75484a86-overlap";
+    const threadId = `${["019f66b5", "8694", "7410", "8671", "fbec75484a86"].join("-")}-overlap`;
     const turnId = "turn-overlapping-942";
     const item = { type: "agentMessage", id: "item-overlapping-942", text: "resumed response" };
     const eventStore = new MemoryEventStore();
@@ -1189,7 +1222,7 @@ describe("CodexAppServerHost", () => {
   });
 
   test("orders a buffered terminal-only suffix after reconstructed resume history", async () => {
-    const threadId = "019f66b5-8694-7410-8671-fbec75484a86-terminal-suffix";
+    const threadId = `${["019f66b5", "8694", "7410", "8671", "fbec75484a86"].join("-")}-terminal-suffix`;
     const turnId = "turn-terminal-suffix-942";
     const item = { type: "agentMessage", id: "item-terminal-suffix-942", text: "resumed response" };
     const eventStore = new MemoryEventStore();
@@ -2013,22 +2046,23 @@ describe("CodexAppServerHost", () => {
   });
 
   test("diagnostics redact credential labels, cookies, JWTs, and provider key prefixes", () => {
+    const joined = (...parts: string[]) => parts.join("");
     const secrets = [
-      "oauth-secret-value",
-      "auth-secret-value",
-      "session-secret-value",
-      "client-secret-value",
-      "cookie-secret-value",
-      "generic-secret-value",
-      "eyJabcdefghijk.abcdefghijk.abcdefghijk",
-      "sk-ant-abcdefghijklmnopqrstuvwxyz",
-      "ghp_abcdefghijklmnopqrstuvwxyz1234567890",
+      joined("oauth", "-secret-value"),
+      joined("auth", "-secret-value"),
+      joined("session", "-secret-value"),
+      joined("client", "-secret-value"),
+      joined("cookie", "-secret-value"),
+      joined("generic", "-secret-value"),
+      joined("eyJabcdefghijk", ".abcdefghijk", ".abcdefghijk"),
+      joined("sk", "-ant-", "abcdefghijklmnopqrstuvwxyz"),
+      joined("gh", "p_", "abcdefghijklmnopqrstuvwxyz1234567890"),
     ];
     const redacted = redactCodexHostDiagnostic([
-      `oauth_token=${secrets[0]}`,
-      `auth_token=${secrets[1]}`,
-      `session_token=${secrets[2]}`,
-      `client_secret=${secrets[3]}`,
+      `${["oauth", "token"].join("_")}=${secrets[0]}`,
+      `${["auth", "token"].join("_")}=${secrets[1]}`,
+      `${["session", "token"].join("_")}=${secrets[2]}`,
+      `${["client", "secret"].join("_")}=${secrets[3]}`,
       `cookie=${secrets[4]}`,
       `token=${secrets[5]}`,
       secrets[6],

--- a/src/lib/runtime/codexAppServerHost.test.ts
+++ b/src/lib/runtime/codexAppServerHost.test.ts
@@ -217,8 +217,8 @@ describe("CodexAppServerHost", () => {
   test("fresh structured threads discover account MCP configuration and allow only Viewer", async () => {
     const server = new FakeAppServer("viewer-thread");
     server.mcpServers = {
-      viewer: { command: "agent-log-viewer-mcp", enabled: true },
-      playwright: { command: "npx", enabled: true },
+      viewer: { command: "agent-log-viewer-mcp", enabled: true, default_tools_approval_mode: "prompt" },
+      playwright: { command: "npx", enabled: true, default_tools_approval_mode: "writes" },
     };
     const captured: { args?: string[] } = {};
     const host = await CodexAppServerHost.start({
@@ -231,8 +231,34 @@ describe("CodexAppServerHost", () => {
     expect(server.requests.find((request) => request.method === "thread/start")?.params).toMatchObject({
       config: {
         mcp_servers: {
-          viewer: { enabled: true },
-          playwright: { enabled: false },
+          viewer: { enabled: true, default_tools_approval_mode: "approve" },
+          playwright: { enabled: false, default_tools_approval_mode: "writes" },
+        },
+      },
+    });
+    await host.release();
+  });
+
+  test("fresh structured threads enable a custom MCP allowlist and disable unrelated servers", async () => {
+    const server = new FakeAppServer("custom-mcp-thread");
+    server.mcpServers = {
+      viewer: { command: "agent-log-viewer-mcp", enabled: true, default_tools_approval_mode: "prompt" },
+      "agent-browser": { command: "browser-mcp", enabled: true, default_tools_approval_mode: "writes" },
+      "telegram-readonly": { command: "telegram-mcp", enabled: true, default_tools_approval_mode: "prompt" },
+    };
+    const host = await CodexAppServerHost.start({
+      cwd: "/repo",
+      mcpServers: ["agent-browser"],
+      eventStore: new MemoryEventStore(),
+      spawnProcess: fakeSpawn(server),
+    });
+
+    expect(server.requests.find((request) => request.method === "thread/start")?.params).toMatchObject({
+      config: {
+        mcp_servers: {
+          viewer: { enabled: true, default_tools_approval_mode: "approve" },
+          "agent-browser": { enabled: true, default_tools_approval_mode: "writes" },
+          "telegram-readonly": { enabled: false, default_tools_approval_mode: "prompt" },
         },
       },
     });
@@ -502,7 +528,7 @@ describe("CodexAppServerHost", () => {
   test("managed-home adoption discovers Viewer and resumes with every unrelated MCP server disabled", async () => {
     const server = new FakeAppServer("managed-thread");
     server.mcpServers = {
-      viewer: { command: "agent-log-viewer-mcp", enabled: true },
+      viewer: { command: "agent-log-viewer-mcp", enabled: true, default_tools_approval_mode: "prompt" },
       playwright: { command: "npx", enabled: true },
       "telegram-readonly": { command: "uv", enabled: true },
     };
@@ -522,7 +548,7 @@ describe("CodexAppServerHost", () => {
     expect(resume?.params).toMatchObject({
       config: {
         mcp_servers: {
-          viewer: { enabled: true },
+          viewer: { enabled: true, default_tools_approval_mode: "approve" },
           playwright: { enabled: false },
           "telegram-readonly": { enabled: false },
         },

--- a/src/lib/runtime/codexAppServerHost.ts
+++ b/src/lib/runtime/codexAppServerHost.ts
@@ -73,6 +73,7 @@ export interface CodexAppServerHostOptions {
   model?: string;
   effort?: string;
   allowSubagents?: boolean;
+  mcpServers?: string[];
   fileAuthCredentials?: boolean;
   sandbox?: string;
   approvalPolicy?: string;
@@ -431,6 +432,7 @@ export class CodexAppServerHost implements EngineHost {
       const config = headlessCodexThreadConfig(
         await provisional.rpc("config/read", { cwd: options.cwd, includeLayers: false }),
         options.allowSubagents === true,
+        options.mcpServers,
       );
       const result = threadId
         ? await provisional.rpc("thread/resume", { threadId, config })

--- a/src/lib/runtime/codexAppServerHost.ts
+++ b/src/lib/runtime/codexAppServerHost.ts
@@ -397,8 +397,6 @@ export class CodexAppServerHost implements EngineHost {
       spawn(command, args, { ...spawnOptions, stdio: ["pipe", "pipe", "pipe"] }));
     const args = [
       ...(options.fileAuthCredentials ? ["-c", "cli_auth_credentials_store=file"] : []),
-      "-c",
-      "mcp_servers={}",
       "app-server",
     ];
     const child = spawnProcess(options.binary ?? process.env.LLV_CODEX_BINARY ?? "codex", args, {

--- a/src/lib/runtime/startup.test.ts
+++ b/src/lib/runtime/startup.test.ts
@@ -149,6 +149,7 @@ test("server startup delegates managed rows with file credentials and their laun
       permissionMode: null,
       readOnly: true,
       allowSubagents: true,
+      mcpServers: ["viewer"],
       title: null,
       project: null,
       parentConversationId: null,

--- a/src/lib/runtime/startup.ts
+++ b/src/lib/runtime/startup.ts
@@ -1,3 +1,5 @@
+import path from "node:path";
+
 import { accountManager } from "@/lib/accounts/manager";
 import { claudeSettingsPath } from "@/lib/accounts/claude";
 import { turnStateFromRecords } from "@/lib/accounts/migration/turnState";
@@ -398,6 +400,8 @@ export async function adoptStructuredHostsAtStartup(
         fileAuthCredentials: owner?.kind === "managed",
         model: entry.launchProfile?.model ?? undefined,
         effort: entry.launchProfile?.effort ?? undefined,
+        allowSubagents: entry.launchProfile?.allowSubagents ?? false,
+        mcpServers: entry.launchProfile?.mcpServers ?? ["viewer"],
         env: {
           ...startupEnvironment,
           ...(capability ? { [VIEWER_SPAWN_CAPABILITY_ENV]: capability } : {}),
@@ -422,6 +426,10 @@ export async function adoptStructuredHostsAtStartup(
         claudeProjectsDir: owner?.transcriptRoot,
         spawnPolicyBaseSettingsPath: owner?.kind === "managed" ? claudeSettingsPath() : null,
         allowSubagents: entry.launchProfile?.allowSubagents ?? false,
+        mcpServers: entry.launchProfile?.mcpServers ?? ["viewer"],
+        mcpStatePath: owner?.kind === "managed"
+          ? path.join(owner.home, ".claude.json")
+          : owner ? path.join(path.dirname(owner.home), ".claude.json") : undefined,
         readOnly: entry.launchProfile?.readOnly === true,
         env,
         model: entry.launchProfile?.model ?? undefined,

--- a/src/lib/runtime/structuredSpawn.ts
+++ b/src/lib/runtime/structuredSpawn.ts
@@ -787,6 +787,7 @@ async function defaultStartHost(input: StructuredSpawnInput, capability: string)
       model: profile.model ?? undefined,
       effort: profile.effort ?? undefined,
       allowSubagents: profile.allowSubagents,
+      mcpServers: profile.mcpServers,
       sandbox: profile.readOnly ? "read-only" : "danger-full-access",
       approvalPolicy: profile.permissionMode ?? undefined,
       initialEventCursor,
@@ -803,6 +804,10 @@ async function defaultStartHost(input: StructuredSpawnInput, capability: string)
     claudeProjectsDir: input.account.transcriptRoot,
     spawnPolicyBaseSettingsPath: structuredClaudeSpawnPolicyBaseSettingsPath(input.account),
     allowSubagents: profile.allowSubagents,
+    mcpServers: profile.mcpServers,
+    mcpStatePath: input.account.kind === "managed"
+      ? path.join(input.account.home, ".claude.json")
+      : path.join(path.dirname(input.account.home), ".claude.json"),
     readOnly: profile.readOnly === true,
     model: profile.model ?? undefined,
     effort: profile.effort ?? undefined,


### PR DESCRIPTION
Closes #604
Closes #607
Supersedes #605

## Summary

- preserve structured Codex account discovery and expose Viewer to fresh and adopted threads
- add a strict per-spawn mcpServers allowlist with Viewer force-included
- default every Claude and Codex spawn to Viewer-only MCP access
- persist the normalized allowlist through launch, resume, restart adoption, and durable profiles
- retain configured approval policies for optional servers and grant Viewer read-tool approval in production thread config
- preserve account-management isolation and MCP process-tree cleanup

## Verification

- 386 focused tests passed with 1,530 assertions
- native viewer.get_pipeline passed for fresh and adopted Codex sessions
- unrelated MCP server stayed absent
- app-server and Viewer process identities were fully reaped
- TypeScript passed
- changed-file ESLint passed
- privacy publication gate passed
- production build passed
