### PR TITLE
fix(feed): preserve shell cards despite MCP attribution

### DIFF
--- a/src/components/feed/parse.test.ts
+++ b/src/components/feed/parse.test.ts
@@ -103,6 +103,30 @@ function itemsOfKind(feed: ReturnType<typeof buildFeed>, kind: Item["kind"]) {
 }
 
 describe("feed session parity with one-shot parse", () => {
+  test("keeps a Claude Bash command when the enclosing record carries Viewer MCP attribution", () => {
+    const call = JSON.stringify({
+      type: "assistant",
+      timestamp: "2026-07-24T19:57:42Z",
+      attributionMcpServer: "viewer",
+      attributionMcpTool: "deployment_status",
+      message: { content: [{
+        type: "tool_use",
+        id: "bash-gh-pr",
+        name: "Bash",
+        input: { command: "gh pr view 665 --json number,title", description: "Inspect latest merged PRs" },
+      }] },
+    });
+
+    const item = buildFeed(claudeFile, [call], false, "").items[0];
+    expect(item).toMatchObject({
+      kind: "tool",
+      tool: "Bash",
+      summary: "gh pr view 665 --json number,title",
+    });
+    if (item.kind !== "tool") throw new Error("expected tool");
+    expect(item.mcp).toBeUndefined();
+  });
+
   test("claude transcript: tools, results, grouping, tmsg delivery, compaction", () => {
     const lines = [
       claudeUser("take the first step"),

--- a/src/components/feed/parse.ts
+++ b/src/components/feed/parse.ts
@@ -1947,7 +1947,12 @@ export function createFeedSession(cfg: FeedSessionConfig): FeedSession {
           } else {
             const command = familyOf(name) === "shell" ? textPart(input.command) : undefined;
             const lang = familyOf(name) === "read" ? extLang(textPart(input.file_path)) : undefined;
-            const mcpIdentity = viewerMcpToolUse(name) ?? attributedMcp;
+            /* Claude may stamp an entire assistant record with the MCP tool that
+             * supplied context. That provenance is useful only for an actual
+             * MCP call. Applying it to a sibling Bash/Read call turns a real
+             * command into an unrelated MCP card (for example, `gh pr view`
+             * rendered as "Reading deployment status"). */
+            const mcpIdentity = viewerMcpToolUse(name) ?? (name.startsWith("mcp__") ? attributedMcp : null);
             const mcp = mcpIdentity
               ? { ...mcpIdentity, args: input, result: null }
               : undefined;


### PR DESCRIPTION
Fixes Viewer feed parsing where Claude Bash calls inherited enclosing Viewer MCP attribution and rendered as unrelated MCP cards, e.g. gh pr view 665 as Reading deployment status.\n\nAdds a regression test for the production-shaped transcript record.