### PR TITLE
fix(composer): retire bounded and replied outbox echoes

### DIFF
--- a/src/components/TmuxComposer.deliveryState.dom.test.tsx
+++ b/src/components/TmuxComposer.deliveryState.dom.test.tsx
@@ -13,7 +13,8 @@ import { Window } from "happy-dom";
 import { flushSync } from "react-dom";
 import { createRoot, type Root } from "react-dom/client";
 
-import type { RuntimeReceipt } from "@/components/runtime/runtimeModel";
+import { emptyStore, type RuntimeReceipt } from "@/components/runtime/runtimeModel";
+import type { RuntimeSessionView } from "@/hooks/useRuntime";
 import type { FileEntry } from "@/lib/types";
 import { setLocale, translate } from "@/lib/i18n";
 
@@ -47,14 +48,35 @@ Object.assign(globalThis, {
    pendingImages harness: receipts arrive the way production delivers them. */
 const actualRuntimeHooks = await import("@/hooks/useRuntime");
 const receiptListeners = new Set<() => void>();
+const runtimeStore = emptyStore();
 let busReceipts: RuntimeReceipt[] = [];
+let runtimeView: RuntimeSessionView | null = null;
 function publishReceipts(next: RuntimeReceipt[]): void {
   busReceipts = next;
   for (const listener of receiptListeners) listener();
 }
+function publishRuntimeView(next: RuntimeSessionView | null): void {
+  runtimeView = next;
+  for (const listener of receiptListeners) listener();
+}
 mock.module("@/hooks/useRuntime", () => ({
   ...actualRuntimeHooks,
-  useRuntimeSession: () => null,
+  useRuntime: () => ({
+    enabled: runtimeView !== null,
+    structuredHostsEnabled: runtimeView !== null,
+    connection: runtimeView ? "live" : "offline",
+    resyncedAt: null,
+    store: runtimeStore,
+  }),
+  useRuntimeSession: () => useSyncExternalStore(
+    (listener) => {
+      receiptListeners.add(listener);
+      return () => receiptListeners.delete(listener);
+    },
+    () => runtimeView,
+    () => runtimeView,
+  ),
+  useRuntimeSessionByArtifact: () => null,
   useRuntimeReceiptsForArtifact: () => useSyncExternalStore(
     (listener) => {
       receiptListeners.add(listener);
@@ -68,7 +90,13 @@ afterAll(() => {
   mock.module("@/hooks/useRuntime", () => actualRuntimeHooks);
 });
 
-const { publishTranscriptEchoes, resetOutboxForTests } = await import("./conversation/outbox");
+const {
+  enqueueOutbox,
+  publishTranscriptEchoes,
+  readOutbox,
+  resetOutboxForTests,
+  updateOutbox,
+} = await import("./conversation/outbox");
 const { RuntimeComposerReceipts, TmuxComposer } = await import("./TmuxComposer");
 
 const realFetch = globalThis.fetch;
@@ -77,6 +105,7 @@ afterEach(() => {
   setLocale("en");
   globalThis.fetch = realFetch;
   publishReceipts([]);
+  publishRuntimeView(null);
   document.body.replaceChildren();
   localStorage.clear();
   sessionStorage.clear();
@@ -92,6 +121,36 @@ const receipt = (overrides: Partial<RuntimeReceipt> & { operationId: string }): 
   at: new Date().toISOString(),
   revision: 1,
   ...overrides,
+});
+
+const structuredRuntimeView = (
+  liveTurn: { turnId: string; text: string } | null,
+): RuntimeSessionView => ({
+  session: {
+    conversationId: "conv-quiet",
+    sessionKey: { engine: "codex", sessionId: "conv-quiet" },
+    hostKind: "codex-app-server",
+    host: "hosted",
+    turn: liveTurn ? "running" : "idle",
+    provenance: "structured",
+    revision: 1,
+    attentionIds: [],
+    recentReceipts: busReceipts,
+    accountId: null,
+    parentConversationId: null,
+    flowId: null,
+    workflowId: null,
+    cwd: "/repo",
+    artifactPath: "/codex-quiet.jsonl",
+    capabilities: { steer: true, structuredAttention: true },
+    activeTurnId: liveTurn?.turnId ?? null,
+    liveTurn,
+  },
+  uiState: liveTurn ? "working" : "idle",
+  attentions: [],
+  receipts: busReceipts,
+  legacy: false,
+  structuredControlsEnabled: true,
 });
 
 const file = (mtimeSeconds: number): FileEntry => ({
@@ -264,6 +323,40 @@ test("a delivered send shows one quiet echo line that clears when the exact bubb
   // the final delivered receipt.
   await settle(() => publishTranscriptEchoes("conv-quiet", new Map([[delivered.text!, 1]])));
   expect(host.querySelector("[data-delivery-echo]")).toBeNull();
+  await act(async () => root.unmount());
+});
+
+test("a streaming assistant reply retires its delivering outbox bubble", async () => {
+  mockTargets();
+  const responding = receipt({
+    operationId: "turn-replied",
+    idempotencyKey: "key-replied",
+    status: "delivering",
+    turnId: null,
+    text: "the assistant is answering this",
+  });
+  enqueueOutbox("conv-quiet", {
+    id: responding.idempotencyKey,
+    text: responding.text!,
+    images: 0,
+    at: Date.parse(responding.at),
+  });
+  updateOutbox("conv-quiet", responding.idempotencyKey, { state: "delivering" });
+  publishReceipts([responding]);
+  publishRuntimeView(structuredRuntimeView(null));
+
+  const { root } = await renderInto(<TmuxComposer file={file(1)} />);
+  expect(readOutbox("conv-quiet")[0]).toMatchObject({ state: "delivering" });
+
+  await settle(() => publishRuntimeView(structuredRuntimeView({
+    turnId: responding.operationId,
+    text: "streaming reply",
+  })));
+  expect(readOutbox("conv-quiet")[0]).toMatchObject({
+    id: responding.idempotencyKey,
+    state: "delivered",
+  });
+  expect(readOutbox("conv-quiet")[0]!.responseStartedAt).toBeNumber();
   await act(async () => root.unmount());
 });
 

--- a/src/components/TmuxComposer.tsx
+++ b/src/components/TmuxComposer.tsx
@@ -24,6 +24,7 @@ import {
   adoptOutbox,
   cancelOutbox,
   enqueueOutbox,
+  markOutboxResponded,
   outboxHistory,
   outboxStateForReceiptStatus,
   transcriptEchoCount,
@@ -50,6 +51,7 @@ import {
   deliveryEchoes,
   deliveryProblem,
   dismissedReceiptsKey,
+  messageReceiptForAssistantTurn,
   readDismissedReceipts,
   visibleStandaloneReceipts,
   withDismissedReceipts,
@@ -1057,6 +1059,19 @@ export function TmuxComposer({
      is disabled or the session is legacy/unhosted). */
   const runtimeReceipts = useRuntimeReceiptsForArtifact(file.path, cardId);
   const displayedRuntimeReceipts = mergeRuntimeReceipts(runtimeReceipts, immediateRuntimeReceipts);
+  const assistantTurnReceipt = messageReceiptForAssistantTurn(
+    displayedRuntimeReceipts,
+    structuredSession?.session.liveTurn?.turnId,
+  );
+  const assistantTurnMessageKey = assistantTurnReceipt?.idempotencyKey;
+  /* A live assistant delta proves the matching message reached its turn even
+     while the receipt stream still projects `delivering`. Persist that causal
+     settlement so the optimistic bubble stays retired after the delta folds
+     into the transcript. */
+  useEffect(() => {
+    if (!assistantTurnMessageKey) return;
+    markOutboxResponded(cardId, assistantTurnMessageKey, nowMs());
+  }, [cardId, assistantTurnMessageKey]);
   const displayedRuntimeReceiptsRef = useRef(displayedRuntimeReceipts);
   useLayoutEffect(() => {
     displayedRuntimeReceiptsRef.current = displayedRuntimeReceipts;
@@ -1077,6 +1092,12 @@ export function TmuxComposer({
     setDismissedReceiptIds(next);
     writeDismissedReceipts(cardId, next);
   };
+  const respondedMessageKeys = new Set(
+    outbox
+      .filter((entry) => entry.responseStartedAt !== undefined)
+      .map((entry) => entry.id),
+  );
+  if (assistantTurnMessageKey) respondedMessageKeys.add(assistantTurnMessageKey);
   /* Successful sends whose bubble has not landed in the visible feed yet:
      quiet one-line echoes derived from the receipt stream (issue #264 rule 2).
      They self-clear the moment the transcript grows — the bubble in the feed
@@ -1087,6 +1108,7 @@ export function TmuxComposer({
     dismissedReceipts,
     nowMs(),
     transcriptEchoCounts,
+    respondedMessageKeys,
   );
 
   const persistPendingDeliveries = (next: PendingDelivery[]) => {

--- a/src/components/conversation/outbox.test.ts
+++ b/src/components/conversation/outbox.test.ts
@@ -5,6 +5,7 @@ import {
   adoptOutbox,
   cancelOutbox,
   enqueueOutbox,
+  markOutboxResponded,
   nextDispatch,
   outboxHistory,
   OUTBOX_DELIVERED_TTL_MS,
@@ -117,6 +118,36 @@ test("queued / delivering / launch-owned bubbles stay until their echo lands, ne
   expect(visibleOutbox([queued, delivering, launch], echoes(), far)).toHaveLength(3);
   /* Each retires only on its own echo. */
   expect(visibleOutbox([queued, delivering, launch], echoes("the launch prompt"), far).map((e) => e.id)).toEqual(["k1", "k2"]);
+});
+
+test("assistant reply evidence settles and retires its delivering outbox bubble", () => {
+  const submittedAt = 1_000_000;
+  enqueueOutbox("conv", { id: "key-replied", text: "please inspect this", images: 0, at: submittedAt });
+  updateOutbox("conv", "key-replied", { state: "delivering" });
+
+  markOutboxResponded("conv", "key-replied", submittedAt + 2_000);
+
+  const [responded] = readOutbox("conv");
+  expect(responded).toMatchObject({
+    id: "key-replied",
+    state: "delivered",
+    settledAt: submittedAt + 2_000,
+    responseStartedAt: submittedAt + 2_000,
+  });
+  expect(visibleOutbox([responded!], echoes(), submittedAt + 2_001)).toEqual([]);
+});
+
+test("assistant reply evidence leaves an unrelated pending outbox bubble visible", () => {
+  const submittedAt = 1_000_000;
+  enqueueOutbox("conv", { id: "key-replied", text: "first turn", images: 0, at: submittedAt });
+  updateOutbox("conv", "key-replied", { state: "delivering" });
+  enqueueOutbox("conv", { id: "key-pending", text: "still waiting", images: 0, at: submittedAt + 1 });
+
+  markOutboxResponded("conv", "key-replied", submittedAt + 2_000);
+
+  expect(visibleOutbox(readOutbox("conv"), echoes(), submittedAt + 2_001).map((entry) => entry.id))
+    .toEqual(["key-pending"]);
+  expect(readOutbox("conv").find((entry) => entry.id === "key-pending")).toMatchObject({ state: "queued" });
 });
 
 test("finding 2: a pre-existing identical user message leaves a freshly queued bubble visible", () => {

--- a/src/components/conversation/outbox.ts
+++ b/src/components/conversation/outbox.ts
@@ -36,6 +36,9 @@ export interface OutboxEntry {
   state: OutboxState;
   /** Moment the entry left `queued`/`delivering` (ms), for the hard-cap TTL. */
   settledAt?: number;
+  /** Assistant output began for the turn created by this submission. This is
+      causal delivery proof and permanently retires the optimistic bubble. */
+  responseStartedAt?: number;
   error?: string;
   /** The attachment bytes of this submission did not survive a page refresh
       (previews are memory-only). The entry is held back rather than delivered
@@ -208,6 +211,20 @@ export function updateOutbox(cardId: string, id: string, patch: Partial<Omit<Out
   write(cardId, queue.map((entry) => (entry.id === id ? { ...entry, ...patch } : entry)));
 }
 
+/** Settle one submission when the assistant starts its matching runtime turn.
+    The entry remains in recent history while its optimistic bubble retires. */
+export function markOutboxResponded(cardId: string, id: string, at: number): void {
+  const queue = readOutbox(cardId);
+  const entry = queue.find((item) => item.id === id);
+  if (!entry || entry.responseStartedAt !== undefined) return;
+  write(cardId, queue.map((item) => (item.id === id ? {
+    ...item,
+    state: "delivered",
+    settledAt: item.settledAt ?? at,
+    responseStartedAt: at,
+  } : item)));
+}
+
 /** Remove an entry outright — the operator cancelled a message that never left. */
 export function cancelOutbox(cardId: string, id: string): void {
   const queue = readOutbox(cardId);
@@ -331,6 +348,7 @@ export function visibleOutbox(
       consumed.set(key, floor + 1);
       continue;
     }
+    if (entry.responseStartedAt !== undefined) continue;
     if (entry.state === "delivered") {
       const settledAt = entry.settledAt ?? entry.at;
       if (nowMs - settledAt >= OUTBOX_DELIVERED_TTL_MS) continue;

--- a/src/components/runtime/deliveryState.test.ts
+++ b/src/components/runtime/deliveryState.test.ts
@@ -15,6 +15,7 @@ import {
   visibleStandaloneReceipts,
   withDismissedReceipts,
   writeDismissedReceipts,
+  messageReceiptForAssistantTurn,
 } from "./deliveryState";
 import type { ReceiptStatus, RuntimeReceipt } from "./runtimeModel";
 
@@ -157,6 +158,67 @@ test("an exact feed echo retires a delivered row while queued and delivering rec
     new Map([[text, 1]]),
   )).toEqual([]);
   expect(deliveryAttemptGroups(active).map((group) => group.current.status)).toEqual(["queued", "delivering"]);
+});
+
+test("full feed bubbles retire every delivered row whose receipt text is a bounded prefix", () => {
+  const now = Date.parse("2026-07-23T07:13:25.000Z");
+  const fullTexts = [
+    "а".repeat(286),
+    "б".repeat(325),
+  ];
+  const receipts = fullTexts.map((text, index) => receipt({
+    operationId: `op-bounded-${index}`,
+    status: "delivered",
+    text: text.slice(0, 240),
+    at: `2026-07-23T07:13:2${index}.000Z`,
+  }));
+
+  expect(deliveryEchoes(
+    receipts,
+    Date.parse("2026-07-23T07:13:00.000Z"),
+    new Set(),
+    now,
+    new Map(fullTexts.map((text) => [text, 1])),
+  )).toEqual([]);
+});
+
+test("assistant turn evidence identifies its delivering message and leaves another pending message unmatched", () => {
+  const delivering = receipt({
+    operationId: "turn-replied",
+    idempotencyKey: "key-replied",
+    status: "delivering",
+    turnId: null,
+    text: "the assistant is answering this",
+  });
+  const pending = receipt({
+    operationId: "op-pending",
+    idempotencyKey: "key-pending",
+    status: "queued",
+    turnId: null,
+    text: "still waiting",
+  });
+
+  expect(messageReceiptForAssistantTurn([pending, delivering], "turn-replied")?.idempotencyKey).toBe("key-replied");
+  expect(messageReceiptForAssistantTurn([pending, delivering], "some-other-turn")).toBeNull();
+});
+
+test("assistant response evidence retires a delivered echo before its feed bubble lands", () => {
+  const delivered = receipt({
+    operationId: "op-replied",
+    idempotencyKey: "key-replied",
+    status: "delivered",
+    text: "reply already streaming",
+    at: "2026-07-23T07:13:20.000Z",
+  });
+
+  expect(deliveryEchoes(
+    [delivered],
+    Date.parse("2026-07-23T07:13:00.000Z"),
+    new Set(),
+    Date.parse("2026-07-23T07:13:25.000Z"),
+    new Map(),
+    new Set([delivered.idempotencyKey]),
+  )).toEqual([]);
 });
 
 test("active, problem, and interrupted receipts never echo", () => {

--- a/src/components/runtime/deliveryState.ts
+++ b/src/components/runtime/deliveryState.ts
@@ -34,6 +34,21 @@ function isMessage(receipt: RuntimeReceipt): boolean {
 
 const newestFirst = (left: RuntimeReceipt, right: RuntimeReceipt) => Date.parse(right.at) - Date.parse(left.at);
 
+/** Message receipt causally owned by the assistant turn that emitted a live
+    delta. Claude commonly uses the operation id as its native turn id while
+    the intermediate delivering receipt still carries a null `turnId`. */
+export function messageReceiptForAssistantTurn(
+  receipts: readonly RuntimeReceipt[],
+  assistantTurnId: string | null | undefined,
+): RuntimeReceipt | null {
+  if (!assistantTurnId) return null;
+  return [...receipts]
+    .sort(newestFirst)
+    .find((receipt) =>
+      isMessage(receipt)
+      && (receipt.turnId === assistantTurnId || receipt.operationId === assistantTurnId)) ?? null;
+}
+
 export interface DeliveryAttemptGroup {
   /** Newest visible attempt — carries the current state and the action set. */
   current: RuntimeReceipt;
@@ -103,7 +118,25 @@ export const DELIVERY_ECHO_MTIME_GRACE_MS = 2_000;
 /** Hard cap so a conversation whose transcript never grows again (finished
     pane, lost poll) cannot keep echoes around forever. */
 export const DELIVERY_ECHO_TTL_MS = 10 * 60_000;
+/** Runtime-host receipts carry a bounded display summary of the submitted text. */
+const RECEIPT_TEXT_SUMMARY_LIMIT = 240;
 const EMPTY_TRANSCRIPT_ECHO_COUNTS: ReadonlyMap<string, number> = new Map();
+const EMPTY_RESPONDED_KEYS: ReadonlySet<string> = new Set();
+
+function consumeTranscriptEcho(
+  receiptText: string,
+  remaining: Map<string, number>,
+): boolean {
+  const summary = receiptText.trim();
+  for (const [transcriptText, count] of remaining) {
+    if (count <= 0) continue;
+    const echo = transcriptText.trim();
+    if (echo !== summary && (summary.length !== RECEIPT_TEXT_SUMMARY_LIMIT || !echo.startsWith(summary))) continue;
+    remaining.set(transcriptText, count - 1);
+    return true;
+  }
+  return false;
+}
 
 /**
  * Successful sends whose bubble has not landed in the visible feed yet: the
@@ -118,19 +151,37 @@ export function deliveryEchoes(
   dismissed: ReadonlySet<string>,
   nowMs: number,
   transcriptEchoCounts: ReadonlyMap<string, number> = EMPTY_TRANSCRIPT_ECHO_COUNTS,
+  respondedIdempotencyKeys: ReadonlySet<string> = EMPTY_RESPONDED_KEYS,
 ): RuntimeReceipt[] {
   const seenKeys = new Set<string>();
-  const echoes: RuntimeReceipt[] = [];
-  const sorted = receipts
+  const currentReceipts: RuntimeReceipt[] = [];
+  for (const receipt of receipts
     .filter((receipt) => isMessage(receipt) && Boolean(receipt.text))
-    .sort(newestFirst);
-  for (const receipt of sorted) {
+    .sort(newestFirst)) {
     if (seenKeys.has(receipt.idempotencyKey)) continue;
     seenKeys.add(receipt.idempotencyKey);
+    currentReceipts.push(receipt);
+  }
+
+  /* Match oldest sends first so each transcript occurrence confirms one
+     logical message when identical text was submitted more than once. */
+  const remainingTranscriptEchoes = new Map(transcriptEchoCounts);
+  const echoedOperationIds = new Set<string>();
+  for (const receipt of [...currentReceipts].reverse()) {
     if (!deliveryResolved(receipt.status) || receipt.status === "interrupted") continue;
     if (dismissed.has(receipt.operationId)) continue;
     const text = receipt.text?.trim();
-    if (text && (transcriptEchoCounts.get(text) ?? 0) > 0) continue;
+    if (!text) continue;
+    if (!consumeTranscriptEcho(text, remainingTranscriptEchoes)) continue;
+    echoedOperationIds.add(receipt.operationId);
+  }
+
+  const echoes: RuntimeReceipt[] = [];
+  for (const receipt of currentReceipts) {
+    if (!deliveryResolved(receipt.status) || receipt.status === "interrupted") continue;
+    if (dismissed.has(receipt.operationId)) continue;
+    if (respondedIdempotencyKeys.has(receipt.idempotencyKey)) continue;
+    if (echoedOperationIds.has(receipt.operationId)) continue;
     const at = Date.parse(receipt.at);
     if (!Number.isFinite(at)) continue;
     if (fileMtimeMs >= at + DELIVERY_ECHO_MTIME_GRACE_MS) continue;


### PR DESCRIPTION
## Summary

- match each delivered receipt summary against complete feed bubbles, including the runtime host's 240-character text cap
- consume transcript occurrences oldest-first so repeated messages retire causally
- settle the matching outbox entry when its assistant turn emits a live delta
- persist assistant-response evidence so optimistic bubbles and success echoes stay retired
- preserve unrelated queued and in-flight messages

## Root cause

PR #620 keyed retirement on exact trimmed text. Runtime-host receipts store `command.text.slice(0, 240)`, while the feed renders the complete transcript message. Every longer message therefore missed the lookup even with its bubble visible.

The conversation runtime also exposed `liveTurn`, yet composer/outbox retirement never consumed it. A Claude turn could stream assistant output while the matching optimistic bubble still projected `Delivering`.

## Before / after

**Before:** the affected production conversation held several `✓ text time ✕` rows. Five of its eight recent send receipts had 240-character summaries that failed exact feed lookup. A matching assistant delta could leave the optimistic bubble in `Delivering`.

**After:** capped receipt summaries match their full feed bubbles with one occurrence consumed per logical send. A live assistant turn maps through the receipt to its idempotency key, durably settles that outbox entry, and retires its success echo. An unrelated pending message remains visible.

## Live replay

Replaying the affected production receipt snapshot against its full Claude transcript now yields zero remaining delivery echoes.

## Verification

- `bun test src/components/runtime/deliveryState.test.ts src/components/conversation/outbox.test.ts src/components/TmuxComposer.deliveryState.dom.test.tsx` — 48 pass
- `bun x tsc --noEmit` — pass
- changed-file ESLint — pass
- `bun run build` — pass
- `bun run privacy:check` — pass

Closes #622
