### PR TITLE
fix(ci): pin the commit-message fixture repo to the main branch

### DIFF
--- a/scripts/privacy-publication-gate.test.ts
+++ b/scripts/privacy-publication-gate.test.ts
@@ -2674,7 +2674,7 @@ describe("commitMessageFindings", () => {
   function gitRepo(): string {
     const repo = mkdtempSync(join(tmpdir(), "llv-privacy-commit-"));
     temporaryDirectories.push(repo);
-    Bun.spawnSync({ cmd: ["git", "init", repo], stderr: "pipe", stdout: "pipe" });
+    Bun.spawnSync({ cmd: ["git", "init", "-b", "main", repo], stderr: "pipe", stdout: "pipe" });
     Bun.spawnSync({ cmd: ["git", "-C", repo, "config", "user.email", "test@example.com"], stderr: "pipe", stdout: "pipe" });
     Bun.spawnSync({ cmd: ["git", "-C", repo, "config", "user.name", "Test"], stderr: "pipe", stdout: "pipe" });
     writeFileSync(join(repo, "init.txt"), "init");


### PR DESCRIPTION
Fixes #733.

## Cause

The `commitMessageFindings` fixtures build a throwaway repository with
`git init` and then ask for findings across `main..HEAD`:

```ts
Bun.spawnSync({ cmd: ["git", "init", repo], ... });
// ...
const findings = commitMessageFindings(repo, "main");
```

`git init` names the initial branch after `init.defaultBranch`. On a machine
configured with `main` the fixture works; on a GitHub runner the default is
`master`, so `main` does not exist, the range resolves against nothing, and
five assertions collapse — including `passes when commit messages contain no
sensitive data`, which is why the failure did not look like a simple
"scanner found nothing".

## Why every PR was red

The failing step runs from the **trusted** checkout of the default branch:

```yaml
- name: Verify privacy gate behavior
  working-directory: trusted   # ref: default_branch
  run: bun test scripts/privacy-publication-gate.test.ts
```

Its result never depended on the pull request under review. That has two
consequences worth stating plainly:

1. Every open PR has been red since the fixtures landed in #722, regardless of
   content. The last green run was 2026-07-26T22:06, before that merge.
2. **This PR will also show the check red.** It cannot do otherwise — the step
   is still running the default branch's copy. The check goes green for every
   PR once this is on the default branch, and not before. Merging it therefore
   needs a deliberate override.

## Fix

Create the fixture repository on `main` explicitly, so the comparison branch
exists regardless of host git configuration.

## Verification

Suite run with `init.defaultBranch=master` to reproduce the runner:

| | result |
|---|---|
| before, runner-like default | 105 pass / **5 fail** — matches CI exactly |
| after, runner-like default | 110 pass / 0 fail |
| after, ordinary default | 110 pass / 0 fail |

The seeded-sensitive-message cases still detect their findings, so the check
keeps its protective intent rather than being silenced.
