### PR TITLE
#516 recovery-record turn release: unhosted recovery tails must not reopen a released turn

### DIFF
--- a/src/lib/accounts/migration/coordinator.test.ts
+++ b/src/lib/accounts/migration/coordinator.test.ts
@@ -10,6 +10,7 @@ import type { FileEntry } from "@/lib/types";
 
 import { advanceConversationMigration, createMigrationIntent, drainHeldDeliveries, previewMigration, reconcileMigrationInventory, reconcileMigrations } from "./coordinator";
 import { emptyLaunchProfile, type ProviderReceipt, type SuccessorProviderPort } from "./contracts";
+import { oauthFailureWithRecoveryTail } from "./fixtures/claudeRecoveryTail";
 import { CodexForkOutcomeUnknownError, SuccessorPendingError } from "./provider";
 
 const roots: string[] = [];
@@ -135,6 +136,19 @@ async function withInterruptedTailRead<T>(
     fs.readSync = originalReadSync;
     fs.closeSync = originalCloseSync;
   }
+}
+
+function tmuxHost(windowName: string): NonNullable<Parameters<AgentRegistry["upsert"]>[0]["host"]> {
+  return {
+    kind: "tmux",
+    endpoint: "/tmp/tmux-1000/default",
+    server: { pid: 4100, startIdentity: "4100:recovery" },
+    paneId: "%41",
+    panePid: { pid: 4101, startIdentity: "4101:recovery" },
+    windowName,
+    agent: { pid: 4102, startIdentity: "4102:recovery" },
+    argv: ["claude", "--resume"],
+  };
 }
 
 function inventoryEntry(pathname: string, overrides: Partial<FileEntry> = {}): FileEntry {
@@ -3430,6 +3444,172 @@ describe("durable account migration coordinator", () => {
     expect(restarted.conversation(conversation.id)?.migration?.operationId).toBe(operationId);
     expect(restarted.conversation(conversation.id)?.generations).toHaveLength(2);
     expect(restarted.pendingDeliveries(conversation.id)).toEqual([]);
+  });
+
+  test("recovery records on an unhosted predecessor release the reseat and deliver held input once", async () => {
+    /* Issue #516 production acceptance blocker: after the terminal OAuth
+       failure released the turn, a recovery attempt appended a replayed
+       continuation prompt, the synthetic `No response requested.` no-op, the
+       inherited reporting prompt, and the interrupt sentinel its host wrote on
+       the way out. The predecessor is unhosted and none of those records are
+       provider work, so the reseat must still complete: one successor, the
+       held delivery sent once with its stable clientMessageId, zero sends to
+       the predecessor, and repeated ticks through a reopened registry stay
+       converged. */
+    const store = registry();
+    const pathname = path.join(path.dirname(store.filename), "recovery-tail-source.jsonl");
+    const successorPath = "/recovery-tail-successor.jsonl";
+    fs.writeFileSync(pathname, oauthFailureWithRecoveryTail().map((record) => JSON.stringify(record)).join("\n") + "\n");
+    store.reconcileConversations([{ ...observation(pathname, "expired", "busy"), engine: "claude" }]);
+    const conversation = store.conversationForPath(pathname)!;
+    expect(conversation.generations.at(-1)?.host ?? null).toBeNull();
+    expect(store.requestConversationReseat(conversation.id, "healthy").migration?.phase).toBe("waiting-turn");
+    store.holdDelivery(conversation.id, "continue after reseat", "recovery-held-client");
+    const entry = inventoryEntry(pathname, {
+      root: "claude-projects",
+      engine: "claude",
+      fmt: "claude",
+      model: "claude-fable-5",
+      activity: "stalled",
+      activityReason: undefined,
+    });
+    const counts = { create: 0, verify: 0 };
+    const baseProvider = provider([successorPath], counts);
+    const createdOperations: string[] = [];
+    const migrationProvider: SuccessorProviderPort = {
+      ...baseProvider,
+      async create(input) {
+        createdOperations.push(input.operationId);
+        return baseProvider.create(input);
+      },
+    };
+    const sends: { path: string; clientMessageId: string }[] = [];
+    const deliveryPort = {
+      async deliver(input: { path: string; clientMessageId: string }) {
+        sends.push({ path: input.path, clientMessageId: input.clientMessageId });
+        return "delivered" as const;
+      },
+    };
+
+    await reconcileMigrationInventory(store, [entry]);
+
+    expect(store.conversation(conversation.id)?.turn).toMatchObject({ state: "terminal", source: "lifecycle" });
+    const operationId = store.conversation(conversation.id)!.migration!.operationId;
+    const restarted = new AgentRegistry(store.filename);
+    await reconcileMigrations(migrationProvider, deliveryPort, restarted);
+
+    const committed = restarted.conversation(conversation.id)!;
+    expect(committed.migration?.phase).toBe("committed");
+    expect(createdOperations).toEqual([operationId]);
+    expect(committed.generations.map((generation) => generation.path)).toEqual([pathname, successorPath]);
+    expect(sends).toEqual([{ path: successorPath, clientMessageId: "recovery-held-client" }]);
+    expect(restarted.pendingDeliveries(conversation.id)).toEqual([]);
+
+    await reconcileMigrationInventory(restarted, [entry]);
+    await reconcileMigrations(migrationProvider, deliveryPort, restarted);
+    await drainHeldDeliveries(conversation.id, deliveryPort, restarted);
+    expect(counts.create).toBe(1);
+    expect(sends).toEqual([{ path: successorPath, clientMessageId: "recovery-held-client" }]);
+    expect(restarted.conversation(conversation.id)?.generations).toHaveLength(2);
+    expect(restarted.snapshot().migrationIntents[committed.migration!.intentId]).toMatchObject({ scope: "conversation", state: "complete" });
+  });
+
+  test("a registered host keeps a recovery tail busy until it exits", async () => {
+    /* The same records under a live registered host are not release evidence:
+       the host can still append real provider work, so the turn stays busy and
+       the successor waits. Once the host is gone the release applies. */
+    const store = registry();
+    const pathname = path.join(path.dirname(store.filename), "hosted-recovery-tail.jsonl");
+    fs.writeFileSync(pathname, oauthFailureWithRecoveryTail().map((record) => JSON.stringify(record)).join("\n") + "\n");
+    store.reconcileConversations([{ ...observation(pathname, "expired", "busy"), engine: "claude" }]);
+    const conversation = store.conversationForPath(pathname)!;
+    const key = { engine: "claude" as const, sessionId: conversation.generations[0]!.id };
+    const hostEntry = {
+      key,
+      artifactPath: pathname,
+      cwd: "/repo",
+      accountId: "expired",
+      claimEpoch: 1,
+      claimOwner: "test-owner",
+      pendingAction: null,
+    };
+    store.upsert({
+      ...hostEntry,
+      status: "live",
+      host: tmuxHost("llv-recovery"),
+    });
+    expect(store.requestConversationReseat(conversation.id, "healthy").migration?.phase).toBe("waiting-turn");
+    const entry = inventoryEntry(pathname, {
+      root: "claude-projects",
+      engine: "claude",
+      fmt: "claude",
+      model: "claude-fable-5",
+      activity: "stalled",
+      activityReason: undefined,
+    });
+    const counts = { create: 0, verify: 0 };
+    const successorProvider = provider(["/hosted-recovery-successor.jsonl"], counts);
+
+    await reconcileMigrationInventory(store, [entry]);
+    await advanceConversationMigration(conversation.id, store, successorProvider);
+
+    expect(store.conversation(conversation.id)?.turn.state).toBe("busy");
+    expect(counts.create).toBe(0);
+    expect(store.conversation(conversation.id)?.migration?.phase).toBe("waiting-turn");
+
+    store.upsert({ ...hostEntry, status: "unhosted", host: null });
+
+    await reconcileMigrationInventory(store, [entry]);
+    await advanceConversationMigration(conversation.id, store, successorProvider);
+
+    expect(store.conversation(conversation.id)?.turn.state).toBe("terminal");
+    expect(counts.create).toBe(1);
+    expect(store.conversation(conversation.id)?.migration?.phase).toBe("committed");
+  });
+
+  test("a host registered after the released inventory fences successor creation", async () => {
+    /* The release is transcript evidence, so a host that appears between the
+       inventory tick and provider creation must still fence the successor. */
+    const store = registry();
+    const pathname = path.join(path.dirname(store.filename), "raced-recovery-tail.jsonl");
+    fs.writeFileSync(pathname, oauthFailureWithRecoveryTail().map((record) => JSON.stringify(record)).join("\n") + "\n");
+    store.reconcileConversations([{ ...observation(pathname, "expired", "busy"), engine: "claude" }]);
+    const conversation = store.conversationForPath(pathname)!;
+    expect(store.requestConversationReseat(conversation.id, "healthy").migration?.phase).toBe("waiting-turn");
+    await reconcileMigrationInventory(store, [inventoryEntry(pathname, {
+      root: "claude-projects",
+      engine: "claude",
+      fmt: "claude",
+      model: "claude-fable-5",
+      activity: "stalled",
+      activityReason: undefined,
+    })]);
+    expect(store.conversation(conversation.id)?.turn.state).toBe("terminal");
+    const hostEntry = {
+      key: { engine: "claude" as const, sessionId: conversation.generations[0]!.id },
+      artifactPath: pathname,
+      cwd: "/repo",
+      accountId: "expired",
+      claimEpoch: 1,
+      claimOwner: "test-owner",
+      pendingAction: null,
+    };
+    store.upsert({
+      ...hostEntry,
+      status: "live",
+      host: tmuxHost("llv-raced-recovery"),
+    });
+    const counts = { create: 0, verify: 0 };
+    const successorProvider = provider(["/raced-recovery-successor.jsonl"], counts);
+
+    await advanceConversationMigration(conversation.id, store, successorProvider);
+    expect(counts.create).toBe(0);
+
+    store.upsert({ ...hostEntry, status: "unhosted", host: null });
+    await advanceConversationMigration(conversation.id, store, successorProvider);
+
+    expect(counts.create).toBe(1);
+    expect(store.conversation(conversation.id)?.migration?.phase).toBe("committed");
   });
 
   test("a conversation reseat completes without booking the engine auto-balance outcome or cooldown", async () => {

--- a/src/lib/accounts/migration/coordinator.ts
+++ b/src/lib/accounts/migration/coordinator.ts
@@ -326,10 +326,14 @@ function completeProviderTurnObservation(
     return false;
   }
   if (after.size !== before.size || after.mtimeMs !== before.mtimeMs) return false;
+  /* An explicit composer release is the operator's own signal and outranks
+     the recovery-tail host fence: a live-but-idle host at the composer must
+     not hold the reseat hostage. */
+  if (observed.composerReleased) return true;
   /* A host registered between inventory and creation still owns a recovery
      tail's turn (issue #516), so its release must not reach the provider. */
   if (observed.recoveryReleased && hasActiveRegisteredHost(registry, source.path)) return false;
-  if (observed.turn.state === "terminal" || observed.composerReleased) return true;
+  if (observed.turn.state === "terminal") return true;
 
   /* A crashed Codex rollout can retain its final task_started record forever.
      An inventory release plus a stable file with no writable holder proves

--- a/src/lib/accounts/migration/coordinator.ts
+++ b/src/lib/accounts/migration/coordinator.ts
@@ -12,7 +12,7 @@ import {
 } from "@/lib/board/store";
 import { forEachCooperatively, yieldToRuntime } from "@/lib/cooperative";
 import { listFiles } from "@/lib/scanner";
-import { recordTranscriptComposerRelease, transcriptTurnResult } from "@/lib/scanner/activity";
+import { recordTranscriptComposerRelease, transcriptTurnResult, type TranscriptTurnResult } from "@/lib/scanner/activity";
 import { writingHolders } from "@/lib/scanner/process";
 import type { FileEntry } from "@/lib/types";
 import { isStructuredDeliveryControllerUnavailable } from "@/lib/runtime/structuredDeliveryController";
@@ -28,6 +28,7 @@ import {
   type MigrationOrigin,
   type ProviderReceipt,
   type SuccessorProviderPort,
+  type TurnState,
   type ViewerConversationId,
 } from "./contracts";
 import { CodexForkOutcomeUnknownError, RegisteredSuccessorProvider, SuccessorPendingError } from "./provider";
@@ -73,6 +74,32 @@ function deadStalledTurn(entry: FileEntry, existing: RegistryConversation | null
     && !hasActiveRegisteredHost;
 }
 
+/** Transcript paths a registered host still owns. A host in any of these
+    statuses can append real provider work at any moment, so transcript-only
+    release evidence must not outrank it. */
+function activeRegisteredHostPaths(snapshot: ReturnType<AgentRegistry["readOnlySnapshot"]>): Set<string> {
+  return new Set(Object.values(snapshot.entries)
+    .filter((entry) => entry.artifactPath
+      && ["starting", "live", "idle", "handoff"].includes(entry.status)
+      && (entry.host !== null || entry.structuredHost !== null))
+    .map((entry) => entry.artifactPath!));
+}
+
+function hasActiveRegisteredHost(registry: AgentRegistry, pathname: string): boolean {
+  return activeRegisteredHostPaths(registry.readOnlySnapshot()).has(pathname);
+}
+
+/** Issue #516 — a Claude recovery tail (replayed continuation, synthetic
+    `No response requested.` no-op, interrupt sentinel) releases the turn on
+    transcript evidence alone. That evidence describes a session that already
+    exited; while a host is still registered for the path the turn stays busy,
+    because its next record can be genuine provider work. */
+function hostFencedTurn(observed: TranscriptTurnResult, hasActiveHost: boolean): TurnState {
+  return observed.recoveryReleased && hasActiveHost
+    ? { state: "busy", source: "lifecycle", terminalAt: null }
+    : observed.turn;
+}
+
 function projectedInventoryTurn(
   entry: FileEntry,
   parsed: ConversationObservation["turn"] | null,
@@ -105,11 +132,7 @@ async function inventory(files: FileEntry[], registry: AgentRegistry): Promise<C
   const snapshot = registry.readOnlySnapshot();
   const conversationByPath = new Map<string, RegistryConversation>();
   const launchProfileByPath = new Map<string, RegistryConversation["generations"][number]["launchProfile"]>();
-  const activeRegisteredHostPaths = new Set(Object.values(snapshot.entries)
-    .filter((entry) => entry.artifactPath
-      && ["starting", "live", "idle", "handoff"].includes(entry.status)
-      && (entry.host !== null || entry.structuredHost !== null))
-    .map((entry) => entry.artifactPath));
+  const hostedPaths = activeRegisteredHostPaths(snapshot);
   await forEachCooperatively(Object.values(snapshot.conversations), (conversation) => {
     for (const generation of conversation.generations) {
       if (!conversationByPath.has(generation.path)) conversationByPath.set(generation.path, conversation);
@@ -135,8 +158,9 @@ async function inventory(files: FileEntry[], registry: AgentRegistry): Promise<C
     const owner = accountManager.resolveTranscriptOwner(engine, entry.path);
     const mtimeMs = entry.mtime * 1000;
     const observedTurn = transcriptTurnResult(entry.path, entry.size, mtimeMs, engine === "codex");
-    const parsed = observedTurn.complete ? observedTurn.turn : null;
-    const releasedDeadTurn = deadStalledTurn(entry, existing, activeRegisteredHostPaths.has(entry.path));
+    const hostedPath = hostedPaths.has(entry.path);
+    const parsed = observedTurn.complete ? hostFencedTurn(observedTurn, hostedPath) : null;
+    const releasedDeadTurn = deadStalledTurn(entry, existing, hostedPath);
     if (observedTurn.complete && entry.derivationComplete !== false && (
       entry.activityReason === "pane_at_composer"
       || currentPaneWall(entry)
@@ -144,7 +168,7 @@ async function inventory(files: FileEntry[], registry: AgentRegistry): Promise<C
     )) {
       recordTranscriptComposerRelease(entry.path, entry.size, mtimeMs, engine === "codex");
     }
-    const turn = projectedInventoryTurn(entry, parsed, existing, activeRegisteredHostPaths.has(entry.path));
+    const turn = projectedInventoryTurn(entry, parsed, existing, hostedPath);
     const currentProfile = launchProfileByPath.get(entry.path)
       ?? existing?.generations.find((generation) => generation.path === entry.path)?.launchProfile;
     const configuredRoot = process.env.LLV_ROOT_CONVERSATION_ID;
@@ -285,6 +309,7 @@ function completeProviderTurnObservation(
   conversation: RegistryConversation,
   source: RegistryConversation["generations"][number],
   virtualSource: boolean,
+  registry: AgentRegistry,
 ): boolean {
   let before: fs.Stats;
   try {
@@ -301,6 +326,9 @@ function completeProviderTurnObservation(
     return false;
   }
   if (after.size !== before.size || after.mtimeMs !== before.mtimeMs) return false;
+  /* A host registered between inventory and creation still owns a recovery
+     tail's turn (issue #516), so its release must not reach the provider. */
+  if (observed.recoveryReleased && hasActiveRegisteredHost(registry, source.path)) return false;
   if (observed.turn.state === "terminal" || observed.composerReleased) return true;
 
   /* A crashed Codex rollout can retain its final task_started record forever.
@@ -507,7 +535,7 @@ export async function advanceConversationMigration(
       let source = conversation.generations.find((generation) => generation.id === migration.sourceGenerationId)
         ?? conversation.generations.at(-1);
       if (!source) throw new Error("conversation has no source generation");
-      if (!completeProviderTurnObservation(conversation, source, successorProvider.virtualSource === true)) return conversation;
+      if (!completeProviderTurnObservation(conversation, source, successorProvider.virtualSource === true, registry)) return conversation;
       if (migration.phase === "requested") {
         conversation = registry.transitionConversationMigration(conversation.id, migration.revision, ["requested"], { phase: "preparing" });
         migration = conversation.migration!;
@@ -522,7 +550,7 @@ export async function advanceConversationMigration(
       source = conversation.generations.find((generation) => generation.id === migration.sourceGenerationId)
         ?? conversation.generations.at(-1);
       if (!source) throw new Error("conversation has no source generation");
-      if (!completeProviderTurnObservation(conversation, source, successorProvider.virtualSource === true)) return restoreCreationFence(conversation);
+      if (!completeProviderTurnObservation(conversation, source, successorProvider.virtualSource === true, registry)) return restoreCreationFence(conversation);
       const conversationId = conversation.id;
       const creationOwner = { operationId: migration.operationId, revision: migration.revision };
       receipt = await successorProvider.create({

--- a/src/lib/accounts/migration/fixtures/claudeRecoveryTail.ts
+++ b/src/lib/accounts/migration/fixtures/claudeRecoveryTail.ts
@@ -1,0 +1,177 @@
+/**
+ * The record shapes behind issue #516: a Claude transcript whose terminal OAuth
+ * failure is followed by the recovery bookkeeping a dying session appends.
+ * Modelled field by field on the affected production transcript so the turn
+ * projection and the migration coordinator regress against the real envelope
+ * shape; every identifier and prompt body here is synthetic.
+ */
+
+export type TranscriptRecord = Record<string, unknown>;
+
+const OAUTH_FAILURE_UUID = "rec-oauth-failure";
+const CONTINUATION_UUID = "rec-continuation-prompt";
+const SYNTHETIC_NO_OP_UUID = "rec-synthetic-no-op";
+const INHERITED_PROMPT_UUID = "rec-inherited-prompt";
+const INTERRUPT_UUID = "rec-shutdown-interrupt";
+const RECOVERY_PROMPT_ID = "prompt-recovery-attempt";
+const INHERITED_PROMPT_TEXT = "Report on the reseat probe: read the live transcript first, then summarise.";
+
+/** The structured API-error assistant record that ends the provider turn. */
+export function oauthFailureRecord(timestamp: string): TranscriptRecord {
+  return {
+    parentUuid: "rec-reseat-probe-prompt",
+    isSidechain: false,
+    type: "assistant",
+    uuid: OAUTH_FAILURE_UUID,
+    timestamp,
+    error: "authentication_failed",
+    isApiErrorMessage: true,
+    apiErrorStatus: 401,
+    message: {
+      id: "msg-oauth-failure",
+      model: "<synthetic>",
+      role: "assistant",
+      stop_reason: "stop_sequence",
+      stop_sequence: "",
+      type: "message",
+      content: [{ type: "text", text: "Failed to authenticate: OAuth session expired and could not be refreshed" }],
+    },
+    userType: "external",
+    entrypoint: "sdk-cli",
+  };
+}
+
+/** `Continue from where you left off.` — the replayed continuation prompt a
+    recovery attempt injects, journaled as harness meta. */
+export function continuationPromptRecord(timestamp: string): TranscriptRecord {
+  return {
+    parentUuid: INTERRUPT_UUID,
+    isSidechain: false,
+    promptId: RECOVERY_PROMPT_ID,
+    type: "user",
+    message: { role: "user", content: [{ type: "text", text: "Continue from where you left off." }] },
+    isMeta: true,
+    uuid: CONTINUATION_UUID,
+    timestamp,
+    userType: "external",
+    entrypoint: "sdk-cli",
+  };
+}
+
+/** The synthetic assistant no-op that retires a queued prompt without asking
+    the provider for anything. */
+export function syntheticNoOpRecord(timestamp: string): TranscriptRecord {
+  return {
+    parentUuid: CONTINUATION_UUID,
+    isSidechain: false,
+    type: "assistant",
+    uuid: SYNTHETIC_NO_OP_UUID,
+    timestamp,
+    message: {
+      id: "msg-synthetic-no-op",
+      model: "<synthetic>",
+      role: "assistant",
+      stop_reason: "stop_sequence",
+      stop_sequence: "",
+      type: "message",
+      usage: { input_tokens: 0, output_tokens: 0 },
+      content: [{ type: "text", text: "No response requested." }],
+    },
+    isApiErrorMessage: false,
+    userType: "external",
+    entrypoint: "sdk-cli",
+  };
+}
+
+/** The inherited reporting prompt the recovery host replayed into the dead
+    session — a genuine SDK prompt that never reached the provider. */
+export function inheritedPromptRecord(timestamp: string): TranscriptRecord {
+  return {
+    parentUuid: SYNTHETIC_NO_OP_UUID,
+    isSidechain: false,
+    promptId: RECOVERY_PROMPT_ID,
+    type: "user",
+    message: { role: "user", content: INHERITED_PROMPT_TEXT },
+    isMeta: true,
+    uuid: INHERITED_PROMPT_UUID,
+    timestamp,
+    permissionMode: "bypassPermissions",
+    promptSource: "sdk",
+    userType: "external",
+    entrypoint: "sdk-cli",
+  };
+}
+
+/** `[Request interrupted by user]` with the shutdown flag the exiting host sets. */
+export function shutdownInterruptRecord(timestamp: string): TranscriptRecord {
+  return {
+    parentUuid: INHERITED_PROMPT_UUID,
+    isSidechain: false,
+    promptId: RECOVERY_PROMPT_ID,
+    type: "user",
+    message: { role: "user", content: [{ type: "text", text: "[Request interrupted by user]" }] },
+    uuid: INTERRUPT_UUID,
+    timestamp,
+    interruptedByShutdown: true,
+    userType: "external",
+    entrypoint: "sdk-cli",
+  };
+}
+
+/** A real in-flight assistant record: ordinary model, no stop reason. */
+export function workingAssistantRecord(timestamp: string): TranscriptRecord {
+  return {
+    type: "assistant",
+    timestamp,
+    isApiErrorMessage: false,
+    message: {
+      model: "claude-opus-4-8",
+      role: "assistant",
+      stop_reason: null,
+      type: "message",
+      content: [{ type: "text", text: "Reading the migration controller now." }],
+    },
+  };
+}
+
+/** The bookkeeping rows Claude interleaves with conversation records; the turn
+    projection must keep ignoring them. */
+export function queueOperationRecords(timestamp: string): TranscriptRecord[] {
+  return [
+    { type: "queue-operation", operation: "enqueue", timestamp, content: INHERITED_PROMPT_TEXT },
+    { type: "queue-operation", operation: "dequeue", timestamp },
+  ];
+}
+
+export function lastPromptRecord(): TranscriptRecord {
+  return { type: "last-prompt", lastPrompt: INHERITED_PROMPT_TEXT, leafUuid: INHERITED_PROMPT_UUID };
+}
+
+/** One recovery attempt: replayed continuation, synthetic no-op, the inherited
+    prompt, and the interrupt sentinel written as the host shut down. */
+export function recoveryAttemptRecords(base: string): TranscriptRecord[] {
+  return [
+    ...queueOperationRecords(`${base}:23.764Z`),
+    continuationPromptRecord(`${base}:23.736Z`),
+    syntheticNoOpRecord(`${base}:23.736Z`),
+    inheritedPromptRecord(`${base}:23.804Z`),
+    lastPromptRecord(),
+    shutdownInterruptRecord(`${base}:25.176Z`),
+  ];
+}
+
+export const OAUTH_FAILURE_AT = "2026-07-24T06:36:50.079Z";
+export const SHUTDOWN_INTERRUPT_UUID = INTERRUPT_UUID;
+
+/** The full production tail: the terminal OAuth failure followed by the
+    recovery attempt observed on the stuck migration source. */
+export function oauthFailureWithRecoveryTail(attempts = 1): TranscriptRecord[] {
+  const records: TranscriptRecord[] = [
+    { type: "user", timestamp: "2026-07-24T06:36:44.000Z", message: { role: "user", content: [{ type: "text", text: "Continue the reseat probe." }] } },
+    oauthFailureRecord(OAUTH_FAILURE_AT),
+  ];
+  for (let attempt = 0; attempt < attempts; attempt += 1) {
+    records.push(...recoveryAttemptRecords(`2026-07-24T07:0${4 + attempt}`));
+  }
+  return records;
+}

--- a/src/lib/accounts/migration/turnState.test.ts
+++ b/src/lib/accounts/migration/turnState.test.ts
@@ -1,5 +1,15 @@
 import { describe, expect, test } from "bun:test";
 
+import {
+  OAUTH_FAILURE_AT,
+  SHUTDOWN_INTERRUPT_UUID,
+  continuationPromptRecord,
+  inheritedPromptRecord,
+  oauthFailureWithRecoveryTail,
+  shutdownInterruptRecord,
+  syntheticNoOpRecord,
+  workingAssistantRecord,
+} from "./fixtures/claudeRecoveryTail";
 import { turnStateFromRecords } from "./turnState";
 
 test("issue 51 keeps a Codex turn busy through interim assistant text and tool work", () => {
@@ -186,6 +196,73 @@ describe("issue 516 — structured Claude API-error records project the terminal
       state: "terminal",
       source: "lifecycle",
       terminalAt: "2026-07-17T15:00:01Z",
+    });
+  });
+});
+
+describe("issue 516 — recovery records must not reopen a released turn", () => {
+  const authoritative = (records: Record<string, unknown>[]) => turnStateFromRecords(records, false, true);
+  const released = { state: "terminal", source: "lifecycle", terminalAt: OAUTH_FAILURE_AT } as const;
+
+  test("the production recovery tail after a terminal OAuth failure projects a released turn", () => {
+    expect(authoritative(oauthFailureWithRecoveryTail())).toEqual(released);
+  });
+
+  test("a repeated recovery attempt stays released", () => {
+    expect(authoritative(oauthFailureWithRecoveryTail(3))).toEqual(released);
+  });
+
+  test("a recovery run that ends on a live prompt keeps the turn busy", () => {
+    const records = oauthFailureWithRecoveryTail();
+    const upToPrompt = records.slice(0, records.findIndex((record) => record.uuid === SHUTDOWN_INTERRUPT_UUID));
+    expect(authoritative(upToPrompt)).toEqual({ state: "busy", source: "lifecycle", terminalAt: null });
+  });
+
+  test("a real in-flight assistant record inside the run keeps the turn busy", () => {
+    const records = [
+      ...oauthFailureWithRecoveryTail(),
+      workingAssistantRecord("2026-07-24T07:05:00.000Z"),
+    ];
+    expect(authoritative(records)).toEqual({ state: "busy", source: "assistant", terminalAt: null });
+  });
+
+  test("a synthetic-model record carrying real prose is not a no-op", () => {
+    const prose = syntheticNoOpRecord("2026-07-24T07:04:23.736Z");
+    (prose.message as Record<string, unknown>).content = [{ type: "text", text: "Правда — я запустив його" }];
+    const records = [...oauthFailureWithRecoveryTail(), prose];
+    expect(authoritative(records)).toEqual({ state: "busy", source: "assistant", terminalAt: null });
+  });
+
+  test("a recovery run without a terminal boundary keeps the turn busy", () => {
+    const records = [
+      { type: "user", timestamp: "2026-07-24T07:00:00.000Z", message: { role: "user", content: [{ type: "text", text: "start" }] } },
+      continuationPromptRecord("2026-07-24T07:04:23.736Z"),
+      syntheticNoOpRecord("2026-07-24T07:04:23.736Z"),
+      inheritedPromptRecord("2026-07-24T07:04:23.804Z"),
+      shutdownInterruptRecord("2026-07-24T07:04:25.176Z"),
+    ];
+    expect(authoritative(records)).toEqual({ state: "busy", source: "lifecycle", terminalAt: null });
+  });
+
+  test("an ordinary result boundary also releases its recovery tail", () => {
+    const records = [
+      { type: "user", timestamp: "2026-07-24T06:36:44.000Z", message: { role: "user", content: [{ type: "text", text: "go" }] } },
+      { type: "result", timestamp: "2026-07-24T06:36:50.000Z", subtype: "success" },
+      continuationPromptRecord("2026-07-24T07:04:23.736Z"),
+      syntheticNoOpRecord("2026-07-24T07:04:23.736Z"),
+    ];
+    expect(authoritative(records)).toEqual({
+      state: "terminal",
+      source: "lifecycle",
+      terminalAt: "2026-07-24T06:36:50.000Z",
+    });
+  });
+
+  test("the activity projection keeps its own live semantics for the same tail", () => {
+    expect(turnStateFromRecords(oauthFailureWithRecoveryTail(), false)).toEqual({
+      state: "busy",
+      source: "lifecycle",
+      terminalAt: null,
     });
   });
 });

--- a/src/lib/accounts/migration/turnState.test.ts
+++ b/src/lib/accounts/migration/turnState.test.ts
@@ -5,6 +5,7 @@ import {
   SHUTDOWN_INTERRUPT_UUID,
   continuationPromptRecord,
   inheritedPromptRecord,
+  oauthFailureRecord,
   oauthFailureWithRecoveryTail,
   shutdownInterruptRecord,
   syntheticNoOpRecord,
@@ -210,6 +211,16 @@ describe("issue 516 — recovery records must not reopen a released turn", () =>
 
   test("a repeated recovery attempt stays released", () => {
     expect(authoritative(oauthFailureWithRecoveryTail(3))).toEqual(released);
+  });
+
+  test("a tail ending on the synthetic no-op right after the OAuth boundary is released", () => {
+    const records = [
+      { type: "user", timestamp: "2026-07-24T06:36:44.000Z", message: { role: "user", content: [{ type: "text", text: "Continue the reseat probe." }] } },
+      oauthFailureRecord(OAUTH_FAILURE_AT),
+      continuationPromptRecord("2026-07-24T07:04:23.736Z"),
+      syntheticNoOpRecord("2026-07-24T07:04:23.736Z"),
+    ];
+    expect(authoritative(records)).toEqual(released);
   });
 
   test("a recovery run that ends on a live prompt keeps the turn busy", () => {

--- a/src/lib/accounts/migration/turnState.ts
+++ b/src/lib/accounts/migration/turnState.ts
@@ -1,4 +1,4 @@
-import { recordValue, stringValue } from "@/lib/scanner/json";
+import { recordValue, recordsValue, stringValue } from "@/lib/scanner/json";
 
 import type { TurnState } from "./contracts";
 
@@ -19,6 +19,72 @@ function terminalApiError(record: RecordLike): boolean {
   return record.isApiErrorMessage === true
     && typeof record.error === "string"
     && TERMINAL_API_ERRORS.has(record.error);
+}
+
+function messageText(record: RecordLike): string {
+  const content = recordValue(record.message)?.content;
+  if (typeof content === "string") return content;
+  return recordsValue(content).map((part) => stringValue(part.text) ?? "").join("\n");
+}
+
+/** The synthetic assistant record Claude journals when a queued prompt is
+    retired without asking the provider for anything. The `<synthetic>` model id
+    alone is not enough — replayed transcripts carry real prose under it — so the
+    no-op text has to match too. */
+const SYNTHETIC_NO_OP_TEXT = /^no response requested\.?$/i;
+
+function syntheticNoOpAssistant(record: RecordLike): boolean {
+  if (record.isApiErrorMessage === true) return false;
+  if (stringValue((recordValue(record.message) ?? {}).model) !== "<synthetic>") return false;
+  return SYNTHETIC_NO_OP_TEXT.test(messageText(record).trim());
+}
+
+/** Claude's interrupt evidence on a user record: the bracket sentinel plus the
+    envelope flags an exiting or operator-interrupted host writes. Same shapes
+    the turn-duration scanner treats as authoritative failure evidence. */
+const INTERRUPT_SENTINEL_TEXT = /^\s*\[Request interrupted by user(?: for tool use)?\]\s*$/;
+
+function interruptionMarker(record: RecordLike): boolean {
+  if (record.interruptedByShutdown === true || "interruptedMessageId" in record) return true;
+  return INTERRUPT_SENTINEL_TEXT.test(messageText(record));
+}
+
+/** Issue #516 — recovery bookkeeping appended to a session that already
+    surrendered its turn: the replayed `Continue from where you left off.`
+    prompt, the synthetic `No response requested.` no-op that retires a queued
+    prompt, and the interrupt sentinel the host writes on its way out. None of
+    it is provider work, yet the forward projection below reopens the turn on
+    every user and assistant record and leaves an unhosted transcript busy
+    forever, which strands account reseat in `waiting-turn`.
+
+    The release stays deliberately narrow. Scanning back from the newest
+    record: the run must END on a release marker (interrupt sentinel or
+    synthetic no-op), may contain nothing but user records and those markers,
+    and must reach a terminal lifecycle boundary — a `result` record or a
+    terminal API error. A genuine assistant record anywhere in the run, a run
+    that ends on a live prompt still awaiting its first assistant record, or a
+    run with no terminal boundary in the tail window all keep the busy
+    projection. Host evidence is out of scope here: the migration coordinator
+    re-imposes busy while a live host still owns the transcript.
+
+    Returns the boundary's terminal evidence, or null when the tail is not a
+    recovery run. */
+export function claudeRecoveryTailRelease(records: RecordLike[]): { terminalAt: string | null } | null {
+  let closedByMarker = false;
+  for (let index = records.length - 1; index >= 0; index -= 1) {
+    const record = records[index]!;
+    if (record.type === "result") return closedByMarker ? { terminalAt: timestamp(record) } : null;
+    if (record.type === "assistant") {
+      if (terminalApiError(record)) return closedByMarker ? { terminalAt: timestamp(record) } : null;
+      if (!syntheticNoOpAssistant(record)) return null;
+      closedByMarker = true;
+      continue;
+    }
+    if (record.type !== "user") continue;
+    if (!closedByMarker && !interruptionMarker(record)) return null;
+    closedByMarker = true;
+  }
+  return null;
 }
 
 /** The newest authoritative lifecycle or tool event wins. Assistant prose
@@ -94,7 +160,9 @@ export function turnStateFromRecords(records: RecordLike[], codex: boolean, auth
           : { state: "busy", source: "assistant", terminalAt: null };
       }
     }
-    return state;
+    if (state.state !== "busy") return state;
+    const release = claudeRecoveryTailRelease(records);
+    return release ? { state: "terminal", source: "lifecycle", terminalAt: release.terminalAt } : state;
   }
 
   for (const record of [...records].reverse()) {

--- a/src/lib/scanner/activity.test.ts
+++ b/src/lib/scanner/activity.test.ts
@@ -12,6 +12,7 @@ import {
   transcriptTurnResult,
   turnStateFromRecords,
 } from "./activity";
+import { OAUTH_FAILURE_AT, oauthFailureWithRecoveryTail } from "@/lib/accounts/migration/fixtures/claudeRecoveryTail";
 
 const sandbox = fs.mkdtempSync(path.join(os.tmpdir(), "llv-activity-test-"));
 
@@ -95,6 +96,19 @@ describe("turnStateFromRecords (claude)", () => {
 
   test("no assistant/user records yields no verdict", () => {
     expect(turnStateFromRecords([{ type: "summary" }], false)).toBeNull();
+  });
+
+  test("a restart prime cannot disable the recovery-release host fence", () => {
+    const pathname = path.join(sandbox, "claude-recovery-restart.jsonl");
+    fs.writeFileSync(
+      pathname,
+      oauthFailureWithRecoveryTail().map((record) => JSON.stringify(record)).join("\n") + "\n",
+    );
+    const stat = fs.statSync(pathname);
+    const terminal = { state: "terminal" as const, source: "lifecycle" as const, terminalAt: OAUTH_FAILURE_AT };
+    primeTranscriptTurnEvidence(pathname, stat.size, stat.mtimeMs, false, terminal);
+
+    expect(transcriptTurnResult(pathname, stat.size, stat.mtimeMs, false).recoveryReleased).toBe(true);
   });
 });
 

--- a/src/lib/scanner/activity.ts
+++ b/src/lib/scanner/activity.ts
@@ -198,8 +198,12 @@ export function transcriptTurnResult(
 }
 
 /** A persisted scan snapshot carries the projected turn but not the records
-    behind it, so `recoveryReleased` primes false: the host guard rebuilds from
-    real evidence the first time the transcript is re-read. */
+    behind it, so it cannot carry `recoveryReleased`. A terminal authoritative
+    Claude turn is exactly the shape whose release may hinge on that flag, and
+    a primed cache entry is served for as long as size/mtime stay stable — a
+    false prime would silently disable the live-host fence across a restart.
+    Those transcripts stay unprimed so the first read rebuilds the evidence
+    from the actual tail; every other shape primes as before. */
 export function primeTranscriptTurnEvidence(
   pathname: string,
   size: number,
@@ -210,6 +214,7 @@ export function primeTranscriptTurnEvidence(
 ): void {
   const authoritative = options.authoritative ?? true;
   const composerReleased = options.composerReleased ?? false;
+  if (!codex && authoritative && turn.state === "terminal") return;
   storeTurnEvidence(pathname, {
     size,
     mtimeMs,

--- a/src/lib/scanner/activity.ts
+++ b/src/lib/scanner/activity.ts
@@ -5,7 +5,7 @@ import type { Activity, RootKey } from "../types";
 import { globalCache } from "./caches";
 import { readHead } from "./head";
 import { outputHolders } from "./process";
-import { turnStateFromRecords as structuredTurnStateFromRecords } from "@/lib/accounts/migration/turnState";
+import { claudeRecoveryTailRelease, turnStateFromRecords as structuredTurnStateFromRecords } from "@/lib/accounts/migration/turnState";
 
 type CachedTurnEvidence = {
   size: number;
@@ -14,10 +14,12 @@ type CachedTurnEvidence = {
   authoritative: boolean;
   turn: TurnState;
   composerReleased: boolean;
+  recoveryReleased: boolean;
 };
 
 globalCache<unknown>("turn").clear();
-const turnEvidenceCache = globalCache<CachedTurnEvidence>("turn-evidence-v1");
+globalCache<unknown>("turn-evidence-v1").clear();
+const turnEvidenceCache = globalCache<CachedTurnEvidence>("turn-evidence-v2");
 const TURN_EVIDENCE_CACHE_CAP = 4_096;
 
 /** Shared tail read+parse, keyed by path and file identity. Within one
@@ -132,6 +134,20 @@ export interface TranscriptTurnResult {
   turn: TurnState;
   complete: boolean;
   composerReleased: boolean;
+  /** True when the projection was released only because the tail is Claude
+      recovery bookkeeping (issue #516). Host-aware consumers re-impose busy
+      while a live host still owns the transcript. */
+  recoveryReleased: boolean;
+}
+
+function recoveryRelease(
+  turn: TurnState,
+  records: Record<string, unknown>[],
+  codex: boolean,
+  authoritative: boolean,
+): boolean {
+  if (codex || !authoritative || turn.state !== "terminal") return false;
+  return claudeRecoveryTailRelease(records) !== null;
 }
 
 /** Complete, identity-bound turn evidence shared by scanner and migration
@@ -148,12 +164,18 @@ export function transcriptTurnResult(
   const cached = turnEvidenceCache.get(key);
   if (cached && cached.size === size && cached.mtimeMs === mtimeMs && cached.codex === codex) {
     storeTurnEvidence(pathname, cached);
-    return { turn: { ...cached.turn }, complete: true, composerReleased: cached.composerReleased };
+    return {
+      turn: { ...cached.turn },
+      complete: true,
+      composerReleased: cached.composerReleased,
+      recoveryReleased: cached.recoveryReleased,
+    };
   }
   const tail = tailRecordsResult(pathname, size, mtimeMs);
   const turn = structuredTurnStateFromRecords(tail.records, codex, authoritative);
+  const recoveryReleased = tail.complete && recoveryRelease(turn, tail.records, codex, authoritative);
   if (tail.complete) {
-    storeTurnEvidence(pathname, { size, mtimeMs, codex, authoritative, turn, composerReleased: false });
+    storeTurnEvidence(pathname, { size, mtimeMs, codex, authoritative, turn, composerReleased: false, recoveryReleased });
     const companionAuthoritative = !authoritative;
     const companionKey = `${companionAuthoritative ? "authoritative" : "activity"}:${pathname}`;
     const cachedCompanion = turnEvidenceCache.get(companionKey);
@@ -169,11 +191,15 @@ export function transcriptTurnResult(
       authoritative: companionAuthoritative,
       turn: companionTurn,
       composerReleased: companionComposerReleased,
+      recoveryReleased: recoveryRelease(companionTurn, tail.records, codex, companionAuthoritative),
     });
   }
-  return { turn, complete: tail.complete, composerReleased: false };
+  return { turn, complete: tail.complete, composerReleased: false, recoveryReleased };
 }
 
+/** A persisted scan snapshot carries the projected turn but not the records
+    behind it, so `recoveryReleased` primes false: the host guard rebuilds from
+    real evidence the first time the transcript is re-read. */
 export function primeTranscriptTurnEvidence(
   pathname: string,
   size: number,
@@ -184,7 +210,15 @@ export function primeTranscriptTurnEvidence(
 ): void {
   const authoritative = options.authoritative ?? true;
   const composerReleased = options.composerReleased ?? false;
-  storeTurnEvidence(pathname, { size, mtimeMs, codex, authoritative, turn: { ...turn }, composerReleased });
+  storeTurnEvidence(pathname, {
+    size,
+    mtimeMs,
+    codex,
+    authoritative,
+    turn: { ...turn },
+    composerReleased,
+    recoveryReleased: false,
+  });
 }
 
 export function recordTranscriptComposerRelease(


### PR DESCRIPTION
Closes the production acceptance blocker on #516.

## Problem

After the terminal OAuth failure was correctly classified, a recovery attempt appended bookkeeping to the predecessor transcript of `conversation_fb4dae92-b571-4ced-9fc9-dce53ac05050`:

- user `Continue from where you left off.`
- synthetic assistant `No response requested.` (`model: <synthetic>`)
- user — the inherited reporting prompt
- user `[Request interrupted by user]` (`interruptedByShutdown: true`)

None of that is provider work, but the authoritative Claude projection reopened the turn on every user and assistant record. The conversation went back to `busy/lifecycle` with no active host, intent `dadda37f-5b0e-4f0b-85ea-02c73af17548` stayed `requested/draining`, and held delivery `51ee4a51-1d5f-4a18-9a8e-690fc88a7456` never reached a successor.

## The contract

`claudeRecoveryTailRelease` (turnState.ts) scans back from the newest record. The trailing run must

- end on a release marker — the interrupt sentinel (bracket text, `interruptedMessageId`, or `interruptedByShutdown`) or a synthetic `No response requested.` no-op,
- contain nothing but user records and those markers, and
- reach a terminal lifecycle boundary: a `result` record or a terminal API error.

Then the authoritative turn projects `terminal/lifecycle` at the boundary's timestamp. Everything else keeps today's busy projection: a genuine in-flight assistant record, a run that ends on a live prompt still awaiting its first assistant record, a `<synthetic>` record carrying real prose, and a run with no terminal boundary in the tail window.

Host evidence outranks the transcript. `transcriptTurnResult` reports `recoveryReleased`, and the coordinator re-imposes busy while a registered host still owns the path — in the inventory projection and again at the successor-creation fence, so a host that appears after a released inventory tick cannot leak a successor.

The activity projection is untouched; only the authoritative Claude branch releases.

## Coverage

turnState: the production tail and its repeat project released; the five guards above stay busy; a `result` boundary releases its own tail; the activity projection keeps its live semantics.

coordinator: an unhosted predecessor completes the reseat through a reopened registry — one successor generation, the held delivery sent exactly once with its stable `clientMessageId`, zero predecessor sends, intent `complete`, and repeated inventory/reconcile/drain ticks stay converged. A live registered host keeps the turn busy and creates nothing, and releases only after it exits; a host registered after the released inventory fences creation.

## Verification

- `bun test src/lib/accounts/migration/` — 163 pass, 0 fail
- `bun test src/lib/scanner src/lib/pipelines src/lib/runtime/startup.test.ts src/components/scheme` — 1050 pass, 0 fail
- `bun test src/lib/accounts` — 352 pass, 1 fail (`interprocess mutation matrix`, subprocess-timing failure reproduced on `origin/main`)
- `tsc --noEmit` clean; ESLint clean on changed files
- `bun run privacy:check` — PASS
- `bun run build` — production build and MCP bundle succeed

Both host fences were confirmed load-bearing by removing them and watching the new tests fail.