### PR TITLE
Repair managed MCP health-probe admission

### DIFF
--- a/bin/mcp-server.mjs
+++ b/bin/mcp-server.mjs
@@ -2,7 +2,7 @@
 
 import { spawn } from "node:child_process";
 import { createHash } from "node:crypto";
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, fstatSync, readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
@@ -77,7 +77,16 @@ const bundled = join(selectedPackageRoot, "dist", "mcp-server.mjs");
 const source = join(selectedPackageRoot, "src", "lib", "mcp", "entry.ts");
 
 async function runChild(runtime, entry) {
-  const child = spawn(runtime, [entry], viewerChildProcessOptions({ cwd: selectedPackageRoot, stdio: "inherit" }));
+  let admissionChannel = false;
+  try {
+    admissionChannel = fstatSync(3).isSocket();
+  } catch {
+    admissionChannel = false;
+  }
+  const child = spawn(runtime, [entry], viewerChildProcessOptions({
+    cwd: selectedPackageRoot,
+    stdio: admissionChannel ? [0, 1, 2, 3] : [0, 1, 2, "ignore"],
+  }));
   let childExited = false;
   const forwardInterrupt = () => {
     if (!childExited) child.kill("SIGINT");

--- a/scripts/runtime-host-viewer-adapter.test.ts
+++ b/scripts/runtime-host-viewer-adapter.test.ts
@@ -4,12 +4,15 @@ import os from "node:os";
 import path from "node:path";
 
 import { WAKATIME_CREDENTIAL_ENV, withoutWakatimeCredential } from "../src/lib/wakatime/credential";
+import { MCP_TOOL_NAMES } from "../src/lib/mcp/server";
+import { UnixRuntimeHostClient } from "../src/lib/runtime/client";
 import { viewerComposeSnapshotName } from "../src/runtime-host/deploymentArtifacts";
 import { RuntimeHost } from "../src/runtime-host/host";
 import { RuntimeJournal } from "../src/runtime-host/journal";
 import { McpHealthProbeAdmissions } from "../src/runtime-host/mcpHealthProbeAdmission";
+import { probeMcpRuntime } from "../src/runtime-host/mcpRuntimeProbe";
 import { serveRuntimeHost } from "../src/runtime-host/socket";
-import { MCP_TOOL_NAMES } from "../src/lib/mcp/server";
+import { runBootstrapRelease } from "./runtime-host-viewer-adapter";
 
 const root = path.resolve(import.meta.dir, "..");
 const adapter = path.join(root, "scripts", "runtime-host-viewer-adapter.ts");
@@ -81,6 +84,150 @@ test("malformed rollback target blocks promotion with a durable-target error", a
   const result = await currentRelease({ target: "{broken" });
   expect(result.code).not.toBe(0);
   expect(result.stderr).toContain("current release target is invalid");
+});
+
+test("documented bootstrap input obtains host-owned admission through the final MCP transport", async () => {
+  const sandbox = fs.mkdtempSync(path.join(os.tmpdir(), "llv-mcp-bootstrap-admission-"));
+  const state = path.join(sandbox, "state");
+  const socketPath = path.join(state, "runtime-host.sock");
+  const revision = "7".repeat(40);
+  const candidate = {
+    ...release,
+    revision,
+    mcpRuntime: {
+      source: "managed" as const,
+      revision,
+      releaseId: "bootstrap-candidate",
+      artifactDigest: "a".repeat(64),
+      stagedAt: "2026-07-28T00:00:00.000Z",
+    },
+  };
+  const calls: string[] = [];
+  fs.mkdirSync(state, { recursive: true });
+  const environment = Object.fromEntries(Object.entries(withoutWakatimeCredential(process.env))
+    .filter((entry): entry is [string, string] => typeof entry[1] === "string"));
+  Object.assign(environment, {
+    HOME: sandbox,
+    XDG_CONFIG_HOME: path.join(sandbox, "config"),
+    TMPDIR: path.join(sandbox, "tmp"),
+    LLV_STATE_DIR: state,
+    LLV_RUNTIME_EVENTS: "1",
+    LLV_RUNTIME_HOST_SOCKET: socketPath,
+    LLV_AGENT_REGISTRY_SQLITE: "off",
+    LLV_CODEX_HOME: path.join(sandbox, "codex"),
+    LLV_CLAUDE_HOME: path.join(sandbox, "claude"),
+  });
+  fs.mkdirSync(environment.TMPDIR, { recursive: true });
+
+  try {
+    const result = await runBootstrapRelease({ revision: "origin/main" }, {
+      runtimeSocket: socketPath,
+      targetExists: () => false,
+      resolveRevision: async (requested) => {
+        calls.push(`resolve:${requested}`);
+        return revision;
+      },
+      buildCandidate: async () => {
+        calls.push("build");
+        return candidate;
+      },
+      startCandidate: async () => {
+        calls.push("start");
+      },
+      verifyCandidate: async (releaseIdentity, healthProbeCapability) => {
+        calls.push("verify");
+        const mcpRuntime = await probeMcpRuntime({
+          command: process.execPath,
+          args: [path.join(root, "bin", "mcp-server.mjs")],
+          cwd: root,
+          env: environment,
+          runtime: releaseIdentity.mcpRuntime!,
+          healthProbeCapability,
+        });
+        return {
+          checkedAt: mcpRuntime.checkedAt,
+          endpoint: releaseIdentity.endpoint,
+          processReady: true,
+          rootStatus: 200,
+          authenticatedStatus: null,
+          unauthorizedStatus: null,
+          assets: [{ path: "/_next/static/app.js", status: 200 }],
+          mcpRuntime,
+          ok: mcpRuntime.ok,
+          ...(mcpRuntime.detail ? { detail: mcpRuntime.detail } : {}),
+        };
+      },
+      publishTarget: async () => {
+        calls.push("publish");
+      },
+      targetMatches: () => false,
+      retireCandidate: async () => {
+        calls.push("retire");
+      },
+    });
+
+    expect(calls).toEqual(["resolve:origin/main", "build", "start", "verify", "publish"]);
+    expect(result.health.mcpRuntime).toMatchObject({
+      processReady: true,
+      calls: { deploymentStatus: true, boardSnapshot: true },
+      ok: true,
+    });
+    expect(result.health.mcpRuntime?.tools).toHaveLength(MCP_TOOL_NAMES.length);
+    expect(fs.existsSync(socketPath)).toBe(false);
+    expect(fs.existsSync(`${socketPath}.lock`)).toBe(false);
+  } finally {
+    fs.rmSync(sandbox, { recursive: true, force: true });
+  }
+}, 20_000);
+
+test("bootstrap rejects caller-selected probe authority and spends its own admission once", async () => {
+  const sandbox = fs.mkdtempSync(path.join(os.tmpdir(), "llv-mcp-bootstrap-forgery-"));
+  const socketPath = path.join(sandbox, "state", "runtime-host.sock");
+  const callerCapability = new McpHealthProbeAdmissions().issue();
+  fs.mkdirSync(path.dirname(socketPath), { recursive: true });
+
+  try {
+    const result = await runBootstrapRelease({
+      revision: "origin/main",
+      healthProbeCapability: callerCapability,
+    }, {
+      runtimeSocket: socketPath,
+      targetExists: () => false,
+      resolveRevision: async () => release.revision,
+      buildCandidate: async () => release,
+      startCandidate: async () => {},
+      verifyCandidate: async (candidate, healthProbeCapability) => {
+        const client = new UnixRuntimeHostClient(socketPath);
+        expect(healthProbeCapability).not.toBe(callerCapability);
+        await expect(client.requestViewerDeployment({
+          idempotencyKey: "bootstrap-forgery",
+        })).rejects.toThrow("runtime request method is unsupported");
+        expect((await client.snapshot()).deployments).toEqual([]);
+        expect(await client.admitMcpHealthProbe(callerCapability)).toBe(false);
+        expect(await client.admitMcpHealthProbe(healthProbeCapability)).toBe(true);
+        expect(await client.admitMcpHealthProbe(healthProbeCapability)).toBe(false);
+        return {
+          checkedAt: "2026-07-28T00:00:00.000Z",
+          endpoint: candidate.endpoint,
+          processReady: true,
+          rootStatus: 200,
+          authenticatedStatus: null,
+          unauthorizedStatus: null,
+          assets: [{ path: "/_next/static/app.js", status: 200 }],
+          ok: true,
+        };
+      },
+      publishTarget: async () => {},
+      targetMatches: () => false,
+      retireCandidate: async () => {},
+    });
+
+    expect(result.candidate).toEqual(release);
+    expect(fs.existsSync(socketPath)).toBe(false);
+    expect(fs.existsSync(`${socketPath}.lock`)).toBe(false);
+  } finally {
+    fs.rmSync(sandbox, { recursive: true, force: true });
+  }
 });
 
 function composeSnapshot(): string {

--- a/scripts/runtime-host-viewer-adapter.test.ts
+++ b/scripts/runtime-host-viewer-adapter.test.ts
@@ -7,7 +7,9 @@ import { WAKATIME_CREDENTIAL_ENV, withoutWakatimeCredential } from "../src/lib/w
 import { viewerComposeSnapshotName } from "../src/runtime-host/deploymentArtifacts";
 import { RuntimeHost } from "../src/runtime-host/host";
 import { RuntimeJournal } from "../src/runtime-host/journal";
+import { McpHealthProbeAdmissions } from "../src/runtime-host/mcpHealthProbeAdmission";
 import { serveRuntimeHost } from "../src/runtime-host/socket";
+import { MCP_TOOL_NAMES } from "../src/lib/mcp/server";
 
 const root = path.resolve(import.meta.dir, "..");
 const adapter = path.join(root, "scripts", "runtime-host-viewer-adapter.ts");
@@ -204,7 +206,10 @@ function successorPackage(prefix: string, options: { revision: string; bundle?: 
   return { sandbox, state, packageRoot, stableRuntime, target };
 }
 
-async function runReconcile(fixture: ReturnType<typeof successorPackage>, options: { revision: string; socketPath?: string }) {
+async function runReconcile(
+  fixture: ReturnType<typeof successorPackage>,
+  options: { revision: string; socketPath?: string; healthProbeCapability?: string },
+) {
   const child = Bun.spawn([process.execPath, adapter, "reconcile-mcp-runtime"], {
     cwd: root,
     env: {
@@ -224,7 +229,10 @@ async function runReconcile(fixture: ReturnType<typeof successorPackage>, option
     stdout: "pipe",
     stderr: "pipe",
   });
-  child.stdin.write(`${JSON.stringify({ revision: options.revision })}\n`);
+  child.stdin.write(`${JSON.stringify({
+    revision: options.revision,
+    ...(options.healthProbeCapability ? { healthProbeCapability: options.healthProbeCapability } : {}),
+  })}\n`);
   child.stdin.end();
   const [code, stdout, stderr] = await Promise.all([
     child.exited,
@@ -239,11 +247,23 @@ test("the first successor boot publishes and probes the MCP runtime after an old
   const fixture = successorPackage("llv-mcp-successor-reconcile-", { revision });
   const socketPath = path.join(fixture.state, "runtime-host.sock");
   const journal = new RuntimeJournal(path.join(fixture.state, "runtime.sqlite"));
-  const server = serveRuntimeHost(socketPath, new RuntimeHost(journal));
+  const admissions = new McpHealthProbeAdmissions();
+  const server = serveRuntimeHost(socketPath, new RuntimeHost(
+    journal,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    admissions,
+  ));
   await new Promise<void>((resolve) => server.once("listening", resolve));
 
   try {
-    const { code, stdout, stderr } = await runReconcile(fixture, { revision, socketPath });
+    const { code, stdout, stderr } = await runReconcile(fixture, {
+      revision,
+      socketPath,
+      healthProbeCapability: admissions.issue(),
+    });
 
     expect({ code, stderr }).toEqual({ code: 0, stderr: "" });
     const result = JSON.parse(stdout);
@@ -262,7 +282,7 @@ test("the first successor boot publishes and probes the MCP runtime after an old
         },
       },
     });
-    expect(result.health.tools).toHaveLength(23);
+    expect(result.health.tools).toHaveLength(MCP_TOOL_NAMES.length);
     const target = JSON.parse(fs.readFileSync(path.join(fixture.state, "viewer-release.json"), "utf8"));
     expect(target).toMatchObject({
       revision,
@@ -279,7 +299,11 @@ test("the first successor boot publishes and probes the MCP runtime after an old
        published and reconciles nothing. */
     const releases = path.join(fixture.state, "mcp-runtime", "releases");
     const published = fs.readdirSync(releases);
-    const reboot = await runReconcile(fixture, { revision, socketPath });
+    const reboot = await runReconcile(fixture, {
+      revision,
+      socketPath,
+      healthProbeCapability: admissions.issue(),
+    });
 
     expect({ code: reboot.code, stdout: reboot.stdout, stderr: reboot.stderr })
       .toEqual({ code: 0, stdout: "null\n", stderr: "" });

--- a/scripts/runtime-host-viewer-adapter.test.ts
+++ b/scripts/runtime-host-viewer-adapter.test.ts
@@ -11,6 +11,7 @@ import { RuntimeHost } from "../src/runtime-host/host";
 import { RuntimeJournal } from "../src/runtime-host/journal";
 import { McpHealthProbeAdmissions } from "../src/runtime-host/mcpHealthProbeAdmission";
 import { probeMcpRuntime } from "../src/runtime-host/mcpRuntimeProbe";
+import { RuntimeHostFence } from "../src/runtime-host/runtimeHostFence";
 import { serveRuntimeHost } from "../src/runtime-host/socket";
 import { runBootstrapRelease } from "./runtime-host-viewer-adapter";
 
@@ -174,7 +175,9 @@ test("documented bootstrap input obtains host-owned admission through the final 
     });
     expect(result.health.mcpRuntime?.tools).toHaveLength(MCP_TOOL_NAMES.length);
     expect(fs.existsSync(socketPath)).toBe(false);
-    expect(fs.existsSync(`${socketPath}.lock`)).toBe(false);
+    const successor = new RuntimeHostFence(`${socketPath}.lock`);
+    successor.acquire();
+    successor.release();
   } finally {
     fs.rmSync(sandbox, { recursive: true, force: true });
   }
@@ -224,7 +227,9 @@ test("bootstrap rejects caller-selected probe authority and spends its own admis
 
     expect(result.candidate).toEqual(release);
     expect(fs.existsSync(socketPath)).toBe(false);
-    expect(fs.existsSync(`${socketPath}.lock`)).toBe(false);
+    const successor = new RuntimeHostFence(`${socketPath}.lock`);
+    successor.acquire();
+    successor.release();
   } finally {
     fs.rmSync(sandbox, { recursive: true, force: true });
   }

--- a/scripts/runtime-host-viewer-adapter.test.ts
+++ b/scripts/runtime-host-viewer-adapter.test.ts
@@ -1,7 +1,9 @@
 import { expect, test } from "bun:test";
+import { spawn } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import type { Readable } from "node:stream";
 
 import { WAKATIME_CREDENTIAL_ENV, withoutWakatimeCredential } from "../src/lib/wakatime/credential";
 import { MCP_TOOL_NAMES } from "../src/lib/mcp/server";
@@ -10,6 +12,10 @@ import { viewerComposeSnapshotName } from "../src/runtime-host/deploymentArtifac
 import { RuntimeHost } from "../src/runtime-host/host";
 import { RuntimeJournal } from "../src/runtime-host/journal";
 import { McpHealthProbeAdmissions } from "../src/runtime-host/mcpHealthProbeAdmission";
+import {
+  createMcpHealthProbeAdmissionChannel,
+  serveMcpHealthProbeAdmissionChannel,
+} from "../src/runtime-host/mcpHealthProbeAdmissionChannel";
 import { probeMcpRuntime } from "../src/runtime-host/mcpRuntimeProbe";
 import { RuntimeHostFence } from "../src/runtime-host/runtimeHostFence";
 import { serveRuntimeHost } from "../src/runtime-host/socket";
@@ -135,7 +141,7 @@ test("documented bootstrap input obtains host-owned admission through the final 
       startCandidate: async () => {
         calls.push("start");
       },
-      verifyCandidate: async (releaseIdentity, healthProbeCapability) => {
+      verifyCandidate: async (releaseIdentity, healthProbeCapability, healthProbeAdmissions) => {
         calls.push("verify");
         const mcpRuntime = await probeMcpRuntime({
           command: process.execPath,
@@ -144,6 +150,7 @@ test("documented bootstrap input obtains host-owned admission through the final 
           env: environment,
           runtime: releaseIdentity.mcpRuntime!,
           healthProbeCapability,
+          healthProbeAdmissions,
         });
         return {
           checkedAt: mcpRuntime.checkedAt,
@@ -360,37 +367,72 @@ function successorPackage(prefix: string, options: { revision: string; bundle?: 
 
 async function runReconcile(
   fixture: ReturnType<typeof successorPackage>,
-  options: { revision: string; socketPath?: string; healthProbeCapability?: string },
+  options: {
+    revision: string;
+    socketPath?: string;
+    healthProbeCapability?: string;
+    healthProbeAdmissions?: McpHealthProbeAdmissions;
+  },
 ) {
-  const child = Bun.spawn([process.execPath, adapter, "reconcile-mcp-runtime"], {
-    cwd: root,
-    env: {
-      ...withoutWakatimeCredential(process.env),
-      LLV_AGENT_REGISTRY_SQLITE: "off",
-      LLV_CLAUDE_HOME: path.join(fixture.sandbox, "claude"),
-      LLV_CODEX_HOME: path.join(fixture.sandbox, "codex"),
-      LLV_DEPLOYMENT_ADAPTER_PROTOCOL: "1",
-      LLV_DEPLOYMENT_PACKAGE_ROOT: fixture.packageRoot,
-      LLV_MCP_RUNTIME_ROOT: fixture.stableRuntime,
-      LLV_RUNTIME_EVENTS: "1",
-      ...(options.socketPath ? { LLV_RUNTIME_HOST_SOCKET: options.socketPath } : {}),
-      LLV_STATE_DIR: fixture.state,
-      LLV_VIEWER_PORT: "1",
-    },
-    stdin: "pipe",
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-  child.stdin.write(`${JSON.stringify({
+  const admissionChannel = options.healthProbeAdmissions
+    ? await createMcpHealthProbeAdmissionChannel()
+    : null;
+  let child: ReturnType<typeof spawn>;
+  try {
+    child = spawn(process.execPath, [adapter, "reconcile-mcp-runtime"], {
+      cwd: root,
+      env: {
+        ...withoutWakatimeCredential(process.env),
+        LLV_AGENT_REGISTRY_SQLITE: "off",
+        LLV_CLAUDE_HOME: path.join(fixture.sandbox, "claude"),
+        LLV_CODEX_HOME: path.join(fixture.sandbox, "codex"),
+        LLV_DEPLOYMENT_ADAPTER_PROTOCOL: "1",
+        LLV_DEPLOYMENT_PACKAGE_ROOT: fixture.packageRoot,
+        LLV_MCP_RUNTIME_ROOT: fixture.stableRuntime,
+        LLV_RUNTIME_EVENTS: "1",
+        ...(options.socketPath ? { LLV_RUNTIME_HOST_SOCKET: options.socketPath } : {}),
+        LLV_STATE_DIR: fixture.state,
+        LLV_VIEWER_PORT: "1",
+      },
+      stdio: ["pipe", "pipe", "pipe", admissionChannel?.childFd ?? "ignore"],
+    });
+  } catch (error) {
+    admissionChannel?.close();
+    throw error;
+  } finally {
+    admissionChannel?.closeChildFd();
+  }
+  const closeHealthAdmission = options.healthProbeAdmissions && admissionChannel
+    ? (() => {
+        const closeServing = serveMcpHealthProbeAdmissionChannel(
+          admissionChannel.channel,
+          options.healthProbeAdmissions,
+        );
+        return () => {
+          closeServing();
+          admissionChannel.close();
+        };
+      })()
+    : null;
+  child.stdin?.write(`${JSON.stringify({
     revision: options.revision,
     ...(options.healthProbeCapability ? { healthProbeCapability: options.healthProbeCapability } : {}),
   })}\n`);
-  child.stdin.end();
+  child.stdin?.end();
+  const readStream = async (stream: Readable | null): Promise<string> => {
+    let body = "";
+    if (!stream) return body;
+    for await (const chunk of stream) body += String(chunk);
+    return body;
+  };
   const [code, stdout, stderr] = await Promise.all([
-    child.exited,
-    new Response(child.stdout).text(),
-    new Response(child.stderr).text(),
-  ]);
+    new Promise<number>((resolve, reject) => {
+      child.once("error", reject);
+      child.once("close", (exitCode) => resolve(exitCode ?? 1));
+    }),
+    readStream(child.stdout),
+    readStream(child.stderr),
+  ]).finally(() => closeHealthAdmission?.());
   return { code, stdout, stderr };
 }
 
@@ -415,6 +457,7 @@ test("the first successor boot publishes and probes the MCP runtime after an old
       revision,
       socketPath,
       healthProbeCapability: admissions.issue(),
+      healthProbeAdmissions: admissions,
     });
 
     expect({ code, stderr }).toEqual({ code: 0, stderr: "" });
@@ -455,6 +498,7 @@ test("the first successor boot publishes and probes the MCP runtime after an old
       revision,
       socketPath,
       healthProbeCapability: admissions.issue(),
+      healthProbeAdmissions: admissions,
     });
 
     expect({ code: reboot.code, stdout: reboot.stdout, stderr: reboot.stderr })

--- a/scripts/runtime-host-viewer-adapter.ts
+++ b/scripts/runtime-host-viewer-adapter.ts
@@ -23,6 +23,7 @@ import {
 } from "../src/runtime-host/candidateContainer";
 import { ensureCanonicalMirror } from "../src/runtime-host/canonicalMirror";
 import { allocateBuiltCandidatePort, candidatePortsFromEnvironmentLists, isCandidatePortAvailable } from "../src/runtime-host/candidatePort";
+import { withBootstrapMcpHealthProbeAdmission } from "../src/runtime-host/bootstrapMcpHealthProbeAdmission";
 import { viewerCandidateContainerName, viewerCandidateImageName, viewerComposeSnapshotName } from "../src/runtime-host/deploymentArtifacts";
 import { bootstrapViewerRelease } from "../src/runtime-host/deploymentBootstrap";
 import { probeMcpRuntime } from "../src/runtime-host/mcpRuntimeProbe";
@@ -517,25 +518,50 @@ async function stageRuntimeHostSuccessor(candidate: ViewerReleaseIdentity): Prom
   }, { registryBackendMode });
 }
 
+export interface BootstrapReleaseDependencies {
+  runtimeSocket: string;
+  targetExists(): boolean;
+  resolveRevision(requested: string): Promise<string>;
+  buildCandidate(deploymentId: string, revision: string): Promise<ViewerReleaseIdentity>;
+  startCandidate(candidate: ViewerReleaseIdentity): Promise<void>;
+  verifyCandidate(candidate: ViewerReleaseIdentity, healthProbeCapability: string): Promise<ViewerHealthEvidence>;
+  publishTarget(candidate: ViewerReleaseIdentity): Promise<void>;
+  targetMatches(candidate: ViewerReleaseIdentity): boolean;
+  retireCandidate(candidate: ViewerReleaseIdentity): Promise<void>;
+}
+
+export async function runBootstrapRelease(
+  input: Record<string, unknown>,
+  dependencies: BootstrapReleaseDependencies = {
+    runtimeSocket,
+    targetExists: () => fs.existsSync(targetFile),
+    resolveRevision,
+    buildCandidate,
+    startCandidate,
+    verifyCandidate: (candidate, healthProbeCapability) =>
+      verify(candidate, candidate.endpoint, { healthProbeCapability }),
+    publishTarget: async (candidate) => { switchTarget(candidate, "activate"); },
+    targetMatches: (candidate) => releasesEqual(readTarget(), candidate),
+    retireCandidate: retireRelease,
+  },
+) {
+  return bootstrapViewerRelease(String(input.revision ?? "origin/main"), `bootstrap-${randomUUID()}`, {
+    ...dependencies,
+    verifyCandidate: (candidate) => withBootstrapMcpHealthProbeAdmission(
+      dependencies.runtimeSocket,
+      (healthProbeCapability) => dependencies.verifyCandidate(candidate, healthProbeCapability),
+    ),
+  });
+}
+
 async function main(): Promise<unknown> {
   if (process.env.LLV_DEPLOYMENT_ADAPTER_PROTOCOL !== "1") throw new Error("deployment adapter protocol is required");
   const action = process.argv[2];
   const input = JSON.parse(await Bun.stdin.text()) as Record<string, unknown>;
+  if (action === "bootstrap-release") return runBootstrapRelease(input);
   const healthProbeCapability = typeof input.healthProbeCapability === "string"
     ? input.healthProbeCapability
     : undefined;
-  if (action === "bootstrap-release") {
-    return bootstrapViewerRelease(String(input.revision ?? "origin/main"), `bootstrap-${randomUUID()}`, {
-      targetExists: () => fs.existsSync(targetFile),
-      resolveRevision,
-      buildCandidate,
-      startCandidate,
-      verifyCandidate: (candidate) => verify(candidate, candidate.endpoint, { healthProbeCapability }),
-      publishTarget: async (candidate) => { switchTarget(candidate, "activate"); },
-      targetMatches: (candidate) => releasesEqual(readTarget(), candidate),
-      retireCandidate: retireRelease,
-    });
-  }
   if (action === "resolve-revision") return { revision: await resolveRevision(String(input.revision ?? "")) };
   if (action === "build-candidate") return buildCandidate(String(input.deploymentId ?? ""), String(input.revision ?? ""));
   if (action === "start-candidate") { await startCandidate(release(input.candidate)); return {}; }
@@ -595,16 +621,18 @@ async function main(): Promise<unknown> {
   throw new Error("deployment adapter action is unsupported");
 }
 
-let output: string;
-let exitCode = 0;
-try {
-  output = `${JSON.stringify(await main())}\n`;
-} catch (error) {
-  output = `${error instanceof Error ? error.message : "deployment adapter failed"}\n`;
-  exitCode = 1;
+if (import.meta.main) {
+  let output: string;
+  let exitCode = 0;
+  try {
+    output = `${JSON.stringify(await main())}\n`;
+  } catch (error) {
+    output = `${error instanceof Error ? error.message : "deployment adapter failed"}\n`;
+    exitCode = 1;
+  }
+  const stream = exitCode === 0 ? process.stdout : process.stderr;
+  await new Promise<void>((resolve, reject) => {
+    stream.write(output, (error) => error ? reject(error) : resolve());
+  });
+  process.exit(exitCode);
 }
-const stream = exitCode === 0 ? process.stdout : process.stderr;
-await new Promise<void>((resolve, reject) => {
-  stream.write(output, (error) => error ? reject(error) : resolve());
-});
-process.exit(exitCode);

--- a/scripts/runtime-host-viewer-adapter.ts
+++ b/scripts/runtime-host-viewer-adapter.ts
@@ -348,13 +348,17 @@ async function verifyViewer(candidate: ViewerReleaseIdentity, endpoint: string, 
   });
 }
 
-async function verify(candidate: ViewerReleaseIdentity, endpoint: string, expectedAssetsEndpoint?: string): Promise<ViewerHealthEvidence> {
-  const viewer = await verifyViewer(candidate, endpoint, expectedAssetsEndpoint);
+async function verify(
+  candidate: ViewerReleaseIdentity,
+  endpoint: string,
+  options: { expectedAssetsEndpoint?: string; healthProbeCapability?: string } = {},
+): Promise<ViewerHealthEvidence> {
+  const viewer = await verifyViewer(candidate, endpoint, options.expectedAssetsEndpoint);
   if (!viewer.ok) return viewer;
   if (!candidate.mcpRuntime || candidate.mcpRuntime.source !== "managed") {
     return { ...viewer, ok: false, detail: "candidate MCP runtime identity is missing" };
   }
-  const promoted = expectedAssetsEndpoint !== undefined;
+  const promoted = options.expectedAssetsEndpoint !== undefined;
   const probeTarget = promoted
     ? targetFile
     : path.join(stateDir, `mcp-candidate-probe-${candidate.mcpRuntime.releaseId}.json`);
@@ -368,6 +372,7 @@ async function verify(candidate: ViewerReleaseIdentity, endpoint: string, expect
     cwd: mcpRuntimeRoot,
     env: probeEnvironment,
     runtime: candidate.mcpRuntime,
+    ...(options.healthProbeCapability ? { healthProbeCapability: options.healthProbeCapability } : {}),
   });
   if (!promoted) {
     fs.rmSync(probeTarget, { force: true });
@@ -445,7 +450,10 @@ async function currentMcpRuntime(): Promise<ViewerMcpRuntimeIdentity> {
    surface. `stagePreparedPackage` derives its release id from the deployment
    id, so a boot that crashed mid-reconcile reuses (never duplicates) the same
    release, and a boot that already matches does nothing at all. */
-async function reconcileMcpRuntime(revision: string): Promise<ViewerMcpRuntimeReconciliation | null> {
+async function reconcileMcpRuntime(
+  revision: string,
+  healthProbeCapability?: string,
+): Promise<ViewerMcpRuntimeReconciliation | null> {
   if (!/^[0-9a-f]{40}$/.test(revision)) throw new Error("runtime-host MCP revision is invalid");
   const previous = readTarget();
   if (previous.revision !== revision) throw new Error("runtime-host MCP revision differs from the active Viewer release");
@@ -464,6 +472,7 @@ async function reconcileMcpRuntime(revision: string): Promise<ViewerMcpRuntimeRe
       cwd: mcpRuntimeRoot,
       env: probeEnvironment,
       runtime,
+      ...(healthProbeCapability ? { healthProbeCapability } : {}),
     });
     if (!health.ok) throw new Error(health.detail ?? "runtime-host MCP reconciliation health gate failed");
     return { publication, health };
@@ -512,13 +521,16 @@ async function main(): Promise<unknown> {
   if (process.env.LLV_DEPLOYMENT_ADAPTER_PROTOCOL !== "1") throw new Error("deployment adapter protocol is required");
   const action = process.argv[2];
   const input = JSON.parse(await Bun.stdin.text()) as Record<string, unknown>;
+  const healthProbeCapability = typeof input.healthProbeCapability === "string"
+    ? input.healthProbeCapability
+    : undefined;
   if (action === "bootstrap-release") {
     return bootstrapViewerRelease(String(input.revision ?? "origin/main"), `bootstrap-${randomUUID()}`, {
       targetExists: () => fs.existsSync(targetFile),
       resolveRevision,
       buildCandidate,
       startCandidate,
-      verifyCandidate: (candidate) => verify(candidate, candidate.endpoint),
+      verifyCandidate: (candidate) => verify(candidate, candidate.endpoint, { healthProbeCapability }),
       publishTarget: async (candidate) => { switchTarget(candidate, "activate"); },
       targetMatches: (candidate) => releasesEqual(readTarget(), candidate),
       retireCandidate: retireRelease,
@@ -535,14 +547,23 @@ async function main(): Promise<unknown> {
     return current;
   }
   if (action === "current-mcp-runtime") return currentMcpRuntime();
-  if (action === "reconcile-mcp-runtime") return reconcileMcpRuntime(String(input.revision ?? ""));
-  if (action === "verify-candidate") { const candidate = release(input.candidate); return verify(candidate, candidate.endpoint); }
+  if (action === "reconcile-mcp-runtime") return reconcileMcpRuntime(String(input.revision ?? ""), healthProbeCapability);
+  if (action === "verify-candidate") {
+    const candidate = release(input.candidate);
+    return verify(candidate, candidate.endpoint, { healthProbeCapability });
+  }
   if (action === "promote") {
     const candidate = release(input.candidate);
     if (candidate.mcpRuntime?.source !== "managed") throw new Error("candidate MCP runtime identity is missing");
     return switchTarget(candidate, "activate");
   }
-  if (action === "verify-promoted") { const candidate = release(input.candidate); return verify(candidate, stableEndpoint, candidate.endpoint); }
+  if (action === "verify-promoted") {
+    const candidate = release(input.candidate);
+    return verify(candidate, stableEndpoint, {
+      expectedAssetsEndpoint: candidate.endpoint,
+      healthProbeCapability,
+    });
+  }
   if (action === "rollback") {
     const previous = release(input.previous);
     await startCandidate(previous);

--- a/scripts/runtime-host-viewer-adapter.ts
+++ b/scripts/runtime-host-viewer-adapter.ts
@@ -11,6 +11,7 @@ import type {
   ViewerMcpRuntimeReconciliation,
   ViewerReleaseIdentity,
 } from "../src/lib/runtime/contracts";
+import { admittedMcpHealthProbe } from "../src/lib/mcp/healthProbeAdmission";
 import {
   obsoleteManagedViewerContainers,
   viewerAuthenticationTokenFromConfig,
@@ -26,6 +27,8 @@ import { allocateBuiltCandidatePort, candidatePortsFromEnvironmentLists, isCandi
 import { withBootstrapMcpHealthProbeAdmission } from "../src/runtime-host/bootstrapMcpHealthProbeAdmission";
 import { viewerCandidateContainerName, viewerCandidateImageName, viewerComposeSnapshotName } from "../src/runtime-host/deploymentArtifacts";
 import { bootstrapViewerRelease } from "../src/runtime-host/deploymentBootstrap";
+import { McpHealthProbeAdmissions } from "../src/runtime-host/mcpHealthProbeAdmission";
+import type { McpHealthProbeAdmissionConsumer } from "../src/runtime-host/mcpHealthProbeAdmissionChannel";
 import { probeMcpRuntime } from "../src/runtime-host/mcpRuntimeProbe";
 import { McpRuntimeReleaseStore } from "../src/runtime-host/mcpRuntimeRelease";
 import {
@@ -352,7 +355,11 @@ async function verifyViewer(candidate: ViewerReleaseIdentity, endpoint: string, 
 async function verify(
   candidate: ViewerReleaseIdentity,
   endpoint: string,
-  options: { expectedAssetsEndpoint?: string; healthProbeCapability?: string } = {},
+  options: {
+    expectedAssetsEndpoint?: string;
+    healthProbeCapability?: string;
+    healthProbeAdmissions?: McpHealthProbeAdmissionConsumer;
+  } = {},
 ): Promise<ViewerHealthEvidence> {
   const viewer = await verifyViewer(candidate, endpoint, options.expectedAssetsEndpoint);
   if (!viewer.ok) return viewer;
@@ -374,6 +381,7 @@ async function verify(
     env: probeEnvironment,
     runtime: candidate.mcpRuntime,
     ...(options.healthProbeCapability ? { healthProbeCapability: options.healthProbeCapability } : {}),
+    ...(options.healthProbeAdmissions ? { healthProbeAdmissions: options.healthProbeAdmissions } : {}),
   });
   if (!promoted) {
     fs.rmSync(probeTarget, { force: true });
@@ -453,7 +461,10 @@ async function currentMcpRuntime(): Promise<ViewerMcpRuntimeIdentity> {
    release, and a boot that already matches does nothing at all. */
 async function reconcileMcpRuntime(
   revision: string,
-  healthProbeCapability?: string,
+  healthProbe?: {
+    healthProbeCapability: string;
+    healthProbeAdmissions: McpHealthProbeAdmissionConsumer;
+  },
 ): Promise<ViewerMcpRuntimeReconciliation | null> {
   if (!/^[0-9a-f]{40}$/.test(revision)) throw new Error("runtime-host MCP revision is invalid");
   const previous = readTarget();
@@ -473,7 +484,7 @@ async function reconcileMcpRuntime(
       cwd: mcpRuntimeRoot,
       env: probeEnvironment,
       runtime,
-      ...(healthProbeCapability ? { healthProbeCapability } : {}),
+      ...(healthProbe ?? {}),
     });
     if (!health.ok) throw new Error(health.detail ?? "runtime-host MCP reconciliation health gate failed");
     return { publication, health };
@@ -524,7 +535,11 @@ export interface BootstrapReleaseDependencies {
   resolveRevision(requested: string): Promise<string>;
   buildCandidate(deploymentId: string, revision: string): Promise<ViewerReleaseIdentity>;
   startCandidate(candidate: ViewerReleaseIdentity): Promise<void>;
-  verifyCandidate(candidate: ViewerReleaseIdentity, healthProbeCapability: string): Promise<ViewerHealthEvidence>;
+  verifyCandidate(
+    candidate: ViewerReleaseIdentity,
+    healthProbeCapability: string,
+    healthProbeAdmissions: McpHealthProbeAdmissionConsumer,
+  ): Promise<ViewerHealthEvidence>;
   publishTarget(candidate: ViewerReleaseIdentity): Promise<void>;
   targetMatches(candidate: ViewerReleaseIdentity): boolean;
   retireCandidate(candidate: ViewerReleaseIdentity): Promise<void>;
@@ -538,8 +553,8 @@ export async function runBootstrapRelease(
     resolveRevision,
     buildCandidate,
     startCandidate,
-    verifyCandidate: (candidate, healthProbeCapability) =>
-      verify(candidate, candidate.endpoint, { healthProbeCapability }),
+    verifyCandidate: (candidate, healthProbeCapability, healthProbeAdmissions) =>
+      verify(candidate, candidate.endpoint, { healthProbeCapability, healthProbeAdmissions }),
     publishTarget: async (candidate) => { switchTarget(candidate, "activate"); },
     targetMatches: (candidate) => releasesEqual(readTarget(), candidate),
     retireCandidate: retireRelease,
@@ -549,9 +564,24 @@ export async function runBootstrapRelease(
     ...dependencies,
     verifyCandidate: (candidate) => withBootstrapMcpHealthProbeAdmission(
       dependencies.runtimeSocket,
-      (healthProbeCapability) => dependencies.verifyCandidate(candidate, healthProbeCapability),
+      (healthProbeCapability, healthProbeAdmissions) =>
+        dependencies.verifyCandidate(candidate, healthProbeCapability, healthProbeAdmissions),
     ),
   });
+}
+
+async function delegatedHealthProbeAdmission(
+  hostCapability: string | undefined,
+): Promise<{
+  healthProbeCapability: string;
+  healthProbeAdmissions: McpHealthProbeAdmissionConsumer;
+} | undefined> {
+  if (!await admittedMcpHealthProbe(hostCapability)) return undefined;
+  const admissions = new McpHealthProbeAdmissions();
+  return {
+    healthProbeCapability: admissions.issue(),
+    healthProbeAdmissions: admissions,
+  };
 }
 
 async function main(): Promise<unknown> {
@@ -573,10 +603,19 @@ async function main(): Promise<unknown> {
     return current;
   }
   if (action === "current-mcp-runtime") return currentMcpRuntime();
-  if (action === "reconcile-mcp-runtime") return reconcileMcpRuntime(String(input.revision ?? ""), healthProbeCapability);
+  if (action === "reconcile-mcp-runtime") {
+    const healthProbe = await delegatedHealthProbeAdmission(healthProbeCapability);
+    return reconcileMcpRuntime(
+      String(input.revision ?? ""),
+      healthProbe,
+    );
+  }
   if (action === "verify-candidate") {
     const candidate = release(input.candidate);
-    return verify(candidate, candidate.endpoint, { healthProbeCapability });
+    const healthProbe = await delegatedHealthProbeAdmission(healthProbeCapability);
+    return verify(candidate, candidate.endpoint, {
+      ...(healthProbe ?? {}),
+    });
   }
   if (action === "promote") {
     const candidate = release(input.candidate);
@@ -585,9 +624,10 @@ async function main(): Promise<unknown> {
   }
   if (action === "verify-promoted") {
     const candidate = release(input.candidate);
+    const healthProbe = await delegatedHealthProbeAdmission(healthProbeCapability);
     return verify(candidate, stableEndpoint, {
       expectedAssetsEndpoint: candidate.endpoint,
-      healthProbeCapability,
+      ...(healthProbe ?? {}),
     });
   }
   if (action === "rollback") {

--- a/src/lib/mcp/bindings.ts
+++ b/src/lib/mcp/bindings.ts
@@ -1003,13 +1003,16 @@ async function requestAttention(args: McpToolArgs, dependencies: ViewerMcpDomain
  */
 export function viewerMcpToolPolicy(
   domainDependencies: ViewerMcpDomainDependencies = productionDomainDependencies,
+  hostHealthProbe = false,
 ): McpToolPolicy {
   const manager = (): ManagerTarget | null => {
     const record = readOrchestratorRecord();
     return record ? { conversationId: record.conversationId, path: record.path } : null;
   };
   return mcpToolPolicy(
-    () => mcpCallerIdentity(domainDependencies.attentionAuthority(), manager()),
+    () => hostHealthProbe
+      ? { kind: "health-probe" }
+      : mcpCallerIdentity(domainDependencies.attentionAuthority(), manager()),
     manager,
   );
 }

--- a/src/lib/mcp/healthProbeAdmission.test.ts
+++ b/src/lib/mcp/healthProbeAdmission.test.ts
@@ -1,0 +1,17 @@
+import { expect, test } from "bun:test";
+
+import { admittedMcpHealthProbe } from "./healthProbeAdmission";
+
+test("health admission trusts only a valid capability redeemed by the runtime host", async () => {
+  const capability = "A".repeat(43);
+  const admitted = {
+    admitMcpHealthProbe: async (candidate: string) => candidate === capability,
+  };
+
+  expect(await admittedMcpHealthProbe(capability, admitted)).toBe(true);
+  expect(await admittedMcpHealthProbe("self-selected", admitted)).toBe(false);
+  expect(await admittedMcpHealthProbe(capability, null)).toBe(false);
+  expect(await admittedMcpHealthProbe(capability, {
+    admitMcpHealthProbe: async () => { throw new Error("runtime host unavailable"); },
+  })).toBe(false);
+});

--- a/src/lib/mcp/healthProbeAdmission.ts
+++ b/src/lib/mcp/healthProbeAdmission.ts
@@ -1,21 +1,106 @@
-import { runtimeHostClient, type RuntimeHostClient } from "@/lib/runtime/client";
+import crypto from "node:crypto";
+import {
+  fstatSync,
+  readSync,
+  writeSync,
+} from "node:fs";
+
+import type { RuntimeSocketRequest, RuntimeSocketResponse } from "@/lib/runtime/contracts";
 
 export const MCP_HEALTH_PROBE_CAPABILITY_ENV = "LLV_MCP_HEALTH_PROBE_CAPABILITY";
+export const MCP_HEALTH_PROBE_ADMISSION_FD = 3;
 
 const CAPABILITY_PATTERN = /^[A-Za-z0-9_-]{43}$/;
-type HealthAdmissionClient = Pick<RuntimeHostClient, "admitMcpHealthProbe">;
+const MAX_RESPONSE_BYTES = 16 * 1024;
+const ADMISSION_TIMEOUT_MS = 3_000;
+const IO_RETRY_MS = 5;
+type HealthAdmissionClient = { admitMcpHealthProbe(capability: string): Promise<boolean> };
+
+function retryableIoError(error: unknown): boolean {
+  return error instanceof Error
+    && "code" in error
+    && (error.code === "EAGAIN" || error.code === "EWOULDBLOCK");
+}
+
+async function waitForIo(): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, IO_RETRY_MS));
+}
+
+async function writeFrame(fd: number, frame: Buffer, deadline: number): Promise<boolean> {
+  let offset = 0;
+  while (offset < frame.length && Date.now() < deadline) {
+    try {
+      const bytesWritten = writeSync(fd, frame, offset, frame.length - offset);
+      if (bytesWritten === 0) await waitForIo();
+      else offset += bytesWritten;
+    } catch (error) {
+      if (!retryableIoError(error)) return false;
+      await waitForIo();
+    }
+  }
+  return offset === frame.length;
+}
+
+async function readFrame(fd: number, deadline: number): Promise<string | null> {
+  const chunks: Buffer[] = [];
+  let size = 0;
+  while (Date.now() < deadline) {
+    const chunk = Buffer.allocUnsafe(4 * 1024);
+    try {
+      const bytesRead = readSync(fd, chunk, 0, chunk.length, null);
+      if (bytesRead === 0) return null;
+      const received = chunk.subarray(0, bytesRead);
+      const newline = received.indexOf(0x0a);
+      const accepted = newline < 0 ? received : received.subarray(0, newline);
+      chunks.push(accepted);
+      size += accepted.length;
+      if (size > MAX_RESPONSE_BYTES) return null;
+      if (newline >= 0) return Buffer.concat(chunks, size).toString("utf8");
+    } catch (error) {
+      if (!retryableIoError(error)) return null;
+      await waitForIo();
+    }
+  }
+  return null;
+}
+
+function inheritedHealthAdmissionClient(): HealthAdmissionClient {
+  return {
+    async admitMcpHealthProbe(capability) {
+      const fd = MCP_HEALTH_PROBE_ADMISSION_FD;
+      try {
+        const type = fstatSync(fd);
+        if (!type.isSocket()) return false;
+        const request: RuntimeSocketRequest = {
+          id: crypto.randomUUID(),
+          method: "mcp-health-probe-admission",
+          params: { capability },
+        };
+        const deadline = Date.now() + ADMISSION_TIMEOUT_MS;
+        const sent = await writeFrame(fd, Buffer.from(JSON.stringify(request) + "\n"), deadline);
+        if (!sent) return false;
+        const frame = await readFrame(fd, deadline);
+        if (frame === null) return false;
+        const response = JSON.parse(frame) as RuntimeSocketResponse;
+        return response.id === request.id && response.ok === true && response.result === true;
+      } catch {
+        return false;
+      }
+    },
+  };
+}
 
 /**
- * Redeem a runtime-host-minted health capability. The environment value is
- * only a carrier: a missing client, malformed/self-selected value, host
- * rejection, or transport failure all resolve to ordinary fail-closed policy.
+ * Redeem a runtime-host-minted health capability over descriptor 3 inherited
+ * from the host-owned probe chain. Environment values carry the capability
+ * and cannot select the issuer.
  */
 export async function admittedMcpHealthProbe(
   capability: unknown,
   client?: HealthAdmissionClient | null,
 ): Promise<boolean> {
   if (typeof capability !== "string" || !CAPABILITY_PATTERN.test(capability)) return false;
-  const host = client === undefined ? runtimeHostClient() : client;
+  const host = client === undefined ? inheritedHealthAdmissionClient() : client;
   if (!host?.admitMcpHealthProbe) return false;
   try {
     return await host.admitMcpHealthProbe(capability);

--- a/src/lib/mcp/healthProbeAdmission.ts
+++ b/src/lib/mcp/healthProbeAdmission.ts
@@ -1,0 +1,25 @@
+import { runtimeHostClient, type RuntimeHostClient } from "@/lib/runtime/client";
+
+export const MCP_HEALTH_PROBE_CAPABILITY_ENV = "LLV_MCP_HEALTH_PROBE_CAPABILITY";
+
+const CAPABILITY_PATTERN = /^[A-Za-z0-9_-]{43}$/;
+type HealthAdmissionClient = Pick<RuntimeHostClient, "admitMcpHealthProbe">;
+
+/**
+ * Redeem a runtime-host-minted health capability. The environment value is
+ * only a carrier: a missing client, malformed/self-selected value, host
+ * rejection, or transport failure all resolve to ordinary fail-closed policy.
+ */
+export async function admittedMcpHealthProbe(
+  capability: unknown,
+  client?: HealthAdmissionClient | null,
+): Promise<boolean> {
+  if (typeof capability !== "string" || !CAPABILITY_PATTERN.test(capability)) return false;
+  const host = client === undefined ? runtimeHostClient() : client;
+  if (!host?.admitMcpHealthProbe) return false;
+  try {
+    return await host.admitMcpHealthProbe(capability);
+  } catch {
+    return false;
+  }
+}

--- a/src/lib/mcp/server.ts
+++ b/src/lib/mcp/server.ts
@@ -1224,11 +1224,15 @@ export function createViewerMcpServer(service: McpToolService): McpServer {
 }
 
 export async function startViewerMcpServer(): Promise<void> {
+  const { admittedMcpHealthProbe, MCP_HEALTH_PROBE_CAPABILITY_ENV } = await import("./healthProbeAdmission");
   const { viewerMcpBindings, viewerMcpToolPolicy } = await import("./bindings");
+  const healthProbeCapability = process.env[MCP_HEALTH_PROBE_CAPABILITY_ENV];
+  delete process.env[MCP_HEALTH_PROBE_CAPABILITY_ENV];
+  const hostHealthProbe = await admittedMcpHealthProbe(healthProbeCapability);
   const service = createMcpToolService(
     viewerMcpBindings(),
     new FileMcpReceiptStore(statePath("mcp-receipts.json")),
-    viewerMcpToolPolicy(),
+    viewerMcpToolPolicy(undefined, hostHealthProbe),
   );
   const server = createViewerMcpServer(service);
   const transport = new StdioServerTransport();

--- a/src/lib/mcp/toolAllowlist.test.ts
+++ b/src/lib/mcp/toolAllowlist.test.ts
@@ -5,6 +5,7 @@ import type { AttentionCallerAuthority } from "@/lib/attention/callerAuthority";
 import { MCP_TOOL_NAMES, type McpToolName } from "./server";
 import {
   GATEWAY_ALLOWED_TOOLS,
+  HEALTH_PROBE_ALLOWED_TOOLS,
   MANAGER_ONLY_TOOLS,
   mcpCallerIdentity,
   permitMcpTool,
@@ -37,6 +38,14 @@ test("the gateway's whole surface is the relay, the message and attention — no
   const permitted = MCP_TOOL_NAMES.filter((toolName) =>
     permit(toolName, { conversationId: MANAGER.conversationId, text: "go", target: "x", sha: "a".repeat(40) }).allowed);
   expect([...permitted].sort()).toEqual(["bridge_directive", "request_attention", "send_message"]);
+});
+
+test("host health admission reaches exactly the two deployment reads and no agent action", () => {
+  const admitted = MCP_TOOL_NAMES.filter((toolName) =>
+    permitMcpTool({ kind: "health-probe" }, toolName, { clientRequestId: "health" }, MANAGER).allowed);
+
+  expect([...HEALTH_PROBE_ALLOWED_TOOLS].sort()).toEqual(["board_snapshot", "deployment_status"]);
+  expect([...admitted].sort()).toEqual(["board_snapshot", "deployment_status"]);
 });
 
 test("the gateway cannot reach any worker, task, pipeline, flow or deploy tool (AC21, AC20)", () => {

--- a/src/lib/mcp/toolAllowlist.ts
+++ b/src/lib/mcp/toolAllowlist.ts
@@ -56,6 +56,13 @@ export const MANAGER_ONLY_TOOLS: readonly McpToolName[] = ["bridge_report"];
 
 const MANAGER_ONLY_TOOL_SET: ReadonlySet<string> = new Set(MANAGER_ONLY_TOOLS);
 
+export const HEALTH_PROBE_ALLOWED_TOOLS: readonly McpToolName[] = [
+  "board_snapshot",
+  "deployment_status",
+];
+
+const HEALTH_PROBE_TOOL_SET: ReadonlySet<string> = new Set(HEALTH_PROBE_ALLOWED_TOOLS);
+
 /** Where the manager currently sits, resolved from its designation record. Both
     addressing forms `send_message` accepts must be checkable, or the restriction
     is bypassed by using the other one. */
@@ -65,6 +72,9 @@ export interface ManagerTarget {
 }
 
 export type McpCallerIdentity =
+  /** A single-use admission minted and redeemed by the runtime host. This
+      identity can exercise only the two reads that gate an exact deployment. */
+  | { kind: "health-probe" }
   /** Held to the gateway allowlist. `gateway` is the voice root; `unidentified`
       is a caller the registry could not name, which is denied for the same
       reason — see {@link mcpCallerIdentity}. */
@@ -134,6 +144,15 @@ export function permitMcpTool(
   args: McpToolArgs,
   manager: ManagerTarget | null,
 ): McpToolVerdict {
+  if (identity.kind === "health-probe") {
+    return HEALTH_PROBE_TOOL_SET.has(toolName)
+      ? ALLOWED
+      : {
+        allowed: false,
+        code: "tool_not_permitted",
+        error: `${toolName} is outside the managed MCP health-probe surface.`,
+      };
+  }
   /* Checked before the restricted branch so it covers every identity that is not
      the manager, in one place: gateway, unidentified, and ordinary workers. */
   if (MANAGER_ONLY_TOOL_SET.has(toolName)

--- a/src/lib/runtime/client.ts
+++ b/src/lib/runtime/client.ts
@@ -48,6 +48,7 @@ export interface RuntimeHostClient {
   ): Promise<RuntimeOperationResult>;
   requestViewerDeployment(request: ViewerDeploymentRequest): Promise<ViewerDeploymentReceipt>;
   readViewerDeployment(deploymentId: string): Promise<ViewerDeploymentStatus | null>;
+  admitMcpHealthProbe?(capability: string): Promise<boolean>;
 }
 
 export class UnixRuntimeHostClient implements RuntimeHostClient {
@@ -96,6 +97,7 @@ export class UnixRuntimeHostClient implements RuntimeHostClient {
   }
   requestViewerDeployment(request: ViewerDeploymentRequest): Promise<ViewerDeploymentReceipt> { return this.call("viewer-deployment-request", request as unknown as Record<string, unknown>, this.deploymentTimeoutMs) as Promise<ViewerDeploymentReceipt>; }
   readViewerDeployment(deploymentId: string): Promise<ViewerDeploymentStatus | null> { return this.call("viewer-deployment-read", { deploymentId }) as Promise<ViewerDeploymentStatus | null>; }
+  admitMcpHealthProbe(capability: string): Promise<boolean> { return this.call("mcp-health-probe-admission", { capability }) as Promise<boolean>; }
 
   private call(method: RuntimeSocketRequest["method"], params?: Record<string, unknown>, timeoutMs = this.timeoutMs, signal?: AbortSignal): Promise<unknown> {
     return new Promise((resolve, reject) => {

--- a/src/lib/runtime/contracts.ts
+++ b/src/lib/runtime/contracts.ts
@@ -509,7 +509,7 @@ export interface RuntimeReplay {
 
 export interface RuntimeSocketRequest {
   id: string;
-  method: "snapshot" | "events" | "wait" | "append" | "operation" | "command" | "operation-status" | "operation-retry" | "effect-batch" | "operation-transition" | "producer-cursor" | "viewer-deployment-request" | "viewer-deployment-read";
+  method: "snapshot" | "events" | "wait" | "append" | "operation" | "command" | "operation-status" | "operation-retry" | "effect-batch" | "operation-transition" | "producer-cursor" | "viewer-deployment-request" | "viewer-deployment-read" | "mcp-health-probe-admission";
   params?: Record<string, unknown>;
 }
 

--- a/src/runtime-host/bootstrapMcpHealthProbeAdmission.test.ts
+++ b/src/runtime-host/bootstrapMcpHealthProbeAdmission.test.ts
@@ -1,10 +1,22 @@
-import { expect, test } from "bun:test";
+import { expect, spyOn, test } from "bun:test";
 import fs from "node:fs";
+import net from "node:net";
 import os from "node:os";
 import path from "node:path";
 
 import { withBootstrapMcpHealthProbeAdmission } from "./bootstrapMcpHealthProbeAdmission";
 import { RuntimeHostFence } from "./host";
+
+async function readListener(socketPath: string): Promise<string> {
+  return await new Promise<string>((resolve, reject) => {
+    const socket = net.createConnection(socketPath);
+    let response = "";
+    socket.setEncoding("utf8");
+    socket.on("data", (chunk) => { response += chunk; });
+    socket.once("end", () => resolve(response));
+    socket.once("error", reject);
+  });
+}
 
 test("bootstrap admission cannot replace the canonical runtime host owner", async () => {
   const sandbox = fs.mkdtempSync(path.join(os.tmpdir(), "llv-mcp-bootstrap-owner-"));
@@ -22,6 +34,89 @@ test("bootstrap admission cannot replace the canonical runtime host owner", asyn
     expect(fs.readFileSync(socketPath, "utf8")).toBe("owned-by-runtime-host");
   } finally {
     fence.release();
+    fs.rmSync(sandbox, { recursive: true, force: true });
+  }
+});
+
+test("bootstrap cleanup preserves a successor canonical socket", async () => {
+  const sandbox = fs.mkdtempSync(path.join(os.tmpdir(), "llv-mcp-bootstrap-socket-race-"));
+  const socketPath = path.join(sandbox, "runtime-host.sock");
+  const originalLstat = fs.lstatSync.bind(fs);
+  const originalRename = fs.renameSync.bind(fs);
+  const successor: { server: ReturnType<typeof Bun.listen> | null } = { server: null };
+  let armed = false;
+  let replaced = false;
+  const installSuccessor = () => {
+    if (replaced) return;
+    replaced = true;
+    fs.unlinkSync(socketPath);
+    successor.server = Bun.listen({
+      unix: socketPath,
+      socket: {
+        open(socket) {
+          socket.end("successor");
+        },
+        data() {},
+      },
+    });
+  };
+  const lstat = spyOn(fs, "lstatSync").mockImplementation(((filename: fs.PathLike, options?: unknown) => {
+    const identity = originalLstat(filename, options as never);
+    if (armed && filename === socketPath) installSuccessor();
+    return identity;
+  }) as typeof fs.lstatSync);
+  const rename = spyOn(fs, "renameSync").mockImplementation(((oldPath: fs.PathLike, newPath: fs.PathLike) => {
+    if (armed && oldPath === socketPath) installSuccessor();
+    return originalRename(oldPath, newPath);
+  }) as typeof fs.renameSync);
+  let cleanupError: unknown;
+
+  try {
+    try {
+      await withBootstrapMcpHealthProbeAdmission(socketPath, async () => {
+        armed = true;
+      });
+    } catch (error) {
+      cleanupError = error;
+    }
+    expect(cleanupError).toBeInstanceOf(Error);
+    expect(String(cleanupError)).toContain("socket changed during bootstrap probe");
+    expect(await readListener(socketPath)).toBe("successor");
+  } finally {
+    lstat.mockRestore();
+    rename.mockRestore();
+    successor.server?.stop(true);
+    fs.rmSync(sandbox, { recursive: true, force: true });
+  }
+});
+
+test("bootstrap operation failure releases its fence and socket", async () => {
+  const sandbox = fs.mkdtempSync(path.join(os.tmpdir(), "llv-mcp-bootstrap-operation-failure-"));
+  const socketPath = path.join(sandbox, "runtime-host.sock");
+  try {
+    await expect(withBootstrapMcpHealthProbeAdmission(socketPath, async () => {
+      throw new Error("forced bootstrap operation failure");
+    })).rejects.toThrow("forced bootstrap operation failure");
+    expect(fs.existsSync(socketPath)).toBe(false);
+    await expect(withBootstrapMcpHealthProbeAdmission(socketPath, async () => "recovered")).resolves.toBe("recovered");
+  } finally {
+    fs.rmSync(sandbox, { recursive: true, force: true });
+  }
+});
+
+test("bootstrap listen failure releases its fence", async () => {
+  const sandbox = fs.mkdtempSync(path.join(os.tmpdir(), "llv-mcp-bootstrap-listen-failure-"));
+  const socketPath = path.join(sandbox, `${"s".repeat(120)}.sock`);
+  let called = false;
+  try {
+    await expect(withBootstrapMcpHealthProbeAdmission(socketPath, async () => {
+      called = true;
+    })).rejects.toThrow();
+    expect(called).toBe(false);
+    const successor = new RuntimeHostFence(`${socketPath}.lock`);
+    successor.acquire();
+    successor.release();
+  } finally {
     fs.rmSync(sandbox, { recursive: true, force: true });
   }
 });

--- a/src/runtime-host/bootstrapMcpHealthProbeAdmission.test.ts
+++ b/src/runtime-host/bootstrapMcpHealthProbeAdmission.test.ts
@@ -1,0 +1,27 @@
+import { expect, test } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { withBootstrapMcpHealthProbeAdmission } from "./bootstrapMcpHealthProbeAdmission";
+import { RuntimeHostFence } from "./host";
+
+test("bootstrap admission cannot replace the canonical runtime host owner", async () => {
+  const sandbox = fs.mkdtempSync(path.join(os.tmpdir(), "llv-mcp-bootstrap-owner-"));
+  const socketPath = path.join(sandbox, "runtime-host.sock");
+  const fence = new RuntimeHostFence(`${socketPath}.lock`);
+  fs.writeFileSync(socketPath, "owned-by-runtime-host");
+  fence.acquire();
+  let called = false;
+
+  try {
+    await expect(withBootstrapMcpHealthProbeAdmission(socketPath, async () => {
+      called = true;
+    })).rejects.toThrow("runtime host singleton fence is held");
+    expect(called).toBe(false);
+    expect(fs.readFileSync(socketPath, "utf8")).toBe("owned-by-runtime-host");
+  } finally {
+    fence.release();
+    fs.rmSync(sandbox, { recursive: true, force: true });
+  }
+});

--- a/src/runtime-host/bootstrapMcpHealthProbeAdmission.ts
+++ b/src/runtime-host/bootstrapMcpHealthProbeAdmission.ts
@@ -5,6 +5,7 @@ import type { RuntimeSocketRequest, RuntimeSocketResponse } from "@/lib/runtime/
 
 import { RuntimeHostFence } from "./runtimeHostFence";
 import { McpHealthProbeAdmissions } from "./mcpHealthProbeAdmission";
+import type { McpHealthProbeAdmissionConsumer } from "./mcpHealthProbeAdmissionChannel";
 import { serveRuntimeHost, type RuntimeHostSocketHandler } from "./socket";
 
 function admissionHandler(admissions: McpHealthProbeAdmissions): RuntimeHostSocketHandler {
@@ -42,7 +43,10 @@ async function closeServer(server: ReturnType<typeof serveRuntimeHost>): Promise
  */
 export async function withBootstrapMcpHealthProbeAdmission<T>(
   socketPath: string,
-  operation: (capability: string) => Promise<T>,
+  operation: (
+    capability: string,
+    admissions: McpHealthProbeAdmissionConsumer,
+  ) => Promise<T>,
 ): Promise<T> {
   if (!path.isAbsolute(socketPath)) throw new Error("runtime host socket must be absolute");
   const fence = new RuntimeHostFence(`${socketPath}.lock`);
@@ -61,7 +65,7 @@ export async function withBootstrapMcpHealthProbeAdmission<T>(
     socketIdentity = { dev: stat.dev, ino: stat.ino };
     const capability = admissions.issue();
     try {
-      return await operation(capability);
+      return await operation(capability, admissions);
     } finally {
       admissions.revoke(capability);
     }

--- a/src/runtime-host/bootstrapMcpHealthProbeAdmission.ts
+++ b/src/runtime-host/bootstrapMcpHealthProbeAdmission.ts
@@ -3,7 +3,7 @@ import path from "node:path";
 
 import type { RuntimeSocketRequest, RuntimeSocketResponse } from "@/lib/runtime/contracts";
 
-import { RuntimeHostFence } from "./host";
+import { RuntimeHostFence } from "./runtimeHostFence";
 import { McpHealthProbeAdmissions } from "./mcpHealthProbeAdmission";
 import { serveRuntimeHost, type RuntimeHostSocketHandler } from "./socket";
 
@@ -30,20 +30,6 @@ async function closeServer(server: ReturnType<typeof serveRuntimeHost>): Promise
   await new Promise<void>((resolve, reject) => {
     server.close((error) => error ? reject(error) : resolve());
   });
-}
-
-function removeOwnedSocket(socketPath: string, identity: { dev: number; ino: number }): void {
-  let current: fs.Stats;
-  try {
-    current = fs.lstatSync(socketPath);
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code === "ENOENT") return;
-    throw error;
-  }
-  if (!current.isSocket() || current.dev !== identity.dev || current.ino !== identity.ino) {
-    throw new Error("runtime host socket changed during bootstrap probe");
-  }
-  fs.rmSync(socketPath);
 }
 
 /**
@@ -84,7 +70,7 @@ export async function withBootstrapMcpHealthProbeAdmission<T>(
       if (server) await closeServer(server);
     } finally {
       try {
-        if (socketIdentity) removeOwnedSocket(socketPath, socketIdentity);
+        if (socketIdentity) fence.removeOwnedSocket(socketPath, socketIdentity);
       } finally {
         fence.release();
       }

--- a/src/runtime-host/bootstrapMcpHealthProbeAdmission.ts
+++ b/src/runtime-host/bootstrapMcpHealthProbeAdmission.ts
@@ -1,0 +1,93 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import type { RuntimeSocketRequest, RuntimeSocketResponse } from "@/lib/runtime/contracts";
+
+import { RuntimeHostFence } from "./host";
+import { McpHealthProbeAdmissions } from "./mcpHealthProbeAdmission";
+import { serveRuntimeHost, type RuntimeHostSocketHandler } from "./socket";
+
+function admissionHandler(admissions: McpHealthProbeAdmissions): RuntimeHostSocketHandler {
+  return {
+    async handle(request: RuntimeSocketRequest): Promise<RuntimeSocketResponse> {
+      if (request.method === "snapshot") {
+        return { id: request.id, ok: true, result: { deployments: [] } };
+      }
+      if (request.method !== "mcp-health-probe-admission") {
+        return { id: request.id, ok: false, error: "runtime request method is unsupported" };
+      }
+      return {
+        id: request.id,
+        ok: true,
+        result: admissions.consume(request.params?.capability),
+      };
+    },
+  };
+}
+
+async function closeServer(server: ReturnType<typeof serveRuntimeHost>): Promise<void> {
+  if (!server.listening) return;
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => error ? reject(error) : resolve());
+  });
+}
+
+function removeOwnedSocket(socketPath: string, identity: { dev: number; ino: number }): void {
+  let current: fs.Stats;
+  try {
+    current = fs.lstatSync(socketPath);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return;
+    throw error;
+  }
+  if (!current.isSocket() || current.dev !== identity.dev || current.ino !== identity.ino) {
+    throw new Error("runtime host socket changed during bootstrap probe");
+  }
+  fs.rmSync(socketPath);
+}
+
+/**
+ * Own one bootstrap probe admission at the canonical runtime-host seam.
+ *
+ * Bootstrap runs before the long-lived runtime host exists, so it temporarily
+ * acquires the same singleton fence and serves capability redemption plus the
+ * empty deployment snapshot needed by `deployment_status`. The capability is
+ * minted in this process and never comes from adapter input.
+ */
+export async function withBootstrapMcpHealthProbeAdmission<T>(
+  socketPath: string,
+  operation: (capability: string) => Promise<T>,
+): Promise<T> {
+  if (!path.isAbsolute(socketPath)) throw new Error("runtime host socket must be absolute");
+  const fence = new RuntimeHostFence(`${socketPath}.lock`);
+  fence.acquire();
+  const admissions = new McpHealthProbeAdmissions();
+  let server: ReturnType<typeof serveRuntimeHost> | null = null;
+  let socketIdentity: { dev: number; ino: number } | null = null;
+  try {
+    server = serveRuntimeHost(socketPath, admissionHandler(admissions));
+    await new Promise<void>((resolve, reject) => {
+      server!.once("listening", resolve);
+      server!.once("error", reject);
+    });
+    const stat = fs.lstatSync(socketPath);
+    if (!stat.isSocket()) throw new Error("runtime host socket is invalid");
+    socketIdentity = { dev: stat.dev, ino: stat.ino };
+    const capability = admissions.issue();
+    try {
+      return await operation(capability);
+    } finally {
+      admissions.revoke(capability);
+    }
+  } finally {
+    try {
+      if (server) await closeServer(server);
+    } finally {
+      try {
+        if (socketIdentity) removeOwnedSocket(socketPath, socketIdentity);
+      } finally {
+        fence.release();
+      }
+    }
+  }
+}

--- a/src/runtime-host/deploymentAdapter.test.ts
+++ b/src/runtime-host/deploymentAdapter.test.ts
@@ -110,6 +110,51 @@ test("host adapter exposes fixed actions and carries structured release data", a
   expect(calls.every((call) => !Object.hasOwn(call.input, "command") && !Object.hasOwn(call.input, "args"))).toBe(true);
 });
 
+test("the host injects and revokes health authority only around probe-bearing adapter actions", async () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-adapter-health-authority-"));
+  sandboxes.push(directory);
+  const executable = path.join(directory, "adapter.sh");
+  const capture = path.join(directory, "input.json");
+  const stateFile = path.join(directory, "adapter-process.json");
+  const revision = "a".repeat(40);
+  const capability = "H".repeat(43);
+  fs.writeFileSync(executable, `#!/bin/sh
+payload="$(cat)"
+printf '%s' "$payload" > ${JSON.stringify(capture)}
+if [ "$1" = "resolve-revision" ]; then
+  printf '%s\\n' '{"revision":"${revision}"}'
+else
+  printf '%s\\n' '{"checkedAt":"2026-07-28T00:00:00.000Z","endpoint":"http://127.0.0.1:18001","processReady":true,"rootStatus":200,"authenticatedStatus":null,"unauthorizedStatus":null,"assets":[],"ok":true}'
+fi
+`, { mode: 0o700 });
+  const issued: string[] = [];
+  const revoked: string[] = [];
+  const adapter = HostCommandViewerDeploymentAdapter.fromExecutable(executable, {
+    stateFile,
+    mcpHealthProbeAdmissions: {
+      issue: () => { issued.push(capability); return capability; },
+      revoke: (value) => { revoked.push(value); },
+    },
+  });
+  const candidate = {
+    image: "viewer:test",
+    container: "viewer-candidate",
+    endpoint: "http://127.0.0.1:18001",
+    revision,
+  };
+
+  await adapter.verifyCandidate(candidate);
+  expect(JSON.parse(fs.readFileSync(capture, "utf8"))).toEqual({
+    candidate,
+    healthProbeCapability: capability,
+  });
+  expect({ issued, revoked }).toEqual({ issued: [capability], revoked: [capability] });
+
+  await adapter.resolveRevision(revision);
+  expect(JSON.parse(fs.readFileSync(capture, "utf8"))).toEqual({ revision });
+  expect({ issued, revoked }).toEqual({ issued: [capability], revoked: [capability] });
+});
+
 test("a boot whose MCP runtime is already published carries no reconciliation", async () => {
   const adapter = new HostCommandViewerDeploymentAdapter(async () => null);
 

--- a/src/runtime-host/deploymentAdapter.test.ts
+++ b/src/runtime-host/deploymentAdapter.test.ts
@@ -20,7 +20,7 @@ function sleepingAdapter(): { executable: string; stateFile: string } {
 }
 
 async function waitForFile(filename: string): Promise<void> {
-  for (let attempt = 0; attempt < 100; attempt += 1) {
+  for (let attempt = 0; attempt < 1_000; attempt += 1) {
     if (fs.existsSync(filename)) return;
     await new Promise((resolve) => setTimeout(resolve, 2));
   }
@@ -133,6 +133,7 @@ fi
     stateFile,
     mcpHealthProbeAdmissions: {
       issue: () => { issued.push(capability); return capability; },
+      consume: (value) => value === capability,
       revoke: (value) => { revoked.push(value); },
     },
   });
@@ -168,7 +169,13 @@ test("replacement host reconciles an orphaned adapter process before replay", as
   const outcome: Promise<Error | null> = pending
     .then(() => null)
     .catch((error: unknown) => error instanceof Error ? error : new Error(String(error)));
-  await waitForFile(fixture.stateFile);
+  await Promise.race([
+    waitForFile(fixture.stateFile),
+    outcome.then((error) => {
+      if (error) throw error;
+      throw new Error("orphaned adapter exited before publishing ownership");
+    }),
+  ]);
   const orphanedPid = recordedPid(fixture.stateFile);
 
   const replacement = HostCommandViewerDeploymentAdapter.fromExecutable(fixture.executable, { stateFile: fixture.stateFile });

--- a/src/runtime-host/deploymentAdapter.ts
+++ b/src/runtime-host/deploymentAdapter.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
-import { spawn, spawnSync } from "node:child_process";
+import { spawn, spawnSync, type StdioOptions } from "node:child_process";
 import { randomUUID } from "node:crypto";
 
 import { statePath } from "@/lib/configDir";
@@ -17,6 +17,10 @@ import { withoutWakatimeCredential } from "@/lib/wakatime/credential";
 
 import type { ViewerDeploymentAdapter } from "./deployment";
 import type { McpHealthProbeAdmissions } from "./mcpHealthProbeAdmission";
+import {
+  createMcpHealthProbeAdmissionChannel,
+  serveMcpHealthProbeAdmissionChannel,
+} from "./mcpHealthProbeAdmissionChannel";
 
 type CommandRunner = (action: string, input: Record<string, unknown>) => Promise<unknown>;
 type AdapterAction = "resolve-revision" | "build-candidate" | "start-candidate" | "current-release" | "current-mcp-runtime" | "reconcile-mcp-runtime" | "verify-candidate" | "promote" | "verify-promoted" | "rollback" | "retire" | "retain-only" | "stage-host-successor" | "complete-host-handoff";
@@ -54,7 +58,7 @@ export interface HostCommandViewerDeploymentAdapterOptions {
   stateFile?: string;
   timeouts?: Partial<Record<AdapterAction, number>>;
   proc?: ProcBackend;
-  mcpHealthProbeAdmissions?: Pick<McpHealthProbeAdmissions, "issue" | "revoke">;
+  mcpHealthProbeAdmissions?: Pick<McpHealthProbeAdmissions, "issue" | "consume" | "revoke">;
 }
 
 function readProcessRecord(filename: string): AdapterProcessRecord | null {
@@ -273,25 +277,68 @@ export class HostCommandViewerDeploymentAdapter implements ViewerDeploymentAdapt
       await terminateAdapterProcess(previous, proc);
       clearProcessRecord(stateFile, previous);
     };
-    const runAction = async (action: AdapterAction, input: Record<string, unknown>): Promise<unknown> => {
-      const child = spawn("/usr/bin/setpriv", ["--pdeathsig", "KILL", "--", executable, action], {
-        stdio: ["pipe", "pipe", "pipe"],
-        env: { ...withoutWakatimeCredential(process.env), LLV_DEPLOYMENT_ADAPTER_PROTOCOL: "1" },
-        detached: true,
-      });
+    const runAction = async (
+      action: AdapterAction,
+      input: Record<string, unknown>,
+      healthAdmissions?: Pick<McpHealthProbeAdmissions, "consume">,
+    ): Promise<unknown> => {
+      const admissionChannel = healthAdmissions
+        ? await createMcpHealthProbeAdmissionChannel()
+        : null;
+      const stdio: StdioOptions = admissionChannel
+        ? ["pipe", "pipe", "pipe", admissionChannel.childFd]
+        : ["pipe", "pipe", "pipe"];
+      let child: ReturnType<typeof spawn>;
+      try {
+        child = spawn("/usr/bin/setpriv", ["--pdeathsig", "KILL", "--", executable, action], {
+          stdio,
+          env: { ...withoutWakatimeCredential(process.env), LLV_DEPLOYMENT_ADAPTER_PROTOCOL: "1" },
+          detached: true,
+        });
+      } catch (error) {
+        admissionChannel?.close();
+        throw error;
+      } finally {
+        admissionChannel?.closeChildFd();
+      }
+      const closeHealthAdmission = healthAdmissions && admissionChannel
+        ? (() => {
+            const closeServing = serveMcpHealthProbeAdmissionChannel(
+              admissionChannel.channel,
+              healthAdmissions,
+            );
+            return () => {
+              closeServing();
+              admissionChannel.close();
+            };
+          })()
+        : null;
       child.stdin?.on("error", () => {});
       child.stdin?.end(JSON.stringify(input));
-      if (!child.pid) throw new Error("deployment adapter process did not start");
+      if (!child.pid) {
+        closeHealthAdmission?.();
+        throw new Error("deployment adapter process did not start");
+      }
       const exitPromise = new Promise<number>((resolve, reject) => {
         child.once("error", reject);
         child.once("close", (code) => resolve(code ?? 1));
       });
       let startIdentity: string;
       try { startIdentity = await waitForProcessIdentity(child.pid, proc); }
-      catch (error) { signalProcessGroup(child.pid, "SIGKILL"); await exitPromise; throw error; }
+      catch (error) {
+        signalProcessGroup(child.pid, "SIGKILL");
+        await exitPromise;
+        closeHealthAdmission?.();
+        throw error;
+      }
       const record: AdapterProcessRecord = { pid: child.pid, startIdentity, action };
       try { writeProcessRecord(stateFile, record); }
-      catch (error) { await terminateAdapterProcess(record, proc); await exitPromise; throw error; }
+      catch (error) {
+        await terminateAdapterProcess(record, proc);
+        await exitPromise;
+        closeHealthAdmission?.();
+        throw error;
+      }
       const stdoutPromise = readStream(child.stdout);
       const stderrPromise = readStream(child.stderr);
       let timer: ReturnType<typeof setTimeout> | null = null;
@@ -313,6 +360,7 @@ export class HostCommandViewerDeploymentAdapter implements ViewerDeploymentAdapt
         catch { throw new Error(`deployment adapter ${action} returned invalid JSON`); }
       } finally {
         if (timer) clearTimeout(timer);
+        closeHealthAdmission?.();
         clearProcessRecord(stateFile, record);
       }
     };
@@ -324,7 +372,7 @@ export class HostCommandViewerDeploymentAdapter implements ViewerDeploymentAdapt
       }
       const healthProbeCapability = options.mcpHealthProbeAdmissions.issue();
       try {
-        return await runAction(action, { ...input, healthProbeCapability });
+        return await runAction(action, { ...input, healthProbeCapability }, options.mcpHealthProbeAdmissions);
       } finally {
         options.mcpHealthProbeAdmissions.revoke(healthProbeCapability);
       }

--- a/src/runtime-host/deploymentAdapter.ts
+++ b/src/runtime-host/deploymentAdapter.ts
@@ -16,6 +16,7 @@ import type {
 import { withoutWakatimeCredential } from "@/lib/wakatime/credential";
 
 import type { ViewerDeploymentAdapter } from "./deployment";
+import type { McpHealthProbeAdmissions } from "./mcpHealthProbeAdmission";
 
 type CommandRunner = (action: string, input: Record<string, unknown>) => Promise<unknown>;
 type AdapterAction = "resolve-revision" | "build-candidate" | "start-candidate" | "current-release" | "current-mcp-runtime" | "reconcile-mcp-runtime" | "verify-candidate" | "promote" | "verify-promoted" | "rollback" | "retire" | "retain-only" | "stage-host-successor" | "complete-host-handoff";
@@ -37,6 +38,12 @@ const ACTION_TIMEOUTS: Record<AdapterAction, number> = {
   "complete-host-handoff": 60_000,
 };
 
+const MCP_HEALTH_PROBE_ACTIONS: ReadonlySet<AdapterAction> = new Set([
+  "reconcile-mcp-runtime",
+  "verify-candidate",
+  "verify-promoted",
+]);
+
 interface AdapterProcessRecord {
   pid: number;
   startIdentity: string;
@@ -47,6 +54,7 @@ export interface HostCommandViewerDeploymentAdapterOptions {
   stateFile?: string;
   timeouts?: Partial<Record<AdapterAction, number>>;
   proc?: ProcBackend;
+  mcpHealthProbeAdmissions?: Pick<McpHealthProbeAdmissions, "issue" | "revoke">;
 }
 
 function readProcessRecord(filename: string): AdapterProcessRecord | null {
@@ -265,9 +273,7 @@ export class HostCommandViewerDeploymentAdapter implements ViewerDeploymentAdapt
       await terminateAdapterProcess(previous, proc);
       clearProcessRecord(stateFile, previous);
     };
-    return new HostCommandViewerDeploymentAdapter(async (rawAction, input) => {
-      const action = rawAction as AdapterAction;
-      await reconcile();
+    const runAction = async (action: AdapterAction, input: Record<string, unknown>): Promise<unknown> => {
       const child = spawn("/usr/bin/setpriv", ["--pdeathsig", "KILL", "--", executable, action], {
         stdio: ["pipe", "pipe", "pipe"],
         env: { ...withoutWakatimeCredential(process.env), LLV_DEPLOYMENT_ADAPTER_PROTOCOL: "1" },
@@ -309,7 +315,21 @@ export class HostCommandViewerDeploymentAdapter implements ViewerDeploymentAdapt
         if (timer) clearTimeout(timer);
         clearProcessRecord(stateFile, record);
       }
-    }, reconcile);
+    };
+    const run: CommandRunner = async (rawAction, input) => {
+      const action = rawAction as AdapterAction;
+      await reconcile();
+      if (!MCP_HEALTH_PROBE_ACTIONS.has(action) || !options.mcpHealthProbeAdmissions) {
+        return runAction(action, input);
+      }
+      const healthProbeCapability = options.mcpHealthProbeAdmissions.issue();
+      try {
+        return await runAction(action, { ...input, healthProbeCapability });
+      } finally {
+        options.mcpHealthProbeAdmissions.revoke(healthProbeCapability);
+      }
+    };
+    return new HostCommandViewerDeploymentAdapter(run, reconcile);
   }
 
   reconcile(): Promise<void> { return this.reconcileProcess(); }

--- a/src/runtime-host/fixtures/runtimeHostFenceContender.ts
+++ b/src/runtime-host/fixtures/runtimeHostFenceContender.ts
@@ -1,0 +1,56 @@
+import fs from "node:fs";
+import net from "node:net";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+const [moduleFilename, fenceFilename, barrierDir, contender] = process.argv.slice(2);
+if (!moduleFilename || !fenceFilename || !barrierDir || !contender) {
+  throw new Error("runtime host fence contender arguments are required");
+}
+
+const waitFor = (filename: string): void => {
+  const deadline = Date.now() + 10_000;
+  while (!fs.existsSync(filename)) {
+    if (Date.now() >= deadline) throw new Error(`timed out waiting for ${path.basename(filename)}`);
+    Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 10);
+  }
+};
+
+const waitForAsync = async (filename: string): Promise<void> => {
+  const deadline = Date.now() + 10_000;
+  while (!fs.existsSync(filename)) {
+    if (Date.now() >= deadline) throw new Error(`timed out waiting for ${path.basename(filename)}`);
+    await Bun.sleep(10);
+  }
+};
+
+const observedFilename = path.join(barrierDir, `observed-${contender}`);
+const outcomeFilename = path.join(barrierDir, `outcome-${contender}`);
+const listenerFilename = path.join(barrierDir, `listener-${contender}.sock`);
+const releaseFilename = path.join(barrierDir, "release");
+const { RuntimeHostFence } = await import(pathToFileURL(moduleFilename).href);
+const fence = new RuntimeHostFence(fenceFilename, () => {
+  fs.writeFileSync(observedFilename, "");
+  if (contender === "A") waitFor(path.join(barrierDir, "observed-B"));
+  else waitFor(path.join(barrierDir, "outcome-A"));
+  return false;
+});
+
+let server: net.Server | null = null;
+try {
+  fence.acquire();
+  server = net.createServer((socket) => socket.end(contender));
+  await new Promise<void>((resolve, reject) => {
+    server!.once("error", reject);
+    server!.listen(listenerFilename, resolve);
+  });
+  fs.writeFileSync(outcomeFilename, "active");
+  await waitForAsync(releaseFilename);
+} catch (error) {
+  fs.writeFileSync(outcomeFilename, `blocked:${error instanceof Error ? error.message : String(error)}`);
+} finally {
+  if (server) {
+    await new Promise<void>((resolve) => server!.close(() => resolve()));
+  }
+  fence.release();
+}

--- a/src/runtime-host/fixtures/runtimeHostFenceLegacyNullIdentity.ts
+++ b/src/runtime-host/fixtures/runtimeHostFenceLegacyNullIdentity.ts
@@ -1,0 +1,64 @@
+import fs from "node:fs";
+import net from "node:net";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+const [role, hostModule, procModule, fenceFilename, sandbox] = process.argv.slice(2);
+if (!role || !hostModule || !procModule || !fenceFilename || !sandbox) {
+  throw new Error("legacy runtime host fence fixture arguments are required");
+}
+
+const releaseFilename = path.join(sandbox, "release");
+const waitForRelease = async (): Promise<void> => {
+  const deadline = Date.now() + 10_000;
+  while (!fs.existsSync(releaseFilename)) {
+    if (Date.now() >= deadline) throw new Error("timed out waiting for fixture release");
+    await Bun.sleep(10);
+  }
+};
+
+if (role === "owner") {
+  fs.writeFileSync(fenceFilename, JSON.stringify({
+    pid: process.pid,
+    startIdentity: "legacy-owner-start",
+  }), { mode: 0o600 });
+  const listenerFilename = path.join(sandbox, "listener-owner.sock");
+  const server = net.createServer((socket) => socket.end("owner"));
+  try {
+    await new Promise<void>((resolve, reject) => {
+      server.once("error", reject);
+      server.listen(listenerFilename, resolve);
+    });
+    fs.writeFileSync(path.join(sandbox, "owner-ready"), "");
+    await waitForRelease();
+  } finally {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  }
+} else if (role === "contender") {
+  const { procBackend } = await import(pathToFileURL(procModule).href);
+  const { RuntimeHostFence } = await import(pathToFileURL(hostModule).href);
+  procBackend.processIdentity = () => null;
+  const fence = new RuntimeHostFence(fenceFilename);
+  let server: net.Server | null = null;
+  try {
+    fence.acquire();
+    const listenerFilename = path.join(sandbox, "listener-contender.sock");
+    server = net.createServer((socket) => socket.end("contender"));
+    await new Promise<void>((resolve, reject) => {
+      server!.once("error", reject);
+      server!.listen(listenerFilename, resolve);
+    });
+    fs.writeFileSync(path.join(sandbox, "contender-outcome"), "active");
+    await waitForRelease();
+  } catch (error) {
+    fs.writeFileSync(
+      path.join(sandbox, "contender-outcome"),
+      `blocked:${error instanceof Error ? error.message : String(error)}`,
+    );
+  } finally {
+    if (server) await new Promise<void>((resolve) => server!.close(() => resolve()));
+    fence.release();
+  }
+} else {
+  throw new Error("legacy runtime host fence fixture role is invalid");
+}

--- a/src/runtime-host/host.ts
+++ b/src/runtime-host/host.ts
@@ -8,6 +8,7 @@ import { procBackend } from "@/lib/proc";
 
 import { RuntimeJournal } from "./journal";
 import type { ViewerDeploymentCoordinator } from "./deployment";
+import type { McpHealthProbeAdmissions } from "./mcpHealthProbeAdmission";
 
 export class RuntimeHostFence {
   private held = false;
@@ -51,6 +52,7 @@ export class RuntimeHost {
     private readonly deployments?: ViewerDeploymentCoordinator,
     private readonly structuredHosts = structuredHostsEnabled(),
     private readonly signalFlowPipelineProgress?: () => void,
+    private readonly mcpHealthProbeAdmissions?: McpHealthProbeAdmissions,
   ) {}
 
   async recoverConsumers(): Promise<number> {
@@ -214,6 +216,8 @@ export class RuntimeHost {
       } else if (request.method === "viewer-deployment-read") {
         if (!this.deployments) throw new Error("viewer deployments are disabled");
         result = this.deployments.readViewerDeployment(String(request.params?.deploymentId ?? ""));
+      } else if (request.method === "mcp-health-probe-admission") {
+        result = this.mcpHealthProbeAdmissions?.consume(request.params?.capability) ?? false;
       } else throw new Error("runtime request method is unsupported");
       return { id: request.id, ok: true, result };
     } catch (error) {

--- a/src/runtime-host/host.ts
+++ b/src/runtime-host/host.ts
@@ -1,46 +1,12 @@
-import fs from "node:fs";
-import path from "node:path";
-
 import { RuntimeIdempotencyConflictError, type RuntimeEvent, type RuntimeEventInput, type RuntimeOperationCommand, type RuntimeReceiptStatus, type RuntimeSocketRequest, type RuntimeSocketResponse } from "@/lib/runtime/contracts";
 import { structuredHostsEnabled } from "@/lib/runtime/flags";
 import { consumeRuntimeEvent, type RuntimeConsumerPorts } from "@/lib/runtime/consumers";
-import { procBackend } from "@/lib/proc";
 
 import { RuntimeJournal } from "./journal";
 import type { ViewerDeploymentCoordinator } from "./deployment";
 import type { McpHealthProbeAdmissions } from "./mcpHealthProbeAdmission";
 
-export class RuntimeHostFence {
-  private held = false;
-  constructor(
-    private readonly filename: string,
-    private readonly ownerAlive: (owner: { pid: number; startIdentity: string | null }) => boolean = (owner) =>
-      procBackend.pidAlive(owner.pid) && (owner.startIdentity === null || procBackend.processIdentity(owner.pid) === owner.startIdentity),
-  ) {}
-  acquire(): void {
-    fs.mkdirSync(path.dirname(this.filename), { recursive: true, mode: 0o700 });
-    for (let attempt = 0; attempt < 2; attempt += 1) {
-      try {
-        fs.writeFileSync(this.filename, JSON.stringify({ pid: process.pid, startIdentity: procBackend.processIdentity(process.pid) }), { flag: "wx", mode: 0o600 });
-        this.held = true;
-        return;
-      } catch (error) {
-        if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
-        let stale = false;
-        try {
-          const owner = JSON.parse(fs.readFileSync(this.filename, "utf8")) as { pid: number; startIdentity?: string | null };
-          stale = Number.isInteger(owner.pid) && owner.pid > 0 && !this.ownerAlive({ pid: owner.pid, startIdentity: owner.startIdentity ?? null });
-        } catch {
-          stale = false;
-        }
-        if (!stale) throw new Error("runtime host singleton fence is held");
-        fs.rmSync(this.filename, { force: true });
-      }
-    }
-    throw new Error("runtime host singleton fence is held");
-  }
-  release(): void { if (this.held) fs.rmSync(this.filename, { force: true }); this.held = false; }
-}
+export { RuntimeHostFence } from "./runtimeHostFence";
 
 export class RuntimeHost {
   private consumerQueue: Promise<void> = Promise.resolve();

--- a/src/runtime-host/journal.test.ts
+++ b/src/runtime-host/journal.test.ts
@@ -2256,9 +2256,14 @@ test("runtime host fencing reclaims a stale process identity", () => {
   fs.writeFileSync(filename, JSON.stringify({ pid: 42, startIdentity: "42:old" }), { mode: 0o600 });
   const fence = new RuntimeHostFence(filename, () => false);
   fence.acquire();
-  expect(JSON.parse(fs.readFileSync(filename, "utf8"))).toMatchObject({ pid: process.pid });
+  expect(JSON.parse(fs.readFileSync(filename, "utf8"))).toMatchObject({
+    pid: process.pid,
+    acquisitionId: expect.any(String),
+  });
   fence.release();
-  expect(fs.existsSync(filename)).toBe(false);
+  const successor = new RuntimeHostFence(filename);
+  successor.acquire();
+  successor.release();
 });
 
 test("issue 367: a failed structured spawn retires its registering placeholder with the terminal receipt", () => {

--- a/src/runtime-host/main.ts
+++ b/src/runtime-host/main.ts
@@ -8,6 +8,7 @@ const { createServerRuntimeConsumers } = await import("@/lib/runtime/serverConsu
 const { requestPipelineTick } = await import("@/lib/pipelines/controllerSignal");
 const { RuntimeHost, RuntimeHostFence } = await import("./host");
 const { RuntimeJournal } = await import("./journal");
+const { McpHealthProbeAdmissions } = await import("./mcpHealthProbeAdmission");
 const { createLegacyRuntimeScheduler } = await import("./legacyScheduler");
 const { serveRuntimeHost } = await import("./socket");
 const { ViewerDeploymentCoordinator } = await import("./deployment");
@@ -59,8 +60,9 @@ if (deploymentsEnabled && !deploymentAdapterPath) {
    successor process — a missing record is the legacy fixed-tag image and is
    never provably current. */
 const bootGeneration = currentRuntimeHostGeneration();
+const mcpHealthProbeAdmissions = new McpHealthProbeAdmissions();
 const deploymentAdapter = deploymentAdapterPath
-  ? HostCommandViewerDeploymentAdapter.fromExecutable(deploymentAdapterPath)
+  ? HostCommandViewerDeploymentAdapter.fromExecutable(deploymentAdapterPath, { mcpHealthProbeAdmissions })
   : undefined;
 const bootContainer = process.env[RUNTIME_HOST_CONTAINER_ENV];
 if (deploymentAdapter && bootGeneration.image && bootGeneration.revision && bootContainer) {
@@ -81,7 +83,14 @@ const deployments = deploymentAdapter
     },
   )
   : undefined;
-const host = new RuntimeHost(journal, createServerRuntimeConsumers(), deployments, undefined, requestPipelineTick);
+const host = new RuntimeHost(
+  journal,
+  createServerRuntimeConsumers(),
+  deployments,
+  undefined,
+  requestPipelineTick,
+  mcpHealthProbeAdmissions,
+);
 const deploymentProxy = deployments
   ? serveViewerDeploymentProxy(
     process.env.LLV_VIEWER_DEPLOY_TARGET || statePath("viewer-release.json"),

--- a/src/runtime-host/mcpHealthProbeAdmission.test.ts
+++ b/src/runtime-host/mcpHealthProbeAdmission.test.ts
@@ -1,0 +1,23 @@
+import { expect, test } from "bun:test";
+
+import { McpHealthProbeAdmissions } from "./mcpHealthProbeAdmission";
+
+test("host health capabilities are single-use, expiring, and explicitly revocable", () => {
+  let now = 100;
+  const admissions = new McpHealthProbeAdmissions(() => now, 10);
+
+  const consumed = admissions.issue();
+  expect(admissions.consume(consumed)).toBe(true);
+  expect(admissions.consume(consumed)).toBe(false);
+
+  const expired = admissions.issue();
+  now = 110;
+  expect(admissions.consume(expired)).toBe(false);
+
+  const revoked = admissions.issue();
+  admissions.revoke(revoked);
+  expect(admissions.consume(revoked)).toBe(false);
+
+  expect(admissions.consume(undefined)).toBe(false);
+  expect(admissions.consume("self-selected")).toBe(false);
+});

--- a/src/runtime-host/mcpHealthProbeAdmission.ts
+++ b/src/runtime-host/mcpHealthProbeAdmission.ts
@@ -10,10 +10,11 @@ function digest(capability: string): string {
 /**
  * Runtime-host-owned, single-use authority for managed MCP health probes.
  *
- * Only the long-lived runtime host holds this set. The short-lived deployment
- * adapter receives a random capability for the probe it is about to launch;
- * the managed MCP child must redeem it back at this host before its two health
- * reads are admitted. Agent registry rows and launch receipts never participate.
+ * A long-lived runtime host, or the fenced bootstrap host that precedes it,
+ * holds this set. A short-lived deployment probe receives a random capability
+ * for the child it is about to launch; the managed MCP child must redeem it
+ * before its two health reads are admitted. Agent registry rows and launch
+ * receipts never participate.
  */
 export class McpHealthProbeAdmissions {
   private readonly pending = new Map<string, number>();

--- a/src/runtime-host/mcpHealthProbeAdmission.ts
+++ b/src/runtime-host/mcpHealthProbeAdmission.ts
@@ -1,0 +1,53 @@
+import { createHash, randomBytes } from "node:crypto";
+
+const CAPABILITY_PATTERN = /^[A-Za-z0-9_-]{43}$/;
+const DEFAULT_TTL_MS = 15 * 60_000;
+
+function digest(capability: string): string {
+  return createHash("sha256").update(capability).digest("hex");
+}
+
+/**
+ * Runtime-host-owned, single-use authority for managed MCP health probes.
+ *
+ * Only the long-lived runtime host holds this set. The short-lived deployment
+ * adapter receives a random capability for the probe it is about to launch;
+ * the managed MCP child must redeem it back at this host before its two health
+ * reads are admitted. Agent registry rows and launch receipts never participate.
+ */
+export class McpHealthProbeAdmissions {
+  private readonly pending = new Map<string, number>();
+
+  constructor(
+    private readonly now: () => number = Date.now,
+    private readonly ttlMs = DEFAULT_TTL_MS,
+  ) {}
+
+  issue(): string {
+    this.prune();
+    const capability = randomBytes(32).toString("base64url");
+    this.pending.set(digest(capability), this.now() + this.ttlMs);
+    return capability;
+  }
+
+  consume(capability: unknown): boolean {
+    this.prune();
+    if (typeof capability !== "string" || !CAPABILITY_PATTERN.test(capability)) return false;
+    const key = digest(capability);
+    const expiresAt = this.pending.get(key);
+    if (expiresAt === undefined) return false;
+    this.pending.delete(key);
+    return expiresAt > this.now();
+  }
+
+  revoke(capability: string): void {
+    if (CAPABILITY_PATTERN.test(capability)) this.pending.delete(digest(capability));
+  }
+
+  private prune(): void {
+    const now = this.now();
+    for (const [key, expiresAt] of this.pending) {
+      if (expiresAt <= now) this.pending.delete(key);
+    }
+  }
+}

--- a/src/runtime-host/mcpHealthProbeAdmissionChannel.ts
+++ b/src/runtime-host/mcpHealthProbeAdmissionChannel.ts
@@ -1,0 +1,162 @@
+import fs from "node:fs";
+import net from "node:net";
+import { createRequire } from "node:module";
+import os from "node:os";
+import path from "node:path";
+import type { Duplex } from "node:stream";
+
+import type { RuntimeSocketRequest, RuntimeSocketResponse } from "@/lib/runtime/contracts";
+
+import type { McpHealthProbeAdmissions } from "./mcpHealthProbeAdmission";
+
+const MAX_REQUEST_BYTES = 16 * 1024;
+
+export type McpHealthProbeAdmissionConsumer = Pick<McpHealthProbeAdmissions, "consume">;
+
+interface BunFfiModule {
+  FFIType: { i32: number };
+  dlopen(path: string, symbols: Record<string, unknown>): {
+    symbols: { dup: (fd: number) => number };
+  };
+}
+
+let cachedDup: ((fd: number) => number) | null = null;
+
+function duplicateDescriptor(fd: number): number {
+  if (!cachedDup) {
+    const runtimeRequire = createRequire(import.meta.url);
+    const ffi = runtimeRequire(`bun:${"ffi"}`) as BunFfiModule;
+    const library = ffi.dlopen(
+      process.platform === "darwin" ? "/usr/lib/libSystem.B.dylib" : "libc.so.6",
+      {
+        dup: {
+          args: [ffi.FFIType.i32],
+          returns: ffi.FFIType.i32,
+        },
+      },
+    );
+    cachedDup = (sourceFd) => library.symbols.dup(sourceFd);
+  }
+  return cachedDup(fd);
+}
+
+export interface McpHealthProbeAdmissionChannel {
+  childFd: number;
+  channel: Duplex;
+  closeChildFd(): void;
+  close(): void;
+}
+
+/**
+ * Create an unnamed, connected Unix channel for one managed MCP child.
+ *
+ * The temporary pathname exists only while the two endpoints connect. The
+ * child receives a duplicated raw descriptor, so Bun owns no parent-side
+ * stdio watcher whose descriptor can race with later process launches.
+ */
+export async function createMcpHealthProbeAdmissionChannel(): Promise<McpHealthProbeAdmissionChannel> {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "llv-mcp-health-channel-"));
+  const socketPath = path.join(directory, "channel.sock");
+  const server = net.createServer({ pauseOnConnect: true });
+  let accepted: net.Socket | null = null;
+  let client: net.Socket | null = null;
+  let childFd: number | null = null;
+  try {
+    const acceptedPromise = new Promise<net.Socket>((resolve) => {
+      server.once("connection", resolve);
+    });
+    await new Promise<void>((resolve, reject) => {
+      server.once("error", reject);
+      server.listen(socketPath, resolve);
+    });
+    client = net.createConnection(socketPath);
+    const [endpoint] = await Promise.all([
+      acceptedPromise,
+      new Promise<void>((resolve, reject) => {
+        client!.once("connect", resolve);
+        client!.once("error", reject);
+      }),
+    ]);
+    accepted = endpoint;
+    const handle = (client as net.Socket & { _handle?: { fd?: unknown } })._handle;
+    if (!handle || !Number.isInteger(handle.fd) || Number(handle.fd) < 0) {
+      throw new Error("MCP health admission channel descriptor is unavailable");
+    }
+    childFd = duplicateDescriptor(Number(handle.fd));
+    if (childFd < 0) throw new Error("MCP health admission channel descriptor duplication failed");
+    client.destroy();
+    client = null;
+    fs.unlinkSync(socketPath);
+    server.close();
+    fs.rmdirSync(directory);
+
+    const closeChildFd = () => {
+      if (childFd === null) return;
+      const fd = childFd;
+      childFd = null;
+      try { fs.closeSync(fd); } catch { /* already closed */ }
+    };
+    const close = () => {
+      closeChildFd();
+      if (accepted && !accepted.destroyed) accepted.destroy();
+    };
+    return {
+      childFd,
+      channel: accepted,
+      closeChildFd,
+      close,
+    };
+  } catch (error) {
+    if (childFd !== null) {
+      try { fs.closeSync(childFd); } catch { /* already closed */ }
+    }
+    client?.destroy();
+    accepted?.destroy();
+    server.close();
+    fs.rmSync(directory, { recursive: true, force: true });
+    throw error;
+  }
+}
+
+export function serveMcpHealthProbeAdmissionChannel(
+  channel: Duplex,
+  admissions: McpHealthProbeAdmissionConsumer,
+): () => void {
+  let buffer = "";
+  let handled = false;
+  const finish = (response: RuntimeSocketResponse) => {
+    if (handled) return;
+    handled = true;
+    channel.end(JSON.stringify(response) + "\n");
+  };
+  channel.on("data", (chunk: Buffer | string) => {
+    if (handled) return;
+    buffer += String(chunk);
+    if (Buffer.byteLength(buffer) > MAX_REQUEST_BYTES) {
+      finish({ id: "unknown", ok: false, error: "runtime request exceeds limit" });
+      return;
+    }
+    const newline = buffer.indexOf("\n");
+    if (newline < 0) return;
+    try {
+      const request = JSON.parse(buffer.slice(0, newline)) as RuntimeSocketRequest;
+      if (!request.id || request.method !== "mcp-health-probe-admission") {
+        finish({ id: request.id || "unknown", ok: false, error: "runtime request method is unsupported" });
+        return;
+      }
+      finish({
+        id: request.id,
+        ok: true,
+        result: admissions.consume(request.params?.capability),
+      });
+    } catch {
+      finish({ id: "unknown", ok: false, error: "runtime request is malformed" });
+    }
+  });
+  const close = () => {
+    if (!channel.destroyed) channel.destroy();
+  };
+  channel.once("error", close);
+  channel.resume();
+  return close;
+}

--- a/src/runtime-host/mcpProbeStdioTransport.ts
+++ b/src/runtime-host/mcpProbeStdioTransport.ts
@@ -1,0 +1,150 @@
+import {
+  spawn,
+  type ChildProcess,
+  type SpawnOptions,
+  type StdioOptions,
+} from "node:child_process";
+import { PassThrough, type Stream } from "node:stream";
+
+import { getDefaultEnvironment } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { ReadBuffer, serializeMessage } from "@modelcontextprotocol/sdk/shared/stdio.js";
+import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
+import type { JSONRPCMessage } from "@modelcontextprotocol/sdk/types.js";
+
+import {
+  createMcpHealthProbeAdmissionChannel,
+  serveMcpHealthProbeAdmissionChannel,
+  type McpHealthProbeAdmissionConsumer,
+} from "./mcpHealthProbeAdmissionChannel";
+
+export interface McpProbeStdioParameters {
+  command: string;
+  args: string[];
+  cwd: string;
+  env: Record<string, string>;
+  healthAdmissions?: McpHealthProbeAdmissionConsumer;
+}
+
+/**
+ * MCP stdio transport with one reserved descriptor inherited from the
+ * host-owned probe chain. Launch environment and JSON input cannot select or
+ * redirect descriptor 3.
+ */
+export class McpProbeStdioTransport implements Transport {
+  private child?: ChildProcess;
+  private closeHealthAdmission?: () => void;
+  private readonly readBuffer = new ReadBuffer();
+  private readonly stderrStream = new PassThrough();
+
+  onclose?: () => void;
+  onerror?: (error: Error) => void;
+  onmessage?: <T extends JSONRPCMessage>(message: T) => void;
+
+  constructor(private readonly parameters: McpProbeStdioParameters) {}
+
+  get stderr(): Stream {
+    return this.stderrStream;
+  }
+
+  get pid(): number | null {
+    return this.child?.pid ?? null;
+  }
+
+  async start(): Promise<void> {
+    if (this.child) throw new Error("MCP probe transport already started");
+    const admissionChannel = this.parameters.healthAdmissions
+      ? await createMcpHealthProbeAdmissionChannel()
+      : null;
+    await new Promise<void>((resolve, reject) => {
+      const healthAdmission = admissionChannel?.childFd ?? "ignore";
+      const stdio: StdioOptions = ["pipe", "pipe", "pipe", healthAdmission];
+      const spawnOptions: SpawnOptions = {
+        cwd: this.parameters.cwd,
+        env: { ...getDefaultEnvironment(), ...this.parameters.env } as NodeJS.ProcessEnv,
+        stdio,
+        shell: false,
+        windowsHide: process.platform === "win32",
+      };
+      let child: ChildProcess;
+      try {
+        child = spawn(this.parameters.command, this.parameters.args, spawnOptions);
+      } catch (error) {
+        admissionChannel?.close();
+        throw error;
+      } finally {
+        admissionChannel?.closeChildFd();
+      }
+      this.child = child;
+      if (this.parameters.healthAdmissions && admissionChannel) {
+        const closeServing = serveMcpHealthProbeAdmissionChannel(
+          admissionChannel.channel,
+          this.parameters.healthAdmissions,
+        );
+        this.closeHealthAdmission = () => {
+          closeServing();
+          admissionChannel.close();
+        };
+      }
+      child.once("error", (error) => {
+        this.closeHealthAdmission?.();
+        this.closeHealthAdmission = undefined;
+        reject(error);
+        this.onerror?.(error);
+      });
+      child.once("spawn", resolve);
+      child.once("close", () => {
+        this.closeHealthAdmission?.();
+        this.closeHealthAdmission = undefined;
+        this.child = undefined;
+        this.onclose?.();
+      });
+      child.stdin?.on("error", (error) => this.onerror?.(error));
+      child.stdout?.on("data", (chunk: Buffer) => {
+        this.readBuffer.append(chunk);
+        this.processReadBuffer();
+      });
+      child.stdout?.on("error", (error) => this.onerror?.(error));
+      child.stderr?.pipe(this.stderrStream);
+    });
+  }
+
+  async close(): Promise<void> {
+    const child = this.child;
+    if (child) {
+      this.child = undefined;
+      const closed = new Promise<void>((resolve) => child.once("close", () => resolve()));
+      try { child.stdin?.end(); } catch { /* already closed */ }
+      await Promise.race([closed, new Promise<void>((resolve) => setTimeout(resolve, 2_000).unref())]);
+      if (child.exitCode === null) {
+        try { child.kill("SIGTERM"); } catch { /* already exited */ }
+        await Promise.race([closed, new Promise<void>((resolve) => setTimeout(resolve, 2_000).unref())]);
+      }
+      if (child.exitCode === null) {
+        try { child.kill("SIGKILL"); } catch { /* already exited */ }
+      }
+    }
+    this.closeHealthAdmission?.();
+    this.closeHealthAdmission = undefined;
+    this.readBuffer.clear();
+  }
+
+  async send(message: JSONRPCMessage): Promise<void> {
+    const stdin = this.child?.stdin;
+    if (!stdin) throw new Error("MCP probe transport is not connected");
+    const serialized = serializeMessage(message);
+    if (stdin.write(serialized)) return;
+    await new Promise<void>((resolve) => stdin.once("drain", resolve));
+  }
+
+  private processReadBuffer(): void {
+    while (true) {
+      try {
+        const message = this.readBuffer.readMessage();
+        if (message === null) return;
+        this.onmessage?.(message);
+      } catch (error) {
+        this.onerror?.(error instanceof Error ? error : new Error(String(error)));
+      }
+    }
+  }
+}

--- a/src/runtime-host/mcpRuntimeProbe.test.ts
+++ b/src/runtime-host/mcpRuntimeProbe.test.ts
@@ -132,11 +132,12 @@ test("a release target naming a runtime this host never staged falls back to the
   }
 }, 20_000);
 
-test("absent, forged, and replayed health admissions cannot imitate the runtime host", async () => {
+test("absent, forged, expired, and replayed health admissions cannot imitate the runtime host", async () => {
   const sandbox = fs.mkdtempSync(path.join(os.tmpdir(), "llv-mcp-probe-adversarial-"));
   const socketPath = path.join(sandbox, "runtime.sock");
   const journal = new RuntimeJournal(path.join(sandbox, "runtime.sqlite"));
-  const admissions = new McpHealthProbeAdmissions();
+  let now = 100;
+  const admissions = new McpHealthProbeAdmissions(() => now, 10);
   const server = serveRuntimeHost(socketPath, new RuntimeHost(
     journal,
     undefined,
@@ -173,6 +174,10 @@ test("absent, forged, and replayed health admissions cannot imitate the runtime 
   try {
     expect((await run()).calls).toEqual({ deploymentStatus: false, boardSnapshot: false });
     expect((await run("A".repeat(43))).calls).toEqual({ deploymentStatus: false, boardSnapshot: false });
+
+    const expired = admissions.issue();
+    now = 110;
+    expect((await run(expired)).calls).toEqual({ deploymentStatus: false, boardSnapshot: false });
 
     const legitimate = admissions.issue();
     expect((await run(legitimate)).calls).toEqual({ deploymentStatus: true, boardSnapshot: true });

--- a/src/runtime-host/mcpRuntimeProbe.test.ts
+++ b/src/runtime-host/mcpRuntimeProbe.test.ts
@@ -3,16 +3,27 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
+import { MCP_TOOL_NAMES } from "@/lib/mcp/server";
+
 import { RuntimeHost } from "./host";
 import { RuntimeJournal } from "./journal";
+import { McpHealthProbeAdmissions } from "./mcpHealthProbeAdmission";
 import { probeMcpRuntime } from "./mcpRuntimeProbe";
 import { serveRuntimeHost } from "./socket";
 
-test("fresh Claude and Codex MCP processes discover the complete surface, call required reads, and exit", async () => {
+test("host-admitted managed MCP probes discover the complete surface, call required reads, and exit", async () => {
   const sandbox = fs.mkdtempSync(path.join(os.tmpdir(), "llv-mcp-probe-"));
   const socketPath = path.join(sandbox, "runtime.sock");
   const journal = new RuntimeJournal(path.join(sandbox, "runtime.sqlite"));
-  const server = serveRuntimeHost(socketPath, new RuntimeHost(journal));
+  const admissions = new McpHealthProbeAdmissions();
+  const server = serveRuntimeHost(socketPath, new RuntimeHost(
+    journal,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    admissions,
+  ));
   await new Promise<void>((resolve) => server.once("listening", resolve));
   const environment = Object.fromEntries(Object.entries(process.env)
     .filter((entry): entry is [string, string] => typeof entry[1] === "string"));
@@ -38,6 +49,7 @@ test("fresh Claude and Codex MCP processes discover the complete surface, call r
           artifactDigest: "a".repeat(64),
           stagedAt: "2026-07-23T08:00:00.000Z",
         },
+        healthProbeCapability: admissions.issue(),
         onProcessReady: (pid) => { processId = pid; },
       });
 
@@ -48,7 +60,7 @@ test("fresh Claude and Codex MCP processes discover the complete surface, call r
         processReady: true,
         calls: { deploymentStatus: true, boardSnapshot: true },
       });
-      expect(evidence.tools).toHaveLength(23);
+      expect(evidence.tools).toHaveLength(MCP_TOOL_NAMES.length);
       expect(evidence.tools).toContain("deployment_status");
       expect(evidence.tools).toContain("board_snapshot");
       expect(processId).not.toBeNull();
@@ -65,7 +77,15 @@ test("a release target naming a runtime this host never staged falls back to the
   const sandbox = fs.mkdtempSync(path.join(os.tmpdir(), "llv-mcp-probe-missing-"));
   const socketPath = path.join(sandbox, "runtime.sock");
   const journal = new RuntimeJournal(path.join(sandbox, "runtime.sqlite"));
-  const server = serveRuntimeHost(socketPath, new RuntimeHost(journal));
+  const admissions = new McpHealthProbeAdmissions();
+  const server = serveRuntimeHost(socketPath, new RuntimeHost(
+    journal,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    admissions,
+  ));
   await new Promise<void>((resolve) => server.once("listening", resolve));
   const revision = "7".repeat(40);
   const runtime = {
@@ -100,10 +120,63 @@ test("a release target naming a runtime this host never staged falls back to the
       cwd: process.cwd(),
       env: environment,
       runtime,
+      healthProbeCapability: admissions.issue(),
     });
 
     expect(evidence).toMatchObject({ ok: true, processReady: true });
-    expect(evidence.tools).toHaveLength(23);
+    expect(evidence.tools).toHaveLength(MCP_TOOL_NAMES.length);
+  } finally {
+    await new Promise<void>((resolve, reject) => server.close((error) => error ? reject(error) : resolve()));
+    journal.close();
+    fs.rmSync(sandbox, { recursive: true, force: true });
+  }
+}, 20_000);
+
+test("absent, forged, and replayed health admissions cannot imitate the runtime host", async () => {
+  const sandbox = fs.mkdtempSync(path.join(os.tmpdir(), "llv-mcp-probe-adversarial-"));
+  const socketPath = path.join(sandbox, "runtime.sock");
+  const journal = new RuntimeJournal(path.join(sandbox, "runtime.sqlite"));
+  const admissions = new McpHealthProbeAdmissions();
+  const server = serveRuntimeHost(socketPath, new RuntimeHost(
+    journal,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    admissions,
+  ));
+  await new Promise<void>((resolve) => server.once("listening", resolve));
+  const environment = Object.fromEntries(Object.entries(process.env)
+    .filter((entry): entry is [string, string] => typeof entry[1] === "string"));
+  environment.LLV_STATE_DIR = sandbox;
+  environment.LLV_RUNTIME_EVENTS = "1";
+  environment.LLV_RUNTIME_HOST_SOCKET = socketPath;
+  environment.LLV_AGENT_REGISTRY_SQLITE = "off";
+  environment.LLV_CODEX_HOME = path.join(sandbox, "codex");
+  environment.LLV_CLAUDE_HOME = path.join(sandbox, "claude");
+  const runtime = {
+    source: "managed" as const,
+    revision: "7".repeat(40),
+    releaseId: "deploy-adversarial",
+    artifactDigest: "a".repeat(64),
+    stagedAt: "2026-07-23T08:00:00.000Z",
+  };
+  const run = (healthProbeCapability?: string) => probeMcpRuntime({
+    command: process.execPath,
+    args: [path.join(process.cwd(), "bin", "mcp-server.mjs")],
+    cwd: process.cwd(),
+    env: environment,
+    runtime,
+    ...(healthProbeCapability ? { healthProbeCapability } : {}),
+  });
+
+  try {
+    expect((await run()).calls).toEqual({ deploymentStatus: false, boardSnapshot: false });
+    expect((await run("A".repeat(43))).calls).toEqual({ deploymentStatus: false, boardSnapshot: false });
+
+    const legitimate = admissions.issue();
+    expect((await run(legitimate)).calls).toEqual({ deploymentStatus: true, boardSnapshot: true });
+    expect((await run(legitimate)).calls).toEqual({ deploymentStatus: false, boardSnapshot: false });
   } finally {
     await new Promise<void>((resolve, reject) => server.close((error) => error ? reject(error) : resolve()));
     journal.close();

--- a/src/runtime-host/mcpRuntimeProbe.test.ts
+++ b/src/runtime-host/mcpRuntimeProbe.test.ts
@@ -38,7 +38,7 @@ test("host-admitted managed MCP probes discover the complete surface, call requi
     for (const host of ["claude", "codex"]) {
       let processId: number | null = null;
       const evidence = await probeMcpRuntime({
-        command: process.execPath,
+        command: host === "claude" ? process.execPath : "/usr/bin/node",
         args: [path.join(process.cwd(), "bin", "mcp-server.mjs")],
         cwd: process.cwd(),
         env: { ...environment, LLV_TEST_HOST: host },
@@ -50,6 +50,7 @@ test("host-admitted managed MCP probes discover the complete surface, call requi
           stagedAt: "2026-07-23T08:00:00.000Z",
         },
         healthProbeCapability: admissions.issue(),
+        healthProbeAdmissions: admissions,
         onProcessReady: (pid) => { processId = pid; },
       });
 
@@ -115,12 +116,13 @@ test("a release target naming a runtime this host never staged falls back to the
 
   try {
     const evidence = await probeMcpRuntime({
-      command: process.execPath,
+      command: "/usr/bin/node",
       args: [path.join(process.cwd(), "bin", "mcp-server.mjs")],
       cwd: process.cwd(),
       env: environment,
       runtime,
       healthProbeCapability: admissions.issue(),
+      healthProbeAdmissions: admissions,
     });
 
     expect(evidence).toMatchObject({ ok: true, processReady: true });
@@ -162,14 +164,17 @@ test("absent, forged, expired, and replayed health admissions cannot imitate the
     artifactDigest: "a".repeat(64),
     stagedAt: "2026-07-23T08:00:00.000Z",
   };
-  const run = (healthProbeCapability?: string) => probeMcpRuntime({
-    command: process.execPath,
-    args: [path.join(process.cwd(), "bin", "mcp-server.mjs")],
-    cwd: process.cwd(),
-    env: environment,
-    runtime,
-    ...(healthProbeCapability ? { healthProbeCapability } : {}),
-  });
+  const run = async (healthProbeCapability?: string) => {
+    return await probeMcpRuntime({
+      command: process.execPath,
+      args: [path.join(process.cwd(), "bin", "mcp-server.mjs")],
+      cwd: process.cwd(),
+      env: environment,
+      runtime,
+      ...(healthProbeCapability ? { healthProbeCapability } : {}),
+      healthProbeAdmissions: admissions,
+    });
+  };
 
   try {
     expect((await run()).calls).toEqual({ deploymentStatus: false, boardSnapshot: false });
@@ -185,6 +190,54 @@ test("absent, forged, expired, and replayed health admissions cannot imitate the
   } finally {
     await new Promise<void>((resolve, reject) => server.close((error) => error ? reject(error) : resolve()));
     journal.close();
+    fs.rmSync(sandbox, { recursive: true, force: true });
+  }
+}, 20_000);
+
+test("the final launcher rejects capability approval from a caller-selected runtime socket", async () => {
+  const sandbox = fs.mkdtempSync(path.join(os.tmpdir(), "llv-mcp-probe-forged-socket-"));
+  const socketPath = path.join(sandbox, "forged-runtime.sock");
+  const server = serveRuntimeHost(socketPath, {
+    async handle(request) {
+      if (request.method === "mcp-health-probe-admission") {
+        return { id: request.id, ok: true, result: true };
+      }
+      if (request.method === "snapshot") {
+        return { id: request.id, ok: true, result: { deployments: [] } };
+      }
+      return { id: request.id, ok: false, error: "unsupported" };
+    },
+  });
+  await new Promise<void>((resolve) => server.once("listening", resolve));
+  const environment = Object.fromEntries(Object.entries(process.env)
+    .filter((entry): entry is [string, string] => typeof entry[1] === "string"));
+  environment.LLV_STATE_DIR = sandbox;
+  environment.LLV_RUNTIME_EVENTS = "1";
+  environment.LLV_RUNTIME_HOST_SOCKET = socketPath;
+  environment.LLV_AGENT_REGISTRY_SQLITE = "off";
+  environment.LLV_CODEX_HOME = path.join(sandbox, "codex");
+  environment.LLV_CLAUDE_HOME = path.join(sandbox, "claude");
+
+  try {
+    const evidence = await probeMcpRuntime({
+      command: process.execPath,
+      args: [path.join(process.cwd(), "bin", "mcp-server.mjs")],
+      cwd: process.cwd(),
+      env: environment,
+      runtime: {
+        source: "managed",
+        revision: "7".repeat(40),
+        releaseId: "deploy-forged-socket",
+        artifactDigest: "a".repeat(64),
+        stagedAt: "2026-07-23T08:00:00.000Z",
+      },
+      healthProbeCapability: "A".repeat(43),
+    });
+
+    expect(evidence.calls).toEqual({ deploymentStatus: false, boardSnapshot: false });
+    expect(evidence.ok).toBe(false);
+  } finally {
+    await new Promise<void>((resolve, reject) => server.close((error) => error ? reject(error) : resolve()));
     fs.rmSync(sandbox, { recursive: true, force: true });
   }
 }, 20_000);

--- a/src/runtime-host/mcpRuntimeProbe.ts
+++ b/src/runtime-host/mcpRuntimeProbe.ts
@@ -3,6 +3,7 @@ import { randomUUID } from "node:crypto";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 
+import { MCP_HEALTH_PROBE_CAPABILITY_ENV } from "@/lib/mcp/healthProbeAdmission";
 import { MCP_TOOL_NAMES } from "@/lib/mcp/server";
 import type { ViewerMcpRuntimeHealthEvidence, ViewerMcpRuntimeIdentity } from "@/lib/runtime/contracts";
 
@@ -16,6 +17,7 @@ export interface McpRuntimeProbeOptions {
   cwd: string;
   env: Record<string, string>;
   runtime: ViewerMcpRuntimeIdentity;
+  healthProbeCapability?: string;
   timeoutMs?: number;
   onProcessReady?: (pid: number) => void;
 }
@@ -30,11 +32,16 @@ function successfulToolCall(value: unknown): boolean {
 export async function probeMcpRuntime(options: McpRuntimeProbeOptions): Promise<ViewerMcpRuntimeHealthEvidence> {
   const checkedAt = new Date().toISOString();
   const timeout = Math.max(1, options.timeoutMs ?? 15_000);
+  const environment = { ...options.env };
+  delete environment[MCP_HEALTH_PROBE_CAPABILITY_ENV];
+  if (options.healthProbeCapability) {
+    environment[MCP_HEALTH_PROBE_CAPABILITY_ENV] = options.healthProbeCapability;
+  }
   const transport = new StdioClientTransport({
     command: options.command,
     args: options.args,
     cwd: options.cwd,
-    env: options.env,
+    env: environment,
     stderr: "pipe",
   });
   const client = new Client({ name: "viewer-deployment-mcp-probe", version: "1.0.0" });

--- a/src/runtime-host/mcpRuntimeProbe.ts
+++ b/src/runtime-host/mcpRuntimeProbe.ts
@@ -1,11 +1,13 @@
 import { randomUUID } from "node:crypto";
 
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
-import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 
 import { MCP_HEALTH_PROBE_CAPABILITY_ENV } from "@/lib/mcp/healthProbeAdmission";
 import { MCP_TOOL_NAMES } from "@/lib/mcp/server";
 import type { ViewerMcpRuntimeHealthEvidence, ViewerMcpRuntimeIdentity } from "@/lib/runtime/contracts";
+
+import { McpProbeStdioTransport } from "./mcpProbeStdioTransport";
+import type { McpHealthProbeAdmissionConsumer } from "./mcpHealthProbeAdmissionChannel";
 
 /* The probe gate is the tool surface this generation ships; a duplicated list
    silently stops gating whenever a tool is added. */
@@ -18,6 +20,7 @@ export interface McpRuntimeProbeOptions {
   env: Record<string, string>;
   runtime: ViewerMcpRuntimeIdentity;
   healthProbeCapability?: string;
+  healthProbeAdmissions?: McpHealthProbeAdmissionConsumer;
   timeoutMs?: number;
   onProcessReady?: (pid: number) => void;
 }
@@ -37,12 +40,12 @@ export async function probeMcpRuntime(options: McpRuntimeProbeOptions): Promise<
   if (options.healthProbeCapability) {
     environment[MCP_HEALTH_PROBE_CAPABILITY_ENV] = options.healthProbeCapability;
   }
-  const transport = new StdioClientTransport({
+  const transport = new McpProbeStdioTransport({
     command: options.command,
     args: options.args,
     cwd: options.cwd,
     env: environment,
-    stderr: "pipe",
+    ...(options.healthProbeAdmissions ? { healthAdmissions: options.healthProbeAdmissions } : {}),
   });
   const client = new Client({ name: "viewer-deployment-mcp-probe", version: "1.0.0" });
   let processReady = false;

--- a/src/runtime-host/runtimeHostFence.test.ts
+++ b/src/runtime-host/runtimeHostFence.test.ts
@@ -1,0 +1,97 @@
+import { expect, test } from "bun:test";
+import fs from "node:fs";
+import net from "node:net";
+import os from "node:os";
+import path from "node:path";
+
+import { RuntimeHostFence } from "./runtimeHostFence";
+
+const fixture = path.join(import.meta.dir, "fixtures", "runtimeHostFenceContender.ts");
+const hostModule = path.join(import.meta.dir, "runtimeHostFence.ts");
+
+async function waitForFiles(filenames: string[]): Promise<void> {
+  const deadline = Date.now() + 10_000;
+  while (!filenames.every((filename) => fs.existsSync(filename))) {
+    if (Date.now() >= deadline) throw new Error("timed out waiting for runtime host fence contenders");
+    await Bun.sleep(10);
+  }
+}
+
+async function readListener(socketPath: string): Promise<string> {
+  return await new Promise<string>((resolve, reject) => {
+    const socket = net.createConnection(socketPath);
+    let response = "";
+    socket.setEncoding("utf8");
+    socket.on("data", (chunk) => { response += chunk; });
+    socket.once("end", () => resolve(response));
+    socket.once("error", reject);
+  });
+}
+
+test("stale fence reclamation activates exactly one process after both observe the stale owner", async () => {
+  const sandbox = fs.mkdtempSync(path.join(os.tmpdir(), "llv-runtime-fence-race-"));
+  const fenceFilename = path.join(sandbox, "runtime-host.lock");
+  fs.writeFileSync(fenceFilename, JSON.stringify({ pid: 42, startIdentity: "stale" }), { mode: 0o600 });
+  const contenders = ["A", "B"].map((contender) => Bun.spawn(
+    [process.execPath, fixture, hostModule, fenceFilename, sandbox, contender],
+    { cwd: import.meta.dir, stdout: "pipe", stderr: "pipe" },
+  ));
+  const outcomeFilenames = ["A", "B"].map((contender) => path.join(sandbox, `outcome-${contender}`));
+
+  try {
+    await waitForFiles(outcomeFilenames);
+    const outcomes = outcomeFilenames.map((filename) => fs.readFileSync(filename, "utf8"));
+    expect(outcomes.filter((outcome) => outcome === "active")).toHaveLength(1);
+    const active = outcomes[0] === "active" ? "A" : "B";
+    expect(await readListener(path.join(sandbox, `listener-${active}.sock`))).toBe(active);
+  } finally {
+    fs.writeFileSync(path.join(sandbox, "release"), "");
+    await Promise.all(contenders.map((contender) => contender.exited));
+    fs.rmSync(sandbox, { recursive: true, force: true });
+  }
+});
+
+test("predecessor release preserves a successor fence generation", () => {
+  const sandbox = fs.mkdtempSync(path.join(os.tmpdir(), "llv-runtime-fence-release-"));
+  const fenceFilename = path.join(sandbox, "runtime-host.lock");
+  const predecessor = new RuntimeHostFence(fenceFilename);
+  predecessor.acquire();
+  fs.rmSync(fenceFilename);
+  const successor = JSON.stringify({ pid: 73, startIdentity: "successor", acquisitionId: "successor-generation" });
+  fs.writeFileSync(fenceFilename, successor, { mode: 0o600 });
+
+  try {
+    predecessor.release();
+    expect(fs.readFileSync(fenceFilename, "utf8")).toBe(successor);
+  } finally {
+    predecessor.release();
+    fs.rmSync(sandbox, { recursive: true, force: true });
+  }
+});
+
+test("legacy live-owner metadata remains a rolling-upgrade fence", () => {
+  const sandbox = fs.mkdtempSync(path.join(os.tmpdir(), "llv-runtime-fence-legacy-"));
+  const fenceFilename = path.join(sandbox, "runtime-host.lock");
+  const metadata = JSON.stringify({ pid: 42, startIdentity: "live-predecessor" });
+  fs.writeFileSync(fenceFilename, metadata, { mode: 0o600 });
+
+  try {
+    expect(() => new RuntimeHostFence(fenceFilename, () => true).acquire()).toThrow("singleton fence is held");
+    expect(fs.readFileSync(fenceFilename, "utf8")).toBe(metadata);
+  } finally {
+    fs.rmSync(sandbox, { recursive: true, force: true });
+  }
+});
+
+test("malformed existing fence metadata fails closed", () => {
+  const sandbox = fs.mkdtempSync(path.join(os.tmpdir(), "llv-runtime-fence-malformed-"));
+  const fenceFilename = path.join(sandbox, "runtime-host.lock");
+  fs.writeFileSync(fenceFilename, "{broken", { mode: 0o600 });
+
+  try {
+    expect(() => new RuntimeHostFence(fenceFilename, () => false).acquire()).toThrow("singleton fence is held");
+    expect(fs.readFileSync(fenceFilename, "utf8")).toBe("{broken");
+  } finally {
+    fs.rmSync(sandbox, { recursive: true, force: true });
+  }
+});

--- a/src/runtime-host/runtimeHostFence.test.ts
+++ b/src/runtime-host/runtimeHostFence.test.ts
@@ -7,7 +7,9 @@ import path from "node:path";
 import { RuntimeHostFence } from "./runtimeHostFence";
 
 const fixture = path.join(import.meta.dir, "fixtures", "runtimeHostFenceContender.ts");
+const legacyFixture = path.join(import.meta.dir, "fixtures", "runtimeHostFenceLegacyNullIdentity.ts");
 const hostModule = path.join(import.meta.dir, "runtimeHostFence.ts");
+const procModule = path.join(import.meta.dir, "..", "lib", "proc", "index.ts");
 
 async function waitForFiles(filenames: string[]): Promise<void> {
   const deadline = Date.now() + 10_000;
@@ -79,6 +81,43 @@ test("legacy live-owner metadata remains a rolling-upgrade fence", () => {
     expect(() => new RuntimeHostFence(fenceFilename, () => true).acquire()).toThrow("singleton fence is held");
     expect(fs.readFileSync(fenceFilename, "utf8")).toBe(metadata);
   } finally {
+    fs.rmSync(sandbox, { recursive: true, force: true });
+  }
+});
+
+test("a live legacy owner remains the only listener when its start identity is temporarily unreadable", async () => {
+  const sandbox = fs.mkdtempSync(path.join(os.tmpdir(), "llv-runtime-fence-legacy-null-"));
+  const fenceFilename = path.join(sandbox, "runtime-host.lock");
+  const releaseFilename = path.join(sandbox, "release");
+  const owner = Bun.spawn(
+    [process.execPath, legacyFixture, "owner", hostModule, procModule, fenceFilename, sandbox],
+    { cwd: import.meta.dir, stdout: "pipe", stderr: "pipe" },
+  );
+  let contender: ReturnType<typeof Bun.spawn> | null = null;
+
+  try {
+    await waitForFiles([path.join(sandbox, "owner-ready")]);
+    const ownerMetadata = fs.readFileSync(fenceFilename, "utf8");
+    contender = Bun.spawn(
+      [process.execPath, legacyFixture, "contender", hostModule, procModule, fenceFilename, sandbox],
+      { cwd: import.meta.dir, stdout: "pipe", stderr: "pipe" },
+    );
+    const outcomeFilename = path.join(sandbox, "contender-outcome");
+    await waitForFiles([outcomeFilename]);
+
+    expect(fs.readFileSync(outcomeFilename, "utf8")).toStartWith("blocked:");
+    expect([
+      path.join(sandbox, "listener-owner.sock"),
+      path.join(sandbox, "listener-contender.sock"),
+    ].filter((filename) => fs.existsSync(filename))).toHaveLength(1);
+    expect(await readListener(path.join(sandbox, "listener-owner.sock"))).toBe("owner");
+    expect(fs.readFileSync(fenceFilename, "utf8")).toBe(ownerMetadata);
+  } finally {
+    fs.writeFileSync(releaseFilename, "");
+    await Promise.all([
+      owner.exited,
+      ...(contender ? [contender.exited] : []),
+    ]);
     fs.rmSync(sandbox, { recursive: true, force: true });
   }
 });

--- a/src/runtime-host/runtimeHostFence.ts
+++ b/src/runtime-host/runtimeHostFence.ts
@@ -85,8 +85,16 @@ export class RuntimeHostFence {
 
   constructor(
     private readonly filename: string,
-    private readonly ownerAlive: (owner: { pid: number; startIdentity: string | null }) => boolean = (owner) =>
-      procBackend.pidAlive(owner.pid) && (owner.startIdentity === null || procBackend.processIdentity(owner.pid) === owner.startIdentity),
+    private readonly ownerAlive: (owner: { pid: number; startIdentity: string | null }) => boolean = (owner) => {
+      try {
+        if (!procBackend.pidAlive(owner.pid)) return false;
+        if (owner.startIdentity === null) return true;
+        const currentIdentity = procBackend.processIdentity(owner.pid);
+        return currentIdentity === null || currentIdentity === owner.startIdentity;
+      } catch {
+        return true;
+      }
+    },
   ) {}
 
   acquire(): void {

--- a/src/runtime-host/runtimeHostFence.ts
+++ b/src/runtime-host/runtimeHostFence.ts
@@ -1,0 +1,205 @@
+import crypto from "node:crypto";
+import fs from "node:fs";
+import { createRequire } from "node:module";
+import path from "node:path";
+
+import { procBackend } from "@/lib/proc";
+
+const LOCK_EX = 2;
+const LOCK_NB = 4;
+const LOCK_UN = 8;
+const MAX_OWNER_BYTES = 4_096;
+// Linux and Darwin expose O_CLOEXEC under different numeric values.
+const O_CLOEXEC = process.platform === "darwin" ? 0x01000000 : 0x00080000;
+
+interface RuntimeHostFenceOwner {
+  pid: number;
+  startIdentity: string | null;
+  acquisitionId?: string;
+}
+
+interface BunFfiModule {
+  FFIType: { i32: number };
+  dlopen(path: string, symbols: Record<string, unknown>): {
+    symbols: { flock: (fd: number, operation: number) => number };
+  };
+}
+
+let cachedFlock: ((fd: number, operation: number) => number) | null = null;
+
+function flock(fd: number, operation: number): number {
+  if (!cachedFlock) {
+    const runtimeRequire = createRequire(import.meta.url);
+    const ffi = runtimeRequire(`bun:${"ffi"}`) as BunFfiModule;
+    const library = ffi.dlopen(
+      process.platform === "darwin" ? "/usr/lib/libSystem.B.dylib" : "libc.so.6",
+      {
+        flock: {
+          args: [ffi.FFIType.i32, ffi.FFIType.i32],
+          returns: ffi.FFIType.i32,
+        },
+      },
+    );
+    cachedFlock = (lockedFd, lockedOperation) => library.symbols.flock(lockedFd, lockedOperation);
+  }
+  return cachedFlock(fd, operation);
+}
+
+function readOwner(fd: number): RuntimeHostFenceOwner | null {
+  const stat = fs.fstatSync(fd);
+  if (!stat.isFile() || stat.size <= 0 || stat.size > MAX_OWNER_BYTES) return null;
+  const bytes = Buffer.alloc(stat.size);
+  if (fs.readSync(fd, bytes, 0, bytes.byteLength, 0) !== bytes.byteLength) return null;
+  try {
+    const owner = JSON.parse(bytes.toString("utf8")) as Partial<RuntimeHostFenceOwner>;
+    if (!Number.isInteger(owner.pid) || Number(owner.pid) <= 0) return null;
+    if (owner.startIdentity !== null && typeof owner.startIdentity !== "string" && owner.startIdentity !== undefined) return null;
+    if (owner.acquisitionId !== undefined && (typeof owner.acquisitionId !== "string" || owner.acquisitionId.length < 16)) return null;
+    return {
+      pid: Number(owner.pid),
+      startIdentity: owner.startIdentity ?? null,
+      ...(owner.acquisitionId ? { acquisitionId: owner.acquisitionId } : {}),
+    };
+  } catch {
+    return null;
+  }
+}
+
+function sameFile(left: fs.Stats, right: fs.Stats): boolean {
+  return left.dev === right.dev && left.ino === right.ino;
+}
+
+export interface RuntimeHostSocketIdentity {
+  dev: number;
+  ino: number;
+}
+
+/**
+ * Serializes bootstrap and long-lived runtime-host ownership on one stable
+ * inode. The open descriptor is the authority; JSON is diagnostic metadata
+ * and a rolling-upgrade guard for predecessors that only owned the pathname.
+ */
+export class RuntimeHostFence {
+  private fd: number | null = null;
+  private acquisitionId: string | null = null;
+
+  constructor(
+    private readonly filename: string,
+    private readonly ownerAlive: (owner: { pid: number; startIdentity: string | null }) => boolean = (owner) =>
+      procBackend.pidAlive(owner.pid) && (owner.startIdentity === null || procBackend.processIdentity(owner.pid) === owner.startIdentity),
+  ) {}
+
+  acquire(): void {
+    if (this.fd !== null) throw new Error("runtime host singleton fence is held");
+    fs.mkdirSync(path.dirname(this.filename), { recursive: true, mode: 0o700 });
+    let created = false;
+    let fd: number;
+    const openFlags = fs.constants.O_RDWR | O_CLOEXEC | fs.constants.O_NOFOLLOW;
+    try {
+      fd = fs.openSync(this.filename, openFlags | fs.constants.O_CREAT | fs.constants.O_EXCL, 0o600);
+      created = true;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
+      fd = fs.openSync(this.filename, openFlags);
+    }
+
+    let locked = false;
+    try {
+      const observedOwner = readOwner(fd);
+      if (!created && !observedOwner) throw new Error("runtime host singleton fence is held");
+      if (observedOwner && !observedOwner.acquisitionId && this.ownerAlive(observedOwner)) {
+        throw new Error("runtime host singleton fence is held");
+      }
+      if (flock(fd, LOCK_EX | LOCK_NB) !== 0) throw new Error("runtime host singleton fence is held");
+      locked = true;
+
+      const lockedOwner = readOwner(fd);
+      if (!created && !lockedOwner) throw new Error("runtime host singleton fence is held");
+      if (lockedOwner && !lockedOwner.acquisitionId && this.ownerAlive(lockedOwner)) {
+        throw new Error("runtime host singleton fence is held");
+      }
+      const descriptorIdentity = fs.fstatSync(fd);
+      const canonicalIdentity = fs.lstatSync(this.filename);
+      if (!descriptorIdentity.isFile() || !sameFile(descriptorIdentity, canonicalIdentity)) {
+        throw new Error("runtime host singleton fence changed during acquisition");
+      }
+
+      const acquisitionId = crypto.randomUUID();
+      const metadata = JSON.stringify({
+        pid: process.pid,
+        startIdentity: procBackend.processIdentity(process.pid),
+        acquisitionId,
+      });
+      fs.ftruncateSync(fd, 0);
+      fs.writeSync(fd, metadata, 0, "utf8");
+      fs.fsyncSync(fd);
+      if (!sameFile(fs.fstatSync(fd), fs.lstatSync(this.filename))) {
+        throw new Error("runtime host singleton fence changed during acquisition");
+      }
+      this.fd = fd;
+      this.acquisitionId = acquisitionId;
+    } catch (error) {
+      if (locked) flock(fd, LOCK_UN);
+      fs.closeSync(fd);
+      throw error;
+    }
+  }
+
+  /**
+   * Detach the canonical name before validating it. A moved replacement is
+   * linked back without overwriting a later successor; only the socket inode
+   * captured by this acquisition is unlinked from the private retirement path.
+   */
+  removeOwnedSocket(socketPath: string, identity: RuntimeHostSocketIdentity): void {
+    const fd = this.fd;
+    const acquisitionId = this.acquisitionId;
+    if (fd === null || !acquisitionId) throw new Error("runtime host singleton fence is not held");
+    const owner = readOwner(fd);
+    if (owner?.acquisitionId !== acquisitionId || !sameFile(fs.fstatSync(fd), fs.lstatSync(this.filename))) {
+      throw new Error("runtime host singleton fence changed during socket cleanup");
+    }
+
+    const retirementDir = fs.mkdtempSync(path.join(
+      path.dirname(socketPath),
+      `.${path.basename(socketPath)}.retire-${acquisitionId}-`,
+    ));
+    const retiredSocket = path.join(retirementDir, "socket");
+    try {
+      try {
+        fs.renameSync(socketPath, retiredSocket);
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code === "ENOENT") return;
+        throw error;
+      }
+      const retiredIdentity = fs.lstatSync(retiredSocket);
+      if (!retiredIdentity.isSocket() || retiredIdentity.dev !== identity.dev || retiredIdentity.ino !== identity.ino) {
+        try {
+          fs.linkSync(retiredSocket, socketPath);
+          fs.unlinkSync(retiredSocket);
+        } catch (error) {
+          if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
+        }
+        throw new Error("runtime host socket changed during bootstrap probe");
+      }
+      fs.unlinkSync(retiredSocket);
+    } finally {
+      try {
+        fs.rmdirSync(retirementDir);
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== "ENOTEMPTY") throw error;
+      }
+    }
+  }
+
+  release(): void {
+    const fd = this.fd;
+    this.fd = null;
+    this.acquisitionId = null;
+    if (fd === null) return;
+    try {
+      flock(fd, LOCK_UN);
+    } finally {
+      fs.closeSync(fd);
+    }
+  }
+}

--- a/src/runtime-host/socket.ts
+++ b/src/runtime-host/socket.ts
@@ -4,7 +4,7 @@ import path from "node:path";
 
 import type { RuntimeSocketRequest, RuntimeSocketResponse } from "@/lib/runtime/contracts";
 
-import { RuntimeHost } from "./host";
+import type { RuntimeHost } from "./host";
 
 const MAX_FRAME_BYTES = 512 * 1024;
 const DEFAULT_SOCKET_TIMEOUT_MS = 31_000;
@@ -19,8 +19,10 @@ export interface RuntimeHostSocketOptions {
   maxWaitConnections?: number;
 }
 
+export type RuntimeHostSocketHandler = Pick<RuntimeHost, "handle">;
+
 /** Newline-framed local protocol. It intentionally binds a Unix path only. */
-export function serveRuntimeHost(socketPath: string, host: RuntimeHost, options: RuntimeHostSocketOptions = {}): net.Server {
+export function serveRuntimeHost(socketPath: string, host: RuntimeHostSocketHandler, options: RuntimeHostSocketOptions = {}): net.Server {
   const defaultTimeoutMs = options.defaultTimeoutMs ?? DEFAULT_SOCKET_TIMEOUT_MS;
   const deploymentTimeoutMs = options.deploymentTimeoutMs ?? DEPLOYMENT_SOCKET_TIMEOUT_MS;
   const maxConnections = options.maxConnections ?? DEFAULT_MAX_CONNECTIONS;


### PR DESCRIPTION
## Summary

- bind managed MCP health admission to a private Unix channel inherited from the host-owned launch chain
- redeem long-lived runtime-host authority in the trusted adapter, then mint a fresh single-use capability for the final MCP child
- ignore caller-selected runtime socket environment when deciding health-probe authority
- keep the documented revision-only bootstrap rooted in its fenced one-shot issuer
- keep a live legacy fence owner authoritative when process-start identity is temporarily unreadable

## Root cause

The MCP child previously selected its admission issuer through `LLV_RUNTIME_HOST_SOCKET`. A final-launcher caller could redirect that environment value to a forged Unix server and obtain approval for an arbitrary capability.

The legacy fence liveness check also treated an alive PID as stale when its process-start identity lookup returned no value. Since legacy owners hold no advisory lock, a contender could overwrite live ownership metadata and publish a second listener.

## Fix

The runtime host creates a private connected Unix channel, passes only a duplicated raw child descriptor, and removes the temporary pathname before the managed action proceeds. The trusted adapter redeems the host-issued capability over that inherited channel. It then creates a separate private child channel and a fresh single-use capability for the final `bin/mcp-server.mjs` transport. Launch JSON and environment values cannot select either issuer.

The final launcher preserves descriptor 3 only when it is a connected Unix socket. Missing descriptors, caller-selected runtime sockets, malformed capabilities, forged capabilities, expired capabilities, and replayed capabilities all retain ordinary fail-closed policy.

Legacy fence reclamation now requires confirmed PID death or a positive process-start identity mismatch. An alive PID with an unavailable identity remains held, including lookup failures.

## Security properties

- host and bootstrap capabilities remain random, expiring, revocable, and single-use
- the adapter accepts health authority only after redemption through its inherited host channel
- the MCP child receives a separately minted capability over an unnamed child channel
- ordinary agent calls and grant-bearing receipt paths remain fail-closed
- health admission grants exactly `board_snapshot` and `deployment_status`
- stale fence reclamation remains serialized by the fd-held advisory lock and acquisition generation
- predecessor fence and canonical socket cleanup cannot remove successor artifacts

## Verification

- isolated focused matrix: 155 tests passed, 960 assertions, 0 failures across 12 files
- immutable grant and receipt mutation matrix: 36 tests passed, 155 assertions, 0 failures
- aggregate focused evidence: 191 tests passed, 1,115 assertions, 0 failures
- final launcher E2E: authentic runtime-host and documented bootstrap probes pass both required reads
- forged runtime socket plus arbitrary capability: both required reads are denied
- absent, forged, expired, revoked, and replayed authority controls pass
- deterministic multiprocess live-legacy/null-identity race leaves exactly one listener and preserves owner artifacts
- stale-observation, successor fence/socket, listen-failure, and operation-failure controls pass
- standalone TypeScript check passes
- lint passes with zero errors and one pre-existing warning outside this diff
- privacy publication gate passes against the exact merge base
- production Next.js build and managed MCP bundle build pass
