### PR TITLE
fix(pipelines): make the pipeline board readable — role-first titles, collapsed settled stages, execution order (#658)

### DIFF
--- a/src/components/BranchPane.stageTitle.render.test.tsx
+++ b/src/components/BranchPane.stageTitle.render.test.tsx
@@ -33,13 +33,23 @@ test("a titleOverride names the pane and keeps the transcript's own title in the
   expect(html).toMatch(/title="Builder · integrate_v3_voice · stage 2\/3 — Work alone and launch no helpers/);
 });
 
-test("a renamable stage pane still shows the imposed title, not the prompt's first line", () => {
+test("a renamable stage pane shows the imposed title and drops the inline rename pencil, by design", () => {
   /* A renamable conversation would otherwise render the editable SessionTitle
-     seeded from the prompt-derived title — the very string #658 is about. */
-  const html = renderToStaticMarkup(
+     seeded from the prompt-derived title — the very string #658 is about. The
+     imposed identity replaces that editor, so the card carries no rename pencil;
+     renaming stays reachable through F2 → the full-window overlay, which drops
+     the override while a rename token is pending (SchemeBoard `stageTitle`,
+     `titleUnderRename`). Losing the pencil here is a decision, not a slip. */
+  const stagePane = renderToStaticMarkup(
     <BranchPane file={file({ renamable: true } as Partial<FileEntry>)} tasks={[]} isRoot titleOverride="Architect · plan_v3_voice · stage 1/3" />,
   );
-  expect(html).toContain("Architect · plan_v3_voice · stage 1/3");
+  expect(stagePane).toContain("Architect · plan_v3_voice · stage 1/3");
+  expect(stagePane).not.toContain("Rename ");
+
+  /* The same conversation without an override keeps its editor: the pencil is
+     lost only where an owner imposes an identity. */
+  const plainPane = renderToStaticMarkup(<BranchPane file={file({ renamable: true } as Partial<FileEntry>)} tasks={[]} isRoot />);
+  expect(plainPane).toContain("Rename ");
 });
 
 test("without an override the pane keeps the transcript-derived title (every other surface)", () => {

--- a/src/components/BranchPane.stageTitle.render.test.tsx
+++ b/src/components/BranchPane.stageTitle.render.test.tsx
@@ -1,0 +1,49 @@
+import { expect, test } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import type { FileEntry } from "@/lib/types";
+
+import { BranchPane } from "./BranchPane";
+
+/*
+ * A pipeline stage's live pane is titled by its place in the chain (#658). The
+ * scanner titles a conversation by the first line of its opening prompt, and
+ * every stage prompt opens with the same shared safety preamble — so every stage
+ * pane on the board carried the identical meaningless title. The owner imposes
+ * the identity instead; the transcript's own title stays in the tooltip.
+ */
+
+function file(over: Partial<FileEntry> = {}): FileEntry {
+  return {
+    path: "/stage.jsonl", root: "claude-projects", name: "stage.jsonl", project: "viewer",
+    title: "Work alone and launch no helpers, workflows, teams or subagents.",
+    engine: "claude", kind: "session", fmt: "claude", parent: null, mtime: 1, size: 1, activity: "live",
+    proc: "running", pid: 5, model: "sonnet", effort: "high", fast: false, pendingQuestion: null, waitingInput: null,
+    ...over,
+  } as FileEntry;
+}
+
+test("a titleOverride names the pane and keeps the transcript's own title in the tooltip", () => {
+  const html = renderToStaticMarkup(
+    <BranchPane file={file()} tasks={[]} isRoot titleOverride="Builder · integrate_v3_voice · stage 2/3" />,
+  );
+  expect(html).toContain("Builder · integrate_v3_voice · stage 2/3");
+  expect(html).toContain("data-pane-title-override");
+  /* Reachable, not lost: the prompt-derived title rides the header tooltip. */
+  expect(html).toMatch(/title="Builder · integrate_v3_voice · stage 2\/3 — Work alone and launch no helpers/);
+});
+
+test("a renamable stage pane still shows the imposed title, not the prompt's first line", () => {
+  /* A renamable conversation would otherwise render the editable SessionTitle
+     seeded from the prompt-derived title — the very string #658 is about. */
+  const html = renderToStaticMarkup(
+    <BranchPane file={file({ renamable: true } as Partial<FileEntry>)} tasks={[]} isRoot titleOverride="Architect · plan_v3_voice · stage 1/3" />,
+  );
+  expect(html).toContain("Architect · plan_v3_voice · stage 1/3");
+});
+
+test("without an override the pane keeps the transcript-derived title (every other surface)", () => {
+  const html = renderToStaticMarkup(<BranchPane file={file({ title: "Plain conversation" })} tasks={[]} isRoot />);
+  expect(html).toContain("Plain conversation");
+  expect(html).not.toContain("data-pane-title-override");
+});

--- a/src/components/BranchPane.tsx
+++ b/src/components/BranchPane.tsx
@@ -135,9 +135,17 @@ interface Props {
   /** Opens/centers a related task card — the conversation-side half of the
       bidirectional task↔agent navigation. The strip renders only when wired. */
   onOpenTask?: (task: BoardTask) => void;
+  /** Title imposed by whatever owns this pane's identity, replacing the
+      transcript-derived one (#658). A pipeline stage pane passes «role · stage ·
+      position»: the scanner titles a conversation by the first line of its
+      opening prompt, and every stage prompt opens with the same shared preamble,
+      so every stage pane on the board carried the identical meaningless title.
+      The transcript's own title stays reachable as the header tooltip, and the
+      prompt itself is the transcript's first message. */
+  titleOverride?: string;
 }
 
-export function BranchPane({ file, tasks, isRoot, onClose, dragHandle, noComposer, banner, headerActions, onToggleExpand, expanded, dormant, autoEditToken, showFavorite, onSpawnRetry, relatedTasks, onOpenTask }: Props) {
+export function BranchPane({ file, tasks, isRoot, onClose, dragHandle, noComposer, banner, headerActions, onToggleExpand, expanded, dormant, autoEditToken, showFavorite, onSpawnRetry, relatedTasks, onOpenTask, titleOverride }: Props) {
   const { t } = useLocale();
   const isMobile = useIsMobile();
   const paneRef = useRef<HTMLElement | null>(null);
@@ -271,7 +279,18 @@ export function BranchPane({ file, tasks, isRoot, onClose, dragHandle, noCompose
         >
           <div className="flex min-w-0 items-center gap-1.5">
             <span className={`h-2 w-2 shrink-0 rounded-full ${activityDot(file.activity)}`} title={t(`branch.${state}`)} />
-            {file.renamable ? (
+            {titleOverride ? (
+              /* The owner names this pane (#658). The transcript's own title —
+                 the first line of the prompt it opened with — stays in the
+                 tooltip, so nothing is lost by leading with the identity. */
+              <span
+                className="min-w-0 flex-1 truncate text-[12px] font-semibold"
+                data-pane-title-override
+                title={`${titleOverride} — ${cleanTitle(file.title)}`}
+              >
+                {titleOverride}
+              </span>
+            ) : file.renamable ? (
               <SessionTitle file={file} displayMax={90} titleClassName="text-[12px] font-semibold" alwaysVisible={isMobile} autoEditToken={autoEditToken} />
             ) : (
               <span className="min-w-0 flex-1 truncate text-[12px] font-semibold" title={cleanTitle(file.title)}>

--- a/src/components/BranchPane.tsx
+++ b/src/components/BranchPane.tsx
@@ -141,7 +141,17 @@ interface Props {
       opening prompt, and every stage prompt opens with the same shared preamble,
       so every stage pane on the board carried the identical meaningless title.
       The transcript's own title stays reachable as the header tooltip, and the
-      prompt itself is the transcript's first message. */
+      prompt itself is the transcript's first message.
+
+      RENAME, deliberately: an imposed title replaces the inline `SessionTitle`
+      editor, so a stage card carries no hover pencil — renaming a transcript
+      whose own title is the preamble is not what that affordance is for, and a
+      rename would not change what the card shows anyway. The rename path stays
+      open where it is meaningful: F2 on the selected node expands it, and the
+      board's overlay drops the override while that rename token is pending
+      (SchemeBoard `stageTitle`), mounting the real editor. Any surface that
+      passes an override on a renamable conversation owes the operator the same
+      escape hatch. */
   titleOverride?: string;
 }
 

--- a/src/components/pipelines/StageCompletedCard.tsx
+++ b/src/components/pipelines/StageCompletedCard.tsx
@@ -13,7 +13,6 @@ import {
   STAGE_TONES,
   VERDICT_TONES,
   attemptStateLabel,
-  stageChipLabel,
   stageChipState,
   stagePaneTitle,
   verdictStatusLabel,
@@ -35,8 +34,9 @@ export function StageCompletedCard({ slot, onOpen }: { slot: StageSlot; onOpen?:
   const { pipeline, stage, attempt } = slot;
   const state = stageChipState(pipeline, stage);
   const tone = STAGE_TONES[state];
-  const label = stageChipLabel(t, stage);
-  /* Role · stage · position, never the prompt's shared preamble (#658). */
+  /* Role · stage · position, never the prompt's shared preamble (#658) — the
+     visible title and the card's accessible name are the same string, so two
+     stages sharing a role are still told apart by assistive tech. */
   const title = stagePaneTitle(t, stage, slot.index, slot.total);
   const review = stage.kind === "review-loop";
   const tint = engineTintOf(stage.effectiveRole.engine);
@@ -53,7 +53,7 @@ export function StageCompletedCard({ slot, onOpen }: { slot: StageSlot; onOpen?:
       data-pipeline-stage-card={`${pipeline.id}::${stage.id}`}
       data-pipeline-stage-state={state}
       data-pipeline-stage-completed="true"
-      aria-label={t("pipelineSlot.completedAria", { role: label })}
+      aria-label={t("pipelineSlot.completedAria", { title })}
       className="relative flex h-full min-h-0 min-w-0 flex-1 flex-col overflow-hidden rounded-control border-2 bg-card shadow-1"
       style={{ borderColor: tone.color }}
     >

--- a/src/components/pipelines/StageCompletedCard.tsx
+++ b/src/components/pipelines/StageCompletedCard.tsx
@@ -15,6 +15,7 @@ import {
   attemptStateLabel,
   stageChipLabel,
   stageChipState,
+  stagePaneTitle,
   verdictStatusLabel,
 } from "./pipelineModel";
 
@@ -35,6 +36,8 @@ export function StageCompletedCard({ slot, onOpen }: { slot: StageSlot; onOpen?:
   const state = stageChipState(pipeline, stage);
   const tone = STAGE_TONES[state];
   const label = stageChipLabel(t, stage);
+  /* Role · stage · position, never the prompt's shared preamble (#658). */
+  const title = stagePaneTitle(t, stage, slot.index, slot.total);
   const review = stage.kind === "review-loop";
   const tint = engineTintOf(stage.effectiveRole.engine);
   const model = stage.effectiveRole.model ?? "";
@@ -60,8 +63,8 @@ export function StageCompletedCard({ slot, onOpen }: { slot: StageSlot; onOpen?:
         <span className="shrink-0 rounded-full border border-border bg-card/70 px-1.5 py-0.5 text-caption font-bold capitalize text-muted">
           {stage.effectiveRole.engine}
         </span>
-        <span className="min-w-0 flex-1 truncate text-ui font-semibold text-muted" title={label}>
-          {label} · {t("pipelineSlot.stageOf", { k: slot.index + 1, n: slot.total })}
+        <span className="min-w-0 flex-1 truncate text-ui font-semibold text-muted" title={title}>
+          {title}
         </span>
         <span className="shrink-0 rounded-full border border-border bg-card/70 px-1.5 py-0.5 text-caption font-bold uppercase tracking-wide text-muted">
           {review ? `⟳ ${t("groupOverride.reviewKind")}` : t("groupOverride.runKind")}

--- a/src/components/pipelines/StagePlaceholderPane.tsx
+++ b/src/components/pipelines/StagePlaceholderPane.tsx
@@ -251,7 +251,7 @@ export function StagePlaceholderPane({ slot, interactive }: { slot: StageSlot; i
       data-pan-ignore
       data-pipeline-stage-card={`${pipeline.id}::${stage.id}`}
       data-pipeline-stage-state={state}
-      aria-label={t("pipelineSlot.paneAria", { role: label })}
+      aria-label={t("pipelineSlot.paneAria", { title })}
       className="relative flex h-full min-h-0 min-w-0 flex-1 flex-col overflow-hidden rounded-control border-2 border-dashed bg-card shadow-1"
       style={{ borderColor: active ? tone.color : "var(--border-strong)" }}
     >

--- a/src/components/pipelines/StagePlaceholderPane.tsx
+++ b/src/components/pipelines/StagePlaceholderPane.tsx
@@ -27,6 +27,7 @@ import {
   stageAttempts,
   stageChipLabel,
   stageChipState,
+  stagePaneTitle,
   stagePromptExtra,
   stageReceivesPrevOutput,
 } from "./pipelineModel";
@@ -67,6 +68,9 @@ export function StagePlaceholderPane({ slot, interactive }: { slot: StageSlot; i
   const state = stageChipState(pipeline, stage);
   const tone = STAGE_TONES[state];
   const label = stageChipLabel(t, stage);
+  /* Role first, then the stage id, then the position (#658) — never the prompt's
+     first line, which is the same shared preamble on every stage. */
+  const title = stagePaneTitle(t, stage, slot.index, slot.total);
   const review = stage.kind === "review-loop";
   const draft = pipeline.state === "draft";
   /* Only a stage that has never run can be re-configured — the engine snapshots
@@ -265,8 +269,8 @@ export function StagePlaceholderPane({ slot, interactive }: { slot: StageSlot; i
             {engine}
           </span>
         )}
-        <span className="min-w-0 flex-1 truncate text-ui font-semibold text-muted" title={label}>
-          {label} · {t("pipelineSlot.stageOf", { k: slot.index + 1, n: slot.total })}
+        <span className="min-w-0 flex-1 truncate text-ui font-semibold text-muted" title={title}>
+          {title}
         </span>
         <span className="shrink-0 rounded-full border border-border bg-card/70 px-1.5 py-0.5 text-caption font-bold uppercase tracking-wide text-muted">
           {review ? `⟳ ${t("groupOverride.reviewKind")}` : t("groupOverride.runKind")}

--- a/src/components/pipelines/StageStatusRow.tsx
+++ b/src/components/pipelines/StageStatusRow.tsx
@@ -21,10 +21,13 @@ import { STAGE_GLYPH, STAGE_TONES, latestAttempt, stageChipState, stageOutcomeRe
 export function StageStatusRow({
   slot,
   expanded,
+  controls,
   onToggle,
 }: {
   slot: StageSlot;
   expanded: boolean;
+  /** DOM id of the card this row discloses, tying the toggle to what it opens. */
+  controls?: string;
   onToggle?: () => void;
 }) {
   const { t } = useLocale();
@@ -67,6 +70,7 @@ export function StageStatusRow({
             data-scheme-ui
             data-stage-row-toggle
             aria-expanded={expanded}
+            aria-controls={controls}
             aria-label={expanded ? t("pipelineSlot.rowCollapse") : t("pipelineSlot.rowExpand")}
             title={expanded ? t("pipelineSlot.rowCollapse") : t("pipelineSlot.rowExpand")}
             className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-control border border-border bg-canvas text-muted hover:border-accent/45 hover:text-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40"

--- a/src/components/pipelines/StageStatusRow.tsx
+++ b/src/components/pipelines/StageStatusRow.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import { ChevronRight } from "lucide-react";
+
+import type { StageSlot } from "@/components/scheme/layout";
+import { useLocale } from "@/lib/i18n";
+
+import { STAGE_GLYPH, STAGE_TONES, latestAttempt, stageChipState, stageOutcomeReason, stagePaneTitle } from "./pipelineModel";
+
+/**
+ * A settled pipeline stage as ONE status row (#658). A stage the chain has
+ * already left behind — skipped by the operator, or completed evidence — used to
+ * render with the full weight of a pending or active stage, stage-prompt block
+ * included, so a board with two finished stages read as if all that work were
+ * still ahead. The row states the three things that remain interesting about
+ * finished work: the state badge, which stage it was (role · stage · position,
+ * never the prompt's first line), and why it ended that way. The full card stays
+ * one click away — the disclosure is owned by the slot shell, which floats the
+ * real card over the board while it is open.
+ */
+export function StageStatusRow({
+  slot,
+  expanded,
+  onToggle,
+}: {
+  slot: StageSlot;
+  expanded: boolean;
+  onToggle?: () => void;
+}) {
+  const { t } = useLocale();
+  const { pipeline, stage, attempt } = slot;
+  const state = stageChipState(pipeline, stage);
+  const tone = STAGE_TONES[state];
+  const title = stagePaneTitle(t, stage, slot.index, slot.total);
+  /* A completed slot carries the exact attempt whose transcript it stands in for;
+     a skipped stage that never reached the board has no slot attempt, so its
+     latest one supplies the outcome. */
+  const reason = stageOutcomeReason(t, pipeline, stage, attempt ?? latestAttempt(pipeline, stage.id));
+
+  return (
+    <section
+      data-pan-ignore
+      /* Exactly one element per declared stage carries the stage-card identity:
+         the row owns it while collapsed and hands it to the disclosed full card
+         when open, so a stage never projects two surfaces at once. */
+      data-pipeline-stage-card={expanded ? undefined : `${pipeline.id}::${stage.id}`}
+      data-pipeline-stage-state={state}
+      data-pipeline-stage-row="true"
+      aria-label={t("pipelineSlot.rowAria", { title })}
+      className="flex h-full min-h-0 min-w-0 flex-col justify-center gap-1 overflow-hidden rounded-control border bg-card px-3 py-2 shadow-1"
+      style={{ borderColor: "var(--border-strong)" }}
+    >
+      <div className="flex min-w-0 items-center gap-2">
+        <span
+          className="inline-flex shrink-0 items-center gap-1 rounded-full px-2 py-0.5 text-label font-bold"
+          style={{ backgroundColor: tone.soft, color: tone.color }}
+        >
+          <span aria-hidden>{STAGE_GLYPH[state]}</span>
+          {t(`pipelineChipState.${state}`)}
+        </span>
+        <span className="min-w-0 flex-1 truncate text-ui font-semibold text-secondary" title={title}>
+          {title}
+        </span>
+        {onToggle ? (
+          <button
+            type="button"
+            data-scheme-ui
+            data-stage-row-toggle
+            aria-expanded={expanded}
+            aria-label={expanded ? t("pipelineSlot.rowCollapse") : t("pipelineSlot.rowExpand")}
+            title={expanded ? t("pipelineSlot.rowCollapse") : t("pipelineSlot.rowExpand")}
+            className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-control border border-border bg-canvas text-muted hover:border-accent/45 hover:text-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40"
+            onClick={onToggle}
+          >
+            <ChevronRight className={`h-3.5 w-3.5 transition-transform ${expanded ? "rotate-90" : ""}`} aria-hidden />
+          </button>
+        ) : null}
+      </div>
+      <p className="min-w-0 truncate text-label text-muted" title={reason}>
+        {reason}
+      </p>
+    </section>
+  );
+}

--- a/src/components/pipelines/pipelineModel.test.ts
+++ b/src/components/pipelines/pipelineModel.test.ts
@@ -1616,11 +1616,26 @@ describe("stage surface titles and settled rows (#658)", () => {
     });
     expect(stageOutcomeReason(fakeT, withFinding, buildStage)).toBe("pipelineVerdict.fail — the relay drops the persona");
 
+    /* A skip is narrated by the engine in a hardcoded English sentence stamped
+       into `output`; the row reads the catalogue instead, so a localized badge
+       and title never sit beside an English line. */
     const skipped = pipeline({
       stages,
       runs: [{ stageId: "integrate_v3_voice", attempts: [{ n: 1, state: "skipped", output: "Skipped by operator." } as never] }],
     });
-    expect(stageOutcomeReason(fakeT, skipped, buildStage)).toBe("Skipped by operator.");
+    expect(stageOutcomeReason(fakeT, skipped, buildStage)).toBe("pipelineSlot.reasonSkipped");
+    /* A skip that recorded a real error still leads with the error. */
+    const skippedWithError = pipeline({
+      stages,
+      runs: [{ stageId: "integrate_v3_voice", attempts: [{ n: 1, state: "skipped", output: "Skipped by operator.", error: "worktree reset failed" } as never] }],
+    });
+    expect(stageOutcomeReason(fakeT, skippedWithError, buildStage)).toBe("worktree reset failed");
+    /* Free-form agent output on a settled non-skip stage stays verbatim. */
+    const finished = pipeline({
+      stages,
+      runs: [{ stageId: "integrate_v3_voice", attempts: [{ n: 1, state: "passed", output: "Relay wired, 14 tests green." } as never] }],
+    });
+    expect(stageOutcomeReason(fakeT, finished, buildStage)).toBe("Relay wired, 14 tests green.");
 
     const bare = pipeline({ stages, runs: [{ stageId: "integrate_v3_voice", attempts: [{ n: 1, state: "passed" } as never] }] });
     expect(stageOutcomeReason(fakeT, bare, buildStage)).toBe("pipelineChipState.passed");

--- a/src/components/pipelines/pipelineModel.test.ts
+++ b/src/components/pipelines/pipelineModel.test.ts
@@ -56,6 +56,9 @@ import {
   optimisticReorderStage,
   stagePromptExtra,
   stageReceivesPrevOutput,
+  stagePaneTitle,
+  stageRowCollapsible,
+  stageOutcomeReason,
 } from "./pipelineModel";
 import { foldClaimedReviewers } from "../flows/flowModel";
 import type { Flow } from "@/lib/flows/types";
@@ -1549,5 +1552,79 @@ describe("stage-graph attempt navigation (path-only + current generation — PR 
   test("resolveStageNavFile stays a no-op when the id is only an archived predecessor and no path is recorded", () => {
     const files = [fileAt("/old.jsonl", { conversationId: "c1", migratedTo: "/new.jsonl" })];
     expect(resolveStageNavFile({ conversationId: "c1", agentPath: null }, files)).toBeNull();
+  });
+});
+
+describe("stage surface titles and settled rows (#658)", () => {
+  const buildStage = stage("integrate_v3_voice", "run", "builder");
+  const rawStage = stage("stage-2");
+
+  test("stagePaneTitle leads with the role, then the stage id, then the position — never the prompt", () => {
+    /* Every stage prompt opens with the same shared preamble, so a
+       prompt-derived title named every pane identically. The title answers
+       which role, which stage, how far along. */
+    expect(stagePaneTitle(fakeT, buildStage, 1, 3)).toBe(
+      'roleCopy.builder.name · integrate_v3_voice · pipelineSlot.stageOf:{"k":2,"n":3}',
+    );
+  });
+
+  test("stagePaneTitle emits a role-less stage's id once, never twice", () => {
+    expect(stagePaneTitle(fakeT, rawStage, 0, 2)).toBe('stage-2 · pipelineSlot.stageOf:{"k":1,"n":2}');
+  });
+
+  test("stageRowCollapsible collapses skipped and completed work, never pending, active, or a parked decision", () => {
+    const stages = [buildStage, stage("verify")];
+    const skipped = pipeline({
+      stages,
+      runs: [{ stageId: "integrate_v3_voice", attempts: [{ n: 1, state: "skipped" } as never] }],
+      cursor: { stageId: "verify", state: "running", input: null, activatedBy: null },
+    });
+    expect(stageRowCollapsible(skipped, buildStage, "placeholder")).toBe(true);
+    expect(stageRowCollapsible(skipped, buildStage, "completed")).toBe(true);
+    /* The active cursor stage keeps its full card. */
+    expect(stageRowCollapsible(skipped, stages[1]!, "placeholder")).toBe(false);
+
+    const passed = pipeline({ stages, runs: [{ stageId: "integrate_v3_voice", attempts: [{ n: 1, state: "passed" } as never] }] });
+    expect(stageRowCollapsible(passed, buildStage, "completed")).toBe(true);
+    const failed = pipeline({ stages, runs: [{ stageId: "integrate_v3_voice", attempts: [{ n: 1, state: "failed" } as never] }] });
+    expect(stageRowCollapsible(failed, buildStage, "completed")).toBe(true);
+    /* A parked decision is the one settled state the operator must act on. */
+    const parked = pipeline({
+      stages,
+      state: "needs_decision",
+      runs: [{ stageId: "integrate_v3_voice", attempts: [{ n: 1, state: "needs_decision" } as never] }],
+    });
+    expect(stageRowCollapsible(parked, buildStage, "completed")).toBe(false);
+    /* A never-launched future stage is ahead, not behind — full card. */
+    expect(stageRowCollapsible(pipeline({ stages }), buildStage, "placeholder")).toBe(false);
+  });
+
+  test("stageOutcomeReason states why a settled stage ended: error, then verdict finding, then output", () => {
+    const stages = [buildStage];
+    const withError = pipeline({
+      stages,
+      runs: [{ stageId: "integrate_v3_voice", attempts: [{ n: 1, state: "failed", error: "worktree is dirty\nsecond line" } as never] }],
+    });
+    expect(stageOutcomeReason(fakeT, withError, buildStage)).toBe("worktree is dirty");
+
+    const withFinding = pipeline({
+      stages,
+      runs: [{
+        stageId: "integrate_v3_voice",
+        attempts: [{ n: 1, state: "failed", verdict: { status: "fail", findings: ["the relay drops the persona"] } } as never],
+      }],
+    });
+    expect(stageOutcomeReason(fakeT, withFinding, buildStage)).toBe("pipelineVerdict.fail — the relay drops the persona");
+
+    const skipped = pipeline({
+      stages,
+      runs: [{ stageId: "integrate_v3_voice", attempts: [{ n: 1, state: "skipped", output: "Skipped by operator." } as never] }],
+    });
+    expect(stageOutcomeReason(fakeT, skipped, buildStage)).toBe("Skipped by operator.");
+
+    const bare = pipeline({ stages, runs: [{ stageId: "integrate_v3_voice", attempts: [{ n: 1, state: "passed" } as never] }] });
+    expect(stageOutcomeReason(fakeT, bare, buildStage)).toBe("pipelineChipState.passed");
+    /* Attemptless: the chip state itself, so the row is never blank. */
+    expect(stageOutcomeReason(fakeT, pipeline({ stages }), buildStage)).toBe("pipelineChipState.pending");
   });
 });

--- a/src/components/pipelines/pipelineModel.ts
+++ b/src/components/pipelines/pipelineModel.ts
@@ -750,6 +750,69 @@ export function stageChipLabel(t: TFunction, stage: PipelineStage): string {
   return stage.id;
 }
 
+/**
+ * The title a stage's surface carries on the board (#658): role first, then the
+ * stage id, then the chain position — «Builder · integrate_v3_voice · stage 2/3».
+ * Every stage surface (live pane, completed card, placeholder, collapsed status
+ * row) reads this ONE derivation, so a pane is never titled by the first line of
+ * its prompt: every stage prompt opens with the same shared preamble, which made
+ * every pane on the board carry the identical meaningless title. The identity a
+ * title must answer — which role, which stage, how far along — comes from the
+ * declared chain instead, so it stays meaningful whatever the prompt says.
+ * A role-less stage falls back to its id (stageChipLabel), which the id segment
+ * would then repeat — so it is emitted once.
+ */
+export function stagePaneTitle(t: TFunction, stage: PipelineStage, index: number, total: number): string {
+  const role = stageChipLabel(t, stage);
+  const position = t("pipelineSlot.stageOf", { k: index + 1, n: total });
+  return role === stage.id ? `${role} · ${position}` : `${role} · ${stage.id} · ${position}`;
+}
+
+/**
+ * Whether a stage's board surface collapses to a one-line status row (#658).
+ * Skipped and completed work is BEHIND the operator: rendering it at the same
+ * weight as a pending or active stage — full stage-prompt block included — made
+ * the board read as if finished work were still ahead. Such a stage collapses to
+ * a badge + title + why-it-ended row, expandable on demand.
+ * `needs_decision` never collapses: it is the one settled state that asks the
+ * operator to act, so it keeps its full card.
+ */
+export function stageRowCollapsible(pipeline: Pipeline, stage: PipelineStage, presentation: "placeholder" | "completed"): boolean {
+  const state = stageChipState(pipeline, stage);
+  if (state === "skipped") return true;
+  return presentation === "completed" && (state === "passed" || state === "failed");
+}
+
+/** First non-empty line of a multi-line record, bounded for a one-line row. */
+function firstLine(value: string | null | undefined, max = 120): string {
+  const line = (value ?? "").split("\n").map((part) => part.trim()).find((part) => part.length > 0) ?? "";
+  return line.length > max ? `${line.slice(0, max - 1)}…` : line;
+}
+
+/**
+ * Why a settled stage ended the way it did, in one line (#658) — the substance
+ * the collapsed status row carries in place of the stage prompt. The record the
+ * engine actually wrote wins, in order: a recorded error, the verdict's first
+ * finding, then the attempt's output summary (a skip writes its own). Without any
+ * of those the row states the attempt's raw state, so the row is never blank.
+ */
+export function stageOutcomeReason(
+  t: TFunction,
+  pipeline: Pipeline,
+  stage: PipelineStage,
+  attempt: PipelineStageAttempt | null = latestAttempt(pipeline, stage.id),
+): string {
+  const error = firstLine(attempt?.error);
+  if (error) return error;
+  const finding = firstLine(attempt?.verdict?.findings?.[0]);
+  if (finding) return `${verdictStatusLabel(t, attempt!.verdict!.status)} — ${finding}`;
+  const output = firstLine(attempt?.output);
+  if (output) return output;
+  if (attempt?.verdict) return verdictStatusLabel(t, attempt.verdict.status);
+  if (attempt) return attemptStateLabel(t, attempt.state);
+  return t(`pipelineChipState.${stageChipState(pipeline, stage)}`);
+}
+
 /* A cursorless pipeline rests on its last in-flight stage; the live attempt states
    that mark it are exactly {@link LIVE_ATTEMPT_STATES}. */
 const CURSORLESS_LIVE_STATES = LIVE_ATTEMPT_STATES;

--- a/src/components/pipelines/pipelineModel.ts
+++ b/src/components/pipelines/pipelineModel.ts
@@ -829,8 +829,13 @@ function firstLine(value: string | null | undefined, max = 120): string {
  * Why a settled stage ended the way it did, in one line (#658) — the substance
  * the collapsed status row carries in place of the stage prompt. The record the
  * engine actually wrote wins, in order: a recorded error, the verdict's first
- * finding, then the attempt's output summary (a skip writes its own). Without any
- * of those the row states the attempt's raw state, so the row is never blank.
+ * finding, then the attempt's output summary. Without any of those the row states
+ * the attempt's raw state, so the row is never blank.
+ * A SKIP is the one outcome the engine narrates itself, in a hardcoded English
+ * sentence it stamps into `output` — so a skipped attempt with nothing more
+ * specific to say reads from the catalogue instead, and a Ukrainian badge and
+ * title never sit beside an English line. Free-form agent output on a
+ * passed/failed stage stays verbatim: that is data, not copy.
  */
 export function stageOutcomeReason(
   t: TFunction,
@@ -842,6 +847,7 @@ export function stageOutcomeReason(
   if (error) return error;
   const finding = firstLine(attempt?.verdict?.findings?.[0]);
   if (finding) return `${verdictStatusLabel(t, attempt!.verdict!.status)} — ${finding}`;
+  if (attempt?.state === "skipped") return t("pipelineSlot.reasonSkipped");
   const output = firstLine(attempt?.output);
   if (output) return output;
   if (attempt?.verdict) return verdictStatusLabel(t, attempt.verdict.status);

--- a/src/components/pipelines/pipelineModel.ts
+++ b/src/components/pipelines/pipelineModel.ts
@@ -768,6 +768,42 @@ export function stagePaneTitle(t: TFunction, stage: PipelineStage, index: number
   return role === stage.id ? `${role} · ${position}` : `${role} · ${stage.id} · ${position}`;
 }
 
+/** A live conversation resolved to the pipeline stage it runs (#658): the stage's
+    declared identity plus its position in the chain. */
+export type PipelineStagePane = {
+  pipeline: Pipeline;
+  stage: PipelineStage;
+  index: number;
+  total: number;
+};
+
+/**
+ * Which pipeline stage each live transcript belongs to, keyed by `agentPath`
+ * (#658). One index shared by every surface that must name a stage conversation
+ * — the board node and the full-window overlay both read it, so the two can
+ * never disagree about what a pane is. Closed pipelines are excluded: their
+ * transcripts are history, not a stage in flight.
+ */
+export function pipelineStageByAgentPath(pipelines: readonly Pipeline[]): Map<string, PipelineStagePane> {
+  const map = new Map<string, PipelineStagePane>();
+  for (const pipeline of pipelines) {
+    if (pipeline.state === "closed") continue;
+    pipeline.stages.forEach((stage, index) => {
+      const attempt = latestAttempt(pipeline, stage.id);
+      if (!attempt?.agentPath) return;
+      map.set(attempt.agentPath, { pipeline, stage, index, total: pipeline.stages.length });
+    });
+  }
+  return map;
+}
+
+/** The imposed title for a resolved stage pane, or undefined when a conversation
+    is not a pipeline stage — the ONE composition point every pane-title call site
+    goes through, so no surface can grow its own variant. */
+export function stagePaneTitleOf(t: TFunction, pane: PipelineStagePane | null | undefined): string | undefined {
+  return pane ? stagePaneTitle(t, pane.stage, pane.index, pane.total) : undefined;
+}
+
 /**
  * Whether a stage's board surface collapses to a one-line status row (#658).
  * Skipped and completed work is BEHIND the operator: rendering it at the same

--- a/src/components/pipelines/stageCardAria.render.test.tsx
+++ b/src/components/pipelines/stageCardAria.render.test.tsx
@@ -1,0 +1,52 @@
+import { expect, test } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import type { StageSlot } from "@/components/scheme/layout";
+import type { Pipeline, PipelineStage } from "@/lib/pipelines/types";
+
+import { StageCompletedCard } from "./StageCompletedCard";
+import { StagePlaceholderPane } from "./StagePlaceholderPane";
+
+/*
+ * A stage card's accessible name carries the same identity its visible title
+ * does (#658). Naming it by the role alone left two same-role stages of one
+ * pipeline indistinguishable to assistive tech while their visible titles
+ * differed — the exact confusion the issue is about, one layer down.
+ */
+
+const effectiveRole = { roleId: "builder", engine: "codex" as const, model: null, effort: null, access: "read-write" as const, promptScaffold: null };
+
+function stage(id: string): PipelineStage {
+  return { id, kind: "run", role: { roleId: "builder" }, next: null, effectiveRole, prompt: "{{task}}" } as unknown as PipelineStage;
+}
+
+const stages = [stage("integrate_v3_voice"), stage("harden_v3_voice")];
+
+const pipeline = {
+  id: "p658", task: "V3 voice", project: "demo", repoDir: "/r", worktreeDir: "/w", branch: "b",
+  baseBranch: "main", baseRef: "a", lastPassedCommit: "a", stages,
+  runs: [{ stageId: "integrate_v3_voice", attempts: [{ n: 1, state: "passed", agentPath: "/integrate", flowId: null }] }],
+  cursor: null, state: "running", pausedState: null, stateDetail: null,
+  srcPath: null, srcConversationId: null, createdAt: "1970", closedAt: null,
+} as unknown as Pipeline;
+
+function slot(index: number, presentation: "placeholder" | "completed"): StageSlot {
+  return {
+    key: `slot::p658::${stages[index]!.id}`, pipeline, stage: stages[index]!, index, total: stages.length,
+    presentation, x: 0, y: 0, w: 600, h: 620,
+  } as StageSlot;
+}
+
+const ariaLabels = (html: string) => [...html.matchAll(/aria-label="([^"]+)"/g)].map((match) => match[1]!);
+
+test("two same-role stages expose distinct accessible names on their cards", () => {
+  const first = ariaLabels(renderToStaticMarkup(<StagePlaceholderPane slot={slot(0, "placeholder")} interactive={false} />));
+  const second = ariaLabels(renderToStaticMarkup(<StagePlaceholderPane slot={slot(1, "placeholder")} interactive={false} />));
+  expect(first).toContain("Planned stage Builder · integrate_v3_voice · stage 1/2");
+  expect(second).toContain("Planned stage Builder · harden_v3_voice · stage 2/2");
+});
+
+test("a completed stage card names itself by role, stage and position too", () => {
+  const html = renderToStaticMarkup(<StageCompletedCard slot={slot(0, "completed")} />);
+  expect(ariaLabels(html)).toContain("Completed stage Builder · integrate_v3_voice · stage 1/2 — open to review");
+});

--- a/src/components/scheme/SchemeBoard.pipelineComposition.dom.test.tsx
+++ b/src/components/scheme/SchemeBoard.pipelineComposition.dom.test.tsx
@@ -154,11 +154,13 @@ test("the production scene keeps EVERY current stage a full real card and shells
   expect(host.querySelector("[data-pipeline-stage-graph]")).toBeNull();
 });
 
-test("an idle completed stage still renders as a full conversation card inside the halo, not a compact stub (#507 F2)", async () => {
+test("an idle completed stage stands at its stage position as ONE status row, expandable to the full card (#658)", async () => {
   /* Realistic scene: the two passed stages have gone idle, so the board's
-     activity gate would not surface them as live nodes. They must still stand in
-     at their stage positions as FULL conversation cards (the completed slot), so
-     the five-stage graph stays five real/placeholder cards. */
+     activity gate would not surface them as live nodes. They still own their
+     stage positions, but as collapsed status rows — finished work may not carry
+     a pending stage's weight (#658 narrows #507 F2, which gave them the full
+     card footprint). The full completed card, prompt and transcript link
+     included, is one disclosure away. */
   const idleArchitect = { ...architect, activity: "idle" as const };
   const idleBuilder = { ...builder, activity: "idle" as const };
   const files = [idleArchitect, idleBuilder, verify];
@@ -166,21 +168,29 @@ test("an idle completed stage still renders as a full conversation card inside t
   await settle();
 
   expect(host.querySelectorAll('[data-scheme-group="pipeline"]')).toHaveLength(1);
-  /* The live cursor stage is a full board node; the idle passed stages are full
-     completed cards at their slot positions. */
+  /* The live cursor stage is a full board node; the idle passed stages are
+     collapsed rows at their slot positions. */
   expect(host.querySelector('[data-scheme-node="/verify"]')).toBeTruthy();
-  const completed = [...host.querySelectorAll('[data-pipeline-stage-completed="true"]')];
-  expect(completed).toHaveLength(2);
+  const rows = [...host.querySelectorAll('[data-pipeline-stage-row="true"]')];
+  expect(rows).toHaveLength(2);
+  expect(host.querySelectorAll('[data-pipeline-stage-completed="true"]')).toHaveLength(0);
   expect(host.querySelector('[data-scheme-node="slot::pipe-1::architect"]')).toBeTruthy();
   expect(host.querySelector('[data-scheme-node="slot::pipe-1::builder"]')).toBeTruthy();
-  /* The completed card is full-size (the live/placeholder footprint), NOT the
-     old 168px compact stub. */
+  /* One row of board, not a full card's footprint. */
   const archSlot = host.querySelector('[data-scheme-node="slot::pipe-1::architect"]') as HTMLElement;
-  expect(Number.parseInt(archSlot.style.height, 10)).toBeGreaterThan(400);
-  /* It shows the real prompt that was sent (minimal visual difference from the
-     eventual live conversation) and opens the transcript. */
+  expect(Number.parseInt(archSlot.style.height, 10)).toBeLessThan(200);
+  /* Each row states which stage it was and how it ended. */
+  expect(rows[0]!.textContent).toContain("architect");
+  expect(rows[0]!.textContent).toContain("passed");
+  /* Expanding one reveals the real conversation card: the prompt that was sent
+     and the affordance that opens the transcript. */
+  const toggle = archSlot.querySelector("button[data-stage-row-toggle]") as HTMLButtonElement;
+  flushSync(() => toggle.dispatchEvent(new dom.MouseEvent("click", { bubbles: true }) as unknown as Event));
+  await settle();
+  const completed = [...host.querySelectorAll('[data-pipeline-stage-completed="true"]')];
+  expect(completed).toHaveLength(1);
   expect(completed[0]!.textContent).toContain("Pinned task:");
-  expect(completed.some((card) => card.textContent?.includes("Open conversation"))).toBe(true);
+  expect(completed[0]!.textContent).toContain("Open conversation");
 
   /* Still exactly five stage cards, one per declared stage. */
   const stageCards = [...host.querySelectorAll('[data-pipeline-stage-card^="pipe-1::"]')];

--- a/src/components/scheme/SchemeBoard.stageOverlay.dom.test.tsx
+++ b/src/components/scheme/SchemeBoard.stageOverlay.dom.test.tsx
@@ -1,0 +1,173 @@
+import { afterEach, expect, test } from "bun:test";
+import { Window } from "happy-dom";
+import { createRoot, type Root } from "react-dom/client";
+import { flushSync } from "react-dom";
+
+import type { Pipeline } from "@/lib/pipelines/types";
+import type { FileEntry } from "@/lib/types";
+import { buildBranchGroups } from "@/components/projectModel";
+
+import { SchemeBoard } from "./SchemeBoard";
+
+/*
+ * The full-window overlay is the surface a stage conversation is actually READ
+ * in, so it carries the same imposed identity as the board card (#658). Without
+ * it, expanding the live stage put the operator back in front of the shared
+ * safety preamble the scanner titled the transcript with — visibly and in the
+ * dialog's accessible name — one click from the surface that fixed it.
+ */
+
+const dom = new Window();
+class TestResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+(dom as unknown as { matchMedia: (q: string) => unknown }).matchMedia = () => ({
+  matches: false, media: "", addEventListener() {}, removeEventListener() {}, addListener() {}, removeListener() {}, onchange: null, dispatchEvent: () => false,
+});
+Object.assign(globalThis, {
+  window: dom,
+  document: dom.document,
+  navigator: dom.navigator,
+  Node: dom.Node,
+  HTMLElement: dom.HTMLElement,
+  HTMLButtonElement: dom.HTMLButtonElement,
+  HTMLDivElement: dom.HTMLDivElement,
+  Event: dom.Event,
+  CustomEvent: dom.CustomEvent,
+  MouseEvent: dom.MouseEvent,
+  KeyboardEvent: dom.KeyboardEvent,
+  sessionStorage: dom.sessionStorage,
+  localStorage: dom.localStorage,
+  ResizeObserver: TestResizeObserver,
+  IntersectionObserver: undefined,
+});
+
+const roots = new Set<Root>();
+afterEach(() => {
+  for (const root of roots) flushSync(() => root.unmount());
+  roots.clear();
+  document.body.replaceChildren();
+  dom.sessionStorage.clear();
+  dom.localStorage.clear();
+});
+
+/* The transcript title the scanner derives: the stage prompt's first line, which
+   is the same shared preamble on every stage of every pipeline. */
+const preamble = "Work alone and launch no helpers, workflows, teams or subagents.";
+
+function entry(over: Partial<FileEntry> & { path: string }): FileEntry {
+  return {
+    root: "claude-projects", name: over.path, project: "demo", title: preamble,
+    engine: "claude", kind: "session", fmt: "claude", parent: null, mtime: 1000,
+    size: 10, activity: "live", proc: "running", pid: 7, model: null,
+    pendingQuestion: null, waitingInput: null, ...over,
+  };
+}
+
+const stageRole = { roleId: null, engine: "codex" as const, model: null, effort: null, access: "read-write" as const, promptScaffold: null };
+const integrate = entry({ path: "/integrate", conversationId: "c-integrate", renamable: true });
+
+const pipeline = {
+  id: "p658", task: "V3 voice", project: "demo", repoDir: "/r", worktreeDir: "/w", branch: "b",
+  baseBranch: "main", baseRef: "a", lastPassedCommit: "a",
+  stages: [
+    { id: "plan_v3_voice", kind: "run", role: { roleId: "architect" }, prompt: "", next: "integrate_v3_voice", effectiveRole: stageRole },
+    { id: "integrate_v3_voice", kind: "run", role: { roleId: "builder" }, prompt: "", next: null, effectiveRole: stageRole },
+  ],
+  runs: [{ stageId: "integrate_v3_voice", attempts: [{ n: 1, state: "running", agentPath: "/integrate", flowId: null }] }],
+  cursor: { stageId: "integrate_v3_voice", state: "running", input: null, activatedBy: null },
+  state: "running", pausedState: null, stateDetail: null,
+  srcPath: null, srcConversationId: null, createdAt: new Date(0).toISOString(), closedAt: null,
+} as unknown as Pipeline;
+
+const settle = async () => {
+  for (let i = 0; i < 5; i += 1) await new Promise((resolve) => setTimeout(resolve, 0));
+  flushSync(() => undefined);
+};
+
+function mountBoard(files: FileEntry[], pipelines: Pipeline[], focus: string | null = null): HTMLElement {
+  const groups = buildBranchGroups(files, "demo");
+  const host = document.createElement("div");
+  document.body.append(host);
+  const root = createRoot(host);
+  roots.add(root);
+  flushSync(() => root.render(
+    <SchemeBoard
+      project="demo"
+      groups={groups}
+      manual={[]}
+      files={files}
+      flows={[]}
+      pipelines={pipelines}
+      surfacePipelines={pipelines}
+      tasks={[]}
+      drafts={[]}
+      focus={focus}
+      onSelect={() => {}}
+      onClose={() => {}}
+      onDraftClose={() => {}}
+      onDraftSpawned={() => {}}
+    />,
+  ));
+  return host;
+}
+
+function expandBoardPane(host: HTMLElement, path: string): void {
+  const pane = host.querySelector(`[data-scheme-node="${path}"]`)!;
+  const expand = [...pane.querySelectorAll("button")].find((button) =>
+    (button.getAttribute("aria-label") ?? "").startsWith("Expand conversation"),
+  ) as HTMLButtonElement;
+  expect(expand).toBeTruthy();
+  flushSync(() => expand.dispatchEvent(new dom.MouseEvent("click", { bubbles: true }) as unknown as Event));
+}
+
+test("expanding a live stage pane keeps the role-first identity, in the header and in the dialog's accessible name", async () => {
+  const host = mountBoard([integrate], [pipeline]);
+  await settle();
+  /* The board card is already named by its stage. */
+  expect(host.querySelector("[data-pane-title-override]")?.textContent).toBe("Builder · integrate_v3_voice · stage 2/2");
+
+  expandBoardPane(host, "/integrate");
+  await settle();
+
+  const dialog = host.querySelector('[role="dialog"]') as HTMLElement;
+  expect(dialog).toBeTruthy();
+  expect(dialog.getAttribute("aria-label")).toBe("Builder · integrate_v3_voice · stage 2/2");
+  expect(dialog.getAttribute("aria-label")).not.toContain("Work alone");
+  const title = dialog.querySelector("[data-pane-title-override]") as HTMLElement;
+  expect(title.textContent).toBe("Builder · integrate_v3_voice · stage 2/2");
+  /* Reachable, not lost: the transcript's own title rides the header tooltip. */
+  expect(title.getAttribute("title")).toContain(preamble);
+});
+
+test("F2 on the selected stage node opens a working rename editor in the overlay", async () => {
+  /* Renaming works by expanding the node and replaying a token into the
+     overlay's SessionTitle; the imposed identity steps aside while that token is
+     live, so imposing it never removes the last rename path stage transcripts
+     have. */
+  /* A focus jump selects its node, which is what F2 acts on. */
+  const host = mountBoard([integrate], [pipeline], "/integrate");
+  await settle();
+  flushSync(() => window.dispatchEvent(new dom.KeyboardEvent("keydown", { key: "F2", bubbles: true }) as unknown as Event));
+  await settle();
+
+  const dialog = host.querySelector('[role="dialog"]') as HTMLElement;
+  expect(dialog).toBeTruthy();
+  /* The editor is mounted (the override yielded), so the operator can type. */
+  expect(dialog.querySelector("input")).toBeTruthy();
+  expect(dialog.querySelector("[data-pane-title-override]")).toBeNull();
+});
+
+test("a conversation that is not a pipeline stage keeps its own title in the overlay", async () => {
+  const plain = entry({ path: "/plain", conversationId: "c-plain", title: "Plain conversation" });
+  const host = mountBoard([plain], []);
+  await settle();
+  expandBoardPane(host, "/plain");
+  await settle();
+
+  const dialog = host.querySelector('[role="dialog"]') as HTMLElement;
+  expect(dialog.getAttribute("aria-label")).toBe("Plain conversation");
+  expect(dialog.querySelector("[data-pane-title-override]")).toBeNull();
+});

--- a/src/components/scheme/SchemeBoard.tsx
+++ b/src/components/scheme/SchemeBoard.tsx
@@ -23,12 +23,12 @@ import { pushTaskToast } from "@/components/tasks/taskToast";
 import { cleanTitle } from "@/components/utils";
 import { taskDeliveryText } from "@/lib/tasks/helpers";
 
-import { compactPipelineLayoutFlows, compactPipelineOpenTarget, pipelineAnnouncement, pipelineLinkedTasks, pipelineStripByPath, renderableFlowIds } from "@/components/pipelines/pipelineModel";
+import { compactPipelineLayoutFlows, compactPipelineOpenTarget, pipelineAnnouncement, pipelineLinkedTasks, pipelineStageByAgentPath, pipelineStripByPath, renderableFlowIds, stagePaneTitleOf } from "@/components/pipelines/pipelineModel";
 import { BulkActionBar } from "./BulkActionBar";
 import { EdgeChips } from "./EdgeChips";
 import { nodesInRect, pruneSelection, selectionBBox } from "./lasso";
 import { resolveExpandedNode } from "./expandedNode";
-import { autoEditTokenFor, clearStaleRename, requestRename, type RenameRequest } from "./renameRequest";
+import { autoEditTokenFor, clearStaleRename, requestRename, titleUnderRename, type RenameRequest } from "./renameRequest";
 import { currentWorkRect, currentWorkRects, rectUnion } from "./currentWork";
 import { buildSchemeLayout } from "./layout";
 import { Minimap, stackDotsFor, type StackDot } from "./Minimap";
@@ -354,6 +354,10 @@ export function SchemeBoard({
      stage's node. Review-loop current stages resolve to null here — their
      FlowStrip owns that slot — so the two controls never stack. */
   const pipelineStrips = useMemo(() => pipelineStripByPath(pipelines), [pipelines]);
+  /* Which stage each live transcript runs (#658) — the same index the board's
+     nodes read, so a stage pane is named identically on the board and in the
+     full-window overlay it expands into. */
+  const stagePaneByPath = useMemo(() => pipelineStageByAgentPath(pipelines), [pipelines]);
 
   /* One conversation expanded full-window at a time. React state only — never
      persisted, gone on reload; the board underneath stays mounted, so camera,
@@ -1334,33 +1338,47 @@ export function SchemeBoard({
         viewport, with the live feed and the composer of exactly this
         conversation. Sibling of the viewport, so its clicks never reach the
         canvas pan/select handlers. */}
-    {expandedNode ? (
-      <div
-        className="fixed inset-0 z-40 flex flex-col bg-canvas p-3"
-        role="dialog"
-        aria-modal="true"
-        aria-label={cleanTitle(expandedNode.file.title, 90)}
-      >
-        <BranchPane
-          /* Not keyed by identity: SessionTitle resets its own edit state on a
-             real A→B switch (and preserves it across conversation-id enrichment
-             or succession), so a key here would only cause spurious remounts —
-             and replay a retained F2 token — when a poll fills in identity. */
-          file={expandedNode.file}
-          tasks={expandedNode.tasks}
-          isRoot={expandedNode.isRoot}
-          expanded
-          showFavorite
-          onToggleExpand={() => setExpanded(null)}
-          autoEditToken={autoEditTokenFor(renameRequest, expandedNode.file.path)}
-          onSpawnRetry={onSpawnRetry ? stableSpawnRetry : undefined}
-          relatedTasks={relatedTasksByPath.get(expandedNode.file.path)}
-          /* Opening a task from the full-window conversation returns to the
-             board first — the card the camera centers must be visible. */
-          onOpenTask={onOpenTask ? (task) => { setExpanded(null); stableOpenTask(task); } : undefined}
-        />
-      </div>
-    ) : null}
+    {expandedNode ? (() => {
+      /* The overlay is the surface a stage conversation is actually READ in, so
+         it carries the same imposed identity as the board card (#658) — without
+         it, expanding a stage put the operator back in front of the shared
+         safety preamble the scanner titled the transcript with, in the visible
+         header and in the dialog's accessible name alike.
+         A pending F2 rename suppresses the override: renaming works by expanding
+         the node and replaying the token into THIS pane's SessionTitle, so while
+         a rename is in flight the editable transcript title must stay mounted —
+         it is the only rename path a stage transcript has left. */
+      const renameToken = autoEditTokenFor(renameRequest, expandedNode.file.path);
+      const stageTitle = titleUnderRename(stagePaneTitleOf(t, stagePaneByPath.get(expandedNode.file.path)), renameToken);
+      return (
+        <div
+          className="fixed inset-0 z-40 flex flex-col bg-canvas p-3"
+          role="dialog"
+          aria-modal="true"
+          aria-label={stageTitle ?? cleanTitle(expandedNode.file.title, 90)}
+        >
+          <BranchPane
+            /* Not keyed by identity: SessionTitle resets its own edit state on a
+               real A→B switch (and preserves it across conversation-id enrichment
+               or succession), so a key here would only cause spurious remounts —
+               and replay a retained F2 token — when a poll fills in identity. */
+            file={expandedNode.file}
+            tasks={expandedNode.tasks}
+            isRoot={expandedNode.isRoot}
+            expanded
+            showFavorite
+            titleOverride={stageTitle}
+            onToggleExpand={() => setExpanded(null)}
+            autoEditToken={renameToken}
+            onSpawnRetry={onSpawnRetry ? stableSpawnRetry : undefined}
+            relatedTasks={relatedTasksByPath.get(expandedNode.file.path)}
+            /* Opening a task from the full-window conversation returns to the
+               board first — the card the camera centers must be visible. */
+            onOpenTask={onOpenTask ? (task) => { setExpanded(null); stableOpenTask(task); } : undefined}
+          />
+        </div>
+      );
+    })() : null}
     </>
   );
 }

--- a/src/components/scheme/layout.test.ts
+++ b/src/components/scheme/layout.test.ts
@@ -13,7 +13,7 @@ import { applyBoardMutations } from "@/lib/board/mutations";
 import { autoTaskSlotPosition } from "@/lib/tasks/lattice";
 
 import { deckKey, flowLinkKey, stageSlotKey } from "./agentLinks";
-import { REST_BAND_MAX_W, buildSchemeLayout } from "./layout";
+import { REST_BAND_MAX_W, SLOT_H, SLOT_ROW_H, buildSchemeLayout } from "./layout";
 import { TASK_W, taskWorldBounds } from "./taskGeometry";
 
 function entry(overrides: Partial<FileEntry> & { path: string }): FileEntry {
@@ -559,9 +559,16 @@ describe("every current stage keeps a full real card under production compaction
     expect(layout.nodes.map((node) => node.file.path)).not.toContain("/build");
     const slotByStage = new Map(layout.slots.map((slot) => [slot.stage.id, slot]));
     expect(slotByStage.get("builder")?.presentation).toBe("completed");
-    /* Full-size footprint, shared with the live/placeholder cards (#507 F2). */
-    expect(slotByStage.get("builder")?.h).toBe(slotByStage.get("future")!.h);
+    /* The completed stage keeps its stage position and its full-width footprint,
+       but reserves ONE status row rather than the pending card's height (#658
+       narrows #507 F2's equal footprint): finished work may not read as if it were
+       still ahead. The full card stays available on the row's disclosure. */
+    expect(slotByStage.get("builder")?.collapsedRow).toBe(true);
+    expect(slotByStage.get("builder")?.h).toBe(SLOT_ROW_H);
+    expect(slotByStage.get("builder")?.w).toBe(slotByStage.get("future")!.w);
     expect(slotByStage.get("future")?.presentation).toBe("placeholder");
+    expect(slotByStage.get("future")?.collapsedRow).toBeUndefined();
+    expect(slotByStage.get("future")?.h).toBe(SLOT_H);
 
     const builderSlot = stageSlotKey("p", "builder");
     const futureSlot = stageSlotKey("p", "future");
@@ -966,5 +973,65 @@ describe("direct one-shot review groups on the scheme (issue #325)", () => {
     expect(layout.links.some((link) => link.key === flowLinkKey("flow-managed"))).toBe(true);
     expect(layout.groups.some((halo) => halo.id === "flow-managed")).toBe(true);
     expect(layout.groups.some((halo) => halo.id === projected[0]!.id)).toBe(false);
+  });
+});
+
+describe("a pipeline's stages read in execution order (#658)", () => {
+  /* Three stages, each transcript surfacing as its OWN root (structured
+     continuations — no placed lineage host): stage 1 skipped and idle, stage 2
+     live, stage 3 not launched. */
+  const threeStage = (): Pipeline =>
+    ({
+      id: "p658", task: "Voice", project: "demo", repoDir: "/r", worktreeDir: "/w", branch: "b", baseBranch: "main",
+      baseRef: "a", lastPassedCommit: "a",
+      stages: [
+        { id: "plan_v3_voice", kind: "run", prompt: "", next: "integrate_v3_voice" },
+        { id: "integrate_v3_voice", kind: "run", prompt: "", next: "verify_v3_voice" },
+        { id: "verify_v3_voice", kind: "run", prompt: "", next: null },
+      ],
+      runs: [
+        { stageId: "plan_v3_voice", attempts: [{ n: 1, state: "skipped", agentPath: "/plan", flowId: null, output: "Skipped by operator." }] },
+        { stageId: "integrate_v3_voice", attempts: [{ n: 1, state: "running", agentPath: "/integrate", flowId: null }] },
+      ],
+      cursor: { stageId: "integrate_v3_voice", state: "running", input: null, activatedBy: null },
+      state: "running", pausedState: null, stateDetail: null,
+      srcPath: null, srcConversationId: null, createdAt: "1970", closedAt: null,
+    }) as unknown as Pipeline;
+
+  const rootGroup = (file: FileEntry): BranchGroup =>
+    ({ key: file.path, columns: [{ file, tasks: [] }], returnable: [], finished: [], smt: file.mtime, orphanTask: false });
+
+  test("separate stage roots place stage 1 before the fresher live stage 2, not after it", () => {
+    /* The band ranks trees by activity+recency, which put the LIVE stage 2 first
+       and pushed the earlier stage 1 rightwards (or onto the next row): reading
+       order fought execution order. Execution order now wins inside the region. */
+    const p = threeStage();
+    const plan = entry({ path: "/plan", mtime: 1_000, activity: "idle" });
+    const integrate = entry({ path: "/integrate", mtime: 9_000, activity: "live", proc: "running" });
+    const layout = buildSchemeLayout([rootGroup(plan), rootGroup(integrate)], [], [plan, integrate], [], [], [p], [p]);
+
+    const byPath = new Map(layout.nodes.map((node) => [node.file.path, node] as const));
+    expect(byPath.has("/plan")).toBe(true);
+    expect(byPath.has("/integrate")).toBe(true);
+    expect(byPath.get("/plan")!.x).toBeLessThan(byPath.get("/integrate")!.x);
+    expect(byPath.get("/plan")!.y).toBe(byPath.get("/integrate")!.y);
+    /* The unlaunched last stage still trails the chain, inside the same halo. */
+    const future = layout.slots.find((slot) => slot.stage.id === "verify_v3_voice")!;
+    expect(future.x).toBeGreaterThan(byPath.get("/integrate")!.x);
+    const halo = layout.groups.find((group) => group.kind === "pipeline" && group.id === "p658")!;
+    expect(byPath.get("/plan")!.x).toBeGreaterThanOrEqual(halo.x);
+    expect(future.x + future.w).toBeLessThanOrEqual(halo.x + halo.w);
+  });
+
+  test("a skipped stage with no placed transcript reserves one status row, not a full card", () => {
+    /* Stage 1 was skipped and its transcript never reached the board: it surfaces
+       as a slot, and a skipped slot is settled work — one row. */
+    const p = threeStage();
+    const integrate = entry({ path: "/integrate", activity: "live", proc: "running" });
+    const layout = buildSchemeLayout([rootGroup(integrate)], [], [integrate], [], [], [p], [p]);
+    const slotByStage = new Map(layout.slots.map((slot) => [slot.stage.id, slot]));
+    expect(slotByStage.get("plan_v3_voice")?.collapsedRow).toBe(true);
+    expect(slotByStage.get("plan_v3_voice")?.h).toBe(SLOT_ROW_H);
+    expect(slotByStage.get("verify_v3_voice")?.h).toBe(SLOT_H);
   });
 });

--- a/src/components/scheme/layout.test.ts
+++ b/src/components/scheme/layout.test.ts
@@ -1043,6 +1043,48 @@ describe("a pipeline's stages read in execution order (#658)", () => {
     expect(future.incomingAnchorY).toBe(HANDOFF_BADGE_Y);
   });
 
+  test("all three stages launched — zero slots — still read stage 1 → 2 → 3 in one halo", () => {
+    /* The configuration this ordering exists for, at its END state: every stage
+       transcript surfaced as its own root, so there is no lineage host, and the
+       last stage has launched, so there is no slot left either. The chain plan is
+       dropped for having nothing to emit — and with it (round 2 regression) went
+       every stage rank, leaving the band to fall back on activity+recency:
+       newest stage leftmost, i.e. the whole chain backwards. Ranks come from the
+       declared pipeline now, so the order survives the plan being dropped. */
+    const p = threeStage();
+    (p as unknown as { runs: unknown }).runs = [
+      { stageId: "plan_v3_voice", attempts: [{ n: 1, state: "passed", agentPath: "/s1", flowId: null }] },
+      { stageId: "integrate_v3_voice", attempts: [{ n: 1, state: "passed", agentPath: "/s2", flowId: null }] },
+      { stageId: "verify_v3_voice", attempts: [{ n: 1, state: "running", agentPath: "/s3", flowId: null }] },
+    ];
+    (p as unknown as { cursor: unknown }).cursor = { stageId: "verify_v3_voice", state: "running", input: null, activatedBy: null };
+    /* The freshest, liveliest tree is the LAST stage — what the band would put first. */
+    const s1 = entry({ path: "/s1", mtime: 1_000, activity: "idle" });
+    const s2 = entry({ path: "/s2", mtime: 2_000, activity: "idle" });
+    const s3 = entry({ path: "/s3", mtime: 9_000, activity: "live", proc: "running" });
+    const layout = buildSchemeLayout(
+      [rootGroup(s1), rootGroup(s2), rootGroup(s3)], [], [s1, s2, s3], [], [], [p], [p],
+    );
+
+    expect(layout.slots).toHaveLength(0);
+    const byPath = new Map(layout.nodes.map((node) => [node.file.path, node] as const));
+    expect([...byPath.keys()].sort()).toEqual(["/s1", "/s2", "/s3"]);
+    expect(byPath.get("/s1")!.x).toBeLessThan(byPath.get("/s2")!.x);
+    expect(byPath.get("/s2")!.x).toBeLessThan(byPath.get("/s3")!.x);
+    /* One row: execution order reads left→right, never bottom-up. */
+    expect(byPath.get("/s1")!.y).toBe(byPath.get("/s2")!.y);
+    expect(byPath.get("/s2")!.y).toBe(byPath.get("/s3")!.y);
+    /* The halo still spans exactly the three stage panes — ranking emits nothing. */
+    const halos = layout.groups.filter((group) => group.kind === "pipeline" && group.id === "p658");
+    expect(halos).toHaveLength(1);
+    expect([...halos[0]!.members].sort()).toEqual(["/s1", "/s2", "/s3"]);
+    for (const path of ["/s1", "/s2", "/s3"]) {
+      const node = byPath.get(path)!;
+      expect(node.x).toBeGreaterThanOrEqual(halos[0]!.x);
+      expect(node.x + node.w).toBeLessThanOrEqual(halos[0]!.x + halos[0]!.w);
+    }
+  });
+
   test("a skipped stage with no placed transcript reserves one status row, not a full card", () => {
     /* Stage 1 was skipped and its transcript never reached the board: it surfaces
        as a slot, and a skipped slot is settled work — one row. */

--- a/src/components/scheme/layout.test.ts
+++ b/src/components/scheme/layout.test.ts
@@ -13,7 +13,7 @@ import { applyBoardMutations } from "@/lib/board/mutations";
 import { autoTaskSlotPosition } from "@/lib/tasks/lattice";
 
 import { deckKey, flowLinkKey, stageSlotKey } from "./agentLinks";
-import { REST_BAND_MAX_W, SLOT_H, SLOT_ROW_H, buildSchemeLayout } from "./layout";
+import { HANDOFF_BADGE_Y, REST_BAND_MAX_W, SLOT_H, SLOT_ROW_H, buildSchemeLayout } from "./layout";
 import { TASK_W, taskWorldBounds } from "./taskGeometry";
 
 function entry(overrides: Partial<FileEntry> & { path: string }): FileEntry {
@@ -1021,6 +1021,26 @@ describe("a pipeline's stages read in execution order (#658)", () => {
     const halo = layout.groups.find((group) => group.kind === "pipeline" && group.id === "p658")!;
     expect(byPath.get("/plan")!.x).toBeGreaterThanOrEqual(halo.x);
     expect(future.x + future.w).toBeLessThanOrEqual(halo.x + halo.w);
+  });
+
+  test("the handoff badge into a full card sits on the seam it shares with a collapsed row", () => {
+    /* Adjacent slots are top-aligned, so a 96px row beside a 620px card share
+       only the row's own span: anchoring the arrow at the card's header level
+       (110px) floated it below the row it visually leaves. */
+    const p = threeStage();
+    const layout = buildSchemeLayout([], [], [], [], [], [p], [p]);
+    const slotByStage = new Map(layout.slots.map((slot) => [slot.stage.id, slot]));
+    const skipped = slotByStage.get("plan_v3_voice")!;
+    const live = slotByStage.get("integrate_v3_voice")!;
+    const future = slotByStage.get("verify_v3_voice")!;
+    /* Row → full card: the badge stays inside the row's vertical span. */
+    expect(skipped.h).toBe(SLOT_ROW_H);
+    expect(live.incoming).toBe("run");
+    expect(live.incomingAnchorY).toBe(SLOT_ROW_H / 2);
+    expect(live.incomingAnchorY!).toBeGreaterThan(skipped.y - live.y);
+    expect(live.incomingAnchorY!).toBeLessThan(skipped.y + skipped.h - live.y);
+    /* Two full cards keep the header-level anchor. */
+    expect(future.incomingAnchorY).toBe(HANDOFF_BADGE_Y);
   });
 
   test("a skipped stage with no placed transcript reserves one status row, not a full card", () => {

--- a/src/components/scheme/layout.ts
+++ b/src/components/scheme/layout.ts
@@ -20,7 +20,7 @@ import {
   type AgentLink,
   type SchemeGroupSpec,
 } from "./agentLinks";
-import { PIPELINE_PLACEHOLDER_STATES, latestAttempt, pipelinePlaceholderStages, stageAttempts } from "@/components/pipelines/pipelineModel";
+import { PIPELINE_PLACEHOLDER_STATES, latestAttempt, pipelinePlaceholderStages, stageAttempts, stageRowCollapsible } from "@/components/pipelines/pipelineModel";
 import { linkedPipelineTasks } from "./pipelineAnchor";
 import { TASK_W, isPlacedTask, taskBoxHeight } from "./taskGeometry";
 import { type BranchGroup, descendantsOf, isChildConversation, kidsIndex, projectDescendantsOf } from "@/components/projectModel";
@@ -79,11 +79,19 @@ const MEMBERLESS_PIPELINE_GAP = GROUP_PAD * 2 + GROUP_STRIP_HEADROOM + 24;
 export const SLOT_W = NODE_W;
 export const SLOT_H = 620;
 export const SLOT_GAP = 72;
+/* A settled stage (skipped, or completed evidence) collapses to ONE status row
+   (#658): finished work reserves a row of board, not a full card's footprint, so
+   the chain no longer reads as if everything in it were still ahead. The row is
+   expandable — the shell floats the full card over the board on demand, which is
+   why the reserved geometry stays this row. */
+export const SLOT_ROW_H = 96;
 /* Completed stage cards (#507 F2): a terminal stage of an ACTIVE pipeline whose
    idle transcript is not surfaced as a live node still stands in at its stage
-   position as a FULL conversation card — same footprint (SLOT_H) as the live
-   and placeholder cards, so a five-stage graph reads as five real/placeholder
-   cards, not one live pane beside compact history stubs. */
+   position with the live cards' width, so a five-stage graph reads as five
+   real/placeholder cards, not one live pane beside compact history stubs. Its
+   HEIGHT is now the status row above (#658) — the full card is the row's
+   disclosure, so finished work keeps its position without keeping a pending
+   stage's weight. */
 /* Quiet-branch mini cards stacked under their parent pane. */
 const MINI_W = 360;
 const MINI_H = 52;
@@ -186,6 +194,11 @@ export interface StageSlot extends SchemeRect {
   presentation: "placeholder" | "completed";
   /** Completed slots: the terminal attempt whose transcript the card opens. */
   attempt?: PipelineStageAttempt;
+  /** This stage is settled (skipped/completed evidence) and reserves ONE status
+      row instead of a full card (#658, `stageRowCollapsible`). The layout owns the
+      decision so the reserved geometry and the rendered surface can never
+      disagree; the shell floats the full card over the board when expanded. */
+  collapsedRow?: true;
   /** Render an incoming handoff badge on this slot's left edge: set when the
       previous stage's slot sits directly beside it in the same row. */
   incoming?: "run" | "review-loop";
@@ -527,6 +540,9 @@ export function buildSchemeLayout(
     /* The handoff badge renders only between chain-adjacent slots — a gap (a
        live pane between them) breaks the visual chain. */
     const adjacent = previous !== null && plan.pipeline.stages[index - 1]?.id === previous.stage.id;
+    /* Settled work reserves ONE row (#658); everything still ahead — pending,
+       active, or a parked decision — keeps the full card footprint. */
+    const collapsedRow = stageRowCollapsible(plan.pipeline, stage, presentation);
     const slot: StageSlot = {
       key: stageSlotKey(plan.pipeline.id, stage.id),
       pipeline: plan.pipeline,
@@ -536,12 +552,14 @@ export function buildSchemeLayout(
       presentation,
       ...(attempt ? { attempt } : {}),
       ...(adjacent ? { incoming: stage.kind } : {}),
+      ...(collapsedRow ? { collapsedRow: true as const } : {}),
       x,
       y,
       w: SLOT_W,
-      /* Every slot is a full-size card — completed and placeholder alike share
-         the live conversation's footprint (#507 F2). */
-      h: SLOT_H,
+      /* A pending/active slot is a full-size card — placeholder and completed
+         alike share the live conversation's footprint (#507 F2); a settled stage
+         collapses to its status row (#658). */
+      h: collapsedRow ? SLOT_ROW_H : SLOT_H,
     };
     slots.push(slot);
     regionKeys(plan.pipeline.id).push(slot.key);
@@ -1033,18 +1051,43 @@ export function buildSchemeLayout(
      exactly the cluster's span. Keyless trees stay single-item runs in their
      original order. A tree carrying keys of several clusters bridges them —
      their halos interlock through it, so the clusters merge into one run. */
-  type RestItem = { keys: ReadonlySet<string>; place: (top: number) => void };
+  /* Execution order inside a pipeline cluster (#658): the band ranks trees by
+     activity and recency, so a pipeline whose stages surfaced as separate roots
+     placed its LIVE later stage first and pushed the earlier, already-finished
+     one rightwards — or, on an overflowing row, down onto the next row. Reading
+     order then fought execution order: stage 1/3 ended up below the active 2/3.
+     A stage member tree carries its stage's position, and the cluster below lays
+     its ranked trees out in that order, so a pipeline always reads
+     stage 1 → stage 2 → stage 3 along the band. Ranking spans plans (a cluster
+     may bridge two pipelines) by keying on the plan first, the stage second. */
+  const stageRankByPath = new Map<string, number>();
+  stageChainPlans.forEach((plan, planIndex) => {
+    for (const entry of plan.entries) {
+      if (entry.kind !== "node" || stageRankByPath.has(entry.path)) continue;
+      stageRankByPath.set(entry.path, planIndex * 10_000 + entry.index);
+    }
+  });
+  const stageRankOf = (paths: readonly string[]): number | null => {
+    const ranks = paths.flatMap((path) => {
+      const rank = stageRankByPath.get(path);
+      return rank === undefined ? [] : [rank];
+    });
+    return ranks.length ? Math.min(...ranks) : null;
+  };
+  type RestItem = { keys: ReadonlySet<string>; stageRank: number | null; place: (top: number) => void };
   const restItems: RestItem[] = [
     ...restGroups
       .filter((group) => !chainForeignTrees.has(group.key))
       .map((group) => ({
         keys: new Set(group.columns.flatMap((column) => [...subtreeGroups(column.file)])),
+        stageRank: stageRankOf(group.columns.map((column) => column.file.path)),
         place: (top: number) => placeGroup(group, top),
       })),
     ...restManual
       .filter((file) => !chainForeignTrees.has(file.path))
       .map((file) => ({
         keys: subtreeGroups(file),
+        stageRank: stageRankOf([file.path]),
         place: (top: number) => placeManual(file, top),
       })),
   ];
@@ -1069,7 +1112,17 @@ export function buildSchemeLayout(
       restClusters.splice(restClusters.indexOf(extra), 1);
     }
   }
-  for (const cluster of restClusters) placeRestRun(cluster.items.map((item) => item.place));
+  /* Stage member trees take execution order among themselves while every other
+     tree keeps the position activity+recency gave it: the ranked trees are sorted
+     and dealt back into exactly the slots ranked trees already occupied, so a
+     cluster's foreign or flow-owned members never shift. */
+  const inExecutionOrder = (items: readonly RestItem[]): RestItem[] => {
+    const ranked = items.filter((item) => item.stageRank !== null).sort((a, b) => a.stageRank! - b.stageRank!);
+    if (ranked.length < 2) return [...items];
+    let next = 0;
+    return items.map((item) => (item.stageRank === null ? item : ranked[next++]!));
+  };
+  for (const cluster of restClusters) placeRestRun(inExecutionOrder(cluster.items).map((item) => item.place));
 
   /* Remaining drafts join the same bounded band as fresh top-level cards. */
   for (const id of draftIds) {

--- a/src/components/scheme/layout.ts
+++ b/src/components/scheme/layout.ts
@@ -436,6 +436,19 @@ export function buildSchemeLayout(
   const chainPlansByHost = new Map<string, StageChainPlan[]>();
   const rowPlansByTip = new Map<string, StageChainPlan[]>();
   const stageChainPlans: StageChainPlan[] = [];
+  /* Execution-order rank of every stage transcript, keyed by the path the board
+     may place it at (#658). Read by the rest band far below to lay a pipeline's
+     scattered stage trees out stage 1 → stage 2 → stage 3 instead of in
+     activity+recency order (newest first, i.e. the chain backwards).
+     Populated from the DECLARED pipelines, before any plan is dropped: the chains
+     that need the ordering most are exactly the ones that get discarded. Once a
+     pipeline's last stage launches it has no slot left, and with every stage
+     transcript its own root there is no lineage host either — so the plan has
+     nothing to emit and is dropped, and ranks derived from surviving plans
+     vanished with it precisely when a long chain is read most. Ranks emit
+     nothing on their own: no slot, no region, no halo, no revived empty plan.
+     The pipeline's own position keys the ranks so two chains never interleave. */
+  const stageRankByPath = new Map<string, number>();
   {
     /* Only THIS project's pipelines may grow memberless slot rows — the global
        list serves cross-project stage membership, so without this fence a
@@ -450,7 +463,17 @@ export function buildSchemeLayout(
     });
     /* Each placed task card belongs to at most one pipeline region. */
     const claimedTaskIds = new Set<string>();
-    for (const pipeline of pool) {
+    for (const [pipelineIndex, pipeline] of pool.entries()) {
+      /* Rank first, unconditionally — every declared stage, whatever becomes of
+         this pipeline's plan below. A folded review-loop ranks at its flow
+         implementer, the path the board actually places for it. */
+      pipeline.stages.forEach((stage, stageIndex) => {
+        const attempt = latestAttempt(pipeline, stage.id);
+        const implPath = stage.kind === "review-loop" && attempt?.flowId ? implOfFlow(attempt.flowId) : null;
+        for (const path of [attempt?.agentPath ?? null, implPath]) {
+          if (path && !stageRankByPath.has(path)) stageRankByPath.set(path, pipelineIndex * 10_000 + stageIndex);
+        }
+      });
       const placeholderIds = new Set(pipelinePlaceholderStages(pipeline, prePlacedNodePaths, prePlacedDeckFlowIds).map((stage) => stage.id));
       /* Completed cards only grow on an active pipeline, and never for the cursor
          stage itself: a cursor stage whose only transcript is quiet history
@@ -1071,17 +1094,12 @@ export function buildSchemeLayout(
      placed its LIVE later stage first and pushed the earlier, already-finished
      one rightwards — or, on an overflowing row, down onto the next row. Reading
      order then fought execution order: stage 1/3 ended up below the active 2/3.
-     A stage member tree carries its stage's position, and the cluster below lays
-     its ranked trees out in that order, so a pipeline always reads
-     stage 1 → stage 2 → stage 3 along the band. Ranking spans plans (a cluster
-     may bridge two pipelines) by keying on the plan first, the stage second. */
-  const stageRankByPath = new Map<string, number>();
-  stageChainPlans.forEach((plan, planIndex) => {
-    for (const entry of plan.entries) {
-      if (entry.kind !== "node" || stageRankByPath.has(entry.path)) continue;
-      stageRankByPath.set(entry.path, planIndex * 10_000 + entry.index);
-    }
-  });
+     Every stage transcript carries its stage's position (`stageRankByPath`, built
+     from the declared pipelines above so it outlives a dropped plan), and the
+     cluster below lays its ranked trees out in that order, so a pipeline always
+     reads stage 1 → stage 2 → stage 3 along the band. A tree ranks by the
+     earliest stage it carries, which keeps a pipeline's trees in chain order even
+     when one tree hosts several stages. */
   const stageRankOf = (paths: readonly string[]): number | null => {
     const ranks = paths.flatMap((path) => {
       const rank = stageRankByPath.get(path);

--- a/src/components/scheme/layout.ts
+++ b/src/components/scheme/layout.ts
@@ -85,6 +85,13 @@ export const SLOT_GAP = 72;
    expandable — the shell floats the full card over the board on demand, which is
    why the reserved geometry stays this row. */
 export const SLOT_ROW_H = 96;
+/* Where the handoff badge rides in the gap between two chain-adjacent slots:
+   on the seam of the two surfaces it joins. Adjacent slots are top-aligned, so
+   their shared vertical span is the shorter of the two — a pair of full cards
+   keeps this header-level anchor, while a collapsed row pins the arrow inside
+   its own 96px span instead of floating below its bottom edge (#658). */
+export const HANDOFF_BADGE_Y = 110;
+const handoffBadgeY = (a: number, b: number) => Math.min(HANDOFF_BADGE_Y, Math.round(Math.min(a, b) / 2));
 /* Completed stage cards (#507 F2): a terminal stage of an ACTIVE pipeline whose
    idle transcript is not surfaced as a live node still stands in at its stage
    position with the live cards' width, so a five-stage graph reads as five
@@ -202,6 +209,10 @@ export interface StageSlot extends SchemeRect {
   /** Render an incoming handoff badge on this slot's left edge: set when the
       previous stage's slot sits directly beside it in the same row. */
   incoming?: "run" | "review-loop";
+  /** Distance from this slot's top to the incoming badge's center — the seam the
+      two joined surfaces share (`handoffBadgeY`). Set with `incoming`, so an
+      arrow out of a collapsed row never floats below the row it leaves (#658). */
+  incomingAnchorY?: number;
 }
 
 /** A board task card owned by a pipeline region (#531): the layout places it
@@ -543,6 +554,10 @@ export function buildSchemeLayout(
     /* Settled work reserves ONE row (#658); everything still ahead — pending,
        active, or a parked decision — keeps the full card footprint. */
     const collapsedRow = stageRowCollapsible(plan.pipeline, stage, presentation);
+    const height = collapsedRow ? SLOT_ROW_H : SLOT_H;
+    /* The badge sits on the seam the two adjacent surfaces share, so a mixed
+       row/card pair keeps the arrow on the chain rather than under it. */
+    const previousHeight = previous && stageRowCollapsible(plan.pipeline, previous.stage, previous.presentation) ? SLOT_ROW_H : SLOT_H;
     const slot: StageSlot = {
       key: stageSlotKey(plan.pipeline.id, stage.id),
       pipeline: plan.pipeline,
@@ -551,7 +566,7 @@ export function buildSchemeLayout(
       total: plan.pipeline.stages.length,
       presentation,
       ...(attempt ? { attempt } : {}),
-      ...(adjacent ? { incoming: stage.kind } : {}),
+      ...(adjacent ? { incoming: stage.kind, incomingAnchorY: handoffBadgeY(previousHeight, height) } : {}),
       ...(collapsedRow ? { collapsedRow: true as const } : {}),
       x,
       y,
@@ -559,7 +574,7 @@ export function buildSchemeLayout(
       /* A pending/active slot is a full-size card — placeholder and completed
          alike share the live conversation's footprint (#507 F2); a settled stage
          collapses to its status row (#658). */
-      h: collapsedRow ? SLOT_ROW_H : SLOT_H,
+      h: height,
     };
     slots.push(slot);
     regionKeys(plan.pipeline.id).push(slot.key);

--- a/src/components/scheme/nodes.stageRow.dom.test.tsx
+++ b/src/components/scheme/nodes.stageRow.dom.test.tsx
@@ -1,0 +1,244 @@
+import { afterAll, afterEach, beforeEach, expect, mock, test } from "bun:test";
+import { Window as HappyWindow } from "happy-dom";
+import { flushSync } from "react-dom";
+import { createRoot, type Root } from "react-dom/client";
+
+import type { Pipeline, PipelineStage } from "@/lib/pipelines/types";
+import type { FileEntry } from "@/lib/types";
+import { emptyStore } from "@/components/runtime/runtimeModel";
+
+import type { SchemeLayout, SchemeNode, StageSlot } from "./layout";
+import { SLOT_H, SLOT_ROW_H } from "./layout";
+
+/*
+ * Settled pipeline stages on the board collapse to one status row (#658). A
+ * skipped or completed stage used to render its whole conversation card —
+ * stage-prompt block included — at its stage position, so a chain that had
+ * already walked past two stages read as if all that work were still ahead.
+ */
+
+const dom = new HappyWindow();
+
+class InertResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+function bindDomGlobals() {
+  Object.assign(globalThis, {
+    window: dom,
+    document: dom.document,
+    navigator: dom.navigator,
+    Node: dom.Node,
+    HTMLElement: dom.HTMLElement,
+    HTMLButtonElement: dom.HTMLButtonElement,
+    HTMLInputElement: dom.HTMLInputElement,
+    HTMLSelectElement: dom.HTMLSelectElement,
+    HTMLTextAreaElement: dom.HTMLTextAreaElement,
+    Event: dom.Event,
+    CustomEvent: dom.CustomEvent,
+    MouseEvent: dom.MouseEvent,
+    sessionStorage: dom.sessionStorage,
+    localStorage: dom.localStorage,
+    ResizeObserver: InertResizeObserver,
+    IntersectionObserver: undefined,
+  });
+}
+
+bindDomGlobals();
+
+const actualRuntimeHooks = await import("@/hooks/useRuntime");
+const inertRuntime = { enabled: false, connection: "offline" as const, resyncedAt: null, store: emptyStore() };
+mock.module("@/hooks/useRuntime", () => ({
+  ...actualRuntimeHooks,
+  useRuntimeBusState: () => ({ ...inertRuntime, lastEventAt: null }),
+  useRuntime: () => inertRuntime,
+  useRuntimeSession: () => null,
+  useRuntimeReceiptsForArtifact: () => [],
+  useRuntimeFlow: () => null,
+}));
+
+const actualLogTail = await import("@/hooks/useLogTail");
+mock.module("@/hooks/useLogTail", () => ({
+  useLogTail: () => ({
+    lines: [], linesStart: 0, size: 0, loading: false, error: null, tickTime: null, paused: false,
+    setPaused: () => undefined, clear: () => undefined, hasMore: false, loadingOlder: false,
+    loadOlder: async () => 0, prependGen: 0,
+  }),
+}));
+
+const { NodesLayer } = await import("./nodes");
+
+const roots = new Set<Root>();
+
+beforeEach(bindDomGlobals);
+
+afterAll(() => {
+  mock.module("@/hooks/useRuntime", () => actualRuntimeHooks);
+  mock.module("@/hooks/useLogTail", () => actualLogTail);
+});
+
+afterEach(() => {
+  for (const root of roots) flushSync(() => root.unmount());
+  roots.clear();
+  dom.document.body.replaceChildren();
+});
+
+/* A stage prompt shaped like the real ones: a shared preamble first (the string
+   that used to become every pane's title), the actual instruction after. */
+const stagePrompt = ["Work alone and launch no helpers, workflows, teams or subagents.", "", "Integrate the voice relay."].join("\n");
+
+function stage(id: string, roleId?: string): PipelineStage {
+  return {
+    id,
+    kind: "run",
+    ...(roleId ? { role: { roleId } } : {}),
+    next: null, prompt: stagePrompt,
+    effectiveRole: { roleId: roleId ?? null, engine: "codex", model: null, effort: null, access: "read-write", promptScaffold: null },
+  } as unknown as PipelineStage;
+}
+
+const stages = [stage("plan_v3_voice", "architect"), stage("integrate_v3_voice", "builder"), stage("verify_v3_voice", "verifier")];
+
+function pipeline(over: Partial<Pipeline> = {}): Pipeline {
+  return {
+    id: "p658", task: "V3 voice", project: "project", repoDir: "/r", worktreeDir: "/w", branch: "b",
+    baseBranch: "main", baseRef: "a", lastPassedCommit: "a", stages, runs: [],
+    cursor: { stageId: "integrate_v3_voice", state: "running", input: null, activatedBy: null },
+    state: "running", pausedState: null, stateDetail: null, srcPath: null, srcConversationId: null,
+    createdAt: "1970", closedAt: null, ...over,
+  } as unknown as Pipeline;
+}
+
+function slot(over: Partial<StageSlot> & { stage: PipelineStage; index: number }): StageSlot {
+  return {
+    key: `slot::p658::${over.stage.id}`,
+    pipeline: pipeline(over.pipeline ? { ...over.pipeline } : {}),
+    total: stages.length,
+    presentation: "placeholder",
+    x: 0,
+    y: 0,
+    w: 600,
+    h: SLOT_H,
+    ...over,
+  } as StageSlot;
+}
+
+function layout(slots: StageSlot[]): SchemeLayout {
+  return {
+    nodes: [], edges: [], stacks: [], decks: [], loops: [], groups: [], links: [], drafts: [],
+    slots, regionTasks: [], byPath: new Map(), width: 2000, height: 1000,
+  };
+}
+
+function mountLayer(next: SchemeLayout, pipelines: Pipeline[] = []): { host: HTMLElement; root: Root } {
+  const element = dom.document.createElement("div");
+  dom.document.body.append(element);
+  const host = element as unknown as HTMLElement;
+  const root = createRoot(host);
+  roots.add(root);
+  flushSync(() => {
+    root.render(
+      <NodesLayer
+        layout={next}
+        project="project"
+        files={next.nodes.map((item) => item.file)}
+        pipelines={pipelines}
+        interactive
+        lite={false}
+        dormant
+        selected={null}
+        multi={new Set()}
+        session={false}
+        focus={null}
+        attentionPaths={null}
+        flowsByImpl={new Map()}
+        flows={[]}
+        pipelineStrips={new Map()}
+        linkedTasksByPipeline={new Map()}
+        deckFocus={null}
+        onSelect={() => undefined}
+        onClose={() => undefined}
+        onFocusRound={() => undefined}
+        onDraftClose={() => undefined}
+        onDraftSpawned={() => undefined}
+        onExpand={() => undefined}
+      />,
+    );
+  });
+  return { host, root };
+}
+
+const skippedPipeline = pipeline({
+  runs: [{ stageId: "plan_v3_voice", attempts: [{ n: 1, state: "skipped", output: "Skipped by operator." } as never] }],
+});
+
+test("a skipped stage collapses to one status row — badge, role-first title, why — with no stage-prompt block", () => {
+  const { host } = mountLayer(layout([
+    slot({ stage: stages[0]!, index: 0, pipeline: skippedPipeline, collapsedRow: true, h: SLOT_ROW_H }),
+  ]));
+  const row = host.querySelector('[data-pipeline-stage-row="true"]') as HTMLElement;
+  expect(row).toBeTruthy();
+  expect(row.getAttribute("data-pipeline-stage-state")).toBe("skipped");
+  /* The title is the stage's identity, not the prompt's shared preamble. */
+  expect(row.textContent).toContain("Architect · plan_v3_voice · stage 1/3");
+  expect(row.textContent).toContain("skipped");
+  expect(row.textContent).toContain("Skipped by operator.");
+  expect(row.textContent).not.toContain("Work alone");
+  /* Collapsed means collapsed: no prompt block, and the reserved row height. */
+  expect(host.textContent).not.toContain("Stage prompt");
+  expect((host.querySelector('[data-scheme-node="slot::p658::plan_v3_voice"]') as HTMLElement).style.height).toBe(`${SLOT_ROW_H}px`);
+});
+
+test("the collapsed row discloses the full stage card on demand", () => {
+  const { host } = mountLayer(layout([
+    slot({ stage: stages[0]!, index: 0, pipeline: skippedPipeline, collapsedRow: true, h: SLOT_ROW_H }),
+  ]));
+  const toggle = host.querySelector("button[data-stage-row-toggle]") as HTMLButtonElement;
+  expect(toggle.getAttribute("aria-expanded")).toBe("false");
+  flushSync(() => toggle.dispatchEvent(new dom.MouseEvent("click", { bubbles: true }) as unknown as Event));
+  expect((host.querySelector("button[data-stage-row-toggle]") as HTMLButtonElement).getAttribute("aria-expanded")).toBe("true");
+  /* The full card — prompt included — floats over the board, so the row's own
+     reserved geometry stays one row. */
+  expect(host.textContent).toContain("Stage prompt");
+  expect(host.textContent).toContain("Integrate the voice relay.");
+  /* One surface per declared stage: the identity moves to the disclosed card
+     instead of being claimed twice. */
+  expect(host.querySelectorAll('[data-pipeline-stage-card="p658::plan_v3_voice"]')).toHaveLength(1);
+});
+
+test("a pending stage ahead of the cursor keeps its full card", () => {
+  const { host } = mountLayer(layout([slot({ stage: stages[2]!, index: 2 })]));
+  expect(host.querySelector('[data-pipeline-stage-row="true"]')).toBeNull();
+  expect(host.textContent).toContain("Stage prompt");
+  expect(host.textContent).toContain("Verifier · verify_v3_voice · stage 3/3");
+});
+
+function conversation(path: string, title: string): FileEntry {
+  return {
+    path, root: "codex-sessions", name: path, project: "project", title, engine: "codex", kind: "session",
+    fmt: "codex", parent: null, mtime: 1, size: 1, activity: "live", proc: "running", pid: 1, model: null,
+    pendingQuestion: null, waitingInput: null,
+  } as FileEntry;
+}
+
+function node(file: FileEntry): SchemeNode {
+  return { file, tasks: [], under: [], isRoot: true, x: 0, y: 0, w: 600, h: 780 };
+}
+
+test("a live stage pane is titled role · stage · position, never the prompt's shared preamble", () => {
+  /* The scanner titled this transcript by its opening prompt — the preamble every
+     stage prompt starts with, which named every stage pane on the board the
+     same. The pane leads with the stage identity and keeps the transcript title
+     in its tooltip. */
+  const live = conversation("/integrate", "Work alone and launch no helpers, workflows, teams or subagents.");
+  const running = pipeline({
+    runs: [{ stageId: "integrate_v3_voice", attempts: [{ n: 1, state: "running", agentPath: "/integrate", flowId: null } as never] }],
+  });
+  const { host } = mountLayer({ ...layout([]), nodes: [node(live)] }, [running]);
+  const pane = host.querySelector("[data-pane-title-override]") as HTMLElement;
+  expect(pane).toBeTruthy();
+  expect(pane.textContent).toBe("Builder · integrate_v3_voice · stage 2/3");
+  expect(pane.getAttribute("title")).toContain("Work alone and launch no helpers");
+});

--- a/src/components/scheme/nodes.stageRow.dom.test.tsx
+++ b/src/components/scheme/nodes.stageRow.dom.test.tsx
@@ -39,6 +39,7 @@ function bindDomGlobals() {
     Event: dom.Event,
     CustomEvent: dom.CustomEvent,
     MouseEvent: dom.MouseEvent,
+    KeyboardEvent: dom.KeyboardEvent,
     sessionStorage: dom.sessionStorage,
     localStorage: dom.localStorage,
     ResizeObserver: InertResizeObserver,
@@ -132,7 +133,10 @@ function layout(slots: StageSlot[]): SchemeLayout {
   };
 }
 
-function mountLayer(next: SchemeLayout, pipelines: Pipeline[] = []): { host: HTMLElement; root: Root } {
+/* Escaping a slot key (it carries `::`) for a CSS id selector. */
+const CSS_ESCAPE = (value: string) => value.replace(/[^a-zA-Z0-9_-]/g, (ch) => `\\${ch}`);
+
+function mountLayer(next: SchemeLayout, pipelines: Pipeline[] = [], options: { lite?: boolean } = {}): { host: HTMLElement; root: Root } {
   const element = dom.document.createElement("div");
   dom.document.body.append(element);
   const host = element as unknown as HTMLElement;
@@ -146,7 +150,7 @@ function mountLayer(next: SchemeLayout, pipelines: Pipeline[] = []): { host: HTM
         files={next.nodes.map((item) => item.file)}
         pipelines={pipelines}
         interactive
-        lite={false}
+        lite={options.lite ?? false}
         dormant
         selected={null}
         multi={new Set()}
@@ -184,7 +188,8 @@ test("a skipped stage collapses to one status row — badge, role-first title, w
   /* The title is the stage's identity, not the prompt's shared preamble. */
   expect(row.textContent).toContain("Architect · plan_v3_voice · stage 1/3");
   expect(row.textContent).toContain("skipped");
-  expect(row.textContent).toContain("Skipped by operator.");
+  /* The why-line comes from the catalogue, not from the engine's English marker. */
+  expect(row.textContent).toContain("Skipped by the operator — the chain moved on");
   expect(row.textContent).not.toContain("Work alone");
   /* Collapsed means collapsed: no prompt block, and the reserved row height. */
   expect(host.textContent).not.toContain("Stage prompt");
@@ -206,6 +211,36 @@ test("the collapsed row discloses the full stage card on demand", () => {
   /* One surface per declared stage: the identity moves to the disclosed card
      instead of being claimed twice. */
   expect(host.querySelectorAll('[data-pipeline-stage-card="p658::plan_v3_voice"]')).toHaveLength(1);
+});
+
+test("the disclosure is a real overlay: the toggle names the card it opens, and Escape closes it", () => {
+  /* The disclosed card floats over whatever the board placed below it, so it owes
+     the operator the same way out an overlay does — and the toggle owes assistive
+     tech a pointer to what it controls. */
+  const { host } = mountLayer(layout([
+    slot({ stage: stages[0]!, index: 0, pipeline: skippedPipeline, collapsedRow: true, h: SLOT_ROW_H }),
+  ]));
+  const toggle = host.querySelector("button[data-stage-row-toggle]") as HTMLButtonElement;
+  const controls = toggle.getAttribute("aria-controls")!;
+  expect(controls).toBeTruthy();
+  flushSync(() => toggle.dispatchEvent(new dom.MouseEvent("click", { bubbles: true }) as unknown as Event));
+  /* aria-controls resolves to the card that just appeared. */
+  const card = host.querySelector(`#${CSS_ESCAPE(controls)}`) as HTMLElement;
+  expect(card).toBeTruthy();
+  expect(card.hasAttribute("data-stage-row-card")).toBe(true);
+  expect(card.textContent).toContain("Stage prompt");
+
+  flushSync(() => dom.document.dispatchEvent(new dom.KeyboardEvent("keydown", { key: "Escape", bubbles: true })));
+  expect(host.querySelector("[data-stage-row-card]")).toBeNull();
+  expect((host.querySelector("button[data-stage-row-toggle]") as HTMLButtonElement).getAttribute("aria-expanded")).toBe("false");
+});
+
+test("at map zoom the row is a label, not a control — no disclosure to open", () => {
+  const { host } = mountLayer(layout([
+    slot({ stage: stages[0]!, index: 0, pipeline: skippedPipeline, collapsedRow: true, h: SLOT_ROW_H }),
+  ]), [], { lite: true });
+  expect(host.querySelector('[data-pipeline-stage-row="true"]')).toBeTruthy();
+  expect(host.querySelector("button[data-stage-row-toggle]")).toBeNull();
 });
 
 test("a pending stage ahead of the cursor keeps its full card", () => {

--- a/src/components/scheme/nodes.tsx
+++ b/src/components/scheme/nodes.tsx
@@ -23,7 +23,8 @@ import { PipelineStrip } from "@/components/pipelines/PipelineStrip";
 import { PipelineTemplatePicker } from "@/components/pipelines/PipelineTemplatePicker";
 import { StagePlaceholderPane } from "@/components/pipelines/StagePlaceholderPane";
 import { StageCompletedCard } from "@/components/pipelines/StageCompletedCard";
-import { STAGE_TONES, attemptNavTarget, canSourcePipeline, createDraftPipeline, latestAttempt, optimisticAddStage, patchPipeline, pipelineStagePosition, pipelineStateLabel, renderableFlowIds, resolveStageNavFile, reviewLoopChainValid, stageChipLabel, stageChipState } from "@/components/pipelines/pipelineModel";
+import { StageStatusRow } from "@/components/pipelines/StageStatusRow";
+import { STAGE_TONES, attemptNavTarget, canSourcePipeline, createDraftPipeline, latestAttempt, optimisticAddStage, patchPipeline, pipelineStagePosition, pipelineStateLabel, renderableFlowIds, resolveStageNavFile, reviewLoopChainValid, stageChipLabel, stageChipState, stagePaneTitle } from "@/components/pipelines/pipelineModel";
 import { pushTaskToast } from "@/components/tasks/taskToast";
 import type { TaskRelation } from "@/components/tasks/taskRelations";
 import { MAX_PIPELINE_STAGES } from "@/lib/pipelines/limits";
@@ -52,6 +53,7 @@ import {
   LOOP_GAP,
   NODE_W,
   SLOT_GAP,
+  SLOT_H,
   type DeckNode,
   type DraftNode,
   type FlowLoop,
@@ -941,6 +943,11 @@ function NodeShell({
           isRoot={node.isRoot}
           dormant={dormant}
           showFavorite
+          /* A live stage pane is titled by its place in the chain, not by the
+             first line of its prompt — every stage prompt opens with the same
+             shared preamble, so prompt-derived titles named every pane on the
+             board identically (#658). */
+          titleOverride={pipelineStage ? stagePaneTitle(t, pipelineStage.stage, pipelineStage.index, pipelineStage.total) : undefined}
           onClose={() => onClose(node.file.path)}
           onToggleExpand={() => onExpand(node.file.path)}
           onSpawnRetry={onSpawnRetry}
@@ -1061,8 +1068,45 @@ function DraftShell({
 function StageSlotShell({ slot, lite, dimmed, files, onSelect }: { slot: StageSlot; lite: boolean; dimmed: boolean; files: FileEntry[]; onSelect: (file: FileEntry) => void }) {
   const { t } = useLocale();
   const [busy, setBusy] = useState(false);
+  const [rowOpen, setRowOpen] = useState(false);
   const tone = STAGE_TONES[stageChipState(slot.pipeline, slot.stage)];
   const { pipeline } = slot;
+  /* Settled work — skipped, or completed evidence — collapses to ONE status row
+     at its stage position (#658): the layout reserved exactly that row, and the
+     disclosure floats the full card over the board on demand, so the operator can
+     still read the prompt and open the transcript without the finished stage
+     claiming a pending card's weight. */
+  if (slot.collapsedRow) {
+    const target = slot.attempt ? attemptNavTarget(slot.attempt) : null;
+    const file = target ? resolveStageNavFile(target, files) : null;
+    return (
+      <div
+        data-scheme-node={slot.key}
+        className={`scheme-enter absolute${dimClass(dimmed)} ${rowOpen ? "z-30" : ""}`}
+        style={{ transform: `translate(${slot.x}px, ${slot.y}px)`, width: slot.w, height: slot.h, transition: MOVE_TRANSITION }}
+      >
+        {slot.incoming ? (
+          <span
+            aria-hidden
+            className="absolute top-1/2 z-[2] inline-flex h-6 -translate-x-1/2 -translate-y-1/2 items-center rounded-full border bg-card px-1.5 text-[12px] font-bold shadow-1"
+            style={{ left: -SLOT_GAP / 2, borderColor: tone.color, color: tone.color }}
+          >
+            {slot.incoming === "review-loop" ? "⟳" : "→"}
+          </span>
+        ) : null}
+        <StageStatusRow slot={slot} expanded={rowOpen} onToggle={lite ? undefined : () => setRowOpen((open) => !open)} />
+        {rowOpen ? (
+          <div className="absolute left-0 top-[calc(100%+8px)] z-30 flex" style={{ width: slot.w, height: SLOT_H }}>
+            {slot.presentation === "completed" ? (
+              <StageCompletedCard slot={slot} onOpen={file && !lite ? () => onSelect(file) : undefined} />
+            ) : (
+              <StagePlaceholderPane slot={slot} interactive={!lite} />
+            )}
+          </div>
+        ) : null}
+      </div>
+    );
+  }
   /* A completed stage of an active pipeline renders as a full conversation card
      at its stage position — same footprint as the live and placeholder cards, so
      the group reads as real cards rather than compact history stubs (#507 F2). */

--- a/src/components/scheme/nodes.tsx
+++ b/src/components/scheme/nodes.tsx
@@ -24,7 +24,7 @@ import { PipelineTemplatePicker } from "@/components/pipelines/PipelineTemplateP
 import { StagePlaceholderPane } from "@/components/pipelines/StagePlaceholderPane";
 import { StageCompletedCard } from "@/components/pipelines/StageCompletedCard";
 import { StageStatusRow } from "@/components/pipelines/StageStatusRow";
-import { STAGE_TONES, attemptNavTarget, canSourcePipeline, createDraftPipeline, latestAttempt, optimisticAddStage, patchPipeline, pipelineStagePosition, pipelineStateLabel, renderableFlowIds, resolveStageNavFile, reviewLoopChainValid, stageChipLabel, stageChipState, stagePaneTitle } from "@/components/pipelines/pipelineModel";
+import { STAGE_TONES, attemptNavTarget, canSourcePipeline, createDraftPipeline, optimisticAddStage, patchPipeline, pipelineStagePosition, pipelineStateLabel, renderableFlowIds, resolveStageNavFile, reviewLoopChainValid, stageChipLabel, stageChipState, pipelineStageByAgentPath, stagePaneTitleOf, type PipelineStagePane } from "@/components/pipelines/pipelineModel";
 import { pushTaskToast } from "@/components/tasks/taskToast";
 import type { TaskRelation } from "@/components/tasks/taskRelations";
 import { MAX_PIPELINE_STAGES } from "@/lib/pipelines/limits";
@@ -50,6 +50,7 @@ import { SubagentBadges } from "./SubagentBadges";
 import { SubagentTray, type SubagentTrayApi } from "./SubagentTrayView";
 import type { SubagentBadgeAnchorRegistry } from "./subagentBadgeAnchors";
 import {
+  HANDOFF_BADGE_Y,
   LOOP_GAP,
   NODE_W,
   SLOT_GAP,
@@ -797,7 +798,7 @@ function NodeShell({
       review-loop (the FlowStrip owns that slot). */
   pipeline: Pipeline | null;
   /** The exact pipeline stage represented by this real conversation pane. */
-  pipelineStage: { pipeline: Pipeline; stage: Pipeline["stages"][number]; index: number; total: number } | null;
+  pipelineStage: PipelineStagePane | null;
   /** All flows, for the strip's review-loop round counters + open-review. */
   flows: Flow[];
   files: readonly FileEntry[];
@@ -947,7 +948,7 @@ function NodeShell({
              first line of its prompt — every stage prompt opens with the same
              shared preamble, so prompt-derived titles named every pane on the
              board identically (#658). */
-          titleOverride={pipelineStage ? stagePaneTitle(t, pipelineStage.stage, pipelineStage.index, pipelineStage.total) : undefined}
+          titleOverride={stagePaneTitleOf(t, pipelineStage)}
           onClose={() => onClose(node.file.path)}
           onToggleExpand={() => onExpand(node.file.path)}
           onSpawnRetry={onSpawnRetry}
@@ -1088,8 +1089,8 @@ function StageSlotShell({ slot, lite, dimmed, files, onSelect }: { slot: StageSl
         {slot.incoming ? (
           <span
             aria-hidden
-            className="absolute top-1/2 z-[2] inline-flex h-6 -translate-x-1/2 -translate-y-1/2 items-center rounded-full border bg-card px-1.5 text-[12px] font-bold shadow-1"
-            style={{ left: -SLOT_GAP / 2, borderColor: tone.color, color: tone.color }}
+            className="absolute z-[2] inline-flex h-6 -translate-x-1/2 -translate-y-1/2 items-center rounded-full border bg-card px-1.5 text-[12px] font-bold shadow-1"
+            style={{ left: -SLOT_GAP / 2, top: slot.incomingAnchorY ?? HANDOFF_BADGE_Y, borderColor: tone.color, color: tone.color }}
           >
             {slot.incoming === "review-loop" ? "⟳" : "→"}
           </span>
@@ -1122,8 +1123,8 @@ function StageSlotShell({ slot, lite, dimmed, files, onSelect }: { slot: StageSl
         {slot.incoming ? (
           <span
             aria-hidden
-            className="absolute top-[110px] z-[2] inline-flex h-6 -translate-x-1/2 -translate-y-1/2 items-center rounded-full border bg-card px-1.5 text-[12px] font-bold shadow-1"
-            style={{ left: -SLOT_GAP / 2, borderColor: tone.color, color: tone.color }}
+            className="absolute z-[2] inline-flex h-6 -translate-x-1/2 -translate-y-1/2 items-center rounded-full border bg-card px-1.5 text-[12px] font-bold shadow-1"
+            style={{ left: -SLOT_GAP / 2, top: slot.incomingAnchorY ?? HANDOFF_BADGE_Y, borderColor: tone.color, color: tone.color }}
           >
             {slot.incoming === "review-loop" ? "⟳" : "→"}
           </span>
@@ -1164,8 +1165,8 @@ function StageSlotShell({ slot, lite, dimmed, files, onSelect }: { slot: StageSl
       {slot.incoming ? (
         <span
           aria-hidden
-          className="absolute top-[110px] z-[2] inline-flex h-6 -translate-x-1/2 -translate-y-1/2 items-center rounded-full border bg-card px-1.5 text-[12px] font-bold shadow-1"
-          style={{ left: -SLOT_GAP / 2, borderColor: tone.color, color: tone.color }}
+          className="absolute z-[2] inline-flex h-6 -translate-x-1/2 -translate-y-1/2 items-center rounded-full border bg-card px-1.5 text-[12px] font-bold shadow-1"
+          style={{ left: -SLOT_GAP / 2, top: slot.incomingAnchorY ?? HANDOFF_BADGE_Y, borderColor: tone.color, color: tone.color }}
         >
           {slot.incoming === "review-loop" ? "⟳" : "→"}
         </span>
@@ -1337,19 +1338,9 @@ export const NodesLayer = memo(function NodesLayer({
   /* Paths still in the scan; a run stage action is disabled once its transcript
      leaves the file set (AC4). */
   const renderablePaths = useMemo(() => new Set(files.map((entry) => entry.path)), [files]);
-  const pipelineStageByPath = useMemo(() => {
-    const map = new Map<string, { pipeline: Pipeline; stage: Pipeline["stages"][number]; index: number; total: number }>();
-    for (const pipeline of pipelines) {
-      if (pipeline.state === "closed") continue;
-      for (let index = 0; index < pipeline.stages.length; index += 1) {
-        const stage = pipeline.stages[index]!;
-        const attempt = latestAttempt(pipeline, stage.id);
-        if (!attempt?.agentPath) continue;
-        map.set(attempt.agentPath, { pipeline, stage, index, total: pipeline.stages.length });
-      }
-    }
-    return map;
-  }, [pipelines]);
+  /* Which stage each live transcript runs — the shared index (#658), so the
+     board node and the full-window overlay name a stage pane identically. */
+  const pipelineStageByPath = useMemo(() => pipelineStageByAgentPath(pipelines), [pipelines]);
   /* Activity ranking reaches the screen through each host's x/y transform.
      Stable sibling order keeps React from moving stateful hosts in the DOM,
      preserving scroll, focus, selection, and draft/deck state. */

--- a/src/components/scheme/nodes.tsx
+++ b/src/components/scheme/nodes.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Check, Layers } from "lucide-react";
-import { memo, useMemo, useState } from "react";
+import { memo, useEffect, useMemo, useState } from "react";
 
 import { ChevronRight } from "@/components/icons";
 import { conversationIdentity } from "@/lib/accounts/identity";
@@ -1055,6 +1055,29 @@ function DraftShell({
 }
 
 /**
+ * Escape for a board disclosure (#658). Mounted only while its disclosure is
+ * open, capture-phase so the innermost open thing wins, and it stops propagation
+ * so the same key does not also clear the canvas selection underneath. Text
+ * fields keep their own Escape — the disclosed stage card carries a prompt
+ * editor.
+ */
+function EscapeToClose({ onClose }: { onClose: () => void }) {
+  useEffect(() => {
+    const onKey = (event: KeyboardEvent) => {
+      if (event.key !== "Escape") return;
+      const el = event.target as HTMLElement | null;
+      if (el && (["INPUT", "TEXTAREA", "SELECT"].includes(el.tagName) || el.isContentEditable)) return;
+      event.preventDefault();
+      event.stopPropagation();
+      onClose();
+    };
+    window.addEventListener("keydown", onKey, true);
+    return () => window.removeEventListener("keydown", onKey, true);
+  }, [onClose]);
+  return null;
+}
+
+/**
  * A planned pipeline stage's dashed placeholder window as a scheme citizen
  * (issue #196): the SAME draft-agent window recipe, plus the handoff badge
  * riding the gap to its left when the previous stage's slot sits directly
@@ -1080,6 +1103,7 @@ function StageSlotShell({ slot, lite, dimmed, files, onSelect }: { slot: StageSl
   if (slot.collapsedRow) {
     const target = slot.attempt ? attemptNavTarget(slot.attempt) : null;
     const file = target ? resolveStageNavFile(target, files) : null;
+    const cardId = `${slot.key}::card`;
     return (
       <div
         data-scheme-node={slot.key}
@@ -1095,9 +1119,27 @@ function StageSlotShell({ slot, lite, dimmed, files, onSelect }: { slot: StageSl
             {slot.incoming === "review-loop" ? "⟳" : "→"}
           </span>
         ) : null}
-        <StageStatusRow slot={slot} expanded={rowOpen} onToggle={lite ? undefined : () => setRowOpen((open) => !open)} />
+        {/* At map zoom the row is a label, not a control: card text is unreadable
+            there anyway and the transcript link is already inert, so the
+            disclosure asks the operator to zoom in rather than opening a 620px
+            card nobody can read. */}
+        <StageStatusRow
+          slot={slot}
+          expanded={rowOpen}
+          controls={cardId}
+          onToggle={lite ? undefined : () => setRowOpen((open) => !open)}
+        />
         {rowOpen ? (
-          <div className="absolute left-0 top-[calc(100%+8px)] z-30 flex" style={{ width: slot.w, height: SLOT_H }}>
+          /* The disclosed card floats over whatever the board placed below, so it
+             behaves like the overlay it is: Escape closes it, same as the
+             full-window pane and the canvas selection. */
+          <div
+            id={cardId}
+            data-stage-row-card
+            className="absolute left-0 top-[calc(100%+8px)] z-30 flex"
+            style={{ width: slot.w, height: SLOT_H }}
+          >
+            <EscapeToClose onClose={() => setRowOpen(false)} />
             {slot.presentation === "completed" ? (
               <StageCompletedCard slot={slot} onOpen={file && !lite ? () => onSelect(file) : undefined} />
             ) : (

--- a/src/components/scheme/renameRequest.test.ts
+++ b/src/components/scheme/renameRequest.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "bun:test";
 
-import { autoEditTokenFor, clearStaleRename, requestRename, type RenameRequest } from "./renameRequest";
+import { autoEditTokenFor, clearStaleRename, requestRename, titleUnderRename, type RenameRequest } from "./renameRequest";
 
 test("F2 opens the expanded node, and a plain re-expand after close does not replay", () => {
   let request: RenameRequest = null;
@@ -36,4 +36,20 @@ test("a request for one node never leaks to another expanded node", () => {
 test("a matching request survives an unrelated re-render (still expanded)", () => {
   const request = requestRename(null, "A");
   expect(clearStaleRename(request, "A")).toBe(request);
+});
+
+test("an imposed stage title yields to a pending rename, so the F2 editor still mounts (#658)", () => {
+  const stageTitle = "Builder · integrate_v3_voice · stage 2/3";
+  /* No rename in flight: the expanded stage pane carries its imposed identity
+     instead of the prompt-derived transcript title. */
+  expect(titleUnderRename(stageTitle, undefined)).toBe(stageTitle);
+  /* F2 replayed into this overlay: the override steps aside for exactly as long
+     as the token lives, so SessionTitle — the last rename path a stage
+     transcript has — is mounted and editable. */
+  const request: RenameRequest = requestRename(null, "/integrate");
+  expect(titleUnderRename(stageTitle, autoEditTokenFor(request, "/integrate"))).toBeUndefined();
+  /* A rename aimed at another node never suppresses this pane's identity. */
+  expect(titleUnderRename(stageTitle, autoEditTokenFor(request, "/other"))).toBe(stageTitle);
+  /* A non-stage pane has no imposed title either way. */
+  expect(titleUnderRename(undefined, undefined)).toBeUndefined();
 });

--- a/src/components/scheme/renameRequest.ts
+++ b/src/components/scheme/renameRequest.ts
@@ -22,3 +22,12 @@ export function clearStaleRename(prev: RenameRequest, expandedPath: string | nul
 export function autoEditTokenFor(request: RenameRequest, expandedPath: string | null): number | undefined {
   return request && expandedPath !== null && request.path === expandedPath ? request.token : undefined;
 }
+
+/** An imposed pane title (a pipeline stage's «role · stage · position», #658)
+    yields to a pending rename: the F2 editor is the expanded pane's SessionTitle,
+    and an override replaces it, so the override is dropped exactly while a token
+    is live. Without this, imposing an identity on a stage pane would silently
+    remove the last rename path those transcripts have. */
+export function titleUnderRename(title: string | undefined, autoEditToken: number | undefined): string | undefined {
+  return autoEditToken === undefined ? title : undefined;
+}

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -1144,8 +1144,8 @@ export const en = {
   "pipelineGroup.openHistory": "Open pipeline history for {task}",
 
   // pipeline stage placeholders + template picker (#196)
-  "pipelineSlot.paneAria": "Planned stage {role}",
-  "pipelineSlot.completedAria": "Completed stage {role} — open to review",
+  "pipelineSlot.paneAria": "Planned stage {title}",
+  "pipelineSlot.completedAria": "Completed stage {title} — open to review",
   "pipelineSlot.openTranscript": "Open conversation",
   "pipelineSlot.stageOf": "stage {k}/{n}",
   "pipelineSlot.promptLabel": "Stage prompt",

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -1157,6 +1157,10 @@ export const en = {
   "pipelineSlot.reviewHint": "Review cycle over the previous stage — its rounds land here.",
   "pipelineSlot.frozen": "This stage already ran — its configuration is locked.",
   "pipelineSlot.saved": "Saved",
+  // settled stages collapsed to one status row (#658)
+  "pipelineSlot.rowAria": "Finished stage {title}",
+  "pipelineSlot.rowExpand": "Show the full stage card",
+  "pipelineSlot.rowCollapse": "Collapse back to the status row",
   "pipelineTemplates.planBuildReview": "Plan → Build → Review",
   "pipelineTemplates.buildReview": "Build → Review",
   "pipelineTemplates.buildVerify": "Build → Verify",

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -1159,6 +1159,7 @@ export const en = {
   "pipelineSlot.saved": "Saved",
   // settled stages collapsed to one status row (#658)
   "pipelineSlot.rowAria": "Finished stage {title}",
+  "pipelineSlot.reasonSkipped": "Skipped by the operator — the chain moved on",
   "pipelineSlot.rowExpand": "Show the full stage card",
   "pipelineSlot.rowCollapse": "Collapse back to the status row",
   "pipelineTemplates.planBuildReview": "Plan → Build → Review",

--- a/src/lib/i18n/uk.ts
+++ b/src/lib/i18n/uk.ts
@@ -1128,6 +1128,7 @@ export const uk: Record<keyof typeof en, Message> = {
   "pipelineSlot.saved": "Збережено",
   // згорнуті завершені стадії в один рядок статусу (#658)
   "pipelineSlot.rowAria": "Завершений етап {title}",
+  "pipelineSlot.reasonSkipped": "Пропущено оператором — ланцюжок пішов далі",
   "pipelineSlot.rowExpand": "Показати повну картку етапу",
   "pipelineSlot.rowCollapse": "Згорнути назад до рядка статусу",
   "pipelineTemplates.planBuildReview": "План → Збірка → Рев’ю",

--- a/src/lib/i18n/uk.ts
+++ b/src/lib/i18n/uk.ts
@@ -1126,6 +1126,10 @@ export const uk: Record<keyof typeof en, Message> = {
   "pipelineSlot.reviewHint": "Цикл рев’ю попереднього етапу — його раунди з’являться тут.",
   "pipelineSlot.frozen": "Етап уже виконувався — конфігурацію заморожено.",
   "pipelineSlot.saved": "Збережено",
+  // згорнуті завершені стадії в один рядок статусу (#658)
+  "pipelineSlot.rowAria": "Завершений етап {title}",
+  "pipelineSlot.rowExpand": "Показати повну картку етапу",
+  "pipelineSlot.rowCollapse": "Згорнути назад до рядка статусу",
   "pipelineTemplates.planBuildReview": "План → Збірка → Рев’ю",
   "pipelineTemplates.buildReview": "Збірка → Рев’ю",
   "pipelineTemplates.buildVerify": "Збірка → Перевірка",

--- a/src/lib/i18n/uk.ts
+++ b/src/lib/i18n/uk.ts
@@ -1113,8 +1113,8 @@ export const uk: Record<keyof typeof en, Message> = {
   "pipelineGroup.openHistory": "Відкрити історію пайплайна {task}",
 
   // плейсхолдери етапів пайплайна + вибір шаблону (#196)
-  "pipelineSlot.paneAria": "Запланований етап {role}",
-  "pipelineSlot.completedAria": "Завершений етап {role} — відкрийте для перегляду",
+  "pipelineSlot.paneAria": "Запланований етап {title}",
+  "pipelineSlot.completedAria": "Завершений етап {title} — відкрийте для перегляду",
   "pipelineSlot.openTranscript": "Відкрити розмову",
   "pipelineSlot.stageOf": "етап {k}/{n}",
   "pipelineSlot.promptLabel": "Промпт стадії",


### PR DESCRIPTION
## What was wrong

Three separate things made a running pipeline hard to read on the board:

1. Every live pane's title was the first line of its stage prompt, and every prompt opened with the same shared preamble — so every pane on the board carried the same meaningless title.
2. A skipped or completed stage rendered at full weight, prompt block included, so finished work read as still ahead.
3. Stage order flowed bottom-up: the auto-layout placed spawned panes above the pipeline node, putting stage 1 at the bottom and the active stage at the top.

## The commits

**`e01703fc`** — pane titles derive from role, stage id and position and ignore the prompt entirely, so a generic first line cannot leak; settled stages collapse to a status row that expands on demand; stages lay out in execution order.

**`ad801e12`** — closes the back door the first review found: `titleOverride` reached only the board node, so expanding a stage to the full window put the operator back in front of the preamble, in the header and in the dialog's accessible name. The overlay now carries the same identity, with the rename editor kept alive — an unconditional override would have silently killed the only rename path for stage transcripts.

**`cbcd040b`** — closes what the second review found: the execution-order ranking read from plans that a slot/task filter drops one screen earlier, so ordering reverted to reverse-recency the moment every stage had launched, which is exactly when a long pipeline is read most. Ranks now come from the pipeline itself, independent of whether the plan survives that filter.

## Review

Three independent read-only rounds: REQUEST_CHANGES, REQUEST_CHANGES, then **APPROVE**. The third round left four LOW comments, none blocking: Escape closes every open disclosure rather than the innermost, an already-open disclosure has no close affordance at map zoom, the reason tooltip repeats an already-truncated string, and one comment over-claims its reach.

Each round's reviewer verified revert-sensitivity explicitly — for the ordering fix, by running the same scene through the layout with and without stage ranks.

## Verification

Touched tests pass by path, `tsc --noEmit` clean, `lint` adds no new problems, privacy gate green. i18n keys inserted in both catalogues at the same position, no reordering.

Closes #658