### PR TITLE
fix(registry): readers resolve the writer's backend instead of guessing it

### DIFF
--- a/src/lib/agent/registry.backendResolution.test.ts
+++ b/src/lib/agent/registry.backendResolution.test.ts
@@ -1,0 +1,156 @@
+import { afterEach, expect, test } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { attentionCallerAuthority } from "@/lib/attention/callerAuthority";
+
+import { AgentRegistry } from "./registry";
+import { publishRegistryBackendIdentity, RegistryBackendIdentityError } from "./registryBackendIdentity";
+
+const roots: string[] = [];
+const HOST_PID = 248965;
+
+function stateRoot(): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "llv-backend-resolution-"));
+  roots.push(root);
+  return root;
+}
+
+function withoutBackendEnv<T>(run: () => T): T {
+  const previous = process.env.LLV_AGENT_REGISTRY_SQLITE;
+  delete process.env.LLV_AGENT_REGISTRY_SQLITE;
+  try {
+    return run();
+  } finally {
+    if (previous === undefined) delete process.env.LLV_AGENT_REGISTRY_SQLITE;
+    else process.env.LLV_AGENT_REGISTRY_SQLITE = previous;
+  }
+}
+
+afterEach(() => {
+  while (roots.length) fs.rmSync(roots.pop()!, { recursive: true, force: true });
+});
+
+function registryFileWithHost(transcript: string, hostPid: number, status: string): unknown {
+  return {
+    version: 2,
+    entries: {
+      "claude:live-session": {
+        artifactPath: transcript,
+        status,
+        structuredHost: { kind: "claude-broker", process: { pid: hostPid, startIdentity: null } },
+      },
+    },
+    receipts: {},
+    conversations: {
+      conversation_live: {
+        id: "conversation_live",
+        engine: "claude",
+        generations: [{ id: "live-session", path: transcript, accountId: "default" }],
+      },
+    },
+  };
+}
+
+/** The authoritative content: one conversation whose structured host pid is
+    the process an MCP server would find by walking its own ancestry. */
+function authoritativeFile(transcript: string): unknown {
+  return registryFileWithHost(transcript, HOST_PID, "live");
+}
+
+/** What the production mirror looked like: the same conversation, but carrying
+    a host pid from a generation that died hours earlier. */
+function staleMirrorFile(transcript: string): unknown {
+  return registryFileWithHost(transcript, 8351, "idle");
+}
+
+function hostPidsFor(registry: AgentRegistry): number[] {
+  const snapshot = registry.readOnlySnapshot();
+  return Object.values(snapshot.entries)
+    .map((entry) => entry.structuredHost?.process?.pid)
+    .filter((pid): pid is number => typeof pid === "number");
+}
+
+function seedAuthoritativeStore(root: string): { filename: string; store: string; transcript: string } {
+  const filename = path.join(root, "agent-registry.json");
+  const store = path.join(root, "agent-registry.sqlite");
+  const transcript = path.join(root, "live-session.jsonl");
+  fs.writeFileSync(filename, JSON.stringify(authoritativeFile(transcript)));
+  /* The writer: explicit mode, and it imports the JSON seed into SQLite. */
+  new AgentRegistry(filename, undefined, undefined, { sqliteMode: "sqlite", sqliteFilename: store });
+  publishRegistryBackendIdentity(filename, "sqlite", store);
+  /* Now the mirror diverges, exactly as it had in production. */
+  fs.writeFileSync(filename, JSON.stringify(staleMirrorFile(transcript)));
+  return { filename, store, transcript };
+}
+
+test("a reader with no env opens the writer's SQLite store, not the diverged mirror", () => {
+  const { filename } = seedAuthoritativeStore(stateRoot());
+
+  const reader = withoutBackendEnv(() => new AgentRegistry(filename, undefined, undefined, { resolveBackendIdentity: true }));
+
+  expect(hostPidsFor(reader)).toEqual([HOST_PID]);
+  expect(hostPidsFor(reader)).not.toContain(8351);
+});
+
+test("a live hosted caller is identified from the authoritative registry", () => {
+  const { filename } = seedAuthoritativeStore(stateRoot());
+  const reader = withoutBackendEnv(() => new AgentRegistry(filename, undefined, undefined, { resolveBackendIdentity: true }));
+  const snapshot = reader.readOnlySnapshot();
+  const hosted = Object.values(snapshot.conversations).map((conversation) => ({
+    conversationId: conversation.id,
+    role: null,
+    pids: Object.values(snapshot.entries)
+      .filter((entry) => conversation.generations.some((generation) => generation.path === entry.artifactPath))
+      .map((entry) => entry.structuredHost?.process?.pid)
+      .filter((pid): pid is number => typeof pid === "number"),
+  }));
+
+  /* The MCP server's own chain: itself, the agent, then the structured host. */
+  const authority = attentionCallerAuthority({
+    ancestry: () => [248998, 248968, HOST_PID],
+    hosted: () => hosted,
+    rootConversationId: () => null,
+  });
+
+  expect(authority).toEqual({ kind: "worker", conversationId: "conversation_live", role: null });
+});
+
+/* The fix must not hand authority to anyone it could not name before. */
+test("a caller whose ancestry matches no recorded host stays unidentified", () => {
+  const { filename } = seedAuthoritativeStore(stateRoot());
+  const reader = withoutBackendEnv(() => new AgentRegistry(filename, undefined, undefined, { resolveBackendIdentity: true }));
+  const snapshot = reader.readOnlySnapshot();
+
+  const authority = attentionCallerAuthority({
+    ancestry: () => [999001, 999002],
+    hosted: () => Object.values(snapshot.conversations).map((conversation) => ({
+      conversationId: conversation.id,
+      role: null,
+      pids: [HOST_PID],
+    })),
+    rootConversationId: () => null,
+  });
+
+  expect(authority).toEqual({ kind: "unidentified" });
+});
+
+test("a reader refuses to start when a store exists but no identity was published", () => {
+  const root = stateRoot();
+  const filename = path.join(root, "agent-registry.json");
+  fs.writeFileSync(filename, JSON.stringify({ version: 2, entries: {}, receipts: {} }));
+  fs.writeFileSync(path.join(root, "agent-registry.sqlite"), "");
+
+  expect(() => withoutBackendEnv(() => new AgentRegistry(filename, undefined, undefined, { resolveBackendIdentity: true }))).toThrow(RegistryBackendIdentityError);
+});
+
+test("a JSON-only deployment still constructs without a descriptor", () => {
+  const root = stateRoot();
+  const filename = path.join(root, "agent-registry.json");
+  fs.writeFileSync(filename, JSON.stringify({ version: 2, entries: {}, receipts: {} }));
+
+  const reader = withoutBackendEnv(() => new AgentRegistry(filename, undefined, undefined, { resolveBackendIdentity: true }));
+
+  expect(reader.readOnlySnapshot().entries).toEqual({});
+});

--- a/src/lib/agent/registry.ts
+++ b/src/lib/agent/registry.ts
@@ -41,6 +41,13 @@ import {
   type SpawnRejection,
 } from "./spawnAdmission";
 import { sessionKeyFromTranscript, sessionKeyId, type SessionKey } from "./sessionKey";
+import {
+  defaultRegistrySqliteFilename,
+  publishRegistryBackendIdentity,
+  registryBackendModeFromEnvironment,
+  resolveRegistryBackend,
+  type RegistryBackendResolution,
+} from "./registryBackendIdentity";
 import { SqliteAgentRegistryStore, type SqliteRegistrySnapshot } from "./sqliteRegistryStore";
 import type { ResumePaneRecord } from "@/lib/resumePanesFile";
 import { assertStructuredTextEnvelope, parseStructuredImageRefs, structuredContent, type StructuredImageRef } from "@/lib/runtime/structuredContent";
@@ -2465,6 +2472,11 @@ export type AgentRegistrySqliteMode = "off" | "dual-write" | "read" | "sqlite";
 
 export interface AgentRegistryStorageOptions {
   sqliteMode?: AgentRegistrySqliteMode;
+  /** Resolve (and, for a writer, publish) the durable backend identity instead
+      of trusting this process's environment. Only the process-wide registry
+      sets it: a reader that guesses wrong opens a store the writer does not
+      own. See {@link resolveRegistryBackend}. */
+  resolveBackendIdentity?: boolean;
   /** Grant bound for the MCP origin rebound (issue #739). Production omits it;
       a test supplies a policy that HAS a grantable connector, since the shipped
       bound has none and an empty bound proves nothing about the origin rule. */
@@ -2502,13 +2514,7 @@ export class RegistryParityError extends Error {
 /** Pure env read: lets health/capability probes answer without paying the
     full registry load (a multi-MB JSON parse) on first touch. */
 export function sqliteModeFromEnvironment(): AgentRegistrySqliteMode {
-  const configured = process.env.LLV_AGENT_REGISTRY_SQLITE ?? "off";
-  if (configured === "off" || configured === "dual-write" || configured === "read" || configured === "sqlite") return configured;
-  throw new Error("LLV_AGENT_REGISTRY_SQLITE must be off, dual-write, read, or sqlite");
-}
-
-function defaultSqliteFilename(jsonFilename: string): string {
-  return jsonFilename.endsWith(".json") ? `${jsonFilename.slice(0, -5)}.sqlite` : `${jsonFilename}.sqlite`;
+  return registryBackendModeFromEnvironment();
 }
 
 function sqliteMirrorRevision(filename: string): number | null {
@@ -2558,7 +2564,27 @@ export class AgentRegistry {
     private readonly lockTiming: RegistryLockTiming = SYSTEM_LOCK_TIMING,
     storage: AgentRegistryStorageOptions = {},
   ) {
-    this.sqliteMode = storage.sqliteMode ?? sqliteModeFromEnvironment();
+    /* Which store the PROCESS-WIDE registry opens is never guessed. A writer
+       states its mode in the environment and publishes it; every other process
+       — the MCP server above all, which Claude launches with an empty env —
+       resolves that published identity, and an unprovable identity throws here
+       rather than opening a stale JSON mirror behind the writer's back. That
+       mirror read is what reported every MCP caller as unidentified.
+
+       Identity resolution is a property of the shared registry, not of an
+       AgentRegistry value: only `agentRegistry()` opts in. Fixtures and the
+       SQLite child processes construct their own files directly and keep the
+       historical env default, so a test directory that happens to hold a store
+       is not mistaken for a deployment whose writer went silent. */
+    const backend: RegistryBackendResolution = storage.sqliteMode !== undefined
+      ? { mode: storage.sqliteMode, sqliteFilename: null, source: "explicit" }
+      : storage.resolveBackendIdentity === true
+        ? resolveRegistryBackend(filename)
+        : { mode: registryBackendModeFromEnvironment(), sqliteFilename: null, source: "unmanaged" };
+    this.sqliteMode = backend.mode;
+    const sqliteFilename = storage.sqliteFilename
+      ?? backend.sqliteFilename
+      ?? defaultRegistrySqliteFilename(filename);
     this.mcpGrantPolicy = storage.mcpGrantPolicy;
     this.mirrorCheckpointMs = Math.max(0, storage.mirrorCheckpointMs ?? 5_000);
     this.now = storage.now ?? Date.now;
@@ -2568,7 +2594,7 @@ export class AgentRegistry {
     this.beforeDualWriteMutationReplace = storage.beforeDualWriteMutationReplace;
     this.sqliteStore = this.sqliteMode === "off"
       ? null
-      : new SqliteAgentRegistryStore(storage.sqliteFilename ?? defaultSqliteFilename(filename), {
+      : new SqliteAgentRegistryStore(sqliteFilename, {
           initialSnapshot: readFile(filename, storage.mcpGrantPolicy),
           normalize: (value) => normalizeRegistry(value, storage.mcpGrantPolicy),
           mcpGrantPolicy: storage.mcpGrantPolicy,
@@ -2603,6 +2629,12 @@ export class AgentRegistry {
         throw new RegistryParityError("agent registry JSON mirror revision is ahead of SQLite");
       }
       this.mirrorSqliteSnapshot(sqlite);
+    }
+    /* Only the writer that was TOLD its mode publishes it. Test and child
+       constructions pass `sqliteMode` explicitly and stay silent, so a
+       fixture can never install an identity a reader would then trust. */
+    if (backend.source === "environment") {
+      publishRegistryBackendIdentity(filename, this.sqliteMode, sqliteFilename);
     }
   }
 
@@ -6056,7 +6088,7 @@ const registryProcessState = process as typeof process & {
 };
 
 export function agentRegistry(): AgentRegistry {
-  registryProcessState.__llvAgentRegistry ??= new AgentRegistry();
+  registryProcessState.__llvAgentRegistry ??= new AgentRegistry(undefined, undefined, undefined, { resolveBackendIdentity: true });
   return registryProcessState.__llvAgentRegistry;
 }
 

--- a/src/lib/agent/registryBackendIdentity.test.ts
+++ b/src/lib/agent/registryBackendIdentity.test.ts
@@ -1,0 +1,197 @@
+import { afterEach, expect, test } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import {
+  RegistryBackendIdentityError,
+  publishRegistryBackendIdentity,
+  registryBackendDescriptorPath,
+  resolveRegistryBackend,
+  type RegistryBackendIo,
+} from "./registryBackendIdentity";
+
+const roots: string[] = [];
+
+function stateRoot(): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "llv-registry-backend-"));
+  roots.push(root);
+  return root;
+}
+
+afterEach(() => {
+  while (roots.length) fs.rmSync(roots.pop()!, { recursive: true, force: true });
+});
+
+function registryFile(root: string): string {
+  const filename = path.join(root, "agent-registry.json");
+  fs.writeFileSync(filename, JSON.stringify({ entries: {} }));
+  return filename;
+}
+
+function withStore(root: string): string {
+  const store = path.join(root, "agent-registry.sqlite");
+  fs.writeFileSync(store, "");
+  return store;
+}
+
+/* The production defect, reduced: Claude launches the MCP server with an empty
+   env, so the reader saw `off` and opened the JSON mirror while the writer
+   owned SQLite. Every host pid it then read was dead, and caller authority
+   reported every MCP caller as unidentified. */
+test("an MCP reader with no env resolves the writer's SQLite backend, not the JSON mirror", () => {
+  const root = stateRoot();
+  const filename = registryFile(root);
+  const store = withStore(root);
+  publishRegistryBackendIdentity(filename, "sqlite", store);
+
+  const resolved = resolveRegistryBackend(filename, {});
+
+  expect(resolved).toEqual({ mode: "sqlite", sqliteFilename: store, source: "descriptor" });
+});
+
+test("a stale JSON mirror is never chosen when the descriptor names SQLite", () => {
+  const root = stateRoot();
+  const filename = registryFile(root);
+  const store = withStore(root);
+  publishRegistryBackendIdentity(filename, "sqlite", store);
+  /* A mirror far behind the store is exactly the state that produced dead
+     host pids in production; resolution must not even consider it. */
+  fs.writeFileSync(filename, JSON.stringify({ entries: {}, _sqliteRevision: 1 }));
+
+  expect(resolveRegistryBackend(filename, {}).mode).toBe("sqlite");
+});
+
+test("an explicit environment overrides the descriptor and stays authoritative", () => {
+  const root = stateRoot();
+  const filename = registryFile(root);
+  const store = withStore(root);
+  publishRegistryBackendIdentity(filename, "sqlite", store);
+
+  const resolved = resolveRegistryBackend(filename, { LLV_AGENT_REGISTRY_SQLITE: "sqlite" });
+
+  expect(resolved).toEqual({ mode: "sqlite", sqliteFilename: null, source: "environment" });
+});
+
+test("a genuine JSON-only deployment keeps working without a descriptor", () => {
+  const root = stateRoot();
+  const filename = registryFile(root);
+
+  const resolved = resolveRegistryBackend(filename, {});
+
+  expect(resolved).toEqual({ mode: "off", sqliteFilename: null, source: "json-only" });
+});
+
+test("a descriptor that declares the JSON backend resolves off when no store exists", () => {
+  const root = stateRoot();
+  const filename = registryFile(root);
+  publishRegistryBackendIdentity(filename, "off", path.join(root, "unused.sqlite"));
+
+  expect(resolveRegistryBackend(filename, {})).toEqual({ mode: "off", sqliteFilename: null, source: "descriptor" });
+});
+
+test("an unpublished identity beside an existing store fails closed", () => {
+  const root = stateRoot();
+  const filename = registryFile(root);
+  withStore(root);
+
+  expect(() => resolveRegistryBackend(filename, {})).toThrow(RegistryBackendIdentityError);
+  expect(() => resolveRegistryBackend(filename, {})).toThrow(/unpublished while agent-registry\.sqlite exists/);
+});
+
+test("a descriptor contradicted by an existing store fails closed", () => {
+  const root = stateRoot();
+  const filename = registryFile(root);
+  publishRegistryBackendIdentity(filename, "off", path.join(root, "unused.sqlite"));
+  withStore(root);
+
+  expect(() => resolveRegistryBackend(filename, {})).toThrow(/claims the JSON backend while agent-registry\.sqlite exists/);
+});
+
+test("a descriptor naming an unavailable store fails closed", () => {
+  const root = stateRoot();
+  const filename = registryFile(root);
+  const store = withStore(root);
+  publishRegistryBackendIdentity(filename, "sqlite", store);
+  fs.rmSync(store);
+
+  expect(() => resolveRegistryBackend(filename, {})).toThrow(/which is unavailable/);
+});
+
+test("a corrupt descriptor fails closed instead of falling back", () => {
+  const root = stateRoot();
+  const filename = registryFile(root);
+  withStore(root);
+  fs.writeFileSync(registryBackendDescriptorPath(filename), "{not json");
+
+  expect(() => resolveRegistryBackend(filename, {})).toThrow(/is not valid JSON/);
+});
+
+test("a descriptor from a future schema fails closed", () => {
+  const root = stateRoot();
+  const filename = registryFile(root);
+  withStore(root);
+  fs.writeFileSync(
+    registryBackendDescriptorPath(filename),
+    JSON.stringify({ schemaVersion: 2, mode: "sqlite", sqliteFile: "agent-registry.sqlite", publishedAt: "" }),
+  );
+
+  expect(() => resolveRegistryBackend(filename, {})).toThrow(/schema version 2/);
+});
+
+test("a descriptor declaring an unknown mode fails closed", () => {
+  const root = stateRoot();
+  const filename = registryFile(root);
+  withStore(root);
+  fs.writeFileSync(
+    registryBackendDescriptorPath(filename),
+    JSON.stringify({ schemaVersion: 1, mode: "postgres", sqliteFile: "agent-registry.sqlite", publishedAt: "" }),
+  );
+
+  expect(() => resolveRegistryBackend(filename, {})).toThrow(/unknown backend mode/);
+});
+
+test("a descriptor cannot point a reader outside its own state directory", () => {
+  const root = stateRoot();
+  const filename = registryFile(root);
+  withStore(root);
+  fs.writeFileSync(
+    registryBackendDescriptorPath(filename),
+    JSON.stringify({ schemaVersion: 1, mode: "sqlite", sqliteFile: "../elsewhere.sqlite", publishedAt: "" }),
+  );
+
+  expect(() => resolveRegistryBackend(filename, {})).toThrow(/bare filename/);
+});
+
+test("an unreadable descriptor fails closed rather than reading as absent", () => {
+  const root = stateRoot();
+  const filename = registryFile(root);
+  withStore(root);
+  const io: RegistryBackendIo = {
+    readText: () => { throw new RegistryBackendIdentityError("agent-registry.backend.json is unreadable: EACCES"); },
+    exists: () => true,
+    writeText: () => { throw new Error("unexpected write"); },
+  };
+
+  expect(() => resolveRegistryBackend(filename, {}, io)).toThrow(/unreadable: EACCES/);
+});
+
+test("publishing is idempotent and replaces a corrupt identity", () => {
+  const root = stateRoot();
+  const filename = registryFile(root);
+  const store = withStore(root);
+  const descriptorPath = registryBackendDescriptorPath(filename);
+
+  publishRegistryBackendIdentity(filename, "sqlite", store, undefined, () => "first");
+  publishRegistryBackendIdentity(filename, "sqlite", store, undefined, () => "second");
+  expect(JSON.parse(fs.readFileSync(descriptorPath, "utf8")).publishedAt).toBe("first");
+
+  fs.writeFileSync(descriptorPath, "{corrupt");
+  publishRegistryBackendIdentity(filename, "sqlite", store, undefined, () => "third");
+  expect(JSON.parse(fs.readFileSync(descriptorPath, "utf8"))).toMatchObject({
+    schemaVersion: 1,
+    mode: "sqlite",
+    sqliteFile: "agent-registry.sqlite",
+    publishedAt: "third",
+  });
+});

--- a/src/lib/agent/registryBackendIdentity.ts
+++ b/src/lib/agent/registryBackendIdentity.ts
@@ -1,0 +1,220 @@
+import { randomUUID } from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+
+export type RegistryBackendMode = "off" | "dual-write" | "read" | "sqlite";
+
+export const REGISTRY_BACKEND_ENV = "LLV_AGENT_REGISTRY_SQLITE";
+
+/** Only the one variable is read, so tests need not fabricate a whole env. */
+export type RegistryBackendEnvironment = Readonly<Record<string, string | undefined>>;
+export const REGISTRY_BACKEND_DESCRIPTOR_VERSION = 1;
+
+/** A reader could not prove which backend the writer owns. Every construction
+    path treats this as fatal: reading the JSON mirror while SQLite is (or may
+    be) authoritative is exactly the silent divergence this descriptor exists
+    to prevent — a reader that resolves a stale mirror sees dead host pids and
+    reports every MCP caller as unidentified. */
+export class RegistryBackendIdentityError extends Error {
+  override name = "RegistryBackendIdentityError";
+}
+
+export interface RegistryBackendDescriptor {
+  schemaVersion: number;
+  mode: RegistryBackendMode;
+  /** Bare filename resolved against the descriptor's own directory, so the
+      record carries no absolute path and survives host/container path skew. */
+  sqliteFile: string | null;
+  publishedAt: string;
+}
+
+export interface RegistryBackendResolution {
+  mode: RegistryBackendMode;
+  /** The store the writer named. `null` leaves the default to the caller. */
+  sqliteFilename: string | null;
+  source: "environment" | "descriptor" | "json-only" | "explicit" | "unmanaged";
+}
+
+/** The filesystem seam. Tests drive unreadable and contradictory states
+    without depending on the runner's uid or umask. */
+export interface RegistryBackendIo {
+  /** `null` means absent; any other failure must throw. */
+  readText(filename: string): string | null;
+  exists(filename: string): boolean;
+  writeText(filename: string, contents: string): void;
+}
+
+export const nodeRegistryBackendIo: RegistryBackendIo = {
+  readText(filename) {
+    try {
+      return fs.readFileSync(filename, "utf8");
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
+      throw new RegistryBackendIdentityError(
+        `${path.basename(filename)} is unreadable: ${(error as NodeJS.ErrnoException).code ?? "unknown error"}`,
+      );
+    }
+  },
+  exists(filename) {
+    return fs.existsSync(filename);
+  },
+  writeText(filename, contents) {
+    fs.mkdirSync(path.dirname(filename), { recursive: true, mode: 0o700 });
+    const temporary = `${filename}.${process.pid}.${randomUUID()}.tmp`;
+    const descriptor = fs.openSync(temporary, "wx", 0o600);
+    try {
+      fs.writeFileSync(descriptor, contents);
+      fs.fsyncSync(descriptor);
+    } finally {
+      fs.closeSync(descriptor);
+    }
+    fs.renameSync(temporary, filename);
+  },
+};
+
+export function registryBackendDescriptorPath(registryFilename: string): string {
+  const base = path.basename(registryFilename).replace(/\.json$/, "");
+  return path.join(path.dirname(registryFilename), `${base}.backend.json`);
+}
+
+export function defaultRegistrySqliteFilename(registryFilename: string): string {
+  return registryFilename.endsWith(".json")
+    ? `${registryFilename.slice(0, -5)}.sqlite`
+    : `${registryFilename}.sqlite`;
+}
+
+function isBackendMode(value: unknown): value is RegistryBackendMode {
+  return value === "off" || value === "dual-write" || value === "read" || value === "sqlite";
+}
+
+/** Pure env read: lets health/capability probes answer without paying the
+    full registry load (a multi-MB JSON parse) on first touch. */
+export function registryBackendModeFromEnvironment(
+  environment: RegistryBackendEnvironment = process.env,
+): RegistryBackendMode {
+  const configured = environment[REGISTRY_BACKEND_ENV] ?? "off";
+  if (isBackendMode(configured)) return configured;
+  throw new Error(`${REGISTRY_BACKEND_ENV} must be off, dual-write, read, or sqlite`);
+}
+
+function parseDescriptor(raw: string, label: string): RegistryBackendDescriptor {
+  let value: unknown;
+  try {
+    value = JSON.parse(raw) as unknown;
+  } catch {
+    throw new RegistryBackendIdentityError(`${label} is not valid JSON`);
+  }
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new RegistryBackendIdentityError(`${label} is not an object`);
+  }
+  const record = value as Record<string, unknown>;
+  if (record.schemaVersion !== REGISTRY_BACKEND_DESCRIPTOR_VERSION) {
+    throw new RegistryBackendIdentityError(
+      `${label} declares schema version ${String(record.schemaVersion)}, but this build understands ${REGISTRY_BACKEND_DESCRIPTOR_VERSION}`,
+    );
+  }
+  if (!isBackendMode(record.mode)) {
+    throw new RegistryBackendIdentityError(`${label} declares an unknown backend mode`);
+  }
+  const sqliteFile = record.sqliteFile;
+  if (sqliteFile !== null && typeof sqliteFile !== "string") {
+    throw new RegistryBackendIdentityError(`${label} declares an invalid store filename`);
+  }
+  /* A bare name only: the descriptor must never be able to point a reader at
+     a store outside the state directory it lives in. */
+  if (typeof sqliteFile === "string" && (sqliteFile === "" || sqliteFile !== path.basename(sqliteFile))) {
+    throw new RegistryBackendIdentityError(`${label} must name its store as a bare filename`);
+  }
+  if (record.mode !== "off" && sqliteFile === null) {
+    throw new RegistryBackendIdentityError(`${label} declares the ${record.mode} backend but names no store`);
+  }
+  return {
+    schemaVersion: REGISTRY_BACKEND_DESCRIPTOR_VERSION,
+    mode: record.mode,
+    sqliteFile: sqliteFile ?? null,
+    publishedAt: typeof record.publishedAt === "string" ? record.publishedAt : "",
+  };
+}
+
+/**
+ * Which backend this process must open.
+ *
+ * A writer states its mode in the environment and is authoritative. Every
+ * other process — most importantly the MCP server, which Claude launches with
+ * an empty env — resolves the durable descriptor the writer published, so a
+ * reader can never silently open a different store than the writer owns.
+ *
+ * Absent, invalid, contradictory, and unavailable identities all fail closed.
+ * The one safe fallback is a deployment that genuinely has no SQLite store:
+ * there is nothing to diverge from, so the JSON backend is proven, not assumed.
+ */
+export function resolveRegistryBackend(
+  registryFilename: string,
+  environment: RegistryBackendEnvironment = process.env,
+  io: RegistryBackendIo = nodeRegistryBackendIo,
+): RegistryBackendResolution {
+  if (environment[REGISTRY_BACKEND_ENV] !== undefined) {
+    return { mode: registryBackendModeFromEnvironment(environment), sqliteFilename: null, source: "environment" };
+  }
+  const descriptorPath = registryBackendDescriptorPath(registryFilename);
+  const descriptorName = path.basename(descriptorPath);
+  const defaultStore = defaultRegistrySqliteFilename(registryFilename);
+  const raw = io.readText(descriptorPath);
+  if (raw === null) {
+    if (io.exists(defaultStore)) {
+      throw new RegistryBackendIdentityError(
+        `the agent registry backend identity is unpublished while ${path.basename(defaultStore)} exists,`
+        + ` so SQLite may be authoritative and the JSON mirror may be stale;`
+        + ` start the registry writer with ${REGISTRY_BACKEND_ENV} set so it publishes ${descriptorName}`,
+      );
+    }
+    return { mode: "off", sqliteFilename: null, source: "json-only" };
+  }
+  const descriptor = parseDescriptor(raw, descriptorName);
+  if (descriptor.mode === "off") {
+    if (io.exists(defaultStore)) {
+      throw new RegistryBackendIdentityError(
+        `${descriptorName} claims the JSON backend while ${path.basename(defaultStore)} exists;`
+        + ` remove the stale store or republish the descriptor from the writer`,
+      );
+    }
+    return { mode: "off", sqliteFilename: null, source: "descriptor" };
+  }
+  const store = path.join(path.dirname(descriptorPath), descriptor.sqliteFile!);
+  if (!io.exists(store)) {
+    throw new RegistryBackendIdentityError(
+      `${descriptorName} names the ${descriptor.mode} backend store ${descriptor.sqliteFile}, which is unavailable`,
+    );
+  }
+  return { mode: descriptor.mode, sqliteFilename: store, source: "descriptor" };
+}
+
+/** Publishes the writer's own backend identity. Idempotent: an unchanged
+    identity is left alone so readers never observe a torn rewrite, and a
+    corrupt descriptor is replaced rather than trusted. */
+export function publishRegistryBackendIdentity(
+  registryFilename: string,
+  mode: RegistryBackendMode,
+  sqliteFilename: string,
+  io: RegistryBackendIo = nodeRegistryBackendIo,
+  now: () => string = () => new Date().toISOString(),
+): void {
+  const descriptorPath = registryBackendDescriptorPath(registryFilename);
+  const sqliteFile = mode === "off" ? null : path.basename(sqliteFilename);
+  const existing = io.readText(descriptorPath);
+  if (existing !== null) {
+    try {
+      const current = parseDescriptor(existing, path.basename(descriptorPath));
+      if (current.mode === mode && current.sqliteFile === sqliteFile) return;
+    } catch {
+      /* An unreadable identity is worse than no identity: republish it. */
+    }
+  }
+  const descriptor: RegistryBackendDescriptor = {
+    schemaVersion: REGISTRY_BACKEND_DESCRIPTOR_VERSION,
+    mode,
+    sqliteFile,
+    publishedAt: now(),
+  };
+  io.writeText(descriptorPath, `${JSON.stringify(descriptor)}\n`);
+}


### PR DESCRIPTION
## The defect

The registry backend is chosen from `LLV_AGENT_REGISTRY_SQLITE`, which defaults to the JSON backend. The deployed viewer container sets it; nothing else does. The MCP server is launched from a generated config with an empty env, so it opened the **JSON mirror** while the writer owned **SQLite**.

The mirror lags the store, so every host pid the MCP server read was already dead. `attentionCallerAuthority` resolves a conversation by matching the MCP process's own ancestry against those pids — it matched nothing, so **every Viewer MCP caller was refused as `unidentified`** and held to the voice gateway's surface.

Measured on the affected deployment: the store held 5 entries with host pids, all live; the mirror held 3, none live.

## The fix

The writer publishes its backend identity to a durable descriptor beside the registry, and the process-wide registry resolves that descriptor instead of trusting its own environment.

Fails closed with a diagnostic when the identity is absent-while-a-store-exists, corrupt, from a future schema, declares an unknown mode, names a store outside its own directory, names an unavailable store, or is contradicted by a store on disk. It never silently falls back to a mirror that may be stale.

Compatibility: a deployment that genuinely has no SQLite store still resolves the JSON backend, because there is nothing to diverge from.

Resolution is a property of the *shared* registry, not of every `AgentRegistry` value — only `agentRegistry()` opts in, so fixtures and the SQLite child processes keep constructing their own files directly.

## Authority is not weakened

No change to `callerAuthority`, the tool allowlist, or manager designation. A caller whose ancestry matches no recorded host is still `unidentified`; the fix only lets a genuinely hosted caller be named from the store the writer actually owns. Covered by an explicit test.

## Tests

126 focused tests pass, 0 fail, across the new suites plus `registry.sqlite`, `callerAuthority`, `candidateContainer`, `toolAllowlist`, and `bindings`. TypeScript clean. Privacy gate pass.

New failure-path coverage: MCP env unset while the writer uses SQLite; stale JSON mirror never chosen; valid JSON-only deployment; missing / corrupt / future-schema / unknown-mode / traversal / unavailable-store / contradicted descriptors; unreadable descriptor; idempotent publish that replaces a corrupt identity; live hosted caller resolved from the authoritative store; unmatched ancestry still unidentified.

## Scope

Layer 1 only. Does not touch the stale-migration-intent spawn hold, the receipt/reaper convergence gap, or durable manager authority across host replacement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)