### PR TITLE
fix(accounts): terminalize stale delivery-uncertain held deliveries so removal unblocks (#652)

### DIFF
--- a/src/lib/accounts/removal.test.ts
+++ b/src/lib/accounts/removal.test.ts
@@ -9,8 +9,10 @@ process.env.LLV_STATE_DIR = path.join(sandbox, "state");
 
 const { AgentRegistry, setAgentRegistryForTests } = await import("@/lib/agent/registry");
 const { emptyLaunchProfile } = await import("@/lib/accounts/migration/contracts");
+type ViewerConversationId = import("@/lib/accounts/migration/contracts").ViewerConversationId;
 const { procBackend } = await import("@/lib/proc");
 const { accountRemovalBlockers } = await import("./removal");
+const { terminalizeStaleUndeliverableHeldDeliveries } = await import("@/lib/reaperRuntime");
 
 type Registry = InstanceType<typeof AgentRegistry>;
 
@@ -155,6 +157,121 @@ test("a pending migration keeps its conversation current", () => {
   });
 
   expect(accountRemovalBlockers("claude", "work", DAYS_LATER)).toEqual(["current_conversations"]);
+});
+
+/** Production shape of issue #652: an `assigned` queued turn whose attempt
+    started (state `delivery-uncertain`) but never reported an outcome. */
+function uncertainDelivery(store: Registry, conversationId: ViewerConversationId, text: string) {
+  const held = store.holdDelivery(conversationId, text);
+  expect(held.state).toBe("assigned");
+  const uncertain = store.beginDeliveryAttempt(held.id, held.generationId!);
+  expect(uncertain?.state).toBe("delivery-uncertain");
+  return uncertain!;
+}
+
+function settledMigration(store: Registry, conversationId: ViewerConversationId) {
+  store.setConversationMigration(conversationId, {
+    intentId: "intent-652",
+    phase: "rolled-back",
+    targetId: "default",
+    revision: 1,
+    error: null,
+    updatedAt: new Date().toISOString(),
+  });
+}
+
+test("a stale delivery-uncertain delivery on a settled migration no longer blocks removal (issue #652)", () => {
+  const store = registry();
+  const conversation = deadConversation(store, "/accounts/claude/work/projects/-repo/uncertain.jsonl", "work");
+  uncertainDelivery(store, conversation.id, "queued but never resolved");
+  settledMigration(store, conversation.id);
+
+  // Reproduces the production block (issue #652): a days-old delivery-uncertain,
+  // a rolled-back migration, and no live host — must stop counting as current.
+  expect(accountRemovalBlockers("claude", "work", DAYS_LATER)).toEqual([]);
+});
+
+test("a delivery-uncertain delivery still blocks during its recovery grace", () => {
+  const store = registry();
+  const conversation = deadConversation(store, "/accounts/claude/work/projects/-repo/fresh.jsonl", "work");
+  uncertainDelivery(store, conversation.id, "attempt just started");
+  settledMigration(store, conversation.id);
+
+  // Evaluated at the current time, still inside the recovery grace window.
+  expect(accountRemovalBlockers("claude", "work")).toEqual(["current_conversations"]);
+});
+
+test("a delivery-uncertain delivery on an unsettled migration still blocks", () => {
+  const store = registry();
+  const conversation = deadConversation(store, "/accounts/claude/work/projects/-repo/moving-uncertain.jsonl", "work");
+  uncertainDelivery(store, conversation.id, "attempt in flight");
+  store.setConversationMigration(conversation.id, {
+    intentId: "intent-3",
+    phase: "preparing",
+    targetId: "default",
+    revision: 1,
+    error: null,
+    updatedAt: new Date().toISOString(),
+  });
+
+  expect(accountRemovalBlockers("claude", "work", DAYS_LATER)).toEqual(["current_conversations"]);
+});
+
+test("a delivery-uncertain delivery with a live host still blocks", () => {
+  const store = registry();
+  const artifactPath = "/accounts/claude/work/projects/-repo/live-uncertain.jsonl";
+  const conversation = deadConversation(store, artifactPath, "work");
+  uncertainDelivery(store, conversation.id, "attempt against a live retry target");
+  settledMigration(store, conversation.id);
+  store.upsert({
+    key: { engine: "claude", sessionId: "55555555-5555-5555-5555-555555555555" },
+    artifactPath,
+    cwd: "/repo", accountId: "work", status: "live", host: liveTmuxHost(),
+    claimEpoch: 0, claimOwner: null, pendingAction: null,
+  });
+
+  expect(accountRemovalBlockers("claude", "work", DAYS_LATER)).toEqual(["live_sessions", "current_conversations"]);
+});
+
+test("committed and rolled-back migrations both settle a delivery-uncertain delivery", () => {
+  const store = registry();
+  const conversation = deadConversation(store, "/accounts/claude/work/projects/-repo/committed-uncertain.jsonl", "work");
+  uncertainDelivery(store, conversation.id, "queued but never resolved");
+  store.setConversationMigration(conversation.id, {
+    intentId: "intent-4",
+    phase: "committed",
+    targetId: "default",
+    revision: 1,
+    error: null,
+    updatedAt: new Date().toISOString(),
+  });
+
+  expect(accountRemovalBlockers("claude", "work", DAYS_LATER)).toEqual([]);
+});
+
+test("the reaper terminalizes a stale delivery-uncertain delivery so it stops being owed (issue #652)", () => {
+  const store = registry();
+  const conversation = deadConversation(store, "/accounts/claude/work/projects/-repo/reaped.jsonl", "work");
+  const uncertain = uncertainDelivery(store, conversation.id, "queued but never resolved");
+  settledMigration(store, conversation.id);
+
+  const failed = terminalizeStaleUndeliverableHeldDeliveries(store, Date.now() + 3 * 24 * 60 * 60 * 1000);
+
+  expect(failed).toEqual([uncertain.id]);
+  expect(store.readOnlySnapshot().heldDeliveries[uncertain.id]?.state).toBe("failed");
+  // Removal stays clear once the registry no longer carries it as owed.
+  expect(accountRemovalBlockers("claude", "work", DAYS_LATER)).toEqual([]);
+});
+
+test("the reaper leaves an in-grace or in-flight delivery-uncertain delivery owed", () => {
+  const store = registry();
+  const conversation = deadConversation(store, "/accounts/claude/work/projects/-repo/kept.jsonl", "work");
+  const uncertain = uncertainDelivery(store, conversation.id, "attempt just started");
+  settledMigration(store, conversation.id);
+
+  // Within the recovery grace: nothing terminalized.
+  expect(terminalizeStaleUndeliverableHeldDeliveries(store, Date.now())).toEqual([]);
+  expect(store.readOnlySnapshot().heldDeliveries[uncertain.id]?.state).toBe("delivery-uncertain");
 });
 
 test("a committed migration leaves its conversation removable", () => {

--- a/src/lib/agent/accountLiveness.ts
+++ b/src/lib/agent/accountLiveness.ts
@@ -13,7 +13,15 @@ const HOSTED_ENTRY_STATUSES = new Set<AgentRegistryEntry["status"]>(["starting",
 const OPEN_RECEIPT_STATES = new Set<SpawnReceipt["state"]>(["starting", "pane-bound", "host-verified", "prompt-delivered", "path-pending"]);
 /** Migration phases with nothing left in flight. */
 const SETTLED_MIGRATION_PHASES = new Set(["committed", "rolled-back"]);
-/** Held-delivery states where the Viewer still owes the conversation a message. */
+/**
+ * Held-delivery states where the Viewer still owes the conversation a message.
+ *
+ * `held`/`assigned` are unconditionally in flight: the queued turn has not been
+ * attempted yet. `delivery-uncertain` is conditional (issue #652): an attempt
+ * started but its outcome is unknown, and once its owning migration has settled
+ * and the conversation has no live host/receipt it can never resolve, so past a
+ * recovery grace it stops counting as live and the reaper terminalizes it.
+ */
 const UNDELIVERED_DELIVERY_STATES = new Set(["held", "assigned", "delivery-uncertain"]);
 
 /**
@@ -132,7 +140,15 @@ export function conversationIsLive(
   const owns = (id: ViewerConversationId) => canonicalId(file, id) === conversation.id;
   for (const delivery of Object.values(file.heldDeliveries)) {
     if (!UNDELIVERED_DELIVERY_STATES.has(delivery.state)) continue;
-    if (owns(delivery.conversationId) || owns(delivery.runtimeConversationId)) return true;
+    if (!owns(delivery.conversationId) && !owns(delivery.runtimeConversationId)) continue;
+    /* held/assigned: the queued turn has not been attempted — always current. */
+    if (delivery.state !== "delivery-uncertain") return true;
+    /* delivery-uncertain (issue #652): reaching here means this conversation
+       already has no live host and a settled migration (the checks above
+       returned otherwise). The attempt can still recover only while its grace
+       holds; a live receipt below is the one remaining in-flight signal, so a
+       grace-expired uncertain delivery contributes nothing on its own. */
+    if (withinGrace(delivery.createdAt, probe)) return true;
   }
   for (const receipt of Object.values(file.receipts)) {
     if (!owns(receipt.conversationId)) continue;
@@ -171,6 +187,41 @@ export function accountHasLiveSessions(
     if (receiptIsLive(file, receipt, probe)) return true;
   }
   return false;
+}
+
+/**
+ * Held deliveries that can never resolve and no longer keep any conversation
+ * current (issue #652): a `delivery-uncertain` attempt past its recovery grace
+ * whose canonical conversation is not live — its owning migration has settled
+ * and it owns no live host, entry, or receipt. This is the exact set that
+ * `conversationIsLive` has already stopped counting as live, surfaced so the
+ * reaper can terminalize it durably and blocker evaluation and the reaper agree
+ * on which deliveries are dead.
+ */
+export function staleUndeliverableHeldDeliveryIds(
+  file: RegistryFile,
+  options: AccountLivenessOptions = {},
+): string[] {
+  const probe = livenessProbe(options);
+  const pathsByEngine = new Map<ManagedAccountEngine, Set<string>>();
+  const livePathsFor = (engine: ManagedAccountEngine): Set<string> => {
+    let paths = pathsByEngine.get(engine);
+    if (!paths) {
+      paths = liveEntryPaths(file, engine, probe);
+      pathsByEngine.set(engine, paths);
+    }
+    return paths;
+  };
+  const ids: string[] = [];
+  for (const delivery of Object.values(file.heldDeliveries)) {
+    if (delivery.state !== "delivery-uncertain") continue;
+    if (withinGrace(delivery.createdAt, probe)) continue;
+    const conversation = file.conversations[canonicalId(file, delivery.conversationId)];
+    if (!conversation) continue;
+    if (conversationIsLive(file, conversation, livePathsFor(conversation.engine), probe)) continue;
+    ids.push(delivery.id);
+  }
+  return ids;
 }
 
 /** Conversations whose latest generation is genuinely live on the account. */

--- a/src/lib/reaperRuntime.ts
+++ b/src/lib/reaperRuntime.ts
@@ -3,6 +3,7 @@ import crypto from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 
+import { staleUndeliverableHeldDeliveryIds } from "@/lib/agent/accountLiveness";
 import { agentRegistry, type AgentRegistry, type RegistryFile, type TmuxHostEvidence } from "@/lib/agent/registry";
 import { readTranscriptHosts, type TranscriptHost, type TranscriptHostSnapshot } from "@/lib/agent/transcriptHost";
 import { boardFor } from "@/lib/board/store";
@@ -799,6 +800,26 @@ export interface ReaperActuationOverrides {
   terminalizeStaleSpawns?: typeof terminalizeStaleStructuredSpawns;
 }
 
+/** Fails every held delivery the liveness contract has abandoned (#652). Each
+    settle is one guarded registry mutation, so a race that re-settled a delivery
+    since the snapshot is a no-op rather than a clobber. Returns the ids failed. */
+export function terminalizeStaleUndeliverableHeldDeliveries(
+  registry: AgentRegistry,
+  now: number = Date.now(),
+): string[] {
+  const ids = staleUndeliverableHeldDeliveryIds(registry.readOnlySnapshot(), { now: () => now });
+  const terminalized: string[] = [];
+  for (const id of ids) {
+    const settled = registry.recordDeliveryOutcome(
+      id,
+      "failed",
+      "delivery-uncertain abandoned: owning migration settled with no live host or receipt (#652)",
+    );
+    if (settled.state === "failed") terminalized.push(id);
+  }
+  return terminalized;
+}
+
 export async function runReaperCycle(options: {
   registry?: AgentRegistry;
   hosts: TranscriptHost[];
@@ -808,6 +829,19 @@ export async function runReaperCycle(options: {
 }): Promise<ReaperReport> {
   const registry = options.registry ?? agentRegistry();
   const now = options.now ?? Date.now();
+  /* Stale undeliverable held-delivery convergence (#652): a delivery-uncertain
+     attempt whose owning migration has settled and whose conversation has no
+     live host/receipt can never resolve, yet it keeps counting as an owed turn
+     and blocks account removal forever. The reaper cycle terminalizes exactly
+     what `conversationIsLive` has already stopped counting as live, so the
+     registry stops carrying it as owed. Registry hygiene, never a process kill,
+     so it runs regardless of `LLV_REAPER_ENABLED`; failure never blocks the
+     reaper. */
+  try {
+    terminalizeStaleUndeliverableHeldDeliveries(registry, now);
+  } catch (error) {
+    console.error("[reaper] stale undeliverable held-delivery convergence failed", error);
+  }
   /* Stale structured launch convergence (#334): the reaper cycle is the
      while-running seam that turns dead-evidence pending receipts terminal, so
      a permanent spinner no longer waits for a replay POST or a restart. The


### PR DESCRIPTION
Closes #652.

## Problem

`DELETE /api/accounts/claude` for a managed account returned `409` with blockers `["current_conversations"]`, caused solely by a `delivery-uncertain` held delivery (attempts 9, 6 days old, `accountId: null`) on a conversation whose migration was **rolled-back** (settled) and whose latest generation was an unhosted rollout — no live target, no retry in flight. `UNDELIVERED_DELIVERY_STATES` in `src/lib/agent/accountLiveness.ts` counted `delivery-uncertain` unconditionally, and nothing ever terminalized it.

## Fix

1. **`delivery-uncertain` stops counting as live once it can never resolve.** `held`/`assigned` remain unconditionally in flight (the queued turn was never attempted). A `delivery-uncertain` delivery only keeps its conversation current while a recovery grace holds, or while the conversation is otherwise live (unsettled migration, live host, or open receipt) — reaching the delivery loop in `conversationIsLive` already guarantees a settled migration and no live host, so past the grace it contributes nothing on its own. The grace mirrors the reaper's `UNPROVEN_LAUNCH_GRACE_MS` style so blocker evaluation and the reaper agree on when a delivery is dead.

2. **Durable terminalization via the reaper.** `staleUndeliverableHeldDeliveryIds` surfaces exactly the set `conversationIsLive` has abandoned; a new `runReaperCycle` pre-pass (`terminalizeStaleUndeliverableHeldDeliveries`) fails those deliveries. It is registry hygiene, never a process kill, so it runs regardless of `LLV_REAPER_ENABLED` and its failure never blocks the reaper. The registry stops carrying the delivery as owed — no manual surgery.

3. **Genuinely in-flight deliveries still block exactly as today** — `held`/`assigned`, and `delivery-uncertain` with an unsettled migration, a live host, or inside its recovery grace. Explicit tests cover each.

4. **The DELETE route and `retireAccount` keep using the shared `accountLiveness` definition** unchanged, so #643 transcript preservation holds.

## Tests

Added to `src/lib/accounts/removal.test.ts` (TDD, red-first against production shape):
- stale `delivery-uncertain` on a settled migration no longer blocks removal
- still blocks during the recovery grace
- still blocks on an unsettled migration
- still blocks with a live host
- committed and rolled-back migrations both settle it
- the reaper terminalizes it durably (state → `failed`, removal stays clear)
- the reaper leaves an in-grace / in-flight delivery owed

## Verification

- `bun test` — accounts, removal, migration, registry, and reaper-adjacent suites pass (one pre-existing flaky interprocess timing race and Next `route.test.ts` `next/server` resolution are unrelated and fail identically on clean `main`).
- `bunx tsc --noEmit` — clean (0 errors with devDeps installed).
- ESLint on changed files — 0 errors (one pre-existing unrelated warning).
- `bun run privacy:check` — PASS.
- `bun run build` — production build succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)