### PR TITLE
fix(attach): host-correct terminal command, one-click copy with toast

### DIFF
--- a/src/components/AgentControlStrip.tsx
+++ b/src/components/AgentControlStrip.tsx
@@ -298,6 +298,34 @@ export function AgentControlStrip({ file }: { file: FileEntry }) {
   const [attachOpen, setAttachOpen] = useState(false);
   const [status, setStatus] = useState<{ kind: "ok" | "info" | "err"; text: string } | null>(null);
 
+  /* One click, one command (operator request): the terminal button copies the
+     COMPLETE resume command (cd + env + CLI) straight to the clipboard and
+     confirms via the strip's own status toast — no dialog hop. The dialog
+     remains the fallback for the live-tmux mode (two commands to choose from)
+     and for any fetch/clipboard failure, so nothing is ever less capable than
+     before. */
+  const copyAttachCommand = async () => {
+    if (attachMode === "live") {
+      setAttachOpen(true);
+      return;
+    }
+    setStatus(null);
+    try {
+      const response = await fetch(`/api/attach-command?path=${encodeURIComponent(file.path)}`);
+      const body = (await response.json()) as { fullCommand?: string; error?: string };
+      if (response.ok && body.fullCommand) {
+        const { copyText } = await import("@/components/feed/CopyButton");
+        if (await copyText(body.fullCommand)) {
+          setStatus({ kind: "ok", text: t("attach.copiedFull") });
+          return;
+        }
+      }
+    } catch {
+      /* fall through to the dialog */
+    }
+    setAttachOpen(true);
+  };
+
   /* Width is the collapse trigger (§3) — scheme nodes vary continuously with
      zoom, so a ResizeObserver on the strip beats any media query. A callback
      ref (not a mount-once effect) attaches it, because the strip root can mount
@@ -397,7 +425,7 @@ export function AgentControlStrip({ file }: { file: FileEntry }) {
         onStop={() => void stop()}
         onCompact={() => void compact()}
         onRecheck={() => void recheck()}
-        onTerminal={() => setAttachOpen(true)}
+        onTerminal={() => void copyAttachCommand()}
         onToggleOverflow={() => setOverflowOpen((open) => !open)}
         status={status}
       />

--- a/src/lib/agent/attachCommand.ts
+++ b/src/lib/agent/attachCommand.ts
@@ -66,7 +66,7 @@ export type AttachResolution =
 
 export interface AttachResolverDeps {
   files: FileEntry[];
-  resumeSpecFor: (root: string, path: string, options?: { model?: string | null; effort?: string | null; allowSubagents?: boolean; mcpServers?: readonly string[]; cwd?: string | null }) => ResumeSpec | null;
+  resumeSpecFor: (root: string, path: string, options?: { model?: string | null; effort?: string | null; allowSubagents?: boolean; mcpServers?: readonly string[]; cwd?: string | null; hostTerminal?: boolean }) => ResumeSpec | null;
   accountIdForPath: (path: string) => string;
   accountLabelFor: (engine: AgentEngine, accountId: string) => string;
   allowSubagentsForPath?: (path: string) => boolean | undefined;
@@ -100,6 +100,9 @@ export function resolveAttachCommand(path: string, deps: AttachResolverDeps): At
     allowSubagents: deps.allowSubagentsForPath?.(target.entry.path),
     mcpServers: deps.mcpServersForPath?.(target.entry.path),
     cwd: effectiveCwd,
+    /* The composed string is pasted into the operator's own shell: the CLI
+       binary must resolve as the host sees it, never the container shim. */
+    hostTerminal: true,
   });
   if (!spec) return { ok: false, error: "this conversation cannot be attached", status: 409 };
 
@@ -139,7 +142,7 @@ export interface LaunchAttachDeps {
     sessionId: string,
     cwd: string,
     home: string,
-    options?: { model?: string | null; effort?: string | null; fast?: boolean | null; allowSubagents?: boolean; mcpServers?: readonly string[] },
+    options?: { model?: string | null; effort?: string | null; fast?: boolean | null; allowSubagents?: boolean; mcpServers?: readonly string[]; hostTerminal?: boolean },
   ) => ResumeSpec | null;
   homeForAccount: (engine: AgentEngine, accountId: string) => string | null;
   accountLabelFor: (engine: AgentEngine, accountId: string) => string;
@@ -175,6 +178,8 @@ export function resolveLaunchAttachCommand(deps: LaunchAttachDeps): AttachResolu
     /* Re-apply the launch's recorded MCP allowlist (PR #610) so the resumed
        command enforces the same server scope the launch ran under. */
     mcpServers: receipt.launchProfile.mcpServers,
+    /* Destined for the operator's own shell, same as the path flow above. */
+    hostTerminal: true,
   });
   if (!spec) return { ok: false, error: "this launch cannot be attached", status: 409 };
   return {

--- a/src/lib/agent/cli.test.ts
+++ b/src/lib/agent/cli.test.ts
@@ -439,3 +439,37 @@ test("deferred Claude policy planning leaves disk unchanged before route admissi
   expect(fresh.command).toContain(path.join(account.home, ".llv", "spawn-settings", `${sid}.json`));
   expect(fs.existsSync(path.join(account.home, ".llv"))).toBe(false);
 });
+
+test("resolveHostBinary never emits the container nsenter shim", async () => {
+  const { resolveHostBinary } = await import("./cli");
+  const previous = process.env.LLV_DOCKER_NSENTER_SHIMS;
+  process.env.LLV_DOCKER_NSENTER_SHIMS = "1";
+  try {
+    const resolved = resolveHostBinary("claude");
+    expect(resolved.startsWith("/usr/local/bin/")).toBe(false);
+    expect(resolved.startsWith("/usr/bin/")).toBe(false);
+  } finally {
+    if (previous === undefined) delete process.env.LLV_DOCKER_NSENTER_SHIMS;
+    else process.env.LLV_DOCKER_NSENTER_SHIMS = previous;
+  }
+});
+
+test("a host-terminal resume spec resolves the CLI as the host, not the container shim", async () => {
+  const { resumeSpecForSession } = await import("./cli");
+  const account = createManagedClaudeAccount("host-terminal-probe");
+  const previous = process.env.LLV_DOCKER_NSENTER_SHIMS;
+  process.env.LLV_DOCKER_NSENTER_SHIMS = "1";
+  try {
+    const sessionId = "12345678-1234-1234-1234-123456789abc";
+    const inContainer = resumeSpecForSession("claude", sessionId, SANDBOX, account.home, {});
+    const forHost = resumeSpecForSession("claude", sessionId, SANDBOX, account.home, { hostTerminal: true });
+    expect(forHost).not.toBeNull();
+    expect(inContainer).not.toBeNull();
+    expect(forHost!.command.includes("/usr/local/bin/claude")).toBe(false);
+    /* Same session, same flags — only the binary resolution differs. */
+    expect(forHost!.command.includes(`--resume' '${sessionId}`)).toBe(true);
+  } finally {
+    if (previous === undefined) delete process.env.LLV_DOCKER_NSENTER_SHIMS;
+    else process.env.LLV_DOCKER_NSENTER_SHIMS = previous;
+  }
+});

--- a/src/lib/agent/cli.ts
+++ b/src/lib/agent/cli.ts
@@ -57,6 +57,35 @@ export function resolveBinary(name: string): string {
   return name;
 }
 
+/** Binary path as the OPERATOR'S OWN terminal resolves it. Inside the runtime
+    container the nsenter shim lives at /usr/local/bin and points at container
+    plumbing that does not exist on the host, so a command composed for a host
+    terminal must never embed it (issue: "Підключитися у своєму терміналі"
+    emitted /usr/local/bin/claude → "No such file or directory"). Only the
+    mounted $HOME install locations are probed there; system directories are
+    container-owned and untrustworthy. Outside a container the system paths are
+    probed too. When nothing matches, the bare name defers to the user's PATH. */
+export function resolveHostBinary(name: string): string {
+  const home = os.homedir();
+  const homeCandidates = [
+    path.join(home, ".bun", "bin", name),
+    path.join(home, ".npm-global", "bin", name),
+    path.join(home, ".local", "bin", name),
+    path.join(home, "go", "bin", name),
+  ];
+  const containerized = process.env.LLV_DOCKER_NSENTER_SHIMS === "1";
+  const candidates = containerized ? homeCandidates : [...homeCandidates, "/usr/local/bin/" + name, "/usr/bin/" + name];
+  for (const candidate of candidates) {
+    try {
+      fs.accessSync(candidate, fs.constants.X_OK);
+      return candidate;
+    } catch {
+      /* keep looking */
+    }
+  }
+  return name;
+}
+
 export function shellQuote(value: string): string {
   return "'" + value.replace(/'/g, "'\\''") + "'";
 }
@@ -125,6 +154,9 @@ export interface ResumeSpecOptions {
       project-scoped MCP servers in the wrong directory (finding 1). Absent/empty
       ⇒ safe fallback to the sniffed cwd. */
   cwd?: string | null;
+  /** The command is destined for the operator's own terminal: resolve the CLI
+      binary as the HOST sees it, never the in-container nsenter shim. */
+  hostTerminal?: boolean;
 }
 
 function normalizedMcpServers(value: readonly string[] | undefined): string[] {
@@ -382,7 +414,7 @@ export function resumeSpecForSession(
       mcpServers,
       mcpStatePath: managed ? path.join(home, ".claude.json") : path.join(path.dirname(home), ".claude.json"),
     });
-    const args = [resolveBinary("claude")];
+    const args = [(options.hostTerminal ? resolveHostBinary : resolveBinary)("claude")];
     const permissionMode = effectiveClaudePermissionMode(options);
     if (options.readOnly || permissionMode === "plan") {
       args.push("--permission-mode", "plan", "--disallowedTools", "Edit,Write,NotebookEdit");
@@ -405,7 +437,7 @@ export function resumeSpecForSession(
       launchProfile: { ...emptyLaunchProfileForResume(cwd, launchModel, options.effort ?? null), readOnly: options.readOnly ?? null, permissionMode, allowSubagents: options.allowSubagents ?? false, mcpServers },
     };
   }
-  let command = `${resolveBinary("codex")}`;
+  let command = `${(options.hostTerminal ? resolveHostBinary : resolveBinary)("codex")}`;
   if (isManagedCodexHome(home)) command += " -c cli_auth_credentials_store=file";
   for (const override of codexMcpRuntimeOverrides(home, cwd, mcpServers)) command += ` -c ${shellQuote(override)}`;
   if (options.model) command += ` -m ${shellQuote(options.model)}`;

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -372,6 +372,7 @@ export const en = {
   "attach.copyCwd": "Copy working directory",
   "attach.copyCommand": "Copy command",
   "attach.copyFull": "Copy full command",
+  "attach.copiedFull": "Full command copied to clipboard",
   "attach.takeoverWarning": "Resuming here takes over the conversation from the viewer.",
   "attach.subagentNote": "Subagents resume through their root session.",
   "attach.secondaryViewer": "Open a read-only viewer pane in tmux",

--- a/src/lib/i18n/uk.ts
+++ b/src/lib/i18n/uk.ts
@@ -395,6 +395,7 @@ export const uk: Record<keyof typeof en, Message> = {
   "attach.copyCwd": "Скопіювати робочу директорію",
   "attach.copyCommand": "Скопіювати команду",
   "attach.copyFull": "Скопіювати повну команду",
+  "attach.copiedFull": "Повну команду скопійовано в буфер",
   "attach.takeoverWarning": "Відновлення тут перебирає розмову у переглядача.",
   "attach.subagentNote": "Субагенти відновлюються через свою кореневу сесію.",
   "attach.secondaryViewer": "Відкрити панель перегляду лише для читання в tmux",


### PR DESCRIPTION
## Problem (operator report, 2026-07-24)

1. "Підключитися у своєму терміналі" hands the operator a command embedding `/usr/local/bin/claude` — the runtime container's nsenter shim, which does not exist on the host: `env: '/usr/local/bin/claude': No such file or directory`.
2. The flow takes too many steps: open dialog → pick between per-part copy buttons → copy full command. The operator wants one click → full command in the clipboard → toast.

## Fix

- `resolveHostBinary` in `src/lib/agent/cli.ts`: resolves the CLI as the HOST sees it. Inside the container (`LLV_DOCKER_NSENTER_SHIMS=1`) only the mounted `$HOME` install locations are probed (`~/.bun/bin` first — the CLI the user actually runs); system directories are container-owned and excluded; bare-name fallback defers to the user's PATH. Outside a container the system paths remain probed.
- `ResumeSpecOptions.hostTerminal` — both attach composition sites in `src/lib/agent/attachCommand.ts` (path flow and `spawn:<launchId>` receipt flow) set it, so every command the dialog or button ever shows is host-correct. Actual in-container spawn paths keep `resolveBinary` untouched.
- `AgentControlStrip`: the terminal button now fetches `/api/attach-command` and copies `fullCommand` (cd + env + CLI) in one click, confirming via the strip's existing status toast (`attach.copiedFull`, en+uk). The dialog remains for live-tmux mode (two command variants to choose from) and as the fallback on any fetch/clipboard failure.

## Verification

- New tests: `resolveHostBinary` never emits `/usr/local/bin` or `/usr/bin` under the shim env; a `hostTerminal` resume spec contains no shim path while keeping identical resume flags.
- `cli.test.ts` + `attachCommand.test.ts` + strip/dialog dom tests: 48 pass, 0 fail; `tsc --noEmit` clean; changed-file ESLint clean; `bun run privacy:check` PASS; production build + MCP bundle built.

🤖 Generated with [Claude Code](https://claude.com/claude-code)