### PR TITLE
feat(codex): grant Computer Use to operator root sessions only (#687)

### DIFF
--- a/docs/design/computer-use-grant.md
+++ b/docs/design/computer-use-grant.md
@@ -1,0 +1,103 @@
+# Computer Use for operator root Codex sessions (issue #687)
+
+Codex plugins are installed and enabled globally in the operator's
+`config.toml`. Hosted Viewer sessions have always suppressed the whole plugin
+subsystem (`features.plugins: false` in the per-thread configuration), so no
+hosted session ever saw a plugin tool. This design grants exactly one plugin —
+`computer-use` — to the sessions the operator launches for themselves, and to
+nothing else. The Viewer never edits the operator's Codex configuration and
+never enables plugins for the app-server as a whole.
+
+## Who gets it
+
+| session | grant |
+| --- | --- |
+| operator-launched root Codex session | `["computer-use"]` by default |
+| same session, launched with `plugins: []` | none (explicit opt-out) |
+| delegated: agent-initiated spawn, lineage parent, or any role preset (builder, reviewer, verifier, pipeline helper) | none |
+| any Claude session | none — plugins are a Codex thread capability |
+
+`sessionOriginFor` in `src/lib/agent/pluginAllowlist.ts` classifies the launch.
+It is fail-closed: a non-operator origin, a lineage parent, a role preset, a
+non-zero delegation depth, or an unrecognized origin kind all mean *delegated*.
+
+The grant for a delegated session is the constant `DELEGATED_PLUGINS`, empty in
+this slice. Delegated grants are a separate decision; expressing a different
+answer later is a change to that list, not to the surrounding structure.
+
+## Why it cannot widen
+
+Three independent bounds, all on the same allowlist:
+
+1. `normalizeSpawnPlugins` rejects any requested name outside
+   `GRANTABLE_PLUGINS` — `*`, `all`, and any other plugin are 400s, never
+   trimmed silently.
+2. `pluginAllowlistForSession` returns the policy default for the origin
+   *narrowed* by the request. A request can deny a grant; it can never create
+   one, so nothing is inheritable down a spawn chain.
+3. `emptyLaunchProfile`, `headlessCodexThreadConfig` and the structured host all
+   re-validate against `GRANTABLE_PLUGINS`, so a hand-edited durable profile
+   cannot smuggle a plugin into a thread.
+
+## What Codex actually honours
+
+Probed against Codex CLI 0.145.0 with two threads inside a single app-server
+process, comparing `mcpServerStatus/list` per thread:
+
+- `config.features.plugins` on `thread/start` **is** per-thread. The thread that
+  passed `false` gained no plugin server; the thread that passed `true` gained
+  the `computer-use` MCP server, in the same process, at the same time.
+- the per-thread `config.plugins` table is accepted without error but **is not
+  applied**: enabling or disabling entries there does not change the plugin
+  surface, and even `plugins.<id>.enabled=false` in the effective configuration
+  does not stop a bundled plugin server once the feature flag is on.
+
+So the Viewer sends the `plugins` table as the declarative record of the grant —
+correct the day Codex applies it — and does not rely on it. Enforcement is a
+verification step: after a granted thread starts, `CodexAppServerHost` lists the
+thread's MCP servers and refuses to open if any server outside the thread's own
+configured table and the granted plugins' server names appeared. A grant that
+cannot be verified is not granted, so a widened surface fails the launch instead
+of reaching the model.
+
+## Desktop environment
+
+A granted host also receives an enumerated set of desktop-session variables that
+the bundled Computer Use backend reads: `DISPLAY`, `XAUTHORITY`,
+`WAYLAND_DISPLAY`, `XDG_SESSION_TYPE`, `XDG_CURRENT_DESKTOP`, `DESKTOP_SESSION`.
+`XDG_RUNTIME_DIR` and `DBUS_SESSION_BUS_ADDRESS` are equally required and were
+already forwarded to every host. Nothing else is added — in particular no
+input-backend variable such as `YDOTOOL_SOCKET`. A session without a grant gets
+no desktop variables at all.
+
+## Resume and handoff
+
+The grant is decided once, at spawn, and stored on the durable launch profile.
+
+- **Resume / restart adoption**: the stored value is replayed
+  (`mergeResumeLaunchProfile` keeps the current profile's `plugins`, startup
+  adoption passes `launchProfile.plugins`). A resume can therefore never widen
+  the grant, and a running session is never restarted to change it.
+- **Handoff / successor**: a successor is admitted through the same path, and a
+  delegated conversation — one carrying a role preset or a lineage parent — has
+  its grant cleared at admission regardless of what its profile claims.
+- **Sessions that pre-date this change** carry no `plugins` value, which
+  normalizes to none. They acquire the tool only by an explicit controlled
+  resume with a profile that carries the grant.
+
+## Tests
+
+- `src/lib/agent/pluginAllowlist.test.ts` — origin policy, default-on for root,
+  opt-out, delegated denial, and the widening rejections.
+- `src/lib/codexHeadlessConfig.test.ts` — the thread configuration a grant
+  produces, and the absence of a plugin table without one.
+- `src/lib/runtime/codexAppServerHost.pluginGrant.test.ts` — thread
+  configuration, desktop environment scoping, and the two fail-closed
+  verification paths.
+- `src/app/api/spawn/route.test.ts` — the durable profile a spawn request
+  produces for each session class.
+- `src/lib/agent/registry.admission.test.ts` — a delegated conversation cannot
+  acquire the grant at admission.
+
+No automated test performs a desktop input action; validation is limited to the
+read-only surface (tool inventory, window list, screenshot).

--- a/src/app/api/spawn/route.test.ts
+++ b/src/app/api/spawn/route.test.ts
@@ -134,6 +134,87 @@ test("spawn admission persists Viewer-only defaults and normalized custom MCP al
   }
 });
 
+test("spawn admission grants Computer Use to an operator root Codex session only (#687)", async () => {
+  const cwd = fs.mkdtempSync(path.join(routeSandbox, "plugin-grant-"));
+  const store = registry();
+  const previousTransport = process.env.LLV_SPAWN_TRANSPORT;
+  const previousHosts = process.env.LLV_STRUCTURED_HOSTS;
+  const previousEvents = process.env.LLV_RUNTIME_EVENTS;
+  const previousSocket = process.env.LLV_RUNTIME_HOST_SOCKET;
+  const previousUi = process.env.NEXT_PUBLIC_RUNTIME_UI;
+  const previousBinary = process.env.LLV_CODEX_BINARY;
+  process.env.LLV_SPAWN_TRANSPORT = "structured";
+  process.env.LLV_STRUCTURED_HOSTS = "1";
+  process.env.LLV_RUNTIME_EVENTS = "1";
+  process.env.LLV_RUNTIME_HOST_SOCKET = path.join(cwd, "runtime.sock");
+  process.env.NEXT_PUBLIC_RUNTIME_UI = "1";
+  /* Codex MCP enumeration shells out to the real CLI; a stub keeps this test
+     off the operator's Codex installation and its account state. */
+  const codexStub = path.join(cwd, "codex-stub.sh");
+  fs.writeFileSync(codexStub, "#!/bin/sh\nprintf '[]'\n", { mode: 0o700 });
+  process.env.LLV_CODEX_BINARY = codexStub;
+  try {
+    const base = structuredRouteDependencies(cwd);
+    const codexAccount = {
+      engine: "codex" as const,
+      accountId: "codex-test",
+      kind: "managed" as const,
+      home: path.join(cwd, "account"),
+      transcriptRoot: path.join(cwd, "sessions"),
+      env: { CODEX_HOME: path.join(cwd, "account"), NODE_ENV: "test" as const },
+    };
+    const dependencies = {
+      ...base,
+      registry: () => store,
+      resolveHealthySpawnAccount: async () => codexAccount,
+      resolveSpawnAccount: () => codexAccount,
+    };
+    const capability = rotateOperatorSpawnCapability();
+    const post = async (clientAttemptId: string, extra: Record<string, unknown>) => POST.withDependencies(new NextRequest("http://127.0.0.1/api/spawn", {
+      method: "POST",
+      headers: {
+        origin: "http://127.0.0.1",
+        host: "127.0.0.1",
+        "content-type": "application/json",
+        "sec-fetch-site": "same-origin",
+        "x-llv-spawn-capability": capability,
+      },
+      body: JSON.stringify({ engine: "codex", cwd, prompt: "inspect", clientAttemptId, ...extra }),
+    }), dependencies);
+
+    const rootResponse = await post("plugins_root_20260726", {});
+    expect({ status: rootResponse.status, body: await rootResponse.clone().json() }).toMatchObject({ status: 202 });
+    expect((await post("plugins_role_20260726", { role: "builder" })).status).toBe(202);
+    expect((await post("plugins_optout_20260726", { plugins: [] })).status).toBe(202);
+
+    /* Default-on for the operator's own root session… */
+    expect(store.spawnReceiptForClientAttempt("plugins_root_20260726")?.launchProfile.plugins).toEqual(["computer-use"]);
+    /* …off for a delegated helper, even from the operator's own lane… */
+    expect(store.spawnReceiptForClientAttempt("plugins_role_20260726")?.launchProfile.plugins).toEqual([]);
+    /* …and off when the operator opts this root session out. */
+    expect(store.spawnReceiptForClientAttempt("plugins_optout_20260726")?.launchProfile.plugins).toEqual([]);
+
+    const widened = await post("plugins_widened_20260726", { plugins: ["browser"] });
+    expect(widened.status).toBe(400);
+    expect(await widened.json()).toMatchObject({ error: expect.stringContaining("browser") });
+    const everything = await post("plugins_star_20260726", { plugins: ["*"] });
+    expect(everything.status).toBe(400);
+  } finally {
+    if (previousTransport === undefined) delete process.env.LLV_SPAWN_TRANSPORT;
+    else process.env.LLV_SPAWN_TRANSPORT = previousTransport;
+    if (previousHosts === undefined) delete process.env.LLV_STRUCTURED_HOSTS;
+    else process.env.LLV_STRUCTURED_HOSTS = previousHosts;
+    if (previousEvents === undefined) delete process.env.LLV_RUNTIME_EVENTS;
+    else process.env.LLV_RUNTIME_EVENTS = previousEvents;
+    if (previousSocket === undefined) delete process.env.LLV_RUNTIME_HOST_SOCKET;
+    else process.env.LLV_RUNTIME_HOST_SOCKET = previousSocket;
+    if (previousUi === undefined) delete process.env.NEXT_PUBLIC_RUNTIME_UI;
+    else process.env.NEXT_PUBLIC_RUNTIME_UI = previousUi;
+    if (previousBinary === undefined) delete process.env.LLV_CODEX_BINARY;
+    else process.env.LLV_CODEX_BINARY = previousBinary;
+  }
+});
+
 test("a materialized structured child is offered for pipeline attempt adoption", async () => {
   const cwd = fs.mkdtempSync(path.join(routeSandbox, "pipeline-adoption-"));
   const store = registry();

--- a/src/lib/accounts/migration/contracts.ts
+++ b/src/lib/accounts/migration/contracts.ts
@@ -1,5 +1,6 @@
 import type { AgentEngine } from "@/lib/agent/cli";
 import { normalizeSpawnMcpServers } from "@/lib/agent/mcpAllowlist";
+import { grantedPlugins } from "@/lib/agent/pluginAllowlist";
 import type { StructuredImageRef } from "@/lib/runtime/structuredContent";
 import type { AgentGoal, AgentPlan, EngineLimits, LimitsProvenance } from "@/lib/types";
 
@@ -58,6 +59,10 @@ export interface LaunchProfile {
   readOnly: boolean | null;
   allowSubagents: boolean;
   mcpServers: string[];
+  /** Codex plugins granted to this session (issue #687). Decided once, at
+      spawn, from the session's origin; a resume replays it and can never
+      widen it. Empty for every delegated session. */
+  plugins: string[];
   title: string | null;
   project: string | null;
   parentConversationId: ViewerConversationId | null;
@@ -84,6 +89,9 @@ export function emptyLaunchProfile(overrides: Partial<LaunchProfile> = {}): Laun
     plan: null,
     ...overrides,
     mcpServers: mcpServers.ok ? mcpServers.value : ["viewer"],
+    /* The grant bound is enforced again here: a durable profile can only ever
+       carry plugins the Viewer is allowed to grant (issue #687). */
+    plugins: grantedPlugins(overrides.plugins),
   };
 }
 

--- a/src/lib/agent/cli.ts
+++ b/src/lib/agent/cli.ts
@@ -9,6 +9,7 @@ import { claudeHomeOwningTranscript, claudeSettingsPath, isManagedClaudeHome, le
 
 import { claudeTranscriptPath, headCwd } from "./transcript";
 import { normalizeSpawnMcpServers } from "./mcpAllowlist";
+import { grantedPlugins } from "./pluginAllowlist";
 import { normalizeClaudeLaunchModel } from "./models";
 import { applyClaudeSpawnPolicy, claudeSpawnPolicyPaths, VIEWER_SPAWN_CAPABILITY_ENV } from "./spawnPolicy";
 import type { LaunchProfile } from "@/lib/accounts/migration/contracts";
@@ -147,6 +148,10 @@ export interface ResumeSpecOptions {
   permissionMode?: string | null;
   allowSubagents?: boolean;
   mcpServers?: readonly string[];
+  /** Codex plugin grant replayed from the conversation's durable profile
+      (issue #687). A resume is the controlled path by which an existing
+      session picks the grant up; absent ⇒ no plugin, the default. */
+  plugins?: readonly string[];
   /** The conversation's authoritative working directory. When set it is the ONE
       effective cwd used for MCP policy enumeration, materialization, and the
       rendered command. The resume spec otherwise re-derives cwd by sniffing the
@@ -260,6 +265,10 @@ export function freshSpecFor(engine: AgentEngine, cwd: string, options: FreshSpe
         readOnly: options.readOnly ?? false,
         allowSubagents: options.allowSubagents ?? false,
         mcpServers,
+        /* Plugin grants are a Codex thread capability decided by the spawn
+           route from the session's origin (issue #687), never by the command
+           builder — a fresh spec carries none. */
+        plugins: [],
         title: null,
         project: null,
         parentConversationId: null,
@@ -293,6 +302,7 @@ export function freshSpecFor(engine: AgentEngine, cwd: string, options: FreshSpe
       readOnly: options.readOnly ?? false,
       allowSubagents: options.allowSubagents ?? false,
       mcpServers,
+      plugins: [],
       title: null,
       project: null,
       parentConversationId: null,
@@ -434,7 +444,7 @@ export function resumeSpecForSession(
       cwd,
       windowName: "claude-resume",
       engine: "claude",
-      launchProfile: { ...emptyLaunchProfileForResume(cwd, launchModel, options.effort ?? null), readOnly: options.readOnly ?? null, permissionMode, allowSubagents: options.allowSubagents ?? false, mcpServers },
+      launchProfile: { ...emptyLaunchProfileForResume(cwd, launchModel, options.effort ?? null), readOnly: options.readOnly ?? null, permissionMode, allowSubagents: options.allowSubagents ?? false, mcpServers, plugins: grantedPlugins(options.plugins) },
     };
   }
   let command = `${(options.hostTerminal ? resolveHostBinary : resolveBinary)("codex")}`;
@@ -454,7 +464,7 @@ export function resumeSpecForSession(
     cwd,
     windowName: "codex-resume",
     engine: "codex",
-    launchProfile: { ...emptyLaunchProfileForResume(cwd, options.model ?? null, options.effort ?? null), fast: options.fast ?? null, readOnly: options.readOnly ?? null, permissionMode: options.permissionMode ?? null, allowSubagents: options.allowSubagents ?? false, mcpServers },
+    launchProfile: { ...emptyLaunchProfileForResume(cwd, options.model ?? null, options.effort ?? null), fast: options.fast ?? null, readOnly: options.readOnly ?? null, permissionMode: options.permissionMode ?? null, allowSubagents: options.allowSubagents ?? false, mcpServers, plugins: grantedPlugins(options.plugins) },
   };
 }
 
@@ -468,6 +478,7 @@ function emptyLaunchProfileForResume(cwd: string, model: string | null, effort: 
     readOnly: null,
     allowSubagents: false,
     mcpServers: ["viewer"],
+    plugins: [],
     title: null,
     project: null,
     parentConversationId: null,

--- a/src/lib/agent/pluginAllowlist.test.ts
+++ b/src/lib/agent/pluginAllowlist.test.ts
@@ -1,0 +1,90 @@
+import { expect, test } from "bun:test";
+
+import {
+  GRANTABLE_PLUGINS,
+  grantedPluginServerNames,
+  grantedPlugins,
+  normalizeSpawnPlugins,
+  pluginAllowlistForSession,
+  sessionOriginFor,
+} from "./pluginAllowlist";
+
+test("an operator-launched root session is granted computer use by default", () => {
+  const origin = sessionOriginFor({ origin: { kind: "operator" } });
+  expect(origin).toBe("operator-root");
+  expect(pluginAllowlistForSession({ origin })).toEqual(["computer-use"]);
+});
+
+test("a root grant contains computer use and nothing else", () => {
+  const granted = pluginAllowlistForSession({ origin: "operator-root" });
+  expect(granted).toEqual(["computer-use"]);
+  expect(granted.every((name) => GRANTABLE_PLUGINS.includes(name))).toBe(true);
+});
+
+test("a Claude root session carries no Codex plugin grant", () => {
+  expect(pluginAllowlistForSession({ origin: "operator-root", engine: "claude" })).toEqual([]);
+  expect(pluginAllowlistForSession({ origin: "operator-root", engine: "codex" })).toEqual(["computer-use"]);
+});
+
+test("an operator root session opts out with an explicit empty allowlist", () => {
+  expect(pluginAllowlistForSession({ origin: "operator-root", requested: [] })).toEqual([]);
+});
+
+test("every delegated launch signal denies the grant", () => {
+  const delegated = [
+    { origin: { kind: "agent" } },
+    { origin: { kind: "container" } },
+    { origin: { kind: "operator" }, parentConversationId: "conversation_1" },
+    { origin: { kind: "operator" }, agentRole: "builder" },
+    { origin: { kind: "operator" }, agentRole: "reviewer" },
+    { origin: { kind: "operator" }, delegationDepth: 1 },
+  ];
+  for (const input of delegated) {
+    expect(sessionOriginFor(input)).toBe("delegated");
+    expect(pluginAllowlistForSession({ origin: "delegated" })).toEqual([]);
+  }
+});
+
+test("a delegated session cannot inherit the grant by asking for it", () => {
+  const origin = sessionOriginFor({ origin: { kind: "agent" }, parentConversationId: "conversation_1" });
+  expect(pluginAllowlistForSession({ origin, requested: ["computer-use"] })).toEqual([]);
+});
+
+test("an unknown origin kind is treated as delegated", () => {
+  expect(sessionOriginFor({ origin: { kind: "successor" } })).toBe("delegated");
+});
+
+test("a request can never widen the allowlist to every plugin", () => {
+  for (const requested of [["*"], ["all"], ["computer-use", "browser"], ["chrome"], ["computer-use", "*"]]) {
+    const normalized = normalizeSpawnPlugins(requested);
+    expect(normalized.ok).toBe(false);
+  }
+});
+
+test("a rejected plugin name is reported rather than silently dropped", () => {
+  const normalized = normalizeSpawnPlugins(["computer-use", "browser"]);
+  expect(normalized).toMatchObject({ ok: false });
+  if (!normalized.ok) expect(normalized.error).toContain("browser");
+});
+
+test("an absent request leaves the decision to policy and an empty one opts out", () => {
+  expect(normalizeSpawnPlugins(undefined)).toEqual({ ok: true, value: null });
+  expect(normalizeSpawnPlugins([])).toEqual({ ok: true, value: [] });
+  expect(normalizeSpawnPlugins(["computer-use", "computer-use"])).toEqual({ ok: true, value: ["computer-use"] });
+});
+
+test("a malformed request is rejected", () => {
+  expect(normalizeSpawnPlugins("computer-use")).toMatchObject({ ok: false });
+  expect(normalizeSpawnPlugins([1])).toMatchObject({ ok: false });
+});
+
+test("a stored profile cannot smuggle a plugin past the grant bound", () => {
+  expect(grantedPlugins(["computer-use", "browser", "*"])).toEqual(["computer-use"]);
+  expect(grantedPlugins(undefined)).toEqual([]);
+  expect(grantedPlugins("computer-use" as unknown as string[])).toEqual([]);
+});
+
+test("a grant maps to the MCP servers its plugins may contribute", () => {
+  expect(grantedPluginServerNames(["computer-use"])).toEqual(["computer-use"]);
+  expect(grantedPluginServerNames([])).toEqual([]);
+});

--- a/src/lib/agent/pluginAllowlist.ts
+++ b/src/lib/agent/pluginAllowlist.ts
@@ -1,0 +1,130 @@
+/**
+ * Per-session Codex plugin grants (issue #687).
+ *
+ * Codex plugins are installed and enabled globally in the operator's
+ * `config.toml`. The Viewer never touches that file and never turns the plugin
+ * subsystem on for every session: a grant is decided per session here, carried
+ * on the durable launch profile, and applied to the thread configuration of a
+ * single structured host.
+ *
+ * The grant is expressed as an allowlist of plugin names. Two properties hold
+ * for every path into this module:
+ *
+ *  - nothing outside {@link GRANTABLE_PLUGINS} can ever be granted, so no
+ *    caller can widen a session to "all installed plugins";
+ *  - a request can only narrow the policy default, never widen it, so a
+ *    delegated session cannot inherit a grant through a spawn chain.
+ */
+
+/** Outer bound of the mechanism: the only plugins the Viewer can grant at all.
+    Everything the operator has installed stays off unless it is listed here. */
+export const GRANTABLE_PLUGINS: readonly string[] = Object.freeze(["computer-use"]);
+
+/** What an operator-launched root Codex session receives when it does not opt
+    out. Computer Use is the default capability of that whole session class —
+    the operator does not ask for it per session. */
+export const OPERATOR_ROOT_PLUGINS: readonly string[] = Object.freeze(["computer-use"]);
+
+/** What a delegated session (subagent, builder, reviewer, pipeline helper)
+    receives. Empty in this slice by deliberate decision, not by structure:
+    delegated grants are decided separately, and expressing a different answer
+    later means changing this list — no branch elsewhere assumes it is empty. */
+export const DELEGATED_PLUGINS: readonly string[] = Object.freeze([]);
+
+/** MCP server names each grantable plugin contributes to a thread. Used to
+    verify the realized tool surface of a granted thread against the grant. */
+export const PLUGIN_MCP_SERVER_NAMES: Readonly<Record<string, readonly string[]>> = Object.freeze({
+  "computer-use": Object.freeze(["computer-use"]),
+});
+
+export type SpawnPluginsResult =
+  /** `null` means the request said nothing and the policy default applies. */
+  | { ok: true; value: string[] | null }
+  | { ok: false; error: string };
+
+/** Durable origin of a session, as recorded on its spawn receipt. */
+export type SessionOrigin = "operator-root" | "delegated";
+
+export interface SessionOriginInput {
+  /** Initiating origin recorded at admission (#393). */
+  origin?: { kind: string } | null;
+  /** Lineage parent, if the launch named one. */
+  parentConversationId?: string | null;
+  /** Role preset id — every preset launch is a delegated helper. */
+  agentRole?: string | null;
+  /** Delegation depth computed at admission (#393): 0 for roots. */
+  delegationDepth?: number | null;
+}
+
+/**
+ * Classifies a launch as an operator-launched root session or a delegated one.
+ * Fail-closed: anything that carries a delegation signal — a non-operator
+ * origin, a lineage parent, a role preset, or a non-zero delegation depth — is
+ * delegated, and an unknown origin kind is delegated too.
+ */
+export function sessionOriginFor(input: SessionOriginInput): SessionOrigin {
+  const originKind = input.origin?.kind;
+  if (originKind !== undefined && originKind !== "operator") return "delegated";
+  if (input.parentConversationId) return "delegated";
+  if (input.agentRole) return "delegated";
+  const depth = input.delegationDepth;
+  if (typeof depth === "number" && depth !== 0) return "delegated";
+  return "operator-root";
+}
+
+/** Policy default for a session class, before any request narrows it. */
+export function defaultPluginsForOrigin(origin: SessionOrigin): readonly string[] {
+  return origin === "operator-root" ? OPERATOR_ROOT_PLUGINS : DELEGATED_PLUGINS;
+}
+
+/**
+ * Validates a requested plugin allowlist. `undefined` leaves the decision to
+ * policy; `[]` is the explicit opt-out. Any name outside
+ * {@link GRANTABLE_PLUGINS} — including wildcards such as `*` or `all` — is
+ * rejected rather than silently dropped, so a caller cannot smuggle a wider
+ * surface past validation.
+ */
+export function normalizeSpawnPlugins(value: unknown): SpawnPluginsResult {
+  if (value === undefined || value === null) return { ok: true, value: null };
+  if (!Array.isArray(value) || value.some((name) => typeof name !== "string")) {
+    return { ok: false, error: "plugins must be an array of plugin names" };
+  }
+  const names = value as string[];
+  const unknown = names.filter((name) => !GRANTABLE_PLUGINS.includes(name));
+  if (unknown.length > 0) {
+    return { ok: false, error: `plugins may only contain ${GRANTABLE_PLUGINS.join(", ")}; rejected: ${[...new Set(unknown)].join(", ")}` };
+  }
+  return { ok: true, value: [...new Set(names)] };
+}
+
+/**
+ * Final allowlist for a session: the policy default for its origin, narrowed
+ * by whatever the request asked for. The result is always a subset of both, so
+ * a request can deny a grant (the opt-out) but never create one.
+ */
+export function pluginAllowlistForSession(input: {
+  origin: SessionOrigin;
+  /** Plugins are a Codex thread capability; other engines never carry one. */
+  engine?: string;
+  requested?: readonly string[] | null;
+}): string[] {
+  if (input.engine !== undefined && input.engine !== "codex") return [];
+  const policy = defaultPluginsForOrigin(input.origin);
+  const granted = input.requested == null
+    ? policy
+    : policy.filter((name) => input.requested!.includes(name));
+  return granted.filter((name) => GRANTABLE_PLUGINS.includes(name));
+}
+
+/** Re-validates a stored allowlist on the way into a thread configuration.
+    Profiles are durable and can be edited by hand, so the bound is enforced
+    again at the point of use rather than trusted from storage. */
+export function grantedPlugins(value: readonly string[] | undefined | null): string[] {
+  if (!Array.isArray(value)) return [];
+  return [...new Set(value.filter((name) => GRANTABLE_PLUGINS.includes(name)))];
+}
+
+/** MCP server names a granted thread is allowed to gain from its plugins. */
+export function grantedPluginServerNames(granted: readonly string[]): string[] {
+  return [...new Set(granted.flatMap((name) => PLUGIN_MCP_SERVER_NAMES[name] ?? []))];
+}

--- a/src/lib/agent/registry.admission.test.ts
+++ b/src/lib/agent/registry.admission.test.ts
@@ -4,7 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import { afterAll, expect, test } from "bun:test";
 
-import type { ViewerConversationId } from "@/lib/accounts/migration/contracts";
+import { emptyLaunchProfile, type ViewerConversationId } from "@/lib/accounts/migration/contracts";
 
 const previousStateDir = process.env.LLV_STATE_DIR;
 const sandbox = fs.mkdtempSync(path.join(os.tmpdir(), "llv-registry-admission-"));
@@ -54,6 +54,53 @@ function spawnAtDepth(
   if (begun.kind !== "created") throw new Error("expected create");
   return { launchId: begun.receipt.launchId, conversationId: settleLaunch(store, begun.receipt.launchId) };
 }
+
+test("a delegated conversation never acquires a Codex plugin grant (#687)", () => {
+  const { store } = registryAt("plugin-grant-delegation");
+  const parent = store.ensureConversation("codex", "/sessions/plugin-grant-parent.jsonl", "terra");
+  /* A stored profile that claims the grant is overridden for every delegated
+     launch shape: a role preset, and a lineage parent. */
+  const claimed = { plugins: ["computer-use"] };
+  const roleLaunch = store.beginSpawnRequest({
+    engine: "codex",
+    cwd: "/repo",
+    role: "builder",
+    origin: { kind: "operator" },
+    launchProfile: emptyLaunchProfile({ cwd: "/repo", ...claimed }),
+  });
+  if (roleLaunch.kind !== "created") throw new Error("expected create");
+  const roleConversation = settleLaunch(store, roleLaunch.receipt.launchId);
+  const resumed = store.beginSpawnRequest({
+    engine: "codex",
+    cwd: "/repo",
+    conversationId: roleConversation,
+    purpose: "resume-successor",
+    origin: { kind: "operator" },
+    launchProfile: emptyLaunchProfile({ cwd: "/repo", ...claimed }),
+  });
+  if (resumed.kind !== "created") throw new Error("expected create");
+  expect(resumed.receipt.launchProfile.plugins).toEqual([]);
+
+  const childLaunch = store.beginSpawnRequest({
+    engine: "codex",
+    cwd: "/repo",
+    parentConversationId: parent.id,
+    origin: { kind: "agent", conversationId: parent.id },
+    launchProfile: emptyLaunchProfile({ cwd: "/repo", ...claimed }),
+  });
+  if (childLaunch.kind !== "created") throw new Error("expected create");
+  expect(childLaunch.receipt.launchProfile.plugins).toEqual([]);
+
+  /* The operator's own root session keeps the grant its spawn decided. */
+  const rootLaunch = store.beginSpawnRequest({
+    engine: "codex",
+    cwd: "/repo",
+    origin: { kind: "operator" },
+    launchProfile: emptyLaunchProfile({ cwd: "/repo", ...claimed }),
+  });
+  if (rootLaunch.kind !== "created") throw new Error("expected create");
+  expect(rootLaunch.receipt.launchProfile.plugins).toEqual(["computer-use"]);
+});
 
 test("a reviewer-origin launch is terminally rejected with a durable typed receipt and zero child artifacts", () => {
   const { store } = registryAt("reviewer-origin");

--- a/src/lib/agent/registry.ts
+++ b/src/lib/agent/registry.ts
@@ -647,6 +647,9 @@ function mergeResumeLaunchProfile(current: LaunchProfile, requested: LaunchProfi
     readOnly: requested.readOnly ?? current.readOnly,
     allowSubagents: current.allowSubagents || requested.allowSubagents,
     mcpServers: current.mcpServers,
+    /* The plugin grant was decided at spawn from the session's origin; a
+       resume replays the durable value and can never widen it (issue #687). */
+    plugins: current.plugins ?? [],
     title: requested.title ?? current.title,
     project: requested.project ?? current.project,
     parentConversationId: requested.parentConversationId ?? current.parentConversationId,
@@ -2252,6 +2255,7 @@ function compactLaunchProfile(profile: LaunchProfile): Partial<LaunchProfile> {
   if (compact.role === "worker") delete compact.role;
   if (compact.allowSubagents === false) delete compact.allowSubagents;
   if (compact.mcpServers?.length === 1 && compact.mcpServers[0] === "viewer") delete compact.mcpServers;
+  if (compact.plugins?.length === 0) delete compact.plugins;
   return compact;
 }
 
@@ -3134,6 +3138,10 @@ export class AgentRegistry {
          corrupted profile are both overridden here, so restart adoption and
          resume successors re-derive their launch flags from a denying profile. */
       if (isSpawnDeniedRole(existingConversation?.agentRole)) profile.allowSubagents = false;
+      /* A delegated conversation never acquires a plugin grant (#687): a role
+         preset or a lineage parent denies it on resume, successor and restart
+         adoption alike, whatever a stored or requested profile claims. */
+      if (existingConversation?.agentRole || parentConversationId) profile.plugins = [];
       if (existingConversation && existingConversation.engine !== input.engine) {
         throw new Error("spawn conversation ownership is invalid");
       }

--- a/src/lib/agent/spawnCommand.ts
+++ b/src/lib/agent/spawnCommand.ts
@@ -12,6 +12,7 @@ import { freshSpecFor, type AgentEngine } from "@/lib/agent/cli";
 import { agentRegistry, SpawnChildLimitError } from "@/lib/agent/registry";
 import { reasoningFromBody } from "@/lib/agent/efforts";
 import { normalizeSpawnMcpServers } from "@/lib/agent/mcpAllowlist";
+import { normalizeSpawnPlugins, pluginAllowlistForSession, sessionOriginFor } from "@/lib/agent/pluginAllowlist";
 import { codexModelSupportsImages, modelFromBody } from "@/lib/agent/models";
 import { resolveSpawnRole } from "@/lib/roles/registry";
 import { assertDarwinStructuredRuntime } from "@/lib/proc/darwinIdentity";
@@ -140,7 +141,7 @@ export async function executeSpawnRequest(
   const rejection = rejectCrossOrigin(req);
   if (rejection) return rejection;
 
-  let body: { engine?: unknown; model?: unknown; cwd?: unknown; prompt?: unknown; images?: unknown; src?: unknown; parent?: unknown; parentConversationId?: unknown; effort?: unknown; fast?: unknown; accountId?: unknown; clientAttemptId?: unknown; role?: unknown; roleParams?: unknown; confirm?: unknown; reviews?: unknown; allowSubagents?: unknown; mcpServers?: unknown; project?: unknown; supersedes?: unknown };
+  let body: { engine?: unknown; model?: unknown; cwd?: unknown; prompt?: unknown; images?: unknown; src?: unknown; parent?: unknown; parentConversationId?: unknown; effort?: unknown; fast?: unknown; accountId?: unknown; clientAttemptId?: unknown; role?: unknown; roleParams?: unknown; confirm?: unknown; reviews?: unknown; allowSubagents?: unknown; mcpServers?: unknown; plugins?: unknown; project?: unknown; supersedes?: unknown };
   try {
     body = (await req.json()) as typeof body;
   } catch {
@@ -149,6 +150,11 @@ export async function executeSpawnRequest(
 
   const mcpServers = normalizeSpawnMcpServers(body.mcpServers);
   if (!mcpServers.ok) return NextResponse.json({ error: mcpServers.error }, { status: 400 });
+  /* Requested plugin grant (issue #687). Absent leaves the decision to policy;
+     `[]` is the operator's explicit opt-out for this root session. Anything
+     outside the grantable set is rejected here, never trimmed silently. */
+  const requestedPlugins = normalizeSpawnPlugins(body.plugins);
+  if (!requestedPlugins.ok) return NextResponse.json({ error: requestedPlugins.error }, { status: 400 });
 
   const lineageError = agentSpawnLineageError(req, body);
   if (lineageError) return NextResponse.json({ error: lineageError }, { status: 400 });
@@ -326,6 +332,19 @@ export async function executeSpawnRequest(
       : null;
     const parentSessionKey = parent?.sessionKey ?? null;
     const parentArtifactPath = parent?.artifactPath ?? null;
+    /* Session-origin policy (issue #687): an operator-launched root session —
+       no agent caller, no lineage parent, no role preset — carries the Computer
+       Use grant by default; every delegated launch carries none, and the
+       request can only narrow that, never widen it. */
+    const plugins = pluginAllowlistForSession({
+      engine,
+      origin: sessionOriginFor({
+        origin: { kind: authenticatedCaller?.kind === "agent" ? "agent" : "operator" },
+        parentConversationId,
+        agentRole: role.value?.role ?? null,
+      }),
+      requested: requestedPlugins.value,
+    });
     const digest = spawnRequestDigest({
       engine,
       cwd,
@@ -335,6 +354,7 @@ export async function executeSpawnRequest(
       accountId: account.accountId,
       role: role.value?.role ?? null,
       mcpServers: mcpServers.value,
+      ...(plugins.length ? { plugins } : {}),
       ...(body.allowSubagents === true ? { allowSubagents: true } : {}),
       ...(explicitProject ? { project: explicitProject } : {}),
       parent: spawnParentSelector({ parentConversationId: parentConversationId ?? undefined }),
@@ -372,6 +392,7 @@ export async function executeSpawnRequest(
         parentConversationId,
         allowSubagents: body.allowSubagents === true,
         mcpServers: mcpServers.value,
+        plugins,
         permissionMode,
         ...(explicitProject ? { project: explicitProject } : {}),
       }),

--- a/src/lib/codexHeadlessConfig.test.ts
+++ b/src/lib/codexHeadlessConfig.test.ts
@@ -48,6 +48,51 @@ test("an operator-granted Codex thread enables native collaboration", () => {
   });
 });
 
+test("a granted thread enables the plugin subsystem for itself and allowlists only computer use", () => {
+  const config = headlessCodexThreadConfig({
+    config: {
+      mcp_servers: {},
+      plugins: {
+        "computer-use@openai-bundled": { enabled: true },
+        "browser@openai-bundled": { enabled: true },
+        "github@openai-curated": { enabled: true },
+      },
+    },
+  }, false, undefined, ["computer-use"]);
+  expect(config).toMatchObject({
+    features: { plugins: true, apps: false, multi_agent: false },
+    plugins: {
+      "computer-use@openai-bundled": { enabled: true },
+      "browser@openai-bundled": { enabled: false },
+      "github@openai-curated": { enabled: false },
+    },
+    include_apps_instructions: false,
+  });
+});
+
+test("a thread without a grant keeps the plugin subsystem off and carries no plugin table", () => {
+  const config = headlessCodexThreadConfig({
+    config: { mcp_servers: {}, plugins: { "computer-use@openai-bundled": { enabled: true } } },
+  }, false, undefined, []);
+  expect(config).toMatchObject({ features: { plugins: false } });
+  expect(config).not.toHaveProperty("plugins");
+});
+
+test("a thread configuration cannot be widened to every installed plugin", () => {
+  /* Whatever a stored profile claims, only grantable names reach the thread —
+     an unknown name never enables a plugin and never turns the subsystem on. */
+  const wide = headlessCodexThreadConfig({
+    config: { mcp_servers: {}, plugins: { "browser@openai-bundled": { enabled: true } } },
+  }, false, undefined, ["browser", "*"]);
+  expect(wide).toMatchObject({ features: { plugins: false } });
+  expect(wide).not.toHaveProperty("plugins");
+});
+
+test("a granted plugin missing from the effective config is still stated in the thread table", () => {
+  expect(headlessCodexThreadConfig({ config: { mcp_servers: {} } }, false, undefined, ["computer-use"]))
+    .toMatchObject({ plugins: { "computer-use": { enabled: true } } });
+});
+
 test("a Codex thread approves Viewer and retains optional server approval policy", () => {
   expect(headlessCodexThreadConfig({
     config: {

--- a/src/lib/codexHeadlessConfig.ts
+++ b/src/lib/codexHeadlessConfig.ts
@@ -1,5 +1,6 @@
 import { CODEX_VIEWER_SPAWN_FEATURES } from "@/lib/agent/spawnPolicy";
 import { normalizeSpawnMcpServers } from "@/lib/agent/mcpAllowlist";
+import { grantedPlugins } from "@/lib/agent/pluginAllowlist";
 
 type JsonObject = Record<string, unknown>;
 const MCP_APPROVAL_MODES = new Set(["auto", "prompt", "writes", "approve"]);
@@ -8,17 +9,37 @@ function record(value: unknown): JsonObject | null {
   return value && typeof value === "object" && !Array.isArray(value) ? value as JsonObject : null;
 }
 
+/** Per-plugin thread table for a granted session: every plugin Codex knows
+ *  about, with only the granted names enabled. Codex 0.145 accepts this table
+ *  on `thread/start` but resolves plugins from the global config instead, so it
+ *  is the declarative record of the grant — the realized surface is verified
+ *  against the same allowlist once the thread exists (`codexAppServerHost`). */
+function pluginTable(config: JsonObject, granted: readonly string[]): JsonObject {
+  const installed = record(config.plugins) ?? {};
+  const keys = new Set(Object.keys(installed));
+  /* Plugin ids are `<name>@<marketplace>`; the grant names the plugin only. */
+  for (const name of granted) {
+    if (![...keys].some((key) => key.split("@")[0] === name)) keys.add(name);
+  }
+  return Object.fromEntries([...keys].map((key) => [key, { enabled: granted.includes(key.split("@")[0]) }]));
+}
+
 /** Builds a fail-closed thread override from Codex's effective configuration. */
 export function headlessCodexThreadConfig(
   configRead: unknown,
   allowSubagents = false,
   mcpServers: readonly string[] | undefined = undefined,
+  plugins: readonly string[] | undefined = undefined,
 ): JsonObject {
   const config = record(record(configRead)?.config);
   const servers = record(config?.mcp_servers);
   if (!config || !servers) throw new Error("config/read returned no MCP server table");
   const normalized = normalizeSpawnMcpServers(mcpServers);
   const enabled = new Set(normalized.ok ? normalized.value : ["viewer"]);
+  /* The plugin subsystem is off for every session that holds no grant, which
+     is the default. A grant turns it on for THIS thread only — never for the
+     app-server, never in the operator's configuration. */
+  const granted = grantedPlugins(plugins);
   return {
     mcp_servers: Object.fromEntries(Object.entries(servers).map(([name, server]) => {
       const configuredApproval = record(server)?.default_tools_approval_mode;
@@ -35,7 +56,13 @@ export function headlessCodexThreadConfig(
     /* The per-thread features table replaces the app-server's global one, so
        the realtime flag the host passes via `--enable realtime_conversation`
        must be restated here or thread/realtime/start fails locally (#621). */
-    features: { ...CODEX_VIEWER_SPAWN_FEATURES, multi_agent: allowSubagents, realtime_conversation: true },
+    features: {
+      ...CODEX_VIEWER_SPAWN_FEATURES,
+      plugins: granted.length > 0,
+      multi_agent: allowSubagents,
+      realtime_conversation: true,
+    },
+    ...(granted.length > 0 ? { plugins: pluginTable(config, granted) } : {}),
     include_apps_instructions: false,
   };
 }

--- a/src/lib/delivery.ts
+++ b/src/lib/delivery.ts
@@ -134,6 +134,7 @@ export async function reconfigureConversation(
     readOnly: profile?.readOnly ?? null,
     permissionMode: profile?.permissionMode ?? null,
     allowSubagents: profile?.allowSubagents ?? false,
+    plugins: profile?.plugins,
   });
   const deliver = overrides.deliver ?? deliverToTranscriptHost;
   const observedHost = await (overrides.livePaneHost ?? livePaneHost)(filePath);
@@ -362,6 +363,7 @@ export async function resumeConversation(
     model: entry.launchModel ?? entry.model,
     effort: entry.effort,
     allowSubagents: registry.launchProfileForPath(entry.path)?.allowSubagents,
+    plugins: registry.launchProfileForPath(entry.path)?.plugins,
   });
   if (!spec) return failure("this conversation cannot be resumed", 409);
   try {
@@ -643,6 +645,7 @@ export async function deliverConversationMessage(message: ConversationMessage, o
       effort: message.resumeEffort ?? entry.effort,
       ...(typeof message.resumeFast === "boolean" ? { fast: message.resumeFast } : {}),
       allowSubagents: registry.launchProfileForPath(entry.path)?.allowSubagents,
+      plugins: registry.launchProfileForPath(entry.path)?.plugins,
     });
     if (spec) {
       const bundle = materializePayload();
@@ -670,6 +673,7 @@ export async function deliverConversationMessage(message: ConversationMessage, o
       model: root.launchModel ?? root.model,
       effort: root.effort,
       allowSubagents: registry.launchProfileForPath(root.path)?.allowSubagents,
+      plugins: registry.launchProfileForPath(root.path)?.plugins,
     });
     if (!rootSpec) {
       return settle(failure("root session is unavailable for messaging", 409));

--- a/src/lib/flows/engine.ts
+++ b/src/lib/flows/engine.ts
@@ -272,6 +272,7 @@ export async function sendToImplementer(flow: Flow, entriesByPath: Map<string, F
     effort: entry.effort,
     allowSubagents: agentRegistry().launchProfileForPath(entry.path)?.allowSubagents,
     mcpServers: agentRegistry().launchProfileForPath(entry.path)?.mcpServers,
+    plugins: agentRegistry().launchProfileForPath(entry.path)?.plugins,
   });
   if (!spec) throw new Error("implementer session cannot be resumed");
   const outcome = await deliverToTranscriptHost({ entry, spec, payload: text });

--- a/src/lib/runtime/codexAppServerHost.pluginGrant.test.ts
+++ b/src/lib/runtime/codexAppServerHost.pluginGrant.test.ts
@@ -1,0 +1,216 @@
+import { EventEmitter } from "node:events";
+import { PassThrough } from "node:stream";
+import type { ChildProcessWithoutNullStreams, SpawnOptionsWithoutStdio } from "node:child_process";
+import { expect, test } from "bun:test";
+
+import { CodexAppServerHost } from "./codexAppServerHost";
+import type { RuntimeEvent } from "./engineHost";
+import type { RuntimeEventStore } from "./eventStore";
+
+/**
+ * Per-thread Computer Use grant (issue #687). Codex resolves plugins from the
+ * operator's global configuration, so these cases pin what the Viewer controls:
+ * which thread asks for the plugin subsystem, which desktop-session variables
+ * reach the host process, and what happens when the realized tool surface is
+ * wider than the grant.
+ */
+
+class MemoryEventStore implements RuntimeEventStore {
+  private readonly events: RuntimeEvent[] = [];
+  load(): RuntimeEvent[] { return structuredClone(this.events); }
+  append(_threadId: string, event: RuntimeEvent): void { this.events.push(structuredClone(event)); }
+}
+
+class FakeAppServer extends EventEmitter {
+  readonly stdin = new PassThrough();
+  readonly stdout = new PassThrough();
+  readonly stderr = new PassThrough();
+  readonly pid = 5151;
+  readonly requests: Array<Record<string, unknown>> = [];
+  /** MCP servers the thread gains from plugins on top of its own table. */
+  pluginServers: string[] = [];
+  statusError: string | null = null;
+
+  constructor(private readonly threadId = "thread-687") {
+    super();
+    let buffer = "";
+    this.stdin.on("data", (chunk) => {
+      buffer += String(chunk);
+      for (let newline = buffer.indexOf("\n"); newline >= 0; newline = buffer.indexOf("\n")) {
+        const line = buffer.slice(0, newline);
+        buffer = buffer.slice(newline + 1);
+        if (line) this.accept(JSON.parse(line) as Record<string, unknown>);
+      }
+    });
+  }
+
+  kill(signal: NodeJS.Signals = "SIGTERM"): boolean {
+    queueMicrotask(() => this.emit("close", signal === "SIGKILL" ? null : 0, signal));
+    return true;
+  }
+
+  private accept(message: Record<string, unknown>): void {
+    this.requests.push(message);
+    if (typeof message.id !== "number") return;
+    const method = message.method;
+    if (method === "initialize") return this.respond(message.id, { userAgent: "codex_desktop_app/0.145.0 (Linux)" });
+    if (method === "account/read") return this.respond(message.id, { account: { type: "chatgpt", planType: "pro" } });
+    if (method === "model/list") return this.respond(message.id, { data: [{ id: "gpt-5.3-codex-spark", isDefault: true }] });
+    if (method === "config/read") return this.respond(message.id, {
+      config: {
+        mcp_servers: { viewer: { command: "agent-log-viewer-mcp" }, playwright: { command: "npx" } },
+        plugins: { "computer-use@openai-bundled": { enabled: true }, "browser@openai-bundled": { enabled: true } },
+      },
+    });
+    if (method === "thread/start" || method === "thread/resume") {
+      return this.respond(message.id, { thread: { id: this.threadId, path: `/sessions/${this.threadId}.jsonl` } });
+    }
+    if (method === "mcpServerStatus/list") {
+      if (this.statusError) return this.respondError(message.id, this.statusError);
+      return this.respond(message.id, {
+        data: ["viewer", "playwright", ...this.pluginServers].map((name) => ({ name, tools: {} })),
+      });
+    }
+  }
+
+  private respond(id: number, result: unknown): void {
+    this.stdout.write(`${JSON.stringify({ jsonrpc: "2.0", id, result })}\n`);
+  }
+
+  private respondError(id: number, message: string): void {
+    this.stdout.write(`${JSON.stringify({ jsonrpc: "2.0", id, error: { code: -32603, message } })}\n`);
+  }
+}
+
+function fakeSpawn(server: FakeAppServer, captured?: { options?: SpawnOptionsWithoutStdio }) {
+  return (_command: string, _args: string[], options: SpawnOptionsWithoutStdio) => {
+    if (captured) captured.options = options;
+    return server as unknown as ChildProcessWithoutNullStreams;
+  };
+}
+
+const DESKTOP_ENV: NodeJS.ProcessEnv & Record<string, string | undefined> = {
+  NODE_ENV: "test",
+  DISPLAY: ":0",
+  XAUTHORITY: "/tmp/xauth-test",
+  WAYLAND_DISPLAY: "wayland-9",
+  XDG_SESSION_TYPE: "wayland",
+  XDG_CURRENT_DESKTOP: "GNOME",
+  DESKTOP_SESSION: "gnome",
+  XDG_RUNTIME_DIR: "/tmp/runtime-test",
+  DBUS_SESSION_BUS_ADDRESS: "unix:path=/tmp/runtime-test/bus",
+  SECRET_TOKEN: "must-not-leak",
+  PATH: process.env.PATH,
+};
+
+test("a granted thread turns the plugin subsystem on for itself and allowlists computer use only", async () => {
+  const server = new FakeAppServer();
+  server.pluginServers = ["computer-use"];
+  const host = await CodexAppServerHost.start({
+    cwd: "/repo",
+    plugins: ["computer-use"],
+    env: DESKTOP_ENV,
+    eventStore: new MemoryEventStore(),
+    spawnProcess: fakeSpawn(server),
+  });
+  const config = (server.requests.find((request) => request.method === "thread/start")
+    ?.params as { config: { features: Record<string, unknown>; plugins: Record<string, { enabled: boolean }> } }).config;
+  expect(config.features).toMatchObject({ plugins: true, apps: false, multi_agent: false });
+  expect(config.plugins).toEqual({
+    "computer-use@openai-bundled": { enabled: true },
+    "browser@openai-bundled": { enabled: false },
+  });
+  await host.release();
+});
+
+test("a session without a grant leaves the plugin subsystem off", async () => {
+  const server = new FakeAppServer();
+  const host = await CodexAppServerHost.start({
+    cwd: "/repo",
+    env: DESKTOP_ENV,
+    eventStore: new MemoryEventStore(),
+    spawnProcess: fakeSpawn(server),
+  });
+  const config = (server.requests.find((request) => request.method === "thread/start")
+    ?.params as { config: Record<string, unknown> }).config;
+  expect(config.features).toMatchObject({ plugins: false });
+  expect(config).not.toHaveProperty("plugins");
+  /* No grant, no desktop reach: the verification RPC is not even asked for. */
+  expect(server.requests.some((request) => request.method === "mcpServerStatus/list")).toBe(false);
+  await host.release();
+});
+
+test("only a granted host receives the desktop session environment", async () => {
+  const granted = { options: undefined as SpawnOptionsWithoutStdio | undefined };
+  const denied = { options: undefined as SpawnOptionsWithoutStdio | undefined };
+  const grantedServer = new FakeAppServer();
+  grantedServer.pluginServers = ["computer-use"];
+  const grantedHost = await CodexAppServerHost.start({
+    cwd: "/repo",
+    plugins: ["computer-use"],
+    env: DESKTOP_ENV,
+    eventStore: new MemoryEventStore(),
+    spawnProcess: fakeSpawn(grantedServer, granted),
+  });
+  const deniedHost = await CodexAppServerHost.start({
+    cwd: "/repo",
+    env: DESKTOP_ENV,
+    eventStore: new MemoryEventStore(),
+    spawnProcess: fakeSpawn(new FakeAppServer(), denied),
+  });
+  const grantedEnv: Record<string, string | undefined> = { ...granted.options?.env };
+  const deniedEnv: Record<string, string | undefined> = { ...denied.options?.env };
+  for (const name of ["DISPLAY", "XAUTHORITY", "WAYLAND_DISPLAY", "XDG_SESSION_TYPE", "XDG_CURRENT_DESKTOP", "DESKTOP_SESSION"]) {
+    expect(grantedEnv[name]).toBe(DESKTOP_ENV[name]!);
+    expect(deniedEnv).not.toHaveProperty(name);
+  }
+  /* Session bus and runtime dir every host already needs; the grant does not
+     open the environment any further than the enumerated desktop variables. */
+  expect(deniedEnv.XDG_RUNTIME_DIR).toBe(DESKTOP_ENV.XDG_RUNTIME_DIR);
+  expect(grantedEnv.DBUS_SESSION_BUS_ADDRESS).toBe(DESKTOP_ENV.DBUS_SESSION_BUS_ADDRESS);
+  expect(grantedEnv).not.toHaveProperty("SECRET_TOKEN");
+  await grantedHost.release();
+  await deniedHost.release();
+});
+
+test("a granted thread that surfaces another plugin's server never opens", async () => {
+  const server = new FakeAppServer();
+  server.pluginServers = ["computer-use", "browser"];
+  await expect(CodexAppServerHost.start({
+    cwd: "/repo",
+    plugins: ["computer-use"],
+    env: DESKTOP_ENV,
+    eventStore: new MemoryEventStore(),
+    spawnProcess: fakeSpawn(server),
+  })).rejects.toThrow("Codex plugin grant surfaced servers outside the allowlist: browser");
+});
+
+test("a grant that cannot be verified is not granted", async () => {
+  const server = new FakeAppServer();
+  server.statusError = "mcpServerStatus/list is unavailable";
+  await expect(CodexAppServerHost.start({
+    cwd: "/repo",
+    plugins: ["computer-use"],
+    env: DESKTOP_ENV,
+    eventStore: new MemoryEventStore(),
+    spawnProcess: fakeSpawn(server),
+  })).rejects.toThrow("Codex plugin grant could not be verified");
+});
+
+test("a stored profile naming an ungrantable plugin gets no grant at all", async () => {
+  const server = new FakeAppServer();
+  const captured = { options: undefined as SpawnOptionsWithoutStdio | undefined };
+  const host = await CodexAppServerHost.start({
+    cwd: "/repo",
+    plugins: ["browser", "*"],
+    env: DESKTOP_ENV,
+    eventStore: new MemoryEventStore(),
+    spawnProcess: fakeSpawn(server, captured),
+  });
+  const config = (server.requests.find((request) => request.method === "thread/start")
+    ?.params as { config: Record<string, unknown> }).config;
+  expect(config.features).toMatchObject({ plugins: false });
+  expect(config).not.toHaveProperty("plugins");
+  expect(captured.options?.env).not.toHaveProperty("WAYLAND_DISPLAY");
+  await host.release();
+});

--- a/src/lib/runtime/codexAppServerHost.ts
+++ b/src/lib/runtime/codexAppServerHost.ts
@@ -5,6 +5,7 @@ import { isKnownEffortTier } from "@/lib/agent/efforts";
 import { procBackend } from "@/lib/proc";
 import { signalDetachedProcessGroup, signalProcessGroup, type ProcessSignal } from "@/lib/processGroup";
 import { headlessCodexThreadConfig } from "@/lib/codexHeadlessConfig";
+import { grantedPluginServerNames, grantedPlugins } from "@/lib/agent/pluginAllowlist";
 import { hardenedRedact } from "@/lib/view/compactText";
 import { decodeCodexStructuredUserText, encodeCodexStructuredUserText } from "./codexStructuredUserText";
 import { runtimeImageStore } from "./runtimeImageStore";
@@ -89,6 +90,9 @@ export interface CodexAppServerHostOptions {
   effort?: string;
   allowSubagents?: boolean;
   mcpServers?: string[];
+  /** Codex plugins granted to this session (issue #687). Empty or absent
+      denies the plugin subsystem, which is the default for every session. */
+  plugins?: readonly string[];
   fileAuthCredentials?: boolean;
   sandbox?: string;
   approvalPolicy?: string;
@@ -143,6 +147,33 @@ const CHILD_ENV_ALLOWLIST = [
   "SSL_CERT_FILE",
   "SSL_CERT_DIR",
   "LLV_SPAWN_CAPABILITY",
+] as const;
+/**
+ * Desktop-session variables forwarded ONLY to a host that holds a plugin grant
+ * (issue #687). The bundled `computer-use` backend reads each of these to find
+ * the operator's live session; without them it can only guess from defaults,
+ * which breaks outside a single-session GNOME/Wayland layout. Kept minimal and
+ * enumerated — no blanket environment passthrough:
+ *
+ *  - `DISPLAY`/`XAUTHORITY`: X11 (and Xwayland) server address plus the auth
+ *    cookie that connection needs — used by the AT-SPI and `xprop` paths.
+ *  - `WAYLAND_DISPLAY`: compositor socket name, for the Wayland window
+ *    backends when it is not the default `wayland-0`.
+ *  - `XDG_SESSION_TYPE`, `XDG_CURRENT_DESKTOP`, `DESKTOP_SESSION`: which
+ *    backend the plugin selects (GNOME Shell introspection, KWin, COSMIC …).
+ *
+ * `XDG_RUNTIME_DIR` and `DBUS_SESSION_BUS_ADDRESS` are equally required and
+ * already forwarded to every host above. Deliberately excluded: `YDOTOOL_SOCKET`
+ * and every other input-backend variable — this grant is for reading the
+ * desktop, and input stays behind the desktop permission path.
+ */
+const DESKTOP_ENV_ALLOWLIST = [
+  "DISPLAY",
+  "XAUTHORITY",
+  "WAYLAND_DISPLAY",
+  "XDG_SESSION_TYPE",
+  "XDG_CURRENT_DESKTOP",
+  "DESKTOP_SESSION",
 ] as const;
 const DEFAULT_TIMEOUT_MS = 30_000;
 const DEFAULT_DELIVERY_CONFIRMATION_TIMEOUT_MS = 5 * 60_000;
@@ -217,9 +248,10 @@ function stderrExitDiagnostic(value: string): string {
     .slice(0, 430);
 }
 
-function subscriptionEnv(source: NodeJS.ProcessEnv, codexHome?: string): NodeJS.ProcessEnv {
+function subscriptionEnv(source: NodeJS.ProcessEnv, codexHome?: string, desktopSession = false): NodeJS.ProcessEnv {
   const env: NodeJS.ProcessEnv = { NODE_ENV: source.NODE_ENV };
-  for (const name of CHILD_ENV_ALLOWLIST) {
+  const names = desktopSession ? [...CHILD_ENV_ALLOWLIST, ...DESKTOP_ENV_ALLOWLIST] : CHILD_ENV_ALLOWLIST;
+  for (const name of names) {
     if (source[name] !== undefined) env[name] = source[name];
   }
   if (codexHome) env.CODEX_HOME = codexHome;
@@ -458,9 +490,10 @@ export class CodexAppServerHost implements EngineHost {
       "--enable",
       "realtime_conversation",
     ];
+    const granted = grantedPlugins(options.plugins);
     const child = spawnProcess(options.binary ?? process.env.LLV_CODEX_BINARY ?? "codex", args, {
       cwd: options.cwd,
-      env: subscriptionEnv(options.env ?? process.env, options.codexHome),
+      env: subscriptionEnv(options.env ?? process.env, options.codexHome, granted.length > 0),
       detached: true,
     });
     const provisional = new CodexAppServerHost(child, { threadId: threadId ?? "pending", path: null }, options);
@@ -491,6 +524,7 @@ export class CodexAppServerHost implements EngineHost {
         await provisional.rpc("config/read", { cwd: options.cwd, includeLayers: false }),
         options.allowSubagents === true,
         options.mcpServers,
+        granted,
       );
       const result = threadId
         ? await provisional.rpc("thread/resume", { threadId, config })
@@ -507,6 +541,7 @@ export class CodexAppServerHost implements EngineHost {
       }
       provisional.identity.threadId = identity.threadId;
       provisional.identity.path = identity.path;
+      if (granted.length > 0) await provisional.verifyPluginGrant(granted, config);
       provisional.rememberConfirmedDeliveries(result);
       provisional.restoreEvents();
       provisional.beginBufferedNotificationReconciliation();
@@ -523,6 +558,33 @@ export class CodexAppServerHost implements EngineHost {
         throw new StructuredHostAdoptionCleanupError(safeError(error), provisional, { cause: cleanupError });
       }
       throw new Error(safeError(error));
+    }
+  }
+
+  /**
+   * Fails a granted thread closed when its realized tool surface is wider than
+   * the grant (issue #687). Codex resolves plugins from the global config, so
+   * `features.plugins` is the only per-thread gate it applies — this check is
+   * what turns that coarse gate into the allowlist: every MCP server the thread
+   * gained beyond its own configured table must belong to a granted plugin, or
+   * the host never opens. A grant that cannot be verified is not granted.
+   */
+  private async verifyPluginGrant(granted: readonly string[], config: JsonObject): Promise<void> {
+    const configured = new Set(Object.keys(record(config.mcp_servers) ?? {}));
+    const allowed = new Set(grantedPluginServerNames(granted));
+    let listed: unknown;
+    try {
+      listed = await this.rpc("mcpServerStatus/list", { threadId: this.identity.threadId });
+    } catch (error) {
+      throw new Error(`Codex plugin grant could not be verified: ${safeError(error)}`);
+    }
+    const entries = record(listed)?.data ?? listed;
+    if (!Array.isArray(entries)) throw new Error("Codex plugin grant could not be verified: mcpServerStatus/list returned no server list");
+    const unexpected = entries
+      .map((entry) => stringField(record(entry), "name"))
+      .filter((name): name is string => name !== null && !configured.has(name) && !allowed.has(name));
+    if (unexpected.length > 0) {
+      throw new Error(`Codex plugin grant surfaced servers outside the allowlist: ${[...new Set(unexpected)].sort().join(", ")}`);
     }
   }
 

--- a/src/lib/runtime/startup.test.ts
+++ b/src/lib/runtime/startup.test.ts
@@ -150,6 +150,7 @@ test("server startup delegates managed rows with file credentials and their laun
       readOnly: true,
       allowSubagents: true,
       mcpServers: ["viewer"],
+      plugins: [],
       title: null,
       project: null,
       parentConversationId: null,

--- a/src/lib/runtime/startup.ts
+++ b/src/lib/runtime/startup.ts
@@ -402,6 +402,9 @@ export async function adoptStructuredHostsAtStartup(
         effort: entry.launchProfile?.effort ?? undefined,
         allowSubagents: entry.launchProfile?.allowSubagents ?? false,
         mcpServers: entry.launchProfile?.mcpServers ?? ["viewer"],
+        /* Re-adoption replays the durable grant (issue #687) — a session never
+           gains or loses Computer Use by being picked up again at startup. */
+        plugins: entry.launchProfile?.plugins ?? [],
         env: {
           ...startupEnvironment,
           ...(capability ? { [VIEWER_SPAWN_CAPABILITY_ENV]: capability } : {}),

--- a/src/lib/runtime/structuredSpawn.ts
+++ b/src/lib/runtime/structuredSpawn.ts
@@ -788,6 +788,9 @@ async function defaultStartHost(input: StructuredSpawnInput, capability: string)
       effort: profile.effort ?? undefined,
       allowSubagents: profile.allowSubagents,
       mcpServers: profile.mcpServers,
+      /* Plugin grant from the durable profile (issue #687): present only for
+         an operator-launched root session that did not opt out. */
+      plugins: profile.plugins,
       sandbox: profile.readOnly ? "read-only" : "danger-full-access",
       approvalPolicy: profile.permissionMode ?? undefined,
       initialEventCursor,


### PR DESCRIPTION
Closes #687.

## What this does

A Codex session the operator launches for themselves now carries the bundled `computer-use` plugin **by default**. Every delegated session — agent-initiated spawn, lineage child, or role preset (builder, reviewer, verifier, pipeline helper) — carries none. Plugins are never enabled globally and the operator's Codex configuration is never touched.

The grant is an allowlist decided once at spawn from the session's durable origin, stored on the launch profile, and replayed by resume, successor and restart adoption. A running session is never restarted to change it, and a resume can never widen it. `plugins: []` on the spawn request is the explicit opt-out for a root session; any name outside the grantable set is a 400.

| session | grant |
| --- | --- |
| operator-launched root Codex session | `["computer-use"]` by default |
| same session with `plugins: []` | none (explicit opt-out) |
| delegated: agent-initiated, lineage parent, or any role preset | none |
| any Claude session | none — plugins are a Codex thread capability |

## What Codex actually honours

Probed against Codex CLI 0.145.0 with two threads inside one app-server process, comparing `mcpServerStatus/list` per thread (confirmed thread-scoped, not global):

- `config.features.plugins` on `thread/start` **is** per-thread — the `false` thread gained no plugin server, the `true` thread gained `computer-use`, same process, same moment.
- the per-thread `config.plugins` table is accepted without error but **is not applied**; even disabling the plugin in the effective configuration does not stop a bundled plugin server once the feature flag is on.

So the thread configuration states the `plugins` table as the declarative record of the grant and does not rely on it. Enforcement is a verification step: after a granted thread starts, the host lists the thread's MCP servers and refuses to open if any server appeared outside the thread's own configured table and the granted plugins' server names — or if the surface cannot be listed at all. A grant that cannot be verified is not granted.

## Why it cannot widen

1. Request validation rejects any name outside `GRANTABLE_PLUGINS` (`*`, `all`, any other plugin) rather than trimming silently.
2. The allowlist is the policy default for the origin *narrowed* by the request — a request can deny a grant, never create one, so nothing is inheritable down a spawn chain.
3. The profile constructor, the thread-config builder and the host each re-validate against the same bound, so a hand-edited durable profile cannot smuggle a plugin into a thread.
4. A delegated conversation has its grant cleared at registry admission whatever its stored profile claims.

## Desktop environment

A granted host additionally receives an enumerated set the bundled Computer Use backend reads: `DISPLAY`, `XAUTHORITY`, `WAYLAND_DISPLAY`, `XDG_SESSION_TYPE`, `XDG_CURRENT_DESKTOP`, `DESKTOP_SESSION`. `XDG_RUNTIME_DIR` and `DBUS_SESSION_BUS_ADDRESS` are equally required and were already forwarded to every host. No input-backend variable (e.g. `YDOTOOL_SOCKET`) is passed. A session without a grant receives none of the six.

## Verification

End-to-end read-only validation on a thread configured exactly as the granted path configures it: plugin servers in thread = `computer-use` (18 tools), enabled config servers = `viewer`, `list_windows` returned a window list, `screenshot` returned image bytes. No input action was performed anywhere, and no screenshot or session data is in this repository.

Focused suites, each pinned to an isolated state directory and run by file path (no directory sweeps):

- `bun test src/lib/agent/pluginAllowlist.test.ts src/lib/codexHeadlessConfig.test.ts src/lib/runtime/codexAppServerHost.pluginGrant.test.ts` — 29 pass
- `bun test src/app/api/spawn/route.test.ts src/lib/agent/registry.admission.test.ts` — 47 pass
- `bun test src/lib/agent/registry.test.ts` (108), `src/lib/agent/cli.test.ts` (23), `src/lib/delivery.test.ts` (31), `src/lib/flows/engine.test.ts` (31), `src/lib/runtime/startup.test.ts` (59), `src/lib/runtime/structuredSpawn.integration.test.ts` (63), `src/lib/accounts/migration/coordinator.test.ts` (91) — all pass
- `bun test src/lib/runtime/codexAppServerHost.test.ts` — 78 pass, 2 fail; the same 2 fail on the untouched tree (pre-existing)
- `bunx tsc --noEmit` clean; `bun run lint` adds no problem in any changed file; privacy gate passes

Every added test fails without the fix (verified by stashing only the source files).

Documentation: `docs/design/computer-use-grant.md` covers the policy, the probe findings, and resume/handoff behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)