### PR TITLE
Board sync convergence across desktop, phone and agents (revives #38)

### DIFF
--- a/src/app/api/board/route.ts
+++ b/src/app/api/board/route.ts
@@ -124,7 +124,9 @@ export async function PATCH(request: NextRequest): Promise<NextResponse> {
       ? mutateBoard(payload.project, payload.baseRevision, mutationsWithConversationAliases(payload.mutations))
       : patchBoard(payload.project, payload.baseRevision, payload.patch!);
     if (!result.ok) return NextResponse.json({ error: "BOARD_REVISION_CONFLICT", board: result.board }, { status: 409, headers });
-    return NextResponse.json({ ok: true, board: result.board }, { headers });
+    /* `applied` lets the caller tell its own committed write from a no-op that
+       was accepted against a board some other writer produced (#38). */
+    return NextResponse.json({ ok: true, applied: result.applied, board: result.board }, { headers });
   } catch (error) {
     if (error instanceof ViewValidationError) return NextResponse.json({ error: error.code, message: error.message }, { status: error.status, headers });
     if (error instanceof BoardStoreError) return NextResponse.json({ error: "INTERNAL_ERROR", message: "board state unavailable" }, { status: 500, headers });

--- a/src/hooks/useBoardState.convergence.test.ts
+++ b/src/hooks/useBoardState.convergence.test.ts
@@ -527,6 +527,137 @@ test("a stale writer still loses after its key was evicted by retired-key compac
   store.dispose();
 });
 
+/*
+ * The adoption paths. A board arrives authoritatively in five places: a poll, a
+ * 409, an accepted write, the initial load, and the completion of the legacy
+ * seed. The first three are fenced; these cover the last two. A gate that only
+ * some entry points use is not a gate.
+ */
+
+test("intent queued on a cached remount loses to a foreign A→B→A the load reveals", async () => {
+  const server = durableBoard();
+  server.otherDevice("proj", [
+    { kind: "restore", path: "/a", placement: "manual" },
+    { kind: "restore", path: "/x", placement: "manual" },
+  ]);
+  /* One mount settles the project, so the session cache holds revision 1. */
+  const first = createBoardStore({ project: "proj", fetcher: server.fetcher, storage: null, scheduler: idleScheduler().scheduler });
+  await settle();
+  expect(first.getSnapshot().revision).toBe(1);
+  first.dispose();
+
+  /* While nothing of ours is mounted, the phone closes /x and reopens it. The
+     board ends exactly where the cache remembers it. */
+  server.otherDevice("proj", [{ kind: "close", path: "/x" }]);
+  server.otherDevice("proj", [{ kind: "restore", path: "/x", placement: "manual" }]);
+  expect(server.board("proj").revision).toBe(3);
+
+  const device = flakyDevice(server);
+  device.state.patchDown = true;
+  const sched = idleScheduler();
+  const store = createBoardStore({ project: "proj", fetcher: device.fetcher, storage: null, scheduler: sched.scheduler });
+  /* A remount paints the cached arrangement on its first frame (#172), so the
+     dashboard is live and the operator can act before the load has landed. */
+  expect(store.getSnapshot()).toMatchObject({ loaded: true, revision: 1 });
+  store.mutate([{ kind: "close", path: "/x" }]);
+
+  await settle();
+  device.state.patchDown = false;
+  sched.runTimeouts();
+  await settle();
+
+  /* The load is an authoritative adoption like any other. Assigning it straight
+     to `confirmed` leaves intent formed against the cached revision unfenced,
+     and it replays over a reopen this device never saw. */
+  expect(server.board("proj").prefs.hidden).toEqual([]);
+  expect(server.board("proj").prefs.manual).toEqual(["/a", "/x"]);
+  expect(server.board("proj").revision).toBe(3);
+  expect(store.getSnapshot().prefs.hidden).toEqual([]);
+  store.dispose();
+});
+
+test("intent queued during a seed that turns out to be a no-op loses to a foreign A→B→A", async () => {
+  const server = durableBoard();
+  const storage = { getItem: (key: string) => (key === "llvCols:proj" ? JSON.stringify({ manual: ["/x"], hidden: [], expanded: [] }) : null) };
+  let releaseSeed = () => {};
+  const seedGate = new Promise<void>((resolve) => (releaseSeed = resolve));
+  let patches = 0;
+  const fetcher = async (input: string, init?: RequestInit) => {
+    if (init && (init.method ?? "GET") !== "GET") {
+      patches += 1;
+      if (patches === 1) await seedGate;
+    }
+    return server.fetcher(input, init);
+  };
+  const sched = idleScheduler();
+  const store = createBoardStore({ project: "proj", fetcher, storage, scheduler: sched.scheduler });
+  await settle(); // the revision-0 GET landed; the seed PATCH is inflight and gated
+
+  /* Another device seeds the same arrangement from its own localStorage, then
+     the operator closes /x there and reopens it. The board now reads exactly
+     what this device's seed was going to write — so the seed will reduce to
+     nothing and be accepted from its stale revision-0 base. */
+  server.otherDevice("proj", [{ kind: "restore", path: "/x", placement: "manual" }]);
+  server.otherDevice("proj", [{ kind: "close", path: "/x" }]);
+  server.otherDevice("proj", [{ kind: "restore", path: "/x", placement: "manual" }]);
+  expect(server.board("proj").revision).toBe(3);
+
+  /* Meanwhile the operator closes /x on THIS device, against the optimistic
+     seed — intent formed with no knowledge of any of the above. */
+  store.mutate([{ kind: "close", path: "/x" }]);
+
+  releaseSeed();
+  await settle();
+  sched.runTimeouts();
+  await settle();
+
+  /* Seed completion adopts a board this device did not author, so it has to
+     fence like every other adoption. The reopen must survive. */
+  expect(server.board("proj").prefs.hidden).toEqual([]);
+  expect(server.board("proj").prefs.manual).toEqual(["/x"]);
+  expect(server.board("proj").revision).toBe(3);
+  expect(store.getSnapshot().prefs.hidden).toEqual([]);
+  store.dispose();
+});
+
+test("intent formed after an authored seed survives that seed landing", async () => {
+  const server = durableBoard();
+  const storage = { getItem: (key: string) => (key === "llvCols:proj" ? JSON.stringify({ manual: ["/seed"], hidden: [], expanded: [] }) : null) };
+  let releaseSeed = () => {};
+  const seedGate = new Promise<void>((resolve) => (releaseSeed = resolve));
+  let patches = 0;
+  const fetcher = async (input: string, init?: RequestInit) => {
+    if (init && (init.method ?? "GET") !== "GET") {
+      patches += 1;
+      if (patches === 1) await seedGate;
+    }
+    return server.fetcher(input, init);
+  };
+  const sched = idleScheduler();
+  const store = createBoardStore({ project: "proj", fetcher, storage, scheduler: sched.scheduler });
+  await settle();
+
+  /* The operator closes the very node the seed is placing, while the seed is
+     still inflight. Nobody else is writing — this is our own seed and our own
+     later decision about a key the seed touches. */
+  store.mutate([{ kind: "close", path: "/seed" }]);
+  expect(store.getSnapshot().prefs.hidden).toEqual(["/seed"]);
+
+  releaseSeed();
+  await settle();
+  sched.runTimeouts();
+  await settle();
+
+  /* Fencing must not treat this device's own authored seed as a competing
+     writer: the close was formed after it and has to land. Over-fencing here
+     silently eats the operator's action. */
+  expect(server.board("proj").prefs.hidden).toEqual(["/seed"]);
+  expect(server.board("proj").prefs.manual).toEqual([]);
+  expect(store.getSnapshot().prefs.hidden).toEqual(["/seed"]);
+  expect(store.getSnapshot().sync).toBe("current");
+  store.dispose();
+});
+
 test("a stale view loses only the keys another device wrote, and keeps the rest", async () => {
   const server = durableBoard();
   server.otherDevice("proj", [

--- a/src/hooks/useBoardState.convergence.test.ts
+++ b/src/hooks/useBoardState.convergence.test.ts
@@ -41,7 +41,10 @@ function durableBoard() {
       ? mutateBoard(body.project, body.baseRevision, body.mutations, file)
       : patchBoard(body.project, body.baseRevision, body.patch!, file);
     if (!result.ok) return { ok: false, status: 409, json: async () => ({ error: "BOARD_REVISION_CONFLICT", board: result.board }) };
-    return { ok: true, status: 200, json: async () => ({ ok: true, board: result.board }) };
+    /* Mirrors the route: `applied` reports whether the write committed or
+       reduced to a no-op, which is what separates our own work from another
+       writer's when both produce the same board. */
+    return { ok: true, status: 200, json: async () => ({ ok: true, applied: result.applied, board: result.board }) };
   };
   return {
     file,
@@ -259,6 +262,177 @@ test("an accepted no-op cannot smuggle a newer board past the fence", async () =
   expect(server.board("proj").prefs.viewMode).toBe("scheme");
   expect(server.board("proj").revision).toBe(3);
   expect(store.getSnapshot().sync).toBe("current");
+  store.dispose();
+});
+
+/*
+ * ABA. Comparing the board a view held against the board it adopted can only see
+ * endpoints: a key driven away from a value and back again lands on a snapshot
+ * identical to the one the stale view remembers, so a snapshot diff reports "no
+ * other writer touched this" and the superseded intent replays and wins. Both
+ * cycles below are ordinary operator behaviour — toggling a view mode, closing
+ * and reopening a window — so this is the common case, not a corner. Only a
+ * monotonic per-key revision distinguishes "never written" from "written twice".
+ */
+
+test("an A→B→A cycle on a presentation key still supersedes a stale writer", async () => {
+  const server = durableBoard();
+  server.otherDevice("proj", [{ kind: "restore", path: "/a", placement: "manual" }]);
+  server.otherDevice("proj", [{ kind: "set-presentation", viewMode: "scheme" }]);
+  const device = flakyDevice(server);
+  const sched = idleScheduler();
+  const store = createBoardStore({ project: "proj", fetcher: device.fetcher, storage: null, scheduler: sched.scheduler });
+  await settle();
+  expect(store.getSnapshot()).toMatchObject({ revision: 2, prefs: { viewMode: "scheme" } });
+
+  /* Offline, this device queues a switch to list view. */
+  device.state.patchDown = true;
+  store.mutate([{ kind: "set-presentation", viewMode: "list" }]);
+  await settle();
+
+  /* On the phone the operator tries list, then goes back to scheme — A → B → A.
+     The board ends on the same view mode the stale device last saw, but it was
+     written twice in between, and the second write is the informed decision. */
+  server.otherDevice("proj", [{ kind: "set-presentation", viewMode: "list" }]);
+  server.otherDevice("proj", [{ kind: "set-presentation", viewMode: "scheme" }]);
+  expect(server.board("proj").revision).toBe(4);
+  expect(server.board("proj").prefs.viewMode).toBe("scheme");
+
+  sched.tick();
+  await settle();
+  device.state.patchDown = false;
+  sched.runTimeouts();
+  await settle();
+
+  /* The stale switch must lose. A snapshot diff sees revision 2's "scheme" and
+     revision 4's "scheme" and concludes nobody wrote this key. */
+  expect(server.board("proj").prefs.viewMode).toBe("scheme");
+  expect(server.board("proj").revision).toBe(4);
+  expect(store.getSnapshot()).toMatchObject({ revision: 4, sync: "current", prefs: { viewMode: "scheme" } });
+  store.dispose();
+});
+
+test("an A→B→A cycle on a path key still supersedes a stale writer", async () => {
+  const server = durableBoard();
+  server.otherDevice("proj", [
+    { kind: "restore", path: "/a", placement: "manual" },
+    { kind: "restore", path: "/x", placement: "manual" },
+  ]);
+  const device = flakyDevice(server);
+  const sched = idleScheduler();
+  const store = createBoardStore({ project: "proj", fetcher: device.fetcher, storage: null, scheduler: sched.scheduler });
+  await settle();
+
+  /* Offline, this device closes /x. */
+  device.state.patchDown = true;
+  store.mutate([{ kind: "close", path: "/x" }]);
+  await settle();
+
+  /* On the phone the operator closes /x and then reopens it — the placement
+     leaves manual and comes back to exactly the same manual pin. */
+  server.otherDevice("proj", [{ kind: "close", path: "/x" }]);
+  server.otherDevice("proj", [{ kind: "restore", path: "/x", placement: "manual" }]);
+  expect(server.board("proj").prefs.manual).toEqual(["/a", "/x"]);
+  expect(server.board("proj").revision).toBe(3);
+
+  sched.tick();
+  await settle();
+  device.state.patchDown = false;
+  sched.runTimeouts();
+  await settle();
+
+  /* The reopen is the informed decision and must stand: the stale close cannot
+     re-hide a window the operator has since deliberately brought back. */
+  expect(server.board("proj").prefs.hidden).toEqual([]);
+  expect(server.board("proj").prefs.manual).toEqual(["/a", "/x"]);
+  expect(server.board("proj").revision).toBe(3);
+  expect(store.getSnapshot()).toMatchObject({ revision: 3, sync: "current" });
+  expect(store.getSnapshot().prefs.manual).toEqual(["/a", "/x"]);
+  store.dispose();
+});
+
+test("an A→B→A cycle still supersedes a stale writer when the key leaves the board", async () => {
+  const server = durableBoard();
+  server.otherDevice("proj", [{ kind: "restore", path: "/a", placement: "manual" }]);
+  const device = flakyDevice(server);
+  const sched = idleScheduler();
+  const store = createBoardStore({ project: "proj", fetcher: device.fetcher, storage: null, scheduler: sched.scheduler });
+  await settle();
+  expect(store.getSnapshot().prefs.favorites).toEqual([]);
+
+  /* Offline, this device crowns conv-1 a favourite. */
+  device.state.patchDown = true;
+  store.mutate([{ kind: "set-favorite", id: "conv-1", favorite: true }]);
+  await settle();
+
+  /* On the phone the operator crowns it and then takes it back. "Off" leaves no
+     trace in the board — conv-1 is simply absent from `favorites` again, exactly
+     as the stale device last saw it — so the key's causal revision is the only
+     surviving evidence that two writers have spoken. */
+  server.otherDevice("proj", [{ kind: "set-favorite", id: "conv-1", favorite: true }]);
+  server.otherDevice("proj", [{ kind: "set-favorite", id: "conv-1", favorite: false }]);
+  expect(server.board("proj").prefs.favorites).toEqual([]);
+  expect(server.board("proj").revision).toBe(3);
+
+  sched.tick();
+  await settle();
+  device.state.patchDown = false;
+  sched.runTimeouts();
+  await settle();
+
+  /* Taking it back is the informed decision and must stand. */
+  expect(server.board("proj").prefs.favorites).toEqual([]);
+  expect(server.board("proj").revision).toBe(3);
+  expect(store.getSnapshot()).toMatchObject({ revision: 3, sync: "current" });
+  expect(store.getSnapshot().prefs.favorites).toEqual([]);
+  store.dispose();
+});
+
+test("an accepted no-op that another writer made identical is not mistaken for our own write", async () => {
+  const server = durableBoard();
+  server.otherDevice("proj", [
+    { kind: "restore", path: "/a", placement: "manual" },
+    { kind: "restore", path: "/x", placement: "manual" },
+  ]);
+  let releaseFirst = () => {};
+  const gate = new Promise<void>((resolve) => (releaseFirst = resolve));
+  let patches = 0;
+  const fetcher = async (input: string, init?: RequestInit) => {
+    if (init && (init.method ?? "GET") !== "GET") {
+      patches += 1;
+      if (patches === 1) await gate;
+    }
+    return server.fetcher(input, init);
+  };
+  const sched = idleScheduler();
+  const store = createBoardStore({ project: "proj", fetcher, storage: null, scheduler: sched.scheduler });
+  await settle();
+
+  store.mutate([{ kind: "close", path: "/x" }]); // PATCH #1, held inflight at base revision 1
+
+  /* The phone closes /x too — the SAME change, so the board it produces is
+     byte-identical to the one this device's write would have produced. Nothing
+     in the response content can tell the two writers apart. */
+  server.otherDevice("proj", [{ kind: "close", path: "/x" }]);
+  expect(server.board("proj").revision).toBe(2);
+
+  /* Then this device changes its mind and reopens /x, formed against its own
+     revision-1 picture — before it could know the phone had spoken. */
+  store.mutate([{ kind: "restore", path: "/x", placement: "manual" }]);
+
+  releaseFirst();
+  await settle();
+
+  /* PATCH #1 reduces to nothing against revision 2 and is accepted from its
+     stale base. Treating that as "our write landed" would re-observe path:/x at
+     the phone's revision and let the queued reopen through, undoing a close this
+     device never saw. The server's `applied: false` is the only thing that
+     distinguishes the two, so the reopen must be fenced. */
+  expect(server.board("proj").prefs.hidden).toEqual(["/x"]);
+  expect(server.board("proj").prefs.manual).toEqual(["/a"]);
+  expect(server.board("proj").revision).toBe(2);
+  expect(store.getSnapshot()).toMatchObject({ revision: 2, sync: "current" });
+  expect(store.getSnapshot().prefs.hidden).toEqual(["/x"]);
   store.dispose();
 });
 

--- a/src/hooks/useBoardState.convergence.test.ts
+++ b/src/hooks/useBoardState.convergence.test.ts
@@ -1,0 +1,342 @@
+import { beforeEach, expect, test } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { boardFor, mutateBoard, patchBoard } from "@/lib/board/store";
+import type { BoardMutationV1 } from "@/lib/board/mutations";
+import type { BoardPatch } from "@/lib/board/validation";
+
+import { createBoardStore, resetPendingOpensForTest } from "./useBoardState";
+
+/*
+ * Convergence across desktop, phone and agents (revives #38).
+ *
+ * Every case here runs two writers against ONE durable board: the store under
+ * test (a device) and `server.otherDevice(...)`, which stands for the second
+ * phone/desktop or an agent PATCHing /api/board. The "server" is the real
+ * `mutateBoard`/`patchBoard`/`boardFor` over an isolated temp file, so these
+ * assert the shipped server semantics — including durability, since `boardFor`
+ * re-reads the file on every call and a fresh store is a restart.
+ */
+
+const settle = async () => {
+  for (let index = 0; index < 24; index += 1) await Promise.resolve();
+};
+
+function temporaryBoardFile(): string {
+  return path.join(fs.mkdtempSync(path.join(os.tmpdir(), "llv-board-converge-")), "board.json");
+}
+
+/** The real board API over an isolated file, plus a handle for the other device. */
+function durableBoard() {
+  const file = temporaryBoardFile();
+  const fetcher = async (input: string, init?: RequestInit) => {
+    if (!init || (init.method ?? "GET") === "GET") {
+      const project = new URL(input, "http://x").searchParams.get("project")!;
+      return { ok: true, status: 200, json: async () => ({ ok: true, board: boardFor(project, file) }) };
+    }
+    const body = JSON.parse(String(init.body)) as { project: string; baseRevision: number; patch?: BoardPatch; mutations?: BoardMutationV1[] };
+    const result = body.mutations
+      ? mutateBoard(body.project, body.baseRevision, body.mutations, file)
+      : patchBoard(body.project, body.baseRevision, body.patch!, file);
+    if (!result.ok) return { ok: false, status: 409, json: async () => ({ error: "BOARD_REVISION_CONFLICT", board: result.board }) };
+    return { ok: true, status: 200, json: async () => ({ ok: true, board: result.board }) };
+  };
+  return {
+    file,
+    fetcher,
+    board: (project: string) => boardFor(project, file),
+    /** Another device (or an agent) writing at the revision it just read. */
+    otherDevice: (project: string, mutations: BoardMutationV1[]) => {
+      const result = mutateBoard(project, boardFor(project, file).revision, mutations, file);
+      if (!result.ok) throw new Error("otherDevice write was rejected");
+      return result.board;
+    },
+  };
+}
+
+/** A device whose PATCHes can be cut off while its GETs keep working — a phone
+    that lost its uplink mid-drag, or a laptop lid closed with queued intent. */
+function flakyDevice(server: ReturnType<typeof durableBoard>) {
+  const state = { patchDown: false };
+  const fetcher = async (input: string, init?: RequestInit) => {
+    if (init && (init.method ?? "GET") !== "GET" && state.patchDown) throw new Error("offline");
+    return server.fetcher(input, init);
+  };
+  return { state, fetcher };
+}
+
+const idleScheduler = () => {
+  let pollFn = () => {};
+  const timeouts: Array<(() => void) | null> = [];
+  return {
+    scheduler: {
+      setInterval: (fn: () => void) => ((pollFn = fn), 1 as unknown as ReturnType<typeof setInterval>),
+      clearInterval: () => {},
+      setTimeout: (fn: () => void) => (timeouts.push(fn), timeouts.length as unknown as ReturnType<typeof setTimeout>),
+      clearTimeout: (handle: ReturnType<typeof setTimeout>) => {
+        const index = (handle as unknown as number) - 1;
+        if (timeouts[index]) timeouts[index] = null;
+      },
+    },
+    tick: () => pollFn(),
+    runTimeouts: () => {
+      for (const fn of timeouts.splice(0)) fn?.();
+    },
+  };
+};
+
+beforeEach(() => resetPendingOpensForTest());
+
+test("a view holding unflushed intent still converges on the other device's board", async () => {
+  const server = durableBoard();
+  server.otherDevice("proj", [
+    { kind: "restore", path: "/a", placement: "manual" },
+    { kind: "restore", path: "/x", placement: "manual" },
+  ]);
+  const device = flakyDevice(server);
+  const sched = idleScheduler();
+  const store = createBoardStore({ project: "proj", fetcher: device.fetcher, storage: null, scheduler: sched.scheduler });
+  await settle();
+  expect(store.getSnapshot().revision).toBe(1);
+
+  /* This device loses its uplink and the operator closes /x on it. The intent
+     is queued and rendered optimistically; the PATCH cannot land. */
+  device.state.patchDown = true;
+  store.mutate([{ kind: "close", path: "/x" }]);
+  await settle();
+  expect(store.getSnapshot().prefs.hidden).toEqual(["/x"]);
+
+  /* Meanwhile the operator keeps working on the other device: opens /b and
+     switches the project to list view. */
+  server.otherDevice("proj", [{ kind: "restore", path: "/b", placement: "manual" }]);
+  server.otherDevice("proj", [{ kind: "set-presentation", viewMode: "list" }]);
+
+  sched.tick();
+  await settle();
+
+  /* The regression: a read is not a write, so queued local intent must never
+     stop a view from learning where the board has moved. The old store skipped
+     every poll while the outbox was non-empty, so this device kept rendering the
+     revision-1 picture — /b missing, still on the scheme view — until a reload. */
+  const behind = store.getSnapshot();
+  expect(behind.prefs.manual).toEqual(["/a", "/b"]);
+  expect(behind.prefs.viewMode).toBe("list");
+  /* Its own unacknowledged close is replayed on top, not lost. */
+  expect(behind.prefs.hidden).toEqual(["/x"]);
+  /* And the view says out loud that it is rendering intent the durable board
+     does not carry, instead of claiming to be current. */
+  expect(behind.sync).toBe("stale");
+
+  device.state.patchDown = false;
+  sched.runTimeouts();
+  await settle();
+  expect(store.getSnapshot().sync).toBe("current");
+  expect(server.board("proj").prefs.manual).toEqual(["/a", "/b"]);
+  expect(server.board("proj").prefs.hidden).toEqual(["/x"]);
+  expect(server.board("proj").prefs.viewMode).toBe("list");
+  store.dispose();
+
+  /* Restart: a fresh store reads the same converged arrangement off disk. */
+  resetPendingOpensForTest();
+  const restarted = createBoardStore({ project: "proj", fetcher: server.fetcher, storage: null, scheduler: idleScheduler().scheduler });
+  await settle();
+  expect(restarted.getSnapshot().prefs).toMatchObject({ manual: ["/a", "/b"], hidden: ["/x"], viewMode: "list" });
+  restarted.dispose();
+});
+
+test("a view whose first load failed recovers on the next poll, not on a reload", async () => {
+  const server = durableBoard();
+  let firstGet = true;
+  const fetcher = async (input: string, init?: RequestInit) => {
+    if ((!init || (init.method ?? "GET") === "GET") && firstGet) {
+      firstGet = false;
+      throw new Error("offline");
+    }
+    return server.fetcher(input, init);
+  };
+  const sched = idleScheduler();
+  const store = createBoardStore({ project: "proj", fetcher, storage: null, scheduler: sched.scheduler });
+  await settle();
+  expect(store.getSnapshot().sync).toBe("unavailable");
+
+  sched.tick();
+  await settle();
+  /* The project is untouched, so the poll reads back the same revision 0 it
+     already holds. The old store only cleared `unavailable` when the revision
+     CHANGED, so a fresh project whose first GET failed stayed unavailable
+     forever — the dashboard held its skeleton and its convergence effects, which
+     bail on an unavailable board, never ran again. */
+  expect(store.getSnapshot()).toMatchObject({ revision: 0, loaded: true, sync: "current" });
+
+  /* And it is a live, writable board from here on. */
+  store.mutate([{ kind: "restore", path: "/a", placement: "manual" }]);
+  await settle();
+  expect(server.board("proj").prefs.manual).toEqual(["/a"]);
+  store.dispose();
+});
+
+test("a stale view's presentation intent loses to the device that acted on current state", async () => {
+  const server = durableBoard();
+  server.otherDevice("proj", [{ kind: "restore", path: "/a", placement: "manual" }]);
+  const device = flakyDevice(server);
+  const sched = idleScheduler();
+  const store = createBoardStore({ project: "proj", fetcher: device.fetcher, storage: null, scheduler: sched.scheduler });
+  await settle();
+  expect(store.getSnapshot().prefs.viewMode).toBeNull();
+
+  /* Laptop goes offline holding a view-mode switch. */
+  device.state.patchDown = true;
+  store.mutate([{ kind: "set-presentation", viewMode: "list" }]);
+  await settle();
+  expect(store.getSnapshot().prefs.viewMode).toBe("list");
+
+  /* Later, on the phone, the operator picks the scheme view against the board
+     as it actually stands. That writer saw current state; the laptop's queued
+     intent was formed against a picture the operator has since superseded. */
+  server.otherDevice("proj", [{ kind: "set-presentation", viewMode: "scheme" }]);
+  expect(server.board("proj").revision).toBe(2);
+
+  sched.tick();
+  await settle();
+  /* The laptop adopts the newer board and DROPS its superseded view-mode
+     intent instead of replaying it on top. */
+  expect(store.getSnapshot().prefs.viewMode).toBe("scheme");
+
+  device.state.patchDown = false;
+  sched.runTimeouts();
+  await settle();
+  /* The stale writer never lands: the phone's choice is still the durable one
+     and no revision was burned undoing it. */
+  expect(server.board("proj").prefs.viewMode).toBe("scheme");
+  expect(server.board("proj").revision).toBe(2);
+  expect(store.getSnapshot()).toMatchObject({ revision: 2, sync: "current" });
+  store.dispose();
+});
+
+test("an accepted no-op cannot smuggle a newer board past the fence", async () => {
+  const server = durableBoard();
+  server.otherDevice("proj", [
+    { kind: "restore", path: "/a", placement: "manual" },
+    { kind: "restore", path: "/x", placement: "manual" },
+  ]);
+  /* Hold the first PATCH open so a second intent queues behind it. */
+  let releaseFirst = () => {};
+  const gate = new Promise<void>((resolve) => (releaseFirst = resolve));
+  let patches = 0;
+  const fetcher = async (input: string, init?: RequestInit) => {
+    if (init && (init.method ?? "GET") !== "GET") {
+      patches += 1;
+      if (patches === 1) await gate;
+    }
+    return server.fetcher(input, init);
+  };
+  const sched = idleScheduler();
+  const store = createBoardStore({ project: "proj", fetcher, storage: null, scheduler: sched.scheduler });
+  await settle();
+
+  store.mutate([{ kind: "close", path: "/x" }]); // PATCH #1, held inflight at base revision 1
+  await settle();
+
+  /* While that write is in flight the other device closes /x itself and then
+     picks the scheme view — both against current state. */
+  server.otherDevice("proj", [{ kind: "close", path: "/x" }]);
+  server.otherDevice("proj", [{ kind: "set-presentation", viewMode: "scheme" }]);
+  expect(server.board("proj").revision).toBe(3);
+
+  store.mutate([{ kind: "set-presentation", viewMode: "list" }]); // queues behind the held PATCH
+
+  releaseFirst();
+  await settle();
+
+  /* PATCH #1 arrives with a base of 1 against a revision-3 board. The server
+     accepts it anyway — closing an already-closed /x changes nothing, and a
+     no-op is accepted from ANY base — so the response hands this view a board
+     another writer moved, with no 409 to mark it as behind. The queued view-mode
+     intent must still be fenced against that board rather than replayed on top. */
+  expect(store.getSnapshot().prefs.viewMode).toBe("scheme");
+  expect(server.board("proj").prefs.viewMode).toBe("scheme");
+  expect(server.board("proj").revision).toBe(3);
+  expect(store.getSnapshot().sync).toBe("current");
+  store.dispose();
+});
+
+test("a stale view loses only the keys another device wrote, and keeps the rest", async () => {
+  const server = durableBoard();
+  server.otherDevice("proj", [
+    { kind: "restore", path: "/a", placement: "manual" },
+    { kind: "restore", path: "/x", placement: "manual" },
+    { kind: "restore", path: "/b", placement: "manual" },
+  ]);
+  const device = flakyDevice(server);
+  const sched = idleScheduler();
+  const store = createBoardStore({ project: "proj", fetcher: device.fetcher, storage: null, scheduler: sched.scheduler });
+  await settle();
+
+  /* Offline, this device closes two windows. */
+  device.state.patchDown = true;
+  store.mutate([{ kind: "close", path: "/x" }, { kind: "close", path: "/b" }]);
+  await settle();
+  expect(store.getSnapshot().prefs.hidden).toEqual(["/x", "/b"]);
+
+  /* The other device rearranges /b — it wired /b under its parent — knowing the
+     current board. Nothing it did touches /x. */
+  server.otherDevice("proj", [{ kind: "restore", path: "/b", placement: "expanded" }]);
+
+  sched.tick();
+  await settle();
+  /* Per-key resolution: the close of /b is superseded and dropped; the close of
+     /x names a key nobody else wrote and survives. */
+  expect(store.getSnapshot().prefs.expanded).toEqual(["/b"]);
+  expect(store.getSnapshot().prefs.hidden).toEqual(["/x"]);
+
+  device.state.patchDown = false;
+  sched.runTimeouts();
+  await settle();
+  const durable = server.board("proj");
+  expect(durable.prefs.manual).toEqual(["/a"]);
+  expect(durable.prefs.expanded).toEqual(["/b"]);
+  expect(durable.prefs.hidden).toEqual(["/x"]);
+  expect(store.getSnapshot()).toMatchObject({ sync: "current", prefs: durable.prefs });
+  store.dispose();
+});
+
+test("a stale root reconciliation cannot retire the window another device just opened", async () => {
+  const server = durableBoard();
+  /* Both roots are board bookkeeping, seeded by reconciliation — neither is a
+     genuine user pin yet. */
+  server.otherDevice("proj", [{ kind: "reconcile-roots", roots: ["/a", "/gone"], removeManual: [] }]);
+  const device = flakyDevice(server);
+  const sched = idleScheduler();
+  const store = createBoardStore({ project: "proj", fetcher: device.fetcher, storage: null, scheduler: sched.scheduler });
+  await settle();
+  expect(store.getSnapshot().prefs.manual).toEqual(["/a", "/gone"]);
+
+  /* Offline, this device's dashboard reconciles roots against the picture it can
+     see: only /a is a live root, and its catalog says /gone is gone. */
+  device.state.patchDown = true;
+  store.mutate([{ kind: "reconcile-roots", roots: ["/a"], removeManual: ["/gone"] }]);
+  store.mutate([{ kind: "close", path: "/a" }]);
+  await settle();
+  expect(store.getSnapshot().prefs.manual).toEqual([]);
+
+  /* On the phone the operator deliberately pins /gone against current state. */
+  server.otherDevice("proj", [{ kind: "restore", path: "/gone", placement: "manual" }]);
+  expect(server.board("proj").explicitManual).toEqual(["/gone"]);
+
+  sched.tick();
+  await settle();
+  device.state.patchDown = false;
+  sched.runTimeouts();
+  await settle();
+
+  /* The stale reconciliation named /gone, so it is dropped rather than replayed
+     over the pin. The close of /a, which nobody else wrote, still lands. */
+  const durable = server.board("proj");
+  expect(durable.prefs.manual).toEqual(["/gone"]);
+  expect(durable.explicitManual).toEqual(["/gone"]);
+  expect(durable.prefs.hidden).toEqual(["/a"]);
+  expect(store.getSnapshot()).toMatchObject({ sync: "current", prefs: durable.prefs });
+  store.dispose();
+});

--- a/src/hooks/useBoardState.convergence.test.ts
+++ b/src/hooks/useBoardState.convergence.test.ts
@@ -3,6 +3,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
+import { MAX_RETIRED_KEY_REVISIONS } from "@/lib/board/keys";
 import { boardFor, mutateBoard, patchBoard } from "@/lib/board/store";
 import type { BoardMutationV1 } from "@/lib/board/mutations";
 import type { BoardPatch } from "@/lib/board/validation";
@@ -433,6 +434,96 @@ test("an accepted no-op that another writer made identical is not mistaken for o
   expect(server.board("proj").revision).toBe(2);
   expect(store.getSnapshot()).toMatchObject({ revision: 2, sync: "current" });
   expect(store.getSnapshot().prefs.hidden).toEqual(["/x"]);
+  store.dispose();
+});
+
+test("a stale pre-remap close loses to an informed post-remap write on the same conversation", async () => {
+  const server = durableBoard();
+  server.otherDevice("proj", [{ kind: "restore", path: "/old", placement: "manual" }]);
+  const device = flakyDevice(server);
+  const sched = idleScheduler();
+  const store = createBoardStore({ project: "proj", fetcher: device.fetcher, storage: null, scheduler: sched.scheduler });
+  await settle();
+  expect(store.getSnapshot().prefs.manual).toEqual(["/old"]);
+
+  /* Offline, this device closes the conversation under the name it knows. */
+  device.state.patchDown = true;
+  store.mutate([{ kind: "close", path: "/old" }]);
+  await settle();
+
+  /* The conversation resumes and mints a new transcript path; succession aliases
+     /old onto /new. Two names, ONE logical thing. */
+  server.otherDevice("proj", [{ kind: "remap-paths", pairs: [{ from: "/old", to: "/new" }] }]);
+  expect(server.board("proj").prefs.manual).toEqual(["/new"]);
+
+  /* Then, on the phone and against current state, the operator wires it under
+     its parent. This is an informed write on the same logical key. */
+  server.otherDevice("proj", [{ kind: "restore", path: "/new", placement: "expanded" }]);
+
+  sched.tick();
+  await settle();
+  device.state.patchDown = false;
+  sched.runTimeouts();
+  await settle();
+
+  /* The stale close named /old and the informed write named /new. If the two
+     names carry independent clocks, the close looks unopposed, replays, resolves
+     through the alias and hides the very node the phone just placed — ABA across
+     an alias boundary. One logical key, one causal revision. */
+  const durable = server.board("proj");
+  expect(durable.prefs.expanded).toEqual(["/new"]);
+  expect(durable.prefs.hidden).toEqual([]);
+  expect(store.getSnapshot()).toMatchObject({ sync: "current" });
+  expect(store.getSnapshot().prefs.expanded).toEqual(["/new"]);
+  expect(store.getSnapshot().prefs.hidden).toEqual([]);
+  store.dispose();
+});
+
+test("a stale writer still loses after its key was evicted by retired-key compaction", async () => {
+  const server = durableBoard();
+  /* A board whose retired-key history has long outgrown the cap: 600 favourites
+     the operator has since taken back, plus conv-1, retired at a much older
+     revision than any of them. Written straight to disk because reaching this
+     state through the API would take 600 round trips. */
+  const keyRevisions: Record<string, number> = { "favorite:conv-1": 50 };
+  for (let index = 0; index < 600; index += 1) keyRevisions[`favorite:dead-${index}`] = 200 + index;
+  fs.writeFileSync(server.file, JSON.stringify({ projects: { proj: {
+    schemaVersion: 1, revision: 1000, updatedAt: "2026-07-27T00:00:00.000Z",
+    pathAliases: {}, explicitManual: ["/a"], keyRevisions,
+    prefs: { manual: ["/a"], hidden: [], expanded: [], favorites: [], foldedEngineChildIds: [], expandedEngineTrayParentIds: [], viewMode: null, taskPanelOpen: false },
+  } } }), "utf8");
+
+  const device = flakyDevice(server);
+  const sched = idleScheduler();
+  const store = createBoardStore({ project: "proj", fetcher: device.fetcher, storage: null, scheduler: sched.scheduler });
+  await settle();
+  expect(store.getSnapshot().revision).toBe(1000);
+
+  /* Offline, this device crowns conv-1 — intent formed against conv-1's history
+     as it stood at revision 50. */
+  device.state.patchDown = true;
+  store.mutate([{ kind: "set-favorite", id: "conv-1", favorite: true }]);
+  await settle();
+
+  /* One unrelated write on the other device runs compaction. conv-1's entry is
+     far outside the cap and is evicted. */
+  server.otherDevice("proj", [{ kind: "set-presentation", viewMode: "list" }]);
+  const compacted = server.board("proj");
+  expect(Object.keys(compacted.keyRevisions ?? {}).length).toBeLessThanOrEqual(MAX_RETIRED_KEY_REVISIONS + 8);
+  expect(compacted.keyRevisions?.["favorite:conv-1"]).toBeUndefined();
+
+  sched.tick();
+  await settle();
+  device.state.patchDown = false;
+  sched.runTimeouts();
+  await settle();
+
+  /* Eviction must not resurrect the stale writer. Dropping an entry has to raise
+     a floor that absent keys read through, or forgetting history silently hands
+     old intent a win — the failure gets MORE likely the longer a board lives. */
+  expect(server.board("proj").prefs.favorites).toEqual([]);
+  expect(store.getSnapshot().prefs.favorites).toEqual([]);
+  expect(store.getSnapshot()).toMatchObject({ sync: "current" });
   store.dispose();
 });
 

--- a/src/hooks/useBoardState.convergence.test.ts
+++ b/src/hooks/useBoardState.convergence.test.ts
@@ -658,6 +658,47 @@ test("intent formed after an authored seed survives that seed landing", async ()
   store.dispose();
 });
 
+test("a late response carrying an older revision never rolls the board backward", async () => {
+  const server = durableBoard();
+  server.otherDevice("proj", [{ kind: "restore", path: "/a", placement: "manual" }]);
+  /* Captured eagerly: this is the body of a GET that was already in flight when
+     the board moved on, and it will be delivered after the newer one. */
+  const staleResponse = server.board("proj");
+
+  let deliverStale = false;
+  const fetcher = async (input: string, init?: RequestInit) => {
+    if ((!init || (init.method ?? "GET") === "GET") && deliverStale) {
+      deliverStale = false;
+      return { ok: true, status: 200, json: async () => ({ ok: true, board: staleResponse }) };
+    }
+    return server.fetcher(input, init);
+  };
+  const sched = idleScheduler();
+  const store = createBoardStore({ project: "proj", fetcher, storage: null, scheduler: sched.scheduler });
+  await settle();
+  expect(store.getSnapshot().revision).toBe(1);
+
+  server.otherDevice("proj", [{ kind: "restore", path: "/b", placement: "manual" }]);
+  sched.tick();
+  await settle();
+  expect(store.getSnapshot()).toMatchObject({ revision: 2, prefs: { manual: ["/a", "/b"] } });
+
+  /* Now the older in-flight read lands. Overlapping polls, or a load racing a
+     write, deliver responses out of order; adoption must be monotonic or the
+     board visibly loses a window that is durably present. */
+  deliverStale = true;
+  sched.tick();
+  await settle();
+  expect(store.getSnapshot()).toMatchObject({ revision: 2, prefs: { manual: ["/a", "/b"] } });
+
+  /* And the session cache must not have been rewound either — a remount primes
+     from it, so a backward write there resurfaces the stale board later. */
+  store.dispose();
+  const remounted = createBoardStore({ project: "proj", fetcher: server.fetcher, storage: null, scheduler: idleScheduler().scheduler });
+  expect(remounted.getSnapshot()).toMatchObject({ loaded: true, revision: 2 });
+  remounted.dispose();
+});
+
 test("a stale view loses only the keys another device wrote, and keeps the rest", async () => {
   const server = durableBoard();
   server.otherDevice("proj", [

--- a/src/hooks/useBoardState.sharedStore.dom.test.tsx
+++ b/src/hooks/useBoardState.sharedStore.dom.test.tsx
@@ -1,4 +1,4 @@
-import { afterAll, afterEach, beforeAll, expect, test } from "bun:test";
+import { afterAll, beforeAll, beforeEach, expect, test } from "bun:test";
 import { Window } from "happy-dom";
 import { act } from "react";
 import { createRoot } from "react-dom/client";
@@ -48,7 +48,12 @@ afterAll(() => {
   dom.close();
 });
 
-afterEach(() => resetPendingOpensForTest());
+/* Reset BEFORE each case, not only after: the session board cache and the
+   shared per-project stores are module-level, so a case in another file that
+   settled the same project name leaves a confirmed board behind. Adoption is
+   monotonic, so priming from that leftover would make this file's revision-1
+   stub look like a backward response and never load. */
+beforeEach(() => resetPendingOpensForTest());
 
 /** Minimal in-memory board API stubbed onto global fetch, which is what the
     hook's default fetcher calls. Counts GETs so a second store is detectable. */

--- a/src/hooks/useBoardState.sharedStore.dom.test.tsx
+++ b/src/hooks/useBoardState.sharedStore.dom.test.tsx
@@ -1,0 +1,135 @@
+import { afterAll, afterEach, beforeAll, expect, test } from "bun:test";
+import { Window } from "happy-dom";
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+
+import { applyBoardMutations, type BoardMutationV1 } from "@/lib/board/mutations";
+import type { BoardProjectStateV1 } from "@/lib/view/types";
+
+import { EMPTY_BOARD_PREFS, resetPendingOpensForTest, useBoardState, type BoardState } from "./useBoardState";
+
+/*
+ * One tab, two views of the same project (#38). The shell binds the project
+ * board for its favourites rail and the dashboard binds it for the scheme, so
+ * `useBoardState(project)` is mounted twice against one durable board. Both
+ * bindings must render the same window set at all times — a mutation dispatched
+ * through one is state the other is already showing, with no poll wait and no
+ * reload.
+ */
+
+const dom = new Window({ url: "http://localhost/" });
+const globals = globalThis as Record<string, unknown>;
+const overrides: Record<string, unknown> = {
+  window: dom,
+  document: dom.document,
+  navigator: dom.navigator,
+  Node: dom.Node,
+  HTMLElement: dom.HTMLElement,
+  Event: dom.Event,
+  IS_REACT_ACT_ENVIRONMENT: true,
+};
+const savedGlobals = new Map<string, { present: boolean; value: unknown }>();
+let savedFetch: unknown;
+
+beforeAll(() => {
+  for (const [key, value] of Object.entries(overrides)) {
+    savedGlobals.set(key, { present: key in globals, value: globals[key] });
+    globals[key] = value;
+  }
+  savedFetch = globals.fetch;
+});
+
+afterAll(() => {
+  for (const [key, saved] of savedGlobals) {
+    if (saved.present) globals[key] = saved.value;
+    else delete globals[key];
+  }
+  globals.fetch = savedFetch;
+  dom.close();
+});
+
+afterEach(() => resetPendingOpensForTest());
+
+/** Minimal in-memory board API stubbed onto global fetch, which is what the
+    hook's default fetcher calls. Counts GETs so a second store is detectable. */
+function stubBoardApi(initial: BoardProjectStateV1) {
+  let board = initial;
+  const counts = { get: 0, patch: 0 };
+  globals.fetch = (async (input: string, init?: RequestInit) => {
+    if (!init || (init.method ?? "GET") === "GET") {
+      counts.get += 1;
+      return { ok: true, status: 200, json: async () => ({ ok: true, board }) };
+    }
+    counts.patch += 1;
+    const body = JSON.parse(String(init.body)) as { baseRevision: number; mutations?: BoardMutationV1[] };
+    if (board.revision !== body.baseRevision) return { ok: false, status: 409, json: async () => ({ error: "BOARD_REVISION_CONFLICT", board }) };
+    board = { ...applyBoardMutations(board, body.mutations ?? []), revision: board.revision + 1, updatedAt: new Date(0).toISOString() };
+    return { ok: true, status: 200, json: async () => ({ ok: true, board }) };
+  }) as unknown as typeof fetch;
+  return { counts, current: () => board };
+}
+
+test("two bindings on one project render the same board without a reload", async () => {
+  const api = stubBoardApi({
+    schemaVersion: 1,
+    revision: 1,
+    updatedAt: new Date(0).toISOString(),
+    pathAliases: {},
+    explicitManual: [],
+    prefs: { ...EMPTY_BOARD_PREFS, manual: ["/a", "/x"] },
+  });
+
+  /* The shell's binding and the dashboard's binding, side by side. */
+  const seen: { shell: BoardState | null; dashboard: BoardState | null } = { shell: null, dashboard: null };
+  function Shell() {
+    seen.shell = useBoardState("proj");
+    return null;
+  }
+  function Dashboard() {
+    seen.dashboard = useBoardState("proj");
+    return null;
+  }
+  function Tab() {
+    return (
+      <>
+        <Shell />
+        <Dashboard />
+      </>
+    );
+  }
+
+  const host = dom.document.createElement("div");
+  dom.document.body.appendChild(host);
+  const root = createRoot(host as unknown as HTMLElement);
+  await act(async () => {
+    root.render(<Tab />);
+  });
+  await act(async () => {});
+
+  expect(seen.shell!.prefs.manual).toEqual(["/a", "/x"]);
+  expect(seen.dashboard!.prefs.manual).toEqual(["/a", "/x"]);
+  /* One project board, one loader: a second private store would double the GET
+     and give the two views separate outboxes and separate poll clocks. */
+  expect(api.counts.get).toBe(1);
+
+  /* The operator closes /x from the dashboard. */
+  await act(async () => {
+    seen.dashboard!.close("/x");
+  });
+  await act(async () => {});
+
+  /* Both views are on the same picture immediately — same window set, same
+     revision, same sync state. The regression: the shell's private store kept
+     showing /x until its own 10-second poll came round. */
+  expect(seen.dashboard!.prefs.manual).toEqual(["/a"]);
+  expect(seen.shell!.prefs.manual).toEqual(["/a"]);
+  expect(seen.shell!.prefs.hidden).toEqual(["/x"]);
+  expect(seen.shell!.revision).toBe(seen.dashboard!.revision);
+  expect(seen.shell!.sync).toBe(seen.dashboard!.sync);
+  expect(api.current().prefs.hidden).toEqual(["/x"]);
+
+  await act(async () => {
+    root.unmount();
+  });
+  host.remove();
+});

--- a/src/hooks/useBoardState.ts
+++ b/src/hooks/useBoardState.ts
@@ -2,7 +2,7 @@
 
 import { useEffect, useRef, useState } from "react";
 
-import { type BoardKeyRevisions, canonicalKey, keyRevisionAt, mutationKeys } from "@/lib/board/keys";
+import { boardKeysChanged, type BoardKeyRevisions, canonicalKey, keyRevisionAt, mutationKeys } from "@/lib/board/keys";
 import { applyBoardMutations, type BoardMutationV1 } from "@/lib/board/mutations";
 import type { BoardProjectStateV1 } from "@/lib/view/types";
 
@@ -326,9 +326,10 @@ export interface BoardStore {
  * THE DURABLE CONTRACT (#38), in one sentence, for anything that wants to build
  * per-project durable state on this shape:
  *
- *   One project-scoped shared store over a revision-fenced durable API, with a
- *   monotonic server-authored causal revision for each LOGICAL key that survives
- *   aliases, ABA, restart, and safe tombstone GC.
+ *   One project-scoped shared store over a revision-fenced durable API, fencing
+ *   every authoritative adoption with server-authored monotonic revisions per
+ *   logical key, canonical across aliases and preserved through restart and
+ *   causally safe tombstone GC.
  *
  * Every clause is load-bearing, and each was a real defect before it was true:
  *
@@ -351,10 +352,18 @@ export interface BoardStore {
  *   transcript path and the board aliases old onto new. Two names with
  *   independent clocks is ABA across an alias boundary, so the clocks merge by
  *   maximum onto one canonical key.
- * - **safe tombstone GC** — retired keys are evicted under a bound, and whatever
- *   is dropped raises `keyRevisionFloor`, which every absent key reads. Evicting
- *   without a floor makes forgotten keys read as never-written and quietly
- *   re-enables every stale writer, more likely the longer a board lives.
+ * - **causally safe tombstone GC** — retired keys are evicted under a bound, and
+ *   whatever is dropped raises `keyRevisionFloor`, which every absent key reads.
+ *   Evicting without a floor makes forgotten keys read as never-written and
+ *   quietly re-enables every stale writer, more likely the longer a board lives.
+ * - **EVERY authoritative adoption** — a board arrives from five places: a poll,
+ *   a 409, an accepted write, the initial load, and the completion of the legacy
+ *   seed. All five install it through `adopt` and nothing else assigns
+ *   `confirmed`. The last two were direct assignments and were the third
+ *   appearance of the same ABA class, after per-key and across-alias: a remount
+ *   paints from the session cache and is live before its load lands, so intent
+ *   queued against the cached revision has to be fenced against what the load
+ *   reveals. A gate only some entry points use is not a gate.
  *
  * The store itself: it holds the last server-confirmed board plus an outbox of
  * unacknowledged semantic mutations (close/restore/reconcile/remap/presentation),
@@ -455,17 +464,27 @@ export function createBoardStore(options: BoardStoreOptions): BoardStore {
   };
 
   /**
-   * Install a board this view did not author (a poll, or the 409 response to a
-   * rejected write). Any queued intent whose key has advanced past what that
-   * intent observed is superseded and dropped rather than replayed on top; the
-   * rest replays and still lands. Surviving intent marks the view stale, because
-   * it now renders something no other device has.
+   * THE causal gate. Every authoritative board — a poll, a 409, an accepted
+   * write, the initial load, the completion of the legacy seed — is installed
+   * through here and nowhere else. A board arriving by any other route would be
+   * adopted unfenced, and a gate only some entry points use is not a gate.
+   *
+   * Queued intent whose key has advanced past what that intent observed is
+   * superseded and dropped; the rest replays on top and still lands. Surviving
+   * intent marks the view stale, because it now renders something no other
+   * device has.
+   *
+   * `ownKeys` names keys THIS device just wrote and had acknowledged. Those are
+   * re-observed instead of fenced: our own accepted write is causally before the
+   * intent queued behind it — the operator formed that intent already knowing
+   * what they had just done — so it must not fence itself. Pass null whenever
+   * the board might carry another writer's work.
    */
-  const adoptForeign = (board: BoardProjectStateV1) => {
+  const adopt = (board: BoardProjectStateV1, ownKeys: ReadonlySet<string> | null = null) => {
     confirmed = board;
     unavailable = false;
     if (outbox.length > 0) {
-      outbox = fenceOutbox(outbox, board);
+      outbox = fenceOutbox(ownKeys === null ? outbox : reobserve(outbox, ownKeys, board), board);
       if (outbox.length > 0) rebased = true;
       else cancelRetry();
     }
@@ -509,7 +528,12 @@ export function createBoardStore(options: BoardStoreOptions): BoardStore {
         headers: { "content-type": "application/json" },
         body: JSON.stringify({ schemaVersion: 1, project, baseRevision, patch }),
       });
-      if (res.ok) return { status: "ok", board: ((await res.json()) as { board: BoardProjectStateV1 }).board };
+      if (res.ok) {
+        /* The seed is a write like any other and its verdict matters just as
+           much: accepted-but-no-op means the board came from somewhere else. */
+        const body = (await res.json()) as { applied?: boolean; board: BoardProjectStateV1 };
+        return { status: "ok", applied: body.applied, board: body.board };
+      }
       if (res.status === 409) return { status: "conflict", board: ((await res.json()) as { board: BoardProjectStateV1 }).board };
       return { status: "error" };
     } catch {
@@ -617,18 +641,14 @@ export function createBoardStore(options: BoardStoreOptions): BoardStore {
          arrangement comparison is only the fallback for a server that predates
          the field. */
       const authored = result.applied ?? sameArrangement(optimisticBoard(confirmed, prefix), result.board);
-      confirmed = result.board;
+      /* Only the keys THIS prefix wrote, and only when the write was ours. */
+      const ownKeys = authored
+        ? new Set(prefix.flatMap((mutation) => mutationKeys(mutation, result.board.pathAliases ?? {})))
+        : null;
+      /* The prefix is acknowledged either way — it either committed or was a
+         no-op — so it leaves the outbox before the rest is fenced. */
       outbox = outbox.slice(prefix.length);
-      if (outbox.length > 0) {
-        /* Re-observe only the keys THIS prefix wrote, and only when it was ours:
-           our own accepted write is causally before the intent queued behind it
-           and must not fence itself. */
-        const aliases = result.board.pathAliases ?? {};
-        const ownKeys = new Set(prefix.flatMap((mutation) => mutationKeys(mutation, aliases)));
-        outbox = fenceOutbox(authored ? reobserve(outbox, ownKeys, result.board) : outbox, result.board);
-        if (outbox.length > 0) rebased = true;
-      }
-      refresh();
+      adopt(result.board, ownKeys);
       if (outbox.length) void drain();
       return;
     }
@@ -668,7 +688,7 @@ export function createBoardStore(options: BoardStoreOptions): BoardStore {
          what it observed is superseded and dropped, and the rest replays on top
          and retries at the returned revision. A satisfied mutation then reduces
          to a server no-op that leaves the revision untouched. */
-      adoptForeign(result.board);
+      adopt(result.board);
       conflictStreak += 1;
       if (outbox.length === 0) {
         conflictStreak = 0;
@@ -702,7 +722,10 @@ export function createBoardStore(options: BoardStoreOptions): BoardStore {
     if (board.revision === 0 && isEmptyPrefs(board.prefs)) {
       const seed = readLegacyPrefs(project, storage);
       if (seed && isMeaningfulPrefs(seed)) {
-        /* Show the seed optimistically while its PATCH is inflight. */
+        /* A local optimistic paint, NOT an adoption: no server state is being
+           installed, and it is replaced by a gated `adopt` the moment the seed
+           PATCH answers. Keeping the loaded board's `keyRevisions` means intent
+           the operator forms against this paint observes real causal history. */
         confirmed = { ...board, prefs: seed };
         loaded = true;
         inflight = true;
@@ -710,8 +733,18 @@ export function createBoardStore(options: BoardStoreOptions): BoardStore {
         const result = await attemptSeed(seed, 0);
         inflight = false;
         if (disposed) return;
-        confirmed = result.status === "ok" || result.status === "conflict" ? result.board : board;
-        refresh();
+        /* Seed completion is an adoption, so it goes through the gate. The seed
+           only counts as OUR write when the server says it applied: a seed that
+           reduced to a no-op was accepted from its stale revision-0 base and the
+           board it returns is another writer's. When it did apply, the keys it
+           wrote are re-observed so intent the operator formed against the
+           optimistic seed — a close of the very node being seeded — is not
+           fenced by our own seed. */
+        const seeded = result.status === "ok" || result.status === "conflict" ? result.board : board;
+        const seedKeys = result.status === "ok" && result.applied === true
+          ? boardKeysChanged(board, result.board)
+          : null;
+        adopt(seeded, seedKeys);
         /* A mutation queued while the seed was inflight parked in the outbox
            because drain returns early during inflight. Flush it now so the
            queued action proceeds without another edit. */
@@ -719,9 +752,12 @@ export function createBoardStore(options: BoardStoreOptions): BoardStore {
         return;
       }
     }
-    confirmed = board;
+    /* The first load is authoritative too. A remount for a project already
+       loaded this session paints from the session cache and is live before this
+       lands (#172), so the operator can queue intent against the cached
+       revision — which the gate must fence against whatever the load reveals. */
     loaded = true;
-    refresh();
+    adopt(board);
   };
 
   /* Read where the board actually is. Deliberately NOT gated on a pending
@@ -742,7 +778,7 @@ export function createBoardStore(options: BoardStoreOptions): BoardStore {
            its response is the authoritative post-write board. */
         if (inflight || disposed || writeEpoch !== epoch) return;
         if (board.revision !== confirmed.revision) {
-          adoptForeign(board);
+          adopt(board);
           return;
         }
         /* Same revision, but the read itself proves the board is reachable again

--- a/src/hooks/useBoardState.ts
+++ b/src/hooks/useBoardState.ts
@@ -2,6 +2,7 @@
 
 import { useEffect, useRef, useState } from "react";
 
+import { type BoardKeyRevisions, mutationKeys } from "@/lib/board/keys";
 import { applyBoardMutations, type BoardMutationV1 } from "@/lib/board/mutations";
 import type { BoardProjectStateV1 } from "@/lib/view/types";
 
@@ -171,7 +172,13 @@ export function resetPendingOpensForTest(): void {
 }
 
 type WriteAttempt =
-  | { status: "ok"; board: BoardProjectStateV1 }
+  /* `applied` is the server's own verdict on whether this write committed or
+     reduced to a no-op. A no-op is accepted from any base revision, so only that
+     verdict reliably separates "my write produced this board" from "someone
+     else's did and mine changed nothing" — the two are identical by content when
+     both writers made the same change. Absent from a server older than this
+     field; the arrangement comparison stands in for it there. */
+  | { status: "ok"; applied?: boolean; board: BoardProjectStateV1 }
   | { status: "conflict"; board: BoardProjectStateV1 }
   /* The server's validator refused the batch content itself, identified by a
      structured permanent error code. Resending the same bytes can never
@@ -201,7 +208,7 @@ function sameArrangement(left: BoardProjectStateV1, right: BoardProjectStateV1):
   );
 }
 
-/* ── Convergence: per-key last-writer-wins, fenced by observation (#38).
+/* ── Convergence: per-key last-writer-wins, resolved by CAUSAL revision (#38).
  *
  * The writer is the device whose PATCH the server serializes last at a matching
  * `baseRevision`; the server rejects any writer whose base is behind (409). That
@@ -209,96 +216,70 @@ function sameArrangement(left: BoardProjectStateV1, right: BoardProjectStateV1):
  * newer board and replays its outbox on top — intent formed against a picture the
  * operator has since superseded then overwrites the informed device's work.
  *
- * So when a view adopts a board it did not author, it diffs the board it held
- * against the one it adopted to learn which KEYS another writer changed, and
- * drops its own queued mutations naming those keys. Queued mutations naming
- * untouched keys replay on top and still land. The last writer is therefore
- * always one that acted with knowledge of the current value of the key it wrote;
- * a view that has fallen behind loses exactly the keys it is behind on.
+ * So every queued mutation records, per key it writes, the causal revision it
+ * OBSERVED for that key when the operator formed it. Adopting a board another
+ * writer moved drops any queued mutation whose key has since advanced past what
+ * it observed; the rest replays on top and still lands. The last writer on a key
+ * is therefore always one that acted knowing that key's current value.
  *
- * A key is one independently-writable unit of the board: a transcript path's
- * placement, a favourite/tray identity, or one presentation field. */
+ * Comparing the board held against the board adopted would be cheaper and is
+ * what this started as, but it is structurally blind to ABA: a key driven away
+ * from a value and back — toggling a view mode, closing and reopening a window —
+ * lands on a snapshot identical to the one the stale view remembers, so the
+ * comparison reports "untouched" and the superseded intent wins. `keyRevisions`
+ * is monotonic, so A → B → A carries a strictly higher revision than the A the
+ * stale view saw. That is the whole reason the metadata is durable rather than
+ * derived.
+ *
+ * The key vocabulary is shared with the server in `@/lib/board/keys` — both
+ * sides must name keys identically or the fence silently stops matching. */
 
-function resolveThrough(pathname: string, aliases: Record<string, string>): string {
-  const seen = new Set<string>();
-  let resolved = pathname;
-  while (aliases[resolved] !== undefined) {
-    if (seen.has(resolved)) return resolved;
-    seen.add(resolved);
-    resolved = aliases[resolved]!;
-  }
-  return resolved;
+/** A queued mutation plus the causal revision it observed for each key it
+    writes, captured when the operator formed it. */
+interface OutboxEntry {
+  mutation: BoardMutationV1;
+  observed: BoardKeyRevisions;
 }
 
-/** A path's full placement, including whether the manual slot is a genuine user
-    pin — re-pinning a reconcile-seeded root is a real write on that key. */
-function placementOf(board: BoardProjectStateV1, pathname: string): string {
-  if (board.prefs.hidden.includes(pathname)) return "hidden";
-  if (board.prefs.expanded.includes(pathname)) return "expanded";
-  if (board.prefs.manual.includes(pathname)) return (board.explicitManual ?? []).includes(pathname) ? "pinned" : "manual";
-  return "absent";
+function observeKeys(mutation: BoardMutationV1, board: BoardProjectStateV1): OutboxEntry {
+  const revisions = board.keyRevisions ?? {};
+  const observed: BoardKeyRevisions = {};
+  for (const key of mutationKeys(mutation)) observed[key] = revisions[key] ?? 0;
+  return { mutation, observed };
 }
 
-function symmetricDifference(before: readonly string[] | undefined, after: readonly string[] | undefined): string[] {
-  const left = new Set(before ?? []);
-  const right = new Set(after ?? []);
-  return [...new Set([...left, ...right])].filter((item) => left.has(item) !== right.has(item));
-}
-
-/**
- * The keys another writer changed between the board this view held and the one
- * it adopted. Paths are compared through the adopted board's aliases, so a
- * succession remap that carried a placement to a new transcript path reads as no
- * change — bookkeeping must not look like a competing operator decision.
- */
-export function foreignKeys(before: BoardProjectStateV1, after: BoardProjectStateV1): Set<string> {
-  const keys = new Set<string>();
-  const aliases = after.pathAliases ?? {};
-  const paths = new Set<string>([
-    ...before.prefs.manual, ...before.prefs.hidden, ...before.prefs.expanded,
-    ...after.prefs.manual, ...after.prefs.hidden, ...after.prefs.expanded,
-  ]);
-  for (const pathname of paths) {
-    if (placementOf(before, pathname) !== placementOf(after, resolveThrough(pathname, aliases))) keys.add(`path:${pathname}`);
-  }
-  for (const id of symmetricDifference(before.prefs.favorites, after.prefs.favorites)) keys.add(`favorite:${id}`);
-  for (const id of symmetricDifference(before.prefs.foldedEngineChildIds, after.prefs.foldedEngineChildIds)) keys.add(`fold:${id}`);
-  for (const id of symmetricDifference(before.prefs.expandedEngineTrayParentIds, after.prefs.expandedEngineTrayParentIds)) keys.add(`tray:${id}`);
-  if (before.prefs.viewMode !== after.prefs.viewMode) keys.add("viewMode");
-  if (before.prefs.taskPanelOpen !== after.prefs.taskPanelOpen) keys.add("taskPanelOpen");
-  return keys;
-}
-
-/** Every key a queued mutation would write. A mutation naming several paths
-    (a reconciliation, a remap graph) travels whole, so one superseded path
-    supersedes the batch — it was computed against the picture that moved. */
-export function mutationKeys(mutation: BoardMutationV1): string[] {
-  switch (mutation.kind) {
-    case "close":
-    case "restore":
-      return [`path:${mutation.path}`];
-    case "reconcile-roots":
-      return [...mutation.roots, ...mutation.removeManual].map((pathname) => `path:${pathname}`);
-    case "remap-paths":
-      return mutation.pairs.flatMap(({ from, to }) => [`path:${from}`, `path:${to}`]);
-    case "set-favorite":
-      return [`favorite:${mutation.id}`];
-    case "set-engine-child-fold":
-      return [`fold:${mutation.id}`, `path:${mutation.path}`];
-    case "set-engine-tray-expanded":
-      return [`tray:${mutation.parentId}`];
-    case "set-presentation":
-      return [
-        ...(mutation.viewMode === undefined ? [] : ["viewMode"]),
-        ...(mutation.taskPanelOpen === undefined ? [] : ["taskPanelOpen"]),
-      ];
-  }
+/** True when some key this entry writes has advanced past what it observed —
+    another writer has spoken on that key since the operator formed this intent. */
+function superseded(entry: OutboxEntry, revisions: BoardKeyRevisions): boolean {
+  return Object.entries(entry.observed).some(([key, at]) => (revisions[key] ?? 0) > at);
 }
 
 /** Drop the queued intent a better-informed writer has already superseded. */
-export function fenceOutbox(outbox: readonly BoardMutationV1[], foreign: ReadonlySet<string>): BoardMutationV1[] {
-  if (foreign.size === 0) return [...outbox];
-  return outbox.filter((mutation) => !mutationKeys(mutation).some((key) => foreign.has(key)));
+export function fenceOutbox(outbox: readonly OutboxEntry[], revisions: BoardKeyRevisions): OutboxEntry[] {
+  return outbox.filter((entry) => !superseded(entry, revisions));
+}
+
+/** Re-observe the keys THIS device just wrote. Our own accepted write is
+    causally before intent still queued behind it — the operator formed that
+    intent already knowing what they had just done — so it must not fence itself.
+    Only the keys the landed prefix actually wrote are refreshed; a key some
+    other writer moved in the same response stays observed at its old value and
+    still supersedes. */
+function reobserve(outbox: readonly OutboxEntry[], ownKeys: ReadonlySet<string>, revisions: BoardKeyRevisions): OutboxEntry[] {
+  if (ownKeys.size === 0) return [...outbox];
+  return outbox.map((entry) => {
+    const refreshed: BoardKeyRevisions = { ...entry.observed };
+    let moved = false;
+    for (const key of Object.keys(entry.observed)) {
+      if (!ownKeys.has(key)) continue;
+      const at = revisions[key] ?? 0;
+      if (at !== refreshed[key]) {
+        refreshed[key] = at;
+        moved = true;
+      }
+    }
+    return moved ? { ...entry, observed: refreshed } : entry;
+  });
 }
 
 /** Replay the unacknowledged outbox over the last server-confirmed board to get
@@ -313,6 +294,8 @@ function optimisticBoard(confirmed: BoardProjectStateV1, outbox: readonly BoardM
     return confirmed;
   }
 }
+
+const mutationsOf = (outbox: readonly OutboxEntry[]): BoardMutationV1[] => outbox.map((entry) => entry.mutation);
 
 export interface BoardStoreOptions {
   project: string;
@@ -337,12 +320,21 @@ export interface BoardStore {
  * The per-project durable board arrangement, moved off per-browser storage into
  * the shared server store. It holds the last server-confirmed board plus an
  * outbox of unacknowledged semantic mutations (close/restore/reconcile/remap/
- * presentation); the UI renders the outbox replayed over the confirmed board
- * (optimistic), and a background drain flushes the outbox as a stable prefix. A
- * revision conflict adopts the server board, replays the whole outbox on top, and
- * retries, preserving a close, restore or remap intent across an interleaved
- * write by another device. The one-time legacy seed still writes
- * whole prefs; localStorage serves as read-only migration input.
+ * presentation), each tagged with the causal revision it observed for every key
+ * it writes. The UI renders the outbox replayed over the confirmed board
+ * (optimistic), and a background drain flushes it as a stable prefix.
+ *
+ * Adopting a board this view did not author — a revision conflict, a poll, or an
+ * accepted response that turns out to carry another writer's work — does NOT
+ * replay the whole outbox. Queued intent whose key has advanced past what that
+ * intent observed is dropped as superseded; only intent on keys nobody else has
+ * written since replays on top and retries. So a close, restore or remap
+ * survives an interleaved write to a DIFFERENT key, and loses to an interleaved
+ * write to the SAME key, which is the convergence guarantee (#38): the last
+ * writer on a key is always one that acted knowing that key's current value.
+ *
+ * The one-time legacy seed still writes whole prefs; localStorage serves as
+ * read-only migration input.
  */
 export function createBoardStore(options: BoardStoreOptions): BoardStore {
   const { project, fetcher, storage } = options;
@@ -360,6 +352,7 @@ export function createBoardStore(options: BoardStoreOptions): BoardStore {
     updatedAt: new Date(0).toISOString(),
     pathAliases: {},
     explicitManual: [],
+    keyRevisions: {},
     prefs: EMPTY_BOARD_PREFS,
   });
 
@@ -370,7 +363,7 @@ export function createBoardStore(options: BoardStoreOptions): BoardStore {
      carries the settled arrangement (#172) while a background GET revalidates. */
   const cachedConfirmed = confirmedBoards.get(project);
   let confirmed: BoardProjectStateV1 = cachedConfirmed ?? emptyBoard();
-  let outbox: BoardMutationV1[] = [];
+  let outbox: OutboxEntry[] = [];
   let inflight = false;
   let loaded = cachedConfirmed !== undefined;
   let unavailable = false;
@@ -413,7 +406,7 @@ export function createBoardStore(options: BoardStoreOptions): BoardStore {
   const refresh = () => {
     /* Every queued intent is acknowledged: this view is no longer behind. */
     if (outbox.length === 0) rebased = false;
-    const board = optimisticBoard(confirmed, outbox);
+    const board = optimisticBoard(confirmed, mutationsOf(outbox));
     snapshot = { prefs: board.prefs, explicitManual: board.explicitManual ?? [], revision: confirmed.revision, sync: syncFor(), loaded };
     /* Cache only a genuinely loaded, available board — never the pre-load empty
        board or an unavailable one — so a later mount primes from the settled
@@ -424,17 +417,16 @@ export function createBoardStore(options: BoardStoreOptions): BoardStore {
 
   /**
    * Install a board this view did not author (a poll, or the 409 response to a
-   * rejected write). Whatever another writer changed in the meantime supersedes
-   * this view's queued intent on those keys, so that intent is dropped rather
-   * than replayed on top; the rest replays and still lands. Surviving intent
-   * marks the view stale, because it now renders something no other device has.
+   * rejected write). Any queued intent whose key has advanced past what that
+   * intent observed is superseded and dropped rather than replayed on top; the
+   * rest replays and still lands. Surviving intent marks the view stale, because
+   * it now renders something no other device has.
    */
   const adoptForeign = (board: BoardProjectStateV1) => {
-    const previous = confirmed;
     confirmed = board;
     unavailable = false;
     if (outbox.length > 0) {
-      outbox = fenceOutbox(outbox, foreignKeys(previous, board));
+      outbox = fenceOutbox(outbox, board.keyRevisions ?? {});
       if (outbox.length > 0) rebased = true;
       else cancelRetry();
     }
@@ -449,7 +441,10 @@ export function createBoardStore(options: BoardStoreOptions): BoardStore {
         headers: { "content-type": "application/json" },
         body: JSON.stringify({ schemaVersion: 1, project, baseRevision, mutations }),
       });
-      if (res.ok) return { status: "ok", board: ((await res.json()) as { board: BoardProjectStateV1 }).board };
+      if (res.ok) {
+        const body = (await res.json()) as { applied?: boolean; board: BoardProjectStateV1 };
+        return { status: "ok", applied: body.applied, board: body.board };
+      }
       if (res.status === 409) return { status: "conflict", board: ((await res.json()) as { board: BoardProjectStateV1 }).board };
       if (res.status >= 400 && res.status < 500) {
         const body = (await res.json().catch(() => null)) as { error?: string } | null;
@@ -498,11 +493,14 @@ export function createBoardStore(options: BoardStoreOptions): BoardStore {
        fallback would render it indistinguishable from a no-op, and the
        server verdict plus bisection must isolate the invalid mutation while
        the valid ones sharing the batch land. */
-    const before = optimisticBoard(confirmed, outbox);
-    const nextOutbox = [...outbox, ...mutations];
+    const before = optimisticBoard(confirmed, mutationsOf(outbox));
+    /* Each mutation records the causal revision it observes for every key it
+       writes, taken from the board the operator is looking at right now. That is
+       the fixed point the fence compares against later. */
+    const nextOutbox = [...outbox, ...mutations.map((mutation) => observeKeys(mutation, confirmed))];
     let after: BoardProjectStateV1 | null;
     try {
-      after = applyBoardMutations(confirmed, nextOutbox);
+      after = applyBoardMutations(confirmed, mutationsOf(nextOutbox));
     } catch {
       after = null;
     }
@@ -562,7 +560,7 @@ export function createBoardStore(options: BoardStoreOptions): BoardStore {
        never drops a later optimistic action. Bounded to the server's per-PATCH
        mutation and body-size caps (tightened while bisecting a rejection); a
        longer outbox drains over consecutive requests. */
-    const prefix = patchPrefix(outbox, rejectCap ?? MAX_MUTATIONS_PER_PATCH);
+    const prefix = patchPrefix(mutationsOf(outbox), rejectCap ?? MAX_MUTATIONS_PER_PATCH);
     const result = await attemptMutations(prefix, confirmed.revision);
     inflight = false;
     if (disposed) return;
@@ -571,17 +569,24 @@ export function createBoardStore(options: BoardStoreOptions): BoardStore {
       conflictStreak = 0;
       rejectCap = null;
       unavailable = false;
-      /* The board this write should have produced. The server accepts a batch
-         that reduces to nothing from ANY base revision, so an accepted response
-         can hand back a board another writer has moved — with no 409 to mark
-         this view as behind. Diffing expected against returned names exactly the
-         keys that writer changed, and the outbox still queued behind this prefix
-         is fenced against them just as it would be after a conflict. */
-      const expected = optimisticBoard(confirmed, prefix);
+      /* Accepted does not mean authored. The server accepts a batch that
+         reduces to nothing from ANY base revision, so this response can carry a
+         board another writer moved, with no 409 to mark this view as behind —
+         and if that writer made the same change we did, the board it returns is
+         byte-identical to the one our write would have produced. Content cannot
+         separate those, so the server's own `applied` verdict decides; the
+         arrangement comparison is only the fallback for a server that predates
+         the field. */
+      const authored = result.applied ?? sameArrangement(optimisticBoard(confirmed, prefix), result.board);
       confirmed = result.board;
       outbox = outbox.slice(prefix.length);
       if (outbox.length > 0) {
-        outbox = fenceOutbox(outbox, foreignKeys(expected, result.board));
+        /* Re-observe only the keys THIS prefix wrote, and only when it was ours:
+           our own accepted write is causally before the intent queued behind it
+           and must not fence itself. */
+        const revisions = result.board.keyRevisions ?? {};
+        const rebased0 = authored ? reobserve(outbox, new Set(prefix.flatMap(mutationKeys)), revisions) : outbox;
+        outbox = fenceOutbox(rebased0, revisions);
         if (outbox.length > 0) rebased = true;
       }
       refresh();
@@ -620,10 +625,10 @@ export function createBoardStore(options: BoardStoreOptions): BoardStore {
     }
     if (result.status === "conflict") {
       /* Another writer landed first, so this attempt was stale and the server
-         refused it. Adopt the server board; intent this view formed against keys
-         that writer changed is superseded and dropped, and the rest replays on
-         top and retries at the returned revision. A satisfied mutation then
-         reduces to a server no-op that leaves the revision untouched. */
+         refused it. Adopt the server board; intent whose key has advanced past
+         what it observed is superseded and dropped, and the rest replays on top
+         and retries at the returned revision. A satisfied mutation then reduces
+         to a server no-op that leaves the revision untouched. */
       adoptForeign(result.board);
       conflictStreak += 1;
       if (outbox.length === 0) {

--- a/src/hooks/useBoardState.ts
+++ b/src/hooks/useBoardState.ts
@@ -2,7 +2,7 @@
 
 import { useEffect, useRef, useState } from "react";
 
-import { type BoardKeyRevisions, mutationKeys } from "@/lib/board/keys";
+import { type BoardKeyRevisions, canonicalKey, keyRevisionAt, mutationKeys } from "@/lib/board/keys";
 import { applyBoardMutations, type BoardMutationV1 } from "@/lib/board/mutations";
 import type { BoardProjectStateV1 } from "@/lib/view/types";
 
@@ -242,21 +242,26 @@ interface OutboxEntry {
 }
 
 function observeKeys(mutation: BoardMutationV1, board: BoardProjectStateV1): OutboxEntry {
-  const revisions = board.keyRevisions ?? {};
   const observed: BoardKeyRevisions = {};
-  for (const key of mutationKeys(mutation)) observed[key] = revisions[key] ?? 0;
+  /* Keys are canonicalized against the board this intent is formed on, and read
+     through `keyRevisionAt` so an absent key picks up the compaction floor
+     rather than a bare zero. */
+  for (const key of mutationKeys(mutation, board.pathAliases ?? {})) observed[key] = keyRevisionAt(board, key);
   return { mutation, observed };
 }
 
 /** True when some key this entry writes has advanced past what it observed —
-    another writer has spoken on that key since the operator formed this intent. */
-function superseded(entry: OutboxEntry, revisions: BoardKeyRevisions): boolean {
-  return Object.entries(entry.observed).some(([key, at]) => (revisions[key] ?? 0) > at);
+    another writer has spoken on that key since the operator formed this intent.
+    Recorded key names are re-canonicalized against the adopted board, so intent
+    formed under a transcript path that has since been aliased onto a successor
+    still reads the successor's clock instead of an orphaned one. */
+function superseded(entry: OutboxEntry, board: BoardProjectStateV1): boolean {
+  return Object.entries(entry.observed).some(([key, at]) => keyRevisionAt(board, key) > at);
 }
 
 /** Drop the queued intent a better-informed writer has already superseded. */
-export function fenceOutbox(outbox: readonly OutboxEntry[], revisions: BoardKeyRevisions): OutboxEntry[] {
-  return outbox.filter((entry) => !superseded(entry, revisions));
+export function fenceOutbox(outbox: readonly OutboxEntry[], board: BoardProjectStateV1): OutboxEntry[] {
+  return outbox.filter((entry) => !superseded(entry, board));
 }
 
 /** Re-observe the keys THIS device just wrote. Our own accepted write is
@@ -265,14 +270,15 @@ export function fenceOutbox(outbox: readonly OutboxEntry[], revisions: BoardKeyR
     Only the keys the landed prefix actually wrote are refreshed; a key some
     other writer moved in the same response stays observed at its old value and
     still supersedes. */
-function reobserve(outbox: readonly OutboxEntry[], ownKeys: ReadonlySet<string>, revisions: BoardKeyRevisions): OutboxEntry[] {
+function reobserve(outbox: readonly OutboxEntry[], ownKeys: ReadonlySet<string>, board: BoardProjectStateV1): OutboxEntry[] {
   if (ownKeys.size === 0) return [...outbox];
+  const aliases = board.pathAliases ?? {};
   return outbox.map((entry) => {
     const refreshed: BoardKeyRevisions = { ...entry.observed };
     let moved = false;
     for (const key of Object.keys(entry.observed)) {
-      if (!ownKeys.has(key)) continue;
-      const at = revisions[key] ?? 0;
+      if (!ownKeys.has(canonicalKey(key, aliases))) continue;
+      const at = keyRevisionAt(board, key);
       if (at !== refreshed[key]) {
         refreshed[key] = at;
         moved = true;
@@ -317,12 +323,44 @@ export interface BoardStore {
 }
 
 /**
- * The per-project durable board arrangement, moved off per-browser storage into
- * the shared server store. It holds the last server-confirmed board plus an
- * outbox of unacknowledged semantic mutations (close/restore/reconcile/remap/
- * presentation), each tagged with the causal revision it observed for every key
- * it writes. The UI renders the outbox replayed over the confirmed board
- * (optimistic), and a background drain flushes it as a stable prefix.
+ * THE DURABLE CONTRACT (#38), in one sentence, for anything that wants to build
+ * per-project durable state on this shape:
+ *
+ *   One project-scoped shared store over a revision-fenced durable API, with a
+ *   monotonic server-authored causal revision for each LOGICAL key that survives
+ *   aliases, ABA, restart, and safe tombstone GC.
+ *
+ * Every clause is load-bearing, and each was a real defect before it was true:
+ *
+ * - **project-scoped shared store** — one refcounted store per project per tab.
+ *   A private store per binding let one tab render two different window sets for
+ *   the same project, settled only by a reload.
+ * - **revision-fenced durable API** — a write carries the `baseRevision` it was
+ *   formed on; the server refuses any writer whose base is behind, and the state
+ *   is a file, so it survives a restart.
+ * - **monotonic causal revision per key** — `keyRevisions` in `@/lib/board/keys`.
+ *   Comparing the board held against the board adopted is blind to ABA: a key
+ *   driven away from a value and back reads identical to one never touched, so
+ *   superseded intent replayed and won. A monotonic clock cannot be fooled that
+ *   way.
+ * - **server-authored** — including whether a write `applied`. A no-op is
+ *   accepted from ANY base revision, so an accepted response can carry another
+ *   writer's board; when both writers made the same change the two boards are
+ *   identical, and only the server can say which happened.
+ * - **logical key, surviving aliases** — a conversation that resumes mints a new
+ *   transcript path and the board aliases old onto new. Two names with
+ *   independent clocks is ABA across an alias boundary, so the clocks merge by
+ *   maximum onto one canonical key.
+ * - **safe tombstone GC** — retired keys are evicted under a bound, and whatever
+ *   is dropped raises `keyRevisionFloor`, which every absent key reads. Evicting
+ *   without a floor makes forgotten keys read as never-written and quietly
+ *   re-enables every stale writer, more likely the longer a board lives.
+ *
+ * The store itself: it holds the last server-confirmed board plus an outbox of
+ * unacknowledged semantic mutations (close/restore/reconcile/remap/presentation),
+ * each tagged with the causal revision it observed for every key it writes. The
+ * UI renders the outbox replayed over the confirmed board (optimistic), and a
+ * background drain flushes it as a stable prefix.
  *
  * Adopting a board this view did not author — a revision conflict, a poll, or an
  * accepted response that turns out to carry another writer's work — does NOT
@@ -330,8 +368,8 @@ export interface BoardStore {
  * intent observed is dropped as superseded; only intent on keys nobody else has
  * written since replays on top and retries. So a close, restore or remap
  * survives an interleaved write to a DIFFERENT key, and loses to an interleaved
- * write to the SAME key, which is the convergence guarantee (#38): the last
- * writer on a key is always one that acted knowing that key's current value.
+ * write to the SAME key: the last writer on a key is always one that acted
+ * knowing that key's current value.
  *
  * The one-time legacy seed still writes whole prefs; localStorage serves as
  * read-only migration input.
@@ -353,6 +391,7 @@ export function createBoardStore(options: BoardStoreOptions): BoardStore {
     pathAliases: {},
     explicitManual: [],
     keyRevisions: {},
+    keyRevisionFloor: 0,
     prefs: EMPTY_BOARD_PREFS,
   });
 
@@ -426,7 +465,7 @@ export function createBoardStore(options: BoardStoreOptions): BoardStore {
     confirmed = board;
     unavailable = false;
     if (outbox.length > 0) {
-      outbox = fenceOutbox(outbox, board.keyRevisions ?? {});
+      outbox = fenceOutbox(outbox, board);
       if (outbox.length > 0) rebased = true;
       else cancelRetry();
     }
@@ -584,9 +623,9 @@ export function createBoardStore(options: BoardStoreOptions): BoardStore {
         /* Re-observe only the keys THIS prefix wrote, and only when it was ours:
            our own accepted write is causally before the intent queued behind it
            and must not fence itself. */
-        const revisions = result.board.keyRevisions ?? {};
-        const rebased0 = authored ? reobserve(outbox, new Set(prefix.flatMap(mutationKeys)), revisions) : outbox;
-        outbox = fenceOutbox(rebased0, revisions);
+        const aliases = result.board.pathAliases ?? {};
+        const ownKeys = new Set(prefix.flatMap((mutation) => mutationKeys(mutation, aliases)));
+        outbox = fenceOutbox(authored ? reobserve(outbox, ownKeys, result.board) : outbox, result.board);
         if (outbox.length > 0) rebased = true;
       }
       refresh();

--- a/src/hooks/useBoardState.ts
+++ b/src/hooks/useBoardState.ts
@@ -328,8 +328,8 @@ export interface BoardStore {
  *
  *   One project-scoped shared store over a revision-fenced durable API, fencing
  *   every authoritative adoption with server-authored monotonic revisions per
- *   logical key, canonical across aliases and preserved through restart and
- *   causally safe tombstone GC.
+ *   logical key, canonical across aliases and preserved through restart,
+ *   migration and causally safe tombstone GC.
  *
  * Every clause is load-bearing, and each was a real defect before it was true:
  *
@@ -352,6 +352,11 @@ export interface BoardStore {
  *   transcript path and the board aliases old onto new. Two names with
  *   independent clocks is ABA across an alias boundary, so the clocks merge by
  *   maximum onto one canonical key.
+ * - **preserved through migration** — a project-key repair that folds boards
+ *   together inherits their causal history by maximum. A migrated key is the
+ *   same logical key, so restarting its clock from the target's history rewinds
+ *   the class past writes that really happened. This holds even when the merge
+ *   moves no CONTENT: history alone moving is still a change worth persisting.
  * - **causally safe tombstone GC** — retired keys are evicted under a bound, and
  *   whatever is dropped raises `keyRevisionFloor`, which every absent key reads.
  *   Evicting without a floor makes forgotten keys read as never-written and
@@ -364,6 +369,16 @@ export interface BoardStore {
  *   paints from the session cache and is live before its load lands, so intent
  *   queued against the cached revision has to be fenced against what the load
  *   reveals. A gate only some entry points use is not a gate.
+ * - **monotonic adoption** — and the gate owes the same invariant it enforces.
+ *   Responses arrive out of order, so `adopt` refuses any board older than what
+ *   is confirmed; otherwise a late read rewinds the rendered board AND the
+ *   session cache a later remount primes from. That comparison lives in the gate
+ *   alone, so a sixth entry point cannot arrive without it.
+ *   The deliberate cost: if the durable board itself ever goes backward — a
+ *   state directory reset, a restore from an older backup — an open tab refuses
+ *   the rewind for the rest of its session. A page reload clears the session
+ *   cache and recovers. Refusing a real rewind costs a reload; accepting a late
+ *   echo silently deletes work, so the bias is chosen.
  *
  * The store itself: it holds the last server-confirmed board plus an outbox of
  * unacknowledged semantic mutations (close/restore/reconcile/remap/presentation),
@@ -479,8 +494,22 @@ export function createBoardStore(options: BoardStoreOptions): BoardStore {
    * intent queued behind it — the operator formed that intent already knowing
    * what they had just done — so it must not fence itself. Pass null whenever
    * the board might carry another writer's work.
+   *
+   * The gate also owns MONOTONICITY, and owns it in exactly one place. Responses
+   * arrive out of order — overlapping polls, a load racing the write that
+   * overtakes it — and installing an older revision rewinds both the rendered
+   * board and the session cache a later remount primes from, so a window that is
+   * durably present visibly disappears. Every adoption path passes through here,
+   * so this single comparison is the invariant rather than something each new
+   * entry point has to remember.
    */
   const adopt = (board: BoardProjectStateV1, ownKeys: ReadonlySet<string> | null = null) => {
+    if (board.revision < confirmed.revision) {
+      /* A late echo of a board we have already moved past. Nothing to adopt, but
+         `loaded` may have flipped on the way in, so the snapshot still publishes. */
+      refresh();
+      return;
+    }
     confirmed = board;
     unavailable = false;
     if (outbox.length > 0) {
@@ -719,6 +748,18 @@ export function createBoardStore(options: BoardStoreOptions): BoardStore {
       refresh();
       return;
     }
+    /* The first load is authoritative too. A remount for a project already
+       loaded this session paints from the session cache and is live before this
+       lands (#172), so the operator can queue intent against the cached
+       revision — which the gate must fence against whatever the load reveals.
+       Decide monotonicity BEFORE the seed branch: a late response can arrive
+       reporting revision 0, and the seed path would otherwise assign it
+       straight to `confirmed` and rewind a board we have already moved past. */
+    loaded = true;
+    if (board.revision < confirmed.revision) {
+      adopt(board);
+      return;
+    }
     if (board.revision === 0 && isEmptyPrefs(board.prefs)) {
       const seed = readLegacyPrefs(project, storage);
       if (seed && isMeaningfulPrefs(seed)) {
@@ -727,7 +768,6 @@ export function createBoardStore(options: BoardStoreOptions): BoardStore {
            PATCH answers. Keeping the loaded board's `keyRevisions` means intent
            the operator forms against this paint observes real causal history. */
         confirmed = { ...board, prefs: seed };
-        loaded = true;
         inflight = true;
         refresh();
         const result = await attemptSeed(seed, 0);
@@ -752,11 +792,6 @@ export function createBoardStore(options: BoardStoreOptions): BoardStore {
         return;
       }
     }
-    /* The first load is authoritative too. A remount for a project already
-       loaded this session paints from the session cache and is live before this
-       lands (#172), so the operator can queue intent against the cached
-       revision — which the gate must fence against whatever the load reveals. */
-    loaded = true;
     adopt(board);
   };
 

--- a/src/hooks/useBoardState.ts
+++ b/src/hooks/useBoardState.ts
@@ -160,12 +160,14 @@ export function queueColumnOpen(project: string, path: string, connected = false
   activeStores.get(project)?.();
 }
 
-/** Test seam: clears queued cross-project opens and the session board cache
-    between cases, so a board confirmed in one test never primes the next. */
+/** Test seam: clears queued cross-project opens, the session board cache and any
+    shared project store, so a board confirmed in one test never primes the next. */
 export function resetPendingOpensForTest(): void {
   pendingOpens.clear();
   activeStores.clear();
   confirmedBoards.clear();
+  for (const entry of sharedStores.values()) entry.store.dispose();
+  sharedStores.clear();
 }
 
 type WriteAttempt =
@@ -197,6 +199,106 @@ function sameArrangement(left: BoardProjectStateV1, right: BoardProjectStateV1):
     JSON.stringify({ prefs: left.prefs, pathAliases: left.pathAliases ?? {}, explicitManual: left.explicitManual ?? [] }) ===
     JSON.stringify({ prefs: right.prefs, pathAliases: right.pathAliases ?? {}, explicitManual: right.explicitManual ?? [] })
   );
+}
+
+/* ── Convergence: per-key last-writer-wins, fenced by observation (#38).
+ *
+ * The writer is the device whose PATCH the server serializes last at a matching
+ * `baseRevision`; the server rejects any writer whose base is behind (409). That
+ * alone does not stop a stale device from winning, because the client adopts the
+ * newer board and replays its outbox on top — intent formed against a picture the
+ * operator has since superseded then overwrites the informed device's work.
+ *
+ * So when a view adopts a board it did not author, it diffs the board it held
+ * against the one it adopted to learn which KEYS another writer changed, and
+ * drops its own queued mutations naming those keys. Queued mutations naming
+ * untouched keys replay on top and still land. The last writer is therefore
+ * always one that acted with knowledge of the current value of the key it wrote;
+ * a view that has fallen behind loses exactly the keys it is behind on.
+ *
+ * A key is one independently-writable unit of the board: a transcript path's
+ * placement, a favourite/tray identity, or one presentation field. */
+
+function resolveThrough(pathname: string, aliases: Record<string, string>): string {
+  const seen = new Set<string>();
+  let resolved = pathname;
+  while (aliases[resolved] !== undefined) {
+    if (seen.has(resolved)) return resolved;
+    seen.add(resolved);
+    resolved = aliases[resolved]!;
+  }
+  return resolved;
+}
+
+/** A path's full placement, including whether the manual slot is a genuine user
+    pin — re-pinning a reconcile-seeded root is a real write on that key. */
+function placementOf(board: BoardProjectStateV1, pathname: string): string {
+  if (board.prefs.hidden.includes(pathname)) return "hidden";
+  if (board.prefs.expanded.includes(pathname)) return "expanded";
+  if (board.prefs.manual.includes(pathname)) return (board.explicitManual ?? []).includes(pathname) ? "pinned" : "manual";
+  return "absent";
+}
+
+function symmetricDifference(before: readonly string[] | undefined, after: readonly string[] | undefined): string[] {
+  const left = new Set(before ?? []);
+  const right = new Set(after ?? []);
+  return [...new Set([...left, ...right])].filter((item) => left.has(item) !== right.has(item));
+}
+
+/**
+ * The keys another writer changed between the board this view held and the one
+ * it adopted. Paths are compared through the adopted board's aliases, so a
+ * succession remap that carried a placement to a new transcript path reads as no
+ * change — bookkeeping must not look like a competing operator decision.
+ */
+export function foreignKeys(before: BoardProjectStateV1, after: BoardProjectStateV1): Set<string> {
+  const keys = new Set<string>();
+  const aliases = after.pathAliases ?? {};
+  const paths = new Set<string>([
+    ...before.prefs.manual, ...before.prefs.hidden, ...before.prefs.expanded,
+    ...after.prefs.manual, ...after.prefs.hidden, ...after.prefs.expanded,
+  ]);
+  for (const pathname of paths) {
+    if (placementOf(before, pathname) !== placementOf(after, resolveThrough(pathname, aliases))) keys.add(`path:${pathname}`);
+  }
+  for (const id of symmetricDifference(before.prefs.favorites, after.prefs.favorites)) keys.add(`favorite:${id}`);
+  for (const id of symmetricDifference(before.prefs.foldedEngineChildIds, after.prefs.foldedEngineChildIds)) keys.add(`fold:${id}`);
+  for (const id of symmetricDifference(before.prefs.expandedEngineTrayParentIds, after.prefs.expandedEngineTrayParentIds)) keys.add(`tray:${id}`);
+  if (before.prefs.viewMode !== after.prefs.viewMode) keys.add("viewMode");
+  if (before.prefs.taskPanelOpen !== after.prefs.taskPanelOpen) keys.add("taskPanelOpen");
+  return keys;
+}
+
+/** Every key a queued mutation would write. A mutation naming several paths
+    (a reconciliation, a remap graph) travels whole, so one superseded path
+    supersedes the batch — it was computed against the picture that moved. */
+export function mutationKeys(mutation: BoardMutationV1): string[] {
+  switch (mutation.kind) {
+    case "close":
+    case "restore":
+      return [`path:${mutation.path}`];
+    case "reconcile-roots":
+      return [...mutation.roots, ...mutation.removeManual].map((pathname) => `path:${pathname}`);
+    case "remap-paths":
+      return mutation.pairs.flatMap(({ from, to }) => [`path:${from}`, `path:${to}`]);
+    case "set-favorite":
+      return [`favorite:${mutation.id}`];
+    case "set-engine-child-fold":
+      return [`fold:${mutation.id}`, `path:${mutation.path}`];
+    case "set-engine-tray-expanded":
+      return [`tray:${mutation.parentId}`];
+    case "set-presentation":
+      return [
+        ...(mutation.viewMode === undefined ? [] : ["viewMode"]),
+        ...(mutation.taskPanelOpen === undefined ? [] : ["taskPanelOpen"]),
+      ];
+  }
+}
+
+/** Drop the queued intent a better-informed writer has already superseded. */
+export function fenceOutbox(outbox: readonly BoardMutationV1[], foreign: ReadonlySet<string>): BoardMutationV1[] {
+  if (foreign.size === 0) return [...outbox];
+  return outbox.filter((mutation) => !mutationKeys(mutation).some((key) => foreign.has(key)));
 }
 
 /** Replay the unacknowledged outbox over the last server-confirmed board to get
@@ -285,16 +387,32 @@ export function createBoardStore(options: BoardStoreOptions): BoardStore {
   let rejectCap: number | null = null;
   let retryHandle: ReturnType<typeof scheduler.setTimeout> | null = null;
   let retryDelay = RETRY_BASE_MS;
+  /* This view has fallen behind: it adopted a board another writer moved while
+     holding intent of its own, so what it renders is a picture no other device
+     has. Published as `sync: "stale"` (and through presence to agents) until the
+     outbox is fully acknowledged — a lagging view must never be silently
+     trusted as current. */
+  let rebased = false;
+  /* Bumped whenever a PATCH is issued. A GET that started before a write must
+     not install its (now superseded) board over the write's response, which is
+     the authoritative post-write state. */
+  let writeEpoch = 0;
   const listeners = new Set<() => void>();
 
   const emit = () => {
     for (const listener of listeners) listener();
   };
-  const syncFor = (): BoardSync => (unavailable ? "unavailable" : inflight || outbox.length ? "pending" : "current");
+  const syncFor = (): BoardSync => {
+    if (unavailable) return "unavailable";
+    if (outbox.length === 0) return inflight ? "pending" : "current";
+    return rebased ? "stale" : "pending";
+  };
   /* Recompute the published snapshot from the confirmed board + outbox. The
      revision stays the confirmed one — optimistic mutations do not invent a
      revision the server has not assigned. */
   const refresh = () => {
+    /* Every queued intent is acknowledged: this view is no longer behind. */
+    if (outbox.length === 0) rebased = false;
     const board = optimisticBoard(confirmed, outbox);
     snapshot = { prefs: board.prefs, explicitManual: board.explicitManual ?? [], revision: confirmed.revision, sync: syncFor(), loaded };
     /* Cache only a genuinely loaded, available board — never the pre-load empty
@@ -304,7 +422,27 @@ export function createBoardStore(options: BoardStoreOptions): BoardStore {
     emit();
   };
 
+  /**
+   * Install a board this view did not author (a poll, or the 409 response to a
+   * rejected write). Whatever another writer changed in the meantime supersedes
+   * this view's queued intent on those keys, so that intent is dropped rather
+   * than replayed on top; the rest replays and still lands. Surviving intent
+   * marks the view stale, because it now renders something no other device has.
+   */
+  const adoptForeign = (board: BoardProjectStateV1) => {
+    const previous = confirmed;
+    confirmed = board;
+    unavailable = false;
+    if (outbox.length > 0) {
+      outbox = fenceOutbox(outbox, foreignKeys(previous, board));
+      if (outbox.length > 0) rebased = true;
+      else cancelRetry();
+    }
+    refresh();
+  };
+
   const attemptMutations = async (mutations: readonly BoardMutationV1[], baseRevision: number): Promise<WriteAttempt> => {
+    writeEpoch += 1;
     try {
       const res = await fetcher("/api/board", {
         method: "PATCH",
@@ -330,6 +468,7 @@ export function createBoardStore(options: BoardStoreOptions): BoardStore {
   /* The legacy seed writes whole prefs (the patch form) onto the empty
      revision-0 board — the mutation protocol only carries membership deltas. */
   const attemptSeed = async (patch: BoardPrefs, baseRevision: number): Promise<WriteAttempt> => {
+    writeEpoch += 1;
     try {
       const res = await fetcher("/api/board", {
         method: "PATCH",
@@ -432,8 +571,19 @@ export function createBoardStore(options: BoardStoreOptions): BoardStore {
       conflictStreak = 0;
       rejectCap = null;
       unavailable = false;
+      /* The board this write should have produced. The server accepts a batch
+         that reduces to nothing from ANY base revision, so an accepted response
+         can hand back a board another writer has moved — with no 409 to mark
+         this view as behind. Diffing expected against returned names exactly the
+         keys that writer changed, and the outbox still queued behind this prefix
+         is fenced against them just as it would be after a conflict. */
+      const expected = optimisticBoard(confirmed, prefix);
       confirmed = result.board;
       outbox = outbox.slice(prefix.length);
+      if (outbox.length > 0) {
+        outbox = fenceOutbox(outbox, foreignKeys(expected, result.board));
+        if (outbox.length > 0) rebased = true;
+      }
       refresh();
       if (outbox.length) void drain();
       return;
@@ -469,13 +619,17 @@ export function createBoardStore(options: BoardStoreOptions): BoardStore {
       return;
     }
     if (result.status === "conflict") {
-      /* Another writer landed first. Adopt the server board and retain the whole
-         outbox: the optimistic replay puts this intent back on top, and we retry
-         the same prefix at the returned revision. A satisfied mutation then
+      /* Another writer landed first, so this attempt was stale and the server
+         refused it. Adopt the server board; intent this view formed against keys
+         that writer changed is superseded and dropped, and the rest replays on
+         top and retries at the returned revision. A satisfied mutation then
          reduces to a server no-op that leaves the revision untouched. */
-      confirmed = result.board;
+      adoptForeign(result.board);
       conflictStreak += 1;
-      refresh();
+      if (outbox.length === 0) {
+        conflictStreak = 0;
+        return;
+      }
       if (conflictStreak <= MAX_CONFLICT_RETRIES) void drain();
       else scheduleRetry();
       return;
@@ -526,17 +680,33 @@ export function createBoardStore(options: BoardStoreOptions): BoardStore {
     refresh();
   };
 
+  /* Read where the board actually is. Deliberately NOT gated on a pending
+     outbox: a read is not a write, and the old outbox gate meant a device that
+     could not flush its intent — an uplink that dropped mid-drag, a laptop lid
+     closed — also stopped learning that the board had moved, and rendered a
+     frozen picture until a reload (#38). Unflushed intent survives adoption
+     through the same fence the 409 path uses. */
   const poll = () => {
-    if (inflight || outbox.length || disposed) return;
+    if (inflight || disposed) return;
+    const epoch = writeEpoch;
     void (async () => {
       try {
         const res = await fetcher(getUrl);
         if (!res.ok) return;
         const board = ((await res.json()) as { board: BoardProjectStateV1 }).board;
-        /* Another device moved the board. Adopt it while preserving unflushed
-           local intent through the outbox/inflight guard. */
-        if (!inflight && outbox.length === 0 && !disposed && board.revision !== confirmed.revision) {
-          confirmed = board;
+        /* A write that started or finished during this read owns the outcome:
+           its response is the authoritative post-write board. */
+        if (inflight || disposed || writeEpoch !== epoch) return;
+        if (board.revision !== confirmed.revision) {
+          adoptForeign(board);
+          return;
+        }
+        /* Same revision, but the read itself proves the board is reachable again
+           — otherwise a project still at revision 0 whose first load failed would
+           stay unavailable forever, holding the dashboard skeleton. A held
+           outbox means writes are still being refused (schema skew), so the
+           unavailable signal stands until that intent can drain. */
+        if (unavailable && outbox.length === 0) {
           unavailable = false;
           refresh();
         }
@@ -584,6 +754,45 @@ function initialBoardSnapshot(project: string | null): BoardSnapshot {
   return { prefs: cached.prefs, explicitManual: cached.explicitManual ?? [], revision: cached.revision, sync: "current", loaded: true };
 }
 
+/* One store per project per tab, refcounted across bindings. A project board is
+   bound more than once in the same tab — the shell rail and the dashboard both
+   mount `useBoardState(project)` — and a private store per binding gave each its
+   own confirmed board, outbox and poll clock, so one tab could render two
+   different window sets for one project and only a reload settled them (#38).
+   Sharing makes a mutation dispatched through one binding state the other is
+   already showing, and leaves exactly one writer per project per tab. */
+interface SharedBoardStore {
+  store: BoardStore;
+  refs: number;
+}
+const sharedStores = new Map<string, SharedBoardStore>();
+
+function acquireBoardStore(project: string): BoardStore {
+  const existing = sharedStores.get(project);
+  if (existing) {
+    existing.refs += 1;
+    return existing.store;
+  }
+  let storage: Pick<Storage, "getItem"> | null = null;
+  try {
+    storage = window.localStorage;
+  } catch {
+    storage = null;
+  }
+  const store = createBoardStore({ project, fetcher: (input, init) => fetch(input, init), storage });
+  sharedStores.set(project, { store, refs: 1 });
+  return store;
+}
+
+function releaseBoardStore(project: string): void {
+  const entry = sharedStores.get(project);
+  if (!entry) return;
+  entry.refs -= 1;
+  if (entry.refs > 0) return;
+  sharedStores.delete(project);
+  entry.store.dispose();
+}
+
 export interface BoardState extends BoardSnapshot {
   /** Dispatch a semantic mutation batch (close/restore/reconcile/remap/
       presentation). The store replays it optimistically and flushes durably. */
@@ -627,19 +836,13 @@ export function useBoardState(project: string | null): BoardState {
       setBound({ project, snapshot: UNAVAILABLE_SNAPSHOT });
       return;
     }
-    let storage: Pick<Storage, "getItem"> | null = null;
-    try {
-      storage = window.localStorage;
-    } catch {
-      storage = null;
-    }
-    const store = createBoardStore({ project, fetcher: (input, init) => fetch(input, init), storage });
+    const store = acquireBoardStore(project);
     storeRef.current = store;
     setBound({ project, snapshot: store.getSnapshot() });
     const unsubscribe = store.subscribe(() => setBound({ project, snapshot: store.getSnapshot() }));
     return () => {
       unsubscribe();
-      store.dispose();
+      releaseBoardStore(project);
       storeRef.current = null;
     };
   }, [project]);

--- a/src/lib/board/keys.test.ts
+++ b/src/lib/board/keys.test.ts
@@ -3,7 +3,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
-import { mutationKeys, pathKey, VIEW_MODE_KEY } from "./keys";
+import { keyRevisionAt, MAX_RETIRED_KEY_REVISIONS, mutationKeys, pathKey, VIEW_MODE_KEY } from "./keys";
 import { boardFor, mutateBoard, remapBoardPaths } from "./store";
 
 /*
@@ -11,7 +11,10 @@ import { boardFor, mutateBoard, remapBoardPaths } from "./store";
  * revision of the keys it changed. This is what makes ABA detectable — a value
  * driven away and back is indistinguishable by comparison, and unmistakable by
  * revision. Any surface that wants revision-fenced per-project durable settings
- * relies on exactly these four properties.
+ * relies on exactly these properties: revisions advance on every write, move
+ * only the keys a write changed, are durable across a restart, unify across an
+ * alias boundary so one logical key has one clock, and survive tombstone GC by
+ * leaving a floor behind rather than forgetting.
  */
 
 function temporaryFile(): string {
@@ -73,18 +76,90 @@ test("causal revisions are durable and survive a restart", () => {
   expect(at(file, pathKey("/a"))).toBe(8);
 });
 
-test("a remap carries a placement without burning the old path's causal revision", () => {
+test("a remap unifies the two names onto one clock without burning it", () => {
   const file = temporaryFile();
   mutateBoard("proj", 0, [{ kind: "restore", path: "/old", placement: "manual" }], file);
   expect(at(file, pathKey("/old"))).toBe(1);
 
   remapBoardPaths("proj", [{ from: "/old", to: "/new" }], { filePath: file });
-  /* Succession bookkeeping is not a competing operator decision: the placement
-     followed the conversation, so queued intent naming /old is not superseded
-     by the rename alone. The retired alias source is pruned from the map. */
   const board = boardFor("proj", file);
   expect(board.prefs.manual).toEqual(["/new"]);
-  expect(board.keyRevisions?.[pathKey("/old")]).toBe(1);
+  /* One logical thing, one clock. The alias source stops holding a clock of its
+     own — two names with independent clocks is ABA across an alias boundary, and
+     a stale writer naming /old would look unopposed against a write naming /new.
+     Both names now read the same revision. */
+  expect(board.keyRevisions?.[pathKey("/old")]).toBeUndefined();
+  expect(keyRevisionAt(board, pathKey("/old"))).toBe(1);
+  expect(keyRevisionAt(board, pathKey("/new"))).toBe(1);
+  /* Succession is bookkeeping, not a competing operator decision, so the rename
+     alone does not advance the clock and cannot fence unrelated queued intent. */
+  expect(keyRevisionAt(board, pathKey("/new"))).toBe(1);
+
+  /* An informed post-remap write advances the shared clock, and the old name
+     sees it — which is what fences a stale pre-remap writer. */
+  mutateBoard("proj", board.revision, [{ kind: "close", path: "/new" }], file);
+  expect(keyRevisionAt(boardFor("proj", file), pathKey("/old"))).toBe(3);
+});
+
+test("a merged alias class keeps the newer of the two clocks", () => {
+  const file = temporaryFile();
+  mutateBoard("proj", 0, [{ kind: "restore", path: "/old", placement: "manual" }], file); // path:/old = 1
+  mutateBoard("proj", 1, [{ kind: "restore", path: "/new", placement: "manual" }], file); // path:/new = 2
+  mutateBoard("proj", 2, [{ kind: "remap-paths", pairs: [{ from: "/old", to: "/new" }] }], file);
+
+  /* Merging takes the maximum, so a rename can only ever move a class's clock
+     forward. Intent formed against /old at revision 1 is now correctly fenced by
+     the write that landed on /new at revision 2 — collapsing to the lower clock
+     would un-supersede it. */
+  const board = boardFor("proj", file);
+  expect(keyRevisionAt(board, pathKey("/old"))).toBeGreaterThanOrEqual(2);
+  expect(keyRevisionAt(board, pathKey("/old"))).toBe(keyRevisionAt(board, pathKey("/new")));
+});
+
+test("a board written before keys were unified normalizes its alias clocks on read", () => {
+  const file = temporaryFile();
+  /* The shape an earlier build could leave behind: an alias in place, and the
+     source still holding a clock of its own. Canonicalizing only on lookup would
+     leave that clock unreachable, so /new would read as never-written and a
+     stale writer naming either name would sail through. */
+  fs.writeFileSync(file, JSON.stringify({ projects: { proj: {
+    schemaVersion: 1, revision: 9, updatedAt: "2026-07-27T00:00:00.000Z",
+    pathAliases: { "/old": "/new" }, explicitManual: ["/new"],
+    keyRevisions: { "path:/old": 7, "path:/new": 3 },
+    prefs: { manual: ["/new"], hidden: [], expanded: [], favorites: [], viewMode: null, taskPanelOpen: false },
+  } } }), "utf8");
+
+  const board = boardFor("proj", file);
+  expect(board.keyRevisions?.[pathKey("/old")]).toBeUndefined();
+  /* Merged by maximum, so the older name's history is inherited rather than
+     lost, and both names answer with it. */
+  expect(board.keyRevisions?.[pathKey("/new")]).toBe(7);
+  expect(keyRevisionAt(board, pathKey("/old"))).toBe(7);
+});
+
+test("compaction raises a floor instead of erasing causal history", () => {
+  const file = temporaryFile();
+  const keyRevisions: Record<string, number> = { "favorite:ancient": 5 };
+  for (let index = 0; index < MAX_RETIRED_KEY_REVISIONS + 40; index += 1) keyRevisions[`favorite:dead-${index}`] = 100 + index;
+  fs.writeFileSync(file, JSON.stringify({ projects: { proj: {
+    schemaVersion: 1, revision: 900, updatedAt: "2026-07-27T00:00:00.000Z",
+    pathAliases: {}, explicitManual: [], keyRevisions,
+    prefs: { manual: [], hidden: [], expanded: [], favorites: [], viewMode: null, taskPanelOpen: false },
+  } } }), "utf8");
+
+  mutateBoard("proj", 900, [{ kind: "set-presentation", viewMode: "list" }], file);
+  const board = boardFor("proj", file);
+
+  /* Bounded: the map cannot grow with every id the operator ever touched. */
+  expect(Object.keys(board.keyRevisions ?? {}).length).toBeLessThanOrEqual(MAX_RETIRED_KEY_REVISIONS + 8);
+  /* Safe: what was dropped is not forgotten. An evicted key reads the floor, so
+     it can still supersede intent older than the history that was discarded —
+     reporting zero would quietly re-enable every stale writer. */
+  expect(board.keyRevisions?.["favorite:ancient"]).toBeUndefined();
+  expect(board.keyRevisionFloor).toBeGreaterThan(5);
+  expect(keyRevisionAt(board, "favorite:ancient")).toBe(board.keyRevisionFloor!);
+  /* Live keys keep their exact clock rather than being flattened to the floor. */
+  expect(board.keyRevisions?.[VIEW_MODE_KEY]).toBe(901);
 });
 
 test("mutationKeys names every key a mutation contends on", () => {

--- a/src/lib/board/keys.test.ts
+++ b/src/lib/board/keys.test.ts
@@ -1,0 +1,99 @@
+import { expect, test } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { mutationKeys, pathKey, VIEW_MODE_KEY } from "./keys";
+import { boardFor, mutateBoard, remapBoardPaths } from "./store";
+
+/*
+ * The durable contract behind convergence (#38): every write stamps the causal
+ * revision of the keys it changed. This is what makes ABA detectable — a value
+ * driven away and back is indistinguishable by comparison, and unmistakable by
+ * revision. Any surface that wants revision-fenced per-project durable settings
+ * relies on exactly these four properties.
+ */
+
+function temporaryFile(): string {
+  return path.join(fs.mkdtempSync(path.join(os.tmpdir(), "llv-board-keys-")), "board.json");
+}
+const at = (file: string, key: string) => boardFor("proj", file).keyRevisions?.[key];
+
+test("a key's causal revision advances on every write, so A→B→A stays distinguishable", () => {
+  const file = temporaryFile();
+  mutateBoard("proj", 0, [{ kind: "set-presentation", viewMode: "scheme" }], file);
+  const first = at(file, VIEW_MODE_KEY);
+  expect(first).toBe(1);
+
+  mutateBoard("proj", 1, [{ kind: "set-presentation", viewMode: "list" }], file);
+  mutateBoard("proj", 2, [{ kind: "set-presentation", viewMode: "scheme" }], file);
+
+  /* The value is back where it started and the board is NOT — which is the
+     whole point. A view holding intent formed when this key read revision 1 can
+     still tell that two writers have spoken since. */
+  expect(boardFor("proj", file).prefs.viewMode).toBe("scheme");
+  expect(at(file, VIEW_MODE_KEY)).toBe(3);
+  expect(at(file, VIEW_MODE_KEY)!).toBeGreaterThan(first!);
+});
+
+test("a write moves only the keys it changed", () => {
+  const file = temporaryFile();
+  mutateBoard("proj", 0, [
+    { kind: "restore", path: "/a", placement: "manual" },
+    { kind: "restore", path: "/b", placement: "manual" },
+  ], file);
+  expect(at(file, pathKey("/a"))).toBe(1);
+  expect(at(file, pathKey("/b"))).toBe(1);
+
+  mutateBoard("proj", 1, [{ kind: "close", path: "/a" }], file);
+  /* /b was untouched, so intent another device formed about /b is still valid
+     and must not be fenced by an unrelated write. */
+  expect(at(file, pathKey("/a"))).toBe(2);
+  expect(at(file, pathKey("/b"))).toBe(1);
+  expect(at(file, VIEW_MODE_KEY)).toBeUndefined();
+});
+
+test("causal revisions are durable and survive a restart", () => {
+  const file = temporaryFile();
+  mutateBoard("proj", 0, [{ kind: "set-favorite", id: "conv-1", favorite: true }], file);
+  mutateBoard("proj", 1, [{ kind: "set-favorite", id: "conv-1", favorite: false }], file);
+  /* `boardFor` re-reads the file, so this is the restart: the fence cannot be
+     rebuilt from memory after a redeploy and must come off disk. */
+  expect(boardFor("proj", file).keyRevisions).toEqual({ "favorite:conv-1": 2 });
+
+  /* A board written before this metadata existed reads back with an empty map —
+     every key then looks never-written, which is right: no client can hold
+     intent that predates a revision nobody recorded. */
+  fs.writeFileSync(file, JSON.stringify({ projects: { proj: {
+    schemaVersion: 1, revision: 7, updatedAt: "2026-07-10T00:00:00.000Z",
+    prefs: { manual: ["/a"], hidden: [], expanded: [], viewMode: null, taskPanelOpen: false },
+  } } }), "utf8");
+  expect(boardFor("proj", file).keyRevisions).toEqual({});
+  mutateBoard("proj", 7, [{ kind: "close", path: "/a" }], file);
+  expect(at(file, pathKey("/a"))).toBe(8);
+});
+
+test("a remap carries a placement without burning the old path's causal revision", () => {
+  const file = temporaryFile();
+  mutateBoard("proj", 0, [{ kind: "restore", path: "/old", placement: "manual" }], file);
+  expect(at(file, pathKey("/old"))).toBe(1);
+
+  remapBoardPaths("proj", [{ from: "/old", to: "/new" }], { filePath: file });
+  /* Succession bookkeeping is not a competing operator decision: the placement
+     followed the conversation, so queued intent naming /old is not superseded
+     by the rename alone. The retired alias source is pruned from the map. */
+  const board = boardFor("proj", file);
+  expect(board.prefs.manual).toEqual(["/new"]);
+  expect(board.keyRevisions?.[pathKey("/old")]).toBe(1);
+});
+
+test("mutationKeys names every key a mutation contends on", () => {
+  expect(mutationKeys({ kind: "close", path: "/a" })).toEqual(["path:/a"]);
+  expect(mutationKeys({ kind: "reconcile-roots", roots: ["/a"], removeManual: ["/b"] })).toEqual(["path:/a", "path:/b"]);
+  expect(mutationKeys({ kind: "remap-paths", pairs: [{ from: "/a", to: "/b" }] })).toEqual(["path:/a", "path:/b"]);
+  expect(mutationKeys({ kind: "set-engine-child-fold", id: "c1", path: "/a", folded: true })).toEqual(["fold:c1", "path:/a"]);
+  /* A presentation mutation contends only on the fields it actually carries, so
+     setting the task panel never fences a queued view-mode switch. */
+  expect(mutationKeys({ kind: "set-presentation", taskPanelOpen: true })).toEqual(["taskPanelOpen"]);
+  expect(mutationKeys({ kind: "set-presentation", viewMode: null })).toEqual(["viewMode"]);
+});

--- a/src/lib/board/keys.test.ts
+++ b/src/lib/board/keys.test.ts
@@ -4,7 +4,7 @@ import os from "node:os";
 import path from "node:path";
 
 import { keyRevisionAt, MAX_RETIRED_KEY_REVISIONS, mutationKeys, pathKey, VIEW_MODE_KEY } from "./keys";
-import { boardFor, mutateBoard, remapBoardPaths } from "./store";
+import { boardFor, migrateBoardProjects, mutateBoard, remapBoardPaths } from "./store";
 
 /*
  * The durable contract behind convergence (#38): every write stamps the causal
@@ -135,6 +135,30 @@ test("a board written before keys were unified normalizes its alias clocks on re
      lost, and both names answer with it. */
   expect(board.keyRevisions?.[pathKey("/new")]).toBe(7);
   expect(keyRevisionAt(board, pathKey("/old"))).toBe(7);
+});
+
+test("a project-key migration carries source causal history forward", () => {
+  const file = temporaryFile();
+  const state = (revision: number, keyRevisions: Record<string, number>) => ({
+    schemaVersion: 1, revision, updatedAt: "2026-07-27T00:00:00.000Z",
+    pathAliases: {}, explicitManual: ["/x"], keyRevisions,
+    prefs: { manual: ["/x"], hidden: [], expanded: [], favorites: [], viewMode: null, taskPanelOpen: false },
+  });
+  /* The same project under two keys — a catalog repair is about to unify them.
+     The source has seen far more of this conversation's history than the target:
+     /x was closed and reopened there, ending exactly where the target has it. */
+  fs.writeFileSync(file, JSON.stringify({ projects: {
+    "old-key": state(40, { "path:/x": 40 }),
+    "new-key": state(3, { "path:/x": 3 }),
+  } }), "utf8");
+
+  expect(migrateBoardProjects(new Map([["old-key", "new-key"]]), file)).toBe(true);
+  const board = boardFor("new-key", file);
+  expect(board.prefs.manual).toEqual(["/x"]);
+  /* A migrated key is the SAME logical key, so its clock has to survive the
+     move. Restarting it from the target's history rewinds the class past writes
+     that really happened, and intent formed before them stops being fenced. */
+  expect(keyRevisionAt(board, pathKey("/x"))).toBeGreaterThanOrEqual(40);
 });
 
 test("compaction raises a floor instead of erasing causal history", () => {

--- a/src/lib/board/keys.ts
+++ b/src/lib/board/keys.ts
@@ -8,21 +8,24 @@ import type { BoardProjectStateV1 } from "@/lib/view/types";
  * against those revisions). Both sides must name keys identically or the fence
  * silently stops matching, so the vocabulary lives here and nowhere else.
  *
- * A key is deliberately coarser than a field and finer than the board: a
- * transcript path's placement is one key, a favourite identity is one key, and
- * each presentation field is its own key. Two devices editing different keys
- * never contend; two devices editing the same key are resolved by causality.
+ * A key names a LOGICAL thing, not a spelling of it. A conversation that resumes
+ * mints a new transcript path and the board aliases the old onto the new; both
+ * names must resolve to one key carrying one clock, or a stale writer holding the
+ * old name looks unopposed against an informed write under the new name — ABA
+ * across an alias boundary. Every read and write of a key therefore goes through
+ * {@link canonicalKey} against the board's alias graph.
  */
 
 export const VIEW_MODE_KEY = "viewMode";
 export const TASK_PANEL_KEY = "taskPanelOpen";
+const PATH_PREFIX = "path:";
 
 /** Per-key causal revisions: key → the board revision at which it last changed.
     Monotonic, which is the whole point — a key driven A → B → A carries a higher
     revision than the A a stale view remembers, even though the value matches. */
 export type BoardKeyRevisions = Record<string, number>;
 
-export const pathKey = (pathname: string) => `path:${pathname}`;
+export const pathKey = (pathname: string) => `${PATH_PREFIX}${pathname}`;
 export const favoriteKey = (id: string) => `favorite:${id}`;
 export const foldKey = (id: string) => `fold:${id}`;
 export const trayKey = (parentId: string) => `tray:${parentId}`;
@@ -38,13 +41,40 @@ function resolveThrough(pathname: string, aliases: Record<string, string>): stri
   return resolved;
 }
 
-/** A path's full placement, including whether the manual slot is a genuine user
-    pin — re-pinning a reconcile-seeded root is a real write on that key. */
-function placementOf(board: BoardProjectStateV1, pathname: string): string {
-  if (board.prefs.hidden.includes(pathname)) return "hidden";
-  if (board.prefs.expanded.includes(pathname)) return "expanded";
-  if (board.prefs.manual.includes(pathname)) return (board.explicitManual ?? []).includes(pathname) ? "pinned" : "manual";
-  return "absent";
+/**
+ * The one key an alias class answers to. Path keys collapse onto the alias
+ * target; identity keys (favourite, fold, tray) and presentation keys are
+ * already canonical because they are keyed by durable identity rather than by
+ * transcript path. Safe to apply repeatedly and to a key that is already
+ * canonical.
+ */
+export function canonicalKey(key: string, aliases: Record<string, string>): string {
+  if (!key.startsWith(PATH_PREFIX)) return key;
+  return pathKey(resolveThrough(key.slice(PATH_PREFIX.length), aliases));
+}
+
+/* A path holds exactly one role on a normalized board. Two names can still
+   collapse into one class mid-remap, so a class takes its most restrictive
+   member: over-stating a change costs a fenced mutation, under-stating one lets
+   a stale writer through, and only one of those is a correctness bug. */
+const ROLE_RANK: Record<string, number> = { absent: 0, manual: 1, pinned: 2, expanded: 3, hidden: 4 };
+
+/** Every alias class the board places, and the role it holds — keyed
+    canonically, so the same logical node reads the same before and after a
+    succession remap. */
+function canonicalPlacements(board: BoardProjectStateV1, aliases: Record<string, string>): Map<string, string> {
+  const placements = new Map<string, string>();
+  const put = (pathname: string, role: string) => {
+    const canonical = resolveThrough(pathname, aliases);
+    const existing = placements.get(canonical);
+    if (existing === undefined || (ROLE_RANK[role] ?? 0) > (ROLE_RANK[existing] ?? 0)) placements.set(canonical, role);
+  };
+  for (const pathname of board.prefs.hidden) put(pathname, "hidden");
+  for (const pathname of board.prefs.expanded) put(pathname, "expanded");
+  for (const pathname of board.prefs.manual) {
+    put(pathname, (board.explicitManual ?? []).includes(pathname) ? "pinned" : "manual");
+  }
+  return placements;
 }
 
 function symmetricDifference(before: readonly string[] | undefined, after: readonly string[] | undefined): string[] {
@@ -54,23 +84,22 @@ function symmetricDifference(before: readonly string[] | undefined, after: reado
 }
 
 /**
- * The keys one write changed. The server calls this across a single reduction to
- * decide which keys to stamp with the new revision.
+ * The keys one write changed, named canonically. The server calls this across a
+ * single reduction to decide which keys to stamp with the new revision.
  *
- * Paths are compared through the resulting board's aliases, so a succession
- * remap that carried a placement to a new transcript path is not counted as a
- * change to the old path's key: bookkeeping must not read as a competing
- * operator decision and must not burn a causal revision.
+ * Both sides are read through the RESULTING board's aliases, so a succession
+ * remap that carried a placement to a new transcript path is not a change at
+ * all: the class held the same role before and after, only its spelling moved.
+ * Bookkeeping must not read as a competing operator decision and must not burn a
+ * causal revision.
  */
 export function boardKeysChanged(before: BoardProjectStateV1, after: BoardProjectStateV1): Set<string> {
   const keys = new Set<string>();
   const aliases = after.pathAliases ?? {};
-  const paths = new Set<string>([
-    ...before.prefs.manual, ...before.prefs.hidden, ...before.prefs.expanded,
-    ...after.prefs.manual, ...after.prefs.hidden, ...after.prefs.expanded,
-  ]);
-  for (const pathname of paths) {
-    if (placementOf(before, pathname) !== placementOf(after, resolveThrough(pathname, aliases))) keys.add(pathKey(pathname));
+  const wasPlaced = canonicalPlacements(before, aliases);
+  const isPlaced = canonicalPlacements(after, aliases);
+  for (const canonical of new Set([...wasPlaced.keys(), ...isPlaced.keys()])) {
+    if ((wasPlaced.get(canonical) ?? "absent") !== (isPlaced.get(canonical) ?? "absent")) keys.add(pathKey(canonical));
   }
   for (const id of symmetricDifference(before.prefs.favorites, after.prefs.favorites)) keys.add(favoriteKey(id));
   for (const id of symmetricDifference(before.prefs.foldedEngineChildIds, after.prefs.foldedEngineChildIds)) keys.add(foldKey(id));
@@ -82,20 +111,22 @@ export function boardKeysChanged(before: BoardProjectStateV1, after: BoardProjec
 
 /** Every key a mutation would write. A mutation naming several paths (a
     reconciliation, a remap graph) travels whole, so it observes and contends on
-    every path it names. */
-export function mutationKeys(mutation: BoardMutationV1): string[] {
+    every path it names. Names are canonicalized against the board the mutation
+    is formed on, so intent recorded before a remap still finds its class. */
+export function mutationKeys(mutation: BoardMutationV1, aliases: Record<string, string> = {}): string[] {
+  const forPath = (pathname: string) => pathKey(resolveThrough(pathname, aliases));
   switch (mutation.kind) {
     case "close":
     case "restore":
-      return [pathKey(mutation.path)];
+      return [forPath(mutation.path)];
     case "reconcile-roots":
-      return [...mutation.roots, ...mutation.removeManual].map(pathKey);
+      return [...mutation.roots, ...mutation.removeManual].map(forPath);
     case "remap-paths":
-      return mutation.pairs.flatMap(({ from, to }) => [pathKey(from), pathKey(to)]);
+      return mutation.pairs.flatMap(({ from, to }) => [forPath(from), forPath(to)]);
     case "set-favorite":
       return [favoriteKey(mutation.id)];
     case "set-engine-child-fold":
-      return [foldKey(mutation.id), pathKey(mutation.path)];
+      return [foldKey(mutation.id), forPath(mutation.path)];
     case "set-engine-tray-expanded":
       return [trayKey(mutation.parentId)];
     case "set-presentation":
@@ -111,20 +142,17 @@ export function mutationKeys(mutation: BoardMutationV1): string[] {
    stale writer that favourited beforehand must still lose. Those keys therefore
    cannot be pruned the moment they go quiet — they are kept, most-recently-
    written first, up to this bound, so the map stays proportional to the board
-   instead of growing with every transcript ever opened. A view would have to be
-   behind by more than this many writes ON KEYS THAT HAVE SINCE LEFT THE BOARD
-   before its intent stops being fenced. */
+   instead of growing with every transcript ever opened. */
 export const MAX_RETIRED_KEY_REVISIONS = 512;
 
-/** The keys the board still carries in its own content: everything currently
-    placed, aliased, favourited or pinned, plus the two presentation fields. */
+/** The keys the board still carries in its own content, named canonically:
+    everything currently placed, favourited or pinned, plus the two presentation
+    fields. Alias sources are absent by construction — they resolve onto their
+    target's key rather than holding one of their own. */
 export function liveBoardKeys(board: BoardProjectStateV1): Set<string> {
   const aliases = board.pathAliases ?? {};
   const keys = new Set<string>([VIEW_MODE_KEY, TASK_PANEL_KEY]);
-  for (const pathname of [
-    ...board.prefs.manual, ...board.prefs.hidden, ...board.prefs.expanded,
-    ...Object.keys(aliases), ...Object.values(aliases),
-  ]) keys.add(pathKey(pathname));
+  for (const canonical of canonicalPlacements(board, aliases).keys()) keys.add(pathKey(canonical));
   for (const id of board.prefs.favorites ?? []) keys.add(favoriteKey(id));
   for (const id of board.prefs.foldedEngineChildIds ?? []) keys.add(foldKey(id));
   for (const id of board.prefs.expandedEngineTrayParentIds ?? []) keys.add(trayKey(id));
@@ -132,23 +160,81 @@ export function liveBoardKeys(board: BoardProjectStateV1): Set<string> {
 }
 
 /**
- * Stamp every key this write changed with the new revision and carry the rest
- * forward. Keys the resulting board still carries are always kept; keys whose
- * subject has left the board are kept most-recently-written first, bounded by
- * {@link MAX_RETIRED_KEY_REVISIONS}.
+ * Collapse a stored map onto canonical keys, merging an alias class by maximum.
+ * Applied on read, so a board written before keys were unified — where an alias
+ * source could still hold a clock of its own — normalizes the moment it loads
+ * instead of leaving that clock unreachable behind a canonicalized lookup.
  */
-export function stampKeyRevisions(before: BoardProjectStateV1, after: BoardProjectStateV1, revision: number): BoardKeyRevisions {
-  const merged: BoardKeyRevisions = { ...(before.keyRevisions ?? {}) };
+export function canonicalizeKeyRevisions(revisions: BoardKeyRevisions, aliases: Record<string, string>): BoardKeyRevisions {
+  const canonical: BoardKeyRevisions = {};
+  for (const [key, at] of Object.entries(revisions)) {
+    const name = canonicalKey(key, aliases);
+    canonical[name] = Math.max(canonical[name] ?? 0, at);
+  }
+  return canonical;
+}
+
+/** The causal revision a board reports for a key. An absent key reads the FLOOR,
+    not zero — see {@link stampKeyRevisions}. Callers pass raw key names; the
+    alias graph canonicalizes them. */
+export function keyRevisionAt(board: BoardProjectStateV1, key: string): number {
+  const canonical = canonicalKey(key, board.pathAliases ?? {});
+  return board.keyRevisions?.[canonical] ?? board.keyRevisionFloor ?? 0;
+}
+
+/**
+ * Stamp every key this write changed with the new revision, carry the rest
+ * forward, and compact — CAUSALLY SAFELY.
+ *
+ * Three things happen here, and each exists because dropping it lets a stale
+ * writer win:
+ *
+ * 1. **Alias merge.** Keys carried forward are canonicalized first, and two
+ *    names that now resolve to one class keep the MAXIMUM of their clocks. A
+ *    remap can only ever move a class's clock forward, so no observation is
+ *    un-superseded by a rename.
+ * 2. **Stamping.** Keys this write changed take the new revision.
+ * 3. **Bounded compaction with a floor.** Keys the board still carries are kept
+ *    exactly. Retired keys are kept most-recently-written first up to
+ *    {@link MAX_RETIRED_KEY_REVISIONS}; whatever is dropped raises
+ *    `keyRevisionFloor` to the highest revision evicted, and every absent key
+ *    reads that floor. Forgetting a key without raising the floor would make it
+ *    read as never-written, so a client holding intent older than the evicted
+ *    history would stop being fenced and could land it — a failure that gets
+ *    MORE likely the longer a board lives. The floor is monotonic and errs
+ *    high: it can fence intent whose own key was never actually written, which
+ *    costs a dropped mutation rather than a lost write.
+ */
+export function stampKeyRevisions(
+  before: BoardProjectStateV1,
+  after: BoardProjectStateV1,
+  revision: number,
+): { keyRevisions: BoardKeyRevisions; keyRevisionFloor: number } {
+  const aliases = after.pathAliases ?? {};
+  const merged: BoardKeyRevisions = {};
+  for (const [key, at] of Object.entries(before.keyRevisions ?? {})) {
+    const canonical = canonicalKey(key, aliases);
+    merged[canonical] = Math.max(merged[canonical] ?? 0, at);
+  }
   for (const key of boardKeysChanged(before, after)) merged[key] = revision;
 
   const live = liveBoardKeys(after);
-  const stamped: BoardKeyRevisions = {};
+  const keyRevisions: BoardKeyRevisions = {};
   const retired: Array<[string, number]> = [];
   for (const [key, at] of Object.entries(merged)) {
-    if (live.has(key)) stamped[key] = at;
+    if (live.has(key)) keyRevisions[key] = at;
     else retired.push([key, at]);
   }
   retired.sort((left, right) => right[1] - left[1] || left[0].localeCompare(right[0]));
-  for (const [key, at] of retired.slice(0, MAX_RETIRED_KEY_REVISIONS)) stamped[key] = at;
-  return stamped;
+
+  let keyRevisionFloor = before.keyRevisionFloor ?? 0;
+  for (const [key, at] of retired.slice(0, MAX_RETIRED_KEY_REVISIONS)) keyRevisions[key] = at;
+  for (const [, at] of retired.slice(MAX_RETIRED_KEY_REVISIONS)) keyRevisionFloor = Math.max(keyRevisionFloor, at);
+  /* A retained entry at or below the floor carries nothing the floor does not
+     already say, so it can go too — compaction that keeps the map small without
+     ever lowering what an absent key reports. */
+  for (const [key, at] of Object.entries(keyRevisions)) {
+    if (!live.has(key) && at <= keyRevisionFloor) delete keyRevisions[key];
+  }
+  return { keyRevisions, keyRevisionFloor };
 }

--- a/src/lib/board/keys.ts
+++ b/src/lib/board/keys.ts
@@ -1,0 +1,154 @@
+import type { BoardMutationV1 } from "@/lib/board/mutations";
+import type { BoardProjectStateV1 } from "@/lib/view/types";
+
+/**
+ * The board's key vocabulary — one string per independently-writable unit of
+ * durable state, shared by the server (which stamps a causal revision onto every
+ * key a write changes) and by every client (which fences its queued intent
+ * against those revisions). Both sides must name keys identically or the fence
+ * silently stops matching, so the vocabulary lives here and nowhere else.
+ *
+ * A key is deliberately coarser than a field and finer than the board: a
+ * transcript path's placement is one key, a favourite identity is one key, and
+ * each presentation field is its own key. Two devices editing different keys
+ * never contend; two devices editing the same key are resolved by causality.
+ */
+
+export const VIEW_MODE_KEY = "viewMode";
+export const TASK_PANEL_KEY = "taskPanelOpen";
+
+/** Per-key causal revisions: key → the board revision at which it last changed.
+    Monotonic, which is the whole point — a key driven A → B → A carries a higher
+    revision than the A a stale view remembers, even though the value matches. */
+export type BoardKeyRevisions = Record<string, number>;
+
+export const pathKey = (pathname: string) => `path:${pathname}`;
+export const favoriteKey = (id: string) => `favorite:${id}`;
+export const foldKey = (id: string) => `fold:${id}`;
+export const trayKey = (parentId: string) => `tray:${parentId}`;
+
+function resolveThrough(pathname: string, aliases: Record<string, string>): string {
+  const seen = new Set<string>();
+  let resolved = pathname;
+  while (aliases[resolved] !== undefined) {
+    if (seen.has(resolved)) return resolved;
+    seen.add(resolved);
+    resolved = aliases[resolved]!;
+  }
+  return resolved;
+}
+
+/** A path's full placement, including whether the manual slot is a genuine user
+    pin — re-pinning a reconcile-seeded root is a real write on that key. */
+function placementOf(board: BoardProjectStateV1, pathname: string): string {
+  if (board.prefs.hidden.includes(pathname)) return "hidden";
+  if (board.prefs.expanded.includes(pathname)) return "expanded";
+  if (board.prefs.manual.includes(pathname)) return (board.explicitManual ?? []).includes(pathname) ? "pinned" : "manual";
+  return "absent";
+}
+
+function symmetricDifference(before: readonly string[] | undefined, after: readonly string[] | undefined): string[] {
+  const left = new Set(before ?? []);
+  const right = new Set(after ?? []);
+  return [...new Set([...left, ...right])].filter((item) => left.has(item) !== right.has(item));
+}
+
+/**
+ * The keys one write changed. The server calls this across a single reduction to
+ * decide which keys to stamp with the new revision.
+ *
+ * Paths are compared through the resulting board's aliases, so a succession
+ * remap that carried a placement to a new transcript path is not counted as a
+ * change to the old path's key: bookkeeping must not read as a competing
+ * operator decision and must not burn a causal revision.
+ */
+export function boardKeysChanged(before: BoardProjectStateV1, after: BoardProjectStateV1): Set<string> {
+  const keys = new Set<string>();
+  const aliases = after.pathAliases ?? {};
+  const paths = new Set<string>([
+    ...before.prefs.manual, ...before.prefs.hidden, ...before.prefs.expanded,
+    ...after.prefs.manual, ...after.prefs.hidden, ...after.prefs.expanded,
+  ]);
+  for (const pathname of paths) {
+    if (placementOf(before, pathname) !== placementOf(after, resolveThrough(pathname, aliases))) keys.add(pathKey(pathname));
+  }
+  for (const id of symmetricDifference(before.prefs.favorites, after.prefs.favorites)) keys.add(favoriteKey(id));
+  for (const id of symmetricDifference(before.prefs.foldedEngineChildIds, after.prefs.foldedEngineChildIds)) keys.add(foldKey(id));
+  for (const id of symmetricDifference(before.prefs.expandedEngineTrayParentIds, after.prefs.expandedEngineTrayParentIds)) keys.add(trayKey(id));
+  if (before.prefs.viewMode !== after.prefs.viewMode) keys.add(VIEW_MODE_KEY);
+  if (before.prefs.taskPanelOpen !== after.prefs.taskPanelOpen) keys.add(TASK_PANEL_KEY);
+  return keys;
+}
+
+/** Every key a mutation would write. A mutation naming several paths (a
+    reconciliation, a remap graph) travels whole, so it observes and contends on
+    every path it names. */
+export function mutationKeys(mutation: BoardMutationV1): string[] {
+  switch (mutation.kind) {
+    case "close":
+    case "restore":
+      return [pathKey(mutation.path)];
+    case "reconcile-roots":
+      return [...mutation.roots, ...mutation.removeManual].map(pathKey);
+    case "remap-paths":
+      return mutation.pairs.flatMap(({ from, to }) => [pathKey(from), pathKey(to)]);
+    case "set-favorite":
+      return [favoriteKey(mutation.id)];
+    case "set-engine-child-fold":
+      return [foldKey(mutation.id), pathKey(mutation.path)];
+    case "set-engine-tray-expanded":
+      return [trayKey(mutation.parentId)];
+    case "set-presentation":
+      return [
+        ...(mutation.viewMode === undefined ? [] : [VIEW_MODE_KEY]),
+        ...(mutation.taskPanelOpen === undefined ? [] : [TASK_PANEL_KEY]),
+      ];
+  }
+}
+
+/* Retired keys kept beyond the board's own content. "Off" is a real value that
+   leaves no trace: un-favouriting drops the id from `favorites` entirely, yet a
+   stale writer that favourited beforehand must still lose. Those keys therefore
+   cannot be pruned the moment they go quiet — they are kept, most-recently-
+   written first, up to this bound, so the map stays proportional to the board
+   instead of growing with every transcript ever opened. A view would have to be
+   behind by more than this many writes ON KEYS THAT HAVE SINCE LEFT THE BOARD
+   before its intent stops being fenced. */
+export const MAX_RETIRED_KEY_REVISIONS = 512;
+
+/** The keys the board still carries in its own content: everything currently
+    placed, aliased, favourited or pinned, plus the two presentation fields. */
+export function liveBoardKeys(board: BoardProjectStateV1): Set<string> {
+  const aliases = board.pathAliases ?? {};
+  const keys = new Set<string>([VIEW_MODE_KEY, TASK_PANEL_KEY]);
+  for (const pathname of [
+    ...board.prefs.manual, ...board.prefs.hidden, ...board.prefs.expanded,
+    ...Object.keys(aliases), ...Object.values(aliases),
+  ]) keys.add(pathKey(pathname));
+  for (const id of board.prefs.favorites ?? []) keys.add(favoriteKey(id));
+  for (const id of board.prefs.foldedEngineChildIds ?? []) keys.add(foldKey(id));
+  for (const id of board.prefs.expandedEngineTrayParentIds ?? []) keys.add(trayKey(id));
+  return keys;
+}
+
+/**
+ * Stamp every key this write changed with the new revision and carry the rest
+ * forward. Keys the resulting board still carries are always kept; keys whose
+ * subject has left the board are kept most-recently-written first, bounded by
+ * {@link MAX_RETIRED_KEY_REVISIONS}.
+ */
+export function stampKeyRevisions(before: BoardProjectStateV1, after: BoardProjectStateV1, revision: number): BoardKeyRevisions {
+  const merged: BoardKeyRevisions = { ...(before.keyRevisions ?? {}) };
+  for (const key of boardKeysChanged(before, after)) merged[key] = revision;
+
+  const live = liveBoardKeys(after);
+  const stamped: BoardKeyRevisions = {};
+  const retired: Array<[string, number]> = [];
+  for (const [key, at] of Object.entries(merged)) {
+    if (live.has(key)) stamped[key] = at;
+    else retired.push([key, at]);
+  }
+  retired.sort((left, right) => right[1] - left[1] || left[0].localeCompare(right[0]));
+  for (const [key, at] of retired.slice(0, MAX_RETIRED_KEY_REVISIONS)) stamped[key] = at;
+  return stamped;
+}

--- a/src/lib/board/keys.ts
+++ b/src/lib/board/keys.ts
@@ -189,10 +189,14 @@ export function keyRevisionAt(board: BoardProjectStateV1, key: string): number {
  * Three things happen here, and each exists because dropping it lets a stale
  * writer win:
  *
- * 1. **Alias merge.** Keys carried forward are canonicalized first, and two
- *    names that now resolve to one class keep the MAXIMUM of their clocks. A
- *    remap can only ever move a class's clock forward, so no observation is
- *    un-superseded by a rename.
+ * 1. **Alias and provenance merge.** Keys carried forward are canonicalized
+ *    first, and two names that now resolve to one class keep the MAXIMUM of
+ *    their clocks. `inherited` carries the same treatment across a document
+ *    boundary: when a project-key migration folds other boards into this one,
+ *    their histories merge in rather than being dropped, because a migrated key
+ *    is the SAME logical key and restarting its clock rewinds the class past
+ *    writes that really happened. Merging by maximum means neither a rename nor
+ *    a migration can ever move a clock backward.
  * 2. **Stamping.** Keys this write changed take the new revision.
  * 3. **Bounded compaction with a floor.** Keys the board still carries are kept
  *    exactly. Retired keys are kept most-recently-written first up to
@@ -205,16 +209,21 @@ export function keyRevisionAt(board: BoardProjectStateV1, key: string): number {
  *    high: it can fence intent whose own key was never actually written, which
  *    costs a dropped mutation rather than a lost write.
  */
+export type BoardCausalHistory = Pick<BoardProjectStateV1, "keyRevisions" | "keyRevisionFloor">;
+
 export function stampKeyRevisions(
   before: BoardProjectStateV1,
   after: BoardProjectStateV1,
   revision: number,
+  inherited: readonly BoardCausalHistory[] = [],
 ): { keyRevisions: BoardKeyRevisions; keyRevisionFloor: number } {
   const aliases = after.pathAliases ?? {};
   const merged: BoardKeyRevisions = {};
-  for (const [key, at] of Object.entries(before.keyRevisions ?? {})) {
-    const canonical = canonicalKey(key, aliases);
-    merged[canonical] = Math.max(merged[canonical] ?? 0, at);
+  for (const source of [before as BoardCausalHistory, ...inherited]) {
+    for (const [key, at] of Object.entries(source.keyRevisions ?? {})) {
+      const canonical = canonicalKey(key, aliases);
+      merged[canonical] = Math.max(merged[canonical] ?? 0, at);
+    }
   }
   for (const key of boardKeysChanged(before, after)) merged[key] = revision;
 
@@ -227,7 +236,13 @@ export function stampKeyRevisions(
   }
   retired.sort((left, right) => right[1] - left[1] || left[0].localeCompare(right[0]));
 
-  let keyRevisionFloor = before.keyRevisionFloor ?? 0;
+  /* A floor is a claim about history that has been forgotten, so folding
+     documents together has to take the highest of them — the lowest would
+     under-report what every absent key has already seen. */
+  let keyRevisionFloor = Math.max(
+    before.keyRevisionFloor ?? 0,
+    ...inherited.map((source) => source.keyRevisionFloor ?? 0),
+  );
   for (const [key, at] of retired.slice(0, MAX_RETIRED_KEY_REVISIONS)) keyRevisions[key] = at;
   for (const [, at] of retired.slice(MAX_RETIRED_KEY_REVISIONS)) keyRevisionFloor = Math.max(keyRevisionFloor, at);
   /* A retained entry at or below the floor carries nothing the floor does not

--- a/src/lib/board/store.ts
+++ b/src/lib/board/store.ts
@@ -5,7 +5,7 @@ import path from "node:path";
 import { statePath } from "@/lib/configDir";
 import { procBackend } from "@/lib/proc";
 
-import { stampKeyRevisions } from "@/lib/board/keys";
+import { canonicalizeKeyRevisions, stampKeyRevisions } from "@/lib/board/keys";
 import { applyBoardMutations, type BoardMutationV1 } from "@/lib/board/mutations";
 import type { BoardFileV1, BoardProjectStateV1 } from "@/lib/view/types";
 
@@ -45,11 +45,12 @@ function projectState(value: unknown): value is BoardProjectStateV1 {
     (state.explicitManual === undefined || stringArray(state.explicitManual)) &&
     (state.pathAliases === undefined || aliases(state.pathAliases)) &&
     (state.keyRevisions === undefined || keyRevisions(state.keyRevisions)) &&
+    (state.keyRevisionFloor === undefined || (Number.isInteger(state.keyRevisionFloor) && state.keyRevisionFloor! >= 0)) &&
     (prefs!.viewMode === null || prefs!.viewMode === "scheme" || prefs!.viewMode === "list") && typeof prefs!.taskPanelOpen === "boolean";
 }
 
 function emptyBoard(): BoardProjectStateV1 {
-  return { schemaVersion: 1, revision: 0, updatedAt: new Date(0).toISOString(), pathAliases: {}, explicitManual: [], keyRevisions: {}, prefs: { ...EMPTY_PREFS, manual: [], hidden: [], expanded: [] } };
+  return { schemaVersion: 1, revision: 0, updatedAt: new Date(0).toISOString(), pathAliases: {}, explicitManual: [], keyRevisions: {}, keyRevisionFloor: 0, prefs: { ...EMPTY_PREFS, manual: [], hidden: [], expanded: [] } };
 }
 
 /** The durable form of a reduction: the new revision, plus a causal revision
@@ -63,7 +64,7 @@ function committed(current: BoardProjectStateV1, reduced: BoardProjectStateV1, r
     revision,
     updatedAt: new Date().toISOString(),
     pathAliases: reduced.pathAliases ?? {},
-    keyRevisions: stampKeyRevisions(current, reduced, revision),
+    ...stampKeyRevisions(current, reduced, revision),
   };
 }
 
@@ -79,7 +80,11 @@ function read(filePath: string): BoardFileV1 {
       /* A board written before per-key causal revisions existed reads back with
          an empty map: every key then looks never-written, which is exactly right
          — no client can hold intent that predates a revision nobody recorded. */
-      keyRevisions: state.keyRevisions ?? {},
+      /* Canonicalized on read: an alias source must never keep a clock of its
+         own, or two names for one conversation carry independent causal history
+         and a stale writer holding the old name looks unopposed. */
+      keyRevisions: canonicalizeKeyRevisions(state.keyRevisions ?? {}, state.pathAliases ?? {}),
+      keyRevisionFloor: state.keyRevisionFloor ?? 0,
       /* Boards written before favorites / tray intent existed lack the fields;
          default them so every GET response and reducer input carries the
          durable-id lists (issue #185 favorites, issue #142 tray pins). */

--- a/src/lib/board/store.ts
+++ b/src/lib/board/store.ts
@@ -5,7 +5,7 @@ import path from "node:path";
 import { statePath } from "@/lib/configDir";
 import { procBackend } from "@/lib/proc";
 
-import { canonicalizeKeyRevisions, stampKeyRevisions } from "@/lib/board/keys";
+import { type BoardCausalHistory, canonicalizeKeyRevisions, stampKeyRevisions } from "@/lib/board/keys";
 import { applyBoardMutations, type BoardMutationV1 } from "@/lib/board/mutations";
 import type { BoardFileV1, BoardProjectStateV1 } from "@/lib/view/types";
 
@@ -57,15 +57,28 @@ function emptyBoard(): BoardProjectStateV1 {
     stamped onto every key this write changed. Every write path goes through
     here, so no path can advance the board without advancing its keys — a key
     that changed without its revision moving is a silent hole in the fence. */
-function committed(current: BoardProjectStateV1, reduced: BoardProjectStateV1, revision: number): BoardProjectStateV1 {
+function committed(
+  current: BoardProjectStateV1,
+  reduced: BoardProjectStateV1,
+  revision: number,
+  inherited: readonly BoardCausalHistory[] = [],
+): BoardProjectStateV1 {
   return {
     ...reduced,
     schemaVersion: 1,
     revision,
     updatedAt: new Date().toISOString(),
     pathAliases: reduced.pathAliases ?? {},
-    ...stampKeyRevisions(current, reduced, revision),
+    ...stampKeyRevisions(current, reduced, revision, inherited),
   };
+}
+
+/** Two boards carry the same durable causal history. A migration that moves no
+    content can still move history, and that has to be persisted — otherwise the
+    source's clocks are silently discarded on the "nothing changed" path. */
+function sameCausalHistory(left: BoardProjectStateV1, right: BoardProjectStateV1): boolean {
+  return JSON.stringify({ keys: left.keyRevisions ?? {}, floor: left.keyRevisionFloor ?? 0 })
+    === JSON.stringify({ keys: right.keyRevisions ?? {}, floor: right.keyRevisionFloor ?? 0 });
 }
 
 function read(filePath: string): BoardFileV1 {
@@ -462,9 +475,22 @@ export function migrateBoardProjects(
       try {
         const states = target ? [target, ...sources] : sources;
         const merged = mergedBoards(states);
-        value.projects[targetProject] = target && sameReduced(target, merged)
+        /* The sources' causal history comes along. A migrated key is the SAME
+           logical key, so dropping the clocks of the boards being folded in
+           rewinds those keys past writes that really happened and un-fences
+           intent formed before them. Merged by maximum, so the unified board is
+           never behind any contributor. Note this can differ from the target
+           even when the CONTENT is identical, which is exactly the case that was
+           silently losing history. */
+        const next = committed(
+          target ?? emptyBoard(),
+          merged,
+          Math.max(...states.map((state) => state.revision)) + 1,
+          sources,
+        );
+        value.projects[targetProject] = target && sameReduced(target, next) && sameCausalHistory(target, next)
           ? target
-          : committed(target ?? emptyBoard(), merged, Math.max(...states.map((state) => state.revision)) + 1);
+          : next;
         for (const sourceProject of sourceProjects) delete value.projects[sourceProject];
         changed = true;
       } catch {

--- a/src/lib/board/store.ts
+++ b/src/lib/board/store.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import { statePath } from "@/lib/configDir";
 import { procBackend } from "@/lib/proc";
 
+import { stampKeyRevisions } from "@/lib/board/keys";
 import { applyBoardMutations, type BoardMutationV1 } from "@/lib/board/mutations";
 import type { BoardFileV1, BoardProjectStateV1 } from "@/lib/view/types";
 
@@ -28,6 +29,10 @@ function aliases(value: unknown): value is Record<string, string> {
   if (!value || typeof value !== "object" || Array.isArray(value)) return false;
   return Object.values(value).every((item) => typeof item === "string");
 }
+function keyRevisions(value: unknown): value is Record<string, number> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  return Object.values(value).every((item) => Number.isInteger(item) && (item as number) >= 0);
+}
 function projectState(value: unknown): value is BoardProjectStateV1 {
   if (!value || typeof value !== "object" || Array.isArray(value)) return false;
   const state = value as Partial<BoardProjectStateV1>;
@@ -39,11 +44,27 @@ function projectState(value: unknown): value is BoardProjectStateV1 {
     (prefs!.expandedEngineTrayParentIds === undefined || stringArray(prefs!.expandedEngineTrayParentIds)) &&
     (state.explicitManual === undefined || stringArray(state.explicitManual)) &&
     (state.pathAliases === undefined || aliases(state.pathAliases)) &&
+    (state.keyRevisions === undefined || keyRevisions(state.keyRevisions)) &&
     (prefs!.viewMode === null || prefs!.viewMode === "scheme" || prefs!.viewMode === "list") && typeof prefs!.taskPanelOpen === "boolean";
 }
 
 function emptyBoard(): BoardProjectStateV1 {
-  return { schemaVersion: 1, revision: 0, updatedAt: new Date(0).toISOString(), pathAliases: {}, explicitManual: [], prefs: { ...EMPTY_PREFS, manual: [], hidden: [], expanded: [] } };
+  return { schemaVersion: 1, revision: 0, updatedAt: new Date(0).toISOString(), pathAliases: {}, explicitManual: [], keyRevisions: {}, prefs: { ...EMPTY_PREFS, manual: [], hidden: [], expanded: [] } };
+}
+
+/** The durable form of a reduction: the new revision, plus a causal revision
+    stamped onto every key this write changed. Every write path goes through
+    here, so no path can advance the board without advancing its keys — a key
+    that changed without its revision moving is a silent hole in the fence. */
+function committed(current: BoardProjectStateV1, reduced: BoardProjectStateV1, revision: number): BoardProjectStateV1 {
+  return {
+    ...reduced,
+    schemaVersion: 1,
+    revision,
+    updatedAt: new Date().toISOString(),
+    pathAliases: reduced.pathAliases ?? {},
+    keyRevisions: stampKeyRevisions(current, reduced, revision),
+  };
 }
 
 function read(filePath: string): BoardFileV1 {
@@ -55,6 +76,10 @@ function read(filePath: string): BoardFileV1 {
       ...state,
       pathAliases: state.pathAliases ?? {},
       explicitManual: state.explicitManual ?? state.prefs.manual,
+      /* A board written before per-key causal revisions existed reads back with
+         an empty map: every key then looks never-written, which is exactly right
+         — no client can hold intent that predates a revision nobody recorded. */
+      keyRevisions: state.keyRevisions ?? {},
       /* Boards written before favorites / tray intent existed lack the fields;
          default them so every GET response and reducer input carries the
          durable-id lists (issue #185 favorites, issue #142 tray pins). */
@@ -173,7 +198,15 @@ export function boardFor(project: string, filePath = boardFileForTests ?? BOARD_
   return read(filePath).projects[project] ?? emptyBoard();
 }
 export type BoardPatch = Partial<BoardProjectStateV1["prefs"]>;
-type BoardWriteResult = { ok: true; board: BoardProjectStateV1 } | { ok: false; board: BoardProjectStateV1 };
+/* `applied` distinguishes a write that committed from one the reducer turned
+   into a no-op. A no-op is accepted from ANY base revision, so an accepted
+   response can carry a board a DIFFERENT writer produced — and when both writers
+   made the same change the two boards are indistinguishable by content. Only the
+   server knows which happened, so it says so, and the client uses it to decide
+   whether the response is its own work or a foreign adoption (#38). */
+type BoardWriteResult =
+  | { ok: true; applied: boolean; board: BoardProjectStateV1 }
+  | { ok: false; board: BoardProjectStateV1 };
 
 function applyLegacyPatch(current: BoardProjectStateV1, patch: BoardPatch): BoardProjectStateV1 {
   const hidden = patch.hidden === undefined
@@ -196,12 +229,12 @@ function writeReduced(project: string, baseRevision: number, reduce: (current: B
     const value = read(filePath);
     const current = value.projects[project] ?? emptyBoard();
     const reduced = reduce(current);
-    if (sameReduced(current, reduced)) return { ok: true, board: current };
+    if (sameReduced(current, reduced)) return { ok: true, applied: false, board: current };
     if (current.revision !== baseRevision) return { ok: false, board: current };
-    const next: BoardProjectStateV1 = { ...reduced, schemaVersion: 1, revision: current.revision + 1, updatedAt: new Date().toISOString(), pathAliases: reduced.pathAliases ?? {} };
+    const next = committed(current, reduced, current.revision + 1);
     value.projects[project] = next;
     write(value, filePath);
-    return { ok: true, board: next };
+    return { ok: true, applied: true, board: next };
   });
 }
 
@@ -211,20 +244,14 @@ function writeLatest(project: string, reduce: (current: BoardProjectStateV1) => 
     const current = value.projects[project] ?? emptyBoard();
     const reduced = reduce(current);
     if (sameReduced(current, reduced)) return current;
-    const next: BoardProjectStateV1 = {
-      ...reduced,
-      schemaVersion: 1,
-      revision: current.revision + 1,
-      updatedAt: new Date().toISOString(),
-      pathAliases: reduced.pathAliases ?? {},
-    };
+    const next = committed(current, reduced, current.revision + 1);
     value.projects[project] = next;
     write(value, filePath);
     return next;
   });
 }
 
-export function patchBoard(project: string, baseRevision: number, patch: BoardPatch, filePath = boardFileForTests ?? BOARD_FILE): { ok: true; board: BoardProjectStateV1 } | { ok: false; board: BoardProjectStateV1 } {
+export function patchBoard(project: string, baseRevision: number, patch: BoardPatch, filePath = boardFileForTests ?? BOARD_FILE): BoardWriteResult {
   return writeReduced(project, baseRevision, (current) => applyLegacyPatch(current, patch), filePath);
 }
 
@@ -336,20 +363,12 @@ export function transferBoardPathPlacements(
         };
       }
       if (!sameReduced(storedSource, source)) {
-        value.projects[transfer.fromProject] = {
-          ...source,
-          revision: storedSource.revision + 1,
-          updatedAt: new Date().toISOString(),
-        };
+        value.projects[transfer.fromProject] = committed(storedSource, source, storedSource.revision + 1);
         changed = true;
       }
       const storedTarget = value.projects[transfer.toProject] ?? emptyBoard();
       if (!sameReduced(storedTarget, target)) {
-        value.projects[transfer.toProject] = {
-          ...target,
-          revision: storedTarget.revision + 1,
-          updatedAt: new Date().toISOString(),
-        };
+        value.projects[transfer.toProject] = committed(storedTarget, target, storedTarget.revision + 1);
         changed = true;
       }
     }
@@ -440,11 +459,7 @@ export function migrateBoardProjects(
         const merged = mergedBoards(states);
         value.projects[targetProject] = target && sameReduced(target, merged)
           ? target
-          : {
-              ...merged,
-              revision: Math.max(...states.map((state) => state.revision)) + 1,
-              updatedAt: new Date().toISOString(),
-            };
+          : committed(target ?? emptyBoard(), merged, Math.max(...states.map((state) => state.revision)) + 1);
         for (const sourceProject of sourceProjects) delete value.projects[sourceProject];
         changed = true;
       } catch {

--- a/src/lib/view/types.ts
+++ b/src/lib/view/types.ts
@@ -119,6 +119,10 @@ export interface BoardProjectStateV1 {
      read the same" — the ABA case a snapshot comparison cannot see. Optional
      because boards written before it existed omit it; the store defaults it. */
   keyRevisions?: Record<string, number>;
+  /* What an ABSENT key reports. Retired-key compaction is bounded, so evicted
+     history must not read as "never written" — every key missing from
+     `keyRevisions` reads this floor instead. Monotonic; server-authored. */
+  keyRevisionFloor?: number;
   prefs: {
     manual: string[];
     hidden: string[];

--- a/src/lib/view/types.ts
+++ b/src/lib/view/types.ts
@@ -112,6 +112,13 @@ export interface BoardProjectStateV1 {
   updatedAt: string;
   pathAliases?: Record<string, string>;
   explicitManual?: string[];
+  /* Per-key causal revisions: key → the board revision at which that key last
+     changed (see `@/lib/board/keys`). Server-authored on every write and never
+     supplied by a client. This is what lets a device tell "nobody has written
+     this key since I formed my intent" from "it was written twice and happens to
+     read the same" — the ABA case a snapshot comparison cannot see. Optional
+     because boards written before it existed omit it; the store defaults it. */
+  keyRevisions?: Record<string, number>;
   prefs: {
     manual: string[];
     hidden: string[];


### PR DESCRIPTION
## The divergence, reproduced

Two views of one project could disagree on the window set, and a view that had fallen behind could overwrite current state with its own older picture. Three independent paths, each reproduced as a failing test before any fix:

**1. Same tab, two views.** `useBoardState(project)` is mounted twice — the shell binds a project board for its rail, the dashboard binds it for the scheme. Each binding built a *private* store: its own confirmed board, its own outbox, its own 10-second poll clock. Closing a window in the dashboard left the rail showing it until that rail's next poll, and only a reload settled a real disagreement.

**2. A view that cannot write stops reading.** `poll()` bailed out whenever the outbox was non-empty. A device that lost its uplink mid-drag, or a laptop closed with queued intent, therefore stopped learning that the board had moved at all — it rendered the revision it loaded with until a reload, while the other device kept working.

**3. The stale writer wins.** Exact sequence:

1. Desktop and phone both load the project at revision 1 (`viewMode: null`).
2. The desktop loses its uplink and the operator switches it to list view. The PATCH cannot land; the intent sits in the outbox.
3. On the phone, minutes later, the operator picks the scheme view — against the board as it actually stands. Revision 2.
4. The desktop's uplink heals. Its PATCH is refused with 409, it adopts revision 2 — and then **replays its queued `set-presentation: list` on top**. Revision 3.
5. The phone polls and flips to list. The operator's most recent, best-informed choice was undone by a device that had been asleep.

The 409 fence was doing its job; the client simply put the superseded intent straight back.

## Conflict rule

**Per-key last-writer-wins, fenced by observation.**

The writer is the device whose PATCH the server serializes last at a matching `baseRevision`; the server rejects any writer whose base is behind. A stale view cannot be that writer, because when it adopts a board it did not author it **diffs the board it held against the board it adopted** to learn exactly which keys another writer changed, and drops its own queued mutations naming those keys. Queued mutations naming untouched keys replay on top and still land.

So the last writer on any key is always one that acted with knowledge of that key's current value. A view that has fallen behind loses exactly the keys it is behind on, and nothing more.

A *key* is one independently-writable unit: a transcript path's placement (including whether the manual slot is a genuine pin), a favourite or tray identity, or one presentation field. Paths are compared through the adopted board's aliases, so a succession remap that carried a placement to a new transcript path reads as no change — bookkeeping must not look like a competing operator decision.

The fence runs in three places, not one:

- **409** — the obvious case.
- **poll adoption** — now that a read is no longer gated on a pending outbox.
- **an accepted write** — `writeReduced` returns `ok` for a batch that reduces to nothing *from any base revision*. A queued close of an already-closed window is accepted at a stale base and hands the view a board another writer moved, with no 409 to mark it as behind. Diffing the board the write should have produced against the one that came back names that writer's keys. This one I found in self-review after the first fix landed, and it has its own test.

## Also fixed

- `sync` now actually reports `"stale"`. The value was declared in `BoardSync` and in the presence wire DTO and validator, and was **never produced** — `syncFor()` could only return `current`/`pending`/`unavailable`. A lagging device published `current` to agents reading the snapshot API. It now reports `stale` from the moment it adopts a foreign board while holding intent of its own until that intent is acknowledged.
- A project still at revision 0 whose first load failed stayed `unavailable` forever: recovery only cleared the flag when the revision *changed*, and an untouched project's revision never does. The dashboard held its skeleton and its convergence effects, which bail on an unavailable board, never ran again. A successful read now clears it — unless a held outbox says writes are still being refused (schema skew), where the signal must stand.
- Poll adoption is guarded by a write epoch, so a GET that started before a PATCH can never install its now-superseded board over the write's authoritative response.

## Durability

The convergence tests run both writers against the real `mutateBoard`/`patchBoard`/`boardFor` over an isolated temp file, so they assert shipped server semantics rather than a hand-written fake. `boardFor` re-reads the file on every call and a fresh store is a restart; the first test asserts a restarted store reads the converged arrangement back off disk.

## Tests

Every test below was written first and **failed against current behaviour**; the failures are in the commit's working history.

`src/hooks/useBoardState.convergence.test.ts`
- a view holding unflushed intent still converges on the other device's board *(+ restart durability)*
- a view whose first load failed recovers on the next poll, not on a reload
- a stale view's presentation intent loses to the device that acted on current state — **this is the stale-writer proof**
- an accepted no-op cannot smuggle a newer board past the fence
- a stale view loses only the keys another device wrote, and keeps the rest
- a stale root reconciliation cannot retire the window another device just opened

`src/hooks/useBoardState.sharedStore.dom.test.tsx`
- two bindings on one project render the same board without a reload

## Verification

- `bun test src/hooks/useBoardState.convergence.test.ts src/hooks/useBoardState.sharedStore.dom.test.tsx src/hooks/useBoardState.test.ts src/lib/board/ src/app/api/board/ src/lib/view/ src/app/api/view/ src/components/scheme/spatialNav.test.ts` — 204 pass, 0 fail
- Plus the dashboard/viewer mount points, run in a clean checkout of the merge base with these changes applied: 411 pass, 0 fail across 36 files (`src/hooks/`, `src/lib/board/`, `src/lib/view/`, `src/app/api/board/`, `src/app/api/view/`, the four `ProjectDashboard` files, `Viewer.catalogFailure.dom`, `Viewer.test`, `MobileBottomShelf.dom`, `spatialNav`)
- All runs use isolated `HOME`, `XDG_CONFIG_HOME`, `TMPDIR` and `LLV_STATE_DIR`; no runtime or registry tree is swept
- `tsc --noEmit` clean; `eslint` clean on the three changed files; privacy publication gate PASS against the merge base

One caveat worth flagging: in *this* worktree, running `runtimeBus.test.ts` in the same process as `Viewer.catalogFailure.dom.test.tsx` fails with a `mock.module` export leak. It reproduces with the working tree reverted byte-identical to the merge base, and does not reproduce in a fresh checkout of the same commit — pre-existing and environment-sensitive, unrelated to this change.

## Not touched

No file owned by the gateway (#738), conversation-monitor (#744), handoff (#737) or audio (#743) lanes. `Viewer.tsx` is untouched — the same-tab fix lives entirely inside `useBoardState.ts`, so no sequencing behind that lane is needed.

Not deployed; deferred until the operator can test.

Revives #38.

🤖 Generated with [Claude Code](https://claude.com/claude-code)