### PR TITLE
Deterministic builder-to-review handoff: publish the head, relay to structured implementers

### DIFF
--- a/src/lib/flows/engine.test.ts
+++ b/src/lib/flows/engine.test.ts
@@ -14,7 +14,7 @@ let relayDeliveries = 0;
 let releaseRelayDeliveries: Array<() => void> = [];
 
 process.env.LLV_STATE_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "llv-flow-engine-test-"));
-const { captureReviewHead, newRound, tickFlow, tickFlows, persistTickFlows, flowTickBase, reviewerLaunchPersisted, abandonLaunch, adoptSyntheticLaunchTakeover, recordHeadlessLaunch, relayFixOrPark, reserveReviewerSpawn, setRelayDeliveryForTest } = await import("./engine");
+const { captureReviewHead, newRound, tickFlow, tickFlows, persistTickFlows, flowTickBase, reviewerLaunchPersisted, abandonLaunch, adoptSyntheticLaunchTakeover, recordHeadlessLaunch, relayFixOrPark, reserveReviewerSpawn, sendToImplementer, setRelayDeliveryForTest } = await import("./engine");
 const { loadFlows, outputPathFor, saveFlows, stderrPathFor, stdoutPathFor } = await import("./store");
 
 afterAll(() => {
@@ -1613,4 +1613,70 @@ test("a pane-mode Claude review launch under structured transport parks without 
     else process.env.LLV_CLAUDE_HOME = previousClaudeHome;
     fs.rmSync(cwd, { recursive: true, force: true });
   }
+});
+
+/* --- the review verdict must reach a pane-less structured implementer ------ */
+
+function structuredImplementer(name: string) {
+  const implementerPath = path.join(process.env.LLV_STATE_DIR!, `${name}.jsonl`);
+  fs.writeFileSync(implementerPath, "");
+  const conversation = agentRegistry().ensureConversation("claude", implementerPath, null);
+  const flow = {
+    id: `flow-${name}`,
+    cwd: "/repo",
+    implementerPath,
+    implementerConversationId: conversation.id,
+  } as unknown as Flow;
+  return { flow, implementerPath, conversationId: conversation.id, entries: new Map([[implementerPath, entryFor(implementerPath, 1)]]) };
+}
+
+test("a review relay reaches a pane-less structured implementer instead of dying on the tmux ladder", async () => {
+  const subject = structuredImplementer("structured-implementer");
+  const enqueued: Array<{ text: string; conversationId?: string | null }> = [];
+  const legacy: string[] = [];
+
+  const target = await sendToImplementer(subject.flow, subject.entries, "REQUEST_CHANGES: fix the fence", {
+    recover: async () => ({ target: null, path: subject.implementerPath, conversationId: subject.conversationId, spawned: false }),
+    enqueueStructured: async (request) => {
+      enqueued.push({ text: request.text, conversationId: request.conversationId });
+      return { ok: true, structured: true, target: null, outcome: "queued", operationId: "op-relay", receipt: {} as never };
+    },
+    /* The legacy ladder is what refused flow 0d1364f8's relay outright. If the
+       structured branch is ever skipped for a structured implementer, this
+       records the regression rather than letting it pass silently. */
+    deliver: async () => {
+      legacy.push("tmux");
+      return { ok: false, outcome: "failed", error: "structured transport prohibits legacy tmux Claude launches", status: 409 };
+    },
+  });
+
+  expect(target).toBe(subject.implementerPath);
+  expect(enqueued).toEqual([{ text: "REQUEST_CHANGES: fix the fence", conversationId: subject.conversationId }]);
+  expect(legacy).toEqual([]);
+});
+
+test("a structured relay that cannot be owned surfaces its reason instead of reporting delivery", async () => {
+  const subject = structuredImplementer("unowned-implementer");
+
+  await expect(sendToImplementer(subject.flow, subject.entries, "relay", {
+    recover: async () => ({ target: null, path: subject.implementerPath, conversationId: subject.conversationId, spawned: false }),
+    enqueueStructured: async () => ({ ok: false, structured: true, outcome: "failed", error: "runtime host is unavailable", status: 503 }),
+    deliver: async () => ({ ok: true, outcome: "delivered-to-live", target: "%7" }),
+  })).rejects.toThrow("runtime host is unavailable");
+});
+
+test("a conversation with no structured host falls through to the legacy transcript host", async () => {
+  const subject = structuredImplementer("legacy-implementer");
+  let structuredAttempted = false;
+
+  /* This fixture has no resume spec, so the legacy ladder is entered and stops
+     at its first gate. That is the evidence the test wants: the relay left the
+     structured branch rather than enqueueing against a host it never recovered,
+     so legacy pane-hosted flows keep exactly today's behavior. */
+  await expect(sendToImplementer(subject.flow, subject.entries, "relay text", {
+    recover: async () => null,
+    enqueueStructured: async () => { structuredAttempted = true; return null; },
+  })).rejects.toThrow("implementer session cannot be resumed");
+
+  expect(structuredAttempted).toBe(false);
 });

--- a/src/lib/flows/engine.ts
+++ b/src/lib/flows/engine.ts
@@ -11,6 +11,8 @@ import { sessionKeyFromTranscript } from "@/lib/agent/sessionKey";
 import { resolveSpawnedTranscriptPath } from "@/lib/agent/spawnedTranscript";
 import { headCwd } from "@/lib/agent/transcript";
 import { isNativeCodexSubagentTranscript } from "@/lib/scanner/codexNative";
+import { enqueueStructuredMessage } from "@/lib/runtime/structuredMessageDelivery";
+import { recoverDeadStructuredConversation } from "@/lib/runtime/structuredRecovery";
 import { isShellCommand } from "@/lib/status";
 import { killPane, paneInfo, spawnAgentWithPrompt } from "@/lib/tmux";
 import type { FileEntry } from "@/lib/types";
@@ -264,9 +266,47 @@ function currentConversationPath(conversationId: string | null | undefined, fall
   return agentRegistry().canonicalPath(fallback);
 }
 
-export async function sendToImplementer(flow: Flow, entriesByPath: Map<string, FileEntry>, text: string): Promise<string> {
+export interface RelayDeliveryOverrides {
+  recover?: typeof recoverDeadStructuredConversation;
+  enqueueStructured?: typeof enqueueStructuredMessage;
+  deliver?: typeof deliverToTranscriptHost;
+}
+
+export async function sendToImplementer(
+  flow: Flow,
+  entriesByPath: Map<string, FileEntry>,
+  text: string,
+  overrides: RelayDeliveryOverrides = {},
+): Promise<string> {
   const entry = entriesByPath.get(currentConversationPath(flow.implementerConversationId, flow.implementerPath));
   if (!entry) throw new Error("implementer transcript is missing from scanner");
+  /* Structured hosts first, exactly as deliverConversationMessage does. The
+     legacy tmux ladder below refuses a pane-less Claude host outright
+     ("structured transport prohibits legacy tmux Claude launches"), so a relay
+     that only knew that ladder could not hand a finished review back to a
+     structured implementer: flow 0d1364f8 held a real round-1 verdict and
+     paused in `relaying` with nowhere to deliver it. The recovery probe is the
+     same gate the canonical send path uses — it returns null whenever the
+     conversation is not structured, which leaves legacy pane flows untouched. */
+  const registry = agentRegistry();
+  const conversation = flow.implementerConversationId?.startsWith("conversation_")
+    ? registry.conversation(flow.implementerConversationId as `conversation_${string}`)
+    : registry.conversationForPath(entry.path);
+  if (conversation) {
+    const recovered = await (overrides.recover ?? recoverDeadStructuredConversation)(
+      { path: entry.path, conversationId: conversation.id },
+      { registry },
+    );
+    if (recovered) {
+      const structured = await (overrides.enqueueStructured ?? enqueueStructuredMessage)(
+        { path: recovered.path, conversationId: recovered.conversationId, text },
+        { registry: () => registry },
+      );
+      if (!structured) throw new Error("structured delivery ownership is unavailable");
+      if (!structured.ok) throw new Error(structured.error);
+      return recovered.path;
+    }
+  }
   const spec = resumeSpecFor(entry.root, entry.path, {
     model: entry.launchModel ?? entry.model,
     effort: entry.effort,
@@ -275,7 +315,7 @@ export async function sendToImplementer(flow: Flow, entriesByPath: Map<string, F
     plugins: agentRegistry().launchProfileForPath(entry.path)?.plugins,
   });
   if (!spec) throw new Error("implementer session cannot be resumed");
-  const outcome = await deliverToTranscriptHost({ entry, spec, payload: text });
+  const outcome = await (overrides.deliver ?? deliverToTranscriptHost)({ entry, spec, payload: text });
   if (!outcome.ok) throw new Error(outcome.error);
   return entry.path;
 }

--- a/src/lib/pipelines/engine.test.ts
+++ b/src/lib/pipelines/engine.test.ts
@@ -117,6 +117,9 @@ function harness() {
       if (args[0] === "rev-parse" && args[1] === "--verify") return { code: 0, stdout: `${ORIGIN_MAIN_SHA}\n`, stderr: "" };
       if (args[0] === "rev-parse" && args[1] === "--abbrev-ref") return { code: 0, stdout: "main\n", stderr: "" };
       if (args[0] === "branch" && args[1] === "--show-current") return { code: 0, stdout: `${loadPipelines()[0]?.branch ?? ""}\n`, stderr: "" };
+      /* Review ingress requires a publishable remote, so the default repo has
+         one. A test that needs the no-origin case overrides this. */
+      if (args[0] === "remote" && args[1] === "get-url") return { code: 0, stdout: "git@example.invalid:owner/repo.git\n", stderr: "" };
       if (args[0] === "ls-remote") {
         const branch = loadPipelines()[0]?.branch ?? "pipeline/test";
         return { code: 0, stdout: `${ORIGIN_MAIN_SHA}\trefs/heads/${branch}\n`, stderr: "" };
@@ -1442,9 +1445,16 @@ function countDurableReads(h: ReturnType<typeof harness>): () => number {
 
 function pinStageHead(h: ReturnType<typeof harness>) {
   const baseExec = h.ports.exec;
-  h.ports.exec = (command, args, cwd) => args[0] === "rev-parse" && args[1] === "HEAD"
-    ? { code: 0, stdout: `${STAGE_HEAD}\n`, stderr: "" }
-    : baseExec(command, args, cwd);
+  h.ports.exec = (command, args, cwd) => {
+    if (args[0] === "rev-parse" && args[1] === "HEAD") return { code: 0, stdout: `${STAGE_HEAD}\n`, stderr: "" };
+    /* The remote carries the same stage commit: these tests are about durable
+       turn evidence, not publication, so origin is modelled as already current
+       and publication short-circuits without a push. */
+    if (args[0] === "ls-remote") {
+      return { code: 0, stdout: `${STAGE_HEAD}\trefs/heads/${loadPipelines()[0]?.branch ?? "pipeline/test"}\n`, stderr: "" };
+    }
+    return baseExec(command, args, cwd);
+  };
 }
 
 /** Provision + spawn the first stage, then strip its pane so the attempt is a
@@ -2008,6 +2018,15 @@ test("issue 533: an in-loop repair advances expectedReviewHeadSha with reviewHea
   const persisted = loadPipelines()[0]!;
   persisted.lastPassedCommit = beforeRepair;
   savePipelines([persisted]);
+  /* The accepted commit IS the worktree head, and origin already carries it:
+     review ingress publishes the exact accepted head, so a fixture whose
+     worktree disagreed with its own accepted commit would park instead. */
+  const baseExec = h.ports.exec;
+  h.ports.exec = (command, args, cwd) => {
+    if (command === "git" && args[0] === "rev-parse" && args[1] === "HEAD") return { code: 0, stdout: `${beforeRepair}\n`, stderr: "" };
+    if (command === "git" && args[0] === "ls-remote") return { code: 0, stdout: `${beforeRepair}\trefs/heads/${loadPipelines()[0]!.branch}\n`, stderr: "" };
+    return baseExec(command, args, cwd);
+  };
   await tickPipelines([entry("/codex/stage-1.jsonl")], h.ports);
 
   const actualReviewHead = "5755f992b195cc8637fd7129d9be4049c10494fa";
@@ -2702,13 +2721,16 @@ test("retrying a paused review with a live reviewer never mutates its checkout (
   ] as const;
   const repairHead = "e".repeat(40);
   let localHead = ORIGIN_MAIN_SHA;
+  let repaired = false;
   const baseExec = h.ports.exec;
   h.ports.exec = (command, args, cwd) => {
     if (command === "git" && args[0] === "status") return { code: 0, stdout: "", stderr: "" };
     if (command === "git" && args[0] === "branch" && args[1] === "--show-current") return { code: 0, stdout: `${loadPipelines()[0]!.branch}\n`, stderr: "" };
     if (command === "git" && args[0] === "rev-parse" && args[1] === "HEAD") return { code: 0, stdout: `${localHead}\n`, stderr: "" };
-    if (command === "git" && args[0] === "ls-remote") return { code: 0, stdout: `${repairHead}\trefs/heads/${loadPipelines()[0]!.branch}\n`, stderr: "" };
-    if (command === "git" && args[0] === "rev-parse" && String(args[1]).startsWith("refs/remotes/origin/")) return { code: 0, stdout: `${repairHead}\n`, stderr: "" };
+    /* The repair only exists on the remote once it has actually landed there;
+       before that origin simply carries what the pipeline published. */
+    if (command === "git" && args[0] === "ls-remote") return { code: 0, stdout: `${repaired ? repairHead : localHead}\trefs/heads/${loadPipelines()[0]!.branch}\n`, stderr: "" };
+    if (command === "git" && args[0] === "rev-parse" && String(args[1]).startsWith("refs/remotes/origin/")) return { code: 0, stdout: `${repaired ? repairHead : localHead}\n`, stderr: "" };
     if (command === "git" && args[0] === "merge-base") return { code: 0, stdout: "", stderr: "" };
     if (command === "git" && args[0] === "merge" && args[1] === "--ff-only") {
       localHead = repairHead;
@@ -2730,6 +2752,7 @@ test("retrying a paused review with a live reviewer never mutates its checkout (
   flow.stateDetail = "reviewer paused";
   await tickPipelines([entry("/codex/stage-1.jsonl")], h.ports);
 
+  repaired = true;
   const retried = await patchPipeline(pipeline.id, { action: "retry-stage" }, h.ports);
 
   expect(retried).toMatchObject({ status: 409, error: expect.stringContaining("still be running") });
@@ -2746,13 +2769,16 @@ test("retry parks without synchronizing when reviewer termination cannot be veri
   ] as const;
   const repairHead = "f".repeat(40);
   let localHead = ORIGIN_MAIN_SHA;
+  let repaired = false;
   const baseExec = h.ports.exec;
   h.ports.exec = (command, args, cwd) => {
     if (command === "git" && args[0] === "status") return { code: 0, stdout: "", stderr: "" };
     if (command === "git" && args[0] === "branch" && args[1] === "--show-current") return { code: 0, stdout: `${loadPipelines()[0]!.branch}\n`, stderr: "" };
     if (command === "git" && args[0] === "rev-parse" && args[1] === "HEAD") return { code: 0, stdout: `${localHead}\n`, stderr: "" };
-    if (command === "git" && args[0] === "ls-remote") return { code: 0, stdout: `${repairHead}\trefs/heads/${loadPipelines()[0]!.branch}\n`, stderr: "" };
-    if (command === "git" && args[0] === "rev-parse" && String(args[1]).startsWith("refs/remotes/origin/")) return { code: 0, stdout: `${repairHead}\n`, stderr: "" };
+    /* The repair only exists on the remote once it has actually landed there;
+       before that origin simply carries what the pipeline published. */
+    if (command === "git" && args[0] === "ls-remote") return { code: 0, stdout: `${repaired ? repairHead : localHead}\trefs/heads/${loadPipelines()[0]!.branch}\n`, stderr: "" };
+    if (command === "git" && args[0] === "rev-parse" && String(args[1]).startsWith("refs/remotes/origin/")) return { code: 0, stdout: `${repaired ? repairHead : localHead}\n`, stderr: "" };
     if (command === "git" && args[0] === "merge-base") return { code: 0, stdout: "", stderr: "" };
     if (command === "git" && args[0] === "merge" && args[1] === "--ff-only") {
       localHead = repairHead;
@@ -2770,6 +2796,7 @@ test("retry parks without synchronizing when reviewer termination cannot be veri
   await tickPipelines([entry("/codex/stage-1.jsonl")], h.ports);
   h.ports.closeFlow = async () => ({ error: "reviewer process group did not terminate", status: 409 });
 
+  repaired = true;
   const retried = await patchPipeline(pipeline.id, { action: "retry-stage" }, h.ports);
 
   expect(retried).toEqual({ error: "reviewer process group did not terminate", status: 409 });
@@ -4514,6 +4541,7 @@ function publishHarness(h: ReturnType<typeof harness>, options: { origin?: boole
   let localHead = ORIGIN_MAIN_SHA;
   let remoteBranch: string | null = null;
   let dirty = true;
+  let pushFails = false;
   const baseExec = h.ports.exec;
   h.ports.exec = (command, args, cwd) => {
     if (command !== "git") return baseExec(command, args, cwd);
@@ -4536,12 +4564,16 @@ function publishHarness(h: ReturnType<typeof harness>, options: { origin?: boole
       return { code: 0, stdout: remoteBranch ? `${remoteBranch}\trefs/heads/${branch}\n` : "", stderr: "" };
     }
     if (args[0] === "push") {
-      if (options.pushFails) {
+      if (options.pushFails || pushFails) {
         order.push("push-rejected");
         return { code: 1, stdout: "", stderr: "! [remote rejected] (shallow update not allowed)" };
       }
       remoteBranch = localHead;
       order.push(`push:${localHead}`);
+      return { code: 0, stdout: "", stderr: "" };
+    }
+    if (args[0] === "reset" || args[0] === "clean") {
+      dirty = false;
       return { code: 0, stdout: "", stderr: "" };
     }
     if (args[0] === "cat-file") return { code: history.includes(String(args[2]).replace("^{commit}", "")) ? 0 : 1, stdout: "", stderr: "" };
@@ -4572,7 +4604,9 @@ function publishHarness(h: ReturnType<typeof harness>, options: { origin?: boole
     passedSha,
     order,
     remote: () => remoteBranch,
-    setRemote: (sha: string) => { remoteBranch = sha; },
+    setRemote: (sha: string | null) => { remoteBranch = sha; },
+    setDirty: (value: boolean) => { dirty = value; },
+    setPushFails: (value: boolean) => { pushFails = value; },
     setLocalHead: (sha: string) => { localHead = sha; if (!history.includes(sha)) history.push(sha); },
     /* Records a revision nobody's local checkout contains — a repair pushed
        from another clone, which must never be fast-forwarded away. */
@@ -4625,18 +4659,29 @@ test("a publication that cannot land parks the pass without losing the commit", 
   expect(h.flows.size).toBe(0);
 });
 
-test("a pipeline whose repo has no origin advances without publishing anything", async () => {
+test("a pipeline whose repo has no origin parks at review ingress instead of fencing on a remote it cannot have", async () => {
   const h = harness();
   const box = publishHarness(h, { origin: false });
   await create(h.ports, PUBLISH_STAGES as never);
   await tickPipelines([], h.ports);
   await tickPipelines([], h.ports);
+  /* The pass itself still advances — an unpublishable repo is not a reason to
+     lose the builder's commit. */
   await tickPipelines([h.finish("/codex/stage-1.jsonl", "pass")], h.ports);
+  expect(loadPipelines()[0]).toMatchObject({ state: "running", lastPassedCommit: box.passedSha, publishedCommit: null });
+
   await tickPipelines([entry("/codex/stage-1.jsonl")], h.ports);
 
-  expect(box.order).toEqual(["commit", "createFlow"]);
-  expect(box.remote()).toBeNull();
-  expect(loadPipelines()[0]).toMatchObject({ state: "running", lastPassedCommit: box.passedSha, publishedCommit: null });
+  const parked = loadPipelines()[0]!;
+  expect(parked.state).toBe("needs_decision");
+  expect(parked.stateDetail).toBe(
+    `review stage requires a published pipeline branch, but this repository has no origin remote to publish ${box.passedSha} to`,
+  );
+  /* Parked BEFORE the flow exists: no reviewer is ever fenced on a remote head
+     that cannot be created. */
+  expect(box.order).toEqual(["commit"]);
+  expect(h.flows.size).toBe(0);
+  expect(parked.lastPassedCommit).toBe(box.passedSha);
 });
 
 test("retrying a parked review stage republishes a local repair before the reviewer relaunches", async () => {
@@ -4660,4 +4705,158 @@ test("retrying a parked review stage republishes a local repair before the revie
   expect(box.remote()).toBe(repairHead);
   expect(loadPipelines()[0]).toMatchObject({ state: "running", lastPassedCommit: repairHead, publishedCommit: repairHead });
   expect(box.order).toEqual(["commit", `push:${box.passedSha}`, "createFlow", `push:${repairHead}`]);
+});
+
+/* --- exact-head publication is a precondition of EVERY review ingress ------ */
+
+/* A review stage needs a passed run session to review, so both the skip path
+   and the fail-edge path reach ingress only behind an earlier passed stage. */
+const SKIP_STAGES = [
+  { id: "plan", kind: "run", role: { roleId: "builder" }, ["prompt"]: "plan", next: "build" },
+  { id: "build", kind: "run", role: { roleId: "builder" }, ["prompt"]: "build", next: "review" },
+  { id: "review", kind: "review-loop", role: { roleId: "reviewer" }, ["prompt"]: "review", next: null },
+] as const;
+
+const FAIL_EDGE_STAGES = [
+  { id: "plan", kind: "run", role: { roleId: "builder" }, ["prompt"]: "plan", next: "build" },
+  { id: "build", kind: "run", role: { roleId: "builder" }, ["prompt"]: "build", next: "review", onFail: { to: "review", maxRounds: 2 } },
+  { id: "review", kind: "review-loop", role: { roleId: "reviewer" }, ["prompt"]: "review", next: null },
+] as const;
+
+test("a skipped stage publishes the accepted head before its review flow is created", async () => {
+  const h = harness();
+  const box = publishHarness(h);
+  const pipeline = await create(h.ports, SKIP_STAGES as never);
+  await tickPipelines([], h.ports);
+  await tickPipelines([], h.ports);
+  await tickPipelines([h.finish("/codex/stage-1.jsonl", "pass")], h.ports);
+  await tickPipelines([entry("/codex/stage-1.jsonl")], h.ports);
+  await tickPipelines([h.finish("/codex/stage-2.jsonl", "needs_decision", "operator call")], h.ports);
+  expect(loadPipelines()[0]!.state).toBe("needs_decision");
+
+  /* Nothing on the skip route publishes: the branch is unpublished when the
+     cursor reaches review. */
+  box.setRemote(null);
+  await patchPipeline(pipeline.id, { action: "skip-stage" }, h.ports);
+  const beforeIngress = box.order.length;
+  await tickPipelines([entry("/codex/stage-1.jsonl"), entry("/codex/stage-2.jsonl")], h.ports);
+
+  const accepted = loadPipelines()[0]!.lastPassedCommit;
+  expect(box.remote()).toBe(accepted);
+  expect(box.order.slice(beforeIngress)).toEqual([`push:${accepted}`, "createFlow"]);
+  expect(loadPipelines()[0]).toMatchObject({ state: "running", publishedCommit: accepted });
+});
+
+test("a fail edge into a review stage publishes the accepted head before its review flow is created", async () => {
+  const h = harness();
+  const box = publishHarness(h);
+  await create(h.ports, FAIL_EDGE_STAGES as never);
+  await tickPipelines([], h.ports);
+  await tickPipelines([], h.ports);
+  await tickPipelines([h.finish("/codex/stage-1.jsonl", "pass")], h.ports);
+  await tickPipelines([entry("/codex/stage-1.jsonl")], h.ports);
+  /* A failed stage commits nothing; the worktree is clean at the accepted head. */
+  box.setDirty(false);
+  box.setRemote(null);
+  await tickPipelines([h.finish("/codex/stage-2.jsonl", "fail", "needs a reviewer")], h.ports);
+
+  const beforeIngress = box.order.length;
+  await tickPipelines([entry("/codex/stage-1.jsonl"), entry("/codex/stage-2.jsonl")], h.ports);
+
+  const accepted = loadPipelines()[0]!.lastPassedCommit;
+  expect(box.remote()).toBe(accepted);
+  expect(box.order.slice(beforeIngress)).toEqual([`push:${accepted}`, "createFlow"]);
+  expect(loadPipelines()[0]!.state).toBe("running");
+});
+
+test("review ingress re-probes the remote instead of trusting a stale publishedCommit", async () => {
+  const h = harness();
+  const box = publishHarness(h);
+  await create(h.ports, PUBLISH_STAGES as never);
+  await tickPipelines([], h.ports);
+  await tickPipelines([], h.ports);
+  await tickPipelines([h.finish("/codex/stage-1.jsonl", "pass")], h.ports);
+  expect(loadPipelines()[0]!.publishedCommit).toBe(box.passedSha);
+
+  /* The durable record says published, but origin does not have it — a migrated
+     record, or a branch deleted on the remote. Ingress must not believe it. */
+  box.setRemote(null);
+  await tickPipelines([entry("/codex/stage-1.jsonl")], h.ports);
+
+  expect(box.remote()).toBe(box.passedSha);
+  expect(box.order).toEqual(["commit", `push:${box.passedSha}`, `push:${box.passedSha}`, "createFlow"]);
+  expect(loadPipelines()[0]!.state).toBe("running");
+});
+
+test("a worktree head that is not the accepted review head parks without publishing anything", async () => {
+  const h = harness();
+  const box = publishHarness(h);
+  await create(h.ports, FAIL_EDGE_STAGES as never);
+  await tickPipelines([], h.ports);
+  await tickPipelines([], h.ports);
+  await tickPipelines([h.finish("/codex/stage-1.jsonl", "pass")], h.ports);
+  await tickPipelines([entry("/codex/stage-1.jsonl")], h.ports);
+  const accepted = loadPipelines()[0]!.lastPassedCommit;
+
+  /* The failed stage committed on its own. That revision was never accepted by
+     the pipeline, so it must never reach origin. */
+  const unaccepted = "c".repeat(40);
+  box.setDirty(false);
+  box.setRemote(null);
+  await tickPipelines([h.finish("/codex/stage-2.jsonl", "fail", "self-committed")], h.ports);
+  box.setLocalHead(unaccepted);
+  const beforeIngress = box.order.length;
+
+  await tickPipelines([entry("/codex/stage-1.jsonl"), entry("/codex/stage-2.jsonl")], h.ports);
+
+  const parked = loadPipelines()[0]!;
+  expect(parked.state).toBe("needs_decision");
+  expect(parked.stateDetail).toBe(
+    `review stage head mismatch: the accepted review head is ${accepted}, but the pipeline worktree is at ${unaccepted}; nothing was published`,
+  );
+  expect(box.remote()).toBeNull();
+  expect(box.order.slice(beforeIngress)).toEqual([]);
+  expect(h.flows.size).toBe(0);
+});
+
+test("a remote that diverged from the accepted head parks review ingress and keeps both revisions", async () => {
+  const h = harness();
+  const box = publishHarness(h);
+  await create(h.ports, PUBLISH_STAGES as never);
+  await tickPipelines([], h.ports);
+  await tickPipelines([], h.ports);
+  await tickPipelines([h.finish("/codex/stage-1.jsonl", "pass")], h.ports);
+
+  /* Someone else's repair landed on the branch; the accepted head does not
+     contain it, so publication must refuse rather than fast-forward over it. */
+  const foreignRepair = "d".repeat(40);
+  box.setDivergentRemote(foreignRepair);
+  await tickPipelines([entry("/codex/stage-1.jsonl")], h.ports);
+
+  const parked = loadPipelines()[0]!;
+  expect(parked.state).toBe("needs_decision");
+  expect(parked.stateDetail).toContain(`review stage could not publish the accepted head ${box.passedSha}`);
+  expect(parked.stateDetail).toContain("diverged");
+  expect(box.remote()).toBe(foreignRepair);
+  expect(h.flows.size).toBe(0);
+});
+
+test("a push that fails at review ingress parks before the review flow exists", async () => {
+  const h = harness();
+  const box = publishHarness(h);
+  await create(h.ports, PUBLISH_STAGES as never);
+  await tickPipelines([], h.ports);
+  await tickPipelines([], h.ports);
+  await tickPipelines([h.finish("/codex/stage-1.jsonl", "pass")], h.ports);
+
+  box.setRemote(null);
+  box.setPushFails(true);
+  await tickPipelines([entry("/codex/stage-1.jsonl")], h.ports);
+
+  const parked = loadPipelines()[0]!;
+  expect(parked.state).toBe("needs_decision");
+  expect(parked.stateDetail).toContain(`review stage could not publish the accepted head ${box.passedSha}`);
+  expect(parked.stateDetail).toContain("publishing the pipeline branch:");
+  expect(h.flows.size).toBe(0);
+  expect(parked.lastPassedCommit).toBe(box.passedSha);
 });

--- a/src/lib/pipelines/engine.test.ts
+++ b/src/lib/pipelines/engine.test.ts
@@ -4502,3 +4502,162 @@ test("closing a fail-edge target with an older terminal attempt records a fresh 
   expect(buildRun.attempts[1]!.input).toContain("regression");
   expect(reloaded.runs.find((run) => run.stageId === "verify")!.attempts[0]!.state).toBe("failed");
 });
+
+/* --- #729: the orchestrator publishes the head the review layer fences on --- */
+
+function publishHarness(h: ReturnType<typeof harness>, options: { origin?: boolean; pushFails?: boolean } = {}) {
+  const passedSha = "7".repeat(40);
+  const order: string[] = [];
+  /* Oldest first. `merge-base --is-ancestor` is answered from this, so the
+     fake cannot accidentally agree that a divergence is a fast-forward. */
+  const history = [ORIGIN_MAIN_SHA, passedSha];
+  let localHead = ORIGIN_MAIN_SHA;
+  let remoteBranch: string | null = null;
+  let dirty = true;
+  const baseExec = h.ports.exec;
+  h.ports.exec = (command, args, cwd) => {
+    if (command !== "git") return baseExec(command, args, cwd);
+    const branch = loadPipelines()[0]?.branch ?? "pipeline/test";
+    if (args[0] === "status") return { code: 0, stdout: dirty ? " M src/lib/thing.ts\n" : "", stderr: "" };
+    if (args[0] === "add") return { code: 0, stdout: "", stderr: "" };
+    if (args[0] === "commit") {
+      dirty = false;
+      localHead = passedSha;
+      order.push("commit");
+      return { code: 0, stdout: "", stderr: "" };
+    }
+    if (args[0] === "branch" && args[1] === "--show-current") return { code: 0, stdout: `${branch}\n`, stderr: "" };
+    if (args[0] === "remote" && args[1] === "get-url") {
+      return options.origin === false
+        ? { code: 128, stdout: "", stderr: "error: No such remote 'origin'" }
+        : { code: 0, stdout: "git@example.invalid:owner/repo.git\n", stderr: "" };
+    }
+    if (args[0] === "ls-remote") {
+      return { code: 0, stdout: remoteBranch ? `${remoteBranch}\trefs/heads/${branch}\n` : "", stderr: "" };
+    }
+    if (args[0] === "push") {
+      if (options.pushFails) {
+        order.push("push-rejected");
+        return { code: 1, stdout: "", stderr: "! [remote rejected] (shallow update not allowed)" };
+      }
+      remoteBranch = localHead;
+      order.push(`push:${localHead}`);
+      return { code: 0, stdout: "", stderr: "" };
+    }
+    if (args[0] === "cat-file") return { code: history.includes(String(args[2]).replace("^{commit}", "")) ? 0 : 1, stdout: "", stderr: "" };
+    if (args[0] === "merge-base" && args[1] === "--is-ancestor") {
+      const ancestor = history.indexOf(String(args[2]));
+      const descendant = history.indexOf(String(args[3]));
+      return { code: ancestor >= 0 && descendant >= 0 && ancestor <= descendant ? 0 : 1, stdout: "", stderr: "" };
+    }
+    if (args[0] === "fetch") return { code: 0, stdout: "", stderr: "" };
+    if (args[0] === "merge" && args[1] === "--ff-only") {
+      localHead = remoteBranch ?? localHead;
+      return { code: 0, stdout: "", stderr: "" };
+    }
+    if (args[0] === "rev-parse" && args[1] === "HEAD") return { code: 0, stdout: `${localHead}\n`, stderr: "" };
+    if (args[0] === "rev-parse" && String(args[1]).startsWith("refs/remotes/origin/")) {
+      return remoteBranch
+        ? { code: 0, stdout: `${remoteBranch}\n`, stderr: "" }
+        : { code: 128, stdout: "", stderr: "fatal: bad revision" };
+    }
+    return baseExec(command, args, cwd);
+  };
+  const baseCreateFlow = h.ports.createFlow;
+  h.ports.createFlow = async (req, entries) => {
+    order.push("createFlow");
+    return await baseCreateFlow(req, entries);
+  };
+  return {
+    passedSha,
+    order,
+    remote: () => remoteBranch,
+    setRemote: (sha: string) => { remoteBranch = sha; },
+    setLocalHead: (sha: string) => { localHead = sha; if (!history.includes(sha)) history.push(sha); },
+    /* Records a revision nobody's local checkout contains — a repair pushed
+       from another clone, which must never be fast-forwarded away. */
+    setDivergentRemote: (sha: string) => { remoteBranch = sha; },
+  };
+}
+
+const PUBLISH_STAGES = [
+  { id: "build", kind: "run", role: { roleId: "builder" }, ["prompt"]: "build", next: "review" },
+  { id: "review", kind: "review-loop", role: { roleId: "reviewer" }, ["prompt"]: "review", next: null },
+] as const;
+
+test("a passed run stage publishes its committed head before the review stage creates its flow (#729)", async () => {
+  const h = harness();
+  const box = publishHarness(h);
+  await create(h.ports, PUBLISH_STAGES as never);
+  await tickPipelines([], h.ports);
+  await tickPipelines([], h.ports);
+  await tickPipelines([h.finish("/codex/stage-1.jsonl", "pass")], h.ports);
+
+  /* The builder's commit reaches origin before anything can gate on it: this is
+     the exact ordering pipeline 2ae14391 lacked when its review stage parked on
+     `review remote head is unavailable before launch`. */
+  expect(box.remote()).toBe(box.passedSha);
+  expect(loadPipelines()[0]).toMatchObject({ lastPassedCommit: box.passedSha, publishedCommit: box.passedSha });
+
+  await tickPipelines([entry("/codex/stage-1.jsonl")], h.ports);
+
+  expect(box.order).toEqual(["commit", `push:${box.passedSha}`, "createFlow"]);
+  expect(h.flows.get("flow-1")).toMatchObject({ headRef: loadPipelines()[0]!.branch, targetSha: box.passedSha });
+  expect(loadPipelines()[0]!.state).toBe("running");
+});
+
+test("a publication that cannot land parks the pass without losing the commit", async () => {
+  const h = harness();
+  const box = publishHarness(h, { pushFails: true });
+  await create(h.ports, PUBLISH_STAGES as never);
+  await tickPipelines([], h.ports);
+  await tickPipelines([], h.ports);
+  await tickPipelines([h.finish("/codex/stage-1.jsonl", "pass")], h.ports);
+
+  const parked = loadPipelines()[0]!;
+  expect(parked.state).toBe("needs_decision");
+  expect(parked.stateDetail).toContain("publishing the passed stage: publishing the pipeline branch:");
+  /* The stage's work is committed and recorded — the park is recoverable, and a
+     retry resets to this commit rather than discarding the builder's output. */
+  expect(parked.lastPassedCommit).toBe(box.passedSha);
+  expect(parked.publishedCommit ?? null).toBeNull();
+  expect(box.order).toEqual(["commit", "push-rejected"]);
+  expect(h.flows.size).toBe(0);
+});
+
+test("a pipeline whose repo has no origin advances without publishing anything", async () => {
+  const h = harness();
+  const box = publishHarness(h, { origin: false });
+  await create(h.ports, PUBLISH_STAGES as never);
+  await tickPipelines([], h.ports);
+  await tickPipelines([], h.ports);
+  await tickPipelines([h.finish("/codex/stage-1.jsonl", "pass")], h.ports);
+  await tickPipelines([entry("/codex/stage-1.jsonl")], h.ports);
+
+  expect(box.order).toEqual(["commit", "createFlow"]);
+  expect(box.remote()).toBeNull();
+  expect(loadPipelines()[0]).toMatchObject({ state: "running", lastPassedCommit: box.passedSha, publishedCommit: null });
+});
+
+test("retrying a parked review stage republishes a local repair before the reviewer relaunches", async () => {
+  const h = harness();
+  const box = publishHarness(h);
+  const pipeline = await create(h.ports, PUBLISH_STAGES as never);
+  await tickPipelines([], h.ports);
+  await tickPipelines([], h.ports);
+  await tickPipelines([h.finish("/codex/stage-1.jsonl", "pass")], h.ports);
+  await tickPipelines([entry("/codex/stage-1.jsonl")], h.ports);
+  h.flows.get("flow-1")!.state = "done_comment";
+  await tickPipelines([entry("/codex/stage-1.jsonl")], h.ports);
+  expect(loadPipelines()[0]!.state).toBe("needs_decision");
+
+  /* The operator commits a repair in the shared worktree. Without republication
+     the retried reviewer fences on a remote that never learned about it. */
+  const repairHead = "9".repeat(40);
+  box.setLocalHead(repairHead);
+  await patchPipeline(pipeline.id, { action: "retry-stage" }, h.ports);
+
+  expect(box.remote()).toBe(repairHead);
+  expect(loadPipelines()[0]).toMatchObject({ state: "running", lastPassedCommit: repairHead, publishedCommit: repairHead });
+  expect(box.order).toEqual(["commit", `push:${box.passedSha}`, "createFlow", `push:${repairHead}`]);
+});

--- a/src/lib/pipelines/engine.ts
+++ b/src/lib/pipelines/engine.ts
@@ -1160,7 +1160,10 @@ function commitPassedStage(
      is what left pipeline 2ae14391 parked for over seven hours. Publication
      failure is its own recoverable class: the commit is already durable in
      `lastPassedCommit`, so nothing is lost while the operator resolves it. */
-  const published = publishPipelineBranch(pipeline, ports.exec, pipeline.publishedCommit ?? null);
+  const published = publishPipelineBranch(pipeline, ports.exec, {
+    acceptedSha: result.sha,
+    publishedSha: pipeline.publishedCommit ?? null,
+  });
   if (!published.ok) {
     park(pipeline, `publishing the passed stage: ${published.error}`, attempt);
     return;
@@ -1500,7 +1503,9 @@ function publishReviewIngressHead(pipeline: Pipeline, attempt: PipelineStageAtte
     return `review stage head mismatch: the accepted review head is ${expected}, but the pipeline worktree is at ${local.sha}; nothing was published`;
   }
 
-  const published = publishPipelineBranch(pipeline, ports.exec, null);
+  /* `publishedSha` is deliberately omitted: ingress probes the remote for real
+     rather than trusting a durable record that may be stale or migrated. */
+  const published = publishPipelineBranch(pipeline, ports.exec, { acceptedSha: expected });
   if (!published.ok) return `review stage could not publish the accepted head ${expected}: ${published.error}`;
   if (published.remote === "unavailable") {
     return `review stage requires a published pipeline branch, but this repository has no origin remote to publish ${expected} to`;
@@ -2672,7 +2677,10 @@ export async function patchPipeline(
            one. Without this, a local repair the operator committed in the
            worktree would park the retry on the same unavailable remote the
            retry was meant to escape — an unbounded operator loop. */
-        const republished = publishPipelineBranch(pipeline, ports.exec, pipeline.publishedCommit ?? null);
+        const republished = publishPipelineBranch(pipeline, ports.exec, {
+          acceptedSha: retryReviewHead!.sha,
+          publishedSha: pipeline.publishedCommit ?? null,
+        });
         if (!republished.ok) {
           pipeline.stateDetail = republished.error;
           persist();

--- a/src/lib/pipelines/engine.ts
+++ b/src/lib/pipelines/engine.ts
@@ -27,7 +27,7 @@ import { realExec, type ExecPort } from "@/lib/workflows/provision";
 
 import { requestPipelineTick } from "./controllerSignal";
 import { durableStageTurnEvidence, type StageTurnEvidence } from "./durableEvidence";
-import { commitPipelineStage, currentPipelineBranchHead, currentPipelineRemoteBranchHead, pipelineWorktreeChanges, provisionPipelineWorktree, resetPipelineStage, resolvePipelineBase, synchronizePipelineRetryHead } from "./git";
+import { commitPipelineStage, currentPipelineBranchHead, currentPipelineRemoteBranchHead, pipelineWorktreeChanges, provisionPipelineWorktree, publishPipelineBranch, resetPipelineStage, resolvePipelineBase, synchronizePipelineRetryHead } from "./git";
 import {
   DEFAULT_FAIL_EDGE_ROUNDS,
   MAX_FAIL_EDGE_ROUNDS,
@@ -1153,6 +1153,19 @@ function commitPassedStage(
     return;
   }
   pipeline.lastPassedCommit = result.sha;
+  /* Publish before the next stage can gate on the publication (#729). A review
+     stage fences every round on `origin/<branch>` through captureReviewHead, so
+     a builder that produced a usable head strands the whole handoff unless the
+     orchestrator itself pushes it — waiting for a stage to have run `git push`
+     is what left pipeline 2ae14391 parked for over seven hours. Publication
+     failure is its own recoverable class: the commit is already durable in
+     `lastPassedCommit`, so nothing is lost while the operator resolves it. */
+  const published = publishPipelineBranch(pipeline, ports.exec, pipeline.publishedCommit ?? null);
+  if (!published.ok) {
+    park(pipeline, `publishing the passed stage: ${published.error}`, attempt);
+    return;
+  }
+  pipeline.publishedCommit = published.remote === "published" ? published.sha : null;
   attempt.state = "passed";
   attempt.completedAt = ports.now();
   advancePipeline(pipeline, stage, ports, attempt);
@@ -2611,6 +2624,17 @@ export async function patchPipeline(
         pipeline.state = "provisioning";
       } else if (stage?.kind === "review-loop") {
         pipeline.lastPassedCommit = retryReviewHead!.sha;
+        /* A retried reviewer fences on the published head exactly like the first
+           one. Without this, a local repair the operator committed in the
+           worktree would park the retry on the same unavailable remote the
+           retry was meant to escape — an unbounded operator loop. */
+        const republished = publishPipelineBranch(pipeline, ports.exec, pipeline.publishedCommit ?? null);
+        if (!republished.ok) {
+          pipeline.stateDetail = republished.error;
+          persist();
+          return { error: republished.error, status: 409 };
+        }
+        pipeline.publishedCommit = republished.remote === "published" ? republished.sha : null;
         pipeline.state = "running";
       } else if (pipeline.lastPassedCommit) {
         const reset = resetPipelineStage(pipeline, ports.exec);

--- a/src/lib/pipelines/engine.ts
+++ b/src/lib/pipelines/engine.ts
@@ -1471,6 +1471,44 @@ export function reviewNote(pipeline: Pipeline, stage: PipelineStage, role: Effec
   return { note: trimmedBody ? `${prompt}${header}${trimmedBody}${fences}` : `${prompt}${fences}` };
 }
 
+/**
+ * Exact-head publication as a precondition of review ingress.
+ *
+ * Publishing on the pass path alone is not enough: a migrated record with no
+ * `publishedCommit`, an operator `skip-stage`, and a fail edge whose target is a
+ * review-loop stage all reach this point without ever having published, and the
+ * flow would then fence on an `origin/<branch>` that does not exist. Every route
+ * into a review flow goes through here, so the guarantee holds regardless of how
+ * the cursor arrived.
+ *
+ * The local head must already BE the accepted review head. When it is not — a
+ * failed stage that committed on its own, a worktree someone advanced by hand —
+ * this parks WITHOUT pushing, so a revision the pipeline never accepted is never
+ * published. A dirty worktree fails the same way and its work is left untouched.
+ *
+ * The cached `publishedCommit` is deliberately not trusted here: ingress passes
+ * null so the remote is genuinely probed, which is what makes a stale or
+ * migrated record safe. Publication itself stays fast-forward-only.
+ */
+function publishReviewIngressHead(pipeline: Pipeline, attempt: PipelineStageAttempt, ports: PipelinePorts): string | null {
+  const expected = attempt.expectedReviewHeadSha;
+  if (!expected) return "review-loop stage requires a verified pipeline commit";
+
+  const local = currentPipelineBranchHead(pipeline, ports.exec);
+  if (!local.ok) return `review stage could not verify the pipeline head before publishing: ${local.error}`;
+  if (local.sha !== expected) {
+    return `review stage head mismatch: the accepted review head is ${expected}, but the pipeline worktree is at ${local.sha}; nothing was published`;
+  }
+
+  const published = publishPipelineBranch(pipeline, ports.exec, null);
+  if (!published.ok) return `review stage could not publish the accepted head ${expected}: ${published.error}`;
+  if (published.remote === "unavailable") {
+    return `review stage requires a published pipeline branch, but this repository has no origin remote to publish ${expected} to`;
+  }
+  pipeline.publishedCommit = published.sha;
+  return null;
+}
+
 async function tickReviewStage(
   pipeline: Pipeline,
   stage: PipelineStage,
@@ -1511,6 +1549,12 @@ async function tickReviewStage(
   }
 
   if (!attempt.flowId) {
+    const ingressError = publishReviewIngressHead(pipeline, attempt, ports);
+    if (ingressError) {
+      park(pipeline, ingressError, attempt);
+      return;
+    }
+    persist();
     const existing = ports.findFlow(implementer.agentPath, implementer.conversationId, pipeline.baseRef, attempt.expectedReviewHeadSha);
     if (existing) {
       attachReviewFlowAttempt(attempt, existing);

--- a/src/lib/pipelines/git.test.ts
+++ b/src/lib/pipelines/git.test.ts
@@ -3,7 +3,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
-import { commitPipelineStage, pipelineWorktreeChanges, provisionPipelineWorktree, resetPipelineStage, resolvePipelineBase, synchronizePipelineRetryHead } from "./git";
+import { commitPipelineStage, pipelineWorktreeChanges, provisionPipelineWorktree, publishPipelineBranch, resetPipelineStage, resolvePipelineBase, synchronizePipelineRetryHead } from "./git";
 import type { Pipeline } from "./types";
 import { realExec, type ExecPort } from "@/lib/workflows/provision";
 
@@ -263,4 +263,164 @@ test("worktree change reporting truncates long lists and surfaces an unreadable 
     ok: false,
     error: "checking the pipeline worktree: fatal: not a git repository",
   });
+});
+
+/* --- publishPipelineBranch (#729): the orchestrator owns publication ------- */
+
+interface PublishSandbox {
+  root: string;
+  origin: string;
+  repo: string;
+  subject: Pipeline;
+  commit: (name: string, body: string) => string;
+  originHead: () => string;
+}
+
+function publishSandbox(withOrigin = true): PublishSandbox {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "llv-pipeline-publish-"));
+  const origin = path.join(root, "origin.git");
+  const repo = path.join(root, "repo");
+  fs.mkdirSync(repo);
+  git(repo, "init", "--initial-branch=main");
+  git(repo, "config", "user.email", "pipeline-test@example.com");
+  git(repo, "config", "user.name", "Pipeline Test");
+  git(repo, "config", "commit.gpgSign", "false");
+  fs.writeFileSync(path.join(repo, "base.txt"), "base\n");
+  git(repo, "add", "base.txt");
+  git(repo, "commit", "-m", "base");
+  if (withOrigin) {
+    git(root, "init", "--bare", "--initial-branch=main", origin);
+    git(repo, "remote", "add", "origin", origin);
+    git(repo, "push", "-u", "origin", "main");
+  }
+
+  const subject = pipeline();
+  subject.repoDir = repo;
+  subject.worktreeDir = path.join(root, "repo-pipeline-12345678");
+  subject.baseBranch = "main";
+  subject.baseRef = git(repo, "rev-parse", "HEAD");
+  subject.lastPassedCommit = subject.baseRef;
+  const provisioned = provisionPipelineWorktree(subject, realExec);
+  if (!provisioned.ok) throw new Error(provisioned.error);
+
+  return {
+    root,
+    origin,
+    repo,
+    subject,
+    commit: (name, body) => {
+      fs.writeFileSync(path.join(subject.worktreeDir, name), body);
+      git(subject.worktreeDir, "add", "-A");
+      git(subject.worktreeDir, "commit", "-m", `stage ${name}`);
+      return git(subject.worktreeDir, "rev-parse", "HEAD");
+    },
+    originHead: () => {
+      const listed = git(subject.worktreeDir, "ls-remote", "--heads", "origin", `refs/heads/${subject.branch}`);
+      return listed.split(/\s+/)[0] ?? "";
+    },
+  };
+}
+
+test("publishPipelineBranch pushes the passed commit and confirms origin carries it", () => {
+  const box = publishSandbox();
+  try {
+    const passed = box.commit("stage.txt", "stage work\n");
+    expect(box.originHead()).toBe("");
+
+    expect(publishPipelineBranch(box.subject, realExec)).toEqual({ ok: true, sha: passed, remote: "published" });
+    expect(box.originHead()).toBe(passed);
+  } finally {
+    fs.rmSync(box.root, { recursive: true, force: true });
+  }
+});
+
+test("publishPipelineBranch fast-forwards a branch it already published", () => {
+  const box = publishSandbox();
+  try {
+    const first = box.commit("one.txt", "one\n");
+    expect(publishPipelineBranch(box.subject, realExec)).toMatchObject({ ok: true, sha: first });
+    const second = box.commit("two.txt", "two\n");
+
+    expect(publishPipelineBranch(box.subject, realExec, first)).toEqual({ ok: true, sha: second, remote: "published" });
+    expect(box.originHead()).toBe(second);
+  } finally {
+    fs.rmSync(box.root, { recursive: true, force: true });
+  }
+});
+
+test("publishPipelineBranch refuses a diverged remote and leaves both revisions intact", () => {
+  const box = publishSandbox();
+  try {
+    const shared = box.commit("shared.txt", "shared\n");
+    expect(publishPipelineBranch(box.subject, realExec)).toMatchObject({ ok: true, sha: shared });
+
+    /* Someone else's repair lands on the remote branch; the local head does not
+       contain it. Publishing it away would destroy that work. */
+    const other = path.join(box.root, "other");
+    git(box.root, "clone", "--branch", box.subject.branch, box.origin, other);
+    git(other, "config", "user.email", "pipeline-test@example.com");
+    git(other, "config", "user.name", "Pipeline Test");
+    git(other, "config", "commit.gpgSign", "false");
+    fs.writeFileSync(path.join(other, "repair.txt"), "remote repair\n");
+    git(other, "add", "-A");
+    git(other, "commit", "-m", "remote repair");
+    git(other, "push", "origin", box.subject.branch);
+    const remoteRepair = git(other, "rev-parse", "HEAD");
+
+    const local = box.commit("local.txt", "local\n");
+    const refused = publishPipelineBranch(box.subject, realExec, shared);
+
+    expect(refused).toEqual({
+      ok: false,
+      error: "the local and remote pipeline branches diverged; choose which revision to publish before the review stage can start",
+    });
+    expect(box.originHead()).toBe(remoteRepair);
+    expect(git(box.subject.worktreeDir, "rev-parse", "HEAD")).toBe(local);
+  } finally {
+    fs.rmSync(box.root, { recursive: true, force: true });
+  }
+});
+
+test("publishPipelineBranch reports a repo with no origin as unavailable rather than a failure", () => {
+  const box = publishSandbox(false);
+  try {
+    const passed = box.commit("stage.txt", "stage work\n");
+    expect(publishPipelineBranch(box.subject, realExec)).toEqual({ ok: true, sha: passed, remote: "unavailable" });
+  } finally {
+    fs.rmSync(box.root, { recursive: true, force: true });
+  }
+});
+
+test("publishPipelineBranch refuses a dirty worktree and preserves the uncommitted work", () => {
+  const box = publishSandbox();
+  try {
+    box.commit("stage.txt", "stage work\n");
+    fs.writeFileSync(path.join(box.subject.worktreeDir, "in-progress.txt"), "unfinished\n");
+
+    expect(publishPipelineBranch(box.subject, realExec)).toEqual({
+      ok: false,
+      error: "the pipeline worktree has uncommitted changes; choose whether to commit or discard them before retrying review",
+    });
+    expect(git(box.subject.worktreeDir, "status", "--porcelain")).toBe("?? in-progress.txt");
+    expect(fs.readFileSync(path.join(box.subject.worktreeDir, "in-progress.txt"), "utf8")).toBe("unfinished\n");
+  } finally {
+    fs.rmSync(box.root, { recursive: true, force: true });
+  }
+});
+
+test("a head already recorded as published costs no remote probe at all", () => {
+  const head = "a".repeat(40);
+  const calls: string[] = [];
+  const exec: ExecPort = (command, args) => {
+    calls.push(`${command} ${args.join(" ")}`);
+    if (args[0] === "status") return { code: 0, stdout: "", stderr: "" };
+    if (args[0] === "branch") return { code: 0, stdout: `${pipeline().branch}\n`, stderr: "" };
+    if (args[0] === "rev-parse") return { code: 0, stdout: `${head}\n`, stderr: "" };
+    return { code: 0, stdout: "", stderr: "" };
+  };
+
+  expect(publishPipelineBranch(pipeline(), exec, head)).toEqual({ ok: true, sha: head, remote: "published" });
+  expect(calls.some((call) => call.includes("ls-remote"))).toBe(false);
+  expect(calls.some((call) => call.includes("push"))).toBe(false);
+  expect(calls.some((call) => call.includes("remote get-url"))).toBe(false);
 });

--- a/src/lib/pipelines/git.test.ts
+++ b/src/lib/pipelines/git.test.ts
@@ -327,7 +327,7 @@ test("publishPipelineBranch pushes the passed commit and confirms origin carries
     const passed = box.commit("stage.txt", "stage work\n");
     expect(box.originHead()).toBe("");
 
-    expect(publishPipelineBranch(box.subject, realExec)).toEqual({ ok: true, sha: passed, remote: "published" });
+    expect(publishPipelineBranch(box.subject, realExec, { acceptedSha: passed })).toEqual({ ok: true, sha: passed, remote: "published" });
     expect(box.originHead()).toBe(passed);
   } finally {
     fs.rmSync(box.root, { recursive: true, force: true });
@@ -338,10 +338,10 @@ test("publishPipelineBranch fast-forwards a branch it already published", () => 
   const box = publishSandbox();
   try {
     const first = box.commit("one.txt", "one\n");
-    expect(publishPipelineBranch(box.subject, realExec)).toMatchObject({ ok: true, sha: first });
+    expect(publishPipelineBranch(box.subject, realExec, { acceptedSha: first })).toMatchObject({ ok: true, sha: first });
     const second = box.commit("two.txt", "two\n");
 
-    expect(publishPipelineBranch(box.subject, realExec, first)).toEqual({ ok: true, sha: second, remote: "published" });
+    expect(publishPipelineBranch(box.subject, realExec, { acceptedSha: second, publishedSha: first })).toEqual({ ok: true, sha: second, remote: "published" });
     expect(box.originHead()).toBe(second);
   } finally {
     fs.rmSync(box.root, { recursive: true, force: true });
@@ -352,7 +352,7 @@ test("publishPipelineBranch refuses a diverged remote and leaves both revisions 
   const box = publishSandbox();
   try {
     const shared = box.commit("shared.txt", "shared\n");
-    expect(publishPipelineBranch(box.subject, realExec)).toMatchObject({ ok: true, sha: shared });
+    expect(publishPipelineBranch(box.subject, realExec, { acceptedSha: shared })).toMatchObject({ ok: true, sha: shared });
 
     /* Someone else's repair lands on the remote branch; the local head does not
        contain it. Publishing it away would destroy that work. */
@@ -368,7 +368,7 @@ test("publishPipelineBranch refuses a diverged remote and leaves both revisions 
     const remoteRepair = git(other, "rev-parse", "HEAD");
 
     const local = box.commit("local.txt", "local\n");
-    const refused = publishPipelineBranch(box.subject, realExec, shared);
+    const refused = publishPipelineBranch(box.subject, realExec, { acceptedSha: local, publishedSha: shared });
 
     expect(refused).toEqual({
       ok: false,
@@ -385,7 +385,7 @@ test("publishPipelineBranch reports a repo with no origin as unavailable rather 
   const box = publishSandbox(false);
   try {
     const passed = box.commit("stage.txt", "stage work\n");
-    expect(publishPipelineBranch(box.subject, realExec)).toEqual({ ok: true, sha: passed, remote: "unavailable" });
+    expect(publishPipelineBranch(box.subject, realExec, { acceptedSha: passed })).toEqual({ ok: true, sha: passed, remote: "unavailable" });
   } finally {
     fs.rmSync(box.root, { recursive: true, force: true });
   }
@@ -394,10 +394,10 @@ test("publishPipelineBranch reports a repo with no origin as unavailable rather 
 test("publishPipelineBranch refuses a dirty worktree and preserves the uncommitted work", () => {
   const box = publishSandbox();
   try {
-    box.commit("stage.txt", "stage work\n");
+    const passed = box.commit("stage.txt", "stage work\n");
     fs.writeFileSync(path.join(box.subject.worktreeDir, "in-progress.txt"), "unfinished\n");
 
-    expect(publishPipelineBranch(box.subject, realExec)).toEqual({
+    expect(publishPipelineBranch(box.subject, realExec, { acceptedSha: passed })).toEqual({
       ok: false,
       error: "the pipeline worktree has uncommitted changes; choose whether to commit or discard them before retrying review",
     });
@@ -419,8 +419,72 @@ test("a head already recorded as published costs no remote probe at all", () => 
     return { code: 0, stdout: "", stderr: "" };
   };
 
-  expect(publishPipelineBranch(pipeline(), exec, head)).toEqual({ ok: true, sha: head, remote: "published" });
+  expect(publishPipelineBranch(pipeline(), exec, { acceptedSha: head, publishedSha: head })).toEqual({ ok: true, sha: head, remote: "published" });
   expect(calls.some((call) => call.includes("ls-remote"))).toBe(false);
   expect(calls.some((call) => call.includes("push"))).toBe(false);
   expect(calls.some((call) => call.includes("remote get-url"))).toBe(false);
+});
+
+test("publication pushes only the immutable accepted revision when the branch advances mid-publish", () => {
+  const box = publishSandbox();
+  try {
+    const accepted = box.commit("accepted.txt", "accepted\n");
+    let racy: string | null = null;
+
+    /* The branch advances in the window between the publisher capturing the
+       accepted revision and the push running — here on the remote probe, which
+       sits exactly in that window. Pushing `refs/heads/<branch>` would carry
+       this unaccepted commit to origin and leave review fenced on a target that
+       never passed; pushing the accepted object cannot. */
+    const racing: ExecPort = (command, args, cwd) => {
+      if (command === "git" && args[0] === "ls-remote" && racy === null) {
+        racy = box.commit("racy.txt", "never accepted\n");
+      }
+      return realExec(command, args, cwd);
+    };
+
+    const published = publishPipelineBranch(box.subject, racing, { acceptedSha: accepted });
+
+    expect(racy).not.toBeNull();
+    expect(racy).not.toBe(accepted);
+    /* The local branch really did move on mid-publish ... */
+    expect(git(box.subject.worktreeDir, "rev-parse", "HEAD")).toBe(racy!);
+    /* ... and origin carries exactly the accepted revision, never the racy one. */
+    expect(published).toEqual({ ok: true, sha: accepted, remote: "published" });
+    expect(box.originHead()).toBe(accepted);
+  } finally {
+    fs.rmSync(box.root, { recursive: true, force: true });
+  }
+});
+
+test("a worktree that has moved past the accepted revision publishes nothing", () => {
+  const box = publishSandbox();
+  try {
+    const accepted = box.commit("accepted.txt", "accepted\n");
+    const advanced = box.commit("later.txt", "later\n");
+
+    const result = publishPipelineBranch(box.subject, realExec, { acceptedSha: accepted });
+
+    expect(result).toEqual({
+      ok: false,
+      error: `the pipeline worktree is at ${advanced}, not the accepted revision ${accepted}; nothing was published`,
+    });
+    expect(box.originHead()).toBe("");
+  } finally {
+    fs.rmSync(box.root, { recursive: true, force: true });
+  }
+});
+
+test("publication refuses an accepted revision that is not an exact commit SHA", () => {
+  const calls: string[] = [];
+  const exec: ExecPort = (command, args) => {
+    calls.push(`${command} ${args.join(" ")}`);
+    return { code: 0, stdout: "", stderr: "" };
+  };
+
+  expect(publishPipelineBranch(pipeline(), exec, { acceptedSha: "HEAD" })).toEqual({
+    ok: false,
+    error: "the accepted pipeline revision is not an exact commit SHA: HEAD",
+  });
+  expect(calls).toEqual([]);
 });

--- a/src/lib/pipelines/git.ts
+++ b/src/lib/pipelines/git.ts
@@ -170,6 +170,20 @@ export function publishPipelineBranch(pipeline: Pipeline, exec: ExecPort, publis
   if (remoteSha === local.sha) return { ok: true, sha: local.sha, remote: "published" };
   if (remoteSha) {
     if (!/^[0-9a-f]{40}$/i.test(remoteSha)) return { ok: false, error: "the remote pipeline branch has no exact commit SHA" };
+    /* A revision pushed from another checkout is not in this worktree's object
+       database, and `merge-base` cannot reason about a commit it does not have
+       — it fails outright, which would report a transient git error where the
+       truth is a divergence. Fetch it first, and only when it is genuinely
+       unknown, so an ordinary fast-forward still costs no extra round trip. */
+    const known = exec("git", ["cat-file", "-e", `${remoteSha}^{commit}`], pipeline.worktreeDir);
+    if (known.code !== 0) {
+      const fetched = exec(
+        "git",
+        ["fetch", "--no-tags", "origin", `+refs/heads/${pipeline.branch}:refs/remotes/origin/${pipeline.branch}`],
+        pipeline.worktreeDir,
+      );
+      if (fetched.code !== 0) return failure("fetching the remote pipeline branch", fetched);
+    }
     /* Only a fast-forward is ever published. A remote revision the local head
        does not contain is someone else's repair; overwriting it would discard
        work, so the pipeline parks and lets the operator choose. */

--- a/src/lib/pipelines/git.ts
+++ b/src/lib/pipelines/git.ts
@@ -140,6 +140,57 @@ export function currentPipelineRemoteBranchHead(pipeline: Pipeline, exec: ExecPo
   return { ok: true, sha };
 }
 
+export type PipelinePublishResult =
+  | { ok: true; sha: string; remote: "published" | "unavailable" }
+  | { ok: false; error: string };
+
+/**
+ * Publishes the pipeline branch so the review layer can fence on the exact
+ * revision it reviews. The orchestrator owns this step: a builder that commits
+ * a usable head without pushing it must still hand off deterministically, and
+ * every review round fences on `origin/<branch>` (captureReviewHead), so a
+ * branch nobody published strands the handoff for good.
+ *
+ * `publishedSha` is the caller's record of what it last published; a local head
+ * that still matches it settles with no network probe at all. A repo with no
+ * `origin` reports `unavailable` — there is nothing to publish to, which is a
+ * different fact from a failed publication and never a stall on its own.
+ */
+export function publishPipelineBranch(pipeline: Pipeline, exec: ExecPort, publishedSha: string | null = null): PipelinePublishResult {
+  const local = currentPipelineBranchHead(pipeline, exec);
+  if (!local.ok) return local;
+  if (publishedSha && publishedSha === local.sha) return { ok: true, sha: local.sha, remote: "published" };
+
+  const origin = exec("git", ["remote", "get-url", "origin"], pipeline.worktreeDir);
+  if (origin.code !== 0 || !origin.stdout.trim()) return { ok: true, sha: local.sha, remote: "unavailable" };
+
+  const probe = exec("git", ["ls-remote", "--heads", "origin", `refs/heads/${pipeline.branch}`], pipeline.worktreeDir);
+  if (probe.code !== 0) return failure("checking the remote pipeline branch", probe);
+  const remoteSha = probe.stdout.trim().split(/\s+/)[0] ?? "";
+  if (remoteSha === local.sha) return { ok: true, sha: local.sha, remote: "published" };
+  if (remoteSha) {
+    if (!/^[0-9a-f]{40}$/i.test(remoteSha)) return { ok: false, error: "the remote pipeline branch has no exact commit SHA" };
+    /* Only a fast-forward is ever published. A remote revision the local head
+       does not contain is someone else's repair; overwriting it would discard
+       work, so the pipeline parks and lets the operator choose. */
+    const remoteIsAncestor = exec("git", ["merge-base", "--is-ancestor", remoteSha, local.sha], pipeline.worktreeDir);
+    if (remoteIsAncestor.code === 1) {
+      return { ok: false, error: "the local and remote pipeline branches diverged; choose which revision to publish before the review stage can start" };
+    }
+    if (remoteIsAncestor.code !== 0) return failure("comparing local and remote pipeline revisions", remoteIsAncestor);
+  }
+
+  const push = exec("git", ["push", "origin", `refs/heads/${pipeline.branch}:refs/heads/${pipeline.branch}`], pipeline.worktreeDir);
+  if (push.code !== 0) return failure("publishing the pipeline branch", push);
+  const confirm = exec("git", ["ls-remote", "--heads", "origin", `refs/heads/${pipeline.branch}`], pipeline.worktreeDir);
+  if (confirm.code !== 0) return failure("confirming the published pipeline branch", confirm);
+  const publishedHead = confirm.stdout.trim().split(/\s+/)[0] ?? "";
+  if (publishedHead !== local.sha) {
+    return { ok: false, error: `publishing the pipeline branch did not land: origin/${pipeline.branch} is ${publishedHead || "absent"}, expected ${local.sha}` };
+  }
+  return { ok: true, sha: local.sha, remote: "published" };
+}
+
 /**
  * Resolves the exact revision a retried reviewer will receive. A remote repair
  * fast-forwards the shared worktree; a local repair stays intact; divergence

--- a/src/lib/pipelines/git.ts
+++ b/src/lib/pipelines/git.ts
@@ -144,30 +144,57 @@ export type PipelinePublishResult =
   | { ok: true; sha: string; remote: "published" | "unavailable" }
   | { ok: false; error: string };
 
+export interface PipelinePublishRequest {
+  /** The immutable revision the pipeline accepted. This exact object is what
+      gets pushed and what the publication is revalidated against. */
+  acceptedSha: string;
+  /** What the caller last recorded as published; a match short-circuits the
+      whole probe. */
+  publishedSha?: string | null;
+}
+
 /**
- * Publishes the pipeline branch so the review layer can fence on the exact
- * revision it reviews. The orchestrator owns this step: a builder that commits
- * a usable head without pushing it must still hand off deterministically, and
- * every review round fences on `origin/<branch>` (captureReviewHead), so a
- * branch nobody published strands the handoff for good.
+ * Publishes the accepted pipeline revision so the review layer can fence on the
+ * exact revision it reviews. The orchestrator owns this step: a builder that
+ * commits a usable head without pushing it must still hand off
+ * deterministically, and every review round fences on `origin/<branch>`
+ * (captureReviewHead), so a branch nobody published strands the handoff.
  *
- * `publishedSha` is the caller's record of what it last published; a local head
- * that still matches it settles with no network probe at all. A repo with no
- * `origin` reports `unavailable` — there is nothing to publish to, which is a
- * different fact from a failed publication and never a stall on its own.
+ * The accepted SHA is an input, never re-derived here, and the push source is
+ * that immutable object rather than `refs/heads/<branch>`. A branch ref is a
+ * moving target: between capturing the head and running the push, a concurrent
+ * stage can advance it, and pushing the ref would publish a commit the pipeline
+ * never accepted — leaving review fenced on a different target than the one
+ * that passed. Pushing `<sha>:refs/heads/<branch>` makes that unrepresentable,
+ * and the fast-forward and confirmation checks compare against the same
+ * immutable SHA, so a mid-flight advance can only fail the publication, never
+ * redirect it.
+ *
+ * A repo with no `origin` reports `unavailable` — there is nothing to publish
+ * to, which is a different fact from a failed publication and never a stall on
+ * its own.
  */
-export function publishPipelineBranch(pipeline: Pipeline, exec: ExecPort, publishedSha: string | null = null): PipelinePublishResult {
+export function publishPipelineBranch(pipeline: Pipeline, exec: ExecPort, request: PipelinePublishRequest): PipelinePublishResult {
+  const acceptedSha = request.acceptedSha;
+  if (!/^[0-9a-f]{40}$/i.test(acceptedSha)) {
+    return { ok: false, error: `the accepted pipeline revision is not an exact commit SHA: ${acceptedSha || "absent"}` };
+  }
   const local = currentPipelineBranchHead(pipeline, exec);
   if (!local.ok) return local;
-  if (publishedSha && publishedSha === local.sha) return { ok: true, sha: local.sha, remote: "published" };
+  /* The worktree must still hold the accepted revision when publication starts.
+     A head that has moved on is not this publication's business to push. */
+  if (local.sha !== acceptedSha) {
+    return { ok: false, error: `the pipeline worktree is at ${local.sha}, not the accepted revision ${acceptedSha}; nothing was published` };
+  }
+  if (request.publishedSha && request.publishedSha === acceptedSha) return { ok: true, sha: acceptedSha, remote: "published" };
 
   const origin = exec("git", ["remote", "get-url", "origin"], pipeline.worktreeDir);
-  if (origin.code !== 0 || !origin.stdout.trim()) return { ok: true, sha: local.sha, remote: "unavailable" };
+  if (origin.code !== 0 || !origin.stdout.trim()) return { ok: true, sha: acceptedSha, remote: "unavailable" };
 
   const probe = exec("git", ["ls-remote", "--heads", "origin", `refs/heads/${pipeline.branch}`], pipeline.worktreeDir);
   if (probe.code !== 0) return failure("checking the remote pipeline branch", probe);
   const remoteSha = probe.stdout.trim().split(/\s+/)[0] ?? "";
-  if (remoteSha === local.sha) return { ok: true, sha: local.sha, remote: "published" };
+  if (remoteSha === acceptedSha) return { ok: true, sha: acceptedSha, remote: "published" };
   if (remoteSha) {
     if (!/^[0-9a-f]{40}$/i.test(remoteSha)) return { ok: false, error: "the remote pipeline branch has no exact commit SHA" };
     /* A revision pushed from another checkout is not in this worktree's object
@@ -184,25 +211,25 @@ export function publishPipelineBranch(pipeline: Pipeline, exec: ExecPort, publis
       );
       if (fetched.code !== 0) return failure("fetching the remote pipeline branch", fetched);
     }
-    /* Only a fast-forward is ever published. A remote revision the local head
-       does not contain is someone else's repair; overwriting it would discard
-       work, so the pipeline parks and lets the operator choose. */
-    const remoteIsAncestor = exec("git", ["merge-base", "--is-ancestor", remoteSha, local.sha], pipeline.worktreeDir);
+    /* Only a fast-forward is ever published. A remote revision the ACCEPTED
+       revision does not contain is someone else's repair; overwriting it would
+       discard work, so the pipeline parks and lets the operator choose. */
+    const remoteIsAncestor = exec("git", ["merge-base", "--is-ancestor", remoteSha, acceptedSha], pipeline.worktreeDir);
     if (remoteIsAncestor.code === 1) {
       return { ok: false, error: "the local and remote pipeline branches diverged; choose which revision to publish before the review stage can start" };
     }
     if (remoteIsAncestor.code !== 0) return failure("comparing local and remote pipeline revisions", remoteIsAncestor);
   }
 
-  const push = exec("git", ["push", "origin", `refs/heads/${pipeline.branch}:refs/heads/${pipeline.branch}`], pipeline.worktreeDir);
+  const push = exec("git", ["push", "origin", `${acceptedSha}:refs/heads/${pipeline.branch}`], pipeline.worktreeDir);
   if (push.code !== 0) return failure("publishing the pipeline branch", push);
   const confirm = exec("git", ["ls-remote", "--heads", "origin", `refs/heads/${pipeline.branch}`], pipeline.worktreeDir);
   if (confirm.code !== 0) return failure("confirming the published pipeline branch", confirm);
   const publishedHead = confirm.stdout.trim().split(/\s+/)[0] ?? "";
-  if (publishedHead !== local.sha) {
-    return { ok: false, error: `publishing the pipeline branch did not land: origin/${pipeline.branch} is ${publishedHead || "absent"}, expected ${local.sha}` };
+  if (publishedHead !== acceptedSha) {
+    return { ok: false, error: `publishing the pipeline branch did not land: origin/${pipeline.branch} is ${publishedHead || "absent"}, expected ${acceptedSha}` };
   }
-  return { ok: true, sha: local.sha, remote: "published" };
+  return { ok: true, sha: acceptedSha, remote: "published" };
 }
 
 /**

--- a/src/lib/pipelines/store.ts
+++ b/src/lib/pipelines/store.ts
@@ -261,6 +261,7 @@ function isPipeline(value: unknown): value is Pipeline {
     typeof pipeline.baseBranch === "string" &&
     typeof pipeline.baseRef === "string" &&
     typeof pipeline.lastPassedCommit === "string" &&
+    (pipeline.publishedCommit === undefined || isNullableString(pipeline.publishedCommit)) &&
     Array.isArray(pipeline.stages) &&
     pipeline.stages.every(isStage) &&
     Array.isArray(pipeline.runs) &&
@@ -403,6 +404,7 @@ export function loadPipelines(): Pipeline[] {
     baseBranch: pipeline.baseBranch ?? "",
     baseRef: pipeline.baseRef ?? "",
     lastPassedCommit: pipeline.lastPassedCommit ?? "",
+    publishedCommit: pipeline.publishedCommit ?? null,
     pausedState: pipeline.pausedState ?? null,
     stateDetail: pipeline.stateDetail ?? null,
     srcPath: pipeline.srcPath ?? null,
@@ -524,6 +526,7 @@ export function buildPipeline(input: {
     baseBranch: "",
     baseRef: "",
     lastPassedCommit: "",
+    publishedCommit: null,
     stages: (JSON.parse(JSON.stringify(input.stages)) as PipelineStage[]).map((stage) => ({ ...stage, onFail: stage.onFail ?? null })),
     runs: input.stages.map((stage) => ({ stageId: stage.id, attempts: [] })),
     cursor: input.stages.length ? { stageId: input.stages[0]!.id, state: "pending", input: null, activatedBy: null } : null,

--- a/src/lib/pipelines/types.ts
+++ b/src/lib/pipelines/types.ts
@@ -197,6 +197,12 @@ export type Pipeline = {
   baseBranch: string;
   baseRef: string;
   lastPassedCommit: string;
+  /** The revision the orchestrator last published to `origin/<branch>`. The
+      review layer fences every round on the published head, so publication is
+      the pipeline's job, not a stage's; recording what landed lets a steady
+      state skip the remote probe entirely. Null while nothing is published
+      (a fresh pipeline, or a repo with no `origin` to publish to). */
+  publishedCommit?: string | null;
   stages: PipelineStage[];
   runs: PipelineStageRun[];
   /** The cursor carries the durable relay record (#353): the forwarded input and


### PR DESCRIPTION
Recurring builder-to-review stalls had two independent causes, both reproduced from pipelines that stalled today.

## 1. The pipeline branch was never published, but the review gate required it

`tickReviewStage` creates its flow with `headRef: pipeline.branch`, and `captureReviewHead` fences every round on `origin/<branch>` existing and matching the local head. Nothing in the pipeline ever pushed: `provisionPipelineWorktree` and `commitPipelineStage` are purely local. Whether a review stage started came down to whether the builder happened to run `git push` on its own.

Pipeline `2ae14391` is the clean case — the builder passed with a usable commit, the review stage parked **0.7s later** on `review remote head is unavailable before launch: origin/pipeline/729-…`, and it stayed parked until the branch was pushed by hand **7h14m** later.

`publishPipelineBranch` gives the orchestrator the missing half of that contract, wired into the two places a pipeline produces a head the review layer will gate on:

- **`commitPassedStage`** — after the stage's work is committed, before the cursor advances.
- **the `retry-stage` review path** — so a repair the operator committed locally is published before the retried reviewer fences on it. Without it the retry parks on the same unavailable remote it was meant to escape.

Properties:

- **Fast-forward only.** A remote revision the local head does not contain is someone else's repair; publishing over it would destroy work, so the pipeline refuses and lets the operator choose.
- **Failure is recoverable, never lossy.** The commit is already durable in `lastPassedCommit` when publication is attempted, so a park preserves the builder's work and a retry resumes from it.
- **No origin is not a stall.** A repo with no remote reports `unavailable` and the pipeline advances unpublished.
- **Steady state is free.** `publishedCommit` records what landed, so an unchanged head costs no network probe.

Two defects the tests forced out:

- Comparing against a revision pushed from another clone failed outright — `merge-base` cannot reason about a commit this worktree never fetched, so a genuine divergence surfaced as a transient git error instead of the actionable message. The ref is now fetched, and only when the object is genuinely absent.
- `newPipeline` had to seed the new field for the store round-trip to stay an identity.

## 2. A finished review could not be relayed to a pane-less implementer

`sendToImplementer` went straight to the legacy tmux ladder, which refuses a pane-less Claude host outright. A review whose implementer was structured had nowhere to deliver its result: flow `0d1364f8` held a real round-1 verdict and sat in `relaying` with its pipeline parked behind it.

The canonical send path has always tried structured hosts first with the tmux ladder as fallback. The relay now uses the same gate — `recoverDeadStructuredConversation` returns null whenever the conversation is not structured, so legacy pane-hosted flows keep exactly today's behavior.

## Verification

All suites run by path against an isolated `LLV_STATE_DIR`; nothing touches shared registry or runtime state.

| Suite | Result |
|---|---|
| `src/lib/pipelines/git.test.ts` | 18 pass (6 new, real bare-origin sandboxes) |
| `src/lib/pipelines/engine.test.ts` | 154 pass (4 new) |
| `src/lib/flows/engine.test.ts` | 34 pass (3 new) |
| `store` / `stageHostTeardown` / `controller` / `visibility` | 28 pass |
| **Combined** | **234 pass, 0 fail** |

New coverage: publication before flow creation with asserted ordering; a rejected push parking without losing the commit; a no-origin repo advancing; retry republishing a local repair; fast-forward, divergence, dirty-worktree refusal and the zero-probe steady state against real git; and both relay branches.

TypeScript clean, ESLint clean on all changed files, privacy publication gate PASS.

## Not included

The pipeline's `review flow paused during startup:` message is untruthful for a flow that paused while relaying (`0d1364f8` paused in `relaying`). That string is a load-bearing prefix in `RECONCILABLE_BOUND_FLOW_ERRORS`, so correcting the wording means changing an un-parking contract — left as a follow-up rather than destabilised alongside these fixes. With cause 2 fixed, that pause no longer occurs for this reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)