### PR TITLE
fix(attention): reach the desktop that is open, and land the focus on it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ versions follow [SemVer](https://semver.org/) (0.x — the API may still move).
 ## [Unreleased]
 
 ### Fixed
+- An agent asking for the operator's attention reaches the desktop that is
+  actually open, and the automatic focus lands (#688). Three things had to be
+  true for that and none of them were. Presence — who is looking at the viewer —
+  lived in one process's memory, written only by the server that receives the
+  browser's heartbeat, so every other process on the machine (the MCP server,
+  where the agent's tools run) read an empty map and concluded nobody was there;
+  it is now mirrored to the shared state dir, which is also what stops
+  `operator_snapshot` reporting no active view while the board is open. A raised
+  request now names the views that are open at the moment it is raised, rather
+  than filling that list in seconds later on some browser's next poll, so the
+  answer the agent gets can say who it reached — a phone, a hidden tab and a
+  long-silent view are still named by nobody, because none of them will move.
+  And the move itself now finds conversations the board draws inside a container
+  — a worker that folded into its parent's stack once it went quiet, a reviewer
+  round drawn in its flow's deck — instead of reporting a card on the operator's
+  screen as gone: the focus index resolves through the same layout the board's
+  own links route through, and a conversation the layout left out entirely is
+  asked for through the shell before the handoff gives up. A move that happens
+  this way is recorded as the automatic follow it is, and leaves the Back
+  control that returns the operator to where they were.
 - Agent chips on the conversation canvas report the agent's real output, not
   the state of its process (#669). Chip activity now derives from how long ago
   the conversation's transcript last grew, so a lane appending records every

--- a/src/components/ProjectDashboard.tsx
+++ b/src/components/ProjectDashboard.tsx
@@ -106,6 +106,11 @@ interface Props {
       re-flashes repeated jumps to the same path; prefs stay untouched — a
       read-only jump must not mutate manual column state. */
   focusRequest?: { path: string; nonce: number } | null;
+  /** Put this node in the layout and DO NOT move the camera to it. The focus
+      handoff frames its own destination through the board controller, so the
+      card only has to exist; arming the glide channel too would race that move
+      with a second one. Same one-shot nonce discipline as `focusRequest`. */
+  placeRequest?: { path: string; nonce: number } | null;
   /** «Show only needs me»: non-null dims every scheme node not in the set. */
   attentionPaths?: ReadonlySet<string> | null;
   /** The project is shelved: hidden from the rail and the overview. */
@@ -319,6 +324,7 @@ export function ProjectDashboard({
   catalogFailures = 0,
   openNonce,
   focusRequest,
+  placeRequest,
   attentionPaths,
   archived,
   catalogKnown,
@@ -348,6 +354,9 @@ export function ProjectDashboard({
      gate lives for the mount, so a consumed edge stays consumed across every
      poll, render and idempotent replay. */
   const focusEdge = useRef(createFocusEdgeGate());
+  /* Its own gate: placement and navigation are separate edges and one must
+     never consume the other's nonce. */
+  const placeEdge = useRef(createFocusEdgeGate());
   /* The board arrangement (which windows, hidden/expanded, view mode, task
      panel) now lives in the shared server store, synced across devices, with a
      one-time seed from the old per-browser localStorage (#38). Reads stay
@@ -888,6 +897,23 @@ export function ProjectDashboard({
       ? replaceCompactPipelineEphemeral(prev, path, pipelines, deckFlows, files)
       : prev.includes(path) ? prev : [...prev, path]);
   }, [focusRequest, compactPipelinePaths, pipelines, deckFlows, files]);
+
+  /* Placement with no navigation: the same materialization as above, minus the
+     line that arms `pendingFocusRef`. That ref is what the next effect turns
+     into `flashNode`, and `flashNode` is what glides the camera — so leaving it
+     alone is precisely the difference between putting a card on the board and
+     taking the operator to it. Waits for placeability and consumes the edge on
+     the same terms, for the same reasons. */
+  useEffect(() => {
+    if (!placeRequest) return;
+    const placeable = pendingFocusTarget(placeRequest.path, files) !== null
+      || compactPipelinePaths.has(placeRequest.path);
+    if (!placeable || !placeEdge.current.consume(placeRequest)) return;
+    const { path } = placeRequest;
+    setEphemeral((prev) => compactPipelinePaths.has(path)
+      ? replaceCompactPipelineEphemeral(prev, path, pipelines, deckFlows, files)
+      : prev.includes(path) ? prev : [...prev, path]);
+  }, [placeRequest, compactPipelinePaths, pipelines, deckFlows, files]);
   /* eslint-enable react-hooks/set-state-in-effect */
 
   /* A node added from the switchboard enters the layout on the next render;

--- a/src/components/Viewer.tsx
+++ b/src/components/Viewer.tsx
@@ -377,6 +377,10 @@ export function Viewer() {
     openProject: selectProject,
     openPath: requestFocus,
     placePath: placeOnBoard,
+    /* The overview is a project selection like any other here — it just is not
+       a project. `selectProject` already speaks the sentinel; the bus should
+       not have to. */
+    openOverview: () => selectProject(OVERVIEW),
   }), [project, selectProject, requestFocus, placeOnBoard]);
 
   /* The N-cycle position anchors to an id: an item answered elsewhere drops

--- a/src/components/Viewer.tsx
+++ b/src/components/Viewer.tsx
@@ -138,6 +138,9 @@ export function Viewer() {
   /* The jump channel into the board: nonce so repeated jumps to the same node
      re-flash (D9); consumed by ProjectDashboard's pendingFocusRef path. */
   const [focusRequest, setFocusRequest] = useState<{ path: string; nonce: number; catalog: boolean } | null>(null);
+  /* Placement without navigation — see `placePath` below. Its own state and its
+     own nonce, so a place and a focus can never consume each other's edge. */
+  const [placeRequest, setPlaceRequest] = useState<{ path: string; nonce: number } | null>(null);
 
   /* eslint-disable react-hooks/set-state-in-effect */
   useEffect(() => {
@@ -356,6 +359,15 @@ export function Viewer() {
     setFocusRequest((prev) => ({ path, nonce: (prev?.nonce ?? 0) + 1, catalog: false }));
   }, []);
 
+  /* Reveal a card without going to it. `requestFocus` above both materializes
+     the node and arms the board's glide; a focus handoff wants only the first,
+     because it frames its own destination at its own zoom through the board
+     controller. Asking through `requestFocus` gave the handoff a competing
+     camera move it then had to race. */
+  const placeOnBoard = useCallback((path: string) => {
+    setPlaceRequest((prev) => ({ path, nonce: (prev?.nonce ?? 0) + 1 }));
+  }, []);
+
   /* #688: the shell half of a focus handoff. An accepted request opens the
      project it lives in and, when its intent is `open`, the conversation
      itself — the same hand-off an attention jump already uses, so a handoff and
@@ -364,7 +376,8 @@ export function Viewer() {
     project: project === OVERVIEW ? null : project,
     openProject: selectProject,
     openPath: requestFocus,
-  }), [project, selectProject, requestFocus]);
+    placePath: placeOnBoard,
+  }), [project, selectProject, requestFocus, placeOnBoard]);
 
   /* The N-cycle position anchors to an id: an item answered elsewhere drops
      out without moving the pointer's neighbors (D12). */
@@ -674,6 +687,7 @@ export function Viewer() {
             catalogFailures={catalogFailures}
             openNonce={openNonce}
             focusRequest={focusRequest?.catalog && catalogPin?.path !== focusRequest.path ? null : focusRequest}
+            placeRequest={placeRequest}
             attentionPaths={attentionPaths}
             archived={archivedProjects.has(project)}
             catalogKnown={catalogProjects.has(project)}

--- a/src/components/attention/AttentionHost.dom.test.tsx
+++ b/src/components/attention/AttentionHost.dom.test.tsx
@@ -140,6 +140,7 @@ function board(rects: Record<string, FocusRect>, project = "demo") {
   const bus = createFocusHandoffBus();
   const log: BoardLog = { moved: [], restored: [] };
   const opened: string[] = [];
+  const placed: string[] = [];
   const controller: BoardFocusController = {
     project,
     index: {
@@ -152,8 +153,13 @@ function board(rects: Record<string, FocusRect>, project = "demo") {
     restoreCamera: (camera) => { log.restored.push(camera); return true; },
   };
   bus.setBoard(controller);
-  bus.setShell({ project, openProject: () => {}, openPath: (path) => { opened.push(path); } });
-  return { bus, log, opened };
+  bus.setShell({
+    project,
+    openProject: () => {},
+    openPath: (path) => { opened.push(path); },
+    placePath: (path) => { placed.push(path); },
+  });
+  return { bus, log, opened, placed };
 }
 
 function raise(rect: FocusRect = RAISED_RECT) {
@@ -469,6 +475,7 @@ function layoutBoard(slice: FocusLayoutSlice, onOpenPath?: (path: string, publis
   const bus = createFocusHandoffBus();
   const log: BoardLog = { moved: [], restored: [] };
   const opened: string[] = [];
+  const placed: string[] = [];
   const publish = (next: FocusLayoutSlice) => {
     bus.setBoard({
       project: "demo",
@@ -481,9 +488,13 @@ function layoutBoard(slice: FocusLayoutSlice, onOpenPath?: (path: string, publis
   bus.setShell({
     project: "demo",
     openProject: () => {},
-    openPath: (path) => { opened.push(path); onOpenPath?.(path, publish); },
+    openPath: (path) => { opened.push(path); },
+    /* Placement is what the recovery asks for now, so this is the stub that has
+       to make the card appear. The camera is untouched: the only entry that
+       reaches `log.moved` is the handoff's own `moveTo`. */
+    placePath: (path) => { placed.push(path); onOpenPath?.(path, publish); },
   });
-  return { bus, log, opened };
+  return { bus, log, opened, placed };
 }
 
 test("a worker folded into its parent's stack is followed to the stack that is drawing it", async () => {
@@ -518,7 +529,7 @@ test("a worker folded into its parent's stack is followed to the stack that is d
 test("a conversation the board is not showing is asked for, followed once, and returned from", async () => {
   raise(UNREAD_FRAME_RECT);
   const empty: FocusLayoutSlice = { nodes: [], groups: [], stacks: [], byPath: new Map() };
-  const { bus, log, opened } = layoutBoard(empty, (path, publish) => {
+  const { bus, log, opened, placed } = layoutBoard(empty, (path, publish) => {
     /* What the shell does with a path the layout left out: the card enters. */
     publish({ ...empty, byPath: new Map<string, SchemeRect>([[path, LIVE_RECT as SchemeRect]]) });
   });
@@ -526,7 +537,12 @@ test("a conversation the board is not showing is asked for, followed once, and r
   mount(bus);
   await settle();
 
-  expect(opened).toEqual([ANCHOR]);
+  /* Placed, not navigated to: the recovery reveals the card and the handoff's
+     own `moveTo` is the only thing that moves the camera. Routing this through
+     `openPath` put the production focus glide in front of that move and the two
+     fought over the same camera. */
+  expect(placed).toEqual([ANCHOR]);
+  expect(opened).toEqual([]);
   expect(log.moved).toEqual([LIVE_RECT]);
   expect(record().state).toBe("following");
 
@@ -534,7 +550,8 @@ test("a conversation the board is not showing is asked for, followed once, and r
      and the card was placed by an edge that must not re-arm. */
   for (let i = 0; i < 5; i += 1) await poll();
   expect(log.moved).toHaveLength(1);
-  expect(opened).toEqual([ANCHOR]);
+  expect(placed).toEqual([ANCHOR]);
+  expect(opened).toEqual([]);
 
   click(one("[data-testid='attention-return']")!);
   await settle();

--- a/src/components/attention/AttentionHost.dom.test.tsx
+++ b/src/components/attention/AttentionHost.dom.test.tsx
@@ -13,6 +13,9 @@ import { OFFER_TTL_MS, type FocusRect } from "@/lib/attention/types";
 import { UNREAD_FRAME_RECT } from "@/lib/attention/frames";
 import { validateAttentionEvent } from "@/lib/attention/validation";
 
+import { buildFocusFrameIndex, type FocusLayoutSlice } from "@/components/scheme/focusFrames";
+import type { MiniStack, SchemeRect } from "@/components/scheme/layout";
+
 import { AttentionHost } from "./AttentionHost";
 import { createFocusHandoffBus, type BoardFocusController } from "./focusHandoffBus";
 
@@ -218,7 +221,9 @@ test("an explicit focus event moves the desktop view immediately, with no prompt
      to agree to. */
   expect(log.moved).toEqual([LIVE_RECT]);
   expect(record().state).toBe("following");
-  expect(record().acceptedVia).toBe("operator");
+  /* And the record says what it was: the desktop followed on its own. Calling
+     this the operator's own act would tell the agent they chose to come. */
+  expect(record().acceptedVia).toBe("auto-follow");
 });
 
 test("the whole confirmation panel is gone: no accept, preview, decline, message or pop-out control renders", async () => {
@@ -438,4 +443,101 @@ test("a hidden desktop surface moves nothing and reports nothing, and the reques
 
   expect(swept.expired).toEqual(["attention_1"]);
   expect(record().expiredCause).toBe("ttl");
+});
+
+/* ── Cards the board is drawing, but not as a rect of their own ─────────── */
+
+const STACK_KEY = "/tmp/root.jsonl::stack";
+const STACK_RECT: FocusRect = { x: 2_400, y: 900, w: 240, h: 400 };
+
+function stackHolding(paths: string[]): MiniStack {
+  return {
+    ...(STACK_RECT as SchemeRect),
+    key: STACK_KEY,
+    parent: "/tmp/root.jsonl",
+    items: paths.map((path) => ({ file: { path } as never, branches: 0 })),
+  };
+}
+
+/**
+ * A board that resolves through the REAL frame index, over a layout the board
+ * would actually produce. The seam this closes is between the two: the record
+ * and the host were both fine, and the request still died because the index the
+ * board publishes did not know its own layout was drawing the target.
+ */
+function layoutBoard(slice: FocusLayoutSlice, onOpenPath?: (path: string, publish: (next: FocusLayoutSlice) => void) => void) {
+  const bus = createFocusHandoffBus();
+  const log: BoardLog = { moved: [], restored: [] };
+  const opened: string[] = [];
+  const publish = (next: FocusLayoutSlice) => {
+    bus.setBoard({
+      project: "demo",
+      index: buildFocusFrameIndex(next, "demo", { boardRevision: 9 }),
+      moveTo: ({ rect }) => { log.moved.push(rect); return true; },
+      restoreCamera: (camera) => { log.restored.push(camera); return true; },
+    });
+  };
+  publish(slice);
+  bus.setShell({
+    project: "demo",
+    openProject: () => {},
+    openPath: (path) => { opened.push(path); onOpenPath?.(path, publish); },
+  });
+  return { bus, log, opened };
+}
+
+test("a worker folded into its parent's stack is followed to the stack that is drawing it", async () => {
+  /* The live failure, end to end. An orchestration worker collapses once it goes
+     quiet, so the board draws it as a row inside a mini-stack rather than as a
+     node — and a request raised through the agent's tool carries no frame to
+     fall back on. Nothing moved, the record was closed as `lost`, and the agent
+     was told the operator never arrived while its card was on their screen. */
+  raise(UNREAD_FRAME_RECT);
+  const { bus, log } = layoutBoard({
+    nodes: [],
+    groups: [],
+    stacks: [stackHolding([ANCHOR])],
+    byPath: new Map<string, SchemeRect>([[STACK_KEY, STACK_RECT as SchemeRect]]),
+  });
+
+  mount(bus);
+  await settle();
+
+  expect(log.moved).toEqual([STACK_RECT]);
+  expect(record().state).toBe("following");
+  expect(record().resolution).toBe("exact");
+
+  /* And the way back is on offer, which is the half the operator loses when the
+     move never happens. */
+  click(one("[data-testid='attention-return']")!);
+  await settle();
+  expect(log.restored).toEqual([{ x: 120, y: 340, zoom: 0.55 }]);
+  expect(record().state).toBe("returned");
+});
+
+test("a conversation the board is not showing is asked for, followed once, and returned from", async () => {
+  raise(UNREAD_FRAME_RECT);
+  const empty: FocusLayoutSlice = { nodes: [], groups: [], stacks: [], byPath: new Map() };
+  const { bus, log, opened } = layoutBoard(empty, (path, publish) => {
+    /* What the shell does with a path the layout left out: the card enters. */
+    publish({ ...empty, byPath: new Map<string, SchemeRect>([[path, LIVE_RECT as SchemeRect]]) });
+  });
+
+  mount(bus);
+  await settle();
+
+  expect(opened).toEqual([ANCHOR]);
+  expect(log.moved).toEqual([LIVE_RECT]);
+  expect(record().state).toBe("following");
+
+  /* Once, and only once: the poll re-delivers the same offer every few seconds
+     and the card was placed by an edge that must not re-arm. */
+  for (let i = 0; i < 5; i += 1) await poll();
+  expect(log.moved).toHaveLength(1);
+  expect(opened).toEqual([ANCHOR]);
+
+  click(one("[data-testid='attention-return']")!);
+  await settle();
+  expect(log.restored).toEqual([{ x: 120, y: 340, zoom: 0.55 }]);
+  expect(record().state).toBe("returned");
 });

--- a/src/components/attention/AttentionHost.dom.test.tsx
+++ b/src/components/attention/AttentionHost.dom.test.tsx
@@ -158,6 +158,7 @@ function board(rects: Record<string, FocusRect>, project = "demo") {
     openProject: () => {},
     openPath: (path) => { opened.push(path); },
     placePath: (path) => { placed.push(path); },
+    openOverview: () => {},
   });
   return { bus, log, opened, placed };
 }
@@ -493,6 +494,7 @@ function layoutBoard(slice: FocusLayoutSlice, onOpenPath?: (path: string, publis
        to make the card appear. The camera is untouched: the only entry that
        reaches `log.moved` is the handoff's own `moveTo`. */
     placePath: (path) => { placed.push(path); onOpenPath?.(path, publish); },
+    openOverview: () => {},
   });
   return { bus, log, opened, placed };
 }

--- a/src/components/attention/AttentionHost.tsx
+++ b/src/components/attention/AttentionHost.tsx
@@ -143,7 +143,11 @@ export function AttentionHost({ mobile, bus = focusHandoffBus, deviceId: forcedD
     leaving.current.set(request.id, before);
     let keepReturnPoint = false;
     try {
-      const accepted = await offers.accept(request);
+      /* `auto-follow`, because that is what this is: nothing was put in front of
+         the operator and nothing was pressed. Recording it as the operator's own
+         act would tell the agent they chose to come — the one thing the record
+         is there to keep honest. */
+      const accepted = await offers.accept(request, "auto-follow");
       if (!accepted.ok) return;
       /* Written after the server confirmed ownership, so a rejected device
          never stores a return point it will never use. */

--- a/src/components/attention/focusHandoffBus.ts
+++ b/src/components/attention/focusHandoffBus.ts
@@ -70,6 +70,17 @@ export interface ShellNavigator {
    * So placement is separable and this is the half that does it.
    */
   placePath(path: string): void;
+  /**
+   * Leave every project and show the overview.
+   *
+   * `openProject` cannot express this: the overview is the ABSENCE of an open
+   * project, which is why `project` reads null there. Without a way to say it,
+   * a return point captured on the overview had nowhere to go — the restore
+   * skipped the project switch, found no camera (the overview has none) and no
+   * focused path, and the Back control the operator had been offered did
+   * nothing at all.
+   */
+  openOverview(): void;
 }
 
 export interface FocusHandoffBus {

--- a/src/components/attention/focusHandoffBus.ts
+++ b/src/components/attention/focusHandoffBus.ts
@@ -54,8 +54,22 @@ export interface ShellNavigator {
   /** The open project, or null on the overview. */
   project: string | null;
   openProject(project: string): void;
-  /** Open a conversation by transcript path — what `intent: "open"` means. */
+  /** Open a conversation by transcript path — what `intent: "open"` means.
+      This is a NAVIGATION: it places the card and glides the camera to it. */
   openPath(path: string): void;
+  /**
+   * Put a card into the layout WITHOUT moving the camera to it.
+   *
+   * `openPath` does two things at once — it materializes the node and it arms
+   * the board's pending-focus channel, which flashes the node and glides the
+   * camera. A handoff needs only the first: it has its own destination, at its
+   * own zoom, and issues it through `moveTo`. Calling `openPath` to reveal a
+   * missing card therefore bought the placement at the price of a second,
+   * competing camera move that raced the one the handoff actually wanted.
+   *
+   * So placement is separable and this is the half that does it.
+   */
+  placePath(path: string): void;
 }
 
 export interface FocusHandoffBus {

--- a/src/components/attention/navigate.test.ts
+++ b/src/components/attention/navigate.test.ts
@@ -31,12 +31,14 @@ interface Moves {
   opened: string[];
   /** PLACEMENTS: the card enters the layout and the camera does not move. */
   placed: string[];
+  /** How many times the shell was sent back to the overview. */
+  overview: number;
   projects: string[];
 }
 
 function harness(project: string, rects: Record<string, FocusRect>, shellProject: string | null = project) {
   const bus = createFocusHandoffBus();
-  const log: Moves = { moved: [], restored: [], opened: [], placed: [], projects: [] };
+  const log: Moves = { moved: [], restored: [], opened: [], placed: [], projects: [], overview: 0 };
   const board: BoardFocusController = {
     project,
     index: index(project, rects),
@@ -47,7 +49,8 @@ function harness(project: string, rects: Record<string, FocusRect>, shellProject
     project: shellProject,
     openProject: (next) => log.projects.push(next),
     openPath: (path) => log.opened.push(path),
-    placePath: (path) => log.placed.push(path),
+    placePath: (path) => { log.placed.push(path); },
+    openOverview: () => { log.overview += 1; },
   };
   bus.setBoard(board);
   bus.setShell(shell);
@@ -124,9 +127,10 @@ test("a vanished anchor whose request never read a board reports lost rather tha
 
 test("a target in another project opens that project first and waits for its board", async () => {
   const bus = createFocusHandoffBus();
-  const log: Moves = { moved: [], restored: [], opened: [], placed: [], projects: [] };
+  const log: Moves = { moved: [], restored: [], opened: [], placed: [], projects: [], overview: 0 };
   bus.setShell({
     placePath: () => {},
+    openOverview: () => {},
     project: "demo",
     openProject: (next) => {
       log.projects.push(next);
@@ -155,8 +159,8 @@ test("a target in another project opens that project first and waits for its boa
 
 test("nothing moves when no board ever answers for the target's project", async () => {
   const bus = createFocusHandoffBus();
-  const log: Moves = { moved: [], restored: [], opened: [], placed: [], projects: [] };
-  bus.setShell({ project: "demo", openProject: (next) => { log.projects.push(next); }, openPath: (path) => { log.opened.push(path); }, placePath: (path) => { log.placed.push(path); } });
+  const log: Moves = { moved: [], restored: [], opened: [], placed: [], projects: [], overview: 0 };
+  bus.setShell({ project: "demo", openProject: (next) => { log.projects.push(next); }, openPath: (path) => { log.opened.push(path); }, placePath: (path) => { log.placed.push(path); }, openOverview: () => {} });
 
   const outcome = await runFocusHandoff(request({ frameAtCreation: frame("gone") }), bus, { timeoutMs: 5, pollMs: 1 });
 
@@ -190,10 +194,10 @@ test("returning on a camera-less surface falls back to what was focused there", 
   const bus = createFocusHandoffBus();
   const opened: string[] = [];
   bus.setBoard({ project: "demo", index: index("demo", {}), moveTo: () => true, restoreCamera: () => false });
-  bus.setShell({ project: "demo", openProject: () => {}, openPath: (path) => { opened.push(path); }, placePath: () => {} });
+  bus.setShell({ project: "demo", openProject: () => {}, openPath: (path) => { opened.push(path); }, placePath: () => {}, openOverview: () => {} });
 
   const restored = await restoreFocusPoint(
-    { camera: { x: 1, y: 2, zoom: 3 }, focusedPath: "/tmp/what-i-was-reading.jsonl" },
+    { mode: "scheme" as const, camera: { x: 1, y: 2, zoom: 3 }, focusedPath: "/tmp/what-i-was-reading.jsonl" },
     "demo",
     bus,
     NO_WAIT,
@@ -207,7 +211,7 @@ test("returning restores the exact camera the device left, and does not re-open 
   const { bus, log } = harness("demo", { "/tmp/reviewer.jsonl": RECT });
 
   const restored = await restoreFocusPoint(
-    { camera: { x: 120, y: 340, zoom: 0.55 }, focusedPath: "/tmp/what-i-was-reading.jsonl" },
+    { mode: "scheme" as const, camera: { x: 120, y: 340, zoom: 0.55 }, focusedPath: "/tmp/what-i-was-reading.jsonl" },
     "demo",
     bus,
     NO_WAIT,
@@ -235,6 +239,7 @@ test("Back after a recovered handoff returns to the exact camera the operator le
     openProject: (next) => log.projects.push(next),
     openPath: (path) => log.opened.push(path),
     placePath: (path) => { log.placed.push(path); rects[path] = { x: 40, y: 60, w: 600, h: 780 }; },
+    openOverview: () => {},
   });
   const wasReading = { x: 1_204, y: 88, zoom: 0.42 };
 
@@ -246,7 +251,7 @@ test("Back after a recovered handoff returns to the exact camera the operator le
   expect(log.moved).toHaveLength(1);
 
   const restored = await restoreFocusPoint(
-    { camera: wasReading, focusedPath: "/tmp/what-i-was-reading.jsonl" },
+    { mode: "scheme" as const, camera: wasReading, focusedPath: "/tmp/what-i-was-reading.jsonl" },
     "demo",
     bus,
     NO_WAIT,
@@ -268,7 +273,7 @@ test("a camera is never restored into a project it was not captured in", async (
   const { bus, log } = harness("some-other-project", { "/tmp/reviewer.jsonl": RECT });
 
   const restored = await restoreFocusPoint(
-    { camera: { x: 120, y: 340, zoom: 0.55 }, focusedPath: "/tmp/what-i-was-reading.jsonl" },
+    { mode: "scheme" as const, camera: { x: 120, y: 340, zoom: 0.55 }, focusedPath: "/tmp/what-i-was-reading.jsonl" },
     null,
     bus,
     NO_WAIT,
@@ -286,7 +291,7 @@ test("returning to a camera-less mode restores what was focused there instead", 
   const { bus, log } = harness("demo", {}, "other");
 
   const restored = await restoreFocusPoint(
-    { camera: null, focusedPath: "/tmp/what-i-was-reading.jsonl" },
+    { mode: "scheme" as const, camera: null, focusedPath: "/tmp/what-i-was-reading.jsonl" },
     "demo",
     bus,
     NO_WAIT,
@@ -335,7 +340,7 @@ test("a launched stage reaches a key-navigating surface as the card the board is
     },
     restoreCamera: () => false,
   });
-  bus.setShell({ project: "demo", openProject: () => {}, openPath: () => {}, placePath: () => {} });
+  bus.setShell({ project: "demo", openProject: () => {}, openPath: () => {}, placePath: () => {}, openOverview: () => {} });
 
   const outcome = await runFocusHandoff({
     target: { kind: "stage", pipelineId: "p1", stageId: "review" },
@@ -367,7 +372,7 @@ test("a stage still waiting to launch is pinned by its own slot", async () => {
     moveTo: (destination) => { destinations.push(destination); return true; },
     restoreCamera: () => false,
   });
-  bus.setShell({ project: "demo", openProject: () => {}, openPath: () => {}, placePath: () => {} });
+  bus.setShell({ project: "demo", openProject: () => {}, openPath: () => {}, placePath: () => {}, openOverview: () => {} });
 
   await runFocusHandoff({
     target: { kind: "stage", pipelineId: "p1", stageId: "deploy" },
@@ -395,6 +400,7 @@ test("a conversation the board is not showing is asked for, and the handoff land
     /* What placement does on the real board: the card enters the layout, and
        the camera stays exactly where the operator left it. */
     placePath: (path) => { log.placed.push(path); rects[path] = landed; },
+    openOverview: () => {},
   });
 
   const outcome = await runFocusHandoff(
@@ -438,6 +444,7 @@ test("recovering a missing card still moves the camera exactly once, at the requ
       log.moved.push({ rect: rects[path]!, zoom: "situate", anchorKeys: [path] });
     },
     placePath: (path) => { log.placed.push(path); rects[path] = landed; },
+    openOverview: () => {},
   });
 
   const outcome = await runFocusHandoff(
@@ -487,4 +494,61 @@ test("a board that never produces the card still reports lost rather than a fals
   expect(outcome.resolution).toBe("lost");
   expect(log.moved).toEqual([]);
   expect(log.opened).toEqual([]);
+});
+
+test("Back from a handoff that began on the overview returns to the overview", async () => {
+  /* The inert-Back defect. A request raised while the operator was on the
+     overview opens a project to land, so every step of the old restore
+     described somewhere INSIDE a project: the project switch, the camera, the
+     focused path. None of them can say "no project at all", so pressing Back
+     did nothing at all — the control was rendered, the record moved on, and the
+     view stayed exactly where the handoff had put it. */
+  const { bus, log } = harness("demo", { "/tmp/reviewer.jsonl": RECT });
+
+  const restored = await restoreFocusPoint(
+    { mode: "overview", camera: null, focusedPath: null },
+    null,
+    bus,
+    NO_WAIT,
+  );
+
+  expect(restored).toBe(true);
+  expect(log.overview).toBe(1);
+  /* Nothing else fires: the overview is the destination, not a stop on the way
+     to one, and opening a project or a path here would undo it. */
+  expect(log.projects).toEqual([]);
+  expect(log.opened).toEqual([]);
+  expect(log.moved).toEqual([]);
+  expect(log.restored).toEqual([]);
+});
+
+test("an overview return point is honoured even when a project and a path were captured with it", async () => {
+  /* The mode is what says where they were, and it outranks the rest of the
+     record. A capture can carry a stale project or a focused path from before
+     the operator stepped out to the overview; restoring either would put them
+     back in the project they were being brought out of. */
+  const { bus, log } = harness("demo", { "/tmp/reviewer.jsonl": RECT });
+
+  const restored = await restoreFocusPoint(
+    { mode: "overview", camera: { x: 5, y: 6, zoom: 0.7 }, focusedPath: "/tmp/reviewer.jsonl" },
+    "demo",
+    bus,
+    NO_WAIT,
+  );
+
+  expect(restored).toBe(true);
+  expect(log.overview).toBe(1);
+  expect(log.projects).toEqual([]);
+  expect(log.restored).toEqual([]);
+  expect(log.opened).toEqual([]);
+});
+
+test("an overview return with no shell to steer reports that it did not restore", async () => {
+  /* Honesty at the boundary, the same rule the rest of this module follows: a
+     restore that could not happen must not report that it did, or the record
+     leaves `following` and the way back disappears with it. */
+  const bus = createFocusHandoffBus();
+
+  expect(await restoreFocusPoint({ mode: "overview", camera: null, focusedPath: null }, null, bus, NO_WAIT))
+    .toBe(false);
 });

--- a/src/components/attention/navigate.test.ts
+++ b/src/components/attention/navigate.test.ts
@@ -27,13 +27,16 @@ function index(project: string, rects: Record<string, FocusRect>): FocusFrameInd
 interface Moves {
   moved: FocusDestination[];
   restored: { x: number; y: number; zoom: number }[];
+  /** NAVIGATIONS: `openPath` places a card and glides the camera to it. */
   opened: string[];
+  /** PLACEMENTS: the card enters the layout and the camera does not move. */
+  placed: string[];
   projects: string[];
 }
 
 function harness(project: string, rects: Record<string, FocusRect>, shellProject: string | null = project) {
   const bus = createFocusHandoffBus();
-  const log: Moves = { moved: [], restored: [], opened: [], projects: [] };
+  const log: Moves = { moved: [], restored: [], opened: [], placed: [], projects: [] };
   const board: BoardFocusController = {
     project,
     index: index(project, rects),
@@ -44,6 +47,7 @@ function harness(project: string, rects: Record<string, FocusRect>, shellProject
     project: shellProject,
     openProject: (next) => log.projects.push(next),
     openPath: (path) => log.opened.push(path),
+    placePath: (path) => log.placed.push(path),
   };
   bus.setBoard(board);
   bus.setShell(shell);
@@ -120,8 +124,9 @@ test("a vanished anchor whose request never read a board reports lost rather tha
 
 test("a target in another project opens that project first and waits for its board", async () => {
   const bus = createFocusHandoffBus();
-  const log: Moves = { moved: [], restored: [], opened: [], projects: [] };
+  const log: Moves = { moved: [], restored: [], opened: [], placed: [], projects: [] };
   bus.setShell({
+    placePath: () => {},
     project: "demo",
     openProject: (next) => {
       log.projects.push(next);
@@ -150,8 +155,8 @@ test("a target in another project opens that project first and waits for its boa
 
 test("nothing moves when no board ever answers for the target's project", async () => {
   const bus = createFocusHandoffBus();
-  const log: Moves = { moved: [], restored: [], opened: [], projects: [] };
-  bus.setShell({ project: "demo", openProject: (next) => log.projects.push(next), openPath: (path) => log.opened.push(path) });
+  const log: Moves = { moved: [], restored: [], opened: [], placed: [], projects: [] };
+  bus.setShell({ project: "demo", openProject: (next) => { log.projects.push(next); }, openPath: (path) => { log.opened.push(path); }, placePath: (path) => { log.placed.push(path); } });
 
   const outcome = await runFocusHandoff(request({ frameAtCreation: frame("gone") }), bus, { timeoutMs: 5, pollMs: 1 });
 
@@ -185,7 +190,7 @@ test("returning on a camera-less surface falls back to what was focused there", 
   const bus = createFocusHandoffBus();
   const opened: string[] = [];
   bus.setBoard({ project: "demo", index: index("demo", {}), moveTo: () => true, restoreCamera: () => false });
-  bus.setShell({ project: "demo", openProject: () => {}, openPath: (path) => opened.push(path) });
+  bus.setShell({ project: "demo", openProject: () => {}, openPath: (path) => { opened.push(path); }, placePath: () => {} });
 
   const restored = await restoreFocusPoint(
     { camera: { x: 1, y: 2, zoom: 3 }, focusedPath: "/tmp/what-i-was-reading.jsonl" },
@@ -209,9 +214,48 @@ test("returning restores the exact camera the device left, and does not re-open 
   );
 
   expect(restored).toBe(true);
+  /* Exactly where the operator was: the same three numbers, once, and nothing
+     else touching the camera afterwards. */
   expect(log.restored).toEqual([{ x: 120, y: 340, zoom: 0.55 }]);
+  expect(log.moved).toEqual([]);
   /* Opening the focused path would glide the board to that node and undo the
      framing that was just restored, so the captured camera wins outright. */
+  expect(log.opened).toEqual([]);
+  expect(log.placed).toEqual([]);
+});
+
+test("Back after a recovered handoff returns to the exact camera the operator left", async () => {
+  /* End to end over the fixed path: the request reveals a card that was not on
+     the board, lands one move on it, and Back puts the operator back on the
+     precise framing they were reading before they agreed — not near it. */
+  const rects: Record<string, FocusRect> = {};
+  const { bus, log } = harness("demo", rects);
+  bus.setShell({
+    project: "demo",
+    openProject: (next) => log.projects.push(next),
+    openPath: (path) => log.opened.push(path),
+    placePath: (path) => { log.placed.push(path); rects[path] = { x: 40, y: 60, w: 600, h: 780 }; },
+  });
+  const wasReading = { x: 1_204, y: 88, zoom: 0.42 };
+
+  await runFocusHandoff(
+    request({ zoom: "inspect", frameAtCreation: { project: "demo", rect: UNREAD_FRAME_RECT, boardRevision: null } }),
+    bus,
+    NO_WAIT,
+  );
+  expect(log.moved).toHaveLength(1);
+
+  const restored = await restoreFocusPoint(
+    { camera: wasReading, focusedPath: "/tmp/what-i-was-reading.jsonl" },
+    "demo",
+    bus,
+    NO_WAIT,
+  );
+
+  expect(restored).toBe(true);
+  expect(log.restored).toEqual([wasReading]);
+  /* Back restores a framing; it must not frame a thing on the way. */
+  expect(log.moved).toHaveLength(1);
   expect(log.opened).toEqual([]);
 });
 
@@ -291,7 +335,7 @@ test("a launched stage reaches a key-navigating surface as the card the board is
     },
     restoreCamera: () => false,
   });
-  bus.setShell({ project: "demo", openProject: () => {}, openPath: () => {} });
+  bus.setShell({ project: "demo", openProject: () => {}, openPath: () => {}, placePath: () => {} });
 
   const outcome = await runFocusHandoff({
     target: { kind: "stage", pipelineId: "p1", stageId: "review" },
@@ -323,7 +367,7 @@ test("a stage still waiting to launch is pinned by its own slot", async () => {
     moveTo: (destination) => { destinations.push(destination); return true; },
     restoreCamera: () => false,
   });
-  bus.setShell({ project: "demo", openProject: () => {}, openPath: () => {} });
+  bus.setShell({ project: "demo", openProject: () => {}, openPath: () => {}, placePath: () => {} });
 
   await runFocusHandoff({
     target: { kind: "stage", pipelineId: "p1", stageId: "deploy" },
@@ -347,8 +391,10 @@ test("a conversation the board is not showing is asked for, and the handoff land
   bus.setShell({
     project: "demo",
     openProject: (next) => log.projects.push(next),
-    /* What `openPath` does on the real board: the card enters the layout. */
-    openPath: (path) => { log.opened.push(path); rects[path] = landed; },
+    openPath: (path) => log.opened.push(path),
+    /* What placement does on the real board: the card enters the layout, and
+       the camera stays exactly where the operator left it. */
+    placePath: (path) => { log.placed.push(path); rects[path] = landed; },
   });
 
   const outcome = await runFocusHandoff(
@@ -357,30 +403,74 @@ test("a conversation the board is not showing is asked for, and the handoff land
     NO_WAIT,
   );
 
-  expect(log.opened).toEqual(["/tmp/reviewer.jsonl"]);
+  expect(log.placed).toEqual(["/tmp/reviewer.jsonl"]);
   expect(outcome.resolution).toBe("exact");
   expect(outcome.moved).toBe(true);
   expect(log.moved).toEqual([{ rect: landed, zoom: "situate", anchorKeys: ["/tmp/reviewer.jsonl"] }]);
+  /* The recovery reveals; it never navigates. A single production-path move
+     stands between the operator and the target. */
+  expect(log.opened).toEqual([]);
 });
 
-test("asking for the card is one focus edge, never two", async () => {
-  /* `openPath` is an edge the board consumes by nonce: asking twice for the same
-     path glides the camera a second time, over the move that just finished. */
+test("recovering a missing card still moves the camera exactly once, at the requested zoom", async () => {
+  /* The defect this pins: recovery used `openPath`, which places the card AND
+     glides the camera through the production focus pipeline. The handoff then
+     issued its own `moveTo` at its own zoom — two competing moves for one
+     camera, and the operator watched the view arrive and slide off again.
+     Placement carries no camera, so `moveTo` is the whole of the navigation.
+
+     `intent: "open"` is the strictest case: it is the one intent that legitimately
+     calls `openPath` afterwards, so if anything is going to move twice it is
+     this. The surface opens; the camera does not move again. */
   const rects: Record<string, FocusRect> = {};
+  const landed: FocusRect = { x: 0, y: 0, w: 600, h: 780 };
   const { bus, log } = harness("demo", rects);
   bus.setShell({
     project: "demo",
     openProject: (next) => log.projects.push(next),
-    openPath: (path) => { log.opened.push(path); rects[path] = { x: 0, y: 0, w: 600, h: 780 }; },
+    /* Modelled as the shell really behaves: `openPath` arms the board's
+       pending-focus channel, which flashes the node and GLIDES THE CAMERA. It
+       is a move, and counting it is the whole point of this test — a recovery
+       routed through here shows up below as a second entry in `log.moved`. */
+    openPath: (path) => {
+      log.opened.push(path);
+      rects[path] ??= landed;
+      log.moved.push({ rect: rects[path]!, zoom: "situate", anchorKeys: [path] });
+    },
+    placePath: (path) => { log.placed.push(path); rects[path] = landed; },
   });
 
-  await runFocusHandoff(
-    request({ intent: "open", frameAtCreation: { project: "demo", rect: UNREAD_FRAME_RECT, boardRevision: null } }),
+  const outcome = await runFocusHandoff(
+    request({ intent: "open", zoom: "inspect", frameAtCreation: { project: "demo", rect: UNREAD_FRAME_RECT, boardRevision: null } }),
     bus,
     NO_WAIT,
   );
 
+  /* Exactly one move through the production path, and it carries the zoom the
+     request asked for rather than whatever the focus pipeline would have used.
+     Asserted FIRST: when this regresses, the count is the diagnosis. */
+  expect(log.moved).toHaveLength(1);
+  expect(log.placed).toEqual(["/tmp/reviewer.jsonl"]);
+  expect(log.moved[0]!.zoom).toBe("inspect");
+  expect(log.moved[0]!.rect).toEqual(landed);
+  /* No navigation edge at all: the card is already placed and framed, so the
+     only thing `openPath` could add here is the glide `moveTo` just performed. */
+  expect(log.opened).toEqual([]);
+  expect(outcome.moved).toBe(true);
+});
+
+test("an open intent with the card already on the board opens the surface and still moves once", async () => {
+  /* The path that does NOT go through recovery: nothing is missing, so `open`
+     opens the conversation's own surface as it always did — and that is still
+     one camera move, not two. */
+  const { bus, log } = harness("demo", { "/tmp/reviewer.jsonl": RECT });
+
+  await runFocusHandoff(request({ intent: "open", zoom: "inspect" }), bus, NO_WAIT);
+
+  expect(log.placed).toEqual([]);
   expect(log.opened).toEqual(["/tmp/reviewer.jsonl"]);
+  expect(log.moved).toHaveLength(1);
+  expect(log.moved[0]!.zoom).toBe("inspect");
 });
 
 test("a board that never produces the card still reports lost rather than a false arrival", async () => {
@@ -393,7 +483,8 @@ test("a board that never produces the card still reports lost rather than a fals
   );
 
   /* Asked for, never delivered: the request is still owed an honest answer. */
-  expect(log.opened).toEqual(["/tmp/reviewer.jsonl"]);
+  expect(log.placed).toEqual(["/tmp/reviewer.jsonl"]);
   expect(outcome.resolution).toBe("lost");
   expect(log.moved).toEqual([]);
+  expect(log.opened).toEqual([]);
 });

--- a/src/components/attention/navigate.test.ts
+++ b/src/components/attention/navigate.test.ts
@@ -334,3 +334,66 @@ test("a stage still waiting to launch is pinned by its own slot", async () => {
 
   expect(destinations[0]!.anchorKeys).toEqual(["slot::p1::deploy"]);
 });
+
+test("a conversation the board is not showing is asked for, and the handoff lands once it arrives", async () => {
+  /* The live failure this closes: a worker conversation that has folded away or
+     never entered this layout is not in the index, and a request raised through
+     the agent's tool carries no frame to fall back on — so the handoff reported
+     `lost`, nothing moved, and no way back was ever offered. The shell can place
+     that card; it was simply never asked. */
+  const rects: Record<string, FocusRect> = {};
+  const landed: FocusRect = { x: 320, y: 880, w: 600, h: 780 };
+  const { bus, log } = harness("demo", rects);
+  bus.setShell({
+    project: "demo",
+    openProject: (next) => log.projects.push(next),
+    /* What `openPath` does on the real board: the card enters the layout. */
+    openPath: (path) => { log.opened.push(path); rects[path] = landed; },
+  });
+
+  const outcome = await runFocusHandoff(
+    request({ frameAtCreation: { project: "demo", rect: UNREAD_FRAME_RECT, boardRevision: null } }),
+    bus,
+    NO_WAIT,
+  );
+
+  expect(log.opened).toEqual(["/tmp/reviewer.jsonl"]);
+  expect(outcome.resolution).toBe("exact");
+  expect(outcome.moved).toBe(true);
+  expect(log.moved).toEqual([{ rect: landed, zoom: "situate", anchorKeys: ["/tmp/reviewer.jsonl"] }]);
+});
+
+test("asking for the card is one focus edge, never two", async () => {
+  /* `openPath` is an edge the board consumes by nonce: asking twice for the same
+     path glides the camera a second time, over the move that just finished. */
+  const rects: Record<string, FocusRect> = {};
+  const { bus, log } = harness("demo", rects);
+  bus.setShell({
+    project: "demo",
+    openProject: (next) => log.projects.push(next),
+    openPath: (path) => { log.opened.push(path); rects[path] = { x: 0, y: 0, w: 600, h: 780 }; },
+  });
+
+  await runFocusHandoff(
+    request({ intent: "open", frameAtCreation: { project: "demo", rect: UNREAD_FRAME_RECT, boardRevision: null } }),
+    bus,
+    NO_WAIT,
+  );
+
+  expect(log.opened).toEqual(["/tmp/reviewer.jsonl"]);
+});
+
+test("a board that never produces the card still reports lost rather than a false arrival", async () => {
+  const { bus, log } = harness("demo", {});
+
+  const outcome = await runFocusHandoff(
+    request({ frameAtCreation: { project: "demo", rect: UNREAD_FRAME_RECT, boardRevision: null } }),
+    bus,
+    NO_WAIT,
+  );
+
+  /* Asked for, never delivered: the request is still owed an honest answer. */
+  expect(log.opened).toEqual(["/tmp/reviewer.jsonl"]);
+  expect(outcome.resolution).toBe("lost");
+  expect(log.moved).toEqual([]);
+});

--- a/src/components/attention/navigate.ts
+++ b/src/components/attention/navigate.ts
@@ -195,12 +195,28 @@ export async function runFocusHandoff(
  * comes back instead.
  */
 export async function restoreFocusPoint(
-  point: Pick<ReturnPoint, "camera" | "focusedPath">,
+  point: Pick<ReturnPoint, "camera" | "focusedPath" | "mode">,
   project: string | null,
   bus: FocusHandoffBus,
   timing: HandoffTiming = {},
 ): Promise<boolean> {
   const shell = bus.shell();
+
+  /* The mode is part of where they were, not decoration on it. The overview is
+     the case that proves it: a handoff raised from there opens a project, and
+     every step below — the project switch, the camera, the focused path — then
+     describes somewhere INSIDE a project. None of them can express "no project
+     at all", so a return point captured on the overview restored nothing and
+     the Back control sat there doing nothing every time it was pressed.
+
+     Answered before anything else, because the steps below would otherwise put
+     the operator back into the project they were being brought out of. */
+  if (point.mode === "overview") {
+    if (!shell) return false;
+    shell.openOverview();
+    return true;
+  }
+
   if (project && shell && shell.project !== project) shell.openProject(project);
 
   if (point.camera && project) {

--- a/src/components/attention/navigate.ts
+++ b/src/components/attention/navigate.ts
@@ -85,6 +85,14 @@ function presentAnchorKeys(target: FocusTarget | null, index: FocusFrameIndex): 
 }
 
 async function boardForProject(bus: FocusHandoffBus, project: string, timing: HandoffTiming) {
+  return waitForBoard(bus, timing, (board) => board.project === project);
+}
+
+async function waitForBoard(
+  bus: FocusHandoffBus,
+  timing: HandoffTiming,
+  ready: (board: NonNullable<ReturnType<FocusHandoffBus["board"]>>) => boolean,
+) {
   const timeoutMs = timing.timeoutMs ?? BOARD_WAIT_MS;
   const pollMs = timing.pollMs ?? BOARD_POLL_MS;
   const sleep = timing.sleep ?? wait;
@@ -92,7 +100,7 @@ async function boardForProject(bus: FocusHandoffBus, project: string, timing: Ha
   const deadline = now() + timeoutMs;
   for (;;) {
     const board = bus.board();
-    if (board?.project === project) return board;
+    if (board && ready(board)) return board;
     if (now() >= deadline) return null;
     await sleep(pollMs);
   }
@@ -114,8 +122,29 @@ export async function runFocusHandoff(
   const shell = bus.shell();
   if (shell && shell.project !== project) shell.openProject(project);
 
-  const board = await boardForProject(bus, project, timing);
-  const resolved = resolveFocusTarget(request.target, usableFrame(request.frameAtCreation), board?.index ?? null);
+  let board = await boardForProject(bus, project, timing);
+  let resolved = resolveFocusTarget(request.target, usableFrame(request.frameAtCreation), board?.index ?? null);
+
+  /* Last resort for a conversation the board is not showing: ASK for it.
+     `openPath` is the same door the operator's own attention jump uses, and it
+     places a card the board would otherwise leave out — one folded away, or one
+     that has not entered this layout at all. Until this existed, a request
+     raised through the agent's tool (which carries no frame, so the anchor is
+     the whole of the resolution) was reported `lost` for a conversation the
+     shell could have put on screen in a hundred milliseconds, and the operator
+     saw nothing move and got no way back. Tried only after a plain resolution
+     failed, so nothing that already worked changes, and bounded by the same
+     wait as everything else here. */
+  let asked = false;
+  if (board && resolved.resolution === "lost" && request.target.kind === "conversation" && shell) {
+    const wanted = request.target.path;
+    shell.openPath(wanted);
+    asked = true;
+    board = await waitForBoard(bus, timing, (candidate) => candidate.project === project && candidate.index.rectFor(wanted) !== null)
+      ?? board;
+    resolved = resolveFocusTarget(request.target, usableFrame(request.frameAtCreation), board.index);
+  }
+
   if (!board || !resolved.frame || resolved.resolution === "lost") {
     /* Nowhere to land. Nothing moves, and the caller reports `lost` to the
        record rather than pretending the operator arrived somewhere. */
@@ -135,8 +164,10 @@ export async function runFocusHandoff(
   /* `open` also opens the target's own surface; `show` frames it and stops
      there. Only a conversation has a surface to open — a geometric target is
      refused the intent at creation, and the rest are board objects the frame
-     itself puts on screen. */
-  if (request.intent === "open" && request.target.kind === "conversation") shell?.openPath(request.target.path);
+     itself puts on screen. Skipped when the recovery above already asked for
+     exactly this path: each ask is a fresh focus EDGE, and a second one would
+     glide the camera again over the move that just finished. */
+  if (!asked && request.intent === "open" && request.target.kind === "conversation") shell?.openPath(request.target.path);
   return { resolution: resolved.resolution, moved: true, frame: resolved.frame };
 }
 

--- a/src/components/attention/navigate.ts
+++ b/src/components/attention/navigate.ts
@@ -126,19 +126,25 @@ export async function runFocusHandoff(
   let resolved = resolveFocusTarget(request.target, usableFrame(request.frameAtCreation), board?.index ?? null);
 
   /* Last resort for a conversation the board is not showing: ASK for it.
-     `openPath` is the same door the operator's own attention jump uses, and it
-     places a card the board would otherwise leave out — one folded away, or one
-     that has not entered this layout at all. Until this existed, a request
-     raised through the agent's tool (which carries no frame, so the anchor is
-     the whole of the resolution) was reported `lost` for a conversation the
-     shell could have put on screen in a hundred milliseconds, and the operator
-     saw nothing move and got no way back. Tried only after a plain resolution
-     failed, so nothing that already worked changes, and bounded by the same
-     wait as everything else here. */
+     This places a card the board would otherwise leave out — one folded away,
+     or one that has not entered this layout at all. Until this existed, a
+     request raised through the agent's tool (which carries no frame, so the
+     anchor is the whole of the resolution) was reported `lost` for a
+     conversation the shell could have put on screen in a hundred milliseconds,
+     and the operator saw nothing move and got no way back. Tried only after a
+     plain resolution failed, so nothing that already worked changes, and
+     bounded by the same wait as everything else here.
+
+     `placePath`, NOT `openPath`: the recovery wants the card in the layout, and
+     nothing else. `openPath` would also arm the board's pending-focus channel,
+     which glides the camera on its own — so the handoff's own `moveTo` below
+     became the SECOND move of two, at a different zoom, each fighting the
+     other for the same camera. The operator saw the view arrive somewhere and
+     then slide off it. Placement here, navigation once, further down. */
   let asked = false;
   if (board && resolved.resolution === "lost" && request.target.kind === "conversation" && shell) {
     const wanted = request.target.path;
-    shell.openPath(wanted);
+    shell.placePath(wanted);
     asked = true;
     board = await waitForBoard(bus, timing, (candidate) => candidate.project === project && candidate.index.rectFor(wanted) !== null)
       ?? board;
@@ -164,9 +170,9 @@ export async function runFocusHandoff(
   /* `open` also opens the target's own surface; `show` frames it and stops
      there. Only a conversation has a surface to open — a geometric target is
      refused the intent at creation, and the rest are board objects the frame
-     itself puts on screen. Skipped when the recovery above already asked for
-     exactly this path: each ask is a fresh focus EDGE, and a second one would
-     glide the camera again over the move that just finished. */
+     itself puts on screen. Skipped when the recovery above already placed
+     exactly this path: the card is in the layout and framed, so the only thing
+     `openPath` would add here is the camera glide that `moveTo` just made. */
   if (!asked && request.intent === "open" && request.target.kind === "conversation") shell?.openPath(request.target.path);
   return { resolution: resolved.resolution, moved: true, frame: resolved.frame };
 }

--- a/src/components/scheme/focusFrames.test.ts
+++ b/src/components/scheme/focusFrames.test.ts
@@ -6,7 +6,7 @@ import type { FileEntry } from "@/lib/types";
 import type { Pipeline } from "@/lib/pipelines/types";
 
 import { buildFocusFrameIndex, stageAnchorAliases, type FocusLayoutSlice } from "./focusFrames";
-import type { SchemeGroup, SchemeNode, SchemeRect } from "./layout";
+import type { MiniStack, SchemeGroup, SchemeNode, SchemeRect } from "./layout";
 
 const rect = (x: number, y: number, w = 600, h = 780): SchemeRect => ({ x, y, w, h });
 
@@ -126,4 +126,79 @@ test("the board reports which card a launched stage's anchor actually resolves t
   });
   expect(orphaned.concreteAnchorKey!("slot::p1::s2")).toBeNull();
   expect(orphaned.rectFor("slot::p1::s2")).toBeNull();
+});
+
+/* ── Cards the board draws inside a container ───────────────────────────── */
+
+function stack(key: string, box: SchemeRect, paths: string[]): MiniStack {
+  return { ...box, key, parent: "/tmp/root.jsonl", items: paths.map((path) => ({ file: { path } as FileEntry, branches: 0 })) };
+}
+
+test("a quiet worker folded into its parent's stack resolves to the stack that is drawing it", () => {
+  /* The live defect: an orchestration worker collapses ~15 minutes after it goes
+     quiet (#112) and stops being a node of its own. It is still on screen — one
+     row inside the mini-stack — but the focus index only knew about placed
+     rects, so every request naming that conversation resolved to `lost`, the
+     view never moved, and no way back was ever offered. */
+  const folded = "/tmp/quiet-worker.jsonl";
+  const stacked: FocusLayoutSlice = {
+    ...layout(),
+    stacks: [stack("/tmp/root.jsonl::stack", rect(2_400, 900, 240, 400), [folded])],
+    byPath: new Map<string, SchemeRect>([["/tmp/root.jsonl::stack", rect(2_400, 900, 240, 400)]]),
+  };
+
+  const index = buildFocusFrameIndex(stacked, "demo", { boardRevision: 12 });
+
+  expect(index.rectFor(folded)).toEqual({ x: 2_400, y: 900, w: 240, h: 400 });
+  /* Named as the key the board is actually drawing, so a surface that navigates
+     by key — the phone — pins the stack rather than hunting for a pane that is
+     not on its own list. */
+  expect(index.concreteAnchorKey!(folded)).toBe("/tmp/root.jsonl::stack");
+  expect(resolveFocusTarget({ kind: "conversation", path: folded }, null, index).resolution).toBe("exact");
+});
+
+test("a full node of its own always wins over the stack that used to hold it", () => {
+  const expanded = "/tmp/quiet-worker.jsonl";
+  const own = rect(120, 240);
+  const both: FocusLayoutSlice = {
+    ...layout(),
+    stacks: [stack("/tmp/root.jsonl::stack", rect(2_400, 900, 240, 400), [expanded])],
+    byPath: new Map<string, SchemeRect>([
+      [expanded, own],
+      ["/tmp/root.jsonl::stack", rect(2_400, 900, 240, 400)],
+    ]),
+  };
+
+  const index = buildFocusFrameIndex(both, "demo");
+
+  expect(index.rectFor(expanded)).toEqual(own);
+  expect(index.concreteAnchorKey!(expanded)).toBe(expanded);
+});
+
+test("a launched stage that has since gone quiet resolves through the stack holding its card", () => {
+  const agent = "/tmp/stage-agent.jsonl";
+  const stacked: FocusLayoutSlice = {
+    ...layout(),
+    stacks: [stack("/tmp/root.jsonl::stack", rect(2_400, 900, 240, 400), [agent])],
+    byPath: new Map<string, SchemeRect>([["/tmp/root.jsonl::stack", rect(2_400, 900, 240, 400)]]),
+  };
+
+  const index = buildFocusFrameIndex(stacked, "demo", { aliases: new Map([["slot::p1::s2", agent]]) });
+
+  expect(resolveFocusTarget({ kind: "stage", pipelineId: "p1", stageId: "s2" }, null, index).resolution).toBe("exact");
+  expect(index.concreteAnchorKey!("slot::p1::s2")).toBe("/tmp/root.jsonl::stack");
+});
+
+test("a conversation no container is drawing is still gone", () => {
+  const stacked: FocusLayoutSlice = {
+    ...layout(),
+    stacks: [stack("/tmp/root.jsonl::stack", rect(2_400, 900, 240, 400), ["/tmp/quiet-worker.jsonl"])],
+  };
+
+  const index = buildFocusFrameIndex(stacked, "demo");
+
+  /* The stack itself is not in `byPath` here, so nothing on this board hosts the
+     folded card — and inventing a rect for it would land the operator nowhere. */
+  expect(index.rectFor("/tmp/quiet-worker.jsonl")).toBeNull();
+  expect(index.rectFor("/tmp/never-here.jsonl")).toBeNull();
 });

--- a/src/components/scheme/focusFrames.ts
+++ b/src/components/scheme/focusFrames.ts
@@ -3,8 +3,8 @@ import type { FocusRect } from "@/lib/attention/types";
 import type { Pipeline } from "@/lib/pipelines/types";
 import { cleanTitle } from "@/lib/title";
 
-import { stageSlotKey } from "./agentLinks";
-import type { SchemeLayout, SchemeRect } from "./layout";
+import { buildAnchorIndex, stageSlotKey } from "./agentLinks";
+import type { DeckNode, MiniStack, SchemeLayout, SchemeRect } from "./layout";
 
 /**
  * The board's side of #688's target resolution: one read-only view of the
@@ -16,8 +16,19 @@ import type { SchemeLayout, SchemeRect } from "./layout";
  * resolution it feeds stays testable without a renderer or a camera.
  */
 
-/** Exactly the parts of a scheme layout a focus frame comes from. */
-export type FocusLayoutSlice = Pick<SchemeLayout, "byPath" | "groups" | "nodes">;
+/**
+ * Exactly the parts of a scheme layout a focus frame comes from.
+ *
+ * `stacks` and `decks` are here because a conversation the board is DRAWING is
+ * not always a rect of its own: a worker that has gone quiet folds into its
+ * parent's mini-stack, and a reviewer round is drawn inside its flow's deck.
+ * Both are still on screen in front of the operator, and both are absent from
+ * `byPath` under their own transcript path — so a focus request naming one used
+ * to resolve to nothing at all. Optional so a caller with a partial layout (a
+ * fixture) still builds an index; a caller that has them must pass them.
+ */
+export type FocusLayoutSlice = Pick<SchemeLayout, "byPath" | "groups" | "nodes">
+  & Partial<Pick<SchemeLayout, "stacks" | "decks">>;
 
 const toFocusRect = (rect: SchemeRect): FocusRect => ({ x: rect.x, y: rect.y, w: rect.w, h: rect.h });
 
@@ -91,12 +102,29 @@ export function buildFocusFrameIndex(
     return extra ? toFocusRect(extra) : null;
   };
 
+  /* Transcript path → the rect that visually HOSTS it, for the conversations the
+     board draws inside a container rather than as a node of their own. The same
+     resolution the agent links already route through, taken from the same
+     builder on purpose: a card an arrow can point at is a card a focus request
+     can be taken to, and letting the two answer differently is precisely how a
+     conversation on screen came to be reported as gone. */
+  const hosts = buildAnchorIndex(
+    layout.nodes.map((node) => node.file.path),
+    (layout.decks ?? []).map((deck: DeckNode) => ({ key: deck.key, flow: deck.flow })),
+    (layout.stacks ?? []).map((stack: MiniStack) => ({ key: stack.key, paths: stack.items.map((item) => item.file.path) })),
+  );
+
   /** The key the layout genuinely holds this anchor under: itself when it is
-      placed directly, otherwise its alias. Null when neither is on the board. */
+      placed directly, then its alias, then whatever container is drawing it.
+      Null when the board is not showing it at all. */
   const concreteAnchorKey = (anchorKey: string): string | null => {
     if (lookup(anchorKey)) return anchorKey;
     const alias = options.aliases?.get(anchorKey);
-    return alias && lookup(alias) ? alias : null;
+    if (alias && lookup(alias)) return alias;
+    /* A launched stage that has since gone quiet is both aliased AND hosted, so
+       the container is looked up under the alias when there is one. */
+    const host = hosts.get(alias ?? anchorKey);
+    return host && lookup(host) ? host : null;
   };
 
   return {

--- a/src/lib/attention/service.test.ts
+++ b/src/lib/attention/service.test.ts
@@ -3,6 +3,9 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
+import { resetPresenceForTest, upsertPresence } from "@/lib/view/presenceStore";
+import type { PresencePayloadV1 } from "@/lib/view/types";
+
 import { readAttentionFile } from "./store";
 import { answerAttentionRequest, attentionForDevice, autoFollowEligible, raiseAttentionRequest } from "./service";
 import { AttentionRequestError, validateAttentionCreate, validateAttentionEvent } from "./validation";
@@ -19,9 +22,13 @@ beforeEach(() => {
   previousStateDir = process.env.LLV_STATE_DIR;
   sandbox = fs.mkdtempSync(path.join(os.tmpdir(), "llv-attention-service-"));
   process.env.LLV_STATE_DIR = sandbox;
+  /* Presence decides who a request is offered to, so a view left over from
+     another test would answer this one's question for it. */
+  resetPresenceForTest();
 });
 
 afterEach(() => {
+  resetPresenceForTest();
   if (previousStateDir === undefined) delete process.env.LLV_STATE_DIR;
   else process.env.LLV_STATE_DIR = previousStateDir;
   fs.rmSync(sandbox, { recursive: true, force: true });
@@ -288,4 +295,97 @@ test("a conversation target with no durable owner is left exactly as raised", ()
   }, { now: T0, id: "attention_unknown", conversations });
 
   expect(raised.request.target).toEqual({ kind: "conversation", path: unknown });
+});
+
+/* ── Who the request is put in front of ─────────────────────────────────── */
+
+function view(overrides: Partial<PresencePayloadV1> = {}): PresencePayloadV1 {
+  return {
+    schemaVersion: 1,
+    viewSessionId: "view-1",
+    deviceId: DEVICE,
+    device: { kind: "desktop", browser: "chrome" },
+    visibility: "visible",
+    sequence: 1,
+    inputSequence: 1,
+    project: "demo",
+    mode: "scheme",
+    viewport: { width: 1_600, height: 900, dpr: 2 },
+    camera: { x: 10, y: 20, zoom: 0.6, worldRect: { x: 0, y: 0, width: 100, height: 80 } },
+    focusedPath: "/tmp/reviewer.jsonl",
+    selectedPaths: [],
+    visiblePaths: [],
+    board: { renderedRevision: 4, durableRevision: 4, sync: "current" },
+    ...overrides,
+  };
+}
+
+test("a request names the desktop views that are open when it is raised", () => {
+  /* The operator's symptom: the agent's tool answers synchronously and then
+     speaks about what it asked for, so an `offeredTo` that only fills in on some
+     browser's next poll told every caller that nobody was there. */
+  upsertPresence(view(), T0.getTime());
+
+  const raised = raise().request;
+
+  expect(raised.offeredTo).toEqual([DEVICE]);
+  /* Naming the device is not agreeing on its behalf: the request is still
+     waiting for a surface to render it. */
+  expect(raised.state).toBe("pending");
+  expect(raised.acknowledgedBy).toBeUndefined();
+});
+
+test("the phone is never named: it cannot render an offer and cannot move its board", () => {
+  upsertPresence(view({ viewSessionId: "view-phone", deviceId: "device-phone", device: { kind: "mobile", browser: "safari" } }), T0.getTime());
+
+  expect(raise().request.offeredTo).toEqual([]);
+});
+
+test("a backgrounded or long-silent view is not somewhere the operator can be taken", () => {
+  upsertPresence(view({ viewSessionId: "view-hidden", deviceId: "device-hidden", visibility: "hidden" }), T0.getTime());
+  /* Visible, but last heard from long enough ago that it may be a laptop that
+     was shut. */
+  upsertPresence(view({ viewSessionId: "view-stale", deviceId: "device-stale" }), T0.getTime() - 120_000);
+
+  expect(raise().request.offeredTo).toEqual([]);
+});
+
+test("two tabs on one machine are one place to be taken", () => {
+  upsertPresence(view({ viewSessionId: "view-a" }), T0.getTime());
+  upsertPresence(view({ viewSessionId: "view-b" }), T0.getTime());
+
+  expect(raise().request.offeredTo).toEqual([DEVICE]);
+});
+
+test("a device offered at creation may answer the request without any further ceremony", () => {
+  upsertPresence(view(), T0.getTime());
+  raise();
+
+  /* The seeded list is the same list the machine checks, so the surface that was
+     named can take the request through its whole life. */
+  answerAttentionRequest("attention_1", { kind: "offer", deviceId: DEVICE }, { now: T0 });
+  expect(attentionForDevice(DEVICE, { now: T0 }).offer!.status).toBe("actionable");
+  expect(readAttentionFile().requests[0]!.offeredTo).toEqual([DEVICE]);
+
+  const accepted = answerAttentionRequest("attention_1", { kind: "accept", deviceId: DEVICE, via: "auto-follow" }, { now: T0 });
+  expect(accepted.ok).toBe(true);
+});
+
+test("an operator command still names its own device and nothing else", () => {
+  /* An operator command is their own act on one surface; presence must never
+     widen it, because the first named device is the one recorded as having
+     accepted it. */
+  upsertPresence(view({ viewSessionId: "view-other", deviceId: "device-elsewhere" }), T0.getTime());
+
+  const raised = raiseAttentionRequest({
+    origin: "operator",
+    target: { kind: "conversation", path: "/tmp/reviewer.jsonl" },
+    frameAtCreation: frame,
+    intent: "show",
+    reason: "Take me to the reviewer.",
+    offeredTo: [DEVICE],
+  }, { now: T0, id: "attention_operator" }).request;
+
+  expect(raised.offeredTo).toEqual([DEVICE]);
+  expect(raised.acknowledgedBy).toBe(DEVICE);
 });

--- a/src/lib/attention/service.test.ts
+++ b/src/lib/attention/service.test.ts
@@ -341,6 +341,28 @@ test("the phone is never named: it cannot render an offer and cannot move its bo
   expect(raise().request.offeredTo).toEqual([]);
 });
 
+test("a desktop reading the history list is not named: there is no board to move", () => {
+  /* The silent failure this offer exists to remove, reappearing one level up. A
+     board controller is registered by the scheme board and the phone's focus
+     view and by nothing else, so a desktop sitting in the list has no camera and
+     no anchors: the handoff finds no controller, resolves `lost`, and NOTHING
+     ON SCREEN MOVES. Naming it anyway means the request is accepted, the agent
+     is told which desktop is watching, and the operator is shown nothing. */
+  upsertPresence(view({ viewSessionId: "view-list", deviceId: "device-list", mode: "list" }), T0.getTime());
+
+  expect(raise().request.offeredTo).toEqual([]);
+});
+
+test("a desktop on the overview is still named: landing there opens a project and mounts a board", () => {
+  /* Not symmetric with the list, and the difference is the whole point. A
+     handoff from the overview OPENS the target's project, which mounts the
+     board, and the handoff already waits for that board to publish. The list is
+     the mode the operator chose INSTEAD of a board, so no wait can produce one. */
+  upsertPresence(view({ viewSessionId: "view-overview", deviceId: DEVICE, mode: "overview", project: null, camera: null }), T0.getTime());
+
+  expect(raise().request.offeredTo).toEqual([DEVICE]);
+});
+
 test("a backgrounded or long-silent view is not somewhere the operator can be taken", () => {
   upsertPresence(view({ viewSessionId: "view-hidden", deviceId: "device-hidden", visibility: "hidden" }), T0.getTime());
   /* Visible, but last heard from long enough ago that it may be a laptop that

--- a/src/lib/attention/service.ts
+++ b/src/lib/attention/service.ts
@@ -1,6 +1,7 @@
 import { agentRegistry, type ConversationLookup } from "@/lib/agent/registry";
 import { rootIdentity } from "@/lib/root/store";
 import { freshness, listPresence } from "@/lib/view/presenceStore";
+import type { ViewMode } from "@/lib/view/types";
 
 import {
   applyAttentionEvent,
@@ -139,11 +140,33 @@ export function raiseAttentionRequest(
  * One entry per device, newest interaction first — two tabs on one machine are
  * one place to be taken.
  */
+/**
+ * Modes a desktop can actually BE moved in.
+ *
+ * A focus handoff needs a board controller, and only the scheme board and the
+ * phone's focus view ever register one. A desktop sitting in the history list
+ * has no camera and no anchors to select: the handoff finds no controller,
+ * reports `lost`, and nothing on screen moves. Offering to it is therefore the
+ * silent failure this whole surface exists to remove — the request is accepted,
+ * the agent is told which desktop is watching, and the operator sees nothing.
+ *
+ * `overview` stays offerable, and the distinction is not arbitrary: a handoff
+ * from the overview OPENS the target's project, which mounts the board, and
+ * `runFocusHandoff` already waits for that board to publish. The list is the
+ * mode the operator has chosen INSTEAD of a board, so no wait can produce one.
+ *
+ * The mode reported by presence is the only signal that crosses the process
+ * boundary here — the bus lives in the browser and this runs wherever the tool
+ * was called — so it is what the offer has to answer from.
+ */
+const FOLLOWABLE_MODES = new Set<ViewMode>(["overview", "scheme", "mobile-focus", "mobile-map"]);
+
 function followCapableDevices(now = new Date()): string[] {
   const at = now.getTime();
   const devices: string[] = [];
   for (const session of listPresence(at)) {
     if (session.device.kind === "mobile") continue;
+    if (!FOLLOWABLE_MODES.has(session.mode)) continue;
     /* The same guard a standing auto-follow passes, so "who was this offered
        to" and "who may be moved" can never drift apart. */
     if (!autoFollowEligible({ visibility: session.visibility, freshness: freshness(session, at) })) continue;

--- a/src/lib/attention/service.ts
+++ b/src/lib/attention/service.ts
@@ -1,5 +1,6 @@
 import { agentRegistry, type ConversationLookup } from "@/lib/agent/registry";
 import { rootIdentity } from "@/lib/root/store";
+import { freshness, listPresence } from "@/lib/view/presenceStore";
 
 import {
   applyAttentionEvent,
@@ -108,9 +109,47 @@ export function raiseAttentionRequest(
 ): ReturnType<typeof createAttentionRequest> {
   return createAttentionRequest({
     ...input,
+    /* Who this is being put in front of, answered AT CREATION rather than left
+       for whichever surface polls next. The caller — the agent's tool, most of
+       all — gets one synchronous response and then goes on talking to the
+       operator about it; an `offeredTo` that only fills in seconds later, on a
+       browser's next poll, meant that response could never name a device and
+       the agent was told nobody was there while the operator watched the board.
+       An explicit list still wins: the operator's own commands name their own
+       device, and nothing here may overrule that. */
+    offeredTo: input.offeredTo ?? (input.origin === "root-agent" ? followCapableDevices(options.now) : undefined),
     target: canonicalConversationTarget(input.target, options.conversations),
     rootId: rootIdentity(),
   }, options);
+}
+
+/**
+ * The devices that could actually follow this request right now.
+ *
+ * Read from presence, which is where "a view is open" is already recorded — and
+ * filtered by the same two rules the surfaces enforce, so the list never
+ * promises the agent a device that will not move:
+ *
+ * - VISIBLE AND ACTIVE. A backgrounded tab neither renders an offer nor follows
+ *   one, and a stale one may be a laptop that was shut hours ago;
+ * - NOT A PHONE. Mobile is chat-only by design: it withholds its device id, so
+ *   it can neither report the offer nor move its board. Counting it would tell
+ *   an agent its request had somewhere to land when it has not.
+ *
+ * One entry per device, newest interaction first — two tabs on one machine are
+ * one place to be taken.
+ */
+function followCapableDevices(now = new Date()): string[] {
+  const at = now.getTime();
+  const devices: string[] = [];
+  for (const session of listPresence(at)) {
+    if (session.device.kind === "mobile") continue;
+    /* The same guard a standing auto-follow passes, so "who was this offered
+       to" and "who may be moved" can never drift apart. */
+    if (!autoFollowEligible({ visibility: session.visibility, freshness: freshness(session, at) })) continue;
+    if (!devices.includes(session.deviceId)) devices.push(session.deviceId);
+  }
+  return devices;
 }
 
 /**

--- a/src/lib/mcp/requestAttention.test.ts
+++ b/src/lib/mcp/requestAttention.test.ts
@@ -12,6 +12,8 @@ import { adoptLiveRootSession } from "@/lib/root/adopt";
 import { readRootLineage } from "@/lib/root/store";
 import type { BoardTask } from "@/lib/tasks/types";
 import type { FileEntry } from "@/lib/types";
+import { resetPresenceForTest, upsertPresence } from "@/lib/view/presenceStore";
+import type { PresencePayloadV1 } from "@/lib/view/types";
 
 import { viewerMcpBindings } from "./bindings";
 import { createMcpToolService, MemoryMcpReceiptStore, MCP_TOOL_NAMES, type McpToolResult } from "./server";
@@ -347,4 +349,55 @@ test("a caller no recorded host names is allowed through", async () => {
 
   expect(result.ok).toBe(true);
   expect(readAttentionFile().requests).toHaveLength(1);
+});
+
+/* ── What the answer says about who will see it ─────────────────────────── */
+
+function openView(overrides: Partial<PresencePayloadV1> = {}): PresencePayloadV1 {
+  return {
+    schemaVersion: 1,
+    viewSessionId: "view-1",
+    deviceId: "device-desktop",
+    device: { kind: "desktop", browser: "chrome" },
+    visibility: "visible",
+    sequence: 1,
+    inputSequence: 1,
+    project: "live-log-viewer-next",
+    mode: "scheme",
+    viewport: { width: 1_600, height: 900, dpr: 2 },
+    camera: { x: 10, y: 20, zoom: 0.6, worldRect: { x: 0, y: 0, width: 100, height: 80 } },
+    focusedPath: null,
+    selectedPaths: [],
+    visiblePaths: [],
+    board: { renderedRevision: 4, durableRevision: 4, sync: "current" },
+    ...overrides,
+  };
+}
+
+test("the answer names the desktop the operator is sitting in front of", async () => {
+  /* The reported defect, at the exact surface it was reported from: an open,
+     visible desktop viewer, and a tool answering `offeredTo: []`. The presence
+     the browser publishes lives in the server's process; the tool runs in
+     another one, so the answer has to come off the shared record rather than
+     out of whichever map this process happens to hold. */
+  resetPresenceForTest();
+  upsertPresence(openView());
+
+  const result = await service().callTool("request_attention", ask()) as McpToolResult & { request?: { offeredTo?: string[]; state?: string } };
+
+  expect(result.ok).toBe(true);
+  expect(result.request!.offeredTo).toEqual(["device-desktop"]);
+  /* Still only an ask: naming the desktop is not agreeing on its behalf. */
+  expect(result.request!.state).toBe("pending");
+  resetPresenceForTest();
+});
+
+test("with nobody at a desk the answer says so rather than naming a device that will not move", async () => {
+  resetPresenceForTest();
+  upsertPresence(openView({ viewSessionId: "view-phone", deviceId: "device-phone", device: { kind: "mobile", browser: "safari" } }));
+
+  const result = await service().callTool("request_attention", ask()) as McpToolResult & { request?: { offeredTo?: string[] } };
+
+  expect(result.request!.offeredTo).toEqual([]);
+  resetPresenceForTest();
 });

--- a/src/lib/view/presenceStore.test.ts
+++ b/src/lib/view/presenceStore.test.ts
@@ -1,0 +1,124 @@
+import { afterEach, beforeEach, expect, test } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { freshness, listPresence, presenceFile, presenceLimits, resetPresenceForTest, upsertPresence } from "./presenceStore";
+import type { PresencePayloadV1 } from "./types";
+
+/*
+ * Presence has to answer the same question in every process on the machine.
+ *
+ * It used to be one in-memory map, and only the Next server ever writes to it —
+ * the browser's heartbeat goes to `POST /api/view/presence` and nowhere else.
+ * Every other process therefore read an empty map and concluded nobody was
+ * looking: the MCP stdio server, which is where the agent's tools run, reported
+ * `NO_ACTIVE_VIEW` from `operator_snapshot` and raised attention requests with
+ * an empty `offeredTo` while the operator was sitting in front of the board.
+ */
+
+let sandbox = "";
+let previousStateDir: string | undefined;
+
+const T0 = Date.parse("2026-07-01T10:00:00.000Z");
+
+beforeEach(() => {
+  previousStateDir = process.env.LLV_STATE_DIR;
+  sandbox = fs.mkdtempSync(path.join(os.tmpdir(), "llv-presence-store-"));
+  process.env.LLV_STATE_DIR = sandbox;
+  resetPresenceForTest();
+});
+
+afterEach(() => {
+  resetPresenceForTest();
+  if (previousStateDir === undefined) delete process.env.LLV_STATE_DIR;
+  else process.env.LLV_STATE_DIR = previousStateDir;
+  fs.rmSync(sandbox, { recursive: true, force: true });
+});
+
+function payload(overrides: Partial<PresencePayloadV1> = {}): PresencePayloadV1 {
+  return {
+    schemaVersion: 1,
+    viewSessionId: "view-1",
+    deviceId: "device-desktop",
+    device: { kind: "desktop", browser: "chrome" },
+    visibility: "visible",
+    sequence: 1,
+    inputSequence: 1,
+    project: "demo",
+    mode: "scheme",
+    viewport: { width: 1_600, height: 900, dpr: 2 },
+    camera: { x: 10, y: 20, zoom: 0.6, worldRect: { x: 0, y: 0, width: 100, height: 80 } },
+    focusedPath: "/tmp/reviewer.jsonl",
+    selectedPaths: [],
+    visiblePaths: ["/tmp/reviewer.jsonl"],
+    board: { renderedRevision: 4, durableRevision: 4, sync: "current" },
+    ...overrides,
+  };
+}
+
+/** What another process on this machine sees: it was never told anything, so its
+    own map is empty and the shared state dir is all it has. */
+function anotherProcess<T>(read: () => T): T {
+  (globalThis as Record<string, unknown>).__llvViewPresence = new Map();
+  return read();
+}
+
+test("a view published to the server is visible to every other process on the machine", () => {
+  upsertPresence(payload(), T0);
+
+  const seen = anotherProcess(() => listPresence(T0 + 1_000));
+
+  expect(seen.map((session) => session.viewSessionId)).toEqual(["view-1"]);
+  expect(seen[0]!.deviceId).toBe("device-desktop");
+  expect(seen[0]!.project).toBe("demo");
+  expect(freshness(seen[0]!, T0 + 1_000)).toBe("active");
+});
+
+test("the mirror lives in the shared state dir, beside the record it is read with", () => {
+  upsertPresence(payload(), T0);
+
+  expect(presenceFile()).toBe(path.join(sandbox, "view-presence.json"));
+  expect(fs.existsSync(presenceFile())).toBe(true);
+});
+
+test("a later heartbeat is what another process sees, and an older one is ignored", () => {
+  upsertPresence(payload({ sequence: 1, project: "demo" }), T0);
+  upsertPresence(payload({ sequence: 2, project: "other" }), T0 + 5_000);
+  /* A retransmitted older beat must not walk the view backwards. */
+  expect(upsertPresence(payload({ sequence: 1, project: "demo" }), T0 + 6_000).accepted).toBe(false);
+
+  const seen = anotherProcess(() => listPresence(T0 + 6_000));
+
+  expect(seen).toHaveLength(1);
+  expect(seen[0]!.project).toBe("other");
+});
+
+test("a view that stopped publishing ages out for every reader, not just the one that held it", () => {
+  upsertPresence(payload(), T0);
+
+  const seen = anotherProcess(() => listPresence(T0 + presenceLimits.RETENTION_MS + 1));
+
+  expect(seen).toEqual([]);
+});
+
+test("two devices are two entries, newest interaction first", () => {
+  upsertPresence(payload({ viewSessionId: "view-1", deviceId: "device-desktop" }), T0);
+  upsertPresence(payload({ viewSessionId: "view-2", deviceId: "device-phone", device: { kind: "mobile", browser: "safari" } }), T0 + 1_000);
+
+  const seen = anotherProcess(() => listPresence(T0 + 2_000));
+
+  expect(seen.map((session) => session.deviceId)).toEqual(["device-phone", "device-desktop"]);
+});
+
+test("an unreadable mirror never fails the heartbeat or the read", () => {
+  upsertPresence(payload(), T0);
+  fs.writeFileSync(presenceFile(), "{ this is not json", "utf8");
+
+  /* The process that owns the heartbeat still knows its own sessions, and a
+     publish after the damage repairs the file rather than throwing into the
+     route the browser is calling. */
+  expect(listPresence(T0 + 1_000)).toHaveLength(1);
+  expect(upsertPresence(payload({ sequence: 9 }), T0 + 2_000).accepted).toBe(true);
+  expect(anotherProcess(() => listPresence(T0 + 3_000))).toHaveLength(1);
+});

--- a/src/lib/view/presenceStore.test.ts
+++ b/src/lib/view/presenceStore.test.ts
@@ -3,7 +3,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
-import { freshness, listPresence, presenceFile, presenceLimits, resetPresenceForTest, upsertPresence } from "./presenceStore";
+import { freshness, listPresence, presenceFile, presenceLimits, resetPresenceForTest, sessionSummary, upsertPresence } from "./presenceStore";
 import type { PresencePayloadV1 } from "./types";
 
 /*
@@ -121,4 +121,119 @@ test("an unreadable mirror never fails the heartbeat or the read", () => {
   expect(listPresence(T0 + 1_000)).toHaveLength(1);
   expect(upsertPresence(payload({ sequence: 9 }), T0 + 2_000).accepted).toBe(true);
   expect(anotherProcess(() => listPresence(T0 + 3_000))).toHaveLength(1);
+});
+
+/*
+ * A phantom desktop is worse than no desktop.
+ *
+ * The two ways this can be wrong are not symmetric. Reading nothing makes an
+ * attention request fail where the operator can see it fail — that is the
+ * original defect, and it is loud. Reading a session that is not really there
+ * makes the request succeed silently in front of an empty chair: it is recorded
+ * as offered, nobody is watching, and nothing ever says so. So the mirror is
+ * read with suspicion, and anything it cannot fully vouch for is dropped.
+ */
+
+/** Write the mirror directly, the way a foreign process or a damaged write
+    would leave it — bypassing `upsertPresence`, which would sanitize it. */
+function mirror(sessions: unknown[], now = T0): void {
+  fs.writeFileSync(
+    presenceFile(),
+    JSON.stringify({ schemaVersion: 1, updatedAt: new Date(now).toISOString(), sessions }, null, 2),
+    "utf8",
+  );
+}
+
+function stored(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return { ...payload(), lastSeenAt: T0, lastInteractionAt: T0, ...overrides };
+}
+
+test("a session claiming the future is discarded, not believed forever", () => {
+  /* `freshness` clamps a negative age at zero, so a future `lastSeenAt` reads
+     `active` no matter how long anyone waits, and `expire` — which needs the age
+     to EXCEED retention — can never remove it. One such record advertises a
+     desktop that does not exist, permanently, and every attention request from
+     then on is offered to it. */
+  mirror([stored({ viewSessionId: "from-the-future", lastSeenAt: T0 + 3_600_000, lastInteractionAt: T0 + 3_600_000 })]);
+
+  expect(anotherProcess(() => listPresence(T0))).toEqual([]);
+  /* Rejected for as long as it is impossible — the whole hour, not just the
+     instant it was read. This is the permanence that mattered: unrejected, the
+     clamp in `freshness` and the comparison in `expire` between them made the
+     entry `active` and unexpirable FOREVER.
+
+     What is deliberately NOT claimed: once the clock reaches its timestamp the
+     record is merely old, and it is believed for the ordinary retention window
+     like any session that stopped publishing. Refusing it beyond that would
+     mean remembering every id ever rejected, which trades a bounded two-minute
+     phantom for an unbounded set and a session that a legitimate clock
+     correction can never re-admit. */
+  expect(anotherProcess(() => listPresence(T0 + 3_000_000))).toEqual([]);
+});
+
+test("a small clock disagreement between machines is tolerated", () => {
+  /* Two processes sharing a state dir do not share a clock to the millisecond.
+     Suspicion is for the impossible, not for the merely early. */
+  mirror([stored({ viewSessionId: "slightly-ahead", lastSeenAt: T0 + 1_000, lastInteractionAt: T0 + 1_000 })]);
+
+  expect(anotherProcess(() => listPresence(T0)).map((session) => session.viewSessionId))
+    .toEqual(["slightly-ahead"]);
+});
+
+test("a partial session is discarded rather than completed with guesses", () => {
+  const complete = stored({ viewSessionId: "whole" });
+  const cases: Record<string, unknown>[] = [
+    { ...stored({ viewSessionId: "no-device" }), deviceId: undefined },
+    { ...stored({ viewSessionId: "empty-device" }), deviceId: "" },
+    { ...stored({ viewSessionId: "no-input-sequence" }), inputSequence: undefined },
+    { ...stored({ viewSessionId: "no-last-seen" }), lastSeenAt: undefined },
+    { ...stored({ viewSessionId: "no-interaction" }), lastInteractionAt: undefined },
+    { ...stored({ viewSessionId: "no-visibility" }), visibility: undefined },
+    { ...stored({ viewSessionId: "bad-visibility" }), visibility: "maybe" },
+    { ...stored({ viewSessionId: "" }) },
+  ];
+  mirror([...cases, complete]);
+
+  /* Only the one entry that answered every question survives. */
+  expect(anotherProcess(() => listPresence(T0)).map((session) => session.viewSessionId)).toEqual(["whole"]);
+});
+
+test("a malformed timestamp is discarded instead of crashing the read", () => {
+  /* A finite number far outside the range `Date` can represent passes a
+     `typeof` check, survives the round trip through JSON — unlike `NaN` and
+     `Infinity`, which `JSON.stringify` writes as `null` and the shape check
+     already refuses — and then reaches `new Date(…).toISOString()`, which
+     throws `RangeError: Invalid Date`. That call sits on the read path of
+     `request_attention` and `operator_snapshot`, so one damaged record in a
+     shared file takes the tool down for every caller on the machine.
+
+     A negative timestamp is the quieter one: `Date` accepts it happily as a
+     moment in 1969, so nothing throws and the entry simply lies about a
+     desktop that has been stale since before the epoch. */
+  mirror([
+    stored({ viewSessionId: "out-of-range", lastSeenAt: 1e308 }),
+    stored({ viewSessionId: "out-of-range-interaction", lastInteractionAt: 1e308 }),
+    stored({ viewSessionId: "string-time", lastSeenAt: "2026-07-01T10:00:00.000Z" }),
+    stored({ viewSessionId: "negative", lastSeenAt: -1 }),
+    stored({ viewSessionId: "epoch", lastSeenAt: 0 }),
+    stored({ viewSessionId: "null-time", lastSeenAt: null }),
+  ]);
+
+  /* Summarizing is what `operator_snapshot` and `request_attention` actually do
+     with what they read, and it is where the throw lands — so the test has to
+     go through it rather than stopping at the id list. */
+  let seen: unknown;
+  expect(() => {
+    seen = anotherProcess(() => listPresence(T0).map((session) => sessionSummary(session, T0).viewSessionId));
+  }).not.toThrow();
+  expect(seen).toEqual([]);
+});
+
+test("a mirror of nothing but junk leaves a real local session standing", () => {
+  /* Degrading to "this process knows only what it was told" is the designed
+     failure. Dropping the bad entries must not drop the good ones with them. */
+  upsertPresence(payload(), T0);
+  mirror([stored({ viewSessionId: "future", lastSeenAt: T0 + 3_600_000 }), null, 7, "session", []], T0);
+
+  expect(listPresence(T0 + 1_000).map((session) => session.viewSessionId)).toEqual(["view-1"]);
 });

--- a/src/lib/view/presenceStore.test.ts
+++ b/src/lib/view/presenceStore.test.ts
@@ -237,3 +237,43 @@ test("a mirror of nothing but junk leaves a real local session standing", () => 
 
   expect(listPresence(T0 + 1_000).map((session) => session.viewSessionId)).toEqual(["view-1"]);
 });
+
+test("a record whose nested shape is incomplete is discarded, however plausible its surface", () => {
+  /* The quiet one, and the reason this matters more than its severity: a record
+     can be well-formed exactly where the offer path looks and arbitrary
+     everywhere else. `followCapableDevices` reads `session.device.kind` and
+     nothing more, so such an entry advertises a desktop that does not exist —
+     the request is recorded as offered, nobody is watching, and the operator is
+     never told. A partial record is untrustworthy, not degraded. */
+  const cases: Record<string, unknown>[] = [
+    { ...stored({ viewSessionId: "no-device" }), device: undefined },
+    { ...stored({ viewSessionId: "device-not-an-object" }), device: "desktop" },
+    { ...stored({ viewSessionId: "device-half" }), device: { kind: "desktop" } },
+    { ...stored({ viewSessionId: "device-unknown-kind" }), device: { kind: "toaster", browser: "chrome" } },
+    { ...stored({ viewSessionId: "device-unknown-browser" }), device: { kind: "desktop", browser: "netscape" } },
+    { ...stored({ viewSessionId: "no-viewport" }), viewport: undefined },
+    { ...stored({ viewSessionId: "viewport-half" }), viewport: { width: 1_600 } },
+    { ...stored({ viewSessionId: "camera-half" }), camera: { x: 1, y: 2, zoom: 3 } },
+    { ...stored({ viewSessionId: "camera-world-half" }), camera: { x: 1, y: 2, zoom: 3, worldRect: { x: 0, y: 0 } } },
+    { ...stored({ viewSessionId: "no-board" }), board: undefined },
+    { ...stored({ viewSessionId: "board-unknown-sync" }), board: { renderedRevision: 1, durableRevision: 1, sync: "vibes" } },
+    { ...stored({ viewSessionId: "unknown-mode" }), mode: "hologram" },
+    { ...stored({ viewSessionId: "paths-not-strings" }), visiblePaths: [1, 2] },
+    { ...stored({ viewSessionId: "wrong-schema" }), schemaVersion: 99 },
+  ];
+  mirror([...cases, stored({ viewSessionId: "whole" })]);
+
+  expect(anotherProcess(() => listPresence(T0)).map((session) => session.viewSessionId)).toEqual(["whole"]);
+});
+
+test("a session with no device never reaches the code that dereferences it", () => {
+  /* `followCapableDevices` — inside `request_attention` — reads
+     `session.device.kind` with no guard. An entry that got that far without a
+     device does not degrade the answer, it throws and takes the tool call down
+     for every caller on the machine. */
+  mirror([{ ...stored({ viewSessionId: "no-device" }), device: undefined }]);
+
+  const seen = anotherProcess(() => listPresence(T0));
+  expect(seen).toEqual([]);
+  expect(() => seen.map((session) => session.device.kind)).not.toThrow();
+});

--- a/src/lib/view/presenceStore.ts
+++ b/src/lib/view/presenceStore.ts
@@ -4,7 +4,7 @@ import path from "node:path";
 
 import { statePath } from "@/lib/configDir";
 
-import type { PresencePayloadV1, StoredViewSession, ViewFreshness, ViewSessionSummary } from "./types";
+import { VIEW_SCHEMA_VERSION, type PresencePayloadV1, type StoredViewSession, type ViewFreshness, type ViewSessionSummary } from "./types";
 
 /**
  * Who is looking at the viewer right now.
@@ -57,40 +57,107 @@ export function presenceFile(): string {
     not a clock skew, it is a record nobody should be believing. */
 const CLOCK_SKEW_MS = 5_000;
 
+const DEVICE_KINDS = new Set(["desktop", "tablet", "mobile"]);
+const BROWSER_KINDS = new Set(["chrome", "firefox", "safari", "other"]);
+const VIEW_MODES = new Set(["overview", "scheme", "list", "mobile-focus", "mobile-map"]);
+const BOARD_SYNC = new Set(["current", "pending", "stale", "unavailable"]);
+
 function finiteNumber(value: unknown): value is number {
   return typeof value === "number" && Number.isFinite(value);
 }
 
+function object(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : null;
+}
+
+function stringOrNull(value: unknown): boolean {
+  return value === null || typeof value === "string";
+}
+
+function stringArray(value: unknown): boolean {
+  return Array.isArray(value) && value.every((entry) => typeof entry === "string");
+}
+
+function numberOrNull(value: unknown): boolean {
+  return value === null || finiteNumber(value);
+}
+
+function validDevice(value: unknown): boolean {
+  const device = object(value);
+  return device !== null
+    && typeof device.kind === "string" && DEVICE_KINDS.has(device.kind)
+    && typeof device.browser === "string" && BROWSER_KINDS.has(device.browser);
+}
+
+function validViewport(value: unknown): boolean {
+  const viewport = object(value);
+  return viewport !== null
+    && finiteNumber(viewport.width) && finiteNumber(viewport.height) && finiteNumber(viewport.dpr);
+}
+
+function validCamera(value: unknown): boolean {
+  if (value === null) return true;
+  const camera = object(value);
+  if (!camera) return false;
+  const world = object(camera.worldRect);
+  return finiteNumber(camera.x) && finiteNumber(camera.y) && finiteNumber(camera.zoom)
+    && world !== null
+    && finiteNumber(world.x) && finiteNumber(world.y)
+    && finiteNumber(world.width) && finiteNumber(world.height);
+}
+
+function validBoard(value: unknown): boolean {
+  const board = object(value);
+  return board !== null
+    && numberOrNull(board.renderedRevision) && numberOrNull(board.durableRevision)
+    && typeof board.sync === "string" && BOARD_SYNC.has(board.sync);
+}
+
 /**
- * Whether a mirrored entry can be believed, in full.
+ * Whether a mirrored entry can be believed, in full and all the way down.
  *
  * Presence answers "is someone watching?", and both ways of being wrong are NOT
  * equal. Reading nothing makes an attention request fail visibly, which is the
  * defect this mirror exists to fix. Reading a session that is not really there
- * makes it succeed silently in front of nobody, which is worse: the request is
- * marked delivered and the operator never learns it was raised. So a partial or
- * impossible entry is discarded, never repaired into an optimistic one.
+ * makes it succeed silently in front of nobody: the request is marked delivered,
+ * the desktop it named does not exist, and nothing ever says so. So a partial
+ * record is not a degraded record to be repaired with defaults — it is an
+ * untrustworthy one, and it is dropped whole.
  *
- * Two shapes get in past a `typeof` check and have to be named:
+ * The nested shape is the part that bites, because a top-level `typeof` sweep
+ * makes a record look answered while the fields anyone actually USES are still
+ * arbitrary:
  *
- * - a finite number outside the range `Date` can represent is still a number,
- *   and unlike `NaN` it round-trips through JSON intact. It reaches
- *   `sessionSummary`, where `new Date(…).toISOString()` throws `RangeError` —
- *   and that summary is built on the read path of `request_attention` and
- *   `operator_snapshot`, so one malformed record in a shared file takes down
- *   the tool for every caller. The future bound below is what catches it, which
- *   is why that bound is a rejection and not a clamp.
- * - a FUTURE `lastSeenAt` is the phantom. `freshness` clamps the age at zero,
- *   so the entry reads `active` forever, and `expire` — which needs the age to
- *   exceed retention — can never remove it. One such record advertises a
- *   desktop that does not exist, permanently.
+ * - `device` is dereferenced unguarded by the offer path — `session.device.kind`
+ *   in `followCapableDevices`, which runs inside `request_attention`. A record
+ *   without it does not degrade, it throws, and takes the whole tool call down.
+ * - `device` present but the rest of the record junk is the worse case, and the
+ *   quiet one: the entry is well-formed exactly where the offer looks, so a
+ *   desktop that does not exist is advertised as followable and the request is
+ *   recorded as offered to it.
+ * - a finite number outside the range `Date` can represent still round-trips
+ *   through JSON, unlike `NaN`, and reaches `toISOString` in `sessionSummary` —
+ *   also on the read path of `request_attention` and `operator_snapshot`.
+ * - a FUTURE `lastSeenAt` is the permanent phantom. `freshness` clamps the age
+ *   at zero, so the entry reads `active` forever, and `expire` — which needs the
+ *   age to exceed retention — can never remove it.
  */
 function isStoredSession(value: unknown, now: number): value is StoredViewSession {
-  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
-  const session = value as Partial<StoredViewSession>;
+  const session = object(value);
+  if (!session) return false;
+  if (session.schemaVersion !== VIEW_SCHEMA_VERSION) return false;
   if (typeof session.viewSessionId !== "string" || session.viewSessionId.length === 0) return false;
   if (typeof session.deviceId !== "string" || session.deviceId.length === 0) return false;
   if (session.visibility !== "visible" && session.visibility !== "hidden") return false;
+  if (typeof session.mode !== "string" || !VIEW_MODES.has(session.mode)) return false;
+  if (!stringOrNull(session.project) || !stringOrNull(session.focusedPath)) return false;
+  if (!stringArray(session.selectedPaths) || !stringArray(session.visiblePaths)) return false;
+  if (!validDevice(session.device)) return false;
+  if (!validViewport(session.viewport)) return false;
+  if (!validCamera(session.camera)) return false;
+  if (!validBoard(session.board)) return false;
   if (!finiteNumber(session.sequence) || !finiteNumber(session.inputSequence)) return false;
   if (!finiteNumber(session.lastSeenAt) || !finiteNumber(session.lastInteractionAt)) return false;
   if (session.lastSeenAt <= 0 || session.lastInteractionAt <= 0) return false;

--- a/src/lib/view/presenceStore.ts
+++ b/src/lib/view/presenceStore.ts
@@ -51,22 +51,59 @@ export function presenceFile(): string {
   return statePath("view-presence.json");
 }
 
-function isStoredSession(value: unknown): value is StoredViewSession {
+/** How far ahead of this clock a mirrored timestamp may sit before the entry is
+    treated as untrustworthy rather than as merely early. Two machines sharing a
+    state dir disagree by a little; a session claiming a future far past that is
+    not a clock skew, it is a record nobody should be believing. */
+const CLOCK_SKEW_MS = 5_000;
+
+function finiteNumber(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value);
+}
+
+/**
+ * Whether a mirrored entry can be believed, in full.
+ *
+ * Presence answers "is someone watching?", and both ways of being wrong are NOT
+ * equal. Reading nothing makes an attention request fail visibly, which is the
+ * defect this mirror exists to fix. Reading a session that is not really there
+ * makes it succeed silently in front of nobody, which is worse: the request is
+ * marked delivered and the operator never learns it was raised. So a partial or
+ * impossible entry is discarded, never repaired into an optimistic one.
+ *
+ * Two shapes get in past a `typeof` check and have to be named:
+ *
+ * - a finite number outside the range `Date` can represent is still a number,
+ *   and unlike `NaN` it round-trips through JSON intact. It reaches
+ *   `sessionSummary`, where `new Date(…).toISOString()` throws `RangeError` —
+ *   and that summary is built on the read path of `request_attention` and
+ *   `operator_snapshot`, so one malformed record in a shared file takes down
+ *   the tool for every caller. The future bound below is what catches it, which
+ *   is why that bound is a rejection and not a clamp.
+ * - a FUTURE `lastSeenAt` is the phantom. `freshness` clamps the age at zero,
+ *   so the entry reads `active` forever, and `expire` — which needs the age to
+ *   exceed retention — can never remove it. One such record advertises a
+ *   desktop that does not exist, permanently.
+ */
+function isStoredSession(value: unknown, now: number): value is StoredViewSession {
   if (!value || typeof value !== "object" || Array.isArray(value)) return false;
   const session = value as Partial<StoredViewSession>;
-  return typeof session.viewSessionId === "string" && session.viewSessionId.length > 0
-    && typeof session.deviceId === "string"
-    && (session.visibility === "visible" || session.visibility === "hidden")
-    && typeof session.sequence === "number"
-    && typeof session.lastSeenAt === "number"
-    && typeof session.lastInteractionAt === "number";
+  if (typeof session.viewSessionId !== "string" || session.viewSessionId.length === 0) return false;
+  if (typeof session.deviceId !== "string" || session.deviceId.length === 0) return false;
+  if (session.visibility !== "visible" && session.visibility !== "hidden") return false;
+  if (!finiteNumber(session.sequence) || !finiteNumber(session.inputSequence)) return false;
+  if (!finiteNumber(session.lastSeenAt) || !finiteNumber(session.lastInteractionAt)) return false;
+  if (session.lastSeenAt <= 0 || session.lastInteractionAt <= 0) return false;
+  if (session.lastSeenAt > now + CLOCK_SKEW_MS) return false;
+  if (session.lastInteractionAt > now + CLOCK_SKEW_MS) return false;
+  return true;
 }
 
 /** The mirrored sessions, or nothing at all when the file is missing or has
     been corrupted. Presence is an observation, so an unreadable mirror degrades
     to "this process knows only what it was told" rather than throwing into a
     heartbeat or a snapshot. */
-function readMirror(): StoredViewSession[] {
+function readMirror(now: number): StoredViewSession[] {
   let text: string;
   try {
     text = fs.readFileSync(presenceFile(), "utf8");
@@ -76,7 +113,7 @@ function readMirror(): StoredViewSession[] {
   try {
     const parsed = JSON.parse(text) as Partial<PresenceFileV1>;
     if (parsed.schemaVersion !== PRESENCE_SCHEMA_VERSION || !Array.isArray(parsed.sessions)) return [];
-    return parsed.sessions.filter(isStoredSession);
+    return parsed.sessions.filter((session): session is StoredViewSession => isStoredSession(session, now));
   } catch {
     return [];
   }
@@ -112,7 +149,7 @@ function writeMirror(sessions: Iterable<StoredViewSession>, now: number): void {
  */
 function sessions(now: number): Store {
   const current = store();
-  for (const mirrored of readMirror()) {
+  for (const mirrored of readMirror(now)) {
     const held = current.get(mirrored.viewSessionId);
     if (!held || mirrored.sequence > held.sequence) current.set(mirrored.viewSessionId, mirrored);
   }

--- a/src/lib/view/presenceStore.ts
+++ b/src/lib/view/presenceStore.ts
@@ -1,12 +1,124 @@
+import crypto from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+
+import { statePath } from "@/lib/configDir";
+
 import type { PresencePayloadV1, StoredViewSession, ViewFreshness, ViewSessionSummary } from "./types";
+
+/**
+ * Who is looking at the viewer right now.
+ *
+ * The map used to live in this process's memory and nowhere else, which made it
+ * invisible to every OTHER process on the machine. Only the Next server ever
+ * receives a presence heartbeat (`POST /api/view/presence`), so anything asking
+ * "is a desktop view open?" from outside that server — the MCP stdio server,
+ * most of all, which is a separate process — read an empty map and concluded
+ * nobody was there while the operator was sitting in front of the board. That
+ * is what `operator_snapshot` reported as `NO_ACTIVE_VIEW`, and what left every
+ * attention request's `offeredTo` empty.
+ *
+ * So presence is mirrored to the shared state dir, the same place the attention
+ * record already lives, and every read merges the file in. Memory stays the fast
+ * path for the process that owns the heartbeat; the file is what makes the
+ * answer the same for everyone else on the machine.
+ *
+ * Written by temp-and-rename with no lock, deliberately: presence is a
+ * best-effort observation with a 25-second freshness window and one writer
+ * (the HTTP route). A reader sees either the whole previous file or the whole
+ * next one, and a lost race is corrected by the next heartbeat ten seconds
+ * later — which is a far better trade than taking a file lock twice a second.
+ */
 
 const ACTIVE_MS = 25_000;
 const RETENTION_MS = 120_000;
 const CAPACITY = 32;
 
+/** Schema of the mirrored file. Bumped only if the stored shape changes. */
+const PRESENCE_SCHEMA_VERSION = 1;
+
+interface PresenceFileV1 {
+  schemaVersion: number;
+  updatedAt: string;
+  sessions: StoredViewSession[];
+}
+
 type Store = Map<string, StoredViewSession>;
 const globals = globalThis as unknown as { __llvViewPresence?: Store };
 function store(): Store { return (globals.__llvViewPresence ??= new Map()); }
+
+export function presenceFile(): string {
+  return statePath("view-presence.json");
+}
+
+function isStoredSession(value: unknown): value is StoredViewSession {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  const session = value as Partial<StoredViewSession>;
+  return typeof session.viewSessionId === "string" && session.viewSessionId.length > 0
+    && typeof session.deviceId === "string"
+    && (session.visibility === "visible" || session.visibility === "hidden")
+    && typeof session.sequence === "number"
+    && typeof session.lastSeenAt === "number"
+    && typeof session.lastInteractionAt === "number";
+}
+
+/** The mirrored sessions, or nothing at all when the file is missing or has
+    been corrupted. Presence is an observation, so an unreadable mirror degrades
+    to "this process knows only what it was told" rather than throwing into a
+    heartbeat or a snapshot. */
+function readMirror(): StoredViewSession[] {
+  let text: string;
+  try {
+    text = fs.readFileSync(presenceFile(), "utf8");
+  } catch {
+    return [];
+  }
+  try {
+    const parsed = JSON.parse(text) as Partial<PresenceFileV1>;
+    if (parsed.schemaVersion !== PRESENCE_SCHEMA_VERSION || !Array.isArray(parsed.sessions)) return [];
+    return parsed.sessions.filter(isStoredSession);
+  } catch {
+    return [];
+  }
+}
+
+function writeMirror(sessions: Iterable<StoredViewSession>, now: number): void {
+  const file: PresenceFileV1 = {
+    schemaVersion: PRESENCE_SCHEMA_VERSION,
+    updatedAt: new Date(now).toISOString(),
+    sessions: [...sessions],
+  };
+  const target = presenceFile();
+  const temp = path.join(path.dirname(target), `.${path.basename(target)}.${process.pid}.${crypto.randomUUID()}.tmp`);
+  try {
+    fs.mkdirSync(path.dirname(target), { recursive: true });
+    fs.writeFileSync(temp, JSON.stringify(file, null, 2) + "\n", { encoding: "utf8", mode: 0o600 });
+    fs.renameSync(temp, target);
+  } catch {
+    /* A presence mirror that cannot be written must never fail the heartbeat
+       the operator's browser is sending, nor the snapshot someone is reading.
+       The in-memory map is still correct for this process. */
+    fs.rmSync(temp, { force: true });
+  }
+}
+
+/**
+ * This process's map, brought up to date with the mirror.
+ *
+ * Merged by `sequence`, which the browser makes monotonic per view session, so
+ * folding the file in is idempotent and can only move a session forward. That
+ * is what lets a reader in another process see the operator's live view without
+ * any of them having to agree on who owns the map.
+ */
+function sessions(now: number): Store {
+  const current = store();
+  for (const mirrored of readMirror()) {
+    const held = current.get(mirrored.viewSessionId);
+    if (!held || mirrored.sequence > held.sequence) current.set(mirrored.viewSessionId, mirrored);
+  }
+  expire(now, current);
+  return current;
+}
 
 export function freshness(session: StoredViewSession, now = Date.now()): ViewFreshness {
   const age = Math.max(0, now - session.lastSeenAt);
@@ -15,34 +127,34 @@ export function freshness(session: StoredViewSession, now = Date.now()): ViewFre
   return "stale";
 }
 
-function expire(now = Date.now()): void {
-  const sessions = store();
-  for (const [id, session] of sessions) if (now - session.lastSeenAt > RETENTION_MS) sessions.delete(id);
+function expire(now: number, current: Store = store()): void {
+  for (const [id, session] of current) if (now - session.lastSeenAt > RETENTION_MS) current.delete(id);
 }
 
-function makeRoomForNewSession(): void {
-  const sessions = store();
-  while (sessions.size >= CAPACITY) {
-    const oldest = [...sessions.values()].sort((a, b) => a.lastSeenAt - b.lastSeenAt)[0];
+function makeRoomForNewSession(current: Store): void {
+  while (current.size >= CAPACITY) {
+    const oldest = [...current.values()].sort((a, b) => a.lastSeenAt - b.lastSeenAt)[0];
     if (!oldest) break;
-    sessions.delete(oldest.viewSessionId);
+    current.delete(oldest.viewSessionId);
   }
 }
 
 export function upsertPresence(payload: PresencePayloadV1, now = Date.now()): { accepted: boolean; session: StoredViewSession } {
-  expire(now);
-  const sessions = store();
-  const current = sessions.get(payload.viewSessionId);
-  if (current && payload.sequence <= current.sequence) return { accepted: false, session: current };
-  if (!current) makeRoomForNewSession();
-  const inputAdvanced = !current || payload.inputSequence > current.inputSequence;
+  const current = sessions(now);
+  const held = current.get(payload.viewSessionId);
+  if (held && payload.sequence <= held.sequence) return { accepted: false, session: held };
+  if (!held) makeRoomForNewSession(current);
+  const inputAdvanced = !held || payload.inputSequence > held.inputSequence;
   const session: StoredViewSession = {
     ...payload,
-    inputSequence: Math.max(current?.inputSequence ?? 0, payload.inputSequence),
+    inputSequence: Math.max(held?.inputSequence ?? 0, payload.inputSequence),
     lastSeenAt: now,
-    lastInteractionAt: inputAdvanced ? now : current?.lastInteractionAt ?? now,
+    lastInteractionAt: inputAdvanced ? now : held?.lastInteractionAt ?? now,
   };
-  sessions.set(payload.viewSessionId, session);
+  current.set(payload.viewSessionId, session);
+  /* Only an accepted heartbeat writes: a replayed or stale sequence changed
+     nothing, and re-serializing the same map for it would be pure churn. */
+  writeMirror(current.values(), now);
   return { accepted: true, session };
 }
 
@@ -51,9 +163,15 @@ export function sessionSummary(session: StoredViewSession, now = Date.now()): Vi
 }
 
 export function listPresence(now = Date.now()): StoredViewSession[] {
-  expire(now);
-  return [...store().values()].sort((a, b) => b.lastInteractionAt - a.lastInteractionAt || b.lastSeenAt - a.lastSeenAt || a.viewSessionId.localeCompare(b.viewSessionId));
+  return [...sessions(now).values()].sort((a, b) => b.lastInteractionAt - a.lastInteractionAt || b.lastSeenAt - a.lastSeenAt || a.viewSessionId.localeCompare(b.viewSessionId));
 }
 
-export function resetPresenceForTest(): void { globals.__llvViewPresence = new Map(); }
+export function resetPresenceForTest(): void {
+  globals.__llvViewPresence = new Map();
+  try {
+    fs.rmSync(presenceFile(), { force: true });
+  } catch {
+    /* nothing mirrored yet */
+  }
+}
 export const presenceLimits = { ACTIVE_MS, RETENTION_MS, CAPACITY };


### PR DESCRIPTION
## The symptom

`request_attention` answers `offeredTo: []` with an open, visible desktop
viewer; the one-shot automatic focus moves nothing; the Back control never
appears. **All three are live on `main` and on the deployed revision** — the two
are byte-identical across every attention surface (`src/lib/attention/**`,
`src/components/attention/**`, `src/components/overlay/useAttentionOffers.ts`,
`src/app/api/attention/**`, the MCP request path), so this is not a
main-versus-prod skew. The one-shot surface commit is an ancestor of both. The
`focus_follow` completion-contract commit named in the brief is **not** on
`main` at all — it lives on an unmerged branch — so nothing here depends on it.

Evidence from the live record (states only, no identities): every recent
request reached the browser, was offered to exactly one device, was accepted by
it, and then ended `expired / cause: lost` with no `resolution` — the record's
own account of "the view was asked to move and found nowhere to land".

## Three causes

**1. Presence was process-local.** Who is looking at the viewer lived in one
in-memory map (`globalThis.__llvViewPresence`), and only the Next server ever
writes it — the browser's heartbeat goes to `POST /api/view/presence` and
nowhere else. The MCP server is a **separate process**, so every presence
question asked from an agent tool answered "nobody". That is exactly the known
behaviour where `operator_snapshot` reports `NO_ACTIVE_VIEW` while the board is
visibly open, and `offeredTo` shares it. Presence is now mirrored to the shared
state dir (beside the attention record it is read with) and every read merges it
in by the sequence the browser already makes monotonic. Temp-and-rename, no
lock: one writer, a 25 s freshness window, and a lost race that the next
heartbeat corrects.

**2. Nothing named the devices at creation.** `offeredTo` was only ever filled
in when a browser polled and reported having *rendered* the offer — seconds
after the tool had already answered. The tool answers synchronously and the
agent then speaks to the operator about what it asked for, so that answer could
never name a device. A raised request now names the views open at the moment it
is raised, filtered by the rules the surfaces already enforce: not a phone
(mobile is chat-only and withholds its device id), not a hidden tab, not a view
that has gone quiet. An explicit list still wins, so an operator command keeps
naming its own device and the acceptance it implies.

**3. The move could not find cards the board was drawing.** Failure mode:
**refused** — the request reaches the browser, is accepted, and the handoff then
resolves to `lost`. A request raised through the tool records no geometry, so
the anchor is the whole of the resolution — and the focus index only knew about
rects placed *directly*. An orchestration worker folds into its parent's
mini-stack ~15 minutes after it goes quiet (#112), and a reviewer round is drawn
inside its flow's deck: both are on screen and neither is a rect of its own, so
every request naming one resolved to `lost`. The index now resolves through the
same layout resolution the board's own agent links route through
(`buildAnchorIndex`), and reports the container as the concrete key so a
key-navigating surface pins what is actually drawn. A conversation the layout
left out entirely is asked for through the shell — the same door the operator's
own attention jump uses — and the handoff waits for it before giving up.

The follow is also recorded as `auto-follow` rather than as the operator's own
act: nothing was put in front of them and nothing was pressed.

## Scope

`src/lib/mcp/bindings.ts` and `src/lib/mcp/toolAllowlist.ts` are **untouched** —
the fence holds. `offeredTo` is seeded inside `raiseAttentionRequest`, which the
binding already calls, so no gateway-lane dependency and no sequencing needed.

## Tests

Every one is RED against the previous behaviour (verified in a throwaway
worktree at `main`), and each runs against an isolated `HOME` /
`XDG_CONFIG_HOME` / `TMPDIR` / `LLV_STATE_DIR`:

| file | proves |
| --- | --- |
| `src/lib/view/presenceStore.test.ts` | a view published to the server is visible to another process; ordering, ageing and a corrupt mirror |
| `src/lib/attention/service.test.ts` | a request names the open desktop; a phone / hidden / stale view is named by nobody; two tabs are one device; an operator command still names its own |
| `src/lib/mcp/requestAttention.test.ts` | the tool's own answer names the desktop the operator is at — the reported symptom, at the reported surface |
| `src/components/scheme/focusFrames.test.ts` | a folded worker resolves to the stack drawing it; a full node still wins; nothing is invented for a card no container holds |
| `src/components/attention/navigate.test.ts` | a conversation the board is not showing is asked for and landed; one focus edge, never two; a board that never produces it still reports `lost` |
| `src/components/attention/AttentionHost.dom.test.tsx` | end to end on the real record and the real frame index: the focus fires **once** and **Back restores the exact viewport**, for a folded worker and for a card the board was not showing |

`bunx tsc --noEmit` clean · `eslint` clean on changed files · privacy gate PASS ·
`bun run build` green. One unrelated pre-existing failure
(`src/components/mobile/issue613Evidence.browser.test.tsx`) fails identically on
`main`.

Not deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
