### PR TITLE
fix(board): agent chips report real activity, not process liveness (#669)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ versions follow [SemVer](https://semver.org/) (0.x — the API may still move).
 ## [Unreleased]
 
 ### Fixed
+- Agent chips on the conversation canvas report the agent's real output, not
+  the state of its process (#669). Chip activity now derives from how long ago
+  the conversation's transcript last grew, so a lane appending records every
+  few seconds reads as working however stale the snapshot's own activity
+  verdict has become, and a host that stayed alive with nothing to say gets its
+  own state — «alive but silent» after five minutes of transcript silence, a
+  steady warning ring and its own tray dot, told apart from both working and
+  finished. The chips carry a ticking clock, so a state change settles in
+  place: a wedged host leaves the working state with no reload and no new scan,
+  and a batch change (several conversations killed at once) settles every chip
+  from the one poll that carries it.
 - Multi-gigabyte active transcripts no longer starve the Viewer (#287). One
   process-wide scan coordinator now owns every catalog generation: the HTTP
   files cache, the pipeline watchdog, and the account controller join or queue

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,11 +14,14 @@ versions follow [SemVer](https://semver.org/) (0.x — the API may still move).
   verdict has become, and a host that stayed alive with nothing to say gets its
   own state — «alive but silent» after five minutes of transcript silence, a
   steady warning ring and its own tray dot, told apart from both working and
-  finished. Silence never claims completion while anything could still write:
-  an in-harness subagent owns no process of its own, so its open turn keeps a
-  six-minute tool call reading as silent instead of finished. The chips carry a
-  ticking clock, so a state change settles in place: a wedged host leaves the
-  working state with no reload and no new scan, and a batch change (several
+  finished. What the silence means is settled by the transcript's last turn,
+  never by its age: a turn still open keeps the chip amber (an in-harness
+  subagent owns no process of its own, so its open turn is what carries a
+  six-minute tool call through), while a turn that ended cleanly reads as done
+  even with the host still attached — so a delivered worker greys out instead
+  of sitting amber beside a genuinely wedged one. The chips carry a ticking
+  clock, so a state change settles in place: a wedged host leaves the working
+  state with no reload and no new scan, and a batch change (several
   conversations killed at once) settles every chip from the one poll that
   carries it.
 - Multi-gigabyte active transcripts no longer starve the Viewer (#287). One

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,10 +14,13 @@ versions follow [SemVer](https://semver.org/) (0.x — the API may still move).
   verdict has become, and a host that stayed alive with nothing to say gets its
   own state — «alive but silent» after five minutes of transcript silence, a
   steady warning ring and its own tray dot, told apart from both working and
-  finished. The chips carry a ticking clock, so a state change settles in
-  place: a wedged host leaves the working state with no reload and no new scan,
-  and a batch change (several conversations killed at once) settles every chip
-  from the one poll that carries it.
+  finished. Silence never claims completion while anything could still write:
+  an in-harness subagent owns no process of its own, so its open turn keeps a
+  six-minute tool call reading as silent instead of finished. The chips carry a
+  ticking clock, so a state change settles in place: a wedged host leaves the
+  working state with no reload and no new scan, and a batch change (several
+  conversations killed at once) settles every chip from the one poll that
+  carries it.
 - Multi-gigabyte active transcripts no longer starve the Viewer (#287). One
   process-wide scan coordinator now owns every catalog generation: the HTTP
   files cache, the pipeline watchdog, and the account controller join or queue

--- a/src/components/ProjectDashboard.tsx
+++ b/src/components/ProjectDashboard.tsx
@@ -689,7 +689,9 @@ export function ProjectDashboard({
       hiddenPaths,
       claimedPaths,
       hostEligibleParentIds,
-      now: nowMs,
+      /* Epoch SECONDS: the projection compares this against transcript `mtime`
+         (chip freshness, attention TTLs), which is seconds. */
+      now: nowMs / 1000,
     });
   }, [baseGroups, prefs.hidden, prefs.manual, board.prefs.foldedEngineChildIds, board.prefs.expandedEngineTrayParentIds, filesByPath, project, files, compactPipelinePaths, collapsedPaths, launchHistoryPaths, pinnedPaths, nowMs]);
   const groups = useMemo(

--- a/src/components/ProjectDashboard.tsx
+++ b/src/components/ProjectDashboard.tsx
@@ -8,6 +8,7 @@ import { queueColumnOpen, useBoardState } from "@/hooks/useBoardState";
 import { FavoritesProvider, type FavoritesApi } from "./favorites/FavoritesContext";
 import { resolveFavoriteRows } from "./favorites/favoriteRows";
 import { useIsMobile } from "@/hooks/useIsMobile";
+import { useNowSeconds } from "@/hooks/useNowSeconds";
 import { viewBus } from "@/hooks/viewPresenceBus";
 import { projectDisplayName } from "@/lib/displayNames";
 import type { Flow } from "@/lib/flows/types";
@@ -70,6 +71,10 @@ import { ResidualStrip } from "./TreeAside";
 
 /** How long an opened node keeps its highlight ring on the scheme. */
 const HIGHLIGHT_MS = 1800;
+
+/** Cadence of the board's wall clocks — the idle windows they drive are
+    minutes wide, so both the millisecond and the seconds clock tick here. */
+const BOARD_CLOCK_MS = 30_000;
 
 interface Props {
   files: FileEntry[];
@@ -405,6 +410,12 @@ export function ProjectDashboard({
      the first tick lands the real time, and reviewer verdicts collapse without
      waiting on the clock at all. */
   const [nowMs, setNowMs] = useState(0);
+  /* The subagent-tray projection measures transcript freshness and attention
+     TTLs against `mtime`, which is SECONDS. It takes the seconds clock
+     straight from the shared hook rather than a conversion of `nowMs` — the
+     unit is then carried by the type (`EpochSeconds`), so a millisecond clock
+     cannot reach it by an edit that reads plausibly (issue #669). */
+  const nowSeconds = useNowSeconds(BOARD_CLOCK_MS);
   const projectCwdFallbacks = useMemo(() => [
     ...pipelines.filter((pipeline) => pipeline.project === project).map((pipeline) => pipeline.repoDir),
     ...workflows.filter((workflow) => workflow.project === project).map((workflow) => workflow.repoDir),
@@ -420,7 +431,7 @@ export function ProjectDashboard({
   useEffect(() => {
     const tick = () => setNowMs(Date.now());
     tick();
-    const id = window.setInterval(tick, 30_000);
+    const id = window.setInterval(tick, BOARD_CLOCK_MS);
     return () => window.clearInterval(id);
   }, []);
 
@@ -689,11 +700,9 @@ export function ProjectDashboard({
       hiddenPaths,
       claimedPaths,
       hostEligibleParentIds,
-      /* Epoch SECONDS: the projection compares this against transcript `mtime`
-         (chip freshness, attention TTLs), which is seconds. */
-      now: nowMs / 1000,
+      now: nowSeconds,
     });
-  }, [baseGroups, prefs.hidden, prefs.manual, board.prefs.foldedEngineChildIds, board.prefs.expandedEngineTrayParentIds, filesByPath, project, files, compactPipelinePaths, collapsedPaths, launchHistoryPaths, pinnedPaths, nowMs]);
+  }, [baseGroups, prefs.hidden, prefs.manual, board.prefs.foldedEngineChildIds, board.prefs.expandedEngineTrayParentIds, filesByPath, project, files, compactPipelinePaths, collapsedPaths, launchHistoryPaths, pinnedPaths, nowSeconds]);
   const groups = useMemo(
     () => (engineProjection.promotedPaths.size || engineProjection.foldedPaths.size
       ? buildBranchGroups(sceneFiles, project, {

--- a/src/components/scheme/SubagentBadges.dom.test.tsx
+++ b/src/components/scheme/SubagentBadges.dom.test.tsx
@@ -72,6 +72,34 @@ function mount(entries: FileEntry[], onNavigate: (id: string) => void) {
   return host;
 }
 
+/** Mount with an explicit clock (epoch seconds) and keep the handle to
+    re-render — the surface must settle on new state in place, never through a
+    remount or a reload (issue #669). */
+function mountWithClock(entries: FileEntry[], now: number) {
+  const element = dom.document.createElement("div");
+  dom.document.body.append(element);
+  const host = element as unknown as HTMLElement;
+  const root = createRoot(host);
+  roots.add(root);
+  const render = (nextEntries: FileEntry[], nextNow: number) => {
+    flushSync(() => {
+      root.render(
+        <SubagentBadges
+          conversationId="parent"
+          entries={nextEntries}
+          cardRect={{ x: 100, y: 200, w: 600, h: 70 }}
+          onNavigate={() => undefined}
+          now={nextNow}
+        />,
+      );
+    });
+  };
+  render(entries, now);
+  const stateOf = (id: string) =>
+    (host.querySelector(`[data-subagent-badge="${id}"]`) as HTMLButtonElement | null)?.dataset.subagentState;
+  return { host, render, stateOf };
+}
+
 test("hover expands a subagent circle to its title and click navigates by current transcript path", async () => {
   const navigated: string[] = [];
   const parent = entry({ path: "/parent", conversationId: "parent" });
@@ -244,4 +272,67 @@ test("removing the expanded child releases the parent card foreground layer", as
   await Bun.sleep(0);
   await Bun.sleep(0);
   expect(expandedStates.at(-1)).toBe(false);
+});
+
+// ── chip activity from transcript freshness (issue #669) ────────────────────
+
+const NOW = 1_800_000_000;
+
+test("each chip renders its own reading: writing pulses, alive-but-silent rings steady, finished dims", () => {
+  const parent = entry({ path: "/parent", conversationId: "parent" });
+  /* All three hosts look identical to a liveness check — the transcript is the
+     only thing that tells them apart. */
+  const writing = entry({ path: "/writing", conversationId: "writing", parent: parent.path, title: "Writing worker", proc: "running", activity: "idle", mtime: NOW - 3 });
+  const wedged = entry({ path: "/wedged", conversationId: "wedged", parent: parent.path, title: "Wedged worker", proc: "running", activity: "stalled", mtime: NOW - 7.5 * 3600 });
+  const finished = entry({ path: "/finished", conversationId: "finished", parent: parent.path, title: "Finished worker", proc: "done", mtime: NOW - 60 });
+  const { host } = mountWithClock([parent, writing, wedged, finished], NOW);
+  const badge = (id: string) => host.querySelector(`[data-subagent-badge="${id}"]`) as HTMLButtonElement;
+
+  expect(badge("writing").dataset.subagentState).toBe("running");
+  expect(badge("writing").querySelector('[data-subagent-ring="working"]')).toBeTruthy();
+  expect(badge("writing").className).not.toContain("opacity-45");
+
+  expect(badge("wedged").dataset.subagentState).toBe("silent");
+  const silentRing = badge("wedged").querySelector('[data-subagent-ring="silent"]') as HTMLElement;
+  expect(silentRing).toBeTruthy();
+  /* Distinct from working: a steady warning ring, no pulse. */
+  expect(silentRing.className).toContain("ring-warning");
+  expect(silentRing.className).not.toContain("animate-pulse");
+  expect(badge("wedged").querySelector('[data-subagent-ring="working"]')).toBeNull();
+  /* Distinct from finished: still lit, and it says why. */
+  expect(badge("wedged").className).not.toContain("opacity-45");
+  expect(badge("wedged").title).toContain("alive but silent");
+
+  expect(badge("finished").dataset.subagentState).toBe("closed");
+  expect(badge("finished").querySelector("[data-subagent-ring]")).toBeNull();
+  expect(badge("finished").className).toContain("opacity-45");
+});
+
+test("the chip leaves the working state on transcript silence alone — no new scan, no reload", () => {
+  const parent = entry({ path: "/parent", conversationId: "parent" });
+  const worker = entry({ path: "/worker", conversationId: "worker", parent: parent.path, title: "Worker", proc: "running", activity: "live", mtime: NOW - 10 });
+  const entries = [parent, worker];
+  const { render, stateOf } = mountWithClock(entries, NOW);
+  expect(stateOf("worker")).toBe("running");
+
+  /* A two-minute think must not flicker the chip. */
+  render(entries, NOW + 120);
+  expect(stateOf("worker")).toBe("running");
+
+  /* The very same snapshot, only the clock moved past the silence threshold. */
+  render(entries, NOW + 600);
+  expect(stateOf("worker")).toBe("silent");
+});
+
+test("a batch status change settles every chip in place", () => {
+  const parent = entry({ path: "/parent", conversationId: "parent" });
+  const ids = ["a", "b", "c"];
+  const running = ids.map((id) => entry({ path: `/${id}`, conversationId: id, parent: parent.path, title: `Worker ${id}`, proc: "running", mtime: NOW - 5 }));
+  const { render, stateOf } = mountWithClock([parent, ...running], NOW);
+  expect(ids.map(stateOf)).toEqual(["running", "running", "running"]);
+
+  /* Several conversations killed at once — one poll carries them all. */
+  const killed = running.map((file) => ({ ...file, proc: "killed" as const }));
+  render([parent, ...killed], NOW + 1);
+  expect(ids.map(stateOf)).toEqual(["closed", "closed", "closed"]);
 });

--- a/src/components/scheme/SubagentBadges.dom.test.tsx
+++ b/src/components/scheme/SubagentBadges.dom.test.tsx
@@ -3,6 +3,7 @@ import { Window } from "happy-dom";
 import { flushSync } from "react-dom";
 import { createRoot, type Root } from "react-dom/client";
 
+import { setLocale, translate } from "@/lib/i18n";
 import type { FileEntry } from "@/lib/types";
 
 import { SubagentBadges } from "./SubagentBadges";
@@ -360,4 +361,64 @@ test("a busy in-harness subagent gone quiet keeps a lit chip: ringed, not greyed
   expect(badge.querySelector('[data-subagent-ring="silent"]')).toBeTruthy();
   expect(badge.className).not.toContain("opacity-45");
   expect(badge.className).not.toContain("grayscale");
+});
+
+test("a finished agent whose host stayed attached reads done: dimmed, no ring", () => {
+  /* The counterpart of the wedged chip above — same live process, same hour of
+     silence, opposite turn. They must not paint the same. */
+  const parent = entry({ path: "/parent", conversationId: "parent" });
+  const finished = entry({
+    path: "/finished",
+    conversationId: "finished",
+    parent: parent.path,
+    title: "Delivered worker",
+    proc: "running",
+    mtime: NOW - 3_600,
+    authoritativeTurn: { state: "terminal", source: "assistant", terminalAt: "2026-07-25T00:00:00Z" },
+  });
+  const wedged = entry({
+    path: "/wedged",
+    conversationId: "wedged",
+    parent: parent.path,
+    title: "Wedged worker",
+    proc: "running",
+    mtime: NOW - 3_600,
+    authoritativeTurn: { state: "busy", source: "assistant", terminalAt: null },
+  });
+  const { host } = mountWithClock([parent, finished, wedged], NOW);
+  const badge = (id: string) => host.querySelector(`[data-subagent-badge="${id}"]`) as HTMLButtonElement;
+
+  expect(badge("finished").dataset.subagentState).toBe("closed");
+  expect(badge("finished").querySelector("[data-subagent-ring]")).toBeNull();
+  expect(badge("finished").className).toContain("opacity-45");
+  expect(badge("wedged").dataset.subagentState).toBe("silent");
+  expect(badge("wedged").querySelector('[data-subagent-ring="silent"]')).toBeTruthy();
+});
+
+test("the unavailable note comes from the catalogue, so the tooltip is not half-translated", () => {
+  const parent = entry({ path: "/parent", conversationId: "parent" });
+  const dead = entry({
+    path: "/dead",
+    conversationId: "dead",
+    parent: parent.path,
+    title: "Removed worker",
+    spawn: {
+      launchId: "launch-dead",
+      clientAttemptId: null,
+      accountId: null,
+      state: "failed",
+      initialMessage: "failed",
+      retrySafe: false,
+      error: "no host",
+    },
+  });
+  setLocale("uk");
+  try {
+    const { host } = mountWithClock([parent, dead], NOW);
+    const badge = host.querySelector('[data-subagent-badge="dead"]') as HTMLButtonElement;
+    expect(badge.title).toContain(translate("uk", "subagentTray.state.dead"));
+    expect(badge.title).not.toContain("unavailable");
+  } finally {
+    setLocale("en");
+  }
 });

--- a/src/components/scheme/SubagentBadges.dom.test.tsx
+++ b/src/components/scheme/SubagentBadges.dom.test.tsx
@@ -336,3 +336,28 @@ test("a batch status change settles every chip in place", () => {
   render([parent, ...killed], NOW + 1);
   expect(ids.map(stateOf)).toEqual(["closed", "closed", "closed"]);
 });
+
+test("a busy in-harness subagent gone quiet keeps a lit chip: ringed, not greyed out", () => {
+  /* No pid of its own (its parent's process writes the transcript) and no
+     record for ten minutes because a tool call is running. Reading that as
+     finished is the #669 bug on a five-minute clock. */
+  const parent = entry({ path: "/parent", conversationId: "parent" });
+  const subagent = entry({
+    path: "/proj/parent/subagents/agent-abc.jsonl",
+    conversationId: "sub",
+    parent: parent.path,
+    title: "Tool-call worker",
+    engine: "claude",
+    proc: null,
+    activity: "stalled",
+    mtime: NOW - 600,
+    authoritativeTurn: { state: "busy", source: "assistant", terminalAt: null },
+  });
+  const { host } = mountWithClock([parent, subagent], NOW);
+  const badge = host.querySelector('[data-subagent-badge="sub"]') as HTMLButtonElement;
+
+  expect(badge.dataset.subagentState).toBe("silent");
+  expect(badge.querySelector('[data-subagent-ring="silent"]')).toBeTruthy();
+  expect(badge.className).not.toContain("opacity-45");
+  expect(badge.className).not.toContain("grayscale");
+});

--- a/src/components/scheme/SubagentBadges.tsx
+++ b/src/components/scheme/SubagentBadges.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useMemo, useRef, useState } from "react";
 
+import { useNowSeconds } from "@/hooks/useNowSeconds";
 import type { FileEntry } from "@/lib/types";
 import { useLocale } from "@/lib/i18n";
 
@@ -25,6 +26,10 @@ export interface SubagentBadgesProps {
   exclude?: ReadonlySet<string>;
   /** Hand-fold a promoted child into the parent tray (a durable fold pin). */
   onFold?: (id: string, path: string) => void;
+  /** Epoch SECONDS, for chip activity. Omitted outside tests: the component
+      then owns a ticking clock so a chip leaves the working state on transcript
+      silence alone, with no reload and no new scan (issue #669). */
+  now?: number;
 }
 
 function seedHue(seed: string): number {
@@ -38,12 +43,14 @@ function initials(title: string): string {
   return (words.length > 1 ? words[0]![0]! + words.at(-1)![0]! : words[0]?.slice(0, 2) || "AI").toUpperCase();
 }
 
-export function SubagentBadges({ conversationId, entries, cardRect, onNavigate, onExpandedChange, anchorRegistry, exclude, onFold }: SubagentBadgesProps) {
+export function SubagentBadges({ conversationId, entries, cardRect, onNavigate, onExpandedChange, anchorRegistry, exclude, onFold, now }: SubagentBadgesProps) {
   const { t } = useLocale();
   const foldLabel = (name: string) => t("subagentTray.fold", { name });
   const [expandedId, setExpandedId] = useState<string | null>(null);
   const suppressTouchClick = useRef(false);
-  const children = useMemo(() => subagentsOf(conversationId, entries, exclude), [conversationId, entries, exclude]);
+  const clock = useNowSeconds();
+  const at = now ?? clock;
+  const children = useMemo(() => subagentsOf(conversationId, entries, exclude, at), [conversationId, entries, exclude, at]);
   const positions = useMemo(() => layoutBadges(children, cardRect), [children, cardRect]);
   const hasExpandedChild = expandedId !== null && children.some((child) => child.id === expandedId);
 
@@ -92,7 +99,15 @@ export function SubagentBadges({ conversationId, entries, cardRect, onNavigate, 
         const unavailable = child.state === "dead";
         const dimmed = unavailable || child.state === "closed";
         const hue = seedHue(child.avatarSeed);
-        const tooltip = `${child.title} · ${child.engine}${child.model ? ` / ${child.model}` : ""}${unavailable ? " · unavailable" : ""}`;
+        /* Three visually distinct readings (issue #669): a pulsing success ring
+           for a transcript still producing records, a steady warning ring for a
+           host that is alive but has gone quiet, and no ring at all for the
+           dimmed finished/unavailable states. */
+        const working = child.state === "running" || child.state === "live";
+        const stateNote = child.state === "silent"
+          ? ` · ${t("subagentTray.state.silent")}`
+          : unavailable ? " · unavailable" : "";
+        const tooltip = `${child.title} · ${child.engine}${child.model ? ` / ${child.model}` : ""}${stateNote}`;
         return (
           <span key={child.id} className="contents">
           {expanded && onFold && !unavailable ? (
@@ -163,8 +178,11 @@ export function SubagentBadges({ conversationId, entries, cardRect, onNavigate, 
               aria-hidden
             >
               {initials(child.title)}
-              {child.state === "running" ? (
-                <span className="absolute inset-[-2px] rounded-full ring-2 ring-success/70 animate-pulse motion-reduce:animate-none" />
+              {working ? (
+                <span data-subagent-ring="working" className="absolute inset-[-2px] rounded-full ring-2 ring-success/70 animate-pulse motion-reduce:animate-none" />
+              ) : null}
+              {child.state === "silent" ? (
+                <span data-subagent-ring="silent" className="absolute inset-[-2px] rounded-full ring-2 ring-warning" />
               ) : null}
             </span>
             <span className={`min-w-0 truncate px-2.5 text-[11px] font-semibold text-primary ${expanded ? "opacity-100" : "opacity-0"}`}>

--- a/src/components/scheme/SubagentBadges.tsx
+++ b/src/components/scheme/SubagentBadges.tsx
@@ -104,9 +104,11 @@ export function SubagentBadges({ conversationId, entries, cardRect, onNavigate, 
            host that is alive but has gone quiet, and no ring at all for the
            dimmed finished/unavailable states. */
         const working = child.state === "running" || child.state === "live";
-        const stateNote = child.state === "silent"
-          ? ` · ${t("subagentTray.state.silent")}`
-          : unavailable ? " · unavailable" : "";
+        /* Both notes come from the catalogue: a half-translated tooltip is a
+           bug in the one locale that is not English. */
+        const stateNote = child.state === "silent" || unavailable
+          ? ` · ${t(`subagentTray.state.${child.state}` as "subagentTray.state.silent")}`
+          : "";
         const tooltip = `${child.title} · ${child.engine}${child.model ? ` / ${child.model}` : ""}${stateNote}`;
         return (
           <span key={child.id} className="contents">

--- a/src/components/scheme/SubagentTrayView.dom.test.tsx
+++ b/src/components/scheme/SubagentTrayView.dom.test.tsx
@@ -148,3 +148,20 @@ test("the inline (mobile) variant uses 44px targets and a full-width block witho
   expect(unfoldButton.className).toContain("min-h-11");
   expect(unfoldButton.className).toContain("min-w-11");
 });
+
+test("a silent-but-alive member carries its own dot colour and label (issue #669)", () => {
+  const host = mount(tray({
+    members: [member({ id: "wedged", title: "Wedged worker", state: "silent" }), member({ id: "done", title: "Finished worker" })],
+    hottest: "silent",
+    expanded: true,
+  }));
+  const row = host.querySelector('[data-subagent-tray-member="wedged"]') as HTMLButtonElement;
+  const finished = host.querySelector('[data-subagent-tray-member="done"]') as HTMLButtonElement;
+
+  expect(row.dataset.subagentState).toBe("silent");
+  expect((row.querySelector("span") as HTMLElement).className).toContain("bg-warning");
+  /* Neither working green nor finished grey. */
+  expect((row.querySelector("span") as HTMLElement).className).not.toContain("bg-success");
+  expect((finished.querySelector("span") as HTMLElement).className).toContain("bg-muted");
+  expect(row.title).toContain("alive but silent");
+});

--- a/src/components/scheme/SubagentTrayView.tsx
+++ b/src/components/scheme/SubagentTrayView.tsx
@@ -40,6 +40,9 @@ const MAX_DOTS = 6;
 
 function dotClass(state: SubagentBadgeState): string {
   if (state === "running" || state === "live") return "bg-success";
+  /* Alive but not writing: its own colour, so a wedged member neither reads as
+     working (green) nor as finished (grey) — issue #669. */
+  if (state === "silent") return "bg-warning";
   if (state === "closed") return "bg-muted";
   return "bg-danger";
 }

--- a/src/components/scheme/subagentBadgeModel.test.ts
+++ b/src/components/scheme/subagentBadgeModel.test.ts
@@ -214,3 +214,43 @@ test("subagentsOf marks an unscanned structured-spawn placeholder unavailable", 
     expect.objectContaining({ id: "child", state: "dead" }),
   ]);
 });
+
+test("subagentsOf ranks a writing child above a silent-but-alive one above a finished one (issue #669)", () => {
+  const now = 1_000_000;
+  const parent = entry({ path: "/parent", conversationId: "parent" });
+  /* Spawn order is the reverse of activity order, so only the state ranking can
+     produce the expected sequence. */
+  const finished = entry({
+    path: "/finished",
+    conversationId: "finished",
+    parent: parent.path,
+    sessionStartedAt: "2026-07-19T08:00:00Z",
+    proc: "done",
+    mtime: now - 4,
+  });
+  const wedged = entry({
+    path: "/wedged",
+    conversationId: "wedged",
+    parent: parent.path,
+    sessionStartedAt: "2026-07-19T09:00:00Z",
+    activity: "stalled",
+    proc: "running",
+    mtime: now - 3_600,
+  });
+  const writing = entry({
+    path: "/writing",
+    conversationId: "writing",
+    parent: parent.path,
+    sessionStartedAt: "2026-07-19T10:00:00Z",
+    /* The scan verdict has gone stale; the transcript says otherwise. */
+    activity: "idle",
+    proc: "running",
+    mtime: now - 9,
+  });
+
+  expect(subagentsOf("parent", [finished, wedged, writing, parent], new Set(), now).map((badge) => [badge.id, badge.state])).toEqual([
+    ["writing", "running"],
+    ["wedged", "silent"],
+    ["finished", "closed"],
+  ]);
+});

--- a/src/components/scheme/subagentBadgeModel.ts
+++ b/src/components/scheme/subagentBadgeModel.ts
@@ -5,10 +5,11 @@ import { badgeState, currentGenerationChildrenOf, type SubagentBadgeState } from
 
 export type { SubagentBadgeState } from "./subagentTray";
 
-/** Badge display rank: active leads, every quiet/dead state trails together —
-    ties break by spawn time, unchanged from the pre-#142 ordering. */
+/** Badge display rank: active leads, a silent-but-alive host follows, every
+    quiet/dead state trails together — ties break by spawn time. */
 function activeRank(state: SubagentBadgeState): number {
-  return state === "running" || state === "live" ? 0 : 1;
+  if (state === "running" || state === "live") return 0;
+  return state === "silent" ? 1 : 2;
 }
 
 export interface SubagentBadge {
@@ -33,16 +34,19 @@ function spawnTime(entry: FileEntry): number {
  * Direct spawned children of one stable conversation, ordered for bottom-up
  * display. `exclude` drops any child already placed on another surface — a tray
  * member folded into the parent card must not also enumerate as a promoted
- * badge (issue #142: a card renders in exactly one place).
+ * badge (issue #142: a card renders in exactly one place). `now` is epoch
+ * SECONDS: chip state is a function of transcript freshness, so it moves with
+ * the clock and not only with the next scan (issue #669).
  */
 export function subagentsOf(
   conversationId: string,
   entries: readonly FileEntry[],
   exclude: ReadonlySet<string> = new Set(),
+  now = 0,
 ): SubagentBadge[] {
   return currentGenerationChildrenOf(conversationId, entries)
     .filter((entry) => !exclude.has(entry.path) && !exclude.has(conversationIdentity(entry)))
-    .map((entry) => ({ entry, state: badgeState(entry) }))
+    .map((entry) => ({ entry, state: badgeState(entry, now) }))
     .sort((left, right) =>
       activeRank(left.state) - activeRank(right.state)
       || spawnTime(left.entry) - spawnTime(right.entry)

--- a/src/components/scheme/subagentTray.test.ts
+++ b/src/components/scheme/subagentTray.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "bun:test";
 
-import type { FileEntry } from "@/lib/types";
+import { epochSeconds, type FileEntry } from "@/lib/types";
 
 import {
   badgeState,
@@ -63,7 +63,7 @@ function baseInput(entries: FileEntry[], hostParentIds: string[], overrides: Par
     hiddenPaths: new Set(),
     claimedPaths: new Set(),
     hostEligibleParentIds: new Set(hostParentIds),
-    now: 1_000_000,
+    now: epochSeconds(NOW),
     ...overrides,
   };
 }
@@ -150,6 +150,29 @@ test("badgeState closes a returned subagent whose turn ended, without waiting ou
   expect(badgeState(stillOwned, NOW)).toBe("running");
 });
 
+test("badgeState keeps a busy in-harness subagent alive through a long tool call", () => {
+  /* A Claude in-harness subagent is written by its PARENT's process and never
+     owns a pid — the scanner's isTopLevelTranscript skips both `agent-`
+     basenames and the subagents directory — so process evidence is absent for
+     its whole life, and it writes nothing while a tool call runs. A six-minute
+     test run must read silent, never finished. */
+  const toolCall = (seconds: number) =>
+    badgeState(entry({
+      path: "/proj/parent/subagents/agent-abc.jsonl",
+      conversationId: "a",
+      engine: "claude",
+      proc: null,
+      activity: "stalled",
+      mtime: wrote(seconds),
+      authoritativeTurn: { state: "busy", source: "assistant", terminalAt: null },
+    }), NOW);
+  expect(toolCall(240)).toBe("live");
+  expect(toolCall(600)).toBe("silent");
+  /* Hours of silence stay silent: an open turn is evidence of a live owner,
+     never a reason to claim work is still happening. */
+  expect(toolCall(7.5 * 3600)).toBe("silent");
+});
+
 test("badgeState closes a silent transcript with nothing alive behind it, and an exit wins over freshness", () => {
   const abandoned = entry({ path: "/a", conversationId: "a", proc: null, activity: "recent", mtime: wrote(SILENT_AFTER_SECONDS) });
   expect(badgeState(abandoned, NOW)).toBe("closed");
@@ -204,7 +227,7 @@ test("engineChildNeedsAttention fires on question, spawn failure and killed host
 
 // ── precedence matrix (§1.2 / presence policy) ──────────────────────────────
 
-const ctx = { folded: false, pinned: false, now: 1_000_000 };
+const ctx = { folded: false, pinned: false, now: epochSeconds(NOW) };
 
 test("attention promotes ahead of an explicit fold", () => {
   const c = entry({ path: "/a", conversationId: "a", pendingQuestion: { toolUseId: "t", prompt: "?" } as never });
@@ -331,7 +354,7 @@ test("buildSubagentTrays reads its clock in epoch seconds, the unit `mtime` and 
   });
   const projection = buildSubagentTrays(baseInput([parent, wedged, writing], ["parent"], {
     foldedEngineChildIds: new Set(["wedged", "writing"]),
-    now,
+    now: epochSeconds(now),
   }));
   const tray = projection.traysByParent.get("parent")!;
   expect(tray.members.map((member) => [member.id, member.state])).toEqual([
@@ -357,7 +380,7 @@ test("buildSubagentTrays promotes a stalled live child inside the attention TTL 
   });
   const projection = buildSubagentTrays(baseInput([parent, stalled], ["parent"], {
     foldedEngineChildIds: new Set(["stalled"]),
-    now,
+    now: epochSeconds(now),
   }));
   expect(projection.promotedPaths).toEqual(new Set(["/stalled"]));
   expect(projection.foldedPaths.size).toBe(0);

--- a/src/components/scheme/subagentTray.test.ts
+++ b/src/components/scheme/subagentTray.test.ts
@@ -173,6 +173,75 @@ test("badgeState keeps a busy in-harness subagent alive through a long tool call
   expect(toolCall(7.5 * 3600)).toBe("silent");
 });
 
+test("badgeState tells a finished agent from a wedged one while both keep a host attached", () => {
+  /* An attached host is how a worker waits for follow-ups, so liveness cannot
+     be what separates these two — the turn is. Side by side, an hour silent,
+     same process state. */
+  const finished = entry({
+    path: "/a",
+    conversationId: "a",
+    proc: "running",
+    mtime: wrote(3_600),
+    authoritativeTurn: { state: "terminal", source: "assistant", terminalAt: "2026-07-25T00:00:00Z" },
+  });
+  const wedged = entry({
+    path: "/b",
+    conversationId: "b",
+    proc: "running",
+    mtime: wrote(3_600),
+    authoritativeTurn: { state: "busy", source: "assistant", terminalAt: null },
+  });
+  expect(badgeState(finished, NOW)).toBe("closed");
+  expect(badgeState(wedged, NOW)).toBe("silent");
+
+  /* The scanner's completion reason carries the same shape for an entry whose
+     authoritative projection did not complete — and it is fixed before any
+     clock is consulted, so this stays a shape test, not an age test. */
+  const scannerSaysCompleted = entry({
+    path: "/c",
+    conversationId: "c",
+    proc: "running",
+    mtime: wrote(3_600),
+    activity: "recent",
+    activityReason: "jsonl_turn_completed",
+  });
+  const scannerSaysStalled = entry({
+    path: "/d",
+    conversationId: "d",
+    proc: "running",
+    mtime: wrote(3_600),
+    activity: "stalled",
+    activityReason: "jsonl_turn_stalled",
+  });
+  expect(badgeState(scannerSaysCompleted, NOW)).toBe("closed");
+  expect(badgeState(scannerSaysStalled, NOW)).toBe("silent");
+
+  /* A clean turn still keeps its chip working while the transcript is fresh:
+     completion is what silence MEANS here, not a state of its own. */
+  expect(badgeState({ ...finished, mtime: wrote(4) }, NOW)).toBe("running");
+});
+
+test("a tray of finished children with attached hosts rolls up closed, not silent", () => {
+  const now = epochSeconds(NOW);
+  const parent = entry({ path: "/parent", conversationId: "parent", activity: "live" });
+  const done = (id: string) => child({
+    path: `/${id}`,
+    conversationId: id,
+    parentId: "parent",
+    parent: parent.path,
+    proc: "running",
+    mtime: wrote(3_600),
+    authoritativeTurn: { state: "terminal", source: "assistant", terminalAt: "2026-07-25T00:00:00Z" },
+  });
+  const projection = buildSubagentTrays(baseInput([parent, done("one"), done("two")], ["parent"], {
+    foldedEngineChildIds: new Set(["one", "two"]),
+    now,
+  }));
+  const tray = projection.traysByParent.get("parent")!;
+  expect(tray.members.map((member) => member.state)).toEqual(["closed", "closed"]);
+  expect(tray.hottest).toBe("closed");
+});
+
 test("badgeState closes a silent transcript with nothing alive behind it, and an exit wins over freshness", () => {
   const abandoned = entry({ path: "/a", conversationId: "a", proc: null, activity: "recent", mtime: wrote(SILENT_AFTER_SECONDS) });
   expect(badgeState(abandoned, NOW)).toBe("closed");

--- a/src/components/scheme/subagentTray.test.ts
+++ b/src/components/scheme/subagentTray.test.ts
@@ -3,11 +3,14 @@ import { expect, test } from "bun:test";
 import type { FileEntry } from "@/lib/types";
 
 import {
+  badgeState,
   buildSubagentTrays,
   classifyEngineChild,
   currentGenerationChildrenOf,
   engineChildNeedsAttention,
   rollUpState,
+  SILENT_AFTER_SECONDS,
+  transcriptSilence,
   type SubagentTrayInput,
 } from "./subagentTray";
 
@@ -84,12 +87,110 @@ test("currentGenerationChildrenOf honours the provenance filter", () => {
   expect(rows.map((row) => row.path)).toEqual(["/engine"]);
 });
 
+// ── chip activity from transcript freshness (issue #669) ────────────────────
+
+const NOW = 1_000_000;
+/** A transcript record written `seconds` ago. */
+const wrote = (seconds: number) => NOW - seconds;
+
+test("badgeState reads a writing transcript as working however stale the snapshot verdict is", () => {
+  /* The false-finished half of #669: the scan's own activity verdict has gone
+     idle while the lane keeps appending records every few seconds. */
+  const busy = entry({ path: "/a", conversationId: "a", proc: "running", activity: "idle", mtime: wrote(2) });
+  expect(badgeState(busy, NOW)).toBe("running");
+  const unmapped = entry({ path: "/b", conversationId: "b", proc: null, activity: "idle", mtime: wrote(13) });
+  expect(badgeState(unmapped, NOW)).toBe("live");
+});
+
+test("badgeState keeps a thinking agent working right up to the silence threshold", () => {
+  const thinking = (seconds: number) =>
+    badgeState(entry({ path: "/a", conversationId: "a", proc: "running", activity: "live", mtime: wrote(seconds) }), NOW);
+  expect(thinking(0)).toBe("running");
+  expect(thinking(120)).toBe("running");
+  expect(thinking(SILENT_AFTER_SECONDS - 1)).toBe("running");
+  expect(thinking(SILENT_AFTER_SECONDS)).toBe("silent");
+});
+
+test("badgeState gives an alive-but-silent host its own state instead of working or finished", () => {
+  /* The false-active half of #669: a closed pipeline's host never exits and
+     never writes again. Its process is alive, so it is not finished either. */
+  const wedged = entry({ path: "/a", conversationId: "a", proc: "running", activity: "stalled", mtime: wrote(7.5 * 3600) });
+  expect(badgeState(wedged, NOW)).toBe("silent");
+  const starting = entry({
+    path: "/b",
+    conversationId: "b",
+    proc: null,
+    mtime: wrote(7.5 * 3600),
+    spawn: { launchId: "l", clientAttemptId: null, accountId: null, state: "binding", initialMessage: "pending", retrySafe: true, error: null },
+  });
+  expect(badgeState(starting, NOW)).toBe("silent");
+});
+
+test("badgeState closes a returned subagent whose turn ended, without waiting out the silence window", () => {
+  /* A Claude in-harness child owns no process: freshness alone would keep its
+     final answer pulsing for minutes. The turn's shape settles it — and being
+     shape, not age, a stale snapshot cannot flip a busy turn to finished. */
+  const returned = entry({
+    path: "/a",
+    conversationId: "a",
+    proc: null,
+    activity: "recent",
+    mtime: wrote(4),
+    authoritativeTurn: { state: "terminal", source: "assistant", terminalAt: "2026-07-25T00:00:00Z" },
+  });
+  expect(badgeState(returned, NOW)).toBe("closed");
+  const stillOwned = entry({
+    path: "/b",
+    conversationId: "b",
+    proc: "running",
+    activity: "idle",
+    mtime: wrote(4),
+    authoritativeTurn: { state: "terminal", source: "assistant", terminalAt: "2026-07-25T00:00:00Z" },
+  });
+  expect(badgeState(stillOwned, NOW)).toBe("running");
+});
+
+test("badgeState closes a silent transcript with nothing alive behind it, and an exit wins over freshness", () => {
+  const abandoned = entry({ path: "/a", conversationId: "a", proc: null, activity: "recent", mtime: wrote(SILENT_AFTER_SECONDS) });
+  expect(badgeState(abandoned, NOW)).toBe("closed");
+  const justExited = entry({ path: "/b", conversationId: "b", proc: "done", activity: "live", mtime: wrote(2) });
+  expect(badgeState(justExited, NOW)).toBe("closed");
+  const killed = entry({ path: "/c", conversationId: "c", proc: "killed", activity: "live", mtime: wrote(2) });
+  expect(badgeState(killed, NOW)).toBe("closed");
+});
+
+test("badgeState keeps spawn placeholders and failed launches unavailable", () => {
+  const placeholder = entry({ path: "spawn:launch-1", conversationId: "a", proc: "running", mtime: wrote(1) });
+  expect(badgeState(placeholder, NOW)).toBe("dead");
+  const failed = entry({
+    path: "/b",
+    conversationId: "b",
+    mtime: wrote(1),
+    spawn: { launchId: "l", clientAttemptId: null, accountId: null, state: "failed", initialMessage: "failed", retrySafe: false, error: "no host" },
+  });
+  expect(badgeState(failed, NOW)).toBe("dead");
+});
+
+test("badgeState leaves every chip undemoted while the client has no clock yet", () => {
+  /* The server render and the first client render pass 0 (no hydration skew):
+     an unknown age is not evidence of silence. */
+  const wedged = entry({ path: "/a", conversationId: "a", proc: "running", mtime: wrote(7.5 * 3600) });
+  expect(badgeState(wedged, 0)).toBe("running");
+  expect(transcriptSilence(wedged, 0)).toBeNull();
+  expect(transcriptSilence(wedged, NOW)).toBe(7.5 * 3600);
+});
+
 // ── roll-up ─────────────────────────────────────────────────────────────────
 
 test("rollUpState returns the hottest state", () => {
   expect(rollUpState(["closed", "running", "dead"])).toBe("running");
   expect(rollUpState(["closed", "dead"])).toBe("closed");
   expect(rollUpState([])).toBe("dead");
+});
+
+test("rollUpState ranks a silent-but-alive member above a closed one", () => {
+  expect(rollUpState(["closed", "silent", "dead"])).toBe("silent");
+  expect(rollUpState(["silent", "running"])).toBe("running");
 });
 
 // ── attention detection ─────────────────────────────────────────────────────
@@ -182,7 +283,7 @@ test("buildSubagentTrays leaves viewer, hidden and claimed children to their own
 
 test("buildSubagentTrays reflects the durable fold pin and tray-disclosure intent", () => {
   const parent = entry({ path: "/parent", conversationId: "parent", activity: "live" });
-  const live = child({ path: "/live", conversationId: "live", parentId: "parent", parent: parent.path, activity: "live", proc: "running" });
+  const live = child({ path: "/live", conversationId: "live", parentId: "parent", parent: parent.path, activity: "live", proc: "running", mtime: 999_990 });
   const projection = buildSubagentTrays(baseInput([parent, live], ["parent"], {
     foldedEngineChildIds: new Set(["live"]),
     expandedTrayParentIds: new Set(["parent"]),
@@ -196,10 +297,68 @@ test("buildSubagentTrays reflects the durable fold pin and tray-disclosure inten
 test("buildSubagentTrays orders tray members hottest first", () => {
   const parent = entry({ path: "/parent", conversationId: "parent", activity: "live" });
   const doneOld = child({ path: "/done", conversationId: "done", parentId: "parent", parent: parent.path, activity: "idle", proc: "done", sessionStartedAt: "2026-07-19T08:00:00Z" });
-  const liveFolded = child({ path: "/livef", conversationId: "livef", parentId: "parent", parent: parent.path, activity: "live", proc: "running", sessionStartedAt: "2026-07-19T09:00:00Z" });
+  const liveFolded = child({ path: "/livef", conversationId: "livef", parentId: "parent", parent: parent.path, activity: "live", proc: "running", mtime: 999_990, sessionStartedAt: "2026-07-19T09:00:00Z" });
   const projection = buildSubagentTrays(baseInput([parent, doneOld, liveFolded], ["parent"], {
     foldedEngineChildIds: new Set(["done", "livef"]),
   }));
   const tray = projection.traysByParent.get("parent")!;
   expect(tray.members.map((member) => member.id)).toEqual(["livef", "done"]);
+});
+
+test("buildSubagentTrays reads its clock in epoch seconds, the unit `mtime` and attention TTLs use", () => {
+  const now = 1_800_000_000;
+  const parent = entry({ path: "/parent", conversationId: "parent", activity: "live" });
+  /* Alive, no attention signal, and silent for an hour — a folded row that
+     must read silent rather than working. */
+  const wedged = child({
+    path: "/wedged",
+    conversationId: "wedged",
+    parentId: "parent",
+    parent: parent.path,
+    activity: "recent",
+    proc: "running",
+    mtime: now - 3_600,
+  });
+  const writing = child({
+    path: "/writing",
+    conversationId: "writing",
+    parentId: "parent",
+    parent: parent.path,
+    /* The scan verdict has gone stale; the transcript says otherwise. */
+    activity: "idle",
+    proc: "running",
+    mtime: now - 2,
+  });
+  const projection = buildSubagentTrays(baseInput([parent, wedged, writing], ["parent"], {
+    foldedEngineChildIds: new Set(["wedged", "writing"]),
+    now,
+  }));
+  const tray = projection.traysByParent.get("parent")!;
+  expect(tray.members.map((member) => [member.id, member.state])).toEqual([
+    ["writing", "running"],
+    ["wedged", "silent"],
+  ]);
+  expect(tray.hottest).toBe("running");
+});
+
+test("buildSubagentTrays promotes a stalled live child inside the attention TTL (seconds, not milliseconds)", () => {
+  /* Feeding this clock milliseconds put every child hours past the attention
+     TTL, so an interrupted agent could never surface out of the tray. */
+  const now = 1_800_000_000;
+  const parent = entry({ path: "/parent", conversationId: "parent", activity: "live" });
+  const stalled = child({
+    path: "/stalled",
+    conversationId: "stalled",
+    parentId: "parent",
+    parent: parent.path,
+    activity: "stalled",
+    proc: "running",
+    mtime: now - 600,
+  });
+  const projection = buildSubagentTrays(baseInput([parent, stalled], ["parent"], {
+    foldedEngineChildIds: new Set(["stalled"]),
+    now,
+  }));
+  expect(projection.promotedPaths).toEqual(new Set(["/stalled"]));
+  expect(projection.foldedPaths.size).toBe(0);
 });

--- a/src/components/scheme/subagentTray.ts
+++ b/src/components/scheme/subagentTray.ts
@@ -1,6 +1,6 @@
 import { attentionId } from "@/components/attention";
 import { conversationIdentity, isArchivedPredecessor } from "@/lib/accounts/identity";
-import type { Engine, FileEntry } from "@/lib/types";
+import type { EpochSeconds, Engine, FileEntry } from "@/lib/types";
 
 /*
  * Engine-native subagent tray — the single presence projection for issue #142
@@ -60,12 +60,30 @@ export type PresenceReason =
   | "quiet"
   | "fail-visible";
 
-/** A launch that is still binding its host owns no transcript yet, so its
-    silence carries no meaning — it counts as alive, never as silent. */
+/** A process of this conversation's own, or a launch still binding one. A
+    launch wedged in `binding` counts as hosted, so it surfaces as silent
+    rather than as finished. */
 function hostAlive(entry: FileEntry): boolean {
   if (entry.proc === "running") return true;
   const spawn = entry.spawn?.state;
   return spawn === "starting" || spawn === "binding" || spawn === "queued";
+}
+
+/**
+ * Whether anything could still write to this transcript — the question silence
+ * has to answer before it may mean "finished".
+ *
+ * A mapped process is not the only evidence, and for the population that fills
+ * this surface it is never available: a Claude in-harness subagent is written
+ * by its PARENT's process and never gets a pid of its own (the scanner's
+ * `isTopLevelTranscript` excludes `agent-*` basenames and anything under
+ * `subagents/`), so `proc` stays null for its whole life. Its open
+ * authoritative turn is the only liveness it will ever carry — and a subagent
+ * writes nothing at all while a tool call is in flight, so a six-minute test
+ * run must not be read as a finished agent.
+ */
+function couldStillWrite(entry: FileEntry): boolean {
+  return hostAlive(entry) || entry.authoritativeTurn?.state === "busy";
 }
 
 /**
@@ -89,22 +107,31 @@ export function transcriptSilence(entry: FileEntry, now: number): number | null 
  * only decides which side of the ladder the entry falls on — exited is
  * terminal, alive-and-silent is wedged, alive-and-writing is working.
  *
- * Freshness is only evidence of work while something could still write. A
- * closed turn with no host behind it is finished the moment it lands: its last
- * record is the answer, not a sign of life. Note that this reads the turn's
- * SHAPE, never its age — an ageing snapshot cannot flip that judgement, which
- * is what let a lane writing every two seconds render as finished.
+ * Silence only means "finished" once nothing could still write
+ * ({@link couldStillWrite}); short of that it means "silent", never "done". A
+ * closed turn with no host behind it, on the other hand, is finished the moment
+ * it lands: its last record is the answer, not a sign of life. Both readings of
+ * the turn take its SHAPE, never its age — an ageing snapshot cannot flip
+ * either judgement, which is what let a lane writing every two seconds render
+ * as finished.
+ *
+ * A closed turn does NOT close a chip whose host is still alive, deliberately:
+ * a terminal Claude turn under a live host can be recovery bookkeeping rather
+ * than a finished agent (issue #516 — `lib/scanner/activity.ts` keeps that
+ * release behind a live-host fence for the same reason). Such a chip leaves
+ * the working state on transcript silence like any other, which costs at most
+ * one silence window of green and never claims completion on weak evidence.
  */
 export function badgeState(entry: FileEntry, now: number): SubagentBadgeState {
   if (entry.path.startsWith("spawn:")) return "dead";
   if (entry.spawn?.state === "failed") return "dead";
   if (entry.proc === "done" || entry.proc === "killed" || entry.supersededBy) return "closed";
-  const alive = hostAlive(entry);
+  const hosted = hostAlive(entry);
   const turn = entry.authoritativeTurn?.state;
-  if (!alive && (turn === "terminal" || turn === "idle")) return "closed";
+  if (!hosted && (turn === "terminal" || turn === "idle")) return "closed";
   const silence = transcriptSilence(entry, now);
-  if (silence === null || silence < SILENT_AFTER_SECONDS) return alive ? "running" : "live";
-  return alive ? "silent" : "closed";
+  if (silence === null || silence < SILENT_AFTER_SECONDS) return hosted ? "running" : "live";
+  return couldStillWrite(entry) ? "silent" : "closed";
 }
 
 function spawnTime(entry: FileEntry): number {
@@ -207,8 +234,8 @@ export interface EngineChildContext {
   folded: boolean;
   /** The child is manually placed / expanded / pinned on the board. */
   pinned: boolean;
-  /** Epoch SECONDS — the same clock `mtime` and `attentionId` are measured on. */
-  now: number;
+  /** The same clock `mtime` and `attentionId` are measured on. */
+  now: EpochSeconds;
 }
 
 export interface EngineChildClassification {
@@ -278,9 +305,9 @@ export interface SubagentTrayInput {
       whose host is missing (hidden, deleted, cross-project, deck-claimed,
       compacted) stays visible through the existing full-node path. */
   hostEligibleParentIds: ReadonlySet<string>;
-  /** Epoch SECONDS — transcript freshness and attention TTLs share this clock
-      with `mtime`, so a caller holding milliseconds must divide first. */
-  now: number;
+  /** Transcript freshness and attention TTLs share this clock with `mtime`;
+      the branded type keeps a millisecond clock from landing here silently. */
+  now: EpochSeconds;
 }
 
 export interface SubagentTrayProjection {

--- a/src/components/scheme/subagentTray.ts
+++ b/src/components/scheme/subagentTray.ts
@@ -19,7 +19,34 @@ import type { Engine, FileEntry } from "@/lib/types";
  * only their exclusion sets so a card is never placed in two surfaces at once.
  */
 
-export type SubagentBadgeState = "running" | "live" | "closed" | "dead";
+/**
+ * Chip states, hottest first (issue #669):
+ * - `running` — a live host whose transcript is still producing records.
+ * - `live` — no process evidence, but the transcript is producing records.
+ * - `silent` — the host is alive and the transcript has said nothing for
+ *   {@link SILENT_AFTER_SECONDS}. Its own state: a wedged host must not keep
+ *   masquerading as working, and it is not finished either.
+ * - `closed` — the host exited, was superseded, or nothing is alive behind a
+ *   transcript that stopped writing.
+ * - `dead` — a spawn placeholder or a failed launch: no conversation to open.
+ */
+export type SubagentBadgeState = "running" | "live" | "silent" | "closed" | "dead";
+
+/**
+ * Transcript silence (seconds) after which a still-alive agent leaves the
+ * working state for `silent`.
+ *
+ * Five minutes. The gaps a healthy agent legitimately leaves between records
+ * are tool calls that block the turn — a type-check, a test run, a fetch, a
+ * long thinking block — and those land inside a couple of minutes; the scanner
+ * already calls an open turn `stalled` at 180s (`lib/scanner/activity.ts`), so
+ * 300s is deliberately the more forgiving of the two and a two-minute think
+ * cannot flicker the chip. The pathology this catches ran for hours (issue
+ * #669: four hosts silent for 7.5h while their chips read as working), so
+ * every threshold in minutes catches it — the only question is how much
+ * headroom to leave the honest agent, and this leaves 2.5x the scanner's.
+ */
+export const SILENT_AFTER_SECONDS = 300;
 
 /** Presence surface an engine-native child renders on (§1.2 ladder). */
 export type TrayPresence = "promoted" | "folded";
@@ -33,14 +60,51 @@ export type PresenceReason =
   | "quiet"
   | "fail-visible";
 
-export function badgeState(entry: FileEntry): SubagentBadgeState {
+/** A launch that is still binding its host owns no transcript yet, so its
+    silence carries no meaning — it counts as alive, never as silent. */
+function hostAlive(entry: FileEntry): boolean {
+  if (entry.proc === "running") return true;
+  const spawn = entry.spawn?.state;
+  return spawn === "starting" || spawn === "binding" || spawn === "queued";
+}
+
+/**
+ * Seconds since the conversation's last transcript record, or `null` when the
+ * caller has no clock yet (the server render and the first client render pass
+ * `0` so their markup agrees — see {@link useNowSeconds}). A null age never
+ * demotes a chip: an unknown age is not evidence of silence.
+ */
+export function transcriptSilence(entry: FileEntry, now: number): number | null {
+  if (!Number.isFinite(now) || now <= 0) return null;
+  return Math.max(0, now - entry.mtime);
+}
+
+/**
+ * The chip state of one conversation. `now` is epoch SECONDS.
+ *
+ * Activity is read off the transcript, not off the process (issue #669): a
+ * host that is alive but has written nothing for {@link SILENT_AFTER_SECONDS}
+ * reads `silent`, and a transcript that is still writing reads active however
+ * stale the snapshot's own `activity` verdict has become. Process evidence
+ * only decides which side of the ladder the entry falls on — exited is
+ * terminal, alive-and-silent is wedged, alive-and-writing is working.
+ *
+ * Freshness is only evidence of work while something could still write. A
+ * closed turn with no host behind it is finished the moment it lands: its last
+ * record is the answer, not a sign of life. Note that this reads the turn's
+ * SHAPE, never its age — an ageing snapshot cannot flip that judgement, which
+ * is what let a lane writing every two seconds render as finished.
+ */
+export function badgeState(entry: FileEntry, now: number): SubagentBadgeState {
   if (entry.path.startsWith("spawn:")) return "dead";
   if (entry.spawn?.state === "failed") return "dead";
-  if (entry.proc === "done" || entry.proc === "killed" || entry.supersededBy || entry.activity === "idle") return "closed";
-  if (entry.proc === "running" || entry.spawn?.state === "starting" || entry.spawn?.state === "binding" || entry.spawn?.state === "queued") {
-    return "running";
-  }
-  return "live";
+  if (entry.proc === "done" || entry.proc === "killed" || entry.supersededBy) return "closed";
+  const alive = hostAlive(entry);
+  const turn = entry.authoritativeTurn?.state;
+  if (!alive && (turn === "terminal" || turn === "idle")) return "closed";
+  const silence = transcriptSilence(entry, now);
+  if (silence === null || silence < SILENT_AFTER_SECONDS) return alive ? "running" : "live";
+  return alive ? "silent" : "closed";
 }
 
 function spawnTime(entry: FileEntry): number {
@@ -48,11 +112,14 @@ function spawnTime(entry: FileEntry): number {
   return Number.isFinite(started) ? started : entry.mtime * 1_000;
 }
 
-/** Activity rank for ordering + tray roll-up: lower is hotter. */
+/** Activity rank for ordering + tray roll-up: lower is hotter. A silent host
+    is still alive, so it outranks a closed one — a wedged agent must surface
+    through a folded row rather than hide behind finished siblings. */
 export function activeRank(state: SubagentBadgeState): number {
   if (state === "running" || state === "live") return 0;
-  if (state === "closed") return 1;
-  return 2;
+  if (state === "silent") return 1;
+  if (state === "closed") return 2;
+  return 3;
 }
 
 /** The hottest (most-active) state across a set of members — the tray badge
@@ -140,6 +207,7 @@ export interface EngineChildContext {
   folded: boolean;
   /** The child is manually placed / expanded / pinned on the board. */
   pinned: boolean;
+  /** Epoch SECONDS — the same clock `mtime` and `attentionId` are measured on. */
   now: number;
 }
 
@@ -210,6 +278,8 @@ export interface SubagentTrayInput {
       whose host is missing (hidden, deleted, cross-project, deck-claimed,
       compacted) stays visible through the existing full-node path. */
   hostEligibleParentIds: ReadonlySet<string>;
+  /** Epoch SECONDS — transcript freshness and attention TTLs share this clock
+      with `mtime`, so a caller holding milliseconds must divide first. */
   now: number;
 }
 
@@ -235,7 +305,7 @@ export function engineChildParentId(entry: FileEntry, byPath: ReadonlyMap<string
   return entry.parentRemoved?.conversationId ?? null;
 }
 
-function toMember(entry: FileEntry): TrayMember {
+function toMember(entry: FileEntry, now: number): TrayMember {
   const id = conversationIdentity(entry);
   return {
     id,
@@ -243,7 +313,7 @@ function toMember(entry: FileEntry): TrayMember {
     title: entry.title,
     engine: entry.engine,
     model: entry.model,
-    state: badgeState(entry),
+    state: badgeState(entry, now),
     avatarSeed: id,
   };
 }
@@ -309,7 +379,7 @@ export function buildSubagentTrays(input: SubagentTrayInput): SubagentTrayProjec
     foldedIds.add(id);
     spawnByChildId.set(id, spawnTime(entry));
     const list = membersByParent.get(parentId) ?? [];
-    list.push(toMember(entry));
+    list.push(toMember(entry, input.now));
     membersByParent.set(parentId, list);
   }
 

--- a/src/components/scheme/subagentTray.ts
+++ b/src/components/scheme/subagentTray.ts
@@ -87,6 +87,23 @@ function couldStillWrite(entry: FileEntry): boolean {
 }
 
 /**
+ * The transcript's last turn ended on its own terms — the agent answered and
+ * stopped, as opposed to going quiet mid-turn.
+ *
+ * Shape only, never age: both signals describe what the tail RECORDS say. The
+ * scanner's `jsonl_turn_completed` reason is fixed by the turn projection
+ * before any clock is consulted (only the recent/idle split that follows it is
+ * age-derived, and that split is exactly what must not come back in here).
+ * This is the same reading `isTerminalOrIdle` folds a child on, so the
+ * projection's "quiet, fold it" and the chip it emits for that row agree.
+ */
+function turnEndedCleanly(entry: FileEntry): boolean {
+  const turn = entry.authoritativeTurn?.state;
+  if (turn === "terminal" || turn === "idle") return true;
+  return entry.activityReason === "jsonl_turn_completed";
+}
+
+/**
  * Seconds since the conversation's last transcript record, or `null` when the
  * caller has no clock yet (the server render and the first client render pass
  * `0` so their markup agrees — see {@link useNowSeconds}). A null age never
@@ -107,30 +124,36 @@ export function transcriptSilence(entry: FileEntry, now: number): number | null 
  * only decides which side of the ladder the entry falls on — exited is
  * terminal, alive-and-silent is wedged, alive-and-writing is working.
  *
- * Silence only means "finished" once nothing could still write
- * ({@link couldStillWrite}); short of that it means "silent", never "done". A
- * closed turn with no host behind it, on the other hand, is finished the moment
- * it lands: its last record is the answer, not a sign of life. Both readings of
- * the turn take its SHAPE, never its age — an ageing snapshot cannot flip
- * either judgement, which is what let a lane writing every two seconds render
- * as finished.
+ * What silence MEANS is settled by the turn, and only by its shape:
+ * - a turn that ended cleanly ({@link turnEndedCleanly}) — the agent answered
+ *   and stopped. With no host behind it that is finished the moment it lands:
+ *   the last record is the answer, not a sign of life. With a host still
+ *   attached it is finished as soon as the transcript goes quiet — an attached
+ *   host is how a worker waits for follow-ups, so keeping such a chip amber
+ *   forever would leave nothing to tell a wedged agent from a done one.
+ * - a turn still open, or no turn evidence at all — the agent went quiet
+ *   mid-work. That is what `silent` is for, and something must still be able to
+ *   write ({@link couldStillWrite}) for the chip to claim it.
  *
- * A closed turn does NOT close a chip whose host is still alive, deliberately:
- * a terminal Claude turn under a live host can be recovery bookkeeping rather
- * than a finished agent (issue #516 — `lib/scanner/activity.ts` keeps that
- * release behind a live-host fence for the same reason). Such a chip leaves
- * the working state on transcript silence like any other, which costs at most
- * one silence window of green and never claims completion on weak evidence.
+ * Age is not an input to either branch — an ageing snapshot cannot flip these
+ * judgements, which is what let a lane writing every two seconds render as
+ * finished.
+ *
+ * The cost of closing a hosted clean turn is bounded by #516: a terminal
+ * Claude turn under a live host can be recovery bookkeeping rather than a
+ * finished agent. That chip greys out only after a full silence window, and
+ * the next record it writes returns it to working on the following poll.
  */
 export function badgeState(entry: FileEntry, now: number): SubagentBadgeState {
   if (entry.path.startsWith("spawn:")) return "dead";
   if (entry.spawn?.state === "failed") return "dead";
   if (entry.proc === "done" || entry.proc === "killed" || entry.supersededBy) return "closed";
   const hosted = hostAlive(entry);
-  const turn = entry.authoritativeTurn?.state;
-  if (!hosted && (turn === "terminal" || turn === "idle")) return "closed";
+  const ended = turnEndedCleanly(entry);
+  if (!hosted && ended) return "closed";
   const silence = transcriptSilence(entry, now);
   if (silence === null || silence < SILENT_AFTER_SECONDS) return hosted ? "running" : "live";
+  if (ended) return "closed";
   return couldStillWrite(entry) ? "silent" : "closed";
 }
 

--- a/src/hooks/useNowSeconds.dom.test.tsx
+++ b/src/hooks/useNowSeconds.dom.test.tsx
@@ -1,0 +1,63 @@
+import { afterEach, expect, test } from "bun:test";
+import { Window } from "happy-dom";
+import { flushSync } from "react-dom";
+import { createRoot, type Root } from "react-dom/client";
+
+import { useNowSeconds } from "./useNowSeconds";
+
+const dom = new Window();
+Object.assign(globalThis, {
+  window: dom,
+  document: dom.document,
+  navigator: dom.navigator,
+  Node: dom.Node,
+  HTMLElement: dom.HTMLElement,
+  Event: dom.Event,
+});
+
+const roots = new Set<Root>();
+
+afterEach(() => {
+  for (const root of roots) flushSync(() => root.unmount());
+  roots.clear();
+  dom.document.body.replaceChildren();
+});
+
+function mount(tickMs: number, count = 1) {
+  const element = dom.document.createElement("div");
+  dom.document.body.append(element);
+  const host = element as unknown as HTMLElement;
+  const root = createRoot(host);
+  roots.add(root);
+  function Reader() {
+    const now = useNowSeconds(tickMs);
+    return <span data-now={String(now)} />;
+  }
+  flushSync(() => {
+    root.render(<>{Array.from({ length: count }, (_, index) => <Reader key={index} />)}</>);
+  });
+  return host;
+}
+
+test("the clock lands the real time on subscription and reports epoch seconds", () => {
+  const host = mount(60_000);
+  const now = Number((host.querySelector("span") as HTMLElement).dataset.now);
+  expect(now).toBeGreaterThan(1_700_000_000);
+  expect(Math.abs(now - Date.now() / 1000)).toBeLessThan(2);
+});
+
+test("every subscriber of one cadence shares a single clock value", async () => {
+  const host = mount(60, 3);
+  await Bun.sleep(120);
+  const values = [...host.querySelectorAll("span")].map((node) => (node as unknown as HTMLElement).dataset.now);
+  expect(values).toHaveLength(3);
+  expect(new Set(values).size).toBe(1);
+});
+
+test("the clock advances on its own so an age-derived surface never needs a reload", async () => {
+  const host = mount(60);
+  const first = Number((host.querySelector("span") as HTMLElement).dataset.now);
+  await Bun.sleep(150);
+  const later = Number((host.querySelector("span") as HTMLElement).dataset.now);
+  expect(later).toBeGreaterThan(first);
+});

--- a/src/hooks/useNowSeconds.dom.test.tsx
+++ b/src/hooks/useNowSeconds.dom.test.tsx
@@ -2,6 +2,7 @@ import { afterEach, expect, test } from "bun:test";
 import { Window } from "happy-dom";
 import { flushSync } from "react-dom";
 import { createRoot, type Root } from "react-dom/client";
+import { renderToStaticMarkup } from "react-dom/server";
 
 import { useNowSeconds } from "./useNowSeconds";
 
@@ -60,4 +61,30 @@ test("the clock advances on its own so an age-derived surface never needs a relo
   await Bun.sleep(150);
   const later = Number((host.querySelector("span") as HTMLElement).dataset.now);
   expect(later).toBeGreaterThan(first);
+});
+
+test("the first client render already carries the real time — no undemoted first frame", () => {
+  /* Reading 0 on the first frame would paint every age-derived chip
+     undemoted (a rail of pulsing green) and correct it a frame later, the
+     exact lie issue #669 exists to remove. #172 forbids that flash. */
+  const seen: number[] = [];
+  const element = dom.document.createElement("div");
+  dom.document.body.append(element);
+  const root = createRoot(element as unknown as HTMLElement);
+  roots.add(root);
+  function Reader() {
+    seen.push(useNowSeconds(90_000));
+    return null;
+  }
+  flushSync(() => root.render(<Reader />));
+
+  expect(seen.length).toBeGreaterThan(0);
+  expect(seen[0]).toBeGreaterThan(1_700_000_000);
+});
+
+test("the server render still reads 0, so hydration markup agrees", () => {
+  function Reader() {
+    return <span>{String(useNowSeconds(120_000))}</span>;
+  }
+  expect(renderToStaticMarkup(<Reader />)).toBe("<span>0</span>");
 });

--- a/src/hooks/useNowSeconds.ts
+++ b/src/hooks/useNowSeconds.ts
@@ -1,0 +1,65 @@
+"use client";
+
+import { useSyncExternalStore } from "react";
+
+/** Default cadence: a chip state whose threshold is minutes settles well
+    inside one tick, and every subscriber shares the one timer below. */
+const DEFAULT_TICK_MS = 15_000;
+
+interface Clock {
+  now: number;
+  listeners: Set<() => void>;
+  timer: ReturnType<typeof setInterval> | null;
+  /* Stable per cadence: `useSyncExternalStore` resubscribes whenever these
+     change identity, and a fresh subscription each render would restart the
+     timer forever. */
+  subscribe: (listener: () => void) => () => void;
+  read: () => number;
+}
+
+/* One clock per cadence, shared by every subscriber: a board carries a chip
+   surface per card, and each owning its own timer would tick them apart from
+   each other for no gain. */
+const clocks = new Map<number, Clock>();
+
+function clockFor(tickMs: number): Clock {
+  const existing = clocks.get(tickMs);
+  if (existing) return existing;
+  const clock = { now: 0, listeners: new Set<() => void>(), timer: null } as Clock;
+  clock.subscribe = (listener) => {
+    clock.listeners.add(listener);
+    if (clock.timer === null) {
+      clock.now = Date.now() / 1000;
+      clock.timer = setInterval(() => {
+        clock.now = Date.now() / 1000;
+        for (const notify of [...clock.listeners]) notify();
+      }, tickMs);
+    }
+    return () => {
+      clock.listeners.delete(listener);
+      if (clock.listeners.size === 0 && clock.timer !== null) {
+        clearInterval(clock.timer);
+        clock.timer = null;
+      }
+    };
+  };
+  clock.read = () => clock.now;
+  clocks.set(tickMs, clock);
+  return clock;
+}
+
+const serverSnapshot = () => 0;
+
+/**
+ * A ticking wall clock in epoch SECONDS for age-derived UI (issue #669: chip
+ * activity follows transcript freshness, so it must advance between scans).
+ *
+ * Reads `0` on the server render and through hydration, so their markup
+ * agrees; the subscription then lands the real time. Age consumers read `0` as
+ * "no clock yet" and leave their state undemoted for that frame rather than
+ * inventing an age.
+ */
+export function useNowSeconds(tickMs: number = DEFAULT_TICK_MS): number {
+  const clock = clockFor(tickMs);
+  return useSyncExternalStore(clock.subscribe, clock.read, serverSnapshot);
+}

--- a/src/hooks/useNowSeconds.ts
+++ b/src/hooks/useNowSeconds.ts
@@ -2,19 +2,21 @@
 
 import { useSyncExternalStore } from "react";
 
+import { epochSeconds, epochSecondsFromMs, type EpochSeconds } from "@/lib/types";
+
 /** Default cadence: a chip state whose threshold is minutes settles well
     inside one tick, and every subscriber shares the one timer below. */
 const DEFAULT_TICK_MS = 15_000;
 
 interface Clock {
-  now: number;
+  now: EpochSeconds;
   listeners: Set<() => void>;
   timer: ReturnType<typeof setInterval> | null;
   /* Stable per cadence: `useSyncExternalStore` resubscribes whenever these
      change identity, and a fresh subscription each render would restart the
      timer forever. */
   subscribe: (listener: () => void) => () => void;
-  read: () => number;
+  read: () => EpochSeconds;
 }
 
 /* One clock per cadence, shared by every subscriber: a board carries a chip
@@ -24,14 +26,26 @@ const clocks = new Map<number, Clock>();
 
 function clockFor(tickMs: number): Clock {
   const existing = clocks.get(tickMs);
-  if (existing) return existing;
-  const clock = { now: 0, listeners: new Set<() => void>(), timer: null } as Clock;
+  /* While nothing is subscribed the timer is off, so a clock re-read after a
+     gap would hand out its last value. Re-seed it there — never per read,
+     which must stay cached (React re-renders forever on a moving snapshot). */
+  if (existing) {
+    if (existing.timer === null && Date.now() / 1000 - existing.now >= tickMs / 1000) {
+      existing.now = epochSecondsFromMs(Date.now());
+    }
+    return existing;
+  }
+  /* Seeded at creation, so the FIRST client frame already carries the real
+     time: a board that painted `0` would paint every chip undemoted — a rail
+     of pulsing green — and correct itself a frame later, which is the exact
+     lie issue #669 exists to remove. */
+  const clock = { now: epochSecondsFromMs(Date.now()), listeners: new Set<() => void>(), timer: null } as Clock;
   clock.subscribe = (listener) => {
     clock.listeners.add(listener);
     if (clock.timer === null) {
-      clock.now = Date.now() / 1000;
+      clock.now = epochSecondsFromMs(Date.now());
       clock.timer = setInterval(() => {
-        clock.now = Date.now() / 1000;
+        clock.now = epochSecondsFromMs(Date.now());
         for (const notify of [...clock.listeners]) notify();
       }, tickMs);
     }
@@ -48,18 +62,18 @@ function clockFor(tickMs: number): Clock {
   return clock;
 }
 
-const serverSnapshot = () => 0;
+/** Hydration renders against the server's value, so both sides paint `0` and
+    their markup agrees; consumers read `0` as "no clock yet" and leave an
+    age-derived state undemoted rather than inventing an age. */
+const serverSnapshot = () => epochSeconds(0);
 
 /**
- * A ticking wall clock in epoch SECONDS for age-derived UI (issue #669: chip
+ * A ticking wall clock in epoch seconds for age-derived UI (issue #669: chip
  * activity follows transcript freshness, so it must advance between scans).
- *
- * Reads `0` on the server render and through hydration, so their markup
- * agrees; the subscription then lands the real time. Age consumers read `0` as
- * "no clock yet" and leave their state undemoted for that frame rather than
- * inventing an age.
+ * Client renders read the real time from the first frame; only the server
+ * render and the hydration pass read `0`.
  */
-export function useNowSeconds(tickMs: number = DEFAULT_TICK_MS): number {
+export function useNowSeconds(tickMs: number = DEFAULT_TICK_MS): EpochSeconds {
   const clock = clockFor(tickMs);
   return useSyncExternalStore(clock.subscribe, clock.read, serverSnapshot);
 }

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -1042,6 +1042,7 @@ export const en = {
   "subagentTray.unfold": "Restore {name} to a full card",
   "subagentTray.state.running": "working",
   "subagentTray.state.live": "live",
+  "subagentTray.state.silent": "alive but silent",
   "subagentTray.state.closed": "idle",
   "subagentTray.state.dead": "unavailable",
 

--- a/src/lib/i18n/uk.ts
+++ b/src/lib/i18n/uk.ts
@@ -1012,6 +1012,7 @@ export const uk: Record<keyof typeof en, Message> = {
   "subagentTray.unfold": "Повернути {name} як повну картку",
   "subagentTray.state.running": "працює",
   "subagentTray.state.live": "наживо",
+  "subagentTray.state.silent": "живий, але мовчить",
   "subagentTray.state.closed": "простій",
   "subagentTray.state.dead": "недоступний",
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -14,6 +14,29 @@ export type Engine = "codex" | "claude" | "shell";
 export type Activity = "live" | "recent" | "stalled" | "idle";
 export type Fmt = "codex" | "claude" | "plain";
 
+declare const epochSecondsBrand: unique symbol;
+/**
+ * A wall clock in epoch SECONDS — the unit {@link FileEntry.mtime} and every
+ * age comparison drawn against it are measured in.
+ *
+ * Branded on purpose: a millisecond clock is the same primitive and reads the
+ * same at a glance, and feeding one to a seconds comparison is silent (an age
+ * 1000x too large, every TTL blown, every transcript "ancient"). Passing a
+ * plain `number` where this is asked for is a type error, so the conversion
+ * has to happen where it can be seen.
+ */
+export type EpochSeconds = number & { readonly [epochSecondsBrand]: true };
+
+/** Declare that a number already IS epoch seconds (a fixture, a parsed field). */
+export function epochSeconds(value: number): EpochSeconds {
+  return value as EpochSeconds;
+}
+
+/** Convert a millisecond wall clock (`Date.now()`) to epoch seconds. */
+export function epochSecondsFromMs(ms: number): EpochSeconds {
+  return (ms / 1000) as EpochSeconds;
+}
+
 export interface StructuredSpawnCardState {
   launchId: string;
   clientAttemptId: string | null;


### PR DESCRIPTION
## What was wrong

The chips lied in both directions. Seven hosts of closed pipelines kept a live process with no transcript output — four of them silent for 7.5 hours — and stayed coloured as working; opening one showed nothing happening. Meanwhile three lanes writing records every few seconds rendered grey, as finished. Colour followed process liveness plus snapshot age, never actual output.

## The commits

**`a7c80948`** derives chip activity from how long ago the transcript last grew, and gives a host that stayed alive with nothing to say its own state — alive but silent after five minutes, a steady warning ring, told apart from both working and finished. The threshold is 2.5× the scanner's own 180s stall gate, so a two-minute think cannot flicker.

**`5b0429e3`** fixes a regression the first review caught: `hostAlive` was process-only, and a Claude in-harness subagent is never assigned a pid, so every one of them had no process forever and any gap past the threshold read as *finished*. A six-minute test run, a build, a long fetch — all routine — showed a working agent as done. An open turn now counts as liveness, so silence demotes to the honest amber rather than claiming completion.

**`0f8a1cfb`** closes the other half the second review raised: a turn that ended cleanly reads as done even with the host still attached, so a delivered worker greys out instead of sitting amber beside a genuinely wedged one.

## Review

Three independent read-only rounds: REQUEST_CHANGES, COMMENT, then **APPROVE** with four LOW comments. The second reviewer ran the shipped function to demonstrate the regression (busy subagent at ten minutes → closed, at four minutes → live) rather than arguing from the code.

## Verification

`subagentTray.test.ts` and `SubagentBadges.dom.test.tsx`: 43 pass, 0 fail on the merge result. `tsc --noEmit` clean, `lint` adds no new problems, privacy gate green. Merged with current `main`; the only conflict was two CHANGELOG entries under the same heading, both kept.

Closes #669