### PR TITLE
fix(composer): retire delivered receipt echoes from feed

### DIFF
--- a/src/components/TmuxComposer.deliveryState.dom.test.tsx
+++ b/src/components/TmuxComposer.deliveryState.dom.test.tsx
@@ -68,6 +68,7 @@ afterAll(() => {
   mock.module("@/hooks/useRuntime", () => actualRuntimeHooks);
 });
 
+const { publishTranscriptEchoes, resetOutboxForTests } = await import("./conversation/outbox");
 const { RuntimeComposerReceipts, TmuxComposer } = await import("./TmuxComposer");
 
 const realFetch = globalThis.fetch;
@@ -79,6 +80,7 @@ afterEach(() => {
   document.body.replaceChildren();
   localStorage.clear();
   sessionStorage.clear();
+  resetOutboxForTests();
 });
 
 const receipt = (overrides: Partial<RuntimeReceipt> & { operationId: string }): RuntimeReceipt => ({
@@ -242,7 +244,7 @@ test("a dismissed failure stays dismissed across a composer remount", async () =
   await act(async () => second.root.unmount());
 });
 
-test("a delivered send shows one quiet echo line that clears when the bubble lands in the feed", async () => {
+test("a delivered send shows one quiet echo line that clears when the exact bubble lands in the feed", async () => {
   setLocale("uk");
   mockTargets();
   const delivered = receipt({ operationId: "op-echo", status: "delivered", text: "я хочу стрілочками переміщатися" });
@@ -258,8 +260,9 @@ test("a delivered send shows one quiet echo line that clears when the bubble lan
   expect(host.querySelector("[data-receipt-status]")).toBeNull();
   expect(host.querySelector("[data-runtime-receipt-stack]")).toBeNull();
 
-  // The transcript grew past the delivery moment — the bubble is the receipt.
-  await settle(() => root.render(<TmuxComposer file={file((Date.now() + 5_000) / 1000)} />));
+  // The exact transcript bubble is authoritative even when its mtime predates
+  // the final delivered receipt.
+  await settle(() => publishTranscriptEchoes("conv-quiet", new Map([[delivered.text!, 1]])));
   expect(host.querySelector("[data-delivery-echo]")).toBeNull();
   await act(async () => root.unmount());
 });

--- a/src/components/TmuxComposer.tsx
+++ b/src/components/TmuxComposer.tsx
@@ -29,6 +29,7 @@ import {
   transcriptEchoCount,
   updateOutbox,
   useOutbox,
+  useTranscriptEchoes,
   type OutboxEntry,
   type OutboxState,
 } from "./conversation/outbox";
@@ -1008,6 +1009,10 @@ export function TmuxComposer({
      moment they are submitted, so the feed can render them as optimistic user
      bubbles while the composer clears and stays typable. */
   const outbox = useOutbox(cardId);
+  /* Exact transcript user echoes are the authoritative retirement signal for
+     temporary delivered rows. The feed publishes them reactively because the
+     transcript write commonly precedes the final delivered receipt. */
+  const transcriptEchoCounts = useTranscriptEchoes(cardId);
   /* Attachment bytes for queued submissions. Memory-only: a refresh restores
      the queue's text but not its images, and the restore path marks any
      image-bearing entry as needing re-attachment rather than silently sending
@@ -1076,7 +1081,13 @@ export function TmuxComposer({
      quiet one-line echoes derived from the receipt stream (issue #264 rule 2).
      They self-clear the moment the transcript grows — the bubble in the feed
      is the real confirmation — so success never accumulates chrome. */
-  const echoedReceipts = deliveryEchoes(displayedRuntimeReceipts, file.mtime * 1000, dismissedReceipts, nowMs());
+  const echoedReceipts = deliveryEchoes(
+    displayedRuntimeReceipts,
+    file.mtime * 1000,
+    dismissedReceipts,
+    nowMs(),
+    transcriptEchoCounts,
+  );
 
   const persistPendingDeliveries = (next: PendingDelivery[]) => {
     pendingDeliveries.current = next;

--- a/src/components/conversation/outbox.ts
+++ b/src/components/conversation/outbox.ts
@@ -260,16 +260,34 @@ export type TranscriptEchoCounts = ReadonlyMap<string, number>;
  * the same stable conversation identity as the queue itself.
  */
 const echoSnapshots = new Map<string, TranscriptEchoCounts>();
+const echoListeners = new Set<() => void>();
+const EMPTY_ECHO_COUNTS: TranscriptEchoCounts = new Map();
 
 /** Publish the transcript's current user-echo counts for a conversation. */
 export function publishTranscriptEchoes(cardId: string, counts: TranscriptEchoCounts): void {
+  if (echoSnapshots.get(cardId) === counts) return;
   echoSnapshots.set(cardId, counts);
+  for (const listener of echoListeners) listener();
 }
 
 /** How many transcript echoes of `text` the feed has published for a
     conversation — the submission watermark a new entry stamps onto itself. */
 export function transcriptEchoCount(cardId: string, text: string): number {
   return echoSnapshots.get(cardId)?.get(echoKey(text)) ?? 0;
+}
+
+/** Reactive transcript-echo snapshot for the composer. Delivery success can
+    arrive after its user bubble was already written, so exact feed evidence
+    retires the temporary receipt row immediately. */
+export function useTranscriptEchoes(cardId: string): TranscriptEchoCounts {
+  return useSyncExternalStore(
+    (listener) => {
+      echoListeners.add(listener);
+      return () => echoListeners.delete(listener);
+    },
+    () => echoSnapshots.get(cardId) ?? EMPTY_ECHO_COUNTS,
+    () => EMPTY_ECHO_COUNTS,
+  );
 }
 
 /**
@@ -367,4 +385,5 @@ export function resetOutboxForTests(): void {
   queues.clear();
   listeners.clear();
   echoSnapshots.clear();
+  echoListeners.clear();
 }

--- a/src/components/runtime/deliveryState.test.ts
+++ b/src/components/runtime/deliveryState.test.ts
@@ -133,6 +133,32 @@ test("a delivered send echoes only until the transcript grows past the delivery 
   expect(deliveryEchoes([delivered], staleMtime, new Set(["op-echo"]), now)).toEqual([]);
 });
 
+test("an exact feed echo retires a delivered row while queued and delivering receipts stay active", () => {
+  const now = Date.parse("2026-07-18T10:00:05.000Z");
+  const text = "already visible in the feed";
+  const delivered = receipt({
+    operationId: "op-delivered",
+    status: "delivered",
+    text,
+    at: "2026-07-18T10:00:04.000Z",
+  });
+  const active = [
+    receipt({ operationId: "op-queued", status: "queued", text: "waiting in queue" }),
+    receipt({ operationId: "op-delivering", status: "delivering", text: "on the wire" }),
+  ];
+
+  /* Production ordering writes the transcript user bubble before the runtime
+     receipt reaches `delivered`, so mtime alone can remain older than receipt.at. */
+  expect(deliveryEchoes(
+    [delivered],
+    Date.parse("2026-07-18T10:00:03.000Z"),
+    new Set(),
+    now,
+    new Map([[text, 1]]),
+  )).toEqual([]);
+  expect(deliveryAttemptGroups(active).map((group) => group.current.status)).toEqual(["queued", "delivering"]);
+});
+
 test("active, problem, and interrupted receipts never echo", () => {
   const now = Date.parse("2026-07-18T10:00:05.000Z");
   const mtime = 0;

--- a/src/components/runtime/deliveryState.ts
+++ b/src/components/runtime/deliveryState.ts
@@ -97,25 +97,27 @@ export function visibleStandaloneReceipts(
     && !(receiptIsTerminal(receipt.status) && dismissed.has(receipt.operationId)));
 }
 
-/** The echo self-clears once the transcript grows past the delivery moment
-    (small grace: the bubble's write IS what bumps the mtime). */
+/** The mtime fallback self-clears an echo once the transcript grows past the
+    delivery moment (small grace: the bubble's write bumps the mtime). */
 export const DELIVERY_ECHO_MTIME_GRACE_MS = 2_000;
 /** Hard cap so a conversation whose transcript never grows again (finished
     pane, lost poll) cannot keep echoes around forever. */
 export const DELIVERY_ECHO_TTL_MS = 10 * 60_000;
+const EMPTY_TRANSCRIPT_ECHO_COUNTS: ReadonlyMap<string, number> = new Map();
 
 /**
  * Successful sends whose bubble has not landed in the visible feed yet: the
  * quiet one-line echo above the composer (rule 2). Derived, never stored — one
- * echo per idempotency key, only while the receipt's delivery moment is newer
- * than the transcript's mtime and younger than the TTL. `interrupted` resolves
- * quiet but delivered nothing, so it never echoes.
+ * echo per idempotency key. An exact user-text occurrence in the rendered feed
+ * retires it immediately. The mtime and TTL checks cover legacy or temporarily
+ * incomplete feed snapshots. `interrupted` resolves quietly and never echoes.
  */
 export function deliveryEchoes(
   receipts: readonly RuntimeReceipt[],
   fileMtimeMs: number,
   dismissed: ReadonlySet<string>,
   nowMs: number,
+  transcriptEchoCounts: ReadonlyMap<string, number> = EMPTY_TRANSCRIPT_ECHO_COUNTS,
 ): RuntimeReceipt[] {
   const seenKeys = new Set<string>();
   const echoes: RuntimeReceipt[] = [];
@@ -127,6 +129,8 @@ export function deliveryEchoes(
     seenKeys.add(receipt.idempotencyKey);
     if (!deliveryResolved(receipt.status) || receipt.status === "interrupted") continue;
     if (dismissed.has(receipt.operationId)) continue;
+    const text = receipt.text?.trim();
+    if (text && (transcriptEchoCounts.get(text) ?? 0) > 0) continue;
     const at = Date.parse(receipt.at);
     if (!Number.isFinite(at)) continue;
     if (fileMtimeMs >= at + DELIVERY_ECHO_MTIME_GRACE_MS) continue;


### PR DESCRIPTION
## Summary

- retire the temporary delivered receipt row as soon as the exact user message is present in the rendered feed
- publish transcript echo counts through a reactive external-store snapshot so receipt arrival ordering cannot strand the row
- keep the existing mtime and TTL fallbacks for incomplete feed snapshots
- preserve active `queued` and `delivering` receipt surfaces

## Root cause

The runtime and held-delivery records already reached `delivered`. The client success-echo retirement compared transcript mtime with `receipt.at + 2s`. Production writes the transcript user bubble before the final receipt, so the same bubble could already be visible while its mtime remained older than the delivered receipt. A quiet conversation then retained the `✓ text time ✕` row.

This behavior came from the delivery echo UI introduced before #609/#615.

## Before / after

**Before:** a delivered message could appear in the feed and remain duplicated above the composer until a later transcript write, a React render after the TTL, or manual dismissal.

**After:** an exact feed echo retires the delivered row immediately. Active delivery receipts continue to show their pending state.

## Verification

- `bun test src/components/runtime/deliveryState.test.ts src/components/TmuxComposer.deliveryState.dom.test.tsx src/components/conversation/outbox.test.ts` — 42 pass
- `bun x tsc --noEmit` — pass
- changed-file ESLint — pass
- `bun run build` — pass
- `bun run privacy:check` — pass

Closes #619
