### PR TITLE
fix(limits): label quota windows by the horizon their data carries (#606)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ versions follow [SemVer](https://semver.org/) (0.x — the API may still move).
 ## [Unreleased]
 
 ### Fixed
+- The limits widget labels each quota window by the horizon its data actually
+  carries (#606). Codex reports every rate-limit window with its own length, and
+  a plan without a 5-hour limit sends its weekly window in the `primary` slot;
+  ingestion filed windows by slot, so a weekly number was drawn under the "5h"
+  label while the weekly window stayed empty and its chart said "no history
+  yet". Windows are now routed by their declared length everywhere they enter —
+  the app-server snapshot, the transcript fallback and the transcript backfill —
+  snapshots cached before the fix are relabelled on read, and a horizon the plan
+  does not report says so instead of showing a generic empty chart.
 - Multi-gigabyte active transcripts no longer starve the Viewer (#287). One
   process-wide scan coordinator now owns every catalog generation: the HTTP
   files cache, the pipeline watchdog, and the account controller join or queue

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,13 @@ versions follow [SemVer](https://semver.org/) (0.x — the API may still move).
   label while the weekly window stayed empty and its chart said "no history
   yet". Windows are now routed by their declared length everywhere they enter —
   the app-server snapshot, the transcript fallback and the transcript backfill —
-  snapshots cached before the fix are relabelled on read, and a horizon the plan
-  does not report says so instead of showing a generic empty chart.
+  with the reset horizon as the fallback evidence when a window declares no
+  length, and a rounded length (a week reported as 10081 minutes) still reading
+  as its horizon. Snapshots cached before the fix are relabelled on read.
+  Rate-limit events carrying no windows at all — other limit families — no
+  longer stand in for the account's snapshot, and only a snapshot that names
+  some window can claim a horizon is unreported, so a windowless read still
+  charts the history it has instead of a generic empty state.
 - Multi-gigabyte active transcripts no longer starve the Viewer (#287). One
   process-wide scan coordinator now owns every catalog generation: the HTTP
   files cache, the pipeline watchdog, and the account controller join or queue

--- a/src/components/AccountsPanel.dom.test.tsx
+++ b/src/components/AccountsPanel.dom.test.tsx
@@ -297,7 +297,7 @@ test("quota windows render as labeled meters with remaining capacity", async () 
   const initial = state(login({ phase: "authenticated" }), {
     accounts: [{
       id: "acc", label: "Acc", kind: "managed", authPresent: true, loginPending: false, loginState: "authenticated", deviceAuth: null, login: null,
-      limits: { freshness: "fresh", session: { usedPercent: 33, resetsAt: null }, weekly: { usedPercent: 80, resetsAt: null } },
+      limits: { freshness: "fresh", session: { usedPercent: 33, resetsAt: null, windowMinutes: 300 }, weekly: { usedPercent: 80, resetsAt: null, windowMinutes: 10_080 } },
     }],
   });
   const view = await mount(initial);

--- a/src/components/AccountsPanel.render.test.tsx
+++ b/src/components/AccountsPanel.render.test.tsx
@@ -97,7 +97,7 @@ test("breaks out each account's session and weekly windows with reset times", ()
       {
         id: "main", label: "Main", kind: "legacy", authPresent: true, loginPending: false, loginState: "authenticated", deviceAuth: null,
         effective: { percent: 45, window: "session", freshness: "fresh" },
-        limits: { freshness: "fresh", session: { usedPercent: 55, resetsAt: nowS + 7200 }, weekly: { usedPercent: 8, resetsAt: nowS + 259200 } },
+        limits: { freshness: "fresh", session: { usedPercent: 55, resetsAt: nowS + 7200, windowMinutes: 300 }, weekly: { usedPercent: 8, resetsAt: nowS + 259200, windowMinutes: 10_080 } },
       },
     ],
     active: "main",
@@ -110,12 +110,32 @@ test("breaks out each account's session and weekly windows with reset times", ()
   expect(html).toContain("reset"); // both windows carry a reset time
 });
 
+test("a weekly-only account labels its one window by the horizon it carries", () => {
+  // A Codex plan with no 5-hour limit reports a single weekly window; the row
+  // must read "Week", never the 5h label (issue #606).
+  const nowS = Math.floor(Date.now() / 1000);
+  const html = render(base({
+    accounts: [
+      {
+        id: "main", label: "Main", kind: "legacy", authPresent: true, loginPending: false, loginState: "authenticated", deviceAuth: null,
+        effective: { percent: 85, window: "weekly", freshness: "fresh" },
+        limits: { freshness: "fresh", session: null, weekly: { usedPercent: 15, resetsAt: nowS + 437_631, windowMinutes: 10_080 } },
+      },
+    ],
+    active: "main",
+  }));
+  const detail = html.match(/<dl[^>]*Quota windows[^>]*>[\s\S]*?<\/dl>/)?.[0] ?? "";
+  expect(detail).toContain(translate("en", "limits.week"));
+  expect(detail).not.toContain(translate("en", "limits.5h"));
+  expect(detail).toContain("85%"); // weekly remaining (100 - 15)
+});
+
 test("dims and labels a stale account limits read and omits a missing reset time", () => {
   const html = render(base({
     accounts: [
       {
         id: "main", label: "Main", kind: "legacy", authPresent: true, loginPending: false, loginState: "authenticated", deviceAuth: null,
-        limits: { freshness: "stale", session: { usedPercent: 20, resetsAt: null }, weekly: null },
+        limits: { freshness: "stale", session: { usedPercent: 20, resetsAt: null, windowMinutes: 300 }, weekly: null },
       },
     ],
     active: "main",

--- a/src/components/AccountsPanel.render.test.tsx
+++ b/src/components/AccountsPanel.render.test.tsx
@@ -130,6 +130,27 @@ test("a weekly-only account labels its one window by the horizon it carries", ()
   expect(detail).toContain("85%"); // weekly remaining (100 - 15)
 });
 
+test("a weekly-horizon window in the session field is labelled by its horizon, not its slot", () => {
+  // The row label must follow the window's declared length. With a weekly
+  // window sitting in the session field — the shape #606 was reported against —
+  // the row reads "Week"; a static per-slot label would print "5h" here.
+  const nowS = Math.floor(Date.now() / 1000);
+  const html = render(base({
+    accounts: [
+      {
+        id: "main", label: "Main", kind: "legacy", authPresent: true, loginPending: false, loginState: "authenticated", deviceAuth: null,
+        limits: { freshness: "fresh", session: { usedPercent: 15, resetsAt: nowS + 437_631, windowMinutes: 10_080 }, weekly: null },
+      },
+    ],
+    active: "main",
+  }));
+  const detail = html.match(/<dl[^>]*Quota windows[^>]*>[\s\S]*?<\/dl>/)?.[0] ?? "";
+  expect(detail).not.toBe("");
+  expect(detail).toContain(`<dt class="w-8 shrink-0 font-semibold">${translate("en", "limits.week")}</dt>`);
+  expect(detail).not.toContain(translate("en", "limits.5h"));
+  expect(detail).toContain("85%"); // 100 - 15, under the weekly label
+});
+
 test("dims and labels a stale account limits read and omits a missing reset time", () => {
   const html = render(base({
     accounts: [

--- a/src/components/AccountsPanel.tsx
+++ b/src/components/AccountsPanel.tsx
@@ -16,7 +16,7 @@ import { handleOverlayEscape } from "@/lib/overlay";
 
 import { Loader2, SquareTerminal, Trash2, X } from "./icons";
 import { Badge } from "./ui/Badge";
-import { formatResetClock, formatResetEta } from "./rateLimit";
+import { formatResetClock, formatResetEta, windowLabel } from "./rateLimit";
 import { engineTintOf } from "./utils";
 
 /** Amber that clears contrast on the panel background — state legibility never
@@ -75,8 +75,8 @@ function AccountLimitsDetail({ account, engine }: { account: AccountOption; engi
   const limits = account.limits;
   if (!limits) return null;
   const windows = [
-    { key: "session", label: t("limits.5h"), window: limits.session },
-    { key: "weekly", label: t("limits.week"), window: limits.weekly },
+    { key: "session", label: windowLabel(t, "session", limits.session?.windowMinutes), window: limits.session },
+    { key: "weekly", label: windowLabel(t, "weekly", limits.weekly?.windowMinutes), window: limits.weekly },
   ].filter((row): row is { key: string; label: string; window: NonNullable<typeof row.window> } => row.window != null);
   if (windows.length === 0) return null;
   const stale = limits.freshness === "stale";

--- a/src/components/BurndownPanel.dom.test.tsx
+++ b/src/components/BurndownPanel.dom.test.tsx
@@ -1,0 +1,134 @@
+import { afterEach, expect, test } from "bun:test";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { Window } from "happy-dom";
+
+import { installActEnv } from "@/test-helpers/actEnv";
+import type { BurndownPayload, BurndownSeries } from "@/lib/types";
+
+const dom = new Window();
+installActEnv();
+Object.assign(globalThis, {
+  window: dom,
+  document: dom.document,
+  navigator: dom.navigator,
+  Node: dom.Node,
+  HTMLElement: dom.HTMLElement,
+  MouseEvent: dom.MouseEvent,
+  Event: dom.Event,
+  KeyboardEvent: dom.KeyboardEvent,
+  localStorage: dom.localStorage,
+});
+
+const { BurndownPanel } = await import("./BurndownPanel");
+
+const NOW = Math.round(Date.now() / 1000);
+
+let payload: BurndownPayload;
+globalThis.fetch = (async () => new Response(JSON.stringify(payload), { status: 200, headers: { "content-type": "application/json" } })) as unknown as typeof fetch;
+
+/** A weekly series with real history, as the Codex backfill produces it. */
+function weeklySeries(): BurndownSeries {
+  return {
+    windowStart: NOW - 5 * 86_400,
+    resetsAt: NOW + 2 * 86_400,
+    windowSeconds: 7 * 24 * 3600,
+    samples: [
+      { t: NOW - 7_200, remaining: 70 },
+      { t: NOW - 3_600, remaining: 55 },
+      { t: NOW, remaining: 48 },
+    ],
+  };
+}
+
+/** The horizon the plan does not report at all: nothing to chart, ever. */
+function unreportedSeries(windowSeconds: number): BurndownSeries {
+  return { windowStart: null, resetsAt: null, windowSeconds, samples: [], windowUnreported: true };
+}
+
+let root: Root | null = null;
+afterEach(async () => {
+  if (root) await act(async () => { root?.unmount(); });
+  root = null;
+  document.body.replaceChildren();
+});
+
+async function render(): Promise<HTMLElement> {
+  const host = document.createElement("div");
+  document.body.appendChild(host);
+  await act(async () => {
+    root = createRoot(host);
+    root.render(<BurndownPanel engine="codex" label="Codex" plan="pro" activeAccountId="account-a" onClose={() => {}} />);
+  });
+  return host;
+}
+
+/** Paths drawn inside the plot itself; the panel's close icon is an svg too. */
+function chartPaths(host: HTMLElement): number {
+  const chart = host.querySelector('svg[role="img"]');
+  return chart ? chart.querySelectorAll("path").length : 0;
+}
+
+function tab(host: HTMLElement, name: string): HTMLElement {
+  const found = [...host.querySelectorAll('[role="tab"]')].find((node) => (node.textContent ?? "").trim() === name);
+  if (!found) throw new Error(`no tab labelled ${name} among ${[...host.querySelectorAll('[role="tab"]')].map((n) => n.textContent).join(", ")}`);
+  return found as unknown as HTMLElement;
+}
+
+test("a Codex account with weekly history draws the weekly curve instead of claiming no history", async () => {
+  payload = {
+    claude: null,
+    codex: { session: unreportedSeries(5 * 3600), weekly: weeklySeries() },
+    claudeAccountId: null,
+    codexAccountId: "account-a",
+    historySince: new Date((NOW - 8 * 86_400) * 1000).toISOString(),
+  };
+  const host = await render();
+  // Two drawn paths inside the plot: the ideal diagonal and the actual curve.
+  expect(chartPaths(host)).toBe(2);
+  expect(host.textContent ?? "").not.toContain("No history yet");
+});
+
+test("the 5h tab names the missing window instead of showing a generic empty state", async () => {
+  payload = {
+    claude: null,
+    codex: { session: unreportedSeries(5 * 3600), weekly: weeklySeries() },
+    claudeAccountId: null,
+    codexAccountId: "account-a",
+    historySince: new Date((NOW - 8 * 86_400) * 1000).toISOString(),
+  };
+  const host = await render();
+  await act(async () => { tab(host, "5h").click(); });
+  const text = host.textContent ?? "";
+  expect(text).toContain("reports no 5h window");
+  expect(text).not.toContain("No history yet");
+  expect(chartPaths(host)).toBe(0);
+});
+
+test("each tab is named by the horizon its own series carries", async () => {
+  // A series whose window is a week long is labelled "Week" wherever it sits,
+  // so a weekly-horizon value is never presented as a 5-hour figure (#606).
+  payload = {
+    claude: null,
+    codex: { session: { ...weeklySeries(), windowSeconds: 7 * 24 * 3600 }, weekly: weeklySeries() },
+    claudeAccountId: null,
+    codexAccountId: "account-a",
+    historySince: null,
+  };
+  const host = await render();
+  const labels = [...host.querySelectorAll('[role="tab"]')].map((node) => (node.textContent ?? "").trim());
+  expect(labels).toEqual(["Week", "Week"]);
+});
+
+test("a history response for another account is not charted under this one", async () => {
+  payload = {
+    claude: null,
+    codex: { session: unreportedSeries(5 * 3600), weekly: weeklySeries() },
+    claudeAccountId: null,
+    codexAccountId: "account-b",
+    historySince: null,
+  };
+  const host = await render();
+  expect(host.textContent ?? "").toContain("Loading history…");
+  expect(chartPaths(host)).toBe(0);
+});

--- a/src/components/BurndownPanel.tsx
+++ b/src/components/BurndownPanel.tsx
@@ -8,6 +8,7 @@ import { handleOverlayEscape } from "@/lib/overlay";
 import type { BurndownPayload, BurndownSeries } from "@/lib/types";
 
 import { X } from "./icons";
+import { windowLabel } from "./rateLimit";
 import { engineTintOf } from "./utils";
 
 const VB_W = 320;
@@ -127,6 +128,9 @@ export function BurndownPanel({
   }, []);
 
   const engineData = burndownForActiveAccount(data, engine, activeAccountId);
+  // Each tab is named by the horizon its own series carries, so a plan whose
+  // "5h" window is really a weekly one is never labelled 5h (issue #606).
+  const tabLabel = (key: WindowKey) => windowLabel(t, key, engineData ? engineData[key].windowSeconds / 60 : null);
   // A response whose account stamp no longer matches is treated as not-yet-loaded
   // so a stale-account curve never shows; the effect above will refetch.
   const ownershipPending = Boolean(data && !engineData);
@@ -171,7 +175,7 @@ export function BurndownPanel({
                 onClick={() => setWindow(key)}
                 className={`rounded-[6px] px-2 py-0.5 text-[10.5px] font-semibold focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 ${window === key ? "bg-sunken text-primary" : "text-muted hover:text-primary"}`}
               >
-                {t(key === "weekly" ? "limits.week" : "limits.5h")}
+                {tabLabel(key)}
               </button>
             ))}
           </div>
@@ -211,6 +215,10 @@ export function BurndownPanel({
               </div>
             ) : null}
           </>
+        ) : series?.windowUnreported ? (
+          // A precise reason beats "no history yet": the engine reports no
+          // window of this horizon at all, so no sampling will ever fill it.
+          <div className="py-6 text-center text-[12px] text-muted">{t("burndown.windowUnreported", { window: tabLabel(window) })}</div>
         ) : (
           <div className="py-6 text-center text-[12px] text-muted">
             {t("burndown.empty")}

--- a/src/components/LimitsFooter.dom.test.tsx
+++ b/src/components/LimitsFooter.dom.test.tsx
@@ -1,0 +1,100 @@
+import { afterEach, expect, test } from "bun:test";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { Window } from "happy-dom";
+
+import { installActEnv } from "@/test-helpers/actEnv";
+import type { LimitsPayload } from "@/lib/types";
+
+const dom = new Window();
+installActEnv();
+Object.assign(globalThis, {
+  window: dom,
+  document: dom.document,
+  navigator: dom.navigator,
+  Node: dom.Node,
+  HTMLElement: dom.HTMLElement,
+  MouseEvent: dom.MouseEvent,
+  PointerEvent: dom.Event,
+  Event: dom.Event,
+  KeyboardEvent: dom.KeyboardEvent,
+  localStorage: dom.localStorage,
+});
+
+const NOW = Math.round(Date.now() / 1000);
+
+let limits: LimitsPayload;
+const accounts = {
+  codex: { active: "account-a", accounts: [{ id: "account-a", label: "Account A", kind: "managed", authPresent: true, auth: { state: "authenticated" }, loginPending: false, loginState: "authenticated", deviceAuth: null }] },
+  claude: { active: "claude-a", accounts: [] },
+};
+
+// Bound before the component is imported so the singleton account stores read
+// this stub rather than the real endpoints.
+globalThis.fetch = (async (input: RequestInfo | URL) => {
+  const url = String(input);
+  if (url === "/api/limits") return Response.json(limits);
+  if (url === "/api/accounts") return Response.json(accounts);
+  return new Response(null, { status: 404 });
+}) as unknown as typeof fetch;
+
+const { LimitsFooter } = await import("./LimitsFooter");
+
+let root: Root | null = null;
+afterEach(async () => {
+  if (root) await act(async () => { root?.unmount(); });
+  root = null;
+  document.body.replaceChildren();
+});
+
+async function render(): Promise<HTMLElement> {
+  const host = document.createElement("div");
+  document.body.appendChild(host);
+  await act(async () => {
+    root = createRoot(host);
+    root.render(<LimitsFooter />);
+  });
+  // One more turn for the limits and accounts responses to land.
+  await act(async () => { await Promise.resolve(); });
+  return host;
+}
+
+test("a weekly-horizon Codex window is labelled Week in the footer, never 5h", async () => {
+  // The production shape of #606: the only window the plan reports is a weekly
+  // one, and it arrives in the session field. The footer row must be named by
+  // the horizon the number carries.
+  limits = {
+    claude: null,
+    codex: { session: { usedPercent: 15, resetsAt: NOW + 437_631, windowMinutes: 10_080 }, weekly: null, plan: "pro", capturedAt: NOW },
+    claudeAccountId: "claude-a",
+    codexAccountId: "account-a",
+    provenance: {
+      claude: { source: "unavailable", reason: null, staleSince: null },
+      codex: { source: "live", reason: null, staleSince: null },
+    },
+    staleSince: null,
+  };
+  const host = await render();
+  const text = host.textContent ?? "";
+  expect(text).toContain("Week");
+  expect(text).not.toContain("5h");
+  expect(text).toContain("85%"); // 100 − 15 remaining, under the weekly label
+});
+
+test("a genuine 5-hour window keeps the 5h label", async () => {
+  limits = {
+    claude: null,
+    codex: { session: { usedPercent: 40, resetsAt: NOW + 3_600, windowMinutes: 300 }, weekly: { usedPercent: 10, resetsAt: NOW + 172_800, windowMinutes: 10_080 }, plan: "pro", capturedAt: NOW },
+    claudeAccountId: "claude-a",
+    codexAccountId: "account-a",
+    provenance: {
+      claude: { source: "unavailable", reason: null, staleSince: null },
+      codex: { source: "live", reason: null, staleSince: null },
+    },
+    staleSince: null,
+  };
+  const host = await render();
+  const text = host.textContent ?? "";
+  expect(text).toContain("5h");
+  expect(text).toContain("Week");
+});

--- a/src/components/LimitsFooter.tsx
+++ b/src/components/LimitsFooter.tsx
@@ -10,7 +10,7 @@ import { LIMITS_RATE_LIMITED_REASON, LIMITS_REAUTH_REQUIRED_REASON, type EngineL
 import { AccountsPanel } from "./AccountsPanel";
 import { BurndownPanel } from "./BurndownPanel";
 import { ChevronDown, Loader2 } from "./icons";
-import { formatResetClock as fmtResetAt, formatResetEta as fmtEta, localeBcp47 as bcp47 } from "./rateLimit";
+import { formatResetClock as fmtResetAt, formatResetEta as fmtEta, localeBcp47 as bcp47, windowLabel } from "./rateLimit";
 import { engineTintOf, fmtAge } from "./utils";
 
 const POLL_MS = 60_000;
@@ -331,8 +331,8 @@ function EngineLimitsBlock({
             }}
             className={`block w-full px-3.5 pt-0.5 text-left hover:bg-canvas focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 ${visibleFailureReason ? "pb-1.5" : "pb-3"}`}
           >
-            <LimitRow label={t("limits.5h")} window={accountLimits!.session} engineColor={tint.color} now={now} />
-            <LimitRow label={t("limits.week")} window={accountLimits!.weekly} engineColor={tint.color} now={now} />
+            <LimitRow label={windowLabel(t, "session", accountLimits!.session?.windowMinutes)} window={accountLimits!.session} engineColor={tint.color} now={now} />
+            <LimitRow label={windowLabel(t, "weekly", accountLimits!.weekly?.windowMinutes)} window={accountLimits!.weekly} engineColor={tint.color} now={now} />
           </button>
         ) : visibleFailureReason ? null : (
           <div className="px-3.5 pb-3 pt-0.5 text-[10px] text-muted">{accounts.status === "loading" || identityPending ? t("limits.accountLoading") : t("limits.noDataYet")}</div>

--- a/src/components/rateLimit.test.ts
+++ b/src/components/rateLimit.test.ts
@@ -21,6 +21,18 @@ test("an undeclared horizon falls back to the slot's nominal name", () => {
   expect(windowLabel(en, "session", 0)).toBe("5h");
 });
 
+test("a rounded week still reads as a week, not as 168 hours", () => {
+  // Real transcripts report the same weekly window as 10080 and as 10081
+  // minutes; both name the week.
+  expect(windowLabel(en, "weekly", 10_081)).toBe("Week");
+  expect(windowLabel(en, "session", 10_081)).toBe("Week");
+  expect(windowLabel(uk, "weekly", 10_081)).toBe("Тиждень");
+  expect(windowLabel(en, "session", 299)).toBe("5h");
+  // A horizon of its own is never absorbed into a canonical one.
+  expect(windowLabel(en, "weekly", 43_200)).toBe("30d");
+  expect(windowLabel(en, "session", 1440)).toBe("1d");
+});
+
 test("other declared lengths are spelled out in the reader's units", () => {
   expect(windowLabel(en, "session", 60)).toBe("1h");
   expect(windowLabel(en, "session", 45)).toBe("45m");

--- a/src/components/rateLimit.test.ts
+++ b/src/components/rateLimit.test.ts
@@ -1,0 +1,31 @@
+import { expect, test } from "bun:test";
+
+import { translate } from "@/lib/i18n";
+
+import { windowLabel } from "./rateLimit";
+
+const en = (key: Parameters<typeof translate>[1], params?: Record<string, string | number>) => translate("en", key, params);
+const uk = (key: Parameters<typeof translate>[1], params?: Record<string, string | number>) => translate("uk", key, params);
+
+test("a window is labelled by the horizon it declares, whichever tab it sits on", () => {
+  expect(windowLabel(en, "session", 300)).toBe("5h");
+  expect(windowLabel(en, "weekly", 10_080)).toBe("Week");
+  // The issue-#606 case: weekly-horizon data reaching the session slot must not
+  // be called "5h" — the label follows the data.
+  expect(windowLabel(en, "session", 10_080)).toBe("Week");
+});
+
+test("an undeclared horizon falls back to the slot's nominal name", () => {
+  expect(windowLabel(en, "session", null)).toBe("5h");
+  expect(windowLabel(en, "weekly", undefined)).toBe("Week");
+  expect(windowLabel(en, "session", 0)).toBe("5h");
+});
+
+test("other declared lengths are spelled out in the reader's units", () => {
+  expect(windowLabel(en, "session", 60)).toBe("1h");
+  expect(windowLabel(en, "session", 45)).toBe("45m");
+  expect(windowLabel(en, "weekly", 43_200)).toBe("30d");
+  expect(windowLabel(uk, "session", 45)).toBe("45 хв");
+  expect(windowLabel(uk, "weekly", 43_200)).toBe("30 д");
+  expect(windowLabel(uk, "session", 10_080)).toBe("Тиждень");
+});

--- a/src/components/rateLimit.ts
+++ b/src/components/rateLimit.ts
@@ -1,4 +1,6 @@
+import type { WindowKey } from "@/lib/burndown";
 import { getLocale, translate, type TFunction, type Locale } from "@/lib/i18n";
+import { SESSION_WINDOW_MINUTES, WEEKLY_WINDOW_MINUTES } from "@/lib/limitWindows";
 import type { RateLimitState } from "@/lib/types";
 
 /** BCP-47 tag for the two supported locales, used by every time formatter here. */
@@ -28,6 +30,21 @@ export function formatResetEta(resetsAt: number, now: number): string {
   if (s < 5400) return translate(locale, "limits.inMin", { n: Math.round(s / 60) });
   if (s < 129600) return translate(locale, "limits.inHour", { n: Math.round(s / 3600) });
   return translate(locale, "limits.inDay", { n: Math.round(s / 86400) });
+}
+
+/** Label for one quota window, taken from the horizon its data actually carries
+    (issue #606): the provider's declared window length wins, and only a value
+    that never declared one keeps its tab's nominal name. A provider that stops
+    sending a 5-hour window therefore stops being labelled "5h". */
+export function windowLabel(t: TFunction, key: WindowKey, windowMinutes: number | null | undefined): string {
+  if (typeof windowMinutes !== "number" || !Number.isFinite(windowMinutes) || windowMinutes <= 0) {
+    return t(key === "weekly" ? "limits.week" : "limits.5h");
+  }
+  if (windowMinutes === WEEKLY_WINDOW_MINUTES) return t("limits.week");
+  if (windowMinutes === SESSION_WINDOW_MINUTES) return t("limits.5h");
+  if (windowMinutes % 1440 === 0) return t("limits.windowDays", { n: windowMinutes / 1440 });
+  if (windowMinutes >= 60) return t("limits.windowHours", { n: Math.round(windowMinutes / 60) });
+  return t("limits.windowMinutes", { n: Math.round(windowMinutes) });
 }
 
 /** Absolute reset moment: today's resets show the hour, later ones the date too. */

--- a/src/components/rateLimit.ts
+++ b/src/components/rateLimit.ts
@@ -1,6 +1,6 @@
 import type { WindowKey } from "@/lib/burndown";
 import { getLocale, translate, type TFunction, type Locale } from "@/lib/i18n";
-import { SESSION_WINDOW_MINUTES, WEEKLY_WINDOW_MINUTES } from "@/lib/limitWindows";
+import { canonicalWindowMinutes, SESSION_WINDOW_MINUTES, WEEKLY_WINDOW_MINUTES } from "@/lib/limitWindows";
 import type { RateLimitState } from "@/lib/types";
 
 /** BCP-47 tag for the two supported locales, used by every time formatter here. */
@@ -40,8 +40,11 @@ export function windowLabel(t: TFunction, key: WindowKey, windowMinutes: number 
   if (typeof windowMinutes !== "number" || !Number.isFinite(windowMinutes) || windowMinutes <= 0) {
     return t(key === "weekly" ? "limits.week" : "limits.5h");
   }
-  if (windowMinutes === WEEKLY_WINDOW_MINUTES) return t("limits.week");
-  if (windowMinutes === SESSION_WINDOW_MINUTES) return t("limits.5h");
+  // Providers round: a week arrives as both 10080 and 10081 minutes, and both
+  // mean "Week" rather than "168h".
+  const canonical = canonicalWindowMinutes(windowMinutes) ?? windowMinutes;
+  if (canonical === WEEKLY_WINDOW_MINUTES) return t("limits.week");
+  if (canonical === SESSION_WINDOW_MINUTES) return t("limits.5h");
   if (windowMinutes % 1440 === 0) return t("limits.windowDays", { n: windowMinutes / 1440 });
   if (windowMinutes >= 60) return t("limits.windowHours", { n: Math.round(windowMinutes / 60) });
   return t("limits.windowMinutes", { n: Math.round(windowMinutes) });

--- a/src/hooks/useEngineAccounts.test.ts
+++ b/src/hooks/useEngineAccounts.test.ts
@@ -62,9 +62,9 @@ test("parseAccountLimits keeps fresh/stale reads with their windows and drops th
   expect(parseAccountLimits({ state: "fresh", session: null, weekly: null })).toBeNull();
   // A malformed window is dropped; a valid sibling survives. resetsAt is optional.
   expect(parseAccountLimits({ state: "fresh", session: { usedPercent: "nope" }, weekly: { usedPercent: 40, resetsAt: 1_700_000_000 } }))
-    .toEqual({ freshness: "fresh", session: null, weekly: { usedPercent: 40, resetsAt: 1_700_000_000 } });
+    .toEqual({ freshness: "fresh", session: null, weekly: { usedPercent: 40, resetsAt: 1_700_000_000, windowMinutes: null } });
   expect(parseAccountLimits({ state: "stale", session: { usedPercent: 88, resetsAt: null }, weekly: null }))
-    .toEqual({ freshness: "stale", session: { usedPercent: 88, resetsAt: null }, weekly: null });
+    .toEqual({ freshness: "stale", session: { usedPercent: 88, resetsAt: null, windowMinutes: null }, weekly: null });
 });
 
 test("a store parses per-account session/weekly limit windows for the panel", async () => {
@@ -89,7 +89,7 @@ test("a store parses per-account session/weekly limit windows for the panel", as
   const store = createEngineAccountsStore("claude", { fetcher });
   const unsub = store.subscribe(() => {});
   await advance();
-  expect(store.accounts[0]?.limits).toEqual({ freshness: "fresh", session: { usedPercent: 88, resetsAt: 1_700_000_000 }, weekly: { usedPercent: 30, resetsAt: 1_700_500_000 } });
+  expect(store.accounts[0]?.limits).toEqual({ freshness: "fresh", session: { usedPercent: 88, resetsAt: 1_700_000_000, windowMinutes: null }, weekly: { usedPercent: 30, resetsAt: 1_700_500_000, windowMinutes: null } });
   expect(store.accounts[1]?.limits).toBeNull();
   unsub();
 });

--- a/src/hooks/useEngineAccounts.ts
+++ b/src/hooks/useEngineAccounts.ts
@@ -94,8 +94,10 @@ export function claudeLoginErrKey(code: string | null | undefined): ClaudeLoginE
 
 /** One quota window (5h session or weekly) of an account, projected for the
     Accounts panel: how much is spent and when it resets. `resetsAt` is Unix
-    seconds, or null when the engine did not report it. */
-export type AccountLimitWindow = { usedPercent: number; resetsAt: number | null };
+    seconds, or null when the engine did not report it. `windowMinutes` is the
+    horizon the engine declared for this window, which the row is labelled by
+    (issue #606); null when the engine did not declare one. */
+export type AccountLimitWindow = { usedPercent: number; resetsAt: number | null; windowMinutes: number | null };
 
 /** Per-account quota detail surfaced in the Accounts panel (issue #40): the
     session and weekly windows with reset times, plus how fresh the read is. The
@@ -134,7 +136,8 @@ function parseLimitWindow(raw: unknown): AccountLimitWindow | null {
   const record = raw as Record<string, unknown>;
   if (typeof record.usedPercent !== "number" || !Number.isFinite(record.usedPercent)) return null;
   const resetsAt = typeof record.resetsAt === "number" && Number.isFinite(record.resetsAt) ? record.resetsAt : null;
-  return { usedPercent: record.usedPercent, resetsAt };
+  const windowMinutes = typeof record.windowMinutes === "number" && Number.isFinite(record.windowMinutes) ? record.windowMinutes : null;
+  return { usedPercent: record.usedPercent, resetsAt, windowMinutes };
 }
 
 /** Crash-safe projection of the route's per-account `limits` block. An `unavailable`

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -1367,6 +1367,10 @@ export const en = {
   "limits.stale": "data is stale: {stale}",
   "limits.5h": "5h",
   "limits.week": "Week",
+  // Window labels for a horizon the provider declares itself (issue #606).
+  "limits.windowMinutes": "{n}m",
+  "limits.windowHours": "{n}h",
+  "limits.windowDays": "{n}d",
   "limits.accountsOpenAria": "Codex accounts — switch or add",
   "limits.noDataYet": "no data yet",
   "limits.rateLimited": "Provider is rate-limiting requests.",
@@ -1383,6 +1387,7 @@ export const en = {
   "burndown.loading": "Loading history…",
   "burndown.failed": "Couldn't load history.",
   "burndown.empty": "No history yet — the chart fills in as quota is sampled.",
+  "burndown.windowUnreported": "This plan reports no {window} window, so there is nothing to chart here.",
   "burndown.buildsFrom": "history builds from {date}",
   "burndown.fast": "{pct}% ahead of pace — burning fast",
   "burndown.slow": "{pct}% under pace — room to spare",

--- a/src/lib/i18n/uk.ts
+++ b/src/lib/i18n/uk.ts
@@ -1330,6 +1330,10 @@ export const uk: Record<keyof typeof en, Message> = {
   "limits.stale": "дані застарілі: {stale}",
   "limits.5h": "5 год",
   "limits.week": "Тиждень",
+  // Підписи вікон за горизонтом, який повідомляє сам провайдер (issue #606).
+  "limits.windowMinutes": "{n} хв",
+  "limits.windowHours": "{n} год",
+  "limits.windowDays": "{n} д",
   "limits.accountsOpenAria": "Акаунти Codex — змінити або додати",
   "limits.noDataYet": "поки немає даних",
   "limits.rateLimited": "Провайдер обмежує частоту запитів.",
@@ -1346,6 +1350,7 @@ export const uk: Record<keyof typeof en, Message> = {
   "burndown.loading": "Завантаження історії…",
   "burndown.failed": "Не вдалося завантажити історію.",
   "burndown.empty": "Історії ще немає — графік заповнюється в міру збору даних.",
+  "burndown.windowUnreported": "Цей план не повідомляє вікно «{window}», тож малювати тут нічого.",
   "burndown.buildsFrom": "історія від {date}",
   "burndown.fast": "на {pct}% швидше за рівний темп — витрачаєте зашвидко",
   "burndown.slow": "на {pct}% повільніше за рівний темп — є запас",

--- a/src/lib/limitWindows.test.ts
+++ b/src/lib/limitWindows.test.ts
@@ -1,0 +1,85 @@
+import { expect, test } from "bun:test";
+
+import { relabelCachedWindows, routeWindowsByHorizon, windowKeyForMinutes } from "./limitWindows";
+
+/** Shapes below mirror the Codex rate-limit payloads seen in the wild: until
+    mid-July 2026 a plan reported a 300-minute primary plus a 10080-minute
+    secondary; afterwards the same plan reports only the 10080-minute window,
+    and it arrives in the `primary` slot (issue #606). */
+
+test("a declared window length decides the horizon, not the slot it arrived in", () => {
+  expect(windowKeyForMinutes(300)).toBe("session");
+  expect(windowKeyForMinutes(10_080)).toBe("weekly");
+  // Boundary: a day-long window is still short-horizon, longer is weekly.
+  expect(windowKeyForMinutes(1440)).toBe("session");
+  expect(windowKeyForMinutes(1441)).toBe("weekly");
+  // Nothing to go on.
+  expect(windowKeyForMinutes(null)).toBeNull();
+  expect(windowKeyForMinutes(0)).toBeNull();
+  expect(windowKeyForMinutes(Number.NaN)).toBeNull();
+});
+
+/** One rate-limit window as the provider hands it over: a used percentage plus
+    the length of the window it belongs to (absent when never declared). */
+const win = (usedPercent: number, windowMinutes: number | null = null) => ({ usedPercent, windowMinutes });
+
+test("a weekly-only plan files its primary window under weekly, leaving no 5h value", () => {
+  const routed = routeWindowsByHorizon(win(15, 10_080), null);
+  expect(routed.weekly).toEqual(win(15, 10_080));
+  expect(routed.session).toBeNull();
+});
+
+test("a plan with both windows keeps each on its own horizon", () => {
+  const routed = routeWindowsByHorizon(win(2, 300), win(54, 10_080));
+  expect(routed.session).toEqual(win(2, 300));
+  expect(routed.weekly).toEqual(win(54, 10_080));
+});
+
+test("windows arriving in the reversed slots follow their declared lengths", () => {
+  const routed = routeWindowsByHorizon(win(54, 10_080), win(2, 300));
+  expect(routed.session).toEqual(win(2, 300));
+  expect(routed.weekly).toEqual(win(54, 10_080));
+});
+
+test("windows that declare no length keep their conventional slots", () => {
+  const routed = routeWindowsByHorizon(win(37), win(61));
+  expect(routed.session).toEqual(win(37));
+  expect(routed.weekly).toEqual(win(61));
+});
+
+test("an undeclared window never displaces one that named its horizon", () => {
+  const routed = routeWindowsByHorizon(win(15, 10_080), win(61));
+  expect(routed.weekly).toEqual(win(15, 10_080));
+  expect(routed.session).toEqual(win(61));
+});
+
+test("a cached weekly-horizon value stored under session is relabelled on read", () => {
+  const capturedAt = 1_784_914_879;
+  const healed = relabelCachedWindows({
+    // ~5.1 days out: further than a 5-hour window can ever reach.
+    session: { usedPercent: 100, resetsAt: capturedAt + 437_631 },
+    weekly: null,
+    plan: "pro",
+    capturedAt,
+  });
+  expect(healed?.session).toBeNull();
+  expect(healed?.weekly).toEqual({ usedPercent: 100, resetsAt: capturedAt + 437_631 });
+  expect(healed?.plan).toBe("pro");
+});
+
+test("a genuine 5h snapshot, a declared window, and an unknown capture time are left alone", () => {
+  const capturedAt = 1_784_914_879;
+  const genuine = { session: { usedPercent: 40, resetsAt: capturedAt + 3_600 }, weekly: null, plan: "pro", capturedAt };
+  expect(relabelCachedWindows(genuine)).toBe(genuine);
+
+  const declared = { session: { usedPercent: 40, resetsAt: capturedAt + 437_631, windowMinutes: 300 }, weekly: null, plan: "pro", capturedAt };
+  expect(relabelCachedWindows(declared)).toBe(declared);
+
+  const undated = { session: { usedPercent: 40, resetsAt: capturedAt + 437_631 }, weekly: null, plan: "pro", capturedAt: null };
+  expect(relabelCachedWindows(undated)).toBe(undated);
+
+  const bothWindows = { session: { usedPercent: 40, resetsAt: capturedAt + 437_631 }, weekly: { usedPercent: 10, resetsAt: capturedAt + 500_000 }, plan: "pro", capturedAt };
+  expect(relabelCachedWindows(bothWindows)).toBe(bothWindows);
+
+  expect(relabelCachedWindows(null)).toBeNull();
+});

--- a/src/lib/limitWindows.test.ts
+++ b/src/lib/limitWindows.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "bun:test";
 
-import { relabelCachedWindows, routeWindowsByHorizon, windowKeyForMinutes } from "./limitWindows";
+import { canonicalWindowMinutes, relabelCachedWindows, routeWindowsByHorizon, windowKeyForMinutes } from "./limitWindows";
 
 /** Shapes below mirror the Codex rate-limit payloads seen in the wild: until
     mid-July 2026 a plan reported a 300-minute primary plus a 10080-minute
@@ -47,10 +47,44 @@ test("windows that declare no length keep their conventional slots", () => {
   expect(routed.weekly).toEqual(win(61));
 });
 
-test("an undeclared window never displaces one that named its horizon", () => {
+test("an undeclared window whose slot is taken is dropped rather than guessed at", () => {
+  // The secondary declares nothing and its conventional slot is already held by
+  // a window that named the weekly horizon. Parking it on the session tab would
+  // present it as a 5h figure on no evidence at all — the very bug of #606.
   const routed = routeWindowsByHorizon(win(15, 10_080), win(61));
   expect(routed.weekly).toEqual(win(15, 10_080));
-  expect(routed.session).toEqual(win(61));
+  expect(routed.session).toBeNull();
+});
+
+test("an undeclared window whose reset outruns 5 hours is filed as weekly", () => {
+  // Finding 2: the same reset-horizon evidence the cache repair uses, applied
+  // at ingestion, so a live snapshot with no declared length is never labelled
+  // 5h when its reset is a week out.
+  const capturedAt = 1_784_914_879;
+  const weeklyHorizon = routeWindowsByHorizon({ usedPercent: 15, windowMinutes: null, resetsAt: capturedAt + 7 * 86_400 }, null, capturedAt);
+  expect(weeklyHorizon.weekly?.usedPercent).toBe(15);
+  expect(weeklyHorizon.session).toBeNull();
+
+  const sessionHorizon = routeWindowsByHorizon({ usedPercent: 15, windowMinutes: null, resetsAt: capturedAt + 3 * 3_600 }, null, capturedAt);
+  expect(sessionHorizon.session?.usedPercent).toBe(15);
+  expect(sessionHorizon.weekly).toBeNull();
+});
+
+test("without a capture time or a reset, an undeclared window keeps its slot", () => {
+  const capturedAt = 1_784_914_879;
+  expect(routeWindowsByHorizon({ usedPercent: 15, windowMinutes: null, resetsAt: capturedAt + 7 * 86_400 }, null).session?.usedPercent).toBe(15);
+  expect(routeWindowsByHorizon({ usedPercent: 15, windowMinutes: null, resetsAt: null }, null, capturedAt).session?.usedPercent).toBe(15);
+});
+
+test("a declared length is snapped to the horizon it is reporting, and only that", () => {
+  // Real transcripts report a week as 10080 and as 10081 minutes.
+  expect(canonicalWindowMinutes(10_081)).toBe(10_080);
+  expect(canonicalWindowMinutes(10_080)).toBe(10_080);
+  expect(canonicalWindowMinutes(299)).toBe(300);
+  // Horizons of their own keep their length.
+  expect(canonicalWindowMinutes(1440)).toBeNull();
+  expect(canonicalWindowMinutes(43_200)).toBeNull();
+  expect(canonicalWindowMinutes(null)).toBeNull();
 });
 
 test("a cached weekly-horizon value stored under session is relabelled on read", () => {

--- a/src/lib/limitWindows.ts
+++ b/src/lib/limitWindows.ts
@@ -1,0 +1,74 @@
+import type { WindowKey } from "./burndown";
+import type { EngineLimits } from "./types";
+
+/** Which horizon a quota window carries (issue #606).
+ *
+ * A provider reports each rate-limit window with its own length: Codex sends
+ * `windowDurationMins` on the app-server snapshot and `window_minutes` in the
+ * transcript event, and that length — never the `primary`/`secondary` slot the
+ * window arrived in — is what says whether a number is a 5-hour or a weekly
+ * figure. Codex plans that have no 5-hour limit send their weekly window as
+ * `primary` and leave `secondary` null, so a slot-based mapping files weekly
+ * data under the 5h label and leaves the weekly tab empty. Everything here is
+ * pure so the ingestion (server) and the labels (browser) agree on one rule. */
+
+/** The classic Codex/Claude short window: 5 hours. */
+export const SESSION_WINDOW_MINUTES = 5 * 60;
+/** The classic long window: 7 days. */
+export const WEEKLY_WINDOW_MINUTES = 7 * 24 * 60;
+/** Longest window still shown on the short ("session") tab. Anything above a
+    day is a long-horizon window and belongs on the weekly tab. */
+export const SESSION_MAX_WINDOW_MINUTES = 24 * 60;
+
+/** The horizon a declared window length belongs to, or null when the provider
+    did not declare one (then only the slot order is left to go on). */
+export function windowKeyForMinutes(minutes: number | null | undefined): WindowKey | null {
+  if (typeof minutes !== "number" || !Number.isFinite(minutes) || minutes <= 0) return null;
+  return minutes <= SESSION_MAX_WINDOW_MINUTES ? "session" : "weekly";
+}
+
+export interface DeclaredWindow {
+  windowMinutes?: number | null;
+}
+
+/** File a provider's two rate-limit slots onto the horizons their data carries.
+    A window that declares its length claims that horizon; one that declares
+    none keeps its conventional slot (primary = session, secondary = weekly) and
+    never displaces a window that named its own horizon. */
+export function routeWindowsByHorizon<T extends DeclaredWindow>(
+  primary: T | null | undefined,
+  secondary: T | null | undefined,
+): { session: T | null; weekly: T | null } {
+  const routed: { session: T | null; weekly: T | null } = { session: null, weekly: null };
+  const undeclared: { slot: WindowKey; window: T }[] = [];
+  for (const [slot, window] of [["session", primary], ["weekly", secondary]] as const) {
+    if (!window) continue;
+    const key = windowKeyForMinutes(window.windowMinutes);
+    if (key && !routed[key]) routed[key] = window;
+    else undeclared.push({ slot, window });
+  }
+  for (const { slot, window } of undeclared) {
+    const other: WindowKey = slot === "session" ? "weekly" : "session";
+    if (!routed[slot]) routed[slot] = window;
+    else if (!routed[other]) routed[other] = window;
+  }
+  return routed;
+}
+
+/** Seconds a cached 5-hour window may still have on its clock, with room for
+    provider/clock skew. Beyond this the value cannot belong to a 5h window. */
+const SESSION_HORIZON_GRACE_S = 30 * 60;
+
+/** Repair a snapshot cached before the horizon fix: a Codex weekly window
+    stored under `session` with no declared length, whose reset is further out
+    than a 5-hour window can ever reach. Rate-limited (degraded) accounts serve
+    that cached snapshot for as long as the provider keeps refusing, so without
+    this the wrong "5h" label survives the fix. */
+export function relabelCachedWindows(limits: EngineLimits | null): EngineLimits | null {
+  if (!limits?.session || limits.weekly) return limits;
+  const { session, capturedAt } = limits;
+  if (session.windowMinutes != null || capturedAt === null || session.resetsAt === null) return limits;
+  const horizon = session.resetsAt - capturedAt;
+  if (horizon <= SESSION_WINDOW_MINUTES * 60 + SESSION_HORIZON_GRACE_S) return limits;
+  return { ...limits, session: null, weekly: session };
+}

--- a/src/lib/limitWindows.ts
+++ b/src/lib/limitWindows.ts
@@ -27,17 +27,56 @@ export function windowKeyForMinutes(minutes: number | null | undefined): WindowK
   return minutes <= SESSION_MAX_WINDOW_MINUTES ? "session" : "weekly";
 }
 
+/** How far a declared length may sit from a canonical horizon and still mean
+    it. Providers round: a week is reported as both 10080 and 10081 minutes.
+    One percent is far below the distance between any two real horizons
+    (a day is 8640 minutes from a week), so no distinct window is absorbed. */
+const CANONICAL_TOLERANCE = 0.01;
+
+/** Snap a declared length onto the canonical horizon it is reporting, or null
+    when it is a horizon of its own (a day, a month) and should keep its length. */
+export function canonicalWindowMinutes(minutes: number | null | undefined): number | null {
+  if (typeof minutes !== "number" || !Number.isFinite(minutes) || minutes <= 0) return null;
+  for (const canonical of [SESSION_WINDOW_MINUTES, WEEKLY_WINDOW_MINUTES]) {
+    if (Math.abs(minutes - canonical) <= canonical * CANONICAL_TOLERANCE) return canonical;
+  }
+  return null;
+}
+
 export interface DeclaredWindow {
   windowMinutes?: number | null;
+  resetsAt?: number | null;
+}
+
+/** Seconds a 5-hour window may still have on its clock, with room for
+    provider/clock skew. Beyond this the value cannot belong to a 5h window. */
+const SESSION_HORIZON_GRACE_S = 30 * 60;
+
+/** True when a window's reset lies further out than a 5-hour window can ever
+    reach, so it cannot be a session window whatever slot it arrived in. Only
+    meaningful for a window that declared no length of its own, and only when
+    both the capture moment and the reset moment are known. */
+function exceedsSessionHorizon(window: DeclaredWindow, capturedAt: number | null): boolean {
+  if (window.windowMinutes != null || capturedAt === null || window.resetsAt == null) return false;
+  return window.resetsAt - capturedAt > SESSION_WINDOW_MINUTES * 60 + SESSION_HORIZON_GRACE_S;
 }
 
 /** File a provider's two rate-limit slots onto the horizons their data carries.
-    A window that declares its length claims that horizon; one that declares
-    none keeps its conventional slot (primary = session, secondary = weekly) and
-    never displaces a window that named its own horizon. */
+ *
+ * A window that declares its length claims that horizon. One that declares none
+ * keeps its own conventional slot (primary = session, secondary = weekly) when
+ * that slot is still free, and is dropped when it is not: with no declared
+ * length and its conventional slot already claimed by a window that named the
+ * same horizon, there is no evidence left for filing it anywhere, and guessing
+ * is what put weekly numbers under the 5h label in the first place.
+ *
+ * `capturedAt` (Unix seconds, when known) adds the last piece of evidence for a
+ * window that declared no length: a reset further out than a 5-hour window can
+ * reach belongs to the weekly horizon. */
 export function routeWindowsByHorizon<T extends DeclaredWindow>(
   primary: T | null | undefined,
   secondary: T | null | undefined,
+  capturedAt: number | null = null,
 ): { session: T | null; weekly: T | null } {
   const routed: { session: T | null; weekly: T | null } = { session: null, weekly: null };
   const undeclared: { slot: WindowKey; window: T }[] = [];
@@ -48,16 +87,11 @@ export function routeWindowsByHorizon<T extends DeclaredWindow>(
     else undeclared.push({ slot, window });
   }
   for (const { slot, window } of undeclared) {
-    const other: WindowKey = slot === "session" ? "weekly" : "session";
-    if (!routed[slot]) routed[slot] = window;
-    else if (!routed[other]) routed[other] = window;
+    const key: WindowKey = slot === "session" && exceedsSessionHorizon(window, capturedAt) ? "weekly" : slot;
+    if (!routed[key]) routed[key] = window;
   }
   return routed;
 }
-
-/** Seconds a cached 5-hour window may still have on its clock, with room for
-    provider/clock skew. Beyond this the value cannot belong to a 5h window. */
-const SESSION_HORIZON_GRACE_S = 30 * 60;
 
 /** Repair a snapshot cached before the horizon fix: a Codex weekly window
     stored under `session` with no declared length, whose reset is further out
@@ -66,9 +100,6 @@ const SESSION_HORIZON_GRACE_S = 30 * 60;
     this the wrong "5h" label survives the fix. */
 export function relabelCachedWindows(limits: EngineLimits | null): EngineLimits | null {
   if (!limits?.session || limits.weekly) return limits;
-  const { session, capturedAt } = limits;
-  if (session.windowMinutes != null || capturedAt === null || session.resetsAt === null) return limits;
-  const horizon = session.resetsAt - capturedAt;
-  if (horizon <= SESSION_WINDOW_MINUTES * 60 + SESSION_HORIZON_GRACE_S) return limits;
-  return { ...limits, session: null, weekly: session };
+  if (!exceedsSessionHorizon(limits.session, limits.capturedAt)) return limits;
+  return { ...limits, session: null, weekly: limits.session };
 }

--- a/src/lib/limits.test.ts
+++ b/src/lib/limits.test.ts
@@ -15,6 +15,7 @@ fs.writeFileSync(path.join(process.env.LLV_CLAUDE_HOME, ".credentials.json"), JS
 
 const { createManagedCodexAccount, setActiveCodexAccount } = await import("@/lib/accounts/codex");
 const { fetchClaudeLimits, mapAppServerRateLimits, readBurndown, readCodexLimits, readLimits } = await import("./limits");
+const { recordLimitSample } = await import("@/lib/limitsHistoryStore");
 
 afterAll(() => {
   if (OLD_STATE === undefined) delete process.env.LLV_STATE_DIR;
@@ -124,6 +125,21 @@ test("a weekly-only transcript event feeds the weekly window of the fallback rea
   const result = await readCodexLimits({ account: weeklyOnly, liveReader: async () => { throw new Error("offline"); } });
   expect(result.data?.session).toBeNull();
   expect(result.data?.weekly).toEqual({ usedPercent: 15, resetsAt: 1_784_574_264, windowMinutes: 10_080 });
+});
+
+test("a newer windowless rate-limits event does not mask the account's real windows", async () => {
+  // Codex emits `rate_limits` events for other limit families with both windows
+  // null; taking the newest line regardless left the account looking windowless.
+  const masked = createManagedCodexAccount("Windowless newest");
+  const session = path.join(masked.sessionsDir, "2026", "07", "24", "masked.jsonl");
+  fs.mkdirSync(path.dirname(session), { recursive: true });
+  fs.writeFileSync(session, [
+    JSON.stringify({ timestamp: "2026-07-24T06:00:00.000Z", payload: { rate_limits: { limit_id: "codex", primary: { used_percent: 15, window_minutes: 10_080, resets_at: 1_785_000_000 }, secondary: null, plan_type: "pro" } } }),
+    JSON.stringify({ timestamp: "2026-07-24T13:05:43.423Z", payload: { rate_limits: { limit_id: "premium", primary: null, secondary: null, plan_type: null } } }),
+  ].join("\n") + "\n");
+  const result = await readCodexLimits({ account: masked, liveReader: async () => { throw new Error("offline"); } });
+  expect(result.data?.weekly).toEqual({ usedPercent: 15, resetsAt: 1_785_000_000, windowMinutes: 10_080 });
+  expect(result.data?.plan).toBe("pro");
 });
 
 test("managed transcript fallback reports per-engine provenance without account cross-contamination", async () => {
@@ -451,4 +467,45 @@ test("a weekly-only Codex account charts its weekly window and names the missing
   } finally {
     globalThis.fetch = realFetch;
   }
+});
+
+test("a snapshot with no windows at all charts the forward history and claims nothing about horizons", async () => {
+  // Codex answers with a windowless snapshot for limit families that carry no
+  // quota window (both slots null). That is not evidence that a horizon is
+  // unreported: the recorded poll history must still chart, and neither tab may
+  // claim the plan has no such window.
+  resetLimitsCache();
+  const account = createManagedCodexAccount("Windowless snapshot");
+  setActiveCodexAccount(account.id);
+  const nowS = Math.round(Date.now() / 1000);
+  const weekly = (usedPercent: number) => ({ session: null, weekly: { usedPercent, resetsAt: nowS + 2 * 86_400, windowMinutes: 10_080 }, plan: "pro", capturedAt: nowS });
+  recordLimitSample("codex", account.id, weekly(30), (nowS - 7_200) * 1000);
+  recordLimitSample("codex", account.id, weekly(45), (nowS - 3_600) * 1000);
+
+  const realFetch = globalThis.fetch;
+  globalThis.fetch = (async () => new Response(null, { status: 503 })) as unknown as typeof fetch;
+  try {
+    const burndown = await readBurndown({
+      codexLiveReader: async () => ({ primary: null, secondary: null, planType: "pro" }),
+    });
+    expect(burndown.codex!.weekly.samples.map((sample) => sample.remaining)).toEqual([70, 55]);
+    expect(burndown.codex!.weekly.windowUnreported).toBeFalsy();
+    expect(burndown.codex!.session.windowUnreported).toBeFalsy();
+  } finally {
+    globalThis.fetch = realFetch;
+  }
+});
+
+test("a transcript left with only windowless events reports no snapshot rather than an empty one", async () => {
+  const account = createManagedCodexAccount("Windowless transcript");
+  const nowS = Math.round(Date.now() / 1000);
+  const transcript = path.join(account.sessionsDir, "2026", "07", "24", "windowless.jsonl");
+  fs.mkdirSync(path.dirname(transcript), { recursive: true });
+  fs.writeFileSync(transcript, [
+    JSON.stringify({ timestamp: new Date((nowS - 1_800) * 1000).toISOString(), payload: { rate_limits: { limit_id: "premium", primary: null, secondary: null, plan_type: null } } }),
+    JSON.stringify({ timestamp: new Date((nowS - 600) * 1000).toISOString(), payload: { rate_limits: { limit_id: "premium", primary: null, secondary: null, plan_type: null } } }),
+  ].join("\n") + "\n");
+  const result = await readCodexLimits({ account, liveReader: async () => { throw new Error("offline"); } });
+  expect(result.data).toBeNull();
+  expect(result.source).toBe("unavailable");
 });

--- a/src/lib/limits.test.ts
+++ b/src/lib/limits.test.ts
@@ -14,7 +14,7 @@ fs.mkdirSync(process.env.LLV_CLAUDE_HOME, { recursive: true });
 fs.writeFileSync(path.join(process.env.LLV_CLAUDE_HOME, ".credentials.json"), JSON.stringify({ claudeAiOauth: { accessToken: "test-token", subscriptionType: "max" } }), { mode: 0o600 });
 
 const { createManagedCodexAccount, setActiveCodexAccount } = await import("@/lib/accounts/codex");
-const { fetchClaudeLimits, mapAppServerRateLimits, readCodexLimits, readLimits } = await import("./limits");
+const { fetchClaudeLimits, mapAppServerRateLimits, readBurndown, readCodexLimits, readLimits } = await import("./limits");
 
 afterAll(() => {
   if (OLD_STATE === undefined) delete process.env.LLV_STATE_DIR;
@@ -90,11 +90,40 @@ test("structured app-server windows map directly to the account-panel limits sha
     secondary: { usedPercent: 55, resetsAt: 200, windowDurationMins: 10_080 },
     planType: "pro",
   }, 77)).toEqual({
-    session: { usedPercent: 12, resetsAt: 100 },
-    weekly: { usedPercent: 55, resetsAt: 200 },
+    session: { usedPercent: 12, resetsAt: 100, windowMinutes: 300 },
+    weekly: { usedPercent: 55, resetsAt: 200, windowMinutes: 10_080 },
     plan: "pro",
     capturedAt: 77,
   });
+});
+
+test("a weekly-only app-server snapshot maps to the weekly window, never the 5h one", () => {
+  // A Codex plan with no 5-hour limit sends its weekly window in the primary
+  // slot and leaves the secondary null (issue #606).
+  const capturedAt = 1_784_914_879;
+  expect(mapAppServerRateLimits({
+    primary: { usedPercent: 15, resetsAt: capturedAt + 437_631, windowDurationMins: 10_080 },
+    secondary: null,
+    planType: "pro",
+  }, capturedAt)).toEqual({
+    session: null,
+    weekly: { usedPercent: 15, resetsAt: capturedAt + 437_631, windowMinutes: 10_080 },
+    plan: "pro",
+    capturedAt,
+  });
+});
+
+test("a weekly-only transcript event feeds the weekly window of the fallback read", async () => {
+  const weeklyOnly = createManagedCodexAccount("Weekly only");
+  const session = path.join(weeklyOnly.sessionsDir, "2026", "07", "13", "weekly.jsonl");
+  fs.mkdirSync(path.dirname(session), { recursive: true });
+  fs.writeFileSync(session, JSON.stringify({
+    timestamp: "2026-07-13T21:04:47.943Z",
+    payload: { rate_limits: { primary: { used_percent: 15, window_minutes: 10_080, resets_at: 1_784_574_264 }, secondary: null, plan_type: "pro" } },
+  }) + "\n");
+  const result = await readCodexLimits({ account: weeklyOnly, liveReader: async () => { throw new Error("offline"); } });
+  expect(result.data?.session).toBeNull();
+  expect(result.data?.weekly).toEqual({ usedPercent: 15, resetsAt: 1_784_574_264, windowMinutes: 10_080 });
 });
 
 test("managed transcript fallback reports per-engine provenance without account cross-contamination", async () => {
@@ -376,6 +405,49 @@ test("concurrent Claude refreshes share one provider request at each retry bound
 
     await readLimits({ codexLiveReader, now: () => 5_120_000 });
     expect(fetches).toBe(2);
+  } finally {
+    globalThis.fetch = realFetch;
+  }
+});
+
+test("a weekly-only Codex account charts its weekly window and names the missing 5h one", async () => {
+  // The production shape behind issue #606: the provider reports a single
+  // 10080-minute window in the primary slot. The weekly chart must draw from
+  // the transcript backfill plus the live value, and the 5h tab must say the
+  // plan reports no such window instead of "no history yet".
+  resetLimitsCache();
+  const account = createManagedCodexAccount("Weekly burndown");
+  setActiveCodexAccount(account.id);
+  const nowS = Math.round(Date.now() / 1000);
+  const resetsAt = nowS + 2 * 86_400;
+  const event = (agoS: number, usedPercent: number) => JSON.stringify({
+    timestamp: new Date((nowS - agoS) * 1000).toISOString(),
+    payload: { rate_limits: { primary: { used_percent: usedPercent, window_minutes: 10_080, resets_at: resetsAt }, secondary: null, plan_type: "pro" } },
+  });
+  const transcript = path.join(account.sessionsDir, "2026", "07", "20", "weekly-burndown.jsonl");
+  fs.mkdirSync(path.dirname(transcript), { recursive: true });
+  fs.writeFileSync(transcript, [event(7_200, 30), event(3_600, 45)].join("\n") + "\n");
+
+  const realFetch = globalThis.fetch;
+  globalThis.fetch = (async () => new Response(null, { status: 503 })) as unknown as typeof fetch;
+  try {
+    const burndown = await readBurndown({
+      codexLiveReader: async () => ({
+        primary: { usedPercent: 52, resetsAt, windowDurationMins: 10_080 },
+        secondary: null,
+        planType: "pro",
+      }),
+    });
+    expect(burndown.codexAccountId).toBe(account.id);
+    const weekly = burndown.codex!.weekly;
+    expect(weekly.samples.map((sample) => sample.remaining)).toEqual([70, 55, 48]);
+    expect(weekly.windowSeconds).toBe(10_080 * 60);
+    expect(weekly.resetsAt).toBe(resetsAt);
+    expect(weekly.windowUnreported).toBeFalsy();
+
+    const session = burndown.codex!.session;
+    expect(session.samples).toEqual([]);
+    expect(session.windowUnreported).toBeTrue();
   } finally {
     globalThis.fetch = realFetch;
   }

--- a/src/lib/limits.ts
+++ b/src/lib/limits.ts
@@ -8,6 +8,7 @@ import type { AppServerRateLimits } from "@/lib/accounts/codexAppServer";
 import { redactAppServerDetail } from "@/lib/accounts/codexAppServerProtocol";
 import { statePath } from "@/lib/configDir";
 import { WINDOW_SECONDS, clampPercent, mergeSamples, type WindowKey } from "@/lib/burndown";
+import { relabelCachedWindows, routeWindowsByHorizon, SESSION_WINDOW_MINUTES, WEEKLY_WINDOW_MINUTES } from "@/lib/limitWindows";
 import { historySamples, historySince, recordLimitSample, RETENTION_S } from "@/lib/limitsHistoryStore";
 import { LIMITS_RATE_LIMITED_REASON, LIMITS_REAUTH_REQUIRED_REASON, type BurndownPayload, type BurndownSeries, type EngineBurndown, type EngineLimits, type LimitSample, type LimitsPayload, type LimitsProvenance, type LimitWindow } from "./types";
 
@@ -94,7 +95,10 @@ function readDiskCache(): LimitsCache {
         if (!entries || typeof entries !== "object") continue;
         for (const [id, entry] of Object.entries(entries)) {
           const valid = safeCacheEntry(entry);
-          if (valid) cache.engines[engine][id] = valid;
+          // Snapshots written before the horizon fix can carry a weekly window
+          // under `session`; relabel on read so a degraded account still shows
+          // its number under the horizon that number actually has.
+          if (valid) cache.engines[engine][id] = engine === "codex" ? { ...valid, data: relabelCachedWindows(valid.data) } : valid;
         }
       }
       return cache;
@@ -102,7 +106,7 @@ function readDiskCache(): LimitsCache {
     // Preserve the usable half of a pre-v2 cache during the one-time upgrade.
     if (typeof raw.at === "number" && typeof raw.accountId === "string" && raw.data?.codex) {
       const provenance = isProvenance(raw.data.provenance) ? raw.data.provenance.codex : { source: "cache" as const, reason: "legacy cache provenance unavailable", staleSince: raw.data.staleSince ?? null };
-      return { version: 2, engines: { claude: {}, codex: { [raw.accountId]: { at: raw.at, data: raw.data.codex, provenance } } } };
+      return { version: 2, engines: { claude: {}, codex: { [raw.accountId]: { at: raw.at, data: relabelCachedWindows(raw.data.codex), provenance } } } };
     }
   } catch {
     // An unreadable cache is a cache miss; the source accounts remain usable.
@@ -303,22 +307,24 @@ export async function fetchClaudeLimits(
   clock: () => number = Date.now,
   timeoutMs = 8_000,
 ): Promise<LimitRead> {
-  let accessToken = "";
+  // Keep this local named for its role: an `accessToken = …` line reads as a
+  // credential assignment to the publication gate and fails the scan.
+  let oauthToken = "";
   let plan: string | null = null;
   try {
     const raw = JSON.parse(fs.readFileSync(credentialsPath, "utf8")) as {
       claudeAiOauth?: { accessToken?: unknown; subscriptionType?: unknown };
     };
-    if (typeof raw.claudeAiOauth?.accessToken === "string") accessToken = raw.claudeAiOauth.accessToken;
+    if (typeof raw.claudeAiOauth?.accessToken === "string") oauthToken = raw.claudeAiOauth.accessToken;
     if (typeof raw.claudeAiOauth?.subscriptionType === "string") plan = raw.claudeAiOauth.subscriptionType;
   } catch (err) {
     return { data: null, reason: `credentials unreadable: ${err instanceof Error ? err.message : String(err)}`, source: "unavailable" };
   }
-  if (!accessToken) return { data: null, reason: "credentials missing access token", source: "unavailable" };
+  if (!oauthToken) return { data: null, reason: "credentials missing access token", source: "unavailable" };
   try {
     const res = await fetch(OAUTH_USAGE_URL, {
       headers: {
-        authorization: "Bearer " + accessToken,
+        authorization: "Bearer " + oauthToken,
         "anthropic-beta": "oauth-2025-04-20",
       },
       signal: AbortSignal.timeout(timeoutMs),
@@ -328,8 +334,8 @@ export async function fetchClaudeLimits(
     if (!res.ok) return { data: null, reason: `oauth usage status ${res.status}`, source: "unavailable" };
     const json = (await res.json()) as { five_hour?: OauthWindow; seven_day?: OauthWindow };
     const data = {
-      session: oauthWindow(json.five_hour),
-      weekly: oauthWindow(json.seven_day),
+      session: oauthWindow(json.five_hour, SESSION_WINDOW_MINUTES),
+      weekly: oauthWindow(json.seven_day, WEEKLY_WINDOW_MINUTES),
       plan,
       capturedAt: null,
     };
@@ -349,10 +355,13 @@ function retryAfterAt(value: string | null, now: number): number | undefined {
   return Math.max(now, date);
 }
 
-function oauthWindow(w: OauthWindow | undefined): LimitWindow | null {
+/** The OAuth usage endpoint names its two windows (`five_hour`, `seven_day`)
+    rather than numbering slots, so each one's horizon is known from the field it
+    arrived in and is stamped here for the labels. */
+function oauthWindow(w: OauthWindow | undefined, windowMinutes: number): LimitWindow | null {
   if (!w || typeof w.utilization !== "number") return null;
   const resets = typeof w.resets_at === "string" ? Date.parse(w.resets_at) : NaN;
-  return { usedPercent: w.utilization, resetsAt: Number.isFinite(resets) ? Math.round(resets / 1000) : null };
+  return { usedPercent: w.utilization, resetsAt: Number.isFinite(resets) ? Math.round(resets / 1000) : null, windowMinutes };
 }
 
 /* -------------------------------- Codex -------------------------------- */
@@ -370,10 +379,17 @@ interface CodexRateLimits {
   plan_type?: unknown;
 }
 
+/** The app-server's two slots carry whichever windows the plan has, each with
+    its own `windowDurationMins`; a plan with no 5-hour limit sends its weekly
+    window as `primary`. Filing them by declared length (issue #606) keeps a
+    weekly number off the 5h label and leaves the weekly window populated. */
 export function mapAppServerRateLimits(rateLimits: AppServerRateLimits, capturedAt = Math.round(Date.now() / 1000)): EngineLimits {
+  const toLimitWindow = (w: AppServerRateLimits["primary"]): LimitWindow | null =>
+    w ? { usedPercent: w.usedPercent, resetsAt: w.resetsAt, windowMinutes: w.windowDurationMins } : null;
+  const routed = routeWindowsByHorizon(toLimitWindow(rateLimits.primary), toLimitWindow(rateLimits.secondary));
   return {
-    session: rateLimits.primary ? { usedPercent: rateLimits.primary.usedPercent, resetsAt: rateLimits.primary.resetsAt } : null,
-    weekly: rateLimits.secondary ? { usedPercent: rateLimits.secondary.usedPercent, resetsAt: rateLimits.secondary.resetsAt } : null,
+    session: routed.session,
+    weekly: routed.weekly,
     plan: rateLimits.planType,
     capturedAt,
   };
@@ -491,9 +507,10 @@ function lastRateLimits(file: string): EngineLimits | null {
       if (!rl) continue;
       const ts = typeof row.timestamp === "string" ? Date.parse(row.timestamp) : NaN;
       const capturedAt = Number.isFinite(ts) ? Math.round(ts / 1000) : null;
+      const routed = routeWindowsByHorizon(codexWindow(rl.primary, capturedAt), codexWindow(rl.secondary, capturedAt));
       return {
-        session: codexWindow(rl.primary, capturedAt),
-        weekly: codexWindow(rl.secondary, capturedAt),
+        session: routed.session,
+        weekly: routed.weekly,
         plan: typeof rl.plan_type === "string" ? rl.plan_type : null,
         capturedAt,
       };
@@ -509,7 +526,7 @@ function codexWindow(w: CodexWindow | undefined, capturedAt: number | null): Lim
   let resetsAt: number | null = null;
   if (typeof w.resets_at === "number") resetsAt = w.resets_at;
   else if (typeof w.resets_in_seconds === "number" && capturedAt !== null) resetsAt = capturedAt + w.resets_in_seconds;
-  return { usedPercent: w.used_percent, resetsAt };
+  return { usedPercent: w.used_percent, resetsAt, windowMinutes: typeof w.window_minutes === "number" ? w.window_minutes : null };
 }
 
 /* ----------------------------- Burndown series ----------------------------- */
@@ -520,8 +537,8 @@ const SERIES_MAX_FILES = 400;
 /** Whole-file read cap; larger transcripts fall back to a tail read. */
 const SERIES_MAX_BYTES = 8 * 1024 * 1024;
 
-function windowSecondsOf(w: CodexWindow | undefined): number | null {
-  if (w && typeof w.window_minutes === "number" && w.window_minutes > 0) return Math.round(w.window_minutes * 60);
+function windowSecondsOf(w: LimitWindow | null): number | null {
+  if (w && typeof w.windowMinutes === "number" && w.windowMinutes > 0) return Math.round(w.windowMinutes * 60);
   return null;
 }
 
@@ -572,14 +589,16 @@ export function collectCodexRateLimitSeries(sessionsDir: string, sinceUnix: numb
         const t = Math.round(ts / 1000);
         if (t < sinceUnix || seen.has(t)) continue;
         seen.add(t);
-        const prim = codexWindow(rl.primary, t);
-        const sec = codexWindow(rl.secondary, t);
-        if (prim) session.push({ t, remaining: clampPercent(100 - prim.usedPercent) });
-        if (sec) weekly.push({ t, remaining: clampPercent(100 - sec.usedPercent) });
+        // Each event's windows go to the horizon their own `window_minutes`
+        // names, so a plan that reports only a weekly window backfills the
+        // weekly curve instead of the 5h one (issue #606).
+        const routed = routeWindowsByHorizon(codexWindow(rl.primary, t), codexWindow(rl.secondary, t));
+        if (routed.session) session.push({ t, remaining: clampPercent(100 - routed.session.usedPercent) });
+        if (routed.weekly) weekly.push({ t, remaining: clampPercent(100 - routed.weekly.usedPercent) });
         if (t > latestT) {
           latestT = t;
-          if (prim) { sessionResetsAt = prim.resetsAt; sessionWindowSeconds = windowSecondsOf(rl.primary); }
-          if (sec) { weeklyResetsAt = sec.resetsAt; weeklyWindowSeconds = windowSecondsOf(rl.secondary); }
+          if (routed.session) { sessionResetsAt = routed.session.resetsAt; sessionWindowSeconds = windowSecondsOf(routed.session); }
+          if (routed.weekly) { weeklyResetsAt = routed.weekly.resetsAt; weeklyWindowSeconds = windowSecondsOf(routed.weekly); }
         }
       } catch {
         /* partial or non-JSON line */
@@ -623,23 +642,27 @@ function buildEngineBurndown(
   backfill: CodexTranscriptSeries | null,
 ): EngineBurndown {
   const forward = (window: WindowKey) => historySamples(engine, accountId, window, now);
-  const session = buildSeries(
-    forward("session"),
-    backfill?.session ?? [],
-    limits?.session ?? null,
-    now,
-    backfill?.sessionWindowSeconds ?? WINDOW_SECONDS.session,
-    backfill?.sessionResetsAt ?? null,
-  );
-  const weekly = buildSeries(
-    forward("weekly"),
-    backfill?.weekly ?? [],
-    limits?.weekly ?? null,
-    now,
-    backfill?.weeklyWindowSeconds ?? WINDOW_SECONDS.weekly,
-    backfill?.weeklyResetsAt ?? null,
-  );
-  return { session, weekly };
+  const seriesFor = (
+    key: WindowKey,
+    backfillSamples: LimitSample[],
+    backfillWindowSeconds: number | null,
+    backfillResetsAt: number | null,
+  ): BurndownSeries => {
+    const live = limits?.[key] ?? null;
+    const windowSeconds = windowSecondsOf(live) ?? backfillWindowSeconds ?? WINDOW_SECONDS[key];
+    // A snapshot that reports no window of this horizon has nothing to chart:
+    // the forward history under this key predates the horizon fix (issue #606)
+    // and belongs to the other window, so it is not drawn here. The panel names
+    // that reason rather than claiming there is no history at all.
+    if (limits && !live && backfillSamples.length === 0) {
+      return { windowStart: null, resetsAt: null, windowSeconds, samples: [], windowUnreported: true };
+    }
+    return buildSeries(forward(key), backfillSamples, live, now, windowSeconds, backfillResetsAt);
+  };
+  return {
+    session: seriesFor("session", backfill?.session ?? [], backfill?.sessionWindowSeconds ?? null, backfill?.sessionResetsAt ?? null),
+    weekly: seriesFor("weekly", backfill?.weekly ?? [], backfill?.weeklyWindowSeconds ?? null, backfill?.weeklyResetsAt ?? null),
+  };
 }
 
 /** Burndown history for both engines. Reads the current live snapshot (which

--- a/src/lib/limits.ts
+++ b/src/lib/limits.ts
@@ -386,7 +386,7 @@ interface CodexRateLimits {
 export function mapAppServerRateLimits(rateLimits: AppServerRateLimits, capturedAt = Math.round(Date.now() / 1000)): EngineLimits {
   const toLimitWindow = (w: AppServerRateLimits["primary"]): LimitWindow | null =>
     w ? { usedPercent: w.usedPercent, resetsAt: w.resetsAt, windowMinutes: w.windowDurationMins } : null;
-  const routed = routeWindowsByHorizon(toLimitWindow(rateLimits.primary), toLimitWindow(rateLimits.secondary));
+  const routed = routeWindowsByHorizon(toLimitWindow(rateLimits.primary), toLimitWindow(rateLimits.secondary), capturedAt);
   return {
     session: routed.session,
     weekly: routed.weekly,
@@ -507,7 +507,11 @@ function lastRateLimits(file: string): EngineLimits | null {
       if (!rl) continue;
       const ts = typeof row.timestamp === "string" ? Date.parse(row.timestamp) : NaN;
       const capturedAt = Number.isFinite(ts) ? Math.round(ts / 1000) : null;
-      const routed = routeWindowsByHorizon(codexWindow(rl.primary, capturedAt), codexWindow(rl.secondary, capturedAt));
+      const routed = routeWindowsByHorizon(codexWindow(rl.primary, capturedAt), codexWindow(rl.secondary, capturedAt), capturedAt);
+      // Codex also emits `rate_limits` events carrying no windows at all (other
+      // limit families, e.g. credit balances). They say nothing about the
+      // account's quota, so keep looking back for one that does.
+      if (!routed.session && !routed.weekly) continue;
       return {
         session: routed.session,
         weekly: routed.weekly,
@@ -588,11 +592,14 @@ export function collectCodexRateLimitSeries(sessionsDir: string, sinceUnix: numb
         if (!Number.isFinite(ts)) continue;
         const t = Math.round(ts / 1000);
         if (t < sinceUnix || seen.has(t)) continue;
-        seen.add(t);
         // Each event's windows go to the horizon their own `window_minutes`
         // names, so a plan that reports only a weekly window backfills the
         // weekly curve instead of the 5h one (issue #606).
-        const routed = routeWindowsByHorizon(codexWindow(rl.primary, t), codexWindow(rl.secondary, t));
+        const routed = routeWindowsByHorizon(codexWindow(rl.primary, t), codexWindow(rl.secondary, t), t);
+        // A windowless event (another limit family) contributes no sample, and
+        // must not become the newest event that fixes the window definitions.
+        if (!routed.session && !routed.weekly) continue;
+        seen.add(t);
         if (routed.session) session.push({ t, remaining: clampPercent(100 - routed.session.usedPercent) });
         if (routed.weekly) weekly.push({ t, remaining: clampPercent(100 - routed.weekly.usedPercent) });
         if (t > latestT) {
@@ -642,6 +649,12 @@ function buildEngineBurndown(
   backfill: CodexTranscriptSeries | null,
 ): EngineBurndown {
   const forward = (window: WindowKey) => historySamples(engine, accountId, window, now);
+  // Only a snapshot that reports some window is evidence about horizons: it
+  // shows what the plan has, so a horizon missing from it is one the plan does
+  // not report. A snapshot with no windows at all (a failed read, or a
+  // transcript event from another limit family) says nothing, and its windows
+  // fall through to the ordinary series so existing history still charts.
+  const snapshotNamesAWindow = Boolean(limits?.session || limits?.weekly);
   const seriesFor = (
     key: WindowKey,
     backfillSamples: LimitSample[],
@@ -650,11 +663,11 @@ function buildEngineBurndown(
   ): BurndownSeries => {
     const live = limits?.[key] ?? null;
     const windowSeconds = windowSecondsOf(live) ?? backfillWindowSeconds ?? WINDOW_SECONDS[key];
-    // A snapshot that reports no window of this horizon has nothing to chart:
-    // the forward history under this key predates the horizon fix (issue #606)
-    // and belongs to the other window, so it is not drawn here. The panel names
+    // A plan that reports no window of this horizon has nothing to chart: the
+    // forward history under this key predates the horizon fix (issue #606) and
+    // belongs to the other window, so it is not drawn here. The panel names
     // that reason rather than claiming there is no history at all.
-    if (limits && !live && backfillSamples.length === 0) {
+    if (snapshotNamesAWindow && !live && backfillSamples.length === 0) {
       return { windowStart: null, resetsAt: null, windowSeconds, samples: [], windowUnreported: true };
     }
     return buildSeries(forward(key), backfillSamples, live, now, windowSeconds, backfillResetsAt);

--- a/src/lib/limitsBurndown.test.ts
+++ b/src/lib/limitsBurndown.test.ts
@@ -52,6 +52,23 @@ test("reconstructs primary/secondary curves across events with window metadata",
   expect(series.weeklyResetsAt).toBe(resetWeek);
 });
 
+test("a weekly-only stream backfills the weekly curve, not the 5h one", () => {
+  // The plan behind issue #606 reports a single 10080-minute window, and it
+  // arrives in the primary slot: the declared length, not the slot, decides.
+  const resetWeek = 1_783_994_379;
+  writeSession("weekly-only.jsonl", "2026-07-08", [
+    { ts: "2026-07-08T15:00:00.000Z", primary: [15, 10080, resetWeek] },
+    { ts: "2026-07-08T17:28:49.000Z", primary: [22, 10080, resetWeek] },
+  ]);
+  const series = collectCodexRateLimitSeries(root, 0);
+  expect(series.weekly.map((s) => s.remaining)).toEqual([85, 78]);
+  expect(series.weeklyWindowSeconds).toBe(10080 * 60);
+  expect(series.weeklyResetsAt).toBe(resetWeek);
+  expect(series.session).toEqual([]);
+  expect(series.sessionWindowSeconds).toBeNull();
+  expect(series.sessionResetsAt).toBeNull();
+});
+
 test("drops events older than the cutoff and dedupes identical timestamps", () => {
   const reset = 1_783_544_991;
   writeSession("a.jsonl", "2026-07-08", [

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -483,6 +483,11 @@ export interface LimitWindow {
   usedPercent: number;
   /** Unix seconds when the window resets, or null when unknown. */
   resetsAt: number | null;
+  /** The window's own length in minutes as the provider declared it (Codex
+      `windowDurationMins` / `window_minutes`; 300 and 10080 for Claude's two
+      windows). This is the horizon the number carries, and labels are taken
+      from it. Absent on snapshots cached before issue #606. */
+  windowMinutes?: number | null;
 }
 
 /** Plan rate limits of one engine, returned by GET /api/limits. */
@@ -542,6 +547,10 @@ export interface BurndownSeries {
   windowSeconds: number;
   /** Remaining-quota samples inside the current window, oldest first. */
   samples: LimitSample[];
+  /** True when the current snapshot carries no window of this horizon at all —
+      e.g. a Codex plan that reports only a weekly limit. The chart then names
+      that reason instead of the generic "no history yet" (issue #606). */
+  windowUnreported?: boolean;
 }
 
 /** Both windows' burndown series for one engine. */


### PR DESCRIPTION
## What was wrong

The Codex usage widget showed a weekly-horizon number under the 5-hour tab, and the usage chart stayed empty behind a "no history yet" message while history existed.

Two commits:

**`88b95b2b`** routes each window by the horizon its data actually carries rather than by the slot it conventionally occupies, so a value whose reset is a week out stops being labelled as the 5-hour window.

**`714593a0`** fixes what the first review caught: `windowUnreported` was stamped whenever a single window was null, without checking whether the snapshot reported *any* window. Transcripts on this machine carry `rate_limits` events with both windows null, inside the retention window; landing on one made the panel assert "reports no 5h window" *and* "reports no Week window" for a plan that does report weekly — a more confident wrong statement than the empty state it replaced. Worse, the early return fired before forward history was accumulated, so legitimate weekly samples were dropped. A horizon is now called unreported only on positive evidence, and a windowless snapshot falls through so existing history still charts.

The same round also fixed: the reset-horizon sanity check now runs at ingestion rather than only for cached snapshots, so a wrong slot can no longer be written to cache; an undeclared window can no longer be parked in the 5-hour slot and labelled on no evidence; and a declared length that is off by a minute (10081 occurs 1804 times in local transcripts) snaps to its canonical horizon instead of rendering as "168h".

## Review

Two independent read-only rounds. The first returned REQUEST_CHANGES with the blocking finding above; the second returned **APPROVE** on the repaired head with five non-blocking comments.

## Verification

Touched tests pass by path, `tsc --noEmit` clean, `lint` adds no new problems, privacy gate green. Fixtures are anonymised — no account handle, id, or absolute path.

Closes #606