### PR TITLE
fix(voice): make the built-in persona name English so nothing is exempt from the language guard

### DIFF
--- a/src/lib/runtime/voicePersona.test.ts
+++ b/src/lib/runtime/voicePersona.test.ts
@@ -28,13 +28,13 @@ const FOREIGN_SCRIPT =
  * defers the choice to the operator's locale at runtime and names no language
  * anywhere, so no sentence shape can be the thing being asserted.
  *
- * The name is stripped first — it is a proper noun the operator chose, not
- * prose, and it is allowed to be in its own script.
+ * Nothing is exempt, the name included. An exemption is a hole the size of
+ * whatever is exempt, and a name in another script is read aloud in that
+ * script's language just as surely as a sentence in it would be.
  */
 function languagePins(persona: string): string[] {
-  const body = persona.split(PERSONA_NAME).join("");
-  const pins: string[] = LANGUAGE_NAMES.filter((name) => new RegExp(`\\b${name}\\b`, "iu").test(body));
-  if (FOREIGN_SCRIPT.test(body)) pins.push("non-Latin script");
+  const pins: string[] = LANGUAGE_NAMES.filter((name) => new RegExp(`\\b${name}\\b`, "iu").test(persona));
+  if (FOREIGN_SCRIPT.test(persona)) pins.push("non-Latin script");
   return pins;
 }
 
@@ -82,22 +82,38 @@ test("appending a hard pin to any language is caught", () => {
   }
 });
 
+/* Adversarial samples built from bare codepoint numbers rather than written out
+   as foreign words, so this file's own text stays English while still proving
+   the guard reacts to each script it claims to cover. */
+function nonLatin(...codePoints: number[]): string {
+  return String.fromCodePoint(...codePoints);
+}
+
 test("a persona rewritten in another script is caught", () => {
-  /* Bare codepoints rather than foreign sentences, so this file itself carries
-     no non-English content: the guard has to notice body text in another
-     script, which is how a persona translated back into one arrives. */
-  for (const sample of ["Аб", "中", "א", "あ"]) {
+  /* Body text in another script is how a persona translated back into one
+     arrives, and it pins the spoken locale as hard as naming the language. */
+  for (const sample of [nonLatin(0x0410, 0x0431), nonLatin(0x4e2d), nonLatin(0x05d0), nonLatin(0x3042)]) {
     expect(languagePins(`${DEFAULT_VOICE_PERSONA}\n\n${sample}`)).toContain("non-Latin script");
   }
 });
 
-test("the name survives the guard, because a proper noun is not prose", () => {
-  /* The name is the operator's decision and stays in its own script. If
-     stripping it ever stops working, the guard would fail the shipped persona
-     and the next reader would "fix" the name. */
-  expect(DEFAULT_VOICE_PERSONA).toContain(PERSONA_NAME);
-  expect(FOREIGN_SCRIPT.test(PERSONA_NAME)).toBeTrue();
+test("the name is English too, so the guard carves out no exception for it", () => {
+  /* The name used to be the one token stripped before the guard ran, which left
+     the only spelling in the file that could pin a locale sitting outside the
+     only check that would catch it. It is Latin now and goes through the guard
+     with the rest of the prose. */
+  expect(PERSONA_NAME).toBe("Alik");
+  expect(PERSONA_NAME).toMatch(/^[A-Za-z]+$/);
+  expect(DEFAULT_VOICE_PERSONA).toContain(`Your name is ${PERSONA_NAME}.`);
   expect(languagePins(PERSONA_NAME)).toEqual([]);
+});
+
+test("a name in another script is caught like any other foreign text", () => {
+  /* The regression that made this a defect: a name respelled in a non-Latin
+     script has to fail the language guard rather than slip past it. */
+  const renamed = DEFAULT_VOICE_PERSONA.replace(PERSONA_NAME, nonLatin(0x0410, 0x043b, 0x0438, 0x043a));
+  expect(renamed).not.toBe(DEFAULT_VOICE_PERSONA);
+  expect(languagePins(renamed)).toContain("non-Latin script");
 });
 
 test("the persona hands the spoken language to the operator's locale", () => {

--- a/src/lib/runtime/voicePersona.ts
+++ b/src/lib/runtime/voicePersona.ts
@@ -4,17 +4,17 @@ import path from "node:path";
 import { configFilePath } from "@/lib/configDir";
 
 /**
- * The assistant's established name, kept in its own script.
+ * The assistant's established name, in its canonical English spelling.
  *
- * The Cyrillic spelling is the operator's decision and is deliberately not
- * translated or transliterated. English-only governs the persona prose and the
- * tests; a proper name is not prose. Do not "fix" this.
- *
- * It is therefore the one non-Latin token in {@link DEFAULT_VOICE_PERSONA},
- * which is what lets the persona tests strip it and assert that everything left
- * pins no language.
+ * A name written in one script is read aloud in that script's language, so a
+ * non-Latin spelling here would nudge the spoken locale exactly the way a
+ * non-English prompt body does — the defect this file already guards against,
+ * arriving through the one token that used to be exempt from the guard. English
+ * only therefore covers the name too, and {@link DEFAULT_VOICE_PERSONA} carries
+ * no non-Latin token at all. A caller that needs the name in another script gets
+ * it the same way it gets any other wording change: the operator override.
  */
-export const PERSONA_NAME = "Алик";
+export const PERSONA_NAME = "Alik";
 
 /**
  * How the voice agent should sound, injected as the call's first thread item.
@@ -33,7 +33,7 @@ export const PERSONA_NAME = "Алик";
  * instruction to speak that language, whatever its words claim, so composing it
  * in one would hard-code the spoken locale into the build. English keeps the
  * choice at runtime, where the prompt hands it to the operator's locale and to
- * whatever they actually speak. Only the name stays in its own script.
+ * whatever they actually speak. The name is English for the same reason.
  *
  * Editable without a deploy — see {@link voicePersona}.
  */


### PR DESCRIPTION
Follow-up repair on top of #695, which merged before this correction landed. GitHub refuses to reopen a merged pull request, so the same branch carries one new commit and this pull request is the review surface for it. Closes the reviewer's remaining P1 on #692.

## The defect

#695 made the persona body English and then exempted the name from the check that enforced it. `PERSONA_NAME` stayed in Cyrillic, and `languagePins()` in the test stripped the name out of the prompt before scanning what was left. The one token in the file that could still pin a spoken locale was the one token the guard never saw.

The exemption's stated reason — a proper noun is not prose — does not hold for this prompt. A name written in a script is read aloud in that script's language, so shipping a Cyrillic name in the default persona nudges the spoken locale exactly the way a Russian prompt body did before #695. The prompt says the build pins no locale; the name contradicted it.

## What changed

- `PERSONA_NAME` is `Alik`, the canonical English spelling already used by the issue title and by #695's own title. Nothing else in the persona text moved.
- `languagePins()` strips nothing. The shipped persona goes through the language guard whole, so the property the guard claims to hold now actually covers every character of it.
- New case: respelling the name in a non-Latin script has to fail the guard. This is the regression that would otherwise reintroduce the exemption by hand.
- The adversarial script samples are built from codepoint numbers through a small `nonLatin()` helper instead of being written out as foreign words, so the test file's own text is English end to end.

No Cyrillic or Russian literal remains in the persona source or in its tests. The operator override (`prompts/voice-persona.md` under the config dir) is untouched and still replaces the built-in text wholesale, so a name in any script is a file edit away and needs no deploy.

## Verification

Run by path against an isolated state directory (`XDG_CONFIG_HOME` / `XDG_CACHE_HOME` / `HOME` pointed at a scratch dir), never as a directory sweep:

```
bun test src/lib/runtime/voicePersona.test.ts
  14 pass, 0 fail

bun test src/lib/runtime/voicePersona.test.ts src/lib/runtime/codexAppServerHost.test.ts
  93 pass, 2 fail
```

The 2 failures are the same pre-existing ones documented on #695. Re-checked here with this commit stashed: `CodexAppServerHost > requires an exact opt-in value` and `CodexAppServerHost > boot adoption resumes every flagged Codex registry row` fail identically at the merge-base, 79 pass / 2 fail. Neither test touches the persona.

The new guard was checked by mutation rather than assumed:

| Mutation | Result |
|---|---|
| `PERSONA_NAME` put back to the Cyrillic spelling | `the shipped persona pins no spoken language anywhere`, `the name is English too, so the guard carves out no exception for it` and `a name in another script is caught like any other foreign text` **fail** (3 fail, 11 pass) |

Restored, 14 pass again.

`bunx tsc --noEmit` clean. `bun run lint` unchanged from baseline at 12 problems, none of them in either file this commit touches. Privacy gate against the merge-base: PASS.

Not merged, not deployed.
