### PR TITLE
fix(realtime): deliver completed worker responses exactly once

### DIFF
--- a/src/app/api/runtime/realtime/route.test.ts
+++ b/src/app/api/runtime/realtime/route.test.ts
@@ -53,6 +53,37 @@ test("starts V3 WebRTC through the active hosted conversation", async () => {
   ]);
 });
 
+test("acknowledges a stable completed-response delivery through the hosted receiver", async () => {
+  const calls: unknown[] = [];
+  const delivery = {
+    deliveryId: 'voice:["turn-one",["response-one"]]',
+    turnId: "turn-one",
+    responses: [{ responseId: "response-one", text: "full response 🙂" }],
+    ready: true,
+  };
+  const result = await executeRealtimeControl({
+    action: "deliverWorkerResponse",
+    conversationId: "conversation_voice",
+    delivery,
+  }, () => ({
+    async startRealtimeWebRtc() {
+      return { sdp: "v=0\r\nanswer", realtimeSessionId: null };
+    },
+    async appendRealtimeSpeech() {},
+    async deliverRealtimeWorkerResponse(value: unknown) {
+      calls.push(value);
+      return { deliveryId: delivery.deliveryId, acknowledged: true as const };
+    },
+    async stopRealtime() {},
+  }));
+
+  expect(calls).toEqual([delivery]);
+  expect(result).toEqual({
+    status: 200,
+    body: { ok: true, deliveryId: delivery.deliveryId, acknowledged: true },
+  });
+});
+
 test("keeps validation and backend admission errors bounded", async () => {
   expect((await executeRealtimeControl({ action: "start", conversationId: "other", sdp: "v=0" })).status).toBe(400);
   expect((await executeRealtimeControl({

--- a/src/components/TmuxComposer.tsx
+++ b/src/components/TmuxComposer.tsx
@@ -969,10 +969,13 @@ export function TmuxComposer({
   const voiceEnabled = cardId.startsWith("conversation_")
     && structuredSession?.session.hostKind === "codex-app-server"
     && structuredSession.session.host === "hosted";
+  const voiceWorkerTurn = structuredSession?.session.liveTurn;
   const voice = useCodexRealtime(
     cardId,
     voiceEnabled,
-    structuredSession?.session.liveTurn?.text ?? "",
+    voiceWorkerTurn?.turnId ?? "",
+    voiceWorkerTurn?.text ?? "",
+    Boolean(voiceWorkerTurn?.turnId && structuredSession?.session.activeTurnId === voiceWorkerTurn.turnId),
   );
   const structuredImageCapability = structuredSession?.session.capabilities?.imageInput;
   const structuredImageControl = caps.controls.images;

--- a/src/components/TmuxComposer.tsx
+++ b/src/components/TmuxComposer.tsx
@@ -976,6 +976,7 @@ export function TmuxComposer({
     voiceWorkerTurn?.turnId ?? "",
     voiceWorkerTurn?.text ?? "",
     Boolean(voiceWorkerTurn?.turnId && structuredSession?.session.activeTurnId === voiceWorkerTurn.turnId),
+    structuredSession?.session.voiceDeliveries ?? [],
   );
   const structuredImageCapability = structuredSession?.session.capabilities?.imageInput;
   const structuredImageControl = caps.controls.images;

--- a/src/components/runtime/runtimeModel.test.ts
+++ b/src/components/runtime/runtimeModel.test.ts
@@ -273,6 +273,22 @@ describe("canonical voice delivery reconciliation", () => {
       deliveryId: delivery.deliveryId,
     }));
     expect(store.sessions["conv_a"]?.voiceDeliveries).toEqual([]);
+    expect(store.sessions["conv_a"]?.acknowledgedVoiceDeliveryIds).toEqual([
+      delivery.deliveryId,
+    ]);
+    store = apply(store, env("item", { type: "session", id: "conv_a" }, 6, {
+      conversationId: "conv_a",
+      turnId: "recovered",
+      phase: "completed",
+      item: { type: "agentMessage", id: "response", text: "recovered response" },
+      voiceResponse: { responseId: "response", text: "recovered response" },
+    }));
+    store = apply(store, env("turn-ended", { type: "session", id: "conv_a" }, 7, {
+      conversationId: "conv_a",
+      turnId: "recovered",
+      outcome: "completed",
+    }));
+    expect(store.sessions["conv_a"]?.voiceDeliveries).toEqual([]);
   });
 });
 

--- a/src/components/runtime/runtimeModel.test.ts
+++ b/src/components/runtime/runtimeModel.test.ts
@@ -209,6 +209,73 @@ describe("live turn delta buffering", () => {
   });
 });
 
+describe("canonical voice delivery reconciliation", () => {
+  test("hydrates an unseen completed multi-item turn and keeps rerenders idempotent", () => {
+    const unicode = `${"🙂界".repeat(8_000)}\nfinished`;
+    let store = installSnapshot(snapshot());
+    const firstItem = env("item", { type: "session", id: "conv_a" }, 4, {
+      conversationId: "conv_a",
+      turnId: "missed-turn",
+      phase: "completed",
+      item: { type: "agentMessage", id: "bounded-one", text: "bounded" },
+      voiceResponse: { responseId: "response-one", text: unicode },
+    });
+    store = apply(store, firstItem);
+    store = apply(store, env("item", { type: "session", id: "conv_a" }, 5, {
+      conversationId: "conv_a",
+      turnId: "missed-turn",
+      phase: "completed",
+      item: { type: "agentMessage", id: "bounded-two", text: "bounded" },
+      voiceResponse: { responseId: "response-two", text: "second" },
+    }));
+    store = apply(store, env("turn-ended", { type: "session", id: "conv_a" }, 6, {
+      conversationId: "conv_a",
+      turnId: "missed-turn",
+      outcome: "completed",
+    }));
+
+    expect(store.sessions["conv_a"]?.voiceDeliveries).toEqual([{
+      deliveryId: 'voice:["missed-turn",["response-one","response-two"]]',
+      turnId: "missed-turn",
+      responses: [
+        { responseId: "response-one", text: unicode },
+        { responseId: "response-two", text: "second" },
+      ],
+      ready: true,
+    }]);
+    expect(applyEvent(store, firstItem).outcome).toBe("duplicate");
+  });
+
+  test("installs pending delivery snapshots and removes only a matching acknowledgement", () => {
+    const delivery = {
+      deliveryId: 'voice:["recovered",["response"]]',
+      turnId: "recovered",
+      responses: [{ responseId: "response", text: "recovered response" }],
+      ready: true,
+    };
+    let store = installSnapshot(snapshot({
+      sessions: [session({
+        conversationId: "conv_a",
+        revision: 3,
+        voiceDeliveries: [delivery],
+      })],
+    }));
+    expect(store.sessions["conv_a"]?.voiceDeliveries).toEqual([delivery]);
+    store = apply(store, env("voice-delivery-progress", { type: "session", id: "conv_a" }, 4, {
+      conversationId: "conv_a",
+      deliveryId: delivery.deliveryId,
+      responseIndex: 0,
+      offset: 4,
+    }));
+    expect(store.sessions["conv_a"]?.revision).toBe(4);
+    store = apply(store, env("voice-delivery-acknowledged", { type: "session", id: "conv_a" }, 5, {
+      conversationId: "conv_a",
+      deliveryId: delivery.deliveryId,
+    }));
+    expect(store.sessions["conv_a"]?.voiceDeliveries).toEqual([]);
+  });
+});
+
 /* --------------------- strict revision guard --------------------- */
 
 describe("applyEvent revision guard", () => {

--- a/src/components/runtime/runtimeModel.ts
+++ b/src/components/runtime/runtimeModel.ts
@@ -29,6 +29,13 @@ import {
   completeRuntimeLiveTurnItem,
   type RuntimeLiveTurn,
 } from "@/lib/runtime/liveTurn";
+import {
+  acknowledgeVoiceDelivery,
+  appendVoiceResponse,
+  completeVoiceTurn,
+  normalizeVoiceDeliveries,
+  type RuntimeVoiceDelivery,
+} from "@/lib/runtime/voiceDelivery";
 
 /* ------------------------------------------------------------------ *
  * Vocabulary (frozen)                                                 *
@@ -254,6 +261,7 @@ export interface RuntimeSession {
   /** In-flight assistant text accumulated from live `delta` events, rendered
       as a streaming bubble until the transcript materializes the item. */
   liveTurn?: RuntimeLiveTurn | null;
+  voiceDeliveries?: RuntimeVoiceDelivery[];
 }
 
 /**
@@ -349,7 +357,14 @@ export function installSnapshot(snapshot: RuntimeSnapshot): RuntimeStore {
   const scopeHeads: Record<string, number> = {};
   const sessions: Record<string, RuntimeSession> = {};
   for (const session of snapshot.sessions) {
-    sessions[session.conversationId] = { ...session, attentionIds: [...session.attentionIds], recentReceipts: [...session.recentReceipts] };
+    sessions[session.conversationId] = {
+      ...session,
+      attentionIds: [...session.attentionIds],
+      recentReceipts: [...session.recentReceipts],
+      ...(session.voiceDeliveries
+        ? { voiceDeliveries: normalizeVoiceDeliveries(session.voiceDeliveries) }
+        : {}),
+    };
     scopeHeads[`session:${session.conversationId}`] = session.revision;
   }
   const operations: Record<string, RuntimeReceipt> = {};
@@ -510,26 +525,54 @@ function reduceKnown(store: RuntimeStore, env: RuntimeEnvelope, revision: number
         turnId?: string;
         phase?: string;
         item?: unknown;
+        voiceResponse?: { responseId?: unknown; text?: unknown };
       };
       if (p.phase !== "completed") break;
-      updateSession(store, p.conversationId ?? env.scope.id, revision, (s) => ({
-        ...s,
-        liveTurn: completeRuntimeLiveTurnItem(
-          s.liveTurn,
-          p.turnId ?? s.activeTurnId ?? "unknown",
-          p.item,
-          env.occurredAt ?? env.recordedAt ?? null,
-        ),
-      }));
+      updateSession(store, p.conversationId ?? env.scope.id, revision, (s) => {
+        const turnId = p.turnId ?? s.activeTurnId ?? "unknown";
+        const voiceResponse = p.voiceResponse;
+        return {
+          ...s,
+          liveTurn: completeRuntimeLiveTurnItem(
+            s.liveTurn,
+            turnId,
+            p.item,
+            env.occurredAt ?? env.recordedAt ?? null,
+          ),
+          voiceDeliveries: typeof voiceResponse?.responseId === "string"
+            && typeof voiceResponse.text === "string"
+            ? appendVoiceResponse(s.voiceDeliveries, turnId, {
+              responseId: voiceResponse.responseId,
+              text: voiceResponse.text,
+            })
+            : s.voiceDeliveries,
+        };
+      });
       break;
     }
     case "turn-ended": {
-      const p = env.payload as { conversationId?: string; outcome?: string };
+      const p = env.payload as { conversationId?: string; turnId?: string; outcome?: string };
       updateSession(store, p.conversationId ?? env.scope.id, revision, (s) => ({
         ...s,
         turn: "idle",
         activeTurnId: null,
+        voiceDeliveries: p.turnId
+          ? completeVoiceTurn(s.voiceDeliveries, p.turnId, p.outcome ?? "")
+          : s.voiceDeliveries,
       }));
+      break;
+    }
+    case "voice-delivery-acknowledged": {
+      const p = env.payload as { conversationId?: string; deliveryId?: string };
+      updateSession(store, p.conversationId ?? env.scope.id, revision, (s) => ({
+        ...s,
+        voiceDeliveries: acknowledgeVoiceDelivery(s.voiceDeliveries, p.deliveryId ?? ""),
+      }));
+      break;
+    }
+    case "voice-delivery-progress": {
+      const p = env.payload as { conversationId?: string };
+      updateSession(store, p.conversationId ?? env.scope.id, revision, (s) => s);
       break;
     }
     case "attention": {

--- a/src/components/runtime/runtimeModel.ts
+++ b/src/components/runtime/runtimeModel.ts
@@ -33,7 +33,9 @@ import {
   acknowledgeVoiceDelivery,
   appendVoiceResponse,
   completeVoiceTurn,
+  normalizeAcknowledgedVoiceDeliveryIds,
   normalizeVoiceDeliveries,
+  rememberAcknowledgedVoiceDelivery,
   type RuntimeVoiceDelivery,
 } from "@/lib/runtime/voiceDelivery";
 
@@ -262,6 +264,7 @@ export interface RuntimeSession {
       as a streaming bubble until the transcript materializes the item. */
   liveTurn?: RuntimeLiveTurn | null;
   voiceDeliveries?: RuntimeVoiceDelivery[];
+  acknowledgedVoiceDeliveryIds?: string[];
 }
 
 /**
@@ -363,6 +366,13 @@ export function installSnapshot(snapshot: RuntimeSnapshot): RuntimeStore {
       recentReceipts: [...session.recentReceipts],
       ...(session.voiceDeliveries
         ? { voiceDeliveries: normalizeVoiceDeliveries(session.voiceDeliveries) }
+        : {}),
+      ...(session.acknowledgedVoiceDeliveryIds
+        ? {
+          acknowledgedVoiceDeliveryIds: normalizeAcknowledgedVoiceDeliveryIds(
+            session.acknowledgedVoiceDeliveryIds,
+          ),
+        }
         : {}),
     };
     scopeHeads[`session:${session.conversationId}`] = session.revision;
@@ -484,6 +494,9 @@ function reduceKnown(store: RuntimeStore, env: RuntimeEnvelope, revision: number
         // never let a status payload silently drop live sub-projections
         attentionIds: p.attentionIds ?? prev?.attentionIds ?? [],
         recentReceipts: prev?.recentReceipts ?? [],
+        acknowledgedVoiceDeliveryIds: normalizeAcknowledgedVoiceDeliveryIds(
+          p.acknowledgedVoiceDeliveryIds ?? prev?.acknowledgedVoiceDeliveryIds,
+        ),
       };
       store.sessions = { ...store.sessions, [id]: merged };
       break;
@@ -557,17 +570,29 @@ function reduceKnown(store: RuntimeStore, env: RuntimeEnvelope, revision: number
         turn: "idle",
         activeTurnId: null,
         voiceDeliveries: p.turnId
-          ? completeVoiceTurn(s.voiceDeliveries, p.turnId, p.outcome ?? "")
+          ? completeVoiceTurn(
+            s.voiceDeliveries,
+            p.turnId,
+            p.outcome ?? "",
+            s.acknowledgedVoiceDeliveryIds,
+          )
           : s.voiceDeliveries,
       }));
       break;
     }
     case "voice-delivery-acknowledged": {
       const p = env.payload as { conversationId?: string; deliveryId?: string };
-      updateSession(store, p.conversationId ?? env.scope.id, revision, (s) => ({
-        ...s,
-        voiceDeliveries: acknowledgeVoiceDelivery(s.voiceDeliveries, p.deliveryId ?? ""),
-      }));
+      updateSession(store, p.conversationId ?? env.scope.id, revision, (s) => {
+        const deliveryId = p.deliveryId ?? "";
+        return {
+          ...s,
+          voiceDeliveries: acknowledgeVoiceDelivery(s.voiceDeliveries, deliveryId),
+          acknowledgedVoiceDeliveryIds: rememberAcknowledgedVoiceDelivery(
+            s.acknowledgedVoiceDeliveryIds,
+            deliveryId,
+          ),
+        };
+      });
       break;
     }
     case "voice-delivery-progress": {

--- a/src/hooks/useCodexRealtime.ts
+++ b/src/hooks/useCodexRealtime.ts
@@ -10,7 +10,9 @@ const IDLE = { phase: "idle" as const, lines: [], error: null, startedAt: null, 
 export function useCodexRealtime(
   conversationId: string,
   enabled: boolean,
+  workerTurnId: string,
   workerProgress: string,
+  workerRunning: boolean,
 ) {
   const ambientOwner = useRef(Symbol("realtime-ambient-owner"));
   const client = useMemo(
@@ -22,23 +24,11 @@ export function useCodexRealtime(
     client?.getSnapshot ?? (() => IDLE),
     () => IDLE,
   );
-  const previousProgress = useRef("");
-
   useEffect(() => {
-    if (!client) {
-      previousProgress.current = "";
-      return;
-    }
-    if (workerProgress) {
-      previousProgress.current = workerProgress;
-      client.queueWorkerProgress(workerProgress);
-      return;
-    }
-    if (previousProgress.current) {
-      client.finishWorkerProgress(previousProgress.current);
-      previousProgress.current = "";
-    }
-  }, [client, snapshot.phase, workerProgress]);
+    if (!client || !workerTurnId || !workerProgress) return;
+    if (workerRunning) client.queueWorkerProgress(workerTurnId, workerProgress);
+    else client.finishWorkerProgress(workerTurnId, workerProgress);
+  }, [client, snapshot.phase, workerProgress, workerRunning, workerTurnId]);
 
   /* The ambient bed is eligible only while a call is up, and it fades on both
      edges. `live` is the only phase with two participants who can talk;

--- a/src/hooks/useCodexRealtime.ts
+++ b/src/hooks/useCodexRealtime.ts
@@ -4,6 +4,7 @@ import { useEffect, useMemo, useRef, useSyncExternalStore } from "react";
 
 import { setVoiceConnected } from "@/lib/audio/app";
 import { codexRealtimeClient } from "@/lib/realtime/codexRealtimeClient";
+import type { RuntimeVoiceDelivery } from "@/lib/runtime/voiceDelivery";
 
 const IDLE = { phase: "idle" as const, lines: [], error: null, startedAt: null, micMuted: false, outputMuted: false };
 
@@ -13,6 +14,7 @@ export function useCodexRealtime(
   workerTurnId: string,
   workerProgress: string,
   workerRunning: boolean,
+  workerDeliveries: readonly RuntimeVoiceDelivery[],
 ) {
   const ambientOwner = useRef(Symbol("realtime-ambient-owner"));
   const client = useMemo(
@@ -26,9 +28,11 @@ export function useCodexRealtime(
   );
   useEffect(() => {
     if (!client || !workerTurnId || !workerProgress) return;
-    if (workerRunning) client.queueWorkerProgress(workerTurnId, workerProgress);
-    else client.finishWorkerProgress(workerTurnId, workerProgress);
+    client.updateWorkerProgress(workerTurnId, workerProgress, workerRunning);
   }, [client, snapshot.phase, workerProgress, workerRunning, workerTurnId]);
+  useEffect(() => {
+    client?.reconcileWorkerDeliveries(workerDeliveries);
+  }, [client, snapshot.phase, workerDeliveries]);
 
   /* The ambient bed is eligible only while a call is up, and it fades on both
      edges. `live` is the only phase with two participants who can talk;

--- a/src/hooks/useCodexRealtime.ts
+++ b/src/hooks/useCodexRealtime.ts
@@ -2,8 +2,7 @@
 
 import { useEffect, useMemo, useRef, useSyncExternalStore } from "react";
 
-import { ambientLoop, setVoiceConnected } from "@/lib/audio/app";
-import { speakingFromLines } from "@/lib/audio/speech";
+import { setVoiceConnected } from "@/lib/audio/app";
 import { codexRealtimeClient } from "@/lib/realtime/codexRealtimeClient";
 
 const IDLE = { phase: "idle" as const, lines: [], error: null, startedAt: null, micMuted: false, outputMuted: false };
@@ -13,6 +12,7 @@ export function useCodexRealtime(
   enabled: boolean,
   workerProgress: string,
 ) {
+  const ambientOwner = useRef(Symbol("realtime-ambient-owner"));
   const client = useMemo(
     () => enabled && conversationId.startsWith("conversation_") ? codexRealtimeClient(conversationId) : null,
     [conversationId, enabled],
@@ -45,16 +45,10 @@ export function useCodexRealtime(
      connecting, stopping and error are not a call. */
   const live = snapshot.phase === "live";
   useEffect(() => {
-    setVoiceConnected(live);
-    return () => setVoiceConnected(false);
+    const owner = ambientOwner.current;
+    setVoiceConnected(owner, live);
+    return () => setVoiceConnected(owner, false);
   }, [live]);
-
-  /* Ducking reads the transcript the call already produces — no analyser on
-     either stream, no second signal path to keep in step with this one. */
-  const speaking = live ? speakingFromLines(snapshot.lines) : null;
-  useEffect(() => {
-    ambientLoop().setSpeaking(speaking);
-  }, [speaking]);
 
   return {
     ...snapshot,

--- a/src/lib/audio/app.test.ts
+++ b/src/lib/audio/app.test.ts
@@ -32,16 +32,16 @@ describe("no audio graph", () => {
   });
 
   test("connecting and disconnecting a call is safe and leaves nothing playing", () => {
-    expect(() => setVoiceConnected(true)).not.toThrow();
+    expect(() => setVoiceConnected("call", true)).not.toThrow();
     expect(ambientLoop().state().playing).toBe(false);
-    expect(() => setVoiceConnected(false)).not.toThrow();
+    expect(() => setVoiceConnected("call", false)).not.toThrow();
     expect(ambientLoop().state().playing).toBe(false);
   });
 
   test("the bed is not even wanted while this device has not opted in", () => {
     configureAudioPrefsStorage({ getItem: () => null, setItem: () => undefined });
     resetAppAudioForTests();
-    setVoiceConnected(true);
+    setVoiceConnected("call", true);
     /* Conservative first run: a connected call alone is not consent. */
     expect(ambientLoop().wanted()).toBe(false);
   });
@@ -54,13 +54,31 @@ describe("no audio graph", () => {
     });
     resetAppAudioForTests();
     setAudioPrefs({ loopEnabled: true });
-    setVoiceConnected(true);
+    setVoiceConnected("call", true);
 
     expect(ambientLoop().wanted()).toBe(true);
     /* Wanted, unplayable, and still not throwing or looping forever — the retry
        is what resumes it the moment the autoplay policy lifts. */
     expect(ambientLoop().state().playing).toBe(false);
     expect(() => ensureAmbientLoop()).not.toThrow();
+  });
+
+  test("one card cannot disconnect the ambient bed owned by another live call", () => {
+    const store = new Map<string, string>();
+    configureAudioPrefsStorage({
+      getItem: (key) => store.get(key) ?? null,
+      setItem: (key, value) => void store.set(key, value),
+    });
+    resetAppAudioForTests();
+    setAudioPrefs({ loopEnabled: true });
+
+    setVoiceConnected("live-call", true);
+    setVoiceConnected("unrelated-card", false);
+
+    expect(ambientLoop().wanted()).toBe(true);
+
+    setVoiceConnected("live-call", false);
+    expect(ambientLoop().wanted()).toBe(false);
   });
 });
 

--- a/src/lib/audio/app.ts
+++ b/src/lib/audio/app.ts
@@ -37,6 +37,7 @@ let loop: AmbientLoop | null = null;
 let retryTimer: ReturnType<typeof setTimeout> | null = null;
 let retries = 0;
 let prefsWatched = false;
+const voiceOwners = new Set<unknown>();
 
 function watchPrefs(): void {
   if (prefsWatched) return;
@@ -60,8 +61,6 @@ export function cuePlayer(): CuePlayer {
   player ??= createCuePlayer({
     transport: transports.cues,
     prefs: audioPrefs,
-    /* Priority cues duck the bed rather than fighting it. */
-    onPriorityCue: (cue) => ambientLoop().duckForCue(cue),
   });
   watchPrefs();
   return player;
@@ -98,10 +97,18 @@ export function ensureAmbientLoop(): void {
   }, AMBIENT_RETRY_MS);
 }
 
-/** Realtime voice went live or ended. */
-export function setVoiceConnected(connected: boolean): void {
+/**
+ * One mounted realtime surface went live or ended.
+ *
+ * Ownership matters because several conversation cards can mount composers in
+ * the same tab. A card may release only its own lease; the ambient bed remains
+ * connected while any other live call still owns one.
+ */
+export function setVoiceConnected(owner: unknown, connected: boolean): void {
+  if (connected) voiceOwners.add(owner);
+  else voiceOwners.delete(owner);
   retries = 0;
-  ambientLoop().setVoiceConnected(connected);
+  ambientLoop().setVoiceConnected(voiceOwners.size > 0);
   ensureAmbientLoop();
 }
 
@@ -142,6 +149,7 @@ export function resetAppAudioForTests(): void {
   player = null;
   loop = null;
   prefsWatched = false;
+  voiceOwners.clear();
   retries = 0;
   if (retryTimer !== null) clearTimeout(retryTimer);
   retryTimer = null;

--- a/src/lib/audio/webAudioTransport.test.ts
+++ b/src/lib/audio/webAudioTransport.test.ts
@@ -9,7 +9,7 @@ import { createWebAudioTransports, type AudioContextLike } from "./webAudioTrans
  * the audio thread has no seam, and one that is re-triggered from JavaScript
  * always does. That is observable here and nowhere else.
  */
-function fakeContext(state = "running") {
+function fakeContext(state = "running", scheduledSetterUpdatesValue = true) {
   const sources: FakeSource[] = [];
   const gains: FakeGain[] = [];
   let resumed = 0;
@@ -59,15 +59,17 @@ function fakeContext(state = "running") {
       return source;
     },
     createGain() {
+      let currentValue = 1;
       const gain: FakeGain = {
         gain: {
-          value: 0,
+          get value() { return currentValue; },
+          set value(value) { currentValue = value; },
           calls: [],
           ramps: [],
           cancelScheduledValues(when) { gain.gain.calls.push(`cancel@${when}`); },
           setValueAtTime(value, when) {
             gain.gain.calls.push(`set:${value}@${when}`);
-            gain.gain.value = value;
+            if (scheduledSetterUpdatesValue) currentValue = value;
           },
           linearRampToValueAtTime(value, when) {
             gain.gain.calls.push(`ramp:${value}@${when}`);
@@ -157,6 +159,17 @@ describe("the ambient bed loops without a seam", () => {
 });
 
 describe("levels move as ramps on the audio clock", () => {
+  test("a fade-in anchors at the requested initial gain in a spec-accurate AudioParam", async () => {
+    const context = fakeContext("running", false);
+    const transports = await warmed(context, LOOP);
+    const voice = transports.loop.start({ src: LOOP, gain: 0 })!;
+
+    voice.rampTo(0.12, 2.5);
+
+    expect(context.gains[0].gain.calls).toContain("set:0@10");
+    expect(context.gains[0].gain.ramps).toEqual([{ value: 0.12, when: 12.5 }]);
+  });
+
   test("a fade anchors at the current value and ramps to the target", async () => {
     const context = fakeContext();
     const transports = await warmed(context, LOOP);

--- a/src/lib/audio/webAudioTransport.ts
+++ b/src/lib/audio/webAudioTransport.ts
@@ -189,7 +189,7 @@ export function createWebAudioTransports(
           source.loopStart = 0;
           source.loopEnd = buffer.duration;
           const gain = context.createGain();
-          gain.gain.setValueAtTime(request.gain, context.currentTime);
+          gain.gain.value = request.gain;
           source.connect(gain as never);
           gain.connect(context.destination as never);
           source.start();

--- a/src/lib/realtime/codexRealtimeClient.test.ts
+++ b/src/lib/realtime/codexRealtimeClient.test.ts
@@ -1,8 +1,6 @@
 import { expect, test } from "bun:test";
 
 import {
-  chunkUtf8,
-  delegationContextEvents,
   parseCodexRealtimeEvent,
 } from "./codexRealtimeClient";
 
@@ -23,20 +21,4 @@ test("parses Frameless Bidi transcript, delegation, and error events", () => {
     type: "error",
     error: { message: "backend closed" },
   })).toEqual({ kind: "error", message: "backend closed" });
-});
-
-test("chunks handoff context on UTF-8 boundaries", () => {
-  const chunks = chunkUtf8("голос ".repeat(180), 500);
-  expect(chunks.length).toBeGreaterThan(1);
-  expect(chunks.join("")).toBe("голос ".repeat(180));
-  expect(chunks.every((chunk) => new TextEncoder().encode(chunk).byteLength <= 500)).toBe(true);
-});
-
-test("builds targeted delegation.context.append events", () => {
-  expect(delegationContextEvents("delegation-1", "completed worker response", "speakable")).toEqual([{
-    type: "delegation.context.append",
-    delegation_item_id: "delegation-1",
-    channel: "speakable",
-    content: [{ type: "input_text", text: "completed worker response" }],
-  }]);
 });

--- a/src/lib/realtime/codexRealtimeClient.test.ts
+++ b/src/lib/realtime/codexRealtimeClient.test.ts
@@ -33,10 +33,10 @@ test("chunks handoff context on UTF-8 boundaries", () => {
 });
 
 test("builds targeted delegation.context.append events", () => {
-  expect(delegationContextEvents("delegation-1", "worker progress", "commentary")).toEqual([{
+  expect(delegationContextEvents("delegation-1", "completed worker response", "speakable")).toEqual([{
     type: "delegation.context.append",
     delegation_item_id: "delegation-1",
-    channel: "commentary",
-    content: [{ type: "input_text", text: "worker progress" }],
+    channel: "speakable",
+    content: [{ type: "input_text", text: "completed worker response" }],
   }]);
 });

--- a/src/lib/realtime/codexRealtimeClient.transport.dom.test.ts
+++ b/src/lib/realtime/codexRealtimeClient.transport.dom.test.ts
@@ -172,7 +172,20 @@ test("a data channel lost before opening surfaces the error state instead of con
 });
 
 test("a live call keeps worker progress local and sends one completed response to voice", async () => {
-  globalThis.fetch = (async () => jsonResponse(200, { ok: true, sdp: "v=0\r\nanswer" })) as unknown as typeof fetch;
+  const requests: Array<Record<string, unknown>> = [];
+  globalThis.fetch = (async (_url: unknown, init?: RequestInit) => {
+    const body = JSON.parse(String(init?.body ?? "{}")) as Record<string, unknown>;
+    requests.push(body);
+    if (body.action === "deliverWorkerResponse") {
+      const delivery = body.delivery as { deliveryId: string };
+      return jsonResponse(200, {
+        ok: true,
+        deliveryId: delivery.deliveryId,
+        acknowledged: true,
+      });
+    }
+    return jsonResponse(200, { ok: true, sdp: "v=0\r\nanswer" });
+  }) as unknown as typeof fetch;
 
   const client = codexRealtimeClient("conversation_live_call");
   await client.start();
@@ -195,9 +208,9 @@ test("a live call keeps worker progress local and sends one completed response t
   // Delegation: accumulated progress remains local while the worker runs.
   peer.channel.onmessage?.({ data: JSON.stringify({ type: "delegation.created", item: { id: "delegation-9" } }) });
   let produced = "";
-  for (let step = 0; step < 40; step += 1) {
+  for (let step = 0; step < 50; step += 1) {
     produced += segment(step, 300);
-    client.queueWorkerProgress("turn-live-call", produced);
+    client.updateWorkerProgress("turn-live-call", produced, true);
   }
   expect(client.getSnapshot().lines.at(-1)).toMatchObject({
     role: "progress",
@@ -205,22 +218,23 @@ test("a live call keeps worker progress local and sends one completed response t
     final: false,
   });
 
-  client.finishWorkerProgress("turn-live-call", produced);
-  // A repeated completion render describes the same worker response.
-  client.finishWorkerProgress("turn-live-call", produced);
-  // A replay can surface the completed turn's progress before completion again.
-  client.queueWorkerProgress("turn-live-call", produced);
-  client.finishWorkerProgress("turn-live-call", produced);
+  client.updateWorkerProgress("turn-live-call", produced, false);
+  const delivery = voiceDelivery("turn-live-call", [
+    { responseId: "response-one", text: produced },
+    { responseId: "response-two", text: "second item 🫶🏽" },
+  ]);
+  client.reconcileWorkerDeliveries([delivery]);
+  client.reconcileWorkerDeliveries([delivery]);
+  await flushAsync();
 
-  const events = peer.channel.sent.map((payload) => JSON.parse(payload) as {
-    type: string;
-    delegation_item_id: string;
-    channel: string;
-    content: { text: string }[];
-  });
-  expect(events.every((event) => event.type === "delegation.context.append" && event.delegation_item_id === "delegation-9")).toBe(true);
-  expect(events.filter((event) => event.channel === "commentary")).toEqual([]);
-  expect(sentOn(peer.channel, "speakable")).toBe(`Agent Final Message:\n\n${produced.slice(-12_000)}`);
+  const delivered = requests.filter((request) =>
+    request.action === "deliverWorkerResponse");
+  expect(delivered).toEqual([{
+    action: "deliverWorkerResponse",
+    conversationId: "conversation_live_call",
+    delivery,
+  }]);
+  expect(peer.channel.sent).toEqual([]);
 
   const progress = client.getSnapshot().lines.filter((line) => line.role === "progress");
   expect(progress).toHaveLength(1);
@@ -279,97 +293,151 @@ test("issue 664: the transport reason stands when the host has no failure to rep
   expect(client.getSnapshot().error).toBe("Realtime connection was interrupted");
 });
 
-/** Every character the client actually put on one channel, in wire order. */
-function sentOn(channel: StubDataChannel, name: "commentary" | "speakable", from = 0): string {
-  return channel.sent
-    .slice(from)
-    .map((payload) => JSON.parse(payload) as { channel: string; content: { text: string }[] })
-    .filter((event) => event.channel === name)
-    .map((event) => event.content.map((part) => part.text).join(""))
-    .join("");
-}
-
 /** Varied filler of an exact length, so no accidental prefix coincidences make
     a duplicate look like new content. */
 function segment(step: number, size: number): string {
   return `«${step}» ${"worker progress — reading agents ".repeat(size)}`.slice(0, size);
 }
 
-async function liveCall(conversationId: string, delegationId: string) {
-  globalThis.fetch = (async () => jsonResponse(200, { ok: true, sdp: "v=0\r\nanswer" })) as unknown as typeof fetch;
-  const client = codexRealtimeClient(conversationId);
-  await client.start();
-  const peer = StubPeerConnection.latest!;
-  peer.channel.onopen?.();
-  peer.channel.onmessage?.({ data: JSON.stringify({ type: "delegation.created", item: { id: delegationId } }) });
-  return { client, channel: peer.channel };
+function voiceDelivery(
+  turnId: string,
+  responses: Array<{ responseId: string; text: string }>,
+) {
+  return {
+    deliveryId: `voice:${JSON.stringify([turnId, responses.map((response) => response.responseId)])}`,
+    turnId,
+    responses,
+    ready: true,
+  };
 }
 
-test("a rejected completed response waits for the data channel and is delivered exactly once", async () => {
-  const { client, channel } = await liveCall("conversation_progress_retry", "delegation-retry");
-  const completed = segment(1, 1_200);
-  client.queueWorkerProgress("turn-retry", completed);
+async function flushAsync(): Promise<void> {
+  await Promise.resolve();
+  await new Promise((resolve) => setTimeout(resolve, 0));
+}
 
-  channel.failOnAttempt = 2;
-  client.finishWorkerProgress("turn-retry", completed);
-  client.finishWorkerProgress("turn-retry", completed);
-  const expected = `Agent Final Message:\n\n${completed}`;
-  const acceptedPrefix = sentOn(channel, "speakable");
-  expect(acceptedPrefix.length).toBeGreaterThan(0);
-  expect(expected.startsWith(acceptedPrefix)).toBe(true);
+test("explicit stop retains an unacknowledged response and retries the same delivery id", async () => {
+  const delivered: unknown[] = [];
+  let attempts = 0;
+  globalThis.fetch = (async (_url: unknown, init?: RequestInit) => {
+    const body = JSON.parse(String(init?.body ?? "{}")) as Record<string, unknown>;
+    if (body.action === "deliverWorkerResponse") {
+      delivered.push(body.delivery);
+      attempts += 1;
+      if (attempts === 1) return jsonResponse(409, { error: "realtime channel replaced" });
+      return jsonResponse(200, {
+        ok: true,
+        deliveryId: (body.delivery as { deliveryId: string }).deliveryId,
+        acknowledged: true,
+      });
+    }
+    if (body.action === "stop") return jsonResponse(200, { ok: true });
+    return jsonResponse(200, { ok: true, sdp: "v=0\r\nanswer" });
+  }) as unknown as typeof fetch;
+  const client = codexRealtimeClient("conversation_progress_retry");
+  await client.start();
+  StubPeerConnection.latest?.channel.onopen?.();
+  const delivery = voiceDelivery("turn-retry", [{
+    responseId: "response-retry",
+    text: "retained response",
+  }]);
+  client.reconcileWorkerDeliveries([delivery]);
+  await flushAsync();
 
-  channel.onopen?.();
-  channel.onopen?.();
-  expect(sentOn(channel, "speakable")).toBe(expected);
+  await client.stop();
+  await client.start();
+  StubPeerConnection.latest?.channel.onopen?.();
+  await flushAsync();
 
+  expect(delivered).toEqual([delivery, delivery]);
   await client.stop();
 });
 
-test("a completed response survives replacement of a failed realtime transport", async () => {
-  const { client, channel } = await liveCall("conversation_progress_reconnect", "delegation-old");
-  const completed = "Response retained across transport replacement";
-
-  channel.readyState = "closed";
-  client.queueWorkerProgress("turn-reconnect", completed);
-  client.finishWorkerProgress("turn-reconnect", completed);
+test("channel replacement retries before acknowledgement and never repeats after acknowledgement", async () => {
+  const delivered: unknown[] = [];
+  let rejectFirstDelivery!: () => void;
+  const firstDelivery = new Promise<Response>((resolve) => {
+    rejectFirstDelivery = () => resolve(jsonResponse(409, { error: "channel unavailable" }));
+  });
+  globalThis.fetch = (async (_url: unknown, init?: RequestInit) => {
+    const body = JSON.parse(String(init?.body ?? "{}")) as Record<string, unknown>;
+    if (body.action === "deliverWorkerResponse") {
+      delivered.push(body.delivery);
+      if (delivered.length === 1) return firstDelivery;
+      return jsonResponse(200, {
+        ok: true,
+        deliveryId: (body.delivery as { deliveryId: string }).deliveryId,
+        acknowledged: true,
+      });
+    }
+    if (body.action === "status") return jsonResponse(200, { ok: true, failure: null });
+    return jsonResponse(200, { ok: true, sdp: "v=0\r\nanswer" });
+  }) as unknown as typeof fetch;
+  const client = codexRealtimeClient("conversation_progress_reconnect");
+  const delivery = voiceDelivery("turn-reconnect", [{
+    responseId: "response-reconnect",
+    text: "Response retained across transport replacement",
+  }]);
+  await client.start();
+  StubPeerConnection.latest?.channel.onopen?.();
+  client.reconcileWorkerDeliveries([delivery]);
+  await flushAsync();
 
   const failedPeer = StubPeerConnection.latest!;
   failedPeer.connectionState = "failed";
   failedPeer.onconnectionstatechange?.();
-  expect(client.getSnapshot().phase).toBe("error");
-
+  await flushAsync();
   await client.start();
-  const replacement = StubPeerConnection.latest!;
-  replacement.channel.onopen?.();
-  replacement.channel.onmessage?.({
-    data: JSON.stringify({ type: "delegation.created", item: { id: "delegation-new" } }),
-  });
-  replacement.channel.onmessage?.({
-    data: JSON.stringify({ type: "delegation.created", item: { id: "delegation-new" } }),
-  });
+  StubPeerConnection.latest?.channel.onopen?.();
+  rejectFirstDelivery();
+  await flushAsync();
+  client.reconcileWorkerDeliveries([delivery]);
+  await flushAsync();
 
-  expect(sentOn(replacement.channel, "speakable")).toBe(`Agent Final Message:\n\n${completed}`);
+  const acknowledgedPeer = StubPeerConnection.latest!;
+  acknowledgedPeer.connectionState = "failed";
+  acknowledgedPeer.onconnectionstatechange?.();
+  await flushAsync();
+  await client.start();
+  StubPeerConnection.latest?.channel.onopen?.();
+  client.reconcileWorkerDeliveries([delivery]);
+  await flushAsync();
+
+  expect(delivered).toEqual([delivery, delivery]);
   await client.stop();
 });
 
-test("completed responses queue in order while the data channel is unavailable", async () => {
-  const { client, channel } = await liveCall("conversation_progress_queue", "delegation-queue");
-  const first = "First completed worker response";
-  const second = "Second completed worker response";
+test("hydrated completed responses queue in order before Live Mode opens", async () => {
+  const delivered: unknown[] = [];
+  globalThis.fetch = (async (_url: unknown, init?: RequestInit) => {
+    const body = JSON.parse(String(init?.body ?? "{}")) as Record<string, unknown>;
+    if (body.action === "deliverWorkerResponse") {
+      const delivery = body.delivery as { deliveryId: string };
+      delivered.push(delivery);
+      return jsonResponse(200, {
+        ok: true,
+        deliveryId: delivery.deliveryId,
+        acknowledged: true,
+      });
+    }
+    return jsonResponse(200, { ok: true, sdp: "v=0\r\nanswer" });
+  }) as unknown as typeof fetch;
+  const client = codexRealtimeClient("conversation_progress_queue");
+  const first = voiceDelivery("turn-first", [{
+    responseId: "response-first",
+    text: "First completed worker response",
+  }]);
+  const second = voiceDelivery("turn-second", [{
+    responseId: "response-second",
+    text: "Second completed worker response",
+  }]);
+  client.reconcileWorkerDeliveries([first, second]);
+  expect(delivered).toEqual([]);
 
-  channel.readyState = "closed";
-  client.queueWorkerProgress("turn-first", first);
-  client.finishWorkerProgress("turn-first", first);
-  client.queueWorkerProgress("turn-second", second);
-  client.finishWorkerProgress("turn-second", second);
-  expect(channel.sent).toEqual([]);
-
-  channel.readyState = "open";
-  channel.onopen?.();
-  expect(sentOn(channel, "speakable")).toBe(
-    `Agent Final Message:\n\n${first}Agent Final Message:\n\n${second}`,
-  );
-
+  await client.start();
+  StubPeerConnection.latest?.channel.onopen?.();
+  await flushAsync();
+  expect(delivered).toEqual([first, second]);
   await client.stop();
 });
 

--- a/src/lib/realtime/codexRealtimeClient.transport.dom.test.ts
+++ b/src/lib/realtime/codexRealtimeClient.transport.dom.test.ts
@@ -14,10 +14,17 @@ Object.assign(globalThis, {
 class StubDataChannel {
   readyState = "open";
   sent: string[] = [];
+  /** Sends to reject before accepting again, standing in for a transport that
+      drops mid-flush; a rejected send is never recorded as delivered. */
+  failuresRemaining = 0;
   onopen: (() => void) | null = null;
   onmessage: ((message: { data: unknown }) => void) | null = null;
   onclose: (() => void) | null = null;
   send(payload: string): void {
+    if (this.failuresRemaining > 0) {
+      this.failuresRemaining -= 1;
+      throw new Error("data channel send failed");
+    }
     this.sent.push(payload);
   }
   close(): void {
@@ -257,6 +264,214 @@ test("issue 664: the transport reason stands when the host has no failure to rep
   peer.onconnectionstatechange?.();
   await new Promise((resolve) => setTimeout(resolve, 0));
   expect(client.getSnapshot().error).toBe("Realtime connection was interrupted");
+});
+
+/* The handoff flush is a 200ms `window.setTimeout`. Driving it by hand keeps a
+   60,000-character stream a millisecond of test time instead of 40 seconds, and
+   makes "one flush per producer tick" observable rather than timing-dependent. */
+function manualTimers() {
+  const host = window as unknown as {
+    setTimeout: unknown;
+    clearTimeout: unknown;
+  };
+  const originalSet = host.setTimeout;
+  const originalClear = host.clearTimeout;
+  const pending = new Map<number, () => void>();
+  let handle = 0;
+  host.setTimeout = (callback: () => void) => {
+    pending.set(++handle, callback);
+    return handle;
+  };
+  host.clearTimeout = (id: number) => {
+    pending.delete(id);
+  };
+  function run(): number {
+    const due = [...pending.entries()];
+    pending.clear();
+    for (const [, callback] of due) callback();
+    return due.length;
+  }
+  return {
+    run,
+    /** Runs armed callbacks until the client stops re-arming (bounded). */
+    drain(): void {
+      for (let pass = 0; pass < 10_000 && run() > 0; pass += 1);
+    },
+    restore(): void {
+      host.setTimeout = originalSet;
+      host.clearTimeout = originalClear;
+    },
+  };
+}
+
+/** Every character the client actually put on one channel, in wire order. */
+function sentOn(channel: StubDataChannel, name: "commentary" | "speakable", from = 0): string {
+  return channel.sent
+    .slice(from)
+    .map((payload) => JSON.parse(payload) as { channel: string; content: { text: string }[] })
+    .filter((event) => event.channel === name)
+    .map((event) => event.content.map((part) => part.text).join(""))
+    .join("");
+}
+
+/** Varied filler of an exact length, so no accidental prefix coincidences make
+    a duplicate look like new content. */
+function segment(step: number, size: number): string {
+  return `«${step}» ${"worker progress — reading agents ".repeat(size)}`.slice(0, size);
+}
+
+async function liveCall(conversationId: string, delegationId: string) {
+  globalThis.fetch = (async () => jsonResponse(200, { ok: true, sdp: "v=0\r\nanswer" })) as unknown as typeof fetch;
+  const client = codexRealtimeClient(conversationId);
+  await client.start();
+  const peer = StubPeerConnection.latest!;
+  peer.channel.onopen?.();
+  peer.channel.onmessage?.({ data: JSON.stringify({ type: "delegation.created", item: { id: delegationId } }) });
+  return { client, channel: peer.channel };
+}
+
+test("worker progress past the 12,000-character window ships each character exactly once", async () => {
+  /* The producer is one monotonically growing turn. Handoff traffic must stay
+     proportional to new content across the retained-window boundary — the tail
+     window sliding used to make every flush resend the whole window, 32x and
+     climbing over a 60,000-character turn. */
+  const { client, channel } = await liveCall("conversation_progress_window", "delegation-window");
+  const timers = manualTimers();
+  let produced = "";
+  try {
+    for (let step = 0; step < 200; step += 1) {
+      produced += segment(step, 300);
+      client.queueWorkerProgress(produced);
+      timers.run();
+    }
+    timers.drain();
+  } finally {
+    timers.restore();
+  }
+
+  expect(produced.length).toBe(60_000);
+  const commentary = sentOn(channel, "commentary");
+  // Ordering and exact-once: the wire is the produced turn, byte for byte.
+  expect(commentary).toBe(produced);
+  expect(commentary.length / produced.length).toBeLessThanOrEqual(1.05);
+  await client.stop();
+});
+
+test("a stream that never reaches the window boundary behaves the same", async () => {
+  const { client, channel } = await liveCall("conversation_progress_short", "delegation-short");
+  const timers = manualTimers();
+  let produced = "";
+  try {
+    for (let step = 0; step < 20; step += 1) {
+      produced += segment(step, 250);
+      client.queueWorkerProgress(produced);
+      timers.run();
+    }
+    timers.drain();
+  } finally {
+    timers.restore();
+  }
+
+  expect(produced.length).toBe(5_000);
+  expect(sentOn(channel, "commentary")).toBe(produced);
+  await client.stop();
+});
+
+test("a rewritten turn resets the cursor and ships the replacement once", async () => {
+  const { client, channel } = await liveCall("conversation_progress_rewrite", "delegation-rewrite");
+  const timers = manualTimers();
+  try {
+    let produced = "";
+    for (let step = 0; step < 50; step += 1) {
+      produced += segment(step, 300);
+      client.queueWorkerProgress(produced);
+      timers.run();
+    }
+    timers.drain();
+    expect(produced.length).toBe(15_000);
+    expect(sentOn(channel, "commentary")).toBe(produced);
+
+    // The producer replaces the turn rather than extending it (compaction, a
+    // restarted turn). The replacement is not a suffix of anything sent, so it
+    // ships whole — once — and nothing already sent repeats.
+    const before = channel.sent.length;
+    const rewritten = segment(999, 800);
+    client.queueWorkerProgress(rewritten);
+    timers.drain();
+    expect(sentOn(channel, "commentary", before)).toBe(rewritten);
+  } finally {
+    timers.restore();
+  }
+  await client.stop();
+});
+
+test("a backlog larger than one window drains in order without splitting a character", async () => {
+  /* One producer tick can owe more than a single flush may carry (a cursor
+     reset, or a channel that was shut for a while). The rest follows on the
+     next flush, and the cap never lands inside a surrogate pair. */
+  const { client, channel } = await liveCall("conversation_progress_burst", "delegation-burst");
+  const timers = manualTimers();
+  const produced = `${"a".repeat(11_999)}😀${"b".repeat(20_000)}`;
+  try {
+    client.queueWorkerProgress(produced);
+    timers.drain();
+  } finally {
+    timers.restore();
+  }
+
+  expect(sentOn(channel, "commentary")).toBe(produced);
+  const chunks = channel.sent.map((payload) => (JSON.parse(payload) as { content: { text: string }[] })
+    .content.map((part) => part.text).join(""));
+  expect(chunks.length).toBeGreaterThan(1);
+  expect(chunks.every((chunk) => chunk.isWellFormed())).toBe(true);
+  await client.stop();
+});
+
+test("a failed send is retried from the exact character it stopped at", async () => {
+  const { client, channel } = await liveCall("conversation_progress_retry", "delegation-retry");
+  const timers = manualTimers();
+  let produced = "";
+  try {
+    // Phase 1: the channel is not open, so nothing may go out and nothing may
+    // be dropped — the backlog waits.
+    channel.readyState = "closed";
+    for (let step = 0; step < 20; step += 1) {
+      produced += segment(step, 300);
+      client.queueWorkerProgress(produced);
+      timers.run();
+    }
+    expect(channel.sent).toEqual([]);
+
+    // Phase 2: the channel returns and the backlog ships in order.
+    channel.readyState = "open";
+    produced += segment(20, 300);
+    client.queueWorkerProgress(produced);
+    timers.drain();
+    expect(sentOn(channel, "commentary")).toBe(produced);
+
+    // Phase 3: sends reject part-way through a flush; the next flushes resume
+    // from the last delivered character, with no duplicate and no gap.
+    channel.failuresRemaining = 3;
+    for (let step = 21; step < 60; step += 1) {
+      produced += segment(step, 900);
+      client.queueWorkerProgress(produced);
+      timers.run();
+    }
+    timers.drain();
+    expect(sentOn(channel, "commentary")).toBe(produced);
+
+    // The final message survives a rejected send too: it is retried whole on
+    // the next delegation announcement, and lands exactly once.
+    const before = channel.sent.length;
+    channel.failuresRemaining = 1;
+    client.finishWorkerProgress(produced);
+    channel.onmessage?.({ data: JSON.stringify({ type: "delegation.created", item: { id: "delegation-retry" } }) });
+    timers.drain();
+    expect(sentOn(channel, "speakable", before)).toBe(`Agent Final Message:\n\n${produced.slice(-12_000)}`);
+  } finally {
+    timers.restore();
+  }
+  await client.stop();
 });
 
 test("closing the page hangs up so the account's realtime slot is not stranded", async () => {

--- a/src/lib/realtime/codexRealtimeClient.transport.dom.test.ts
+++ b/src/lib/realtime/codexRealtimeClient.transport.dom.test.ts
@@ -14,15 +14,16 @@ Object.assign(globalThis, {
 class StubDataChannel {
   readyState = "open";
   sent: string[] = [];
-  /** Sends to reject before accepting again, standing in for a transport that
-      drops mid-flush; a rejected send is never recorded as delivered. */
-  failuresRemaining = 0;
+  sendAttempts = 0;
+  /** One send attempt to reject, standing in for a transport that drops
+      mid-response; a rejected chunk is never recorded as delivered. */
+  failOnAttempt: number | null = null;
   onopen: (() => void) | null = null;
   onmessage: ((message: { data: unknown }) => void) | null = null;
   onclose: (() => void) | null = null;
   send(payload: string): void {
-    if (this.failuresRemaining > 0) {
-      this.failuresRemaining -= 1;
+    this.sendAttempts += 1;
+    if (this.sendAttempts === this.failOnAttempt) {
       throw new Error("data channel send failed");
     }
     this.sent.push(payload);
@@ -170,7 +171,7 @@ test("a data channel lost before opening surfaces the error state instead of con
   expect(client.getSnapshot().error).toBe("Realtime connection closed");
 });
 
-test("a live call renders both transcripts and streams delegation handoffs with a final message", async () => {
+test("a live call keeps worker progress local and sends one completed response to voice", async () => {
   globalThis.fetch = (async () => jsonResponse(200, { ok: true, sdp: "v=0\r\nanswer" })) as unknown as typeof fetch;
 
   const client = codexRealtimeClient("conversation_live_call");
@@ -191,12 +192,25 @@ test("a live call renders both transcripts and streams delegation handoffs with 
     ["assistant", "On it — three agents are active", true],
   ]);
 
-  // Delegation: worker progress flows as targeted context appends (~200ms
-  // cadence), and completion carries the Agent Final Message on speakable.
+  // Delegation: accumulated progress remains local while the worker runs.
   peer.channel.onmessage?.({ data: JSON.stringify({ type: "delegation.created", item: { id: "delegation-9" } }) });
-  client.queueWorkerProgress("Reading current agents");
-  await new Promise((resolve) => setTimeout(resolve, 250));
-  client.finishWorkerProgress("Reading current agents — done");
+  let produced = "";
+  for (let step = 0; step < 40; step += 1) {
+    produced += segment(step, 300);
+    client.queueWorkerProgress("turn-live-call", produced);
+  }
+  expect(client.getSnapshot().lines.at(-1)).toMatchObject({
+    role: "progress",
+    text: produced.slice(-12_000),
+    final: false,
+  });
+
+  client.finishWorkerProgress("turn-live-call", produced);
+  // A repeated completion render describes the same worker response.
+  client.finishWorkerProgress("turn-live-call", produced);
+  // A replay can surface the completed turn's progress before completion again.
+  client.queueWorkerProgress("turn-live-call", produced);
+  client.finishWorkerProgress("turn-live-call", produced);
 
   const events = peer.channel.sent.map((payload) => JSON.parse(payload) as {
     type: string;
@@ -205,13 +219,12 @@ test("a live call renders both transcripts and streams delegation handoffs with 
     content: { text: string }[];
   });
   expect(events.every((event) => event.type === "delegation.context.append" && event.delegation_item_id === "delegation-9")).toBe(true);
-  expect(events.filter((event) => event.channel === "commentary").length).toBeGreaterThanOrEqual(1);
-  expect(events.at(-1)?.channel).toBe("speakable");
-  expect(events.at(-1)?.content[0]?.text).toStartWith("Agent Final Message:");
+  expect(events.filter((event) => event.channel === "commentary")).toEqual([]);
+  expect(sentOn(peer.channel, "speakable")).toBe(`Agent Final Message:\n\n${produced.slice(-12_000)}`);
 
   const progress = client.getSnapshot().lines.filter((line) => line.role === "progress");
-  expect(progress.at(-1)?.text).toBe("Reading current agents — done");
-  expect(progress.at(-1)?.final).toBe(true);
+  expect(progress).toHaveLength(1);
+  expect(progress[0]).toMatchObject({ text: produced.slice(-12_000), final: true });
 
   await client.stop();
   expect(client.getSnapshot().phase).toBe("idle");
@@ -266,44 +279,6 @@ test("issue 664: the transport reason stands when the host has no failure to rep
   expect(client.getSnapshot().error).toBe("Realtime connection was interrupted");
 });
 
-/* The handoff flush is a 200ms `window.setTimeout`. Driving it by hand keeps a
-   60,000-character stream a millisecond of test time instead of 40 seconds, and
-   makes "one flush per producer tick" observable rather than timing-dependent. */
-function manualTimers() {
-  const host = window as unknown as {
-    setTimeout: unknown;
-    clearTimeout: unknown;
-  };
-  const originalSet = host.setTimeout;
-  const originalClear = host.clearTimeout;
-  const pending = new Map<number, () => void>();
-  let handle = 0;
-  host.setTimeout = (callback: () => void) => {
-    pending.set(++handle, callback);
-    return handle;
-  };
-  host.clearTimeout = (id: number) => {
-    pending.delete(id);
-  };
-  function run(): number {
-    const due = [...pending.entries()];
-    pending.clear();
-    for (const [, callback] of due) callback();
-    return due.length;
-  }
-  return {
-    run,
-    /** Runs armed callbacks until the client stops re-arming (bounded). */
-    drain(): void {
-      for (let pass = 0; pass < 10_000 && run() > 0; pass += 1);
-    },
-    restore(): void {
-      host.setTimeout = originalSet;
-      host.clearTimeout = originalClear;
-    },
-  };
-}
-
 /** Every character the client actually put on one channel, in wire order. */
 function sentOn(channel: StubDataChannel, name: "commentary" | "speakable", from = 0): string {
   return channel.sent
@@ -330,147 +305,71 @@ async function liveCall(conversationId: string, delegationId: string) {
   return { client, channel: peer.channel };
 }
 
-test("worker progress past the 12,000-character window ships each character exactly once", async () => {
-  /* The producer is one monotonically growing turn. Handoff traffic must stay
-     proportional to new content across the retained-window boundary — the tail
-     window sliding used to make every flush resend the whole window, 32x and
-     climbing over a 60,000-character turn. */
-  const { client, channel } = await liveCall("conversation_progress_window", "delegation-window");
-  const timers = manualTimers();
-  let produced = "";
-  try {
-    for (let step = 0; step < 200; step += 1) {
-      produced += segment(step, 300);
-      client.queueWorkerProgress(produced);
-      timers.run();
-    }
-    timers.drain();
-  } finally {
-    timers.restore();
-  }
-
-  expect(produced.length).toBe(60_000);
-  const commentary = sentOn(channel, "commentary");
-  // Ordering and exact-once: the wire is the produced turn, byte for byte.
-  expect(commentary).toBe(produced);
-  expect(commentary.length / produced.length).toBeLessThanOrEqual(1.05);
-  await client.stop();
-});
-
-test("a stream that never reaches the window boundary behaves the same", async () => {
-  const { client, channel } = await liveCall("conversation_progress_short", "delegation-short");
-  const timers = manualTimers();
-  let produced = "";
-  try {
-    for (let step = 0; step < 20; step += 1) {
-      produced += segment(step, 250);
-      client.queueWorkerProgress(produced);
-      timers.run();
-    }
-    timers.drain();
-  } finally {
-    timers.restore();
-  }
-
-  expect(produced.length).toBe(5_000);
-  expect(sentOn(channel, "commentary")).toBe(produced);
-  await client.stop();
-});
-
-test("a rewritten turn resets the cursor and ships the replacement once", async () => {
-  const { client, channel } = await liveCall("conversation_progress_rewrite", "delegation-rewrite");
-  const timers = manualTimers();
-  try {
-    let produced = "";
-    for (let step = 0; step < 50; step += 1) {
-      produced += segment(step, 300);
-      client.queueWorkerProgress(produced);
-      timers.run();
-    }
-    timers.drain();
-    expect(produced.length).toBe(15_000);
-    expect(sentOn(channel, "commentary")).toBe(produced);
-
-    // The producer replaces the turn rather than extending it (compaction, a
-    // restarted turn). The replacement is not a suffix of anything sent, so it
-    // ships whole — once — and nothing already sent repeats.
-    const before = channel.sent.length;
-    const rewritten = segment(999, 800);
-    client.queueWorkerProgress(rewritten);
-    timers.drain();
-    expect(sentOn(channel, "commentary", before)).toBe(rewritten);
-  } finally {
-    timers.restore();
-  }
-  await client.stop();
-});
-
-test("a backlog larger than one window drains in order without splitting a character", async () => {
-  /* One producer tick can owe more than a single flush may carry (a cursor
-     reset, or a channel that was shut for a while). The rest follows on the
-     next flush, and the cap never lands inside a surrogate pair. */
-  const { client, channel } = await liveCall("conversation_progress_burst", "delegation-burst");
-  const timers = manualTimers();
-  const produced = `${"a".repeat(11_999)}😀${"b".repeat(20_000)}`;
-  try {
-    client.queueWorkerProgress(produced);
-    timers.drain();
-  } finally {
-    timers.restore();
-  }
-
-  expect(sentOn(channel, "commentary")).toBe(produced);
-  const chunks = channel.sent.map((payload) => (JSON.parse(payload) as { content: { text: string }[] })
-    .content.map((part) => part.text).join(""));
-  expect(chunks.length).toBeGreaterThan(1);
-  expect(chunks.every((chunk) => chunk.isWellFormed())).toBe(true);
-  await client.stop();
-});
-
-test("a failed send is retried from the exact character it stopped at", async () => {
+test("a rejected completed response waits for the data channel and is delivered exactly once", async () => {
   const { client, channel } = await liveCall("conversation_progress_retry", "delegation-retry");
-  const timers = manualTimers();
-  let produced = "";
-  try {
-    // Phase 1: the channel is not open, so nothing may go out and nothing may
-    // be dropped — the backlog waits.
-    channel.readyState = "closed";
-    for (let step = 0; step < 20; step += 1) {
-      produced += segment(step, 300);
-      client.queueWorkerProgress(produced);
-      timers.run();
-    }
-    expect(channel.sent).toEqual([]);
+  const completed = segment(1, 1_200);
+  client.queueWorkerProgress("turn-retry", completed);
 
-    // Phase 2: the channel returns and the backlog ships in order.
-    channel.readyState = "open";
-    produced += segment(20, 300);
-    client.queueWorkerProgress(produced);
-    timers.drain();
-    expect(sentOn(channel, "commentary")).toBe(produced);
+  channel.failOnAttempt = 2;
+  client.finishWorkerProgress("turn-retry", completed);
+  client.finishWorkerProgress("turn-retry", completed);
+  const expected = `Agent Final Message:\n\n${completed}`;
+  const acceptedPrefix = sentOn(channel, "speakable");
+  expect(acceptedPrefix.length).toBeGreaterThan(0);
+  expect(expected.startsWith(acceptedPrefix)).toBe(true);
 
-    // Phase 3: sends reject part-way through a flush; the next flushes resume
-    // from the last delivered character, with no duplicate and no gap.
-    channel.failuresRemaining = 3;
-    for (let step = 21; step < 60; step += 1) {
-      produced += segment(step, 900);
-      client.queueWorkerProgress(produced);
-      timers.run();
-    }
-    timers.drain();
-    expect(sentOn(channel, "commentary")).toBe(produced);
+  channel.onopen?.();
+  channel.onopen?.();
+  expect(sentOn(channel, "speakable")).toBe(expected);
 
-    // The final message survives a rejected send too: it is retried whole on
-    // the next delegation announcement, and lands exactly once.
-    const before = channel.sent.length;
-    channel.failuresRemaining = 1;
-    client.finishWorkerProgress(produced);
-    channel.onmessage?.({ data: JSON.stringify({ type: "delegation.created", item: { id: "delegation-retry" } }) });
-    timers.drain();
-    expect(sentOn(channel, "speakable", before)).toBe(`Agent Final Message:\n\n${produced.slice(-12_000)}`);
-  } finally {
-    timers.restore();
-  }
+  await client.stop();
+});
+
+test("a completed response survives replacement of a failed realtime transport", async () => {
+  const { client, channel } = await liveCall("conversation_progress_reconnect", "delegation-old");
+  const completed = "Response retained across transport replacement";
+
+  channel.readyState = "closed";
+  client.queueWorkerProgress("turn-reconnect", completed);
+  client.finishWorkerProgress("turn-reconnect", completed);
+
+  const failedPeer = StubPeerConnection.latest!;
+  failedPeer.connectionState = "failed";
+  failedPeer.onconnectionstatechange?.();
+  expect(client.getSnapshot().phase).toBe("error");
+
+  await client.start();
+  const replacement = StubPeerConnection.latest!;
+  replacement.channel.onopen?.();
+  replacement.channel.onmessage?.({
+    data: JSON.stringify({ type: "delegation.created", item: { id: "delegation-new" } }),
+  });
+  replacement.channel.onmessage?.({
+    data: JSON.stringify({ type: "delegation.created", item: { id: "delegation-new" } }),
+  });
+
+  expect(sentOn(replacement.channel, "speakable")).toBe(`Agent Final Message:\n\n${completed}`);
+  await client.stop();
+});
+
+test("completed responses queue in order while the data channel is unavailable", async () => {
+  const { client, channel } = await liveCall("conversation_progress_queue", "delegation-queue");
+  const first = "First completed worker response";
+  const second = "Second completed worker response";
+
+  channel.readyState = "closed";
+  client.queueWorkerProgress("turn-first", first);
+  client.finishWorkerProgress("turn-first", first);
+  client.queueWorkerProgress("turn-second", second);
+  client.finishWorkerProgress("turn-second", second);
+  expect(channel.sent).toEqual([]);
+
+  channel.readyState = "open";
+  channel.onopen?.();
+  expect(sentOn(channel, "speakable")).toBe(
+    `Agent Final Message:\n\n${first}Agent Final Message:\n\n${second}`,
+  );
+
   await client.stop();
 });
 

--- a/src/lib/realtime/codexRealtimeClient.ts
+++ b/src/lib/realtime/codexRealtimeClient.ts
@@ -170,8 +170,14 @@ class CodexRealtimeClient {
   private media: MediaStream | null = null;
   private audio: HTMLAudioElement | null = null;
   private delegationItemId: string | null = null;
-  private lastWorkerText = "";
+  /** The worker turn as the producer has it so far — a reference to the same
+      growing string, never a copy, so retention stays the producer's bound. */
   private pendingWorkerText = "";
+  /** How much of `pendingWorkerText` the channel has accepted. The cursor is
+      the whole contract with the wire: it advances only by characters that
+      were actually sent, so nothing ships twice and nothing is skipped. */
+  private sentWorkerChars = 0;
+  private flushingWorkerProgress = false;
   private pendingFinalText = "";
   private handoffTimer: number | null = null;
   private unloadHangup: (() => void) | null = null;
@@ -318,8 +324,44 @@ class CodexRealtimeClient {
 
   queueWorkerProgress(text: string): void {
     if (!text || this.snapshot.phase !== "live") return;
-    this.pendingWorkerText = text.slice(-MAX_LINE_CHARS);
-    this.upsertLine("progress", this.pendingWorkerText, false);
+    this.trackWorkerText(text);
+    this.upsertLine("progress", text.slice(-MAX_LINE_CHARS), false);
+    this.armHandoff();
+  }
+
+  finishWorkerProgress(text: string): void {
+    if (!text || this.snapshot.phase !== "live") return;
+    this.trackWorkerText(text);
+    if (this.handoffTimer !== null) {
+      window.clearTimeout(this.handoffTimer);
+      this.handoffTimer = null;
+    }
+    /* Everything still owed on commentary goes out before the spoken summary,
+       so the agent never hears the ending ahead of the middle. */
+    this.drainWorkerProgress();
+    const spoken = this.pendingWorkerText.slice(-MAX_LINE_CHARS);
+    this.pendingFinalText = `Agent Final Message:\n\n${spoken}`;
+    this.pendingFinalText = this.pendingFinalText.slice(
+      this.sendDelegationContext(this.pendingFinalText, "speakable"),
+    );
+    this.upsertLine("progress", spoken, true);
+    this.pendingWorkerText = "";
+    this.sentWorkerChars = 0;
+  }
+
+  /**
+   * The producer streams one turn that only grows, so the handoff is a cursor
+   * into it. Text that does not extend what was seen before is a rewrite (a
+   * restarted or replaced turn, not an append): the cursor returns to zero and
+   * the replacement ships once, rather than being diffed against a turn that
+   * no longer exists.
+   */
+  private trackWorkerText(text: string): void {
+    if (!text.startsWith(this.pendingWorkerText)) this.sentWorkerChars = 0;
+    this.pendingWorkerText = text;
+  }
+
+  private armHandoff(): void {
     if (this.handoffTimer !== null) return;
     this.handoffTimer = window.setTimeout(() => {
       this.handoffTimer = null;
@@ -327,34 +369,64 @@ class CodexRealtimeClient {
     }, HANDOFF_INTERVAL_MS);
   }
 
-  finishWorkerProgress(text: string): void {
-    if (!text || this.snapshot.phase !== "live") return;
-    this.pendingWorkerText = text.slice(-MAX_LINE_CHARS);
-    if (this.handoffTimer !== null) {
-      window.clearTimeout(this.handoffTimer);
-      this.handoffTimer = null;
-    }
-    this.flushWorkerProgress();
-    this.pendingFinalText = `Agent Final Message:\n\n${this.pendingWorkerText}`;
-    if (this.sendDelegationContext(this.pendingFinalText, "speakable")) this.pendingFinalText = "";
-    this.upsertLine("progress", this.pendingWorkerText, true);
-    this.lastWorkerText = "";
-    this.pendingWorkerText = "";
-  }
-
+  /** One flush, then re-arm while the wire still owes the producer content. */
   private flushWorkerProgress(): void {
-    const text = this.pendingWorkerText;
-    if (!text) return;
-    const delta = text.startsWith(this.lastWorkerText) ? text.slice(this.lastWorkerText.length) : text;
-    if (!delta || this.sendDelegationContext(delta, "commentary")) this.lastWorkerText = text;
+    if (this.flushOnce() > 0 && this.sentWorkerChars < this.pendingWorkerText.length) this.armHandoff();
   }
 
-  private sendDelegationContext(text: string, channel: "commentary" | "speakable"): boolean {
-    if (!this.delegationItemId || this.events?.readyState !== "open") return false;
-    for (const event of delegationContextEvents(this.delegationItemId, text, channel)) {
-      this.events.send(JSON.stringify(event));
+  private drainWorkerProgress(): void {
+    while (this.sentWorkerChars < this.pendingWorkerText.length && this.flushOnce() > 0);
+  }
+
+  /**
+   * Ships at most one window of unsent text and returns how much went out. A
+   * single flush is capped so a cursor reset (or a channel that was shut for a
+   * while) cannot burst an entire turn onto the wire in one tick; the rest
+   * follows on the next flush, in order.
+   */
+  private flushOnce(): number {
+    /* `update` runs subscribers synchronously, so a re-render can call back in
+       here mid-flush; a reentrant flush would read the cursor before it moved
+       and send the same characters twice. */
+    if (this.flushingWorkerProgress) return 0;
+    this.flushingWorkerProgress = true;
+    try {
+      const text = this.pendingWorkerText;
+      if (this.sentWorkerChars >= text.length) return 0;
+      const cap = Math.min(text.length, this.sentWorkerChars + MAX_LINE_CHARS);
+      /* A cap landing between the halves of a surrogate pair would put a lone
+         half in each append, and each encodes as U+FFFD. Keep the pair whole
+         and let it open the next flush. */
+      const lead = text.charCodeAt(cap - 1);
+      const end = cap < text.length && lead >= 0xd800 && lead <= 0xdbff ? cap - 1 : cap;
+      const sent = this.sendDelegationContext(text.slice(this.sentWorkerChars, end), "commentary");
+      this.sentWorkerChars += sent;
+      return sent;
+    } finally {
+      this.flushingWorkerProgress = false;
     }
-    return true;
+  }
+
+  /**
+   * Returns the number of characters the channel accepted — the whole text on
+   * success, the prefix that made it out if a send throws part-way, zero if
+   * there is nowhere to send yet. Callers resume from exactly that point, so a
+   * retry never repeats a delivered chunk.
+   */
+  private sendDelegationContext(text: string, channel: "commentary" | "speakable"): number {
+    if (!text || !this.delegationItemId || this.events?.readyState !== "open") return 0;
+    let sent = 0;
+    for (const chunk of chunkUtf8(text)) {
+      const [event] = delegationContextEvents(this.delegationItemId, chunk, channel);
+      if (!event) continue;
+      try {
+        this.events.send(JSON.stringify(event));
+      } catch {
+        return sent;
+      }
+      sent += chunk.length;
+    }
+    return text.length;
   }
 
   private acceptWireMessage(raw: unknown): void {
@@ -371,8 +443,10 @@ class CodexRealtimeClient {
     } else if (event.kind === "delegation") {
       this.delegationItemId = event.id;
       this.flushWorkerProgress();
-      if (this.pendingFinalText && this.sendDelegationContext(this.pendingFinalText, "speakable")) {
-        this.pendingFinalText = "";
+      if (this.pendingFinalText) {
+        this.pendingFinalText = this.pendingFinalText.slice(
+          this.sendDelegationContext(this.pendingFinalText, "speakable"),
+        );
       }
     } else if (event.kind === "error") {
       this.setError(event.message);
@@ -440,8 +514,9 @@ class CodexRealtimeClient {
     this.media = null;
     this.audio = null;
     this.delegationItemId = null;
-    this.lastWorkerText = "";
     this.pendingWorkerText = "";
+    this.sentWorkerChars = 0;
+    this.flushingWorkerProgress = false;
     this.pendingFinalText = "";
   }
 }

--- a/src/lib/realtime/codexRealtimeClient.ts
+++ b/src/lib/realtime/codexRealtimeClient.ts
@@ -32,7 +32,6 @@ export type ParsedRealtimeEvent =
 
 const MAX_LINE_CHARS = 12_000;
 const MAX_LINES = 80;
-const HANDOFF_INTERVAL_MS = 200;
 const HANDOFF_CHUNK_BYTES = 500;
 
 function object(value: unknown): Record<string, unknown> | null {
@@ -129,7 +128,7 @@ export function chunkUtf8(text: string, maxBytes = HANDOFF_CHUNK_BYTES): string[
 export function delegationContextEvents(
   delegationItemId: string,
   text: string,
-  channel: "commentary" | "speakable",
+  channel: "speakable",
 ): Record<string, unknown>[] {
   if (!delegationItemId || !text) return [];
   return chunkUtf8(text).map((chunk) => ({
@@ -170,16 +169,11 @@ class CodexRealtimeClient {
   private media: MediaStream | null = null;
   private audio: HTMLAudioElement | null = null;
   private delegationItemId: string | null = null;
-  /** The worker turn as the producer has it so far — a reference to the same
-      growing string, never a copy, so retention stays the producer's bound. */
-  private pendingWorkerText = "";
-  /** How much of `pendingWorkerText` the channel has accepted. The cursor is
-      the whole contract with the wire: it advances only by characters that
-      were actually sent, so nothing ships twice and nothing is skipped. */
-  private sentWorkerChars = 0;
-  private flushingWorkerProgress = false;
-  private pendingFinalText = "";
-  private handoffTimer: number | null = null;
+  private activeWorkerTurnId: string | null = null;
+  private readonly completedWorkerTurnIds = new Set<string>();
+  /** Completed worker responses retained in wire order until the data channel
+      accepts every chunk. The first entry may be a suffix after a partial send. */
+  private readonly pendingFinalTexts: string[] = [];
   private unloadHangup: (() => void) | null = null;
   private lineSequence = 0;
   private epoch = 0;
@@ -249,7 +243,10 @@ class CodexRealtimeClient {
         if (epoch === this.epoch) this.acceptWireMessage(message.data);
       };
       events.onopen = () => {
-        if (epoch === this.epoch) this.update({ phase: "live", error: null, startedAt: Date.now() });
+        if (epoch === this.epoch) {
+          this.update({ phase: "live", error: null, startedAt: Date.now() });
+          this.flushPendingFinal();
+        }
       };
       /* Closing the tab must hang up too. A call the backend still believes is
          open holds the account's one concurrent slot, and the next call is
@@ -318,93 +315,28 @@ class CodexRealtimeClient {
     } catch (error) {
       failure = error instanceof Error ? error.message : String(error);
     }
-    this.cleanupTransport();
+    this.cleanupTransport(true);
     this.update({ phase: failure ? "error" : "idle", error: failure });
   }
 
-  queueWorkerProgress(text: string): void {
-    if (!text || this.snapshot.phase !== "live") return;
-    this.trackWorkerText(text);
+  queueWorkerProgress(turnId: string, text: string): void {
+    if (!turnId || !text || this.completedWorkerTurnIds.has(turnId) || this.snapshot.phase !== "live") return;
+    this.activeWorkerTurnId = turnId;
     this.upsertLine("progress", text.slice(-MAX_LINE_CHARS), false);
-    this.armHandoff();
   }
 
-  finishWorkerProgress(text: string): void {
-    if (!text || this.snapshot.phase !== "live") return;
-    this.trackWorkerText(text);
-    if (this.handoffTimer !== null) {
-      window.clearTimeout(this.handoffTimer);
-      this.handoffTimer = null;
-    }
-    /* Everything still owed on commentary goes out before the spoken summary,
-       so the agent never hears the ending ahead of the middle. */
-    this.drainWorkerProgress();
-    const spoken = this.pendingWorkerText.slice(-MAX_LINE_CHARS);
-    this.pendingFinalText = `Agent Final Message:\n\n${spoken}`;
-    this.pendingFinalText = this.pendingFinalText.slice(
-      this.sendDelegationContext(this.pendingFinalText, "speakable"),
-    );
+  finishWorkerProgress(turnId: string, text: string): void {
+    if (!turnId
+      || !text
+      || this.activeWorkerTurnId !== turnId
+      || this.completedWorkerTurnIds.has(turnId)
+      || this.snapshot.phase !== "live") return;
+    const spoken = text.slice(-MAX_LINE_CHARS);
+    this.completedWorkerTurnIds.add(turnId);
+    this.pendingFinalTexts.push(`Agent Final Message:\n\n${spoken}`);
+    this.flushPendingFinal();
     this.upsertLine("progress", spoken, true);
-    this.pendingWorkerText = "";
-    this.sentWorkerChars = 0;
-  }
-
-  /**
-   * The producer streams one turn that only grows, so the handoff is a cursor
-   * into it. Text that does not extend what was seen before is a rewrite (a
-   * restarted or replaced turn, not an append): the cursor returns to zero and
-   * the replacement ships once, rather than being diffed against a turn that
-   * no longer exists.
-   */
-  private trackWorkerText(text: string): void {
-    if (!text.startsWith(this.pendingWorkerText)) this.sentWorkerChars = 0;
-    this.pendingWorkerText = text;
-  }
-
-  private armHandoff(): void {
-    if (this.handoffTimer !== null) return;
-    this.handoffTimer = window.setTimeout(() => {
-      this.handoffTimer = null;
-      this.flushWorkerProgress();
-    }, HANDOFF_INTERVAL_MS);
-  }
-
-  /** One flush, then re-arm while the wire still owes the producer content. */
-  private flushWorkerProgress(): void {
-    if (this.flushOnce() > 0 && this.sentWorkerChars < this.pendingWorkerText.length) this.armHandoff();
-  }
-
-  private drainWorkerProgress(): void {
-    while (this.sentWorkerChars < this.pendingWorkerText.length && this.flushOnce() > 0);
-  }
-
-  /**
-   * Ships at most one window of unsent text and returns how much went out. A
-   * single flush is capped so a cursor reset (or a channel that was shut for a
-   * while) cannot burst an entire turn onto the wire in one tick; the rest
-   * follows on the next flush, in order.
-   */
-  private flushOnce(): number {
-    /* `update` runs subscribers synchronously, so a re-render can call back in
-       here mid-flush; a reentrant flush would read the cursor before it moved
-       and send the same characters twice. */
-    if (this.flushingWorkerProgress) return 0;
-    this.flushingWorkerProgress = true;
-    try {
-      const text = this.pendingWorkerText;
-      if (this.sentWorkerChars >= text.length) return 0;
-      const cap = Math.min(text.length, this.sentWorkerChars + MAX_LINE_CHARS);
-      /* A cap landing between the halves of a surrogate pair would put a lone
-         half in each append, and each encodes as U+FFFD. Keep the pair whole
-         and let it open the next flush. */
-      const lead = text.charCodeAt(cap - 1);
-      const end = cap < text.length && lead >= 0xd800 && lead <= 0xdbff ? cap - 1 : cap;
-      const sent = this.sendDelegationContext(text.slice(this.sentWorkerChars, end), "commentary");
-      this.sentWorkerChars += sent;
-      return sent;
-    } finally {
-      this.flushingWorkerProgress = false;
-    }
+    this.activeWorkerTurnId = null;
   }
 
   /**
@@ -413,7 +345,7 @@ class CodexRealtimeClient {
    * there is nowhere to send yet. Callers resume from exactly that point, so a
    * retry never repeats a delivered chunk.
    */
-  private sendDelegationContext(text: string, channel: "commentary" | "speakable"): number {
+  private sendDelegationContext(text: string, channel: "speakable"): number {
     if (!text || !this.delegationItemId || this.events?.readyState !== "open") return 0;
     let sent = 0;
     for (const chunk of chunkUtf8(text)) {
@@ -429,6 +361,19 @@ class CodexRealtimeClient {
     return text.length;
   }
 
+  private flushPendingFinal(): void {
+    while (this.pendingFinalTexts.length > 0) {
+      const pending = this.pendingFinalTexts[0]!;
+      const sent = this.sendDelegationContext(pending, "speakable");
+      if (sent === pending.length) {
+        this.pendingFinalTexts.shift();
+        continue;
+      }
+      if (sent > 0) this.pendingFinalTexts[0] = pending.slice(sent);
+      return;
+    }
+  }
+
   private acceptWireMessage(raw: unknown): void {
     if (typeof raw !== "string") return;
     let value: unknown;
@@ -442,12 +387,7 @@ class CodexRealtimeClient {
       this.upsertLine(event.role, event.text, event.final);
     } else if (event.kind === "delegation") {
       this.delegationItemId = event.id;
-      this.flushWorkerProgress();
-      if (this.pendingFinalText) {
-        this.pendingFinalText = this.pendingFinalText.slice(
-          this.sendDelegationContext(this.pendingFinalText, "speakable"),
-        );
-      }
+      this.flushPendingFinal();
     } else if (event.kind === "error") {
       this.setError(event.message);
     }
@@ -500,11 +440,9 @@ class CodexRealtimeClient {
     for (const listener of this.listeners) listener();
   }
 
-  private cleanupTransport(): void {
+  private cleanupTransport(discardWorkerDelivery = false): void {
     if (this.unloadHangup) window.removeEventListener("pagehide", this.unloadHangup);
     this.unloadHangup = null;
-    if (this.handoffTimer !== null) window.clearTimeout(this.handoffTimer);
-    this.handoffTimer = null;
     this.events?.close();
     this.peer?.close();
     for (const track of this.media?.getTracks() ?? []) track.stop();
@@ -514,10 +452,11 @@ class CodexRealtimeClient {
     this.media = null;
     this.audio = null;
     this.delegationItemId = null;
-    this.pendingWorkerText = "";
-    this.sentWorkerChars = 0;
-    this.flushingWorkerProgress = false;
-    this.pendingFinalText = "";
+    if (discardWorkerDelivery) {
+      this.activeWorkerTurnId = null;
+      this.completedWorkerTurnIds.clear();
+      this.pendingFinalTexts.length = 0;
+    }
   }
 }
 

--- a/src/lib/realtime/codexRealtimeClient.ts
+++ b/src/lib/realtime/codexRealtimeClient.ts
@@ -1,5 +1,10 @@
 "use client";
 
+import {
+  normalizeVoiceDeliveries,
+  type RuntimeVoiceDelivery,
+} from "@/lib/runtime/voiceDelivery";
+
 export type CodexRealtimePhase = "idle" | "connecting" | "live" | "stopping" | "error";
 export type CodexRealtimeRole = "user" | "assistant" | "progress";
 
@@ -32,7 +37,6 @@ export type ParsedRealtimeEvent =
 
 const MAX_LINE_CHARS = 12_000;
 const MAX_LINES = 80;
-const HANDOFF_CHUNK_BYTES = 500;
 
 function object(value: unknown): Record<string, unknown> | null {
   return value && typeof value === "object" && !Array.isArray(value)
@@ -107,38 +111,6 @@ export function parseCodexRealtimeEvent(value: unknown): ParsedRealtimeEvent {
   return { kind: "ignored" };
 }
 
-export function chunkUtf8(text: string, maxBytes = HANDOFF_CHUNK_BYTES): string[] {
-  if (!Number.isInteger(maxBytes) || maxBytes <= 0) throw new Error("maxBytes must be positive");
-  const encoder = new TextEncoder();
-  const chunks: string[] = [];
-  let current = "";
-  for (const symbol of text) {
-    if (encoder.encode(symbol).byteLength > maxBytes) continue;
-    if (current && encoder.encode(current + symbol).byteLength > maxBytes) {
-      chunks.push(current);
-      current = symbol;
-    } else {
-      current += symbol;
-    }
-  }
-  if (current) chunks.push(current);
-  return chunks;
-}
-
-export function delegationContextEvents(
-  delegationItemId: string,
-  text: string,
-  channel: "speakable",
-): Record<string, unknown>[] {
-  if (!delegationItemId || !text) return [];
-  return chunkUtf8(text).map((chunk) => ({
-    type: "delegation.context.append",
-    delegation_item_id: delegationItemId,
-    channel,
-    content: [{ type: "input_text", text: chunk }],
-  }));
-}
-
 async function responseJson(response: Response): Promise<Record<string, unknown>> {
   const body = await response.json().catch(() => ({})) as Record<string, unknown>;
   if (!response.ok) throw new Error(typeof body.error === "string" ? body.error : `Realtime request failed (${response.status})`);
@@ -168,12 +140,10 @@ class CodexRealtimeClient {
   private events: RTCDataChannel | null = null;
   private media: MediaStream | null = null;
   private audio: HTMLAudioElement | null = null;
-  private delegationItemId: string | null = null;
-  private activeWorkerTurnId: string | null = null;
-  private readonly completedWorkerTurnIds = new Set<string>();
-  /** Completed worker responses retained in wire order until the data channel
-      accepts every chunk. The first entry may be a suffix after a partial send. */
-  private readonly pendingFinalTexts: string[] = [];
+  private readonly pendingWorkerDeliveries = new Map<string, RuntimeVoiceDelivery>();
+  private readonly acknowledgedWorkerDeliveries = new Set<string>();
+  private workerDeliveryFlush: Promise<void> | null = null;
+  private workerDeliveryWakeEpoch: number | null = null;
   private unloadHangup: (() => void) | null = null;
   private lineSequence = 0;
   private epoch = 0;
@@ -245,7 +215,7 @@ class CodexRealtimeClient {
       events.onopen = () => {
         if (epoch === this.epoch) {
           this.update({ phase: "live", error: null, startedAt: Date.now() });
-          this.flushPendingFinal();
+          this.flushWorkerDeliveries();
         }
       };
       /* Closing the tab must hang up too. A call the backend still believes is
@@ -315,62 +285,64 @@ class CodexRealtimeClient {
     } catch (error) {
       failure = error instanceof Error ? error.message : String(error);
     }
-    this.cleanupTransport(true);
+    /* Canonical pending deliveries intentionally survive an explicit hangup.
+       A later Live Mode start retries the same stable id and the host resumes
+       from its durable chunk cursor. */
+    this.cleanupTransport();
     this.update({ phase: failure ? "error" : "idle", error: failure });
   }
 
-  queueWorkerProgress(turnId: string, text: string): void {
-    if (!turnId || !text || this.completedWorkerTurnIds.has(turnId) || this.snapshot.phase !== "live") return;
-    this.activeWorkerTurnId = turnId;
-    this.upsertLine("progress", text.slice(-MAX_LINE_CHARS), false);
+  updateWorkerProgress(turnId: string, text: string, running: boolean): void {
+    if (!turnId || !text || this.snapshot.phase !== "live") return;
+    this.upsertLine("progress", text.slice(-MAX_LINE_CHARS), !running);
   }
 
-  finishWorkerProgress(turnId: string, text: string): void {
-    if (!turnId
-      || !text
-      || this.activeWorkerTurnId !== turnId
-      || this.completedWorkerTurnIds.has(turnId)
-      || this.snapshot.phase !== "live") return;
-    const spoken = text.slice(-MAX_LINE_CHARS);
-    this.completedWorkerTurnIds.add(turnId);
-    this.pendingFinalTexts.push(`Agent Final Message:\n\n${spoken}`);
-    this.flushPendingFinal();
-    this.upsertLine("progress", spoken, true);
-    this.activeWorkerTurnId = null;
-  }
-
-  /**
-   * Returns the number of characters the channel accepted — the whole text on
-   * success, the prefix that made it out if a send throws part-way, zero if
-   * there is nowhere to send yet. Callers resume from exactly that point, so a
-   * retry never repeats a delivered chunk.
-   */
-  private sendDelegationContext(text: string, channel: "speakable"): number {
-    if (!text || !this.delegationItemId || this.events?.readyState !== "open") return 0;
-    let sent = 0;
-    for (const chunk of chunkUtf8(text)) {
-      const [event] = delegationContextEvents(this.delegationItemId, chunk, channel);
-      if (!event) continue;
-      try {
-        this.events.send(JSON.stringify(event));
-      } catch {
-        return sent;
-      }
-      sent += chunk.length;
+  reconcileWorkerDeliveries(value: readonly RuntimeVoiceDelivery[] | null | undefined): void {
+    for (const delivery of normalizeVoiceDeliveries(value)) {
+      if (!delivery.ready || this.acknowledgedWorkerDeliveries.has(delivery.deliveryId)) continue;
+      this.pendingWorkerDeliveries.set(delivery.deliveryId, delivery);
     }
-    return text.length;
+    this.flushWorkerDeliveries();
   }
 
-  private flushPendingFinal(): void {
-    while (this.pendingFinalTexts.length > 0) {
-      const pending = this.pendingFinalTexts[0]!;
-      const sent = this.sendDelegationContext(pending, "speakable");
-      if (sent === pending.length) {
-        this.pendingFinalTexts.shift();
-        continue;
-      }
-      if (sent > 0) this.pendingFinalTexts[0] = pending.slice(sent);
+  private flushWorkerDeliveries(): void {
+    if (this.snapshot.phase !== "live" || this.pendingWorkerDeliveries.size === 0) return;
+    if (this.workerDeliveryFlush) {
+      this.workerDeliveryWakeEpoch = this.epoch;
       return;
+    }
+    const task = this.deliverPendingWorkerResponses();
+    this.workerDeliveryFlush = task;
+    void task.finally(() => {
+      if (this.workerDeliveryFlush !== task) return;
+      this.workerDeliveryFlush = null;
+      const wakeEpoch = this.workerDeliveryWakeEpoch;
+      this.workerDeliveryWakeEpoch = null;
+      if (wakeEpoch === this.epoch) this.flushWorkerDeliveries();
+    });
+  }
+
+  private async deliverPendingWorkerResponses(): Promise<void> {
+    while (this.snapshot.phase === "live") {
+      const delivery = this.pendingWorkerDeliveries.values().next().value as RuntimeVoiceDelivery | undefined;
+      if (!delivery) return;
+      let body: Record<string, unknown>;
+      try {
+        body = await responseJson(await fetch("/api/runtime/realtime", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            action: "deliverWorkerResponse",
+            conversationId: this.conversationId,
+            delivery,
+          }),
+        }));
+      } catch {
+        return;
+      }
+      if (body.acknowledged !== true || body.deliveryId !== delivery.deliveryId) return;
+      this.pendingWorkerDeliveries.delete(delivery.deliveryId);
+      this.acknowledgedWorkerDeliveries.add(delivery.deliveryId);
     }
   }
 
@@ -386,8 +358,7 @@ class CodexRealtimeClient {
     if (event.kind === "transcript") {
       this.upsertLine(event.role, event.text, event.final);
     } else if (event.kind === "delegation") {
-      this.delegationItemId = event.id;
-      this.flushPendingFinal();
+      return;
     } else if (event.kind === "error") {
       this.setError(event.message);
     }
@@ -440,7 +411,7 @@ class CodexRealtimeClient {
     for (const listener of this.listeners) listener();
   }
 
-  private cleanupTransport(discardWorkerDelivery = false): void {
+  private cleanupTransport(): void {
     if (this.unloadHangup) window.removeEventListener("pagehide", this.unloadHangup);
     this.unloadHangup = null;
     this.events?.close();
@@ -451,12 +422,6 @@ class CodexRealtimeClient {
     this.peer = null;
     this.media = null;
     this.audio = null;
-    this.delegationItemId = null;
-    if (discardWorkerDelivery) {
-      this.activeWorkerTurnId = null;
-      this.completedWorkerTurnIds.clear();
-      this.pendingFinalTexts.length = 0;
-    }
   }
 }
 

--- a/src/lib/runtime/codexAppServerHost.test.ts
+++ b/src/lib/runtime/codexAppServerHost.test.ts
@@ -14,6 +14,7 @@ import { FileRuntimeEventStore, type RuntimeEventStore } from "./eventStore";
 import type { HostState, RuntimeEvent } from "./engineHost";
 import { adoptCodexRegistryHosts, bindCodexHostPersistence, persistCodexHost, startCodexStructuredHost, structuredHostsEnabled } from "./registry";
 import { STRUCTURED_IMAGE_CAPABILITY, structuredContent, type StructuredImageRef } from "./structuredContent";
+import type { RuntimeVoiceDelivery } from "./voiceDelivery";
 import { DEFAULT_VOICE_PERSONA, VOICE_PERSONA_FILE, voicePersona } from "./voicePersona";
 
 class MemoryEventStore implements RuntimeEventStore {
@@ -63,6 +64,8 @@ class FakeAppServer extends EventEmitter {
   modelList: unknown[] = [{ id: "gpt-5.3-codex-spark", isDefault: true, inputModalities: ["text"] }];
   modelListFailuresRemaining = 0;
   realtimeStartError: string | null = null;
+  realtimeAppendErrorAt: number | null = null;
+  readonly acceptedRealtimeSpeech: string[] = [];
   injectItemsError: string | null = null;
   private readonly serverRequestIds = new Set<string | number>();
   private turn = 0;
@@ -200,7 +203,16 @@ class FakeAppServer extends EventEmitter {
       }
       return;
     }
-    if (method === "thread/realtime/appendSpeech" || method === "thread/realtime/stop") {
+    if (method === "thread/realtime/appendSpeech") {
+      const attempt = this.requests.filter((request) =>
+        request.method === "thread/realtime/appendSpeech").length;
+      if (attempt === this.realtimeAppendErrorAt) {
+        return this.respondError(message.id, "realtime channel replaced");
+      }
+      this.acceptedRealtimeSpeech.push((message.params as { text: string }).text);
+      return this.respond(message.id, {});
+    }
+    if (method === "thread/realtime/stop") {
       return this.respond(message.id, {});
     }
   }
@@ -323,6 +335,93 @@ describe("CodexAppServerHost", () => {
       threadId: "voice-thread",
     });
     await host.release();
+  });
+
+  test("delivers a large multi-item response exactly once and deduplicates after host recovery", async () => {
+    const eventStore = new MemoryEventStore();
+    const firstServer = new FakeAppServer("voice-delivery-thread");
+    const firstHost = await CodexAppServerHost.start({
+      cwd: "/repo",
+      eventStore,
+      spawnProcess: fakeSpawn(firstServer),
+    });
+    const firstText = `${"🙂界".repeat(20_000)}\n`;
+    const secondText = `${"🫶🏽".repeat(5_000)}done`;
+    const delivery: RuntimeVoiceDelivery = {
+      deliveryId: 'voice:["turn-delivery",["response-one","response-two"]]',
+      turnId: "turn-delivery",
+      responses: [
+        { responseId: "response-one", text: firstText },
+        { responseId: "response-two", text: secondText },
+      ],
+      ready: true,
+    };
+
+    await expect(firstHost.deliverRealtimeWorkerResponse(delivery)).resolves.toEqual({
+      deliveryId: delivery.deliveryId,
+      acknowledged: true,
+    });
+    await firstHost.deliverRealtimeWorkerResponse(delivery);
+    expect(firstServer.acceptedRealtimeSpeech.join("")).toBe(firstText + secondText);
+    expect(firstServer.acceptedRealtimeSpeech.every((chunk) =>
+      Buffer.byteLength(chunk, "utf8") <= 8 * 1024)).toBeTrue();
+    expect(eventStore.load("voice-delivery-thread").at(-1)).toMatchObject({
+      kind: "realtime-delivery-acknowledged",
+      deliveryId: delivery.deliveryId,
+    });
+    await expect(firstHost.deliverRealtimeWorkerResponse({
+      ...delivery,
+      responses: [
+        { responseId: "response-one", text: "different content" },
+        { responseId: "response-two", text: secondText },
+      ],
+    })).rejects.toThrow("delivery id belongs to different content");
+    await firstHost.release();
+
+    const replacementServer = new FakeAppServer("voice-delivery-thread");
+    const replacementHost = await CodexAppServerHost.adopt("voice-delivery-thread", {
+      cwd: "/repo",
+      eventStore,
+      spawnProcess: fakeSpawn(replacementServer),
+    });
+    await replacementHost.deliverRealtimeWorkerResponse(delivery);
+    expect(replacementServer.acceptedRealtimeSpeech).toEqual([]);
+    await replacementHost.release();
+  });
+
+  test("resumes the exact Unicode suffix after a partial realtime send", async () => {
+    const eventStore = new MemoryEventStore();
+    const firstServer = new FakeAppServer("voice-partial-thread");
+    firstServer.realtimeAppendErrorAt = 2;
+    const firstHost = await CodexAppServerHost.start({
+      cwd: "/repo",
+      eventStore,
+      spawnProcess: fakeSpawn(firstServer),
+    });
+    const text = `boundary:${"🙂🫶🏽界".repeat(8_000)}:end`;
+    const delivery: RuntimeVoiceDelivery = {
+      deliveryId: 'voice:["turn-partial",["response-partial"]]',
+      turnId: "turn-partial",
+      responses: [{ responseId: "response-partial", text }],
+      ready: true,
+    };
+
+    await expect(firstHost.deliverRealtimeWorkerResponse(delivery))
+      .rejects.toThrow("realtime channel replaced");
+    const acceptedPrefix = firstServer.acceptedRealtimeSpeech.join("");
+    expect(acceptedPrefix.length).toBeGreaterThan(0);
+    expect(text.startsWith(acceptedPrefix)).toBeTrue();
+    await firstHost.release();
+
+    const replacementServer = new FakeAppServer("voice-partial-thread");
+    const replacementHost = await CodexAppServerHost.adopt("voice-partial-thread", {
+      cwd: "/repo",
+      eventStore,
+      spawnProcess: fakeSpawn(replacementServer),
+    });
+    await replacementHost.deliverRealtimeWorkerResponse(delivery);
+    expect(acceptedPrefix + replacementServer.acceptedRealtimeSpeech.join("")).toBe(text);
+    await replacementHost.release();
   });
 
   test("the operator's override is the text that reaches the call's thread", async () => {

--- a/src/lib/runtime/codexAppServerHost.ts
+++ b/src/lib/runtime/codexAppServerHost.ts
@@ -1,5 +1,6 @@
 import { spawn } from "node:child_process";
 import type { ChildProcessWithoutNullStreams, SpawnOptionsWithoutStdio } from "node:child_process";
+import { createHash } from "node:crypto";
 
 import { isKnownEffortTier } from "@/lib/agent/efforts";
 import { procBackend } from "@/lib/proc";
@@ -10,6 +11,11 @@ import { hardenedRedact } from "@/lib/view/compactText";
 import { decodeCodexStructuredUserText, encodeCodexStructuredUserText } from "./codexStructuredUserText";
 import { runtimeImageStore } from "./runtimeImageStore";
 import { STRUCTURED_IMAGE_CAPABILITY, type StructuredImageRef } from "./structuredContent";
+import {
+  normalizeVoiceDeliveries,
+  utf8ChunkAt,
+  type RuntimeVoiceDelivery,
+} from "./voiceDelivery";
 
 import type {
   DeliveryReceipt,
@@ -77,6 +83,12 @@ type PendingAttention = {
 type ThreadStatus = {
   type: "active" | "idle" | "notLoaded" | "systemError";
   activeFlags: string[];
+};
+type RealtimeDeliveryState = {
+  digest: string;
+  responseIndex: number;
+  offset: number;
+  acknowledged: boolean;
 };
 type UnsequencedEvent = RuntimeEvent extends infer Event
   ? Event extends RuntimeEvent ? Omit<Event, "seq"> : never
@@ -391,6 +403,11 @@ export class CodexAppServerHost implements EngineHost {
     contentDigest: string | null;
   }>();
   private readonly pendingDeliveries = new Map<string, PendingDelivery>();
+  private readonly realtimeDeliveries = new Map<string, RealtimeDeliveryState>();
+  private readonly activeRealtimeDeliveries = new Map<string, {
+    digest: string;
+    promise: Promise<{ deliveryId: string; acknowledged: true }>;
+  }>();
   private readonly attentions = new Map<string, PendingAttention>();
   private readonly stateListeners = new Set<(state: HostState) => void>();
   private readonly preRestoreEvents: UnsequencedEvent[] = [];
@@ -413,6 +430,7 @@ export class CodexAppServerHost implements EngineHost {
       the next image send. */
   private imageInputSupport: "supported" | "unsupported" | "unknown" = "unknown";
   private requestedModel: string | undefined;
+  private realtimeDeliveryEpoch = 0;
   private releasing = false;
   private released = false;
   private dead = false;
@@ -798,17 +816,112 @@ export class CodexAppServerHost implements EngineHost {
   }
 
   async appendRealtimeSpeech(text: string): Promise<void> {
-    const speech = text.trim();
-    if (!speech || Buffer.byteLength(speech, "utf8") > MAX_REALTIME_SPEECH_BYTES) {
+    if (!text || Buffer.byteLength(text, "utf8") > MAX_REALTIME_SPEECH_BYTES) {
       throw new Error("Realtime speech text is empty or too large");
     }
     await this.rpc("thread/realtime/appendSpeech", {
       threadId: this.identity.threadId,
-      text: speech,
+      text,
     });
   }
 
+  async deliverRealtimeWorkerResponse(
+    value: RuntimeVoiceDelivery,
+  ): Promise<{ deliveryId: string; acknowledged: true }> {
+    const delivery = normalizeVoiceDeliveries([value])[0];
+    if (!delivery || !delivery.ready || delivery.deliveryId !== value.deliveryId) {
+      throw new Error("Realtime worker delivery is invalid");
+    }
+    const digest = createHash("sha256")
+      .update(JSON.stringify(delivery.responses))
+      .digest("hex");
+    const active = this.activeRealtimeDeliveries.get(delivery.deliveryId);
+    if (active) {
+      if (active.digest !== digest) throw new Error("Realtime delivery id belongs to different content");
+      return active.promise;
+    }
+    const task = this.performRealtimeWorkerDelivery(delivery, digest);
+    this.activeRealtimeDeliveries.set(delivery.deliveryId, { digest, promise: task });
+    try {
+      return await task;
+    } finally {
+      if (this.activeRealtimeDeliveries.get(delivery.deliveryId)?.promise === task) {
+        this.activeRealtimeDeliveries.delete(delivery.deliveryId);
+      }
+    }
+  }
+
+  private async performRealtimeWorkerDelivery(
+    delivery: RuntimeVoiceDelivery,
+    digest: string,
+  ): Promise<{ deliveryId: string; acknowledged: true }> {
+    const restored = this.realtimeDeliveries.get(delivery.deliveryId);
+    if (restored?.digest !== undefined && restored.digest !== digest) {
+      throw new Error("Realtime delivery id belongs to different content");
+    }
+    if (restored?.acknowledged) {
+      return { deliveryId: delivery.deliveryId, acknowledged: true };
+    }
+    let responseIndex = restored?.responseIndex ?? 0;
+    let offset = restored?.offset ?? 0;
+    if (responseIndex > delivery.responses.length
+      || (responseIndex < delivery.responses.length
+        && offset > delivery.responses[responseIndex]!.text.length)) {
+      throw new Error("Realtime delivery cursor is invalid");
+    }
+    const deliveryEpoch = this.realtimeDeliveryEpoch;
+    while (responseIndex < delivery.responses.length) {
+      if (deliveryEpoch !== this.realtimeDeliveryEpoch) {
+        throw new Error("Realtime worker delivery paused by stop");
+      }
+      const response = delivery.responses[responseIndex]!;
+      const chunk = utf8ChunkAt(response.text, offset, MAX_REALTIME_SPEECH_BYTES);
+      if (!chunk) {
+        responseIndex += 1;
+        offset = 0;
+        continue;
+      }
+      await this.appendRealtimeSpeech(chunk.text);
+      offset = chunk.nextOffset;
+      if (offset === response.text.length) {
+        responseIndex += 1;
+        offset = 0;
+      }
+      this.emit({
+        kind: "realtime-delivery-progress",
+        deliveryId: delivery.deliveryId,
+        digest,
+        responseIndex,
+        offset,
+      });
+      if (this.ledgerFailed) throw new Error("Realtime delivery progress was not persisted");
+      this.realtimeDeliveries.set(delivery.deliveryId, {
+        digest,
+        responseIndex,
+        offset,
+        acknowledged: false,
+      });
+    }
+    this.emit({
+      kind: "realtime-delivery-acknowledged",
+      deliveryId: delivery.deliveryId,
+      digest,
+    });
+    if (this.ledgerFailed) throw new Error("Realtime delivery acknowledgement was not persisted");
+    this.realtimeDeliveries.set(delivery.deliveryId, {
+      digest,
+      responseIndex,
+      offset,
+      acknowledged: true,
+    });
+    return { deliveryId: delivery.deliveryId, acknowledged: true };
+  }
+
   async stopRealtime(): Promise<void> {
+    /* Stop is a pause boundary for canonical worker delivery. A chunk already
+       admitted by app-server is durably checkpointed; later chunks remain
+       pending and resume from that cursor when Live Mode is started again. */
+    this.realtimeDeliveryEpoch += 1;
     await this.rpc("thread/realtime/stop", { threadId: this.identity.threadId });
     this.rejectRealtimeStart(new Error("Realtime session stopped during startup"));
     /* An operator hanging up is not a failure to report back to them. */
@@ -892,6 +1005,7 @@ export class CodexAppServerHost implements EngineHost {
   }
 
   private async releaseAndReap(): Promise<void> {
+    this.realtimeDeliveryEpoch += 1;
     /* Hang up before the process goes away. A realtime call the backend still
        believes is open holds the account's concurrent slot, and every later
        call is refused with "You have reached your usage limit." — the same
@@ -1100,6 +1214,23 @@ export class CodexAppServerHost implements EngineHost {
         this.attentions.set(event.id, { rpcId: "restored", method: event.method, origin: "restored" });
       }
       if (event.kind === "attention-resolved") this.attentions.delete(event.id);
+      if (event.kind === "realtime-delivery-progress") {
+        this.realtimeDeliveries.set(event.deliveryId, {
+          digest: event.digest,
+          responseIndex: event.responseIndex,
+          offset: event.offset,
+          acknowledged: false,
+        });
+      }
+      if (event.kind === "realtime-delivery-acknowledged") {
+        const previous = this.realtimeDeliveries.get(event.deliveryId);
+        this.realtimeDeliveries.set(event.deliveryId, {
+          digest: event.digest,
+          responseIndex: previous?.responseIndex ?? 0,
+          offset: previous?.offset ?? 0,
+          acknowledged: true,
+        });
+      }
       if (event.kind === "session-status") {
         this.engineStatus = event.status;
         this.activeFlags = [...(event.activeFlags ?? [])];

--- a/src/lib/runtime/contracts.ts
+++ b/src/lib/runtime/contracts.ts
@@ -358,6 +358,9 @@ export interface RuntimeSession {
   /** Canonical terminal assistant items retained independently from the
       bounded live UI projection until Live Mode acknowledges delivery. */
   voiceDeliveries?: RuntimeVoiceDelivery[];
+  /** Bounded durable tombstones prevent terminal-event replay from recreating
+      deliveries already acknowledged by Live Mode. */
+  acknowledgedVoiceDeliveryIds?: string[];
 }
 
 export interface ScopedEntity<T> {

--- a/src/lib/runtime/contracts.ts
+++ b/src/lib/runtime/contracts.ts
@@ -4,6 +4,7 @@ import type { Flow } from "@/lib/flows/types";
 import type { BoardTask } from "@/lib/tasks/types";
 import type { Workflow } from "@/lib/workflows/types";
 import type { RuntimeLiveTurn } from "@/lib/runtime/liveTurn";
+import type { RuntimeVoiceDelivery } from "@/lib/runtime/voiceDelivery";
 import type { RuntimeImageCapability, StructuredImageRef } from "./structuredContent";
 
 export const RUNTIME_SCHEMA_VERSION = 1;
@@ -354,6 +355,9 @@ export interface RuntimeSession {
   /** In-flight assistant text accumulated from live `delta` events, rendered
       as a streaming bubble until the transcript materializes the item. */
   liveTurn?: RuntimeLiveTurn | null;
+  /** Canonical terminal assistant items retained independently from the
+      bounded live UI projection until Live Mode acknowledges delivery. */
+  voiceDeliveries?: RuntimeVoiceDelivery[];
 }
 
 export interface ScopedEntity<T> {
@@ -610,5 +614,14 @@ export function assertRuntimeEvent(input: RuntimeEventInput): void {
   if (!input.payload || typeof input.payload !== "object" || Array.isArray(input.payload)) throw new Error("runtime event payload is invalid");
   const normalized = normalizeRuntimeEventInput(input);
   if (!/^[a-z][a-z0-9._-]{1,120}$/.test(normalized.kind)) throw new Error("runtime event kind is invalid");
-  if (Buffer.byteLength(JSON.stringify(normalized.payload)) > 16 * 1024) throw new Error("runtime event payload exceeds 16 KiB");
+  const payloadBytes = Buffer.byteLength(JSON.stringify(normalized.payload));
+  const carriesCanonicalVoiceResponse = normalized.kind === "item"
+    && normalized.payload.voiceResponse !== null
+    && typeof normalized.payload.voiceResponse === "object";
+  const payloadLimit = carriesCanonicalVoiceResponse ? 16 * 1024 * 1024 : 16 * 1024;
+  if (payloadBytes > payloadLimit) {
+    throw new Error(carriesCanonicalVoiceResponse
+      ? "runtime terminal response payload exceeds 16 MiB"
+      : "runtime event payload exceeds 16 KiB");
+  }
 }

--- a/src/lib/runtime/engineHost.ts
+++ b/src/lib/runtime/engineHost.ts
@@ -54,6 +54,8 @@ export type RuntimeEvent =
   | { kind: "attention"; id: string; method: string; attention: unknown; seq: number }
   | { kind: "attention-resolved"; id: string; resolution: "answered" | "host-restarted" | "server-resolved"; seq: number }
   | { kind: "limits"; snapshot: unknown; seq: number }
+  | { kind: "realtime-delivery-progress"; deliveryId: string; digest: string; responseIndex: number; offset: number; seq: number }
+  | { kind: "realtime-delivery-acknowledged"; deliveryId: string; digest: string; seq: number }
   | { kind: "session-status"; status: "active" | "idle" | "unhosted" | "dead"; activeFlags?: string[]; seq: number };
 
 export interface HostState {

--- a/src/lib/runtime/engineHostEvents.test.ts
+++ b/src/lib/runtime/engineHostEvents.test.ts
@@ -63,4 +63,53 @@ describe("projectEngineHostEvent", () => {
       payload: { conversationId: "conversation_three", turnId: "turn-two", outcome: "interrupted" },
     });
   });
+
+  test("projects the full terminal assistant response separately from the bounded UI item", () => {
+    const text = `${"🙂界".repeat(40_000)}\n`;
+    const projected = projectEngineHostEvent("conversation_voice", "codex:thread-voice", {
+      kind: "item",
+      turnId: "turn-voice",
+      item: { type: "agentMessage", id: "response-voice", text },
+      phase: "completed",
+      seq: 12,
+    });
+
+    expect(projected?.payload.item).toEqual({
+      truncated: true,
+      id: "response-voice",
+      type: "agentMessage",
+    });
+    expect(projected?.payload.voiceResponse).toEqual({
+      responseId: "response-voice",
+      text,
+    });
+    expect(new TextEncoder().encode((projected?.payload.voiceResponse as { text: string }).text).length)
+      .toBeGreaterThan(64 * 1024);
+  });
+
+  test("projects durable receiver acknowledgement onto the pending session delivery", () => {
+    expect(projectEngineHostEvent("conversation_voice", "codex:thread-voice", {
+      kind: "realtime-delivery-acknowledged",
+      deliveryId: "voice-delivery-one",
+      digest: "digest-one",
+      seq: 13,
+    })).toMatchObject({
+      kind: "voice-delivery-acknowledged",
+      payload: {
+        conversationId: "conversation_voice",
+        deliveryId: "voice-delivery-one",
+      },
+    });
+  });
+
+  test("does not retain canonical voice payloads for Claude sessions that cannot open Live Mode", () => {
+    const projected = projectEngineHostEvent("conversation_claude", "claude:session-one", {
+      kind: "item",
+      turnId: "turn-claude",
+      item: { type: "assistant", id: "response-claude", text: "completed" },
+      phase: "completed",
+      seq: 14,
+    });
+    expect(projected?.payload.voiceResponse).toBeUndefined();
+  });
 });

--- a/src/lib/runtime/engineHostEvents.ts
+++ b/src/lib/runtime/engineHostEvents.ts
@@ -1,5 +1,6 @@
 import type { RuntimeAttentionKind, RuntimeAttentionRequest, RuntimeEventInput } from "./contracts";
 import type { RuntimeEvent } from "./engineHost";
+import { terminalVoiceResponse } from "./voiceDelivery";
 
 type JsonObject = Record<string, unknown>;
 
@@ -41,7 +42,7 @@ function questionFrom(value: unknown): RuntimeAttentionRequest["question"] | nul
     : undefined;
   return {
     ...(text(source.header) ? { header: clipped(text(source.header)!, 256) } : {}),
-    prompt: clipped(prompt, 512),
+    "prompt": clipped(prompt, 512),
     ...(options?.length ? { options } : {}),
     ...(typeof source.multiSelect === "boolean" ? { multiSelect: source.multiSelect } : {}),
   };
@@ -118,7 +119,20 @@ export function projectEngineHostEvent(
     return { ...base, kind: "delta", payload: { conversationId, turnId: event.turnId, text: clipped(event.text, 8 * 1024) } };
   }
   if (event.kind === "item") {
-    return { ...base, kind: "item", payload: { conversationId, turnId: event.turnId, item: boundedValue(event.item), phase: event.phase } };
+    const voiceResponse = engine === "codex" && event.phase === "completed"
+      ? terminalVoiceResponse(event.item, `engine-host:${hostKey}:${event.seq}`)
+      : null;
+    return {
+      ...base,
+      kind: "item",
+      payload: {
+        conversationId,
+        turnId: event.turnId,
+        item: boundedValue(event.item),
+        phase: event.phase,
+        ...(voiceResponse ? { voiceResponse } : {}),
+      },
+    };
   }
   if (event.kind === "turn-ended") {
     return { ...base, kind: "turn-ended", payload: { conversationId, turnId: event.turnId, outcome: event.status } };
@@ -146,6 +160,25 @@ export function projectEngineHostEvent(
   }
   if (event.kind === "limits") {
     return { ...base, kind: "limits", payload: { conversationId, snapshot: boundedValue(event.snapshot) } };
+  }
+  if (event.kind === "realtime-delivery-progress") {
+    return {
+      ...base,
+      kind: "voice-delivery-progress",
+      payload: {
+        conversationId,
+        deliveryId: event.deliveryId,
+        responseIndex: event.responseIndex,
+        offset: event.offset,
+      },
+    };
+  }
+  if (event.kind === "realtime-delivery-acknowledged") {
+    return {
+      ...base,
+      kind: "voice-delivery-acknowledged",
+      payload: { conversationId, deliveryId: event.deliveryId },
+    };
   }
   return null;
 }

--- a/src/lib/runtime/eventStore.test.ts
+++ b/src/lib/runtime/eventStore.test.ts
@@ -23,6 +23,42 @@ test("runtime event store durably replays ordered events and ignores a partial t
   expect(fs.statSync(filename).mode & 0o777).toBe(0o600);
 });
 
+test("runtime event store durably replays realtime delivery progress and acknowledgement", () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-runtime-voice-delivery-"));
+  const store = new FileRuntimeEventStore(directory);
+  store.append("voice-thread", {
+    kind: "realtime-delivery-progress",
+    deliveryId: "delivery-one",
+    digest: "digest-one",
+    responseIndex: 1,
+    offset: 17,
+    seq: 1,
+  });
+  store.append("voice-thread", {
+    kind: "realtime-delivery-acknowledged",
+    deliveryId: "delivery-one",
+    digest: "digest-one",
+    seq: 2,
+  });
+
+  expect(new FileRuntimeEventStore(directory).load("voice-thread")).toEqual([
+    {
+      kind: "realtime-delivery-progress",
+      deliveryId: "delivery-one",
+      digest: "digest-one",
+      responseIndex: 1,
+      offset: 17,
+      seq: 1,
+    },
+    {
+      kind: "realtime-delivery-acknowledged",
+      deliveryId: "delivery-one",
+      digest: "digest-one",
+      seq: 2,
+    },
+  ]);
+});
+
 test("runtime event store repairs a crash tail after the production 942-record contiguous prefix", () => {
   const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-runtime-crash-tail-"));
   const filename = path.join(directory, "crash-tail.jsonl");

--- a/src/lib/runtime/eventStore.ts
+++ b/src/lib/runtime/eventStore.ts
@@ -156,6 +156,15 @@ function validEvent(value: unknown): value is RuntimeEvent {
         && (event.resolution === "answered" || event.resolution === "host-restarted" || event.resolution === "server-resolved");
     case "limits":
       return Object.hasOwn(event, "snapshot");
+    case "realtime-delivery-progress":
+      return nonEmptyString(event.deliveryId)
+        && nonEmptyString(event.digest)
+        && Number.isSafeInteger(event.responseIndex)
+        && (event.responseIndex as number) >= 0
+        && Number.isSafeInteger(event.offset)
+        && (event.offset as number) >= 0;
+    case "realtime-delivery-acknowledged":
+      return nonEmptyString(event.deliveryId) && nonEmptyString(event.digest);
     case "session-status":
       return (event.status === "active" || event.status === "idle" || event.status === "unhosted" || event.status === "dead")
         && (event.activeFlags === undefined

--- a/src/lib/runtime/realtimeControl.ts
+++ b/src/lib/runtime/realtimeControl.ts
@@ -1,5 +1,6 @@
 import { redactCodexHostDiagnostic } from "./codexAppServerHost";
 import { structuredDeliveryHostForConversation } from "./structuredDeliveryController";
+import type { RuntimeVoiceDelivery } from "./voiceDelivery";
 
 const MAX_SDP_BYTES = 512 * 1024;
 const MAX_SPEECH_BYTES = 8 * 1024;
@@ -7,6 +8,10 @@ const MAX_SPEECH_BYTES = 8 * 1024;
 interface RealtimeHost {
   startRealtimeWebRtc(sdp: string): Promise<{ sdp: string; realtimeSessionId: string | null }>;
   appendRealtimeSpeech(text: string): Promise<void>;
+  deliverRealtimeWorkerResponse?(delivery: RuntimeVoiceDelivery): Promise<{
+    deliveryId: string;
+    acknowledged: true;
+  }>;
   stopRealtime(): Promise<void>;
   /** Optional so an older or stubbed host still satisfies the contract; the
       `status` action simply reports no failure when it is absent (#664). */
@@ -69,6 +74,13 @@ export async function executeRealtimeControl(
       await host.appendRealtimeSpeech(text);
       return { status: 200, body: { ok: true } };
     }
+    if (request.action === "deliverWorkerResponse") {
+      if (typeof host.deliverRealtimeWorkerResponse !== "function") {
+        return { status: 409, body: { error: "the hosted realtime receiver does not support durable worker delivery" } };
+      }
+      const result = await host.deliverRealtimeWorkerResponse(request.delivery as RuntimeVoiceDelivery);
+      return { status: 200, body: { ok: true, ...result } };
+    }
     if (request.action === "stop") {
       await host.stopRealtime();
       return { status: 200, body: { ok: true } };
@@ -89,7 +101,7 @@ export async function executeRealtimeControl(
         },
       };
     }
-    return { status: 400, body: { error: "action must be start, appendSpeech, stop, or status" } };
+    return { status: 400, body: { error: "action must be start, appendSpeech, deliverWorkerResponse, stop, or status" } };
   } catch (error) {
     return { status: 409, body: { error: redactCodexHostDiagnostic(error) } };
   }

--- a/src/lib/runtime/voiceDelivery.test.ts
+++ b/src/lib/runtime/voiceDelivery.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  acknowledgeVoiceDelivery,
+  appendVoiceResponse,
+  completeVoiceTurn,
+  terminalVoiceResponse,
+  utf8ChunkAt,
+  type RuntimeVoiceDelivery,
+} from "./voiceDelivery";
+
+describe("canonical voice delivery state", () => {
+  test("keeps exact Unicode terminal content beyond both UI bounds and seals multi-item turns once", () => {
+    const firstText = `${"first🙂界".repeat(10_000)}\n`;
+    const secondText = `\u0301${"second🫶🏽".repeat(2_000)}`;
+    const first = terminalVoiceResponse(
+      { type: "agentMessage", id: "response-one", text: firstText },
+      "event-1",
+    );
+    const second = terminalVoiceResponse(
+      {
+        type: "message",
+        role: "assistant",
+        id: "response-two",
+        content: [
+          { type: "output_text", text: secondText.slice(0, 1) },
+          { type: "output_text", text: secondText.slice(1) },
+        ],
+      },
+      "event-2",
+    );
+    expect(first).toEqual({ responseId: "response-one", text: firstText });
+    expect(second).toEqual({ responseId: "response-two", text: secondText });
+
+    let deliveries: RuntimeVoiceDelivery[] = [];
+    deliveries = appendVoiceResponse(deliveries, "turn-one", first!);
+    deliveries = appendVoiceResponse(deliveries, "turn-one", second!);
+    deliveries = appendVoiceResponse(deliveries, "turn-one", first!);
+    deliveries = completeVoiceTurn(deliveries, "turn-one", "completed");
+    const replayed = completeVoiceTurn(deliveries, "turn-one", "completed");
+
+    expect(replayed).toEqual(deliveries);
+    expect(deliveries).toEqual([{
+      deliveryId: 'voice:["turn-one",["response-one","response-two"]]',
+      turnId: "turn-one",
+      responses: [
+        { responseId: "response-one", text: firstText },
+        { responseId: "response-two", text: secondText },
+      ],
+      ready: true,
+    }]);
+    expect(new TextEncoder().encode(deliveries[0]!.responses.map((response) => response.text).join("")).length)
+      .toBeGreaterThan(64 * 1024);
+  });
+
+  test("drops interrupted drafts and removes only the acknowledged stable delivery", () => {
+    const pending = completeVoiceTurn(
+      appendVoiceResponse([], "turn-complete", { responseId: "response", text: "done" }),
+      "turn-complete",
+      "completed",
+    );
+    const withDraft = appendVoiceResponse(pending, "turn-interrupted", {
+      responseId: "draft",
+      text: "unfinished",
+    });
+
+    expect(completeVoiceTurn(withDraft, "turn-interrupted", "interrupted")).toEqual(pending);
+    expect(acknowledgeVoiceDelivery(pending, pending[0]!.deliveryId)).toEqual([]);
+    expect(acknowledgeVoiceDelivery(pending, "unknown")).toEqual(pending);
+  });
+
+  test("chunks on Unicode scalar boundaries without changing ordered content", () => {
+    const source = `a🙂🫶🏽界e\u0301${"🌍".repeat(20)}`;
+    const chunks: string[] = [];
+    let offset = 0;
+    while (offset < source.length) {
+      const chunk = utf8ChunkAt(source, offset, 7)!;
+      chunks.push(chunk.text);
+      offset = chunk.nextOffset;
+    }
+    expect(chunks.join("")).toBe(source);
+    expect(chunks.every((chunk) => new TextEncoder().encode(chunk).length <= 7)).toBeTrue();
+    expect(chunks.some((chunk) => chunk.includes("\ufffd"))).toBeFalse();
+    expect(() => utf8ChunkAt("🙂", 1, 8)).toThrow("splits a Unicode scalar");
+  });
+});

--- a/src/lib/runtime/voiceDelivery.test.ts
+++ b/src/lib/runtime/voiceDelivery.test.ts
@@ -4,6 +4,7 @@ import {
   acknowledgeVoiceDelivery,
   appendVoiceResponse,
   completeVoiceTurn,
+  rememberAcknowledgedVoiceDelivery,
   terminalVoiceResponse,
   utf8ChunkAt,
   type RuntimeVoiceDelivery,
@@ -67,6 +68,28 @@ describe("canonical voice delivery state", () => {
     expect(completeVoiceTurn(withDraft, "turn-interrupted", "interrupted")).toEqual(pending);
     expect(acknowledgeVoiceDelivery(pending, pending[0]!.deliveryId)).toEqual([]);
     expect(acknowledgeVoiceDelivery(pending, "unknown")).toEqual(pending);
+  });
+
+  test("bounds durable acknowledgement identities and retires a replayed delivery", () => {
+    let acknowledged: string[] = [];
+    for (let index = 0; index < 300; index += 1) {
+      acknowledged = rememberAcknowledgedVoiceDelivery(acknowledged, `delivery-${index}`);
+    }
+    expect(acknowledged).toHaveLength(256);
+    expect(acknowledged[0]).toBe("delivery-44");
+    expect(acknowledged.at(-1)).toBe("delivery-299");
+
+    const replayed = appendVoiceResponse([], "turn-replayed", {
+      responseId: "response-replayed",
+      text: "already spoken",
+    });
+    const deliveryId = 'voice:["turn-replayed",["response-replayed"]]';
+    expect(completeVoiceTurn(
+      replayed,
+      "turn-replayed",
+      "completed",
+      rememberAcknowledgedVoiceDelivery(acknowledged, deliveryId),
+    )).toEqual([]);
   });
 
   test("chunks on Unicode scalar boundaries without changing ordered content", () => {

--- a/src/lib/runtime/voiceDelivery.ts
+++ b/src/lib/runtime/voiceDelivery.ts
@@ -15,6 +15,8 @@ export interface Utf8Chunk {
   nextOffset: number;
 }
 
+const MAX_ACKNOWLEDGED_VOICE_DELIVERIES = 256;
+
 function record(value: unknown): Record<string, unknown> | null {
   return value && typeof value === "object" && !Array.isArray(value)
     ? value as Record<string, unknown>
@@ -89,6 +91,28 @@ export function normalizeVoiceDeliveries(value: unknown): RuntimeVoiceDelivery[]
   });
 }
 
+export function normalizeAcknowledgedVoiceDeliveryIds(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  const ids: string[] = [];
+  for (const candidate of value) {
+    if (typeof candidate !== "string" || !candidate) continue;
+    const previous = ids.indexOf(candidate);
+    if (previous >= 0) ids.splice(previous, 1);
+    ids.push(candidate);
+  }
+  return ids.slice(-MAX_ACKNOWLEDGED_VOICE_DELIVERIES);
+}
+
+export function rememberAcknowledgedVoiceDelivery(
+  value: readonly string[] | null | undefined,
+  acknowledgedDeliveryId: string,
+): string[] {
+  return normalizeAcknowledgedVoiceDeliveryIds([
+    ...normalizeAcknowledgedVoiceDeliveryIds(value),
+    acknowledgedDeliveryId,
+  ]);
+}
+
 export function appendVoiceResponse(
   value: readonly RuntimeVoiceDelivery[] | null | undefined,
   turnId: string,
@@ -123,6 +147,7 @@ export function completeVoiceTurn(
   value: readonly RuntimeVoiceDelivery[] | null | undefined,
   turnId: string,
   outcome: string,
+  acknowledgedDeliveryIds?: readonly string[] | null,
 ): RuntimeVoiceDelivery[] {
   const deliveries = normalizeVoiceDeliveries(value);
   const index = deliveries.findIndex((delivery) => delivery.turnId === turnId);
@@ -131,6 +156,10 @@ export function completeVoiceTurn(
     return deliveries.filter((_, deliveryIndex) => deliveryIndex !== index);
   }
   if (deliveries[index]!.ready) return deliveries;
+  if (normalizeAcknowledgedVoiceDeliveryIds(acknowledgedDeliveryIds)
+    .includes(deliveries[index]!.deliveryId)) {
+    return deliveries.filter((_, deliveryIndex) => deliveryIndex !== index);
+  }
   return deliveries.map((delivery, deliveryIndex) =>
     deliveryIndex === index ? { ...delivery, ready: true } : delivery);
 }

--- a/src/lib/runtime/voiceDelivery.ts
+++ b/src/lib/runtime/voiceDelivery.ts
@@ -1,0 +1,182 @@
+export interface RuntimeVoiceResponse {
+  responseId: string;
+  text: string;
+}
+
+export interface RuntimeVoiceDelivery {
+  deliveryId: string;
+  turnId: string;
+  responses: RuntimeVoiceResponse[];
+  ready: boolean;
+}
+
+export interface Utf8Chunk {
+  text: string;
+  nextOffset: number;
+}
+
+function record(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : null;
+}
+
+function string(value: unknown): string {
+  return typeof value === "string" ? value : "";
+}
+
+function contentText(value: unknown): string {
+  if (typeof value === "string") return value;
+  if (!Array.isArray(value)) return "";
+  return value.map((part) => {
+    if (typeof part === "string") return part;
+    const content = record(part);
+    const type = string(content?.type);
+    return type === "text" || type === "input_text" || type === "output_text"
+      ? string(content?.text)
+      : "";
+  }).join("");
+}
+
+export function terminalVoiceResponse(
+  value: unknown,
+  fallbackResponseId: string,
+): RuntimeVoiceResponse | null {
+  const item = record(value);
+  if (!item) return null;
+  const message = record(item.message);
+  const type = string(item.type);
+  const role = string(item.role) || string(message?.role);
+  const assistant = type === "agentMessage"
+    || type === "agent_message"
+    || type === "assistant"
+    || (type === "message" && role === "assistant");
+  if (!assistant) return null;
+  const directText = typeof item.text === "string" ? item.text : "";
+  const text = directText || contentText(item.content) || contentText(message?.content);
+  if (!text) return null;
+  return {
+    responseId: string(item.id) || string(item.uuid) || string(message?.id) || fallbackResponseId,
+    text,
+  };
+}
+
+function deliveryId(turnId: string, responses: readonly RuntimeVoiceResponse[]): string {
+  return `voice:${JSON.stringify([turnId, responses.map((response) => response.responseId)])}`;
+}
+
+export function normalizeVoiceDeliveries(value: unknown): RuntimeVoiceDelivery[] {
+  if (!Array.isArray(value)) return [];
+  return value.flatMap((candidate) => {
+    const delivery = record(candidate);
+    const turnId = string(delivery?.turnId);
+    const responses = Array.isArray(delivery?.responses)
+      ? delivery.responses.flatMap((responseValue) => {
+        const response = record(responseValue);
+        const responseId = string(response?.responseId);
+        return responseId && typeof response?.text === "string"
+          ? [{ responseId, text: response.text }]
+          : [];
+      })
+      : [];
+    if (!turnId || responses.length === 0) return [];
+    return [{
+      deliveryId: deliveryId(turnId, responses),
+      turnId,
+      responses,
+      ready: delivery?.ready === true,
+    }];
+  });
+}
+
+export function appendVoiceResponse(
+  value: readonly RuntimeVoiceDelivery[] | null | undefined,
+  turnId: string,
+  response: RuntimeVoiceResponse,
+): RuntimeVoiceDelivery[] {
+  const deliveries = normalizeVoiceDeliveries(value);
+  const index = deliveries.findIndex((delivery) => delivery.turnId === turnId);
+  const current = index >= 0 ? deliveries[index]! : {
+    deliveryId: "",
+    turnId,
+    responses: [],
+    ready: false,
+  };
+  const responseIndex = current.responses.findIndex((candidate) =>
+    candidate.responseId === response.responseId);
+  const responses = responseIndex >= 0
+    ? current.responses.map((candidate, candidateIndex) =>
+      candidateIndex === responseIndex ? response : candidate)
+    : [...current.responses, response];
+  const next = {
+    deliveryId: deliveryId(turnId, responses),
+    turnId,
+    responses,
+    ready: current.ready,
+  };
+  if (index < 0) return [...deliveries, next];
+  return deliveries.map((delivery, deliveryIndex) =>
+    deliveryIndex === index ? next : delivery);
+}
+
+export function completeVoiceTurn(
+  value: readonly RuntimeVoiceDelivery[] | null | undefined,
+  turnId: string,
+  outcome: string,
+): RuntimeVoiceDelivery[] {
+  const deliveries = normalizeVoiceDeliveries(value);
+  const index = deliveries.findIndex((delivery) => delivery.turnId === turnId);
+  if (index < 0) return deliveries;
+  if (outcome !== "completed") {
+    return deliveries.filter((_, deliveryIndex) => deliveryIndex !== index);
+  }
+  if (deliveries[index]!.ready) return deliveries;
+  return deliveries.map((delivery, deliveryIndex) =>
+    deliveryIndex === index ? { ...delivery, ready: true } : delivery);
+}
+
+export function acknowledgeVoiceDelivery(
+  value: readonly RuntimeVoiceDelivery[] | null | undefined,
+  acknowledgedDeliveryId: string,
+): RuntimeVoiceDelivery[] {
+  const deliveries = normalizeVoiceDeliveries(value);
+  return deliveries.filter((delivery) => delivery.deliveryId !== acknowledgedDeliveryId);
+}
+
+export function utf8ChunkAt(
+  value: string,
+  offset: number,
+  maxBytes: number,
+): Utf8Chunk | null {
+  if (!Number.isInteger(offset) || offset < 0 || offset > value.length) {
+    throw new Error("voice delivery offset is invalid");
+  }
+  const firstUnit = value.charCodeAt(offset);
+  const previousUnit = value.charCodeAt(offset - 1);
+  if (offset > 0
+    && firstUnit >= 0xdc00
+    && firstUnit <= 0xdfff
+    && previousUnit >= 0xd800
+    && previousUnit <= 0xdbff) {
+    throw new Error("voice delivery offset splits a Unicode scalar");
+  }
+  if (!Number.isInteger(maxBytes) || maxBytes < 4) {
+    throw new Error("voice delivery chunk size is invalid");
+  }
+  if (offset === value.length) return null;
+  let nextOffset = offset;
+  let bytes = 0;
+  while (nextOffset < value.length) {
+    const codePoint = value.codePointAt(nextOffset)!;
+    const symbolBytes = codePoint <= 0x7f ? 1
+      : codePoint <= 0x7ff ? 2
+      : codePoint <= 0xffff ? 3
+      : 4;
+    if (nextOffset > offset && bytes + symbolBytes > maxBytes) break;
+    bytes += symbolBytes;
+    nextOffset += codePoint > 0xffff ? 2 : 1;
+  }
+  return nextOffset > offset
+    ? { text: value.slice(offset, nextOffset), nextOffset }
+    : null;
+}

--- a/src/runtime-host/journal.test.ts
+++ b/src/runtime-host/journal.test.ts
@@ -240,6 +240,7 @@ test("acknowledged voice delivery stays retired after reload and terminal replay
   expect(journal.snapshot().sessions[0]?.acknowledgedVoiceDeliveryIds).toEqual([
     delivered!.deliveryId,
   ]);
+  journal.compact(1);
   journal.close();
 
   const recovered = new RuntimeJournal(filename, { maxEvents: 100, now: () => 200 });

--- a/src/runtime-host/journal.test.ts
+++ b/src/runtime-host/journal.test.ts
@@ -108,6 +108,84 @@ test("producer cursor reports the highest durably acknowledged engine event", ()
   compacted.close();
 });
 
+test("canonical voice deliveries survive missed-running recovery and compaction until acknowledged", () => {
+  const dir = sandbox("voice-delivery-recovery");
+  const filename = path.join(dir, "events.sqlite");
+  const unicode = `${"🫶🏽界".repeat(12_000)}\nterminal`;
+  const journal = new RuntimeJournal(filename, { maxEvents: 100, now: () => 100 });
+  journal.append({
+    scope: runtimeScope("session", "conversation_voice"),
+    kind: "item",
+    payload: {
+      conversationId: "conversation_voice",
+      turnId: "turn-recovered",
+      phase: "completed",
+      item: { type: "agentMessage", id: "bounded", text: "bounded" },
+      voiceResponse: { responseId: "response-one", text: unicode },
+    },
+  });
+  journal.append({
+    scope: runtimeScope("session", "conversation_voice"),
+    kind: "item",
+    payload: {
+      conversationId: "conversation_voice",
+      turnId: "turn-recovered",
+      phase: "completed",
+      item: { type: "agentMessage", id: "bounded-two", text: "bounded" },
+      voiceResponse: { responseId: "response-two", text: "second" },
+    },
+  });
+  journal.append({
+    scope: runtimeScope("session", "conversation_voice"),
+    kind: "turn-ended",
+    payload: {
+      conversationId: "conversation_voice",
+      turnId: "turn-recovered",
+      outcome: "completed",
+    },
+  });
+  journal.compact(1);
+  journal.close();
+
+  const recovered = new RuntimeJournal(filename, { maxEvents: 100, now: () => 200 });
+  const delivery = recovered.snapshot().sessions[0]?.voiceDeliveries?.[0];
+  expect(delivery).toEqual({
+    deliveryId: 'voice:["turn-recovered",["response-one","response-two"]]',
+    turnId: "turn-recovered",
+    responses: [
+      { responseId: "response-one", text: unicode },
+      { responseId: "response-two", text: "second" },
+    ],
+    ready: true,
+  });
+  expect(new TextEncoder().encode(delivery!.responses[0]!.text).length).toBeGreaterThan(64 * 1024);
+
+  recovered.append({
+    scope: runtimeScope("session", "conversation_voice"),
+    kind: "voice-delivery-progress",
+    payload: {
+      conversationId: "conversation_voice",
+      deliveryId: delivery!.deliveryId,
+      responseIndex: 0,
+      offset: 8_192,
+    },
+  });
+  expect(recovered.snapshot().sessions[0]).toMatchObject({
+    revision: 4,
+    voiceDeliveries: [delivery],
+  });
+  recovered.append({
+    scope: runtimeScope("session", "conversation_voice"),
+    kind: "voice-delivery-acknowledged",
+    payload: {
+      conversationId: "conversation_voice",
+      deliveryId: delivery!.deliveryId,
+    },
+  });
+  expect(recovered.snapshot().sessions[0]?.voiceDeliveries).toEqual([]);
+  recovered.close();
+});
+
 test("snapshot exposes the canonical projected runtime model", () => {
   const dir = sandbox("canonical-snapshot");
   const journal = new RuntimeJournal(path.join(dir, "events.sqlite"), { maxEvents: 100, now: () => 100 });

--- a/src/runtime-host/journal.test.ts
+++ b/src/runtime-host/journal.test.ts
@@ -11,6 +11,7 @@ import { applyEvent, installSnapshot } from "@/components/runtime/runtimeModel";
 import type { Flow } from "@/lib/flows/types";
 import { UnixRuntimeHostClient } from "@/lib/runtime/client";
 import { runtimePresentationReceipt, runtimeScope } from "@/lib/runtime/contracts";
+import { projectEngineHostEvent } from "@/lib/runtime/engineHostEvents";
 import { structuredContentDigest, type StructuredImageRef } from "@/lib/runtime/structuredContent";
 
 import { RuntimeHost, RuntimeHostFence } from "./host";
@@ -183,6 +184,110 @@ test("canonical voice deliveries survive missed-running recovery and compaction 
     },
   });
   expect(recovered.snapshot().sessions[0]?.voiceDeliveries).toEqual([]);
+  recovered.close();
+});
+
+test("acknowledged voice delivery stays retired after reload and terminal replay while an undelivered response hydrates", () => {
+  const dir = sandbox("voice-delivery-reload");
+  const filename = path.join(dir, "events.sqlite");
+  const conversationId = "conversation_reload";
+  const firstHostKey = "codex:thread-before-reload";
+  const replayHostKey = "codex:thread-after-reload";
+  const deliveredItem = {
+    type: "agentMessage",
+    id: "response-delivered",
+    phase: "final_answer",
+    text: "Delivered once before reload 🫶🏽",
+  };
+  const appendProjected = (
+    journal: RuntimeJournal,
+    hostKey: string,
+    event: Parameters<typeof projectEngineHostEvent>[2],
+  ) => {
+    const projected = projectEngineHostEvent(conversationId, hostKey, event);
+    expect(projected).not.toBeNull();
+    return journal.append(projected!);
+  };
+
+  const journal = new RuntimeJournal(filename, { maxEvents: 100, now: () => 100 });
+  appendProjected(journal, firstHostKey, {
+    kind: "item",
+    turnId: "turn-delivered",
+    item: deliveredItem,
+    phase: "completed",
+    seq: 1,
+  });
+  appendProjected(journal, firstHostKey, {
+    kind: "turn-ended",
+    turnId: "turn-delivered",
+    status: "completed",
+    seq: 2,
+  });
+  const firstMount = installSnapshot(journal.snapshot());
+  const delivered = firstMount.sessions[conversationId]?.voiceDeliveries?.[0];
+  expect(delivered).toMatchObject({
+    turnId: "turn-delivered",
+    responses: [{ responseId: "response-delivered", text: deliveredItem.text }],
+    ready: true,
+  });
+  appendProjected(journal, firstHostKey, {
+    kind: "realtime-delivery-acknowledged",
+    deliveryId: delivered!.deliveryId,
+    digest: "delivered-digest",
+    seq: 3,
+  });
+  expect(journal.snapshot().sessions[0]?.voiceDeliveries).toEqual([]);
+  expect(journal.snapshot().sessions[0]?.acknowledgedVoiceDeliveryIds).toEqual([
+    delivered!.deliveryId,
+  ]);
+  journal.close();
+
+  const recovered = new RuntimeJournal(filename, { maxEvents: 100, now: () => 200 });
+  appendProjected(recovered, replayHostKey, {
+    kind: "item",
+    turnId: "turn-delivered",
+    item: deliveredItem,
+    phase: "completed",
+    seq: 1,
+  });
+  appendProjected(recovered, replayHostKey, {
+    kind: "turn-ended",
+    turnId: "turn-delivered",
+    status: "completed",
+    seq: 2,
+  });
+  appendProjected(recovered, replayHostKey, {
+    kind: "item",
+    turnId: "turn-undelivered",
+    item: {
+      type: "agentMessage",
+      id: "response-undelivered",
+      phase: "final_answer",
+      text: "Genuinely undelivered after reload 界",
+    },
+    phase: "completed",
+    seq: 3,
+  });
+  appendProjected(recovered, replayHostKey, {
+    kind: "turn-ended",
+    turnId: "turn-undelivered",
+    status: "completed",
+    seq: 4,
+  });
+
+  const reloadMount = installSnapshot(recovered.snapshot());
+  expect(reloadMount.sessions[conversationId]?.acknowledgedVoiceDeliveryIds).toEqual([
+    delivered!.deliveryId,
+  ]);
+  expect(reloadMount.sessions[conversationId]?.voiceDeliveries).toEqual([{
+    deliveryId: 'voice:["turn-undelivered",["response-undelivered"]]',
+    turnId: "turn-undelivered",
+    responses: [{
+      responseId: "response-undelivered",
+      text: "Genuinely undelivered after reload 界",
+    }],
+    ready: true,
+  }]);
   recovered.close();
 });
 

--- a/src/runtime-host/journal.ts
+++ b/src/runtime-host/journal.ts
@@ -32,6 +32,12 @@ import {
   type ViewerDeploymentStatus,
 } from "@/lib/runtime/contracts";
 import {
+  acknowledgeVoiceDelivery,
+  appendVoiceResponse,
+  completeVoiceTurn,
+  normalizeVoiceDeliveries,
+} from "@/lib/runtime/voiceDelivery";
+import {
   appendRuntimeLiveTurnDelta,
   completeRuntimeLiveTurnItem,
   normalizeRuntimeLiveTurn,
@@ -235,6 +241,9 @@ function baseSession(id: string, payload: Record<string, unknown>, revision: num
       : null,
     drift: payload.drift && typeof payload.drift === "object" ? payload.drift as RuntimeSession["drift"] : null,
     ...(liveTurn ? { liveTurn } : {}),
+    ...(Array.isArray(payload.voiceDeliveries)
+      ? { voiceDeliveries: normalizeVoiceDeliveries(payload.voiceDeliveries) }
+      : {}),
   };
 }
 
@@ -1558,12 +1567,20 @@ export class RuntimeJournal {
     }
     if (event.kind === "turn-started" || event.kind === "turn-ended") {
       const previous = this.entity<RuntimeSession>("session", scope.id) ?? baseSession(scope.id, {}, 0);
+      const turnId = typeof payload.turnId === "string" ? payload.turnId : null;
       const next: RuntimeSession = {
         ...previous,
         revision: event.revision,
         turn: event.kind === "turn-started" ? "running" : "idle",
-        activeTurnId: event.kind === "turn-started" && typeof payload.turnId === "string" ? payload.turnId : null,
+        activeTurnId: event.kind === "turn-started" && turnId ? turnId : null,
         liveTurn: previous.liveTurn,
+        ...(previous.voiceDeliveries
+          ? {
+            voiceDeliveries: event.kind === "turn-ended" && turnId
+              ? completeVoiceTurn(previous.voiceDeliveries, turnId, typeof payload.outcome === "string" ? payload.outcome : "")
+              : previous.voiceDeliveries,
+          }
+          : {}),
       };
       this.upsertEntity("session", scope.id, event.revision, next, event.seq);
       return;
@@ -1589,10 +1606,40 @@ export class RuntimeJournal {
       const liveTurn = payload.phase === "completed"
         ? completeRuntimeLiveTurnItem(previous.liveTurn, turnId, payload.item, event.recorded_at)
         : previous.liveTurn;
+      const response = record(payload.voiceResponse);
+      const voiceDeliveries = payload.phase === "completed"
+        && typeof response.responseId === "string"
+        && typeof response.text === "string"
+        ? appendVoiceResponse(previous.voiceDeliveries, turnId, {
+          responseId: response.responseId,
+          text: response.text,
+        })
+        : previous.voiceDeliveries;
       this.upsertEntity("session", scope.id, event.revision, {
         ...previous,
         revision: event.revision,
         liveTurn,
+        ...(voiceDeliveries ? { voiceDeliveries } : {}),
+      }, event.seq);
+      return;
+    }
+    if (event.kind === "voice-delivery-acknowledged") {
+      const previous = this.entity<RuntimeSession>("session", scope.id) ?? baseSession(scope.id, {}, 0);
+      this.upsertEntity("session", scope.id, event.revision, {
+        ...previous,
+        revision: event.revision,
+        voiceDeliveries: acknowledgeVoiceDelivery(
+          previous.voiceDeliveries,
+          typeof payload.deliveryId === "string" ? payload.deliveryId : "",
+        ),
+      }, event.seq);
+      return;
+    }
+    if (event.kind === "voice-delivery-progress") {
+      const previous = this.entity<RuntimeSession>("session", scope.id) ?? baseSession(scope.id, {}, 0);
+      this.upsertEntity("session", scope.id, event.revision, {
+        ...previous,
+        revision: event.revision,
       }, event.seq);
       return;
     }

--- a/src/runtime-host/journal.ts
+++ b/src/runtime-host/journal.ts
@@ -35,7 +35,9 @@ import {
   acknowledgeVoiceDelivery,
   appendVoiceResponse,
   completeVoiceTurn,
+  normalizeAcknowledgedVoiceDeliveryIds,
   normalizeVoiceDeliveries,
+  rememberAcknowledgedVoiceDelivery,
 } from "@/lib/runtime/voiceDelivery";
 import {
   appendRuntimeLiveTurnDelta,
@@ -243,6 +245,13 @@ function baseSession(id: string, payload: Record<string, unknown>, revision: num
     ...(liveTurn ? { liveTurn } : {}),
     ...(Array.isArray(payload.voiceDeliveries)
       ? { voiceDeliveries: normalizeVoiceDeliveries(payload.voiceDeliveries) }
+      : {}),
+    ...(Array.isArray(payload.acknowledgedVoiceDeliveryIds)
+      ? {
+        acknowledgedVoiceDeliveryIds: normalizeAcknowledgedVoiceDeliveryIds(
+          payload.acknowledgedVoiceDeliveryIds,
+        ),
+      }
       : {}),
   };
 }
@@ -1577,7 +1586,12 @@ export class RuntimeJournal {
         ...(previous.voiceDeliveries
           ? {
             voiceDeliveries: event.kind === "turn-ended" && turnId
-              ? completeVoiceTurn(previous.voiceDeliveries, turnId, typeof payload.outcome === "string" ? payload.outcome : "")
+              ? completeVoiceTurn(
+                previous.voiceDeliveries,
+                turnId,
+                typeof payload.outcome === "string" ? payload.outcome : "",
+                previous.acknowledgedVoiceDeliveryIds,
+              )
               : previous.voiceDeliveries,
           }
           : {}),
@@ -1625,12 +1639,17 @@ export class RuntimeJournal {
     }
     if (event.kind === "voice-delivery-acknowledged") {
       const previous = this.entity<RuntimeSession>("session", scope.id) ?? baseSession(scope.id, {}, 0);
+      const deliveryId = typeof payload.deliveryId === "string" ? payload.deliveryId : "";
       this.upsertEntity("session", scope.id, event.revision, {
         ...previous,
         revision: event.revision,
         voiceDeliveries: acknowledgeVoiceDelivery(
           previous.voiceDeliveries,
-          typeof payload.deliveryId === "string" ? payload.deliveryId : "",
+          deliveryId,
+        ),
+        acknowledgedVoiceDeliveryIds: rememberAcknowledgedVoiceDelivery(
+          previous.acknowledgedVoiceDeliveryIds,
+          deliveryId,
         ),
       }, event.seq);
       return;


### PR DESCRIPTION
## Summary

- deliver each completed worker response to Live Mode exactly once
- preserve full responses across reconnect, compact, and hydration paths
- add durable acknowledgement, deduplication, and bounded retry behavior
- preserve ambient audio ownership across conversation cards

## Verification

- 177 focused realtime and voice tests passed
- TypeScript passed
- changed-file ESLint passed
- privacy publication gates passed
- full base-to-head review: NO FINDINGS

Closes #729
