### PR TITLE
fix(outbox): settle the launch bubble from the delivery receipt when echo matching fails (#648)

### DIFF
--- a/evidence/issue-648/geometry.json
+++ b/evidence/issue-648/geometry.json
@@ -1,0 +1,46 @@
+{
+  "delivering-control-desktop": {
+    "scrollWidth": 1280,
+    "viewportWidth": 1280,
+    "feedHeight": 667.75,
+    "composerHeight": 99,
+    "textarea": true,
+    "outboxEntries": 1,
+    "outboxState": "delivering",
+    "statusLabel": "Доставляється",
+    "promptVisible": true
+  },
+  "receipt-settled-no-echo-desktop": {
+    "scrollWidth": 1280,
+    "viewportWidth": 1280,
+    "feedHeight": 667.75,
+    "composerHeight": 99,
+    "textarea": true,
+    "outboxEntries": 1,
+    "outboxState": "delivered",
+    "statusLabel": "Доставлено",
+    "promptVisible": true
+  },
+  "delivering-control-mobile-390": {
+    "scrollWidth": 390,
+    "viewportWidth": 390,
+    "feedHeight": 653,
+    "composerHeight": 105,
+    "textarea": true,
+    "outboxEntries": 1,
+    "outboxState": "delivering",
+    "statusLabel": "Доставляється",
+    "promptVisible": true
+  },
+  "receipt-settled-no-echo-mobile-390": {
+    "scrollWidth": 390,
+    "viewportWidth": 390,
+    "feedHeight": 653,
+    "composerHeight": 105,
+    "textarea": true,
+    "outboxEntries": 1,
+    "outboxState": "delivered",
+    "statusLabel": "Доставлено",
+    "promptVisible": true
+  }
+}

--- a/src/components/LogFeed.tsx
+++ b/src/components/LogFeed.tsx
@@ -22,7 +22,7 @@ import {
   visibleRuntimeLiveTurnItems,
 } from "./conversation/liveTurnHandoff";
 import { orderedConversationTail } from "./conversation/tailOrder";
-import { publishTranscriptEchoes, seedLaunchOutbox, useOutbox, visibleOutbox } from "./conversation/outbox";
+import { publishTranscriptEchoes, seedLaunchOutbox, settleLaunchOutboxDelivered, useOutbox, visibleOutbox } from "./conversation/outbox";
 import { createFeedSession, type FeedSession, type FeedSnapshot } from "./feed/parse";
 import { FeedItem } from "./feed/FeedItem";
 import { RawLineProvider, type RawLineLookup } from "./feed/rawLine";
@@ -407,13 +407,36 @@ export function LogFeed({ file, showSvc, lineFilter, onStatus, paused, follow, s
      causally by occurrence count. A user text that appears twice is two echoes
      that retire two bubbles; a message that predates a queued bubble leaves it
      visible. The counts carry that occurrence information. */
+  /* The launch's own first message identity (issue #648): a structured / MCP
+     spawn journals its first user record with SDK / agent provenance, so the
+     transcript parser renders it as a SYSTEM row, not a `user` bubble — the
+     echo-text retirement path would never see it. Its text is still the launch
+     prompt's transcript echo, so treat a system-row row that matches a
+     launch-owned bubble's own text (raw draft OR scaffolded echo) as that
+     bubble's echo. Derived from the outbox so it survives adoption (which strips
+     the launch prompt fields from the server projection). */
+  const launchEchoKeys = useMemo(() => {
+    const keys = new Set<string>();
+    for (const entry of outbox) {
+      if (!entry.launchOwned) continue;
+      const echo = entry.echoText?.trim();
+      if (echo) keys.add(echo);
+      const text = entry.text.trim();
+      if (text) keys.add(text);
+    }
+    return keys;
+  }, [outbox]);
   const transcriptEchoes = useMemo(() => {
     if (!transcriptGeneration) return [];
-    return feed.items.flatMap(({ anchorKey, key, item }) =>
-      item.kind === "user" && item.text.trim()
-        ? [{ generation: transcriptGeneration, id: anchorKey ?? `key:${key}`, text: item.text }]
-        : []);
-  }, [feed.items, transcriptGeneration]);
+    return feed.items.flatMap(({ anchorKey, key, item }) => {
+      const text = "text" in item ? item.text : "";
+      if (!text.trim()) return [];
+      /* A genuine user bubble is always an echo; a non-user row only echoes the
+         launch when it exactly carries a launch-owned bubble's own identity. */
+      if (item.kind !== "user" && !launchEchoKeys.has(text.trim())) return [];
+      return [{ generation: transcriptGeneration, id: anchorKey ?? `key:${key}`, text }];
+    });
+  }, [feed.items, transcriptGeneration, launchEchoKeys]);
   const transcriptEchoCounts = useMemo(() => {
     const counts = new Map<string, number>();
     for (const echo of transcriptEchoes) {
@@ -451,6 +474,23 @@ export function LogFeed({ file, showSvc, lineFilter, onStatus, paused, follow, s
       ...(launch.promptEcho ? { echoText: launch.promptEcho } : {}),
     });
   }, [memoryKey, launch?.launchId, launch?.prompt, launch?.promptImages, launch?.promptAt, launch?.promptEcho]);
+  /* Settle the launch bubble from the delivery receipt the server projects
+     (issue #648), independent of any transcript echo. A structured / MCP spawn's
+     first message is journaled as a system row (SDK / agent provenance), so echo
+     retirement can never fire; the delivered receipt is the proof the prompt
+     reached the agent. It settles the bubble to `delivered` with the receipt time
+     as `settledAt`, so it retires on the delivered TTL instead of spinning on
+     "delivering" forever. Keyed on the launch id and the receipt time only, so it
+     still fires on a materialized window that has stripped the prompt fields. */
+  useEffect(() => {
+    if (!memoryKey || !launch?.launchId) return;
+    if (launch.initialMessage !== "delivered" || launch.deliveredAt === undefined) return;
+    settleLaunchOutboxDelivered(memoryKey, {
+      id: launch.launchId,
+      at: launch.promptAt ?? launch.deliveredAt,
+      settledAt: launch.deliveredAt,
+    });
+  }, [memoryKey, launch?.launchId, launch?.initialMessage, launch?.deliveredAt, launch?.promptAt]);
   const pendingOutbox = file ? visibleOutbox(outbox, transcriptEchoCounts, nowMs()) : [];
   useEffect(() => {
     if (!memoryKey || !file) return;

--- a/src/components/conversation/issue648Evidence.browser.test.tsx
+++ b/src/components/conversation/issue648Evidence.browser.test.tsx
@@ -1,0 +1,258 @@
+import { afterAll, beforeEach, afterEach, expect, test } from "bun:test";
+import { act } from "react";
+import { installActEnv } from "@/test-helpers/actEnv";
+import fs from "node:fs";
+import path from "node:path";
+import { Window } from "happy-dom";
+import { createRoot } from "react-dom/client";
+import { chromium, type Browser } from "playwright-core";
+
+import type { FileEntry, StructuredSpawnCardState } from "@/lib/types";
+import { setLocale } from "@/lib/i18n";
+
+import { BranchPane } from "@/components/BranchPane";
+import { resetOutboxForTests } from "./outbox";
+
+/**
+ * Browser-rendered evidence for issue #648: a structured / MCP spawn's launch
+ * bubble that the transcript echo can NEVER retire — its first user record is
+ * journaled with SDK / agent provenance, so it renders as a system row, not a
+ * `user` echo. Before the fix such a bubble spun on "Доставляється" (delivering)
+ * forever. The server projects the delivery receipt (`initialMessage:"delivered"`
+ * + `deliveredAt`), and the client settles the launch bubble to `delivered`
+ * INDEPENDENT of any echo, so it renders delivered and retires on the delivered
+ * TTL. This captures the receipt-settled-no-echo window (and a delivering
+ * control) at desktop (1280×900) and 390px, with the real production CSS.
+ */
+
+const EVIDENCE_DIR = path.join(process.cwd(), "evidence", "issue-648");
+const CSS_DIR = path.join(process.cwd(), ".next", "static", "css");
+
+/** The compiled production Tailwind CSS emitted by `next build`. */
+function productionCss(): string {
+  const files = fs.existsSync(CSS_DIR) ? fs.readdirSync(CSS_DIR).filter((name) => name.endsWith(".css")) : [];
+  return files.map((name) => fs.readFileSync(path.join(CSS_DIR, name), "utf8")).join("\n");
+}
+
+const dom = new Window({ url: "http://localhost/" });
+installActEnv();
+let mobile = false;
+Object.assign(globalThis, {
+  window: dom,
+  document: dom.document,
+  navigator: dom.navigator,
+  sessionStorage: dom.sessionStorage,
+  localStorage: dom.localStorage,
+  Node: dom.Node,
+  HTMLElement: dom.HTMLElement,
+  HTMLButtonElement: dom.HTMLButtonElement,
+  HTMLTextAreaElement: dom.HTMLTextAreaElement,
+  Event: dom.Event,
+  CustomEvent: dom.CustomEvent,
+  MouseEvent: dom.MouseEvent,
+  KeyboardEvent: dom.KeyboardEvent,
+  ResizeObserver: class { observe() {} unobserve() {} disconnect() {} },
+  IntersectionObserver: undefined,
+  requestAnimationFrame: dom.requestAnimationFrame.bind(dom),
+  cancelAnimationFrame: dom.cancelAnimationFrame.bind(dom),
+});
+(dom as unknown as { matchMedia(q: string): unknown }).matchMedia = (q: string) => ({
+  matches: q.includes("max-width: 767px") ? mobile : q.includes("pointer: coarse") ? mobile : false,
+  media: q,
+  addEventListener() {},
+  removeEventListener() {},
+});
+
+let browser: Browser;
+const originalDateNow = Date.now;
+/** Fixed clock: the launch settled 3s after it was submitted, well inside the
+    delivered TTL, so the settled bubble renders (as delivered) at capture. */
+const NOW = Date.parse("2026-07-24T10:38:30.000Z");
+const PROMPT_AT = Date.parse("2026-07-24T10:38:21.000Z");
+const DELIVERED_AT = Date.parse("2026-07-24T10:38:24.240Z");
+
+beforeEach(() => {
+  dom.sessionStorage.clear();
+  resetOutboxForTests();
+  setLocale("uk");
+  Date.now = () => NOW;
+});
+afterEach(() => {
+  document.body.replaceChildren();
+  mobile = false;
+});
+afterAll(async () => {
+  await browser?.close();
+  Date.now = originalDateNow;
+});
+
+const CONV = "conversation_648_evidence";
+/* A structured launch whose transcript echo never matches: the prompt is the
+   plain operator draft, and the transcript (absent here) would journal it as a
+   system row, so ONLY the delivery receipt can settle the bubble. Synthetic
+   prompt text — no real operator content in committed evidence. */
+const LAUNCH_PROMPT = "Прочитай синтетичну розмову у файлі-фікстурі та підсумуй її";
+
+function baseFile(over: Partial<FileEntry>): FileEntry {
+  return {
+    path: "spawn:launch_648_evidence",
+    root: "claude-projects",
+    name: "spawn:launch_648_evidence",
+    project: "live-log-viewer",
+    title: "Builder · settle the launch bubble (#648)",
+    engine: "claude",
+    kind: "session",
+    fmt: "claude",
+    parent: null,
+    mtime: 1,
+    size: 0,
+    activity: "live",
+    proc: null,
+    pid: null,
+    model: "claude-opus-4-8",
+    pendingQuestion: null,
+    waitingInput: null,
+    conversationId: CONV,
+    ...over,
+  } as FileEntry;
+}
+
+const DELIVERING_LAUNCH: StructuredSpawnCardState = {
+  launchId: "launch_648_evidence", clientAttemptId: null, accountId: "acct_evidence",
+  state: "queued", initialMessage: "queued", retrySafe: false, error: null,
+  promptImages: 0, promptAt: PROMPT_AT, prompt: LAUNCH_PROMPT, promptEcho: LAUNCH_PROMPT,
+};
+/* The #648 fix: the delivery receipt reports delivered with its timestamp, so
+   the launch bubble settles to `delivered` even though no echo ever matches. */
+const RECEIPT_SETTLED_LAUNCH: StructuredSpawnCardState = {
+  ...DELIVERING_LAUNCH,
+  state: "recovered", initialMessage: "delivered", deliveredAt: DELIVERED_AT,
+};
+
+const STATES: Array<{ id: string; launch: StructuredSpawnCardState; expectState: "delivering" | "delivered" }> = [
+  { id: "delivering-control", launch: DELIVERING_LAUNCH, expectState: "delivering" },
+  { id: "receipt-settled-no-echo", launch: RECEIPT_SETTLED_LAUNCH, expectState: "delivered" },
+];
+
+const VIEWPORTS: Array<{ id: string; mobile: boolean; width: number; height: number }> = [
+  { id: "desktop", mobile: false, width: 1280, height: 900 },
+  { id: "mobile-390", mobile: true, width: 390, height: 844 },
+];
+
+async function renderWindow(node: React.ReactElement): Promise<string> {
+  const host = document.createElement("div");
+  document.body.append(host);
+  const root = createRoot(host);
+  await act(async () => {
+    root.render(node);
+    await new Promise((r) => setTimeout(r, 0));
+  });
+  /* A second flush so the launch-seed effect and the delivered-receipt
+     settlement effect both run and the outbox re-renders. */
+  await act(async () => {
+    await new Promise((r) => setTimeout(r, 0));
+  });
+  const html = host.innerHTML;
+  await act(async () => root.unmount());
+  host.remove();
+  return html;
+}
+
+const CSS = productionCss();
+
+function pageHtml(inner: string, width: number): string {
+  return `<!doctype html><html><head><meta charset="utf-8"><style>${CSS}
+    html,body{margin:0;padding:0;background:var(--color-canvas,#fff);}
+    #evidence-host{display:flex;flex-direction:column;width:${width}px;height:100vh;overflow:hidden;}
+    </style></head><body><div id="evidence-host">${inner}</div></body></html>`;
+}
+
+interface Geometry {
+  scrollWidth: number;
+  viewportWidth: number;
+  feedHeight: number;
+  composerHeight: number;
+  textarea: boolean;
+  outboxEntries: number;
+  outboxState: string;
+  statusLabel: string;
+  promptVisible: boolean;
+}
+
+test("issue 648 evidence: a delivery-receipt-settled launch bubble renders delivered (never delivering forever) at desktop and 390px", async () => {
+  expect(CSS.length).toBeGreaterThan(10_000); // the production build's CSS is present
+  fs.mkdirSync(EVIDENCE_DIR, { recursive: true });
+  browser = await chromium.launch({ executablePath: chromium.executablePath() });
+  const manifest: Record<string, Geometry> = {};
+
+  for (const viewport of VIEWPORTS) {
+    for (const state of STATES) {
+      mobile = viewport.mobile;
+      resetOutboxForTests();
+      dom.sessionStorage.clear();
+
+      const inner = await renderWindow(<BranchPane file={baseFile({ launch: state.launch })} tasks={[]} isRoot />);
+      /* The launch prompt renders as the conversation's first optimistic bubble
+         on every surface (issue #614), delivering or delivered. */
+      expect(inner).toContain(LAUNCH_PROMPT);
+      expect(inner).toContain("data-outbox");
+
+      const page = await browser.newPage({ viewport: { width: viewport.width, height: viewport.height }, deviceScaleFactor: 1 });
+      await page.setContent(pageHtml(inner, viewport.width), { waitUntil: "load" });
+      const key = `${state.id}-${viewport.id}`;
+      fs.writeFileSync(path.join(EVIDENCE_DIR, `${key}.html`), pageHtml(inner, viewport.width));
+      await page.screenshot({ path: path.join(EVIDENCE_DIR, `${key}.png`) });
+
+      const geometry = await page.evaluate((prompt) => {
+        const rect = (sel: string) => {
+          const el = document.querySelector(sel);
+          return el ? (el as HTMLElement).getBoundingClientRect().height : 0;
+        };
+        const entry = document.querySelector<HTMLElement>("[data-outbox-entry]");
+        const status = document.querySelector<HTMLElement>("[data-outbox-status]");
+        return {
+          scrollWidth: document.documentElement.scrollWidth,
+          viewportWidth: window.innerWidth,
+          feedHeight: rect("[data-log-feed-scroller]"),
+          composerHeight: rect("form"),
+          textarea: Boolean(document.querySelector("textarea")),
+          outboxEntries: document.querySelectorAll("[data-outbox-entry]").length,
+          outboxState: entry?.dataset.outboxState ?? "",
+          statusLabel: status?.textContent ?? "",
+          promptVisible: document.body.textContent?.includes(prompt) === true,
+        } as Geometry;
+      }, LAUNCH_PROMPT);
+      await page.close();
+      manifest[key] = geometry;
+
+      /* No horizontal overflow at either width (the 390px contract). */
+      expect(geometry.scrollWidth).toBeLessThanOrEqual(viewport.width + 1);
+      /* The one shell/feed/composer, transcript-dominant. */
+      expect(geometry.feedHeight).toBeGreaterThan(0);
+      expect(geometry.textarea).toBe(true);
+      expect(geometry.feedHeight).toBeGreaterThan(geometry.composerHeight);
+      /* Exactly one launch bubble, in the expected lifecycle state. */
+      expect(geometry.outboxEntries).toBe(1);
+      expect(geometry.outboxState).toBe(state.expectState);
+      expect(geometry.promptVisible).toBe(true);
+    }
+  }
+
+  /* The heart of #648: the receipt-settled launch reads DELIVERED, not the
+     eternal delivering ghost — at desktop and at 390px. */
+  expect(manifest["receipt-settled-no-echo-desktop"]!.outboxState).toBe("delivered");
+  expect(manifest["receipt-settled-no-echo-desktop"]!.statusLabel).toContain("Доставлено");
+  expect(manifest["receipt-settled-no-echo-mobile-390"]!.outboxState).toBe("delivered");
+  expect(manifest["receipt-settled-no-echo-mobile-390"]!.statusLabel).toContain("Доставлено");
+  /* The control proves the contrast: an un-settled launch still reads delivering. */
+  expect(manifest["delivering-control-desktop"]!.outboxState).toBe("delivering");
+  expect(manifest["delivering-control-desktop"]!.statusLabel).toContain("Доставляється");
+
+  fs.writeFileSync(path.join(EVIDENCE_DIR, "geometry.json"), JSON.stringify(manifest, null, 2));
+
+  for (const [key, g] of Object.entries(manifest)) {
+    expect(g.scrollWidth).toBeLessThanOrEqual(g.viewportWidth + 1);
+    expect(g.feedHeight > 0 && g.textarea).toBe(true);
+    expect(key.includes("receipt-settled") ? g.outboxState === "delivered" : true).toBe(true);
+  }
+});

--- a/src/components/conversation/outbox.test.ts
+++ b/src/components/conversation/outbox.test.ts
@@ -15,6 +15,7 @@ import {
   readOutbox,
   resetOutboxForTests,
   seedLaunchOutbox,
+  settleLaunchOutboxDelivered,
   transcriptEchoCount,
   updateOutbox,
   visibleOutbox,
@@ -1138,6 +1139,112 @@ describe("seedLaunchOutbox (P1#2)", () => {
     } finally {
       Date.now = originalDateNow;
     }
+  });
+
+  test("issue 648: a delivered receipt settles a launch bubble whose transcript echo never matches, and it retires on the TTL", () => {
+    const originalDateNow = Date.now;
+    Date.now = () => 5_000;
+    try {
+      const provisional = "spawn:launch_648_structured";
+      const conversation = "conversation_648_structured";
+      const launchId = "launch_648_structured";
+      const displayed = "Прочитай синтетичну розмову у файлі-фікстурі та підсумуй її";
+      const echo = displayed;
+      const deliveredAt = 4_240;
+
+      /* The launch prompt seeds as a delivering, launch-owned bubble. */
+      seedLaunchOutbox(provisional, {
+        id: launchId,
+        text: displayed,
+        images: 0,
+        at: 4_000,
+        echoText: echo,
+      });
+      expect(readOutbox(provisional)[0]).toMatchObject({ state: "delivering", launchOwned: true });
+
+      /* The structured spawn's replayed user record is journaled with SDK / agent
+         provenance, so the transcript renders it as a SYSTEM row — it never lands
+         as a user echo that text-matches the bubble's identity. Simulate exactly
+         that: a transcript whose only user-classified rows carry unrelated text. */
+      publishTranscriptEchoes(provisional, [{
+        generation: "/transcripts/648-structured.jsonl",
+        id: "row:0:0",
+        text: "some unrelated user row that does not match the launch echo",
+      }]);
+
+      /* Without consuming the delivered receipt the bubble is stranded: a
+         launch-owned `delivering` entry has no TTL, so even far past the delivered
+         TTL it is STILL visible — the eternal "Доставляється" ghost of #648. */
+      const wayPastTtl = deliveredAt + OUTBOX_DELIVERED_TTL_MS + 60_000;
+      expect(visibleOutbox(readOutbox(provisional), echoes(), wayPastTtl)
+        .some((entry) => entry.id === launchId)).toBe(true);
+      expect(readOutbox(provisional).find((entry) => entry.id === launchId)?.state).toBe("delivering");
+
+      /* The server-projected delivered receipt settles it to `delivered` with the
+         receipt time as `settledAt`, INDEPENDENT of any echo match. */
+      settleLaunchOutboxDelivered(provisional, { id: launchId, at: 4_000, settledAt: deliveredAt });
+      const settled = readOutbox(provisional).find((entry) => entry.id === launchId);
+      expect(settled?.state).toBe("delivered");
+      expect(settled?.settledAt).toBe(deliveredAt);
+
+      /* Inside the delivered TTL it renders (as delivered); past it, it retires. */
+      expect(visibleOutbox(readOutbox(provisional), echoes(), deliveredAt + 60_000)
+        .some((entry) => entry.id === launchId)).toBe(true);
+      expect(visibleOutbox(readOutbox(provisional), echoes(), wayPastTtl)
+        .some((entry) => entry.id === launchId)).toBe(false);
+
+      /* The settlement is idempotent and monotonic — a re-projected receipt keeps
+         the original settledAt and never revives a fresh delivering entry. */
+      settleLaunchOutboxDelivered(provisional, { id: launchId, at: 4_000, settledAt: deliveredAt + 999 });
+      expect(readOutbox(provisional).find((entry) => entry.id === launchId)?.settledAt).toBe(deliveredAt);
+
+      /* The settlement survives adoption, refresh, and a recurring reseed inside
+         the TTL: the bubble comes back visibly DELIVERED, not delivering. */
+      adoptOutbox(provisional, conversation);
+      resetOutboxForTests();
+      Date.now = () => deliveredAt + 30_000;
+      seedLaunchOutbox(conversation, { id: launchId, text: displayed, images: 0, at: 4_000, echoText: echo });
+      const reseeded = readOutbox(conversation).find((entry) => entry.id === launchId);
+      expect(reseeded?.state).toBe("delivered");
+      expect(reseeded?.settledAt).toBe(deliveredAt);
+
+      /* Past the TTL the launch retires for good and a reseed cannot revive it. */
+      resetOutboxForTests();
+      Date.now = () => deliveredAt + OUTBOX_DELIVERED_TTL_MS;
+      seedLaunchOutbox(conversation, { id: launchId, text: displayed, images: 0, at: 4_000, echoText: echo });
+      expect(visibleOutbox(readOutbox(conversation), echoes(), deliveredAt + OUTBOX_DELIVERED_TTL_MS)
+        .some((entry) => entry.id === launchId)).toBe(false);
+    } finally {
+      Date.now = originalDateNow;
+    }
+  });
+
+  test("issue 648: a delivered receipt for one launch never settles an unrelated launch's slot", () => {
+    const conversation = "conversation_648_isolation";
+    seedLaunchOutbox(conversation, { id: "launch_a", text: "launch A prompt", images: 0, at: 1_000 });
+    /* A receipt addressed to a DIFFERENT launch id must not touch the live slot
+       or the visible bubble — the current launch stays delivering. */
+    settleLaunchOutboxDelivered(conversation, { id: "launch_b", at: 900, settledAt: 950 });
+    expect(readOutbox(conversation).find((entry) => entry.id === "launch_a")?.state).toBe("delivering");
+  });
+
+  test("issue 648: an echo match still wins when it lands before the delivered receipt is consumed", () => {
+    const provisional = "spawn:launch_648_echo_first";
+    const text = "launch prompt that DOES echo as a user row";
+    seedLaunchOutbox(provisional, { id: "launch_echo_first", text, images: 0, at: 1_000 });
+    publishTranscriptEchoes(provisional, [{
+      generation: "/transcripts/648-echo-first.jsonl",
+      id: "row:echo:0",
+      text,
+    }]);
+    const retired = readOutbox(provisional).find((entry) => entry.id === "launch_echo_first");
+    expect(typeof retired?.retiredEchoId).toBe("string");
+    /* A delayed delivered receipt is a no-op on an already echo-retired bubble. */
+    settleLaunchOutboxDelivered(provisional, { id: "launch_echo_first", at: 1_000, settledAt: 2_000 });
+    const after = readOutbox(provisional).find((entry) => entry.id === "launch_echo_first");
+    expect(after?.retiredEchoId).toBe(retired?.retiredEchoId);
+    expect(visibleOutbox(readOutbox(provisional), echoes([text, 1]), 3_000)
+      .some((entry) => entry.id === "launch_echo_first")).toBe(false);
   });
 
   test("issue 626: terminal launch retirement survives both ledgers churning beyond 512 entries", () => {

--- a/src/components/conversation/outbox.ts
+++ b/src/components/conversation/outbox.ts
@@ -634,6 +634,58 @@ export function markOutboxResponded(cardId: string, id: string, at: number): voi
   write(cardId, next);
 }
 
+/**
+ * Settle a launch-owned bubble from the server-projected delivery receipt
+ * (issue #648). A structured / MCP spawn delivers its first message through the
+ * runtime, and the agent journals that user record with SDK / agent provenance —
+ * so the transcript renders it as a system row, never a `user` echo, and the
+ * echo-text retirement path can never fire. The delivered receipt is the
+ * independent proof the prompt reached the agent: it settles the bubble to
+ * `delivered` with the receipt time as `settledAt`, so it renders delivered and
+ * retires on the delivered TTL exactly like a composer-delivered bubble, whether
+ * or not any echo ever matches.
+ *
+ * Idempotent and monotonic. The settlement is also recorded into the durable
+ * current-launch slot, so a compaction reseed inside the TTL restores the
+ * `delivered` state (issue #644) and the slot still retires at the delivered TTL
+ * even after the recent entry is evicted. A launch already responded, retired,
+ * or settled keeps its earlier settlement; a newer launch owning the slot is
+ * left untouched.
+ */
+export function settleLaunchOutboxDelivered(
+  cardId: string,
+  launch: { id: string; at: number; settledAt: number },
+): void {
+  const current = readCurrentLaunch(cardId);
+  if (current && current.id !== launch.id) return;
+  /* Fold the receipt settlement into the durable slot first: this is the only
+     carrier once the recent entry is compacted out, and it is what a within-TTL
+     reseed reads to restore `delivered` rather than a fresh `delivering` entry. */
+  recordCurrentLaunch(cardId, {
+    id: launch.id,
+    at: current?.at ?? launch.at,
+    settledAt: launch.settledAt,
+  });
+  const queue = readOutbox(cardId);
+  const existing = queue.find((item) => item.id === launch.id);
+  if (!existing || !existing.launchOwned) return;
+  if (
+    existing.retiredEchoId
+    || existing.responseStartedAt !== undefined
+    || existing.state === "delivered"
+    || existing.state === "failed"
+  ) {
+    recordCurrentLaunchEntry(cardId, existing);
+    return;
+  }
+  const next = queue.map((item) => (item.id === launch.id
+    ? { ...item, state: "delivered" as const, settledAt: item.settledAt ?? launch.settledAt }
+    : item));
+  const updated = next.find((item) => item.id === launch.id);
+  if (updated) recordCurrentLaunchEntry(cardId, updated);
+  write(cardId, next);
+}
+
 /** Remove an entry outright — the operator cancelled a message that never left. */
 export function cancelOutbox(cardId: string, id: string): void {
   const queue = readOutbox(cardId);

--- a/src/lib/agent/spawnProjection.test.ts
+++ b/src/lib/agent/spawnProjection.test.ts
@@ -350,6 +350,11 @@ test("issue 615 HIGH1: the launch prompt projects from the durable display paylo
     const scanLag = projectLaunchConversations([], snapshot, createdMs + 20_000);
     expect(scanLag.cards).toHaveLength(1);
     expect(scanLag.cards[0]!.spawn).toMatchObject({ prompt: "LLV615_RAW_PROMPT", promptImages: 2, promptEcho: "scaffold\n\nLLV615_RAW_PROMPT" });
+    /* The delivered receipt time is projected so the client can settle the launch
+       bubble even when the transcript echo never matches (issue #648). */
+    const deliveredAt = scanLag.cards[0]!.spawn!.deliveredAt;
+    expect(typeof deliveredAt).toBe("number");
+    expect(Number.isFinite(deliveredAt)).toBe(true);
 
     /* The response that ADOPTS the live transcript stops projecting the prompt —
        the transcript now renders the message, so the facts carry no bubble. */
@@ -360,6 +365,9 @@ test("issue 615 HIGH1: the launch prompt projects from the durable display paylo
     expect(facts.prompt).toBeUndefined();
     expect(facts.promptEcho).toBeUndefined();
     expect(facts.promptImages).toBeUndefined();
+    /* The delivered receipt time survives prompt scrubbing: a materialized window
+       whose echo never matches can still settle the launch bubble (issue #648). */
+    expect(facts.deliveredAt).toBe(deliveredAt);
   } finally {
     fs.rmSync(directory, { recursive: true, force: true });
   }

--- a/src/lib/agent/spawnProjection.ts
+++ b/src/lib/agent/spawnProjection.ts
@@ -82,6 +82,13 @@ function cardState(snapshot: RegistryFile, receipt: SpawnReceipt): StructuredSpa
     state = "binding";
   }
   const launchPrompt = launchPromptOf(receipt, delivery);
+  /* The receipt time the initial message reached the agent (issue #648). Prefer
+     the held delivery's own `deliveredAt`; a launch that completed without a
+     retained delivery record (its text already scrubbed) falls back to the
+     receipt creation time, which still bounds the delivered TTL. */
+  const deliveredAt = delivered
+    ? (Date.parse(delivery?.deliveredAt ?? "") || Date.parse(receipt.createdAt) || undefined)
+    : undefined;
   return {
     launchId: receipt.launchId,
     clientAttemptId: receipt.clientAttemptId,
@@ -90,6 +97,7 @@ function cardState(snapshot: RegistryFile, receipt: SpawnReceipt): StructuredSpa
     initialMessage,
     retrySafe: receipt.state === "failed",
     error: receipt.error,
+    ...(deliveredAt !== undefined ? { deliveredAt } : {}),
     ...(launchPrompt
       ? {
           promptImages: launchPrompt.promptImages,

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -40,6 +40,15 @@ export interface StructuredSpawnCardState {
       draft. The optimistic bubble displays `prompt` (the raw draft) but retires on
       THIS text, so a scaffolded role launch never lingers and never duplicates. */
   promptEcho?: string;
+  /** When the launch's initial message actually reached the agent (ms, issue
+      #648). A structured / MCP spawn journals its first user record with SDK /
+      agent provenance, so the transcript renders it as a system row and the
+      echo-text retirement never fires. This receipt timestamp is the independent
+      settlement proof: the client settles the launch bubble to `delivered` with
+      THIS value as its `settledAt`, so it retires on the delivered TTL even when
+      no echo ever matches. Present once the delivery receipt reports delivered;
+      it survives prompt scrubbing so a materialized window can still settle. */
+  deliveredAt?: number;
 }
 
 /** Current quota wall affecting a hosted conversation. Account provenance


### PR DESCRIPTION
## Problem (#648)

A freshly spawned conversation's launch-prompt bubble renders **"Доставляється"** (delivering) forever on a hard-refreshed client, while the launch receipt chip above it reads **"Перше повідомлення: доставлено"**. The delivered settlement never reaches the outbox bubble.

Root cause (confirmed empirically against the feed parser): a structured / MCP spawn's first user record is journaled with SDK / agent provenance (`promptSource:"sdk"` or `origin:{kind:"agent"|"operator"}`), so `isClaudeProtocolUser` classifies it as a **system row**, not a `user` echo. The launch bubble's only settlement paths were:

- transcript **echo-text retirement** — never fires, because that record is never a `user` echo; and
- the **delivered TTL** — only applies to `delivered` entries, and the bubble is stuck at `delivering`.

So `settledAt` was never observed client-side at all. This is distinct from the within-TTL compaction reseed fixed by #644.

## Fix

Two independent fixes, both inside the launch seam:

1. **Delivered-receipt settlement (echo-independent).** The server projects `deliveredAt` (the delivery receipt time) onto the launch card state — surviving prompt-scrubbing on adoption. `LogFeed` consumes it through the new `settleLaunchOutboxDelivered`, which settles the bubble to `delivered` with the receipt time as `settledAt`, so it renders delivered and retires on the delivered TTL even when no echo ever matches. The settlement folds into the durable current-launch slot, so it survives compaction, within-TTL reseed (#644), adoption, and refresh, and is monotonic (an echo retirement, a response, or a prior settlement always wins; a newer launch owning the slot is untouched).

2. **Echo identity for the replayed record.** `LogFeed` now treats a non-user transcript row that exactly carries a launch-owned bubble's own identity (raw draft or scaffolded echo, issue #615) as that bubble's echo — so the launch's system-row replay retires it cleanly instead of leaving a delivered duplicate on screen for the whole TTL.

## Acceptance

- ✅ A launch whose delivery receipt reports delivered renders delivered and retires on the delivered TTL even when echo matching never fires.
- ✅ Echo identity for structured / MCP spawns matches the actual replayed transcript record (system-row replay retires the bubble).
- ✅ Regression coverage: seed → delivered receipt (no echo match) → bubble delivered → TTL retirement, plus every #626/#644 contract stays green (within-TTL reseed, composer path, delayed echo, repeated text, chronology, unrelated pending survival, TTL retirement permanence).
- ✅ Browser evidence for the receipt-settled-no-echo window at 1280×900 and 390×844.

## Verification

- `outbox`, `spawnProjection`, conversation + feed, parser (incl. large-input stress), session reader, agent/registry suites — green in isolation.
- New `issue648Evidence.browser.test.tsx` + existing `issue626Evidence` / `conversationWindowEvidence` browser suites — green (chromium, production CSS).
- TypeScript `tsc --noEmit` clean; changed-file ESLint clean.
- Trusted-base privacy publication gate: **PASS** (no real operator data in committed test/evidence).
- Production build + MCP bundle succeed.

The only failing tests in the environment are `cli.integration.test.ts` real-tmux/Codex-runtime tests that require live infrastructure not present in the sandbox; they are unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)