### PR TITLE
fix(realtime): give voice transcript lines a stable identity

### DIFF
--- a/src/lib/realtime/codexRealtimeClient.transport.dom.test.ts
+++ b/src/lib/realtime/codexRealtimeClient.transport.dom.test.ts
@@ -463,3 +463,71 @@ test("closing the page hangs up so the account's realtime slot is not stranded",
 
   await client.stop();
 });
+
+/**
+ * A delegating turn talks and streams worker progress at the same time, so
+ * progress ticks and assistant deltas arrive interleaved. Position-based line
+ * merging ("update the last line if it has my role and is not final") loses
+ * the progress line the moment anything else is appended after it, and the
+ * next tick — which carries the WHOLE accumulated text, not a delta — lands as
+ * a new line. The operator sees the same answer redrawn once per tick as a
+ * ladder of ever-longer prefixes, with the agent's own deltas shredded into
+ * one line each between them.
+ */
+test("interleaved progress and assistant deltas keep one line each", async () => {
+  globalThis.fetch = (async () => jsonResponse(200, { ok: true, sdp: "v=0\r\nanswer" })) as unknown as typeof fetch;
+  const client = codexRealtimeClient("conversation_interleaved");
+  await client.start();
+  const peer = StubPeerConnection.latest!;
+  peer.channel.onopen?.();
+  expect(client.getSnapshot().phase).toBe("live");
+
+  const words = ["Yes", " the", " fix", " works", " well"];
+  let spoken = "";
+  let progress = "";
+  for (const word of words) {
+    spoken += word;
+    progress += word;
+    peer.channel.onmessage?.({ data: JSON.stringify({ type: "output_transcript.added", item: { text: word } }) });
+    client.updateWorkerProgress("turn-interleaved", progress, true);
+  }
+  peer.channel.onmessage?.({ data: JSON.stringify({ type: "turn.done", turn: { role: "assistant", transcript: spoken } }) });
+
+  const lines = client.getSnapshot().lines;
+  expect(lines.filter((line) => line.role === "progress")).toHaveLength(1);
+  expect(lines.filter((line) => line.role === "assistant")).toHaveLength(1);
+  expect(lines.map((line) => [line.role, line.text, line.final])).toEqual([
+    ["assistant", spoken, true],
+    ["progress", progress, false],
+  ]);
+
+  await client.stop();
+});
+
+/**
+ * `workerRunning` goes false the moment the turn ends while the accumulated
+ * text is still on screen, which finalizes the progress line. Any later tick
+ * for the SAME turn — a trailing update, or the effect re-firing when the call
+ * phase changes — must reuse that turn's line instead of starting a new one.
+ */
+test("a finalized progress line is reused by later ticks of the same turn", async () => {
+  globalThis.fetch = (async () => jsonResponse(200, { ok: true, sdp: "v=0\r\nanswer" })) as unknown as typeof fetch;
+  const client = codexRealtimeClient("conversation_progress_refinal");
+  await client.start();
+  const peer = StubPeerConnection.latest!;
+  peer.channel.onopen?.();
+
+  client.updateWorkerProgress("turn-a", "partial answer", true);
+  client.updateWorkerProgress("turn-a", "partial answer complete", false);
+  // Replay of the same accumulated text (phase change re-fires the effect).
+  client.updateWorkerProgress("turn-a", "partial answer complete", false);
+  // A different turn is a different line.
+  client.updateWorkerProgress("turn-b", "next answer", true);
+
+  expect(client.getSnapshot().lines.map((line) => [line.role, line.text, line.final])).toEqual([
+    ["progress", "partial answer complete", true],
+    ["progress", "next answer", false],
+  ]);
+
+  await client.stop();
+});

--- a/src/lib/realtime/codexRealtimeClient.ts
+++ b/src/lib/realtime/codexRealtimeClient.ts
@@ -7,6 +7,9 @@ import {
 
 export type CodexRealtimePhase = "idle" | "connecting" | "live" | "stopping" | "error";
 export type CodexRealtimeRole = "user" | "assistant" | "progress";
+/** The two roles that stream a turn. Worker progress is excluded: its line is
+    addressed by turn id, not by who is currently holding the floor. */
+type TranscriptSpeaker = Exclude<CodexRealtimeRole, "progress">;
 
 export interface CodexRealtimeLine {
   id: string;
@@ -146,6 +149,11 @@ class CodexRealtimeClient {
   private workerDeliveryWakeEpoch: number | null = null;
   private unloadHangup: (() => void) | null = null;
   private lineSequence = 0;
+  /** The line each speaker is still streaming into, by line id. Held here
+      rather than read off the end of the list because a delegating turn
+      interleaves both speakers with worker progress, so "the last line" is
+      almost never the line an update belongs to. */
+  private readonly openTranscriptLines = new Map<TranscriptSpeaker, string>();
   private epoch = 0;
 
   constructor(readonly conversationId: string) {}
@@ -294,7 +302,13 @@ class CodexRealtimeClient {
 
   updateWorkerProgress(turnId: string, text: string, running: boolean): void {
     if (!turnId || !text || this.snapshot.phase !== "live") return;
-    this.upsertLine("progress", text.slice(-MAX_LINE_CHARS), !running);
+    /* One line per turn, addressed by turn id. Every tick carries the whole
+       accumulated answer rather than a delta, so a tick that cannot find its
+       own line redraws the entire text as a new one — the operator sees the
+       answer once per tick as a ladder of ever-longer prefixes. The turn id
+       also survives the line being finalized when the turn ends, so a trailing
+       tick reuses it instead of opening a second copy. */
+    this.writeLine(`progress:${turnId}`, "progress", text, !running, "replace");
   }
 
   reconcileWorkerDeliveries(value: readonly RuntimeVoiceDelivery[] | null | undefined): void {
@@ -356,7 +370,7 @@ class CodexRealtimeClient {
     }
     const event = parseCodexRealtimeEvent(value);
     if (event.kind === "transcript") {
-      this.upsertLine(event.role, event.text, event.final);
+      this.writeTranscript(event.role, event.text, event.final);
     } else if (event.kind === "delegation") {
       return;
     } else if (event.kind === "error") {
@@ -364,14 +378,41 @@ class CodexRealtimeClient {
     }
   }
 
-  private upsertLine(role: CodexRealtimeRole, text: string, final: boolean): void {
+  /**
+   * Route a speaker's text to the line that speaker currently owns. Barge-in
+   * puts the operator's turn after the agent's half-finished one, and worker
+   * progress lands between the two, so position says nothing about ownership.
+   * Whoever speaks closes the other's line: an interrupted turn that resumes
+   * opens a fresh line instead of growing the one it abandoned.
+   */
+  private writeTranscript(role: TranscriptSpeaker, text: string, final: boolean): void {
+    this.openTranscriptLines.delete(role === "user" ? "assistant" : "user");
+    const key = this.openTranscriptLines.get(role) ?? `${role}:${++this.lineSequence}`;
+    if (final) this.openTranscriptLines.delete(role);
+    else this.openTranscriptLines.set(role, key);
+    /* A final event carries the complete turn, a streamed one only the new
+       fragment — except on backends that resend the whole text, which the
+       prefix check below absorbs. */
+    this.writeLine(key, role, text, final, final ? "replace" : "append");
+  }
+
+  private writeLine(
+    key: string,
+    role: CodexRealtimeRole,
+    text: string,
+    final: boolean,
+    mode: "replace" | "append",
+  ): void {
     const lines = [...this.snapshot.lines];
-    const previous = lines.at(-1);
-    if (previous?.role === role && !previous.final) {
-      const combined = final || text.startsWith(previous.text) ? text : `${previous.text}${text}`;
-      lines[lines.length - 1] = { ...previous, text: combined.slice(-MAX_LINE_CHARS), final };
+    const index = lines.findIndex((line) => line.id === key);
+    if (index < 0) {
+      lines.push({ id: key, role, text: text.slice(-MAX_LINE_CHARS), final });
     } else {
-      lines.push({ id: `${Date.now()}-${++this.lineSequence}`, role, text: text.slice(-MAX_LINE_CHARS), final });
+      const previous = lines[index]!;
+      const combined = mode === "replace" || text.startsWith(previous.text)
+        ? text
+        : `${previous.text}${text}`;
+      lines[index] = { ...previous, text: combined.slice(-MAX_LINE_CHARS), final };
     }
     this.update({ lines: lines.slice(-MAX_LINES) });
   }
@@ -412,6 +453,9 @@ class CodexRealtimeClient {
   }
 
   private cleanupTransport(): void {
+    /* No line survives a dead transport as "still streaming": the next call
+       opens its own rather than appending to a turn nobody can finish. */
+    this.openTranscriptLines.clear();
     if (this.unloadHangup) window.removeEventListener("pagehide", this.unloadHangup);
     this.unloadHangup = null;
     this.events?.close();


### PR DESCRIPTION
## Problem

In a Live Mode call with a delegating turn, the transcript panel repeats the
same answer once per progress tick as a ladder of ever-longer prefixes, and the
agent's own speech is shredded into one line per delta between them. A complete
sentence then appears a final time after its own fragments.

This is **not** the delivery duplication fixed in #729. That governs what
reaches the voice model; the audio is spoken once. This governs what the panel
draws, and it reproduces on a build that already contains the #729 fix.

## Cause

`CodexRealtimeClient.upsertLine` picked its target by position:

```ts
const previous = lines.at(-1);
if (previous?.role === role && !previous.final) { /* merge */ }
else { lines.push({ id: `${Date.now()}-${++this.lineSequence}`, ... }) }
```

Lines carried no identity, which produced two independent generators:

1. **Interleaving.** `updateWorkerProgress` passes the whole accumulated turn
   text on every tick, not a delta. Any assistant delta landing between two
   ticks displaces the progress line from the end, so the next tick pushes the
   full text again as a new line. Symmetrically, each assistant delta following
   a progress line opens its own line.
2. **Finalization.** `final = !running` marks the progress line final the moment
   the turn ends; no later tick for that turn can ever merge again. `turn.done`
   does the same to the assistant line, which is why the complete sentence is
   drawn once more after its fragments.

## Fix

Address lines by identity rather than position.

- Worker progress is one line per **turn id**. The key survives finalization and
  any number of lines appended after it, so a trailing tick or an effect
  re-firing on a phase change reuses the same line.
- Transcript text goes to the line its speaker currently owns, tracked
  independently of array position. Whoever speaks closes the other speaker's
  line, so barge-in still opens a fresh line instead of growing an abandoned
  turn — the existing barge-in expectations are unchanged.

## Tests

Two regressions, both RED before the change (the interleaved case produced 5
progress lines where 1 is correct):

- `interleaved progress and assistant deltas keep one line each`
- `a finalized progress line is reused by later ticks of the same turn`

The existing single-turn progress test passed throughout — it never interleaved,
which is why this shipped.

## Verification

- 22 focused realtime + voice-panel tests pass
- TypeScript clean
- ESLint clean on changed files
- privacy publication gate PASS

## Base

Branched from the **deployed** commit on `integrate/voice-reload-focus-20260727`
rather than `main`, because production currently runs that branch and `main`
contains none of the nine voice/audio commits behind it. Reconciling
`main` with production is tracked separately.
