### PR TITLE
Staging deployment target: stage branch on 127.0.0.1:8899 with hard state isolation (#659)

### DIFF
--- a/docs/staging.md
+++ b/docs/staging.md
@@ -1,0 +1,83 @@
+# Staging deployment target (#659)
+
+The delivery flow is builder → merge to `stage` → **staging deploy** →
+operator review on staging → promote to `main` → prod deploy. The staging
+instance serves the `stage` branch beside prod so the operator can browse
+both at once.
+
+## Ports on this host
+
+| Port | Owner |
+| --- | --- |
+| `127.0.0.1:8898` | Prod front proxy (runtime-host `deploymentProxy`) |
+| `127.0.0.1:8899` | **Staging viewer (fixed; this feature)** |
+| `127.0.0.1:8901` | `viewer-test` compose default (`LLV_TEST_PORT`) |
+| `127.0.0.1:18000–19999` | Prod blue-green candidate Viewers |
+
+8899 was chosen because it is unused by the deploy config and free on the
+host; it is now reserved for staging (older notes used it for ad-hoc local
+`next start` runs — pick another port for those).
+
+## Deploying
+
+```sh
+bun run deploy:staging                     # deploy the current origin/stage head
+bun scripts/deploy-staging.ts --revision <40-hex sha>   # deploy an exact stage sha
+```
+
+Simple replace, no blue-green: the script keeps its own canonical mirror
+under the staging state dir, resolves `refs/heads/stage`, builds the image
+through the same Dockerfile path prod deployments use
+(`agent-log-viewer:staging-<sha12>`), removes the previous
+`llv-staging-runtime-host` + `llv-staging-viewer` pair, starts the new one,
+and gates on `http://127.0.0.1:8899/api/staging` serving the exact deployed
+revision.
+
+The deployed revision is recorded in
+`~/.config/agent-log-viewer/state-staging/staging-release.json` and exposed
+at `GET /api/staging`; the UI shows a fixed **Staging · <sha7>** badge.
+Staging containers are labelled `dev.live-log-viewer.staging=1` — never
+`dev.live-log-viewer.managed=1` — so prod retain/cleanup sweeps and
+candidate-port reservation cannot touch them.
+
+## State isolation (the hard contract)
+
+Staging processes run with `LLV_STAGING=1` and their own state dir
+(default `~/.config/agent-log-viewer/state-staging`). Everything mutable —
+agent registry, runtime events journal + socket, board, pipelines, flows,
+inbox, release records — resolves through `stateDir()`, and in staging mode
+that resolver **throws** if it would land on the prod state dir or the
+legacy `~/.claude/viewer-state` dir, and never runs the legacy migration
+copy. The container builders (`src/runtime-host/stagingContainer.ts`)
+re-assert the same guard and strip prod-only env
+(`LLV_VIEWER_DEPLOY_TARGET`, `LLV_VIEWER_PORT`) before any `docker run`.
+
+Agent launches stay enabled on staging (operator revision of #659, comment
+of 2026-07-24): spawn, attach, migrations, pipelines and message delivery
+work against staging's own registry/journal/board, so agents launched from
+staging live on staging's board and never enter prod state. Transcripts are
+inherently machine-global: agents spawned from staging write real
+transcripts under `~/.claude` / `~/.codex`, which any viewer on the machine
+(including prod) can *see* in its file feed — exactly as it sees every other
+agent on the host. Prod's registry, board, events and pipelines stay
+untouched.
+
+## Verification after a stage deploy
+
+1. **Staging serves the stage revision** —
+   `curl -s http://127.0.0.1:8899/api/staging` reports
+   `{"staging":true,"revision":<deployed sha>,…}` matching
+   `git rev-parse origin/stage` and `staging-release.json`; the UI at
+   `http://127.0.0.1:8899` shows the staging badge with that sha prefix.
+2. **Prod untouched** — the deploy script fingerprints (sha256 + mtime)
+   prod's `viewer-release.json`, `agent-registry.json`,
+   `runtime-events.sqlite`, `board.json`, `pipelines.json`, `flows.json`
+   before and after, prints the diff, and **fails** if
+   `viewer-release.json` changed (only deploy machinery writes it; the
+   other files keep changing while live prod works — they are reported for
+   the operator to eyeball).
+3. **Prod still serves prod** — `curl -s http://127.0.0.1:8898/api/staging`
+   reports `{"staging":false,…}`.
+4. **Launches stay staging-local** — spawn an agent from the staging UI;
+   it appears on staging's board (`state-staging/agent-registry.json`)
+   and prod's `agent-registry.json` fingerprint stays unchanged.

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "build": "next build --webpack && bun run build:mcp",
     "build:mcp": "bun scripts/build-mcp.ts",
     "demo:capture": "bun scripts/demo-capture.ts",
+    "deploy:staging": "bun scripts/deploy-staging.ts",
     "demo:motion": "bun scripts/demo-motion.ts",
     "start": "next start",
     "lint": "eslint",

--- a/scripts/bun-spawn-credential-isolation.test.ts
+++ b/scripts/bun-spawn-credential-isolation.test.ts
@@ -50,6 +50,7 @@ test("production Bun child paths use the credential-isolated environment seam", 
 
   expect(uncovered).toEqual([]);
   expect(inventory).toEqual([
+    { file: "scripts/deploy-staging.ts", method: "spawn" },
     ...Array.from({ length: 8 }, () => ({ file: "scripts/privacy-publication-gate.ts", method: "spawnSync" })),
     { file: "scripts/runtime-host-viewer-adapter.ts", method: "spawn" },
   ]);

--- a/scripts/deploy-staging.test.ts
+++ b/scripts/deploy-staging.test.ts
@@ -1,0 +1,45 @@
+import { expect, test } from "bun:test";
+
+import {
+  PROD_STATE_EVIDENCE_FILES,
+  prodStateChanges,
+  type ProdStateFingerprint,
+} from "./deploy-staging";
+
+function fingerprint(digest: string, mtimeMs: number): ProdStateFingerprint {
+  return { digest, mtimeMs };
+}
+
+test("the prod evidence set covers every state family staging must not touch", () => {
+  expect([...PROD_STATE_EVIDENCE_FILES].sort()).toEqual([
+    "agent-registry.json",
+    "board.json",
+    "flows.json",
+    "pipelines.json",
+    "runtime-events.sqlite",
+    "viewer-release.json",
+  ]);
+});
+
+test("prod state changes distinguish untouched, changed and absent files", () => {
+  const before = new Map<string, ProdStateFingerprint | null>([
+    ["viewer-release.json", fingerprint("aa", 1)],
+    ["board.json", fingerprint("bb", 2)],
+    ["pipelines.json", null],
+  ]);
+  const after = new Map<string, ProdStateFingerprint | null>([
+    ["viewer-release.json", fingerprint("aa", 1)],
+    ["board.json", fingerprint("cc", 3)],
+    ["pipelines.json", null],
+  ]);
+  const changes = prodStateChanges(before, after);
+  expect(changes.unchanged).toEqual(["pipelines.json", "viewer-release.json"]);
+  expect(changes.changed).toEqual(["board.json"]);
+});
+
+test("a viewer-release change is flagged as a deploy-machinery violation", () => {
+  const before = new Map<string, ProdStateFingerprint | null>([["viewer-release.json", fingerprint("aa", 1)]]);
+  const after = new Map<string, ProdStateFingerprint | null>([["viewer-release.json", fingerprint("zz", 9)]]);
+  expect(prodStateChanges(before, after).violation).toBe("viewer-release.json");
+  expect(prodStateChanges(before, before).violation).toBeNull();
+});

--- a/scripts/deploy-staging.ts
+++ b/scripts/deploy-staging.ts
@@ -20,7 +20,7 @@
  * instance itself never reads any of the prod paths referenced here.
  */
 
-import crypto from "node:crypto";
+import crypto, { randomUUID } from "node:crypto";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -136,7 +136,7 @@ function parseOptions(argv: string[]): DeployOptions {
 
 function writeReleaseRecord(filename: string, record: StagingReleaseRecord): void {
   fs.mkdirSync(path.dirname(filename), { recursive: true, mode: 0o700 });
-  const temporary = `${filename}.${process.pid}.tmp`;
+  const temporary = `${filename}.${process.pid}.${randomUUID()}.tmp`;
   fs.writeFileSync(temporary, `${JSON.stringify(stagingReleaseRecord(record), null, 2)}\n`, { mode: 0o600, flag: "wx" });
   fs.renameSync(temporary, filename);
 }

--- a/scripts/deploy-staging.ts
+++ b/scripts/deploy-staging.ts
@@ -1,0 +1,252 @@
+#!/usr/bin/env bun
+
+/**
+ * Stage deploy entrypoint (#659): deploy the current `stage` head (or an
+ * explicit full SHA) to the staging instance on 127.0.0.1:8899.
+ *
+ *   bun scripts/deploy-staging.ts            # deploy origin/stage head
+ *   bun scripts/deploy-staging.ts --revision <40-hex sha>
+ *
+ * Simple replace, no blue-green: build the image from the resolved revision
+ * (the same Dockerfile path prod deployments use), remove the previous
+ * staging pair, start the new one against the staging state dir, write the
+ * staging-release.json record there, and gate on the staging port serving
+ * that exact revision. Prod evidence: the script fingerprints prod's state
+ * files before and after and fails if the deploy machinery touched
+ * viewer-release.json. (Other prod files may legitimately change while the
+ * live prod instance keeps working — they are reported, not failed on.)
+ *
+ * This script runs host-side in the operator's session. The staging
+ * instance itself never reads any of the prod paths referenced here.
+ */
+
+import crypto from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { stagingReleaseRecord, STAGING_RELEASE_FILE, type StagingReleaseRecord } from "../src/lib/staging";
+import {
+  viewerCandidateTmuxEnvironment,
+  viewerComposeServiceFromConfig,
+  viewerComposeServiceUid,
+  viewerComposeSnapshotWithoutWakatimeCredential,
+} from "../src/runtime-host/candidateContainer";
+import { ensureCanonicalMirror } from "../src/runtime-host/canonicalMirror";
+import {
+  STAGING_FRONT_PORT,
+  STAGING_RUNTIME_HOST_CONTAINER,
+  STAGING_VIEWER_CONTAINER,
+  stagingImageName,
+  stagingRuntimeHostDockerArgs,
+  stagingStatePaths,
+  stagingViewerDockerArgs,
+} from "../src/runtime-host/stagingContainer";
+import { withoutWakatimeCredential } from "../src/lib/wakatime/credential";
+
+/** Prod state families the issue forbids staging from touching. */
+export const PROD_STATE_EVIDENCE_FILES: ReadonlySet<string> = new Set([
+  "viewer-release.json",
+  "agent-registry.json",
+  "runtime-events.sqlite",
+  "board.json",
+  "pipelines.json",
+  "flows.json",
+]);
+
+export interface ProdStateFingerprint {
+  digest: string;
+  mtimeMs: number;
+}
+
+export interface ProdStateChanges {
+  unchanged: string[];
+  changed: string[];
+  /** viewer-release.json is written by deploy machinery alone, so any change
+      there is proof the stage deploy leaked into prod; other files change
+      whenever the live prod instance works. */
+  violation: string | null;
+}
+
+export function prodStateChanges(
+  before: Map<string, ProdStateFingerprint | null>,
+  after: Map<string, ProdStateFingerprint | null>,
+): ProdStateChanges {
+  const unchanged: string[] = [];
+  const changed: string[] = [];
+  for (const [name, fingerprint] of [...before.entries()].sort(([left], [right]) => left.localeCompare(right))) {
+    const current = after.get(name) ?? null;
+    const same = fingerprint === null
+      ? current === null
+      : current !== null && current.digest === fingerprint.digest && current.mtimeMs === fingerprint.mtimeMs;
+    (same ? unchanged : changed).push(name);
+  }
+  return { unchanged, changed, violation: changed.includes("viewer-release.json") ? "viewer-release.json" : null };
+}
+
+function collectProdState(prodStateDir: string): Map<string, ProdStateFingerprint | null> {
+  const fingerprints = new Map<string, ProdStateFingerprint | null>();
+  for (const name of PROD_STATE_EVIDENCE_FILES) {
+    const filename = path.join(prodStateDir, name);
+    try {
+      const stat = fs.statSync(filename);
+      const digest = crypto.createHash("sha256").update(fs.readFileSync(filename)).digest("hex");
+      fingerprints.set(name, { digest, mtimeMs: stat.mtimeMs });
+    } catch {
+      fingerprints.set(name, null);
+    }
+  }
+  return fingerprints;
+}
+
+async function command(argv: string[], options: { cwd?: string } = {}): Promise<string> {
+  const child = Bun.spawn(argv, {
+    cwd: options.cwd,
+    stdout: "pipe",
+    stderr: "pipe",
+    env: withoutWakatimeCredential(process.env),
+  });
+  const [stdout, stderr, code] = await Promise.all([
+    new Response(child.stdout).text(),
+    new Response(child.stderr).text(),
+    child.exited,
+  ]);
+  if (code !== 0) throw new Error((stderr.trim() || `${argv[0]} failed`).slice(0, 1000));
+  return stdout.trim();
+}
+
+interface DeployOptions {
+  revision: string | null;
+}
+
+function parseOptions(argv: string[]): DeployOptions {
+  const options: DeployOptions = { revision: null };
+  for (let index = 0; index < argv.length; index += 1) {
+    if (argv[index] === "--revision") {
+      const value = argv[index + 1] ?? "";
+      if (!/^[0-9a-f]{40}$/.test(value)) throw new Error("--revision requires a full 40-character commit SHA");
+      options.revision = value;
+      index += 1;
+      continue;
+    }
+    throw new Error(`unsupported argument: ${argv[index]}`);
+  }
+  return options;
+}
+
+function writeReleaseRecord(filename: string, record: StagingReleaseRecord): void {
+  fs.mkdirSync(path.dirname(filename), { recursive: true, mode: 0o700 });
+  const temporary = `${filename}.${process.pid}.tmp`;
+  fs.writeFileSync(temporary, `${JSON.stringify(stagingReleaseRecord(record), null, 2)}\n`, { mode: 0o600, flag: "wx" });
+  fs.renameSync(temporary, filename);
+}
+
+async function containerGone(container: string): Promise<void> {
+  try { await command(["docker", "container", "rm", "-f", container]); }
+  catch (error) {
+    const message = error instanceof Error ? error.message : "";
+    if (!message.includes("No such container") && !message.includes("No such object")) throw error;
+  }
+}
+
+async function waitForStagingRevision(endpoint: string, revision: string, timeoutMs = 180_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  let last = "staging endpoint did not answer";
+  while (Date.now() < deadline) {
+    try {
+      const response = await fetch(`${endpoint}/api/staging`, { signal: AbortSignal.timeout(5_000) });
+      if (response.ok) {
+        const payload = await response.json() as { staging?: unknown; revision?: unknown };
+        if (payload.staging === true && payload.revision === revision) return;
+        last = `staging endpoint reported staging=${String(payload.staging)} revision=${String(payload.revision)}`;
+      } else {
+        last = `staging endpoint returned HTTP ${response.status}`;
+      }
+    } catch (error) {
+      last = error instanceof Error ? error.message : "staging endpoint fetch failed";
+    }
+    await new Promise((resolve) => setTimeout(resolve, 2_000));
+  }
+  throw new Error(`staging health gate failed: ${last}`);
+}
+
+async function main(): Promise<void> {
+  const options = parseOptions(process.argv.slice(2));
+  const configRoot = process.env.XDG_CONFIG_HOME || path.join(os.homedir(), ".config");
+  const prodStateDir = path.join(configRoot, "agent-log-viewer", "state");
+  const stagingStateDir = process.env.LLV_STAGING_STATE_DIR || path.join(configRoot, "agent-log-viewer", "state-staging");
+  const paths = stagingStatePaths(stagingStateDir);
+  const remote = process.env.LLV_VIEWER_CANONICAL_REMOTE || "https://github.com/Latand/live-log-viewer-next.git";
+  const endpoint = `http://127.0.0.1:${STAGING_FRONT_PORT}`;
+
+  const before = collectProdState(prodStateDir);
+
+  /* Staging keeps its own mirror under its own state dir; the prod
+     deployments mirror stays untouched. */
+  const deploymentDir = path.join(stagingStateDir, "deployments");
+  const mirrorDir = path.join(deploymentDir, "canonical.git");
+  await ensureCanonicalMirror({ deploymentDir, mirrorDir, remote }, { run: (argv) => command(argv) });
+  const requested = options.revision ? `${options.revision}^{commit}` : "refs/heads/stage^{commit}";
+  const revision = await command(["git", "--git-dir", mirrorDir, "rev-parse", "--verify", requested]);
+  if (!/^[0-9a-f]{40}$/.test(revision)) throw new Error("stage revision did not resolve to a commit SHA");
+
+  const image = stagingImageName(revision);
+  const sourceDir = path.join(deploymentDir, "stage-source", "source");
+  fs.rmSync(path.dirname(sourceDir), { recursive: true, force: true });
+  fs.mkdirSync(path.dirname(sourceDir), { recursive: true, mode: 0o700 });
+  await command(["git", "--git-dir", mirrorDir, "worktree", "prune"]);
+  await command(["git", "--git-dir", mirrorDir, "worktree", "add", "--detach", sourceDir, revision]);
+  let service;
+  try {
+    const composeConfig = await command([
+      "docker", "compose", "--project-directory", sourceDir, "-f", path.join(sourceDir, "docker-compose.yml"),
+      "--profile", "*", "config", "--format", "json",
+    ]);
+    service = viewerComposeServiceFromConfig(viewerComposeSnapshotWithoutWakatimeCredential(composeConfig));
+    await command(["docker", "build", "--pull", "--label", `dev.live-log-viewer.revision=${revision}`, "-t", image, sourceDir]);
+  } finally {
+    try { await command(["git", "--git-dir", mirrorDir, "worktree", "remove", "--force", sourceDir]); }
+    catch { fs.rmSync(sourceDir, { recursive: true, force: true }); }
+  }
+
+  /* The host tmux supervisor migration marker lives in prod state; reading it
+     here (operator-side) keeps the staging containers on the same tmux
+     transport as prod without the staging instance touching prod state. */
+  const tmux = viewerCandidateTmuxEnvironment(prodStateDir, viewerComposeServiceUid(service), {
+    legacyTmuxExternal: service.environment.LLV_LEGACY_TMUX_EXTERNAL || "0",
+    tmuxTmpdir: service.environment.TMUX_TMPDIR || "/tmp",
+  });
+  const context = { revision, image, service, paths, tmux };
+
+  fs.mkdirSync(stagingStateDir, { recursive: true, mode: 0o700 });
+  await containerGone(STAGING_VIEWER_CONTAINER);
+  await containerGone(STAGING_RUNTIME_HOST_CONTAINER);
+  await command(stagingRuntimeHostDockerArgs(context));
+  await command(stagingViewerDockerArgs(context));
+
+  const record: StagingReleaseRecord = {
+    revision,
+    image,
+    endpoint,
+    containers: { viewer: STAGING_VIEWER_CONTAINER, runtimeHost: STAGING_RUNTIME_HOST_CONTAINER },
+    deployedAt: new Date().toISOString(),
+  };
+  writeReleaseRecord(path.join(stagingStateDir, STAGING_RELEASE_FILE), record);
+
+  await waitForStagingRevision(endpoint, revision);
+
+  const changes = prodStateChanges(before, collectProdState(prodStateDir));
+  if (changes.violation) {
+    throw new Error(`stage deploy touched prod ${changes.violation} — investigate before trusting this staging instance`);
+  }
+  console.log(JSON.stringify({ ...record, prodState: changes }, null, 2));
+}
+
+if (import.meta.main) {
+  try {
+    await main();
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : "stage deploy failed");
+    process.exit(1);
+  }
+}

--- a/src/app/api/staging/route.test.ts
+++ b/src/app/api/staging/route.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, expect, test } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const SANDBOX = fs.mkdtempSync(path.join(os.tmpdir(), "llv-staging-route-test-"));
+const SAVED = {
+  LLV_STATE_DIR: process.env.LLV_STATE_DIR,
+  LLV_STAGING: process.env.LLV_STAGING,
+};
+
+const { GET } = await import("./route");
+
+afterEach(() => {
+  for (const [key, value] of Object.entries(SAVED)) {
+    if (value !== undefined) process.env[key] = value;
+    else delete process.env[key];
+  }
+});
+
+test("production instances report staging=false", async () => {
+  delete process.env.LLV_STAGING;
+  const payload = await (await GET()).json();
+  expect(payload).toEqual({ staging: false, revision: null, deployedAt: null, endpoint: null });
+});
+
+test("staging instances report the deployed staging release record", async () => {
+  const state = fs.mkdtempSync(path.join(SANDBOX, "state-"));
+  process.env.LLV_STAGING = "1";
+  process.env.LLV_STATE_DIR = state;
+  fs.writeFileSync(path.join(state, "staging-release.json"), JSON.stringify({
+    revision: "c".repeat(40),
+    image: `agent-log-viewer:staging-${"c".repeat(12)}`,
+    endpoint: "http://127.0.0.1:8899",
+    containers: { viewer: "llv-staging-viewer", runtimeHost: "llv-staging-runtime-host" },
+    deployedAt: "2026-07-24T12:00:00.000Z",
+  }));
+  const response = await GET();
+  expect(response.headers.get("cache-control")).toBe("no-store");
+  const payload = await response.json();
+  expect(payload).toEqual({
+    staging: true,
+    revision: "c".repeat(40),
+    deployedAt: "2026-07-24T12:00:00.000Z",
+    endpoint: "http://127.0.0.1:8899",
+  });
+});
+
+test("a staging instance without a readable release record still identifies itself", async () => {
+  const state = fs.mkdtempSync(path.join(SANDBOX, "state-"));
+  process.env.LLV_STAGING = "1";
+  process.env.LLV_STATE_DIR = state;
+  const missing = await (await GET()).json();
+  expect(missing).toEqual({ staging: true, revision: null, deployedAt: null, endpoint: null });
+  fs.writeFileSync(path.join(state, "staging-release.json"), "{corrupt");
+  const corrupt = await (await GET()).json();
+  expect(corrupt).toEqual({ staging: true, revision: null, deployedAt: null, endpoint: null });
+});

--- a/src/app/api/staging/route.ts
+++ b/src/app/api/staging/route.ts
@@ -1,0 +1,35 @@
+import fs from "node:fs";
+
+import { NextResponse } from "next/server";
+
+import { statePath } from "@/lib/configDir";
+import { isStagingMode, STAGING_RELEASE_FILE, stagingReleaseRecord } from "@/lib/staging";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+interface StagingIdentity {
+  staging: boolean;
+  revision: string | null;
+  deployedAt: string | null;
+  endpoint: string | null;
+}
+
+/** The instance's own staging identity: drives the UI badge and lets a stage
+    deploy verify which revision the staging port actually serves. */
+export function GET(): NextResponse<StagingIdentity> {
+  const headers = { "Cache-Control": "no-store" };
+  if (!isStagingMode()) {
+    return NextResponse.json({ staging: false, revision: null, deployedAt: null, endpoint: null }, { headers });
+  }
+  try {
+    const record = stagingReleaseRecord(JSON.parse(fs.readFileSync(statePath(STAGING_RELEASE_FILE), "utf8")));
+    return NextResponse.json(
+      { staging: true, revision: record.revision, deployedAt: record.deployedAt, endpoint: record.endpoint },
+      { headers },
+    );
+  } catch {
+    /* No readable release record yet — the instance still identifies as staging. */
+    return NextResponse.json({ staging: true, revision: null, deployedAt: null, endpoint: null }, { headers });
+  }
+}

--- a/src/components/StagingBadge.dom.test.tsx
+++ b/src/components/StagingBadge.dom.test.tsx
@@ -1,0 +1,58 @@
+import { afterEach, expect, test } from "bun:test";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { Window } from "happy-dom";
+
+import { installActEnv } from "@/test-helpers/actEnv";
+
+const dom = new Window();
+installActEnv();
+Object.assign(globalThis, {
+  window: dom,
+  document: dom.document,
+  navigator: dom.navigator,
+  Node: dom.Node,
+  HTMLElement: dom.HTMLElement,
+  MouseEvent: dom.MouseEvent,
+  Event: dom.Event,
+  localStorage: dom.localStorage,
+});
+
+const { StagingBadge } = await import("./StagingBadge");
+
+let payload: Record<string, unknown> = { staging: false, revision: null, deployedAt: null, endpoint: null };
+globalThis.fetch = (async () =>
+  new Response(JSON.stringify(payload), { status: 200, headers: { "content-type": "application/json" } })
+) as typeof fetch;
+
+let root: Root | null = null;
+afterEach(async () => {
+  if (root) await act(async () => { root?.unmount(); });
+  root = null;
+  document.body.replaceChildren();
+});
+
+async function render(): Promise<HTMLElement> {
+  const host = document.createElement("div");
+  document.body.appendChild(host);
+  await act(async () => {
+    root = createRoot(host);
+    root.render(<StagingBadge />);
+  });
+  return host;
+}
+
+test("a staging instance shows the staging badge with its deployed revision", async () => {
+  payload = { staging: true, revision: "e".repeat(40), deployedAt: "2026-07-24T12:00:00.000Z", endpoint: "http://127.0.0.1:8899" };
+  const host = await render();
+  const badge = host.querySelector("[data-staging-badge]");
+  expect(badge).not.toBeNull();
+  expect(badge?.textContent ?? "").toContain("Staging");
+  expect(badge?.textContent ?? "").toContain("e".repeat(7));
+});
+
+test("a production instance renders no staging badge", async () => {
+  payload = { staging: false, revision: null, deployedAt: null, endpoint: null };
+  const host = await render();
+  expect(host.querySelector("[data-staging-badge]")).toBeNull();
+});

--- a/src/components/StagingBadge.dom.test.tsx
+++ b/src/components/StagingBadge.dom.test.tsx
@@ -21,9 +21,11 @@ Object.assign(globalThis, {
 const { StagingBadge } = await import("./StagingBadge");
 
 let payload: Record<string, unknown> = { staging: false, revision: null, deployedAt: null, endpoint: null };
-globalThis.fetch = (async () =>
-  new Response(JSON.stringify(payload), { status: 200, headers: { "content-type": "application/json" } })
-) as typeof fetch;
+const requested: string[] = [];
+globalThis.fetch = (async (input: RequestInfo | URL) => {
+  requested.push(String(input));
+  return new Response(JSON.stringify(payload), { status: 200, headers: { "content-type": "application/json" } });
+}) as typeof fetch;
 
 let root: Root | null = null;
 afterEach(async () => {
@@ -49,6 +51,7 @@ test("a staging instance shows the staging badge with its deployed revision", as
   expect(badge).not.toBeNull();
   expect(badge?.textContent ?? "").toContain("Staging");
   expect(badge?.textContent ?? "").toContain("e".repeat(7));
+  expect(requested).toContain("/api/staging");
 });
 
 test("a production instance renders no staging badge", async () => {

--- a/src/components/StagingBadge.tsx
+++ b/src/components/StagingBadge.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+import { Badge } from "@/components/ui/Badge";
+import { useLocale } from "@/lib/i18n";
+
+interface StagingIdentity {
+  staging: boolean;
+  revision: string | null;
+}
+
+/**
+ * Always-visible marker of a staging instance (#659). The flag is runtime
+ * state (the same image serves prod and staging), so it arrives from
+ * /api/staging instead of a build-time constant. Prod instances render
+ * nothing.
+ */
+export function StagingBadge() {
+  const { t } = useLocale();
+  const [identity, setIdentity] = useState<StagingIdentity | null>(null);
+  useEffect(() => {
+    let cancelled = false;
+    void fetch("/api/staging")
+      .then(async (response) => (response.ok ? response.json() as Promise<StagingIdentity> : null))
+      .then((payload) => { if (!cancelled && payload) setIdentity(payload); })
+      .catch(() => {});
+    return () => { cancelled = true; };
+  }, []);
+  if (!identity?.staging) return null;
+  return (
+    <div className="pointer-events-none fixed left-1/2 top-1.5 z-40 -translate-x-1/2">
+      <Badge tone="warning" data-staging-badge title={t("staging.badgeTitle")} className="shadow-1 backdrop-blur">
+        <span className="h-2 w-2 rounded-full bg-warning" aria-hidden />
+        <span>{t("staging.badge")}</span>
+        {identity.revision ? <span className="font-normal text-muted">· {identity.revision.slice(0, 7)}</span> : null}
+      </Badge>
+    </div>
+  );
+}

--- a/src/components/Viewer.tsx
+++ b/src/components/Viewer.tsx
@@ -26,6 +26,7 @@ import { ProjectDashboard, queueColumnOpen } from "./ProjectDashboard";
 import { isChildConversation, OVERVIEW, projectKey } from "./projectModel";
 import { ProjectRail } from "./ProjectRail";
 import { DeploymentStatusPill } from "./runtime/DeploymentStatusPill";
+import { StagingBadge } from "./StagingBadge";
 import { activityDot, cleanTitle, fmtAge } from "./utils";
 
 const PROJECT_KEY = "llvProject";
@@ -678,6 +679,9 @@ export function Viewer() {
           of the bottom-right CornerStatus and the top-right attention anchor. */}
       {isMobile ? null : <ConnectionPill />}
       <DeploymentStatusPill />
+      {/* Staging instances (#659) announce themselves on every device; prod
+          renders nothing. Top-center, clear of both corner anchors. */}
+      <StagingBadge />
     </div>
   );
 }

--- a/src/lib/configDir.staging.test.ts
+++ b/src/lib/configDir.staging.test.ts
@@ -1,0 +1,78 @@
+import { afterEach, expect, test } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const SANDBOX = fs.mkdtempSync(path.join(os.tmpdir(), "llv-configdir-staging-test-"));
+const SAVED = {
+  XDG_CONFIG_HOME: process.env.XDG_CONFIG_HOME,
+  LLV_STATE_DIR: process.env.LLV_STATE_DIR,
+  LLV_STAGING: process.env.LLV_STAGING,
+};
+
+const { inboxDir, stateDir, statePath } = await import("./configDir");
+
+afterEach(() => {
+  for (const [key, value] of Object.entries(SAVED)) {
+    if (value !== undefined) process.env[key] = value;
+    else delete process.env[key];
+  }
+  fs.rmSync(SANDBOX, { recursive: true, force: true });
+});
+
+test("staging mode pins the state dir to its own state-staging default", () => {
+  const xdg = path.join(SANDBOX, "xdg-default");
+  process.env.XDG_CONFIG_HOME = xdg;
+  process.env.LLV_STAGING = "1";
+  delete process.env.LLV_STATE_DIR;
+  expect(stateDir()).toBe(path.join(xdg, "agent-log-viewer", "state-staging"));
+  expect(statePath("agent-registry.json"))
+    .toBe(path.join(xdg, "agent-log-viewer", "state-staging", "agent-registry.json"));
+});
+
+test("staging mode never migrates or copies prod legacy state", () => {
+  const xdg = path.join(SANDBOX, "xdg-no-migration");
+  process.env.XDG_CONFIG_HOME = xdg;
+  process.env.LLV_STAGING = "1";
+  delete process.env.LLV_STATE_DIR;
+  const resolved = stateDir();
+  /* The legacy migration copies ~/.claude/viewer-state and stamps a sentinel.
+     Staging resolution must be pure: no dir creation, no sentinel, no copy. */
+  expect(fs.existsSync(resolved)).toBe(false);
+  expect(fs.existsSync(path.join(xdg, "agent-log-viewer", "state"))).toBe(false);
+});
+
+test("staging mode refuses the production state dir", () => {
+  const xdg = path.join(SANDBOX, "xdg-prod-clash");
+  process.env.XDG_CONFIG_HOME = xdg;
+  process.env.LLV_STAGING = "1";
+  process.env.LLV_STATE_DIR = path.join(xdg, "agent-log-viewer", "state");
+  expect(() => stateDir()).toThrow(/staging/i);
+  process.env.LLV_STATE_DIR = path.join(xdg, "agent-log-viewer", "state", "");
+  expect(() => stateDir()).toThrow(/staging/i);
+});
+
+test("staging mode refuses the legacy viewer-state dirs", () => {
+  process.env.LLV_STAGING = "1";
+  process.env.XDG_CONFIG_HOME = path.join(SANDBOX, "xdg-legacy-clash");
+  process.env.LLV_STATE_DIR = path.join(os.homedir(), ".claude", "viewer-state");
+  expect(() => stateDir()).toThrow(/staging/i);
+  process.env.LLV_STATE_DIR = path.join(path.join(SANDBOX, "xdg-legacy-clash"), "live-log-viewer", "state");
+  expect(() => stateDir()).toThrow(/staging/i);
+});
+
+test("staging mode accepts an explicit non-prod override", () => {
+  process.env.LLV_STAGING = "1";
+  process.env.XDG_CONFIG_HOME = path.join(SANDBOX, "xdg-override");
+  process.env.LLV_STATE_DIR = path.join(SANDBOX, "elsewhere", "staging-state");
+  expect(stateDir()).toBe(path.join(SANDBOX, "elsewhere", "staging-state"));
+});
+
+test("staging mode keeps the inbox inside the staging state dir", () => {
+  const xdg = path.join(SANDBOX, "xdg-inbox");
+  process.env.XDG_CONFIG_HOME = xdg;
+  process.env.LLV_STAGING = "1";
+  delete process.env.LLV_STATE_DIR;
+  expect(inboxDir()).toBe(path.join(xdg, "agent-log-viewer", "state-staging", "inbox"));
+  expect(fs.existsSync(path.join(xdg, "agent-log-viewer", "inbox"))).toBe(false);
+});

--- a/src/lib/configDir.ts
+++ b/src/lib/configDir.ts
@@ -2,6 +2,8 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
+import { isStagingMode, STAGING_STATE_DIRNAME } from "@/lib/staging";
+
 /** App dir that matches the npm package name; new installs land here. */
 const APP_DIR = "agent-log-viewer";
 /** Former app dir, still honored as a fallback so existing setups keep working. */
@@ -115,9 +117,29 @@ export function migrateLegacyDir(target: string, legacy: string): void {
  */
 export function stateDir(): string {
   const override = process.env.LLV_STATE_DIR;
+  if (isStagingMode()) return stagingStateDir(override);
   if (override) return override;
   const dir = path.join(configRoot(), APP_DIR, "state");
   migrateLegacyDir(dir, path.join(os.homedir(), ".claude", "viewer-state"));
+  return dir;
+}
+
+/* The staging isolation seam (#659). A staging process must never resolve
+   its mutable state (registry, events, board, pipelines, flows, release
+   records) into the prod state dir — not by default, not by misconfigured
+   override, and never through the legacy migration copy, which would clone
+   prod state into staging or stamp sentinels into shared legacy dirs. */
+function stagingStateDir(override: string | undefined): string {
+  const dir = override || path.join(configRoot(), APP_DIR, STAGING_STATE_DIRNAME);
+  const resolved = path.resolve(dir);
+  const prodDirs = [
+    path.join(configRoot(), APP_DIR, "state"),
+    path.join(configRoot(), LEGACY_APP_DIR, "state"),
+    path.join(os.homedir(), ".claude", "viewer-state"),
+  ];
+  if (prodDirs.some((prod) => path.resolve(prod) === resolved)) {
+    throw new Error(`staging mode refuses the production state dir ${resolved}; set LLV_STATE_DIR to a staging-only dir`);
+  }
   return dir;
 }
 
@@ -126,8 +148,11 @@ export function statePath(...segments: string[]): string {
   return path.join(stateDir(), ...segments);
 }
 
-/** Composer-pasted images the agents receive as file paths. */
+/** Composer-pasted images the agents receive as file paths. Staging keeps
+    its inbox inside the staging state dir, so composer uploads on the
+    staging instance never land in (or migrate) the prod inbox. */
 export function inboxDir(): string {
+  if (isStagingMode()) return statePath("inbox");
   const dir = path.join(configRoot(), APP_DIR, "inbox");
   migrateLegacyDir(dir, path.join(os.homedir(), ".claude", "viewer-inbox"));
   return dir;

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -1710,6 +1710,8 @@ export const en = {
   "runtime.staleSince": "stale {duration}",
   "runtime.lastKnown": "last update {duration} ago",
   "runtime.legacyProvenance": "legacy · derived state",
+  "staging.badge": "Staging",
+  "staging.badgeTitle": "Staging instance — isolated state; nothing here touches prod",
   "runtime.drift": "drift: {evidence}",
   "runtime.driftDismiss": "Dismiss",
   "runtime.receipt.pending": "sending…",

--- a/src/lib/i18n/uk.ts
+++ b/src/lib/i18n/uk.ts
@@ -1662,6 +1662,8 @@ export const uk: Record<keyof typeof en, Message> = {
   "runtime.staleSince": "застаріло {duration}",
   "runtime.lastKnown": "останнє оновлення {duration} тому",
   "runtime.legacyProvenance": "легасі · похідний стан",
+  "staging.badge": "Стейджинг",
+  "staging.badgeTitle": "Стейджинг-інстанс — ізольований стан; нічого звідси не торкається проду",
   "runtime.drift": "розбіжність: {evidence}",
   "runtime.driftDismiss": "Сховати",
   "runtime.receipt.pending": "надсилання…",

--- a/src/lib/staging.test.ts
+++ b/src/lib/staging.test.ts
@@ -1,0 +1,43 @@
+import { expect, test } from "bun:test";
+
+import { isStagingMode, stagingReleaseRecord, STAGING_RELEASE_FILE } from "./staging";
+
+test("isStagingMode requires the exact LLV_STAGING=1 opt-in", () => {
+  expect(isStagingMode({ LLV_STAGING: "1" } as NodeJS.ProcessEnv)).toBe(true);
+  expect(isStagingMode({} as NodeJS.ProcessEnv)).toBe(false);
+  expect(isStagingMode({ LLV_STAGING: "0" } as NodeJS.ProcessEnv)).toBe(false);
+  expect(isStagingMode({ LLV_STAGING: "true" } as NodeJS.ProcessEnv)).toBe(false);
+});
+
+test("staging release records carry the deployed revision and container pair", () => {
+  const record = stagingReleaseRecord({
+    revision: "b".repeat(40),
+    image: `agent-log-viewer:staging-${"b".repeat(12)}`,
+    endpoint: "http://127.0.0.1:8899",
+    containers: { viewer: "llv-staging-viewer", runtimeHost: "llv-staging-runtime-host" },
+    deployedAt: "2026-07-24T00:00:00.000Z",
+  });
+  expect(record.revision).toBe("b".repeat(40));
+  expect(record.endpoint).toBe("http://127.0.0.1:8899");
+  expect(record.containers.viewer).toBe("llv-staging-viewer");
+  expect(STAGING_RELEASE_FILE).toBe("staging-release.json");
+});
+
+test("staging release records reject partial or malformed payloads", () => {
+  expect(() => stagingReleaseRecord(null)).toThrow();
+  expect(() => stagingReleaseRecord({ revision: "not-a-sha" })).toThrow();
+  expect(() => stagingReleaseRecord({
+    revision: "b".repeat(40),
+    image: "agent-log-viewer:staging-b",
+    endpoint: "not-a-url",
+    containers: { viewer: "v", runtimeHost: "r" },
+    deployedAt: "2026-07-24T00:00:00.000Z",
+  })).toThrow();
+  expect(() => stagingReleaseRecord({
+    revision: "b".repeat(40),
+    image: "agent-log-viewer:staging-b",
+    endpoint: "http://127.0.0.1:8899",
+    containers: { viewer: "v" },
+    deployedAt: "2026-07-24T00:00:00.000Z",
+  })).toThrow();
+});

--- a/src/lib/staging.test.ts
+++ b/src/lib/staging.test.ts
@@ -3,10 +3,11 @@ import { expect, test } from "bun:test";
 import { isStagingMode, stagingReleaseRecord, STAGING_RELEASE_FILE } from "./staging";
 
 test("isStagingMode requires the exact LLV_STAGING=1 opt-in", () => {
-  expect(isStagingMode({ LLV_STAGING: "1" } as NodeJS.ProcessEnv)).toBe(true);
-  expect(isStagingMode({} as NodeJS.ProcessEnv)).toBe(false);
-  expect(isStagingMode({ LLV_STAGING: "0" } as NodeJS.ProcessEnv)).toBe(false);
-  expect(isStagingMode({ LLV_STAGING: "true" } as NodeJS.ProcessEnv)).toBe(false);
+  const env = (values: Record<string, string>) => values as unknown as NodeJS.ProcessEnv;
+  expect(isStagingMode(env({ LLV_STAGING: "1" }))).toBe(true);
+  expect(isStagingMode(env({}))).toBe(false);
+  expect(isStagingMode(env({ LLV_STAGING: "0" }))).toBe(false);
+  expect(isStagingMode(env({ LLV_STAGING: "true" }))).toBe(false);
 });
 
 test("staging release records carry the deployed revision and container pair", () => {

--- a/src/lib/staging.ts
+++ b/src/lib/staging.ts
@@ -1,0 +1,58 @@
+/**
+ * Staging instance mode (#659). A staging deployment serves the `stage`
+ * branch on its own fixed front port so the operator can review features
+ * next to prod. The hard contract is state isolation: a staging process must
+ * never read or mutate prod viewer-release state, the agent registry,
+ * runtime events, the board, or pipelines. Agent launches stay enabled —
+ * they run against staging's own state — and the UI shows a staging badge
+ * instead of refusing operator actions (operator revision, 2026-07-24).
+ */
+
+export const STAGING_MODE_ENV = "LLV_STAGING";
+
+/** Default staging state dir name, a sibling of the prod `state` dir. */
+export const STAGING_STATE_DIRNAME = "state-staging";
+
+/** Inspectable record of the deployed staging revision, inside the staging state dir. */
+export const STAGING_RELEASE_FILE = "staging-release.json";
+
+export function isStagingMode(env: NodeJS.ProcessEnv = process.env): boolean {
+  return env[STAGING_MODE_ENV] === "1";
+}
+
+export interface StagingReleaseRecord {
+  revision: string;
+  image: string;
+  endpoint: string;
+  containers: { viewer: string; runtimeHost: string };
+  deployedAt: string;
+}
+
+/** Validating parse shared by the deploy script (writer) and /api/staging (reader). */
+export function stagingReleaseRecord(value: unknown): StagingReleaseRecord {
+  if (!value || typeof value !== "object" || Array.isArray(value)) throw new Error("staging release record is invalid");
+  const record = value as Record<string, unknown>;
+  const containers = record.containers;
+  if (typeof record.revision !== "string" || !/^[0-9a-f]{40}$/.test(record.revision)
+    || typeof record.image !== "string" || !record.image
+    || typeof record.deployedAt !== "string" || Number.isNaN(Date.parse(record.deployedAt))
+    || !containers || typeof containers !== "object" || Array.isArray(containers)) {
+    throw new Error("staging release record is invalid");
+  }
+  if (typeof record.endpoint !== "string") throw new Error("staging release record is invalid");
+  let endpoint: URL;
+  try { endpoint = new URL(record.endpoint); }
+  catch { throw new Error("staging release endpoint is invalid"); }
+  if (endpoint.protocol !== "http:" || !endpoint.port) throw new Error("staging release endpoint is invalid");
+  const pair = containers as Record<string, unknown>;
+  if (typeof pair.viewer !== "string" || !pair.viewer || typeof pair.runtimeHost !== "string" || !pair.runtimeHost) {
+    throw new Error("staging release containers are invalid");
+  }
+  return {
+    revision: record.revision,
+    image: record.image,
+    endpoint: record.endpoint,
+    containers: { viewer: pair.viewer, runtimeHost: pair.runtimeHost },
+    deployedAt: record.deployedAt,
+  };
+}

--- a/src/runtime-host/candidateContainer.ts
+++ b/src/runtime-host/candidateContainer.ts
@@ -157,7 +157,7 @@ export function viewerCandidateTmuxEnvironment(
     : configured;
 }
 
-function viewerCandidateVolumes(
+export function viewerCandidateVolumes(
   service: ViewerComposeService,
   overrides: Pick<ViewerCandidateContainerOverrides, "legacyTmuxExternal" | "tmuxTmpdir">,
 ): ViewerComposeVolume[] {

--- a/src/runtime-host/stagingContainer.test.ts
+++ b/src/runtime-host/stagingContainer.test.ts
@@ -1,0 +1,140 @@
+import { expect, test } from "bun:test";
+import path from "node:path";
+
+import type { ViewerComposeService } from "./candidateContainer";
+import {
+  STAGING_FRONT_PORT,
+  STAGING_LABEL,
+  STAGING_RUNTIME_HOST_CONTAINER,
+  STAGING_VIEWER_CONTAINER,
+  stagingImageName,
+  stagingRuntimeHostDockerArgs,
+  stagingStatePaths,
+  stagingViewerDockerArgs,
+} from "./stagingContainer";
+
+const revision = "d".repeat(40);
+
+const composeService = {
+  build: { context: "/source", dockerfile: "Dockerfile" },
+  command: ["sh", "-c", "exec bun-container --bun node_modules/.bin/next start --port \"$${PORT:-8898}\" --hostname \"$${HOSTNAME:-127.0.0.1}\""],
+  entrypoint: null,
+  environment: {
+    HOME: "/home/user",
+    HOSTNAME: "127.0.0.1",
+    PORT: "8898",
+    XDG_CONFIG_HOME: "/home/user/.config",
+    XDG_CACHE_HOME: "/home/user/.cache",
+    LLV_RUNTIME_EVENTS: "0",
+    LLV_RUNTIME_HOST_SOCKET: "/home/user/.config/agent-log-viewer/state/runtime-host.sock",
+    LLV_VIEWER_DEPLOY_TARGET: "/home/user/.config/agent-log-viewer/state/viewer-release.json",
+    LLV_VIEWER_PORT: "8898",
+    LLV_LEGACY_TMUX_EXTERNAL: "0",
+    TMUX_TMPDIR: "/tmp",
+    LLV_DOCKER_NSENTER_SHIMS: "1",
+    GIT_SSH_COMMAND: "ssh compose-config",
+  },
+  image: "agent-log-viewer:node22",
+  labels: { "compose.viewer": "production" },
+  network_mode: "host",
+  pid: "host",
+  profiles: [],
+  privileged: true,
+  restart: "unless-stopped",
+  "user": "1000:1000",
+  volumes: [
+    { type: "bind", source: "/home/user", target: "/home/user", bind: {} },
+    { type: "bind", source: "/tmp/tmux-1000", target: "/tmp/tmux-1000", bind: {} },
+  ],
+  working_dir: "/app",
+} satisfies ViewerComposeService;
+
+const paths = stagingStatePaths("/home/user/.config/agent-log-viewer/state-staging");
+const tmux = { legacyTmuxExternal: "0", tmuxTmpdir: "/tmp" };
+
+function valuesAfter(args: string[], flag: string): string[] {
+  return args.flatMap((value, index) => value === flag ? [args[index + 1]!] : []);
+}
+
+function environmentFromArgs(args: string[]): Record<string, string> {
+  return Object.fromEntries(valuesAfter(args, "-e").map((entry) => {
+    const separator = entry.indexOf("=");
+    return [entry.slice(0, separator), entry.slice(separator + 1)];
+  }));
+}
+
+test("the staging front port is a documented fixed port distinct from prod and tests", () => {
+  expect(STAGING_FRONT_PORT).toBe(8899);
+});
+
+test("staging image names pin the deployed revision", () => {
+  expect(stagingImageName(revision)).toBe(`agent-log-viewer:staging-${"d".repeat(12)}`);
+  expect(() => stagingImageName("origin/stage")).toThrow();
+});
+
+test("staging state paths all live inside the staging state dir", () => {
+  expect(paths.runtimeSocket.startsWith(`${paths.stateDir}${path.sep}`)).toBe(true);
+  expect(paths.runtimeJournal.startsWith(`${paths.stateDir}${path.sep}`)).toBe(true);
+});
+
+test("the staging viewer container serves the fixed staging port from isolated state", () => {
+  const args = stagingViewerDockerArgs({ revision, image: stagingImageName(revision), service: composeService, paths, tmux });
+  const environment = environmentFromArgs(args);
+  expect(valuesAfter(args, "--name")).toEqual([STAGING_VIEWER_CONTAINER]);
+  expect(args[args.length - composeService.command.length - 1]).toBe(stagingImageName(revision));
+  expect(environment.PORT).toBe("8899");
+  expect(environment.LLV_STAGING).toBe("1");
+  expect(environment.LLV_STATE_DIR).toBe(paths.stateDir);
+  expect(environment.LLV_RUNTIME_EVENTS).toBe("1");
+  expect(environment.LLV_RUNTIME_HOST_SOCKET).toBe(paths.runtimeSocket);
+  /* The compose command keeps its legacy-launch gate, so the grant travels along. */
+  expect(environment.LLV_ALLOW_LEGACY_VIEWER).toBe("1");
+  expect(args.slice(-composeService.command.length + 2)[0]).toContain("next start");
+});
+
+test("staging containers are never labelled as prod-managed releases", () => {
+  for (const args of [
+    stagingViewerDockerArgs({ revision, image: stagingImageName(revision), service: composeService, paths, tmux }),
+    stagingRuntimeHostDockerArgs({ revision, image: stagingImageName(revision), service: composeService, paths, tmux }),
+  ]) {
+    const labels = valuesAfter(args, "--label");
+    expect(labels).toContain(`${STAGING_LABEL}=1`);
+    expect(labels).toContain(`dev.live-log-viewer.revision=${revision}`);
+    expect(labels.some((label) => label.startsWith("dev.live-log-viewer.managed="))).toBe(false);
+  }
+});
+
+test("staging containers never carry prod deployment or release state env", () => {
+  for (const args of [
+    stagingViewerDockerArgs({ revision, image: stagingImageName(revision), service: composeService, paths, tmux }),
+    stagingRuntimeHostDockerArgs({ revision, image: stagingImageName(revision), service: composeService, paths, tmux }),
+  ]) {
+    const environment = environmentFromArgs(args);
+    expect(environment.LLV_VIEWER_DEPLOY_TARGET).toBeUndefined();
+    expect(environment.LLV_VIEWER_PORT).toBeUndefined();
+    expect(environment.LLV_STATE_DIR).toBe(paths.stateDir);
+    expect(environment.LLV_STAGING).toBe("1");
+  }
+});
+
+test("the staging runtime-host runs the events host against the staging journal without deployments", () => {
+  const args = stagingRuntimeHostDockerArgs({ revision, image: stagingImageName(revision), service: composeService, paths, tmux });
+  const environment = environmentFromArgs(args);
+  expect(valuesAfter(args, "--name")).toEqual([STAGING_RUNTIME_HOST_CONTAINER]);
+  expect(environment.LLV_RUNTIME_EVENTS).toBe("1");
+  expect(environment.LLV_RUNTIME_JOURNAL).toBe(paths.runtimeJournal);
+  expect(environment.LLV_RUNTIME_HOST_SOCKET).toBe(paths.runtimeSocket);
+  expect(environment.LLV_VIEWER_DEPLOYMENTS).toBe("0");
+  expect(args.slice(-3)).toEqual(["bun-container", "run", "src/runtime-host/main.ts"]);
+});
+
+test("staging container args refuse a state dir that resolves to prod state", () => {
+  const prodPaths = stagingStatePaths("/home/user/.config/agent-log-viewer/state");
+  expect(() => stagingViewerDockerArgs({ revision, image: stagingImageName(revision), service: composeService, paths: prodPaths, tmux }))
+    .toThrow(/staging/i);
+  expect(() => stagingRuntimeHostDockerArgs({ revision, image: stagingImageName(revision), service: composeService, paths: prodPaths, tmux }))
+    .toThrow(/staging/i);
+  const legacyPaths = stagingStatePaths("/home/user/.claude/viewer-state");
+  expect(() => stagingViewerDockerArgs({ revision, image: stagingImageName(revision), service: composeService, paths: legacyPaths, tmux }))
+    .toThrow(/staging/i);
+});

--- a/src/runtime-host/stagingContainer.ts
+++ b/src/runtime-host/stagingContainer.ts
@@ -1,0 +1,154 @@
+import path from "node:path";
+
+import { withoutWakatimeCredential } from "@/lib/wakatime/credential";
+
+import {
+  AGENT_REGISTRY_SQLITE_ENV,
+  viewerCandidateVolumes,
+  viewerRegistryBackendMode,
+  type ViewerCandidateContainerOverrides,
+  type ViewerComposeService,
+} from "./candidateContainer";
+
+/**
+ * Staging deployment target (#659). One fixed pair of containers serves the
+ * `stage` branch beside prod: same image build path, simple replace (no
+ * blue-green), own state dir. Front ports on this host: 8898 prod front
+ * proxy, 8899 staging viewer (this constant), 8901 test compose default,
+ * 18000–19999 prod blue-green candidates.
+ */
+export const STAGING_FRONT_PORT = 8899;
+
+/** Staging containers carry this label INSTEAD of dev.live-log-viewer.managed,
+    so prod retain/cleanup sweeps and candidate port reservation never see them. */
+export const STAGING_LABEL = "dev.live-log-viewer.staging";
+
+export const STAGING_VIEWER_CONTAINER = "llv-staging-viewer";
+export const STAGING_RUNTIME_HOST_CONTAINER = "llv-staging-runtime-host";
+
+export interface StagingStatePaths {
+  stateDir: string;
+  runtimeSocket: string;
+  runtimeJournal: string;
+}
+
+/** Every mutable staging path hangs off the one staging state dir. */
+export function stagingStatePaths(stateDir: string): StagingStatePaths {
+  return {
+    stateDir,
+    runtimeSocket: path.join(stateDir, "runtime-host.sock"),
+    runtimeJournal: path.join(stateDir, "runtime-events.sqlite"),
+  };
+}
+
+export function stagingImageName(revision: string): string {
+  if (!/^[0-9a-f]{40}$/.test(revision)) throw new Error("staging image revision must be a full commit SHA");
+  return `agent-log-viewer:staging-${revision.slice(0, 12)}`;
+}
+
+export interface StagingContainerContext {
+  revision: string;
+  image: string;
+  service: ViewerComposeService;
+  paths: StagingStatePaths;
+  tmux: Pick<ViewerCandidateContainerOverrides, "legacyTmuxExternal" | "tmuxTmpdir">;
+  port?: number;
+}
+
+/* The isolation guard at container-construction time: whatever the compose
+   snapshot or the caller's configuration says, a staging container is never
+   assembled around the prod state dir (or the legacy dirs that alias it). */
+function assertIsolatedStateDir(context: StagingContainerContext): void {
+  const home = context.service.environment.HOME;
+  if (!home) throw new Error("Viewer Compose service HOME is required");
+  const configRoot = context.service.environment.XDG_CONFIG_HOME || path.join(home, ".config");
+  const prodDirs = [
+    path.join(configRoot, "agent-log-viewer", "state"),
+    path.join(configRoot, "live-log-viewer", "state"),
+    path.join(home, ".claude", "viewer-state"),
+  ];
+  const resolved = path.resolve(context.paths.stateDir);
+  if (prodDirs.some((prod) => path.resolve(prod) === resolved)) {
+    throw new Error(`staging containers refuse the production state dir ${resolved}`);
+  }
+}
+
+/* Shared shape for both staging containers: prod release/deployment env is
+   stripped (LLV_VIEWER_DEPLOY_TARGET names prod's viewer-release.json and
+   LLV_VIEWER_PORT the prod front port), and every state-bearing knob is
+   repinned into the staging state dir. */
+function stagingEnvironment(context: StagingContainerContext): Record<string, string> {
+  const snapshot = withoutWakatimeCredential({
+    ...context.service.environment,
+    [AGENT_REGISTRY_SQLITE_ENV]: viewerRegistryBackendMode(context.service),
+    LLV_STAGING: "1",
+    LLV_STATE_DIR: context.paths.stateDir,
+    LLV_RUNTIME_EVENTS: "1",
+    LLV_RUNTIME_HOST_SOCKET: context.paths.runtimeSocket,
+    LLV_LEGACY_TMUX_EXTERNAL: context.tmux.legacyTmuxExternal,
+    TMUX_TMPDIR: context.tmux.tmuxTmpdir,
+  });
+  delete snapshot.LLV_VIEWER_DEPLOY_TARGET;
+  delete snapshot.LLV_VIEWER_PORT;
+  return Object.fromEntries(Object.entries(snapshot)
+    .filter((entry): entry is [string, string] => typeof entry[1] === "string"));
+}
+
+function stagingDockerArgs(
+  context: StagingContainerContext,
+  container: string,
+  environment: Record<string, string>,
+  command: string[],
+): string[] {
+  assertIsolatedStateDir(context);
+  const labels = {
+    ...context.service.labels,
+    [STAGING_LABEL]: "1",
+    "dev.live-log-viewer.revision": context.revision,
+  };
+  const volumes = viewerCandidateVolumes(context.service, context.tmux);
+  return [
+    "docker", "run", "-d",
+    "--restart", context.service.restart,
+    "--name", container,
+    ...Object.entries(labels).sort(([left], [right]) => left.localeCompare(right)).flatMap(([key, value]) => ["--label", `${key}=${value}`]),
+    "--network", context.service.network_mode,
+    "--pid", context.service.pid,
+    ...(context.service.privileged ? ["--privileged"] : []),
+    "--user", context.service.user,
+    "--workdir", context.service.working_dir,
+    ...Object.entries(environment).sort(([left], [right]) => left.localeCompare(right)).flatMap(([key, value]) => ["-e", `${key}=${value}`]),
+    ...volumes.flatMap((volume) => [
+      "--mount",
+      `type=bind,source=${volume.source},target=${volume.target}${volume.read_only ? ",readonly" : ""}`,
+    ]),
+    context.image,
+    ...command,
+  ];
+}
+
+/** The staging Viewer: the compose viewer command on the fixed staging port. */
+export function stagingViewerDockerArgs(context: StagingContainerContext): string[] {
+  const port = context.port ?? STAGING_FRONT_PORT;
+  const environment = {
+    ...stagingEnvironment(context),
+    PORT: String(port),
+    LLV_ALLOW_LEGACY_VIEWER: "1",
+  };
+  const command = context.service.command?.map((argument) => argument.replaceAll("$$", () => "$")) ?? [];
+  return stagingDockerArgs(context, STAGING_VIEWER_CONTAINER, environment, command);
+}
+
+/** The staging runtime-host: events host for spawn/attach/message delivery
+    against the staging journal; Viewer deployments (and with them the prod
+    front proxy and viewer-release writes) stay off. */
+export function stagingRuntimeHostDockerArgs(context: StagingContainerContext): string[] {
+  const environment: Record<string, string> = {
+    ...stagingEnvironment(context),
+    LLV_RUNTIME_JOURNAL: context.paths.runtimeJournal,
+    LLV_VIEWER_DEPLOYMENTS: "0",
+    LLV_RUNTIME_LEGACY_SCHEDULER: "0",
+  };
+  delete environment.PORT;
+  return stagingDockerArgs(context, STAGING_RUNTIME_HOST_CONTAINER, environment, ["bun-container", "run", "src/runtime-host/main.ts"]);
+}


### PR DESCRIPTION
Closes #659.

Implements the staging deployment target per the issue, with the operator revision from the 2026-07-24 issue comment applied: **point 3 is relaxed** — agent launches (spawn, attach, migrations, pipelines, message delivery) stay enabled on staging so features like #621 voice mode can be tested for real. The hard requirement is state isolation, and the UI shows a staging badge instead of refusals.

## What ships

**1. Separate instance on a fixed front port — `127.0.0.1:8899`**
Chosen after checking the deploy config and host: 8898 is the prod front proxy, 8901 the compose test default, 18000–19999 the prod blue-green candidate range; 8899 is free and is now documented as reserved for staging (`docs/staging.md`).

**2. Hard state isolation (`LLV_STAGING=1`)**
- `stateDir()` in staging mode defaults to `~/.config/agent-log-viewer/state-staging`, **throws** if pointed at the prod state dir or either legacy state dir, and never runs the legacy-migration copy. Registry, runtime events journal + socket, board, pipelines, flows, inbox and release records all resolve through it.
- `src/runtime-host/stagingContainer.ts` re-asserts the same guard when assembling `docker run` args, strips prod-only env (`LLV_VIEWER_DEPLOY_TARGET`, `LLV_VIEWER_PORT`), and labels staging containers `dev.live-log-viewer.staging=1` — never `dev.live-log-viewer.managed=1` — so prod retain/cleanup sweeps and candidate-port reservation cannot touch them.
- Agents launched from staging register on staging's own board/registry/journal. Transcripts are machine-global by design (any viewer on the host sees every transcript in its file feed); prod's registry/board/events/pipelines stay untouched.

**3. Staging badge instead of refusals**
`GET /api/staging` reports `{staging, revision, deployedAt, endpoint}` from `staging-release.json`; `StagingBadge` renders a fixed top-center **Staging · <sha7>** pill on staging and nothing on prod (runtime state, not a build-time constant — the same image serves both).

**4. Stage deploy entrypoint (sibling of the exact-SHA prod tool)**
`bun run deploy:staging` (or `bun scripts/deploy-staging.ts --revision <sha>`) deploys the exact current `stage` head: own canonical mirror under the staging state dir, the same Dockerfile build path as prod deployments, simple replace of the `llv-staging-runtime-host` + `llv-staging-viewer` pair (no blue-green), health gate until `/api/staging` on 8899 serves the exact deployed revision, and the inspectable `staging-release.json` record.

**5. Verification built in**
The deploy script fingerprints (sha256 + mtime) prod's `viewer-release.json`, `agent-registry.json`, `runtime-events.sqlite`, `board.json`, `pipelines.json`, `flows.json` before/after and **fails** if `viewer-release.json` changed; the diff for the rest is printed for the operator (live prod legitimately keeps writing them). Full operator verification steps in `docs/staging.md`. No deploy was performed from this pipeline — the operator's session runs `bun run deploy:staging`.

## TDD + gates

RED commit `cc49421e` first (isolation seams, release record, route, container args, badge, prod-evidence set), then GREEN. Evidence:
- affected suites: 183 pass / 0 fail (staging tests + full `src/runtime-host/`), Viewer tests pass
- `bunx tsc --noEmit` clean; changed-file ESLint clean; `bun run privacy:check` PASS; `bun run build` OK (`/api/staging` in the route table)
- full `bun test` compared against an origin/main baseline worktree: baseline fails 103 / branch 96–99 in this sandbox (docker/tmux/timing-dependent suites, fail-set fluctuates run-to-run); every branch-unique failing file passes solo (87/87). The one deterministic branch delta was the `Bun.spawn` credential-inventory gate picking up the new deploy script's (already credential-isolated) spawn — registered in `ccfe0adf`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
