### PR TITLE
fix(feed): classify tool cards by the call's own MCP name (#650)

### DIFF
--- a/src/components/feed/mcpIdentity.parse.test.tsx
+++ b/src/components/feed/mcpIdentity.parse.test.tsx
@@ -1,0 +1,132 @@
+import { expect, test } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import type { FileEntry } from "@/lib/types";
+
+import { FeedItem } from "./FeedItem";
+import { buildFeed, createFeedSession, type Item } from "./parse";
+
+/* Issue #650: a Claude assistant record carries the MCP tool that produced the
+   turn's context in `attributionMcpServer`/`attributionMcpTool`. That stamp
+   sits on the whole record, so every sibling tool_use inherits it — a Bash
+   command made after a viewer MCP call used to render as "MCP · viewer ·
+   Updating pipeline". A card's identity comes from its own tool_use name, and
+   from nothing else. */
+
+const claudeFile = { path: "/tmp/x.jsonl", engine: "claude", fmt: "claude", activity: "recent" } as FileEntry;
+
+const attributed = (block: Record<string, unknown>, ts: string) =>
+  JSON.stringify({
+    type: "assistant",
+    timestamp: ts,
+    attributionMcpServer: "viewer",
+    attributionMcpTool: "pipeline_action",
+    message: { content: [block] },
+  });
+
+const toolResult = (id: string, text: string, ts: string) =>
+  JSON.stringify({
+    type: "user",
+    timestamp: ts,
+    message: { content: [{ type: "tool_result", tool_use_id: id, content: [{ type: "text", text }] }] },
+  });
+
+/* A conversation shaped like the production repro: a real viewer MCP call, then
+   ordinary tool calls that follow it inside attributed records. */
+const conversation = [
+  JSON.stringify({ type: "user", timestamp: "2026-07-24T10:50:00Z", message: { content: "advance the pipeline" } }),
+  attributed({
+    type: "tool_use",
+    id: "call-viewer",
+    name: "mcp__viewer__pipeline_action",
+    input: { pipelineId: "pipe-1", action: "update" },
+  }, "2026-07-24T10:50:10Z"),
+  toolResult("call-viewer", "{\"ok\":true}", "2026-07-24T10:50:11Z"),
+  attributed({
+    type: "tool_use",
+    id: "call-bash",
+    name: "Bash",
+    input: { command: "bun test src/components/feed/parse.test.ts", description: "Run the feed parser tests", timeout: 600000 },
+  }, "2026-07-24T10:51:44Z"),
+  toolResult("call-bash", "12 pass", "2026-07-24T10:51:50Z"),
+  attributed({
+    type: "tool_use",
+    id: "call-browse",
+    name: "mcp__agent-browser__navigate",
+    input: { url: "https://example.invalid/board" },
+  }, "2026-07-24T10:52:20Z"),
+  attributed({
+    type: "tool_use",
+    id: "call-read",
+    name: "Read",
+    input: { file_path: "src/components/feed/parse.ts" },
+  }, "2026-07-24T10:52:52Z"),
+];
+
+function toolItems(items: Item[]) {
+  const byId = new Map<string, Extract<Item, { kind: "tool" }>>();
+  for (const item of items) {
+    if (item.kind === "tool") byId.set(item.id, item);
+    if (item.kind === "cmd-group") for (const call of item.calls) byId.set(call.id, call);
+  }
+  return byId;
+}
+
+test("a Bash call after a viewer MCP call keeps its own shell identity", () => {
+  const calls = toolItems(buildFeed(claudeFile, conversation, false, "").items);
+
+  const bash = calls.get("call-bash");
+  expect(bash).toBeDefined();
+  expect(bash!.tool).toBe("Bash");
+  expect(bash!.family).toBe("shell");
+  expect(bash!.summary).toBe("bun test src/components/feed/parse.test.ts");
+  expect(bash!.mcp).toBeUndefined();
+
+  const read = calls.get("call-read");
+  expect(read!.tool).toBe("Read");
+  expect(read!.mcp).toBeUndefined();
+
+  // The genuine viewer call still gets its MCP identity, from its own name.
+  const viewer = calls.get("call-viewer");
+  expect(viewer!.mcp).toMatchObject({ serverName: "viewer", toolName: "pipeline_action" });
+});
+
+test("a non-viewer MCP call is never relabelled with the record's viewer attribution", () => {
+  const calls = toolItems(buildFeed(claudeFile, conversation, false, "").items);
+
+  const browse = calls.get("call-browse");
+  expect(browse).toBeDefined();
+  expect(browse!.tool).toBe("mcp__agent-browser__navigate");
+  expect(browse!.mcp).toBeUndefined();
+});
+
+test("the incremental session classifies the same way as a one-shot parse", () => {
+  const session = createFeedSession({ engine: "claude", fmt: "claude", showSvc: false, lineFilter: "" });
+  let fed = 0;
+  let snapshot: Item[] = [];
+  while (fed < conversation.length) {
+    fed += 2;
+    snapshot = session.feed(conversation.slice(0, fed), 0, true).items.map((entry) => entry.item);
+  }
+  const calls = toolItems(snapshot);
+  expect(calls.get("call-bash")!.mcp).toBeUndefined();
+  expect(calls.get("call-browse")!.mcp).toBeUndefined();
+  expect(calls.get("call-viewer")!.mcp).toMatchObject({ serverName: "viewer", toolName: "pipeline_action" });
+});
+
+test("the feed renders the Bash call as a shell card and the viewer call as an MCP card", () => {
+  const calls = toolItems(buildFeed(claudeFile, conversation, false, "").items);
+
+  const bashHtml = renderToStaticMarkup(<FeedItem item={calls.get("call-bash")!} />);
+  expect(bashHtml).not.toContain("mcp-call-card");
+  expect(bashHtml).not.toContain("Updating pipeline");
+  expect(bashHtml).toContain("bun test src/components/feed/parse.test.ts");
+
+  const browseHtml = renderToStaticMarkup(<FeedItem item={calls.get("call-browse")!} />);
+  expect(browseHtml).not.toContain("mcp-call-card");
+  expect(browseHtml).not.toContain("Updating pipeline");
+
+  const viewerHtml = renderToStaticMarkup(<FeedItem item={calls.get("call-viewer")!} />);
+  expect(viewerHtml).toContain("mcp-call-card");
+  expect(viewerHtml).toContain("Updating pipeline");
+});

--- a/src/components/feed/parse.ts
+++ b/src/components/feed/parse.ts
@@ -1925,11 +1925,6 @@ export function createFeedSession(cfg: FeedSessionConfig): FeedSession {
       return;
     }
     if (obj.type === "assistant" && obj.message) {
-      const attributedServer = textPart(obj.attributionMcpServer);
-      const attributedTool = textPart(obj.attributionMcpTool);
-      const attributedMcp = attributedServer && attributedTool && isViewerMcpServer(attributedServer)
-        ? { serverName: attributedServer, toolName: attributedTool }
-        : null;
       for (const part of arr(rec(obj.message).content)) {
         if (part.type === "text" && textPart(part.text).trim()) {
           addProse(ts, textPart(part.text), textPart(obj.uuid) || undefined);
@@ -1970,12 +1965,14 @@ export function createFeedSession(cfg: FeedSessionConfig): FeedSession {
           } else {
             const command = familyOf(name) === "shell" ? textPart(input.command) : undefined;
             const lang = familyOf(name) === "read" ? extLang(textPart(input.file_path)) : undefined;
-            /* Claude may stamp an entire assistant record with the MCP tool that
-             * supplied context. That provenance is useful only for an actual
-             * MCP call. Applying it to a sibling Bash/Read call turns a real
-             * command into an unrelated MCP card (for example, `gh pr view`
-             * rendered as "Reading deployment status"). */
-            const mcpIdentity = viewerMcpToolUse(name) ?? (name.startsWith("mcp__") ? attributedMcp : null);
+            /* A card's identity is the call's own `mcp__<server>__<tool>` name
+             * and nothing else (issue #650). Claude stamps whole assistant
+             * records with `attributionMcpServer`/`attributionMcpTool` — the
+             * MCP tool that supplied the turn's context — and every sibling
+             * tool_use inherits that stamp, so honouring it renders a Bash
+             * command or an agent-browser call as "MCP · viewer · Updating
+             * pipeline" with the wrong tool's payload underneath. */
+            const mcpIdentity = viewerMcpToolUse(name);
             const mcp = mcpIdentity
               ? { ...mcpIdentity, args: input, result: null }
               : undefined;


### PR DESCRIPTION
## What was actually broken

The Bash symptom in #650 was already fixed by `ba52e262` — the implementer proved it by running the current parser over the production transcript named in the issue: 484 items, 100 MCP cards, zero non-MCP tools rendered as MCP cards.

The **classification leak** was not fixed. `ba52e262` narrowed the record-level attribution stamp rather than removing it, so any `mcp__` call whose own server is not the viewer — `mcp__agent-browser__navigate`, for instance, and `agent-browser` is a real spawn-profile server here — still inherited the surrounding record's attribution and rendered the issue's exact card: header `MCP · viewer`, title "Updating pipeline", subtitle `update`, with the browser call's payload inside.

## The fix

Card identity now comes solely from the `tool_use` name. The `attributionMcpServer` / `attributionMcpTool` record stamp is dropped from classification entirely: `mcp__<viewer-server>__<tool>` renders as an MCP card, everything else keeps its own family.

A reviewer corroborated this against 19 real transcripts carrying the stamp: it is routinely stale even on genuine MCP calls — 14 records stamped `viewer/get_pipeline` wrapped a `pipeline_action` call, 4 stamped `viewer/pipeline_action` wrapped `create_pipeline`. The old code mislabelled all of those; every genuine MCP `tool_use` in the sample carried a well-formed `mcp__server__tool` name, so nothing loses its identity.

## Verification

- New `src/components/feed/mcpIdentity.parse.test.tsx`: 4 tests, 3 of which fail on the base — including the DOM path through `FeedItem` and the incremental session path the live feed uses.
- Adjacent feed suites: 141 pass, 0 fail; a reviewer's wider run over the feed plus MCP presentation: 224 pass, 0 fail.
- `tsc --noEmit` clean; lint clean on both changed files (the 11 pre-existing errors live in untouched `scripts/*.cjs`).
- Privacy publication gate: PASS. The absolute transcript path quoted in the issue did not reach the fixtures.

## Review

Two independent read-only passes, both APPROVE, no blocking findings. Their non-blocking notes: the headline Bash test is documentation rather than the regression guard (the guard is the non-viewer MCP assertions), and non-viewer MCP calls now render as ordinary tool cards titled with their raw name — consistent with how they already behaved in unstamped records.

Closes #650