### PR TITLE
fix(mobile): keep the conversation header inside a 390px viewport (#613)

### DIFF
--- a/evidence/issue-613/geometry.json
+++ b/evidence/issue-613/geometry.json
@@ -1,0 +1,207 @@
+{
+  "header-390": {
+    "scrollWidth": 390,
+    "bodyScrollWidth": 390,
+    "viewportWidth": 390,
+    "headerScrollWidth": 390,
+    "headerClientWidth": 390,
+    "controls": [
+      {
+        "label": "Open project list",
+        "left": 8,
+        "right": 52,
+        "width": 44,
+        "height": 44
+      },
+      {
+        "label": "Undo — reopen “Closed card” (Ctrl+Z)",
+        "left": 133.171875,
+        "right": 177.171875,
+        "width": 44,
+        "height": 44
+      },
+      {
+        "label": "3 waiting",
+        "left": 186.171875,
+        "right": 237,
+        "width": 50.828125,
+        "height": 44
+      },
+      {
+        "label": "Hidden",
+        "left": 242,
+        "right": 286,
+        "width": 44,
+        "height": 44
+      },
+      {
+        "label": "Create",
+        "left": 290,
+        "right": 334,
+        "width": 44,
+        "height": 44
+      },
+      {
+        "label": "More actions",
+        "left": 338,
+        "right": 382,
+        "width": 44,
+        "height": 44
+      }
+    ],
+    "titleText": "live-log-viewer-next-mobile",
+    "paneControls": [
+      {
+        "label": "Rename “Builder · keep the conversation header inside a 390px viewp…”",
+        "left": 125,
+        "right": 169,
+        "width": 44,
+        "height": 44
+      },
+      {
+        "label": "Show conversation details",
+        "left": 181,
+        "right": 225,
+        "width": 44,
+        "height": 44
+      },
+      {
+        "label": "Mark as favorite",
+        "left": 231,
+        "right": 275,
+        "width": 44,
+        "height": 44
+      },
+      {
+        "label": "Delete the conversation from disk",
+        "left": 281,
+        "right": 325,
+        "width": 44,
+        "height": 44
+      },
+      {
+        "label": "Remove column Builder · keep the conversation header inside a 390px viewp…",
+        "left": 331,
+        "right": 375,
+        "width": 44,
+        "height": 44
+      }
+    ],
+    "paneHeaderScrollWidth": 376,
+    "paneHeaderClientWidth": 376,
+    "paneTitleText": "Builder · keep the conversation header inside a 390px viewport (613)"
+  },
+  "header-390-more-open": {
+    "scrollWidth": 390,
+    "bodyScrollWidth": 390,
+    "viewportWidth": 390,
+    "headerScrollWidth": 390,
+    "headerClientWidth": 390,
+    "controls": [
+      {
+        "label": "Open project list",
+        "left": 8,
+        "right": 52,
+        "width": 44,
+        "height": 44
+      },
+      {
+        "label": "Undo — reopen “Closed card” (Ctrl+Z)",
+        "left": 133.171875,
+        "right": 177.171875,
+        "width": 44,
+        "height": 44
+      },
+      {
+        "label": "3 waiting",
+        "left": 186.171875,
+        "right": 237,
+        "width": 50.828125,
+        "height": 44
+      },
+      {
+        "label": "Hidden",
+        "left": 242,
+        "right": 286,
+        "width": 44,
+        "height": 44
+      },
+      {
+        "label": "Create",
+        "left": 290,
+        "right": 334,
+        "width": 44,
+        "height": 44
+      },
+      {
+        "label": "More actions",
+        "left": 338,
+        "right": 382,
+        "width": 44,
+        "height": 44
+      },
+      {
+        "label": "View: scheme",
+        "left": 179,
+        "right": 375,
+        "width": 196,
+        "height": 44
+      },
+      {
+        "label": "View: conversations",
+        "left": 179,
+        "right": 375,
+        "width": 196,
+        "height": 44
+      },
+      {
+        "label": "Mute sound notifications",
+        "left": 325,
+        "right": 369,
+        "width": 44,
+        "height": 44
+      }
+    ],
+    "titleText": "live-log-viewer-next-mobile",
+    "paneControls": [
+      {
+        "label": "Rename “Builder · keep the conversation header inside a 390px viewp…”",
+        "left": 125,
+        "right": 169,
+        "width": 44,
+        "height": 44
+      },
+      {
+        "label": "Show conversation details",
+        "left": 181,
+        "right": 225,
+        "width": 44,
+        "height": 44
+      },
+      {
+        "label": "Mark as favorite",
+        "left": 231,
+        "right": 275,
+        "width": 44,
+        "height": 44
+      },
+      {
+        "label": "Delete the conversation from disk",
+        "left": 281,
+        "right": 325,
+        "width": 44,
+        "height": 44
+      },
+      {
+        "label": "Remove column Builder · keep the conversation header inside a 390px viewp…",
+        "left": 331,
+        "right": 375,
+        "width": 44,
+        "height": 44
+      }
+    ],
+    "paneHeaderScrollWidth": 376,
+    "paneHeaderClientWidth": 376,
+    "paneTitleText": "Builder · keep the conversation header inside a 390px viewport (613)"
+  }
+}

--- a/src/components/ProjectDashboard.shelf.dom.test.tsx
+++ b/src/components/ProjectDashboard.shelf.dom.test.tsx
@@ -188,10 +188,15 @@ test("mobile: the project name takes priority in the header and the shelf stays 
   const ready = await waitFor(() => trigger(host) !== null);
   expect(ready).toBe(true);
   /* The project title is content-width priority (never flex-1 that compresses
-     «atlas» to «a…»), capped so a long name truncates instead of overflowing. */
+     «atlas» to «a…»), capped so a long name truncates instead of overflowing.
+     It IS allowed to shrink as the last resort (issue #613): the empty filler
+     beside it collapses first, and only a row that would otherwise push its
+     controls off a 390px screen makes the name give up pixels — short names
+     like «atlas» still show in full. */
   const h1 = q(host, "h1")!;
   expect(h1.textContent).toBe("atlas");
-  expect(h1.className).toContain("shrink-0");
+  expect(h1.className).toContain("min-w-0");
+  expect(h1.className).toContain("truncate");
   expect(h1.className).toContain("max-w-[45vw]");
   expect(h1.className).not.toContain("flex-1");
   /* One-tap shelf access is preserved: exactly one trigger, a 44px target. */

--- a/src/components/ProjectDashboard.tsx
+++ b/src/components/ProjectDashboard.tsx
@@ -1375,9 +1375,13 @@ export function ProjectDashboard({
           most five fixed 44px targets (projects, undo, shelf, create, more) plus
           the bounded attention pill — ~326px with the gaps and padding — and the
           project name as the ONE elastic cell, which truncates into whatever is
-          left. Nothing here can push the document into a horizontal scroll.
-          Any control added later either fits that budget as a 44px target or
-          folds into the «⋯» menu, the way the scheme/list switch did. */}
+          left. 390px is the narrowest viewport this layout supports — a fully
+          populated row leaves the name ~73px there, ~43px at 360px, a sliver at
+          320px, and at 280px the fixed targets alone overflow the row by ~29px.
+          That collapse below 390px is a documented limit, not a defect: a
+          narrower phone would need a further fold into the «⋯» menu. Any control
+          added later either fits the budget as a 44px target or folds into that
+          menu, the way the scheme/list switch did. */}
       <div
         data-testid={isMobile ? "mobile-project-header" : undefined}
         className={
@@ -1587,8 +1591,9 @@ export function ProjectDashboard({
 
       {isMobile ? (
         <>
-          {/* The scheme/list toggle moved into the header row (finding 7), so the
-              phone shell is two nav rows at most: header + the focus-view strip. */}
+          {/* The phone shell is two nav rows at most: header + the focus-view
+              strip (finding 7). The scheme/list switch is not one of them — it
+              is one tap inside the header's «⋯» menu (issue #613). */}
           {!boardReady ? (
             <SchemeSkeleton />
           ) : projectView === "scheme" && schemeAvailable ? (

--- a/src/components/ProjectDashboard.tsx
+++ b/src/components/ProjectDashboard.tsx
@@ -185,20 +185,16 @@ function ProjectViewTabs({
   value,
   onChange,
   floating = false,
-  header = false,
 }: {
   value: ProjectView;
   onChange: (next: ProjectView) => void;
   floating?: boolean;
-  /** Compact, unpositioned pill for the mobile toolbar row (finding 7): the
-      scheme/list toggle rides in the header instead of its own stacked row. */
-  header?: boolean;
 }) {
   const { t } = useLocale();
   return (
     <div
       className={`z-30 inline-flex shrink-0 items-center gap-0.5 rounded-full border border-border bg-card p-0.5 shadow-1 ${
-        header ? "" : floating ? "absolute left-3 top-3" : "mx-3 mt-3 self-start"
+        floating ? "absolute left-3 top-3" : "mx-3 mt-3 self-start"
       }`}
     >
       {(["scheme", "list"] as const).map((mode) => (
@@ -208,12 +204,12 @@ function ProjectViewTabs({
           aria-pressed={value === mode}
           onClick={() => onChange(mode)}
           aria-label={t(mode === "scheme" ? "dash.viewScheme" : "dash.viewList")}
-          className={`inline-flex items-center justify-center gap-1 rounded-full text-[11px] font-bold focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 ${
-            header ? "h-11 w-11" : "px-2 py-1"
-          } ${value === mode ? "bg-accent/10 text-accent" : "text-muted hover:text-primary"}`}
+          className={`inline-flex items-center justify-center gap-1 rounded-full px-2 py-1 text-[11px] font-bold focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 ${
+            value === mode ? "bg-accent/10 text-accent" : "text-muted hover:text-primary"
+          }`}
         >
-          {mode === "scheme" ? <Network className={header ? "h-3.5 w-3.5" : "h-3 w-3"} aria-hidden /> : <List className={header ? "h-3.5 w-3.5" : "h-3 w-3"} aria-hidden />}
-          {header ? null : t(mode === "scheme" ? "dash.viewScheme" : "dash.viewList")}
+          {mode === "scheme" ? <Network className="h-3 w-3" aria-hidden /> : <List className="h-3 w-3" aria-hidden />}
+          {t(mode === "scheme" ? "dash.viewScheme" : "dash.viewList")}
         </button>
       ))}
     </div>
@@ -274,15 +270,20 @@ function HeaderMenu({
   );
 }
 
-/** One 44px-tall row inside a HeaderMenu popover. */
-function HeaderMenuItem({ icon, label, onSelect, disabled = false }: { icon: React.ReactNode; label: string; onSelect: () => void; disabled?: boolean }) {
+/** One 44px-tall row inside a HeaderMenu popover. Passing `checked` turns the
+    row into a radio option (the folded scheme/list switch, issue #613) so the
+    face currently shown is announced instead of merely tinted. */
+function HeaderMenuItem({ icon, label, onSelect, disabled = false, checked }: { icon: React.ReactNode; label: string; onSelect: () => void; disabled?: boolean; checked?: boolean }) {
   return (
     <button
       type="button"
-      role="menuitem"
+      role={checked === undefined ? "menuitem" : "menuitemradio"}
+      aria-checked={checked}
       onClick={onSelect}
       disabled={disabled}
-      className="flex min-h-11 w-full items-center gap-2 rounded-[9px] px-2.5 text-left text-[13px] font-semibold text-primary hover:bg-canvas focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 disabled:cursor-not-allowed disabled:opacity-45"
+      className={`flex min-h-11 w-full items-center gap-2 rounded-[9px] px-2.5 text-left text-[13px] font-semibold hover:bg-canvas focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 disabled:cursor-not-allowed disabled:opacity-45 ${
+        checked ? "bg-accent/10 text-accent" : "text-primary"
+      }`}
     >
       <span className="flex h-5 w-5 shrink-0 items-center justify-center text-accent">{icon}</span>
       {label}
@@ -1369,10 +1370,19 @@ export function ProjectDashboard({
   return (
     <FavoritesProvider value={favoritesApi}>
     <div className="relative flex min-h-0 min-w-0 flex-1 flex-col">
+      {/* The phone header fits 390px BY CONSTRUCTION (issue #613, where it
+          measured 422px and hung «More actions» off the screen). Its budget: at
+          most five fixed 44px targets (projects, undo, shelf, create, more) plus
+          the bounded attention pill — ~326px with the gaps and padding — and the
+          project name as the ONE elastic cell, which truncates into whatever is
+          left. Nothing here can push the document into a horizontal scroll.
+          Any control added later either fits that budget as a 44px target or
+          folds into the «⋯» menu, the way the scheme/list switch did. */}
       <div
+        data-testid={isMobile ? "mobile-project-header" : undefined}
         className={
           isMobile
-            ? "flex min-h-[52px] shrink-0 items-center gap-1 border-b border-border bg-card px-2 py-1.5"
+            ? "flex min-h-[52px] min-w-0 shrink-0 items-center gap-1 border-b border-border bg-card px-2 py-1.5"
             : "flex h-10 shrink-0 items-center gap-2.5 border-b border-border bg-card px-4"
         }
       >
@@ -1389,11 +1399,12 @@ export function ProjectDashboard({
           </button>
         ) : null}
         {/* The project name takes priority on the phone (issue #419 finding 2):
-            it shows in full (short names like «atlas» never compress to «a…»),
-            capped at 45vw so a very long name truncates instead of overflowing.
-            The attention filler beside it yields the slack. Desktop keeps its
-            natural width. */}
-        <h1 className={`truncate text-[13.5px] font-bold ${isMobile ? "min-w-0 shrink-0 max-w-[45vw]" : ""}`} title={project}>{projectDisplayName(project)}</h1>
+            short names like «atlas» never compress to «a…», and it is capped at
+            45vw so a very long one truncates. It is also the ONLY cell that
+            gives width back when the row runs out (issue #613 — as `shrink-0` it
+            held its 45vw and pushed «More actions» off a 390px screen instead).
+            Desktop keeps its natural width. */}
+        <h1 className={`truncate text-[13.5px] font-bold ${isMobile ? "min-w-0 max-w-[45vw]" : ""}`} title={project}>{projectDisplayName(project)}</h1>
         <BoardHistoryControls
           canUndo={history.canUndo}
           canRedo={history.canRedo}
@@ -1405,15 +1416,21 @@ export function ProjectDashboard({
         />
         {isMobile ? (
           <>
-            {/* Toolbar folds to a single row (findings 1, 7): the scheme/list
-                toggle rides here instead of its own stacked row, all create
-                actions collapse into one `+` menu, and the secondary project
-                actions into a `⋯` menu — every control is a 44px hit target. */}
-            {viewToggle ? <ProjectViewTabs value={projectView} onChange={chooseEmptyView} header /> : null}
-            {/* Flexible filler beside the prioritized title: absorbs the slack
-                and shrinks/truncates first so the row never overflows and the
-                project name keeps its width (issue #419 finding 2). */}
-            <span className="min-w-0 flex-1 shrink truncate">{attention}</span>
+            {/* Toolbar folds to a single row (findings 1, 7): all create actions
+                collapse into one `+` menu and the secondary project actions into
+                a `⋯` menu — every control is a 44px hit target. The scheme/list
+                switch used to sit here as a 94px segmented pair; at 390px it is
+                one tap inside the `⋯` menu instead (issue #613). */}
+            {/* Empty filler: absorbs whatever slack the row has so the control
+                cluster stays right-aligned while the project name keeps its
+                natural width (issue #419 finding 2). It collapses to nothing
+                first, before the name starts truncating. */}
+            <span aria-hidden className="min-w-0 flex-1" />
+            {/* The attention queue badge is an ACTION (it opens the queue), not
+                decoration, so it holds its own bounded pill width — riding the
+                elastic filler squeezed it to zero px at 390px, which hid it
+                (issue #613). */}
+            {attention ? <span className="flex shrink-0 items-center">{attention}</span> : null}
             {/* Handoff/hidden/readiness access as a compact header trigger (issue
                 #419 reopened) — the focused chat below reserves no bottom row for
                 it; a tap opens the overlay sheet. */}
@@ -1445,6 +1462,29 @@ export function ProjectDashboard({
             <HeaderMenu triggerLabel={t("dash.moreMenu")} icon={<MoreHorizontal className="h-5 w-5" aria-hidden />}>
               {(close) => (
                 <>
+                  {/* The scheme/list switch (issue #613). Inline it cost 94px of
+                      a 390px row and pushed this very trigger off screen; here
+                      both faces stay one tap away and the current one is
+                      announced as the checked radio option. */}
+                  {viewToggle ? (
+                    <>
+                      <div role="group" aria-label={t("dash.viewMenuGroup")} className="flex flex-col gap-0.5">
+                        <HeaderMenuItem
+                          icon={<Network className="h-4 w-4" aria-hidden />}
+                          label={t("dash.viewSchemeMenu")}
+                          checked={projectView === "scheme"}
+                          onSelect={() => { close(); chooseEmptyView("scheme"); }}
+                        />
+                        <HeaderMenuItem
+                          icon={<List className="h-4 w-4" aria-hidden />}
+                          label={t("dash.viewListMenu")}
+                          checked={projectView === "list"}
+                          onSelect={() => { close(); chooseEmptyView("list"); }}
+                        />
+                      </div>
+                      <span aria-hidden className="my-0.5 h-px shrink-0 bg-border" />
+                    </>
+                  ) : null}
                   {/* Redo lives here on mobile — the header shows only a single
                       undo button, so its counterpart rides the «⋯» menu (and
                       Ctrl+Shift+Z), shown only while a redo is possible. */}

--- a/src/components/mobile/issue613Evidence.browser.test.tsx
+++ b/src/components/mobile/issue613Evidence.browser.test.tsx
@@ -19,11 +19,13 @@ import type { BoardTask } from "@/lib/tasks/types";
  * page scroll, with the «More actions» trigger hanging off the right edge.
  *
  * The header now fits BY CONSTRUCTION: every always-mounted control is a fixed
- * 44px target, the project name and the attention filler are the only elastic
- * cells (they truncate), and the scheme/list switch rides the «more» menu on the
- * phone instead of a 94px inline segmented pair. This renders the REAL
- * ProjectDashboard with a populated board and measures the production CSS in
- * Chromium, exactly as the issue's repro did.
+ * 44px target, the ONE elastic cell is the project name (the filler beside it is
+ * an empty spacer that collapses to nothing first, and the attention pill holds
+ * its own width), and the scheme/list switch is one tap inside the «more» menu
+ * instead of a 94px inline segmented pair. The budget itself is documented at
+ * the header in ProjectDashboard.tsx. This renders the REAL ProjectDashboard
+ * with a populated board and measures the production CSS in Chromium, exactly as
+ * the issue's repro did.
  */
 
 const actualRuntimeHooks = await import("@/hooks/useRuntime");
@@ -293,7 +295,8 @@ test("issue 613: the populated phone header fits a 390px viewport with every con
     expect(labels.some((label) => label.startsWith(translate("en", key).slice(0, 12)))).toBe(true);
   }
   /* The attention-queue badge is an action, so a full row must not squeeze it
-     out of existence (it used to ride the elastic filler). */
+     out of existence — it is no longer elastic (before #613 it rode the
+     flex-1 filler and collapsed to zero px here). */
   expect(labels).toContain(ATTENTION_LABEL);
 
   /* The long project name truncates instead of pushing the row wide. */

--- a/src/components/mobile/issue613Evidence.browser.test.tsx
+++ b/src/components/mobile/issue613Evidence.browser.test.tsx
@@ -1,0 +1,331 @@
+import { afterAll, beforeEach, afterEach, expect, mock, test } from "bun:test";
+import { act } from "react";
+import { installActEnv } from "@/test-helpers/actEnv";
+import fs from "node:fs";
+import path from "node:path";
+import { Window } from "happy-dom";
+import { createRoot } from "react-dom/client";
+import { chromium, type Browser } from "playwright-core";
+
+import { emptyStore } from "@/components/runtime/runtimeModel";
+import { setLocale, translate } from "@/lib/i18n";
+import type { FileEntry } from "@/lib/types";
+import type { BoardTask } from "@/lib/tasks/types";
+
+/**
+ * Browser-rendered evidence for issue #613: at a 390x844 phone viewport the
+ * project header row (hamburger, project name, undo, view switch, hidden shelf,
+ * create and «more» menus) pushed the document to 422px — a 32px horizontal
+ * page scroll, with the «More actions» trigger hanging off the right edge.
+ *
+ * The header now fits BY CONSTRUCTION: every always-mounted control is a fixed
+ * 44px target, the project name and the attention filler are the only elastic
+ * cells (they truncate), and the scheme/list switch rides the «more» menu on the
+ * phone instead of a 94px inline segmented pair. This renders the REAL
+ * ProjectDashboard with a populated board and measures the production CSS in
+ * Chromium, exactly as the issue's repro did.
+ */
+
+const actualRuntimeHooks = await import("@/hooks/useRuntime");
+const actualConversationCatalogHooks = await import("@/hooks/useConversationCatalog");
+const inertRuntime = { enabled: false, connection: "offline" as const, resyncedAt: null, store: emptyStore() };
+mock.module("@/hooks/useRuntime", () => ({
+  ...actualRuntimeHooks,
+  useRuntimeBusState: () => ({ ...inertRuntime, lastEventAt: null }),
+  useRuntime: () => inertRuntime,
+  useRuntimeSession: () => null,
+  useRuntimeReceiptsForArtifact: () => [],
+  useRuntimeFlow: () => null,
+}));
+mock.module("@/hooks/useConversationCatalog", () => ({
+  useConversationCatalog: () => ({
+    items: [], nextCursor: null, total: 0, loading: false, error: false, loadMore: () => {}, retry: () => {},
+  }),
+}));
+
+const EVIDENCE_DIR = path.join(process.cwd(), "evidence", "issue-613");
+const CSS_DIR = path.join(process.cwd(), ".next", "static", "css");
+
+function productionCss(): string {
+  const files = fs.existsSync(CSS_DIR) ? fs.readdirSync(CSS_DIR).filter((name) => name.endsWith(".css")) : [];
+  return files.map((name) => fs.readFileSync(path.join(CSS_DIR, name), "utf8")).join("\n");
+}
+
+const dom = new Window({ url: "http://localhost/" });
+installActEnv();
+/* The phone face: useIsMobile reads window.matchMedia off the dom itself. */
+(dom as unknown as { matchMedia(q: string): unknown }).matchMedia = (q: string) => ({
+  matches: /max-width|pointer: coarse/.test(String(q)),
+  media: String(q),
+  onchange: null,
+  addEventListener() {}, removeEventListener() {}, addListener() {}, removeListener() {}, dispatchEvent() { return false; },
+});
+Object.assign(globalThis, {
+  window: dom,
+  document: dom.document,
+  navigator: dom.navigator,
+  sessionStorage: dom.sessionStorage,
+  localStorage: dom.localStorage,
+  Node: dom.Node,
+  HTMLElement: dom.HTMLElement,
+  HTMLButtonElement: dom.HTMLButtonElement,
+  HTMLTextAreaElement: dom.HTMLTextAreaElement,
+  Event: dom.Event,
+  CustomEvent: dom.CustomEvent,
+  MouseEvent: dom.MouseEvent,
+  KeyboardEvent: dom.KeyboardEvent,
+  PointerEvent: dom.MouseEvent,
+  ResizeObserver: class { observe() {} unobserve() {} disconnect() {} },
+  IntersectionObserver: class { observe() {} unobserve() {} disconnect() {} takeRecords() { return []; } },
+  requestAnimationFrame: (cb: (t: number) => void) => setTimeout(() => cb(0), 0) as unknown as number,
+  cancelAnimationFrame: (id: number) => clearTimeout(id),
+  fetch: (async (input: string | URL | Request) => {
+    const url = String(input);
+    const body = url.startsWith("/api/conversations") ? { items: [], nextCursor: null } : {};
+    return { ok: true, status: 200, json: async () => body, text: async () => JSON.stringify(body) };
+  }) as unknown as typeof fetch,
+});
+(dom.HTMLElement.prototype as unknown as { scrollIntoView: () => void }).scrollIntoView = () => {};
+
+let browser: Browser;
+
+/* A long project name and a long conversation title — the two strings that used
+   to push the layout wide. Synthetic, no operator content. */
+const PROJECT = "live-log-viewer-next-mobile";
+const TITLE = "Builder · keep the conversation header inside a 390px viewport (#613)";
+
+const conversation: FileEntry = {
+  path: "/repo/worktrees/mobile-header/0f1e2d3c.jsonl",
+  root: "claude-projects",
+  name: "0f1e2d3c.jsonl",
+  project: PROJECT,
+  title: TITLE,
+  engine: "claude",
+  kind: "session",
+  fmt: "claude",
+  parent: null,
+  mtime: 9_000,
+  size: 4_096,
+  activity: "live",
+  proc: null,
+  pid: null,
+  model: "claude-opus-4-8",
+  effort: "high",
+  ctx: 62,
+  renamable: true,
+  conversationId: "conversation_613mobile",
+  pendingQuestion: null,
+  waitingInput: null,
+} as unknown as FileEntry;
+
+const task: BoardTask = {
+  id: "t-613", project: PROJECT, status: "inbox", text: "Keep the header inside 390px",
+  placement: "pinned", pos: { x: 720, y: 140 }, assignments: [],
+  createdAt: "2026-07-25T00:00:00.000Z", updatedAt: "2026-07-25T00:00:00.000Z",
+} as unknown as BoardTask;
+
+const ATTENTION_LABEL = translate("en", "attention.badge", { count: 3 });
+/* The production attention badge as Viewer renders it on the phone: a bounded
+   «⚠ N» pill whose button opens the queue. It is an action, so it must survive
+   a full header at 390px. */
+const attentionBadge = (
+  <div className="pointer-events-auto relative">
+    <div className="flex items-center overflow-hidden rounded-full border border-warning/45 bg-warning-soft shadow-1">
+      <button type="button" className="inline-flex min-h-11 items-center px-3.5 text-[12px] font-bold text-warning" aria-label={ATTENTION_LABEL}>
+        <span className="inline-flex items-center gap-1">
+          <span className="inline-block h-3 w-3" aria-hidden />3
+        </span>
+      </button>
+    </div>
+  </div>
+);
+
+const dashboardProps = () => ({
+  files: [conversation], flows: [], pipelines: [], workflows: [], tasks: [task],
+  project: PROJECT, loaded: true, openNonce: 0, archived: false,
+  /* Both view faces available → the scheme/list switch is offered. */
+  catalogKnown: true, catalogConversationCount: 1,
+  projectCwd: "/repo", onArchive: () => {}, onUnarchive: () => {},
+  onMenu: () => {},
+  attention: attentionBadge,
+});
+
+const { ProjectDashboard } = await import("@/components/ProjectDashboard");
+
+beforeEach(() => {
+  dom.sessionStorage.clear();
+  dom.localStorage.clear();
+  /* A closed card in the device-local log → the header offers undo (#184). */
+  dom.localStorage.setItem(
+    `llvBoardHistory:${PROJECT}`,
+    JSON.stringify({ entries: [{ kind: "close", path: "/repo/closed.jsonl", title: "Closed card" }], cursor: 1 }),
+  );
+  setLocale("en");
+});
+afterEach(() => {
+  document.body.replaceChildren();
+});
+afterAll(async () => {
+  await browser?.close();
+  mock.module("@/hooks/useRuntime", () => actualRuntimeHooks);
+  mock.module("@/hooks/useConversationCatalog", () => actualConversationCatalogHooks);
+});
+
+const settle = async () => {
+  await act(async () => { await new Promise((r) => setTimeout(r, 30)); });
+  await act(async () => { await new Promise((r) => setTimeout(r, 30)); });
+};
+
+const CSS = productionCss();
+
+function pageHtml(inner: string, width: number): string {
+  /* No clipping wrapper: the host is exactly the phone viewport, so any header
+     overflow reaches the document, which is what production measured. */
+  return `<!doctype html><html><head><meta charset="utf-8"><style>${CSS}
+    html,body{margin:0;padding:0;background:var(--color-canvas,#fff);}
+    #evidence-host{display:flex;flex-direction:column;width:${width}px;height:100vh;}
+    </style></head><body><div id="evidence-host">${inner}</div></body></html>`;
+}
+
+interface Box { label: string; left: number; right: number; width: number; height: number }
+interface Geometry {
+  scrollWidth: number;
+  bodyScrollWidth: number;
+  viewportWidth: number;
+  headerScrollWidth: number;
+  headerClientWidth: number;
+  controls: Box[];
+  titleText: string;
+  /* The focused conversation's own header (BranchPane) inside the same phone. */
+  paneControls: Box[];
+  paneHeaderScrollWidth: number;
+  paneHeaderClientWidth: number;
+  paneTitleText: string;
+}
+
+const VIEWPORT = { width: 390, height: 844 };
+
+async function measure(inner: string, key: string): Promise<Geometry> {
+  const page = await browser.newPage({ viewport: VIEWPORT, deviceScaleFactor: 1 });
+  await page.setContent(pageHtml(inner, VIEWPORT.width), { waitUntil: "load" });
+  fs.writeFileSync(path.join(EVIDENCE_DIR, `${key}.html`), pageHtml(inner, VIEWPORT.width));
+  await page.screenshot({ path: path.join(EVIDENCE_DIR, `${key}.png`) });
+  const geometry = await page.evaluate(() => {
+    const collect = (root: Element | null): Box[] => {
+      const boxes: Box[] = [];
+      for (const node of Array.from(root?.querySelectorAll("button, [role='menuitem'], [role='menuitemradio'], a") ?? [])) {
+        const el = node as HTMLElement;
+        const rect = el.getBoundingClientRect();
+        if (rect.width === 0 && rect.height === 0) continue;
+        boxes.push({
+          label: el.getAttribute("aria-label") ?? el.textContent?.trim().slice(0, 40) ?? "",
+          left: rect.left, right: rect.right, width: rect.width, height: rect.height,
+        });
+      }
+      return boxes;
+    };
+    const header = document.querySelector("[data-testid='mobile-project-header']") as HTMLElement | null;
+    const paneHeader = document.querySelector("[data-testid='mobile-focused-pane'] header") as HTMLElement | null;
+    const title = header?.querySelector("h1") as HTMLElement | null;
+    return {
+      scrollWidth: document.documentElement.scrollWidth,
+      bodyScrollWidth: document.body.scrollWidth,
+      viewportWidth: window.innerWidth,
+      headerScrollWidth: header?.scrollWidth ?? -1,
+      headerClientWidth: header?.clientWidth ?? -1,
+      controls: collect(header),
+      titleText: title?.textContent ?? "",
+      paneControls: collect(paneHeader),
+      paneHeaderScrollWidth: paneHeader?.scrollWidth ?? -1,
+      paneHeaderClientWidth: paneHeader?.clientWidth ?? -1,
+      paneTitleText: (paneHeader?.querySelector("[role='button']") as HTMLElement | null)?.textContent ?? "",
+    } as Geometry;
+  });
+  await page.close();
+  return geometry;
+}
+
+async function renderDashboard(openMoreMenu: boolean): Promise<string> {
+  const host = document.createElement("div");
+  document.body.append(host);
+  const root = createRoot(host);
+  await act(async () => { root.render(<ProjectDashboard {...dashboardProps()} />); });
+  await settle();
+  if (openMoreMenu) {
+    const trigger = host.querySelector(
+      `[data-testid="mobile-project-header"] button[aria-label="${translate("en", "dash.moreMenu")}"]`,
+    ) as unknown as HTMLButtonElement | null;
+    expect(trigger).not.toBeNull();
+    await act(async () => { trigger!.click(); });
+    await settle();
+  }
+  const html = host.innerHTML;
+  await act(async () => root.unmount());
+  host.remove();
+  return html;
+}
+
+test("issue 613: the populated phone header fits a 390px viewport with every control reachable", async () => {
+  expect(CSS.length).toBeGreaterThan(10_000);
+  fs.mkdirSync(EVIDENCE_DIR, { recursive: true });
+  browser = await chromium.launch({ executablePath: chromium.executablePath() });
+
+  const closed = await measure(await renderDashboard(false), "header-390");
+
+  /* The acceptance measurement from the issue: no page-level horizontal scroll. */
+  expect(closed.viewportWidth).toBe(390);
+  expect(closed.scrollWidth).toBeLessThanOrEqual(390);
+  expect(closed.bodyScrollWidth).toBeLessThanOrEqual(390);
+  /* And the header row itself is not internally clipped — it FITS, so nothing
+     hides behind an invisible edge. */
+  expect(closed.headerScrollWidth).toBeLessThanOrEqual(closed.headerClientWidth);
+
+  /* Every control the row still owns is inside the viewport at a 44px target. */
+  expect(closed.controls.length).toBeGreaterThanOrEqual(6);
+  for (const control of closed.controls) {
+    expect(control.left).toBeGreaterThanOrEqual(0);
+    expect(control.right).toBeLessThanOrEqual(390);
+    expect(control.height).toBeGreaterThanOrEqual(44);
+    expect(control.width).toBeGreaterThanOrEqual(44);
+  }
+  const labels = closed.controls.map((control) => control.label);
+  for (const key of ["dash.openProjects", "board.undo", "dash.hiddenShelf", "dash.createMenu", "dash.moreMenu"] as const) {
+    expect(labels.some((label) => label.startsWith(translate("en", key).slice(0, 12)))).toBe(true);
+  }
+  /* The attention-queue badge is an action, so a full row must not squeeze it
+     out of existence (it used to ride the elastic filler). */
+  expect(labels).toContain(ATTENTION_LABEL);
+
+  /* The long project name truncates instead of pushing the row wide. */
+  expect(closed.titleText.length).toBeGreaterThan(0);
+
+  /* The focused conversation's own header sits in the same 390px: its long
+     title truncates and every pane control (rename, details, favorite, delete,
+     close) stays on screen at a 44px target rather than behind the clip. */
+  expect(closed.paneControls.length).toBeGreaterThanOrEqual(5);
+  expect(closed.paneHeaderScrollWidth).toBeLessThanOrEqual(closed.paneHeaderClientWidth);
+  for (const control of closed.paneControls) {
+    expect(control.left).toBeGreaterThanOrEqual(0);
+    expect(control.right).toBeLessThanOrEqual(390);
+    expect(control.height).toBeGreaterThanOrEqual(44);
+  }
+  expect(closed.paneTitleText.length).toBeGreaterThan(0);
+
+  /* Nothing was dropped: the scheme/list switch moved into the «more» menu and
+     both faces are one tap away there, still inside the viewport. */
+  const opened = await measure(await renderDashboard(true), "header-390-more-open");
+  const openLabels = opened.controls.map((control) => control.label);
+  expect(openLabels).toContain(translate("en", "dash.viewSchemeMenu"));
+  expect(openLabels).toContain(translate("en", "dash.viewListMenu"));
+  expect(opened.scrollWidth).toBeLessThanOrEqual(390);
+  for (const control of opened.controls) {
+    expect(control.left).toBeGreaterThanOrEqual(0);
+    expect(control.right).toBeLessThanOrEqual(390);
+    expect(control.height).toBeGreaterThanOrEqual(44);
+  }
+
+  fs.writeFileSync(
+    path.join(EVIDENCE_DIR, "geometry.json"),
+    JSON.stringify({ "header-390": closed, "header-390-more-open": opened }, null, 2),
+  );
+});

--- a/src/components/mobile/mobileHeaderFit.dom.test.tsx
+++ b/src/components/mobile/mobileHeaderFit.dom.test.tsx
@@ -1,0 +1,259 @@
+import { afterAll, afterEach, beforeAll, beforeEach, expect, mock, test } from "bun:test";
+import { Window } from "happy-dom";
+import { createRoot, type Root } from "react-dom/client";
+import { flushSync } from "react-dom";
+
+import { emptyStore } from "@/components/runtime/runtimeModel";
+import { translate } from "@/lib/i18n";
+import type { FileEntry } from "@/lib/types";
+import type { BoardTask } from "@/lib/tasks/types";
+
+/*
+ * Issue #613 — the phone header must fit a 390px viewport. happy-dom does no
+ * layout, so this guards the *structural* contract the geometry depends on
+ * (issue613Evidence.browser.test.tsx measures the pixels in Chromium):
+ *
+ *   - the row carries only fixed 44px targets plus ONE elastic cell, the
+ *     project name, which truncates;
+ *   - the attention badge keeps its own width — it is an action, not filler;
+ *   - the 94px scheme/list segmented pair no longer rides the row: both faces
+ *     live in the «⋯» menu as radio options and still switch the board.
+ */
+
+const actualRuntimeHooks = await import("@/hooks/useRuntime");
+const actualConversationCatalogHooks = await import("@/hooks/useConversationCatalog");
+const inertRuntime = { enabled: false, connection: "offline" as const, resyncedAt: null, store: emptyStore() };
+mock.module("@/hooks/useRuntime", () => ({
+  ...actualRuntimeHooks,
+  useRuntimeBusState: () => ({ ...inertRuntime, lastEventAt: null }),
+  useRuntime: () => inertRuntime,
+  useRuntimeSession: () => null,
+  useRuntimeReceiptsForArtifact: () => [],
+  useRuntimeFlow: () => null,
+}));
+mock.module("@/hooks/useConversationCatalog", () => ({
+  useConversationCatalog: () => ({
+    items: [], nextCursor: null, total: 0, loading: false, error: false, loadMore: () => {}, retry: () => {},
+  }),
+}));
+
+const { ProjectDashboard } = await import("@/components/ProjectDashboard");
+
+const dom = new Window({ url: "http://localhost/", width: 390, height: 844 });
+const G = globalThis as Record<string, unknown>;
+(dom as unknown as { matchMedia: (query: string) => unknown }).matchMedia = (query: string) => ({
+  matches: /max-width|pointer: coarse/.test(String(query)),
+  media: String(query), onchange: null,
+  addEventListener() {}, removeEventListener() {}, addListener() {}, removeListener() {}, dispatchEvent() { return false; },
+});
+const OVERRIDES: Record<string, unknown> = {
+  window: dom,
+  document: dom.document,
+  navigator: dom.navigator,
+  Node: dom.Node,
+  HTMLElement: dom.HTMLElement,
+  HTMLButtonElement: dom.HTMLButtonElement,
+  Event: dom.Event,
+  KeyboardEvent: dom.KeyboardEvent,
+  MouseEvent: dom.MouseEvent,
+  PointerEvent: dom.MouseEvent,
+  sessionStorage: dom.sessionStorage,
+  localStorage: dom.localStorage,
+  requestAnimationFrame: (cb: (t: number) => void) => setTimeout(() => cb(0), 0) as unknown as number,
+  cancelAnimationFrame: (id: number) => clearTimeout(id),
+  ResizeObserver: class { observe() {} unobserve() {} disconnect() {} },
+  IntersectionObserver: class { observe() {} unobserve() {} disconnect() {} takeRecords() { return []; } },
+  /* A tiny in-memory board API: the view switch writes through /api/board, and
+     the store needs a real `{ board }` envelope back to fold the write in. */
+  fetch: (async (input: string | URL | Request, init?: RequestInit) => {
+    const url = String(input);
+    if (url.startsWith("/api/board")) {
+      if (init?.method === "PATCH") {
+        const body = JSON.parse(String(init.body)) as {
+          patch?: Record<string, unknown>;
+          mutations?: Array<{ kind: string; viewMode?: "scheme" | "list" | null }>;
+        };
+        for (const mutation of body.mutations ?? []) {
+          if (mutation.kind === "set-presentation" && mutation.viewMode !== undefined) boardPrefs.viewMode = mutation.viewMode;
+        }
+        if (body.patch) boardPrefs = { ...boardPrefs, ...body.patch };
+        boardRevision += 1;
+      }
+      return jsonResponse({ board: boardState() });
+    }
+    if (url.startsWith("/api/conversations")) return jsonResponse({ items: [], nextCursor: null });
+    return jsonResponse({});
+  }) as unknown as typeof fetch,
+};
+
+let boardRevision = 1;
+let boardPrefs: Record<string, unknown> = {};
+const emptyPrefs = () => ({
+  manual: [], hidden: [], expanded: [], favorites: [], foldedEngineChildIds: [],
+  expandedEngineTrayParentIds: [], viewMode: null, taskPanelOpen: false,
+});
+const boardState = () => ({
+  schemaVersion: 1, revision: boardRevision, updatedAt: new Date(0).toISOString(),
+  pathAliases: {}, explicitManual: [], prefs: { ...emptyPrefs(), ...boardPrefs },
+});
+const jsonResponse = (body: unknown) => ({
+  ok: true, status: 200, json: async () => body, text: async () => JSON.stringify(body),
+});
+const HAS: Record<string, boolean> = {};
+const SAVED: Record<string, unknown> = {};
+
+const settle = async () => { await new Promise((r) => setTimeout(r, 0)); await new Promise((r) => setTimeout(r, 0)); };
+const waitFor = async (pred: () => boolean, timeoutMs = 4000): Promise<boolean> => {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    if (pred()) return true;
+    await new Promise((r) => setTimeout(r, 15));
+  }
+  return pred();
+};
+
+beforeAll(() => {
+  for (const key of Object.keys(OVERRIDES)) { HAS[key] = key in G; SAVED[key] = G[key]; G[key] = OVERRIDES[key]; }
+  (dom.HTMLElement.prototype as unknown as { scrollIntoView: () => void }).scrollIntoView = () => {};
+});
+afterAll(async () => {
+  await settle();
+  for (const key of Object.keys(OVERRIDES)) { if (HAS[key]) G[key] = SAVED[key]; else delete G[key]; }
+  mock.module("@/hooks/useRuntime", () => actualRuntimeHooks);
+  mock.module("@/hooks/useConversationCatalog", () => actualConversationCatalogHooks);
+});
+
+const PROJECT = "live-log-viewer-next-mobile";
+
+const conversation = {
+  path: "/repo/worktrees/mobile-header/0f1e2d3c.jsonl",
+  root: "claude-projects", name: "0f1e2d3c.jsonl", project: PROJECT,
+  title: "Builder · keep the conversation header inside a 390px viewport (#613)",
+  engine: "claude", kind: "session", fmt: "claude", parent: null, mtime: 9_000, size: 4_096,
+  activity: "live", proc: null, pid: null, model: "claude-opus-4-8", effort: "high", ctx: 62,
+  renamable: true, conversationId: "conversation_613mobile", pendingQuestion: null, waitingInput: null,
+} as unknown as FileEntry;
+
+const task = {
+  id: "t-613", project: PROJECT, status: "inbox", text: "Keep the header inside 390px",
+  placement: "pinned", pos: { x: 720, y: 140 }, assignments: [],
+  createdAt: "2026-07-25T00:00:00.000Z", updatedAt: "2026-07-25T00:00:00.000Z",
+} as unknown as BoardTask;
+
+const ATTENTION_LABEL = translate("en", "attention.badge", { count: 3 });
+
+const dashboardProps = () => ({
+  files: [conversation], flows: [], pipelines: [], workflows: [], tasks: [task],
+  project: PROJECT, loaded: true, openNonce: 0, archived: false,
+  catalogKnown: true, catalogConversationCount: 1,
+  projectCwd: "/repo", onArchive: () => {}, onUnarchive: () => {},
+  onMenu: () => {},
+  attention: (
+    <button type="button" className="inline-flex min-h-11 items-center px-3.5" aria-label={ATTENTION_LABEL}>3</button>
+  ),
+});
+
+let roots: Root[] = [];
+beforeEach(() => {
+  roots = [];
+  boardRevision = 1;
+  boardPrefs = {};
+  dom.document.body.replaceChildren();
+  dom.sessionStorage.clear();
+  dom.localStorage.clear();
+  /* A closed card in the device-local log → the header offers undo (#184). */
+  dom.localStorage.setItem(
+    `llvBoardHistory:${PROJECT}`,
+    JSON.stringify({ entries: [{ kind: "close", path: "/repo/closed.jsonl", title: "Closed card" }], cursor: 1 }),
+  );
+});
+afterEach(async () => { for (const root of roots) flushSync(() => root.unmount()); roots = []; await settle(); });
+
+function mount(): HTMLElement {
+  const host = dom.document.createElement("div");
+  dom.document.body.appendChild(host);
+  const root = createRoot(host as unknown as Element);
+  flushSync(() => root.render(<ProjectDashboard {...dashboardProps()} />));
+  roots.push(root);
+  return host as unknown as HTMLElement;
+}
+
+const header = (host: HTMLElement) => host.querySelector('[data-testid="mobile-project-header"]') as unknown as HTMLElement;
+const label = (el: Element) => el.getAttribute("aria-label") ?? el.textContent?.trim() ?? "";
+
+const shelfReady = (host: HTMLElement) => host.querySelector('[data-testid="mobile-shelf-trigger"]') !== null;
+
+test("the 390px header row keeps one elastic cell — the project name — and fixed 44px targets (#613)", async () => {
+  const host = mount();
+  /* Wait for the fully populated row — the shelf trigger is the last control to
+     appear, once the board arrangement settles. */
+  expect(await waitFor(() => shelfReady(host))).toBe(true);
+  const row = header(host);
+  expect(row).not.toBeNull();
+
+  /* The project name is the cell that gives way: capped, truncating, and NOT
+     shrink-0 — as shrink-0 it held 45vw and pushed the row past the viewport. */
+  const title = row.querySelector("h1") as unknown as HTMLElement;
+  expect(title.className).toContain("min-w-0");
+  expect(title.className).toContain("max-w-[45vw]");
+  expect(title.className).toContain("truncate");
+  expect(title.className).not.toContain("shrink-0");
+
+  /* The attention badge holds its own width beside the name. */
+  const attention = row.querySelector(`[aria-label="${ATTENTION_LABEL}"]`) as unknown as HTMLElement;
+  expect(attention).not.toBeNull();
+  expect((attention.parentElement as unknown as HTMLElement).className).toContain("shrink-0");
+
+  /* Every direct control of the row is a fixed 44px (h-11) target. */
+  const triggers = Array.from(row.querySelectorAll("button")).filter((el) => label(el) !== ATTENTION_LABEL);
+  expect(triggers.length).toBeGreaterThanOrEqual(4);
+  for (const trigger of triggers) {
+    expect(`${trigger.className} `).toMatch(/(^|\s)(h-11|min-h-11)(\s|$)/);
+    expect(`${trigger.className} `).toMatch(/(^|\s)(w-11|min-w-11|w-full)(\s|$)/);
+  }
+
+  /* The controls the operator relies on are all still in the row. */
+  const labels = triggers.map(label);
+  for (const key of ["dash.openProjects", "dash.hiddenShelf", "dash.createMenu", "dash.moreMenu"] as const) {
+    expect(labels.some((entry) => entry.startsWith(translate("en", key)))).toBe(true);
+  }
+  expect(labels.some((entry) => entry.startsWith(translate("en", "board.undo")))).toBe(true);
+
+  /* And the 94px segmented scheme/list pair is gone from the row. */
+  expect(labels).not.toContain(translate("en", "dash.viewScheme"));
+  expect(labels).not.toContain(translate("en", "dash.viewList"));
+});
+
+test("both board faces stay one tap away inside the «more» menu and still switch the board (#613)", async () => {
+  const host = mount();
+  expect(await waitFor(() => shelfReady(host))).toBe(true);
+  const row = header(host);
+
+  const more = Array.from(row.querySelectorAll("button")).find(
+    (el) => label(el) === translate("en", "dash.moreMenu"),
+  ) as unknown as HTMLButtonElement;
+  expect(more).not.toBeNull();
+  flushSync(() => more.click());
+  await settle();
+
+  const options = Array.from(row.querySelectorAll('[role="menuitemradio"]'));
+  expect(options.map(label)).toEqual([translate("en", "dash.viewSchemeMenu"), translate("en", "dash.viewListMenu")]);
+  /* The face currently shown is announced, not merely tinted. */
+  expect(options[0]!.getAttribute("aria-checked")).toBe("true");
+  expect(options[1]!.getAttribute("aria-checked")).toBe("false");
+
+  /* The focused chat is the scheme face; picking the list swaps the board. */
+  expect(host.querySelector('[data-testid="mobile-chat-shell"]')).not.toBeNull();
+  flushSync(() => (options[1] as unknown as HTMLButtonElement).click());
+  await settle();
+  expect(await waitFor(() => host.querySelector('[data-testid="mobile-chat-shell"]') === null)).toBe(true);
+
+  /* Reopening the menu shows the list face checked — the switch is reversible. */
+  const moreAgain = Array.from(header(host).querySelectorAll("button")).find(
+    (el) => label(el) === translate("en", "dash.moreMenu"),
+  ) as unknown as HTMLButtonElement;
+  flushSync(() => moreAgain.click());
+  await settle();
+  const reopened = Array.from(header(host).querySelectorAll('[role="menuitemradio"]'));
+  expect(reopened[1]!.getAttribute("aria-checked")).toBe("true");
+});

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -88,6 +88,9 @@ export const en = {
   "dash.emptyHint": "Open the switchboard in the bottom-right corner and click a conversation — it will appear here",
   "dash.viewScheme": "scheme",
   "dash.viewList": "conversations",
+  "dash.viewSchemeMenu": "View: scheme",
+  "dash.viewListMenu": "View: conversations",
+  "dash.viewMenuGroup": "Board view",
   "dash.hiddenShelf": "Hidden",
 
   // ProjectTrash

--- a/src/lib/i18n/uk.ts
+++ b/src/lib/i18n/uk.ts
@@ -82,6 +82,9 @@ export const uk: Record<keyof typeof en, Message> = {
   "dash.emptyHint": "Відкрий пульт у правому нижньому куті і клікни розмову — вона з'явиться тут",
   "dash.viewScheme": "схема",
   "dash.viewList": "розмови",
+  "dash.viewSchemeMenu": "Вигляд: схема",
+  "dash.viewListMenu": "Вигляд: розмови",
+  "dash.viewMenuGroup": "Вигляд дошки",
   "dash.hiddenShelf": "Приховане",
 
   "trash.title": "Кореневі розмови",


### PR DESCRIPTION
## What was wrong

The conversation header overflowed a 390px viewport: the row pushed the document into horizontal scroll and controls fell off the edge.

**`07f6269c`** fits the header at 390px. The scheme/list toggle folds into the `⋯` menu instead of riding the header row, the project name becomes the single elastic cell, and every touch target keeps its 44×44 minimum. Measured on the shipped CSS: `documentElement.scrollWidth` 390 at a 390px viewport, all controls within the right edge.

**`fd202bb1`** closes what the review asked for: the comments now describe the shipped structure rather than the one they replaced — no comment claims the toggle sits in the header row or that the attention filler truncates — and the header comment records 390px as the narrowest viewport this layout supports, so the collapse below it is a documented limit rather than an unstated one.

## Review

Two independent read-only rounds, both **APPROVE**. The first raised two comment-level items, both closed by `fd202bb1`. The second measured the header across widths and confirmed the trade is now documented: 390px fits with headroom, and narrower viewports degrade in a way the code states explicitly.

## Verification

Touched tests pass by path, `tsc --noEmit` clean, `lint` adds no new problems, privacy gate green. No account handle, path, or identifier in the diff or its evidence.

Closes #613