### PR TITLE
fix(spawn): project a starting launch into its canonical window with the prompt bubble (#614)

### DIFF
--- a/evidence/conversation-window/geometry.json
+++ b/evidence/conversation-window/geometry.json
@@ -10,6 +10,17 @@
     "launchChips": true,
     "outbox": false
   },
+  "pre-transcript-prompt-desktop": {
+    "scrollWidth": 1280,
+    "viewportWidth": 1280,
+    "feedHeight": 667.75,
+    "composerHeight": 99,
+    "controlStrip": true,
+    "mobileDetailsToggle": false,
+    "textarea": true,
+    "launchChips": true,
+    "outbox": true
+  },
   "delivering-desktop": {
     "scrollWidth": 1280,
     "viewportWidth": 1280,
@@ -42,6 +53,17 @@
     "textarea": true,
     "launchChips": true,
     "outbox": false
+  },
+  "pre-transcript-prompt-mobile-390": {
+    "scrollWidth": 390,
+    "viewportWidth": 390,
+    "feedHeight": 653,
+    "composerHeight": 105,
+    "controlStrip": false,
+    "mobileDetailsToggle": true,
+    "textarea": true,
+    "launchChips": true,
+    "outbox": true
   },
   "delivering-mobile-390": {
     "scrollWidth": 390,

--- a/src/components/LogFeed.tsx
+++ b/src/components/LogFeed.tsx
@@ -15,7 +15,7 @@ import { isAwaitingUser } from "@/hooks/useSwitchboardData";
 import { LaunchChips } from "./conversation/LaunchChips";
 import { OutboxBubbles } from "./conversation/OutboxBubbles";
 import { orderedConversationTail } from "./conversation/tailOrder";
-import { publishTranscriptEchoes, useOutbox, visibleOutbox } from "./conversation/outbox";
+import { publishTranscriptEchoes, seedLaunchOutbox, useOutbox, visibleOutbox } from "./conversation/outbox";
 import { createFeedSession, type FeedSession, type FeedSnapshot } from "./feed/parse";
 import { FeedItem } from "./feed/FeedItem";
 import { RawLineProvider, type RawLineLookup } from "./feed/rawLine";
@@ -411,6 +411,25 @@ export function LogFeed({ file, showSvc, lineFilter, onStatus, paused, follow, s
   useEffect(() => {
     if (memoryKey) publishTranscriptEchoes(memoryKey, transcriptEchoCounts);
   }, [memoryKey, transcriptEchoCounts]);
+  /* The launch prompt as the conversation's first user bubble on EVERY surface
+     (issue #614): the server projects the queued initial prompt onto the launch
+     state, so a board that did not run the composer (an MCP spawn, a second tab,
+     a fresh refresh) seeds the same launch-owned bubble the composer path seeds.
+     Keyed by the launch id under the stable conversation identity, so it is
+     idempotent with the composer's own seed (no duplicate), survives a refresh,
+     folds through transcript adoption, and retires on its transcript echo. */
+  useEffect(() => {
+    if (!memoryKey || !launch?.launchId) return;
+    const promptText = launch.prompt ?? "";
+    const promptImages = launch.promptImages ?? 0;
+    if (!promptText.trim() && !promptImages) return;
+    seedLaunchOutbox(memoryKey, {
+      id: launch.launchId,
+      text: promptText,
+      images: promptImages,
+      at: launch.promptAt ?? Date.now(),
+    });
+  }, [memoryKey, launch?.launchId, launch?.prompt, launch?.promptImages, launch?.promptAt]);
   const pendingOutbox = file ? visibleOutbox(outbox, transcriptEchoCounts, nowMs()) : [];
   /* Anything the window shows below the transcript. While it is present an
      empty transcript is not "no output" — it is a conversation mid-launch. */

--- a/src/components/LogFeed.tsx
+++ b/src/components/LogFeed.tsx
@@ -428,8 +428,12 @@ export function LogFeed({ file, showSvc, lineFilter, onStatus, paused, follow, s
       text: promptText,
       images: promptImages,
       at: launch.promptAt ?? Date.now(),
+      /* The canonical echo identity (issue #615): the bubble displays the raw
+         draft but retires on the delivered (possibly scaffolded) transcript
+         echo. Reconciled onto a composer-seeded bubble under the same id. */
+      ...(launch.promptEcho ? { echoText: launch.promptEcho } : {}),
     });
-  }, [memoryKey, launch?.launchId, launch?.prompt, launch?.promptImages, launch?.promptAt]);
+  }, [memoryKey, launch?.launchId, launch?.prompt, launch?.promptImages, launch?.promptAt, launch?.promptEcho]);
   const pendingOutbox = file ? visibleOutbox(outbox, transcriptEchoCounts, nowMs()) : [];
   /* Anything the window shows below the transcript. While it is present an
      empty transcript is not "no output" — it is a conversation mid-launch. */

--- a/src/components/conversation/conversationWindowEvidence.browser.test.tsx
+++ b/src/components/conversation/conversationWindowEvidence.browser.test.tsx
@@ -116,7 +116,7 @@ const DELIVERED_LAUNCH: StructuredSpawnCardState = { ...QUEUED_LAUNCH, state: "l
 const PRE_TRANSCRIPT_PROMPT = "LLV614_CANONICAL_PROBE_20260723";
 const PROMPTED_LAUNCH: StructuredSpawnCardState = {
   ...QUEUED_LAUNCH, launchId: "launch_evidence_614",
-  promptImages: 0, promptAt: 1, prompt: PRE_TRANSCRIPT_PROMPT,
+  promptImages: 0, promptAt: 1, prompt: PRE_TRANSCRIPT_PROMPT, promptEcho: PRE_TRANSCRIPT_PROMPT,
 };
 
 const STATES: Array<{ id: string; file: FileEntry; seedOutbox?: "delivering"; expectPrompt?: string }> = [

--- a/src/components/conversation/conversationWindowEvidence.browser.test.tsx
+++ b/src/components/conversation/conversationWindowEvidence.browser.test.tsx
@@ -110,9 +110,22 @@ const QUEUED_LAUNCH: StructuredSpawnCardState = {
   state: "queued", initialMessage: "queued", retrySafe: false, error: null,
 };
 const DELIVERED_LAUNCH: StructuredSpawnCardState = { ...QUEUED_LAUNCH, state: "live-late-success", initialMessage: "delivered" };
+/* The #614 pre-transcript launch: a transcript-less `spawn:` window whose queued
+   prompt the server projected onto the launch state, so LogFeed seeds it as the
+   first user bubble even on a surface that never ran the composer. */
+const PRE_TRANSCRIPT_PROMPT = "LLV614_CANONICAL_PROBE_20260723";
+const PROMPTED_LAUNCH: StructuredSpawnCardState = {
+  ...QUEUED_LAUNCH, launchId: "launch_evidence_614",
+  promptImages: 0, promptAt: 1, prompt: PRE_TRANSCRIPT_PROMPT,
+};
 
-const STATES: Array<{ id: string; file: FileEntry; seedOutbox?: "delivering" }> = [
+const STATES: Array<{ id: string; file: FileEntry; seedOutbox?: "delivering"; expectPrompt?: string }> = [
   { id: "queued", file: baseFile({ path: "spawn:launch_evidence", name: "spawn:launch_evidence", spawn: QUEUED_LAUNCH }) },
+  {
+    id: "pre-transcript-prompt",
+    file: baseFile({ path: "spawn:launch_evidence_614", name: "spawn:launch_evidence_614", size: 0, spawn: PROMPTED_LAUNCH }),
+    expectPrompt: PRE_TRANSCRIPT_PROMPT,
+  },
   { id: "delivering", file: baseFile({ launch: DELIVERED_LAUNCH }), seedOutbox: "delivering" },
   { id: "live", file: baseFile({ launch: DELIVERED_LAUNCH }) },
 ];
@@ -181,6 +194,13 @@ test("browser-rendered conversation-window evidence: geometry, overflow, and lif
         updateOutbox(CONV, "op_evidence", { state: "delivering" });
       }
       const inner = await renderWindow(<BranchPane file={state.file} tasks={[]} isRoot />);
+      /* #614: the projected launch prompt renders as the first user bubble on a
+         surface that never ran the composer — the server-seeded launch-owned
+         bubble, present at both desktop and 390px. */
+      if (state.expectPrompt) {
+        expect(inner).toContain(state.expectPrompt);
+        expect(inner).toContain("data-outbox");
+      }
 
       const page = await browser.newPage({ viewport: { width: viewport.width, height: viewport.height }, deviceScaleFactor: 1 });
       await page.setContent(pageHtml(inner, viewport.width), { waitUntil: "load" });
@@ -229,6 +249,12 @@ test("browser-rendered conversation-window evidence: geometry, overflow, and lif
   expect(manifest["queued-desktop"]!.launchChips).toBe(true);
   expect(manifest["delivering-desktop"]!.outbox).toBe(true);
   expect(manifest["delivering-mobile-390"]!.outbox).toBe(true);
+  /* #614: the pre-transcript launch shows its queued prompt as the first user
+     bubble (data-outbox) alongside its launch chips, at desktop and 390px — the
+     window is a conversation mid-launch, never an empty shell. */
+  expect(manifest["pre-transcript-prompt-desktop"]!.outbox).toBe(true);
+  expect(manifest["pre-transcript-prompt-desktop"]!.launchChips).toBe(true);
+  expect(manifest["pre-transcript-prompt-mobile-390"]!.outbox).toBe(true);
 
   fs.writeFileSync(path.join(EVIDENCE_DIR, "geometry.json"), JSON.stringify(manifest, null, 2));
 

--- a/src/components/conversation/outbox.test.ts
+++ b/src/components/conversation/outbox.test.ts
@@ -210,6 +210,32 @@ describe("seedLaunchOutbox (P1#2)", () => {
     expect(readOutbox("spawn:launch_1")).toHaveLength(0);
     expect(readOutbox("conversation_live")[0]).toMatchObject({ id: "launch_1", launchOwned: true });
   });
+
+  test("issue 614: a server-projected seed and the composer's own seed (identical launch id and text) are ONE bubble that survives a refresh and retires on its own echo — never a duplicate", () => {
+    const identical = "LLV614_CANONICAL_PROBE_20260723";
+    /* The board that ran the composer seeds under the canonical identity. */
+    seedLaunchOutbox("conversation_614", { id: "launch_614", text: identical, images: 0, at: 1_000 });
+    /* A later /api/files poll carries the server-projected launch prompt; LogFeed
+       re-seeds by the SAME launch id with the SAME text — idempotent, no second
+       bubble. This is also the ONLY seed a surface that never ran the composer
+       (an MCP spawn observer, a second tab) receives. */
+    seedLaunchOutbox("conversation_614", { id: "launch_614", text: identical, images: 0, at: 2_000 });
+    expect(readOutbox("conversation_614")).toHaveLength(1);
+
+    /* A page refresh (fresh module state) rehydrates exactly one launch-owned
+       bubble from sessionStorage — the prompt is preserved, never re-queued. */
+    resetOutboxForTests();
+    const refreshed = readOutbox("conversation_614");
+    expect(refreshed).toHaveLength(1);
+    expect(refreshed[0]).toMatchObject({ id: "launch_614", text: identical, state: "delivering", launchOwned: true });
+
+    /* Before the transcript flush the bubble is the only representation of the
+       prompt (visible). */
+    expect(visibleOutbox(refreshed, echoes(), 5_000).map((entry) => entry.id)).toEqual(["launch_614"]);
+    /* Transcript adoption: the flushed transcript echoes the prompt exactly once,
+       which retires the launch-owned bubble — one window, zero duplicate. */
+    expect(visibleOutbox(refreshed, echoes(identical), 5_000)).toEqual([]);
+  });
 });
 
 test("adoption moves a queue onto the materialized conversation identity idempotently", () => {

--- a/src/components/conversation/outbox.test.ts
+++ b/src/components/conversation/outbox.test.ts
@@ -211,6 +211,54 @@ describe("seedLaunchOutbox (P1#2)", () => {
     expect(readOutbox("conversation_live")[0]).toMatchObject({ id: "launch_1", launchOwned: true });
   });
 
+  test.each([
+    ["builder", "You are a Builder in TDD mode.\n\nLLV615_RAW_PROMPT"],
+    ["reviewer", "You are a Reviewer.\nSafety fences:\n- stay in scope\n\nLLV615_RAW_PROMPT"],
+  ])("issue 615 HIGH2: a %s role launch displays the raw draft but retires on the canonical scaffolded echo", (_role, scaffolded) => {
+    const raw = "LLV615_RAW_PROMPT";
+    /* The composer seeds the RAW operator draft (no scaffold — the server adds
+       it), so the bubble is user-facing. Its canonical echo identity is the
+       delivered scaffolded text the transcript will actually record. */
+    seedLaunchOutbox("conversation_615", { id: "launch_615", text: raw, images: 1, at: 1_000, echoText: scaffolded });
+    const queue = readOutbox("conversation_615");
+    expect(queue).toHaveLength(1);
+    expect(queue[0]).toMatchObject({ text: raw, echoText: scaffolded, launchOwned: true });
+
+    /* Exact-text matching on the RAW draft can NEVER retire it — the transcript
+       echoes the scaffolded text, not the raw draft. The bubble stays visible. */
+    expect(visibleOutbox(queue, echoes(raw), 5_000).map((e) => e.id)).toEqual(["launch_615"]);
+    /* The canonical scaffolded echo landing in the transcript retires it. */
+    expect(visibleOutbox(queue, echoes(scaffolded), 5_000)).toEqual([]);
+  });
+
+  test("issue 615 HIGH2: identical launch id reconciliation attaches the canonical echo identity while preserving the raw draft; refresh, images and zero duplicate hold", () => {
+    const raw = "LLV615_RAW_PROMPT";
+    const scaffolded = "You are a Builder in TDD mode.\n\nLLV615_RAW_PROMPT";
+    /* DraftAgentPane seeds first, immediately, with the RAW draft and no echo
+       identity (the client never composes the scaffold). */
+    seedLaunchOutbox("conversation_615", { id: "launch_615", text: raw, images: 3, at: 1_000 });
+    expect(readOutbox("conversation_615")[0]).toMatchObject({ text: raw, images: 3, launchOwned: true });
+    /* Exact-text matching cannot retire it yet — this is the reported bug. */
+    expect(visibleOutbox(readOutbox("conversation_615"), echoes(scaffolded), 5_000).map((e) => e.id)).toEqual(["launch_615"]);
+
+    /* The next /api/files poll carries the server-projected launch: LogFeed
+       re-seeds the SAME launch id WITH the canonical echo identity. Reconciliation
+       attaches it to the existing bubble — one bubble, RAW draft preserved. */
+    seedLaunchOutbox("conversation_615", { id: "launch_615", text: raw, images: 3, at: 2_000, echoText: scaffolded });
+    const merged = readOutbox("conversation_615");
+    expect(merged).toHaveLength(1);
+    expect(merged[0]).toMatchObject({ text: raw, images: 3, echoText: scaffolded, launchOwned: true });
+
+    /* A refresh rehydrates the one reconciled bubble, echo identity intact. */
+    resetOutboxForTests();
+    const refreshed = readOutbox("conversation_615");
+    expect(refreshed).toHaveLength(1);
+    expect(refreshed[0]).toMatchObject({ text: raw, images: 3, echoText: scaffolded });
+
+    /* The live scaffolded echo retires it — zero duplicate, zero lingering. */
+    expect(visibleOutbox(refreshed, echoes(scaffolded), 5_000)).toEqual([]);
+  });
+
   test("issue 614: a server-projected seed and the composer's own seed (identical launch id and text) are ONE bubble that survives a refresh and retires on its own echo — never a duplicate", () => {
     const identical = "LLV614_CANONICAL_PROBE_20260723";
     /* The board that ran the composer seeds under the canonical identity. */

--- a/src/components/conversation/outbox.ts
+++ b/src/components/conversation/outbox.ts
@@ -47,6 +47,13 @@ export interface OutboxEntry {
       drain of the operator's follow-up messages. It retires on its transcript
       echo like any other bubble. */
   launchOwned?: true;
+  /** The canonical text this bubble's transcript echo will carry (issue #615),
+      when it differs from the displayed {@link text}. A role launch DISPLAYS the
+      operator's raw draft but the transcript echoes the delivered scaffold-plus-
+      draft, so retirement matches THIS text while the bubble still shows the raw
+      draft. Absent ⇒ the display text is its own echo identity (plain launches
+      and ordinary composer sends). */
+  echoText?: string;
   /** Submission watermark (round-2 finding 2): how many transcript echoes of THIS
       exact text already existed when the entry was submitted. Retirement consumes
       only echoes BEYOND this baseline, so a freshly queued bubble survives a
@@ -173,10 +180,24 @@ export function enqueueOutbox(cardId: string, entry: Omit<OutboxEntry, "state">)
  * reached. The entry is `launchOwned` — delivered by the spawn, so it is never
  * dispatched and never blocks the operator's follow-up messages.
  */
-export function seedLaunchOutbox(cardId: string, entry: { id: string; text: string; images: number; at: number }): void {
+export function seedLaunchOutbox(
+  cardId: string,
+  entry: { id: string; text: string; images: number; at: number; echoText?: string },
+): void {
   if (!entry.text.trim() && !entry.images) return;
   const queue = readOutbox(cardId);
-  if (queue.some((item) => item.id === entry.id)) return;
+  const existing = queue.find((item) => item.id === entry.id);
+  if (existing) {
+    /* Reconcile the canonical echo identity onto an already-seeded bubble (issue
+       #615): the composer seeds the RAW draft first, without an echo identity (it
+       never composes the role scaffold); the later server projection supplies it.
+       Attach it while preserving the user-facing raw text and the bubble's current
+       state — one bubble, never a second. Idempotent once attached. */
+    if (entry.echoText && entry.echoText !== existing.echoText) {
+      write(cardId, queue.map((item) => (item.id === entry.id ? { ...item, echoText: entry.echoText } : item)));
+    }
+    return;
+  }
   const seeded: OutboxEntry = { ...entry, state: "delivering", launchOwned: true };
   write(cardId, [...queue, seeded].slice(-OUTBOX_LIMIT));
 }
@@ -279,7 +300,10 @@ export function visibleOutbox(
   const consumed = new Map<string, number>();
   const visible: OutboxEntry[] = [];
   for (const entry of queue) {
-    const key = echoKey(entry.text);
+    /* A bubble retires on ITS canonical transcript echo — the delivered text,
+       which for a role launch is the scaffold-plus-draft carried on `echoText`,
+       not the raw draft it displays (issue #615). */
+    const key = echoKey(entry.echoText ?? entry.text);
     const total = transcriptEchoCounts.get(key) ?? 0;
     /* Echoes below this floor belong to messages submitted before this entry
        (its own baseline) or to earlier queued siblings that already consumed

--- a/src/lib/agent/registry.ts
+++ b/src/lib/agent/registry.ts
@@ -181,6 +181,18 @@ export interface SpawnReceipt {
   /** Validated explicit operator project. Becomes durable conversation
       ownership at admission; `launchProfile.project` stays a hint. */
   explicitProject: string | null;
+  /** Durable launch DISPLAY payload (issue #614/#615), captured at receipt birth
+      — before any deferred delivery admission and before receipt publication — so
+      a surface that never ran the composer renders the first user bubble across
+      the WHOLE pre-transcript lifecycle: `starting` (before the held delivery
+      exists), and the delivered-but-scan-lagged interval after the held-delivery
+      text is scrubbed. `prompt` is the operator's RAW draft (user-facing); `echo`
+      is the delivered text (scaffold + draft for role launches) — the canonical
+      identity the transcript echoes, so the optimistic bubble retires on its real
+      message even when display text and delivered text differ. Set only on the
+      operator/UI launch path; successor and resume receipts never inherit it. The
+      projection stops emitting it in the response that adopts the live transcript. */
+  launchDisplay: { prompt: string; images: number; echo: string } | null;
   /** Cross-process CAS fence acquired before a failed launch is retried. */
   retryClaim?: { claimId: string; claimedAt: string };
 }
@@ -250,6 +262,10 @@ export interface SpawnRequest {
   /** Explicit operator project intent; validated and admitted as durable
       conversation ownership. Never inferred from sidebar selection. */
   explicitProject?: string | null;
+  /** Durable launch DISPLAY payload (issue #614/#615): the operator's raw prompt
+      (display), the delivered/scaffolded text (canonical echo identity), and the
+      image count. Only the operator/UI launch path supplies it. */
+  launchDisplay?: { prompt: string; images: number; echo: string } | null;
   memberships?: DurableMembershipInput[];
   conversationId?: ViewerConversationId;
   purpose?: SpawnReceipt["purpose"];
@@ -1996,12 +2012,27 @@ function normalizeReceipt(value: SpawnReceipt): SpawnReceipt {
     rejection: normalizeSpawnRejection(value.rejection),
     launchProfile: emptyLaunchProfile({ ...(value.launchProfile ?? {}), cwd: value.launchProfile?.cwd ?? value.cwd }),
     explicitProject: validExplicitProject(value.explicitProject),
+    launchDisplay: normalizeLaunchDisplay(value.launchDisplay),
     ...(value.retryClaim
       && typeof value.retryClaim.claimId === "string"
       && typeof value.retryClaim.claimedAt === "string"
       ? { retryClaim: { claimId: value.retryClaim.claimId, claimedAt: value.retryClaim.claimedAt } }
       : {}),
   };
+}
+
+/** Validate a durable launch display payload (issue #614/#615) on load and at
+    admission. A malformed value degrades to null (the window falls back to the
+    held delivery), never a partial payload. `echo` defaults to `prompt` for
+    plain (scaffold-less) launches. */
+function normalizeLaunchDisplay(value: unknown): SpawnReceipt["launchDisplay"] {
+  if (!value || typeof value !== "object") return null;
+  const candidate = value as { prompt?: unknown; images?: unknown; echo?: unknown };
+  if (typeof candidate.prompt !== "string") return null;
+  const images = Number.isInteger(candidate.images) && (candidate.images as number) >= 0 ? candidate.images as number : 0;
+  const echo = typeof candidate.echo === "string" ? candidate.echo : candidate.prompt;
+  if (!candidate.prompt.trim() && !echo.trim() && images === 0) return null;
+  return { prompt: candidate.prompt, images, echo };
 }
 
 function normalizeAgentRole(value: unknown): string | null {
@@ -3178,6 +3209,7 @@ export class AgentRegistry {
         rejection,
         launchProfile: profile,
         explicitProject,
+        launchDisplay: normalizeLaunchDisplay(input.launchDisplay),
       };
       file.receipts[receipt.launchId] = receipt;
       /* A rejected launch persists exactly one terminal receipt: no lineage

--- a/src/lib/agent/spawnCommand.ts
+++ b/src/lib/agent/spawnCommand.ts
@@ -400,6 +400,15 @@ export async function executeSpawnRequest(
       launchProfile: spec.launchProfile,
       clientAttemptId,
       requestDigest: digest,
+      /* Durable launch DISPLAY payload (issue #614/#615): the RAW operator draft
+         for the first user bubble, the scaffold-composed delivered text as its
+         canonical transcript-echo identity, and the image count — persisted with
+         the receipt so a surface that never ran the composer shows the bubble
+         through starting, scan-lag and text-scrubbed delivery, and retires it on
+         the real (possibly scaffolded) transcript echo. */
+      launchDisplay: (userPrompt.trim() || images.length)
+        ? { prompt: userPrompt, images: images.length, echo: prompt }
+        : null,
       memberships: pipelineAttemptTarget && pipelineSourceConversationId ? [{
         kind: "pipeline",
         containerId: pipelineAttemptTarget.pipelineId,

--- a/src/lib/agent/spawnProjection.test.ts
+++ b/src/lib/agent/spawnProjection.test.ts
@@ -301,6 +301,99 @@ test("issue 614: a materialized launch whose transcript a scoped scan omits keep
   }
 });
 
+test("issue 615 HIGH1: the launch prompt projects from the durable display payload across the whole lifecycle, independent of held-delivery text, and stops on transcript adoption", () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-615-durable-display-"));
+  const artifactPath = path.join(directory, "019f8dbe_e6cc_9e62_40df_06fb8f88b8b2.jsonl");
+  try {
+    fs.writeFileSync(artifactPath, `${JSON.stringify({ type: "user", message: "scaffold\n\nLLV615_RAW_PROMPT" })}\n`);
+    const registry = new AgentRegistry(path.join(directory, "agent-registry.json"), undefined, undefined, { sqliteMode: "off" });
+    const begun = registry.beginSpawnRequest({
+      engine: "codex", cwd: directory, transport: "structured", accountId: "work",
+      launchProfile: emptyLaunchProfile({ cwd: directory }),
+      /* Persisted at receipt birth — BEFORE any deferred delivery admission and
+         BEFORE receipt publication. Raw prompt for display, the delivered
+         (scaffolded) text as the canonical echo identity, plus the image count. */
+      launchDisplay: { prompt: "LLV615_RAW_PROMPT", images: 2, echo: "scaffold\n\nLLV615_RAW_PROMPT" },
+    });
+    if (begun.kind !== "created") throw new Error("expected structured launch creation");
+    const createdMs = Date.parse(begun.receipt.createdAt);
+
+    /* `starting`, BEFORE the held delivery exists: the display payload still
+       projects the raw prompt, its echo identity, and the image count. */
+    const starting = projectLaunchConversations([], registry.snapshot(), createdMs + 1_000);
+    expect(starting.cards[0]!.spawn).toMatchObject({
+      state: "starting",
+      promptImages: 2,
+      promptAt: createdMs,
+      promptEcho: "scaffold\n\nLLV615_RAW_PROMPT", prompt: "LLV615_RAW_PROMPT",
+    });
+
+    /* Delivered settlement scrubs held-delivery text; the display payload is
+       independent, so the prompt still projects during the scan-lag interval. */
+    registry.settleSpawn(begun.receipt.launchId, {
+      key: { engine: "codex", sessionId: "019f8dbe-" + "e6cc-9e62-40df-06fb8f88b8b2" },
+      artifactPath, cwd: directory, accountId: "work",
+      launchProfile: emptyLaunchProfile({ cwd: directory }),
+      status: "idle", host: null, claimEpoch: 0, claimOwner: null, pendingAction: null,
+    });
+    registry.holdDelivery(begun.receipt.conversationId, "scaffold\n\nLLV615_RAW_PROMPT", `spawn_${begun.receipt.launchId}`);
+    registry.recordDeliveryOutcome(
+      Object.values(registry.snapshot().heldDeliveries).find((d) => d.clientMessageId === `spawn_${begun.receipt.launchId}`)!.id,
+      "delivered",
+    );
+    observeArtifact(registry, artifactPath, directory);
+    const snapshot = registry.snapshot();
+    /* The held-delivery text is scrubbed (or the reservation compacted) once
+       delivered — no longer a source for the prompt. */
+    expect(Object.values(snapshot.heldDeliveries).find((d) => d.clientMessageId === `spawn_${begun.receipt.launchId}`)?.text ?? "").toBe("");
+
+    const scanLag = projectLaunchConversations([], snapshot, createdMs + 20_000);
+    expect(scanLag.cards).toHaveLength(1);
+    expect(scanLag.cards[0]!.spawn).toMatchObject({ prompt: "LLV615_RAW_PROMPT", promptImages: 2, promptEcho: "scaffold\n\nLLV615_RAW_PROMPT" });
+
+    /* The response that ADOPTS the live transcript stops projecting the prompt —
+       the transcript now renders the message, so the facts carry no bubble. */
+    const adopted = projectLaunchConversations([scannedFile(artifactPath)], snapshot, createdMs + 21_000);
+    expect(adopted.cards).toEqual([]);
+    const facts = adopted.facts.get(artifactPath)!;
+    expect(facts).toMatchObject({ state: "recovered" });
+    expect(facts.prompt).toBeUndefined();
+    expect(facts.promptEcho).toBeUndefined();
+    expect(facts.promptImages).toBeUndefined();
+  } finally {
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+test("issue 615 HIGH1: the durable display payload survives restart and never leaks into a successor receipt", () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-615-display-restart-"));
+  const filename = path.join(directory, "agent-registry.json");
+  try {
+    const registry = new AgentRegistry(filename, undefined, undefined, { sqliteMode: "off" });
+    const begun = registry.beginSpawnRequest({
+      engine: "codex", cwd: directory, transport: "structured", accountId: "work",
+      launchProfile: emptyLaunchProfile({ cwd: directory }),
+      launchDisplay: { prompt: "LLV615_RAW_PROMPT", images: 0, echo: "LLV615_RAW_PROMPT" },
+    });
+    if (begun.kind !== "created") throw new Error("expected structured launch creation");
+
+    /* A refresh/restart rehydrates the durable payload from disk unchanged. */
+    const restarted = new AgentRegistry(filename, undefined, undefined, { sqliteMode: "off" });
+    expect(restarted.snapshot().receipts[begun.receipt.launchId]?.launchDisplay)
+      .toEqual({ prompt: "LLV615_RAW_PROMPT", images: 0, echo: "LLV615_RAW_PROMPT" });
+
+    /* A second, unrelated launch never inherits the first launch's display. */
+    const other = restarted.beginSpawnRequest({
+      engine: "codex", cwd: directory, transport: "structured", accountId: "work",
+      launchProfile: emptyLaunchProfile({ cwd: directory }),
+    });
+    if (other.kind !== "created") throw new Error("expected structured launch creation");
+    expect(restarted.snapshot().receipts[other.receipt.launchId]?.launchDisplay).toBeNull();
+  } finally {
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});
+
 test("terminal synthetic spawn cards join compact history after the scanner freshness horizon", () => {
   const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-spawn-projection-terminal-age-"));
   const filename = path.join(directory, "agent-registry.json");

--- a/src/lib/agent/spawnProjection.test.ts
+++ b/src/lib/agent/spawnProjection.test.ts
@@ -212,6 +212,95 @@ test("issue 569: a launch with no materialized transcript still projects the con
   }
 });
 
+test("issue 614: a transcript-less launch projects the queued prompt as the first user bubble across multiple polls", () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-614-pre-transcript-prompt-"));
+  try {
+    const registry = new AgentRegistry(path.join(directory, "agent-registry.json"), undefined, undefined, { sqliteMode: "off" });
+    const begun = registry.beginSpawnRequest({
+      engine: "codex", cwd: directory, transport: "structured", accountId: "work",
+      launchProfile: emptyLaunchProfile({ cwd: directory }),
+    });
+    if (begun.kind !== "created") throw new Error("expected structured launch creation");
+    /* The queued initial delivery the spawn holds for this launch — the durable
+       source of the first user bubble on EVERY surface, not only the browser
+       that ran the composer. */
+    registry.holdDelivery(begun.receipt.conversationId, "LLV614_CANONICAL_PROBE_20260723", `spawn_${begun.receipt.launchId}`);
+
+    const createdMs = Date.parse(begun.receipt.createdAt);
+    /* The launch stays transcript-less across several projection polls (the
+       production regression sampled ~0s / ~17s / ~32s). Every poll keeps ONE
+       window carrying the prompt as its first user bubble — never an empty shell
+       under status chips, and never a vanished window. */
+    for (const offset of [0, 17_000, 32_000, 4 * 60_000]) {
+      const projection = projectLaunchConversations([], registry.snapshot(), createdMs + offset);
+      expect(projection.cards).toHaveLength(1);
+      expect(projection.cards[0]!.spawn).toMatchObject({
+        state: "queued",
+        initialMessage: "queued",
+        promptImages: 0,
+        promptAt: createdMs, prompt: "LLV614_CANONICAL_PROBE_20260723",
+      });
+    }
+  } finally {
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+test("issue 614: a materialized launch whose transcript a scoped scan omits keeps its window until the live conversation is in the response", () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-614-pre-adoption-continuity-"));
+  const artifactPath = path.join(directory, "019f8dbe_e6cc_9e62_40df_06fb8f88b8a1.jsonl");
+  try {
+    fs.writeFileSync(artifactPath, `${JSON.stringify({ type: "user", message: "LLV614_CANONICAL_PROBE_20260723" })}\n`);
+    const registry = new AgentRegistry(path.join(directory, "agent-registry.json"), undefined, undefined, { sqliteMode: "off" });
+    const begun = registry.beginSpawnRequest({
+      engine: "codex", cwd: directory, transport: "structured", accountId: "work",
+      launchProfile: emptyLaunchProfile({ cwd: directory }),
+    });
+    if (begun.kind !== "created") throw new Error("expected structured launch creation");
+    registry.settleSpawn(begun.receipt.launchId, {
+      key: { engine: "codex", sessionId: "019f8dbe-" + "e6cc-9e62-40df-06fb8f88b8a1" },
+      artifactPath,
+      cwd: directory,
+      accountId: "work",
+      launchProfile: emptyLaunchProfile({ cwd: directory }),
+      status: "idle",
+      host: null,
+      claimEpoch: 0,
+      claimOwner: null,
+      pendingAction: null,
+    });
+    observeArtifact(registry, artifactPath, directory);
+    const createdMs = Date.parse(begun.receipt.createdAt);
+    const snapshot = registry.snapshot();
+    expect(snapshot.receipts[begun.receipt.launchId]?.artifactLifecycle).toBe("materialized");
+
+    /* The #614 vanish: inventory materialized the transcript, but the canonical
+       project poll that the operator is watching has not carried it yet. The
+       window must NOT blink out — the launch keeps its window while the
+       transcript still exists on disk and the launch is recent. */
+    const gap = projectLaunchConversations([], snapshot, createdMs + 17_000);
+    expect(gap.cards).toHaveLength(1);
+    expect(gap.cards[0]!).toMatchObject({ path: `spawn:${begun.receipt.launchId}` });
+
+    /* The receipt-to-transcript handoff in ONE response: the live transcript
+       arrives, the launch folds into that single window as transient facts, and
+       there is exactly one card — never a duplicate. */
+    const adopted = projectLaunchConversations([scannedFile(artifactPath)], snapshot, createdMs + 20_000);
+    expect(adopted.cards).toEqual([]);
+    expect(adopted.facts.get(artifactPath)).toMatchObject({ state: "recovered", initialMessage: "delivered" });
+
+    /* Aged past the pre-adoption grace with the transcript still outside the
+       scoped scan: it folds into history rather than resurrecting a phantom. */
+    expect(projectLaunchConversations([], snapshot, createdMs + 16 * 60_000).cards).toEqual([]);
+
+    /* A genuinely deleted transcript retires the window rather than lingering. */
+    fs.unlinkSync(artifactPath);
+    expect(projectLaunchConversations([], snapshot, createdMs + 17_000).cards).toEqual([]);
+  } finally {
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});
+
 test("terminal synthetic spawn cards join compact history after the scanner freshness horizon", () => {
   const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-spawn-projection-terminal-age-"));
   const filename = path.join(directory, "agent-registry.json");

--- a/src/lib/agent/spawnProjection.ts
+++ b/src/lib/agent/spawnProjection.ts
@@ -1,3 +1,4 @@
+import fs from "node:fs";
 import path from "node:path";
 
 import type { RegistryFile, SpawnReceipt } from "./registry";
@@ -30,6 +31,18 @@ function initialDelivery(snapshot: RegistryFile, receipt: SpawnReceipt) {
       && delivery.clientMessageId === `spawn_${receipt.launchId}`) ?? null;
 }
 
+/** The initial launch prompt still recoverable from the queued initial delivery
+    (issue #614). The held delivery carries the operator's launch text until it is
+    delivered, after which the registry clears it (the transcript then echoes it),
+    so this returns a value only during the pre-transcript window — exactly when a
+    surface that did not run the composer would otherwise show an empty feed. */
+function launchPromptOf(delivery: ReturnType<typeof initialDelivery>): { prompt: string; promptImages: number } | null {
+  if (!delivery) return null;
+  const promptImages = delivery.runtimeImages.length;
+  if (!delivery.text.trim() && !promptImages) return null;
+  return { prompt: delivery.text, promptImages };
+}
+
 function cardState(snapshot: RegistryFile, receipt: SpawnReceipt): StructuredSpawnCardState {
   const delivery = initialDelivery(snapshot, receipt);
   const failed = receipt.state === "failed" || receipt.state === "conflicted";
@@ -59,6 +72,7 @@ function cardState(snapshot: RegistryFile, receipt: SpawnReceipt): StructuredSpa
   } else if (binding) {
     state = "binding";
   }
+  const launchPrompt = launchPromptOf(delivery);
   return {
     launchId: receipt.launchId,
     clientAttemptId: receipt.clientAttemptId,
@@ -67,6 +81,9 @@ function cardState(snapshot: RegistryFile, receipt: SpawnReceipt): StructuredSpa
     initialMessage,
     retrySafe: receipt.state === "failed",
     error: receipt.error,
+    ...(launchPrompt
+      ? { prompt: launchPrompt.prompt, promptImages: launchPrompt.promptImages, promptAt: Date.parse(receipt.createdAt) || undefined }
+      : {}),
   };
 }
 
@@ -156,6 +173,30 @@ function transientLaunchFact(spawn: StructuredSpawnCardState, createdAt: string,
   return !Number.isFinite(createdMs) || nowMs - createdMs < TERMINAL_SPAWN_RECENT_MS;
 }
 
+/** The pre-adoption grace (issue #614): a launch whose transcript inventory
+    already materialized but which THIS scan did not carry stays projected only
+    while it is this recent — long enough to cover a project-scoped or
+    cache-lagged poll before the live transcript reaches the same view, short
+    enough that an aged materialized receipt whose transcript legitimately lives
+    outside a scoped scan folds into history instead of resurrecting a phantom
+    placeholder. */
+function withinAdoptionGrace(receipt: SpawnReceipt, nowMs: number): boolean {
+  const createdMs = Date.parse(receipt.createdAt);
+  return !Number.isFinite(createdMs) || nowMs - createdMs < TERMINAL_SPAWN_RECENT_MS;
+}
+
+/** Disk existence of a materialized artifact, the discriminator between the
+    #614 pre-adoption gap (the transcript exists but this scan omitted it — keep
+    the window) and a deleted transcript (gone — retire the window). Injected so
+    the projection stays a deterministic read model in tests. */
+function artifactOnDisk(pathname: string): boolean {
+  try {
+    return fs.existsSync(pathname);
+  } catch {
+    return false;
+  }
+}
+
 /**
  * The one launch read-model (issue #569). Every structured launch receipt
  * resolves to exactly ONE conversation surface:
@@ -181,6 +222,7 @@ export function projectLaunchConversations(
   files: readonly FileEntry[],
   snapshot: RegistryFile,
   nowMs = Date.now(),
+  artifactExists: (pathname: string) => boolean = artifactOnDisk,
 ): LaunchProjection {
   const byPath = new Map(files.map((file) => [file.path, file]));
   const scannedPaths = new Set(byPath.keys());
@@ -193,18 +235,28 @@ export function projectLaunchConversations(
   for (const receipt of receipts) {
     const spawn = cardState(snapshot, receipt);
     /* The materialized live conversation immediately retires the duplicate
-       spawn projection (#569): the launch folds into that window as chips. */
+       spawn projection (#569/#614): the launch folds into that window as chips.
+       Retirement happens ONLY here — when the adopted live conversation is
+       available in the SAME response — so the window never blinks out before its
+       transcript reaches the view. */
     const live = materializedEntry(byPath, files, snapshot, receipt);
     if (live) {
       if (transientLaunchFact(spawn, receipt.createdAt, nowMs)) facts.set(live.path, spawn);
       continue;
     }
-    /* No live transcript in this payload: the launch still owns the window.
-       A receipt whose artifact inventory already materialized elsewhere (a
-       project-scoped or capped scan that simply did not carry it) must not
-       resurrect a phantom placeholder. */
-    if (receipt.artifactLifecycle !== "pending") continue;
-    if (receipt.artifactPath && scannedPaths.has(receipt.artifactPath)) continue;
+    /* No live transcript in this payload: the launch still owns the window
+       across every pre-adoption state (starting/queued/reconciling/delivering).
+       A receipt whose artifact inventory already materialized keeps its window
+       only while the transcript still exists on disk (a project-scoped or
+       cache-lagged scan that simply did not carry it — issue #614) and the
+       launch is still recent; a gone transcript, or an aged materialized receipt
+       whose transcript legitimately lives outside a scoped scan, retires instead
+       of resurrecting a phantom placeholder. A still-`pending` launch always
+       projects — inventory has never materialized its artifact. */
+    if (receipt.artifactLifecycle !== "pending") {
+      const present = Boolean(receipt.artifactPath && artifactExists(receipt.artifactPath));
+      if (!present || !withinAdoptionGrace(receipt, nowMs)) continue;
+    }
     cards.push(spawnCard(snapshot, receipt, spawn, scannedPaths, nowMs));
   }
   return { cards, facts, routes };

--- a/src/lib/agent/spawnProjection.ts
+++ b/src/lib/agent/spawnProjection.ts
@@ -31,16 +31,25 @@ function initialDelivery(snapshot: RegistryFile, receipt: SpawnReceipt) {
       && delivery.clientMessageId === `spawn_${receipt.launchId}`) ?? null;
 }
 
-/** The initial launch prompt still recoverable from the queued initial delivery
-    (issue #614). The held delivery carries the operator's launch text until it is
-    delivered, after which the registry clears it (the transcript then echoes it),
-    so this returns a value only during the pre-transcript window — exactly when a
-    surface that did not run the composer would otherwise show an empty feed. */
-function launchPromptOf(delivery: ReturnType<typeof initialDelivery>): { prompt: string; promptImages: number } | null {
-  if (!delivery) return null;
-  const promptImages = delivery.runtimeImages.length;
-  if (!delivery.text.trim() && !promptImages) return null;
-  return { prompt: delivery.text, promptImages };
+/** The launch DISPLAY payload projected as the conversation's first user bubble
+    (issue #614/#615). The durable `receipt.launchDisplay`, captured at receipt
+    birth, is the authority: it is available across the WHOLE pre-transcript
+    lifecycle — `starting` before any deferred delivery exists, and the
+    delivered-but-scan-lagged interval after the held-delivery text is scrubbed.
+    A legacy receipt with no durable payload falls back to the queued delivery
+    text (its own echo identity), preserving the earlier behavior. */
+function launchPromptOf(
+  receipt: SpawnReceipt,
+  delivery: ReturnType<typeof initialDelivery>,
+): { prompt: string; promptImages: number; promptEcho: string } | null {
+  const display = receipt.launchDisplay;
+  if (display && (display.prompt.trim() || display.echo.trim() || display.images > 0)) {
+    return { prompt: display.prompt, promptImages: display.images, promptEcho: display.echo };
+  }
+  if (delivery && (delivery.text.trim() || delivery.runtimeImages.length)) {
+    return { prompt: delivery.text, promptImages: delivery.runtimeImages.length, promptEcho: delivery.text };
+  }
+  return null;
 }
 
 function cardState(snapshot: RegistryFile, receipt: SpawnReceipt): StructuredSpawnCardState {
@@ -72,7 +81,7 @@ function cardState(snapshot: RegistryFile, receipt: SpawnReceipt): StructuredSpa
   } else if (binding) {
     state = "binding";
   }
-  const launchPrompt = launchPromptOf(delivery);
+  const launchPrompt = launchPromptOf(receipt, delivery);
   return {
     launchId: receipt.launchId,
     clientAttemptId: receipt.clientAttemptId,
@@ -82,9 +91,29 @@ function cardState(snapshot: RegistryFile, receipt: SpawnReceipt): StructuredSpa
     retrySafe: receipt.state === "failed",
     error: receipt.error,
     ...(launchPrompt
-      ? { prompt: launchPrompt.prompt, promptImages: launchPrompt.promptImages, promptAt: Date.parse(receipt.createdAt) || undefined }
+      ? {
+          promptImages: launchPrompt.promptImages,
+          promptAt: Date.parse(receipt.createdAt) || undefined,
+          promptEcho: launchPrompt.promptEcho, prompt: launchPrompt.prompt,
+        }
       : {}),
   };
+}
+
+/** The launch facts INSIDE an adopted live conversation window (issue #615): the
+    transcript now renders the operator's message itself, so the launch stops
+    contributing a prompt bubble in the same response — only its transient status
+    chips remain. Strips every prompt-display field from the state. */
+function launchFactsWithoutPrompt(spawn: StructuredSpawnCardState): StructuredSpawnCardState {
+  if (spawn.prompt === undefined && spawn.promptEcho === undefined && spawn.promptImages === undefined && spawn.promptAt === undefined) {
+    return spawn;
+  }
+  const facts = { ...spawn };
+  delete facts.prompt;
+  delete facts.promptImages;
+  delete facts.promptAt;
+  delete facts.promptEcho;
+  return facts;
 }
 
 /** The scanned transcript entry that already represents a launch's conversation.
@@ -241,7 +270,7 @@ export function projectLaunchConversations(
        transcript reaches the view. */
     const live = materializedEntry(byPath, files, snapshot, receipt);
     if (live) {
-      if (transientLaunchFact(spawn, receipt.createdAt, nowMs)) facts.set(live.path, spawn);
+      if (transientLaunchFact(spawn, receipt.createdAt, nowMs)) facts.set(live.path, launchFactsWithoutPrompt(spawn));
       continue;
     }
     /* No live transcript in this payload: the launch still owns the window

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -22,6 +22,19 @@ export interface StructuredSpawnCardState {
   initialMessage: "pending" | "queued" | "delivered" | "failed";
   retrySafe: boolean;
   error: string | null;
+  /** The initial launch prompt (issue #614), sourced from the queued initial
+      delivery so ANY surface — not only the browser that ran the composer —
+      renders it as the conversation's first user bubble while the transcript is
+      still absent. Present only while the delivery still carries its text (it is
+      cleared once delivered, by which point the transcript echoes it); the seed
+      it produces is keyed by {@link launchId}, so it survives a refresh and
+      transcript adoption and never duplicates the composer's own seed. */
+  prompt?: string;
+  /** How many images rode with the launch prompt, for the bubble's count chip. */
+  promptImages?: number;
+  /** Submission moment (ms) of the launch prompt — the receipt's creation time —
+      so the seeded bubble orders ahead of any follow-up the operator queues. */
+  promptAt?: number;
 }
 
 /** Current quota wall affecting a hosted conversation. Account provenance

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -35,6 +35,11 @@ export interface StructuredSpawnCardState {
   /** Submission moment (ms) of the launch prompt — the receipt's creation time —
       so the seeded bubble orders ahead of any follow-up the operator queues. */
   promptAt?: number;
+  /** The canonical text the transcript will echo for this launch (issue #615) —
+      the delivered message, which for a role launch is the scaffold PLUS the raw
+      draft. The optimistic bubble displays `prompt` (the raw draft) but retires on
+      THIS text, so a scaffolded role launch never lingers and never duplicates. */
+  promptEcho?: string;
 }
 
 /** Current quota wall affecting a hosted conversation. Account provenance


### PR DESCRIPTION
## Problem

Verified on production `b57717ff` (canonical project key `-agents-tools-live-log-viewer-next`): a transcript-less structured launch (`conversation_e6ccc9e6…` / launch `fe448e06…`, `transcriptPath: null`) first rendered a `starting`/`reconciling` shell **without** its queued initial prompt, then the `spawn:<launchId>` node **disappeared before transcript adoption**. Two breaks in the #569 one-window contract during the pre-transcript states.

## Fix

**Prompt as the first user bubble on every surface.** The server now projects the queued initial prompt — recovered from the held `spawn_<launchId>` delivery, which carries the operator's launch text until it is delivered — onto the launch state (`prompt`/`promptImages`/`promptAt`). `LogFeed` seeds the launch-owned outbox bubble from it, keyed by launch id under the stable conversation identity: idempotent with the composer's own seed (**no duplicate**), so a board that never ran the composer (an MCP spawn, a second tab, a fresh refresh) shows the same first user bubble. It survives a refresh, folds through transcript adoption, and retires on its transcript echo.

**One window across every pre-adoption state.** `projectLaunchConversations` retires the spawn projection **only when the adopted live conversation is available in the same response**. A receipt whose inventory already materialized but which this (project-scoped or cache-lagged) poll did not carry keeps its window while the transcript still exists on disk and the launch is recent, so a just-live conversation never blinks out before its transcript reaches the view; a gone transcript, or an aged materialized receipt whose transcript lives outside a scoped scan, still folds into history rather than resurrecting a phantom placeholder. The disk probe is injected so the projection stays a deterministic read model.

Preserves the #609 contract: queue-first multi-send, first assistant JSON-RPC deltas, stage/reviewer conversation windows, image capability gating, canonical routing, privacy redaction, desktop/mobile.

## Tests & evidence (RED-first)

- `spawnProjection.test.ts` — a transcript-less launch projects the queued prompt as the first user bubble across multiple polls; a materialized launch whose transcript a scoped scan omits keeps its window until the live conversation is in the response (and the receipt-to-transcript handoff folds into one window with zero duplicate; aged/deleted transcripts retire). Both fail on `b57717ff`, pass here.
- `outbox.test.ts` — a server-projected seed and the composer's own seed (identical launch id and text) are one bubble that survives a refresh and retires on its own echo — never a duplicate.
- `conversationWindowEvidence.browser.test.tsx` — adds a `pre-transcript-prompt` state rendered with production CSS in headless Chromium at desktop (1280px) and 390px; committed `geometry.json` asserts the prompt bubble (`data-outbox`) + launch chips render with no horizontal overflow and a feed-dominant layout.

Focused tests, `tsc --noEmit`, changed-file ESLint, the privacy publication gate, and `bun run build` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)