### PR TITLE
fix(accounts): share mutation lock state across duplicated module copies

### DIFF
--- a/src/lib/accounts/accountMutation.test.ts
+++ b/src/lib/accounts/accountMutation.test.ts
@@ -138,3 +138,37 @@ test("a sync contender fails quickly while another process owns the file lock", 
     holderError: "",
   });
 });
+
+test("a duplicated module copy joins the transaction instead of failing busy", async () => {
+  const state = path.join(sandbox, "duplicate-copy-state");
+  const result = path.join(sandbox, "duplicate-copy-result.json");
+  const modulePath = path.join(import.meta.dir, "accountMutation.ts");
+  const child = Bun.spawn({
+    cmd: [process.execPath, "-e", `
+      process.env.LLV_STATE_DIR = ${JSON.stringify(state)};
+      const fs = await import("node:fs");
+      const first = await import(${JSON.stringify(modulePath)});
+      const second = await import(${JSON.stringify(modulePath)} + "?bundler-duplicate");
+      const outcome = await first.withAccountMutationLockAsync(async () => {
+        let nestedRan = false;
+        let nestedError = null;
+        try { second.withAccountMutationLock(() => { nestedRan = true; }); }
+        catch (error) { nestedError = String(error); }
+        return { nestedRan, nestedError };
+      });
+      fs.writeFileSync(${JSON.stringify(result)}, JSON.stringify(outcome));
+    `],
+    stdout: "ignore",
+    stderr: "pipe",
+  });
+
+  const completed = await Promise.race([
+    child.exited.then(() => true),
+    Bun.sleep(5_000).then(() => false),
+  ]);
+  if (!completed) child.kill();
+  const error = await new Response(child.stderr).text();
+
+  expect({ completed, error }).toEqual({ completed: true, error: "" });
+  expect(JSON.parse(fs.readFileSync(result, "utf8"))).toEqual({ nestedRan: true, nestedError: null });
+});

--- a/src/lib/accounts/accountMutation.ts
+++ b/src/lib/accounts/accountMutation.ts
@@ -15,9 +15,23 @@ type LockOwner = { pid: number; startIdentity: string | null; token: string };
 type TransactionContext = { active: boolean; revision: number };
 type PendingLock = { lock: string; queue: string; owner: LockOwner; ticket: string };
 type AcquiredLock = { context: TransactionContext; release(): void };
-const transactionContext = new AsyncLocalStorage<TransactionContext>();
-const localWaiters: Array<() => void> = [];
-let localHeld = false;
+
+/* The bundler may duplicate this module across route chunks. Every copy must
+   share one transaction context and one local-held flag, or a nested acquire
+   in a second copy observes its own process as a foreign lock holder and
+   fails instantly with a busy error. */
+type MutationRuntime = {
+  transactionContext: AsyncLocalStorage<TransactionContext>;
+  localWaiters: Array<() => void>;
+  localHeld: boolean;
+};
+const runtime: MutationRuntime = ((globalThis as unknown as { __llvAccountMutationRuntime?: MutationRuntime }).__llvAccountMutationRuntime ??= {
+  transactionContext: new AsyncLocalStorage<TransactionContext>(),
+  localWaiters: [],
+  localHeld: false,
+});
+const transactionContext = runtime.transactionContext;
+const localWaiters = runtime.localWaiters;
 
 function delay(milliseconds: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, milliseconds));
@@ -33,18 +47,18 @@ export class AccountMutationBusyError extends Error {
 function releaseLocal(): void {
   const next = localWaiters.shift();
   if (next) next();
-  else localHeld = false;
+  else runtime.localHeld = false;
 }
 
 function acquireLocalSync(): () => void {
-  if (localHeld) throw new AccountMutationBusyError("account mutation is busy in this process; retry shortly");
-  localHeld = true;
+  if (runtime.localHeld) throw new AccountMutationBusyError("account mutation is busy in this process; retry shortly");
+  runtime.localHeld = true;
   return releaseLocal;
 }
 
 async function acquireLocalAsync(): Promise<() => void> {
-  if (localHeld) await new Promise<void>((resolve) => localWaiters.push(resolve));
-  else localHeld = true;
+  if (runtime.localHeld) await new Promise<void>((resolve) => localWaiters.push(resolve));
+  else runtime.localHeld = true;
   return releaseLocal;
 }
 


### PR DESCRIPTION
## Problem

Production account switching and account removal always fail with `account mutation is busy; retry shortly`, instantly (0.04s, not the 10s async wait). Observed on deployed revision `665b459d` with repeated `[accounts] claude selection failed: Error [AccountMutationBusyError]` in the deploy container log.

## Root cause

The webpack server build duplicates `src/lib/accounts/accountMutation.ts` into two chunks (`chunks/814.js` and `chunks/5622.js` — both frames appear in the production stack). `selectAccount` acquires the async mutation lock through one copy; the nested `setActiveClaudeAccount` → `withRegistryLock` path calls the sync `withAccountMutationLock` in the other copy. Each copy has its own `AsyncLocalStorage` transaction context and `localHeld` flag, so the nested acquire cannot see the inherited transaction, observes the on-disk lock file held by its own process as a live foreign owner (pid alive, identity matches → not stale), exhausts its 2 sync attempts, and throws busy immediately.

## Fix

Store the transaction context, waiter queue, and local-held flag on a `globalThis`-backed runtime object (same pattern as the migration controller globals), so all bundled copies share one in-process lock state.

## Regression coverage

New test loads the module twice (second instance via query-string import, simulating a bundler duplicate), holds the async lock in copy one, and asserts a nested sync acquire through copy two joins the transaction instead of failing busy. Red against the previous implementation, green with the fix.

`bun test src/lib/accounts/` — 341 pass; the single failure (`manager.interprocess.test.ts` controllerSelectionRace ready-file timeout) fails identically with the fix stashed, i.e. pre-existing (#364 territory), not introduced here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)