### PR TITLE
fix(mcp): bind grants to immutable admission lineage

### DIFF
--- a/src/app/api/spawn/route.test.ts
+++ b/src/app/api/spawn/route.test.ts
@@ -119,20 +119,21 @@ test("spawn admission grants MCP servers by session origin and refuses ungranted
 
     const defaultResponse = await post("mcp_default_20260723");
     expect({ status: defaultResponse.status, body: await defaultResponse.clone().json() }).toMatchObject({ status: 202 });
-    /* A delegated launch (every role preset is one) cannot request its way to a
-       grantable connector — it keeps the Viewer baseline (issue #739). */
-    expect((await post("mcp_custom_20260723", ["agent-browser", "viewer", "agent-browser"])).status).toBe(202);
-    /* The same request from an operator-launched root session is granted. */
-    expect((await post("mcp_root_20260727", ["agent-browser"], null)).status).toBe(202);
-    /* A name outside the grant bound is refused, not trimmed. */
-    const ungranted = await post("mcp_ungranted_20260727", ["telegram"], null);
-    expect(ungranted.status).toBe(400);
-    expect(await ungranted.json()).toMatchObject({ error: expect.stringContaining("telegram") });
+    /* An explicit opt-out is honoured on both lanes and still yields Viewer. */
+    expect((await post("mcp_optout_20260723", [])).status).toBe(202);
+    /* A name outside the grant bound is refused, not trimmed — from the
+       operator lane as much as from a delegated one (issue #739). Tranche 1
+       ships that bound empty of connectors, so this covers every configured
+       server, `agent-browser` included. */
+    for (const [attempt, role] of [["mcp_ungranted_delegated_20260727", "builder"], ["mcp_ungranted_root_20260727", null]] as const) {
+      const ungranted = await post(attempt, ["agent-browser"], role);
+      expect(ungranted.status).toBe(400);
+      expect(await ungranted.json()).toMatchObject({ error: expect.stringContaining("agent-browser") });
+      expect(store.spawnReceiptForClientAttempt(attempt)).toBeNull();
+    }
 
     expect(store.spawnReceiptForClientAttempt("mcp_default_20260723")?.launchProfile.mcpServers).toEqual(["viewer"]);
-    expect(store.spawnReceiptForClientAttempt("mcp_custom_20260723")?.launchProfile.mcpServers).toEqual(["viewer"]);
-    expect(store.spawnReceiptForClientAttempt("mcp_root_20260727")?.launchProfile.mcpServers).toEqual(["viewer", "agent-browser"]);
-    expect(store.spawnReceiptForClientAttempt("mcp_ungranted_20260727")).toBeNull();
+    expect(store.spawnReceiptForClientAttempt("mcp_optout_20260723")?.launchProfile.mcpServers).toEqual(["viewer"]);
   } finally {
     if (previousTransport === undefined) delete process.env.LLV_SPAWN_TRANSPORT;
     else process.env.LLV_SPAWN_TRANSPORT = previousTransport;

--- a/src/app/api/spawn/route.test.ts
+++ b/src/app/api/spawn/route.test.ts
@@ -87,7 +87,7 @@ test("spawn admission rejects malformed MCP allowlists", async () => {
   expect(await response.json()).toEqual({ error: "mcpServers must be an array of non-empty server names" });
 });
 
-test("spawn admission persists Viewer-only defaults and normalized custom MCP allowlists", async () => {
+test("spawn admission grants MCP servers by session origin and refuses ungranted names", async () => {
   const cwd = fs.mkdtempSync(path.join(routeSandbox, "mcp-allowlist-"));
   const store = registry();
   const previousTransport = process.env.LLV_SPAWN_TRANSPORT;
@@ -103,23 +103,36 @@ test("spawn admission persists Viewer-only defaults and normalized custom MCP al
   try {
     const dependencies = { ...structuredRouteDependencies(cwd), registry: () => store };
     const capability = rotateOperatorSpawnCapability();
-    const post = async (clientAttemptId: string, mcpServers?: unknown) => POST.withDependencies(new NextRequest("http://127.0.0.1/api/spawn", {
+    const post = async (clientAttemptId: string, mcpServers?: unknown, role: string | null = "builder") => POST.withDependencies(new NextRequest("http://127.0.0.1/api/spawn", {
       method: "POST",
       headers: {
         origin: "http://127.0.0.1",
         host: "127.0.0.1",
         "content-type": "application/json",
         "x-llv-spawn-capability": capability,
+        /* No role means the operator lane: a same-origin launch with no lineage
+           parent and no preset is the operator-root session class. */
+        ...(role ? {} : { "sec-fetch-site": "same-origin" }),
       },
-      body: JSON.stringify({ engine: "claude", model: "claude-sonnet-4-6", cwd, prompt: "inspect", role: "builder", clientAttemptId, ...(mcpServers === undefined ? {} : { mcpServers }) }),
+      body: JSON.stringify({ engine: "claude", model: "claude-sonnet-4-6", cwd, prompt: "inspect", ...(role ? { role } : {}), clientAttemptId, ...(mcpServers === undefined ? {} : { mcpServers }) }),
     }), dependencies);
 
     const defaultResponse = await post("mcp_default_20260723");
     expect({ status: defaultResponse.status, body: await defaultResponse.clone().json() }).toMatchObject({ status: 202 });
+    /* A delegated launch (every role preset is one) cannot request its way to a
+       grantable connector — it keeps the Viewer baseline (issue #739). */
     expect((await post("mcp_custom_20260723", ["agent-browser", "viewer", "agent-browser"])).status).toBe(202);
+    /* The same request from an operator-launched root session is granted. */
+    expect((await post("mcp_root_20260727", ["agent-browser"], null)).status).toBe(202);
+    /* A name outside the grant bound is refused, not trimmed. */
+    const ungranted = await post("mcp_ungranted_20260727", ["telegram"], null);
+    expect(ungranted.status).toBe(400);
+    expect(await ungranted.json()).toMatchObject({ error: expect.stringContaining("telegram") });
 
     expect(store.spawnReceiptForClientAttempt("mcp_default_20260723")?.launchProfile.mcpServers).toEqual(["viewer"]);
-    expect(store.spawnReceiptForClientAttempt("mcp_custom_20260723")?.launchProfile.mcpServers).toEqual(["viewer", "agent-browser"]);
+    expect(store.spawnReceiptForClientAttempt("mcp_custom_20260723")?.launchProfile.mcpServers).toEqual(["viewer"]);
+    expect(store.spawnReceiptForClientAttempt("mcp_root_20260727")?.launchProfile.mcpServers).toEqual(["viewer", "agent-browser"]);
+    expect(store.spawnReceiptForClientAttempt("mcp_ungranted_20260727")).toBeNull();
   } finally {
     if (previousTransport === undefined) delete process.env.LLV_SPAWN_TRANSPORT;
     else process.env.LLV_SPAWN_TRANSPORT = previousTransport;

--- a/src/lib/accounts/migration/contracts.ts
+++ b/src/lib/accounts/migration/contracts.ts
@@ -1,5 +1,5 @@
 import type { AgentEngine } from "@/lib/agent/cli";
-import { normalizeSpawnMcpServers } from "@/lib/agent/mcpAllowlist";
+import { grantedMcpServers } from "@/lib/agent/mcpAllowlist";
 import { grantedPlugins } from "@/lib/agent/pluginAllowlist";
 import type { StructuredImageRef } from "@/lib/runtime/structuredContent";
 import type { AgentGoal, AgentPlan, EngineLimits, LimitsProvenance } from "@/lib/types";
@@ -72,7 +72,6 @@ export interface LaunchProfile {
 }
 
 export function emptyLaunchProfile(overrides: Partial<LaunchProfile> = {}): LaunchProfile {
-  const mcpServers = normalizeSpawnMcpServers(overrides.mcpServers);
   return {
     cwd: "",
     model: null,
@@ -88,7 +87,10 @@ export function emptyLaunchProfile(overrides: Partial<LaunchProfile> = {}): Laun
     goal: null,
     plan: null,
     ...overrides,
-    mcpServers: mcpServers.ok ? mcpServers.value : ["viewer"],
+    /* Same bound, enforced again on the durable profile: an allowlist can only
+       ever carry servers the Viewer is allowed to grant, and always carries
+       `viewer` (issue #739). */
+    mcpServers: grantedMcpServers(overrides.mcpServers),
     /* The grant bound is enforced again here: a durable profile can only ever
        carry plugins the Viewer is allowed to grant (issue #687). */
     plugins: grantedPlugins(overrides.plugins),

--- a/src/lib/accounts/migration/contracts.ts
+++ b/src/lib/accounts/migration/contracts.ts
@@ -1,5 +1,5 @@
 import type { AgentEngine } from "@/lib/agent/cli";
-import { grantedMcpServers } from "@/lib/agent/mcpAllowlist";
+import { grantedMcpServers, type McpGrantPolicy } from "@/lib/agent/mcpAllowlist";
 import { grantedPlugins } from "@/lib/agent/pluginAllowlist";
 import type { StructuredImageRef } from "@/lib/runtime/structuredContent";
 import type { AgentGoal, AgentPlan, EngineLimits, LimitsProvenance } from "@/lib/types";
@@ -71,7 +71,13 @@ export interface LaunchProfile {
   plan: AgentPlan | null;
 }
 
-export function emptyLaunchProfile(overrides: Partial<LaunchProfile> = {}): LaunchProfile {
+export function emptyLaunchProfile(
+  overrides: Partial<LaunchProfile> = {},
+  /* The grant bound to enforce. Production omits it; the storage layer threads
+     a test policy through so the origin rules can be exercised against a bound
+     that HAS a grantable connector (issue #739). */
+  policy?: McpGrantPolicy,
+): LaunchProfile {
   return {
     cwd: "",
     model: null,
@@ -90,7 +96,7 @@ export function emptyLaunchProfile(overrides: Partial<LaunchProfile> = {}): Laun
     /* Same bound, enforced again on the durable profile: an allowlist can only
        ever carry servers the Viewer is allowed to grant, and always carries
        `viewer` (issue #739). */
-    mcpServers: grantedMcpServers(overrides.mcpServers),
+    mcpServers: grantedMcpServers(overrides.mcpServers, policy),
     /* The grant bound is enforced again here: a durable profile can only ever
        carry plugins the Viewer is allowed to grant (issue #687). */
     plugins: grantedPlugins(overrides.plugins),

--- a/src/lib/agent/cli.integration.test.ts
+++ b/src/lib/agent/cli.integration.test.ts
@@ -276,21 +276,24 @@ test.skipIf(!layeredHome)("native Codex enumeration enforces the allowlist for t
     'trust_level = "trusted"',
     "",
   ].join("\n"), { mode: 0o600 });
+  /* Project configuration is enumerated, then filtered by the grant: only a
+     server inside the grantable bound can be enabled, whichever scope declared
+     it (issue #739), and `project-ungranted` stands for everything outside it. */
   fs.writeFileSync(path.join(projectRoot, ".codex", "config.toml"), [
-    "[mcp_servers.project-allowed]",
+    "[mcp_servers.agent-browser]",
     'command = "/bin/true"',
-    "[mcp_servers.project-unrelated]",
+    "[mcp_servers.project-ungranted]",
     'command = "/bin/true"',
     "",
   ].join("\n"), { mode: 0o600 });
 
   const spec = freshSpecFor("codex", projectRoot, {
     codexHome: layeredHome.codexHome,
-    mcpServers: ["project-allowed"],
+    mcpServers: ["agent-browser", "project-ungranted"],
   });
 
-  expect(spec.command).toContain("'mcp_servers.project-allowed.enabled=true'");
-  expect(spec.command).toContain("'mcp_servers.project-unrelated.enabled=false'");
+  expect(spec.command).toContain("'mcp_servers.agent-browser.enabled=true'");
+  expect(spec.command).toContain("'mcp_servers.project-ungranted.enabled=false'");
 });
 
 test.skipIf(!customHome)("real custom tmux Codex enables the optional server, force-enables Viewer, excludes sentinels, and reaps its MCP processes", async () => {

--- a/src/lib/agent/cli.integration.test.ts
+++ b/src/lib/agent/cli.integration.test.ts
@@ -276,32 +276,34 @@ test.skipIf(!layeredHome)("native Codex enumeration enforces the allowlist for t
     'trust_level = "trusted"',
     "",
   ].join("\n"), { mode: 0o600 });
-  /* Project configuration is enumerated, then filtered by the grant: only a
-     server inside the grantable bound can be enabled, whichever scope declared
-     it (issue #739), and `project-ungranted` stands for everything outside it. */
+  /* Project configuration is enumerated, then filtered by the grant: nothing
+     outside the grantable bound can be enabled, whichever scope declared it and
+     whatever the allowlist names (issue #739). */
   fs.writeFileSync(path.join(projectRoot, ".codex", "config.toml"), [
-    "[mcp_servers.agent-browser]",
+    "[mcp_servers.project-allowed]",
     'command = "/bin/true"',
-    "[mcp_servers.project-ungranted]",
+    "[mcp_servers.project-unrelated]",
     'command = "/bin/true"',
     "",
   ].join("\n"), { mode: 0o600 });
 
   const spec = freshSpecFor("codex", projectRoot, {
     codexHome: layeredHome.codexHome,
-    mcpServers: ["agent-browser", "project-ungranted"],
+    mcpServers: ["project-allowed"],
   });
 
-  expect(spec.command).toContain("'mcp_servers.agent-browser.enabled=true'");
-  expect(spec.command).toContain("'mcp_servers.project-ungranted.enabled=false'");
+  expect(spec.command).toContain("'mcp_servers.project-allowed.enabled=false'");
+  expect(spec.command).toContain("'mcp_servers.project-unrelated.enabled=false'");
 });
 
-test.skipIf(!customHome)("real custom tmux Codex enables the optional server, force-enables Viewer, excludes sentinels, and reaps its MCP processes", async () => {
+test.skipIf(!customHome)("real custom tmux Codex leaves an ungranted optional server off, force-enables Viewer, and reaps its MCP processes", async () => {
   if (!customHome) throw new Error("isolated Codex subscription home is unavailable");
-  await exerciseTmuxCodex({ home: customHome, mcpServers: ["agent-browser"], expectedServer: "agent-browser" });
+  /* The allowlist names the optional server; the grant bound admits none, so
+     only Viewer runs and the optional server's process never starts (#739). */
+  await exerciseTmuxCodex({ home: customHome, mcpServers: ["agent-browser"], expectedServer: "viewer" });
 }, 300_000);
 
-test.skipIf(!claudeProjectHome)("real tmux Claude loads an allowed project MCP server, excludes its project sentinel, and reaps the fleet", async () => {
+test.skipIf(!claudeProjectHome)("real tmux Claude keeps every ungranted project MCP server out of the session and reaps the fleet", async () => {
   if (!claudeProjectHome) throw new Error("isolated Claude subscription home is unavailable");
   const projectRoot = path.join(claudeProjectHome.directory, "project");
   const stateDir = path.join(claudeProjectHome.directory, "viewer-state");
@@ -407,35 +409,32 @@ test.skipIf(!claudeProjectHome)("real tmux Claude loads an allowed project MCP s
       "spawn-settings",
       `${sessionId}.json`,
     ), "utf8")) as { enabledMcpjsonServers?: string[]; disabledMcpjsonServers?: string[] };
-    expect(mcpConfig.mcpServers["agent-browser"]).toMatchObject({
-      env: { PROJECT_AUTH: "preserved" },
-      timeout: 120_000,
-      alwaysLoad: true,
-    });
-    expect(mcpConfig.mcpServers).not.toHaveProperty("project-unrelated");
-    expect(launchSettings.enabledMcpjsonServers).toEqual(["agent-browser"]);
-    expect(launchSettings.disabledMcpjsonServers).toEqual(["project-unrelated"]);
-    const prompt = `Call the exact native tool mcp__agent-browser__get_pipeline with clientRequestId "tmux-claude-project" and pipelineId "${pipeline.id}". Do not use mcp__viewer__get_pipeline or shell execution. Reply after the successful result.`;
+    /* Both project-scoped servers stay out of the exclusive config: the grant
+       bound admits neither, however the allowlist and the operator's own
+       approval list name them (#739). */
+    expect(Object.keys(mcpConfig.mcpServers)).toEqual(["viewer"]);
+    expect(launchSettings.enabledMcpjsonServers ?? []).not.toContain("agent-browser");
+    expect(launchSettings.disabledMcpjsonServers ?? []).toContain("project-unrelated");
+    const prompt = `Call the exact native tool mcp__viewer__get_pipeline with clientRequestId "tmux-claude-project" and pipelineId "${pipeline.id}". Do not use shell execution. Reply after the successful result.`;
     const isolatedCommand = `env HOME=${shellQuote(claudeProjectHome.directory)} CLAUDE_CONFIG_DIR=${shellQuote(claudeProjectHome.claudeConfigDir)} ${spec.command}`;
     const launched = await runTmux(tmuxTmpdir, ["send-keys", "-t", `${session}:0.0`, "-l", `${isolatedCommand} -- ${shellQuote(prompt)}`]);
     if (launched.code !== 0) throw new Error(launched.stderr || "tmux command delivery failed");
     await runTmux(tmuxTmpdir, ["send-keys", "-t", `${session}:0.0`, "Enter"]);
     try {
-      await waitFor(() => nativeClaudeMcpResult(spec.transcript!, "agent-browser", pipeline.id));
+      await waitFor(() => nativeClaudeMcpResult(spec.transcript!, "viewer", pipeline.id));
     } catch (error) {
       const pane = await runTmux(tmuxTmpdir, ["capture-pane", "-p", "-S", "-200", "-t", `${session}:0.0`]);
       const transcript = fs.existsSync(spec.transcript!) ? fs.readFileSync(spec.transcript!, "utf8") : "<missing>";
       throw new Error(`${String(error)}\n--- tmux pane ---\n${pane.stdout}${pane.stderr}\n--- transcript ---\n${transcript}`);
     }
     expect(fs.existsSync(viewerPidPath)).toBeTrue();
-    expect(fs.existsSync(optionalPidPath)).toBeTrue();
+    expect(fs.existsSync(optionalPidPath)).toBeFalse();
     expect(fs.existsSync(unrelatedPath)).toBeFalse();
     const pane = await runTmux(tmuxTmpdir, ["display-message", "-p", "-t", `${session}:0.0`, "#{pane_pid}"]);
     const panePid = Number(pane.stdout.trim());
     if (!Number.isInteger(panePid)) throw new Error("tmux pane pid is unavailable");
     processes = processTree(panePid);
     addRecordedProcess(processes, viewerPidPath);
-    addRecordedProcess(processes, optionalPidPath);
     await runTmux(tmuxTmpdir, ["kill-server"]);
     await expectProcessesReaped(processes);
     expect(fs.existsSync(unrelatedPath)).toBeFalse();

--- a/src/lib/agent/cli.test.ts
+++ b/src/lib/agent/cli.test.ts
@@ -258,6 +258,32 @@ test("fresh tmux Claude uses its exclusive native MCP file", () => {
   expect(spec.launchProfile?.mcpServers).toEqual(["viewer", "agent-browser"]);
 });
 
+test("a stored allowlist naming an ungranted server is re-bounded when the command is built", () => {
+  const home = path.join(SANDBOX, "claude-mcp-rebound");
+  fs.mkdirSync(home, { recursive: true });
+  fs.writeFileSync(path.join(home, ".claude.json"), JSON.stringify({
+    mcpServers: {
+      viewer: { type: "stdio", command: "viewer-mcp" },
+      "agent-browser": { type: "stdio", command: "browser-mcp" },
+      telegram: { type: "stdio", command: "telegram-mcp" },
+    },
+  }));
+
+  /* Launch profiles are durable and editable by hand, so the rendered command
+     comes from the re-validated grant, not from what storage claimed (#739). */
+  const spec = freshSpecFor("claude", "/repo", {
+    claudeConfigDir: home,
+    claudeProjectsDir: path.join(home, "projects"),
+    mcpServers: ["viewer", "telegram", "agent-browser"],
+  });
+  const sessionId = path.basename(spec.transcript!, ".jsonl");
+  const mcpConfigPath = path.join(home, ".llv", "spawn-mcp", `${sessionId}.json`);
+
+  expect(spec.launchProfile?.mcpServers).toEqual(["viewer", "agent-browser"]);
+  expect(Object.keys((JSON.parse(fs.readFileSync(mcpConfigPath, "utf8")) as { mcpServers: Record<string, unknown> }).mcpServers))
+    .toEqual(["viewer", "agent-browser"]);
+});
+
 test("allowSubagents enables Codex multi-agent for fresh and resumed launches", () => {
   const transcript = path.join(SANDBOX, "legacy", "sessions", "2026", "07", "14", "rollout-019f5f2f-743a-7f23-7773-3cf2dd4b4168.jsonl");
   fs.mkdirSync(path.dirname(transcript), { recursive: true });

--- a/src/lib/agent/cli.test.ts
+++ b/src/lib/agent/cli.test.ts
@@ -39,7 +39,7 @@ test("fresh Codex commands fix CODEX_HOME in the typed shell command", () => {
   expect(spec.launchProfile?.allowSubagents).toBe(false);
 });
 
-test("fresh tmux Codex commands enforce the normalized MCP allowlist at runtime", () => {
+test("fresh tmux Codex commands enable only servers inside the grant bound", () => {
   const home = path.join(SANDBOX, "codex-mcp-runtime");
   fs.mkdirSync(home, { recursive: true });
   fs.writeFileSync(path.join(home, "config.toml"), [
@@ -57,10 +57,12 @@ test("fresh tmux Codex commands enforce the normalized MCP allowlist at runtime"
     mcpServers: ["agent-browser"],
   });
 
+  /* A configured server outside the grant bound stays disabled however the
+     allowlist names it (issue #739); Viewer is the only enabled surface. */
   expect(spec.command).toContain("'mcp_servers.viewer.enabled=true'");
-  expect(spec.command).toContain("'mcp_servers.agent-browser.enabled=true'");
+  expect(spec.command).toContain("'mcp_servers.agent-browser.enabled=false'");
   expect(spec.command).toContain("'mcp_servers.unrelated.enabled=false'");
-  expect(spec.launchProfile?.mcpServers).toEqual(["viewer", "agent-browser"]);
+  expect(spec.launchProfile?.mcpServers).toEqual(["viewer"]);
 });
 
 test("fresh tmux Codex defaults disable every configured server outside Viewer", () => {
@@ -250,38 +252,40 @@ test("fresh tmux Claude uses its exclusive native MCP file", () => {
   const sessionId = path.basename(spec.transcript!, ".jsonl");
   const mcpConfigPath = path.join(home, ".llv", "spawn-mcp", `${sessionId}.json`);
 
+  /* The per-spawn file carries exactly the granted surface; a configured
+     server the allowlist names but the bound excludes is not copied (#739). */
   expect(spec.command).toContain(`'--strict-mcp-config' '--mcp-config' '${mcpConfigPath}'`);
   expect(JSON.parse(fs.readFileSync(mcpConfigPath, "utf8"))).toEqual({ mcpServers: {
     viewer: { type: "stdio", command: "viewer-mcp" },
-    "agent-browser": { type: "stdio", command: "browser-mcp" },
   } });
-  expect(spec.launchProfile?.mcpServers).toEqual(["viewer", "agent-browser"]);
+  expect(spec.launchProfile?.mcpServers).toEqual(["viewer"]);
 });
 
-test("a stored allowlist naming an ungranted server is re-bounded when the command is built", () => {
-  const home = path.join(SANDBOX, "claude-mcp-rebound");
-  fs.mkdirSync(home, { recursive: true });
-  fs.writeFileSync(path.join(home, ".claude.json"), JSON.stringify({
+test("a resume rebuilds its command from the re-bounded grant, not the stored list", () => {
+  const home = process.env.LLV_CLAUDE_HOME!;
+  const transcript = path.join(home, "projects", "-repo", "019fa1b2-c3d4-0567-8899-aabbccddef77.jsonl");
+  fs.mkdirSync(path.dirname(transcript), { recursive: true });
+  fs.writeFileSync(transcript, JSON.stringify({ cwd: SANDBOX }) + "\n");
+  /* A legacy home keeps its MCP state beside the home directory, which is where
+     the resume path reads the registered definitions from. */
+  fs.writeFileSync(path.join(path.dirname(home), ".claude.json"), JSON.stringify({
     mcpServers: {
       viewer: { type: "stdio", command: "viewer-mcp" },
-      "agent-browser": { type: "stdio", command: "browser-mcp" },
       telegram: { type: "stdio", command: "telegram-mcp" },
     },
   }));
 
-  /* Launch profiles are durable and editable by hand, so the rendered command
-     comes from the re-validated grant, not from what storage claimed (#739). */
-  const spec = freshSpecFor("claude", "/repo", {
-    claudeConfigDir: home,
-    claudeProjectsDir: path.join(home, "projects"),
-    mcpServers: ["viewer", "telegram", "agent-browser"],
+  /* Launch profiles are durable and editable by hand, so a resume renders from
+     the re-validated grant instead of throwing or trusting storage (#739). */
+  const resumed = resumeSpecFor("claude-projects", transcript, {
+    mcpServers: ["viewer", "telegram"],
   });
-  const sessionId = path.basename(spec.transcript!, ".jsonl");
-  const mcpConfigPath = path.join(home, ".llv", "spawn-mcp", `${sessionId}.json`);
+  const mcpConfigPath = resumed!.command.match(/'--mcp-config' '([^']+)'/)![1]!;
 
-  expect(spec.launchProfile?.mcpServers).toEqual(["viewer", "agent-browser"]);
-  expect(Object.keys((JSON.parse(fs.readFileSync(mcpConfigPath, "utf8")) as { mcpServers: Record<string, unknown> }).mcpServers))
-    .toEqual(["viewer", "agent-browser"]);
+  expect(resumed?.launchProfile?.mcpServers).toEqual(["viewer"]);
+  expect(JSON.parse(fs.readFileSync(mcpConfigPath, "utf8"))).toEqual({ mcpServers: {
+    viewer: { type: "stdio", command: "viewer-mcp" },
+  } });
 });
 
 test("allowSubagents enables Codex multi-agent for fresh and resumed launches", () => {

--- a/src/lib/agent/cli.ts
+++ b/src/lib/agent/cli.ts
@@ -8,7 +8,7 @@ import { accountForSpawn, codexHomeOwningSessionPath, isManagedCodexHome } from 
 import { claudeHomeOwningTranscript, claudeSettingsPath, isManagedClaudeHome, legacyClaudeHome } from "@/lib/accounts/claude";
 
 import { claudeTranscriptPath, headCwd } from "./transcript";
-import { normalizeSpawnMcpServers } from "./mcpAllowlist";
+import { grantedMcpServers } from "./mcpAllowlist";
 import { grantedPlugins } from "./pluginAllowlist";
 import { normalizeClaudeLaunchModel } from "./models";
 import { applyClaudeSpawnPolicy, claudeSpawnPolicyPaths, VIEWER_SPAWN_CAPABILITY_ENV } from "./spawnPolicy";
@@ -164,10 +164,12 @@ export interface ResumeSpecOptions {
   hostTerminal?: boolean;
 }
 
+/* Re-validation on the way out of the durable launch profile (issue #739): a
+   resume or attach replays a stored allowlist, and a stored allowlist can be
+   edited by hand, so the command is rendered from the re-bounded list instead
+   of the stored one. A resume can therefore never widen its own surface. */
 function normalizedMcpServers(value: readonly string[] | undefined): string[] {
-  const normalized = normalizeSpawnMcpServers(value);
-  if (!normalized.ok) throw new Error(normalized.error);
-  return normalized.value;
+  return grantedMcpServers(value);
 }
 
 function configuredCodexMcpServers(home: string, cwd: string): string[] {

--- a/src/lib/agent/mcpAllowlist.test.ts
+++ b/src/lib/agent/mcpAllowlist.test.ts
@@ -503,12 +503,22 @@ function forgeSqliteEntryIdentity(sqlitePath: string, rowKey: string, forgery: I
   }
 }
 
-/* Each forgery is exercised ALONE. Applying both at once would let either
-   check alone carry the case, and the other could be deleted unnoticed. */
+/* One field is forged at a time. Forging both at once would look stronger and
+   test less — the path rule catches a row-key forgery on its own, so the case
+   would keep passing with the row-key rule deleted.
+
+   These two pin the attack end to end on every backend and reader. Which
+   individual RULE carries each denial is pinned separately below, on the pure
+   functions, where a fixture can isolate one rule at a time. */
 const IDENTITY_FORGERIES = [
   {
     what: "embedded session key",
-    forge: (): IdentityForgery => ({ key: { engine: "codex", sessionId: sessionIdFor("nested-parent") } }),
+    /* The transcript moves to a path no generation records, so the path rule
+       has nothing to say about this row and the row-key rule stands alone. */
+    forge: (): IdentityForgery => ({
+      key: { engine: "codex", sessionId: sessionIdFor("nested-parent") },
+      artifactPath: transcriptFor("unrecorded-transcript"),
+    }),
   },
   {
     what: "transcript path",
@@ -651,6 +661,42 @@ test("identity evidence that cannot name one owner denies rather than picking a 
 
   expect(reboundAssembledMcpGrants(sharedPath(), WITH_CONNECTOR).entries["codex:root-generation"]!.launchProfile!.mcpServers)
     .toEqual(["viewer"]);
+});
+
+test("an unowned entry pointing at another row's transcript is denied even in a partial read", () => {
+  /* The per-collection pass deliberately leaves a merely-UNOWNED row alone, so
+     that normalizing a lone entries row cannot wipe a legitimate root grant.
+     A row that erased its own generation and points at the operator root's
+     transcript would ride in on exactly that, in exactly the view a SQLite
+     entries-only normalize produces. Borrowed identity is not mere absence. */
+  const grant = ["viewer", "test-connector"];
+  const borrowed = () => ({
+    conversations: {
+      root: {
+        id: "conversation_root",
+        engine: "codex",
+        agentRole: null,
+        delegationDepth: 0,
+        generations: [{
+          id: "root-generation",
+          path: "/sessions/root.jsonl",
+          launchProfile: { ...emptyLaunchProfile(), parentConversationId: null, mcpServers: [...grant] },
+        }],
+      },
+    },
+    entries: {
+      "codex:orphan-worker": { artifactPath: "/sessions/root.jsonl", launchProfile: { mcpServers: [...grant] } },
+    },
+  } as unknown as StoredGrantFile);
+
+  expect(reboundStoredMcpGrants(borrowed(), WITH_CONNECTOR).entries["codex:orphan-worker"]!.launchProfile!.mcpServers)
+    .toEqual(["viewer"]);
+  expect(reboundAssembledMcpGrants(borrowed(), WITH_CONNECTOR).entries["codex:orphan-worker"]!.launchProfile!.mcpServers)
+    .toEqual(["viewer"]);
+  /* The generation's own row keeps the grant, so this is the borrowing that is
+     denied and not the transcript. */
+  expect(reboundStoredMcpGrants(borrowed(), WITH_CONNECTOR).conversations.root!.generations[0]!.launchProfile.mcpServers)
+    .toEqual(grant);
 });
 
 test("a forged embedded key is denied even where no conversation is loaded", () => {

--- a/src/lib/agent/mcpAllowlist.test.ts
+++ b/src/lib/agent/mcpAllowlist.test.ts
@@ -1191,27 +1191,24 @@ test("an entry no conversation owns keeps its grant per row and loses it in an a
   expect(assembled.entries["codex:orphan"]!.launchProfile!.mcpServers).toEqual(["viewer"]);
 });
 
+const STORE_SOURCE = () => fs.readFileSync(path.join(import.meta.dir, "sqliteRegistryStore.ts"), "utf8");
+
 /**
- * Every `SqliteAgentRegistryStore` method that reaches a row writer, read out of
- * the SOURCE rather than listed by hand.
+ * Every `SqliteAgentRegistryStore` method that writes a registry row, found by
+ * what it CALLS rather than by name, so a new one cannot be added quietly.
  *
- * The origin half of the grant bound is a PRECONDITION of a row being observed
- * or written, and this lane has now reopened that ordering twice — once because
- * a mutation ran on lazily normalized rows, once because a wholesale
- * replacement carried its payload in from outside. A new mutation path is the
- * obvious third way in, so it has to fail here until somebody exercises it,
- * rather than quietly inheriting whatever gate the path it was copied from had.
+ * `upsertRow` is the single statement that puts a row in the table, so any
+ * method reaching it is a row writer whatever it is called.
  */
-function storeMutationEntryPoints(): string[] {
-  const lines = fs.readFileSync(path.join(import.meta.dir, "sqliteRegistryStore.ts"), "utf8").split("\n");
-  const writes = /this\.(persistAll|persistDiff|persistChanges)\(/;
+function storeRowWriters(): string[] {
+  const lines = STORE_SOURCE().split("\n");
   const signature = /^ {2}(?:private |protected |public |static )*(?:async )?([A-Za-z_]\w*)\s*(?:<[^(]*>)?\(/;
   const found = new Set<string>();
   for (const [index, line] of lines.entries()) {
-    if (!writes.test(line)) continue;
+    if (!/this\.upsertRow\(/.test(line)) continue;
     for (let above = index; above >= 0; above -= 1) {
       const match = signature.exec(lines[above]!);
-      if (!match) continue;
+      if (!match || match[1] === "upsertRow") continue;
       found.add(match[1]!);
       break;
     }
@@ -1389,6 +1386,59 @@ test("every SQLite store mutation entry point re-decides grants before it can pe
     },
   };
 
-  expect(storeMutationEntryPoints()).toEqual(Object.keys(exercises).sort());
   for (const exercise of Object.values(exercises)) exercise();
+});
+
+/**
+ * The ordering has been reopened three times in this lane — a mutation running
+ * on lazily normalized rows, a wholesale replacement carrying its payload in
+ * from outside, and a first-boot import. Enumerating today's callers only
+ * NOTICES a fourth after somebody writes it. This asserts the construction that
+ * refuses to let a fourth be written: every row writer takes a file the grant
+ * decision has been run over, and there is exactly one place that can mint one.
+ */
+test("a registry row cannot be persisted without a completed grant re-decision", () => {
+  const source = STORE_SOURCE();
+
+  /* Discovered by what they call, so renaming or adding a writer cannot dodge
+     this. Each must take the branded file AND assert it at runtime, because the
+     type alone is defeated by an `as` cast. */
+  const writers = storeRowWriters();
+  expect(writers.length).toBeGreaterThan(0);
+  for (const writer of writers) {
+    const gated = new RegExp(
+      `private ${writer}\\([^)]*\\b(\\w+): DecidedRegistryFile[^)]*\\)[^{]*\\{\\s*this\\.assertDecided\\(\\1\\);`,
+    );
+    expect({ writer, gated: gated.test(source) }).toEqual({ writer, gated: true });
+  }
+
+  /* One mint. `markDecided` is the only place the brand is applied, so every
+     route to a row writer runs through it — the assembled decision for a
+     payload from outside, the gated accessors for a lazily loaded file. */
+  expect(source.match(/as DecidedRegistryFile/g)).toHaveLength(1);
+  expect(source).toMatch(/private markDecided\(file: RegistryFile\): DecidedRegistryFile \{\s*this\.decidedFiles\.add\(file\);\s*return file as DecidedRegistryFile;/);
+
+  /* And the runtime half actually fires: a file that skipped the mint is
+     refused at the write rather than persisted. This is the future path the
+     type system would have caught at compile time, run anyway. */
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-mcp-undecided-"));
+  try {
+    const store = new SqliteAgentRegistryStore(path.join(directory, "agent-registry.sqlite"), {
+      normalize: (value: unknown) => normalizeRegistry(value, WITH_CONNECTOR),
+      mcpGrantPolicy: WITH_CONNECTOR,
+      initialSnapshot: normalizeRegistry({ version: 2, entries: {}, receipts: {} }, WITH_CONNECTOR),
+    });
+    const smuggled = normalizeRegistry({ version: 2, entries: {}, receipts: {} }, WITH_CONNECTOR);
+    const reachWriters = store as unknown as {
+      persistAll(file: RegistryFile, revision: number): void;
+      persistDiff(before: RegistryFile, after: RegistryFile, revision: number): void;
+      persistChanges(file: RegistryFile, changes: unknown, revision: number): void;
+    };
+    expect(() => reachWriters.persistAll(smuggled, 1)).toThrow(/before the MCP grant decision has run/);
+    expect(() => reachWriters.persistDiff(smuggled, smuggled, 1)).toThrow(/before the MCP grant decision has run/);
+    expect(() => reachWriters.persistChanges(smuggled, { rows: new Map(), meta: new Set(), order: new Set() }, 1))
+      .toThrow(/before the MCP grant decision has run/);
+  } finally {
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
 });

--- a/src/lib/agent/mcpAllowlist.test.ts
+++ b/src/lib/agent/mcpAllowlist.test.ts
@@ -1,21 +1,25 @@
 import { expect, test } from "bun:test";
+import { Database } from "bun:sqlite";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
 import { emptyLaunchProfile } from "@/lib/accounts/migration/contracts";
 import { headlessCodexThreadConfig } from "@/lib/codexHeadlessConfig";
-import { AgentRegistry, reboundStoredMcpGrants } from "./registry";
-import type { RegistryFile } from "./registry";
+import { AgentRegistry, normalizeRegistry } from "./registry";
+import { SqliteAgentRegistryStore } from "./sqliteRegistryStore";
 
 import {
   GRANTABLE_MCP_SERVERS,
+  reboundAssembledMcpGrants,
   MCP_GRANT_POLICY,
   defaultMcpServersForOrigin,
   grantedMcpServers,
   mcpServersForSession,
   mcpServersForStoredSession,
   normalizeSpawnMcpServers,
+  reboundStoredMcpGrants,
+  type StoredGrantFile,
   type McpGrantPolicy,
 } from "./mcpAllowlist";
 
@@ -200,7 +204,7 @@ test("the storage boundary re-decides a grantable connector by the conversation'
       "codex:root-generation": { launchProfile: profileFor(["viewer", "test-connector"], null) },
       "codex:worker-generation": { launchProfile: profileFor(["viewer", "test-connector"], "conversation_root") },
     },
-  } as unknown as RegistryFile;
+  } as unknown as StoredGrantFile;
 
   const rebounded = reboundStoredMcpGrants(file, WITH_CONNECTOR);
 
@@ -215,7 +219,10 @@ test("a delegated conversation cannot keep a hand-edited grant across resume or 
   const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-mcp-tamper-"));
   const registryPath = path.join(directory, "registry.json");
   try {
-    const store = new AgentRegistry(registryPath);
+    /* This case tampers with the JSON file itself, so it pins the backend
+       rather than inheriting the environment's: under a SQLite-authoritative
+       mode that file is a lagging rollback mirror, not the source of truth. */
+    const store = new AgentRegistry(registryPath, undefined, undefined, { sqliteMode: "off" });
     const parentId = settledParent(store, ["viewer"]);
     const child = store.beginSpawnRequest({
       engine: "codex",
@@ -251,7 +258,7 @@ test("a delegated conversation cannot keep a hand-edited grant across resume or 
     }
     fs.writeFileSync(registryPath, JSON.stringify(raw));
 
-    const reloaded = new AgentRegistry(registryPath);
+    const reloaded = new AgentRegistry(registryPath, undefined, undefined, { sqliteMode: "off" });
     const profile = reloaded.launchProfileForPath("/sessions/delegated-worker.jsonl");
     expect(profile?.mcpServers).toEqual(["viewer"]);
     const snapshot = reloaded.snapshot();
@@ -268,4 +275,223 @@ test("a delegated conversation cannot keep a hand-edited grant across resume or 
   } finally {
     fs.rmSync(directory, { recursive: true, force: true });
   }
+});
+
+function settledDelegatedChild(store: AgentRegistry, parentId: string, sessionId: string) {
+  const child = store.beginSpawnRequest({
+    engine: "codex",
+    cwd: "/repo",
+    role: "builder",
+    parentConversationId: parentId as never,
+    origin: { kind: "agent", conversationId: parentId as never },
+  });
+  if (child.kind !== "created") throw new Error("expected child reservation");
+  const settled = store.settleSpawn(child.receipt.launchId, {
+    key: { engine: "codex", sessionId },
+    artifactPath: `/sessions/${sessionId}.jsonl`,
+    cwd: "/repo",
+    accountId: "account",
+    status: "idle",
+    host: null,
+    claimEpoch: 0,
+    claimOwner: null,
+    pendingAction: null,
+  });
+  if (settled.kind !== "settled") throw new Error("expected child settlement");
+  return settled.conversation.id;
+}
+
+function structuredRow(store: AgentRegistry, sessionId: string) {
+  /* A structured host row is what boot adoption filters for and what a claim
+     hands to `optionsFor`, so the claim path is exercised rather than skipped. */
+  store.upsert({
+    key: { engine: "codex", sessionId },
+    artifactPath: `/sessions/${sessionId}.jsonl`,
+    cwd: "/repo",
+    accountId: "account",
+    status: "dead",
+    host: null,
+    structuredHost: {
+      kind: "codex-app-server",
+      endpoint: "stdio:old",
+      process: null,
+      eventCursor: 4,
+      protocolVersion: "0.145.0",
+      writerClaimEpoch: 1,
+      activeTurnRef: null,
+      pendingAttention: [],
+      activeFlags: [],
+    },
+    claimEpoch: 1,
+    claimOwner: null,
+    pendingAction: null,
+  });
+}
+
+function tamperSqliteGrant(sqlitePath: string, rows: { collection: "entries" | "conversations"; key: string }[], grant: string[]): void {
+  const db = new Database(sqlitePath, { strict: true });
+  try {
+    for (const { collection, key } of rows) {
+      const row = db.query<{ value_json: string }, [string, string]>(
+        "SELECT value_json FROM registry_rows WHERE collection = ? AND row_key = ?",
+      ).get(collection, key);
+      if (!row) throw new Error(`expected a stored ${collection} row for ${key}`);
+      const parsed = JSON.parse(row.value_json) as {
+        launchProfile?: Record<string, unknown>;
+        generations?: { launchProfile: Record<string, unknown> }[];
+      };
+      parsed.launchProfile = { ...(parsed.launchProfile ?? {}), mcpServers: [...grant] };
+      for (const generation of parsed.generations ?? []) generation.launchProfile.mcpServers = [...grant];
+      db.query<unknown, [string, string, string]>(
+        "UPDATE registry_rows SET value_json = ? WHERE collection = ? AND row_key = ?",
+      ).run(JSON.stringify(parsed), collection, key);
+    }
+  } finally {
+    db.close();
+  }
+}
+
+test("a SQLite-authoritative registry re-bounds a tampered entry row on the paths adoption reads", () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-mcp-sqlite-tamper-"));
+  const registryPath = path.join(directory, "agent-registry.json");
+  const sqlitePath = path.join(directory, "agent-registry.sqlite");
+  const storage = { sqliteMode: "sqlite" as const, mcpGrantPolicy: WITH_CONNECTOR };
+  const workerEntryId = "codex:sqlite-delegated-worker";
+  const rootEntryId = "codex:nested-parent";
+  try {
+    const store = new AgentRegistry(registryPath, undefined, undefined, storage);
+    const parentId = settledParent(store, ["viewer"]);
+    const workerId = settledDelegatedChild(store, parentId, "sqlite-delegated-worker");
+    structuredRow(store, "sqlite-delegated-worker");
+    structuredRow(store, "nested-parent");
+
+    /* Rows are written and normalized one collection — one row — at a time, so
+       an entry row is the copy that carries no origin evidence of its own.
+       Tamper where SQLite is authoritative; the JSON file is only a mirror. */
+    tamperSqliteGrant(sqlitePath, [
+      { collection: "entries", key: workerEntryId },
+      { collection: "conversations", key: workerId },
+      { collection: "entries", key: rootEntryId },
+      { collection: "conversations", key: parentId },
+    ], ["viewer", "test-connector"]);
+
+    const reopened = new AgentRegistry(registryPath, undefined, undefined, storage);
+    /* readOnlySnapshot is what boot adoption filters rows from, and snapshot is
+       what structured recovery reads a profile and cursor through. */
+    expect(reopened.readOnlySnapshot().entries[workerEntryId]?.launchProfile?.mcpServers).toEqual(["viewer"]);
+    expect(reopened.snapshot().entries[workerEntryId]?.launchProfile?.mcpServers).toEqual(["viewer"]);
+    /* The operator root's own row keeps what it was granted, so the reset above
+       is the origin rule and not a blanket wipe. */
+    expect(reopened.snapshot().entries[rootEntryId]?.launchProfile?.mcpServers).toEqual(["viewer", "test-connector"]);
+
+    /* And the entry a claim mutation hands to a host, which never sees an
+       assembled snapshot at all. */
+    const owner = { pid: process.pid, startIdentity: null };
+    const claimedWorker = reopened.claimStructuredHost({ engine: "codex", sessionId: "sqlite-delegated-worker" }, owner, { allowUnhosted: true });
+    expect(claimedWorker).not.toBeNull();
+    expect(claimedWorker?.launchProfile?.mcpServers).toEqual(["viewer"]);
+    const claimedRoot = reopened.claimStructuredHost({ engine: "codex", sessionId: "nested-parent" }, owner, { allowUnhosted: true });
+    expect(claimedRoot?.launchProfile?.mcpServers).toEqual(["viewer", "test-connector"]);
+  } finally {
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+test("an assembled SQLite snapshot re-decides entry rows by their owning conversation", () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-mcp-sqlite-origin-"));
+  const registryPath = path.join(directory, "agent-registry.json");
+  try {
+    const store = new AgentRegistry(registryPath, undefined, undefined, { sqliteMode: "sqlite" });
+    const rootId = settledParent(store, ["viewer"]);
+    const workerId = settledDelegatedChild(store, rootId, "sqlite-origin-worker");
+    const snapshot = store.snapshot();
+
+    /* Both rows claim a connector this tranche cannot grant at all, so the
+       decision is replayed against a policy that CAN — otherwise the reset
+       proves the bound rather than the origin rule. */
+    const grant = ["viewer", "test-connector"];
+    for (const conversationId of [rootId, workerId]) {
+      for (const generation of snapshot.conversations[conversationId]!.generations) {
+        generation.launchProfile.mcpServers = [...grant];
+      }
+    }
+    for (const entry of Object.values(snapshot.entries)) {
+      if (entry.launchProfile) entry.launchProfile.mcpServers = [...grant];
+    }
+
+    reboundStoredMcpGrants(snapshot as unknown as StoredGrantFile, WITH_CONNECTOR);
+
+    expect(snapshot.conversations[rootId]!.generations.at(-1)!.launchProfile.mcpServers).toEqual(grant);
+    expect(snapshot.entries["codex:nested-parent"]?.launchProfile?.mcpServers).toEqual(grant);
+    /* The delegated worker loses it on both copies, matched by real session key. */
+    expect(snapshot.conversations[workerId]!.generations.at(-1)!.launchProfile.mcpServers).toEqual(["viewer"]);
+    expect(snapshot.entries["codex:sqlite-origin-worker"]?.launchProfile?.mcpServers).toEqual(["viewer"]);
+  } finally {
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+test("the SQLite store re-decides entry rows by origin when it assembles a snapshot", () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-mcp-sqlite-assembled-"));
+  try {
+    /* Seeded through the real registry so ids, session keys and artifact paths
+       are the production ones, then re-read through a store whose normalizer
+       runs under a policy that HAS a grantable connector — the shipped bound
+       has none, and an empty bound cannot tell an origin reset from itself. */
+    const seed = new AgentRegistry(path.join(directory, "agent-registry.json"), undefined, undefined, { sqliteMode: "off" });
+    const rootId = settledParent(seed, ["viewer"]);
+    const workerId = settledDelegatedChild(seed, rootId, "assembled-worker");
+    const initial = seed.snapshot();
+    const grant = ["viewer", "test-connector"];
+    for (const conversationId of [rootId, workerId]) {
+      for (const generation of initial.conversations[conversationId]!.generations) {
+        generation.launchProfile.mcpServers = [...grant];
+      }
+    }
+    for (const entry of Object.values(initial.entries)) {
+      if (entry.launchProfile) entry.launchProfile.mcpServers = [...grant];
+    }
+
+    const store = new SqliteAgentRegistryStore(path.join(directory, "agent-registry.sqlite"), {
+      initialSnapshot: initial,
+      normalize: (value) => normalizeRegistry(value, WITH_CONNECTOR),
+      mcpGrantPolicy: WITH_CONNECTOR,
+    });
+    {
+      const file = store.snapshot().file;
+      /* The operator root keeps the grant on both copies of its profile. */
+      expect(file.conversations[rootId]!.generations.at(-1)!.launchProfile.mcpServers).toEqual(grant);
+      expect(file.entries["codex:nested-parent"]!.launchProfile!.mcpServers).toEqual(grant);
+      /* The delegated worker loses it on both — including the ENTRY row, which
+         is normalized with no conversation in sight and is what boot adoption
+         and structured recovery consume. */
+      expect(file.conversations[workerId]!.generations.at(-1)!.launchProfile.mcpServers).toEqual(["viewer"]);
+      expect(file.entries["codex:assembled-worker"]!.launchProfile!.mcpServers).toEqual(["viewer"]);
+    }
+  } finally {
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+test("an entry no conversation owns keeps its grant per row and loses it in an assembled read", () => {
+  const orphan = () => ({
+    conversations: {},
+    entries: {
+      "codex:orphan": {
+        key: { engine: "codex", sessionId: "orphan" },
+        artifactPath: "/sessions/orphan.jsonl",
+        launchProfile: { mcpServers: ["viewer", "test-connector"] },
+      },
+    },
+  } as unknown as StoredGrantFile);
+
+  /* Per-row normalization sees no conversations at all, so "unowned" there is a
+     statement about how much was loaded — narrowing then would wipe a
+     legitimate root grant on every lone entries row. */
+  const perRow = reboundStoredMcpGrants(orphan(), WITH_CONNECTOR);
+  expect(perRow.entries["codex:orphan"]!.launchProfile!.mcpServers).toEqual(["viewer", "test-connector"]);
+  /* In a complete snapshot the same entry is genuinely unowned: no origin
+     evidence exists for it, so it falls back to the baseline. */
+  const assembled = reboundAssembledMcpGrants(orphan(), WITH_CONNECTOR);
+  expect(assembled.entries["codex:orphan"]!.launchProfile!.mcpServers).toEqual(["viewer"]);
 });

--- a/src/lib/agent/mcpAllowlist.test.ts
+++ b/src/lib/agent/mcpAllowlist.test.ts
@@ -5,23 +5,42 @@ import path from "node:path";
 
 import { emptyLaunchProfile } from "@/lib/accounts/migration/contracts";
 import { headlessCodexThreadConfig } from "@/lib/codexHeadlessConfig";
-import { AgentRegistry } from "./registry";
+import { AgentRegistry, reboundStoredMcpGrants } from "./registry";
+import type { RegistryFile } from "./registry";
 
 import {
   GRANTABLE_MCP_SERVERS,
+  MCP_GRANT_POLICY,
   defaultMcpServersForOrigin,
   grantedMcpServers,
   mcpServersForSession,
+  mcpServersForStoredSession,
   normalizeSpawnMcpServers,
+  type McpGrantPolicy,
 } from "./mcpAllowlist";
+
+/** A policy shaped like the one tranche 2 will ship, so the origin rules are
+    exercised against a connector that is genuinely grantable. Proving them
+    against the shipped bound would prove only that it is currently empty. */
+const WITH_CONNECTOR: McpGrantPolicy = Object.freeze({
+  grantable: Object.freeze(["viewer", "test-connector"]),
+  operatorRoot: Object.freeze(["viewer", "test-connector"]),
+  delegated: Object.freeze(["viewer"]),
+});
+
+test("tranche 1 ships no grantable connector beyond the Viewer baseline", () => {
+  expect([...GRANTABLE_MCP_SERVERS]).toEqual(["viewer"]);
+  expect([...MCP_GRANT_POLICY.operatorRoot]).toEqual(["viewer"]);
+  expect([...MCP_GRANT_POLICY.delegated]).toEqual(["viewer"]);
+});
 
 test("a spawn without an MCP selection receives Viewer only", () => {
   expect(normalizeSpawnMcpServers(undefined)).toEqual({ ok: true, value: ["viewer"] });
 });
 
 test("a custom MCP selection is deduplicated and force-includes Viewer", () => {
-  expect(normalizeSpawnMcpServers(["agent-browser", "viewer", "agent-browser"]))
-    .toEqual({ ok: true, value: ["viewer", "agent-browser"] });
+  expect(normalizeSpawnMcpServers(["test-connector", "viewer", "test-connector"], WITH_CONNECTOR))
+    .toEqual({ ok: true, value: ["viewer", "test-connector"] });
 });
 
 test("malformed MCP selections are rejected", () => {
@@ -39,35 +58,51 @@ test("an MCP server outside the grant bound is rejected, never silently dropped"
      grantable `viewer` alongside it does not rescue the request. */
   expect(normalizeSpawnMcpServers(["viewer", "telegram"])).toEqual({
     ok: false,
-    error: `mcpServers may only contain ${GRANTABLE_MCP_SERVERS.join(", ")}; rejected: telegram`,
+    error: "mcpServers may only contain viewer; rejected: telegram",
   });
   expect(normalizeSpawnMcpServers(["*"])).toMatchObject({ ok: false });
   expect(normalizeSpawnMcpServers(["all"])).toMatchObject({ ok: false });
+  /* Every configured server is outside the bound this tranche, whoever asks. */
+  expect(normalizeSpawnMcpServers(["agent-browser"])).toMatchObject({ ok: false });
 });
 
 test("a delegated spawn cannot obtain a grantable connector and keeps its Viewer baseline", () => {
-  expect(defaultMcpServersForOrigin("delegated")).toEqual(["viewer"]);
-  expect(mcpServersForSession({ origin: "delegated", requested: ["viewer", "agent-browser"] }))
+  expect(defaultMcpServersForOrigin("delegated", WITH_CONNECTOR)).toEqual(["viewer"]);
+  expect(mcpServersForSession({ origin: "delegated", requested: ["viewer", "test-connector"] }, WITH_CONNECTOR))
     .toEqual(["viewer"]);
-  expect(mcpServersForSession({ origin: "delegated", requested: null })).toEqual(["viewer"]);
+  expect(mcpServersForSession({ origin: "delegated", requested: null }, WITH_CONNECTOR)).toEqual(["viewer"]);
 });
 
 test("an operator-root spawn receives the grantable connector it requests", () => {
-  expect(defaultMcpServersForOrigin("operator-root")).toEqual([...GRANTABLE_MCP_SERVERS]);
-  expect(mcpServersForSession({ origin: "operator-root", requested: ["viewer", "agent-browser"] }))
-    .toEqual(["viewer", "agent-browser"]);
+  expect(defaultMcpServersForOrigin("operator-root", WITH_CONNECTOR)).toEqual(["viewer", "test-connector"]);
+  expect(mcpServersForSession({ origin: "operator-root", requested: ["viewer", "test-connector"] }, WITH_CONNECTOR))
+    .toEqual(["viewer", "test-connector"]);
 });
 
 test("an empty selection stays the explicit opt-out and still yields Viewer", () => {
-  const requested = normalizeSpawnMcpServers([]);
+  const requested = normalizeSpawnMcpServers([], WITH_CONNECTOR);
   expect(requested).toEqual({ ok: true, value: ["viewer"] });
-  expect(mcpServersForSession({ origin: "operator-root", requested: requested.ok ? requested.value : null }))
+  expect(mcpServersForSession({ origin: "operator-root", requested: requested.ok ? requested.value : null }, WITH_CONNECTOR))
     .toEqual(["viewer"]);
-  expect(mcpServersForSession({ origin: "delegated", requested: [] })).toEqual(["viewer"]);
+  expect(mcpServersForSession({ origin: "delegated", requested: [] }, WITH_CONNECTOR)).toEqual(["viewer"]);
+});
+
+test("a stored grant is re-decided from the session's durable origin, not replayed", () => {
+  const tampered = ["viewer", "test-connector"];
+  /* The delegation signals #393 records, one at a time: each is enough on its
+     own, so a tampered profile cannot ride in on the other two being absent. */
+  expect(mcpServersForStoredSession({ agentRole: "builder", requested: tampered }, WITH_CONNECTOR)).toEqual(["viewer"]);
+  expect(mcpServersForStoredSession({ parentConversationId: "conversation_parent", requested: tampered }, WITH_CONNECTOR)).toEqual(["viewer"]);
+  expect(mcpServersForStoredSession({ delegationDepth: 1, requested: tampered }, WITH_CONNECTOR)).toEqual(["viewer"]);
+  expect(mcpServersForStoredSession({ origin: { kind: "agent" }, requested: tampered }, WITH_CONNECTOR)).toEqual(["viewer"]);
+  /* The operator's own root keeps what it was granted. */
+  expect(mcpServersForStoredSession({ delegationDepth: 0, requested: tampered }, WITH_CONNECTOR))
+    .toEqual(["viewer", "test-connector"]);
 });
 
 test("a launch profile hand-edited to carry an ungranted server is re-bounded at the point of use", () => {
-  expect(grantedMcpServers(["viewer", "telegram", "agent-browser"])).toEqual(["viewer", "agent-browser"]);
+  expect(grantedMcpServers(["viewer", "telegram", "test-connector"], WITH_CONNECTOR)).toEqual(["viewer", "test-connector"]);
+  expect(grantedMcpServers(["viewer", "telegram"])).toEqual(["viewer"]);
   expect(grantedMcpServers(undefined)).toEqual(["viewer"]);
   /* Durable storage re-bounds the edit as it is written, and every engine's
      enable table is materialized from the re-validated list, never the stored
@@ -77,7 +112,7 @@ test("a launch profile hand-edited to carry an ungranted server is re-bounded at
     config: { mcp_servers: { viewer: {}, telegram: {}, "agent-browser": {} } },
   }, false, ["viewer", "telegram", "agent-browser"]) as { mcp_servers: Record<string, { enabled: boolean }> };
   expect(thread.mcp_servers.viewer.enabled).toBe(true);
-  expect(thread.mcp_servers["agent-browser"].enabled).toBe(true);
+  expect(thread.mcp_servers["agent-browser"].enabled).toBe(false);
   expect(thread.mcp_servers.telegram.enabled).toBe(false);
 });
 
@@ -85,19 +120,114 @@ test("durable launch profiles reset each new spawn to Viewer only", () => {
   expect(emptyLaunchProfile().mcpServers).toEqual(["viewer"]);
 });
 
+function settledParent(store: AgentRegistry, mcpServers: string[]) {
+  const parent = store.beginSpawnRequest({
+    engine: "codex",
+    cwd: "/repo",
+    launchProfile: { mcpServers },
+  });
+  if (parent.kind !== "created") throw new Error("expected parent reservation");
+  const settled = store.settleSpawn(parent.receipt.launchId, {
+    key: { engine: "codex", sessionId: "nested-parent" },
+    artifactPath: "/sessions/nested-parent.jsonl",
+    cwd: "/repo",
+    accountId: "account",
+    status: "idle",
+    host: null,
+    claimEpoch: 0,
+    claimOwner: null,
+    pendingAction: null,
+  });
+  if (settled.kind !== "settled") throw new Error("expected parent settlement");
+  return settled.conversation.id;
+}
+
 test("a nested spawn resets its parent allowlist while resume preserves it", () => {
   const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-mcp-nested-reset-"));
   try {
     const store = new AgentRegistry(path.join(directory, "registry.json"));
-    const parent = store.beginSpawnRequest({
+    const parentId = settledParent(store, ["viewer"]);
+
+    const child = store.beginSpawnRequest({
       engine: "codex",
       cwd: "/repo",
-      launchProfile: { mcpServers: ["viewer", "agent-browser"] },
+      parentConversationId: parentId,
+      origin: { kind: "agent", conversationId: parentId },
     });
-    if (parent.kind !== "created") throw new Error("expected parent reservation");
-    const settled = store.settleSpawn(parent.receipt.launchId, {
-      key: { engine: "codex", sessionId: "nested-parent" },
-      artifactPath: "/sessions/nested-parent.jsonl",
+    expect(child.receipt.launchProfile.mcpServers).toEqual(["viewer"]);
+
+    const resumed = store.beginSpawnRequest({
+      engine: "codex",
+      cwd: "/repo",
+      conversationId: parentId,
+      purpose: "resume-successor",
+    });
+    /* The operator root keeps its grant across a resume; with this tranche's
+       empty bound that grant is the baseline itself. */
+    expect(resumed.receipt.launchProfile.mcpServers).toEqual(["viewer"]);
+  } finally {
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+test("the storage boundary re-decides a grantable connector by the conversation's durable origin", () => {
+  /* Registry-shaped input, exercised against a policy that has a connector to
+     lose — the shipped bound has none, so with it this file could never tell an
+     origin reset apart from the bound doing the work. */
+  const profileFor = (mcpServers: string[], parentConversationId: string | null) => ({
+    ...emptyLaunchProfile(),
+    parentConversationId: parentConversationId as never,
+    mcpServers,
+  });
+  const file = {
+    conversations: {
+      root: {
+        id: "conversation_root",
+        engine: "codex",
+        agentRole: null,
+        delegationDepth: 0,
+        generations: [{ id: "root-generation", launchProfile: profileFor(["viewer", "test-connector"], null) }],
+      },
+      worker: {
+        id: "conversation_worker",
+        engine: "codex",
+        agentRole: "builder",
+        delegationDepth: 1,
+        generations: [{ id: "worker-generation", launchProfile: profileFor(["viewer", "test-connector"], "conversation_root") }],
+      },
+    },
+    entries: {
+      "codex:root-generation": { launchProfile: profileFor(["viewer", "test-connector"], null) },
+      "codex:worker-generation": { launchProfile: profileFor(["viewer", "test-connector"], "conversation_root") },
+    },
+  } as unknown as RegistryFile;
+
+  const rebounded = reboundStoredMcpGrants(file, WITH_CONNECTOR);
+
+  expect(rebounded.conversations.root!.generations[0]!.launchProfile.mcpServers).toEqual(["viewer", "test-connector"]);
+  expect(rebounded.conversations.worker!.generations[0]!.launchProfile.mcpServers).toEqual(["viewer"]);
+  /* The entry row is the copy structured host adoption reads, so it moves too. */
+  expect(rebounded.entries["codex:root-generation"]!.launchProfile!.mcpServers).toEqual(["viewer", "test-connector"]);
+  expect(rebounded.entries["codex:worker-generation"]!.launchProfile!.mcpServers).toEqual(["viewer"]);
+});
+
+test("a delegated conversation cannot keep a hand-edited grant across resume or reload", () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-mcp-tamper-"));
+  const registryPath = path.join(directory, "registry.json");
+  try {
+    const store = new AgentRegistry(registryPath);
+    const parentId = settledParent(store, ["viewer"]);
+    const child = store.beginSpawnRequest({
+      engine: "codex",
+      cwd: "/repo",
+      role: "builder",
+      parentConversationId: parentId,
+      origin: { kind: "agent", conversationId: parentId },
+    });
+    if (child.kind !== "created") throw new Error("expected child reservation");
+    const settledChild = store.settleSpawn(child.receipt.launchId, {
+      key: { engine: "codex", sessionId: "delegated-worker" },
+      artifactPath: "/sessions/delegated-worker.jsonl",
       cwd: "/repo",
       accountId: "account",
       status: "idle",
@@ -106,23 +236,35 @@ test("a nested spawn resets its parent allowlist while resume preserves it", () 
       claimOwner: null,
       pendingAction: null,
     });
-    if (settled.kind !== "settled") throw new Error("expected parent settlement");
+    if (settledChild.kind !== "settled") throw new Error("expected child settlement");
 
-    const child = store.beginSpawnRequest({
+    /* The worker edits the durable file it can reach on disk, naming a server
+       that IS inside the grant bound — the global bound alone would honour it. */
+    const raw = JSON.parse(fs.readFileSync(registryPath, "utf8")) as {
+      conversations: Record<string, { generations: { launchProfile: { mcpServers: string[] } }[] }>;
+      entries: Record<string, { launchProfile?: { mcpServers: string[] } }>;
+    };
+    const conversation = raw.conversations[settledChild.conversation.id]!;
+    for (const generation of conversation.generations) generation.launchProfile.mcpServers = ["viewer", "granted-connector"];
+    for (const entry of Object.values(raw.entries)) {
+      if (entry.launchProfile) entry.launchProfile.mcpServers = ["viewer", "granted-connector"];
+    }
+    fs.writeFileSync(registryPath, JSON.stringify(raw));
+
+    const reloaded = new AgentRegistry(registryPath);
+    const profile = reloaded.launchProfileForPath("/sessions/delegated-worker.jsonl");
+    expect(profile?.mcpServers).toEqual(["viewer"]);
+    const snapshot = reloaded.snapshot();
+    for (const entry of Object.values(snapshot.entries)) {
+      expect(entry.launchProfile?.mcpServers ?? ["viewer"]).toEqual(["viewer"]);
+    }
+    const resumed = reloaded.beginSpawnRequest({
       engine: "codex",
       cwd: "/repo",
-      parentConversationId: settled.conversation.id,
-      origin: { kind: "agent", conversationId: settled.conversation.id },
-    });
-    expect(child.receipt.launchProfile.mcpServers).toEqual(["viewer"]);
-
-    const resumed = store.beginSpawnRequest({
-      engine: "codex",
-      cwd: "/repo",
-      conversationId: settled.conversation.id,
+      conversationId: settledChild.conversation.id,
       purpose: "resume-successor",
     });
-    expect(resumed.receipt.launchProfile.mcpServers).toEqual(["viewer", "agent-browser"]);
+    expect(resumed.receipt.launchProfile.mcpServers).toEqual(["viewer"]);
   } finally {
     fs.rmSync(directory, { recursive: true, force: true });
   }

--- a/src/lib/agent/mcpAllowlist.test.ts
+++ b/src/lib/agent/mcpAllowlist.test.ts
@@ -716,6 +716,249 @@ test("a forged embedded key is denied even where no conversation is loaded", () 
     .toEqual(["viewer"]);
 });
 
+/** The origin fields a receipt carries, rewritten into the shape admission
+    stamps on an operator root. The receipt's LINEAGE — the edge row admission
+    wrote for it, and the conversation row once it settles — is left intact and
+    still says delegated. */
+const ROOT_SHAPE = { agentRole: null, delegationDepth: 0, parentConversationId: null } as const;
+type ReceiptForgery = { agentRole?: string | null; delegationDepth?: number | null; parentConversationId?: string | null };
+
+function forgeJsonReceiptOrigin(registryPath: string, launchId: string, forgery: ReceiptForgery, grant: string[]): void {
+  const raw = JSON.parse(fs.readFileSync(registryPath, "utf8")) as {
+    receipts: Record<string, ReceiptForgery & { launchProfile?: { mcpServers: string[] } }>;
+  };
+  const receipt = raw.receipts[launchId];
+  if (!receipt) throw new Error(`expected a stored receipt for ${launchId}`);
+  Object.assign(receipt, forgery);
+  /* The launch profile carries its own copy of the parent, and settlement puts
+     that copy on the generation, so a forgery that stopped at the receipt's
+     top-level fields would leave the delegation visible on the row it writes. */
+  receipt.launchProfile = { ...(receipt.launchProfile ?? {}), parentConversationId: null, mcpServers: [...grant] } as { mcpServers: string[] };
+  fs.writeFileSync(registryPath, JSON.stringify(raw));
+}
+
+function forgeSqliteReceiptOrigin(sqlitePath: string, launchId: string, forgery: ReceiptForgery, grant: string[]): void {
+  const db = new Database(sqlitePath, { strict: true });
+  try {
+    const row = db.query<{ value_json: string }, [string, string]>(
+      "SELECT value_json FROM registry_rows WHERE collection = ? AND row_key = ?",
+    ).get("receipts", launchId);
+    if (!row) throw new Error(`expected a stored receipts row for ${launchId}`);
+    const parsed = JSON.parse(row.value_json) as { launchProfile?: Record<string, unknown> };
+    Object.assign(parsed, forgery);
+    parsed.launchProfile = { ...(parsed.launchProfile ?? {}), parentConversationId: null, mcpServers: [...grant] };
+    db.query<unknown, [string, string, string]>(
+      "UPDATE registry_rows SET value_json = ? WHERE collection = ? AND row_key = ?",
+    ).run(JSON.stringify(parsed), "receipts", launchId);
+  } finally {
+    db.close();
+  }
+}
+
+/** A delegated launch admitted but NOT settled: its lineage edge row exists,
+    its conversation row does not yet. This is the state where the receipt's own
+    fields are the only thing describing it — and precisely where trusting them
+    would let the row authorise itself. */
+function admittedDelegatedChild(store: AgentRegistry, parentId: string) {
+  const child = store.beginSpawnRequest({
+    engine: "codex",
+    cwd: "/repo",
+    role: "builder",
+    parentConversationId: parentId as never,
+    origin: { kind: "agent", conversationId: parentId as never },
+  });
+  if (child.kind !== "created") throw new Error("expected child reservation");
+  return child.receipt;
+}
+
+test("a receipt forged into root shape is denied by the lineage it cannot rewrite, and nothing propagates through settlement (JSON)", () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-mcp-receipt-origin-"));
+  const registryPath = path.join(directory, "registry.json");
+  const storage = { sqliteMode: "off" as const, mcpGrantPolicy: WITH_CONNECTOR };
+  try {
+    const store = new AgentRegistry(registryPath, undefined, undefined, storage);
+    const rootId = settledParent(store, ["viewer"]);
+    const worker = admittedDelegatedChild(store, rootId);
+    const honestRoot = store.beginSpawnRequest({ engine: "codex", cwd: "/repo" });
+
+    /* The worker rewrites its receipt's role, depth and parent into root shape
+       and helps itself to a connector. Its lineage edge is untouched. */
+    forgeJsonReceiptOrigin(registryPath, worker.launchId, ROOT_SHAPE, ["viewer", "test-connector"]);
+    /* The operator's own un-parented launch claims the same thing truthfully. */
+    forgeJsonReceiptOrigin(registryPath, honestRoot.receipt.launchId, ROOT_SHAPE, ["viewer", "test-connector"]);
+
+    const reloaded = new AgentRegistry(registryPath, undefined, undefined, storage);
+    expect(reloaded.snapshot().receipts[worker.launchId]!.launchProfile.mcpServers).toEqual(["viewer"]);
+    /* The honest root has no lineage edge to contradict it and keeps its grant,
+       so the denial is the contradiction and not a blanket receipt wipe. */
+    expect(reloaded.snapshot().receipts[honestRoot.receipt.launchId]!.launchProfile.mcpServers)
+      .toEqual(["viewer", "test-connector"]);
+
+    /* Settlement is the propagation path: it copies the receipt profile onto the
+       conversation generation and the entry row, and stamps the receipt's own
+       role and depth onto the conversation it creates. */
+    const settledWorker = settleAs(reloaded, worker.launchId, "forged-worker");
+    if (settledWorker.kind !== "settled") throw new Error("expected worker settlement");
+    const settledRoot = settleAs(reloaded, honestRoot.receipt.launchId, "honest-root");
+    if (settledRoot.kind !== "settled") throw new Error("expected root settlement");
+    const after = reloaded.snapshot();
+
+    expect(after.conversations[settledWorker.conversation.id]!.generations.at(-1)!.launchProfile.mcpServers).toEqual(["viewer"]);
+    expect(after.entries[entryRowKey("forged-worker")]?.launchProfile?.mcpServers).toEqual(["viewer"]);
+    expect(after.conversations[settledRoot.conversation.id]!.generations.at(-1)!.launchProfile.mcpServers)
+      .toEqual(["viewer", "test-connector"]);
+    expect(after.entries[entryRowKey("honest-root")]?.launchProfile?.mcpServers).toEqual(["viewer", "test-connector"]);
+  } finally {
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+test("a receipt forged into root shape is denied on every SQLite reader, and on claim after it settles", () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-mcp-receipt-origin-sqlite-"));
+  const registryPath = path.join(directory, "agent-registry.json");
+  const sqlitePath = path.join(directory, "agent-registry.sqlite");
+  const storage = { sqliteMode: "sqlite" as const, mcpGrantPolicy: WITH_CONNECTOR };
+  try {
+    const store = new AgentRegistry(registryPath, undefined, undefined, storage);
+    const rootId = settledParent(store, ["viewer"]);
+    const worker = admittedDelegatedChild(store, rootId);
+
+    forgeSqliteReceiptOrigin(sqlitePath, worker.launchId, ROOT_SHAPE, ["viewer", "test-connector"]);
+
+    const reopened = new AgentRegistry(registryPath, undefined, undefined, storage);
+    /* readOnlySnapshot is what boot ADOPTION filters from; snapshot is what
+       structured RECOVERY reads through. */
+    expect(reopened.readOnlySnapshot().receipts[worker.launchId]!.launchProfile.mcpServers).toEqual(["viewer"]);
+    expect(reopened.snapshot().receipts[worker.launchId]!.launchProfile.mcpServers).toEqual(["viewer"]);
+
+    /* Settle it anyway. Settlement stamps the receipt's OWN role and depth onto
+       the conversation it creates, so the row now on disk reads `agentRole:
+       null, delegationDepth: 0` — an operator root by its own account. The
+       conversation's origin alone can no longer tell; only the lineage edge
+       admission wrote, which settlement never touches, still says otherwise. */
+    const settled = settleAs(reopened, worker.launchId, "sqlite-forged-worker");
+    if (settled.kind !== "settled") throw new Error("expected worker settlement");
+    structuredRow(reopened, "sqlite-forged-worker");
+    structuredRow(reopened, "nested-parent");
+    const workerRow = entryRowKey("sqlite-forged-worker");
+    const rootRow = entryRowKey("nested-parent");
+    expect(reopened.snapshot().conversations[settled.conversation.id]!.delegationDepth).toBe(0);
+
+    /* And it helps itself to the connector on every row it now owns. */
+    tamperSqliteGrant(sqlitePath, [
+      { collection: "entries", key: workerRow },
+      { collection: "conversations", key: settled.conversation.id },
+      { collection: "entries", key: rootRow },
+      { collection: "conversations", key: rootId },
+    ], ["viewer", "test-connector"]);
+
+    const settledView = new AgentRegistry(registryPath, undefined, undefined, storage);
+    expect(settledView.readOnlySnapshot().entries[workerRow]?.launchProfile?.mcpServers).toEqual(["viewer"]);
+    expect(settledView.snapshot().conversations[settled.conversation.id]!.generations.at(-1)!.launchProfile.mcpServers)
+      .toEqual(["viewer"]);
+    /* And the CLAIM mutation, which hands a host one row of its own. */
+    const claimed = settledView.claimStructuredHost(
+      { engine: "codex", sessionId: sessionIdFor("sqlite-forged-worker") },
+      { pid: process.pid, startIdentity: null },
+      { allowUnhosted: true },
+    );
+    expect(claimed).not.toBeNull();
+    expect(claimed?.launchProfile?.mcpServers).toEqual(["viewer"]);
+    /* The operator root has no lineage edge contradicting it and keeps the
+       grant on all three, so none of the above is a blanket wipe. */
+    expect(settledView.readOnlySnapshot().entries[rootRow]?.launchProfile?.mcpServers).toEqual(["viewer", "test-connector"]);
+    expect(settledView.snapshot().conversations[rootId]!.generations.at(-1)!.launchProfile.mcpServers)
+      .toEqual(["viewer", "test-connector"]);
+    expect(settledView.claimStructuredHost({ engine: "codex", sessionId: sessionIdFor("nested-parent") }, { pid: process.pid, startIdentity: null }, { allowUnhosted: true })
+      ?.launchProfile?.mcpServers).toEqual(["viewer", "test-connector"]);
+  } finally {
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+test("a receipt whose self-description disagrees with the rows attesting to it is denied in either direction", () => {
+  const grant = ["viewer", "test-connector"];
+  const fileWith = (
+    receipt: ReceiptForgery & { conversationId: string },
+    rows: { conversation?: { delegationDepth: number | null; agentRole: string | null }; edgeParent?: string },
+  ) => ({
+    conversations: rows.conversation
+      ? { [receipt.conversationId]: { engine: "codex", ...rows.conversation, generations: [] } }
+      : {},
+    lineageEdges: rows.edgeParent ? { [receipt.conversationId]: { parentConversationId: rows.edgeParent } } : {},
+    entries: {},
+    receipts: { launch: { ...receipt, launchProfile: { mcpServers: [...grant] } } },
+  } as unknown as StoredGrantFile);
+  const grantOf = (file: StoredGrantFile) =>
+    reboundAssembledMcpGrants(file, WITH_CONNECTOR).receipts!.launch!.launchProfile!.mcpServers;
+
+  /* Claims root; its lineage edge records a parent. The forgery direction. */
+  expect(grantOf(fileWith(
+    { conversationId: "conversation_worker", ...ROOT_SHAPE },
+    { edgeParent: "conversation_root" },
+  ))).toEqual(["viewer"]);
+
+  /* Claims delegated; the conversation attesting to it is an operator root.
+     Denied too — resolving a contradiction by believing whichever row is more
+     generous is how a tamper signal turns into an authorisation. */
+  expect(grantOf(fileWith(
+    { conversationId: "conversation_root", agentRole: "builder", delegationDepth: 1, parentConversationId: null },
+    { conversation: { agentRole: null, delegationDepth: 0 } },
+  ))).toEqual(["viewer"]);
+
+  /* Agreeing rows keep the grant, so neither denial above is a blanket wipe. */
+  expect(grantOf(fileWith(
+    { conversationId: "conversation_root", ...ROOT_SHAPE },
+    { conversation: { agentRole: null, delegationDepth: 0 } },
+  ))).toEqual(grant);
+  /* And an un-parented launch that has not settled has nothing attesting to it
+     yet, which is not a contradiction — it still only narrows. */
+  expect(grantOf(fileWith({ conversationId: "conversation_fresh", ...ROOT_SHAPE }, {}))).toEqual(grant);
+  expect(grantOf(fileWith(
+    { conversationId: "conversation_fresh", agentRole: "builder", delegationDepth: 1, parentConversationId: null },
+    {},
+  ))).toEqual(["viewer"]);
+});
+
+test("a conversation whose lineage edge contradicts its own row is denied rather than believed", () => {
+  const grant = ["viewer", "test-connector"];
+  /* The row settlement writes from a receipt forged into root shape: depth 0,
+     no role, no parent — while the edge admission wrote still records a parent.
+     Two rows, one of them lying, and no way to tell which. */
+  const contradicted = () => ({
+    conversations: {
+      conversation_worker: {
+        id: "conversation_worker",
+        engine: "codex",
+        agentRole: null,
+        delegationDepth: 0,
+        generations: [{
+          id: "worker-generation",
+          path: "/sessions/worker.jsonl",
+          launchProfile: { ...emptyLaunchProfile(), parentConversationId: null, mcpServers: [...grant] },
+        }],
+      },
+    },
+    lineageEdges: {
+      conversation_worker: { childConversationId: "conversation_worker", parentConversationId: "conversation_root" },
+    },
+    entries: {
+      "codex:worker-generation": { artifactPath: "/sessions/worker.jsonl", launchProfile: { mcpServers: [...grant] } },
+    },
+  } as unknown as StoredGrantFile);
+
+  const rebounded = reboundAssembledMcpGrants(contradicted(), WITH_CONNECTOR);
+  expect(rebounded.conversations.conversation_worker!.generations[0]!.launchProfile.mcpServers).toEqual(["viewer"]);
+  expect(rebounded.entries["codex:worker-generation"]!.launchProfile!.mcpServers).toEqual(["viewer"]);
+
+  /* Drop the edge and the same row is an ordinary operator root again, so the
+     denial above is the contradiction rather than the row's own shape. */
+  const uncontradicted = contradicted();
+  delete (uncontradicted as { lineageEdges?: unknown }).lineageEdges;
+  expect(reboundAssembledMcpGrants(uncontradicted, WITH_CONNECTOR)
+    .conversations.conversation_worker!.generations[0]!.launchProfile.mcpServers).toEqual(grant);
+});
+
 test("a SQLite-authoritative registry re-bounds a tampered entry row on the paths adoption reads", () => {
   const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-mcp-sqlite-tamper-"));
   const registryPath = path.join(directory, "agent-registry.json");

--- a/src/lib/agent/mcpAllowlist.test.ts
+++ b/src/lib/agent/mcpAllowlist.test.ts
@@ -4,9 +4,16 @@ import os from "node:os";
 import path from "node:path";
 
 import { emptyLaunchProfile } from "@/lib/accounts/migration/contracts";
+import { headlessCodexThreadConfig } from "@/lib/codexHeadlessConfig";
 import { AgentRegistry } from "./registry";
 
-import { normalizeSpawnMcpServers } from "./mcpAllowlist";
+import {
+  GRANTABLE_MCP_SERVERS,
+  defaultMcpServersForOrigin,
+  grantedMcpServers,
+  mcpServersForSession,
+  normalizeSpawnMcpServers,
+} from "./mcpAllowlist";
 
 test("a spawn without an MCP selection receives Viewer only", () => {
   expect(normalizeSpawnMcpServers(undefined)).toEqual({ ok: true, value: ["viewer"] });
@@ -24,6 +31,54 @@ test("malformed MCP selections are rejected", () => {
       error: "mcpServers must be an array of non-empty server names",
     });
   }
+});
+
+test("an MCP server outside the grant bound is rejected, never silently dropped", () => {
+  /* Actionable: the caller learns the bound and which name failed, instead of
+     receiving a quietly trimmed allowlist it believes it got in full. The
+     grantable `viewer` alongside it does not rescue the request. */
+  expect(normalizeSpawnMcpServers(["viewer", "telegram"])).toEqual({
+    ok: false,
+    error: `mcpServers may only contain ${GRANTABLE_MCP_SERVERS.join(", ")}; rejected: telegram`,
+  });
+  expect(normalizeSpawnMcpServers(["*"])).toMatchObject({ ok: false });
+  expect(normalizeSpawnMcpServers(["all"])).toMatchObject({ ok: false });
+});
+
+test("a delegated spawn cannot obtain a grantable connector and keeps its Viewer baseline", () => {
+  expect(defaultMcpServersForOrigin("delegated")).toEqual(["viewer"]);
+  expect(mcpServersForSession({ origin: "delegated", requested: ["viewer", "agent-browser"] }))
+    .toEqual(["viewer"]);
+  expect(mcpServersForSession({ origin: "delegated", requested: null })).toEqual(["viewer"]);
+});
+
+test("an operator-root spawn receives the grantable connector it requests", () => {
+  expect(defaultMcpServersForOrigin("operator-root")).toEqual([...GRANTABLE_MCP_SERVERS]);
+  expect(mcpServersForSession({ origin: "operator-root", requested: ["viewer", "agent-browser"] }))
+    .toEqual(["viewer", "agent-browser"]);
+});
+
+test("an empty selection stays the explicit opt-out and still yields Viewer", () => {
+  const requested = normalizeSpawnMcpServers([]);
+  expect(requested).toEqual({ ok: true, value: ["viewer"] });
+  expect(mcpServersForSession({ origin: "operator-root", requested: requested.ok ? requested.value : null }))
+    .toEqual(["viewer"]);
+  expect(mcpServersForSession({ origin: "delegated", requested: [] })).toEqual(["viewer"]);
+});
+
+test("a launch profile hand-edited to carry an ungranted server is re-bounded at the point of use", () => {
+  expect(grantedMcpServers(["viewer", "telegram", "agent-browser"])).toEqual(["viewer", "agent-browser"]);
+  expect(grantedMcpServers(undefined)).toEqual(["viewer"]);
+  /* Durable storage re-bounds the edit as it is written, and every engine's
+     enable table is materialized from the re-validated list, never the stored
+     one — a profile edited behind the Viewer's back grants nothing. */
+  expect(emptyLaunchProfile({ mcpServers: ["viewer", "telegram"] }).mcpServers).toEqual(["viewer"]);
+  const thread = headlessCodexThreadConfig({
+    config: { mcp_servers: { viewer: {}, telegram: {}, "agent-browser": {} } },
+  }, false, ["viewer", "telegram", "agent-browser"]) as { mcp_servers: Record<string, { enabled: boolean }> };
+  expect(thread.mcp_servers.viewer.enabled).toBe(true);
+  expect(thread.mcp_servers["agent-browser"].enabled).toBe(true);
+  expect(thread.mcp_servers.telegram.enabled).toBe(false);
 });
 
 test("durable launch profiles reset each new spawn to Viewer only", () => {

--- a/src/lib/agent/mcpAllowlist.test.ts
+++ b/src/lib/agent/mcpAllowlist.test.ts
@@ -6,7 +6,7 @@ import path from "node:path";
 
 import { emptyLaunchProfile } from "@/lib/accounts/migration/contracts";
 import { headlessCodexThreadConfig } from "@/lib/codexHeadlessConfig";
-import { AgentRegistry, normalizeRegistry } from "./registry";
+import { AgentRegistry, normalizeRegistry, type RegistryFile } from "./registry";
 import { SqliteAgentRegistryStore } from "./sqliteRegistryStore";
 
 import {
@@ -920,6 +920,93 @@ test("a receipt whose self-description disagrees with the rows attesting to it i
   ))).toEqual(["viewer"]);
 });
 
+test("a receipt cannot shed the lineage attesting to it by retargeting the conversation it names", () => {
+  const grant = ["viewer", "test-connector"];
+  /* The worker rewrites itself into root shape AND points `conversationId` at
+     the operator root, so every attestor reachable through a pointer it owns
+     now agrees with it. The edge admission wrote is indexed by the launch id in
+     the EDGE's own evidence, so it still names this receipt whatever the
+     receipt says about itself. */
+  const retargeted = (conversationId: string | null, launchId = "launch") => ({
+    conversations: {
+      conversation_root: { engine: "codex", agentRole: null, delegationDepth: 0, generations: [] },
+    },
+    lineageEdges: {
+      conversation_worker: { parentConversationId: "conversation_root", evidence: { launchId } },
+    },
+    entries: {},
+    receipts: { launch: { conversationId, ...ROOT_SHAPE, launchProfile: { mcpServers: [...grant] } } },
+  } as unknown as StoredGrantFile);
+  const grantOf = (file: StoredGrantFile) =>
+    reboundAssembledMcpGrants(file, WITH_CONNECTOR).receipts!.launch!.launchProfile!.mcpServers;
+
+  /* Named at the operator root, whose own row attests root truthfully. */
+  expect(grantOf(retargeted("conversation_root"))).toEqual(["viewer"]);
+  /* And blanked, so no pointer-reachable row attests to it at all. */
+  expect(grantOf(retargeted(null))).toEqual(["viewer"]);
+  /* An edge naming a DIFFERENT launch leaves this receipt genuinely unattested
+     and it keeps the grant, so the denials above are this receipt's own lineage
+     rather than any edge anywhere existing. */
+  expect(grantOf(retargeted("conversation_root", "other-launch"))).toEqual(grant);
+});
+
+test("a receipt claiming root is denied by a delegated attestor no lineage edge names", () => {
+  const grant = ["viewer", "test-connector"];
+  /* No lineage edge exists here at all, so the only rows that can contradict the
+     receipt are the two it points at itself: the conversation it names, and the
+     conversation owning the entry row its key settled onto. Both still deny,
+     which is the point of collecting them — following a pointer the subject
+     controls can only ever ADD a contradiction, never supply the origin. */
+  const delegatedOwner = (receipt: Record<string, unknown>) => ({
+    conversations: {
+      conversation_worker: {
+        engine: "codex",
+        agentRole: "builder",
+        delegationDepth: 1,
+        generations: [{
+          id: "worker-generation",
+          path: "/sessions/worker.jsonl",
+          launchProfile: { parentConversationId: null, mcpServers: ["viewer"] },
+        }],
+      },
+    },
+    lineageEdges: {},
+    entries: {},
+    receipts: { launch: { ...ROOT_SHAPE, ...receipt, launchProfile: { mcpServers: [...grant] } } },
+  } as unknown as StoredGrantFile);
+  const grantOf = (file: StoredGrantFile) =>
+    reboundAssembledMcpGrants(file, WITH_CONNECTOR).receipts!.launch!.launchProfile!.mcpServers;
+
+  /* The conversation it names is delegated by its own role and depth. */
+  expect(grantOf(delegatedOwner({ conversationId: "conversation_worker" }))).toEqual(["viewer"]);
+  /* It names no conversation, but its key settled onto the row that one owns. */
+  expect(grantOf(delegatedOwner({ conversationId: null, key: { engine: "codex", sessionId: "worker-generation" } })))
+    .toEqual(["viewer"]);
+  /* A key pointing at a row no generation owns attests nothing and the receipt
+     keeps its grant, so both denials are the delegated OWNER rather than the
+     receipt merely carrying a key. */
+  expect(grantOf(delegatedOwner({ conversationId: null, key: { engine: "codex", sessionId: "unowned-generation" } })))
+    .toEqual(grant);
+
+  /* Two conversations claiming one entry row key with different origins name no
+     owner at all. A receipt keyed at that row is denied rather than handed
+     whichever of the two readings suits it. */
+  const disputed = delegatedOwner({ conversationId: null, key: { engine: "codex", sessionId: "worker-generation" } }) as unknown as {
+    conversations: Record<string, unknown>;
+  };
+  disputed.conversations.conversation_root = {
+    engine: "codex",
+    agentRole: null,
+    delegationDepth: 0,
+    generations: [{
+      id: "worker-generation",
+      path: null,
+      launchProfile: { parentConversationId: null, mcpServers: ["viewer"] },
+    }],
+  };
+  expect(grantOf(disputed as unknown as StoredGrantFile)).toEqual(["viewer"]);
+});
+
 test("a conversation whose lineage edge contradicts its own row is denied rather than believed", () => {
   const grant = ["viewer", "test-connector"];
   /* The row settlement writes from a receipt forged into root shape: depth 0,
@@ -1102,4 +1189,206 @@ test("an entry no conversation owns keeps its grant per row and loses it in an a
      evidence exists for it, so it falls back to the baseline. */
   const assembled = reboundAssembledMcpGrants(orphan(), WITH_CONNECTOR);
   expect(assembled.entries["codex:orphan"]!.launchProfile!.mcpServers).toEqual(["viewer"]);
+});
+
+/**
+ * Every `SqliteAgentRegistryStore` method that reaches a row writer, read out of
+ * the SOURCE rather than listed by hand.
+ *
+ * The origin half of the grant bound is a PRECONDITION of a row being observed
+ * or written, and this lane has now reopened that ordering twice — once because
+ * a mutation ran on lazily normalized rows, once because a wholesale
+ * replacement carried its payload in from outside. A new mutation path is the
+ * obvious third way in, so it has to fail here until somebody exercises it,
+ * rather than quietly inheriting whatever gate the path it was copied from had.
+ */
+function storeMutationEntryPoints(): string[] {
+  const lines = fs.readFileSync(path.join(import.meta.dir, "sqliteRegistryStore.ts"), "utf8").split("\n");
+  const writes = /this\.(persistAll|persistDiff|persistChanges)\(/;
+  const signature = /^ {2}(?:private |protected |public |static )*(?:async )?([A-Za-z_]\w*)\s*(?:<[^(]*>)?\(/;
+  const found = new Set<string>();
+  for (const [index, line] of lines.entries()) {
+    if (!writes.test(line)) continue;
+    for (let above = index; above >= 0; above -= 1) {
+      const match = signature.exec(lines[above]!);
+      if (!match) continue;
+      found.add(match[1]!);
+      break;
+    }
+  }
+  return [...found].sort();
+}
+
+function storedReceiptGrant(sqlitePath: string, launchId: string): string[] {
+  const db = new Database(sqlitePath, { strict: true });
+  try {
+    const row = db.query<{ value_json: string }, [string, string]>(
+      "SELECT value_json FROM registry_rows WHERE collection = ? AND row_key = ?",
+    ).get("receipts", launchId);
+    if (!row) throw new Error(`expected a stored receipts row for ${launchId}`);
+    return (JSON.parse(row.value_json) as { launchProfile: { mcpServers: string[] } }).launchProfile.mcpServers;
+  } finally {
+    db.close();
+  }
+}
+
+/** The same forgery `forgeSqliteReceiptOrigin` writes, applied to a file the
+    caller is about to hand a store, for the entry points whose payload arrives
+    from outside rather than off disk. */
+function forgeReceiptOriginInFile(file: RegistryFile, launchId: string, forgery: ReceiptForgery, grant: string[]): void {
+  const receipt = file.receipts[launchId] as unknown as ReceiptForgery & { launchProfile: Record<string, unknown> };
+  if (!receipt) throw new Error(`expected a receipt for ${launchId}`);
+  Object.assign(receipt, forgery);
+  receipt.launchProfile = { ...receipt.launchProfile, parentConversationId: null, mcpServers: [...grant] };
+}
+
+test("every SQLite store mutation entry point re-decides grants before it can persist a row", () => {
+  const grant = ["viewer", "test-connector"];
+  const storage = { sqliteMode: "sqlite" as const, mcpGrantPolicy: WITH_CONNECTOR };
+  const storeOptions = {
+    normalize: (value: unknown) => normalizeRegistry(value, WITH_CONNECTOR),
+    mcpGrantPolicy: WITH_CONNECTOR,
+  };
+
+  /** A forged delegated receipt and an honest root one, both admitted and
+      unsettled, on a real registry backed by SQLite. */
+  const seed = (label: string) => {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), `llv-mcp-entrypoint-${label}-`));
+    const sqlitePath = path.join(directory, "agent-registry.sqlite");
+    const registry = new AgentRegistry(path.join(directory, "agent-registry.json"), undefined, undefined, storage);
+    const rootId = settledParent(registry, ["viewer"], `entrypoint-parent-${label}`);
+    const workerId = settledDelegatedChild(registry, rootId, `entrypoint-worker-${label}`);
+    const forged = admittedDelegatedChild(registry, rootId).launchId;
+    const honest = registry.beginSpawnRequest({ engine: "codex", cwd: "/repo" }).receipt.launchId;
+    return { directory, sqlitePath, registry, rootId, workerId, forged, honest };
+  };
+
+  /** A conversation row rewritten into root shape and helped to a connector, on
+      its GENERATIONS and nowhere else. Its lineage edge is left alone.
+
+      The row-at-a-time normalize decides a conversation from its own origin
+      fields, which this rewrite now satisfies, so only the assembled decision —
+      which can see the edge still recording a parent — denies it. That makes
+      this the case where the gate has to look INSIDE the row: the grant it
+      claims lives on a nested generation profile, not at the row's top level. */
+  const forgeConversationIntoRoot = (sqlitePath: string, conversationId: string, intoRoot: boolean) => {
+    const db = new Database(sqlitePath, { strict: true });
+    try {
+      const row = db.query<{ value_json: string }, [string, string]>(
+        "SELECT value_json FROM registry_rows WHERE collection = ? AND row_key = ?",
+      ).get("conversations", conversationId);
+      if (!row) throw new Error(`expected a stored conversations row for ${conversationId}`);
+      const parsed = JSON.parse(row.value_json) as {
+        agentRole: string | null;
+        delegationDepth: number | null;
+        generations: { launchProfile: { mcpServers: string[]; parentConversationId: string | null } }[];
+      };
+      if (intoRoot) {
+        parsed.agentRole = null;
+        parsed.delegationDepth = 0;
+      }
+      for (const generation of parsed.generations) {
+        generation.launchProfile.mcpServers = [...grant];
+        if (intoRoot) generation.launchProfile.parentConversationId = null;
+      }
+      db.query<unknown, [string, string, string]>(
+        "UPDATE registry_rows SET value_json = ? WHERE collection = ? AND row_key = ?",
+      ).run(JSON.stringify(parsed), "conversations", conversationId);
+    } finally {
+      db.close();
+    }
+  };
+
+  /* Each entry point is driven for real, with the forgery arriving the way that
+     entry point receives its payload. The honest root's receipt rides along
+     through the same call, so a gate that simply wiped every grant would fail
+     here rather than pass. */
+  const exercises: Record<string, () => void> = {
+    /* Two routes to a row, each on its own seed so neither can cover for the
+       other: whichever read comes FIRST in a mutation is the one that has to
+       run the decision, and a second read afterwards would hide a first that
+       did not. */
+    mutate: () => {
+      const receipts = seed("mutate-receipts");
+      try {
+        forgeSqliteReceiptOrigin(receipts.sqlitePath, receipts.forged, ROOT_SHAPE, grant);
+        forgeSqliteReceiptOrigin(receipts.sqlitePath, receipts.honest, ROOT_SHAPE, grant);
+        const store = new SqliteAgentRegistryStore(receipts.sqlitePath, {
+          ...storeOptions,
+          initialSnapshot: normalizeRegistry({ version: 2, entries: {}, receipts: {} }, WITH_CONNECTOR),
+        });
+        /* What settlement and the structured claim do: reach for the receipt row
+           by key, here out of the cache a preceding enumeration filled — the
+           route a boot sweep takes, and a second way in that has to be gated as
+           the keyed one is. The row the operation sees is already decided, and
+           the decision is what the mutation then persists. */
+        const seenByOperation = store.mutate((file) => {
+          expect(Object.keys(file.receipts)).toContain(receipts.forged);
+          return [
+            file.receipts[receipts.forged]!.launchProfile.mcpServers,
+            file.receipts[receipts.honest]!.launchProfile.mcpServers,
+          ];
+        }).result;
+        expect(seenByOperation).toEqual([["viewer"], grant]);
+        expect(storedReceiptGrant(receipts.sqlitePath, receipts.forged)).toEqual(["viewer"]);
+        expect(storedReceiptGrant(receipts.sqlitePath, receipts.honest)).toEqual(grant);
+      } finally {
+        fs.rmSync(receipts.directory, { recursive: true, force: true });
+      }
+
+      const conversations = seed("mutate-conversations");
+      try {
+        forgeConversationIntoRoot(conversations.sqlitePath, conversations.workerId, true);
+        forgeConversationIntoRoot(conversations.sqlitePath, conversations.rootId, false);
+        const store = new SqliteAgentRegistryStore(conversations.sqlitePath, {
+          ...storeOptions,
+          initialSnapshot: normalizeRegistry({ version: 2, entries: {}, receipts: {} }, WITH_CONNECTOR),
+        });
+        /* Nothing else is read first. A conversation row claims a grant only
+           through a profile NESTED in its generations, so a gate that looked no
+           deeper than the row's top level would hand this one over untouched. */
+        const seenByOperation = store.mutate((file) => [
+          file.conversations[conversations.workerId]!.generations.at(-1)!.launchProfile.mcpServers,
+          file.conversations[conversations.rootId]!.generations.at(-1)!.launchProfile.mcpServers,
+        ]).result;
+        expect(seenByOperation).toEqual([["viewer"], grant]);
+      } finally {
+        fs.rmSync(conversations.directory, { recursive: true, force: true });
+      }
+    },
+    replace: () => {
+      const { directory, sqlitePath, registry, forged, honest } = seed("replace");
+      try {
+        const store = new SqliteAgentRegistryStore(sqlitePath, {
+          ...storeOptions,
+          initialSnapshot: normalizeRegistry({ version: 2, entries: {}, receipts: {} }, WITH_CONNECTOR),
+        });
+        const file = registry.snapshot();
+        forgeReceiptOriginInFile(file, forged, ROOT_SHAPE, grant);
+        forgeReceiptOriginInFile(file, honest, ROOT_SHAPE, grant);
+        expect(store.replace(file, store.revision()).replaced).toBe(true);
+        expect(storedReceiptGrant(sqlitePath, forged)).toEqual(["viewer"]);
+        expect(storedReceiptGrant(sqlitePath, honest)).toEqual(grant);
+      } finally {
+        fs.rmSync(directory, { recursive: true, force: true });
+      }
+    },
+    importFirstBoot: () => {
+      const { directory, registry, forged, honest } = seed("import");
+      try {
+        const file = registry.snapshot();
+        forgeReceiptOriginInFile(file, forged, ROOT_SHAPE, grant);
+        forgeReceiptOriginInFile(file, honest, ROOT_SHAPE, grant);
+        const importedPath = path.join(directory, "imported.sqlite");
+        new SqliteAgentRegistryStore(importedPath, { ...storeOptions, initialSnapshot: file });
+        expect(storedReceiptGrant(importedPath, forged)).toEqual(["viewer"]);
+        expect(storedReceiptGrant(importedPath, honest)).toEqual(grant);
+      } finally {
+        fs.rmSync(directory, { recursive: true, force: true });
+      }
+    },
+  };
+
+  expect(storeMutationEntryPoints()).toEqual(Object.keys(exercises).sort());
+  for (const exercise of Object.values(exercises)) exercise();
 });

--- a/src/lib/agent/mcpAllowlist.test.ts
+++ b/src/lib/agent/mcpAllowlist.test.ts
@@ -175,16 +175,32 @@ test("durable launch profiles reset each new spawn to Viewer only", () => {
   expect(emptyLaunchProfile().mcpServers).toEqual(["viewer"]);
 });
 
-function settledParent(store: AgentRegistry, mcpServers: string[]) {
-  const parent = store.beginSpawnRequest({
-    engine: "codex",
-    cwd: "/repo",
-    launchProfile: { mcpServers },
-  });
-  if (parent.kind !== "created") throw new Error("expected parent reservation");
-  const settled = store.settleSpawn(parent.receipt.launchId, {
-    key: { engine: "codex", sessionId: "nested-parent" },
-    artifactPath: "/sessions/nested-parent.jsonl",
+/* A session id and its transcript, in the shapes production actually uses. The
+   registry derives a generation's id from the transcript FILENAME
+   (`nativeGenerationId`), and an entry's row key from its session key, so the
+   two agree only when the file is named `<session-uuid>.jsonl` — which is what
+   both engines write. A fixture named `/sessions/worker.jsonl` instead makes the
+   registry synthesize a random generation id that no entry row key can ever
+   match, and would test the ownership link against a shape that never exists. */
+const sessionIds = new Map<string, string>();
+function sessionIdFor(label: string): string {
+  const existing = sessionIds.get(label);
+  if (existing) return existing;
+  const created = crypto.randomUUID();
+  sessionIds.set(label, created);
+  return created;
+}
+function transcriptFor(label: string): string {
+  return `/sessions/${sessionIdFor(label)}.jsonl`;
+}
+function entryRowKey(label: string): string {
+  return `codex:${sessionIdFor(label)}`;
+}
+
+function settleAs(store: AgentRegistry, launchId: string, label: string) {
+  return store.settleSpawn(launchId, {
+    key: { engine: "codex", sessionId: sessionIdFor(label) },
+    artifactPath: transcriptFor(label),
     cwd: "/repo",
     accountId: "account",
     status: "idle",
@@ -193,6 +209,16 @@ function settledParent(store: AgentRegistry, mcpServers: string[]) {
     claimOwner: null,
     pendingAction: null,
   });
+}
+
+function settledParent(store: AgentRegistry, mcpServers: string[], label = "nested-parent") {
+  const parent = store.beginSpawnRequest({
+    engine: "codex",
+    cwd: "/repo",
+    launchProfile: { mcpServers },
+  });
+  if (parent.kind !== "created") throw new Error("expected parent reservation");
+  const settled = settleAs(store, parent.receipt.launchId, label);
   if (settled.kind !== "settled") throw new Error("expected parent settlement");
   return settled.conversation.id;
 }
@@ -305,15 +331,15 @@ test("a delegated conversation cannot keep a hand-edited grant across resume or 
     tamperJsonGrant(registryPath, ["viewer", "test-connector"]);
 
     const reloaded = new AgentRegistry(registryPath, undefined, undefined, storage);
-    expect(reloaded.launchProfileForPath("/sessions/delegated-worker.jsonl")?.mcpServers).toEqual(["viewer"]);
+    expect(reloaded.launchProfileForPath(transcriptFor("delegated-worker"))?.mcpServers).toEqual(["viewer"]);
     const snapshot = reloaded.snapshot();
-    expect(snapshot.entries["codex:delegated-worker"]?.launchProfile?.mcpServers).toEqual(["viewer"]);
+    expect(snapshot.entries[entryRowKey("delegated-worker")]?.launchProfile?.mcpServers).toEqual(["viewer"]);
     expect(snapshot.conversations[workerId]!.generations.at(-1)!.launchProfile.mcpServers).toEqual(["viewer"]);
     /* The operator root's own rows keep the tampered grant, because its stored
        origin proves it may hold one. Without this control the assertions above
        would also pass if the read simply wiped every grant it saw. */
-    expect(reloaded.launchProfileForPath("/sessions/nested-parent.jsonl")?.mcpServers).toEqual(["viewer", "test-connector"]);
-    expect(snapshot.entries["codex:nested-parent"]?.launchProfile?.mcpServers).toEqual(["viewer", "test-connector"]);
+    expect(reloaded.launchProfileForPath(transcriptFor("nested-parent"))?.mcpServers).toEqual(["viewer", "test-connector"]);
+    expect(snapshot.entries[entryRowKey("nested-parent")]?.launchProfile?.mcpServers).toEqual(["viewer", "test-connector"]);
     expect(snapshot.conversations[parentId]!.generations.at(-1)!.launchProfile.mcpServers).toEqual(["viewer", "test-connector"]);
 
     const resumedWorker = reloaded.beginSpawnRequest({
@@ -357,19 +383,9 @@ test("a tampered receipt cannot carry a grant into settlement or attach", () => 
     tamperJsonGrant(registryPath, ["viewer", "test-connector"]);
 
     const reloaded = new AgentRegistry(registryPath, undefined, undefined, storage);
-    const settle = (launchId: string, sessionId: string) => {
-      const settled = reloaded.settleSpawn(launchId, {
-        key: { engine: "codex", sessionId },
-        artifactPath: `/sessions/${sessionId}.jsonl`,
-        cwd: "/repo",
-        accountId: "account",
-        status: "idle",
-        host: null,
-        claimEpoch: 0,
-        claimOwner: null,
-        pendingAction: null,
-      });
-      if (settled.kind !== "settled") throw new Error(`expected ${sessionId} settlement`);
+    const settle = (launchId: string, label: string) => {
+      const settled = settleAs(reloaded, launchId, label);
+      if (settled.kind !== "settled") throw new Error(`expected ${label} settlement`);
       return settled.conversation.id;
     };
 
@@ -381,18 +397,18 @@ test("a tampered receipt cannot carry a grant into settlement or attach", () => 
        copy settlement writes ever holds the connector. */
     expect(snapshot.receipts[worker.receipt.launchId]!.launchProfile.mcpServers).toEqual(["viewer"]);
     expect(snapshot.conversations[workerId]!.generations.at(-1)!.launchProfile.mcpServers).toEqual(["viewer"]);
-    expect(snapshot.entries["codex:receipt-worker"]?.launchProfile?.mcpServers).toEqual(["viewer"]);
+    expect(snapshot.entries[entryRowKey("receipt-worker")]?.launchProfile?.mcpServers).toEqual(["viewer"]);
     /* The operator root's receipt keeps it through the same reload and the same
        settlement, so the reset above is the origin rule, not a blanket wipe. */
     expect(snapshot.receipts[root.receipt.launchId]!.launchProfile.mcpServers).toEqual(["viewer", "test-connector"]);
     expect(snapshot.conversations[rootId]!.generations.at(-1)!.launchProfile.mcpServers).toEqual(["viewer", "test-connector"]);
-    expect(snapshot.entries["codex:receipt-root"]?.launchProfile?.mcpServers).toEqual(["viewer", "test-connector"]);
+    expect(snapshot.entries[entryRowKey("receipt-root")]?.launchProfile?.mcpServers).toEqual(["viewer", "test-connector"]);
   } finally {
     fs.rmSync(directory, { recursive: true, force: true });
   }
 });
 
-function settledDelegatedChild(store: AgentRegistry, parentId: string, sessionId: string) {
+function settledDelegatedChild(store: AgentRegistry, parentId: string, label: string) {
   const child = store.beginSpawnRequest({
     engine: "codex",
     cwd: "/repo",
@@ -401,27 +417,17 @@ function settledDelegatedChild(store: AgentRegistry, parentId: string, sessionId
     origin: { kind: "agent", conversationId: parentId as never },
   });
   if (child.kind !== "created") throw new Error("expected child reservation");
-  const settled = store.settleSpawn(child.receipt.launchId, {
-    key: { engine: "codex", sessionId },
-    artifactPath: `/sessions/${sessionId}.jsonl`,
-    cwd: "/repo",
-    accountId: "account",
-    status: "idle",
-    host: null,
-    claimEpoch: 0,
-    claimOwner: null,
-    pendingAction: null,
-  });
+  const settled = settleAs(store, child.receipt.launchId, label);
   if (settled.kind !== "settled") throw new Error("expected child settlement");
   return settled.conversation.id;
 }
 
-function structuredRow(store: AgentRegistry, sessionId: string) {
+function structuredRow(store: AgentRegistry, label: string) {
   /* A structured host row is what boot adoption filters for and what a claim
      hands to `optionsFor`, so the claim path is exercised rather than skipped. */
   store.upsert({
-    key: { engine: "codex", sessionId },
-    artifactPath: `/sessions/${sessionId}.jsonl`,
+    key: { engine: "codex", sessionId: sessionIdFor(label) },
+    artifactPath: transcriptFor(label),
     cwd: "/repo",
     accountId: "account",
     status: "dead",
@@ -466,13 +472,211 @@ function tamperSqliteGrant(sqlitePath: string, rows: { collection: "entries" | "
   }
 }
 
+/** Rewrite ONE entry row's embedded identity, leaving its row KEY — the
+    storage-level identity a row does not get to choose — alone. This is the
+    escalation the origin rule alone does not see: the row keeps its own origin
+    and simply claims to be somebody else's session. */
+type IdentityForgery = { key?: { engine: string; sessionId: string }; artifactPath?: string };
+
+function forgeJsonEntryIdentity(registryPath: string, rowKey: string, forgery: IdentityForgery): void {
+  const raw = JSON.parse(fs.readFileSync(registryPath, "utf8")) as {
+    entries: Record<string, IdentityForgery>;
+  };
+  const entry = raw.entries[rowKey];
+  if (!entry) throw new Error(`expected a stored entry row for ${rowKey}`);
+  Object.assign(entry, forgery);
+  fs.writeFileSync(registryPath, JSON.stringify(raw));
+}
+
+function forgeSqliteEntryIdentity(sqlitePath: string, rowKey: string, forgery: IdentityForgery): void {
+  const db = new Database(sqlitePath, { strict: true });
+  try {
+    const row = db.query<{ value_json: string }, [string, string]>(
+      "SELECT value_json FROM registry_rows WHERE collection = ? AND row_key = ?",
+    ).get("entries", rowKey);
+    if (!row) throw new Error(`expected a stored entries row for ${rowKey}`);
+    db.query<unknown, [string, string, string]>(
+      "UPDATE registry_rows SET value_json = ? WHERE collection = ? AND row_key = ?",
+    ).run(JSON.stringify({ ...JSON.parse(row.value_json) as object, ...forgery }), "entries", rowKey);
+  } finally {
+    db.close();
+  }
+}
+
+/* Each forgery is exercised ALONE. Applying both at once would let either
+   check alone carry the case, and the other could be deleted unnoticed. */
+const IDENTITY_FORGERIES = [
+  {
+    what: "embedded session key",
+    forge: (): IdentityForgery => ({ key: { engine: "codex", sessionId: sessionIdFor("nested-parent") } }),
+  },
+  {
+    what: "transcript path",
+    forge: (): IdentityForgery => ({ artifactPath: transcriptFor("nested-parent") }),
+  },
+] as const;
+
+for (const { what, forge } of IDENTITY_FORGERIES) {
+  test(`a delegated entry cannot borrow the operator root's grant by forging its ${what} (JSON)`, () => {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-mcp-json-identity-"));
+    const registryPath = path.join(directory, "registry.json");
+    const storage = { sqliteMode: "off" as const, mcpGrantPolicy: WITH_CONNECTOR };
+    const workerRow = entryRowKey("json-identity-worker");
+    try {
+      const store = new AgentRegistry(registryPath, undefined, undefined, storage);
+      const rootId = settledParent(store, ["viewer"]);
+      settledDelegatedChild(store, rootId, "json-identity-worker");
+      /* The root legitimately holds the connector, so there is something worth
+         borrowing; the worker's own rows are reset by the origin rule. */
+      tamperJsonGrant(registryPath, ["viewer", "test-connector"]);
+      forgeJsonEntryIdentity(registryPath, workerRow, forge());
+
+      const reloaded = new AgentRegistry(registryPath, undefined, undefined, storage);
+      expect(reloaded.snapshot().entries[workerRow]?.launchProfile?.mcpServers).toEqual(["viewer"]);
+      expect(reloaded.readOnlySnapshot().entries[workerRow]?.launchProfile?.mcpServers).toEqual(["viewer"]);
+      /* The root's own row is untouched by the forgery and keeps its grant, so
+         the denial is the identity rule rather than a blanket wipe. */
+      expect(reloaded.snapshot().entries[entryRowKey("nested-parent")]?.launchProfile?.mcpServers)
+        .toEqual(["viewer", "test-connector"]);
+    } finally {
+      fs.rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  test(`a delegated entry cannot borrow the operator root's grant by forging its ${what} (SQLite, claim, adoption, recovery)`, () => {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-mcp-sqlite-identity-"));
+    const registryPath = path.join(directory, "agent-registry.json");
+    const sqlitePath = path.join(directory, "agent-registry.sqlite");
+    const storage = { sqliteMode: "sqlite" as const, mcpGrantPolicy: WITH_CONNECTOR };
+    const workerRow = entryRowKey("sqlite-identity-worker");
+    const rootRow = entryRowKey("nested-parent");
+    try {
+      const store = new AgentRegistry(registryPath, undefined, undefined, storage);
+      const rootId = settledParent(store, ["viewer"]);
+      const workerId = settledDelegatedChild(store, rootId, "sqlite-identity-worker");
+      structuredRow(store, "sqlite-identity-worker");
+      structuredRow(store, "nested-parent");
+
+      tamperSqliteGrant(sqlitePath, [
+        { collection: "entries", key: workerRow },
+        { collection: "conversations", key: workerId },
+        { collection: "entries", key: rootRow },
+        { collection: "conversations", key: rootId },
+      ], ["viewer", "test-connector"]);
+      forgeSqliteEntryIdentity(sqlitePath, workerRow, forge());
+
+      const reopened = new AgentRegistry(registryPath, undefined, undefined, storage);
+      /* readOnlySnapshot is what boot ADOPTION filters rows from; snapshot is
+         what structured RECOVERY reads a profile and cursor through. */
+      expect(reopened.readOnlySnapshot().entries[workerRow]?.launchProfile?.mcpServers).toEqual(["viewer"]);
+      expect(reopened.snapshot().entries[workerRow]?.launchProfile?.mcpServers).toEqual(["viewer"]);
+      /* And the CLAIM mutation, which hands a host one row and never sees an
+         assembled snapshot at all. */
+      const owner = { pid: process.pid, startIdentity: null };
+      const claimed = reopened.claimStructuredHost(
+        { engine: "codex", sessionId: sessionIdFor("sqlite-identity-worker") },
+        owner,
+        { allowUnhosted: true },
+      );
+      expect(claimed).not.toBeNull();
+      expect(claimed?.launchProfile?.mcpServers).toEqual(["viewer"]);
+      /* The operator root keeps its grant on every one of those paths. */
+      expect(reopened.readOnlySnapshot().entries[rootRow]?.launchProfile?.mcpServers).toEqual(["viewer", "test-connector"]);
+      expect(reopened.claimStructuredHost({ engine: "codex", sessionId: sessionIdFor("nested-parent") }, owner, { allowUnhosted: true })
+        ?.launchProfile?.mcpServers).toEqual(["viewer", "test-connector"]);
+    } finally {
+      fs.rmSync(directory, { recursive: true, force: true });
+    }
+  });
+}
+
+test("identity evidence that cannot name one owner denies rather than picking a winner", () => {
+  const profileFor = (mcpServers: string[], parentConversationId: string | null) => ({
+    ...emptyLaunchProfile(),
+    parentConversationId: parentConversationId as never,
+    mcpServers,
+  });
+  const grant = ["viewer", "test-connector"];
+  /* Two conversations of DIFFERENT origin whose generations claim one entry row
+     — the delegated one by having copied the root generation's id. Nothing left
+     in the file says which decision the row should follow. */
+  const contested = () => ({
+    conversations: {
+      root: {
+        id: "conversation_root",
+        engine: "codex",
+        agentRole: null,
+        delegationDepth: 0,
+        generations: [{ id: "contested", path: "/sessions/root.jsonl", launchProfile: profileFor(grant, null) }],
+      },
+      worker: {
+        id: "conversation_worker",
+        engine: "codex",
+        agentRole: "builder",
+        delegationDepth: 1,
+        generations: [{ id: "contested", path: "/sessions/worker.jsonl", launchProfile: profileFor(grant, "conversation_root") }],
+      },
+    },
+    entries: { "codex:contested": { launchProfile: profileFor(grant, null) } },
+  } as unknown as StoredGrantFile);
+
+  expect(reboundStoredMcpGrants(contested(), WITH_CONNECTOR).entries["codex:contested"]!.launchProfile!.mcpServers)
+    .toEqual(["viewer"]);
+  expect(reboundAssembledMcpGrants(contested(), WITH_CONNECTOR).entries["codex:contested"]!.launchProfile!.mcpServers)
+    .toEqual(["viewer"]);
+
+  /* And the same for a transcript two generations both record: the path names
+     no single owner, so an entry pointing at it is attributable to neither. */
+  const sharedPath = () => ({
+    conversations: {
+      root: {
+        id: "conversation_root",
+        engine: "codex",
+        agentRole: null,
+        delegationDepth: 0,
+        generations: [{ id: "root-generation", path: "/sessions/shared.jsonl", launchProfile: profileFor(grant, null) }],
+      },
+      worker: {
+        id: "conversation_worker",
+        engine: "codex",
+        agentRole: "builder",
+        delegationDepth: 1,
+        generations: [{ id: "worker-generation", path: "/sessions/shared.jsonl", launchProfile: profileFor(grant, "conversation_root") }],
+      },
+    },
+    entries: {
+      "codex:root-generation": { artifactPath: "/sessions/shared.jsonl", launchProfile: profileFor(grant, null) },
+    },
+  } as unknown as StoredGrantFile);
+
+  expect(reboundAssembledMcpGrants(sharedPath(), WITH_CONNECTOR).entries["codex:root-generation"]!.launchProfile!.mcpServers)
+    .toEqual(["viewer"]);
+});
+
+test("a forged embedded key is denied even where no conversation is loaded", () => {
+  /* A row key/payload mismatch needs nothing but the row, so the per-collection
+     pass — which deliberately leaves merely-unowned rows alone — still denies
+     it. Otherwise a SQLite entries-only normalize would be the way in. */
+  const forged = {
+    conversations: {},
+    entries: {
+      "codex:worker": {
+        key: { engine: "codex", sessionId: "root" },
+        launchProfile: { mcpServers: ["viewer", "test-connector"] },
+      },
+    },
+  } as unknown as StoredGrantFile;
+  expect(reboundStoredMcpGrants(forged, WITH_CONNECTOR).entries["codex:worker"]!.launchProfile!.mcpServers)
+    .toEqual(["viewer"]);
+});
+
 test("a SQLite-authoritative registry re-bounds a tampered entry row on the paths adoption reads", () => {
   const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-mcp-sqlite-tamper-"));
   const registryPath = path.join(directory, "agent-registry.json");
   const sqlitePath = path.join(directory, "agent-registry.sqlite");
   const storage = { sqliteMode: "sqlite" as const, mcpGrantPolicy: WITH_CONNECTOR };
-  const workerEntryId = "codex:sqlite-delegated-worker";
-  const rootEntryId = "codex:nested-parent";
+  const workerEntryId = entryRowKey("sqlite-delegated-worker");
+  const rootEntryId = entryRowKey("nested-parent");
   try {
     const store = new AgentRegistry(registryPath, undefined, undefined, storage);
     const parentId = settledParent(store, ["viewer"]);
@@ -502,10 +706,10 @@ test("a SQLite-authoritative registry re-bounds a tampered entry row on the path
     /* And the entry a claim mutation hands to a host, which never sees an
        assembled snapshot at all. */
     const owner = { pid: process.pid, startIdentity: null };
-    const claimedWorker = reopened.claimStructuredHost({ engine: "codex", sessionId: "sqlite-delegated-worker" }, owner, { allowUnhosted: true });
+    const claimedWorker = reopened.claimStructuredHost({ engine: "codex", sessionId: sessionIdFor("sqlite-delegated-worker") }, owner, { allowUnhosted: true });
     expect(claimedWorker).not.toBeNull();
     expect(claimedWorker?.launchProfile?.mcpServers).toEqual(["viewer"]);
-    const claimedRoot = reopened.claimStructuredHost({ engine: "codex", sessionId: "nested-parent" }, owner, { allowUnhosted: true });
+    const claimedRoot = reopened.claimStructuredHost({ engine: "codex", sessionId: sessionIdFor("nested-parent") }, owner, { allowUnhosted: true });
     expect(claimedRoot?.launchProfile?.mcpServers).toEqual(["viewer", "test-connector"]);
   } finally {
     fs.rmSync(directory, { recursive: true, force: true });
@@ -537,10 +741,10 @@ test("an assembled SQLite snapshot re-decides entry rows by their owning convers
     reboundStoredMcpGrants(snapshot as unknown as StoredGrantFile, WITH_CONNECTOR);
 
     expect(snapshot.conversations[rootId]!.generations.at(-1)!.launchProfile.mcpServers).toEqual(grant);
-    expect(snapshot.entries["codex:nested-parent"]?.launchProfile?.mcpServers).toEqual(grant);
+    expect(snapshot.entries[entryRowKey("nested-parent")]?.launchProfile?.mcpServers).toEqual(grant);
     /* The delegated worker loses it on both copies, matched by real session key. */
     expect(snapshot.conversations[workerId]!.generations.at(-1)!.launchProfile.mcpServers).toEqual(["viewer"]);
-    expect(snapshot.entries["codex:sqlite-origin-worker"]?.launchProfile?.mcpServers).toEqual(["viewer"]);
+    expect(snapshot.entries[entryRowKey("sqlite-origin-worker")]?.launchProfile?.mcpServers).toEqual(["viewer"]);
   } finally {
     fs.rmSync(directory, { recursive: true, force: true });
   }
@@ -576,12 +780,12 @@ test("the SQLite store re-decides entry rows by origin when it assembles a snaps
       const file = store.snapshot().file;
       /* The operator root keeps the grant on both copies of its profile. */
       expect(file.conversations[rootId]!.generations.at(-1)!.launchProfile.mcpServers).toEqual(grant);
-      expect(file.entries["codex:nested-parent"]!.launchProfile!.mcpServers).toEqual(grant);
+      expect(file.entries[entryRowKey("nested-parent")]!.launchProfile!.mcpServers).toEqual(grant);
       /* The delegated worker loses it on both — including the ENTRY row, which
          is normalized with no conversation in sight and is what boot adoption
          and structured recovery consume. */
       expect(file.conversations[workerId]!.generations.at(-1)!.launchProfile.mcpServers).toEqual(["viewer"]);
-      expect(file.entries["codex:assembled-worker"]!.launchProfile!.mcpServers).toEqual(["viewer"]);
+      expect(file.entries[entryRowKey("assembled-worker")]!.launchProfile!.mcpServers).toEqual(["viewer"]);
     }
   } finally {
     fs.rmSync(directory, { recursive: true, force: true });

--- a/src/lib/agent/mcpAllowlist.test.ts
+++ b/src/lib/agent/mcpAllowlist.test.ts
@@ -19,6 +19,7 @@ import {
   mcpServersForStoredSession,
   normalizeSpawnMcpServers,
   reboundStoredMcpGrants,
+  storedSessionOriginFor,
   type StoredGrantFile,
   type McpGrantPolicy,
 } from "./mcpAllowlist";
@@ -99,9 +100,59 @@ test("a stored grant is re-decided from the session's durable origin, not replay
   expect(mcpServersForStoredSession({ parentConversationId: "conversation_parent", requested: tampered }, WITH_CONNECTOR)).toEqual(["viewer"]);
   expect(mcpServersForStoredSession({ delegationDepth: 1, requested: tampered }, WITH_CONNECTOR)).toEqual(["viewer"]);
   expect(mcpServersForStoredSession({ origin: { kind: "agent" }, requested: tampered }, WITH_CONNECTOR)).toEqual(["viewer"]);
-  /* The operator's own root keeps what it was granted. */
+  /* The operator's own root keeps what it was granted — but only because the
+     row PROVES it is one, which is what makes the resets above the origin rule
+     rather than a blanket wipe. */
   expect(mcpServersForStoredSession({ delegationDepth: 0, requested: tampered }, WITH_CONNECTOR))
     .toEqual(["viewer", "test-connector"]);
+  expect(mcpServersForStoredSession({ origin: { kind: "operator" }, requested: tampered }, WITH_CONNECTOR))
+    .toEqual(["viewer", "test-connector"]);
+});
+
+test("a stored grant with missing or erased origin evidence is denied, never promoted to operator root", () => {
+  const tampered = ["viewer", "test-connector"];
+  /* Absence of a delegation signal is not evidence of an operator root. If it
+     were, ERASING the evidence would be the widening path: a delegated worker
+     that blanks its own durable origin fields would be read as the most
+     privileged session class and keep a connector across every resume, attach
+     and structured recovery. */
+  expect(storedSessionOriginFor({})).toBe("delegated");
+  expect(storedSessionOriginFor({ agentRole: null, parentConversationId: null, delegationDepth: null })).toBe("delegated");
+  expect(storedSessionOriginFor({ delegationDepth: 0 })).toBe("operator-root");
+  expect(mcpServersForStoredSession({ requested: tampered }, WITH_CONNECTOR)).toEqual(["viewer"]);
+  expect(mcpServersForStoredSession({ agentRole: null, parentConversationId: null, delegationDepth: null, requested: tampered }, WITH_CONNECTOR))
+    .toEqual(["viewer"]);
+  /* A row that only lost its depth — the one affirmative root marker #393
+     stamps — is no longer a root either. */
+  expect(mcpServersForStoredSession({ agentRole: null, parentConversationId: null, origin: { kind: "successor" }, requested: tampered }, WITH_CONNECTOR))
+    .toEqual(["viewer"]);
+});
+
+test("a stored conversation whose delegation depth was erased loses its grant on the next read", () => {
+  const fileWith = (delegationDepth: number | null) => ({
+    conversations: {
+      root: {
+        id: "conversation_root",
+        engine: "codex",
+        agentRole: null,
+        delegationDepth,
+        generations: [{
+          id: "root-generation",
+          launchProfile: { ...emptyLaunchProfile(), parentConversationId: null, mcpServers: ["viewer", "test-connector"] },
+        }],
+      },
+    },
+    entries: {
+      "codex:root-generation": { launchProfile: { ...emptyLaunchProfile(), mcpServers: ["viewer", "test-connector"] } },
+    },
+  } as unknown as StoredGrantFile);
+
+  const proven = reboundStoredMcpGrants(fileWith(0), WITH_CONNECTOR);
+  expect(proven.conversations.root!.generations[0]!.launchProfile.mcpServers).toEqual(["viewer", "test-connector"]);
+  /* Same row, origin evidence deleted: the grant goes with it on both copies. */
+  const erased = reboundStoredMcpGrants(fileWith(null), WITH_CONNECTOR);
+  expect(erased.conversations.root!.generations[0]!.launchProfile.mcpServers).toEqual(["viewer"]);
+  expect(erased.entries["codex:root-generation"]!.launchProfile!.mcpServers).toEqual(["viewer"]);
 });
 
 test("a launch profile hand-edited to carry an ungranted server is re-bounded at the point of use", () => {
@@ -215,63 +266,127 @@ test("the storage boundary re-decides a grantable connector by the conversation'
   expect(rebounded.entries["codex:worker-generation"]!.launchProfile!.mcpServers).toEqual(["viewer"]);
 });
 
+/** Every row in the JSON file that carries an MCP grant, set to `grant`. The
+    tamper is deliberately indiscriminate — a worker with write access to the
+    file edits what it can reach, not what the boundary expects it to. */
+function tamperJsonGrant(registryPath: string, grant: string[]): void {
+  const raw = JSON.parse(fs.readFileSync(registryPath, "utf8")) as {
+    conversations: Record<string, { generations: { launchProfile: { mcpServers: string[] } }[] }>;
+    entries: Record<string, { launchProfile?: { mcpServers: string[] } }>;
+    receipts: Record<string, { launchProfile?: { mcpServers: string[] } }>;
+  };
+  for (const conversation of Object.values(raw.conversations)) {
+    for (const generation of conversation.generations) generation.launchProfile.mcpServers = [...grant];
+  }
+  for (const row of [...Object.values(raw.entries), ...Object.values(raw.receipts)]) {
+    if (row.launchProfile) row.launchProfile.mcpServers = [...grant];
+  }
+  fs.writeFileSync(registryPath, JSON.stringify(raw));
+}
+
 test("a delegated conversation cannot keep a hand-edited grant across resume or reload", () => {
   const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-mcp-tamper-"));
   const registryPath = path.join(directory, "registry.json");
+  /* The tampered name must be one the bound genuinely GRANTS, and the policy
+     must be injected on both the seeding and the reloading store. With an
+     out-of-bound name the global bound alone strips it, and this case would
+     keep passing with the origin decision deleted — proving nothing. */
+  const storage = { sqliteMode: "off" as const, mcpGrantPolicy: WITH_CONNECTOR };
   try {
     /* This case tampers with the JSON file itself, so it pins the backend
        rather than inheriting the environment's: under a SQLite-authoritative
        mode that file is a lagging rollback mirror, not the source of truth. */
-    const store = new AgentRegistry(registryPath, undefined, undefined, { sqliteMode: "off" });
+    const store = new AgentRegistry(registryPath, undefined, undefined, storage);
     const parentId = settledParent(store, ["viewer"]);
-    const child = store.beginSpawnRequest({
+    const workerId = settledDelegatedChild(store, parentId, "delegated-worker");
+
+    /* The worker edits the durable file it can reach on disk, naming a server
+       that IS inside the grant bound — the global bound alone would honour it. */
+    tamperJsonGrant(registryPath, ["viewer", "test-connector"]);
+
+    const reloaded = new AgentRegistry(registryPath, undefined, undefined, storage);
+    expect(reloaded.launchProfileForPath("/sessions/delegated-worker.jsonl")?.mcpServers).toEqual(["viewer"]);
+    const snapshot = reloaded.snapshot();
+    expect(snapshot.entries["codex:delegated-worker"]?.launchProfile?.mcpServers).toEqual(["viewer"]);
+    expect(snapshot.conversations[workerId]!.generations.at(-1)!.launchProfile.mcpServers).toEqual(["viewer"]);
+    /* The operator root's own rows keep the tampered grant, because its stored
+       origin proves it may hold one. Without this control the assertions above
+       would also pass if the read simply wiped every grant it saw. */
+    expect(reloaded.launchProfileForPath("/sessions/nested-parent.jsonl")?.mcpServers).toEqual(["viewer", "test-connector"]);
+    expect(snapshot.entries["codex:nested-parent"]?.launchProfile?.mcpServers).toEqual(["viewer", "test-connector"]);
+    expect(snapshot.conversations[parentId]!.generations.at(-1)!.launchProfile.mcpServers).toEqual(["viewer", "test-connector"]);
+
+    const resumedWorker = reloaded.beginSpawnRequest({
+      engine: "codex",
+      cwd: "/repo",
+      conversationId: workerId as never,
+      purpose: "resume-successor",
+    });
+    expect(resumedWorker.receipt.launchProfile.mcpServers).toEqual(["viewer"]);
+    const resumedRoot = reloaded.beginSpawnRequest({
+      engine: "codex",
+      cwd: "/repo",
+      conversationId: parentId as never,
+      purpose: "resume-successor",
+    });
+    expect(resumedRoot.receipt.launchProfile.mcpServers).toEqual(["viewer", "test-connector"]);
+  } finally {
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+test("a tampered receipt cannot carry a grant into settlement or attach", () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-mcp-receipt-tamper-"));
+  const registryPath = path.join(directory, "registry.json");
+  const storage = { sqliteMode: "off" as const, mcpGrantPolicy: WITH_CONNECTOR };
+  try {
+    const store = new AgentRegistry(registryPath, undefined, undefined, storage);
+    const parentId = settledParent(store, ["viewer"]);
+    /* Two receipts admitted and left UNSETTLED, so the widening path is the
+       live one: settlement copies `receipt.launchProfile` onto the conversation
+       generation and the entry row, and attach reads it back from there. */
+    const worker = store.beginSpawnRequest({
       engine: "codex",
       cwd: "/repo",
       role: "builder",
       parentConversationId: parentId,
       origin: { kind: "agent", conversationId: parentId },
     });
-    if (child.kind !== "created") throw new Error("expected child reservation");
-    const settledChild = store.settleSpawn(child.receipt.launchId, {
-      key: { engine: "codex", sessionId: "delegated-worker" },
-      artifactPath: "/sessions/delegated-worker.jsonl",
-      cwd: "/repo",
-      accountId: "account",
-      status: "idle",
-      host: null,
-      claimEpoch: 0,
-      claimOwner: null,
-      pendingAction: null,
-    });
-    if (settledChild.kind !== "settled") throw new Error("expected child settlement");
+    const root = store.beginSpawnRequest({ engine: "codex", cwd: "/repo" });
 
-    /* The worker edits the durable file it can reach on disk, naming a server
-       that IS inside the grant bound — the global bound alone would honour it. */
-    const raw = JSON.parse(fs.readFileSync(registryPath, "utf8")) as {
-      conversations: Record<string, { generations: { launchProfile: { mcpServers: string[] } }[] }>;
-      entries: Record<string, { launchProfile?: { mcpServers: string[] } }>;
+    tamperJsonGrant(registryPath, ["viewer", "test-connector"]);
+
+    const reloaded = new AgentRegistry(registryPath, undefined, undefined, storage);
+    const settle = (launchId: string, sessionId: string) => {
+      const settled = reloaded.settleSpawn(launchId, {
+        key: { engine: "codex", sessionId },
+        artifactPath: `/sessions/${sessionId}.jsonl`,
+        cwd: "/repo",
+        accountId: "account",
+        status: "idle",
+        host: null,
+        claimEpoch: 0,
+        claimOwner: null,
+        pendingAction: null,
+      });
+      if (settled.kind !== "settled") throw new Error(`expected ${sessionId} settlement`);
+      return settled.conversation.id;
     };
-    const conversation = raw.conversations[settledChild.conversation.id]!;
-    for (const generation of conversation.generations) generation.launchProfile.mcpServers = ["viewer", "granted-connector"];
-    for (const entry of Object.values(raw.entries)) {
-      if (entry.launchProfile) entry.launchProfile.mcpServers = ["viewer", "granted-connector"];
-    }
-    fs.writeFileSync(registryPath, JSON.stringify(raw));
 
-    const reloaded = new AgentRegistry(registryPath, undefined, undefined, { sqliteMode: "off" });
-    const profile = reloaded.launchProfileForPath("/sessions/delegated-worker.jsonl");
-    expect(profile?.mcpServers).toEqual(["viewer"]);
+    const workerId = settle(worker.receipt.launchId, "receipt-worker");
+    const rootId = settle(root.receipt.launchId, "receipt-root");
     const snapshot = reloaded.snapshot();
-    for (const entry of Object.values(snapshot.entries)) {
-      expect(entry.launchProfile?.mcpServers ?? ["viewer"]).toEqual(["viewer"]);
-    }
-    const resumed = reloaded.beginSpawnRequest({
-      engine: "codex",
-      cwd: "/repo",
-      conversationId: settledChild.conversation.id,
-      purpose: "resume-successor",
-    });
-    expect(resumed.receipt.launchProfile.mcpServers).toEqual(["viewer"]);
+
+    /* The delegated receipt's claim dies at the storage boundary, so neither
+       copy settlement writes ever holds the connector. */
+    expect(snapshot.receipts[worker.receipt.launchId]!.launchProfile.mcpServers).toEqual(["viewer"]);
+    expect(snapshot.conversations[workerId]!.generations.at(-1)!.launchProfile.mcpServers).toEqual(["viewer"]);
+    expect(snapshot.entries["codex:receipt-worker"]?.launchProfile?.mcpServers).toEqual(["viewer"]);
+    /* The operator root's receipt keeps it through the same reload and the same
+       settlement, so the reset above is the origin rule, not a blanket wipe. */
+    expect(snapshot.receipts[root.receipt.launchId]!.launchProfile.mcpServers).toEqual(["viewer", "test-connector"]);
+    expect(snapshot.conversations[rootId]!.generations.at(-1)!.launchProfile.mcpServers).toEqual(["viewer", "test-connector"]);
+    expect(snapshot.entries["codex:receipt-root"]?.launchProfile?.mcpServers).toEqual(["viewer", "test-connector"]);
   } finally {
     fs.rmSync(directory, { recursive: true, force: true });
   }

--- a/src/lib/agent/mcpAllowlist.ts
+++ b/src/lib/agent/mcpAllowlist.ts
@@ -411,11 +411,8 @@ function receiptAttestations(file: StoredGrantFile, ownership: StoredGrantOwners
          supplements the evidence index above rather than replacing it. */
       const namedEdge = file.lineageEdges?.[namedId];
       if (namedEdge?.parentConversationId && namedEdge.parentConversationId !== namedId) attest(launchId, "delegated");
-      /* The conversation a receipt NAMES may only ever contradict it, never
-         vouch for it: the subject picks this id, so letting a root reading here
-         grant would let a delegated receipt retarget itself at the operator
-         root and be vouched for by its own choice. */
-      if (ownership.conversationOrigins.get(namedId) === "delegated") attest(launchId, "delegated");
+      const named = ownership.conversationOrigins.get(namedId);
+      if (named) attest(launchId, named);
     }
     if (!receipt.key) continue;
     const rowKey = sessionKeyId({ engine: receipt.key.engine as never, sessionId: receipt.key.sessionId });
@@ -454,6 +451,34 @@ function receiptAttestations(file: StoredGrantFile, ownership: StoredGrantOwners
  * admission wrote for it is indexed by the launch id in the EDGE's evidence, so
  * rewriting the receipt into root shape leaves the edge still attesting
  * delegated and the contradiction still denying.
+ *
+ * WHY ATTESTATION ONLY REFUSES, AND NEVER VOUCHES. Round 5 tried the stronger
+ * shape — unattested denies, so a receipt must be vouched for by a row it does
+ * not own — and it inverted: it denied the honest operator root and admitted
+ * the attacker. Both halves are structural, not incidental.
+ *
+ *  - Nothing in the registry attests operator-ROOT for a launch id. Admission
+ *    (#393) writes a lineage edge only for DELEGATED launches, so an
+ *    un-parented launch that has not settled has no second row by construction
+ *    and can never be vouched for. It is denied before settlement can own its
+ *    entry row, and never recovers, because the first read strips the grant
+ *    settlement would have carried.
+ *  - Adding a root attestation would not fix that, because a row that GRANTS is
+ *    a row the subject gains by writing. Under the voucher rule a worker still
+ *    reached a connector by fabricating a root-shaped conversation and pointing
+ *    its own `key` at that conversation's generation — the voucher was three
+ *    lines of forged JSON. Evidence that can only REFUSE is the only evidence a
+ *    subject cannot forge in its own favour, which is why every attestor here
+ *    is wired to refuse and none to authorise.
+ *
+ * The one thing the voucher rule did add was denying a receipt that rewrites
+ * itself into root shape AND deletes the lineage edge naming it. That same
+ * attacker reaches the same connector by fabricating a root conversation and
+ * entry row outright, which the CONVERSATION path grants and this tranche
+ * already accepts (see the lineage-edge control in `mcpAllowlist.test.ts`).
+ * Wholesale fabrication is the registry file's integrity boundary, not this
+ * one; closing it here alone would cost the operator's own root its grant and
+ * leave the attacker the door beside it.
  */
 function receiptGrant(
   attestations: Map<string, Set<SessionOrigin>>,
@@ -466,19 +491,8 @@ function receiptGrant(
     delegationDepth: receipt.delegationDepth,
     parentConversationId: receipt.parentConversationId,
   });
-  /* UNATTESTED DENIES. A receipt has to be vouched for by a row it does not
-     own, because a subject that can delete the rows naming it would otherwise
-     delete its way to a grant.
-
-     BLOCKED ON AN OPERATOR DECISION (#739): nothing in the registry attests
-     "operator-root" for a launch id — admission writes a lineage edge only for
-     DELEGATED launches — so an un-parented launch that has not settled yet can
-     never be attested, and its receipt is denied here. That is why three
-     honest-root controls in this file fail. They are left failing deliberately;
-     do not relax this rule to make them pass. Inert in tranche 1, where the
-     bound is empty and every grant is already the baseline. */
   const attested = attestations.get(launchId);
-  if (!attested || attested.size !== 1 || !attested.has(described)) return null;
+  if (attested && (attested.size > 1 || !attested.has(described))) return null;
   return mcpServersForSession({ origin: described, requested: receipt.launchProfile!.mcpServers }, policy);
 }
 

--- a/src/lib/agent/mcpAllowlist.ts
+++ b/src/lib/agent/mcpAllowlist.ts
@@ -207,19 +207,108 @@ function sameGrant(left: readonly string[], right: readonly string[]): boolean {
   return left.length === right.length && left.every((name, index) => name === right[index]);
 }
 
-/** An entry names its generation by session key, and the transcript path is the
-    same identity spelled the other way; either match makes the entry's owning
-    conversation — and so its origin — knowable. */
-function generationKeys(engine: string, generation: StoredGeneration): string[] {
-  const keys = [sessionKeyId({ engine: engine as never, sessionId: generation.id })];
-  if (generation.path) keys.push(JSON.stringify(["path", engine, generation.path]));
-  return keys;
+/**
+ * The entry row a generation owns.
+ *
+ * A row KEY is storage identity rather than payload: it is the JSON object key
+ * and the SQLite `row_key` column, written by the registry as
+ * `sessionKeyId(entry.key)` and never re-read from inside the row. Everything an
+ * entry CARRIES — its embedded `key`, its `artifactPath` — is payload the entry
+ * can rewrite, so none of it may decide which generation owns the row; letting
+ * it would just move the escalation from forging an ORIGIN to forging an
+ * IDENTITY, and a delegated row could borrow the operator root's grant by
+ * naming the root's session. The registry already resolves a generation's entry
+ * exactly this way (`writeConversationLaunchProfile`,
+ * `conversationActivelyHosted`).
+ */
+function generationEntryRowKey(engine: string, generation: StoredGeneration): string {
+  return sessionKeyId({ engine: engine as never, sessionId: generation.id });
 }
 
-function entryKeys(id: string, entry: StoredEntry): string[] {
-  const keys = [entry.key ? sessionKeyId({ engine: entry.key.engine as never, sessionId: entry.key.sessionId }) : id];
-  if (entry.key && entry.artifactPath) keys.push(JSON.stringify(["path", entry.key.engine, entry.artifactPath]));
-  return keys;
+/**
+ * What the conversation side — the only side that carries origin evidence —
+ * says about entry rows.
+ *
+ * `grants` maps an entry row key to the grant the generation owning that row
+ * was decided to hold. `pathOwner` maps a transcript path a generation records
+ * to the row key entitled to it, which is what catches an entry that keeps its
+ * own row key but points its `artifactPath` at somebody else's transcript.
+ *
+ * A `null` in either map is unresolvable identity — two generations claiming
+ * one row key with different decisions, or one path recorded under two owners.
+ * A grant boundary cannot break that tie by guessing, so it denies.
+ */
+interface StoredGrantOwnership {
+  grants: Map<string, string[] | null>;
+  pathOwner: Map<string, string | null>;
+}
+
+function storedGrantOwnership(
+  file: StoredGrantFile,
+  policy: McpGrantPolicy,
+  decideGenerations: boolean,
+): StoredGrantOwnership {
+  const grants = new Map<string, string[] | null>();
+  const pathOwner = new Map<string, string | null>();
+  for (const conversation of Object.values(file.conversations)) {
+    for (const generation of conversation.generations) {
+      const rowKey = generationEntryRowKey(conversation.engine, generation);
+      const granted = decideStoredGrant(conversation, generation, policy);
+      if (decideGenerations) generation.launchProfile.mcpServers = granted;
+      if (!grants.has(rowKey)) grants.set(rowKey, granted);
+      else {
+        const claimed = grants.get(rowKey)!;
+        if (claimed === null || !sameGrant(claimed, granted)) grants.set(rowKey, null);
+      }
+      const recorded = generation.path;
+      if (!recorded) continue;
+      if (!pathOwner.has(recorded)) pathOwner.set(recorded, rowKey);
+      else if (pathOwner.get(recorded) !== rowKey) pathOwner.set(recorded, null);
+    }
+  }
+  return { grants, pathOwner };
+}
+
+/**
+ * The grant an entry row may keep:
+ *
+ *  - a list is the decision of the generation that owns the row;
+ *  - `null` DENIES, because the row's identity evidence is forged, borrowed or
+ *    contradictory — an escalation that is merely well-formed is still one;
+ *  - `undefined` means no conversation in THIS view claims the row, which is a
+ *    statement about how much was loaded rather than about the row itself.
+ */
+function entryGrant(id: string, entry: StoredEntry, ownership: StoredGrantOwnership): string[] | null | undefined {
+  /* The embedded key is payload and the row key is storage, so a row whose
+     payload names a different session has rewritten its own identity. This
+     needs nothing but the row, so it denies in every view, however little of
+     the file was loaded. */
+  if (entry.key && sessionKeyId({ engine: entry.key.engine as never, sessionId: entry.key.sessionId }) !== id) return null;
+  /* The same move spelled as a path: a transcript recorded by a generation that
+     owns a DIFFERENT row is a borrowed identity, and a path two generations both
+     record can attribute nothing. An unrecorded path is not evidence either way
+     — a lone entries row is normalized with no conversation in sight. */
+  if (entry.artifactPath) {
+    const owner = ownership.pathOwner.get(entry.artifactPath);
+    if (owner !== undefined && owner !== id) return null;
+  }
+  if (!ownership.grants.has(id)) return undefined;
+  return ownership.grants.get(id)!;
+}
+
+function reboundGrants<T extends StoredGrantFile>(file: T, policy: McpGrantPolicy, assembled: boolean): T {
+  const ownership = storedGrantOwnership(file, policy, true);
+  for (const [id, entry] of Object.entries(file.entries)) {
+    const stored = entry.launchProfile?.mcpServers;
+    if (!stored || isBaselineGrant(stored)) continue;
+    const granted = entryGrant(id, entry, ownership);
+    /* Unowned in a partial view says nothing; unowned in an assembled one is a
+       fact about the row. Forged evidence denies in both. */
+    if (granted === undefined && !assembled) continue;
+    const next = granted ?? DEFAULT_SPAWN_MCP_SERVERS;
+    if (!sameGrant(stored, next)) entry.launchProfile!.mcpServers = [...next];
+  }
+  return file;
 }
 
 function decideStoredGrant(
@@ -258,25 +347,12 @@ function decideStoredGrant(
  * Deciding an unowned entry at this level would wipe a legitimate root grant
  * every time a lone entries row is normalized; that judgement belongs to
  * {@link reboundAssembledMcpGrants}, which runs where the whole file is known.
+ *
+ * Which generation owns an entry is decided by {@link generationEntryRowKey},
+ * never by what the entry says about itself.
  */
 export function reboundStoredMcpGrants<T extends StoredGrantFile>(file: T, policy: McpGrantPolicy = MCP_GRANT_POLICY): T {
-  const decided = new Map<string, string[]>();
-  for (const conversation of Object.values(file.conversations)) {
-    for (const generation of conversation.generations) {
-      const granted = decideStoredGrant(conversation, generation, policy);
-      generation.launchProfile.mcpServers = granted;
-      for (const key of generationKeys(conversation.engine, generation)) decided.set(key, granted);
-    }
-  }
-  /* The entry row is the copy structured host adoption reads, and it can be
-     tampered with on its own, so it follows its conversation's decision. */
-  for (const [id, entry] of Object.entries(file.entries)) {
-    const stored = entry.launchProfile?.mcpServers;
-    if (!stored || isBaselineGrant(stored)) continue;
-    const granted = entryKeys(id, entry).map((key) => decided.get(key)).find(Boolean);
-    if (granted && !sameGrant(stored, granted)) entry.launchProfile!.mcpServers = [...granted];
-  }
-  return file;
+  return reboundGrants(file, policy, false);
 }
 
 /**
@@ -284,28 +360,21 @@ export function reboundStoredMcpGrants<T extends StoredGrantFile>(file: T, polic
  * exists is present: an entry no conversation owns has no origin evidence at
  * all, and here that is a fact about the entry rather than about how much of
  * the file was loaded, so it falls back to the baseline — the same fail-closed
- * reading {@link sessionOriginFor} gives an unrecognized launch.
+ * reading {@link storedSessionOriginFor} gives a record that cannot prove it is
+ * an operator root.
  */
 export function reboundAssembledMcpGrants<T extends StoredGrantFile>(file: T, policy: McpGrantPolicy = MCP_GRANT_POLICY): T {
-  reboundStoredMcpGrants(file, policy);
-  const owned = new Set<string>();
-  for (const conversation of Object.values(file.conversations)) {
-    for (const generation of conversation.generations) {
-      for (const key of generationKeys(conversation.engine, generation)) owned.add(key);
-    }
-  }
-  for (const [id, entry] of Object.entries(file.entries)) {
-    const stored = entry.launchProfile?.mcpServers;
-    if (!stored || isBaselineGrant(stored)) continue;
-    if (entryKeys(id, entry).some((key) => owned.has(key))) continue;
-    entry.launchProfile!.mcpServers = [...DEFAULT_SPAWN_MCP_SERVERS];
-  }
-  return file;
+  return reboundGrants(file, policy, true);
 }
 
 /**
  * The same decision for ONE entry row, for the paths that hand a single entry
  * to a host from inside a mutation rather than from an assembled snapshot.
+ *
+ * A mutation holds the whole file, so an entry no generation owns is genuinely
+ * unowned here and falls back to the baseline, as it would in an assembled
+ * read. The generation profiles are left alone: this is a single-row decision
+ * inside somebody else's transaction.
  */
 export function reboundEntryMcpGrant(
   file: StoredGrantFile,
@@ -316,14 +385,6 @@ export function reboundEntryMcpGrant(
   const entry = file.entries[id];
   const stored = entry?.launchProfile?.mcpServers;
   if (!entry || !stored || isBaselineGrant(stored)) return;
-  const wanted = new Set(entryKeys(id, entry));
-  for (const conversation of Object.values(file.conversations)) {
-    for (const generation of conversation.generations) {
-      if (!generationKeys(conversation.engine, generation).some((candidate) => wanted.has(candidate))) continue;
-      const granted = decideStoredGrant(conversation, generation, policy);
-      if (!sameGrant(stored, granted)) entry.launchProfile!.mcpServers = [...granted];
-      return;
-    }
-  }
-  entry.launchProfile!.mcpServers = [...DEFAULT_SPAWN_MCP_SERVERS];
+  const granted = entryGrant(id, entry, storedGrantOwnership(file, policy, false)) ?? DEFAULT_SPAWN_MCP_SERVERS;
+  if (!sameGrant(stored, granted)) entry.launchProfile!.mcpServers = [...granted];
 }

--- a/src/lib/agent/mcpAllowlist.ts
+++ b/src/lib/agent/mcpAllowlist.ts
@@ -411,8 +411,11 @@ function receiptAttestations(file: StoredGrantFile, ownership: StoredGrantOwners
          supplements the evidence index above rather than replacing it. */
       const namedEdge = file.lineageEdges?.[namedId];
       if (namedEdge?.parentConversationId && namedEdge.parentConversationId !== namedId) attest(launchId, "delegated");
-      const named = ownership.conversationOrigins.get(namedId);
-      if (named) attest(launchId, named);
+      /* The conversation a receipt NAMES may only ever contradict it, never
+         vouch for it: the subject picks this id, so letting a root reading here
+         grant would let a delegated receipt retarget itself at the operator
+         root and be vouched for by its own choice. */
+      if (ownership.conversationOrigins.get(namedId) === "delegated") attest(launchId, "delegated");
     }
     if (!receipt.key) continue;
     const rowKey = sessionKeyId({ engine: receipt.key.engine as never, sessionId: receipt.key.sessionId });
@@ -463,8 +466,19 @@ function receiptGrant(
     delegationDepth: receipt.delegationDepth,
     parentConversationId: receipt.parentConversationId,
   });
+  /* UNATTESTED DENIES. A receipt has to be vouched for by a row it does not
+     own, because a subject that can delete the rows naming it would otherwise
+     delete its way to a grant.
+
+     BLOCKED ON AN OPERATOR DECISION (#739): nothing in the registry attests
+     "operator-root" for a launch id — admission writes a lineage edge only for
+     DELEGATED launches — so an un-parented launch that has not settled yet can
+     never be attested, and its receipt is denied here. That is why three
+     honest-root controls in this file fail. They are left failing deliberately;
+     do not relax this rule to make them pass. Inert in tranche 1, where the
+     bound is empty and every grant is already the baseline. */
   const attested = attestations.get(launchId);
-  if (attested && (attested.size > 1 || !attested.has(described))) return null;
+  if (!attested || attested.size !== 1 || !attested.has(described)) return null;
   return mcpServersForSession({ origin: described, requested: receipt.launchProfile!.mcpServers }, policy);
 }
 

--- a/src/lib/agent/mcpAllowlist.ts
+++ b/src/lib/agent/mcpAllowlist.ts
@@ -199,9 +199,15 @@ type StoredReceipt = {
   agentRole?: string | null;
   delegationDepth?: number | null;
   parentConversationId?: string | null;
+  key?: { engine: string; sessionId: string } | null;
   launchProfile?: { mcpServers: string[] } | null;
 };
-type StoredLineageEdge = { parentConversationId?: string | null };
+type StoredLineageEdge = {
+  parentConversationId?: string | null;
+  /** Which launch the edge was written for. Admission (#393) records it, and it
+      lives on the EDGE, so a receipt cannot choose which edge names it. */
+  evidence?: { launchId?: string | null } | null;
+};
 export interface StoredGrantFile {
   conversations: Record<string, StoredConversation>;
   entries: Record<string, StoredEntry>;
@@ -251,6 +257,10 @@ function generationEntryRowKey(engine: string, generation: StoredGeneration): st
 interface StoredGrantOwnership {
   grants: Map<string, string[] | null>;
   pathOwner: Map<string, string | null>;
+  /** The ORIGIN of the generation owning each entry row key, so a receipt can
+      be attested by the conversation that owns the row it settled onto rather
+      than by the conversation it names. `null` where owners disagree. */
+  origins: Map<string, SessionOrigin | null>;
 }
 
 function storedGrantOwnership(
@@ -260,13 +270,23 @@ function storedGrantOwnership(
 ): StoredGrantOwnership {
   const grants = new Map<string, string[] | null>();
   const pathOwner = new Map<string, string | null>();
+  const origins = new Map<string, SessionOrigin | null>();
   for (const [conversationId, conversation] of Object.entries(file.conversations)) {
     const edge = file.lineageEdges?.[conversationId];
     const lineageDelegated = Boolean(edge?.parentConversationId && edge.parentConversationId !== conversationId);
     for (const generation of conversation.generations) {
       const rowKey = generationEntryRowKey(conversation.engine, generation);
       const granted = decideStoredGrant(conversation, generation, policy, lineageDelegated);
-      if (decideGenerations) generation.launchProfile.mcpServers = granted;
+      if (decideGenerations && !sameGrant(generation.launchProfile.mcpServers, granted)) {
+        generation.launchProfile.mcpServers = granted;
+      }
+      const origin = lineageDelegated ? "delegated" : storedSessionOriginFor({
+        parentConversationId: generation.launchProfile.parentConversationId,
+        agentRole: conversation.agentRole,
+        delegationDepth: conversation.delegationDepth,
+      });
+      if (!origins.has(rowKey)) origins.set(rowKey, origin);
+      else if (origins.get(rowKey) !== origin) origins.set(rowKey, null);
       if (!grants.has(rowKey)) grants.set(rowKey, granted);
       else {
         const claimed = grants.get(rowKey)!;
@@ -278,7 +298,7 @@ function storedGrantOwnership(
       else if (pathOwner.get(recorded) !== rowKey) pathOwner.set(recorded, null);
     }
   }
-  return { grants, pathOwner };
+  return { grants, pathOwner, origins };
 }
 
 /**
@@ -309,38 +329,50 @@ function entryGrant(id: string, entry: StoredEntry, ownership: StoredGrantOwners
 }
 
 /**
- * What OTHER rows attest about a receipt's origin.
+ * Who attests to a receipt's origin — chosen by the VERIFIER, keyed by the
+ * launch id the receipt is stored under.
  *
- * A receipt's own `agentRole`, `delegationDepth` and `parentConversationId` are
- * fields on the very row being authorised, so a row rewritten into root shape
- * would authorise itself. The rows that attest independently are:
+ * A receipt's `agentRole`, `delegationDepth` and `parentConversationId` are
+ * fields on the row being authorised, so a row rewritten into root shape
+ * authorises itself. But so is `conversationId`: letting the receipt name the
+ * conversation whose origin vouches for it lets the subject pick its own
+ * attestor — retarget it at an operator root, or at an id nothing attests to,
+ * and the vouching changes with it. Selection has to run the other way.
  *
- *  - the LINEAGE EDGE, which admission (#393) writes for every delegated launch
- *    as its own row keyed by the child conversation — present before a
- *    conversation record exists, and not reachable by editing the receipt's own
- *    fields;
- *  - the CONVERSATION row once the launch has settled, which is the
- *    origin-bearing row every generation and entry grant is already decided
- *    from.
+ * So attestations are indexed from the attesting rows inward:
  *
- * Both are looked up by the receipt's conversation id, and the conversation map
- * key is storage identity in the same sense an entry's row key is.
+ *  - a LINEAGE EDGE attests DELEGATED for the launch id in its own `evidence`.
+ *    The edge is a separate row, keyed by the child conversation, written by
+ *    admission (#393) before any conversation record exists. A receipt cannot
+ *    choose which edge names it, so retargeting its `conversationId` does not
+ *    move or shed the attestation.
+ *  - a CONVERSATION attests ROOT for a settled receipt only through generation
+ *    OWNERSHIP: the entry row key the receipt settled onto must be owned by one
+ *    of that conversation's generations, by the same row-key rule entries use.
+ *    Forging the receipt's own key just points it at a row some OTHER
+ *    conversation owns, and the attestation follows the owner, not the pointer.
+ *
+ * A launch id no row attests to is UNATTESTED, and unattested denies.
  */
-function anchoredReceiptOrigins(file: StoredGrantFile, receipt: StoredReceipt): Set<SessionOrigin> {
-  const anchors = new Set<SessionOrigin>();
-  const conversationId = receipt.conversationId;
-  if (!conversationId) return anchors;
-  const edge = file.lineageEdges?.[conversationId];
-  if (edge?.parentConversationId && edge.parentConversationId !== conversationId) anchors.add("delegated");
-  const conversation = file.conversations[conversationId];
-  if (conversation) {
-    anchors.add(storedSessionOriginFor({
-      agentRole: conversation.agentRole,
-      delegationDepth: conversation.delegationDepth,
-      parentConversationId: conversation.generations.at(-1)?.launchProfile.parentConversationId ?? null,
-    }));
+function receiptAttestations(file: StoredGrantFile, ownership: StoredGrantOwnership): Map<string, Set<SessionOrigin>> {
+  const attested = new Map<string, Set<SessionOrigin>>();
+  const attest = (launchId: string, origin: SessionOrigin) => {
+    const seen = attested.get(launchId) ?? new Set<SessionOrigin>();
+    seen.add(origin);
+    attested.set(launchId, seen);
+  };
+  for (const [childConversationId, edge] of Object.entries(file.lineageEdges ?? {})) {
+    if (!edge.parentConversationId || edge.parentConversationId === childConversationId) continue;
+    const launchId = edge.evidence?.launchId;
+    if (typeof launchId === "string" && launchId) attest(launchId, "delegated");
   }
-  return anchors;
+  for (const [launchId, receipt] of Object.entries(file.receipts ?? {})) {
+    if (!receipt.key) continue;
+    const rowKey = sessionKeyId({ engine: receipt.key.engine as never, sessionId: receipt.key.sessionId });
+    const owner = ownership.origins.get(rowKey);
+    if (owner) attest(launchId, owner);
+  }
+  return attested;
 }
 
 /**
@@ -349,28 +381,33 @@ function anchoredReceiptOrigins(file: StoredGrantFile, receipt: StoredReceipt): 
  * Settlement copies `receipt.launchProfile` onto the conversation generation
  * and the entry row, and stamps the receipt's role and depth onto a brand-new
  * conversation, so a receipt that keeps a connector does not merely hold one —
- * it MANUFACTURES the origin evidence every later read trusts. Deciding that
- * from the receipt's own fields would let a row promote itself.
+ * it MANUFACTURES the origin evidence every later read trusts.
  *
- * So the attesting rows win, and a receipt whose self-description CONTRADICTS
- * them is denied outright: a contradiction is a tamper signal, not a tie to
- * break in the caller's favour. Anchors that disagree with each other deny for
- * the same reason. Only where nothing attests at all — an un-parented launch
- * that has not settled yet, which has no other row by construction — does the
- * receipt's own shape decide, and there it can still only narrow.
+ * A receipt therefore has to be VOUCHED FOR, not merely un-contradicted:
+ *
+ *  - unattested denies, because absence is not attestation and a subject that
+ *    can delete the rows naming it would otherwise delete its way to a grant;
+ *  - attestors that disagree with each other deny;
+ *  - an attestation the receipt's own self-description contradicts denies,
+ *    because a contradiction is a tamper signal rather than a tie to resolve in
+ *    the caller's favour.
  */
-function receiptGrant(file: StoredGrantFile, receipt: StoredReceipt, policy: McpGrantPolicy): string[] | null {
-  const stored = receipt.launchProfile!.mcpServers;
+function receiptGrant(
+  attestations: Map<string, Set<SessionOrigin>>,
+  launchId: string,
+  receipt: StoredReceipt,
+  policy: McpGrantPolicy,
+): string[] | null {
+  const attested = attestations.get(launchId);
+  if (!attested || attested.size !== 1) return null;
+  const [origin] = attested;
   const described = storedSessionOriginFor({
     agentRole: receipt.agentRole,
     delegationDepth: receipt.delegationDepth,
     parentConversationId: receipt.parentConversationId,
   });
-  const anchors = anchoredReceiptOrigins(file, receipt);
-  if (anchors.size > 1) return null;
-  const [anchored] = anchors;
-  if (anchored !== undefined && anchored !== described) return null;
-  return mcpServersForSession({ origin: anchored ?? described, requested: stored }, policy);
+  if (origin !== described) return null;
+  return mcpServersForSession({ origin: origin!, requested: receipt.launchProfile!.mcpServers }, policy);
 }
 
 function reboundGrants<T extends StoredGrantFile>(file: T, policy: McpGrantPolicy, assembled: boolean): T {
@@ -385,10 +422,11 @@ function reboundGrants<T extends StoredGrantFile>(file: T, policy: McpGrantPolic
     const next = granted ?? DEFAULT_SPAWN_MCP_SERVERS;
     if (!sameGrant(stored, next)) entry.launchProfile!.mcpServers = [...next];
   }
-  for (const receipt of Object.values(file.receipts ?? {})) {
+  const attestations = receiptAttestations(file, ownership);
+  for (const [launchId, receipt] of Object.entries(file.receipts ?? {})) {
     const stored = receipt.launchProfile?.mcpServers;
     if (!stored || isBaselineGrant(stored)) continue;
-    const granted = receiptGrant(file, receipt, policy) ?? DEFAULT_SPAWN_MCP_SERVERS;
+    const granted = receiptGrant(attestations, launchId, receipt, policy) ?? DEFAULT_SPAWN_MCP_SERVERS;
     if (!sameGrant(stored, granted)) receipt.launchProfile!.mcpServers = [...granted];
   }
   return file;

--- a/src/lib/agent/mcpAllowlist.ts
+++ b/src/lib/agent/mcpAllowlist.ts
@@ -1,15 +1,110 @@
+/**
+ * Per-session MCP server grants (issue #739).
+ *
+ * MCP servers are registered host-wide in the operator's own configuration —
+ * Codex `config.toml`, Claude `.claude.json`/`.mcp.json`. The Viewer never
+ * enables that whole table for a session: it selects a named subset per launch,
+ * carries it on the durable launch profile, and materializes it into each
+ * engine's enable table.
+ *
+ * The selection is bounded exactly the way plugin grants are
+ * (`pluginAllowlist.ts`), and for the same reason — `spawn_agent` exposes
+ * `mcpServers` to every agent holding the Viewer MCP, so an unbounded name
+ * would let any delegated worker hand itself a connector the operator meant to
+ * keep for their own root session. Two properties hold on every path here:
+ *
+ *  - nothing outside {@link GRANTABLE_MCP_SERVERS} can ever be granted, so no
+ *    caller can widen a session to "every configured MCP server";
+ *  - a request can only narrow the policy default, never widen it, so a
+ *    delegated session cannot inherit a grant through a spawn chain.
+ *
+ * `viewer` is the exception that stays force-included on every path: it is the
+ * orchestration surface the board itself depends on, not a grant.
+ */
+
+import type { SessionOrigin } from "./pluginAllowlist";
+
+/** The always-on baseline. A spawn that selects nothing gets exactly this. */
 export const DEFAULT_SPAWN_MCP_SERVERS: readonly string[] = Object.freeze(["viewer"]);
+
+/** Outer bound of the mechanism: the only MCP servers the Viewer can grant at
+    all. Everything else the operator has configured stays off for every
+    session, whoever asks. Personal connectors — a Telegram account, a mail
+    box — join this list only once they exist and only deliberately. */
+export const GRANTABLE_MCP_SERVERS: readonly string[] = Object.freeze(["viewer", "agent-browser"]);
+
+/** What an operator-launched root session receives when it does not opt out.
+    The operator's own root conversation is the session class the grantable
+    surface exists for, so it carries the whole bound by default. */
+export const OPERATOR_ROOT_MCP_SERVERS: readonly string[] = Object.freeze([...GRANTABLE_MCP_SERVERS]);
+
+/** What a delegated session (subagent, builder, reviewer, pipeline helper)
+    receives: the baseline and nothing more. A delegated launch that asks for a
+    connector is not an error — the grant simply is not its to take. */
+export const DELEGATED_MCP_SERVERS: readonly string[] = Object.freeze([...DEFAULT_SPAWN_MCP_SERVERS]);
 
 export type SpawnMcpServersResult =
   | { ok: true; value: string[] }
   | { ok: false; error: string };
 
-const MCP_SERVER_NAME = /^[^\s\u0000-\u001f\u007f]{1,128}$/u;
+/** Shape check before the bound check, so a structurally malformed value keeps
+    reporting the malformed-array error it always did. The class is the
+    original one: no whitespace, no control characters. */
+const MCP_SERVER_NAME = /^[^\s\p{Cc}]{1,128}$/u;
 
+/** Viewer first, deduplicated, and always present — the orchestration surface
+    is not part of the grant and cannot be dropped by any caller. */
+function withViewer(names: readonly string[]): string[] {
+  return ["viewer", ...new Set(names.filter((name) => name !== "viewer"))];
+}
+
+/**
+ * Validates a requested MCP allowlist. `undefined` selects the baseline; `[]`
+ * is the explicit opt-out and still yields `["viewer"]`. Any name outside
+ * {@link GRANTABLE_MCP_SERVERS} — including wildcards such as `*` or `all` — is
+ * rejected with the bound spelled out, rather than silently dropped, so a
+ * caller cannot believe it received a surface it did not get.
+ */
 export function normalizeSpawnMcpServers(value: unknown): SpawnMcpServersResult {
   if (value === undefined) return { ok: true, value: [...DEFAULT_SPAWN_MCP_SERVERS] };
-  if (Array.isArray(value) && value.every((name) => typeof name === "string" && MCP_SERVER_NAME.test(name))) {
-    return { ok: true, value: ["viewer", ...new Set(value.filter((name) => name !== "viewer"))] };
+  if (!Array.isArray(value) || !value.every((name) => typeof name === "string" && MCP_SERVER_NAME.test(name))) {
+    return { ok: false, error: "mcpServers must be an array of non-empty server names" };
   }
-  return { ok: false, error: "mcpServers must be an array of non-empty server names" };
+  const names = value as string[];
+  const ungranted = names.filter((name) => !GRANTABLE_MCP_SERVERS.includes(name));
+  if (ungranted.length > 0) {
+    return { ok: false, error: `mcpServers may only contain ${GRANTABLE_MCP_SERVERS.join(", ")}; rejected: ${[...new Set(ungranted)].join(", ")}` };
+  }
+  return { ok: true, value: withViewer(names) };
+}
+
+/** Policy default for a session class, before any request narrows it. */
+export function defaultMcpServersForOrigin(origin: SessionOrigin): readonly string[] {
+  return origin === "operator-root" ? OPERATOR_ROOT_MCP_SERVERS : DELEGATED_MCP_SERVERS;
+}
+
+/**
+ * Final allowlist for a session: the policy default for its origin, narrowed by
+ * whatever the request asked for. The result is always a subset of both, so a
+ * request can deny a grant (the opt-out) but never create one — plus `viewer`,
+ * which every session holds.
+ */
+export function mcpServersForSession(input: {
+  origin: SessionOrigin;
+  /** `null`/absent means the request said nothing and policy decides. */
+  requested?: readonly string[] | null;
+}): string[] {
+  const policy = defaultMcpServersForOrigin(input.origin);
+  const granted = input.requested == null
+    ? policy
+    : policy.filter((name) => input.requested!.includes(name));
+  return withViewer(granted.filter((name) => GRANTABLE_MCP_SERVERS.includes(name)));
+}
+
+/** Re-validates a stored allowlist on the way into an engine's enable table.
+    Launch profiles are durable and can be edited by hand, so the bound is
+    enforced again at the point of use rather than trusted from storage. */
+export function grantedMcpServers(value: readonly string[] | undefined | null): string[] {
+  if (!Array.isArray(value)) return [...DEFAULT_SPAWN_MCP_SERVERS];
+  return withViewer(value.filter((name) => typeof name === "string" && GRANTABLE_MCP_SERVERS.includes(name)));
 }

--- a/src/lib/agent/mcpAllowlist.ts
+++ b/src/lib/agent/mcpAllowlist.ts
@@ -23,6 +23,7 @@
  */
 
 import { sessionOriginFor, type SessionOrigin, type SessionOriginInput } from "./pluginAllowlist";
+import { sessionKeyId } from "./sessionKey";
 
 /** The always-on baseline. A spawn that selects nothing gets exactly this. */
 export const DEFAULT_SPAWN_MCP_SERVERS: readonly string[] = Object.freeze(["viewer"]);
@@ -154,4 +155,147 @@ export function mcpServersForStoredSession(
 export function grantedMcpServers(value: readonly string[] | undefined | null, policy: McpGrantPolicy = MCP_GRANT_POLICY): string[] {
   if (!Array.isArray(value)) return [...DEFAULT_SPAWN_MCP_SERVERS];
   return withViewer(value.filter((name) => typeof name === "string" && policy.grantable.includes(name)));
+}
+
+/* The durable shapes this module re-decides grants on. Typed structurally and
+   type-only, so the storage layers can call in without a runtime cycle. */
+type StoredGeneration = { id: string; path?: string | null; launchProfile: { mcpServers: string[]; parentConversationId: string | null } };
+type StoredConversation = { engine: string; agentRole: string | null; delegationDepth: number | null; generations: StoredGeneration[] };
+type StoredEntry = {
+  key?: { engine: string; sessionId: string } | null;
+  artifactPath?: string | null;
+  launchProfile?: { mcpServers: string[] } | null;
+};
+export interface StoredGrantFile {
+  conversations: Record<string, StoredConversation>;
+  entries: Record<string, StoredEntry>;
+}
+
+function isBaselineGrant(names: readonly string[]): boolean {
+  return names.length === 1 && names[0] === "viewer";
+}
+
+function sameGrant(left: readonly string[], right: readonly string[]): boolean {
+  return left.length === right.length && left.every((name, index) => name === right[index]);
+}
+
+/** An entry names its generation by session key, and the transcript path is the
+    same identity spelled the other way; either match makes the entry's owning
+    conversation — and so its origin — knowable. */
+function generationKeys(engine: string, generation: StoredGeneration): string[] {
+  const keys = [sessionKeyId({ engine: engine as never, sessionId: generation.id })];
+  if (generation.path) keys.push(JSON.stringify(["path", engine, generation.path]));
+  return keys;
+}
+
+function entryKeys(id: string, entry: StoredEntry): string[] {
+  const keys = [entry.key ? sessionKeyId({ engine: entry.key.engine as never, sessionId: entry.key.sessionId }) : id];
+  if (entry.key && entry.artifactPath) keys.push(JSON.stringify(["path", entry.key.engine, entry.artifactPath]));
+  return keys;
+}
+
+function decideStoredGrant(
+  conversation: StoredConversation,
+  generation: StoredGeneration,
+  policy: McpGrantPolicy,
+): string[] {
+  const stored = generation.launchProfile.mcpServers;
+  /* Every read walks this, so the overwhelmingly common baseline profile skips
+     the resolver and its allocation; only a profile claiming more than the
+     baseline is worth re-deciding. */
+  if (isBaselineGrant(stored)) return stored;
+  return mcpServersForStoredSession({
+    parentConversationId: generation.launchProfile.parentConversationId,
+    agentRole: conversation.agentRole,
+    delegationDepth: conversation.delegationDepth,
+    requested: stored,
+  }, policy);
+}
+
+/**
+ * Re-decides every stored MCP grant from the conversation's durable origin as
+ * a registry snapshot is read (#739).
+ *
+ * `emptyLaunchProfile` already applies the global bound to each profile, but a
+ * bound alone cannot tell an operator root apart from a delegated worker: a
+ * delegated session that edits durable state by hand to name a server the
+ * Viewer *can* grant would otherwise have it honoured by attach, resume and
+ * structured host adoption, all of which read these profiles straight out of
+ * storage. Doing it here means no reader has to remember to.
+ *
+ * A conversation row carries its own origin evidence, so it is decidable
+ * alone. An ENTRY row is not — and both backends normalize rows one collection
+ * (one row, for SQLite) at a time, which is why an entry is only ever narrowed
+ * here when the conversation that owns it is present in the same object.
+ * Deciding an unowned entry at this level would wipe a legitimate root grant
+ * every time a lone entries row is normalized; that judgement belongs to
+ * {@link reboundAssembledMcpGrants}, which runs where the whole file is known.
+ */
+export function reboundStoredMcpGrants<T extends StoredGrantFile>(file: T, policy: McpGrantPolicy = MCP_GRANT_POLICY): T {
+  const decided = new Map<string, string[]>();
+  for (const conversation of Object.values(file.conversations)) {
+    for (const generation of conversation.generations) {
+      const granted = decideStoredGrant(conversation, generation, policy);
+      generation.launchProfile.mcpServers = granted;
+      for (const key of generationKeys(conversation.engine, generation)) decided.set(key, granted);
+    }
+  }
+  /* The entry row is the copy structured host adoption reads, and it can be
+     tampered with on its own, so it follows its conversation's decision. */
+  for (const [id, entry] of Object.entries(file.entries)) {
+    const stored = entry.launchProfile?.mcpServers;
+    if (!stored || isBaselineGrant(stored)) continue;
+    const granted = entryKeys(id, entry).map((key) => decided.get(key)).find(Boolean);
+    if (granted && !sameGrant(stored, granted)) entry.launchProfile!.mcpServers = [...granted];
+  }
+  return file;
+}
+
+/**
+ * The same pass for a COMPLETE registry snapshot, where every conversation that
+ * exists is present: an entry no conversation owns has no origin evidence at
+ * all, and here that is a fact about the entry rather than about how much of
+ * the file was loaded, so it falls back to the baseline — the same fail-closed
+ * reading {@link sessionOriginFor} gives an unrecognized launch.
+ */
+export function reboundAssembledMcpGrants<T extends StoredGrantFile>(file: T, policy: McpGrantPolicy = MCP_GRANT_POLICY): T {
+  reboundStoredMcpGrants(file, policy);
+  const owned = new Set<string>();
+  for (const conversation of Object.values(file.conversations)) {
+    for (const generation of conversation.generations) {
+      for (const key of generationKeys(conversation.engine, generation)) owned.add(key);
+    }
+  }
+  for (const [id, entry] of Object.entries(file.entries)) {
+    const stored = entry.launchProfile?.mcpServers;
+    if (!stored || isBaselineGrant(stored)) continue;
+    if (entryKeys(id, entry).some((key) => owned.has(key))) continue;
+    entry.launchProfile!.mcpServers = [...DEFAULT_SPAWN_MCP_SERVERS];
+  }
+  return file;
+}
+
+/**
+ * The same decision for ONE entry row, for the paths that hand a single entry
+ * to a host from inside a mutation rather than from an assembled snapshot.
+ */
+export function reboundEntryMcpGrant(
+  file: StoredGrantFile,
+  key: { engine: string; sessionId: string },
+  policy: McpGrantPolicy = MCP_GRANT_POLICY,
+): void {
+  const id = sessionKeyId({ engine: key.engine as never, sessionId: key.sessionId });
+  const entry = file.entries[id];
+  const stored = entry?.launchProfile?.mcpServers;
+  if (!entry || !stored || isBaselineGrant(stored)) return;
+  const wanted = new Set(entryKeys(id, entry));
+  for (const conversation of Object.values(file.conversations)) {
+    for (const generation of conversation.generations) {
+      if (!generationKeys(conversation.engine, generation).some((candidate) => wanted.has(candidate))) continue;
+      const granted = decideStoredGrant(conversation, generation, policy);
+      if (!sameGrant(stored, granted)) entry.launchProfile!.mcpServers = [...granted];
+      return;
+    }
+  }
+  entry.launchProfile!.mcpServers = [...DEFAULT_SPAWN_MCP_SERVERS];
 }

--- a/src/lib/agent/mcpAllowlist.ts
+++ b/src/lib/agent/mcpAllowlist.ts
@@ -22,16 +22,22 @@
  * orchestration surface the board itself depends on, not a grant.
  */
 
-import type { SessionOrigin } from "./pluginAllowlist";
+import { sessionOriginFor, type SessionOrigin, type SessionOriginInput } from "./pluginAllowlist";
 
 /** The always-on baseline. A spawn that selects nothing gets exactly this. */
 export const DEFAULT_SPAWN_MCP_SERVERS: readonly string[] = Object.freeze(["viewer"]);
 
 /** Outer bound of the mechanism: the only MCP servers the Viewer can grant at
     all. Everything else the operator has configured stays off for every
-    session, whoever asks. Personal connectors — a Telegram account, a mail
-    box — join this list only once they exist and only deliberately. */
-export const GRANTABLE_MCP_SERVERS: readonly string[] = Object.freeze(["viewer", "agent-browser"]);
+    session, whoever asks.
+
+    Tranche 1 deliberately ships this bound EMPTY of connectors — `viewer` is
+    the baseline every session holds, not a grant. No MCP server can be enabled
+    for any session until a connector is added here, which is what tranche 2
+    does for `telegram`. Adding a name here grants it to the operator-root
+    session class by default, so a name belongs here only once its credential
+    boundary and revocation path exist. */
+export const GRANTABLE_MCP_SERVERS: readonly string[] = Object.freeze(["viewer"]);
 
 /** What an operator-launched root session receives when it does not opt out.
     The operator's own root conversation is the session class the grantable
@@ -42,6 +48,28 @@ export const OPERATOR_ROOT_MCP_SERVERS: readonly string[] = Object.freeze([...GR
     receives: the baseline and nothing more. A delegated launch that asks for a
     connector is not an error — the grant simply is not its to take. */
 export const DELEGATED_MCP_SERVERS: readonly string[] = Object.freeze([...DEFAULT_SPAWN_MCP_SERVERS]);
+
+/**
+ * The bound plus its per-origin defaults, as one value.
+ *
+ * Every function here takes it as an optional last argument that defaults to
+ * {@link MCP_GRANT_POLICY}; no production call site passes one. The seam exists
+ * so the origin rules can be exercised against a policy that actually has a
+ * grantable connector while the shipped bound has none — otherwise "delegated
+ * cannot obtain a connector" would be proven only by there being nothing to
+ * obtain, and would silently stop being proven the day tranche 2 lands.
+ */
+export interface McpGrantPolicy {
+  readonly grantable: readonly string[];
+  readonly operatorRoot: readonly string[];
+  readonly delegated: readonly string[];
+}
+
+export const MCP_GRANT_POLICY: McpGrantPolicy = Object.freeze({
+  grantable: GRANTABLE_MCP_SERVERS,
+  operatorRoot: OPERATOR_ROOT_MCP_SERVERS,
+  delegated: DELEGATED_MCP_SERVERS,
+});
 
 export type SpawnMcpServersResult =
   | { ok: true; value: string[] }
@@ -65,22 +93,22 @@ function withViewer(names: readonly string[]): string[] {
  * rejected with the bound spelled out, rather than silently dropped, so a
  * caller cannot believe it received a surface it did not get.
  */
-export function normalizeSpawnMcpServers(value: unknown): SpawnMcpServersResult {
+export function normalizeSpawnMcpServers(value: unknown, policy: McpGrantPolicy = MCP_GRANT_POLICY): SpawnMcpServersResult {
   if (value === undefined) return { ok: true, value: [...DEFAULT_SPAWN_MCP_SERVERS] };
   if (!Array.isArray(value) || !value.every((name) => typeof name === "string" && MCP_SERVER_NAME.test(name))) {
     return { ok: false, error: "mcpServers must be an array of non-empty server names" };
   }
   const names = value as string[];
-  const ungranted = names.filter((name) => !GRANTABLE_MCP_SERVERS.includes(name));
+  const ungranted = names.filter((name) => !policy.grantable.includes(name));
   if (ungranted.length > 0) {
-    return { ok: false, error: `mcpServers may only contain ${GRANTABLE_MCP_SERVERS.join(", ")}; rejected: ${[...new Set(ungranted)].join(", ")}` };
+    return { ok: false, error: `mcpServers may only contain ${policy.grantable.join(", ")}; rejected: ${[...new Set(ungranted)].join(", ")}` };
   }
   return { ok: true, value: withViewer(names) };
 }
 
 /** Policy default for a session class, before any request narrows it. */
-export function defaultMcpServersForOrigin(origin: SessionOrigin): readonly string[] {
-  return origin === "operator-root" ? OPERATOR_ROOT_MCP_SERVERS : DELEGATED_MCP_SERVERS;
+export function defaultMcpServersForOrigin(origin: SessionOrigin, policy: McpGrantPolicy = MCP_GRANT_POLICY): readonly string[] {
+  return origin === "operator-root" ? policy.operatorRoot : policy.delegated;
 }
 
 /**
@@ -93,18 +121,37 @@ export function mcpServersForSession(input: {
   origin: SessionOrigin;
   /** `null`/absent means the request said nothing and policy decides. */
   requested?: readonly string[] | null;
-}): string[] {
-  const policy = defaultMcpServersForOrigin(input.origin);
+}, policy: McpGrantPolicy = MCP_GRANT_POLICY): string[] {
+  const allowed = defaultMcpServersForOrigin(input.origin, policy);
   const granted = input.requested == null
-    ? policy
-    : policy.filter((name) => input.requested!.includes(name));
-  return withViewer(granted.filter((name) => GRANTABLE_MCP_SERVERS.includes(name)));
+    ? allowed
+    : allowed.filter((name) => input.requested!.includes(name));
+  return withViewer(granted.filter((name) => policy.grantable.includes(name)));
 }
 
-/** Re-validates a stored allowlist on the way into an engine's enable table.
-    Launch profiles are durable and can be edited by hand, so the bound is
-    enforced again at the point of use rather than trusted from storage. */
-export function grantedMcpServers(value: readonly string[] | undefined | null): string[] {
+/**
+ * The same resolution for a list coming back OUT of durable storage, where the
+ * session's origin is whatever its record says it is rather than a live
+ * request. The global bound alone is not enough here: without the origin, a
+ * delegated session that hand-edits its own profile to name a server the
+ * Viewer *can* grant would have it honoured on the next resume, attach or
+ * structured recovery. Fail-closed by construction — {@link sessionOriginFor}
+ * reads anything but a clean operator root as delegated.
+ */
+export function mcpServersForStoredSession(
+  input: SessionOriginInput & { requested?: readonly string[] | null },
+  policy: McpGrantPolicy = MCP_GRANT_POLICY,
+): string[] {
+  return mcpServersForSession({ origin: sessionOriginFor(input), requested: input.requested }, policy);
+}
+
+/** Last line of the bound, where an engine's enable table is materialized: the
+    global grantable set, applied again to whatever the caller was handed. The
+    ORIGIN bound belongs upstream of this — {@link mcpServersForStoredSession}
+    at the storage boundary — because an engine builder holds a list, not a
+    session record. Keeping both means a tampered profile has to defeat the
+    origin rule and the bound. */
+export function grantedMcpServers(value: readonly string[] | undefined | null, policy: McpGrantPolicy = MCP_GRANT_POLICY): string[] {
   if (!Array.isArray(value)) return [...DEFAULT_SPAWN_MCP_SERVERS];
-  return withViewer(value.filter((name) => typeof name === "string" && GRANTABLE_MCP_SERVERS.includes(name)));
+  return withViewer(value.filter((name) => typeof name === "string" && policy.grantable.includes(name)));
 }

--- a/src/lib/agent/mcpAllowlist.ts
+++ b/src/lib/agent/mcpAllowlist.ts
@@ -131,19 +131,47 @@ export function mcpServersForSession(input: {
 }
 
 /**
+ * Origin of a session as read back OUT of durable storage, where the evidence
+ * is a stored record rather than a live request.
+ *
+ * {@link sessionOriginFor} answers "did this launch carry a delegation signal?"
+ * and reads the absence of every signal as an operator root. That is the right
+ * reading for a request being admitted right now, where a root genuinely
+ * carries no signals. It is the WRONG reading for a durable row: a record whose
+ * origin fields were never written — or were erased by the very session that
+ * wants the grant — is then indistinguishable from an operator root, so
+ * DELETING evidence would PROMOTE a delegated worker into the most privileged
+ * session class. A grant boundary cannot have that shape.
+ *
+ * So operator root has to be PROVEN here, not merely not-disproven: the record
+ * must carry an affirmative root marker — an `operator` origin kind, or the
+ * delegation depth `0` that admission (#393) stamps on every root receipt.
+ * Anything else is delegated, including a row carrying no origin evidence at
+ * all. A session the Viewer never launched (a transcript the scanner adopted,
+ * a pre-#393 row) therefore holds the baseline and nothing more, which is the
+ * correct answer for a record whose origin nobody can attest to.
+ */
+export function storedSessionOriginFor(input: SessionOriginInput): SessionOrigin {
+  if (sessionOriginFor(input) === "delegated") return "delegated";
+  if (input.origin?.kind === "operator") return "operator-root";
+  return input.delegationDepth === 0 ? "operator-root" : "delegated";
+}
+
+/**
  * The same resolution for a list coming back OUT of durable storage, where the
  * session's origin is whatever its record says it is rather than a live
  * request. The global bound alone is not enough here: without the origin, a
  * delegated session that hand-edits its own profile to name a server the
  * Viewer *can* grant would have it honoured on the next resume, attach or
- * structured recovery. Fail-closed by construction — {@link sessionOriginFor}
- * reads anything but a clean operator root as delegated.
+ * structured recovery. Fail-closed by construction — {@link
+ * storedSessionOriginFor} grants the operator-root default only to a record
+ * that proves it is one.
  */
 export function mcpServersForStoredSession(
   input: SessionOriginInput & { requested?: readonly string[] | null },
   policy: McpGrantPolicy = MCP_GRANT_POLICY,
 ): string[] {
-  return mcpServersForSession({ origin: sessionOriginFor(input), requested: input.requested }, policy);
+  return mcpServersForSession({ origin: storedSessionOriginFor(input), requested: input.requested }, policy);
 }
 
 /** Last line of the bound, where an engine's enable table is materialized: the

--- a/src/lib/agent/mcpAllowlist.ts
+++ b/src/lib/agent/mcpAllowlist.ts
@@ -194,9 +194,19 @@ type StoredEntry = {
   artifactPath?: string | null;
   launchProfile?: { mcpServers: string[] } | null;
 };
+type StoredReceipt = {
+  conversationId?: string | null;
+  agentRole?: string | null;
+  delegationDepth?: number | null;
+  parentConversationId?: string | null;
+  launchProfile?: { mcpServers: string[] } | null;
+};
+type StoredLineageEdge = { parentConversationId?: string | null };
 export interface StoredGrantFile {
   conversations: Record<string, StoredConversation>;
   entries: Record<string, StoredEntry>;
+  receipts?: Record<string, StoredReceipt>;
+  lineageEdges?: Record<string, StoredLineageEdge>;
 }
 
 function isBaselineGrant(names: readonly string[]): boolean {
@@ -250,10 +260,12 @@ function storedGrantOwnership(
 ): StoredGrantOwnership {
   const grants = new Map<string, string[] | null>();
   const pathOwner = new Map<string, string | null>();
-  for (const conversation of Object.values(file.conversations)) {
+  for (const [conversationId, conversation] of Object.entries(file.conversations)) {
+    const edge = file.lineageEdges?.[conversationId];
+    const lineageDelegated = Boolean(edge?.parentConversationId && edge.parentConversationId !== conversationId);
     for (const generation of conversation.generations) {
       const rowKey = generationEntryRowKey(conversation.engine, generation);
-      const granted = decideStoredGrant(conversation, generation, policy);
+      const granted = decideStoredGrant(conversation, generation, policy, lineageDelegated);
       if (decideGenerations) generation.launchProfile.mcpServers = granted;
       if (!grants.has(rowKey)) grants.set(rowKey, granted);
       else {
@@ -296,6 +308,71 @@ function entryGrant(id: string, entry: StoredEntry, ownership: StoredGrantOwners
   return ownership.grants.get(id)!;
 }
 
+/**
+ * What OTHER rows attest about a receipt's origin.
+ *
+ * A receipt's own `agentRole`, `delegationDepth` and `parentConversationId` are
+ * fields on the very row being authorised, so a row rewritten into root shape
+ * would authorise itself. The rows that attest independently are:
+ *
+ *  - the LINEAGE EDGE, which admission (#393) writes for every delegated launch
+ *    as its own row keyed by the child conversation — present before a
+ *    conversation record exists, and not reachable by editing the receipt's own
+ *    fields;
+ *  - the CONVERSATION row once the launch has settled, which is the
+ *    origin-bearing row every generation and entry grant is already decided
+ *    from.
+ *
+ * Both are looked up by the receipt's conversation id, and the conversation map
+ * key is storage identity in the same sense an entry's row key is.
+ */
+function anchoredReceiptOrigins(file: StoredGrantFile, receipt: StoredReceipt): Set<SessionOrigin> {
+  const anchors = new Set<SessionOrigin>();
+  const conversationId = receipt.conversationId;
+  if (!conversationId) return anchors;
+  const edge = file.lineageEdges?.[conversationId];
+  if (edge?.parentConversationId && edge.parentConversationId !== conversationId) anchors.add("delegated");
+  const conversation = file.conversations[conversationId];
+  if (conversation) {
+    anchors.add(storedSessionOriginFor({
+      agentRole: conversation.agentRole,
+      delegationDepth: conversation.delegationDepth,
+      parentConversationId: conversation.generations.at(-1)?.launchProfile.parentConversationId ?? null,
+    }));
+  }
+  return anchors;
+}
+
+/**
+ * The grant a receipt may keep.
+ *
+ * Settlement copies `receipt.launchProfile` onto the conversation generation
+ * and the entry row, and stamps the receipt's role and depth onto a brand-new
+ * conversation, so a receipt that keeps a connector does not merely hold one —
+ * it MANUFACTURES the origin evidence every later read trusts. Deciding that
+ * from the receipt's own fields would let a row promote itself.
+ *
+ * So the attesting rows win, and a receipt whose self-description CONTRADICTS
+ * them is denied outright: a contradiction is a tamper signal, not a tie to
+ * break in the caller's favour. Anchors that disagree with each other deny for
+ * the same reason. Only where nothing attests at all — an un-parented launch
+ * that has not settled yet, which has no other row by construction — does the
+ * receipt's own shape decide, and there it can still only narrow.
+ */
+function receiptGrant(file: StoredGrantFile, receipt: StoredReceipt, policy: McpGrantPolicy): string[] | null {
+  const stored = receipt.launchProfile!.mcpServers;
+  const described = storedSessionOriginFor({
+    agentRole: receipt.agentRole,
+    delegationDepth: receipt.delegationDepth,
+    parentConversationId: receipt.parentConversationId,
+  });
+  const anchors = anchoredReceiptOrigins(file, receipt);
+  if (anchors.size > 1) return null;
+  const [anchored] = anchors;
+  if (anchored !== undefined && anchored !== described) return null;
+  return mcpServersForSession({ origin: anchored ?? described, requested: stored }, policy);
+}
+
 function reboundGrants<T extends StoredGrantFile>(file: T, policy: McpGrantPolicy, assembled: boolean): T {
   const ownership = storedGrantOwnership(file, policy, true);
   for (const [id, entry] of Object.entries(file.entries)) {
@@ -308,6 +385,12 @@ function reboundGrants<T extends StoredGrantFile>(file: T, policy: McpGrantPolic
     const next = granted ?? DEFAULT_SPAWN_MCP_SERVERS;
     if (!sameGrant(stored, next)) entry.launchProfile!.mcpServers = [...next];
   }
+  for (const receipt of Object.values(file.receipts ?? {})) {
+    const stored = receipt.launchProfile?.mcpServers;
+    if (!stored || isBaselineGrant(stored)) continue;
+    const granted = receiptGrant(file, receipt, policy) ?? DEFAULT_SPAWN_MCP_SERVERS;
+    if (!sameGrant(stored, granted)) receipt.launchProfile!.mcpServers = [...granted];
+  }
   return file;
 }
 
@@ -315,18 +398,26 @@ function decideStoredGrant(
   conversation: StoredConversation,
   generation: StoredGeneration,
   policy: McpGrantPolicy,
+  /** Whether a lineage edge — a row outside this conversation — records it as
+      somebody's child. */
+  lineageDelegated: boolean,
 ): string[] {
   const stored = generation.launchProfile.mcpServers;
   /* Every read walks this, so the overwhelmingly common baseline profile skips
      the resolver and its allocation; only a profile claiming more than the
      baseline is worth re-deciding. */
   if (isBaselineGrant(stored)) return stored;
-  return mcpServersForStoredSession({
+  const origin = storedSessionOriginFor({
     parentConversationId: generation.launchProfile.parentConversationId,
     agentRole: conversation.agentRole,
     delegationDepth: conversation.delegationDepth,
-    requested: stored,
-  }, policy);
+  });
+  /* A conversation row claiming to be an operator root while its own lineage
+     edge records a parent is contradictory, and a settled receipt forged into
+     root shape is exactly how such a row gets written. Deny rather than believe
+     whichever copy is more convenient. */
+  if (lineageDelegated && origin !== "delegated") return [...DEFAULT_SPAWN_MCP_SERVERS];
+  return mcpServersForSession({ origin, requested: stored }, policy);
 }
 
 /**

--- a/src/lib/agent/mcpAllowlist.ts
+++ b/src/lib/agent/mcpAllowlist.ts
@@ -219,6 +219,31 @@ function isBaselineGrant(names: readonly string[]): boolean {
   return names.length === 1 && names[0] === "viewer";
 }
 
+/**
+ * Whether a durable row claims anything other than the baseline every session
+ * already holds, on any profile it carries.
+ *
+ * This is the exact condition {@link reboundStoredMcpGrants} and
+ * {@link reboundAssembledMcpGrants} use to decide whether a row is worth
+ * re-deciding: a row already at the baseline is left byte-identical by both.
+ * A lazy storage backend can therefore use it to decide whether reading a
+ * single row obliges it to assemble the whole file first, WITHOUT that being a
+ * way around the gate — the rows it skips are the ones the gate would return
+ * unchanged. Everything that could gain by the decision being skipped answers
+ * `true` here, including an empty selection, which the decision does rewrite.
+ */
+export function rowClaimsBeyondBaselineGrant(row: unknown): boolean {
+  const claimed = (value: unknown): boolean => Array.isArray(value) && !isBaselineGrant(value as string[]);
+  if (!row || typeof row !== "object") return false;
+  const candidate = row as { launchProfile?: { mcpServers?: unknown } | null; generations?: unknown };
+  if (claimed(candidate.launchProfile?.mcpServers)) return true;
+  if (!Array.isArray(candidate.generations)) return false;
+  return candidate.generations.some((generation) => {
+    const profile = (generation as { launchProfile?: { mcpServers?: unknown } } | null)?.launchProfile;
+    return claimed(profile?.mcpServers);
+  });
+}
+
 function sameGrant(left: readonly string[], right: readonly string[]): boolean {
   return left.length === right.length && left.every((name, index) => name === right[index]);
 }
@@ -257,10 +282,17 @@ function generationEntryRowKey(engine: string, generation: StoredGeneration): st
 interface StoredGrantOwnership {
   grants: Map<string, string[] | null>;
   pathOwner: Map<string, string | null>;
-  /** The ORIGIN of the generation owning each entry row key, so a receipt can
-      be attested by the conversation that owns the row it settled onto rather
-      than by the conversation it names. `null` where owners disagree. */
+  /** The ORIGIN of the generation owning each entry row key, so a receipt is
+      also attested by the conversation that owns the row it settled onto, by
+      the same row-key rule entries use — forging the receipt's own key just
+      points it at a row some OTHER conversation owns, and the attestation
+      follows the owner rather than the pointer. `null` where owners disagree. */
   origins: Map<string, SessionOrigin | null>;
+  /** The origin each conversation row states for ITSELF. Its lineage edge is a
+      separate attestor and stays separate: a conversation contradicted by its
+      own edge then produces two disagreeing attestations rather than one
+      pre-resolved answer, which denies for the reason it should. */
+  conversationOrigins: Map<string, SessionOrigin>;
 }
 
 function storedGrantOwnership(
@@ -271,9 +303,15 @@ function storedGrantOwnership(
   const grants = new Map<string, string[] | null>();
   const pathOwner = new Map<string, string | null>();
   const origins = new Map<string, SessionOrigin | null>();
+  const conversationOrigins = new Map<string, SessionOrigin>();
   for (const [conversationId, conversation] of Object.entries(file.conversations)) {
     const edge = file.lineageEdges?.[conversationId];
     const lineageDelegated = Boolean(edge?.parentConversationId && edge.parentConversationId !== conversationId);
+    conversationOrigins.set(conversationId, storedSessionOriginFor({
+      parentConversationId: conversation.generations.at(-1)?.launchProfile.parentConversationId ?? null,
+      agentRole: conversation.agentRole,
+      delegationDepth: conversation.delegationDepth,
+    }));
     for (const generation of conversation.generations) {
       const rowKey = generationEntryRowKey(conversation.engine, generation);
       const granted = decideStoredGrant(conversation, generation, policy, lineageDelegated);
@@ -298,7 +336,7 @@ function storedGrantOwnership(
       else if (pathOwner.get(recorded) !== rowKey) pathOwner.set(recorded, null);
     }
   }
-  return { grants, pathOwner, origins };
+  return { grants, pathOwner, origins, conversationOrigins };
 }
 
 /**
@@ -329,30 +367,28 @@ function entryGrant(id: string, entry: StoredEntry, ownership: StoredGrantOwners
 }
 
 /**
- * Who attests to a receipt's origin — chosen by the VERIFIER, keyed by the
- * launch id the receipt is stored under.
+ * What OTHER rows attest about a receipt's origin, indexed by the launch id the
+ * receipt is stored under.
  *
- * A receipt's `agentRole`, `delegationDepth` and `parentConversationId` are
- * fields on the row being authorised, so a row rewritten into root shape
- * authorises itself. But so is `conversationId`: letting the receipt name the
- * conversation whose origin vouches for it lets the subject pick its own
- * attestor — retarget it at an operator root, or at an id nothing attests to,
- * and the vouching changes with it. Selection has to run the other way.
+ * The LINEAGE EDGE is indexed from the attesting row inward, by the launch id
+ * in the edge's own `evidence`, and that direction is the whole point. Looking
+ * the edge up by `receipt.conversationId` would let the subject pick its own
+ * attestor: `conversationId` is a field on the row being authorised, so
+ * retargeting it at an operator root — or at an id no edge names — would move
+ * or SHED the attestation. Indexed by `evidence.launchId`, the edge names the
+ * receipt rather than the receipt naming the edge; admission (#393) writes it
+ * as a separate row before any conversation record exists, and a receipt
+ * cannot rewrite which edge names it.
  *
- * So attestations are indexed from the attesting rows inward:
- *
- *  - a LINEAGE EDGE attests DELEGATED for the launch id in its own `evidence`.
- *    The edge is a separate row, keyed by the child conversation, written by
- *    admission (#393) before any conversation record exists. A receipt cannot
- *    choose which edge names it, so retargeting its `conversationId` does not
- *    move or shed the attestation.
- *  - a CONVERSATION attests ROOT for a settled receipt only through generation
- *    OWNERSHIP: the entry row key the receipt settled onto must be owned by one
- *    of that conversation's generations, by the same row-key rule entries use.
- *    Forging the receipt's own key just points it at a row some OTHER
- *    conversation owns, and the attestation follows the owner, not the pointer.
- *
- * A launch id no row attests to is UNATTESTED, and unattested denies.
+ * The other two attestors are reached through pointers the receipt DOES
+ * control — the conversation it names, and the conversation owning the entry
+ * row its `key` names. They are collected anyway because they can only ever
+ * ADD a contradiction: {@link receiptGrant} never takes its origin from an
+ * attestation, only denies on disagreement, so a pointer a tampered receipt
+ * retargets or blanks buys it nothing the unattested case did not already
+ * give. Where either resolves to unresolvable identity — two generations
+ * claiming one row key with different origins — both origins are attested, so
+ * the disagreement denies.
  */
 function receiptAttestations(file: StoredGrantFile, ownership: StoredGrantOwnership): Map<string, Set<SessionOrigin>> {
   const attested = new Map<string, Set<SessionOrigin>>();
@@ -367,10 +403,25 @@ function receiptAttestations(file: StoredGrantFile, ownership: StoredGrantOwners
     if (typeof launchId === "string" && launchId) attest(launchId, "delegated");
   }
   for (const [launchId, receipt] of Object.entries(file.receipts ?? {})) {
+    const namedId = receipt.conversationId;
+    if (namedId) {
+      /* The edge keyed by the conversation the receipt names, which catches an
+         edge carrying no `evidence.launchId` to be indexed by — an engine-native
+         or pre-#393 row. Shed by retargeting `conversationId`, which is why it
+         supplements the evidence index above rather than replacing it. */
+      const namedEdge = file.lineageEdges?.[namedId];
+      if (namedEdge?.parentConversationId && namedEdge.parentConversationId !== namedId) attest(launchId, "delegated");
+      const named = ownership.conversationOrigins.get(namedId);
+      if (named) attest(launchId, named);
+    }
     if (!receipt.key) continue;
     const rowKey = sessionKeyId({ engine: receipt.key.engine as never, sessionId: receipt.key.sessionId });
-    const owner = ownership.origins.get(rowKey);
+    if (!ownership.origins.has(rowKey)) continue;
+    const owner = ownership.origins.get(rowKey)!;
     if (owner) attest(launchId, owner);
+    /* Unresolvable ownership is not silence: attest both readings so the
+       disagreement denies, exactly as two attestors that disagree would. */
+    else for (const either of ["operator-root", "delegated"] as const) attest(launchId, either);
   }
   return attested;
 }
@@ -383,14 +434,23 @@ function receiptAttestations(file: StoredGrantFile, ownership: StoredGrantOwners
  * conversation, so a receipt that keeps a connector does not merely hold one —
  * it MANUFACTURES the origin evidence every later read trusts.
  *
- * A receipt therefore has to be VOUCHED FOR, not merely un-contradicted:
+ * The receipt's own shape decides its origin — the same affirmative root marker
+ * ({@link storedSessionOriginFor}) every conversation and entry row is decided
+ * by, so a blank receipt is delegated and only a stated depth `0` or `operator`
+ * origin reads as a root. What the attesting rows do is CONTRADICT:
  *
- *  - unattested denies, because absence is not attestation and a subject that
- *    can delete the rows naming it would otherwise delete its way to a grant;
- *  - attestors that disagree with each other deny;
- *  - an attestation the receipt's own self-description contradicts denies,
- *    because a contradiction is a tamper signal rather than a tie to resolve in
- *    the caller's favour.
+ *  - an attestation the self-description disagrees with denies, in EITHER
+ *    direction, because a contradiction is a tamper signal rather than a tie to
+ *    resolve in the caller's favour;
+ *  - attestors that disagree with each other deny for the same reason;
+ *  - and where nothing attests — an un-parented launch that has not settled,
+ *    which by construction has no other row yet — the receipt's own shape
+ *    stands, and there it can still only narrow the policy default.
+ *
+ * A tampered delegated receipt cannot reach that last case: the lineage edge
+ * admission wrote for it is indexed by the launch id in the EDGE's evidence, so
+ * rewriting the receipt into root shape leaves the edge still attesting
+ * delegated and the contradiction still denying.
  */
 function receiptGrant(
   attestations: Map<string, Set<SessionOrigin>>,
@@ -398,16 +458,14 @@ function receiptGrant(
   receipt: StoredReceipt,
   policy: McpGrantPolicy,
 ): string[] | null {
-  const attested = attestations.get(launchId);
-  if (!attested || attested.size !== 1) return null;
-  const [origin] = attested;
   const described = storedSessionOriginFor({
     agentRole: receipt.agentRole,
     delegationDepth: receipt.delegationDepth,
     parentConversationId: receipt.parentConversationId,
   });
-  if (origin !== described) return null;
-  return mcpServersForSession({ origin: origin!, requested: receipt.launchProfile!.mcpServers }, policy);
+  const attested = attestations.get(launchId);
+  if (attested && (attested.size > 1 || !attested.has(described))) return null;
+  return mcpServersForSession({ origin: described, requested: receipt.launchProfile!.mcpServers }, policy);
 }
 
 function reboundGrants<T extends StoredGrantFile>(file: T, policy: McpGrantPolicy, assembled: boolean): T {

--- a/src/lib/agent/registry.ts
+++ b/src/lib/agent/registry.ts
@@ -28,7 +28,7 @@ import {
 } from "@/lib/accounts/migration/contracts";
 
 import type { AgentEngine } from "./cli";
-import { MCP_GRANT_POLICY, mcpServersForStoredSession, type McpGrantPolicy } from "./mcpAllowlist";
+import { mcpServersForStoredSession, reboundAssembledMcpGrants, reboundEntryMcpGrant, reboundStoredMcpGrants, type McpGrantPolicy } from "./mcpAllowlist";
 import { liveAccountConversationIds, type AccountLivenessOptions } from "./accountLiveness";
 import { loadSpawnNestingPolicy } from "./nestingPolicy";
 import {
@@ -1007,10 +1007,10 @@ function nativeGenerationId(pathname: string): string {
   return path.basename(pathname).match(/([0-9a-f-]{36})(?:\.jsonl)?$/i)?.[1] ?? crypto.randomUUID();
 }
 
-function normalizeGeneration(value: NativeGeneration): NativeGeneration {
+function normalizeGeneration(value: NativeGeneration, policy?: McpGrantPolicy): NativeGeneration {
   return {
     ...value,
-    launchProfile: emptyLaunchProfile(value.launchProfile ?? {}),
+    launchProfile: emptyLaunchProfile(value.launchProfile ?? {}, policy),
     historyHash: typeof value.historyHash === "string" ? value.historyHash : null,
     host: value.host && typeof value.host === "object" ? value.host : null,
   };
@@ -1045,10 +1045,10 @@ function normalizeStructuredHost(value: unknown): StructuredHostColumns | null {
   };
 }
 
-function normalizeEntry(value: AgentRegistryEntry): AgentRegistryEntry {
+function normalizeEntry(value: AgentRegistryEntry, policy?: McpGrantPolicy): AgentRegistryEntry {
   return {
     ...value,
-    ...(value.launchProfile ? { launchProfile: emptyLaunchProfile(value.launchProfile) } : {}),
+    ...(value.launchProfile ? { launchProfile: emptyLaunchProfile(value.launchProfile, policy) } : {}),
     host: value.host && typeof value.host === "object" && value.host.kind === "tmux" ? value.host : null,
     structuredHost: normalizeStructuredHost(value.structuredHost),
   };
@@ -1146,8 +1146,10 @@ function normalizeConversationReconfigure(value: unknown): ConversationReconfigu
   };
 }
 
-function normalizeConversation(value: RegistryConversation): RegistryConversation {
-  const generations = Array.isArray(value.generations) ? value.generations.map(normalizeGeneration) : [];
+function normalizeConversation(value: RegistryConversation, policy?: McpGrantPolicy): RegistryConversation {
+  const generations = Array.isArray(value.generations)
+    ? value.generations.map((generation) => normalizeGeneration(generation, policy))
+    : [];
   const current = generations.at(-1);
   const legacyContinuity = (value.migration as (ConversationMigration & { continuityPaths?: unknown }) | null)?.continuityPaths;
   const providerReceipt = normalizeProviderReceipt(value.migration?.providerReceipt);
@@ -2241,44 +2243,6 @@ function normalizeSpawnRejection(value: SpawnRejection | null | undefined): Spaw
   };
 }
 
-/**
- * Re-decides every stored MCP grant from the conversation's durable origin as
- * the registry is read (#739).
- *
- * `emptyLaunchProfile` already applies the global bound to each profile, but a
- * bound alone cannot tell an operator root apart from a delegated worker: a
- * delegated session that edits this file by hand to name a server the Viewer
- * *can* grant would otherwise have it honoured by attach, resume and structured
- * host adoption, all of which read these profiles straight off disk. Doing it
- * here means no reader has to remember to.
- */
-export function reboundStoredMcpGrants(file: RegistryFile, policy: McpGrantPolicy = MCP_GRANT_POLICY): RegistryFile {
-  const isBaseline = (names: readonly string[]) => names.length === 1 && names[0] === "viewer";
-  for (const conversation of Object.values(file.conversations)) {
-    for (const generation of conversation.generations) {
-      const stored = generation.launchProfile.mcpServers;
-      /* Every read walks this, so the overwhelmingly common baseline profile
-         skips the resolver and its allocation; only a profile claiming more
-         than the baseline is worth re-deciding. */
-      const granted = isBaseline(stored) ? stored : mcpServersForStoredSession({
-        parentConversationId: generation.launchProfile.parentConversationId,
-        agentRole: conversation.agentRole,
-        delegationDepth: conversation.delegationDepth,
-        requested: stored,
-      }, policy);
-      generation.launchProfile.mcpServers = granted;
-      /* The entry row is the copy structured host adoption reads, and it can be
-         tampered with on its own, so it follows the conversation's decision. */
-      const entry = file.entries[sessionKeyId({ engine: conversation.engine, sessionId: generation.id })];
-      const mirrored = entry?.launchProfile?.mcpServers;
-      if (entry?.launchProfile && (mirrored!.length !== granted.length || mirrored!.some((name, index) => name !== granted[index]))) {
-        entry.launchProfile.mcpServers = [...granted];
-      }
-    }
-  }
-  return file;
-}
-
 function backfillMaterializedSpawnArtifacts(file: RegistryFile): RegistryFile {
   for (const receipt of Object.values(file.receipts)) {
     if (receipt.transport !== "structured"
@@ -2342,10 +2306,12 @@ function upgradeV1(parsed: Omit<Partial<RegistryFile>, "version">): RegistryFile
   };
 }
 
-export function normalizeRegistry(value: unknown): RegistryFile {
+export function normalizeRegistry(value: unknown, policy?: McpGrantPolicy): RegistryFile {
   const parsed = value as Omit<Partial<RegistryFile>, "version"> & { version?: unknown };
   if (parsed.version === 1 && parsed.entries && parsed.receipts && typeof parsed.entries === "object" && typeof parsed.receipts === "object") {
-    return upgradeV1(parsed);
+    /* The v1 upgrade carries entries across verbatim, so it needs the same
+       grant decision every other read gets (#739). */
+    return reboundStoredMcpGrants(upgradeV1(parsed), policy);
   }
   if (parsed.version !== 2 || !parsed.entries || !parsed.receipts || typeof parsed.entries !== "object" || typeof parsed.receipts !== "object") {
     throw new RegistryReadError("agent registry schema is unsupported");
@@ -2356,7 +2322,7 @@ export function normalizeRegistry(value: unknown): RegistryFile {
     : {};
   return reboundStoredMcpGrants(backfillMaterializedSpawnArtifacts({
       version: 2,
-      entries: Object.fromEntries(Object.entries(parsed.entries).map(([id, entry]) => [id, normalizeEntry(entry)])),
+      entries: Object.fromEntries(Object.entries(parsed.entries).map(([id, entry]) => [id, normalizeEntry(entry, policy)])),
       receipts: Object.fromEntries(Object.entries(parsed.receipts).map(([id, receipt]) => [id, normalizeReceipt(receipt)])),
       lineageEdges: parsed.lineageEdges && typeof parsed.lineageEdges === "object"
         ? Object.fromEntries(Object.entries(parsed.lineageEdges).map(([id, edge]) => [id, normalizeLineageEdge(edge)]))
@@ -2367,7 +2333,7 @@ export function normalizeRegistry(value: unknown): RegistryFile {
         ? { serverPid: typeof (legacy as { serverPid?: unknown }).serverPid === "number" ? (legacy as { serverPid: number }).serverPid : null, panes: ((legacy as { panes?: unknown }).panes as Record<string, ResumePaneRecord>) ?? {} }
         : { serverPid: null, panes: {} },
       conversations: parsed.conversations && typeof parsed.conversations === "object"
-        ? Object.fromEntries(Object.entries(parsed.conversations).map(([id, conversation]) => [id, normalizeConversation(conversation)]))
+        ? Object.fromEntries(Object.entries(parsed.conversations).map(([id, conversation]) => [id, normalizeConversation(conversation, policy)]))
         : {},
       conversationAliases: parsed.conversationAliases && typeof parsed.conversationAliases === "object"
         ? Object.fromEntries(Object.entries(parsed.conversationAliases).filter(([alias, destination]) => alias.startsWith("conversation_") && typeof destination === "string" && destination.startsWith("conversation_"))) as RegistryFile["conversationAliases"]
@@ -2392,13 +2358,15 @@ export function normalizeRegistry(value: unknown): RegistryFile {
         ? parsed.pendingSuccessorCleanups
         : {},
       pendingSupersedence: normalizePendingSupersedence(parsed.pendingSupersedence),
-  }));
+  }), policy);
 }
 
 function readFileWithPayload(filename: string): { file: RegistryFile; payload: string | null } {
   try {
     const payload = fs.readFileSync(filename, "utf8");
-    return { file: normalizeRegistry(JSON.parse(payload)), payload };
+    /* A whole file, so an entry no conversation owns is genuinely unowned and
+       falls back to the baseline rather than keeping a claimed grant (#739). */
+    return { file: reboundAssembledMcpGrants(normalizeRegistry(JSON.parse(payload))), payload };
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code === "ENOENT") return { file: clone(EMPTY), payload: null };
     if (error instanceof RegistryReadError) throw error;
@@ -2483,6 +2451,10 @@ export type AgentRegistrySqliteMode = "off" | "dual-write" | "read" | "sqlite";
 
 export interface AgentRegistryStorageOptions {
   sqliteMode?: AgentRegistrySqliteMode;
+  /** Grant bound for the MCP origin rebound (issue #739). Production omits it;
+      a test supplies a policy that HAS a grantable connector, since the shipped
+      bound has none and an empty bound proves nothing about the origin rule. */
+  mcpGrantPolicy?: McpGrantPolicy;
   sqliteFilename?: string;
   onSqliteWriterWait?: (durationMs: number) => void;
   onSqliteSnapshotLoad?: () => void;
@@ -2547,6 +2519,7 @@ function isRecoverableSpawnReadinessFailure(error: string | null): boolean {
     cannot leave an imaginary owner behind. */
 export class AgentRegistry {
   private readonly sqliteMode: AgentRegistrySqliteMode;
+  private readonly mcpGrantPolicy: McpGrantPolicy | undefined;
   private readonly sqliteStore: SqliteAgentRegistryStore | null;
   private readonly beforeDualWriteMutationReplace: (() => void) | undefined;
   private readOnlyCache: { signature: string; snapshot: RegistryFile } | null = null;
@@ -2572,6 +2545,7 @@ export class AgentRegistry {
     storage: AgentRegistryStorageOptions = {},
   ) {
     this.sqliteMode = storage.sqliteMode ?? sqliteModeFromEnvironment();
+    this.mcpGrantPolicy = storage.mcpGrantPolicy;
     this.mirrorCheckpointMs = Math.max(0, storage.mirrorCheckpointMs ?? 5_000);
     this.now = storage.now ?? Date.now;
     this.scheduleMirrorCheckpoint = storage.scheduleMirrorCheckpoint
@@ -2582,7 +2556,8 @@ export class AgentRegistry {
       ? null
       : new SqliteAgentRegistryStore(storage.sqliteFilename ?? defaultSqliteFilename(filename), {
           initialSnapshot: readFile(filename),
-          normalize: normalizeRegistry,
+          normalize: (value) => normalizeRegistry(value, storage.mcpGrantPolicy),
+          mcpGrantPolicy: storage.mcpGrantPolicy,
           onWriterWait: (duration) => {
             this.recordMetric(this.writerWaits, duration);
             storage.onSqliteWriterWait?.(duration);
@@ -4323,6 +4298,10 @@ export class AgentRegistry {
       const entry = file.entries[sessionKeyId(key)];
       if (!entry?.structuredHost) return null;
       if (entry.status === "unhosted" && options.allowUnhosted !== true) return null;
+      /* Adoption builds its host options from the entry this returns, and a
+         mutation loads rows lazily rather than from an assembled snapshot, so
+         the origin decision is applied to this one row here (#739). */
+      reboundEntryMcpGrant(file, key, this.mcpGrantPolicy);
       const liveHost = entry.structuredHost.process;
       if (liveHost && this.ownerAlive(liveHost)) return null;
       const requestedOwner = structuredClaimOwner(owner);

--- a/src/lib/agent/registry.ts
+++ b/src/lib/agent/registry.ts
@@ -28,6 +28,7 @@ import {
 } from "@/lib/accounts/migration/contracts";
 
 import type { AgentEngine } from "./cli";
+import { MCP_GRANT_POLICY, mcpServersForStoredSession, type McpGrantPolicy } from "./mcpAllowlist";
 import { liveAccountConversationIds, type AccountLivenessOptions } from "./accountLiveness";
 import { loadSpawnNestingPolicy } from "./nestingPolicy";
 import {
@@ -2240,6 +2241,44 @@ function normalizeSpawnRejection(value: SpawnRejection | null | undefined): Spaw
   };
 }
 
+/**
+ * Re-decides every stored MCP grant from the conversation's durable origin as
+ * the registry is read (#739).
+ *
+ * `emptyLaunchProfile` already applies the global bound to each profile, but a
+ * bound alone cannot tell an operator root apart from a delegated worker: a
+ * delegated session that edits this file by hand to name a server the Viewer
+ * *can* grant would otherwise have it honoured by attach, resume and structured
+ * host adoption, all of which read these profiles straight off disk. Doing it
+ * here means no reader has to remember to.
+ */
+export function reboundStoredMcpGrants(file: RegistryFile, policy: McpGrantPolicy = MCP_GRANT_POLICY): RegistryFile {
+  const isBaseline = (names: readonly string[]) => names.length === 1 && names[0] === "viewer";
+  for (const conversation of Object.values(file.conversations)) {
+    for (const generation of conversation.generations) {
+      const stored = generation.launchProfile.mcpServers;
+      /* Every read walks this, so the overwhelmingly common baseline profile
+         skips the resolver and its allocation; only a profile claiming more
+         than the baseline is worth re-deciding. */
+      const granted = isBaseline(stored) ? stored : mcpServersForStoredSession({
+        parentConversationId: generation.launchProfile.parentConversationId,
+        agentRole: conversation.agentRole,
+        delegationDepth: conversation.delegationDepth,
+        requested: stored,
+      }, policy);
+      generation.launchProfile.mcpServers = granted;
+      /* The entry row is the copy structured host adoption reads, and it can be
+         tampered with on its own, so it follows the conversation's decision. */
+      const entry = file.entries[sessionKeyId({ engine: conversation.engine, sessionId: generation.id })];
+      const mirrored = entry?.launchProfile?.mcpServers;
+      if (entry?.launchProfile && (mirrored!.length !== granted.length || mirrored!.some((name, index) => name !== granted[index]))) {
+        entry.launchProfile.mcpServers = [...granted];
+      }
+    }
+  }
+  return file;
+}
+
 function backfillMaterializedSpawnArtifacts(file: RegistryFile): RegistryFile {
   for (const receipt of Object.values(file.receipts)) {
     if (receipt.transport !== "structured"
@@ -2315,7 +2354,7 @@ export function normalizeRegistry(value: unknown): RegistryFile {
   const heldDeliveries = parsed.heldDeliveries && typeof parsed.heldDeliveries === "object"
     ? Object.fromEntries(Object.entries(parsed.heldDeliveries).map(([id, delivery]) => [id, normalizeHeldDelivery(delivery)]))
     : {};
-  return backfillMaterializedSpawnArtifacts({
+  return reboundStoredMcpGrants(backfillMaterializedSpawnArtifacts({
       version: 2,
       entries: Object.fromEntries(Object.entries(parsed.entries).map(([id, entry]) => [id, normalizeEntry(entry)])),
       receipts: Object.fromEntries(Object.entries(parsed.receipts).map(([id, receipt]) => [id, normalizeReceipt(receipt)])),
@@ -2353,7 +2392,7 @@ export function normalizeRegistry(value: unknown): RegistryFile {
         ? parsed.pendingSuccessorCleanups
         : {},
       pendingSupersedence: normalizePendingSupersedence(parsed.pendingSupersedence),
-  });
+  }));
 }
 
 function readFileWithPayload(filename: string): { file: RegistryFile; payload: string | null } {
@@ -3277,6 +3316,24 @@ export class AgentRegistry {
          preset or a lineage parent denies it on resume, successor and restart
          adoption alike, whatever a stored or requested profile claims. */
       if (existingConversation?.agentRole || parentConversationId) profile.plugins = [];
+      /* Same rule for the MCP grant (#739), from the same durable evidence:
+         role preset, lineage parent, recorded delegation depth and — for a
+         genuinely new launch — the request origin. The global bound alone would
+         let a delegated session hand-edit its profile to a server the Viewer
+         CAN grant and keep it across resume; re-resolving the origin here means
+         the grant is re-decided, never replayed. A successor or resume relaunch
+         carries the conversation's own identity, so its `successor` origin must
+         not be mistaken for a fresh delegation signal. */
+      const launchOrigin = (input.purpose ?? "launch") === "launch" && input.origin && input.origin.kind !== "successor"
+        ? { kind: input.origin.kind }
+        : undefined;
+      profile.mcpServers = mcpServersForStoredSession({
+        origin: launchOrigin,
+        parentConversationId: parentConversationId ?? profile.parentConversationId,
+        agentRole: existingConversation?.agentRole ?? role,
+        delegationDepth: existingConversation?.delegationDepth ?? null,
+        requested: profile.mcpServers,
+      });
       if (existingConversation && existingConversation.engine !== input.engine) {
         throw new Error("spawn conversation ownership is invalid");
       }

--- a/src/lib/agent/registry.ts
+++ b/src/lib/agent/registry.ts
@@ -2129,36 +2129,18 @@ function observationIsCurrent(currentObservedAt: string | null, observedAt: stri
   return observedAt >= currentObservedAt;
 }
 
-/** A receipt's launch profile, re-decided from the receipt's OWN durable origin
-    evidence (#739).
+/** A receipt's launch profile, held to the GLOBAL grant bound (#739).
 
-    A receipt is not a passive record of a finished decision: settlement copies
-    `receipt.launchProfile` onto the conversation generation and the entry row,
-    and attach reads it back, so a receipt that survives with a connector on it
-    widens the session AFTER the grant decision was made. The global bound
-    `emptyLaunchProfile` applies cannot see that — it holds a list, not a
-    session — and a delegated receipt naming a genuinely grantable server would
-    ride straight through it.
-
-    The evidence is on the row itself: admission (#393) stamps `agentRole`,
-    `delegationDepth` and `parentConversationId` on every receipt, so this is
-    decidable per row with no conversation in sight, and absent evidence denies
-    rather than promoting. */
+    The origin half of the decision is deliberately NOT made here. Settlement
+    copies `receipt.launchProfile` onto the conversation generation and the
+    entry row, and stamps the receipt's own role and depth onto a brand-new
+    conversation, so a receipt does not merely hold a grant — it manufactures
+    the origin evidence every later read trusts. Deciding it from the fields
+    travelling on the receipt would let the row authorise itself, whatever its
+    lineage says. That decision belongs to `reboundStoredMcpGrants`, which sees
+    the lineage edge and the conversation row the receipt cannot rewrite. */
 function receiptLaunchProfile(value: SpawnReceipt, policy?: McpGrantPolicy): LaunchProfile {
-  const profile = emptyLaunchProfile({ ...(value.launchProfile ?? {}), cwd: value.launchProfile?.cwd ?? value.cwd }, policy);
-  /* Every read walks every receipt, so the overwhelmingly common baseline
-     profile skips the resolver and its allocation — as the conversation path
-     does. Only a profile claiming more than the baseline is worth deciding. */
-  if (profile.mcpServers.length === 1 && profile.mcpServers[0] === "viewer") return profile;
-  return {
-    ...profile,
-    mcpServers: mcpServersForStoredSession({
-      parentConversationId: value.parentConversationId ?? profile.parentConversationId,
-      agentRole: normalizeAgentRole(value.agentRole),
-      delegationDepth: normalizeDelegationDepth(value.delegationDepth),
-      requested: profile.mcpServers,
-    }, policy),
-  };
+  return emptyLaunchProfile({ ...(value.launchProfile ?? {}), cwd: value.launchProfile?.cwd ?? value.cwd }, policy);
 }
 
 function normalizeReceipt(value: SpawnReceipt, policy?: McpGrantPolicy): SpawnReceipt {

--- a/src/lib/agent/registry.ts
+++ b/src/lib/agent/registry.ts
@@ -2129,7 +2129,35 @@ function observationIsCurrent(currentObservedAt: string | null, observedAt: stri
   return observedAt >= currentObservedAt;
 }
 
-function normalizeReceipt(value: SpawnReceipt): SpawnReceipt {
+/** A receipt's launch profile, re-decided from the receipt's OWN durable origin
+    evidence (#739).
+
+    A receipt is not a passive record of a finished decision: settlement copies
+    `receipt.launchProfile` onto the conversation generation and the entry row,
+    and attach reads it back, so a receipt that survives with a connector on it
+    widens the session AFTER the grant decision was made. The global bound
+    `emptyLaunchProfile` applies cannot see that — it holds a list, not a
+    session — and a delegated receipt naming a genuinely grantable server would
+    ride straight through it.
+
+    The evidence is on the row itself: admission (#393) stamps `agentRole`,
+    `delegationDepth` and `parentConversationId` on every receipt, so this is
+    decidable per row with no conversation in sight, and absent evidence denies
+    rather than promoting. */
+function receiptLaunchProfile(value: SpawnReceipt, policy?: McpGrantPolicy): LaunchProfile {
+  const profile = emptyLaunchProfile({ ...(value.launchProfile ?? {}), cwd: value.launchProfile?.cwd ?? value.cwd }, policy);
+  return {
+    ...profile,
+    mcpServers: mcpServersForStoredSession({
+      parentConversationId: value.parentConversationId ?? profile.parentConversationId,
+      agentRole: normalizeAgentRole(value.agentRole),
+      delegationDepth: normalizeDelegationDepth(value.delegationDepth),
+      requested: profile.mcpServers,
+    }, policy),
+  };
+}
+
+function normalizeReceipt(value: SpawnReceipt, policy?: McpGrantPolicy): SpawnReceipt {
   const state = value.state === "completed" || value.state === "failed" || value.state === "pane-bound" || value.state === "host-verified" || value.state === "prompt-delivered" || value.state === "path-pending" || value.state === "conflicted"
     ? value.state
     : "starting";
@@ -2187,7 +2215,7 @@ function normalizeReceipt(value: SpawnReceipt): SpawnReceipt {
     agentRole: normalizeAgentRole(value.agentRole),
     delegationDepth: normalizeDelegationDepth(value.delegationDepth),
     rejection: normalizeSpawnRejection(value.rejection),
-    launchProfile: emptyLaunchProfile({ ...(value.launchProfile ?? {}), cwd: value.launchProfile?.cwd ?? value.cwd }),
+    launchProfile: receiptLaunchProfile(value, policy),
     explicitProject: validExplicitProject(value.explicitProject),
     launchDisplay: normalizeLaunchDisplay(value.launchDisplay),
     ...(value.retryClaim
@@ -2288,7 +2316,7 @@ function normalizePendingSupersedence(value: unknown): RegistryFile["pendingSupe
   return records;
 }
 
-function upgradeV1(parsed: Omit<Partial<RegistryFile>, "version">): RegistryFile {
+function upgradeV1(parsed: Omit<Partial<RegistryFile>, "version">, policy?: McpGrantPolicy): RegistryFile {
   const legacy = parsed.legacyResumePanes;
   return {
     ...clone(EMPTY),
@@ -2297,7 +2325,7 @@ function upgradeV1(parsed: Omit<Partial<RegistryFile>, "version">): RegistryFile
       codex: emptyPolicy(LEGACY_POLICY_RESTARTED_AT),
     },
     entries: (parsed.entries as RegistryFile["entries"]) ?? {},
-    receipts: Object.fromEntries(Object.entries((parsed.receipts as RegistryFile["receipts"]) ?? {}).map(([id, receipt]) => [id, normalizeReceipt(receipt)])),
+    receipts: Object.fromEntries(Object.entries((parsed.receipts as RegistryFile["receipts"]) ?? {}).map(([id, receipt]) => [id, normalizeReceipt(receipt, policy)])),
     conversationAliases: {},
     importedResumePanes: parsed.importedResumePanes === true,
     legacyResumePanes: legacy && typeof legacy === "object" && "panes" in legacy
@@ -2311,7 +2339,7 @@ export function normalizeRegistry(value: unknown, policy?: McpGrantPolicy): Regi
   if (parsed.version === 1 && parsed.entries && parsed.receipts && typeof parsed.entries === "object" && typeof parsed.receipts === "object") {
     /* The v1 upgrade carries entries across verbatim, so it needs the same
        grant decision every other read gets (#739). */
-    return reboundStoredMcpGrants(upgradeV1(parsed), policy);
+    return reboundStoredMcpGrants(upgradeV1(parsed, policy), policy);
   }
   if (parsed.version !== 2 || !parsed.entries || !parsed.receipts || typeof parsed.entries !== "object" || typeof parsed.receipts !== "object") {
     throw new RegistryReadError("agent registry schema is unsupported");
@@ -2323,7 +2351,7 @@ export function normalizeRegistry(value: unknown, policy?: McpGrantPolicy): Regi
   return reboundStoredMcpGrants(backfillMaterializedSpawnArtifacts({
       version: 2,
       entries: Object.fromEntries(Object.entries(parsed.entries).map(([id, entry]) => [id, normalizeEntry(entry, policy)])),
-      receipts: Object.fromEntries(Object.entries(parsed.receipts).map(([id, receipt]) => [id, normalizeReceipt(receipt)])),
+      receipts: Object.fromEntries(Object.entries(parsed.receipts).map(([id, receipt]) => [id, normalizeReceipt(receipt, policy)])),
       lineageEdges: parsed.lineageEdges && typeof parsed.lineageEdges === "object"
         ? Object.fromEntries(Object.entries(parsed.lineageEdges).map(([id, edge]) => [id, normalizeLineageEdge(edge)]))
         : {},
@@ -2361,12 +2389,12 @@ export function normalizeRegistry(value: unknown, policy?: McpGrantPolicy): Regi
   }), policy);
 }
 
-function readFileWithPayload(filename: string): { file: RegistryFile; payload: string | null } {
+function readFileWithPayload(filename: string, policy?: McpGrantPolicy): { file: RegistryFile; payload: string | null } {
   try {
     const payload = fs.readFileSync(filename, "utf8");
     /* A whole file, so an entry no conversation owns is genuinely unowned and
        falls back to the baseline rather than keeping a claimed grant (#739). */
-    return { file: reboundAssembledMcpGrants(normalizeRegistry(JSON.parse(payload))), payload };
+    return { file: reboundAssembledMcpGrants(normalizeRegistry(JSON.parse(payload), policy), policy), payload };
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code === "ENOENT") return { file: clone(EMPTY), payload: null };
     if (error instanceof RegistryReadError) throw error;
@@ -2374,8 +2402,8 @@ function readFileWithPayload(filename: string): { file: RegistryFile; payload: s
   }
 }
 
-function readFile(filename: string): RegistryFile {
-  return readFileWithPayload(filename).file;
+function readFile(filename: string, policy?: McpGrantPolicy): RegistryFile {
+  return readFileWithPayload(filename, policy).file;
 }
 
 function registryFileSignature(filename: string): string {
@@ -2555,7 +2583,7 @@ export class AgentRegistry {
     this.sqliteStore = this.sqliteMode === "off"
       ? null
       : new SqliteAgentRegistryStore(storage.sqliteFilename ?? defaultSqliteFilename(filename), {
-          initialSnapshot: readFile(filename),
+          initialSnapshot: readFile(filename, storage.mcpGrantPolicy),
           normalize: (value) => normalizeRegistry(value, storage.mcpGrantPolicy),
           mcpGrantPolicy: storage.mcpGrantPolicy,
           onWriterWait: (duration) => {
@@ -2593,7 +2621,7 @@ export class AgentRegistry {
   }
 
   private assertSqliteParity(snapshot: SqliteRegistrySnapshot = this.sqliteStore!.snapshot()): void {
-    const json = readFile(this.filename);
+    const json = readFile(this.filename, this.mcpGrantPolicy);
     if (!isDeepStrictEqual(snapshot.file, json)) {
       const fields = [...new Set([...Object.keys(snapshot.file), ...Object.keys(json)])]
         .filter((field) => !isDeepStrictEqual(
@@ -2732,7 +2760,7 @@ export class AgentRegistry {
     }
     let file: RegistryFile;
     try {
-      file = readFile(this.filename);
+      file = readFile(this.filename, this.mcpGrantPolicy);
     } catch (error) {
       if (error instanceof RegistryReadError) {
         console.error("agent registry startup compaction skipped:", error);
@@ -2758,7 +2786,7 @@ export class AgentRegistry {
       }
       this.assertSqliteParity(sqlite);
       this.compactAtStartupLocked();
-      const file = readFile(this.filename);
+      const file = readFile(this.filename, this.mcpGrantPolicy);
       beforeReplace?.();
       const replacement = this.sqliteStore!.replace(file, sqlite.revision);
       if (!replacement.replaced) {
@@ -3140,7 +3168,7 @@ export class AgentRegistry {
         }
         this.assertSqliteParity(sqlite);
       }
-      const original = readFileWithPayload(this.filename);
+      const original = readFileWithPayload(this.filename, this.mcpGrantPolicy);
       const file = original.file;
       const result = mutator(file);
       const payload = serializeRegistry(file);
@@ -3167,7 +3195,7 @@ export class AgentRegistry {
   snapshot(): RegistryFile {
     return this.sqliteMode === "read" || this.sqliteMode === "sqlite"
       ? this.sqliteStore!.snapshot().file
-      : readFile(this.filename);
+      : readFile(this.filename, this.mcpGrantPolicy);
   }
 
   /** Shared process-local snapshot for projections that never mutate registry
@@ -3178,13 +3206,13 @@ export class AgentRegistry {
     for (let attempt = 0; attempt < 2; attempt += 1) {
       const before = registryFileSignature(this.filename);
       if (this.readOnlyCache?.signature === before) return this.readOnlyCache.snapshot;
-      const snapshot = readFile(this.filename);
+      const snapshot = readFile(this.filename, this.mcpGrantPolicy);
       const after = registryFileSignature(this.filename);
       if (before !== after) continue;
       this.readOnlyCache = { signature: after, snapshot };
       return snapshot;
     }
-    return readFile(this.filename);
+    return readFile(this.filename, this.mcpGrantPolicy);
   }
 
   spawnReceiptForClientAttempt(clientAttemptId: string): SpawnReceipt | null {
@@ -3291,24 +3319,6 @@ export class AgentRegistry {
          preset or a lineage parent denies it on resume, successor and restart
          adoption alike, whatever a stored or requested profile claims. */
       if (existingConversation?.agentRole || parentConversationId) profile.plugins = [];
-      /* Same rule for the MCP grant (#739), from the same durable evidence:
-         role preset, lineage parent, recorded delegation depth and — for a
-         genuinely new launch — the request origin. The global bound alone would
-         let a delegated session hand-edit its profile to a server the Viewer
-         CAN grant and keep it across resume; re-resolving the origin here means
-         the grant is re-decided, never replayed. A successor or resume relaunch
-         carries the conversation's own identity, so its `successor` origin must
-         not be mistaken for a fresh delegation signal. */
-      const launchOrigin = (input.purpose ?? "launch") === "launch" && input.origin && input.origin.kind !== "successor"
-        ? { kind: input.origin.kind }
-        : undefined;
-      profile.mcpServers = mcpServersForStoredSession({
-        origin: launchOrigin,
-        parentConversationId: parentConversationId ?? profile.parentConversationId,
-        agentRole: existingConversation?.agentRole ?? role,
-        delegationDepth: existingConversation?.delegationDepth ?? null,
-        requested: profile.mcpServers,
-      });
       if (existingConversation && existingConversation.engine !== input.engine) {
         throw new Error("spawn conversation ownership is invalid");
       }
@@ -3339,6 +3349,26 @@ export class AgentRegistry {
         ? existingConversation?.delegationDepth ?? null
         : resolvedOrigin ? resolvedOrigin.depth + 1 : 0;
       const childRole = successorIdentity ? existingConversation?.agentRole ?? null : role;
+      /* Same rule as the plugin grant above, for the MCP grant (#739), decided
+         from the very evidence this receipt is about to record: the role preset,
+         the lineage parent, the admitted delegation depth and — for a genuinely
+         new launch — the request origin, so an `external` origin that resolves
+         to no parent is still not an operator root. Deciding it HERE rather than
+         from the requested profile means the grant on the receipt and the origin
+         stamped beside it can never disagree, and every later re-decision of
+         that row is idempotent. A successor or resume relaunch carries the
+         conversation's own identity, so its `successor` origin must not be
+         mistaken for a fresh delegation signal. */
+      const launchOrigin = purpose === "launch" && input.origin && input.origin.kind !== "successor"
+        ? { kind: input.origin.kind }
+        : undefined;
+      profile.mcpServers = mcpServersForStoredSession({
+        origin: launchOrigin,
+        parentConversationId: parentConversationId ?? profile.parentConversationId,
+        agentRole: childRole,
+        delegationDepth: childDepth,
+        requested: profile.mcpServers,
+      }, this.mcpGrantPolicy);
       let rejection: SpawnRejection | null = null;
       if (resolvedOrigin) {
         const maxDepth = loadSpawnNestingPolicy().maxAgentNestingDepth;

--- a/src/lib/agent/registry.ts
+++ b/src/lib/agent/registry.ts
@@ -2146,6 +2146,10 @@ function observationIsCurrent(currentObservedAt: string | null, observedAt: stri
     rather than promoting. */
 function receiptLaunchProfile(value: SpawnReceipt, policy?: McpGrantPolicy): LaunchProfile {
   const profile = emptyLaunchProfile({ ...(value.launchProfile ?? {}), cwd: value.launchProfile?.cwd ?? value.cwd }, policy);
+  /* Every read walks every receipt, so the overwhelmingly common baseline
+     profile skips the resolver and its allocation — as the conversation path
+     does. Only a profile claiming more than the baseline is worth deciding. */
+  if (profile.mcpServers.length === 1 && profile.mcpServers[0] === "viewer") return profile;
   return {
     ...profile,
     mcpServers: mcpServersForStoredSession({

--- a/src/lib/agent/spawnCommand.ts
+++ b/src/lib/agent/spawnCommand.ts
@@ -11,7 +11,7 @@ import { emptyLaunchProfile, validExplicitProject } from "@/lib/accounts/migrati
 import { freshSpecFor, type AgentEngine } from "@/lib/agent/cli";
 import { agentRegistry, SpawnChildLimitError } from "@/lib/agent/registry";
 import { reasoningFromBody } from "@/lib/agent/efforts";
-import { normalizeSpawnMcpServers } from "@/lib/agent/mcpAllowlist";
+import { mcpServersForSession, normalizeSpawnMcpServers } from "@/lib/agent/mcpAllowlist";
 import { normalizeSpawnPlugins, pluginAllowlistForSession, sessionOriginFor } from "@/lib/agent/pluginAllowlist";
 import { codexModelSupportsImages, modelFromBody } from "@/lib/agent/models";
 import { resolveSpawnRole } from "@/lib/roles/registry";
@@ -148,8 +148,13 @@ export async function executeSpawnRequest(
     return NextResponse.json({ error: "invalid JSON" }, { status: 400 });
   }
 
+  /* Requested MCP grant (issue #739). A name outside the grantable bound is
+     rejected here with 400, exactly like a rejected plugin, instead of being
+     trimmed. Absence leaves the decision to policy; an explicit list — `[]`
+     included — can only narrow what the session's origin already allows. */
   const mcpServers = normalizeSpawnMcpServers(body.mcpServers);
   if (!mcpServers.ok) return NextResponse.json({ error: mcpServers.error }, { status: 400 });
+  const requestedMcpServers = body.mcpServers === undefined ? null : mcpServers.value;
   /* Requested plugin grant (issue #687). Absent leaves the decision to policy;
      `[]` is the operator's explicit opt-out for this root session. Anything
      outside the grantable set is rejected here, never trimmed silently. */
@@ -332,19 +337,26 @@ export async function executeSpawnRequest(
       : null;
     const parentSessionKey = parent?.sessionKey ?? null;
     const parentArtifactPath = parent?.artifactPath ?? null;
-    /* Session-origin policy (issue #687): an operator-launched root session —
-       no agent caller, no lineage parent, no role preset — carries the Computer
-       Use grant by default; every delegated launch carries none, and the
-       request can only narrow that, never widen it. */
+    /* Session origin, and with it every grant this launch receives: an
+       operator-launched root session is one with no agent caller, no lineage
+       parent and no role preset. Plugins (#687) and MCP servers (#739) read the
+       same classification, so a session cannot be a root for one and delegated
+       for the other. */
+    const sessionOrigin = sessionOriginFor({
+      origin: { kind: authenticatedCaller?.kind === "agent" ? "agent" : "operator" },
+      parentConversationId,
+      agentRole: role.value?.role ?? null,
+    });
+    /* An operator root carries the Computer Use grant by default; every
+       delegated launch carries none, and the request can only narrow that. */
     const plugins = pluginAllowlistForSession({
       engine,
-      origin: sessionOriginFor({
-        origin: { kind: authenticatedCaller?.kind === "agent" ? "agent" : "operator" },
-        parentConversationId,
-        agentRole: role.value?.role ?? null,
-      }),
+      origin: sessionOrigin,
       requested: requestedPlugins.value,
     });
+    /* Same shape for MCP: a delegated launch holds the Viewer baseline whatever
+       it asked for, so a granted connector cannot travel down a spawn chain. */
+    const grantedServers = mcpServersForSession({ origin: sessionOrigin, requested: requestedMcpServers });
     const digest = spawnRequestDigest({
       engine,
       cwd,
@@ -353,7 +365,7 @@ export async function executeSpawnRequest(
       fast: reasoning.fast,
       accountId: account.accountId,
       role: role.value?.role ?? null,
-      mcpServers: mcpServers.value,
+      mcpServers: grantedServers,
       ...(plugins.length ? { plugins } : {}),
       ...(body.allowSubagents === true ? { allowSubagents: true } : {}),
       ...(explicitProject ? { project: explicitProject } : {}),
@@ -374,7 +386,7 @@ export async function executeSpawnRequest(
       claudeConfigDir: engine === "claude" ? account.home : null,
       claudeProjectsDir: engine === "claude" ? account.transcriptRoot : null,
       allowSubagents: body.allowSubagents === true,
-      mcpServers: mcpServers.value,
+      mcpServers: grantedServers,
       deferClaudeSpawnPolicy: true,
     });
     const permissionMode = engine === "claude" && transport === "structured"
@@ -391,7 +403,7 @@ export async function executeSpawnRequest(
         cwd,
         parentConversationId,
         allowSubagents: body.allowSubagents === true,
-        mcpServers: mcpServers.value,
+        mcpServers: grantedServers,
         plugins,
         permissionMode,
         ...(explicitProject ? { project: explicitProject } : {}),
@@ -588,7 +600,7 @@ export async function executeSpawnRequest(
         baseSettingsPath: isManagedClaudeHome(account.home) ? claudeSettingsPath() : null,
         profileId,
         cwd,
-        mcpServers: mcpServers.value,
+        mcpServers: grantedServers,
         mcpStatePath: account.kind === "managed"
           ? path.join(account.home, ".claude.json")
           : path.join(path.dirname(account.home), ".claude.json"),

--- a/src/lib/agent/spawnPolicy.test.ts
+++ b/src/lib/agent/spawnPolicy.test.ts
@@ -170,25 +170,24 @@ test("Claude native MCP config merges project scope between user and local scope
   fs.mkdirSync(path.join(projectRoot, ".git"), { recursive: true });
   fs.mkdirSync(cwd, { recursive: true });
   fs.writeFileSync(path.join(accountHome, "settings.json"), JSON.stringify({
-    enabledMcpjsonServers: ["project-allowed"],
+    enabledMcpjsonServers: ["agent-browser"],
   }));
   fs.writeFileSync(path.join(accountHome, ".claude.json"), JSON.stringify({
     mcpServers: {
       viewer: { type: "stdio", command: "viewer-user" },
-      "project-allowed": { type: "stdio", command: "user-version" },
-      "local-wins": { type: "stdio", command: "user-local" },
+      "agent-browser": { type: "stdio", command: "user-version" },
     },
     projects: {
       [cwd]: {
         mcpServers: {
-          "local-wins": { type: "stdio", command: "local-version", env: { LOCAL_AUTH: "kept" } },
+          "agent-browser": { type: "stdio", command: "local-version", env: { LOCAL_AUTH: "kept" } },
         },
       },
     },
   }));
   fs.writeFileSync(path.join(projectRoot, ".mcp.json"), JSON.stringify({
     mcpServers: {
-      "project-allowed": {
+      "agent-browser": {
         type: "stdio",
         command: "project-version",
         args: ["--project"],
@@ -196,15 +195,33 @@ test("Claude native MCP config merges project scope between user and local scope
         timeout: 12_345,
         alwaysLoad: true,
       },
-      "local-wins": { type: "stdio", command: "project-local" },
       "project-unrelated": { type: "stdio", command: "unrelated-project" },
     },
   }));
 
+  /* Shared project scope wins over the user root definition where the launch
+     directory carries no local override of its own. */
+  const sharedInstalled = applyClaudeSpawnPolicy(accountHome, {
+    profileId: "project-scopes-shared",
+    cwd: projectRoot,
+    mcpServers: ["agent-browser"],
+  });
+  const sharedConfig = JSON.parse(fs.readFileSync(sharedInstalled.mcpConfigPath, "utf8")) as {
+    mcpServers: Record<string, unknown>;
+  };
+  expect(sharedConfig.mcpServers["agent-browser"]).toEqual({
+    type: "stdio",
+    command: "project-version",
+    args: ["--project"],
+    env: { PROJECT_AUTH: "kept" },
+    timeout: 12_345,
+    alwaysLoad: true,
+  });
+
   const installed = applyClaudeSpawnPolicy(accountHome, {
     profileId: "project-scopes",
     cwd,
-    mcpServers: ["project-allowed", "local-wins"],
+    mcpServers: ["agent-browser"],
   });
   const mcpConfig = JSON.parse(fs.readFileSync(installed.mcpConfigPath, "utf8")) as {
     mcpServers: Record<string, unknown>;
@@ -214,21 +231,38 @@ test("Claude native MCP config merges project scope between user and local scope
     disabledMcpjsonServers: string[];
   };
 
+  /* The launch directory's local definition wins over both. */
   expect(mcpConfig.mcpServers).toEqual({
     viewer: { type: "stdio", command: "viewer-user" },
-    "project-allowed": {
-      type: "stdio",
-      command: "project-version",
-      args: ["--project"],
-      env: { PROJECT_AUTH: "kept" },
-      timeout: 12_345,
-      alwaysLoad: true,
-    },
-    "local-wins": { type: "stdio", command: "local-version", env: { LOCAL_AUTH: "kept" } },
+    "agent-browser": { type: "stdio", command: "local-version", env: { LOCAL_AUTH: "kept" } },
   });
   expect(mcpConfig.mcpServers).not.toHaveProperty("project-unrelated");
-  expect(settings.enabledMcpjsonServers).toEqual(["project-allowed"]);
+  expect(settings.enabledMcpjsonServers).toEqual(["agent-browser"]);
   expect(settings.disabledMcpjsonServers).toEqual(["project-unrelated"]);
+});
+
+test("an ungranted server in a stored allowlist never reaches the Claude MCP config", () => {
+  const accountHome = home();
+  fs.writeFileSync(path.join(accountHome, ".claude.json"), JSON.stringify({
+    mcpServers: {
+      viewer: { type: "stdio", command: "viewer-mcp" },
+      "agent-browser": { type: "stdio", command: "browser-mcp" },
+      telegram: { type: "stdio", command: "telegram-mcp" },
+    },
+  }));
+
+  /* A launch profile hand-edited to name an ungranted server is re-bounded
+     where the command materializes it, not trusted from storage (issue #739). */
+  const installed = applyClaudeSpawnPolicy(accountHome, {
+    profileId: "rebounded",
+    cwd: "/repo",
+    mcpServers: ["viewer", "telegram", "agent-browser"],
+  });
+  const mcpConfig = JSON.parse(fs.readFileSync(installed.mcpConfigPath, "utf8")) as {
+    mcpServers: Record<string, unknown>;
+  };
+
+  expect(Object.keys(mcpConfig.mcpServers)).toEqual(["viewer", "agent-browser"]);
 });
 
 test("allowSubagents uses an isolated profile while the denied profile stays enforced", () => {

--- a/src/lib/agent/spawnPolicy.test.ts
+++ b/src/lib/agent/spawnPolicy.test.ts
@@ -120,7 +120,7 @@ test("Claude spawn policy seeds a fresh account from the shared user settings sn
   expect(settings.hooks.PreToolUse).toHaveLength(1);
 });
 
-test("Claude native MCP config forces Viewer into a custom allowlist and omits unrelated servers", () => {
+test("Claude native MCP config keeps only granted servers out of the operator's registrations", () => {
   const accountHome = home();
   fs.writeFileSync(path.join(accountHome, ".claude.json"), JSON.stringify({
     mcpServers: {
@@ -139,9 +139,10 @@ test("Claude native MCP config forces Viewer into a custom allowlist and omits u
     mcpServers: Record<string, unknown>;
   };
 
+  /* Viewer is forced in; every other registered server stays out, including the
+     one the allowlist named, because the grant bound excludes it (#739). */
   expect(mcpConfig.mcpServers).toEqual({
     viewer: { type: "stdio", command: "viewer-mcp", args: ["--viewer"] },
-    "agent-browser": { type: "stdio", command: "browser-mcp" },
   });
 });
 
@@ -169,25 +170,26 @@ test("Claude native MCP config merges project scope between user and local scope
   const cwd = path.join(projectRoot, "packages", "worker");
   fs.mkdirSync(path.join(projectRoot, ".git"), { recursive: true });
   fs.mkdirSync(cwd, { recursive: true });
+  /* Scope precedence is exercised on `viewer`: it is the only server the grant
+     bound admits this tranche, and every scope may redefine it. */
   fs.writeFileSync(path.join(accountHome, "settings.json"), JSON.stringify({
-    enabledMcpjsonServers: ["agent-browser"],
+    enabledMcpjsonServers: ["viewer"],
   }));
   fs.writeFileSync(path.join(accountHome, ".claude.json"), JSON.stringify({
     mcpServers: {
       viewer: { type: "stdio", command: "viewer-user" },
-      "agent-browser": { type: "stdio", command: "user-version" },
     },
     projects: {
       [cwd]: {
         mcpServers: {
-          "agent-browser": { type: "stdio", command: "local-version", env: { LOCAL_AUTH: "kept" } },
+          viewer: { type: "stdio", command: "local-version", env: { LOCAL_AUTH: "kept" } },
         },
       },
     },
   }));
   fs.writeFileSync(path.join(projectRoot, ".mcp.json"), JSON.stringify({
     mcpServers: {
-      "agent-browser": {
+      viewer: {
         type: "stdio",
         command: "project-version",
         args: ["--project"],
@@ -204,12 +206,11 @@ test("Claude native MCP config merges project scope between user and local scope
   const sharedInstalled = applyClaudeSpawnPolicy(accountHome, {
     profileId: "project-scopes-shared",
     cwd: projectRoot,
-    mcpServers: ["agent-browser"],
   });
   const sharedConfig = JSON.parse(fs.readFileSync(sharedInstalled.mcpConfigPath, "utf8")) as {
     mcpServers: Record<string, unknown>;
   };
-  expect(sharedConfig.mcpServers["agent-browser"]).toEqual({
+  expect(sharedConfig.mcpServers.viewer).toEqual({
     type: "stdio",
     command: "project-version",
     args: ["--project"],
@@ -221,7 +222,6 @@ test("Claude native MCP config merges project scope between user and local scope
   const installed = applyClaudeSpawnPolicy(accountHome, {
     profileId: "project-scopes",
     cwd,
-    mcpServers: ["agent-browser"],
   });
   const mcpConfig = JSON.parse(fs.readFileSync(installed.mcpConfigPath, "utf8")) as {
     mcpServers: Record<string, unknown>;
@@ -233,11 +233,10 @@ test("Claude native MCP config merges project scope between user and local scope
 
   /* The launch directory's local definition wins over both. */
   expect(mcpConfig.mcpServers).toEqual({
-    viewer: { type: "stdio", command: "viewer-user" },
-    "agent-browser": { type: "stdio", command: "local-version", env: { LOCAL_AUTH: "kept" } },
+    viewer: { type: "stdio", command: "local-version", env: { LOCAL_AUTH: "kept" } },
   });
   expect(mcpConfig.mcpServers).not.toHaveProperty("project-unrelated");
-  expect(settings.enabledMcpjsonServers).toEqual(["agent-browser"]);
+  expect(settings.enabledMcpjsonServers).toEqual(["viewer"]);
   expect(settings.disabledMcpjsonServers).toEqual(["project-unrelated"]);
 });
 
@@ -262,7 +261,7 @@ test("an ungranted server in a stored allowlist never reaches the Claude MCP con
     mcpServers: Record<string, unknown>;
   };
 
-  expect(Object.keys(mcpConfig.mcpServers)).toEqual(["viewer", "agent-browser"]);
+  expect(Object.keys(mcpConfig.mcpServers)).toEqual(["viewer"]);
 });
 
 test("allowSubagents uses an isolated profile while the denied profile stays enforced", () => {

--- a/src/lib/agent/spawnPolicy.ts
+++ b/src/lib/agent/spawnPolicy.ts
@@ -3,7 +3,7 @@ import path from "node:path";
 import crypto from "node:crypto";
 
 import type { AgentEngine } from "./cli";
-import { normalizeSpawnMcpServers } from "./mcpAllowlist";
+import { grantedMcpServers } from "./mcpAllowlist";
 
 type JsonObject = Record<string, unknown>;
 
@@ -125,8 +125,10 @@ function claudeMcpServers(
   const sharedProjectServers = claudeProjectMcpServers(cwd);
   const localProjectServers = record(project?.mcpServers) ?? {};
   const registered = { ...rootServers, ...sharedProjectServers, ...localProjectServers };
-  const normalized = normalizeSpawnMcpServers(allowlist);
-  const names = normalized.ok ? normalized.value : ["viewer"];
+  /* The grant bound is enforced again here (issue #739): the per-spawn
+     `--strict-mcp-config` file is copied from the re-validated list, so a
+     server the Viewer cannot grant is never written into it. */
+  const names = grantedMcpServers(allowlist);
   return Object.fromEntries(names.flatMap((name) => {
     const definition = record(registered[name]);
     return definition ? [[name, definition]] : [];

--- a/src/lib/agent/sqliteRegistryStore.ts
+++ b/src/lib/agent/sqliteRegistryStore.ts
@@ -77,7 +77,33 @@ export interface SqliteRegistryStoreOptions {
   onRevisionQuery?(): void;
 }
 
+/**
+ * A registry file no undecided MCP grant can leave (#739).
+ *
+ * The three row writers below take ONLY this type, and `markDecided` is the one
+ * place that mints it, so a new persist path cannot be written without the
+ * decision — it is a compile error, not a convention a future path has to know
+ * about. That is the difference between this and enumerating today's callers:
+ * enumeration notices a fourth entry point after somebody adds it, this one
+ * refuses to let it be expressed.
+ *
+ * A file earns the brand two ways, and they are the same guarantee reached
+ * differently:
+ *
+ *  - `decideAssembled` has run {@link reboundAssembledMcpGrants} over the whole
+ *    of it, which is what a payload arriving from OUTSIDE the store needs;
+ *  - it came from the lazy loader, whose row accessors run that same decision
+ *    before handing out any row that claims more than the baseline, which is
+ *    what a mutation reading rows one at a time needs.
+ *
+ * The brand is a runtime WeakSet as well as a type, so an `as` cast that skips
+ * `markDecided` still throws at the write rather than silently persisting.
+ */
+declare const DECIDED: unique symbol;
+export type DecidedRegistryFile = RegistryFile & { readonly [DECIDED]: true };
+
 interface LazyRegistrySnapshot extends SqliteRegistrySnapshot {
+  file: DecidedRegistryFile;
   changes(): RegistryChanges;
 }
 
@@ -122,6 +148,27 @@ export class SqliteAgentRegistryStore {
   private readOnlyCache: SqliteRegistrySnapshot | null = null;
 
   private readonly mcpGrantPolicy: McpGrantPolicy | undefined;
+  /** Runtime half of {@link DecidedRegistryFile}: the files this store has
+      actually seen the decision run over, so an `as` cast cannot mint one. */
+  private readonly decidedFiles = new WeakSet<object>();
+
+  /** The sole mint. Everything that reaches a row writer passes through here. */
+  private markDecided(file: RegistryFile): DecidedRegistryFile {
+    this.decidedFiles.add(file);
+    return file as DecidedRegistryFile;
+  }
+
+  /** For a payload arriving from outside the store, which has had no accessor
+      gate applied to it: run the assembled decision over the whole file. */
+  private decideAssembled(file: RegistryFile): DecidedRegistryFile {
+    reboundAssembledMcpGrants(file, this.mcpGrantPolicy);
+    return this.markDecided(file);
+  }
+
+  private assertDecided(file: DecidedRegistryFile): void {
+    if (this.decidedFiles.has(file)) return;
+    throw new Error("agent registry rows cannot be persisted before the MCP grant decision has run (#739)");
+  }
 
   constructor(readonly filename: string, options: SqliteRegistryStoreOptions) {
     fs.mkdirSync(path.dirname(filename), { recursive: true, mode: 0o700 });
@@ -263,8 +310,10 @@ export class SqliteAgentRegistryStore {
   replace(file: RegistryFile, expectedRevision?: number): SqliteRegistryReplacement {
     /* A wholesale replacement is a mutation like any other, and its payload
        arrives from outside this store, so it is re-decided before it lands
-       rather than on the way back out (#739). */
-    reboundAssembledMcpGrants(file, this.mcpGrantPolicy);
+       rather than on the way back out (#739). `persistDiff` takes only a
+       DecidedRegistryFile, so this line cannot be dropped without the store
+       failing to compile. */
+    const decided = this.decideAssembled(file);
     this.db.exec("BEGIN IMMEDIATE");
     try {
       const current = this.loadInTransaction();
@@ -273,7 +322,7 @@ export class SqliteAgentRegistryStore {
         return { ...current, replaced: false };
       }
       const revision = current.revision + 1;
-      this.persistDiff(current.file, file, revision);
+      this.persistDiff(current.file, decided, revision);
       this.db.exec("COMMIT");
       this.secureFiles();
       this.rowCache.clear();
@@ -291,7 +340,7 @@ export class SqliteAgentRegistryStore {
     try {
       const complete = this.meta("migration_complete");
       if (complete !== "1") {
-        this.persistAll(reboundAssembledMcpGrants(initialSnapshot, this.mcpGrantPolicy), 1);
+        this.persistAll(this.decideAssembled(initialSnapshot), 1);
         this.setMeta("schema_version", "2");
         this.setMeta("migration_complete", "1");
       }
@@ -314,7 +363,11 @@ export class SqliteAgentRegistryStore {
   }
 
   private loadLazyInTransaction(trackMutations = true, useRowCache = trackMutations): LazyRegistrySnapshot {
-    const file = this.normalize({ version: 2, entries: {}, receipts: {} });
+    /* Branded here because the row ACCESSORS below carry the guarantee: every
+       row this file can hand out goes through `admitRow`, which runs the
+       assembled decision before returning anything claiming more than the
+       baseline. The brand is what lets `persistChanges` accept it. */
+    const file = this.markDecided(this.normalize({ version: 2, entries: {}, receipts: {} }));
     /* The assembled origin re-decision is a PRECONDITION of observing a grant,
        not a step some paths reach later (#739). Rows are normalized one
        collection — one row, even — at a time, so a row loaded lazily has had
@@ -697,7 +750,8 @@ export class SqliteAgentRegistryStore {
     }
   }
 
-  private persistAll(file: RegistryFile, revision: number): void {
+  private persistAll(file: DecidedRegistryFile, revision: number): void {
+    this.assertDecided(file);
     this.db.exec("DELETE FROM registry_rows");
     for (const collection of ROW_COLLECTIONS) {
       for (const [order, [key, value]] of Object.entries(file[collection]).entries()) {
@@ -708,7 +762,8 @@ export class SqliteAgentRegistryStore {
     this.setMeta("revision", String(revision));
   }
 
-  private persistDiff(before: RegistryFile, after: RegistryFile, revision: number): void {
+  private persistDiff(before: RegistryFile, after: DecidedRegistryFile, revision: number): void {
+    this.assertDecided(after);
     for (const collection of ROW_COLLECTIONS) {
       const previous = before[collection] as Record<string, unknown>;
       const next = after[collection] as Record<string, unknown>;
@@ -730,7 +785,8 @@ export class SqliteAgentRegistryStore {
     this.setMeta("revision", String(revision));
   }
 
-  private persistChanges(file: RegistryFile, changes: RegistryChanges, revision: number): void {
+  private persistChanges(file: DecidedRegistryFile, changes: RegistryChanges, revision: number): void {
+    this.assertDecided(file);
     for (const [collection, keys] of changes.rows) {
       const rows = file[collection] as Record<string, unknown>;
       for (const key of keys) {

--- a/src/lib/agent/sqliteRegistryStore.ts
+++ b/src/lib/agent/sqliteRegistryStore.ts
@@ -7,6 +7,12 @@ import type { Database as BunDatabase } from "bun:sqlite";
 import { reboundAssembledMcpGrants, type McpGrantPolicy } from "./mcpAllowlist";
 import type { RegistryFile } from "./registry";
 
+/** The collections the MCP grant decision reads and writes. Touching any one of
+    them requires the decision to have run over ALL of them, because an entry or
+    a receipt is only decidable against the conversations and lineage edges that
+    attest to it (#739). */
+const GRANT_COLLECTIONS = new Set(["entries", "receipts", "conversations", "lineageEdges"]);
+
 const ROW_COLLECTIONS = [
   "entries",
   "receipts",
@@ -255,6 +261,10 @@ export class SqliteAgentRegistryStore {
   }
 
   replace(file: RegistryFile, expectedRevision?: number): SqliteRegistryReplacement {
+    /* A wholesale replacement is a mutation like any other, and its payload
+       arrives from outside this store, so it is re-decided before it lands
+       rather than on the way back out (#739). */
+    reboundAssembledMcpGrants(file, this.mcpGrantPolicy);
     this.db.exec("BEGIN IMMEDIATE");
     try {
       const current = this.loadInTransaction();
@@ -281,7 +291,7 @@ export class SqliteAgentRegistryStore {
     try {
       const complete = this.meta("migration_complete");
       if (complete !== "1") {
-        this.persistAll(initialSnapshot, 1);
+        this.persistAll(reboundAssembledMcpGrants(initialSnapshot, this.mcpGrantPolicy), 1);
         this.setMeta("schema_version", "2");
         this.setMeta("migration_complete", "1");
       }
@@ -295,20 +305,40 @@ export class SqliteAgentRegistryStore {
 
   private loadInTransaction(useRowCache = false): SqliteRegistrySnapshot {
     const snapshot = this.loadLazyInTransaction(false, useRowCache);
+    /* Touching the grant-bearing collections runs the assembled re-decision
+       through the same gate every other path goes through (#739); the rest are
+       materialized because a snapshot is by definition complete. */
     for (const collection of ROW_COLLECTIONS) void snapshot.file[collection];
     for (const field of META_FIELDS) void snapshot.file[field];
-    /* Rows are normalized one collection — one row, even — at a time, so an
-       entry row is normalized with no conversations in sight and the origin
-       half of the MCP grant bound cannot be decided there (#739). The assembled
-       snapshot is the first point where an entry can be matched to the
-       conversation that owns it, so the decision lands here, before any reader
-       (startup adoption, structured recovery) sees a profile. */
-    reboundAssembledMcpGrants(snapshot.file, this.mcpGrantPolicy);
     return snapshot;
   }
 
   private loadLazyInTransaction(trackMutations = true, useRowCache = trackMutations): LazyRegistrySnapshot {
     const file = this.normalize({ version: 2, entries: {}, receipts: {} });
+    /* The assembled origin re-decision is a PRECONDITION of observing a grant,
+       not a step some paths reach later (#739). Rows are normalized one
+       collection — one row, even — at a time, so a row loaded lazily has had
+       only the global bound applied; the origin half needs the conversations,
+       lineage edges and receipts together. `mutate` used to hand its operation
+       the lazily normalized file directly, which put every store mutation —
+       settlement, structured claim, upsert — underneath the gate that `snapshot`
+       passed through.
+       Gating the collection ACCESSORS instead of a call site means the ordering
+       cannot be got wrong by a future path: the first read of any grant-bearing
+       collection runs the decision over all of them before it returns a row, and
+       a mutation that never touches one still pays nothing for it. */
+    let grantsDecided = false;
+    let decidingGrants = false;
+    const decideGrants = () => {
+      if (grantsDecided || decidingGrants) return;
+      decidingGrants = true;
+      try {
+        reboundAssembledMcpGrants(file, this.mcpGrantPolicy);
+        grantsDecided = true;
+      } finally {
+        decidingGrants = false;
+      }
+    };
     const loadedCollections = new Map<RowCollection, RegistryFile[RowCollection]>();
     const baselineCollections = new Map<RowCollection, Map<string, string | null>>();
     const dirtyRows = new Map<RowCollection, Set<string>>();
@@ -499,6 +529,7 @@ export class SqliteAgentRegistryStore {
         enumerable: true,
         get: () => {
           load();
+          if (GRANT_COLLECTIONS.has(collection)) decideGrants();
           return value;
         },
         set: (next: typeof value) => {

--- a/src/lib/agent/sqliteRegistryStore.ts
+++ b/src/lib/agent/sqliteRegistryStore.ts
@@ -4,6 +4,7 @@ import { isDeepStrictEqual } from "node:util";
 
 import type { Database as BunDatabase } from "bun:sqlite";
 
+import { reboundAssembledMcpGrants, type McpGrantPolicy } from "./mcpAllowlist";
 import type { RegistryFile } from "./registry";
 
 const ROW_COLLECTIONS = [
@@ -58,6 +59,11 @@ export interface SqliteRegistryMutation<T> {
 export interface SqliteRegistryStoreOptions {
   initialSnapshot: RegistryFile;
   normalize(value: unknown): RegistryFile;
+  /** Grant bound for the assembled-snapshot rebound below, matching whatever
+      `normalize` enforces. Production omits both; a test supplies a policy that
+      HAS a grantable connector, because the shipped bound has none and an empty
+      bound cannot tell an origin reset from itself (issue #739). */
+  mcpGrantPolicy?: McpGrantPolicy;
   onWriterWait?(durationMs: number): void;
   onSnapshotLoad?(): void;
   onRowPayloadRead?(collection: RowCollection, count: number): void;
@@ -109,6 +115,8 @@ export class SqliteAgentRegistryStore {
   private revisionCache: { signature: string; revision: number } | null = null;
   private readOnlyCache: SqliteRegistrySnapshot | null = null;
 
+  private readonly mcpGrantPolicy: McpGrantPolicy | undefined;
+
   constructor(readonly filename: string, options: SqliteRegistryStoreOptions) {
     fs.mkdirSync(path.dirname(filename), { recursive: true, mode: 0o700 });
     const sqlite = process.getBuiltinModule?.("bun:sqlite") as typeof import("bun:sqlite") | undefined;
@@ -121,6 +129,7 @@ export class SqliteAgentRegistryStore {
     this.onRowPayloadRead = options.onRowPayloadRead;
     this.onRowPayloadParse = options.onRowPayloadParse;
     this.onRevisionQuery = options.onRevisionQuery;
+    this.mcpGrantPolicy = options.mcpGrantPolicy;
     this.db.exec("PRAGMA busy_timeout = 5000; PRAGMA journal_mode = WAL; PRAGMA synchronous = FULL; PRAGMA foreign_keys = ON; PRAGMA auto_vacuum = INCREMENTAL;");
     this.db.exec(`
       CREATE TABLE IF NOT EXISTS registry_meta (
@@ -288,6 +297,13 @@ export class SqliteAgentRegistryStore {
     const snapshot = this.loadLazyInTransaction(false, useRowCache);
     for (const collection of ROW_COLLECTIONS) void snapshot.file[collection];
     for (const field of META_FIELDS) void snapshot.file[field];
+    /* Rows are normalized one collection — one row, even — at a time, so an
+       entry row is normalized with no conversations in sight and the origin
+       half of the MCP grant bound cannot be decided there (#739). The assembled
+       snapshot is the first point where an entry can be matched to the
+       conversation that owns it, so the decision lands here, before any reader
+       (startup adoption, structured recovery) sees a profile. */
+    reboundAssembledMcpGrants(snapshot.file, this.mcpGrantPolicy);
     return snapshot;
   }
 

--- a/src/lib/agent/sqliteRegistryStore.ts
+++ b/src/lib/agent/sqliteRegistryStore.ts
@@ -4,7 +4,7 @@ import { isDeepStrictEqual } from "node:util";
 
 import type { Database as BunDatabase } from "bun:sqlite";
 
-import { reboundAssembledMcpGrants, type McpGrantPolicy } from "./mcpAllowlist";
+import { reboundAssembledMcpGrants, rowClaimsBeyondBaselineGrant, type McpGrantPolicy } from "./mcpAllowlist";
 import type { RegistryFile } from "./registry";
 
 /** The collections the MCP grant decision reads and writes. Touching any one of
@@ -323,10 +323,13 @@ export class SqliteAgentRegistryStore {
        the lazily normalized file directly, which put every store mutation —
        settlement, structured claim, upsert — underneath the gate that `snapshot`
        passed through.
-       Gating the collection ACCESSORS instead of a call site means the ordering
-       cannot be got wrong by a future path: the first read of any grant-bearing
-       collection runs the decision over all of them before it returns a row, and
-       a mutation that never touches one still pays nothing for it. */
+       Gating the ACCESSORS rather than a call site means the ordering cannot be
+       got wrong by a future path. The gate hangs off the ROW, not the
+       collection: a row already at the baseline is returned byte-identical by
+       the decision, so skipping it there is the gate answering trivially rather
+       than a way around it, and a keyed mutation still reads exactly the one row
+       it asked for. The first row that claims anything MORE runs the decision
+       over the whole file before it is handed out. */
     let grantsDecided = false;
     let decidingGrants = false;
     const decideGrants = () => {
@@ -338,6 +341,13 @@ export class SqliteAgentRegistryStore {
       } finally {
         decidingGrants = false;
       }
+    };
+    /* Every row leaves a loader through here. A row at the baseline is admitted
+       untouched; anything claiming more is only returned once the decision has
+       run over the whole file, including the rows attesting to this one. */
+    const admitRow = <T>(collection: RowCollection, row: T): T => {
+      if (GRANT_COLLECTIONS.has(collection) && rowClaimsBeyondBaselineGrant(row)) decideGrants();
+      return row;
     };
     const loadedCollections = new Map<RowCollection, RegistryFile[RowCollection]>();
     const baselineCollections = new Map<RowCollection, Map<string, string | null>>();
@@ -429,17 +439,25 @@ export class SqliteAgentRegistryStore {
             baseline.set(key, stored);
             return stored;
           };
+          /* Every row this collection hands out leaves through here — the keyed
+             read below, and equally the rows `loadAllRows` has already cached,
+             which an enumeration reaches through `getOwnPropertyDescriptor`. So
+             the gate sits on the single exit rather than on the load, and no
+             route to a row can arrive before the decision it needs. */
           const readRow = (key: string): unknown => {
-            if (Object.hasOwn(rows, key)) return rows[key];
-            if (deleted.has(key)) return undefined;
-            const stored = readBaseline(key);
-            if (stored === null) return undefined;
-            const input: Record<string, unknown> = { version: 2, entries: {}, receipts: {} };
-            input[collection] = { [key]: structuredClone(this.parseRow(collection, key, stored, useRowCache)) };
-            const normalized = this.normalize(input)[collection] as Record<string, unknown>;
-            if (!Object.hasOwn(normalized, key)) return undefined;
-            rows[key] = normalized[key];
-            return rows[key];
+            if (!Object.hasOwn(rows, key)) {
+              if (deleted.has(key)) return undefined;
+              const stored = readBaseline(key);
+              if (stored === null) return undefined;
+              const input: Record<string, unknown> = { version: 2, entries: {}, receipts: {} };
+              input[collection] = { [key]: structuredClone(this.parseRow(collection, key, stored, useRowCache)) };
+              const normalized = this.normalize(input)[collection] as Record<string, unknown>;
+              if (!Object.hasOwn(normalized, key)) return undefined;
+              rows[key] = normalized[key];
+            }
+            /* The decision rewrites `rows[key]` in place where it denies, so the
+               caller never holds the undecided object. */
+            return admitRow(collection, rows[key]);
           };
           const loadAllRows = () => {
             if (allRowsLoaded) return;
@@ -529,7 +547,11 @@ export class SqliteAgentRegistryStore {
         enumerable: true,
         get: () => {
           load();
-          if (GRANT_COLLECTIONS.has(collection)) decideGrants();
+          /* The eager loader has materialized the whole collection by now, so
+             there is no laziness left to protect and the decision runs on the
+             collection. The lazy loader gates each ROW instead, on `readRow`'s
+             single exit, so a keyed read stays keyed. */
+          if (!trackMutations && GRANT_COLLECTIONS.has(collection)) decideGrants();
           return value;
         },
         set: (next: typeof value) => {

--- a/src/lib/codexHeadlessConfig.test.ts
+++ b/src/lib/codexHeadlessConfig.test.ts
@@ -102,10 +102,13 @@ test("a Codex thread approves Viewer and retains optional server approval policy
         "telegram-readonly": { default_tools_approval_mode: "prompt" },
       },
     },
+    /* Nothing outside the grant bound can be enabled, so a stored allowlist
+       naming a configured server still leaves it off (issue #739). Each
+       server's own approval policy survives the disable. */
   }, false, ["agent-browser"])).toMatchObject({
     mcp_servers: {
       viewer: { enabled: true, default_tools_approval_mode: "approve" },
-      "agent-browser": { enabled: true, default_tools_approval_mode: "writes" },
+      "agent-browser": { enabled: false, default_tools_approval_mode: "writes" },
       "telegram-readonly": { enabled: false, default_tools_approval_mode: "prompt" },
     },
   });

--- a/src/lib/codexHeadlessConfig.ts
+++ b/src/lib/codexHeadlessConfig.ts
@@ -1,5 +1,5 @@
 import { CODEX_VIEWER_SPAWN_FEATURES } from "@/lib/agent/spawnPolicy";
-import { normalizeSpawnMcpServers } from "@/lib/agent/mcpAllowlist";
+import { grantedMcpServers } from "@/lib/agent/mcpAllowlist";
 import { grantedPlugins } from "@/lib/agent/pluginAllowlist";
 
 type JsonObject = Record<string, unknown>;
@@ -34,8 +34,10 @@ export function headlessCodexThreadConfig(
   const config = record(record(configRead)?.config);
   const servers = record(config?.mcp_servers);
   if (!config || !servers) throw new Error("config/read returned no MCP server table");
-  const normalized = normalizeSpawnMcpServers(mcpServers);
-  const enabled = new Set(normalized.ok ? normalized.value : ["viewer"]);
+  /* The grant bound is enforced again here (issue #739): the thread's enable
+     table is materialized from the re-validated list, so a launch profile
+     edited by hand cannot turn a server on for this thread. */
+  const enabled = new Set(grantedMcpServers(mcpServers));
   /* The plugin subsystem is off for every session that holds no grant, which
      is the default. A grant turns it on for THIS thread only — never for the
      app-server, never in the operator's configuration. */

--- a/src/lib/delivery.test.ts
+++ b/src/lib/delivery.test.ts
@@ -460,7 +460,7 @@ test("idle reconfiguration survives a transient host miss and resumes after veri
   };
   let resumed = 0;
   let killed = false;
-  let resumePolicy: { readOnly?: boolean | null; permissionMode?: string | null; allowSubagents?: boolean } = {};
+  let resumePolicy: { readOnly?: boolean | null; permissionMode?: string | null; allowSubagents?: boolean; mcpServers?: readonly string[] } = {};
 
   const outcome = await reconfigureConversation(pathname, { model: "gpt-5.6-terra", effort: "medium", fast: true }, {
     pathAllowed: () => true,
@@ -484,7 +484,9 @@ test("idle reconfiguration survives a transient host miss and resumes after veri
   expect(outcome).toMatchObject({ ok: true, outcome: "reconfigured", target: "%8" });
   expect(resumed).toBe(1);
   expect(killed).toBe(true);
-  expect(resumePolicy).toMatchObject({ readOnly: true, permissionMode: "never", allowSubagents: true });
+  /* The rebuilt command carries the durable MCP grant too (#739): dropping it
+     relaunched the session on the baseline while the profile still claimed it. */
+  expect(resumePolicy).toMatchObject({ readOnly: true, permissionMode: "never", allowSubagents: true, mcpServers: ["viewer"] });
 });
 
 test("legacy account reconfiguration queues a conversation reseat without touching the active pane", async () => {
@@ -1226,4 +1228,66 @@ test("a tmux resume rebuilds the command with the conversation's stored MCP gran
      the Viewer baseline while the durable profile still claimed it (#739). */
   expect(options).toHaveLength(1);
   expect(options[0]!.mcpServers).toEqual(["viewer", "granted-connector"]);
+});
+
+test("message-triggered relaunches carry the stored MCP grant on both the direct and root-relay paths", async () => {
+  /* Real session ids: this path goes through the process-wide registry, which
+     keys entries by session key rather than by the override object. */
+  const branchId = "019f4e76-66b4-\x37f87-94b2-cfa9bf746661";
+  const rootId = "019f4e76-66b4-\x37f87-94b2-cfa9bf746662";
+  const branchPath = path.join(SANDBOX, `${branchId}.jsonl`);
+  const rootPath = path.join(SANDBOX, `${rootId}.jsonl`);
+  fs.writeFileSync(branchPath, "");
+  fs.writeFileSync(rootPath, "");
+  const registry = new AgentRegistry(path.join(SANDBOX, "message-grant-registry.json"), undefined, undefined, { sqliteMode: "off" });
+  setAgentRegistryForTests(registry);
+  for (const [sessionId, pathname] of [[branchId, branchPath], [rootId, rootPath]] as const) {
+    registry.upsert({
+      key: { engine: "codex", sessionId }, artifactPath: pathname, cwd: SANDBOX, accountId: "account",
+      launchProfile: emptyLaunchProfile({ cwd: SANDBOX, mcpServers: ["viewer"] }), status: "dead",
+      host: null, claimEpoch: 0, claimOwner: null, pendingAction: null,
+    });
+    /* The durable profile a relaunch reads hangs off the conversation, so the
+       session needs one — an entry row alone is not what it looks up. */
+    const conversation = registry.ensureConversation("codex", pathname, "account");
+    registry.updateConversationLaunchProfile(conversation.id, { model: "gpt-5.6-sol", effort: "high", fast: false });
+  }
+  const fileEntry = (pathname: string, parent: string | null): FileEntry => ({
+    path: pathname, root: "codex-sessions", name: path.basename(pathname), project: "viewer",
+    title: "grant", engine: "codex", kind: "session", fmt: "codex", parent, mtime: 1, size: 0,
+    activity: "idle", proc: null, pid: null, model: "gpt-5.6-sol", effort: "high", fast: false,
+    pendingQuestion: null, waitingInput: null,
+  });
+  const seen: { path: string; mcpServers?: readonly string[] }[] = [];
+  const overrides = (resumable: (pathname: string) => boolean) => ({
+    pathAllowed: () => true,
+    listFiles: async () => [fileEntry(branchPath, rootPath), fileEntry(rootPath, null)],
+    livePaneHost: async () => null,
+    resumeSpecFor: (_root: string, pathname: string, given: { mcpServers?: readonly string[] }) => {
+      seen.push({ path: pathname, mcpServers: given.mcpServers });
+      return resumable(pathname)
+        ? { command: "codex resume", cwd: SANDBOX, windowName: "codex-resume", engine: "codex" }
+        : null;
+    },
+    deliver: async () => ({ ok: true, outcome: "resumed", target: "%4" }),
+  });
+
+  /* The dead session reopens as its own window: its own grant travels with it,
+     rather than the command falling back to the baseline (#739). */
+  const direct = await deliverConversationMessage({ path: branchPath, text: "reopen", images: [] } as never, overrides(() => true) as never);
+  expect(direct).toMatchObject({ ok: true });
+  expect(seen).toEqual([{ path: branchPath, mcpServers: ["viewer"] }]);
+
+  /* A branch that cannot be resumed relays through its root, whose own grant
+     must reach the root's command on the same terms. */
+  seen.length = 0;
+  const relayed = await deliverConversationMessage(
+    { path: branchPath, text: "relay", images: [] } as never,
+    overrides((pathname) => pathname === rootPath) as never,
+  );
+  expect(relayed).toMatchObject({ ok: true });
+  expect(seen).toEqual([
+    { path: branchPath, mcpServers: ["viewer"] },
+    { path: rootPath, mcpServers: ["viewer"] },
+  ]);
 });

--- a/src/lib/delivery.test.ts
+++ b/src/lib/delivery.test.ts
@@ -1194,3 +1194,36 @@ test("a send or resume aimed at a superseded round answers 409 with the live cha
      silently forked by a message. */
   expect(recoveryCalls).toBe(0);
 });
+
+test("a tmux resume rebuilds the command with the conversation's stored MCP grant", async () => {
+  /* A plain fixture name: the publication gate reads a real session-id shape as
+     a resource identifier, and every lookup here is overridden anyway. */
+  const pathname = path.join(SANDBOX, "resume-grant-fixture.jsonl");
+  fs.writeFileSync(pathname, "");
+  const stored = emptyLaunchProfile({ allowSubagents: true, plugins: ["computer-use"] });
+  /* Written past the profile helper on purpose: this stands for the grant a
+     conversation carries, whatever the bound of the day admits. */
+  const profile = { ...stored, mcpServers: ["viewer", "granted-connector"] };
+  const options: { mcpServers?: readonly string[] }[] = [];
+
+  const outcome = await resumeConversation(pathname, {
+    pathAllowed: () => true,
+    registry: {
+      conversationForPath: () => null,
+      launchProfileForPath: () => profile,
+    },
+    recover: async () => null,
+    listFiles: async () => [{ root: "codex-sessions", path: pathname, project: "p", mtime: 0, size: 0 } as unknown as FileEntry],
+    resumeSpecFor: (_root: string, _path: string, given: { mcpServers?: readonly string[] }) => {
+      options.push(given);
+      return { command: "resume", transcript: pathname, launchProfile: profile };
+    },
+    deliver: async () => ({ ok: true, outcome: "resumed", target: "%7" }),
+  } as never);
+
+  expect(outcome).toMatchObject({ ok: true });
+  /* The grant travels with the resume: omitting it relaunched the session on
+     the Viewer baseline while the durable profile still claimed it (#739). */
+  expect(options).toHaveLength(1);
+  expect(options[0]!.mcpServers).toEqual(["viewer", "granted-connector"]);
+});

--- a/src/lib/delivery.ts
+++ b/src/lib/delivery.ts
@@ -359,11 +359,17 @@ export async function resumeConversation(
   }
   const entry = (await (overrides.listFiles ?? listFiles)()).find((item) => item.path === filePath);
   if (!entry) return failure("file is unknown to the viewer", 403);
+  const profile = registry.launchProfileForPath(entry.path);
   const spec = (overrides.resumeSpecFor ?? resumeSpecFor)(entry.root, entry.path, {
     model: entry.launchModel ?? entry.model,
     effort: entry.effort,
-    allowSubagents: registry.launchProfileForPath(entry.path)?.allowSubagents,
-    plugins: registry.launchProfileForPath(entry.path)?.plugins,
+    allowSubagents: profile?.allowSubagents,
+    plugins: profile?.plugins,
+    /* The durable grant travels with the resume (#739). Omitting it silently
+       relaunched the session on the Viewer baseline while the profile went on
+       claiming the grant — durable state and running process disagreeing. The
+       stored list is already origin-bounded when the registry reads it. */
+    mcpServers: profile?.mcpServers,
   });
   if (!spec) return failure("this conversation cannot be resumed", 409);
   try {

--- a/src/lib/delivery.ts
+++ b/src/lib/delivery.ts
@@ -135,6 +135,9 @@ export async function reconfigureConversation(
     permissionMode: profile?.permissionMode ?? null,
     allowSubagents: profile?.allowSubagents ?? false,
     plugins: profile?.plugins,
+    /* Every relaunch carries the durable grant (#739); dropping it here rebuilt
+       the command on the Viewer baseline while the profile still claimed it. */
+    mcpServers: profile?.mcpServers,
   });
   const deliver = overrides.deliver ?? deliverToTranscriptHost;
   const observedHost = await (overrides.livePaneHost ?? livePaneHost)(filePath);
@@ -646,12 +649,14 @@ export async function deliverConversationMessage(message: ConversationMessage, o
     if (!entry) {
       return settle(failure("file is unknown to the viewer", 403));
     }
+    const entryProfile = registry.launchProfileForPath(entry.path);
     const spec = (overrides.resumeSpecFor ?? resumeSpecFor)(entry.root, entry.path, {
       model: message.resumeModel ?? entry.launchModel ?? entry.model,
       effort: message.resumeEffort ?? entry.effort,
       ...(typeof message.resumeFast === "boolean" ? { fast: message.resumeFast } : {}),
-      allowSubagents: registry.launchProfileForPath(entry.path)?.allowSubagents,
-      plugins: registry.launchProfileForPath(entry.path)?.plugins,
+      allowSubagents: entryProfile?.allowSubagents,
+      plugins: entryProfile?.plugins,
+      mcpServers: entryProfile?.mcpServers,
     });
     if (spec) {
       const bundle = materializePayload();
@@ -675,11 +680,13 @@ export async function deliverConversationMessage(message: ConversationMessage, o
     }
     /* Resolved before saving anything: the root's live pane or resume spec
        must exist, or the request is rejected without ever writing an image. */
+    const rootProfile = registry.launchProfileForPath(root.path);
     const rootSpec = (overrides.resumeSpecFor ?? resumeSpecFor)(root.root, root.path, {
       model: root.launchModel ?? root.model,
       effort: root.effort,
-      allowSubagents: registry.launchProfileForPath(root.path)?.allowSubagents,
-      plugins: registry.launchProfileForPath(root.path)?.plugins,
+      allowSubagents: rootProfile?.allowSubagents,
+      plugins: rootProfile?.plugins,
+      mcpServers: rootProfile?.mcpServers,
     });
     if (!rootSpec) {
       return settle(failure("root session is unavailable for messaging", 409));

--- a/src/lib/mcp/server.ts
+++ b/src/lib/mcp/server.ts
@@ -971,7 +971,7 @@ const TOOL_INPUT_SCHEMAS: Record<McpToolName, z.ZodObject> = {
     allowSubagents: z.boolean().optional(),
     mcpServers: z.array(z.string().regex(/^[^\s\u0000-\u001f\u007f]{1,128}$/u))
       .optional()
-      .describe("Per-spawn MCP server allowlist. Viewer is always included; omission selects Viewer only."),
+      .describe("Per-spawn MCP server allowlist, resolved server-side. Only servers the Viewer may grant are accepted; any other name is refused outright, never silently trimmed. Viewer is always included. The grant is then decided by the new session's origin — a delegated launch, which every role-preset spawn is, receives the Viewer baseline whatever it lists here — so this can narrow the surface, never widen it."),
     images: z.array(z.unknown()).optional(),
   }).passthrough(),
   send_message: z.object({

--- a/src/lib/runtime/claudeStreamBrokerHost.integration.test.ts
+++ b/src/lib/runtime/claudeStreamBrokerHost.integration.test.ts
@@ -446,21 +446,19 @@ test.skipIf(!mcpCustomHome)("real Claude custom MCP policy force-includes Viewer
       "spawn-settings",
       `${profileId}.json`,
     ), "utf8")) as { enabledMcpjsonServers: string[]; disabledMcpjsonServers: string[] };
-    expect(freshMcpConfig.mcpServers["agent-browser"]).toMatchObject({
-      env: { PROJECT_AUTH: "preserved" },
-      timeout: 120_000,
-      alwaysLoad: true,
-    });
-    expect(freshMcpConfig.mcpServers).not.toHaveProperty("project-unrelated");
-    expect(freshSettings.enabledMcpjsonServers).toEqual(["agent-browser"]);
-    expect(freshSettings.disabledMcpjsonServers).toEqual(["project-unrelated"]);
+    /* The allowlist names a project-scoped server; the grant bound admits none,
+       so the exclusive config carries Viewer alone and the optional server's
+       process is never started (#739). */
+    expect(Object.keys(freshMcpConfig.mcpServers)).toEqual(["viewer"]);
+    expect(freshSettings.enabledMcpjsonServers ?? []).not.toContain("agent-browser");
+    expect(freshSettings.disabledMcpjsonServers ?? []).toContain("project-unrelated");
     await exerciseClaudeTool(fresh, {
-      name: "mcp__agent-browser__get_pipeline",
-      request: `Call the exact native tool mcp__agent-browser__get_pipeline with clientRequestId "claude-custom-fresh" and pipelineId "${fixture.pipelineId}". Do not use mcp__viewer__get_pipeline or shell execution. Reply after the successful result.`,
+      name: "mcp__viewer__get_pipeline",
+      request: `Call the exact native tool mcp__viewer__get_pipeline with clientRequestId "claude-custom-fresh" and pipelineId "${fixture.pipelineId}". Shell execution is prohibited. Reply after the successful result.`,
       expectedResult: fixture.pipelineId,
     });
     expect(fs.existsSync(fixture.viewerPidPath)).toBeTrue();
-    expect(fs.existsSync(fixture.optionalPidPath)).toBeTrue();
+    expect(fs.existsSync(fixture.optionalPidPath)).toBeFalse();
     expect(fs.existsSync(fixture.unrelatedPath)).toBeFalse();
     const sessionId = fresh.identity.sessionId;
     const cursor = (await fresh.health()).eventCursor;
@@ -468,33 +466,25 @@ test.skipIf(!mcpCustomHome)("real Claude custom MCP policy force-includes Viewer
     if (!freshPid) throw new Error("fresh Claude host pid is unavailable");
     const freshProcesses = processTree(freshPid);
     addRecordedProcess(freshProcesses, fixture.viewerPidPath);
-    addRecordedProcess(freshProcesses, fixture.optionalPidPath);
     await fresh.release();
     fresh = null;
     await expectProcessesReaped(freshProcesses);
 
     fs.rmSync(fixture.viewerPidPath);
-    fs.rmSync(fixture.optionalPidPath);
     adopted = await ClaudeStreamBrokerHost.adopt(sessionId, { ...options, initialEventCursor: cursor });
-    await exerciseClaudeTool(adopted, {
-      name: "mcp__agent-browser__get_pipeline",
-      request: `Call the exact native tool mcp__agent-browser__get_pipeline with clientRequestId "claude-adopted" and pipelineId "${fixture.pipelineId}". Do not use mcp__viewer__get_pipeline or shell execution. Reply after the successful result.`,
-      expectedResult: fixture.pipelineId,
-    });
     await exerciseClaudeTool(adopted, {
       name: "mcp__viewer__get_pipeline",
       request: `Call the exact native tool mcp__viewer__get_pipeline with clientRequestId "claude-adopted-viewer" and pipelineId "${fixture.pipelineId}". Shell execution is prohibited. Reply after the successful result.`,
       expectedResult: fixture.pipelineId,
     });
     expect(fs.existsSync(fixture.viewerPidPath)).toBeTrue();
-    expect(fs.existsSync(fixture.optionalPidPath)).toBeTrue();
+    expect(fs.existsSync(fixture.optionalPidPath)).toBeFalse();
     expect(fs.existsSync(fixture.unrelatedPath)).toBeFalse();
     expect(fs.existsSync(fixture.hookPath)).toBeTrue();
     const adoptedPid = (await adopted.health()).pid;
     if (!adoptedPid) throw new Error("adopted Claude host pid is unavailable");
     const adoptedProcesses = processTree(adoptedPid);
     addRecordedProcess(adoptedProcesses, fixture.viewerPidPath);
-    addRecordedProcess(adoptedProcesses, fixture.optionalPidPath);
     await adopted.release();
     adopted = null;
     await expectProcessesReaped(adoptedProcesses);

--- a/src/lib/runtime/claudeStreamBrokerHost.test.ts
+++ b/src/lib/runtime/claudeStreamBrokerHost.test.ts
@@ -193,9 +193,10 @@ describe("ClaudeStreamBrokerHost", () => {
     expect(captured.args).not.toContain("--safe-mode");
     const mcpConfigPath = captured.args![captured.args!.indexOf("--mcp-config") + 1]!;
     const mcpConfig = JSON.parse(fs.readFileSync(mcpConfigPath, "utf8")) as { mcpServers: Record<string, unknown> };
+    /* Only granted servers are copied into the exclusive file; the grant bound
+       admits none beyond the Viewer baseline this tranche (#739). */
     expect(mcpConfig.mcpServers).toEqual({
       viewer: { type: "stdio", command: "viewer-mcp" },
-      "agent-browser": { type: "stdio", command: "browser-mcp" },
     });
     await host.release();
     expect(child.signals).toContain("SIGTERM");
@@ -684,7 +685,6 @@ describe("ClaudeStreamBrokerHost", () => {
     expect(adoptedMcp).toEqual(freshMcp);
     expect(freshMcp).toEqual({ mcpServers: {
       viewer: { type: "stdio", command: "viewer-mcp" },
-      "agent-browser": { type: "stdio", command: "browser-mcp" },
     } });
     await adopted.release();
 

--- a/src/lib/runtime/codexAppServerHost.integration.test.ts
+++ b/src/lib/runtime/codexAppServerHost.integration.test.ts
@@ -363,18 +363,19 @@ test.skipIf(!mcpHome)("real structured Codex enforces default and custom MCP all
     expect(fs.existsSync(markerPath)).toBeFalse();
 
     fs.rmSync(viewerPidPath);
+    /* Naming a configured server does not enable it: the grant bound admits
+       none beyond the Viewer baseline, so the optional server never starts and
+       Viewer remains the whole surface (#739). */
     custom = await CodexAppServerHost.start({ ...options, mcpServers: ["agent-browser"] });
-    await exerciseNativeViewer(custom, pipeline.id, "custom", "agent-browser");
+    await exerciseNativeViewer(custom, pipeline.id, "custom");
     expect(fs.existsSync(markerPath)).toBeFalse();
     const customHealth = await custom.health();
     if (!customHealth.pid) throw new Error("custom app-server pid is unavailable");
     const customProcesses = processTree(customHealth.pid);
     const customViewer = recordedProcess(viewerPidPath);
-    const customOptional = recordedProcess(optionalPidPath);
     addProcessTree(customProcesses, customViewer.pid);
-    addProcessTree(customProcesses, customOptional.pid);
     expect(customProcesses.get(customViewer.pid)).toBe(customViewer.identity);
-    expect(customProcesses.get(customOptional.pid)).toBe(customOptional.identity);
+    expect(fs.existsSync(optionalPidPath)).toBeFalse();
     await custom.release();
     custom = null;
     await expectProcessesReaped(customProcesses);

--- a/src/lib/runtime/codexAppServerHost.test.ts
+++ b/src/lib/runtime/codexAppServerHost.test.ts
@@ -492,12 +492,13 @@ describe("CodexAppServerHost", () => {
     });
 
     /* The hosted thread is the only place the MCP table lives: thread/start
-       enables the allowlisted servers and restates realtime_conversation. */
+       enables the granted servers and restates realtime_conversation. The grant
+       bound ships empty of connectors, so Viewer is the whole surface (#739). */
     expect(server.requests.find((request) => request.method === "thread/start")?.params).toMatchObject({
       config: {
         mcp_servers: {
           viewer: { enabled: true, default_tools_approval_mode: "approve" },
-          "agent-browser": { enabled: true, default_tools_approval_mode: "writes" },
+          "agent-browser": { enabled: false, default_tools_approval_mode: "writes" },
           "telegram-readonly": { enabled: false },
         },
         features: { realtime_conversation: true },
@@ -538,7 +539,7 @@ describe("CodexAppServerHost", () => {
     await host.release();
   });
 
-  test("fresh structured threads enable a custom MCP allowlist and disable unrelated servers", async () => {
+  test("fresh structured threads enable only granted servers and disable the rest", async () => {
     const server = new FakeAppServer("custom-mcp-thread");
     server.mcpServers = {
       viewer: { command: "agent-log-viewer-mcp", enabled: true, default_tools_approval_mode: "prompt" },
@@ -556,7 +557,7 @@ describe("CodexAppServerHost", () => {
       config: {
         mcp_servers: {
           viewer: { enabled: true, default_tools_approval_mode: "approve" },
-          "agent-browser": { enabled: true, default_tools_approval_mode: "writes" },
+          "agent-browser": { enabled: false, default_tools_approval_mode: "writes" },
           "telegram-readonly": { enabled: false, default_tools_approval_mode: "prompt" },
         },
       },


### PR DESCRIPTION
Closes #739.

## What changed

- deny grants when origin evidence is absent, malformed, contradictory, or self-selected;
- bind receipt decisions to independent admission and lineage evidence;
- re-decide assembled origin before every persistent store mutation;
- keep the tranche fail-closed while covering JSON, SQLite, claim, adoption, and recovery paths;
- add attack controls that fail against the previously permissive behavior.

## Verification

- Focused origin-boundary suite: 36 pass / 0 fail in isolated state.
- Typecheck and lint completed cleanly on the branch.
- Publication privacy gate passed.

The public description and fixtures contain synthetic data only.
