### PR TITLE
Fix #626 within-TTL compaction reseed ghost

### DIFF
--- a/src/components/conversation/issue626Evidence.browser.test.tsx
+++ b/src/components/conversation/issue626Evidence.browser.test.tsx
@@ -1096,6 +1096,161 @@ test("issue 626 production LogFeed does not reseed a compacted terminal launch a
   }
 }, 120_000);
 
+test("issue 626 production LogFeed reseeds a compacted delivered launch inside the TTL and retires it after at 1280px and 390px", async () => {
+  const css = productionCss();
+  expect(css.length).toBeGreaterThan(10_000);
+  const provisional = "spawn:launch_issue_626_ttl_reseed";
+  const launchId = "launch_issue_626_ttl_reseed";
+  const prompt = "Issue 626 delivered launch compacted inside the TTL.";
+  const promptAt = launchBase.promptAt ?? CAPTURE_NOW;
+  const settledAt = promptAt + 1_000;
+  const reseedLaunch: StructuredSpawnCardState = {
+    ...launchBase,
+    launchId,
+    state: "live-late-success",
+    initialMessage: "delivered",
+    ["prompt"]: prompt,
+    promptEcho: prompt,
+    promptAt,
+  };
+  const state: EvidenceState = {
+    id: "ttl-reseed-launch",
+    envelopeCount: 0,
+    filesRevision: 45,
+    path: fixture.identity.adoptedPath,
+    launch: reseedLaunch,
+    logMode: "empty",
+    logOverride: "",
+    expectedOrder: ["outbox"],
+  };
+  const { instance: evidenceBrowser, closeOwned } = await openEvidenceBrowser();
+
+  try {
+    for (const viewport of VIEWPORTS) {
+      /* CAPTURE_NOW is two minutes past the launch — inside the 10-minute TTL. */
+      Date.now = () => CAPTURE_NOW;
+      mobile = viewport.mobile;
+      dom.sessionStorage.clear();
+      resetOutboxForTests();
+      resetCanonicalAssistantClaimsForTests();
+      resetLogTailCacheForTests();
+      logs.clear();
+      getRuntimeBus().stop();
+
+      seedLaunchOutbox(provisional, {
+        id: launchId,
+        text: prompt,
+        images: 0,
+        at: promptAt,
+      });
+      updateOutbox(provisional, launchId, {
+        state: outboxStateForReceiptStatus("delivered"),
+        settledAt,
+      });
+      /* Compaction evicts the delivered launch BEFORE its TTL elapses; the
+         warm follow-ups retire on their own echoes so only the launch bubble
+         and the unrelated pending entry render. */
+      for (let index = 0; index < OUTBOX_LIMIT; index += 1) {
+        const id = `ttl-reseed-browser-warm-${index}`;
+        const text = `TTL reseed browser warm ${index}`;
+        enqueueOutbox(provisional, {
+          id,
+          text,
+          images: 0,
+          at: promptAt + 2_000 + index,
+        });
+        updateOutbox(provisional, id, {
+          state: outboxStateForReceiptStatus("delivered"),
+          settledAt: promptAt + 2_000 + index,
+        });
+        publishTranscriptEchoes(provisional, [{
+          generation: "/synthetic/issue-626-ttl-reseed-generation-1.jsonl",
+          id: `row:ttl-reseed-browser-warm:${index}`,
+          text,
+        }]);
+      }
+      expect(readOutbox(provisional).some((entry) => entry.id === launchId)).toBe(false);
+
+      adoptOutbox(provisional, CONVERSATION_ID);
+      enqueueOutbox(CONVERSATION_ID, {
+        id: "ttl-reseed-browser-unrelated-pending",
+        text: "TTL reseed browser unrelated pending entry",
+        images: 0,
+        at: promptAt + 20_000,
+      });
+      resetOutboxForTests();
+
+      /* One recurring LogFeed seed inside the TTL window: the bubble comes back
+         visibly DELIVERED with its original settlement. */
+      const withinRender = await renderState(state);
+      const reseeded = readOutbox(CONVERSATION_ID).find((entry) => entry.id === launchId);
+      expect(reseeded?.state).toBe("delivered");
+      expect(reseeded?.settledAt).toBe(settledAt);
+
+      const withinPage = await evidenceBrowser.newPage({
+        viewport: { width: viewport.width, height: viewport.height },
+        deviceScaleFactor: 1,
+      });
+      await withinPage.setContent(pageHtml(withinRender.html, css), { waitUntil: "load" });
+      const withinEvidence = await withinPage.evaluate((text) => ({
+        ids: Array.from(document.querySelectorAll<HTMLElement>("[data-outbox-entry]"))
+          .map((entry) => entry.dataset.outboxEntry ?? ""),
+        occurrences: (document.body.textContent ?? "").split(text).length - 1,
+        scrollWidth: document.documentElement.scrollWidth,
+        productionWindow: Boolean(document.querySelector("[data-pan-ignore]"))
+          && Boolean(document.querySelector("[data-log-feed-scroller]"))
+          && Boolean(document.querySelector("textarea")),
+      }), prompt);
+      /* The reseed appends to the queue tail (the same position the pre-fix
+         delivering ghost took), so the pending entry precedes it. */
+      expect(withinEvidence.ids).toEqual(["ttl-reseed-browser-unrelated-pending", launchId]);
+      expect(withinEvidence.occurrences).toBe(1);
+      expect(withinEvidence.scrollWidth).toBeLessThanOrEqual(viewport.width + 1);
+      expect(withinEvidence.productionWindow).toBe(true);
+      await withinPage.screenshot({
+        path: path.join(EVIDENCE_DIR, `ttl-reseed-within-ttl-${viewport.id}.png`),
+        fullPage: false,
+      });
+      await withinPage.close();
+
+      /* Past the TTL: refresh plus another recurring seed retire the launch
+         while the unrelated pending entry keeps rendering. */
+      Date.now = () => settledAt + OUTBOX_DELIVERED_TTL_MS;
+      resetOutboxForTests();
+      resetLogTailCacheForTests();
+      logs.clear();
+      getRuntimeBus().stop();
+      const afterRender = await renderState(state);
+      const afterPage = await evidenceBrowser.newPage({
+        viewport: { width: viewport.width, height: viewport.height },
+        deviceScaleFactor: 1,
+      });
+      await afterPage.setContent(pageHtml(afterRender.html, css), { waitUntil: "load" });
+      const afterEvidence = await afterPage.evaluate((text) => ({
+        ids: Array.from(document.querySelectorAll<HTMLElement>("[data-outbox-entry]"))
+          .map((entry) => entry.dataset.outboxEntry ?? ""),
+        occurrences: (document.body.textContent ?? "").split(text).length - 1,
+        scrollWidth: document.documentElement.scrollWidth,
+        productionWindow: Boolean(document.querySelector("[data-pan-ignore]"))
+          && Boolean(document.querySelector("[data-log-feed-scroller]"))
+          && Boolean(document.querySelector("textarea")),
+      }), prompt);
+      expect(afterEvidence.ids).toEqual(["ttl-reseed-browser-unrelated-pending"]);
+      expect(afterEvidence.ids).not.toContain(launchId);
+      expect(afterEvidence.occurrences).toBe(0);
+      expect(afterEvidence.scrollWidth).toBeLessThanOrEqual(viewport.width + 1);
+      expect(afterEvidence.productionWindow).toBe(true);
+      await afterPage.screenshot({
+        path: path.join(EVIDENCE_DIR, `ttl-reseed-after-ttl-${viewport.id}.png`),
+        fullPage: false,
+      });
+      await afterPage.close();
+    }
+  } finally {
+    await closeOwned();
+  }
+}, 120_000);
+
 test("issue 626 production LogFeed preserves both no-echo terminal launch reasons at 1280px and 390px", async () => {
   const css = productionCss();
   expect(css.length).toBeGreaterThan(10_000);

--- a/src/components/conversation/outbox.test.ts
+++ b/src/components/conversation/outbox.test.ts
@@ -1015,6 +1015,131 @@ describe("seedLaunchOutbox (P1#2)", () => {
     }
   });
 
+  test("issue 626: a delivered launch compacted inside the TTL reseeds as delivered and still retires at the TTL", () => {
+    const originalDateNow = Date.now;
+    const settledAt = 1_100;
+    /* Inside the TTL window: the launch settled recently and its echo has not
+       arrived yet. */
+    let now = settledAt + 60_000;
+    Date.now = () => now;
+    try {
+      const provisional = "spawn:launch_626_ttl_reseed";
+      const conversation = "conversation_626_ttl_reseed";
+      const launchId = "launch_626_ttl_reseed";
+      const text = "delivered launch compacted before its TTL elapses";
+
+      seedLaunchOutbox(provisional, {
+        id: launchId,
+        text,
+        images: 0,
+        at: 1_000,
+      });
+      updateOutbox(provisional, launchId, {
+        state: outboxStateForReceiptStatus("delivered"),
+        settledAt,
+      });
+      expect(visibleOutbox(readOutbox(provisional), echoes(), now).map((entry) => entry.id))
+        .toEqual([launchId]);
+
+      /* Compaction evicts the delivered entry from the recent queue BEFORE the
+         TTL elapses; its settlement survives only in the current-launch slot. */
+      for (let index = 0; index < OUTBOX_LIMIT; index += 1) {
+        enqueueOutbox(provisional, {
+          id: `ttl-reseed-warm-${index}`,
+          text: `ttl reseed warm ${index}`,
+          images: 0,
+          at: 2_000 + index,
+        });
+      }
+      expect(readOutbox(provisional).some((entry) => entry.id === launchId)).toBe(false);
+
+      /* The recurring LogFeed seed fires once inside the TTL window. The bubble
+         must come back visibly DELIVERED with its original settlement — never as
+         a fresh delivering entry that no echo or TTL could ever retire. */
+      seedLaunchOutbox(provisional, {
+        id: launchId,
+        text,
+        images: 0,
+        at: 1_000,
+      });
+      const reseeded = readOutbox(provisional).find((entry) => entry.id === launchId);
+      expect(reseeded?.state).toBe("delivered");
+      expect(reseeded?.settledAt).toBe(settledAt);
+      expect(visibleOutbox(readOutbox(provisional), echoes(), now).some((entry) => entry.id === launchId))
+        .toBe(true);
+
+      /* Past the TTL the launch retires and a recurring seed cannot revive it. */
+      now = settledAt + OUTBOX_DELIVERED_TTL_MS;
+      expect(visibleOutbox(readOutbox(provisional), echoes(), now).some((entry) => entry.id === launchId))
+        .toBe(false);
+      seedLaunchOutbox(provisional, {
+        id: launchId,
+        text,
+        images: 0,
+        at: 1_000,
+      });
+      expect(visibleOutbox(readOutbox(provisional), echoes(), now).some((entry) => entry.id === launchId))
+        .toBe(false);
+
+      /* Adoption, generation rollover past both retention bounds, and tail
+         eviction leave the launch retired. */
+      adoptOutbox(provisional, conversation);
+      for (let index = 0; index < 512 + OUTBOX_LIMIT + 1; index += 1) {
+        const id = `ttl-reseed-churn-${index}`;
+        const churnText = `ttl reseed churn ${index}`;
+        enqueueOutbox(conversation, {
+          id,
+          text: churnText,
+          images: 0,
+          at: 3_000 + index,
+        });
+        updateOutbox(conversation, id, {
+          state: outboxStateForReceiptStatus("delivered"),
+          settledAt: 3_000 + index,
+        });
+        publishTranscriptEchoes(conversation, [{
+          generation: index < 256
+            ? "/transcripts/626-ttl-reseed-1.jsonl"
+            : "/transcripts/626-ttl-reseed-2.jsonl",
+          id: `row:ttl-reseed:${index}`,
+          text: churnText,
+        }]);
+      }
+      enqueueOutbox(conversation, {
+        id: "ttl-reseed-unrelated-pending",
+        text: "unrelated pending survives the TTL reseed retirement",
+        images: 0,
+        at: 10_000,
+      });
+
+      /* Refresh/reconnect plus further recurring seeds never resurrect it. */
+      resetOutboxForTests();
+      publishTranscriptEchoes(conversation, []);
+      seedLaunchOutbox(conversation, {
+        id: launchId,
+        text,
+        images: 0,
+        at: 1_000,
+      });
+      resetOutboxForTests();
+      seedLaunchOutbox(conversation, {
+        id: launchId,
+        text,
+        images: 0,
+        at: 1_000,
+      });
+
+      const refreshed = readOutbox(conversation);
+      expect(refreshed.some((entry) => entry.id === launchId)).toBe(false);
+      expect(refreshed.find((entry) => entry.id === "ttl-reseed-unrelated-pending")?.state)
+        .toBe("queued");
+      expect(visibleOutbox(refreshed, echoes(), now).some((entry) => entry.id === launchId))
+        .toBe(false);
+    } finally {
+      Date.now = originalDateNow;
+    }
+  });
+
   test("issue 626: terminal launch retirement survives both ledgers churning beyond 512 entries", () => {
     const provisional = "spawn:launch_626_terminal_priority";
     const conversation = "conversation_626_terminal_priority";

--- a/src/components/conversation/outbox.ts
+++ b/src/components/conversation/outbox.ts
@@ -592,7 +592,15 @@ export function seedLaunchOutbox(
     return;
   }
   recordCurrentLaunch(cardId, { id: entry.id, at: entry.at });
-  const seeded: OutboxEntry = { ...entry, state: "delivering", launchOwned: true };
+  /* A delivered launch compacted out of the recent queue keeps its settlement
+     only in the current-launch slot. A reseed inside the TTL window restores
+     that delivered state so the bubble stays visibly delivered and still
+     retires at the TTL — never a fresh `delivering` entry that no echo or TTL
+     could ever retire. */
+  const settledAt = currentLaunch?.id === entry.id ? currentLaunch.settledAt : undefined;
+  const seeded: OutboxEntry = settledAt === undefined
+    ? { ...entry, state: "delivering", launchOwned: true }
+    : { ...entry, state: "delivered", settledAt, launchOwned: true };
   writeBounded(cardId, [...queue, seeded]);
   /* A refreshed surface can see the canonical transcript row before the launch
      projection effect seeds its optimistic bubble. Reconcile the persisted row


### PR DESCRIPTION
## What

Fixes the final-review P2 residual from #640 (issue #626): a **delivered** launch compacted out of the recent outbox queue **before** its 10-minute TTL elapsed was reseeded by the recurring LogFeed projection as a fresh `delivering` entry without `settledAt`. After the TTL passed, the current-launch slot correctly turned terminal (`delivered-ttl`), but the requeued entry had no echo, no `responseStartedAt`, and no delivered state for the TTL rule to act on — so the optimistic bubble rendered forever on the exact no-echo path the TTL exists for.

## Fix (smallest durable seam)

`seedLaunchOutbox` reseed path: when the seeded id owns the current-launch slot, restore `state: "delivered"` and the slot's original `settledAt` onto the reseeded entry. The bubble stays visibly delivered inside the TTL window and retires at the TTL like any delivered entry; a launch compacted while still delivering reseeds exactly as before. One 10-line change in `src/components/conversation/outbox.ts`, no interface changes.

## Tests

- **Public-seam lifecycle test** (`outbox.test.ts`, RED against unfixed main): seed → settle delivered with `settledAt` → compact out with 32 follow-ups before the TTL → recurring seed inside the TTL keeps the bubble visibly delivered with the original `settledAt` → beyond the TTL it retires and never reappears across refresh/reconnect, generation rollover past both 512-entry retention bounds, stable adoption, tail eviction, and further recurring seeds; the unrelated pending entry keeps its ownership throughout.
- **Production-shaped Chromium evidence** (`issue626Evidence.browser.test.tsx`): compaction before the TTL, one real LogFeed reseed inside the TTL (bubble rendered "Delivered"), disappearance after the TTL, at 1280×900 and 390×844 with zero horizontal overflow (screenshots are local-only per the evidence dir `.gitignore`).

## Verification

- outbox 46/46; conversation+feed 271/271; parser 94/94 ×3 (stress); session reader + journal 75/75; browser evidence 5/5 (real Chromium)
- MCP suites 37/38 — the 1 failing `writerConcurrency` pipeline-create test reproduces identically on clean `main` (pre-existing, environment-dependent)
- `tsc` clean; ESLint clean on changed files; `privacy:check` PASS against `origin/main`; production Next build + MCP bundle built

Closes the P2 from pipeline a1c05a55 final review of the (already merged) #640; refs #626.

🤖 Generated with [Claude Code](https://claude.com/claude-code)