### PR TITLE
fix(mcp): reuse completed scan for board snapshot

### DIFF
--- a/src/lib/mcp/bindings.test.ts
+++ b/src/lib/mcp/bindings.test.ts
@@ -327,18 +327,34 @@ test("link_task_to_pipeline follows the cursor retry after a fail-edge loop-back
 
 test("board_snapshot returns an inert bounded board projection with durable lineage and redaction", async () => {
   let writes = 0;
+  let rawScans = 0;
   const credentialLabel = ["api", "key"].join("_");
   const titleFixture = ["super", "secret"].join("-");
   const bindings = viewerMcpBindings(undefined, undefined, {
-    listFiles: async () => [{
-      path: "/sessions/worker.jsonl",
-      project: "viewer",
-      title: `Audit ${credentialLabel}=${titleFixture}`,
-      engine: "codex",
-      activity: "live",
-      proc: "codex",
-      conversationId: "conversation_worker",
-    }],
+    listFiles: async () => {
+      rawScans += 1;
+      throw new Error("board_snapshot must not start a raw transcript scan");
+    },
+    completedFileScan: async () => ({
+      snapshot: {
+        files: [{
+          path: "/sessions/worker.jsonl",
+          project: "viewer",
+          title: `Audit ${credentialLabel}=${titleFixture}`,
+          engine: "codex",
+          activity: "live",
+          proc: "codex",
+          conversationId: "conversation_worker",
+        }],
+        projectCatalog: [],
+        complete: true,
+      },
+      generation: 7,
+      targetGeneration: 8,
+      cacheStatus: "stale",
+      requestCount: 1,
+      cloneDurationMs: 0,
+    }),
     registrySnapshot: () => ({
       conversations: {
         conversation_worker: {
@@ -387,6 +403,7 @@ test("board_snapshot returns an inert bounded board projection with durable line
   });
   expect(JSON.stringify(result)).not.toContain("super-secret");
   expect(writes).toBe(0);
+  expect(rawScans).toBe(0);
 });
 
 test("flow tools read durable flows and return a stable action receipt", async () => {

--- a/src/lib/mcp/bindings.ts
+++ b/src/lib/mcp/bindings.ts
@@ -26,6 +26,7 @@ import { requestPipelineTick } from "@/lib/pipelines/controllerSignal";
 import { projectTaskPipelineIds } from "@/lib/pipelines/taskBinding";
 import type { CreatePipelineRequest, PatchPipelineRequest, PipelineAction } from "@/lib/pipelines/types";
 import { listFiles } from "@/lib/scanner";
+import { completedFileScan } from "@/lib/scanner/scanCache";
 import { readResources } from "@/lib/resources";
 import { adoptLiveRootSession, conversationRole, liveRootSession, type RootSessionSource } from "@/lib/root/adopt";
 import { runtimeHostClient, type RuntimeHostClient } from "@/lib/runtime/client";
@@ -92,6 +93,7 @@ type RegistrySnapshot = ReturnType<ReturnType<typeof agentRegistry>["readOnlySna
 
 export interface ViewerMcpDomainDependencies {
   listFiles(options?: Parameters<typeof listFiles>[0]): Promise<FileEntry[]>;
+  completedFileScan(): ReturnType<typeof completedFileScan>;
   registrySnapshot(): RegistrySnapshot;
   boardFor(project: string): ReturnType<typeof boardFor>;
   getFlowsWithPresets(): ReturnType<typeof getFlowsWithPresets>;
@@ -177,6 +179,7 @@ function attentionCallerSources(): AttentionCallerSources {
 
 const productionDomainDependencies: ViewerMcpDomainDependencies = {
   listFiles,
+  completedFileScan,
   registrySnapshot: () => agentRegistry().readOnlySnapshot(),
   boardFor,
   getFlowsWithPresets,
@@ -450,7 +453,8 @@ async function boardSnapshot(
     for (const generation of conversation.generations) conversationsByPath.set(generation.path, conversation);
     for (const pathname of conversation.continuityPaths ?? []) conversationsByPath.set(pathname, conversation);
   }
-  const conversations = (await dependencies.listFiles({ fresh: true, persist: false }))
+  const files = (await dependencies.completedFileScan()).snapshot.files;
+  const conversations = files
     .filter((entry) => entry.engine === "claude" || entry.engine === "codex")
     .filter((entry) => !project || entry.project === project)
     .filter((entry) => !activity || entry.activity === activity)


### PR DESCRIPTION
## Summary

- route MCP `board_snapshot` through the shared completed scan generation
- serve the durable cached projection immediately while the ordinary refresh continues in the background
- prevent deployment health probes from starting a redundant full transcript inventory scan

## Root cause

The MCP binding called raw `listFiles({ fresh: true })`, bypassing the scan cache used by the Viewer files surface. On the production-shaped archive the cold call took 24.1 seconds and exceeded the 15-second MCP health budget.

## Evidence

- RED: focused binding test failed when raw scanning was forbidden
- GREEN: focused binding suite passes, 17/17
- typecheck passes
- privacy publication gate passes
- production-shaped cold-process measurement: 698 ms for `board_snapshot(limit: 1)`

Follow-up phased scheduling and archival hydration are tracked in #723.
