### PR TITLE
fix(audio): tick every newly appended tool call, however fast it settles

### DIFF
--- a/src/components/LogFeed.tsx
+++ b/src/components/LogFeed.tsx
@@ -312,10 +312,13 @@ export function LogFeed({ file, showSvc, lineFilter, onStatus, paused, follow, s
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [session, file?.activity, tail.lines, tail.linesStart],
   );
-  /* Tool activity earns its cue from the parse itself: an in-flight call ticks
-     once, keyed on the engine's call id, so a tail tick that re-parses the same
-     window is silent and history never replays. */
-  useToolActivityCues(feed.items, memoryKey);
+  /* Tool activity earns its cue from the parse itself: every newly appended
+     call ticks once, keyed on the engine's call id — even one that settled
+     inside a single tail tick — while re-parses, remounts and paged-in history
+     stay silent. The window end anchors "newly appended" to the tail stream;
+     loading gates the baseline so an unloaded feed is not mistaken for an
+     empty conversation. */
+  useToolActivityCues(feed.items, memoryKey, file?.path ?? null, tail.linesStart + tail.lines.length, Boolean(file) && !tail.loading);
   const hiddenLocal = Math.max(0, feed.items.length - visibleCount);
   const visibleItems = hiddenLocal ? feed.items.slice(-visibleCount) : feed.items;
   const visibleStartIndex = feed.items.length - visibleItems.length;

--- a/src/hooks/useToolActivityCues.ts
+++ b/src/hooks/useToolActivityCues.ts
@@ -1,24 +1,54 @@
 "use client";
 
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 
 import type { FeedEntry } from "@/components/feed/parse";
 import { playCue } from "@/lib/audio/app";
-import { toolActivityCues } from "@/lib/audio/toolCues";
+import { createToolCueScanner, type ToolCueScanner } from "@/lib/audio/toolCues";
 import { panForPane } from "@/lib/chime";
 
 /**
  * Rings the tool-activity cues for one conversation's feed.
  *
- * Runs on every parse the pane produces, which is the point: the player owns
- * de-duplication, so re-parsing the same window, remounting the pane, or two
- * panes rendering the same conversation cannot double-ring. The hook stays this
- * thin deliberately — the moment it starts remembering what it played, there are
- * two answers to "did this event already sound" and they drift.
+ * Runs on every parse the pane produces. The scanner holds the one fact the
+ * parse alone cannot carry — where the previously heard window ended — so a
+ * call that settled inside a single tail tick still reads as newly appended.
+ * What actually sounds stays the player's call: it de-duplicates on the call
+ * id tab-wide, so re-parsing the same window, remounting the pane, or two
+ * panes rendering the same conversation cannot double-ring.
+ *
+ * `ready` gates the baseline: until the tail delivered its first window the
+ * feed is empty because nothing has LOADED, not because nothing has run, and
+ * baselining on that emptiness would replay the whole history as sound.
  */
-export function useToolActivityCues(items: readonly FeedEntry[], conversation: string | null): void {
+export function useToolActivityCues(
+  items: readonly FeedEntry[],
+  conversation: string | null,
+  path: string | null,
+  windowEnd: number,
+  ready: boolean,
+): void {
+  const scannerRef = useRef<{ key: string; scanner: ToolCueScanner } | null>(null);
   useEffect(() => {
-    if (!conversation) return;
-    for (const request of toolActivityCues(items, conversation, panForPane(conversation))) playCue(request);
-  }, [items, conversation]);
+    if (!conversation || !path || !ready) return;
+    /* The window-end floor only means something within one transcript's line
+       stream, so the scanner lives exactly as long as one path in one pane.
+       The conversation identity, by contrast, names the cue events — it can
+       outlive a path (lineage continuation) and the player carries the
+       already-rung ids across. */
+    const key = `${conversation}\n${path}`;
+    if (scannerRef.current?.key !== key) {
+      const switching = scannerRef.current !== null;
+      scannerRef.current = { key, scanner: createToolCueScanner(conversation) };
+      /* A pane switching transcripts renders one commit where the new key is
+         still paired with the OLD file's window — the tail hook's reset lands
+         a commit later. Baselining on that mixed commit would anchor the floor
+         in the wrong stream and ring the newly loaded history; skip it and let
+         a clean later commit take the baseline. A fresh mount has no old
+         window, so it baselines immediately. */
+      if (switching) return;
+    }
+    const requests = scannerRef.current.scanner.scan(items, windowEnd, panForPane(conversation));
+    for (const request of requests) playCue(request);
+  }, [items, conversation, path, windowEnd, ready]);
 }

--- a/src/lib/audio/toolCues.feed.test.ts
+++ b/src/lib/audio/toolCues.feed.test.ts
@@ -1,0 +1,91 @@
+import { expect, test } from "bun:test";
+
+import { createFeedSession } from "@/components/feed/parse";
+
+import { createToolCueScanner } from "./toolCues";
+
+/**
+ * The scanner against the real parser: a short call whose call AND output land
+ * in one tail tick — the parse only ever observes it settled — must still tick
+ * exactly once, for every record shape an engine writes tool calls in.
+ */
+
+const userLine = JSON.stringify({
+  type: "user",
+  timestamp: "2026-07-10T09:59:00Z",
+  message: { content: "run the checks" },
+});
+
+const claudeToolUse = (id: string, command: string) =>
+  JSON.stringify({ type: "assistant", timestamp: "2026-07-10T10:00:00Z", message: { content: [{ type: "tool_use", id, name: "Bash", input: { command } }] } });
+const claudeToolResult = (id: string, text: string) =>
+  JSON.stringify({ type: "user", timestamp: "2026-07-10T10:00:01Z", message: { content: [{ type: "tool_result", tool_use_id: id, content: [{ type: "text", text }] }] } });
+
+const codexLine = (payload: Record<string, unknown>) =>
+  JSON.stringify({ type: "response_item", timestamp: "2026-07-10T10:00:00Z", payload });
+
+function feedThenAppend(engine: "claude" | "codex", baseline: string[], appended: string[]) {
+  const session = createFeedSession({ engine, fmt: engine, showSvc: false, lineFilter: "" });
+  const scanner = createToolCueScanner("conv-1");
+  const first = scanner.scan(session.feed(baseline, 0, true).items, baseline.length);
+  const all = [...baseline, ...appended];
+  const second = scanner.scan(session.feed(all, 0, true).items, all.length);
+  return { session, scanner, all, first, second };
+}
+
+test("claude: a tool_use whose tool_result arrived in the same update ticks once", () => {
+  const { session, scanner, all, first, second } = feedThenAppend(
+    "claude",
+    [userLine],
+    [claudeToolUse("b1", "git status --short"), claudeToolResult("b1", " M src/index.ts")],
+  );
+  expect(first).toEqual([]);
+  expect(second).toEqual([{ cue: "tool-tick", eventId: "tool:conv-1:b1", pan: 0 }]);
+  /* The next tick re-parses the same window: nothing new, nothing rings. */
+  expect(scanner.scan(session.feed(all, 0, true).items, all.length)).toEqual([]);
+});
+
+test("codex: a function_call settled by its function_call_output in the same update ticks once", () => {
+  const { first, second } = feedThenAppend(
+    "codex",
+    [codexLine({ type: "message", role: "user", content: [{ type: "input_text", text: "build it" }] })],
+    [
+      codexLine({ type: "function_call", call_id: "call-fast", name: "exec_command", arguments: JSON.stringify({ cmd: "make", workdir: "/workspace/build" }) }),
+      codexLine({ type: "function_call_output", call_id: "call-fast", output: "Process exited with code 0\nOutput:\nok" }),
+    ],
+  );
+  expect(first).toEqual([]);
+  expect(second).toEqual([{ cue: "tool-tick", eventId: "tool:conv-1:call-fast", pan: 0 }]);
+});
+
+test("codex: a custom_tool_call settled in the same update ticks once", () => {
+  const { first, second } = feedThenAppend(
+    "codex",
+    [codexLine({ type: "message", role: "user", content: [{ type: "input_text", text: "open it" }] })],
+    [
+      codexLine({ type: "custom_tool_call", call_id: "call-custom", name: "browser.open", input: "https://example.invalid" }),
+      codexLine({ type: "custom_tool_call_output", call_id: "call-custom", output: "opened" }),
+    ],
+  );
+  expect(first).toEqual([]);
+  expect(second).toEqual([{ cue: "tool-tick", eventId: "tool:conv-1:call-custom", pan: 0 }]);
+});
+
+test("paging older history in resets the parser but never replays a sound", () => {
+  const session = createFeedSession({ engine: "claude", fmt: "claude", showSvc: false, lineFilter: "" });
+  const scanner = createToolCueScanner("conv-1");
+  /* The pane opens on a window that starts at absolute line 2 — two older
+     lines exist on disk but are not loaded. */
+  const window = [userLine, claudeToolUse("b7", "bun test"), claudeToolResult("b7", "5 pass")];
+  expect(scanner.scan(session.feed(window, 2, true).items, 5)).toEqual([]);
+  /* A fast call lands (call + output in one tick) and rings. */
+  const grown = [...window, claudeToolUse("b8", "bun run build"), claudeToolResult("b8", "done")];
+  expect(scanner.scan(session.feed(grown, 2, true).items, 7)).toEqual([
+    { cue: "tool-tick", eventId: "tool:conv-1:b8", pan: 0 },
+  ]);
+  /* «Show earlier»: the window now starts at 0, which resets the session and
+     re-parses everything — fresh item objects, same transcript. The revealed
+     old call and the already-heard calls all stay silent. */
+  const paged = [claudeToolUse("b0", "ls"), claudeToolResult("b0", "README.md"), ...grown];
+  expect(scanner.scan(session.feed(paged, 0, true).items, 7)).toEqual([]);
+});

--- a/src/lib/audio/toolCues.test.ts
+++ b/src/lib/audio/toolCues.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "bun:test";
 
 import type { FeedEntry, ToolEvent } from "@/components/feed/parse";
 
-import { toolActivityCues } from "./toolCues";
+import { createToolCueScanner, toolActivityCues } from "./toolCues";
 
 function tool(over: Partial<ToolEvent> & { id: string }): ToolEvent {
   return {
@@ -24,6 +24,111 @@ function tool(over: Partial<ToolEvent> & { id: string }): ToolEvent {
 }
 
 const row = (item: FeedEntry["item"]): FeedEntry => ({ anchorKey: null, key: "k", item });
+
+describe("a newly appended call ticks even when it arrives already settled", () => {
+  test("call and output landing in one update still produce exactly one tick", () => {
+    const scanner = createToolCueScanner("conv-1");
+    /* Baseline: the conversation is open, ten lines of non-tool content, no
+       tool has run yet. */
+    expect(scanner.scan([], 10)).toEqual([]);
+    /* One tail tick delivers the call AND its output — the parse only ever
+       sees the settled event. It must still tick, once. */
+    const appended = [row(tool({ id: "fast-1", status: "ok", srcCall: 10 }))];
+    expect(scanner.scan(appended, 12)).toEqual([
+      { cue: "tool-tick", eventId: "tool:conv-1:fast-1", pan: 0 },
+    ]);
+    /* The same window re-parsed is a duplicate observation, not a new call. */
+    expect(scanner.scan(appended, 12)).toEqual([]);
+  });
+
+  test("a fast call that failed ticks the same generic cue — status does not gate newness", () => {
+    const scanner = createToolCueScanner("conv-1");
+    expect(scanner.scan([], 10)).toEqual([]);
+    const appended = [row(tool({ id: "boom", status: "err", srcCall: 10 }))];
+    expect(scanner.scan(appended, 12)).toEqual([
+      { cue: "tool-tick", eventId: "tool:conv-1:boom", pan: 0 },
+    ]);
+  });
+
+  test("a fast Viewer MCP call keeps its distinct cue", () => {
+    const scanner = createToolCueScanner("conv-1");
+    expect(scanner.scan([], 10)).toEqual([]);
+    const mcp = tool({
+      id: "call-mcp",
+      status: "ok",
+      srcCall: 10,
+      tool: "mcp__viewer__send_message",
+      mcp: { serverName: "viewer", toolName: "send_message", args: {}, result: null },
+    });
+    expect(scanner.scan([row(mcp)], 12)).toEqual([
+      { cue: "viewer-mcp", eventId: "tool:conv-1:call-mcp", pan: 0 },
+    ]);
+  });
+
+  test("a fast call folded into a command group still ticks", () => {
+    const scanner = createToolCueScanner("conv-1");
+    expect(scanner.scan([], 10)).toEqual([]);
+    const group = {
+      kind: "cmd-group" as const,
+      ids: ["fast-a"],
+      calls: [tool({ id: "fast-a", status: "ok", srcCall: 11 })],
+      t0: null,
+    } as FeedEntry["item"];
+    expect(scanner.scan([row(group)], 13)).toEqual([
+      { cue: "tool-tick", eventId: "tool:conv-1:fast-a", pan: 0 },
+    ]);
+  });
+});
+
+describe("history is silent, wherever it comes from", () => {
+  test("the baseline scan of a long settled transcript makes no sound at all", () => {
+    const scanner = createToolCueScanner("conv-1");
+    const history = Array.from({ length: 200 }, (_, index) =>
+      row(tool({ id: `old-${index}`, status: "ok", srcCall: index })),
+    );
+    expect(scanner.scan(history, 200)).toEqual([]);
+  });
+
+  test("paging older settled history in (prepend) stays silent", () => {
+    const scanner = createToolCueScanner("conv-1");
+    /* Window starts at absolute line 100. */
+    const current = [row(tool({ id: "seen", status: "ok", srcCall: 120 }))];
+    expect(scanner.scan(current, 150)).toEqual([]);
+    /* «Show earlier» reveals lines 0…99: old calls below the heard window. */
+    const paged = [
+      row(tool({ id: "ancient-1", status: "ok", srcCall: 5 })),
+      row(tool({ id: "ancient-2", status: "err", srcCall: 40 })),
+      ...current,
+    ];
+    expect(scanner.scan(paged, 150)).toEqual([]);
+  });
+
+  test("after a truncation restart the floor follows the window back down", () => {
+    const scanner = createToolCueScanner("conv-1");
+    expect(scanner.scan([row(tool({ id: "before", status: "ok", srcCall: 400 }))], 500)).toEqual([]);
+    /* The transcript was truncated: absolute indices restart at zero. The
+       re-fed window is history and stays silent… */
+    expect(scanner.scan([row(tool({ id: "before", status: "ok", srcCall: 4 }))], 10)).toEqual([]);
+    /* …but the pane is not deaf afterwards: the next appended call ticks. */
+    expect(scanner.scan([
+      row(tool({ id: "before", status: "ok", srcCall: 4 })),
+      row(tool({ id: "after", status: "ok", srcCall: 10 })),
+    ], 12)).toEqual([
+      { cue: "tool-tick", eventId: "tool:conv-1:after", pan: 0 },
+    ]);
+  });
+
+  test("a call still running at baseline is happening now and ticks", () => {
+    const scanner = createToolCueScanner("conv-1");
+    const opened = [
+      row(tool({ id: "done", status: "ok", srcCall: 10 })),
+      row(tool({ id: "live", status: "run", srcCall: 90 })),
+    ];
+    expect(scanner.scan(opened, 100)).toEqual([
+      { cue: "tool-tick", eventId: "tool:conv-1:live", pan: 0 },
+    ]);
+  });
+});
 
 describe("only work that is happening now ticks", () => {
   test("an in-flight call ticks; a finished one is history and stays silent", () => {

--- a/src/lib/audio/toolCues.ts
+++ b/src/lib/audio/toolCues.ts
@@ -7,20 +7,27 @@ import type { CueRequest } from "./cues";
 /**
  * Tool activity, read from the transcript the feed already parses.
  *
- * Two decisions carry this:
+ * Three decisions carry this:
  *
- * - only a call that is still RUNNING ticks. A tool event whose result has
- *   attached (`ok`/`err`) is history, and history must be silent: opening a
- *   month-old conversation, or pressing «show earlier», would otherwise replay
- *   every tool it ever ran as a burst of sound. `status === "run"` is exactly
- *   "this is happening now", and the parser sets it from the absence of a
- *   result record rather than from any clock;
+ * - a call is NEW when its source line lies at or past the end of the last
+ *   window this pane has heard. A short call settles inside one tail tick —
+ *   the parse only ever sees it with `ok`/`err` attached — so status cannot
+ *   mean "new": the transcript position is what distinguishes a freshly
+ *   appended call (any status) from settled history. Prepended pages and
+ *   re-parsed windows sit below the heard end and stay silent;
+ * - the first scan is the baseline and absorbs the whole window silently —
+ *   opening a month-old conversation, or remounting a pane, must not replay
+ *   every tool it ever ran as a burst of sound. The one exception is a call
+ *   still RUNNING at baseline: that is happening now, and it ticks;
  * - the identity is the engine's own call id, namespaced by conversation. The
  *   feed is re-parsed on every tail tick and from scratch on a remount, so the
- *   id is the only thing that survives both unchanged. Codex synthesizes ids for
- *   records that carry none (`plain-<n>-<ts>`), and those repeat ACROSS
+ *   id is the only thing that survives both unchanged. Codex synthesizes ids
+ *   for records that carry none (`plain-<n>-<ts>`), and those repeat ACROSS
  *   conversations — hence the namespace, or a tick in one pane would silence a
- *   different pane's first tool.
+ *   different pane's first tool. The player's tab-wide de-duplication on that
+ *   identity is what keeps duplicate scanners honest: a remounted pane or a
+ *   second pane on the same conversation re-baselines and re-requests, and the
+ *   player answers "already considered".
  */
 
 /** A Viewer MCP call is the agent reaching back into this viewer; it gets its
@@ -29,15 +36,59 @@ function cueFor(event: ToolEvent): CueRequest["cue"] {
   return event.mcp ? "viewer-mcp" : "tool-tick";
 }
 
-function requestFor(event: ToolEvent, conversation: string, pan: number): CueRequest | null {
-  if (event.status !== "run") return null;
+function requestFor(event: ToolEvent, conversation: string, pan: number): CueRequest {
   return { cue: cueFor(event), eventId: `tool:${conversation}:${event.id}`, pan };
 }
 
+/** Walks every tool event in one feed snapshot, folded command groups
+    included: the live trailing group is where an active call usually sits. */
+function eachToolEvent(items: readonly FeedEntry[], visit: (event: ToolEvent) => void): void {
+  for (const entry of items) {
+    const item = entry.item;
+    if (item.kind === "tool") visit(item);
+    else if (item.kind === "cmd-group") for (const call of item.calls) visit(call);
+  }
+}
+
+export interface ToolCueScanner {
+  /**
+   * Cue requests earned by one parse of the pane's window. `windowEnd` is the
+   * absolute line index just past the window (`linesStart + lines.length`),
+   * measured in the same stream as each event's `srcCall`; it becomes the
+   * floor future scans use to tell appended calls from revealed history.
+   */
+  scan(items: readonly FeedEntry[], windowEnd: number, pan?: number): CueRequest[];
+}
+
 /**
- * Cue requests for every in-flight tool call in one feed snapshot. Returns them
- * all; de-duplication is the player's job, so this stays a pure read of the
- * current parse.
+ * One pane's view of one conversation. State is exactly one number — the end
+ * of the last heard window — so a scanner lost to a remount costs nothing: the
+ * replacement re-baselines silently and the player still owns what actually
+ * sounds. A truncated transcript (indices restart at zero) simply moves the
+ * floor back down with the window; the id-keyed de-duplication in the player
+ * is what guarantees that even then nothing rings twice.
+ */
+export function createToolCueScanner(conversation: string): ToolCueScanner {
+  /** Absolute index just past the last scanned window; null before baseline. */
+  let heardEnd: number | null = null;
+  return {
+    scan(items, windowEnd, pan = 0) {
+      const floor = heardEnd;
+      heardEnd = windowEnd;
+      const requests: CueRequest[] = [];
+      eachToolEvent(items, (event) => {
+        const appended = floor !== null && event.srcCall >= floor;
+        if (appended || event.status === "run") requests.push(requestFor(event, conversation, pan));
+      });
+      return requests;
+    },
+  };
+}
+
+/**
+ * Cue requests for every in-flight tool call in one feed snapshot — the
+ * stateless view a baseline scan also produces. De-duplication is the player's
+ * job, so this stays a pure read of the current parse.
  */
 export function toolActivityCues(
   items: readonly FeedEntry[],
@@ -45,20 +96,8 @@ export function toolActivityCues(
   pan = 0,
 ): CueRequest[] {
   const requests: CueRequest[] = [];
-  for (const entry of items) {
-    const item = entry.item;
-    if (item.kind === "tool") {
-      const request = requestFor(item, conversation, pan);
-      if (request) requests.push(request);
-    } else if (item.kind === "cmd-group") {
-      /* A folded run of consecutive calls hides its members from the row, not
-         from the ear: the live trailing group is where an active call usually
-         sits. */
-      for (const call of item.calls) {
-        const request = requestFor(call, conversation, pan);
-        if (request) requests.push(request);
-      }
-    }
-  }
+  eachToolEvent(items, (event) => {
+    if (event.status === "run") requests.push(requestFor(event, conversation, pan));
+  });
   return requests;
 }


### PR DESCRIPTION
## Problem

A short tool call settles inside one tail tick: the frontend's first parse already sees it with `ok`/`err` attached. The cue logic in `src/lib/audio/toolCues.ts` gated the generic tool cue on `status === "run"`, so those calls never rang. Production symptom: agents doing quick tool work sound silent.

## Contract implemented

- Every newly appended tool call in the watched conversation produces exactly one generic tool cue, regardless of tool kind and regardless of whether call and output arrive in one update.
- Viewer MCP calls keep their distinct cue.
- Loading, remounting, or paging old settled history stays silent.
- Duplicate parses, multiple panes, and replay never double-ring.

## Approach

`createToolCueScanner` (per pane, per transcript path) replaces the pure per-snapshot read. It keeps one number — the absolute line index just past the last heard window — and rings any tool event whose `srcCall` lies at or past that floor, whatever its status:

- The first loaded parse is the baseline and absorbs the whole window silently; a call still running at baseline is happening now and still ticks (previous behavior preserved).
- Paged-in history (`show earlier`) sits below the floor and stays silent; a session reset re-parse produces the same `srcCall`s and stays silent.
- A truncation restart moves the floor back down with the window, so the pane is not deaf afterwards.
- The tab-wide cue player still owns what actually sounds by de-duplicating on `tool:<conversation>:<callId>` — remounts, second panes and replays re-request and get `deduped`.

`useToolActivityCues` gates the baseline on the tail having loaded (an unloaded feed is not an empty conversation) and skips the one mixed commit a pane switch renders, where the new conversation key is still paired with the old file's window.

## Parser coverage inspected

Codex `function_call` (shell and generic), `custom_tool_call`, and Claude `tool_use` all flow through `newToolEvent` → `srcCall = curSrc`, with outputs attached by call id (`function_call_output`, `custom_tool_call_output`, `tool_result`). The feed-level tests exercise all three shapes through `createFeedSession`.

## TDD evidence

RED (scanner stubbed to today's status-gated semantics — the exact production bug):

```
expect(scanner.scan(appended, 12)).toEqual([...])
- [ { "cue": "tool-tick", "eventId": "tool:conv-1:fast-1", "pan": 0 } ]
+ []
 8 pass / 1 fail — src/lib/audio/toolCues.test.ts
```

GREEN, then lifecycle/replay cases added one at a time (baseline silence, prepend silence, in-flight baseline, failed fast call, MCP cue, folded cmd-group, truncation restart, and four feed-level cases against the real parser):

```
bun test src/lib/audio/toolCues.test.ts src/lib/audio/toolCues.feed.test.ts \
  src/lib/audio/cuePlayer.test.ts src/lib/audio/app.test.ts \
  src/components/feed/toolLifecycle.parse.test.ts
 45 pass / 0 fail
```

## Checks

- `bunx tsc --noEmit` — clean
- `bunx eslint` on the five changed files — clean
- `bun scripts/privacy-publication-gate.ts --base c4494bbb` — PRIVACY GATE: PASS
- Only exact focused test files were run; no broad live-state suites.

Blocker note: this PR gates the next production deployment. Do not deploy without it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)