### PR TITLE
feat(attention): wire the #688 handoff loop end to end — mount, tool, navigate, return

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,7 +225,11 @@ The MCP surface includes:
 - operator/runtime reads: `operator_snapshot`, `deployment_status`, and
   `resources`;
 - agent/runtime mutations: `spawn_agent`, `conversation_migration`, and
-  `deploy_exact_sha`.
+  `deploy_exact_sha`;
+- the operator's attention: `request_attention`, which offers to move their
+  Viewer to a target and waits for their answer. It only asks — nothing moves
+  until they agree on a device, and the request names the root agent by an
+  identity the server resolves, never one the caller supplies.
 
 Every call requires a stable `clientRequestId`. Reusing that id with the same
 arguments returns the durable result as a replay. Reusing it with different

--- a/src/components/Viewer.attentionMount.test.ts
+++ b/src/components/Viewer.attentionMount.test.ts
@@ -1,0 +1,47 @@
+import { expect, test } from "bun:test";
+import fs from "node:fs";
+import path from "node:path";
+
+/*
+ * The shell renders the attention host (#688 D3).
+ *
+ * This is the defect class the mount closed: a complete feature — record,
+ * machine, route, overlay, board seam — with a green suite and no surface,
+ * because every test mounted the pieces directly and nothing asserted that the
+ * shipped shell rendered any of them. So this asserts the one thing those tests
+ * cannot: that `Viewer` still contains the host.
+ *
+ * It reads the source rather than rendering, deliberately. The host renders
+ * NOTHING until there is something to answer — that contract is asserted in
+ * `AttentionHost.dom.test.tsx` — so a rendered tree is empty in exactly the
+ * state a shell test could set up, and would go on being empty after the mount
+ * was deleted. The import graph is the part that can actually be checked.
+ */
+
+const source = fs.readFileSync(path.join(process.cwd(), "src/components/Viewer.tsx"), "utf8");
+
+/** The file with comments removed, so a mount that survives only inside a
+    comment does not read as a mount. */
+const code = source
+  .replace(/\/\*[\s\S]*?\*\//g, "")
+  .replace(/^[ \t]*\/\/.*$/gm, "");
+
+test("the shell imports the attention host", () => {
+  expect(code).toMatch(/import\s*\{[^}]*\bAttentionHost\b[^}]*\}\s*from\s*"\.\/attention\/AttentionHost"/);
+});
+
+test("the shell renders the attention host, and does not gate it behind a flag", () => {
+  const mounted = code.match(/<AttentionHost\b[^>]*\/>/);
+  expect(mounted).not.toBeNull();
+  /* Every device that can answer a request has to be able to see one, so the
+     mount takes only the surface it renders on. A condition here would be a
+     device the root agent can address and never reach. */
+  expect(mounted![0]).toBe("<AttentionHost mobile={isMobile} />");
+});
+
+test("the shell registers the navigator half of the handoff", () => {
+  /* The host can answer a request without this, and then move nothing: the
+     board knows where things are, the shell knows which project is open, and a
+     handoff needs both. */
+  expect(code).toMatch(/focusHandoffBus\.setShell\(/);
+});

--- a/src/components/Viewer.tsx
+++ b/src/components/Viewer.tsx
@@ -19,6 +19,8 @@ import { type TFunction, useLocale } from "@/lib/i18n";
 import type { FileEntry } from "@/lib/types";
 
 import { attentionId, buildAttentionQueue, nextAttention, STALLED_ATTENTION_TTL, type AttentionItem } from "./attention";
+import { AttentionHost } from "./attention/AttentionHost";
+import { focusHandoffBus } from "./attention/focusHandoffBus";
 import { ConnectionPill } from "./ConnectionPill";
 import { resolveFavoriteRows, type FavoriteRow } from "./favorites/favoriteRows";
 import { OverviewBoard } from "./OverviewBoard";
@@ -353,6 +355,16 @@ export function Viewer() {
     setFocusRequest((prev) => ({ path, nonce: (prev?.nonce ?? 0) + 1, catalog: false }));
   }, []);
 
+  /* #688: the shell half of a focus handoff. An accepted request opens the
+     project it lives in and, when its intent is `open`, the conversation
+     itself — the same hand-off an attention jump already uses, so a handoff and
+     a tap can never land differently. The board half registers in SchemeBoard. */
+  useEffect(() => focusHandoffBus.setShell({
+    project: project === OVERVIEW ? null : project,
+    openProject: selectProject,
+    openPath: requestFocus,
+  }), [project, selectProject, requestFocus]);
+
   /* The N-cycle position anchors to an id: an item answered elsewhere drops
      out without moving the pointer's neighbors (D12). */
   const cycleRef = useRef<string | null>(null);
@@ -681,6 +693,10 @@ export function Viewer() {
           of the bottom-right CornerStatus and the top-right attention anchor. */}
       {isMobile ? null : <ConnectionPill />}
       <DeploymentStatusPill />
+      {/* #688: polls the attention record for this device and renders the
+          root agent's focus handoff when there is one to answer. Renders
+          nothing at all the rest of the time. */}
+      <AttentionHost mobile={isMobile} />
       {/* Staging instances (#659) announce themselves on every device; prod
           renders nothing. Top-center, clear of both corner anchors. */}
       <StagingBadge />

--- a/src/components/attention/AttentionHost.dom.test.tsx
+++ b/src/components/attention/AttentionHost.dom.test.tsx
@@ -62,6 +62,9 @@ beforeEach(() => {
   dom.document.body.replaceChildren();
   roots = [];
   visibility = "visible";
+  /* The return-project memory lives here and is keyed by request id, which the
+     tests reuse; a leak between them would hide the case where it is empty. */
+  dom.localStorage.clear();
   previousStateDir = process.env.LLV_STATE_DIR;
   sandbox = fs.mkdtempSync(path.join(os.tmpdir(), "llv-attention-host-"));
   process.env.LLV_STATE_DIR = sandbox;
@@ -114,18 +117,27 @@ interface BoardLog {
   restored: { x: number; y: number; zoom: number }[];
 }
 
-function board(rects: Record<string, FocusRect>) {
+/** The board the handoff lands on. `project` names which project's layout this
+    is — the tests that pass another one are the ones about a camera or a name
+    that must not cross a project boundary. */
+function board(rects: Record<string, FocusRect>, project = "demo") {
   const bus = createFocusHandoffBus();
   const log: BoardLog = { moved: [], restored: [] };
+  const opened: string[] = [];
   const controller: BoardFocusController = {
-    project: "demo",
-    index: { project: "demo", boardRevision: 9, rectFor: (key) => rects[key] ?? null },
+    project,
+    index: {
+      project,
+      boardRevision: 9,
+      rectFor: (key) => rects[key] ?? null,
+      named: [{ key: ANCHOR, label: "Reviewer — login fix", rect: LIVE_RECT }],
+    },
     moveTo: ({ rect }) => { log.moved.push(rect); return true; },
     restoreCamera: (camera) => { log.restored.push(camera); return true; },
   };
   bus.setBoard(controller);
-  bus.setShell({ project: "demo", openProject: () => {}, openPath: () => {} });
-  return { bus, log };
+  bus.setShell({ project, openProject: () => {}, openPath: (path) => { opened.push(path); } });
+  return { bus, log, opened };
 }
 
 function raise(rect: FocusRect = RAISED_RECT) {
@@ -151,6 +163,12 @@ function mount(bus: ReturnType<typeof board>["bus"]) {
 const one = (selector: string) => dom.document.querySelector(selector) as unknown as HTMLElement | null;
 const click = (element: HTMLElement) => element.dispatchEvent(new dom.MouseEvent("click", { bubbles: true }) as unknown as Event);
 const record = () => readAttentionFile().requests[0]!;
+/** One poll tick. Coming back to the tab is a poll like any other, and it is
+    the one a test can trigger without waiting out the interval. */
+async function poll() {
+  dom.document.dispatchEvent(new dom.Event("visibilitychange"));
+  await settle();
+}
 
 test("a raised request renders within one poll and the record moves pending → offered", async () => {
   raise();
@@ -241,6 +259,66 @@ test("the return point is this device's viewport from before the move, and retur
   expect(record().returnedVia).toBe("control");
 });
 
+/** Drive a request all the way to `following` on this device without going
+    through the host — a record that outlived whatever tab accepted it. */
+function seedFollowing(focusedPath: string | null = "/tmp/what-i-was-reading.jsonl") {
+  const request = raise();
+  answerAttentionRequest(request.id, { kind: "offer", deviceId: DEVICE }, { now });
+  answerAttentionRequest(request.id, { kind: "accept", deviceId: DEVICE }, { now });
+  answerAttentionRequest(request.id, {
+    kind: "arrive",
+    deviceId: DEVICE,
+    resolution: "exact",
+    returnPoint: { deviceId: DEVICE, mode: "scheme", camera: { x: 120, y: 340, zoom: 0.55 }, focusedPath, capturedAt: now.toISOString() },
+  }, { now });
+  return request;
+}
+
+test("a return with no memory of where the camera was captured never restores it into another project", async () => {
+  /* The record's ReturnPoint carries a camera but no project, and this browser
+     has no memory of capturing it: the tab that accepted is gone, or this is a
+     second tab that shares the device id and renders the same return control.
+     World coordinates from one project's layout mean nothing in another's. */
+  seedFollowing();
+  const { bus, log, opened } = board({ [ANCHOR]: LIVE_RECT }, "elsewhere");
+  mount(bus);
+  await settle();
+
+  click(one("[data-testid='attention-return']")!);
+  await settle();
+
+  expect(log.restored).toEqual([]);
+  /* The focused path names a thing rather than a coordinate, so it is the part
+     of that viewport that survives not knowing which project it belonged to. */
+  expect(opened).toEqual(["/tmp/what-i-was-reading.jsonl"]);
+  expect(record().state).toBe("returned");
+});
+
+test("the capture project outlives the tab, so a return after a reload restores the camera", async () => {
+  raise();
+  const first = board({ [ANCHOR]: LIVE_RECT });
+  mount(first.bus);
+  await settle();
+  click(one("[data-testid='attention-accept']")!);
+  await settle();
+
+  /* The reload: this component's memory is gone, the record and the device id
+     are not. */
+  for (const root of roots) flushSync(() => root.unmount());
+  roots = [];
+  dom.document.body.replaceChildren();
+
+  const second = board({ [ANCHOR]: LIVE_RECT });
+  mount(second.bus);
+  await settle();
+
+  click(one("[data-testid='attention-return']")!);
+  await settle();
+
+  expect(second.log.restored).toEqual([{ x: 120, y: 340, zoom: 0.55 }]);
+  expect(record().state).toBe("returned");
+});
+
 test("a vanished anchor degrades to where it was rather than failing or landing anywhere", async () => {
   raise();
   /* The reviewer's card is gone from the board; the frame the request was
@@ -257,18 +335,23 @@ test("a vanished anchor degrades to where it was rather than failing or landing 
   expect(record().resolution).toBe("approximate");
 });
 
-test("a target that resolved to nothing is refused out loud rather than passing for an arrival", async () => {
-  /* No live anchor and no frame worth degrading to. The record refuses to call
-     that a follow, and the surface that asked says so — a control that appeared
-     to work while the view never moved is the failure this whole row exists to
-     avoid. */
-  raiseAttentionRequest({
+/** A request with no live anchor and no frame worth degrading to: there is
+    nowhere on the board to take anyone. */
+function raiseUnlandable(id = "attention_1", reason = "The reviewer finished with request-changes.") {
+  return raiseAttentionRequest({
     origin: "root-agent",
     target: { kind: "conversation", path: ANCHOR },
     frameAtCreation: { project: "demo", rect: { x: 0, y: 0, w: 0, h: 0 }, boardRevision: null },
     intent: "show",
-    reason: "The reviewer finished with request-changes.",
-  }, { now, id: "attention_1" });
+    reason,
+  }, { now, id }).request;
+}
+
+test("a target that resolved to nothing ends the request then and there, as its own kind of ending", async () => {
+  /* The record refuses to call that a follow, and the surface that asked says
+     so — a control that appeared to work while the view never moved is the
+     failure this whole row exists to avoid. */
+  raiseUnlandable();
   const { bus, log } = board({});
   mount(bus);
   await settle();
@@ -277,9 +360,111 @@ test("a target that resolved to nothing is refused out loud rather than passing 
   await settle();
 
   expect(log.moved).toEqual([]);
-  expect(record().state).toBe("accepted");
+  /* Terminal within the same answer, and never recorded as an arrival. The
+     alternative — leaving it `accepted` — is unrecoverable: no event is legal
+     from there, so it stays this device's oldest live entry for the life of the
+     record. */
+  expect(record().state).toBe("expired");
+  expect(record().expiredCause).toBe("lost");
   expect(record().resolution).toBeUndefined();
+  /* Not a refusal, and not "they never answered": three different things to be
+     able to say, and this is the third. */
+  expect(record().state).not.toBe("declined");
+  expect(attentionForDevice(DEVICE, { now }).offer).toBeNull();
   expect(one("[data-testid='attention-refused']")).not.toBeNull();
+});
+
+test("a request raised after a handoff that could not land is rendered and answerable", async () => {
+  raiseUnlandable();
+  /* The anchor arrives on the board only after the first handoff has failed —
+     the reviewer's card appearing a moment later, which is the ordinary way
+     this happens. */
+  const rects: Record<string, FocusRect> = {};
+  const { bus } = board(rects);
+  mount(bus);
+  await settle();
+
+  click(one("[data-testid='attention-accept']")!);
+  await settle();
+  rects[ANCHOR] = LIVE_RECT;
+
+  /* The second ask is the one that matters. With the first wedged in
+     `accepted` it would be stamped `offered` by the poll, rendered by nothing,
+     and expire looking exactly like "they saw it and said nothing" — the record
+     lying about the operator, permanently, on that device. */
+  const second = raiseAttentionRequest({
+    origin: "root-agent",
+    target: { kind: "conversation", path: ANCHOR },
+    frameAtCreation: { project: "demo", rect: RAISED_RECT, boardRevision: 4 },
+    intent: "show",
+    reason: "The verifier is blocked on you.",
+  }, { now, id: "attention_2" }).request;
+
+  await poll();
+
+  expect(one("[data-testid='attention-request']")!.textContent).toContain("The verifier is blocked on you.");
+  expect(attentionForDevice(DEVICE, { now }).offer?.request.id).toBe(second.id);
+
+  click(one("[data-testid='attention-accept']")!);
+  await settle();
+
+  const stored = readAttentionFile().requests.find((entry) => entry.id === "attention_2")!;
+  expect(stored.state).toBe("following");
+});
+
+test("the refusal band can be dismissed, so a one-off refusal is not a permanent warning", async () => {
+  raiseUnlandable();
+  const { bus } = board({});
+  mount(bus);
+  await settle();
+
+  click(one("[data-testid='attention-accept']")!);
+  await settle();
+  expect(one("[data-testid='attention-refused']")).not.toBeNull();
+
+  click(one("[data-testid='attention-refused-dismiss']")!);
+  await settle();
+
+  /* Nothing is left to answer and nothing is left to say, so the surface goes
+     away entirely rather than leaving a band the operator cannot get rid of. */
+  expect(one("[data-testid='attention-refused']")).toBeNull();
+  expect(dom.document.body.textContent).toBe("");
+});
+
+test("asking for a preview shows what it is about, named by the board when the board knows it", async () => {
+  raise();
+  const { bus } = board({ [ANCHOR]: LIVE_RECT });
+  mount(bus);
+  await settle();
+
+  click(one("[data-testid='attention-preview']")!);
+  await settle();
+
+  /* The third branch of the loop — accept, decline, or look first — and it has
+     to show something, or it is a control that does nothing. */
+  const card = one("[data-testid='attention-preview-card']");
+  expect(card).not.toBeNull();
+  expect(card!.textContent).toContain("Reviewer — login fix");
+  expect(card!.textContent).toContain("demo");
+  /* Previewing never moves the view, whatever the target. */
+  expect(record().state).toBe("previewing");
+  expect(one("[data-testid='attention-accept']")).not.toBeNull();
+});
+
+test("a preview for a target the board cannot name still says what was asked about", async () => {
+  raise();
+  /* Another project's board is registered, so no label here may be borrowed
+     from it: the same key can mean a different thing in a different layout. */
+  const { bus } = board({ [ANCHOR]: LIVE_RECT }, "elsewhere");
+  mount(bus);
+  await settle();
+
+  click(one("[data-testid='attention-preview']")!);
+  await settle();
+
+  const card = one("[data-testid='attention-preview-card']");
+  expect(card!.textContent).toContain("reviewer");
+  expect(card!.textContent).toContain("demo");
 });
 
 test("nothing renders while there is nothing to answer", async () => {

--- a/src/components/attention/AttentionHost.dom.test.tsx
+++ b/src/components/attention/AttentionHost.dom.test.tsx
@@ -1,0 +1,293 @@
+import { afterAll, afterEach, beforeAll, beforeEach, expect, test } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { Window } from "happy-dom";
+import { createRoot, type Root } from "react-dom/client";
+import { flushSync } from "react-dom";
+
+import { viewBus, type ViewSlice } from "@/hooks/viewPresenceBus";
+import { answerAttentionRequest, attentionForDevice, raiseAttentionRequest } from "@/lib/attention/service";
+import { readAttentionFile } from "@/lib/attention/store";
+import { OFFER_TTL_MS, type FocusRect } from "@/lib/attention/types";
+import { validateAttentionEvent } from "@/lib/attention/validation";
+
+import { AttentionHost } from "./AttentionHost";
+import { createFocusHandoffBus, type BoardFocusController } from "./focusHandoffBus";
+
+/*
+ * #688's last mile, end to end on a device.
+ *
+ * These drive the REAL record through the real service — only the transport and
+ * the board are stood in for — because the failures this closes were all in the
+ * seam between them: a request nothing polled, an offer nothing rendered, and an
+ * acceptance that moved nothing. A test that mocked the record would have passed
+ * against the broken build.
+ */
+
+const dom = new Window({ url: "http://localhost/" });
+const G = globalThis as Record<string, unknown>;
+const OVERRIDES: Record<string, unknown> = {
+  window: dom,
+  document: dom.document,
+  navigator: dom.navigator,
+  Node: dom.Node,
+  HTMLElement: dom.HTMLElement,
+  Event: dom.Event,
+  MouseEvent: dom.MouseEvent,
+  localStorage: dom.localStorage,
+  ResizeObserver: class { observe() {} unobserve() {} disconnect() {} },
+};
+const HAS: Record<string, boolean> = {};
+const SAVED: Record<string, unknown> = {};
+const settle = async () => { for (let i = 0; i < 8; i += 1) await new Promise((r) => setTimeout(r, 0)); };
+
+let sandbox = "";
+let previousStateDir: string | undefined;
+let visibility: "visible" | "hidden" = "visible";
+
+beforeAll(() => {
+  for (const key of Object.keys(OVERRIDES)) { HAS[key] = key in G; SAVED[key] = G[key]; G[key] = OVERRIDES[key]; }
+  /* The hidden-surface contract is the default `document.visibilityState` read,
+     so the test drives that rather than a seam the production mount never uses. */
+  Object.defineProperty(dom.document, "visibilityState", { get: () => visibility, configurable: true });
+});
+afterAll(async () => {
+  await settle();
+  for (const key of Object.keys(OVERRIDES)) { if (HAS[key]) G[key] = SAVED[key]; else delete G[key]; }
+});
+
+let roots: Root[] = [];
+beforeEach(() => {
+  dom.document.body.replaceChildren();
+  roots = [];
+  visibility = "visible";
+  previousStateDir = process.env.LLV_STATE_DIR;
+  sandbox = fs.mkdtempSync(path.join(os.tmpdir(), "llv-attention-host-"));
+  process.env.LLV_STATE_DIR = sandbox;
+  viewBus.reportContext({ project: "demo", board: { renderedRevision: null, durableRevision: null, sync: "unavailable" } });
+  viewBus.reportSlice(WHERE_I_WAS);
+});
+afterEach(async () => {
+  for (const root of roots) flushSync(() => root.unmount());
+  roots = [];
+  await settle();
+  if (previousStateDir === undefined) delete process.env.LLV_STATE_DIR;
+  else process.env.LLV_STATE_DIR = previousStateDir;
+  fs.rmSync(sandbox, { recursive: true, force: true });
+});
+
+const DEVICE = "device-desktop";
+const ANCHOR = "/tmp/reviewer.jsonl";
+const LIVE_RECT: FocusRect = { x: 900, y: 1_400, w: 600, h: 780 };
+const RAISED_RECT: FocusRect = { x: 10, y: 20, w: 600, h: 780 };
+
+/** The viewport the operator is at before anything moves. */
+const WHERE_I_WAS: ViewSlice = {
+  mode: "scheme",
+  focusedPath: "/tmp/what-i-was-reading.jsonl",
+  selectedPaths: [],
+  visiblePaths: [],
+  camera: { x: 120, y: 340, zoom: 0.55, worldRect: { x: 0, y: 0, width: 1_000, height: 800 } },
+};
+
+let now = new Date("2026-07-01T10:00:00.000Z");
+const at = (ms: number) => new Date(now.getTime() + ms);
+
+/** The two routes, answering exactly as `/api/attention` does — including the
+    409-with-state that a refused transition comes back as. */
+function transport(): typeof fetch {
+  return (async (url: string, init?: { body?: string }) => {
+    if (!init?.body) {
+      return { ok: true, status: 200, json: async () => ({ ok: true, ...attentionForDevice(DEVICE, { now }) }) };
+    }
+    const id = decodeURIComponent(url.split("/").pop()!);
+    const outcome = answerAttentionRequest(id, validateAttentionEvent(JSON.parse(init.body)), { now });
+    if (outcome.ok) return { ok: true, status: 200, json: async () => ({ ok: true, request: outcome.request }) };
+    if (outcome.reason === "not-found") return { ok: false, status: 404, json: async () => ({ error: "NOT_FOUND" }) };
+    return { ok: false, status: 409, json: async () => ({ error: outcome.reason, state: outcome.state }) };
+  }) as unknown as typeof fetch;
+}
+
+interface BoardLog {
+  moved: FocusRect[];
+  restored: { x: number; y: number; zoom: number }[];
+}
+
+function board(rects: Record<string, FocusRect>) {
+  const bus = createFocusHandoffBus();
+  const log: BoardLog = { moved: [], restored: [] };
+  const controller: BoardFocusController = {
+    project: "demo",
+    index: { project: "demo", boardRevision: 9, rectFor: (key) => rects[key] ?? null },
+    moveTo: ({ rect }) => { log.moved.push(rect); return true; },
+    restoreCamera: (camera) => { log.restored.push(camera); return true; },
+  };
+  bus.setBoard(controller);
+  bus.setShell({ project: "demo", openProject: () => {}, openPath: () => {} });
+  return { bus, log };
+}
+
+function raise(rect: FocusRect = RAISED_RECT) {
+  return raiseAttentionRequest({
+    origin: "root-agent",
+    target: { kind: "conversation", path: ANCHOR },
+    frameAtCreation: { project: "demo", rect, boardRevision: 4 },
+    intent: "show",
+    reason: "The reviewer finished with request-changes.",
+  }, { now, id: "attention_1" }).request;
+}
+
+function mount(bus: ReturnType<typeof board>["bus"]) {
+  const host = dom.document.createElement("div");
+  dom.document.body.appendChild(host);
+  const root = createRoot(host as unknown as Element);
+  flushSync(() => root.render(
+    <AttentionHost mobile={false} bus={bus} deviceId={DEVICE} fetchFn={transport()} pollMs={100_000} timing={{ timeoutMs: 0, pollMs: 0 }} />,
+  ));
+  roots.push(root);
+}
+
+const one = (selector: string) => dom.document.querySelector(selector) as unknown as HTMLElement | null;
+const click = (element: HTMLElement) => element.dispatchEvent(new dom.MouseEvent("click", { bubbles: true }) as unknown as Event);
+const record = () => readAttentionFile().requests[0]!;
+
+test("a raised request renders within one poll and the record moves pending → offered", async () => {
+  raise();
+  expect(record().state).toBe("pending");
+  const { bus } = board({ [ANCHOR]: LIVE_RECT });
+
+  mount(bus);
+  await settle();
+
+  /* On screen, answerable, with the agent's sentence and which of show/open the
+     operator is about to agree to. */
+  expect(one("[data-testid='attention-request']")).not.toBeNull();
+  expect(one("[data-testid='attention-accept']")).not.toBeNull();
+  /* And the record now says a device showed it — which is what makes the
+     eventual expiry line "you never saw it" or "you said nothing", honestly. */
+  expect(record().state).toBe("offered");
+  expect(record().offeredTo).toEqual([DEVICE]);
+});
+
+test("a hidden surface renders nothing and reports nothing, and the request expires unseen", async () => {
+  visibility = "hidden";
+  raise();
+  const { bus } = board({ [ANCHOR]: LIVE_RECT });
+
+  mount(bus);
+  await settle();
+
+  /* A background tab claiming the operator saw an offer teaches the agent the
+     wrong lesson about whether to ask again. The operator's Viewer is
+     frequently backgrounded, so this is the common case, not the edge one. */
+  expect(record().state).toBe("pending");
+  expect(record().offeredTo).toEqual([]);
+  expect(one("[data-testid='attention-request']")).toBeNull();
+
+  now = at(OFFER_TTL_MS + 1);
+  const swept = attentionForDevice(DEVICE, { now });
+  now = new Date("2026-07-01T10:00:00.000Z");
+
+  expect(swept.expired).toEqual(["attention_1"]);
+  expect(record().state).toBe("expired");
+  expect(record().expiredCause).toBe("ttl");
+  expect(record().offeredTo).toEqual([]);
+});
+
+test("accepting resolves the target against the live board, moves the view, and records the arrival", async () => {
+  raise();
+  const { bus, log } = board({ [ANCHOR]: LIVE_RECT });
+  mount(bus);
+  await settle();
+
+  click(one("[data-testid='attention-accept']")!);
+  await settle();
+
+  /* The rect the board holds NOW, not the one the request was raised against. */
+  expect(log.moved).toEqual([LIVE_RECT]);
+  expect(record().state).toBe("following");
+  expect(record().resolution).toBe("exact");
+  expect(record().acknowledgedBy).toBe(DEVICE);
+});
+
+test("the return point is this device's viewport from before the move, and returning restores it", async () => {
+  raise();
+  const { bus, log } = board({ [ANCHOR]: LIVE_RECT });
+  mount(bus);
+  await settle();
+
+  click(one("[data-testid='attention-accept']")!);
+  await settle();
+
+  /* Captured before anything moved, against this device — presence is
+     per-device and two devices in the same seat do not share a framing. */
+  expect(record().returnPoints).toEqual([{
+    deviceId: DEVICE,
+    mode: "scheme",
+    camera: { x: 120, y: 340, zoom: 0.55 },
+    focusedPath: "/tmp/what-i-was-reading.jsonl",
+    capturedAt: expect.any(String) as unknown as string,
+  }]);
+
+  /* The board has since moved on, exactly as it would have after a real glide. */
+  viewBus.reportSlice({ ...WHERE_I_WAS, focusedPath: ANCHOR, camera: { x: -900, y: -1_400, zoom: 0.9, worldRect: { x: 0, y: 0, width: 10, height: 10 } } });
+
+  click(one("[data-testid='attention-return']")!);
+  await settle();
+
+  expect(log.restored).toEqual([{ x: 120, y: 340, zoom: 0.55 }]);
+  expect(record().state).toBe("returned");
+  expect(record().returnedVia).toBe("control");
+});
+
+test("a vanished anchor degrades to where it was rather than failing or landing anywhere", async () => {
+  raise();
+  /* The reviewer's card is gone from the board; the frame the request was
+     raised against is still a place the operator can be taken. */
+  const { bus, log } = board({ "/tmp/somebody-else.jsonl": LIVE_RECT });
+  mount(bus);
+  await settle();
+
+  click(one("[data-testid='attention-accept']")!);
+  await settle();
+
+  expect(log.moved).toEqual([RAISED_RECT]);
+  expect(record().state).toBe("following");
+  expect(record().resolution).toBe("approximate");
+});
+
+test("a target that resolved to nothing is refused out loud rather than passing for an arrival", async () => {
+  /* No live anchor and no frame worth degrading to. The record refuses to call
+     that a follow, and the surface that asked says so — a control that appeared
+     to work while the view never moved is the failure this whole row exists to
+     avoid. */
+  raiseAttentionRequest({
+    origin: "root-agent",
+    target: { kind: "conversation", path: ANCHOR },
+    frameAtCreation: { project: "demo", rect: { x: 0, y: 0, w: 0, h: 0 }, boardRevision: null },
+    intent: "show",
+    reason: "The reviewer finished with request-changes.",
+  }, { now, id: "attention_1" });
+  const { bus, log } = board({});
+  mount(bus);
+  await settle();
+
+  click(one("[data-testid='attention-accept']")!);
+  await settle();
+
+  expect(log.moved).toEqual([]);
+  expect(record().state).toBe("accepted");
+  expect(record().resolution).toBeUndefined();
+  expect(one("[data-testid='attention-refused']")).not.toBeNull();
+});
+
+test("nothing renders while there is nothing to answer", async () => {
+  const { bus } = board({ [ANCHOR]: LIVE_RECT });
+
+  mount(bus);
+  await settle();
+
+  expect(dom.document.body.textContent).toBe("");
+  expect(one("[data-testid='root-overlay-dock']")).toBeNull();
+});

--- a/src/components/attention/AttentionHost.dom.test.tsx
+++ b/src/components/attention/AttentionHost.dom.test.tsx
@@ -9,7 +9,7 @@ import { flushSync } from "react-dom";
 import { viewBus, type ViewSlice } from "@/hooks/viewPresenceBus";
 import { answerAttentionRequest, attentionForDevice, raiseAttentionRequest } from "@/lib/attention/service";
 import { readAttentionFile } from "@/lib/attention/store";
-import { OFFER_TTL_MS, type FocusRect } from "@/lib/attention/types";
+import { FOLLOW_HOLD_MS, OFFER_TTL_MS, RETURN_WINDOW_MS, type FocusRect } from "@/lib/attention/types";
 import { validateAttentionEvent } from "@/lib/attention/validation";
 
 import { AttentionHost } from "./AttentionHost";
@@ -65,6 +65,9 @@ beforeEach(() => {
   /* The return-project memory lives here and is keyed by request id, which the
      tests reuse; a leak between them would hide the case where it is empty. */
   dom.localStorage.clear();
+  /* The tests that wait a clock out move this, so it is put back rather than
+     leaking a later `now` into whichever test runs next. */
+  now = new Date("2026-07-01T10:00:00.000Z");
   previousStateDir = process.env.LLV_STATE_DIR;
   sandbox = fs.mkdtempSync(path.join(os.tmpdir(), "llv-attention-host-"));
   process.env.LLV_STATE_DIR = sandbox;
@@ -410,6 +413,66 @@ test("a request raised after a handoff that could not land is rendered and answe
 
   const stored = readAttentionFile().requests.find((entry) => entry.id === "attention_2")!;
   expect(stored.state).toBe("following");
+});
+
+test("a request raised after a follow the operator never closed is rendered and answerable", async () => {
+  /* The same silent swallow as the lost landing above, by the other route.
+     `following` admits no event but Return, so an operator who follows and then
+     walks away leaves that request live for good — and, being the oldest live
+     entry, it is the only thing this device is ever shown again. */
+  raise();
+  const { bus } = board({ [ANCHOR]: LIVE_RECT });
+  mount(bus);
+  await settle();
+
+  click(one("[data-testid='attention-accept']")!);
+  await settle();
+  expect(record().state).toBe("following");
+
+  /* Long enough that the card has stopped naming where they came from, so there
+     is nothing left on it to take away. */
+  now = new Date(now.getTime() + RETURN_WINDOW_MS + 1);
+  const second = raiseAttentionRequest({
+    origin: "root-agent",
+    target: { kind: "conversation", path: ANCHOR },
+    frameAtCreation: { project: "demo", rect: RAISED_RECT, boardRevision: 4 },
+    intent: "show",
+    reason: "The verifier is blocked on you.",
+  }, { now, id: "attention_2" }).request;
+
+  await poll();
+
+  expect(one("[data-testid='attention-request']")!.textContent).toContain("The verifier is blocked on you.");
+  expect(attentionForDevice(DEVICE, { now }).offer?.request.id).toBe(second.id);
+  /* Replaced by the agent's newer ask, which is a different fact from the
+     operator refusing it and from nobody ever seeing it. */
+  expect(record().state).toBe("superseded");
+
+  click(one("[data-testid='attention-accept']")!);
+  await settle();
+  expect(readAttentionFile().requests.find((entry) => entry.id === "attention_2")!.state).toBe("following");
+});
+
+test("a follow nobody closes and nothing replaces is still bounded by the clock", async () => {
+  raise();
+  const { bus } = board({ [ANCHOR]: LIVE_RECT });
+  mount(bus);
+  await settle();
+
+  click(one("[data-testid='attention-accept']")!);
+  await settle();
+  expect(record().state).toBe("following");
+
+  /* Nothing is raised after it and Return is never pressed. Without a clock the
+     record stays live indefinitely and the slot with it. */
+  now = new Date(now.getTime() + FOLLOW_HOLD_MS);
+  await poll();
+
+  expect(record().state).toBe("expired");
+  /* Seen, agreed to, never closed — not a refusal, and not "they never saw it". */
+  expect(record().expiredCause).toBe("follow-elapsed");
+  expect(attentionForDevice(DEVICE, { now }).offer).toBeNull();
+  expect(dom.document.body.textContent).toBe("");
 });
 
 test("the refusal band can be dismissed, so a one-off refusal is not a permanent warning", async () => {

--- a/src/components/attention/AttentionHost.tsx
+++ b/src/components/attention/AttentionHost.tsx
@@ -1,0 +1,170 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+import { viewBus } from "@/hooks/viewPresenceBus";
+import { stableDeviceId } from "@/hooks/useViewPresence";
+import type { AttentionRequestV1, ReturnPoint } from "@/lib/attention/types";
+import { useLocale } from "@/lib/i18n";
+import { RootOverlayHost } from "@/components/overlay/RootOverlayHost";
+import { useAttentionOffers, type ViewportCapture } from "@/components/overlay/useAttentionOffers";
+
+import { focusHandoffBus, type FocusHandoffBus } from "./focusHandoffBus";
+import { restoreFocusPoint, runFocusHandoff, type HandoffTiming } from "./navigate";
+
+/**
+ * Where #688's loop is actually mounted (D3).
+ *
+ * Everything below it already existed and is unchanged; what was missing was a
+ * surface that polls the record on a real device and can move the real board.
+ * Three things this file is responsible for, and nothing else is:
+ *
+ * - the DEVICE. One stable id per browser, the same one presence already uses,
+ *   so "which device was offered this" and "which device is looking at what"
+ *   name the same thing. Resolved in an effect because localStorage does not
+ *   exist during the server render;
+ * - the RETURN POINT, captured from this device's own viewport immediately
+ *   before anything moves. It has to be taken before the move rather than at
+ *   arrival, because opening another project moves the view on the way;
+ * - the ORDER: agree, move, then report arrival with how the target resolved.
+ *   A target that resolved to nothing is reported as `lost` and the record
+ *   refuses to call it a follow, which is what keeps "you are looking at it"
+ *   from being written about a view that never went anywhere.
+ *
+ * The overlay renders only while something needs an answer. The root
+ * conversation's own turns are a separate slice (they need a transcript feed
+ * adapter), and a permanently docked empty conversation would be worse than
+ * none — but an unanswered request must never be invisible, which is the whole
+ * failure this mount exists to end.
+ */
+
+/** Fallback height for the mobile sheet before the window can be measured. */
+const DEFAULT_USABLE_HEIGHT = 720;
+
+export interface AttentionHostProps {
+  mobile: boolean;
+  /** Test seams. Production passes none of these. */
+  bus?: FocusHandoffBus;
+  deviceId?: string | null;
+  fetchFn?: typeof fetch;
+  pollMs?: number;
+  timing?: HandoffTiming;
+}
+
+type CapturedViewport = Pick<ReturnPoint, "mode" | "camera" | "focusedPath"> & { project: string | null };
+
+/** This device's viewport, read from the same bus presence publishes from — so
+    the point a return restores is the one the operator was actually at. */
+export function currentViewport(): CapturedViewport {
+  const slice = viewBus.getSlice();
+  const camera = slice.camera;
+  return {
+    mode: slice.mode,
+    /* Null in the modes presence forbids a camera in; there the handoff is a
+       change of mode and focused path rather than a pan. */
+    camera: camera ? { x: camera.x, y: camera.y, zoom: camera.zoom } : null,
+    focusedPath: slice.focusedPath,
+    project: viewBus.getContext().project,
+  };
+}
+
+function browserStorage(): Storage | null {
+  if (typeof window === "undefined") return null;
+  try {
+    return window.localStorage;
+  } catch {
+    /* private-mode storage throw — useViewPresence falls back the same way */
+    return null;
+  }
+}
+
+export function AttentionHost({ mobile, bus = focusHandoffBus, deviceId: forcedDeviceId, fetchFn, pollMs, timing }: AttentionHostProps) {
+  const { t } = useLocale();
+  const [resolvedDeviceId, setResolvedDeviceId] = useState<string | null>(forcedDeviceId ?? null);
+  useEffect(() => {
+    if (forcedDeviceId !== undefined) return;
+    /* eslint-disable-next-line react-hooks/set-state-in-effect -- localStorage is unavailable during the server render, so the id can only be resolved once mounted */
+    setResolvedDeviceId(stableDeviceId(browserStorage()));
+  }, [forcedDeviceId]);
+  const deviceId = forcedDeviceId ?? resolvedDeviceId;
+
+  const [usableHeight, setUsableHeight] = useState(DEFAULT_USABLE_HEIGHT);
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const measure = () => setUsableHeight(window.innerHeight || DEFAULT_USABLE_HEIGHT);
+    measure();
+    window.addEventListener("resize", measure);
+    return () => window.removeEventListener("resize", measure);
+  }, []);
+
+  /* The viewport the operator is leaving, taken before the move and handed to
+     the arrival that records it. Held in a ref because `arrive` reads it after
+     the camera has already gone somewhere else. */
+  const leaving = useRef<CapturedViewport | null>(null);
+  /* The project each return point belongs to. The record's ReturnPoint carries
+     mode, camera and focused path but no project, so the device that captured
+     it remembers that part itself — which is per-device anyway. */
+  const returnProjects = useRef(new Map<string, string | null>());
+
+  const captureViewport = useCallback<ViewportCapture>(() => {
+    const captured = leaving.current ?? currentViewport();
+    return { mode: captured.mode, camera: captured.camera, focusedPath: captured.focusedPath };
+  }, []);
+
+  const offers = useAttentionOffers({
+    deviceId,
+    captureViewport,
+    ...(fetchFn ? { fetchFn } : {}),
+    ...(pollMs ? { pollMs } : {}),
+  });
+
+  const onAccept = useCallback(async (request: AttentionRequestV1) => {
+    const before = currentViewport();
+    leaving.current = before;
+    returnProjects.current.set(request.id, before.project);
+    try {
+      await offers.accept(request);
+      const outcome = await runFocusHandoff(request, bus, timing ?? {});
+      /* Reported whichever way it went: an `exact` or `approximate` arrival
+         becomes a follow with a return point, and a `lost` one is refused by
+         the record — visibly, rather than looking like a move that happened. */
+      await offers.arrive(request, outcome.resolution);
+    } finally {
+      leaving.current = null;
+    }
+  }, [offers, bus, timing]);
+
+  const onReturn = useCallback(async (request: AttentionRequestV1) => {
+    const point = request.returnPoints.find((entry) => entry.deviceId === deviceId);
+    if (point) await restoreFocusPoint(point, returnProjects.current.get(request.id) ?? null, bus, timing ?? {});
+    await offers.goBack(request, "control");
+    returnProjects.current.delete(request.id);
+  }, [offers, bus, deviceId, timing]);
+
+  const handlers = useMemo(() => ({
+    onAcceptAttention: (request: AttentionRequestV1) => { void onAccept(request); },
+    onPreviewAttention: (request: AttentionRequestV1) => { void offers.preview(request); },
+    onDeclineAttention: (request: AttentionRequestV1) => { void offers.decline(request); },
+    onDismissAttention: (request: AttentionRequestV1) => { void offers.dismiss(request); },
+    onReturnAttention: (request: AttentionRequestV1) => { void onReturn(request); },
+  }), [onAccept, onReturn, offers]);
+
+  const offer = offers.offer;
+  const live = Boolean(offer && offer.status !== "none" && offer.status !== "closed");
+  if (!live && !offers.refusal) return null;
+
+  return (
+    <RootOverlayHost
+      mobile={mobile}
+      usableHeight={usableHeight}
+      state="idle"
+      turns={NO_TURNS}
+      attention={offer}
+      attentionRefused={Boolean(offers.refusal)}
+      t={t}
+      {...handlers}
+    />
+  );
+}
+
+const NO_TURNS = Object.freeze([]) as readonly never[];

--- a/src/components/attention/AttentionHost.tsx
+++ b/src/components/attention/AttentionHost.tsx
@@ -11,6 +11,8 @@ import { useAttentionOffers, type ViewportCapture } from "@/components/overlay/u
 
 import { focusHandoffBus, type FocusHandoffBus } from "./focusHandoffBus";
 import { restoreFocusPoint, runFocusHandoff, type HandoffTiming } from "./navigate";
+import { attentionPreviewFor } from "./preview";
+import { forgetReturnProject, readReturnProject, rememberReturnProject } from "./returnProjectMemory";
 
 /**
  * Where #688's loop is actually mounted (D3).
@@ -101,10 +103,6 @@ export function AttentionHost({ mobile, bus = focusHandoffBus, deviceId: forcedD
      the arrival that records it. Held in a ref because `arrive` reads it after
      the camera has already gone somewhere else. */
   const leaving = useRef<CapturedViewport | null>(null);
-  /* The project each return point belongs to. The record's ReturnPoint carries
-     mode, camera and focused path but no project, so the device that captured
-     it remembers that part itself — which is per-device anyway. */
-  const returnProjects = useRef(new Map<string, string | null>());
 
   const captureViewport = useCallback<ViewportCapture>(() => {
     const captured = leaving.current ?? currentViewport();
@@ -121,24 +119,36 @@ export function AttentionHost({ mobile, bus = focusHandoffBus, deviceId: forcedD
   const onAccept = useCallback(async (request: AttentionRequestV1) => {
     const before = currentViewport();
     leaving.current = before;
-    returnProjects.current.set(request.id, before.project);
+    /* Written before the move and outside this component's lifetime, so a
+       reload or a second tab on the same device restores the camera into the
+       project it was captured in — or, knowing nothing, restores no camera at
+       all rather than one project's coordinates in another's layout. */
+    rememberReturnProject(browserStorage(), deviceId, request.id, before.project);
+    let landed = false;
     try {
       await offers.accept(request);
       const outcome = await runFocusHandoff(request, bus, timing ?? {});
+      landed = outcome.resolution !== "lost";
       /* Reported whichever way it went: an `exact` or `approximate` arrival
-         becomes a follow with a return point, and a `lost` one is refused by
-         the record — visibly, rather than looking like a move that happened. */
+         becomes a follow with a return point, and a `lost` one ends the request
+         then and there — visibly, rather than looking like a move that
+         happened, and without leaving it agreed-to but never landed. */
       await offers.arrive(request, outcome.resolution);
     } finally {
       leaving.current = null;
+      /* Nothing landed, so there is no return to make and nothing to remember
+         the project for. Also the path a throw takes out. */
+      if (!landed) forgetReturnProject(browserStorage(), deviceId, request.id);
     }
-  }, [offers, bus, timing]);
+  }, [offers, bus, deviceId, timing]);
 
   const onReturn = useCallback(async (request: AttentionRequestV1) => {
     const point = request.returnPoints.find((entry) => entry.deviceId === deviceId);
-    if (point) await restoreFocusPoint(point, returnProjects.current.get(request.id) ?? null, bus, timing ?? {});
+    if (point) {
+      await restoreFocusPoint(point, readReturnProject(browserStorage(), deviceId, request.id), bus, timing ?? {});
+    }
     await offers.goBack(request, "control");
-    returnProjects.current.delete(request.id);
+    forgetReturnProject(browserStorage(), deviceId, request.id);
   }, [offers, bus, deviceId, timing]);
 
   const handlers = useMemo(() => ({
@@ -153,6 +163,12 @@ export function AttentionHost({ mobile, bus = focusHandoffBus, deviceId: forcedD
   const live = Boolean(offer && offer.status !== "none" && offer.status !== "closed");
   if (!live && !offers.refusal) return null;
 
+  /* The preview card's content, so "let me look first" shows something. Built
+     here rather than in the row because only this side can see the board, which
+     is where the anchor's own name comes from when the operator is already in
+     the project that holds it. */
+  const preview = offer && offer.status === "actionable" ? attentionPreviewFor(offer.request, bus.board()) : null;
+
   return (
     <RootOverlayHost
       mobile={mobile}
@@ -160,7 +176,10 @@ export function AttentionHost({ mobile, bus = focusHandoffBus, deviceId: forcedD
       state="idle"
       turns={NO_TURNS}
       attention={offer}
+      attentionPreview={preview}
       attentionRefused={Boolean(offers.refusal)}
+      attentionRefusedReason={offers.refusal?.reason ?? null}
+      onDismissAttentionRefusal={offers.dismissRefusal}
       t={t}
       {...handlers}
     />

--- a/src/components/attention/focusHandoffBus.ts
+++ b/src/components/attention/focusHandoffBus.ts
@@ -1,0 +1,90 @@
+"use client";
+
+import type { FocusFrameIndex } from "@/lib/attention/resolve";
+import type { FocusRect, ZoomIntent } from "@/lib/attention/types";
+
+/**
+ * The seam an accepted attention request crosses to reach the board (#688).
+ *
+ * Two surfaces already own the halves of a focus handoff and neither can see
+ * the other: the scheme board knows where everything is and how to move the
+ * camera, while the shell knows which project is open and how to open a
+ * conversation. The overlay that answers the request sits beside both. Rather
+ * than thread either through the tree, each registers here — the same idiom
+ * `viewPresenceBus` already uses for exactly this problem, and for the same
+ * reason: publishing a layout must never re-render the board.
+ *
+ * Registration is last-writer-wins with an unregister that only clears its own
+ * entry, so an unmounting board cannot blank the controller a freshly mounted
+ * one just published.
+ */
+
+/**
+ * Where an accepted request landed, in both of the vocabularies a surface might
+ * speak. The desktop board frames the rect; the phone, which shows one pane at
+ * a time and has no camera, selects the anchor. Both are on the destination so
+ * neither surface has to re-derive the other's, and a surface that can honour
+ * neither says so rather than pretending it moved.
+ */
+export interface FocusDestination {
+  rect: FocusRect;
+  /** `inspect` zooms in until the target reads; `situate` fits it with context. */
+  zoom: ZoomIntent;
+  /** Board keys the anchor actually resolved under. Empty when there is no
+      object to select: a geometric target, or a landing degraded to the frame a
+      vanished anchor used to occupy. */
+  anchorKeys: readonly string[];
+}
+
+export interface BoardFocusController {
+  /** Which project's layout this controller speaks for. */
+  project: string;
+  /** The board as it is NOW — rebuilt on every relayout, because a rect read at
+      request time is stale as soon as a sibling appears. */
+  index: FocusFrameIndex;
+  /** Take the view there. False means this surface cannot — the caller then
+      reports `lost` rather than recording an arrival that never happened. */
+  moveTo(destination: FocusDestination): boolean;
+  /** Put the camera back exactly where it was — the return path, which restores
+      a framing rather than framing a thing. False on a surface with no camera. */
+  restoreCamera(camera: { x: number; y: number; zoom: number }): boolean;
+}
+
+export interface ShellNavigator {
+  /** The open project, or null on the overview. */
+  project: string | null;
+  openProject(project: string): void;
+  /** Open a conversation by transcript path — what `intent: "open"` means. */
+  openPath(path: string): void;
+}
+
+export interface FocusHandoffBus {
+  setBoard(controller: BoardFocusController | null): () => void;
+  board(): BoardFocusController | null;
+  setShell(navigator: ShellNavigator | null): () => void;
+  shell(): ShellNavigator | null;
+}
+
+export function createFocusHandoffBus(): FocusHandoffBus {
+  let board: BoardFocusController | null = null;
+  let shell: ShellNavigator | null = null;
+  return {
+    setBoard(controller) {
+      board = controller;
+      return () => {
+        if (board === controller) board = null;
+      };
+    },
+    board: () => board,
+    setShell(navigator) {
+      shell = navigator;
+      return () => {
+        if (shell === navigator) shell = null;
+      };
+    },
+    shell: () => shell,
+  };
+}
+
+/** The app-wide singleton. Components import this; tests build isolated buses. */
+export const focusHandoffBus: FocusHandoffBus = createFocusHandoffBus();

--- a/src/components/attention/navigate.test.ts
+++ b/src/components/attention/navigate.test.ts
@@ -1,0 +1,243 @@
+import { expect, test } from "bun:test";
+
+import { UNREAD_FRAME_RECT } from "@/lib/attention/frames";
+import type { FocusFrameIndex } from "@/lib/attention/resolve";
+import type { AttentionRequestV1, FocusFrame, FocusRect } from "@/lib/attention/types";
+
+import { createFocusHandoffBus, type BoardFocusController, type FocusDestination, type ShellNavigator } from "./focusHandoffBus";
+import { restoreFocusPoint, runFocusHandoff, usableFrame } from "./navigate";
+
+/*
+ * What an accepted request does to the view (#688). Everything here is the part
+ * that was missing entirely: the record and its resolution were built and
+ * tested, but nothing turned a resolution into a move.
+ */
+
+const RECT: FocusRect = { x: 900, y: 1_400, w: 600, h: 780 };
+
+function index(project: string, rects: Record<string, FocusRect>): FocusFrameIndex {
+  return {
+    project,
+    boardRevision: 7,
+    rectFor: (key) => rects[key] ?? null,
+    named: Object.entries(rects).map(([key, rect]) => ({ key, label: key, rect })),
+  };
+}
+
+interface Moves {
+  moved: FocusDestination[];
+  restored: { x: number; y: number; zoom: number }[];
+  opened: string[];
+  projects: string[];
+}
+
+function harness(project: string, rects: Record<string, FocusRect>, shellProject: string | null = project) {
+  const bus = createFocusHandoffBus();
+  const log: Moves = { moved: [], restored: [], opened: [], projects: [] };
+  const board: BoardFocusController = {
+    project,
+    index: index(project, rects),
+    moveTo: (destination) => { log.moved.push(destination); return true; },
+    restoreCamera: (camera) => { log.restored.push(camera); return true; },
+  };
+  const shell: ShellNavigator = {
+    project: shellProject,
+    openProject: (next) => log.projects.push(next),
+    openPath: (path) => log.opened.push(path),
+  };
+  bus.setBoard(board);
+  bus.setShell(shell);
+  return { bus, log, board };
+}
+
+const frame = (project: string, rect: FocusRect = RECT): FocusFrame => ({ project, rect, boardRevision: 4 });
+
+function request(overrides: Partial<AttentionRequestV1> = {}): Pick<AttentionRequestV1, "target" | "frameAtCreation" | "intent" | "zoom"> {
+  return {
+    target: { kind: "conversation", path: "/tmp/reviewer.jsonl" },
+    frameAtCreation: frame("demo"),
+    intent: "show",
+    zoom: "situate",
+    ...overrides,
+  } as Pick<AttentionRequestV1, "target" | "frameAtCreation" | "intent" | "zoom">;
+}
+
+const NO_WAIT = { timeoutMs: 0, pollMs: 0 };
+
+test("accepting resolves the anchor against the board as it is now and moves the camera there", async () => {
+  const live: FocusRect = { x: 40, y: 60, w: 600, h: 780 };
+  const { bus, log } = harness("demo", { "/tmp/reviewer.jsonl": live });
+
+  const outcome = await runFocusHandoff(request(), bus, NO_WAIT);
+
+  expect(outcome.resolution).toBe("exact");
+  expect(outcome.moved).toBe(true);
+  /* The CURRENT rect, never the one recorded at creation: the board reflows, so
+     a stored rect is stale the moment a sibling appears. */
+  expect(log.moved).toEqual([{ rect: live, zoom: "situate", anchorKeys: ["/tmp/reviewer.jsonl"] }]);
+  expect(log.opened).toEqual([]);
+});
+
+test("show frames the target and open also opens it", async () => {
+  const { bus, log } = harness("demo", { "/tmp/reviewer.jsonl": RECT });
+
+  await runFocusHandoff(request({ intent: "open", zoom: "inspect" }), bus, NO_WAIT);
+
+  expect(log.moved).toEqual([{ rect: RECT, zoom: "inspect", anchorKeys: ["/tmp/reviewer.jsonl"] }]);
+  expect(log.opened).toEqual(["/tmp/reviewer.jsonl"]);
+});
+
+test("a vanished anchor degrades to the frame it was raised against, and says so", async () => {
+  /* One-way degradation with a destination, rather than a failure: the anchor
+     is gone but where it was is still somewhere the operator can be taken. */
+  const { bus, log } = harness("demo", { "/tmp/other.jsonl": { x: 0, y: 0, w: 600, h: 780 } });
+
+  const outcome = await runFocusHandoff(request(), bus, NO_WAIT);
+
+  expect(outcome.resolution).toBe("approximate");
+  /* No anchor key travels with a degraded landing: there is no object there any
+     more, so a surface that can only select objects must refuse it. */
+  expect(log.moved).toEqual([{ rect: RECT, zoom: "situate", anchorKeys: [] }]);
+});
+
+test("a vanished anchor whose request never read a board reports lost rather than landing at the origin", async () => {
+  /* A request raised through the agent's tool records no geometry. Degrading to
+     that empty frame would drop the operator at world (0,0) and call it "where
+     it was" — the silent arbitrary landing the design refuses. */
+  const { bus, log } = harness("demo", {});
+
+  const outcome = await runFocusHandoff(
+    request({ frameAtCreation: { project: "demo", rect: UNREAD_FRAME_RECT, boardRevision: null } }),
+    bus,
+    NO_WAIT,
+  );
+
+  expect(outcome.resolution).toBe("lost");
+  expect(outcome.moved).toBe(false);
+  expect(log.moved).toEqual([]);
+  expect(usableFrame({ project: "demo", rect: UNREAD_FRAME_RECT, boardRevision: null })).toBeNull();
+});
+
+test("a target in another project opens that project first and waits for its board", async () => {
+  const bus = createFocusHandoffBus();
+  const log: Moves = { moved: [], restored: [], opened: [], projects: [] };
+  bus.setShell({
+    project: "demo",
+    openProject: (next) => {
+      log.projects.push(next);
+      /* The board of the newly opened project publishes its layout once it has
+         one — the handoff must not resolve against the project it is leaving. */
+      bus.setBoard({
+        project: next,
+        index: index(next, { "task::t1": RECT }),
+        moveTo: (destination) => { log.moved.push(destination); return true; },
+        restoreCamera: (camera) => { log.restored.push(camera); return true; },
+      });
+    },
+    openPath: (path) => log.opened.push(path),
+  });
+
+  const outcome = await runFocusHandoff(
+    request({ target: { kind: "task", taskId: "t1" }, frameAtCreation: frame("other") }),
+    bus,
+    { timeoutMs: 200, pollMs: 1 },
+  );
+
+  expect(log.projects).toEqual(["other"]);
+  expect(outcome.resolution).toBe("exact");
+  expect(log.moved).toEqual([{ rect: RECT, zoom: "situate", anchorKeys: ["task::t1"] }]);
+});
+
+test("nothing moves when no board ever answers for the target's project", async () => {
+  const bus = createFocusHandoffBus();
+  const log: Moves = { moved: [], restored: [], opened: [], projects: [] };
+  bus.setShell({ project: "demo", openProject: (next) => log.projects.push(next), openPath: (path) => log.opened.push(path) });
+
+  const outcome = await runFocusHandoff(request({ frameAtCreation: frame("gone") }), bus, { timeoutMs: 5, pollMs: 1 });
+
+  expect(outcome).toEqual({ resolution: "lost", moved: false, frame: null });
+});
+
+test("a surface that cannot honour the destination reports lost instead of a false arrival", async () => {
+  /* The phone shows one pane at a time and has no camera, so it arrives by
+     pinning the anchor. "Where that card used to be" is not somewhere it can
+     take anyone — and a card claiming the operator arrived would be worse than
+     the honest refusal. */
+  const bus = createFocusHandoffBus();
+  const refusals: FocusDestination[] = [];
+  bus.setBoard({
+    project: "demo",
+    index: index("demo", { "/tmp/other.jsonl": RECT }),
+    moveTo: (destination) => {
+      refusals.push(destination);
+      return destination.anchorKeys.length > 0;
+    },
+    restoreCamera: () => false,
+  });
+
+  const outcome = await runFocusHandoff(request(), bus, NO_WAIT);
+
+  expect(refusals).toHaveLength(1);
+  expect(outcome).toEqual({ resolution: "lost", moved: false, frame: null });
+});
+
+test("returning on a camera-less surface falls back to what was focused there", async () => {
+  const bus = createFocusHandoffBus();
+  const opened: string[] = [];
+  bus.setBoard({ project: "demo", index: index("demo", {}), moveTo: () => true, restoreCamera: () => false });
+  bus.setShell({ project: "demo", openProject: () => {}, openPath: (path) => opened.push(path) });
+
+  const restored = await restoreFocusPoint(
+    { camera: { x: 1, y: 2, zoom: 3 }, focusedPath: "/tmp/what-i-was-reading.jsonl" },
+    "demo",
+    bus,
+    NO_WAIT,
+  );
+
+  expect(restored).toBe(true);
+  expect(opened).toEqual(["/tmp/what-i-was-reading.jsonl"]);
+});
+
+test("returning restores the exact camera the device left, and does not re-open the node", async () => {
+  const { bus, log } = harness("demo", { "/tmp/reviewer.jsonl": RECT });
+
+  const restored = await restoreFocusPoint(
+    { camera: { x: 120, y: 340, zoom: 0.55 }, focusedPath: "/tmp/what-i-was-reading.jsonl" },
+    "demo",
+    bus,
+    NO_WAIT,
+  );
+
+  expect(restored).toBe(true);
+  expect(log.restored).toEqual([{ x: 120, y: 340, zoom: 0.55 }]);
+  /* Opening the focused path would glide the board to that node and undo the
+     framing that was just restored, so the captured camera wins outright. */
+  expect(log.opened).toEqual([]);
+});
+
+test("returning to a camera-less mode restores what was focused there instead", async () => {
+  const { bus, log } = harness("demo", {}, "other");
+
+  const restored = await restoreFocusPoint(
+    { camera: null, focusedPath: "/tmp/what-i-was-reading.jsonl" },
+    "demo",
+    bus,
+    NO_WAIT,
+  );
+
+  expect(restored).toBe(true);
+  expect(log.projects).toEqual(["demo"]);
+  expect(log.opened).toEqual(["/tmp/what-i-was-reading.jsonl"]);
+});
+
+test("an unmounting board never blanks the controller a fresh one just published", () => {
+  const bus = createFocusHandoffBus();
+  const first: BoardFocusController = { project: "a", index: index("a", {}), moveTo: () => true, restoreCamera: () => true };
+  const second: BoardFocusController = { project: "b", index: index("b", {}), moveTo: () => true, restoreCamera: () => true };
+
+  const releaseFirst = bus.setBoard(first);
+  bus.setBoard(second);
+  releaseFirst();
+
+  expect(bus.board()).toBe(second);
+});

--- a/src/components/attention/navigate.test.ts
+++ b/src/components/attention/navigate.test.ts
@@ -215,6 +215,29 @@ test("returning restores the exact camera the device left, and does not re-open 
   expect(log.opened).toEqual([]);
 });
 
+test("a camera is never restored into a project it was not captured in", async () => {
+  /* A null capture project means this device has no memory of taking the point
+     — a reload, or a second tab that shares the device id and renders the same
+     return control. Whatever board happens to be registered is not the one
+     those world coordinates describe, so restoring into it would land the
+     operator at a position that means nothing there. */
+  const { bus, log } = harness("some-other-project", { "/tmp/reviewer.jsonl": RECT });
+
+  const restored = await restoreFocusPoint(
+    { camera: { x: 120, y: 340, zoom: 0.55 }, focusedPath: "/tmp/what-i-was-reading.jsonl" },
+    null,
+    bus,
+    NO_WAIT,
+  );
+
+  expect(log.restored).toEqual([]);
+  /* The focused path names a thing rather than a coordinate, so it is the part
+     of that viewport that still means the same thing anywhere. */
+  expect(restored).toBe(true);
+  expect(log.opened).toEqual(["/tmp/what-i-was-reading.jsonl"]);
+  expect(log.projects).toEqual([]);
+});
+
 test("returning to a camera-less mode restores what was focused there instead", async () => {
   const { bus, log } = harness("demo", {}, "other");
 

--- a/src/components/attention/navigate.ts
+++ b/src/components/attention/navigate.ts
@@ -138,6 +138,15 @@ export async function runFocusHandoff(
  * the focused path would glide the board to that node and undo the restore. In
  * the modes presence forbids a camera in, the focused path IS what they were
  * looking at, so that is what comes back.
+ *
+ * A camera is world coordinates in ONE project's layout, so it is only ever
+ * restored into the project it was captured in. `project` is null when this
+ * device has no memory of capturing the point — after a reload, or in a second
+ * tab that shares the device id and therefore renders the same return control.
+ * Restoring into whichever board happens to be registered would put the
+ * operator at a position that means nothing there, so the camera is skipped and
+ * the focused path — which names a thing rather than a coordinate — is what
+ * comes back instead.
  */
 export async function restoreFocusPoint(
   point: Pick<ReturnPoint, "camera" | "focusedPath">,
@@ -148,8 +157,8 @@ export async function restoreFocusPoint(
   const shell = bus.shell();
   if (project && shell && shell.project !== project) shell.openProject(project);
 
-  if (point.camera) {
-    const board = project ? await boardForProject(bus, project, timing) : bus.board();
+  if (point.camera && project) {
+    const board = await boardForProject(bus, project, timing);
     if (board?.restoreCamera(point.camera)) return true;
     /* A surface with no camera falls through to what was focused there, which
        is the only part of that viewport it can put back. */

--- a/src/components/attention/navigate.ts
+++ b/src/components/attention/navigate.ts
@@ -1,0 +1,164 @@
+import { frameWasRead } from "@/lib/attention/frames";
+import { resolveFocusTarget, type FocusFrameIndex } from "@/lib/attention/resolve";
+import { focusTargetAnchorKeys, isGeometricTarget } from "@/lib/attention/targets";
+import type { FocusTarget } from "@/lib/attention/types";
+import type { AttentionRequestV1, FocusFrame, FocusResolutionKind, ReturnPoint } from "@/lib/attention/types";
+
+import type { FocusHandoffBus } from "./focusHandoffBus";
+
+/**
+ * What an accepted request actually does to the view (#688 D7/D8).
+ *
+ * The whole move is one function of a request and a bus, so the part that is
+ * easy to get wrong — which project, which frame, and what happens when the
+ * anchor is gone — is testable without a renderer or a camera.
+ *
+ * Two rules from the design are enforced here rather than left to the caller:
+ *
+ * - the anchor is resolved against the CURRENT layout, never the stored rect,
+ *   because the board reflows and a rect recorded at creation is stale as soon
+ *   as a sibling appears. The stored frame is the destination only when the
+ *   anchor itself has vanished;
+ * - a frame that was never really read is not a destination. A request raised
+ *   through the agent's tool has no board geometry to record, so it carries a
+ *   zero-area frame; degrading to it would drop the operator at the world
+ *   origin, which is precisely the "somewhere arbitrary" the design forbids.
+ *   Such a frame is discarded, and the resolution reports `lost` instead.
+ */
+
+/** How long a handoff waits for another project's board to publish its layout
+    after the shell was asked to open it. */
+export const BOARD_WAIT_MS = 4_000;
+const BOARD_POLL_MS = 40;
+
+/** Zoom the camera reaches for when the operator is about to READ the target. */
+export const INSPECT_ZOOM = 0.9;
+
+export interface FocusHandoffResult {
+  resolution: FocusResolutionKind;
+  /** Whether the view was actually asked to move. False for `lost`. */
+  moved: boolean;
+  frame: FocusFrame | null;
+}
+
+export interface HandoffTiming {
+  timeoutMs?: number;
+  pollMs?: number;
+  sleep?: (ms: number) => Promise<void>;
+  now?: () => number;
+}
+
+const wait = (ms: number) => new Promise<void>((resolve) => { setTimeout(resolve, ms); });
+
+/** The project a request lands in. A geometric target names its own; every
+    object anchor is found in whichever project's layout holds it, so the frame
+    recorded at creation is what says where to look. */
+export function focusHandoffProject(request: Pick<AttentionRequestV1, "target" | "frameAtCreation">): string {
+  return isGeometricTarget(request.target) ? request.target.project : request.frameAtCreation.project;
+}
+
+/**
+ * The stored frame, but only when it is a real reading of a board.
+ *
+ * See the module note: a degenerate rect is the signature of a request raised
+ * without a board in front of it, and standing in for a vanished anchor with it
+ * would land the operator nowhere in particular.
+ */
+export function usableFrame(frame: FocusFrame | null | undefined): FocusFrame | null {
+  return frameWasRead(frame) ? frame! : null;
+}
+
+/** The anchor's keys that the board actually holds, in preference order. Empty
+    when the landing has no object behind it at all. */
+function presentAnchorKeys(target: FocusTarget | null, index: FocusFrameIndex): string[] {
+  if (!target || isGeometricTarget(target)) return [];
+  return focusTargetAnchorKeys(target).filter((key) => index.rectFor(key) !== null);
+}
+
+async function boardForProject(bus: FocusHandoffBus, project: string, timing: HandoffTiming) {
+  const timeoutMs = timing.timeoutMs ?? BOARD_WAIT_MS;
+  const pollMs = timing.pollMs ?? BOARD_POLL_MS;
+  const sleep = timing.sleep ?? wait;
+  const now = timing.now ?? (() => Date.now());
+  const deadline = now() + timeoutMs;
+  for (;;) {
+    const board = bus.board();
+    if (board?.project === project) return board;
+    if (now() >= deadline) return null;
+    await sleep(pollMs);
+  }
+}
+
+/**
+ * Move the operator's view to an accepted request's target.
+ *
+ * The caller has already captured where they were leaving from — that has to
+ * happen before this runs, because opening another project moves the view on
+ * its own.
+ */
+export async function runFocusHandoff(
+  request: Pick<AttentionRequestV1, "target" | "frameAtCreation" | "intent" | "zoom">,
+  bus: FocusHandoffBus,
+  timing: HandoffTiming = {},
+): Promise<FocusHandoffResult> {
+  const project = focusHandoffProject(request);
+  const shell = bus.shell();
+  if (shell && shell.project !== project) shell.openProject(project);
+
+  const board = await boardForProject(bus, project, timing);
+  const resolved = resolveFocusTarget(request.target, usableFrame(request.frameAtCreation), board?.index ?? null);
+  if (!board || !resolved.frame || resolved.resolution === "lost") {
+    /* Nowhere to land. Nothing moves, and the caller reports `lost` to the
+       record rather than pretending the operator arrived somewhere. */
+    return { resolution: "lost", moved: false, frame: null };
+  }
+
+  const moved = board.moveTo({
+    rect: resolved.frame.rect,
+    zoom: request.zoom,
+    anchorKeys: presentAnchorKeys(resolved.degraded ? null : resolved.target, board.index),
+  });
+  /* A surface that cannot go there has not gone there. The phone shows one pane
+     at a time and has no camera, so "where that card used to be" is not
+     somewhere it can take anyone — and saying so is better than a card that
+     claims the operator arrived. */
+  if (!moved) return { resolution: "lost", moved: false, frame: null };
+  /* `open` also opens the target's own surface; `show` frames it and stops
+     there. Only a conversation has a surface to open — a geometric target is
+     refused the intent at creation, and the rest are board objects the frame
+     itself puts on screen. */
+  if (request.intent === "open" && request.target.kind === "conversation") shell?.openPath(request.target.path);
+  return { resolution: resolved.resolution, moved: true, frame: resolved.frame };
+}
+
+/**
+ * Put the view back where the operator was before they agreed.
+ *
+ * A captured camera is the authoritative framing and wins outright: re-opening
+ * the focused path would glide the board to that node and undo the restore. In
+ * the modes presence forbids a camera in, the focused path IS what they were
+ * looking at, so that is what comes back.
+ */
+export async function restoreFocusPoint(
+  point: Pick<ReturnPoint, "camera" | "focusedPath">,
+  project: string | null,
+  bus: FocusHandoffBus,
+  timing: HandoffTiming = {},
+): Promise<boolean> {
+  const shell = bus.shell();
+  if (project && shell && shell.project !== project) shell.openProject(project);
+
+  if (point.camera) {
+    const board = project ? await boardForProject(bus, project, timing) : bus.board();
+    if (board?.restoreCamera(point.camera)) return true;
+    /* A surface with no camera falls through to what was focused there, which
+       is the only part of that viewport it can put back. */
+  }
+  if (point.focusedPath && shell) {
+    shell.openPath(point.focusedPath);
+    return true;
+  }
+  /* Nothing was captured worth restoring — an overview with no focused card is
+     already where they were, and the project switch above is the whole move. */
+  return Boolean(project && shell);
+}

--- a/src/components/attention/preview.ts
+++ b/src/components/attention/preview.ts
@@ -1,0 +1,73 @@
+import { focusTargetAnchorKeys } from "@/lib/attention/targets";
+import type { AttentionRequestV1, FocusTarget } from "@/lib/attention/types";
+import type { AttentionPreview } from "@/components/overlay/AttentionActionRow";
+
+import type { BoardFocusController } from "./focusHandoffBus";
+import { focusHandoffProject } from "./navigate";
+
+/**
+ * What "let me look first" actually shows (#688 step 3).
+ *
+ * A preview NEVER moves the view, so everything it says has to come from
+ * something already known here: the board's own label for the anchor when this
+ * device is looking at the project that holds it, the target's own identity
+ * otherwise, and the project the request recorded. Nothing is invented — a
+ * request raised through the agent's tool has no board geometry behind it, and
+ * the preview says what the request is about rather than describing a layout
+ * the raiser never read.
+ *
+ * The context label is the one line of detail, and it is already bounded and
+ * operator-safe on the record. The target's contents are deliberately not here:
+ * that is what accepting, and the transcript, are for.
+ */
+
+/** The last path segment, without the transcript extension — what a
+    conversation is called when the board has no label for it. */
+function conversationName(path: string): string {
+  const leaf = path.split("/").filter(Boolean).at(-1) ?? path;
+  return leaf.replace(/\.jsonl$/i, "") || path;
+}
+
+/** The target's own identity, in the vocabulary the operator already sees on
+    the board. Never a guess: every one of these is on the request. */
+export function focusTargetName(target: FocusTarget): string {
+  switch (target.kind) {
+    case "conversation":
+      return conversationName(target.path);
+    case "pipeline":
+      return target.pipelineId;
+    case "stage":
+      return `${target.pipelineId} · ${target.stageId}`;
+    case "flowRound":
+      return `${target.flowId} · ${target.round}`;
+    case "task":
+      return target.taskId;
+    case "draft":
+      return target.draftId;
+    case "region":
+      return `${Math.round(target.rect.x)}, ${Math.round(target.rect.y)}`;
+    case "point":
+      return `${Math.round(target.x)}, ${Math.round(target.y)}`;
+  }
+}
+
+/**
+ * The preview card for a request, built from the target and — when this device
+ * is already looking at the right project — the board's own name for it.
+ */
+export function attentionPreviewFor(
+  request: Pick<AttentionRequestV1, "target" | "frameAtCreation" | "contextLabel">,
+  board: BoardFocusController | null,
+): AttentionPreview {
+  const project = focusHandoffProject(request);
+  const keys = focusTargetAnchorKeys(request.target);
+  /* Only this project's board may name the anchor: another project's layout can
+     hold the same key for a different thing. */
+  const named = board && board.project === project ? board.index.named ?? [] : [];
+  const label = keys.length ? named.find((frame) => keys.includes(frame.key))?.label ?? null : null;
+  return {
+    title: label ?? focusTargetName(request.target),
+    project,
+    detail: request.contextLabel ?? null,
+  };
+}

--- a/src/components/attention/returnProjectMemory.test.ts
+++ b/src/components/attention/returnProjectMemory.test.ts
@@ -1,0 +1,96 @@
+import { expect, test } from "bun:test";
+
+import { forgetReturnProject, readReturnProject, rememberReturnProject } from "./returnProjectMemory";
+
+/*
+ * The per-device half of a return point (#688 D8).
+ *
+ * The record cannot hold this: return points are per-device, and a project
+ * written into the shared record by the device that accepted would be read by
+ * every other device's restore. A component ref cannot hold it either — the
+ * device id is in localStorage and therefore shared by every tab, so a reload
+ * or a second tab renders the same return control with the memory gone.
+ */
+
+/** localStorage, near enough: the same three methods, and a throwing variant
+    for the private-mode case. */
+function storage(initial: Record<string, string> = {}): Storage & { data: Record<string, string> } {
+  const data = { ...initial };
+  return {
+    data,
+    get length() { return Object.keys(data).length; },
+    clear() { for (const key of Object.keys(data)) delete data[key]; },
+    getItem: (key: string) => data[key] ?? null,
+    setItem: (key: string, value: string) => { data[key] = value; },
+    removeItem: (key: string) => { delete data[key]; },
+    key: (index: number) => Object.keys(data)[index] ?? null,
+  } as Storage & { data: Record<string, string> };
+}
+
+test("what one tab remembers, the next one reads — that is the whole point of it being durable", () => {
+  const shared = storage();
+
+  rememberReturnProject(shared, "device-a", "attention_1", "demo");
+
+  expect(readReturnProject(shared, "device-a", "attention_1")).toBe("demo");
+});
+
+test("the memory is per device, so one device's capture never steers another's restore", () => {
+  const shared = storage();
+  rememberReturnProject(shared, "device-a", "attention_1", "demo");
+
+  expect(readReturnProject(shared, "device-b", "attention_1")).toBeNull();
+});
+
+test("an unknown request reads as nothing remembered, which is what refuses a foreign camera", () => {
+  const shared = storage();
+
+  expect(readReturnProject(shared, "device-a", "attention_1")).toBeNull();
+  expect(readReturnProject(null, "device-a", "attention_1")).toBeNull();
+  expect(readReturnProject(shared, null, "attention_1")).toBeNull();
+});
+
+test("a return forgets its own entry and leaves the others alone", () => {
+  const shared = storage();
+  rememberReturnProject(shared, "device-a", "attention_1", "demo");
+  rememberReturnProject(shared, "device-a", "attention_2", "other");
+
+  forgetReturnProject(shared, "device-a", "attention_1");
+
+  expect(readReturnProject(shared, "device-a", "attention_1")).toBeNull();
+  expect(readReturnProject(shared, "device-a", "attention_2")).toBe("other");
+});
+
+test("the memory is bounded, and it is the oldest entries that fall away", () => {
+  const shared = storage();
+  for (let index = 0; index < 12; index += 1) {
+    rememberReturnProject(shared, "device-a", `attention_${index}`, `project_${index}`);
+  }
+
+  expect(readReturnProject(shared, "device-a", "attention_0")).toBeNull();
+  expect(readReturnProject(shared, "device-a", "attention_11")).toBe("project_11");
+});
+
+test("a mode with no camera is remembered as its project all the same", () => {
+  /* The overview has no project and no camera. Remembering that is a different
+     fact from never having captured anything, but both restore the same way —
+     what matters is that neither invents a project to restore a camera into. */
+  const shared = storage();
+  rememberReturnProject(shared, "device-a", "attention_1", null);
+
+  expect(readReturnProject(shared, "device-a", "attention_1")).toBeNull();
+});
+
+test("unreadable storage is an empty memory rather than a thrown return", () => {
+  const broken = {
+    getItem: () => "{not json",
+    setItem: () => { throw new Error("quota"); },
+    removeItem: () => {},
+  } as unknown as Storage;
+
+  expect(readReturnProject(broken, "device-a", "attention_1")).toBeNull();
+  /* Private mode refuses the write; the return still happens, it just cannot
+     restore a camera afterwards. */
+  expect(() => rememberReturnProject(broken, "device-a", "attention_1", "demo")).not.toThrow();
+  expect(() => forgetReturnProject(broken, "device-a", "attention_1")).not.toThrow();
+});

--- a/src/components/attention/returnProjectMemory.ts
+++ b/src/components/attention/returnProjectMemory.ts
@@ -1,0 +1,84 @@
+/**
+ * Which project each return point was captured in (#688 D8).
+ *
+ * The record's `ReturnPoint` carries mode, camera and focused path but no
+ * project, and it must not carry one: return points are per-device, and a
+ * project written into the shared record by the device that accepted would be
+ * read by every other device's restore. So the capturing device remembers that
+ * part itself.
+ *
+ * It has to be remembered somewhere durable rather than in a component ref. The
+ * device id lives in `localStorage` and is therefore shared by every tab in the
+ * browser, so a second tab renders the same `following` request and offers the
+ * same return control — and a reload of the accepting tab does too. A camera is
+ * world coordinates in one project's layout; restoring one into a different
+ * project's board lands the operator somewhere arbitrary, which is exactly what
+ * the return promise rules out. Storing it beside the device id puts the memory
+ * in the same scope as the identity that can act on it.
+ *
+ * A missing entry is not an error: it means this browser never captured that
+ * point, and the restore degrades to the focused path rather than guessing.
+ */
+
+const KEY_PREFIX = "llv.attention.return-project.";
+/** Return windows are 60s and one request is answered at a time; anything past
+    a handful of entries is history nobody can act on. */
+const MAX_REMEMBERED = 8;
+
+type Remembered = Record<string, string | null>;
+
+function keyFor(deviceId: string): string {
+  return `${KEY_PREFIX}${deviceId}`;
+}
+
+function read(storage: Storage | null, deviceId: string | null): Remembered {
+  if (!storage || !deviceId) return {};
+  try {
+    const raw = storage.getItem(keyFor(deviceId));
+    if (!raw) return {};
+    const parsed = JSON.parse(raw) as unknown;
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return {};
+    return Object.fromEntries(
+      Object.entries(parsed as Record<string, unknown>)
+        .filter(([, value]) => value === null || typeof value === "string"),
+    ) as Remembered;
+  } catch {
+    /* Unreadable or unparseable storage is an empty memory, never a throw: the
+       return still works, it just cannot restore a camera. */
+    return {};
+  }
+}
+
+function write(storage: Storage | null, deviceId: string | null, value: Remembered): void {
+  if (!storage || !deviceId) return;
+  try {
+    storage.setItem(keyFor(deviceId), JSON.stringify(value));
+  } catch {
+    /* Private mode, or a full quota. The restore degrades; nothing else does. */
+  }
+}
+
+/** The project this device was in when it captured the point for `requestId`,
+    or null when this browser has no record of capturing it. */
+export function readReturnProject(storage: Storage | null, deviceId: string | null, requestId: string): string | null {
+  return read(storage, deviceId)[requestId] ?? null;
+}
+
+export function rememberReturnProject(
+  storage: Storage | null,
+  deviceId: string | null,
+  requestId: string,
+  project: string | null,
+): void {
+  const current = read(storage, deviceId);
+  delete current[requestId];
+  const entries = [...Object.entries(current), [requestId, project] as const].slice(-MAX_REMEMBERED);
+  write(storage, deviceId, Object.fromEntries(entries) as Remembered);
+}
+
+export function forgetReturnProject(storage: Storage | null, deviceId: string | null, requestId: string): void {
+  const current = read(storage, deviceId);
+  if (!(requestId in current)) return;
+  delete current[requestId];
+  write(storage, deviceId, current);
+}

--- a/src/components/mobile/MobileFocusView.tsx
+++ b/src/components/mobile/MobileFocusView.tsx
@@ -33,7 +33,9 @@ import { MobilePipelineDock } from "./MobilePipelineDock";
 import { MobilePipelineDockSheet, MobilePipelineSummaryButton, MobilePipelineSummaryRow } from "./MobilePipelineDockSheet";
 import { conversationIdentity } from "@/lib/accounts/identity";
 import { SubagentTray, type SubagentTrayApi } from "../scheme/SubagentTrayView";
+import { focusHandoffBus } from "@/components/attention/focusHandoffBus";
 import { deckKey } from "@/components/scheme/agentLinks";
+import { buildFocusFrameIndex, stageAnchorAliases } from "@/components/scheme/focusFrames";
 import { buildSchemeLayout } from "@/components/scheme/layout";
 import { SubagentBadges } from "@/components/scheme/SubagentBadges";
 import { layoutPipelineGroups, type PipelinePane } from "@/components/scheme/pipelineAnchor";
@@ -201,6 +203,26 @@ export function MobileFocusView({ project, groups, manual, files, flows, reviewG
     [layout],
   );
   const byKey = useMemo(() => new Map(entries.map((entry) => [entry.key, entry])), [entries]);
+
+  /* #688: the phone's half of a focus handoff. It resolves anchors through the
+     same index the desktop board publishes, but arrives by pinning the pane
+     rather than by moving a camera — there is no camera here, and one pane is
+     on screen at a time. A destination with no pane behind it (a coordinate, or
+     the space a vanished card used to occupy) is refused rather than answered
+     with an arrival that did not happen. */
+  const focusIndex = useMemo(() => buildFocusFrameIndex(layout, project, { aliases: stageAnchorAliases(pipelines) }), [layout, project, pipelines]);
+  useEffect(() => focusHandoffBus.setBoard({
+    project,
+    index: focusIndex,
+    moveTo: ({ anchorKeys }) => {
+      const landing = anchorKeys.find((key) => byKey.has(key));
+      if (!landing) return false;
+      setFocusPath(landing);
+      setMapOpen(false);
+      return true;
+    },
+    restoreCamera: () => false,
+  }), [project, focusIndex, byKey]);
 
   /* eslint-disable react-hooks/set-state-in-effect */
   useEffect(() => {

--- a/src/components/overlay/AttentionActionRow.tsx
+++ b/src/components/overlay/AttentionActionRow.tsx
@@ -6,6 +6,8 @@ import type { DeviceAttentionOffer } from "@/lib/attention/service";
 import type { AttentionRequestV1 } from "@/lib/attention/types";
 import type { TFunction } from "@/lib/i18n";
 
+import { LOST_TARGET_REFUSAL } from "./useAttentionOffers";
+
 /**
  * The overlay's action row — the band that is 0px tall until something needs an
  * answer (#691), and the surface where #688's consent contract becomes visible.
@@ -40,8 +42,14 @@ export interface AttentionActionRowProps {
   onDismiss: (request: AttentionRequestV1) => void;
   onReturn: (request: AttentionRequestV1) => void;
   onRevokeAutoFollow?: () => void;
-  /** Set when this device's last answer was refused by the record. */
+  /** Set when this device's last answer was refused by the record, or when the
+      handoff it agreed to found nowhere to land. */
   refused?: boolean;
+  /** Why, when the surface knows. `lost-target` is the one case with its own
+      sentence: nothing was refused, there was simply nowhere to go. */
+  refusedReason?: string | null;
+  /** Take the refusal band off screen. Absent leaves it to its own expiry. */
+  onDismissRefusal?: () => void;
   /** Mobile controls are larger, deliberately. */
   controlSize: number;
   t: TFunction;
@@ -88,16 +96,33 @@ export function AttentionActionRow({
   onReturn,
   onRevokeAutoFollow,
   refused,
+  refusedReason,
+  onDismissRefusal,
   controlSize,
   t,
 }: AttentionActionRowProps) {
   /* An answer the record turned down is said out loud on the surface that sent
      it. Silently swallowing it would leave the operator tapping a control that
-     does nothing — the failure this whole row exists to avoid. */
+     does nothing — the failure this whole row exists to avoid. It is a message
+     about one answer, so it can always be got rid of: a band with no way out
+     would be the same dead surface in the other direction. */
   const refusal = refused ? (
-    <p className="px-2 py-1 text-caption text-warning" role="status" aria-live="polite" data-testid="attention-refused">
-      {t("attention.refused")}
-    </p>
+    <div className="flex items-start gap-2 px-2 py-1" data-testid="attention-refused">
+      <p className="flex-1 text-caption text-warning" role="status" aria-live="polite">
+        {t(refusedReason === LOST_TARGET_REFUSAL ? "attention.lostTarget" : "attention.refused")}
+      </p>
+      {onDismissRefusal ? (
+        <button
+          type="button"
+          data-testid="attention-refused-dismiss"
+          onClick={onDismissRefusal}
+          aria-label={t("attention.refusedDismiss")}
+          className="shrink-0 text-caption text-muted underline hover:text-secondary"
+        >
+          {t("attention.refusedDismiss")}
+        </button>
+      ) : null}
+    </div>
   ) : null;
 
   /* Standing consent is visible wherever it is in force and revocable from

--- a/src/components/overlay/RootOverlay.dom.test.tsx
+++ b/src/components/overlay/RootOverlay.dom.test.tsx
@@ -219,6 +219,22 @@ test("an answer the record refused is said on the surface that sent it", () => {
   expect(one("[data-testid='attention-refused']")).not.toBeNull();
 });
 
+test("a refusal can be got rid of, and a handoff with nowhere to go says that instead", () => {
+  const dismissals: number[] = [];
+  mount({
+    attention: null,
+    attentionRefused: true,
+    attentionRefusedReason: "lost-target",
+    onDismissAttentionRefusal: () => dismissals.push(1),
+  });
+
+  /* Nothing was refused — there was simply nowhere to take them — and saying
+     "that did not go through" would describe the wrong thing. */
+  expect(one("[data-testid='attention-refused']")!.textContent).toContain("nowhere to take you");
+  click(one("[data-testid='attention-refused-dismiss']")!);
+  expect(dismissals).toEqual([1]);
+});
+
 test("a preview shows a text card and never moves the view", () => {
   mount({
     attention: offer({ request: request({ state: "previewing" }) }),

--- a/src/components/overlay/RootOverlay.tsx
+++ b/src/components/overlay/RootOverlay.tsx
@@ -55,6 +55,10 @@ export interface RootOverlayProps {
   /** This device's last answer was refused by the record; the action row says
       so rather than leaving the operator with a control that did nothing. */
   attentionRefused?: boolean;
+  /** Which refusal it was, when the surface knows. */
+  attentionRefusedReason?: string | null;
+  /** Take the refusal band off screen. */
+  onDismissAttentionRefusal?: () => void;
   autoFollow?: { scope: "session" | "project"; label: string } | null;
   /** Sheet only: Rail collapses the timeline to a single line. */
   density?: TimelineDensity;
@@ -256,6 +260,8 @@ export function RootOverlay(props: RootOverlayProps) {
             preview={attentionPreview ?? null}
             autoFollow={autoFollow ?? null}
             refused={attentionRefused}
+            refusedReason={props.attentionRefusedReason ?? null}
+            onDismissRefusal={props.onDismissAttentionRefusal}
             controlSize={controlSize}
             onAccept={props.onAcceptAttention}
             onPreview={props.onPreviewAttention}

--- a/src/components/overlay/useAttentionOffers.dom.test.tsx
+++ b/src/components/overlay/useAttentionOffers.dom.test.tsx
@@ -92,7 +92,7 @@ const viewport: Pick<ReturnPoint, "mode" | "camera" | "focusedPath"> = {
   focusedPath: "/tmp/what-i-was-reading.jsonl",
 };
 
-function mount(fetchFn: typeof fetch, surfaceVisible?: () => boolean): { current: AttentionOffersHandle | null } {
+function mount(fetchFn: typeof fetch, surfaceVisible?: () => boolean, refusalTtlMs?: number): { current: AttentionOffersHandle | null } {
   const box: { current: AttentionOffersHandle | null } = { current: null };
   function Harness() {
     box.current = useAttentionOffers({
@@ -100,6 +100,7 @@ function mount(fetchFn: typeof fetch, surfaceVisible?: () => boolean): { current
       captureViewport: () => viewport,
       fetchFn,
       pollMs: 100_000,
+      ...(refusalTtlMs === undefined ? {} : { refusalTtlMs }),
       ...(surfaceVisible ? { surfaceVisible } : {}),
     });
     return null;
@@ -231,6 +232,56 @@ test("a refused answer re-reads the record and is visible, rather than passing f
   await handle.current!.preview(request("offered"));
   await settle();
   expect(handle.current!.refusal).toBeNull();
+});
+
+test("a refusal takes itself off screen, and can be taken off sooner", async () => {
+  const refusing = (async () => ({
+    ok: false,
+    status: 409,
+    json: async () => ({ error: "invalid-transition", state: "previewing" }),
+  })) as unknown as typeof fetch;
+
+  const handle = mount(refusing, undefined, 20);
+  await settle();
+  await handle.current!.decline(request("previewing"));
+  await settle();
+  expect(handle.current!.refusal).not.toBeNull();
+
+  /* A one-off race must not leave a warning band standing for the rest of the
+     session — nothing else ever clears it if no further answer is sent. */
+  await new Promise((resolve) => setTimeout(resolve, 40));
+  await settle();
+  expect(handle.current!.refusal).toBeNull();
+
+  await handle.current!.decline(request("previewing"));
+  await settle();
+  expect(handle.current!.refusal).not.toBeNull();
+  handle.current!.dismissRefusal();
+  await settle();
+  expect(handle.current!.refusal).toBeNull();
+});
+
+test("a handoff with nowhere to land closes the request rather than reporting an arrival", async () => {
+  const posted: unknown[] = [];
+  const fetchFn = (async (_url: string, init?: { body?: string }) => {
+    if (init?.body) posted.push(JSON.parse(init.body));
+    return { ok: true, status: 200, json: async () => view("offered") };
+  }) as unknown as typeof fetch;
+
+  const handle = mount(fetchFn);
+  await settle();
+  posted.length = 0;
+
+  await handle.current!.arrive(request("accepted"), "lost");
+  await settle();
+
+  /* `arrive` with a lost resolution is refused by the machine and leaves the
+     request agreed-to forever, so this device closes it instead — and never
+     sends a return point for a move that did not happen. */
+  expect(posted).toEqual([{ kind: "abandon", deviceId: DEVICE }]);
+  /* The operator pressed a control and the view stayed put; the surface says so
+     on the same band a refusal uses. */
+  expect(handle.current!.refusal).toEqual({ requestId: "attention_1", reason: "lost-target", state: null });
 });
 
 test("a server that cannot be reached is not a refusal", async () => {

--- a/src/components/overlay/useAttentionOffers.ts
+++ b/src/components/overlay/useAttentionOffers.ts
@@ -29,6 +29,17 @@ import type { AttentionRequestV1, AttentionState, FocusResolutionKind, ReturnPoi
 /** The viewport this device is about to leave. */
 export type ViewportCapture = () => Pick<ReturnPoint, "mode" | "camera" | "focusedPath">;
 
+/** How long a refusal stays on screen before it takes itself off. A refusal is
+    a message about one answer, not a status: left standing it becomes a warning
+    band the operator cannot get rid of, and after the record has moved on it is
+    describing something that is no longer true. Dismissible before then. */
+export const REFUSAL_TTL_MS = 12_000;
+
+/** The refusal reason a handoff that found nowhere to land reports. Not a
+    server code: the record accepted the close, and this is what the surface
+    says about it. */
+export const LOST_TARGET_REFUSAL = "lost-target";
+
 /** The server refused this device's own answer. Transport failures are NOT
     refusals: those retry silently, because nothing was decided. */
 export interface AttentionRefusal {
@@ -43,8 +54,10 @@ export interface AttentionOffersHandle {
   view: DeviceAttentionView | null;
   offer: DeviceAttentionView["offer"];
   /** Set when this device's last answer was refused; cleared by the next one
-      that lands. */
+      that lands, by the operator, or by its own expiry. */
   refusal: AttentionRefusal | null;
+  /** Take the refusal band off screen. */
+  dismissRefusal: () => void;
   accept: (request: AttentionRequestV1, via?: "operator" | "auto-follow") => Promise<void>;
   preview: (request: AttentionRequestV1) => Promise<void>;
   /** Refuse before looking. Valid only from `offered`. */
@@ -52,7 +65,8 @@ export interface AttentionOffersHandle {
   /** Looked, and stayed put. Valid only from `previewing` — a different fact
       from declining unseen, and the machine keeps them apart. */
   dismiss: (request: AttentionRequestV1) => Promise<void>;
-  /** Called once the camera has landed, with how the target resolved. */
+  /** Called once the camera has landed, with how the target resolved. A `lost`
+      resolution ends the request instead of recording an arrival — see below. */
   arrive: (request: AttentionRequestV1, resolution: FocusResolutionKind) => Promise<void>;
   goBack: (request: AttentionRequestV1, via?: "control" | "manual-move") => Promise<void>;
   refresh: () => Promise<void>;
@@ -71,12 +85,15 @@ export function useAttentionOffers({
   deviceId,
   captureViewport,
   pollMs = 4_000,
+  refusalTtlMs = REFUSAL_TTL_MS,
   fetchFn,
   surfaceVisible,
 }: {
   deviceId: string | null;
   captureViewport: ViewportCapture;
   pollMs?: number;
+  /** Test seam. Production leaves this at {@link REFUSAL_TTL_MS}. */
+  refusalTtlMs?: number;
   fetchFn?: typeof fetch;
   /** Whether this surface is on screen. Defaults to the document's own
       visibility; a sheet collapsed out of sight passes its own answer. */
@@ -199,6 +216,17 @@ export function useAttentionOffers({
 
   const arrive = useCallback(async (request: AttentionRequestV1, resolution: FocusResolutionKind) => {
     if (!deviceId) return;
+    if (resolution === "lost") {
+      /* Nothing moved, so there is no arrival to record and no return point
+         worth keeping. The device that agreed closes its own request: reporting
+         it as an arrival would be refused by the record and leave the request
+         `accepted` forever — the oldest live entry, and therefore the only
+         thing this device is ever offered again. The operator is told on the
+         same surface, because they pressed a control and the view stayed put. */
+      await answer(request.id, { kind: "abandon", deviceId });
+      setRefusal({ requestId: request.id, reason: LOST_TARGET_REFUSAL, state: null });
+      return;
+    }
     await answer(request.id, {
       kind: "arrive",
       deviceId,
@@ -207,10 +235,20 @@ export function useAttentionOffers({
     });
   }, [answer, deviceId, captureViewport]);
 
+  /* A refusal is about one answer, so it outlives that answer by a bounded
+     moment and no longer. Keyed on the refusal itself, so a second one restarts
+     the clock rather than inheriting the first one's remaining time. */
+  useEffect(() => {
+    if (!refusal) return;
+    const timer = setTimeout(() => setRefusal((current) => (current === refusal ? null : current)), refusalTtlMs);
+    return () => clearTimeout(timer);
+  }, [refusal, refusalTtlMs]);
+
   return {
     view,
     offer: view?.offer ?? null,
     refusal,
+    dismissRefusal: useCallback(() => setRefusal(null), []),
     accept,
     preview: useCallback(async (request) => {
       if (deviceId) await answer(request.id, { kind: "preview", deviceId });

--- a/src/components/scheme/SchemeBoard.tsx
+++ b/src/components/scheme/SchemeBoard.tsx
@@ -24,7 +24,10 @@ import { cleanTitle } from "@/components/utils";
 import { taskDeliveryText } from "@/lib/tasks/helpers";
 
 import { compactPipelineLayoutFlows, compactPipelineOpenTarget, pipelineAnnouncement, pipelineLinkedTasks, pipelineStageByAgentPath, pipelineStripByPath, renderableFlowIds, stagePaneTitleOf } from "@/components/pipelines/pipelineModel";
+import { focusHandoffBus } from "@/components/attention/focusHandoffBus";
+import { INSPECT_ZOOM } from "@/components/attention/navigate";
 import { BulkActionBar } from "./BulkActionBar";
+import { buildFocusFrameIndex, stageAnchorAliases } from "./focusFrames";
 import { EdgeChips } from "./EdgeChips";
 import { nodesInRect, pruneSelection, selectionBBox } from "./lasso";
 import { resolveExpandedNode } from "./expandedNode";
@@ -717,6 +720,7 @@ export function SchemeBoard({
     manualNonce,
     glideBy,
     glideFrame,
+    glideToCamera,
   } = useSchemeCamera({
     project,
     layout,
@@ -739,6 +743,37 @@ export function SchemeBoard({
     onZoomKey: navZoomRef,
     onFit: announceFit,
   });
+
+  /* #688: the board half of a focus handoff. The index is rebuilt from the
+     layout on every relayout on purpose — an accepted request resolves its
+     anchor against the board as it is NOW, never against the rect recorded when
+     the request was raised. The map instance stays out of it: a phone's
+     full-screen map is a transient overlay, not the surface a handoff lands on. */
+  const stageAliases = useMemo(() => stageAnchorAliases(pipelines), [pipelines]);
+  const focusIndex = useMemo(
+    () => buildFocusFrameIndex(layout, project, { extraRects: taskRects, aliases: stageAliases }),
+    [layout, project, taskRects, stageAliases],
+  );
+  useEffect(() => {
+    if (mapMode) return;
+    return focusHandoffBus.setBoard({
+      project,
+      index: focusIndex,
+      /* Zoom follows intent (D8): `inspect` goes in until the target reads,
+         `situate` fits the frame with context around it. A camera can go
+         anywhere, including to where a vanished card used to be, so this
+         surface never refuses a destination. */
+      moveTo: ({ rect, zoom }) => {
+        if (zoom === "inspect") glideFrame({ ...rect }, INSPECT_ZOOM);
+        else fitRect({ ...rect });
+        return true;
+      },
+      restoreCamera: (camera) => {
+        glideToCamera(camera);
+        return true;
+      },
+    });
+  }, [mapMode, project, focusIndex, glideFrame, fitRect, glideToCamera]);
 
   /* Screen-space boxes of fixed board chrome an edge chip must never paint over
      — the subagent avatar/round stack and the composer/input, tagged

--- a/src/components/scheme/focusFrames.test.ts
+++ b/src/components/scheme/focusFrames.test.ts
@@ -3,7 +3,9 @@ import { expect, test } from "bun:test";
 import { resolveFocusTarget } from "@/lib/attention/resolve";
 import type { FileEntry } from "@/lib/types";
 
-import { buildFocusFrameIndex, type FocusLayoutSlice } from "./focusFrames";
+import type { Pipeline } from "@/lib/pipelines/types";
+
+import { buildFocusFrameIndex, stageAnchorAliases, type FocusLayoutSlice } from "./focusFrames";
 import type { SchemeGroup, SchemeNode, SchemeRect } from "./layout";
 
 const rect = (x: number, y: number, w = 600, h = 780): SchemeRect => ({ x, y, w, h });
@@ -66,6 +68,25 @@ test("a stage that has launched resolves through its live card under the same ke
 
   expect(resolved.resolution).toBe("exact");
   expect(resolved.frame!.rect).toEqual({ x: 4_000, y: 4_000, w: 600, h: 780 });
+});
+
+test("a launched stage's alias follows the attempt the operator would be taken to", () => {
+  /* A retried stage has several attempts; the slot it dissolved into belongs to
+     the newest one with a transcript, not the first one that ever ran. */
+  const pipelines = [{
+    id: "p1",
+    runs: [
+      { stageId: "s1", attempts: [{ agentPath: "/tmp/first.jsonl" }, { agentPath: "/tmp/retry.jsonl" }] },
+      { stageId: "s2", attempts: [{ agentPath: null }] },
+    ],
+  }] as unknown as Pipeline[];
+
+  const aliases = stageAnchorAliases(pipelines);
+
+  expect(aliases.get("slot::p1::s1")).toBe("/tmp/retry.jsonl");
+  /* A stage that never launched has no alias — its own slot is still on the
+     board, and the frame index resolves it directly. */
+  expect(aliases.has("slot::p1::s2")).toBe(false);
 });
 
 test("a point borrows the name of the nearest card for the spoken sentence", () => {

--- a/src/components/scheme/focusFrames.ts
+++ b/src/components/scheme/focusFrames.ts
@@ -1,7 +1,9 @@
 import type { FocusFrameIndex, NamedFrame } from "@/lib/attention/resolve";
 import type { FocusRect } from "@/lib/attention/types";
+import type { Pipeline } from "@/lib/pipelines/types";
 import { cleanTitle } from "@/lib/title";
 
+import { stageSlotKey } from "./agentLinks";
 import type { SchemeLayout, SchemeRect } from "./layout";
 
 /**
@@ -34,6 +36,26 @@ export interface FocusFrameIndexOptions {
    */
   aliases?: ReadonlyMap<string, string>;
   boardRevision?: number | null;
+}
+
+/**
+ * Stage anchor → the layout key that holds it once the stage has launched.
+ *
+ * A planned stage IS its slot and resolves directly; a launched one dissolved
+ * its slot into the live conversation card of the agent running it. The newest
+ * attempt with a transcript wins, so a retried stage points at the attempt the
+ * operator would actually be taken to. Everything this reads is already on the
+ * pipeline record, so the frame index never has to learn the pipeline model.
+ */
+export function stageAnchorAliases(pipelines: readonly Pipeline[]): Map<string, string> {
+  const aliases = new Map<string, string>();
+  for (const pipeline of pipelines) {
+    for (const run of pipeline.runs) {
+      const path = [...run.attempts].reverse().find((attempt) => attempt.agentPath)?.agentPath;
+      if (path) aliases.set(stageSlotKey(pipeline.id, run.stageId), path);
+    }
+  }
+  return aliases;
 }
 
 /** Everything on the board that has a name a spoken sentence can borrow. */

--- a/src/components/scheme/useSchemeCamera.ts
+++ b/src/components/scheme/useSchemeCamera.ts
@@ -102,6 +102,8 @@ export interface SchemeCamera {
   /** Glide the anchor to the `centerOn` placement at an explicit zoom — the
       keyboard zoom ladder, which unlike `centerOn` may zoom out below `c.z`. */
   glideFrame: (rect: SchemeRect, z: number) => void;
+  /** Put the camera back at an exact position (#688's return point). */
+  glideToCamera: (camera: { x: number; y: number; zoom: number }) => void;
 }
 
 /**
@@ -395,6 +397,16 @@ export function useSchemeCamera({
   const glideBy = useCallback(
     (wdx: number, wdy: number) => {
       glideTo((c) => clampCam({ ...c, x: c.x - wdx * c.z, y: c.y - wdy * c.z }));
+    },
+    [glideTo, clampCam],
+  );
+
+  /* Restore an exact camera — #688's return point, which puts back a framing
+     rather than framing a thing, so unlike every other move here it takes the
+     position verbatim (still clamped, since the world may have shrunk). */
+  const glideToCamera = useCallback(
+    (next: { x: number; y: number; zoom: number }) => {
+      glideTo(clampCam({ x: next.x, y: next.y, z: next.zoom }));
     },
     [glideTo, clampCam],
   );
@@ -795,5 +807,6 @@ export function useSchemeCamera({
     manualNonce,
     glideBy,
     glideFrame,
+    glideToCamera,
   };
 }

--- a/src/lib/attention/frames.ts
+++ b/src/lib/attention/frames.ts
@@ -1,0 +1,24 @@
+import type { FocusFrame, FocusRect } from "./types";
+
+/**
+ * Whether a request's frame is a real reading of a board (#688 D7).
+ *
+ * The anchor/frame split exists so a vanished anchor still leaves a usable
+ * destination — but only when the frame was read off a board in the first
+ * place. A request raised through the agent's tool has no board in front of it:
+ * the server knows which project the target lives in and nothing about where it
+ * sits, so the frame it records is deliberately empty.
+ *
+ * Standing in for a vanished anchor with an empty frame would take the operator
+ * to the world origin and call it "where it was", which is exactly the silent
+ * arbitrary landing the design refuses. One predicate, shared by whoever writes
+ * such a frame and whoever would otherwise navigate to it, so the two cannot
+ * drift.
+ */
+
+/** The frame recorded when the raiser could not read the board. */
+export const UNREAD_FRAME_RECT: FocusRect = { x: 0, y: 0, w: 0, h: 0 };
+
+export function frameWasRead(frame: FocusFrame | null | undefined): boolean {
+  return Boolean(frame && frame.project.length > 0 && frame.rect.w > 0 && frame.rect.h > 0);
+}

--- a/src/lib/attention/machine.test.ts
+++ b/src/lib/attention/machine.test.ts
@@ -2,13 +2,22 @@ import { expect, test } from "bun:test";
 
 import {
   applyAttentionEvent,
+  expiryCauseByClock,
   expiryFrom,
   isExpiredByClock,
   offerStatusForDevice,
   returnControlIsLive,
   type AttentionEvent,
 } from "./machine";
-import { OFFER_TTL_MS, RETURN_WINDOW_MS, type AttentionRequestV1, type AttentionState, type ReturnPoint } from "./types";
+import {
+  ACCEPTED_LANDING_GRACE_MS,
+  isTerminalAttentionState,
+  OFFER_TTL_MS,
+  RETURN_WINDOW_MS,
+  type AttentionRequestV1,
+  type AttentionState,
+  type ReturnPoint,
+} from "./types";
 
 const T0 = new Date("2026-07-01T10:00:00.000Z");
 const later = (ms: number) => new Date(T0.getTime() + ms);
@@ -173,7 +182,7 @@ test("a device that was never offered the request cannot answer it", () => {
   expect(wrongLander.ok === false && wrongLander.reason).toBe("not-acknowledger");
 });
 
-test("landing on a lost target is refused so the caller expires it instead", () => {
+test("landing on a lost target is refused, and the device closes the request instead", () => {
   const accepted = drive([{ kind: "offer", deviceId: "device-a" }, { kind: "accept", deviceId: "device-a" }]);
 
   const transition = applyAttentionEvent(accepted, {
@@ -186,6 +195,69 @@ test("landing on a lost target is refused so the caller expires it instead", () 
   expect(transition.ok).toBe(false);
   if (transition.ok) return;
   expect(transition.reason).toBe("lost-target");
+
+  /* And that is the whole point of `abandon`: without it the request has no
+     legal event left at all — every one of these is refused from `accepted` —
+     so it stays the device's oldest live entry forever and every later request
+     is offered behind it, rendered by nothing, and expires as if ignored. */
+  for (const event of [
+    { kind: "expire", cause: "ttl" },
+    { kind: "decline", deviceId: "device-a" },
+    { kind: "dismiss", deviceId: "device-a" },
+    { kind: "return", deviceId: "device-a", via: "control" },
+    { kind: "offer", deviceId: "device-a" },
+    { kind: "supersede", by: "attention_2" },
+  ] as const satisfies readonly AttentionEvent[]) {
+    expect(applyAttentionEvent(accepted, event, { now: T0 }).ok).toBe(false);
+  }
+
+  const closed = applyAttentionEvent(accepted, { kind: "abandon", deviceId: "device-a" }, { now: T0 });
+  expect(closed.ok).toBe(true);
+  if (!closed.ok) return;
+  expect(closed.request.state).toBe("expired");
+  /* Its own cause: not a refusal, and not "they never answered". */
+  expect(closed.request.expiredCause).toBe("lost");
+  expect(isTerminalAttentionState(closed.request.state)).toBe(true);
+});
+
+test("only the device that agreed may abandon, and only from accepted", () => {
+  const accepted = drive([
+    { kind: "offer", deviceId: "device-a" },
+    { kind: "offer", deviceId: "device-b" },
+    { kind: "accept", deviceId: "device-a" },
+  ]);
+
+  const other = applyAttentionEvent(accepted, { kind: "abandon", deviceId: "device-b" }, { now: T0 });
+  expect(other.ok).toBe(false);
+  if (other.ok) return;
+  expect(other.reason).toBe("not-acknowledger");
+
+  /* A device that has not agreed to anything cannot close an offer it simply
+     does not like — that is what `decline` is, and it is a different fact. */
+  const offered = drive([{ kind: "offer", deviceId: "device-a" }]);
+  const early = applyAttentionEvent(offered, { kind: "abandon", deviceId: "device-a" }, { now: T0 });
+  expect(early.ok).toBe(false);
+  if (early.ok) return;
+  expect(early.reason).toBe("invalid-transition");
+});
+
+test("an agreed request that never lands is ended by the clock as lost, never as unseen", () => {
+  const accepted = drive([{ kind: "offer", deviceId: "device-a" }, { kind: "accept", deviceId: "device-a" }]);
+
+  /* The move is bounded by the board wait, so a request still `accepted` a
+     minute later is a device that agreed and then went away — a closed tab, a
+     crash. Nothing else could ever end it. */
+  expect(expiryCauseByClock(accepted, later(ACCEPTED_LANDING_GRACE_MS - 1))).toBeNull();
+  expect(expiryCauseByClock(accepted, later(ACCEPTED_LANDING_GRACE_MS))).toBe("lost");
+
+  /* And a TTL is not a thing that may be said about it: "they never answered"
+     is exactly the fact the record is there to keep straight. */
+  const asUnseen = applyAttentionEvent(accepted, { kind: "expire", cause: "ttl" }, { now: later(ACCEPTED_LANDING_GRACE_MS) });
+  expect(asUnseen.ok).toBe(false);
+  const asLost = applyAttentionEvent(accepted, { kind: "expire", cause: "lost" }, { now: later(ACCEPTED_LANDING_GRACE_MS) });
+  expect(asLost.ok).toBe(true);
+  if (!asLost.ok) return;
+  expect(asLost.request.expiredCause).toBe("lost");
 });
 
 test("a writer working from a revision that has moved is refused", () => {
@@ -198,9 +270,10 @@ test("a writer working from a revision that has moved is refused", () => {
   expect(stale.reason).toBe("stale-revision");
 });
 
-test("only pre-acceptance requests run out on the clock", () => {
+test("an unanswered request runs out on the TTL, and a followed one has no clock at all", () => {
   const pending = request();
-  expect(isExpiredByClock(pending, later(OFFER_TTL_MS - 1))).toBe(false);
+  expect(expiryCauseByClock(pending, later(OFFER_TTL_MS - 1))).toBeNull();
+  expect(expiryCauseByClock(pending, later(OFFER_TTL_MS))).toBe("ttl");
   expect(isExpiredByClock(pending, later(OFFER_TTL_MS))).toBe(true);
 
   const following = drive([

--- a/src/lib/attention/machine.test.ts
+++ b/src/lib/attention/machine.test.ts
@@ -11,6 +11,7 @@ import {
 } from "./machine";
 import {
   ACCEPTED_LANDING_GRACE_MS,
+  FOLLOW_HOLD_MS,
   isTerminalAttentionState,
   OFFER_TTL_MS,
   RETURN_WINDOW_MS,
@@ -134,8 +135,8 @@ test.each<[string, AttentionEvent, AttentionState]>([
   ["returning from an offer nobody accepted", { kind: "return", deviceId: "device-a", via: "control" }, "offered"],
   ["previewing something already accepted", { kind: "preview", deviceId: "device-a" }, "accepted"],
   ["declining something already accepted", { kind: "decline", deviceId: "device-a" }, "accepted"],
-  ["expiring a request the view already moved for", { kind: "expire", cause: "ttl" }, "following"],
-  ["superseding a request the view already moved for", { kind: "supersede", by: "attention_2" }, "following"],
+  ["expiring a follow as though nobody had ever seen it", { kind: "expire", cause: "ttl" }, "following"],
+  ["superseding a follow while its way back is still live", { kind: "supersede", by: "attention_2" }, "following"],
 ])("out-of-order transition is refused: %s", (_label, event, state) => {
   const setup: Record<string, AttentionEvent[]> = {
     offered: [{ kind: "offer", deviceId: "device-a" }],
@@ -270,20 +271,93 @@ test("a writer working from a revision that has moved is refused", () => {
   expect(stale.reason).toBe("stale-revision");
 });
 
-test("an unanswered request runs out on the TTL, and a followed one has no clock at all", () => {
+test("an unanswered request runs out on the TTL", () => {
   const pending = request();
   expect(expiryCauseByClock(pending, later(OFFER_TTL_MS - 1))).toBeNull();
   expect(expiryCauseByClock(pending, later(OFFER_TTL_MS))).toBe("ttl");
   expect(isExpiredByClock(pending, later(OFFER_TTL_MS))).toBe(true);
+});
 
-  const following = drive([
+const followed = () => drive([
+  { kind: "offer", deviceId: "device-a" },
+  { kind: "accept", deviceId: "device-a" },
+  { kind: "arrive", deviceId: "device-a", returnPoint: returnPoint("device-a"), resolution: "exact" },
+]);
+
+test("a follow nobody ever closes is bounded by the clock, and never called unseen", () => {
+  const following = followed();
+
+  /* The bound is what matters: `following` has no other way out — Return is the
+     only event it admits — so without a clock this request stays live forever,
+     holds the device's one offer slot as the oldest live entry, and every later
+     request is stamped `offered`, rendered by nothing, and expires as if the
+     operator had ignored it. */
+  expect(expiryCauseByClock(following, later(FOLLOW_HOLD_MS - 1))).toBeNull();
+  expect(expiryCauseByClock(following, later(FOLLOW_HOLD_MS))).toBe("follow-elapsed");
+  expect(isExpiredByClock(following, later(FOLLOW_HOLD_MS))).toBe(true);
+
+  const closed = applyAttentionEvent(following, { kind: "expire", cause: "follow-elapsed" }, { now: later(FOLLOW_HOLD_MS) });
+  expect(closed.ok).toBe(true);
+  if (!closed.ok) return;
+  expect(isTerminalAttentionState(closed.request.state)).toBe(true);
+  /* The operator saw this one and agreed to it. Reporting it to the agent as a
+     TTL expiry would say they never looked, which is the opposite lesson. */
+  expect(closed.request.expiredCause).toBe("follow-elapsed");
+
+  /* And the hold sits far past the window in which the card still names where
+     the operator came from, so nothing live is ever taken away. */
+  expect(FOLLOW_HOLD_MS).toBeGreaterThan(RETURN_WINDOW_MS);
+});
+
+test("a newer request replaces a follow once its way back has collapsed, and not before", () => {
+  const following = followed();
+
+  /* Mid-handoff the return point is the operator's, and a newer request waits:
+     superseding here would take away the only way back they still have. */
+  const tooSoon = applyAttentionEvent(following, { kind: "supersede", by: "attention_2" }, { now: later(RETURN_WINDOW_MS - 1) });
+  expect(tooSoon.ok).toBe(false);
+
+  /* Afterwards the control has collapsed and the record holds nothing the
+     operator can press — so it yields rather than shadowing a live agent. */
+  const replaced = applyAttentionEvent(following, { kind: "supersede", by: "attention_2" }, { now: later(RETURN_WINDOW_MS) });
+  expect(replaced.ok).toBe(true);
+  if (!replaced.ok) return;
+  expect(replaced.request.state).toBe("superseded");
+  expect(replaced.request.supersededBy).toBe("attention_2");
+});
+
+test("a device whose clock reads far ahead cannot keep its follow un-evictable", () => {
+  /* The return point's `capturedAt` is the CLIENT's clock. Reading the window
+     off it would let the one party the bound exists to constrain decide it is
+     never over — the wedge back again, wearing a wristwatch. */
+  const skewed = drive([
     { kind: "offer", deviceId: "device-a" },
     { kind: "accept", deviceId: "device-a" },
-    { kind: "arrive", deviceId: "device-a", returnPoint: returnPoint("device-a"), resolution: "exact" },
+    {
+      kind: "arrive",
+      deviceId: "device-a",
+      returnPoint: { ...returnPoint("device-a"), capturedAt: later(RETURN_WINDOW_MS * 1_000).toISOString() },
+      resolution: "exact",
+    },
   ]);
-  /* A timer taking the return point away after the view already moved would
-     strand the operator wherever they landed. */
-  expect(isExpiredByClock(following, later(OFFER_TTL_MS * 10))).toBe(false);
+
+  const replaced = applyAttentionEvent(skewed, { kind: "supersede", by: "attention_2" }, { now: later(RETURN_WINDOW_MS) });
+
+  expect(replaced.ok).toBe(true);
+  if (!replaced.ok) return;
+  expect(replaced.request.state).toBe("superseded");
+});
+
+test("a move still in flight is never superseded, however long it takes", () => {
+  const accepted = drive([{ kind: "offer", deviceId: "device-a" }, { kind: "accept", deviceId: "device-a" }]);
+
+  /* `accepted` has its own clock (the landing grace) and its own ending. It has
+     no return point yet, so nothing here may read "the way back has collapsed"
+     as licence to drop a handoff that is still happening. */
+  const transition = applyAttentionEvent(accepted, { kind: "supersede", by: "attention_2" }, { now: later(RETURN_WINDOW_MS * 10) });
+  expect(transition.ok).toBe(false);
+  if (transition.ok) return;
+  expect(transition.reason).toBe("invalid-transition");
 });
 
 test("the return control names where you came from for its window, then stops", () => {

--- a/src/lib/attention/machine.ts
+++ b/src/lib/attention/machine.ts
@@ -1,5 +1,6 @@
 import {
   ACCEPTED_LANDING_GRACE_MS,
+  FOLLOW_HOLD_MS,
   isTerminalAttentionState,
   OFFER_TTL_MS,
   RETURN_WINDOW_MS,
@@ -86,9 +87,15 @@ function advance(
  * acceptance it is the TTL: nobody answered. After acceptance it is the landing
  * grace: somebody agreed and the move never completed, which is the one state a
  * request could otherwise never leave — `arrive` refuses a lost landing, and
- * `return` needs a follow that never began. A `following` request has no clock
- * at all: the view is where the request asked for, and a timer taking the
- * return point away would strand the operator there.
+ * `return` needs a follow that never began. And after landing it is the follow
+ * hold: the only way out of `following` is the operator pressing Return, so an
+ * operator who walks away instead leaves it live forever, holding the device's
+ * one offer slot against every request raised after it.
+ *
+ * The hold runs far past the return window on purpose. Within that window the
+ * card still names where the operator came from and a clock taking it away
+ * would strand them; long after it, the control has already collapsed and the
+ * record is holding a slot on behalf of a card with nothing left to press.
  */
 export function expiryCauseByClock(request: AttentionRequestV1, now: Date): ExpiryCause | null {
   if (PRE_ACCEPTANCE.includes(request.state)) {
@@ -97,7 +104,30 @@ export function expiryCauseByClock(request: AttentionRequestV1, now: Date): Expi
   if (request.state === "accepted") {
     return now.getTime() - Date.parse(request.stateChangedAt) >= ACCEPTED_LANDING_GRACE_MS ? "lost" : null;
   }
+  if (request.state === "following") {
+    return now.getTime() - Date.parse(request.stateChangedAt) >= FOLLOW_HOLD_MS ? "follow-elapsed" : null;
+  }
   return null;
+}
+
+/**
+ * Whether a follow is still inside the window in which the way back is live.
+ *
+ * The device-agnostic counterpart to {@link returnControlIsLive}, because the
+ * one thing that may end a follow early — a newer request from the same agent —
+ * has no device to ask about. It means the same thing by it: is there still a
+ * live way back that dropping this record would take away.
+ *
+ * Measured from `stateChangedAt`, which the SERVER wrote when the arrival
+ * landed, and never from a return point's `capturedAt`, which is the client's
+ * own clock. A device whose clock reads far ahead would otherwise keep its
+ * follow permanently un-evictable — the wedge this bound exists to close,
+ * reintroduced by trusting the wedged party for the time. `capturedAt` is at or
+ * before the arrival, so this window closes no earlier than the control the
+ * operator can actually see.
+ */
+export function followReturnWindowOpen(request: AttentionRequestV1, now: Date): boolean {
+  return request.state === "following" && now.getTime() - Date.parse(request.stateChangedAt) < RETURN_WINDOW_MS;
 }
 
 /** Whether the clock alone has run this request out. */
@@ -111,6 +141,13 @@ export function returnControlIsLive(request: AttentionRequestV1, deviceId: strin
   if (request.state !== "following" || request.acknowledgedBy !== deviceId) return false;
   const captured = request.returnPoints.find((point) => point.deviceId === deviceId);
   return captured !== undefined && now.getTime() - Date.parse(captured.capturedAt) < RETURN_WINDOW_MS;
+}
+
+/** Whether this request is still holding the screen for something the operator
+    can act on, as opposed to a follow they have long since wandered away from.
+    A collapsed follow yields the device's one offer slot to a live request. */
+export function offerStillActionable(request: AttentionRequestV1, now: Date): boolean {
+  return request.state !== "following" || followReturnWindowOpen(request, now);
 }
 
 /**
@@ -238,7 +275,11 @@ export function applyAttentionEvent(
          cause is checked rather than trusted: nothing may end an agreed request
          by calling it a TTL expiry, which would say the operator never saw it. */
       const landingLost = request.state === "accepted" && event.cause === "lost";
-      if (!PRE_ACCEPTANCE.includes(request.state) && !landingLost) return refuse(request, "invalid-transition");
+      /* And from `following` it is only ever the follow hold, for the same
+         reason: a follow the operator saw and agreed to may not be closed as a
+         TTL expiry, which would report it to the agent as never seen. */
+      const followElapsed = request.state === "following" && event.cause === "follow-elapsed";
+      if (!PRE_ACCEPTANCE.includes(request.state) && !landingLost && !followElapsed) return refuse(request, "invalid-transition");
       /* The cause is kept, not just acted on: the caller that dropped a request
          to make room is gone as soon as its response is written, and the record
          still has to be able to say which kind of ending this was. */
@@ -246,11 +287,19 @@ export function applyAttentionEvent(
     }
 
     case "supersede": {
-      /* One speaker, so a second request means it changed its mind. It may not
-         supersede a request the operator already agreed to: the view has moved,
-         and taking the record away would take the return point with it. */
-      if (!PRE_ACCEPTANCE.includes(request.state)) return refuse(request, "invalid-transition");
-      return advance(request, "superseded", now, { supersededBy: event.by });
+      /* One speaker, so a second request means it changed its mind. */
+      if (PRE_ACCEPTANCE.includes(request.state)) return advance(request, "superseded", now, { supersededBy: event.by });
+      /* A follow may be replaced once its way back has collapsed, and never
+         before. While the return control still names where the operator came
+         from, superseding would take that point away from someone who is mid-
+         handoff — so it is refused, and the newer request waits the window out.
+         Afterwards the record holds nothing the operator can still use, and
+         letting it shadow the newer request is how a live agent goes unheard.
+         `accepted` is never superseded either way: the move is in flight. */
+      if (request.state === "following" && !followReturnWindowOpen(request, now)) {
+        return advance(request, "superseded", now, { supersededBy: event.by });
+      }
+      return refuse(request, "invalid-transition");
     }
   }
 }

--- a/src/lib/attention/machine.ts
+++ b/src/lib/attention/machine.ts
@@ -1,4 +1,5 @@
 import {
+  ACCEPTED_LANDING_GRACE_MS,
   isTerminalAttentionState,
   OFFER_TTL_MS,
   RETURN_WINDOW_MS,
@@ -26,6 +27,9 @@ export type AttentionEvent =
   | { kind: "accept"; deviceId: string; via?: "operator" | "auto-follow" }
   /** The view reached the target; the pre-move viewport comes with it. */
   | { kind: "arrive"; deviceId: string; returnPoint: ReturnPoint; resolution: FocusResolutionKind }
+  /** The device that agreed could not land: there was nowhere to go. Its own
+      close for a handoff that never happened — see the `abandon` case. */
+  | { kind: "abandon"; deviceId: string }
   | { kind: "decline"; deviceId: string }
   /** Looked, and stayed put. */
   | { kind: "dismiss"; deviceId: string }
@@ -76,12 +80,29 @@ function advance(
 }
 
 /**
- * Whether the clock alone has run this request out. Only pre-acceptance states
- * expire: once the operator has agreed, the view has moved or is moving, and a
- * timer taking the return point away with it would strand them.
+ * How the clock alone would end this request, or null while it may still run.
+ *
+ * Two different clocks, because they answer two different questions. Before
+ * acceptance it is the TTL: nobody answered. After acceptance it is the landing
+ * grace: somebody agreed and the move never completed, which is the one state a
+ * request could otherwise never leave — `arrive` refuses a lost landing, and
+ * `return` needs a follow that never began. A `following` request has no clock
+ * at all: the view is where the request asked for, and a timer taking the
+ * return point away would strand the operator there.
  */
+export function expiryCauseByClock(request: AttentionRequestV1, now: Date): ExpiryCause | null {
+  if (PRE_ACCEPTANCE.includes(request.state)) {
+    return Date.parse(request.expiresAt) <= now.getTime() ? "ttl" : null;
+  }
+  if (request.state === "accepted") {
+    return now.getTime() - Date.parse(request.stateChangedAt) >= ACCEPTED_LANDING_GRACE_MS ? "lost" : null;
+  }
+  return null;
+}
+
+/** Whether the clock alone has run this request out. */
 export function isExpiredByClock(request: AttentionRequestV1, now: Date): boolean {
-  return PRE_ACCEPTANCE.includes(request.state) && Date.parse(request.expiresAt) <= now.getTime();
+  return expiryCauseByClock(request, now) !== null;
 }
 
 /** Whether the return control still names where the operator came from. Past
@@ -168,14 +189,29 @@ export function applyAttentionEvent(
     case "arrive": {
       if (request.state !== "accepted") return refuse(request, "invalid-transition");
       if (request.acknowledgedBy !== event.deviceId) return refuse(request, "not-acknowledger");
-      /* Nowhere to land is not a follow. The caller expires the request, which
-         writes one line to the conversation rather than a silent no-op. */
+      /* Nowhere to land is not a follow. The device that agreed closes it with
+         `abandon` instead, which writes one line to the conversation rather
+         than a silent no-op — and never records a follow that did not happen. */
       if (event.resolution === "lost") return refuse(request, "lost-target");
       const returnPoints = [
         ...request.returnPoints.filter((point) => point.deviceId !== event.deviceId),
         event.returnPoint,
       ];
       return advance(request, "following", now, { returnPoints, resolution: event.resolution });
+    }
+
+    /* The accepting device's own way out of a handoff that found nowhere to go.
+       It is deliberately none of the other three endings: nobody refused
+       anything, so it is not `declined`; the offer was seen and agreed to, so
+       it is not a TTL expiry; and the view never moved, so it is not a follow
+       that was returned from. The cause on the record says which it was, and
+       the request becomes terminal at once — otherwise it stays `accepted`
+       forever and, being the oldest live entry, hides every later offer on that
+       device behind a card nothing renders. */
+    case "abandon": {
+      if (request.state !== "accepted") return refuse(request, "invalid-transition");
+      if (request.acknowledgedBy !== event.deviceId) return refuse(request, "not-acknowledger");
+      return advance(request, "expired", now, { expiredCause: "lost" });
     }
 
     case "decline": {
@@ -197,7 +233,12 @@ export function applyAttentionEvent(
     }
 
     case "expire": {
-      if (!PRE_ACCEPTANCE.includes(request.state)) return refuse(request, "invalid-transition");
+      /* The clock's own event, and never a client's — see `validateAttentionEvent`.
+         From `accepted` it is only ever the landing grace running out, so the
+         cause is checked rather than trusted: nothing may end an agreed request
+         by calling it a TTL expiry, which would say the operator never saw it. */
+      const landingLost = request.state === "accepted" && event.cause === "lost";
+      if (!PRE_ACCEPTANCE.includes(request.state) && !landingLost) return refuse(request, "invalid-transition");
       /* The cause is kept, not just acted on: the caller that dropped a request
          to make room is gone as soon as its response is written, and the record
          still has to be able to say which kind of ending this was. */

--- a/src/lib/attention/service.test.ts
+++ b/src/lib/attention/service.test.ts
@@ -6,7 +6,7 @@ import path from "node:path";
 import { readAttentionFile } from "./store";
 import { answerAttentionRequest, attentionForDevice, autoFollowEligible, raiseAttentionRequest } from "./service";
 import { AttentionRequestError, validateAttentionCreate, validateAttentionEvent } from "./validation";
-import { OFFER_TTL_MS, RETURN_WINDOW_MS, type FocusFrame, type ReturnPoint } from "./types";
+import { FOLLOW_HOLD_MS, OFFER_TTL_MS, RETURN_WINDOW_MS, type FocusFrame, type ReturnPoint } from "./types";
 
 let sandbox = "";
 let previousStateDir: string | undefined;
@@ -102,6 +102,89 @@ test("the return control collapses after its window while the record stays put",
      itself must survive the control disappearing. */
   expect(after.offer!.request.returnPoints).toEqual([whereIWas]);
   expect(answerAttentionRequest("attention_1", { kind: "return", deviceId: DEVICE, via: "control" }, { now: later(RETURN_WINDOW_MS + 1) }).ok).toBe(true);
+});
+
+/** Drive one request all the way to `following` at this device. */
+function followAt(id: string, now = T0) {
+  answerAttentionRequest(id, { kind: "offer", deviceId: DEVICE }, { now });
+  answerAttentionRequest(id, { kind: "accept", deviceId: DEVICE }, { now });
+  answerAttentionRequest(id, {
+    kind: "arrive",
+    deviceId: DEVICE,
+    returnPoint: { ...whereIWas, capturedAt: now.toISOString() },
+    resolution: "exact",
+  }, { now });
+}
+
+test("a follow the operator never closes stops being this device's only offer", () => {
+  raise();
+  followAt("attention_1");
+
+  /* The whole defect, at the surface it is felt on. `following` admits no event
+     but Return, so an operator who walks away instead leaves this request live
+     forever; as the oldest live entry it is what the device renders, and the
+     request raised after it never reaches a screen at all. */
+  const second = raiseAttentionRequest({
+    origin: "root-agent",
+    target: { kind: "conversation", path: "/tmp/verifier.jsonl" },
+    frameAtCreation: frame,
+    intent: "show",
+    reason: "The verifier is blocked on you.",
+  }, { now: later(RETURN_WINDOW_MS + 1), id: "attention_2" });
+
+  /* Raising it is what collapses the stale follow: one speaker, and its way
+     back had already gone. */
+  expect(second.superseded).toEqual(["attention_1"]);
+
+  /* And it reaches the screen — the device renders it exactly as the polling
+     surface does, and the record moves pending → offered. */
+  answerAttentionRequest("attention_2", { kind: "offer", deviceId: DEVICE }, { now: later(RETURN_WINDOW_MS + 1) });
+
+  const view = attentionForDevice(DEVICE, { now: later(RETURN_WINDOW_MS + 1) });
+  expect(view.offer!.request.id).toBe("attention_2");
+  expect(view.offer!.status).toBe("actionable");
+});
+
+test("a follow is bounded even when nothing is ever raised after it", () => {
+  raise();
+  followAt("attention_1");
+
+  /* Nothing supersedes it, nobody presses Return: the clock is the only thing
+     left, and without it this record is live for the life of the file. */
+  const view = attentionForDevice(DEVICE, { now: later(FOLLOW_HOLD_MS) });
+
+  expect(view.expired).toEqual(["attention_1"]);
+  expect(view.offer).toBeNull();
+  expect(view.live).toEqual([]);
+  /* Ended as what it was: seen, agreed to, and never closed. */
+  expect(readAttentionFile().requests[0]!.expiredCause).toBe("follow-elapsed");
+});
+
+test("an operator still mid-handoff keeps the return control, and the newer request waits", () => {
+  raise();
+  followAt("attention_1");
+
+  const second = raiseAttentionRequest({
+    origin: "root-agent",
+    target: { kind: "conversation", path: "/tmp/verifier.jsonl" },
+    frameAtCreation: frame,
+    intent: "show",
+    reason: "The verifier is blocked on you.",
+  }, { now: later(RETURN_WINDOW_MS - 1), id: "attention_2" });
+
+  /* Inside the window the way back is still the operator's, so nothing takes it
+     from them — the newer request queues rather than evicting a live handoff. */
+  expect(second.superseded).toEqual([]);
+  answerAttentionRequest("attention_2", { kind: "offer", deviceId: DEVICE }, { now: later(RETURN_WINDOW_MS - 1) });
+
+  const view = attentionForDevice(DEVICE, { now: later(RETURN_WINDOW_MS - 1) });
+  expect(view.offer!.request.id).toBe("attention_1");
+  expect(view.offer!.returnAvailable).toBe(true);
+
+  /* And it is a wait, not a loss: the moment the control collapses the newer
+     request is what this device is shown. */
+  const after = attentionForDevice(DEVICE, { now: later(RETURN_WINDOW_MS) });
+  expect(after.offer!.request.id).toBe("attention_2");
 });
 
 test("reading sweeps the clock, so an unacknowledged request cannot linger as a live card", () => {

--- a/src/lib/attention/service.ts
+++ b/src/lib/attention/service.ts
@@ -1,6 +1,13 @@
 import { rootIdentity } from "@/lib/root/store";
 
-import { applyAttentionEvent, offerStatusForDevice, returnControlIsLive, type AttentionEvent, type DeviceOfferStatus } from "./machine";
+import {
+  applyAttentionEvent,
+  offerStatusForDevice,
+  offerStillActionable,
+  returnControlIsLive,
+  type AttentionEvent,
+  type DeviceOfferStatus,
+} from "./machine";
 import {
   createAttentionRequest,
   liveAttentionRequests,
@@ -66,9 +73,21 @@ export function attentionForDevice(
       returnAvailable: returnControlIsLive(request, deviceId, now),
     }));
 
+  /* At most one request is rendered per device, oldest first — but a follow the
+     operator has wandered away from must not be what that one is. Its return
+     control has already collapsed, so it offers nothing to press, and being the
+     oldest live entry it would go on being this device's only offer while every
+     newer request sat behind it unseen. So a follow still naming its way back
+     wins (the operator is mid-handoff and Return is the thing to show), then
+     anything answerable, and only then a collapsed follow. */
+  const slot = live.filter((entry) => entry.status === "actionable" || entry.status === "following");
+  const offer = slot.find((entry) => offerStillActionable(entry.request, now))
+    ?? slot[0]
+    ?? null;
+
   return {
     rootId: rootIdentity(),
-    offer: live.find((entry) => entry.status === "actionable" || entry.status === "following") ?? null,
+    offer,
     live,
     expired,
   };

--- a/src/lib/attention/store.test.ts
+++ b/src/lib/attention/store.test.ts
@@ -16,7 +16,7 @@ import {
   transitionAttentionRequest,
   type AttentionCreateInput,
 } from "./store";
-import { ACCEPTED_LANDING_GRACE_MS, OFFER_TTL_MS, QUEUE_CAP, type FocusFrame } from "./types";
+import { ACCEPTED_LANDING_GRACE_MS, FOLLOW_HOLD_MS, OFFER_TTL_MS, QUEUE_CAP, RETURN_WINDOW_MS, type FocusFrame } from "./types";
 
 let sandbox = "";
 let previousStateDir: string | undefined;
@@ -123,7 +123,7 @@ test("a device that agreed and then vanished mid-handoff is recovered by the swe
   expect(liveAttentionRequests(readAttentionFile())).toEqual([]);
 });
 
-test("a followed request has no clock, so a sweep never takes the return point away", () => {
+test("a sweep leaves a live follow alone, then closes one nobody ever came back from", () => {
   createAttentionRequest(input(), { now: T0, id: "attention_1" });
   transitionAttentionRequest("attention_1", { kind: "offer", deviceId: "device-a" }, { now: T0 });
   transitionAttentionRequest("attention_1", { kind: "accept", deviceId: "device-a" }, { now: T0 });
@@ -134,8 +134,21 @@ test("a followed request has no clock, so a sweep never takes the return point a
     returnPoint: { deviceId: "device-a", mode: "scheme", camera: { x: 1, y: 2, zoom: 0.5 }, focusedPath: null, capturedAt: T0.toISOString() },
   }, { now: T0 });
 
-  expect(sweepExpiredAttention({ now: later(OFFER_TTL_MS * 10) })).toEqual([]);
+  /* A clock taking the return point away while the control still names it would
+     strand the operator wherever they landed, so nothing does. */
+  expect(sweepExpiredAttention({ now: later(RETURN_WINDOW_MS) })).toEqual([]);
   expect(readAttentionFile().requests[0]!.state).toBe("following");
+
+  /* But `following` admits no event except Return, so an operator who never
+     presses it would otherwise leave this live for the life of the file —
+     holding the device's one offer slot against everything raised after it. */
+  expect(sweepExpiredAttention({ now: later(FOLLOW_HOLD_MS) })).toEqual(["attention_1"]);
+  const swept = readAttentionFile().requests[0]!;
+  expect(swept.state).toBe("expired");
+  /* Its own cause: they saw this one and agreed to it, so reporting it as a TTL
+     would tell the agent it was never looked at. */
+  expect(swept.expiredCause).toBe("follow-elapsed");
+  expect(liveAttentionRequests(readAttentionFile())).toEqual([]);
 });
 
 test("a request nobody ever rendered expires on the same clock", () => {

--- a/src/lib/attention/store.test.ts
+++ b/src/lib/attention/store.test.ts
@@ -16,7 +16,7 @@ import {
   transitionAttentionRequest,
   type AttentionCreateInput,
 } from "./store";
-import { OFFER_TTL_MS, QUEUE_CAP, type FocusFrame } from "./types";
+import { ACCEPTED_LANDING_GRACE_MS, OFFER_TTL_MS, QUEUE_CAP, type FocusFrame } from "./types";
 
 let sandbox = "";
 let previousStateDir: string | undefined;
@@ -101,6 +101,41 @@ test("an unacknowledged request expires on the clock and reports which ones did"
   expect(readAttentionFile().requests[0]!.state).toBe("expired");
   /* One sweep, one expiry: a second pass has nothing left to say. */
   expect(sweepExpiredAttention({ now: later(OFFER_TTL_MS * 2) })).toEqual([]);
+});
+
+test("a device that agreed and then vanished mid-handoff is recovered by the sweep, as lost", () => {
+  createAttentionRequest(input(), { now: T0, id: "attention_1" });
+  transitionAttentionRequest("attention_1", { kind: "offer", deviceId: "device-a" }, { now: T0 });
+  transitionAttentionRequest("attention_1", { kind: "accept", deviceId: "device-a" }, { now: T0 });
+
+  /* Nothing else can end an `accepted` request: `arrive` never came, and the
+     tab that would have sent it is gone. Left alone it stays the oldest live
+     entry for that device forever, so every later request is offered behind a
+     card nothing renders. */
+  expect(sweepExpiredAttention({ now: later(ACCEPTED_LANDING_GRACE_MS - 1) })).toEqual([]);
+  expect(sweepExpiredAttention({ now: later(ACCEPTED_LANDING_GRACE_MS) })).toEqual(["attention_1"]);
+
+  const swept = readAttentionFile().requests[0]!;
+  expect(swept.state).toBe("expired");
+  /* Its own cause. Calling it a TTL would say the operator never saw it, when
+     in fact they saw it and agreed. */
+  expect(swept.expiredCause).toBe("lost");
+  expect(liveAttentionRequests(readAttentionFile())).toEqual([]);
+});
+
+test("a followed request has no clock, so a sweep never takes the return point away", () => {
+  createAttentionRequest(input(), { now: T0, id: "attention_1" });
+  transitionAttentionRequest("attention_1", { kind: "offer", deviceId: "device-a" }, { now: T0 });
+  transitionAttentionRequest("attention_1", { kind: "accept", deviceId: "device-a" }, { now: T0 });
+  transitionAttentionRequest("attention_1", {
+    kind: "arrive",
+    deviceId: "device-a",
+    resolution: "exact",
+    returnPoint: { deviceId: "device-a", mode: "scheme", camera: { x: 1, y: 2, zoom: 0.5 }, focusedPath: null, capturedAt: T0.toISOString() },
+  }, { now: T0 });
+
+  expect(sweepExpiredAttention({ now: later(OFFER_TTL_MS * 10) })).toEqual([]);
+  expect(readAttentionFile().requests[0]!.state).toBe("following");
 });
 
 test("a request nobody ever rendered expires on the same clock", () => {

--- a/src/lib/attention/store.ts
+++ b/src/lib/attention/store.ts
@@ -5,7 +5,7 @@ import path from "node:path";
 import { statePath } from "@/lib/configDir";
 import { withFileTransactionSync } from "@/lib/state/fileTransaction";
 
-import { applyAttentionEvent, expiryFrom, isExpiredByClock, type AttentionEvent, type AttentionTransition } from "./machine";
+import { applyAttentionEvent, expiryCauseByClock, expiryFrom, type AttentionEvent, type AttentionTransition } from "./machine";
 import { defaultZoomIntent, isFocusTarget, targetAcceptsIntent } from "./targets";
 import {
   ATTENTION_SCHEMA_VERSION,
@@ -306,14 +306,20 @@ export function transitionAttentionRequest(
  * Expire everything the clock has run out on. Every expiry is a fact both sides
  * can see — the caller writes one line to the conversation and one event to the
  * journal for each id returned here.
+ *
+ * The clock has two causes, and the sweep carries whichever applies rather than
+ * stamping them all `ttl`: an unanswered offer ran out, while an agreed request
+ * that never landed is `lost`. That second case is also the recovery path for a
+ * device that agreed and then vanished mid-handoff, which nothing else can end.
  */
 export function sweepExpiredAttention(options: { filePath?: string; now?: Date } = {}): string[] {
   const now = options.now ?? new Date();
   return mutateAttention((file) => {
     const expired: string[] = [];
     const requests = file.requests.map((request) => {
-      if (!isExpiredByClock(request, now)) return request;
-      const transition = applyAttentionEvent(request, { kind: "expire", cause: "ttl" }, { now });
+      const cause = expiryCauseByClock(request, now);
+      if (!cause) return request;
+      const transition = applyAttentionEvent(request, { kind: "expire", cause }, { now });
       if (!transition.ok) return request;
       expired.push(request.id);
       return transition.request;

--- a/src/lib/attention/store.ts
+++ b/src/lib/attention/store.ts
@@ -211,7 +211,10 @@ export function liveAttentionRequests(file: AttentionFileV1): AttentionRequestV1
  * are about the *set* of requests rather than one of them:
  *
  * - a newer root-agent request supersedes that root's older un-acknowledged
- *   ones. There is one speaker, so a second request means it changed its mind;
+ *   ones. There is one speaker, so a second request means it changed its mind.
+ *   It also supersedes a follow whose way back has already collapsed: the
+ *   machine decides that, and it is what keeps a handoff the operator never
+ *   closed from shadowing everything raised afterwards;
  * - the queue is capped, and overflow drops the oldest routine entry. The
  *   caller is told which, so a dropped request can be said out loud instead of
  *   vanishing, and the record itself keeps `expiredCause: "queue-evicted"` so
@@ -307,10 +310,13 @@ export function transitionAttentionRequest(
  * can see — the caller writes one line to the conversation and one event to the
  * journal for each id returned here.
  *
- * The clock has two causes, and the sweep carries whichever applies rather than
- * stamping them all `ttl`: an unanswered offer ran out, while an agreed request
- * that never landed is `lost`. That second case is also the recovery path for a
- * device that agreed and then vanished mid-handoff, which nothing else can end.
+ * The clock has three causes, and the sweep carries whichever applies rather
+ * than stamping them all `ttl`: an unanswered offer ran out; an agreed request
+ * that never landed is `lost`; a follow nobody ever closed is `follow-elapsed`.
+ * The last two are the recovery paths for the two states a request cannot leave
+ * on its own — a device that agreed and then vanished mid-handoff, and an
+ * operator who followed and walked away — and each of those, left live, is the
+ * device's one offer slot held against everything raised after it.
  */
 export function sweepExpiredAttention(options: { filePath?: string; now?: Date } = {}): string[] {
   const now = options.now ?? new Date();

--- a/src/lib/attention/types.ts
+++ b/src/lib/attention/types.ts
@@ -26,6 +26,13 @@ export const OFFER_TTL_MS = 10 * 60_000;
 /** How long the return control names where you came from before collapsing to
     a conversation line that still restores it. */
 export const RETURN_WINDOW_MS = 60_000;
+/** How long an `accepted` request may go without landing before the clock ends
+    it as lost. Acceptance is a move in progress and lives for seconds — the
+    board wait bounds it — so a request still `accepted` this long afterwards is
+    a device that agreed and then went away: a closed tab, a crash, a reload
+    mid-handoff. Without this that request could never leave `accepted`, and it
+    would stay that device's only offer for the life of the record. */
+export const ACCEPTED_LANDING_GRACE_MS = 60_000;
 /** Auto-follow may move the view; it may not chain-move it. A request arriving
     inside this window after a move waits. */
 export const AUTO_FOLLOW_SETTLE_MS = 4_000;

--- a/src/lib/attention/types.ts
+++ b/src/lib/attention/types.ts
@@ -33,6 +33,23 @@ export const RETURN_WINDOW_MS = 60_000;
     mid-handoff. Without this that request could never leave `accepted`, and it
     would stay that device's only offer for the life of the record. */
 export const ACCEPTED_LANDING_GRACE_MS = 60_000;
+/**
+ * How long a follow nobody ever closed stays live before the clock ends it.
+ *
+ * `following` is the other state a request could never leave on its own: the
+ * only way out is the operator pressing Return, and an operator who simply
+ * walks away never presses anything. Being live and the oldest entry, that
+ * request goes on being the device's one offer, so every later request is
+ * stamped `offered`, rendered by nothing, and expires as if it had been
+ * ignored — the same silent swallow a lost landing used to cause.
+ *
+ * Deliberately far longer than {@link RETURN_WINDOW_MS}: by the time this runs
+ * the return control has long since stopped naming where the operator came
+ * from, so nothing is taken away that was still on offer. Ending the record
+ * never moves the view, so an operator still reading the target keeps reading
+ * it — what they lose is a card that had no action left on it.
+ */
+export const FOLLOW_HOLD_MS = 10 * 60_000;
 /** Auto-follow may move the view; it may not chain-move it. A request arriving
     inside this window after a move waits. */
 export const AUTO_FOLLOW_SETTLE_MS = 4_000;
@@ -93,11 +110,17 @@ export type FocusResolutionKind = "exact" | "approximate" | "lost";
 /**
  * Why a request ended without an answer. Kept on the record rather than only in
  * the reply to whoever caused it: "nobody answered in ten minutes", "the anchor
- * was gone" and "the queue was full" are three different things to say out loud,
- * and the last one is the one a caller would otherwise have to remember for the
- * record's whole life.
+ * was gone", "the queue was full" and "they followed and never came back" are
+ * four different things to say out loud, and the record is the only place the
+ * distinction outlives the response that caused it.
+ *
+ * `follow-elapsed` is the odd one out and says so: the operator DID see the
+ * request and DID agree to it. It is on this list rather than being its own
+ * state because the ending is the same shape — the clock closed a record nobody
+ * closed by hand — and reading it as a refusal or as "never seen" would teach
+ * the agent exactly the wrong lesson about asking again.
  */
-export type ExpiryCause = "ttl" | "lost" | "queue-evicted";
+export type ExpiryCause = "ttl" | "lost" | "queue-evicted" | "follow-elapsed";
 
 /** `show` frames and highlights; `open` also opens the target's natural surface,
     and return closes what it opened — which is why the two are one field (D8). */
@@ -124,8 +147,9 @@ export type AttentionState =
       silence — the difference between an agent that learns to stop asking and
       one that keeps asking. */
   | "declined"
-  /** TTL elapsed unacknowledged, the target resolved as lost, or the queue was
-      full. Which one is on the record as `expiredCause`. Terminal. */
+  /** TTL elapsed unacknowledged, the target resolved as lost, the queue was
+      full, or a follow was never closed. Which one is on the record as
+      `expiredCause`. Terminal. */
   | "expired"
   /** Replaced by a newer request from the root agent. Terminal. */
   | "superseded";

--- a/src/lib/attention/validation.ts
+++ b/src/lib/attention/validation.ts
@@ -131,6 +131,11 @@ export function validateAttentionEvent(value: unknown): AttentionEvent {
     case "preview":
     case "decline":
     case "dismiss":
+    /* `abandon` is a device closing ITS OWN agreed request that found nowhere
+       to land. It is safe from a client for the same reason `arrive` is: the
+       machine accepts it only from `accepted`, and only from the device the
+       record names as the acknowledger. */
+    case "abandon":
       return { kind: body.kind, deviceId: text(body.deviceId, "deviceId", 256) };
     case "accept": {
       const via = body.via;

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -1853,4 +1853,6 @@ export const en = {
   "attention.autoFollowRevoke": "Turn auto-follow off",
   "attention.previewClose": "Close the preview",
   "attention.refused": "That did not go through — here is where the request stands now.",
+  "attention.lostTarget": "There was nowhere to take you — that is gone from the board. The request is closed.",
+  "attention.refusedDismiss": "Dismiss",
 } satisfies Dictionary;

--- a/src/lib/i18n/uk.ts
+++ b/src/lib/i18n/uk.ts
@@ -1804,4 +1804,6 @@ export const uk: Record<keyof typeof en, Message> = {
   "attention.autoFollowRevoke": "Вимкнути автоперехід",
   "attention.previewClose": "Закрити перегляд",
   "attention.refused": "Це не пройшло — ось де зараз цей запит.",
+  "attention.lostTarget": "Немає куди вести — цього вже немає на дошці. Запит закрито.",
+  "attention.refusedDismiss": "Сховати",
 };

--- a/src/lib/mcp/bindings.ts
+++ b/src/lib/mcp/bindings.ts
@@ -106,16 +106,18 @@ export interface ViewerMcpDomainDependencies {
   raiseAttentionRequest: typeof raiseAttentionRequest;
 }
 
-/** The registry slice {@link adoptLiveRootSession} resolves the root from. */
+/**
+ * The registry slice {@link adoptLiveRootSession} resolves the root from.
+ *
+ * Handed over verbatim: `RootSessionSource` is described structurally against
+ * the registry's own conversation shape — id, updatedAt, and the generations
+ * with their launch profiles — so there is no field mapping here to fall out of
+ * step with what the registry actually stamps.
+ */
 function rootSessionSource(): RootSessionSource {
   const snapshot = agentRegistry().readOnlySnapshot();
   return {
-    conversations: Object.values(snapshot.conversations).map((conversation) => ({
-      id: conversation.id,
-      agentRole: conversation.agentRole,
-      generations: conversation.generations.map((generation) => ({ path: generation.path })),
-      updatedAt: conversation.updatedAt,
-    })),
+    conversations: Object.values(snapshot.conversations),
     configuredRootId: process.env.LLV_ROOT_CONVERSATION_ID?.trim() || null,
   };
 }

--- a/src/lib/mcp/bindings.ts
+++ b/src/lib/mcp/bindings.ts
@@ -4,6 +4,10 @@ import { agentRegistry } from "@/lib/agent/registry";
 import { ensureOperatorSpawnCapability } from "@/lib/agent/operatorCapability";
 import { VIEWER_SPAWN_CAPABILITY_HEADER } from "@/lib/agent/spawnPolicy";
 import { applyConversationMigration } from "@/lib/accounts/migration/conversationCommand";
+import { UNREAD_FRAME_RECT } from "@/lib/attention/frames";
+import { raiseAttentionRequest } from "@/lib/attention/service";
+import { geometricFrameRect, isFocusTarget, isGeometricTarget } from "@/lib/attention/targets";
+import type { FocusIntent, FocusTarget, ZoomIntent } from "@/lib/attention/types";
 import { boardFor } from "@/lib/board/store";
 import { applyConversationAction } from "@/lib/conversation/actions";
 import { cancelRound, closeFlow, patchFlow } from "@/lib/flows/commands";
@@ -16,6 +20,7 @@ import { projectTaskPipelineIds } from "@/lib/pipelines/taskBinding";
 import type { CreatePipelineRequest, PatchPipelineRequest, PipelineAction } from "@/lib/pipelines/types";
 import { listFiles } from "@/lib/scanner";
 import { readResources } from "@/lib/resources";
+import { adoptLiveRootSession, type RootSessionSource } from "@/lib/root/adopt";
 import { runtimeHostClient, type RuntimeHostClient } from "@/lib/runtime/client";
 import { runtimeEventsEnabled } from "@/lib/runtime/flags";
 import { readSession } from "@/lib/session/reader";
@@ -94,6 +99,25 @@ export interface ViewerMcpDomainDependencies {
   readResources: typeof readResources;
   applyConversationAction: typeof applyConversationAction;
   applyConversationMigration: typeof applyConversationMigration;
+  /** #688 D5: fold the live root session into the rollover chain, so a request
+      references the root by an identity that survives the session it was raised
+      from. Called on the raise path, which is the moment that identity matters. */
+  adoptRootSession(): void;
+  raiseAttentionRequest: typeof raiseAttentionRequest;
+}
+
+/** The registry slice {@link adoptLiveRootSession} resolves the root from. */
+function rootSessionSource(): RootSessionSource {
+  const snapshot = agentRegistry().readOnlySnapshot();
+  return {
+    conversations: Object.values(snapshot.conversations).map((conversation) => ({
+      id: conversation.id,
+      agentRole: conversation.agentRole,
+      generations: conversation.generations.map((generation) => ({ path: generation.path })),
+      updatedAt: conversation.updatedAt,
+    })),
+    configuredRootId: process.env.LLV_ROOT_CONVERSATION_ID?.trim() || null,
+  };
 }
 
 const productionDomainDependencies: ViewerMcpDomainDependencies = {
@@ -113,6 +137,8 @@ const productionDomainDependencies: ViewerMcpDomainDependencies = {
   readResources,
   applyConversationAction,
   applyConversationMigration,
+  adoptRootSession: () => { adoptLiveRootSession(rootSessionSource()); },
+  raiseAttentionRequest,
 };
 
 function text(value: unknown): string {
@@ -557,6 +583,102 @@ async function conversationMigration(args: McpToolArgs, dependencies: ViewerMcpD
   });
 }
 
+/**
+ * Which project a target lives in, so the request can record one.
+ *
+ * Only the project is derived here — never a rect. The server has no board
+ * layout, and inventing one would put a made-up destination on a durable record
+ * (see `@/lib/attention/frames`). An explicit `project` wins, and is the only
+ * way to name a target the server cannot attribute at all: a board draft exists
+ * on the operator's canvas and nowhere else.
+ */
+async function focusTargetProject(
+  target: FocusTarget,
+  explicit: string,
+  dependencies: ViewerMcpDomainDependencies,
+): Promise<string> {
+  if (explicit) return explicit;
+  if (isGeometricTarget(target)) return target.project;
+  switch (target.kind) {
+    case "conversation": {
+      const files = await dependencies.listFiles({ fresh: true, persist: false, pin: target.path });
+      const entry = files.find((candidate) => candidate.path === target.path);
+      if (!entry) throw new Error("no conversation on the board has that transcript path");
+      return entry.project;
+    }
+    case "pipeline":
+    case "stage": {
+      const pipeline = dependencies.getPipelines().pipelines.find((candidate) => candidate.id === target.pipelineId);
+      if (!pipeline) throw new Error("pipeline not found");
+      return pipeline.project;
+    }
+    case "flowRound": {
+      const flow = dependencies.getFlowsWithPresets().flows.find((candidate) => candidate.id === target.flowId);
+      if (!flow) throw new Error("flow not found");
+      return flow.project;
+    }
+    case "task": {
+      const task = dependencies.loadTasks().find((candidate) => candidate.id === target.taskId);
+      if (!task) throw new Error("task not found");
+      return task.project;
+    }
+    case "draft":
+      throw new Error("a draft target needs an explicit project");
+  }
+}
+
+/**
+ * The root agent's own door into #688: ask the operator to look at something.
+ *
+ * It only ASKS. The request lands at `pending`, nothing moves until the
+ * operator agrees on a device, and their refusal comes back as a refusal rather
+ * than as silence. The root identity is resolved server-side by the service, so
+ * a caller cannot name a root other than the operator's own — which is the
+ * whole of D4's authority rule and why no rootId appears in this schema.
+ */
+async function requestAttention(args: McpToolArgs, dependencies: ViewerMcpDomainDependencies): Promise<McpToolPayload> {
+  const target = args.target;
+  if (!isFocusTarget(target)) throw new Error("target must be a typed focus target");
+  const intent = (text(args.intent) || "show") as FocusIntent;
+  if (intent !== "show" && intent !== "open") throw new Error("intent must be show or open");
+  const zoom = text(args.zoom) as ZoomIntent | "";
+  if (zoom && zoom !== "inspect" && zoom !== "situate") throw new Error("zoom must be inspect or situate");
+  const reason = required(args, "reason");
+  const contextLabel = text(args.contextLabel);
+  const project = await focusTargetProject(target, text(args.project), dependencies);
+
+  /* Before the request is written, not after: the request names the root by the
+     identity this call may have just extended with a fresh session. */
+  dependencies.adoptRootSession();
+  const created = dependencies.raiseAttentionRequest({
+    origin: "root-agent",
+    target,
+    /* Geometric targets ARE their own frame; everything else records that no
+       board was read, so a vanished anchor reports `lost` rather than landing
+       the operator at the world origin. */
+    frameAtCreation: {
+      project,
+      rect: isGeometricTarget(target) ? geometricFrameRect(target) : UNREAD_FRAME_RECT,
+      boardRevision: null,
+    },
+    intent,
+    reason,
+    ...(zoom ? { zoom } : {}),
+    ...(contextLabel ? { contextLabel } : {}),
+  });
+  const operationId = mcpOperationId("request_attention", requestId(args));
+  return redactPayload({
+    attentionId: created.request.id,
+    request: created.request,
+    /* A newer request from the same root replaces its own unanswered ones, and
+       an overfull queue drops the oldest routine entry. Both are named so the
+       agent can say so out loud instead of leaving a dropped ask silent. */
+    superseded: created.superseded,
+    dropped: created.dropped,
+    ...mutationReceipt(operationId),
+  });
+}
+
 export function viewerMcpBindings(
   linkTaskDependencies: LinkTaskToPipelineDependencies = productionLinkTaskDependencies,
   controlDependencies: ViewerControlDependencies = productionViewerControlDependencies,
@@ -586,5 +708,6 @@ export function viewerMcpBindings(
     resources: (args) => resources(args, domainDependencies),
     conversation_action: (args) => conversationAction(args, domainDependencies),
     conversation_migration: (args) => conversationMigration(args, domainDependencies),
+    request_attention: (args) => requestAttention(args, domainDependencies),
   };
 }

--- a/src/lib/mcp/presentation.test.ts
+++ b/src/lib/mcp/presentation.test.ts
@@ -51,6 +51,8 @@ describe("describeMcpCall", () => {
       ["deployment_status", { deploymentId: "deployment-a" }, "deploy", "Reading deployment status"],
       ["resources", { fresh: true }, "tool", "Reading resources"],
       ["conversation_migration", { conversationId: "conversation_a", action: "rollback" }, "conversation", "Rolling back conversation migration"],
+      ["request_attention", { target: { kind: "conversation", path: "/tmp/a.jsonl" }, reason: "The reviewer finished." }, "conversation", "Asking to show a conversation"],
+      ["request_attention", { target: { kind: "task", taskId: "task-a" }, intent: "open", reason: "This is blocked." }, "conversation", "Asking to open a task"],
     ] as const;
 
     for (const [tool, args, icon, prefix] of cases) {

--- a/src/lib/mcp/presentation.ts
+++ b/src/lib/mcp/presentation.ts
@@ -369,6 +369,24 @@ export function describeMcpCall(
     };
   }
 
+  if (toolName === "request_attention") {
+    /* The operator reads this line about a request made ABOUT them, so it says
+       what was asked and which of show/open it was — the same two facts the
+       card itself puts in front of them before they agree. */
+    const target = record(args.target);
+    const kind = string(target.kind) || "target";
+    const opening = string(args.intent) === "open";
+    return {
+      icon: "conversation",
+      verb: "Asking",
+      title: `Asking to ${opening ? "open" : "show"} a ${kind}`,
+      subtitle: replaySubtitle(result, compact(string(args.reason))),
+      links: kind === "conversation" && string(target.path)
+        ? []
+        : entityLink(kind === "task" ? "task" : "pipeline", string(target.taskId) || string(target.pipelineId)),
+    };
+  }
+
   return {
     icon: "tool",
     verb: "Running",

--- a/src/lib/mcp/requestAttention.test.ts
+++ b/src/lib/mcp/requestAttention.test.ts
@@ -3,8 +3,11 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
+import { emptyLaunchProfile } from "@/lib/accounts/migration/contracts";
+import type { RegistryConversation } from "@/lib/agent/registry";
 import { raiseAttentionRequest } from "@/lib/attention/service";
 import { readAttentionFile } from "@/lib/attention/store";
+import { adoptLiveRootSession } from "@/lib/root/adopt";
 import { readRootLineage } from "@/lib/root/store";
 import type { BoardTask } from "@/lib/tasks/types";
 import type { FileEntry } from "@/lib/types";
@@ -58,13 +61,13 @@ const task = {
 
 interface Adoptions { count: number }
 
-function bindings(adoptions: Adoptions = { count: 0 }) {
+function bindings(adoptions: Adoptions = { count: 0 }, adoptRootSession = () => { adoptions.count += 1; }) {
   return viewerMcpBindings(undefined, undefined, {
     listFiles: async () => [reviewerFile],
     loadTasks: () => [task],
     getPipelines: () => ({ pipelines: [{ id: "pipeline_1", project: "pipeline-project" }] }),
     getFlowsWithPresets: () => ({ flows: [{ id: "flow_1", project: "flow-project" }] }),
-    adoptRootSession: () => { adoptions.count += 1; },
+    adoptRootSession,
     /* The real one: it resolves the state path per call, so the sandbox set in
        beforeEach applies and the request lands on a real record. */
     raiseAttentionRequest,
@@ -73,6 +76,39 @@ function bindings(adoptions: Adoptions = { count: 0 }) {
 
 function service(adoptions: Adoptions = { count: 0 }) {
   return createMcpToolService(bindings(adoptions), new MemoryMcpReceiptStore());
+}
+
+/** A root conversation exactly as the registry holds one — the `root` role on
+    the newest generation's launch profile, which is the only place the registry
+    ever writes it. Typed as the real thing so the shape cannot drift. */
+function rootConversation(id: string, transcript: string, updatedAt: string): RegistryConversation {
+  return {
+    id: id as RegistryConversation["id"],
+    engine: "claude",
+    generations: [{
+      id: `${id}_g0`,
+      path: transcript,
+      accountId: null,
+      launchProfile: emptyLaunchProfile({ cwd: "/repo", role: "root" }),
+      historyHash: null,
+      host: null,
+      createdAt: "2026-07-01T09:00:00.000Z",
+      archivedAt: null,
+    }],
+    continuityPaths: [],
+    abandonedContinuityPaths: [],
+    projectOwnership: null,
+    migration: null,
+    migrationOptOut: null,
+    supersededBy: null,
+    /* No role PRESET: the operator's own session is precisely the one without
+       one, which is why the preset id can never identify it. */
+    agentRole: null,
+    delegationDepth: null,
+    turn: { state: "idle", source: "empty", terminalAt: null, observedAt: null },
+    createdAt: "2026-07-01T09:00:00.000Z",
+    updatedAt,
+  };
 }
 
 const ask = (overrides: Record<string, unknown> = {}) => ({
@@ -194,6 +230,37 @@ test("the ask is a mutation, so its receipt outlives the MCP process", async () 
      second time for the same thing. */
   expect(retentions).toEqual(["durable"]);
   expect(MCP_TOOL_NAMES).toContain("request_attention");
+});
+
+test("a raise folds the real live root session into the chain, and a rollover keeps the link", async () => {
+  /* The adoption runs for real here against registry-shaped conversations — not
+     a counter — because the defect this closes was the resolution reading a
+     field the registry never writes `root` into: the raise worked, the chain
+     stayed empty, and every request named an identity with no sessions behind
+     it. Only a production-shaped source can tell the two apart. */
+  let live = [rootConversation("conversation_root", "/tmp/root.jsonl", "2026-07-01T10:00:00.000Z")];
+  const tools = createMcpToolService(
+    bindings(undefined, () => { adoptLiveRootSession({ conversations: live, configuredRootId: null }); }),
+    new MemoryMcpReceiptStore(),
+  );
+
+  await tools.callTool("request_attention", ask());
+
+  const identity = readRootLineage()!.rootId;
+  expect(readRootLineage()!.sessions).toHaveLength(1);
+  expect(readRootLineage()!.sessions[0]).toMatchObject({ conversationId: "conversation_root", path: "/tmp/root.jsonl" });
+
+  /* The rollover D5 exists for: the session the operator is talking to is
+     replaced, and a request raised before it must still resolve after. */
+  live = [...live, rootConversation("conversation_root_2", "/tmp/root-2.jsonl", "2026-07-01T11:00:00.000Z")];
+  await tools.callTool("request_attention", ask({ clientRequestId: "raise-2", reason: "The verifier is blocked on you." }));
+
+  const sessions = readRootLineage()!.sessions;
+  expect(sessions.map((session) => session.conversationId)).toEqual(["conversation_root", "conversation_root_2"]);
+  expect(sessions[1]!.seededFrom).toBe("conversation_root");
+  /* Same stable identity across the rollover, and both requests named it. */
+  expect(readRootLineage()!.rootId).toBe(identity);
+  expect(readAttentionFile().requests.map((entry) => entry.requestedBy.rootId)).toEqual([identity, identity]);
 });
 
 test("no rootId can be named by the caller", async () => {

--- a/src/lib/mcp/requestAttention.test.ts
+++ b/src/lib/mcp/requestAttention.test.ts
@@ -1,0 +1,208 @@
+import { afterEach, beforeEach, expect, test } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { raiseAttentionRequest } from "@/lib/attention/service";
+import { readAttentionFile } from "@/lib/attention/store";
+import { readRootLineage } from "@/lib/root/store";
+import type { BoardTask } from "@/lib/tasks/types";
+import type { FileEntry } from "@/lib/types";
+
+import { viewerMcpBindings } from "./bindings";
+import { createMcpToolService, MemoryMcpReceiptStore, MCP_TOOL_NAMES, type McpToolResult } from "./server";
+
+/*
+ * The root agent's own door into #688.
+ *
+ * Before this there was none: the record, the machine and the HTTP surface all
+ * existed, and the only way to raise a request was a hand-written POST. The
+ * agent could not ask for the operator's attention through the surface it
+ * actually has.
+ */
+
+let sandbox = "";
+let previousStateDir: string | undefined;
+
+beforeEach(() => {
+  previousStateDir = process.env.LLV_STATE_DIR;
+  sandbox = fs.mkdtempSync(path.join(os.tmpdir(), "llv-mcp-attention-"));
+  process.env.LLV_STATE_DIR = sandbox;
+});
+afterEach(() => {
+  if (previousStateDir === undefined) delete process.env.LLV_STATE_DIR;
+  else process.env.LLV_STATE_DIR = previousStateDir;
+  fs.rmSync(sandbox, { recursive: true, force: true });
+});
+
+const REVIEWER = "/tmp/reviewer.jsonl";
+
+const reviewerFile = {
+  path: REVIEWER,
+  project: "live-log-viewer-next",
+  title: "Reviewer — login fix",
+  engine: "claude",
+  activity: "live",
+} as unknown as FileEntry;
+
+const task = {
+  id: "task_1",
+  project: "other-project",
+  status: "inbox",
+  text: "Ship the handoff",
+  placement: "unplaced",
+  assignments: [],
+  createdAt: "2026-07-01T10:00:00.000Z",
+  updatedAt: "2026-07-01T10:00:00.000Z",
+} as unknown as BoardTask;
+
+interface Adoptions { count: number }
+
+function bindings(adoptions: Adoptions = { count: 0 }) {
+  return viewerMcpBindings(undefined, undefined, {
+    listFiles: async () => [reviewerFile],
+    loadTasks: () => [task],
+    getPipelines: () => ({ pipelines: [{ id: "pipeline_1", project: "pipeline-project" }] }),
+    getFlowsWithPresets: () => ({ flows: [{ id: "flow_1", project: "flow-project" }] }),
+    adoptRootSession: () => { adoptions.count += 1; },
+    /* The real one: it resolves the state path per call, so the sandbox set in
+       beforeEach applies and the request lands on a real record. */
+    raiseAttentionRequest,
+  } as never);
+}
+
+function service(adoptions: Adoptions = { count: 0 }) {
+  return createMcpToolService(bindings(adoptions), new MemoryMcpReceiptStore());
+}
+
+const ask = (overrides: Record<string, unknown> = {}) => ({
+  clientRequestId: "raise-1",
+  target: { kind: "conversation", path: REVIEWER },
+  reason: "The reviewer finished with request-changes.",
+  ...overrides,
+});
+
+test("the root agent can raise a request through its normal tool surface", async () => {
+  const adoptions = { count: 0 };
+  const result = await service(adoptions).callTool("request_attention", ask()) as McpToolResult & { attentionId?: string };
+
+  expect(result.ok).toBe(true);
+  expect(result.attentionId).toStartWith("attention_");
+  const stored = readAttentionFile().requests[0]!;
+  /* It only ASKS: nothing moves until the operator agrees on a device. */
+  expect(stored.state).toBe("pending");
+  expect(stored.origin).toBe("root-agent");
+  expect(stored.intent).toBe("show");
+  /* The project is derived from the target rather than taken from the caller,
+     and the frame records that no board was read. */
+  expect(stored.frameAtCreation).toEqual({ project: "live-log-viewer-next", rect: { x: 0, y: 0, w: 0, h: 0 }, boardRevision: null });
+  /* The root is named by stable identity, never by a session path — and the
+     live session was folded into the chain on the way past. */
+  expect(stored.requestedBy.rootId).toBe(readRootLineage()!.rootId);
+  expect(adoptions.count).toBe(1);
+});
+
+test("a repeated clientRequestId replays the same receipt instead of asking twice", async () => {
+  const tools = service();
+
+  const first = await tools.callTool("request_attention", ask()) as McpToolResult & { attentionId?: string };
+  const again = await tools.callTool("request_attention", ask()) as McpToolResult & { attentionId?: string };
+
+  expect(again.replayed).toBe(true);
+  expect(again.attentionId).toBe(first.attentionId!);
+  /* One ask on the record. Without this a retried tool call would supersede its
+     own previous request and the operator would watch the card replace itself. */
+  expect(readAttentionFile().requests).toHaveLength(1);
+});
+
+test("the same key with different arguments is a conflict, not a second ask", async () => {
+  const tools = service();
+  await tools.callTool("request_attention", ask());
+
+  const conflict = await tools.callTool("request_attention", ask({ reason: "Something else entirely." })) as McpToolResult;
+
+  expect(conflict).toMatchObject({ ok: false, code: "idempotency_conflict" });
+  expect(readAttentionFile().requests).toHaveLength(1);
+});
+
+test("every target kind the server can attribute resolves its own project", async () => {
+  const tools = service();
+
+  for (const [key, target, project] of [
+    ["pipeline", { kind: "pipeline", pipelineId: "pipeline_1" }, "pipeline-project"],
+    ["stage", { kind: "stage", pipelineId: "pipeline_1", stageId: "review" }, "pipeline-project"],
+    ["flow", { kind: "flowRound", flowId: "flow_1", round: 2 }, "flow-project"],
+    ["task", { kind: "task", taskId: "task_1" }, "other-project"],
+    ["point", { kind: "point", project: "geometric", x: 10, y: 20 }, "geometric"],
+  ] as const) {
+    const result = await tools.callTool("request_attention", ask({ clientRequestId: `raise-${key}`, target })) as McpToolResult;
+    expect(result.ok).toBe(true);
+    expect(readAttentionFile().requests.at(-1)!.frameAtCreation.project).toBe(project);
+  }
+
+  /* A geometric target IS its own frame, so it is the one kind that can degrade
+     to a real destination when nothing named survives. */
+  expect(readAttentionFile().requests.at(-1)!.frameAtCreation.rect).toEqual({ x: -290, y: -280, w: 600, h: 600 });
+});
+
+test("a target the server cannot attribute is refused rather than filed under a guess", async () => {
+  const tools = service();
+
+  const draft = await tools.callTool("request_attention", ask({ clientRequestId: "raise-draft", target: { kind: "draft", draftId: "d1" } })) as McpToolResult;
+  const missing = await tools.callTool("request_attention", ask({ clientRequestId: "raise-missing", target: { kind: "conversation", path: "/tmp/nope.jsonl" } })) as McpToolResult;
+  const nonsense = await tools.callTool("request_attention", ask({ clientRequestId: "raise-nonsense", target: { kind: "elsewhere" } })) as McpToolResult;
+
+  expect(draft).toMatchObject({ ok: false, error: "a draft target needs an explicit project" });
+  expect(missing).toMatchObject({ ok: false, error: "no conversation on the board has that transcript path" });
+  expect(nonsense).toMatchObject({ ok: false, error: "target must be a typed focus target" });
+  expect(readAttentionFile().requests).toEqual([]);
+
+  /* Naming the project explicitly is the way through for a board draft. */
+  const named = await tools.callTool("request_attention", ask({ clientRequestId: "raise-draft-2", target: { kind: "draft", draftId: "d1" }, project: "demo" })) as McpToolResult;
+  expect(named.ok).toBe(true);
+  expect(readAttentionFile().requests[0]!.frameAtCreation.project).toBe("demo");
+});
+
+test("a geometric target may not be opened, and the refusal reaches the caller", async () => {
+  const tools = service();
+
+  const refused = await tools.callTool("request_attention", ask({
+    target: { kind: "region", project: "demo", rect: { x: 0, y: 0, w: 100, h: 100 } },
+    intent: "open",
+  })) as McpToolResult;
+
+  /* Refused, never silently downgraded: the operator is told which of show and
+     open they are agreeing to, so a rewritten intent would make that a lie. */
+  expect(refused).toMatchObject({ ok: false, error: "a geometric target can only be shown, not opened" });
+  expect(readAttentionFile().requests).toEqual([]);
+});
+
+test("the ask is a mutation, so its receipt outlives the MCP process", async () => {
+  const retentions: string[] = [];
+  const store = new MemoryMcpReceiptStore();
+  const spy = {
+    claim: (key: string, digest: string, retention: string) => {
+      retentions.push(retention);
+      return store.claim(key, digest);
+    },
+    complete: (key: string, digest: string, result: McpToolResult) => store.complete(key, digest, result),
+  };
+
+  await createMcpToolService(bindings(), spy as never).callTool("request_attention", ask());
+
+  /* A bounded receipt would let a retry after a restart ask the operator a
+     second time for the same thing. */
+  expect(retentions).toEqual(["durable"]);
+  expect(MCP_TOOL_NAMES).toContain("request_attention");
+});
+
+test("no rootId can be named by the caller", async () => {
+  const tools = service();
+
+  await tools.callTool("request_attention", ask({ rootId: "root_somebody_else" }));
+
+  /* D4's authority rule: the service resolves the root identity itself, so a
+     worker holding this tool still cannot speak as a root of its choosing. */
+  expect(readAttentionFile().requests[0]!.requestedBy.rootId).toBe(readRootLineage()!.rootId);
+  expect(readAttentionFile().requests[0]!.requestedBy.rootId).not.toBe("root_somebody_else");
+});

--- a/src/lib/mcp/server.test.ts
+++ b/src/lib/mcp/server.test.ts
@@ -1087,6 +1087,7 @@ describe("MCP tool service", () => {
         "deployment_status",
         "resources",
         "conversation_migration",
+        "request_attention",
       ]);
       for (const tool of listed.tools) {
         expect(tool.inputSchema.required).toContain("clientRequestId");

--- a/src/lib/mcp/server.ts
+++ b/src/lib/mcp/server.ts
@@ -35,6 +35,7 @@ export const MCP_TOOL_NAMES = [
   "deployment_status",
   "resources",
   "conversation_migration",
+  "request_attention",
 ] as const;
 
 export type McpToolName = typeof MCP_TOOL_NAMES[number];
@@ -52,6 +53,7 @@ const MUTATING_MCP_TOOL_NAMES = new Set<McpToolName>([
   "flow_action",
   "conversation_action",
   "conversation_migration",
+  "request_attention",
 ]);
 
 export type McpToolArgs = Record<string, unknown> & { clientRequestId?: unknown };
@@ -935,6 +937,7 @@ const TOOL_DESCRIPTIONS: Record<McpToolName, string> = {
   deployment_status: "Read Viewer deployment or runtime operation status, or list recent deployments.",
   resources: "Read system and Viewer-owned agent resource usage.",
   conversation_migration: "Reseat, retry, or roll back a conversation account migration.",
+  request_attention: "Ask the operator to look at something: raise an attention request that offers to move their Viewer to a target and waits for their yes.",
 };
 
 const clientRequestIdSchema = z.string().min(1).describe("Stable idempotency key for this logical call.");
@@ -1103,6 +1106,15 @@ const TOOL_INPUT_SCHEMAS: Record<McpToolName, z.ZodObject> = {
     action: z.enum(["reseat", "retry", "rollback"]),
     expectedRevision: z.number().int().min(0).optional(),
     transcriptPath: z.string().optional(),
+  }).passthrough(),
+  request_attention: z.object({
+    clientRequestId: clientRequestIdSchema,
+    target: z.record(z.string(), z.unknown()).describe("Typed focus target: conversation | pipeline | stage | flowRound | task | draft | region | point."),
+    reason: z.string().min(1).describe("One operator-safe sentence saying why it is worth looking at. Never the target's contents."),
+    intent: z.enum(["show", "open"]).optional().describe("show frames and highlights; open also opens the target's own surface. Default show."),
+    zoom: z.enum(["inspect", "situate"]).optional(),
+    contextLabel: z.string().optional().describe("Named in the spoken sentence but never navigated to."),
+    project: z.string().optional().describe("Required only for a target the server cannot attribute on its own (a board draft)."),
   }).passthrough(),
 };
 

--- a/src/lib/root/adopt.test.ts
+++ b/src/lib/root/adopt.test.ts
@@ -1,0 +1,114 @@
+import { afterEach, beforeEach, expect, test } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { adoptLiveRootSession, liveRootSession, type RootSessionSource } from "./adopt";
+import { readRootLineage, rootIdentity } from "./store";
+
+/*
+ * #688 D5. The lineage arithmetic was already built and tested; what was
+ * missing was anything that told it which session the operator is talking to,
+ * so the file carried a minted rootId over an empty session list — a stable
+ * identity with no chain to survive a rollover with.
+ */
+
+let sandbox = "";
+let previousStateDir: string | undefined;
+
+beforeEach(() => {
+  previousStateDir = process.env.LLV_STATE_DIR;
+  sandbox = fs.mkdtempSync(path.join(os.tmpdir(), "llv-root-adopt-"));
+  process.env.LLV_STATE_DIR = sandbox;
+});
+afterEach(() => {
+  if (previousStateDir === undefined) delete process.env.LLV_STATE_DIR;
+  else process.env.LLV_STATE_DIR = previousStateDir;
+  fs.rmSync(sandbox, { recursive: true, force: true });
+});
+
+function source(
+  conversations: { id: string; agentRole: string | null; path: string | null; updatedAt: string }[],
+  configuredRootId: string | null = null,
+): RootSessionSource {
+  return {
+    conversations: conversations.map((conversation) => ({
+      id: conversation.id,
+      agentRole: conversation.agentRole,
+      generations: conversation.path ? [{ path: conversation.path }] : [],
+      updatedAt: conversation.updatedAt,
+    })),
+    configuredRootId,
+  };
+}
+
+const worker = { id: "conversation_worker", agentRole: "builder", path: "/tmp/worker.jsonl", updatedAt: "2026-07-01T09:00:00.000Z" };
+const root = { id: "conversation_root", agentRole: "root", path: "/tmp/root.jsonl", updatedAt: "2026-07-01T10:00:00.000Z" };
+
+test("the live root session is recorded, so the identity has a chain instead of an empty list", () => {
+  const before = rootIdentity();
+  expect(readRootLineage()!.sessions).toEqual([]);
+
+  const adoption = adoptLiveRootSession(source([worker, root]));
+
+  expect(adoption!.outcome).toBe("created");
+  /* The identity itself is untouched: it is what in-flight requests were
+     written against, so minting a replacement would orphan every one of them. */
+  expect(readRootLineage()!.rootId).toBe(before);
+  expect(readRootLineage()!.sessions).toEqual([{
+    conversationId: "conversation_root",
+    path: "/tmp/root.jsonl",
+    startedAt: expect.any(String) as unknown as string,
+  }]);
+});
+
+test("a rollover appends a linked successor and keeps the same stable identity", () => {
+  adoptLiveRootSession(source([root]));
+  const identity = readRootLineage()!.rootId;
+
+  const successor = { id: "conversation_root_2", agentRole: "root", path: "/tmp/root-2.jsonl", updatedAt: "2026-07-01T11:00:00.000Z" };
+  const adoption = adoptLiveRootSession(source([root, successor]));
+
+  expect(adoption!.outcome).toBe("rolled-over");
+  expect(readRootLineage()!.rootId).toBe(identity);
+  const sessions = readRootLineage()!.sessions;
+  expect(sessions.map((session) => session.conversationId)).toEqual(["conversation_root", "conversation_root_2"]);
+  expect(sessions[0]!.endedAt).toEqual(expect.any(String));
+  /* The successor records what it continues from — that link is the whole
+     point: a request raised before the rollover still resolves after it. */
+  expect(sessions[1]!.seededFrom).toBe("conversation_root");
+});
+
+test("re-reporting the same session writes nothing, so a raise is not a serialized write", () => {
+  adoptLiveRootSession(source([root]));
+  const revision = readRootLineage()!.revision;
+
+  expect(adoptLiveRootSession(source([root]))).toBeNull();
+  expect(readRootLineage()!.revision).toBe(revision);
+});
+
+test("only the root is ever adopted, and a board with none adopts nothing", () => {
+  expect(liveRootSession(source([worker]))).toBeNull();
+  expect(adoptLiveRootSession(source([worker]))).toBeNull();
+  expect(readRootLineage()).toBeNull();
+
+  /* The operator's configured id wins over the role, which is how a rollover is
+     followed the moment they re-point it. */
+  expect(liveRootSession(source([worker, root], "conversation_worker"))).toEqual({
+    conversationId: "conversation_worker",
+    path: "/tmp/worker.jsonl",
+  });
+});
+
+test("a root session whose transcript has not landed yet is adopted path-pending", () => {
+  const pathless = { id: "conversation_root", agentRole: "root", path: null, updatedAt: "2026-07-01T10:00:00.000Z" };
+
+  adoptLiveRootSession(source([pathless]));
+  expect(readRootLineage()!.sessions[0]!.path).toBeNull();
+
+  /* And the path settling later is a change worth recording, not a new session. */
+  const adoption = adoptLiveRootSession(source([root]));
+  expect(adoption!.outcome).toBe("settled");
+  expect(readRootLineage()!.sessions).toHaveLength(1);
+  expect(readRootLineage()!.sessions[0]!.path).toBe("/tmp/root.jsonl");
+});

--- a/src/lib/root/adopt.test.ts
+++ b/src/lib/root/adopt.test.ts
@@ -3,6 +3,9 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
+import { emptyLaunchProfile, type NativeGeneration } from "@/lib/accounts/migration/contracts";
+import type { RegistryConversation } from "@/lib/agent/registry";
+
 import { adoptLiveRootSession, liveRootSession, type RootSessionSource } from "./adopt";
 import { readRootLineage, rootIdentity } from "./store";
 
@@ -11,6 +14,11 @@ import { readRootLineage, rootIdentity } from "./store";
  * missing was anything that told it which session the operator is talking to,
  * so the file carried a minted rootId over an empty session list — a stable
  * identity with no chain to survive a rollover with.
+ *
+ * The fixtures below are real `RegistryConversation` values with real
+ * `LaunchProfile`s, not a hand-written slice: the whole defect this closes was
+ * reading a field the registry never writes `root` into, and a fixture that
+ * invents the field it reads would pass against exactly that bug.
  */
 
 let sandbox = "";
@@ -27,23 +35,68 @@ afterEach(() => {
   fs.rmSync(sandbox, { recursive: true, force: true });
 });
 
-function source(
-  conversations: { id: string; agentRole: string | null; path: string | null; updatedAt: string }[],
-  configuredRootId: string | null = null,
-): RootSessionSource {
+function generation(id: string, transcript: string, role: "root" | "worker"): NativeGeneration {
   return {
-    conversations: conversations.map((conversation) => ({
-      id: conversation.id,
-      agentRole: conversation.agentRole,
-      generations: conversation.path ? [{ path: conversation.path }] : [],
-      updatedAt: conversation.updatedAt,
-    })),
-    configuredRootId,
+    id,
+    path: transcript,
+    accountId: null,
+    launchProfile: emptyLaunchProfile({ cwd: "/repo", role }),
+    historyHash: null,
+    host: null,
+    createdAt: "2026-07-01T09:00:00.000Z",
+    archivedAt: null,
   };
 }
 
-const worker = { id: "conversation_worker", agentRole: "builder", path: "/tmp/worker.jsonl", updatedAt: "2026-07-01T09:00:00.000Z" };
-const root = { id: "conversation_root", agentRole: "root", path: "/tmp/root.jsonl", updatedAt: "2026-07-01T10:00:00.000Z" };
+/** A registry conversation exactly as the registry holds one. Typed as the real
+    thing, so a change to that shape breaks this rather than passing silently. */
+function conversation(input: {
+  id: string;
+  role: "root" | "worker";
+  /** Role-preset id. The operator's root has NONE — that is what defines it. */
+  agentRole?: string | null;
+  /** One entry per generation. Empty means the transcript has not landed yet. */
+  paths?: string[];
+  updatedAt: string;
+}): RegistryConversation {
+  const paths = input.paths ?? [];
+  return {
+    id: input.id as RegistryConversation["id"],
+    engine: "claude",
+    generations: paths.map((transcript, index) => generation(`${input.id}_g${index}`, transcript, input.role)),
+    continuityPaths: [],
+    abandonedContinuityPaths: [],
+    projectOwnership: null,
+    migration: null,
+    migrationOptOut: null,
+    supersededBy: null,
+    agentRole: input.agentRole ?? null,
+    delegationDepth: null,
+    turn: { state: "idle", source: "empty", terminalAt: null, observedAt: null },
+    createdAt: "2026-07-01T09:00:00.000Z",
+    updatedAt: input.updatedAt,
+  };
+}
+
+function source(conversations: RegistryConversation[], configuredRootId: string | null = null): RootSessionSource {
+  /* Handed over the way `rootSessionSource()` in the MCP bindings hands it
+     over: the registry's own values, with no field mapping in between. */
+  return { conversations, configuredRootId };
+}
+
+const worker = conversation({
+  id: "conversation_worker",
+  role: "worker",
+  agentRole: "builder",
+  paths: ["/tmp/worker.jsonl"],
+  updatedAt: "2026-07-01T09:00:00.000Z",
+});
+const root = conversation({
+  id: "conversation_root",
+  role: "root",
+  paths: ["/tmp/root.jsonl"],
+  updatedAt: "2026-07-01T10:00:00.000Z",
+});
 
 test("the live root session is recorded, so the identity has a chain instead of an empty list", () => {
   const before = rootIdentity();
@@ -62,11 +115,36 @@ test("the live root session is recorded, so the identity has a chain instead of 
   }]);
 });
 
+test("the root is the launch-profile role, which is the only place the registry writes it", () => {
+  /* `agentRole` is the role-PRESET id and has no `root` member: the operator's
+     own session is the one with no preset at all. A conversation carrying that
+     string as a preset is still a worker, and the durable profile is what says
+     so — this is the exact confusion that left the lineage empty in production. */
+  const impostor = conversation({
+    id: "conversation_impostor",
+    role: "worker",
+    agentRole: "root",
+    paths: ["/tmp/impostor.jsonl"],
+    updatedAt: "2026-07-01T11:00:00.000Z",
+  });
+
+  expect(liveRootSession(source([impostor]))).toBeNull();
+  expect(liveRootSession(source([impostor, root]))).toEqual({
+    conversationId: "conversation_root",
+    path: "/tmp/root.jsonl",
+  });
+});
+
 test("a rollover appends a linked successor and keeps the same stable identity", () => {
   adoptLiveRootSession(source([root]));
   const identity = readRootLineage()!.rootId;
 
-  const successor = { id: "conversation_root_2", agentRole: "root", path: "/tmp/root-2.jsonl", updatedAt: "2026-07-01T11:00:00.000Z" };
+  const successor = conversation({
+    id: "conversation_root_2",
+    role: "root",
+    paths: ["/tmp/root-2.jsonl"],
+    updatedAt: "2026-07-01T11:00:00.000Z",
+  });
   const adoption = adoptLiveRootSession(source([root, successor]));
 
   expect(adoption!.outcome).toBe("rolled-over");
@@ -77,6 +155,27 @@ test("a rollover appends a linked successor and keeps the same stable identity",
   /* The successor records what it continues from — that link is the whole
      point: a request raised before the rollover still resolves after it. */
   expect(sessions[1]!.seededFrom).toBe("conversation_root");
+});
+
+test("a resume in place carries the role forward and the newest generation names the transcript", () => {
+  /* A resume writes a second generation on the SAME conversation with the role
+     copied onto it. Reading the role off the oldest generation, or off none,
+     would drop the root the first time the operator resumes it. */
+  const resumed = conversation({
+    id: "conversation_root",
+    role: "root",
+    paths: ["/tmp/root.jsonl", "/tmp/root-resumed.jsonl"],
+    updatedAt: "2026-07-01T12:00:00.000Z",
+  });
+
+  adoptLiveRootSession(source([root]));
+  const adoption = adoptLiveRootSession(source([resumed]));
+
+  /* Same conversation, so the head settles onto the new transcript rather than
+     rolling over — the stable identity never moved. */
+  expect(adoption!.outcome).toBe("settled");
+  expect(readRootLineage()!.sessions).toHaveLength(1);
+  expect(readRootLineage()!.sessions[0]!.path).toBe("/tmp/root-resumed.jsonl");
 });
 
 test("re-reporting the same session writes nothing, so a raise is not a serialized write", () => {
@@ -101,9 +200,12 @@ test("only the root is ever adopted, and a board with none adopts nothing", () =
 });
 
 test("a root session whose transcript has not landed yet is adopted path-pending", () => {
-  const pathless = { id: "conversation_root", agentRole: "root", path: null, updatedAt: "2026-07-01T10:00:00.000Z" };
+  /* Before the engine writes a transcript the conversation has no generation at
+     all — and therefore no launch profile to read a role from, so the operator's
+     configured id is the only thing that can name it this early. */
+  const pathless = conversation({ id: "conversation_root", role: "root", updatedAt: "2026-07-01T10:00:00.000Z" });
 
-  adoptLiveRootSession(source([pathless]));
+  adoptLiveRootSession(source([pathless], "conversation_root"));
   expect(readRootLineage()!.sessions[0]!.path).toBeNull();
 
   /* And the path settling later is a change worth recording, not a new session. */

--- a/src/lib/root/adopt.ts
+++ b/src/lib/root/adopt.ts
@@ -1,0 +1,74 @@
+import { headSession } from "./lineage";
+import { readRootLineage, recordRootSession, rootLineageFile } from "./store";
+import type { RootAdoption } from "./types";
+
+/**
+ * Who the live root session actually is, and recording it (#688 D5).
+ *
+ * The lineage module can already fold a session into the chain; what was
+ * missing was anything that tells it which session that is. Without this the
+ * file carries a minted `rootId` over an empty session list — the stable
+ * identity exists, but the chain it is supposed to survive is never written, so
+ * a rollover leaves no link and the continuity marker has nothing to point at.
+ *
+ * The root is named the way the rest of the app already names it: the
+ * conversation id the operator configured, and failing that the conversation
+ * the registry recorded a `root` role for at admission. Both are durable
+ * launch-time facts, so neither can drift onto a worker.
+ */
+
+/** The narrow slice of a registry snapshot this needs — passed as data so the
+    resolution is testable without the shared registry. */
+export interface RootSessionSource {
+  conversations: readonly {
+    id: string;
+    agentRole: string | null;
+    generations: readonly { path: string }[];
+    updatedAt: string;
+  }[];
+  /** `LLV_ROOT_CONVERSATION_ID`, the same env the migration coordinator reads
+      to stamp the `root` role in the first place. */
+  configuredRootId: string | null;
+}
+
+export interface RootSessionCandidate {
+  conversationId: string;
+  path: string | null;
+}
+
+export function liveRootSession(source: RootSessionSource): RootSessionCandidate | null {
+  const configured = source.configuredRootId
+    ? source.conversations.find((conversation) => conversation.id === source.configuredRootId)
+    : undefined;
+  /* Falling back to the role means a rollover is seen even before the operator
+     re-points the env at the successor; the newest such conversation is the one
+     they are talking to. */
+  const chosen = configured ?? [...source.conversations]
+    .filter((conversation) => conversation.agentRole === "root")
+    .sort((left, right) => left.updatedAt.localeCompare(right.updatedAt))
+    .at(-1);
+  if (!chosen) return null;
+  return { conversationId: chosen.id, path: chosen.generations.at(-1)?.path ?? null };
+}
+
+/**
+ * Record the live root session, or do nothing when it is already the head.
+ *
+ * The unchanged case is answered from a plain read, before the file
+ * transaction: this runs on the path that raises a request, and taking a lock
+ * to conclude that nothing moved would put a serialized write in front of every
+ * one of them.
+ */
+export function adoptLiveRootSession(
+  source: RootSessionSource,
+  options: { filePath?: string; now?: Date } = {},
+): RootAdoption | null {
+  const candidate = liveRootSession(source);
+  if (!candidate) return null;
+  const filePath = options.filePath ?? rootLineageFile();
+  const head = headSession(readRootLineage(filePath));
+  if (head?.conversationId === candidate.conversationId && (candidate.path === null || head.path === candidate.path)) {
+    return null;
+  }
+  return recordRootSession(candidate, { filePath, ...(options.now ? { now: options.now } : {}) });
+}

--- a/src/lib/root/adopt.ts
+++ b/src/lib/root/adopt.ts
@@ -11,21 +11,31 @@ import type { RootAdoption } from "./types";
  * identity exists, but the chain it is supposed to survive is never written, so
  * a rollover leaves no link and the continuity marker has nothing to point at.
  *
- * The root is named the way the rest of the app already names it: the
- * conversation id the operator configured, and failing that the conversation
- * the registry recorded a `root` role for at admission. Both are durable
- * launch-time facts, so neither can drift onto a worker.
+ * The root is named the way the registry already names it: the conversation id
+ * the operator configured, and failing that the conversation whose launch
+ * profile carries the `root` role. Both are durable launch-time facts, so
+ * neither can drift onto a worker.
+ *
+ * The role lives on the LAUNCH PROFILE, not on `agentRole`. `agentRole` is the
+ * role-PRESET id (`builder`, `reviewer`, …) and has no `root` member at all —
+ * the operator's own session is precisely the one with no preset — so keying on
+ * it would adopt nothing, and would adopt a worker outright if anyone ever
+ * defined a preset by that name.
  */
 
-/** The narrow slice of a registry snapshot this needs — passed as data so the
-    resolution is testable without the shared registry. */
+/**
+ * The slice of a registry snapshot this reads, described structurally so a
+ * `RegistryConversation` satisfies it as-is and nothing here has to import the
+ * registry. The resolution stays a pure function of data.
+ */
+export interface RootConversationSlice {
+  id: string;
+  updatedAt: string;
+  generations: readonly { path: string; launchProfile?: { role?: string | null } | null }[];
+}
+
 export interface RootSessionSource {
-  conversations: readonly {
-    id: string;
-    agentRole: string | null;
-    generations: readonly { path: string }[];
-    updatedAt: string;
-  }[];
+  conversations: readonly RootConversationSlice[];
   /** `LLV_ROOT_CONVERSATION_ID`, the same env the migration coordinator reads
       to stamp the `root` role in the first place. */
   configuredRootId: string | null;
@@ -36,6 +46,23 @@ export interface RootSessionCandidate {
   path: string | null;
 }
 
+/**
+ * The role the registry stamped on this conversation, read from the newest
+ * generation that carries a launch profile.
+ *
+ * Newest, because a resume or a migration writes a fresh generation and the
+ * role is copied forward onto it; older generations are history. A generation
+ * with no profile at all is legacy and says nothing either way, so it is
+ * skipped rather than read as "worker".
+ */
+function conversationRole(conversation: RootConversationSlice): string | null {
+  for (let index = conversation.generations.length - 1; index >= 0; index -= 1) {
+    const role = conversation.generations[index]?.launchProfile?.role;
+    if (role) return role;
+  }
+  return null;
+}
+
 export function liveRootSession(source: RootSessionSource): RootSessionCandidate | null {
   const configured = source.configuredRootId
     ? source.conversations.find((conversation) => conversation.id === source.configuredRootId)
@@ -44,7 +71,7 @@ export function liveRootSession(source: RootSessionSource): RootSessionCandidate
      re-points the env at the successor; the newest such conversation is the one
      they are talking to. */
   const chosen = configured ?? [...source.conversations]
-    .filter((conversation) => conversation.agentRole === "root")
+    .filter((conversation) => conversationRole(conversation) === "root")
     .sort((left, right) => left.updatedAt.localeCompare(right.updatedAt))
     .at(-1);
   if (!chosen) return null;


### PR DESCRIPTION
Closes the last mile of #688. The record, the machine, the store, the target model and `/api/attention` all worked; nothing used them.

## What was actually wrong

The entire #688 client surface — `RootOverlayHost`, `RootOverlay`, `RootSheet`, `useAttentionOffers` and `buildFocusFrameIndex` — was imported by nothing but its own tests. No shipped page polled `/api/attention`, and the deployed bundle contained none of that path. A live request sat at `state=pending` with `offeredTo: []` for its full 10-minute TTL, which is the proof: `useAttentionOffers` documents that *rendering* an offer is the `pending → offered` transition, precisely so "nobody saw it" and "they saw it and said nothing" stay different facts. An empty `offeredTo` at expiry means no surface ever rendered it.

There was also no agent-facing tool, so the root agent could not raise a request through its normal surface — the only live requests were created by raw HTTP. And accepting could not have navigated anyway: camera movement was deliberately left unstarted, so `resolveFocusTarget` was reachable only from tests.

Nothing here changes the record, the machine, the store or the routes.

## The four pieces

**Mounted.** `AttentionHost` (`src/components/attention/AttentionHost.tsx`) polls the record for one stable per-device id — the same `stableDeviceId` presence already uses, so "which device was offered this" and "which device is looking at what" name the same thing. It renders the existing overlay the moment there is something to answer and nothing at all otherwise; the root conversation's own turns need a transcript-feed adapter and stay their own slice, but an unanswered request being invisible is the failure this ends.

The hidden-surface contract is untouched and is now tested *through* the mount rather than only at the hook: a background tab reads the record, renders nothing, reports nothing, and the request expires with `offeredTo: []`. The operator's Viewer is frequently backgrounded, so that is the common case.

**A tool.** `request_attention`, following the conventions already in `bindings.ts` and `server.ts`: `clientRequestId` idempotency, the established `mutationReceipt` shape, and registration as a mutating tool so the receipt is durable — a bounded one would let a retry after a restart ask the operator twice. It only asks: the request lands at `pending` and nothing moves until they agree on a device. No `rootId` appears in the schema, because the service resolves the root identity itself.

The server derives which project a target lives in (from the scanner, the pipelines, the flows or the tasks) and refuses a target it cannot attribute rather than filing it under a guess. A board draft exists only on the operator's canvas, so it needs an explicit `project`.

**Navigation.** One bus (`focusHandoffBus`), the same idiom `viewPresenceBus` already uses for the "leaf publishes, shell consumes" problem: `SchemeBoard` publishes its live frame index plus its two camera moves, and `Viewer` publishes project and conversation opening. `runFocusHandoff` opens the target's project if it is not the open one, waits for that board's layout, resolves the anchor against the board **as it is now** — never the rect stored at creation, since the board reflows — and glides there with zoom following intent.

`MobileFocusView` registers the same way but arrives by pinning the pane: there is no camera on a phone and one pane is on screen at a time. A destination it has no pane for (a coordinate, or the space a vanished card used to occupy) is **refused**, and the handoff reports `lost` rather than recording an arrival that did not happen.

**Return.** The viewport is captured on the answering device immediately before anything moves, because the move can open another project and capturing at arrival would record the destination. Returning restores that camera exactly, and does not re-open the focused path — that would glide the board to the node and undo the framing just restored. On a surface with no camera the focused path is what comes back, which is all of that viewport it can put back.

## The secondary gap

`adoptRootSession` was never called from app code, so `root-lineage.json` carried a minted `rootId` over `"sessions": []` — a stable identity with no chain to survive a rollover with. `adoptLiveRootSession` resolves the root the way the rest of the app already names it (the configured conversation id, else the `root` role the registry stamped at admission) and the raise path folds it in. A rollover appends a linked successor under the same identity, so a request raised before it still resolves after.

## One judgement worth a second look

A request raised through the tool has no board in front of it, so the frame it records is deliberately empty. `frameWasRead` refuses to degrade to such a frame: standing in for a vanished anchor with it would drop the operator at world (0,0) and call it "where it was", which is the silent arbitrary landing the design forbids. Those requests report `lost` instead — visibly, since the record refuses to call it a follow and the action row says so. The alternative would be for the tool to carry geometry it has no way to know.

## Design decisions honoured as given

- Only the root may surface a request, and it is still enforced server-side: `rootIdentity()` is resolved in `service.ts` and never accepted from the caller. A worker holding this tool cannot name a root of its choosing. Worth stating plainly: the MCP transport carries no caller identity, so the guarantee is over *which* root is named, not over which agent may call.
- A hidden or background surface reports nothing.
- Every request declares show vs open, and that reaches the operator before they agree.
- Anchor and frame stay separate; a vanished anchor resolves to approximate or lost.
- The return point is per-device, captured on the device that accepted.

Not built here: #691's wider overlay redesign, the Computer Use seam, standing-consent storage, and the root-transcript feed.

## Verification

- Focused tests, by path, against an isolated state dir: **197 pass, 0 fail** across `src/components/attention/`, `focusFrames.test.ts`, the two `MobileFocusView` suites, `src/components/overlay/`, `src/lib/attention/`, `src/lib/root/`, `src/app/api/attention/`, and the four `src/lib/mcp/` suites.
- `./node_modules/.bin/tsc --noEmit` — clean.
- `bun run lint` — 11 errors + 1 warning, all pre-existing (`scripts/*.cjs` require-imports, `reaperRuntime.ts` unused var); unchanged from the merge base.
- `bun scripts/privacy-publication-gate.ts --base <merge-base>` — PASS.

Each new test was checked by reverting its fix and watching it go red: stubbing the mount fails 4 host tests; removing the camera move fails 6; removing the camera restore fails the 2 return tests; dropping `adoptRootSession()` from the raise path fails the adoption assertion; making `liveRootSession` resolve nobody fails 4 lineage tests; loosening `frameWasRead` fails the origin-landing test; unregistering the tool fails all 8 tool tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)