### PR TITLE
Kill the delivering ghost class: terminalize failed-spawn held deliveries + stop cross-conversation outbox leak (#653)

### DIFF
--- a/evidence/issue-653/geometry.json
+++ b/evidence/issue-653/geometry.json
@@ -1,0 +1,26 @@
+{
+  "foreign-leak-suppressed-desktop": {
+    "scrollWidth": 1280,
+    "viewportWidth": 1280,
+    "outboxEntries": 0,
+    "foreignPromptVisible": false
+  },
+  "own-launch-renders-desktop": {
+    "scrollWidth": 1280,
+    "viewportWidth": 1280,
+    "outboxEntries": 1,
+    "foreignPromptVisible": true
+  },
+  "foreign-leak-suppressed-mobile-390": {
+    "scrollWidth": 390,
+    "viewportWidth": 390,
+    "outboxEntries": 0,
+    "foreignPromptVisible": false
+  },
+  "own-launch-renders-mobile-390": {
+    "scrollWidth": 390,
+    "viewportWidth": 390,
+    "outboxEntries": 1,
+    "foreignPromptVisible": true
+  }
+}

--- a/src/components/LogFeed.tsx
+++ b/src/components/LogFeed.tsx
@@ -130,6 +130,16 @@ export function LogFeed({ file, showSvc, lineFilter, onStatus, paused, follow, s
      the launch that is still becoming it (issue #569) — the same chips either
      way, because it is the same window. */
   const launch = file?.launch ?? file?.spawn ?? null;
+  /* Pane ownership by durable conversation id (issue #653): a launch bubble is
+     seeded/settled/rendered ONLY when it belongs to THIS pane's conversation. A
+     launch whose own conversation id differs from this file's is a foreign bubble
+     (its pane's structured entry may have gone dead) and must never leak in. When
+     either id is absent (a path-only card, or a legacy payload with no launch
+     conversation id) the check cannot fire, preserving prior behaviour. */
+  const paneConversationId = file?.conversationId ?? null;
+  const launchOwnsThisPane = !launch?.conversationId
+    || !paneConversationId
+    || launch.conversationId === paneConversationId;
   /* Live streaming text: `delta` events from the structured host render the
      in-flight assistant reply immediately, ahead of the transcript flush. The
      host is resolved by conversation identity FIRST (round-1 P1#3): during
@@ -459,7 +469,7 @@ export function LogFeed({ file, showSvc, lineFilter, onStatus, paused, follow, s
      idempotent with the composer's own seed (no duplicate), survives a refresh,
      folds through transcript adoption, and retires on its transcript echo. */
   useEffect(() => {
-    if (!memoryKey || !launch?.launchId) return;
+    if (!memoryKey || !launch?.launchId || !launchOwnsThisPane) return;
     const promptText = launch.prompt ?? "";
     const promptImages = launch.promptImages ?? 0;
     if (!promptText.trim() && !promptImages) return;
@@ -472,8 +482,11 @@ export function LogFeed({ file, showSvc, lineFilter, onStatus, paused, follow, s
          draft but retires on the delivered (possibly scaffolded) transcript
          echo. Reconciled onto a composer-seeded bubble under the same id. */
       ...(launch.promptEcho ? { echoText: launch.promptEcho } : {}),
+      /* Stamp the launch's durable conversation as the bubble's owner so a stale
+         copy under another pane's key is filtered at render (issue #653). */
+      ...(launch.conversationId ? { owner: launch.conversationId } : {}),
     });
-  }, [memoryKey, launch?.launchId, launch?.prompt, launch?.promptImages, launch?.promptAt, launch?.promptEcho]);
+  }, [memoryKey, launch?.launchId, launch?.prompt, launch?.promptImages, launch?.promptAt, launch?.promptEcho, launch?.conversationId, launchOwnsThisPane]);
   /* Settle the launch bubble from the delivery receipt the server projects
      (issue #648), independent of any transcript echo. A structured / MCP spawn's
      first message is journaled as a system row (SDK / agent provenance), so echo
@@ -483,15 +496,18 @@ export function LogFeed({ file, showSvc, lineFilter, onStatus, paused, follow, s
      "delivering" forever. Keyed on the launch id and the receipt time only, so it
      still fires on a materialized window that has stripped the prompt fields. */
   useEffect(() => {
-    if (!memoryKey || !launch?.launchId) return;
+    if (!memoryKey || !launch?.launchId || !launchOwnsThisPane) return;
     if (launch.initialMessage !== "delivered" || launch.deliveredAt === undefined) return;
     settleLaunchOutboxDelivered(memoryKey, {
       id: launch.launchId,
       at: launch.promptAt ?? launch.deliveredAt,
       settledAt: launch.deliveredAt,
     });
-  }, [memoryKey, launch?.launchId, launch?.initialMessage, launch?.deliveredAt, launch?.promptAt]);
-  const pendingOutbox = file ? visibleOutbox(outbox, transcriptEchoCounts, nowMs()) : [];
+  }, [memoryKey, launch?.launchId, launch?.initialMessage, launch?.deliveredAt, launch?.promptAt, launchOwnsThisPane]);
+  /* Render only bubbles owned by this pane's conversation (issue #653). memoryKey
+     is the durable conversation id when the payload carries one; a foreign
+     launch bubble stamped with another conversation id is dropped here. */
+  const pendingOutbox = file ? visibleOutbox(outbox, transcriptEchoCounts, nowMs(), memoryKey ?? undefined) : [];
   useEffect(() => {
     if (!memoryKey || !file) return;
     adoptCanonicalAssistantClaims(file.path, memoryKey);

--- a/src/components/conversation/issue653Evidence.browser.test.tsx
+++ b/src/components/conversation/issue653Evidence.browser.test.tsx
@@ -1,0 +1,221 @@
+import { afterAll, beforeEach, afterEach, expect, test } from "bun:test";
+import { act } from "react";
+import { installActEnv } from "@/test-helpers/actEnv";
+import fs from "node:fs";
+import path from "node:path";
+import { Window } from "happy-dom";
+import { createRoot } from "react-dom/client";
+import { chromium, type Browser } from "playwright-core";
+
+import type { FileEntry, StructuredSpawnCardState } from "@/lib/types";
+import { setLocale } from "@/lib/i18n";
+
+import { BranchPane } from "@/components/BranchPane";
+import { resetOutboxForTests } from "./outbox";
+
+/**
+ * Browser-rendered evidence for issue #653 (defect 1): a launch bubble keyed to a
+ * DIFFERENT conversation must never leak into an unrelated pane — the exact
+ * production failure where a failed reviewer spawn's "Доставляється" bubble
+ * appeared inside the #621 voice builder's pane after that pane's own structured
+ * entry went dead. Pane ownership is now keyed on the durable conversation id, so
+ * a foreign launch (its `conversationId` differs from this pane's) is neither
+ * seeded nor rendered. A same-conversation launch (the control) still renders.
+ * Captured at desktop (1280×900) and 390px with the real production CSS.
+ */
+
+const EVIDENCE_DIR = path.join(process.cwd(), "evidence", "issue-653");
+const CSS_DIR = path.join(process.cwd(), ".next", "static", "css");
+
+function productionCss(): string {
+  const files = fs.existsSync(CSS_DIR) ? fs.readdirSync(CSS_DIR).filter((name) => name.endsWith(".css")) : [];
+  return files.map((name) => fs.readFileSync(path.join(CSS_DIR, name), "utf8")).join("\n");
+}
+
+const dom = new Window({ url: "http://localhost/" });
+installActEnv();
+let mobile = false;
+Object.assign(globalThis, {
+  window: dom,
+  document: dom.document,
+  navigator: dom.navigator,
+  sessionStorage: dom.sessionStorage,
+  localStorage: dom.localStorage,
+  Node: dom.Node,
+  HTMLElement: dom.HTMLElement,
+  HTMLButtonElement: dom.HTMLButtonElement,
+  HTMLTextAreaElement: dom.HTMLTextAreaElement,
+  Event: dom.Event,
+  CustomEvent: dom.CustomEvent,
+  MouseEvent: dom.MouseEvent,
+  KeyboardEvent: dom.KeyboardEvent,
+  ResizeObserver: class { observe() {} unobserve() {} disconnect() {} },
+  IntersectionObserver: undefined,
+  requestAnimationFrame: dom.requestAnimationFrame.bind(dom),
+  cancelAnimationFrame: dom.cancelAnimationFrame.bind(dom),
+});
+(dom as unknown as { matchMedia(q: string): unknown }).matchMedia = (q: string) => ({
+  matches: q.includes("max-width: 767px") ? mobile : q.includes("pointer: coarse") ? mobile : false,
+  media: q,
+  addEventListener() {},
+  removeEventListener() {},
+});
+
+let browser: Browser;
+const originalDateNow = Date.now;
+const NOW = Date.parse("2026-07-24T11:58:00.000Z");
+const PROMPT_AT = Date.parse("2026-07-24T08:07:37.000Z");
+
+beforeEach(() => {
+  dom.sessionStorage.clear();
+  resetOutboxForTests();
+  setLocale("uk");
+  Date.now = () => NOW;
+});
+afterEach(() => {
+  document.body.replaceChildren();
+  mobile = false;
+});
+afterAll(async () => {
+  await browser?.close();
+  Date.now = originalDateNow;
+});
+
+/* The pane's own conversation (issue #621 voice builder), whose structured entry
+   went dead at the deploy cutover. */
+const PANE_CONVERSATION = "conversation_0d5a6c49";
+/* The foreign reviewer conversation (PR #618 round 2) whose failed spawn owns the
+   leaked launch bubble. Synthetic prompt text — no real operator content. */
+const FOREIGN_CONVERSATION = "conversation_64a866e0";
+const FOREIGN_PROMPT = "Fresh-context review, round 2, for PR #618 (synthetic fixture text)";
+
+function baseFile(over: Partial<FileEntry>): FileEntry {
+  return {
+    path: "/repo/pipeline-f8c801d8/00031cd0.jsonl",
+    root: "claude-projects",
+    name: "00031cd0.jsonl",
+    project: "live-log-viewer",
+    title: "Builder · voice (#621)",
+    engine: "claude",
+    kind: "session",
+    fmt: "claude",
+    parent: null,
+    mtime: 1,
+    size: 0,
+    /* The pane's own structured entry is dead (the deploy cutover). */
+    activity: "idle",
+    activityReason: "registry_terminal",
+    proc: "killed",
+    pid: null,
+    model: "claude-opus-4-8",
+    pendingQuestion: null,
+    waitingInput: null,
+    conversationId: PANE_CONVERSATION,
+    ...over,
+  } as FileEntry;
+}
+
+/* The leaked bubble as the server projects it onto a launch card: a failed
+   reviewer spawn whose durable conversation is the FOREIGN one. */
+const FOREIGN_LAUNCH: StructuredSpawnCardState = {
+  launchId: "launch_653_foreign",
+  clientAttemptId: null, accountId: "acct_reviewer", conversationId: FOREIGN_CONVERSATION,
+  state: "queued", initialMessage: "queued", retrySafe: false, error: null,
+  promptImages: 0, promptAt: PROMPT_AT, prompt: FOREIGN_PROMPT, promptEcho: FOREIGN_PROMPT,
+};
+/* The control: the SAME launch facts, but owned by this pane's conversation. It
+   is a legitimate delivering launch bubble and must render. */
+const OWN_LAUNCH: StructuredSpawnCardState = {
+  ...FOREIGN_LAUNCH, conversationId: PANE_CONVERSATION,
+};
+
+const STATES: Array<{ id: string; file: FileEntry; expectEntries: number }> = [
+  { id: "foreign-leak-suppressed", file: baseFile({ launch: FOREIGN_LAUNCH }), expectEntries: 0 },
+  { id: "own-launch-renders", file: baseFile({ launch: OWN_LAUNCH }), expectEntries: 1 },
+];
+
+const VIEWPORTS: Array<{ id: string; mobile: boolean; width: number; height: number }> = [
+  { id: "desktop", mobile: false, width: 1280, height: 900 },
+  { id: "mobile-390", mobile: true, width: 390, height: 844 },
+];
+
+async function renderWindow(node: React.ReactElement): Promise<string> {
+  const host = document.createElement("div");
+  document.body.append(host);
+  const root = createRoot(host);
+  await act(async () => {
+    root.render(node);
+    await new Promise((r) => setTimeout(r, 0));
+  });
+  await act(async () => {
+    await new Promise((r) => setTimeout(r, 0));
+  });
+  const html = host.innerHTML;
+  await act(async () => root.unmount());
+  host.remove();
+  return html;
+}
+
+const CSS = productionCss();
+
+function pageHtml(inner: string, width: number): string {
+  return `<!doctype html><html><head><meta charset="utf-8"><style>${CSS}
+    html,body{margin:0;padding:0;background:var(--color-canvas,#fff);}
+    #evidence-host{display:flex;flex-direction:column;width:${width}px;height:100vh;overflow:hidden;}
+    </style></head><body><div id="evidence-host">${inner}</div></body></html>`;
+}
+
+interface Geometry {
+  scrollWidth: number;
+  viewportWidth: number;
+  outboxEntries: number;
+  foreignPromptVisible: boolean;
+}
+
+test("issue 653 evidence: a foreign launch bubble never leaks into a dead-entry pane at desktop and 390px", async () => {
+  expect(CSS.length).toBeGreaterThan(10_000);
+  fs.mkdirSync(EVIDENCE_DIR, { recursive: true });
+  browser = await chromium.launch({ executablePath: chromium.executablePath() });
+  const manifest: Record<string, Geometry> = {};
+
+  for (const viewport of VIEWPORTS) {
+    for (const state of STATES) {
+      mobile = viewport.mobile;
+      resetOutboxForTests();
+      dom.sessionStorage.clear();
+
+      const inner = await renderWindow(<BranchPane file={state.file} tasks={[]} isRoot />);
+
+      const page = await browser.newPage({ viewport: { width: viewport.width, height: viewport.height }, deviceScaleFactor: 1 });
+      await page.setContent(pageHtml(inner, viewport.width), { waitUntil: "load" });
+      const key = `${state.id}-${viewport.id}`;
+      fs.writeFileSync(path.join(EVIDENCE_DIR, `${key}.html`), pageHtml(inner, viewport.width));
+      await page.screenshot({ path: path.join(EVIDENCE_DIR, `${key}.png`) });
+
+      const geometry = await page.evaluate((prompt) => {
+        return {
+          scrollWidth: document.documentElement.scrollWidth,
+          viewportWidth: window.innerWidth,
+          outboxEntries: document.querySelectorAll("[data-outbox-entry]").length,
+          foreignPromptVisible: document.body.textContent?.includes(prompt) === true,
+        } as Geometry;
+      }, FOREIGN_PROMPT);
+      await page.close();
+      manifest[key] = geometry;
+
+      expect(geometry.scrollWidth).toBeLessThanOrEqual(viewport.width + 1);
+      expect(geometry.outboxEntries).toBe(state.expectEntries);
+    }
+  }
+
+  /* The heart of #653: the foreign bubble is gone from the dead pane at both
+     widths, while the same launch owned by this pane still renders. */
+  expect(manifest["foreign-leak-suppressed-desktop"]!.outboxEntries).toBe(0);
+  expect(manifest["foreign-leak-suppressed-desktop"]!.foreignPromptVisible).toBe(false);
+  expect(manifest["foreign-leak-suppressed-mobile-390"]!.outboxEntries).toBe(0);
+  expect(manifest["foreign-leak-suppressed-mobile-390"]!.foreignPromptVisible).toBe(false);
+  expect(manifest["own-launch-renders-desktop"]!.outboxEntries).toBe(1);
+  expect(manifest["own-launch-renders-desktop"]!.foreignPromptVisible).toBe(true);
+
+  fs.writeFileSync(path.join(EVIDENCE_DIR, "geometry.json"), JSON.stringify(manifest, null, 2));
+});

--- a/src/components/conversation/outbox.test.ts
+++ b/src/components/conversation/outbox.test.ts
@@ -1606,6 +1606,44 @@ describe("seedLaunchOutbox (P1#2)", () => {
   });
 });
 
+describe("issue 653: pane ownership by durable conversation id", () => {
+  const withOwner = (over: Partial<OutboxEntry>): OutboxEntry => ({
+    id: "ccb088d2", text: "Round 2 review PR #618", images: 0, at: 1_000,
+    state: "delivering", launchOwned: true, ...over,
+  });
+
+  test("a foreign-owned launch bubble is never rendered in an unrelated pane", () => {
+    const queue = [withOwner({ owner: "conversation_A" })];
+    /* Conversation B's pane (dead structured entry): the leaked bubble owned by A
+       must not render. */
+    expect(visibleOutbox(queue, echoes(), 5_000, "conversation_B")).toEqual([]);
+    /* A's own pane still shows it. */
+    expect(visibleOutbox(queue, echoes(), 5_000, "conversation_A").map((entry) => entry.id)).toEqual(["ccb088d2"]);
+  });
+
+  test("owner-less composer sends and same-owner launches still render", () => {
+    const composer = { id: "k1", text: "hi", images: 0, at: 1, state: "queued" as const };
+    const own = withOwner({ owner: "conversation_B" });
+    expect(visibleOutbox([composer, own], echoes(), 5_000, "conversation_B").map((entry) => entry.id))
+      .toEqual(["k1", "ccb088d2"]);
+    /* No pane owner supplied (legacy call sites) → no filtering at all. */
+    expect(visibleOutbox([withOwner({ owner: "conversation_A" })], echoes(), 5_000).map((entry) => entry.id))
+      .toEqual(["ccb088d2"]);
+  });
+
+  test("seedLaunchOutbox stamps the owner and the foreign pane filters it durably", () => {
+    /* A prior mis-seed (or a payload that carried a foreign launch) left A's
+       launch bubble in B's queue. */
+    seedLaunchOutbox("conversation_B", {
+      id: "ccb088d2", text: "Round 2 review PR #618", images: 0, at: 1_000, owner: "conversation_A",
+    });
+    const queue = readOutbox("conversation_B");
+    expect(queue[0]!.owner).toBe("conversation_A");
+    /* B's pane renders nothing; the entry is durably filtered by owner. */
+    expect(visibleOutbox(queue, echoes(), 5_000, "conversation_B")).toEqual([]);
+  });
+});
+
 test("adoption moves a queue onto the materialized conversation identity idempotently", () => {
   submit("spawn:launch", "k1", "queued into the launch window");
   /* The launch materializes into its conversation; the queue rides along. */

--- a/src/components/conversation/outbox.ts
+++ b/src/components/conversation/outbox.ts
@@ -71,6 +71,13 @@ export interface OutboxEntry {
       retirement is monotonic across tail eviction, adoption, and refresh. */
   retiredEchoId?: string;
   retiredAt?: number;
+  /** The durable conversation identity that OWNS this bubble (issue #653). A
+      launch-owned bubble records the launch's own conversation id here, so a pane
+      renders it ONLY inside that conversation — never leaked into an unrelated
+      pane whose structured entry went dead. Absent for ordinary composer sends,
+      which are enqueued into their own pane's queue and so are inherently owned
+      by it; absence therefore renders as before. */
+  owner?: string;
 }
 
 /**
@@ -538,7 +545,7 @@ export function enqueueOutbox(cardId: string, entry: Omit<OutboxEntry, "state">)
  */
 export function seedLaunchOutbox(
   cardId: string,
-  entry: { id: string; text: string; images: number; at: number; echoText?: string },
+  entry: { id: string; text: string; images: number; at: number; echoText?: string; owner?: string },
 ): void {
   if (!entry.text.trim() && !entry.images) return;
   const currentLaunch = readCurrentLaunch(cardId);
@@ -1016,10 +1023,18 @@ export function visibleOutbox(
   queue: readonly OutboxEntry[],
   transcriptEchoCounts: TranscriptEchoCounts,
   nowMs: number,
+  paneOwner?: string,
 ): OutboxEntry[] {
   const consumed = new Map<string, number>();
   const visible: OutboxEntry[] = [];
   for (const entry of queue) {
+    /* Pane ownership by durable conversation id (issue #653): a bubble that
+       records an owner renders ONLY in that conversation's pane. This keeps a
+       launch bubble keyed to another conversation from leaking into an unrelated
+       pane (e.g. when that pane's own structured entry went dead). An owner-less
+       entry — an ordinary composer send — is inherently owned by the pane whose
+       queue holds it, so it renders as before. */
+    if (paneOwner !== undefined && entry.owner !== undefined && entry.owner !== paneOwner) continue;
     /* A bubble retires on ITS canonical transcript echo — the delivered text,
        which for a role launch is the scaffold-plus-draft carried on `echoText`,
        not the raw draft it displays (issue #615). */

--- a/src/lib/agent/failedSpawnDelivery.test.ts
+++ b/src/lib/agent/failedSpawnDelivery.test.ts
@@ -1,0 +1,178 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, expect, test } from "bun:test";
+
+import { emptyLaunchProfile, type HeldDelivery } from "@/lib/accounts/migration/contracts";
+import { runReaperCycle } from "@/lib/reaperRuntime";
+
+import { AgentRegistry } from "./registry";
+import { conversationIsLive, livenessProbe } from "./accountLiveness";
+import { projectLaunchConversations } from "./spawnProjection";
+
+const originalStateDir = process.env.LLV_STATE_DIR;
+afterEach(() => {
+  if (originalStateDir === undefined) delete process.env.LLV_STATE_DIR;
+  else process.env.LLV_STATE_DIR = originalStateDir;
+});
+
+/**
+ * Issue #653, defect 2: a held delivery whose spawn receipt reached the terminal
+ * `failed` state can never deliver its first message, yet its `spawn_<launchId>`
+ * reservation stays `held` forever — it keeps counting as an owed delivery and
+ * keeps the ghost "delivering" bubble alive. The registry must terminalize it
+ * durably (failed), race-safe against a concurrent delivery attempt (only a
+ * still-`held` reservation is touched).
+ */
+
+interface FailedSpawnFixture {
+  registry: AgentRegistry;
+  launchId: string;
+  conversationId: string;
+  deliveryId: string;
+  dir: string;
+}
+
+/** A structured launch that failed at 08:07Z with its initial `spawn_<launchId>`
+    message still `held`, attempts 0 — the exact production shape from the issue. */
+function makeFailedSpawnWithHeldDelivery(): FailedSpawnFixture {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "llv-failed-spawn-delivery-"));
+  const filename = path.join(dir, "agent-registry.json");
+  const cwd = path.join(dir, "pipeline-f9424665");
+  const registry = new AgentRegistry(filename, undefined, undefined, { sqliteMode: "off" });
+  /* The reviewer conversation exists (it materialized a transcript) but its host
+     is gone; only the stuck initial delivery keeps it "owed". */
+  const conversation = registry.ensureConversation("claude", path.join(cwd, "reviewer.jsonl"), "acctA");
+  const begun = registry.beginSpawnRequest({
+    engine: "claude",
+    cwd,
+    transport: "structured",
+    accountId: "acctA",
+    conversationId: conversation.id,
+    launchProfile: emptyLaunchProfile({ cwd }),
+    launchDisplay: { prompt: "Round 2 review PR #618", images: 0, echo: "Round 2 review PR #618" },
+  });
+  if (begun.kind !== "created") throw new Error("expected structured launch creation");
+  const { launchId, conversationId } = begun.receipt;
+  registry.failStructuredSpawn(launchId, "spawn failed");
+
+  const deliveryId = "held-6244ae52";
+  const snapshot = registry.snapshot();
+  snapshot.heldDeliveries[deliveryId] = {
+    id: deliveryId,
+    conversationId,
+    runtimeConversationId: conversationId,
+    text: "Round 2 review PR #618",
+    createdAt: "2026-07-24T08:07:37.000Z",
+    clientMessageId: `spawn_${launchId}`,
+    payloadKind: "text",
+    runtimeImages: [],
+    contentDigest: null,
+    artifactPaths: [],
+    command: { operationId: `spawn_message_${launchId}`, kind: "send", policy: "queue" },
+    requestDigest: null,
+    state: "held",
+    generationId: null,
+    attempts: 0,
+    assignedAt: null,
+    deliveredAt: null,
+    error: null,
+  } satisfies HeldDelivery;
+  fs.writeFileSync(filename, JSON.stringify(snapshot));
+
+  return {
+    registry: new AgentRegistry(filename, undefined, undefined, { sqliteMode: "off" }),
+    launchId,
+    conversationId,
+    deliveryId,
+    dir,
+  };
+}
+
+test("issue 653: a held delivery of a failed spawn terminalizes to failed and stops being owed", () => {
+  const fixture = makeFailedSpawnWithHeldDelivery();
+  try {
+    const before = fixture.registry.snapshot();
+    /* Today's rot: the reservation is stuck `held` even though the spawn failed. */
+    expect(before.heldDeliveries[fixture.deliveryId]?.state).toBe("held");
+    expect(before.receipts[fixture.launchId]?.state).toBe("failed");
+
+    /* The conversation is still "live"/owed only because of this stuck delivery. */
+    const conversation = before.conversations[fixture.conversationId]!;
+    const probe = livenessProbe({ now: () => Date.parse("2026-07-24T11:58:00.000Z") });
+    expect(conversationIsLive(before, conversation, new Set(), probe)).toBe(true);
+
+    const failed = fixture.registry.terminalizeFailedSpawnDeliveries();
+    expect(failed).toContain(fixture.deliveryId);
+
+    const after = fixture.registry.snapshot();
+    expect(after.heldDeliveries[fixture.deliveryId]?.state).toBe("failed");
+    /* No longer owed: a failed reservation is not an undelivered one. */
+    expect(conversationIsLive(after, after.conversations[fixture.conversationId]!, new Set(), probe)).toBe(false);
+
+    /* Idempotent: a second sweep is a no-op and never churns a terminal row. */
+    expect(fixture.registry.terminalizeFailedSpawnDeliveries()).toEqual([]);
+  } finally {
+    fs.rmSync(fixture.dir, { recursive: true, force: true });
+  }
+});
+
+test("issue 653: failStructuredSpawn terminalizes the initial held delivery in the same transaction", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "llv-failed-spawn-inline-"));
+  try {
+    const filename = path.join(dir, "agent-registry.json");
+    const cwd = path.join(dir, "pipeline");
+    const registry = new AgentRegistry(filename, undefined, undefined, { sqliteMode: "off" });
+    const begun = registry.beginSpawnRequest({
+      engine: "claude", cwd, transport: "structured", accountId: "acctA",
+      launchProfile: emptyLaunchProfile({ cwd }),
+    });
+    if (begun.kind !== "created") throw new Error("expected structured launch creation");
+    const { launchId, conversationId } = begun.receipt;
+
+    // Seed a held initial delivery, then fail the spawn.
+    const deliveryId = "held-inline";
+    const snapshot = registry.snapshot();
+    snapshot.heldDeliveries[deliveryId] = {
+      id: deliveryId, conversationId, runtimeConversationId: conversationId,
+      text: "prompt", createdAt: "2026-07-24T08:07:37.000Z",
+      clientMessageId: `spawn_${launchId}`, payloadKind: "text", runtimeImages: [],
+      contentDigest: null, artifactPaths: [],
+      command: { operationId: `spawn_message_${launchId}`, kind: "send", policy: "queue" },
+      requestDigest: null, state: "held", generationId: null, attempts: 0,
+      assignedAt: null, deliveredAt: null, error: null,
+    } satisfies HeldDelivery;
+    fs.writeFileSync(filename, JSON.stringify(snapshot));
+
+    const reloaded = new AgentRegistry(filename, undefined, undefined, { sqliteMode: "off" });
+    reloaded.failStructuredSpawn(launchId, "spawn failed after held delivery");
+    expect(reloaded.snapshot().heldDeliveries[deliveryId]?.state).toBe("failed");
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("issue 653: the reaper cycle durably terminalizes a failed spawn's stuck initial held delivery", async () => {
+  const fixture = makeFailedSpawnWithHeldDelivery();
+  try {
+    process.env.LLV_STATE_DIR = fixture.dir;
+    expect(fixture.registry.snapshot().heldDeliveries[fixture.deliveryId]?.state).toBe("held");
+    await runReaperCycle({ registry: fixture.registry, hosts: [], files: [], now: Date.parse("2026-07-24T11:58:00.000Z") });
+    expect(fixture.registry.snapshot().heldDeliveries[fixture.deliveryId]?.state).toBe("failed");
+  } finally {
+    fs.rmSync(fixture.dir, { recursive: true, force: true });
+  }
+});
+
+test("issue 653: the failed spawn launch never projects a delivering initial message", () => {
+  const fixture = makeFailedSpawnWithHeldDelivery();
+  try {
+    fixture.registry.terminalizeFailedSpawnDeliveries();
+    const proj = projectLaunchConversations([], fixture.registry.snapshot(), Date.parse("2026-07-24T08:08:00.000Z"), () => false);
+    const card = proj.cards.find((entry) => entry.conversationId === fixture.conversationId);
+    expect(card?.spawn?.state).toBe("failed");
+    expect(card?.spawn?.initialMessage).not.toBe("queued");
+  } finally {
+    fs.rmSync(fixture.dir, { recursive: true, force: true });
+  }
+});

--- a/src/lib/agent/registry.ts
+++ b/src/lib/agent/registry.ts
@@ -1325,6 +1325,41 @@ function syncDeliveryOperationOwnerState(file: RegistryFile, delivery: HeldDeliv
   if (owner?.deliveryId === delivery.id) owner.terminalState = terminalDeliveryState(delivery);
 }
 
+/** The launch receipt a spawn's initial `spawn_<launchId>` held delivery belongs
+    to, if that receipt is a launch that reached the terminal `failed` state
+    (issue #653). Such a delivery can never actuate — the spawn is gone — so it
+    is registry rot that must be terminalized. */
+function failedSpawnLaunchIdOf(file: RegistryFile, delivery: HeldDelivery): string | null {
+  const clientMessageId = delivery.clientMessageId;
+  if (!clientMessageId || !clientMessageId.startsWith("spawn_")) return null;
+  const launchId = clientMessageId.slice("spawn_".length);
+  const receipt = file.receipts[launchId];
+  if (!receipt || receipt.purpose !== "launch" || receipt.state !== "failed") return null;
+  return launchId;
+}
+
+/** Durably terminalize the `spawn_<launchId>` initial delivery of a FAILED
+    structured spawn (issue #653). Only a still-`held` reservation is touched, so
+    a concurrent `beginDeliveryAttempt` — which claims only an `assigned`
+    reservation — is never clobbered, and an in-flight attempt settles on its own
+    outcome. Returns the ids it failed; idempotent, so a terminal reservation is
+    skipped. */
+function terminalizeFailedSpawnDeliveriesInFile(file: RegistryFile): string[] {
+  const failed: string[] = [];
+  for (const delivery of Object.values(file.heldDeliveries)) {
+    if (delivery.state !== "held") continue;
+    if (!failedSpawnLaunchIdOf(file, delivery)) continue;
+    delivery.state = "failed";
+    delivery.generationId = null;
+    delivery.assignedAt = null;
+    delivery.deliveredAt = null;
+    delivery.error = "spawn failed before its initial message was delivered";
+    syncDeliveryOperationOwnerState(file, delivery);
+    failed.push(delivery.id);
+  }
+  return failed;
+}
+
 interface DeliveryReservationInspection {
   canonicalId: ViewerConversationId;
   existing: HeldDelivery | undefined;
@@ -3869,12 +3904,31 @@ export class AgentRegistry {
     });
   }
 
+  /** Durably terminalize every FAILED structured spawn's stuck initial held
+      delivery (issue #653). The reaper cycle calls this so a spawn that already
+      failed before this fix shipped still stops owing a delivery and stops
+      projecting the ghost "delivering" bubble. Peeks first so a quiet registry
+      stays byte-stable across polls. Returns the reservation ids it failed. */
+  terminalizeFailedSpawnDeliveries(): string[] {
+    const snapshot = this.readOnlySnapshot();
+    const hasCandidate = Object.values(snapshot.heldDeliveries).some(
+      (delivery) => delivery.state === "held" && failedSpawnLaunchIdOf(snapshot, delivery),
+    );
+    if (!hasCandidate) return [];
+    return this.mutate((file) => terminalizeFailedSpawnDeliveriesInFile(file));
+  }
+
   failStructuredSpawn(launchId: string, error: string): void {
     this.mutate((file) => {
       const receipt = file.receipts[launchId];
       if (!receipt || receipt.state === "completed" || receipt.state === "failed" || receipt.state === "conflicted") return;
       receipt.state = "failed";
       receipt.error = error;
+      /* A structured spawn that fails can never deliver its initial message, so
+         its still-`held` `spawn_<launchId>` reservation is terminalized in the
+         same transaction (issue #653) rather than left as an eternal owed
+         delivery. */
+      terminalizeFailedSpawnDeliveriesInFile(file);
       if (!receipt.key || !receipt.artifactPath) return;
       const entry = file.entries[sessionKeyId(receipt.key)];
       if (!entry || entry.artifactPath !== receipt.artifactPath) return;

--- a/src/lib/agent/spawnProjection.ts
+++ b/src/lib/agent/spawnProjection.ts
@@ -93,6 +93,7 @@ function cardState(snapshot: RegistryFile, receipt: SpawnReceipt): StructuredSpa
     launchId: receipt.launchId,
     clientAttemptId: receipt.clientAttemptId,
     accountId: receipt.accountId,
+    conversationId: receipt.conversationId,
     state,
     initialMessage,
     retrySafe: receipt.state === "failed",

--- a/src/lib/reaperRuntime.ts
+++ b/src/lib/reaperRuntime.ts
@@ -842,6 +842,16 @@ export async function runReaperCycle(options: {
   } catch (error) {
     console.error("[reaper] stale undeliverable held-delivery convergence failed", error);
   }
+  /* Durable ghost-delivery convergence (issue #653): a structured spawn that
+     reached the terminal `failed` state can never deliver its initial message,
+     so its stuck `spawn_<launchId>` reservation is failed here — it stops owing a
+     delivery and stops projecting a "delivering" bubble. Pure registry mutation,
+     independent of the runtime client, byte-stable when there is nothing to do. */
+  try {
+    registry.terminalizeFailedSpawnDeliveries();
+  } catch (error) {
+    console.error("[reaper] failed-spawn held-delivery convergence failed", error);
+  }
   /* Stale structured launch convergence (#334): the reaper cycle is the
      while-running seam that turns dead-evidence pending receipts terminal, so
      a permanent spinner no longer waits for a replay POST or a restart. The

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -18,6 +18,12 @@ export interface StructuredSpawnCardState {
   launchId: string;
   clientAttemptId: string | null;
   accountId: string | null;
+  /** The durable conversation this launch created/owns (issue #653). The client
+      keys the launch-owned optimistic bubble on THIS id, so a pane renders the
+      bubble only inside its own conversation — never leaked into an unrelated
+      pane. Absent on legacy payloads, where the client falls back to prior
+      (path-based) behaviour. */
+  conversationId?: string;
   state: "starting" | "binding" | "queued" | "reconciling" | "recoverable-timeout" | "live-late-success" | "failed" | "recovered";
   initialMessage: "pending" | "queued" | "delivered" | "failed";
   retrySafe: boolean;


### PR DESCRIPTION
Fixes #653.

The operator's top-priority bug: eternal «Доставляється» bubbles. Two composing defects, fixed here.

## 1. Cross-conversation leak (client)
A launch-owned optimistic bubble keyed to one conversation could render inside an **unrelated** pane — the production case where a failed PR #618 reviewer spawn's bubble appeared in the #621 voice builder's pane after that pane's own structured entry went `dead`.

Pane ownership is now keyed on the **durable conversation id**:
- The launch card state carries its own `conversationId` (`spawnProjection.cardState`).
- `LogFeed` seeds and settles the launch bubble **only** when it belongs to this pane's conversation (`launchOwnsThisPane`), and stamps the bubble's `owner`.
- `visibleOutbox` renders only entries owned by the pane, so a stale foreign copy is filtered at render even after a deploy cutover.
- Absent ids (path-only cards / legacy payloads) preserve prior behaviour.

## 2. No terminal state (server)
A held delivery whose spawn receipt reached the terminal `failed` state stayed `held` forever — it could never deliver, yet kept counting as an owed delivery (accountLiveness) and projecting as delivering.

The registry now terminalizes the `spawn_<launchId>` reservation to `failed`, **race-safe** (only a still-`held` reservation is touched, never a concurrent `beginDeliveryAttempt`):
- inline in `failStructuredSpawn` (same transaction), and
- durably every reaper cycle (`terminalizeFailedSpawnDeliveries`), so spawns that failed *before* this fix converge too.

Server-side scope is kept to **failed-spawn** deliveries; the `delivery-uncertain`/liveness seams touched by the concurrent #652 pipeline are left alone. Rebased check: `origin/main` unchanged at `4162c216`.

## Tests / verification
- `failedSpawnDelivery.test.ts` — registry terminalization, `failStructuredSpawn` inline, reaper-cycle durability, liveness no-longer-owed, projection never-delivering.
- `outbox.test.ts` — pane-ownership filter (foreign owner suppressed; owner-less + same-owner render).
- `issue653Evidence.browser.test.tsx` — dead-entry-pane leak suppressed vs same-conversation control, at **1280×900** and **390×844** with production CSS.
- Existing #626 / #644 / #648 outbox contracts stay green.
- `bunx tsc --noEmit` clean; changed-file ESLint clean (0 errors); trusted-base privacy gate PASS; production build + MCP bundle succeed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)