### PR TITLE
fix(feed): stop a stale live-turn row pinning below fresher records (#674)

### DIFF
--- a/src/components/LogFeed.tsx
+++ b/src/components/LogFeed.tsx
@@ -146,10 +146,16 @@ export function LogFeed({ file, showSvc, lineFilter, onStatus, paused, follow, s
      launch the file path is still `spawn:<launchId>` with no artifact, so an
      artifact-only lookup would miss the live host and drop the first deltas; the
      transcript path stays a fallback for subagents that carry no bus id. */
-  const runtimeLiveTurn = useRuntimeSessionForConversation(
+  const runtimeSession = useRuntimeSessionForConversation(
     file?.conversationId ?? null,
     file?.path ?? null,
-  )?.session.liveTurn ?? null;
+  )?.session ?? null;
+  const runtimeLiveTurn = runtimeSession?.liveTurn ?? null;
+  /* Liveness for the in-flight exemption (issue #674 review): a `streaming`
+     overlay row outranks the transcript only while the turn is actually
+     running. Once the turn is idle a lingering one — a broker that died
+     mid-stream leaves it streaming forever — is fenced like any other. */
+  const runtimeTurn = runtimeSession?.turn ?? null;
   /* The scroll magnet lives per feed instance, so each column remembers its
      own state across polls: glued to the live tail, or released by the user.
      A remount inherits the transcript's remembered state. */
@@ -514,8 +520,8 @@ export function LogFeed({ file, showSvc, lineFilter, onStatus, paused, follow, s
     publishCanonicalAssistantClaims(memoryKey, feed.items);
   }, [file, memoryKey, feed.items]);
   const visibleLiveTurnItems = useMemo(
-    () => visibleRuntimeLiveTurnItems(runtimeLiveTurn, feed.items, assistantClaims),
-    [runtimeLiveTurn, feed.items, assistantClaims],
+    () => visibleRuntimeLiveTurnItems(runtimeLiveTurn, feed.items, assistantClaims, runtimeTurn),
+    [runtimeLiveTurn, feed.items, assistantClaims, runtimeTurn],
   );
   /* Anything the window shows below the transcript. While it is present an
      empty transcript is not "no output" — it is a conversation mid-launch. */

--- a/src/components/conversation/liveTurnHandoff.ts
+++ b/src/components/conversation/liveTurnHandoff.ts
@@ -2,6 +2,7 @@
 
 import type { FeedEntry } from "@/components/feed/parse";
 import { newestTranscriptInstant } from "@/components/feed/transcriptOrder";
+import type { RuntimeTurnAxis } from "@/lib/runtime/contracts";
 import { useSyncExternalStore } from "react";
 import {
   LIVE_TURN_ITEM_LIMIT,
@@ -147,20 +148,35 @@ function canonicalAssistantItems(feed: readonly FeedEntry[]): CanonicalAssistant
  * Canonical transcript rows claim completed live items by response identity.
  * Older engine records without ids use a timestamp-fenced text echo.
  *
- * These overlay rows render BELOW every transcript row, so a completed item the
- * transcript has already moved past would sit under records written after it
+ * These overlay rows render BELOW every transcript row, so an item the
+ * transcript has already moved past sits under records written after it
  * (issue #674): the session's opening answer pinned beneath tool cards from
  * minutes later, permanently, because its own transcript row is far above the
- * window the pane keeps and no claim can ever be made from it. A completed item
- * older than the newest record in the window is therefore dropped — the
- * transcript is demonstrably past it, so it belongs above, where the transcript
- * already renders it. In-flight (`streaming`) items are always the newest thing
- * in the conversation and stay.
+ * window the pane keeps and no claim can ever be made from it.
+ *
+ * An unclaimed item older than the newest record in the window is therefore
+ * dropped. What that comparison proves is narrow: the transcript has advanced
+ * past this instant. It cannot prove the item's own row is in the file, and it
+ * never could — eviction of that row is the very case being handled, so there is
+ * nothing left here to check it against. The trade is deliberate: an item the
+ * transcript never recorded at all is dropped too when it predates the newest
+ * record. Keeping it would put an old line below fresher ones, which is the
+ * reported defect; the transcript stays the authority on what was said.
+ *
+ * `sessionTurn` fences the in-flight exemption. A `streaming` item is the newest
+ * thing in the conversation only while the turn is actually running — nothing
+ * flips a lingering `streaming` item to `awaiting-echo` (`turn-ended` leaves item
+ * phases alone and no path clears `liveTurn`), so a broker that dies mid-stream
+ * would otherwise pin a stale partial answer at the bottom forever. Once the turn
+ * is `idle` a streaming item faces the same staleness rule. `running`,
+ * `interrupt_requested`, `unknown` (a recovering host) and an absent turn all
+ * keep it, so a genuinely in-flight item is never dropped.
  */
 export function visibleRuntimeLiveTurnItems(
   liveTurn: RuntimeLiveTurn | null | undefined,
   feed: readonly FeedEntry[],
   persistedClaims: ReadonlySet<string> = EMPTY_CLAIMS,
+  sessionTurn: RuntimeTurnAxis | null = null,
 ): RuntimeLiveTurnItem[] {
   const overlay = runtimeLiveTurnItems(liveTurn);
   if (!overlay.length) return overlay;
@@ -168,8 +184,13 @@ export function visibleRuntimeLiveTurnItems(
   const currentClaims = new Set(canonical.flatMap((item) => item.sourceId ? [item.sourceId] : []));
   const transcriptAt = newestTranscriptInstant(feed);
   const claimed = new Set<number>();
+  /** The transcript has moved past this item, so the tail must not show it. */
+  const transcriptMovedPast = (live: RuntimeLiveTurnItem): boolean => {
+    const liveAt = timestamp(live.completedAt) ?? timestamp(live.startedAt);
+    return transcriptAt !== null && liveAt !== null && liveAt <= transcriptAt;
+  };
   return overlay.filter((live) => {
-    if (live.phase === "streaming") return true;
+    if (live.phase === "streaming") return sessionTurn !== "idle" || !transcriptMovedPast(live);
     if (live.itemId && (persistedClaims.has(live.itemId) || currentClaims.has(live.itemId))) return false;
     let owner = live.itemId
       ? canonical.findIndex((item, index) => !claimed.has(index) && item.sourceId === live.itemId)
@@ -183,10 +204,7 @@ export function visibleRuntimeLiveTurnItems(
         && (startedAt === null || item.at === null || item.at >= startedAt),
       );
     }
-    if (owner < 0) {
-      const liveAt = timestamp(live.completedAt) ?? timestamp(live.startedAt);
-      return transcriptAt === null || liveAt === null || liveAt > transcriptAt;
-    }
+    if (owner < 0) return !transcriptMovedPast(live);
     claimed.add(owner);
     return false;
   });

--- a/src/components/conversation/liveTurnHandoff.ts
+++ b/src/components/conversation/liveTurnHandoff.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import type { FeedEntry } from "@/components/feed/parse";
+import { newestTranscriptInstant } from "@/components/feed/transcriptOrder";
 import { useSyncExternalStore } from "react";
 import {
   LIVE_TURN_ITEM_LIMIT,
@@ -145,16 +146,29 @@ function canonicalAssistantItems(feed: readonly FeedEntry[]): CanonicalAssistant
 /**
  * Canonical transcript rows claim completed live items by response identity.
  * Older engine records without ids use a timestamp-fenced text echo.
+ *
+ * These overlay rows render BELOW every transcript row, so a completed item the
+ * transcript has already moved past would sit under records written after it
+ * (issue #674): the session's opening answer pinned beneath tool cards from
+ * minutes later, permanently, because its own transcript row is far above the
+ * window the pane keeps and no claim can ever be made from it. A completed item
+ * older than the newest record in the window is therefore dropped — the
+ * transcript is demonstrably past it, so it belongs above, where the transcript
+ * already renders it. In-flight (`streaming`) items are always the newest thing
+ * in the conversation and stay.
  */
 export function visibleRuntimeLiveTurnItems(
   liveTurn: RuntimeLiveTurn | null | undefined,
   feed: readonly FeedEntry[],
   persistedClaims: ReadonlySet<string> = EMPTY_CLAIMS,
 ): RuntimeLiveTurnItem[] {
+  const overlay = runtimeLiveTurnItems(liveTurn);
+  if (!overlay.length) return overlay;
   const canonical = canonicalAssistantItems(feed);
   const currentClaims = new Set(canonical.flatMap((item) => item.sourceId ? [item.sourceId] : []));
+  const transcriptAt = newestTranscriptInstant(feed);
   const claimed = new Set<number>();
-  return runtimeLiveTurnItems(liveTurn).filter((live) => {
+  return overlay.filter((live) => {
     if (live.phase === "streaming") return true;
     if (live.itemId && (persistedClaims.has(live.itemId) || currentClaims.has(live.itemId))) return false;
     let owner = live.itemId
@@ -169,7 +183,10 @@ export function visibleRuntimeLiveTurnItems(
         && (startedAt === null || item.at === null || item.at >= startedAt),
       );
     }
-    if (owner < 0) return true;
+    if (owner < 0) {
+      const liveAt = timestamp(live.completedAt) ?? timestamp(live.startedAt);
+      return transcriptAt === null || liveAt === null || liveAt > transcriptAt;
+    }
     claimed.add(owner);
     return false;
   });

--- a/src/components/feed/transcriptOrder.test.ts
+++ b/src/components/feed/transcriptOrder.test.ts
@@ -113,23 +113,57 @@ test("issue 674: a live item newer than every transcript record still renders in
     .toEqual(["item-674-fresh"]);
 });
 
-test("issue 674: a streaming item and an empty transcript keep their overlay rows", () => {
-  const streaming: RuntimeLiveTurn = {
-    turnId: "turn-674-streaming",
+/** A partial answer the host was still streaming when the transcript moved on:
+    nothing ever flips it to `awaiting-echo`, so a broker that dies mid-stream
+    leaves it in this shape forever. */
+const strandedStream: RuntimeLiveTurn = {
+  turnId: "turn-674-streaming",
+  text: "Reading src/components/feed",
+  items: [{
+    itemId: null,
     text: "Reading src/components/feed",
-    items: [{
-      itemId: null,
-      text: "Reading src/components/feed",
-      phase: "streaming",
-      startedAt: "2026-07-25T10:00:03.000Z",
-      completedAt: null,
-    }],
-  };
+    phase: "streaming",
+    startedAt: "2026-07-25T10:00:03.000Z",
+    completedAt: null,
+  }],
+};
 
+test("issue 674: a streaming item and an empty transcript keep their overlay rows", () => {
   /* In flight: newer than anything the transcript can hold, whatever its dates. */
-  expect(visibleRuntimeLiveTurnItems(streaming, feedOf(TRANSCRIPT)).map((item) => item.phase))
+  expect(visibleRuntimeLiveTurnItems(strandedStream, feedOf(TRANSCRIPT), undefined, "running")
+    .map((item) => item.phase))
     .toEqual(["streaming"]);
   /* Mid-launch, before the transcript flushes a single record. */
   expect(visibleRuntimeLiveTurnItems(staleOpening, []).map((item) => item.itemId))
     .toEqual(["item-674-opening"]);
+});
+
+test("issue 674: a streaming item stranded by a dead broker is fenced once the turn is idle", () => {
+  const paneWindow = feedOf(TRANSCRIPT);
+
+  /* The turn ended without the item/turn events that would have settled it. */
+  expect(visibleRuntimeLiveTurnItems(strandedStream, paneWindow, undefined, "idle")).toEqual([]);
+
+  /* The same row while the turn is genuinely running stays put — an in-flight
+     answer is never dropped for being older than a record already written. */
+  expect(visibleRuntimeLiveTurnItems(strandedStream, paneWindow, undefined, "running")
+    .map((item) => item.text))
+    .toEqual(["Reading src/components/feed"]);
+  /* A recovering host reports `unknown`, and a pane with no hosted session
+     reports nothing at all; neither is proof the turn stopped. */
+  for (const turn of ["unknown", "interrupt_requested", null] as const) {
+    expect(visibleRuntimeLiveTurnItems(strandedStream, paneWindow, undefined, turn)).toHaveLength(1);
+  }
+});
+
+test("issue 674: an idle turn still keeps a streaming item the transcript has not reached", () => {
+  const fresh: RuntimeLiveTurn = {
+    ...strandedStream,
+    items: [{ ...strandedStream.items![0]!, startedAt: "2026-07-25T10:20:00.000Z" }],
+  };
+
+  expect(visibleRuntimeLiveTurnItems(fresh, feedOf(TRANSCRIPT), undefined, "idle"))
+    .toHaveLength(1);
+  /* And a launch tail with no transcript at all is untouched by liveness. */
+  expect(visibleRuntimeLiveTurnItems(strandedStream, [], undefined, "idle")).toHaveLength(1);
 });

--- a/src/components/feed/transcriptOrder.test.ts
+++ b/src/components/feed/transcriptOrder.test.ts
@@ -1,0 +1,135 @@
+import { expect, test } from "bun:test";
+
+import { visibleRuntimeLiveTurnItems } from "@/components/conversation/liveTurnHandoff";
+import type { RuntimeLiveTurn } from "@/lib/runtime/liveTurn";
+
+import { createFeedSession, type FeedEntry } from "./parse";
+import { newestTranscriptInstant } from "./transcriptOrder";
+
+const OPENING_ANSWER = "Reading the issue and the entry points now.";
+
+/* A synthetic session in write order: the opening assistant message, the
+   bookkeeping records the engine writes with NO `timestamp` field at all
+   (`ai-title`, `last-prompt`, `mode`), later tool work, a later answer, and one
+   more undated bookkeeping tail. */
+const TRANSCRIPT = [
+  { type: "user", uuid: "rec-1", timestamp: "2026-07-25T10:00:00.000Z", message: { role: "user", content: "Investigate issue 674." } },
+  { type: "assistant", uuid: "rec-2", timestamp: "2026-07-25T10:00:04.000Z", message: { role: "assistant", content: [{ type: "text", text: OPENING_ANSWER }] } },
+  { type: "ai-title", title: "Feed ordering" },
+  { type: "last-prompt", lastPrompt: "Investigate issue 674." },
+  { type: "mode", mode: "default" },
+  { type: "assistant", uuid: "rec-6", timestamp: "2026-07-25T10:12:00.000Z", message: { role: "assistant", content: [{ type: "tool_use", id: "call-1", name: "Bash", input: { command: "rg --files src/components/feed" } }] } },
+  { type: "user", uuid: "rec-7", timestamp: "2026-07-25T10:12:01.000Z", message: { role: "user", content: [{ type: "tool_result", tool_use_id: "call-1", content: "parse.ts" }] } },
+  { type: "ai-title", title: "Feed ordering" },
+  { type: "assistant", uuid: "rec-9", timestamp: "2026-07-25T10:14:30.000Z", message: { role: "assistant", content: [{ type: "text", text: "The parser keeps record order." }] } },
+  { type: "mode", mode: "default" },
+  { type: "last-prompt", lastPrompt: "Investigate issue 674." },
+];
+
+function feedOf(records: readonly Record<string, unknown>[], showSvc = true): FeedEntry[] {
+  const session = createFeedSession({ engine: "claude", fmt: "claude", showSvc, lineFilter: "" });
+  return session.feed(records.map((record) => JSON.stringify(record)), 0, true).items;
+}
+
+test("issue 674: interleaved undated records never displace a dated row in the transcript feed", () => {
+  const items = feedOf(TRANSCRIPT).map(({ item }) => ({
+    kind: item.kind,
+    text: "text" in item ? item.text : undefined,
+  }));
+
+  /* Record sequence, verbatim: the opening answer stays second, and the undated
+     rows sit exactly where they were written — never dragged past dated rows. */
+  expect(items).toEqual([
+    { kind: "user", text: "Investigate issue 674." },
+    { kind: "prose", text: OPENING_ANSWER },
+    { kind: "svc", text: "ai-title" },
+    { kind: "svc", text: "last-prompt" },
+    { kind: "svc", text: "mode" },
+    { kind: "tool", text: undefined },
+    { kind: "svc", text: "ai-title" },
+    { kind: "prose", text: "The parser keeps record order." },
+    { kind: "svc", text: "mode" },
+    { kind: "svc", text: "last-prompt" },
+  ]);
+});
+
+test("issue 674: the newest transcript instant skips the undated tail instead of collapsing", () => {
+  const feed = feedOf(TRANSCRIPT);
+  /* The last three rows carry no timestamp; the answer written at 10:14:30 is
+     still the transcript's high-water mark. */
+  expect(newestTranscriptInstant(feed)).toBe(Date.parse("2026-07-25T10:14:30.000Z"));
+  expect(newestTranscriptInstant([])).toBeNull();
+  expect(newestTranscriptInstant(feedOf([{ type: "ai-title", title: "only" }, { type: "mode", mode: "default" }])))
+    .toBeNull();
+});
+
+/** The opening answer as the structured host still holds it: completed, never
+    claimed, because its transcript row is far above the window the pane keeps. */
+const staleOpening: RuntimeLiveTurn = {
+  turnId: "turn-674-opening",
+  text: OPENING_ANSWER,
+  items: [{
+    itemId: "item-674-opening",
+    text: OPENING_ANSWER,
+    phase: "awaiting-echo",
+    startedAt: "2026-07-25T10:00:03.000Z",
+    completedAt: "2026-07-25T10:00:04.000Z",
+  }],
+};
+
+test("issue 674: an unclaimed opening answer never renders below fresher transcript records", () => {
+  /* The window the pane actually holds: the opening answer's row has slid out,
+     so no claim can be made from it and none was ever persisted. */
+  const paneWindow = feedOf(TRANSCRIPT.slice(5));
+  expect(paneWindow.some(({ item }) => "text" in item && item.text === OPENING_ANSWER)).toBe(false);
+
+  expect(visibleRuntimeLiveTurnItems(staleOpening, paneWindow)).toEqual([]);
+});
+
+test("issue 674: an undated tail cannot resurrect the stale opening answer", () => {
+  /* Same window, but the transcript's last three records carry no timestamp —
+     the case that made the stale line stick. */
+  const paneWindow = feedOf(TRANSCRIPT.slice(5));
+  expect(paneWindow.at(-1)?.item.kind).toBe("svc");
+
+  expect(visibleRuntimeLiveTurnItems(staleOpening, paneWindow)).toEqual([]);
+});
+
+test("issue 674: a live item newer than every transcript record still renders in the tail", () => {
+  const paneWindow = feedOf(TRANSCRIPT);
+  const fresh: RuntimeLiveTurn = {
+    turnId: "turn-674-fresh",
+    text: "Still writing the fix.",
+    items: [{
+      itemId: "item-674-fresh",
+      text: "Still writing the fix.",
+      phase: "awaiting-echo",
+      startedAt: "2026-07-25T10:15:00.000Z",
+      completedAt: "2026-07-25T10:15:02.000Z",
+    }],
+  };
+
+  expect(visibleRuntimeLiveTurnItems(fresh, paneWindow).map((item) => item.itemId))
+    .toEqual(["item-674-fresh"]);
+});
+
+test("issue 674: a streaming item and an empty transcript keep their overlay rows", () => {
+  const streaming: RuntimeLiveTurn = {
+    turnId: "turn-674-streaming",
+    text: "Reading src/components/feed",
+    items: [{
+      itemId: null,
+      text: "Reading src/components/feed",
+      phase: "streaming",
+      startedAt: "2026-07-25T10:00:03.000Z",
+      completedAt: null,
+    }],
+  };
+
+  /* In flight: newer than anything the transcript can hold, whatever its dates. */
+  expect(visibleRuntimeLiveTurnItems(streaming, feedOf(TRANSCRIPT)).map((item) => item.phase))
+    .toEqual(["streaming"]);
+  /* Mid-launch, before the transcript flushes a single record. */
+  expect(visibleRuntimeLiveTurnItems(staleOpening, []).map((item) => item.itemId))
+    .toEqual(["item-674-opening"]);
+});

--- a/src/components/feed/transcriptOrder.ts
+++ b/src/components/feed/transcriptOrder.ts
@@ -1,0 +1,41 @@
+import type { FeedEntry, Item } from "./parse";
+
+/**
+ * How far the transcript has advanced, read from its own rows (issue #674).
+ *
+ * The feed itself is already ordered by record sequence — the parser pushes one
+ * item per line and nothing downstream re-sorts. What can still break the
+ * invariant is the window tail, which renders live-turn overlay rows BELOW every
+ * transcript row: an overlay row that the transcript already moved past would
+ * show a session-opening line under tool cards written minutes later.
+ *
+ * Comparing against the transcript needs an instant, and transcripts carry rows
+ * that have none: engines interleave bookkeeping records — `ai-title`,
+ * `last-prompt`, `mode` — with no `timestamp` field at all, and they parse into
+ * `svc` rows. Those must never read as "dated at zero" or collapse the answer to
+ * "unknown"; they simply do not carry ordering information and are skipped.
+ */
+
+/** The row's own instant, or null when its record carries no usable timestamp. */
+export function transcriptInstant(item: Item): number | null {
+  const raw = item.kind === "cmd-group" ? (item.t1 ?? item.t0) : "ts" in item ? item.ts : undefined;
+  if (typeof raw !== "string" || !raw) return null;
+  const parsed = Date.parse(raw);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+/**
+ * The newest instant any row in the window was written at, or null when the
+ * window holds no dated row at all (an empty feed, or a launch whose transcript
+ * has not flushed). Undated rows contribute nothing, so a tail of `ai-title` /
+ * `last-prompt` / `mode` records leaves the answer at the last dated record
+ * instead of erasing it.
+ */
+export function newestTranscriptInstant(feed: readonly FeedEntry[]): number | null {
+  let newest: number | null = null;
+  for (const entry of feed) {
+    const at = transcriptInstant(entry.item);
+    if (at !== null && (newest === null || at > newest)) newest = at;
+  }
+  return newest;
+}


### PR DESCRIPTION
## What was wrong

The first assistant message of a session rendered as the **last** item in the feed, below tool cards written minutes later, and stayed pinned there while new records arrived. The transcript was never at fault: the pinned text existed once, near the start, with its original timestamp, and the newest records carried correct later ones. The ordering came from the live-turn overlay, not from the reader.

**`0ed9afd4`** stops a stale live-turn row from rendering below fresher transcript records.

**`00f543a1`** closes the second door the review found: the `streaming` exemption was unconditional, justified by in-flight items always being the newest thing in the conversation — which holds only while the host is alive. Nothing flips an item out of `streaming` except an event for a *different* turn, `turn-ended` does not touch item phases, and nothing clears the live turn. So a broker that died mid-stream left a permanently streaming row pinned below fresher records — the same symptom, through another entrance. The exemption is now fenced on turn liveness.

## Review

Two independent read-only rounds, both **APPROVE**. The second returned four non-blocking comments, all coverage suggestions: extend a fixture so a collapsed command run forms a `cmd-group` row and assert the newest-instant read against it, and add a browser-evidence case for the `LogFeed` wiring. Worth doing, not worth holding the fix.

## Verification

Touched tests pass by path, `tsc --noEmit` clean, `lint` adds no new problems, privacy gate green.

Closes #674