### PR TITLE
fix(feed): render live turn rows through the transcript markdown pass (#676)

### DIFF
--- a/src/components/conversation/LiveTurnRows.tsx
+++ b/src/components/conversation/LiveTurnRows.tsx
@@ -2,7 +2,13 @@
 
 import type { RuntimeLiveTurnItem } from "@/lib/runtime/liveTurn";
 import { useLocale } from "@/lib/i18n";
+import { StreamingMd } from "@/components/feed/markdown";
 
+/* A live row is the same message its transcript echo will carry a moment later,
+   so it goes through the same markdown grammar — otherwise the text visibly
+   changes appearance when the echo lands. While the item is still streaming,
+   StreamingMd holds the unfinished tail as plain text instead of guessing at a
+   construct whose closer has not arrived. */
 export function LiveTurnRows({ items }: { items: readonly RuntimeLiveTurnItem[] }) {
   const { t } = useLocale();
   if (!items.length) return null;
@@ -27,7 +33,7 @@ export function LiveTurnRows({ items }: { items: readonly RuntimeLiveTurnItem[] 
               {`${t("feed.liveOmittedChars", { chars: item.omittedChars })}\n`}
             </span>
           ) : null}
-          {item.text}
+          <StreamingMd text={item.text} streaming={item.phase === "streaming"} />
           {item.phase === "streaming" && index === items.length - 1 ? (
             <span className="ml-0.5 inline-block h-3.5 w-1.5 animate-pulse rounded-[2px] bg-accent align-text-bottom" aria-hidden />
           ) : null}

--- a/src/components/conversation/liveTurnMarkdown.dom.test.tsx
+++ b/src/components/conversation/liveTurnMarkdown.dom.test.tsx
@@ -153,6 +153,37 @@ test("an unclosed code fence renders verbatim instead of swallowing the tail", (
   expect(liveRow(host).textContent).not.toContain("```");
 });
 
+test("a message that ends on its closing fence renders the block right away", () => {
+  const { host, root } = mount();
+  const ends = ["Patch:", "", "```ts", "const x = 1;", "```"].join("\n");
+  stream(root, ends, 6);
+  expect(liveRow(host).querySelector("pre")?.textContent).toBe("const x = 1;");
+  expect(liveRow(host).textContent).not.toContain("```");
+
+  /* Settling it changes nothing but the caret. */
+  paint(root, <LiveTurnRows items={[item(ends, "awaiting-echo")]} />);
+  expect(liveRow(host).innerHTML).toBe(settledHtml(ends));
+
+  /* A fence that has NOT closed still degrades to readable text. */
+  paint(root, <LiveTurnRows items={[item("Patch:\n\n```ts\nconst x = 1;", "streaming")]} />);
+  expect(liveRow(host).querySelector("pre")).toBeNull();
+  expect(liveRow(host).textContent).toContain("```ts");
+});
+
+test("a closing fence the next delta reopens goes back to text, separator intact", () => {
+  const { host, root } = mount();
+  const open = ["Patch:", "", "```ts", "const x = 1;"];
+  paint(root, <LiveTurnRows items={[item([...open, "```"].join("\n"), "streaming")]} />);
+  expect(liveRow(host).querySelector("pre")).not.toBeNull();
+
+  /* That line was not a closing fence after all: the block goes back to text,
+     and the separator it had shed has to come back with it. */
+  const reopened = [...open, "```json"].join("\n");
+  paint(root, <LiveTurnRows items={[item(reopened, "streaming")]} />);
+  expect(liveRow(host).querySelector("pre")).toBeNull();
+  expect(liveRow(host).textContent).toContain(reopened);
+});
+
 test("an unterminated bold run stays literal until its closer arrives", () => {
   const { host, root } = mount();
   paint(root, <LiveTurnRows items={[item("Result: **bol", "streaming")]} />);
@@ -205,6 +236,32 @@ test("settled lines are frozen once written: the boundary only moves forward", (
   expect(settledLineCount("a\n| x |\n| y".split("\n"))).toBe(1);
   expect(settledLineCount("a\n```ts\ncode".split("\n"))).toBe(1);
   expect(settledLineCount("a\n```ts\ncode\n```\ntail".split("\n"))).toBe(4);
+});
+
+test("per-delta work stays proportional to the delta, not to the accumulated message", () => {
+  const body = Array.from(
+    { length: 400 },
+    (_, i) => `line ${i} with **bold** and a [link](https://example.com/${i}).`,
+  ).join("\n");
+  expect(body.length).toBeGreaterThan(20_000);
+
+  const stream = createMdStream();
+  let worst = 0;
+  let scanned = 0;
+  for (let end = 1; end <= body.length; end += 37) {
+    advanceMdStream(stream, body.slice(0, end), true);
+    worst = Math.max(worst, stream.scannedChars - scanned);
+    scanned = stream.scannedChars;
+  }
+  const tree = advanceMdStream(stream, body, false);
+  /* One volatile line plus the delta that just arrived — never the 20k+ behind it. */
+  expect(worst).toBeLessThan(256);
+  expect(stream.parsedLines).toBe(400);
+
+  /* …and the rendering it arrived at is still the transcript pass, exactly. */
+  const { host, root } = mount();
+  paint(root, <div className="whitespace-pre-wrap">{tree}</div>);
+  expect((host.firstElementChild as HTMLElement).innerHTML).toBe(settledHtml(body));
 });
 
 test("a long stream block-parses every line exactly once, never the whole message", () => {

--- a/src/components/conversation/liveTurnMarkdown.dom.test.tsx
+++ b/src/components/conversation/liveTurnMarkdown.dom.test.tsx
@@ -6,7 +6,7 @@ import type { ReactNode } from "react";
 
 import { setLocale } from "@/lib/i18n";
 import type { RuntimeLiveTurnItem, RuntimeLiveTurnItemPhase } from "@/lib/runtime/liveTurn";
-import { advanceMdStream, createMdStream, mdBlocks, settledLineCount } from "@/components/feed/markdown";
+import { advanceMdStream, createMdStream, mdBlocks, type MdStreamState } from "@/components/feed/markdown";
 
 import { LiveTurnRows } from "./LiveTurnRows";
 
@@ -223,22 +223,34 @@ test("a completed item that rewrites its draft is re-rendered from scratch", () 
   expect(liveRow(host).innerHTML).toBe(settledHtml(authoritative));
 });
 
-test("settled lines are frozen once written: the boundary only moves forward", () => {
-  const text = SAMPLE;
-  let previous = 0;
-  for (let end = 1; end <= text.length; end++) {
-    const settled = settledLineCount(text.slice(0, end).split("\n"));
-    expect(settled).toBeGreaterThanOrEqual(previous);
-    previous = settled;
+test("only the line still being written is volatile: the boundary is its start", () => {
+  /* Everything behind the boundary has been consumed into nodes, so a delta can
+     never reach back into it — including inside an open construct. */
+  const stream = createMdStream();
+  for (let end = 1; end <= SAMPLE.length; end++) {
+    const text = SAMPLE.slice(0, end);
+    advanceMdStream(stream, text, true);
+    expect(stream.stableChars).toBe(text.lastIndexOf("\n") + 1);
   }
-  /* The volatile region is the open construct, never the whole document. */
-  expect(settledLineCount("a\nb\nc".split("\n"))).toBe(2);
-  expect(settledLineCount("a\n| x |\n| y".split("\n"))).toBe(1);
-  expect(settledLineCount("a\n```ts\ncode".split("\n"))).toBe(1);
-  expect(settledLineCount("a\n```ts\ncode\n```\ntail".split("\n"))).toBe(4);
 });
 
-test("per-delta work stays proportional to the delta, not to the accumulated message", () => {
+/** The chars the next advance will have to look at. */
+function pending(stream: MdStreamState, text: string): number {
+  return text.length - stream.stableChars;
+}
+
+/** Streams `body` in `step`-sized deltas, returning the worst per-delta scan. */
+function worstScan(stream: MdStreamState, body: string, step: number): number {
+  let worst = 0;
+  for (let end = 1; end <= body.length; end += step) {
+    const text = body.slice(0, end);
+    worst = Math.max(worst, pending(stream, text));
+    advanceMdStream(stream, text, true);
+  }
+  return worst;
+}
+
+test("per-delta work stays proportional to the delta, not to the accumulated prose", () => {
   const body = Array.from(
     { length: 400 },
     (_, i) => `line ${i} with **bold** and a [link](https://example.com/${i}).`,
@@ -246,48 +258,149 @@ test("per-delta work stays proportional to the delta, not to the accumulated mes
   expect(body.length).toBeGreaterThan(20_000);
 
   const stream = createMdStream();
-  let worst = 0;
-  let scanned = 0;
-  for (let end = 1; end <= body.length; end += 37) {
-    advanceMdStream(stream, body.slice(0, end), true);
-    worst = Math.max(worst, stream.scannedChars - scanned);
-    scanned = stream.scannedChars;
-  }
+  const worst = worstScan(stream, body, 37);
   const tree = advanceMdStream(stream, body, false);
-  /* One volatile line plus the delta that just arrived — never the 20k+ behind it. */
+  /* One volatile line plus the delta that just arrived — never the 20k behind it. */
   expect(worst).toBeLessThan(256);
-  expect(stream.parsedLines).toBe(400);
+  expect(stream.stableLines).toBe(400);
 
-  /* …and the rendering it arrived at is still the transcript pass, exactly. */
   const { host, root } = mount();
   paint(root, <div className="whitespace-pre-wrap">{tree}</div>);
   expect((host.firstElementChild as HTMLElement).innerHTML).toBe(settledHtml(body));
 });
 
-test("a long stream block-parses every line exactly once, never the whole message", () => {
-  /* Re-parsing the accumulated text per delta would cost ~180k line parses for
-     this message; the settled prefix is parsed once, so it costs 600. */
+test("a long OPEN code fence does not re-scan itself on every delta", () => {
+  /* The case that matters most here: an agent streaming a patch. Freezing the
+     boundary at the fence's opening line made every token re-read the whole
+     block — 19 KB scanned per delta by the end. */
+  const body = [
+    "Patch:",
+    "",
+    "```ts",
+    ...Array.from({ length: 900 }, (_, i) => `const line${i} = ${i};`),
+    "```",
+  ].join("\n");
+  expect(body.length).toBeGreaterThan(18_000);
+
+  const stream = createMdStream();
+  const worst = worstScan(stream, body, 13);
+  const tree = advanceMdStream(stream, body, false);
+  expect(worst).toBeLessThan(64);
+  expect(stream.stableLines).toBe(904);
+
+  const { host, root } = mount();
+  paint(root, <div className="whitespace-pre-wrap">{tree}</div>);
+  expect((host.firstElementChild as HTMLElement).innerHTML).toBe(settledHtml(body));
+});
+
+test("a long OPEN table does not re-scan itself on every delta", () => {
+  const body = [
+    "| step | result |",
+    "| --- | --- |",
+    ...Array.from({ length: 300 }, (_, i) => `| step ${i} | ok ${i} |`),
+  ].join("\n");
+
+  const stream = createMdStream();
+  const worst = worstScan(stream, body, 11);
+  const tree = advanceMdStream(stream, body, false);
+  expect(worst).toBeLessThan(64);
+  expect(stream.stableLines).toBe(302);
+
+  const { host, root } = mount();
+  paint(root, <div className="whitespace-pre-wrap">{tree}</div>);
+  expect((host.firstElementChild as HTMLElement).innerHTML).toBe(settledHtml(body));
+});
+
+test("a line consumed by an earlier delta is never consumed again", () => {
   const lines = Array.from({ length: 600 }, (_, i) => `line ${i} with **bold** text`);
   const body = lines.join("\n");
   const stream = createMdStream();
-  for (let end = 1; end <= body.length; end += 3) {
-    advanceMdStream(stream, body.slice(0, end), true);
-  }
+  for (let end = 1; end <= body.length; end += 3) advanceMdStream(stream, body.slice(0, end), true);
   advanceMdStream(stream, body, true);
-  expect(stream.parsedLines).toBe(lines.length - 1);
+  expect(stream.stableLines).toBe(lines.length - 1);
   /* The echo settles the last, still-volatile line — and nothing before it. */
   advanceMdStream(stream, body, false);
-  expect(stream.parsedLines).toBe(lines.length);
+  expect(stream.stableLines).toBe(lines.length);
 });
 
-test("a fenced block that has closed is never re-parsed by later deltas", () => {
-  const head = ["intro", "```ts", "const x = 1;", "```", ""].join("\n");
-  const stream = createMdStream();
-  advanceMdStream(stream, `${head}\n`, true);
-  const afterFence = stream.parsedLines;
-  expect(afterFence).toBeGreaterThan(0);
-  for (const tail of ["t", "ta", "tai", "tail"]) {
-    advanceMdStream(stream, `${head}\n${tail}`, true);
+test("a block already on screen is not remounted when it settles", () => {
+  const { host, root } = mount();
+  const table = ["Here:", "", "| col | val |", "| --- | --- |", "| a | 1 |"];
+  paint(root, <LiveTurnRows items={[item([...table, "| b"].join("\n"), "streaming")]} />);
+  const painted = liveRow(host).querySelector("table");
+  expect(painted).not.toBeNull();
+
+  /* The run ends: the same table, in the same place, must survive the settling. */
+  paint(root, <LiveTurnRows items={[item([...table, "| b | 2 |", "", "done"].join("\n"), "streaming")]} />);
+  expect(liveRow(host).querySelector("table")).toBe(painted);
+  paint(root, <LiveTurnRows items={[item([...table, "| b | 2 |", "", "done"].join("\n"), "awaiting-echo")]} />);
+  expect(liveRow(host).querySelector("table")).toBe(painted);
+
+  /* Same for a code block first shown when the message stopped on its fence. */
+  const fence = ["Patch:", "", "```", "const x = 1;", "```"];
+  paint(root, <LiveTurnRows items={[item(fence.join("\n"), "streaming")]} />);
+  const pre = liveRow(host).querySelector("pre");
+  expect(pre).not.toBeNull();
+  paint(root, <LiveTurnRows items={[item([...fence, "", "done"].join("\n"), "awaiting-echo")]} />);
+  expect(liveRow(host).querySelector("pre")).toBe(pre);
+});
+
+test("a boundary closer to the start than the anchor window still recognises the message", () => {
+  /* A short opening line followed by a long paragraph: the boundary sits inside
+     the window the cache compares, and a message must not be re-parsed from
+     scratch just because it has not produced 128 chars of settled text yet. */
+  const { host, root } = mount();
+  const head = "Note **one**\n";
+  paint(root, <LiveTurnRows items={[item(`${head}and then a much longer paragraph `, "streaming")]} />);
+  const bold = liveRow(host).querySelector("b");
+  expect(bold).not.toBeNull();
+  let tail = "and then a much longer paragraph ";
+  for (let delta = 0; delta < 12; delta++) {
+    tail += "that keeps on going and going ";
+    paint(root, <LiveTurnRows items={[item(head + tail, "streaming")]} />);
   }
-  expect(stream.parsedLines).toBe(afterFence);
+  expect(head.length + tail.length).toBeGreaterThan(300);
+  expect(liveRow(host).querySelector("b")).toBe(bold);
+});
+
+test("the consumed-line count stays exact across runs and a trim", () => {
+  const lines = [
+    ...Array.from({ length: 60 }, (_, i) => `line ${i} with **bold** text`),
+    "| col | val |",
+    "| --- | --- |",
+    "| a | 1 |",
+    "",
+    "```ts",
+    "const x = 1;",
+    "```",
+    ...Array.from({ length: 60 }, (_, i) => `tail ${i}`),
+  ];
+  const body = lines.join("\n");
+  const stream = createMdStream();
+  advanceMdStream(stream, body, true);
+  expect(stream.stableLines).toBe(lines.length - 1);
+
+  const trimmed = body.slice(700);
+  advanceMdStream(stream, trimmed, true);
+  expect(stream.stableLines).toBe(trimmed.split("\n").length - 1);
+});
+
+test("a head-trimmed projection keeps what it has already rendered", () => {
+  /* Past its 64 KiB bound the projection drops chars off the front on every
+     delta. Re-reading the whole window each time is what makes the longest
+     answers crawl, so the shift is followed instead: what the trim did not
+     reach stays exactly as it is, down to the DOM nodes on screen. */
+  const full = Array.from({ length: 400 }, (_, i) => `line ${i} with **bold** text`).join("\n");
+  const { host, root } = mount();
+  paint(root, <LiveTurnRows items={[item(full, "streaming")]} />);
+  const deep = liveRow(host).querySelectorAll("b")[350];
+  expect(deep).toBeDefined();
+
+  const trimmed = full.slice(600);
+  paint(root, <LiveTurnRows items={[item(trimmed, "streaming")]} />);
+  expect(liveRow(host).contains(deep)).toBe(true);
+
+  paint(root, <LiveTurnRows items={[item(trimmed, "awaiting-echo")]} />);
+  expect(liveRow(host).contains(deep)).toBe(true);
+  expect(liveRow(host).innerHTML).toBe(settledHtml(trimmed));
 });

--- a/src/components/conversation/liveTurnMarkdown.dom.test.tsx
+++ b/src/components/conversation/liveTurnMarkdown.dom.test.tsx
@@ -1,0 +1,236 @@
+import { afterEach, expect, test } from "bun:test";
+import { Window } from "happy-dom";
+import { flushSync } from "react-dom";
+import { createRoot, type Root } from "react-dom/client";
+import type { ReactNode } from "react";
+
+import { setLocale } from "@/lib/i18n";
+import type { RuntimeLiveTurnItem, RuntimeLiveTurnItemPhase } from "@/lib/runtime/liveTurn";
+import { advanceMdStream, createMdStream, mdBlocks, settledLineCount } from "@/components/feed/markdown";
+
+import { LiveTurnRows } from "./LiveTurnRows";
+
+/**
+ * Issue #676: a live turn row must render markdown through the same grammar as
+ * the transcript row that replaces it, so a message does not visibly change
+ * appearance when the echo lands — and the still-unwritten tail must degrade to
+ * readable text instead of guessing at a construct whose closer has not arrived.
+ */
+
+const dom = new Window({ url: "http://localhost/" });
+Object.assign(globalThis, {
+  window: dom,
+  document: dom.document,
+  navigator: dom.navigator,
+  localStorage: dom.localStorage,
+  Node: dom.Node,
+  HTMLElement: dom.HTMLElement,
+  Event: dom.Event,
+  KeyboardEvent: dom.KeyboardEvent,
+  MouseEvent: dom.MouseEvent,
+});
+setLocale("en");
+
+const SAMPLE = [
+  "Here is the **bold** answer.",
+  "",
+  "| col | val |",
+  "| --- | --- |",
+  "| a | 1 |",
+  "| b | 2 |",
+  "",
+  "```ts",
+  "const x = 1;",
+  "```",
+  "",
+  "> quoted tail",
+].join("\n");
+
+function item(text: string, phase: RuntimeLiveTurnItemPhase, extra: Partial<RuntimeLiveTurnItem> = {}): RuntimeLiveTurnItem {
+  return { itemId: "item-1", text, phase, startedAt: null, completedAt: null, ...extra };
+}
+
+function mount(): { host: HTMLElement; root: Root } {
+  const host = document.createElement("div");
+  document.body.append(host);
+  return { host, root: createRoot(host) };
+}
+
+function paint(root: Root, node: ReactNode): void {
+  flushSync(() => { root.render(node); });
+}
+
+function liveRow(host: HTMLElement): HTMLElement {
+  const row = host.querySelector("[data-live-turn]");
+  if (!row) throw new Error("no live turn row rendered");
+  return row as HTMLElement;
+}
+
+/** The settled counterpart: the transcript row's markdown body, same renderer. */
+function settledHtml(text: string): string {
+  const { host, root } = mount();
+  paint(root, <div className="whitespace-pre-wrap">{mdBlocks(text)}</div>);
+  return (host.firstElementChild as HTMLElement).innerHTML;
+}
+
+/** Feed a message in `step`-sized deltas, as the runtime projection does. */
+function stream(root: Root, text: string, step: number): void {
+  for (let end = step; end < text.length; end += step) {
+    paint(root, <LiveTurnRows items={[item(text.slice(0, end), "streaming")]} />);
+  }
+  paint(root, <LiveTurnRows items={[item(text, "streaming")]} />);
+}
+
+afterEach(() => {
+  document.body.replaceChildren();
+});
+
+test("a settled live row renders the same markdown as its transcript counterpart", () => {
+  const { host, root } = mount();
+  paint(root, <LiveTurnRows items={[item(SAMPLE, "awaiting-echo")]} />);
+  expect(liveRow(host).innerHTML).toBe(settledHtml(SAMPLE));
+  expect(liveRow(host).querySelector("b")?.textContent).toBe("bold");
+  expect(liveRow(host).querySelectorAll("table")).toHaveLength(1);
+  expect(liveRow(host).querySelector("pre")?.textContent).toBe("const x = 1;");
+});
+
+test("streaming a message delta by delta lands on exactly the settled rendering", () => {
+  const { host, root } = mount();
+  stream(root, SAMPLE, 7);
+  paint(root, <LiveTurnRows items={[item(SAMPLE, "awaiting-echo")]} />);
+  expect(liveRow(host).innerHTML).toBe(settledHtml(SAMPLE));
+});
+
+test("markdown already behind the writing frontier renders while the message streams", () => {
+  const { host, root } = mount();
+  paint(root, <LiveTurnRows items={[item("Here is the **bold** answer.\nstill writ", "streaming")]} />);
+  const row = liveRow(host);
+  expect(row.querySelector("b")?.textContent).toBe("bold");
+  expect(row.textContent).toContain("still writ");
+});
+
+test("a table's first row waits for the separator that decides the header", () => {
+  const { host, root } = mount();
+  /* Rendering one row early would print it as a body row and then move it into
+     the header when the separator lands — the flicker this must not do. */
+  stream(root, "Here it is:\n\n| col | val |\n| ---", 9);
+  const row = liveRow(host);
+  expect(row.querySelector("table")).toBeNull();
+  expect(row.textContent).toContain("| col | val |");
+  expect(row.textContent).toContain("| ---");
+});
+
+test("a half-written table row stays readable text below the rows that closed", () => {
+  const { host, root } = mount();
+  const partial = "Here it is:\n\n| col | val |\n| --- | --- |\n| a | 1";
+  stream(root, partial, 9);
+  const row = liveRow(host);
+  const streamingTable = row.querySelector("table");
+  expect(streamingTable!.querySelector("th")?.textContent).toBe("col");
+  expect(streamingTable!.querySelectorAll("tbody tr")).toHaveLength(0);
+  expect(row.textContent).toContain("| a | 1");
+  expect(row.textContent).not.toContain("| col | val |");
+
+  paint(root, <LiveTurnRows items={[item(`${partial} |\n\ndone`, "streaming")]} />);
+  const table = liveRow(host).querySelector("table");
+  expect(table!.querySelector("th")?.textContent).toBe("col");
+  expect(table!.querySelectorAll("tbody tr")).toHaveLength(1);
+  expect(liveRow(host).textContent).not.toContain("| a | 1 |");
+});
+
+test("an unclosed code fence renders verbatim instead of swallowing the tail", () => {
+  const { host, root } = mount();
+  const partial = "Patch:\n\n```ts\nconst x = 1;";
+  const closed = [partial, "```", "", "done"].join("\n");
+  stream(root, partial, 6);
+  const row = liveRow(host);
+  expect(row.querySelector("pre")).toBeNull();
+  expect(row.textContent).toContain("```ts");
+  expect(row.textContent).toContain("const x = 1;");
+
+  paint(root, <LiveTurnRows items={[item(closed, "streaming")]} />);
+  expect(liveRow(host).querySelector("pre")?.textContent).toBe("const x = 1;");
+  expect(liveRow(host).textContent).not.toContain("```");
+});
+
+test("an unterminated bold run stays literal until its closer arrives", () => {
+  const { host, root } = mount();
+  paint(root, <LiveTurnRows items={[item("Result: **bol", "streaming")]} />);
+  expect(liveRow(host).querySelector("b")).toBeNull();
+  expect(liveRow(host).textContent).toContain("**bol");
+
+  paint(root, <LiveTurnRows items={[item("Result: **bold** ok", "streaming")]} />);
+  expect(liveRow(host).querySelector("b")?.textContent).toBe("bold");
+});
+
+test("the streaming caret and the omission notices survive the markdown pass", () => {
+  const { host, root } = mount();
+  paint(
+    root,
+    <LiveTurnRows
+      items={[
+        item("| col |\n| --- |\n| a |\n\nEarlier **items** folded.", "streaming", { omittedItems: 3, omittedChars: 40 }),
+      ]}
+    />,
+  );
+  const row = liveRow(host);
+  expect(row.querySelector("[data-live-turn-omitted-items]")?.textContent).toContain("3");
+  expect(row.querySelector(".animate-pulse")).not.toBeNull();
+  expect(row.querySelector("table")).not.toBeNull();
+  expect(row.querySelector("b")?.textContent).toBe("items");
+
+  paint(root, <LiveTurnRows items={[item("Only chars dropped.", "streaming", { omittedChars: 12 })]} />);
+  expect(liveRow(host).querySelector("[data-live-turn-omitted-chars]")?.textContent).toContain("12");
+});
+
+test("a completed item that rewrites its draft is re-rendered from scratch", () => {
+  const { host, root } = mount();
+  stream(root, "Draft **half** written\n| a | b |\n| - | - |", 5);
+  /* The completion event may legitimately replace the observed stream. */
+  const authoritative = "Final **answer**\n\n| x | y |\n| --- | --- |\n| 1 | 2 |";
+  paint(root, <LiveTurnRows items={[item(authoritative, "awaiting-echo")]} />);
+  expect(liveRow(host).innerHTML).toBe(settledHtml(authoritative));
+});
+
+test("settled lines are frozen once written: the boundary only moves forward", () => {
+  const text = SAMPLE;
+  let previous = 0;
+  for (let end = 1; end <= text.length; end++) {
+    const settled = settledLineCount(text.slice(0, end).split("\n"));
+    expect(settled).toBeGreaterThanOrEqual(previous);
+    previous = settled;
+  }
+  /* The volatile region is the open construct, never the whole document. */
+  expect(settledLineCount("a\nb\nc".split("\n"))).toBe(2);
+  expect(settledLineCount("a\n| x |\n| y".split("\n"))).toBe(1);
+  expect(settledLineCount("a\n```ts\ncode".split("\n"))).toBe(1);
+  expect(settledLineCount("a\n```ts\ncode\n```\ntail".split("\n"))).toBe(4);
+});
+
+test("a long stream block-parses every line exactly once, never the whole message", () => {
+  /* Re-parsing the accumulated text per delta would cost ~180k line parses for
+     this message; the settled prefix is parsed once, so it costs 600. */
+  const lines = Array.from({ length: 600 }, (_, i) => `line ${i} with **bold** text`);
+  const body = lines.join("\n");
+  const stream = createMdStream();
+  for (let end = 1; end <= body.length; end += 3) {
+    advanceMdStream(stream, body.slice(0, end), true);
+  }
+  advanceMdStream(stream, body, true);
+  expect(stream.parsedLines).toBe(lines.length - 1);
+  /* The echo settles the last, still-volatile line — and nothing before it. */
+  advanceMdStream(stream, body, false);
+  expect(stream.parsedLines).toBe(lines.length);
+});
+
+test("a fenced block that has closed is never re-parsed by later deltas", () => {
+  const head = ["intro", "```ts", "const x = 1;", "```", ""].join("\n");
+  const stream = createMdStream();
+  advanceMdStream(stream, `${head}\n`, true);
+  const afterFence = stream.parsedLines;
+  expect(afterFence).toBeGreaterThan(0);
+  for (const tail of ["t", "ta", "tai", "tail"]) {
+    advanceMdStream(stream, `${head}\n${tail}`, true);
+  }
+  expect(stream.parsedLines).toBe(afterFence);
+});

--- a/src/components/conversation/liveTurnMarkdown.dom.test.tsx
+++ b/src/components/conversation/liveTurnMarkdown.dom.test.tsx
@@ -385,6 +385,76 @@ test("the consumed-line count stays exact across runs and a trim", () => {
   expect(stream.stableLines).toBe(trimmed.split("\n").length - 1);
 });
 
+/** Renders a streaming tree on its own root, for per-frame comparison. */
+function frameHtml(tree: ReactNode): string {
+  const { host, root } = mount();
+  paint(root, <div className="whitespace-pre-wrap">{tree}</div>);
+  return (host.firstElementChild as HTMLElement).innerHTML;
+}
+
+test("a head-trimmed message of repeated lines renders its source on every delta", () => {
+  /* The writing frontier sits inside 128+ chars of identical content — ordinary
+     for repeated log lines, boilerplate or a spinner — and the head-trim shift
+     is a whole number of those lines, so a fixed anchor window matches at the
+     STALE offset. Trusting that window renders a head the message no longer
+     contains, and because nothing re-checks it the drift only grows: this same
+     walk leaves 82 of its 98 frames wrong. Distinctive lines ahead of the
+     repeats are what makes the stale head visible. */
+  const unique = Array.from({ length: 30 }, (_, i) => `unique line ${i} of the answer`);
+  const repeat = "repeating tail line";
+  const source = [...unique, ...Array.from({ length: 90 }, () => repeat)].join("\n");
+  const WINDOW = 600;
+  const PERIOD = repeat.length + 1;
+  const stream = createMdStream();
+  let frames = 0;
+  for (let end = 700; end <= source.length; end += PERIOD) {
+    /* What the bounded projection hands the row: a sliding window, trimmed at
+       the head by exactly what each delta appends. */
+    const text = source.slice(0, end).slice(-WINDOW);
+    expect(frameHtml(advanceMdStream(stream, text, true))).toBe(settledHtml(text));
+    frames++;
+  }
+  expect(frames).toBeGreaterThan(90);
+});
+
+test("a message whose head changed under an unchanged anchor is re-rendered", () => {
+  /* The evidence a reused frame rests on has to identify the reused region.
+     Here the last 128+ chars before the boundary are untouched while the head
+     is rewritten — which is what a completed item replacing its draft looks
+     like — so anything keyed on a window alone keeps rendering the old head. */
+  const tail = Array.from({ length: 12 }, () => "identical tail line").join("\n");
+  const first = `opening line one\n${tail}\n`;
+  const second = `opening line two\n${tail}\n`;
+  expect(second.length).toBe(first.length);
+
+  const stream = createMdStream();
+  advanceMdStream(stream, first, true);
+  expect(frameHtml(advanceMdStream(stream, second, true))).toBe(settledHtml(second));
+  /* …and the frame after it, so nothing absorbed the divergence. */
+  const grown = `${second}and on it goes`;
+  expect(frameHtml(advanceMdStream(stream, grown, true))).toBe(settledHtml(grown));
+
+  /* A boundary that is no longer a line start is not evidence either. */
+  stream.stableChars -= 7;
+  expect(frameHtml(advanceMdStream(stream, `${grown} further`, true)))
+    .toBe(settledHtml(`${grown} further`));
+});
+
+test("a whole-line image is mounted once, when its line lands", () => {
+  const { host, root } = mount();
+  const shot = "![shot](data:image/gif;base64,R0lGODlhAQABAAAAACw=)";
+  paint(root, <LiveTurnRows items={[item(`Here:\n\n${shot}`, "streaming")]} />);
+  /* Still being written: readable text, not an image mounted to be thrown away. */
+  expect(liveRow(host).querySelector("img")).toBeNull();
+  expect(liveRow(host).textContent).toContain(shot);
+
+  paint(root, <LiveTurnRows items={[item(`Here:\n\n${shot}\n\ndone`, "streaming")]} />);
+  const img = liveRow(host).querySelector("img");
+  expect(img).not.toBeNull();
+  paint(root, <LiveTurnRows items={[item(`Here:\n\n${shot}\n\ndone`, "awaiting-echo")]} />);
+  expect(liveRow(host).querySelector("img")).toBe(img);
+});
+
 test("a head-trimmed projection keeps what it has already rendered", () => {
   /* Past its 64 KiB bound the projection drops chars off the front on every
      delta. Re-reading the whole window each time is what makes the longest

--- a/src/components/feed/markdown.tsx
+++ b/src/components/feed/markdown.tsx
@@ -214,31 +214,34 @@ function MdTable({ rows }: { rows: string[] }) {
   );
 }
 
-/* Block-level pass for whole prose messages rendered inside whitespace-pre-wrap:
-   newlines survive as text; tables group into real <table>, headings and
-   blockquotes are styled per line, everything else goes through the inline pass. */
-export function mdBlocks(text: string): ReactNode {
-  const lines = text.split("\n");
-  const out: ReactNode[] = [];
-  let i = 0;
-  while (i < lines.length) {
-    if (/^\s*```/.test(lines[i])) {
+const FENCE_OPEN_RE = /^\s*```/;
+const FENCE_CLOSE_RE = /^\s*```\s*$/;
+
+/* Block-level pass over `lines[from, to)`, appended to `out`. Every node is
+   keyed by its ABSOLUTE line index, and the trailing-newline bookkeeping reads
+   `out` rather than local state, so one document can be rendered in several
+   append-only slices and still come out identical to a single pass — that is
+   what lets the streaming renderer below freeze what it has already parsed. */
+function pushBlocks(out: ReactNode[], lines: string[], from: number, to: number): void {
+  let i = from;
+  while (i < to) {
+    if (FENCE_OPEN_RE.test(lines[i])) {
       const start = i;
       /* The opening fence's info string (```ts, ```python, …) is the language
          hint highlight.js resolves; fence-only names like `python`/`shell` have
          no file-extension equivalent, so this is their only entry point. */
       const lang = lines[i].match(/^\s*```+\s*([A-Za-z0-9+#_-]+)/)?.[1] ?? null;
       i++;
-      while (i < lines.length && !/^\s*```\s*$/.test(lines[i])) i++;
+      while (i < to && !FENCE_CLOSE_RE.test(lines[i])) i++;
       const code = lines.slice(start + 1, i).join("\n");
-      if (i < lines.length) i++;
+      if (i < to) i++;
       if (out[out.length - 1] === "\n") out.pop();
       out.push(<CodeBlock key={`c${start}`} code={code} lang={lang} />);
       continue;
     }
     if (TABLE_ROW_RE.test(lines[i])) {
       const start = i;
-      while (i < lines.length && TABLE_ROW_RE.test(lines[i])) i++;
+      while (i < to && TABLE_ROW_RE.test(lines[i])) i++;
       /* The table div is a block element: the pending newline would add an empty row. */
       if (out[out.length - 1] === "\n") out.pop();
       out.push(<MdTable key={`t${start}`} rows={lines.slice(start, i)} />);
@@ -247,7 +250,7 @@ export function mdBlocks(text: string): ReactNode {
     if (IMAGE_LINE_RE.test(lines[i])) {
       const start = i;
       const images: { alt: string; src: string }[] = [];
-      while (i < lines.length) {
+      while (i < to) {
         const m = lines[i].match(IMAGE_LINE_RE);
         if (!m) break;
         images.push({ alt: m[1], src: m[2] });
@@ -277,7 +280,154 @@ export function mdBlocks(text: string): ReactNode {
       out.push(<Fragment key={i}>{md(line)}</Fragment>);
     }
     i++;
+    /* The newline belongs to the document, not to the slice: a slice that stops
+       short of the end is followed by more lines, so it keeps its separator. */
     if (i < lines.length) out.push("\n");
   }
+}
+
+/* Block-level pass for whole prose messages rendered inside whitespace-pre-wrap:
+   newlines survive as text; tables group into real <table>, headings and
+   blockquotes are styled per line, everything else goes through the inline pass. */
+export function mdBlocks(text: string): ReactNode {
+  const lines = text.split("\n");
+  const out: ReactNode[] = [];
+  pushBlocks(out, lines, 0, lines.length);
   return out;
+}
+
+/* How far the block extending from `lines[i]` reaches, and whether a line
+   arriving after `limit` could still be swallowed by it. */
+function blockSpan(lines: string[], i: number, limit: number): { end: number; extendable: boolean } {
+  if (FENCE_OPEN_RE.test(lines[i])) {
+    let j = i + 1;
+    while (j < limit && !FENCE_CLOSE_RE.test(lines[j])) j++;
+    /* A closed fence is finished; an open one keeps eating whatever comes. */
+    return j < limit ? { end: j + 1, extendable: false } : { end: limit, extendable: true };
+  }
+  const run = TABLE_ROW_RE.test(lines[i]) ? TABLE_ROW_RE : IMAGE_LINE_RE.test(lines[i]) ? IMAGE_LINE_RE : null;
+  if (run) {
+    let j = i;
+    while (j < limit && run.test(lines[j])) j++;
+    return { end: j, extendable: true };
+  }
+  return { end: i + 1, extendable: false };
+}
+
+/**
+ * How many leading lines of a still-arriving message can no longer change
+ * meaning. The last line has no terminating newline yet, so it is always
+ * volatile; and a construct that runs up against it — an unclosed fence, a
+ * table or image run that the next line may join — is volatile with it.
+ * Everything before that point is final: later deltas cannot reinterpret it.
+ */
+export function settledLineCount(lines: string[]): number {
+  const complete = lines.length - 1;
+  let i = 0;
+  while (i < complete) {
+    const span = blockSpan(lines, i, complete);
+    if (span.extendable && span.end >= complete) return i;
+    i = span.end;
+  }
+  return Math.max(complete, 0);
+}
+
+/* Lines the agent is still writing, rendered so that nothing ever re-interprets
+   itself on a later delta — the message must not twitch as it is typed. The
+   inline pass alone already degrades to plain text for any construct whose
+   closer has not arrived (`**bol`, a half-written row), and the block grammar
+   runs only where the answer can no longer change: */
+function pushPending(out: ReactNode[], lines: string[], from: number): void {
+  /* …never inside an open fence. Its body is code, must stay verbatim, and a
+     growing <pre> would re-run highlight.js on every delta. */
+  if (FENCE_OPEN_RE.test(lines[from] ?? "")) {
+    for (let i = from; i < lines.length; i++) {
+      out.push(<Fragment key={`p${i}`}>{lines[i]}</Fragment>);
+      if (i < lines.length - 1) out.push("\n");
+    }
+    return;
+  }
+  /* …but yes for the closed lines of a trailing table or image run, which is
+     how a message that ENDS with a table gets to look like its settled self
+     while it streams. A table waits for its second row: until that row lands,
+     the header/body split is still open, and deciding it early is exactly the
+     kind of re-interpretation this is avoiding. Rows only ever append after. */
+  const complete = lines.length - 1;
+  const closed = lines.slice(from, complete);
+  const rows = closed.length >= 2 && closed.every((line) => TABLE_ROW_RE.test(line)) ? closed : null;
+  const matches = rows ? [] : closed.map((line) => line.match(IMAGE_LINE_RE));
+  const images = matches.length && matches.every((m) => m !== null)
+    ? matches.map((m) => ({ alt: m![1], src: m![2] }))
+    : null;
+  let i = from;
+  if (rows || images) {
+    /* Block element: drop the newline the settled slice left pending. */
+    if (out[out.length - 1] === "\n") out.pop();
+    /* Same key the settled pass will give this block, so it is reconciled in
+       place — the table does not blink out and back when the run terminates. */
+    out.push(rows
+      ? <MdTable key={`t${from}`} rows={rows} />
+      : <MdImageRow key={`i${from}`} images={images!} />);
+    i = complete;
+  }
+  for (; i < lines.length; i++) {
+    out.push(<Fragment key={`p${i}`}>{md(lines[i])}</Fragment>);
+    if (i < lines.length - 1) out.push("\n");
+  }
+}
+
+export interface MdStreamState {
+  source: string;
+  settled: number;
+  blocks: ReactNode[];
+  /** Lines block-parsed so far. A delta must not grow this by more than the
+      lines it just settled — that is the whole point of the cache. */
+  parsedLines: number;
+}
+
+export function createMdStream(): MdStreamState {
+  return { source: "", settled: 0, blocks: [], parsedLines: 0 };
+}
+
+/**
+ * Advances a streaming prose body to `text` and returns its nodes.
+ *
+ * The settled prefix is parsed ONCE and kept in `state`: a call parses only the
+ * lines that just became final, and re-renders the volatile tail — normally one
+ * line, at most the open construct. The cached nodes keep their element
+ * identity, so React skips those subtrees and highlight.js never re-runs for a
+ * fence that is already closed. Re-parsing the accumulated text on every delta
+ * would be quadratic over a long answer; this is linear over the whole stream.
+ */
+export function advanceMdStream(state: MdStreamState, text: string, streaming: boolean): ReactNode[] {
+  const lines = text.split("\n");
+  const settled = streaming ? settledLineCount(lines) : lines.length;
+  /* Deltas append; anything else (a completed item replacing its draft, a
+     bounded projection trimming its head) invalidates what was parsed. */
+  if (!text.startsWith(state.source) || settled < state.settled) {
+    state.blocks = [];
+    state.settled = 0;
+  }
+  if (settled > state.settled) {
+    pushBlocks(state.blocks, lines, state.settled, settled);
+    state.parsedLines += settled - state.settled;
+    state.settled = settled;
+  }
+  state.source = text;
+  const out = state.blocks.slice();
+  if (settled < lines.length) pushPending(out, lines, settled);
+  return out;
+}
+
+/**
+ * A prose body that may still be streaming, rendered by the same grammar as a
+ * settled transcript message — so nothing changes appearance when the echo of a
+ * live turn lands.
+ */
+export function StreamingMd({ text, streaming }: { text: string; streaming: boolean }): ReactNode {
+  /* A memo of the props, held in state because it is grown across renders and
+     must survive every one of them. Advancing it is idempotent, so a repeated
+     render of the same text yields the same tree. */
+  const [stream] = useState(createMdStream);
+  return advanceMdStream(stream, text, streaming);
 }

--- a/src/components/feed/markdown.tsx
+++ b/src/components/feed/markdown.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Fragment, useEffect, useRef, useState } from "react";
+import { Fragment, memo, useEffect, useRef, useState } from "react";
 import type { ReactNode } from "react";
 
 import { CopyButton, copyText } from "./CopyButton";
@@ -217,26 +217,31 @@ function MdTable({ rows }: { rows: string[] }) {
 const FENCE_OPEN_RE = /^\s*```/;
 const FENCE_CLOSE_RE = /^\s*```\s*$/;
 
-/* Block-level pass over `lines[from, to)`, appended to `out`. Every node is
-   keyed by its ABSOLUTE line index, and the trailing-newline bookkeeping reads
-   `out` rather than local state, so one document can be rendered in several
-   append-only slices and still come out identical to a single pass — that is
-   what lets the streaming renderer below freeze what it has already parsed. */
-function pushBlocks(out: ReactNode[], lines: string[], from: number, to: number): void {
+/* The opening fence's info string (```ts, ```python, …) is the language hint
+   highlight.js resolves; fence-only names like `python`/`shell` have no
+   file-extension equivalent, so this is their only entry point. */
+function fenceLang(line: string): string | null {
+  return line.match(/^\s*```+\s*([A-Za-z0-9+#_-]+)/)?.[1] ?? null;
+}
+
+/* Block-level pass over `lines[from, to)`, appended to `out`. `lines` may be a
+   TAIL of the document starting at absolute line `base`: every node is keyed by
+   its absolute index and the trailing-newline bookkeeping reads `out` rather
+   than local state, so a document can be rendered in several append-only slices
+   and still come out identical to a single pass. That is what lets the
+   streaming renderer below parse only what has just arrived. */
+function pushBlocks(out: ReactNode[], lines: string[], from: number, to: number, base = 0): void {
   let i = from;
   while (i < to) {
     if (FENCE_OPEN_RE.test(lines[i])) {
       const start = i;
-      /* The opening fence's info string (```ts, ```python, …) is the language
-         hint highlight.js resolves; fence-only names like `python`/`shell` have
-         no file-extension equivalent, so this is their only entry point. */
-      const lang = lines[i].match(/^\s*```+\s*([A-Za-z0-9+#_-]+)/)?.[1] ?? null;
+      const lang = fenceLang(lines[i]);
       i++;
       while (i < to && !FENCE_CLOSE_RE.test(lines[i])) i++;
       const code = lines.slice(start + 1, i).join("\n");
       if (i < to) i++;
       if (out[out.length - 1] === "\n") out.pop();
-      out.push(<CodeBlock key={`c${start}`} code={code} lang={lang} />);
+      out.push(<CodeBlock key={`c${base + start}`} code={code} lang={lang} />);
       continue;
     }
     if (TABLE_ROW_RE.test(lines[i])) {
@@ -244,7 +249,7 @@ function pushBlocks(out: ReactNode[], lines: string[], from: number, to: number)
       while (i < to && TABLE_ROW_RE.test(lines[i])) i++;
       /* The table div is a block element: the pending newline would add an empty row. */
       if (out[out.length - 1] === "\n") out.pop();
-      out.push(<MdTable key={`t${start}`} rows={lines.slice(start, i)} />);
+      out.push(<MdTable key={`t${base + start}`} rows={lines.slice(start, i)} />);
       continue;
     }
     if (IMAGE_LINE_RE.test(lines[i])) {
@@ -258,7 +263,7 @@ function pushBlocks(out: ReactNode[], lines: string[], from: number, to: number)
       }
       /* The row is a block element: drop the pending newline before it. */
       if (out[out.length - 1] === "\n") out.pop();
-      out.push(<MdImageRow key={`i${start}`} images={images} />);
+      out.push(<MdImageRow key={`i${base + start}`} images={images} />);
       continue;
     }
     const line = lines[i];
@@ -266,18 +271,18 @@ function pushBlocks(out: ReactNode[], lines: string[], from: number, to: number)
     const quote = line.match(/^>\s?(.*)$/);
     if (heading) {
       out.push(
-        <span key={i} className="text-[14px] font-bold">
+        <span key={base + i} className="text-[14px] font-bold">
           {md(heading[1])}
         </span>,
       );
     } else if (quote) {
       out.push(
-        <span key={i} className="border-l-2 border-border pl-2 text-muted">
+        <span key={base + i} className="border-l-2 border-border pl-2 text-muted">
           {md(quote[1])}
         </span>,
       );
     } else {
-      out.push(<Fragment key={i}>{md(line)}</Fragment>);
+      out.push(<Fragment key={base + i}>{md(line)}</Fragment>);
     }
     i++;
     /* The newline belongs to the document, not to the slice: a slice that stops
@@ -336,87 +341,195 @@ export function settledLineCount(lines: string[]): number {
    itself on a later delta — the message must not twitch as it is typed. The
    inline pass alone already degrades to plain text for any construct whose
    closer has not arrived (`**bol`, a half-written row), and the block grammar
-   runs only where the answer can no longer change: */
-function pushPending(out: ReactNode[], lines: string[], from: number): void {
-  /* …never inside an open fence. Its body is code, must stay verbatim, and a
-     growing <pre> would re-run highlight.js on every delta. */
+   runs only where the answer can no longer change. Returns whether it opened
+   with a block element, which the caller answers by dropping the newline the
+   settled slice left pending — exactly what the settled pass will do when these
+   lines eventually freeze. */
+function pushPending(out: ReactNode[], lines: string[], from: number, base: number): boolean {
+  const last = lines.length - 1;
   if (FENCE_OPEN_RE.test(lines[from] ?? "")) {
-    for (let i = from; i < lines.length; i++) {
-      out.push(<Fragment key={`p${i}`}>{lines[i]}</Fragment>);
-      if (i < lines.length - 1) out.push("\n");
+    /* A message may stop exactly ON its closing fence: that line has no newline
+       yet, but the code between the fences is complete, and leaving the last
+       block of an answer raw until the turn settles is the visible defect. The
+       cost is the rare delta that continues the line and takes the block back. */
+    if (last > from && FENCE_CLOSE_RE.test(lines[last])) {
+      out.push(
+        <CodeBlock key={`c${base + from}`} code={lines.slice(from + 1, last).join("\n")} lang={fenceLang(lines[from])} />,
+      );
+      return true;
     }
-    return;
+    /* An open fence stays verbatim. Its body is code, and a growing <pre> would
+       re-run highlight.js on every delta. */
+    for (let i = from; i <= last; i++) {
+      out.push(<Fragment key={`p${base + i}`}>{lines[i]}</Fragment>);
+      if (i < last) out.push("\n");
+    }
+    return false;
   }
-  /* …but yes for the closed lines of a trailing table or image run, which is
-     how a message that ENDS with a table gets to look like its settled self
-     while it streams. A table waits for its second row: until that row lands,
-     the header/body split is still open, and deciding it early is exactly the
-     kind of re-interpretation this is avoiding. Rows only ever append after. */
-  const complete = lines.length - 1;
-  const closed = lines.slice(from, complete);
+  /* The closed lines of a trailing table or image run do render — that is how a
+     message ENDING in a table looks like its settled self while it streams. A
+     table waits for its second row: until that row lands the header/body split
+     is still open, and deciding it early is exactly the kind of
+     re-interpretation this avoids. Rows only ever append after. */
+  const closed = lines.slice(from, last);
   const rows = closed.length >= 2 && closed.every((line) => TABLE_ROW_RE.test(line)) ? closed : null;
   const matches = rows ? [] : closed.map((line) => line.match(IMAGE_LINE_RE));
   const images = matches.length && matches.every((m) => m !== null)
     ? matches.map((m) => ({ alt: m![1], src: m![2] }))
     : null;
   let i = from;
+  let block = false;
   if (rows || images) {
-    /* Block element: drop the newline the settled slice left pending. */
-    if (out[out.length - 1] === "\n") out.pop();
     /* Same key the settled pass will give this block, so it is reconciled in
        place — the table does not blink out and back when the run terminates. */
     out.push(rows
-      ? <MdTable key={`t${from}`} rows={rows} />
-      : <MdImageRow key={`i${from}`} images={images!} />);
-    i = complete;
+      ? <MdTable key={`t${base + from}`} rows={rows} />
+      : <MdImageRow key={`i${base + from}`} images={images!} />);
+    i = last;
+    block = true;
   }
-  for (; i < lines.length; i++) {
-    out.push(<Fragment key={`p${i}`}>{md(lines[i])}</Fragment>);
-    if (i < lines.length - 1) out.push("\n");
+  for (; i <= last; i++) {
+    out.push(<Fragment key={`p${base + i}`}>{md(lines[i])}</Fragment>);
+    if (i < last) out.push("\n");
   }
+  return block;
 }
 
+/* How much text before the cached boundary is compared to detect a rewrite. */
+const ANCHOR = 128;
+
 export interface MdStreamState {
-  source: string;
-  settled: number;
+  /** Chars already parsed into `blocks`, at a line start unless `lineStart`. */
+  settledChars: number;
+  /** Absolute index of the first unparsed line — the key base for the next slice. */
+  settledLines: number;
+  /** Whether `settledChars` sits at a line start (false only once a completed
+      item has consumed its final, unterminated line). */
+  lineStart: boolean;
   blocks: ReactNode[];
-  /** Lines block-parsed so far. A delta must not grow this by more than the
-      lines it just settled — that is the whole point of the cache. */
+  /** Bumped whenever `blocks` changes: `blocks` is grown in place, so this is
+      what tells the memoized prefix that it has to re-render. */
+  revision: number;
+  /** Whether the prefix's trailing newline was dropped for a pending block, and
+      so has to come back if that block turns out not to be one after all. */
+  droppedNewline: boolean;
+  /** Text ending at `settledChars`, compared per delta instead of the prefix. */
+  anchor: string;
+  /** Inputs and output of the last advance, to make a repeated render free. */
+  source: string;
+  streaming: boolean;
+  rendered: ReactNode;
+  /** Chars scanned so far. A delta adds only the text from the last stable
+      boundary — never the accumulated message. */
+  scannedChars: number;
+  /** Lines block-parsed so far: every line is parsed exactly once. */
   parsedLines: number;
 }
 
 export function createMdStream(): MdStreamState {
-  return { source: "", settled: 0, blocks: [], parsedLines: 0 };
+  return {
+    settledChars: 0,
+    settledLines: 0,
+    lineStart: true,
+    blocks: [],
+    revision: 0,
+    droppedNewline: false,
+    anchor: "",
+    source: "",
+    streaming: false,
+    rendered: null,
+    scannedChars: 0,
+    parsedLines: 0,
+  };
 }
 
 /**
- * Advances a streaming prose body to `text` and returns its nodes.
+ * Whether what was parsed still describes the head of `text`.
  *
- * The settled prefix is parsed ONCE and kept in `state`: a call parses only the
- * lines that just became final, and re-renders the volatile tail — normally one
- * line, at most the open construct. The cached nodes keep their element
- * identity, so React skips those subtrees and highlight.js never re-runs for a
- * fence that is already closed. Re-parsing the accumulated text on every delta
- * would be quadratic over a long answer; this is linear over the whole stream.
+ * Deltas append; anything else — a completed item replacing its draft, the
+ * bounded projection trimming its head — has to invalidate the cache. Comparing
+ * the whole prefix would put the accumulated length back into every delta, so
+ * while streaming the check is the anchor window ending at the boundary plus
+ * monotone length. The completion call, which is the one that can legitimately
+ * carry rewritten text, is checked exactly — it happens once per item.
  */
-export function advanceMdStream(state: MdStreamState, text: string, streaming: boolean): ReactNode[] {
-  const lines = text.split("\n");
-  const settled = streaming ? settledLineCount(lines) : lines.length;
-  /* Deltas append; anything else (a completed item replacing its draft, a
-     bounded projection trimming its head) invalidates what was parsed. */
-  if (!text.startsWith(state.source) || settled < state.settled) {
+function reusable(state: MdStreamState, text: string, streaming: boolean): boolean {
+  if (state.settledChars === 0) return true;
+  if (text.length < state.settledChars) return false;
+  if (!state.lineStart && text.length !== state.settledChars) return false;
+  if (!streaming) return text.startsWith(state.source.slice(0, state.settledChars));
+  return text.length >= state.source.length
+    && text.slice(Math.max(0, state.settledChars - ANCHOR), state.settledChars) === state.anchor;
+}
+
+/* The parsed prefix, isolated behind memo: a delta that settles nothing leaves
+   `revision` alone and React skips this subtree without walking it. */
+const SettledPrefix = memo(function SettledPrefix({ nodes }: { nodes: ReactNode[]; revision: number }) {
+  return nodes;
+});
+
+/**
+ * Advances a streaming prose body to `text` and returns its tree.
+ *
+ * Work per call is proportional to what arrived, not to what has accumulated:
+ * only the text after the last stable boundary is sliced, split and scanned, the
+ * lines that just settled are parsed once and appended to the cached prefix, and
+ * the volatile tail is re-rendered — normally one line, at most the open
+ * construct. Re-parsing the accumulated text on every delta would be quadratic
+ * over a long answer; this is linear over the whole stream.
+ */
+export function advanceMdStream(state: MdStreamState, text: string, streaming: boolean): ReactNode {
+  if (state.rendered !== null && text === state.source && streaming === state.streaming) return state.rendered;
+  if (!reusable(state, text, streaming)) {
+    state.settledChars = 0;
+    state.settledLines = 0;
+    state.lineStart = true;
     state.blocks = [];
-    state.settled = 0;
+    state.droppedNewline = false;
+    state.revision++;
   }
-  if (settled > state.settled) {
-    pushBlocks(state.blocks, lines, state.settled, settled);
-    state.parsedLines += settled - state.settled;
-    state.settled = settled;
+  const base = state.settledLines;
+  const rest = text.slice(state.settledChars);
+  const lines = rest.split("\n");
+  const settled = streaming ? settledLineCount(lines) : lines.length;
+  state.scannedChars += rest.length;
+  if (settled > 0) {
+    pushBlocks(state.blocks, lines, 0, settled, base);
+    let chars = 0;
+    for (let i = 0; i < settled; i++) chars += lines[i].length + 1;
+    /* The last line of a completed item ends the text instead of a newline. */
+    state.lineStart = state.settledChars + chars <= text.length;
+    state.settledChars = Math.min(state.settledChars + chars, text.length);
+    state.settledLines += settled;
+    state.anchor = text.slice(Math.max(0, state.settledChars - ANCHOR), state.settledChars);
+    state.parsedLines += settled;
+    /* pushBlocks has re-established the separator itself. */
+    state.droppedNewline = false;
+    state.revision++;
   }
+  let pending: ReactNode[] | null = null;
+  if (settled < lines.length) {
+    pending = [];
+    const block = pushPending(pending, lines, settled, base);
+    /* A pending block element sheds the separator the prefix left behind — and
+       takes it back if the next delta turns it into ordinary text again, which
+       is what an unfinished line reopening a fence does. */
+    if (block && state.blocks[state.blocks.length - 1] === "\n") {
+      state.blocks.pop();
+      state.droppedNewline = true;
+      state.revision++;
+    } else if (!block && state.droppedNewline) {
+      state.blocks.push("\n");
+      state.droppedNewline = false;
+      state.revision++;
+    }
+  }
+  let tree: ReactNode = <SettledPrefix nodes={state.blocks} revision={state.revision} />;
+  if (pending) tree = <>{tree}{pending}</>;
   state.source = text;
-  const out = state.blocks.slice();
-  if (settled < lines.length) pushPending(out, lines, settled);
-  return out;
+  state.streaming = streaming;
+  state.rendered = tree;
+  return tree;
 }
 
 /**

--- a/src/components/feed/markdown.tsx
+++ b/src/components/feed/markdown.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Fragment, memo, useEffect, useRef, useState } from "react";
+import { Fragment, useEffect, useRef, useState } from "react";
 import type { ReactNode } from "react";
 
 import { CopyButton, copyText } from "./CopyButton";
@@ -224,6 +224,28 @@ function fenceLang(line: string): string | null {
   return line.match(/^\s*```+\s*([A-Za-z0-9+#_-]+)/)?.[1] ?? null;
 }
 
+/* One line that is not part of a multi-line block: a styled heading or
+   blockquote, otherwise the inline pass. */
+function lineNode(line: string, key: number | string): ReactNode {
+  const heading = line.match(/^#{1,6}\s+(.*)$/);
+  if (heading) {
+    return (
+      <span key={key} className="text-[14px] font-bold">
+        {md(heading[1])}
+      </span>
+    );
+  }
+  const quote = line.match(/^>\s?(.*)$/);
+  if (quote) {
+    return (
+      <span key={key} className="border-l-2 border-border pl-2 text-muted">
+        {md(quote[1])}
+      </span>
+    );
+  }
+  return <Fragment key={key}>{md(line)}</Fragment>;
+}
+
 /* Block-level pass over `lines[from, to)`, appended to `out`. `lines` may be a
    TAIL of the document starting at absolute line `base`: every node is keyed by
    its absolute index and the trailing-newline bookkeeping reads `out` rather
@@ -266,24 +288,7 @@ function pushBlocks(out: ReactNode[], lines: string[], from: number, to: number,
       out.push(<MdImageRow key={`i${base + start}`} images={images} />);
       continue;
     }
-    const line = lines[i];
-    const heading = line.match(/^#{1,6}\s+(.*)$/);
-    const quote = line.match(/^>\s?(.*)$/);
-    if (heading) {
-      out.push(
-        <span key={base + i} className="text-[14px] font-bold">
-          {md(heading[1])}
-        </span>,
-      );
-    } else if (quote) {
-      out.push(
-        <span key={base + i} className="border-l-2 border-border pl-2 text-muted">
-          {md(quote[1])}
-        </span>,
-      );
-    } else {
-      out.push(<Fragment key={base + i}>{md(line)}</Fragment>);
-    }
+    out.push(lineNode(lines[i], base + i));
     i++;
     /* The newline belongs to the document, not to the slice: a slice that stops
        short of the end is followed by more lines, so it keeps its separator. */
@@ -301,231 +306,385 @@ export function mdBlocks(text: string): ReactNode {
   return out;
 }
 
-/* How far the block extending from `lines[i]` reaches, and whether a line
-   arriving after `limit` could still be swallowed by it. */
-function blockSpan(lines: string[], i: number, limit: number): { end: number; extendable: boolean } {
-  if (FENCE_OPEN_RE.test(lines[i])) {
-    let j = i + 1;
-    while (j < limit && !FENCE_CLOSE_RE.test(lines[j])) j++;
-    /* A closed fence is finished; an open one keeps eating whatever comes. */
-    return j < limit ? { end: j + 1, extendable: false } : { end: limit, extendable: true };
-  }
-  const run = TABLE_ROW_RE.test(lines[i]) ? TABLE_ROW_RE : IMAGE_LINE_RE.test(lines[i]) ? IMAGE_LINE_RE : null;
-  if (run) {
-    let j = i;
-    while (j < limit && run.test(lines[j])) j++;
-    return { end: j, extendable: true };
-  }
-  return { end: i + 1, extendable: false };
-}
 
-/**
- * How many leading lines of a still-arriving message can no longer change
- * meaning. The last line has no terminating newline yet, so it is always
- * volatile; and a construct that runs up against it — an unclosed fence, a
- * table or image run that the next line may join — is volatile with it.
- * Everything before that point is final: later deltas cannot reinterpret it.
- */
-export function settledLineCount(lines: string[]): number {
-  const complete = lines.length - 1;
-  let i = 0;
-  while (i < complete) {
-    const span = blockSpan(lines, i, complete);
-    if (span.extendable && span.end >= complete) return i;
-    i = span.end;
-  }
-  return Math.max(complete, 0);
-}
+/* ---------------------------------------------------------------------------
+   Streaming.
 
-/* Lines the agent is still writing, rendered so that nothing ever re-interprets
-   itself on a later delta — the message must not twitch as it is typed. The
-   inline pass alone already degrades to plain text for any construct whose
-   closer has not arrived (`**bol`, a half-written row), and the block grammar
-   runs only where the answer can no longer change. Returns whether it opened
-   with a block element, which the caller answers by dropping the newline the
-   settled slice left pending — exactly what the settled pass will do when these
-   lines eventually freeze. */
-function pushPending(out: ReactNode[], lines: string[], from: number, base: number): boolean {
-  const last = lines.length - 1;
-  if (FENCE_OPEN_RE.test(lines[from] ?? "")) {
-    /* A message may stop exactly ON its closing fence: that line has no newline
-       yet, but the code between the fences is complete, and leaving the last
-       block of an answer raw until the turn settles is the visible defect. The
-       cost is the rare delta that continues the line and takes the block back. */
-    if (last > from && FENCE_CLOSE_RE.test(lines[last])) {
-      out.push(
-        <CodeBlock key={`c${base + from}`} code={lines.slice(from + 1, last).join("\n")} lang={fenceLang(lines[from])} />,
-      );
-      return true;
-    }
-    /* An open fence stays verbatim. Its body is code, and a growing <pre> would
-       re-run highlight.js on every delta. */
-    for (let i = from; i <= last; i++) {
-      out.push(<Fragment key={`p${base + i}`}>{lines[i]}</Fragment>);
-      if (i < last) out.push("\n");
-    }
-    return false;
-  }
-  /* The closed lines of a trailing table or image run do render — that is how a
-     message ENDING in a table looks like its settled self while it streams. A
-     table waits for its second row: until that row lands the header/body split
-     is still open, and deciding it early is exactly the kind of
-     re-interpretation this avoids. Rows only ever append after. */
-  const closed = lines.slice(from, last);
-  const rows = closed.length >= 2 && closed.every((line) => TABLE_ROW_RE.test(line)) ? closed : null;
-  const matches = rows ? [] : closed.map((line) => line.match(IMAGE_LINE_RE));
-  const images = matches.length && matches.every((m) => m !== null)
-    ? matches.map((m) => ({ alt: m![1], src: m![2] }))
-    : null;
-  let i = from;
-  let block = false;
-  if (rows || images) {
-    /* Same key the settled pass will give this block, so it is reconciled in
-       place — the table does not blink out and back when the run terminates. */
-    out.push(rows
-      ? <MdTable key={`t${base + from}`} rows={rows} />
-      : <MdImageRow key={`i${base + from}`} images={images!} />);
-    i = last;
-    block = true;
-  }
-  for (; i <= last; i++) {
-    out.push(<Fragment key={`p${base + i}`}>{md(lines[i])}</Fragment>);
-    if (i < last) out.push("\n");
-  }
-  return block;
-}
+   A live turn row re-renders on every delta, so the renderer above cannot just
+   be re-run: the message would be re-parsed hundreds of times. The machine
+   below consumes a message the way it arrives — one complete line at a time —
+   and appends the nodes it produces to a list it never re-walks. A delta only
+   ever touches the line still being written and the construct that line is
+   inside, so its cost is the delta's, not the accumulated message's.
+--------------------------------------------------------------------------- */
 
-/* How much text before the cached boundary is compared to detect a rewrite. */
+/** Nodes per chunk: the ceiling on what one settled line can make React redo. */
+const CHUNK = 48;
+/** Text kept before the boundary to recognise the message on the next delta. */
 const ANCHOR = 128;
 
+/* A run of already-rendered nodes. A chunk's element is re-created only when
+   its own nodes change, so React skips every untouched chunk on element
+   identity alone — it never walks what the message has already shown. */
+function MdChunk({ nodes }: { nodes: ReactNode[] }): ReactNode {
+  return nodes;
+}
+
+interface MdChunk {
+  key: number;
+  /** Char offset of the chunk's first line, and the separator owed at it —
+      a chunk always begins at a line where no construct is open, so this is
+      all the context needed to re-parse from here. */
+  from: number;
+  sep: boolean;
+  /** Lines consumed into this chunk, so a trim can recount what survived. */
+  lines: number;
+  nodes: ReactNode[];
+  element: ReactNode;
+}
+
+interface MdRegion {
+  chunks: MdChunk[];
+  keys: number;
+}
+
+function newRegion(): MdRegion {
+  return { chunks: [], keys: 0 };
+}
+
+/** The chunk to append to, cutting a new one when the current is full. Only
+    ever called where no construct is open, so a chunk boundary is always a
+    point the message can be re-parsed from. */
+function chunkFor(region: MdRegion, from: number, sep: boolean): MdChunk {
+  const last = region.chunks[region.chunks.length - 1];
+  if (last && last.nodes.length < CHUNK) return last;
+  const chunk: MdChunk = { key: region.keys++, from, sep, lines: 0, nodes: [], element: null };
+  region.chunks.push(chunk);
+  return chunk;
+}
+
+/** Re-creates the live chunk's element; every frozen chunk keeps its own. */
+function seal(region: MdRegion): void {
+  const chunk = region.chunks[region.chunks.length - 1];
+  chunk.element = <MdChunk key={chunk.key} nodes={chunk.nodes} />;
+}
+
+function regionNodes(region: MdRegion): ReactNode[] {
+  return region.chunks.map((chunk) => chunk.element);
+}
+
+/* The construct currently swallowing lines. It owns exactly one node slot in
+   the live chunk, so it can change shape — a row count deciding a table, a
+   fence closing — by re-emitting that slot, never by moving anything. */
+type MdRun =
+  | { kind: "fence"; slot: number; sep: boolean; key: number; lang: string | null; code: string[]; joined: string | null; body: MdRegion; shown: number }
+  | { kind: "table"; slot: number; sep: boolean; key: number; rows: string[] }
+  | { kind: "images"; slot: number; sep: boolean; key: number; images: { alt: string; src: string }[] };
+
 export interface MdStreamState {
-  /** Chars already parsed into `blocks`, at a line start unless `lineStart`. */
-  settledChars: number;
-  /** Absolute index of the first unparsed line — the key base for the next slice. */
-  settledLines: number;
-  /** Whether `settledChars` sits at a line start (false only once a completed
-      item has consumed its final, unterminated line). */
+  /** Chars consumed into nodes: the start of the line still being written.
+      Everything a delta does begins here. */
+  stableChars: number;
+  /** Lines consumed into nodes. */
+  stableLines: number;
+  /** False once a completed message has consumed its final, unterminated line. */
   lineStart: boolean;
-  blocks: ReactNode[];
-  /** Bumped whenever `blocks` changes: `blocks` is grown in place, so this is
-      what tells the memoized prefix that it has to re-render. */
-  revision: number;
-  /** Whether the prefix's trailing newline was dropped for a pending block, and
-      so has to come back if that block turns out not to be one after all. */
-  droppedNewline: boolean;
-  /** Text ending at `settledChars`, compared per delta instead of the prefix. */
+  region: MdRegion;
+  run: MdRun | null;
+  /** A newline owed to the next node, dropped if that node is a block —
+      which is how the separator bookkeeping stays local to one append. */
+  sep: boolean;
+  /** Whether the volatile line is currently being shown as a closing fence. */
+  provisional: boolean;
   anchor: string;
-  /** Inputs and output of the last advance, to make a repeated render free. */
   source: string;
   streaming: boolean;
   rendered: ReactNode;
-  /** Chars scanned so far. A delta adds only the text from the last stable
-      boundary — never the accumulated message. */
-  scannedChars: number;
-  /** Lines block-parsed so far: every line is parsed exactly once. */
-  parsedLines: number;
+  keys: number;
 }
 
 export function createMdStream(): MdStreamState {
   return {
-    settledChars: 0,
-    settledLines: 0,
+    stableChars: 0,
+    stableLines: 0,
     lineStart: true,
-    blocks: [],
-    revision: 0,
-    droppedNewline: false,
+    region: newRegion(),
+    run: null,
+    sep: false,
+    provisional: false,
     anchor: "",
     source: "",
     streaming: false,
     rendered: null,
-    scannedChars: 0,
-    parsedLines: 0,
+    keys: 0,
   };
 }
 
-/**
- * Whether what was parsed still describes the head of `text`.
- *
- * Deltas append; anything else — a completed item replacing its draft, the
- * bounded projection trimming its head — has to invalidate the cache. Comparing
- * the whole prefix would put the accumulated length back into every delta, so
- * while streaming the check is the anchor window ending at the boundary plus
- * monotone length. The completion call, which is the one that can legitimately
- * carry rewritten text, is checked exactly — it happens once per item.
- */
-function reusable(state: MdStreamState, text: string, streaming: boolean): boolean {
-  if (state.settledChars === 0) return true;
-  if (text.length < state.settledChars) return false;
-  if (!state.lineStart && text.length !== state.settledChars) return false;
-  if (!streaming) return text.startsWith(state.source.slice(0, state.settledChars));
-  return text.length >= state.source.length
-    && text.slice(Math.max(0, state.settledChars - ANCHOR), state.settledChars) === state.anchor;
+function resetMdStream(state: MdStreamState): void {
+  state.stableChars = 0;
+  state.stableLines = 0;
+  state.lineStart = true;
+  state.region = newRegion();
+  state.run = null;
+  state.sep = false;
+  state.provisional = false;
+  state.anchor = "";
 }
 
-/* The parsed prefix, isolated behind memo: a delta that settles nothing leaves
-   `revision` alone and React skips this subtree without walking it. */
-const SettledPrefix = memo(function SettledPrefix({ nodes }: { nodes: ReactNode[]; revision: number }) {
-  return nodes;
-});
+/** What an open run looks like right now, and whether that is a block element. */
+function runNode(run: MdRun, closing: boolean): { node: ReactNode; block: boolean } {
+  if (run.kind === "images") return { node: <MdImageRow key={`i${run.key}`} images={run.images} />, block: true };
+  if (run.kind === "table") {
+    /* One row cannot say whether it is a header: rendering it as a table now
+       would move it into the header when the separator row lands. */
+    if (!closing && run.rows.length < 2) return { node: lineNode(run.rows[0], `p${run.key}`), block: false };
+    return { node: <MdTable key={`t${run.key}`} rows={run.rows} />, block: true };
+  }
+  if (closing) {
+    run.joined ??= run.code.join("\n");
+    return { node: <CodeBlock key={`c${run.key}`} code={run.joined} lang={run.lang} />, block: true };
+  }
+  /* An open fence stays verbatim: its body is code, and a growing <pre> would
+     re-run highlight.js on every delta. The lines already written accumulate
+     in their own region, so a new one costs one node, not a re-render. */
+  return { node: <MdChunk key={`f${run.key}`} nodes={regionNodes(run.body)} />, block: false };
+}
+
+/* Re-emits the open run's slot in place. Truncating back to the slot is what
+   lets a run change shape without leaving anything behind — and because the
+   slot never moves, a block that is already on screen is never remounted. */
+function paintRun(state: MdStreamState, closing: boolean): void {
+  const run = state.run!;
+  const chunk = state.region.chunks[state.region.chunks.length - 1];
+  chunk.nodes.length = run.slot;
+  const { node, block } = runNode(run, closing);
+  if (!block && run.sep) chunk.nodes.push("\n");
+  chunk.nodes.push(node);
+  state.sep = !block;
+  seal(state.region);
+}
+
+function closeRun(state: MdStreamState): void {
+  paintRun(state, true);
+  state.run = null;
+  state.provisional = false;
+}
+
+/** One more verbatim line of an open fence, appended to its own region. */
+function pushFenceLine(run: Extract<MdRun, { kind: "fence" }>, line: string, key: number): void {
+  const chunk = chunkFor(run.body, 0, false);
+  if (run.shown++ > 0) chunk.nodes.push("\n");
+  chunk.nodes.push(<Fragment key={key}>{line}</Fragment>);
+  seal(run.body);
+}
+
+/** Appends one finished line's node, honouring the owed separator. */
+function emitNode(state: MdStreamState, node: ReactNode, block: boolean): void {
+  const chunk = state.region.chunks[state.region.chunks.length - 1];
+  if (!block && state.sep) chunk.nodes.push("\n");
+  chunk.nodes.push(node);
+  state.sep = !block;
+  seal(state.region);
+}
+
+/* Consumes one COMPLETE line — a line whose newline has arrived, so neither its
+   text nor (given the run it lands in) its meaning can change again. */
+function consume(state: MdStreamState, line: string, from: number): void {
+  const run = state.run;
+  if (run) {
+    /* A line the run swallows belongs to the chunk the run lives in. */
+    const held = state.region.chunks[state.region.chunks.length - 1];
+    if (run.kind === "fence") {
+      held.lines++;
+      if (FENCE_CLOSE_RE.test(line)) {
+        closeRun(state);
+        return;
+      }
+      run.code.push(line);
+      run.joined = null;
+      pushFenceLine(run, line, state.keys++);
+      paintRun(state, false);
+      return;
+    }
+    if (run.kind === "table" && TABLE_ROW_RE.test(line)) {
+      held.lines++;
+      run.rows.push(line);
+      paintRun(state, false);
+      return;
+    }
+    if (run.kind === "images") {
+      const more = line.match(IMAGE_LINE_RE);
+      if (more) {
+        held.lines++;
+        run.images.push({ alt: more[1], src: more[2] });
+        paintRun(state, false);
+        return;
+      }
+    }
+    /* The run ends here; this line is whatever it is on its own. */
+    closeRun(state);
+  }
+  /* No run is open, so this is a point the message can be re-parsed from: the
+     only place a chunk may be cut. */
+  const chunk = chunkFor(state.region, from, state.sep);
+  chunk.lines++;
+  if (FENCE_OPEN_RE.test(line)) {
+    state.run = {
+      kind: "fence",
+      slot: chunk.nodes.length,
+      sep: state.sep,
+      key: state.keys++,
+      lang: fenceLang(line),
+      code: [],
+      joined: null,
+      body: newRegion(),
+      shown: 0,
+    };
+    pushFenceLine(state.run, line, state.keys++);
+    paintRun(state, false);
+    return;
+  }
+  if (TABLE_ROW_RE.test(line)) {
+    state.run = { kind: "table", slot: chunk.nodes.length, sep: state.sep, key: state.keys++, rows: [line] };
+    paintRun(state, false);
+    return;
+  }
+  const image = line.match(IMAGE_LINE_RE);
+  if (image) {
+    state.run = {
+      kind: "images",
+      slot: chunk.nodes.length,
+      sep: state.sep,
+      key: state.keys++,
+      images: [{ alt: image[1], src: image[2] }],
+    };
+    paintRun(state, false);
+    return;
+  }
+  emitNode(state, lineNode(line, state.keys++), false);
+}
+
+/**
+ * Whether what has been consumed still describes the head of `text`.
+ *
+ * Deltas append, and re-reading the message to prove it would put the
+ * accumulated length back into every delta. While streaming the proof is the
+ * anchor window ending at the boundary plus monotone length; the completion
+ * call, the one that can legitimately carry rewritten text, is checked exactly.
+ */
+function reusable(state: MdStreamState, text: string, streaming: boolean): boolean {
+  if (state.stableChars === 0) return true;
+  if (!state.lineStart || text.length < state.stableChars) return false;
+  if (!streaming) return text.startsWith(state.source.slice(0, state.stableChars));
+  return text.length >= state.source.length
+    && text.slice(Math.max(0, state.stableChars - ANCHOR), state.stableChars) === state.anchor;
+}
+
+/**
+ * Recovers the shift when the live projection trims a message's head, which it
+ * does on EVERY delta once a turn passes its 64 KiB bound — exactly the long
+ * answers where re-parsing the whole window per delta hurts most.
+ *
+ * Chunks the trim reached are dropped and the lines in front of the first
+ * survivor are parsed again; everything behind it is context-free (a chunk
+ * begins where no construct is open) and is kept as it is. If that head parse
+ * ends inside a construct, the trim has changed how the rest reads, and nothing
+ * is reused.
+ *
+ * Only a streaming delta is recovered: the completion call is the one that can
+ * legitimately carry rewritten text, and a rewrite that happened to keep the
+ * anchor would be mistaken for a shift. A caller MUST reset the stream when
+ * this returns false — it shifts the chunk offsets before it can know.
+ */
+function recoverTrim(state: MdStreamState, text: string, streaming: boolean): boolean {
+  if (!streaming || !state.anchor || !state.lineStart) return false;
+  const at = text.lastIndexOf(state.anchor);
+  if (at < 0) return false;
+  const stable = at + state.anchor.length;
+  const shift = state.stableChars - stable;
+  if (shift <= 0) return false;
+  const chunks = state.region.chunks;
+  for (const chunk of chunks) chunk.from -= shift;
+  const keep = chunks.findIndex((chunk) => chunk.from >= 0);
+  if (keep < 0) return false;
+  const survivors = chunks.slice(keep);
+  const head = createMdStream();
+  const kept = survivors[0].from;
+  const lines = text.slice(0, kept).split("\n");
+  let from = 0;
+  /* The head ends where the first survivor begins, so its last line is
+     complete and split leaves a trailing empty entry to drop. */
+  for (let i = 0; i < lines.length - 1; i++) {
+    consume(head, lines[i], from);
+    from += lines[i].length + 1;
+  }
+  if (head.run || head.sep !== survivors[0].sep) return false;
+  for (const chunk of head.region.chunks) {
+    chunk.key = state.region.keys++;
+    chunk.element = <MdChunk key={chunk.key} nodes={chunk.nodes} />;
+  }
+  state.region.chunks = [...head.region.chunks, ...survivors];
+  state.stableChars = stable;
+  state.stableLines = state.region.chunks.reduce((total, chunk) => total + chunk.lines, 0);
+  return true;
+}
 
 /**
  * Advances a streaming prose body to `text` and returns its tree.
  *
- * Work per call is proportional to what arrived, not to what has accumulated:
- * only the text after the last stable boundary is sliced, split and scanned, the
- * lines that just settled are parsed once and appended to the cached prefix, and
- * the volatile tail is re-rendered — normally one line, at most the open
- * construct. Re-parsing the accumulated text on every delta would be quadratic
- * over a long answer; this is linear over the whole stream.
+ * The cost of a call is the cost of what arrived: the text is sliced, split and
+ * scanned only from the line still being written, each complete line is parsed
+ * once into an append-only chunk list, and an open construct accumulates its
+ * lines the same way instead of being re-read. Nothing already rendered is
+ * re-parsed, re-walked or moved.
  */
 export function advanceMdStream(state: MdStreamState, text: string, streaming: boolean): ReactNode {
   if (state.rendered !== null && text === state.source && streaming === state.streaming) return state.rendered;
-  if (!reusable(state, text, streaming)) {
-    state.settledChars = 0;
-    state.settledLines = 0;
-    state.lineStart = true;
-    state.blocks = [];
-    state.droppedNewline = false;
-    state.revision++;
-  }
-  const base = state.settledLines;
-  const rest = text.slice(state.settledChars);
+  if (!reusable(state, text, streaming) && !recoverTrim(state, text, streaming)) resetMdStream(state);
+
+  const rest = text.slice(state.stableChars);
   const lines = rest.split("\n");
-  const settled = streaming ? settledLineCount(lines) : lines.length;
-  state.scannedChars += rest.length;
-  if (settled > 0) {
-    pushBlocks(state.blocks, lines, 0, settled, base);
-    let chars = 0;
-    for (let i = 0; i < settled; i++) chars += lines[i].length + 1;
-    /* The last line of a completed item ends the text instead of a newline. */
-    state.lineStart = state.settledChars + chars <= text.length;
-    state.settledChars = Math.min(state.settledChars + chars, text.length);
-    state.settledLines += settled;
-    state.anchor = text.slice(Math.max(0, state.settledChars - ANCHOR), state.settledChars);
-    state.parsedLines += settled;
-    /* pushBlocks has re-established the separator itself. */
-    state.droppedNewline = false;
-    state.revision++;
+  const complete = streaming ? lines.length - 1 : lines.length;
+  let from = state.stableChars;
+  for (let i = 0; i < complete; i++) {
+    consume(state, lines[i], from);
+    from += lines[i].length + 1;
+    state.provisional = false;
   }
-  let pending: ReactNode[] | null = null;
-  if (settled < lines.length) {
-    pending = [];
-    const block = pushPending(pending, lines, settled, base);
-    /* A pending block element sheds the separator the prefix left behind — and
-       takes it back if the next delta turns it into ordinary text again, which
-       is what an unfinished line reopening a fence does. */
-    if (block && state.blocks[state.blocks.length - 1] === "\n") {
-      state.blocks.pop();
-      state.droppedNewline = true;
-      state.revision++;
-    } else if (!block && state.droppedNewline) {
-      state.blocks.push("\n");
-      state.droppedNewline = false;
-      state.revision++;
+  if (complete > 0) {
+    state.lineStart = from <= text.length;
+    state.stableChars = Math.min(from, text.length);
+    state.stableLines += complete;
+    state.anchor = text.slice(Math.max(0, state.stableChars - ANCHOR), state.stableChars);
+  }
+  /* A completed message ends where it ends: an unclosed fence or a trailing run
+     becomes its block, exactly as the transcript pass renders it. */
+  if (!streaming && state.run) closeRun(state);
+
+  let volatile_: ReactNode = null;
+  if (streaming) {
+    const last = lines[lines.length - 1];
+    /* A message can stop ON its closing fence: that line has no newline yet,
+       but the code between the fences is complete, and leaving the last block
+       of an answer raw until the turn settles is the visible defect. */
+    const closes = state.run?.kind === "fence" && FENCE_CLOSE_RE.test(last);
+    if (closes !== state.provisional) {
+      paintRun(state, closes);
+      state.provisional = closes;
+    }
+    if (!closes) {
+      const parts: ReactNode[] = [];
+      if (state.sep) parts.push("\n");
+      /* Inside a fence the tail is code; elsewhere the inline pass renders it,
+         degrading to plain text for anything whose closer has not arrived. */
+      parts.push(state.run?.kind === "fence"
+        ? <Fragment key="v">{last}</Fragment>
+        : <Fragment key="v">{md(last)}</Fragment>);
+      volatile_ = parts;
     }
   }
-  let tree: ReactNode = <SettledPrefix nodes={state.blocks} revision={state.revision} />;
-  if (pending) tree = <>{tree}{pending}</>;
+
+  const tree = <>{regionNodes(state.region)}{volatile_}</>;
   state.source = text;
   state.streaming = streaming;
   state.rendered = tree;
@@ -538,9 +697,9 @@ export function advanceMdStream(state: MdStreamState, text: string, streaming: b
  * live turn lands.
  */
 export function StreamingMd({ text, streaming }: { text: string; streaming: boolean }): ReactNode {
-  /* A memo of the props, held in state because it is grown across renders and
-     must survive every one of them. Advancing it is idempotent, so a repeated
-     render of the same text yields the same tree. */
+  /* Held in state because it is grown across renders and must survive every one
+     of them. Advancing it is idempotent, so a repeated render of the same text
+     returns the same tree. */
   const [stream] = useState(createMdStream);
   return advanceMdStream(stream, text, streaming);
 }

--- a/src/components/feed/markdown.tsx
+++ b/src/components/feed/markdown.tsx
@@ -246,38 +246,39 @@ function lineNode(line: string, key: number | string): ReactNode {
   return <Fragment key={key}>{md(line)}</Fragment>;
 }
 
-/* Block-level pass over `lines[from, to)`, appended to `out`. `lines` may be a
-   TAIL of the document starting at absolute line `base`: every node is keyed by
-   its absolute index and the trailing-newline bookkeeping reads `out` rather
-   than local state, so a document can be rendered in several append-only slices
-   and still come out identical to a single pass. That is what lets the
-   streaming renderer below parse only what has just arrived. */
-function pushBlocks(out: ReactNode[], lines: string[], from: number, to: number, base = 0): void {
-  let i = from;
-  while (i < to) {
+/* Block-level pass for whole prose messages rendered inside whitespace-pre-wrap:
+   newlines survive as text; tables group into real <table>, headings and
+   blockquotes are styled per line, everything else goes through the inline pass.
+   This is the settled rendering — the one a transcript row shows and the one
+   the streaming machine below has to arrive at exactly. */
+export function mdBlocks(text: string): ReactNode {
+  const lines = text.split("\n");
+  const out: ReactNode[] = [];
+  let i = 0;
+  while (i < lines.length) {
     if (FENCE_OPEN_RE.test(lines[i])) {
       const start = i;
       const lang = fenceLang(lines[i]);
       i++;
-      while (i < to && !FENCE_CLOSE_RE.test(lines[i])) i++;
+      while (i < lines.length && !FENCE_CLOSE_RE.test(lines[i])) i++;
       const code = lines.slice(start + 1, i).join("\n");
-      if (i < to) i++;
+      if (i < lines.length) i++;
       if (out[out.length - 1] === "\n") out.pop();
-      out.push(<CodeBlock key={`c${base + start}`} code={code} lang={lang} />);
+      out.push(<CodeBlock key={`c${start}`} code={code} lang={lang} />);
       continue;
     }
     if (TABLE_ROW_RE.test(lines[i])) {
       const start = i;
-      while (i < to && TABLE_ROW_RE.test(lines[i])) i++;
+      while (i < lines.length && TABLE_ROW_RE.test(lines[i])) i++;
       /* The table div is a block element: the pending newline would add an empty row. */
       if (out[out.length - 1] === "\n") out.pop();
-      out.push(<MdTable key={`t${base + start}`} rows={lines.slice(start, i)} />);
+      out.push(<MdTable key={`t${start}`} rows={lines.slice(start, i)} />);
       continue;
     }
     if (IMAGE_LINE_RE.test(lines[i])) {
       const start = i;
       const images: { alt: string; src: string }[] = [];
-      while (i < to) {
+      while (i < lines.length) {
         const m = lines[i].match(IMAGE_LINE_RE);
         if (!m) break;
         images.push({ alt: m[1], src: m[2] });
@@ -285,24 +286,13 @@ function pushBlocks(out: ReactNode[], lines: string[], from: number, to: number,
       }
       /* The row is a block element: drop the pending newline before it. */
       if (out[out.length - 1] === "\n") out.pop();
-      out.push(<MdImageRow key={`i${base + start}`} images={images} />);
+      out.push(<MdImageRow key={`i${start}`} images={images} />);
       continue;
     }
-    out.push(lineNode(lines[i], base + i));
+    out.push(lineNode(lines[i], i));
     i++;
-    /* The newline belongs to the document, not to the slice: a slice that stops
-       short of the end is followed by more lines, so it keeps its separator. */
     if (i < lines.length) out.push("\n");
   }
-}
-
-/* Block-level pass for whole prose messages rendered inside whitespace-pre-wrap:
-   newlines survive as text; tables group into real <table>, headings and
-   blockquotes are styled per line, everything else goes through the inline pass. */
-export function mdBlocks(text: string): ReactNode {
-  const lines = text.split("\n");
-  const out: ReactNode[] = [];
-  pushBlocks(out, lines, 0, lines.length);
   return out;
 }
 
@@ -320,7 +310,8 @@ export function mdBlocks(text: string): ReactNode {
 
 /** Nodes per chunk: the ceiling on what one settled line can make React redo. */
 const CHUNK = 48;
-/** Text kept before the boundary to recognise the message on the next delta. */
+/** Text kept before the boundary, to PROPOSE where a head-trim moved it to.
+    Never evidence on its own — every proposal is verified against the text. */
 const ANCHOR = 128;
 
 /* A run of already-rendered nodes. A chunk's element is re-created only when
@@ -565,19 +556,22 @@ function consume(state: MdStreamState, line: string, from: number): void {
 }
 
 /**
- * Whether what has been consumed still describes the head of `text`.
+ * Whether what has been rendered still describes the head of `text`.
  *
- * Deltas append, and re-reading the message to prove it would put the
- * accumulated length back into every delta. While streaming the proof is the
- * anchor window ending at the boundary plus monotone length; the completion
- * call, the one that can legitimately carry rewritten text, is checked exactly.
+ * This is checked EXACTLY, against the whole text the nodes were built from.
+ * A fixed window is not evidence: 128 chars of repeated log lines, boilerplate
+ * or a spinner alias trivially, and a message that matched at a stale offset
+ * would keep rendering lines it no longer contains — a divergence that grows
+ * and never heals. One native comparison per delta is the price, and it is the
+ * comparison, not a re-parse: what a reused frame costs stays flat.
  */
-function reusable(state: MdStreamState, text: string, streaming: boolean): boolean {
+function reusable(state: MdStreamState, text: string): boolean {
   if (state.stableChars === 0) return true;
-  if (!state.lineStart || text.length < state.stableChars) return false;
-  if (!streaming) return text.startsWith(state.source.slice(0, state.stableChars));
-  return text.length >= state.source.length
-    && text.slice(Math.max(0, state.stableChars - ANCHOR), state.stableChars) === state.anchor;
+  if (!state.lineStart || text.length < state.source.length) return false;
+  /* The boundary is a line start by construction; if it is not, the state is
+     not describing this text and nothing may be reused from it. */
+  if (text.charCodeAt(state.stableChars - 1) !== 10) return false;
+  return text.startsWith(state.source);
 }
 
 /**
@@ -591,10 +585,12 @@ function reusable(state: MdStreamState, text: string, streaming: boolean): boole
  * ends inside a construct, the trim has changed how the rest reads, and nothing
  * is reused.
  *
- * Only a streaming delta is recovered: the completion call is the one that can
- * legitimately carry rewritten text, and a rewrite that happened to keep the
- * anchor would be mistaken for a shift. A caller MUST reset the stream when
- * this returns false — it shifts the chunk offsets before it can know.
+ * The anchor only PROPOSES a shift — a window can alias, so the proposal is
+ * then verified exactly against the text it claims to describe, and a shift
+ * that does not hold up is no shift at all. Only a streaming delta is
+ * recovered: the completion call is the one that can legitimately carry
+ * rewritten text. A caller MUST reset the stream when this returns false — it
+ * shifts the chunk offsets before it can know.
  */
 function recoverTrim(state: MdStreamState, text: string, streaming: boolean): boolean {
   if (!streaming || !state.anchor || !state.lineStart) return false;
@@ -603,6 +599,7 @@ function recoverTrim(state: MdStreamState, text: string, streaming: boolean): bo
   const stable = at + state.anchor.length;
   const shift = state.stableChars - stable;
   if (shift <= 0) return false;
+  if (!text.startsWith(state.source.slice(shift))) return false;
   const chunks = state.region.chunks;
   for (const chunk of chunks) chunk.from -= shift;
   const keep = chunks.findIndex((chunk) => chunk.from >= 0);
@@ -640,7 +637,7 @@ function recoverTrim(state: MdStreamState, text: string, streaming: boolean): bo
  */
 export function advanceMdStream(state: MdStreamState, text: string, streaming: boolean): ReactNode {
   if (state.rendered !== null && text === state.source && streaming === state.streaming) return state.rendered;
-  if (!reusable(state, text, streaming) && !recoverTrim(state, text, streaming)) resetMdStream(state);
+  if (!reusable(state, text) && !recoverTrim(state, text, streaming)) resetMdStream(state);
 
   const rest = text.slice(state.stableChars);
   const lines = rest.split("\n");
@@ -676,10 +673,12 @@ export function advanceMdStream(state: MdStreamState, text: string, streaming: b
       const parts: ReactNode[] = [];
       if (state.sep) parts.push("\n");
       /* Inside a fence the tail is code; elsewhere the inline pass renders it,
-         degrading to plain text for anything whose closer has not arrived. */
-      parts.push(state.run?.kind === "fence"
-        ? <Fragment key="v">{last}</Fragment>
-        : <Fragment key="v">{md(last)}</Fragment>);
+         degrading to plain text for anything whose closer has not arrived.
+         A line that is nothing BUT an image is left as text too: it becomes a
+         thumbnail row when its newline lands, and embedding it inline first
+         would only mount the image to throw it away a moment later. */
+      const verbatim = state.run?.kind === "fence" || IMAGE_LINE_RE.test(last);
+      parts.push(<Fragment key="v">{verbatim ? last : md(last)}</Fragment>);
       volatile_ = parts;
     }
   }


### PR DESCRIPTION
## What was wrong

While an agent was answering, its text showed raw — asterisks around bold, tables as pipes and dashes, list markers literal. Once the transcript echo replaced the live row the same text rendered properly, so a message visibly changed appearance. The renderer already handled all of it; the live path simply did not use it.

## How it was fixed, round by round

**`f2e9dbbd`** routes live turn rows through the same markdown pass the settled transcript rows use, so the two renderings agree.

**`8184b949`** — the first attempt at incremental streaming: advance from the last stable boundary instead of re-parsing the accumulated text.

**`3e30f2a6`** — that boundary froze at the *start* of a volatile construct, so an open code fence, table or image run was fully re-scanned every token. Measured across a stream: a 900-line open fence scanned 186,903,085 characters (306 ms) against 202,982 (10 ms) for the same volume of settled prose, and the worst single delta on a 19 KB block scanned 18,981 of its 19,005 characters. Since an agent streaming a patch is the common case here, this was the case that mattered. The stream is now consumed line by line and never re-read, and blocks no longer remount when they cross from pending to settled.

**`5a138ea7`** — the reuse fast path trusted a 128-character anchor alone. Past the 64 KiB live-turn bound the projection head-trims on every delta, so those offsets are load-bearing on the longest answers; with repeated content at the writing frontier — identical log lines, repeated table rows, a spinner — the anchor aliased, no shift was applied, and the row froze its head while the projection advanced, wrong on 35 of 40 deltas and never self-healing. A reused frame is now proven against the text it claims to describe, and falls back to a full re-render when the evidence is insufficient.

## Review

Three independent read-only rounds: APPROVE with comments, REQUEST_CHANGES on the two performance majors, REQUEST_CHANGES on the correctness high, then **APPROVE** with one low and three nits. Each round backed its finding with measurements or a reproduction rather than argument.

## Verification

Touched tests pass by path, `tsc --noEmit` clean, lint adds no new problems, privacy gate green. The settled rendering stays byte-identical to the transcript pass.

Closes #676