### PR TITLE
fix(pipelines): closing a pipeline stops its hosts and reports what it stopped (#670)

### DIFF
--- a/src/app/api/pipelines/[id]/route.test.ts
+++ b/src/app/api/pipelines/[id]/route.test.ts
@@ -6,6 +6,7 @@ const pipeline = { id: "pipeline-1" };
 const closeReport = {
   stopped: [{ stageId: "build", attempt: 1, conversationId: "conversation_stage_1", agentPath: null, paneId: null }],
   alreadyStopped: [],
+  unconfirmed: [],
   stillRunning: [],
   worktree: { dir: "/repo-pipeline-1", uncommitted: ["notes.md"], truncated: false },
 };

--- a/src/app/api/pipelines/[id]/route.test.ts
+++ b/src/app/api/pipelines/[id]/route.test.ts
@@ -7,6 +7,8 @@ const closeReport = {
   stopped: [{ stageId: "build", attempt: 1, conversationId: "conversation_stage_1", agentPath: null, paneId: null }],
   alreadyStopped: [],
   unconfirmed: [],
+  acknowledged: [],
+  reviewers: [],
   stillRunning: [],
   worktree: { dir: "/repo-pipeline-1", uncommitted: ["notes.md"], truncated: false },
 };
@@ -110,5 +112,23 @@ test("pipeline PATCH forwards repository-admission fields from final revalidatio
     code: "git_metadata_unwritable",
     field: "repoDir",
     path: "/blocked/.git",
+  });
+});
+
+test("pipeline close forwards the operator's host acknowledgement to the engine (#670)", async () => {
+  const response = await PATCH(
+    new NextRequest("http://127.0.0.1/api/pipelines/pipeline-1", {
+      method: "PATCH",
+      headers: { host: "127.0.0.1" },
+      body: JSON.stringify({ action: "close", acknowledgeHosts: true }),
+    }),
+    { params: Promise.resolve({ id: "pipeline-1" }) },
+  );
+  expect(response.status).toBe(200);
+  /* The dismissal has to survive the route, or the operator's only way out of
+     an unidentifiable pane never reaches the close. */
+  expect(await response.json()).toMatchObject({
+    ok: true,
+    pipeline: { body: { action: "close", acknowledgeHosts: true } },
   });
 });

--- a/src/app/api/pipelines/[id]/route.test.ts
+++ b/src/app/api/pipelines/[id]/route.test.ts
@@ -3,6 +3,17 @@ import { expect, mock, test } from "bun:test";
 import { NextRequest } from "next/server";
 
 const pipeline = { id: "pipeline-1" };
+const closeReport = {
+  stopped: [{ stageId: "build", attempt: 1, conversationId: "conversation_stage_1", agentPath: null, paneId: null }],
+  alreadyStopped: [],
+  stillRunning: [],
+  worktree: { dir: "/repo-pipeline-1", uncommitted: ["notes.md"], truncated: false },
+};
+const refusedClose = {
+  ...closeReport,
+  stopped: [],
+  stillRunning: [{ stageId: "build", attempt: 1, conversationId: "conversation_stage_1", agentPath: null, paneId: null, error: "host is unreachable" }],
+};
 mock.module("@/lib/pipelines/engine", () => ({
   getPipelines: () => ({ pipelines: [pipeline] }),
   createPipelineFromRequest: () => ({ pipeline }),
@@ -11,6 +22,12 @@ mock.module("@/lib/pipelines/engine", () => ({
     if (id !== pipeline.id) return { error: "pipeline not found", status: 404 };
     if ((body as { repoDir?: string }).repoDir === "/blocked") {
       return { error: "Git metadata is not writable: /blocked/.git", status: 403, code: "git_metadata_unwritable", field: "repoDir", path: "/blocked/.git" };
+    }
+    if ((body as { action?: string }).action === "close") {
+      if ((body as { stageId?: string }).stageId === "stuck") {
+        return { error: "could not stop stage build attempt 1", status: 409, close: refusedClose };
+      }
+      return { pipeline: { ...pipeline, body }, close: closeReport };
     }
     return { pipeline: { ...pipeline, body } };
   },
@@ -41,6 +58,22 @@ test("pipeline DELETE discards a draft through the delete action", async () => {
   );
   expect(response.status).toBe(200);
   expect(await response.json()).toEqual({ ok: true, pipeline: { ...pipeline, body: { action: "delete" } } });
+});
+
+test("pipeline close forwards its host-teardown report on success and on refusal (#670)", async () => {
+  const response = await PATCH(
+    new NextRequest("http://127.0.0.1/api/pipelines/pipeline-1", { method: "PATCH", headers: { host: "127.0.0.1" }, body: JSON.stringify({ action: "close" }) }),
+    { params: Promise.resolve({ id: "pipeline-1" }) },
+  );
+  expect(response.status).toBe(200);
+  expect(await response.json()).toMatchObject({ ok: true, close: closeReport });
+
+  const refused = await PATCH(
+    new NextRequest("http://127.0.0.1/api/pipelines/pipeline-1", { method: "PATCH", headers: { host: "127.0.0.1" }, body: JSON.stringify({ action: "close", stageId: "stuck" }) }),
+    { params: Promise.resolve({ id: "pipeline-1" }) },
+  );
+  expect(refused.status).toBe(409);
+  expect(await refused.json()).toEqual({ error: "could not stop stage build attempt 1", close: refusedClose });
 });
 
 test("pipeline PATCH rejects unknown actions", async () => {

--- a/src/app/api/pipelines/[id]/route.ts
+++ b/src/app/api/pipelines/[id]/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 
 import { requestPipelineTick } from "@/lib/pipelines/controllerSignal";
-import { patchPipeline } from "@/lib/pipelines/engine";
+import { patchPipeline, type PipelineCloseReport } from "@/lib/pipelines/engine";
 import type { PatchPipelineRequest, Pipeline, PipelineAction, PipelineRepoPreflightErrorCode } from "@/lib/pipelines/types";
 import { rejectCrossOrigin } from "@/lib/sameOrigin";
 import type { ApiError } from "@/lib/types";
@@ -21,12 +21,14 @@ type PipelineApiError = ApiError & {
   code?: PipelineRepoPreflightErrorCode;
   field?: "repoDir";
   path?: string;
+  /** Present when a close was refused: the hosts it stopped and the one it could not. */
+  close?: PipelineCloseReport;
 };
 
 export async function PATCH(
   req: NextRequest,
   ctx: { params: Promise<{ id: string }> },
-): Promise<NextResponse<{ ok: true; pipeline: Pipeline } | PipelineApiError>> {
+): Promise<NextResponse<{ ok: true; pipeline: Pipeline; close?: PipelineCloseReport } | PipelineApiError>> {
   const rejection = rejectCrossOrigin(req);
   if (rejection) return rejection;
   let body: PatchPipelineRequest;
@@ -44,9 +46,10 @@ export async function PATCH(
     if (!result.pipeline) return NextResponse.json({
       error: result.error ?? "could not update pipeline",
       ...(result.code ? { code: result.code, field: result.field, path: result.path } : {}),
+      ...(result.close ? { close: result.close } : {}),
     }, { status: result.status ?? 400 });
     if (CONTROLLER_ACTIONS.has(body.action)) requestPipelineTick();
-    return NextResponse.json({ ok: true, pipeline: result.pipeline });
+    return NextResponse.json({ ok: true, pipeline: result.pipeline, ...(result.close ? { close: result.close } : {}) });
   } catch (error) {
     return NextResponse.json({ error: error instanceof Error ? error.message : "could not update pipeline" }, { status: 500 });
   }

--- a/src/lib/flows/commands.ts
+++ b/src/lib/flows/commands.ts
@@ -299,7 +299,14 @@ export async function cancelRound(id: string): Promise<{ flow?: Flow; error?: st
  * still run and close the loop. The implementer session is untouched — only
  * the reviewer side goes away.
  */
-export async function closeFlow(id: string): Promise<{ flow?: Flow; error?: string; status?: number }> {
+export async function closeFlow(id: string): Promise<{
+  flow?: Flow;
+  error?: string;
+  status?: number;
+  /** The round whose live reviewer this close terminated, so a caller can report
+      what it stopped instead of claiming nothing was running (#670). */
+  stoppedReviewer?: { round: number } | null;
+}> {
   const flows = loadFlows();
   const flow = flows.find((item) => item.id === id);
   if (!flow) return { error: "flow not found", status: 404 };
@@ -312,10 +319,11 @@ export async function closeFlow(id: string): Promise<{ flow?: Flow; error?: stri
       return { error: "reviewer process group did not terminate", status: 409 };
     }
   }
+  const stoppedReviewer = stoppedRound === null ? null : { round: stoppedRound.n };
   return await withFlowMutation((current, persist) => {
     const currentFlow = current.find((item) => item.id === id);
     if (!currentFlow) return { error: "flow not found", status: 404 };
-    if (currentFlow.state === "closed") return { flow: currentFlow };
+    if (currentFlow.state === "closed") return { flow: currentFlow, stoppedReviewer };
     const currentRound = lastRound(currentFlow);
     if (stoppedRound !== null
       && (currentRound?.n !== stoppedRound.n
@@ -330,7 +338,7 @@ export async function closeFlow(id: string): Promise<{ flow?: Flow; error?: stri
     currentFlow.closedAt = isoNow();
     currentFlow.stateDetail = null;
     persist();
-    return { flow: currentFlow };
+    return { flow: currentFlow, stoppedReviewer };
   });
 }
 

--- a/src/lib/mcp/bindings.test.ts
+++ b/src/lib/mcp/bindings.test.ts
@@ -607,6 +607,8 @@ test("a refused pipeline close exposes its host report through MCP, not only pro
     stopped: [{ stageId: "plan", attempt: 1, conversationId: "conversation_plan", agentPath: null, paneId: null }],
     alreadyStopped: [],
     unconfirmed: [],
+    acknowledged: [],
+    reviewers: [],
     stillRunning: [{ stageId: "build", attempt: 2, conversationId: "conversation_build", agentPath: null, paneId: "%7", error: "structured runtime host is unavailable" }],
     worktree: { dir: "/repo-pipeline-1", uncommitted: ["notes.md"], truncated: false },
   };

--- a/src/lib/mcp/bindings.test.ts
+++ b/src/lib/mcp/bindings.test.ts
@@ -9,6 +9,7 @@ import type { BoardTask } from "@/lib/tasks/types";
 import type { FileEntry } from "@/lib/types";
 
 import { viewerMcpBindings } from "./bindings";
+import { createMcpToolService, type McpToolResult } from "./server";
 
 const sandboxes: string[] = [];
 const originalStateDir = process.env.LLV_STATE_DIR;
@@ -599,4 +600,47 @@ test("conversation_migration delegates to the revision-fenced migration command 
   });
   expect(migrationOperationId).toMatch(/^mcp_conversation_migration_[0-9a-f]{24}$/);
   expect((result.receipt as { operationId: string }).operationId).toBe(migrationOperationId);
+});
+
+test("a refused pipeline close exposes its host report through MCP, not only prose (#670)", async () => {
+  const close = {
+    stopped: [{ stageId: "plan", attempt: 1, conversationId: "conversation_plan", agentPath: null, paneId: null }],
+    alreadyStopped: [],
+    unconfirmed: [],
+    stillRunning: [{ stageId: "build", attempt: 2, conversationId: "conversation_build", agentPath: null, paneId: "%7", error: "structured runtime host is unavailable" }],
+    worktree: { dir: "/repo-pipeline-1", uncommitted: ["notes.md"], truncated: false },
+  };
+  const bindings = viewerMcpBindings(undefined, undefined, {
+    patchPipeline: async (_id: string, request: { action?: string }) => (request.action === "close"
+      ? { error: "could not stop stage build attempt 2 (conversation_build): structured runtime host is unavailable", status: 409, close }
+      : { pipeline: { id: "pipeline_1", state: "paused" } }),
+  } as never);
+  const results = new Map<string, McpToolResult>();
+  const service = createMcpToolService(bindings, {
+    claim: async (key: string) => (results.has(key) ? { kind: "replay" as const, result: results.get(key)! } : { kind: "fresh" as const }),
+    complete: async (key: string, _digest: string, result: McpToolResult) => { results.set(key, result); },
+  } as never);
+
+  const refused = await service.callTool("pipeline_action", {
+    clientRequestId: "close-refused",
+    pipelineId: "pipeline_1",
+    action: "close",
+  });
+
+  expect(refused.ok).toBeFalse();
+  /* An agent driving the board gets the structured evidence an HTTP caller
+     gets — which host survived and where to find it — not just the prose. */
+  expect(refused).toMatchObject({
+    code: "tool_failed",
+    error: "could not stop stage build attempt 2 (conversation_build): structured runtime host is unavailable",
+    details: { close: { stillRunning: [{ stageId: "build", attempt: 2, conversationId: "conversation_build", paneId: "%7" }] } },
+  });
+
+  const paused = await service.callTool("pipeline_action", {
+    clientRequestId: "pause-ok",
+    pipelineId: "pipeline_1",
+    action: "pause",
+  });
+  expect(paused).toMatchObject({ ok: true, pipelineId: "pipeline_1" });
+  expect((paused as { details?: unknown }).details).toBeUndefined();
 });

--- a/src/lib/mcp/bindings.ts
+++ b/src/lib/mcp/bindings.ts
@@ -235,7 +235,9 @@ async function pipelineAction(args: McpToolArgs): Promise<McpToolPayload> {
   const result = await patchPipeline(pipelineId, request as PatchPipelineRequest);
   if (!result.pipeline) throw new Error(result.error ?? "could not update pipeline");
   if (PIPELINE_CONTROLLER_ACTIONS.has(action)) requestPipelineTick();
-  return { pipelineId, pipeline: result.pipeline };
+  /* A close reports the stage hosts it terminated and the uncommitted work it
+     left behind (#670), so an agent driving the board sees it too. */
+  return { pipelineId, pipeline: result.pipeline, ...(result.close ? { close: result.close } : {}) };
 }
 
 async function linkTaskToPipeline(args: McpToolArgs, dependencies: LinkTaskToPipelineDependencies): Promise<McpToolPayload> {

--- a/src/lib/mcp/bindings.ts
+++ b/src/lib/mcp/bindings.ts
@@ -28,7 +28,7 @@ import { collectSnapshot } from "@/lib/view/collect";
 import { hardenedRedact } from "@/lib/view/compactText";
 import { validateSnapshotRequest } from "@/lib/view/validation";
 
-import type { McpToolArgs, McpToolBindings, McpToolPayload } from "./server";
+import { McpToolRefusal, type McpToolArgs, type McpToolBindings, type McpToolPayload } from "./server";
 
 const PIPELINE_CONTROLLER_ACTIONS = new Set<PipelineAction>(["start", "resume", "retry-stage", "skip-stage"]);
 
@@ -86,6 +86,7 @@ export interface ViewerMcpDomainDependencies {
   cancelRound: typeof cancelRound;
   closeFlow: typeof closeFlow;
   getPipelines: typeof getPipelines;
+  patchPipeline: typeof patchPipeline;
   loadTasks: typeof loadTasks;
   collectSnapshot: typeof collectSnapshot;
   runtimeEventsEnabled: typeof runtimeEventsEnabled;
@@ -104,6 +105,7 @@ const productionDomainDependencies: ViewerMcpDomainDependencies = {
   cancelRound,
   closeFlow,
   getPipelines,
+  patchPipeline,
   loadTasks,
   collectSnapshot,
   runtimeEventsEnabled,
@@ -228,12 +230,17 @@ async function createPipeline(args: McpToolArgs): Promise<McpToolPayload> {
   return { pipelineId: result.pipeline.id, pipeline: result.pipeline };
 }
 
-async function pipelineAction(args: McpToolArgs): Promise<McpToolPayload> {
+async function pipelineAction(args: McpToolArgs, dependencies: ViewerMcpDomainDependencies): Promise<McpToolPayload> {
   const pipelineId = required(args, "pipelineId");
   const action = required(args, "action") as PipelineAction;
   const request = withoutKeys(args, ["pipelineId", "clientRequestId"]);
-  const result = await patchPipeline(pipelineId, request as PatchPipelineRequest);
-  if (!result.pipeline) throw new Error(result.error ?? "could not update pipeline");
+  const result = await dependencies.patchPipeline(pipelineId, request as PatchPipelineRequest);
+  if (!result.pipeline) {
+    const message = result.error ?? "could not update pipeline";
+    /* A refused close carries the hosts it stopped and the one it could not
+       (#670); an agent driving the board must not get less than an HTTP caller. */
+    throw result.close ? new McpToolRefusal(message, { close: result.close }) : new Error(message);
+  }
   if (PIPELINE_CONTROLLER_ACTIONS.has(action)) requestPipelineTick();
   /* A close reports the stage hosts it terminated and the uncommitted work it
      left behind (#670), so an agent driving the board sees it too. */
@@ -561,7 +568,7 @@ export function viewerMcpBindings(
     create_task: createBoardTask,
     update_task: updateBoardTask,
     create_pipeline: createPipeline,
-    pipeline_action: pipelineAction,
+    pipeline_action: (args) => pipelineAction(args, domainDependencies),
     link_task_to_pipeline: (args) => linkTaskToPipeline(args, linkTaskDependencies),
     list_conversations: listConversations,
     get_conversation: (args) => getConversation(args, domainDependencies),

--- a/src/lib/mcp/server.ts
+++ b/src/lib/mcp/server.ts
@@ -74,7 +74,18 @@ export type McpToolFailure = {
   error: string;
   code: string;
   retryable: boolean;
+  /** Structured evidence a binding attached to its refusal, so an agent gets the
+      same payload an HTTP caller does instead of only the prose message. */
+  details?: McpToolPayload;
 };
+
+/** Thrown by a binding that refuses with machine-readable evidence. */
+export class McpToolRefusal extends Error {
+  constructor(message: string, readonly details: McpToolPayload) {
+    super(message);
+    this.name = "McpToolRefusal";
+  }
+}
 
 export type McpToolResult = McpToolSuccess | McpToolFailure;
 
@@ -830,8 +841,9 @@ function failure(
   error: string,
   retryable: boolean,
   replayed = false,
+  details?: McpToolPayload,
 ): McpToolFailure {
-  return { ok: false, toolName, clientRequestId: requestId, replayed, error, code, retryable };
+  return { ok: false, toolName, clientRequestId: requestId, replayed, error, code, retryable, ...(details ? { details } : {}) };
 }
 
 export interface McpToolService {
@@ -882,6 +894,8 @@ export function createMcpToolService(
             "tool_failed",
             error instanceof Error ? error.message : String(error),
             true,
+            false,
+            error instanceof McpToolRefusal ? error.details : undefined,
           );
         }
         await receipts.complete(key, digest, settled, retention);

--- a/src/lib/pipelines/engine.test.ts
+++ b/src/lib/pipelines/engine.test.ts
@@ -106,7 +106,8 @@ function harness() {
   /* Panes the harness considers killable, and the clock the teardown budget
      reads. Both default to the benign case so existing tests are unaffected. */
   const killedPanes: string[] = [];
-  let paneKill: { ok: true } | { ok: false; error: string } = { ok: true };
+  let paneStop: Awaited<ReturnType<PipelinePorts["stopStagePane"]>> = { outcome: "stopped" };
+  let worktreePresent = true;
   let residentHosts = false;
   let monotonic: () => number = () => Date.now();
   const ports: PipelinePorts = {
@@ -151,19 +152,20 @@ function harness() {
       calls.push(`stop-host:${target.stageId}:${target.attempt}:${target.conversationId ?? "none"}`);
       return stageHosts.get(target.conversationId ?? "") ?? { outcome: "not-running" };
     },
-    killStagePane: async (paneId) => {
-      calls.push(`kill-pane:${paneId}`);
-      if (paneKill.ok) {
-        killedPanes.push(paneId);
+    stopStagePane: async (target) => {
+      calls.push(`stop-pane:${target.stageId}:${target.attempt}:${target.paneId ?? "none"}`);
+      if (paneStop.outcome === "stopped" && target.paneId) {
+        killedPanes.push(target.paneId);
         paneAlive = false;
       }
-      return paneKill;
+      return paneStop;
     },
     stageHostResident: async (target) => {
       calls.push(`host-resident:${target.stageId}:${target.attempt}`);
       return residentHosts;
     },
     monotonicNow: () => monotonic(),
+    worktreePresent: () => worktreePresent,
     conversationAgentActive: async () => conversationActive,
     durableTurnEvidence: async (_engine, transcriptPath) => durableTurns.get(transcriptPath) ?? null,
     headCwd: () => loadPipelines()[0]?.worktreeDir ?? null,
@@ -211,7 +213,8 @@ function harness() {
     setBuilderEffort: (effort: string) => { builderEffort = effort; },
     setPaneAlive: (alive: boolean) => { paneAlive = alive; },
     setStageHost: (conversationId: string, result: PipelineStageStopResult) => { stageHosts.set(conversationId, result); },
-    setPaneKill: (result: { ok: true } | { ok: false; error: string }) => { paneKill = result; },
+    setPaneStop: (result: Awaited<ReturnType<PipelinePorts["stopStagePane"]>>) => { paneStop = result; },
+    setWorktreePresent: (present: boolean) => { worktreePresent = present; },
     setHostsResident: (resident: boolean) => { residentHosts = resident; },
     setMonotonicClock: (clock: () => number) => { monotonic = clock; },
     killedPanes,
@@ -2782,7 +2785,12 @@ test("retry parks without synchronizing when reviewer termination cannot be veri
   /* The close carries its host-teardown report (#670) even when the flow refuses
      to close, so nothing it already stopped is swallowed by the rejection. */
   expect(closed).toMatchObject({ error: "reviewer process group did not terminate", status: 409 });
-  expect(closed.close).toMatchObject({ stopped: [], stillRunning: [] });
+  /* A reviewer that would not die leaves through the same report a surviving
+     stage host does, not only through the prose error (#670). */
+  expect(closed.close).toMatchObject({
+    stopped: [],
+    stillRunning: [{ stageId: "review", attempt: 1, error: "reviewer process group did not terminate" }],
+  });
   expect(loadPipelines()[0]).toMatchObject({ state: "needs_decision", closedAt: null, stateDetail: "reviewer process group did not terminate" });
 });
 
@@ -3225,6 +3233,7 @@ test("a parked stage with no resident host still reports nothing was running (#6
 test("closing a pipeline whose host is already gone reports that nothing was running (#670)", async () => {
   const h = harness();
   h.setPaneAlive(false);
+  h.setPaneStop({ outcome: "not-running" });
   const pipeline = await create(h.ports);
   await tickPipelines([], h.ports);
   await tickPipelines([], h.ports);
@@ -3341,6 +3350,55 @@ test("an unconfirmed host record retires once its host is demonstrably gone (#67
   expect(h.calls.filter((call) => call.startsWith("stop-host:")).length).toBe(1);
 });
 
+test("closing mid-review counts the reviewer it stopped (#670)", async () => {
+  const h = harness();
+  const stages = [
+    { id: "build", kind: "run", ["prompt"]: "build", next: "review" },
+    { id: "review", kind: "review-loop", role: { roleId: "reviewer" }, ["prompt"]: "review", next: null },
+  ] as const;
+  const pipeline = await create(h.ports, stages as never);
+  await tickPipelines([], h.ports);
+  await tickPipelines([], h.ports);
+  await tickPipelines([h.finish("/codex/stage-1.jsonl", "pass")], h.ports);
+  await tickPipelines([entry("/codex/stage-1.jsonl")], h.ports);
+  h.setPaneAlive(false);
+  h.setPaneStop({ outcome: "not-running" });
+  /* A headless reviewer is a child process with no registry entry, so the host
+     teardown cannot see it — closeFlow is what stops it. */
+  h.ports.closeFlow = async (id) => {
+    h.calls.push(`flow-close:${id}`);
+    return { flow: h.flows.get(id), stoppedReviewer: { round: 1 } };
+  };
+
+  const closed = await patchPipeline(pipeline.id, { action: "close" }, h.ports);
+
+  expect(closed.error).toBeUndefined();
+  expect(closed.close?.reviewers).toMatchObject([{ stageId: "review", flowId: "flow-1", round: 1 }]);
+  /* The lane must not report "closed, nothing was running" after killing one. */
+  expect(loadPipelines()[0]!.stateDetail).toBe("closed; stopped 1 review round");
+});
+
+test("a worktree removed after a merge closes tidily, with no error text (#670)", async () => {
+  const h = harness();
+  h.setPaneAlive(false);
+  h.setPaneStop({ outcome: "not-running" });
+  const baseExec = h.ports.exec;
+  h.ports.exec = (command, args, cwd) => {
+    /* What realExec answers for a missing cwd. It must never be reached. */
+    if (command === "git" && args[0] === "status") return { code: 1, stdout: "", stderr: "spawnSync git ENOENT" };
+    return baseExec(command, args, cwd);
+  };
+  const pipeline = await create(h.ports);
+  await tickPipelines([], h.ports);
+  await tickPipelines([], h.ports);
+  h.setWorktreePresent(false);
+
+  const closed = await patchPipeline(pipeline.id, { action: "close" }, h.ports);
+
+  expect(closed.close?.worktree).toBeNull();
+  expect(loadPipelines()[0]).toMatchObject({ state: "closed", stateDetail: null });
+});
+
 test("a settled attempt with an idle CLI in its pane does not block the close (#670)", async () => {
   const h = harness();
   const pipeline = await create(h.ports);
@@ -3361,44 +3419,48 @@ test("a settled attempt with an idle CLI in its pane does not block the close (#
   expect(loadPipelines()[0]!.state).toBe("closed");
 });
 
-test("a live pane behind a host the registry does not know is killed, not refused (#670)", async () => {
+test("a pane the teardown can identify as this stage's is stopped, not refused (#670)", async () => {
   const h = harness();
   const pipeline = await create(h.ports);
   await tickPipelines([], h.ports);
   await tickPipelines([], h.ports);
-  /* The registry entry is gone (stopStageAgent says not-running) but the pane
-     still runs a mid-turn agent. Refusing would hand the operator a card that
-     never closes and a host to kill by hand. */
+  /* The registry has no resident host but the pane's recorded identity still
+     matches, so the orphan is stopped instead of handed back to the operator. */
   h.setPaneAlive(true);
+  h.setPaneStop({ outcome: "stopped" });
 
   const closed = await patchPipeline(pipeline.id, { action: "close" }, h.ports);
 
   expect(closed.error).toBeUndefined();
-  expect(h.calls).toContain("kill-pane:%1");
+  expect(h.calls).toContain("stop-pane:plan:1:%1");
   expect(h.killedPanes).toEqual(["%1"]);
   expect(closed.close?.stopped).toMatchObject([{ stageId: "plan", attempt: 1, paneId: "%1" }]);
   expect(loadPipelines()[0]).toMatchObject({ state: "closed", stateDetail: "closed; stopped 1 stage host" });
 });
 
-test("a pane that survives its kill still refuses the close (#670)", async () => {
+test("a pane that cannot be identified is reported, never killed (#670)", async () => {
   const h = harness();
   const pipeline = await create(h.ports);
   await tickPipelines([], h.ports);
   await tickPipelines([], h.ports);
   h.setPaneAlive(true);
-  h.setPaneKill({ ok: false, error: "no server running on /tmp/tmux-1000/default" });
+  h.setPaneStop({ outcome: "unknown", detail: "pane %1 runs an agent that cannot be identified as this stage's" });
 
-  const refused = await patchPipeline(pipeline.id, { action: "close" }, h.ports);
+  const closed = await patchPipeline(pipeline.id, { action: "close" }, h.ports);
 
-  expect(refused.status).toBe(409);
-  expect(refused.error).toContain("could not kill pane %1");
-  expect(refused.close?.stillRunning).toMatchObject([{ stageId: "plan", attempt: 1, paneId: "%1" }]);
-  expect(loadPipelines()[0]!.state).not.toBe("closed");
+  /* Unidentifiable is neither a stop nor a silent pass: nothing was signalled,
+     and the lane stays visible with the pane named. */
+  expect(h.killedPanes).toEqual([]);
+  expect(closed.close?.stopped).toEqual([]);
+  expect(closed.close?.unconfirmed).toMatchObject([{ stageId: "plan", attempt: 1, paneId: "%1", operationId: null }]);
+  expect(loadPipelines()[0]!.hiddenAt).toBeNull();
+  expect(loadPipelines()[0]!.stateDetail).toContain("cannot be identified");
 });
 
 test("an unreadable worktree is reported instead of closing as if nothing was left (#670)", async () => {
   const h = harness();
   h.setPaneAlive(false);
+  h.setPaneStop({ outcome: "not-running" });
   const baseExec = h.ports.exec;
   let failStatus = false;
   h.ports.exec = (command, args, cwd) => {

--- a/src/lib/pipelines/engine.test.ts
+++ b/src/lib/pipelines/engine.test.ts
@@ -21,6 +21,7 @@ const { registerPipelineTick } = await import("./controllerSignal");
 const { loadPipelines, savePipelines } = await import("./store");
 const { saveTasks } = await import("@/lib/tasks/store");
 type PipelinePorts = import("./engine").PipelinePorts;
+type PipelineStageStopResult = import("./engine").PipelineStageStopResult;
 type StageTurnEvidence = import("./durableEvidence").StageTurnEvidence;
 
 /* tickPipelines self-schedules a follow-up tick when a pass leaves a pending
@@ -99,6 +100,9 @@ function harness() {
   let builderEffort = "medium";
   let paneAlive = true;
   let conversationActive: boolean | null = null;
+  /* Stage hosts are "not running" unless a test seats one; nothing in this
+     suite may reach a real host or the operator's registry. */
+  const stageHosts = new Map<string, PipelineStageStopResult>();
   const ports: PipelinePorts = {
     exec: (command, args) => {
       calls.push(`${command} ${args.join(" ")}`);
@@ -137,6 +141,10 @@ function harness() {
       return { launchId: `launch-${spawn}`, conversationId: `conversation_stage_${spawn}`, sessionId: `session-${spawn}`, transcript: `/codex/stage-${spawn}.jsonl`, paneId: `%${spawn}` };
     },
     paneAgentAlive: async () => paneAlive,
+    stopStageAgent: async (target) => {
+      calls.push(`stop-host:${target.stageId}:${target.attempt}:${target.conversationId ?? "none"}`);
+      return stageHosts.get(target.conversationId ?? "") ?? { outcome: "not-running" };
+    },
     conversationAgentActive: async () => conversationActive,
     durableTurnEvidence: async (_engine, transcriptPath) => durableTurns.get(transcriptPath) ?? null,
     headCwd: () => loadPipelines()[0]?.worktreeDir ?? null,
@@ -183,6 +191,7 @@ function harness() {
     finish,
     setBuilderEffort: (effort: string) => { builderEffort = effort; },
     setPaneAlive: (alive: boolean) => { paneAlive = alive; },
+    setStageHost: (conversationId: string, result: PipelineStageStopResult) => { stageHosts.set(conversationId, result); },
     setConversationActive: (active: boolean | null) => { conversationActive = active; },
   };
 }
@@ -2747,7 +2756,10 @@ test("retry parks without synchronizing when reviewer termination cannot be veri
   expect(loadPipelines()[0]).toMatchObject({ state: "needs_decision", stateDetail: "reviewer process group did not terminate" });
 
   const closed = await patchPipeline(pipeline.id, { action: "close" }, h.ports);
-  expect(closed).toEqual({ error: "reviewer process group did not terminate", status: 409 });
+  /* The close carries its host-teardown report (#670) even when the flow refuses
+     to close, so nothing it already stopped is swallowed by the rejection. */
+  expect(closed).toMatchObject({ error: "reviewer process group did not terminate", status: 409 });
+  expect(closed.close).toMatchObject({ stopped: [], stillRunning: [] });
   expect(loadPipelines()[0]).toMatchObject({ state: "needs_decision", closedAt: null, stateDetail: "reviewer process group did not terminate" });
 });
 
@@ -3094,6 +3106,119 @@ test("closing a mid-run or parked pipeline persists a record that loads back", a
   expect(loadPipelines()[0]!.state).toBe("needs_decision");
   await patchPipeline(parked.id, { action: "close" }, h.ports);
   expect(loadPipelines()[0]!).toMatchObject({ state: "closed", cursor: null });
+});
+
+test("closing a running pipeline terminates its stage host and reports the stop (#670)", async () => {
+  const h = harness();
+  const pipeline = await create(h.ports);
+  await tickPipelines([], h.ports);
+  await tickPipelines([], h.ports);
+  h.setStageHost("conversation_stage_1", { outcome: "stopped" });
+
+  const closed = await patchPipeline(pipeline.id, { action: "close" }, h.ports);
+
+  expect(h.calls).toContain("stop-host:plan:1:conversation_stage_1");
+  expect(closed.error).toBeUndefined();
+  expect(closed.close).toMatchObject({
+    stopped: [{ stageId: "plan", attempt: 1, conversationId: "conversation_stage_1", agentPath: "/codex/stage-1.jsonl" }],
+    alreadyStopped: [],
+    stillRunning: [],
+  });
+  expect(loadPipelines()[0]).toMatchObject({
+    state: "closed",
+    cursor: null,
+    stateDetail: "closed; stopped 1 stage host",
+  });
+});
+
+test("closing stops every non-terminal stage host and leaves settled rounds alone (#670)", async () => {
+  const h = harness();
+  const pipeline = await create(h.ports);
+  await tickPipelines([], h.ports);
+  await tickPipelines([], h.ports);
+  /* A second lane whose round already settled must not be touched, while its
+     live successor round must be: the close targets hosts, not stages. */
+  const stored = loadPipelines();
+  const buildRun = stored[0]!.runs.find((run) => run.stageId === "build")!;
+  const template = stored[0]!.runs[0]!.attempts[0]!;
+  buildRun.attempts.push(
+    { ...structuredClone(template), n: 1, state: "passed", conversationId: "conversation_stage_settled", agentPath: "/codex/stage-settled.jsonl", completedAt: h.ports.now() },
+    { ...structuredClone(template), n: 2, state: "running", conversationId: "conversation_stage_2", agentPath: "/codex/stage-2.jsonl" },
+  );
+  savePipelines(stored);
+  h.setStageHost("conversation_stage_1", { outcome: "stopped" });
+  h.setStageHost("conversation_stage_2", { outcome: "stopped" });
+
+  const closed = await patchPipeline(pipeline.id, { action: "close" }, h.ports);
+
+  expect(closed.close?.stopped.map((item) => `${item.stageId}:${item.attempt}`)).toEqual(["plan:1", "build:2"]);
+  expect(h.calls).not.toContain("stop-host:build:1:conversation_stage_settled");
+  expect(loadPipelines()[0]!.stateDetail).toBe("closed; stopped 2 stage hosts");
+});
+
+test("closing a pipeline whose host is already gone reports that nothing was running (#670)", async () => {
+  const h = harness();
+  const pipeline = await create(h.ports);
+  await tickPipelines([], h.ports);
+  await tickPipelines([], h.ports);
+
+  const closed = await patchPipeline(pipeline.id, { action: "close" }, h.ports);
+
+  expect(closed.close).toMatchObject({
+    stopped: [],
+    alreadyStopped: [{ stageId: "plan", attempt: 1, conversationId: "conversation_stage_1" }],
+    stillRunning: [],
+  });
+  /* "closed, nothing was running" carries no stop claim of any kind. */
+  expect(loadPipelines()[0]).toMatchObject({ state: "closed", stateDetail: null });
+});
+
+test("a stage host that cannot be stopped refuses the close instead of hiding it (#670)", async () => {
+  const h = harness();
+  const pipeline = await create(h.ports);
+  await tickPipelines([], h.ports);
+  await tickPipelines([], h.ports);
+  h.setStageHost("conversation_stage_1", { outcome: "failed", error: "structured host ownership is unavailable" });
+
+  const refused = await patchPipeline(pipeline.id, { action: "close" }, h.ports);
+
+  expect(refused.status).toBe(409);
+  expect(refused.error).toBe(
+    "could not stop stage plan attempt 1 (conversation_stage_1): structured host ownership is unavailable",
+  );
+  expect(refused.close?.stillRunning).toMatchObject([{ stageId: "plan", conversationId: "conversation_stage_1" }]);
+  const stored = loadPipelines()[0]!;
+  expect(stored.state).not.toBe("closed");
+  expect(stored.closedAt).toBeNull();
+  expect(stored.stateDetail).toContain("structured host ownership is unavailable");
+});
+
+test("closing preserves uncommitted stage work and names what it left behind (#670)", async () => {
+  const h = harness();
+  const baseExec = h.ports.exec;
+  h.ports.exec = (command, args, cwd) => {
+    if (command === "git" && args[0] === "status") {
+      return { code: 0, stdout: " M src/lib/app.ts\n?? notes.md\n", stderr: "" };
+    }
+    return baseExec(command, args, cwd);
+  };
+  const pipeline = await create(h.ports);
+  await tickPipelines([], h.ports);
+  await tickPipelines([], h.ports);
+  h.setStageHost("conversation_stage_1", { outcome: "stopped" });
+
+  const closed = await patchPipeline(pipeline.id, { action: "close" }, h.ports);
+
+  expect(closed.close?.worktree).toEqual({
+    dir: loadPipelines()[0]!.worktreeDir,
+    uncommitted: ["src/lib/app.ts", "notes.md"],
+    truncated: false,
+  });
+  /* The whole point of the report: the work stays on disk. */
+  expect(h.calls.some((call) => call.includes("reset --hard"))).toBeFalse();
+  expect(h.calls.some((call) => call.startsWith("git clean"))).toBeFalse();
+  expect(h.calls.some((call) => call.startsWith("git checkout"))).toBeFalse();
+  expect(loadPipelines()[0]!.stateDetail).toBe("closed; stopped 1 stage host; kept 2 uncommitted paths in the worktree");
 });
 
 test("a lost advance on a fresh review flow is re-issued instead of waiting forever", async () => {

--- a/src/lib/pipelines/engine.test.ts
+++ b/src/lib/pipelines/engine.test.ts
@@ -3089,6 +3089,9 @@ test("retry and skip recover a completed pane-hosted semantic contradiction", as
 
 test("closing a mid-run or parked pipeline persists a record that loads back", async () => {
   const h = harness();
+  /* No host and no live pane behind these stages: the close has nothing to stop
+     and records the closed pipeline. A live pane is covered separately (#670). */
+  h.setPaneAlive(false);
   const running = await create(h.ports);
   await tickPipelines([], h.ports);
   await tickPipelines([], h.ports);
@@ -3158,6 +3161,7 @@ test("closing stops every non-terminal stage host and leaves settled rounds alon
 
 test("closing a pipeline whose host is already gone reports that nothing was running (#670)", async () => {
   const h = harness();
+  h.setPaneAlive(false);
   const pipeline = await create(h.ports);
   await tickPipelines([], h.ports);
   await tickPipelines([], h.ports);
@@ -3167,10 +3171,80 @@ test("closing a pipeline whose host is already gone reports that nothing was run
   expect(closed.close).toMatchObject({
     stopped: [],
     alreadyStopped: [{ stageId: "plan", attempt: 1, conversationId: "conversation_stage_1" }],
+    unconfirmed: [],
     stillRunning: [],
   });
   /* "closed, nothing was running" carries no stop claim of any kind. */
   expect(loadPipelines()[0]).toMatchObject({ state: "closed", stateDetail: null });
+});
+
+test("an accepted but unconfirmed kill never counts as a clean stop (#670)", async () => {
+  const h = harness();
+  const pipeline = await create(h.ports);
+  await tickPipelines([], h.ports);
+  await tickPipelines([], h.ports);
+  h.setStageHost("conversation_stage_1", {
+    outcome: "unconfirmed",
+    operationId: "kill-op-1",
+    detail: "kill accepted as queued but termination was not confirmed",
+  });
+
+  const closed = await patchPipeline(pipeline.id, { action: "close" }, h.ports);
+
+  /* A queued receipt is the normal first answer, so this still closes — but it
+     records no stop and names the operation that may have left a survivor. */
+  expect(closed.error).toBeUndefined();
+  expect(closed.close).toMatchObject({
+    stopped: [],
+    stillRunning: [],
+    unconfirmed: [{ stageId: "plan", attempt: 1, operationId: "kill-op-1" }],
+  });
+  expect(loadPipelines()[0]!.stateDetail).toBe(
+    "closed; kill accepted as queued but termination was not confirmed for stage plan attempt 1 (conversation_stage_1) (operation kill-op-1)",
+  );
+});
+
+test("a live pane behind a host the registry does not know refuses the close (#670)", async () => {
+  const h = harness();
+  const pipeline = await create(h.ports);
+  await tickPipelines([], h.ports);
+  await tickPipelines([], h.ports);
+  /* The registry entry is gone (stopStageAgent says not-running) but the pane
+     still runs an agent — closing here would hide a live agent. */
+  h.setPaneAlive(true);
+
+  const refused = await patchPipeline(pipeline.id, { action: "close" }, h.ports);
+
+  expect(refused.status).toBe(409);
+  expect(refused.close?.stillRunning).toMatchObject([{ stageId: "plan", attempt: 1, paneId: "%1" }]);
+  expect(refused.error).toContain("an agent is still running in pane %1");
+  expect(loadPipelines()[0]!.state).not.toBe("closed");
+});
+
+test("an unreadable worktree is reported instead of closing as if nothing was left (#670)", async () => {
+  const h = harness();
+  h.setPaneAlive(false);
+  const baseExec = h.ports.exec;
+  let failStatus = false;
+  h.ports.exec = (command, args, cwd) => {
+    if (failStatus && command === "git" && args[0] === "status") {
+      return { code: 128, stdout: "", stderr: "fatal: not a git repository" };
+    }
+    return baseExec(command, args, cwd);
+  };
+  const pipeline = await create(h.ports);
+  await tickPipelines([], h.ports);
+  await tickPipelines([], h.ports);
+  failStatus = true;
+
+  const closed = await patchPipeline(pipeline.id, { action: "close" }, h.ports);
+
+  expect(closed.error).toBeUndefined();
+  expect(closed.close?.worktree).toMatchObject({ uncommitted: [], error: "checking the pipeline worktree: fatal: not a git repository" });
+  /* An unreadable worktree must not look like a verified-clean one. */
+  expect(loadPipelines()[0]!.stateDetail).toBe(
+    `closed; could not read the worktree at ${loadPipelines()[0]!.worktreeDir}: checking the pipeline worktree: fatal: not a git repository`,
+  );
 });
 
 test("a stage host that cannot be stopped refuses the close instead of hiding it (#670)", async () => {

--- a/src/lib/pipelines/engine.test.ts
+++ b/src/lib/pipelines/engine.test.ts
@@ -103,6 +103,12 @@ function harness() {
   /* Stage hosts are "not running" unless a test seats one; nothing in this
      suite may reach a real host or the operator's registry. */
   const stageHosts = new Map<string, PipelineStageStopResult>();
+  /* Panes the harness considers killable, and the clock the teardown budget
+     reads. Both default to the benign case so existing tests are unaffected. */
+  const killedPanes: string[] = [];
+  let paneKill: { ok: true } | { ok: false; error: string } = { ok: true };
+  let residentHosts = false;
+  let monotonic: () => number = () => Date.now();
   const ports: PipelinePorts = {
     exec: (command, args) => {
       calls.push(`${command} ${args.join(" ")}`);
@@ -145,6 +151,19 @@ function harness() {
       calls.push(`stop-host:${target.stageId}:${target.attempt}:${target.conversationId ?? "none"}`);
       return stageHosts.get(target.conversationId ?? "") ?? { outcome: "not-running" };
     },
+    killStagePane: async (paneId) => {
+      calls.push(`kill-pane:${paneId}`);
+      if (paneKill.ok) {
+        killedPanes.push(paneId);
+        paneAlive = false;
+      }
+      return paneKill;
+    },
+    stageHostResident: async (target) => {
+      calls.push(`host-resident:${target.stageId}:${target.attempt}`);
+      return residentHosts;
+    },
+    monotonicNow: () => monotonic(),
     conversationAgentActive: async () => conversationActive,
     durableTurnEvidence: async (_engine, transcriptPath) => durableTurns.get(transcriptPath) ?? null,
     headCwd: () => loadPipelines()[0]?.worktreeDir ?? null,
@@ -192,6 +211,10 @@ function harness() {
     setBuilderEffort: (effort: string) => { builderEffort = effort; },
     setPaneAlive: (alive: boolean) => { paneAlive = alive; },
     setStageHost: (conversationId: string, result: PipelineStageStopResult) => { stageHosts.set(conversationId, result); },
+    setPaneKill: (result: { ok: true } | { ok: false; error: string }) => { paneKill = result; },
+    setHostsResident: (resident: boolean) => { residentHosts = resident; },
+    setMonotonicClock: (clock: () => number) => { monotonic = clock; },
+    killedPanes,
     setConversationActive: (active: boolean | null) => { conversationActive = active; },
   };
 }
@@ -3256,6 +3279,68 @@ test("an accepted but unconfirmed kill never counts as a clean stop (#670)", asy
   expect(loadPipelines()[0]!.hiddenAt).toBe(loadPipelines()[0]!.closedAt);
 });
 
+test("a teardown that runs out of budget reports the hosts it never probed (#670)", async () => {
+  const h = harness();
+  const pipeline = await create(h.ports);
+  await tickPipelines([], h.ports);
+  await tickPipelines([], h.ports);
+  const stored = loadPipelines();
+  const buildRun = stored[0]!.runs.find((run) => run.stageId === "build")!;
+  const template = stored[0]!.runs[0]!.attempts[0]!;
+  buildRun.attempts.push({ ...structuredClone(template), n: 1, state: "running", conversationId: "conversation_stage_2", agentPath: "/codex/stage-2.jsonl", paneId: "%2" });
+  savePipelines(stored);
+  h.setStageHost("conversation_stage_1", { outcome: "stopped" });
+  h.setStageHost("conversation_stage_2", { outcome: "stopped" });
+  /* The clock jumps past the aggregate ceiling after the first host: the close
+     holds the pipelines transaction, so it must stop working, not run long. */
+  let reading = 0;
+  h.setMonotonicClock(() => (reading += 60_000));
+
+  const closed = await patchPipeline(pipeline.id, { action: "close" }, h.ports);
+
+  expect(closed.error).toBeUndefined();
+  expect(closed.close?.stopped).toMatchObject([{ stageId: "plan", attempt: 1 }]);
+  /* Truthful, not silent: the unprobed host is named, and the lane stays
+     visible so a later close finishes the work. */
+  expect(closed.close?.unconfirmed).toMatchObject([
+    { stageId: "build", attempt: 1, operationId: null, detail: "close teardown budget expired before this host was probed" },
+  ]);
+  expect(h.calls).not.toContain("stop-host:build:1:conversation_stage_2");
+  const record = loadPipelines()[0]!;
+  expect(record.hiddenAt).toBeNull();
+  expect(record.unconfirmedHosts).toHaveLength(1);
+});
+
+test("an unconfirmed host record retires once its host is demonstrably gone (#670)", async () => {
+  const h = harness();
+  h.setPaneAlive(false);
+  const pipeline = await create(h.ports);
+  await tickPipelines([], h.ports);
+  await tickPipelines([], h.ports);
+  h.setStageHost("conversation_stage_1", {
+    outcome: "unconfirmed",
+    operationId: "kill-op-1",
+    detail: "kill accepted as queued but termination was not confirmed",
+  });
+  await patchPipeline(pipeline.id, { action: "close" }, h.ports);
+  expect(loadPipelines()[0]!.unconfirmedHosts).toHaveLength(1);
+
+  /* Still resident: the lane keeps its record and stays on the board. */
+  h.setHostsResident(true);
+  await tickPipelines([], h.ports);
+  expect(loadPipelines()[0]).toMatchObject({ hiddenAt: null });
+  expect(loadPipelines()[0]!.unconfirmedHosts).toHaveLength(1);
+
+  /* Gone: the record retires and the closed lane hides like any other. */
+  h.setHostsResident(false);
+  await tickPipelines([], h.ports);
+  const settled = loadPipelines()[0]!;
+  expect(settled.unconfirmedHosts).toBeUndefined();
+  expect(settled.hiddenAt).toBe(settled.closedAt);
+  /* The probe never kills anything — it only reads. */
+  expect(h.calls.filter((call) => call.startsWith("stop-host:")).length).toBe(1);
+});
+
 test("a settled attempt with an idle CLI in its pane does not block the close (#670)", async () => {
   const h = harness();
   const pipeline = await create(h.ports);
@@ -3276,20 +3361,38 @@ test("a settled attempt with an idle CLI in its pane does not block the close (#
   expect(loadPipelines()[0]!.state).toBe("closed");
 });
 
-test("a live pane behind a host the registry does not know refuses the close (#670)", async () => {
+test("a live pane behind a host the registry does not know is killed, not refused (#670)", async () => {
   const h = harness();
   const pipeline = await create(h.ports);
   await tickPipelines([], h.ports);
   await tickPipelines([], h.ports);
   /* The registry entry is gone (stopStageAgent says not-running) but the pane
-     still runs an agent — closing here would hide a live agent. */
+     still runs a mid-turn agent. Refusing would hand the operator a card that
+     never closes and a host to kill by hand. */
   h.setPaneAlive(true);
+
+  const closed = await patchPipeline(pipeline.id, { action: "close" }, h.ports);
+
+  expect(closed.error).toBeUndefined();
+  expect(h.calls).toContain("kill-pane:%1");
+  expect(h.killedPanes).toEqual(["%1"]);
+  expect(closed.close?.stopped).toMatchObject([{ stageId: "plan", attempt: 1, paneId: "%1" }]);
+  expect(loadPipelines()[0]).toMatchObject({ state: "closed", stateDetail: "closed; stopped 1 stage host" });
+});
+
+test("a pane that survives its kill still refuses the close (#670)", async () => {
+  const h = harness();
+  const pipeline = await create(h.ports);
+  await tickPipelines([], h.ports);
+  await tickPipelines([], h.ports);
+  h.setPaneAlive(true);
+  h.setPaneKill({ ok: false, error: "no server running on /tmp/tmux-1000/default" });
 
   const refused = await patchPipeline(pipeline.id, { action: "close" }, h.ports);
 
   expect(refused.status).toBe(409);
+  expect(refused.error).toContain("could not kill pane %1");
   expect(refused.close?.stillRunning).toMatchObject([{ stageId: "plan", attempt: 1, paneId: "%1" }]);
-  expect(refused.error).toContain("an agent is still running in pane %1");
   expect(loadPipelines()[0]!.state).not.toBe("closed");
 });
 

--- a/src/lib/pipelines/engine.test.ts
+++ b/src/lib/pipelines/engine.test.ts
@@ -3134,29 +3134,69 @@ test("closing a running pipeline terminates its stage host and reports the stop 
   });
 });
 
-test("closing stops every non-terminal stage host and leaves settled rounds alone (#670)", async () => {
+test("closing probes every host the pipeline launched, settled rounds included (#670)", async () => {
   const h = harness();
   const pipeline = await create(h.ports);
   await tickPipelines([], h.ports);
   await tickPipelines([], h.ports);
-  /* A second lane whose round already settled must not be touched, while its
-     live successor round must be: the close targets hosts, not stages. */
+  /* A settled round's attempt state says nothing about its host: the passed
+     round below is still resident, and a close that trusted the state machine
+     would leave it burning quota. */
   const stored = loadPipelines();
   const buildRun = stored[0]!.runs.find((run) => run.stageId === "build")!;
   const template = stored[0]!.runs[0]!.attempts[0]!;
   buildRun.attempts.push(
-    { ...structuredClone(template), n: 1, state: "passed", conversationId: "conversation_stage_settled", agentPath: "/codex/stage-settled.jsonl", completedAt: h.ports.now() },
+    { ...structuredClone(template), n: 1, state: "passed", verdict: { status: "pass" }, conversationId: "conversation_stage_settled", agentPath: "/codex/stage-settled.jsonl", completedAt: h.ports.now() },
     { ...structuredClone(template), n: 2, state: "running", conversationId: "conversation_stage_2", agentPath: "/codex/stage-2.jsonl" },
   );
   savePipelines(stored);
   h.setStageHost("conversation_stage_1", { outcome: "stopped" });
+  h.setStageHost("conversation_stage_settled", { outcome: "stopped" });
   h.setStageHost("conversation_stage_2", { outcome: "stopped" });
 
   const closed = await patchPipeline(pipeline.id, { action: "close" }, h.ports);
 
-  expect(closed.close?.stopped.map((item) => `${item.stageId}:${item.attempt}`)).toEqual(["plan:1", "build:2"]);
-  expect(h.calls).not.toContain("stop-host:build:1:conversation_stage_settled");
-  expect(loadPipelines()[0]!.stateDetail).toBe("closed; stopped 2 stage hosts");
+  expect(h.calls).toContain("stop-host:build:1:conversation_stage_settled");
+  expect(closed.close?.stopped.map((item) => `${item.stageId}:${item.attempt}`)).toEqual(["plan:1", "build:1", "build:2"]);
+  expect(loadPipelines()[0]!.stateDetail).toBe("closed; stopped 3 stage hosts");
+});
+
+test("a parked stage whose host is still resident is stopped, not read as terminal (#670)", async () => {
+  const h = harness();
+  const pipeline = await create(h.ports);
+  await tickPipelines([], h.ports);
+  await tickPipelines([], h.ports);
+  /* park() writes needs_decision while the agent process is still there — the
+     7.5-hour orphans of #670 were exactly this shape. */
+  await tickPipelines([h.finish("/codex/stage-1.jsonl", "needs_decision", "operator choice")], h.ports);
+  const parked = loadPipelines()[0]!.runs[0]!.attempts[0]!;
+  expect(parked.state).toBe("needs_decision");
+  h.setStageHost("conversation_stage_1", { outcome: "stopped" });
+
+  const closed = await patchPipeline(pipeline.id, { action: "close" }, h.ports);
+
+  expect(h.calls).toContain("stop-host:plan:1:conversation_stage_1");
+  expect(closed.close?.stopped).toMatchObject([{ stageId: "plan", attempt: 1, conversationId: "conversation_stage_1" }]);
+  expect(loadPipelines()[0]).toMatchObject({ state: "closed", stateDetail: "closed; stopped 1 stage host" });
+});
+
+test("a parked stage with no resident host still reports nothing was running (#670)", async () => {
+  const h = harness();
+  h.setPaneAlive(false);
+  const pipeline = await create(h.ports);
+  await tickPipelines([], h.ports);
+  await tickPipelines([], h.ports);
+  await tickPipelines([h.finish("/codex/stage-1.jsonl", "needs_decision", "operator choice")], h.ports);
+  expect(loadPipelines()[0]!.runs[0]!.attempts[0]!.state).toBe("needs_decision");
+
+  const closed = await patchPipeline(pipeline.id, { action: "close" }, h.ports);
+
+  expect(closed.close).toMatchObject({
+    stopped: [],
+    alreadyStopped: [{ stageId: "plan", attempt: 1, conversationId: "conversation_stage_1" }],
+    stillRunning: [],
+  });
+  expect(loadPipelines()[0]).toMatchObject({ state: "closed", stateDetail: null });
 });
 
 test("closing a pipeline whose host is already gone reports that nothing was running (#670)", async () => {
@@ -3202,6 +3242,38 @@ test("an accepted but unconfirmed kill never counts as a clean stop (#670)", asy
   expect(loadPipelines()[0]!.stateDetail).toBe(
     "closed; kill accepted as queued but termination was not confirmed for stage plan attempt 1 (conversation_stage_1) (operation kill-op-1)",
   );
+  /* The possible survivor stays addressable: the lane is not hidden, and the
+     durable record names the operation to chase. */
+  const parked = loadPipelines()[0]!;
+  expect(parked.hiddenAt).toBeNull();
+  expect(parked.unconfirmedHosts).toMatchObject([{ stageId: "plan", attempt: 1, operationId: "kill-op-1" }]);
+
+  /* Closing again once the kill is confirmed settles the lane and hides it. */
+  h.setStageHost("conversation_stage_1", { outcome: "stopped" });
+  const settled = await patchPipeline(pipeline.id, { action: "close" }, h.ports);
+  expect(settled.close?.unconfirmed).toEqual([]);
+  expect(loadPipelines()[0]!.unconfirmedHosts).toBeUndefined();
+  expect(loadPipelines()[0]!.hiddenAt).toBe(loadPipelines()[0]!.closedAt);
+});
+
+test("a settled attempt with an idle CLI in its pane does not block the close (#670)", async () => {
+  const h = harness();
+  const pipeline = await create(h.ports);
+  await tickPipelines([], h.ports);
+  await tickPipelines([], h.ports);
+  /* A verdict means the turn ended, so what is left in the pane is an idle CLI —
+     the exemption orphanAgentPane applies to a retry. The pane stays alive here. */
+  await tickPipelines([h.finish("/codex/stage-1.jsonl", "pass")], h.ports);
+  const settled = loadPipelines()[0]!.runs[0]!.attempts[0]!;
+  expect(settled.verdict).toMatchObject({ status: "pass" });
+  expect(settled.paneId).toBe("%1");
+
+  const closed = await patchPipeline(pipeline.id, { action: "close" }, h.ports);
+
+  expect(closed.error).toBeUndefined();
+  expect(closed.close?.stillRunning).toEqual([]);
+  expect(closed.close?.alreadyStopped).toMatchObject([{ stageId: "plan", attempt: 1 }]);
+  expect(loadPipelines()[0]!.state).toBe("closed");
 });
 
 test("a live pane behind a host the registry does not know refuses the close (#670)", async () => {

--- a/src/lib/pipelines/engine.test.ts
+++ b/src/lib/pipelines/engine.test.ts
@@ -3350,6 +3350,109 @@ test("an unconfirmed host record retires once its host is demonstrably gone (#67
   expect(h.calls.filter((call) => call.startsWith("stop-host:")).length).toBe(1);
 });
 
+test("an adopted stage child is stopped and counted, never silently left running (#670)", async () => {
+  const h = harness();
+  const pipeline = await create(h.ports);
+  await tickPipelines([], h.ports);
+  await tickPipelines([], h.ports);
+  /* The build agent spawned a helper through the viewer; adoptAttempt seats it
+     on the stage run as historical and running, with its own live host. */
+  const stored = loadPipelines();
+  const run = stored[0]!.runs[0]!;
+  run.attempts.push({
+    ...structuredClone(run.attempts[0]!),
+    n: 2,
+    historical: true,
+    state: "running",
+    conversationId: "conversation_helper",
+    agentPath: "/codex/helper.jsonl",
+    paneId: "%9",
+  });
+  savePipelines(stored);
+  h.setStageHost("conversation_stage_1", { outcome: "stopped" });
+  h.setStageHost("conversation_helper", { outcome: "stopped" });
+
+  const closed = await patchPipeline(pipeline.id, { action: "close" }, h.ports);
+
+  expect(h.calls).toContain("stop-host:plan:2:conversation_helper");
+  expect(closed.close?.stopped).toMatchObject([
+    { attempt: 1, conversationId: "conversation_stage_1" },
+    { attempt: 2, conversationId: "conversation_helper", adopted: true },
+  ]);
+  expect(loadPipelines()[0]!.stateDetail).toBe("closed; stopped 1 stage host; stopped 1 adopted agent");
+});
+
+test("an adopted child that cannot be stopped keeps the lane visible (#670)", async () => {
+  const h = harness();
+  const pipeline = await create(h.ports);
+  await tickPipelines([], h.ports);
+  await tickPipelines([], h.ports);
+  const stored = loadPipelines();
+  const run = stored[0]!.runs[0]!;
+  run.attempts.push({
+    ...structuredClone(run.attempts[0]!),
+    n: 2,
+    historical: true,
+    state: "running",
+    conversationId: "conversation_helper",
+    agentPath: "/codex/helper.jsonl",
+    paneId: null,
+  });
+  savePipelines(stored);
+  h.setStageHost("conversation_stage_1", { outcome: "stopped" });
+  h.setStageHost("conversation_helper", { outcome: "failed", error: "structured host ownership is unavailable" });
+
+  const refused = await patchPipeline(pipeline.id, { action: "close" }, h.ports);
+
+  expect(refused.status).toBe(409);
+  expect(refused.error).toContain("adopted agent of stage plan attempt 2");
+  expect(loadPipelines()[0]!.state).not.toBe("closed");
+});
+
+test("an unidentifiable pane can be dismissed by the operator once judged (#670)", async () => {
+  const h = harness();
+  const pipeline = await create(h.ports);
+  await tickPipelines([], h.ports);
+  await tickPipelines([], h.ports);
+  h.setPaneAlive(true);
+  h.setPaneStop({
+    outcome: "unknown",
+    detail: "pane %1 now runs codex in window other and cannot be identified as this stage's agent",
+  });
+
+  const pinned = await patchPipeline(pipeline.id, { action: "close" }, h.ports);
+  expect(pinned.close?.unconfirmed).toHaveLength(1);
+  expect(loadPipelines()[0]!.hiddenAt).toBeNull();
+  /* The detail names what the pane actually shows, so the operator can find it. */
+  expect(loadPipelines()[0]!.stateDetail).toContain("now runs codex in window other");
+
+  /* Their judgement is the way out: the lane stops claiming a host it could
+     never identify, and leaves the board. */
+  const dismissed = await patchPipeline(pipeline.id, { action: "close", acknowledgeHosts: true }, h.ports);
+
+  expect(dismissed.error).toBeUndefined();
+  expect(dismissed.close?.acknowledged).toMatchObject([{ stageId: "plan", attempt: 1, paneId: "%1" }]);
+  expect(dismissed.close?.unconfirmed).toEqual([]);
+  const settled = loadPipelines()[0]!;
+  expect(settled.unconfirmedHosts).toBeUndefined();
+  expect(settled.hiddenAt).toBe(settled.closedAt);
+  expect(settled.stateDetail).toContain("dismissed 1 unconfirmed host");
+});
+
+test("an acknowledgement never dismisses a host that is provably still running (#670)", async () => {
+  const h = harness();
+  const pipeline = await create(h.ports);
+  await tickPipelines([], h.ports);
+  await tickPipelines([], h.ports);
+  h.setStageHost("conversation_stage_1", { outcome: "failed", error: "structured host ownership is unavailable" });
+
+  const refused = await patchPipeline(pipeline.id, { action: "close", acknowledgeHosts: true }, h.ports);
+
+  expect(refused.status).toBe(409);
+  expect(refused.close?.acknowledged).toEqual([]);
+  expect(loadPipelines()[0]!.state).not.toBe("closed");
+});
+
 test("closing mid-review counts the reviewer it stopped (#670)", async () => {
   const h = harness();
   const stages = [

--- a/src/lib/pipelines/engine.ts
+++ b/src/lib/pipelines/engine.ts
@@ -90,7 +90,7 @@ export type PipelineStageStopResult =
 export type PipelineCloseReport = {
   /** Hosts this close terminated, with termination evidenced. */
   stopped: PipelineStageHostRef[];
-  /** Non-terminal stages whose host was already gone. */
+  /** Launched stages — settled or parked included — whose host was already gone. */
   alreadyStopped: PipelineStageHostRef[];
   /** Kills the runtime accepted without confirming termination in time. The
       operation id keeps the possible survivor addressable. */
@@ -2047,26 +2047,53 @@ async function orphanAgentPane(
   return { error: `stage agent may still be running in pane ${attempt.paneId}; wait for it to exit or kill the pane first`, status: 409 };
 }
 
-/** Stage attempts that may still own a live agent host: every current round
-    that has not reached a terminal state and named a conversation. Historical
-    (lineage-adopted) evidence never owns a host this pipeline may terminate. */
-function liveStageHosts(pipeline: Pipeline): PipelineStageHostRef[] {
-  const targets: PipelineStageHostRef[] = [];
+/**
+ * Every host this pipeline ever launched, as a close must consider it.
+ *
+ * A terminal attempt state says nothing about whether its host is still
+ * resident: `park()` writes `needs_decision` precisely when a hosted session
+ * went idle, produced an unparseable verdict, or stopped reporting — the agent
+ * process is still there, still holding the account's quota. Those parked lanes
+ * are the orphans #670 was filed for, so residency is decided downstream from
+ * evidence about the host (the registry, then the pane), never from the attempt
+ * state machine. Lineage-adopted (`historical`) evidence is left alone: those
+ * conversations belong to their own lineage, and a close must not reach outside
+ * this pipeline's own stage launches.
+ */
+function launchedStageHosts(pipeline: Pipeline): StageHostCandidate[] {
+  const candidates: StageHostCandidate[] = [];
+  const seen = new Set<string>();
   for (const run of pipeline.runs) {
     for (const attempt of run.attempts) {
-      if (attempt.historical || TERMINAL_ATTEMPT_STATES.has(attempt.state)) continue;
-      if (!attempt.conversationId && !attempt.agentPath) continue;
-      targets.push({
-        stageId: run.stageId,
-        attempt: attempt.n,
-        conversationId: attempt.conversationId,
-        agentPath: attempt.agentPath,
-        paneId: attempt.paneId,
+      if (attempt.historical) continue;
+      if (!attempt.conversationId && !attempt.agentPath && !attempt.paneId) continue;
+      /* Rounds can share a host identity (a review round re-reads its reviewer
+         conversation); probing one host once keeps the counts truthful. */
+      const identity = `${attempt.conversationId ?? ""}|${attempt.agentPath ?? ""}|${attempt.paneId ?? ""}`;
+      if (seen.has(identity)) continue;
+      seen.add(identity);
+      candidates.push({
+        target: {
+          stageId: run.stageId,
+          attempt: attempt.n,
+          conversationId: attempt.conversationId,
+          agentPath: attempt.agentPath,
+          paneId: attempt.paneId,
+        },
+        /* Same reading orphanAgentPane uses: a verdict or a completion stamp
+           means the turn ended, so what is left in the pane is an idle CLI. A
+           parked attempt has neither (park writes only state and error), which
+           is why the pane heuristic still applies to it. */
+        turnSettled: Boolean(attempt.verdict || attempt.completedAt),
       });
     }
   }
-  return targets;
+  return candidates;
 }
+
+/** A launched host plus whether its attempt's turn ended, which decides only
+    whether the pane heuristic may speak for it. */
+type StageHostCandidate = { target: PipelineStageHostRef; turnSettled: boolean };
 
 function stageHostLabel(target: PipelineStageHostRef): string {
   return `stage ${target.stageId} attempt ${target.attempt} (${target.conversationId ?? target.agentPath ?? "unknown host"})`;
@@ -2542,16 +2569,17 @@ export async function patchPipeline(
          what was stopped. Nothing on disk is touched — uncommitted stage work
          stays in the worktree and is named in the report instead. */
       const close: PipelineCloseReport = { stopped: [], alreadyStopped: [], unconfirmed: [], stillRunning: [], worktree: null };
-      for (const target of liveStageHosts(pipeline)) {
+      for (const { target, turnSettled } of launchedStageHosts(pipeline)) {
         const result = await ports.stopStageAgent(target);
         if (result.outcome === "stopped") close.stopped.push(target);
         else if (result.outcome === "failed") close.stillRunning.push({ ...target, error: result.error });
         else if (result.outcome === "unconfirmed") {
           close.unconfirmed.push({ ...target, operationId: result.operationId, detail: result.detail });
-        } else if (target.paneId && await ports.paneAgentAlive(target.paneId)) {
-          /* The registry knows no host, but an agent is still running in the
-             attempt's pane — the same evidence orphanAgentPane refuses a retry
-             on. Surface it rather than closing cleanly over a live agent. */
+        } else if (!turnSettled && target.paneId && await ports.paneAgentAlive(target.paneId)) {
+          /* The registry knows no host, but the attempt never finished its turn
+             and an agent is still running in its pane — the same evidence
+             orphanAgentPane refuses a retry on. Surface it rather than closing
+             cleanly over a live agent. */
           close.stillRunning.push({
             ...target,
             error: `an agent is still running in pane ${target.paneId}; kill the pane, then close again`,
@@ -2592,7 +2620,22 @@ export async function patchPipeline(
       pipeline.pausedState = null;
       pipeline.stateDetail = closeSummary(close);
       pipeline.closedAt = ports.now();
-      pipeline.hiddenAt = pipeline.closedAt;
+      /* An unconfirmed kill may have left a resident host. Hiding the lane would
+         make that survivor invisible on the board, which is the opposite of
+         surfacing it, so the closed record stays visible (and durable) until a
+         later close confirms the host is gone and clears it. */
+      pipeline.unconfirmedHosts = close.unconfirmed.length > 0
+        ? close.unconfirmed.map((item) => ({
+            stageId: item.stageId,
+            attempt: item.attempt,
+            conversationId: item.conversationId,
+            agentPath: item.agentPath,
+            operationId: item.operationId,
+            detail: item.detail,
+            at: pipeline.closedAt!,
+          }))
+        : undefined;
+      pipeline.hiddenAt = pipeline.unconfirmedHosts ? null : pipeline.closedAt;
       persist();
       return { pipeline, close };
     } else {

--- a/src/lib/pipelines/engine.ts
+++ b/src/lib/pipelines/engine.ts
@@ -13,7 +13,7 @@ import { lastAssistantMessage } from "@/lib/flows/findings";
 import { loadFlows } from "@/lib/flows/store";
 import type { CreateFlowRequest, Flow, RoleConfig } from "@/lib/flows/types";
 import { persistHandoffLineage, rememberHandoffChild } from "@/lib/handoffLineage";
-import { runtimeHostClient } from "@/lib/runtime/client";
+import { runtimeHostClient, type RuntimeHostClient } from "@/lib/runtime/client";
 import { spawnStructuredConversation } from "@/lib/runtime/structuredSpawn";
 import { projectForCwd } from "@/lib/scanner/describe";
 import { loadTasks } from "@/lib/tasks/store";
@@ -73,8 +73,13 @@ export type PipelineStageHostRef = {
 };
 
 export type PipelineStageStopResult =
+  /** Termination is evidenced: the kill was delivered, or the host is gone. */
   | { outcome: "stopped" }
   | { outcome: "not-running" }
+  /** The kill was accepted (a `queued` receipt is the normal first answer) but
+      termination was not evidenced inside the confirmation budget. The host may
+      still be alive, so a close carrying one of these never claims a clean stop. */
+  | { outcome: "unconfirmed"; operationId: string | null; detail: string }
   | { outcome: "failed"; error: string };
 
 /**
@@ -83,10 +88,13 @@ export type PipelineStageStopResult =
  * was burning quota; a non-empty `stillRunning` means the close was refused.
  */
 export type PipelineCloseReport = {
-  /** Hosts this close terminated. */
+  /** Hosts this close terminated, with termination evidenced. */
   stopped: PipelineStageHostRef[];
   /** Non-terminal stages whose host was already gone. */
   alreadyStopped: PipelineStageHostRef[];
+  /** Kills the runtime accepted without confirming termination in time. The
+      operation id keeps the possible survivor addressable. */
+  unconfirmed: Array<PipelineStageHostRef & { operationId: string | null; detail: string }>;
   /** Hosts that survived teardown, so the close cannot claim to be clean. */
   stillRunning: Array<PipelineStageHostRef & { error: string }>;
   /** Uncommitted stage work preserved in the worktree; null when unprovisioned. */
@@ -276,6 +284,26 @@ async function spawnPipelineAgent(
   };
 }
 
+/** Confirmation window for an accepted kill. The whole close runs inside the
+    pipelines file transaction, so this stays short enough that a slow host
+    cannot stall every other pipeline mutation and the controller tick. */
+const KILL_CONFIRMATION_BUDGET_MS = 1_500;
+const KILL_CONFIRMATION_INTERVAL_MS = 250;
+const KILL_CONFIRMATION_MAX_POLLS = 8;
+/** Receipt states that terminally settle a kill operation: the delivery queue
+    transitions a terminated host to `delivered` and a refused termination to
+    `failed`; everything else (`queued`, `delivering`, …) is still in flight. */
+const KILL_DELIVERED_STATES = new Set(["delivered"]);
+const KILL_REFUSED_STATES = new Set(["failed", "rejected"]);
+
+export type StageStopProbes = {
+  client?: RuntimeHostClient | null;
+  sleep?: (ms: number) => Promise<void>;
+  now?: () => number;
+  budgetMs?: number;
+  intervalMs?: number;
+};
+
 /**
  * Terminates the agent host a stage attempt owns, through the same control path
  * an operator's kill uses — structured hosts go over the runtime command
@@ -283,30 +311,83 @@ async function spawnPipelineAgent(
  * worktree, including uncommitted stage work, is left exactly as the agent left
  * it. Residency is read from the durable registry first so a lane whose host is
  * already gone reports `not-running` instead of a manufactured kill.
+ *
+ * A structured kill answers `queued` before the host has gone anywhere, so an
+ * accepted receipt is not termination. Within a bounded window this re-reads
+ * host residency (the registry file signature invalidates the read cache, so a
+ * teardown written by the host process is visible here) and the durable
+ * operation receipt. Kills are idempotent, so re-checking is free of side
+ * effects. Only evidence yields `stopped`; a terminally refused operation
+ * yields `failed`; anything still in flight yields `unconfirmed` with its
+ * operation id, and the close reports that instead of a clean stop.
  */
-async function stopPipelineStageAgent(target: PipelineStageHostRef): Promise<PipelineStageStopResult> {
+export async function stopPipelineStageAgent(
+  target: PipelineStageHostRef,
+  probes: StageStopProbes = {},
+): Promise<PipelineStageStopResult> {
   const registry = agentRegistry();
-  const conversation = target.conversationId?.startsWith("conversation_")
+  /* applyConversationAction resolves by id or by path; residency must too, or a
+     prefixed id the registry cannot resolve short-circuits to not-running while
+     the attempt's transcript would have found the live conversation. */
+  const byId = target.conversationId?.startsWith("conversation_")
     ? registry.conversation(target.conversationId as ViewerConversationId)
-    : target.agentPath
-      ? registry.conversationForPath(target.agentPath)
-      : null;
+    : null;
+  const conversation = byId ?? (target.agentPath ? registry.conversationForPath(target.agentPath) : null);
   const generation = conversation?.generations.at(-1) ?? null;
   if (!conversation || !generation) return { outcome: "not-running" };
-  const entry = registry.readOnlySnapshot().entries[sessionKeyId({ engine: conversation.engine, sessionId: generation.id })];
-  if (!entry || entry.status === "dead" || entry.status === "unhosted") return { outcome: "not-running" };
+  const sessionKey = sessionKeyId({ engine: conversation.engine, sessionId: generation.id });
   try {
     const { structuredHostProcessAlive } = await import("@/lib/runtime/structuredRecovery");
-    if (!structuredHostProcessAlive(entry.structuredHost?.process ?? null) && !entry.host) return { outcome: "not-running" };
+    const resident = (): boolean => {
+      const entry = registry.readOnlySnapshot().entries[sessionKey];
+      if (!entry || entry.status === "dead" || entry.status === "unhosted") return false;
+      return structuredHostProcessAlive(entry.structuredHost?.process ?? null) || Boolean(entry.host);
+    };
+    if (!resident()) return { outcome: "not-running" };
+
     const { applyConversationAction } = await import("@/lib/conversation/actions");
     const result = await applyConversationAction({
       conversationId: conversation.id,
       transcriptPath: generation.path,
       action: "kill",
     });
-    const body = result.body as { ok?: boolean; error?: string };
-    if (result.status < 400 && body.ok === true) return { outcome: "stopped" };
-    return { outcome: "failed", error: body.error ?? `stage host kill was refused with status ${result.status}` };
+    const body = result.body as { ok?: boolean; error?: string; operationId?: string; receipt?: { status?: string } };
+    if (result.status >= 400 || body.ok !== true) {
+      return { outcome: "failed", error: body.error ?? `stage host kill was refused with status ${result.status}` };
+    }
+    /* No receipt means the control settled synchronously — the legacy pane
+       ladder, or a replayed terminal kill on an already-dead host. */
+    const receiptStatus = body.receipt?.status ?? null;
+    if (!receiptStatus || KILL_DELIVERED_STATES.has(receiptStatus)) return { outcome: "stopped" };
+
+    const operationId = body.operationId ?? null;
+    const client = probes.client === undefined ? runtimeHostClient() : probes.client;
+    const now = probes.now ?? Date.now;
+    const sleep = probes.sleep ?? ((ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms)));
+    const deadline = now() + (probes.budgetMs ?? KILL_CONFIRMATION_BUDGET_MS);
+    const interval = probes.intervalMs ?? KILL_CONFIRMATION_INTERVAL_MS;
+    for (let poll = 0; poll < KILL_CONFIRMATION_MAX_POLLS; poll += 1) {
+      if (!resident()) return { outcome: "stopped" };
+      if (operationId && client) {
+        const durable = await client.operationStatus(operationId).catch(() => null);
+        const status = durable?.receipt.status ?? null;
+        if (status && KILL_DELIVERED_STATES.has(status)) return { outcome: "stopped" };
+        if (status && KILL_REFUSED_STATES.has(status)) {
+          return {
+            outcome: "failed",
+            error: durable?.receipt.reason ?? `stage host kill ${status} (operation ${operationId})`,
+          };
+        }
+      }
+      if (now() >= deadline) break;
+      await sleep(interval);
+    }
+    if (!resident()) return { outcome: "stopped" };
+    return {
+      outcome: "unconfirmed",
+      operationId,
+      detail: `kill accepted as ${receiptStatus} but termination was not confirmed`,
+    };
   } catch (error) {
     return { outcome: "failed", error: error instanceof Error ? error.message : String(error) };
   }
@@ -336,7 +417,7 @@ export function defaultPipelinePorts(): PipelinePorts {
       const info = await paneInfo(paneId);
       return info !== null && !isShellCommand(info.command);
     },
-    stopStageAgent: stopPipelineStageAgent,
+    stopStageAgent: (target) => stopPipelineStageAgent(target),
     conversationAgentActive: async (conversationId) => {
       const client = runtimeHostClient();
       if (!client) return null;
@@ -2001,15 +2082,24 @@ function closeWorktreeReport(pipeline: Pipeline, ports: PipelinePorts): Pipeline
 }
 
 /** Durable one-line account of a close, so the board and the API agree on
-    whether anything was stopped and what was preserved. */
+    whether anything was stopped, what could not be confirmed, and what was
+    preserved. An unreadable worktree is reported as such — never as the silence
+    that a verified-clean worktree produces. */
 function closeSummary(report: PipelineCloseReport): string | null {
   const parts: string[] = [];
   if (report.stopped.length > 0) {
     parts.push(`stopped ${report.stopped.length} stage host${report.stopped.length === 1 ? "" : "s"}`);
   }
-  const kept = report.worktree?.uncommitted.length ?? 0;
-  if (kept > 0) {
-    parts.push(`kept ${kept}${report.worktree?.truncated ? "+" : ""} uncommitted path${kept === 1 ? "" : "s"} in the worktree`);
+  for (const item of report.unconfirmed) {
+    parts.push(`${item.detail} for ${stageHostLabel(item)}${item.operationId ? ` (operation ${item.operationId})` : ""}`);
+  }
+  if (report.worktree?.error) {
+    parts.push(`could not read the worktree at ${report.worktree.dir}: ${report.worktree.error}`);
+  } else {
+    const kept = report.worktree?.uncommitted.length ?? 0;
+    if (kept > 0) {
+      parts.push(`kept ${kept}${report.worktree?.truncated ? "+" : ""} uncommitted path${kept === 1 ? "" : "s"} in the worktree`);
+    }
   }
   return parts.length > 0 ? `closed; ${parts.join("; ")}` : null;
 }
@@ -2451,12 +2541,22 @@ export async function patchPipeline(
          the hosts down before the flow and the state write, and report exactly
          what was stopped. Nothing on disk is touched — uncommitted stage work
          stays in the worktree and is named in the report instead. */
-      const close: PipelineCloseReport = { stopped: [], alreadyStopped: [], stillRunning: [], worktree: null };
+      const close: PipelineCloseReport = { stopped: [], alreadyStopped: [], unconfirmed: [], stillRunning: [], worktree: null };
       for (const target of liveStageHosts(pipeline)) {
         const result = await ports.stopStageAgent(target);
         if (result.outcome === "stopped") close.stopped.push(target);
-        else if (result.outcome === "not-running") close.alreadyStopped.push(target);
-        else close.stillRunning.push({ ...target, error: result.error });
+        else if (result.outcome === "failed") close.stillRunning.push({ ...target, error: result.error });
+        else if (result.outcome === "unconfirmed") {
+          close.unconfirmed.push({ ...target, operationId: result.operationId, detail: result.detail });
+        } else if (target.paneId && await ports.paneAgentAlive(target.paneId)) {
+          /* The registry knows no host, but an agent is still running in the
+             attempt's pane — the same evidence orphanAgentPane refuses a retry
+             on. Surface it rather than closing cleanly over a live agent. */
+          close.stillRunning.push({
+            ...target,
+            error: `an agent is still running in pane ${target.paneId}; kill the pane, then close again`,
+          });
+        } else close.alreadyStopped.push(target);
       }
       close.worktree = closeWorktreeReport(pipeline, ports);
       if (close.stillRunning.length > 0) {

--- a/src/lib/pipelines/engine.ts
+++ b/src/lib/pipelines/engine.ts
@@ -72,6 +72,9 @@ export type PipelineStageHostRef = {
   conversationId: string | null;
   agentPath: string | null;
   paneId: string | null;
+  /** Set for a conversation a stage agent spawned and the pipeline adopted, so
+      the report distinguishes it from the stage's own launch. */
+  adopted?: true;
 };
 
 export type PipelineStageStopResult =
@@ -101,6 +104,8 @@ export type PipelineCloseReport = {
       Headless reviewers are child processes with no registry entry, so they are
       counted here rather than in `stopped`. */
   reviewers: Array<{ stageId: string; attempt: number; flowId: string; round: number }>;
+  /** Unconfirmed hosts the operator explicitly dismissed on this close. */
+  acknowledged: Array<PipelineStageHostRef & { detail: string }>;
   /** Hosts that survived teardown, so the close cannot claim to be clean. */
   stillRunning: Array<PipelineStageHostRef & { error: string }>;
   /** Uncommitted stage work preserved in the worktree; null when unprovisioned. */
@@ -389,7 +394,8 @@ async function stageHostProbe(target: PipelineStageHostRef): Promise<StageHostPr
 
 export type StagePaneProbes = {
   killHostIfMatches?: (host: TmuxHostEvidence) => Promise<boolean>;
-  paneAgentAlive?: (paneId: string) => Promise<boolean>;
+  /** What the pane shows right now. Null when tmux has no such pane. */
+  paneSnapshot?: (paneId: string) => Promise<{ windowName: string; command: string } | null>;
 };
 
 /**
@@ -411,28 +417,32 @@ export async function stopPipelineStagePane(
 ): Promise<{ outcome: "stopped" | "not-running" } | { outcome: "unknown"; detail: string } | { outcome: "failed"; error: string }> {
   const paneId = target.paneId;
   if (!paneId) return { outcome: "not-running" };
-  const alive = probes.paneAgentAlive ?? (async (id: string) => {
-    const info = await paneInfo(id);
-    return info !== null && !isShellCommand(info.command);
-  });
+  const snapshot = probes.paneSnapshot ?? paneInfo;
+  /* Name what the pane actually shows. An operator handed "pane %3 now runs
+     codex in window review" can find it in tmux and decide; "it could not be
+     identified" alone leaves them nothing to act on. */
+  const describe = (info: { windowName: string; command: string } | null): string =>
+    info ? `pane ${paneId} now runs ${info.command} in window ${info.windowName}` : `pane ${paneId}`;
   try {
     const probe = await stageHostProbe(target);
     const host = probe?.host() ?? null;
     if (!host || host.paneId !== paneId) {
       /* No durable evidence ties this id to this agent. Report what is there,
          but never signal it. */
-      if (!(await alive(paneId))) return { outcome: "not-running" };
+      const info = await snapshot(paneId);
+      if (!info || isShellCommand(info.command)) return { outcome: "not-running" };
       return {
         outcome: "unknown",
-        detail: `pane ${paneId} runs an agent that cannot be identified as this stage's; stop it by hand if it is the orphan`,
+        detail: `${describe(info)} and cannot be identified as this stage's agent; stop it yourself if it is the orphan, or close again with acknowledgeHosts to dismiss it`,
       };
     }
     const killed = await (probes.killHostIfMatches ?? killTmuxHostIfMatches)(host);
     if (killed) return { outcome: "stopped" };
-    if (!(await alive(paneId))) return { outcome: "not-running" };
+    const info = await snapshot(paneId);
+    if (!info || isShellCommand(info.command)) return { outcome: "not-running" };
     return {
       outcome: "unknown",
-      detail: `pane ${paneId} changed or its agent did not exit; it was left running`,
+      detail: `${describe(info)}; it changed or its agent did not exit, so it was left running`,
     };
   } catch (error) {
     return { outcome: "failed", error: error instanceof Error ? error.message : String(error) };
@@ -2201,16 +2211,20 @@ async function orphanAgentPane(
  * process is still there, still holding the account's quota. Those parked lanes
  * are the orphans #670 was filed for, so residency is decided downstream from
  * evidence about the host (the registry, then the pane), never from the attempt
- * state machine. Lineage-adopted (`historical`) evidence is left alone: those
- * conversations belong to their own lineage, and a close must not reach outside
- * this pipeline's own stage launches.
+ * state machine.
+ *
+ * Adopted (`historical`) attempts count too. They are not passive evidence: a
+ * stage agent spawned that conversation through the viewer, adoptAttempt seats
+ * it running with its own launch, conversation and pane, and the tick tracks it
+ * as a live host until it produces a verdict. Skipping them let a helper the
+ * pipeline started keep burning quota behind a lane that had already left the
+ * board — this issue again, through another door.
  */
 function launchedStageHosts(pipeline: Pipeline): StageHostCandidate[] {
   const candidates: StageHostCandidate[] = [];
   const seen = new Set<string>();
   for (const run of pipeline.runs) {
     for (const attempt of run.attempts) {
-      if (attempt.historical) continue;
       if (!attempt.conversationId && !attempt.agentPath && !attempt.paneId) continue;
       /* Rounds can share a host identity (a review round re-reads its reviewer
          conversation); probing one host once keeps the counts truthful. */
@@ -2224,6 +2238,7 @@ function launchedStageHosts(pipeline: Pipeline): StageHostCandidate[] {
           conversationId: attempt.conversationId,
           agentPath: attempt.agentPath,
           paneId: attempt.paneId,
+          ...(attempt.historical ? { adopted: true as const } : {}),
         },
         /* Same reading orphanAgentPane uses: a verdict or a completion stamp
            means the turn ended, so what is left in the pane is an idle CLI. A
@@ -2244,7 +2259,8 @@ type StageHostCandidate = { target: PipelineStageHostRef; turnSettled: boolean }
 const CLOSE_TEARDOWN_BUDGET_MS = 10_000;
 
 function stageHostLabel(target: PipelineStageHostRef): string {
-  return `stage ${target.stageId} attempt ${target.attempt} (${target.conversationId ?? target.agentPath ?? "unknown host"})`;
+  const what = target.adopted ? "adopted agent of stage" : "stage";
+  return `${what} ${target.stageId} attempt ${target.attempt} (${target.conversationId ?? target.agentPath ?? "unknown host"})`;
 }
 
 /** Reads the uncommitted work a close leaves behind. Skipped while the pipeline
@@ -2265,14 +2281,18 @@ function closeWorktreeReport(pipeline: Pipeline, ports: PipelinePorts): Pipeline
     that a verified-clean worktree produces. */
 function closeSummary(report: PipelineCloseReport): string | null {
   const parts: string[] = [];
-  if (report.stopped.length > 0) {
-    parts.push(`stopped ${report.stopped.length} stage host${report.stopped.length === 1 ? "" : "s"}`);
-  }
+  const adopted = report.stopped.filter((item) => item.adopted).length;
+  const launched = report.stopped.length - adopted;
+  if (launched > 0) parts.push(`stopped ${launched} stage host${launched === 1 ? "" : "s"}`);
+  if (adopted > 0) parts.push(`stopped ${adopted} adopted agent${adopted === 1 ? "" : "s"}`);
   if (report.reviewers.length > 0) {
     parts.push(`stopped ${report.reviewers.length} review round${report.reviewers.length === 1 ? "" : "s"}`);
   }
   for (const item of report.unconfirmed) {
     parts.push(`${item.detail} for ${stageHostLabel(item)}${item.operationId ? ` (operation ${item.operationId})` : ""}`);
+  }
+  if (report.acknowledged.length > 0) {
+    parts.push(`dismissed ${report.acknowledged.length} unconfirmed host${report.acknowledged.length === 1 ? "" : "s"} on the operator's word`);
   }
   if (report.worktree?.error) {
     parts.push(`could not read the worktree at ${report.worktree.dir}: ${report.worktree.error}`);
@@ -2722,7 +2742,10 @@ export async function patchPipeline(
          the hosts down before the flow and the state write, and report exactly
          what was stopped. Nothing on disk is touched — uncommitted stage work
          stays in the worktree and is named in the report instead. */
-      const close: PipelineCloseReport = { stopped: [], alreadyStopped: [], unconfirmed: [], reviewers: [], stillRunning: [], worktree: null };
+      if (req.acknowledgeHosts !== undefined && typeof req.acknowledgeHosts !== "boolean") {
+        return { error: "acknowledgeHosts must be a boolean", status: 400 };
+      }
+      const close: PipelineCloseReport = { stopped: [], alreadyStopped: [], unconfirmed: [], acknowledged: [], reviewers: [], stillRunning: [], worktree: null };
       /* Each host's confirmation is bounded, but N of them multiply, and this
          whole loop holds the pipelines file transaction — every other pipeline
          mutation and the controller tick queue behind it. So the aggregate is
@@ -2808,6 +2831,15 @@ export async function patchPipeline(
       pipeline.state = "closed";
       pipeline.cursor = null;
       pipeline.pausedState = null;
+      /* The operator's way out of an unresolvable host (#670): a pane whose id
+         was recycled can look alive forever, so the lane would otherwise stay
+         pinned to the board with no dismissal. An acknowledgement clears only
+         hosts that are unconfirmed — anything proven to be still running has
+         already refused this close above. */
+      if (req.acknowledgeHosts === true && close.unconfirmed.length > 0) {
+        close.acknowledged.push(...close.unconfirmed.map((item) => ({ ...item, detail: item.detail })));
+        close.unconfirmed.length = 0;
+      }
       pipeline.stateDetail = closeSummary(close);
       pipeline.closedAt = ports.now();
       /* An unconfirmed kill may have left a resident host. Hiding the lane would

--- a/src/lib/pipelines/engine.ts
+++ b/src/lib/pipelines/engine.ts
@@ -1,10 +1,11 @@
 import crypto from "node:crypto";
+import fs from "node:fs";
 import path from "node:path";
 
 import { accountManager } from "@/lib/accounts/manager";
 import { emptyLaunchProfile, type ViewerConversationId } from "@/lib/accounts/migration/contracts";
 import { freshSpecFor } from "@/lib/agent/cli";
-import { agentRegistry, type DurableMembershipInput } from "@/lib/agent/registry";
+import { agentRegistry, type DurableMembershipInput, type TmuxHostEvidence } from "@/lib/agent/registry";
 import { transcriptAllowed } from "@/lib/agent/spawnParent";
 import { sessionKeyFromTranscript, sessionKeyId } from "@/lib/agent/sessionKey";
 import { headCwd } from "@/lib/agent/transcript";
@@ -20,7 +21,7 @@ import { loadTasks } from "@/lib/tasks/store";
 import type { BoardTask } from "@/lib/tasks/types";
 import { claudeProjectRootFor, codexSessionRootFor } from "@/lib/scanner/roots";
 import { isShellCommand } from "@/lib/status";
-import { killPane, paneInfo } from "@/lib/tmux";
+import { killTmuxHostIfMatches, paneInfo } from "@/lib/tmux";
 import type { FileEntry } from "@/lib/types";
 import { realExec, type ExecPort } from "@/lib/workflows/provision";
 
@@ -96,6 +97,10 @@ export type PipelineCloseReport = {
   /** Kills the runtime accepted without confirming termination in time. The
       operation id keeps the possible survivor addressable. */
   unconfirmed: Array<PipelineStageHostRef & { operationId: string | null; detail: string }>;
+  /** Review rounds whose live reviewer this close terminated through the flow.
+      Headless reviewers are child processes with no registry entry, so they are
+      counted here rather than in `stopped`. */
+  reviewers: Array<{ stageId: string; attempt: number; flowId: string; round: number }>;
   /** Hosts that survived teardown, so the close cannot claim to be clean. */
   stillRunning: Array<PipelineStageHostRef & { error: string }>;
   /** Uncommitted stage work preserved in the worktree; null when unprovisioned. */
@@ -132,15 +137,23 @@ export interface PipelinePorts {
   /** Terminates the host that owns a stage attempt's agent. `not-running` means
       no host was resident, so a close can tell an idle lane from one it stopped. */
   stopStageAgent(target: PipelineStageHostRef): Promise<PipelineStageStopResult>;
-  /** Terminates a stage attempt's tmux pane. The teardown's last resort for a
-      pane-hosted agent the registry cannot address. */
-  killStagePane(paneId: string): Promise<{ ok: true } | { ok: false; error: string }>;
+  /** Identity-verified teardown of a stage attempt's tmux pane, for a
+      pane-hosted agent the registry can no longer address. `unknown` means the
+      pane could not be proven to be this stage's, so nothing was signalled. */
+  stopStagePane(target: PipelineStageHostRef): Promise<
+    | { outcome: "stopped" | "not-running" }
+    | { outcome: "unknown"; detail: string }
+    | { outcome: "failed"; error: string }
+  >;
   /** Residency read with no side effects: `false` means the host is
       demonstrably gone. Used to retire an unconfirmed kill without re-killing. */
   stageHostResident(target: PipelineStageHostRef): Promise<boolean>;
   /** Monotonic milliseconds, kept apart from `now()` so a teardown budget can be
       bounded independently of the ISO timestamps written to the record. */
   monotonicNow(): number;
+  /** Whether the pipeline worktree is still on disk. A checkout removed after a
+      merge is a tidy close, not an unreadable worktree. */
+  worktreePresent(dir: string): boolean;
   conversationAgentActive(conversationId: string): Promise<boolean | null>;
   durableTurnEvidence(engine: EffectivePipelineRole["engine"], transcriptPath: string): Promise<StageTurnEvidence | null>;
   headCwd(transcriptPath: string): string | null;
@@ -151,7 +164,12 @@ export interface PipelinePorts {
   pipelineAdoptionCandidates(pipelineId: string): PipelineAdoptionCandidate[];
   createFlow(req: CreateFlowRequest, entries: FileEntry[]): Promise<{ flow?: Flow; error?: string }>;
   patchFlow(id: string, action: "advance" | "pause" | "resume", note?: string): { error?: string; status?: number };
-  closeFlow(id: string): Promise<{ flow?: Flow; error?: string; status?: number } | void>;
+  closeFlow(id: string): Promise<{
+    flow?: Flow;
+    error?: string;
+    status?: number;
+    stoppedReviewer?: { round: number } | null;
+  } | void>;
   getFlow(id: string): Flow | null;
   findFlow(implementerPath: string, implementerConversationId: string | null, baseRef: string, targetSha: string): Flow | null;
   projectForCwd(cwd: string): string | null;
@@ -337,6 +355,9 @@ type StageHostProbe = {
   conversationId: ViewerConversationId;
   transcriptPath: string;
   resident(): boolean;
+  /** Durable tmux evidence recorded for this session, if any. It is the only
+      thing that can identify a stored pane id as still being this agent's. */
+  host(): TmuxHostEvidence | null;
 };
 
 async function stageHostProbe(target: PipelineStageHostRef): Promise<StageHostProbe | null> {
@@ -362,7 +383,60 @@ async function stageHostProbe(target: PipelineStageHostRef): Promise<StageHostPr
       if (!entry || entry.status === "dead" || entry.status === "unhosted") return false;
       return structuredHostProcessAlive(entry.structuredHost?.process ?? null) || Boolean(entry.host);
     },
+    host: () => registry.readOnlySnapshot().entries[sessionKey]?.host ?? null,
   };
+}
+
+export type StagePaneProbes = {
+  killHostIfMatches?: (host: TmuxHostEvidence) => Promise<boolean>;
+  paneAgentAlive?: (paneId: string) => Promise<boolean>;
+};
+
+/**
+ * Last resort for a pane-hosted stage agent, gated on identity rather than
+ * liveness. A tmux pane id is unique only within one server lifetime and
+ * restarts at %0, while the attempt's stored id outlives that — and this path
+ * runs exactly when the registry has no resident host, which is when a stale id
+ * is most likely. "This pane runs something that is not a shell" would therefore
+ * happily kill an unrelated agent, so the kill goes through
+ * killTmuxHostIfMatches, which verifies the tmux server, the pane pid, the
+ * window name and the agent's process start identity before signalling. Without
+ * durable evidence to match, nothing is killed: the host is reported unknown so
+ * the operator decides. A refused close is a nuisance; killing someone else's
+ * agent is not recoverable.
+ */
+export async function stopPipelineStagePane(
+  target: PipelineStageHostRef,
+  probes: StagePaneProbes = {},
+): Promise<{ outcome: "stopped" | "not-running" } | { outcome: "unknown"; detail: string } | { outcome: "failed"; error: string }> {
+  const paneId = target.paneId;
+  if (!paneId) return { outcome: "not-running" };
+  const alive = probes.paneAgentAlive ?? (async (id: string) => {
+    const info = await paneInfo(id);
+    return info !== null && !isShellCommand(info.command);
+  });
+  try {
+    const probe = await stageHostProbe(target);
+    const host = probe?.host() ?? null;
+    if (!host || host.paneId !== paneId) {
+      /* No durable evidence ties this id to this agent. Report what is there,
+         but never signal it. */
+      if (!(await alive(paneId))) return { outcome: "not-running" };
+      return {
+        outcome: "unknown",
+        detail: `pane ${paneId} runs an agent that cannot be identified as this stage's; stop it by hand if it is the orphan`,
+      };
+    }
+    const killed = await (probes.killHostIfMatches ?? killTmuxHostIfMatches)(host);
+    if (killed) return { outcome: "stopped" };
+    if (!(await alive(paneId))) return { outcome: "not-running" };
+    return {
+      outcome: "unknown",
+      detail: `pane ${paneId} changed or its agent did not exit; it was left running`,
+    };
+  } catch (error) {
+    return { outcome: "failed", error: error instanceof Error ? error.message : String(error) };
+  }
 }
 
 export async function stopPipelineStageAgent(
@@ -443,14 +517,7 @@ export function defaultPipelinePorts(): PipelinePorts {
       return info !== null && !isShellCommand(info.command);
     },
     stopStageAgent: (target) => stopPipelineStageAgent(target),
-    killStagePane: async (paneId) => {
-      try {
-        await killPane(paneId);
-        return { ok: true };
-      } catch (error) {
-        return { ok: false, error: error instanceof Error ? error.message : String(error) };
-      }
-    },
+    stopStagePane: (target) => stopPipelineStagePane(target),
     stageHostResident: async (target) => {
       try {
         const probe = await stageHostProbe(target);
@@ -461,6 +528,7 @@ export function defaultPipelinePorts(): PipelinePorts {
       }
     },
     monotonicNow: () => Date.now(),
+    worktreePresent: (dir) => Boolean(dir) && fs.existsSync(dir),
     conversationAgentActive: async (conversationId) => {
       const client = runtimeHostClient();
       if (!client) return null;
@@ -2175,26 +2243,6 @@ type StageHostCandidate = { target: PipelineStageHostRef; turnSettled: boolean }
 /** Ceiling on a close's whole host teardown, holding the pipelines transaction. */
 const CLOSE_TEARDOWN_BUDGET_MS = 10_000;
 
-/**
- * Last resort for a pane-hosted agent the registry cannot address: kill the
- * pane, then confirm it stopped running one. Refusing instead would leave the
- * operator with a card that never closes and a host they have to kill by hand —
- * the very chore #670 exists to end.
- */
-async function stopStagePaneAgent(
-  paneId: string,
-  ports: PipelinePorts,
-): Promise<{ outcome: "stopped" } | { outcome: "failed"; error: string }> {
-  const killed = await ports.killStagePane(paneId);
-  if (!killed.ok) {
-    return { outcome: "failed", error: `could not kill pane ${paneId}: ${killed.error}` };
-  }
-  if (await ports.paneAgentAlive(paneId)) {
-    return { outcome: "failed", error: `pane ${paneId} still runs an agent after its kill; stop it, then close again` };
-  }
-  return { outcome: "stopped" };
-}
-
 function stageHostLabel(target: PipelineStageHostRef): string {
   return `stage ${target.stageId} attempt ${target.attempt} (${target.conversationId ?? target.agentPath ?? "unknown host"})`;
 }
@@ -2203,6 +2251,9 @@ function stageHostLabel(target: PipelineStageHostRef): string {
     has no provisioned worktree to read. */
 function closeWorktreeReport(pipeline: Pipeline, ports: PipelinePorts): PipelineCloseReport["worktree"] {
   if (pipeline.state === "provisioning" || !pipeline.lastPassedCommit) return null;
+  /* A worktree cleaned up after a merge has nothing to preserve and nothing to
+     report; only a checkout that is present but unreadable is a finding. */
+  if (!ports.worktreePresent(pipeline.worktreeDir)) return null;
   const changes = pipelineWorktreeChanges(pipeline, ports.exec);
   if (!changes.ok) return { dir: pipeline.worktreeDir, uncommitted: [], truncated: false, error: changes.error };
   return { dir: pipeline.worktreeDir, uncommitted: changes.paths, truncated: changes.truncated };
@@ -2216,6 +2267,9 @@ function closeSummary(report: PipelineCloseReport): string | null {
   const parts: string[] = [];
   if (report.stopped.length > 0) {
     parts.push(`stopped ${report.stopped.length} stage host${report.stopped.length === 1 ? "" : "s"}`);
+  }
+  if (report.reviewers.length > 0) {
+    parts.push(`stopped ${report.reviewers.length} review round${report.reviewers.length === 1 ? "" : "s"}`);
   }
   for (const item of report.unconfirmed) {
     parts.push(`${item.detail} for ${stageHostLabel(item)}${item.operationId ? ` (operation ${item.operationId})` : ""}`);
@@ -2668,7 +2722,7 @@ export async function patchPipeline(
          the hosts down before the flow and the state write, and report exactly
          what was stopped. Nothing on disk is touched — uncommitted stage work
          stays in the worktree and is named in the report instead. */
-      const close: PipelineCloseReport = { stopped: [], alreadyStopped: [], unconfirmed: [], stillRunning: [], worktree: null };
+      const close: PipelineCloseReport = { stopped: [], alreadyStopped: [], unconfirmed: [], reviewers: [], stillRunning: [], worktree: null };
       /* Each host's confirmation is bounded, but N of them multiply, and this
          whole loop holds the pipelines file transaction — every other pipeline
          mutation and the controller tick queue behind it. So the aggregate is
@@ -2694,14 +2748,15 @@ export async function patchPipeline(
         else if (result.outcome === "failed") close.stillRunning.push({ ...target, error: result.error });
         else if (result.outcome === "unconfirmed") {
           close.unconfirmed.push({ ...target, operationId: result.operationId, detail: result.detail });
-        } else if (!turnSettled && target.paneId && await ports.paneAgentAlive(target.paneId)) {
+        } else if (!turnSettled && target.paneId) {
           /* The registry knows no host, but the attempt never finished its turn
-             and an agent is still running in its pane. Killing the pane is the
-             last resort the operator would otherwise reach for by hand, so the
-             teardown does it here and confirms the pane went with it. */
-          const pane = await stopStagePaneAgent(target.paneId, ports);
+             and its pane may still hold the agent. The teardown kills it only
+             when durable evidence proves the pane is still this stage's. */
+          const pane = await ports.stopStagePane(target);
           if (pane.outcome === "stopped") close.stopped.push(target);
-          else close.stillRunning.push({ ...target, error: pane.error });
+          else if (pane.outcome === "failed") close.stillRunning.push({ ...target, error: pane.error });
+          else if (pane.outcome === "unknown") close.unconfirmed.push({ ...target, operationId: null, detail: pane.detail });
+          else close.alreadyStopped.push(target);
         } else close.alreadyStopped.push(target);
       }
       close.worktree = closeWorktreeReport(pipeline, ports);
@@ -2717,9 +2772,26 @@ export async function patchPipeline(
       if (flow && flow.state !== "closed") {
         const closed = await ports.closeFlow(flow.id);
         if (closed?.error) {
+          /* A reviewer that would not die is a survivor like any other, so it
+             leaves through the same report the host teardown uses. */
+          if (stage && attempt) close.stillRunning.push({
+            stageId: stage.id,
+            attempt: attempt.n,
+            conversationId: attempt.conversationId,
+            agentPath: attempt.agentPath,
+            paneId: attempt.paneId,
+            error: closed.error,
+          });
           pipeline.stateDetail = closed.error;
           persist();
           return { error: closed.error, status: closed.status ?? 409, close };
+        }
+        /* closeFlow terminates a live reviewer itself; counting what it stopped
+           is what keeps a mid-review close from reporting "nothing was running"
+           (#670). Headless reviewers never reach the agent registry, so the host
+           teardown above cannot see them. */
+        if (closed?.stoppedReviewer && stage && attempt) {
+          close.reviewers.push({ stageId: stage.id, attempt: attempt.n, flowId: flow.id, round: closed.stoppedReviewer.round });
         }
       }
       /* A cursor can rest at state pending before its round's attempt

--- a/src/lib/pipelines/engine.ts
+++ b/src/lib/pipelines/engine.ts
@@ -20,7 +20,7 @@ import { loadTasks } from "@/lib/tasks/store";
 import type { BoardTask } from "@/lib/tasks/types";
 import { claudeProjectRootFor, codexSessionRootFor } from "@/lib/scanner/roots";
 import { isShellCommand } from "@/lib/status";
-import { paneInfo } from "@/lib/tmux";
+import { killPane, paneInfo } from "@/lib/tmux";
 import type { FileEntry } from "@/lib/types";
 import { realExec, type ExecPort } from "@/lib/workflows/provision";
 
@@ -52,6 +52,7 @@ import type {
   PipelineStage,
   PipelineStageInput,
   PipelineStageAttempt,
+  PipelineUnconfirmedHost,
 } from "./types";
 import { parseStageVerdict, type ParsedStageVerdict } from "./verdict";
 
@@ -131,6 +132,15 @@ export interface PipelinePorts {
   /** Terminates the host that owns a stage attempt's agent. `not-running` means
       no host was resident, so a close can tell an idle lane from one it stopped. */
   stopStageAgent(target: PipelineStageHostRef): Promise<PipelineStageStopResult>;
+  /** Terminates a stage attempt's tmux pane. The teardown's last resort for a
+      pane-hosted agent the registry cannot address. */
+  killStagePane(paneId: string): Promise<{ ok: true } | { ok: false; error: string }>;
+  /** Residency read with no side effects: `false` means the host is
+      demonstrably gone. Used to retire an unconfirmed kill without re-killing. */
+  stageHostResident(target: PipelineStageHostRef): Promise<boolean>;
+  /** Monotonic milliseconds, kept apart from `now()` so a teardown budget can be
+      bounded independently of the ISO timestamps written to the record. */
+  monotonicNow(): number;
   conversationAgentActive(conversationId: string): Promise<boolean | null>;
   durableTurnEvidence(engine: EffectivePipelineRole["engine"], transcriptPath: string): Promise<StageTurnEvidence | null>;
   headCwd(transcriptPath: string): string | null;
@@ -321,10 +331,15 @@ export type StageStopProbes = {
  * yields `failed`; anything still in flight yields `unconfirmed` with its
  * operation id, and the close reports that instead of a clean stop.
  */
-export async function stopPipelineStageAgent(
-  target: PipelineStageHostRef,
-  probes: StageStopProbes = {},
-): Promise<PipelineStageStopResult> {
+/** Resolved identity of a stage host plus a live residency read. Null when the
+    registry has no trace of the conversation at all. */
+type StageHostProbe = {
+  conversationId: ViewerConversationId;
+  transcriptPath: string;
+  resident(): boolean;
+};
+
+async function stageHostProbe(target: PipelineStageHostRef): Promise<StageHostProbe | null> {
   const registry = agentRegistry();
   /* applyConversationAction resolves by id or by path; residency must too, or a
      prefixed id the registry cannot resolve short-circuits to not-running while
@@ -334,23 +349,33 @@ export async function stopPipelineStageAgent(
     : null;
   const conversation = byId ?? (target.agentPath ? registry.conversationForPath(target.agentPath) : null);
   const generation = conversation?.generations.at(-1) ?? null;
-  if (!conversation || !generation) return { outcome: "not-running" };
+  if (!conversation || !generation) return null;
   const sessionKey = sessionKeyId({ engine: conversation.engine, sessionId: generation.id });
-  try {
-    const { structuredHostProcessAlive } = await import("@/lib/runtime/structuredRecovery");
-    const resident = (): boolean => {
+  const { structuredHostProcessAlive } = await import("@/lib/runtime/structuredRecovery");
+  return {
+    conversationId: conversation.id,
+    transcriptPath: generation.path,
+    /* Re-read every call: the registry read cache invalidates on the file
+       signature, so a teardown written by the host process is visible here. */
+    resident: () => {
       const entry = registry.readOnlySnapshot().entries[sessionKey];
       if (!entry || entry.status === "dead" || entry.status === "unhosted") return false;
       return structuredHostProcessAlive(entry.structuredHost?.process ?? null) || Boolean(entry.host);
-    };
-    if (!resident()) return { outcome: "not-running" };
+    },
+  };
+}
+
+export async function stopPipelineStageAgent(
+  target: PipelineStageHostRef,
+  probes: StageStopProbes = {},
+): Promise<PipelineStageStopResult> {
+  try {
+    const probe = await stageHostProbe(target);
+    if (!probe || !probe.resident()) return { outcome: "not-running" };
+    const { conversationId, transcriptPath, resident } = probe;
 
     const { applyConversationAction } = await import("@/lib/conversation/actions");
-    const result = await applyConversationAction({
-      conversationId: conversation.id,
-      transcriptPath: generation.path,
-      action: "kill",
-    });
+    const result = await applyConversationAction({ conversationId, transcriptPath, action: "kill" });
     const body = result.body as { ok?: boolean; error?: string; operationId?: string; receipt?: { status?: string } };
     if (result.status >= 400 || body.ok !== true) {
       return { outcome: "failed", error: body.error ?? `stage host kill was refused with status ${result.status}` };
@@ -418,6 +443,24 @@ export function defaultPipelinePorts(): PipelinePorts {
       return info !== null && !isShellCommand(info.command);
     },
     stopStageAgent: (target) => stopPipelineStageAgent(target),
+    killStagePane: async (paneId) => {
+      try {
+        await killPane(paneId);
+        return { ok: true };
+      } catch (error) {
+        return { ok: false, error: error instanceof Error ? error.message : String(error) };
+      }
+    },
+    stageHostResident: async (target) => {
+      try {
+        const probe = await stageHostProbe(target);
+        return probe ? probe.resident() : false;
+      } catch {
+        /* An unreadable probe is not evidence of death; keep the record. */
+        return true;
+      }
+    },
+    monotonicNow: () => Date.now(),
     conversationAgentActive: async (conversationId) => {
       const client = runtimeHostClient();
       if (!client) return null;
@@ -1620,6 +1663,39 @@ function isStructuredSpawnPark(pipeline: Pipeline, attempt: PipelineStageAttempt
     || failure.includes("runtime host request timed out");
 }
 
+/**
+ * Retires the unconfirmed-host records a close left behind, once each host is
+ * demonstrably gone (#670). Without this a lane that has actually finished would
+ * sit on the board forever claiming a survivor it no longer has. The probe has
+ * no side effects — nothing is re-killed here; a host that is still resident
+ * keeps its record and the lane stays visible.
+ */
+async function reconcileUnconfirmedHosts(pipeline: Pipeline, ports: PipelinePorts): Promise<boolean> {
+  const outstanding = pipeline.unconfirmedHosts;
+  if (!outstanding?.length) return false;
+  const remaining: PipelineUnconfirmedHost[] = [];
+  for (const host of outstanding) {
+    const target: PipelineStageHostRef = {
+      stageId: host.stageId,
+      attempt: host.attempt,
+      conversationId: host.conversationId,
+      agentPath: host.agentPath,
+      paneId: host.paneId ?? null,
+    };
+    const resident = await ports.stageHostResident(target);
+    const paneAlive = !resident && target.paneId ? await ports.paneAgentAlive(target.paneId) : false;
+    if (resident || paneAlive) remaining.push(host);
+  }
+  if (remaining.length === outstanding.length) return false;
+  pipeline.unconfirmedHosts = remaining.length > 0 ? remaining : undefined;
+  /* The last survivor retired: the lane has nothing left to surface, so the
+     closed record hides like any other. */
+  if (!pipeline.unconfirmedHosts && pipeline.state === "closed") {
+    pipeline.hiddenAt = pipeline.closedAt ?? ports.now();
+  }
+  return true;
+}
+
 export async function tickPipelines(entries: FileEntry[], ports: PipelinePorts = defaultPipelinePorts()): Promise<{ pipelines: Pipeline[]; changed: boolean }> {
   if (tickStore.__llvPipelineTick) return { pipelines: [], changed: false };
   tickStore.__llvPipelineTick = true;
@@ -1634,6 +1710,7 @@ export async function tickPipelines(entries: FileEntry[], ports: PipelinePorts =
         pipelineChanged = rebindPipelineAttemptPaths(pipeline, ports) || pipelineChanged;
         pipelineChanged = reconcileParkedStructuredSpawn(pipeline, ports) || pipelineChanged;
         pipelineChanged = reconcileBoundReviewFlow(pipeline, ports) || pipelineChanged;
+        pipelineChanged = await reconcileUnconfirmedHosts(pipeline, ports) || pipelineChanged;
         if (!TERMINAL_STATES.has(pipeline.state) && pipeline.state !== "paused" && pipeline.state !== "needs_decision") {
           pipelineChanged = await tickPipeline(pipeline, entries, ports, persist) || pipelineChanged;
         }
@@ -2094,6 +2171,29 @@ function launchedStageHosts(pipeline: Pipeline): StageHostCandidate[] {
 /** A launched host plus whether its attempt's turn ended, which decides only
     whether the pane heuristic may speak for it. */
 type StageHostCandidate = { target: PipelineStageHostRef; turnSettled: boolean };
+
+/** Ceiling on a close's whole host teardown, holding the pipelines transaction. */
+const CLOSE_TEARDOWN_BUDGET_MS = 10_000;
+
+/**
+ * Last resort for a pane-hosted agent the registry cannot address: kill the
+ * pane, then confirm it stopped running one. Refusing instead would leave the
+ * operator with a card that never closes and a host they have to kill by hand —
+ * the very chore #670 exists to end.
+ */
+async function stopStagePaneAgent(
+  paneId: string,
+  ports: PipelinePorts,
+): Promise<{ outcome: "stopped" } | { outcome: "failed"; error: string }> {
+  const killed = await ports.killStagePane(paneId);
+  if (!killed.ok) {
+    return { outcome: "failed", error: `could not kill pane ${paneId}: ${killed.error}` };
+  }
+  if (await ports.paneAgentAlive(paneId)) {
+    return { outcome: "failed", error: `pane ${paneId} still runs an agent after its kill; stop it, then close again` };
+  }
+  return { outcome: "stopped" };
+}
 
 function stageHostLabel(target: PipelineStageHostRef): string {
   return `stage ${target.stageId} attempt ${target.attempt} (${target.conversationId ?? target.agentPath ?? "unknown host"})`;
@@ -2569,7 +2669,26 @@ export async function patchPipeline(
          what was stopped. Nothing on disk is touched — uncommitted stage work
          stays in the worktree and is named in the report instead. */
       const close: PipelineCloseReport = { stopped: [], alreadyStopped: [], unconfirmed: [], stillRunning: [], worktree: null };
-      for (const { target, turnSettled } of launchedStageHosts(pipeline)) {
+      /* Each host's confirmation is bounded, but N of them multiply, and this
+         whole loop holds the pipelines file transaction — every other pipeline
+         mutation and the controller tick queue behind it. So the aggregate is
+         bounded too, and the hosts the budget cut off are reported as
+         unconfirmed rather than silently skipped: the lane stays visible and a
+         later close picks the work up where this one stopped. */
+      const teardownDeadline = ports.monotonicNow() + CLOSE_TEARDOWN_BUDGET_MS;
+      const candidates = launchedStageHosts(pipeline);
+      for (let index = 0; index < candidates.length; index += 1) {
+        const { target, turnSettled } = candidates[index]!;
+        if (index > 0 && ports.monotonicNow() >= teardownDeadline) {
+          for (const remaining of candidates.slice(index)) {
+            close.unconfirmed.push({
+              ...remaining.target,
+              operationId: null,
+              detail: "close teardown budget expired before this host was probed",
+            });
+          }
+          break;
+        }
         const result = await ports.stopStageAgent(target);
         if (result.outcome === "stopped") close.stopped.push(target);
         else if (result.outcome === "failed") close.stillRunning.push({ ...target, error: result.error });
@@ -2577,13 +2696,12 @@ export async function patchPipeline(
           close.unconfirmed.push({ ...target, operationId: result.operationId, detail: result.detail });
         } else if (!turnSettled && target.paneId && await ports.paneAgentAlive(target.paneId)) {
           /* The registry knows no host, but the attempt never finished its turn
-             and an agent is still running in its pane — the same evidence
-             orphanAgentPane refuses a retry on. Surface it rather than closing
-             cleanly over a live agent. */
-          close.stillRunning.push({
-            ...target,
-            error: `an agent is still running in pane ${target.paneId}; kill the pane, then close again`,
-          });
+             and an agent is still running in its pane. Killing the pane is the
+             last resort the operator would otherwise reach for by hand, so the
+             teardown does it here and confirms the pane went with it. */
+          const pane = await stopStagePaneAgent(target.paneId, ports);
+          if (pane.outcome === "stopped") close.stopped.push(target);
+          else close.stillRunning.push({ ...target, error: pane.error });
         } else close.alreadyStopped.push(target);
       }
       close.worktree = closeWorktreeReport(pipeline, ports);
@@ -2630,6 +2748,7 @@ export async function patchPipeline(
             attempt: item.attempt,
             conversationId: item.conversationId,
             agentPath: item.agentPath,
+            paneId: item.paneId,
             operationId: item.operationId,
             detail: item.detail,
             at: pipeline.closedAt!,

--- a/src/lib/pipelines/engine.ts
+++ b/src/lib/pipelines/engine.ts
@@ -6,7 +6,7 @@ import { emptyLaunchProfile, type ViewerConversationId } from "@/lib/accounts/mi
 import { freshSpecFor } from "@/lib/agent/cli";
 import { agentRegistry, type DurableMembershipInput } from "@/lib/agent/registry";
 import { transcriptAllowed } from "@/lib/agent/spawnParent";
-import { sessionKeyFromTranscript } from "@/lib/agent/sessionKey";
+import { sessionKeyFromTranscript, sessionKeyId } from "@/lib/agent/sessionKey";
 import { headCwd } from "@/lib/agent/transcript";
 import { MAX_FLOW_NOTE_LENGTH, closeFlow, createFlowFromRequest, patchFlow } from "@/lib/flows/commands";
 import { lastAssistantMessage } from "@/lib/flows/findings";
@@ -26,7 +26,7 @@ import { realExec, type ExecPort } from "@/lib/workflows/provision";
 
 import { requestPipelineTick } from "./controllerSignal";
 import { durableStageTurnEvidence, type StageTurnEvidence } from "./durableEvidence";
-import { commitPipelineStage, currentPipelineBranchHead, currentPipelineRemoteBranchHead, provisionPipelineWorktree, resetPipelineStage, resolvePipelineBase, synchronizePipelineRetryHead } from "./git";
+import { commitPipelineStage, currentPipelineBranchHead, currentPipelineRemoteBranchHead, pipelineWorktreeChanges, provisionPipelineWorktree, resetPipelineStage, resolvePipelineBase, synchronizePipelineRetryHead } from "./git";
 import {
   DEFAULT_FAIL_EDGE_ROUNDS,
   MAX_FAIL_EDGE_ROUNDS,
@@ -63,6 +63,36 @@ export type PipelineStageSpawn = {
   paneId: string | null;
 };
 
+/** Identity of the agent host a stage attempt owns, as a close reports it. */
+export type PipelineStageHostRef = {
+  stageId: string;
+  attempt: number;
+  conversationId: string | null;
+  agentPath: string | null;
+  paneId: string | null;
+};
+
+export type PipelineStageStopResult =
+  | { outcome: "stopped" }
+  | { outcome: "not-running" }
+  | { outcome: "failed"; error: string };
+
+/**
+ * What closing a pipeline did to its stage hosts, and what it left on disk
+ * (#670). `stopped` is empty and `alreadyStopped` may be populated when nothing
+ * was burning quota; a non-empty `stillRunning` means the close was refused.
+ */
+export type PipelineCloseReport = {
+  /** Hosts this close terminated. */
+  stopped: PipelineStageHostRef[];
+  /** Non-terminal stages whose host was already gone. */
+  alreadyStopped: PipelineStageHostRef[];
+  /** Hosts that survived teardown, so the close cannot claim to be clean. */
+  stillRunning: Array<PipelineStageHostRef & { error: string }>;
+  /** Uncommitted stage work preserved in the worktree; null when unprovisioned. */
+  worktree: { dir: string; uncommitted: string[]; truncated: boolean; error?: string } | null;
+};
+
 export type PipelineStageLaunchReservation = Pick<PipelineStageSpawn, "launchId" | "conversationId">;
 export type PipelineSpawnReceipt = PipelineStageSpawn & {
   state: "starting" | "pane-bound" | "host-verified" | "prompt-delivered" | "path-pending" | "completed" | "failed" | "conflicted";
@@ -90,6 +120,9 @@ export interface PipelinePorts {
   spawnReceipt(launchId: string): PipelineSpawnReceipt | null;
   claimSpawnRetry(launchId: string, claimId: string): "claimed" | "settled" | "conflict";
   paneAgentAlive(paneId: string): Promise<boolean>;
+  /** Terminates the host that owns a stage attempt's agent. `not-running` means
+      no host was resident, so a close can tell an idle lane from one it stopped. */
+  stopStageAgent(target: PipelineStageHostRef): Promise<PipelineStageStopResult>;
   conversationAgentActive(conversationId: string): Promise<boolean | null>;
   durableTurnEvidence(engine: EffectivePipelineRole["engine"], transcriptPath: string): Promise<StageTurnEvidence | null>;
   headCwd(transcriptPath: string): string | null;
@@ -243,6 +276,42 @@ async function spawnPipelineAgent(
   };
 }
 
+/**
+ * Terminates the agent host a stage attempt owns, through the same control path
+ * an operator's kill uses — structured hosts go over the runtime command
+ * channel, legacy panes down the tmux ladder. Nothing on disk is touched: the
+ * worktree, including uncommitted stage work, is left exactly as the agent left
+ * it. Residency is read from the durable registry first so a lane whose host is
+ * already gone reports `not-running` instead of a manufactured kill.
+ */
+async function stopPipelineStageAgent(target: PipelineStageHostRef): Promise<PipelineStageStopResult> {
+  const registry = agentRegistry();
+  const conversation = target.conversationId?.startsWith("conversation_")
+    ? registry.conversation(target.conversationId as ViewerConversationId)
+    : target.agentPath
+      ? registry.conversationForPath(target.agentPath)
+      : null;
+  const generation = conversation?.generations.at(-1) ?? null;
+  if (!conversation || !generation) return { outcome: "not-running" };
+  const entry = registry.readOnlySnapshot().entries[sessionKeyId({ engine: conversation.engine, sessionId: generation.id })];
+  if (!entry || entry.status === "dead" || entry.status === "unhosted") return { outcome: "not-running" };
+  try {
+    const { structuredHostProcessAlive } = await import("@/lib/runtime/structuredRecovery");
+    if (!structuredHostProcessAlive(entry.structuredHost?.process ?? null) && !entry.host) return { outcome: "not-running" };
+    const { applyConversationAction } = await import("@/lib/conversation/actions");
+    const result = await applyConversationAction({
+      conversationId: conversation.id,
+      transcriptPath: generation.path,
+      action: "kill",
+    });
+    const body = result.body as { ok?: boolean; error?: string };
+    if (result.status < 400 && body.ok === true) return { outcome: "stopped" };
+    return { outcome: "failed", error: body.error ?? `stage host kill was refused with status ${result.status}` };
+  } catch (error) {
+    return { outcome: "failed", error: error instanceof Error ? error.message : String(error) };
+  }
+}
+
 export function defaultPipelinePorts(): PipelinePorts {
   let runtimeSnapshot: ReturnType<NonNullable<ReturnType<typeof runtimeHostClient>>["snapshot"]> | null = null;
   return {
@@ -267,6 +336,7 @@ export function defaultPipelinePorts(): PipelinePorts {
       const info = await paneInfo(paneId);
       return info !== null && !isShellCommand(info.command);
     },
+    stopStageAgent: stopPipelineStageAgent,
     conversationAgentActive: async (conversationId) => {
       const client = runtimeHostClient();
       if (!client) return null;
@@ -1669,13 +1739,15 @@ function replaceDraftStages(
   return {};
 }
 
-type PipelineMutationResult = {
+export type PipelineMutationResult = {
   pipeline?: Pipeline;
   error?: string;
   status?: number;
   code?: PipelineRepoPreflightErrorCode;
   field?: "repoDir";
   path?: string;
+  /** Set by the close action: what its host teardown stopped and preserved. */
+  close?: PipelineCloseReport;
 };
 
 type PipelineCreatorLineage = {
@@ -1892,6 +1964,54 @@ async function orphanAgentPane(
   if (!attempt || attempt.verdict || attempt.completedAt || !attempt.paneId) return null;
   if (!(await ports.paneAgentAlive(attempt.paneId))) return null;
   return { error: `stage agent may still be running in pane ${attempt.paneId}; wait for it to exit or kill the pane first`, status: 409 };
+}
+
+/** Stage attempts that may still own a live agent host: every current round
+    that has not reached a terminal state and named a conversation. Historical
+    (lineage-adopted) evidence never owns a host this pipeline may terminate. */
+function liveStageHosts(pipeline: Pipeline): PipelineStageHostRef[] {
+  const targets: PipelineStageHostRef[] = [];
+  for (const run of pipeline.runs) {
+    for (const attempt of run.attempts) {
+      if (attempt.historical || TERMINAL_ATTEMPT_STATES.has(attempt.state)) continue;
+      if (!attempt.conversationId && !attempt.agentPath) continue;
+      targets.push({
+        stageId: run.stageId,
+        attempt: attempt.n,
+        conversationId: attempt.conversationId,
+        agentPath: attempt.agentPath,
+        paneId: attempt.paneId,
+      });
+    }
+  }
+  return targets;
+}
+
+function stageHostLabel(target: PipelineStageHostRef): string {
+  return `stage ${target.stageId} attempt ${target.attempt} (${target.conversationId ?? target.agentPath ?? "unknown host"})`;
+}
+
+/** Reads the uncommitted work a close leaves behind. Skipped while the pipeline
+    has no provisioned worktree to read. */
+function closeWorktreeReport(pipeline: Pipeline, ports: PipelinePorts): PipelineCloseReport["worktree"] {
+  if (pipeline.state === "provisioning" || !pipeline.lastPassedCommit) return null;
+  const changes = pipelineWorktreeChanges(pipeline, ports.exec);
+  if (!changes.ok) return { dir: pipeline.worktreeDir, uncommitted: [], truncated: false, error: changes.error };
+  return { dir: pipeline.worktreeDir, uncommitted: changes.paths, truncated: changes.truncated };
+}
+
+/** Durable one-line account of a close, so the board and the API agree on
+    whether anything was stopped and what was preserved. */
+function closeSummary(report: PipelineCloseReport): string | null {
+  const parts: string[] = [];
+  if (report.stopped.length > 0) {
+    parts.push(`stopped ${report.stopped.length} stage host${report.stopped.length === 1 ? "" : "s"}`);
+  }
+  const kept = report.worktree?.uncommitted.length ?? 0;
+  if (kept > 0) {
+    parts.push(`kept ${kept}${report.worktree?.truncated ? "+" : ""} uncommitted path${kept === 1 ? "" : "s"} in the worktree`);
+  }
+  return parts.length > 0 ? `closed; ${parts.join("; ")}` : null;
 }
 
 export async function patchPipeline(
@@ -2326,12 +2446,34 @@ export async function patchPipeline(
         persist();
         return { pipeline };
       }
+      /* #670: a close used to leave the stage host resident, so the agent kept
+         executing on a paid quota and the board kept a live-looking chip. Tear
+         the hosts down before the flow and the state write, and report exactly
+         what was stopped. Nothing on disk is touched — uncommitted stage work
+         stays in the worktree and is named in the report instead. */
+      const close: PipelineCloseReport = { stopped: [], alreadyStopped: [], stillRunning: [], worktree: null };
+      for (const target of liveStageHosts(pipeline)) {
+        const result = await ports.stopStageAgent(target);
+        if (result.outcome === "stopped") close.stopped.push(target);
+        else if (result.outcome === "not-running") close.alreadyStopped.push(target);
+        else close.stillRunning.push({ ...target, error: result.error });
+      }
+      close.worktree = closeWorktreeReport(pipeline, ports);
+      if (close.stillRunning.length > 0) {
+        /* A host that survived teardown must not be reported as a clean close:
+           the pipeline keeps its state so the survivor stays visible and
+           addressable instead of hiding behind a closed lane. */
+        const detail = `could not stop ${close.stillRunning.map((item) => `${stageHostLabel(item)}: ${item.error}`).join("; ")}`;
+        pipeline.stateDetail = detail;
+        persist();
+        return { error: detail, status: 409, close };
+      }
       if (flow && flow.state !== "closed") {
         const closed = await ports.closeFlow(flow.id);
         if (closed?.error) {
           pipeline.stateDetail = closed.error;
           persist();
-          return { error: closed.error, status: closed.status ?? 409 };
+          return { error: closed.error, status: closed.status ?? 409, close };
         }
       }
       /* A cursor can rest at state pending before its round's attempt
@@ -2348,9 +2490,11 @@ export async function patchPipeline(
       pipeline.state = "closed";
       pipeline.cursor = null;
       pipeline.pausedState = null;
-      pipeline.stateDetail = null;
+      pipeline.stateDetail = closeSummary(close);
       pipeline.closedAt = ports.now();
       pipeline.hiddenAt = pipeline.closedAt;
+      persist();
+      return { pipeline, close };
     } else {
       return { error: "unknown pipeline action", status: 400 };
     }

--- a/src/lib/pipelines/git.test.ts
+++ b/src/lib/pipelines/git.test.ts
@@ -3,7 +3,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
-import { commitPipelineStage, provisionPipelineWorktree, resetPipelineStage, resolvePipelineBase, synchronizePipelineRetryHead } from "./git";
+import { commitPipelineStage, pipelineWorktreeChanges, provisionPipelineWorktree, resetPipelineStage, resolvePipelineBase, synchronizePipelineRetryHead } from "./git";
 import type { Pipeline } from "./types";
 import { realExec, type ExecPort } from "@/lib/workflows/provision";
 
@@ -215,4 +215,52 @@ test("issue 533: manual review retry never resets clean remote 8232d71 to stale 
   expect(synchronizePipelineRetryHead(subject, exec)).toEqual({ ok: true, sha: synchronizedHead });
   expect(calls.some((call) => call.includes("reset --hard"))).toBe(false);
   expect(calls.some((call) => call.startsWith("git merge "))).toBe(false);
+});
+
+test("a real dirty worktree reports its uncommitted paths and keeps every one of them", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "llv-pipeline-close-"));
+  const repo = path.join(root, "repo");
+  try {
+    fs.mkdirSync(repo);
+    git(repo, "init", "--initial-branch=main");
+    git(repo, "config", "user.email", "pipeline-test@example.com");
+    git(repo, "config", "user.name", "Pipeline Test");
+    git(repo, "config", "commit.gpgSign", "false");
+    fs.writeFileSync(path.join(repo, "tracked.txt"), "base\n");
+    fs.writeFileSync(path.join(repo, "renamed.txt"), "moved\n");
+    git(repo, "add", "-A");
+    git(repo, "commit", "-m", "base");
+
+    fs.writeFileSync(path.join(repo, "tracked.txt"), "stage work in progress\n");
+    fs.writeFileSync(path.join(repo, "untracked.txt"), "never discard me\n");
+    git(repo, "mv", "renamed.txt", "moved.txt");
+
+    const subject = pipeline();
+    subject.worktreeDir = repo;
+    const changes = pipelineWorktreeChanges(subject, realExec);
+
+    expect(changes).toEqual({ ok: true, paths: ["moved.txt", "tracked.txt", "untracked.txt"], truncated: false });
+    /* Reading the worktree must never mutate it: the close preserves the work. */
+    expect(fs.readFileSync(path.join(repo, "untracked.txt"), "utf8")).toBe("never discard me\n");
+    expect(fs.readFileSync(path.join(repo, "tracked.txt"), "utf8")).toBe("stage work in progress\n");
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("worktree change reporting truncates long lists and surfaces an unreadable worktree", () => {
+  const many: ExecPort = () => ({
+    code: 0,
+    stdout: Array.from({ length: 22 }, (_, index) => `?? file-${index}.txt`).join("\n"),
+    stderr: "",
+  });
+  const reported = pipelineWorktreeChanges(pipeline(), many, 20);
+  expect(reported).toMatchObject({ ok: true, truncated: true });
+  expect(reported.ok && reported.paths).toHaveLength(20);
+
+  const missing: ExecPort = () => ({ code: 128, stdout: "", stderr: "fatal: not a git repository" });
+  expect(pipelineWorktreeChanges(pipeline(), missing)).toEqual({
+    ok: false,
+    error: "checking the pipeline worktree: fatal: not a git repository",
+  });
 });

--- a/src/lib/pipelines/git.ts
+++ b/src/lib/pipelines/git.ts
@@ -79,6 +79,30 @@ export function commitPipelineStage(pipeline: Pipeline, stageId: string, allowCo
   return { ok: true, sha: head.stdout.trim() };
 }
 
+export type PipelineWorktreeChanges =
+  | { ok: true; paths: string[]; truncated: boolean }
+  | { ok: false; error: string };
+
+/** Lists the uncommitted paths a pipeline worktree still holds. Closing a
+    pipeline (#670) must never discard stage work, so the close only reads this
+    — it reports what it left behind instead of resetting or cleaning. */
+export function pipelineWorktreeChanges(
+  pipeline: Pick<Pipeline, "worktreeDir">,
+  exec: ExecPort,
+  limit = 20,
+): PipelineWorktreeChanges {
+  const status = exec("git", ["status", "--porcelain"], pipeline.worktreeDir);
+  if (status.code !== 0) return failure("checking the pipeline worktree", status);
+  const paths = status.stdout
+    .split("\n")
+    .map((line) => line.trimEnd())
+    /* Porcelain v1 lines are `XY <path>`; a rename carries `<old> -> <new>`. */
+    .filter((line) => line.length > 3)
+    .map((line) => line.slice(3).split(" -> ").at(-1)!.trim())
+    .filter((entry) => entry.length > 0);
+  return { ok: true, paths: paths.slice(0, limit), truncated: paths.length > limit };
+}
+
 export function resetPipelineStage(pipeline: Pipeline, exec: ExecPort): PipelineGitResult {
   if (!pipeline.lastPassedCommit) return { ok: false, error: "the pipeline has no passed-stage commit" };
   const reset = exec("git", ["reset", "--hard", pipeline.lastPassedCommit], pipeline.worktreeDir);

--- a/src/lib/pipelines/stageHostTeardown.test.ts
+++ b/src/lib/pipelines/stageHostTeardown.test.ts
@@ -1,0 +1,126 @@
+import crypto from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { afterAll, beforeEach, expect, mock, test } from "bun:test";
+
+/* This suite exercises the close path's host teardown, which terminates agent
+   processes. Everything it touches is a throwaway registry inside this sandbox
+   and a stubbed conversation-action seam — it never reads the shared runtime
+   state directory and can never dispatch a real kill. */
+const sandbox = fs.mkdtempSync(path.join(os.tmpdir(), "llv-pipeline-stop-host-"));
+process.env.LLV_STATE_DIR = path.join(sandbox, "state");
+fs.mkdirSync(process.env.LLV_STATE_DIR, { recursive: true });
+afterAll(() => fs.rmSync(sandbox, { recursive: true, force: true }));
+
+type KillRequest = { conversationId: string; transcriptPath: string; action: string };
+const killed: KillRequest[] = [];
+let killResult: { status: number; body: Record<string, unknown> } = { status: 200, body: { ok: true, structured: true } };
+
+mock.module("@/lib/conversation/actions", () => ({
+  CONVERSATION_ACTIONS: ["interrupt", "kill", "resume", "compact", "dialog-key"] as const,
+  applyConversationAction: async (request: KillRequest) => {
+    killed.push(request);
+    return killResult;
+  },
+}));
+
+const { AgentRegistry, setAgentRegistryForTests } = await import("@/lib/agent/registry");
+const { procBackend } = await import("@/lib/proc");
+const { sessionKeyId } = await import("@/lib/agent/sessionKey");
+const { defaultPipelinePorts } = await import("./engine");
+
+type Registry = InstanceType<typeof AgentRegistry>;
+
+/** Seats a structured conversation whose host process is this test process, so
+    the liveness probe reports a resident host without spawning anything. */
+function hostedConversation(options: { status?: "live" | "dead"; hosted?: boolean } = {}): {
+  registry: Registry;
+  conversationId: string;
+  path: string;
+} {
+  const id = crypto.randomUUID();
+  const pathname = path.join(sandbox, `${id}.jsonl`);
+  const registry = new AgentRegistry(path.join(sandbox, `${id}.registry.json`), undefined, undefined, { sqliteMode: "off" });
+  const begun = registry.beginSpawnRequest({ engine: "codex", cwd: sandbox, transport: "structured", accountId: "codex-subscription" });
+  if (begun.kind !== "created") throw new Error("spawn receipt was unavailable");
+  const settled = registry.settleSpawn(begun.receipt.launchId, {
+    key: { engine: "codex", sessionId: id },
+    artifactPath: pathname,
+    cwd: sandbox,
+    accountId: "codex-subscription",
+    status: options.status ?? "live",
+    host: null,
+    structuredHost: options.hosted === false ? null : {
+      kind: "codex-app-server",
+      endpoint: "fake:stdio",
+      process: { pid: process.pid, startIdentity: procBackend.processIdentity(process.pid) },
+      eventCursor: 1,
+      protocolVersion: "fake-v1",
+      writerClaimEpoch: 1,
+      activeTurnRef: "turn-live",
+      pendingAttention: [],
+      activeFlags: [],
+    },
+    claimEpoch: 1,
+    claimOwner: "structured-host:test",
+    pendingAction: null,
+  });
+  if (settled.kind !== "settled") throw new Error("structured conversation was unavailable");
+  /* Fence the fixture itself: a "not-running" verdict must come from the seated
+     host state, never from an entry the registry silently failed to record. */
+  const entry = registry.readOnlySnapshot().entries[sessionKeyId({ engine: "codex", sessionId: id })];
+  if (!entry) throw new Error("registry fixture did not record the session entry");
+  expect(entry.status).toBe(options.status ?? "live");
+  setAgentRegistryForTests(registry);
+  return { registry, conversationId: begun.receipt.conversationId, path: pathname };
+}
+
+function target(conversationId: string | null, agentPath: string | null = null) {
+  return { stageId: "build", attempt: 1, conversationId, agentPath, paneId: null };
+}
+
+beforeEach(() => {
+  killed.length = 0;
+  killResult = { status: 200, body: { ok: true, structured: true } };
+});
+
+test("a resident stage host is terminated through the conversation kill control (#670)", async () => {
+  const fixture = hostedConversation();
+
+  const result = await defaultPipelinePorts().stopStageAgent(target(fixture.conversationId));
+
+  expect(result).toEqual({ outcome: "stopped" });
+  expect(killed).toEqual([{ conversationId: fixture.conversationId, transcriptPath: fixture.path, action: "kill" }]);
+  setAgentRegistryForTests(null);
+});
+
+test("a stage whose host is already gone reports not-running without dispatching a kill (#670)", async () => {
+  const dead = hostedConversation({ status: "dead" });
+  expect(await defaultPipelinePorts().stopStageAgent(target(dead.conversationId))).toEqual({ outcome: "not-running" });
+
+  const unhosted = hostedConversation({ hosted: false });
+  expect(await defaultPipelinePorts().stopStageAgent(target(unhosted.conversationId))).toEqual({ outcome: "not-running" });
+
+  const unknown = hostedConversation();
+  expect(await defaultPipelinePorts().stopStageAgent(target("conversation_missing"))).toEqual({ outcome: "not-running" });
+  expect(await defaultPipelinePorts().stopStageAgent(target(null, path.join(sandbox, "never-seen.jsonl")))).toEqual({ outcome: "not-running" });
+  expect(unknown.registry.conversation(unknown.conversationId as `conversation_${string}`)).not.toBeNull();
+
+  expect(killed).toEqual([]);
+  setAgentRegistryForTests(null);
+});
+
+test("a refused kill surfaces the still-running host instead of claiming a stop (#670)", async () => {
+  const fixture = hostedConversation();
+  killResult = { status: 503, body: { error: "structured runtime host is unavailable" } };
+
+  expect(await defaultPipelinePorts().stopStageAgent(target(fixture.conversationId)))
+    .toEqual({ outcome: "failed", error: "structured runtime host is unavailable" });
+
+  killResult = { status: 200, body: { ok: false, outcome: "failed" } };
+  expect(await defaultPipelinePorts().stopStageAgent(target(fixture.conversationId)))
+    .toEqual({ outcome: "failed", error: "stage host kill was refused with status 200" });
+  setAgentRegistryForTests(null);
+});

--- a/src/lib/pipelines/stageHostTeardown.test.ts
+++ b/src/lib/pipelines/stageHostTeardown.test.ts
@@ -35,14 +35,14 @@ mock.module("@/lib/conversation/actions", () => ({
 const { AgentRegistry, setAgentRegistryForTests } = await import("@/lib/agent/registry");
 const { procBackend } = await import("@/lib/proc");
 const { sessionKeyId } = await import("@/lib/agent/sessionKey");
-const { defaultPipelinePorts, stopPipelineStageAgent } = await import("./engine");
+const { defaultPipelinePorts, stopPipelineStageAgent, stopPipelineStagePane } = await import("./engine");
 type RuntimeHostClient = import("@/lib/runtime/client").RuntimeHostClient;
 
 type Registry = InstanceType<typeof AgentRegistry>;
 
 /** Seats a structured conversation whose host process is this test process, so
     the liveness probe reports a resident host without spawning anything. */
-function hostedConversation(options: { status?: "live" | "dead"; hosted?: boolean } = {}): {
+function hostedConversation(options: { status?: "live" | "dead"; hosted?: boolean; pane?: TmuxHostEvidence | null } = {}): {
   registry: Registry;
   conversationId: string;
   path: string;
@@ -59,7 +59,7 @@ function hostedConversation(options: { status?: "live" | "dead"; hosted?: boolea
     cwd: sandbox,
     accountId: "codex-subscription",
     status: options.status ?? "live",
-    host: null,
+    host: options.pane ?? null,
     structuredHost: options.hosted === false ? null : {
       kind: "codex-app-server",
       endpoint: "fake:stdio",
@@ -249,6 +249,83 @@ test("the residency probe reads host state without dispatching anything (#670)",
   live.registry.terminateStructuredHost(live.key);
   expect(await ports.stageHostResident(target(live.conversationId))).toBeFalse();
   expect(await ports.stageHostResident(target("conversation_never_seen"))).toBeFalse();
+  expect(killed).toEqual([]);
+  setAgentRegistryForTests(null);
+});
+
+type TmuxHostEvidence = import("@/lib/agent/registry").TmuxHostEvidence;
+
+/** Durable tmux evidence shaped like a real spawn record. */
+function paneEvidence(paneId: string): TmuxHostEvidence {
+  const identity = { pid: process.pid, startIdentity: procBackend.processIdentity(process.pid) };
+  return {
+    kind: "tmux",
+    endpoint: { tmuxTmpdir: path.join(sandbox, "tmux"), socketName: "default" },
+    windowName: "stage-build",
+    server: identity,
+    agent: identity,
+    paneId,
+    panePid: identity,
+    target: paneId,
+  } as unknown as TmuxHostEvidence;
+}
+
+test("a stage pane is killed only when its recorded identity still matches (#670)", async () => {
+  const fixture = hostedConversation({ status: "dead", hosted: false, pane: paneEvidence("%3") });
+  const attempted: TmuxHostEvidence[] = [];
+
+  const stopped = await stopPipelineStagePane(
+    { stageId: "build", attempt: 1, conversationId: fixture.conversationId, agentPath: null, paneId: "%3" },
+    {
+      killHostIfMatches: async (host) => { attempted.push(host); return true; },
+      paneAgentAlive: async () => true,
+    },
+  );
+
+  expect(stopped).toEqual({ outcome: "stopped" });
+  expect(attempted).toHaveLength(1);
+  expect(attempted[0]!.paneId).toBe("%3");
+  setAgentRegistryForTests(null);
+});
+
+test("a recycled pane id is reported unknown and never signalled (#670)", async () => {
+  /* The tmux server restarted and %3 now belongs to someone else's window, so
+     the identity check refuses. Nothing may be killed here. */
+  const changed = hostedConversation({ status: "dead", hosted: false, pane: paneEvidence("%3") });
+  let signalled = 0;
+
+  const mismatch = await stopPipelineStagePane(
+    { stageId: "build", attempt: 1, conversationId: changed.conversationId, agentPath: null, paneId: "%3" },
+    {
+      killHostIfMatches: async () => { signalled += 1; return false; },
+      paneAgentAlive: async () => true,
+    },
+  );
+  expect(mismatch).toMatchObject({ outcome: "unknown" });
+  expect((mismatch as { detail: string }).detail).toContain("%3");
+  setAgentRegistryForTests(null);
+
+  /* No durable evidence at all: the stored id names a pane we cannot claim. */
+  const unknown = hostedConversation({ status: "dead", hosted: false });
+  const orphan = await stopPipelineStagePane(
+    { stageId: "build", attempt: 1, conversationId: unknown.conversationId, agentPath: null, paneId: "%3" },
+    {
+      killHostIfMatches: async () => { signalled += 1; return true; },
+      paneAgentAlive: async () => true,
+    },
+  );
+  expect(orphan).toMatchObject({ outcome: "unknown" });
+  /* The mismatching kill probe ran once and refused; the evidence-less case
+     never reached a kill at all. */
+  expect(signalled).toBe(1);
+
+  /* Nothing running in the pane at all is simply nothing to stop. */
+  const quiet = await stopPipelineStagePane(
+    { stageId: "build", attempt: 1, conversationId: unknown.conversationId, agentPath: null, paneId: "%3" },
+    { killHostIfMatches: async () => { signalled += 1; return true; }, paneAgentAlive: async () => false },
+  );
+  expect(quiet).toEqual({ outcome: "not-running" });
+  expect(signalled).toBe(1);
   expect(killed).toEqual([]);
   setAgentRegistryForTests(null);
 });

--- a/src/lib/pipelines/stageHostTeardown.test.ts
+++ b/src/lib/pipelines/stageHostTeardown.test.ts
@@ -278,7 +278,7 @@ test("a stage pane is killed only when its recorded identity still matches (#670
     { stageId: "build", attempt: 1, conversationId: fixture.conversationId, agentPath: null, paneId: "%3" },
     {
       killHostIfMatches: async (host) => { attempted.push(host); return true; },
-      paneAgentAlive: async () => true,
+      paneSnapshot: async () => ({ windowName: "stage-build", command: "codex" }),
     },
   );
 
@@ -298,7 +298,7 @@ test("a recycled pane id is reported unknown and never signalled (#670)", async 
     { stageId: "build", attempt: 1, conversationId: changed.conversationId, agentPath: null, paneId: "%3" },
     {
       killHostIfMatches: async () => { signalled += 1; return false; },
-      paneAgentAlive: async () => true,
+      paneSnapshot: async () => ({ windowName: "stage-build", command: "codex" }),
     },
   );
   expect(mismatch).toMatchObject({ outcome: "unknown" });
@@ -311,7 +311,7 @@ test("a recycled pane id is reported unknown and never signalled (#670)", async 
     { stageId: "build", attempt: 1, conversationId: unknown.conversationId, agentPath: null, paneId: "%3" },
     {
       killHostIfMatches: async () => { signalled += 1; return true; },
-      paneAgentAlive: async () => true,
+      paneSnapshot: async () => ({ windowName: "stage-build", command: "codex" }),
     },
   );
   expect(orphan).toMatchObject({ outcome: "unknown" });
@@ -322,7 +322,7 @@ test("a recycled pane id is reported unknown and never signalled (#670)", async 
   /* Nothing running in the pane at all is simply nothing to stop. */
   const quiet = await stopPipelineStagePane(
     { stageId: "build", attempt: 1, conversationId: unknown.conversationId, agentPath: null, paneId: "%3" },
-    { killHostIfMatches: async () => { signalled += 1; return true; }, paneAgentAlive: async () => false },
+    { killHostIfMatches: async () => { signalled += 1; return true; }, paneSnapshot: async () => null },
   );
   expect(quiet).toEqual({ outcome: "not-running" });
   expect(signalled).toBe(1);

--- a/src/lib/pipelines/stageHostTeardown.test.ts
+++ b/src/lib/pipelines/stageHostTeardown.test.ts
@@ -11,6 +11,9 @@ import { afterAll, beforeEach, expect, mock, test } from "bun:test";
    state directory and can never dispatch a real kill. */
 const sandbox = fs.mkdtempSync(path.join(os.tmpdir(), "llv-pipeline-stop-host-"));
 process.env.LLV_STATE_DIR = path.join(sandbox, "state");
+/* Pinned, never inherited: with structured hosting off, even a bypassed module
+   mock could not reach the operator's runtime host. */
+process.env.LLV_STRUCTURED_HOSTS = "0";
 fs.mkdirSync(process.env.LLV_STATE_DIR, { recursive: true });
 afterAll(() => fs.rmSync(sandbox, { recursive: true, force: true }));
 
@@ -18,18 +21,22 @@ type KillRequest = { conversationId: string; transcriptPath: string; action: str
 const killed: KillRequest[] = [];
 let killResult: { status: number; body: Record<string, unknown> } = { status: 200, body: { ok: true, structured: true } };
 
+/** Marks every answer this suite produces, so a test can prove the stubbed
+    action — never the real one — served the kill. */
+const MOCK_MARKER = "stub-conversation-action";
 mock.module("@/lib/conversation/actions", () => ({
   CONVERSATION_ACTIONS: ["interrupt", "kill", "resume", "compact", "dialog-key"] as const,
   applyConversationAction: async (request: KillRequest) => {
     killed.push(request);
-    return killResult;
+    return { status: killResult.status, body: { ...killResult.body, target: MOCK_MARKER } };
   },
 }));
 
 const { AgentRegistry, setAgentRegistryForTests } = await import("@/lib/agent/registry");
 const { procBackend } = await import("@/lib/proc");
 const { sessionKeyId } = await import("@/lib/agent/sessionKey");
-const { defaultPipelinePorts } = await import("./engine");
+const { defaultPipelinePorts, stopPipelineStageAgent } = await import("./engine");
+type RuntimeHostClient = import("@/lib/runtime/client").RuntimeHostClient;
 
 type Registry = InstanceType<typeof AgentRegistry>;
 
@@ -39,6 +46,7 @@ function hostedConversation(options: { status?: "live" | "dead"; hosted?: boolea
   registry: Registry;
   conversationId: string;
   path: string;
+  key: { engine: "codex"; sessionId: string };
 } {
   const id = crypto.randomUUID();
   const pathname = path.join(sandbox, `${id}.jsonl`);
@@ -74,7 +82,7 @@ function hostedConversation(options: { status?: "live" | "dead"; hosted?: boolea
   if (!entry) throw new Error("registry fixture did not record the session entry");
   expect(entry.status).toBe(options.status ?? "live");
   setAgentRegistryForTests(registry);
-  return { registry, conversationId: begun.receipt.conversationId, path: pathname };
+  return { registry, conversationId: begun.receipt.conversationId, path: pathname, key: { engine: "codex", sessionId: id } };
 }
 
 function target(conversationId: string | null, agentPath: string | null = null) {
@@ -87,12 +95,119 @@ beforeEach(() => {
 });
 
 test("a resident stage host is terminated through the conversation kill control (#670)", async () => {
+  /* Prove the seam this suite depends on: the kill control resolves to the stub,
+     so no test here can reach the operator's runtime host. */
+  const { applyConversationAction } = await import("@/lib/conversation/actions");
+  const probe = await applyConversationAction({ conversationId: "", transcriptPath: "", action: "kill" });
+  expect((probe.body as { target?: string }).target).toBe(MOCK_MARKER);
+  killed.length = 0;
+
   const fixture = hostedConversation();
+  /* Delivered on the spot, the shape a legacy pane kill and a replayed terminal
+     kill both produce. */
+  killResult = { status: 200, body: { ok: true, structured: true, operationId: "kill-op-1", receipt: { status: "delivered" } } };
 
   const result = await defaultPipelinePorts().stopStageAgent(target(fixture.conversationId));
 
   expect(result).toEqual({ outcome: "stopped" });
   expect(killed).toEqual([{ conversationId: fixture.conversationId, transcriptPath: fixture.path, action: "kill" }]);
+  setAgentRegistryForTests(null);
+});
+
+test("an attempt whose conversation id no longer resolves is found by its transcript (#670)", async () => {
+  const fixture = hostedConversation();
+
+  const result = await stopPipelineStageAgent({
+    stageId: "build",
+    attempt: 1,
+    conversationId: "conversation_retired_alias",
+    agentPath: fixture.path,
+    paneId: null,
+  });
+
+  expect(result).toEqual({ outcome: "stopped" });
+  expect(killed).toMatchObject([{ conversationId: fixture.conversationId, action: "kill" }]);
+  setAgentRegistryForTests(null);
+});
+
+/** A queued receipt is what the runtime answers first; these cover what the
+    close may conclude from it. */
+function queuedKill() {
+  killResult = { status: 202, body: { ok: true, structured: true, operationId: "kill-op-queued", receipt: { status: "queued" } } };
+}
+
+function confirmationProbes(overrides: Partial<Parameters<typeof stopPipelineStageAgent>[1]> = {}) {
+  let clock = 0;
+  return {
+    now: () => clock,
+    sleep: async (ms: number) => { clock += ms; },
+    client: null,
+    ...overrides,
+  };
+}
+
+function statusClient(receipt: { status: string; reason?: string | null }): RuntimeHostClient {
+  return {
+    operationStatus: async (operationId: string) => ({ operationId, receipt: { ...receipt, at: "now" }, replayed: false }),
+  } as unknown as RuntimeHostClient;
+}
+
+test("a queued kill with no evidence of termination is unconfirmed, never a clean stop (#670)", async () => {
+  const fixture = hostedConversation();
+  queuedKill();
+
+  const result = await stopPipelineStageAgent(target(fixture.conversationId), confirmationProbes());
+
+  expect(result).toEqual({
+    outcome: "unconfirmed",
+    operationId: "kill-op-queued",
+    detail: "kill accepted as queued but termination was not confirmed",
+  });
+  expect(killed).toHaveLength(1);
+  setAgentRegistryForTests(null);
+});
+
+test("a queued kill confirmed by the host leaving the registry is a stop (#670)", async () => {
+  const fixture = hostedConversation();
+  queuedKill();
+  /* The runtime tears the host down while the close waits — exactly what the
+     durable projection records after a delivered kill. */
+  const probes = confirmationProbes();
+  const result = await stopPipelineStageAgent(target(fixture.conversationId), {
+    ...probes,
+    sleep: async (ms: number) => {
+      await probes.sleep(ms);
+      fixture.registry.terminateStructuredHost(fixture.key);
+    },
+  });
+
+  expect(result).toEqual({ outcome: "stopped" });
+  setAgentRegistryForTests(null);
+});
+
+test("a queued kill confirmed by its durable receipt is a stop (#670)", async () => {
+  const fixture = hostedConversation();
+  queuedKill();
+
+  const result = await stopPipelineStageAgent(
+    target(fixture.conversationId),
+    confirmationProbes({ client: statusClient({ status: "delivered" }) }),
+  );
+
+  expect(result).toEqual({ outcome: "stopped" });
+  setAgentRegistryForTests(null);
+});
+
+test("a queued kill whose operation terminally failed leaves the host still running (#670)", async () => {
+  const fixture = hostedConversation();
+  queuedKill();
+
+  const result = await stopPipelineStageAgent(
+    target(fixture.conversationId),
+    confirmationProbes({ client: statusClient({ status: "failed", reason: "host process did not exit" }) }),
+  );
+
+  expect(result).toEqual({ outcome: "failed", error: "host process did not exit" });
   setAgentRegistryForTests(null);
 });
 

--- a/src/lib/pipelines/stageHostTeardown.test.ts
+++ b/src/lib/pipelines/stageHostTeardown.test.ts
@@ -239,3 +239,16 @@ test("a refused kill surfaces the still-running host instead of claiming a stop 
     .toEqual({ outcome: "failed", error: "stage host kill was refused with status 200" });
   setAgentRegistryForTests(null);
 });
+
+test("the residency probe reads host state without dispatching anything (#670)", async () => {
+  const live = hostedConversation();
+  const ports = defaultPipelinePorts();
+  expect(await ports.stageHostResident(target(live.conversationId))).toBeTrue();
+
+  /* What the tick trusts to retire an unconfirmed record: the host is gone. */
+  live.registry.terminateStructuredHost(live.key);
+  expect(await ports.stageHostResident(target(live.conversationId))).toBeFalse();
+  expect(await ports.stageHostResident(target("conversation_never_seen"))).toBeFalse();
+  expect(killed).toEqual([]);
+  setAgentRegistryForTests(null);
+});

--- a/src/lib/pipelines/store.test.ts
+++ b/src/lib/pipelines/store.test.ts
@@ -262,3 +262,51 @@ test("v3 validation: acyclic pass edges, valid fail edges, 1–8 stage bounds (#
     expect(() => savePipelines([orphanReview])).toThrow("malformed pipeline record");
   });
 });
+
+test("an unconfirmed host record survives a round trip and rejects a malformed one (#670)", () => {
+  const previous = process.env.LLV_STATE_DIR;
+  const sandbox = fs.mkdtempSync(path.join(os.tmpdir(), "llv-pipelines-unconfirmed-"));
+  process.env.LLV_STATE_DIR = sandbox;
+  try {
+    const pipeline = buildPipeline({
+      id: "abcdef13",
+      task: "task",
+      taskIds: [],
+      project: "viewer",
+      repoDir: "/repo",
+      stages: [{ id: "build", kind: "run" as const, role: { roleId: "builder" as const }, engine: "codex" as const, model: "gpt-5.6-sol", effort: "medium", access: "read-write" as const, prompt: "build", next: null, effectiveRole: { roleId: "builder" as const, engine: "codex" as const, model: "gpt-5.6-sol", effort: "medium", access: "read-write" as const, promptScaffold: "builder" } }],
+      srcPath: null,
+      srcConversationId: "conversation_creator",
+      now: "now",
+    });
+    pipeline.state = "closed";
+    pipeline.cursor = null;
+    pipeline.closedAt = "2026-07-25T00:00:00.000Z";
+    pipeline.hiddenAt = null;
+    pipeline.unconfirmedHosts = [{
+      stageId: "build",
+      attempt: 1,
+      conversationId: "conversation_build",
+      agentPath: null,
+      operationId: "kill-op-1",
+      detail: "kill accepted as queued but termination was not confirmed",
+      at: "2026-07-25T00:00:00.000Z",
+    }];
+    savePipelines([pipeline]);
+
+    expect(loadPipelines()[0]!.unconfirmedHosts).toEqual(pipeline.unconfirmedHosts);
+
+    /* An empty list normalizes away, so a settled lane carries no marker. */
+    savePipelines([{ ...pipeline, unconfirmedHosts: [] }]);
+    expect(loadPipelines()[0]!.unconfirmedHosts).toBeUndefined();
+
+    expect(() => savePipelines([{
+      ...pipeline,
+      unconfirmedHosts: [{ stageId: "build", attempt: "one" } as never],
+    }])).toThrow();
+  } finally {
+    fs.rmSync(sandbox, { recursive: true, force: true });
+    if (previous === undefined) delete process.env.LLV_STATE_DIR;
+    else process.env.LLV_STATE_DIR = previous;
+  }
+});

--- a/src/lib/pipelines/store.test.ts
+++ b/src/lib/pipelines/store.test.ts
@@ -288,6 +288,7 @@ test("an unconfirmed host record survives a round trip and rejects a malformed o
       attempt: 1,
       conversationId: "conversation_build",
       agentPath: null,
+      paneId: null,
       operationId: "kill-op-1",
       detail: "kill accepted as queued but termination was not confirmed",
       at: "2026-07-25T00:00:00.000Z",

--- a/src/lib/pipelines/store.ts
+++ b/src/lib/pipelines/store.ts
@@ -158,6 +158,7 @@ function isUnconfirmedHost(value: unknown): value is PipelineUnconfirmedHost {
     && Number.isInteger(host.attempt)
     && isNullableString(host.conversationId)
     && isNullableString(host.agentPath)
+    && (host.paneId === undefined || isNullableString(host.paneId))
     && isNullableString(host.operationId)
     && typeof host.detail === "string"
     && typeof host.at === "string";

--- a/src/lib/pipelines/store.ts
+++ b/src/lib/pipelines/store.ts
@@ -10,7 +10,7 @@ import { withFileTransaction, withFileTransactionSync } from "@/lib/state/fileTr
 import type { BoardTask } from "@/lib/tasks/types";
 
 import { MAX_FAIL_EDGE_ROUNDS, MAX_PIPELINE_STAGES } from "./limits";
-import type { EffectivePipelineRole, Pipeline, PipelineCreationIntent, PipelineEdgeActivation, PipelineStage } from "./types";
+import type { EffectivePipelineRole, Pipeline, PipelineCreationIntent, PipelineEdgeActivation, PipelineStage, PipelineUnconfirmedHost } from "./types";
 import { stageVerdictFrom } from "./verdict";
 
 export const PIPELINES_SCHEMA_VERSION = 4;
@@ -151,6 +151,18 @@ function isCreationIntent(value: unknown): value is PipelineCreationIntent {
     && typeof intent.launchId === "string" && Boolean(intent.launchId.trim());
 }
 
+function isUnconfirmedHost(value: unknown): value is PipelineUnconfirmedHost {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  const host = value as Partial<PipelineUnconfirmedHost>;
+  return typeof host.stageId === "string"
+    && Number.isInteger(host.attempt)
+    && isNullableString(host.conversationId)
+    && isNullableString(host.agentPath)
+    && isNullableString(host.operationId)
+    && typeof host.detail === "string"
+    && typeof host.at === "string";
+}
+
 function isStage(value: unknown): value is PipelineStage {
   if (!value || typeof value !== "object" || Array.isArray(value)) return false;
   const stage = value as Partial<PipelineStage>;
@@ -260,6 +272,8 @@ function isPipeline(value: unknown): value is Pipeline {
     typeof pipeline.createdAt === "string" &&
     isNullableString(pipeline.closedAt) &&
     (pipeline.hiddenAt === undefined || isNullableString(pipeline.hiddenAt)) &&
+    (pipeline.unconfirmedHosts === undefined
+      || (Array.isArray(pipeline.unconfirmedHosts) && pipeline.unconfirmedHosts.every(isUnconfirmedHost))) &&
     (pipeline.restored === undefined || typeof pipeline.restored === "boolean") &&
     (pipeline.pos === undefined || (
       typeof pipeline.pos === "object" && pipeline.pos !== null &&
@@ -392,6 +406,9 @@ export function loadPipelines(): Pipeline[] {
     srcConversationId: pipeline.srcConversationId ?? null,
     closedAt: pipeline.closedAt ?? null,
     hiddenAt: pipeline.hiddenAt ?? null,
+    unconfirmedHosts: pipeline.unconfirmedHosts?.length
+      ? pipeline.unconfirmedHosts.map((host) => ({ ...host }))
+      : undefined,
     restored: undefined,
     stages: pipeline.stages.map((stage) => ({ ...stage, onFail: stage.onFail ?? null })),
     cursor: pipeline.cursor

--- a/src/lib/pipelines/types.ts
+++ b/src/lib/pipelines/types.ts
@@ -169,6 +169,7 @@ export type PipelineUnconfirmedHost = {
   attempt: number;
   conversationId: string | null;
   agentPath: string | null;
+  paneId: string | null;
   operationId: string | null;
   detail: string;
   at: string;

--- a/src/lib/pipelines/types.ts
+++ b/src/lib/pipelines/types.ts
@@ -291,6 +291,12 @@ export type PatchPipelineRequest = {
   index?: number;
   stageIds?: string[];
   toIndex?: number;
+  /** for close: dismiss the hosts a previous close could not confirm, once the
+      operator has judged them (a recycled pane id can look alive forever, so an
+      unidentifiable host would otherwise pin the closed lane to the board).
+      Only unconfirmed hosts are dismissed; one proven to be still running still
+      refuses the close. */
+  acknowledgeHosts?: boolean;
   /** for set-edge (#353): rewires `stageId`'s pass or fail edge. `to: null`
       clears it (a cleared pass edge makes the stage terminal). A stage that has
       already run keeps its pass edge frozen (history names its successor); a

--- a/src/lib/pipelines/types.ts
+++ b/src/lib/pipelines/types.ts
@@ -161,6 +161,19 @@ export type PipelineCursorState = "pending" | "spawning" | "running" | "reviewin
 
 export type PipelineState = "draft" | "provisioning" | "running" | "needs_decision" | "paused" | "completed" | "closed";
 
+/** A stage host a close asked the runtime to kill without confirming that it
+    died (#670). Durable, so the possible survivor stays addressable: the board
+    keeps showing the closed lane until a later close settles it. */
+export type PipelineUnconfirmedHost = {
+  stageId: string;
+  attempt: number;
+  conversationId: string | null;
+  agentPath: string | null;
+  operationId: string | null;
+  detail: string;
+  at: string;
+};
+
 export type PipelineCreationIntent = {
   kind: "task-spawn";
   taskId: string;
@@ -198,7 +211,11 @@ export type Pipeline = {
   createdAt: string;
   closedAt: string | null;
   hiddenAt?: string | null;
-  /** Read-model marker set when a hidden container is projected for a pinned member. */
+  /** Hosts the last close could not confirm terminated. Present only while one
+      is outstanding; a close that confirms every kill clears it. */
+  unconfirmedHosts?: PipelineUnconfirmedHost[];
+  /** Read-model marker set when a hidden container is projected for a pinned
+      member, or for a closed lane still holding an unconfirmed host. */
   restored?: boolean;
   /** Durable user pin for the desktop board's world-space pipeline group. */
   pos?: { x: number; y: number };

--- a/src/lib/pipelines/visibility.test.ts
+++ b/src/lib/pipelines/visibility.test.ts
@@ -136,3 +136,28 @@ test("a resumed member keeps its pipeline rail, halo, and open target on the cur
   expect(stageOpenTarget(projected.stages[1]!, currentAttempt, undefined, new Set(currentFiles.map((entry) => entry.path))))
     .toEqual({ kind: "path", path: resumed.path });
 });
+
+test("a closed lane holding an unconfirmed host stays on the board (#670)", () => {
+  const conversationId = "conversation_019f4906-3f67-7b72-9fbc-9ec3b5ad1327";
+  const pipeline = hiddenPipeline(conversationId);
+  pipeline.hiddenAt = null;
+  pipeline.unconfirmedHosts = [{
+    stageId: "build",
+    attempt: 1,
+    conversationId,
+    agentPath: "/old.jsonl",
+    operationId: "kill-op-1",
+    detail: "kill accepted as queued but termination was not confirmed",
+    at: "2026-01-01T01:00:00.000Z",
+  }];
+
+  /* Nothing is pinned and neither repo nor worktree exists — without the
+     unconfirmed host this lane would be dropped from the read model. */
+  const projected = filterPipelinesForFileScan([pipeline], []);
+  expect(projected).toHaveLength(1);
+  /* `restored` is what the client read model honours for a closed pipeline. */
+  expect(projected[0]).toMatchObject({ id: "pipeline-hidden", restored: true });
+
+  pipeline.unconfirmedHosts = undefined;
+  expect(filterPipelinesForFileScan([pipeline], [])).toEqual([]);
+});

--- a/src/lib/pipelines/visibility.test.ts
+++ b/src/lib/pipelines/visibility.test.ts
@@ -146,6 +146,7 @@ test("a closed lane holding an unconfirmed host stays on the board (#670)", () =
     attempt: 1,
     conversationId,
     agentPath: "/old.jsonl",
+    paneId: null,
     operationId: "kill-op-1",
     detail: "kill accepted as queued but termination was not confirmed",
     at: "2026-01-01T01:00:00.000Z",

--- a/src/lib/pipelines/visibility.ts
+++ b/src/lib/pipelines/visibility.ts
@@ -42,6 +42,10 @@ export function filterPipelinesForFileScan(
     };
     const restored = restoredPipelineIds.has(pipeline.id) || pipeline.runs.some((run) => run.attempts.some((attempt) =>
       Boolean((attempt.conversationId && pinnedConversationIds.has(attempt.conversationId)) || (attempt.agentPath && context.pinnedPaths.has(attempt.agentPath)))));
+    /* A close that could not confirm its kill keeps the lane on the board: the
+       possible survivor must stay addressable, never hidden behind a closed
+       record (#670). It clears itself as soon as a close confirms the host. */
+    if (pipeline.unconfirmedHosts?.length) return [{ ...projected, restored: true }];
     if (pipeline.state === "closed" || pipeline.hiddenAt) return restored ? [{ ...projected, restored: true }] : [];
     if ((pipeline.repoDir && fs.existsSync(pipeline.repoDir)) || (pipeline.worktreeDir && fs.existsSync(pipeline.worktreeDir))) return [projected];
     return projected.runs.some((run) => run.attempts.some((attempt) => Boolean(attempt.agentPath && scanned.has(attempt.agentPath)))) ? [projected] : [];


### PR DESCRIPTION
## What was wrong

Closing a pipeline marked it closed and left its agents running. The lane vanished from the board while paid agents kept working — three of them, on one occasion, duplicating the work of the lanes that replaced them, and four more resident with no output for over seven hours. Every one had to be killed by hand.

## How it was fixed, round by round

**`93e11bb4`** stops the hosts of non-terminal stages on close, preserves uncommitted worktree state, and reports what it stopped.

**`865ce743`** — a queued kill receipt is not a confirmed termination. Production returns `202 accepted`; treating that as "stopped" is how a close claims success over a live agent.

**`0c545fb4`** — host residency is decided from evidence about the host, not from the attempt state machine. Parked attempts (`needs_decision`) routinely hold a live, idle host; skipping them was the single biggest gap, and it is exactly the class that produced the zombies above.

**`a44dd9e8`** — a pane-hosted orphan gets a fallback stop instead of being refused forever; the aggregate teardown time is bounded, not just each step, so a slow close cannot stall every other pipeline mutation; and settled unconfirmed records retire instead of pinning a finished lane to the board.

**`2f5315b9`** — the pane fallback is gated on **identity**. tmux pane ids restart at `%0` when the server restarts while the stored id outlives that, and the branch is entered precisely when the registry has no trace of the host. Killing on "this pane runs something non-shell" could have taken down an unrelated live agent; it now matches identity the way `stopReviewer` and `killTmuxHostIfMatches` already do, and refuses to kill when identity cannot be established. A mid-review close also stops claiming nothing was running while it terminates a reviewer.

**`bc801da3`** — adopted stage children are torn down and reported. A stage agent that spawns a helper through the viewer had that helper adopted as a running historical attempt; close never probed it, said nothing about it, and hid the lane — the original symptom through another door.

## Review

Six independent read-only rounds. Every round found a real defect of the same family, and each verified revert-sensitivity explicitly — one reviewer cloned the base into a throwaway checkout and confirmed all eight close tests fail against the reverted implementation. Final round: **APPROVE**.

Two low findings are deliberately deferred to a follow-up: a successful pane kill leaves the registry briefly claiming a live host, and the uncommitted-path report mis-parses filenames containing an arrow sequence.

## Verification

Touched tests pass by path — the teardown suite pins its state directory to a temp sandbox, disables structured hosts, and mocks the conversation actions module before the registry import, so nothing runs against live runtime state. `tsc --noEmit` clean, lint unchanged from base, privacy gate green.

Closes #670